### PR TITLE
feat(server): typed SuppressedReason + audit + new suppressors (#526 slice 2a)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -25,7 +25,24 @@
       "Bash(cargo build:*)",
       "Bash(gh issue *)",
       "Bash(git fetch *)",
-      "Bash(git push *)"
+      "Bash(git push *)",
+      "Skill(superpowers:systematic-debugging)",
+      "Bash(git *)",
+      "Bash(kubectl get *)",
+      "Bash(kubectl logs *)",
+      "Bash(kubectl exec *)",
+      "Bash(awk 'NR>=64 && NR<=200' /Users/oyr/.claude/projects/-Users-oyr-projects-waddle/76e27f42-f40a-4ffb-b714-1fc8f44459d5/tool-results/toolu_013NS8b1dHwZoFDfUo6yPzGB.txt)",
+      "Bash(echo' restartCount')",
+      "Bash(awk -F'\"timestamp\":\"' '{print substr\\($2,1,16\\)}')",
+      "Bash(tee /tmp/state-before.json)",
+      "Bash(kubectl port-forward *)",
+      "Bash(cargo fmt *)",
+      "Bash(awk -F'passed; ' '{print $0}')",
+      "Bash(awk '{ for \\(i=1;i<=NF;i++\\) if \\($i==\"passed;\"\\) p+=$\\(i-1\\); for \\(i=1;i<=NF;i++\\) if \\($i==\"failed;\"\\) f+=$\\(i-1\\) } END { print \"passed:\",p,\"failed:\",f }')",
+      "Bash(awk *)",
+      "Bash(Value::Null)",
+      "Bash(auth_identities.email_verified)",
+      "Bash(Option::)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -25,24 +25,7 @@
       "Bash(cargo build:*)",
       "Bash(gh issue *)",
       "Bash(git fetch *)",
-      "Bash(git push *)",
-      "Skill(superpowers:systematic-debugging)",
-      "Bash(git *)",
-      "Bash(kubectl get *)",
-      "Bash(kubectl logs *)",
-      "Bash(kubectl exec *)",
-      "Bash(awk 'NR>=64 && NR<=200' /Users/oyr/.claude/projects/-Users-oyr-projects-waddle/76e27f42-f40a-4ffb-b714-1fc8f44459d5/tool-results/toolu_013NS8b1dHwZoFDfUo6yPzGB.txt)",
-      "Bash(echo' restartCount')",
-      "Bash(awk -F'\"timestamp\":\"' '{print substr\\($2,1,16\\)}')",
-      "Bash(tee /tmp/state-before.json)",
-      "Bash(kubectl port-forward *)",
-      "Bash(cargo fmt *)",
-      "Bash(awk -F'passed; ' '{print $0}')",
-      "Bash(awk '{ for \\(i=1;i<=NF;i++\\) if \\($i==\"passed;\"\\) p+=$\\(i-1\\); for \\(i=1;i<=NF;i++\\) if \\($i==\"failed;\"\\) f+=$\\(i-1\\) } END { print \"passed:\",p,\"failed:\",f }')",
-      "Bash(awk *)",
-      "Bash(Value::Null)",
-      "Bash(auth_identities.email_verified)",
-      "Bash(Option::)"
+      "Bash(git push *)"
     ]
   }
 }

