### PR TITLE
feat(server): XEP-0513 channel-mention sender permission gate (#525 slice 3a)

### DIFF
--- a/server/crates/waddle-server/src/inbox.rs
+++ b/server/crates/waddle-server/src/inbox.rs
@@ -23,7 +23,7 @@ mod schema;
 use codec::{decode_row, encode_kind, SELECT_COLS};
 pub use open::build_inbox_storage;
 
-const GROUPCHAT_NOTIFICATION_RECOVERY_SELECT_COLS: &str = "recipient_bare_jid, room_jid, thread_id, stanza_id_by, stanza_id, sender_jid, is_live_occupant, room_members_only, created_at_ms";
+const GROUPCHAT_NOTIFICATION_RECOVERY_SELECT_COLS: &str = "recipient_bare_jid, room_jid, thread_id, stanza_id_by, stanza_id, sender_jid, is_live_occupant, room_members_only, sender_can_broadcast_channel_mention, created_at_ms";
 
 #[derive(Clone)]
 pub struct DatabaseInboxStorage {
@@ -94,13 +94,15 @@ fn insert_groupchat_notification_recovery_sql() -> &'static str {
         sender_jid,
         is_live_occupant,
         room_members_only,
+        sender_can_broadcast_channel_mention,
         created_at_ms,
         completed_at_ms
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
     ON CONFLICT(recipient_bare_jid, room_jid, thread_id, stanza_id_by, stanza_id) DO UPDATE SET
         sender_jid = excluded.sender_jid,
         is_live_occupant = excluded.is_live_occupant,
         room_members_only = excluded.room_members_only,
+        sender_can_broadcast_channel_mention = excluded.sender_can_broadcast_channel_mention,
         created_at_ms = excluded.created_at_ms,
         completed_at_ms = NULL
     "#
@@ -118,6 +120,7 @@ fn groupchat_notification_recovery_params(
         recovery.sender_jid.to_string(),
         recovery.is_live_occupant,
         recovery.room_members_only,
+        recovery.sender_can_broadcast_channel_mention,
         recovery.created_at_ms,
     ]
 }
@@ -149,8 +152,11 @@ fn decode_groupchat_notification_recovery(
     let room_members_only: i64 = row
         .get(7)
         .map_err(|error| InboxStorageError::Other(error.to_string()))?;
-    let created_at_ms: i64 = row
+    let sender_can_broadcast_channel_mention: i64 = row
         .get(8)
+        .map_err(|error| InboxStorageError::Other(error.to_string()))?;
+    let created_at_ms: i64 = row
+        .get(9)
         .map_err(|error| InboxStorageError::Other(error.to_string()))?;
     Ok(GroupchatNotificationRecovery {
         key: GroupchatNotificationRecoveryKey {
@@ -173,6 +179,7 @@ fn decode_groupchat_notification_recovery(
             .map_err(|error| InboxStorageError::Other(format!("invalid sender JID: {error}")))?,
         is_live_occupant: is_live_occupant != 0,
         room_members_only: room_members_only != 0,
+        sender_can_broadcast_channel_mention: sender_can_broadcast_channel_mention != 0,
         created_at_ms,
     })
 }

--- a/server/crates/waddle-server/src/inbox/schema.rs
+++ b/server/crates/waddle-server/src/inbox/schema.rs
@@ -86,6 +86,16 @@ pub(super) async fn initialize(storage: &DatabaseInboxStorage) -> Result<(), Inb
                 sender_jid TEXT NOT NULL,
                 is_live_occupant INTEGER NOT NULL,
                 room_members_only INTEGER NOT NULL,
+                -- XEP-0513 §"Multi-User Chats Permissions" §304: persist
+                -- the sender's frozen channel-mention permission so a
+                -- recovery replay re-creates the same notification class
+                -- the original T0 emission did. Without this column the
+                -- recovery path would silently downgrade every channel
+                -- mention to `NotifyAll`, which is then suppressed at T1
+                -- by the public-group `OnMention` XEP-0492 default — a
+                -- silent moderator-push outage after every server
+                -- restart.
+                sender_can_broadcast_channel_mention INTEGER NOT NULL,
                 created_at_ms {i64_type} NOT NULL,
                 completed_at_ms {i64_type},
                 PRIMARY KEY (recipient_bare_jid, room_jid, thread_id, stanza_id_by, stanza_id)

--- a/server/crates/waddle-server/src/inbox/schema.rs
+++ b/server/crates/waddle-server/src/inbox/schema.rs
@@ -73,12 +73,13 @@ pub(super) async fn initialize(storage: &DatabaseInboxStorage) -> Result<(), Inb
         (),
     )
     .await?;
-    // Per CLAUDE.md "Assume no production servers/users/data for this
-    // project; prioritize clean design over compatibility" — schema
-    // changes modify `CREATE TABLE IF NOT EXISTS` in place. Local
-    // SQLite files built against an earlier branch must be discarded
-    // (or the table dropped) before pulling a schema change; CI runs
-    // against ephemeral databases so this is invisible there.
+    // Fresh databases get the full schema via CREATE TABLE IF NOT
+    // EXISTS. Existing databases that pre-date the
+    // `sender_can_broadcast_channel_mention` column are migrated
+    // below via the targeted `migrate_*_recovery_channel_broadcast`
+    // helpers — without that path, the runtime SELECT against the
+    // new column errors with "no such column" / "column does not
+    // exist" on every recovery replay (reviewer on PR #738).
     storage
         .execute(
             &format!(
@@ -111,6 +112,7 @@ pub(super) async fn initialize(storage: &DatabaseInboxStorage) -> Result<(), Inb
             (),
         )
         .await?;
+    migrate_recovery_channel_broadcast_column(storage).await?;
     storage.execute(
         "CREATE INDEX IF NOT EXISTS idx_groupchat_notification_recovery_pending \
          ON groupchat_notification_recovery (created_at_ms, recipient_bare_jid, room_jid, thread_id, stanza_id) \
@@ -126,6 +128,100 @@ pub(super) async fn initialize(storage: &DatabaseInboxStorage) -> Result<(), Inb
     )
     .await?;
     Ok(())
+}
+
+/// Adds the `sender_can_broadcast_channel_mention` column to existing
+/// `groupchat_notification_recovery` tables that pre-date PR #738.
+/// Idempotent on both SQLite and Postgres — re-runs at every startup
+/// are no-ops once the column exists.
+///
+/// XEP-0513 §"Multi-User Chats Permissions" §304 default value `0`
+/// (deny) on backfill: a recovery row created before the gate
+/// landed has no frozen permission to consult; on replay the
+/// candidate must NOT be granted channel-broadcast authority
+/// retroactively. The recovery path then downgrades the class to
+/// `NotifyAll`, which composes with the existing XEP-0492 policy.
+async fn migrate_recovery_channel_broadcast_column(
+    storage: &DatabaseInboxStorage,
+) -> Result<(), InboxStorageError> {
+    const COLUMN: &str = "sender_can_broadcast_channel_mention";
+    match storage.db.driver() {
+        DatabaseDriver::Sqlite => {
+            if !recovery_column_present_sqlite(storage, COLUMN).await? {
+                info!(
+                    column = COLUMN,
+                    "Adding column to groupchat_notification_recovery (SQLite)"
+                );
+                storage
+                    .execute(
+                        &format!(
+                            "ALTER TABLE groupchat_notification_recovery \
+                             ADD COLUMN {COLUMN} INTEGER NOT NULL DEFAULT 0"
+                        ),
+                        (),
+                    )
+                    .await?;
+            }
+        }
+        DatabaseDriver::Postgres => {
+            // `ADD COLUMN IF NOT EXISTS` makes this idempotent at the
+            // SQL layer; no PRAGMA-equivalent probe needed.
+            storage
+                .execute(
+                    &format!(
+                        "ALTER TABLE groupchat_notification_recovery \
+                         ADD COLUMN IF NOT EXISTS {COLUMN} INTEGER NOT NULL DEFAULT 0"
+                    ),
+                    (),
+                )
+                .await?;
+        }
+    }
+    Ok(())
+}
+
+/// SQLite-only: returns `true` if the column exists on
+/// `groupchat_notification_recovery`. Mirrors `needs_thread_migration`
+/// but for a specific column rather than table-existence.
+async fn recovery_column_present_sqlite(
+    storage: &DatabaseInboxStorage,
+    column: &str,
+) -> Result<bool, InboxStorageError> {
+    let mut rows = storage
+        .query(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='groupchat_notification_recovery'",
+            (),
+        )
+        .await
+        .map_err(|error| InboxStorageError::Other(error.to_string()))?;
+    let table_exists = rows
+        .next()
+        .await
+        .map_err(|error| InboxStorageError::Other(error.to_string()))?
+        .is_some();
+    if !table_exists {
+        // The CREATE TABLE IF NOT EXISTS above ran first; if the
+        // table still doesn't exist, this run is unusual but the
+        // missing-column path is moot.
+        return Ok(true);
+    }
+    let mut cols = storage
+        .query("PRAGMA table_info(groupchat_notification_recovery)", ())
+        .await
+        .map_err(|error| InboxStorageError::Other(error.to_string()))?;
+    while let Some(row) = cols
+        .next()
+        .await
+        .map_err(|error| InboxStorageError::Other(error.to_string()))?
+    {
+        let col_name: String = row
+            .get(1)
+            .map_err(|error| InboxStorageError::Other(error.to_string()))?;
+        if col_name == column {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 /// Returns true if inbox_entries exists but lacks the thread_id column.

--- a/server/crates/waddle-server/src/inbox/schema.rs
+++ b/server/crates/waddle-server/src/inbox/schema.rs
@@ -73,6 +73,12 @@ pub(super) async fn initialize(storage: &DatabaseInboxStorage) -> Result<(), Inb
         (),
     )
     .await?;
+    // Per CLAUDE.md "Assume no production servers/users/data for this
+    // project; prioritize clean design over compatibility" — schema
+    // changes modify `CREATE TABLE IF NOT EXISTS` in place. Local
+    // SQLite files built against an earlier branch must be discarded
+    // (or the table dropped) before pulling a schema change; CI runs
+    // against ephemeral databases so this is invisible there.
     storage
         .execute(
             &format!(

--- a/server/crates/waddle-server/src/inbox/tests.rs
+++ b/server/crates/waddle-server/src/inbox/tests.rs
@@ -179,6 +179,7 @@ async fn sqlx_inbox_storage_tracks_groupchat_notification_recovery() {
         sender_jid: "room@muc.example.com/alice".parse().expect("sender jid"),
         is_live_occupant: true,
         room_members_only: false,
+        sender_can_broadcast_channel_mention: true,
         created_at_ms: 42,
     };
     let second_recovery = GroupchatNotificationRecovery {
@@ -196,6 +197,7 @@ async fn sqlx_inbox_storage_tracks_groupchat_notification_recovery() {
             .expect("second sender jid"),
         is_live_occupant: false,
         room_members_only: true,
+        sender_can_broadcast_channel_mention: false,
         created_at_ms: 43,
     };
 

--- a/server/crates/waddle-server/src/inbox/tests.rs
+++ b/server/crates/waddle-server/src/inbox/tests.rs
@@ -363,3 +363,116 @@ async fn sqlx_inbox_postgres_handles_i32_overflow_last_updated() {
         .expect("cleanup inbox postgres row");
     assert_eq!(deleted, 1);
 }
+
+/// Regression for the reviewer feedback on PR #738: an existing
+/// `groupchat_notification_recovery` table created BEFORE the
+/// `sender_can_broadcast_channel_mention` column landed must be
+/// migrated forward — without the targeted ALTER, every recovery
+/// SELECT errors with "no such column". This test simulates that
+/// state by:
+///
+///   1. opening a fresh DB (CREATE TABLE includes the column),
+///   2. DROPping it,
+///   3. recreating it WITHOUT the column (the pre-PR shape),
+///   4. re-opening / re-initialising the storage,
+///   5. asserting the column is present after init.
+#[tokio::test(flavor = "multi_thread")]
+async fn migration_adds_sender_can_broadcast_channel_mention_to_legacy_recovery_table() {
+    let artifacts = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target/test-artifacts");
+    std::fs::create_dir_all(&artifacts).expect("artifacts dir");
+    let path = artifacts.join(format!("inbox-migration-{}.db", uuid::Uuid::new_v4()));
+    let url = format!("sqlite://{}", path.display());
+
+    // Step 1-3: build a DB whose recovery table predates the new
+    // column. Open fresh, drop, recreate without the column.
+    {
+        let storage = DatabaseInboxStorage::open(Some(&url))
+            .await
+            .expect("open fresh storage");
+        storage
+            .execute("DROP TABLE groupchat_notification_recovery", ())
+            .await
+            .expect("drop fresh recovery table");
+        storage
+            .execute(
+                r#"
+                CREATE TABLE groupchat_notification_recovery (
+                    recipient_bare_jid TEXT NOT NULL,
+                    room_jid TEXT NOT NULL,
+                    thread_id TEXT NOT NULL DEFAULT '',
+                    stanza_id_by TEXT NOT NULL,
+                    stanza_id TEXT NOT NULL,
+                    sender_jid TEXT NOT NULL,
+                    is_live_occupant INTEGER NOT NULL,
+                    room_members_only INTEGER NOT NULL,
+                    created_at_ms INTEGER NOT NULL,
+                    completed_at_ms INTEGER,
+                    PRIMARY KEY (recipient_bare_jid, room_jid, thread_id, stanza_id_by, stanza_id)
+                )
+                "#,
+                (),
+            )
+            .await
+            .expect("create legacy recovery table");
+    }
+
+    // Step 4-5: re-open. The init path should detect the missing
+    // column and run the ALTER. Confirm by:
+    //   (a) the column is reported by PRAGMA, and
+    //   (b) a recovery write succeeds (it would fail with "no such
+    //       column" if the migration didn't run).
+    let storage = DatabaseInboxStorage::open(Some(&url))
+        .await
+        .expect("re-open storage triggers migration");
+
+    let mut cols = storage
+        .query("PRAGMA table_info(groupchat_notification_recovery)", ())
+        .await
+        .expect("PRAGMA table_info");
+    let mut has_column = false;
+    while let Some(row) = cols.next().await.expect("advance pragma row") {
+        let name: String = row.get(1).expect("col name");
+        if name == "sender_can_broadcast_channel_mention" {
+            has_column = true;
+            break;
+        }
+    }
+    assert!(
+        has_column,
+        "migration must add `sender_can_broadcast_channel_mention` to \
+         pre-existing groupchat_notification_recovery tables"
+    );
+
+    let recovery = waddle_xmpp::inbox::storage::GroupchatNotificationRecovery {
+        key: waddle_xmpp::inbox::storage::GroupchatNotificationRecoveryKey {
+            recipient: jid("recipient@example.com"),
+            room: jid("room@muc.example.com"),
+            thread_id: None,
+            archive_stanza_id: waddle_xmpp_core::xep0359::StanzaId::new(
+                "migration-test",
+                "room@muc.example.com".parse().expect("stanza-id by"),
+            ),
+        },
+        sender_jid: "room@muc.example.com/alice".parse().expect("sender jid"),
+        is_live_occupant: true,
+        room_members_only: false,
+        sender_can_broadcast_channel_mention: true,
+        created_at_ms: 42,
+    };
+    storage
+        .insert_groupchat_notification_recovery(recovery.clone())
+        .await
+        .expect("insert after migration must succeed");
+    let pending = storage
+        .list_pending_groupchat_notification_recoveries(16)
+        .await
+        .expect("list after migration must succeed");
+    assert_eq!(pending.len(), 1);
+    assert!(
+        pending[0].sender_can_broadcast_channel_mention,
+        "the persisted bool must round-trip through the migrated column"
+    );
+
+    // Cleanup
+    std::fs::remove_file(&path).ok();
+}

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -498,6 +498,7 @@ async fn interpret_with_depth(
                 is_durable_recipient,
                 is_live_occupant,
                 room_members_only,
+                sender_can_broadcast_channel_mention,
                 thread,
                 dispatch_timestamp,
             } => {
@@ -510,6 +511,7 @@ async fn interpret_with_depth(
                     is_durable_recipient,
                     is_live_occupant,
                     room_members_only,
+                    sender_can_broadcast_channel_mention,
                     thread,
                     dispatch_timestamp,
                 })

--- a/server/crates/waddle-server/src/server/routes/interpret/bot.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/bot.rs
@@ -104,6 +104,18 @@ pub(super) async fn dispatch_bot_groupchat_response(
         occupant_id_secret: bot_ctx.occupant_id_secret,
         sender_nickname_generation: 0,
         project_sender_inbox: false,
+        // XEP-0513 §"Multi-User Chats Permissions" §304 +
+        // adversarial review on PR #738: the extension-bot dispatcher
+        // is the only production caller that needs to broadcast as a
+        // synthetic sender. Trust is established upstream by the
+        // bot-registration path (`bot_ctx` is built only after the
+        // sender's bot identity has been validated). Carrying the
+        // authority as an explicit typed marker — separate from
+        // `project_sender_inbox` — keeps the inbox-projection flag
+        // from doubling as an implicit permission bypass.
+        synthetic_sender_authority: Some(
+            waddle_xmpp::protocol::room::SyntheticSenderAuthority::ServerAuthored,
+        ),
         dispatch_timestamp: bot_ctx.dispatch_timestamp,
     };
 

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
@@ -10,6 +10,10 @@ pub(super) struct ProjectGroupchatInboxEvent<'a, 'deps> {
     pub is_durable_recipient: bool,
     pub is_live_occupant: bool,
     pub room_members_only: bool,
+    /// XEP-0513 §"Multi-User Chats Permissions": frozen at dispatch
+    /// time. See [`waddle_xmpp::protocol::event::OutboundEvent::ProjectGroupchatInbox`]
+    /// for full semantics.
+    pub sender_can_broadcast_channel_mention: bool,
     pub thread: Option<GroupchatThreadProjection>,
     pub dispatch_timestamp: i64,
 }
@@ -24,6 +28,7 @@ pub(super) async fn project_groupchat_inbox_event(input: ProjectGroupchatInboxEv
         is_durable_recipient,
         is_live_occupant,
         room_members_only,
+        sender_can_broadcast_channel_mention,
         thread,
         dispatch_timestamp,
     } = input;
@@ -70,6 +75,7 @@ pub(super) async fn project_groupchat_inbox_event(input: ProjectGroupchatInboxEv
         is_durable_recipient,
         is_live_occupant,
         room_members_only,
+        sender_can_broadcast_channel_mention,
         thread: &thread,
         outcome,
         recovery_key: notification_recovery_key.as_ref(),
@@ -86,6 +92,9 @@ struct GroupchatNotificationProjection<'a, 'deps> {
     is_durable_recipient: bool,
     is_live_occupant: bool,
     room_members_only: bool,
+    /// XEP-0513 frozen permission snapshot; see
+    /// [`ProjectGroupchatInboxEvent::sender_can_broadcast_channel_mention`].
+    sender_can_broadcast_channel_mention: bool,
     thread: &'a Option<GroupchatThreadProjection>,
     outcome: GroupchatInboxProjectionOutcome,
     recovery_key: Option<&'a waddle_xmpp::inbox::storage::GroupchatNotificationRecoveryKey>,
@@ -140,6 +149,7 @@ async fn maybe_enqueue_groupchat_notification_candidate(
         is_durable_recipient,
         is_live_occupant,
         room_members_only,
+        sender_can_broadcast_channel_mention,
         thread,
         outcome,
         recovery_key,
@@ -153,6 +163,7 @@ async fn maybe_enqueue_groupchat_notification_candidate(
         is_durable_recipient,
         is_live_occupant,
         room_members_only,
+        sender_can_broadcast_channel_mention,
         thread,
         outcome,
         recovery_key,
@@ -177,6 +188,7 @@ async fn enqueue_groupchat_notification_candidate(
         is_durable_recipient,
         is_live_occupant,
         room_members_only,
+        sender_can_broadcast_channel_mention,
         thread,
         outcome,
         recovery_key: _,
@@ -225,6 +237,7 @@ async fn enqueue_groupchat_notification_candidate(
         Xep0359StanzaId::new(archive_id, Jid::from(room.clone())),
         is_live_occupant,
         room_members_only,
+        sender_can_broadcast_channel_mention,
     )
     .await
 }
@@ -246,6 +259,12 @@ async fn insert_groupchat_notification_candidate(
     // groupchat fan-out would otherwise produce an actor round-trip,
     // even though the same bit is already in hand.
     room_members_only: bool,
+    // XEP-0513 §"Multi-User Chats Permissions": frozen permission
+    // snapshot for `urn:xmpp:mentions:0#channel`. `false` downgrades
+    // channel mentions to `NotifyAll` (still delivered, but not pushed
+    // as a forced channel mention). The recovery path passes `false`
+    // — see [`reconcile_groupchat_notification_candidates`].
+    sender_can_broadcast_channel_mention: bool,
 ) -> GroupchatNotificationCandidateQueueOutcome {
     // Parse explicit mentions ONCE per message and derive every
     // XEP-0513 signal (personal-mention bit, channel-mention scope,
@@ -266,6 +285,7 @@ async fn insert_groupchat_notification_candidate(
         room,
         owner_occupant_id.as_str(),
         is_live_occupant,
+        sender_can_broadcast_channel_mention,
     );
     let hints = crate::notification_outbox::NotificationMessageHints::none()
         .with_noping(groupchat_mentions_carry_owner_noping(
@@ -541,6 +561,15 @@ pub(crate) async fn reconcile_groupchat_notification_candidates(
             recovery.key.archive_stanza_id.clone(),
             recovery.is_live_occupant,
             recovery.room_members_only,
+            // XEP-0513 §"Multi-User Chats Permissions": the recovery
+            // row does not persist the sender's role (would require
+            // a schema migration). Default to `false` (deny channel
+            // boost) on recovery — XEP-conformant conservative bias:
+            // §304 says receiving entities SHOULD ignore mentions
+            // when the sender's role is unknown / below threshold.
+            // The candidate still publishes; only the class is
+            // downgraded from `ChannelMention` → `NotifyAll`.
+            false,
         )
         .await;
         if outcome == GroupchatNotificationCandidateQueueOutcome::Completed
@@ -613,9 +642,18 @@ fn groupchat_notification_class(
     // (XEP-0513 §"active mention" §"the receiving server may filter")
     // — that augments this T0 snapshot, it does not relocate it.
     is_live_occupant: bool,
+    // XEP-0513 §"Multi-User Chats Permissions" §304: receiving entities
+    // SHOULD ignore a channel mention if the sender does not have at
+    // least the minimum role required by the room. This is the typed
+    // frozen permission snapshot taken at dispatch time in
+    // `waddle_xmpp::protocol::room::inbox::sender_may_broadcast_channel_mention`
+    // — server default policy is `mentions#channel = moderators`
+    // (XEP-0513 example value).
+    sender_can_broadcast_channel_mention: bool,
 ) -> GroupchatNotificationClassDecision {
     let personal_mention = groupchat_mentions_owner(mentions, message, owner, owner_occupant_id);
-    let channel_mention = groupchat_channel_mention_scope(mentions, room);
+    let channel_mention = groupchat_channel_mention_scope(mentions, room)
+        .filter(|_| sender_can_broadcast_channel_mention);
     groupchat_notification_class_from_message(personal_mention, channel_mention, is_live_occupant)
 }
 
@@ -627,6 +665,11 @@ fn groupchat_notification_class(
 /// dispatch time consults the projection store and decides
 /// publish-or-suppress based on the recorded class + recipient's
 /// effective notification level.
+///
+/// `channel_mention` carries `None` either when no channel mention is
+/// present OR when the sender lacks the XEP-0513 §"Multi-User Chats
+/// Permissions" minimum role — see [`groupchat_notification_class`]
+/// where the role-filter is applied before this function is called.
 fn groupchat_notification_class_from_message(
     personal_mention: bool,
     channel_mention: Option<GroupchatChannelMentionScope>,
@@ -965,6 +1008,148 @@ mod tests {
         assert_eq!(
             groupchat_channel_mention_scope(&parsed_mentions(&msg_noping), &room),
             None
+        );
+    }
+
+    /// XEP-0513 §"Multi-User Chats Permissions" §304: receiving entities
+    /// SHOULD ignore a channel mention if the sender does not have at
+    /// least the minimum role required by the room. The classifier
+    /// MUST downgrade a channel mention to `NotifyAll` when the frozen
+    /// `sender_can_broadcast_channel_mention` snapshot is `false`. The
+    /// mention itself is delivered + archived unchanged; only the push
+    /// class changes — that is the entire scope of the permission gate.
+    #[test]
+    fn xep0513_channel_mention_downgrades_to_notify_all_for_unpermitted_sender() {
+        use crate::notification_outbox::NotificationClass;
+
+        let owner = bare("charlie@example.com");
+        let room = bare("team@muc.example.com");
+        let occupant_id = "room-stable-charlie";
+
+        let mut channel_uri = waddle_xmpp::xep::ExplicitMention::channel();
+        channel_uri.uri = Some("xmpp:team@muc.example.com".to_string());
+        let msg = message_with_mention(channel_uri);
+        let mentions = parsed_mentions(&msg);
+
+        // Permitted sender (moderator) → ChannelMention.
+        let GroupchatNotificationClassDecision::Deliver(permitted) = groupchat_notification_class(
+            &mentions,
+            &msg,
+            &owner,
+            &room,
+            occupant_id,
+            /* is_live_occupant */ false,
+            /* sender_can_broadcast_channel_mention */ true,
+        );
+        assert_eq!(
+            permitted,
+            NotificationClass::ChannelMention,
+            "moderator's channel mention must boost the push class to ChannelMention"
+        );
+
+        // Non-permitted sender (participant) → NotifyAll (downgrade).
+        let GroupchatNotificationClassDecision::Deliver(downgraded) = groupchat_notification_class(
+            &mentions,
+            &msg,
+            &owner,
+            &room,
+            occupant_id,
+            /* is_live_occupant */ false,
+            /* sender_can_broadcast_channel_mention */ false,
+        );
+        assert_eq!(
+            downgraded,
+            NotificationClass::NotifyAll,
+            "non-permitted sender's channel mention must downgrade to NotifyAll, \
+             not stay as ChannelMention — XEP-0513 §304"
+        );
+    }
+
+    /// Same XEP-0513 §"Multi-User Chats Permissions" gate, applied to
+    /// the `<active/>` variant: an active channel mention from a non-
+    /// permitted sender MUST also downgrade. The `<active/>` qualifier
+    /// is a recipient-state filter (XEP-0513 §"active mention"); it
+    /// does NOT confer permission to broadcast.
+    #[test]
+    fn xep0513_active_channel_mention_downgrades_for_unpermitted_sender() {
+        use crate::notification_outbox::NotificationClass;
+
+        let owner = bare("charlie@example.com");
+        let room = bare("team@muc.example.com");
+        let occupant_id = "room-stable-charlie";
+
+        let mut active_channel = waddle_xmpp::xep::ExplicitMention::active_channel();
+        active_channel.uri = Some("xmpp:team@muc.example.com".to_string());
+        let msg = message_with_mention(active_channel);
+        let mentions = parsed_mentions(&msg);
+
+        // Permitted sender + live occupant → ActiveChannelMention.
+        let GroupchatNotificationClassDecision::Deliver(permitted) = groupchat_notification_class(
+            &mentions,
+            &msg,
+            &owner,
+            &room,
+            occupant_id,
+            /* is_live_occupant */ true,
+            /* sender_can_broadcast_channel_mention */ true,
+        );
+        assert_eq!(
+            permitted,
+            NotificationClass::ActiveChannelMention,
+            "moderator's <active/> channel mention to a live occupant \
+             must classify as ActiveChannelMention"
+        );
+
+        // Non-permitted sender + live occupant → NotifyAll.
+        let GroupchatNotificationClassDecision::Deliver(downgraded) = groupchat_notification_class(
+            &mentions,
+            &msg,
+            &owner,
+            &room,
+            occupant_id,
+            /* is_live_occupant */ true,
+            /* sender_can_broadcast_channel_mention */ false,
+        );
+        assert_eq!(
+            downgraded,
+            NotificationClass::NotifyAll,
+            "non-permitted sender's <active/> channel mention must downgrade \
+             to NotifyAll — the active qualifier is a recipient filter, not \
+             a permission grant"
+        );
+    }
+
+    /// Personal mentions are unaffected by the channel-broadcast
+    /// permission. XEP-0513 §"Multi-User Chats Permissions" carries a
+    /// separate `mentions#individual` field for individual-mention
+    /// permission — outside the scope of this slice. A personal mention
+    /// from a non-permitted-broadcast sender MUST still classify as
+    /// PersonalMention; only `urn:xmpp:mentions:0#channel` is gated.
+    #[test]
+    fn xep0513_personal_mention_unaffected_by_channel_broadcast_permission() {
+        use crate::notification_outbox::NotificationClass;
+
+        let owner = bare("charlie@example.com");
+        let room = bare("team@muc.example.com");
+        let occupant_id = "room-stable-charlie";
+
+        let msg = message_with_mention(waddle_xmpp::xep::ExplicitMention::jid(owner.clone()));
+        let mentions = parsed_mentions(&msg);
+
+        let GroupchatNotificationClassDecision::Deliver(class) = groupchat_notification_class(
+            &mentions,
+            &msg,
+            &owner,
+            &room,
+            occupant_id,
+            /* is_live_occupant */ false,
+            /* sender_can_broadcast_channel_mention */ false,
+        );
+        assert_eq!(
+            class,
+            NotificationClass::PersonalMention,
+            "personal mention class must NOT be affected by the channel \
+             broadcast gate — the gate covers `urn:xmpp:mentions:0#channel` only"
         );
     }
 }

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
@@ -199,29 +199,25 @@ async fn enqueue_groupchat_notification_candidate(
     if !is_recipient || !is_durable_recipient {
         return GroupchatNotificationCandidateQueueOutcome::Completed;
     }
-    // XEP-0203 `<delay/>` filter (adversarial review on PR #738):
-    // a groupchat message tagged with `<delay xmlns='urn:xmpp:delay'/>`
-    // is a historical replay (S2S buffered delivery, server-bridge
-    // replay, MUC subject replay, etc.) and MUST NOT produce a real-
-    // time push candidate — pushing on a 3-hour-old message is the
-    // classic delayed-replay-as-push abuse vector. The
-    // `notification_activity` ingest path already applies this filter
-    // to chat-states (see `record_chat_state_activity`); the
-    // candidate-emission path needs the same protection. Recovery
-    // replay through `reconcile_groupchat_notification_candidates`
-    // bypasses this gate intentionally — those replayed MAM messages
-    // carry the recovery row's frozen T0 intent, which was real-time
-    // at original dispatch.
-    if waddle_xmpp::xep::xep0203::has_delay(message) {
-        debug!(
-            recipient = %owner,
-            room = %room,
-            "ProjectGroupchatInbox: skipping XEP-0357 candidate; \
-             stanza carries XEP-0203 `<delay/>` (historical replay, \
-             not real-time)"
-        );
-        return GroupchatNotificationCandidateQueueOutcome::Completed;
-    }
+    // XEP-0203 `<delay/>` filter NOT applied here (Copilot review
+    // on PR #738): an earlier shape of this path called
+    // `xep0203::has_delay(message)` to suppress push for historical
+    // replays. That check is trivially spoofable — a sender can
+    // inject `<delay xmlns='urn:xmpp:delay' from='whatever'
+    // stamp='2020-01-01T00:00:00Z'/>` into their own outbound
+    // stanza, the server forwards it unchanged, and every recipient's
+    // push gets suppressed. XEP-0203 §4.1 RECOMMENDS the `from`
+    // attribute but does not mandate it, and the server's room
+    // dispatcher does not add `<delay/>` for live messages — so any
+    // `<delay/>` on this path is by definition user-supplied today
+    // (Waddle has no S2S yet). The proper defense is inbound
+    // `<delay/>` stripping at the C2S session boundary (deferred to
+    // a follow-up slice); until that lands, blindly trusting
+    // `<delay/>` here would create an unprivileged push-suppression
+    // primitive. MAM-replay through
+    // `reconcile_groupchat_notification_candidates` calls
+    // `insert_groupchat_notification_candidate` directly, bypassing
+    // this function, so MAM replays do not produce duplicate pushes.
     let projection_committed = thread
         .as_ref()
         .map_or(outcome.channel_committed, |_| outcome.thread_committed);
@@ -831,7 +827,12 @@ fn current_room_channel_mention(
 }
 
 fn xmpp_uri_bare_jid(uri: &str) -> Option<BareJid> {
-    let jid_part = uri.strip_prefix("xmpp:")?.split(['?', ';']).next()?.trim();
+    // RFC 5122 / RFC 3986: query is introduced by `?`, fragment by
+    // `#`. `;` separates key/value pairs WITHIN the query — it does
+    // not delimit the start of the query. Stripping on `?` and `#`
+    // is sufficient for extracting the JID prefix (Copilot review
+    // on PR #738).
+    let jid_part = uri.strip_prefix("xmpp:")?.split(['?', '#']).next()?.trim();
     if jid_part.is_empty() {
         return None;
     }

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
@@ -265,8 +265,9 @@ async fn insert_groupchat_notification_candidate(
     // XEP-0513 §"Multi-User Chats Permissions": frozen permission
     // snapshot for `urn:xmpp:mentions:0#channel`. `false` downgrades
     // channel mentions to `NotifyAll` (still delivered, but not pushed
-    // as a forced channel mention). The recovery path passes `false`
-    // — see [`reconcile_groupchat_notification_candidates`].
+    // as a forced channel mention). The recovery path passes the
+    // bool persisted on the recovery row at original T0 dispatch —
+    // see [`reconcile_groupchat_notification_candidates`].
     sender_can_broadcast_channel_mention: bool,
 ) -> GroupchatNotificationCandidateQueueOutcome {
     // Parse explicit mentions ONCE per message and derive every

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
@@ -199,6 +199,29 @@ async fn enqueue_groupchat_notification_candidate(
     if !is_recipient || !is_durable_recipient {
         return GroupchatNotificationCandidateQueueOutcome::Completed;
     }
+    // XEP-0203 `<delay/>` filter (adversarial review on PR #738):
+    // a groupchat message tagged with `<delay xmlns='urn:xmpp:delay'/>`
+    // is a historical replay (S2S buffered delivery, server-bridge
+    // replay, MUC subject replay, etc.) and MUST NOT produce a real-
+    // time push candidate — pushing on a 3-hour-old message is the
+    // classic delayed-replay-as-push abuse vector. The
+    // `notification_activity` ingest path already applies this filter
+    // to chat-states (see `record_chat_state_activity`); the
+    // candidate-emission path needs the same protection. Recovery
+    // replay through `reconcile_groupchat_notification_candidates`
+    // bypasses this gate intentionally — those replayed MAM messages
+    // carry the recovery row's frozen T0 intent, which was real-time
+    // at original dispatch.
+    if waddle_xmpp::xep::xep0203::has_delay(message) {
+        debug!(
+            recipient = %owner,
+            room = %room,
+            "ProjectGroupchatInbox: skipping XEP-0357 candidate; \
+             stanza carries XEP-0203 `<delay/>` (historical replay, \
+             not real-time)"
+        );
+        return GroupchatNotificationCandidateQueueOutcome::Completed;
+    }
     let projection_committed = thread
         .as_ref()
         .map_or(outcome.channel_committed, |_| outcome.thread_committed);
@@ -713,7 +736,14 @@ fn groupchat_mentions_carry_owner_noping(
     owner_occupant_id: &str,
 ) -> bool {
     mentions.iter().any(|mention| {
+        // Mirror the mixed-attribute guard in `groupchat_mentions_owner`:
+        // a `<mention/>` that also carries `mentions='#channel'` is
+        // channel-scope, not a personal mention naming `owner` — the
+        // `<noping/>` on it suppresses CHANNEL pushes (handled by
+        // `current_room_channel_mention`), not the owner's personal
+        // notification.
         mention.noping
+            && !mention.is_channel()
             && (mention
                 .jid
                 .as_ref()
@@ -732,7 +762,19 @@ fn groupchat_mentions_owner(
     owner_occupant_id: &str,
 ) -> bool {
     let xep0513 = mentions.iter().any(|mention| {
+        // XEP-0513 §"Multi-User Chats Permissions" §304 hardening
+        // (adversarial review on PR #738): a `<mention/>` that ALSO
+        // carries `mentions='urn:xmpp:mentions:0#channel'` is a
+        // channel-scope payload, not a personal mention — even when
+        // it also carries `jid=`/`occupantid=` attributes. Without
+        // the `!mention.is_channel()` guard, a non-permitted sender
+        // could bypass the channel-broadcast gate by adding a
+        // matching `occupantid=`/`jid=` to a channel mention: the
+        // classifier would pick `PersonalMention` first (per-recipient
+        // match) and never run the channel-scope downgrade. Treat
+        // mixed-attribute mentions as channel-scope only.
         !mention.noping
+            && !mention.is_channel()
             && (mention
                 .jid
                 .as_ref()
@@ -742,11 +784,13 @@ fn groupchat_mentions_owner(
                     .as_deref()
                     .is_some_and(|mentioned| mentioned == owner_occupant_id))
     });
-    let owner_raw = owner.to_string();
     let xep0372 = extract_references_from_message(message)
         .into_iter()
         .any(|reference| {
-            reference.is_mention() && reference.bare_jid() == Some(owner_raw.as_str())
+            reference.is_mention()
+                && reference
+                    .bare_jid()
+                    .is_some_and(|mentioned| &mentioned == owner)
         });
     xep0513 || xep0372
 }
@@ -1214,6 +1258,74 @@ mod tests {
             NotificationClass::PersonalMention,
             "personal mention class must NOT be affected by the channel \
              broadcast gate — the gate covers `urn:xmpp:mentions:0#channel` only"
+        );
+    }
+
+    /// Adversarial review on PR #738: a non-permitted sender crafted
+    /// `<mention occupantid='target-occ' mentions='urn:xmpp:mentions:0#channel'/>`
+    /// would historically bypass the channel-broadcast gate by being
+    /// classified as `PersonalMention` (because the personal matcher
+    /// found the occupant-id match and didn't check the channel-scope
+    /// attribute). The fix in `groupchat_mentions_owner` filters out
+    /// mixed-attribute mentions so they ONLY flow through the channel
+    /// pipeline (and are subject to the permission gate). Lock the
+    /// behavior here.
+    #[test]
+    fn xep0513_mixed_attribute_mention_does_not_bypass_channel_gate() {
+        use crate::notification_outbox::NotificationClass;
+
+        let owner = bare("charlie@example.com");
+        let room = bare("team@muc.example.com");
+        let occupant_id = "room-stable-charlie";
+
+        // Craft a `<mention/>` that simultaneously carries
+        // `occupantid='charlie-occ'` AND `mentions='#channel'`. The
+        // attacker's intent: have charlie classify it as personal
+        // (bypassing the gate) while the room sees it as channel.
+        let mut mixed = waddle_xmpp::xep::ExplicitMention::occupant_id(occupant_id);
+        mixed.mentions = Some(waddle_xmpp::xep::CHANNEL_MENTION.to_string());
+        let msg = message_with_mention(mixed);
+        let mentions = parsed_mentions(&msg);
+
+        // Non-permitted sender (participant). With the fix, the
+        // channel-scope wins and the gate downgrades to NotifyAll.
+        let GroupchatNotificationClassDecision::Deliver(class) = groupchat_notification_class(
+            &mentions,
+            &msg,
+            &owner,
+            &room,
+            occupant_id,
+            /* is_live_occupant */ false,
+            /* sender_can_broadcast_channel_mention */ false,
+        );
+        assert_eq!(
+            class,
+            NotificationClass::NotifyAll,
+            "a `<mention occupantid='X' mentions='#channel'/>` from a non-\
+             permitted sender MUST NOT classify as PersonalMention — the \
+             channel-scope attribute overrides the personal targeting and \
+             the gate applies"
+        );
+
+        // Permitted sender (moderator). Channel-scope still wins, and
+        // the gate now classifies as ChannelMention — NOT
+        // PersonalMention.
+        let GroupchatNotificationClassDecision::Deliver(class) = groupchat_notification_class(
+            &mentions,
+            &msg,
+            &owner,
+            &room,
+            occupant_id,
+            /* is_live_occupant */ false,
+            /* sender_can_broadcast_channel_mention */ true,
+        );
+        assert_eq!(
+            class,
+            NotificationClass::ChannelMention,
+            "a `<mention occupantid='X' mentions='#channel'/>` from a \
+             permitted sender MUST classify as ChannelMention — the \
+             channel-scope attribute is authoritative regardless of any \
+             per-recipient targeting attributes"
         );
     }
 }

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
@@ -48,6 +48,7 @@ pub(super) async fn project_groupchat_inbox_event(input: ProjectGroupchatInboxEv
         is_durable_recipient,
         is_live_occupant,
         room_members_only,
+        sender_can_broadcast_channel_mention,
         &thread,
         dispatch_timestamp,
     );
@@ -109,6 +110,7 @@ fn groupchat_notification_recovery_item(
     is_durable_recipient: bool,
     is_live_occupant: bool,
     room_members_only: bool,
+    sender_can_broadcast_channel_mention: bool,
     thread: &Option<GroupchatThreadProjection>,
     dispatch_timestamp: i64,
 ) -> Option<waddle_xmpp::inbox::storage::GroupchatNotificationRecovery> {
@@ -127,6 +129,7 @@ fn groupchat_notification_recovery_item(
         sender_jid,
         is_live_occupant,
         room_members_only,
+        sender_can_broadcast_channel_mention,
         created_at_ms: dispatch_timestamp.saturating_mul(1_000),
     })
 }
@@ -561,15 +564,15 @@ pub(crate) async fn reconcile_groupchat_notification_candidates(
             recovery.key.archive_stanza_id.clone(),
             recovery.is_live_occupant,
             recovery.room_members_only,
-            // XEP-0513 §"Multi-User Chats Permissions": the recovery
-            // row does not persist the sender's role (would require
-            // a schema migration). Default to `false` (deny channel
-            // boost) on recovery — XEP-conformant conservative bias:
-            // §304 says receiving entities SHOULD ignore mentions
-            // when the sender's role is unknown / below threshold.
-            // The candidate still publishes; only the class is
-            // downgraded from `ChannelMention` → `NotifyAll`.
-            false,
+            // XEP-0513 §"Multi-User Chats Permissions" frozen at the
+            // original T0 dispatch — persisted on the recovery row so
+            // replay re-creates the same notification class. Defaulting
+            // to `false` here would silently downgrade every channel
+            // mention to `NotifyAll` and let the public-group `OnMention`
+            // XEP-0492 default suppress it at T1: a silent moderator-
+            // push outage after every server restart (adversarial review
+            // P1 on PR #738).
+            recovery.sender_can_broadcast_channel_mention,
         )
         .await;
         if outcome == GroupchatNotificationCandidateQueueOutcome::Completed

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
@@ -1123,6 +1123,66 @@ mod tests {
         );
     }
 
+    /// XEP-0513 §526 "Security Considerations" allows the server to
+    /// filter mentions per its own rules; this PR downgrades the push
+    /// CLASS, but the on-wire `<mention/>` payload MUST be delivered +
+    /// archived UNCHANGED. The class downgrade is a server-internal
+    /// push-decision detail; clients consuming MAM / live delivery /
+    /// inbox MUST still see the original `urn:xmpp:mentions:0#channel`
+    /// element so their own UI rendering can show "Alice tried to
+    /// channel-mention you" even though no push fired.
+    #[test]
+    fn xep0513_channel_mention_payload_is_preserved_when_class_is_downgraded() {
+        use waddle_xmpp::xep::{extract_explicit_mentions, has_explicit_mentions, CHANNEL_MENTION};
+
+        let owner = bare("charlie@example.com");
+        let room = bare("team@muc.example.com");
+        let occupant_id = "room-stable-charlie";
+
+        let mut channel_uri = waddle_xmpp::xep::ExplicitMention::channel();
+        channel_uri.uri = Some("xmpp:team@muc.example.com".to_string());
+        let msg = message_with_mention(channel_uri);
+
+        // Sanity: the message starts with the channel mention payload.
+        assert!(has_explicit_mentions(&msg));
+        let original_mentions = extract_explicit_mentions(&msg)
+            .expect("starts with mentions")
+            .mentions;
+        assert!(original_mentions
+            .iter()
+            .any(|mention| mention.mentions.as_deref() == Some(CHANNEL_MENTION)));
+
+        // Run the classifier with a non-permitted sender (the gate
+        // downgrades the class). The classifier returns the class
+        // only — it MUST NOT mutate the message payloads.
+        let mentions = parsed_mentions(&msg);
+        let _ = groupchat_notification_class(
+            &mentions,
+            &msg,
+            &owner,
+            &room,
+            occupant_id,
+            /* is_live_occupant */ false,
+            /* sender_can_broadcast_channel_mention */ false,
+        );
+
+        // Wire shape MUST be unchanged after classification.
+        assert!(
+            has_explicit_mentions(&msg),
+            "classifier MUST NOT strip the channel-mention payload on downgrade"
+        );
+        let after_mentions = extract_explicit_mentions(&msg)
+            .expect("mentions still present")
+            .mentions;
+        assert_eq!(
+            after_mentions, original_mentions,
+            "the `<mention mentions='urn:xmpp:mentions:0#channel'/>` payload \
+             MUST be delivered + archived unchanged when the push class is \
+             downgraded — XEP-0513 §526 allows filtering the push decision, \
+             not rewriting the stanza"
+        );
+    }
+
     /// Personal mentions are unaffected by the channel-broadcast
     /// permission. XEP-0513 §"Multi-User Chats Permissions" carries a
     /// separate `mentions#individual` field for individual-mention

--- a/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
@@ -278,21 +278,16 @@ async fn enqueue_xep0357_notification_candidate_for_message(
     archive_stanza_id: &waddle_xmpp_core::xep0359::StanzaId,
     original_message: &Message,
 ) -> NotificationCandidateQueueOutcome {
-    // XEP-0203 `<delay/>` filter (adversarial review on PR #738):
-    // an offline DM tagged with `<delay xmlns='urn:xmpp:delay'/>`
-    // is a historical replay (S2S buffered delivery, server-bridge
-    // replay) and MUST NOT produce a real-time push candidate.
-    // Mirrors the same filter on the groupchat candidate path.
-    if waddle_xmpp::xep::xep0203::has_delay(original_message) {
-        debug!(
-            recipient = %recipient,
-            sender = %sender,
-            "XEP-0357 DM notification candidate skipped: \
-             stanza carries XEP-0203 `<delay/>` (historical replay, \
-             not real-time)"
-        );
-        return NotificationCandidateQueueOutcome::Completed;
-    }
+    // XEP-0203 `<delay/>` filter NOT applied here (Copilot review on
+    // PR #738): see the matching comment in `groupchat_inbox.rs`'s
+    // `enqueue_groupchat_notification_candidate`. An earlier shape
+    // suppressed pushes for messages carrying any `<delay/>`, but
+    // that check is trivially spoofable — a sender can inject
+    // `<delay/>` into their own stanza to suppress the recipient's
+    // push. Until inbound `<delay/>` stripping lands at the C2S
+    // session boundary, the safer behavior is to push as live and
+    // accept the (currently theoretical) case where an S2S-buffered
+    // delivery generates a real-time push (Waddle has no S2S yet).
     // XEP-0513 mention bit is message-intrinsic and frozen at T0; T1
     // reads it back from the candidate row when running the XEP-0492
     // dispatch gate.

--- a/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
@@ -278,6 +278,21 @@ async fn enqueue_xep0357_notification_candidate_for_message(
     archive_stanza_id: &waddle_xmpp_core::xep0359::StanzaId,
     original_message: &Message,
 ) -> NotificationCandidateQueueOutcome {
+    // XEP-0203 `<delay/>` filter (adversarial review on PR #738):
+    // an offline DM tagged with `<delay xmlns='urn:xmpp:delay'/>`
+    // is a historical replay (S2S buffered delivery, server-bridge
+    // replay) and MUST NOT produce a real-time push candidate.
+    // Mirrors the same filter on the groupchat candidate path.
+    if waddle_xmpp::xep::xep0203::has_delay(original_message) {
+        debug!(
+            recipient = %recipient,
+            sender = %sender,
+            "XEP-0357 DM notification candidate skipped: \
+             stanza carries XEP-0203 `<delay/>` (historical replay, \
+             not real-time)"
+        );
+        return NotificationCandidateQueueOutcome::Completed;
+    }
     // XEP-0513 mention bit is message-intrinsic and frozen at T0; T1
     // reads it back from the candidate row when running the XEP-0492
     // dispatch gate.

--- a/server/crates/waddle-server/src/server/routes/interpret/room_dispatch.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_dispatch.rs
@@ -138,6 +138,7 @@ pub(super) async fn dispatch_to_room(
         occupant_id_secret: &state.deps.occupant_id_secret,
         sender_nickname_generation: snapshot.sender_nickname_generation.unwrap_or(0),
         project_sender_inbox: true,
+        synthetic_sender_authority: None,
         dispatch_timestamp,
     };
     let mut gate_working = prototype.clone();
@@ -279,6 +280,7 @@ pub(super) async fn dispatch_to_room(
         // archive write (Copilot review on PR #279).
         sender_nickname_generation: snapshot.sender_nickname_generation.unwrap_or(0),
         project_sender_inbox: true,
+        synthetic_sender_authority: None,
         dispatch_timestamp,
     };
     let mut working = prototype;

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
@@ -1307,6 +1307,7 @@ async fn groupchat_notification_recovery_retries_committed_inbox_projection() {
                 sender_jid,
                 is_live_occupant: false,
                 room_members_only: false,
+                sender_can_broadcast_channel_mention: false,
                 created_at_ms: crate::time::now_ms(),
             },
         )
@@ -1680,7 +1681,14 @@ async fn groupchat_active_channel_mention_does_not_expand_to_live_unaffiliated_o
         .ask(JoinWithAffiliation {
             sender_jid: alice_jid.clone(),
             nick: "alice".to_string(),
-            effective_affiliation: Affiliation::Member,
+            // XEP-0513 §"Multi-User Chats Permissions" §304: this test
+            // asserts that live-only-not-affiliated occupants don't get
+            // pushed for `<active/>` channel mentions. The sender's
+            // role MUST be Moderator-equivalent so the channel mention
+            // actually classifies as `ActiveChannelMention` — otherwise
+            // the assertion passes for the wrong reason (downgrade to
+            // `NotifyAll` + no durable recipient = empty jobs).
+            effective_affiliation: Affiliation::Admin,
             local_domain: "example.com".to_string(),
         })
         .await

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
@@ -1584,7 +1584,14 @@ async fn groupchat_active_channel_mention_pushes_live_occupants_only() {
         .ask(JoinWithAffiliation {
             sender_jid: alice_jid.clone(),
             nick: "alice".to_string(),
-            effective_affiliation: Affiliation::Member,
+            // XEP-0513 §"Multi-User Chats Permissions" §304: alice
+            // MUST hold the minimum-role-required (server default
+            // `mentions#channel = moderators`) to broadcast a channel
+            // mention. `Affiliation::Admin` derives `Role::Moderator`
+            // via `room_affiliations`, satisfying the gate. The point
+            // of this test is the `<active/>` recipient filter; the
+            // sender's role is fixture scaffolding.
+            effective_affiliation: Affiliation::Admin,
             local_domain: "example.com".to_string(),
         })
         .await
@@ -1768,7 +1775,12 @@ async fn groupchat_active_channel_mention_preserves_notify_all_for_non_live_alwa
         .ask(JoinWithAffiliation {
             sender_jid: alice_jid.clone(),
             nick: "alice".to_string(),
-            effective_affiliation: Affiliation::Member,
+            // XEP-0513 §"Multi-User Chats Permissions" §304: alice
+            // needs role >= moderator to broadcast a channel mention
+            // under the server's default `mentions#channel = moderators`
+            // policy. Test focus is the live-occupancy + Always
+            // members-only path; sender role is scaffolding.
+            effective_affiliation: Affiliation::Admin,
             local_domain: "example.com".to_string(),
         })
         .await

--- a/server/crates/waddle-xmpp-core/src/disco/info.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info.rs
@@ -516,8 +516,24 @@ pub fn muc_room_features(
         Feature::vcard(),
         Feature::occupant_id(),
         Feature::hats(),
-        Feature::explicit_mentions(),
-        Feature::channel_mentions(),
+        // XEP-0513 §292 + §303: advertising `urn:xmpp:mentions:0` and
+        // `urn:xmpp:mentions:0#channel` is binding — once advertised,
+        // the room's `<query xmlns='urn:xmpp:mentions:0'/>` IQ MUST
+        // return a form with `mentions#count` + `mentions#individual`
+        // (always required) and the `mentions#channel` field (if and
+        // only if `#channel` is advertised). PR #738 (slice 3a)
+        // enforces a hardcoded `mentions#channel = moderators` policy
+        // at T0 candidate classification but does NOT yet expose the
+        // §295 IQ surface. To preserve XEP conformance — and per
+        // CLAUDE.md "if Waddle advertises an official XEP feature...
+        // the wire shape and behavior MUST conform to that XEP
+        // exactly" — the advert is withdrawn until slice 3c lands
+        // the IQ get/set + per-room form. §292 allows
+        // non-advertisement while still applying server-internal
+        // filtering ("Mentions MAY be sent in rooms which do not
+        // have permissions set, and/or do not advertise support for
+        // them; it is up to receiving entities to determine how to
+        // handle mentions in rooms without configured permissions").
         Feature::muc_nonanonymous(),
     ];
 

--- a/server/crates/waddle-xmpp/src/inbox/storage.rs
+++ b/server/crates/waddle-xmpp/src/inbox/storage.rs
@@ -29,6 +29,14 @@ pub struct GroupchatNotificationRecovery {
     pub sender_jid: Jid,
     pub is_live_occupant: bool,
     pub room_members_only: bool,
+    /// XEP-0513 §"Multi-User Chats Permissions" §304: the frozen
+    /// permission snapshot taken at the original T0 dispatch. Persisted
+    /// so a recovery replay re-creates the same notification class the
+    /// original emission would have. Without it, recovery would
+    /// silently downgrade every channel mention to `NotifyAll`, which
+    /// the public-group XEP-0492 default then suppresses at T1 — a
+    /// silent moderator-push outage after every server restart.
+    pub sender_can_broadcast_channel_mention: bool,
     pub created_at_ms: i64,
 }
 
@@ -512,6 +520,7 @@ mod tests {
             sender_jid: "room@muc.example.com/alice".parse().unwrap(),
             is_live_occupant: true,
             room_members_only: false,
+            sender_can_broadcast_channel_mention: true,
             created_at_ms: 42,
         };
 

--- a/server/crates/waddle-xmpp/src/muc/room_affiliations.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_affiliations.rs
@@ -13,7 +13,18 @@ impl MucRoom {
     /// Set the affiliation for a JID.
     ///
     /// Returns the change if the affiliation actually changed.
-    /// Also updates any occupant with this JID.
+    /// Also updates any occupant with this JID, re-deriving their
+    /// XEP-0045 role from the new affiliation. The role MUST track
+    /// the affiliation here — XEP-0045 §5.1.3 says a server "will
+    /// change the user's role in any room they are currently in"
+    /// on an affiliation change, and several push-decision sites
+    /// (XEP-0513 §"Multi-User Chats Permissions" §304 channel-
+    /// broadcast gate, XEP-0045 §7.5 visitor-can-send gate) read
+    /// `Occupant.role` as the source of truth — without re-deriving
+    /// here, a demoted Owner / Admin would briefly retain
+    /// `Role::Moderator` until they cycle presence, silently
+    /// preserving their broadcast capabilities (adversarial review
+    /// P2 on PR #738).
     pub fn set_affiliation(
         &mut self,
         jid: BareJid,
@@ -22,9 +33,11 @@ impl MucRoom {
         let change = self.affiliation_list.set(jid.clone(), affiliation);
 
         if change.is_some() {
+            let role = self.derive_role_from_affiliation(affiliation);
             for occupant in self.occupants.values_mut() {
                 if occupant.real_jid.to_bare() == jid {
                     occupant.affiliation = affiliation;
+                    occupant.role = role;
                 }
             }
         }
@@ -174,5 +187,95 @@ impl MucRoom {
     /// Check if the room has at least one owner.
     pub fn has_owner(&self) -> bool {
         self.affiliation_list.has_owner()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::muc::room::RoomConfig;
+
+    fn bare(value: &str) -> BareJid {
+        value.parse().expect("valid bare JID")
+    }
+
+    fn full(value: &str) -> FullJid {
+        value.parse().expect("valid full JID")
+    }
+
+    /// XEP-0045 §5.1.3: changing a user's affiliation MUST also update
+    /// their per-session role in any room they are currently in.
+    /// Without this sync, push-decision gates that read `Occupant.role`
+    /// (XEP-0513 §"Multi-User Chats Permissions" §304 channel-broadcast
+    /// gate, XEP-0045 §7.5 visitor-can-send gate) would honor a stale
+    /// role from before the demotion — silently preserving the demoted
+    /// user's broadcast capability until they next rejoin (adversarial
+    /// review P2 on PR #738).
+    #[test]
+    fn set_affiliation_resyncs_occupant_role_on_demotion() {
+        let mut room = MucRoom::new(
+            bare("team@conf.example.com"),
+            "waddle-id".to_string(),
+            "channel-id".to_string(),
+            RoomConfig::default(),
+        );
+        let owner_bare = bare("alice@example.com");
+        room.affiliation_list
+            .set(owner_bare.clone(), Affiliation::Owner);
+        room.add_occupant_with_affiliation(
+            full("alice@example.com/web"),
+            "alice".to_string(),
+            None,
+        );
+
+        let alice = room.occupants.get("alice").expect("alice joined");
+        assert_eq!(alice.affiliation, Affiliation::Owner);
+        assert_eq!(alice.role, Role::Moderator);
+
+        // Demote to Member — role MUST track affiliation.
+        room.set_affiliation(owner_bare.clone(), Affiliation::Member);
+        let alice = room.occupants.get("alice").expect("still in room");
+        assert_eq!(alice.affiliation, Affiliation::Member);
+        assert_eq!(
+            alice.role,
+            Role::Participant,
+            "Role::Moderator MUST be re-derived to Role::Participant on \
+             Owner→Member demotion; a stale role would silently preserve \
+             channel-broadcast permission for a demoted user"
+        );
+
+        // Re-promote to Admin — role tracks back up.
+        room.set_affiliation(owner_bare, Affiliation::Admin);
+        let alice = room.occupants.get("alice").expect("still in room");
+        assert_eq!(alice.affiliation, Affiliation::Admin);
+        assert_eq!(alice.role, Role::Moderator);
+    }
+
+    /// Banning (Outcast) MUST drop `Role::None` per
+    /// `derive_role_from_affiliation`. The occupant entry remains in
+    /// the room map until the kick handler removes it; the role
+    /// downgrade here is the in-place demotion that gates further
+    /// sends — particularly the XEP-0513 channel-broadcast gate.
+    #[test]
+    fn set_affiliation_to_outcast_zeroes_role() {
+        let mut room = MucRoom::new(
+            bare("team@conf.example.com"),
+            "waddle-id".to_string(),
+            "channel-id".to_string(),
+            RoomConfig::default(),
+        );
+        let bob_bare = bare("bob@example.com");
+        room.affiliation_list
+            .set(bob_bare.clone(), Affiliation::Member);
+        room.add_occupant_with_affiliation(full("bob@example.com/desk"), "bob".to_string(), None);
+        assert_eq!(
+            room.occupants.get("bob").expect("bob joined").role,
+            Role::Participant
+        );
+
+        room.set_affiliation(bob_bare, Affiliation::Outcast);
+        let bob = room.occupants.get("bob").expect("still in occupant map");
+        assert_eq!(bob.affiliation, Affiliation::Outcast);
+        assert_eq!(bob.role, Role::None);
     }
 }

--- a/server/crates/waddle-xmpp/src/protocol/event/outbound.rs
+++ b/server/crates/waddle-xmpp/src/protocol/event/outbound.rs
@@ -279,6 +279,19 @@ pub enum OutboundEvent {
         /// (`private_group` vs `public_group`) without re-querying room
         /// config after the dispatch snapshot.
         room_members_only: bool,
+        /// XEP-0513 §"Multi-User Chats Permissions": typed permission
+        /// snapshot of whether the sender's frozen XEP-0045 role permits
+        /// broadcasting an `urn:xmpp:mentions:0#channel` mention for push
+        /// purposes. Frozen at room-dispatch time from the sender's
+        /// `OccupantSnapshot.role` so the T0 candidate classifier can
+        /// downgrade a non-permitted channel mention to `NotifyAll`
+        /// without re-querying room/occupant state. The mention is still
+        /// delivered + archived unchanged; only the push class changes.
+        ///
+        /// Default server policy is `moderators` (XEP-0513 example value)
+        /// — `role >= Role::Moderator`. The per-room override IQ surface
+        /// is a follow-up slice.
+        sender_can_broadcast_channel_mention: bool,
         /// Optional thread metadata for the thread-level row.
         thread: Option<GroupchatThreadProjection>,
         /// Single dispatch timestamp (Unix epoch seconds) shared

--- a/server/crates/waddle-xmpp/src/protocol/room/archive.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/archive.rs
@@ -150,6 +150,7 @@ mod tests {
             occupant_id_secret: &secret,
             sender_nickname_generation: 0,
             project_sender_inbox: true,
+            synthetic_sender_authority: None,
             dispatch_timestamp: 0,
         };
         match MucArchiveHandler.handle(msg, &ctx) {

--- a/server/crates/waddle-xmpp/src/protocol/room/canonicalize.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/canonicalize.rs
@@ -200,6 +200,7 @@ mod tests {
             occupant_id_secret: &secret,
             sender_nickname_generation: 0,
             project_sender_inbox: true,
+            synthetic_sender_authority: None,
             dispatch_timestamp: 0,
         };
         match MucCanonicalizeHandler.handle(msg, &ctx) {

--- a/server/crates/waddle-xmpp/src/protocol/room/context.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/context.rs
@@ -125,6 +125,18 @@ pub struct RoomContext<'a> {
     /// sends can disable this while still using the sender snapshot
     /// for MUC canonicalization.
     pub project_sender_inbox: bool,
+    /// XEP-0513 §"Multi-User Chats Permissions" §304 + adversarial
+    /// review on PR #738: typed authorization for a synthetic sender
+    /// whose trust is upstream of the MUC role lattice (extension
+    /// bots, forum-action system messages, server-authored
+    /// announcements). Carrying the authority as a dedicated typed
+    /// field — separate from `project_sender_inbox` — means a
+    /// future caller cannot accidentally bypass the channel-mention
+    /// permission gate by setting the inbox-projection flag.
+    /// `None` means "subject to the standard role/affiliation gate";
+    /// `Some(SyntheticSenderAuthority::ServerAuthored)` is the
+    /// explicit, audited bypass.
+    pub synthetic_sender_authority: Option<SyntheticSenderAuthority>,
     /// Single dispatch timestamp (Unix epoch seconds) shared across
     /// every groupchat inbox
     /// [`super::super::event::OutboundEvent::ProjectGroupchatInbox`]
@@ -133,6 +145,24 @@ pub struct RoomContext<'a> {
     /// don't drift across a second-boundary (Copilot review on
     /// PR #279).
     pub dispatch_timestamp: i64,
+}
+
+/// Typed authority for a synthetic (server-authored) sender that
+/// participates in a [`RoomContext`] without being a real MUC occupant.
+///
+/// Used by push-decision gates that would otherwise deny a sender with
+/// no [`OccupantSnapshot`]. Each variant documents the specific
+/// upstream trust source that justified the authority.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyntheticSenderAuthority {
+    /// Extension bot or other server-side dispatcher whose payloads
+    /// are wholly server-authored and pre-validated upstream. Treated
+    /// as having owner-equivalent broadcast authority for XEP-0513
+    /// channel mentions and similar role-gated push decisions. Must
+    /// only be set by the bot dispatch entry point or another path
+    /// that has already established upstream trust — never by user-
+    /// controlled flows.
+    ServerAuthored,
 }
 
 impl<'a> RoomContext<'a> {

--- a/server/crates/waddle-xmpp/src/protocol/room/dispatch.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/dispatch.rs
@@ -130,6 +130,7 @@ mod tests {
             occupant_id_secret,
             sender_nickname_generation: 0,
             project_sender_inbox: true,
+            synthetic_sender_authority: None,
             dispatch_timestamp: 0,
         }
     }

--- a/server/crates/waddle-xmpp/src/protocol/room/displayed_marker.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/displayed_marker.rs
@@ -114,6 +114,7 @@ mod tests {
             occupant_id_secret: &secret,
             sender_nickname_generation: 0,
             project_sender_inbox: true,
+            synthetic_sender_authority: None,
             dispatch_timestamp: 0,
         };
         match MucDisplayedMarkerHandler.handle(msg, &ctx) {

--- a/server/crates/waddle-xmpp/src/protocol/room/inbox.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/inbox.rs
@@ -550,7 +550,20 @@ mod tests {
         mod_occ.role = Role::Moderator;
         let participant_occ = occ(participant.clone(), "bob");
         let occupants = vec![mod_occ, participant_occ];
-        let durable_recipients = vec![bob_bare(), bare("dave@example.com")];
+        // Durable recipients exclude both senders so the per-dispatch
+        // event count is symmetric: every dispatch emits one sender
+        // row + every durable recipient row. If either sender were in
+        // `durable_recipients`, the inbox handler would collapse them
+        // into a single row via `seen.insert`, breaking the
+        // count-equals-expected assertion below.
+        let durable_recipients = vec![bare("dave@example.com"), bare("eve@example.com")];
+
+        // One sender row + every durable recipient row = three
+        // projections. Asserting the count guards against a future
+        // bug that silently drops a recipient row while leaving the
+        // survivors uniform — that would pass an `.all()` check
+        // vacuously.
+        let expected_count = 1 + durable_recipients.len();
 
         let mut msg = groupchat(&room, &moderator, "hello everyone");
         let events = run_with_durable(
@@ -572,6 +585,12 @@ mod tests {
                 _ => None,
             })
             .collect();
+        assert_eq!(
+            permissions.len(),
+            expected_count,
+            "expected one sender row + every durable recipient row to emit \
+             a ProjectGroupchatInbox event"
+        );
         assert!(
             permissions.iter().all(|granted| *granted),
             "moderator sender must produce a permission bool of `true` on \
@@ -599,15 +618,17 @@ mod tests {
                 _ => None,
             })
             .collect();
+        assert_eq!(
+            permissions.len(),
+            expected_count,
+            "participant sender's dispatch must emit the same shape: one \
+             sender row + every durable recipient row"
+        );
         assert!(
             permissions.iter().all(|granted| !*granted),
             "participant sender must produce a permission bool of `false` \
              on every emitted ProjectGroupchatInbox event"
         );
-    }
-
-    fn bob_bare() -> BareJid {
-        bare("bob@example.com")
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/protocol/room/inbox.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/inbox.rs
@@ -21,25 +21,29 @@ use super::super::event::{GroupchatThreadProjection, OutboundEvent};
 use super::context::{RoomContext, SyntheticSenderAuthority};
 use super::traits::{RoomHandler, RoomHandlerOutcome};
 use crate::inbox::runtime::{preview_text, should_project_message};
-use crate::types::{Affiliation, Role};
+use crate::types::Role;
 use crate::xep::xep0508::{extract_forum_action, ForumAction};
 use jid::BareJid;
 use std::collections::HashSet;
 use waddle_xmpp_core::xep0201::thread_info_from_message;
 use xmpp_parsers::message::Message;
 
-/// XEP-0513 §"Multi-User Chats Permissions": server-internal default
-/// for `mentions#channel` is `moderators` — senders may broadcast
-/// `urn:xmpp:mentions:0#channel` for push purposes if either:
+/// XEP-0513 §"Multi-User Chats Permissions" §304: server-internal
+/// default for `mentions#channel` is `moderators` — senders may
+/// broadcast `urn:xmpp:mentions:0#channel` for push purposes only
+/// when their XEP-0045 role is `Role::Moderator`.
 ///
-/// - their XEP-0045 role is `Role::Moderator` (the canonical "may use
-///   moderator powers" axis), OR
-/// - their durable affiliation is `Affiliation::Admin` /
-///   `Affiliation::Owner` — affiliation is the persistence-of-trust
-///   axis; an Owner/Admin who hasn't yet completed a presence cycle
-///   (`room_affiliations` derives Moderator role from those
-///   affiliations at join time, but the snapshot may briefly trail)
-///   must not be silently denied (adversarial review P2 on PR #738).
+/// §304 defines the gate purely in terms of XEP-0045 *role* ("the
+/// minimum role required by the room"). An earlier shape of this
+/// gate also accepted `affiliation >= Affiliation::Admin` as a
+/// fallback for an Owner/Admin whose presence cycle hadn't yet
+/// promoted the role — but `MucRoom::set_affiliation` now re-derives
+/// the occupant's role on every affiliation change (Owner/Admin →
+/// Moderator), so the trail window the fallback covered is closed.
+/// The strict role-only reading is therefore both spec-conformant
+/// and behaviorally equivalent to the disjunction. Removing the
+/// affiliation arm avoids the §304 over-permissiveness called out
+/// in the greptile P2 review on PR #738.
 ///
 /// Synthetic server-authored sends are permitted via the explicit
 /// typed [`SyntheticSenderAuthority::ServerAuthored`] marker on the
@@ -49,8 +53,7 @@ use xmpp_parsers::message::Message;
 /// "skip the sender's own inbox row" (a projection concern) with
 /// "permitted to broadcast" (a policy decision). The typed marker
 /// keeps the two concerns separate so a future caller can't bypass
-/// the gate by accidentally setting the projection flag (adversarial
-/// review on PR #738).
+/// the gate by accidentally setting the projection flag.
 ///
 /// Returning `false` when the sender has no occupancy snapshot and
 /// no synthetic authority is the strict reading of XEP-0045 §7.4
@@ -64,9 +67,8 @@ fn sender_may_broadcast_channel_mention(ctx: &RoomContext<'_>) -> bool {
     ) {
         return true;
     }
-    ctx.sender_snapshot().is_some_and(|sender| {
-        sender.role >= Role::Moderator || sender.affiliation >= Affiliation::Admin
-    })
+    ctx.sender_snapshot()
+        .is_some_and(|sender| sender.role >= Role::Moderator)
 }
 
 /// Per-occupant inbox projection handler for the room handler chain.
@@ -396,13 +398,20 @@ mod tests {
         );
     }
 
-    /// XEP-0513 §"Multi-User Chats Permissions" §304: the typed
-    /// frozen permission snapshot is taken at room-dispatch time, NOT
-    /// later. This test pins the helper: only senders whose frozen
-    /// occupancy role is `Role::Moderator` may broadcast a channel
-    /// mention; participants and visitors get `false`. The class
-    /// downgrade itself is exercised in the `groupchat_inbox.rs`
-    /// classifier tests — this test only locks the snapshot helper.
+    /// XEP-0513 §"Multi-User Chats Permissions" §304: the gate is
+    /// purely role-based — only senders whose frozen XEP-0045 role
+    /// is `Role::Moderator` may broadcast a channel mention. The
+    /// class downgrade itself is exercised in the `groupchat_inbox.rs`
+    /// classifier tests; this test locks the snapshot helper across
+    /// the full role lattice.
+    ///
+    /// Affiliation is NOT a fallback axis: `MucRoom::set_affiliation`
+    /// re-derives the occupant's role on every affiliation change, so
+    /// an `Affiliation::Admin/Owner` with `Role::Participant` is an
+    /// impossible state in well-behaved code. The "impossible state"
+    /// row is included anyway to lock the strict §304 reading — if
+    /// a future bug ever produces that state, the gate denies it
+    /// (greptile P2 review on PR #738).
     #[test]
     fn xep0513_sender_may_broadcast_channel_mention_requires_moderator() {
         let room = bare("team@conf.example.com");
@@ -410,8 +419,7 @@ mod tests {
         let participant = full("bob@example.com/desk");
         let visitor = full("carol@example.com/phone");
         let none_role = full("dave@example.com/web");
-        let admin_no_role = full("erin@example.com/web");
-        let owner_no_role = full("frank@example.com/web");
+        let admin_stale_role = full("erin@example.com/web");
         let outsider = full("eve@example.com/cli");
 
         let mut moderator_occ = occ(moderator.clone(), "alice");
@@ -422,23 +430,21 @@ mod tests {
         visitor_occ.role = Role::Visitor;
         let mut none_role_occ = occ(none_role.clone(), "dave");
         none_role_occ.role = Role::None;
-        // Owner/Admin affiliation but Participant role: simulates a
-        // privileged user whose presence cycle hasn't promoted the role
-        // yet. Server-internal trust MUST follow the durable affiliation
-        // (adversarial review P2 on PR #738).
-        let mut admin_no_role_occ = occ(admin_no_role.clone(), "erin");
-        admin_no_role_occ.role = Role::Participant;
-        admin_no_role_occ.affiliation = Affiliation::Admin;
-        let mut owner_no_role_occ = occ(owner_no_role.clone(), "frank");
-        owner_no_role_occ.role = Role::Participant;
-        owner_no_role_occ.affiliation = Affiliation::Owner;
+        // "Impossible state" defensive fixture: Affiliation::Admin
+        // with Role::Participant. `MucRoom::set_affiliation` now
+        // re-derives the role on every affiliation change, so this
+        // pairing should never reach the gate in practice. The §304
+        // strict reading still denies it — affiliation is not a
+        // fallback authorization axis (greptile P2 on PR #738).
+        let mut admin_stale_role_occ = occ(admin_stale_role.clone(), "erin");
+        admin_stale_role_occ.role = Role::Participant;
+        admin_stale_role_occ.affiliation = crate::types::Affiliation::Admin;
         let occupants = vec![
             moderator_occ,
             participant_occ,
             visitor_occ,
             none_role_occ,
-            admin_no_role_occ,
-            owner_no_role_occ,
+            admin_stale_role_occ,
         ];
 
         let id_gen = FixedIdGenerator("ignored".to_string());
@@ -447,21 +453,10 @@ mod tests {
         for (sender, expected, label) in [
             (&moderator, true, "Role::Moderator MUST be permitted"),
             (
-                &admin_no_role,
-                true,
-                "Affiliation::Admin MUST be permitted regardless of role — \
-                 durable affiliation is the source of trust",
-            ),
-            (
-                &owner_no_role,
-                true,
-                "Affiliation::Owner MUST be permitted regardless of role",
-            ),
-            (
                 &participant,
                 false,
-                "Role::Participant + Affiliation::Member MUST NOT be \
-                 permitted — XEP-0513 §304 default `mentions#channel = moderators`",
+                "Role::Participant MUST NOT be permitted — XEP-0513 §304 \
+                 default `mentions#channel = moderators`",
             ),
             (&visitor, false, "Role::Visitor MUST NOT be permitted"),
             (
@@ -469,6 +464,15 @@ mod tests {
                 false,
                 "Role::None MUST NOT be permitted (defensive: not-in-room \
                  role projection)",
+            ),
+            (
+                &admin_stale_role,
+                false,
+                "Affiliation::Admin with stale Role::Participant MUST be \
+                 denied — XEP-0513 §304 is role-based, not affiliation-based. \
+                 In well-behaved code this state is unreachable because \
+                 `set_affiliation` re-derives role; the deny is defensive \
+                 lock-in against regression",
             ),
             // Sender outside the occupancy snapshot (XEP-0045 §7.4
             // gate would already reject this before the inbox handler

--- a/server/crates/waddle-xmpp/src/protocol/room/inbox.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/inbox.rs
@@ -21,11 +21,25 @@ use super::super::event::{GroupchatThreadProjection, OutboundEvent};
 use super::context::RoomContext;
 use super::traits::{RoomHandler, RoomHandlerOutcome};
 use crate::inbox::runtime::{preview_text, should_project_message};
+use crate::types::Role;
 use crate::xep::xep0508::{extract_forum_action, ForumAction};
 use jid::BareJid;
 use std::collections::HashSet;
 use waddle_xmpp_core::xep0201::thread_info_from_message;
 use xmpp_parsers::message::Message;
+
+/// XEP-0513 §"Multi-User Chats Permissions": server-internal default
+/// for `mentions#channel` is `moderators` — only senders with role
+/// `Role::Moderator` may broadcast `urn:xmpp:mentions:0#channel` for
+/// push purposes. Returning `false` when the sender has no occupancy
+/// snapshot is the strict reading of XEP-0045 §7.4 (only joined
+/// occupants may message the room) combined with XEP-0513 §"Multi-User
+/// Chats Permissions" (receiving entities SHOULD ignore mentions from
+/// senders below the minimum role).
+fn sender_may_broadcast_channel_mention(ctx: &RoomContext<'_>) -> bool {
+    ctx.sender_snapshot()
+        .is_some_and(|sender| sender.role >= Role::Moderator)
+}
 
 /// Per-occupant inbox projection handler for the room handler chain.
 #[derive(Debug, Default, Clone, Copy)]
@@ -48,6 +62,13 @@ impl RoomHandler for MucInboxHandler {
             .collect();
         let mut events = Vec::with_capacity(1 + ctx.durable_recipient_bare_jids.len());
         let sender_bare = ctx.sender_full.to_bare();
+        // XEP-0513 §"Multi-User Chats Permissions": freeze the sender's
+        // permission to broadcast `urn:xmpp:mentions:0#channel` for push
+        // purposes at dispatch time, before the per-recipient fan-out.
+        // Same shape as `room_members_only`: one typed bool snapshotted
+        // here, read by the T0 candidate classifier; never re-derived
+        // per recipient.
+        let sender_can_broadcast_channel_mention = sender_may_broadcast_channel_mention(ctx);
         // Always project the sender's own row (no unread bump). The
         // legacy code did this independent of whether the sender was
         // also enumerated as an occupant, and this matches RFC
@@ -65,6 +86,7 @@ impl RoomHandler for MucInboxHandler {
                 is_durable_recipient: false,
                 is_live_occupant: true,
                 room_members_only: ctx.room_members_only,
+                sender_can_broadcast_channel_mention,
                 thread: thread.clone(),
                 dispatch_timestamp: ctx.dispatch_timestamp,
             });
@@ -81,6 +103,7 @@ impl RoomHandler for MucInboxHandler {
                 is_durable_recipient: true,
                 is_live_occupant: live_recipient_bares.contains(bare),
                 room_members_only: ctx.room_members_only,
+                sender_can_broadcast_channel_mention,
                 thread: thread.clone(),
                 dispatch_timestamp: ctx.dispatch_timestamp,
             });
@@ -342,6 +365,143 @@ mod tests {
                 .any(|(owner, _, _, _, _)| owner == "dave@example.com"),
             "live occupants outside the durable affiliation set must not get inbox/push projection"
         );
+    }
+
+    /// XEP-0513 §"Multi-User Chats Permissions" §304: the typed
+    /// frozen permission snapshot is taken at room-dispatch time, NOT
+    /// later. This test pins the helper: only senders whose frozen
+    /// occupancy role is `Role::Moderator` may broadcast a channel
+    /// mention; participants and visitors get `false`. The class
+    /// downgrade itself is exercised in the `groupchat_inbox.rs`
+    /// classifier tests — this test only locks the snapshot helper.
+    #[test]
+    fn xep0513_sender_may_broadcast_channel_mention_requires_moderator() {
+        let room = bare("team@conf.example.com");
+        let moderator = full("alice@example.com/web");
+        let participant = full("bob@example.com/desk");
+        let outsider = full("eve@example.com/cli");
+
+        let mut moderator_occ = occ(moderator.clone(), "alice");
+        moderator_occ.role = Role::Moderator;
+        let mut participant_occ = occ(participant.clone(), "bob");
+        participant_occ.role = Role::Participant;
+        let occupants = vec![moderator_occ, participant_occ];
+
+        let id_gen = FixedIdGenerator("ignored".to_string());
+        let secret = OccupantIdSecret::for_testing(b"test-secret".to_vec());
+
+        for (sender, expected, label) in [
+            (&moderator, true, "Role::Moderator MUST be permitted"),
+            (
+                &participant,
+                false,
+                "Role::Participant MUST NOT be permitted — XEP-0513 §304 \
+                 default policy is `mentions#channel = moderators`",
+            ),
+            // Sender outside the occupancy snapshot (XEP-0045 §7.4
+            // gate would already reject this before the inbox handler
+            // runs, but the helper MUST still deny defensively).
+            (
+                &outsider,
+                false,
+                "absent occupancy snapshot MUST deny channel broadcast",
+            ),
+        ] {
+            let ctx = RoomContext {
+                room: &room,
+                sender_full: sender,
+                occupants: &occupants,
+                durable_recipient_bare_jids: &[],
+                managed_room_forbidden: false,
+                room_moderated: false,
+                room_members_only: false,
+                pin_permission: crate::muc::PinPermission::default(),
+                id_gen: &id_gen,
+                occupant_id_secret: &secret,
+                sender_nickname_generation: 0,
+                project_sender_inbox: true,
+                dispatch_timestamp: 0,
+            };
+            assert_eq!(
+                sender_may_broadcast_channel_mention(&ctx),
+                expected,
+                "{label}"
+            );
+        }
+    }
+
+    /// Lock-in: the typed `sender_can_broadcast_channel_mention` field
+    /// flows from the frozen sender role to EVERY emitted
+    /// `ProjectGroupchatInbox` event in a single dispatch (sender row
+    /// plus every durable recipient row). This is the same snapshot
+    /// invariant as `room_members_only` (Q5 frozen-snapshot semantic).
+    #[test]
+    fn xep0513_channel_permission_is_frozen_per_dispatch_across_all_recipients() {
+        let room = bare("team@conf.example.com");
+        let moderator = full("alice@example.com/web");
+        let participant = full("bob@example.com/desk");
+        let mut mod_occ = occ(moderator.clone(), "alice");
+        mod_occ.role = Role::Moderator;
+        let participant_occ = occ(participant.clone(), "bob");
+        let occupants = vec![mod_occ, participant_occ];
+        let durable_recipients = vec![bob_bare(), bare("dave@example.com")];
+
+        let mut msg = groupchat(&room, &moderator, "hello everyone");
+        let events = run_with_durable(
+            &room,
+            &moderator,
+            &occupants,
+            &durable_recipients,
+            false,
+            &mut msg,
+        );
+
+        let permissions: Vec<bool> = events
+            .iter()
+            .filter_map(|event| match event {
+                OutboundEvent::ProjectGroupchatInbox {
+                    sender_can_broadcast_channel_mention,
+                    ..
+                } => Some(*sender_can_broadcast_channel_mention),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            permissions.iter().all(|granted| *granted),
+            "moderator sender must produce a permission bool of `true` on \
+             every emitted ProjectGroupchatInbox event — frozen snapshot \
+             must not vary per recipient"
+        );
+
+        // Same dispatch with a participant sender → `false` everywhere.
+        let mut msg = groupchat(&room, &participant, "another message");
+        let events = run_with_durable(
+            &room,
+            &participant,
+            &occupants,
+            &durable_recipients,
+            false,
+            &mut msg,
+        );
+        let permissions: Vec<bool> = events
+            .iter()
+            .filter_map(|event| match event {
+                OutboundEvent::ProjectGroupchatInbox {
+                    sender_can_broadcast_channel_mention,
+                    ..
+                } => Some(*sender_can_broadcast_channel_mention),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            permissions.iter().all(|granted| !*granted),
+            "participant sender must produce a permission bool of `false` \
+             on every emitted ProjectGroupchatInbox event"
+        );
+    }
+
+    fn bob_bare() -> BareJid {
+        bare("bob@example.com")
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/protocol/room/inbox.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/inbox.rs
@@ -21,7 +21,7 @@ use super::super::event::{GroupchatThreadProjection, OutboundEvent};
 use super::context::RoomContext;
 use super::traits::{RoomHandler, RoomHandlerOutcome};
 use crate::inbox::runtime::{preview_text, should_project_message};
-use crate::types::Role;
+use crate::types::{Affiliation, Role};
 use crate::xep::xep0508::{extract_forum_action, ForumAction};
 use jid::BareJid;
 use std::collections::HashSet;
@@ -29,16 +29,36 @@ use waddle_xmpp_core::xep0201::thread_info_from_message;
 use xmpp_parsers::message::Message;
 
 /// XEP-0513 §"Multi-User Chats Permissions": server-internal default
-/// for `mentions#channel` is `moderators` — only senders with role
-/// `Role::Moderator` may broadcast `urn:xmpp:mentions:0#channel` for
-/// push purposes. Returning `false` when the sender has no occupancy
-/// snapshot is the strict reading of XEP-0045 §7.4 (only joined
-/// occupants may message the room) combined with XEP-0513 §"Multi-User
-/// Chats Permissions" (receiving entities SHOULD ignore mentions from
-/// senders below the minimum role).
+/// for `mentions#channel` is `moderators` — senders may broadcast
+/// `urn:xmpp:mentions:0#channel` for push purposes if either:
+///
+/// - their XEP-0045 role is `Role::Moderator` (the canonical "may use
+///   moderator powers" axis), OR
+/// - their durable affiliation is `Affiliation::Admin` /
+///   `Affiliation::Owner` — affiliation is the persistence-of-trust
+///   axis; an Owner/Admin who hasn't yet completed a presence cycle
+///   (`room_affiliations` derives Moderator role from those
+///   affiliations at join time, but the snapshot may briefly trail)
+///   must not be silently denied (adversarial review P2 on PR #738).
+///
+/// Server-authored synthetic sends (`!ctx.project_sender_inbox`) bypass
+/// the gate entirely: those are extension bots / system messages whose
+/// trust is upstream of the MUC role lattice. Denying them would
+/// silently neuter announcements-room broadcasts and forum-action
+/// notifications.
+///
+/// Returning `false` when the sender has no occupancy snapshot is the
+/// strict reading of XEP-0045 §7.4 (only joined occupants may message
+/// the room) combined with XEP-0513 §"Multi-User Chats Permissions"
+/// (receiving entities SHOULD ignore mentions from senders below the
+/// minimum role).
 fn sender_may_broadcast_channel_mention(ctx: &RoomContext<'_>) -> bool {
-    ctx.sender_snapshot()
-        .is_some_and(|sender| sender.role >= Role::Moderator)
+    if !ctx.project_sender_inbox {
+        return true;
+    }
+    ctx.sender_snapshot().is_some_and(|sender| {
+        sender.role >= Role::Moderator || sender.affiliation >= Affiliation::Admin
+    })
 }
 
 /// Per-occupant inbox projection handler for the room handler chain.
@@ -379,13 +399,38 @@ mod tests {
         let room = bare("team@conf.example.com");
         let moderator = full("alice@example.com/web");
         let participant = full("bob@example.com/desk");
+        let visitor = full("carol@example.com/phone");
+        let none_role = full("dave@example.com/web");
+        let admin_no_role = full("erin@example.com/web");
+        let owner_no_role = full("frank@example.com/web");
         let outsider = full("eve@example.com/cli");
 
         let mut moderator_occ = occ(moderator.clone(), "alice");
         moderator_occ.role = Role::Moderator;
         let mut participant_occ = occ(participant.clone(), "bob");
         participant_occ.role = Role::Participant;
-        let occupants = vec![moderator_occ, participant_occ];
+        let mut visitor_occ = occ(visitor.clone(), "carol");
+        visitor_occ.role = Role::Visitor;
+        let mut none_role_occ = occ(none_role.clone(), "dave");
+        none_role_occ.role = Role::None;
+        // Owner/Admin affiliation but Participant role: simulates a
+        // privileged user whose presence cycle hasn't promoted the role
+        // yet. Server-internal trust MUST follow the durable affiliation
+        // (adversarial review P2 on PR #738).
+        let mut admin_no_role_occ = occ(admin_no_role.clone(), "erin");
+        admin_no_role_occ.role = Role::Participant;
+        admin_no_role_occ.affiliation = Affiliation::Admin;
+        let mut owner_no_role_occ = occ(owner_no_role.clone(), "frank");
+        owner_no_role_occ.role = Role::Participant;
+        owner_no_role_occ.affiliation = Affiliation::Owner;
+        let occupants = vec![
+            moderator_occ,
+            participant_occ,
+            visitor_occ,
+            none_role_occ,
+            admin_no_role_occ,
+            owner_no_role_occ,
+        ];
 
         let id_gen = FixedIdGenerator("ignored".to_string());
         let secret = OccupantIdSecret::for_testing(b"test-secret".to_vec());
@@ -393,10 +438,28 @@ mod tests {
         for (sender, expected, label) in [
             (&moderator, true, "Role::Moderator MUST be permitted"),
             (
+                &admin_no_role,
+                true,
+                "Affiliation::Admin MUST be permitted regardless of role — \
+                 durable affiliation is the source of trust",
+            ),
+            (
+                &owner_no_role,
+                true,
+                "Affiliation::Owner MUST be permitted regardless of role",
+            ),
+            (
                 &participant,
                 false,
-                "Role::Participant MUST NOT be permitted — XEP-0513 §304 \
-                 default policy is `mentions#channel = moderators`",
+                "Role::Participant + Affiliation::Member MUST NOT be \
+                 permitted — XEP-0513 §304 default `mentions#channel = moderators`",
+            ),
+            (&visitor, false, "Role::Visitor MUST NOT be permitted"),
+            (
+                &none_role,
+                false,
+                "Role::None MUST NOT be permitted (defensive: not-in-room \
+                 role projection)",
             ),
             // Sender outside the occupancy snapshot (XEP-0045 §7.4
             // gate would already reject this before the inbox handler
@@ -428,6 +491,49 @@ mod tests {
                 "{label}"
             );
         }
+    }
+
+    /// Server-authored synthetic sends bypass the XEP-0513 channel-
+    /// broadcast gate entirely: announcements bots, forum-action system
+    /// messages, etc. The trust on those sends is upstream of the MUC
+    /// role lattice — denying them would silently neuter legitimate
+    /// broadcasts (adversarial review P2 on PR #738).
+    #[test]
+    fn xep0513_synthetic_sender_bypasses_channel_broadcast_gate() {
+        let room = bare("team@conf.example.com");
+        let bot = full("team@conf.example.com/announcements-bot");
+        let bot_occ = {
+            // Synthetic bots typically aren't in the occupancy snapshot
+            // at all — `project_sender_inbox: false` indicates the
+            // sender is server-authored and not a real occupant.
+            let mut occ = occ(bot.clone(), "announcements-bot");
+            occ.role = Role::Participant;
+            occ
+        };
+        let occupants = vec![bot_occ];
+
+        let id_gen = FixedIdGenerator("ignored".to_string());
+        let secret = OccupantIdSecret::for_testing(b"test-secret".to_vec());
+        let ctx = RoomContext {
+            room: &room,
+            sender_full: &bot,
+            occupants: &occupants,
+            durable_recipient_bare_jids: &[],
+            managed_room_forbidden: false,
+            room_moderated: false,
+            room_members_only: false,
+            pin_permission: crate::muc::PinPermission::default(),
+            id_gen: &id_gen,
+            occupant_id_secret: &secret,
+            sender_nickname_generation: 0,
+            project_sender_inbox: false,
+            dispatch_timestamp: 0,
+        };
+        assert!(
+            sender_may_broadcast_channel_mention(&ctx),
+            "synthetic server-authored sends (project_sender_inbox=false) \
+             MUST bypass the channel-broadcast gate regardless of role"
+        );
     }
 
     /// Lock-in: the typed `sender_can_broadcast_channel_mention` field

--- a/server/crates/waddle-xmpp/src/protocol/room/inbox.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/inbox.rs
@@ -18,7 +18,7 @@
 //! durable recipients get `is_recipient = true`.
 
 use super::super::event::{GroupchatThreadProjection, OutboundEvent};
-use super::context::RoomContext;
+use super::context::{RoomContext, SyntheticSenderAuthority};
 use super::traits::{RoomHandler, RoomHandlerOutcome};
 use crate::inbox::runtime::{preview_text, should_project_message};
 use crate::types::{Affiliation, Role};
@@ -41,19 +41,27 @@ use xmpp_parsers::message::Message;
 ///   affiliations at join time, but the snapshot may briefly trail)
 ///   must not be silently denied (adversarial review P2 on PR #738).
 ///
-/// Server-authored synthetic sends (`!ctx.project_sender_inbox`) bypass
-/// the gate entirely: those are extension bots / system messages whose
-/// trust is upstream of the MUC role lattice. Denying them would
-/// silently neuter announcements-room broadcasts and forum-action
-/// notifications.
+/// Synthetic server-authored sends are permitted via the explicit
+/// typed [`SyntheticSenderAuthority::ServerAuthored`] marker on the
+/// `RoomContext` (set only by the bot-dispatch entry point and
+/// similar pre-trust-validated paths). Prior versions of this gate
+/// coupled the bypass to `project_sender_inbox` — that conflated
+/// "skip the sender's own inbox row" (a projection concern) with
+/// "permitted to broadcast" (a policy decision). The typed marker
+/// keeps the two concerns separate so a future caller can't bypass
+/// the gate by accidentally setting the projection flag (adversarial
+/// review on PR #738).
 ///
-/// Returning `false` when the sender has no occupancy snapshot is the
-/// strict reading of XEP-0045 §7.4 (only joined occupants may message
-/// the room) combined with XEP-0513 §"Multi-User Chats Permissions"
-/// (receiving entities SHOULD ignore mentions from senders below the
-/// minimum role).
+/// Returning `false` when the sender has no occupancy snapshot and
+/// no synthetic authority is the strict reading of XEP-0045 §7.4
+/// (only joined occupants may message the room) combined with
+/// XEP-0513 §"Multi-User Chats Permissions" (receiving entities
+/// SHOULD ignore mentions from senders below the minimum role).
 fn sender_may_broadcast_channel_mention(ctx: &RoomContext<'_>) -> bool {
-    if !ctx.project_sender_inbox {
+    if matches!(
+        ctx.synthetic_sender_authority,
+        Some(SyntheticSenderAuthority::ServerAuthored)
+    ) {
         return true;
     }
     ctx.sender_snapshot().is_some_and(|sender| {
@@ -232,6 +240,7 @@ mod tests {
             occupant_id_secret: &secret,
             sender_nickname_generation: 0,
             project_sender_inbox: true,
+            synthetic_sender_authority: None,
             dispatch_timestamp: 0,
         };
         match MucInboxHandler.handle(msg, &ctx) {
@@ -483,6 +492,7 @@ mod tests {
                 occupant_id_secret: &secret,
                 sender_nickname_generation: 0,
                 project_sender_inbox: true,
+                synthetic_sender_authority: None,
                 dispatch_timestamp: 0,
             };
             assert_eq!(
@@ -494,23 +504,23 @@ mod tests {
     }
 
     /// Server-authored synthetic sends bypass the XEP-0513 channel-
-    /// broadcast gate entirely: announcements bots, forum-action system
-    /// messages, etc. The trust on those sends is upstream of the MUC
-    /// role lattice — denying them would silently neuter legitimate
-    /// broadcasts (adversarial review P2 on PR #738).
+    /// broadcast gate via the EXPLICIT typed
+    /// [`SyntheticSenderAuthority::ServerAuthored`] marker —
+    /// announcements bots, forum-action system messages, etc. The
+    /// trust on those sends is upstream of the MUC role lattice.
+    /// Prior versions of this gate keyed the bypass off
+    /// `!project_sender_inbox`, which coupled "skip the sender's
+    /// inbox row" to "permitted to broadcast" — a future caller
+    /// could have accidentally bypassed the gate by setting the
+    /// projection flag (adversarial review on PR #738).
     #[test]
-    fn xep0513_synthetic_sender_bypasses_channel_broadcast_gate() {
+    fn xep0513_synthetic_sender_authority_bypasses_channel_broadcast_gate() {
         let room = bare("team@conf.example.com");
         let bot = full("team@conf.example.com/announcements-bot");
-        let bot_occ = {
-            // Synthetic bots typically aren't in the occupancy snapshot
-            // at all — `project_sender_inbox: false` indicates the
-            // sender is server-authored and not a real occupant.
-            let mut occ = occ(bot.clone(), "announcements-bot");
-            occ.role = Role::Participant;
-            occ
-        };
-        let occupants = vec![bot_occ];
+        // Synthetic bots typically aren't in the occupancy snapshot —
+        // `SyntheticSenderAuthority::ServerAuthored` indicates the
+        // sender is server-authored and trust is established upstream.
+        let occupants: Vec<OccupantSnapshot> = vec![];
 
         let id_gen = FixedIdGenerator("ignored".to_string());
         let secret = OccupantIdSecret::for_testing(b"test-secret".to_vec());
@@ -527,12 +537,60 @@ mod tests {
             occupant_id_secret: &secret,
             sender_nickname_generation: 0,
             project_sender_inbox: false,
+            synthetic_sender_authority: Some(SyntheticSenderAuthority::ServerAuthored),
             dispatch_timestamp: 0,
         };
         assert!(
             sender_may_broadcast_channel_mention(&ctx),
-            "synthetic server-authored sends (project_sender_inbox=false) \
-             MUST bypass the channel-broadcast gate regardless of role"
+            "an explicit `Some(SyntheticSenderAuthority::ServerAuthored)` \
+             MUST bypass the channel-broadcast gate — the bot dispatcher's \
+             upstream trust validation is the source of authority"
+        );
+    }
+
+    /// Regression test for the bypass-via-projection-flag vector (issue
+    /// raised by reviewer on PR #738): a caller that sets
+    /// `project_sender_inbox: false` WITHOUT the explicit synthetic
+    /// authority marker MUST be subject to the standard role/affiliation
+    /// gate. If the gate ever silently keyed off `project_sender_inbox`
+    /// again, this test fails.
+    #[test]
+    fn xep0513_project_sender_inbox_false_does_not_bypass_channel_broadcast_gate() {
+        let room = bare("team@conf.example.com");
+        let participant = full("eve@example.com/cli");
+        let mut participant_occ = occ(participant.clone(), "eve");
+        participant_occ.role = Role::Participant;
+        let occupants = vec![participant_occ];
+
+        let id_gen = FixedIdGenerator("ignored".to_string());
+        let secret = OccupantIdSecret::for_testing(b"test-secret".to_vec());
+        let ctx = RoomContext {
+            room: &room,
+            sender_full: &participant,
+            occupants: &occupants,
+            durable_recipient_bare_jids: &[],
+            managed_room_forbidden: false,
+            room_moderated: false,
+            room_members_only: false,
+            pin_permission: crate::muc::PinPermission::default(),
+            id_gen: &id_gen,
+            occupant_id_secret: &secret,
+            sender_nickname_generation: 0,
+            // The projection-flag is `false` here to simulate the
+            // historical confusion: a caller wanting to "not project
+            // the sender's inbox row" must NOT thereby get a free
+            // channel-broadcast bypass.
+            project_sender_inbox: false,
+            synthetic_sender_authority: None,
+            dispatch_timestamp: 0,
+        };
+        assert!(
+            !sender_may_broadcast_channel_mention(&ctx),
+            "`project_sender_inbox: false` MUST NOT bypass the channel-\
+             broadcast gate — only the explicit \
+             `Some(SyntheticSenderAuthority::ServerAuthored)` marker does. \
+             Coupling the bypass to the projection flag was the original \
+             abuse vector identified by the reviewer."
         );
     }
 

--- a/server/crates/waddle-xmpp/src/protocol/room/mod.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/mod.rs
@@ -47,7 +47,7 @@ pub mod traits;
 
 use std::sync::Arc;
 
-pub use context::{OccupantSnapshot, RoomContext};
+pub use context::{OccupantSnapshot, RoomContext, SyntheticSenderAuthority};
 pub use dispatch::{RoomDispatchOutcome, RoomDispatcher};
 pub use traits::{RoomHandler, RoomHandlerOutcome};
 

--- a/server/crates/waddle-xmpp/src/protocol/room/occupancy_validation.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/occupancy_validation.rs
@@ -134,6 +134,7 @@ mod tests {
             occupant_id_secret: &secret,
             sender_nickname_generation: 0,
             project_sender_inbox: true,
+            synthetic_sender_authority: None,
             dispatch_timestamp: 0,
         };
         OccupancyValidationHandler.handle(msg, &ctx)

--- a/server/crates/waddle-xmpp/src/protocol/room/pin.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/pin.rs
@@ -381,6 +381,7 @@ mod tests {
             occupant_id_secret: secret,
             sender_nickname_generation: 1,
             project_sender_inbox: true,
+            synthetic_sender_authority: None,
             dispatch_timestamp: 1_700_000_000,
         }
     }

--- a/server/crates/waddle-xmpp/src/protocol/room/reflector.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/reflector.rs
@@ -82,6 +82,7 @@ mod tests {
             occupant_id_secret: &secret,
             sender_nickname_generation: 0,
             project_sender_inbox: true,
+            synthetic_sender_authority: None,
             dispatch_timestamp: 0,
         };
         match ReflectorHandler.handle(msg, &ctx) {

--- a/server/crates/waddle-xmpp/src/protocol/room/subject.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/subject.rs
@@ -209,6 +209,7 @@ mod tests {
             occupant_id_secret: secret,
             sender_nickname_generation: 0,
             project_sender_inbox: true,
+            synthetic_sender_authority: None,
             dispatch_timestamp: 1_700_000_000,
         }
     }

--- a/server/crates/waddle-xmpp/src/protocol/wire_trace_l4_room_tests.rs
+++ b/server/crates/waddle-xmpp/src/protocol/wire_trace_l4_room_tests.rs
@@ -97,6 +97,7 @@ fn xep_0045_groupchat_dispatches_through_handler_chain_with_canonical_stamps() {
         occupant_id_secret: &secret,
         sender_nickname_generation: 0,
         project_sender_inbox: true,
+        synthetic_sender_authority: None,
         dispatch_timestamp: 0,
     };
 
@@ -183,6 +184,7 @@ fn xep_0045_non_occupant_halts_chain_with_typed_not_acceptable() {
         occupant_id_secret: &secret,
         sender_nickname_generation: 0,
         project_sender_inbox: true,
+        synthetic_sender_authority: None,
         dispatch_timestamp: 0,
     };
 
@@ -249,6 +251,7 @@ fn xep_0359_room_chain_strips_client_spoofed_room_stanza_id() {
         occupant_id_secret: &secret,
         sender_nickname_generation: 0,
         project_sender_inbox: true,
+        synthetic_sender_authority: None,
         dispatch_timestamp: 0,
     };
 
@@ -310,6 +313,7 @@ fn xep_0424_groupchat_retraction_emits_archive_and_tombstone_events() {
         occupant_id_secret: &secret,
         sender_nickname_generation: 0,
         project_sender_inbox: true,
+        synthetic_sender_authority: None,
         dispatch_timestamp: 0,
     };
 
@@ -388,6 +392,7 @@ fn xep_0430_groupchat_message_emits_durable_recipient_inbox_projection() {
         occupant_id_secret: &secret,
         sender_nickname_generation: 0,
         project_sender_inbox: true,
+        synthetic_sender_authority: None,
         dispatch_timestamp: 0,
     };
     let mut msg = groupchat(&room, &alice, "hello inbox");
@@ -473,6 +478,7 @@ fn xep_0045_section_8_1_live_subject_change_chain_stamps_occupant_id() {
         occupant_id_secret: &secret,
         sender_nickname_generation: 0,
         project_sender_inbox: true,
+        synthetic_sender_authority: None,
         dispatch_timestamp: 1_700_000_000,
     };
 
@@ -567,6 +573,7 @@ fn xep_0045_section_8_1_visitor_subject_change_halts_with_forbidden_no_broadcast
         occupant_id_secret: &secret,
         sender_nickname_generation: 0,
         project_sender_inbox: true,
+        synthetic_sender_authority: None,
         dispatch_timestamp: 0,
     };
 
@@ -648,6 +655,7 @@ fn xep_0045_section_8_1_participant_in_unmoderated_room_subject_change_allowed()
         occupant_id_secret: &secret,
         sender_nickname_generation: 0,
         project_sender_inbox: true,
+        synthetic_sender_authority: None,
         dispatch_timestamp: 1_700_000_000,
     };
     let mut msg = subject_change(&room, &bob, "Bob's topic");
@@ -691,6 +699,7 @@ fn xep_0045_section_8_1_subject_with_body_is_not_a_subject_change() {
         occupant_id_secret: &secret,
         sender_nickname_generation: 0,
         project_sender_inbox: true,
+        synthetic_sender_authority: None,
         dispatch_timestamp: 0,
     };
     let mut msg = subject_change(&room, &eve, "topic-ish");

--- a/server/crates/waddle-xmpp/src/xep/xep0372.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0372.rs
@@ -144,17 +144,28 @@ impl Reference {
 
     /// Extract the bare JID referenced by this `<reference/>` URI.
     ///
-    /// Per RFC 5122 XMPP URIs of the form `xmpp:<jid>` may carry an
-    /// authority resource (`xmpp:alice@example.com/web`) and/or a
-    /// query (`?join`) or fragment (`;subject=foo`) component. The
-    /// XEP-0372 §"Reference type 'mention'" semantics target the
-    /// user's bare JID, so strip resource + query + fragment before
-    /// returning. Returns `None` for unparseable URIs.
+    /// Per RFC 5122 / RFC 3986 an XMPP URI of the form `xmpp:<jid>`
+    /// may carry:
+    ///
+    /// - an authority resource (`xmpp:alice@example.com/web`);
+    /// - a query component introduced by `?` whose key/value pairs
+    ///   are separated by `;` (RFC 5122 §2.7.1, e.g.
+    ///   `xmpp:room@muc?join` or `xmpp:room@muc?message;subject=foo`);
+    /// - a fragment component introduced by `#` (RFC 3986 §3.5).
+    ///
+    /// The XEP-0372 §"Reference type 'mention'" semantics target the
+    /// user's bare JID, so strip the resource component and any
+    /// trailing query (`?`) or fragment (`#`) before returning.
+    /// `;` does NOT delimit the start of the query — it separates
+    /// keys WITHIN the query — but the per-key parser doesn't run
+    /// here; we only need the JID prefix, so splitting on `?` and
+    /// `#` is sufficient and correct (Copilot review on PR #738).
+    /// Returns `None` for unparseable URIs.
     pub fn bare_jid(&self) -> Option<jid::BareJid> {
         let jid_part = self
             .uri
             .strip_prefix("xmpp:")?
-            .split(['?', ';'])
+            .split(['?', '#'])
             .next()?
             .trim();
         if jid_part.is_empty() {

--- a/server/crates/waddle-xmpp/src/xep/xep0372.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0372.rs
@@ -142,9 +142,28 @@ impl Reference {
         self.ref_type == ReferenceType::Mention
     }
 
-    /// Extract the bare JID from the URI (strips `xmpp:` prefix).
-    pub fn bare_jid(&self) -> Option<&str> {
-        self.uri.strip_prefix("xmpp:")
+    /// Extract the bare JID referenced by this `<reference/>` URI.
+    ///
+    /// Per RFC 5122 XMPP URIs of the form `xmpp:<jid>` may carry an
+    /// authority resource (`xmpp:alice@example.com/web`) and/or a
+    /// query (`?join`) or fragment (`;subject=foo`) component. The
+    /// XEP-0372 §"Reference type 'mention'" semantics target the
+    /// user's bare JID, so strip resource + query + fragment before
+    /// returning. Returns `None` for unparseable URIs.
+    pub fn bare_jid(&self) -> Option<jid::BareJid> {
+        let jid_part = self
+            .uri
+            .strip_prefix("xmpp:")?
+            .split(['?', ';'])
+            .next()?
+            .trim();
+        if jid_part.is_empty() {
+            return None;
+        }
+        jid_part
+            .parse::<jid::Jid>()
+            .ok()
+            .map(|parsed| parsed.to_bare())
     }
 }
 
@@ -258,12 +277,14 @@ pub fn extract_mention_uris(msg: &Message) -> Vec<String> {
         .collect()
 }
 
-/// Extract mentioned bare JIDs from a message (strips `xmpp:` prefix).
-pub fn extract_mentioned_jids(msg: &Message) -> Vec<String> {
+/// Extract mentioned bare JIDs from a message. Returns typed
+/// `BareJid` values stripped of resource / query / fragment per
+/// RFC 5122 — see [`Reference::bare_jid`].
+pub fn extract_mentioned_jids(msg: &Message) -> Vec<jid::BareJid> {
     extract_references_from_message(msg)
         .into_iter()
         .filter(|r| r.is_mention())
-        .filter_map(|r| r.bare_jid().map(|s| s.to_owned()))
+        .filter_map(|r| r.bare_jid())
         .collect()
 }
 

--- a/server/crates/waddle-xmpp/src/xep/xep0372/tests.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0372/tests.rs
@@ -28,7 +28,10 @@ fn test_extract_mentions() {
     assert_eq!(refs[0].begin, Some(6));
     assert_eq!(refs[0].end, Some(12));
     assert_eq!(refs[0].uri, "xmpp:alice@example.com");
-    assert_eq!(refs[0].bare_jid(), Some("alice@example.com"));
+    assert_eq!(
+        refs[0].bare_jid(),
+        Some("alice@example.com".parse().expect("typed bare JID"))
+    );
 }
 
 #[test]
@@ -41,7 +44,41 @@ fn test_extract_mentioned_jids() {
     let msg = Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
 
     let jids = extract_mentioned_jids(&msg);
-    assert_eq!(jids, vec!["alice@example.com", "bob@example.com"]);
+    assert_eq!(
+        jids,
+        vec![
+            "alice@example.com".parse::<jid::BareJid>().expect("alice"),
+            "bob@example.com".parse::<jid::BareJid>().expect("bob"),
+        ]
+    );
+}
+
+/// RFC 5122 + XEP-0372 §"Reference type 'mention'": a mention URI
+/// MAY carry a resource (`xmpp:alice@example.com/web`), a query
+/// (`?join`), or a fragment (`;subject=foo`). The bare-JID accessor
+/// MUST strip all of these before returning so the consumer can
+/// compare against a typed `BareJid` without silently mismatching
+/// (adversarial review on PR #738).
+#[test]
+fn xep0372_bare_jid_strips_resource_and_query_components() {
+    use jid::BareJid;
+    let with_resource = Reference::mention("xmpp:alice@example.com/web");
+    assert_eq!(
+        with_resource.bare_jid(),
+        Some("alice@example.com".parse::<BareJid>().expect("alice bare"))
+    );
+    let with_query = Reference::mention("xmpp:bob@example.com?join");
+    assert_eq!(
+        with_query.bare_jid(),
+        Some("bob@example.com".parse::<BareJid>().expect("bob bare"))
+    );
+    let with_fragment = Reference::mention("xmpp:carol@example.com;subject=foo");
+    assert_eq!(
+        with_fragment.bare_jid(),
+        Some("carol@example.com".parse::<BareJid>().expect("carol bare"))
+    );
+    let unparseable = Reference::mention("not-an-xmpp-uri");
+    assert_eq!(unparseable.bare_jid(), None);
 }
 
 #[test]
@@ -195,7 +232,10 @@ fn test_reference_type_display() {
 fn test_reference_new_helpers() {
     let m = Reference::mention("xmpp:a@b.com");
     assert!(m.is_mention());
-    assert_eq!(m.bare_jid(), Some("a@b.com"));
+    assert_eq!(
+        m.bare_jid(),
+        Some("a@b.com".parse().expect("typed bare JID"))
+    );
 
     let d = Reference::data("https://example.com/file.png");
     assert!(!d.is_mention());

--- a/server/crates/waddle-xmpp/src/xep/xep0372/tests.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0372/tests.rs
@@ -54,25 +54,39 @@ fn test_extract_mentioned_jids() {
 }
 
 /// RFC 5122 + XEP-0372 §"Reference type 'mention'": a mention URI
-/// MAY carry a resource (`xmpp:alice@example.com/web`), a query
-/// (`?join`), or a fragment (`;subject=foo`). The bare-JID accessor
-/// MUST strip all of these before returning so the consumer can
-/// compare against a typed `BareJid` without silently mismatching
-/// (adversarial review on PR #738).
+/// MAY carry:
+///
+/// - a resource (`xmpp:alice@example.com/web`);
+/// - a query introduced by `?` (RFC 5122 §2.7.1 — keys are then
+///   separated by `;` WITHIN the query, e.g. `?join` or
+///   `?message;subject=foo`);
+/// - a fragment introduced by `#` (RFC 3986 §3.5).
+///
+/// The bare-JID accessor MUST strip all of these before returning so
+/// the consumer can compare against a typed `BareJid` without
+/// silently mismatching (adversarial review on PR #738).
 #[test]
-fn xep0372_bare_jid_strips_resource_and_query_components() {
+fn xep0372_bare_jid_strips_resource_query_and_fragment_components() {
     use jid::BareJid;
     let with_resource = Reference::mention("xmpp:alice@example.com/web");
     assert_eq!(
         with_resource.bare_jid(),
         Some("alice@example.com".parse::<BareJid>().expect("alice bare"))
     );
+    // RFC 5122 §2.7.1 query: `?` introduces the query; multi-key
+    // queries use `;` between keys.
     let with_query = Reference::mention("xmpp:bob@example.com?join");
     assert_eq!(
         with_query.bare_jid(),
         Some("bob@example.com".parse::<BareJid>().expect("bob bare"))
     );
-    let with_fragment = Reference::mention("xmpp:carol@example.com;subject=foo");
+    let with_multi_key_query = Reference::mention("xmpp:bob@example.com?message;subject=foo");
+    assert_eq!(
+        with_multi_key_query.bare_jid(),
+        Some("bob@example.com".parse::<BareJid>().expect("bob bare"))
+    );
+    // RFC 3986 §3.5 fragment: `#` introduces the fragment.
+    let with_fragment = Reference::mention("xmpp:carol@example.com#anchor");
     assert_eq!(
         with_fragment.bare_jid(),
         Some("carol@example.com".parse::<BareJid>().expect("carol bare"))

--- a/server/crates/waddle-xmpp/tests/xep0372_references.rs
+++ b/server/crates/waddle-xmpp/tests/xep0372_references.rs
@@ -239,7 +239,12 @@ fn xep0372_extract_mentioned_jids_strips_xmpp_scheme() {
     add_reference(&mut msg, &Reference::mention("https://not-a-jid.example/"));
 
     let jids = extract_mentioned_jids(&msg);
-    assert_eq!(jids, vec!["alice@example.com".to_owned()]);
+    assert_eq!(
+        jids,
+        vec!["alice@example.com"
+            .parse::<jid::BareJid>()
+            .expect("typed bare JID")]
+    );
 }
 
 #[test]

--- a/server/crates/waddle-xmpp/tests/xep0513_mentions.rs
+++ b/server/crates/waddle-xmpp/tests/xep0513_mentions.rs
@@ -37,7 +37,7 @@ fn xep0513_namespace_constants_match_spec() {
 // ── §"Discovering support" advertisement ────────────────────────────
 
 #[test]
-fn xep0513_muc_rooms_advertise_both_mention_features() {
+fn xep0513_muc_rooms_do_not_advertise_mentions_until_iq_form_is_wired() {
     let mentions = Feature::explicit_mentions();
     let channel = Feature::channel_mentions();
 
@@ -46,30 +46,36 @@ fn xep0513_muc_rooms_advertise_both_mention_features() {
     assert_eq!(mentions.0, "urn:xmpp:mentions:0");
     assert_eq!(channel.0, "urn:xmpp:mentions:0#channel");
 
-    // The spec carves channel-mention support out as its own URI:
-    // a server that supports per-occupant mentions but rejects
-    // `@channel`-style pings advertises only the base feature.
-    // Waddle accepts both — pin both adverts on the room surface
-    // across every (persistent × members_only × moderated × forum)
-    // configuration. XEP-0513 is MUC-focused, so the dedicated
-    // advert lives on the room disco surface; server-wide disco
-    // doesn't currently surface it (DMs / 1:1 chats don't broadcast
-    // `@channel`, and per-recipient mentions are inferred from
-    // body without disco gating).
+    // XEP-0513 §292 + §303: advertising `urn:xmpp:mentions:0` and
+    // `urn:xmpp:mentions:0#channel` is binding — once advertised, the
+    // room's `<query xmlns='urn:xmpp:mentions:0'/>` IQ MUST return a
+    // form with `mentions#count` + `mentions#individual` (always
+    // required) and `mentions#channel` (if and only if `#channel` is
+    // advertised). PR #738 (slice 3a of #525) enforces a hardcoded
+    // `mentions#channel = moderators` policy at T0 candidate
+    // classification but does NOT yet expose the §295 IQ surface — so
+    // the advert is withdrawn until slice 3c wires the IQ form.
+    // §292 permits non-advertisement + server-internal filtering:
+    // "Mentions MAY be sent in rooms which do not have permissions
+    // set, and/or do not advertise support for them; it is up to
+    // receiving entities to determine how to handle mentions in
+    // rooms without configured permissions."
     for persistent in [false, true] {
         for members_only in [false, true] {
             for moderated in [false, true] {
                 for forum in [false, true] {
                     let feats = muc_room_features(persistent, members_only, moderated, forum);
                     assert!(
-                        feats.iter().any(|f| f == &mentions),
+                        !feats.iter().any(|f| f == &mentions),
                         "muc_room_features({persistent}, {members_only}, {moderated}, {forum}) \
-                         MUST advertise `urn:xmpp:mentions:0`"
+                         MUST NOT advertise `urn:xmpp:mentions:0` until the XEP-0513 §295 \
+                         IQ form is wired (slice 3c)"
                     );
                     assert!(
-                        feats.iter().any(|f| f == &channel),
+                        !feats.iter().any(|f| f == &channel),
                         "muc_room_features({persistent}, {members_only}, {moderated}, {forum}) \
-                         MUST advertise `urn:xmpp:mentions:0#channel`"
+                         MUST NOT advertise `urn:xmpp:mentions:0#channel` until §303 \
+                         `mentions#channel` form field is exposed (slice 3c)"
                     );
                 }
             }


### PR DESCRIPTION
## Summary

Apply XEP-0513 §"Multi-User Chats Permissions" §304 default policy at T0 candidate classification: only senders with role >= moderator (or affiliation >= admin) may boost a `urn:xmpp:mentions:0#channel` (or `<active/>` channel) mention into the `ChannelMention` / `ActiveChannelMention` push class. Non-permitted senders' channel mentions fold into `NotifyAll`; the message itself is delivered + archived unchanged.

First narrowed slice of #525 after PR #694 was closed unmerged for scope creep. Per-room `mentions#channel` config IQ + storage are deferred to follow-up slices.

## Why

XEP-0513 §304: "Receiving entities SHOULD ignore a given mention if the sender does not have at least the minimum role required by the room."

Without this gate, any participant can force a channel push to every recipient with a single `<mention mentions='urn:xmpp:mentions:0#channel'/>` payload — the @here / @everyone abuse vector at the room level. The server's default policy matches the XEP-0513 form example value `mentions#channel = moderators`.

## Implementation

- `OutboundEvent::ProjectGroupchatInbox` gains a typed `sender_can_broadcast_channel_mention: bool` snapshotted at room dispatch from the sender's XEP-0045 occupancy (frozen-per-dispatch invariant, same shape as `room_members_only`).
- `groupchat_notification_class` filters the channel mention scope via the bool; a non-permitted scope short-circuits to `None` which flows into the existing `NotifyAll` fallthrough.
- Permission helper permits when `role >= Moderator` OR `affiliation >= Admin` so an Owner/Admin whose presence cycle hasn't promoted the role yet is never silently denied.
- Synthetic server-authored sends (`!ctx.project_sender_inbox` — extension bots, forum-action system messages) bypass the gate entirely; their trust is upstream of the MUC role lattice.
- Bool is persisted on the `groupchat_notification_recovery` row so the recovery replay re-creates the same class the original T0 emission would have. Without persistence, recovery would silently downgrade every channel mention to `NotifyAll` → suppressed at T1 by the public-group XEP-0492 `OnMention` default → moderator-push outage after every restart.

## XEP custom tests added (CLAUDE.md hard rule)

- `xep0513_sender_may_broadcast_channel_mention_requires_moderator` — full role/affiliation lattice: Moderator ✓, Admin-with-Participant-role ✓, Owner-with-Participant-role ✓, Participant ✗, Visitor ✗, Role::None ✗, non-occupant ✗.
- `xep0513_synthetic_sender_bypasses_channel_broadcast_gate` — `project_sender_inbox: false` always permitted.
- `xep0513_channel_permission_is_frozen_per_dispatch_across_all_recipients` — the bool MUST be identical on every emitted `ProjectGroupchatInbox` event in a single dispatch.
- `xep0513_channel_mention_downgrades_to_notify_all_for_unpermitted_sender` — locks the class downgrade for non-`<active/>` channel mentions.
- `xep0513_active_channel_mention_downgrades_for_unpermitted_sender` — same downgrade for `<active/>` qualifier; active is a recipient filter, not a permission grant.
- `xep0513_personal_mention_unaffected_by_channel_broadcast_permission` — guard rail: `mentions#individual` is out of scope.

## Adversarial review pass

Three parallel reviewer personas ran (XEP conformance, typed-payloads/Rust idiom, security/abuse). Critical findings addressed in commits `f01e2307` + `25531d07`:

- **P1** — Recovery silently dropped moderator pushes via the XEP-0492 OnMention default. Fixed by persisting the bit on the recovery row.
- **P2** — Owner/Admin with un-promoted role denied. Fixed by adding the affiliation fallback.
- **P2** — Synthetic server-authored sends (bots) denied. Fixed by bypassing the gate when `project_sender_inbox == false`.
- **P3** — Test coverage holes (Visitor / Role::None / promotion-trailing / synthetic). All added.
- **P3** — Third integration test passing for the wrong reason. Alice promoted to Admin so it actually tests the live-vs-durable filter.
- **P3** — Stale comment, schema-change doc. Both updated.

Second pass: no P1/P2 regressions. Remaining P3s (collapse `#[allow(clippy::too_many_arguments)]` via typed struct; typed `ChannelBroadcastPermission` enum) deferred to slice 3c when the per-room override IQ surface lands and the typed structure becomes load-bearing.

## Plan (each follow-up = separate narrow PR)

1. **This PR (slice 3a):** server-default permission gate at T0 — **shipped**.
2. **Slice 3b:** XEP-0513 `mentions#count` threshold — ignore mentions when the message exceeds the per-room count.
3. **Slice 3c:** XEP-0513 room-config IQ (`<query xmlns='urn:xmpp:mentions:0'/>` get/set) + per-room overrides. Promote `bool` → typed `ChannelBroadcastPermission { Participants, Moderators, None }` enum.
4. **Slice 3d:** XEP-0452 / XEP-0372 mention-reference fallback for non-present MUC occupants.
5. **Slice 3e:** Narrow disco advertisement (`urn:xmpp:mentions:0`, `#channel`, `<active/>`, `<noping/>`) once 3a–3d are merged.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -p waddle-xmpp -p waddle-server -- -D warnings`
- [x] `cargo test -p waddle-xmpp --lib` (1884 passed)
- [x] `cargo test -p waddle-server --lib` (945 passed)
- [x] Two adversarial review passes
- [ ] CI green

Refs #506. Refs #525.