### PR TITLE
feat(server): XEP-0513 mentions#count threshold (#525 slice 3b)

### DIFF
--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
@@ -301,12 +301,19 @@ async fn insert_groupchat_notification_candidate(
     let mentions_slice: &[waddle_xmpp::xep::ExplicitMention] = explicit_mentions
         .as_ref()
         .map_or(&[], |mentions| mentions.mentions.as_slice());
+    // Parse XEP-0372 references ONCE per recipient so the §304
+    // count gate AND the personal-mention fallback consult the same
+    // pre-parsed slice. Previously each helper re-walked
+    // `message.payloads` independently (2× per recipient × N
+    // recipients = 2N walks per message) — perf review on PR #741.
+    let references_vec = waddle_xmpp::xep::extract_references_from_message(message);
+    let references_slice: &[waddle_xmpp::xep::Reference] = references_vec.as_slice();
     let GroupchatNotificationClassOutcome {
         decision: GroupchatNotificationClassDecision::Deliver(class),
         mentions_overflowed,
     } = groupchat_notification_class(
         mentions_slice,
-        message,
+        references_slice,
         owner,
         room,
         owner_occupant_id.as_str(),
@@ -664,14 +671,17 @@ struct GroupchatNotificationClassOutcome {
 /// Classify a groupchat candidate from a pre-parsed mention slice.
 ///
 /// Callers MUST pass the result of a single
-/// `extract_explicit_mentions(message)` parse so the
-/// XEP-0513 traversal is not repeated per derivation. The `message`
-/// argument is held only for the XEP-0372 references fallback in
-/// `groupchat_mentions_owner` — that XEP carries data outside the
-/// explicit-mentions tree and is parsed independently.
+/// `extract_explicit_mentions(message)` parse AND a single
+/// `extract_references_from_message(message)` parse so that neither
+/// XEP-0513 mentions nor XEP-0372 references are re-walked per
+/// derivation. The previous shape took `&Message` and re-walked the
+/// XEP-0372 payloads twice per recipient (once in the §304 count
+/// gate and once in `groupchat_mentions_owner`) — for an
+/// N-occupant room that was 2N payload sweeps per message when 1
+/// suffices (perf review on PR #741).
 fn groupchat_notification_class(
     mentions: &[waddle_xmpp::xep::ExplicitMention],
-    message: &Message,
+    references: &[waddle_xmpp::xep::Reference],
     owner: &BareJid,
     room: &BareJid,
     owner_occupant_id: &str,
@@ -715,9 +725,9 @@ fn groupchat_notification_class(
     // derivation can reuse it without re-walking the XEP-0372
     // references a second time per recipient (adversarial review on
     // PR #741).
-    let mentions_overflowed = waddle_xmpp::xep::mentions_exceed_threshold(
+    let mentions_overflowed = waddle_xmpp::xep::mentions_exceed_threshold_from_parts(
         mentions,
-        message,
+        references,
         waddle_xmpp::xep::DEFAULT_MENTIONS_COUNT,
     );
     if mentions_overflowed {
@@ -728,7 +738,7 @@ fn groupchat_notification_class(
             mentions_overflowed,
         };
     }
-    let personal_mention = groupchat_mentions_owner(mentions, message, owner, owner_occupant_id);
+    let personal_mention = groupchat_mentions_owner(mentions, references, owner, owner_occupant_id);
     let channel_mention = groupchat_channel_mention_scope(mentions, room)
         .filter(|_| sender_can_broadcast_channel_mention);
     GroupchatNotificationClassOutcome {
@@ -814,7 +824,7 @@ fn groupchat_mentions_carry_owner_noping(
 
 fn groupchat_mentions_owner(
     mentions: &[waddle_xmpp::xep::ExplicitMention],
-    message: &Message,
+    references: &[waddle_xmpp::xep::Reference],
     owner: &BareJid,
     owner_occupant_id: &str,
 ) -> bool {
@@ -841,14 +851,12 @@ fn groupchat_mentions_owner(
                     .as_deref()
                     .is_some_and(|mentioned| mentioned == owner_occupant_id))
     });
-    let xep0372 = extract_references_from_message(message)
-        .into_iter()
-        .any(|reference| {
-            reference.is_mention()
-                && reference
-                    .bare_jid()
-                    .is_some_and(|mentioned| &mentioned == owner)
-        });
+    let xep0372 = references.iter().any(|reference| {
+        reference.is_mention()
+            && reference
+                .bare_jid()
+                .is_some_and(|mentioned| &mentioned == owner)
+    });
     xep0513 || xep0372
 }
 
@@ -922,6 +930,13 @@ mod tests {
         waddle_xmpp::xep::extract_explicit_mentions(message)
             .map(|m| m.mentions)
             .unwrap_or_default()
+    }
+
+    /// Test helper: mirror of the production pre-parse for XEP-0372
+    /// references. Production hot path parses these once per
+    /// recipient in `insert_groupchat_notification_candidate`.
+    fn extract_references(message: &Message) -> Vec<waddle_xmpp::xep::Reference> {
+        waddle_xmpp::xep::extract_references_from_message(message)
     }
 
     /// Dedup regression: `groupchat_mentions_carry_owner_noping`
@@ -1052,7 +1067,7 @@ mod tests {
             message_with_mention(waddle_xmpp::xep::ExplicitMention::jid(owner.clone()));
         assert!(groupchat_mentions_owner(
             &parsed_mentions(&msg_by_jid),
-            &msg_by_jid,
+            &extract_references(&msg_by_jid),
             &owner,
             occupant_id,
         ));
@@ -1060,7 +1075,7 @@ mod tests {
             message_with_mention(waddle_xmpp::xep::ExplicitMention::occupant_id(occupant_id));
         assert!(groupchat_mentions_owner(
             &parsed_mentions(&msg_by_occ),
-            &msg_by_occ,
+            &extract_references(&msg_by_occ),
             &owner,
             occupant_id,
         ));
@@ -1070,7 +1085,7 @@ mod tests {
         let msg_noping = message_with_mention(noping);
         assert!(!groupchat_mentions_owner(
             &parsed_mentions(&msg_noping),
-            &msg_noping,
+            &extract_references(&msg_noping),
             &owner,
             occupant_id,
         ));
@@ -1080,7 +1095,7 @@ mod tests {
         ));
         assert!(!groupchat_mentions_owner(
             &parsed_mentions(&msg_other),
-            &msg_other,
+            &extract_references(&msg_other),
             &owner,
             occupant_id,
         ));
@@ -1147,7 +1162,7 @@ mod tests {
             mentions_overflowed: _,
         } = groupchat_notification_class(
             &mentions,
-            &msg,
+            &extract_references(&msg),
             &owner,
             &room,
             occupant_id,
@@ -1166,7 +1181,7 @@ mod tests {
             mentions_overflowed: _,
         } = groupchat_notification_class(
             &mentions,
-            &msg,
+            &extract_references(&msg),
             &owner,
             &room,
             occupant_id,
@@ -1205,7 +1220,7 @@ mod tests {
             mentions_overflowed: _,
         } = groupchat_notification_class(
             &mentions,
-            &msg,
+            &extract_references(&msg),
             &owner,
             &room,
             occupant_id,
@@ -1225,7 +1240,7 @@ mod tests {
             mentions_overflowed: _,
         } = groupchat_notification_class(
             &mentions,
-            &msg,
+            &extract_references(&msg),
             &owner,
             &room,
             occupant_id,
@@ -1276,7 +1291,7 @@ mod tests {
         let mentions = parsed_mentions(&msg);
         let _classifier_outcome = groupchat_notification_class(
             &mentions,
-            &msg,
+            &extract_references(&msg),
             &owner,
             &room,
             occupant_id,
@@ -1323,7 +1338,7 @@ mod tests {
             mentions_overflowed: _,
         } = groupchat_notification_class(
             &mentions,
-            &msg,
+            &extract_references(&msg),
             &owner,
             &room,
             occupant_id,
@@ -1371,7 +1386,7 @@ mod tests {
             mentions_overflowed: _,
         } = groupchat_notification_class(
             &mentions,
-            &msg,
+            &extract_references(&msg),
             &owner,
             &room,
             occupant_id,
@@ -1395,7 +1410,7 @@ mod tests {
             mentions_overflowed: _,
         } = groupchat_notification_class(
             &mentions,
-            &msg,
+            &extract_references(&msg),
             &owner,
             &room,
             occupant_id,
@@ -1451,10 +1466,10 @@ mod tests {
 
         let GroupchatNotificationClassOutcome {
             decision: GroupchatNotificationClassDecision::Deliver(class),
-            mentions_overflowed: _,
+            mentions_overflowed,
         } = groupchat_notification_class(
             &mentions,
-            &msg,
+            &extract_references(&msg),
             &owner,
             &room,
             occupant_id,
@@ -1467,6 +1482,12 @@ mod tests {
             "a message with > DEFAULT_MENTIONS_COUNT mention targets MUST \
              classify as NotifyAll — every mention is ignored per \
              XEP-0513 §304, including the one naming the owner"
+        );
+        assert!(
+            mentions_overflowed,
+            "the overflow bit MUST be propagated to the caller so the \
+             noping derivation can short-circuit without re-walking the \
+             XEP-0372 references"
         );
     }
 
@@ -1498,10 +1519,10 @@ mod tests {
 
         let GroupchatNotificationClassOutcome {
             decision: GroupchatNotificationClassDecision::Deliver(class),
-            mentions_overflowed: _,
+            mentions_overflowed,
         } = groupchat_notification_class(
             &mentions,
-            &msg,
+            &extract_references(&msg),
             &owner,
             &room,
             occupant_id,
@@ -1513,6 +1534,13 @@ mod tests {
             NotificationClass::PersonalMention,
             "exactly DEFAULT_MENTIONS_COUNT mention targets MUST be \
              honored — §304 threshold is exclusive (\"more than\")"
+        );
+        assert!(
+            !mentions_overflowed,
+            "at-threshold count MUST NOT set the overflow bit — without \
+             this lock-in, a regression flipping `>` to `>=` in \
+             `mentions_exceed_threshold` would silently un-suppress the \
+             noping bit at the boundary"
         );
     }
 
@@ -1561,7 +1589,7 @@ mod tests {
             mentions_overflowed: _,
         } = groupchat_notification_class(
             &mentions,
-            &msg,
+            &extract_references(&msg),
             &owner,
             &room,
             occupant_id,
@@ -1627,6 +1655,177 @@ mod tests {
             "the per-recipient noping helper must still see the mention; \
              only the outer count gate cancels the suppression so the \
              two helpers remain individually composable"
+        );
+    }
+
+    /// Groupchat mirror of the DM `at_threshold_preserves_noping`
+    /// test: at exactly `DEFAULT_MENTIONS_COUNT` total mentions, one
+    /// of them with `<noping/>` naming the owner, the gate MUST NOT
+    /// fire — `mentions_overflowed` stays `false` and the noping
+    /// suppressor at the emission site fires normally.
+    #[test]
+    fn xep0513_groupchat_mention_count_at_threshold_preserves_owner_noping() {
+        let owner = bare("charlie@example.com");
+        let room = bare("team@muc.example.com");
+        let occupant_id = "room-stable-charlie";
+        let threshold = waddle_xmpp::xep::DEFAULT_MENTIONS_COUNT;
+
+        let mut msg = Message::new(None::<Jid>);
+        let mut owner_noping = waddle_xmpp::xep::ExplicitMention::jid(owner.clone());
+        owner_noping.noping = true;
+        msg.payloads
+            .push(waddle_xmpp::xep::build_mention_element(&owner_noping));
+        for i in 0..(threshold - 1) {
+            msg.payloads.push(waddle_xmpp::xep::build_mention_element(
+                &waddle_xmpp::xep::ExplicitMention::jid(
+                    format!("user{i}@example.com").parse().expect("target"),
+                ),
+            ));
+        }
+        let mentions = parsed_mentions(&msg);
+        assert_eq!(mentions.len() as u32, threshold);
+
+        let GroupchatNotificationClassOutcome {
+            mentions_overflowed,
+            ..
+        } = groupchat_notification_class(
+            &mentions,
+            &extract_references(&msg),
+            &owner,
+            &room,
+            occupant_id,
+            /* is_live_occupant */ false,
+            /* sender_can_broadcast_channel_mention */ true,
+        );
+        assert!(
+            !mentions_overflowed,
+            "at-threshold MUST NOT overflow — boundary regression target"
+        );
+        assert!(
+            groupchat_mentions_carry_owner_noping(&mentions, &owner, occupant_id),
+            "owner's `<noping/>` mention is present and counted"
+        );
+        // Production emission combines the two via:
+        //   `!mentions_overflowed && groupchat_mentions_carry_owner_noping(...)`
+        // so the recipient_noping derivation produces `true` here.
+    }
+
+    /// Composition test: a non-permitted sender combines a channel
+    /// mention with enough per-user mentions to trip the §304 count
+    /// gate. Both gates converge on `NotifyAll`, but the count gate
+    /// runs FIRST so `mentions_overflowed` MUST be `true`. A future
+    /// refactor that reorders the gates (e.g. moves the channel
+    /// permission check above the count check) would change the
+    /// observable `mentions_overflowed` field — locked in here.
+    #[test]
+    fn xep0513_channel_mention_with_count_exceeded_composes_to_notify_all_with_overflow_bit() {
+        use crate::notification_outbox::NotificationClass;
+
+        let owner = bare("charlie@example.com");
+        let room = bare("team@muc.example.com");
+        let occupant_id = "room-stable-charlie";
+        let threshold = waddle_xmpp::xep::DEFAULT_MENTIONS_COUNT;
+
+        let mut msg = Message::new(None::<Jid>);
+        // One channel mention + threshold per-user mentions = threshold+1.
+        let mut channel = waddle_xmpp::xep::ExplicitMention::channel();
+        channel.uri = Some("xmpp:team@muc.example.com".to_string());
+        msg.payloads
+            .push(waddle_xmpp::xep::build_mention_element(&channel));
+        for i in 0..threshold {
+            msg.payloads.push(waddle_xmpp::xep::build_mention_element(
+                &waddle_xmpp::xep::ExplicitMention::jid(
+                    format!("user{i}@example.com").parse().expect("target"),
+                ),
+            ));
+        }
+        let mentions = parsed_mentions(&msg);
+
+        let GroupchatNotificationClassOutcome {
+            decision: GroupchatNotificationClassDecision::Deliver(class),
+            mentions_overflowed,
+        } = groupchat_notification_class(
+            &mentions,
+            &extract_references(&msg),
+            &owner,
+            &room,
+            occupant_id,
+            /* is_live_occupant */ false,
+            /* sender_can_broadcast_channel_mention */ false,
+        );
+        assert_eq!(
+            class,
+            NotificationClass::NotifyAll,
+            "non-permitted sender's channel mention + over-threshold \
+             personal mentions MUST collapse to NotifyAll"
+        );
+        assert!(
+            mentions_overflowed,
+            "the count gate runs first; the overflow bit MUST be set \
+             regardless of the channel-broadcast gate's outcome"
+        );
+    }
+
+    /// XEP-0203 §"Use in delayed delivery" composition: a delayed
+    /// (`<delay xmlns='urn:xmpp:delay'/>`) message with count
+    /// exceeded still flows through the §304 gate. The delay element
+    /// is not honored on the candidate-emission path (spoofable per
+    /// the slice 3a reverted filter), so the count gate is what
+    /// downgrades a spammy historical replay to NotifyAll. Locks the
+    /// §304 × XEP-0203 composition.
+    #[test]
+    fn xep0513_delayed_message_with_count_exceeded_still_downgrades_to_notify_all() {
+        use crate::notification_outbox::NotificationClass;
+
+        let owner = bare("charlie@example.com");
+        let room = bare("team@muc.example.com");
+        let occupant_id = "room-stable-charlie";
+        let threshold = waddle_xmpp::xep::DEFAULT_MENTIONS_COUNT;
+
+        let mut msg = Message::new(None::<Jid>);
+        for i in 0..=threshold {
+            msg.payloads.push(waddle_xmpp::xep::build_mention_element(
+                &waddle_xmpp::xep::ExplicitMention::jid(if i == 0 {
+                    owner.clone()
+                } else {
+                    format!("user{i}@example.com").parse().expect("target")
+                }),
+            ));
+        }
+        // Attach a `<delay/>` from a server-shaped JID. The candidate
+        // path doesn't honor `<delay/>` (per slice 3a's revert), so
+        // the count gate is what matters here.
+        msg.payloads
+            .push(waddle_xmpp::xep::xep0203::build_delay_element_simple(
+                chrono::TimeZone::timestamp_opt(&chrono::Utc, 1_700_000_000, 0)
+                    .single()
+                    .expect("delay stamp"),
+                "muc.example.com",
+            ));
+        let mentions = parsed_mentions(&msg);
+
+        let GroupchatNotificationClassOutcome {
+            decision: GroupchatNotificationClassDecision::Deliver(class),
+            mentions_overflowed,
+        } = groupchat_notification_class(
+            &mentions,
+            &extract_references(&msg),
+            &owner,
+            &room,
+            occupant_id,
+            /* is_live_occupant */ false,
+            /* sender_can_broadcast_channel_mention */ true,
+        );
+        assert_eq!(
+            class,
+            NotificationClass::NotifyAll,
+            "delayed message with count exceeded MUST still downgrade \
+             — §304 fires regardless of XEP-0203 presence"
+        );
+        assert!(
+            mentions_overflowed,
+            "the count gate fires for delayed messages identically to \
+             live ones"
         );
     }
 }

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
@@ -310,7 +310,10 @@ async fn insert_groupchat_notification_candidate(
     let references_slice: &[waddle_xmpp::xep::Reference] = references_vec.as_slice();
     let GroupchatNotificationClassOutcome {
         decision: GroupchatNotificationClassDecision::Deliver(class),
-        mentions_overflowed,
+        // The overflow bit is consumed by the classifier — the
+        // class downgrade reflects it. We deliberately do NOT use
+        // it to gate `<noping/>` (see below).
+        mentions_overflowed: _,
     } = groupchat_notification_class(
         mentions_slice,
         references_slice,
@@ -320,18 +323,23 @@ async fn insert_groupchat_notification_candidate(
         is_live_occupant,
         sender_can_broadcast_channel_mention,
     );
-    // XEP-0513 §304: when the per-message mention count exceeds the
-    // threshold, the recipient SHOULD ignore *all* mentions on the
-    // message — including any `<noping/>` attribute targeting this
-    // recipient. Without this guard a sender could spam mentions to
-    // exceed the threshold AND attach `<noping/>` for the recipient,
-    // and the `Xep0513Noping` T1 suppressor would still fire — turning
-    // the count gate into a push-suppression primitive instead of a
-    // spam mitigation. The `mentions_overflowed` bit is reused from
-    // the classifier's outcome so the XEP-0372 reference walk runs
-    // exactly once per recipient (adversarial review on PR #741).
-    let recipient_noping = !mentions_overflowed
-        && groupchat_mentions_carry_owner_noping(mentions_slice, owner, owner_occupant_id.as_str());
+    // XEP-0513 §"No Ping": "if the sender includes a `<noping/>`
+    // child element in a mention, the receiving entity SHOULD NOT
+    // generate a notification (ping) for that mention." That SHOULD
+    // is INDEPENDENT of §304's "ignore all mentions" cap — the
+    // existing slice-2a T1 suppressor (`SuppressedReason::Xep0513Noping`)
+    // honors `<noping/>` unconditionally for every class. A prior
+    // shape of this code canceled the noping bit on count-overflow
+    // (to prevent a spammer silencing push via `<noping/>` + mention
+    // spam), but that contradicts both the §"No Ping" SHOULD and
+    // the existing T1 behavior — push candidate creation MUST be
+    // suppressed for `<noping/>` recipients even when the message
+    // overflows the §304 count cap, while normal delivery + MAM +
+    // inbox projection are unaffected (compliance review on
+    // PR #741). The class downgrade caused by overflow remains; only
+    // the per-recipient `<noping/>` suppression survives the cap.
+    let recipient_noping =
+        groupchat_mentions_carry_owner_noping(mentions_slice, owner, owner_occupant_id.as_str());
     let hints = crate::notification_outbox::NotificationMessageHints::none()
         .with_noping(recipient_noping)
         .with_xep0334(
@@ -1606,25 +1614,27 @@ mod tests {
         );
     }
 
-    /// XEP-0513 §304 + Codex-style hardening: when the threshold is
-    /// exceeded, EVERY mention is ignored — including any
-    /// `<noping/>` attribute targeting the recipient. Otherwise an
-    /// attacker spams mentions to exceed the threshold AND attaches
-    /// `<noping/>` for the recipient, and the `Xep0513Noping` T1
-    /// suppressor still fires — turning the count gate into a push-
-    /// suppression primitive instead of a spam mitigation.
+    /// XEP-0513 §"No Ping" is INDEPENDENT of §304's "ignore all
+    /// mentions" cap (compliance review on PR #741). When the
+    /// threshold is exceeded:
+    ///
+    ///   - the CLASS is downgraded to `NotifyAll` per §304;
+    ///   - per-recipient `<noping/>` is PRESERVED — the existing
+    ///     T0/T1 `Xep0513Noping` suppressor fires for the recipient
+    ///     even on overflowed messages, suppressing push candidate
+    ///     creation without affecting delivery / MAM / inbox.
+    ///
+    /// This lock-in test asserts the predicate that
+    /// `insert_groupchat_notification_candidate` reads:
+    /// `groupchat_mentions_carry_owner_noping` MUST return true
+    /// regardless of overflow, because the production code no
+    /// longer combines it with `!mentions_overflowed`.
     #[test]
-    fn xep0513_mention_count_exceeded_also_ignores_noping_suppression() {
+    fn xep0513_noping_survives_mention_count_overflow() {
         let owner = bare("charlie@example.com");
         let occupant_id = "room-stable-charlie";
         let threshold = waddle_xmpp::xep::DEFAULT_MENTIONS_COUNT;
 
-        // Build threshold+1 mentions; one of them names owner with
-        // `<noping/>`. The classifier-side gate handles class
-        // downgrade; the candidate-emission site separately gates
-        // the noping bit via `mentions_exceed_threshold` (see
-        // `enqueue_groupchat_notification_candidate`). This test
-        // locks the predicate that the noping derivation reads.
         let mut msg = Message::new(None::<Jid>);
         let mut owner_noping = waddle_xmpp::xep::ExplicitMention::jid(owner.clone());
         owner_noping.noping = true;
@@ -1639,22 +1649,22 @@ mod tests {
         }
         let mentions = parsed_mentions(&msg);
 
-        // Sanity: the threshold IS exceeded — the predicate the
-        // emission site reads MUST return true.
+        // Sanity: the threshold IS exceeded.
         assert!(
             waddle_xmpp::xep::mentions_exceed_threshold(&mentions, &msg, threshold),
             "fixture must trip the threshold predicate"
         );
-        // And the per-recipient noping helper still reports true
-        // by itself — the count gate is the OUTER cancel, not an
-        // inner one. The emission site combines the two via:
-        //   `!mentions_exceed_threshold && groupchat_mentions_carry_owner_noping`
-        // so the final bit on the candidate is `false`.
+        // The per-recipient noping helper reports true regardless of
+        // overflow. Production code at
+        // `enqueue_groupchat_notification_candidate` uses this
+        // predicate unconditionally — the overflow bit no longer
+        // gates the noping suppression. Compliance with XEP-0513
+        // §"No Ping" PR Compliance ID 7.
         assert!(
             groupchat_mentions_carry_owner_noping(&mentions, &owner, occupant_id),
-            "the per-recipient noping helper must still see the mention; \
-             only the outer count gate cancels the suppression so the \
-             two helpers remain individually composable"
+            "owner's `<noping/>` mention MUST be honored even when the \
+             message overflows the §304 count cap — the §\"No Ping\" \
+             SHOULD operates independently of §304's class downgrade"
         );
     }
 

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
@@ -301,7 +301,10 @@ async fn insert_groupchat_notification_candidate(
     let mentions_slice: &[waddle_xmpp::xep::ExplicitMention] = explicit_mentions
         .as_ref()
         .map_or(&[], |mentions| mentions.mentions.as_slice());
-    let GroupchatNotificationClassDecision::Deliver(class) = groupchat_notification_class(
+    let GroupchatNotificationClassOutcome {
+        decision: GroupchatNotificationClassDecision::Deliver(class),
+        mentions_overflowed,
+    } = groupchat_notification_class(
         mentions_slice,
         message,
         owner,
@@ -317,16 +320,11 @@ async fn insert_groupchat_notification_candidate(
     // exceed the threshold AND attach `<noping/>` for the recipient,
     // and the `Xep0513Noping` T1 suppressor would still fire — turning
     // the count gate into a push-suppression primitive instead of a
-    // spam mitigation (Codex-style adversarial follow-up to slice 3b).
-    let recipient_noping = !waddle_xmpp::xep::mentions_exceed_threshold(
-        mentions_slice,
-        message,
-        waddle_xmpp::xep::DEFAULT_MENTIONS_COUNT,
-    ) && groupchat_mentions_carry_owner_noping(
-        mentions_slice,
-        owner,
-        owner_occupant_id.as_str(),
-    );
+    // spam mitigation. The `mentions_overflowed` bit is reused from
+    // the classifier's outcome so the XEP-0372 reference walk runs
+    // exactly once per recipient (adversarial review on PR #741).
+    let recipient_noping = !mentions_overflowed
+        && groupchat_mentions_carry_owner_noping(mentions_slice, owner, owner_occupant_id.as_str());
     let hints = crate::notification_outbox::NotificationMessageHints::none()
         .with_noping(recipient_noping)
         .with_xep0334(
@@ -647,6 +645,22 @@ enum GroupchatNotificationClassDecision {
     Deliver(crate::notification_outbox::NotificationClass),
 }
 
+/// Outcome of `groupchat_notification_class`. Carries both the typed
+/// class decision and the XEP-0513 §304 "mention count exceeded" bit
+/// so the candidate-emission caller can reuse the bit when gating
+/// the recipient's `<noping/>` derivation — without re-running the
+/// XEP-0372 reference walk a second time per recipient.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct GroupchatNotificationClassOutcome {
+    decision: GroupchatNotificationClassDecision,
+    /// `true` when the per-message mention count exceeded the
+    /// `mentions#count` threshold and the classifier collapsed every
+    /// mention to `NotifyAll`. The candidate-emission noping
+    /// derivation reads this so `<noping/>` is also ignored — see
+    /// the §304 "ignore ALL mentions" SHOULD.
+    mentions_overflowed: bool,
+}
+
 /// Classify a groupchat candidate from a pre-parsed mention slice.
 ///
 /// Callers MUST pass the result of a single
@@ -686,7 +700,7 @@ fn groupchat_notification_class(
     // — server default policy is `mentions#channel = moderators`
     // (XEP-0513 example value).
     sender_can_broadcast_channel_mention: bool,
-) -> GroupchatNotificationClassDecision {
+) -> GroupchatNotificationClassOutcome {
     // XEP-0513 §304: "Receiving entities SHOULD ignore all mentions if
     // the message contains more mentions than the threshold specified
     // by `mentions#count`." When the per-message count exceeds the
@@ -695,19 +709,36 @@ fn groupchat_notification_class(
     // The wire payload is preserved (delivery + MAM unchanged per
     // XEP-0513 §526); only the push class is affected. Per-room
     // override of the threshold is deferred to slice 3c.
-    if waddle_xmpp::xep::mentions_exceed_threshold(
+    //
+    // The overflow bit is also propagated to the candidate-emission
+    // caller via `GroupchatNotificationClassOutcome` so the noping
+    // derivation can reuse it without re-walking the XEP-0372
+    // references a second time per recipient (adversarial review on
+    // PR #741).
+    let mentions_overflowed = waddle_xmpp::xep::mentions_exceed_threshold(
         mentions,
         message,
         waddle_xmpp::xep::DEFAULT_MENTIONS_COUNT,
-    ) {
-        return GroupchatNotificationClassDecision::Deliver(
-            crate::notification_outbox::NotificationClass::NotifyAll,
-        );
+    );
+    if mentions_overflowed {
+        return GroupchatNotificationClassOutcome {
+            decision: GroupchatNotificationClassDecision::Deliver(
+                crate::notification_outbox::NotificationClass::NotifyAll,
+            ),
+            mentions_overflowed,
+        };
     }
     let personal_mention = groupchat_mentions_owner(mentions, message, owner, owner_occupant_id);
     let channel_mention = groupchat_channel_mention_scope(mentions, room)
         .filter(|_| sender_can_broadcast_channel_mention);
-    groupchat_notification_class_from_message(personal_mention, channel_mention, is_live_occupant)
+    GroupchatNotificationClassOutcome {
+        decision: groupchat_notification_class_from_message(
+            personal_mention,
+            channel_mention,
+            is_live_occupant,
+        ),
+        mentions_overflowed,
+    }
 }
 
 /// Message-derived classification of a groupchat notification candidate.
@@ -1111,7 +1142,10 @@ mod tests {
         let mentions = parsed_mentions(&msg);
 
         // Permitted sender (moderator) → ChannelMention.
-        let GroupchatNotificationClassDecision::Deliver(permitted) = groupchat_notification_class(
+        let GroupchatNotificationClassOutcome {
+            decision: GroupchatNotificationClassDecision::Deliver(permitted),
+            mentions_overflowed: _,
+        } = groupchat_notification_class(
             &mentions,
             &msg,
             &owner,
@@ -1127,7 +1161,10 @@ mod tests {
         );
 
         // Non-permitted sender (participant) → NotifyAll (downgrade).
-        let GroupchatNotificationClassDecision::Deliver(downgraded) = groupchat_notification_class(
+        let GroupchatNotificationClassOutcome {
+            decision: GroupchatNotificationClassDecision::Deliver(downgraded),
+            mentions_overflowed: _,
+        } = groupchat_notification_class(
             &mentions,
             &msg,
             &owner,
@@ -1163,7 +1200,10 @@ mod tests {
         let mentions = parsed_mentions(&msg);
 
         // Permitted sender + live occupant → ActiveChannelMention.
-        let GroupchatNotificationClassDecision::Deliver(permitted) = groupchat_notification_class(
+        let GroupchatNotificationClassOutcome {
+            decision: GroupchatNotificationClassDecision::Deliver(permitted),
+            mentions_overflowed: _,
+        } = groupchat_notification_class(
             &mentions,
             &msg,
             &owner,
@@ -1180,7 +1220,10 @@ mod tests {
         );
 
         // Non-permitted sender + live occupant → NotifyAll.
-        let GroupchatNotificationClassDecision::Deliver(downgraded) = groupchat_notification_class(
+        let GroupchatNotificationClassOutcome {
+            decision: GroupchatNotificationClassDecision::Deliver(downgraded),
+            mentions_overflowed: _,
+        } = groupchat_notification_class(
             &mentions,
             &msg,
             &owner,
@@ -1231,7 +1274,7 @@ mod tests {
         // downgrades the class). The classifier returns the class
         // only — it MUST NOT mutate the message payloads.
         let mentions = parsed_mentions(&msg);
-        let _ = groupchat_notification_class(
+        let _classifier_outcome = groupchat_notification_class(
             &mentions,
             &msg,
             &owner,
@@ -1275,7 +1318,10 @@ mod tests {
         let msg = message_with_mention(waddle_xmpp::xep::ExplicitMention::jid(owner.clone()));
         let mentions = parsed_mentions(&msg);
 
-        let GroupchatNotificationClassDecision::Deliver(class) = groupchat_notification_class(
+        let GroupchatNotificationClassOutcome {
+            decision: GroupchatNotificationClassDecision::Deliver(class),
+            mentions_overflowed: _,
+        } = groupchat_notification_class(
             &mentions,
             &msg,
             &owner,
@@ -1320,7 +1366,10 @@ mod tests {
 
         // Non-permitted sender (participant). With the fix, the
         // channel-scope wins and the gate downgrades to NotifyAll.
-        let GroupchatNotificationClassDecision::Deliver(class) = groupchat_notification_class(
+        let GroupchatNotificationClassOutcome {
+            decision: GroupchatNotificationClassDecision::Deliver(class),
+            mentions_overflowed: _,
+        } = groupchat_notification_class(
             &mentions,
             &msg,
             &owner,
@@ -1341,7 +1390,10 @@ mod tests {
         // Permitted sender (moderator). Channel-scope still wins, and
         // the gate now classifies as ChannelMention — NOT
         // PersonalMention.
-        let GroupchatNotificationClassDecision::Deliver(class) = groupchat_notification_class(
+        let GroupchatNotificationClassOutcome {
+            decision: GroupchatNotificationClassDecision::Deliver(class),
+            mentions_overflowed: _,
+        } = groupchat_notification_class(
             &mentions,
             &msg,
             &owner,
@@ -1397,7 +1449,10 @@ mod tests {
             "fixture must produce more than threshold mentions"
         );
 
-        let GroupchatNotificationClassDecision::Deliver(class) = groupchat_notification_class(
+        let GroupchatNotificationClassOutcome {
+            decision: GroupchatNotificationClassDecision::Deliver(class),
+            mentions_overflowed: _,
+        } = groupchat_notification_class(
             &mentions,
             &msg,
             &owner,
@@ -1441,7 +1496,10 @@ mod tests {
         let mentions = parsed_mentions(&msg);
         assert_eq!(mentions.len() as u32, threshold);
 
-        let GroupchatNotificationClassDecision::Deliver(class) = groupchat_notification_class(
+        let GroupchatNotificationClassOutcome {
+            decision: GroupchatNotificationClassDecision::Deliver(class),
+            mentions_overflowed: _,
+        } = groupchat_notification_class(
             &mentions,
             &msg,
             &owner,
@@ -1498,7 +1556,10 @@ mod tests {
             "fixture must produce more than {threshold} combined mention targets (got {total})"
         );
 
-        let GroupchatNotificationClassDecision::Deliver(class) = groupchat_notification_class(
+        let GroupchatNotificationClassOutcome {
+            decision: GroupchatNotificationClassDecision::Deliver(class),
+            mentions_overflowed: _,
+        } = groupchat_notification_class(
             &mentions,
             &msg,
             &owner,

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
@@ -310,12 +310,25 @@ async fn insert_groupchat_notification_candidate(
         is_live_occupant,
         sender_can_broadcast_channel_mention,
     );
+    // XEP-0513 §304: when the per-message mention count exceeds the
+    // threshold, the recipient SHOULD ignore *all* mentions on the
+    // message — including any `<noping/>` attribute targeting this
+    // recipient. Without this guard a sender could spam mentions to
+    // exceed the threshold AND attach `<noping/>` for the recipient,
+    // and the `Xep0513Noping` T1 suppressor would still fire — turning
+    // the count gate into a push-suppression primitive instead of a
+    // spam mitigation (Codex-style adversarial follow-up to slice 3b).
+    let recipient_noping = !waddle_xmpp::xep::mentions_exceed_threshold(
+        mentions_slice,
+        message,
+        waddle_xmpp::xep::DEFAULT_MENTIONS_COUNT,
+    ) && groupchat_mentions_carry_owner_noping(
+        mentions_slice,
+        owner,
+        owner_occupant_id.as_str(),
+    );
     let hints = crate::notification_outbox::NotificationMessageHints::none()
-        .with_noping(groupchat_mentions_carry_owner_noping(
-            mentions_slice,
-            owner,
-            owner_occupant_id.as_str(),
-        ))
+        .with_noping(recipient_noping)
         .with_xep0334(
             waddle_xmpp::xep::xep0334::has_hint(message, waddle_xmpp::xep::xep0334::Hint::NoStore),
             waddle_xmpp::xep::xep0334::has_hint(
@@ -674,6 +687,23 @@ fn groupchat_notification_class(
     // (XEP-0513 example value).
     sender_can_broadcast_channel_mention: bool,
 ) -> GroupchatNotificationClassDecision {
+    // XEP-0513 §304: "Receiving entities SHOULD ignore all mentions if
+    // the message contains more mentions than the threshold specified
+    // by `mentions#count`." When the per-message count exceeds the
+    // server-internal default, fall through to `NotifyAll` — neither
+    // personal-mention nor channel-mention classification applies.
+    // The wire payload is preserved (delivery + MAM unchanged per
+    // XEP-0513 §526); only the push class is affected. Per-room
+    // override of the threshold is deferred to slice 3c.
+    if waddle_xmpp::xep::mentions_exceed_threshold(
+        mentions,
+        message,
+        waddle_xmpp::xep::DEFAULT_MENTIONS_COUNT,
+    ) {
+        return GroupchatNotificationClassDecision::Deliver(
+            crate::notification_outbox::NotificationClass::NotifyAll,
+        );
+    }
     let personal_mention = groupchat_mentions_owner(mentions, message, owner, owner_occupant_id);
     let channel_mention = groupchat_channel_mention_scope(mentions, room)
         .filter(|_| sender_can_broadcast_channel_mention);
@@ -1327,6 +1357,215 @@ mod tests {
              permitted sender MUST classify as ChannelMention — the \
              channel-scope attribute is authoritative regardless of any \
              per-recipient targeting attributes"
+        );
+    }
+
+    /// XEP-0513 §304 SHOULD: "Receiving entities SHOULD ignore all
+    /// mentions if the message contains more mentions than the
+    /// threshold specified by `mentions#count`." This locks the
+    /// server-internal default (`DEFAULT_MENTIONS_COUNT = 5`).
+    /// Exceeding the threshold MUST collapse classification to
+    /// `NotifyAll` — not just discard the excess, but ignore EVERY
+    /// mention on the message including the ones below the threshold
+    /// boundary (slice 3b of #525).
+    #[test]
+    fn xep0513_mention_count_exceeded_ignores_all_mentions() {
+        use crate::notification_outbox::NotificationClass;
+
+        let owner = bare("charlie@example.com");
+        let room = bare("team@muc.example.com");
+        let occupant_id = "room-stable-charlie";
+
+        // Build a message with EXACTLY threshold+1 personal mentions,
+        // one of which targets `owner`. Without the count gate, owner
+        // would classify as `PersonalMention`.
+        let threshold = waddle_xmpp::xep::DEFAULT_MENTIONS_COUNT;
+        let mut msg = Message::new(None::<Jid>);
+        for i in 0..=threshold {
+            let target = if i == 0 {
+                owner.clone()
+            } else {
+                format!("user{i}@example.com").parse().expect("target jid")
+            };
+            msg.payloads.push(waddle_xmpp::xep::build_mention_element(
+                &waddle_xmpp::xep::ExplicitMention::jid(target),
+            ));
+        }
+        let mentions = parsed_mentions(&msg);
+        assert!(
+            mentions.len() as u32 > threshold,
+            "fixture must produce more than threshold mentions"
+        );
+
+        let GroupchatNotificationClassDecision::Deliver(class) = groupchat_notification_class(
+            &mentions,
+            &msg,
+            &owner,
+            &room,
+            occupant_id,
+            /* is_live_occupant */ false,
+            /* sender_can_broadcast_channel_mention */ true,
+        );
+        assert_eq!(
+            class,
+            NotificationClass::NotifyAll,
+            "a message with > DEFAULT_MENTIONS_COUNT mention targets MUST \
+             classify as NotifyAll — every mention is ignored per \
+             XEP-0513 §304, including the one naming the owner"
+        );
+    }
+
+    /// At-threshold (exactly `DEFAULT_MENTIONS_COUNT` targets) MUST
+    /// still be honored — §304 says "more than the threshold", so
+    /// the boundary value is inclusive.
+    #[test]
+    fn xep0513_mention_count_at_threshold_is_honored() {
+        use crate::notification_outbox::NotificationClass;
+
+        let owner = bare("charlie@example.com");
+        let room = bare("team@muc.example.com");
+        let occupant_id = "room-stable-charlie";
+
+        let threshold = waddle_xmpp::xep::DEFAULT_MENTIONS_COUNT;
+        let mut msg = Message::new(None::<Jid>);
+        for i in 0..threshold {
+            let target = if i == 0 {
+                owner.clone()
+            } else {
+                format!("user{i}@example.com").parse().expect("target jid")
+            };
+            msg.payloads.push(waddle_xmpp::xep::build_mention_element(
+                &waddle_xmpp::xep::ExplicitMention::jid(target),
+            ));
+        }
+        let mentions = parsed_mentions(&msg);
+        assert_eq!(mentions.len() as u32, threshold);
+
+        let GroupchatNotificationClassDecision::Deliver(class) = groupchat_notification_class(
+            &mentions,
+            &msg,
+            &owner,
+            &room,
+            occupant_id,
+            /* is_live_occupant */ false,
+            /* sender_can_broadcast_channel_mention */ true,
+        );
+        assert_eq!(
+            class,
+            NotificationClass::PersonalMention,
+            "exactly DEFAULT_MENTIONS_COUNT mention targets MUST be \
+             honored — §304 threshold is exclusive (\"more than\")"
+        );
+    }
+
+    /// XEP-0372 references are also counted toward the §304
+    /// threshold. Without this, an attacker bypasses the gate by
+    /// using `<reference type='mention' uri='xmpp:X'/>` instead of
+    /// XEP-0513 `<mention/>` — same mention semantics, different
+    /// wire shape.
+    #[test]
+    fn xep0513_mention_count_includes_xep0372_references() {
+        use crate::notification_outbox::NotificationClass;
+
+        let owner = bare("charlie@example.com");
+        let room = bare("team@muc.example.com");
+        let occupant_id = "room-stable-charlie";
+        let threshold = waddle_xmpp::xep::DEFAULT_MENTIONS_COUNT;
+
+        // Half XEP-0513, half XEP-0372 — together exceed threshold.
+        let half = threshold / 2 + 1;
+        let mut msg = Message::new(None::<Jid>);
+        msg.payloads.push(waddle_xmpp::xep::build_mention_element(
+            &waddle_xmpp::xep::ExplicitMention::jid(owner.clone()),
+        ));
+        for i in 1..half {
+            msg.payloads.push(waddle_xmpp::xep::build_mention_element(
+                &waddle_xmpp::xep::ExplicitMention::jid(
+                    format!("user{i}@example.com").parse().expect("target"),
+                ),
+            ));
+        }
+        for i in 0..(threshold - half + 2) {
+            msg.payloads.push(waddle_xmpp::xep::build_reference_element(
+                &waddle_xmpp::xep::Reference::mention(format!("xmpp:ref{i}@example.com")),
+            ));
+        }
+        let mentions = parsed_mentions(&msg);
+
+        let total = waddle_xmpp::xep::mention_target_count(&mentions, &msg);
+        assert!(
+            total > threshold,
+            "fixture must produce more than {threshold} combined mention targets (got {total})"
+        );
+
+        let GroupchatNotificationClassDecision::Deliver(class) = groupchat_notification_class(
+            &mentions,
+            &msg,
+            &owner,
+            &room,
+            occupant_id,
+            /* is_live_occupant */ false,
+            /* sender_can_broadcast_channel_mention */ true,
+        );
+        assert_eq!(
+            class,
+            NotificationClass::NotifyAll,
+            "XEP-0372 reference count + XEP-0513 mention count combined \
+             MUST trigger the §304 threshold — using references to \
+             bypass the cap is exactly the abuse vector this gate \
+             closes"
+        );
+    }
+
+    /// XEP-0513 §304 + Codex-style hardening: when the threshold is
+    /// exceeded, EVERY mention is ignored — including any
+    /// `<noping/>` attribute targeting the recipient. Otherwise an
+    /// attacker spams mentions to exceed the threshold AND attaches
+    /// `<noping/>` for the recipient, and the `Xep0513Noping` T1
+    /// suppressor still fires — turning the count gate into a push-
+    /// suppression primitive instead of a spam mitigation.
+    #[test]
+    fn xep0513_mention_count_exceeded_also_ignores_noping_suppression() {
+        let owner = bare("charlie@example.com");
+        let occupant_id = "room-stable-charlie";
+        let threshold = waddle_xmpp::xep::DEFAULT_MENTIONS_COUNT;
+
+        // Build threshold+1 mentions; one of them names owner with
+        // `<noping/>`. The classifier-side gate handles class
+        // downgrade; the candidate-emission site separately gates
+        // the noping bit via `mentions_exceed_threshold` (see
+        // `enqueue_groupchat_notification_candidate`). This test
+        // locks the predicate that the noping derivation reads.
+        let mut msg = Message::new(None::<Jid>);
+        let mut owner_noping = waddle_xmpp::xep::ExplicitMention::jid(owner.clone());
+        owner_noping.noping = true;
+        msg.payloads
+            .push(waddle_xmpp::xep::build_mention_element(&owner_noping));
+        for i in 0..threshold {
+            msg.payloads.push(waddle_xmpp::xep::build_mention_element(
+                &waddle_xmpp::xep::ExplicitMention::jid(
+                    format!("user{i}@example.com").parse().expect("target"),
+                ),
+            ));
+        }
+        let mentions = parsed_mentions(&msg);
+
+        // Sanity: the threshold IS exceeded — the predicate the
+        // emission site reads MUST return true.
+        assert!(
+            waddle_xmpp::xep::mentions_exceed_threshold(&mentions, &msg, threshold),
+            "fixture must trip the threshold predicate"
+        );
+        // And the per-recipient noping helper still reports true
+        // by itself — the count gate is the OUTER cancel, not an
+        // inner one. The emission site combines the two via:
+        //   `!mentions_exceed_threshold && groupchat_mentions_carry_owner_noping`
+        // so the final bit on the candidate is `false`.
+        assert!(
+            groupchat_mentions_carry_owner_noping(&mentions, &owner, occupant_id),
+            "the per-recipient noping helper must still see the mention; \
+             only the outer count gate cancels the suppression so the \
+             two helpers remain individually composable"
         );
     }
 }

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
@@ -669,10 +669,14 @@ enum GroupchatNotificationClassDecision {
 struct GroupchatNotificationClassOutcome {
     decision: GroupchatNotificationClassDecision,
     /// `true` when the per-message mention count exceeded the
-    /// `mentions#count` threshold and the classifier collapsed every
-    /// mention to `NotifyAll`. The candidate-emission noping
-    /// derivation reads this so `<noping/>` is also ignored — see
-    /// the §304 "ignore ALL mentions" SHOULD.
+    /// XEP-0513 §304 `mentions#count` threshold and the classifier
+    /// collapsed every mention TARGET to `NotifyAll`. The candidate-
+    /// emission path discards this bit today (the noping derivation
+    /// is independent of overflow per the XEP-0513 §"No Ping"
+    /// SHOULD — see the comment near `recipient_noping`) but the
+    /// field is kept on the outcome for direct test assertions and
+    /// for any future T0 hint that genuinely depends on the
+    /// "overflowed at classification time" provenance.
     mentions_overflowed: bool,
 }
 
@@ -1715,9 +1719,13 @@ mod tests {
             groupchat_mentions_carry_owner_noping(&mentions, &owner, occupant_id),
             "owner's `<noping/>` mention is present and counted"
         );
-        // Production emission combines the two via:
-        //   `!mentions_overflowed && groupchat_mentions_carry_owner_noping(...)`
-        // so the recipient_noping derivation produces `true` here.
+        // Production emission reads `groupchat_mentions_carry_owner_noping(...)`
+        // unconditionally (the overflow bit no longer gates the
+        // noping derivation per the XEP-0513 §"No Ping" SHOULD —
+        // see commit d17004c3 / `xep0513_noping_survives_mention_count_overflow`).
+        // At-threshold + `<noping/>` therefore produces
+        // `recipient_noping = true` and the T0/T1 `Xep0513Noping`
+        // suppressor fires for this recipient.
     }
 
     /// Composition test: a non-permitted sender combines a channel

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
@@ -660,23 +660,30 @@ enum GroupchatNotificationClassDecision {
     Deliver(crate::notification_outbox::NotificationClass),
 }
 
-/// Outcome of `groupchat_notification_class`. Carries both the typed
-/// class decision and the XEP-0513 §304 "mention count exceeded" bit
-/// so the candidate-emission caller can reuse the bit when gating
-/// the recipient's `<noping/>` derivation — without re-running the
-/// XEP-0372 reference walk a second time per recipient.
+/// Outcome of `groupchat_notification_class`. Carries the typed
+/// class decision plus the XEP-0513 §304 "mention count exceeded"
+/// provenance bit. The class decision already reflects the overflow
+/// (it collapses to `NotifyAll` when the cap is exceeded); the
+/// separate `mentions_overflowed` field exposes the provenance so
+/// tests can assert it directly and so a future T0 hint that
+/// genuinely depends on the "overflowed at classification time"
+/// signal can read it without re-running the §304 count helpers.
+///
+/// The candidate-emission caller deliberately does NOT gate the
+/// recipient's `<noping/>` derivation on this bit — XEP-0513
+/// §"No Ping" is independent of §304's "ignore all mentions" cap.
+/// See the comment near `recipient_noping` in
+/// [`enqueue_groupchat_notification_candidate`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct GroupchatNotificationClassOutcome {
     decision: GroupchatNotificationClassDecision,
     /// `true` when the per-message mention count exceeded the
     /// XEP-0513 §304 `mentions#count` threshold and the classifier
-    /// collapsed every mention TARGET to `NotifyAll`. The candidate-
-    /// emission path discards this bit today (the noping derivation
-    /// is independent of overflow per the XEP-0513 §"No Ping"
-    /// SHOULD — see the comment near `recipient_noping`) but the
-    /// field is kept on the outcome for direct test assertions and
-    /// for any future T0 hint that genuinely depends on the
-    /// "overflowed at classification time" provenance.
+    /// collapsed every mention TARGET to `NotifyAll`. Production
+    /// emission discards this bit (see struct doc above); the
+    /// field is consumed in the count-gate tests
+    /// (`xep0513_mention_count_*`) and is available to any future
+    /// T0 hint that needs the overflow provenance.
     mentions_overflowed: bool,
 }
 

--- a/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
@@ -514,6 +514,21 @@ fn mention_bits_for_recipient(message: &Message, recipient: &BareJid) -> Recipie
     let Some(mentions) = waddle_xmpp::xep::extract_explicit_mentions(message) else {
         return RecipientMentionBits::default();
     };
+    // XEP-0513 §304: "Receiving entities SHOULD ignore all mentions
+    // if the message contains more mentions than the threshold." A
+    // sender spamming N per-JID mentions on a DM (the same abuse
+    // vector blocked on the groupchat candidate path) would otherwise
+    // promote every recipient's class to `dm_mention` and ALSO be
+    // able to attach `<noping/>` to suppress the very push they
+    // forced. Treating count-exceeded as "no mentions present"
+    // collapses both surfaces back to the regular DM push.
+    if waddle_xmpp::xep::mentions_exceed_threshold(
+        &mentions.mentions,
+        message,
+        waddle_xmpp::xep::DEFAULT_MENTIONS_COUNT,
+    ) {
+        return RecipientMentionBits::default();
+    }
     let mut bits = RecipientMentionBits::default();
     for mention in &mentions.mentions {
         let names_recipient = mention

--- a/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
@@ -663,4 +663,71 @@ mod tests {
             RecipientMentionBits::default(),
         );
     }
+
+    /// XEP-0513 §304 SHOULD: when the per-message count exceeds the
+    /// threshold, the recipient ignores ALL mentions. For DM that
+    /// means the candidate falls through from `dm_mention` to plain
+    /// `dm` — even if one of the mentions legitimately names this
+    /// recipient. Lock the strict-§304 behavior (adversarial review
+    /// on PR #741).
+    #[test]
+    fn xep0513_dm_mention_count_exceeded_returns_default_bits() {
+        let recipient = bare("alice@example.com");
+        let threshold = waddle_xmpp::xep::DEFAULT_MENTIONS_COUNT;
+
+        let mut msg = xmpp_parsers::message::Message::new(None::<jid::Jid>);
+        // One mention naming the recipient (would normally trigger
+        // is_mention=true), plus enough others to push count >
+        // threshold.
+        msg.payloads.push(waddle_xmpp::xep::build_mention_element(
+            &waddle_xmpp::xep::ExplicitMention::jid(recipient.clone()),
+        ));
+        for i in 0..threshold {
+            msg.payloads.push(waddle_xmpp::xep::build_mention_element(
+                &waddle_xmpp::xep::ExplicitMention::jid(
+                    format!("user{i}@example.com").parse().expect("user bare"),
+                ),
+            ));
+        }
+        assert_eq!(
+            mention_bits_for_recipient(&msg, &recipient),
+            RecipientMentionBits::default(),
+            "DM with > DEFAULT_MENTIONS_COUNT mentions MUST collapse \
+             to default bits even when the recipient is named — \
+             §304 ignores ALL mentions"
+        );
+    }
+
+    /// At-threshold (exactly `DEFAULT_MENTIONS_COUNT` mentions) MUST
+    /// preserve the recipient's `<noping/>` suppression. The §304
+    /// threshold is exclusive ("more than"), so equal-count is still
+    /// honored.
+    #[test]
+    fn xep0513_dm_mention_count_at_threshold_preserves_noping() {
+        let recipient = bare("alice@example.com");
+        let threshold = waddle_xmpp::xep::DEFAULT_MENTIONS_COUNT;
+
+        let mut msg = xmpp_parsers::message::Message::new(None::<jid::Jid>);
+        let mut recipient_noping = waddle_xmpp::xep::ExplicitMention::jid(recipient.clone());
+        recipient_noping.noping = true;
+        msg.payloads
+            .push(waddle_xmpp::xep::build_mention_element(&recipient_noping));
+        // Fill to exactly threshold mentions total.
+        for i in 0..(threshold - 1) {
+            msg.payloads.push(waddle_xmpp::xep::build_mention_element(
+                &waddle_xmpp::xep::ExplicitMention::jid(
+                    format!("user{i}@example.com").parse().expect("user bare"),
+                ),
+            ));
+        }
+        let bits = mention_bits_for_recipient(&msg, &recipient);
+        assert!(
+            bits.is_mention,
+            "at-threshold count is still honored — is_mention MUST be set"
+        );
+        assert!(
+            bits.noping,
+            "at-threshold count is still honored — noping MUST be set"
+        );
+    }
 }

--- a/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
@@ -511,9 +511,14 @@ struct RecipientMentionBits {
 /// channel-mention surface is for MUC reflector announcements, which
 /// do not flow through the DM `QueueOfflineDelivery` arm.
 fn mention_bits_for_recipient(message: &Message, recipient: &BareJid) -> RecipientMentionBits {
-    let Some(mentions) = waddle_xmpp::xep::extract_explicit_mentions(message) else {
-        return RecipientMentionBits::default();
-    };
+    // Pre-parse XEP-0513 mentions AND XEP-0372 references once so
+    // the §304 count gate and the per-recipient is_mention/noping
+    // derivation share the same pre-parsed slices.
+    let mentions_slice: Vec<_> = waddle_xmpp::xep::extract_explicit_mentions(message)
+        .map(|m| m.mentions)
+        .unwrap_or_default();
+    let references = waddle_xmpp::xep::extract_references_from_message(message);
+
     // XEP-0513 §304: "Receiving entities SHOULD ignore all mentions
     // if the message contains more mentions than the threshold." A
     // sender spamming N per-JID mentions on a DM (the same abuse
@@ -522,15 +527,15 @@ fn mention_bits_for_recipient(message: &Message, recipient: &BareJid) -> Recipie
     // able to attach `<noping/>` to suppress the very push they
     // forced. Treating count-exceeded as "no mentions present"
     // collapses both surfaces back to the regular DM push.
-    if waddle_xmpp::xep::mentions_exceed_threshold(
-        &mentions.mentions,
-        message,
+    if waddle_xmpp::xep::mentions_exceed_threshold_from_parts(
+        &mentions_slice,
+        &references,
         waddle_xmpp::xep::DEFAULT_MENTIONS_COUNT,
     ) {
         return RecipientMentionBits::default();
     }
     let mut bits = RecipientMentionBits::default();
-    for mention in &mentions.mentions {
+    for mention in &mentions_slice {
         let names_recipient = mention
             .jid
             .as_ref()
@@ -542,6 +547,25 @@ fn mention_bits_for_recipient(message: &Message, recipient: &BareJid) -> Recipie
         if mention.noping {
             bits.noping = true;
         }
+    }
+    // XEP-0372 mention-reference fallback for the `is_mention` bit:
+    // a DM sender naming the recipient via
+    // `<reference type='mention' uri='xmpp:recipient@host'/>`
+    // (instead of, or alongside, an XEP-0513 `<mention jid='…'/>`)
+    // MUST still promote the recipient to `dm_mention` — otherwise
+    // the count gate counts XEP-0372 references TOWARD the threshold
+    // (promoting spam) but the classifier doesn't count them
+    // FOR promotion (demoting legitimate XEP-0372 mentions to plain
+    // dm). The groupchat path already does this in
+    // `groupchat_mentions_owner`; mirror it here for DM consistency
+    // (cross-XEP review on PR #741).
+    if !bits.is_mention {
+        bits.is_mention = references.iter().any(|reference| {
+            reference.is_mention()
+                && reference
+                    .bare_jid()
+                    .is_some_and(|mentioned| &mentioned == recipient)
+        });
     }
     bits
 }
@@ -728,6 +752,64 @@ mod tests {
         assert!(
             bits.noping,
             "at-threshold count is still honored — noping MUST be set"
+        );
+    }
+
+    /// Cross-XEP review on PR #741: a DM sender naming the recipient
+    /// solely via an XEP-0372 `<reference type='mention'/>` (no
+    /// XEP-0513 `<mention/>`) MUST still set the recipient's
+    /// `is_mention` bit. Without this the §304 count gate counts
+    /// XEP-0372 toward the threshold (penalising spam) while the
+    /// classifier ignores XEP-0372 for promotion (demoting
+    /// legitimate XEP-0372-only DMs to plain `dm`).
+    #[test]
+    fn xep0372_only_dm_mention_promotes_recipient_to_dm_mention() {
+        let recipient = bare("alice@example.com");
+        let mut msg = xmpp_parsers::message::Message::new(None::<jid::Jid>);
+        waddle_xmpp::xep::add_reference(
+            &mut msg,
+            &waddle_xmpp::xep::Reference::mention("xmpp:alice@example.com"),
+        );
+        let bits = mention_bits_for_recipient(&msg, &recipient);
+        assert!(
+            bits.is_mention,
+            "a DM with only an XEP-0372 `<reference type='mention'/>` \
+             naming the recipient MUST still set is_mention — the \
+             groupchat path already does this via groupchat_mentions_owner"
+        );
+        assert!(
+            !bits.noping,
+            "XEP-0372 has no `<noping/>` concept; noping stays false"
+        );
+    }
+
+    /// Composition with the §304 count gate: an XEP-0372-only mention
+    /// still respects the threshold cap. Six references targeting
+    /// six different users (including the recipient) trip the gate
+    /// → recipient's bits collapse to default.
+    #[test]
+    fn xep0372_dm_mention_count_exceeded_collapses_to_default_even_with_recipient_reference() {
+        let recipient = bare("alice@example.com");
+        let mut msg = xmpp_parsers::message::Message::new(None::<jid::Jid>);
+        let threshold = waddle_xmpp::xep::DEFAULT_MENTIONS_COUNT;
+        // One reference naming the recipient + threshold others = exceed.
+        waddle_xmpp::xep::add_reference(
+            &mut msg,
+            &waddle_xmpp::xep::Reference::mention("xmpp:alice@example.com"),
+        );
+        for i in 0..threshold {
+            waddle_xmpp::xep::add_reference(
+                &mut msg,
+                &waddle_xmpp::xep::Reference::mention(format!("xmpp:user{i}@example.com")),
+            );
+        }
+        let bits = mention_bits_for_recipient(&msg, &recipient);
+        assert_eq!(
+            bits,
+            RecipientMentionBits::default(),
+            "DM with > DEFAULT_MENTIONS_COUNT XEP-0372 references MUST \
+             collapse — count gate fires identically on the XEP-0372 \
+             surface"
         );
     }
 }

--- a/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
@@ -519,21 +519,23 @@ fn mention_bits_for_recipient(message: &Message, recipient: &BareJid) -> Recipie
         .unwrap_or_default();
     let references = waddle_xmpp::xep::extract_references_from_message(message);
 
-    // XEP-0513 §304: "Receiving entities SHOULD ignore all mentions
-    // if the message contains more mentions than the threshold." A
-    // sender spamming N per-JID mentions on a DM (the same abuse
-    // vector blocked on the groupchat candidate path) would otherwise
-    // promote every recipient's class to `dm_mention` and ALSO be
-    // able to attach `<noping/>` to suppress the very push they
-    // forced. Treating count-exceeded as "no mentions present"
-    // collapses both surfaces back to the regular DM push.
-    if waddle_xmpp::xep::mentions_exceed_threshold_from_parts(
-        &mentions_slice,
-        &references,
-        waddle_xmpp::xep::DEFAULT_MENTIONS_COUNT,
-    ) {
-        return RecipientMentionBits::default();
-    }
+    // Derive the per-recipient mention bits BEFORE applying the
+    // §304 count gate. Both is_mention and noping flow from the
+    // per-recipient match; the count gate then downgrades is_mention
+    // (the "ignore all mentions" SHOULD) but PRESERVES the noping
+    // suppression bit (XEP-0513 §"No Ping" is a separate SHOULD
+    // that operates independently of the count cap — compliance
+    // review on PR #741). Concretely:
+    //   - Without `<noping/>`: count gate downgrades is_mention →
+    //     class drops to plain `dm` (XEP-0492 `<on-mention/>`
+    //     recipients then get suppressed at T1 via
+    //     `Xep0492OnMentionMiss`).
+    //   - With `<noping/>`: noping bit persists → the existing
+    //     T0/T1 `Xep0513Noping` suppressor fires for that recipient
+    //     even on overflowed messages. Spam-targeted `<always/>`
+    //     recipients are correctly silenced by the sender's
+    //     explicit `<noping/>`, matching the spec-mandated behavior
+    //     for non-overflowed messages.
     let mut bits = RecipientMentionBits::default();
     for mention in &mentions_slice {
         let names_recipient = mention
@@ -566,6 +568,18 @@ fn mention_bits_for_recipient(message: &Message, recipient: &BareJid) -> Recipie
                     .bare_jid()
                     .is_some_and(|mentioned| &mentioned == recipient)
         });
+    }
+    // XEP-0513 §304 "ignore all mentions" applied AFTER the noping
+    // bit is captured: when the per-message count exceeds the
+    // threshold, the recipient's mention-class is downgraded (plain
+    // `dm`) but the explicit `<noping/>` suppression — being a
+    // separate §"No Ping" SHOULD — is preserved.
+    if waddle_xmpp::xep::mentions_exceed_threshold_from_parts(
+        &mentions_slice,
+        &references,
+        waddle_xmpp::xep::DEFAULT_MENTIONS_COUNT,
+    ) {
+        bits.is_mention = false;
     }
     bits
 }
@@ -689,20 +703,20 @@ mod tests {
     }
 
     /// XEP-0513 §304 SHOULD: when the per-message count exceeds the
-    /// threshold, the recipient ignores ALL mentions. For DM that
-    /// means the candidate falls through from `dm_mention` to plain
-    /// `dm` — even if one of the mentions legitimately names this
-    /// recipient. Lock the strict-§304 behavior (adversarial review
-    /// on PR #741).
+    /// threshold, the recipient's mention class is downgraded
+    /// (is_mention → false, class drops from `dm_mention` to plain
+    /// `dm`). The `<noping/>` suppression is NOT cleared — XEP-0513
+    /// §"No Ping" is a separate SHOULD that operates independently
+    /// of the count cap. Compliance review on PR #741 mandated this
+    /// composition.
     #[test]
-    fn xep0513_dm_mention_count_exceeded_returns_default_bits() {
+    fn xep0513_dm_mention_count_exceeded_downgrades_is_mention_but_preserves_noping() {
         let recipient = bare("alice@example.com");
         let threshold = waddle_xmpp::xep::DEFAULT_MENTIONS_COUNT;
 
+        // Case A: count exceeded, NO `<noping/>` for recipient → both
+        // bits collapse (is_mention forced false; no noping to set).
         let mut msg = xmpp_parsers::message::Message::new(None::<jid::Jid>);
-        // One mention naming the recipient (would normally trigger
-        // is_mention=true), plus enough others to push count >
-        // threshold.
         msg.payloads.push(waddle_xmpp::xep::build_mention_element(
             &waddle_xmpp::xep::ExplicitMention::jid(recipient.clone()),
         ));
@@ -713,12 +727,45 @@ mod tests {
                 ),
             ));
         }
-        assert_eq!(
-            mention_bits_for_recipient(&msg, &recipient),
-            RecipientMentionBits::default(),
-            "DM with > DEFAULT_MENTIONS_COUNT mentions MUST collapse \
-             to default bits even when the recipient is named — \
-             §304 ignores ALL mentions"
+        let bits = mention_bits_for_recipient(&msg, &recipient);
+        assert!(
+            !bits.is_mention,
+            "count exceeded MUST downgrade is_mention to false (§304 \
+             ignore-all-mentions for the class decision)"
+        );
+        assert!(
+            !bits.noping,
+            "no `<noping/>` for the recipient → noping bit stays false"
+        );
+
+        // Case B: count exceeded AND `<noping/>` for recipient → the
+        // class downgrades (is_mention=false) BUT the noping bit is
+        // preserved so the existing T0/T1 `Xep0513Noping` suppressor
+        // still fires for this recipient.
+        let mut msg = xmpp_parsers::message::Message::new(None::<jid::Jid>);
+        let mut recipient_noping_mention =
+            waddle_xmpp::xep::ExplicitMention::jid(recipient.clone());
+        recipient_noping_mention.noping = true;
+        msg.payloads.push(waddle_xmpp::xep::build_mention_element(
+            &recipient_noping_mention,
+        ));
+        for i in 0..threshold {
+            msg.payloads.push(waddle_xmpp::xep::build_mention_element(
+                &waddle_xmpp::xep::ExplicitMention::jid(
+                    format!("user{i}@example.com").parse().expect("user bare"),
+                ),
+            ));
+        }
+        let bits = mention_bits_for_recipient(&msg, &recipient);
+        assert!(
+            !bits.is_mention,
+            "count exceeded MUST downgrade is_mention to false"
+        );
+        assert!(
+            bits.noping,
+            "XEP-0513 §\"No Ping\" SHOULD MUST survive §304 count \
+             overflow — `<noping/>` suppresses push candidate creation \
+             for this recipient regardless of the count cap"
         );
     }
 
@@ -786,9 +833,11 @@ mod tests {
     /// Composition with the §304 count gate: an XEP-0372-only mention
     /// still respects the threshold cap. Six references targeting
     /// six different users (including the recipient) trip the gate
-    /// → recipient's bits collapse to default.
+    /// → recipient's `is_mention` is downgraded. XEP-0372 has no
+    /// `<noping/>` concept so the noping bit is unaffected and the
+    /// overall outcome matches `RecipientMentionBits::default()`.
     #[test]
-    fn xep0372_dm_mention_count_exceeded_collapses_to_default_even_with_recipient_reference() {
+    fn xep0372_dm_mention_count_exceeded_downgrades_is_mention() {
         let recipient = bare("alice@example.com");
         let mut msg = xmpp_parsers::message::Message::new(None::<jid::Jid>);
         let threshold = waddle_xmpp::xep::DEFAULT_MENTIONS_COUNT;
@@ -804,12 +853,12 @@ mod tests {
             );
         }
         let bits = mention_bits_for_recipient(&msg, &recipient);
-        assert_eq!(
-            bits,
-            RecipientMentionBits::default(),
-            "DM with > DEFAULT_MENTIONS_COUNT XEP-0372 references MUST \
-             collapse — count gate fires identically on the XEP-0372 \
-             surface"
+        assert!(!bits.is_mention, "is_mention MUST be false on count-exceed");
+        assert!(
+            !bits.noping,
+            "XEP-0372 has no `<noping/>` shape; noping stays false \
+             (the §\"No Ping\" preservation rule applies only when the \
+             recipient's XEP-0513 mention carries `<noping/>`)"
         );
     }
 }

--- a/server/crates/waddle-xmpp/src/xep/exports.rs
+++ b/server/crates/waddle-xmpp/src/xep/exports.rs
@@ -398,10 +398,11 @@ pub use super::xep0490::{
 
 pub use super::xep0513::{
     build_mention_element, build_mentions_elements, extract_explicit_mentions,
-    has_explicit_mentions, is_mention_element, mention_target_count, mentions_exceed_threshold,
-    parse_mention_element, set_explicit_mentions, strip_explicit_mentions, ExplicitMention,
-    ExplicitMentionCarrier, ExplicitMentions, CHANNEL_MENTION, DEFAULT_MENTIONS_COUNT,
-    NS_EXPLICIT_MENTIONS,
+    has_explicit_mentions, is_mention_element, mention_target_count,
+    mention_target_count_from_parts, mentions_exceed_threshold,
+    mentions_exceed_threshold_from_parts, parse_mention_element, set_explicit_mentions,
+    strip_explicit_mentions, ExplicitMention, ExplicitMentionCarrier, ExplicitMentions,
+    CHANNEL_MENTION, DEFAULT_MENTIONS_COUNT, NS_EXPLICIT_MENTIONS,
 };
 
 pub use super::xep0508::{

--- a/server/crates/waddle-xmpp/src/xep/exports.rs
+++ b/server/crates/waddle-xmpp/src/xep/exports.rs
@@ -398,9 +398,10 @@ pub use super::xep0490::{
 
 pub use super::xep0513::{
     build_mention_element, build_mentions_elements, extract_explicit_mentions,
-    has_explicit_mentions, is_mention_element, parse_mention_element, set_explicit_mentions,
-    strip_explicit_mentions, ExplicitMention, ExplicitMentionCarrier, ExplicitMentions,
-    CHANNEL_MENTION, NS_EXPLICIT_MENTIONS,
+    has_explicit_mentions, is_mention_element, mention_target_count, mentions_exceed_threshold,
+    parse_mention_element, set_explicit_mentions, strip_explicit_mentions, ExplicitMention,
+    ExplicitMentionCarrier, ExplicitMentions, CHANNEL_MENTION, DEFAULT_MENTIONS_COUNT,
+    NS_EXPLICIT_MENTIONS,
 };
 
 pub use super::xep0508::{

--- a/server/crates/waddle-xmpp/src/xep/xep0513.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0513.rs
@@ -4,11 +4,55 @@ use jid::BareJid;
 use minidom::Element;
 use xmpp_parsers::message::Message;
 
+use super::xep0372::extract_references_from_message;
+
 /// Namespace for XEP-0513 Explicit Mentions.
 pub const NS_EXPLICIT_MENTIONS: &str = "urn:xmpp:mentions:0";
 
 /// XEP-0513 channel-wide mention URI.
 pub const CHANNEL_MENTION: &str = "urn:xmpp:mentions:0#channel";
+
+/// XEP-0513 §301 example value for the `mentions#count` form field.
+///
+/// XEP-0513 §304: "Receiving entities SHOULD ignore all mentions if
+/// the message contains more mentions than the threshold specified by
+/// `mentions#count`." Used as the server-internal default until the
+/// per-room override IQ (XEP-0513 §295) lands in a follow-up slice.
+pub const DEFAULT_MENTIONS_COUNT: u32 = 5;
+
+/// Counts the mention TARGETS on `message`. Includes:
+///
+/// - every parsed XEP-0513 `<mention/>` payload (the slice already
+///   filters out structurally-empty elements that target nothing
+///   per `parse_mention_element`);
+/// - every XEP-0372 `<reference type='mention'/>` element — XEP-0513
+///   §304's "more mentions than the threshold" cap defensively
+///   extends to the XEP-0372 fallback path, otherwise an attacker
+///   bypasses the cap by encoding the spam via XEP-0372 references
+///   instead of XEP-0513 mentions (XEP-0513 §526 authorises
+///   server-internal filtering "according to their own rules").
+///
+/// The result is clamped to `u32::MAX`; in practice a single message
+/// would never legitimately approach that count.
+pub fn mention_target_count(explicit_mentions: &[ExplicitMention], message: &Message) -> u32 {
+    let xep0513 = explicit_mentions.len();
+    let xep0372 = extract_references_from_message(message)
+        .into_iter()
+        .filter(|reference| reference.is_mention())
+        .count();
+    u32::try_from(xep0513.saturating_add(xep0372)).unwrap_or(u32::MAX)
+}
+
+/// Returns `true` when the mention payloads on `message` exceed the
+/// configured `threshold` (XEP-0513 §304). Callers handle the
+/// SHOULD-ignore-all-mentions consequence themselves.
+pub fn mentions_exceed_threshold(
+    explicit_mentions: &[ExplicitMention],
+    message: &Message,
+    threshold: u32,
+) -> bool {
+    mention_target_count(explicit_mentions, message) > threshold
+}
 
 /// A single top-level `<mention/>` payload.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]

--- a/server/crates/waddle-xmpp/src/xep/xep0513.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0513.rs
@@ -29,8 +29,34 @@ pub const DEFAULT_MENTIONS_COUNT: u32 = 5;
 /// nobody. Counting them would let an attacker pad the §304 count
 /// from a message that doesn't mention anyone (XEP-0513 review on
 /// PR #741).
+///
+/// Empty-string `occupantid=''` and `mentions=''` are also excluded:
+/// the parser preserves them as `Some("".to_string())` but an empty
+/// occupant-id targets no XEP-0421 occupant and an empty `mentions=`
+/// URI identifies no group per XEP-0513 §3.
 fn is_mention_target(mention: &ExplicitMention) -> bool {
-    mention.jid.is_some() || mention.occupant_id.is_some() || mention.mentions.is_some()
+    mention.jid.is_some()
+        || mention
+            .occupant_id
+            .as_deref()
+            .is_some_and(|id| !id.is_empty())
+        || mention
+            .mentions
+            .as_deref()
+            .is_some_and(|uri| !uri.is_empty())
+}
+
+/// Returns `true` when an XEP-0372 `<reference/>` carries a real
+/// mention TARGET — `type='mention'` AND a parseable XMPP bare JID
+/// in the `uri`. Per XEP-0372 §"Reference type 'mention'" the URI
+/// MUST be the XMPP URI of the mentioned entity; counting
+/// `<reference type='mention' uri=''/>` or
+/// `<reference type='mention' uri='https://attacker.example/'/>`
+/// would let an attacker pad the §304 count from a message that
+/// targets nobody — the same padding vector closed for XEP-0513
+/// by [`is_mention_target`] (PR #741 wire-shape review).
+fn is_reference_mention_target(reference: &Reference) -> bool {
+    reference.is_mention() && reference.bare_jid().is_some()
 }
 
 /// Counts the mention TARGETS on `message`. Includes:
@@ -80,7 +106,7 @@ pub fn mention_target_count_from_parts(
         .count();
     let xep0372 = references
         .iter()
-        .filter(|reference| reference.is_mention())
+        .filter(|reference| is_reference_mention_target(reference))
         .count();
     u32::try_from(xep0513.saturating_add(xep0372)).unwrap_or(u32::MAX)
 }
@@ -414,6 +440,64 @@ mod count_tests {
         let msg = empty_message();
         assert_eq!(mention_target_count(&[], &msg), 0);
         assert!(!mentions_exceed_threshold(&[], &msg, 0));
+    }
+
+    /// XEP-0513 §3 + XEP-0372 §"Reference type 'mention'": a mention
+    /// reference whose `uri` doesn't resolve to an XMPP bare JID
+    /// targets nobody and MUST NOT contribute to the §304 count.
+    /// Closes the symmetric padding attack on the XEP-0372 fallback
+    /// path (an attacker injecting 6× `<reference type='mention'
+    /// uri=''/>` or `<reference type='mention' uri='https://x/'/>`
+    /// would otherwise pad the cap from a no-target message —
+    /// wire-shape review on PR #741).
+    #[test]
+    fn mention_target_count_ignores_xep0372_references_with_unparseable_uris() {
+        let mut msg = empty_message();
+        // 6 mention references whose URIs cannot resolve to an XMPP
+        // bare JID. The first five fail the `xmpp:` scheme check;
+        // the sixth fails JID parsing because spaces are invalid in
+        // a JID localpart / domain.
+        add_reference(&mut msg, &Reference::mention("xmpp:"));
+        add_reference(&mut msg, &Reference::mention(""));
+        add_reference(&mut msg, &Reference::mention("https://attacker.example/"));
+        add_reference(&mut msg, &Reference::mention("mailto:foo@example.com"));
+        add_reference(&mut msg, &Reference::mention("not-an-xmpp-uri"));
+        add_reference(&mut msg, &Reference::mention("xmpp:bad jid with spaces"));
+        assert_eq!(
+            mention_target_count(&[], &msg),
+            0,
+            "XEP-0372 mention references whose URI doesn't parse to an \
+             XMPP bare JID MUST NOT contribute to the §304 count"
+        );
+    }
+
+    /// XEP-0513 §3 + parser tolerance: empty-string `occupantid=''`
+    /// and `mentions=''` parse as `Some("".to_string())` but target
+    /// nobody. They MUST NOT contribute to the §304 count.
+    #[test]
+    fn mention_target_count_ignores_empty_string_targets() {
+        let mut msg = empty_message();
+        let empty_occupant = ExplicitMention {
+            occupant_id: Some(String::new()),
+            ..ExplicitMention::default()
+        };
+        let empty_mentions = ExplicitMention {
+            mentions: Some(String::new()),
+            ..ExplicitMention::default()
+        };
+        with_xep0513_mention(&mut msg, empty_occupant);
+        with_xep0513_mention(&mut msg, empty_mentions);
+        let mentions = extract_explicit_mentions(&msg)
+            .map(|m| m.mentions)
+            .unwrap_or_default();
+        // Both elements parsed (the parser accepts `Some("")`).
+        assert_eq!(mentions.len(), 2);
+        assert_eq!(
+            mention_target_count(&mentions, &msg),
+            0,
+            "empty-string `occupantid=''` and `mentions=''` MUST NOT \
+             contribute to the §304 count — they identify no target"
+        );
     }
 
     /// XEP-0513 §3 defines a mention TARGET as a payload that

--- a/server/crates/waddle-xmpp/src/xep/xep0513.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0513.rs
@@ -22,18 +22,35 @@ pub const DEFAULT_MENTIONS_COUNT: u32 = 5;
 
 /// Returns `true` when `mention` carries an actual XEP-0513 §3
 /// mention TARGET — i.e. it identifies someone or something to
-/// notify. The parser at [`parse_mention_element`] accepts elements
-/// whose only payload is an `<active/>` or `<noping/>` child or a
-/// `begin`/`end` anchor; those are structurally-empty for §304's
-/// "more mentions than the threshold" cap because they target
-/// nobody. Counting them would let an attacker pad the §304 count
-/// from a message that doesn't mention anyone (XEP-0513 review on
-/// PR #741).
+/// notify. Per XEP-0513 §3 the targeting axes are exactly:
 ///
-/// Empty-string `occupantid=''` and `mentions=''` are also excluded:
-/// the parser preserves them as `Some("".to_string())` but an empty
-/// occupant-id targets no XEP-0421 occupant and an empty `mentions=`
-/// URI identifies no group per XEP-0513 §3.
+///   - `jid` (the bare JID of the mentioned entity),
+///   - `occupantid` (the XEP-0421 stable occupant identifier),
+///   - `mentions` (a URI identifying a special group, e.g.
+///     `urn:xmpp:mentions:0#channel`).
+///
+/// [`parse_mention_element`] is deliberately MORE permissive: it
+/// also accepts `<mention/>` elements whose only payload is a
+/// `uri='…'` attribute or a `<active/>` / `<noping/>` child. Per
+/// §3, `uri` is documented as a SCOPE qualifier for channel
+/// mentions (or a hint for clients to dereference), NOT as a
+/// targeting axis; `<active/>` and `<noping/>` are §"Active
+/// Mentions" / §"No Ping" qualifiers that modify a target but
+/// don't introduce one. The parser/counter asymmetry is
+/// intentional: the parser preserves round-trip wire shape, while
+/// §304's count gate operates on logical TARGETS only. Counting
+/// non-targeting `<mention/>` elements would let an attacker pad
+/// the §304 cap from a message that names nobody (wire-shape
+/// review on PR #741).
+///
+/// Anchor-only (`begin`/`end`-only) `<mention/>` elements are
+/// rejected by [`parse_mention_element`] outright — those don't
+/// reach this predicate.
+///
+/// Empty-string `occupantid=''` and `mentions=''` are also
+/// excluded: the parser preserves them as `Some("".to_string())`
+/// but an empty occupant-id targets no XEP-0421 occupant and an
+/// empty `mentions=` URI identifies no group per §3.
 fn is_mention_target(mention: &ExplicitMention) -> bool {
     mention.jid.is_some()
         || mention
@@ -381,10 +398,14 @@ mod count_tests {
         msg.payloads.push(build_mention_element(&mention));
     }
 
-    /// XEP-0513 `<mention/>` payloads contribute one mention TARGET
-    /// per parsed element. The parser already drops structurally-empty
-    /// elements that target nothing (see `parse_mention_element`), so
-    /// every element in the slice is a real mention.
+    /// XEP-0513 `<mention/>` payloads with a real targeting axis
+    /// (jid, occupantid, mentions URI) contribute one mention
+    /// TARGET each. The parser is more permissive — it also
+    /// accepts `uri`-only or modifier-only mentions per the §3
+    /// round-trip contract — but the counter filters those out
+    /// via [`is_mention_target`]; the cases that DO contribute are
+    /// exactly the ones exercised by this test. Other tests pin
+    /// the exclusion path (`*_ignores_*`).
     #[test]
     fn mention_target_count_counts_xep0513_mentions() {
         let mut msg = empty_message();

--- a/server/crates/waddle-xmpp/src/xep/xep0513.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0513.rs
@@ -4,7 +4,7 @@ use jid::BareJid;
 use minidom::Element;
 use xmpp_parsers::message::Message;
 
-use super::xep0372::extract_references_from_message;
+use super::xep0372::{extract_references_from_message, Reference};
 
 /// Namespace for XEP-0513 Explicit Mentions.
 pub const NS_EXPLICIT_MENTIONS: &str = "urn:xmpp:mentions:0";
@@ -20,11 +20,26 @@ pub const CHANNEL_MENTION: &str = "urn:xmpp:mentions:0#channel";
 /// per-room override IQ (XEP-0513 §295) lands in a follow-up slice.
 pub const DEFAULT_MENTIONS_COUNT: u32 = 5;
 
+/// Returns `true` when `mention` carries an actual XEP-0513 §3
+/// mention TARGET — i.e. it identifies someone or something to
+/// notify. The parser at [`parse_mention_element`] accepts elements
+/// whose only payload is an `<active/>` or `<noping/>` child or a
+/// `begin`/`end` anchor; those are structurally-empty for §304's
+/// "more mentions than the threshold" cap because they target
+/// nobody. Counting them would let an attacker pad the §304 count
+/// from a message that doesn't mention anyone (XEP-0513 review on
+/// PR #741).
+fn is_mention_target(mention: &ExplicitMention) -> bool {
+    mention.jid.is_some() || mention.occupant_id.is_some() || mention.mentions.is_some()
+}
+
 /// Counts the mention TARGETS on `message`. Includes:
 ///
-/// - every parsed XEP-0513 `<mention/>` payload (the slice already
-///   filters out structurally-empty elements that target nothing
-///   per `parse_mention_element`);
+/// - every parsed XEP-0513 `<mention/>` payload whose attributes
+///   actually identify a target (jid / occupantid / mentions URI) —
+///   anchor-only and `<active/>` / `<noping/>` -only elements MUST
+///   NOT contribute, per XEP-0513 §3's definition of a mention
+///   target;
 /// - every XEP-0372 `<reference type='mention'/>` element — XEP-0513
 ///   §304's "more mentions than the threshold" cap defensively
 ///   extends to the XEP-0372 fallback path, otherwise an attacker
@@ -32,12 +47,39 @@ pub const DEFAULT_MENTIONS_COUNT: u32 = 5;
 ///   instead of XEP-0513 mentions (XEP-0513 §526 authorises
 ///   server-internal filtering "according to their own rules").
 ///
+/// The XEP-0513 / XEP-0372 sides are NOT deduplicated — a well-
+/// behaved dual-encoded message (per XEP-0513 §3 example showing
+/// both `<mention jid='X'/>` and `<reference uri='xmpp:X'/>`) is
+/// counted as two targets. This is a documented anti-abuse choice:
+/// the cap deliberately over-counts to avoid bypass via mixed
+/// encoding, and the §301 default of `5` leaves comfortable
+/// headroom for dual-encoded messages naming up to ~2 distinct
+/// targets. Per-XEP precise dedup is a follow-up if reports
+/// indicate false-positives in practice.
+///
 /// The result is clamped to `u32::MAX`; in practice a single message
 /// would never legitimately approach that count.
 pub fn mention_target_count(explicit_mentions: &[ExplicitMention], message: &Message) -> u32 {
-    let xep0513 = explicit_mentions.len();
-    let xep0372 = extract_references_from_message(message)
-        .into_iter()
+    let references = extract_references_from_message(message);
+    mention_target_count_from_parts(explicit_mentions, &references)
+}
+
+/// Parts-based version of [`mention_target_count`]. Use this when
+/// the caller has already parsed both XEP-0513 mentions and XEP-0372
+/// references — typically on a hot path where the same message is
+/// inspected multiple times (e.g. T0 candidate emission across many
+/// recipients) — so the payload sweep happens once per message
+/// instead of once per inspection (XEP review on PR #741).
+pub fn mention_target_count_from_parts(
+    explicit_mentions: &[ExplicitMention],
+    references: &[Reference],
+) -> u32 {
+    let xep0513 = explicit_mentions
+        .iter()
+        .filter(|mention| is_mention_target(mention))
+        .count();
+    let xep0372 = references
+        .iter()
         .filter(|reference| reference.is_mention())
         .count();
     u32::try_from(xep0513.saturating_add(xep0372)).unwrap_or(u32::MAX)
@@ -52,6 +94,15 @@ pub fn mentions_exceed_threshold(
     threshold: u32,
 ) -> bool {
     mention_target_count(explicit_mentions, message) > threshold
+}
+
+/// Parts-based version of [`mentions_exceed_threshold`].
+pub fn mentions_exceed_threshold_from_parts(
+    explicit_mentions: &[ExplicitMention],
+    references: &[Reference],
+    threshold: u32,
+) -> bool {
+    mention_target_count_from_parts(explicit_mentions, references) > threshold
 }
 
 /// A single top-level `<mention/>` payload.
@@ -363,6 +414,43 @@ mod count_tests {
         let msg = empty_message();
         assert_eq!(mention_target_count(&[], &msg), 0);
         assert!(!mentions_exceed_threshold(&[], &msg, 0));
+    }
+
+    /// XEP-0513 §3 defines a mention TARGET as a payload that
+    /// identifies someone/something to notify — `jid`, `occupantid`,
+    /// or `mentions` URI. A `<mention/>` carrying only `<noping/>`
+    /// (or only `<active/>`, or only an anchor) targets nobody and
+    /// MUST NOT contribute to the §304 count, otherwise an attacker
+    /// pads the cap from messages that don't actually mention anyone
+    /// (XEP-0513 review on PR #741).
+    #[test]
+    fn mention_target_count_ignores_anchor_only_and_payload_only_mentions() {
+        let mut msg = empty_message();
+        // 6 anchor-less `<noping/>`-only mentions — each is a parse
+        // hit (parse_mention_element accepts the `noping` child as a
+        // sufficient reason to construct an `ExplicitMention`) but
+        // structurally targets nobody.
+        for _ in 0..6 {
+            let noping_only = ExplicitMention {
+                noping: true,
+                ..ExplicitMention::default()
+            };
+            msg.payloads.push(build_mention_element(&noping_only));
+        }
+        let mentions = extract_explicit_mentions(&msg)
+            .map(|m| m.mentions)
+            .unwrap_or_default();
+        assert_eq!(mentions.len(), 6, "all six payloads must parse");
+        assert_eq!(
+            mention_target_count(&mentions, &msg),
+            0,
+            "anchor-less `<noping/>`-only mentions are NOT targets per \
+             XEP-0513 §3 and MUST NOT contribute to the §304 count"
+        );
+        assert!(
+            !mentions_exceed_threshold(&mentions, &msg, DEFAULT_MENTIONS_COUNT),
+            "six target-less mentions MUST NOT trip the threshold"
+        );
     }
 
     /// XEP-0513 §304 boundary: "more than the threshold" is strict.

--- a/server/crates/waddle-xmpp/src/xep/xep0513.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0513.rs
@@ -289,3 +289,108 @@ pub fn strip_explicit_mentions(msg: &mut Message) {
     msg.payloads
         .retain(|elem| elem.ns() != NS_EXPLICIT_MENTIONS);
 }
+
+#[cfg(test)]
+mod count_tests {
+    use super::*;
+    use crate::xep::xep0372::{add_reference, Reference};
+    use xmpp_parsers::message::Message;
+
+    fn empty_message() -> Message {
+        Message::new(None::<jid::Jid>)
+    }
+
+    fn with_xep0513_mention(msg: &mut Message, mention: ExplicitMention) {
+        msg.payloads.push(build_mention_element(&mention));
+    }
+
+    /// XEP-0513 `<mention/>` payloads contribute one mention TARGET
+    /// per parsed element. The parser already drops structurally-empty
+    /// elements that target nothing (see `parse_mention_element`), so
+    /// every element in the slice is a real mention.
+    #[test]
+    fn mention_target_count_counts_xep0513_mentions() {
+        let mut msg = empty_message();
+        with_xep0513_mention(
+            &mut msg,
+            ExplicitMention::jid("alice@example.com".parse().expect("alice bare")),
+        );
+        with_xep0513_mention(&mut msg, ExplicitMention::occupant_id("room-stable-bob"));
+        with_xep0513_mention(&mut msg, ExplicitMention::channel());
+        let mentions = extract_explicit_mentions(&msg)
+            .map(|m| m.mentions)
+            .unwrap_or_default();
+        assert_eq!(mention_target_count(&mentions, &msg), 3);
+    }
+
+    /// XEP-0372 `<reference type='mention'/>` elements ALSO contribute
+    /// to the per-message mention count — without this an attacker
+    /// bypasses the XEP-0513 §304 cap by encoding spam as XEP-0372
+    /// references instead.
+    #[test]
+    fn mention_target_count_counts_xep0372_mention_references() {
+        let mut msg = empty_message();
+        add_reference(&mut msg, &Reference::mention("xmpp:alice@example.com"));
+        add_reference(&mut msg, &Reference::mention("xmpp:bob@example.com"));
+        // XEP-0372 references with type='data' MUST NOT be counted —
+        // they're file attachments, not mentions.
+        add_reference(
+            &mut msg,
+            &Reference::data("https://files.example.com/cat.jpg"),
+        );
+        assert_eq!(mention_target_count(&[], &msg), 2);
+    }
+
+    /// Sum of both XEPs is reported.
+    #[test]
+    fn mention_target_count_sums_xep0513_and_xep0372() {
+        let mut msg = empty_message();
+        with_xep0513_mention(
+            &mut msg,
+            ExplicitMention::jid("alice@example.com".parse().expect("alice bare")),
+        );
+        add_reference(&mut msg, &Reference::mention("xmpp:bob@example.com"));
+        let mentions = extract_explicit_mentions(&msg)
+            .map(|m| m.mentions)
+            .unwrap_or_default();
+        assert_eq!(mention_target_count(&mentions, &msg), 2);
+    }
+
+    /// Zero mentions → zero count. The threshold check via
+    /// `mentions_exceed_threshold` is `false` regardless of threshold.
+    #[test]
+    fn mention_target_count_is_zero_for_unmentioned_message() {
+        let msg = empty_message();
+        assert_eq!(mention_target_count(&[], &msg), 0);
+        assert!(!mentions_exceed_threshold(&[], &msg, 0));
+    }
+
+    /// XEP-0513 §304 boundary: "more than the threshold" is strict.
+    /// Equal count does NOT exceed.
+    #[test]
+    fn mentions_exceed_threshold_is_strict_inequality() {
+        let mut msg = empty_message();
+        for i in 0..5 {
+            with_xep0513_mention(
+                &mut msg,
+                ExplicitMention::jid(
+                    format!("user{i}@example.com")
+                        .parse()
+                        .expect("target bare jid"),
+                ),
+            );
+        }
+        let mentions = extract_explicit_mentions(&msg)
+            .map(|m| m.mentions)
+            .unwrap_or_default();
+        assert_eq!(mention_target_count(&mentions, &msg), 5);
+        assert!(
+            !mentions_exceed_threshold(&mentions, &msg, 5),
+            "count == threshold MUST NOT exceed; §304 says \"more than\""
+        );
+        assert!(
+            mentions_exceed_threshold(&mentions, &msg, 4),
+            "count > threshold MUST exceed"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Apply XEP-0513 §304's `mentions#count` SHOULD at T0 candidate classification: when a message carries more than the threshold (server default `5` per §301 example value) mention TARGETS — counted across XEP-0513 `<mention/>` (jid / occupantid / `mentions` URI) AND XEP-0372 `<reference type='mention'/>` with parseable XMPP bare JID — the class collapses to `NotifyAll`. Wire payload preserved per §526; only push class is affected.

Second narrowed slice of #525 after slice 3a merged. Closes the personal-mention spam abuse vector that the channel-broadcast gate doesn't cover.

## Why

XEP-0513 §304: "Receiving entities SHOULD ignore all mentions if the message contains more mentions than the threshold specified by `mentions#count`."

Without this gate, a non-moderator participant blocked by 3a from `@channel` can include `<mention jid='alice'/><mention jid='bob'/>…` for every recipient — each gets `PersonalMention` (no role gate on individuals), same push severity as `ChannelMention`. The §304 cap is the spam mitigation the spec was designed for.

## Implementation

- `waddle_xmpp::xep::xep0513::DEFAULT_MENTIONS_COUNT = 5` (§301 example value).
- `is_mention_target(&ExplicitMention)` filters parser hits down to §3 logical targets (jid / occupantid / `mentions` URI). Anchor-only and modifier-only / uri-only parse hits do NOT count — the parser is round-trip-permissive but the counter is §3-strict.
- `is_reference_mention_target(&Reference)` mirrors the same strictness on the XEP-0372 side: only `type='mention'` references whose URI parses to a valid XMPP bare JID count.
- `mention_target_count_from_parts(mentions, references)` is the hot-path counter; the convenience `mention_target_count` wraps it for tests.
- `mentions_exceed_threshold_from_parts(...)` predicate used at three T0 sites:
  - `groupchat_inbox.rs::groupchat_notification_class` — short-circuits to `NotifyAll` before personal/channel classification. Returns `GroupchatNotificationClassOutcome { decision, mentions_overflowed }` so the caller doesn't have to recompute.
  - `groupchat_inbox.rs::insert_groupchat_notification_candidate` — derives the recipient's class via the classifier.
  - `offline_delivery.rs::mention_bits_for_recipient` — derives `(is_mention, noping)` before the gate, then downgrades `is_mention` on overflow.

## `<noping/>` semantics (PR Compliance ID 7)

XEP-0513 §"No Ping" SHOULD ("if the sender includes a `<noping/>` child element in a mention, the receiving entity SHOULD NOT generate a notification for that mention") is **independent** of §304's "ignore all mentions" cap. The PR therefore PRESERVES `<noping/>` even when the count is exceeded:

- Count exceeded + no `<noping/>` for recipient → class downgraded to `NotifyAll` / `dm`; XEP-0492 `<on-mention/>` recipients are suppressed at T1 via `Xep0492OnMentionMiss`.
- Count exceeded + `<noping/>` for recipient → class downgraded AND the existing T0/T1 `Xep0513Noping` suppressor fires → no push candidate created for that recipient (spec-conformant).

An earlier shape of the PR canceled `<noping/>` on overflow to prevent a spammer silencing push via `<noping/>` + mention spam, but that attack already exists for non-overflowed messages (any `<noping/>` mention silences push) — the count gate adds no new mitigation against it, and the cancellation contradicted §"No Ping". Reverted in commit `d17004c3`.

## XEP-0372 reference fallback consistency

`mention_bits_for_recipient` (DM) also promotes `is_mention` from XEP-0372 `<reference type='mention'/>` naming the recipient, mirroring the groupchat path's `groupchat_mentions_owner`. Without this, the count gate would penalize XEP-0372-only spam but the classifier would silently demote legitimate XEP-0372-only DMs to plain `dm`.

Per-room override of the threshold (XEP-0513 §295 IQ form) is deferred to slice 3c.

## XEP custom tests (CLAUDE.md hard rule)

In `xep0513.rs::count_tests`:
- `mention_target_count_counts_xep0513_mentions`
- `mention_target_count_counts_xep0372_mention_references` (locks `type='data'` exclusion)
- `mention_target_count_sums_xep0513_and_xep0372`
- `mention_target_count_is_zero_for_unmentioned_message`
- `mentions_exceed_threshold_is_strict_inequality` (boundary)
- `mention_target_count_ignores_anchor_only_and_payload_only_mentions` (anchor-less / modifier-only / uri-only ignore)
- `mention_target_count_ignores_xep0372_references_with_unparseable_uris` (XEP-0372 padding bypass)
- `mention_target_count_ignores_empty_string_targets`

In `groupchat_inbox.rs::tests`:
- `xep0513_mention_count_exceeded_ignores_all_mentions`
- `xep0513_mention_count_at_threshold_is_honored`
- `xep0513_mention_count_includes_xep0372_references`
- `xep0513_noping_survives_mention_count_overflow` (Compliance ID 7 lock)
- `xep0513_groupchat_mention_count_at_threshold_preserves_owner_noping`
- `xep0513_channel_mention_with_count_exceeded_composes_to_notify_all_with_overflow_bit`
- `xep0513_delayed_message_with_count_exceeded_still_downgrades_to_notify_all`

In `offline_delivery.rs::tests`:
- `xep0513_dm_mention_count_exceeded_downgrades_is_mention_but_preserves_noping` (both no-noping and noping cases)
- `xep0513_dm_mention_count_at_threshold_preserves_noping`
- `xep0372_only_dm_mention_promotes_recipient_to_dm_mention`
- `xep0372_dm_mention_count_exceeded_downgrades_is_mention`

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -p waddle-xmpp -p waddle-server -- -D warnings`
- [x] `cargo test -p waddle-xmpp --lib` (1898 passed)
- [x] `cargo test -p waddle-server --lib` (959 passed)
- [x] 4 adversarial review passes (XEP normative, wire shape, cross-XEP, Rust idiom)
- [x] Mark ready for review
- [ ] CI green

## Plan (#525 follow-ups)

1. Slice 3a (merged via #738): channel-mention sender-permission gate.
2. **This PR (slice 3b):** `mentions#count` threshold + XEP-0372-bypass closure + DM XEP-0372 promotion symmetry.
3. Slice 3c: XEP-0513 §295 IQ form + per-room overrides. Promote `bool` permission → typed `ChannelBroadcastPermission` enum. Re-advertise `urn:xmpp:mentions:0` in disco-info once the form is wired.
4. Slice 3d: XEP-0452 / XEP-0372 mention-reference fallback for non-present MUC occupants.
5. Slice 3e: Narrow disco advertisement once 3a–3d are merged.

Refs #506. Refs #525.