### PR TITLE
fix(server): allow local SFU mixer JID through Jingle federation guard

### DIFF
--- a/server/crates/waddle-xmpp/src/protocol/handlers/jingle.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/jingle.rs
@@ -54,6 +54,35 @@ pub fn calls_mixer_jid(server_domain: &str) -> BareJid {
         .unwrap_or_else(|_| panic!("server domain produced an invalid mixer JID: {raw}"))
 }
 
+/// Predicate for the Jingle federation guard: returns `true` iff
+/// `peer` is reachable without crossing a server boundary.
+///
+/// Two shapes count as local:
+/// - the apex domain (regular P2P Jingle to another local account), or
+/// - the local SFU mixer component JID (`calls.<ctx.domain>`, the
+///   XEP-0272 Muji path).
+fn is_local_jingle_peer(peer: &Jid, ctx: &StanzaContext<'_>) -> bool {
+    if peer.domain() == ctx.full_jid.domain() {
+        return true;
+    }
+    peer.to_bare() == calls_mixer_jid(ctx.domain)
+}
+
+/// Predicate for the Muji payload gate: returns `true` iff `room` is
+/// a MUC room on this server's MUC service (`muc.<ctx.domain>`).
+///
+/// XEP-0272 §Joining lets the room JID range over any conference,
+/// but accepting foreign rooms here would mint local LiveKit tokens
+/// scoped to attacker-supplied call ids and pollute the participant
+/// registry. Other servers should run their own SFU; this gate stops
+/// us proxying as theirs.
+fn is_local_muji_room(room: &BareJid, ctx: &StanzaContext<'_>) -> bool {
+    // Single MUC service per server, derived from the apex like the
+    // rest of the routing layer (`waddle-xmpp/src/routing.rs:80`).
+    let expected = format!("muc.{}", ctx.domain);
+    room.domain().as_str() == expected
+}
+
 #[derive(Clone)]
 pub struct JingleHandler {
     sfu: Arc<dyn SfuService>,
@@ -126,7 +155,15 @@ impl IqHandler for JingleHandler {
         // boundary with a clear `feature-not-implemented` so the
         // initiator sees an actionable error instead of a token
         // their peer's server can't make use of.
-        if peer.domain() != ctx.full_jid.domain() {
+        //
+        // "Local" means either the apex domain (P2P) or the local
+        // SFU mixer's component JID (`calls.<ctx.domain>`, Muji path).
+        // The mixer JID is a synthetic XMPP component identifier and
+        // intentionally lives on its own subdomain to disambiguate it
+        // from P2P Jingle on the dispatcher — it does NOT correspond
+        // to a deployed host, so a strict `peer.domain() == ctx.full_jid.domain()`
+        // would misclassify the local mixer as a remote server.
+        if !is_local_jingle_peer(&peer, ctx) {
             return error_reply(
                 iq,
                 DefinedCondition::FeatureNotImplemented,
@@ -339,6 +376,23 @@ impl JingleHandler {
                 "Muji <muji/> child inside <jingle/> requires the 'room' attribute",
             );
         };
+
+        // The `<muji room='…'/>` JID must point at a MUC room on
+        // THIS server's MUC service (`muc.<ctx.domain>`). Without
+        // this check a local user could mint a LiveKit token whose
+        // SFU room id is `victim@muc.other.example`, polluting our
+        // LiveKit namespace with arbitrary attacker-supplied call
+        // ids and (worse) registering themselves into a participant
+        // registry keyed by a foreign room jid that local presence
+        // pumps may join later. The federation guard above is a
+        // peer-JID gate; this is a payload gate.
+        if !is_local_muji_room(&room_jid, ctx) {
+            return error_reply(
+                iq,
+                DefinedCondition::BadRequest,
+                "Muji room JID must reference a MUC room on this server",
+            );
+        }
 
         match jingle.action {
             Action::SessionInitiate => self.handle_muji_session_initiate(iq, jingle, room_jid, ctx),
@@ -1115,6 +1169,47 @@ mod tests {
             },
             _ => panic!("expected SendStanza"),
         }
+    }
+
+    #[test]
+    fn same_domain_p2p_jingle_still_passes_federation_guard() {
+        // Regression for the relaxed federation guard: a P2P
+        // session-initiate between two same-apex-domain accounts
+        // must continue to forward to the peer connection without
+        // tripping `feature-not-implemented`. Muji equivalents live
+        // in the XEP-0272 dedicated test suite at
+        // `crates/waddle-xmpp/tests/xep_0272_muji.rs` per the
+        // CLAUDE.md "XEP custom test-suite hard rule."
+        let iq = session_initiate_iq(
+            "alice@waddle.test/desktop",
+            "bob@waddle.test/desktop",
+            "p2p-1",
+        );
+        let jid = test_ctx_jid();
+        let handler = JingleHandler::new(fixture_sfu());
+        let events = handler.handle(&iq, &ctx(&jid));
+
+        let no_feature_not_implemented = !events.iter().any(|ev| match ev {
+            OutboundEvent::SendStanza(stanza) => match stanza.as_ref() {
+                Stanza::Iq(reply) => matches!(
+                    reply.as_ref(),
+                    Iq::Error { error, .. }
+                        if error.defined_condition == DefinedCondition::FeatureNotImplemented
+                ),
+                _ => false,
+            },
+            _ => false,
+        });
+        assert!(
+            no_feature_not_implemented,
+            "same-apex P2P must not trip the federation guard: {events:?}",
+        );
+        assert!(
+            events
+                .iter()
+                .any(|ev| matches!(ev, OutboundEvent::RouteToConnection { .. })),
+            "expected forward to peer, got: {events:?}",
+        );
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/tests/xep_0272_muji.rs
+++ b/server/crates/waddle-xmpp/tests/xep_0272_muji.rs
@@ -22,9 +22,25 @@
 //! can't be reused from an integration test crate. This file
 //! covers everything else conformantly.
 
-use waddle_sfu::CallId;
-use waddle_xmpp::xep::xep0167::MediaKind;
+use chrono::Duration;
+use minidom::Element;
+use std::sync::Arc;
+use waddle_sfu::{
+    ApiKey, ApiSecret, CallId, LiveKitSfu, SfuConfig, SfuService, TurnHost, TurnSharedSecret,
+    WebsocketUrl,
+};
+use waddle_xmpp::protocol::event::{OutboundEvent, StanzaContext};
+use waddle_xmpp::protocol::handlers::jingle::{calls_mixer_jid, JingleHandler};
+use waddle_xmpp::protocol::traits::IqHandler;
+use waddle_xmpp::xep::xep0167::{opus_audio_description, MediaKind};
 use waddle_xmpp::xep::xep0272::{find_muji, Creator, Muji, MujiContent, MujiParseError, NS_MUJI};
+use waddle_xmpp::xep::xep_waddle_livekit_transport::WaddleLiveKitTransport;
+use waddle_xmpp::Stanza;
+use xmpp_parsers::iq::Iq;
+use xmpp_parsers::jingle::{
+    Action, Content, ContentId, Creator as JingleCreator, Jingle, SessionId, Transport,
+};
+use xmpp_parsers::stanza_error::DefinedCondition;
 
 fn audio_muji() -> Muji {
     Muji::with_contents(vec![MujiContent::new(
@@ -282,4 +298,283 @@ fn default_muji_is_empty() {
     let muji = Muji::default();
     assert!(muji.is_empty());
     assert!(!muji.is_active());
+}
+
+// ── JingleHandler integration: Muji entry path through the federation guard ─
+
+fn fixture_sfu() -> Arc<dyn SfuService> {
+    let cfg = SfuConfig {
+        api_key: ApiKey::new("APIxxxxxxxx"),
+        api_secret: ApiSecret::from_text("super-secret-secret-32-bytes-min")
+            .expect("test secret meets min length"),
+        ws_url: WebsocketUrl::new("wss://livekit.test/".parse().unwrap()).unwrap(),
+        turn_host: TurnHost::new("turn.test"),
+        turn_tls_port: 443,
+        turn_udp_port: 3478,
+        turn_shared_secret: TurnSharedSecret::from_text("turn-secret"),
+        token_ttl: Duration::seconds(3600),
+        turn_ttl: Duration::seconds(3600),
+    };
+    Arc::new(LiveKitSfu::new(cfg))
+}
+
+const TEST_DOMAIN: &str = "waddle.test";
+const TEST_INITIATOR: &str = "alice@waddle.test/desktop";
+
+fn test_full_jid() -> jid::FullJid {
+    TEST_INITIATOR.parse().unwrap()
+}
+
+fn ctx<'a>(jid: &'a jid::FullJid) -> StanzaContext<'a> {
+    StanzaContext {
+        domain: TEST_DOMAIN,
+        full_jid: jid,
+    }
+}
+
+/// Build a Muji-bearing Jingle session-initiate IQ. The wire shape
+/// matches XEP-0272 §Joining: a standard `<jingle action='session-
+/// initiate'>` carrying a `<content/>` plus a `<muji room='…'/>`
+/// sibling that pins it to a specific MUC room.
+fn muji_session_initiate_iq(initiator: &str, responder: &str, room: &str, sid: &str) -> Iq {
+    let mut content = Content::new(JingleCreator::Initiator, ContentId("audio".into()));
+    content.description = Some(xmpp_parsers::jingle::Description::Rtp(
+        opus_audio_description(),
+    ));
+    content.transport = Some(Transport::Unknown(
+        WaddleLiveKitTransport::Request.to_element(),
+    ));
+    let mut jingle = Jingle::new(Action::SessionInitiate, SessionId(sid.into()));
+    jingle.initiator = Some(initiator.parse().unwrap());
+    jingle.contents.push(content);
+    let muji = Muji {
+        room: Some(room.parse().expect("test room is a valid bare JID")),
+        preparing: false,
+        contents: vec![MujiContent::new(
+            "audio",
+            Creator::Initiator,
+            MediaKind::Audio,
+        )],
+    };
+    // xmpp_parsers' Jingle struct exposes no API for arbitrary child
+    // elements, so we serialise to a minidom Element and graft the
+    // <muji/> child in. This produces the exact wire shape the chat
+    // client emits via the wasm bridge.
+    let mut jingle_elem: Element = jingle.into();
+    jingle_elem.append_child(muji.to_element());
+    Iq::Set {
+        from: Some(initiator.parse().unwrap()),
+        to: Some(responder.parse().unwrap()),
+        id: format!("muji-{sid}"),
+        payload: jingle_elem,
+    }
+}
+
+fn muji_session_terminate_iq(initiator: &str, responder: &str, room: &str, sid: &str) -> Iq {
+    let mut jingle = Jingle::new(Action::SessionTerminate, SessionId(sid.into()));
+    jingle.initiator = Some(initiator.parse().unwrap());
+    // XEP-0272 only mandates the `<muji room='…'/>` marker; no
+    // contents required for terminate.
+    let muji = Muji {
+        room: Some(room.parse().expect("test room is a valid bare JID")),
+        preparing: false,
+        contents: vec![],
+    };
+    let mut jingle_elem: Element = jingle.into();
+    jingle_elem.append_child(muji.to_element());
+    Iq::Set {
+        from: Some(initiator.parse().unwrap()),
+        to: Some(responder.parse().unwrap()),
+        id: format!("muji-term-{sid}"),
+        payload: jingle_elem,
+    }
+}
+
+fn has_feature_not_implemented(events: &[OutboundEvent]) -> bool {
+    events.iter().any(|ev| match ev {
+        OutboundEvent::SendStanza(stanza) => match stanza.as_ref() {
+            Stanza::Iq(reply) => matches!(
+                reply.as_ref(),
+                Iq::Error { error, .. }
+                    if error.defined_condition == DefinedCondition::FeatureNotImplemented
+            ),
+            _ => false,
+        },
+        _ => false,
+    })
+}
+
+fn first_error_condition(events: &[OutboundEvent]) -> Option<DefinedCondition> {
+    events.iter().find_map(|ev| {
+        let OutboundEvent::SendStanza(stanza) = ev else {
+            return None;
+        };
+        let Stanza::Iq(reply) = stanza.as_ref() else {
+            return None;
+        };
+        let Iq::Error { error, .. } = reply.as_ref() else {
+            return None;
+        };
+        Some(error.defined_condition.clone())
+    })
+}
+
+fn has_session_accept_to(events: &[OutboundEvent], expected_to: &str) -> bool {
+    events.iter().any(|ev| {
+        let OutboundEvent::SendStanza(stanza) = ev else {
+            return false;
+        };
+        let Stanza::Iq(boxed) = stanza.as_ref() else {
+            return false;
+        };
+        let Iq::Set { payload, to, .. } = boxed.as_ref() else {
+            return false;
+        };
+        to.as_ref().is_some_and(|j| j.to_string() == expected_to)
+            && payload.name() == "jingle"
+            && payload.attr("action") == Some("session-accept")
+    })
+}
+
+#[test]
+fn local_muji_mixer_jid_passes_federation_guard() {
+    // XEP-0272 §Joining: a Jingle session-initiate addressed to the
+    // local SFU mixer (`calls.<server-domain>`, Waddle's synthetic
+    // component JID for disambiguating Muji from P2P on the
+    // dispatcher) must reach `handle_muji_session_initiate`. The
+    // server is the conference focus and replies with a
+    // server-initiated session-accept per XEP-0166 §6.3 (IQ-result
+    // ack on the initiate IQ, separate `<iq type='set'>` carrying
+    // the session-accept).
+    let iq = muji_session_initiate_iq(
+        TEST_INITIATOR,
+        &calls_mixer_jid(TEST_DOMAIN).to_string(),
+        "room@muc.waddle.test",
+        "muji-1",
+    );
+    let jid = test_full_jid();
+    let handler = JingleHandler::new(fixture_sfu());
+    let events = handler.handle(&iq, &ctx(&jid));
+
+    assert!(
+        !has_feature_not_implemented(&events),
+        "local mixer must not be misclassified as federation: {events:?}",
+    );
+    assert!(
+        has_session_accept_to(&events, TEST_INITIATOR),
+        "expected Muji session-accept addressed to initiator: {events:?}",
+    );
+}
+
+#[test]
+fn local_muji_mixer_jid_with_resource_passes_federation_guard() {
+    // The mixer JID's bare form is the policy gate. A `to=` with a
+    // resource (`calls.<domain>/anything`) must still be accepted —
+    // both `is_local_jingle_peer` and the downstream Muji-handler
+    // mixer check use `.to_bare()` to compare, so the resource is
+    // semantically irrelevant.
+    let iq = muji_session_initiate_iq(
+        TEST_INITIATOR,
+        "calls.waddle.test/focus",
+        "room@muc.waddle.test",
+        "muji-resourced",
+    );
+    let jid = test_full_jid();
+    let handler = JingleHandler::new(fixture_sfu());
+    let events = handler.handle(&iq, &ctx(&jid));
+
+    assert!(
+        !has_feature_not_implemented(&events),
+        "mixer JID with resource must be treated as the bare mixer: {events:?}",
+    );
+    assert!(
+        has_session_accept_to(&events, TEST_INITIATOR),
+        "expected Muji session-accept: {events:?}",
+    );
+}
+
+#[test]
+fn foreign_mixer_jid_is_rejected_as_federation() {
+    // The local-mixer carve-out is scoped to `ctx.domain`. A
+    // `calls.<other-host>` JID is a remote-server mixer and must
+    // still be rejected by the federation guard — otherwise a local
+    // user could mint LiveKit tokens scoped to an attacker-supplied
+    // SFU room id by addressing a foreign-looking mixer.
+    let iq = muji_session_initiate_iq(
+        TEST_INITIATOR,
+        "calls.other.test",
+        "room@muc.other.test",
+        "muji-foreign",
+    );
+    let jid = test_full_jid();
+    let handler = JingleHandler::new(fixture_sfu());
+    let events = handler.handle(&iq, &ctx(&jid));
+
+    assert_eq!(
+        first_error_condition(&events),
+        Some(DefinedCondition::FeatureNotImplemented),
+        "foreign-domain mixer JID must remain rejected: {events:?}",
+    );
+}
+
+#[test]
+fn muji_with_foreign_room_jid_is_rejected_as_bad_request() {
+    // Payload gate (distinct from the peer-JID federation guard):
+    // even when the IQ is correctly addressed to the LOCAL mixer,
+    // the `<muji room='…'/>` JID must reference a room on this
+    // server's MUC service (`muc.<ctx.domain>`). Otherwise a local
+    // user could pollute our LiveKit namespace with arbitrary
+    // attacker-supplied call ids and register themselves into a
+    // participant registry keyed by a foreign room JID.
+    let iq = muji_session_initiate_iq(
+        TEST_INITIATOR,
+        &calls_mixer_jid(TEST_DOMAIN).to_string(),
+        "room@muc.other.test",
+        "muji-foreign-room",
+    );
+    let jid = test_full_jid();
+    let handler = JingleHandler::new(fixture_sfu());
+    let events = handler.handle(&iq, &ctx(&jid));
+
+    assert_eq!(
+        first_error_condition(&events),
+        Some(DefinedCondition::BadRequest),
+        "Muji with non-local room must be rejected with bad-request: {events:?}",
+    );
+}
+
+#[test]
+fn muji_session_terminate_to_local_mixer_passes_federation_guard() {
+    // Session-terminate on the Muji branch must traverse the same
+    // relaxed federation guard. The handler responds with an
+    // IQ-result per XEP-0166 §6.7 — not an error.
+    let iq = muji_session_terminate_iq(
+        TEST_INITIATOR,
+        &calls_mixer_jid(TEST_DOMAIN).to_string(),
+        "room@muc.waddle.test",
+        "muji-1",
+    );
+    let jid = test_full_jid();
+    let handler = JingleHandler::new(fixture_sfu());
+    let events = handler.handle(&iq, &ctx(&jid));
+
+    assert!(
+        !has_feature_not_implemented(&events),
+        "session-terminate to local mixer must not trip federation guard: {events:?}",
+    );
+    // The terminate path emits an IQ-result ack; assert at least one
+    // SendStanza that is NOT an error reply.
+    let saw_non_error_reply = events.iter().any(|ev| {
+        let OutboundEvent::SendStanza(stanza) = ev else {
+            return false;
+        };
+        let Stanza::Iq(reply) = stanza.as_ref() else {
+            return false;
+        };
+        !matches!(reply.as_ref(), Iq::Error { .. })
+    });
+    assert!(
+        saw_non_error_reply,
+        "expected non-error reply to session-terminate: {events:?}",
+    );
 }


### PR DESCRIPTION
## Context

Group MUC calls fail at the server with:

```
Cancel: feature-not-implemented
"Jingle calling is currently single-domain only; federation is not yet supported"
```

even when both caller and callee live on the same server.

### Root cause

The same-domain federation guard at `server/crates/waddle-xmpp/src/protocol/handlers/jingle.rs` (original line 129) used strict string equality:

```rust
if peer.domain() != ctx.full_jid.domain() { … feature-not-implemented … }
```

XEP-0272 Muji `session-initiate` IQs are addressed to the SFU mixer at `calls.<server-domain>` (e.g. `calls.waddle.social`) — a **synthetic XMPP component JID**, never a deployed subdomain. LiveKit itself lives at a different, externally-configured `LIVEKIT_WS_URL`. For a user `alice@waddle.social/r1`, `peer.domain()` is `calls.waddle.social` and `ctx.full_jid.domain()` is `waddle.social`; the guard misclassified the local mixer as a remote server and rejected the call before the Muji branch could run.

P2P 1:1 calls (peer-to-peer, both on the apex domain) were unaffected; only Muji group calls tripped the guard.

## Changes

### 1. Federation guard now accepts the local mixer JID

`jingle.rs:is_local_jingle_peer` returns `true` for either:
1. `peer.domain() == ctx.full_jid.domain()` — apex-domain P2P, and
2. `peer.to_bare() == calls_mixer_jid(ctx.domain)` — the local SFU mixer (Muji path).

Anything else still produces `feature-not-implemented` with the original message.

### 2. New payload gate: Muji rooms must be local

Relaxing the federation guard makes `handle_muji_session_initiate` reachable, which exposed a latent issue surfaced in adversarial review: nothing validated that `<muji room='…'/>` belonged to *this* server's MUC service. Without a gate, a local user could mint LiveKit tokens scoped to attacker-supplied foreign room ids and pollute the SFU participant registry.

`jingle.rs:is_local_muji_room` enforces `room.domain() == "muc.<ctx.domain>"`. Applied inside `handle_muji_jingle` before action dispatch, so both `session-initiate` and `session-terminate` are gated identically.

### 3. Tests

Per the CLAUDE.md "XEP custom test-suite hard rule," XEP behavior changes update the dedicated XEP suite:

- **`jingle.rs`** (inline) — `same_domain_p2p_jingle_still_passes_federation_guard`: regression for the apex-domain P2P path. Existing `cross_domain_jingle_returns_feature_not_implemented` is the regression for true cross-domain rejection.
- **`tests/xep_0272_muji.rs`** (dedicated XEP-0272 suite) — five new handler-integration tests:
  - `local_muji_mixer_jid_passes_federation_guard` — mixer JID accepted, session-accept emitted to initiator.
  - `local_muji_mixer_jid_with_resource_passes_federation_guard` — `to=calls.<domain>/anything` still accepted (`.to_bare()` semantics).
  - `foreign_mixer_jid_is_rejected_as_federation` — `calls.<foreign-host>` still rejected.
  - `muji_with_foreign_room_jid_is_rejected_as_bad_request` — payload gate verified.
  - `muji_session_terminate_to_local_mixer_passes_federation_guard` — terminate path covered too.

### Non-goals / out of scope

- No DNS, proxy, or deployment changes. The mixer JID stays an internal-only XMPP component identifier.
- No rename of `MIXER_LOCALPART` — XEP-0272 expects the conference focus to have its own JID distinct from the room JID.
- No new `RoutingDestination::LocalCalls` variant — Jingle IQs are namespace-dispatched before the message router runs.

## Verification

- [x] `cd server && cargo fmt --check && cargo clippy -p waddle-xmpp --all-targets -- -D warnings` clean.
- [x] `cargo test -p waddle-xmpp` — all suites green (lib tests + `xep_0272_muji` integration tests).
- [ ] Manual e2e: two browser sessions on the same apex domain, MUC group call works end-to-end.
- [ ] 1:1 P2P regression check.
- [ ] Foreign-domain rejection regression check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)