### PR TITLE
fix(server): route MUC Muji presence to sender's sibling resources

### DIFF
--- a/chat/tests/muc-call-presence.test.ts
+++ b/chat/tests/muc-call-presence.test.ts
@@ -158,6 +158,46 @@ describe("applyMucCallPresence", () => {
     clearMucCallParticipants();
     expect($mucCallParticipants.get()).toEqual({});
   });
+
+  test("registers the local user's own nick when their sibling resource starts a call (regression: cross-instance indicator)", () => {
+    // Scenario: alice is signed in on two browser instances (web +
+    // mobile). Both have joined `room@muc.test` with the same nick
+    // "alice" — XEP-0045 §7.2 same-bare multi-session join. Web
+    // starts a call; the server reflects the Muji presence to BOTH
+    // sessions per XEP-0045 §7.1. Mobile's wasm bridge surfaces the
+    // reflection here.
+    //
+    // The store MUST register "alice" as an in-call nick on mobile
+    // too — otherwise mobile's sidebar chip never lights up and the
+    // user has to manually re-discover the call. This was the
+    // user-visible symptom of the server-side delivery bug
+    // (`muc_update.rs` routing self-bare recipients onto the
+    // sender's WebSocket via `responses` instead of the sibling's
+    // via the connection registry).
+    //
+    // Pin the contract: a presence whose `from` reflects our own
+    // identity is NOT filtered out. The store has no concept of
+    // "self" — and intentionally so. A future refactor that adds an
+    // implicit self-filter would silently re-break the multi-
+    // instance indicator without any other test catching it.
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muji: activeMuji,
+    });
+    expect($mucCallParticipants.get()["room@muc.test"]).toEqual(["alice"]);
+    expect(mucCallParticipantCount("room@muc.test")).toBe(1);
+
+    // The matching XEP-0272 §Leaving reflection (empty `<muji/>`
+    // gets stripped by the server, so the chat side sees an
+    // available presence with no muji field) must clear the entry
+    // even though it reflects our own identity.
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+    });
+    expect($mucCallParticipants.get()["room@muc.test"]).toBeUndefined();
+  });
 });
 
 describe("awaitPreparingEcho (XEP-0272 §Joining MUST)", () => {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
@@ -154,6 +154,17 @@ pub(super) async fn try_handle_muc_presence_update(
         // session join (Alice on web AND mobile) needs `is_self` for
         // BOTH recipients when Alice updates her presence from web.
         let is_self = recipient.to_bare() == sender_jid.to_bare();
+        // `is_self` covers stanza SHAPE (status-110 stamping). The
+        // delivery CHANNEL is a separate question: only the exact
+        // full JID that emitted this presence shares the inbound
+        // WebSocket, so only that recipient can be returned via the
+        // `responses` vec. Every other recipient — including a
+        // sibling resource of the same bare JID, which is on a
+        // different WebSocket — must be dispatched through the
+        // cross-session connection registry, otherwise the sibling
+        // never receives the Muji reflection and its "call ongoing"
+        // indicator never lights up.
+        let is_sender_session = recipient == sender_jid;
         let mut presence = build_occupant_presence_update(
             incoming,
             &from_room_jid,
@@ -176,11 +187,7 @@ pub(super) async fn try_handle_muc_presence_update(
                 .retain(|payload| !(payload.name() == "muji" && payload.ns() == NS_MUJI));
         }
 
-        if is_self {
-            // Self-presence goes back over the WebSocket session
-            // that sent it (via the `responses` vec); other
-            // recipients are dispatched through the cross-session
-            // connection registry below.
+        if is_sender_session {
             responses.push(stanza_to_xml(&Stanza::Presence(presence)));
         } else {
             let stanza = Stanza::Presence(presence);

--- a/server/crates/waddle-server/tests/calls_e2e_ws.rs
+++ b/server/crates/waddle-server/tests/calls_e2e_ws.rs
@@ -1,15 +1,22 @@
 //! XEP-0353 + XEP-0166 + waddle-livekit-transport wire-conformance
 //! tests against a live waddle-server with `LIVEKIT_*` envs set.
 //!
-//! Scope: the JMI ring layer (alice → bob propose/proceed/reject)
-//! and the Jingle session-initiate transport-rewrite path. The full
-//! engine-level connect-to-LiveKit step is exercised by manual smoke
-//! tests in the browser; this suite covers everything the server is
-//! responsible for.
+//! Scope: the JMI ring layer (alice → bob propose/proceed/reject),
+//! the Jingle session-initiate transport-rewrite path, and the
+//! XEP-0272 Muji MUC-presence reflection path that drives the
+//! per-room "call ongoing" indicator. The full engine-level
+//! connect-to-LiveKit step is exercised by manual smoke tests in
+//! the browser; this suite covers everything the server is
+//! responsible for on the wire.
 
 mod ws_common;
 
 use ws_common::{disco_info_query, TestServer, WsXmppClient};
+use xmpp_parsers::minidom::Element;
+
+const NS_MUC: &str = "http://jabber.org/protocol/muc";
+const NS_MUC_USER: &str = "http://jabber.org/protocol/muc#user";
+const NS_MUJI: &str = "urn:xmpp:jingle:muji:0";
 
 const DOMAIN: &str = "localhost";
 const ALICE: &str = "alice";
@@ -332,5 +339,183 @@ async fn session_initiate_rewrites_empty_waddle_transport() {
     assert!(
         forwarded.contains("<token") && forwarded.matches('.').count() > 2,
         "token child must be a populated JWT; got: {forwarded}"
+    );
+}
+
+// ── XEP-0272 §Joining: sibling-resource Muji reflection ───────────────────
+
+/// Send a XEP-0045 join presence to `room/nick` and drain frames until
+/// the room's historical-subject ack arrives (the last frame in the
+/// join sequence). Mirrors the helper in `xep0045_kick_presence_broadcast_ws.rs`
+/// but local to this test file so we don't have to share mutable state
+/// across integration test binaries.
+async fn muji_join_room(client: &mut WsXmppClient, room: &str, nick: &str) {
+    client
+        .send(&format!(
+            r#"<presence to="{room}/{nick}"><x xmlns="{NS_MUC}"/></presence>"#
+        ))
+        .await
+        .expect("send join");
+    client
+        .recv_until(|frame| frame.contains("<subject"))
+        .await
+        .expect("join responses including subject ack");
+}
+
+fn parse_presence(frame: &str) -> Element {
+    frame
+        .parse::<Element>()
+        .unwrap_or_else(|err| panic!("frame must parse as XML: {err}; frame={frame}"))
+}
+
+fn muc_user_has_status_110(presence: &Element) -> bool {
+    let Some(x) = presence
+        .children()
+        .find(|c| c.name() == "x" && c.ns() == NS_MUC_USER)
+    else {
+        return false;
+    };
+    x.children()
+        .filter(|c| c.name() == "status" && c.ns() == NS_MUC_USER)
+        .any(|s| s.attr("code") == Some("110"))
+}
+
+fn muji_child(presence: &Element) -> Option<&Element> {
+    presence
+        .children()
+        .find(|c| c.name() == "muji" && c.ns() == NS_MUJI)
+}
+
+/// XEP-0272 §Joining + XEP-0045 §7.1: when a multi-session occupant
+/// (the user's own bare JID joined twice with two resources) updates
+/// presence with a `<muji/>` content advertisement, the reflection
+/// MUST reach the *sibling* WebSocket session, not just the sending
+/// one. This is what powers the cross-instance "call ongoing"
+/// indicator: a user starting a call on their desktop client should
+/// see the chip light up in their phone client without any extra
+/// round-trip.
+///
+/// Regression test for the bug where bare-JID `is_self` equality was
+/// used to pick the delivery channel — pushing reflections to *every*
+/// same-bare recipient onto the sender's `responses` vec and never
+/// dispatching them to the sibling's WebSocket via the connection
+/// registry.
+#[tokio::test]
+async fn muji_presence_reflects_to_senders_sibling_resource() {
+    let server = TestServer::start_with_extra_envs(&[], &livekit_test_envs());
+    let admin_pass = server.fixed_account_password().to_string();
+
+    // Two WebSocket sessions for the SAME bare JID — "admin" with the
+    // server-owner localpart so the instant-room join below succeeds.
+    let mut web =
+        WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, "admin", &admin_pass, "muji-web")
+            .await
+            .expect("admin/web connects");
+    let mut mobile = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "admin",
+        &admin_pass,
+        "muji-mobile",
+    )
+    .await
+    .expect("admin/mobile connects");
+
+    let room = format!("muji-sibling-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    let nick = "admin";
+
+    // Web joins first (instant room creation, admin is owner). Then
+    // mobile joins the same room with the same nick — XEP-0045 §7.2
+    // multi-session join: shared occupant entry, two underlying full
+    // JIDs in `occupant_sessions`.
+    muji_join_room(&mut web, &room, nick).await;
+    muji_join_room(&mut mobile, &room, nick).await;
+
+    // Web emits a XEP-0272 §Joining content presence (active call).
+    // Use a minimal `<muji>` body that the typed extractor accepts:
+    // one `<content>` with an RTP `<description media='audio'/>`.
+    let muji_active = format!(
+        r#"<presence to="{room}/{nick}">
+             <x xmlns="{NS_MUC}"/>
+             <muji xmlns="{NS_MUJI}">
+               <content creator="initiator" name="audio">
+                 <description xmlns="urn:xmpp:jingle:apps:rtp:1" media="audio"/>
+               </content>
+             </muji>
+           </presence>"#
+    );
+    web.send(&muji_active)
+        .await
+        .expect("web sends active muji presence");
+
+    // Mobile MUST receive a reflected presence — from the room/nick,
+    // carrying the `<muji>` child with `<content>` intact, plus
+    // XEP-0045 §7.1 `<status code='110'/>` because mobile shares the
+    // sender's bare JID and is therefore a "self" session for the
+    // status-code stamping purpose.
+    let mobile_active = mobile
+        .recv_matching(|frame| frame.contains("<presence") && frame.contains("muji"))
+        .await
+        .expect("mobile receives reflected muji presence on its own WebSocket");
+    let element = parse_presence(&mobile_active);
+    assert_eq!(
+        element.name(),
+        "presence",
+        "expected <presence>: {mobile_active}"
+    );
+    assert_eq!(
+        element.attr("from"),
+        Some(format!("{room}/{nick}").as_str()),
+        "reflection must be from room/nick: {mobile_active}"
+    );
+    let muji = muji_child(&element)
+        .unwrap_or_else(|| panic!("mobile reflection must carry <muji/>: {mobile_active}"));
+    assert!(
+        muji.children().any(|c| c.name() == "content"),
+        "mobile reflection must preserve the <content/> child (active call shape): {mobile_active}"
+    );
+    assert!(
+        muc_user_has_status_110(&element),
+        "XEP-0045 §7.1: sibling session of the sender must receive <status code='110'/>: {mobile_active}"
+    );
+
+    // Web emits the XEP-0272 §Leaving marker — an empty `<muji/>`
+    // element. The room actor clears the call state; the reflection
+    // strips the `<muji/>` child, so the mobile sibling sees a plain
+    // available presence (which the chat-side store reads as "no
+    // active muji" and clears the indicator).
+    let muji_leave = format!(
+        r#"<presence to="{room}/{nick}">
+             <x xmlns="{NS_MUC}"/>
+             <muji xmlns="{NS_MUJI}"/>
+           </presence>"#
+    );
+    web.send(&muji_leave)
+        .await
+        .expect("web sends empty muji leave marker");
+
+    // Mobile MUST receive a follow-up presence from room/nick WITHOUT
+    // the `<muji/>` child. The match predicate is narrow on purpose:
+    // there may be unrelated frames buffered (caps, etc.); we want
+    // the next presence FROM room/nick that has no `<muji/>` element.
+    let mobile_leave = mobile
+        .recv_matching(|frame| {
+            // Skip the active-muji frame we already consumed and the
+            // initial join echoes; we only want a presence whose XML
+            // body has no `<muji` substring.
+            frame.contains("<presence")
+                && frame.contains(&format!("from='{room}/{nick}'"))
+                && !frame.contains("<muji")
+        })
+        .await
+        .expect("mobile receives leave reflection without <muji/>");
+    let leave_element = parse_presence(&mobile_leave);
+    assert!(
+        muji_child(&leave_element).is_none(),
+        "XEP-0272 §Leaving wire shape: muji child must be stripped: {mobile_leave}"
+    );
+    assert!(
+        muc_user_has_status_110(&leave_element),
+        "XEP-0045 §7.1: sibling session still gets <status code='110'/> on a self-driven update: {mobile_leave}"
     );
 }

--- a/server/crates/waddle-server/tests/calls_e2e_ws.rs
+++ b/server/crates/waddle-server/tests/calls_e2e_ws.rs
@@ -421,7 +421,10 @@ async fn muji_presence_reflects_to_senders_sibling_resource() {
     .await
     .expect("admin/mobile connects");
 
-    let room = format!("muji-sibling-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    // Use a UUID prefix that does NOT contain the substring "muji" —
+    // recv_matching's predicate filters by `<muji` literally below,
+    // and a room-JID-embedded "muji" substring would collide with it.
+    let room = format!("sibling-call-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
     let nick = "admin";
 
     // Web joins first (instant room creation, admin is owner). Then
@@ -453,8 +456,13 @@ async fn muji_presence_reflects_to_senders_sibling_resource() {
     // XEP-0045 §7.1 `<status code='110'/>` because mobile shares the
     // sender's bare JID and is therefore a "self" session for the
     // status-code stamping purpose.
+    // Match on the `<muji` element start tag, NOT the substring "muji"
+    // which could collide with the room JID. Both open-tag forms
+    // (with attributes / namespace) are accepted.
     let mobile_active = mobile
-        .recv_matching(|frame| frame.contains("<presence") && frame.contains("muji"))
+        .recv_matching(|frame| {
+            frame.contains("<presence") && (frame.contains("<muji ") || frame.contains("<muji>"))
+        })
         .await
         .expect("mobile receives reflected muji presence on its own WebSocket");
     let element = parse_presence(&mobile_active);
@@ -498,13 +506,18 @@ async fn muji_presence_reflects_to_senders_sibling_resource() {
     // the `<muji/>` child. The match predicate is narrow on purpose:
     // there may be unrelated frames buffered (caps, etc.); we want
     // the next presence FROM room/nick that has no `<muji/>` element.
+    let from_attr_single = format!("from='{room}/{nick}'");
+    let from_attr_double = format!("from=\"{room}/{nick}\"");
     let mobile_leave = mobile
         .recv_matching(|frame| {
             // Skip the active-muji frame we already consumed and the
             // initial join echoes; we only want a presence whose XML
-            // body has no `<muji` substring.
+            // body has no `<muji` element. Accept both attribute
+            // quoting styles to stay robust against a future
+            // minidom/rxml serializer swap (other tests in this file
+            // already guard both forms).
             frame.contains("<presence")
-                && frame.contains(&format!("from='{room}/{nick}'"))
+                && (frame.contains(&from_attr_single) || frame.contains(&from_attr_double))
                 && !frame.contains("<muji")
         })
         .await

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
@@ -918,6 +918,60 @@ async fn upsert_muji_presence_active_stores_and_returns_muji() {
 }
 
 #[tokio::test]
+async fn upsert_muji_presence_recipients_include_every_sibling_session_of_sender() {
+    // Multi-resource regression — pins the contract that the
+    // `presence/muc_update.rs` WebSocket handler relies on. When
+    // alice has TWO sessions in the room under the same nick
+    // (e.g. desktop + mobile, XEP-0045 §7.2 same-bare multi-session)
+    // and one session advertises a Muji presence, the recipients list
+    // MUST contain BOTH session full JIDs. The router uses this list
+    // to dispatch the reflection per session — without the sibling
+    // full JID, the second client never receives the live indicator.
+    let actor = spawn_room_actor().await;
+    let desktop: FullJid = "alice@example.com/desktop".parse().expect("desktop");
+    let mobile: FullJid = "alice@example.com/mobile".parse().expect("mobile");
+
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: desktop.clone(),
+            nick: "alice".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+        })
+        .await
+        .expect("desktop join");
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: mobile.clone(),
+            nick: "alice".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+        })
+        .await
+        .expect("mobile join recognized as same-bare multi-session");
+
+    let outcome = actor
+        .ask(crate::muc::room_actor::UpsertMujiPresence {
+            sender_jid: desktop.clone(),
+            muji: audio_muji(),
+        })
+        .await
+        .expect("ask")
+        .expect("alice is an occupant");
+
+    assert!(
+        outcome.update.recipients.iter().any(|jid| jid == &desktop),
+        "sender's own session must be in the recipient set: {:?}",
+        outcome.update.recipients
+    );
+    assert!(
+        outcome.update.recipients.iter().any(|jid| jid == &mobile),
+        "sibling session of the same bare JID must also be in the recipient set: {:?}",
+        outcome.update.recipients
+    );
+}
+
+#[tokio::test]
 async fn upsert_muji_presence_empty_clears_state_and_returns_none() {
     let actor = spawn_room_actor().await;
     let alice = test_full_jid("alice");


### PR DESCRIPTION
## Summary

When a user starts a MUC call in one chat instance, a **second chat instance signed in as the same user** (same bare JID, different resource) did **not** show the "call ongoing" sidebar indicator for that room. The chat-side store and the wasm/FFI bridge were correct; the bug was server-side routing of live Muji presence updates.

## Root cause

In `server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs` the recipient loop used **bare-JID** equality (`is_self`) for two distinct concerns:

1. Stamping `<status code='110'/>` on the reflected presence (XEP-0045 §7.1) — correct.
2. Picking the delivery channel (push to `responses` vs `connection_registry.try_send_to`) — wrong.

For a sibling resource of the sender (same bare JID, different full JID, *different WebSocket*), the stanza was pushed onto the **sender's** `responses` vec instead of dispatched to the sibling's WebSocket via the connection registry. The sibling therefore never received the live update.

Scenarios this explains:
- A and B both in room R; A starts a call → B never sees the chip light up.
- A in room R starts a call; B joins R *later* → B does see the chip, because `handle_muc_join` replays each occupant's persisted `MucRoom.muji_state` (the join-replay path, not the broken live-update path).
- A ends the call while B is in R → B never sees the chip clear.

## Fix

Decouple **"stamp self status code"** (bare-JID equality, unchanged) from **"which WebSocket gets the stanza"** (full-JID equality). Added `is_sender_session = recipient == sender_jid` and routed delivery on that; `is_self` continues to flow into `build_occupant_presence_update` so the status-110 stamping is unchanged.

Tiny scoped diff in one file. No type or signature changes.

## Tests

- **`server/crates/waddle-server/tests/calls_e2e_ws.rs`**: end-to-end — admin connects with two resources, both join a room, one emits Muji presence with `<content/>`, the sibling resource receives the reflection on its own WebSocket carrying `<muji/>` + `<status code='110'/>`; then the leave marker (empty `<muji/>`) propagates as a presence with the muji child stripped.
- **`server/crates/waddle-xmpp/src/muc/room_actor/tests.rs`**: pin the upstream contract — `UpsertMujiPresence` outcome's `recipients` list expands to every session of every occupant (multi-session same-bare contract).
- **`chat/tests/muc-call-presence.test.ts`**: pin that the chat store has no implicit self-presence filter — a future refactor cannot silently regress the multi-instance indicator.

Tests after adversarial review were hardened: tightened `<muji ` element-start predicate (not the substring `muji` which could collide with a room JID), added quote-style guards on the `from=` match (single + double), and a non-colliding room prefix.

## XEP conformance

- **XEP-0045 §7.1** — `<status code='110'/>` is still stamped on every recipient sharing the sender's bare JID (i.e. all of the sender's sessions). The fix does not change this.
- **XEP-0045 §7.7** — every occupant still receives every reflection; the fix changes the *channel*, never drops a recipient.
- **XEP-0272 §Joining / §Leaving** — the `<muji/>` extension's wire shape is unchanged; only the *delivery channel* for sibling-session reflections is corrected.

## Out of scope

- Reaching users whose other resources are **not** currently occupants of the room. XEP-0272 is occupant-only presence; a cross-roster/cross-room indicator would be a separate feature.
- The join-path multi-session broadcast suppression in `presence/muc.rs` — correct as-is.

## Verification

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p waddle-xmpp` (incl. new actor-level multi-session test) passes
- [x] `cargo test -p waddle-server --test calls_e2e_ws` (incl. new sibling-resource e2e test) passes
- [x] `cd chat && bun test tests/muc-call-presence.test.ts` passes
- [x] `cd chat && bun run lint` (knip) clean

## Manual test plan

- [ ] Open two chat instances signed in as the same user (different browser profiles); both join the same channel.
- [ ] Start a call in instance A → the sidebar indicator lights up in instance B within ~1s.
- [ ] End the call in instance A → the indicator clears in instance B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)