### PR TITLE
feat(chat): global "you're in a call" pill (cross-room + refresh-resume)

### DIFF
--- a/chat/src/components/calls/CallReturnPill.vue
+++ b/chat/src/components/calls/CallReturnPill.vue
@@ -1,0 +1,275 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
+import { useStore } from "@nanostores/vue";
+import { PhoneCall } from "lucide-vue-next";
+import { $activeCallStartedAt } from "@/lib/calls/call-store";
+import { $persistedCallStub } from "@/lib/calls/call-persistence";
+import {
+  $mucCallParticipants,
+  normalizeMucCallRoomJid,
+} from "@/lib/calls/muc-call-presence";
+import { useActiveMucCall } from "@/lib/calls/use-active-muc-call";
+import { channelIdForRoomJid } from "@/lib/channel-room";
+import type { ChannelSummary } from "@/lib/chat-types";
+
+/**
+ * Global "return to your call" pill rendered in the app shell.
+ *
+ * Two visibility modes:
+ *
+ * 1. **live** — the local user is in an active MUC group call AND
+ *    the currently-viewed room is not the call's room. The pill
+ *    shows running duration sourced from `$activeCallStartedAt`
+ *    and a "Return" affordance. Clicking it navigates to the
+ *    room.
+ *
+ * 2. **rejoin** — the in-memory call state is gone (typically a
+ *    hard refresh tore down the WebSocket + WASM client) but a
+ *    `$persistedCallStub` survives in sessionStorage AND that
+ *    room's XEP-0272 Muji participant list still contains other
+ *    active nicks (the call hasn't ended yet). The pill shows
+ *    "Rejoin" with no duration — the local user's stay was
+ *    interrupted, so the previous duration is meaningless. Click
+ *    navigates to the room where `MucCallButton` / `CallActivePill`
+ *    drive the actual rejoin.
+ *
+ * Both modes are hidden when the user is already viewing the
+ * room — the per-channel surfaces (`CallSplitContainer`,
+ * `CallActivePill`) own the in-room story.
+ */
+const props = defineProps<{
+  /** Bare room JID the user is currently viewing, or `null` when
+   *  the active surface isn't a channel (dashboard, settings,
+   *  threads, DMs, etc.). The pill renders for any non-matching
+   *  case, including the null case. */
+  viewedRoomJid: string | null;
+  /** Channel list the controller already exposes. Used to resolve
+   *  the active call's room JID back to a local channel id so the
+   *  click handler can navigate via `selectChannel`. */
+  channels: readonly Pick<ChannelSummary, "id" | "jid" | "name">[];
+  /** Navigate to a channel by id. Wired to the controller's
+   *  `selectChannel` so the click reuses the existing room-load
+   *  + message-fetch path. */
+  onNavigate: (channelId: string) => void;
+}>();
+
+const startedAt = useStore($activeCallStartedAt);
+const stub = useStore($persistedCallStub);
+const participants = useStore($mucCallParticipants);
+const { selfInCall, activeRoomJid } = useActiveMucCall();
+
+const liveRoomJid = computed<string | null>(() => {
+  if (!selfInCall.value) return null;
+  return activeRoomJid.value;
+});
+
+const rejoinRoomJid = computed<string | null>(() => {
+  if (selfInCall.value) return null;
+  const persisted = stub.value;
+  if (!persisted) return null;
+  const normalized = normalizeMucCallRoomJid(persisted.roomJid) || persisted.roomJid;
+  const nicks = participants.value[normalized] ?? [];
+  if (nicks.length === 0) return null;
+  return normalized;
+});
+
+const targetRoomJid = computed<string | null>(() => {
+  return liveRoomJid.value ?? rejoinRoomJid.value;
+});
+
+const mode = computed<"live" | "rejoin" | "hidden">(() => {
+  if (!targetRoomJid.value) return "hidden";
+  const viewed = props.viewedRoomJid
+    ? normalizeMucCallRoomJid(props.viewedRoomJid) || props.viewedRoomJid
+    : null;
+  if (viewed === targetRoomJid.value) return "hidden";
+  return liveRoomJid.value ? "live" : "rejoin";
+});
+
+const targetChannel = computed(() => {
+  const room = targetRoomJid.value;
+  if (!room) return null;
+  const channelId = channelIdForRoomJid(props.channels, room);
+  if (!channelId) return null;
+  const channel = props.channels.find((c) => c.id === channelId);
+  return { channelId, name: channel?.name ?? channelId };
+});
+
+const participantCount = computed<number>(() => {
+  const room = targetRoomJid.value;
+  if (!room) return 0;
+  return (participants.value[room] ?? []).length;
+});
+
+const now = ref(Date.now());
+let tick: ReturnType<typeof setInterval> | null = null;
+
+onMounted(() => {
+  tick = setInterval(() => {
+    now.value = Date.now();
+  }, 1000);
+});
+
+onBeforeUnmount(() => {
+  if (tick) {
+    clearInterval(tick);
+    tick = null;
+  }
+});
+
+const durationLabel = computed<string | null>(() => {
+  if (mode.value !== "live") return null;
+  const start = startedAt.value;
+  if (start === null) return null;
+  const seconds = Math.max(0, Math.floor((now.value - start) / 1000));
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  const mm = m.toString().padStart(2, "0");
+  const ss = s.toString().padStart(2, "0");
+  return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`;
+});
+
+const verb = computed<string>(() => (mode.value === "rejoin" ? "Rejoin" : "Return to"));
+
+const channelLabel = computed<string>(() => {
+  const target = targetChannel.value;
+  if (target) return `#${target.name}`;
+  const room = targetRoomJid.value;
+  if (!room) return "";
+  const local = room.split("@")[0];
+  return local ? `#${local}` : room;
+});
+
+const ariaLabel = computed<string>(() => {
+  if (mode.value === "live") {
+    const count = participantCount.value;
+    const noun = count === 1 ? "person" : "people";
+    return `You are in a call in ${channelLabel.value} with ${count} ${noun}, ${durationLabel.value ?? "0:00"} elapsed. Click to return.`;
+  }
+  const count = participantCount.value;
+  const noun = count === 1 ? "person" : "people";
+  return `A call you were in is still ongoing in ${channelLabel.value} with ${count} ${noun}. Click to rejoin.`;
+});
+
+function onClick(): void {
+  const target = targetChannel.value;
+  if (!target) return;
+  props.onNavigate(target.channelId);
+}
+</script>
+
+<template>
+  <button
+    v-if="mode !== 'hidden' && targetChannel"
+    type="button"
+    class="call-return-pill"
+    :class="[`call-return-pill--${mode}`]"
+    :aria-label="ariaLabel"
+    :title="ariaLabel"
+    role="status"
+    aria-live="polite"
+    @click="onClick"
+  >
+    <span class="call-return-pill__dot" aria-hidden="true" />
+    <PhoneCall class="call-return-pill__icon" aria-hidden="true" />
+    <span class="call-return-pill__verb">{{ verb }}</span>
+    <span class="call-return-pill__room">{{ channelLabel }}</span>
+    <template v-if="durationLabel">
+      <span class="call-return-pill__separator" aria-hidden="true">·</span>
+      <span class="call-return-pill__duration tabular-nums">{{ durationLabel }}</span>
+    </template>
+  </button>
+</template>
+
+<style scoped>
+.call-return-pill {
+  position: fixed;
+  top: calc(env(safe-area-inset-top, 0px) + 0.75rem);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 60;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.375rem 0.875rem;
+  border-radius: 9999px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: white;
+  cursor: pointer;
+  transition: transform 160ms ease-out, box-shadow 160ms ease-out,
+    background-color 160ms ease-out;
+  box-shadow: 0 6px 20px -4px color-mix(in oklab, oklch(0.6 0.2 25) 45%, transparent),
+    0 2px 6px -1px rgba(0, 0, 0, 0.15);
+  backdrop-filter: blur(6px);
+}
+
+.call-return-pill--live {
+  background: linear-gradient(
+    180deg,
+    oklch(0.65 0.18 25) 0%,
+    oklch(0.58 0.2 25) 100%
+  );
+  border: 1px solid color-mix(in oklab, oklch(0.7 0.2 25) 70%, transparent);
+}
+
+.call-return-pill--rejoin {
+  background: linear-gradient(
+    180deg,
+    oklch(0.7 0.16 75) 0%,
+    oklch(0.62 0.18 65) 100%
+  );
+  border: 1px solid color-mix(in oklab, oklch(0.72 0.18 70) 70%, transparent);
+}
+
+.call-return-pill:hover {
+  transform: translateX(-50%) translateY(-1px);
+  box-shadow: 0 10px 28px -4px color-mix(in oklab, oklch(0.6 0.2 25) 55%, transparent),
+    0 4px 10px -1px rgba(0, 0, 0, 0.2);
+}
+
+.call-return-pill:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px color-mix(in oklab, oklch(0.75 0.18 25) 55%, transparent);
+}
+
+.call-return-pill__dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 9999px;
+  background: white;
+  box-shadow: 0 0 0 3px color-mix(in oklab, white 30%, transparent);
+  animation: call-return-pill-pulse 1.6s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .call-return-pill__dot {
+    animation: none;
+  }
+}
+
+@keyframes call-return-pill-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.55; transform: scale(0.8); }
+}
+
+.call-return-pill__icon {
+  width: 0.875rem;
+  height: 0.875rem;
+}
+
+.call-return-pill__separator {
+  opacity: 0.55;
+}
+
+.call-return-pill__room {
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.call-return-pill__duration {
+  font-variant-numeric: tabular-nums;
+  opacity: 0.92;
+}
+</style>

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -12,6 +12,7 @@ import StoriesPane from "@/components/community/StoriesPane.vue";
 import EventsPane from "@/components/community/EventsPane.vue";
 import ChatAppModals from "@/components/chat/ChatAppModals.vue";
 import ChatMobileDrawers from "@/components/chat/ChatMobileDrawers.vue";
+import CallReturnPill from "@/components/calls/CallReturnPill.vue";
 import ContentArea from "@/components/chat/ContentArea.vue";
 import DmPanel from "@/components/chat/DmPanel.vue";
 import ExtensionRouteRail from "@/components/chat/ExtensionRouteRail.vue";
@@ -155,6 +156,20 @@ const callParticipantCounts = computed<Record<string, number>>(() => {
   return mucCallParticipantCounts(mucCallParticipantsStore.value);
 });
 
+/**
+ * Bare room JID of whatever channel the user is currently looking
+ * at, or `null` when the active surface isn't a channel chat
+ * (dashboard, settings, threads, DMs, community feeds, admin).
+ * Used by `CallReturnPill` to decide whether the local user is
+ * already inside the room that owns their active call.
+ */
+const currentlyViewedRoomJid = computed<string | null>(() => {
+  if (ui.activePage.value !== "chat") return null;
+  if (ui.sidebarMode.value !== "channels") return null;
+  if (ui.activeCommunitySurface.value !== null) return null;
+  return activeChannelRoomJid.value ?? null;
+});
+
 const contentPaneClass = computed(() => {
   if (ui.sidebarMode.value !== "channels") return "";
   if (activeRightPanel.value === "thread") {
@@ -231,6 +246,18 @@ onUnmounted(() => {
 </script>
 
 <template>
+  <!--
+    Cross-surface "you're in a call" return pill. Mounted at the
+    template root so it floats above whatever page is active —
+    admin, dashboard, threads, settings, DMs, and channels that
+    don't own the call all surface it. The pill is `position:
+    fixed` so it has no layout impact on the underlying surfaces.
+  -->
+  <CallReturnPill
+    :viewed-room-jid="currentlyViewedRoomJid"
+    :channels="waddles.sortedChannels.value"
+    :on-navigate="(channelId) => { void selectChannel(channelId); }"
+  />
   <AdminView
     v-if="ui.activePage.value === 'admin'"
     :xmpp-client="xmppClient"

--- a/chat/src/lib/calls/call-persistence.ts
+++ b/chat/src/lib/calls/call-persistence.ts
@@ -1,0 +1,94 @@
+import { atom } from "nanostores";
+
+/**
+ * sessionStorage-backed stub of "the last call this tab was in". On
+ * a hard refresh (F5) the in-memory `$callState` is wiped along with
+ * the XMPP WebSocket, the Jingle session, and the LiveKit token, so
+ * the user is XMPP-wise no longer in the call. The stub lets the
+ * UI surface a "rejoin in #room" affordance after the room's Muji
+ * presence repopulates, instead of silently dropping the user.
+ *
+ * Lifecycle:
+ * - Written when `$callState` enters `phase: "active"` with
+ *   `kind: "muc"` (only group calls qualify — DM calls have a
+ *   different rejoin shape and aren't covered here).
+ * - Cleared on local hangup, on `phase: "ended"`, or when the
+ *   room's Muji participant list drops to zero (call wrapped up
+ *   while the tab was gone).
+ * - Bounded by tab lifetime (sessionStorage), which matches the
+ *   "active call session" intent — closing the tab is a deliberate
+ *   exit, no need to nag the user about an old call on reopen.
+ *
+ * Stored shape is intentionally minimal — the room JID is the only
+ * field a rejoin needs, and the timestamp lets us age-out stubs
+ * that survived past their welcome.
+ */
+type PersistedCallStub = {
+  roomJid: string;
+  /** Wall-clock ms when the call became active in this tab. Used
+   *  to age out stubs older than `STALE_AFTER_MS` on boot. */
+  joinedAt: number;
+};
+
+const STORAGE_KEY = "waddle:active-muc-call";
+const STALE_AFTER_MS = 12 * 60 * 60 * 1000;
+
+function readFromStorage(): PersistedCallStub | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<PersistedCallStub> | null;
+    if (!parsed || typeof parsed.roomJid !== "string" || !parsed.roomJid) {
+      return null;
+    }
+    const joinedAt = typeof parsed.joinedAt === "number" ? parsed.joinedAt : 0;
+    if (Date.now() - joinedAt > STALE_AFTER_MS) {
+      window.sessionStorage.removeItem(STORAGE_KEY);
+      return null;
+    }
+    return { roomJid: parsed.roomJid, joinedAt };
+  } catch {
+    return null;
+  }
+}
+
+function writeToStorage(stub: PersistedCallStub | null): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (stub === null) {
+      window.sessionStorage.removeItem(STORAGE_KEY);
+      return;
+    }
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(stub));
+  } catch {
+    // sessionStorage may throw in private modes or when quota is
+    // exhausted — the in-memory atom still reflects the intended
+    // state, so the UI keeps working for the current tab.
+  }
+}
+
+export const $persistedCallStub = atom<PersistedCallStub | null>(readFromStorage());
+
+export function persistCallStub(roomJid: string): void {
+  const stub: PersistedCallStub = { roomJid, joinedAt: Date.now() };
+  $persistedCallStub.set(stub);
+  writeToStorage(stub);
+}
+
+export function clearPersistedCallStub(): void {
+  $persistedCallStub.set(null);
+  writeToStorage(null);
+}
+
+/** Test-only reset hook: wipes both the in-memory atom and the
+ *  storage entry so test ordering doesn't leak stale stubs. */
+export function __resetPersistedCallStubForTests(): void {
+  $persistedCallStub.set(null);
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -8,6 +8,7 @@ import {
   clearMucCallParticipant,
   normalizeMucCallRoomJid,
 } from "./muc-call-presence";
+import { clearPersistedCallStub, persistCallStub } from "./call-persistence";
 import { barePeerJid } from "../xmpp/jid";
 
 /**
@@ -159,6 +160,45 @@ export const $callState = atom<CallState>({ phase: "idle" });
  * successful state transition.
  */
 export const $lastCallError = atom<string | null>(null);
+
+/**
+ * Wall-clock timestamp (ms) of when the local user's active call
+ * began, or `null` when no call is active. Tracked per `sid` so a
+ * call-to-call handoff (rare, but valid) resets the clock instead
+ * of carrying the previous call's duration forward.
+ *
+ * Single source of truth for the "you're in a call" return pill and
+ * any future surface that needs to render a running duration for
+ * the local-user-joined call. Surfaces that show duration for a
+ * call the user has NOT joined yet (e.g. `CallActivePill`) need a
+ * different signal — the room's call onset, not the local user's
+ * join — and stay on their own first-seen-active tracking.
+ */
+export const $activeCallStartedAt = atom<number | null>(null);
+
+let activeCallTrackedSid: string | null = null;
+$callState.listen((state) => {
+  if (state.phase === "active") {
+    if (state.sid !== activeCallTrackedSid) {
+      activeCallTrackedSid = state.sid;
+      $activeCallStartedAt.set(Date.now());
+      if (state.kind === "muc") {
+        // The peer field on an active MUC call is the room's bare
+        // JID by construction (see `phase: "active"` definition in
+        // `./types`). Normalising again is harmless and keeps the
+        // persisted stub aligned with what `useActiveMucCall`
+        // compares against.
+        persistCallStub(normalizeMucCallRoomJid(state.peer) || state.peer);
+      }
+    }
+    return;
+  }
+  if (activeCallTrackedSid !== null) {
+    activeCallTrackedSid = null;
+    $activeCallStartedAt.set(null);
+    clearPersistedCallStub();
+  }
+});
 
 /**
  * Pure reducer over the current call state. Exposed for unit

--- a/chat/src/lib/channel-room.ts
+++ b/chat/src/lib/channel-room.ts
@@ -1,6 +1,7 @@
 import type { ChannelSummary } from "@/lib/chat-types";
 import type { WaddleSession } from "@/lib/server-auth";
 import { barePeerJid, roomBareJidFor } from "@/lib/xmpp-client";
+import { parseManagedRoomBareJid } from "@/lib/xmpp/jid";
 
 export function roomJidForChannelSummary(
   session: WaddleSession,
@@ -16,4 +17,32 @@ export function roomJidForChannelId(
 ): string {
   const channel = channels.find((c) => c.id === channelId);
   return roomJidForChannelSummary(session, channel ?? { id: channelId });
+}
+
+/**
+ * Reverse of `roomJidForChannelId`. Resolves a bare MUC room JID
+ * back to the local channel id it represents, or `null` when no
+ * known channel owns the room.
+ *
+ * Lookup order:
+ * 1. Explicit `channel.jid` match — covers federated rooms whose
+ *    JID does not follow the `{channelId}@muc.{domain}` convention.
+ * 2. `parseManagedRoomBareJid` fallback — for managed rooms minted
+ *    by this server, the localpart IS the channel id, so a
+ *    channel-list miss still resolves as long as the channel exists.
+ */
+export function channelIdForRoomJid(
+  channels: readonly Pick<ChannelSummary, "id" | "jid">[],
+  roomJid: string,
+): string | null {
+  const normalized = barePeerJid(roomJid);
+  if (!normalized) return null;
+  const byJid = channels.find(
+    (c) => c.jid !== undefined && c.jid !== null && barePeerJid(c.jid) === normalized,
+  );
+  if (byJid) return byJid.id;
+  const parsed = parseManagedRoomBareJid(normalized);
+  if (!parsed) return null;
+  const byManagedId = channels.find((c) => c.id === parsed.channelId);
+  return byManagedId ? byManagedId.id : null;
 }

--- a/chat/tests/call-active-started-at.test.ts
+++ b/chat/tests/call-active-started-at.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  $activeCallStartedAt,
+  $callState,
+} from "../src/lib/calls/call-store";
+import {
+  $persistedCallStub,
+  __resetPersistedCallStubForTests,
+} from "../src/lib/calls/call-persistence";
+import type { CallMedia, LiveKitJoin } from "../src/lib/calls/types";
+
+/**
+ * `$activeCallStartedAt` and the `$persistedCallStub` share the
+ * same module-load `$callState.listen` subscription in
+ * `call-store.ts`. Both are derived state, so exercising them
+ * together keeps the contract honest: the listener fires
+ * synchronously after `$callState.set`, and the two atoms move in
+ * lockstep with phase transitions.
+ */
+
+const ROOM = "design@muc.waddle.test";
+const audioVideo: CallMedia = { audio: true, video: true };
+const join: LiveKitJoin = {
+  url: "wss://livekit.test",
+  room: ROOM,
+  identity: "alice@waddle.test/web",
+  token: "tok",
+};
+
+function reset(): void {
+  $callState.set({ phase: "idle" });
+  __resetPersistedCallStubForTests();
+}
+
+describe("$activeCallStartedAt", () => {
+  beforeEach(reset);
+  afterEach(reset);
+
+  test("is null when idle", () => {
+    expect($activeCallStartedAt.get()).toBeNull();
+  });
+
+  test("captures Date.now() on transition into active", () => {
+    const before = Date.now();
+    $callState.set({
+      phase: "active",
+      peer: ROOM,
+      sid: "c1",
+      media: audioVideo,
+      join,
+      kind: "muc",
+    });
+    const captured = $activeCallStartedAt.get();
+    expect(captured).not.toBeNull();
+    expect(captured!).toBeGreaterThanOrEqual(before);
+    expect(captured!).toBeLessThanOrEqual(Date.now());
+  });
+
+  test("does not move on no-op updates within the same sid", () => {
+    $callState.set({
+      phase: "active",
+      peer: ROOM,
+      sid: "c1",
+      media: audioVideo,
+      join,
+      kind: "muc",
+    });
+    const first = $activeCallStartedAt.get();
+    expect(first).not.toBeNull();
+
+    $callState.set({
+      phase: "active",
+      peer: ROOM,
+      sid: "c1",
+      media: audioVideo,
+      join,
+      kind: "muc",
+      selfNick: "alice",
+    });
+    expect($activeCallStartedAt.get()).toBe(first);
+  });
+
+  test("resets on a new sid", () => {
+    $callState.set({
+      phase: "active",
+      peer: ROOM,
+      sid: "c1",
+      media: audioVideo,
+      join,
+      kind: "muc",
+    });
+    expect($activeCallStartedAt.get()).not.toBeNull();
+
+    // Drop back through idle so the listener observes the
+    // "left active" transition and clears its tracking.
+    $callState.set({ phase: "idle" });
+    expect($activeCallStartedAt.get()).toBeNull();
+
+    // New sid → the listener treats this as a fresh call and
+    // re-stamps. Two consecutive Date.now() reads can land on the
+    // same millisecond, so the contract is "non-null again",
+    // not "strictly greater than" or "different from prior".
+    $callState.set({
+      phase: "active",
+      peer: ROOM,
+      sid: "c2",
+      media: audioVideo,
+      join,
+      kind: "muc",
+    });
+    expect($activeCallStartedAt.get()).not.toBeNull();
+  });
+
+  test("clears when phase leaves active", () => {
+    $callState.set({
+      phase: "active",
+      peer: ROOM,
+      sid: "c1",
+      media: audioVideo,
+      join,
+      kind: "muc",
+    });
+    expect($activeCallStartedAt.get()).not.toBeNull();
+
+    $callState.set({ phase: "ended", sid: "c1", reason: "success" });
+    expect($activeCallStartedAt.get()).toBeNull();
+  });
+});
+
+describe("$persistedCallStub", () => {
+  beforeEach(reset);
+  afterEach(reset);
+
+  test("is null at rest", () => {
+    expect($persistedCallStub.get()).toBeNull();
+  });
+
+  test("captures the room JID on active MUC call", () => {
+    $callState.set({
+      phase: "active",
+      peer: ROOM,
+      sid: "c1",
+      media: audioVideo,
+      join,
+      kind: "muc",
+    });
+    const stub = $persistedCallStub.get();
+    expect(stub).not.toBeNull();
+    expect(stub!.roomJid).toBe(ROOM);
+    expect(stub!.joinedAt).toBeGreaterThan(0);
+  });
+
+  test("does NOT persist for active DM calls (rejoin shape differs)", () => {
+    $callState.set({
+      phase: "active",
+      peer: "carol@waddle.test/desktop",
+      sid: "c1",
+      media: audioVideo,
+      join,
+      kind: "dm",
+    });
+    expect($persistedCallStub.get()).toBeNull();
+  });
+
+  test("clears when the call ends", () => {
+    $callState.set({
+      phase: "active",
+      peer: ROOM,
+      sid: "c1",
+      media: audioVideo,
+      join,
+      kind: "muc",
+    });
+    expect($persistedCallStub.get()).not.toBeNull();
+
+    $callState.set({ phase: "ended", sid: "c1", reason: "success" });
+    expect($persistedCallStub.get()).toBeNull();
+  });
+});

--- a/chat/tests/channel-room.test.ts
+++ b/chat/tests/channel-room.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { roomJidForChannelId, roomJidForChannelSummary } from "../src/lib/channel-room";
+import {
+  channelIdForRoomJid,
+  roomJidForChannelId,
+  roomJidForChannelSummary,
+} from "../src/lib/channel-room";
 import type { WaddleSession } from "../src/lib/server-auth";
 
 const session = {
@@ -34,4 +38,47 @@ describe("roomJidForChannelSummary", () => {
     ], "random")).toBe("random@conference.example.net");
   });
 
+});
+
+describe("channelIdForRoomJid", () => {
+  test("resolves a managed-room JID via the local-part convention", () => {
+    expect(channelIdForRoomJid([{ id: "general" }], "general@muc.example.com")).toBe(
+      "general",
+    );
+  });
+
+  test("returns null when no matching channel exists", () => {
+    expect(channelIdForRoomJid([{ id: "general" }], "design@muc.example.com")).toBeNull();
+  });
+
+  test("prefers an explicit channel.jid match over the local-part fallback", () => {
+    // A federated channel's MUC localpart can collide with a
+    // managed-room id elsewhere — the explicit JID match wins so
+    // the federated channel id flows through cleanly instead of
+    // falling back to the managed-room parse.
+    const channels = [
+      { id: "general", jid: "general@muc.example.com" },
+      { id: "external", jid: "general@chat.federated.test" },
+    ];
+    expect(channelIdForRoomJid(channels, "general@chat.federated.test")).toBe(
+      "external",
+    );
+    expect(channelIdForRoomJid(channels, "general@muc.example.com")).toBe("general");
+  });
+
+  test("strips a leaked resource before lookup", () => {
+    expect(
+      channelIdForRoomJid([{ id: "general" }], "general@muc.example.com/alice"),
+    ).toBe("general");
+  });
+
+  test("returns null for an empty input", () => {
+    expect(channelIdForRoomJid([], "")).toBeNull();
+  });
+
+  test("is the inverse of roomJidForChannelId for managed rooms", () => {
+    const channels = [{ id: "design" }, { id: "general" }];
+    const roomJid = roomJidForChannelId(session, channels, "design");
+    expect(channelIdForRoomJid(channels, roomJid)).toBe("design");
+  });
 });


### PR DESCRIPTION
## Summary

After #743 collapsed call UI to per-room `split` + `expanded` surfaces, the user loses every visual cue that they are in a call as soon as they navigate to another room — or after a hard refresh. The channel-list sidebar badge (`callParticipantCountForChannel` in `TopicsPanel`) only signals "a call is ongoing here" generically; it does not say "you're in this one".

This PR adds a fixed-position pill in the app shell with two modes:

| Mode | Trigger | Copy | Click |
|------|---------|------|-------|
| **live** | `selfInCall && viewedRoomJid !== activeRoomJid` | `Return to #room · MM:SS` | Navigate via `selectChannel` |
| **rejoin** | In-memory state gone (refresh) **and** sessionStorage stub points at a room whose Muji participant list still has ≥1 active nick | `Rejoin #room` (no duration — the previous one is meaningless) | Navigate; user manually re-enters via the room's `MucCallButton` / `CallActivePill` |

Hidden when the user is already viewing the call's room — the per-channel `CallSplitContainer` / `CallActivePill` own that surface.

## Why a sessionStorage stub for refresh-resume

A hard refresh tears down:
- The WebSocket and the WASM client → `$callState`, `$activeCallStartedAt`, `$mucCallParticipants` all wiped.
- The server's `cleanup_muc_presence` clears the user's XEP-0272 Muji `active` presence per XEP-0272 §Leaving.
- The LiveKit token was bound to the old WS — unusable.

So after refresh the user is XMPP-wise no longer in the call. The pill is the only UX cue that something is recoverable; the rejoin itself goes through the existing `startMucCallAction` path (fresh `<muji/>` presence + fresh Jingle session-initiate — there is no Jingle "resume" wire shape).

Stub:
- `sessionStorage` (tab-scoped, dies on tab close — matches "active call session" intent).
- Persisted only for `kind: "muc"` active calls (DM rejoin shape differs and isn't covered here).
- Aged out after 12h on read, cleared on call end / hangup.
- Pill visibility additionally requires the room's Muji participant list to be non-empty, so if the call ended while the tab was gone, the pill never appears (no auto-cleanup of the stub needed — it expires naturally).

## What changed

### New
- `src/lib/calls/call-persistence.ts` — sessionStorage-backed `$persistedCallStub` atom with read/write helpers and a test-reset hook.
- `src/components/calls/CallReturnPill.vue` — the pill itself.
- `tests/call-active-started-at.test.ts` — covers `$activeCallStartedAt` transitions and `$persistedCallStub` MUC-only persistence.

### Modified
- `src/lib/calls/call-store.ts` — new `$activeCallStartedAt` atom + single `$callState.listen` subscription that drives both atoms (start-stamp on entry into `phase: "active"` for a fresh `sid`, stub written for MUC kinds, both cleared on exit).
- `src/lib/channel-room.ts` — new `channelIdForRoomJid(channels, roomJid)`, the reverse of `roomJidForChannelId`. Prefers explicit `channel.jid` match, falls back to managed-room local-part convention.
- `src/components/chat/ChatReadyShell.vue` — mounts `CallReturnPill` as a sibling of the admin / chat branches so it floats above every surface. Computes `currentlyViewedRoomJid` (null for non-channel surfaces: dashboard, settings, threads, DMs, community feeds, admin).
- `tests/channel-room.test.ts` — extends with `channelIdForRoomJid` cases (managed-room, explicit JID precedence, resource-stripping, round-trip with `roomJidForChannelId`).

## Conformance

- XEP-0272 Muji: existing presence-broadcast plumbing populates `$mucCallParticipants`; the rejoin path reuses `startMucCallAction` which sends a conformant `<muji/>` preparing → active sequence. No new wire shapes.
- XEP-0166 Jingle: rejoin is a fresh session-initiate, not a resume. Matches the existing `MucCallButton` join path.
- The sessionStorage stub is a client-only UX hint; no server contract is implied or required.

## Test plan

- [x] `cd chat && bun run lint` — knip clean.
- [x] `cd chat && bunx astro check` — 0 errors / 0 warnings / 0 hints.
- [x] `cd chat && timeout 60 bun test` — 1125 pass / 0 fail.
- [ ] Manual: start a MUC call in #A → pill hidden (viewing #A).
- [ ] Manual: navigate to #B → pill "Return to #A · 0:0X" with ticking duration.
- [ ] Manual: navigate to dashboard / settings / threads / DMs → pill still visible.
- [ ] Manual: click pill → lands back on #A, pill hides.
- [ ] Manual: hang up → pill clears.
- [ ] Manual: not in a call → pill never shows.
- [ ] Manual: refresh during active MUC call → on reconnect, pill shows "Rejoin #A" (warmer accent, no duration). Click → land on #A → join via in-room CallActivePill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)