### PR TITLE
fix(chat): harden audio-video call lifecycle

### DIFF
--- a/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_client.swift
+++ b/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_client.swift
@@ -352,19 +352,29 @@ private func uniffiTraitInterfaceCallWithError<T, E>(
         callStatus.pointee.errorBuf = FfiConverterString.lower(String(describing: error))
     }
 }
+// Initial value and increment amount for handles.
+// These ensure that SWIFT handles always have the lowest bit set
+fileprivate let UNIFFI_HANDLEMAP_INITIAL: UInt64 = 1
+fileprivate let UNIFFI_HANDLEMAP_DELTA: UInt64 = 2
+
 fileprivate final class UniffiHandleMap<T>: @unchecked Sendable {
     // All mutation happens with this lock held, which is why we implement @unchecked Sendable.
     private let lock = NSLock()
     private var map: [UInt64: T] = [:]
-    private var currentHandle: UInt64 = 1
+    private var currentHandle: UInt64 = UNIFFI_HANDLEMAP_INITIAL
 
     func insert(obj: T) -> UInt64 {
         lock.withLock {
-            let handle = currentHandle
-            currentHandle += 1
-            map[handle] = obj
-            return handle
+            return doInsert(obj)
         }
+    }
+
+    // Low-level insert function, this assumes `lock` is held.
+    private func doInsert(_ obj: T) -> UInt64 {
+        let handle = currentHandle
+        currentHandle += UNIFFI_HANDLEMAP_DELTA
+        map[handle] = obj
+        return handle
     }
 
      func get(handle: UInt64) throws -> T {
@@ -373,6 +383,15 @@ fileprivate final class UniffiHandleMap<T>: @unchecked Sendable {
                 throw UniffiInternalError.unexpectedStaleHandle
             }
             return obj
+        }
+    }
+
+     func clone(handle: UInt64) throws -> UInt64 {
+        try lock.withLock {
+            guard let obj = map[handle] else {
+                throw UniffiInternalError.unexpectedStaleHandle
+            }
+            return doInsert(obj)
         }
     }
 
@@ -538,23 +557,23 @@ fileprivate struct FfiConverterData: FfiConverterRustBuffer {
 
 
 public protocol WaddleClientProtocol: AnyObject, Sendable {
-    
-    func connect() async 
-    
-    func disconnect() async 
-    
+
+    func connect() async
+
+    func disconnect() async
+
     func discoverTopology() async  -> WaddleTopology
-    
+
     func discoverUploadService() async  -> String?
-    
+
     func fetchDmHistory(peerJid: String, maxMessages: UInt32, beforeId: String?) async  -> WaddleMamPage
-    
+
     func fetchRoomHistory(roomJid: String, maxMessages: UInt32, beforeId: String?) async  -> WaddleMamPage
-    
-    func joinRoom(roomJid: String, nick: String) async 
-    
-    func leaveRoom(roomJid: String, nick: String) async 
-    
+
+    func joinRoom(roomJid: String, nick: String) async
+
+    func leaveRoom(roomJid: String, nick: String) async
+
     /**
      * Request the XEP-0084 avatar for a user. Returns `None` when the target
      * JID hasn't published an avatar or the fetch failed; errors are
@@ -562,34 +581,47 @@ public protocol WaddleClientProtocol: AnyObject, Sendable {
      * "fall back to initials".
      */
     func requestAvatar(jid: String) async  -> WaddleAvatar?
-    
+
     func requestUploadSlot(serviceJid: String, filename: String, size: UInt64, contentType: String) async  -> WaddleUploadSlot?
-    
+
     /**
      * Send a `<finish/>` Waddle JMI extension signaling clean
      * teardown after a call ended. Addressed to the peer's full JID
      * so the originating resource sees the finish notice.
      */
     func sendCallFinish(peerFullJid: String, sid: String) async  -> Bool
-    
+
+    /**
+     * Send Waddle's XEP-0353-compatible migration marker:
+     * `<finish/>` with `<reason><expired/></reason>` and
+     * `<migrated to='new-sid'/>`.
+     */
+    func sendCallFinishMigrated(peerFullJid: String, oldSid: String, newSid: String) async  -> Bool
+
     /**
      * Send a XEP-0353 §5.1.2 `<proceed/>` to the *full* JID of the
      * originator (preserved from the propose `from` per §0.6).
      */
     func sendCallProceed(peerFullJid: String, sid: String) async  -> Bool
-    
+
     /**
      * Send a XEP-0353 §5.1.1 `<propose/>` to the peer's bare JID.
      * The bare JID lets the responder's server ring every connected
      * resource until one of them proceeds or rejects.
      */
     func sendCallPropose(peerBareJid: String, sid: String, audio: Bool, video: Bool) async  -> Bool
-    
+
     /**
      * Send a XEP-0353 §5.1.3 `<reject/>` to the originator's full JID.
      */
     func sendCallReject(peerFullJid: String, sid: String) async  -> Bool
-    
+
+    /**
+     * Send a XEP-0353 tie-break `<reject/>` carrying
+     * `<reason><expired/></reason>` plus `<tie-break/>`.
+     */
+    func sendCallRejectTieBreak(peerFullJid: String, sid: String) async  -> Bool
+
     /**
      * Send a XEP-0353 §5.1.4 `<retract/>` to cancel a ringing call
      * before the peer answers. Addressed to the responder's *bare*
@@ -598,15 +630,21 @@ public protocol WaddleClientProtocol: AnyObject, Sendable {
      * callee's bare JID, exactly like the originating propose).
      */
     func sendCallRetract(peerBareJid: String, sid: String) async  -> Bool
-    
+
     /**
-     * Send a XEP-0166 §7.2 `session-accept` IQ. `initiator` and
-     * `responder` are both validated as full JIDs at the FFI
+     * Send a XEP-0353 tie-break `<retract/>` carrying
+     * `<reason><expired/></reason>` plus `<tie-break/>`.
+     */
+    func sendCallRetractTieBreak(peerFullJid: String, sid: String) async  -> Bool
+
+    /**
+     * Send a XEP-0166 §7.2 `session-accept` IQ. `responder` is
+     * validated as a full JID at the FFI
      * boundary so a malformed JID surfaces as an error before the
      * stanza hits the wire.
      */
-    func sendCallSessionAccept(peerFullJid: String, initiatorFullJid: String, responderFullJid: String, sid: String, audio: Bool, video: Bool) async  -> Bool
-    
+    func sendCallSessionAccept(peerFullJid: String, responderFullJid: String, sid: String, audio: Bool, video: Bool) async  -> Bool
+
     /**
      * Send a XEP-0166 §6.4 `session-initiate` IQ to the peer's full
      * JID. `initiator_full_jid` names the call originator per §7.1;
@@ -616,7 +654,7 @@ public protocol WaddleClientProtocol: AnyObject, Sendable {
      * than letting a malformed stanza hit the wire.
      */
     func sendCallSessionInitiate(peerFullJid: String, initiatorFullJid: String, sid: String, audio: Bool, video: Bool) async  -> Bool
-    
+
     /**
      * Send a XEP-0166 §7.4 `session-terminate` IQ. `reason` is the
      * typed XEP-0166 condition (the FFI rejects unknown values at
@@ -625,22 +663,22 @@ public protocol WaddleClientProtocol: AnyObject, Sendable {
      * Swift, so the wire can't carry one either).
      */
     func sendCallSessionTerminate(peerFullJid: String, sid: String, reason: WaddleJingleReason?) async  -> Bool
-    
+
     func sendChatMessage(peerJid: String, body: String, options: WaddleSendOptions?) async  -> String
-    
+
     func sendGroupchatMessage(roomJid: String, body: String, options: WaddleSendOptions?) async  -> String
-    
-    func sendPresence(status: String?, show: String?) async 
-    
+
+    func sendPresence(status: String?, show: String?) async
+
 }
 open class WaddleClient: WaddleClientProtocol, @unchecked Sendable {
-    fileprivate let pointer: UnsafeMutableRawPointer!
+    fileprivate let handle: UInt64
 
-    /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
+    /// Used to instantiate a [FFIObject] without an actual handle, for fakes in tests, mostly.
 #if swift(>=5.8)
     @_documentation(visibility: private)
 #endif
-    public struct NoPointer {
+    public struct NoHandle {
         public init() {}
     }
 
@@ -650,57 +688,58 @@ open class WaddleClient: WaddleClientProtocol, @unchecked Sendable {
 #if swift(>=5.8)
     @_documentation(visibility: private)
 #endif
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
-        self.pointer = pointer
+    required public init(unsafeFromHandle handle: UInt64) {
+        self.handle = handle
     }
 
     // This constructor can be used to instantiate a fake object.
-    // - Parameter noPointer: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
+    // - Parameter noHandle: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
     //
     // - Warning:
-    //     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
+    //     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing handle the FFI lower functions will crash.
 #if swift(>=5.8)
     @_documentation(visibility: private)
 #endif
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    public init(noHandle: NoHandle) {
+        self.handle = 0
     }
 
 #if swift(>=5.8)
     @_documentation(visibility: private)
 #endif
-    public func uniffiClonePointer() -> UnsafeMutableRawPointer {
-        return try! rustCall { uniffi_waddle_xmpp_client_ffi_fn_clone_waddleclient(self.pointer, $0) }
+    public func uniffiCloneHandle() -> UInt64 {
+        return try! rustCall { uniffi_waddle_xmpp_client_ffi_fn_clone_waddleclient(self.handle, $0) }
     }
 public convenience init(config: WaddleConfig, listener: WaddleEventListener) {
-    let pointer =
+    let handle =
         try! rustCall() {
     uniffi_waddle_xmpp_client_ffi_fn_constructor_waddleclient_new(
         FfiConverterTypeWaddleConfig_lower(config),
         FfiConverterCallbackInterfaceWaddleEventListener_lower(listener),$0
     )
 }
-    self.init(unsafeFromRawPointer: pointer)
+    self.init(unsafeFromHandle: handle)
 }
 
     deinit {
-        guard let pointer = pointer else {
+        if handle == 0 {
+            // Mock objects have handle=0 don't try to free them
             return
         }
 
-        try! rustCall { uniffi_waddle_xmpp_client_ffi_fn_free_waddleclient(pointer, $0) }
+        try! rustCall { uniffi_waddle_xmpp_client_ffi_fn_free_waddleclient(handle, $0) }
     }
 
-    
 
-    
+
+
 open func connect()async   {
     return
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_connect(
-                    self.uniffiClonePointer()
-                    
+                    self.uniffiCloneHandle()
+
                 )
             },
             pollFunc: ffi_waddle_xmpp_client_ffi_rust_future_poll_void,
@@ -708,17 +747,17 @@ open func connect()async   {
             freeFunc: ffi_waddle_xmpp_client_ffi_rust_future_free_void,
             liftFunc: { $0 },
             errorHandler: nil
-            
+
         )
 }
-    
+
 open func disconnect()async   {
     return
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_disconnect(
-                    self.uniffiClonePointer()
-                    
+                    self.uniffiCloneHandle()
+
                 )
             },
             pollFunc: ffi_waddle_xmpp_client_ffi_rust_future_poll_void,
@@ -726,17 +765,17 @@ open func disconnect()async   {
             freeFunc: ffi_waddle_xmpp_client_ffi_rust_future_free_void,
             liftFunc: { $0 },
             errorHandler: nil
-            
+
         )
 }
-    
+
 open func discoverTopology()async  -> WaddleTopology  {
     return
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_discover_topology(
-                    self.uniffiClonePointer()
-                    
+                    self.uniffiCloneHandle()
+
                 )
             },
             pollFunc: ffi_waddle_xmpp_client_ffi_rust_future_poll_rust_buffer,
@@ -744,17 +783,17 @@ open func discoverTopology()async  -> WaddleTopology  {
             freeFunc: ffi_waddle_xmpp_client_ffi_rust_future_free_rust_buffer,
             liftFunc: FfiConverterTypeWaddleTopology_lift,
             errorHandler: nil
-            
+
         )
 }
-    
+
 open func discoverUploadService()async  -> String?  {
     return
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_discover_upload_service(
-                    self.uniffiClonePointer()
-                    
+                    self.uniffiCloneHandle()
+
                 )
             },
             pollFunc: ffi_waddle_xmpp_client_ffi_rust_future_poll_rust_buffer,
@@ -762,16 +801,16 @@ open func discoverUploadService()async  -> String?  {
             freeFunc: ffi_waddle_xmpp_client_ffi_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionString.lift,
             errorHandler: nil
-            
+
         )
 }
-    
+
 open func fetchDmHistory(peerJid: String, maxMessages: UInt32, beforeId: String?)async  -> WaddleMamPage  {
     return
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_fetch_dm_history(
-                    self.uniffiClonePointer(),
+                    self.uniffiCloneHandle(),
                     FfiConverterString.lower(peerJid),FfiConverterUInt32.lower(maxMessages),FfiConverterOptionString.lower(beforeId)
                 )
             },
@@ -780,16 +819,16 @@ open func fetchDmHistory(peerJid: String, maxMessages: UInt32, beforeId: String?
             freeFunc: ffi_waddle_xmpp_client_ffi_rust_future_free_rust_buffer,
             liftFunc: FfiConverterTypeWaddleMamPage_lift,
             errorHandler: nil
-            
+
         )
 }
-    
+
 open func fetchRoomHistory(roomJid: String, maxMessages: UInt32, beforeId: String?)async  -> WaddleMamPage  {
     return
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_fetch_room_history(
-                    self.uniffiClonePointer(),
+                    self.uniffiCloneHandle(),
                     FfiConverterString.lower(roomJid),FfiConverterUInt32.lower(maxMessages),FfiConverterOptionString.lower(beforeId)
                 )
             },
@@ -798,16 +837,16 @@ open func fetchRoomHistory(roomJid: String, maxMessages: UInt32, beforeId: Strin
             freeFunc: ffi_waddle_xmpp_client_ffi_rust_future_free_rust_buffer,
             liftFunc: FfiConverterTypeWaddleMamPage_lift,
             errorHandler: nil
-            
+
         )
 }
-    
+
 open func joinRoom(roomJid: String, nick: String)async   {
     return
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_join_room(
-                    self.uniffiClonePointer(),
+                    self.uniffiCloneHandle(),
                     FfiConverterString.lower(roomJid),FfiConverterString.lower(nick)
                 )
             },
@@ -816,16 +855,16 @@ open func joinRoom(roomJid: String, nick: String)async   {
             freeFunc: ffi_waddle_xmpp_client_ffi_rust_future_free_void,
             liftFunc: { $0 },
             errorHandler: nil
-            
+
         )
 }
-    
+
 open func leaveRoom(roomJid: String, nick: String)async   {
     return
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_leave_room(
-                    self.uniffiClonePointer(),
+                    self.uniffiCloneHandle(),
                     FfiConverterString.lower(roomJid),FfiConverterString.lower(nick)
                 )
             },
@@ -834,10 +873,10 @@ open func leaveRoom(roomJid: String, nick: String)async   {
             freeFunc: ffi_waddle_xmpp_client_ffi_rust_future_free_void,
             liftFunc: { $0 },
             errorHandler: nil
-            
+
         )
 }
-    
+
     /**
      * Request the XEP-0084 avatar for a user. Returns `None` when the target
      * JID hasn't published an avatar or the fetch failed; errors are
@@ -849,7 +888,7 @@ open func requestAvatar(jid: String)async  -> WaddleAvatar?  {
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_request_avatar(
-                    self.uniffiClonePointer(),
+                    self.uniffiCloneHandle(),
                     FfiConverterString.lower(jid)
                 )
             },
@@ -858,16 +897,16 @@ open func requestAvatar(jid: String)async  -> WaddleAvatar?  {
             freeFunc: ffi_waddle_xmpp_client_ffi_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeWaddleAvatar.lift,
             errorHandler: nil
-            
+
         )
 }
-    
+
 open func requestUploadSlot(serviceJid: String, filename: String, size: UInt64, contentType: String)async  -> WaddleUploadSlot?  {
     return
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_request_upload_slot(
-                    self.uniffiClonePointer(),
+                    self.uniffiCloneHandle(),
                     FfiConverterString.lower(serviceJid),FfiConverterString.lower(filename),FfiConverterUInt64.lower(size),FfiConverterString.lower(contentType)
                 )
             },
@@ -876,10 +915,10 @@ open func requestUploadSlot(serviceJid: String, filename: String, size: UInt64, 
             freeFunc: ffi_waddle_xmpp_client_ffi_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeWaddleUploadSlot.lift,
             errorHandler: nil
-            
+
         )
 }
-    
+
     /**
      * Send a `<finish/>` Waddle JMI extension signaling clean
      * teardown after a call ended. Addressed to the peer's full JID
@@ -890,7 +929,7 @@ open func sendCallFinish(peerFullJid: String, sid: String)async  -> Bool  {
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_finish(
-                    self.uniffiClonePointer(),
+                    self.uniffiCloneHandle(),
                     FfiConverterString.lower(peerFullJid),FfiConverterString.lower(sid)
                 )
             },
@@ -899,10 +938,33 @@ open func sendCallFinish(peerFullJid: String, sid: String)async  -> Bool  {
             freeFunc: ffi_waddle_xmpp_client_ffi_rust_future_free_i8,
             liftFunc: FfiConverterBool.lift,
             errorHandler: nil
-            
+
         )
 }
-    
+
+    /**
+     * Send Waddle's XEP-0353-compatible migration marker:
+     * `<finish/>` with `<reason><expired/></reason>` and
+     * `<migrated to='new-sid'/>`.
+     */
+open func sendCallFinishMigrated(peerFullJid: String, oldSid: String, newSid: String)async  -> Bool  {
+    return
+        try!  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_finish_migrated(
+                    self.uniffiCloneHandle(),
+                    FfiConverterString.lower(peerFullJid),FfiConverterString.lower(oldSid),FfiConverterString.lower(newSid)
+                )
+            },
+            pollFunc: ffi_waddle_xmpp_client_ffi_rust_future_poll_i8,
+            completeFunc: ffi_waddle_xmpp_client_ffi_rust_future_complete_i8,
+            freeFunc: ffi_waddle_xmpp_client_ffi_rust_future_free_i8,
+            liftFunc: FfiConverterBool.lift,
+            errorHandler: nil
+
+        )
+}
+
     /**
      * Send a XEP-0353 §5.1.2 `<proceed/>` to the *full* JID of the
      * originator (preserved from the propose `from` per §0.6).
@@ -912,7 +974,7 @@ open func sendCallProceed(peerFullJid: String, sid: String)async  -> Bool  {
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_proceed(
-                    self.uniffiClonePointer(),
+                    self.uniffiCloneHandle(),
                     FfiConverterString.lower(peerFullJid),FfiConverterString.lower(sid)
                 )
             },
@@ -921,10 +983,10 @@ open func sendCallProceed(peerFullJid: String, sid: String)async  -> Bool  {
             freeFunc: ffi_waddle_xmpp_client_ffi_rust_future_free_i8,
             liftFunc: FfiConverterBool.lift,
             errorHandler: nil
-            
+
         )
 }
-    
+
     /**
      * Send a XEP-0353 §5.1.1 `<propose/>` to the peer's bare JID.
      * The bare JID lets the responder's server ring every connected
@@ -935,7 +997,7 @@ open func sendCallPropose(peerBareJid: String, sid: String, audio: Bool, video: 
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_propose(
-                    self.uniffiClonePointer(),
+                    self.uniffiCloneHandle(),
                     FfiConverterString.lower(peerBareJid),FfiConverterString.lower(sid),FfiConverterBool.lower(audio),FfiConverterBool.lower(video)
                 )
             },
@@ -944,10 +1006,10 @@ open func sendCallPropose(peerBareJid: String, sid: String, audio: Bool, video: 
             freeFunc: ffi_waddle_xmpp_client_ffi_rust_future_free_i8,
             liftFunc: FfiConverterBool.lift,
             errorHandler: nil
-            
+
         )
 }
-    
+
     /**
      * Send a XEP-0353 §5.1.3 `<reject/>` to the originator's full JID.
      */
@@ -956,7 +1018,7 @@ open func sendCallReject(peerFullJid: String, sid: String)async  -> Bool  {
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_reject(
-                    self.uniffiClonePointer(),
+                    self.uniffiCloneHandle(),
                     FfiConverterString.lower(peerFullJid),FfiConverterString.lower(sid)
                 )
             },
@@ -965,10 +1027,32 @@ open func sendCallReject(peerFullJid: String, sid: String)async  -> Bool  {
             freeFunc: ffi_waddle_xmpp_client_ffi_rust_future_free_i8,
             liftFunc: FfiConverterBool.lift,
             errorHandler: nil
-            
+
         )
 }
-    
+
+    /**
+     * Send a XEP-0353 tie-break `<reject/>` carrying
+     * `<reason><expired/></reason>` plus `<tie-break/>`.
+     */
+open func sendCallRejectTieBreak(peerFullJid: String, sid: String)async  -> Bool  {
+    return
+        try!  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_reject_tie_break(
+                    self.uniffiCloneHandle(),
+                    FfiConverterString.lower(peerFullJid),FfiConverterString.lower(sid)
+                )
+            },
+            pollFunc: ffi_waddle_xmpp_client_ffi_rust_future_poll_i8,
+            completeFunc: ffi_waddle_xmpp_client_ffi_rust_future_complete_i8,
+            freeFunc: ffi_waddle_xmpp_client_ffi_rust_future_free_i8,
+            liftFunc: FfiConverterBool.lift,
+            errorHandler: nil
+
+        )
+}
+
     /**
      * Send a XEP-0353 §5.1.4 `<retract/>` to cancel a ringing call
      * before the peer answers. Addressed to the responder's *bare*
@@ -981,7 +1065,7 @@ open func sendCallRetract(peerBareJid: String, sid: String)async  -> Bool  {
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_retract(
-                    self.uniffiClonePointer(),
+                    self.uniffiCloneHandle(),
                     FfiConverterString.lower(peerBareJid),FfiConverterString.lower(sid)
                 )
             },
@@ -990,23 +1074,21 @@ open func sendCallRetract(peerBareJid: String, sid: String)async  -> Bool  {
             freeFunc: ffi_waddle_xmpp_client_ffi_rust_future_free_i8,
             liftFunc: FfiConverterBool.lift,
             errorHandler: nil
-            
+
         )
 }
-    
+
     /**
-     * Send a XEP-0166 §7.2 `session-accept` IQ. `initiator` and
-     * `responder` are both validated as full JIDs at the FFI
-     * boundary so a malformed JID surfaces as an error before the
-     * stanza hits the wire.
+     * Send a XEP-0353 tie-break `<retract/>` carrying
+     * `<reason><expired/></reason>` plus `<tie-break/>`.
      */
-open func sendCallSessionAccept(peerFullJid: String, initiatorFullJid: String, responderFullJid: String, sid: String, audio: Bool, video: Bool)async  -> Bool  {
+open func sendCallRetractTieBreak(peerFullJid: String, sid: String)async  -> Bool  {
     return
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
-                uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_session_accept(
-                    self.uniffiClonePointer(),
-                    FfiConverterString.lower(peerFullJid),FfiConverterString.lower(initiatorFullJid),FfiConverterString.lower(responderFullJid),FfiConverterString.lower(sid),FfiConverterBool.lower(audio),FfiConverterBool.lower(video)
+                uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_retract_tie_break(
+                    self.uniffiCloneHandle(),
+                    FfiConverterString.lower(peerFullJid),FfiConverterString.lower(sid)
                 )
             },
             pollFunc: ffi_waddle_xmpp_client_ffi_rust_future_poll_i8,
@@ -1014,10 +1096,34 @@ open func sendCallSessionAccept(peerFullJid: String, initiatorFullJid: String, r
             freeFunc: ffi_waddle_xmpp_client_ffi_rust_future_free_i8,
             liftFunc: FfiConverterBool.lift,
             errorHandler: nil
-            
+
         )
 }
-    
+
+    /**
+     * Send a XEP-0166 §7.2 `session-accept` IQ. `responder` is
+     * validated as a full JID at the FFI
+     * boundary so a malformed JID surfaces as an error before the
+     * stanza hits the wire.
+     */
+open func sendCallSessionAccept(peerFullJid: String, responderFullJid: String, sid: String, audio: Bool, video: Bool)async  -> Bool  {
+    return
+        try!  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_session_accept(
+                    self.uniffiCloneHandle(),
+                    FfiConverterString.lower(peerFullJid),FfiConverterString.lower(responderFullJid),FfiConverterString.lower(sid),FfiConverterBool.lower(audio),FfiConverterBool.lower(video)
+                )
+            },
+            pollFunc: ffi_waddle_xmpp_client_ffi_rust_future_poll_i8,
+            completeFunc: ffi_waddle_xmpp_client_ffi_rust_future_complete_i8,
+            freeFunc: ffi_waddle_xmpp_client_ffi_rust_future_free_i8,
+            liftFunc: FfiConverterBool.lift,
+            errorHandler: nil
+
+        )
+}
+
     /**
      * Send a XEP-0166 §6.4 `session-initiate` IQ to the peer's full
      * JID. `initiator_full_jid` names the call originator per §7.1;
@@ -1031,7 +1137,7 @@ open func sendCallSessionInitiate(peerFullJid: String, initiatorFullJid: String,
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_session_initiate(
-                    self.uniffiClonePointer(),
+                    self.uniffiCloneHandle(),
                     FfiConverterString.lower(peerFullJid),FfiConverterString.lower(initiatorFullJid),FfiConverterString.lower(sid),FfiConverterBool.lower(audio),FfiConverterBool.lower(video)
                 )
             },
@@ -1040,10 +1146,10 @@ open func sendCallSessionInitiate(peerFullJid: String, initiatorFullJid: String,
             freeFunc: ffi_waddle_xmpp_client_ffi_rust_future_free_i8,
             liftFunc: FfiConverterBool.lift,
             errorHandler: nil
-            
+
         )
 }
-    
+
     /**
      * Send a XEP-0166 §7.4 `session-terminate` IQ. `reason` is the
      * typed XEP-0166 condition (the FFI rejects unknown values at
@@ -1056,7 +1162,7 @@ open func sendCallSessionTerminate(peerFullJid: String, sid: String, reason: Wad
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_session_terminate(
-                    self.uniffiClonePointer(),
+                    self.uniffiCloneHandle(),
                     FfiConverterString.lower(peerFullJid),FfiConverterString.lower(sid),FfiConverterOptionTypeWaddleJingleReason.lower(reason)
                 )
             },
@@ -1065,16 +1171,16 @@ open func sendCallSessionTerminate(peerFullJid: String, sid: String, reason: Wad
             freeFunc: ffi_waddle_xmpp_client_ffi_rust_future_free_i8,
             liftFunc: FfiConverterBool.lift,
             errorHandler: nil
-            
+
         )
 }
-    
+
 open func sendChatMessage(peerJid: String, body: String, options: WaddleSendOptions?)async  -> String  {
     return
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_chat_message(
-                    self.uniffiClonePointer(),
+                    self.uniffiCloneHandle(),
                     FfiConverterString.lower(peerJid),FfiConverterString.lower(body),FfiConverterOptionTypeWaddleSendOptions.lower(options)
                 )
             },
@@ -1083,16 +1189,16 @@ open func sendChatMessage(peerJid: String, body: String, options: WaddleSendOpti
             freeFunc: ffi_waddle_xmpp_client_ffi_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
             errorHandler: nil
-            
+
         )
 }
-    
+
 open func sendGroupchatMessage(roomJid: String, body: String, options: WaddleSendOptions?)async  -> String  {
     return
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_groupchat_message(
-                    self.uniffiClonePointer(),
+                    self.uniffiCloneHandle(),
                     FfiConverterString.lower(roomJid),FfiConverterString.lower(body),FfiConverterOptionTypeWaddleSendOptions.lower(options)
                 )
             },
@@ -1101,16 +1207,16 @@ open func sendGroupchatMessage(roomJid: String, body: String, options: WaddleSen
             freeFunc: ffi_waddle_xmpp_client_ffi_rust_future_free_rust_buffer,
             liftFunc: FfiConverterString.lift,
             errorHandler: nil
-            
+
         )
 }
-    
+
 open func sendPresence(status: String?, show: String?)async   {
     return
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_presence(
-                    self.uniffiClonePointer(),
+                    self.uniffiCloneHandle(),
                     FfiConverterOptionString.lower(status),FfiConverterOptionString.lower(show)
                 )
             },
@@ -1119,10 +1225,11 @@ open func sendPresence(status: String?, show: String?)async   {
             freeFunc: ffi_waddle_xmpp_client_ffi_rust_future_free_void,
             liftFunc: { $0 },
             errorHandler: nil
-            
+
         )
 }
-    
+
+
 
 }
 
@@ -1131,33 +1238,24 @@ open func sendPresence(status: String?, show: String?)async   {
 @_documentation(visibility: private)
 #endif
 public struct FfiConverterTypeWaddleClient: FfiConverter {
-
-    typealias FfiType = UnsafeMutableRawPointer
+    typealias FfiType = UInt64
     typealias SwiftType = WaddleClient
 
-    public static func lift(_ pointer: UnsafeMutableRawPointer) throws -> WaddleClient {
-        return WaddleClient(unsafeFromRawPointer: pointer)
+    public static func lift(_ handle: UInt64) throws -> WaddleClient {
+        return WaddleClient(unsafeFromHandle: handle)
     }
 
-    public static func lower(_ value: WaddleClient) -> UnsafeMutableRawPointer {
-        return value.uniffiClonePointer()
+    public static func lower(_ value: WaddleClient) -> UInt64 {
+        return value.uniffiCloneHandle()
     }
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleClient {
-        let v: UInt64 = try readInt(&buf)
-        // The Rust code won't compile if a pointer won't fit in a UInt64.
-        // We have to go via `UInt` because that's the thing that's the size of a pointer.
-        let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
-            throw UniffiInternalError.unexpectedNullPointer
-        }
-        return try lift(ptr!)
+        let handle: UInt64 = try readInt(&buf)
+        return try lift(handle)
     }
 
     public static func write(_ value: WaddleClient, into buf: inout [UInt8]) {
-        // This fiddling is because `Int` is the thing that's the same size as a pointer.
-        // The Rust code won't compile if a pointer won't fit in a `UInt64`.
-        writeInt(&buf, UInt64(bitPattern: Int64(Int(bitPattern: lower(value)))))
+        writeInt(&buf, lower(value))
     }
 }
 
@@ -1165,21 +1263,21 @@ public struct FfiConverterTypeWaddleClient: FfiConverter {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-public func FfiConverterTypeWaddleClient_lift(_ pointer: UnsafeMutableRawPointer) throws -> WaddleClient {
-    return try FfiConverterTypeWaddleClient.lift(pointer)
+public func FfiConverterTypeWaddleClient_lift(_ handle: UInt64) throws -> WaddleClient {
+    return try FfiConverterTypeWaddleClient.lift(handle)
 }
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-public func FfiConverterTypeWaddleClient_lower(_ value: WaddleClient) -> UnsafeMutableRawPointer {
+public func FfiConverterTypeWaddleClient_lower(_ value: WaddleClient) -> UInt64 {
     return FfiConverterTypeWaddleClient.lower(value)
 }
 
 
 
 
-public struct WaddleArchivedMessage {
+public struct WaddleArchivedMessage: Equatable, Hashable {
     public var mamId: String
     public var queryId: String?
     public var id: String?
@@ -1223,99 +1321,15 @@ public struct WaddleArchivedMessage {
         self.replyFallbackEnd = replyFallbackEnd
         self.sharedFiles = sharedFiles
     }
+
+
+
+
 }
 
 #if compiler(>=6)
 extension WaddleArchivedMessage: Sendable {}
 #endif
-
-
-extension WaddleArchivedMessage: Equatable, Hashable {
-    public static func ==(lhs: WaddleArchivedMessage, rhs: WaddleArchivedMessage) -> Bool {
-        if lhs.mamId != rhs.mamId {
-            return false
-        }
-        if lhs.queryId != rhs.queryId {
-            return false
-        }
-        if lhs.id != rhs.id {
-            return false
-        }
-        if lhs.stanzaId != rhs.stanzaId {
-            return false
-        }
-        if lhs.originId != rhs.originId {
-            return false
-        }
-        if lhs.timestamp != rhs.timestamp {
-            return false
-        }
-        if lhs.from != rhs.from {
-            return false
-        }
-        if lhs.to != rhs.to {
-            return false
-        }
-        if lhs.messageType != rhs.messageType {
-            return false
-        }
-        if lhs.body != rhs.body {
-            return false
-        }
-        if lhs.reactionTargetId != rhs.reactionTargetId {
-            return false
-        }
-        if lhs.reactionEmojis != rhs.reactionEmojis {
-            return false
-        }
-        if lhs.thread != rhs.thread {
-            return false
-        }
-        if lhs.parentThreadId != rhs.parentThreadId {
-            return false
-        }
-        if lhs.replyToId != rhs.replyToId {
-            return false
-        }
-        if lhs.replyToSender != rhs.replyToSender {
-            return false
-        }
-        if lhs.replyFallbackStart != rhs.replyFallbackStart {
-            return false
-        }
-        if lhs.replyFallbackEnd != rhs.replyFallbackEnd {
-            return false
-        }
-        if lhs.sharedFiles != rhs.sharedFiles {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(mamId)
-        hasher.combine(queryId)
-        hasher.combine(id)
-        hasher.combine(stanzaId)
-        hasher.combine(originId)
-        hasher.combine(timestamp)
-        hasher.combine(from)
-        hasher.combine(to)
-        hasher.combine(messageType)
-        hasher.combine(body)
-        hasher.combine(reactionTargetId)
-        hasher.combine(reactionEmojis)
-        hasher.combine(thread)
-        hasher.combine(parentThreadId)
-        hasher.combine(replyToId)
-        hasher.combine(replyToSender)
-        hasher.combine(replyFallbackStart)
-        hasher.combine(replyFallbackEnd)
-        hasher.combine(sharedFiles)
-    }
-}
-
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -1324,24 +1338,24 @@ public struct FfiConverterTypeWaddleArchivedMessage: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleArchivedMessage {
         return
             try WaddleArchivedMessage(
-                mamId: FfiConverterString.read(from: &buf), 
-                queryId: FfiConverterOptionString.read(from: &buf), 
-                id: FfiConverterOptionString.read(from: &buf), 
-                stanzaId: FfiConverterOptionString.read(from: &buf), 
-                originId: FfiConverterOptionString.read(from: &buf), 
-                timestamp: FfiConverterOptionString.read(from: &buf), 
-                from: FfiConverterOptionString.read(from: &buf), 
-                to: FfiConverterOptionString.read(from: &buf), 
-                messageType: FfiConverterString.read(from: &buf), 
-                body: FfiConverterOptionString.read(from: &buf), 
-                reactionTargetId: FfiConverterOptionString.read(from: &buf), 
-                reactionEmojis: FfiConverterSequenceString.read(from: &buf), 
-                thread: FfiConverterOptionString.read(from: &buf), 
-                parentThreadId: FfiConverterOptionString.read(from: &buf), 
-                replyToId: FfiConverterOptionString.read(from: &buf), 
-                replyToSender: FfiConverterOptionString.read(from: &buf), 
-                replyFallbackStart: FfiConverterOptionUInt32.read(from: &buf), 
-                replyFallbackEnd: FfiConverterOptionUInt32.read(from: &buf), 
+                mamId: FfiConverterString.read(from: &buf),
+                queryId: FfiConverterOptionString.read(from: &buf),
+                id: FfiConverterOptionString.read(from: &buf),
+                stanzaId: FfiConverterOptionString.read(from: &buf),
+                originId: FfiConverterOptionString.read(from: &buf),
+                timestamp: FfiConverterOptionString.read(from: &buf),
+                from: FfiConverterOptionString.read(from: &buf),
+                to: FfiConverterOptionString.read(from: &buf),
+                messageType: FfiConverterString.read(from: &buf),
+                body: FfiConverterOptionString.read(from: &buf),
+                reactionTargetId: FfiConverterOptionString.read(from: &buf),
+                reactionEmojis: FfiConverterSequenceString.read(from: &buf),
+                thread: FfiConverterOptionString.read(from: &buf),
+                parentThreadId: FfiConverterOptionString.read(from: &buf),
+                replyToId: FfiConverterOptionString.read(from: &buf),
+                replyToSender: FfiConverterOptionString.read(from: &buf),
+                replyFallbackStart: FfiConverterOptionUInt32.read(from: &buf),
+                replyFallbackEnd: FfiConverterOptionUInt32.read(from: &buf),
                 sharedFiles: FfiConverterSequenceTypeWaddleSharedFile.read(from: &buf)
         )
     }
@@ -1392,7 +1406,7 @@ public func FfiConverterTypeWaddleArchivedMessage_lower(_ value: WaddleArchivedM
  * `url` is present when XEP-0084 metadata or vCard `EXTVAL` points to an
  * externally hosted avatar.
  */
-public struct WaddleAvatar {
+public struct WaddleAvatar: Equatable, Hashable {
     /**
      * Bare JID the avatar belongs to (string form).
      */
@@ -1419,16 +1433,16 @@ public struct WaddleAvatar {
     public init(
         /**
          * Bare JID the avatar belongs to (string form).
-         */jid: String, 
+         */jid: String,
         /**
          * SHA-1 content hash advertised on the metadata node.
-         */id: String, 
+         */id: String,
         /**
          * MIME type (e.g. `image/png`).
-         */mimeType: String, 
+         */mimeType: String,
         /**
          * Decoded image bytes.
-         */data: Data, 
+         */data: Data,
         /**
          * Externally hosted avatar URL.
          */url: String?) {
@@ -1438,43 +1452,15 @@ public struct WaddleAvatar {
         self.data = data
         self.url = url
     }
+
+
+
+
 }
 
 #if compiler(>=6)
 extension WaddleAvatar: Sendable {}
 #endif
-
-
-extension WaddleAvatar: Equatable, Hashable {
-    public static func ==(lhs: WaddleAvatar, rhs: WaddleAvatar) -> Bool {
-        if lhs.jid != rhs.jid {
-            return false
-        }
-        if lhs.id != rhs.id {
-            return false
-        }
-        if lhs.mimeType != rhs.mimeType {
-            return false
-        }
-        if lhs.data != rhs.data {
-            return false
-        }
-        if lhs.url != rhs.url {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(jid)
-        hasher.combine(id)
-        hasher.combine(mimeType)
-        hasher.combine(data)
-        hasher.combine(url)
-    }
-}
-
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -1483,10 +1469,10 @@ public struct FfiConverterTypeWaddleAvatar: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleAvatar {
         return
             try WaddleAvatar(
-                jid: FfiConverterString.read(from: &buf), 
-                id: FfiConverterString.read(from: &buf), 
-                mimeType: FfiConverterString.read(from: &buf), 
-                data: FfiConverterData.read(from: &buf), 
+                jid: FfiConverterString.read(from: &buf),
+                id: FfiConverterString.read(from: &buf),
+                mimeType: FfiConverterString.read(from: &buf),
+                data: FfiConverterData.read(from: &buf),
                 url: FfiConverterOptionString.read(from: &buf)
         )
     }
@@ -1522,7 +1508,7 @@ public func FfiConverterTypeWaddleAvatar_lower(_ value: WaddleAvatar) -> RustBuf
  * session-initiate per XEP-0353 §0.6); `sid` is the Jingle
  * session id used to correlate every later event in the call.
  */
-public struct WaddleCallEvent {
+public struct WaddleCallEvent: Equatable, Hashable {
     public var from: String
     public var sid: String
     public var kind: WaddleCallEventKind
@@ -1534,35 +1520,15 @@ public struct WaddleCallEvent {
         self.sid = sid
         self.kind = kind
     }
+
+
+
+
 }
 
 #if compiler(>=6)
 extension WaddleCallEvent: Sendable {}
 #endif
-
-
-extension WaddleCallEvent: Equatable, Hashable {
-    public static func ==(lhs: WaddleCallEvent, rhs: WaddleCallEvent) -> Bool {
-        if lhs.from != rhs.from {
-            return false
-        }
-        if lhs.sid != rhs.sid {
-            return false
-        }
-        if lhs.kind != rhs.kind {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(from)
-        hasher.combine(sid)
-        hasher.combine(kind)
-    }
-}
-
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -1571,8 +1537,8 @@ public struct FfiConverterTypeWaddleCallEvent: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleCallEvent {
         return
             try WaddleCallEvent(
-                from: FfiConverterString.read(from: &buf), 
-                sid: FfiConverterString.read(from: &buf), 
+                from: FfiConverterString.read(from: &buf),
+                sid: FfiConverterString.read(from: &buf),
                 kind: FfiConverterTypeWaddleCallEventKind.read(from: &buf)
         )
     }
@@ -1605,7 +1571,7 @@ public func FfiConverterTypeWaddleCallEvent_lower(_ value: WaddleCallEvent) -> R
  * `waddle_xmpp_client::messaging::CallMedia` 1:1 so the Swift side
  * can read the boolean flags directly without a wrapper enum.
  */
-public struct WaddleCallMedia {
+public struct WaddleCallMedia: Equatable, Hashable {
     public var audio: Bool
     public var video: Bool
 
@@ -1615,31 +1581,15 @@ public struct WaddleCallMedia {
         self.audio = audio
         self.video = video
     }
+
+
+
+
 }
 
 #if compiler(>=6)
 extension WaddleCallMedia: Sendable {}
 #endif
-
-
-extension WaddleCallMedia: Equatable, Hashable {
-    public static func ==(lhs: WaddleCallMedia, rhs: WaddleCallMedia) -> Bool {
-        if lhs.audio != rhs.audio {
-            return false
-        }
-        if lhs.video != rhs.video {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(audio)
-        hasher.combine(video)
-    }
-}
-
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -1648,7 +1598,7 @@ public struct FfiConverterTypeWaddleCallMedia: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleCallMedia {
         return
             try WaddleCallMedia(
-                audio: FfiConverterBool.read(from: &buf), 
+                audio: FfiConverterBool.read(from: &buf),
                 video: FfiConverterBool.read(from: &buf)
         )
     }
@@ -1675,7 +1625,7 @@ public func FfiConverterTypeWaddleCallMedia_lower(_ value: WaddleCallMedia) -> R
 }
 
 
-public struct WaddleChannel {
+public struct WaddleChannel: Equatable, Hashable {
     public var id: String
     public var roomJid: String
     public var name: String
@@ -1695,51 +1645,15 @@ public struct WaddleChannel {
         self.position = position
         self.spaceId = spaceId
     }
+
+
+
+
 }
 
 #if compiler(>=6)
 extension WaddleChannel: Sendable {}
 #endif
-
-
-extension WaddleChannel: Equatable, Hashable {
-    public static func ==(lhs: WaddleChannel, rhs: WaddleChannel) -> Bool {
-        if lhs.id != rhs.id {
-            return false
-        }
-        if lhs.roomJid != rhs.roomJid {
-            return false
-        }
-        if lhs.name != rhs.name {
-            return false
-        }
-        if lhs.description != rhs.description {
-            return false
-        }
-        if lhs.channelType != rhs.channelType {
-            return false
-        }
-        if lhs.position != rhs.position {
-            return false
-        }
-        if lhs.spaceId != rhs.spaceId {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(id)
-        hasher.combine(roomJid)
-        hasher.combine(name)
-        hasher.combine(description)
-        hasher.combine(channelType)
-        hasher.combine(position)
-        hasher.combine(spaceId)
-    }
-}
-
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -1748,12 +1662,12 @@ public struct FfiConverterTypeWaddleChannel: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleChannel {
         return
             try WaddleChannel(
-                id: FfiConverterString.read(from: &buf), 
-                roomJid: FfiConverterString.read(from: &buf), 
-                name: FfiConverterString.read(from: &buf), 
-                description: FfiConverterOptionString.read(from: &buf), 
-                channelType: FfiConverterString.read(from: &buf), 
-                position: FfiConverterInt32.read(from: &buf), 
+                id: FfiConverterString.read(from: &buf),
+                roomJid: FfiConverterString.read(from: &buf),
+                name: FfiConverterString.read(from: &buf),
+                description: FfiConverterOptionString.read(from: &buf),
+                channelType: FfiConverterString.read(from: &buf),
+                position: FfiConverterInt32.read(from: &buf),
                 spaceId: FfiConverterString.read(from: &buf)
         )
     }
@@ -1785,7 +1699,7 @@ public func FfiConverterTypeWaddleChannel_lower(_ value: WaddleChannel) -> RustB
 }
 
 
-public struct WaddleConfig {
+public struct WaddleConfig: Equatable, Hashable {
     public var serverUrl: String
     public var jid: String
     public var accessToken: String
@@ -1799,39 +1713,15 @@ public struct WaddleConfig {
         self.accessToken = accessToken
         self.resource = resource
     }
+
+
+
+
 }
 
 #if compiler(>=6)
 extension WaddleConfig: Sendable {}
 #endif
-
-
-extension WaddleConfig: Equatable, Hashable {
-    public static func ==(lhs: WaddleConfig, rhs: WaddleConfig) -> Bool {
-        if lhs.serverUrl != rhs.serverUrl {
-            return false
-        }
-        if lhs.jid != rhs.jid {
-            return false
-        }
-        if lhs.accessToken != rhs.accessToken {
-            return false
-        }
-        if lhs.resource != rhs.resource {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(serverUrl)
-        hasher.combine(jid)
-        hasher.combine(accessToken)
-        hasher.combine(resource)
-    }
-}
-
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -1840,9 +1730,9 @@ public struct FfiConverterTypeWaddleConfig: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleConfig {
         return
             try WaddleConfig(
-                serverUrl: FfiConverterString.read(from: &buf), 
-                jid: FfiConverterString.read(from: &buf), 
-                accessToken: FfiConverterString.read(from: &buf), 
+                serverUrl: FfiConverterString.read(from: &buf),
+                jid: FfiConverterString.read(from: &buf),
+                accessToken: FfiConverterString.read(from: &buf),
                 resource: FfiConverterString.read(from: &buf)
         )
     }
@@ -1875,7 +1765,7 @@ public func FfiConverterTypeWaddleConfig_lower(_ value: WaddleConfig) -> RustBuf
  * XEP-0448 cipher/key/iv/hashes envelope for encrypted Stateless File
  * Sharing payloads.
  */
-public struct WaddleEncryptedFile {
+public struct WaddleEncryptedFile: Equatable, Hashable {
     /**
      * Cipher URN, e.g. `urn:xmpp:ciphers:aes-256-gcm-nopadding:0`.
      */
@@ -1899,13 +1789,13 @@ public struct WaddleEncryptedFile {
     public init(
         /**
          * Cipher URN, e.g. `urn:xmpp:ciphers:aes-256-gcm-nopadding:0`.
-         */cipher: String, 
+         */cipher: String,
         /**
          * Base64-encoded symmetric key.
-         */keyB64: String, 
+         */keyB64: String,
         /**
          * Base64-encoded initialization vector / nonce.
-         */ivB64: String, hashes: [WaddleEncryptedFileHash], 
+         */ivB64: String, hashes: [WaddleEncryptedFileHash],
         /**
          * Source URLs the ciphertext can be fetched from. Always non-empty.
          */sources: [String]) {
@@ -1915,43 +1805,15 @@ public struct WaddleEncryptedFile {
         self.hashes = hashes
         self.sources = sources
     }
+
+
+
+
 }
 
 #if compiler(>=6)
 extension WaddleEncryptedFile: Sendable {}
 #endif
-
-
-extension WaddleEncryptedFile: Equatable, Hashable {
-    public static func ==(lhs: WaddleEncryptedFile, rhs: WaddleEncryptedFile) -> Bool {
-        if lhs.cipher != rhs.cipher {
-            return false
-        }
-        if lhs.keyB64 != rhs.keyB64 {
-            return false
-        }
-        if lhs.ivB64 != rhs.ivB64 {
-            return false
-        }
-        if lhs.hashes != rhs.hashes {
-            return false
-        }
-        if lhs.sources != rhs.sources {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(cipher)
-        hasher.combine(keyB64)
-        hasher.combine(ivB64)
-        hasher.combine(hashes)
-        hasher.combine(sources)
-    }
-}
-
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -1960,10 +1822,10 @@ public struct FfiConverterTypeWaddleEncryptedFile: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleEncryptedFile {
         return
             try WaddleEncryptedFile(
-                cipher: FfiConverterString.read(from: &buf), 
-                keyB64: FfiConverterString.read(from: &buf), 
-                ivB64: FfiConverterString.read(from: &buf), 
-                hashes: FfiConverterSequenceTypeWaddleEncryptedFileHash.read(from: &buf), 
+                cipher: FfiConverterString.read(from: &buf),
+                keyB64: FfiConverterString.read(from: &buf),
+                ivB64: FfiConverterString.read(from: &buf),
+                hashes: FfiConverterSequenceTypeWaddleEncryptedFileHash.read(from: &buf),
                 sources: FfiConverterSequenceString.read(from: &buf)
         )
     }
@@ -1996,7 +1858,7 @@ public func FfiConverterTypeWaddleEncryptedFile_lower(_ value: WaddleEncryptedFi
 /**
  * XEP-0300 hash entry nested under an `<encrypted/>` envelope.
  */
-public struct WaddleEncryptedFileHash {
+public struct WaddleEncryptedFileHash: Equatable, Hashable {
     public var algo: String
     public var valueB64: String
 
@@ -2006,31 +1868,15 @@ public struct WaddleEncryptedFileHash {
         self.algo = algo
         self.valueB64 = valueB64
     }
+
+
+
+
 }
 
 #if compiler(>=6)
 extension WaddleEncryptedFileHash: Sendable {}
 #endif
-
-
-extension WaddleEncryptedFileHash: Equatable, Hashable {
-    public static func ==(lhs: WaddleEncryptedFileHash, rhs: WaddleEncryptedFileHash) -> Bool {
-        if lhs.algo != rhs.algo {
-            return false
-        }
-        if lhs.valueB64 != rhs.valueB64 {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(algo)
-        hasher.combine(valueB64)
-    }
-}
-
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -2039,7 +1885,7 @@ public struct FfiConverterTypeWaddleEncryptedFileHash: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleEncryptedFileHash {
         return
             try WaddleEncryptedFileHash(
-                algo: FfiConverterString.read(from: &buf), 
+                algo: FfiConverterString.read(from: &buf),
                 valueB64: FfiConverterString.read(from: &buf)
         )
     }
@@ -2070,7 +1916,7 @@ public func FfiConverterTypeWaddleEncryptedFileHash_lower(_ value: WaddleEncrypt
  * XEP-0428 fallback range identifying the quoted-prefix inside the body.
  * Offsets count Unicode scalar values and `end` is exclusive.
  */
-public struct WaddleFallbackRange {
+public struct WaddleFallbackRange: Equatable, Hashable {
     public var start: UInt32
     public var end: UInt32
 
@@ -2080,31 +1926,15 @@ public struct WaddleFallbackRange {
         self.start = start
         self.end = end
     }
+
+
+
+
 }
 
 #if compiler(>=6)
 extension WaddleFallbackRange: Sendable {}
 #endif
-
-
-extension WaddleFallbackRange: Equatable, Hashable {
-    public static func ==(lhs: WaddleFallbackRange, rhs: WaddleFallbackRange) -> Bool {
-        if lhs.start != rhs.start {
-            return false
-        }
-        if lhs.end != rhs.end {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(start)
-        hasher.combine(end)
-    }
-}
-
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -2113,7 +1943,7 @@ public struct FfiConverterTypeWaddleFallbackRange: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleFallbackRange {
         return
             try WaddleFallbackRange(
-                start: FfiConverterUInt32.read(from: &buf), 
+                start: FfiConverterUInt32.read(from: &buf),
                 end: FfiConverterUInt32.read(from: &buf)
         )
     }
@@ -2146,7 +1976,7 @@ public func FfiConverterTypeWaddleFallbackRange_lower(_ value: WaddleFallbackRan
  * session-initiate / session-accept. The Swift app feeds these
  * straight to the LiveKit iOS/macOS SDK.
  */
-public struct WaddleLiveKitJoin {
+public struct WaddleLiveKitJoin: Equatable, Hashable {
     public var url: String
     public var room: String
     public var identity: String
@@ -2160,39 +1990,15 @@ public struct WaddleLiveKitJoin {
         self.identity = identity
         self.token = token
     }
+
+
+
+
 }
 
 #if compiler(>=6)
 extension WaddleLiveKitJoin: Sendable {}
 #endif
-
-
-extension WaddleLiveKitJoin: Equatable, Hashable {
-    public static func ==(lhs: WaddleLiveKitJoin, rhs: WaddleLiveKitJoin) -> Bool {
-        if lhs.url != rhs.url {
-            return false
-        }
-        if lhs.room != rhs.room {
-            return false
-        }
-        if lhs.identity != rhs.identity {
-            return false
-        }
-        if lhs.token != rhs.token {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(url)
-        hasher.combine(room)
-        hasher.combine(identity)
-        hasher.combine(token)
-    }
-}
-
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -2201,9 +2007,9 @@ public struct FfiConverterTypeWaddleLiveKitJoin: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleLiveKitJoin {
         return
             try WaddleLiveKitJoin(
-                url: FfiConverterString.read(from: &buf), 
-                room: FfiConverterString.read(from: &buf), 
-                identity: FfiConverterString.read(from: &buf), 
+                url: FfiConverterString.read(from: &buf),
+                room: FfiConverterString.read(from: &buf),
+                identity: FfiConverterString.read(from: &buf),
                 token: FfiConverterString.read(from: &buf)
         )
     }
@@ -2232,7 +2038,7 @@ public func FfiConverterTypeWaddleLiveKitJoin_lower(_ value: WaddleLiveKitJoin) 
 }
 
 
-public struct WaddleMamPage {
+public struct WaddleMamPage: Equatable, Hashable {
     public var messages: [WaddleArchivedMessage]
     public var firstId: String?
     public var lastId: String?
@@ -2246,39 +2052,15 @@ public struct WaddleMamPage {
         self.lastId = lastId
         self.isComplete = isComplete
     }
+
+
+
+
 }
 
 #if compiler(>=6)
 extension WaddleMamPage: Sendable {}
 #endif
-
-
-extension WaddleMamPage: Equatable, Hashable {
-    public static func ==(lhs: WaddleMamPage, rhs: WaddleMamPage) -> Bool {
-        if lhs.messages != rhs.messages {
-            return false
-        }
-        if lhs.firstId != rhs.firstId {
-            return false
-        }
-        if lhs.lastId != rhs.lastId {
-            return false
-        }
-        if lhs.isComplete != rhs.isComplete {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(messages)
-        hasher.combine(firstId)
-        hasher.combine(lastId)
-        hasher.combine(isComplete)
-    }
-}
-
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -2287,9 +2069,9 @@ public struct FfiConverterTypeWaddleMamPage: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleMamPage {
         return
             try WaddleMamPage(
-                messages: FfiConverterSequenceTypeWaddleArchivedMessage.read(from: &buf), 
-                firstId: FfiConverterOptionString.read(from: &buf), 
-                lastId: FfiConverterOptionString.read(from: &buf), 
+                messages: FfiConverterSequenceTypeWaddleArchivedMessage.read(from: &buf),
+                firstId: FfiConverterOptionString.read(from: &buf),
+                lastId: FfiConverterOptionString.read(from: &buf),
                 isComplete: FfiConverterBool.read(from: &buf)
         )
     }
@@ -2325,7 +2107,7 @@ public func FfiConverterTypeWaddleMamPage_lower(_ value: WaddleMamPage) -> RustB
  * can correlate `chat_id` (PEP item id = bare JID of the chat)
  * with its locally-tracked conversation list directly.
  */
-public struct WaddleMdsDisplayedEntry {
+public struct WaddleMdsDisplayedEntry: Equatable, Hashable {
     /**
      * PEP item id = bare JID of the chat (DM contact or MUC room).
      */
@@ -2345,10 +2127,10 @@ public struct WaddleMdsDisplayedEntry {
     public init(
         /**
          * PEP item id = bare JID of the chat (DM contact or MUC room).
-         */chatId: String, 
+         */chatId: String,
         /**
          * XEP-0359 id of the displayed message.
-         */stanzaId: String, 
+         */stanzaId: String,
         /**
          * JID that injected the stanza-id (the MUC room for group
          * chats; the user's own server for 1:1 chats).
@@ -2357,35 +2139,15 @@ public struct WaddleMdsDisplayedEntry {
         self.stanzaId = stanzaId
         self.stanzaIdBy = stanzaIdBy
     }
+
+
+
+
 }
 
 #if compiler(>=6)
 extension WaddleMdsDisplayedEntry: Sendable {}
 #endif
-
-
-extension WaddleMdsDisplayedEntry: Equatable, Hashable {
-    public static func ==(lhs: WaddleMdsDisplayedEntry, rhs: WaddleMdsDisplayedEntry) -> Bool {
-        if lhs.chatId != rhs.chatId {
-            return false
-        }
-        if lhs.stanzaId != rhs.stanzaId {
-            return false
-        }
-        if lhs.stanzaIdBy != rhs.stanzaIdBy {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(chatId)
-        hasher.combine(stanzaId)
-        hasher.combine(stanzaIdBy)
-    }
-}
-
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -2394,8 +2156,8 @@ public struct FfiConverterTypeWaddleMdsDisplayedEntry: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleMdsDisplayedEntry {
         return
             try WaddleMdsDisplayedEntry(
-                chatId: FfiConverterString.read(from: &buf), 
-                stanzaId: FfiConverterString.read(from: &buf), 
+                chatId: FfiConverterString.read(from: &buf),
+                stanzaId: FfiConverterString.read(from: &buf),
                 stanzaIdBy: FfiConverterString.read(from: &buf)
         )
     }
@@ -2423,7 +2185,7 @@ public func FfiConverterTypeWaddleMdsDisplayedEntry_lower(_ value: WaddleMdsDisp
 }
 
 
-public struct WaddleMessage {
+public struct WaddleMessage: Equatable, Hashable {
     public var id: String?
     public var from: String?
     public var to: String?
@@ -2469,22 +2231,22 @@ public struct WaddleMessage {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(id: String?, from: String?, to: String?, body: String?, messageType: String, timestamp: String?, stanzaId: String?, originId: String?, replacesId: String?, retractsId: String?, reactionTargetId: String?, reactionEmojis: [String], isMuc: Bool, thread: String?, parentThreadId: String?, 
+    public init(id: String?, from: String?, to: String?, body: String?, messageType: String, timestamp: String?, stanzaId: String?, originId: String?, replacesId: String?, retractsId: String?, reactionTargetId: String?, reactionEmojis: [String], isMuc: Bool, thread: String?, parentThreadId: String?,
         /**
          * XEP-0461 reply target message id.
-         */replyToId: String?, 
+         */replyToId: String?,
         /**
          * XEP-0461 reply target author JID (string form).
-         */replyToSender: String?, 
+         */replyToSender: String?,
         /**
          * XEP-0428 fallback range start (char offset, inclusive).
-         */replyFallbackStart: UInt32?, 
+         */replyFallbackStart: UInt32?,
         /**
          * XEP-0428 fallback range end (char offset, exclusive).
-         */replyFallbackEnd: UInt32?, 
+         */replyFallbackEnd: UInt32?,
         /**
          * XEP-0446 / XEP-0447 shared files attached to the message.
-         */sharedFiles: [WaddleSharedFile], 
+         */sharedFiles: [WaddleSharedFile],
         /**
          * XEP-0490 Message Displayed Synchronization PEP event payload.
          * `None` when the message is not an MDS event; `Some(entries)`
@@ -2513,107 +2275,15 @@ public struct WaddleMessage {
         self.sharedFiles = sharedFiles
         self.mdsDisplayed = mdsDisplayed
     }
+
+
+
+
 }
 
 #if compiler(>=6)
 extension WaddleMessage: Sendable {}
 #endif
-
-
-extension WaddleMessage: Equatable, Hashable {
-    public static func ==(lhs: WaddleMessage, rhs: WaddleMessage) -> Bool {
-        if lhs.id != rhs.id {
-            return false
-        }
-        if lhs.from != rhs.from {
-            return false
-        }
-        if lhs.to != rhs.to {
-            return false
-        }
-        if lhs.body != rhs.body {
-            return false
-        }
-        if lhs.messageType != rhs.messageType {
-            return false
-        }
-        if lhs.timestamp != rhs.timestamp {
-            return false
-        }
-        if lhs.stanzaId != rhs.stanzaId {
-            return false
-        }
-        if lhs.originId != rhs.originId {
-            return false
-        }
-        if lhs.replacesId != rhs.replacesId {
-            return false
-        }
-        if lhs.retractsId != rhs.retractsId {
-            return false
-        }
-        if lhs.reactionTargetId != rhs.reactionTargetId {
-            return false
-        }
-        if lhs.reactionEmojis != rhs.reactionEmojis {
-            return false
-        }
-        if lhs.isMuc != rhs.isMuc {
-            return false
-        }
-        if lhs.thread != rhs.thread {
-            return false
-        }
-        if lhs.parentThreadId != rhs.parentThreadId {
-            return false
-        }
-        if lhs.replyToId != rhs.replyToId {
-            return false
-        }
-        if lhs.replyToSender != rhs.replyToSender {
-            return false
-        }
-        if lhs.replyFallbackStart != rhs.replyFallbackStart {
-            return false
-        }
-        if lhs.replyFallbackEnd != rhs.replyFallbackEnd {
-            return false
-        }
-        if lhs.sharedFiles != rhs.sharedFiles {
-            return false
-        }
-        if lhs.mdsDisplayed != rhs.mdsDisplayed {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(id)
-        hasher.combine(from)
-        hasher.combine(to)
-        hasher.combine(body)
-        hasher.combine(messageType)
-        hasher.combine(timestamp)
-        hasher.combine(stanzaId)
-        hasher.combine(originId)
-        hasher.combine(replacesId)
-        hasher.combine(retractsId)
-        hasher.combine(reactionTargetId)
-        hasher.combine(reactionEmojis)
-        hasher.combine(isMuc)
-        hasher.combine(thread)
-        hasher.combine(parentThreadId)
-        hasher.combine(replyToId)
-        hasher.combine(replyToSender)
-        hasher.combine(replyFallbackStart)
-        hasher.combine(replyFallbackEnd)
-        hasher.combine(sharedFiles)
-        hasher.combine(mdsDisplayed)
-    }
-}
-
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -2622,26 +2292,26 @@ public struct FfiConverterTypeWaddleMessage: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleMessage {
         return
             try WaddleMessage(
-                id: FfiConverterOptionString.read(from: &buf), 
-                from: FfiConverterOptionString.read(from: &buf), 
-                to: FfiConverterOptionString.read(from: &buf), 
-                body: FfiConverterOptionString.read(from: &buf), 
-                messageType: FfiConverterString.read(from: &buf), 
-                timestamp: FfiConverterOptionString.read(from: &buf), 
-                stanzaId: FfiConverterOptionString.read(from: &buf), 
-                originId: FfiConverterOptionString.read(from: &buf), 
-                replacesId: FfiConverterOptionString.read(from: &buf), 
-                retractsId: FfiConverterOptionString.read(from: &buf), 
-                reactionTargetId: FfiConverterOptionString.read(from: &buf), 
-                reactionEmojis: FfiConverterSequenceString.read(from: &buf), 
-                isMuc: FfiConverterBool.read(from: &buf), 
-                thread: FfiConverterOptionString.read(from: &buf), 
-                parentThreadId: FfiConverterOptionString.read(from: &buf), 
-                replyToId: FfiConverterOptionString.read(from: &buf), 
-                replyToSender: FfiConverterOptionString.read(from: &buf), 
-                replyFallbackStart: FfiConverterOptionUInt32.read(from: &buf), 
-                replyFallbackEnd: FfiConverterOptionUInt32.read(from: &buf), 
-                sharedFiles: FfiConverterSequenceTypeWaddleSharedFile.read(from: &buf), 
+                id: FfiConverterOptionString.read(from: &buf),
+                from: FfiConverterOptionString.read(from: &buf),
+                to: FfiConverterOptionString.read(from: &buf),
+                body: FfiConverterOptionString.read(from: &buf),
+                messageType: FfiConverterString.read(from: &buf),
+                timestamp: FfiConverterOptionString.read(from: &buf),
+                stanzaId: FfiConverterOptionString.read(from: &buf),
+                originId: FfiConverterOptionString.read(from: &buf),
+                replacesId: FfiConverterOptionString.read(from: &buf),
+                retractsId: FfiConverterOptionString.read(from: &buf),
+                reactionTargetId: FfiConverterOptionString.read(from: &buf),
+                reactionEmojis: FfiConverterSequenceString.read(from: &buf),
+                isMuc: FfiConverterBool.read(from: &buf),
+                thread: FfiConverterOptionString.read(from: &buf),
+                parentThreadId: FfiConverterOptionString.read(from: &buf),
+                replyToId: FfiConverterOptionString.read(from: &buf),
+                replyToSender: FfiConverterOptionString.read(from: &buf),
+                replyFallbackStart: FfiConverterOptionUInt32.read(from: &buf),
+                replyFallbackEnd: FfiConverterOptionUInt32.read(from: &buf),
+                sharedFiles: FfiConverterSequenceTypeWaddleSharedFile.read(from: &buf),
                 mdsDisplayed: FfiConverterOptionSequenceTypeWaddleMdsDisplayedEntry.read(from: &buf)
         )
     }
@@ -2688,70 +2358,62 @@ public func FfiConverterTypeWaddleMessage_lower(_ value: WaddleMessage) -> RustB
 
 
 /**
- * Typed payload of the `urn:waddle:muc-call:0` MUC presence
- * extension.
+ * Typed payload of the `urn:xmpp:jingle:muji:0` MUC presence
+ * extension (XEP-0272).
  */
-public struct WaddleMucCallPresence {
-    public var state: WaddleMucCallPresenceState
+public struct WaddleMujiPresence: Equatable, Hashable {
     /**
-     * `call-id` attribute from the wire — the room JID the
-     * presence describes (mirrors the source value verbatim so
-     * Swift consumers can match against their own room registry).
+     * True when the presence carried a `<preparing/>` child
+     * (XEP-0272 §Joining two-phase flow). UIs typically don't
+     * surface a chip until contents are advertised.
      */
-    public var callId: String
+    public var preparing: Bool
+    /**
+     * True when the presence advertised at least one `<content/>`
+     * child — the occupant is actively participating in the call.
+     */
+    public var active: Bool
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(state: WaddleMucCallPresenceState, 
+    public init(
         /**
-         * `call-id` attribute from the wire — the room JID the
-         * presence describes (mirrors the source value verbatim so
-         * Swift consumers can match against their own room registry).
-         */callId: String) {
-        self.state = state
-        self.callId = callId
+         * True when the presence carried a `<preparing/>` child
+         * (XEP-0272 §Joining two-phase flow). UIs typically don't
+         * surface a chip until contents are advertised.
+         */preparing: Bool,
+        /**
+         * True when the presence advertised at least one `<content/>`
+         * child — the occupant is actively participating in the call.
+         */active: Bool) {
+        self.preparing = preparing
+        self.active = active
     }
+
+
+
+
 }
 
 #if compiler(>=6)
-extension WaddleMucCallPresence: Sendable {}
+extension WaddleMujiPresence: Sendable {}
 #endif
-
-
-extension WaddleMucCallPresence: Equatable, Hashable {
-    public static func ==(lhs: WaddleMucCallPresence, rhs: WaddleMucCallPresence) -> Bool {
-        if lhs.state != rhs.state {
-            return false
-        }
-        if lhs.callId != rhs.callId {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(state)
-        hasher.combine(callId)
-    }
-}
-
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-public struct FfiConverterTypeWaddleMucCallPresence: FfiConverterRustBuffer {
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleMucCallPresence {
+public struct FfiConverterTypeWaddleMujiPresence: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleMujiPresence {
         return
-            try WaddleMucCallPresence(
-                state: FfiConverterTypeWaddleMucCallPresenceState.read(from: &buf), 
-                callId: FfiConverterString.read(from: &buf)
+            try WaddleMujiPresence(
+                preparing: FfiConverterBool.read(from: &buf),
+                active: FfiConverterBool.read(from: &buf)
         )
     }
 
-    public static func write(_ value: WaddleMucCallPresence, into buf: inout [UInt8]) {
-        FfiConverterTypeWaddleMucCallPresenceState.write(value.state, into: &buf)
-        FfiConverterString.write(value.callId, into: &buf)
+    public static func write(_ value: WaddleMujiPresence, into buf: inout [UInt8]) {
+        FfiConverterBool.write(value.preparing, into: &buf)
+        FfiConverterBool.write(value.active, into: &buf)
     }
 }
 
@@ -2759,19 +2421,19 @@ public struct FfiConverterTypeWaddleMucCallPresence: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-public func FfiConverterTypeWaddleMucCallPresence_lift(_ buf: RustBuffer) throws -> WaddleMucCallPresence {
-    return try FfiConverterTypeWaddleMucCallPresence.lift(buf)
+public func FfiConverterTypeWaddleMujiPresence_lift(_ buf: RustBuffer) throws -> WaddleMujiPresence {
+    return try FfiConverterTypeWaddleMujiPresence.lift(buf)
 }
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-public func FfiConverterTypeWaddleMucCallPresence_lower(_ value: WaddleMucCallPresence) -> RustBuffer {
-    return FfiConverterTypeWaddleMucCallPresence.lower(value)
+public func FfiConverterTypeWaddleMujiPresence_lower(_ value: WaddleMujiPresence) -> RustBuffer {
+    return FfiConverterTypeWaddleMujiPresence.lower(value)
 }
 
 
-public struct WaddlePresence {
+public struct WaddlePresence: Equatable, Hashable {
     public var from: String?
     public var to: String?
     public var presenceType: String
@@ -2781,26 +2443,26 @@ public struct WaddlePresence {
     public var mucAffiliation: WaddleMucAffiliation?
     public var mucRole: WaddleMucRole?
     /**
-     * Waddle-specific MUC presence extension
-     * `<call xmlns='urn:waddle:muc-call:0' state='…' call-id='…'/>`
-     * advertising that the occupant has joined / left the room's
-     * group call. `None` when the presence carries no `<call/>`
-     * child. Drives the chat-side "N in call" indicator and the
-     * per-tile call badge.
+     * XEP-0272 Muji presence advertisement
+     * `<muji xmlns='urn:xmpp:jingle:muji:0'/>` indicating the
+     * occupant has joined the room's group call. `None` when the
+     * presence carries no `<muji/>` child — per XEP-0272 §Leaving,
+     * that absence IS the leave marker. Drives the chat-side
+     * "N in call" indicator and the per-tile call badge.
      */
-    public var mucCall: WaddleMucCallPresence?
+    public var muji: WaddleMujiPresence?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(from: String?, to: String?, presenceType: String, show: String?, status: String?, hats: [WaddlePresenceHat], mucAffiliation: WaddleMucAffiliation?, mucRole: WaddleMucRole?, 
+    public init(from: String?, to: String?, presenceType: String, show: String?, status: String?, hats: [WaddlePresenceHat], mucAffiliation: WaddleMucAffiliation?, mucRole: WaddleMucRole?,
         /**
-         * Waddle-specific MUC presence extension
-         * `<call xmlns='urn:waddle:muc-call:0' state='…' call-id='…'/>`
-         * advertising that the occupant has joined / left the room's
-         * group call. `None` when the presence carries no `<call/>`
-         * child. Drives the chat-side "N in call" indicator and the
-         * per-tile call badge.
-         */mucCall: WaddleMucCallPresence?) {
+         * XEP-0272 Muji presence advertisement
+         * `<muji xmlns='urn:xmpp:jingle:muji:0'/>` indicating the
+         * occupant has joined the room's group call. `None` when the
+         * presence carries no `<muji/>` child — per XEP-0272 §Leaving,
+         * that absence IS the leave marker. Drives the chat-side
+         * "N in call" indicator and the per-tile call badge.
+         */muji: WaddleMujiPresence?) {
         self.from = from
         self.to = to
         self.presenceType = presenceType
@@ -2809,61 +2471,17 @@ public struct WaddlePresence {
         self.hats = hats
         self.mucAffiliation = mucAffiliation
         self.mucRole = mucRole
-        self.mucCall = mucCall
+        self.muji = muji
     }
+
+
+
+
 }
 
 #if compiler(>=6)
 extension WaddlePresence: Sendable {}
 #endif
-
-
-extension WaddlePresence: Equatable, Hashable {
-    public static func ==(lhs: WaddlePresence, rhs: WaddlePresence) -> Bool {
-        if lhs.from != rhs.from {
-            return false
-        }
-        if lhs.to != rhs.to {
-            return false
-        }
-        if lhs.presenceType != rhs.presenceType {
-            return false
-        }
-        if lhs.show != rhs.show {
-            return false
-        }
-        if lhs.status != rhs.status {
-            return false
-        }
-        if lhs.hats != rhs.hats {
-            return false
-        }
-        if lhs.mucAffiliation != rhs.mucAffiliation {
-            return false
-        }
-        if lhs.mucRole != rhs.mucRole {
-            return false
-        }
-        if lhs.mucCall != rhs.mucCall {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(from)
-        hasher.combine(to)
-        hasher.combine(presenceType)
-        hasher.combine(show)
-        hasher.combine(status)
-        hasher.combine(hats)
-        hasher.combine(mucAffiliation)
-        hasher.combine(mucRole)
-        hasher.combine(mucCall)
-    }
-}
-
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -2872,15 +2490,15 @@ public struct FfiConverterTypeWaddlePresence: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddlePresence {
         return
             try WaddlePresence(
-                from: FfiConverterOptionString.read(from: &buf), 
-                to: FfiConverterOptionString.read(from: &buf), 
-                presenceType: FfiConverterString.read(from: &buf), 
-                show: FfiConverterOptionString.read(from: &buf), 
-                status: FfiConverterOptionString.read(from: &buf), 
-                hats: FfiConverterSequenceTypeWaddlePresenceHat.read(from: &buf), 
-                mucAffiliation: FfiConverterOptionTypeWaddleMucAffiliation.read(from: &buf), 
-                mucRole: FfiConverterOptionTypeWaddleMucRole.read(from: &buf), 
-                mucCall: FfiConverterOptionTypeWaddleMucCallPresence.read(from: &buf)
+                from: FfiConverterOptionString.read(from: &buf),
+                to: FfiConverterOptionString.read(from: &buf),
+                presenceType: FfiConverterString.read(from: &buf),
+                show: FfiConverterOptionString.read(from: &buf),
+                status: FfiConverterOptionString.read(from: &buf),
+                hats: FfiConverterSequenceTypeWaddlePresenceHat.read(from: &buf),
+                mucAffiliation: FfiConverterOptionTypeWaddleMucAffiliation.read(from: &buf),
+                mucRole: FfiConverterOptionTypeWaddleMucRole.read(from: &buf),
+                muji: FfiConverterOptionTypeWaddleMujiPresence.read(from: &buf)
         )
     }
 
@@ -2893,7 +2511,7 @@ public struct FfiConverterTypeWaddlePresence: FfiConverterRustBuffer {
         FfiConverterSequenceTypeWaddlePresenceHat.write(value.hats, into: &buf)
         FfiConverterOptionTypeWaddleMucAffiliation.write(value.mucAffiliation, into: &buf)
         FfiConverterOptionTypeWaddleMucRole.write(value.mucRole, into: &buf)
-        FfiConverterOptionTypeWaddleMucCallPresence.write(value.mucCall, into: &buf)
+        FfiConverterOptionTypeWaddleMujiPresence.write(value.muji, into: &buf)
     }
 }
 
@@ -2913,7 +2531,7 @@ public func FfiConverterTypeWaddlePresence_lower(_ value: WaddlePresence) -> Rus
 }
 
 
-public struct WaddlePresenceHat {
+public struct WaddlePresenceHat: Equatable, Hashable {
     public var uri: String
     public var title: String
 
@@ -2923,31 +2541,15 @@ public struct WaddlePresenceHat {
         self.uri = uri
         self.title = title
     }
+
+
+
+
 }
 
 #if compiler(>=6)
 extension WaddlePresenceHat: Sendable {}
 #endif
-
-
-extension WaddlePresenceHat: Equatable, Hashable {
-    public static func ==(lhs: WaddlePresenceHat, rhs: WaddlePresenceHat) -> Bool {
-        if lhs.uri != rhs.uri {
-            return false
-        }
-        if lhs.title != rhs.title {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(uri)
-        hasher.combine(title)
-    }
-}
-
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -2956,7 +2558,7 @@ public struct FfiConverterTypeWaddlePresenceHat: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddlePresenceHat {
         return
             try WaddlePresenceHat(
-                uri: FfiConverterString.read(from: &buf), 
+                uri: FfiConverterString.read(from: &buf),
                 title: FfiConverterString.read(from: &buf)
         )
     }
@@ -2986,7 +2588,7 @@ public func FfiConverterTypeWaddlePresenceHat_lower(_ value: WaddlePresenceHat) 
 /**
  * XEP-0461 reply target attached to an outbound message.
  */
-public struct WaddleReplyTarget {
+public struct WaddleReplyTarget: Equatable, Hashable {
     /**
      * JID (string form) of the author of the message being replied to.
      * For MUC this is the occupant full JID; for 1:1 the bare JID.
@@ -3003,38 +2605,22 @@ public struct WaddleReplyTarget {
         /**
          * JID (string form) of the author of the message being replied to.
          * For MUC this is the occupant full JID; for 1:1 the bare JID.
-         */authorJid: String, 
+         */authorJid: String,
         /**
          * Id of the message being replied to.
          */messageId: String) {
         self.authorJid = authorJid
         self.messageId = messageId
     }
+
+
+
+
 }
 
 #if compiler(>=6)
 extension WaddleReplyTarget: Sendable {}
 #endif
-
-
-extension WaddleReplyTarget: Equatable, Hashable {
-    public static func ==(lhs: WaddleReplyTarget, rhs: WaddleReplyTarget) -> Bool {
-        if lhs.authorJid != rhs.authorJid {
-            return false
-        }
-        if lhs.messageId != rhs.messageId {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(authorJid)
-        hasher.combine(messageId)
-    }
-}
-
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -3043,7 +2629,7 @@ public struct FfiConverterTypeWaddleReplyTarget: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleReplyTarget {
         return
             try WaddleReplyTarget(
-                authorJid: FfiConverterString.read(from: &buf), 
+                authorJid: FfiConverterString.read(from: &buf),
                 messageId: FfiConverterString.read(from: &buf)
         )
     }
@@ -3073,7 +2659,7 @@ public func FfiConverterTypeWaddleReplyTarget_lower(_ value: WaddleReplyTarget) 
 /**
  * Options bag attached to an outbound chat or groupchat send.
  */
-public struct WaddleSendOptions {
+public struct WaddleSendOptions: Equatable, Hashable {
     public var stanzaId: String?
     public var reply: WaddleReplyTarget?
     public var fallback: WaddleFallbackRange?
@@ -3089,43 +2675,15 @@ public struct WaddleSendOptions {
         self.thread = thread
         self.sharedFiles = sharedFiles
     }
+
+
+
+
 }
 
 #if compiler(>=6)
 extension WaddleSendOptions: Sendable {}
 #endif
-
-
-extension WaddleSendOptions: Equatable, Hashable {
-    public static func ==(lhs: WaddleSendOptions, rhs: WaddleSendOptions) -> Bool {
-        if lhs.stanzaId != rhs.stanzaId {
-            return false
-        }
-        if lhs.reply != rhs.reply {
-            return false
-        }
-        if lhs.fallback != rhs.fallback {
-            return false
-        }
-        if lhs.thread != rhs.thread {
-            return false
-        }
-        if lhs.sharedFiles != rhs.sharedFiles {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(stanzaId)
-        hasher.combine(reply)
-        hasher.combine(fallback)
-        hasher.combine(thread)
-        hasher.combine(sharedFiles)
-    }
-}
-
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -3134,10 +2692,10 @@ public struct FfiConverterTypeWaddleSendOptions: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleSendOptions {
         return
             try WaddleSendOptions(
-                stanzaId: FfiConverterOptionString.read(from: &buf), 
-                reply: FfiConverterOptionTypeWaddleReplyTarget.read(from: &buf), 
-                fallback: FfiConverterOptionTypeWaddleFallbackRange.read(from: &buf), 
-                thread: FfiConverterOptionTypeWaddleThreadTarget.read(from: &buf), 
+                stanzaId: FfiConverterOptionString.read(from: &buf),
+                reply: FfiConverterOptionTypeWaddleReplyTarget.read(from: &buf),
+                fallback: FfiConverterOptionTypeWaddleFallbackRange.read(from: &buf),
+                thread: FfiConverterOptionTypeWaddleThreadTarget.read(from: &buf),
                 sharedFiles: FfiConverterSequenceTypeWaddleSharedFile.read(from: &buf)
         )
     }
@@ -3170,7 +2728,7 @@ public func FfiConverterTypeWaddleSendOptions_lower(_ value: WaddleSendOptions) 
 /**
  * XEP-0446 / XEP-0447 shared-file metadata exposed to Swift.
  */
-public struct WaddleSharedFile {
+public struct WaddleSharedFile: Equatable, Hashable {
     public var url: String
     public var name: String?
     public var mediaType: String?
@@ -3187,7 +2745,7 @@ public struct WaddleSharedFile {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(url: String, name: String?, mediaType: String?, size: UInt64?, width: UInt32?, height: UInt32?, disposition: String, 
+    public init(url: String, name: String?, mediaType: String?, size: UInt64?, width: UInt32?, height: UInt32?, disposition: String,
         /**
          * XEP-0448 envelope when the bytes at `url` are ciphertext rather than
          * the plaintext file. Recipients MUST use these values to decrypt before
@@ -3202,55 +2760,15 @@ public struct WaddleSharedFile {
         self.disposition = disposition
         self.encrypted = encrypted
     }
+
+
+
+
 }
 
 #if compiler(>=6)
 extension WaddleSharedFile: Sendable {}
 #endif
-
-
-extension WaddleSharedFile: Equatable, Hashable {
-    public static func ==(lhs: WaddleSharedFile, rhs: WaddleSharedFile) -> Bool {
-        if lhs.url != rhs.url {
-            return false
-        }
-        if lhs.name != rhs.name {
-            return false
-        }
-        if lhs.mediaType != rhs.mediaType {
-            return false
-        }
-        if lhs.size != rhs.size {
-            return false
-        }
-        if lhs.width != rhs.width {
-            return false
-        }
-        if lhs.height != rhs.height {
-            return false
-        }
-        if lhs.disposition != rhs.disposition {
-            return false
-        }
-        if lhs.encrypted != rhs.encrypted {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(url)
-        hasher.combine(name)
-        hasher.combine(mediaType)
-        hasher.combine(size)
-        hasher.combine(width)
-        hasher.combine(height)
-        hasher.combine(disposition)
-        hasher.combine(encrypted)
-    }
-}
-
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -3259,13 +2777,13 @@ public struct FfiConverterTypeWaddleSharedFile: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleSharedFile {
         return
             try WaddleSharedFile(
-                url: FfiConverterString.read(from: &buf), 
-                name: FfiConverterOptionString.read(from: &buf), 
-                mediaType: FfiConverterOptionString.read(from: &buf), 
-                size: FfiConverterOptionUInt64.read(from: &buf), 
-                width: FfiConverterOptionUInt32.read(from: &buf), 
-                height: FfiConverterOptionUInt32.read(from: &buf), 
-                disposition: FfiConverterString.read(from: &buf), 
+                url: FfiConverterString.read(from: &buf),
+                name: FfiConverterOptionString.read(from: &buf),
+                mediaType: FfiConverterOptionString.read(from: &buf),
+                size: FfiConverterOptionUInt64.read(from: &buf),
+                width: FfiConverterOptionUInt32.read(from: &buf),
+                height: FfiConverterOptionUInt32.read(from: &buf),
+                disposition: FfiConverterString.read(from: &buf),
                 encrypted: FfiConverterOptionTypeWaddleEncryptedFile.read(from: &buf)
         )
     }
@@ -3298,7 +2816,7 @@ public func FfiConverterTypeWaddleSharedFile_lower(_ value: WaddleSharedFile) ->
 }
 
 
-public struct WaddleSpace {
+public struct WaddleSpace: Equatable, Hashable {
     public var id: String
     public var serviceJid: String
     public var name: String
@@ -3312,39 +2830,15 @@ public struct WaddleSpace {
         self.name = name
         self.description = description
     }
+
+
+
+
 }
 
 #if compiler(>=6)
 extension WaddleSpace: Sendable {}
 #endif
-
-
-extension WaddleSpace: Equatable, Hashable {
-    public static func ==(lhs: WaddleSpace, rhs: WaddleSpace) -> Bool {
-        if lhs.id != rhs.id {
-            return false
-        }
-        if lhs.serviceJid != rhs.serviceJid {
-            return false
-        }
-        if lhs.name != rhs.name {
-            return false
-        }
-        if lhs.description != rhs.description {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(id)
-        hasher.combine(serviceJid)
-        hasher.combine(name)
-        hasher.combine(description)
-    }
-}
-
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -3353,9 +2847,9 @@ public struct FfiConverterTypeWaddleSpace: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleSpace {
         return
             try WaddleSpace(
-                id: FfiConverterString.read(from: &buf), 
-                serviceJid: FfiConverterString.read(from: &buf), 
-                name: FfiConverterString.read(from: &buf), 
+                id: FfiConverterString.read(from: &buf),
+                serviceJid: FfiConverterString.read(from: &buf),
+                name: FfiConverterString.read(from: &buf),
                 description: FfiConverterOptionString.read(from: &buf)
         )
     }
@@ -3387,7 +2881,7 @@ public func FfiConverterTypeWaddleSpace_lower(_ value: WaddleSpace) -> RustBuffe
 /**
  * XEP-0201 thread reference with optional parent for nested threads.
  */
-public struct WaddleThreadTarget {
+public struct WaddleThreadTarget: Equatable, Hashable {
     public var id: String
     public var parent: String?
 
@@ -3397,31 +2891,15 @@ public struct WaddleThreadTarget {
         self.id = id
         self.parent = parent
     }
+
+
+
+
 }
 
 #if compiler(>=6)
 extension WaddleThreadTarget: Sendable {}
 #endif
-
-
-extension WaddleThreadTarget: Equatable, Hashable {
-    public static func ==(lhs: WaddleThreadTarget, rhs: WaddleThreadTarget) -> Bool {
-        if lhs.id != rhs.id {
-            return false
-        }
-        if lhs.parent != rhs.parent {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(id)
-        hasher.combine(parent)
-    }
-}
-
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -3430,7 +2908,7 @@ public struct FfiConverterTypeWaddleThreadTarget: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleThreadTarget {
         return
             try WaddleThreadTarget(
-                id: FfiConverterString.read(from: &buf), 
+                id: FfiConverterString.read(from: &buf),
                 parent: FfiConverterOptionString.read(from: &buf)
         )
     }
@@ -3457,7 +2935,7 @@ public func FfiConverterTypeWaddleThreadTarget_lower(_ value: WaddleThreadTarget
 }
 
 
-public struct WaddleTopology {
+public struct WaddleTopology: Equatable, Hashable {
     public var spaces: [WaddleSpace]
     public var channels: [WaddleChannel]
 
@@ -3467,31 +2945,15 @@ public struct WaddleTopology {
         self.spaces = spaces
         self.channels = channels
     }
+
+
+
+
 }
 
 #if compiler(>=6)
 extension WaddleTopology: Sendable {}
 #endif
-
-
-extension WaddleTopology: Equatable, Hashable {
-    public static func ==(lhs: WaddleTopology, rhs: WaddleTopology) -> Bool {
-        if lhs.spaces != rhs.spaces {
-            return false
-        }
-        if lhs.channels != rhs.channels {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(spaces)
-        hasher.combine(channels)
-    }
-}
-
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -3500,7 +2962,7 @@ public struct FfiConverterTypeWaddleTopology: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleTopology {
         return
             try WaddleTopology(
-                spaces: FfiConverterSequenceTypeWaddleSpace.read(from: &buf), 
+                spaces: FfiConverterSequenceTypeWaddleSpace.read(from: &buf),
                 channels: FfiConverterSequenceTypeWaddleChannel.read(from: &buf)
         )
     }
@@ -3530,7 +2992,7 @@ public func FfiConverterTypeWaddleTopology_lower(_ value: WaddleTopology) -> Rus
 /**
  * Header the client must include when uploading to a XEP-0363 slot.
  */
-public struct WaddleUploadHeader {
+public struct WaddleUploadHeader: Equatable, Hashable {
     public var name: String
     public var value: String
 
@@ -3540,31 +3002,15 @@ public struct WaddleUploadHeader {
         self.name = name
         self.value = value
     }
+
+
+
+
 }
 
 #if compiler(>=6)
 extension WaddleUploadHeader: Sendable {}
 #endif
-
-
-extension WaddleUploadHeader: Equatable, Hashable {
-    public static func ==(lhs: WaddleUploadHeader, rhs: WaddleUploadHeader) -> Bool {
-        if lhs.name != rhs.name {
-            return false
-        }
-        if lhs.value != rhs.value {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(name)
-        hasher.combine(value)
-    }
-}
-
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -3573,7 +3019,7 @@ public struct FfiConverterTypeWaddleUploadHeader: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleUploadHeader {
         return
             try WaddleUploadHeader(
-                name: FfiConverterString.read(from: &buf), 
+                name: FfiConverterString.read(from: &buf),
                 value: FfiConverterString.read(from: &buf)
         )
     }
@@ -3603,7 +3049,7 @@ public func FfiConverterTypeWaddleUploadHeader_lower(_ value: WaddleUploadHeader
 /**
  * XEP-0363 upload slot with PUT/GET URLs and required PUT headers.
  */
-public struct WaddleUploadSlot {
+public struct WaddleUploadSlot: Equatable, Hashable {
     public var putUrl: String
     public var getUrl: String
     public var putHeaders: [WaddleUploadHeader]
@@ -3615,35 +3061,15 @@ public struct WaddleUploadSlot {
         self.getUrl = getUrl
         self.putHeaders = putHeaders
     }
+
+
+
+
 }
 
 #if compiler(>=6)
 extension WaddleUploadSlot: Sendable {}
 #endif
-
-
-extension WaddleUploadSlot: Equatable, Hashable {
-    public static func ==(lhs: WaddleUploadSlot, rhs: WaddleUploadSlot) -> Bool {
-        if lhs.putUrl != rhs.putUrl {
-            return false
-        }
-        if lhs.getUrl != rhs.getUrl {
-            return false
-        }
-        if lhs.putHeaders != rhs.putHeaders {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(putUrl)
-        hasher.combine(getUrl)
-        hasher.combine(putHeaders)
-    }
-}
-
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -3652,8 +3078,8 @@ public struct FfiConverterTypeWaddleUploadSlot: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleUploadSlot {
         return
             try WaddleUploadSlot(
-                putUrl: FfiConverterString.read(from: &buf), 
-                getUrl: FfiConverterString.read(from: &buf), 
+                putUrl: FfiConverterString.read(from: &buf),
+                getUrl: FfiConverterString.read(from: &buf),
                 putHeaders: FfiConverterSequenceTypeWaddleUploadHeader.read(from: &buf)
         )
     }
@@ -3689,8 +3115,8 @@ public func FfiConverterTypeWaddleUploadSlot_lower(_ value: WaddleUploadSlot) ->
  * per variant).
  */
 
-public enum WaddleCallEventKind {
-    
+public enum WaddleCallEventKind: Equatable, Hashable {
+
     /**
      * XEP-0353 §5.1.1 `<propose/>` — the ringing UI start signal.
      */
@@ -3703,15 +3129,19 @@ public enum WaddleCallEventKind {
     /**
      * XEP-0353 §5.1.3 `<reject/>` — peer declined the call.
      */
-    case reject
+    case reject(reason: WaddleJingleReason?, tieBreak: Bool
+    )
     /**
      * XEP-0353 §5.1.4 `<retract/>` — caller cancelled before answer.
      */
-    case retract
+    case retract(reason: WaddleJingleReason?, tieBreak: Bool
+    )
     /**
-     * `<finish/>` Waddle extension — call ended cleanly.
+     * XEP-0353 `<finish/>` — call ended cleanly, or migrated to a
+     * replacement session in the existing-session tie-break case.
      */
-    case finish
+    case finish(reason: WaddleJingleReason?, migratedTo: String?
+    )
     /**
      * XEP-0166 §6.4 `session-initiate` with a populated LiveKit
      * transport. The Swift app uses `join` to connect to the room.
@@ -3734,8 +3164,12 @@ public enum WaddleCallEventKind {
      */
     case sessionTerminate(reason: WaddleJingleReason?
     )
-}
 
+
+
+
+
+}
 
 #if compiler(>=6)
 extension WaddleCallEventKind: Sendable {}
@@ -3750,72 +3184,81 @@ public struct FfiConverterTypeWaddleCallEventKind: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleCallEventKind {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
+
         case 1: return .propose(media: try FfiConverterTypeWaddleCallMedia.read(from: &buf)
         )
-        
+
         case 2: return .proceed
-        
-        case 3: return .reject
-        
-        case 4: return .retract
-        
-        case 5: return .finish
-        
+
+        case 3: return .reject(reason: try FfiConverterOptionTypeWaddleJingleReason.read(from: &buf), tieBreak: try FfiConverterBool.read(from: &buf)
+        )
+
+        case 4: return .retract(reason: try FfiConverterOptionTypeWaddleJingleReason.read(from: &buf), tieBreak: try FfiConverterBool.read(from: &buf)
+        )
+
+        case 5: return .finish(reason: try FfiConverterOptionTypeWaddleJingleReason.read(from: &buf), migratedTo: try FfiConverterOptionString.read(from: &buf)
+        )
+
         case 6: return .sessionInitiate(join: try FfiConverterTypeWaddleLiveKitJoin.read(from: &buf), media: try FfiConverterTypeWaddleCallMedia.read(from: &buf)
         )
-        
+
         case 7: return .sessionAccept(join: try FfiConverterTypeWaddleLiveKitJoin.read(from: &buf), media: try FfiConverterTypeWaddleCallMedia.read(from: &buf)
         )
-        
+
         case 8: return .sessionTerminate(reason: try FfiConverterOptionTypeWaddleJingleReason.read(from: &buf)
         )
-        
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: WaddleCallEventKind, into buf: inout [UInt8]) {
         switch value {
-        
-        
+
+
         case let .propose(media):
             writeInt(&buf, Int32(1))
             FfiConverterTypeWaddleCallMedia.write(media, into: &buf)
-            
-        
+
+
         case .proceed:
             writeInt(&buf, Int32(2))
-        
-        
-        case .reject:
+
+
+        case let .reject(reason,tieBreak):
             writeInt(&buf, Int32(3))
-        
-        
-        case .retract:
+            FfiConverterOptionTypeWaddleJingleReason.write(reason, into: &buf)
+            FfiConverterBool.write(tieBreak, into: &buf)
+
+
+        case let .retract(reason,tieBreak):
             writeInt(&buf, Int32(4))
-        
-        
-        case .finish:
+            FfiConverterOptionTypeWaddleJingleReason.write(reason, into: &buf)
+            FfiConverterBool.write(tieBreak, into: &buf)
+
+
+        case let .finish(reason,migratedTo):
             writeInt(&buf, Int32(5))
-        
-        
+            FfiConverterOptionTypeWaddleJingleReason.write(reason, into: &buf)
+            FfiConverterOptionString.write(migratedTo, into: &buf)
+
+
         case let .sessionInitiate(join,media):
             writeInt(&buf, Int32(6))
             FfiConverterTypeWaddleLiveKitJoin.write(join, into: &buf)
             FfiConverterTypeWaddleCallMedia.write(media, into: &buf)
-            
-        
+
+
         case let .sessionAccept(join,media):
             writeInt(&buf, Int32(7))
             FfiConverterTypeWaddleLiveKitJoin.write(join, into: &buf)
             FfiConverterTypeWaddleCallMedia.write(media, into: &buf)
-            
-        
+
+
         case let .sessionTerminate(reason):
             writeInt(&buf, Int32(8))
             FfiConverterOptionTypeWaddleJingleReason.write(reason, into: &buf)
-            
+
         }
     }
 }
@@ -3836,13 +3279,6 @@ public func FfiConverterTypeWaddleCallEventKind_lower(_ value: WaddleCallEventKi
 }
 
 
-extension WaddleCallEventKind: Equatable, Hashable {}
-
-
-
-
-
-
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 /**
@@ -3853,8 +3289,8 @@ extension WaddleCallEventKind: Equatable, Hashable {}
  * the wire value resolves to one of these variants.
  */
 
-public enum WaddleJingleReason {
-    
+public enum WaddleJingleReason: Equatable, Hashable {
+
     case alternativeSession
     case busy
     case cancel
@@ -3872,8 +3308,12 @@ public enum WaddleJingleReason {
     case timeout
     case unsupportedApplications
     case unsupportedTransports
-}
 
+
+
+
+
+}
 
 #if compiler(>=6)
 extension WaddleJingleReason: Sendable {}
@@ -3888,116 +3328,116 @@ public struct FfiConverterTypeWaddleJingleReason: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleJingleReason {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
+
         case 1: return .alternativeSession
-        
+
         case 2: return .busy
-        
+
         case 3: return .cancel
-        
+
         case 4: return .connectivityError
-        
+
         case 5: return .decline
-        
+
         case 6: return .expired
-        
+
         case 7: return .failedApplication
-        
+
         case 8: return .failedTransport
-        
+
         case 9: return .generalError
-        
+
         case 10: return .gone
-        
+
         case 11: return .incompatibleParameters
-        
+
         case 12: return .mediaError
-        
+
         case 13: return .securityError
-        
+
         case 14: return .success
-        
+
         case 15: return .timeout
-        
+
         case 16: return .unsupportedApplications
-        
+
         case 17: return .unsupportedTransports
-        
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: WaddleJingleReason, into buf: inout [UInt8]) {
         switch value {
-        
-        
+
+
         case .alternativeSession:
             writeInt(&buf, Int32(1))
-        
-        
+
+
         case .busy:
             writeInt(&buf, Int32(2))
-        
-        
+
+
         case .cancel:
             writeInt(&buf, Int32(3))
-        
-        
+
+
         case .connectivityError:
             writeInt(&buf, Int32(4))
-        
-        
+
+
         case .decline:
             writeInt(&buf, Int32(5))
-        
-        
+
+
         case .expired:
             writeInt(&buf, Int32(6))
-        
-        
+
+
         case .failedApplication:
             writeInt(&buf, Int32(7))
-        
-        
+
+
         case .failedTransport:
             writeInt(&buf, Int32(8))
-        
-        
+
+
         case .generalError:
             writeInt(&buf, Int32(9))
-        
-        
+
+
         case .gone:
             writeInt(&buf, Int32(10))
-        
-        
+
+
         case .incompatibleParameters:
             writeInt(&buf, Int32(11))
-        
-        
+
+
         case .mediaError:
             writeInt(&buf, Int32(12))
-        
-        
+
+
         case .securityError:
             writeInt(&buf, Int32(13))
-        
-        
+
+
         case .success:
             writeInt(&buf, Int32(14))
-        
-        
+
+
         case .timeout:
             writeInt(&buf, Int32(15))
-        
-        
+
+
         case .unsupportedApplications:
             writeInt(&buf, Int32(16))
-        
-        
+
+
         case .unsupportedTransports:
             writeInt(&buf, Int32(17))
-        
+
         }
     }
 }
@@ -4018,25 +3458,22 @@ public func FfiConverterTypeWaddleJingleReason_lower(_ value: WaddleJingleReason
 }
 
 
-extension WaddleJingleReason: Equatable, Hashable {}
-
-
-
-
-
-
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
-public enum WaddleMucAffiliation {
-    
+public enum WaddleMucAffiliation: Equatable, Hashable {
+
     case owner
     case admin
     case member
     case outcast
     case none
-}
 
+
+
+
+
+}
 
 #if compiler(>=6)
 extension WaddleMucAffiliation: Sendable {}
@@ -4051,44 +3488,44 @@ public struct FfiConverterTypeWaddleMucAffiliation: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleMucAffiliation {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
+
         case 1: return .owner
-        
+
         case 2: return .admin
-        
+
         case 3: return .member
-        
+
         case 4: return .outcast
-        
+
         case 5: return .none
-        
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: WaddleMucAffiliation, into buf: inout [UInt8]) {
         switch value {
-        
-        
+
+
         case .owner:
             writeInt(&buf, Int32(1))
-        
-        
+
+
         case .admin:
             writeInt(&buf, Int32(2))
-        
-        
+
+
         case .member:
             writeInt(&buf, Int32(3))
-        
-        
+
+
         case .outcast:
             writeInt(&buf, Int32(4))
-        
-        
+
+
         case .none:
             writeInt(&buf, Int32(5))
-        
+
         }
     }
 }
@@ -4109,94 +3546,21 @@ public func FfiConverterTypeWaddleMucAffiliation_lower(_ value: WaddleMucAffilia
 }
 
 
-extension WaddleMucAffiliation: Equatable, Hashable {}
-
-
-
-
-
-
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
-public enum WaddleMucCallPresenceState {
-    
-    case active
-    case inactive
-}
+public enum WaddleMucRole: Equatable, Hashable {
 
-
-#if compiler(>=6)
-extension WaddleMucCallPresenceState: Sendable {}
-#endif
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public struct FfiConverterTypeWaddleMucCallPresenceState: FfiConverterRustBuffer {
-    typealias SwiftType = WaddleMucCallPresenceState
-
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleMucCallPresenceState {
-        let variant: Int32 = try readInt(&buf)
-        switch variant {
-        
-        case 1: return .active
-        
-        case 2: return .inactive
-        
-        default: throw UniffiInternalError.unexpectedEnumCase
-        }
-    }
-
-    public static func write(_ value: WaddleMucCallPresenceState, into buf: inout [UInt8]) {
-        switch value {
-        
-        
-        case .active:
-            writeInt(&buf, Int32(1))
-        
-        
-        case .inactive:
-            writeInt(&buf, Int32(2))
-        
-        }
-    }
-}
-
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public func FfiConverterTypeWaddleMucCallPresenceState_lift(_ buf: RustBuffer) throws -> WaddleMucCallPresenceState {
-    return try FfiConverterTypeWaddleMucCallPresenceState.lift(buf)
-}
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public func FfiConverterTypeWaddleMucCallPresenceState_lower(_ value: WaddleMucCallPresenceState) -> RustBuffer {
-    return FfiConverterTypeWaddleMucCallPresenceState.lower(value)
-}
-
-
-extension WaddleMucCallPresenceState: Equatable, Hashable {}
-
-
-
-
-
-
-// Note that we don't yet support `indirect` for enums.
-// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
-
-public enum WaddleMucRole {
-    
     case moderator
     case participant
     case visitor
     case none
-}
 
+
+
+
+
+}
 
 #if compiler(>=6)
 extension WaddleMucRole: Sendable {}
@@ -4211,38 +3575,38 @@ public struct FfiConverterTypeWaddleMucRole: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleMucRole {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
+
         case 1: return .moderator
-        
+
         case 2: return .participant
-        
+
         case 3: return .visitor
-        
+
         case 4: return .none
-        
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: WaddleMucRole, into buf: inout [UInt8]) {
         switch value {
-        
-        
+
+
         case .moderator:
             writeInt(&buf, Int32(1))
-        
-        
+
+
         case .participant:
             writeInt(&buf, Int32(2))
-        
-        
+
+
         case .visitor:
             writeInt(&buf, Int32(3))
-        
-        
+
+
         case .none:
             writeInt(&buf, Int32(4))
-        
+
         }
     }
 }
@@ -4263,42 +3627,35 @@ public func FfiConverterTypeWaddleMucRole_lower(_ value: WaddleMucRole) -> RustB
 }
 
 
-extension WaddleMucRole: Equatable, Hashable {}
-
-
-
-
-
-
 
 
 
 public protocol WaddleEventListener: AnyObject, Sendable {
-    
-    func onMessage(message: WaddleMessage) 
-    
-    func onPresence(presence: WaddlePresence) 
-    
-    func onMamResult(message: WaddleArchivedMessage) 
-    
-    func onMessageDeliveryAcked(stanzaId: String) 
-    
-    func onMessageDeliveryFailed(stanzaId: String) 
-    
-    func onConnected() 
-    
-    func onDisconnected() 
-    
-    func onError(description: String) 
-    
+
+    func onMessage(message: WaddleMessage)
+
+    func onPresence(presence: WaddlePresence)
+
+    func onMamResult(message: WaddleArchivedMessage)
+
+    func onMessageDeliveryAcked(stanzaId: String)
+
+    func onMessageDeliveryFailed(stanzaId: String)
+
+    func onConnected()
+
+    func onDisconnected()
+
+    func onError(description: String)
+
     /**
      * XEP-0353 / XEP-0166 inbound call event. Fires for every
      * JMI envelope and Jingle session control stanza addressed to
      * the bound resource. The Swift app surfaces it as the
      * ringing UI, the in-call HUD, and the hang-up handler.
      */
-    func onCall(event: WaddleCallEvent) 
-    
+    func onCall(event: WaddleCallEvent)
+
 }
 
 
@@ -4308,9 +3665,22 @@ fileprivate struct UniffiCallbackInterfaceWaddleEventListener {
     // Create the VTable using a series of closures.
     // Swift automatically converts these into C callback functions.
     //
-    // This creates 1-element array, since this seems to be the only way to construct a const
-    // pointer that we can pass to the Rust code.
-    static let vtable: [UniffiVTableCallbackInterfaceWaddleEventListener] = [UniffiVTableCallbackInterfaceWaddleEventListener(
+    // Store the vtable directly.
+    static let vtable: UniffiVTableCallbackInterfaceWaddleEventListener = UniffiVTableCallbackInterfaceWaddleEventListener(
+        uniffiFree: { (uniffiHandle: UInt64) -> () in
+            do {
+                try FfiConverterCallbackInterfaceWaddleEventListener.handleMap.remove(handle: uniffiHandle)
+            } catch {
+                print("Uniffi callback interface WaddleEventListener: handle missing in uniffiFree")
+            }
+        },
+        uniffiClone: { (uniffiHandle: UInt64) -> UInt64 in
+            do {
+                return try FfiConverterCallbackInterfaceWaddleEventListener.handleMap.clone(handle: uniffiHandle)
+            } catch {
+                fatalError("Uniffi callback interface WaddleEventListener: handle missing in uniffiClone")
+            }
+        },
         onMessage: { (
             uniffiHandle: UInt64,
             message: RustBuffer,
@@ -4327,7 +3697,7 @@ fileprivate struct UniffiCallbackInterfaceWaddleEventListener {
                 )
             }
 
-            
+
             let writeReturn = { () }
             uniffiTraitInterfaceCall(
                 callStatus: uniffiCallStatus,
@@ -4351,7 +3721,7 @@ fileprivate struct UniffiCallbackInterfaceWaddleEventListener {
                 )
             }
 
-            
+
             let writeReturn = { () }
             uniffiTraitInterfaceCall(
                 callStatus: uniffiCallStatus,
@@ -4375,7 +3745,7 @@ fileprivate struct UniffiCallbackInterfaceWaddleEventListener {
                 )
             }
 
-            
+
             let writeReturn = { () }
             uniffiTraitInterfaceCall(
                 callStatus: uniffiCallStatus,
@@ -4399,7 +3769,7 @@ fileprivate struct UniffiCallbackInterfaceWaddleEventListener {
                 )
             }
 
-            
+
             let writeReturn = { () }
             uniffiTraitInterfaceCall(
                 callStatus: uniffiCallStatus,
@@ -4423,7 +3793,7 @@ fileprivate struct UniffiCallbackInterfaceWaddleEventListener {
                 )
             }
 
-            
+
             let writeReturn = { () }
             uniffiTraitInterfaceCall(
                 callStatus: uniffiCallStatus,
@@ -4445,7 +3815,7 @@ fileprivate struct UniffiCallbackInterfaceWaddleEventListener {
                 )
             }
 
-            
+
             let writeReturn = { () }
             uniffiTraitInterfaceCall(
                 callStatus: uniffiCallStatus,
@@ -4467,7 +3837,7 @@ fileprivate struct UniffiCallbackInterfaceWaddleEventListener {
                 )
             }
 
-            
+
             let writeReturn = { () }
             uniffiTraitInterfaceCall(
                 callStatus: uniffiCallStatus,
@@ -4491,7 +3861,7 @@ fileprivate struct UniffiCallbackInterfaceWaddleEventListener {
                 )
             }
 
-            
+
             let writeReturn = { () }
             uniffiTraitInterfaceCall(
                 callStatus: uniffiCallStatus,
@@ -4515,25 +3885,27 @@ fileprivate struct UniffiCallbackInterfaceWaddleEventListener {
                 )
             }
 
-            
+
             let writeReturn = { () }
             uniffiTraitInterfaceCall(
                 callStatus: uniffiCallStatus,
                 makeCall: makeCall,
                 writeReturn: writeReturn
             )
-        },
-        uniffiFree: { (uniffiHandle: UInt64) -> () in
-            let result = try? FfiConverterCallbackInterfaceWaddleEventListener.handleMap.remove(handle: uniffiHandle)
-            if result == nil {
-                print("Uniffi callback interface WaddleEventListener: handle missing in uniffiFree")
-            }
         }
-    )]
+    )
+
+    // Rust stores this pointer for future callback invocations, so it must live
+    // for the process lifetime (not just for the init function call).
+    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceWaddleEventListener> = {
+        let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceWaddleEventListener>.allocate(capacity: 1)
+        ptr.initialize(to: vtable)
+        return UnsafePointer(ptr)
+    }()
 }
 
 private func uniffiCallbackInitWaddleEventListener() {
-    uniffi_waddle_xmpp_client_ffi_fn_init_callback_vtable_waddleeventlistener(UniffiCallbackInterfaceWaddleEventListener.vtable)
+    uniffi_waddle_xmpp_client_ffi_fn_init_callback_vtable_waddleeventlistener(UniffiCallbackInterfaceWaddleEventListener.vtablePtr)
 }
 
 // FfiConverter protocol for callback interfaces
@@ -4743,8 +4115,8 @@ fileprivate struct FfiConverterOptionTypeWaddleFallbackRange: FfiConverterRustBu
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-fileprivate struct FfiConverterOptionTypeWaddleMucCallPresence: FfiConverterRustBuffer {
-    typealias SwiftType = WaddleMucCallPresence?
+fileprivate struct FfiConverterOptionTypeWaddleMujiPresence: FfiConverterRustBuffer {
+    typealias SwiftType = WaddleMujiPresence?
 
     public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
         guard let value = value else {
@@ -4752,13 +4124,13 @@ fileprivate struct FfiConverterOptionTypeWaddleMucCallPresence: FfiConverterRust
             return
         }
         writeInt(&buf, Int8(1))
-        FfiConverterTypeWaddleMucCallPresence.write(value, into: &buf)
+        FfiConverterTypeWaddleMujiPresence.write(value, into: &buf)
     }
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
         switch try readInt(&buf) as Int8 {
         case 0: return nil
-        case 1: return try FfiConverterTypeWaddleMucCallPresence.read(from: &buf)
+        case 1: return try FfiConverterTypeWaddleMujiPresence.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }
@@ -5181,7 +4553,7 @@ fileprivate struct FfiConverterSequenceTypeWaddleUploadHeader: FfiConverterRustB
     }
 }
 private let UNIFFI_RUST_FUTURE_POLL_READY: Int8 = 0
-private let UNIFFI_RUST_FUTURE_POLL_MAYBE_READY: Int8 = 1
+private let UNIFFI_RUST_FUTURE_POLL_WAKE: Int8 = 1
 
 fileprivate let uniffiContinuationHandleMap = UniffiHandleMap<UnsafeContinuation<Int8, Never>>()
 
@@ -5205,7 +4577,9 @@ fileprivate func uniffiRustCallAsync<F, T>(
         pollResult = await withUnsafeContinuation {
             pollFunc(
                 rustFuture,
-                uniffiFutureContinuationCallback,
+                { handle, pollResult in
+                    uniffiFutureContinuationCallback(handle: handle, pollResult: pollResult)
+                },
                 uniffiContinuationHandleMap.insert(obj: $0)
             )
         }
@@ -5236,7 +4610,7 @@ private enum InitializationResult {
 // the code inside is only computed once.
 private let initializationResult: InitializationResult = {
     // Get the bindings contract version from our ComponentInterface
-    let bindings_contract_version = 29
+    let bindings_contract_version = 30
     // Get the scaffolding contract version by calling the into the dylib
     let scaffolding_contract_version = ffi_waddle_xmpp_client_ffi_uniffi_contract_version()
     if bindings_contract_version != scaffolding_contract_version {
@@ -5248,16 +4622,16 @@ private let initializationResult: InitializationResult = {
     if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_disconnect() != 16481) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_discover_topology() != 35206) {
+    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_discover_topology() != 22309) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_discover_upload_service() != 12511) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_fetch_dm_history() != 13918) {
+    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_fetch_dm_history() != 19552) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_fetch_room_history() != 10901) {
+    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_fetch_room_history() != 62477) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_join_room() != 24964) {
@@ -5266,13 +4640,16 @@ private let initializationResult: InitializationResult = {
     if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_leave_room() != 31045) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_request_avatar() != 32787) {
+    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_request_avatar() != 34151) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_request_upload_slot() != 18654) {
+    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_request_upload_slot() != 56697) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_call_finish() != 27984) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_call_finish_migrated() != 29693) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_call_proceed() != 57398) {
@@ -5284,55 +4661,61 @@ private let initializationResult: InitializationResult = {
     if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_call_reject() != 7320) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_call_reject_tie_break() != 25295) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_call_retract() != 31803) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_call_session_accept() != 26444) {
+    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_call_retract_tie_break() != 43213) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_call_session_accept() != 35161) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_call_session_initiate() != 55037) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_call_session_terminate() != 16066) {
+    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_call_session_terminate() != 39597) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_chat_message() != 26405) {
+    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_chat_message() != 21298) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_groupchat_message() != 10094) {
+    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_groupchat_message() != 52171) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_presence() != 28282) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_waddle_xmpp_client_ffi_checksum_constructor_waddleclient_new() != 1663) {
+    if (uniffi_waddle_xmpp_client_ffi_checksum_constructor_waddleclient_new() != 16174) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_message() != 4512) {
+    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_message() != 22165) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_presence() != 21904) {
+    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_presence() != 47318) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_mam_result() != 1286) {
+    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_mam_result() != 6626) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_message_delivery_acked() != 24426) {
+    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_message_delivery_acked() != 46331) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_message_delivery_failed() != 12616) {
+    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_message_delivery_failed() != 7405) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_connected() != 40246) {
+    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_connected() != 11479) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_disconnected() != 54320) {
+    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_disconnected() != 39983) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_error() != 54497) {
+    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_error() != 64857) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_call() != 57100) {
+    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_call() != 41030) {
         return InitializationResult.apiChecksumMismatch
     }
 

--- a/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_clientFFI.h
+++ b/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_clientFFI.h
@@ -50,9 +50,9 @@ typedef void (*UniffiRustFutureContinuationCallback)(uint64_t, int8_t
     );
 
 #endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_FREE
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_FREE
-typedef void (*UniffiForeignFutureFree)(uint64_t
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_DROPPED_CALLBACK
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_DROPPED_CALLBACK
+typedef void (*UniffiForeignFutureDroppedCallback)(uint64_t
     );
 
 #endif
@@ -62,254 +62,246 @@ typedef void (*UniffiCallbackInterfaceFree)(uint64_t
     );
 
 #endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE
-typedef struct UniffiForeignFuture {
-    uint64_t handle;
-    UniffiForeignFutureFree _Nonnull free;
-} UniffiForeignFuture;
+#ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_CLONE
+#define UNIFFI_FFIDEF_CALLBACK_INTERFACE_CLONE
+typedef uint64_t (*UniffiCallbackInterfaceClone)(uint64_t
+    );
 
 #endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_U8
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_U8
-typedef struct UniffiForeignFutureStructU8 {
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_DROPPED_CALLBACK_STRUCT
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_DROPPED_CALLBACK_STRUCT
+typedef struct UniffiForeignFutureDroppedCallbackStruct {
+    uint64_t handle;
+    UniffiForeignFutureDroppedCallback _Nonnull free;
+} UniffiForeignFutureDroppedCallbackStruct;
+
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_U8
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_U8
+typedef struct UniffiForeignFutureResultU8 {
     uint8_t returnValue;
     RustCallStatus callStatus;
-} UniffiForeignFutureStructU8;
+} UniffiForeignFutureResultU8;
 
 #endif
 #ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_U8
 #define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_U8
-typedef void (*UniffiForeignFutureCompleteU8)(uint64_t, UniffiForeignFutureStructU8
+typedef void (*UniffiForeignFutureCompleteU8)(uint64_t, UniffiForeignFutureResultU8
     );
 
 #endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_I8
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_I8
-typedef struct UniffiForeignFutureStructI8 {
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_I8
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_I8
+typedef struct UniffiForeignFutureResultI8 {
     int8_t returnValue;
     RustCallStatus callStatus;
-} UniffiForeignFutureStructI8;
+} UniffiForeignFutureResultI8;
 
 #endif
 #ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_I8
 #define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_I8
-typedef void (*UniffiForeignFutureCompleteI8)(uint64_t, UniffiForeignFutureStructI8
+typedef void (*UniffiForeignFutureCompleteI8)(uint64_t, UniffiForeignFutureResultI8
     );
 
 #endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_U16
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_U16
-typedef struct UniffiForeignFutureStructU16 {
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_U16
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_U16
+typedef struct UniffiForeignFutureResultU16 {
     uint16_t returnValue;
     RustCallStatus callStatus;
-} UniffiForeignFutureStructU16;
+} UniffiForeignFutureResultU16;
 
 #endif
 #ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_U16
 #define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_U16
-typedef void (*UniffiForeignFutureCompleteU16)(uint64_t, UniffiForeignFutureStructU16
+typedef void (*UniffiForeignFutureCompleteU16)(uint64_t, UniffiForeignFutureResultU16
     );
 
 #endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_I16
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_I16
-typedef struct UniffiForeignFutureStructI16 {
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_I16
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_I16
+typedef struct UniffiForeignFutureResultI16 {
     int16_t returnValue;
     RustCallStatus callStatus;
-} UniffiForeignFutureStructI16;
+} UniffiForeignFutureResultI16;
 
 #endif
 #ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_I16
 #define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_I16
-typedef void (*UniffiForeignFutureCompleteI16)(uint64_t, UniffiForeignFutureStructI16
+typedef void (*UniffiForeignFutureCompleteI16)(uint64_t, UniffiForeignFutureResultI16
     );
 
 #endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_U32
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_U32
-typedef struct UniffiForeignFutureStructU32 {
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_U32
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_U32
+typedef struct UniffiForeignFutureResultU32 {
     uint32_t returnValue;
     RustCallStatus callStatus;
-} UniffiForeignFutureStructU32;
+} UniffiForeignFutureResultU32;
 
 #endif
 #ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_U32
 #define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_U32
-typedef void (*UniffiForeignFutureCompleteU32)(uint64_t, UniffiForeignFutureStructU32
+typedef void (*UniffiForeignFutureCompleteU32)(uint64_t, UniffiForeignFutureResultU32
     );
 
 #endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_I32
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_I32
-typedef struct UniffiForeignFutureStructI32 {
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_I32
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_I32
+typedef struct UniffiForeignFutureResultI32 {
     int32_t returnValue;
     RustCallStatus callStatus;
-} UniffiForeignFutureStructI32;
+} UniffiForeignFutureResultI32;
 
 #endif
 #ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_I32
 #define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_I32
-typedef void (*UniffiForeignFutureCompleteI32)(uint64_t, UniffiForeignFutureStructI32
+typedef void (*UniffiForeignFutureCompleteI32)(uint64_t, UniffiForeignFutureResultI32
     );
 
 #endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_U64
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_U64
-typedef struct UniffiForeignFutureStructU64 {
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_U64
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_U64
+typedef struct UniffiForeignFutureResultU64 {
     uint64_t returnValue;
     RustCallStatus callStatus;
-} UniffiForeignFutureStructU64;
+} UniffiForeignFutureResultU64;
 
 #endif
 #ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_U64
 #define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_U64
-typedef void (*UniffiForeignFutureCompleteU64)(uint64_t, UniffiForeignFutureStructU64
+typedef void (*UniffiForeignFutureCompleteU64)(uint64_t, UniffiForeignFutureResultU64
     );
 
 #endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_I64
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_I64
-typedef struct UniffiForeignFutureStructI64 {
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_I64
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_I64
+typedef struct UniffiForeignFutureResultI64 {
     int64_t returnValue;
     RustCallStatus callStatus;
-} UniffiForeignFutureStructI64;
+} UniffiForeignFutureResultI64;
 
 #endif
 #ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_I64
 #define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_I64
-typedef void (*UniffiForeignFutureCompleteI64)(uint64_t, UniffiForeignFutureStructI64
+typedef void (*UniffiForeignFutureCompleteI64)(uint64_t, UniffiForeignFutureResultI64
     );
 
 #endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_F32
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_F32
-typedef struct UniffiForeignFutureStructF32 {
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_F32
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_F32
+typedef struct UniffiForeignFutureResultF32 {
     float returnValue;
     RustCallStatus callStatus;
-} UniffiForeignFutureStructF32;
+} UniffiForeignFutureResultF32;
 
 #endif
 #ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_F32
 #define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_F32
-typedef void (*UniffiForeignFutureCompleteF32)(uint64_t, UniffiForeignFutureStructF32
+typedef void (*UniffiForeignFutureCompleteF32)(uint64_t, UniffiForeignFutureResultF32
     );
 
 #endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_F64
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_F64
-typedef struct UniffiForeignFutureStructF64 {
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_F64
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_F64
+typedef struct UniffiForeignFutureResultF64 {
     double returnValue;
     RustCallStatus callStatus;
-} UniffiForeignFutureStructF64;
+} UniffiForeignFutureResultF64;
 
 #endif
 #ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_F64
 #define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_F64
-typedef void (*UniffiForeignFutureCompleteF64)(uint64_t, UniffiForeignFutureStructF64
+typedef void (*UniffiForeignFutureCompleteF64)(uint64_t, UniffiForeignFutureResultF64
     );
 
 #endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_POINTER
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_POINTER
-typedef struct UniffiForeignFutureStructPointer {
-    void*_Nonnull returnValue;
-    RustCallStatus callStatus;
-} UniffiForeignFutureStructPointer;
-
-#endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_POINTER
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_POINTER
-typedef void (*UniffiForeignFutureCompletePointer)(uint64_t, UniffiForeignFutureStructPointer
-    );
-
-#endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_RUST_BUFFER
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_RUST_BUFFER
-typedef struct UniffiForeignFutureStructRustBuffer {
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_RUST_BUFFER
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_RUST_BUFFER
+typedef struct UniffiForeignFutureResultRustBuffer {
     RustBuffer returnValue;
     RustCallStatus callStatus;
-} UniffiForeignFutureStructRustBuffer;
+} UniffiForeignFutureResultRustBuffer;
 
 #endif
 #ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_RUST_BUFFER
 #define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_RUST_BUFFER
-typedef void (*UniffiForeignFutureCompleteRustBuffer)(uint64_t, UniffiForeignFutureStructRustBuffer
+typedef void (*UniffiForeignFutureCompleteRustBuffer)(uint64_t, UniffiForeignFutureResultRustBuffer
     );
 
 #endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_VOID
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_VOID
-typedef struct UniffiForeignFutureStructVoid {
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_VOID
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_VOID
+typedef struct UniffiForeignFutureResultVoid {
     RustCallStatus callStatus;
-} UniffiForeignFutureStructVoid;
+} UniffiForeignFutureResultVoid;
 
 #endif
 #ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_VOID
 #define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_VOID
-typedef void (*UniffiForeignFutureCompleteVoid)(uint64_t, UniffiForeignFutureStructVoid
+typedef void (*UniffiForeignFutureCompleteVoid)(uint64_t, UniffiForeignFutureResultVoid
     );
 
 #endif
 #ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD0
 #define UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD0
-typedef void (*UniffiCallbackInterfaceWaddleEventListenerMethod0)(uint64_t, RustBuffer, void* _Nonnull, 
+typedef void (*UniffiCallbackInterfaceWaddleEventListenerMethod0)(uint64_t, RustBuffer, void* _Nonnull,
         RustCallStatus *_Nonnull uniffiCallStatus
     );
 
 #endif
 #ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD1
 #define UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD1
-typedef void (*UniffiCallbackInterfaceWaddleEventListenerMethod1)(uint64_t, RustBuffer, void* _Nonnull, 
+typedef void (*UniffiCallbackInterfaceWaddleEventListenerMethod1)(uint64_t, RustBuffer, void* _Nonnull,
         RustCallStatus *_Nonnull uniffiCallStatus
     );
 
 #endif
 #ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD2
 #define UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD2
-typedef void (*UniffiCallbackInterfaceWaddleEventListenerMethod2)(uint64_t, RustBuffer, void* _Nonnull, 
+typedef void (*UniffiCallbackInterfaceWaddleEventListenerMethod2)(uint64_t, RustBuffer, void* _Nonnull,
         RustCallStatus *_Nonnull uniffiCallStatus
     );
 
 #endif
 #ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD3
 #define UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD3
-typedef void (*UniffiCallbackInterfaceWaddleEventListenerMethod3)(uint64_t, RustBuffer, void* _Nonnull, 
+typedef void (*UniffiCallbackInterfaceWaddleEventListenerMethod3)(uint64_t, RustBuffer, void* _Nonnull,
         RustCallStatus *_Nonnull uniffiCallStatus
     );
 
 #endif
 #ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD4
 #define UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD4
-typedef void (*UniffiCallbackInterfaceWaddleEventListenerMethod4)(uint64_t, RustBuffer, void* _Nonnull, 
+typedef void (*UniffiCallbackInterfaceWaddleEventListenerMethod4)(uint64_t, RustBuffer, void* _Nonnull,
         RustCallStatus *_Nonnull uniffiCallStatus
     );
 
 #endif
 #ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD5
 #define UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD5
-typedef void (*UniffiCallbackInterfaceWaddleEventListenerMethod5)(uint64_t, void* _Nonnull, 
+typedef void (*UniffiCallbackInterfaceWaddleEventListenerMethod5)(uint64_t, void* _Nonnull,
         RustCallStatus *_Nonnull uniffiCallStatus
     );
 
 #endif
 #ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD6
 #define UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD6
-typedef void (*UniffiCallbackInterfaceWaddleEventListenerMethod6)(uint64_t, void* _Nonnull, 
+typedef void (*UniffiCallbackInterfaceWaddleEventListenerMethod6)(uint64_t, void* _Nonnull,
         RustCallStatus *_Nonnull uniffiCallStatus
     );
 
 #endif
 #ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD7
 #define UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD7
-typedef void (*UniffiCallbackInterfaceWaddleEventListenerMethod7)(uint64_t, RustBuffer, void* _Nonnull, 
+typedef void (*UniffiCallbackInterfaceWaddleEventListenerMethod7)(uint64_t, RustBuffer, void* _Nonnull,
         RustCallStatus *_Nonnull uniffiCallStatus
     );
 
 #endif
 #ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD8
 #define UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD8
-typedef void (*UniffiCallbackInterfaceWaddleEventListenerMethod8)(uint64_t, RustBuffer, void* _Nonnull, 
+typedef void (*UniffiCallbackInterfaceWaddleEventListenerMethod8)(uint64_t, RustBuffer, void* _Nonnull,
         RustCallStatus *_Nonnull uniffiCallStatus
     );
 
@@ -317,6 +309,8 @@ typedef void (*UniffiCallbackInterfaceWaddleEventListenerMethod8)(uint64_t, Rust
 #ifndef UNIFFI_FFIDEF_V_TABLE_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER
 #define UNIFFI_FFIDEF_V_TABLE_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER
 typedef struct UniffiVTableCallbackInterfaceWaddleEventListener {
+    UniffiCallbackInterfaceFree _Nonnull uniffiFree;
+    UniffiCallbackInterfaceClone _Nonnull uniffiClone;
     UniffiCallbackInterfaceWaddleEventListenerMethod0 _Nonnull onMessage;
     UniffiCallbackInterfaceWaddleEventListenerMethod1 _Nonnull onPresence;
     UniffiCallbackInterfaceWaddleEventListenerMethod2 _Nonnull onMamResult;
@@ -326,128 +320,142 @@ typedef struct UniffiVTableCallbackInterfaceWaddleEventListener {
     UniffiCallbackInterfaceWaddleEventListenerMethod6 _Nonnull onDisconnected;
     UniffiCallbackInterfaceWaddleEventListenerMethod7 _Nonnull onError;
     UniffiCallbackInterfaceWaddleEventListenerMethod8 _Nonnull onCall;
-    UniffiCallbackInterfaceFree _Nonnull uniffiFree;
 } UniffiVTableCallbackInterfaceWaddleEventListener;
 
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_CLONE_WADDLECLIENT
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_CLONE_WADDLECLIENT
-void*_Nonnull uniffi_waddle_xmpp_client_ffi_fn_clone_waddleclient(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+uint64_t uniffi_waddle_xmpp_client_ffi_fn_clone_waddleclient(uint64_t handle, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_FREE_WADDLECLIENT
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_FREE_WADDLECLIENT
-void uniffi_waddle_xmpp_client_ffi_fn_free_waddleclient(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+void uniffi_waddle_xmpp_client_ffi_fn_free_waddleclient(uint64_t handle, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_CONSTRUCTOR_WADDLECLIENT_NEW
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_CONSTRUCTOR_WADDLECLIENT_NEW
-void*_Nonnull uniffi_waddle_xmpp_client_ffi_fn_constructor_waddleclient_new(RustBuffer config, uint64_t listener, RustCallStatus *_Nonnull out_status
+uint64_t uniffi_waddle_xmpp_client_ffi_fn_constructor_waddleclient_new(RustBuffer config, uint64_t listener, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_CONNECT
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_CONNECT
-uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_connect(void*_Nonnull ptr
+uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_connect(uint64_t ptr
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_DISCONNECT
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_DISCONNECT
-uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_disconnect(void*_Nonnull ptr
+uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_disconnect(uint64_t ptr
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_DISCOVER_TOPOLOGY
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_DISCOVER_TOPOLOGY
-uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_discover_topology(void*_Nonnull ptr
+uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_discover_topology(uint64_t ptr
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_DISCOVER_UPLOAD_SERVICE
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_DISCOVER_UPLOAD_SERVICE
-uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_discover_upload_service(void*_Nonnull ptr
+uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_discover_upload_service(uint64_t ptr
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_FETCH_DM_HISTORY
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_FETCH_DM_HISTORY
-uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_fetch_dm_history(void*_Nonnull ptr, RustBuffer peer_jid, uint32_t max_messages, RustBuffer before_id
+uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_fetch_dm_history(uint64_t ptr, RustBuffer peer_jid, uint32_t max_messages, RustBuffer before_id
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_FETCH_ROOM_HISTORY
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_FETCH_ROOM_HISTORY
-uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_fetch_room_history(void*_Nonnull ptr, RustBuffer room_jid, uint32_t max_messages, RustBuffer before_id
+uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_fetch_room_history(uint64_t ptr, RustBuffer room_jid, uint32_t max_messages, RustBuffer before_id
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_JOIN_ROOM
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_JOIN_ROOM
-uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_join_room(void*_Nonnull ptr, RustBuffer room_jid, RustBuffer nick
+uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_join_room(uint64_t ptr, RustBuffer room_jid, RustBuffer nick
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_LEAVE_ROOM
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_LEAVE_ROOM
-uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_leave_room(void*_Nonnull ptr, RustBuffer room_jid, RustBuffer nick
+uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_leave_room(uint64_t ptr, RustBuffer room_jid, RustBuffer nick
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_REQUEST_AVATAR
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_REQUEST_AVATAR
-uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_request_avatar(void*_Nonnull ptr, RustBuffer jid
+uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_request_avatar(uint64_t ptr, RustBuffer jid
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_REQUEST_UPLOAD_SLOT
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_REQUEST_UPLOAD_SLOT
-uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_request_upload_slot(void*_Nonnull ptr, RustBuffer service_jid, RustBuffer filename, uint64_t size, RustBuffer content_type
+uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_request_upload_slot(uint64_t ptr, RustBuffer service_jid, RustBuffer filename, uint64_t size, RustBuffer content_type
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_SEND_CALL_FINISH
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_SEND_CALL_FINISH
-uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_finish(void*_Nonnull ptr, RustBuffer peer_full_jid, RustBuffer sid
+uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_finish(uint64_t ptr, RustBuffer peer_full_jid, RustBuffer sid
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_SEND_CALL_FINISH_MIGRATED
+#define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_SEND_CALL_FINISH_MIGRATED
+uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_finish_migrated(uint64_t ptr, RustBuffer peer_full_jid, RustBuffer old_sid, RustBuffer new_sid
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_SEND_CALL_PROCEED
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_SEND_CALL_PROCEED
-uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_proceed(void*_Nonnull ptr, RustBuffer peer_full_jid, RustBuffer sid
+uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_proceed(uint64_t ptr, RustBuffer peer_full_jid, RustBuffer sid
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_SEND_CALL_PROPOSE
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_SEND_CALL_PROPOSE
-uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_propose(void*_Nonnull ptr, RustBuffer peer_bare_jid, RustBuffer sid, int8_t audio, int8_t video
+uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_propose(uint64_t ptr, RustBuffer peer_bare_jid, RustBuffer sid, int8_t audio, int8_t video
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_SEND_CALL_REJECT
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_SEND_CALL_REJECT
-uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_reject(void*_Nonnull ptr, RustBuffer peer_full_jid, RustBuffer sid
+uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_reject(uint64_t ptr, RustBuffer peer_full_jid, RustBuffer sid
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_SEND_CALL_REJECT_TIE_BREAK
+#define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_SEND_CALL_REJECT_TIE_BREAK
+uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_reject_tie_break(uint64_t ptr, RustBuffer peer_full_jid, RustBuffer sid
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_SEND_CALL_RETRACT
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_SEND_CALL_RETRACT
-uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_retract(void*_Nonnull ptr, RustBuffer peer_bare_jid, RustBuffer sid
+uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_retract(uint64_t ptr, RustBuffer peer_bare_jid, RustBuffer sid
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_SEND_CALL_RETRACT_TIE_BREAK
+#define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_SEND_CALL_RETRACT_TIE_BREAK
+uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_retract_tie_break(uint64_t ptr, RustBuffer peer_full_jid, RustBuffer sid
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_SEND_CALL_SESSION_ACCEPT
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_SEND_CALL_SESSION_ACCEPT
-uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_session_accept(void*_Nonnull ptr, RustBuffer peer_full_jid, RustBuffer initiator_full_jid, RustBuffer responder_full_jid, RustBuffer sid, int8_t audio, int8_t video
+uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_session_accept(uint64_t ptr, RustBuffer peer_full_jid, RustBuffer responder_full_jid, RustBuffer sid, int8_t audio, int8_t video
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_SEND_CALL_SESSION_INITIATE
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_SEND_CALL_SESSION_INITIATE
-uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_session_initiate(void*_Nonnull ptr, RustBuffer peer_full_jid, RustBuffer initiator_full_jid, RustBuffer sid, int8_t audio, int8_t video
+uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_session_initiate(uint64_t ptr, RustBuffer peer_full_jid, RustBuffer initiator_full_jid, RustBuffer sid, int8_t audio, int8_t video
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_SEND_CALL_SESSION_TERMINATE
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_SEND_CALL_SESSION_TERMINATE
-uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_session_terminate(void*_Nonnull ptr, RustBuffer peer_full_jid, RustBuffer sid, RustBuffer reason
+uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_call_session_terminate(uint64_t ptr, RustBuffer peer_full_jid, RustBuffer sid, RustBuffer reason
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_SEND_CHAT_MESSAGE
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_SEND_CHAT_MESSAGE
-uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_chat_message(void*_Nonnull ptr, RustBuffer peer_jid, RustBuffer body, RustBuffer options
+uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_chat_message(uint64_t ptr, RustBuffer peer_jid, RustBuffer body, RustBuffer options
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_SEND_GROUPCHAT_MESSAGE
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_SEND_GROUPCHAT_MESSAGE
-uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_groupchat_message(void*_Nonnull ptr, RustBuffer room_jid, RustBuffer body, RustBuffer options
+uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_groupchat_message(uint64_t ptr, RustBuffer room_jid, RustBuffer body, RustBuffer options
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_SEND_PRESENCE
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_METHOD_WADDLECLIENT_SEND_PRESENCE
-uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_presence(void*_Nonnull ptr, RustBuffer status, RustBuffer show
+uint64_t uniffi_waddle_xmpp_client_ffi_fn_method_waddleclient_send_presence(uint64_t ptr, RustBuffer status, RustBuffer show
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_FN_INIT_CALLBACK_VTABLE_WADDLEEVENTLISTENER
@@ -675,26 +683,6 @@ void ffi_waddle_xmpp_client_ffi_rust_future_free_f64(uint64_t handle
 double ffi_waddle_xmpp_client_ffi_rust_future_complete_f64(uint64_t handle, RustCallStatus *_Nonnull out_status
 );
 #endif
-#ifndef UNIFFI_FFIDEF_FFI_WADDLE_XMPP_CLIENT_FFI_RUST_FUTURE_POLL_POINTER
-#define UNIFFI_FFIDEF_FFI_WADDLE_XMPP_CLIENT_FFI_RUST_FUTURE_POLL_POINTER
-void ffi_waddle_xmpp_client_ffi_rust_future_poll_pointer(uint64_t handle, UniffiRustFutureContinuationCallback _Nonnull callback, uint64_t callback_data
-);
-#endif
-#ifndef UNIFFI_FFIDEF_FFI_WADDLE_XMPP_CLIENT_FFI_RUST_FUTURE_CANCEL_POINTER
-#define UNIFFI_FFIDEF_FFI_WADDLE_XMPP_CLIENT_FFI_RUST_FUTURE_CANCEL_POINTER
-void ffi_waddle_xmpp_client_ffi_rust_future_cancel_pointer(uint64_t handle
-);
-#endif
-#ifndef UNIFFI_FFIDEF_FFI_WADDLE_XMPP_CLIENT_FFI_RUST_FUTURE_FREE_POINTER
-#define UNIFFI_FFIDEF_FFI_WADDLE_XMPP_CLIENT_FFI_RUST_FUTURE_FREE_POINTER
-void ffi_waddle_xmpp_client_ffi_rust_future_free_pointer(uint64_t handle
-);
-#endif
-#ifndef UNIFFI_FFIDEF_FFI_WADDLE_XMPP_CLIENT_FFI_RUST_FUTURE_COMPLETE_POINTER
-#define UNIFFI_FFIDEF_FFI_WADDLE_XMPP_CLIENT_FFI_RUST_FUTURE_COMPLETE_POINTER
-void*_Nonnull ffi_waddle_xmpp_client_ffi_rust_future_complete_pointer(uint64_t handle, RustCallStatus *_Nonnull out_status
-);
-#endif
 #ifndef UNIFFI_FFIDEF_FFI_WADDLE_XMPP_CLIENT_FFI_RUST_FUTURE_POLL_RUST_BUFFER
 #define UNIFFI_FFIDEF_FFI_WADDLE_XMPP_CLIENT_FFI_RUST_FUTURE_POLL_RUST_BUFFER
 void ffi_waddle_xmpp_client_ffi_rust_future_poll_rust_buffer(uint64_t handle, UniffiRustFutureContinuationCallback _Nonnull callback, uint64_t callback_data
@@ -738,193 +726,211 @@ void ffi_waddle_xmpp_client_ffi_rust_future_complete_void(uint64_t handle, RustC
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_CONNECT
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_CONNECT
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_connect(void
-    
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_DISCONNECT
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_DISCONNECT
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_disconnect(void
-    
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_DISCOVER_TOPOLOGY
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_DISCOVER_TOPOLOGY
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_discover_topology(void
-    
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_DISCOVER_UPLOAD_SERVICE
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_DISCOVER_UPLOAD_SERVICE
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_discover_upload_service(void
-    
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_FETCH_DM_HISTORY
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_FETCH_DM_HISTORY
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_fetch_dm_history(void
-    
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_FETCH_ROOM_HISTORY
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_FETCH_ROOM_HISTORY
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_fetch_room_history(void
-    
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_JOIN_ROOM
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_JOIN_ROOM
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_join_room(void
-    
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_LEAVE_ROOM
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_LEAVE_ROOM
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_leave_room(void
-    
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_REQUEST_AVATAR
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_REQUEST_AVATAR
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_request_avatar(void
-    
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_REQUEST_UPLOAD_SLOT
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_REQUEST_UPLOAD_SLOT
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_request_upload_slot(void
-    
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_SEND_CALL_FINISH
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_SEND_CALL_FINISH
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_call_finish(void
-    
+
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_SEND_CALL_FINISH_MIGRATED
+#define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_SEND_CALL_FINISH_MIGRATED
+uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_call_finish_migrated(void
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_SEND_CALL_PROCEED
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_SEND_CALL_PROCEED
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_call_proceed(void
-    
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_SEND_CALL_PROPOSE
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_SEND_CALL_PROPOSE
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_call_propose(void
-    
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_SEND_CALL_REJECT
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_SEND_CALL_REJECT
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_call_reject(void
-    
+
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_SEND_CALL_REJECT_TIE_BREAK
+#define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_SEND_CALL_REJECT_TIE_BREAK
+uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_call_reject_tie_break(void
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_SEND_CALL_RETRACT
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_SEND_CALL_RETRACT
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_call_retract(void
-    
+
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_SEND_CALL_RETRACT_TIE_BREAK
+#define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_SEND_CALL_RETRACT_TIE_BREAK
+uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_call_retract_tie_break(void
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_SEND_CALL_SESSION_ACCEPT
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_SEND_CALL_SESSION_ACCEPT
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_call_session_accept(void
-    
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_SEND_CALL_SESSION_INITIATE
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_SEND_CALL_SESSION_INITIATE
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_call_session_initiate(void
-    
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_SEND_CALL_SESSION_TERMINATE
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_SEND_CALL_SESSION_TERMINATE
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_call_session_terminate(void
-    
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_SEND_CHAT_MESSAGE
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_SEND_CHAT_MESSAGE
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_chat_message(void
-    
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_SEND_GROUPCHAT_MESSAGE
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_SEND_GROUPCHAT_MESSAGE
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_groupchat_message(void
-    
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_SEND_PRESENCE
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLECLIENT_SEND_PRESENCE
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleclient_send_presence(void
-    
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_CONSTRUCTOR_WADDLECLIENT_NEW
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_CONSTRUCTOR_WADDLECLIENT_NEW
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_constructor_waddleclient_new(void
-    
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_MESSAGE
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_MESSAGE
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_message(void
-    
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_PRESENCE
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_PRESENCE
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_presence(void
-    
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_MAM_RESULT
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_MAM_RESULT
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_mam_result(void
-    
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_MESSAGE_DELIVERY_ACKED
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_MESSAGE_DELIVERY_ACKED
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_message_delivery_acked(void
-    
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_MESSAGE_DELIVERY_FAILED
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_MESSAGE_DELIVERY_FAILED
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_message_delivery_failed(void
-    
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_CONNECTED
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_CONNECTED
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_connected(void
-    
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_DISCONNECTED
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_DISCONNECTED
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_disconnected(void
-    
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_ERROR
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_ERROR
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_error(void
-    
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_CALL
 #define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_CALL
 uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_call(void
-    
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_FFI_WADDLE_XMPP_CLIENT_FFI_UNIFFI_CONTRACT_VERSION
 #define UNIFFI_FFIDEF_FFI_WADDLE_XMPP_CLIENT_FFI_UNIFFI_CONTRACT_VERSION
 uint32_t ffi_waddle_xmpp_client_ffi_uniffi_contract_version(void
-    
+
 );
 #endif
 

--- a/apps/apple/Waddle/RustClient/RustXmppClient.swift
+++ b/apps/apple/Waddle/RustClient/RustXmppClient.swift
@@ -452,12 +452,12 @@ private func makeCallEvent(_ event: WaddleCallEvent) -> XMPPCallEvent {
             return .propose(media: makeCallMedia(media))
         case .proceed:
             return .proceed
-        case .reject:
-            return .reject
-        case .retract:
-            return .retract
-        case .finish:
-            return .finish
+        case let .reject(reason, tieBreak):
+            return .reject(reason: reason.map(makeJingleReason), tieBreak: tieBreak)
+        case let .retract(reason, tieBreak):
+            return .retract(reason: reason.map(makeJingleReason), tieBreak: tieBreak)
+        case let .finish(reason, migratedTo):
+            return .finish(reason: reason.map(makeJingleReason), migratedTo: migratedTo)
         case let .sessionInitiate(join, media):
             return .sessionInitiate(join: makeLiveKitJoin(join), media: makeCallMedia(media))
         case let .sessionAccept(join, media):

--- a/apps/apple/Waddle/XMPP/XMPPTypes.swift
+++ b/apps/apple/Waddle/XMPP/XMPPTypes.swift
@@ -317,9 +317,9 @@ enum XMPPJingleReason: Sendable, Equatable {
 enum XMPPCallEventKind: Sendable, Equatable {
     case propose(media: XMPPCallMedia)
     case proceed
-    case reject
-    case retract
-    case finish
+    case reject(reason: XMPPJingleReason?, tieBreak: Bool)
+    case retract(reason: XMPPJingleReason?, tieBreak: Bool)
+    case finish(reason: XMPPJingleReason?, migratedTo: String?)
     case sessionInitiate(join: XMPPLiveKitJoin, media: XMPPCallMedia)
     case sessionAccept(join: XMPPLiveKitJoin, media: XMPPCallMedia)
     case sessionTerminate(reason: XMPPJingleReason?)

--- a/chat/scripts/build-xmpp-wasm.mjs
+++ b/chat/scripts/build-xmpp-wasm.mjs
@@ -6,12 +6,40 @@ import { fileURLToPath } from "node:url";
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, "..", "..");
 const crateDir = resolve(repoRoot, "server/crates/waddle-xmpp-client-wasm");
+const clientCrateDir = resolve(repoRoot, "server/crates/waddle-xmpp-client");
+const coreCrateDir = resolve(repoRoot, "server/crates/waddle-xmpp-core");
 const outDir = resolve(repoRoot, "server/wasm-pkg/waddle-xmpp-client-wasm");
 const nodeModulesDir = resolve(scriptDir, "..", "node_modules/@waddle/xmpp-client-wasm");
 
+function newestSourceMtime(paths) {
+  let newest = 0;
+  function visit(path) {
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      for (const entry of readdirSync(path)) {
+        if (entry === "target" || entry === ".git") continue;
+        visit(resolve(path, entry));
+      }
+      return;
+    }
+    if (
+      path.endsWith(".rs") ||
+      path.endsWith(".toml") ||
+      path.endsWith(".lock") ||
+      path.endsWith("build.rs")
+    ) {
+      newest = Math.max(newest, stat.mtimeMs);
+    }
+  }
+  for (const path of paths) visit(path);
+  return newest;
+}
+
 if (process.env.REBUILD_WASM !== "1") {
   // If _bg.js doesn't exist in node_modules, the package is incomplete (fresh checkout or
-  // bun install after the artifact was removed). Auto-rebuild to avoid a broken dev server.
+  // bun install after the artifact was removed). Also rebuild when the Rust sources are
+  // newer than the installed artifact; otherwise an existing node_modules can keep exposing
+  // stale wasm-bindgen methods after a branch checkout.
   const bgJsPath = resolve(nodeModulesDir, "waddle_xmpp_client_wasm_bg.js");
   const realBgJsPath = existsSync(nodeModulesDir)
     ? resolve(realpathSync(nodeModulesDir), "waddle_xmpp_client_wasm_bg.js")
@@ -20,6 +48,11 @@ if (process.env.REBUILD_WASM !== "1") {
     console.log("[wasm] WASM artifacts missing — auto-rebuilding from Rust source...");
     console.log("[wasm] (Set REBUILD_WASM=1 explicitly to force a rebuild when artifacts exist.)");
     // Fall through to the rebuild path below.
+  } else if (
+    newestSourceMtime([crateDir, clientCrateDir, coreCrateDir]) >
+    statSync(realBgJsPath).mtimeMs
+  ) {
+    console.log("[wasm] Rust wasm sources changed — rebuilding @waddle/xmpp-client-wasm...");
   } else {
     // Artifacts present; rely on the local build or published registry version.
     console.log("[wasm] WASM artifacts found — skipping rebuild. Set REBUILD_WASM=1 to force recompile.");
@@ -146,4 +179,3 @@ if (existsSync(viteCacheDir)) {
 
 console.log("[wasm] Done. Local build installed.");
 console.log("[wasm] ⚠️  Next `bun install` will revert to the published registry version.");
-

--- a/chat/src/components/calls/CallButton.vue
+++ b/chat/src/components/calls/CallButton.vue
@@ -32,8 +32,9 @@ async function startCall(media: CallMedia): Promise<void> {
   if (inCall.value) return;
   const sender = getSender();
   if (!sender) return;
+  const initiator = (connectionStore.client as unknown as { fullJid?: string } | null)?.fullJid;
   const sid = newCallSid();
-  beginOutgoingCall(props.peerBareJid, sid, media);
+  beginOutgoingCall(props.peerBareJid, sid, media, initiator);
   try {
     await outboundCalls.propose(sender, props.peerBareJid, sid, media);
     // Arm the auto-retract once the propose is on the wire — if we

--- a/chat/src/components/calls/CallOverlay.vue
+++ b/chat/src/components/calls/CallOverlay.vue
@@ -4,7 +4,6 @@ import { useStore } from "@nanostores/vue";
 import {
   $callState,
   $lastCallError,
-  clearCallState,
   reportCallError,
   tearDownActiveCall,
 } from "@/lib/calls/call-store";
@@ -94,12 +93,15 @@ watch(
       await engine.connect(active.join, active.media);
       micEnabled.value = active.media.audio;
       camEnabled.value = active.media.video;
-    } catch {
+    } catch (err) {
       // The server already verified the JWT before forwarding the
       // transport, so the most common failure here is the browser
-      // denying mic/cam permissions. Hang up locally; the peer will
-      // see session-terminate via the hangup path below.
-      clearCallState();
+      // denying mic/cam permissions. Run the full hangup path so
+      // SFU/session/Muji presence state rolls back before the local
+      // slot disappears.
+      await tearDownActiveCall(getSender(), "gone");
+      await engine.disconnect();
+      reportCallError(err);
     } finally {
       connecting.value = false;
     }

--- a/chat/src/components/calls/IncomingCallToast.vue
+++ b/chat/src/components/calls/IncomingCallToast.vue
@@ -60,7 +60,7 @@ async function accept(): Promise<void> {
   if (!sender) return;
   accepting.value = true;
   try {
-    // Send <proceed/> back to the caller's bare JID; they respond
+    // Send <proceed/> back to the caller's full JID; they respond
     // with a Jingle session-initiate which transitions us to active.
     await outboundCalls.proceed(sender, from, sid);
   } catch (err) {

--- a/chat/src/components/calls/MucCallButton.vue
+++ b/chat/src/components/calls/MucCallButton.vue
@@ -1,16 +1,19 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { useStore } from "@nanostores/vue";
 import { Phone, Video } from "lucide-vue-next";
 import {
   $callState,
-  beginMucCall,
-  reportCallError,
   type RawIqSender,
 } from "@/lib/calls/call-store";
-import { $mucCallParticipants } from "@/lib/calls/muc-call-presence";
+import { startMucCallAction } from "@/lib/calls/muc-call-actions";
+import {
+  $mucCallParticipants,
+  normalizeMucCallRoomJid,
+} from "@/lib/calls/muc-call-presence";
 import { connectionStore } from "@/lib/connection-store";
 import type { CallMedia } from "@/lib/calls/types";
+import { jidDomain } from "@/lib/xmpp/jid";
 
 const props = defineProps<{
   /** MUC room bare JID (`channel@muc.host`). The server uses this
@@ -20,16 +23,24 @@ const props = defineProps<{
 }>();
 
 const state = useStore($callState);
+const starting = ref(false);
 const inCall = computed(() => state.value.phase !== "idle" && state.value.phase !== "ended");
+const callBusy = computed(() => inCall.value || starting.value);
 const participants = useStore($mucCallParticipants);
-/** Other occupants currently in the call. We see our own nick
- *  echoed back in our presence broadcast, so subtract it; the
- *  indicator should read "N others are in this call", and when
- *  it's just us, the regular call button is the right CTA. */
+const normalizedRoomJid = computed(() => normalizeMucCallRoomJid(props.roomJid));
+const callInThisRoom = computed(() => {
+  const current = state.value;
+  return current.phase === "active" &&
+    current.kind === "muc" &&
+    normalizeMucCallRoomJid(current.peer) === normalizedRoomJid.value;
+});
+const busyWithOtherCall = computed(() => inCall.value && !callInThisRoom.value);
+/** Occupants currently in the call, including our own nick when
+ *  the MUC reflects our active Muji presence. The header count must
+ *  match the sidebar count so the same room doesn't appear to have
+ *  different call state depending on where the user looks. */
 const participantCount = computed(() => {
-  const all = participants.value[props.roomJid] ?? [];
-  const selfNick = connectionStore.session?.username;
-  return all.filter((n) => n !== selfNick).length;
+  return (participants.value[normalizedRoomJid.value] ?? []).length;
 });
 
 function getSender(): RawIqSender | null {
@@ -39,25 +50,30 @@ function getSender(): RawIqSender | null {
   return (client?.xmpp as RawIqSender | undefined) ?? null;
 }
 
+function getExpectedMixerJid(): string | undefined {
+  const accountJid = connectionStore.session?.jid;
+  return accountJid ? `calls.${jidDomain(accountJid)}` : undefined;
+}
+
 async function startCall(media: CallMedia): Promise<void> {
-  if (inCall.value) return;
-  const sender = getSender();
-  if (!sender) return;
+  // Group call: the SFU mixer (`calls.<server-domain>`) mints
+  // the room-scoped LiveKit token via a XEP-0272 Muji-bearing
+  // Jingle session-initiate, publishes active Muji presence, then
+  // flips the store to `active` so the overlay's LiveKit connect
+  // only starts after the room-visible call indicator is valid.
   // Our MUC nick is the session username — that's also what
-  // `joinRoom` registered when this user entered the channel, so
-  // it's the resource we'll use on the XEP-0272 `<muji/>` presence.
-  const selfNick = connectionStore.session?.username ?? undefined;
-  try {
-    // Group call: the SFU mixer (`calls.<server-domain>`) mints
-    // the room-scoped LiveKit token via a XEP-0272 Muji-bearing
-    // Jingle session-initiate, the store flips to `active`, and
-    // the overlay's LiveKit connect kicks in. `beginMucCall` then
-    // updates our MUC presence with the `<muji/>` extension so
-    // other occupants see the "N in call" indicator.
-    await beginMucCall(sender, props.roomJid, media, selfNick);
-  } catch (err) {
-    reportCallError(err);
-  }
+  // `joinRoom` registered when this user entered the channel.
+  await startMucCallAction({
+    roomJid: props.roomJid,
+    media,
+    isBusy: () => callBusy.value,
+    setStarting: (next) => {
+      starting.value = next;
+    },
+    getSender,
+    getSelfNick: () => connectionStore.session?.username ?? undefined,
+    getExpectedMixerJid,
+  });
 }
 </script>
 
@@ -65,26 +81,26 @@ async function startCall(media: CallMedia): Promise<void> {
   <div class="flex items-center gap-1.5">
     <button
       class="chat-icon-button chat-icon-button--md transition-all duration-200"
-      :class="inCall
+      :class="callBusy
         ? 'text-muted-foreground opacity-40 cursor-not-allowed'
         : 'text-muted-foreground hover:bg-muted hover:text-foreground'"
       type="button"
       title="Voice call in this channel"
       aria-label="Start voice call in this channel"
-      :disabled="inCall"
+      :disabled="callBusy"
       @click="startCall({ audio: true, video: false })"
     >
       <Phone class="w-3.5 h-3.5" />
     </button>
     <button
       class="chat-icon-button chat-icon-button--md transition-all duration-200"
-      :class="inCall
+      :class="callBusy
         ? 'text-muted-foreground opacity-40 cursor-not-allowed'
         : 'text-muted-foreground hover:bg-muted hover:text-foreground'"
       type="button"
       title="Video call in this channel"
       aria-label="Start video call in this channel"
-      :disabled="inCall"
+      :disabled="callBusy"
       @click="startCall({ audio: true, video: true })"
     >
       <Video class="w-3.5 h-3.5" />
@@ -96,11 +112,12 @@ async function startCall(media: CallMedia): Promise<void> {
          affordance without us having to design a separate "join
          existing call" surface. -->
     <button
-      v-if="participantCount > 0 && !inCall"
+      v-if="participantCount > 0"
       class="chat-icon-button chat-icon-button--md text-primary hover:bg-primary/10 ring-1 ring-primary/30 motion-safe:animate-pulse"
       type="button"
       :title="`${participantCount} ${participantCount === 1 ? 'person is' : 'people are'} in this channel's call`"
       :aria-label="`Join the live call (${participantCount} in call)`"
+      :disabled="callBusy || busyWithOtherCall || callInThisRoom"
       @click="startCall({ audio: true, video: false })"
     >
       <Phone class="w-3.5 h-3.5" />

--- a/chat/src/components/chat/ChatMobileDrawers.vue
+++ b/chat/src/components/chat/ChatMobileDrawers.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { useStore } from "@nanostores/vue";
-import { $mucCallParticipants } from "@/lib/calls/muc-call-presence";
+import {
+  $mucCallParticipants,
+  mucCallParticipantCounts,
+} from "@/lib/calls/muc-call-presence";
 import WaddlesSidebar from "@/components/chat/WaddlesSidebar.vue";
 import TopicsPanel from "@/components/chat/TopicsPanel.vue";
 import DmPanel from "@/components/chat/DmPanel.vue";
@@ -59,11 +62,7 @@ function selectCommunitySurface(surface: "feed" | "stories" | "events") {
 // the same "call ongoing" chip.
 const mucCallParticipantsStore = useStore($mucCallParticipants);
 const callParticipantCounts = computed<Record<string, number>>(() => {
-  const counts: Record<string, number> = {};
-  for (const [jid, nicks] of Object.entries(mucCallParticipantsStore.value)) {
-    counts[jid] = nicks.length;
-  }
-  return counts;
+  return mucCallParticipantCounts(mucCallParticipantsStore.value);
 });
 
 const drawerExtensionRoutes = computed(() =>

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from "vue";
 import { useStore } from "@nanostores/vue";
-import { $mucCallParticipants } from "@/lib/calls/muc-call-presence";
+import {
+  $mucCallParticipants,
+  mucCallParticipantCounts,
+} from "@/lib/calls/muc-call-presence";
 import HomeDashboard from "@/components/chat/HomeDashboard.vue";
 import ThreadsView from "@/components/chat/ThreadsView.vue";
 import FeedPane from "@/components/community/FeedPane.vue";
@@ -149,11 +152,7 @@ const homeDashboardProps = computed(() => buildHomeDashboardProps({
  */
 const mucCallParticipantsStore = useStore($mucCallParticipants);
 const callParticipantCounts = computed<Record<string, number>>(() => {
-  const counts: Record<string, number> = {};
-  for (const [jid, nicks] of Object.entries(mucCallParticipantsStore.value)) {
-    counts[jid] = nicks.length;
-  }
-  return counts;
+  return mucCallParticipantCounts(mucCallParticipantsStore.value);
 });
 
 const contentPaneClass = computed(() => {

--- a/chat/src/components/chat/TopicsPanel.vue
+++ b/chat/src/components/chat/TopicsPanel.vue
@@ -5,6 +5,10 @@ import { isForumChannel as detectForumChannel } from "@/lib/channel-types";
 import type { ChannelSummary, SpaceSummary } from "@/lib/chat-types";
 import type { ChannelThreadInboxEntry } from "@/channels/inbox";
 import { groupChannelsBySpace } from "@/lib/channel-grouping";
+import {
+  callParticipantCountForChannel,
+  collapsedGroupBadgeModel,
+} from "@/lib/calls/muc-call-indicators";
 import type { MemberLoadState } from "@/waddles/directory";
 import Skeleton from "@/components/ui/Skeleton.vue";
 
@@ -54,16 +58,11 @@ const props = defineProps<{
  * same heuristic `hasActivity()` uses for the green dot.
  */
 function callParticipantCount(channel: ChannelSummary): number {
-  if (!props.callParticipantCounts) return 0;
-  if (channel.jid) {
-    return props.callParticipantCounts[channel.jid] ?? 0;
-  }
-  for (const jid of props.activeChannelJids) {
-    if (jid.startsWith(channel.id + "@") || jid.includes(channel.id)) {
-      return props.callParticipantCounts[jid] ?? 0;
-    }
-  }
-  return 0;
+  return callParticipantCountForChannel(
+    channel,
+    props.callParticipantCounts,
+    props.activeChannelJids,
+  );
 }
 
 function hasActivity(channelId: string): boolean {
@@ -91,9 +90,14 @@ function groupUnreadSummary(group: (typeof channelGroups.value)[number]) {
       unread: summary.unread + unread.unread,
       mentions: summary.mentions + unread.mentions,
       hasActivity: summary.hasActivity || hasActivity(channel.id),
+      callCount: summary.callCount + callParticipantCount(channel),
     }),
-    { unread: 0, mentions: 0, hasActivity: false },
+    { unread: 0, mentions: 0, hasActivity: false, callCount: 0 },
   );
+}
+
+function groupBadgeModel(group: (typeof channelGroups.value)[number]) {
+  return collapsedGroupBadgeModel(groupUnreadSummary(group));
 }
 
 function groupToggleLabel(group: (typeof channelGroups.value)[number]) {
@@ -371,17 +375,25 @@ watch(
                      get one too. -->
                 <template v-if="isGroupCollapsed(group.id)">
                   <span
-                    v-if="groupUnreadSummary(group).mentions > 0"
+                    v-if="groupBadgeModel(group).callCount > 0"
+                    class="chat-badge-glow--primary type-count-badge inline-flex min-w-[18px] h-[18px] px-1 items-center justify-center gap-0.5 rounded-full bg-primary/15 text-primary ring-1 ring-primary/30"
+                    aria-hidden="true"
+                  >
+                    <Phone class="w-3 h-3" />
+                    <span class="type-numeric leading-none">{{ groupBadgeModel(group).callCount }}</span>
+                  </span>
+                  <span
+                    v-if="groupBadgeModel(group).notification?.kind === 'mentions'"
                     class="chat-badge-glow--mention type-count-badge inline-flex min-w-[18px] h-[18px] px-1 items-center justify-center rounded-full bg-destructive text-destructive-foreground"
                     aria-hidden="true"
-                  >{{ groupUnreadSummary(group).mentions }}</span>
+                  >{{ groupBadgeModel(group).notification?.count }}</span>
                   <span
-                    v-else-if="groupUnreadSummary(group).unread > 0"
+                    v-else-if="groupBadgeModel(group).notification?.kind === 'unread'"
                     class="chat-badge-glow--primary type-count-badge inline-flex min-w-[18px] h-[18px] px-1 items-center justify-center rounded-full bg-primary text-primary-foreground"
                     aria-hidden="true"
-                  >{{ groupUnreadSummary(group).unread }}</span>
+                  >{{ groupBadgeModel(group).notification?.count }}</span>
                   <span
-                    v-else-if="groupUnreadSummary(group).hasActivity"
+                    v-else-if="groupBadgeModel(group).notification?.kind === 'activity'"
                     class="w-2 h-2 rounded-full bg-primary shadow-[0_0_6px_var(--glow-strong)]"
                     aria-hidden="true"
                   />

--- a/chat/src/lib/calls/call-effects.ts
+++ b/chat/src/lib/calls/call-effects.ts
@@ -1,5 +1,14 @@
 import { outboundCalls, type CallWireSender } from "./outbound";
-import { reportCallError } from "./call-store";
+import {
+  acceptIncomingTieBreakPropose,
+  failCallState,
+  reportCallError,
+  scheduleSessionAcceptTimeout,
+} from "./call-store";
+import {
+  incomingProposeWinsTieBreak,
+  isSameCallBareJid,
+} from "./tie-break";
 import type { CallEvent, CallState } from "./types";
 
 /**
@@ -35,12 +44,64 @@ export async function handleCallEventSideEffect(
   sender: CallWireSender,
   ourFullJid: string,
 ): Promise<void> {
-  // Busy-reject: a propose arriving while we're mid-call (outgoing,
-  // incoming, or active) is silently dropped by the reducer. Without
-  // an explicit reject the proposer sees no response and rings until
-  // their timeout, so respond with reject addressed to their full
-  // JID (the `from` on inbound propose is the proposer's full JID
-  // because the server stamps it).
+  // Simultaneous propose tie-break (XEP-0353 §Tie Breaking). This
+  // is specific to both resources proposing a call to the same bare
+  // peer at the same time; unrelated callers still take the normal
+  // busy-reject path below.
+  if (
+    event.kind === "propose" &&
+    prev.phase === "outgoing" &&
+    isSameCallBareJid(event.from, prev.to)
+  ) {
+    try {
+      if (
+        incomingProposeWinsTieBreak(
+          event.sid,
+          prev.sid,
+          event.from,
+          ourFullJid,
+        )
+      ) {
+        await outboundCalls.retractTieBreak(sender, event.from, prev.sid);
+        acceptIncomingTieBreakPropose(event);
+      } else {
+        await outboundCalls.rejectTieBreak(sender, event.from, event.sid);
+      }
+    } catch (err) {
+      reportCallError(err);
+    }
+    return;
+  }
+
+  if (
+    event.kind === "propose" &&
+    prev.phase === "active" &&
+    prev.kind === "dm" &&
+    isSameCallBareJid(event.from, prev.peer)
+  ) {
+    try {
+      await outboundCalls.finishMigrated(sender, event.from, prev.sid, event.sid);
+      await outboundCalls.proceed(sender, event.from, event.sid);
+      acceptIncomingTieBreakPropose(event);
+      // The old Jingle session may already be orphaned on another
+      // resource, so do not let its IQ round-trip block the XEP-0353
+      // migration markers that keep both users' devices in sync.
+      void outboundCalls
+        .sessionTerminate(sender, prev.peer, prev.sid, "expired")
+        .catch((err) => reportCallError(err));
+    } catch (err) {
+      failCallState(err, prev.sid);
+    }
+    return;
+  }
+
+  // Busy-reject: a propose arriving while we're mid-call (incoming
+  // or active, plus outgoing calls against a different peer) is
+  // silently dropped by the reducer. Without an explicit reject the
+  // proposer sees no response and rings until their timeout, so
+  // respond with reject addressed to their full JID (the `from` on
+  // inbound propose is the proposer's full JID because the server
+  // stamps it).
   if (
     event.kind === "propose" &&
     prev.phase !== "idle" &&
@@ -66,8 +127,9 @@ export async function handleCallEventSideEffect(
         event.sid,
         prev.media,
       );
+      scheduleSessionAcceptTimeout(sender, event.from, event.sid);
     } catch (err) {
-      reportCallError(err);
+      failCallState(err, event.sid);
     }
     return;
   }
@@ -86,13 +148,12 @@ export async function handleCallEventSideEffect(
       await outboundCalls.sessionAccept(
         sender,
         event.from,
-        event.from,
         ourFullJid,
         event.sid,
         event.media,
       );
     } catch (err) {
-      reportCallError(err);
+      failCallState(err, event.sid);
     }
     return;
   }

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -1,7 +1,14 @@
 import { atom } from "nanostores";
 import { outboundCalls, type CallWireSender } from "./outbound";
 import type { CallEvent, CallMedia, CallState, LiveKitJoin } from "./types";
-import { awaitPreparingEcho } from "./muc-call-presence";
+import {
+  awaitPreparingEcho,
+  awaitNoOtherPreparing,
+  cancelMucCallPreparationWaiters,
+  clearMucCallParticipant,
+  normalizeMucCallRoomJid,
+} from "./muc-call-presence";
+import { barePeerJid } from "../xmpp/jid";
 
 /**
  * XEP-0272 §Joining MUST: a client emitting a preparing presence
@@ -12,42 +19,110 @@ import { awaitPreparingEcho } from "./muc-call-presence";
  * from hanging indefinitely on a missed echo.
  */
 const PREPARING_ECHO_TIMEOUT_MS = 2000;
+const PREPARING_PEERS_TIMEOUT_MS = 2000;
 
 /**
  * XEP-0166 §6.3 + XEP-0272 separate-IQ accept: the server's
  * session-accept arrives as an inbound `<iq type='set'>` after
  * the empty IQ-result ack of our session-initiate. We register
- * a resolver keyed by sid (= room JID per Waddle convention)
+ * a resolver keyed by the per-attempt Jingle sid before sending,
  * BEFORE sending the initiate, then await it after the initiate's
  * empty ack returns. 10s timeout covers slow SFU token mints.
  */
 const MUJI_ACCEPT_TIMEOUT_MS = 10_000;
 
 /**
- * Pending Muji session-accept resolvers keyed by sid (= room JID).
+ * Pending Muji session-accept resolvers keyed by per-attempt Jingle sid.
  * The `on_call` dispatcher routes an inbound
  * `CallEventKind::SessionAccept` whose sid matches a registered
  * entry to the resolver instead of running the 1:1 reducer — Muji
  * accepts are owned by `beginMucCall`'s Promise chain, not the
  * `$callState` reducer.
  */
-const pendingMujiAccepts = new Map<
-  string,
-  { resolve: (join: LiveKitJoin) => void; reject: (err: Error) => void; timer: ReturnType<typeof setTimeout> }
->();
+type PendingMujiAccept = {
+  roomJid: string;
+  attemptId: string;
+  expectedFrom?: string;
+  resolve: (join: LiveKitJoin) => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+};
 
-function registerPendingMujiAccept(sid: string): Promise<LiveKitJoin> {
+const pendingMujiAccepts = new Map<string, PendingMujiAccept>();
+
+function rejectPendingMujiAccept(
+  sid: string,
+  err: Error,
+  attemptId?: string,
+): void {
+  const pending = pendingMujiAccepts.get(sid);
+  if (!pending) return;
+  if (attemptId && pending.attemptId !== attemptId) return;
+  pendingMujiAccepts.delete(sid);
+  clearTimeout(pending.timer);
+  pending.reject(err);
+}
+
+function rejectAllPendingMujiAccepts(err: Error): void {
+  for (const [sid, pending] of pendingMujiAccepts) {
+    pendingMujiAccepts.delete(sid);
+    clearTimeout(pending.timer);
+    pending.reject(err);
+  }
+}
+
+function normalizeExpectedMujiAcceptFrom(jid?: string | null): string | undefined {
+  const bare = barePeerJid(jid ?? "").toLowerCase();
+  return bare || undefined;
+}
+
+function registerPendingMujiAccept(
+  sid: string,
+  roomJid: string,
+  attemptId: string,
+  expectedFrom?: string | null,
+): Promise<LiveKitJoin> {
   return new Promise<LiveKitJoin>((resolve, reject) => {
-    const timer = setTimeout(() => {
+    const previous = pendingMujiAccepts.get(sid);
+    if (previous) {
       pendingMujiAccepts.delete(sid);
+      clearTimeout(previous.timer);
+      previous.reject(
+        new Error("Muji session-accept wait replaced by a new call attempt"),
+      );
+    }
+    let entry: PendingMujiAccept;
+    const timer = setTimeout(() => {
+      if (pendingMujiAccepts.get(sid) === entry) {
+        pendingMujiAccepts.delete(sid);
+      }
       reject(
         new Error(
           `Muji session-accept did not arrive within ${MUJI_ACCEPT_TIMEOUT_MS}ms`,
         ),
       );
     }, MUJI_ACCEPT_TIMEOUT_MS);
-    pendingMujiAccepts.set(sid, { resolve, reject, timer });
+    entry = {
+      roomJid,
+      attemptId,
+      expectedFrom: normalizeExpectedMujiAcceptFrom(expectedFrom),
+      resolve,
+      reject,
+      timer,
+    };
+    pendingMujiAccepts.set(sid, entry);
   });
+}
+
+function isExpectedMujiAccept(event: CallEvent, pending: {
+  roomJid: string;
+  expectedFrom?: string;
+}): boolean {
+  if (event.kind !== "session-accept") return false;
+  const eventRoom = normalizeMucCallRoomJid(event.join.room);
+  if (eventRoom !== pending.roomJid) return false;
+  if (!pending.expectedFrom) return true;
+  return barePeerJid(event.from).toLowerCase() === pending.expectedFrom;
 }
 
 /**
@@ -60,6 +135,7 @@ function tryFulfillMujiAccept(event: CallEvent): boolean {
   if (event.kind !== "session-accept") return false;
   const pending = pendingMujiAccepts.get(event.sid);
   if (!pending) return false;
+  if (!isExpectedMujiAccept(event, pending)) return true;
   pendingMujiAccepts.delete(event.sid);
   clearTimeout(pending.timer);
   pending.resolve(event.join);
@@ -125,7 +201,13 @@ export function reduceCallState(current: CallState, event: CallEvent): CallState
         "sid" in current &&
         current.sid === event.sid
       ) {
-        return { phase: "ended", sid: event.sid, reason: event.kind };
+        return {
+          phase: "ended",
+          sid: event.sid,
+          reason: event.tieBreak && event.reason === "expired"
+            ? "expired"
+            : event.kind,
+        };
       }
       return current;
     case "session-initiate":
@@ -142,6 +224,7 @@ export function reduceCallState(current: CallState, event: CallEvent): CallState
         media: event.media,
         join: event.join,
         kind: "dm",
+        initiator: event.from,
       };
     case "session-accept":
       // Initiator receives the Jingle session-accept after the
@@ -151,7 +234,15 @@ export function reduceCallState(current: CallState, event: CallEvent): CallState
       if (current.phase !== "outgoing" || current.sid !== event.sid) {
         return current;
       }
-      return {
+      return current.initiator ? {
+        phase: "active",
+        peer: event.from,
+        sid: event.sid,
+        media: event.media,
+        join: event.join,
+        kind: "dm",
+        initiator: current.initiator,
+      } : {
         phase: "active",
         peer: event.from,
         sid: event.sid,
@@ -171,7 +262,7 @@ export function reduceCallState(current: CallState, event: CallEvent): CallState
         return {
           phase: "ended",
           sid: event.sid,
-          reason: event.kind === "session-terminate" ? event.reason : null,
+          reason: event.kind === "session-terminate" ? event.reason : event.reason ?? null,
         };
       }
       return current;
@@ -186,17 +277,18 @@ export function reduceCallState(current: CallState, event: CallEvent): CallState
  *
  * 1. Clear `$lastCallError` on any non-trivial transition so an
  *    error from a prior call doesn't linger over a fresh one.
- * 2. Cancel the outgoing-ring auto-retract timer when leaving the
- *    `outgoing` phase. Done here, not in the reducer, because
+ * 2. Cancel the outgoing-ring auto-retract timer when the peer
+ *    proceeds or when leaving the `outgoing` phase. Done here, not
+ *    in the reducer, because
  *    `setTimeout`/`clearTimeout` are global-state side-effects.
  */
 export function applyCallEvent(event: CallEvent): void {
   // Route inbound Muji session-accept stanzas to the pending
   // `beginMucCall` Promise BEFORE the 1:1 reducer sees them. A
-  // Muji accept has its sid equal to the room JID and arrives
-  // from the SFU mixer (`calls.<domain>`); the 1:1 reducer would
-  // mis-interpret it as a peer accepting a JMI ring. Consuming
-  // here keeps the two flows cleanly separated.
+  // Muji accept carries a per-attempt sid and arrives from the SFU
+  // mixer (`calls.<domain>`). The 1:1 reducer would mis-interpret
+  // it as a peer accepting a JMI ring. Consuming here keeps the two
+  // flows cleanly separated.
   if (tryFulfillMujiAccept(event)) {
     return;
   }
@@ -204,13 +296,17 @@ export function applyCallEvent(event: CallEvent): void {
   const next = reduceCallState(before, event);
   if (next !== before) {
     $lastCallError.set(null);
-    // Any transition out of outgoing cancels the auto-retract timer:
-    // proceed→outgoing stays outgoing (timer keeps running), but the
-    // moment session-accept lands or the call is rejected/retracted
-    // the slot moves and the timer is moot.
+    // Any transition out of outgoing cancels the auto-retract timer.
     if (before.phase === "outgoing" && next.phase !== "outgoing") {
-      cancelOutgoingTimeout();
+      cancelCallTimers();
     }
+  }
+  if (
+    before.phase === "outgoing" &&
+    event.kind === "proceed" &&
+    event.sid === before.sid
+  ) {
+    cancelOutgoingTimeout();
   }
   $callState.set(next);
 }
@@ -220,8 +316,38 @@ export function applyCallEvent(event: CallEvent): void {
  * the `ended` state (the toast closes, the user clicks dismiss).
  */
 export function clearCallState(): void {
-  cancelOutgoingTimeout();
+  cancelCallTimers();
+  rejectAllPendingMujiAccepts(
+    new Error("Muji session-accept wait cancelled while clearing call state"),
+  );
+  const current = $callState.get();
+  if (current.phase === "muc-pending") {
+    cancelMucCallPreparationWaiters(
+      current.peer,
+      current.selfNick,
+      new Error("Muji preparing wait cancelled while clearing call state"),
+    );
+  }
   $callState.set({ phase: "idle" });
+  $lastCallError.set(null);
+}
+
+export function failCallState(err: unknown, sid: string): void {
+  cancelCallTimers();
+  $callState.set({ phase: "ended", sid, reason: "error" });
+  reportCallError(err);
+}
+
+export function acceptIncomingTieBreakPropose(
+  event: Extract<CallEvent, { kind: "propose" }>,
+): void {
+  cancelCallTimers();
+  $callState.set({
+    phase: "incoming",
+    from: event.from,
+    sid: event.sid,
+    media: event.media,
+  });
   $lastCallError.set(null);
 }
 
@@ -231,8 +357,18 @@ export function clearCallState(): void {
  * overlay. The wire send is the caller's responsibility — keep
  * the store side-effect free for clean unit testing.
  */
-export function beginOutgoingCall(to: string, sid: string, media: CallMedia): void {
-  $callState.set({ phase: "outgoing", to, sid, media });
+export function beginOutgoingCall(
+  to: string,
+  sid: string,
+  media: CallMedia,
+  initiator?: string,
+): void {
+  cancelCallTimers();
+  $callState.set(
+    initiator
+      ? { phase: "outgoing", to, sid, media, initiator }
+      : { phase: "outgoing", to, sid, media },
+  );
   $lastCallError.set(null);
 }
 
@@ -243,8 +379,11 @@ export function beginOutgoingCall(to: string, sid: string, media: CallMedia): vo
  * when the responder is offline / has notifications muted.
  */
 const OUTGOING_TIMEOUT_MS = 45_000;
+const SESSION_ACCEPT_TIMEOUT_MS = 45_000;
 
 let outgoingTimer: ReturnType<typeof setTimeout> | null = null;
+let sessionAcceptTimer: ReturnType<typeof setTimeout> | null = null;
+let sessionAcceptTimeoutMs = SESSION_ACCEPT_TIMEOUT_MS;
 
 /**
  * Schedule the auto-retract for the most recent `beginOutgoingCall`.
@@ -279,11 +418,61 @@ export function scheduleOutgoingTimeout(
   }, timeoutMs);
 }
 
+/**
+ * After a responder sends XEP-0353 `<proceed/>`, the initiator's
+ * ringing timeout is cancelled because the peer did answer. The
+ * call is still not active, though, until XEP-0166
+ * `<session-accept/>` arrives. This second timeout covers the gap
+ * where session-initiate was sent and acked, but the accept never
+ * comes back.
+ */
+export function scheduleSessionAcceptTimeout(
+  sender: CallWireSender,
+  peerFullJid: string,
+  sid: string,
+  timeoutMs: number = sessionAcceptTimeoutMs,
+): void {
+  cancelSessionAcceptTimeout();
+  sessionAcceptTimer = setTimeout(() => {
+    sessionAcceptTimer = null;
+    const s = $callState.get();
+    if (s.phase !== "outgoing" || s.sid !== sid) return;
+    void outboundCalls
+      .sessionTerminate(sender, peerFullJid, sid, "timeout")
+      .catch((err) => reportCallError(err));
+    $callState.set({
+      phase: "ended",
+      sid,
+      reason: "timeout",
+    });
+  }, timeoutMs);
+}
+
+export function setSessionAcceptTimeoutMsForTests(timeoutMs: number): () => void {
+  const previous = sessionAcceptTimeoutMs;
+  sessionAcceptTimeoutMs = timeoutMs;
+  return () => {
+    sessionAcceptTimeoutMs = previous;
+  };
+}
+
 function cancelOutgoingTimeout(): void {
   if (outgoingTimer) {
     clearTimeout(outgoingTimer);
     outgoingTimer = null;
   }
+}
+
+function cancelSessionAcceptTimeout(): void {
+  if (sessionAcceptTimer) {
+    clearTimeout(sessionAcceptTimer);
+    sessionAcceptTimer = null;
+  }
+}
+
+function cancelCallTimers(): void {
+  cancelOutgoingTimeout();
+  cancelSessionAcceptTimeout();
 }
 
 /**
@@ -330,7 +519,7 @@ export async function tearDownActiveCall(
   sender: CallWireSender | null,
   reason: "success" | "gone",
 ): Promise<void> {
-  cancelOutgoingTimeout();
+  cancelCallTimers();
   const s = $callState.get();
   if (sender) {
     try {
@@ -372,10 +561,12 @@ export async function tearDownActiveCall(
                 );
               } catch (err) {
                 reportCallError(err);
+              } finally {
+                clearMucCallParticipant(s.peer, s.selfNick);
               }
             }
             try {
-              await sendMujiSessionTerminate(raw, s.peer);
+              await sendMujiSessionTerminate(raw, s.peer, s.sid);
             } catch (err) {
               reportCallError(err);
             }
@@ -386,6 +577,44 @@ export async function tearDownActiveCall(
           break;
         case "incoming":
           await outboundCalls.reject(sender, s.from, s.sid);
+          break;
+        case "muc-pending":
+          rejectPendingMujiAccept(
+            s.sid,
+            new Error("Muji session-accept wait cancelled while clearing call state"),
+            s.attemptId,
+          );
+          cancelMucCallPreparationWaiters(
+            s.peer,
+            s.selfNick,
+            new Error("Muji preparing wait cancelled while clearing call state"),
+          );
+          $callState.set({ phase: "idle" });
+          {
+            const raw = sender as RawIqSender;
+            if (s.selfNick && raw.update_muji_presence) {
+              try {
+                await raw.update_muji_presence(
+                  s.peer,
+                  s.selfNick,
+                  false,
+                  false,
+                  false,
+                );
+              } catch (err) {
+                reportCallError(err);
+              } finally {
+                clearMucCallParticipant(s.peer, s.selfNick);
+              }
+            }
+            if (s.activePresencePublished) {
+              try {
+                await sendMujiSessionTerminate(raw, s.peer, s.sid);
+              } catch (err) {
+                reportCallError(err);
+              }
+            }
+          }
           break;
         default:
           break;
@@ -421,12 +650,13 @@ export type RawIqSender = {
    * §6.3 and surfaced through the `on_call` callback. The caller
    * (see `sendMujiSessionInitiate` below) registers a pending
    * resolver before invoking this method.
-   */
+  */
   send_muji_session_initiate?: (
     room_jid: string,
+    sid: string,
     video: boolean,
   ) => Promise<void>;
-  send_muji_session_terminate?: (room_jid: string) => Promise<void>;
+  send_muji_session_terminate?: (room_jid: string, sid: string) => Promise<void>;
   update_muji_presence?: (
     room_jid: string,
     nick: string,
@@ -439,7 +669,7 @@ export type RawIqSender = {
 /**
  * XEP-0166 §6.3 + XEP-0272 separate-IQ accept flow:
  *
- *   1. Register a pending Muji-accept resolver keyed by `roomJid`
+ *   1. Register a pending Muji-accept resolver keyed by `attemptId`
  *      BEFORE sending so an inbound session-accept can't beat us
  *      to the table.
  *   2. Send the session-initiate IQ via the wasm bridge. The
@@ -451,27 +681,69 @@ export type RawIqSender = {
 async function sendMujiSessionInitiate(
   sender: RawIqSender,
   roomJid: string,
+  attemptId: string,
   video: boolean,
+  expectedMixerJid?: string | null,
 ): Promise<LiveKitJoin> {
   if (!sender.send_muji_session_initiate) {
     throw new Error(
       "wasm client does not expose send_muji_session_initiate; rebuild the wasm bundle",
     );
   }
-  const acceptWait = registerPendingMujiAccept(roomJid);
+  const acceptWait = registerPendingMujiAccept(
+    attemptId,
+    roomJid,
+    attemptId,
+    expectedMixerJid,
+  );
+  acceptWait.catch(() => undefined);
   try {
-    await sender.send_muji_session_initiate(roomJid, video);
+    await sender.send_muji_session_initiate(roomJid, attemptId, video);
   } catch (err) {
     // Roll back the pending registration so a future call attempt
     // doesn't resolve against this aborted one.
-    const pending = pendingMujiAccepts.get(roomJid);
-    if (pending) {
-      pendingMujiAccepts.delete(roomJid);
-      clearTimeout(pending.timer);
-    }
+    rejectPendingMujiAccept(
+      attemptId,
+      err instanceof Error ? err : new Error(String(err)),
+      attemptId,
+    );
     throw err;
   }
   return await acceptWait;
+}
+
+async function rollbackMucCallSetup(
+  sender: RawIqSender,
+  roomJid: string,
+  selfNick: string,
+  terminateSfu: boolean,
+  sid?: string,
+): Promise<void> {
+  if (sender.update_muji_presence) {
+    try {
+      await sender.update_muji_presence(
+        roomJid,
+        selfNick,
+        false,
+        false,
+        false,
+      );
+    } catch (err) {
+      reportCallError(err);
+    } finally {
+      clearMucCallParticipant(roomJid, selfNick);
+    }
+  }
+  if (terminateSfu) {
+    try {
+      if (!sid) {
+        throw new Error("Cannot terminate Muji session without the active Jingle sid");
+      }
+      await sendMujiSessionTerminate(sender, roomJid, sid);
+    } catch (err) {
+      reportCallError(err);
+    }
+  }
 }
 
 /**
@@ -482,6 +754,7 @@ async function sendMujiSessionInitiate(
 async function sendMujiSessionTerminate(
   sender: RawIqSender | CallWireSender,
   roomJid: string,
+  sid: string,
 ): Promise<void> {
   const rawSender = sender as RawIqSender;
   if (!rawSender.send_muji_session_terminate) {
@@ -489,7 +762,32 @@ async function sendMujiSessionTerminate(
       "wasm client does not expose send_muji_session_terminate; rebuild the wasm bundle",
     );
   }
-  await rawSender.send_muji_session_terminate(roomJid);
+  await rawSender.send_muji_session_terminate(roomJid, sid);
+}
+
+function mucSetupStillPending(
+  roomJid: string,
+  selfNick: string,
+  attemptId: string,
+): boolean {
+  const state = $callState.get();
+  return (
+    state.phase === "muc-pending" &&
+    state.peer === roomJid &&
+    state.sid === attemptId &&
+    state.selfNick === selfNick &&
+    state.attemptId === attemptId
+  );
+}
+
+function assertMucSetupStillPending(
+  roomJid: string,
+  selfNick: string,
+  attemptId: string,
+): void {
+  if (!mucSetupStillPending(roomJid, selfNick, attemptId)) {
+    throw new Error(`Muji call setup for ${roomJid} was cancelled`);
+  }
 }
 
 /**
@@ -498,17 +796,16 @@ async function sendMujiSessionTerminate(
  *
  *   1. Emit `<muji><preparing/></muji>` MUC presence so other
  *      occupants know we are about to join (the XEP MUSTs this).
- *   2. Send the Jingle session-initiate to the SFU mixer.
- *   3. Once the session-accept arrives with a LiveKit token,
- *      re-emit `<muji>` with `<content/>` children so we move
- *      from "preparing" to "in call" on the wire.
+ *   2. Wait for our preparing echo and for any other preparing
+ *      occupants to finish, then publish active content presence.
+ *   3. Send the Jingle session-initiate to the SFU mixer and wait
+ *      for the separate session-accept carrying LiveKit credentials.
  *   4. Transition `$callState` to `active`.
  *
  * XEP-0272's MUST about waiting for the MUC rebroadcast of the
- * preparing presence is satisfied implicitly: the session-initiate
- * IQ round-trip takes longer than the in-process presence echo
- * back from the local MUC, so by the time we move to step 3 the
- * room has already reflected step 1.
+ * preparing presence is a setup precondition: if the echo or active
+ * Muji publication fails, setup rolls back and the local call never
+ * becomes active.
  *
  * No propose/proceed JMI round-trip — MUC calls are
  * presence-discovered, so there's no responder to ring.
@@ -518,67 +815,136 @@ export async function beginMucCall(
   roomJid: string,
   media: CallMedia,
   selfNick?: string,
+  expectedMixerJid?: string | null,
 ): Promise<void> {
-  // Step 1 — preparing presence (XEP-0272 §Joining two-phase flow).
-  // Register the echo waiter BEFORE emitting so a fast MUC echo
-  // can't fire before our listener is ready. The await below
-  // blocks until the MUC rebroadcasts our preparing presence (or
-  // the 2s safety timeout fires). Best-effort: a stale wasm
-  // bundle without `update_muji_presence` skips the two-phase
-  // shape entirely; the call still works but isn't strict-XEP.
-  if (selfNick && sender.update_muji_presence) {
-    const echoWait = awaitPreparingEcho(
-      roomJid,
-      selfNick,
-      PREPARING_ECHO_TIMEOUT_MS,
-    );
-    try {
-      await sender.update_muji_presence(
-        roomJid,
-        selfNick,
-        false, // active (no <content/> yet)
-        true, // preparing
-        false, // video — irrelevant in preparing phase
-      );
-    } catch (err) {
-      reportCallError(err);
-    }
-    // XEP-0272 §Joining: "The client MUST then wait until the MUC
-    // rebroadcasts its presence message". We satisfy the literal
-    // MUST by holding here for the echo.
-    await echoWait;
+  const normalizedRoomJid = normalizeMucCallRoomJid(roomJid);
+  if (!normalizedRoomJid) {
+    throw new Error("Cannot start a group call without a room JID");
   }
+  if (!selfNick) {
+    throw new Error("Cannot start a group call before MUC presence has a nick");
+  }
+  if (!sender.update_muji_presence) {
+    throw new Error(
+      "wasm client does not expose update_muji_presence; rebuild the wasm bundle",
+    );
+  }
+  const current = $callState.get();
+  if (current.phase !== "idle" && current.phase !== "ended") {
+    throw new Error("Cannot start a group call while another call is active or starting");
+  }
+  const attemptId = crypto.randomUUID();
 
-  // Step 2 — session-initiate. By now the MUC has acknowledged
-  // our preparing presence (per XEP-0272 §Joining MUST), so the
-  // SFU mixer's session-accept arrives in a deterministic order.
-  const join = await sendMujiSessionInitiate(sender, roomJid, media.video);
   $callState.set({
-    phase: "active",
-    peer: roomJid,
-    sid: roomJid,
+    phase: "muc-pending",
+    peer: normalizedRoomJid,
+    sid: attemptId,
     media,
-    join,
     kind: "muc",
     selfNick,
+    attemptId,
   });
   $lastCallError.set(null);
 
-  // Step 3 — content-declaring presence. Other occupants now see
-  // the chip pulse because `<muji>` carries `<content/>` (our
-  // store helper's `is_active` check). Audio is implied; we
-  // advertise video only when the user enabled it.
-  if (selfNick && sender.update_muji_presence) {
-    try {
-      await sender.update_muji_presence(
-        roomJid,
-        selfNick,
-        true, // active
-        false, // preparing
-        media.video, // video
-      );
-    } catch (err) {
-      reportCallError(err);
+  // Step 1 — preparing presence (XEP-0272 §Joining two-phase flow).
+  // Register the echo waiter BEFORE emitting so a fast MUC echo
+  // can't fire before our listener is ready. The await below
+  // blocks until the MUC rebroadcasts our preparing presence; the
+  // timeout rejects and rolls setup back.
+  let echoWait: Promise<void> | null = null;
+  let activePresencePublished = false;
+  try {
+    echoWait = awaitPreparingEcho(
+      normalizedRoomJid,
+      selfNick,
+      PREPARING_ECHO_TIMEOUT_MS,
+    );
+    await sender.update_muji_presence(
+      normalizedRoomJid,
+      selfNick,
+      false, // active (no <content/> yet)
+      true, // preparing
+      false, // video — irrelevant in preparing phase
+    );
+    assertMucSetupStillPending(normalizedRoomJid, selfNick, attemptId);
+    // XEP-0272 §Joining: "The client MUST then wait until the MUC
+    // rebroadcasts its presence message", then wait for other
+    // occupants that had `<preparing/>` in their presence to finish
+    // preparation before we publish contents.
+    await echoWait;
+    assertMucSetupStillPending(normalizedRoomJid, selfNick, attemptId);
+    await awaitNoOtherPreparing(
+      normalizedRoomJid,
+      selfNick,
+      PREPARING_PEERS_TIMEOUT_MS,
+    );
+    assertMucSetupStillPending(normalizedRoomJid, selfNick, attemptId);
+
+    // Step 2 — content-declaring presence. XEP-0272 §Joining says a
+    // client advertises contents in MUC presence before initiating
+    // the corresponding Jingle sessions.
+    await sender.update_muji_presence(
+      normalizedRoomJid,
+      selfNick,
+      true, // active
+      false, // preparing
+      media.video, // video
+    );
+    if (!mucSetupStillPending(normalizedRoomJid, selfNick, attemptId)) {
+      await rollbackMucCallSetup(sender, normalizedRoomJid, selfNick, false, attemptId);
+      throw new Error(`Muji call setup for ${normalizedRoomJid} was cancelled`);
     }
+    activePresencePublished = true;
+    $callState.set({
+      phase: "muc-pending",
+      peer: normalizedRoomJid,
+      sid: attemptId,
+      media,
+      kind: "muc",
+      selfNick,
+      attemptId,
+      activePresencePublished: true,
+    });
+
+    // Step 3 — session-initiate. The SFU mixer's session-accept
+    // arrives after the active Muji presence is already room-visible.
+    const join = await sendMujiSessionInitiate(
+      sender,
+      normalizedRoomJid,
+      attemptId,
+      media.video,
+      expectedMixerJid,
+    );
+    assertMucSetupStillPending(normalizedRoomJid, selfNick, attemptId);
+
+    $callState.set({
+      phase: "active",
+      peer: normalizedRoomJid,
+      sid: attemptId,
+      media,
+      join,
+      kind: "muc",
+      selfNick,
+    });
+    $lastCallError.set(null);
+  } catch (err) {
+    echoWait?.catch(() => undefined);
+    const pending = $callState.get();
+    if (
+      pending.phase === "muc-pending" &&
+      pending.peer === normalizedRoomJid &&
+      pending.sid === attemptId &&
+      pending.attemptId === attemptId
+    ) {
+      await rollbackMucCallSetup(
+        sender,
+        normalizedRoomJid,
+        selfNick,
+        activePresencePublished,
+        attemptId,
+      );
+      $callState.set({ phase: "idle" });
+    }
+    throw err;
   }
 }

--- a/chat/src/lib/calls/muc-call-actions.ts
+++ b/chat/src/lib/calls/muc-call-actions.ts
@@ -1,0 +1,47 @@
+import { beginMucCall, reportCallError, type RawIqSender } from "./call-store";
+import type { CallMedia } from "./types";
+
+type MucCallStartActionOptions = {
+  roomJid: string;
+  media: CallMedia;
+  isBusy: () => boolean;
+  setStarting: (starting: boolean) => void;
+  getSender: () => RawIqSender | null;
+  getSelfNick: () => string | undefined;
+  getExpectedMixerJid?: () => string | null | undefined;
+};
+
+/**
+ * Shared action behind the group-call buttons. Kept outside the SFC
+ * so tests can exercise the exact click handler semantics without
+ * introducing a Vue test-utils dependency.
+ */
+export async function startMucCallAction({
+  roomJid,
+  media,
+  isBusy,
+  setStarting,
+  getSender,
+  getSelfNick,
+  getExpectedMixerJid,
+}: MucCallStartActionOptions): Promise<boolean> {
+  if (isBusy()) return false;
+  const sender = getSender();
+  if (!sender) return false;
+  setStarting(true);
+  try {
+    await beginMucCall(
+      sender,
+      roomJid,
+      media,
+      getSelfNick(),
+      getExpectedMixerJid?.(),
+    );
+    return true;
+  } catch (err) {
+    reportCallError(err);
+    return false;
+  } finally {
+    setStarting(false);
+  }
+}

--- a/chat/src/lib/calls/muc-call-indicators.ts
+++ b/chat/src/lib/calls/muc-call-indicators.ts
@@ -1,0 +1,64 @@
+import type { ChannelSummary } from "@/lib/chat-types";
+import { normalizeMucCallRoomJid } from "./muc-call-presence";
+
+function candidateRoomJids(
+  channel: Pick<ChannelSummary, "id" | "jid">,
+  activeChannelJids: Iterable<string>,
+): string[] {
+  const candidates: string[] = [];
+  if (channel.jid) candidates.push(channel.jid);
+  for (const jid of activeChannelJids) {
+    const normalized = normalizeMucCallRoomJid(jid);
+    if (!normalized) continue;
+    const localpart = normalized.split("@")[0] ?? "";
+    if (localpart === channel.id.toLowerCase()) {
+      candidates.push(normalized);
+    }
+  }
+  return candidates;
+}
+
+export function callParticipantCountForChannel(
+  channel: Pick<ChannelSummary, "id" | "jid">,
+  callParticipantCounts: Record<string, number> | undefined,
+  activeChannelJids: Iterable<string>,
+): number {
+  if (!callParticipantCounts) return 0;
+  for (const jid of candidateRoomJids(channel, activeChannelJids)) {
+    const count = callParticipantCounts[normalizeMucCallRoomJid(jid)] ?? 0;
+    if (count > 0) return count;
+  }
+  return 0;
+}
+
+type CollapsedGroupActivitySummary = {
+  unread: number;
+  mentions: number;
+  hasActivity: boolean;
+  callCount: number;
+};
+
+type CollapsedGroupBadgeModel = {
+  callCount: number;
+  notification:
+    | { kind: "mentions"; count: number }
+    | { kind: "unread"; count: number }
+    | { kind: "activity" }
+    | null;
+};
+
+export function collapsedGroupBadgeModel(
+  summary: CollapsedGroupActivitySummary,
+): CollapsedGroupBadgeModel {
+  return {
+    callCount: summary.callCount > 0 ? summary.callCount : 0,
+    notification:
+      summary.mentions > 0
+        ? { kind: "mentions", count: summary.mentions }
+        : summary.unread > 0
+          ? { kind: "unread", count: summary.unread }
+          : summary.hasActivity
+            ? { kind: "activity" }
+            : null,
+  };
+}

--- a/chat/src/lib/calls/muc-call-presence.ts
+++ b/chat/src/lib/calls/muc-call-presence.ts
@@ -20,6 +20,44 @@ import { map } from "nanostores";
  * change.
  */
 export const $mucCallParticipants = map<Record<string, string[]>>({});
+const $mucPreparingParticipants = map<Record<string, string[]>>({});
+
+export function normalizeMucCallRoomJid(roomJid: string): string {
+  return roomJid.split("/")[0]?.trim().toLowerCase() ?? "";
+}
+
+function mucCallParticipantsForRoom(roomJid: string): string[] {
+  const normalized = normalizeMucCallRoomJid(roomJid);
+  if (!normalized) return [];
+  return $mucCallParticipants.get()[normalized] ?? [];
+}
+
+export function mucCallParticipantCounts(
+  participants: Record<string, string[]>,
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const [roomJid, nicks] of Object.entries(participants)) {
+    const normalized = normalizeMucCallRoomJid(roomJid);
+    if (!normalized) continue;
+    counts[normalized] = (counts[normalized] ?? 0) + nicks.length;
+  }
+  return counts;
+}
+
+export function clearMucCallParticipant(roomJid: string, nick: string): void {
+  const normalized = normalizeMucCallRoomJid(roomJid);
+  if (!normalized || !nick) return;
+  const current = $mucCallParticipants.get()[normalized] ?? [];
+  if (!current.includes(nick)) return;
+  const next = current.filter((n) => n !== nick);
+  if (next.length === 0) {
+    const all = { ...$mucCallParticipants.get() };
+    delete all[normalized];
+    $mucCallParticipants.set(all);
+  } else {
+    $mucCallParticipants.setKey(normalized, next);
+  }
+}
 
 /**
  * Apply an inbound presence update to the participants store. The
@@ -45,9 +83,9 @@ export function applyMucCallPresence(
   if (!presence.from) return;
   const slash = presence.from.indexOf("/");
   if (slash < 0) return;
-  const roomJid = presence.from.slice(0, slash);
+  const roomJid = normalizeMucCallRoomJid(presence.from.slice(0, slash));
   const nick = presence.from.slice(slash + 1);
-  if (!nick) return;
+  if (!roomJid || !nick) return;
 
   const wantsActive =
     presence.presence_type !== "unavailable" &&
@@ -59,10 +97,13 @@ export function applyMucCallPresence(
   // listener BEFORE we touch the participant store so the
   // beginMucCall flow unblocks deterministically.
   if (presence.muji?.preparing && presence.muji?.active === false) {
+    addPreparingParticipant(roomJid, nick);
     notifyPrepareEcho(roomJid, nick);
+  } else {
+    removePreparingParticipant(roomJid, nick);
   }
 
-  const current = $mucCallParticipants.get()[roomJid] ?? [];
+  const current = mucCallParticipantsForRoom(roomJid);
   const has = current.includes(nick);
 
   if (wantsActive && !has) {
@@ -87,7 +128,7 @@ export function applyMucCallPresence(
  * Convenience for components that don't need the full list.
  */
 export function mucCallParticipantCount(roomJid: string): number {
-  return ($mucCallParticipants.get()[roomJid] ?? []).length;
+  return mucCallParticipantsForRoom(roomJid).length;
 }
 
 /**
@@ -96,10 +137,48 @@ export function mucCallParticipantCount(roomJid: string): number {
  */
 export function clearMucCallParticipants(): void {
   $mucCallParticipants.set({});
+  $mucPreparingParticipants.set({});
   // Drop any pending preparing-echo waiters too — they'd otherwise
   // resolve when the next presence echo arrives after reconnect,
   // which would race the new login's call setup.
-  prepareEchoListeners.clear();
+  rejectPrepareEchoWaiters(
+    new Error("Muji preparing presence wait cancelled while clearing call state"),
+  );
+  rejectNoOtherPreparingWaiters(
+    new Error("Muji preparing participant wait cancelled while clearing call state"),
+  );
+}
+
+export function cancelMucCallPreparationWaiters(
+  roomJid: string,
+  nick: string,
+  err: Error,
+): void {
+  const normalized = normalizeMucCallRoomJid(roomJid);
+  if (!normalized || !nick) return;
+  rejectPrepareEchoWaiter(`${normalized}/${nick}`, err);
+  rejectNoOtherPreparingWaiter(`${normalized}/${nick}`, err);
+}
+
+function addPreparingParticipant(roomJid: string, nick: string): void {
+  const current = $mucPreparingParticipants.get()[roomJid] ?? [];
+  if (current.includes(nick)) return;
+  $mucPreparingParticipants.setKey(roomJid, [...current, nick]);
+  notifyPreparingChanged(roomJid);
+}
+
+function removePreparingParticipant(roomJid: string, nick: string): void {
+  const current = $mucPreparingParticipants.get()[roomJid] ?? [];
+  if (!current.includes(nick)) return;
+  const next = current.filter((n) => n !== nick);
+  if (next.length === 0) {
+    const all = { ...$mucPreparingParticipants.get() };
+    delete all[roomJid];
+    $mucPreparingParticipants.set(all);
+  } else {
+    $mucPreparingParticipants.setKey(roomJid, next);
+  }
+  notifyPreparingChanged(roomJid);
 }
 
 /**
@@ -115,24 +194,87 @@ export function clearMucCallParticipants(): void {
  * peer consensus (the mixer is the focus), but conformance is
  * conformance — we wait.
  */
-const prepareEchoListeners = new Map<string, () => void>();
+const prepareEchoListeners = new Map<
+  string,
+  {
+    resolve: () => void;
+    reject: (err: Error) => void;
+    timer: ReturnType<typeof setTimeout>;
+  }
+>();
+const noOtherPreparingListeners = new Map<
+  string,
+  {
+    roomJid: string;
+    selfNick: string;
+    resolve: () => void;
+    reject: (err: Error) => void;
+    timer: ReturnType<typeof setTimeout>;
+  }
+>();
 
 function notifyPrepareEcho(roomJid: string, nick: string): void {
   const key = `${roomJid}/${nick}`;
   const listener = prepareEchoListeners.get(key);
   if (listener) {
     prepareEchoListeners.delete(key);
-    listener();
+    clearTimeout(listener.timer);
+    listener.resolve();
   }
+}
+
+function rejectPrepareEchoWaiters(err: Error): void {
+  for (const listener of prepareEchoListeners.values()) {
+    clearTimeout(listener.timer);
+    listener.reject(err);
+  }
+  prepareEchoListeners.clear();
+}
+
+function rejectPrepareEchoWaiter(key: string, err: Error): void {
+  const listener = prepareEchoListeners.get(key);
+  if (!listener) return;
+  prepareEchoListeners.delete(key);
+  clearTimeout(listener.timer);
+  listener.reject(err);
+}
+
+function hasOtherPreparing(roomJid: string, selfNick: string): boolean {
+  return ($mucPreparingParticipants.get()[roomJid] ?? []).some((nick) => nick !== selfNick);
+}
+
+function notifyPreparingChanged(roomJid: string): void {
+  for (const [key, listener] of noOtherPreparingListeners) {
+    if (listener.roomJid !== roomJid) continue;
+    if (hasOtherPreparing(listener.roomJid, listener.selfNick)) continue;
+    noOtherPreparingListeners.delete(key);
+    clearTimeout(listener.timer);
+    listener.resolve();
+  }
+}
+
+function rejectNoOtherPreparingWaiters(err: Error): void {
+  for (const listener of noOtherPreparingListeners.values()) {
+    clearTimeout(listener.timer);
+    listener.reject(err);
+  }
+  noOtherPreparingListeners.clear();
+}
+
+function rejectNoOtherPreparingWaiter(key: string, err: Error): void {
+  const listener = noOtherPreparingListeners.get(key);
+  if (!listener) return;
+  noOtherPreparingListeners.delete(key);
+  clearTimeout(listener.timer);
+  listener.reject(err);
 }
 
 /**
  * Wait for the MUC to rebroadcast our preparing-presence echo for
  * `nick` in `roomJid`, then resolve. If no echo arrives within
- * `timeoutMs`, resolves anyway — the XEP MUST is satisfied
- * (we sent the preparing presence and waited as instructed) and
- * blocking the call setup forever because of a slow/missed echo
- * would be a worse UX than proceeding optimistically.
+ * `timeoutMs`, reject: XEP-0272 makes the echoed preparing
+ * presence part of the joining precondition, and proceeding without
+ * it can leave local UI state ahead of room-visible presence state.
  *
  * Caller must register the listener BEFORE emitting the preparing
  * presence to avoid races where the echo arrives before
@@ -143,20 +285,55 @@ export function awaitPreparingEcho(
   nick: string,
   timeoutMs: number,
 ): Promise<void> {
-  return new Promise((resolve) => {
-    const key = `${roomJid}/${nick}`;
+  return new Promise((resolve, reject) => {
+    const normalized = normalizeMucCallRoomJid(roomJid);
+    const key = `${normalized}/${nick}`;
     // Replacing an existing listener silently is fine — there's
     // only ever one preparing-echo waiter per (room, nick) at a
     // time because beginMucCall serialises through the call store.
+    const previous = prepareEchoListeners.get(key);
+    if (previous) {
+      clearTimeout(previous.timer);
+      previous.reject(new Error(`Replaced pending Muji preparing presence echo waiter in ${normalized}`));
+    }
     const timer = setTimeout(() => {
       if (prepareEchoListeners.get(key)) {
         prepareEchoListeners.delete(key);
-        resolve();
+        reject(new Error(`Timed out waiting for Muji preparing presence echo in ${normalized}`));
       }
     }, timeoutMs);
-    prepareEchoListeners.set(key, () => {
-      clearTimeout(timer);
-      resolve();
+    prepareEchoListeners.set(key, { resolve, reject, timer });
+  });
+}
+
+export function awaitNoOtherPreparing(
+  roomJid: string,
+  selfNick: string,
+  timeoutMs: number,
+): Promise<void> {
+  const normalized = normalizeMucCallRoomJid(roomJid);
+  if (!hasOtherPreparing(normalized, selfNick)) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve, reject) => {
+    const key = `${normalized}/${selfNick}`;
+    const previous = noOtherPreparingListeners.get(key);
+    if (previous) {
+      clearTimeout(previous.timer);
+      previous.reject(new Error(`Replaced pending Muji preparation waiter in ${normalized}`));
+    }
+    const timer = setTimeout(() => {
+      if (noOtherPreparingListeners.get(key)) {
+        noOtherPreparingListeners.delete(key);
+        reject(new Error(`Timed out waiting for other Muji participants to finish preparing in ${normalized}`));
+      }
+    }, timeoutMs);
+    noOtherPreparingListeners.set(key, {
+      roomJid: normalized,
+      selfNick,
+      resolve,
+      reject,
+      timer,
     });
   });
 }

--- a/chat/src/lib/calls/outbound.ts
+++ b/chat/src/lib/calls/outbound.ts
@@ -8,10 +8,13 @@ import type { CallMedia } from "./types";
  */
 export type CallWireSender = {
   send_call_propose?: (peer_bare_jid: string, sid: string, audio: boolean, video: boolean) => Promise<unknown>;
-  send_call_proceed?: (peer_bare_jid: string, sid: string) => Promise<unknown>;
-  send_call_reject?: (peer_bare_jid: string, sid: string) => Promise<unknown>;
-  send_call_retract?: (peer_bare_jid: string, sid: string) => Promise<unknown>;
-  send_call_finish?: (peer_bare_jid: string, sid: string) => Promise<unknown>;
+  send_call_proceed?: (peer_full_jid: string, sid: string) => Promise<unknown>;
+  send_call_reject?: (peer_full_jid: string, sid: string) => Promise<unknown>;
+  send_call_reject_tie_break?: (peer_full_jid: string, sid: string) => Promise<unknown>;
+  send_call_retract?: (peer_jid: string, sid: string) => Promise<unknown>;
+  send_call_retract_tie_break?: (peer_full_jid: string, sid: string) => Promise<unknown>;
+  send_call_finish?: (peer_full_jid: string, sid: string) => Promise<unknown>;
+  send_call_finish_migrated?: (peer_full_jid: string, old_sid: string, new_sid: string) => Promise<unknown>;
   send_call_session_initiate?: (
     peer_full_jid: string,
     initiator_full_jid: string,
@@ -21,7 +24,6 @@ export type CallWireSender = {
   ) => Promise<unknown>;
   send_call_session_accept?: (
     peer_full_jid: string,
-    initiator_full_jid: string,
     responder_full_jid: string,
     sid: string,
     audio: boolean,
@@ -68,24 +70,47 @@ export const outboundCalls = {
     await client.send_call_propose(peerBareJid, sid, media.audio, media.video);
   },
 
-  async proceed(client: CallWireSender, peerBareJid: string, sid: string): Promise<void> {
+  async proceed(client: CallWireSender, peerFullJid: string, sid: string): Promise<void> {
     if (!client.send_call_proceed) throw new WasmCallApiUnavailable("send_call_proceed");
-    await client.send_call_proceed(peerBareJid, sid);
+    await client.send_call_proceed(peerFullJid, sid);
   },
 
-  async reject(client: CallWireSender, peerBareJid: string, sid: string): Promise<void> {
+  async reject(client: CallWireSender, peerFullJid: string, sid: string): Promise<void> {
     if (!client.send_call_reject) throw new WasmCallApiUnavailable("send_call_reject");
-    await client.send_call_reject(peerBareJid, sid);
+    await client.send_call_reject(peerFullJid, sid);
   },
 
-  async retract(client: CallWireSender, peerBareJid: string, sid: string): Promise<void> {
+  async rejectTieBreak(client: CallWireSender, peerFullJid: string, sid: string): Promise<void> {
+    if (!client.send_call_reject_tie_break)
+      throw new WasmCallApiUnavailable("send_call_reject_tie_break");
+    await client.send_call_reject_tie_break(peerFullJid, sid);
+  },
+
+  async retract(client: CallWireSender, peerJid: string, sid: string): Promise<void> {
     if (!client.send_call_retract) throw new WasmCallApiUnavailable("send_call_retract");
-    await client.send_call_retract(peerBareJid, sid);
+    await client.send_call_retract(peerJid, sid);
   },
 
-  async finish(client: CallWireSender, peerBareJid: string, sid: string): Promise<void> {
+  async retractTieBreak(client: CallWireSender, peerFullJid: string, sid: string): Promise<void> {
+    if (!client.send_call_retract_tie_break)
+      throw new WasmCallApiUnavailable("send_call_retract_tie_break");
+    await client.send_call_retract_tie_break(peerFullJid, sid);
+  },
+
+  async finish(client: CallWireSender, peerFullJid: string, sid: string): Promise<void> {
     if (!client.send_call_finish) throw new WasmCallApiUnavailable("send_call_finish");
-    await client.send_call_finish(peerBareJid, sid);
+    await client.send_call_finish(peerFullJid, sid);
+  },
+
+  async finishMigrated(
+    client: CallWireSender,
+    peerFullJid: string,
+    oldSid: string,
+    newSid: string,
+  ): Promise<void> {
+    if (!client.send_call_finish_migrated)
+      throw new WasmCallApiUnavailable("send_call_finish_migrated");
+    await client.send_call_finish_migrated(peerFullJid, oldSid, newSid);
   },
 
   async sessionInitiate(
@@ -103,7 +128,6 @@ export const outboundCalls = {
   async sessionAccept(
     client: CallWireSender,
     peerFullJid: string,
-    initiatorFullJid: string,
     responderFullJid: string,
     sid: string,
     media: CallMedia,
@@ -112,7 +136,6 @@ export const outboundCalls = {
       throw new WasmCallApiUnavailable("send_call_session_accept");
     await client.send_call_session_accept(
       peerFullJid,
-      initiatorFullJid,
       responderFullJid,
       sid,
       media.audio,

--- a/chat/src/lib/calls/tie-break.ts
+++ b/chat/src/lib/calls/tie-break.ts
@@ -1,0 +1,31 @@
+const textEncoder = new TextEncoder();
+
+export function compareOctetStrings(left: string, right: string): number {
+  const leftBytes = textEncoder.encode(left);
+  const rightBytes = textEncoder.encode(right);
+  const len = Math.min(leftBytes.length, rightBytes.length);
+  for (let i = 0; i < len; i += 1) {
+    const diff = leftBytes[i] - rightBytes[i];
+    if (diff !== 0) return diff;
+  }
+  return leftBytes.length - rightBytes.length;
+}
+
+function bareCallJid(jid: string): string {
+  return (jid.split("/")[0] ?? "").toLowerCase();
+}
+
+export function isSameCallBareJid(left: string, right: string): boolean {
+  return bareCallJid(left) === bareCallJid(right);
+}
+
+export function incomingProposeWinsTieBreak(
+  incomingSid: string,
+  outgoingSid: string,
+  incomingFrom: string,
+  ourFullJid: string,
+): boolean {
+  const sidOrder = compareOctetStrings(incomingSid, outgoingSid);
+  if (sidOrder !== 0) return sidOrder < 0;
+  return compareOctetStrings(incomingFrom, ourFullJid) < 0;
+}

--- a/chat/src/lib/calls/types.ts
+++ b/chat/src/lib/calls/types.ts
@@ -17,11 +17,13 @@ export type LiveKitJoin = {
 };
 
 export type CallEvent =
+  // `from` is the sender's full JID for every inbound event. The
+  // only bare-addressed send path is outbound `<propose/>`.
   | { kind: "propose"; from: string; sid: string; media: CallMedia }
   | { kind: "proceed"; from: string; sid: string }
-  | { kind: "reject"; from: string; sid: string }
-  | { kind: "retract"; from: string; sid: string }
-  | { kind: "finish"; from: string; sid: string }
+  | { kind: "reject"; from: string; sid: string; reason?: string | null; tieBreak?: boolean }
+  | { kind: "retract"; from: string; sid: string; reason?: string | null; tieBreak?: boolean }
+  | { kind: "finish"; from: string; sid: string; reason?: string | null; migratedTo?: string | null }
   | {
       kind: "session-initiate";
       from: string;
@@ -47,7 +49,17 @@ export type CallEvent =
 export type CallState =
   | { phase: "idle" }
   | { phase: "incoming"; from: string; sid: string; media: CallMedia }
-  | { phase: "outgoing"; to: string; sid: string; media: CallMedia }
+  | { phase: "outgoing"; to: string; sid: string; media: CallMedia; initiator?: string }
+  | {
+      phase: "muc-pending";
+      peer: string;
+      sid: string;
+      media: CallMedia;
+      kind: "muc";
+      selfNick: string;
+      attemptId: string;
+      activePresencePublished?: boolean;
+    }
   | {
       phase: "active";
       /** 1:1 calls track the peer's full JID here; group calls
@@ -57,10 +69,10 @@ export type CallState =
       media: CallMedia;
       join: LiveKitJoin;
       kind: "dm" | "muc";
+      initiator?: string;
       /** MUC group calls only: the nick we used to join the room.
        *  Stored so `tearDownActiveCall` can emit the matching
-       *  `<presence to='room@muc/nick'><call state='inactive'/></presence>`
-       *  to clear our in-call indicator across other occupants. */
+       *  Muji-clearing presence update for XEP-0272 §Leaving. */
       selfNick?: string;
     }
   | { phase: "ended"; sid: string; reason: string | null };

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -453,6 +453,17 @@ export class BrowserXmppClient {
   /** Bare JID for this session. */
   get bareJid(): string { return this.session.jid; }
 
+  private isCurrentXmpp(xmpp: XmppClientInstance): boolean {
+    return this.xmpp === xmpp && !this.destroying;
+  }
+
+  private rejectRoomJoinWaiters(error: Error): void {
+    for (const waiter of this.roomJoinWaiters.values()) {
+      waiter.reject(error);
+    }
+    this.roomJoinWaiters.clear();
+  }
+
   setMessageHandler(h: (message: LiveRoomMessage) => void) { this.messageHandler = h; }
   /** #414: receive `<pin-event/>` system messages from a room. */
   setPinEventHandler(h: (event: { roomJid: string; event: import("./wasm-types").WasmPinEvent }) => void) { this.pinEventHandler = h; }
@@ -658,11 +669,13 @@ export class BrowserXmppClient {
     this.currentRoom = null;
     this.roomSwitchPromise = null;
     this.roomSwitchTarget = null;
+    this.rejectRoomJoinWaiters(new Error("XMPP disconnected while joining a room"));
     this.uploadServiceJid = null;
     this.roomHats = {};
     this.roomAuthority = {};
     this.roomPresence = {};
     this.roomMemberJids = {};
+    clearMucCallParticipants();
     // Best-effort hangup: if we're in a call when the user logs out
     // we want the peer to see session-terminate before the stream
     // closes. `tearDownActiveCall` handles every phase and clears
@@ -727,11 +740,27 @@ export class BrowserXmppClient {
     }
   }
 
+  private async tearDownMucCallForRoom(roomJid: string, xmpp: XmppClientInstance | null): Promise<void> {
+    const current = $callState.get();
+    if (
+      (current.phase === "active" || current.phase === "muc-pending") &&
+      current.kind === "muc" &&
+      barePeerJid(current.peer) === barePeerJid(roomJid)
+    ) {
+      await tearDownActiveCall(xmpp as unknown as CallWireSender | null, "success");
+    }
+  }
+
   private async performRoomSwitch(nextRoom: string) {
     const xmpp = this.xmpp;
     if (!xmpp) return;
+    if (this.currentRoom) {
+      await this.tearDownMucCallForRoom(this.currentRoom, xmpp);
+      if (!this.isCurrentXmpp(xmpp)) return;
+    }
     if (this.currentRoom && xmpp.leave_room) {
       try { await xmpp.leave_room(this.currentRoom, this.session.username); } catch {}
+      if (!this.isCurrentXmpp(xmpp)) return;
     }
     this.currentRoom = nextRoom;
     this.roomHats = {};
@@ -744,9 +773,20 @@ export class BrowserXmppClient {
     if (xmpp.join_room) {
       const ready = this.waitForRoomSelfPresence(nextRoom, this.session.username);
       await Promise.allSettled([xmpp.join_room(nextRoom, this.session.username)]);
-      await ready;
+      if (!this.isCurrentXmpp(xmpp)) {
+        await ready.catch(() => undefined);
+        return;
+      }
+      try {
+        await ready;
+      } catch (err) {
+        if (!this.isCurrentXmpp(xmpp)) return;
+        throw err;
+      }
+      if (!this.isCurrentXmpp(xmpp)) return;
     } else if (xmpp.joinRoom) {
       await xmpp.joinRoom(nextRoom, this.session.username);
+      if (!this.isCurrentXmpp(xmpp)) return;
     }
     this.startSelfPing();
     await this.flushQueuedRoomMessages(nextRoom);
@@ -2021,12 +2061,23 @@ export class BrowserXmppClient {
     return lastArchiveId;
   }
   private wireEvents(xmpp: XmppClientInstance & { enableKeepAlive?: (opts: { interval: number; timeout: number }) => void; disableKeepAlive?: () => void }) {
-    xmpp.set_on_connected?.(() => { if (this.xmpp !== xmpp) return; void this.enableCarbons(xmpp); });
-    xmpp.set_on_session_lifecycle?.((event: string) => { if (event === "resumed") this.handleSessionReady(xmpp, { type: "resumed" }); else this.handleSessionReady(xmpp, { type: "fresh" }); });
+    if (!this.xmpp && !this.destroying) this.xmpp = xmpp;
+    xmpp.set_on_connected?.(() => { if (!this.isCurrentXmpp(xmpp)) return; void this.enableCarbons(xmpp); });
+    xmpp.set_on_session_lifecycle?.((event: string) => {
+      if (!this.isCurrentXmpp(xmpp)) return;
+      if (event === "resumed") this.handleSessionReady(xmpp, { type: "resumed" }); else this.handleSessionReady(xmpp, { type: "fresh" });
+    });
     xmpp.set_on_disconnected?.(() => this.handleDisconnected(xmpp));
-    xmpp.set_on_error?.((detail: string) => this.emitError({ kind: "stream", recoverable: !this.destroying, detail }));
-    xmpp.set_on_message?.((message: WasmMessage) => this.handleMessage(message));
+    xmpp.set_on_error?.((detail: string) => {
+      if (this.xmpp !== xmpp) return;
+      this.emitError({ kind: "stream", recoverable: !this.destroying, detail });
+    });
+    xmpp.set_on_message?.((message: WasmMessage) => {
+      if (!this.isCurrentXmpp(xmpp)) return;
+      this.handleMessage(message);
+    });
     xmpp.set_on_presence?.((presence: WasmPresence) => {
+      if (!this.isCurrentXmpp(xmpp)) return;
       this.handlePresence(presence);
       // Side-effect track: MUC presence carrying the call extension
       // populates the per-room participants store so any consumer
@@ -2034,24 +2085,53 @@ export class BrowserXmppClient {
       // without subscribing to the raw presence stream.
       applyMucCallPresence(presence);
     });
-    xmpp.set_on_message_delivery_acked?.((id: string) => this.handleMessageAck(id));
-    xmpp.set_on_message_delivery_failed?.((id: string) => this.handleMessageFailed(id));
+    xmpp.set_on_message_delivery_acked?.((id: string) => {
+      if (!this.isCurrentXmpp(xmpp)) return;
+      this.handleMessageAck(id);
+    });
+    xmpp.set_on_message_delivery_failed?.((id: string) => {
+      if (!this.isCurrentXmpp(xmpp)) return;
+      this.handleMessageFailed(id);
+    });
     xmpp.set_on_mds_displayed?.((entry: WasmMdsDisplayedEntry) => {
+      if (!this.isCurrentXmpp(xmpp)) return;
       this.mdsDisplayedHandler?.({ chatId: entry.chat_id, stanzaId: entry.stanza_id, stanzaIdBy: entry.stanza_id_by });
     });
     xmpp.set_on_call?.((event: CallEvent) => {
+      if (!this.isCurrentXmpp(xmpp)) return;
       const prev = $callState.get();
       applyCallEvent(event);
       void handleCallEventSideEffect(event, prev, xmpp as unknown as CallWireSender, this.fullJid);
     });
-    xmpp.on?.("session:started", () => { xmpp.disableKeepAlive?.(); xmpp.enableKeepAlive?.({ interval: 30, timeout: 15 }); this.handleSessionReady(xmpp, { type: "fresh" }); });
-    xmpp.on?.("stream:management:resumed", () => this.handleSessionReady(xmpp, { type: "resumed" }));
+    xmpp.on?.("session:started", () => {
+      if (!this.isCurrentXmpp(xmpp)) return;
+      xmpp.disableKeepAlive?.();
+      xmpp.enableKeepAlive?.({ interval: 30, timeout: 15 });
+      this.handleSessionReady(xmpp, { type: "fresh" });
+    });
+    xmpp.on?.("stream:management:resumed", () => {
+      if (!this.isCurrentXmpp(xmpp)) return;
+      this.handleSessionReady(xmpp, { type: "resumed" });
+    });
     xmpp.on?.("disconnected", (error?: Error) => { xmpp.disableKeepAlive?.(); this.handleDisconnected(xmpp, error); });
-    xmpp.on?.("message:acked", (msg: { id?: string }) => { if (msg?.id) this.handleMessageAck(msg.id); });
-    xmpp.on?.("message:failed", (msg: { id?: string }) => { if (msg?.id) this.handleMessageFailed(msg.id); });
-    xmpp.on?.("message", (message: WasmMessage) => this.handleMessage(message));
-    xmpp.on?.("carbon:sent", (event: { carbon?: { forward?: { message?: WasmMessage } } }) => { const forwarded = event.carbon?.forward?.message; if (forwarded?.id) this.carbonDedupIds.add(forwarded.id); if (forwarded) this.handleMessage({ ...forwarded, _fromCarbon: true }); });
-    xmpp.on?.("carbon:received", (event: { carbon?: { forward?: { message?: WasmMessage } } }) => { const forwarded = event.carbon?.forward?.message; if (forwarded?.id) this.carbonDedupIds.add(forwarded.id); if (forwarded) this.handleMessage({ ...forwarded, _fromCarbon: true }); });
-    xmpp.on?.("presence", (presence: WasmPresence) => this.handlePresence(presence));
+    xmpp.on?.("message:acked", (msg: { id?: string }) => { if (!this.isCurrentXmpp(xmpp)) return; if (msg?.id) this.handleMessageAck(msg.id); });
+    xmpp.on?.("message:failed", (msg: { id?: string }) => { if (!this.isCurrentXmpp(xmpp)) return; if (msg?.id) this.handleMessageFailed(msg.id); });
+    xmpp.on?.("message", (message: WasmMessage) => {
+      if (!this.isCurrentXmpp(xmpp)) return;
+      this.handleMessage(message);
+    });
+    xmpp.on?.("carbon:sent", (event: { carbon?: { forward?: { message?: WasmMessage } } }) => {
+      if (!this.isCurrentXmpp(xmpp)) return;
+      const forwarded = event.carbon?.forward?.message; if (forwarded?.id) this.carbonDedupIds.add(forwarded.id); if (forwarded) this.handleMessage({ ...forwarded, _fromCarbon: true });
+    });
+    xmpp.on?.("carbon:received", (event: { carbon?: { forward?: { message?: WasmMessage } } }) => {
+      if (!this.isCurrentXmpp(xmpp)) return;
+      const forwarded = event.carbon?.forward?.message; if (forwarded?.id) this.carbonDedupIds.add(forwarded.id); if (forwarded) this.handleMessage({ ...forwarded, _fromCarbon: true });
+    });
+    xmpp.on?.("presence", (presence: WasmPresence) => {
+      if (!this.isCurrentXmpp(xmpp)) return;
+      this.handlePresence(presence);
+      applyMucCallPresence(presence);
+    });
   }
 }

--- a/chat/tests/call-effects.test.ts
+++ b/chat/tests/call-effects.test.ts
@@ -1,4 +1,9 @@
 import { describe, expect, mock, test } from "bun:test";
+import {
+  $callState,
+  $lastCallError,
+  clearCallState,
+} from "../src/lib/calls/call-store";
 import { handleCallEventSideEffect } from "../src/lib/calls/call-effects";
 import type { CallWireSender } from "../src/lib/calls/outbound";
 import type { CallEvent, CallMedia, CallState, LiveKitJoin } from "../src/lib/calls/types";
@@ -17,8 +22,11 @@ function mockSender(): CallWireSender {
     send_call_propose: mock(async () => undefined),
     send_call_proceed: mock(async () => undefined),
     send_call_reject: mock(async () => undefined),
+    send_call_reject_tie_break: mock(async () => undefined),
     send_call_retract: mock(async () => undefined),
+    send_call_retract_tie_break: mock(async () => undefined),
     send_call_finish: mock(async () => undefined),
+    send_call_finish_migrated: mock(async () => undefined),
     send_call_session_initiate: mock(async () => undefined),
     send_call_session_accept: mock(async () => undefined),
     send_call_session_terminate: mock(async () => undefined),
@@ -26,6 +34,69 @@ function mockSender(): CallWireSender {
 }
 
 describe("handleCallEventSideEffect", () => {
+  test("proceed side-effect failure ends outgoing UI and preserves a visible error", async () => {
+    clearCallState();
+    const sender = mockSender();
+    sender.send_call_session_initiate = mock(async () => {
+      throw new Error("session-initiate failed");
+    });
+    const prev: CallState = {
+      phase: "outgoing",
+      to: "bob@waddle.test",
+      sid: "c9",
+      media: audioVideo,
+    };
+    $callState.set(prev);
+    await handleCallEventSideEffect({
+      kind: "proceed",
+      from: "bob@waddle.test/desktop",
+      sid: "c9",
+    }, prev, sender, "alice@waddle.test/web-1");
+    expect($callState.get()).toEqual({
+      phase: "ended",
+      sid: "c9",
+      reason: "error",
+    });
+    expect($lastCallError.get()).toBe("session-initiate failed");
+    clearCallState();
+  });
+
+  test("session-initiate side-effect failure ends accepted incoming UI and preserves a visible error", async () => {
+    clearCallState();
+    const sender = mockSender();
+    sender.send_call_session_accept = mock(async () => {
+      throw new Error("session-accept failed");
+    });
+    const prev: CallState = {
+      phase: "incoming",
+      from: "alice@waddle.test/desktop",
+      sid: "c9",
+      media: audioVideo,
+    };
+    $callState.set({
+      phase: "active",
+      peer: "alice@waddle.test/desktop",
+      sid: "c9",
+      media: audioVideo,
+      join,
+      kind: "dm",
+    });
+    await handleCallEventSideEffect({
+      kind: "session-initiate",
+      from: "alice@waddle.test/desktop",
+      sid: "c9",
+      media: audioVideo,
+      join,
+    }, prev, sender, "bob@waddle.test/web-1");
+    expect($callState.get()).toEqual({
+      phase: "ended",
+      sid: "c9",
+      reason: "error",
+    });
+    expect($lastCallError.get()).toBe("session-accept failed");
+    clearCallState();
+  });
+
   test("fires session-initiate when proceed lands on a matching outgoing call", async () => {
     const sender = mockSender();
     const prev: CallState = {
@@ -89,7 +160,7 @@ describe("handleCallEventSideEffect", () => {
     };
     const event: CallEvent = {
       kind: "reject",
-      from: "bob@waddle.test",
+      from: "bob@waddle.test/desktop",
       sid: "c9",
     };
     await handleCallEventSideEffect(event, prev, sender, "alice@waddle.test/web-1");
@@ -100,7 +171,7 @@ describe("handleCallEventSideEffect", () => {
     const sender = mockSender();
     const prev: CallState = {
       phase: "incoming",
-      from: "alice@waddle.test",
+      from: "alice@waddle.test/desktop",
       sid: "c9",
       media: audioVideo,
     };
@@ -115,7 +186,6 @@ describe("handleCallEventSideEffect", () => {
     expect(sender.send_call_session_accept).toHaveBeenCalledTimes(1);
     expect(sender.send_call_session_accept).toHaveBeenCalledWith(
       "alice@waddle.test/desktop", // peer_full_jid
-      "alice@waddle.test/desktop", // initiator_full_jid
       "bob@waddle.test/web-1",     // responder_full_jid
       "c9",
       true,
@@ -127,7 +197,7 @@ describe("handleCallEventSideEffect", () => {
     const sender = mockSender();
     const prev: CallState = {
       phase: "incoming",
-      from: "alice@waddle.test",
+      from: "alice@waddle.test/desktop",
       sid: "c9",
       media: audioOnly,
     };
@@ -140,7 +210,6 @@ describe("handleCallEventSideEffect", () => {
     };
     await handleCallEventSideEffect(event, prev, sender, "bob@waddle.test/web-1");
     expect(sender.send_call_session_accept).toHaveBeenCalledWith(
-      "alice@waddle.test/desktop",
       "alice@waddle.test/desktop",
       "bob@waddle.test/web-1",
       "c9",
@@ -167,7 +236,7 @@ describe("handleCallEventSideEffect", () => {
     const sender = mockSender();
     const prev: CallState = {
       phase: "incoming",
-      from: "alice@waddle.test",
+      from: "alice@waddle.test/desktop",
       sid: "c9",
       media: audioVideo,
     };
@@ -190,19 +259,114 @@ describe("handleCallEventSideEffect", () => {
       sid: "c-existing",
       media: audioVideo,
       join,
+      kind: "dm",
     };
     const event: CallEvent = {
       kind: "propose",
-      from: "dave@waddle.test",
+      from: "dave@waddle.test/phone",
       sid: "c-new",
       media: audioVideo,
     };
     await handleCallEventSideEffect(event, prev, sender, "alice@waddle.test/web-1");
     expect(sender.send_call_reject).toHaveBeenCalledTimes(1);
-    expect(sender.send_call_reject).toHaveBeenCalledWith("dave@waddle.test", "c-new");
+    expect(sender.send_call_reject).toHaveBeenCalledWith("dave@waddle.test/phone", "c-new");
   });
 
-  test("busy-reject: propose while outgoing fires reject", async () => {
+  test("existing-session tie-break: same-peer active propose finishes old sid and proceeds new sid", async () => {
+    const sender = mockSender();
+    const prev: CallState = {
+      phase: "active",
+      peer: "dave@waddle.test/desktop",
+      sid: "old-session",
+      media: audioVideo,
+      join,
+      kind: "dm",
+      initiator: "dave@waddle.test/desktop",
+    };
+    const event: CallEvent = {
+      kind: "propose",
+      from: "dave@waddle.test/tablet",
+      sid: "new-session",
+      media: audioVideo,
+    };
+    $callState.set(prev);
+    await handleCallEventSideEffect(event, prev, sender, "alice@waddle.test/web-1");
+    expect(sender.send_call_finish_migrated).toHaveBeenCalledWith(
+      "dave@waddle.test/tablet",
+      "old-session",
+      "new-session",
+    );
+    expect(sender.send_call_proceed).toHaveBeenCalledWith(
+      "dave@waddle.test/tablet",
+      "new-session",
+    );
+    expect($callState.get()).toEqual({
+      phase: "incoming",
+      from: "dave@waddle.test/tablet",
+      sid: "new-session",
+      media: audioVideo,
+    });
+    clearCallState();
+  });
+
+  test("tie-break: lower inbound propose retracts our outgoing session and becomes incoming", async () => {
+    const sender = mockSender();
+    const prev: CallState = {
+      phase: "outgoing",
+      to: "dave@waddle.test",
+      sid: "z-outgoing",
+      media: audioVideo,
+    };
+    const event: CallEvent = {
+      kind: "propose",
+      from: "dave@waddle.test/phone",
+      sid: "a-incoming",
+      media: audioVideo,
+    };
+    $callState.set(prev);
+    await handleCallEventSideEffect(event, prev, sender, "alice@waddle.test/web-1");
+    expect(sender.send_call_retract_tie_break).toHaveBeenCalledTimes(1);
+    expect(sender.send_call_retract_tie_break).toHaveBeenCalledWith(
+      "dave@waddle.test/phone",
+      "z-outgoing",
+    );
+    expect(sender.send_call_reject_tie_break).not.toHaveBeenCalled();
+    expect($callState.get()).toEqual({
+      phase: "incoming",
+      from: "dave@waddle.test/phone",
+      sid: "a-incoming",
+      media: audioVideo,
+    });
+    clearCallState();
+  });
+
+  test("tie-break: higher inbound propose is rejected and outgoing state stays intact", async () => {
+    const sender = mockSender();
+    const prev: CallState = {
+      phase: "outgoing",
+      to: "dave@waddle.test",
+      sid: "a-outgoing",
+      media: audioVideo,
+    };
+    const event: CallEvent = {
+      kind: "propose",
+      from: "dave@waddle.test/phone",
+      sid: "z-incoming",
+      media: audioVideo,
+    };
+    $callState.set(prev);
+    await handleCallEventSideEffect(event, prev, sender, "alice@waddle.test/web-1");
+    expect(sender.send_call_reject_tie_break).toHaveBeenCalledTimes(1);
+    expect(sender.send_call_reject_tie_break).toHaveBeenCalledWith(
+      "dave@waddle.test/phone",
+      "z-incoming",
+    );
+    expect(sender.send_call_retract_tie_break).not.toHaveBeenCalled();
+    expect($callState.get()).toBe(prev);
+    clearCallState();
+  });
+
+  test("busy-reject: propose while outgoing against a different bare JID fires plain reject", async () => {
     const sender = mockSender();
     const prev: CallState = {
       phase: "outgoing",
@@ -212,12 +376,13 @@ describe("handleCallEventSideEffect", () => {
     };
     const event: CallEvent = {
       kind: "propose",
-      from: "dave@waddle.test",
+      from: "dave@waddle.test/phone",
       sid: "c-new",
       media: audioVideo,
     };
     await handleCallEventSideEffect(event, prev, sender, "alice@waddle.test/web-1");
     expect(sender.send_call_reject).toHaveBeenCalledTimes(1);
+    expect(sender.send_call_reject_tie_break).not.toHaveBeenCalled();
   });
 
   test("busy-reject: propose while idle does NOT fire reject", async () => {
@@ -225,7 +390,7 @@ describe("handleCallEventSideEffect", () => {
     const prev: CallState = { phase: "idle" };
     const event: CallEvent = {
       kind: "propose",
-      from: "dave@waddle.test",
+      from: "dave@waddle.test/phone",
       sid: "c-new",
       media: audioVideo,
     };
@@ -238,7 +403,7 @@ describe("handleCallEventSideEffect", () => {
     const prev: CallState = { phase: "ended", sid: "c-old", reason: "success" };
     const event: CallEvent = {
       kind: "propose",
-      from: "dave@waddle.test",
+      from: "dave@waddle.test/phone",
       sid: "c-new",
       media: audioVideo,
     };

--- a/chat/tests/call-outbound.test.ts
+++ b/chat/tests/call-outbound.test.ts
@@ -15,8 +15,11 @@ function recorder() {
     send_call_propose: track("send_call_propose") as CallWireSender["send_call_propose"],
     send_call_proceed: track("send_call_proceed") as CallWireSender["send_call_proceed"],
     send_call_reject: track("send_call_reject") as CallWireSender["send_call_reject"],
+    send_call_reject_tie_break: track("send_call_reject_tie_break") as CallWireSender["send_call_reject_tie_break"],
     send_call_retract: track("send_call_retract") as CallWireSender["send_call_retract"],
+    send_call_retract_tie_break: track("send_call_retract_tie_break") as CallWireSender["send_call_retract_tie_break"],
     send_call_finish: track("send_call_finish") as CallWireSender["send_call_finish"],
+    send_call_finish_migrated: track("send_call_finish_migrated") as CallWireSender["send_call_finish_migrated"],
     send_call_session_initiate: track("send_call_session_initiate") as CallWireSender["send_call_session_initiate"],
     send_call_session_accept: track("send_call_session_accept") as CallWireSender["send_call_session_accept"],
     send_call_session_terminate: track("send_call_session_terminate") as CallWireSender["send_call_session_terminate"],
@@ -33,21 +36,39 @@ describe("outboundCalls", () => {
     ]);
   });
 
-  test("proceed / reject / retract / finish forward bare jid + sid", async () => {
+  test("proceed / reject / finish forward full jid; retract accepts generic jid", async () => {
     const { client, calls } = recorder();
-    await outboundCalls.proceed(client, "bob@waddle.test", "c1");
-    await outboundCalls.reject(client, "bob@waddle.test", "c1");
+    await outboundCalls.proceed(client, "bob@waddle.test/desktop", "c1");
+    await outboundCalls.reject(client, "bob@waddle.test/desktop", "c1");
     await outboundCalls.retract(client, "bob@waddle.test", "c1");
-    await outboundCalls.finish(client, "bob@waddle.test", "c1");
-    expect(calls.map((c) => c.method)).toEqual([
-      "send_call_proceed",
-      "send_call_reject",
-      "send_call_retract",
-      "send_call_finish",
+    await outboundCalls.finish(client, "bob@waddle.test/desktop", "c1");
+    expect(calls).toEqual([
+      { method: "send_call_proceed", args: ["bob@waddle.test/desktop", "c1"] },
+      { method: "send_call_reject", args: ["bob@waddle.test/desktop", "c1"] },
+      { method: "send_call_retract", args: ["bob@waddle.test", "c1"] },
+      { method: "send_call_finish", args: ["bob@waddle.test/desktop", "c1"] },
     ]);
-    for (const call of calls) {
-      expect(call.args).toEqual(["bob@waddle.test", "c1"]);
-    }
+  });
+
+  test("tie-break helpers forward full jid and sid", async () => {
+    const { client, calls } = recorder();
+    await outboundCalls.rejectTieBreak(client, "bob@waddle.test/desktop", "c-loser");
+    await outboundCalls.retractTieBreak(client, "bob@waddle.test/desktop", "c-loser");
+    await outboundCalls.finishMigrated(client, "bob@waddle.test/desktop", "c-old", "c-new");
+    expect(calls).toEqual([
+      {
+        method: "send_call_reject_tie_break",
+        args: ["bob@waddle.test/desktop", "c-loser"],
+      },
+      {
+        method: "send_call_retract_tie_break",
+        args: ["bob@waddle.test/desktop", "c-loser"],
+      },
+      {
+        method: "send_call_finish_migrated",
+        args: ["bob@waddle.test/desktop", "c-old", "c-new"],
+      },
+    ]);
   });
 
   test("sessionInitiate splits media into audio/video booleans", async () => {
@@ -67,11 +88,10 @@ describe("outboundCalls", () => {
     ]);
   });
 
-  test("sessionAccept passes initiator + responder + media", async () => {
+  test("sessionAccept passes responder + media", async () => {
     const { client, calls } = recorder();
     await outboundCalls.sessionAccept(
       client,
-      "alice@waddle.test/desktop",
       "alice@waddle.test/desktop",
       "bob@waddle.test/desktop",
       "c1",
@@ -81,7 +101,6 @@ describe("outboundCalls", () => {
       {
         method: "send_call_session_accept",
         args: [
-          "alice@waddle.test/desktop",
           "alice@waddle.test/desktop",
           "bob@waddle.test/desktop",
           "c1",
@@ -94,11 +113,27 @@ describe("outboundCalls", () => {
 
   test("sessionTerminate passes reason through (including null)", async () => {
     const { client, calls } = recorder();
-    await outboundCalls.sessionTerminate(client, "bob@waddle.test/desktop", "c1", "success");
-    await outboundCalls.sessionTerminate(client, "bob@waddle.test/desktop", "c1", null);
+    await outboundCalls.sessionTerminate(
+      client,
+      "bob@waddle.test/desktop",
+      "c1",
+      "success",
+    );
+    await outboundCalls.sessionTerminate(
+      client,
+      "bob@waddle.test/desktop",
+      "c1",
+      null,
+    );
     expect(calls).toEqual([
-      { method: "send_call_session_terminate", args: ["bob@waddle.test/desktop", "c1", "success"] },
-      { method: "send_call_session_terminate", args: ["bob@waddle.test/desktop", "c1", null] },
+      {
+        method: "send_call_session_terminate",
+        args: ["bob@waddle.test/desktop", "c1", "success"],
+      },
+      {
+        method: "send_call_session_terminate",
+        args: ["bob@waddle.test/desktop", "c1", null],
+      },
     ]);
   });
 

--- a/chat/tests/call-store.test.ts
+++ b/chat/tests/call-store.test.ts
@@ -23,13 +23,13 @@ describe("call-store reducer", () => {
   test("propose transitions idle → incoming", () => {
     const next = reduceCallState({ phase: "idle" }, {
       kind: "propose",
-      from: "alice@waddle.test",
+      from: "alice@waddle.test/desktop",
       sid: "c1",
       media: audioVideo,
     });
     expect(next).toEqual({
       phase: "incoming",
-      from: "alice@waddle.test",
+      from: "alice@waddle.test/desktop",
       sid: "c1",
       media: audioVideo,
     });
@@ -38,14 +38,15 @@ describe("call-store reducer", () => {
   test("propose is ignored when already in an active call", () => {
     const current = {
       phase: "active" as const,
-      peer: "carol@waddle.test",
+      peer: "carol@waddle.test/desktop",
       sid: "c0",
       media: audioVideo,
       join,
+      kind: "dm",
     };
     const next = reduceCallState(current, {
       kind: "propose",
-      from: "dave@waddle.test",
+      from: "dave@waddle.test/phone",
       sid: "c2",
       media: audioVideo,
     });
@@ -61,7 +62,7 @@ describe("call-store reducer", () => {
     const next = reduceCallState(
       {
         phase: "incoming",
-        from: "alice@waddle.test",
+        from: "alice@waddle.test/desktop",
         sid: "c1",
         media: audioVideo,
       },
@@ -80,6 +81,7 @@ describe("call-store reducer", () => {
       media: audioVideo,
       join,
       kind: "dm",
+      initiator: "alice@waddle.test/desktop",
     });
   });
 
@@ -87,12 +89,13 @@ describe("call-store reducer", () => {
     const next = reduceCallState(
       {
         phase: "active",
-        peer: "alice@waddle.test",
+        peer: "alice@waddle.test/desktop",
         sid: "c1",
         media: audioVideo,
         join,
+      kind: "dm",
       },
-      { kind: "session-terminate", from: "alice@waddle.test", sid: "c1", reason: "success" },
+      { kind: "session-terminate", from: "alice@waddle.test/desktop", sid: "c1", reason: "success" },
     );
     expect(next).toEqual({ phase: "ended", sid: "c1", reason: "success" });
   });
@@ -101,11 +104,11 @@ describe("call-store reducer", () => {
     const next = reduceCallState(
       {
         phase: "incoming",
-        from: "alice@waddle.test",
+        from: "alice@waddle.test/desktop",
         sid: "c1",
         media: audioVideo,
       },
-      { kind: "finish", from: "alice@waddle.test", sid: "c1" },
+      { kind: "finish", from: "alice@waddle.test/desktop", sid: "c1" },
     );
     expect(next).toEqual({ phase: "ended", sid: "c1", reason: null });
   });
@@ -113,7 +116,7 @@ describe("call-store reducer", () => {
   test("reject from idle is a no-op", () => {
     const next = reduceCallState({ phase: "idle" }, {
       kind: "reject",
-      from: "alice@waddle.test",
+      from: "alice@waddle.test/desktop",
       sid: "c1",
     });
     expect(next).toEqual({ phase: "idle" });
@@ -123,11 +126,11 @@ describe("call-store reducer", () => {
     const next = reduceCallState(
       {
         phase: "incoming",
-        from: "alice@waddle.test",
+        from: "alice@waddle.test/desktop",
         sid: "c1",
         media: audioVideo,
       },
-      { kind: "retract", from: "alice@waddle.test", sid: "c1" },
+      { kind: "retract", from: "alice@waddle.test/desktop", sid: "c1" },
     );
     expect(next).toEqual({ phase: "ended", sid: "c1", reason: "retract" });
   });
@@ -137,13 +140,13 @@ describe("call-store reducer", () => {
     expect($callState.get()).toEqual({ phase: "idle" });
     applyCallEvent({
       kind: "propose",
-      from: "alice@waddle.test",
+      from: "alice@waddle.test/desktop",
       sid: "c1",
       media: audioVideo,
     });
     expect($callState.get()).toEqual({
       phase: "incoming",
-      from: "alice@waddle.test",
+      from: "alice@waddle.test/desktop",
       sid: "c1",
       media: audioVideo,
     });
@@ -212,7 +215,7 @@ describe("call-store reducer", () => {
         sid: "c9",
         media: audioVideo,
       },
-      { kind: "reject", from: "bob@waddle.test", sid: "c9" },
+      { kind: "reject", from: "bob@waddle.test/desktop", sid: "c9" },
     );
     expect(next).toEqual({ phase: "ended", sid: "c9", reason: "reject" });
   });
@@ -225,7 +228,7 @@ describe("call-store reducer", () => {
         sid: "c9",
         media: audioVideo,
       },
-      { kind: "retract", from: "alice@waddle.test", sid: "c9" },
+      { kind: "retract", from: "alice@waddle.test/desktop", sid: "c9" },
     );
     expect(next).toEqual({ phase: "ended", sid: "c9", reason: "retract" });
   });
@@ -247,7 +250,7 @@ describe("call-store reducer", () => {
   test("session-initiate is dropped when sid does not match incoming", () => {
     const current = {
       phase: "incoming" as const,
-      from: "alice@waddle.test",
+      from: "alice@waddle.test/desktop",
       sid: "c-live",
       media: audioVideo,
     };
@@ -297,6 +300,7 @@ describe("call-store reducer", () => {
       sid: "c-live",
       media: audioVideo,
       join,
+      kind: "dm",
     };
     const next = reduceCallState(current, {
       kind: "session-terminate",
@@ -314,6 +318,7 @@ describe("call-store reducer", () => {
       sid: "c-live",
       media: audioVideo,
       join,
+      kind: "dm",
     };
     const next = reduceCallState(current, {
       kind: "finish",
@@ -332,7 +337,7 @@ describe("call-store reducer", () => {
     };
     const next = reduceCallState(current, {
       kind: "reject",
-      from: "bob@waddle.test",
+      from: "bob@waddle.test/desktop",
       sid: "c-stale",
     });
     expect(next).toBe(current);
@@ -345,10 +350,11 @@ describe("call-store reducer", () => {
       sid: "c-live",
       media: audioVideo,
       join,
+      kind: "dm",
     };
     const next = reduceCallState(current, {
       kind: "propose",
-      from: "dave@waddle.test",
+      from: "dave@waddle.test/phone",
       sid: "c-new",
       media: audioVideo,
     });

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -1,18 +1,99 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import {
   $callState,
-  applyCallEvent,
+  $lastCallError,
   beginOutgoingCall,
   clearCallState,
   scheduleOutgoingTimeout,
+  setSessionAcceptTimeoutMsForTests,
   tearDownActiveCall,
 } from "../src/lib/calls/call-store";
 import {
-  applyMucCallPresence,
+  $mucCallParticipants,
   clearMucCallParticipants,
 } from "../src/lib/calls/muc-call-presence";
+import { startMucCallAction } from "../src/lib/calls/muc-call-actions";
 import type { CallWireSender } from "../src/lib/calls/outbound";
-import type { CallMedia, LiveKitJoin } from "../src/lib/calls/types";
+import type { CallEvent, CallMedia, LiveKitJoin } from "../src/lib/calls/types";
+import { BrowserXmppClient } from "../src/lib/xmpp-client";
+import type { WaddleSession } from "../src/lib/server-auth";
+
+function session(partial: Partial<WaddleSession> = {}): WaddleSession {
+  return {
+    username: "alice",
+    jid: "alice@waddle.test/web",
+    session_id: "tok",
+    xmpp_websocket_url: "wss://waddle.test/ws",
+    ...partial,
+  } as WaddleSession;
+}
+
+function wireClientEvents(sender: Partial<CallWireSender> = {}) {
+  let onPresence: ((presence: {
+    from?: string;
+    presence_type?: string;
+    muji?: { preparing: boolean; active: boolean };
+  }) => void) | null = null;
+  let onCall: ((event: CallEvent) => void) | null = null;
+  let onDisconnected: (() => void) | null = null;
+  const client = new BrowserXmppClient(session());
+  const xmpp = {
+    set_on_presence: (cb: NonNullable<typeof onPresence>) => {
+      onPresence = cb;
+    },
+    set_on_call: (cb: NonNullable<typeof onCall>) => {
+      onCall = cb;
+    },
+    set_on_disconnected: (cb: NonNullable<typeof onDisconnected>) => {
+      onDisconnected = cb;
+    },
+    ...sender,
+  };
+  (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+  return {
+    client,
+    xmpp,
+    emitPresence(presence: Parameters<NonNullable<typeof onPresence>>[0]) {
+      onPresence?.(presence);
+    },
+    emitCall(event: CallEvent) {
+      onCall?.(event);
+    },
+    emitDisconnected() {
+      onDisconnected?.();
+    },
+  };
+}
+
+async function flushCallSideEffects(): Promise<void> {
+  for (let i = 0; i < 8; i += 1) {
+    await Promise.resolve();
+  }
+}
+
+function firstMockCallArg(fn: unknown, index: number): unknown {
+  return (fn as { mock: { calls: unknown[][] } }).mock.calls[0]?.[index];
+}
+
+function wireEmitterPresenceEvents() {
+  let onPresence: ((presence: {
+    from?: string;
+    presence_type?: string;
+    muji?: { preparing: boolean; active: boolean };
+  }) => void) | null = null;
+  const client = new BrowserXmppClient(session());
+  const xmpp = {
+    on: (event: string, cb: typeof onPresence) => {
+      if (event === "presence") onPresence = cb;
+    },
+  };
+  (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+  return {
+    emitPresence(presence: Parameters<NonNullable<typeof onPresence>>[0]) {
+      onPresence?.(presence);
+    },
+  };
+}
 
 /**
  * Mock the wasm `update_muji_presence` such that the preparing
@@ -22,7 +103,9 @@ import type { CallMedia, LiveKitJoin } from "../src/lib/calls/types";
  * pay the 2s echo-timeout penalty on every call to `beginMucCall`
  * that passes a `selfNick`.
  */
-function mockUpdateMujiPresenceWithEcho() {
+function mockUpdateMujiPresenceWithEcho(
+  emitPresence: ReturnType<typeof wireClientEvents>["emitPresence"],
+) {
   return mock(
     async (
       roomJid: string,
@@ -32,14 +115,14 @@ function mockUpdateMujiPresenceWithEcho() {
       _video: boolean,
     ) => {
       if (preparing) {
-        applyMucCallPresence({
+        emitPresence({
           from: `${roomJid}/${nick}`,
           presence_type: "available",
           muji: { preparing: true, active: false },
         });
       }
       if (active) {
-        applyMucCallPresence({
+        emitPresence({
           from: `${roomJid}/${nick}`,
           presence_type: "available",
           muji: { preparing: false, active: true },
@@ -57,17 +140,20 @@ function mockUpdateMujiPresenceWithEcho() {
  * wasm bridge would parse this from an inbound `<iq type='set'>`
  * stanza routed through `on_call`; tests skip the wire dance.
  */
-function mockSendMujiSessionInitiateWithAccept(join: LiveKitJoin) {
-  return mock(async (roomJid: string, _video: boolean) => {
+function mockSendMujiSessionInitiateWithAccept(
+  join: LiveKitJoin,
+  emitCall: ReturnType<typeof wireClientEvents>["emitCall"],
+) {
+  return mock(async (_roomJid: string, sid: string, _video: boolean) => {
     // Empty IQ-result ack is the function's resolution; fire the
     // inbound session-accept on the next microtask so the await
     // chain in beginMucCall sees the resolver populated before the
     // event lands.
     queueMicrotask(() => {
-      applyCallEvent({
+      emitCall({
         kind: "session-accept",
         from: "calls.waddle.test",
-        sid: roomJid,
+        sid,
         media: { audio: true, video: true },
         join,
       });
@@ -90,6 +176,7 @@ function mockSender(): CallWireSender {
     send_call_reject: mock(async () => undefined),
     send_call_retract: mock(async () => undefined),
     send_call_finish: mock(async () => undefined),
+    send_call_finish_migrated: mock(async () => undefined),
     send_call_session_initiate: mock(async () => undefined),
     send_call_session_accept: mock(async () => undefined),
     send_call_session_terminate: mock(async () => undefined),
@@ -98,6 +185,7 @@ function mockSender(): CallWireSender {
 
 afterEach(() => {
   clearCallState();
+  $lastCallError.set(null);
   // The Muji mocks above fire `applyMucCallPresence` to simulate
   // MUC echoes; clearing the participants store between tests
   // keeps that state from leaking into other test files (e.g.
@@ -115,6 +203,7 @@ describe("tearDownActiveCall", () => {
       media: audioVideo,
       join,
       kind: "dm",
+      initiator: "alice@waddle.test/web",
     });
     await tearDownActiveCall(sender, "gone");
     expect(sender.send_call_session_terminate).toHaveBeenCalledTimes(1);
@@ -140,6 +229,7 @@ describe("tearDownActiveCall", () => {
       media: audioVideo,
       join,
       kind: "dm",
+      initiator: "alice@waddle.test/web",
     });
     await tearDownActiveCall(sender, "success");
     expect(sender.send_call_session_terminate).toHaveBeenCalledTimes(1);
@@ -168,6 +258,7 @@ describe("tearDownActiveCall", () => {
       media: audioVideo,
       join,
       kind: "dm",
+      initiator: "alice@waddle.test/web",
     });
     await tearDownActiveCall(sender, "success");
     expect(sender.send_call_session_terminate).toHaveBeenCalledTimes(1);
@@ -183,6 +274,7 @@ describe("tearDownActiveCall", () => {
       media: audioVideo,
       join,
       kind: "dm",
+      initiator: "alice@waddle.test/web",
     });
     await tearDownActiveCall(sender, "success");
     expect(sender.send_call_session_terminate).toHaveBeenCalledWith(
@@ -205,13 +297,13 @@ describe("tearDownActiveCall", () => {
     const sender = mockSender();
     $callState.set({
       phase: "incoming",
-      from: "alice@waddle.test",
+      from: "alice@waddle.test/desktop",
       sid: "c3",
       media: audioVideo,
     });
     await tearDownActiveCall(sender, "gone");
     expect(sender.send_call_reject).toHaveBeenCalledTimes(1);
-    expect(sender.send_call_reject).toHaveBeenCalledWith("alice@waddle.test", "c3");
+    expect(sender.send_call_reject).toHaveBeenCalledWith("alice@waddle.test/desktop", "c3");
     expect($callState.get()).toEqual({ phase: "idle" });
   });
 
@@ -231,50 +323,975 @@ describe("tearDownActiveCall", () => {
       media: audioVideo,
       join,
       kind: "dm",
+      initiator: "alice@waddle.test/web",
     });
     await tearDownActiveCall(null, "gone");
     expect($callState.get()).toEqual({ phase: "idle" });
   });
 });
 
+describe("1:1 call event wiring", () => {
+  test("real on_call propose event applies lower-sid tie-break and surfaces incoming UI", async () => {
+    const send_call_retract_tie_break = mock(async () => undefined);
+    const events = wireClientEvents({ send_call_retract_tie_break });
+
+    beginOutgoingCall("bob@waddle.test", "z-outgoing", audioVideo);
+    events.emitCall({
+      kind: "propose",
+      from: "bob@waddle.test/phone",
+      sid: "a-incoming",
+      media: audioVideo,
+    });
+    await flushCallSideEffects();
+
+    expect(send_call_retract_tie_break).toHaveBeenCalledTimes(1);
+    expect(send_call_retract_tie_break).toHaveBeenCalledWith(
+      "bob@waddle.test/phone",
+      "z-outgoing",
+    );
+    expect($callState.get()).toEqual({
+      phase: "incoming",
+      from: "bob@waddle.test/phone",
+      sid: "a-incoming",
+      media: audioVideo,
+    });
+  });
+
+  test("real on_call propose event applies higher-sid tie-break without changing outgoing UI", async () => {
+    const send_call_reject_tie_break = mock(async () => undefined);
+    const events = wireClientEvents({ send_call_reject_tie_break });
+
+    beginOutgoingCall("bob@waddle.test", "a-outgoing", audioVideo);
+    events.emitCall({
+      kind: "propose",
+      from: "bob@waddle.test/phone",
+      sid: "z-incoming",
+      media: audioVideo,
+    });
+    await flushCallSideEffects();
+
+    expect(send_call_reject_tie_break).toHaveBeenCalledTimes(1);
+    expect(send_call_reject_tie_break).toHaveBeenCalledWith(
+      "bob@waddle.test/phone",
+      "z-incoming",
+    );
+    expect($callState.get()).toEqual({
+      phase: "outgoing",
+      to: "bob@waddle.test",
+      sid: "a-outgoing",
+      media: audioVideo,
+    });
+  });
+
+  test("real on_call proceed event cancels outgoing ring timeout", async () => {
+    const sender = mockSender();
+    const events = wireClientEvents(sender);
+
+    beginOutgoingCall("bob@waddle.test", "c-accepted", audioVideo);
+    scheduleOutgoingTimeout(sender, "c-accepted", 10);
+    events.emitCall({
+      kind: "proceed",
+      from: "bob@waddle.test/phone",
+      sid: "c-accepted",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(sender.send_call_retract).not.toHaveBeenCalled();
+    expect($callState.get()).toEqual({
+      phase: "outgoing",
+      to: "bob@waddle.test",
+      sid: "c-accepted",
+      media: audioVideo,
+    });
+  });
+
+  test("real on_call proceed event times out if no session-accept follows", async () => {
+    const restoreTimeout = setSessionAcceptTimeoutMsForTests(10);
+    try {
+      const sender = mockSender();
+      const events = wireClientEvents(sender);
+
+      beginOutgoingCall(
+        "bob@waddle.test",
+        "c-no-accept",
+        audioVideo,
+        "alice@waddle.test/web",
+      );
+      scheduleOutgoingTimeout(sender, "c-no-accept", 100);
+      events.emitCall({
+        kind: "proceed",
+        from: "bob@waddle.test/phone",
+        sid: "c-no-accept",
+      });
+      await flushCallSideEffects();
+      await new Promise((resolve) => setTimeout(resolve, 25));
+
+      expect(sender.send_call_retract).not.toHaveBeenCalled();
+      expect(sender.send_call_session_initiate).toHaveBeenCalledTimes(1);
+      const initiateCalls = (
+        sender.send_call_session_initiate as unknown as {
+          mock: { calls: unknown[][] };
+        }
+      ).mock.calls;
+      const initiatorFullJid = String(initiateCalls[0]?.[1] ?? "");
+      expect(initiateCalls[0]?.[0]).toBe("bob@waddle.test/phone");
+      expect(initiatorFullJid.startsWith("alice@waddle.test/web")).toBe(true);
+      expect(initiateCalls[0]?.[2]).toBe("c-no-accept");
+      expect(initiateCalls[0]?.[3]).toBe(true);
+      expect(initiateCalls[0]?.[4]).toBe(true);
+      expect(sender.send_call_session_terminate).toHaveBeenCalledWith(
+        "bob@waddle.test/phone",
+        "c-no-accept",
+        "timeout",
+      );
+      expect($callState.get()).toEqual({
+        phase: "ended",
+        sid: "c-no-accept",
+        reason: "timeout",
+      });
+    } finally {
+      restoreTimeout();
+    }
+  });
+
+  test("real on_call session-accept cancels the post-proceed timeout", async () => {
+    const restoreTimeout = setSessionAcceptTimeoutMsForTests(10);
+    try {
+      const sender = mockSender();
+      const events = wireClientEvents(sender);
+
+      beginOutgoingCall(
+        "bob@waddle.test",
+        "c-accepts",
+        audioVideo,
+        "alice@waddle.test/web",
+      );
+      events.emitCall({
+        kind: "proceed",
+        from: "bob@waddle.test/phone",
+        sid: "c-accepts",
+      });
+      await flushCallSideEffects();
+      events.emitCall({
+        kind: "session-accept",
+        from: "bob@waddle.test/phone",
+        sid: "c-accepts",
+        media: audioVideo,
+        join,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 25));
+
+      expect(sender.send_call_session_terminate).not.toHaveBeenCalled();
+      expect($callState.get()).toEqual({
+        phase: "active",
+        peer: "bob@waddle.test/phone",
+        sid: "c-accepts",
+        media: audioVideo,
+        join,
+        kind: "dm",
+        initiator: "alice@waddle.test/web",
+      });
+    } finally {
+      restoreTimeout();
+    }
+  });
+
+  test("real on_call active same-bare propose migrates the existing session", async () => {
+    const sender = mockSender();
+    const events = wireClientEvents(sender);
+
+    $callState.set({
+      phase: "active",
+      peer: "bob@waddle.test/phone",
+      sid: "old-call",
+      media: audioVideo,
+      join,
+      kind: "dm",
+      initiator: "alice@waddle.test/web",
+    });
+    events.emitCall({
+      kind: "propose",
+      from: "bob@waddle.test/tablet",
+      sid: "new-call",
+      media: audioVideo,
+    });
+    await flushCallSideEffects();
+    await flushCallSideEffects();
+
+    expect(sender.send_call_session_terminate).toHaveBeenCalledWith(
+      "bob@waddle.test/phone",
+      "old-call",
+      "expired",
+    );
+    expect(sender.send_call_finish_migrated).toHaveBeenCalledWith(
+      "bob@waddle.test/tablet",
+      "old-call",
+      "new-call",
+    );
+    expect(sender.send_call_proceed).toHaveBeenCalledWith(
+      "bob@waddle.test/tablet",
+      "new-call",
+    );
+    await flushCallSideEffects();
+    expect($callState.get()).toEqual({
+      phase: "incoming",
+      from: "bob@waddle.test/tablet",
+      sid: "new-call",
+      media: audioVideo,
+    });
+  });
+
+  test("real on_call active migration sends markers before old cleanup completes", async () => {
+    const sender = mockSender();
+    sender.send_call_session_terminate = mock(async () => {
+      await new Promise(() => undefined);
+    });
+    const events = wireClientEvents(sender);
+
+    $callState.set({
+      phase: "active",
+      peer: "bob@waddle.test/phone",
+      sid: "old-call",
+      media: audioVideo,
+      join,
+      kind: "dm",
+      initiator: "alice@waddle.test/web",
+    });
+    events.emitCall({
+      kind: "propose",
+      from: "bob@waddle.test/tablet",
+      sid: "new-call",
+      media: audioVideo,
+    });
+    await flushCallSideEffects();
+
+    expect(sender.send_call_finish_migrated).toHaveBeenCalledWith(
+      "bob@waddle.test/tablet",
+      "old-call",
+      "new-call",
+    );
+    expect(sender.send_call_proceed).toHaveBeenCalledWith(
+      "bob@waddle.test/tablet",
+      "new-call",
+    );
+    expect(sender.send_call_session_terminate).toHaveBeenCalledWith(
+      "bob@waddle.test/phone",
+      "old-call",
+      "expired",
+    );
+    expect($callState.get()).toEqual({
+      phase: "incoming",
+      from: "bob@waddle.test/tablet",
+      sid: "new-call",
+      media: audioVideo,
+    });
+  });
+
+  test("real on_call active migration proceeds even when old cleanup fails", async () => {
+    const sender = mockSender();
+    sender.send_call_session_terminate = mock(async () => {
+      throw new Error("terminate failed");
+    });
+    const events = wireClientEvents(sender);
+
+    $callState.set({
+      phase: "active",
+      peer: "bob@waddle.test/phone",
+      sid: "old-call",
+      media: audioVideo,
+      join,
+      kind: "dm",
+      initiator: "alice@waddle.test/web",
+    });
+    events.emitCall({
+      kind: "propose",
+      from: "bob@waddle.test/tablet",
+      sid: "new-call",
+      media: audioVideo,
+    });
+    await flushCallSideEffects();
+
+    expect(sender.send_call_finish_migrated).toHaveBeenCalledWith(
+      "bob@waddle.test/tablet",
+      "old-call",
+      "new-call",
+    );
+    expect(sender.send_call_proceed).toHaveBeenCalledWith(
+      "bob@waddle.test/tablet",
+      "new-call",
+    );
+    expect($callState.get()).toEqual({
+      phase: "incoming",
+      from: "bob@waddle.test/tablet",
+      sid: "new-call",
+      media: audioVideo,
+    });
+    expect($lastCallError.get()).toBe("terminate failed");
+  });
+
+  test("real on_call active migration does not leave old active UI when proceed fails", async () => {
+    const sender = mockSender();
+    sender.send_call_proceed = mock(async () => {
+      throw new Error("proceed failed");
+    });
+    const events = wireClientEvents(sender);
+
+    $callState.set({
+      phase: "active",
+      peer: "bob@waddle.test/phone",
+      sid: "old-call",
+      media: audioVideo,
+      join,
+      kind: "dm",
+      initiator: "alice@waddle.test/web",
+    });
+    events.emitCall({
+      kind: "propose",
+      from: "bob@waddle.test/tablet",
+      sid: "new-call",
+      media: audioVideo,
+    });
+    await flushCallSideEffects();
+
+    expect(sender.send_call_finish_migrated).toHaveBeenCalledWith(
+      "bob@waddle.test/tablet",
+      "old-call",
+      "new-call",
+    );
+    expect(sender.send_call_session_terminate).not.toHaveBeenCalled();
+    expect($callState.get()).toEqual({
+      phase: "ended",
+      sid: "old-call",
+      reason: "error",
+    });
+    expect($lastCallError.get()).toBe("proceed failed");
+  });
+
+  test("real on_call tie-break reject event surfaces expired rather than normal declined", () => {
+    const events = wireClientEvents();
+
+    beginOutgoingCall("bob@waddle.test", "c-lost", audioVideo);
+    events.emitCall({
+      kind: "reject",
+      from: "bob@waddle.test/phone",
+      sid: "c-lost",
+      reason: "expired",
+      tieBreak: true,
+    });
+
+    expect($callState.get()).toEqual({
+      phase: "ended",
+      sid: "c-lost",
+      reason: "expired",
+    });
+  });
+});
+
 describe("MUC group call", () => {
+  test("legacy presence event path updates the room call indicator from real presence events", () => {
+    const events = wireEmitterPresenceEvents();
+
+    events.emitPresence({
+      from: "Chan@MUC.Test/alice",
+      presence_type: "available",
+      muji: { preparing: false, active: true },
+    });
+
+    expect($mucCallParticipants.get()).toEqual({
+      "chan@muc.test": ["alice"],
+    });
+
+    events.emitPresence({
+      from: "Chan@MUC.Test/alice",
+      presence_type: "available",
+    });
+
+    expect($mucCallParticipants.get()).toEqual({});
+  });
+
+  test("BrowserXmppClient.disconnect clears group-call indicators seeded by presence events", async () => {
+    const disconnect = mock(async () => undefined);
+    const events = wireClientEvents({ disconnect } as unknown as Partial<CallWireSender>);
+    const client = events.client as unknown as {
+      disconnect: () => Promise<void>;
+    };
+
+    events.emitPresence({
+      from: "chan@muc.test/alice",
+      presence_type: "available",
+      muji: { preparing: false, active: true },
+    });
+    expect($mucCallParticipants.get()).toEqual({
+      "chan@muc.test": ["alice"],
+    });
+
+    await client.disconnect();
+
+    expect(disconnect).toHaveBeenCalledTimes(1);
+    expect($mucCallParticipants.get()).toEqual({});
+  });
+
+  test("BrowserXmppClient ignores stale call and presence events after disconnect", async () => {
+    const disconnect = mock(async () => undefined);
+    const events = wireClientEvents({ disconnect } as unknown as Partial<CallWireSender>);
+    const client = events.client as unknown as {
+      disconnect: () => Promise<void>;
+    };
+
+    await client.disconnect();
+
+    events.emitPresence({
+      from: "chan@muc.test/alice",
+      presence_type: "available",
+      muji: { preparing: false, active: true },
+    });
+    events.emitCall({
+      kind: "propose",
+      from: "bob@waddle.test/phone",
+      sid: "late-propose",
+      media: audioVideo,
+    });
+
+    expect($mucCallParticipants.get()).toEqual({});
+    expect($callState.get()).toEqual({ phase: "idle" });
+  });
+
   test("beginMucCall sets active(kind: 'muc') after awaiting the separate session-accept (XEP-0166 §6.3)", async () => {
+    const events = wireClientEvents();
     const expectedJoin: LiveKitJoin = {
       url: "wss://livekit.test",
       room: "chan@muc.test",
       identity: "alice@waddle.test/web",
       token: "jwt.payload.sig",
     };
+    const update_muji_presence = mockUpdateMujiPresenceWithEcho(events.emitPresence);
     const sender = {
       send_muji_session_initiate:
-        mockSendMujiSessionInitiateWithAccept(expectedJoin),
+        mockSendMujiSessionInitiateWithAccept(expectedJoin, events.emitCall),
+      update_muji_presence,
     };
     const { beginMucCall } = await import("../src/lib/calls/call-store");
-    await beginMucCall(sender, "chan@muc.test", audioVideo);
+    await beginMucCall(sender, "chan@muc.test", audioVideo, "alice");
     const state = $callState.get();
-    expect(state).toEqual({
+    expect(state).toMatchObject({
       phase: "active",
       peer: "chan@muc.test",
-      sid: "chan@muc.test",
       media: audioVideo,
       join: expectedJoin,
       kind: "muc",
-      selfNick: undefined,
+      selfNick: "alice",
     });
+    expect(typeof (state as { sid?: unknown }).sid).toBe("string");
+    expect((state as { sid: string }).sid).not.toBe("chan@muc.test");
     expect(sender.send_muji_session_initiate).toHaveBeenCalledWith(
       "chan@muc.test",
+      expect.any(String),
       true, // audioVideo.video
     );
   });
 
+  test("beginMucCall only resolves from the expected mixer and room event", async () => {
+    const events = wireClientEvents();
+    const forgedJoin: LiveKitJoin = {
+      url: "wss://evil-livekit.test",
+      room: "chan@muc.test",
+      identity: "mallory@waddle.test/desktop",
+      token: "evil.jwt",
+    };
+    const wrongRoomJoin: LiveKitJoin = {
+      url: "wss://livekit.test",
+      room: "other@muc.test",
+      identity: "alice@waddle.test/web",
+      token: "wrong.room.jwt",
+    };
+    const expectedJoin: LiveKitJoin = {
+      url: "wss://livekit.test",
+      room: "chan@muc.test",
+      identity: "alice@waddle.test/web",
+      token: "real.jwt",
+    };
+    const update_muji_presence = mockUpdateMujiPresenceWithEcho(events.emitPresence);
+    const send_muji_session_initiate = mock(async (_roomJid: string, sid: string) => {
+      queueMicrotask(() => {
+        events.emitCall({
+          kind: "session-accept",
+          from: "mallory@waddle.test/desktop",
+          sid,
+          media: audioVideo,
+          join: forgedJoin,
+        });
+        events.emitCall({
+          kind: "session-accept",
+          from: "calls.waddle.test",
+          sid,
+          media: audioVideo,
+          join: wrongRoomJoin,
+        });
+        events.emitCall({
+          kind: "session-accept",
+          from: "calls.waddle.test",
+          sid,
+          media: audioVideo,
+          join: expectedJoin,
+        });
+      });
+    });
+    const { beginMucCall } = await import("../src/lib/calls/call-store");
+
+    await beginMucCall(
+      { send_muji_session_initiate, update_muji_presence },
+      "chan@muc.test",
+      audioVideo,
+      "alice",
+      "calls.waddle.test",
+    );
+
+    expect($callState.get()).toMatchObject({
+      phase: "active",
+      peer: "chan@muc.test",
+      media: audioVideo,
+      join: expectedJoin,
+      kind: "muc",
+      selfNick: "alice",
+    });
+  });
+
+  test("beginMucCall rejects a second start while preparing/accept events are pending", async () => {
+    const events = wireClientEvents();
+    const expectedJoin: LiveKitJoin = {
+      url: "wss://livekit.test",
+      room: "chan@muc.test",
+      identity: "alice@waddle.test/web",
+      token: "jwt.payload.sig",
+    };
+    let emitPreparingEcho: (() => void) | null = null;
+    let emitAccept: (() => void) | null = null;
+    const update_muji_presence = mock(
+      async (
+        roomJid: string,
+        nick: string,
+        active: boolean,
+        preparing: boolean,
+        _video: boolean,
+      ) => {
+        if (preparing) {
+          emitPreparingEcho = () => events.emitPresence({
+            from: `${roomJid}/${nick}`,
+            presence_type: "available",
+            muji: { preparing: true, active: false },
+          });
+        }
+        if (active) {
+          events.emitPresence({
+            from: `${roomJid}/${nick}`,
+            presence_type: "available",
+            muji: { preparing: false, active: true },
+          });
+        }
+      },
+    );
+    const send_muji_session_initiate = mock(async (_roomJid: string, sid: string) => {
+      emitAccept = () => events.emitCall({
+        kind: "session-accept",
+        from: "calls.waddle.test",
+        sid,
+        media: audioVideo,
+        join: expectedJoin,
+      });
+    });
+    const { beginMucCall } = await import("../src/lib/calls/call-store");
+    const sender = {
+      send_muji_session_initiate,
+      update_muji_presence,
+    };
+
+    const first = beginMucCall(sender, "chan@muc.test", audioVideo, "alice");
+    const secondError = await beginMucCall(
+      sender,
+      "chan@muc.test",
+      audioVideo,
+      "alice",
+    ).then(
+      () => null,
+      (err) => err,
+    );
+
+    expect(secondError).toBeInstanceOf(Error);
+    expect(update_muji_presence).toHaveBeenCalledTimes(1);
+    const pendingState = $callState.get();
+    expect(pendingState).toMatchObject({
+      phase: "muc-pending",
+      peer: "chan@muc.test",
+      media: audioVideo,
+      kind: "muc",
+      selfNick: "alice",
+    });
+    expect(typeof (pendingState as { attemptId?: unknown }).attemptId).toBe("string");
+
+    emitPreparingEcho?.();
+    await flushCallSideEffects();
+    expect(update_muji_presence).toHaveBeenCalledTimes(2);
+    expect(send_muji_session_initiate).toHaveBeenCalledTimes(1);
+    emitAccept?.();
+    await first;
+
+    expect($callState.get()).toMatchObject({
+      phase: "active",
+      peer: "chan@muc.test",
+      media: audioVideo,
+      join: expectedJoin,
+      kind: "muc",
+      selfNick: "alice",
+    });
+  });
+
+  test("beginMucCall waits for other preparing participants before content presence", async () => {
+    const events = wireClientEvents();
+    const expectedJoin: LiveKitJoin = {
+      url: "wss://livekit.test",
+      room: "chan@muc.test",
+      identity: "alice@waddle.test/web",
+      token: "jwt.payload.sig",
+    };
+    events.emitPresence({
+      from: "chan@muc.test/bob",
+      presence_type: "available",
+      muji: { preparing: true, active: false },
+    });
+    const update_muji_presence = mockUpdateMujiPresenceWithEcho(events.emitPresence);
+    const send_muji_session_initiate =
+      mockSendMujiSessionInitiateWithAccept(expectedJoin, events.emitCall);
+    const { beginMucCall } = await import("../src/lib/calls/call-store");
+    const pending = beginMucCall(
+      { send_muji_session_initiate, update_muji_presence },
+      "chan@muc.test",
+      audioVideo,
+      "alice",
+    );
+
+    await flushCallSideEffects();
+    expect(update_muji_presence).toHaveBeenCalledTimes(1);
+    expect(send_muji_session_initiate).not.toHaveBeenCalled();
+
+    events.emitPresence({
+      from: "chan@muc.test/bob",
+      presence_type: "available",
+    });
+    await pending;
+
+    expect(update_muji_presence).toHaveBeenNthCalledWith(
+      2,
+      "chan@muc.test",
+      "alice",
+      true,
+      false,
+      true,
+    );
+    expect(send_muji_session_initiate).toHaveBeenCalledTimes(1);
+    expect($callState.get()).toMatchObject({
+      phase: "active",
+      peer: "chan@muc.test",
+      media: audioVideo,
+      join: expectedJoin,
+      kind: "muc",
+      selfNick: "alice",
+    });
+  });
+
+  test("group-call button action ignores a second click while start is pending", async () => {
+    const events = wireClientEvents();
+    const expectedJoin: LiveKitJoin = {
+      url: "wss://livekit.test",
+      room: "chan@muc.test",
+      identity: "alice@waddle.test/web",
+      token: "jwt.payload.sig",
+    };
+    let starting = false;
+    let emitPreparingEcho: (() => void) | null = null;
+    let emitAccept: (() => void) | null = null;
+    const update_muji_presence = mock(
+      async (
+        roomJid: string,
+        nick: string,
+        active: boolean,
+        preparing: boolean,
+        _video: boolean,
+      ) => {
+        if (preparing) {
+          emitPreparingEcho = () => events.emitPresence({
+            from: `${roomJid}/${nick}`,
+            presence_type: "available",
+            muji: { preparing: true, active: false },
+          });
+        }
+        if (active) {
+          events.emitPresence({
+            from: `${roomJid}/${nick}`,
+            presence_type: "available",
+            muji: { preparing: false, active: true },
+          });
+        }
+      },
+    );
+    const send_muji_session_initiate = mock(async (_roomJid: string, sid: string) => {
+      emitAccept = () => events.emitCall({
+        kind: "session-accept",
+        from: "calls.waddle.test",
+        sid,
+        media: audioVideo,
+        join: expectedJoin,
+      });
+    });
+    const sender = {
+      send_muji_session_initiate,
+      update_muji_presence,
+    };
+    const run = () => startMucCallAction({
+      roomJid: "chan@muc.test",
+      media: audioVideo,
+      isBusy: () => starting || !["idle", "ended"].includes($callState.get().phase),
+      setStarting: (next) => {
+        starting = next;
+      },
+      getSender: () => sender,
+      getSelfNick: () => "alice",
+    });
+
+    const first = run();
+    await flushCallSideEffects();
+    expect(starting).toBe(true);
+    expect($callState.get().phase).toBe("muc-pending");
+    expect(await run()).toBe(false);
+    expect(update_muji_presence).toHaveBeenCalledTimes(1);
+
+    emitPreparingEcho?.();
+    await flushCallSideEffects();
+    expect(send_muji_session_initiate).toHaveBeenCalledTimes(1);
+    emitAccept?.();
+    expect(await first).toBe(true);
+    expect(starting).toBe(false);
+    expect($callState.get()).toMatchObject({
+      phase: "active",
+      peer: "chan@muc.test",
+      media: audioVideo,
+      join: expectedJoin,
+      kind: "muc",
+      selfNick: "alice",
+    });
+  });
+
+  test("BrowserXmppClient.disconnect rejects a pending MUC preparing wait", async () => {
+    const events = wireClientEvents();
+    const update_muji_presence = mock(async () => undefined);
+    const send_muji_session_terminate = mock(async () => undefined);
+    const disconnect = mock(async () => undefined);
+    const client = events.client as unknown as {
+      xmpp: {
+        update_muji_presence: typeof update_muji_presence;
+        send_muji_session_terminate: typeof send_muji_session_terminate;
+        disconnect: typeof disconnect;
+      };
+      disconnect: () => Promise<void>;
+    };
+    client.xmpp = {
+      update_muji_presence,
+      send_muji_session_terminate,
+      disconnect,
+    };
+    const { beginMucCall } = await import("../src/lib/calls/call-store");
+    const pending = beginMucCall(
+      client.xmpp,
+      "chan@muc.test",
+      audioVideo,
+      "alice",
+    );
+    await flushCallSideEffects();
+    expect($callState.get().phase).toBe("muc-pending");
+
+    await client.disconnect();
+
+    await expect(pending).rejects.toThrow("cancelled");
+    expect(disconnect).toHaveBeenCalledTimes(1);
+    expect(send_muji_session_terminate).not.toHaveBeenCalled();
+    expect($callState.get()).toEqual({ phase: "idle" });
+  });
+
+  test("BrowserXmppClient.disconnect rejects a pending MUC session-accept wait", async () => {
+    const events = wireClientEvents();
+    const update_muji_presence = mockUpdateMujiPresenceWithEcho(events.emitPresence);
+    const send_muji_session_initiate = mock(async () => undefined);
+    const send_muji_session_terminate = mock(async () => undefined);
+    const disconnect = mock(async () => undefined);
+    const client = events.client as unknown as {
+      xmpp: {
+        update_muji_presence: typeof update_muji_presence;
+        send_muji_session_initiate: typeof send_muji_session_initiate;
+        send_muji_session_terminate: typeof send_muji_session_terminate;
+        disconnect: typeof disconnect;
+      };
+      disconnect: () => Promise<void>;
+    };
+    Object.assign(client.xmpp, {
+      update_muji_presence,
+      send_muji_session_initiate,
+      send_muji_session_terminate,
+      disconnect,
+    });
+    const { beginMucCall } = await import("../src/lib/calls/call-store");
+    const pending = beginMucCall(
+      client.xmpp,
+      "chan@muc.test",
+      audioVideo,
+      "alice",
+    );
+    await flushCallSideEffects();
+    await flushCallSideEffects();
+    expect($callState.get().phase).toBe("muc-pending");
+    expect(send_muji_session_initiate).toHaveBeenCalledTimes(1);
+
+    await client.disconnect();
+
+    await expect(pending).rejects.toThrow("cancelled");
+    expect(disconnect).toHaveBeenCalledTimes(1);
+    const attemptSid = firstMockCallArg(send_muji_session_initiate, 1);
+    expect(attemptSid).not.toBe("chan@muc.test");
+    expect(send_muji_session_terminate).toHaveBeenCalledWith(
+      "chan@muc.test",
+      attemptSid,
+    );
+    expect(update_muji_presence).toHaveBeenLastCalledWith(
+      "chan@muc.test",
+      "alice",
+      false,
+      false,
+      false,
+    );
+    expect($callState.get()).toEqual({ phase: "idle" });
+  });
+
+  test("real disconnected event rejects pending MUC session-accept wait without SFU teardown", async () => {
+    const events = wireClientEvents();
+    const update_muji_presence = mockUpdateMujiPresenceWithEcho(events.emitPresence);
+    const send_muji_session_initiate = mock(async () => undefined);
+    const send_muji_session_terminate = mock(async () => undefined);
+    const client = events.client as unknown as {
+      xmpp: {
+        update_muji_presence: typeof update_muji_presence;
+        send_muji_session_initiate: typeof send_muji_session_initiate;
+        send_muji_session_terminate: typeof send_muji_session_terminate;
+      };
+      disconnect: () => Promise<void>;
+    };
+    Object.assign(client.xmpp, {
+      update_muji_presence,
+      send_muji_session_initiate,
+      send_muji_session_terminate,
+    });
+    const { beginMucCall } = await import("../src/lib/calls/call-store");
+    const pending = beginMucCall(
+      client.xmpp,
+      "chan@muc.test",
+      audioVideo,
+      "alice",
+    );
+    await flushCallSideEffects();
+    await flushCallSideEffects();
+    expect(send_muji_session_initiate).toHaveBeenCalledTimes(1);
+
+    events.emitDisconnected();
+
+    await expect(pending).rejects.toThrow("cancelled");
+    expect(send_muji_session_terminate).not.toHaveBeenCalled();
+    expect($callState.get()).toEqual({ phase: "idle" });
+    await client.disconnect();
+  });
+
+  test("replacement MUC start is not rolled back by a stale disconnected attempt", async () => {
+    const firstEvents = wireClientEvents();
+    const secondEvents = wireClientEvents();
+    const expectedJoin: LiveKitJoin = {
+      url: "wss://livekit.test",
+      room: "chan@muc.test",
+      identity: "alice@waddle.test/web",
+      token: "replacement.jwt",
+    };
+    const staleJoin: LiveKitJoin = {
+      url: "wss://old-livekit.test",
+      room: "chan@muc.test",
+      identity: "alice@waddle.test/web",
+      token: "stale.jwt",
+    };
+    let staleSid = "";
+    const firstSender = {
+      send_muji_session_initiate: mock(async (_roomJid: string, sid: string) => {
+        staleSid = sid;
+      }),
+      update_muji_presence: mockUpdateMujiPresenceWithEcho(firstEvents.emitPresence),
+    };
+    const secondSender = {
+      send_muji_session_initiate: mock(async (_roomJid: string, sid: string) => {
+        queueMicrotask(() => {
+          secondEvents.emitCall({
+            kind: "session-accept",
+            from: "calls.waddle.test",
+            sid: staleSid,
+            media: audioVideo,
+            join: staleJoin,
+          });
+          secondEvents.emitCall({
+            kind: "session-accept",
+            from: "calls.waddle.test",
+            sid,
+            media: audioVideo,
+            join: expectedJoin,
+          });
+        });
+      }),
+      update_muji_presence: mockUpdateMujiPresenceWithEcho(secondEvents.emitPresence),
+    };
+    const { beginMucCall } = await import("../src/lib/calls/call-store");
+
+    const first = beginMucCall(
+      firstSender,
+      "chan@muc.test",
+      audioVideo,
+      "alice",
+      "calls.waddle.test",
+    );
+    await flushCallSideEffects();
+    await flushCallSideEffects();
+    expect(firstSender.send_muji_session_initiate).toHaveBeenCalledTimes(1);
+
+    firstEvents.emitDisconnected();
+    const second = beginMucCall(
+      secondSender,
+      "chan@muc.test",
+      audioVideo,
+      "alice",
+      "calls.waddle.test",
+    );
+
+    await expect(first).rejects.toThrow("cancelled");
+    await second;
+    expect($callState.get()).toMatchObject({
+      phase: "active",
+      peer: "chan@muc.test",
+      media: audioVideo,
+      join: expectedJoin,
+      kind: "muc",
+      selfNick: "alice",
+    });
+  });
+
   test("beginMucCall with a nick implements the XEP-0272 §Joining two-phase preparing→content flow", async () => {
+    const events = wireClientEvents();
     const send_muji_session_initiate = mockSendMujiSessionInitiateWithAccept({
       url: "wss://livekit.test",
       room: "chan@muc.test",
       identity: "alice@waddle.test/web",
       token: "jwt.payload.sig",
-    });
-    const update_muji_presence = mockUpdateMujiPresenceWithEcho();
+    }, events.emitCall);
+    const update_muji_presence = mockUpdateMujiPresenceWithEcho(events.emitPresence);
     const { beginMucCall } = await import("../src/lib/calls/call-store");
     await beginMucCall(
       {
@@ -287,8 +1304,8 @@ describe("MUC group call", () => {
     );
     // Two-phase flow:
     //   1. preparing  → `<muji><preparing/></muji>`
-    //   2. (session-initiate IQ round-trip — implicit wait for MUC echo)
-    //   3. active content → `<muji><content .../></muji>`
+    //   2. active content → `<muji><content .../></muji>`
+    //   3. session-initiate IQ round-trip after content presence
     expect(update_muji_presence).toHaveBeenCalledTimes(2);
     expect(update_muji_presence).toHaveBeenNthCalledWith(
       1,
@@ -298,10 +1315,6 @@ describe("MUC group call", () => {
       true, // preparing
       false, // video — irrelevant in preparing phase
     );
-    // The session-initiate must run BETWEEN the preparing and the
-    // content presences. mock() records call order globally
-    // across the mock pair, so we assert relative ordering.
-    expect(send_muji_session_initiate).toHaveBeenCalledTimes(1);
     expect(update_muji_presence).toHaveBeenNthCalledWith(
       2,
       "chan@muc.test",
@@ -310,6 +1323,7 @@ describe("MUC group call", () => {
       false, // preparing
       true, // video (audioVideo fixture has video=true)
     );
+    expect(send_muji_session_initiate).toHaveBeenCalledTimes(1);
   });
 
   test("tearDownActiveCall still clears the Muji presence when sendMujiSessionTerminate throws", async () => {
@@ -318,11 +1332,12 @@ describe("MUC group call", () => {
     // presence cleanup MUST still run — otherwise the user's
     // `<muji/>` advertisement lingers until the XMPP session
     // disconnects, exactly the bug this teardown path exists to fix.
-    const update_muji_presence = mockUpdateMujiPresenceWithEcho();
+    const events = wireClientEvents();
+    const update_muji_presence = mockUpdateMujiPresenceWithEcho(events.emitPresence);
     $callState.set({
       phase: "active",
       peer: "chan@muc.test",
-      sid: "chan@muc.test",
+      sid: "muc-attempt",
       media: audioVideo,
       join,
       kind: "muc",
@@ -347,11 +1362,12 @@ describe("MUC group call", () => {
 
   test("tearDownActiveCall on a MUC call dispatches Muji session-terminate AND clears the presence", async () => {
     const send_muji_session_terminate = mock(async () => undefined);
-    const update_muji_presence = mockUpdateMujiPresenceWithEcho();
+    const events = wireClientEvents();
+    const update_muji_presence = mockUpdateMujiPresenceWithEcho(events.emitPresence);
     $callState.set({
       phase: "active",
       peer: "chan@muc.test",
-      sid: "chan@muc.test",
+      sid: "muc-attempt",
       media: audioVideo,
       join,
       kind: "muc",
@@ -365,7 +1381,10 @@ describe("MUC group call", () => {
       "gone",
     );
     expect(send_muji_session_terminate).toHaveBeenCalledTimes(1);
-    expect(send_muji_session_terminate).toHaveBeenCalledWith("chan@muc.test");
+    expect(send_muji_session_terminate).toHaveBeenCalledWith(
+      "chan@muc.test",
+      "muc-attempt",
+    );
     expect(update_muji_presence).toHaveBeenCalledTimes(1);
     expect(update_muji_presence).toHaveBeenCalledWith(
       "chan@muc.test",
@@ -374,6 +1393,283 @@ describe("MUC group call", () => {
       false, // preparing
       false, // video
     );
+    expect($callState.get()).toEqual({ phase: "idle" });
+  });
+
+  test("beginMucCall treats active Muji presence failure as fatal and rolls back SFU/session work", async () => {
+    const events = wireClientEvents();
+    const send_muji_session_terminate = mock(async () => undefined);
+    const send_muji_session_initiate = mockSendMujiSessionInitiateWithAccept({
+      url: "wss://livekit.test",
+      room: "chan@muc.test",
+      identity: "alice@waddle.test/web",
+      token: "jwt.payload.sig",
+    }, events.emitCall);
+    const update_muji_presence = mock(
+      async (
+        roomJid: string,
+        nick: string,
+        active: boolean,
+        preparing: boolean,
+        _video: boolean,
+      ) => {
+        if (preparing) {
+          events.emitPresence({
+            from: `${roomJid}/${nick}`,
+            presence_type: "available",
+            muji: { preparing: true, active: false },
+          });
+          return;
+        }
+        if (active) throw new Error("presence publish failed");
+        events.emitPresence({
+          from: `${roomJid}/${nick}`,
+          presence_type: "available",
+        });
+      },
+    );
+    const { beginMucCall } = await import("../src/lib/calls/call-store");
+    await expect(beginMucCall(
+      {
+        send_muji_session_initiate,
+        send_muji_session_terminate,
+        update_muji_presence,
+      },
+      "Chan@MUC.Test/ignored",
+      audioVideo,
+      "alice",
+    )).rejects.toThrow("presence publish failed");
+    expect(send_muji_session_initiate).not.toHaveBeenCalled();
+    expect(send_muji_session_terminate).not.toHaveBeenCalled();
+    expect($callState.get()).toEqual({ phase: "idle" });
+    expect($mucCallParticipants.get()["chan@muc.test"]).toBeUndefined();
+  });
+
+  test("room switch tears down the old room's active MUC call before leaving", async () => {
+    const events = wireClientEvents();
+    const send_muji_session_terminate = mock(async () => undefined);
+    const update_muji_presence = mockUpdateMujiPresenceWithEcho(events.emitPresence);
+    const leave_room = mock(async () => undefined);
+    const operationOrder: string[] = [];
+    const xmpp = {
+      send_muji_session_terminate: mock(async (roomJid: string, sid: string) => {
+        operationOrder.push(`terminate:${roomJid}:${sid}`);
+        await send_muji_session_terminate(roomJid, sid);
+      }),
+      update_muji_presence: mock(async (
+        roomJid: string,
+        nick: string,
+        active: boolean,
+        preparing: boolean,
+        video: boolean,
+      ) => {
+        operationOrder.push(`presence:${active}:${preparing}`);
+        await update_muji_presence(roomJid, nick, active, preparing, video);
+      }),
+      leave_room: mock(async (roomJid: string, nick: string) => {
+        operationOrder.push(`leave:${roomJid}/${nick}`);
+        await leave_room(roomJid, nick);
+      }),
+    };
+    const client = events.client as unknown as {
+      xmpp: typeof xmpp;
+      currentRoom: string | null;
+      roomHats: Record<string, unknown>;
+      roomAuthority: Record<string, unknown>;
+      roomPresence: Record<string, unknown>;
+      roomMemberJids: Record<string, string>;
+      performRoomSwitch: (roomJid: string) => Promise<void>;
+    };
+    Object.assign(client.xmpp, xmpp);
+    client.currentRoom = "old@muc.test";
+    $callState.set({
+      phase: "active",
+      peer: "old@muc.test",
+      sid: "old-muc-attempt",
+      media: audioVideo,
+      join,
+      kind: "muc",
+      selfNick: "alice",
+    });
+
+    await client.performRoomSwitch("new@muc.test");
+
+    expect(operationOrder).toEqual([
+      "presence:false:false",
+      "terminate:old@muc.test:old-muc-attempt",
+      "leave:old@muc.test/alice",
+    ]);
+    expect($callState.get()).toEqual({ phase: "idle" });
+  });
+
+  test("room switch does not join the new room after a concurrent disconnect", async () => {
+    const events = wireClientEvents();
+    let releaseLeave: (() => void) | null = null;
+    let leaveStarted: (() => void) | null = null;
+    const leaveGate = new Promise<void>((resolve) => {
+      releaseLeave = resolve;
+    });
+    const leaveStartedWait = new Promise<void>((resolve) => {
+      leaveStarted = resolve;
+    });
+    let leaveCalls = 0;
+    const leave_room = mock(async () => {
+      leaveCalls += 1;
+      if (leaveCalls === 1) {
+        leaveStarted?.();
+        await leaveGate;
+      }
+    });
+    const join_room = mock(async () => undefined);
+    const disconnect = mock(async () => undefined);
+    const xmpp = { leave_room, join_room, disconnect };
+    const client = events.client as unknown as {
+      xmpp: typeof xmpp;
+      currentRoom: string | null;
+      performRoomSwitch: (roomJid: string) => Promise<void>;
+      disconnect: () => Promise<void>;
+    };
+    Object.assign(client.xmpp, xmpp);
+    client.currentRoom = "old@muc.test";
+
+    const switched = client.performRoomSwitch("new@muc.test");
+    await leaveStartedWait;
+    const disconnected = client.disconnect();
+    releaseLeave?.();
+    await switched;
+    await disconnected;
+
+    expect(join_room).not.toHaveBeenCalled();
+    expect(client.currentRoom).toBe(null);
+  });
+
+  test("room switch cancels the old room's pending MUC call before leaving", async () => {
+    const events = wireClientEvents();
+    const send_muji_session_initiate = mock(async () => undefined);
+    const send_muji_session_terminate = mock(async () => undefined);
+    const update_muji_presence = mockUpdateMujiPresenceWithEcho(events.emitPresence);
+    const leave_room = mock(async () => undefined);
+    const operationOrder: string[] = [];
+    const xmpp = {
+      send_muji_session_initiate: mock(async (roomJid: string, _sid: string, video: boolean) => {
+        operationOrder.push(`initiate:${roomJid}:${video}`);
+        await send_muji_session_initiate(roomJid, _sid, video);
+      }),
+      send_muji_session_terminate: mock(async (roomJid: string, sid: string) => {
+        operationOrder.push(`terminate:${roomJid}:${sid}`);
+        await send_muji_session_terminate(roomJid, sid);
+      }),
+      update_muji_presence: mock(async (
+        roomJid: string,
+        nick: string,
+        active: boolean,
+        preparing: boolean,
+        video: boolean,
+      ) => {
+        operationOrder.push(`presence:${active}:${preparing}:${video}`);
+        await update_muji_presence(roomJid, nick, active, preparing, video);
+      }),
+      leave_room: mock(async (roomJid: string, nick: string) => {
+        operationOrder.push(`leave:${roomJid}/${nick}`);
+        await leave_room(roomJid, nick);
+      }),
+    };
+    const client = events.client as unknown as {
+      xmpp: typeof xmpp;
+      currentRoom: string | null;
+      roomHats: Record<string, unknown>;
+      roomAuthority: Record<string, unknown>;
+      roomPresence: Record<string, unknown>;
+      roomMemberJids: Record<string, string>;
+      performRoomSwitch: (roomJid: string) => Promise<void>;
+    };
+    Object.assign(client.xmpp, xmpp);
+    const wiredXmpp = client.xmpp;
+    client.currentRoom = "old@muc.test";
+    const { beginMucCall } = await import("../src/lib/calls/call-store");
+    const pending = beginMucCall(wiredXmpp, "old@muc.test", audioVideo, "alice");
+    await flushCallSideEffects();
+    await flushCallSideEffects();
+    expect($callState.get().phase).toBe("muc-pending");
+    expect(send_muji_session_initiate).toHaveBeenCalledTimes(1);
+    const attemptSid = firstMockCallArg(send_muji_session_initiate, 1);
+    expect(attemptSid).not.toBe("old@muc.test");
+
+    await client.performRoomSwitch("new@muc.test");
+
+    await expect(pending).rejects.toThrow("cancelled");
+    expect(operationOrder).toEqual([
+      "presence:false:true:false",
+      "presence:true:false:true",
+      "initiate:old@muc.test:true",
+      "presence:false:false:false",
+      `terminate:old@muc.test:${attemptSid}`,
+      "leave:old@muc.test/alice",
+    ]);
+    expect($callState.get()).toEqual({ phase: "idle" });
+  });
+
+  test("room switch cancels a MUC start waiting for the old room's preparing echo", async () => {
+    const events = wireClientEvents();
+    const send_muji_session_initiate = mock(async () => undefined);
+    const update_muji_presence = mock(async () => undefined);
+    const leave_room = mock(async () => undefined);
+    const operationOrder: string[] = [];
+    const xmpp = {
+      send_muji_session_initiate: mock(async (roomJid: string, _sid: string, video: boolean) => {
+        operationOrder.push(`initiate:${roomJid}:${video}`);
+        await send_muji_session_initiate(roomJid, _sid, video);
+      }),
+      update_muji_presence: mock(async (
+        roomJid: string,
+        nick: string,
+        active: boolean,
+        preparing: boolean,
+        video: boolean,
+      ) => {
+        operationOrder.push(`presence:${roomJid}/${nick}:${active}:${preparing}:${video}`);
+        await update_muji_presence(roomJid, nick, active, preparing, video);
+      }),
+      leave_room: mock(async (roomJid: string, nick: string) => {
+        operationOrder.push(`leave:${roomJid}/${nick}`);
+        await leave_room(roomJid, nick);
+      }),
+    };
+    const client = events.client as unknown as {
+      xmpp: typeof xmpp;
+      currentRoom: string | null;
+      roomHats: Record<string, unknown>;
+      roomAuthority: Record<string, unknown>;
+      roomPresence: Record<string, unknown>;
+      roomMemberJids: Record<string, string>;
+      performRoomSwitch: (roomJid: string) => Promise<void>;
+    };
+    Object.assign(client.xmpp, xmpp);
+    const wiredXmpp = client.xmpp;
+    client.currentRoom = "old@muc.test";
+    const { beginMucCall } = await import("../src/lib/calls/call-store");
+    const pending = beginMucCall(wiredXmpp, "old@muc.test", audioVideo, "alice");
+    await flushCallSideEffects();
+    await flushCallSideEffects();
+    expect($callState.get().phase).toBe("muc-pending");
+    expect(send_muji_session_initiate).toHaveBeenCalledTimes(0);
+
+    await client.performRoomSwitch("new@muc.test");
+    await expect(pending).rejects.toThrow("cancelled");
+
+    events.emitPresence({
+      from: "old@muc.test/alice",
+      presence_type: "available",
+      muji: { preparing: true, active: false },
+    });
+    await flushCallSideEffects();
+
+    expect(send_muji_session_initiate).toHaveBeenCalledTimes(0);
+    expect(operationOrder).toEqual([
+      "presence:old@muc.test/alice:false:true:false",
+      "presence:old@muc.test/alice:false:false:false",
+      "leave:old@muc.test/alice",
+    ]);
     expect($callState.get()).toEqual({ phase: "idle" });
   });
 });

--- a/chat/tests/call-tie-break.test.ts
+++ b/chat/tests/call-tie-break.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import {
+  compareOctetStrings,
+  incomingProposeWinsTieBreak,
+  isSameCallBareJid,
+} from "../src/lib/calls/tie-break";
+
+describe("call tie-break helpers", () => {
+  test("compares session ids with octet collation semantics", () => {
+    expect(compareOctetStrings("a", "b")).toBeLessThan(0);
+    expect(compareOctetStrings("b", "a")).toBeGreaterThan(0);
+    expect(compareOctetStrings("a", "aa")).toBeLessThan(0);
+    expect(compareOctetStrings("aa", "a")).toBeGreaterThan(0);
+    expect(compareOctetStrings("c1", "c1")).toBe(0);
+  });
+
+  test("lower incoming sid wins the simultaneous propose tie-break", () => {
+    expect(
+      incomingProposeWinsTieBreak(
+        "a-incoming",
+        "z-outgoing",
+        "bob@waddle.test/phone",
+        "alice@waddle.test/web",
+      ),
+    ).toBe(true);
+    expect(
+      incomingProposeWinsTieBreak(
+        "z-incoming",
+        "a-outgoing",
+        "bob@waddle.test/phone",
+        "alice@waddle.test/web",
+      ),
+    ).toBe(false);
+  });
+
+  test("equal sid falls back to lower full JabberID", () => {
+    expect(
+      incomingProposeWinsTieBreak(
+        "same",
+        "same",
+        "alice@waddle.test/phone",
+        "bob@waddle.test/web",
+      ),
+    ).toBe(true);
+    expect(
+      incomingProposeWinsTieBreak(
+        "same",
+        "same",
+        "carol@waddle.test/phone",
+        "bob@waddle.test/web",
+      ),
+    ).toBe(false);
+  });
+
+  test("matches full resources by bare JID before applying tie-break", () => {
+    expect(isSameCallBareJid("Bob@Waddle.Test/phone", "bob@waddle.test")).toBe(true);
+    expect(isSameCallBareJid("carol@waddle.test/phone", "bob@waddle.test")).toBe(false);
+  });
+});

--- a/chat/tests/muc-call-indicators.test.ts
+++ b/chat/tests/muc-call-indicators.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import {
+  callParticipantCountForChannel,
+  collapsedGroupBadgeModel,
+} from "../src/lib/calls/muc-call-indicators";
+
+describe("callParticipantCountForChannel", () => {
+  test("matches channel jid with normalized room jid counts", () => {
+    expect(callParticipantCountForChannel(
+      { id: "general", jid: "General@MUC.Test/mobile" },
+      { "general@muc.test": 2 },
+      new Set(),
+    )).toBe(2);
+  });
+
+  test("falls back to active room jids when the channel summary lacks a jid", () => {
+    expect(callParticipantCountForChannel(
+      { id: "general" },
+      { "general@muc.test": 1 },
+      new Set(["General@MUC.Test"]),
+    )).toBe(1);
+  });
+
+  test("does not let an unrelated active call hide this channel's count", () => {
+    expect(callParticipantCountForChannel(
+      { id: "general", jid: "general@muc.test" },
+      {
+        "general@muc.test": 1,
+        "random@muc.test": 4,
+      },
+      new Set(["random@muc.test"]),
+    )).toBe(1);
+  });
+
+  test("fallback active-room matching does not use substring collisions", () => {
+    expect(callParticipantCountForChannel(
+      { id: "gen" },
+      { "general@muc.test": 3 },
+      new Set(["general@muc.test"]),
+    )).toBe(0);
+  });
+});
+
+describe("collapsedGroupBadgeModel", () => {
+  test("renders call count alongside mentions instead of hiding notifications", () => {
+    expect(collapsedGroupBadgeModel({
+      callCount: 2,
+      mentions: 1,
+      unread: 5,
+      hasActivity: true,
+    })).toEqual({
+      callCount: 2,
+      notification: { kind: "mentions", count: 1 },
+    });
+  });
+
+  test("preserves unread and activity badges when no mention is present", () => {
+    expect(collapsedGroupBadgeModel({
+      callCount: 1,
+      mentions: 0,
+      unread: 3,
+      hasActivity: true,
+    })).toEqual({
+      callCount: 1,
+      notification: { kind: "unread", count: 3 },
+    });
+    expect(collapsedGroupBadgeModel({
+      callCount: 0,
+      mentions: 0,
+      unread: 0,
+      hasActivity: true,
+    })).toEqual({
+      callCount: 0,
+      notification: { kind: "activity" },
+    });
+  });
+});

--- a/chat/tests/muc-call-presence.test.ts
+++ b/chat/tests/muc-call-presence.test.ts
@@ -4,6 +4,7 @@ import {
   applyMucCallPresence,
   awaitPreparingEcho,
   clearMucCallParticipants,
+  mucCallParticipantCounts,
   mucCallParticipantCount,
 } from "../src/lib/calls/muc-call-presence";
 
@@ -21,7 +22,7 @@ const preparingMuji = { preparing: true, active: false } as const;
 describe("applyMucCallPresence", () => {
   test("available presence with active Muji registers the nick", () => {
     applyMucCallPresence({
-      from: "room@muc.test/alice",
+      from: "Room@MUC.Test/alice",
       presence_type: "available",
       muji: activeMuji,
     });
@@ -29,6 +30,7 @@ describe("applyMucCallPresence", () => {
       "room@muc.test": ["alice"],
     });
     expect(mucCallParticipantCount("room@muc.test")).toBe(1);
+    expect(mucCallParticipantCount("ROOM@MUC.TEST/resource")).toBe(1);
   });
 
   test("multiple occupants accumulate per room", () => {
@@ -159,6 +161,27 @@ describe("applyMucCallPresence", () => {
     expect($mucCallParticipants.get()).toEqual({});
   });
 
+  test("clearMucCallParticipants rejects pending preparing echo waiters", async () => {
+    const result = awaitPreparingEcho("room@muc.test", "alice", 5000)
+      .then(() => "resolved" as const)
+      .catch((err) => err);
+    clearMucCallParticipants();
+    const err = await result;
+    expect(err).toBeInstanceOf(Error);
+    expect(String(err.message)).toContain("cancelled");
+  });
+
+  test("mucCallParticipantCounts normalizes room keys for sidebar/header indicators", () => {
+    expect(mucCallParticipantCounts({
+      "Room@MUC.Test/web": ["alice"],
+      "room@muc.test": ["bob"],
+      "other@muc.test": ["carol"],
+    })).toEqual({
+      "room@muc.test": 2,
+      "other@muc.test": 1,
+    });
+  });
+
   test("registers the local user's own nick when their sibling resource starts a call (regression: cross-instance indicator)", () => {
     // Scenario: alice is signed in on two browser instances (web +
     // mobile). Both have joined `room@muc.test` with the same nick
@@ -247,9 +270,9 @@ describe("awaitPreparingEcho (XEP-0272 §Joining MUST)", () => {
     // continue to block until the MUC echoes preparing.
     const wait = awaitPreparingEcho("room@muc.test", "alice", 200);
     let resolved = false;
-    wait.then(() => {
+    void wait.then(() => {
       resolved = true;
-    });
+    }).catch(() => undefined);
     applyMucCallPresence({
       from: "room@muc.test/alice",
       presence_type: "available",
@@ -257,17 +280,14 @@ describe("awaitPreparingEcho (XEP-0272 §Joining MUST)", () => {
     });
     await new Promise((r) => setTimeout(r, 10));
     expect(resolved).toBe(false);
-    // Eventually the 200ms timeout will resolve it; await to clean up.
-    await wait;
+    await expect(wait).rejects.toThrow("Timed out waiting for Muji preparing presence echo");
   });
 
-  test("falls back to timeout when no echo arrives", async () => {
-    // The MUC may have dropped the presence; we don't want to
-    // hang the call setup forever. 50ms timeout for the test.
-    const start = Date.now();
-    await awaitPreparingEcho("room@muc.test/nobody", "alice", 50);
-    const elapsed = Date.now() - start;
-    expect(elapsed).toBeGreaterThanOrEqual(40); // some scheduling slack
-    expect(elapsed).toBeLessThan(500);
+  test("rejects on timeout when no echo arrives", async () => {
+    // Missing preparing echo is fatal for strict XEP-0272 setup:
+    // beginMucCall must roll back instead of proceeding with room
+    // state the MUC never reflected.
+    await expect(awaitPreparingEcho("room@muc.test/nobody", "alice", 50))
+      .rejects.toThrow("Timed out waiting for Muji preparing presence echo");
   });
 });

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -106,7 +106,7 @@ rand = "0.10"
 hex = "0.4"
 lru = "0.18"
 regex = "1.12"
-jsonwebtoken = "10.4"
+jsonwebtoken = { version = "10.4", features = ["aws_lc_rs"] }
 
 # Markdown/Syntax (CLI)
 pulldown-cmark = "0.13"

--- a/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
@@ -57,6 +57,48 @@ pub(crate) fn broadcast_muc_leave_to_remaining(
     }
 }
 
+/// Broadcast a canonical available room/nick presence without
+/// `<muji/>` after the resource that owned the Muji state leaves
+/// while another same-nick session remains.
+pub(crate) fn broadcast_muc_muji_clear_to_remaining(
+    state: &WebSocketState,
+    room_jid: &BareJid,
+    outcome: &LeaveOutcome,
+) {
+    if outcome.removed_last_session || !outcome.cleared_muji_state {
+        return;
+    }
+    let Some(real_jid) = outcome.remaining_nick_real_jid.as_ref() else {
+        return;
+    };
+    let from_jid = room_jid
+        .clone()
+        .with_resource_str(&outcome.nick)
+        .unwrap_or_else(|_| real_jid.clone());
+    let real_bare = real_jid.to_bare();
+    let identity = OccupantIdentity {
+        bare_jid: &real_bare,
+        real_jid: Some(real_jid),
+        secret: &state.deps.occupant_id_secret,
+    };
+    for occupant_jid in &outcome.remaining_occupants {
+        let is_self = occupant_jid.to_bare() == real_bare;
+        let presence = waddle_xmpp::muc::build_occupant_presence(
+            &from_jid,
+            occupant_jid,
+            outcome.affiliation,
+            outcome.role,
+            is_self,
+            &identity,
+        );
+        let _ = state
+            .deps
+            .protocol
+            .connection_registry
+            .try_send_to(occupant_jid, Stanza::Presence(presence));
+    }
+}
+
 /// Clean up MUC room presence when a connection disconnects
 /// Public alias for the MUC-presence cleanup used by the SM expired-session
 /// janitor in `server::mod`. Thin passthrough so the janitor doesn't need
@@ -346,6 +388,7 @@ async fn cleanup_muc_presence(state: &WebSocketState, jid: &FullJid) {
                 // wire shape is identical regardless of how the
                 // session ended.
                 broadcast_muc_leave_to_remaining(state, &room_jid, jid, &outcome);
+                broadcast_muc_muji_clear_to_remaining(state, &room_jid, &outcome);
                 maybe_evict_empty_room(state, &room_jid, &outcome).await;
             }
             Ok(None) => {}

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -394,6 +394,7 @@ pub async fn handle_muc_leave(
     super::super::super::cleanup::broadcast_muc_leave_to_remaining(
         state, room_jid, sender_jid, &outcome,
     );
+    super::super::super::cleanup::broadcast_muc_muji_clear_to_remaining(state, room_jid, &outcome);
 
     let response = vec![build_muc_self_unavailable_xml(
         state,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
@@ -34,7 +34,10 @@
 
 use jid::{BareJid, FullJid};
 use tracing::{debug, warn};
-use waddle_xmpp::muc::{build_occupant_presence_update, room_actor::UpsertMujiPresence};
+use waddle_xmpp::muc::{
+    build_occupant_presence_update,
+    room_actor::{ClearMujiPresence, UpsertMujiPresence},
+};
 use waddle_xmpp::xep::xep0272::{find_muji, Muji, NS_MUJI};
 use waddle_xmpp::xep::xep0421::OccupantIdentity;
 use waddle_xmpp::Stanza;
@@ -73,32 +76,46 @@ pub(super) async fn try_handle_muc_presence_update(
     let actor = get_room_actor(state, room_jid).await?;
     let muji = extract_muji(incoming);
 
-    // No `<muji/>` extension AND the client isn't otherwise updating
-    // a payload we propagate — fall through to the join path. Today
-    // the only payload we explicitly forward is the Muji extension;
-    // generic `<show/>` / `<status/>` updates still re-run join,
-    // which is wasteful but pre-existing behavior. Scoped fix.
-    let muji = muji?;
-
-    let outcome = match actor
-        .ask(UpsertMujiPresence {
-            sender_jid: sender_jid.clone(),
-            muji,
-        })
-        .await
-    {
-        Ok(Some(outcome)) => outcome,
-        Ok(None) => return None,
-        Err(error) => {
-            warn!(
-                room = %room_jid,
-                nick = %nick,
-                sender = %sender_jid,
-                error = ?error,
-                "Failed to upsert MUC Muji presence; falling back to join path"
-            );
-            return None;
-        }
+    let outcome = match muji {
+        Some(muji) => match actor
+            .ask(UpsertMujiPresence {
+                sender_jid: sender_jid.clone(),
+                muji,
+            })
+            .await
+        {
+            Ok(Some(outcome)) => outcome,
+            Ok(None) => return None,
+            Err(error) => {
+                warn!(
+                    room = %room_jid,
+                    nick = %nick,
+                    sender = %sender_jid,
+                    error = ?error,
+                    "Failed to upsert MUC Muji presence; falling back to join path"
+                );
+                return None;
+            }
+        },
+        None => match actor
+            .ask(ClearMujiPresence {
+                sender_jid: sender_jid.clone(),
+            })
+            .await
+        {
+            Ok(Some(outcome)) => outcome,
+            Ok(None) => return None,
+            Err(error) => {
+                warn!(
+                    room = %room_jid,
+                    nick = %nick,
+                    sender = %sender_jid,
+                    error = ?error,
+                    "Failed to clear MUC Muji presence; falling back to join path"
+                );
+                return None;
+            }
+        },
     };
 
     // XEP-0045 §7.7: a user may change their *own* in-room presence

--- a/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
@@ -92,6 +92,10 @@ mod tests {
 
         fn register_call_participant(&self, _: &CallId, _: &Identity) {}
 
+        fn has_call_participant(&self, _: &CallId, _: &Identity) -> bool {
+            false
+        }
+
         fn unregister_call_participant(&self, call_id: &CallId, identity: &Identity) -> CallState {
             self.calls
                 .lock()

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -981,6 +981,248 @@ async fn cleanup_muc_presence_broadcasts_unavailable_to_remaining_occupants() {
     assert_eq!(presence.attr("to"), Some(expected_to.as_str()));
 }
 
+fn active_muji() -> waddle_xmpp::xep::xep0272::Muji {
+    use waddle_xmpp::xep::xep0167::MediaKind;
+    use waddle_xmpp::xep::xep0272::{Creator, Muji, MujiContent};
+    Muji::with_contents(vec![MujiContent::new(
+        "audio",
+        Creator::Initiator,
+        MediaKind::Audio,
+    )])
+}
+
+fn muc_presence_to(room_jid: &BareJid, nick: &str) -> xmpp_parsers::presence::Presence {
+    let mut presence = xmpp_parsers::presence::Presence::new(xmpp_parsers::presence::Type::None);
+    presence.to = Some(
+        room_jid
+            .clone()
+            .with_resource_str(nick)
+            .expect("valid room nick")
+            .into(),
+    );
+    presence
+}
+
+#[tokio::test]
+async fn available_presence_without_muji_clears_existing_muji_state() {
+    let state = create_test_websocket_state().await;
+    let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let room_jid: BareJid = "muji-clear-channel@muc.example.com"
+        .parse()
+        .expect("room jid");
+    let alice: FullJid = "alice@example.com/web".parse().expect("alice jid");
+    let bob: FullJid = "bob@example.com/desktop".parse().expect("bob jid");
+
+    let (bob_tx, mut bob_rx) = mpsc::channel::<OutboundStanza>(8);
+    state
+        .deps
+        .protocol
+        .connection_registry
+        .register(bob.clone(), bob_tx);
+
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &alice,
+        "alice",
+        None,
+        &Some(owner_session.clone()),
+    )
+    .await;
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &bob,
+        "bob",
+        None,
+        &None,
+    )
+    .await;
+    while bob_rx.try_recv().is_ok() {}
+
+    let alice_phase = waddle_xmpp::protocol::ConnectionPhase::ready(alice.clone(), false);
+    let mut active = muc_presence_to(&room_jid, "alice");
+    active.payloads.push(active_muji().to_element());
+    let _ = handlers::presence::handle_presence(
+        active,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &alice_phase,
+        &Some(owner_session),
+    )
+    .await;
+    while bob_rx.try_recv().is_ok() {}
+
+    let plain_available = muc_presence_to(&room_jid, "alice");
+    let responses = handlers::presence::handle_presence(
+        plain_available,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &alice_phase,
+        &None,
+    )
+    .await;
+    assert_eq!(responses.len(), 1, "sender receives reflected clear");
+    let self_clear = Element::from_str(&responses[0]).expect("self clear XML");
+    assert_eq!(
+        self_clear.attr("from"),
+        Some(format!("{room_jid}/alice").as_str())
+    );
+    assert!(
+        self_clear
+            .get_child("muji", waddle_xmpp::xep::xep0272::NS_MUJI)
+            .is_none(),
+        "self reflection must omit <muji/> after clear"
+    );
+
+    let broadcast = bob_rx
+        .try_recv()
+        .expect("Bob must receive canonical non-Muji presence");
+    let xml = stanza_to_xml(&broadcast.stanza);
+    let presence = Element::from_str(&xml).expect("broadcast presence XML");
+    assert_eq!(presence.name(), "presence");
+    assert_eq!(presence.attr("type"), None);
+    assert_eq!(
+        presence.attr("from"),
+        Some(format!("{room_jid}/alice").as_str())
+    );
+    assert_eq!(presence.attr("to"), Some(bob.to_string().as_str()));
+    assert!(
+        presence
+            .get_child("muji", waddle_xmpp::xep::xep0272::NS_MUJI)
+            .is_none(),
+        "clear broadcast must not carry <muji/>"
+    );
+
+    let carol: FullJid = "carol@example.com/web".parse().expect("carol jid");
+    let replay = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &carol,
+        "carol",
+        None,
+        &None,
+    )
+    .await;
+    let alice_replay = replay
+        .iter()
+        .filter_map(|xml| Element::from_str(xml).ok())
+        .find(|element| element.attr("from") == Some(format!("{room_jid}/alice").as_str()))
+        .expect("carol receives alice replay");
+    assert!(
+        alice_replay
+            .get_child("muji", waddle_xmpp::xep::xep0272::NS_MUJI)
+            .is_none(),
+        "late join replay must not include stale Muji"
+    );
+}
+
+#[tokio::test]
+async fn same_nick_originator_leave_broadcasts_muji_clear() {
+    let state = create_test_websocket_state().await;
+    let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let room_jid: BareJid = "same-nick-muji-clear@muc.example.com"
+        .parse()
+        .expect("room jid");
+    let desktop: FullJid = "alice@example.com/desktop".parse().expect("desktop jid");
+    let mobile: FullJid = "alice@example.com/mobile".parse().expect("mobile jid");
+    let bob: FullJid = "bob@example.com/desktop".parse().expect("bob jid");
+
+    let (mobile_tx, mut mobile_rx) = mpsc::channel::<OutboundStanza>(8);
+    state
+        .deps
+        .protocol
+        .connection_registry
+        .register(mobile.clone(), mobile_tx);
+    let (bob_tx, mut bob_rx) = mpsc::channel::<OutboundStanza>(8);
+    state
+        .deps
+        .protocol
+        .connection_registry
+        .register(bob.clone(), bob_tx);
+
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &desktop,
+        "alice",
+        None,
+        &Some(owner_session.clone()),
+    )
+    .await;
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &mobile,
+        "alice",
+        None,
+        &None,
+    )
+    .await;
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &bob,
+        "bob",
+        None,
+        &None,
+    )
+    .await;
+    while mobile_rx.try_recv().is_ok() {}
+    while bob_rx.try_recv().is_ok() {}
+
+    let desktop_phase = waddle_xmpp::protocol::ConnectionPhase::ready(desktop.clone(), false);
+    let mut active = muc_presence_to(&room_jid, "alice");
+    active.payloads.push(active_muji().to_element());
+    let _ = handlers::presence::handle_presence(
+        active,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &desktop_phase,
+        &Some(owner_session),
+    )
+    .await;
+    while mobile_rx.try_recv().is_ok() {}
+    while bob_rx.try_recv().is_ok() {}
+
+    let _ = handle_muc_leave(state.as_ref(), &room_jid, &desktop, "alice").await;
+
+    for (recipient, rx) in [(&mobile, &mut mobile_rx), (&bob, &mut bob_rx)] {
+        let broadcast = rx
+            .try_recv()
+            .unwrap_or_else(|_| panic!("{recipient} must receive Muji clear"));
+        let xml = stanza_to_xml(&broadcast.stanza);
+        let presence = Element::from_str(&xml).expect("clear presence XML");
+        assert_eq!(presence.name(), "presence");
+        assert_eq!(presence.attr("type"), None);
+        assert_eq!(
+            presence.attr("from"),
+            Some(format!("{room_jid}/alice").as_str())
+        );
+        assert_eq!(presence.attr("to"), Some(recipient.to_string().as_str()));
+        assert!(
+            presence
+                .get_child("muji", waddle_xmpp::xep::xep0272::NS_MUJI)
+                .is_none(),
+            "partial-resource clear broadcast must not carry <muji/>"
+        );
+    }
+
+    let room = snapshot_room(state.as_ref(), &room_jid).await.room;
+    assert_eq!(room.find_nick_by_real_jid(&mobile), Some("alice"));
+    assert!(room.find_nick_by_real_jid(&desktop).is_none());
+    assert!(room.muji_for_nick("alice").is_none());
+}
+
 /// XEP-0045 slice-2b ingest: a successful `handle_muc_join` MUST
 /// record `(sender_bare, room)` activity in the
 /// `notification_activity` projection so the T1 XEP-0513 `<active/>`

--- a/server/crates/waddle-sfu/src/lib.rs
+++ b/server/crates/waddle-sfu/src/lib.rs
@@ -64,6 +64,11 @@ pub trait SfuService: Send + Sync + 'static {
     /// repeat join is a no-op (the registry is a set).
     fn register_call_participant(&self, call_id: &CallId, identity: &Identity);
 
+    /// Return whether `identity` is currently registered in
+    /// `call_id`. Call teardown uses this as the authorization check
+    /// before revoking any other participant's token state.
+    fn has_call_participant(&self, call_id: &CallId, identity: &Identity) -> bool;
+
     /// Record that `identity` has left `call_id` and report whether
     /// the call is still active. When the last participant leaves,
     /// the call entry is removed and [`CallState::Ended`] is

--- a/server/crates/waddle-sfu/src/livekit.rs
+++ b/server/crates/waddle-sfu/src/livekit.rs
@@ -150,6 +150,12 @@ impl SfuService for LiveKitSfu {
             .insert(identity.clone());
     }
 
+    fn has_call_participant(&self, call_id: &CallId, identity: &Identity) -> bool {
+        self.calls
+            .get(call_id)
+            .is_some_and(|entry| entry.contains(identity))
+    }
+
     fn unregister_call_participant(&self, call_id: &CallId, identity: &Identity) -> CallState {
         let remaining = match self.calls.get_mut(call_id) {
             Some(mut entry) => {

--- a/server/crates/waddle-xmpp-client-ffi/src/convert.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/convert.rs
@@ -2,8 +2,8 @@ use jid::Jid;
 
 use waddle_xmpp_client::{
     messaging::{
-        self, parse_call_event, CallEventKind, CallMedia, InboundCallEvent, JingleReason,
-        LiveKitJoin, MdsDisplayedEntry, MujiPresence, SendMessageOptions,
+        self, CallEventKind, CallMedia, InboundCallEvent, JingleReason, LiveKitJoin,
+        MdsDisplayedEntry, MujiPresence, SendMessageOptions,
     },
     request::StanzaId,
     xep::{
@@ -54,21 +54,8 @@ pub(super) fn dispatch_event(event: ClientEvent, listener: &dyn WaddleEventListe
         ClientEvent::MessageDelivery(MessageDeliveryEvent::Failed { stanza_id }) => {
             listener.on_message_delivery_failed(stanza_id.to_string());
         }
-        // XEP-0353 JMI envelopes and XEP-0166 Jingle session control
-        // stanzas are not claimed by the built-in messaging parser,
-        // so they surface here as UnhandledStanza. Run them through
-        // the call parser; if it matches, deliver a typed
-        // `WaddleCallEvent` to the Swift listener — mirroring how the
-        // wasm chat client surfaces calls (see
-        // `waddle-xmpp-client-wasm/src/events.rs`). Stanzas the call
-        // parser doesn't recognise are intentionally dropped: the
-        // Swift app has no general-purpose XML escape hatch and a
-        // stanza nobody routes is a bug somewhere else, not data the
-        // app should be expected to render.
-        ClientEvent::UnhandledStanza(element) => {
-            if let Some(call) = parse_call_event(&element) {
-                listener.on_call(call_event_to_ffi(call));
-            }
+        ClientEvent::Call(call) => {
+            listener.on_call(call_event_to_ffi(*call));
         }
         _ => {}
     }
@@ -321,9 +308,21 @@ pub(super) fn call_event_to_ffi(event: InboundCallEvent) -> WaddleCallEvent {
             media: call_media_to_ffi(media),
         },
         CallEventKind::Proceed => WaddleCallEventKind::Proceed,
-        CallEventKind::Reject => WaddleCallEventKind::Reject,
-        CallEventKind::Retract => WaddleCallEventKind::Retract,
-        CallEventKind::Finish => WaddleCallEventKind::Finish,
+        CallEventKind::Reject { reason, tie_break } => WaddleCallEventKind::Reject {
+            reason: reason.map(jingle_reason_to_ffi),
+            tie_break,
+        },
+        CallEventKind::Retract { reason, tie_break } => WaddleCallEventKind::Retract {
+            reason: reason.map(jingle_reason_to_ffi),
+            tie_break,
+        },
+        CallEventKind::Finish {
+            reason,
+            migrated_to,
+        } => WaddleCallEventKind::Finish {
+            reason: reason.map(jingle_reason_to_ffi),
+            migrated_to: migrated_to.map(|sid| sid.0),
+        },
         CallEventKind::SessionInitiate { join, media } => WaddleCallEventKind::SessionInitiate {
             join: livekit_join_to_ffi(join),
             media: call_media_to_ffi(media),
@@ -553,7 +552,7 @@ mod tests {
             </propose>
         </message>"#;
         let stanza: Element = xml.parse().expect("fixture parses");
-        let parsed = parse_call_event(&stanza).expect("propose parses");
+        let parsed = messaging::parse_call_event(&stanza).expect("propose parses");
         let ffi = call_event_to_ffi(parsed);
         assert_eq!(ffi.from, "alice@waddle.test/desktop");
         assert_eq!(ffi.sid, "c1");
@@ -584,7 +583,7 @@ mod tests {
             </jingle>
         </iq>"#;
         let stanza: Element = xml.parse().expect("fixture parses");
-        let parsed = parse_call_event(&stanza).expect("session-initiate parses");
+        let parsed = messaging::parse_call_event(&stanza).expect("session-initiate parses");
         let ffi = call_event_to_ffi(parsed);
         match ffi.kind {
             WaddleCallEventKind::SessionInitiate { join, media } => {
@@ -607,7 +606,7 @@ mod tests {
             </jingle>
         </iq>"#;
         let stanza: Element = xml.parse().expect("fixture parses");
-        let parsed = parse_call_event(&stanza).expect("session-terminate parses");
+        let parsed = messaging::parse_call_event(&stanza).expect("session-terminate parses");
         let ffi = call_event_to_ffi(parsed);
         match ffi.kind {
             WaddleCallEventKind::SessionTerminate { reason } => {
@@ -631,11 +630,74 @@ mod tests {
             </jingle>
         </iq>"#;
         let stanza: Element = xml.parse().expect("fixture parses");
-        let parsed = parse_call_event(&stanza).expect("session-terminate parses");
+        let parsed = messaging::parse_call_event(&stanza).expect("session-terminate parses");
         let ffi = call_event_to_ffi(parsed);
         match ffi.kind {
             WaddleCallEventKind::SessionTerminate { reason } => assert_eq!(reason, None),
             other => panic!("expected SessionTerminate, got {other:?}"),
+        }
+    }
+
+    fn sid(value: &str) -> messaging::SessionId {
+        messaging::SessionId(value.to_string())
+    }
+
+    fn parse_jmi(jmi: Element) -> InboundCallEvent {
+        let stanza = Element::builder("message", "jabber:client")
+            .attr(
+                minidom::rxml::xml_ncname!("from").to_owned(),
+                "alice@waddle.test/desktop",
+            )
+            .append(jmi)
+            .build();
+        messaging::parse_call_event(&stanza).expect("JMI event parses")
+    }
+
+    #[test]
+    fn jmi_tie_break_metadata_survives_call_event_to_ffi() {
+        let reject = call_event_to_ffi(parse_jmi(messaging::build_reject_with_options(
+            &sid("c1"),
+            Some(JingleReason::Expired),
+            true,
+        )));
+        match reject.kind {
+            WaddleCallEventKind::Reject { reason, tie_break } => {
+                assert_eq!(reason, Some(WaddleJingleReason::Expired));
+                assert!(tie_break);
+            }
+            other => panic!("expected Reject, got {other:?}"),
+        }
+
+        let retract = call_event_to_ffi(parse_jmi(messaging::build_retract_with_options(
+            &sid("c2"),
+            Some(JingleReason::Expired),
+            true,
+        )));
+        match retract.kind {
+            WaddleCallEventKind::Retract { reason, tie_break } => {
+                assert_eq!(reason, Some(WaddleJingleReason::Expired));
+                assert!(tie_break);
+            }
+            other => panic!("expected Retract, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn finish_migration_metadata_survives_call_event_to_ffi() {
+        let finish = call_event_to_ffi(parse_jmi(messaging::build_finish_migrated(
+            &sid("old"),
+            JingleReason::Expired,
+            &sid("new"),
+        )));
+        match finish.kind {
+            WaddleCallEventKind::Finish {
+                reason,
+                migrated_to,
+            } => {
+                assert_eq!(reason, Some(WaddleJingleReason::Expired));
+                assert_eq!(migrated_to.as_deref(), Some("new"));
+            }
+            other => panic!("expected Finish, got {other:?}"),
         }
     }
 
@@ -742,16 +804,14 @@ mod tests {
     }
 
     #[test]
-    fn unhandled_stanza_routes_to_on_call_when_recognisable() {
-        // The FFI's `_ => {}` swallow was the bug pre-PR: JMI
-        // envelopes flowed through `ClientEvent::UnhandledStanza`
-        // and never reached Swift. This test pins down the fix.
+    fn typed_call_event_routes_to_on_call() {
         let xml = "<message xmlns='jabber:client' from='bob@waddle.test/desktop'>\
             <proceed xmlns='urn:xmpp:jingle-message:0' id='c1'/>\
         </message>";
         let stanza: Element = xml.parse().expect("fixture parses");
+        let call = messaging::parse_call_event(&stanza).expect("fixture is a call");
         let listener = CapturingListener::default();
-        dispatch_event(ClientEvent::UnhandledStanza(stanza), &listener);
+        dispatch_event(ClientEvent::Call(Box::new(call)), &listener);
         assert_eq!(
             &*listener.events.lock().expect("test capture mutex poisoned"),
             &["call"]

--- a/server/crates/waddle-xmpp-client-ffi/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/lib.rs
@@ -23,9 +23,10 @@ use waddle_xmpp_client::{
     discovery::DiscoveryExt,
     mam::MamExt,
     messaging::{
-        build_finish, build_proceed, build_propose, build_reject, build_retract,
-        build_session_accept, build_session_initiate, build_session_terminate, CallMedia,
-        MessagingExt, SessionId, NS_CLIENT,
+        build_finish, build_finish_migrated, build_proceed, build_propose, build_reject,
+        build_reject_with_options, build_retract, build_retract_with_options, build_session_accept,
+        build_session_initiate, build_session_terminate, CallMedia, JingleReason, MessagingExt,
+        SessionId, NS_CLIENT,
     },
     AccessToken, ClientConfig, ClientHandle, ConnectionConfig, OAuthBearerConfig, WebSocketConfig,
 };
@@ -510,6 +511,23 @@ impl WaddleClient {
         self.send_stanza_or_error(stanza, "send_call_reject").await
     }
 
+    /// Send a XEP-0353 tie-break `<reject/>` carrying
+    /// `<reason><expired/></reason>` plus `<tie-break/>`.
+    pub async fn send_call_reject_tie_break(&self, peer_full_jid: String, sid: String) -> bool {
+        let Some(peer) = self.parse_full_jid(&peer_full_jid, "send_call_reject_tie_break") else {
+            return false;
+        };
+        let Some(sid) = self.parse_session_id(sid, "send_call_reject_tie_break") else {
+            return false;
+        };
+        let stanza = message_with_jmi(
+            &peer.into(),
+            build_reject_with_options(&sid, Some(JingleReason::Expired), true),
+        );
+        self.send_stanza_or_error(stanza, "send_call_reject_tie_break")
+            .await
+    }
+
     /// Send a XEP-0353 §5.1.4 `<retract/>` to cancel a ringing call
     /// before the peer answers. Addressed to the responder's *bare*
     /// JID so every resource that may have been ringing receives the
@@ -526,6 +544,23 @@ impl WaddleClient {
         self.send_stanza_or_error(stanza, "send_call_retract").await
     }
 
+    /// Send a XEP-0353 tie-break `<retract/>` carrying
+    /// `<reason><expired/></reason>` plus `<tie-break/>`.
+    pub async fn send_call_retract_tie_break(&self, peer_full_jid: String, sid: String) -> bool {
+        let Some(peer) = self.parse_full_jid(&peer_full_jid, "send_call_retract_tie_break") else {
+            return false;
+        };
+        let Some(sid) = self.parse_session_id(sid, "send_call_retract_tie_break") else {
+            return false;
+        };
+        let stanza = message_with_jmi(
+            &peer.into(),
+            build_retract_with_options(&sid, Some(JingleReason::Expired), true),
+        );
+        self.send_stanza_or_error(stanza, "send_call_retract_tie_break")
+            .await
+    }
+
     /// Send a `<finish/>` Waddle JMI extension signaling clean
     /// teardown after a call ended. Addressed to the peer's full JID
     /// so the originating resource sees the finish notice.
@@ -538,6 +573,32 @@ impl WaddleClient {
         };
         let stanza = message_with_jmi(&peer.into(), build_finish(&sid));
         self.send_stanza_or_error(stanza, "send_call_finish").await
+    }
+
+    /// Send Waddle's XEP-0353-compatible migration marker:
+    /// `<finish/>` with `<reason><expired/></reason>` and
+    /// `<migrated to='new-sid'/>`.
+    pub async fn send_call_finish_migrated(
+        &self,
+        peer_full_jid: String,
+        old_sid: String,
+        new_sid: String,
+    ) -> bool {
+        let Some(peer) = self.parse_full_jid(&peer_full_jid, "send_call_finish_migrated") else {
+            return false;
+        };
+        let Some(old_sid) = self.parse_session_id(old_sid, "send_call_finish_migrated") else {
+            return false;
+        };
+        let Some(new_sid) = self.parse_session_id(new_sid, "send_call_finish_migrated") else {
+            return false;
+        };
+        let stanza = message_with_jmi(
+            &peer.into(),
+            build_finish_migrated(&old_sid, JingleReason::Expired, &new_sid),
+        );
+        self.send_stanza_or_error(stanza, "send_call_finish_migrated")
+            .await
     }
 
     /// Send a XEP-0166 §6.4 `session-initiate` IQ to the peer's full
@@ -571,24 +632,19 @@ impl WaddleClient {
             .await
     }
 
-    /// Send a XEP-0166 §7.2 `session-accept` IQ. `initiator` and
-    /// `responder` are both validated as full JIDs at the FFI
+    /// Send a XEP-0166 §7.2 `session-accept` IQ. `responder` is
+    /// validated as a full JID at the FFI
     /// boundary so a malformed JID surfaces as an error before the
     /// stanza hits the wire.
     pub async fn send_call_session_accept(
         &self,
         peer_full_jid: String,
-        initiator_full_jid: String,
         responder_full_jid: String,
         sid: String,
         audio: bool,
         video: bool,
     ) -> bool {
         let Some(peer) = self.parse_full_jid(&peer_full_jid, "send_call_session_accept") else {
-            return false;
-        };
-        let Some(initiator) = self.parse_full_jid(&initiator_full_jid, "send_call_session_accept")
-        else {
             return false;
         };
         let Some(responder) = self.parse_full_jid(&responder_full_jid, "send_call_session_accept")
@@ -598,8 +654,7 @@ impl WaddleClient {
         let Some(sid) = self.parse_session_id(sid, "send_call_session_accept") else {
             return false;
         };
-        let payload =
-            build_session_accept(&sid, &initiator, &responder, CallMedia { audio, video });
+        let payload = build_session_accept(&sid, &responder, CallMedia { audio, video });
         let iq = iq_set(&peer.into(), payload);
         self.send_iq_or_error(iq, "send_call_session_accept").await
     }

--- a/server/crates/waddle-xmpp-client-ffi/src/types.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/types.rs
@@ -310,11 +310,21 @@ pub enum WaddleCallEventKind {
     /// XEP-0353 §5.1.2 `<proceed/>` — peer is accepting the call.
     Proceed,
     /// XEP-0353 §5.1.3 `<reject/>` — peer declined the call.
-    Reject,
+    Reject {
+        reason: Option<WaddleJingleReason>,
+        tie_break: bool,
+    },
     /// XEP-0353 §5.1.4 `<retract/>` — caller cancelled before answer.
-    Retract,
-    /// `<finish/>` Waddle extension — call ended cleanly.
-    Finish,
+    Retract {
+        reason: Option<WaddleJingleReason>,
+        tie_break: bool,
+    },
+    /// XEP-0353 `<finish/>` — call ended cleanly, or migrated to a
+    /// replacement session in the existing-session tie-break case.
+    Finish {
+        reason: Option<WaddleJingleReason>,
+        migrated_to: Option<String>,
+    },
     /// XEP-0166 §6.4 `session-initiate` with a populated LiveKit
     /// transport. The Swift app uses `join` to connect to the room.
     SessionInitiate {

--- a/server/crates/waddle-xmpp-client-wasm/src/client_calls.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_calls.rs
@@ -1,11 +1,14 @@
 use super::*;
 use waddle_xmpp_client::messaging::{
-    build_finish, build_proceed, build_propose, build_reject, build_retract, build_session_accept,
+    build_finish, build_finish_migrated, build_proceed, build_propose, build_reject,
+    build_reject_with_options, build_retract, build_retract_with_options, build_session_accept,
     build_session_initiate, build_session_terminate, jingle_reason_from_wire_name,
-    wrap_jmi_message, CallMedia, SessionId,
+    wrap_jmi_message, CallMedia, JingleReason, SessionId,
 };
 
 const NS_JINGLE: &str = "urn:xmpp:jingle:1";
+#[cfg(test)]
+const NS_JINGLE_MESSAGE: &str = "urn:xmpp:jingle-message:0";
 const NS_MUJI: &str = "urn:xmpp:jingle:muji:0";
 const NS_JINGLE_RTP: &str = "urn:xmpp:jingle:apps:rtp:1";
 const NS_WADDLE_LIVEKIT_TRANSPORT: &str = "urn:waddle:transports:livekit:0";
@@ -73,17 +76,51 @@ fn build_muji_jingle_content(media: &str) -> Element {
         .build()
 }
 
+fn build_muji_session_terminate_jingle(room_jid: &str, sid_str: &str) -> Element {
+    let muji = Element::builder("muji", NS_MUJI)
+        .attr(minidom::rxml::xml_ncname!("room").to_owned(), room_jid)
+        .build();
+    let reason = Element::builder("reason", NS_JINGLE)
+        .append(Element::builder("success", NS_JINGLE).build())
+        .build();
+    Element::builder("jingle", NS_JINGLE)
+        .attr(
+            minidom::rxml::xml_ncname!("action").to_owned(),
+            "session-terminate",
+        )
+        .attr(minidom::rxml::xml_ncname!("sid").to_owned(), sid_str)
+        .append(muji)
+        .append(reason)
+        .build()
+}
+
 /// Wrap a JMI body in the XEP-0353 §3-conformant `<message type='chat'>`
 /// envelope with a XEP-0334 `<store/>` hint. Routes through
 /// [`waddle_xmpp_client::messaging::wrap_jmi_message`] so the wasm and
 /// native clients ship byte-identical envelopes; the only wasm-local
 /// concern is parsing the JS `String` `to` into a typed
-/// [`jid::Jid`] at the boundary.
-fn message_with_jmi(to: &str, jmi: Element) -> Result<Element, JsValue> {
-    let to_jid: jid::Jid = to
+/// [`jid::BareJid`] / [`jid::FullJid`] at the boundary.
+fn message_with_jmi(to: jid::Jid, jmi: Element) -> Element {
+    wrap_jmi_message(&to, jmi)
+}
+
+fn message_with_jmi_to_bare(to: &str, jmi: Element) -> Result<Element, JsValue> {
+    let bare: jid::BareJid = to
+        .parse()
+        .map_err(|_| js_error(format!("invalid bare JID for JMI envelope: {to}")))?;
+    Ok(message_with_jmi(bare.into(), jmi))
+}
+
+fn message_with_jmi_to_full(to: &str, jmi: Element) -> Result<Element, JsValue> {
+    let full = parse_full_jid(to)?;
+    Ok(message_with_jmi(full.into(), jmi))
+}
+
+fn message_with_jmi_to_any(to: &str, jmi: Element) -> Result<Element, JsValue> {
+    let jid: jid::Jid = to
         .parse()
         .map_err(|_| js_error(format!("invalid JID for JMI envelope: {to}")))?;
-    Ok(wrap_jmi_message(&to_jid, jmi))
+    Ok(message_with_jmi(jid, jmi))
 }
 
 fn iq_set(to: &str, payload: Element) -> Element {
@@ -115,6 +152,15 @@ fn sid(value: String) -> SessionId {
     SessionId(value)
 }
 
+fn stored_full_jid(
+    inner: &std::rc::Rc<std::cell::RefCell<WaddleClientInner>>,
+) -> Result<jid::FullJid, JsValue> {
+    let stored = inner.borrow().config.clone();
+    format!("{}/{}", stored.jid, stored.resource)
+        .parse()
+        .map_err(|_| js_error("authenticated JID/resource do not form a full JID"))
+}
+
 #[wasm_bindgen]
 impl WaddleClient {
     /// Send a JMI `<propose/>` to the peer's bare JID (XEP-0353
@@ -129,7 +175,7 @@ impl WaddleClient {
     ) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
-            let stanza = message_with_jmi(
+            let stanza = message_with_jmi_to_bare(
                 &peer_bare_jid,
                 build_propose(&sid(sid_str), media_from_flags(audio, video)),
             )?;
@@ -141,7 +187,7 @@ impl WaddleClient {
     pub fn send_call_proceed(&self, peer_full_jid: String, sid_str: String) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
-            let stanza = message_with_jmi(&peer_full_jid, build_proceed(&sid(sid_str)))?;
+            let stanza = message_with_jmi_to_full(&peer_full_jid, build_proceed(&sid(sid_str)))?;
             send_stanza_command(inner, stanza).await?;
             Ok(JsValue::UNDEFINED)
         })
@@ -150,16 +196,40 @@ impl WaddleClient {
     pub fn send_call_reject(&self, peer_full_jid: String, sid_str: String) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
-            let stanza = message_with_jmi(&peer_full_jid, build_reject(&sid(sid_str)))?;
+            let stanza = message_with_jmi_to_full(&peer_full_jid, build_reject(&sid(sid_str)))?;
             send_stanza_command(inner, stanza).await?;
             Ok(JsValue::UNDEFINED)
         })
     }
 
-    pub fn send_call_retract(&self, peer_full_jid: String, sid_str: String) -> Promise {
+    pub fn send_call_reject_tie_break(&self, peer_full_jid: String, sid_str: String) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
-            let stanza = message_with_jmi(&peer_full_jid, build_retract(&sid(sid_str)))?;
+            let stanza = message_with_jmi_to_full(
+                &peer_full_jid,
+                build_reject_with_options(&sid(sid_str), Some(JingleReason::Expired), true),
+            )?;
+            send_stanza_command(inner, stanza).await?;
+            Ok(JsValue::UNDEFINED)
+        })
+    }
+
+    pub fn send_call_retract(&self, peer_jid: String, sid_str: String) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let stanza = message_with_jmi_to_any(&peer_jid, build_retract(&sid(sid_str)))?;
+            send_stanza_command(inner, stanza).await?;
+            Ok(JsValue::UNDEFINED)
+        })
+    }
+
+    pub fn send_call_retract_tie_break(&self, peer_full_jid: String, sid_str: String) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let stanza = message_with_jmi_to_full(
+                &peer_full_jid,
+                build_retract_with_options(&sid(sid_str), Some(JingleReason::Expired), true),
+            )?;
             send_stanza_command(inner, stanza).await?;
             Ok(JsValue::UNDEFINED)
         })
@@ -168,7 +238,25 @@ impl WaddleClient {
     pub fn send_call_finish(&self, peer_full_jid: String, sid_str: String) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
-            let stanza = message_with_jmi(&peer_full_jid, build_finish(&sid(sid_str)))?;
+            let stanza = message_with_jmi_to_full(&peer_full_jid, build_finish(&sid(sid_str)))?;
+            send_stanza_command(inner, stanza).await?;
+            Ok(JsValue::UNDEFINED)
+        })
+    }
+
+    pub fn send_call_finish_migrated(
+        &self,
+        peer_full_jid: String,
+        old_sid_str: String,
+        new_sid_str: String,
+    ) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let new_sid = sid(new_sid_str);
+            let stanza = message_with_jmi_to_full(
+                &peer_full_jid,
+                build_finish_migrated(&sid(old_sid_str), JingleReason::Expired, &new_sid),
+            )?;
             send_stanza_command(inner, stanza).await?;
             Ok(JsValue::UNDEFINED)
         })
@@ -204,13 +292,12 @@ impl WaddleClient {
     }
 
     /// Send a Jingle `session-accept` IQ in response to a received
-    /// session-initiate. `initiator` and `responder` are validated
-    /// as full JIDs at the wasm boundary so a malformed JID surfaces
+    /// session-initiate. `responder` is validated as a full JID at
+    /// the wasm boundary so a malformed JID surfaces
     /// as a clear `JsError` rather than a wire-rejected stanza.
     pub fn send_call_session_accept(
         &self,
         peer_full_jid: String,
-        initiator_full_jid: String,
         responder_full_jid: String,
         sid_str: String,
         audio: bool,
@@ -218,17 +305,11 @@ impl WaddleClient {
     ) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
-            let initiator = parse_full_jid(&initiator_full_jid)?;
             let responder = parse_full_jid(&responder_full_jid)?;
             let _ = parse_full_jid(&peer_full_jid)?;
             let stanza = iq_set(
                 &peer_full_jid,
-                build_session_accept(
-                    &sid(sid_str),
-                    &initiator,
-                    &responder,
-                    media_from_flags(audio, video),
-                ),
+                build_session_accept(&sid(sid_str), &responder, media_from_flags(audio, video)),
             );
             send_iq_command(inner, stanza).await?;
             Ok(JsValue::UNDEFINED)
@@ -251,7 +332,7 @@ impl WaddleClient {
     /// ```xml
     /// <iq type='set' to='calls.<domain>' id='…'>
     ///   <jingle xmlns='urn:xmpp:jingle:1' action='session-initiate'
-    ///           sid='ROOM_JID'>
+    ///           sid='ATTEMPT_ID'>
     ///     <muji xmlns='urn:xmpp:jingle:muji:0' room='ROOM_JID'/>
     ///     <content creator='initiator' name='audio' senders='both'>
     ///       <description xmlns='urn:xmpp:jingle:apps:rtp:1' media='audio'/>
@@ -262,22 +343,26 @@ impl WaddleClient {
     /// </iq>
     /// ```
     ///
-    /// Convention: `sid` is set to the room JID so that the
-    /// corresponding `session-terminate` is unambiguous without
-    /// requiring the client to track its own SIDs across reloads.
+    /// Convention: `sid` is a per-attempt correlation id while
+    /// `<muji room='…'/>` remains the stable SFU room identity.
+    /// This lets the chat UI ignore a stale accept from a cancelled
+    /// same-room retry without changing XEP-0272 room semantics.
     ///
     /// `video` opt-in mirrors the call store's `media.video`
     /// flag — audio is always advertised (the call wouldn't be
     /// useful otherwise); video is included only when the user
     /// asked for it. LiveKit handles the actual codec selection
     /// once connected, so the descriptions are minimal.
-    pub fn send_muji_session_initiate(&self, room_jid: String, video: bool) -> Promise {
+    pub fn send_muji_session_initiate(
+        &self,
+        room_jid: String,
+        sid_str: String,
+        video: bool,
+    ) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
-            let initiator_bare = {
-                let stored = inner.borrow().config.clone();
-                stored.jid.split('/').next().unwrap_or("").to_string()
-            };
+            let initiator = stored_full_jid(&inner)?;
+            let initiator_bare = initiator.to_bare().to_string();
             let server_domain = initiator_bare
                 .split('@')
                 .next_back()
@@ -298,11 +383,11 @@ impl WaddleClient {
                 )
                 .attr(
                     minidom::rxml::xml_ncname!("sid").to_owned(),
-                    room_jid.as_str(),
+                    sid_str.as_str(),
                 )
                 .attr(
                     minidom::rxml::xml_ncname!("initiator").to_owned(),
-                    initiator_bare.as_str(),
+                    initiator.to_string(),
                 )
                 .append(muji)
                 .append(build_muji_jingle_content("audio"));
@@ -324,9 +409,8 @@ impl WaddleClient {
             // `<iq type='set'>` and surfaces to the chat-side via
             // the `on_call` callback as a typed
             // `CallEventKind::SessionAccept`. The chat layer
-            // matches it to the pending session-initiate by `sid`
-            // (which equals the room JID per the Waddle
-            // convention) and resolves its own join Promise.
+            // matches it to the pending session-initiate by the
+            // per-attempt `sid` and resolves its own join Promise.
             send_iq_command(inner, stanza).await?;
             Ok(JsValue::UNDEFINED)
         })
@@ -342,51 +426,25 @@ impl WaddleClient {
     /// ```xml
     /// <iq type='set' to='calls.<domain>' id='…'>
     ///   <jingle xmlns='urn:xmpp:jingle:1' action='session-terminate'
-    ///           sid='ROOM_JID' initiator='alice@…'>
+    ///           sid='PER_ATTEMPT_SID'>
     ///     <muji xmlns='urn:xmpp:jingle:muji:0' room='ROOM_JID'/>
     ///     <reason><success/></reason>
     ///   </jingle>
     /// </iq>
     /// ```
-    pub fn send_muji_session_terminate(&self, room_jid: String) -> Promise {
+    pub fn send_muji_session_terminate(&self, room_jid: String, sid_str: String) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
-            let initiator_bare = {
-                let stored = inner.borrow().config.clone();
-                stored.jid.split('/').next().unwrap_or("").to_string()
-            };
-            let server_domain = initiator_bare
+            let full_jid = stored_full_jid(&inner)?;
+            let bare_jid = full_jid.to_bare().to_string();
+            let server_domain = bare_jid
                 .split('@')
                 .next_back()
                 .map(str::to_owned)
                 .ok_or_else(|| js_error("authenticated JID has no domain"))?;
             let mixer = calls_mixer_jid(&server_domain);
 
-            let muji = Element::builder("muji", NS_MUJI)
-                .attr(
-                    minidom::rxml::xml_ncname!("room").to_owned(),
-                    room_jid.as_str(),
-                )
-                .build();
-            let reason = Element::builder("reason", NS_JINGLE)
-                .append(Element::builder("success", NS_JINGLE).build())
-                .build();
-            let jingle = Element::builder("jingle", NS_JINGLE)
-                .attr(
-                    minidom::rxml::xml_ncname!("action").to_owned(),
-                    "session-terminate",
-                )
-                .attr(
-                    minidom::rxml::xml_ncname!("sid").to_owned(),
-                    room_jid.as_str(),
-                )
-                .attr(
-                    minidom::rxml::xml_ncname!("initiator").to_owned(),
-                    initiator_bare.as_str(),
-                )
-                .append(muji)
-                .append(reason)
-                .build();
+            let jingle = build_muji_session_terminate_jingle(&room_jid, &sid_str);
             let stanza = Element::builder("iq", NS_JABBER_CLIENT)
                 .attr(minidom::rxml::xml_ncname!("type").to_owned(), "set")
                 .attr(
@@ -483,7 +541,8 @@ mod tests {
             &waddle_xmpp_client::messaging::SessionId("c1".into()),
             waddle_xmpp_client::messaging::CallMedia::audio_only(),
         );
-        let stanza = super::message_with_jmi("bob@waddle.test", body).expect("valid JID accepted");
+        let stanza =
+            super::message_with_jmi_to_bare("bob@waddle.test", body).expect("valid JID accepted");
         assert_eq!(stanza.name(), "message");
         assert_eq!(stanza.attr("type"), Some("chat"));
         assert_eq!(stanza.attr("to"), Some("bob@waddle.test"));
@@ -499,6 +558,64 @@ mod tests {
                 .any(|c| c.name() == "propose" && c.ns() == "urn:xmpp:jingle-message:0"),
             "JMI body preserved"
         );
+    }
+
+    #[test]
+    fn jmi_response_envelope_requires_full_jid() {
+        use waddle_xmpp_client::messaging::build_proceed;
+        let body = build_proceed(&waddle_xmpp_client::messaging::SessionId("c1".into()));
+        let stanza = super::message_with_jmi_to_full("bob@waddle.test/phone", body)
+            .expect("full JID accepted");
+        assert_eq!(stanza.attr("to"), Some("bob@waddle.test/phone"));
+        assert!(FullJid::from_str("bob@waddle.test").is_err());
+    }
+
+    #[test]
+    fn jmi_tie_break_response_targets_full_jid_and_carries_expired_reason() {
+        use waddle_xmpp_client::messaging::{build_retract_with_options, JingleReason, SessionId};
+
+        let body =
+            build_retract_with_options(&SessionId("c1".into()), Some(JingleReason::Expired), true);
+        let stanza = super::message_with_jmi_to_full("bob@waddle.test/phone", body)
+            .expect("full JID accepted");
+        let retract = stanza
+            .children()
+            .find(|child| child.name() == "retract" && child.ns() == NS_JINGLE_MESSAGE)
+            .expect("JMI retract child is present");
+        assert_eq!(stanza.attr("to"), Some("bob@waddle.test/phone"));
+        assert!(retract
+            .children()
+            .any(|child| child.name() == "tie-break" && child.ns() == NS_JINGLE_MESSAGE));
+        assert!(retract.children().any(|child| {
+            child.name() == "reason"
+                && child.ns() == NS_JINGLE
+                && child
+                    .children()
+                    .any(|condition| condition.name() == "expired" && condition.ns() == NS_JINGLE)
+        }));
+    }
+
+    #[test]
+    fn muji_session_terminate_uses_session_sid_and_keeps_room_metadata() {
+        let jingle =
+            super::build_muji_session_terminate_jingle("chan@muc.waddle.test", "attempt-123");
+
+        assert_eq!(jingle.name(), "jingle");
+        assert_eq!(jingle.ns(), NS_JINGLE);
+        assert_eq!(jingle.attr("action"), Some("session-terminate"));
+        assert_eq!(jingle.attr("sid"), Some("attempt-123"));
+        assert!(jingle.children().any(|child| {
+            child.name() == "muji"
+                && child.ns() == NS_MUJI
+                && child.attr("room") == Some("chan@muc.waddle.test")
+        }));
+        assert!(jingle.children().any(|child| {
+            child.name() == "reason"
+                && child.ns() == NS_JINGLE
+                && child
+                    .children()
+                    .any(|condition| condition.name() == "success" && condition.ns() == NS_JINGLE)
+        }));
     }
 
     /// `message_with_jmi` returns `Result<_, JsValue>` on the error

--- a/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
@@ -440,6 +440,8 @@ pub(crate) fn call_event_to_js(event: InboundCallEvent) -> WaddleCallEvent {
             }),
             join: None,
             reason: None,
+            tie_break: None,
+            migrated_to: None,
         },
         CallEventKind::Proceed => WaddleCallEvent {
             from,
@@ -448,30 +450,44 @@ pub(crate) fn call_event_to_js(event: InboundCallEvent) -> WaddleCallEvent {
             media: None,
             join: None,
             reason: None,
+            tie_break: None,
+            migrated_to: None,
         },
-        CallEventKind::Reject => WaddleCallEvent {
+        CallEventKind::Reject { reason, tie_break } => WaddleCallEvent {
             from,
             sid,
             kind: "reject",
             media: None,
             join: None,
-            reason: None,
+            reason: reason
+                .map(|r| waddle_xmpp_client::messaging::jingle_reason_wire_name(r).to_string()),
+            tie_break: Some(tie_break),
+            migrated_to: None,
         },
-        CallEventKind::Retract => WaddleCallEvent {
+        CallEventKind::Retract { reason, tie_break } => WaddleCallEvent {
             from,
             sid,
             kind: "retract",
             media: None,
             join: None,
-            reason: None,
+            reason: reason
+                .map(|r| waddle_xmpp_client::messaging::jingle_reason_wire_name(r).to_string()),
+            tie_break: Some(tie_break),
+            migrated_to: None,
         },
-        CallEventKind::Finish => WaddleCallEvent {
+        CallEventKind::Finish {
+            reason,
+            migrated_to,
+        } => WaddleCallEvent {
             from,
             sid,
             kind: "finish",
             media: None,
             join: None,
-            reason: None,
+            reason: reason
+                .map(|r| waddle_xmpp_client::messaging::jingle_reason_wire_name(r).to_string()),
+            tie_break: None,
+            migrated_to: migrated_to.map(|sid| sid.0),
         },
         CallEventKind::SessionInitiate { join, media } => WaddleCallEvent {
             from,
@@ -488,6 +504,8 @@ pub(crate) fn call_event_to_js(event: InboundCallEvent) -> WaddleCallEvent {
                 token: join.token,
             }),
             reason: None,
+            tie_break: None,
+            migrated_to: None,
         },
         CallEventKind::SessionAccept { join, media } => WaddleCallEvent {
             from,
@@ -504,6 +522,8 @@ pub(crate) fn call_event_to_js(event: InboundCallEvent) -> WaddleCallEvent {
                 token: join.token,
             }),
             reason: None,
+            tie_break: None,
+            migrated_to: None,
         },
         CallEventKind::SessionTerminate { reason } => WaddleCallEvent {
             from,
@@ -518,6 +538,8 @@ pub(crate) fn call_event_to_js(event: InboundCallEvent) -> WaddleCallEvent {
             // not a free-form passthrough.
             reason: reason
                 .map(|r| waddle_xmpp_client::messaging::jingle_reason_wire_name(r).to_string()),
+            tie_break: None,
+            migrated_to: None,
         },
     }
 }
@@ -584,6 +606,21 @@ mod inbound_to_js_tests {
     use super::*;
     use minidom::Element;
 
+    fn sid(value: &str) -> messaging::SessionId {
+        messaging::SessionId(value.to_string())
+    }
+
+    fn parse_jmi(jmi: Element) -> messaging::InboundCallEvent {
+        let stanza = Element::builder("message", "jabber:client")
+            .attr(
+                minidom::rxml::xml_ncname!("from").to_owned(),
+                "alice@waddle.test/desktop",
+            )
+            .append(jmi)
+            .build();
+        messaging::parse_call_event(&stanza).expect("JMI event parses")
+    }
+
     fn parse_message_element(xml: &str) -> InboundMessage {
         let el: Element = xml.parse().expect("invalid XML");
         match messaging::parse(&el).expect("expected message") {
@@ -595,6 +632,42 @@ mod inbound_to_js_tests {
     fn parse_mam_archived(xml: &str) -> waddle_xmpp_client::ArchivedMessage {
         let el: Element = xml.parse().expect("invalid XML");
         waddle_xmpp_client::mam::parse_mam_result(&el).expect("expected MAM result")
+    }
+
+    #[test]
+    fn call_event_to_js_preserves_jmi_tie_break_metadata() {
+        let reject = call_event_to_js(parse_jmi(messaging::build_reject_with_options(
+            &sid("c1"),
+            Some(messaging::JingleReason::Expired),
+            true,
+        )));
+        assert_eq!(reject.kind, "reject");
+        assert_eq!(reject.reason.as_deref(), Some("expired"));
+        assert_eq!(reject.tie_break, Some(true));
+        assert_eq!(reject.migrated_to, None);
+
+        let retract = call_event_to_js(parse_jmi(messaging::build_retract_with_options(
+            &sid("c2"),
+            Some(messaging::JingleReason::Expired),
+            true,
+        )));
+        assert_eq!(retract.kind, "retract");
+        assert_eq!(retract.reason.as_deref(), Some("expired"));
+        assert_eq!(retract.tie_break, Some(true));
+        assert_eq!(retract.migrated_to, None);
+    }
+
+    #[test]
+    fn call_event_to_js_preserves_finish_migration_metadata() {
+        let finish = call_event_to_js(parse_jmi(messaging::build_finish_migrated(
+            &sid("old"),
+            messaging::JingleReason::Expired,
+            &sid("new"),
+        )));
+        assert_eq!(finish.kind, "finish");
+        assert_eq!(finish.reason.as_deref(), Some("expired"));
+        assert_eq!(finish.tie_break, None);
+        assert_eq!(finish.migrated_to.as_deref(), Some("new"));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client-wasm/src/events.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/events.rs
@@ -104,70 +104,16 @@ pub(crate) fn dispatch_client_event(inner: &Rc<RefCell<WaddleClientInner>>, even
                 let _ = callback.call1(&JsValue::NULL, &JsValue::from_str(stanza_id.as_str()));
             }
         }
-        ClientEvent::UnhandledStanza(element) => {
-            // Try to recognise an A/V call event (XEP-0353 JMI
-            // envelope or XEP-0166 Jingle session control with a
-            // urn:waddle:transports:livekit:0 transport). If matched,
-            // surface as a typed `on_call` callback so the chat side
-            // doesn't have to parse XML.
-            if let Some(call_event) = parse_call_event(&element) {
-                // XEP-0166 §6.3 conformance: a Muji session-accept
-                // arriving as a server-initiated `<iq type='set'>`
-                // MUST be acknowledged with an empty IQ-result. The
-                // server's IQ tracking layer warns on un-ACK'd
-                // IQ-sets; without this the wire is non-conformant
-                // even when the chat-side flow works.
-                if matches!(
-                    call_event.kind,
-                    waddle_xmpp_client::messaging::CallEventKind::SessionAccept { .. }
-                ) && element.name() == "iq"
-                    && element.attr("type") == Some("set")
-                {
-                    let ack = build_iq_ack(&element);
-                    if let Some(ack) = ack {
-                        if let Some(cmd_tx) = inner.borrow().cmd_tx.clone() {
-                            wasm_bindgen_futures::spawn_local(async move {
-                                let mut tx = cmd_tx;
-                                let (responder, _rx) = futures::channel::oneshot::channel();
-                                let _ = tx
-                                    .send(crate::state::WasmCommand::SendStanza {
-                                        stanza: ack,
-                                        responder,
-                                    })
-                                    .await;
-                            });
-                        }
-                    }
-                }
-                let callback = inner.borrow().on_call.clone();
-                if let Some(callback) = callback {
-                    if let Ok(value) = to_js_value(&call_event_to_js(call_event)) {
-                        let _ = callback.call1(&JsValue::NULL, &value);
-                    }
+        ClientEvent::Call(call_event) => {
+            let callback = inner.borrow().on_call.clone();
+            if let Some(callback) = callback {
+                if let Ok(value) = to_js_value(&call_event_to_js(*call_event)) {
+                    let _ = callback.call1(&JsValue::NULL, &value);
                 }
             }
         }
         _ => {}
     }
-}
-
-/// Build a XEP-0166 §6.3 empty IQ-result acknowledging a
-/// server-initiated `<iq type='set'>` stanza. Used to ACK Muji
-/// session-accept stanzas that arrive from the SFU mixer.
-/// Returns `None` if the input element is missing the `id` or
-/// `from` attributes required for the response.
-fn build_iq_ack(inbound: &Element) -> Option<Element> {
-    let id = inbound.attr("id")?;
-    let from = inbound.attr("from")?;
-    let to = inbound.attr("to");
-    let mut builder = Element::builder("iq", "jabber:client")
-        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
-        .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
-        .attr(minidom::rxml::xml_ncname!("to").to_owned(), from);
-    if let Some(to) = to {
-        builder = builder.attr(minidom::rxml::xml_ncname!("from").to_owned(), to);
-    }
-    Some(builder.build())
 }
 
 pub(crate) fn emit_error_callback(inner: &Rc<RefCell<WaddleClientInner>>, description: &str) {

--- a/server/crates/waddle-xmpp-client-wasm/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/lib.rs
@@ -25,9 +25,9 @@ use waddle_xmpp_client::mds::{
 use waddle_xmpp_client::messaging::{
     self, build_chat_state_message, build_correction_message, build_displayed_message,
     build_moderation_message, build_outbound_message, build_pinned_message, build_reaction_message,
-    build_retraction_message, build_unpinned_message, parse_call_event, InboundCallEvent,
-    InboundMessage, InboundPresence, MarkupSpanData, MarkupSpanType, MucAffiliation, MucRole,
-    ReferenceData, SendMessageOptions, SharedFileDisposition,
+    build_retraction_message, build_unpinned_message, InboundCallEvent, InboundMessage,
+    InboundPresence, MarkupSpanData, MarkupSpanType, MucAffiliation, MucRole, ReferenceData,
+    SendMessageOptions, SharedFileDisposition,
 };
 use waddle_xmpp_client::pep::{
     build_pep_items_iq, build_publish_activity_iq, build_publish_mood_iq, build_publish_tune_iq,

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -258,6 +258,10 @@ pub struct WaddleCallEvent {
     pub join: Option<WaddleLiveKitJoin>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+    #[serde(rename = "tieBreak", skip_serializing_if = "Option::is_none")]
+    pub tie_break: Option<bool>,
+    #[serde(rename = "migratedTo", skip_serializing_if = "Option::is_none")]
+    pub migrated_to: Option<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/server/crates/waddle-xmpp-client/src/event.rs
+++ b/server/crates/waddle-xmpp-client/src/event.rs
@@ -5,7 +5,7 @@ use crate::bootstrap::{
 };
 use crate::inbox::InboxStreamEntry;
 use crate::mam::ArchivedMessage;
-use crate::messaging::MessagingEvent;
+use crate::messaging::{InboundCallEvent, MessagingEvent};
 use crate::pep::PepItem;
 use crate::request::StanzaId;
 use crate::request::{PendingRequest, RequestCorrelation};
@@ -22,6 +22,8 @@ pub enum ClientEvent {
     Transport(TransportEvent),
     /// Typed inbound message or presence event.
     Messaging(MessagingEvent),
+    /// Typed inbound A/V call control event.
+    Call(Box<InboundCallEvent>),
     /// Typed MAM archived message from an active history query.
     ///
     /// Boxed: `ArchivedMessage` ballooned to ~480 bytes after the

--- a/server/crates/waddle-xmpp-client/src/messaging.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging.rs
@@ -21,10 +21,12 @@ pub use builders::{
     build_pinned_message, build_reaction_message, build_retraction_message, build_unpinned_message,
 };
 pub use call::{
-    build_finish, build_proceed, build_propose, build_reject, build_retract, build_session_accept,
-    build_session_initiate, build_session_terminate, jingle_reason_from_wire_name,
-    jingle_reason_wire_name, parse_call_event, parse_jingle_iq, parse_jmi_message,
-    wrap_jmi_message, CallEventKind, CallMedia, InboundCallEvent, LiveKitJoin,
+    build_finish, build_finish_migrated, build_finish_with_options, build_finish_with_reason,
+    build_proceed, build_propose, build_reject, build_reject_with_options, build_retract,
+    build_retract_with_options, build_session_accept, build_session_initiate,
+    build_session_terminate, jingle_reason_from_wire_name, jingle_reason_wire_name,
+    parse_call_event, parse_jingle_iq, parse_jmi_message, wrap_jmi_message, CallEventKind,
+    CallMedia, InboundCallEvent, LiveKitJoin,
 };
 pub use namespaces::{
     build_muji_element, NS_CHAT_MARKERS, NS_CHAT_STATES, NS_CLIENT, NS_JINGLE_RTP,

--- a/server/crates/waddle-xmpp-client/src/messaging/call.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/call.rs
@@ -75,9 +75,18 @@ pub enum CallEventKind {
         media: CallMedia,
     },
     Proceed,
-    Reject,
-    Retract,
-    Finish,
+    Reject {
+        reason: Option<JingleReason>,
+        tie_break: bool,
+    },
+    Retract {
+        reason: Option<JingleReason>,
+        tie_break: bool,
+    },
+    Finish {
+        reason: Option<JingleReason>,
+        migrated_to: Option<SessionId>,
+    },
     SessionInitiate {
         join: LiveKitJoin,
         media: CallMedia,
@@ -138,9 +147,18 @@ pub fn parse_jmi_message(stanza: &Element) -> Option<InboundCallEvent> {
                 media: media_from_descriptions(child),
             },
             "proceed" => CallEventKind::Proceed,
-            "reject" => CallEventKind::Reject,
-            "retract" => CallEventKind::Retract,
-            "finish" => CallEventKind::Finish,
+            "reject" => CallEventKind::Reject {
+                reason: extract_jmi_reason(child),
+                tie_break: has_tie_break(child),
+            },
+            "retract" => CallEventKind::Retract {
+                reason: extract_jmi_reason(child),
+                tie_break: has_tie_break(child),
+            },
+            "finish" => CallEventKind::Finish {
+                reason: extract_jmi_reason(child),
+                migrated_to: extract_migrated_to(child),
+            },
             _ => continue,
         };
         return Some(InboundCallEvent { from, sid, kind });
@@ -258,6 +276,28 @@ fn extract_terminate_reason(jingle: &Element) -> Option<JingleReason> {
     jingle_reason_from_wire_name(condition.name())
 }
 
+fn extract_jmi_reason(envelope: &Element) -> Option<JingleReason> {
+    let reason = envelope
+        .children()
+        .find(|c| c.name() == "reason" && c.ns() == NS_JINGLE)?;
+    let condition = reason.children().next()?;
+    jingle_reason_from_wire_name(condition.name())
+}
+
+fn has_tie_break(envelope: &Element) -> bool {
+    envelope
+        .children()
+        .any(|c| c.name() == "tie-break" && c.ns() == NS_JINGLE_MESSAGE)
+}
+
+fn extract_migrated_to(envelope: &Element) -> Option<SessionId> {
+    envelope
+        .children()
+        .find(|c| c.name() == "migrated" && c.ns() == NS_JINGLE_MESSAGE)
+        .and_then(|c| c.attr("to"))
+        .map(|to| SessionId(to.to_string()))
+}
+
 /// Canonical XEP-0166 §7.4 wire name for a typed `JingleReason`.
 /// Public so wasm/FFI consumers can emit the typed value as the
 /// stable XEP-defined string when crossing into untyped languages
@@ -350,20 +390,78 @@ pub fn build_proceed(sid: &SessionId) -> Element {
 }
 
 pub fn build_reject(sid: &SessionId) -> Element {
-    Element::builder("reject", NS_JINGLE_MESSAGE)
+    build_reject_with_options(sid, None, false)
+}
+
+pub fn build_reject_with_options(
+    sid: &SessionId,
+    reason: Option<JingleReason>,
+    tie_break: bool,
+) -> Element {
+    let mut builder = Element::builder("reject", NS_JINGLE_MESSAGE)
         .attr(minidom::rxml::xml_ncname!("id").to_owned(), sid.0.as_str())
-        .build()
+        .append_all(reason.map(reason_element));
+    if tie_break {
+        builder = builder.append(Element::builder("tie-break", NS_JINGLE_MESSAGE).build());
+    }
+    builder.build()
 }
 
 pub fn build_retract(sid: &SessionId) -> Element {
-    Element::builder("retract", NS_JINGLE_MESSAGE)
+    build_retract_with_options(sid, None, false)
+}
+
+pub fn build_retract_with_options(
+    sid: &SessionId,
+    reason: Option<JingleReason>,
+    tie_break: bool,
+) -> Element {
+    let mut builder = Element::builder("retract", NS_JINGLE_MESSAGE)
         .attr(minidom::rxml::xml_ncname!("id").to_owned(), sid.0.as_str())
-        .build()
+        .append_all(reason.map(reason_element));
+    if tie_break {
+        builder = builder.append(Element::builder("tie-break", NS_JINGLE_MESSAGE).build());
+    }
+    builder.build()
 }
 
 pub fn build_finish(sid: &SessionId) -> Element {
-    Element::builder("finish", NS_JINGLE_MESSAGE)
+    build_finish_with_reason(sid, None)
+}
+
+pub fn build_finish_with_reason(sid: &SessionId, reason: Option<JingleReason>) -> Element {
+    build_finish_with_options(sid, reason, None)
+}
+
+pub fn build_finish_with_options(
+    sid: &SessionId,
+    reason: Option<JingleReason>,
+    migrated_to: Option<&SessionId>,
+) -> Element {
+    let mut builder = Element::builder("finish", NS_JINGLE_MESSAGE)
         .attr(minidom::rxml::xml_ncname!("id").to_owned(), sid.0.as_str())
+        .append_all(reason.map(reason_element));
+    if let Some(to) = migrated_to {
+        builder = builder.append(
+            Element::builder("migrated", NS_JINGLE_MESSAGE)
+                .attr(minidom::rxml::xml_ncname!("to").to_owned(), to.0.as_str())
+                .build(),
+        );
+    }
+    builder.build()
+}
+
+pub fn build_finish_migrated(
+    sid: &SessionId,
+    reason: JingleReason,
+    migrated_to: &SessionId,
+) -> Element {
+    build_finish_with_options(sid, Some(reason), Some(migrated_to))
+}
+
+fn reason_element(reason: JingleReason) -> Element {
+    Element::builder("reason", NS_JINGLE)
+        .append(Element::builder(jingle_reason_wire_name(reason), NS_JINGLE).build())
         .build()
 }
 
@@ -418,22 +516,14 @@ pub fn build_session_initiate(sid: &SessionId, initiator: &FullJid, media: CallM
 
 /// Build the `<jingle/>` body of a session-accept IQ. Per
 /// XEP-0166 §7.1 the `responder` attribute names the accepting
-/// party; the initiator attribute mirrors the originator so the
-/// server can re-derive the call scope.
-pub fn build_session_accept(
-    sid: &SessionId,
-    initiator: &FullJid,
-    responder: &FullJid,
-    media: CallMedia,
-) -> Element {
+/// party. The `initiator` attribute is intentionally omitted
+/// because XEP-0166 recommends it only for `session-initiate` and
+/// says recipients should ignore it on other actions.
+pub fn build_session_accept(sid: &SessionId, responder: &FullJid, media: CallMedia) -> Element {
     let mut builder = Element::builder("jingle", NS_JINGLE)
         .attr(
             minidom::rxml::xml_ncname!("action").to_owned(),
             "session-accept",
-        )
-        .attr(
-            minidom::rxml::xml_ncname!("initiator").to_owned(),
-            initiator.to_string(),
         )
         .attr(
             minidom::rxml::xml_ncname!("responder").to_owned(),
@@ -538,7 +628,48 @@ mod tests {
         </message>";
         let elem: Element = xml.parse().unwrap();
         let ev = parse_call_event(&elem).expect("finish parses");
-        assert!(matches!(ev.kind, CallEventKind::Finish));
+        assert!(matches!(
+            ev.kind,
+            CallEventKind::Finish {
+                reason: None,
+                migrated_to: None
+            }
+        ));
+    }
+
+    #[test]
+    fn parses_tie_break_reject_and_retract_metadata() {
+        let xml = r#"<message xmlns='jabber:client' from='alice@waddle.test/desktop'>
+            <reject xmlns='urn:xmpp:jingle-message:0' id='c1'>
+              <reason xmlns='urn:xmpp:jingle:1'><expired/></reason>
+              <tie-break xmlns='urn:xmpp:jingle-message:0'/>
+            </reject>
+        </message>"#;
+        let elem: Element = xml.parse().unwrap();
+        let ev = parse_call_event(&elem).expect("reject parses");
+        match ev.kind {
+            CallEventKind::Reject { reason, tie_break } => {
+                assert_eq!(reason, Some(JingleReason::Expired));
+                assert!(tie_break);
+            }
+            other => panic!("expected Reject, got {other:?}"),
+        }
+
+        let xml = r#"<message xmlns='jabber:client' from='alice@waddle.test/desktop'>
+            <retract xmlns='urn:xmpp:jingle-message:0' id='c1'>
+              <reason xmlns='urn:xmpp:jingle:1'><expired/></reason>
+              <tie-break xmlns='urn:xmpp:jingle-message:0'/>
+            </retract>
+        </message>"#;
+        let elem: Element = xml.parse().unwrap();
+        let ev = parse_call_event(&elem).expect("retract parses");
+        match ev.kind {
+            CallEventKind::Retract { reason, tie_break } => {
+                assert_eq!(reason, Some(JingleReason::Expired));
+                assert!(tie_break);
+            }
+            other => panic!("expected Retract, got {other:?}"),
+        }
     }
 
     #[test]
@@ -752,10 +883,8 @@ mod tests {
 
     #[test]
     fn build_session_accept_descriptions_include_rtcp_mux() {
-        let initiator: FullJid = "alice@waddle.test/desktop".parse().unwrap();
         let responder: FullJid = "bob@waddle.test/desktop".parse().unwrap();
-        let elem =
-            build_session_accept(&sid("c1"), &initiator, &responder, CallMedia::audio_video());
+        let elem = build_session_accept(&sid("c1"), &responder, CallMedia::audio_video());
         for content in elem.children().filter(|c| c.name() == "content") {
             let desc = content
                 .children()
@@ -791,7 +920,13 @@ mod tests {
             .append(build_reject(&sid("c1")))
             .build();
         let ev = parse_call_event(&stanza).expect("reject parses");
-        assert!(matches!(ev.kind, CallEventKind::Reject));
+        assert!(matches!(
+            ev.kind,
+            CallEventKind::Reject {
+                reason: None,
+                tie_break: false
+            }
+        ));
 
         let stanza = Element::builder("message", "jabber:client")
             .attr(
@@ -801,7 +936,13 @@ mod tests {
             .append(build_retract(&sid("c1")))
             .build();
         let ev = parse_call_event(&stanza).expect("retract parses");
-        assert!(matches!(ev.kind, CallEventKind::Retract));
+        assert!(matches!(
+            ev.kind,
+            CallEventKind::Retract {
+                reason: None,
+                tie_break: false
+            }
+        ));
 
         let stanza = Element::builder("message", "jabber:client")
             .attr(
@@ -811,7 +952,68 @@ mod tests {
             .append(build_finish(&sid("c1")))
             .build();
         let ev = parse_call_event(&stanza).expect("finish parses");
-        assert!(matches!(ev.kind, CallEventKind::Finish));
+        assert!(matches!(
+            ev.kind,
+            CallEventKind::Finish {
+                reason: None,
+                migrated_to: None
+            }
+        ));
+    }
+
+    #[test]
+    fn build_tie_break_jmi_helpers_emit_expired_reason_and_tie_break() {
+        let reject = build_reject_with_options(&sid("c1"), Some(JingleReason::Expired), true);
+        assert!(
+            reject.get_child("tie-break", NS_JINGLE_MESSAGE).is_some(),
+            "XEP-0353 tie-break reject carries <tie-break/>"
+        );
+        assert!(
+            reject
+                .get_child("reason", NS_JINGLE)
+                .and_then(|reason| reason.get_child("expired", NS_JINGLE))
+                .is_some(),
+            "XEP-0353 tie-break reject carries <reason><expired/></reason>"
+        );
+
+        let retract = build_retract_with_options(&sid("c1"), Some(JingleReason::Expired), true);
+        assert!(retract.get_child("tie-break", NS_JINGLE_MESSAGE).is_some());
+        assert!(retract
+            .get_child("reason", NS_JINGLE)
+            .and_then(|reason| reason.get_child("expired", NS_JINGLE))
+            .is_some());
+    }
+
+    #[test]
+    fn build_finish_migrated_emits_expired_reason_and_migrated_target() {
+        let finish = build_finish_migrated(&sid("old"), JingleReason::Expired, &sid("new"));
+        assert!(finish
+            .get_child("reason", NS_JINGLE)
+            .and_then(|reason| reason.get_child("expired", NS_JINGLE))
+            .is_some());
+        let migrated = finish
+            .get_child("migrated", NS_JINGLE_MESSAGE)
+            .expect("finish carries migrated child");
+        assert_eq!(migrated.attr("to"), Some("new"));
+
+        let stanza = Element::builder("message", "jabber:client")
+            .attr(
+                minidom::rxml::xml_ncname!("from").to_owned(),
+                "alice@waddle.test/desktop",
+            )
+            .append(finish)
+            .build();
+        let ev = parse_call_event(&stanza).expect("finish parses");
+        match ev.kind {
+            CallEventKind::Finish {
+                reason,
+                migrated_to,
+            } => {
+                assert_eq!(reason, Some(JingleReason::Expired));
+                assert_eq!(migrated_to.map(|sid| sid.0).as_deref(), Some("new"));
+            }
+            other => panic!("expected Finish, got {other:?}"),
+        }
     }
 
     #[test]
@@ -855,12 +1057,11 @@ mod tests {
     fn build_session_accept_carries_responder_attr_and_empty_transport() {
         let jingle = build_session_accept(
             &sid("c1"),
-            &full("alice@waddle.test/desktop"),
             &full("bob@waddle.test/desktop"),
             CallMedia::audio_only(),
         );
         assert_eq!(jingle.attr("action"), Some("session-accept"));
-        assert_eq!(jingle.attr("initiator"), Some("alice@waddle.test/desktop"));
+        assert_eq!(jingle.attr("initiator"), None);
         assert_eq!(jingle.attr("responder"), Some("bob@waddle.test/desktop"));
         let contents: Vec<_> = jingle
             .children()
@@ -873,6 +1074,7 @@ mod tests {
     fn build_session_terminate_includes_reason_when_supplied() {
         let with_reason =
             build_session_terminate(&sid("c1"), Some(xmpp_parsers::jingle::Reason::Success));
+        assert_eq!(with_reason.attr("initiator"), None);
         let reason_elem = with_reason
             .children()
             .find(|c| c.name() == "reason")

--- a/server/crates/waddle-xmpp-client/src/runtime/app_stanza.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime/app_stanza.rs
@@ -1,4 +1,7 @@
-use crate::event::ClientEvent;
+use minidom::Element;
+
+use crate::event::{ClientEvent, ConnectionEvent};
+use crate::transport::TransportMessage;
 
 use super::XmppRuntime;
 
@@ -8,8 +11,9 @@ impl XmppRuntime {
     /// IQ result and error stanzas are returned as [`ClientEvent::IqResult`] so the
     /// driver can route them to its IQ correlation map without broadcasting them on
     /// the public event bus.  Message stanzas are dispatched to the typed protocol
-    /// handlers in priority order: MAM results, PEP events, then general messaging.
-    /// Unrecognised stanzas fall through to [`ClientEvent::UnhandledStanza`].
+    /// handlers in priority order: MAM results, PEP events, calls, then general
+    /// messaging. Unrecognised stanzas fall through to
+    /// [`ClientEvent::UnhandledStanza`].
     pub fn handle_app_stanza(&mut self, element: &minidom::Element) -> Vec<ClientEvent> {
         use crate::{inbox, mam, messaging, pep};
 
@@ -43,10 +47,39 @@ impl XmppRuntime {
             }
         }
 
+        if let Some(call_event) = messaging::parse_call_event(element) {
+            let mut events = Vec::new();
+            if let Some(ack) = jingle_iq_set_ack(element) {
+                events.push(ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+                    TransportMessage::Element(ack),
+                )));
+            }
+            events.push(ClientEvent::Call(Box::new(call_event)));
+            return events;
+        }
+
         if let Some(ev) = messaging::parse(element) {
             return vec![ClientEvent::Messaging(ev)];
         }
 
         vec![ClientEvent::UnhandledStanza(element.clone())]
     }
+}
+
+fn jingle_iq_set_ack(inbound: &Element) -> Option<Element> {
+    if inbound.name() != "iq" || inbound.attr("type") != Some("set") {
+        return None;
+    }
+    let id = inbound.attr("id")?;
+    let from = inbound.attr("from")?;
+    let to = inbound.attr("to");
+
+    let mut builder = Element::builder("iq", "jabber:client")
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
+        .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
+        .attr(minidom::rxml::xml_ncname!("to").to_owned(), from);
+    if let Some(to) = to {
+        builder = builder.attr(minidom::rxml::xml_ncname!("from").to_owned(), to);
+    }
+    Some(builder.build())
 }

--- a/server/crates/waddle-xmpp-client/src/runtime/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime/tests.rs
@@ -52,6 +52,59 @@ fn runtime_emits_initial_open_when_transport_opens() {
 }
 
 #[test]
+fn app_stanza_routes_jmi_message_to_typed_call_event() {
+    let mut runtime = XmppRuntime::new(config()).unwrap();
+    let stanza: Element =
+        r#"<message xmlns='jabber:client' from='alice@waddle.test/desktop' to='bob@waddle.test'>
+        <propose xmlns='urn:xmpp:jingle-message:0' id='call-1'>
+          <description xmlns='urn:xmpp:jingle:apps:rtp:1' media='audio'/>
+        </propose>
+    </message>"#
+            .parse()
+            .unwrap();
+
+    let events = runtime.handle_app_stanza(&stanza);
+
+    assert_eq!(events.len(), 1);
+    assert!(matches!(
+        &events[0],
+        ClientEvent::Call(call) if call.sid.0 == "call-1"
+    ));
+}
+
+#[test]
+fn app_stanza_acknowledges_jingle_iq_set_and_surfaces_call_event() {
+    let mut runtime = XmppRuntime::new(config()).unwrap();
+    let stanza: Element = r#"<iq xmlns='jabber:client' type='set' id='j1' from='alice@waddle.test/desktop' to='bob@waddle.test/phone'>
+        <jingle xmlns='urn:xmpp:jingle:1' action='session-terminate' sid='call-1'>
+          <reason><success/></reason>
+        </jingle>
+    </iq>"#
+        .parse()
+        .unwrap();
+
+    let events = runtime.handle_app_stanza(&stanza);
+
+    assert_eq!(events.len(), 2);
+    match &events[0] {
+        ClientEvent::Connection(ConnectionEvent::OutboundMessage(TransportMessage::Element(
+            ack,
+        ))) => {
+            assert_eq!(ack.name(), "iq");
+            assert_eq!(ack.attr("type"), Some("result"));
+            assert_eq!(ack.attr("id"), Some("j1"));
+            assert_eq!(ack.attr("to"), Some("alice@waddle.test/desktop"));
+            assert_eq!(ack.attr("from"), Some("bob@waddle.test/phone"));
+        }
+        other => panic!("expected outbound IQ ack, got {other:?}"),
+    }
+    assert!(matches!(
+        &events[1],
+        ClientEvent::Call(call) if call.sid.0 == "call-1"
+    ));
+}
+
+#[test]
 fn runtime_bootstraps_auth_bind_and_ready_state() {
     let mut runtime = XmppRuntime::new(config()).unwrap();
     runtime.queue_request(ClientRequest::Connect).unwrap();

--- a/server/crates/waddle-xmpp/src/muc/room.rs
+++ b/server/crates/waddle-xmpp/src/muc/room.rs
@@ -225,6 +225,24 @@ impl MucRoom {
         self.muji_state.get(nick).map(|entry| &entry.muji)
     }
 
+    /// Clear a nickname's stored Muji advertisement if `originator`
+    /// owns it.
+    ///
+    /// XEP-0272 §Leaving says the Muji information is removed from
+    /// the participant's MUC presence when leaving the conference.
+    /// A regular available presence without `<muji/>` is therefore a
+    /// canonical clear signal for an occupant that previously
+    /// advertised Muji state.
+    pub fn clear_muji_presence(&mut self, nick: &str, originator: &FullJid) -> bool {
+        let Some(entry) = self.muji_state.get(nick) else {
+            return false;
+        };
+        if &entry.originator != originator {
+            return false;
+        }
+        self.muji_state.remove(nick).is_some()
+    }
+
     /// Add an occupant to the room.
     ///
     /// When this is a fresh join (nickname not currently present), the

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -25,8 +25,8 @@ mod tests;
 
 pub use admin_handlers::{ApplyAdminItems, GetAdminContext, IsOwner};
 pub use occupancy_handlers::{
-    JoinWithAffiliation, LeaveByRealJid, MujiPresenceUpdateOutcome, PingSelfCheck,
-    PresenceUpdateData, ReconcileChannelBackedRoom, UpsertMujiPresence,
+    ClearMujiPresence, JoinWithAffiliation, LeaveByRealJid, MujiPresenceUpdateOutcome,
+    PingSelfCheck, PresenceUpdateData, ReconcileChannelBackedRoom, UpsertMujiPresence,
 };
 pub use snapshot_handlers::{
     BuildGroupchatBroadcast, GetNicknameGeneration, GetRoomSnapshot, GroupchatBroadcastResult,
@@ -87,9 +87,12 @@ pub struct JoinOutcome {
 pub struct LeaveOutcome {
     pub nick: String,
     pub affiliation: Affiliation,
+    pub role: Role,
     pub leaving_room_jid: FullJid,
     pub remaining_occupants: Vec<FullJid>,
     pub removed_last_session: bool,
+    pub cleared_muji_state: bool,
+    pub remaining_nick_real_jid: Option<FullJid>,
     pub occupant_count: usize,
     /// Mirrors `MucRoom.config.persistent`. Surfaced so the leave
     /// caller can decide whether to evict the room's `RoomActor` +

--- a/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
@@ -118,6 +118,7 @@ impl kameo::message::Message<LeaveByRealJid> for RoomActor {
             return Ok(None);
         };
         let affiliation = occupant.affiliation;
+        let role = occupant.role;
         let leaving_room_jid = self
             .room
             .room_jid
@@ -131,18 +132,33 @@ impl kameo::message::Message<LeaveByRealJid> for RoomActor {
             .flat_map(|o| self.room.get_occupant_sessions(&o.nick))
             .filter(|jid| *jid != msg.sender_jid)
             .collect();
+        let cleared_muji_state = self
+            .room
+            .muji_state
+            .get(&nick)
+            .is_some_and(|entry| entry.originator == msg.sender_jid);
         let removed_last_session = self
             .room
             .remove_occupant_session(&nick, &msg.sender_jid)
             .unwrap_or(false);
+        let remaining_nick_real_jid = if removed_last_session {
+            None
+        } else {
+            self.room
+                .get_occupant(&nick)
+                .map(|occupant| occupant.real_jid.clone())
+        };
         let occupant_count = self.room.occupant_count();
         let is_persistent = self.room.config.persistent;
         Ok(Some(LeaveOutcome {
             nick,
             affiliation,
+            role,
             leaving_room_jid,
             remaining_occupants,
             removed_last_session,
+            cleared_muji_state,
+            remaining_nick_real_jid,
             occupant_count,
             is_persistent,
         }))
@@ -202,6 +218,10 @@ pub struct UpsertMujiPresence {
     pub muji: crate::xep::xep0272::Muji,
 }
 
+pub struct ClearMujiPresence {
+    pub sender_jid: FullJid,
+}
+
 #[derive(Debug, Clone)]
 pub struct MujiPresenceUpdateOutcome {
     pub update: PresenceUpdateOutcome,
@@ -251,6 +271,45 @@ impl kameo::message::Message<UpsertMujiPresence> for RoomActor {
                 recipients,
             },
             active_muji,
+        }))
+    }
+}
+
+impl kameo::message::Message<ClearMujiPresence> for RoomActor {
+    type Reply = Result<Option<MujiPresenceUpdateOutcome>, Infallible>;
+
+    async fn handle(
+        &mut self,
+        msg: ClearMujiPresence,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let Some(sender_occupant) = self.room.find_occupant_by_real_jid(&msg.sender_jid) else {
+            return Ok(None);
+        };
+        let sender_nick = sender_occupant.nick.clone();
+        let sender_real_jid = sender_occupant.real_jid.clone();
+        let sender_role = sender_occupant.role;
+        let sender_affiliation = sender_occupant.affiliation;
+        if !self.room.clear_muji_presence(&sender_nick, &msg.sender_jid) {
+            return Ok(None);
+        }
+        let room_jid = self.room.room_jid.clone();
+        let recipients = self
+            .room
+            .occupants
+            .values()
+            .flat_map(|o| self.room.get_occupant_sessions(&o.nick))
+            .collect();
+        Ok(Some(MujiPresenceUpdateOutcome {
+            update: PresenceUpdateOutcome {
+                sender_nick,
+                sender_real_jid,
+                sender_role,
+                sender_affiliation,
+                room_jid,
+                recipients,
+            },
+            active_muji: None,
         }))
     }
 }

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
@@ -1014,6 +1014,102 @@ async fn upsert_muji_presence_empty_clears_state_and_returns_none() {
 }
 
 #[tokio::test]
+async fn clear_muji_presence_clears_existing_state_without_muji_payload() {
+    let actor = spawn_room_actor().await;
+    let alice = test_full_jid("alice");
+    let bob = test_full_jid("bob");
+    actor
+        .ask(Join {
+            nick: "alice".to_string(),
+            real_jid: alice.clone(),
+            role: Role::Participant,
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("alice join");
+    actor
+        .ask(Join {
+            nick: "bob".to_string(),
+            real_jid: bob.clone(),
+            role: Role::Participant,
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("bob join");
+    actor
+        .ask(crate::muc::room_actor::UpsertMujiPresence {
+            sender_jid: alice.clone(),
+            muji: audio_muji(),
+        })
+        .await
+        .expect("ask")
+        .expect("alice is an occupant");
+
+    let outcome = actor
+        .ask(crate::muc::room_actor::ClearMujiPresence {
+            sender_jid: alice.clone(),
+        })
+        .await
+        .expect("ask")
+        .expect("alice had Muji state to clear");
+
+    assert_eq!(outcome.update.sender_nick, "alice");
+    assert!(
+        outcome.active_muji.is_none(),
+        "available presence without <muji/> clears the stored Muji advertisement"
+    );
+    assert!(
+        outcome.update.recipients.iter().any(|jid| jid == &bob),
+        "remaining occupants must be notified of the clear"
+    );
+
+    let carol = test_full_jid("carol");
+    let join_outcome = actor
+        .ask(JoinWithAffiliation {
+            sender_jid: carol,
+            nick: "carol".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+        })
+        .await
+        .expect("carol join");
+    let alice_replay = join_outcome
+        .existing_occupants
+        .iter()
+        .find(|o| o.nick == "alice")
+        .expect("alice still present");
+    assert!(
+        alice_replay.muji.is_none(),
+        "late join replay must not include stale Muji after a no-payload clear"
+    );
+}
+
+#[tokio::test]
+async fn clear_muji_presence_returns_none_when_no_state_exists() {
+    let actor = spawn_room_actor().await;
+    let alice = test_full_jid("alice");
+    actor
+        .ask(Join {
+            nick: "alice".to_string(),
+            real_jid: alice.clone(),
+            role: Role::Participant,
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("alice join");
+
+    let outcome = actor
+        .ask(crate::muc::room_actor::ClearMujiPresence { sender_jid: alice })
+        .await
+        .expect("ask");
+
+    assert!(
+        outcome.is_none(),
+        "plain available presence without prior Muji state stays on the existing join/update path"
+    );
+}
+
+#[tokio::test]
 async fn join_replay_includes_active_muji_from_existing_occupant() {
     // Late joiners see the chip light up immediately via the join
     // replay, not just after the next presence update from the call
@@ -1165,6 +1261,15 @@ async fn leaving_originator_session_clears_muji_state_even_with_peer_sessions_re
     assert!(
         !leave_outcome.removed_last_session,
         "mobile is still in the room, so alice's nick is not vacated"
+    );
+    assert!(
+        leave_outcome.cleared_muji_state,
+        "leaving originator resource must report that Muji state was cleared"
+    );
+    assert_eq!(
+        leave_outcome.remaining_nick_real_jid.as_ref(),
+        Some(&mobile),
+        "remaining same-nick resource is the canonical identity for the clear broadcast"
     );
 
     // A late joiner (carol) must NOT see alice's stale Muji ad.

--- a/server/crates/waddle-xmpp/src/protocol/handlers/jingle.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/jingle.rs
@@ -254,16 +254,21 @@ impl JingleHandler {
         };
         let peer_identity = Identity::from_jid(peer_full);
 
-        // Resolve the call's initiator JID. On session-initiate the
-        // initiator MUST be the authenticated session (else a peer
-        // could spoof a call as someone else, leaking tokens scoped
-        // to a victim's identity). On session-accept the initiator
-        // attribute names the original caller and the authenticated
-        // session is the responder.
-        let initiator_bare = match resolve_initiator(&jingle, &jingle.action, ctx) {
-            Ok(bare) => bare,
-            Err(e) => return e.into_reply(iq),
+        // Resolve the call initiator. `session-initiate` is scoped
+        // to the authenticated sender. `session-accept` is addressed
+        // back to the initiator, and XEP-0166 says non-initiate
+        // actions SHOULD NOT carry `initiator`, so derive from `to`.
+        let initiator_bare = match jingle.action {
+            Action::SessionInitiate => match resolve_initiator(&jingle, ctx) {
+                Ok(bare) => bare,
+                Err(e) => return e.into_reply(iq),
+            },
+            Action::SessionAccept => peer.to_bare(),
+            _ => ctx.full_jid.to_bare(),
         };
+        if let Err(e) = validate_responder(&jingle, &jingle.action, ctx) {
+            return e.into_reply(iq);
+        }
 
         // Namespace the LiveKit room by the initiator's bare JID so
         // an attacker can't pick a sid that collides with a victim's
@@ -284,16 +289,11 @@ impl JingleHandler {
             match rewrite_content_transport(content, &call_id, &peer_identity, &*self.sfu) {
                 Ok(()) => {}
                 Err(reason) => {
-                    // 1:1 P2P path — the "responder" perspective of
-                    // the session-terminate is the authenticated
-                    // session (we're the server, but for the
-                    // requester the rejection comes from where the
-                    // call was addressed). XEP-0166 §10.2 doesn't
-                    // strictly mandate the `from` JID; using the
-                    // authenticated full JID keeps the wire
-                    // self-consistent with the rest of the 1:1
-                    // forwarding flow.
-                    return reason.into_error_reply(iq, &jingle.sid, &ctx.full_jid.clone().into());
+                    // 1:1 P2P path: the requester addressed the
+                    // session-initiate to `peer`, so the Jingle-level
+                    // rejection must appear from that peer resource,
+                    // not from the requester back to itself.
+                    return reason.into_error_reply(iq, &jingle.sid, &peer);
                 }
             }
         }
@@ -358,15 +358,14 @@ impl JingleHandler {
             );
         }
 
-        // XEP-0166 §7.1 spoofing defense (same as the 1:1 path):
-        // the `initiator` attribute on `<jingle/>` must match the
-        // authenticated session. Otherwise charlie's session could
-        // mint a token claiming to be alice. Server-side we use
-        // `ctx.full_jid` for the LiveKit identity, but a wrong
-        // initiator attribute is still non-conformant and we reject
-        // rather than silently accept.
-        if let Err(e) = resolve_initiator(&jingle, &jingle.action, ctx) {
-            return e.into_reply(iq);
+        if jingle.action == Action::SessionInitiate {
+            // XEP-0166 §7.1 spoofing defense: when present on
+            // session-initiate, `initiator` must match the
+            // authenticated session. Non-initiate actions should not
+            // carry it, so we ignore it there per the XEP.
+            if let Err(e) = resolve_muji_initiator(&jingle, ctx) {
+                return e.into_reply(iq);
+            }
         }
 
         let Some(room_jid) = muji.room.clone() else {
@@ -489,12 +488,6 @@ impl JingleHandler {
                 minidom::rxml::xml_ncname!("responder").to_owned(),
                 responder.to_string(),
             );
-        if let Some(initiator) = &jingle.initiator {
-            jingle_builder = jingle_builder.attr(
-                minidom::rxml::xml_ncname!("initiator").to_owned(),
-                initiator.to_string(),
-            );
-        }
         // 1. `<muji room='…'/>` first per XEP-0272 §Joining example.
         jingle_builder = jingle_builder.append(Muji::for_room(room_jid).to_element());
         // 2. XEP-0298 §3.1 focus marker — also a direct child of
@@ -567,14 +560,30 @@ impl JingleHandler {
         peer: Jid,
         ctx: &StanzaContext<'_>,
     ) -> Vec<OutboundEvent> {
-        let initiator_bare = match resolve_initiator(&jingle, &jingle.action, ctx) {
-            Ok(bare) => bare,
-            Err(e) => return e.into_reply(iq),
+        let Ok(peer_full) = peer.clone().try_into_full() else {
+            return error_reply(
+                iq,
+                DefinedCondition::BadRequest,
+                "Jingle 'to' must be a full JID (resource required)",
+            );
         };
-        if let Ok(call_id) = scoped_call_id(&initiator_bare, &jingle.sid.0) {
+        let ctx_bare = ctx.full_jid.to_bare();
+        let peer_bare = peer.to_bare();
+        let sender_identity = Identity::from_jid(ctx.full_jid.clone());
+        let peer_identity = Identity::from_jid(peer_full);
+        for initiator_bare in [ctx_bare, peer_bare] {
+            let Ok(call_id) = scoped_call_id(&initiator_bare, &jingle.sid.0) else {
+                continue;
+            };
+            if !self.sfu.has_call_participant(&call_id, &sender_identity) {
+                continue;
+            }
             let _ = self
                 .sfu
-                .unregister_call_participant(&call_id, &Identity::from_jid(ctx.full_jid.clone()));
+                .unregister_call_participant(&call_id, &sender_identity);
+            let _ = self
+                .sfu
+                .unregister_call_participant(&call_id, &peer_identity);
         }
         self.route_unchanged(iq, peer, ctx)
     }
@@ -600,9 +609,10 @@ impl JingleHandler {
     }
 }
 
+#[derive(Debug)]
 enum InitiatorError {
     InitiatorMismatch,
-    InitiatorMissing,
+    ResponderMismatch,
 }
 
 impl InitiatorError {
@@ -613,10 +623,10 @@ impl InitiatorError {
                 DefinedCondition::Forbidden,
                 "Jingle initiator must match the authenticated session",
             ),
-            Self::InitiatorMissing => error_reply(
+            Self::ResponderMismatch => error_reply(
                 iq,
-                DefinedCondition::BadRequest,
-                "Jingle action requires the 'initiator' attribute",
+                DefinedCondition::Forbidden,
+                "Jingle responder must match the authenticated session",
             ),
         }
     }
@@ -625,31 +635,48 @@ impl InitiatorError {
 /// Verify the Jingle stanza's `initiator` attribute is consistent
 /// with the authenticated session and return the initiator's bare
 /// JID used to derive the SFU call-id.
-fn resolve_initiator(
+fn resolve_initiator(jingle: &Jingle, ctx: &StanzaContext<'_>) -> Result<BareJid, InitiatorError> {
+    let ctx_bare = ctx.full_jid.to_bare();
+    // The initiator attribute MAY be present (XEP-0166 §7.1); if so
+    // it must name the authenticated full JID. A same-bare but
+    // different-resource initiator would let alice/mobile mint or
+    // forward a call as alice/desktop.
+    let authenticated = Jid::from(ctx.full_jid.clone());
+    match jingle.initiator.as_ref() {
+        Some(declared) if declared != &authenticated => Err(InitiatorError::InitiatorMismatch),
+        _ => Ok(ctx_bare),
+    }
+}
+
+fn validate_responder(
     jingle: &Jingle,
     action: &Action,
     ctx: &StanzaContext<'_>,
+) -> Result<(), InitiatorError> {
+    if *action != Action::SessionAccept {
+        return Ok(());
+    }
+    let authenticated = Jid::from(ctx.full_jid.clone());
+    match jingle.responder.as_ref() {
+        Some(declared) if declared == &authenticated => Ok(()),
+        Some(_) => Err(InitiatorError::ResponderMismatch),
+        None => Ok(()),
+    }
+}
+
+/// Muji uses the same XEP-0166 initiator rule as 1:1 Jingle when
+/// the attribute is present: it must name the authenticated full
+/// JID. The attribute is still optional on session-initiate, so an
+/// omitted value resolves to the authenticated session.
+fn resolve_muji_initiator(
+    jingle: &Jingle,
+    ctx: &StanzaContext<'_>,
 ) -> Result<BareJid, InitiatorError> {
-    let ctx_bare = ctx.full_jid.to_bare();
-    match action {
-        Action::SessionInitiate => {
-            // The initiator attribute MAY be present (XEP-0166 §7.1);
-            // if so it must name the authenticated session.
-            match jingle.initiator.as_ref().map(|j| j.to_bare()) {
-                Some(declared) if declared != ctx_bare => Err(InitiatorError::InitiatorMismatch),
-                _ => Ok(ctx_bare),
-            }
-        }
-        _ => {
-            // Non-initiate actions MUST identify the initiator so
-            // the server can derive the same scoped call-id used on
-            // the original session-initiate.
-            jingle
-                .initiator
-                .as_ref()
-                .map(|j| j.to_bare())
-                .ok_or(InitiatorError::InitiatorMissing)
-        }
+    let ctx_full = Jid::from(ctx.full_jid.clone());
+    match jingle.initiator.as_ref() {
+        Some(declared) if declared == &ctx_full => Ok(ctx.full_jid.to_bare()),
+        Some(_) => Err(InitiatorError::InitiatorMismatch),
+        None => Ok(ctx.full_jid.to_bare()),
     }
 }
 
@@ -807,7 +834,7 @@ mod tests {
     };
     use xmpp_parsers::jingle::{Content, ContentId, Creator, SessionId};
 
-    fn fixture_sfu() -> Arc<dyn SfuService> {
+    fn fixture_livekit_sfu() -> Arc<LiveKitSfu> {
         let cfg = SfuConfig {
             api_key: ApiKey::new("APIxxxxxxxx"),
             api_secret: ApiSecret::from_text("super-secret-secret-32-bytes-min")
@@ -821,6 +848,10 @@ mod tests {
             turn_ttl: Duration::seconds(3600),
         };
         Arc::new(LiveKitSfu::new(cfg))
+    }
+
+    fn fixture_sfu() -> Arc<dyn SfuService> {
+        fixture_livekit_sfu()
     }
 
     fn test_ctx_jid() -> FullJid {
@@ -850,6 +881,40 @@ mod tests {
             to: Some(responder.parse().unwrap()),
             id: "i1".into(),
             payload: jingle.into(),
+        }
+    }
+
+    fn session_accept_iq(responder: &str, to: &str, sid: &str) -> Iq {
+        let mut content = Content::new(Creator::Initiator, ContentId("audio".into()));
+        content.description = Some(xmpp_parsers::jingle::Description::Rtp(
+            opus_audio_description(),
+        ));
+        content.transport = Some(Transport::Unknown(
+            WaddleLiveKitTransport::Request.to_element(),
+        ));
+        let mut jingle = Jingle::new(Action::SessionAccept, SessionId(sid.into()));
+        jingle.responder = Some(responder.parse().unwrap());
+        jingle.contents.push(content);
+        Iq::Set {
+            from: Some(responder.parse().unwrap()),
+            to: Some(to.parse().unwrap()),
+            id: "a1".into(),
+            payload: jingle.into(),
+        }
+    }
+
+    fn assert_error_condition(events: &[OutboundEvent], condition: DefinedCondition) {
+        match &events[0] {
+            OutboundEvent::SendStanza(stanza) => match stanza.as_ref() {
+                Stanza::Iq(reply) => {
+                    let Iq::Error { error: err, .. } = &**reply else {
+                        panic!("expected error");
+                    };
+                    assert_eq!(err.defined_condition, condition);
+                }
+                _ => panic!("expected Iq"),
+            },
+            _ => panic!("expected SendStanza"),
         }
     }
 
@@ -944,6 +1009,101 @@ mod tests {
     }
 
     #[test]
+    fn session_initiate_with_same_bare_different_resource_is_rejected() {
+        let iq = session_initiate_iq(
+            "alice@waddle.test/mobile",
+            "bob@waddle.test/desktop",
+            "same-bare-spoof",
+        );
+        let jid = test_ctx_jid();
+        let handler = JingleHandler::new(fixture_sfu());
+        let events = handler.handle(&iq, &ctx(&jid));
+
+        match &events[0] {
+            OutboundEvent::SendStanza(stanza) => match stanza.as_ref() {
+                Stanza::Iq(reply) => {
+                    let Iq::Error { error: err, .. } = &**reply else {
+                        panic!("expected error");
+                    };
+                    assert_eq!(err.defined_condition, DefinedCondition::Forbidden);
+                }
+                _ => panic!("expected Iq"),
+            },
+            _ => panic!("expected SendStanza"),
+        }
+    }
+
+    #[test]
+    fn session_initiate_with_bare_initiator_is_rejected_on_p2p_path() {
+        let iq = session_initiate_iq(
+            "alice@waddle.test",
+            "bob@waddle.test/desktop",
+            "bare-initiator",
+        );
+        let jid = test_ctx_jid();
+        let handler = JingleHandler::new(fixture_sfu());
+        let events = handler.handle(&iq, &ctx(&jid));
+
+        match &events[0] {
+            OutboundEvent::SendStanza(stanza) => match stanza.as_ref() {
+                Stanza::Iq(reply) => {
+                    let Iq::Error { error: err, .. } = &**reply else {
+                        panic!("expected error");
+                    };
+                    assert_eq!(err.defined_condition, DefinedCondition::Forbidden);
+                }
+                _ => panic!("expected Iq"),
+            },
+            _ => panic!("expected SendStanza"),
+        }
+    }
+
+    #[test]
+    fn session_accept_with_spoofed_responder_is_rejected() {
+        let iq = session_accept_iq(
+            "charlie@waddle.test/mobile",
+            "alice@waddle.test/desktop",
+            "c1",
+        );
+        let jid: FullJid = "bob@waddle.test/phone".parse().unwrap();
+        let handler = JingleHandler::new(fixture_sfu());
+        let events = handler.handle(&iq, &ctx(&jid));
+
+        assert_error_condition(&events, DefinedCondition::Forbidden);
+    }
+
+    #[test]
+    fn session_accept_without_responder_uses_authenticated_sender() {
+        let mut iq = session_accept_iq("bob@waddle.test/phone", "alice@waddle.test/desktop", "c1");
+        let Iq::Set { payload, .. } = &mut iq else {
+            panic!("expected set");
+        };
+        let mut jingle = Jingle::try_from(payload.clone()).expect("fixture reparses");
+        jingle.responder = None;
+        *payload = jingle.into();
+        let jid: FullJid = "bob@waddle.test/phone".parse().unwrap();
+        let handler = JingleHandler::new(fixture_sfu());
+        let events = handler.handle(&iq, &ctx(&jid));
+
+        assert!(
+            events
+                .iter()
+                .any(|ev| matches!(ev, OutboundEvent::RouteToConnection { .. })),
+            "missing responder should resolve to authenticated sender and route"
+        );
+    }
+
+    #[test]
+    fn muji_session_initiate_rejects_bare_initiator() {
+        let mut jingle = Jingle::new(Action::SessionInitiate, SessionId("muji-bare".into()));
+        jingle.initiator = Some("alice@waddle.test".parse().unwrap());
+        let jid = test_ctx_jid();
+        let err = resolve_muji_initiator(&jingle, &ctx(&jid))
+            .expect_err("Muji path requires full initiator when present");
+        assert!(matches!(err, InitiatorError::InitiatorMismatch));
+    }
+
+    #[test]
     fn unsupported_transport_emits_xep_0166_section_10_2_termination() {
         // XEP-0166 §10.2: a session-initiate with an unacceptable
         // transport MUST be rejected with an IQ-result ack followed
@@ -999,9 +1159,22 @@ mod tests {
         let Stanza::Iq(term_iq) = term_stanza.as_ref() else {
             panic!("expected Iq for terminate");
         };
-        let Iq::Set { payload, .. } = &**term_iq else {
+        let Iq::Set {
+            from, to, payload, ..
+        } = &**term_iq
+        else {
             panic!("expected IQ-set for the session-terminate");
         };
+        assert_eq!(
+            from.as_ref().map(ToString::to_string),
+            Some("bob@waddle.test/desktop".to_string()),
+            "unsupported-transport terminate must come from the addressed peer"
+        );
+        assert_eq!(
+            to.as_ref().map(ToString::to_string),
+            Some("alice@waddle.test/desktop".to_string()),
+            "unsupported-transport terminate must be addressed back to requester"
+        );
         let term_jingle =
             Jingle::try_from(payload.clone()).expect("session-terminate Jingle reparses");
         assert_eq!(
@@ -1023,12 +1196,9 @@ mod tests {
 
     #[test]
     fn session_terminate_routes_to_peer_and_unregisters() {
-        let mut jingle = Jingle::new(Action::SessionTerminate, SessionId("c1".into())).set_reason(
+        let jingle = Jingle::new(Action::SessionTerminate, SessionId("c1".into())).set_reason(
             xep0166::reason_element(xmpp_parsers::jingle::Reason::Success),
         );
-        // Non-initiate actions require `initiator` so the server can
-        // re-derive the scoped call-id.
-        jingle.initiator = Some("alice@waddle.test/desktop".parse().unwrap());
         let iq = Iq::Set {
             from: Some("alice@waddle.test/desktop".parse().unwrap()),
             to: Some("bob@waddle.test/desktop".parse().unwrap()),
@@ -1036,16 +1206,20 @@ mod tests {
             payload: jingle.into(),
         };
 
-        let sfu = fixture_sfu();
+        let sfu = fixture_livekit_sfu();
         // Pre-register under the scoped id so the unregister path
         // has something to remove.
         let call = waddle_sfu::CallId::new("alice@waddle.test::c1").unwrap();
         let alice = Identity::from_jid("alice@waddle.test/desktop".parse().unwrap());
+        let bob = Identity::from_jid("bob@waddle.test/desktop".parse().unwrap());
         sfu.register_call_participant(&call, &alice);
+        sfu.register_call_participant(&call, &bob);
+        assert_eq!(sfu.participant_count(&call), 2);
 
         let jid = test_ctx_jid();
-        let handler = JingleHandler::new(sfu);
+        let handler = JingleHandler::new(sfu.clone());
         let events = handler.handle(&iq, &ctx(&jid));
+        assert_eq!(sfu.participant_count(&call), 0);
 
         // No server-forged ACK — just the forwarded terminate.
         assert_eq!(events.len(), 1);
@@ -1057,6 +1231,57 @@ mod tests {
             }
         }
         assert!(routed);
+    }
+
+    #[test]
+    fn session_terminate_does_not_unregister_peer_when_sender_is_not_participant() {
+        let jingle = Jingle::new(Action::SessionTerminate, SessionId("c1".into())).set_reason(
+            xep0166::reason_element(xmpp_parsers::jingle::Reason::Success),
+        );
+        let iq = Iq::Set {
+            from: Some("eve@waddle.test/laptop".parse().unwrap()),
+            to: Some("bob@waddle.test/desktop".parse().unwrap()),
+            id: "t-third-party".into(),
+            payload: jingle.into(),
+        };
+
+        let sfu = fixture_livekit_sfu();
+        let call = waddle_sfu::CallId::new("bob@waddle.test::c1").unwrap();
+        let alice = Identity::from_jid("alice@waddle.test/desktop".parse().unwrap());
+        let bob = Identity::from_jid("bob@waddle.test/desktop".parse().unwrap());
+        sfu.register_call_participant(&call, &alice);
+        sfu.register_call_participant(&call, &bob);
+        assert_eq!(sfu.participant_count(&call), 2);
+
+        let eve: FullJid = "eve@waddle.test/laptop".parse().unwrap();
+        let handler = JingleHandler::new(sfu.clone());
+        let events = handler.handle(&iq, &ctx(&eve));
+
+        assert_eq!(sfu.participant_count(&call), 2);
+        assert_eq!(events.len(), 1);
+        assert!(
+            matches!(events[0], OutboundEvent::RouteToConnection { .. }),
+            "the stanza still routes to the addressed peer; only SFU cleanup is gated"
+        );
+    }
+
+    #[test]
+    fn session_terminate_to_bare_peer_is_rejected() {
+        let jingle = Jingle::new(Action::SessionTerminate, SessionId("c1".into())).set_reason(
+            xep0166::reason_element(xmpp_parsers::jingle::Reason::Success),
+        );
+        let iq = Iq::Set {
+            from: Some("alice@waddle.test/desktop".parse().unwrap()),
+            to: Some("bob@waddle.test".parse().unwrap()),
+            id: "t-bare".into(),
+            payload: jingle.into(),
+        };
+
+        let jid = test_ctx_jid();
+        let handler = JingleHandler::new(fixture_sfu());
+        let events = handler.handle(&iq, &ctx(&jid));
+
+        assert_error_condition(&events, DefinedCondition::BadRequest);
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/tests/xep_0272_muji.rs
+++ b/server/crates/waddle-xmpp/tests/xep_0272_muji.rs
@@ -420,19 +420,27 @@ fn first_error_condition(events: &[OutboundEvent]) -> Option<DefinedCondition> {
 }
 
 fn has_session_accept_to(events: &[OutboundEvent], expected_to: &str) -> bool {
-    events.iter().any(|ev| {
+    session_accept_payload_to(events, expected_to).is_some()
+}
+
+fn session_accept_payload_to<'a>(
+    events: &'a [OutboundEvent],
+    expected_to: &str,
+) -> Option<&'a Element> {
+    events.iter().find_map(|ev| {
         let OutboundEvent::SendStanza(stanza) = ev else {
-            return false;
+            return None;
         };
         let Stanza::Iq(boxed) = stanza.as_ref() else {
-            return false;
+            return None;
         };
         let Iq::Set { payload, to, .. } = boxed.as_ref() else {
-            return false;
+            return None;
         };
-        to.as_ref().is_some_and(|j| j.to_string() == expected_to)
+        (to.as_ref().is_some_and(|j| j.to_string() == expected_to)
             && payload.name() == "jingle"
-            && payload.attr("action") == Some("session-accept")
+            && payload.attr("action") == Some("session-accept"))
+        .then_some(payload)
     })
 }
 
@@ -463,6 +471,36 @@ fn local_muji_mixer_jid_passes_federation_guard() {
     assert!(
         has_session_accept_to(&events, TEST_INITIATOR),
         "expected Muji session-accept addressed to initiator: {events:?}",
+    );
+}
+
+#[test]
+fn local_muji_session_accept_uses_focus_responder_without_initiator_attr() {
+    // XEP-0166 only recommends echoing `initiator` on actions sent
+    // by the responder. The Muji focus is the authenticated sender
+    // of the server-initiated session-accept, so the conformant and
+    // least ambiguous identity signal is `responder='calls.<domain>'`.
+    let iq = muji_session_initiate_iq(
+        TEST_INITIATOR,
+        &calls_mixer_jid(TEST_DOMAIN).to_string(),
+        "room@muc.waddle.test",
+        "muji-focus-responder",
+    );
+    let jid = test_full_jid();
+    let handler = JingleHandler::new(fixture_sfu());
+    let events = handler.handle(&iq, &ctx(&jid));
+    let accept = session_accept_payload_to(&events, TEST_INITIATOR)
+        .unwrap_or_else(|| panic!("expected Muji session-accept: {events:?}"));
+
+    assert_eq!(
+        accept.attr("responder"),
+        Some("calls.waddle.test"),
+        "Muji session-accept must identify the conference focus as responder",
+    );
+    assert_eq!(
+        accept.attr("initiator"),
+        None,
+        "Muji session-accept should not copy the client's initiator attr",
     );
 }
 

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -146,6 +146,7 @@ export class WaddleClient {
     search_room_history(room_jid: string, query: string, max: number): Promise<any>;
     search_users(query: string): Promise<any>;
     send_call_finish(peer_full_jid: string, sid_str: string): Promise<any>;
+    send_call_finish_migrated(peer_full_jid: string, old_sid_str: string, new_sid_str: string): Promise<any>;
     send_call_proceed(peer_full_jid: string, sid_str: string): Promise<any>;
     /**
      * Send a JMI `<propose/>` to the peer's bare JID (XEP-0353
@@ -154,14 +155,16 @@ export class WaddleClient {
      */
     send_call_propose(peer_bare_jid: string, sid_str: string, audio: boolean, video: boolean): Promise<any>;
     send_call_reject(peer_full_jid: string, sid_str: string): Promise<any>;
-    send_call_retract(peer_full_jid: string, sid_str: string): Promise<any>;
+    send_call_reject_tie_break(peer_full_jid: string, sid_str: string): Promise<any>;
+    send_call_retract(peer_jid: string, sid_str: string): Promise<any>;
+    send_call_retract_tie_break(peer_full_jid: string, sid_str: string): Promise<any>;
     /**
      * Send a Jingle `session-accept` IQ in response to a received
-     * session-initiate. `initiator` and `responder` are validated
-     * as full JIDs at the wasm boundary so a malformed JID surfaces
+     * session-initiate. `responder` is validated as a full JID at
+     * the wasm boundary so a malformed JID surfaces
      * as a clear `JsError` rather than a wire-rejected stanza.
      */
-    send_call_session_accept(peer_full_jid: string, initiator_full_jid: string, responder_full_jid: string, sid_str: string, audio: boolean, video: boolean): Promise<any>;
+    send_call_session_accept(peer_full_jid: string, responder_full_jid: string, sid_str: string, audio: boolean, video: boolean): Promise<any>;
     /**
      * Send a Jingle `session-initiate` IQ to the peer's full JID
      * (XEP-0166 §6.4). The `initiator` attribute names the call
@@ -193,7 +196,7 @@ export class WaddleClient {
      * ```xml
      * <iq type='set' to='calls.<domain>' id='…'>
      *   <jingle xmlns='urn:xmpp:jingle:1' action='session-initiate'
-     *           sid='ROOM_JID'>
+     *           sid='ATTEMPT_ID'>
      *     <muji xmlns='urn:xmpp:jingle:muji:0' room='ROOM_JID'/>
      *     <content creator='initiator' name='audio' senders='both'>
      *       <description xmlns='urn:xmpp:jingle:apps:rtp:1' media='audio'/>
@@ -204,9 +207,10 @@ export class WaddleClient {
      * </iq>
      * ```
      *
-     * Convention: `sid` is set to the room JID so that the
-     * corresponding `session-terminate` is unambiguous without
-     * requiring the client to track its own SIDs across reloads.
+     * Convention: `sid` is a per-attempt correlation id while
+     * `<muji room='…'/>` remains the stable SFU room identity.
+     * This lets the chat UI ignore a stale accept from a cancelled
+     * same-room retry without changing XEP-0272 room semantics.
      *
      * `video` opt-in mirrors the call store's `media.video`
      * flag — audio is always advertised (the call wouldn't be
@@ -214,7 +218,7 @@ export class WaddleClient {
      * asked for it. LiveKit handles the actual codec selection
      * once connected, so the descriptions are minimal.
      */
-    send_muji_session_initiate(room_jid: string, video: boolean): Promise<any>;
+    send_muji_session_initiate(room_jid: string, sid_str: string, video: boolean): Promise<any>;
     /**
      * Send a XEP-0272 Muji-bearing Jingle `session-terminate` IQ
      * to the SFU mixer (`calls.<server-domain>`). Server
@@ -226,14 +230,14 @@ export class WaddleClient {
      * ```xml
      * <iq type='set' to='calls.<domain>' id='…'>
      *   <jingle xmlns='urn:xmpp:jingle:1' action='session-terminate'
-     *           sid='ROOM_JID' initiator='alice@…'>
+     *           sid='PER_ATTEMPT_SID'>
      *     <muji xmlns='urn:xmpp:jingle:muji:0' room='ROOM_JID'/>
      *     <reason><success/></reason>
      *   </jingle>
      * </iq>
      * ```
      */
-    send_muji_session_terminate(room_jid: string): Promise<any>;
+    send_muji_session_terminate(room_jid: string, sid_str: string): Promise<any>;
     send_presence(status?: string | null, show?: string | null): Promise<any>;
     send_raw_iq(xml: string): Promise<any>;
     send_reaction(to: string, msg_type: string, target_id: string, emojis: string[], thread_id?: string | null, thread_parent?: string | null): Promise<any>;

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpeeyixp";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpeeyixp";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpeeyixp";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpfxhu64";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpfxhu64";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpfxhu64";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=mpeeyixp";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=mpfxhu64";


### PR DESCRIPTION
## Summary

Hardens the full audio/video call feature across 1:1 JMI/Jingle calls and Muji group calls.

## Plan / Work Done

- Route typed call events end-to-end through the Rust client runtime, WASM bridge, FFI bridge, and chat UI instead of losing call semantics in generic message paths.
- Preserve XEP-0353 JMI tie-break and migration metadata (`tie-break`, `migrated-to`) across Rust, WASM, FFI, and Apple bindings.
- Fix 1:1 lifecycle races: simultaneous propose tie-breaks, post-proceed session-accept timeout, same-bare-JID device migration, stale callback handling after disconnect, and session-terminate shapes.
- Fix Muji group call lifecycle: two-phase XEP-0272 preparing/content presence, group-call indicators from real MUC presence events, pending start cancellation, room-switch teardown, disconnect cleanup, stale accept rejection, and per-attempt Jingle SIDs while keeping `<muji room>` as the stable SFU room identity.
- Harden server Jingle/Muji handling: initiator/responder validation, unsupported transport termination, participant-scoped SFU cleanup, Muji focus responder shape, and MUC Muji presence cleanup on unavailable/available-without-Muji presence.
- Update generated WASM package and Apple UniFFI bindings for the new typed call surface.
- Add focused UI tests that drive the real event callbacks (`on_call`, presence callbacks, disconnected callbacks) instead of directly mutating stores.

## XEP Review

Reviewed the implementation against local XEPs for:

- XEP-0166 Jingle: session identity, responder/initiator validation, separate `session-accept`, and `session-terminate` behavior.
- XEP-0272 Muji: two-phase preparing/content presence, stable room metadata, mixer focus behavior, and leave cleanup.
- XEP-0353 Jingle Message Initiation: tie-break metadata, finish/proceed migration markers, and full-JID response targeting.

No custom namespace is used for semantics covered by these XEPs.

## Adversarial Review

Multiple review passes found and fixed real issues before marking ready:

- stale callback/disconnect races,
- forged Muji `session-accept` acceptance,
- pending Muji accept waiters surviving disconnect/replacement,
- same-room stale accept correlation,
- and Muji `session-terminate` using the room JID instead of the active per-attempt Jingle SID.

Final adversarial pass found no real actionable issues.

## Tests

- `REBUILD_WASM=1 bun run wasm:build`
- `bun test`
- `bun run lint`
- `bunx astro check`
- `bunx astro build`
- `cargo fmt --all`
- `cargo clippy -p waddle-sfu -p waddle-xmpp-client -p waddle-xmpp-client-wasm -p waddle-xmpp-client-ffi -p waddle-xmpp -p waddle-server --no-deps -- -D warnings`
- `cargo test -p waddle-xmpp --test xep_0272_muji -- --nocapture`
- `cargo test -p waddle-xmpp --lib jingle -- --nocapture`
- `cargo test -p waddle-xmpp-client call -- --nocapture`
- `cargo test -p waddle-xmpp-client-wasm call -- --nocapture --test-threads=1`
- `cargo test -p waddle-xmpp-client-ffi call -- --nocapture`
- `cargo test -p waddle-sfu -- --nocapture`
- `cargo test -p waddle-server --test calls_e2e_ws -- --nocapture`
- `cargo test -p waddle-server muji_clear -- --nocapture`
- `git diff --check`

Notes:

- One parallel `bunx astro check` attempt hit a transient Miniflare SQLite lock while `bunx astro build` was also running. Rerunning `bunx astro check` by itself passed with 0 errors, 0 warnings, 0 hints.
- Native test builds of `waddle-xmpp-client-wasm` still print the existing non-fatal `resolve_component_services` dead-code warning; clippy with `-D warnings` is clean.