--- a/server/crates/waddle-server/src/notification_outbox.rs
+++ b/server/crates/waddle-server/src/notification_outbox.rs
@@ -1969,6 +1969,7 @@ impl NotificationOutboxStore {
             // for the duration of this drain pass so a 100-member
             // groupchat does not produce 100 actor round-trips.
             let outcome = match evaluate_xep0492_at_dispatch(
+                PushEvalStage::T1Drain,
                 settings_projection,
                 room_policy,
                 dnd_reader,
@@ -2930,7 +2931,40 @@ pub(crate) enum UnknownRoomPolicySource {
 ///   [`T1PushDispatchOutcome::DeferUnknownRoomPolicy`] — slice 1 has
 ///   no durable T1 projection of MUC config yet, so an unknown
 ///   policy must defer rather than default-to-public.
+/// Which leg of the push pipeline is invoking the evaluator.
+///
+/// The single typed function runs at two moments per #506 Q3 — T0
+/// emission gate (compliance: no row for XEP-0492 suppressed) and T1
+/// drain (race-window guard + durable audit). The two legs DO NOT
+/// share the full suppressor set: message-frozen suppressors (XEP-0513
+/// `<noping/>`, XEP-0334 `<no-store/>` / `<no-permanent-store/>`) and
+/// Waddle DnD are deliberately skipped at T0 so the candidate row
+/// persists with its hint bits and the typed `suppressed_reason`
+/// audit fires at T1 — without this split, hinted candidates would
+/// be silently filtered at T0 with no audit trail, contradicting the
+/// [`NotificationMessageHints`] contract.
+///
+/// T0 still applies recipient-state suppressors that compliance
+/// requires to leave no row at all (XEP-0492 `<never/>`/`<on-mention/>`
+/// miss). Those persist their suppression intent via metric counters
+/// at the T0 emission site; the row itself is the audit surface for
+/// everything else.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PushEvalStage {
+    /// Called synchronously from `enqueue_xep0357_notification_candidate_*`
+    /// before `insert_candidate`. A `Suppressed` outcome here means
+    /// the row will NOT be persisted — reserve this stage for
+    /// compliance-required suppressors only.
+    T0Emit,
+    /// Called from `drain_pending_candidates_into_outbox` against an
+    /// already-persisted candidate. `Suppressed` outcomes here are
+    /// recorded as `suppressed_reason` on the row and counted via
+    /// `increment_push_suppressed` — full audit + observability.
+    T1Drain,
+}
+
 pub(crate) async fn evaluate_xep0492_at_dispatch(
+    stage: PushEvalStage,
     settings_projection: &crate::notification_settings_projection::NotificationSettingsProjectionStore,
     room_policy: &dyn RoomPolicyStore,
     dnd_reader: &dyn DndReader,
@@ -2938,25 +2972,30 @@ pub(crate) async fn evaluate_xep0492_at_dispatch(
     room_policy_cache: &mut std::collections::BTreeMap<BareJid, RoomPolicyCacheEntry>,
     dnd_cache: &mut std::collections::BTreeMap<BareJid, DndState>,
 ) -> Result<T1PushDispatchOutcome, NotificationOutboxError> {
-    // Message-frozen suppressors take precedence over recipient-state
-    // reads: a sender's `<noping/>` mention or XEP-0334 storage hint
-    // is a final decision by the sender and cannot be overridden by
-    // recipient settings. Evaluate these before issuing storage reads
-    // so the typed outcome captures the most-specific signal first.
-    if candidate.noping() {
-        return Ok(T1PushDispatchOutcome::Suppressed {
-            reason: SuppressedReason::Xep0513Noping,
-        });
-    }
-    if candidate.no_store() {
-        return Ok(T1PushDispatchOutcome::Suppressed {
-            reason: SuppressedReason::Xep0334NoStore,
-        });
-    }
-    if candidate.no_permanent_store() {
-        return Ok(T1PushDispatchOutcome::Suppressed {
-            reason: SuppressedReason::Xep0334NoPermanentStore,
-        });
+    // Message-frozen suppressors (`<noping/>`, XEP-0334 storage hints)
+    // run ONLY at T1Drain so the candidate row is persisted with its
+    // hint bits and the typed `suppressed_reason` audit can fire. At
+    // T0Emit the row doesn't exist yet — suppressing here would leave
+    // no audit trail, defeating the whole purpose of snapshotting the
+    // hint bits onto `NotificationCandidate` in the first place. The
+    // sender-precedence ordering (hints before recipient-state reads)
+    // is preserved within T1Drain.
+    if stage == PushEvalStage::T1Drain {
+        if candidate.noping() {
+            return Ok(T1PushDispatchOutcome::Suppressed {
+                reason: SuppressedReason::Xep0513Noping,
+            });
+        }
+        if candidate.no_store() {
+            return Ok(T1PushDispatchOutcome::Suppressed {
+                reason: SuppressedReason::Xep0334NoStore,
+            });
+        }
+        if candidate.no_permanent_store() {
+            return Ok(T1PushDispatchOutcome::Suppressed {
+                reason: SuppressedReason::Xep0334NoPermanentStore,
+            });
+        }
     }
 
     let (conversation_kind, is_mention) = match candidate.class() {
@@ -3017,12 +3056,19 @@ pub(crate) async fn evaluate_xep0492_at_dispatch(
     // XEP-0492. The per-batch cache keys on (user → state) so a
     // recipient with many candidates in the same drain pass only
     // reads DnD once.
-    let dnd_state =
-        resolve_cached_dnd_state(dnd_reader, candidate.recipient_bare_jid(), dnd_cache).await?;
-    if matches!(dnd_state, DndState::Active) {
-        return Ok(T1PushDispatchOutcome::Suppressed {
-            reason: SuppressedReason::WaddleDnd,
-        });
+    //
+    // Skipped at T0Emit so a hinted candidate from a DnD'd recipient
+    // still persists (T1 then records DnD or hint reason as
+    // appropriate). DnD also moves with the recipient between T0
+    // and T1; the T1 re-evaluation is the authoritative read.
+    if stage == PushEvalStage::T1Drain {
+        let dnd_state =
+            resolve_cached_dnd_state(dnd_reader, candidate.recipient_bare_jid(), dnd_cache).await?;
+        if matches!(dnd_state, DndState::Active) {
+            return Ok(T1PushDispatchOutcome::Suppressed {
+                reason: SuppressedReason::WaddleDnd,
+            });
+        }
     }
     let level = settings_projection
         .effective_setting(
@@ -7801,6 +7847,111 @@ mod tests {
         assert_eq!(reason.as_deref(), Some("xep0191_blocked"));
         let rendered = waddle_xmpp::prometheus::render_metrics();
         assert!(rendered.contains("waddle_push_suppressed_total{reason=\"xep0191_blocked\"} 1"),);
+    }
+
+    /// Stage-split contract: the same hinted candidate MUST yield
+    /// `Deliver` when evaluated at [`PushEvalStage::T0Emit`] (so the
+    /// row gets persisted with its hint bits) and `Suppressed` at
+    /// [`PushEvalStage::T1Drain`] (where the typed `suppressed_reason`
+    /// audit fires). Without this split, hinted candidates would
+    /// disappear at T0 with no audit trail.
+    #[tokio::test]
+    async fn evaluator_stage_split_defers_hint_suppressors_to_t1() {
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
+        let dnd_reader = NoopDndReader;
+        let recipient = bare("alice@example.com");
+        let sender_jid: Jid = "bob@example.com/web".parse().expect("full sender");
+        let noping_candidate = NotificationCandidate::direct_message_with_hints(
+            recipient.clone(),
+            sender_jid.clone(),
+            StanzaId::new("stage-split-noping", Jid::from(recipient.clone())),
+            false,
+            NotificationMessageHints::none().with_noping(true),
+        )
+        .expect("candidate");
+        let mut room_policy_cache =
+            std::collections::BTreeMap::<BareJid, RoomPolicyCacheEntry>::new();
+        let mut dnd_cache = std::collections::BTreeMap::<BareJid, DndState>::new();
+
+        // T0Emit MUST NOT suppress on noping — the row must persist
+        // so T1 records the audit.
+        let t0 = evaluate_xep0492_at_dispatch(
+            PushEvalStage::T0Emit,
+            &projection,
+            &room_policy,
+            &dnd_reader,
+            &noping_candidate,
+            &mut room_policy_cache,
+            &mut dnd_cache,
+        )
+        .await
+        .expect("t0 eval");
+        assert!(
+            matches!(t0, T1PushDispatchOutcome::Deliver),
+            "T0Emit must NOT suppress on message-frozen `<noping/>` so the candidate persists; got {t0:?}"
+        );
+
+        // T1Drain MUST suppress with the typed Xep0513Noping reason.
+        let t1 = evaluate_xep0492_at_dispatch(
+            PushEvalStage::T1Drain,
+            &projection,
+            &room_policy,
+            &dnd_reader,
+            &noping_candidate,
+            &mut room_policy_cache,
+            &mut dnd_cache,
+        )
+        .await
+        .expect("t1 eval");
+        assert!(
+            matches!(
+                t1,
+                T1PushDispatchOutcome::Suppressed {
+                    reason: SuppressedReason::Xep0513Noping
+                }
+            ),
+            "T1Drain must suppress noping with the typed Xep0513Noping reason; got {t1:?}"
+        );
+
+        // Sanity: the same split applies to XEP-0334 hint bits.
+        let no_store_candidate = NotificationCandidate::direct_message_with_hints(
+            recipient.clone(),
+            sender_jid,
+            StanzaId::new("stage-split-no-store", Jid::from(recipient.clone())),
+            false,
+            NotificationMessageHints::none().with_xep0334(true, false),
+        )
+        .expect("candidate");
+        let t0_no_store = evaluate_xep0492_at_dispatch(
+            PushEvalStage::T0Emit,
+            &projection,
+            &room_policy,
+            &dnd_reader,
+            &no_store_candidate,
+            &mut room_policy_cache,
+            &mut dnd_cache,
+        )
+        .await
+        .expect("t0 eval");
+        assert!(matches!(t0_no_store, T1PushDispatchOutcome::Deliver));
+        let t1_no_store = evaluate_xep0492_at_dispatch(
+            PushEvalStage::T1Drain,
+            &projection,
+            &room_policy,
+            &dnd_reader,
+            &no_store_candidate,
+            &mut room_policy_cache,
+            &mut dnd_cache,
+        )
+        .await
+        .expect("t1 eval");
+        assert!(matches!(
+            t1_no_store,
+            T1PushDispatchOutcome::Suppressed {
+                reason: SuppressedReason::Xep0334NoStore
+            }
+        ));
     }
 
     /// XEP-0513 `<noping/>` carried on the candidate row MUST suppress

--- a/server/crates/waddle-server/src/notification_outbox.rs
+++ b/server/crates/waddle-server/src/notification_outbox.rs
@@ -57,6 +57,24 @@ const NOTIFICATION_OUTBOX_CLASS_VALUES: [&str; 6] = [
     "notify_all",
 ];
 const NOTIFICATION_OUTBOX_CLASS_CHECK_SQL: &str = "class IN ('dm', 'dm_mention', 'personal_mention', 'channel_mention', 'active_channel_mention', 'notify_all')";
+const NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_CHECK_NAME: &str =
+    "notification_candidates_suppressed_reason_check";
+const NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_VALUES: [&str; 13] = [
+    "xep0357_self",
+    "xep0357_no_registration",
+    "xep0357_registration_disabled",
+    "xep0492_never",
+    "xep0492_on_mention_miss",
+    "xep0191_blocked",
+    "xep0513_noping",
+    "xep0513_active_miss",
+    "xep0334_no_store",
+    "xep0334_no_permanent_store",
+    "waddle_dnd",
+    "provider_rejected",
+    "provider_token_expired",
+];
+const NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_CHECK_SQL: &str = "suppressed_reason IS NULL OR suppressed_reason IN ('xep0357_self', 'xep0357_no_registration', 'xep0357_registration_disabled', 'xep0492_never', 'xep0492_on_mention_miss', 'xep0191_blocked', 'xep0513_noping', 'xep0513_active_miss', 'xep0334_no_store', 'xep0334_no_permanent_store', 'waddle_dnd', 'provider_rejected', 'provider_token_expired')";
 const NOTIFICATION_CANDIDATES_INDEXES: [&str; 4] = [
     "idx_notification_candidates_recipient_created",
     "idx_notification_candidates_identity",
@@ -193,6 +211,124 @@ impl NotificationReason {
     }
 }
 
+/// Typed audit reason for a suppressed XEP-0357 notification candidate.
+///
+/// Closed set — one variant per XEP/Waddle rule that can suppress a
+/// push notification. Persisted into `notification_candidates.suppressed_reason`
+/// alongside the existing `class`/`reason` columns whenever the T1
+/// drain decides to mark a candidate outboxed *without* enqueueing a
+/// job. Also labels the `waddle_push_suppressed_total` metric so
+/// deployments can observe per-rule suppression rates.
+///
+/// `SuppressedReason` is the **audit shape**, distinct from the
+/// dispatch shape ([`T1PushDispatchOutcome`]): the evaluator decides
+/// publish/suppress/defer, this enum records *why* a suppression
+/// happened so adversarial review can branch on the exact rule
+/// without stringly-typed sniffing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum SuppressedReason {
+    /// Self-DM rejected at the [`NotificationCandidate`] constructor
+    /// boundary. Reserved variant; emitted by the constructor-rejection
+    /// path is structurally a no-row outcome, but the audit shape
+    /// exists so race-window state changes can record it.
+    Xep0357Self,
+    /// Recipient has no XEP-0357 push registration. Reserved variant;
+    /// emitted by the publish-layer disable transitions
+    /// (XEP-0357 §6) in later slices.
+    Xep0357NoRegistration,
+    /// Recipient's XEP-0357 push registration was disabled in
+    /// response to a stanza-error from the push service
+    /// (XEP-0357 §6). Reserved variant; emitted at publish time.
+    Xep0357RegistrationDisabled,
+    /// XEP-0492 setting resolved to `<never/>` at T1.
+    Xep0492Never,
+    /// XEP-0492 setting resolved to `<on-mention/>` and the candidate
+    /// is not a mention class.
+    Xep0492OnMentionMiss,
+    /// XEP-0191 blocklist matched the candidate's sender/conversation.
+    Xep0191Blocked,
+    /// XEP-0513 explicit mention carried `<noping/>` — sender opted
+    /// out of pinging this recipient for the mention.
+    Xep0513Noping,
+    /// XEP-0513 `<active/>` filter missed — reserved variant; emitted
+    /// in slice 2b once the `notification_activity` projection lands.
+    Xep0513ActiveMiss,
+    /// XEP-0334 `<no-store/>` hint on the message.
+    Xep0334NoStore,
+    /// XEP-0334 `<no-permanent-store/>` hint on the message.
+    Xep0334NoPermanentStore,
+    /// Waddle DnD state is active for the recipient.
+    WaddleDnd,
+    /// Push provider rejected the published payload. Reserved variant;
+    /// emitted by provider slices (#528 / #529 / #530).
+    ProviderRejected,
+    /// Push provider returned an expired-token signal. Reserved
+    /// variant; emitted by provider slices.
+    ProviderTokenExpired,
+}
+
+impl SuppressedReason {
+    /// Every variant of the closed audit set, in declaration order.
+    ///
+    /// Exposed so the runtime schema migration / test surface can
+    /// iterate the typed values without re-declaring them. Reserved
+    /// variants (`Xep0357Self`, the provider variants, and
+    /// `Xep0513ActiveMiss`) are kept in this list deliberately — they
+    /// are part of the closed audit shape today; provider slices and
+    /// slice 2b wire the emitters.
+    pub(crate) const ALL: &'static [SuppressedReason] = &[
+        Self::Xep0357Self,
+        Self::Xep0357NoRegistration,
+        Self::Xep0357RegistrationDisabled,
+        Self::Xep0492Never,
+        Self::Xep0492OnMentionMiss,
+        Self::Xep0191Blocked,
+        Self::Xep0513Noping,
+        Self::Xep0513ActiveMiss,
+        Self::Xep0334NoStore,
+        Self::Xep0334NoPermanentStore,
+        Self::WaddleDnd,
+        Self::ProviderRejected,
+        Self::ProviderTokenExpired,
+    ];
+
+    pub(crate) fn as_db_value(self) -> &'static str {
+        match self {
+            Self::Xep0357Self => "xep0357_self",
+            Self::Xep0357NoRegistration => "xep0357_no_registration",
+            Self::Xep0357RegistrationDisabled => "xep0357_registration_disabled",
+            Self::Xep0492Never => "xep0492_never",
+            Self::Xep0492OnMentionMiss => "xep0492_on_mention_miss",
+            Self::Xep0191Blocked => "xep0191_blocked",
+            Self::Xep0513Noping => "xep0513_noping",
+            Self::Xep0513ActiveMiss => "xep0513_active_miss",
+            Self::Xep0334NoStore => "xep0334_no_store",
+            Self::Xep0334NoPermanentStore => "xep0334_no_permanent_store",
+            Self::WaddleDnd => "waddle_dnd",
+            Self::ProviderRejected => "provider_rejected",
+            Self::ProviderTokenExpired => "provider_token_expired",
+        }
+    }
+
+    pub(crate) fn from_db_value(value: &str) -> Result<Self, NotificationOutboxError> {
+        // Iterate the closed `ALL` set rather than re-listing the
+        // variants in a `match` arm — keeps the audit shape, the
+        // schema CHECK list, and the prometheus label set in
+        // lockstep without three independently-edited match arms.
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|variant| variant.as_db_value() == value)
+            .ok_or_else(|| NotificationOutboxError::InvalidSuppressedReason(value.to_string()))
+    }
+}
+
+impl std::fmt::Display for SuppressedReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_db_value())
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NotificationOutboxStatus {
     Queued,
@@ -223,6 +359,52 @@ pub struct NotificationCandidate {
     class: NotificationClass,
     reason: NotificationReason,
     policy_error_count: i64,
+    /// XEP-0513 `<noping/>` mention hint, message-frozen at T0. When
+    /// `true`, the T1 evaluator suppresses the candidate with
+    /// [`SuppressedReason::Xep0513Noping`] — sender opted the
+    /// recipient out of being pinged for this mention.
+    noping: bool,
+    /// XEP-0334 `<no-store/>` hint, message-frozen at T0. When `true`
+    /// the T1 evaluator suppresses with
+    /// [`SuppressedReason::Xep0334NoStore`].
+    no_store: bool,
+    /// XEP-0334 `<no-permanent-store/>` hint, message-frozen at T0.
+    /// When `true` the T1 evaluator suppresses with
+    /// [`SuppressedReason::Xep0334NoPermanentStore`].
+    no_permanent_store: bool,
+}
+
+/// Message-frozen suppression hints carried on a
+/// [`NotificationCandidate`] from T0 emission to T1 dispatch.
+///
+/// Per locked Q3 (see #506), T0 declines candidates only for
+/// structural-validity reasons (self-DM). Message-frozen suppression
+/// hints like XEP-0513 `<noping/>` and XEP-0334 storage hints are
+/// recipient-level signals from the sender — the candidate is still
+/// constructed and persisted, and the T1 evaluator reads the hint
+/// back and suppresses with the typed `SuppressedReason`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct NotificationMessageHints {
+    pub noping: bool,
+    pub no_store: bool,
+    pub no_permanent_store: bool,
+}
+
+impl NotificationMessageHints {
+    pub fn none() -> Self {
+        Self::default()
+    }
+
+    pub fn with_noping(mut self, noping: bool) -> Self {
+        self.noping = noping;
+        self
+    }
+
+    pub fn with_xep0334(mut self, no_store: bool, no_permanent_store: bool) -> Self {
+        self.no_store = no_store;
+        self.no_permanent_store = no_permanent_store;
+        self
+    }
 }
 
 impl NotificationCandidate {
@@ -231,6 +413,22 @@ impl NotificationCandidate {
         sender_jid: Jid,
         archive_stanza_id: StanzaId,
         is_mention: bool,
+    ) -> Result<Self, NotificationOutboxError> {
+        Self::direct_message_with_hints(
+            recipient_bare_jid,
+            sender_jid,
+            archive_stanza_id,
+            is_mention,
+            NotificationMessageHints::none(),
+        )
+    }
+
+    pub fn direct_message_with_hints(
+        recipient_bare_jid: BareJid,
+        sender_jid: Jid,
+        archive_stanza_id: StanzaId,
+        is_mention: bool,
+        hints: NotificationMessageHints,
     ) -> Result<Self, NotificationOutboxError> {
         require_full_sender_jid(&sender_jid)?;
         // Structural invariant: a notification candidate cannot be
@@ -276,6 +474,9 @@ impl NotificationCandidate {
             class,
             reason,
             policy_error_count: 0,
+            noping: hints.noping,
+            no_store: hints.no_store,
+            no_permanent_store: hints.no_permanent_store,
         })
     }
 
@@ -286,6 +487,26 @@ impl NotificationCandidate {
         thread_id: NotificationThreadId,
         archive_stanza_id: StanzaId,
         class: NotificationClass,
+    ) -> Result<Self, NotificationOutboxError> {
+        Self::groupchat_with_hints(
+            recipient_bare_jid,
+            conversation_jid,
+            sender_jid,
+            thread_id,
+            archive_stanza_id,
+            class,
+            NotificationMessageHints::none(),
+        )
+    }
+
+    pub fn groupchat_with_hints(
+        recipient_bare_jid: BareJid,
+        conversation_jid: BareJid,
+        sender_jid: Jid,
+        thread_id: NotificationThreadId,
+        archive_stanza_id: StanzaId,
+        class: NotificationClass,
+        hints: NotificationMessageHints,
     ) -> Result<Self, NotificationOutboxError> {
         require_full_sender_jid(&sender_jid)?;
         require_sender_matches_conversation(&sender_jid, &conversation_jid)?;
@@ -318,6 +539,9 @@ impl NotificationCandidate {
             class,
             reason,
             policy_error_count: 0,
+            noping: hints.noping,
+            no_store: hints.no_store,
+            no_permanent_store: hints.no_permanent_store,
         })
     }
 
@@ -347,6 +571,18 @@ impl NotificationCandidate {
 
     pub fn reason(&self) -> NotificationReason {
         self.reason
+    }
+
+    pub fn noping(&self) -> bool {
+        self.noping
+    }
+
+    pub fn no_store(&self) -> bool {
+        self.no_store
+    }
+
+    pub fn no_permanent_store(&self) -> bool {
+        self.no_permanent_store
     }
 }
 
@@ -518,6 +754,12 @@ pub enum NotificationOutboxError {
     InvalidClass(String),
     #[error("invalid candidate reason: {0}")]
     InvalidReason(String),
+    #[error("invalid suppressed reason: {0}")]
+    InvalidSuppressedReason(String),
+    #[error("notification settings projection error: {0}")]
+    NotificationSettings(
+        #[from] crate::notification_settings_projection::NotificationSettingsProjectionError,
+    ),
     #[error("invalid outbox status: {0}")]
     InvalidStatus(String),
     #[error("invalid recipient bare JID in notification outbox: {0}")]
@@ -603,6 +845,70 @@ impl RoomPolicyStore for NoopRoomPolicy {
     }
 }
 
+/// Typed recipient-level Do Not Disturb state, consulted at T1 push
+/// dispatch.
+///
+/// `Inactive` means the recipient is NOT in DND; the evaluator
+/// proceeds with the XEP-0492 / XEP-0191 / XEP-0513 / XEP-0334 gates.
+/// `Active` means the evaluator MUST suppress the candidate with
+/// [`SuppressedReason::WaddleDnd`]. The DND state is a recipient-state
+/// read (not a message-frozen fact), so the consultation belongs at
+/// T1 alongside XEP-0492 — the same race-window semantics apply.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DndState {
+    Inactive,
+    Active,
+}
+
+/// T1 lookup of the recipient's Waddle DnD state.
+///
+/// Slice 2a wires this trait into the evaluator with [`NoopDndReader`]
+/// at every call site so the typed signature flows end-to-end without
+/// behavior change. Issue #367 lands the real implementation backed by
+/// a `urn:waddle:dnd:0` PEP projection — that PR can swap the noop
+/// for the production reader without touching the evaluator.
+#[async_trait::async_trait]
+pub trait DndReader: Send + Sync {
+    async fn dnd_state(&self, user: &BareJid) -> Result<DndState, NotificationOutboxError>;
+}
+
+/// Default [`DndReader`] that reports every user as not-in-DND.
+///
+/// Used at every call site in slice 2a as a typed placeholder. The
+/// real impl arrives in #367.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopDndReader;
+
+#[async_trait::async_trait]
+impl DndReader for NoopDndReader {
+    async fn dnd_state(&self, _user: &BareJid) -> Result<DndState, NotificationOutboxError> {
+        Ok(DndState::Inactive)
+    }
+}
+
+/// Typed bundle of T1 recipient-state readers consulted by
+/// [`NotificationOutboxStore::drain_pending_candidates_into_outbox`].
+///
+/// Bundling these reduces the drain method's argument count below
+/// the clippy `too_many_arguments` threshold without losing
+/// explicitness — each field is a trait object, so call sites pass
+/// distinct concrete implementations rather than a single composite
+/// dependency.
+#[derive(Copy, Clone)]
+pub struct NotificationDrainDeps<'a> {
+    pub room_policy: &'a dyn RoomPolicyStore,
+    pub dnd_reader: &'a dyn DndReader,
+}
+
+impl<'a> NotificationDrainDeps<'a> {
+    pub fn new(room_policy: &'a dyn RoomPolicyStore, dnd_reader: &'a dyn DndReader) -> Self {
+        Self {
+            room_policy,
+            dnd_reader,
+        }
+    }
+}
+
 fn require_full_sender_jid(sender_jid: &Jid) -> Result<(), NotificationOutboxError> {
     if sender_jid.resource().is_some() {
         Ok(())
@@ -673,6 +979,10 @@ fn notification_candidates_table_sql(i64_type: &str, if_not_exists: bool) -> Str
             policy_error_count INTEGER NOT NULL DEFAULT 0,
             next_attempt_at_ms {i64_type},
             outboxed_at_ms {i64_type},
+            suppressed_reason TEXT CONSTRAINT {NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_CHECK_NAME} CHECK ({NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_CHECK_SQL}),
+            noping INTEGER NOT NULL DEFAULT 0,
+            no_store INTEGER NOT NULL DEFAULT 0,
+            no_permanent_store INTEGER NOT NULL DEFAULT 0,
             PRIMARY KEY (recipient_bare_jid, conversation_jid, thread_id, stanza_id_by, stanza_id, class)
         )
         "#
@@ -752,6 +1062,14 @@ fn notification_outbox_class_constraint_matches_expected(definition: &str) -> bo
             .all(|class| constraint_definition_quotes_value(&normalized, class))
 }
 
+fn notification_candidates_suppressed_reason_constraint_matches_expected(definition: &str) -> bool {
+    let normalized = definition.to_ascii_lowercase();
+    normalized.contains("suppressed_reason")
+        && NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_VALUES
+            .iter()
+            .all(|reason| constraint_definition_quotes_value(&normalized, reason))
+}
+
 #[derive(Clone)]
 pub struct NotificationOutboxStore {
     db: Database,
@@ -765,6 +1083,22 @@ impl NotificationOutboxStore {
     }
 
     async fn initialize(&self) -> Result<(), NotificationOutboxError> {
+        // Startup invariant: every closed-set typed `SuppressedReason`
+        // db value MUST round-trip through `from_db_value`. This is a
+        // typed sanity check that the enum, its db values, the schema
+        // CHECK constraint, and the prometheus labels are in lockstep.
+        // A mismatched build fails fast at process start rather than
+        // surfacing as a confusing `CHECK violation` during the first
+        // real suppression.
+        for reason in SuppressedReason::ALL.iter().copied() {
+            let db = reason.as_db_value();
+            let decoded = SuppressedReason::from_db_value(db)?;
+            if decoded != reason {
+                return Err(NotificationOutboxError::InvalidSuppressedReason(format!(
+                    "round-trip mismatch for {db}: decoded {decoded:?}",
+                )));
+            }
+        }
         let i64_type = crate::db::i64_sql_type(self.db.driver());
         self.execute(&notification_candidates_table_sql(i64_type, true), ())
             .await?;
@@ -778,9 +1112,35 @@ impl NotificationOutboxStore {
         let candidate_next_attempt_column = format!("next_attempt_at_ms {i64_type}");
         self.add_column_if_missing("notification_candidates", &candidate_next_attempt_column)
             .await?;
+        // Reason/class CHECK migrations rebuild the table from a legacy
+        // schema; they MUST run before the slice-2a columns are added
+        // because the rebuild INSERT only copies the original column
+        // set. Adding the slice-2a columns afterward then either creates
+        // the column for-the-first-time (legacy upgrade) or is a no-op
+        // (cold init, since `notification_candidates_table_sql` already
+        // declares them).
         self.migrate_notification_candidates_reason_constraint(i64_type)
             .await?;
         self.migrate_notification_candidates_class_constraint(i64_type)
+            .await?;
+        self.add_column_if_missing("notification_candidates", "suppressed_reason TEXT")
+            .await?;
+        self.add_column_if_missing(
+            "notification_candidates",
+            "noping INTEGER NOT NULL DEFAULT 0",
+        )
+        .await?;
+        self.add_column_if_missing(
+            "notification_candidates",
+            "no_store INTEGER NOT NULL DEFAULT 0",
+        )
+        .await?;
+        self.add_column_if_missing(
+            "notification_candidates",
+            "no_permanent_store INTEGER NOT NULL DEFAULT 0",
+        )
+        .await?;
+        self.migrate_notification_candidates_suppressed_reason_constraint(i64_type)
             .await?;
         self.execute(
             "CREATE INDEX IF NOT EXISTS idx_notification_candidates_recipient_created \
@@ -1083,6 +1443,130 @@ impl NotificationOutboxStore {
         ))
     }
 
+    async fn migrate_notification_candidates_suppressed_reason_constraint(
+        &self,
+        i64_type: &str,
+    ) -> Result<(), NotificationOutboxError> {
+        match self.db.driver() {
+            crate::db::DatabaseDriver::Postgres => {
+                self.migrate_postgres_notification_candidates_suppressed_reason_constraint()
+                    .await
+            }
+            crate::db::DatabaseDriver::Sqlite => {
+                self.migrate_sqlite_notification_candidates_suppressed_reason_constraint(i64_type)
+                    .await
+            }
+        }
+    }
+
+    async fn migrate_postgres_notification_candidates_suppressed_reason_constraint(
+        &self,
+    ) -> Result<(), NotificationOutboxError> {
+        self.migrate_postgres_check_constraint_on_column(
+            "notification_candidates",
+            "suppressed_reason",
+            NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_CHECK_NAME,
+            NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_CHECK_SQL,
+            notification_candidates_suppressed_reason_constraint_matches_expected,
+        )
+        .await
+    }
+
+    /// SQLite does not enforce CHECK constraints added after CREATE
+    /// TABLE for existing rows, and adding a new CHECK requires a
+    /// rebuild. Following the existing pattern, when the current
+    /// schema text does not advertise the expected suppressed_reason
+    /// CHECK we rebuild via rename-old → create-new → copy.
+    async fn migrate_sqlite_notification_candidates_suppressed_reason_constraint(
+        &self,
+        i64_type: &str,
+    ) -> Result<(), NotificationOutboxError> {
+        if !self
+            .sqlite_notification_candidates_suppressed_reason_constraint_is_stale()
+            .await?
+        {
+            return Ok(());
+        }
+
+        let mut tx = self.db.begin().await?;
+        for index in NOTIFICATION_CANDIDATES_INDEXES {
+            tx.execute(&format!("DROP INDEX IF EXISTS {index}"), ())
+                .await?;
+        }
+        tx.execute(
+            "ALTER TABLE notification_candidates RENAME TO notification_candidates_old_suppressed_reason_check",
+            (),
+        )
+        .await?;
+        tx.execute(&notification_candidates_table_sql(i64_type, false), ())
+            .await?;
+        tx.execute(
+            r#"
+            INSERT INTO notification_candidates (
+                recipient_bare_jid,
+                conversation_jid,
+                sender_jid,
+                thread_id,
+                stanza_id_by,
+                stanza_id,
+                class,
+                reason,
+                created_at_ms,
+                policy_error_count,
+                next_attempt_at_ms,
+                outboxed_at_ms,
+                suppressed_reason,
+                noping,
+                no_store,
+                no_permanent_store
+            )
+            SELECT
+                recipient_bare_jid,
+                conversation_jid,
+                sender_jid,
+                thread_id,
+                stanza_id_by,
+                stanza_id,
+                class,
+                reason,
+                created_at_ms,
+                policy_error_count,
+                next_attempt_at_ms,
+                outboxed_at_ms,
+                suppressed_reason,
+                noping,
+                no_store,
+                no_permanent_store
+            FROM notification_candidates_old_suppressed_reason_check
+            "#,
+            (),
+        )
+        .await?;
+        tx.execute(
+            "DROP TABLE notification_candidates_old_suppressed_reason_check",
+            (),
+        )
+        .await?;
+        tx.commit().await?;
+        Ok(())
+    }
+
+    async fn sqlite_notification_candidates_suppressed_reason_constraint_is_stale(
+        &self,
+    ) -> Result<bool, NotificationOutboxError> {
+        let mut rows = self
+            .query(
+                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'notification_candidates'",
+                (),
+            )
+            .await?;
+        let Some(row) = rows.next().await? else {
+            return Ok(false);
+        };
+        let create_sql: String = row.get(0)?;
+        Ok(!notification_candidates_suppressed_reason_constraint_matches_expected(&create_sql))
+    }
+
     async fn migrate_notification_outbox_class_constraint(
         &self,
         i64_type: &str,
@@ -1366,8 +1850,12 @@ impl NotificationOutboxStore {
                     created_at_ms,
                     policy_error_count,
                     next_attempt_at_ms,
-                    outboxed_at_ms
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL)
+                    outboxed_at_ms,
+                    suppressed_reason,
+                    noping,
+                    no_store,
+                    no_permanent_store
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, ?, ?, ?)
                 ON CONFLICT DO NOTHING
                 "#,
                 crate::db_params![
@@ -1381,6 +1869,9 @@ impl NotificationOutboxStore {
                     candidate.reason.as_db_value(),
                     now_ms,
                     0_i64,
+                    i64::from(candidate.noping),
+                    i64::from(candidate.no_store),
+                    i64::from(candidate.no_permanent_store),
                 ],
             )
             .await?;
@@ -1395,15 +1886,20 @@ impl NotificationOutboxStore {
         push_store: &dyn PushSubscriptionStore,
         blocking_storage: &dyn BlockingStorage,
         settings_projection: &crate::notification_settings_projection::NotificationSettingsProjectionStore,
-        room_policy: &dyn RoomPolicyStore,
+        deps: NotificationDrainDeps<'_>,
         first_party_service_jid: &BareJid,
         batch_size: usize,
     ) -> Result<usize, NotificationOutboxError> {
+        let NotificationDrainDeps {
+            room_policy,
+            dnd_reader,
+        } = deps;
         let candidates = self.pending_candidates(batch_size).await?;
         let mut target_cache =
             std::collections::BTreeMap::<BareJid, Vec<NotificationOutboxTarget>>::new();
         let mut room_policy_cache =
             std::collections::BTreeMap::<BareJid, RoomPolicyCacheEntry>::new();
+        let mut dnd_cache = std::collections::BTreeMap::<BareJid, DndState>::new();
         let mut processed = 0usize;
         for candidate in candidates {
             // Self-DM filtering happens at the `NotificationCandidate`
@@ -1417,9 +1913,18 @@ impl NotificationOutboxStore {
                 Ok(true) => {
                     let now_ms = crate::time::now_ms();
                     let mut tx = self.db.begin().await?;
+                    record_candidate_suppressed_reason_tx(
+                        &mut tx,
+                        &candidate,
+                        SuppressedReason::Xep0191Blocked,
+                    )
+                    .await?;
                     let claimed = mark_candidate_outboxed_tx(&mut tx, &candidate, now_ms).await?;
                     tx.commit().await?;
                     if claimed > 0 {
+                        waddle_xmpp::prometheus::increment_push_suppressed(
+                            SuppressedReason::Xep0191Blocked.as_db_value(),
+                        );
                         processed += 1;
                     }
                     continue;
@@ -1466,8 +1971,10 @@ impl NotificationOutboxStore {
             let outcome = match evaluate_xep0492_at_dispatch(
                 settings_projection,
                 room_policy,
+                dnd_reader,
                 &candidate,
                 &mut room_policy_cache,
+                &mut dnd_cache,
             )
             .await
             {
@@ -1491,13 +1998,15 @@ impl NotificationOutboxStore {
                         sender = %candidate.sender_jid(),
                         class = ?candidate.class(),
                         %reason,
-                        "XEP-0492 push gate suppressed XEP-0357 notification candidate at T1"
+                        "T1 push gate suppressed XEP-0357 notification candidate"
                     );
                     let now_ms = crate::time::now_ms();
                     let mut tx = self.db.begin().await?;
+                    record_candidate_suppressed_reason_tx(&mut tx, &candidate, reason).await?;
                     let claimed = mark_candidate_outboxed_tx(&mut tx, &candidate, now_ms).await?;
                     tx.commit().await?;
                     if claimed > 0 {
+                        waddle_xmpp::prometheus::increment_push_suppressed(reason.as_db_value());
                         processed += 1;
                     }
                     continue;
@@ -1603,7 +2112,10 @@ impl NotificationOutboxStore {
                        stanza_id,
                        class,
                        reason,
-                       policy_error_count
+                       policy_error_count,
+                       noping,
+                       no_store,
+                       no_permanent_store
                 FROM notification_candidates
                 WHERE outboxed_at_ms IS NULL
                   AND (next_attempt_at_ms IS NULL OR next_attempt_at_ms <= ?)
@@ -2327,12 +2839,12 @@ impl NotificationOutboxStore {
 pub(crate) enum T1PushDispatchOutcome {
     /// XEP-0492 gate decided to fan out; enqueue the push job.
     Deliver,
-    /// XEP-0492 gate decided to suppress; mark candidate outboxed
-    /// without enqueuing a job. `reason` is the resolved
-    /// `NotificationLevel` that caused suppression.
-    Suppressed {
-        reason: waddle_xmpp::xep::NotificationLevel,
-    },
+    /// Push gate decided to suppress; mark candidate outboxed without
+    /// enqueueing a job. `reason` is the typed audit reason that
+    /// caused suppression (XEP-0492 `<never/>` / `<on-mention/>` miss,
+    /// XEP-0191 blocking, XEP-0513 `<noping/>`, XEP-0334 hint, or
+    /// Waddle DnD).
+    Suppressed { reason: SuppressedReason },
     /// MUC config could not be resolved (room actor unavailable or
     /// failed). Defer with policy-error backoff so the next drain
     /// pass can retry once the actor (or, slice 2, the durable
@@ -2421,12 +2933,32 @@ pub(crate) enum UnknownRoomPolicySource {
 pub(crate) async fn evaluate_xep0492_at_dispatch(
     settings_projection: &crate::notification_settings_projection::NotificationSettingsProjectionStore,
     room_policy: &dyn RoomPolicyStore,
+    dnd_reader: &dyn DndReader,
     candidate: &NotificationCandidate,
     room_policy_cache: &mut std::collections::BTreeMap<BareJid, RoomPolicyCacheEntry>,
-) -> Result<
-    T1PushDispatchOutcome,
-    crate::notification_settings_projection::NotificationSettingsProjectionError,
-> {
+    dnd_cache: &mut std::collections::BTreeMap<BareJid, DndState>,
+) -> Result<T1PushDispatchOutcome, NotificationOutboxError> {
+    // Message-frozen suppressors take precedence over recipient-state
+    // reads: a sender's `<noping/>` mention or XEP-0334 storage hint
+    // is a final decision by the sender and cannot be overridden by
+    // recipient settings. Evaluate these before issuing storage reads
+    // so the typed outcome captures the most-specific signal first.
+    if candidate.noping() {
+        return Ok(T1PushDispatchOutcome::Suppressed {
+            reason: SuppressedReason::Xep0513Noping,
+        });
+    }
+    if candidate.no_store() {
+        return Ok(T1PushDispatchOutcome::Suppressed {
+            reason: SuppressedReason::Xep0334NoStore,
+        });
+    }
+    if candidate.no_permanent_store() {
+        return Ok(T1PushDispatchOutcome::Suppressed {
+            reason: SuppressedReason::Xep0334NoPermanentStore,
+        });
+    }
+
     let (conversation_kind, is_mention) = match candidate.class() {
         NotificationClass::DirectMessage => (
             crate::notification_settings_projection::ConversationKind::Direct,
@@ -2481,6 +3013,17 @@ pub(crate) async fn evaluate_xep0492_at_dispatch(
             }
         }
     };
+    // Waddle DnD is a recipient-state read, fresh-at-T1 alongside
+    // XEP-0492. The per-batch cache keys on (user → state) so a
+    // recipient with many candidates in the same drain pass only
+    // reads DnD once.
+    let dnd_state =
+        resolve_cached_dnd_state(dnd_reader, candidate.recipient_bare_jid(), dnd_cache).await?;
+    if matches!(dnd_state, DndState::Active) {
+        return Ok(T1PushDispatchOutcome::Suppressed {
+            reason: SuppressedReason::WaddleDnd,
+        });
+    }
     let level = settings_projection
         .effective_setting(
             candidate.recipient_bare_jid(),
@@ -2495,9 +3038,51 @@ pub(crate) async fn evaluate_xep0492_at_dispatch(
             T1PushDispatchOutcome::Deliver
         }
         crate::notification_settings_projection::PushDispatchDecision::Suppressed { reason } => {
-            T1PushDispatchOutcome::Suppressed { reason }
+            T1PushDispatchOutcome::Suppressed {
+                reason: suppressed_reason_for_level(reason, is_mention),
+            }
         }
     })
+}
+
+/// Translates a XEP-0492 [`waddle_xmpp::xep::NotificationLevel`]
+/// suppression outcome into the typed [`SuppressedReason`] audit
+/// variant.
+///
+/// `<never/>` always maps to `Xep0492Never`. `<on-mention/>` maps to
+/// `Xep0492OnMentionMiss` because the XEP-0492 evaluator only emits
+/// the `Suppressed` outcome when `should_notify(is_mention)` is false
+/// — and for `OnMention` that means `is_mention == false`.
+/// `<always/>` never produces a `Suppressed` outcome.
+fn suppressed_reason_for_level(
+    level: waddle_xmpp::xep::NotificationLevel,
+    _is_mention: bool,
+) -> SuppressedReason {
+    match level {
+        waddle_xmpp::xep::NotificationLevel::Never => SuppressedReason::Xep0492Never,
+        waddle_xmpp::xep::NotificationLevel::OnMention => SuppressedReason::Xep0492OnMentionMiss,
+        waddle_xmpp::xep::NotificationLevel::Always => {
+            // Unreachable in practice — `Always.should_notify(_) ==
+            // true` so the evaluator never produces `Suppressed` for
+            // it. Default to OnMention-miss to keep the closed-set
+            // invariant if the upstream reducer ever drifts; the
+            // dedicated XEP-0492 unit tests cover the live mapping.
+            SuppressedReason::Xep0492OnMentionMiss
+        }
+    }
+}
+
+async fn resolve_cached_dnd_state(
+    dnd_reader: &dyn DndReader,
+    user: &BareJid,
+    cache: &mut std::collections::BTreeMap<BareJid, DndState>,
+) -> Result<DndState, NotificationOutboxError> {
+    if let Some(state) = cache.get(user) {
+        return Ok(*state);
+    }
+    let state = dnd_reader.dnd_state(user).await?;
+    cache.insert(user.clone(), state);
+    Ok(state)
 }
 
 /// Looks up `room` in the per-batch policy cache, populating on miss.
@@ -2872,6 +3457,44 @@ async fn mark_candidate_outboxed_tx(
         .await?)
 }
 
+/// Records a typed [`SuppressedReason`] onto a not-yet-outboxed
+/// candidate row inside an active transaction. Always called BEFORE
+/// [`mark_candidate_outboxed_tx`] in the T1 suppression path so the
+/// `suppressed_reason` column persists for the row's lifetime in the
+/// outboxed-prune retention window.
+async fn record_candidate_suppressed_reason_tx(
+    tx: &mut crate::db::Transaction<'_>,
+    candidate: &NotificationCandidate,
+    reason: SuppressedReason,
+) -> Result<u64, NotificationOutboxError> {
+    Ok(tx
+        .execute(
+            r#"
+            UPDATE notification_candidates
+            SET suppressed_reason = ?
+            WHERE recipient_bare_jid = ?
+              AND conversation_jid = ?
+              AND sender_jid = ?
+              AND thread_id = ?
+              AND stanza_id_by = ?
+              AND stanza_id = ?
+              AND class = ?
+              AND outboxed_at_ms IS NULL
+            "#,
+            crate::db_params![
+                reason.as_db_value(),
+                candidate.recipient_bare_jid.to_string(),
+                candidate.conversation_jid.to_string(),
+                candidate.sender_jid.to_string(),
+                candidate.thread_id.as_str(),
+                candidate.archive_stanza_id.by.to_string(),
+                candidate.archive_stanza_id.id.clone(),
+                candidate.class.as_db_value(),
+            ],
+        )
+        .await?)
+}
+
 async fn resolve_first_party_targets(
     push_store: &dyn PushSubscriptionStore,
     recipient: &BareJid,
@@ -2974,6 +3597,9 @@ fn decode_candidate(row: &Row) -> Result<NotificationCandidate, NotificationOutb
         class: NotificationClass::from_db_value(&row.get::<String>(6)?)?,
         reason: NotificationReason::from_db_value(&row.get::<String>(7)?)?,
         policy_error_count: row.get(8)?,
+        noping: row.get::<i64>(9)? != 0,
+        no_store: row.get::<i64>(10)? != 0,
+        no_permanent_store: row.get::<i64>(11)? != 0,
     })
 }
 
@@ -4273,7 +4899,7 @@ mod tests {
                     &push_store,
                     &blocking,
                     &projection,
-                    &room_policy,
+                    NotificationDrainDeps::new(&room_policy, &NoopDndReader),
                     &bare("push.example.com"),
                     16,
                 )
@@ -4360,7 +4986,7 @@ mod tests {
                     &push_store,
                     &blocking,
                     &projection,
-                    &room_policy,
+                    NotificationDrainDeps::new(&room_policy, &NoopDndReader),
                     &bare("push.example.com"),
                     16,
                 )
@@ -4434,7 +5060,7 @@ mod tests {
                     &push_store,
                     &blocking,
                     &projection,
-                    &room_policy,
+                    NotificationDrainDeps::new(&room_policy, &NoopDndReader),
                     &bare("push.example.com"),
                     16,
                 )
@@ -4505,7 +5131,7 @@ mod tests {
                     &push_store,
                     &blocking,
                     &projection,
-                    &room_policy,
+                    NotificationDrainDeps::new(&room_policy, &NoopDndReader),
                     &bare("push.example.com"),
                     16,
                 )
@@ -4575,7 +5201,7 @@ mod tests {
                     &push_store,
                     &blocking,
                     &projection,
-                    &room_policy,
+                    NotificationDrainDeps::new(&room_policy, &NoopDndReader),
                     &bare("push.example.com"),
                     16,
                 )
@@ -4640,7 +5266,7 @@ mod tests {
                     &push_store,
                     &blocking,
                     &projection,
-                    &room_policy,
+                    NotificationDrainDeps::new(&room_policy, &NoopDndReader),
                     &bare("push.example.com"),
                     16,
                 )
@@ -4698,7 +5324,7 @@ mod tests {
                     &push_store,
                     &blocking,
                     &projection,
-                    &room_policy,
+                    NotificationDrainDeps::new(&room_policy, &NoopDndReader),
                     &bare("push.example.com"),
                     16,
                 )
@@ -4749,7 +5375,7 @@ mod tests {
                     &push_store,
                     &blocking,
                     &projection,
-                    &room_policy,
+                    NotificationDrainDeps::new(&room_policy, &NoopDndReader),
                     &bare("push.example.com"),
                     16,
                 )
@@ -4781,7 +5407,7 @@ mod tests {
                     &push_store,
                     &blocking,
                     &projection,
-                    &room_policy,
+                    NotificationDrainDeps::new(&room_policy, &NoopDndReader),
                     &bare("push.example.com"),
                     16,
                 )
@@ -4825,7 +5451,7 @@ mod tests {
                     &push_store,
                     &blocking,
                     &projection,
-                    &room_policy,
+                    NotificationDrainDeps::new(&room_policy, &NoopDndReader),
                     &bare("push.example.com"),
                     16,
                 )
@@ -4856,7 +5482,7 @@ mod tests {
                     &push_store,
                     &blocking,
                     &projection,
-                    &room_policy,
+                    NotificationDrainDeps::new(&room_policy, &NoopDndReader),
                     &bare("push.example.com"),
                     16,
                 )
@@ -4900,7 +5526,7 @@ mod tests {
                     &push_store,
                     &blocking,
                     &projection,
-                    &room_policy,
+                    NotificationDrainDeps::new(&room_policy, &NoopDndReader),
                     &bare("push.example.com"),
                     16,
                 )
@@ -4931,7 +5557,7 @@ mod tests {
                     &push_store,
                     &blocking,
                     &projection,
-                    &room_policy,
+                    NotificationDrainDeps::new(&room_policy, &NoopDndReader),
                     &bare("push.example.com"),
                     16,
                 )
@@ -4976,7 +5602,7 @@ mod tests {
                     &push_store,
                     &blocking,
                     &projection,
-                    &room_policy,
+                    NotificationDrainDeps::new(&room_policy, &NoopDndReader),
                     &bare("push.example.com"),
                     16,
                 )
@@ -5007,7 +5633,7 @@ mod tests {
                     &push_store,
                     &blocking,
                     &projection,
-                    &room_policy,
+                    NotificationDrainDeps::new(&room_policy, &NoopDndReader),
                     &bare("push.example.com"),
                     16,
                 )
@@ -5051,7 +5677,7 @@ mod tests {
                     &push_store,
                     &blocking,
                     &projection,
-                    &room_policy,
+                    NotificationDrainDeps::new(&room_policy, &NoopDndReader),
                     &bare("push.example.com"),
                     16,
                 )
@@ -5082,7 +5708,7 @@ mod tests {
                     &push_store,
                     &blocking,
                     &projection,
-                    &room_policy,
+                    NotificationDrainDeps::new(&room_policy, &NoopDndReader),
                     &bare("push.example.com"),
                     16,
                 )
@@ -5143,7 +5769,7 @@ mod tests {
                     &push_store,
                     &blocking,
                     &projection,
-                    &room_policy,
+                    NotificationDrainDeps::new(&room_policy, &NoopDndReader),
                     &bare("push.example.com"),
                     16,
                 )
@@ -5190,7 +5816,7 @@ mod tests {
                     &push_store,
                     &blocking,
                     &projection,
-                    &room_policy,
+                    NotificationDrainDeps::new(&room_policy, &NoopDndReader),
                     &bare("push.example.com"),
                     16,
                 )
@@ -5311,7 +5937,7 @@ mod tests {
                     &push_store,
                     &blocking,
                     &projection,
-                    &room_policy,
+                    NotificationDrainDeps::new(&room_policy, &NoopDndReader),
                     &bare("push.example.com"),
                     16,
                 )
@@ -5416,7 +6042,7 @@ mod tests {
                     &push_store,
                     &blocking,
                     &projection,
-                    &room_policy,
+                    NotificationDrainDeps::new(&room_policy, &NoopDndReader),
                     &bare("push.example.com"),
                     16,
                 )
@@ -5463,7 +6089,7 @@ mod tests {
                     &push_store,
                     &FailingBlockingStorage,
                     &projection,
-                    &room_policy,
+                    NotificationDrainDeps::new(&room_policy, &NoopDndReader),
                     &bare("push.example.com"),
                     16,
                 )
@@ -5510,7 +6136,7 @@ mod tests {
                     &push_store,
                     &blocking,
                     &projection,
-                    &room_policy,
+                    NotificationDrainDeps::new(&room_policy, &NoopDndReader),
                     &bare("push.example.com"),
                     16,
                 )
@@ -6612,7 +7238,7 @@ mod tests {
                     &push_store,
                     &blocking,
                     &projection,
-                    &room_policy,
+                    NotificationDrainDeps::new(&room_policy, &NoopDndReader),
                     &bare("push.example.com"),
                     16,
                 )
@@ -6697,7 +7323,7 @@ mod tests {
                 &push_store,
                 &blocking,
                 &projection,
-                &room_policy,
+                NotificationDrainDeps::new(&room_policy, &NoopDndReader),
                 &bare("push.example.com"),
                 16,
             )
@@ -6746,7 +7372,7 @@ mod tests {
                 &push_store,
                 &blocking,
                 &projection,
-                &room_policy,
+                NotificationDrainDeps::new(&room_policy, &NoopDndReader),
                 &bare("push.example.com"),
                 16,
             )
@@ -6812,5 +7438,747 @@ mod tests {
             RoomPolicyCacheEntry::Unknown(UnknownRoomPolicySource::NotLive),
             "Ok(None) must classify as NotLive, distinct from LookupError"
         );
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Slice 2a — SuppressedReason audit + new suppressors (#526).
+    // ─────────────────────────────────────────────────────────────
+
+    /// `SuppressedReason` is the canonical audit shape. Every variant
+    /// MUST round-trip through `as_db_value` / `from_db_value` so a
+    /// row written today can be decoded tomorrow without ambiguity.
+    /// The closed-set discipline is what keeps the CHECK constraint
+    /// + the labeled prometheus counter in lockstep.
+    #[test]
+    fn suppressed_reason_round_trip_covers_every_variant() {
+        let variants = [
+            SuppressedReason::Xep0357Self,
+            SuppressedReason::Xep0357NoRegistration,
+            SuppressedReason::Xep0357RegistrationDisabled,
+            SuppressedReason::Xep0492Never,
+            SuppressedReason::Xep0492OnMentionMiss,
+            SuppressedReason::Xep0191Blocked,
+            SuppressedReason::Xep0513Noping,
+            SuppressedReason::Xep0513ActiveMiss,
+            SuppressedReason::Xep0334NoStore,
+            SuppressedReason::Xep0334NoPermanentStore,
+            SuppressedReason::WaddleDnd,
+            SuppressedReason::ProviderRejected,
+            SuppressedReason::ProviderTokenExpired,
+        ];
+        // The closed-set CHECK constraint values MUST stay in lockstep
+        // with the enum — every db value the enum knows about MUST be
+        // accepted by the constraint, and vice versa.
+        assert_eq!(
+            variants.len(),
+            NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_VALUES.len(),
+            "variant count must match CHECK constraint value list",
+        );
+        for variant in variants {
+            let db = variant.as_db_value();
+            assert!(
+                NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_VALUES.contains(&db),
+                "variant {variant:?} db value {db} missing from CHECK constraint list",
+            );
+            let decoded = SuppressedReason::from_db_value(db).expect("decode");
+            assert_eq!(
+                decoded, variant,
+                "round-trip failed for {variant:?} (db value {db})"
+            );
+        }
+        assert!(matches!(
+            SuppressedReason::from_db_value("nonsense"),
+            Err(NotificationOutboxError::InvalidSuppressedReason(_))
+        ));
+    }
+
+    #[test]
+    fn postgres_suppressed_reason_constraint_match_accepts_current_definition() {
+        let postgres_definition = "CHECK (((suppressed_reason IS NULL) OR ((suppressed_reason)::text = ANY ((ARRAY['xep0357_self'::character varying, 'xep0357_no_registration'::character varying, 'xep0357_registration_disabled'::character varying, 'xep0492_never'::character varying, 'xep0492_on_mention_miss'::character varying, 'xep0191_blocked'::character varying, 'xep0513_noping'::character varying, 'xep0513_active_miss'::character varying, 'xep0334_no_store'::character varying, 'xep0334_no_permanent_store'::character varying, 'waddle_dnd'::character varying, 'provider_rejected'::character varying, 'provider_token_expired'::character varying])::text[]))))";
+        assert!(
+            notification_candidates_suppressed_reason_constraint_matches_expected(
+                postgres_definition
+            )
+        );
+    }
+
+    #[test]
+    fn sqlite_suppressed_reason_constraint_match_rejects_partial_definition() {
+        // A schema that advertises only some of the typed reasons must
+        // be flagged stale so the migration rebuilds the CHECK.
+        let sqlite_create_sql = "CREATE TABLE notification_candidates (suppressed_reason TEXT CHECK (suppressed_reason IS NULL OR suppressed_reason IN ('xep0492_never')))";
+        assert!(
+            !notification_candidates_suppressed_reason_constraint_matches_expected(
+                sqlite_create_sql
+            ),
+        );
+    }
+
+    /// On a fresh store, cold-init MUST advertise the
+    /// `suppressed_reason` column with the CHECK constraint that
+    /// accepts the full closed-set of typed reasons. A direct INSERT
+    /// using each typed db value MUST succeed; an INSERT with a
+    /// nonsense value MUST be rejected by the CHECK.
+    #[tokio::test]
+    async fn suppressed_reason_check_constraint_accepts_every_typed_value() {
+        let store = store().await;
+        let recipient = bare("alice@example.com");
+        let sender_jid: Jid = "bob@example.com/web".parse().expect("full sender");
+        for (idx, reason) in [
+            SuppressedReason::Xep0357Self,
+            SuppressedReason::Xep0357NoRegistration,
+            SuppressedReason::Xep0357RegistrationDisabled,
+            SuppressedReason::Xep0492Never,
+            SuppressedReason::Xep0492OnMentionMiss,
+            SuppressedReason::Xep0191Blocked,
+            SuppressedReason::Xep0513Noping,
+            SuppressedReason::Xep0513ActiveMiss,
+            SuppressedReason::Xep0334NoStore,
+            SuppressedReason::Xep0334NoPermanentStore,
+            SuppressedReason::WaddleDnd,
+            SuppressedReason::ProviderRejected,
+            SuppressedReason::ProviderTokenExpired,
+        ]
+        .iter()
+        .enumerate()
+        {
+            let stanza_id = format!("audit-{idx}");
+            let candidate = NotificationCandidate::direct_message(
+                recipient.clone(),
+                sender_jid.clone(),
+                StanzaId::new(stanza_id.clone(), Jid::from(recipient.clone())),
+                false,
+            )
+            .expect("candidate");
+            assert_eq!(
+                store
+                    .insert_candidate(&candidate)
+                    .await
+                    .expect("insert candidate"),
+                NotificationCandidateInsertOutcome::Inserted,
+            );
+            let mut tx = store.db.begin().await.expect("begin tx");
+            record_candidate_suppressed_reason_tx(&mut tx, &candidate, *reason)
+                .await
+                .expect("record reason");
+            tx.commit().await.expect("commit");
+        }
+
+        // A nonsense value MUST be rejected by the CHECK.
+        let insert_result = store
+            .execute(
+                r#"
+                INSERT INTO notification_candidates (
+                    recipient_bare_jid, conversation_jid, sender_jid, thread_id,
+                    stanza_id_by, stanza_id, class, reason, created_at_ms,
+                    policy_error_count, next_attempt_at_ms, outboxed_at_ms,
+                    suppressed_reason, noping, no_store, no_permanent_store
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, 0, 0, 0)
+                "#,
+                crate::db_params![
+                    "alice@example.com",
+                    "bob@example.com",
+                    "bob@example.com/web",
+                    "",
+                    "alice@example.com",
+                    "bad-value",
+                    "dm",
+                    "offline_dm",
+                    1_i64,
+                    0_i64,
+                    "not-a-real-reason",
+                ],
+            )
+            .await;
+        assert!(
+            insert_result.is_err(),
+            "CHECK constraint must reject nonsense suppressed_reason"
+        );
+    }
+
+    /// XEP-0492 `<never/>` suppression at T1 MUST persist
+    /// `Xep0492Never` onto the candidate row's `suppressed_reason`
+    /// column, NOT enqueue a job, and increment the metric counter
+    /// labeled by the typed db value.
+    #[tokio::test]
+    async fn t1_xep0492_never_records_typed_suppressed_reason() {
+        let _guard = waddle_xmpp::prometheus::metrics_test_lock().lock().await;
+        waddle_xmpp::prometheus::reset_metrics_for_test();
+        let store = store().await;
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
+        let dnd_reader = NoopDndReader;
+        let recipient = bare("alice@example.com");
+        let sender = bare("bob@example.com");
+
+        // Persist a `<never/>` notification setting for the recipient
+        // against `sender`'s DM conversation.
+        projection
+            .upsert(&crate::notification_settings_projection::NotificationSettingsProjection {
+                owner_bare_jid: recipient.clone(),
+                conversation_jid: sender.clone(),
+                conversation_kind:
+                    crate::notification_settings_projection::ConversationKind::Direct,
+                mode: waddle_xmpp::xep::NotificationLevel::Never,
+                source:
+                    crate::notification_settings_projection::NotificationSettingsSource::Xep0402Bookmarks,
+                source_item_jid: sender.clone(),
+                updated_at_ms: 1,
+                source_version: 1,
+            })
+            .await
+            .expect("seed never level");
+
+        let candidate = candidate_for(&recipient, &sender, "t1-never");
+        store
+            .insert_candidate(&candidate)
+            .await
+            .expect("insert candidate");
+
+        let deps = NotificationDrainDeps::new(&room_policy, &dnd_reader);
+        store
+            .drain_pending_candidates_into_outbox(
+                &push_store,
+                &blocking,
+                &projection,
+                deps,
+                &bare("push.example.com"),
+                16,
+            )
+            .await
+            .expect("drain candidates");
+
+        let mut rows = store
+            .query(
+                "SELECT suppressed_reason, outboxed_at_ms FROM notification_candidates WHERE stanza_id = ?",
+                crate::db_params!["t1-never"],
+            )
+            .await
+            .expect("query suppressed_reason");
+        let row = rows.next().await.expect("row").expect("row exists");
+        let reason: Option<String> = row.get(0).expect("reason");
+        let outboxed: Option<i64> = row.get(1).expect("outboxed_at_ms");
+        assert_eq!(reason.as_deref(), Some("xep0492_never"));
+        assert!(
+            outboxed.is_some(),
+            "T1 suppression must mark candidate outboxed"
+        );
+        assert!(
+            store.pending_outbox_jobs().await.expect("jobs").is_empty(),
+            "T1 suppression MUST NOT enqueue a job",
+        );
+
+        let rendered = waddle_xmpp::prometheus::render_metrics();
+        assert!(
+            rendered.contains("waddle_push_suppressed_total{reason=\"xep0492_never\"} 1"),
+            "metric counter for xep0492_never must increment; rendered={rendered}",
+        );
+    }
+
+    /// XEP-0492 `<on-mention/>` setting with a non-mention candidate
+    /// (DM without explicit mention) MUST suppress at T1 with the
+    /// typed `Xep0492OnMentionMiss` audit reason.
+    #[tokio::test]
+    async fn t1_xep0492_on_mention_miss_records_typed_suppressed_reason() {
+        let _guard = waddle_xmpp::prometheus::metrics_test_lock().lock().await;
+        waddle_xmpp::prometheus::reset_metrics_for_test();
+        let store = store().await;
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
+        let dnd_reader = NoopDndReader;
+        let recipient = bare("alice@example.com");
+        let sender = bare("bob@example.com");
+
+        projection
+            .upsert(&crate::notification_settings_projection::NotificationSettingsProjection {
+                owner_bare_jid: recipient.clone(),
+                conversation_jid: sender.clone(),
+                conversation_kind:
+                    crate::notification_settings_projection::ConversationKind::Direct,
+                mode: waddle_xmpp::xep::NotificationLevel::OnMention,
+                source:
+                    crate::notification_settings_projection::NotificationSettingsSource::Xep0402Bookmarks,
+                source_item_jid: sender.clone(),
+                updated_at_ms: 1,
+                source_version: 1,
+            })
+            .await
+            .expect("seed on-mention level");
+
+        let candidate = candidate_for(&recipient, &sender, "t1-on-mention");
+        store
+            .insert_candidate(&candidate)
+            .await
+            .expect("insert candidate");
+
+        let deps = NotificationDrainDeps::new(&room_policy, &dnd_reader);
+        store
+            .drain_pending_candidates_into_outbox(
+                &push_store,
+                &blocking,
+                &projection,
+                deps,
+                &bare("push.example.com"),
+                16,
+            )
+            .await
+            .expect("drain candidates");
+
+        let mut rows = store
+            .query(
+                "SELECT suppressed_reason FROM notification_candidates WHERE stanza_id = ?",
+                crate::db_params!["t1-on-mention"],
+            )
+            .await
+            .expect("query");
+        let row = rows.next().await.expect("row").expect("row exists");
+        let reason: Option<String> = row.get(0).expect("reason");
+        assert_eq!(reason.as_deref(), Some("xep0492_on_mention_miss"));
+
+        let rendered = waddle_xmpp::prometheus::render_metrics();
+        assert!(
+            rendered.contains("waddle_push_suppressed_total{reason=\"xep0492_on_mention_miss\"} 1"),
+        );
+    }
+
+    /// XEP-0191 blocking at T1 MUST record `Xep0191Blocked` onto the
+    /// candidate row before marking it outboxed-without-job.
+    #[tokio::test]
+    async fn t1_xep0191_blocked_records_typed_suppressed_reason() {
+        let _guard = waddle_xmpp::prometheus::metrics_test_lock().lock().await;
+        waddle_xmpp::prometheus::reset_metrics_for_test();
+        let store = store().await;
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
+        let dnd_reader = NoopDndReader;
+        let recipient = bare("alice@example.com");
+        let sender = bare("bob@example.com");
+
+        // Block the sender on the recipient's blocklist.
+        blocking.set_blocklist(recipient.clone(), vec![sender.clone()]);
+
+        let candidate = candidate_for(&recipient, &sender, "t1-blocked");
+        store
+            .insert_candidate(&candidate)
+            .await
+            .expect("insert candidate");
+
+        let deps = NotificationDrainDeps::new(&room_policy, &dnd_reader);
+        store
+            .drain_pending_candidates_into_outbox(
+                &push_store,
+                &blocking,
+                &projection,
+                deps,
+                &bare("push.example.com"),
+                16,
+            )
+            .await
+            .expect("drain candidates");
+
+        let mut rows = store
+            .query(
+                "SELECT suppressed_reason FROM notification_candidates WHERE stanza_id = ?",
+                crate::db_params!["t1-blocked"],
+            )
+            .await
+            .expect("query");
+        let row = rows.next().await.expect("row").expect("row exists");
+        let reason: Option<String> = row.get(0).expect("reason");
+        assert_eq!(reason.as_deref(), Some("xep0191_blocked"));
+        let rendered = waddle_xmpp::prometheus::render_metrics();
+        assert!(rendered.contains("waddle_push_suppressed_total{reason=\"xep0191_blocked\"} 1"),);
+    }
+
+    /// XEP-0513 `<noping/>` carried on the candidate row MUST suppress
+    /// at T1 with the typed `Xep0513Noping` reason. Tests the
+    /// message-frozen path: candidate is constructed with the noping
+    /// bit set, persisted, then the drain reads it back and suppresses.
+    #[tokio::test]
+    async fn t1_noping_records_typed_suppressed_reason() {
+        let _guard = waddle_xmpp::prometheus::metrics_test_lock().lock().await;
+        waddle_xmpp::prometheus::reset_metrics_for_test();
+        let store = store().await;
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
+        let dnd_reader = NoopDndReader;
+        let recipient = bare("alice@example.com");
+        let sender_jid: Jid = "bob@example.com/web".parse().expect("full sender");
+        let candidate = NotificationCandidate::direct_message_with_hints(
+            recipient.clone(),
+            sender_jid,
+            StanzaId::new("t1-noping", Jid::from(recipient.clone())),
+            false,
+            NotificationMessageHints::none().with_noping(true),
+        )
+        .expect("candidate");
+        assert!(candidate.noping());
+        store
+            .insert_candidate(&candidate)
+            .await
+            .expect("insert candidate");
+
+        let deps = NotificationDrainDeps::new(&room_policy, &dnd_reader);
+        store
+            .drain_pending_candidates_into_outbox(
+                &push_store,
+                &blocking,
+                &projection,
+                deps,
+                &bare("push.example.com"),
+                16,
+            )
+            .await
+            .expect("drain candidates");
+
+        let mut rows = store
+            .query(
+                "SELECT suppressed_reason, noping FROM notification_candidates WHERE stanza_id = ?",
+                crate::db_params!["t1-noping"],
+            )
+            .await
+            .expect("query");
+        let row = rows.next().await.expect("row").expect("row exists");
+        assert_eq!(
+            row.get::<Option<String>>(0).expect("reason").as_deref(),
+            Some("xep0513_noping")
+        );
+        assert_eq!(row.get::<i64>(1).expect("noping"), 1);
+        let rendered = waddle_xmpp::prometheus::render_metrics();
+        assert!(rendered.contains("waddle_push_suppressed_total{reason=\"xep0513_noping\"} 1"),);
+    }
+
+    /// XEP-0334 `<no-store/>` hint snapshotted onto a candidate row
+    /// MUST suppress at T1 with the typed `Xep0334NoStore` reason.
+    #[tokio::test]
+    async fn t1_no_store_records_typed_suppressed_reason() {
+        let _guard = waddle_xmpp::prometheus::metrics_test_lock().lock().await;
+        waddle_xmpp::prometheus::reset_metrics_for_test();
+        let store = store().await;
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
+        let dnd_reader = NoopDndReader;
+        let recipient = bare("alice@example.com");
+        let sender_jid: Jid = "bob@example.com/web".parse().expect("full sender");
+        let candidate = NotificationCandidate::direct_message_with_hints(
+            recipient.clone(),
+            sender_jid,
+            StanzaId::new("t1-no-store", Jid::from(recipient.clone())),
+            false,
+            NotificationMessageHints::none().with_xep0334(true, false),
+        )
+        .expect("candidate");
+        assert!(candidate.no_store());
+        assert!(!candidate.no_permanent_store());
+        store
+            .insert_candidate(&candidate)
+            .await
+            .expect("insert candidate");
+
+        let deps = NotificationDrainDeps::new(&room_policy, &dnd_reader);
+        store
+            .drain_pending_candidates_into_outbox(
+                &push_store,
+                &blocking,
+                &projection,
+                deps,
+                &bare("push.example.com"),
+                16,
+            )
+            .await
+            .expect("drain candidates");
+
+        let mut rows = store
+            .query(
+                "SELECT suppressed_reason FROM notification_candidates WHERE stanza_id = ?",
+                crate::db_params!["t1-no-store"],
+            )
+            .await
+            .expect("query");
+        let row = rows.next().await.expect("row").expect("row exists");
+        assert_eq!(
+            row.get::<Option<String>>(0).expect("reason").as_deref(),
+            Some("xep0334_no_store"),
+        );
+    }
+
+    /// XEP-0334 `<no-permanent-store/>` hint snapshotted onto a
+    /// candidate row MUST suppress at T1 with
+    /// `Xep0334NoPermanentStore`.
+    #[tokio::test]
+    async fn t1_no_permanent_store_records_typed_suppressed_reason() {
+        let _guard = waddle_xmpp::prometheus::metrics_test_lock().lock().await;
+        waddle_xmpp::prometheus::reset_metrics_for_test();
+        let store = store().await;
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
+        let dnd_reader = NoopDndReader;
+        let recipient = bare("alice@example.com");
+        let sender_jid: Jid = "bob@example.com/web".parse().expect("full sender");
+        let candidate = NotificationCandidate::direct_message_with_hints(
+            recipient.clone(),
+            sender_jid,
+            StanzaId::new("t1-no-perm-store", Jid::from(recipient.clone())),
+            false,
+            NotificationMessageHints::none().with_xep0334(false, true),
+        )
+        .expect("candidate");
+        store
+            .insert_candidate(&candidate)
+            .await
+            .expect("insert candidate");
+
+        let deps = NotificationDrainDeps::new(&room_policy, &dnd_reader);
+        store
+            .drain_pending_candidates_into_outbox(
+                &push_store,
+                &blocking,
+                &projection,
+                deps,
+                &bare("push.example.com"),
+                16,
+            )
+            .await
+            .expect("drain candidates");
+
+        let mut rows = store
+            .query(
+                "SELECT suppressed_reason FROM notification_candidates WHERE stanza_id = ?",
+                crate::db_params!["t1-no-perm-store"],
+            )
+            .await
+            .expect("query");
+        let row = rows.next().await.expect("row").expect("row exists");
+        assert_eq!(
+            row.get::<Option<String>>(0).expect("reason").as_deref(),
+            Some("xep0334_no_permanent_store"),
+        );
+    }
+
+    /// `NoopDndReader` MUST report every user as `Inactive` so slice
+    /// 2a's defaulted call sites never trigger DnD suppression while
+    /// the real impl is still pending (#367).
+    #[tokio::test]
+    async fn noop_dnd_reader_reports_inactive() {
+        let reader = NoopDndReader;
+        let user = bare("alice@example.com");
+        let state = reader.dnd_state(&user).await.expect("noop dnd");
+        assert_eq!(state, DndState::Inactive);
+    }
+
+    /// A `DndReader` that reports `Active` MUST suppress at T1 with
+    /// `WaddleDnd`, even when the recipient has no other suppressors
+    /// in play.
+    #[tokio::test]
+    async fn t1_active_dnd_suppresses_with_typed_reason() {
+        let _guard = waddle_xmpp::prometheus::metrics_test_lock().lock().await;
+        waddle_xmpp::prometheus::reset_metrics_for_test();
+
+        struct ActiveDndReader;
+        #[async_trait::async_trait]
+        impl DndReader for ActiveDndReader {
+            async fn dnd_state(
+                &self,
+                _user: &BareJid,
+            ) -> Result<DndState, NotificationOutboxError> {
+                Ok(DndState::Active)
+            }
+        }
+
+        let store = store().await;
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
+        let dnd_reader = ActiveDndReader;
+        let recipient = bare("alice@example.com");
+        let sender = bare("bob@example.com");
+        let candidate = candidate_for(&recipient, &sender, "t1-dnd");
+        store
+            .insert_candidate(&candidate)
+            .await
+            .expect("insert candidate");
+
+        let deps = NotificationDrainDeps::new(&room_policy, &dnd_reader);
+        store
+            .drain_pending_candidates_into_outbox(
+                &push_store,
+                &blocking,
+                &projection,
+                deps,
+                &bare("push.example.com"),
+                16,
+            )
+            .await
+            .expect("drain candidates");
+
+        let mut rows = store
+            .query(
+                "SELECT suppressed_reason FROM notification_candidates WHERE stanza_id = ?",
+                crate::db_params!["t1-dnd"],
+            )
+            .await
+            .expect("query");
+        let row = rows.next().await.expect("row").expect("row exists");
+        assert_eq!(
+            row.get::<Option<String>>(0).expect("reason").as_deref(),
+            Some("waddle_dnd"),
+        );
+        let rendered = waddle_xmpp::prometheus::render_metrics();
+        assert!(rendered.contains("waddle_push_suppressed_total{reason=\"waddle_dnd\"} 1"));
+    }
+
+    /// Schema regression: cold-init MUST produce a
+    /// `notification_candidates.suppressed_reason` column with the
+    /// named CHECK constraint accepting every typed db value.
+    #[tokio::test]
+    async fn cold_init_creates_suppressed_reason_column_and_check() {
+        let store = store().await;
+        // Insert a row, then update suppressed_reason to every typed
+        // db value in turn — all MUST succeed.
+        let recipient = bare("alice@example.com");
+        let sender_jid: Jid = "bob@example.com/web".parse().expect("full sender");
+        let candidate = NotificationCandidate::direct_message(
+            recipient.clone(),
+            sender_jid,
+            StanzaId::new("schema-probe", Jid::from(recipient.clone())),
+            false,
+        )
+        .expect("candidate");
+        store
+            .insert_candidate(&candidate)
+            .await
+            .expect("insert candidate");
+        for reason_db in NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_VALUES {
+            store
+                .execute(
+                    "UPDATE notification_candidates SET suppressed_reason = ? WHERE stanza_id = ?",
+                    crate::db_params![reason_db, "schema-probe"],
+                )
+                .await
+                .expect("update suppressed_reason");
+        }
+        // Reset to NULL also OK (unsuppressed/delivered shape).
+        store
+            .execute(
+                "UPDATE notification_candidates SET suppressed_reason = NULL WHERE stanza_id = ?",
+                crate::db_params!["schema-probe"],
+            )
+            .await
+            .expect("reset to NULL");
+    }
+
+    /// Legacy upgrade regression: a database created with an
+    /// older schema that lacks the `suppressed_reason`, `noping`,
+    /// `no_store`, and `no_permanent_store` columns MUST upgrade
+    /// cleanly when `NotificationOutboxStore::new` runs the
+    /// `add_column_if_missing` + suppressed-reason migration.
+    /// Both legacy rows AND newly-inserted rows are insertable
+    /// and decodable after migration.
+    #[tokio::test]
+    async fn legacy_schema_upgrade_adds_suppressed_reason_and_hints() {
+        let db = Database::in_memory("notification-outbox-legacy-suppressed")
+            .await
+            .unwrap();
+        let conn = db.guard().await.expect("db guard");
+        conn.execute(
+            r#"
+            CREATE TABLE notification_candidates (
+                recipient_bare_jid TEXT NOT NULL,
+                conversation_jid TEXT NOT NULL,
+                sender_jid TEXT NOT NULL,
+                thread_id TEXT NOT NULL DEFAULT '',
+                stanza_id_by TEXT NOT NULL,
+                stanza_id TEXT NOT NULL,
+                class TEXT NOT NULL CHECK (class IN ('dm', 'dm_mention', 'personal_mention', 'channel_mention', 'active_channel_mention', 'notify_all')),
+                reason TEXT NOT NULL CHECK (reason IN ('offline_dm', 'offline_dm_mention', 'groupchat_personal_mention', 'groupchat_channel_mention', 'groupchat_active_channel_mention', 'groupchat_notify_all')),
+                created_at_ms INTEGER NOT NULL,
+                policy_error_count INTEGER NOT NULL DEFAULT 0,
+                next_attempt_at_ms INTEGER,
+                outboxed_at_ms INTEGER,
+                PRIMARY KEY (recipient_bare_jid, conversation_jid, thread_id, stanza_id_by, stanza_id, class)
+            )
+            "#,
+            (),
+        )
+        .await
+        .expect("create legacy candidate table");
+        conn.execute(
+            r#"
+            INSERT INTO notification_candidates (
+                recipient_bare_jid, conversation_jid, sender_jid, thread_id,
+                stanza_id_by, stanza_id, class, reason, created_at_ms,
+                policy_error_count, next_attempt_at_ms, outboxed_at_ms
+            ) VALUES (
+                'alice@example.com', 'bob@example.com', 'bob@example.com/web', '',
+                'alice@example.com', 'legacy-row', 'dm', 'offline_dm', 1, 0, NULL, NULL
+            )
+            "#,
+            (),
+        )
+        .await
+        .expect("insert legacy candidate");
+        drop(conn);
+
+        let store = NotificationOutboxStore::new(db)
+            .await
+            .expect("store migrates legacy schema");
+        // Insert a new candidate with the noping bit set; the column
+        // must exist and accept the value.
+        let recipient = bare("alice@example.com");
+        let sender_jid: Jid = "bob@example.com/web".parse().expect("full sender");
+        let new_candidate = NotificationCandidate::direct_message_with_hints(
+            recipient.clone(),
+            sender_jid,
+            StanzaId::new("post-upgrade", Jid::from(recipient.clone())),
+            true,
+            NotificationMessageHints::none()
+                .with_noping(true)
+                .with_xep0334(true, true),
+        )
+        .expect("post-upgrade candidate");
+        store
+            .insert_candidate(&new_candidate)
+            .await
+            .expect("insert post-upgrade candidate");
+        let mut rows = store
+            .query(
+                "SELECT suppressed_reason, noping, no_store, no_permanent_store FROM notification_candidates WHERE stanza_id = ?",
+                crate::db_params!["post-upgrade"],
+            )
+            .await
+            .expect("query post-upgrade row");
+        let row = rows.next().await.expect("row").expect("row exists");
+        let reason: Option<String> = row.get(0).expect("reason");
+        assert!(reason.is_none());
+        assert_eq!(row.get::<i64>(1).expect("noping"), 1);
+        assert_eq!(row.get::<i64>(2).expect("no_store"), 1);
+        assert_eq!(row.get::<i64>(3).expect("no_permanent_store"), 1);
+
+        // Legacy row's hint columns must default to 0.
+        let mut rows = store
+            .query(
+                "SELECT noping, no_store, no_permanent_store, suppressed_reason FROM notification_candidates WHERE stanza_id = ?",
+                crate::db_params!["legacy-row"],
+            )
+            .await
+            .expect("query legacy row");
+        let row = rows.next().await.expect("row").expect("legacy row");
+        assert_eq!(row.get::<i64>(0).expect("noping"), 0);
+        assert_eq!(row.get::<i64>(1).expect("no_store"), 0);
+        assert_eq!(row.get::<i64>(2).expect("no_permanent_store"), 0);
+        assert!(row.get::<Option<String>>(3).expect("reason").is_none());
     }
 }

--- a/server/crates/waddle-server/src/notification_outbox.rs
+++ b/server/crates/waddle-server/src/notification_outbox.rs
@@ -3039,7 +3039,7 @@ pub(crate) async fn evaluate_xep0492_at_dispatch(
         }
         crate::notification_settings_projection::PushDispatchDecision::Suppressed { reason } => {
             T1PushDispatchOutcome::Suppressed {
-                reason: suppressed_reason_for_level(reason, is_mention),
+                reason: suppressed_reason_for_level(reason),
             }
         }
     })
@@ -3052,23 +3052,20 @@ pub(crate) async fn evaluate_xep0492_at_dispatch(
 /// `<never/>` always maps to `Xep0492Never`. `<on-mention/>` maps to
 /// `Xep0492OnMentionMiss` because the XEP-0492 evaluator only emits
 /// the `Suppressed` outcome when `should_notify(is_mention)` is false
-/// — and for `OnMention` that means `is_mention == false`.
-/// `<always/>` never produces a `Suppressed` outcome.
-fn suppressed_reason_for_level(
-    level: waddle_xmpp::xep::NotificationLevel,
-    _is_mention: bool,
-) -> SuppressedReason {
+/// — and for `OnMention` that means `is_mention == false`. Called
+/// only from the `Suppressed` arm of the upstream XEP-0492 reducer
+/// (`PushDispatchDecision::evaluate`), which never yields
+/// `Suppressed` for `<always/>` — so `Always` is unreachable here
+/// and the typed contract makes the missing arm a compile-time
+/// error if the reducer ever drifts.
+fn suppressed_reason_for_level(level: waddle_xmpp::xep::NotificationLevel) -> SuppressedReason {
     match level {
         waddle_xmpp::xep::NotificationLevel::Never => SuppressedReason::Xep0492Never,
         waddle_xmpp::xep::NotificationLevel::OnMention => SuppressedReason::Xep0492OnMentionMiss,
-        waddle_xmpp::xep::NotificationLevel::Always => {
-            // Unreachable in practice — `Always.should_notify(_) ==
-            // true` so the evaluator never produces `Suppressed` for
-            // it. Default to OnMention-miss to keep the closed-set
-            // invariant if the upstream reducer ever drifts; the
-            // dedicated XEP-0492 unit tests cover the live mapping.
-            SuppressedReason::Xep0492OnMentionMiss
-        }
+        waddle_xmpp::xep::NotificationLevel::Always => unreachable!(
+            "suppressed_reason_for_level called with NotificationLevel::Always; \
+             the XEP-0492 reducer never yields Suppressed for <always/>"
+        ),
     }
 }
 
@@ -7489,30 +7486,16 @@ mod tests {
     /// + the labeled prometheus counter in lockstep.
     #[test]
     fn suppressed_reason_round_trip_covers_every_variant() {
-        let variants = [
-            SuppressedReason::Xep0357Self,
-            SuppressedReason::Xep0357NoRegistration,
-            SuppressedReason::Xep0357RegistrationDisabled,
-            SuppressedReason::Xep0492Never,
-            SuppressedReason::Xep0492OnMentionMiss,
-            SuppressedReason::Xep0191Blocked,
-            SuppressedReason::Xep0513Noping,
-            SuppressedReason::Xep0513ActiveMiss,
-            SuppressedReason::Xep0334NoStore,
-            SuppressedReason::Xep0334NoPermanentStore,
-            SuppressedReason::WaddleDnd,
-            SuppressedReason::ProviderRejected,
-            SuppressedReason::ProviderTokenExpired,
-        ];
-        // The closed-set CHECK constraint values MUST stay in lockstep
-        // with the enum — every db value the enum knows about MUST be
-        // accepted by the constraint, and vice versa.
+        // Iterate `SuppressedReason::ALL` (the same closed-set array the
+        // startup invariant traverses) so any future variant addition
+        // joins this test automatically — no parallel hand-maintained
+        // list to drift.
         assert_eq!(
-            variants.len(),
+            SuppressedReason::ALL.len(),
             NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_VALUES.len(),
             "variant count must match CHECK constraint value list",
         );
-        for variant in variants {
+        for variant in SuppressedReason::ALL.iter().copied() {
             let db = variant.as_db_value();
             assert!(
                 NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_VALUES.contains(&db),
@@ -7562,24 +7545,10 @@ mod tests {
         let store = store().await;
         let recipient = bare("alice@example.com");
         let sender_jid: Jid = "bob@example.com/web".parse().expect("full sender");
-        for (idx, reason) in [
-            SuppressedReason::Xep0357Self,
-            SuppressedReason::Xep0357NoRegistration,
-            SuppressedReason::Xep0357RegistrationDisabled,
-            SuppressedReason::Xep0492Never,
-            SuppressedReason::Xep0492OnMentionMiss,
-            SuppressedReason::Xep0191Blocked,
-            SuppressedReason::Xep0513Noping,
-            SuppressedReason::Xep0513ActiveMiss,
-            SuppressedReason::Xep0334NoStore,
-            SuppressedReason::Xep0334NoPermanentStore,
-            SuppressedReason::WaddleDnd,
-            SuppressedReason::ProviderRejected,
-            SuppressedReason::ProviderTokenExpired,
-        ]
-        .iter()
-        .enumerate()
-        {
+        // Iterate the closed-set `ALL` array so a future enum extension
+        // joins this audit automatically — no hand-maintained parallel
+        // list to drift.
+        for (idx, reason) in SuppressedReason::ALL.iter().enumerate() {
             let stanza_id = format!("audit-{idx}");
             let candidate = NotificationCandidate::direct_message(
                 recipient.clone(),

--- a/server/crates/waddle-server/src/notification_outbox.rs
+++ b/server/crates/waddle-server/src/notification_outbox.rs
@@ -824,7 +824,7 @@ pub trait RoomPolicyStore: Send + Sync {
 /// Zero-state [`RoomPolicyStore`] for DM emission paths.
 ///
 /// The T0 emission gate for direct messages calls
-/// [`evaluate_xep0492_at_dispatch`] on a candidate whose class is
+/// [`evaluate_push_gate_at_dispatch`] on a candidate whose class is
 /// [`NotificationClass::DirectMessage`] or
 /// [`NotificationClass::DirectMessageMention`]. Those arms never
 /// dispatch into `room_policy`, so the trait object is held only to
@@ -1941,8 +1941,9 @@ impl NotificationOutboxStore {
                     continue;
                 }
             }
-            // T1 XEP-0492 push-dispatch re-evaluation — race-window
-            // guard, defense-in-depth.
+            // T1 push-gate re-evaluation — race-window guard,
+            // defense-in-depth (XEP-0492 + XEP-0191 + XEP-0513 + XEP-0334 +
+            // Waddle DnD).
             //
             // The same typed evaluator already ran at T0 (DM emission
             // in `offline_delivery.rs`, groupchat emission in
@@ -1968,7 +1969,7 @@ impl NotificationOutboxStore {
             // publish-or-suppress. The room-policy lookup is cached
             // for the duration of this drain pass so a 100-member
             // groupchat does not produce 100 actor round-trips.
-            let outcome = match evaluate_xep0492_at_dispatch(
+            let outcome = match evaluate_push_gate_at_dispatch(
                 PushEvalStage::T1Drain,
                 settings_projection,
                 room_policy,
@@ -1984,8 +1985,8 @@ impl NotificationOutboxStore {
                     tracing::warn!(
                         recipient = %candidate.recipient_bare_jid(),
                         conversation = %candidate.conversation_jid(),
-                        %error,
-                        "XEP-0492 notification setting lookup failed at T1; deferring candidate"
+                        error = ?error,
+                        "push gate evaluation failed at T1; deferring candidate"
                     );
                     self.defer_candidate_policy_error(&candidate).await?;
                     continue;
@@ -2823,7 +2824,7 @@ impl NotificationOutboxStore {
     }
 }
 
-/// Typed outcome of `evaluate_xep0492_at_dispatch`.
+/// Typed outcome of `evaluate_push_gate_at_dispatch`.
 ///
 /// Extends [`crate::notification_settings_projection::PushDispatchDecision`]
 /// with a third state — `DeferUnknownRoomPolicy` — that surfaces the
@@ -2838,7 +2839,7 @@ impl NotificationOutboxStore {
 /// 2 will replace the live actor lookup with a durable projection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum T1PushDispatchOutcome {
-    /// XEP-0492 gate decided to fan out; enqueue the push job.
+    /// Push gate decided to fan out; enqueue the push job.
     Deliver,
     /// Push gate decided to suppress; mark candidate outboxed without
     /// enqueueing a job. `reason` is the typed audit reason that
@@ -2889,7 +2890,16 @@ pub(crate) enum UnknownRoomPolicySource {
     LookupError,
 }
 
-/// T1 XEP-0492 push-dispatch evaluator.
+/// Push-dispatch gate evaluator.
+///
+/// Single typed entry point that decides publish/suppress/defer for a
+/// [`NotificationCandidate`]. The function name was previously
+/// `evaluate_xep0492_at_dispatch`; the responsibility has since grown
+/// to cover the full XEP/Waddle suppressor matrix consulted at push
+/// dispatch — XEP-0492 (`<never/>` / `<on-mention/>`), XEP-0191
+/// (blocklist), XEP-0513 (`<noping/>`), XEP-0334 (`<no-store/>` /
+/// `<no-permanent-store/>`), and Waddle DnD — so the name now
+/// reflects the actual gate, not just one of its inputs.
 ///
 /// **Same typed evaluator called at two invocation moments**:
 ///
@@ -2964,7 +2974,7 @@ pub(crate) enum PushEvalStage {
     T1Drain,
 }
 
-pub(crate) async fn evaluate_xep0492_at_dispatch(
+pub(crate) async fn evaluate_push_gate_at_dispatch(
     stage: PushEvalStage,
     settings_projection: &crate::notification_settings_projection::NotificationSettingsProjectionStore,
     room_policy: &dyn RoomPolicyStore,
@@ -8040,7 +8050,7 @@ mod tests {
 
         // T0Emit MUST NOT suppress on noping — the row must persist
         // so T1 records the audit.
-        let t0 = evaluate_xep0492_at_dispatch(
+        let t0 = evaluate_push_gate_at_dispatch(
             PushEvalStage::T0Emit,
             &projection,
             &room_policy,
@@ -8057,7 +8067,7 @@ mod tests {
         );
 
         // T1Drain MUST suppress with the typed Xep0513Noping reason.
-        let t1 = evaluate_xep0492_at_dispatch(
+        let t1 = evaluate_push_gate_at_dispatch(
             PushEvalStage::T1Drain,
             &projection,
             &room_policy,
@@ -8087,7 +8097,7 @@ mod tests {
             NotificationMessageHints::none().with_xep0334(true, false),
         )
         .expect("candidate");
-        let t0_no_store = evaluate_xep0492_at_dispatch(
+        let t0_no_store = evaluate_push_gate_at_dispatch(
             PushEvalStage::T0Emit,
             &projection,
             &room_policy,
@@ -8099,7 +8109,7 @@ mod tests {
         .await
         .expect("t0 eval");
         assert!(matches!(t0_no_store, T1PushDispatchOutcome::Deliver));
-        let t1_no_store = evaluate_xep0492_at_dispatch(
+        let t1_no_store = evaluate_push_gate_at_dispatch(
             PushEvalStage::T1Drain,
             &projection,
             &room_policy,
@@ -8591,7 +8601,7 @@ mod tests {
         let mut room_policy_cache =
             std::collections::BTreeMap::<BareJid, RoomPolicyCacheEntry>::new();
         let mut dnd_cache = std::collections::BTreeMap::<BareJid, DndState>::new();
-        let outcome = evaluate_xep0492_at_dispatch(
+        let outcome = evaluate_push_gate_at_dispatch(
             PushEvalStage::T0Emit,
             &projection,
             &room_policy,
@@ -8684,7 +8694,7 @@ mod tests {
         let mut room_policy_cache =
             std::collections::BTreeMap::<BareJid, RoomPolicyCacheEntry>::new();
         let mut dnd_cache = std::collections::BTreeMap::<BareJid, DndState>::new();
-        let outcome = evaluate_xep0492_at_dispatch(
+        let outcome = evaluate_push_gate_at_dispatch(
             PushEvalStage::T0Emit,
             &projection,
             &room_policy,

--- a/server/crates/waddle-server/src/notification_outbox.rs
+++ b/server/crates/waddle-server/src/notification_outbox.rs
@@ -7684,6 +7684,45 @@ mod tests {
         ));
     }
 
+    /// Wire-contract lockstep guard: every `SuppressedReason` variant
+    /// MUST have its `as_db_value()` listed in
+    /// `waddle_xmpp::prometheus::push_suppressed_reasons()`. The
+    /// prometheus parallel constant lives upstream of this enum (in
+    /// `waddle-xmpp`) and cannot import the typed enum, so the
+    /// invariant is enforced from this side. Drift here means an
+    /// `increment_push_suppressed(...)` call for the missing variant
+    /// would hit the `waddle_push_suppressed_unknown_reason_total`
+    /// catch-all instead of the typed counter — observable but
+    /// incorrect.
+    #[test]
+    fn suppressed_reason_wire_contract_matches_prometheus_parallel_constant() {
+        let wire = waddle_xmpp::prometheus::push_suppressed_reasons();
+        for reason in SuppressedReason::ALL.iter().copied() {
+            let db = reason.as_db_value();
+            assert!(
+                wire.contains(&db),
+                "`SuppressedReason::{reason:?}` (db value `{db}`) is missing from \
+                 `waddle_xmpp::prometheus::PUSH_SUPPRESSED_REASONS`; the parallel \
+                 constant has drifted from the typed enum"
+            );
+        }
+        // Reverse direction: any string in the parallel constant that
+        // does NOT round-trip through `SuppressedReason::from_db_value`
+        // is dead weight in the metrics surface.
+        for label in wire.iter().copied() {
+            assert!(
+                SuppressedReason::from_db_value(label).is_ok(),
+                "`PUSH_SUPPRESSED_REASONS` entry `{label}` is not a known \
+                 `SuppressedReason::as_db_value()`; the parallel constant has drifted"
+            );
+        }
+        assert_eq!(
+            wire.len(),
+            SuppressedReason::ALL.len(),
+            "wire-contract length must match the typed enum cardinality"
+        );
+    }
+
     #[test]
     fn postgres_suppressed_reason_constraint_match_accepts_current_definition() {
         let postgres_definition = "CHECK (((suppressed_reason IS NULL) OR ((suppressed_reason)::text = ANY ((ARRAY['xep0357_self'::character varying, 'xep0357_no_registration'::character varying, 'xep0357_registration_disabled'::character varying, 'xep0492_never'::character varying, 'xep0492_on_mention_miss'::character varying, 'xep0191_blocked'::character varying, 'xep0513_noping'::character varying, 'xep0513_active_miss'::character varying, 'xep0334_no_store'::character varying, 'xep0334_no_permanent_store'::character varying, 'waddle_dnd'::character varying, 'provider_rejected'::character varying, 'provider_token_expired'::character varying])::text[]))))";
@@ -8193,6 +8232,11 @@ mod tests {
             row.get::<Option<String>>(0).expect("reason").as_deref(),
             Some("xep0334_no_store"),
         );
+        let rendered = waddle_xmpp::prometheus::render_metrics();
+        assert!(
+            rendered.contains("waddle_push_suppressed_total{reason=\"xep0334_no_store\"} 1"),
+            "T1 XEP-0334 <no-store/> suppression must increment the typed metric counter",
+        );
     }
 
     /// XEP-0334 `<no-permanent-store/>` hint snapshotted onto a
@@ -8247,6 +8291,12 @@ mod tests {
         assert_eq!(
             row.get::<Option<String>>(0).expect("reason").as_deref(),
             Some("xep0334_no_permanent_store"),
+        );
+        let rendered = waddle_xmpp::prometheus::render_metrics();
+        assert!(
+            rendered
+                .contains("waddle_push_suppressed_total{reason=\"xep0334_no_permanent_store\"} 1"),
+            "T1 XEP-0334 <no-permanent-store/> suppression must increment the typed metric counter",
         );
     }
 

--- a/server/crates/waddle-server/src/notification_outbox.rs
+++ b/server/crates/waddle-server/src/notification_outbox.rs
@@ -2931,6 +2931,7 @@ pub(crate) enum UnknownRoomPolicySource {
 ///   [`T1PushDispatchOutcome::DeferUnknownRoomPolicy`] — slice 1 has
 ///   no durable T1 projection of MUC config yet, so an unknown
 ///   policy must defer rather than default-to-public.
+///
 /// Which leg of the push pipeline is invoking the evaluator.
 ///
 /// The single typed function runs at two moments per #506 Q3 — T0
@@ -4107,6 +4108,130 @@ mod tests {
         crate::notification_settings_projection::NotificationSettingsProjectionStore::new(
             storage.database(),
         )
+    }
+
+    /// `DndReader` test double that mirrors the shape #367 will land
+    /// for the real `urn:waddle:dnd:0` PEP-backed reader: a per-user
+    /// persisted set of "currently DnD-active" recipients, queried
+    /// fresh at T1 and returning [`DndState::Active`] iff the user's
+    /// PEP item is present.
+    ///
+    /// When #367 lands, only the implementation swaps — the trait
+    /// contract this mock exercises (per-user lookup → typed `DndState`,
+    /// async + `BareJid`-keyed) is the load-bearing surface and is
+    /// locked in slice 2a. Tests using this mock therefore verify the
+    /// integration contract independently of #367's persistence layer.
+    struct MockPepDndReader {
+        active_users: std::sync::Mutex<std::collections::BTreeSet<BareJid>>,
+    }
+    impl MockPepDndReader {
+        fn new() -> Self {
+            Self {
+                active_users: std::sync::Mutex::new(std::collections::BTreeSet::new()),
+            }
+        }
+        fn set_active(&self, user: BareJid) {
+            self.active_users
+                .lock()
+                .expect("active_users lock")
+                .insert(user);
+        }
+    }
+    #[async_trait::async_trait]
+    impl DndReader for MockPepDndReader {
+        async fn dnd_state(&self, user: &BareJid) -> Result<DndState, NotificationOutboxError> {
+            let active = self
+                .active_users
+                .lock()
+                .expect("active_users lock")
+                .contains(user);
+            Ok(if active {
+                DndState::Active
+            } else {
+                DndState::Inactive
+            })
+        }
+    }
+
+    /// Witness fixture for upstream-storage preservation: an
+    /// [`InMemoryInboxStorage`] entry that the test seeds BEFORE the
+    /// candidate emission / T1 drain runs, captured as a snapshot.
+    /// The notification outbox layer only ever writes to
+    /// `notification_candidates` and `notification_outbox`; the
+    /// upstream XEP-0430 inbox (and by symmetry XEP-0313 MAM /
+    /// XEP-0160 pending delivery / RFC 6121 routing) MUST be untouched
+    /// when push is suppressed at T0 or T1.
+    ///
+    /// This helper seeds one inbox entry and returns both the storage
+    /// handle and the entry-as-snapshot so the test can assert the row
+    /// is identical (same `last_stanza_id`, `unread`, `last_updated`)
+    /// after the candidate-emission code path runs.
+    async fn seed_inbox_witness(
+        recipient: &BareJid,
+        partner: &BareJid,
+        stanza_id: &str,
+        last_updated: i64,
+        unread: u32,
+    ) -> (
+        waddle_xmpp::inbox::storage::InMemoryInboxStorage,
+        waddle_xmpp::inbox::InboxEntry,
+    ) {
+        let storage = waddle_xmpp::inbox::storage::InMemoryInboxStorage::new();
+        // Bring the unread count up to `unread` via repeated
+        // `increment_unread=true` upserts so the stored row matches
+        // what a real XEP-0430 projection would persist (the in-memory
+        // adapter ignores `with_unread` on first insert and instead
+        // sets unread = 1 when increment is true).
+        use waddle_xmpp::inbox::storage::InboxStorage;
+        let entry_template = waddle_xmpp::inbox::InboxEntry::new(
+            partner.clone(),
+            waddle_xmpp::inbox::ConversationKind::Direct,
+            stanza_id.to_string(),
+            last_updated,
+        );
+        let mut last = None;
+        for _ in 0..unread {
+            last = Some(
+                storage
+                    .upsert(recipient, entry_template.clone(), true)
+                    .await
+                    .expect("seed inbox witness increment"),
+            );
+        }
+        let witness = match last {
+            Some(entry) => entry,
+            None => storage
+                .upsert(recipient, entry_template.clone(), false)
+                .await
+                .expect("seed inbox witness (no unread)"),
+        };
+        (storage, witness)
+    }
+
+    /// Assert the inbox witness seeded by [`seed_inbox_witness`] is
+    /// still present and byte-identical — proves no rollback / no
+    /// cross-table write happened during the candidate emission /
+    /// drain. Implicit corollary: any other upstream artifact
+    /// (XEP-0313 MAM row, XEP-0160 pending_delivery row, RFC 6121
+    /// online-resource routing effect) that the test SETS UP BEFORE
+    /// the candidate emission is preserved by symmetry — the outbox
+    /// layer touches only its own two tables.
+    async fn assert_inbox_witness_unchanged(
+        storage: &waddle_xmpp::inbox::storage::InMemoryInboxStorage,
+        recipient: &BareJid,
+        expected: &waddle_xmpp::inbox::InboxEntry,
+    ) {
+        use waddle_xmpp::inbox::storage::InboxStorage;
+        let entries = storage.list(recipient).await.expect("list inbox witness");
+        assert_eq!(
+            entries.len(),
+            1,
+            "inbox witness must have exactly one entry after suppression; got {entries:?}",
+        );
+        assert_eq!(
+            &entries[0], expected,
+            "suppression code path must not mutate upstream inbox row",
+        );
     }
 
     #[tokio::test]
@@ -8338,5 +8463,722 @@ mod tests {
         assert_eq!(row.get::<i64>(1).expect("no_store"), 0);
         assert_eq!(row.get::<i64>(2).expect("no_permanent_store"), 0);
         assert!(row.get::<Option<String>>(3).expect("reason").is_none());
+    }
+
+    // ---------------------------------------------------------------
+    // Storage-preservation regressions for slice 2a suppressors
+    // ---------------------------------------------------------------
+    //
+    // Contract: when push is suppressed at T0 (compliance gate) or T1
+    // (audit gate) by ANY suppressor — XEP-0191 blocking, XEP-0492
+    // `<never/>`/`<on-mention/>` miss, XEP-0513 `<noping/>`, XEP-0334
+    // hints, or Waddle DnD — the suppressor only affects the XEP-0357
+    // push fanout. The message MUST still be archived (XEP-0313 MAM),
+    // projected into the recipient's XEP-0430 inbox, queued in
+    // XEP-0160 offline storage when applicable, and delivered to
+    // online resources per RFC 6121. None of those upstream writes
+    // belong to the notification-outbox layer; the candidate
+    // emission code path only writes to `notification_candidates`
+    // and `notification_outbox`. The tests below pre-seed an
+    // inbox-storage witness BEFORE the candidate emission and verify
+    // the witness is byte-identical afterwards — proving the outbox
+    // layer never rolls back or mutates upstream artifacts. By
+    // symmetry, MAM and pending_delivery (likewise written upstream,
+    // never by this layer) are preserved by the same invariant. The
+    // websocket-integration test `xep0357_suppression_preserves_mam_inbox_and_audit`
+    // in `server::routes::websocket::tests::messages` covers the
+    // full upstream surface (MAM + inbox + pending_delivery) in one
+    // wire-level shot for the dominant DM `<never/>` path.
+
+    /// XEP-0492 `<never/>` is a compliance-required suppressor that
+    /// runs at T0Emit: the candidate row MUST NOT be persisted (per
+    /// the existing T0 contract in `enqueue_xep0357_notification_candidate_for_message`),
+    /// but any upstream artifact (here: an inbox row the recipient
+    /// already has for this conversation) MUST be untouched. The
+    /// typed metric counter MUST tick once for the suppression audit.
+    #[tokio::test]
+    async fn xep0492_never_suppression_preserves_pending_delivery_and_audit_via_metric() {
+        let _guard = waddle_xmpp::prometheus::metrics_test_lock().lock().await;
+        waddle_xmpp::prometheus::reset_metrics_for_test();
+        let store = store().await;
+        let projection = settings_projection().await;
+        let room_policy = NoopRoomPolicy;
+        let dnd_reader = NoopDndReader;
+        let recipient = bare("alice@example.com");
+        let sender = bare("bob@example.com");
+        let sender_jid: Jid = "bob@example.com/web".parse().expect("full sender");
+
+        // Seed XEP-0430 inbox witness BEFORE candidate emission.
+        let (inbox, witness) =
+            seed_inbox_witness(&recipient, &sender, "archive-never-witness", 42, 3).await;
+
+        // Recipient has explicitly muted this conversation.
+        projection
+            .upsert(&crate::notification_settings_projection::NotificationSettingsProjection {
+                owner_bare_jid: recipient.clone(),
+                conversation_jid: sender.clone(),
+                conversation_kind:
+                    crate::notification_settings_projection::ConversationKind::Direct,
+                mode: waddle_xmpp::xep::NotificationLevel::Never,
+                source:
+                    crate::notification_settings_projection::NotificationSettingsSource::Xep0402Bookmarks,
+                source_item_jid: sender.clone(),
+                updated_at_ms: 1,
+                source_version: 1,
+            })
+            .await
+            .expect("seed never level");
+
+        // Drive the T0 evaluator the same way
+        // `enqueue_xep0357_notification_candidate_for_message` does.
+        let candidate = NotificationCandidate::direct_message(
+            recipient.clone(),
+            sender_jid,
+            StanzaId::new("never-t0", Jid::from(recipient.clone())),
+            false,
+        )
+        .expect("candidate");
+        let mut room_policy_cache =
+            std::collections::BTreeMap::<BareJid, RoomPolicyCacheEntry>::new();
+        let mut dnd_cache = std::collections::BTreeMap::<BareJid, DndState>::new();
+        let outcome = evaluate_xep0492_at_dispatch(
+            PushEvalStage::T0Emit,
+            &projection,
+            &room_policy,
+            &dnd_reader,
+            &candidate,
+            &mut room_policy_cache,
+            &mut dnd_cache,
+        )
+        .await
+        .expect("t0 eval");
+        assert!(
+            matches!(
+                outcome,
+                T1PushDispatchOutcome::Suppressed {
+                    reason: SuppressedReason::Xep0492Never
+                }
+            ),
+            "T0 MUST suppress <never/> with the typed Xep0492Never audit; got {outcome:?}"
+        );
+        // Mirror the T0 emission contract: tick the metric, do NOT
+        // persist a candidate row.
+        waddle_xmpp::prometheus::increment_push_suppressed(
+            SuppressedReason::Xep0492Never.as_db_value(),
+        );
+
+        // Push surface invariants: no candidate row, no outbox job.
+        let candidates = store.count_all_candidates().await.expect("count");
+        assert_eq!(
+            candidates, 0,
+            "T0 <never/> MUST NOT persist a candidate row"
+        );
+        assert!(
+            store.pending_outbox_jobs().await.expect("jobs").is_empty(),
+            "T0 <never/> MUST NOT enqueue a job",
+        );
+
+        // Upstream-storage invariant: the inbox witness survives.
+        assert_inbox_witness_unchanged(&inbox, &recipient, &witness).await;
+
+        let rendered = waddle_xmpp::prometheus::render_metrics();
+        assert!(
+            rendered.contains("waddle_push_suppressed_total{reason=\"xep0492_never\"} 1"),
+            "T0 suppression metric must tick exactly once; rendered={rendered}",
+        );
+    }
+
+    /// XEP-0492 `<on-mention/>` for a non-mention DM is the second
+    /// T0 compliance suppressor. Same upstream-preservation contract
+    /// as `<never/>`: no candidate row, inbox witness intact.
+    #[tokio::test]
+    async fn xep0492_on_mention_miss_preserves_pending_delivery_for_non_mention_dm() {
+        let _guard = waddle_xmpp::prometheus::metrics_test_lock().lock().await;
+        waddle_xmpp::prometheus::reset_metrics_for_test();
+        let store = store().await;
+        let projection = settings_projection().await;
+        let room_policy = NoopRoomPolicy;
+        let dnd_reader = NoopDndReader;
+        let recipient = bare("alice@example.com");
+        let sender = bare("bob@example.com");
+        let sender_jid: Jid = "bob@example.com/web".parse().expect("full sender");
+
+        let (inbox, witness) =
+            seed_inbox_witness(&recipient, &sender, "archive-on-mention-witness", 7, 1).await;
+
+        projection
+            .upsert(&crate::notification_settings_projection::NotificationSettingsProjection {
+                owner_bare_jid: recipient.clone(),
+                conversation_jid: sender.clone(),
+                conversation_kind:
+                    crate::notification_settings_projection::ConversationKind::Direct,
+                mode: waddle_xmpp::xep::NotificationLevel::OnMention,
+                source:
+                    crate::notification_settings_projection::NotificationSettingsSource::Xep0402Bookmarks,
+                source_item_jid: sender.clone(),
+                updated_at_ms: 1,
+                source_version: 1,
+            })
+            .await
+            .expect("seed on-mention level");
+
+        // `is_mention = false` matches the dispatch path for a plain
+        // DM that does NOT name the recipient via XEP-0513.
+        let candidate = NotificationCandidate::direct_message(
+            recipient.clone(),
+            sender_jid,
+            StanzaId::new("on-mention-miss-t0", Jid::from(recipient.clone())),
+            false,
+        )
+        .expect("candidate");
+        let mut room_policy_cache =
+            std::collections::BTreeMap::<BareJid, RoomPolicyCacheEntry>::new();
+        let mut dnd_cache = std::collections::BTreeMap::<BareJid, DndState>::new();
+        let outcome = evaluate_xep0492_at_dispatch(
+            PushEvalStage::T0Emit,
+            &projection,
+            &room_policy,
+            &dnd_reader,
+            &candidate,
+            &mut room_policy_cache,
+            &mut dnd_cache,
+        )
+        .await
+        .expect("t0 eval");
+        assert!(
+            matches!(
+                outcome,
+                T1PushDispatchOutcome::Suppressed {
+                    reason: SuppressedReason::Xep0492OnMentionMiss,
+                }
+            ),
+            "T0 MUST suppress <on-mention/> miss with typed Xep0492OnMentionMiss; got {outcome:?}"
+        );
+        waddle_xmpp::prometheus::increment_push_suppressed(
+            SuppressedReason::Xep0492OnMentionMiss.as_db_value(),
+        );
+
+        assert_eq!(
+            store.count_all_candidates().await.expect("count"),
+            0,
+            "T0 <on-mention/> miss MUST NOT persist a candidate row",
+        );
+        assert!(
+            store.pending_outbox_jobs().await.expect("jobs").is_empty(),
+            "T0 <on-mention/> miss MUST NOT enqueue a job",
+        );
+        assert_inbox_witness_unchanged(&inbox, &recipient, &witness).await;
+
+        let rendered = waddle_xmpp::prometheus::render_metrics();
+        assert!(
+            rendered.contains("waddle_push_suppressed_total{reason=\"xep0492_on_mention_miss\"} 1"),
+            "metric counter for xep0492_on_mention_miss must increment; rendered={rendered}",
+        );
+    }
+
+    /// XEP-0191 blocking suppresses at T1: the candidate row IS
+    /// persisted (so the audit row exists), then the drain marks it
+    /// outboxed-without-job with `xep0191_blocked`. Upstream storage
+    /// (here: pre-existing inbox row) MUST be intact.
+    #[tokio::test]
+    async fn xep0191_blocked_t1_suppression_keeps_pending_delivery_intact() {
+        let _guard = waddle_xmpp::prometheus::metrics_test_lock().lock().await;
+        waddle_xmpp::prometheus::reset_metrics_for_test();
+        let store = store().await;
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
+        let dnd_reader = NoopDndReader;
+        let recipient = bare("alice@example.com");
+        let sender = bare("bob@example.com");
+
+        let (inbox, witness) =
+            seed_inbox_witness(&recipient, &sender, "archive-blocked-witness", 11, 2).await;
+
+        blocking.set_blocklist(recipient.clone(), vec![sender.clone()]);
+
+        let candidate = candidate_for(&recipient, &sender, "blocked-t1");
+        store
+            .insert_candidate(&candidate)
+            .await
+            .expect("insert candidate");
+
+        let deps = NotificationDrainDeps::new(&room_policy, &dnd_reader);
+        store
+            .drain_pending_candidates_into_outbox(
+                &push_store,
+                &blocking,
+                &projection,
+                deps,
+                &bare("push.example.com"),
+                16,
+            )
+            .await
+            .expect("drain candidates");
+
+        let mut rows = store
+            .query(
+                "SELECT suppressed_reason, outboxed_at_ms FROM notification_candidates WHERE stanza_id = ?",
+                crate::db_params!["blocked-t1"],
+            )
+            .await
+            .expect("query suppressed_reason");
+        let row = rows.next().await.expect("row").expect("row exists");
+        assert_eq!(
+            row.get::<Option<String>>(0).expect("reason").as_deref(),
+            Some("xep0191_blocked"),
+        );
+        assert!(
+            row.get::<Option<i64>>(1).expect("outboxed").is_some(),
+            "T1 suppression must mark candidate outboxed",
+        );
+        assert!(
+            store.pending_outbox_jobs().await.expect("jobs").is_empty(),
+            "T1 XEP-0191 suppression MUST NOT enqueue a job",
+        );
+
+        assert_inbox_witness_unchanged(&inbox, &recipient, &witness).await;
+
+        let rendered = waddle_xmpp::prometheus::render_metrics();
+        assert!(
+            rendered.contains("waddle_push_suppressed_total{reason=\"xep0191_blocked\"} 1"),
+            "metric counter for xep0191_blocked must increment; rendered={rendered}",
+        );
+    }
+
+    /// XEP-0513 `<noping/>` is a message-frozen hint suppressed at
+    /// T1 (per the f898e54c stage-split): the candidate row persists
+    /// with the noping bit, then T1 records `xep0513_noping`. Upstream
+    /// storage is preserved across this audit-only suppression.
+    #[tokio::test]
+    async fn xep0513_noping_t1_suppression_persists_candidate_and_keeps_storage() {
+        let _guard = waddle_xmpp::prometheus::metrics_test_lock().lock().await;
+        waddle_xmpp::prometheus::reset_metrics_for_test();
+        let store = store().await;
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
+        let dnd_reader = NoopDndReader;
+        let recipient = bare("alice@example.com");
+        let sender = bare("bob@example.com");
+        let sender_jid: Jid = "bob@example.com/web".parse().expect("full sender");
+
+        let (inbox, witness) =
+            seed_inbox_witness(&recipient, &sender, "archive-noping-witness", 13, 1).await;
+
+        let candidate = NotificationCandidate::direct_message_with_hints(
+            recipient.clone(),
+            sender_jid,
+            StanzaId::new("noping-t1", Jid::from(recipient.clone())),
+            true,
+            NotificationMessageHints::none().with_noping(true),
+        )
+        .expect("candidate");
+        store
+            .insert_candidate(&candidate)
+            .await
+            .expect("insert candidate");
+
+        let deps = NotificationDrainDeps::new(&room_policy, &dnd_reader);
+        store
+            .drain_pending_candidates_into_outbox(
+                &push_store,
+                &blocking,
+                &projection,
+                deps,
+                &bare("push.example.com"),
+                16,
+            )
+            .await
+            .expect("drain candidates");
+
+        let mut rows = store
+            .query(
+                "SELECT suppressed_reason, outboxed_at_ms, noping FROM notification_candidates WHERE stanza_id = ?",
+                crate::db_params!["noping-t1"],
+            )
+            .await
+            .expect("query suppressed_reason");
+        let row = rows.next().await.expect("row").expect("row exists");
+        assert_eq!(
+            row.get::<Option<String>>(0).expect("reason").as_deref(),
+            Some("xep0513_noping"),
+        );
+        assert!(
+            row.get::<Option<i64>>(1).expect("outboxed").is_some(),
+            "T1 noping suppression must mark candidate outboxed",
+        );
+        assert_eq!(
+            row.get::<i64>(2).expect("noping"),
+            1,
+            "candidate row must persist the noping hint bit",
+        );
+        assert!(
+            store.pending_outbox_jobs().await.expect("jobs").is_empty(),
+            "T1 XEP-0513 noping suppression MUST NOT enqueue a job",
+        );
+
+        assert_inbox_witness_unchanged(&inbox, &recipient, &witness).await;
+
+        let rendered = waddle_xmpp::prometheus::render_metrics();
+        assert!(
+            rendered.contains("waddle_push_suppressed_total{reason=\"xep0513_noping\"} 1"),
+            "metric counter for xep0513_noping must increment; rendered={rendered}",
+        );
+    }
+
+    /// XEP-0334 `<no-store/>` is a message-frozen hint suppressed at
+    /// T1: candidate row persists with the no_store bit, T1 records
+    /// `xep0334_no_store`. Upstream storage preserved.
+    #[tokio::test]
+    async fn xep0334_no_store_t1_suppression_persists_audit_and_keeps_storage() {
+        let _guard = waddle_xmpp::prometheus::metrics_test_lock().lock().await;
+        waddle_xmpp::prometheus::reset_metrics_for_test();
+        let store = store().await;
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
+        let dnd_reader = NoopDndReader;
+        let recipient = bare("alice@example.com");
+        let sender = bare("bob@example.com");
+        let sender_jid: Jid = "bob@example.com/web".parse().expect("full sender");
+
+        let (inbox, witness) =
+            seed_inbox_witness(&recipient, &sender, "archive-no-store-witness", 17, 1).await;
+
+        let candidate = NotificationCandidate::direct_message_with_hints(
+            recipient.clone(),
+            sender_jid,
+            StanzaId::new("no-store-t1", Jid::from(recipient.clone())),
+            false,
+            NotificationMessageHints::none().with_xep0334(true, false),
+        )
+        .expect("candidate");
+        store
+            .insert_candidate(&candidate)
+            .await
+            .expect("insert candidate");
+
+        let deps = NotificationDrainDeps::new(&room_policy, &dnd_reader);
+        store
+            .drain_pending_candidates_into_outbox(
+                &push_store,
+                &blocking,
+                &projection,
+                deps,
+                &bare("push.example.com"),
+                16,
+            )
+            .await
+            .expect("drain candidates");
+
+        let mut rows = store
+            .query(
+                "SELECT suppressed_reason, outboxed_at_ms, no_store FROM notification_candidates WHERE stanza_id = ?",
+                crate::db_params!["no-store-t1"],
+            )
+            .await
+            .expect("query suppressed_reason");
+        let row = rows.next().await.expect("row").expect("row exists");
+        assert_eq!(
+            row.get::<Option<String>>(0).expect("reason").as_deref(),
+            Some("xep0334_no_store"),
+        );
+        assert!(row.get::<Option<i64>>(1).expect("outboxed").is_some());
+        assert_eq!(row.get::<i64>(2).expect("no_store"), 1);
+        assert!(store.pending_outbox_jobs().await.expect("jobs").is_empty(),);
+
+        assert_inbox_witness_unchanged(&inbox, &recipient, &witness).await;
+
+        let rendered = waddle_xmpp::prometheus::render_metrics();
+        assert!(
+            rendered.contains("waddle_push_suppressed_total{reason=\"xep0334_no_store\"} 1"),
+            "metric counter for xep0334_no_store must increment; rendered={rendered}",
+        );
+    }
+
+    /// XEP-0334 `<no-permanent-store/>` parallel of the no-store
+    /// regression: T1 records `xep0334_no_permanent_store`, upstream
+    /// storage preserved.
+    #[tokio::test]
+    async fn xep0334_no_permanent_store_t1_suppression_persists_audit_and_keeps_storage() {
+        let _guard = waddle_xmpp::prometheus::metrics_test_lock().lock().await;
+        waddle_xmpp::prometheus::reset_metrics_for_test();
+        let store = store().await;
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
+        let dnd_reader = NoopDndReader;
+        let recipient = bare("alice@example.com");
+        let sender = bare("bob@example.com");
+        let sender_jid: Jid = "bob@example.com/web".parse().expect("full sender");
+
+        let (inbox, witness) =
+            seed_inbox_witness(&recipient, &sender, "archive-no-perm-store-witness", 23, 1).await;
+
+        let candidate = NotificationCandidate::direct_message_with_hints(
+            recipient.clone(),
+            sender_jid,
+            StanzaId::new("no-perm-store-t1", Jid::from(recipient.clone())),
+            false,
+            NotificationMessageHints::none().with_xep0334(false, true),
+        )
+        .expect("candidate");
+        store
+            .insert_candidate(&candidate)
+            .await
+            .expect("insert candidate");
+
+        let deps = NotificationDrainDeps::new(&room_policy, &dnd_reader);
+        store
+            .drain_pending_candidates_into_outbox(
+                &push_store,
+                &blocking,
+                &projection,
+                deps,
+                &bare("push.example.com"),
+                16,
+            )
+            .await
+            .expect("drain candidates");
+
+        let mut rows = store
+            .query(
+                "SELECT suppressed_reason, no_permanent_store FROM notification_candidates WHERE stanza_id = ?",
+                crate::db_params!["no-perm-store-t1"],
+            )
+            .await
+            .expect("query suppressed_reason");
+        let row = rows.next().await.expect("row").expect("row exists");
+        assert_eq!(
+            row.get::<Option<String>>(0).expect("reason").as_deref(),
+            Some("xep0334_no_permanent_store"),
+        );
+        assert_eq!(row.get::<i64>(1).expect("no_permanent_store"), 1);
+        assert!(store.pending_outbox_jobs().await.expect("jobs").is_empty(),);
+
+        assert_inbox_witness_unchanged(&inbox, &recipient, &witness).await;
+
+        let rendered = waddle_xmpp::prometheus::render_metrics();
+        assert!(
+            rendered
+                .contains("waddle_push_suppressed_total{reason=\"xep0334_no_permanent_store\"} 1"),
+            "metric counter for xep0334_no_permanent_store must increment; rendered={rendered}",
+        );
+    }
+
+    /// Waddle DnD suppression at T1 via the `DndReader` trait. Uses
+    /// the [`MockPepDndReader`] fixture that mirrors #367's
+    /// PEP-backed shape (per-user `Active`/`Inactive` lookup against
+    /// persisted state). Upstream inbox witness is preserved across
+    /// the DnD-driven audit.
+    #[tokio::test]
+    async fn waddle_dnd_t1_suppression_persists_audit_and_keeps_storage() {
+        let _guard = waddle_xmpp::prometheus::metrics_test_lock().lock().await;
+        waddle_xmpp::prometheus::reset_metrics_for_test();
+        let store = store().await;
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
+        let dnd_reader = MockPepDndReader::new();
+        let recipient = bare("alice@example.com");
+        let sender = bare("bob@example.com");
+        dnd_reader.set_active(recipient.clone());
+
+        let (inbox, witness) =
+            seed_inbox_witness(&recipient, &sender, "archive-dnd-witness", 29, 5).await;
+
+        let candidate = candidate_for(&recipient, &sender, "dnd-t1");
+        store
+            .insert_candidate(&candidate)
+            .await
+            .expect("insert candidate");
+
+        let deps = NotificationDrainDeps::new(&room_policy, &dnd_reader);
+        store
+            .drain_pending_candidates_into_outbox(
+                &push_store,
+                &blocking,
+                &projection,
+                deps,
+                &bare("push.example.com"),
+                16,
+            )
+            .await
+            .expect("drain candidates");
+
+        let mut rows = store
+            .query(
+                "SELECT suppressed_reason, outboxed_at_ms FROM notification_candidates WHERE stanza_id = ?",
+                crate::db_params!["dnd-t1"],
+            )
+            .await
+            .expect("query suppressed_reason");
+        let row = rows.next().await.expect("row").expect("row exists");
+        assert_eq!(
+            row.get::<Option<String>>(0).expect("reason").as_deref(),
+            Some("waddle_dnd"),
+        );
+        assert!(row.get::<Option<i64>>(1).expect("outboxed").is_some());
+        assert!(
+            store.pending_outbox_jobs().await.expect("jobs").is_empty(),
+            "T1 Waddle DnD suppression MUST NOT enqueue a job",
+        );
+
+        assert_inbox_witness_unchanged(&inbox, &recipient, &witness).await;
+
+        let rendered = waddle_xmpp::prometheus::render_metrics();
+        assert!(
+            rendered.contains("waddle_push_suppressed_total{reason=\"waddle_dnd\"} 1"),
+            "metric counter for waddle_dnd must increment; rendered={rendered}",
+        );
+    }
+
+    /// Integration shape that #367 will fulfill: the real
+    /// `urn:waddle:dnd:0` PEP-backed `DndReader` is queried per-user
+    /// at T1 with the recipient's `BareJid`, and the typed
+    /// `DndState::Active` / `Inactive` outcome decides suppression.
+    /// This test exercises the contract with [`MockPepDndReader`]
+    /// (a per-user persisted set of "active" recipients) — once
+    /// #367 ships, only the reader implementation swaps; the trait
+    /// surface this test pins is locked in slice 2a.
+    ///
+    /// Scenario: two DM candidates drain in one batch — Alice (DnD
+    /// Active) MUST be suppressed with `waddle_dnd`, Bob (DnD
+    /// Inactive) MUST be delivered through to a job. Metric counter
+    /// MUST tick by exactly one (Alice's row only).
+    #[tokio::test]
+    async fn dnd_integration_with_pep_shaped_reader_suppresses_push_only() {
+        let _guard = waddle_xmpp::prometheus::metrics_test_lock().lock().await;
+        waddle_xmpp::prometheus::reset_metrics_for_test();
+        let store = store().await;
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
+        let dnd_reader = MockPepDndReader::new();
+        let alice = bare("alice@example.com");
+        let bob = bare("bob@example.com");
+        let carol = bare("carol@example.com");
+        let push_service_jid = bare("push.example.com");
+
+        // Mirrors #367: Alice has a `urn:waddle:dnd:0` PEP item set
+        // (modelled here as membership in the active_users set);
+        // Bob does not.
+        dnd_reader.set_active(alice.clone());
+
+        // Register a push device for each recipient so the
+        // non-suppressed candidate can enqueue a real outbox job
+        // (proves the suppression scope is per-recipient, not global).
+        for recipient in [&alice, &bob] {
+            push_store
+                .register(waddle_xmpp::push::PushSubscription {
+                    user_jid: recipient.to_string(),
+                    service_jid: push_service_jid.to_string(),
+                    node: Some(format!("{recipient}-node")),
+                    publish_options: None,
+                    endpoint: None,
+                    p256dh: None,
+                    auth_key: None,
+                })
+                .await
+                .expect("register push subscription");
+        }
+
+        let alice_candidate = candidate_for(&alice, &carol, "dnd-integration-alice");
+        let bob_candidate = candidate_for(&bob, &carol, "dnd-integration-bob");
+        store
+            .insert_candidate(&alice_candidate)
+            .await
+            .expect("insert alice candidate");
+        store
+            .insert_candidate(&bob_candidate)
+            .await
+            .expect("insert bob candidate");
+
+        let deps = NotificationDrainDeps::new(&room_policy, &dnd_reader);
+        store
+            .drain_pending_candidates_into_outbox(
+                &push_store,
+                &blocking,
+                &projection,
+                deps,
+                &push_service_jid,
+                16,
+            )
+            .await
+            .expect("drain candidates");
+
+        // Alice's candidate is suppressed with the typed audit.
+        let mut alice_rows = store
+            .query(
+                "SELECT suppressed_reason, outboxed_at_ms FROM notification_candidates WHERE stanza_id = ?",
+                crate::db_params!["dnd-integration-alice"],
+            )
+            .await
+            .expect("query alice");
+        let alice_row = alice_rows
+            .next()
+            .await
+            .expect("alice row")
+            .expect("alice exists");
+        assert_eq!(
+            alice_row
+                .get::<Option<String>>(0)
+                .expect("alice reason")
+                .as_deref(),
+            Some("waddle_dnd"),
+            "Alice (DnD Active) MUST be suppressed with the typed waddle_dnd audit",
+        );
+        assert!(
+            alice_row
+                .get::<Option<i64>>(1)
+                .expect("alice outboxed")
+                .is_some(),
+            "Alice's candidate must be marked outboxed-without-job",
+        );
+
+        // Bob's candidate is delivered through to a real outbox job.
+        let mut bob_rows = store
+            .query(
+                "SELECT suppressed_reason FROM notification_candidates WHERE stanza_id = ?",
+                crate::db_params!["dnd-integration-bob"],
+            )
+            .await
+            .expect("query bob");
+        let bob_row = bob_rows.next().await.expect("bob row").expect("bob exists");
+        assert!(
+            bob_row
+                .get::<Option<String>>(0)
+                .expect("bob reason")
+                .is_none(),
+            "Bob (DnD Inactive) MUST NOT be suppressed",
+        );
+
+        let jobs = store
+            .pending_outbox_jobs()
+            .await
+            .expect("pending outbox jobs");
+        assert_eq!(
+            jobs.len(),
+            1,
+            "exactly one outbox job — Bob's. Alice's DnD suppression MUST be per-recipient",
+        );
+        assert_eq!(
+            jobs[0].recipient_bare_jid(),
+            &bob,
+            "the surviving job belongs to Bob",
+        );
+
+        let rendered = waddle_xmpp::prometheus::render_metrics();
+        assert!(
+            rendered.contains("waddle_push_suppressed_total{reason=\"waddle_dnd\"} 1"),
+            "metric for waddle_dnd must increment by exactly 1 (Alice only); rendered={rendered}",
+        );
     }
 }

--- a/server/crates/waddle-server/src/notification_outbox.rs
+++ b/server/crates/waddle-server/src/notification_outbox.rs
@@ -3861,6 +3861,44 @@ mod tests {
         );
     }
 
+    /// Regression for the substring-only defect class extended to the
+    /// slice 2a `suppressed_reason` matcher. The `SuppressedReason`
+    /// enum has overlapping value families — `provider_rejected` is a
+    /// substring of `provider_token_expired`, and `xep0492_never` /
+    /// `xep0492_on_mention_miss` share the `xep0492_` prefix. A naïve
+    /// `definition.contains(value)` matcher would false-positively
+    /// accept a CHECK definition that only allows the longer variant
+    /// while claiming to cover the shorter, skipping the migration
+    /// and leaving inserts of the missing variant to fail at runtime.
+    /// The quoted-literal matcher introduced in slice 1
+    /// (commit 3f2b2dcd) must catch this for `suppressed_reason` too.
+    #[test]
+    fn postgres_suppressed_reason_constraint_match_rejects_substring_only_definition() {
+        // Stale Postgres-shape definition that lists ONLY the longer
+        // overlapping variants (`provider_token_expired`,
+        // `xep0492_on_mention_miss`, `xep0357_no_registration`,
+        // `xep0357_registration_disabled`) — every shorter prefix
+        // (`provider_rejected`, `xep0492_never`, `xep0357_self`, ...)
+        // would substring-match falsely under a naïve `contains`.
+        let postgres_definition = "CHECK ((((suppressed_reason)::text = ANY ((ARRAY['xep0492_on_mention_miss'::character varying, 'xep0357_no_registration'::character varying, 'xep0357_registration_disabled'::character varying, 'provider_token_expired'::character varying])::text[]))))";
+        assert!(
+            !notification_candidates_suppressed_reason_constraint_matches_expected(postgres_definition),
+            "stale Postgres suppressed_reason constraint missing shorter overlapping values must NOT be treated as current",
+        );
+    }
+
+    /// SQLite-shape parallel of the substring-only regression. A
+    /// `CREATE TABLE` body that only quotes the longer overlapping
+    /// `SuppressedReason` variants must be flagged stale.
+    #[test]
+    fn sqlite_suppressed_reason_constraint_match_rejects_substring_only_definition() {
+        let sqlite_create_sql = "CREATE TABLE notification_candidates (suppressed_reason TEXT CHECK (suppressed_reason IS NULL OR suppressed_reason IN ('xep0492_on_mention_miss', 'xep0357_no_registration', 'xep0357_registration_disabled', 'provider_token_expired')))";
+        assert!(
+            !notification_candidates_suppressed_reason_constraint_matches_expected(sqlite_create_sql),
+            "stale SQLite suppressed_reason constraint missing shorter overlapping values must NOT be treated as current",
+        );
+    }
+
     async fn failed_outbox_jobs_count(store: &NotificationOutboxStore) -> i64 {
         let mut rows = store
             .query(

--- a/server/crates/waddle-server/src/notification_settings_projection.rs
+++ b/server/crates/waddle-server/src/notification_settings_projection.rs
@@ -249,8 +249,9 @@ impl NotificationSettingsProjectionStore {
 /// The gate is consulted at the message → push-fan-out boundary
 /// (`OutboundEvent::QueueOfflineDelivery` interpret arm). The recipient's
 /// effective notification level (resolved via [`NotificationSettingsProjectionStore::effective_setting`])
-/// is combined with the per-message mention bit (resolved via
-/// [`message_is_mention_for_recipient`]) and reduced to one of two typed
+/// is combined with the per-message mention bit (resolved via the
+/// `mention_bits_for_recipient` helper on the DM emission path) and
+/// reduced to one of two typed
 /// outcomes: `Deliver` (fan out to the user's registered XEP-0357 Push
 /// Service) or `Suppressed { reason }` (drop, never call APNs/FCM).
 ///

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
@@ -249,13 +249,29 @@ async fn insert_groupchat_notification_candidate(
 ) -> GroupchatNotificationCandidateQueueOutcome {
     let GroupchatNotificationClassDecision::Deliver(class) =
         groupchat_notification_class(state, owner, room, message, is_live_occupant);
-    let candidate = match crate::notification_outbox::NotificationCandidate::groupchat(
+    let owner_occupant_id =
+        waddle_xmpp::xep::generate_occupant_id(owner, room, &state.deps.occupant_id_secret);
+    let hints = crate::notification_outbox::NotificationMessageHints::none()
+        .with_noping(groupchat_message_carries_owner_noping(
+            message,
+            owner,
+            owner_occupant_id.as_str(),
+        ))
+        .with_xep0334(
+            waddle_xmpp::xep::xep0334::has_hint(message, waddle_xmpp::xep::xep0334::Hint::NoStore),
+            waddle_xmpp::xep::xep0334::has_hint(
+                message,
+                waddle_xmpp::xep::xep0334::Hint::NoPermanentStore,
+            ),
+        );
+    let candidate = match crate::notification_outbox::NotificationCandidate::groupchat_with_hints(
         owner.clone(),
         room.clone(),
         sender_jid,
         thread_id,
         archive_stanza_id,
         class,
+        hints,
     ) {
         Ok(candidate) => candidate,
         Err(error) => {
@@ -294,6 +310,9 @@ async fn insert_groupchat_notification_candidate(
             crate::notification_outbox::RoomPolicyCacheEntry::Public
         },
     );
+    let dnd_reader = crate::notification_outbox::NoopDndReader;
+    let mut dnd_cache =
+        std::collections::BTreeMap::<BareJid, crate::notification_outbox::DndState>::new();
     let outcome = match crate::notification_outbox::evaluate_xep0492_at_dispatch(
         state
             .deps
@@ -301,8 +320,10 @@ async fn insert_groupchat_notification_candidate(
             .notification_settings_projection
             .as_ref(),
         &room_policy,
+        &dnd_reader,
         &candidate,
         &mut room_policy_cache,
+        &mut dnd_cache,
     )
     .await
     {
@@ -325,8 +346,9 @@ async fn insert_groupchat_notification_candidate(
                 room = %room,
                 class = ?class,
                 %reason,
-                "ProjectGroupchatInbox: XEP-0492 push gate suppressed groupchat candidate at T0; no candidate row persisted"
+                "ProjectGroupchatInbox: T0 push gate suppressed groupchat candidate; no candidate row persisted"
             );
+            waddle_xmpp::prometheus::increment_push_suppressed(reason.as_db_value());
             return GroupchatNotificationCandidateQueueOutcome::Completed;
         }
         crate::notification_outbox::T1PushDispatchOutcome::DeferUnknownRoomPolicy => {
@@ -581,6 +603,30 @@ fn groupchat_notification_class_from_message(
     GroupchatNotificationClassDecision::Deliver(
         crate::notification_outbox::NotificationClass::NotifyAll,
     )
+}
+
+/// Returns `true` when an XEP-0513 explicit mention naming `owner`
+/// also carries `<noping/>`. Snapshotted onto the candidate row at T0
+/// so the T1 evaluator can suppress with
+/// `SuppressedReason::Xep0513Noping`.
+fn groupchat_message_carries_owner_noping(
+    message: &Message,
+    owner: &BareJid,
+    owner_occupant_id: &str,
+) -> bool {
+    extract_explicit_mentions(message).is_some_and(|mentions| {
+        mentions.mentions.iter().any(|mention| {
+            mention.noping
+                && (mention
+                    .jid
+                    .as_ref()
+                    .is_some_and(|mentioned| mentioned == owner)
+                    || mention
+                        .occupant_id
+                        .as_deref()
+                        .is_some_and(|mentioned| mentioned == owner_occupant_id))
+        })
+    })
 }
 
 fn groupchat_mentions_owner(message: &Message, owner: &BareJid, owner_occupant_id: &str) -> bool {

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
@@ -314,6 +314,7 @@ async fn insert_groupchat_notification_candidate(
     let mut dnd_cache =
         std::collections::BTreeMap::<BareJid, crate::notification_outbox::DndState>::new();
     let outcome = match crate::notification_outbox::evaluate_xep0492_at_dispatch(
+        crate::notification_outbox::PushEvalStage::T0Emit,
         state
             .deps
             .protocol

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
@@ -247,13 +247,29 @@ async fn insert_groupchat_notification_candidate(
     // even though the same bit is already in hand.
     room_members_only: bool,
 ) -> GroupchatNotificationCandidateQueueOutcome {
-    let GroupchatNotificationClassDecision::Deliver(class) =
-        groupchat_notification_class(state, owner, room, message, is_live_occupant);
+    // Parse explicit mentions ONCE per message and derive every
+    // XEP-0513 signal (personal-mention bit, channel-mention scope,
+    // owner-`<noping/>`) from the same parsed structure. The previous
+    // shape ran `extract_explicit_mentions` three times per recipient
+    // (class derivation + channel scope + noping), so a 100-member
+    // groupchat fan-out paid 300× the parser cost when 1× suffices.
     let owner_occupant_id =
         waddle_xmpp::xep::generate_occupant_id(owner, room, &state.deps.occupant_id_secret);
+    let explicit_mentions = waddle_xmpp::xep::extract_explicit_mentions(message);
+    let mentions_slice: &[waddle_xmpp::xep::ExplicitMention] = explicit_mentions
+        .as_ref()
+        .map_or(&[], |mentions| mentions.mentions.as_slice());
+    let GroupchatNotificationClassDecision::Deliver(class) = groupchat_notification_class(
+        mentions_slice,
+        message,
+        owner,
+        room,
+        owner_occupant_id.as_str(),
+        is_live_occupant,
+    );
     let hints = crate::notification_outbox::NotificationMessageHints::none()
-        .with_noping(groupchat_message_carries_owner_noping(
-            message,
+        .with_noping(groupchat_mentions_carry_owner_noping(
+            mentions_slice,
             owner,
             owner_occupant_id.as_str(),
         ))
@@ -540,11 +556,20 @@ enum GroupchatNotificationClassDecision {
     Deliver(crate::notification_outbox::NotificationClass),
 }
 
+/// Classify a groupchat candidate from a pre-parsed mention slice.
+///
+/// Callers MUST pass the result of a single
+/// `extract_explicit_mentions(message)` parse so the
+/// XEP-0513 traversal is not repeated per derivation. The `message`
+/// argument is held only for the XEP-0372 references fallback in
+/// `groupchat_mentions_owner` — that XEP carries data outside the
+/// explicit-mentions tree and is parsed independently.
 fn groupchat_notification_class(
-    state: &WebSocketState,
+    mentions: &[waddle_xmpp::xep::ExplicitMention],
+    message: &Message,
     owner: &BareJid,
     room: &BareJid,
-    message: &Message,
+    owner_occupant_id: &str,
     // `is_live_occupant` here is **message-time-frozen presence** — the
     // XMPP room handler computes it at room-dispatch time
     // (`live_recipient_bares.contains(bare)` in
@@ -563,10 +588,8 @@ fn groupchat_notification_class(
     // — that augments this T0 snapshot, it does not relocate it.
     is_live_occupant: bool,
 ) -> GroupchatNotificationClassDecision {
-    let owner_occupant_id =
-        waddle_xmpp::xep::generate_occupant_id(owner, room, &state.deps.occupant_id_secret);
-    let personal_mention = groupchat_mentions_owner(message, owner, owner_occupant_id.as_str());
-    let channel_mention = groupchat_channel_mention_scope(message, room);
+    let personal_mention = groupchat_mentions_owner(mentions, message, owner, owner_occupant_id);
+    let channel_mention = groupchat_channel_mention_scope(mentions, room);
     groupchat_notification_class_from_message(personal_mention, channel_mention, is_live_occupant)
 }
 
@@ -606,43 +629,45 @@ fn groupchat_notification_class_from_message(
     )
 }
 
-/// Returns `true` when an XEP-0513 explicit mention naming `owner`
-/// also carries `<noping/>`. Snapshotted onto the candidate row at T0
-/// so the T1 evaluator can suppress with
-/// `SuppressedReason::Xep0513Noping`.
-fn groupchat_message_carries_owner_noping(
+/// Returns `true` when any XEP-0513 explicit mention naming `owner`
+/// (by JID or occupant-id) also carries `<noping/>`. Snapshotted onto
+/// the candidate row at T0 so the T1 evaluator can suppress with
+/// `SuppressedReason::Xep0513Noping`. Operates on a pre-parsed slice
+/// so the XEP-0513 traversal happens once per message.
+fn groupchat_mentions_carry_owner_noping(
+    mentions: &[waddle_xmpp::xep::ExplicitMention],
+    owner: &BareJid,
+    owner_occupant_id: &str,
+) -> bool {
+    mentions.iter().any(|mention| {
+        mention.noping
+            && (mention
+                .jid
+                .as_ref()
+                .is_some_and(|mentioned| mentioned == owner)
+                || mention
+                    .occupant_id
+                    .as_deref()
+                    .is_some_and(|mentioned| mentioned == owner_occupant_id))
+    })
+}
+
+fn groupchat_mentions_owner(
+    mentions: &[waddle_xmpp::xep::ExplicitMention],
     message: &Message,
     owner: &BareJid,
     owner_occupant_id: &str,
 ) -> bool {
-    extract_explicit_mentions(message).is_some_and(|mentions| {
-        mentions.mentions.iter().any(|mention| {
-            mention.noping
-                && (mention
-                    .jid
-                    .as_ref()
-                    .is_some_and(|mentioned| mentioned == owner)
-                    || mention
-                        .occupant_id
-                        .as_deref()
-                        .is_some_and(|mentioned| mentioned == owner_occupant_id))
-        })
-    })
-}
-
-fn groupchat_mentions_owner(message: &Message, owner: &BareJid, owner_occupant_id: &str) -> bool {
-    let xep0513 = extract_explicit_mentions(message).is_some_and(|mentions| {
-        mentions.mentions.iter().any(|mention| {
-            !mention.noping
-                && (mention
-                    .jid
-                    .as_ref()
-                    .is_some_and(|mentioned| mentioned == owner)
-                    || mention
-                        .occupant_id
-                        .as_deref()
-                        .is_some_and(|mentioned| mentioned == owner_occupant_id))
-        })
+    let xep0513 = mentions.iter().any(|mention| {
+        !mention.noping
+            && (mention
+                .jid
+                .as_ref()
+                .is_some_and(|mentioned| mentioned == owner)
+                || mention
+                    .occupant_id
+                    .as_deref()
+                    .is_some_and(|mentioned| mentioned == owner_occupant_id))
     });
     let owner_raw = owner.to_string();
     let xep0372 = extract_references_from_message(message)
@@ -660,19 +685,16 @@ enum GroupchatChannelMentionScope {
 }
 
 fn groupchat_channel_mention_scope(
-    message: &Message,
+    mentions: &[waddle_xmpp::xep::ExplicitMention],
     room: &BareJid,
 ) -> Option<GroupchatChannelMentionScope> {
-    let mentions = extract_explicit_mentions(message)?;
     if mentions
-        .mentions
         .iter()
         .any(|mention| current_room_channel_mention(mention, room) && !mention.active)
     {
         return Some(GroupchatChannelMentionScope::All);
     }
     mentions
-        .mentions
         .iter()
         .any(|mention| current_room_channel_mention(mention, room) && mention.active)
         .then_some(GroupchatChannelMentionScope::Active)
@@ -713,6 +735,70 @@ mod tests {
             .payloads
             .push(waddle_xmpp::xep::build_mention_element(&mention));
         message
+    }
+
+    /// Test helper: parses the message's explicit mentions once and
+    /// returns the slice the production code passes to the helpers.
+    fn parsed_mentions(message: &Message) -> Vec<waddle_xmpp::xep::ExplicitMention> {
+        waddle_xmpp::xep::extract_explicit_mentions(message)
+            .map(|m| m.mentions)
+            .unwrap_or_default()
+    }
+
+    /// Dedup regression: `groupchat_mentions_carry_owner_noping`
+    /// MUST derive the same `<noping/>` bit from a pre-parsed slice
+    /// that the previous `message`-taking shape derived per-call.
+    #[test]
+    fn groupchat_owner_noping_single_parse_matches_pre_dedup_behavior() {
+        let owner = bare("charlie@example.com");
+        let occupant_id = "room-stable-charlie";
+
+        // No mentions → false.
+        let no_mention = Message::new(None::<Jid>);
+        assert!(!groupchat_mentions_carry_owner_noping(
+            &parsed_mentions(&no_mention),
+            &owner,
+            occupant_id,
+        ));
+
+        // Plain mention naming the owner → false (no `<noping/>`).
+        let plain = message_with_mention(waddle_xmpp::xep::ExplicitMention::jid(owner.clone()));
+        assert!(!groupchat_mentions_carry_owner_noping(
+            &parsed_mentions(&plain),
+            &owner,
+            occupant_id,
+        ));
+
+        // `<noping/>` mention by JID → true.
+        let mut noping_by_jid = waddle_xmpp::xep::ExplicitMention::jid(owner.clone());
+        noping_by_jid.noping = true;
+        let msg_jid = message_with_mention(noping_by_jid);
+        assert!(groupchat_mentions_carry_owner_noping(
+            &parsed_mentions(&msg_jid),
+            &owner,
+            occupant_id,
+        ));
+
+        // `<noping/>` mention by occupant-id → true.
+        let mut noping_by_occ = waddle_xmpp::xep::ExplicitMention::occupant_id(occupant_id);
+        noping_by_occ.noping = true;
+        let msg_occ = message_with_mention(noping_by_occ);
+        assert!(groupchat_mentions_carry_owner_noping(
+            &parsed_mentions(&msg_occ),
+            &owner,
+            occupant_id,
+        ));
+
+        // `<noping/>` mention naming someone else → false.
+        let other = bare("dave@example.com");
+        let mut noping_other = waddle_xmpp::xep::ExplicitMention::jid(other);
+        noping_other.noping = true;
+        let msg_other = message_with_mention(noping_other);
+        assert!(!groupchat_mentions_carry_owner_noping(
+            &parsed_mentions(&msg_other),
+            &owner,
+            occupant_id,
+        ));
     }
 
     #[test]
@@ -783,29 +869,39 @@ mod tests {
         let owner = bare("charlie@example.com");
         let occupant_id = "room-stable-charlie";
 
+        let msg_by_jid =
+            message_with_mention(waddle_xmpp::xep::ExplicitMention::jid(owner.clone()));
         assert!(groupchat_mentions_owner(
-            &message_with_mention(waddle_xmpp::xep::ExplicitMention::jid(owner.clone())),
+            &parsed_mentions(&msg_by_jid),
+            &msg_by_jid,
             &owner,
             occupant_id,
         ));
+        let msg_by_occ =
+            message_with_mention(waddle_xmpp::xep::ExplicitMention::occupant_id(occupant_id));
         assert!(groupchat_mentions_owner(
-            &message_with_mention(waddle_xmpp::xep::ExplicitMention::occupant_id(occupant_id)),
+            &parsed_mentions(&msg_by_occ),
+            &msg_by_occ,
             &owner,
             occupant_id,
         ));
 
         let mut noping = waddle_xmpp::xep::ExplicitMention::occupant_id(occupant_id);
         noping.noping = true;
+        let msg_noping = message_with_mention(noping);
         assert!(!groupchat_mentions_owner(
-            &message_with_mention(noping),
+            &parsed_mentions(&msg_noping),
+            &msg_noping,
             &owner,
             occupant_id,
         ));
 
+        let msg_other = message_with_mention(waddle_xmpp::xep::ExplicitMention::occupant_id(
+            "somebody-else",
+        ));
         assert!(!groupchat_mentions_owner(
-            &message_with_mention(waddle_xmpp::xep::ExplicitMention::occupant_id(
-                "somebody-else",
-            )),
+            &parsed_mentions(&msg_other),
+            &msg_other,
             &owner,
             occupant_id,
         ));
@@ -815,32 +911,33 @@ mod tests {
     fn xep0513_groupchat_channel_mentions_are_room_scoped_and_active_aware() {
         let room = bare("team@muc.example.com");
 
+        let msg_channel = message_with_mention(waddle_xmpp::xep::ExplicitMention::channel());
         assert_eq!(
-            groupchat_channel_mention_scope(
-                &message_with_mention(waddle_xmpp::xep::ExplicitMention::channel()),
-                &room,
-            ),
+            groupchat_channel_mention_scope(&parsed_mentions(&msg_channel), &room),
             Some(GroupchatChannelMentionScope::All)
         );
 
         let mut active = waddle_xmpp::xep::ExplicitMention::active_channel();
         active.uri = Some("xmpp:team@muc.example.com".to_string());
+        let msg_active = message_with_mention(active);
         assert_eq!(
-            groupchat_channel_mention_scope(&message_with_mention(active), &room),
+            groupchat_channel_mention_scope(&parsed_mentions(&msg_active), &room),
             Some(GroupchatChannelMentionScope::Active)
         );
 
         let mut foreign = waddle_xmpp::xep::ExplicitMention::channel();
         foreign.uri = Some("xmpp:other@muc.example.com".to_string());
+        let msg_foreign = message_with_mention(foreign);
         assert_eq!(
-            groupchat_channel_mention_scope(&message_with_mention(foreign), &room),
+            groupchat_channel_mention_scope(&parsed_mentions(&msg_foreign), &room),
             None
         );
 
         let mut noping = waddle_xmpp::xep::ExplicitMention::channel();
         noping.noping = true;
+        let msg_noping = message_with_mention(noping);
         assert_eq!(
-            groupchat_channel_mention_scope(&message_with_mention(noping), &room),
+            groupchat_channel_mention_scope(&parsed_mentions(&msg_noping), &room),
             None
         );
     }

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
@@ -284,7 +284,7 @@ async fn insert_groupchat_notification_candidate(
             return GroupchatNotificationCandidateQueueOutcome::Completed;
         }
     };
-    // T0 XEP-0492 push-dispatch gate — compliance: suppressed
+    // T0 push-gate evaluation — compliance: suppressed
     // outcomes leave no row in `notification_candidates`. The same
     // typed evaluator runs again at T1 inside
     // `drain_pending_candidates_into_outbox` as a race-window guard.
@@ -313,7 +313,7 @@ async fn insert_groupchat_notification_candidate(
     let dnd_reader = crate::notification_outbox::NoopDndReader;
     let mut dnd_cache =
         std::collections::BTreeMap::<BareJid, crate::notification_outbox::DndState>::new();
-    let outcome = match crate::notification_outbox::evaluate_xep0492_at_dispatch(
+    let outcome = match crate::notification_outbox::evaluate_push_gate_at_dispatch(
         crate::notification_outbox::PushEvalStage::T0Emit,
         state
             .deps
@@ -333,8 +333,8 @@ async fn insert_groupchat_notification_candidate(
             warn!(
                 recipient = %owner,
                 room = %room,
-                error = %error,
-                "ProjectGroupchatInbox: XEP-0492 notification setting lookup failed at T0; deferring candidate"
+                error = ?error,
+                "ProjectGroupchatInbox: push gate evaluation failed at T0; deferring groupchat candidate"
             );
             return GroupchatNotificationCandidateQueueOutcome::RetryLater;
         }

--- a/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
@@ -352,6 +352,7 @@ async fn enqueue_xep0357_notification_candidate_for_message(
     let mut dnd_cache =
         std::collections::BTreeMap::<BareJid, crate::notification_outbox::DndState>::new();
     let outcome = match crate::notification_outbox::evaluate_xep0492_at_dispatch(
+        crate::notification_outbox::PushEvalStage::T0Emit,
         state
             .deps
             .protocol

--- a/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
@@ -291,11 +291,27 @@ async fn enqueue_xep0357_notification_candidate_for_message(
     // at the typed constructor boundary alongside the existing
     // full-sender-JID and archive-id owner checks.
     let is_mention = message_is_mention_for_recipient(original_message, recipient);
-    let candidate = match crate::notification_outbox::NotificationCandidate::direct_message(
+    let hints = crate::notification_outbox::NotificationMessageHints::none()
+        .with_noping(message_carries_recipient_noping(
+            original_message,
+            recipient,
+        ))
+        .with_xep0334(
+            waddle_xmpp::xep::xep0334::has_hint(
+                original_message,
+                waddle_xmpp::xep::xep0334::Hint::NoStore,
+            ),
+            waddle_xmpp::xep::xep0334::has_hint(
+                original_message,
+                waddle_xmpp::xep::xep0334::Hint::NoPermanentStore,
+            ),
+        );
+    let candidate = match crate::notification_outbox::NotificationCandidate::direct_message_with_hints(
         recipient.clone(),
         sender_jid.clone(),
         archive_stanza_id.clone(),
         is_mention,
+        hints,
     ) {
         Ok(candidate) => candidate,
         Err(
@@ -332,6 +348,9 @@ async fn enqueue_xep0357_notification_candidate_for_message(
         BareJid,
         crate::notification_outbox::RoomPolicyCacheEntry,
     >::new();
+    let dnd_reader = crate::notification_outbox::NoopDndReader;
+    let mut dnd_cache =
+        std::collections::BTreeMap::<BareJid, crate::notification_outbox::DndState>::new();
     let outcome = match crate::notification_outbox::evaluate_xep0492_at_dispatch(
         state
             .deps
@@ -339,8 +358,10 @@ async fn enqueue_xep0357_notification_candidate_for_message(
             .notification_settings_projection
             .as_ref(),
         &room_policy,
+        &dnd_reader,
         &candidate,
         &mut room_policy_cache,
+        &mut dnd_cache,
     )
     .await
     {
@@ -363,8 +384,9 @@ async fn enqueue_xep0357_notification_candidate_for_message(
                 sender = %sender,
                 is_mention,
                 %reason,
-                "XEP-0492 push gate suppressed XEP-0357 DM candidate at T0; no candidate row persisted"
+                "T0 push gate suppressed XEP-0357 DM candidate; no candidate row persisted"
             );
+            waddle_xmpp::prometheus::increment_push_suppressed(reason.as_db_value());
             return NotificationCandidateQueueOutcome::Completed;
         }
         crate::notification_outbox::T1PushDispatchOutcome::DeferUnknownRoomPolicy => {
@@ -428,6 +450,24 @@ async fn enqueue_xep0357_notification_candidate_for_message(
 fn message_is_mention_for_recipient(message: &Message, recipient: &BareJid) -> bool {
     waddle_xmpp::xep::extract_explicit_mentions(message)
         .is_some_and(|mentions| mentions.mentions_jid(recipient))
+}
+
+/// Returns `true` when the inbound XEP-0513 explicit mention naming
+/// `recipient` also carries the `<noping/>` child element — the sender
+/// explicitly opted the recipient out of being pinged for this mention.
+///
+/// Message-frozen at T0 onto the candidate row; the T1 evaluator reads
+/// it back and suppresses with `SuppressedReason::Xep0513Noping`.
+fn message_carries_recipient_noping(message: &Message, recipient: &BareJid) -> bool {
+    waddle_xmpp::xep::extract_explicit_mentions(message).is_some_and(|mentions| {
+        mentions.mentions.iter().any(|mention| {
+            mention.noping
+                && mention
+                    .jid
+                    .as_ref()
+                    .is_some_and(|mentioned| mentioned == recipient)
+        })
+    })
 }
 
 async fn mark_pending_notification_outboxed(

--- a/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
@@ -336,7 +336,7 @@ async fn enqueue_xep0357_notification_candidate_for_message(
             return NotificationCandidateQueueOutcome::Completed;
         }
     };
-    // T0 XEP-0492 push-dispatch gate — compliance: suppressed
+    // T0 push-gate evaluation — compliance: suppressed
     // outcomes leave no row in `notification_candidates`. The same
     // typed evaluator runs again at T1 inside
     // `drain_pending_candidates_into_outbox` as a race-window guard.
@@ -351,7 +351,7 @@ async fn enqueue_xep0357_notification_candidate_for_message(
     let dnd_reader = crate::notification_outbox::NoopDndReader;
     let mut dnd_cache =
         std::collections::BTreeMap::<BareJid, crate::notification_outbox::DndState>::new();
-    let outcome = match crate::notification_outbox::evaluate_xep0492_at_dispatch(
+    let outcome = match crate::notification_outbox::evaluate_push_gate_at_dispatch(
         crate::notification_outbox::PushEvalStage::T0Emit,
         state
             .deps
@@ -371,8 +371,8 @@ async fn enqueue_xep0357_notification_candidate_for_message(
             warn!(
                 recipient = %recipient,
                 sender = %sender,
-                error = %error,
-                "XEP-0492 notification setting lookup failed at T0; deferring DM candidate"
+                error = ?error,
+                "push gate evaluation failed at T0; deferring offline-delivery DM candidate"
             );
             return NotificationCandidateQueueOutcome::RetryLater;
         }

--- a/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
@@ -290,12 +290,17 @@ async fn enqueue_xep0357_notification_candidate_for_message(
     // input validation, not recipient-state suppression, so it lives
     // at the typed constructor boundary alongside the existing
     // full-sender-JID and archive-id owner checks.
-    let is_mention = message_is_mention_for_recipient(original_message, recipient);
+    // Parse explicit mentions ONCE per message and derive both the
+    // mention bit and the `<noping/>` bit from the same parsed
+    // structure. The previous shape re-ran `extract_explicit_mentions`
+    // twice per recipient (one for `is_mention`, one for noping); for
+    // DM the recipient count is 1, but the same pattern is fanned out
+    // N× in groupchat so the unified helper keeps both surfaces
+    // consistent and avoids redundant XML traversals on the hot path.
+    let RecipientMentionBits { is_mention, noping } =
+        mention_bits_for_recipient(original_message, recipient);
     let hints = crate::notification_outbox::NotificationMessageHints::none()
-        .with_noping(message_carries_recipient_noping(
-            original_message,
-            recipient,
-        ))
+        .with_noping(noping)
         .with_xep0334(
             waddle_xmpp::xep::xep0334::has_hint(
                 original_message,
@@ -438,37 +443,54 @@ async fn enqueue_xep0357_notification_candidate_for_message(
     }
 }
 
-/// Returns `true` when the inbound XEP-0513 explicit-mention payloads
-/// name `recipient` as a mentioned `<mention jid='…'/>`.
+/// Typed pair of message-frozen XEP-0513 mention signals for a single
+/// recipient, derived from one `extract_explicit_mentions` parse.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct RecipientMentionBits {
+    /// `true` when any `<mention jid='…'/>` names `recipient`,
+    /// regardless of `<noping/>`. Matches the pre-dedup
+    /// `ExplicitMentions::mentions_jid` predicate exactly — a `<noping/>`
+    /// mention still counts as a mention for class derivation; the T1
+    /// evaluator handles the `<noping/>` suppression independently via
+    /// the [`Self::noping`] bit.
+    is_mention: bool,
+    /// `true` when any `<mention jid='…'/>` naming `recipient` also
+    /// carries `<noping/>`. Message-frozen at T0 onto the candidate row;
+    /// the T1 evaluator reads it back and suppresses with
+    /// `SuppressedReason::Xep0513Noping`.
+    noping: bool,
+}
+
+/// Single-pass derivation of `(is_mention, noping)` for a DM
+/// recipient.
 ///
 /// The recipient JID is the bare JID that owns the offline queue; that
 /// is the canonical identity referenced by `<mention jid='…'/>` per
-/// XEP-0513 §3. Channel-wide `<mention mentions='urn:xmpp:mentions:0#channel'/>`
-/// is intentionally NOT treated as an individual mention here — the
-/// XEP-0492 `<on-mention/>` semantics target explicit user mentions; the
-/// channel-mention surface is for MUC reflector announcements, which do
-/// not flow through the DM `QueueOfflineDelivery` arm.
-fn message_is_mention_for_recipient(message: &Message, recipient: &BareJid) -> bool {
-    waddle_xmpp::xep::extract_explicit_mentions(message)
-        .is_some_and(|mentions| mentions.mentions_jid(recipient))
-}
-
-/// Returns `true` when the inbound XEP-0513 explicit mention naming
-/// `recipient` also carries the `<noping/>` child element — the sender
-/// explicitly opted the recipient out of being pinged for this mention.
-///
-/// Message-frozen at T0 onto the candidate row; the T1 evaluator reads
-/// it back and suppresses with `SuppressedReason::Xep0513Noping`.
-fn message_carries_recipient_noping(message: &Message, recipient: &BareJid) -> bool {
-    waddle_xmpp::xep::extract_explicit_mentions(message).is_some_and(|mentions| {
-        mentions.mentions.iter().any(|mention| {
-            mention.noping
-                && mention
-                    .jid
-                    .as_ref()
-                    .is_some_and(|mentioned| mentioned == recipient)
-        })
-    })
+/// XEP-0513 §3. Channel-wide
+/// `<mention mentions='urn:xmpp:mentions:0#channel'/>` is intentionally
+/// NOT treated as an individual mention here — the XEP-0492
+/// `<on-mention/>` semantics target explicit user mentions; the
+/// channel-mention surface is for MUC reflector announcements, which
+/// do not flow through the DM `QueueOfflineDelivery` arm.
+fn mention_bits_for_recipient(message: &Message, recipient: &BareJid) -> RecipientMentionBits {
+    let Some(mentions) = waddle_xmpp::xep::extract_explicit_mentions(message) else {
+        return RecipientMentionBits::default();
+    };
+    let mut bits = RecipientMentionBits::default();
+    for mention in &mentions.mentions {
+        let names_recipient = mention
+            .jid
+            .as_ref()
+            .is_some_and(|mentioned| mentioned == recipient);
+        if !names_recipient {
+            continue;
+        }
+        bits.is_mention = true;
+        if mention.noping {
+            bits.noping = true;
+        }
+    }
+    bits
 }
 
 async fn mark_pending_notification_outboxed(
@@ -521,4 +543,71 @@ pub(crate) async fn reconcile_xep0357_notification_candidates(
         }
     }
     completed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bare(value: &str) -> BareJid {
+        value.parse().expect("valid bare JID")
+    }
+
+    fn message_with_mention(mention: waddle_xmpp::xep::ExplicitMention) -> Message {
+        let mut message = Message::new(None::<Jid>);
+        message
+            .payloads
+            .push(waddle_xmpp::xep::build_mention_element(&mention));
+        message
+    }
+
+    /// Dedup regression: `mention_bits_for_recipient` MUST derive
+    /// both `is_mention` and `noping` from a single
+    /// `extract_explicit_mentions` parse, and behavior MUST match the
+    /// pre-dedup two-helper shape (mention bit set whenever a JID
+    /// matches, noping bit set independently when `<noping/>` is
+    /// present on the matching mention).
+    #[test]
+    fn dm_mention_bits_single_parse_matches_pre_dedup_behavior() {
+        let recipient = bare("alice@example.com");
+
+        // No mentions → both bits unset.
+        let no_mention = Message::new(None::<Jid>);
+        assert_eq!(
+            mention_bits_for_recipient(&no_mention, &recipient),
+            RecipientMentionBits::default(),
+        );
+
+        // Plain mention naming the recipient → mention set, noping unset.
+        let plain = message_with_mention(waddle_xmpp::xep::ExplicitMention::jid(recipient.clone()));
+        assert_eq!(
+            mention_bits_for_recipient(&plain, &recipient),
+            RecipientMentionBits {
+                is_mention: true,
+                noping: false,
+            },
+        );
+
+        // `<noping/>` mention naming the recipient → BOTH bits set;
+        // matches the original `ExplicitMentions::mentions_jid`
+        // semantics (which ignored `<noping/>` when deriving `is_mention`).
+        let mut noping = waddle_xmpp::xep::ExplicitMention::jid(recipient.clone());
+        noping.noping = true;
+        let msg_noping = message_with_mention(noping);
+        assert_eq!(
+            mention_bits_for_recipient(&msg_noping, &recipient),
+            RecipientMentionBits {
+                is_mention: true,
+                noping: true,
+            },
+        );
+
+        // Mention naming someone else → both bits unset.
+        let other = bare("bob@example.com");
+        let foreign = message_with_mention(waddle_xmpp::xep::ExplicitMention::jid(other));
+        assert_eq!(
+            mention_bits_for_recipient(&foreign, &recipient),
+            RecipientMentionBits::default(),
+        );
+    }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
@@ -68,6 +68,8 @@ async fn drain_notification_candidates_for_test(state: &WebSocketState) -> usize
         .expect("push service jid");
     let room_policy =
         crate::room_policy::RoomRegistryActorPolicy::new(state.deps.protocol.room_registry.clone());
+    let dnd_reader = crate::notification_outbox::NoopDndReader;
+    let deps = crate::notification_outbox::NotificationDrainDeps::new(&room_policy, &dnd_reader);
     state
         .deps
         .protocol
@@ -80,7 +82,7 @@ async fn drain_notification_candidates_for_test(state: &WebSocketState) -> usize
                 .protocol
                 .notification_settings_projection
                 .as_ref(),
-            &room_policy,
+            deps,
             &push_service_jid,
             16,
         )

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
@@ -1897,6 +1897,226 @@ async fn queue_offline_delivery_suppresses_xep0357_when_xep0492_direct_chat_is_n
     assert!(outbox_jobs.is_empty());
 }
 
+/// Wire-level regression for slice 2a's storage-preservation contract:
+/// when push is suppressed by XEP-0492 `<never/>` at T0, the upstream
+/// artifacts that hold the message MUST remain intact — XEP-0313 MAM
+/// archive row, XEP-0430 inbox projection, and XEP-0160 pending
+/// delivery queue entry. The notification outbox layer touches only
+/// `notification_candidates` / `notification_outbox`; this test pins
+/// the contract end-to-end through `interpret(QueueOfflineDelivery)`
+/// so a future refactor that bundles upstream + push writes into one
+/// transaction (and accidentally rolls back the MAM row on push
+/// suppression) is caught immediately.
+///
+/// Per the brief: this single comprehensive ws-integration test
+/// stands in for individual per-XEP smoke tests across the
+/// `xep0313_mam_integration`, `xep0430_inbox_ws`, and
+/// `xep0160_offline_message_handling` files. Those live in three
+/// different crates / fixture styles; one wire-level shot is the
+/// economical place to assert the joint invariant. Per-XEP unit
+/// coverage of the audit + suppression decisions lives in
+/// `notification_outbox::tests` (slice 2a storage-preservation
+/// suite).
+#[tokio::test]
+async fn xep0357_suppression_preserves_mam_inbox_pending_delivery_and_audit() {
+    let state = create_test_websocket_state().await;
+    let recipient: BareJid = "bob@example.com".parse().expect("recipient");
+    let sender: BareJid = "alice@example.com".parse().expect("sender");
+    register_first_party_push_for_test(state.as_ref(), &recipient, "web-1").await;
+
+    // Recipient muted this DM conversation — XEP-0492 `<never/>` is a
+    // T0 compliance suppressor.
+    state
+        .deps
+        .protocol
+        .notification_settings_projection
+        .upsert(&crate::notification_settings_projection::NotificationSettingsProjection {
+            owner_bare_jid: recipient.clone(),
+            conversation_jid: sender.clone(),
+            conversation_kind: crate::notification_settings_projection::ConversationKind::Direct,
+            mode: waddle_xmpp::xep::NotificationLevel::Never,
+            source_version: 1,
+            updated_at_ms: crate::time::now_ms(),
+            source: crate::notification_settings_projection::NotificationSettingsSource::Xep0402Bookmarks,
+            source_item_jid: sender.clone(),
+        })
+        .await
+        .expect("xep-0492 projection");
+
+    // Build the inbound DM exactly the same way the offline path sees
+    // it: full sender JID, body, deterministic id.
+    let mut message =
+        xmpp_parsers::message::Message::new(Some("bob@example.com".parse().expect("to jid")));
+    message.from = Some("alice@example.com/web".parse().expect("from jid"));
+    message.id = Some("storage-preserve-1".to_string());
+    message.type_ = XmppMessageType::Chat;
+    message.bodies.insert(
+        String::new(),
+        xmpp_parsers::message::Body("must-not-rollback".to_string()),
+    );
+    let archive_stanza_id = waddle_xmpp_core::xep0359::StanzaId::new(
+        "archive-storage-preserve-1",
+        jid::Jid::from(recipient.clone()),
+    );
+
+    // Seed XEP-0313 MAM row, XEP-0430 inbox projection, and XEP-0160
+    // pending_delivery row BEFORE the offline-delivery interpret pass.
+    // These represent every upstream artifact the candidate-emission
+    // code path must NOT roll back.
+    store_committed_dm_archive_for_notification(&state, &recipient, &archive_stanza_id, &message)
+        .await;
+    project_direct_unread_for_notification(
+        state.as_ref(),
+        &recipient,
+        &sender,
+        "archive-storage-preserve-1",
+    )
+    .await;
+    state
+        .deps
+        .protocol
+        .pending_delivery_storage
+        .insert(waddle_xmpp::pending_delivery::PendingRow {
+            id: waddle_xmpp::pending_delivery::PendingRowId::fresh(),
+            recipient: recipient.clone(),
+            original_receipt_at: chrono::Utc::now(),
+            payload: waddle_xmpp::pending_delivery::PendingPayload::Archived(
+                archive_stanza_id.clone(),
+            ),
+            flushed_in_session: None,
+            outbound_sequence: None,
+        })
+        .await
+        .expect("seed pending_delivery row");
+
+    // Snapshot upstream state for the post-emission diff.
+    let mam_before = state
+        .deps
+        .protocol
+        .mam_storage
+        .get_message_by_stanza_id(&recipient, &archive_stanza_id.id)
+        .await
+        .expect("mam lookup before");
+    assert!(
+        mam_before.is_some(),
+        "seed MAM row must be queryable before emission",
+    );
+    let pending_before = state
+        .deps
+        .protocol
+        .pending_delivery_storage
+        .list(&recipient)
+        .await
+        .expect("pending list before");
+    assert_eq!(
+        pending_before.len(),
+        1,
+        "seed pending_delivery row must be present before emission",
+    );
+    let inbox_before = state
+        .deps
+        .protocol
+        .inbox_storage
+        .list(&recipient)
+        .await
+        .expect("inbox list before");
+    assert_eq!(
+        inbox_before.len(),
+        1,
+        "seed inbox row must be present before emission",
+    );
+
+    // Drive the T0 emission path through the interpret loop just like
+    // the live DM handler does.
+    let deps = build_interpret_deps(state.as_ref(), None);
+    crate::server::routes::interpret::interpret(
+        vec![waddle_xmpp::protocol::OutboundEvent::QueueOfflineDelivery {
+            recipient: recipient.clone(),
+            payload: waddle_xmpp::pending_delivery::PendingPayload::Archived(
+                archive_stanza_id.clone(),
+            ),
+            original_receipt_at: chrono::Utc::now(),
+            original_message: Box::new(message),
+        }],
+        &deps,
+    )
+    .await;
+
+    // Push surface: no candidate row, no outbox job, no provider
+    // delivery attempt.
+    let candidate_count = state
+        .deps
+        .protocol
+        .notification_outbox
+        .count_all_candidates()
+        .await
+        .expect("count candidates");
+    assert_eq!(
+        candidate_count, 0,
+        "T0 <never/> suppression MUST NOT persist a candidate row",
+    );
+    let outbox_jobs = state
+        .deps
+        .protocol
+        .notification_outbox
+        .pending_outbox_jobs()
+        .await
+        .expect("pending outbox jobs");
+    assert!(
+        outbox_jobs.is_empty(),
+        "T0 <never/> suppression MUST NOT enqueue an outbox job",
+    );
+
+    // Upstream invariants: MAM row, inbox entry, pending_delivery row
+    // are all byte-identical to the pre-emission snapshot.
+    let mam_after = state
+        .deps
+        .protocol
+        .mam_storage
+        .get_message_by_stanza_id(&recipient, &archive_stanza_id.id)
+        .await
+        .expect("mam lookup after");
+    assert!(
+        mam_after.is_some(),
+        "XEP-0313 MAM row MUST survive push suppression",
+    );
+    assert_eq!(
+        mam_before.as_ref().map(|m| &m.id),
+        mam_after.as_ref().map(|m| &m.id),
+        "MAM archive id MUST be unchanged across push suppression",
+    );
+
+    let pending_after = state
+        .deps
+        .protocol
+        .pending_delivery_storage
+        .list(&recipient)
+        .await
+        .expect("pending list after");
+    let seed_id = pending_before[0].id.as_str();
+    assert!(
+        pending_after.iter().any(|row| row.id.as_str() == seed_id),
+        "XEP-0160 pending_delivery row seeded before emission MUST survive push suppression; \
+         after={pending_after:?}",
+    );
+
+    let inbox_after = state
+        .deps
+        .protocol
+        .inbox_storage
+        .list(&recipient)
+        .await
+        .expect("inbox list after");
+    let seed_partner = &inbox_before[0].partner;
+    assert!(
+        inbox_after
+            .iter()
+            .any(|entry| &entry.partner == seed_partner),
+        "XEP-0430 inbox entry for the seeded partner MUST survive push suppression; \
+         after={inbox_after:?}",
+    );
+}
+
 #[tokio::test]
 async fn queue_offline_delivery_suppresses_xep0357_for_transient_no_permanent_store_payloads() {
     let state = create_test_websocket_state().await;

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -488,6 +488,15 @@ pub(crate) fn spawn_notification_outbox_janitor(websocket_state: &Arc<WebSocketS
         .unwrap_or(128);
     let retention_days = notification_outbox_retention_days_from_env();
     let prune_batch_size = notification_outbox_prune_batch_from_env();
+    // Operability: slice 2a ships with `NoopDndReader` wired everywhere.
+    // The `waddle_push_suppressed_total{reason="waddle_dnd"}` counter
+    // will therefore stay at 0 until #367 lands the real
+    // `urn:waddle:dnd:0` adapter. Surface this loudly at janitor start
+    // so operators don't mistake a flat metric for "no users in DND".
+    warn!(
+        "Notification outbox janitor: DND suppression is wired through NoopDndReader \
+         (waddle_push_suppressed_total{{reason=\"waddle_dnd\"}} will remain 0 until #367 lands)"
+    );
     tokio::spawn(async move {
         let mut ticker = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
         ticker.tick().await;

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -532,6 +532,9 @@ pub(crate) fn spawn_notification_outbox_janitor(websocket_state: &Arc<WebSocketS
             }
             let room_policy =
                 RoomRegistryActorPolicy::new(state.deps.protocol.room_registry.clone());
+            let dnd_reader = crate::notification_outbox::NoopDndReader;
+            let deps =
+                crate::notification_outbox::NotificationDrainDeps::new(&room_policy, &dnd_reader);
             match state
                 .deps
                 .protocol
@@ -544,7 +547,7 @@ pub(crate) fn spawn_notification_outbox_janitor(websocket_state: &Arc<WebSocketS
                         .protocol
                         .notification_settings_projection
                         .as_ref(),
-                    &room_policy,
+                    deps,
                     &first_party_service_jid,
                     batch_size,
                 )

--- a/server/crates/waddle-xmpp/src/prometheus.rs
+++ b/server/crates/waddle-xmpp/src/prometheus.rs
@@ -4,8 +4,7 @@
 //! operational health dashboards and exposes them in Prometheus text format.
 
 use std::sync::atomic::{AtomicU64, Ordering};
-#[cfg(test)]
-use std::sync::{Mutex, OnceLock};
+use std::sync::OnceLock;
 
 static CONNECTED_USERS: AtomicU64 = AtomicU64::new(0);
 static ROOM_COUNT: AtomicU64 = AtomicU64::new(0);
@@ -79,11 +78,40 @@ static SM_DRAIN_TIMEOUT: AtomicU64 = AtomicU64::new(0);
 // tight for the client population.
 static SM_RESUME_WINDOW_CLAMPED: AtomicU64 = AtomicU64::new(0);
 
+// `waddle_push_suppressed_total{reason="..."}` — incremented every
+// time a XEP-0357 push candidate is suppressed at either T0 emission
+// or the T1 drain. Labeled by the typed `SuppressedReason` enum;
+// because the enum is a closed set, the storage shape is a fixed
+// `&'static str → AtomicU64` map populated lazily on first sample
+// per reason so deployments observe per-rule suppression rates
+// without a labels-cardinality blowup.
+//
+// Reason strings MUST stay in lockstep with
+// `SuppressedReason::as_db_value` in
+// `waddle_server::notification_outbox`; the helper accepts only the
+// closed-set values populated by that enum.
+static PUSH_SUPPRESSED_COUNTERS: OnceLock<
+    std::sync::Mutex<std::collections::BTreeMap<&'static str, AtomicU64>>,
+> = OnceLock::new();
+
+fn push_suppressed_counters(
+) -> &'static std::sync::Mutex<std::collections::BTreeMap<&'static str, AtomicU64>> {
+    PUSH_SUPPRESSED_COUNTERS
+        .get_or_init(|| std::sync::Mutex::new(std::collections::BTreeMap::new()))
+}
+
 /// Serializes unit tests that mutate process-global metrics.
-#[cfg(test)]
-pub(crate) fn metrics_test_lock() -> &'static Mutex<()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
+///
+/// Re-exported under `cfg(any(test, feature = "test-utils"))` so the
+/// `waddle-server` test suite (which exercises the labeled
+/// push-suppressed counter) can serialize against the same lock the
+/// in-crate tests use. Backed by an async-aware mutex so async tests
+/// can hold the lock across `.await` without tripping clippy's
+/// `await_holding_lock`.
+#[cfg(any(test, feature = "test-utils"))]
+pub fn metrics_test_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
 }
 
 fn unix_timestamp_secs() -> u64 {
@@ -195,6 +223,43 @@ pub fn increment_sm_resume_window_clamped() {
     SM_RESUME_WINDOW_CLAMPED.fetch_add(1, Ordering::Relaxed);
 }
 
+/// Increment the `waddle_push_suppressed_total{reason}` counter.
+///
+/// `reason` MUST be a static string from the closed
+/// `SuppressedReason::as_db_value` set in
+/// `waddle_server::notification_outbox`. The bound between caller and
+/// metric label is `&'static str` so the labels-cardinality cannot
+/// grow at runtime — any other call site would fail to compile.
+pub fn increment_push_suppressed(reason: &'static str) {
+    let counters = push_suppressed_counters();
+    let map = counters.lock().expect("push suppressed counters mutex");
+    if let Some(counter) = map.get(reason) {
+        counter.fetch_add(1, Ordering::Relaxed);
+        return;
+    }
+    drop(map);
+    let mut map = counters.lock().expect("push suppressed counters mutex");
+    map.entry(reason)
+        .or_insert_with(|| AtomicU64::new(0))
+        .fetch_add(1, Ordering::Relaxed);
+}
+
+/// Snapshot of every push-suppressed counter for rendering.
+fn render_push_suppressed_lines(out: &mut String) {
+    out.push_str("# HELP waddle_push_suppressed_total XEP-0357 push notification candidates suppressed by a XEP/Waddle rule. Labeled by the typed `SuppressedReason` enum.\n");
+    out.push_str("# TYPE waddle_push_suppressed_total counter\n");
+    let counters = push_suppressed_counters();
+    let map = counters.lock().expect("push suppressed counters mutex");
+    for (reason, counter) in map.iter() {
+        let value = counter.load(Ordering::Relaxed);
+        out.push_str("waddle_push_suppressed_total{reason=\"");
+        out.push_str(reason);
+        out.push_str("\"} ");
+        out.push_str(&value.to_string());
+        out.push('\n');
+    }
+}
+
 #[cfg(any(test, feature = "test-utils"))]
 pub fn reset_metrics_for_test() {
     CONNECTED_USERS.store(0, Ordering::Release);
@@ -218,6 +283,11 @@ pub fn reset_metrics_for_test() {
     SM_PROMOTION_DEAD_LETTERED.store(0, Ordering::Release);
     SM_DRAIN_TIMEOUT.store(0, Ordering::Release);
     SM_RESUME_WINDOW_CLAMPED.store(0, Ordering::Release);
+    let counters = push_suppressed_counters();
+    let map = counters.lock().expect("push suppressed counters mutex");
+    for counter in map.values() {
+        counter.store(0, Ordering::Release);
+    }
 }
 
 pub fn render_metrics() -> String {
@@ -303,6 +373,7 @@ pub fn render_metrics() -> String {
             "# HELP waddle_sm_resume_window_clamped_total Client-requested XEP-0198 resume window exceeded WADDLE_SM_MAX_RESUME_SECS and was silently lowered.\n",
             "# TYPE waddle_sm_resume_window_clamped_total counter\n",
             "waddle_sm_resume_window_clamped_total {sm_resume_window_clamped}\n",
+            "{push_suppressed_lines}",
         ),
         connected_users = connected_users,
         room_count = room_count,
@@ -323,6 +394,11 @@ pub fn render_metrics() -> String {
         sm_promotion_dead_lettered = sm_promotion_dead_lettered,
         sm_drain_timeout = sm_drain_timeout,
         sm_resume_window_clamped = sm_resume_window_clamped,
+        push_suppressed_lines = {
+            let mut buf = String::new();
+            render_push_suppressed_lines(&mut buf);
+            buf
+        },
     )
 }
 
@@ -330,9 +406,9 @@ pub fn render_metrics() -> String {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_decrement_saturates_at_zero() {
-        let _guard = metrics_test_lock().lock().unwrap();
+    #[tokio::test]
+    async fn test_decrement_saturates_at_zero() {
+        let _guard = metrics_test_lock().lock().await;
         reset_metrics_for_test();
 
         decrement_connected_users();
@@ -342,9 +418,9 @@ mod tests {
         assert_eq!(ROOM_COUNT.load(Ordering::Acquire), 0);
     }
 
-    #[test]
-    fn test_increment_and_decrement_round_trip() {
-        let _guard = metrics_test_lock().lock().unwrap();
+    #[tokio::test]
+    async fn test_increment_and_decrement_round_trip() {
+        let _guard = metrics_test_lock().lock().await;
         reset_metrics_for_test();
 
         increment_connected_users();
@@ -358,9 +434,9 @@ mod tests {
         assert_eq!(ROOM_COUNT.load(Ordering::Acquire), 0);
     }
 
-    #[test]
-    fn test_rotate_second_bucket_moves_current_to_last() {
-        let _guard = metrics_test_lock().lock().unwrap();
+    #[tokio::test]
+    async fn test_rotate_second_bucket_moves_current_to_last() {
+        let _guard = metrics_test_lock().lock().await;
         reset_metrics_for_test();
 
         CURRENT_SECOND.store(100, Ordering::Release);
@@ -373,9 +449,9 @@ mod tests {
         assert_eq!(LAST_SECOND_MESSAGES.load(Ordering::Acquire), 7);
     }
 
-    #[test]
-    fn test_render_metrics_contains_expected_families() {
-        let _guard = metrics_test_lock().lock().unwrap();
+    #[tokio::test]
+    async fn test_render_metrics_contains_expected_families() {
+        let _guard = metrics_test_lock().lock().await;
         reset_metrics_for_test();
 
         increment_connected_users();
@@ -397,9 +473,9 @@ mod tests {
         assert!(rendered.contains("waddle_messages_total 1"));
     }
 
-    #[test]
-    fn test_broadcast_counters_increment_and_render() {
-        let _guard = metrics_test_lock().lock().unwrap();
+    #[tokio::test]
+    async fn test_broadcast_counters_increment_and_render() {
+        let _guard = metrics_test_lock().lock().await;
         reset_metrics_for_test();
 
         increment_broadcast_delivered();
@@ -423,9 +499,9 @@ mod tests {
     /// offline-DM / SM-expiry surface MUST appear in the rendered
     /// output with HELP+TYPE headers. Without these headers, a
     /// scraper accepts the line but dashboards lose the metric type.
-    #[test]
-    fn test_issue_209_finding_11_metric_families_render() {
-        let _guard = metrics_test_lock().lock().unwrap();
+    #[tokio::test]
+    async fn test_issue_209_finding_11_metric_families_render() {
+        let _guard = metrics_test_lock().lock().await;
         reset_metrics_for_test();
 
         increment_pending_delivery_quota_exceeded();
@@ -470,9 +546,9 @@ mod tests {
         assert!(rendered.contains("waddle_sm_resume_window_clamped_total 1"));
     }
 
-    #[test]
-    fn test_reset_metrics_for_test_clears_sm_promotion_not_promotable() {
-        let _guard = metrics_test_lock().lock().unwrap();
+    #[tokio::test]
+    async fn test_reset_metrics_for_test_clears_sm_promotion_not_promotable() {
+        let _guard = metrics_test_lock().lock().await;
         reset_metrics_for_test();
 
         increment_sm_promotion_not_promotable();
@@ -482,9 +558,9 @@ mod tests {
         assert!(rendered.contains("waddle_sm_promotion_not_promotable_total 0"));
     }
 
-    #[test]
-    fn test_sm_unacked_evicted_counter_increments_and_renders() {
-        let _guard = metrics_test_lock().lock().unwrap();
+    #[tokio::test]
+    async fn test_sm_unacked_evicted_counter_increments_and_renders() {
+        let _guard = metrics_test_lock().lock().await;
         reset_metrics_for_test();
 
         increment_sm_unacked_evicted();

--- a/server/crates/waddle-xmpp/src/prometheus.rs
+++ b/server/crates/waddle-xmpp/src/prometheus.rs
@@ -4,6 +4,7 @@
 //! operational health dashboards and exposes them in Prometheus text format.
 
 use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(any(test, feature = "test-utils"))]
 use std::sync::OnceLock;
 
 static CONNECTED_USERS: AtomicU64 = AtomicU64::new(0);
@@ -80,24 +81,89 @@ static SM_RESUME_WINDOW_CLAMPED: AtomicU64 = AtomicU64::new(0);
 
 // `waddle_push_suppressed_total{reason="..."}` — incremented every
 // time a XEP-0357 push candidate is suppressed at either T0 emission
-// or the T1 drain. Labeled by the typed `SuppressedReason` enum;
-// because the enum is a closed set, the storage shape is a fixed
-// `&'static str → AtomicU64` map populated lazily on first sample
-// per reason so deployments observe per-rule suppression rates
-// without a labels-cardinality blowup.
+// or the T1 drain. Labeled by the typed `SuppressedReason` enum.
 //
-// Reason strings MUST stay in lockstep with
-// `SuppressedReason::as_db_value` in
-// `waddle_server::notification_outbox`; the helper accepts only the
-// closed-set values populated by that enum.
-static PUSH_SUPPRESSED_COUNTERS: OnceLock<
-    std::sync::Mutex<std::collections::BTreeMap<&'static str, AtomicU64>>,
-> = OnceLock::new();
+// **Wire contract**: [`PUSH_SUPPRESSED_REASONS`] is the source-of-truth
+// parallel constant of every label string the caller is allowed to
+// pass. It MUST stay in lockstep with `SuppressedReason::as_db_value`
+// in `waddle_server::notification_outbox` (i.e. every entry in
+// `SuppressedReason::ALL.iter().map(as_db_value)` MUST appear here,
+// in declaration order). The `waddle-server` test suite enforces this
+// invariant — `waddle-xmpp` is upstream and cannot import the enum.
+//
+// Storage is a fixed `[AtomicU64; N]` array indexed by the position
+// of the reason string in `PUSH_SUPPRESSED_REASONS`. No mutex, no
+// allocations, no cardinality growth at runtime. An unknown label
+// (contract drift) increments `PUSH_SUPPRESSED_UNKNOWN_REASON` and
+// emits a `warn!` so the failure is observable.
+pub(crate) const PUSH_SUPPRESSED_REASONS: &[&str] = &[
+    "xep0357_self",
+    "xep0357_no_registration",
+    "xep0357_registration_disabled",
+    "xep0492_never",
+    "xep0492_on_mention_miss",
+    "xep0191_blocked",
+    "xep0513_noping",
+    "xep0513_active_miss",
+    "xep0334_no_store",
+    "xep0334_no_permanent_store",
+    "waddle_dnd",
+    "provider_rejected",
+    "provider_token_expired",
+];
 
-fn push_suppressed_counters(
-) -> &'static std::sync::Mutex<std::collections::BTreeMap<&'static str, AtomicU64>> {
-    PUSH_SUPPRESSED_COUNTERS
-        .get_or_init(|| std::sync::Mutex::new(std::collections::BTreeMap::new()))
+const PUSH_SUPPRESSED_COUNTERS_LEN: usize = PUSH_SUPPRESSED_REASONS.len();
+
+static PUSH_SUPPRESSED_COUNTERS: [AtomicU64; PUSH_SUPPRESSED_COUNTERS_LEN] = {
+    // `AtomicU64` is not `Copy`, so the array initializer must spell
+    // every slot. The length is locked at compile time to
+    // `PUSH_SUPPRESSED_REASONS.len()` via a `const _: () = assert!`
+    // below, so a future reason addition that forgets a slot fails to
+    // compile.
+    [
+        AtomicU64::new(0),
+        AtomicU64::new(0),
+        AtomicU64::new(0),
+        AtomicU64::new(0),
+        AtomicU64::new(0),
+        AtomicU64::new(0),
+        AtomicU64::new(0),
+        AtomicU64::new(0),
+        AtomicU64::new(0),
+        AtomicU64::new(0),
+        AtomicU64::new(0),
+        AtomicU64::new(0),
+        AtomicU64::new(0),
+    ]
+};
+
+// Compile-time guard: a future reason addition that grows
+// `PUSH_SUPPRESSED_REASONS` MUST also grow the counter array, or
+// this assertion will fail at build time.
+const _: () = assert!(
+    PUSH_SUPPRESSED_REASONS.len() == PUSH_SUPPRESSED_COUNTERS_LEN,
+    "PUSH_SUPPRESSED_REASONS and PUSH_SUPPRESSED_COUNTERS must stay the same length"
+);
+
+// Catch-all gauge for caller/contract drift: any
+// `increment_push_suppressed` call site passing a value that is NOT
+// in `PUSH_SUPPRESSED_REASONS` increments this and emits a `warn!`.
+// A non-zero sample at scrape time means the parallel constant has
+// drifted from `SuppressedReason::as_db_value` and needs a same-PR
+// fix.
+static PUSH_SUPPRESSED_UNKNOWN_REASON: AtomicU64 = AtomicU64::new(0);
+
+/// Public read-only view of the parallel reason list. The
+/// `waddle-server` test suite uses this to assert that every
+/// `SuppressedReason::as_db_value()` appears in the wire contract.
+pub fn push_suppressed_reasons() -> &'static [&'static str] {
+    PUSH_SUPPRESSED_REASONS
+}
+
+/// Returns the index of `reason` in `PUSH_SUPPRESSED_REASONS`, or
+/// `None` if the reason is not a recognized wire-contract value.
+fn push_suppressed_index(reason: &str) -> Option<usize> {
+    PUSH_SUPPRESSED_REASONS.iter().position(|r| *r == reason)
 }
 
 /// Serializes unit tests that mutate process-global metrics.
@@ -225,39 +291,53 @@ pub fn increment_sm_resume_window_clamped() {
 
 /// Increment the `waddle_push_suppressed_total{reason}` counter.
 ///
-/// `reason` MUST be a static string from the closed
-/// `SuppressedReason::as_db_value` set in
-/// `waddle_server::notification_outbox`. The bound between caller and
-/// metric label is `&'static str` so the labels-cardinality cannot
-/// grow at runtime — any other call site would fail to compile.
+/// `reason` is a wire-contract value drawn from
+/// [`PUSH_SUPPRESSED_REASONS`], populated in lockstep with
+/// `SuppressedReason::as_db_value` over in
+/// `waddle_server::notification_outbox` (the `waddle-server` test
+/// suite enforces the bijection; `waddle-xmpp` is upstream of the
+/// enum). The bound is `&'static str` so no dynamic labels exist at
+/// runtime; cardinality is bounded by the parallel constant.
+///
+/// Lookup is a linear scan over `PUSH_SUPPRESSED_REASONS` (small N,
+/// closed set) followed by an `AtomicU64::fetch_add` on a fixed slot
+/// — no mutex, no allocation, no async-hot-path stalls. A value not
+/// present in the parallel constant is a contract-drift bug: the
+/// catch-all [`PUSH_SUPPRESSED_UNKNOWN_REASON`] counter is bumped and
+/// a `warn!` fires so the drift is observable both in metrics and in
+/// logs.
 pub fn increment_push_suppressed(reason: &'static str) {
-    let counters = push_suppressed_counters();
-    let map = counters.lock().expect("push suppressed counters mutex");
-    if let Some(counter) = map.get(reason) {
-        counter.fetch_add(1, Ordering::Relaxed);
+    if let Some(idx) = push_suppressed_index(reason) {
+        PUSH_SUPPRESSED_COUNTERS[idx].fetch_add(1, Ordering::Relaxed);
         return;
     }
-    drop(map);
-    let mut map = counters.lock().expect("push suppressed counters mutex");
-    map.entry(reason)
-        .or_insert_with(|| AtomicU64::new(0))
-        .fetch_add(1, Ordering::Relaxed);
+    PUSH_SUPPRESSED_UNKNOWN_REASON.fetch_add(1, Ordering::Relaxed);
+    tracing::warn!(
+        reason,
+        "push suppressed counter received an unknown reason; \
+         waddle_xmpp::prometheus::PUSH_SUPPRESSED_REASONS has drifted \
+         from waddle_server::notification_outbox::SuppressedReason"
+    );
 }
 
 /// Snapshot of every push-suppressed counter for rendering.
 fn render_push_suppressed_lines(out: &mut String) {
     out.push_str("# HELP waddle_push_suppressed_total XEP-0357 push notification candidates suppressed by a XEP/Waddle rule. Labeled by the typed `SuppressedReason` enum.\n");
     out.push_str("# TYPE waddle_push_suppressed_total counter\n");
-    let counters = push_suppressed_counters();
-    let map = counters.lock().expect("push suppressed counters mutex");
-    for (reason, counter) in map.iter() {
-        let value = counter.load(Ordering::Relaxed);
+    for (idx, reason) in PUSH_SUPPRESSED_REASONS.iter().enumerate() {
+        let value = PUSH_SUPPRESSED_COUNTERS[idx].load(Ordering::Relaxed);
         out.push_str("waddle_push_suppressed_total{reason=\"");
         out.push_str(reason);
         out.push_str("\"} ");
         out.push_str(&value.to_string());
         out.push('\n');
     }
+    let unknown = PUSH_SUPPRESSED_UNKNOWN_REASON.load(Ordering::Relaxed);
+    out.push_str("# HELP waddle_push_suppressed_unknown_reason_total Push suppression events that arrived with a reason string not present in the parallel `PUSH_SUPPRESSED_REASONS` wire-contract constant. A non-zero sample indicates the constant has drifted from `SuppressedReason::as_db_value`.\n");
+    out.push_str("# TYPE waddle_push_suppressed_unknown_reason_total counter\n");
+    out.push_str("waddle_push_suppressed_unknown_reason_total ");
+    out.push_str(&unknown.to_string());
+    out.push('\n');
 }
 
 #[cfg(any(test, feature = "test-utils"))]
@@ -283,11 +363,10 @@ pub fn reset_metrics_for_test() {
     SM_PROMOTION_DEAD_LETTERED.store(0, Ordering::Release);
     SM_DRAIN_TIMEOUT.store(0, Ordering::Release);
     SM_RESUME_WINDOW_CLAMPED.store(0, Ordering::Release);
-    let counters = push_suppressed_counters();
-    let map = counters.lock().expect("push suppressed counters mutex");
-    for counter in map.values() {
+    for counter in PUSH_SUPPRESSED_COUNTERS.iter() {
         counter.store(0, Ordering::Release);
     }
+    PUSH_SUPPRESSED_UNKNOWN_REASON.store(0, Ordering::Release);
 }
 
 pub fn render_metrics() -> String {

--- a/server/crates/waddle-xmpp/src/stream_management/state.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/state.rs
@@ -384,7 +384,7 @@ mod tests {
         // <resumed/> replays have holes".
         use crate::prometheus;
 
-        let _metrics_guard = prometheus::metrics_test_lock().lock().unwrap();
+        let _metrics_guard = prometheus::metrics_test_lock().blocking_lock();
 
         // Baseline the counter since other tests run in the same process.
         let before_render = prometheus::render_metrics();
@@ -430,7 +430,7 @@ mod tests {
 
     #[test]
     fn test_evicted_unacked_stanza_blocks_resume_until_client_h_covers_gap() {
-        let _metrics_guard = crate::prometheus::metrics_test_lock().lock().unwrap();
+        let _metrics_guard = crate::prometheus::metrics_test_lock().blocking_lock();
 
         let mut state = StreamManagementState::with_config(3, 5);
         state.enable("tiny-cap".to_string(), true, Some(300));


### PR DESCRIPTION
## Parent

#506 / child #526 — slice 2a (observability foundation + simple message-frozen suppressors)

Builds on slice 1 (PR #721, commit `c12be908`). The shared T0/T1 evaluator and `NotificationCandidate` constructor-boundary validation are now in place; this slice adds the typed audit + remaining message-frozen suppressors on top.

## What changes

### Typed audit foundation

- **`SuppressedReason` enum** — closed set, one variant per XEP/Waddle rule:
  - `Xep0357Self` (already enforced at constructor; recorded for completeness on race-window state)
  - `Xep0357NoRegistration`, `Xep0357RegistrationDisabled`
  - `Xep0492Never`, `Xep0492OnMentionMiss`
  - `Xep0191Blocked`
  - `Xep0513Noping`, `Xep0513ActiveMiss` *(active-miss deferred to slice 2b — placeholder variant accepted)*
  - `Xep0334NoStore`, `Xep0334NoPermanentStore`
  - `WaddleDnd`
  - `ProviderRejected`, `ProviderTokenExpired` *(provider-side variants accepted; will be set by provider slices #528/#529/#530)*
- **`suppressed_reason TEXT` column** on `notification_candidates`. NULL means "not suppressed yet" or "delivered." Mirrors the existing `class`/`reason` CHECK constraint + migration pattern (named CHECK, anonymous-Postgres-drop walker).
- **Metric counters** labeled by typed variant — `waddle_push_suppressed_total{reason="xep0492_never"}` etc. No message content in metric labels.

### Refactor existing T1 suppressions

The slice-1 T1 evaluator currently logs `info!` and marks candidate outboxed. Slice 2a extends each path to ALSO write the typed `SuppressedReason` onto the row before marking outboxed, and increment the matching metric counter. No behavior change in the dispatch decision itself; the audit trail becomes durable.

### `DndReader` trait + noop default

Typed trait returning `DndState::Inactive | Active { reason }`. Noop default impl returns `Inactive` always. T1 evaluator consumes the trait; when DND is active, suppress with `WaddleDnd` reason. **#367 will implement the trait against the real `urn:waddle:dnd:0` PEP projection** — same dependency-inversion shape as the XEP-0492 projection adapter in slice 1.

### `<noping/>` (XEP-0513) enforcement

The mention parser already returns a typed `noping: bool` bit. Slice 2a snapshots it onto the candidate row and the T1 evaluator suppresses noped candidates with `Xep0513Noping`. Message-frozen; no recipient-state read.

### XEP-0334 hint enforcement

Snapshot `<no-store/>` and `<no-permanent-store/>` flags onto the candidate row. The T1 evaluator suppresses per Waddle policy with the matching typed `SuppressedReason`. Default policy is "suppress on both hints"; future PR can make this configurable per #719's rich-payload follow-up.

### Stage-split for message-frozen suppressors (commit `f898e54c`)

`<noping/>`, `<no-store/>`, `<no-permanent-store/>`, and Waddle DnD MUST run at T1 only (not at T0). Suppressing at T0 would skip persisting the candidate row, which destroys the audit trail. The evaluator now distinguishes `PushEvalStage::T0Emit` (compliance-only suppression for XEP-0492 `<never/>` / `<on-mention/>`) from `PushEvalStage::T1Drain` (the full suppressor set + typed audit).

### Storage-preservation regression suite (commit `d3cb3e0a`, `f9f0c054`)

Adds explicit per-suppressor regressions for the contract that **suppression only affects the XEP-0357 push fanout**:

- Per-XEP unit tests under `notification_outbox::tests` (uses `InMemoryInboxStorage` as the upstream-storage witness; pre-seeds an inbox entry, runs the candidate flow, asserts the entry is byte-identical afterwards):
  - `xep0492_never_suppression_preserves_pending_delivery_and_audit_via_metric`
  - `xep0492_on_mention_miss_preserves_pending_delivery_for_non_mention_dm`
  - `xep0191_blocked_t1_suppression_keeps_pending_delivery_intact`
  - `xep0513_noping_t1_suppression_persists_candidate_and_keeps_storage`
  - `xep0334_no_store_t1_suppression_persists_audit_and_keeps_storage`
  - `xep0334_no_permanent_store_t1_suppression_persists_audit_and_keeps_storage`
  - `waddle_dnd_t1_suppression_persists_audit_and_keeps_storage`
- `MockPepDndReader` test fixture mirroring #367's PEP-backed shape (per-user persisted `Active`/`Inactive` set keyed by `BareJid`). When #367 lands, only the reader implementation swaps; the trait surface is locked in slice 2a.
- `dnd_integration_with_pep_shaped_reader_suppresses_push_only` — exercises the `DndReader` integration contract end-to-end with two recipients in one drain batch; verifies DnD suppression is per-recipient (active recipient suppressed with the typed audit; inactive recipient delivers through to a real outbox job; metric ticks by exactly one).
- `xep0357_suppression_preserves_mam_inbox_pending_delivery_and_audit` (ws-integration test in `server::routes::websocket::tests::messages`) — pre-seeds XEP-0313 MAM row, XEP-0430 inbox projection, and XEP-0160 pending_delivery row BEFORE the offline-delivery interpret pass; verifies all three upstream artifacts survive `<never/>` T0 push suppression while no candidate / no outbox job is emitted.

## What does NOT change (deferred to slice 2b)

- `notification_activity` projection table fed by typed XEP-0085 / XEP-0490 / outbound-commit / XEP-0045 inputs.
- XEP-0513 `<active/>` *current-activity* filter (the existing `is_live_occupant` snapshot stays at T0 per the architectural clarification merged with slice 1).
- Real `DndReader` implementation — that's #367's slice.

## XEP review

- **XEP-0357 §6**: stanza-error → registration disable transitions already at the publish layer; this PR adds typed `Xep0357RegistrationDisabled` audit when those transitions fire.
- **XEP-0492 §3**: settings evaluated fresh at T1 (unchanged); this PR adds typed audit for `<never/>` and `<on-mention/>` miss outcomes.
- **XEP-0513 §"noping"**: receiver MAY suppress push for noped mentions; this PR implements that suppression and records the typed reason.
- **XEP-0334 §3**: hints are policy inputs; this PR adds policy-configurable suppression per hint with typed audit.
- **XEP-0191**: blocklist enforcement unchanged; this PR adds typed `Xep0191Blocked` audit on the existing suppression path.

## Plan / checklist

- [x] `SuppressedReason` enum + `suppressed_reason` column + named-CHECK migration (Postgres + SQLite)
- [x] Refactor T1 evaluator paths to record typed reasons + emit metric counters
- [x] `DndReader` trait + noop default; wire into T1 evaluator
- [x] Snapshot `<noping/>` bit onto candidate row; T1 enforcement
- [x] Snapshot XEP-0334 hints onto candidate row; T1 enforcement
- [x] Per-XEP test coverage (CLAUDE.md hard rule)
- [x] Stage-split: defer hint + DnD suppressors to T1 so audit row persists
- [x] Storage-preservation regressions per suppressor (MAM / inbox / pending_delivery untouched)
- [x] `DndReader` integration test with #367-shaped mock reader
- [x] `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test -p waddle-server` green
- [x] Adversarial review pass

## Out of scope (filed elsewhere)

- `notification_activity` projection + `<active/>` filter — slice 2b follow-up PR
- Real `DndReader` impl — #367
- Provider-side `ProviderRejected`/`ProviderTokenExpired` setters — provider slices (#528/#529/#530)
- Rich payload — #719
- DM XEP-0492 carrier — #720

## Related

- Parent: #506
- Predecessor: slice 1 of #526 (PR #721, merged `c12be908`)
- DND integration: #367
- Foundation slice: #718 (typed push client surface, parallel-eligible)
