### PR TITLE
fix(chat): refocusing a tab jumps to latest message

### DIFF
--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -44,6 +44,7 @@ import { useChannelLiveMerge } from "@/channels/live-merge";
 import { useChannelChatStates } from "@/channels/chat-states";
 import { useChannelReadMarkers } from "@/channels/read-markers";
 import { useChannelMessageSearch } from "@/channels/message-search";
+import { useChatWindowVisibility } from "@/shell/window-visibility";
 
 export function useChannelMessages(
   session: Ref<WaddleSession | null>,
@@ -581,6 +582,15 @@ export function useChannelMessages(
 
   watch(scrollDirection, () => {
     void alignTimelineToPreference();
+  });
+
+  // Browser-tab refocus: re-pin if the user was already at the edge before
+  // switching away. Mirrors the DM-side watcher; see `dms/messages.ts`.
+  const { isWindowFocused } = useChatWindowVisibility();
+  watch(isWindowFocused, (focused, prev) => {
+    if (focused && !prev && pinnedEdgeScroller.isPinnedAtEdge.value) {
+      void scrollToPinnedEdgeAndPin();
+    }
   });
 
   watch(

--- a/chat/src/components/chat/ThreadPanel.vue
+++ b/chat/src/components/chat/ThreadPanel.vue
@@ -17,6 +17,7 @@ import {
   type ScrollDirectionMode,
 } from "@/lib/scroll-direction";
 import { createPinnedEdgeScroller } from "@/lib/pinned-edge-scroll";
+import { useChatWindowVisibility } from "@/shell/window-visibility";
 import { formatTimelineDayDivider, isSameTimelineDay } from "@/channels/timeline";
 
 const props = defineProps<{
@@ -325,6 +326,16 @@ watch(
 
 watch(scrollDirectionMode, () => {
   void scrollToPinnedEdge();
+});
+
+// Browser-tab refocus: re-pin the thread panel if the user was already at
+// the edge before switching away. Mirrors the channel/DM message-list
+// watchers; see `channels/messages.ts` / `dms/messages.ts`.
+const { isWindowFocused } = useChatWindowVisibility();
+watch(isWindowFocused, (focused, prev) => {
+  if (focused && !prev && pinnedEdgeScroller.isPinnedAtEdge.value) {
+    void scrollToPinnedEdge();
+  }
 });
 
 watch(

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -27,6 +27,7 @@ import { useDmLiveMerge } from "@/dms/live-merge";
 import { useDmChatStates } from "@/dms/chat-states";
 import { useDmReadMarkers } from "@/dms/read-markers";
 import { useDmMessageSearch } from "@/dms/message-search";
+import { useChatWindowVisibility } from "@/shell/window-visibility";
 
 export function useDirectMessages(
   session: Ref<WaddleSession | null>,
@@ -314,6 +315,17 @@ export function useDirectMessages(
 
   watch(scrollDirection, () => {
     void alignTimelineToPreference();
+  });
+
+  // Browser-tab refocus: re-pin if the user was already at the edge before
+  // switching away. New messages that arrived while hidden didn't get a
+  // chance to settle (rAF/RO throttled, virtualizer didn't measure
+  // offscreen rows), so the position drifts away from the latest message.
+  const { isWindowFocused } = useChatWindowVisibility();
+  watch(isWindowFocused, (focused, prev) => {
+    if (focused && !prev && pinnedEdgeScroller.isPinnedAtEdge.value) {
+      void scrollToPinnedEdgeAndPin();
+    }
   });
 
   watch(

--- a/chat/src/shell/window-visibility.ts
+++ b/chat/src/shell/window-visibility.ts
@@ -9,7 +9,7 @@ function readFocused(): boolean {
 export function useChatWindowVisibility(): { isWindowFocused: Readonly<Ref<boolean>> } {
   const isWindowFocused = ref(readFocused());
 
-  if (typeof window === "undefined") {
+  if (typeof window === "undefined" || typeof document === "undefined") {
     return { isWindowFocused };
   }
 

--- a/chat/src/shell/window-visibility.ts
+++ b/chat/src/shell/window-visibility.ts
@@ -21,11 +21,16 @@ export function useChatWindowVisibility(): { isWindowFocused: Readonly<Ref<boole
   document.addEventListener("visibilitychange", update);
   window.addEventListener("focus", update);
   window.addEventListener("blur", update);
+  // iOS Safari bfcache restoration surfaces as `pageshow` (often with
+  // `persisted=true`) and may not fire `visibilitychange` in time. Matches
+  // the listener set used by `virtual-timeline-measurement.ts`.
+  window.addEventListener("pageshow", update);
 
   onScopeDispose(() => {
     document.removeEventListener("visibilitychange", update);
     window.removeEventListener("focus", update);
     window.removeEventListener("blur", update);
+    window.removeEventListener("pageshow", update);
   });
 
   return { isWindowFocused };


### PR DESCRIPTION
## Summary

Refocusing the browser tab after switching away does not return the viewport to the latest message, even when the user was pinned to the bottom edge before switching. Repros in three independent scroll surfaces (channel feed, DM feed, thread side panel) on desktop and mobile.

## Root cause

While the tab is hidden:

- `requestAnimationFrame` is throttled and `ResizeObserver` callbacks are deferred.
- The virtualizer in `VirtualTimeline.vue` doesn't measure offscreen rows, so `scrollHeight` doesn't reflect newly-arrived messages.
- The 500 ms settle timer in `pinned-edge-scroll.ts` fires (and disconnects) while still hidden.

On refocus, `virtual-timeline-measurement.ts` re-measures rows correctly, but nothing re-pins the scroll, so the viewport ends up near-bottom instead of at-bottom.

## Approach

1. Extend `useChatWindowVisibility` to also listen for `pageshow` (covers iOS Safari bfcache restoration). Existing `visibilitychange` / `focus` / `blur` already cover desktop tab-switch.
2. Add a focus-transition watcher next to each of the three pinned-edge scrollers (channels, DMs, thread panel). On `isWindowFocused` false→true with `isPinnedAtEdge === true`, call `scrollToPinnedEdgeAndPin()`. Gated on `isPinnedAtEdge` so users who intentionally scrolled up are not yanked.

## Files changed

- `chat/src/shell/window-visibility.ts` — add `pageshow` listener.
- `chat/src/dms/messages.ts` — focus-transition re-pin watcher.
- `chat/src/channels/messages.ts` — focus-transition re-pin watcher.
- `chat/src/components/chat/ThreadPanel.vue` — focus-transition re-pin watcher.

## Test plan

- [ ] Channel, desktop, bottom-pinned: switch tabs while messages arrive, return — lands on newest.
- [ ] DM, desktop, bottom-pinned: same.
- [ ] Thread panel (channel + DM): same; main feed behind it also at latest.
- [ ] Top-pinned (\"social\") scroll direction: same across all surfaces.
- [ ] Negative: user scrolled up before tab-switch — viewport position preserved on return.
- [ ] iOS Safari + Android Chrome: tab switch and app background/restore (bfcache).
- [ ] Installed PWA: same as mobile.
- [ ] \`cd chat && bun test && bun run lint\` green; Knip clean.