### PR TITLE
fix(chat): restore call indicator across refresh via eager MUC auto-join

### DIFF
--- a/chat/src/components/calls/CallActivePill.vue
+++ b/chat/src/components/calls/CallActivePill.vue
@@ -1,13 +1,7 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref } from "vue";
-import { useStore } from "@nanostores/vue";
 import { Phone } from "lucide-vue-next";
-import { $callState } from "@/lib/calls/call-store";
-import {
-  $mucCallParticipants,
-  normalizeMucCallRoomJid,
-} from "@/lib/calls/muc-call-presence";
-import { useActiveMucCall } from "@/lib/calls/use-active-muc-call";
+import { useRoomHasActiveCall } from "@/lib/calls/use-active-muc-call";
 
 /**
  * Live-call indicator shown in the channel header when the room owns
@@ -34,31 +28,26 @@ const props = defineProps<{
   disabled?: boolean;
 }>();
 
-const state = useStore($callState);
-const participants = useStore($mucCallParticipants);
-const { selfInCall, activeRoomJid } = useActiveMucCall();
+// Detection is keyed to the **room's** Muji participants store
+// (XEP-0272 §Joining / §Leaving), NOT the local user's `$callState`.
+// The local call phase is only set when this client is actively in a
+// call; relying on it left the pill dark after every page refresh
+// because the rejoined client's `$callState` starts at `idle` even
+// while every other occupant still advertises Muji presence in the
+// room. `useRoomHasActiveCall` reads `$mucCallParticipants[roomJid]`
+// directly, which is populated by the auto-joined MUC's roster
+// replay within ~200 ms of session ready.
+const { hasActiveCall, selfInCall, participantCount } = useRoomHasActiveCall(() => props.roomJid);
 
-const normalizedRoomJid = computed(() => normalizeMucCallRoomJid(props.roomJid));
-
-const callInThisRoom = computed(() => {
-  return (
-    activeRoomJid.value !== null &&
-    activeRoomJid.value === normalizedRoomJid.value
-  );
-});
+const callInThisRoom = hasActiveCall;
 
 /**
  * The pill is visible only when:
- *   - There is an active MUC call in THIS room.
+ *   - There is an active MUC call in THIS room (per Muji presence).
  *   - The local user is not currently joined to it (otherwise the
  *     split surface is already painting the state for them).
  */
 const isVisible = computed(() => callInThisRoom.value && !selfInCall.value);
-
-const participantCount = computed<number>(() => {
-  if (!callInThisRoom.value) return 0;
-  return (participants.value[normalizedRoomJid.value] ?? []).length;
-});
 
 /**
  * Running call duration. Pegged to a single shared 1Hz tick so we

--- a/chat/src/lib/calls/use-active-muc-call.ts
+++ b/chat/src/lib/calls/use-active-muc-call.ts
@@ -62,6 +62,77 @@ export function useActiveMucCall(): {
 }
 
 /**
+ * Per-room view of "is there an XEP-0272 Muji call happening in this
+ * specific room, regardless of whether the local user is in it?"
+ *
+ * Sourced **directly** from `$mucCallParticipants[roomJid]` so the
+ * answer survives a page refresh: as long as we have joined the MUC
+ * (which happens eagerly on session ready — see `fanOutAutoJoin`),
+ * the server's roster-replay populates the store with every existing
+ * occupant's Muji extension and this selector lights up within ~200 ms
+ * of reconnect.
+ *
+ * `useActiveMucCall()` is a different question — "which room am *I*
+ * currently calling in?" — and stays anchored to `$callState`. The
+ * `CallActivePill` previously read from there and inherited its
+ * local-call-phase keyed semantics by accident, leaving the "click to
+ * join an ongoing call" pill dark after every refresh.
+ */
+export function useRoomHasActiveCall(
+  roomJid: () => string,
+): {
+  hasActiveCall: ComputedRef<boolean>;
+  selfInCall: ComputedRef<boolean>;
+  participantCount: ComputedRef<number>;
+} {
+  const participants = useStore($mucCallParticipants);
+
+  const normalized = computed<string | null>(() => {
+    const value = normalizeMucCallRoomJid(roomJid());
+    return value || null;
+  });
+
+  const participantList = computed<ReadonlyArray<string>>(() => {
+    const key = normalized.value;
+    if (!key) return [];
+    return participants.value[key] ?? [];
+  });
+
+  const hasActiveCall = computed<boolean>(() => participantList.value.length > 0);
+
+  const selfInCall = computed<boolean>(() => {
+    const nick = connectionStore.session?.username;
+    if (!nick) return false;
+    return participantList.value.includes(nick);
+  });
+
+  const participantCount = computed<number>(() => participantList.value.length);
+
+  return { hasActiveCall, selfInCall, participantCount };
+}
+
+/**
+ * Imperative twin of `useRoomHasActiveCall` for non-component code
+ * paths. The composable wraps these reads with Vue refs; this form
+ * is what tests exercise.
+ */
+export function readRoomHasActiveCall(roomJid: string): {
+  hasActiveCall: boolean;
+  selfInCall: boolean;
+  participantCount: number;
+} {
+  const normalized = normalizeMucCallRoomJid(roomJid);
+  if (!normalized) return { hasActiveCall: false, selfInCall: false, participantCount: 0 };
+  const list = $mucCallParticipants.get()[normalized] ?? [];
+  const nick = connectionStore.session?.username ?? null;
+  return {
+    hasActiveCall: list.length > 0,
+    selfInCall: nick !== null && list.includes(nick),
+    participantCount: list.length,
+  };
+}
+
+/**
  * Imperative variant for non-component code paths (e.g. unit tests or
  * effect runners that don't have a Vue setup context). Reads the
  * underlying stores once; callers needing reactivity should use the

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -390,6 +390,17 @@ export class BrowserXmppClient {
    * retries from scratch.
    */
   private readonly joinedMucs = new Map<string, Promise<void>>();
+  /**
+   * Snapshot of the room JIDs we want auto-joined on every session
+   * start. Populated from the topology by `discoverTopology` and
+   * replayed by `handleSessionReady` after a fresh reconnect — without
+   * the replay, only the focused channel comes back joined and the
+   * sibling-channel call indicators stay dark after every drop.
+   * SM resumes don't need this (the server-side MUC occupancy is
+   * preserved across the resume window), but the same idempotent
+   * `ensureJoined` makes the extra fan-out cheap.
+   */
+  private autoJoinRoomJids: ReadonlyArray<string> = [];
   private uploadServiceJid: string | null = null;
   private discoveredRoomJids = new Map<string, string>();
   private reconnectStartedAt: number | null = null;
@@ -678,7 +689,7 @@ export class BrowserXmppClient {
     this.clearReconnectTimer();
     this.clearResumeState();
     const xmpp = this.xmpp;
-    const roomBefore = this.currentRoom;
+    const previouslyJoinedRooms = [...this.joinedMucs.keys()];
     this.stopSelfPing();
     this.connected = false;
     this.connectPromise = null;
@@ -699,12 +710,18 @@ export class BrowserXmppClient {
     // `$callState`.
     await tearDownActiveCall(xmpp as unknown as CallWireSender | null, "success");
     this.xmpp = null;
-    // The auto-join model keeps the user joined to every channel in
-    // their spaces, so emitting unavailable for any single room here
-    // would be misleading. Rely on the server's WebSocket-close
-    // cleanup (cleanup_muc_presence) to broadcast unavailable for
-    // every joined MUC — authoritative for the multi-room case.
-    void roomBefore;
+    // Polite logout per XEP-0045 §7.14: emit unavailable for every
+    // joined MUC so peers see "alice signed out" via the explicit
+    // presence rather than "alice's session dropped" via the
+    // server's WebSocket-close cleanup (which the server stamps with
+    // XEP-0045 §17.3 status code 333 — technical disconnect).
+    // Best-effort and serial: a stuck leave on one room must not
+    // strand the others.
+    if (xmpp?.leave_room) {
+      for (const roomJid of previouslyJoinedRooms) {
+        try { await xmpp.leave_room(roomJid, this.session.username); } catch {}
+      }
+    }
     await xmpp?.disconnect?.();
     this.emitStatus({ state: "offline", detail: "Disconnected" });
   }
@@ -1591,6 +1608,11 @@ export class BrowserXmppClient {
     const autoJoinRoomJids: string[] = topology.rooms
       .filter((room) => room.autojoin !== false && !!room.jid)
       .map((room) => room.jid!);
+    // Cache for the post-reconnect replay path — `handleSessionReady`
+    // calls `fanOutAutoJoin(this.autoJoinRoomJids)` whenever a fresh
+    // session is established so the user doesn't have to refresh to
+    // see call indicators for sibling channels after a reconnect.
+    this.autoJoinRoomJids = autoJoinRoomJids;
     if (autoJoinRoomJids.length > 0) void this.fanOutAutoJoin(autoJoinRoomJids);
     return topology;
   }
@@ -1816,6 +1838,16 @@ export class BrowserXmppClient {
       // xmpp reference so the bootstrap aborts cleanly if the client
       // disconnects before the catch-up IQ resolves.
       void this.bootstrapMdsDisplayed(xmpp);
+      // Re-fan-out the auto-join list cached by the last successful
+      // `discoverTopology()`. `handleDisconnected` cleared `joinedMucs`
+      // and every per-room cache, so a fresh reconnect lands with the
+      // user joined only to the focused channel; the rest of the
+      // sidebar's call indicators would stay dark without this. The
+      // controller will also call `discoverTopology` on its own
+      // bootstrap path, which would refresh the cache, but that path
+      // is one-shot for the lifetime of the controller — we cannot
+      // rely on it for the Nth reconnect.
+      if (this.autoJoinRoomJids.length > 0) void this.fanOutAutoJoin(this.autoJoinRoomJids);
     }
     this.emitSessionLifecycle(lifecycle);
     const catchupEntries = this.catchup.onSessionStarted();
@@ -1975,7 +2007,12 @@ export class BrowserXmppClient {
   /** Push every focused-room handler with a fresh snapshot. Called on
    *  channel switch (where the focused room changes, so the active view
    *  must update from cache) and on full disconnect (where caches are
-   *  cleared to empty). */
+   *  cleared to empty). `memberJidHandler` is replayed nick-by-nick
+   *  from the per-room cache so the consumer's `memberJidByNick` map
+   *  (cleared on every `selectChannel` per chat-app-controller.ts)
+   *  refills without having to wait for fresh presence — auto-join
+   *  drains the roster once and subsequent focus switches must
+   *  reconstruct from cache. */
   private dispatchFocusedRoomHandlers(): void {
     const room = this.currentRoom;
     if (!room) {
@@ -1987,6 +2024,14 @@ export class BrowserXmppClient {
     this.hatsHandler?.({ ...this.hatsFor(room) });
     this.authorityHandler?.({ ...this.authorityFor(room) });
     this.presenceHandler?.({ ...this.presenceFor(room) });
+    const memberJids = this.memberJidsFor(room);
+    const handler = this.memberJidHandler;
+    if (handler) {
+      for (const nick of Object.keys(memberJids)) {
+        const bare = memberJids[nick];
+        if (bare) handler(nick, bare);
+      }
+    }
   }
   private handlePresence(presence: WasmPresence) {
     const from = presence.from ?? "";

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -349,7 +349,14 @@ export class BrowserXmppClient {
   private dmReactionHandler: ((event: DmReactionEvent) => void) | null = null;
   private dmDisplayedHandler: ((event: DmDisplayedEvent) => void) | null = null;
   private presenceUpdateHandler: ((event: PresenceUpdateEvent) => void) | null = null;
-  private roomMemberJids: Record<string, string> = {};
+  /**
+   * Per-room caches. Populated by the presence handler for **every**
+   * joined MUC, not just the focused one — switching channels no longer
+   * leaves the previous room, so the data must accumulate across all
+   * joined rooms. Handlers fire only for the focused room's slice
+   * (see `dispatchFocusedRoomHandlers`). Keyed by bare MUC JID.
+   */
+  private roomMemberJidsByRoom: Map<string, Record<string, string>> = new Map();
   private memberJidHandler: ((nick: string, bareJid: string) => void) | null = null;
   private hatsHandler: ((hats: RoomHats) => void) | null = null;
   private authorityHandler: ((authority: RoomAuthority) => void) | null = null;
@@ -371,9 +378,18 @@ export class BrowserXmppClient {
   private roomSwitchPromise: Promise<void> | null = null;
   private roomSwitchTarget: string | null = null;
   private selfPingTimer: ReturnType<typeof setInterval> | null = null;
-  private roomHats: RoomHats = {};
-  private roomAuthority: RoomAuthority = {};
-  private roomPresence: RoomPresence = {};
+  private roomHatsByRoom: Map<string, RoomHats> = new Map();
+  private roomAuthorityByRoom: Map<string, RoomAuthority> = new Map();
+  private roomPresenceByRoom: Map<string, RoomPresence> = new Map();
+  /**
+   * Idempotent join tracker. Key = bare MUC JID, value = the in-flight
+   * (or resolved) Promise for that room's `<presence/>` join. A second
+   * `ensureJoined` call for the same room awaits the same Promise, so
+   * concurrent UI navigation and the auto-join fan-out don't both fire
+   * a join stanza. Failed joins drop their entry so the next call
+   * retries from scratch.
+   */
+  private readonly joinedMucs = new Map<string, Promise<void>>();
   private uploadServiceJid: string | null = null;
   private discoveredRoomJids = new Map<string, string>();
   private reconnectStartedAt: number | null = null;
@@ -671,10 +687,11 @@ export class BrowserXmppClient {
     this.roomSwitchTarget = null;
     this.rejectRoomJoinWaiters(new Error("XMPP disconnected while joining a room"));
     this.uploadServiceJid = null;
-    this.roomHats = {};
-    this.roomAuthority = {};
-    this.roomPresence = {};
-    this.roomMemberJids = {};
+    this.roomHatsByRoom.clear();
+    this.roomAuthorityByRoom.clear();
+    this.roomPresenceByRoom.clear();
+    this.roomMemberJidsByRoom.clear();
+    this.joinedMucs.clear();
     clearMucCallParticipants();
     // Best-effort hangup: if we're in a call when the user logs out
     // we want the peer to see session-terminate before the stream
@@ -682,11 +699,12 @@ export class BrowserXmppClient {
     // `$callState`.
     await tearDownActiveCall(xmpp as unknown as CallWireSender | null, "success");
     this.xmpp = null;
-    try {
-      if (xmpp && roomBefore && xmpp.leave_room) {
-        await xmpp.leave_room(roomBefore, this.session.username);
-      }
-    } catch {}
+    // The auto-join model keeps the user joined to every channel in
+    // their spaces, so emitting unavailable for any single room here
+    // would be misleading. Rely on the server's WebSocket-close
+    // cleanup (cleanup_muc_presence) to broadcast unavailable for
+    // every joined MUC — authoritative for the multi-room case.
+    void roomBefore;
     await xmpp?.disconnect?.();
     this.emitStatus({ state: "offline", detail: "Disconnected" });
   }
@@ -751,43 +769,106 @@ export class BrowserXmppClient {
     }
   }
 
+  /**
+   * Send a MUC `<presence/>` join for `roomJid` once. Subsequent calls
+   * for the same room return the in-flight (or resolved) Promise so
+   * the auto-join fan-out and ad-hoc `switchRoom` clicks don't double-
+   * join. A failed join clears its entry so the next call retries.
+   *
+   * The room is kept joined for the lifetime of the XMPP session —
+   * channel switches change focus only, not MUC membership. This is
+   * what makes XEP-0272 Muji presence (and the call indicator) visible
+   * across the whole sidebar, not just the focused channel.
+   */
+  async ensureJoined(roomJid: string): Promise<void> {
+    const existing = this.joinedMucs.get(roomJid);
+    if (existing) return existing;
+    const promise = this.performMucJoin(roomJid);
+    this.joinedMucs.set(roomJid, promise);
+    try {
+      await promise;
+    } catch (err) {
+      if (this.joinedMucs.get(roomJid) === promise) {
+        this.joinedMucs.delete(roomJid);
+      }
+      throw err;
+    }
+  }
+
+  private async performMucJoin(roomJid: string): Promise<void> {
+    const xmpp = this.xmpp;
+    if (!xmpp) throw new Error("XMPP session is not ready");
+    const nick = this.session.username;
+    const ready = this.waitForRoomSelfPresence(roomJid, nick);
+    if (xmpp.join_room) {
+      await Promise.allSettled([xmpp.join_room(roomJid, nick)]);
+    } else if (xmpp.joinRoom) {
+      await xmpp.joinRoom(roomJid, nick);
+    } else {
+      throw new Error("XMPP client missing join_room binding");
+    }
+    if (!this.isCurrentXmpp(xmpp)) {
+      await ready.catch(() => undefined);
+      return;
+    }
+    await ready;
+  }
+
+  /**
+   * Eagerly join every channel the user is a member of so their XEP-
+   * 0272 Muji presences populate `$mucCallParticipants` and the call
+   * indicator can fire for any sidebar channel — including after a
+   * full page refresh. Bounded concurrency keeps the initial stanza
+   * burst manageable on large topologies.
+   */
+  async fanOutAutoJoin(roomJids: ReadonlyArray<string>, concurrency = 6): Promise<void> {
+    await this.connect();
+    if (!this.xmpp) return;
+    const queue = [...roomJids];
+    const seen = new Set<string>();
+    const workers: Promise<void>[] = [];
+    const worker = async (): Promise<void> => {
+      while (queue.length > 0) {
+        const next = queue.shift();
+        if (!next || seen.has(next)) continue;
+        seen.add(next);
+        try { await this.ensureJoined(next); } catch { /* failed joins drop their entry; retried on next pass */ }
+      }
+    };
+    for (let i = 0; i < Math.max(1, concurrency); i++) workers.push(worker());
+    await Promise.allSettled(workers);
+  }
+
   private async performRoomSwitch(nextRoom: string) {
     const xmpp = this.xmpp;
     if (!xmpp) return;
     if (this.currentRoom) {
+      // Channel switch ends any active call in the room being left
+      // behind: there is no in-app surface to keep showing the local
+      // call from the new channel today, so preserving session-
+      // terminate / SFU disconnect ordering is more important than
+      // leaving an orphan media session running.
       await this.tearDownMucCallForRoom(this.currentRoom, xmpp);
       if (!this.isCurrentXmpp(xmpp)) return;
     }
-    if (this.currentRoom && xmpp.leave_room) {
-      try { await xmpp.leave_room(this.currentRoom, this.session.username); } catch {}
-      if (!this.isCurrentXmpp(xmpp)) return;
-    }
+    // No `leave_room` — auto-join keeps the user joined to every
+    // channel in their spaces so Muji presence flows for the whole
+    // sidebar. Per-room state caches accumulate across rooms, so the
+    // focused-room handler snapshot is reconstructed from cache below.
     this.currentRoom = nextRoom;
-    this.roomHats = {};
-    this.roomAuthority = {};
-    this.roomPresence = {};
-    this.roomMemberJids = {};
-    this.hatsHandler?.({});
-    this.authorityHandler?.({});
-    this.presenceHandler?.({});
-    if (xmpp.join_room) {
-      const ready = this.waitForRoomSelfPresence(nextRoom, this.session.username);
-      await Promise.allSettled([xmpp.join_room(nextRoom, this.session.username)]);
-      if (!this.isCurrentXmpp(xmpp)) {
-        await ready.catch(() => undefined);
-        return;
-      }
-      try {
-        await ready;
-      } catch (err) {
-        if (!this.isCurrentXmpp(xmpp)) return;
-        throw err;
-      }
+    this.dispatchFocusedRoomHandlers();
+    try {
+      await this.ensureJoined(nextRoom);
+    } catch (err) {
       if (!this.isCurrentXmpp(xmpp)) return;
-    } else if (xmpp.joinRoom) {
-      await xmpp.joinRoom(nextRoom, this.session.username);
-      if (!this.isCurrentXmpp(xmpp)) return;
+      throw err;
     }
+    if (!this.isCurrentXmpp(xmpp)) return;
+    // Replay the focused-room snapshot now that the initial roster has
+    // landed in the per-room cache. The first dispatch above only had
+    // whatever was already cached (empty on cold focus); this second
+    // dispatch ships the freshly-arrived presence to the UI.
+    this.dispatchFocusedRoomHandlers();
     this.startSelfPing();
     await this.flushQueuedRoomMessages(nextRoom);
   }
@@ -957,7 +1038,7 @@ export class BrowserXmppClient {
         if (!this.roomIsReady(roomJid) || !this.xmpp) break;
         if (this.inflightQueuedIds.has(entry.id)) continue;
         this.queuedMessageStatusHandler?.(entry.id, "sending");
-        const messageId = await this.compatSendGroupMessage(this.xmpp, roomJid, entry.body, { ...(entry.markup?.length ? { markup: entry.markup } : {}), ...(entry.references?.length ? { references: entry.references } : {}), mentionJidsByNick: { ...(entry.mentionJidsByNick ?? {}), ...this.roomMemberJids }, ...(entry.files?.length ? { files: entry.files } : {}), ...(entry.replyTo ? { replyTo: entry.replyTo } : {}), ...(entry.threadId ? { threadId: entry.threadId } : {}), ...(entry.parentThreadId ? { parentThreadId: entry.parentThreadId } : {}), ...(entry.threadCreate ? { threadCreate: entry.threadCreate } : {}), ...(entry.threadReply ? { threadReply: entry.threadReply } : {}), id: entry.id });
+        const messageId = await this.compatSendGroupMessage(this.xmpp, roomJid, entry.body, { ...(entry.markup?.length ? { markup: entry.markup } : {}), ...(entry.references?.length ? { references: entry.references } : {}), mentionJidsByNick: { ...(entry.mentionJidsByNick ?? {}), ...this.memberJidsFor(roomJid) }, ...(entry.files?.length ? { files: entry.files } : {}), ...(entry.replyTo ? { replyTo: entry.replyTo } : {}), ...(entry.threadId ? { threadId: entry.threadId } : {}), ...(entry.parentThreadId ? { parentThreadId: entry.parentThreadId } : {}), ...(entry.threadCreate ? { threadCreate: entry.threadCreate } : {}), ...(entry.threadReply ? { threadReply: entry.threadReply } : {}), id: entry.id });
         if (messageId) { this.inflightQueuedIds.add(entry.id); this.recordPendingSend(entry.id, "room"); }
       }
     })();
@@ -972,7 +1053,7 @@ export class BrowserXmppClient {
     if (!body.trim() && !hasFiles && !hasThreadMetadata && !hasForumMetadata) return null;
     const roomJid = this.roomJidForChannel(channelId);
     if (this.roomIsReady(roomJid) && this.xmpp) {
-      const id = await this.compatSendGroupMessage(this.xmpp, roomJid, body, { ...opts, mentionJidsByNick: { ...(opts.mentionJidsByNick ?? {}), ...this.roomMemberJids } });
+      const id = await this.compatSendGroupMessage(this.xmpp, roomJid, body, { ...opts, mentionJidsByNick: { ...(opts.mentionJidsByNick ?? {}), ...this.memberJidsFor(roomJid) } });
       this.recordPendingSend(id, "room");
       return { id, state: "sending" };
     }
@@ -1496,7 +1577,23 @@ export class BrowserXmppClient {
   async listRosterContacts(): Promise<RosterContact[]> { const xmpp = await this.requireConnectedXmpp(); const roster = await xmpp.list_roster_contacts?.() as WasmRosterContact[]; return (roster ?? []).map((item) => { const jid = barePeerJid(item.jid); return { jid, name: item.name, username: item.name?.trim() || jid.split("@")[0] || jid, subscription: (item.subscription ?? "none") as RosterContact["subscription"], groups: item.groups ?? [] }; }); }
   async getServerVersion(): Promise<WasmServerVersion | null> { const xmpp = await this.requireConnectedXmpp(); return await xmpp.get_server_version?.() as WasmServerVersion | null; }
   async discoverSpaceChannels(): Promise<any[]> { const xmpp = await this.requireConnectedXmpp(); return discoverChannels(xmpp as WasmClient, this.session.jid); }
-  async discoverTopology(): Promise<DiscoveredTopology> { const xmpp = await this.requireConnectedXmpp(); const topology = await discoverTopology(xmpp as WasmClient, this.session.jid); this.discoveredRoomJids = new Map(topology.rooms.flatMap((room) => room.jid ? [[room.id, room.jid] as const] : [])); return topology; }
+  async discoverTopology(): Promise<DiscoveredTopology> {
+    const xmpp = await this.requireConnectedXmpp();
+    const topology = await discoverTopology(xmpp as WasmClient, this.session.jid);
+    this.discoveredRoomJids = new Map(topology.rooms.flatMap((room) => room.jid ? [[room.id, room.jid] as const] : []));
+    // XEP-0402 / XEP-0045 auto-join: fan out MUC presence for every
+    // channel the user is a member of so the per-room call indicator
+    // (XEP-0272 Muji presence) fires across the entire sidebar — not
+    // just the focused channel. Fire-and-forget so topology discovery
+    // does not block on N parallel MUC roster replays; ensureJoined
+    // is idempotent so the focused-channel `switchRoom` later joins
+    // through the same Promise.
+    const autoJoinRoomJids: string[] = topology.rooms
+      .filter((room) => room.autojoin !== false && !!room.jid)
+      .map((room) => room.jid!);
+    if (autoJoinRoomJids.length > 0) void this.fanOutAutoJoin(autoJoinRoomJids);
+    return topology;
+  }
   async listRoomMembers(channelId: string, options?: ListRoomMembersOptions): Promise<MemberSummary[]> {
     const xmpp = await this.requireConnectedXmpp(); const roomJid = options?.roomJid ?? this.roomJidForChannel(channelId);
     const listMembers = xmpp.list_room_members
@@ -1832,6 +1929,16 @@ export class BrowserXmppClient {
     clearCallState();
     clearMucCallParticipants();
     void useCallEngine().engine.disconnect();
+    // The transport went down — every join in-flight is dead and the
+    // server's `cleanup_muc_presence` will broadcast unavailable for
+    // each room. Clear the tracker so the post-reconnect auto-join
+    // fan-out re-issues every join (each call is idempotent once the
+    // new session is up).
+    this.joinedMucs.clear();
+    this.roomHatsByRoom.clear();
+    this.roomAuthorityByRoom.clear();
+    this.roomPresenceByRoom.clear();
+    this.roomMemberJidsByRoom.clear();
     if (this.destroying) { this.clearResumeState(); this.emitStatus({ state: "offline", detail: error?.message ?? "Disconnected" }); return; }
     this.setResumeStateHandle(xmpp.get_resume_state_handle?.() ?? null);
     this.resumeState = xmpp.get_resume_state?.() ?? null;
@@ -1845,19 +1952,67 @@ export class BrowserXmppClient {
     if (this.onceConnectFailed) { const fail = this.onceConnectFailed; this.onceConnected = null; this.onceConnectFailed = null; fail(error ?? new Error("XMPP connection failed")); }
     this.scheduleReconnect();
   }
+  private hatsFor(room: string): RoomHats {
+    let cached = this.roomHatsByRoom.get(room);
+    if (!cached) { cached = {}; this.roomHatsByRoom.set(room, cached); }
+    return cached;
+  }
+  private authorityFor(room: string): RoomAuthority {
+    let cached = this.roomAuthorityByRoom.get(room);
+    if (!cached) { cached = {}; this.roomAuthorityByRoom.set(room, cached); }
+    return cached;
+  }
+  private presenceFor(room: string): RoomPresence {
+    let cached = this.roomPresenceByRoom.get(room);
+    if (!cached) { cached = {}; this.roomPresenceByRoom.set(room, cached); }
+    return cached;
+  }
+  private memberJidsFor(room: string): Record<string, string> {
+    let cached = this.roomMemberJidsByRoom.get(room);
+    if (!cached) { cached = {}; this.roomMemberJidsByRoom.set(room, cached); }
+    return cached;
+  }
+  /** Push every focused-room handler with a fresh snapshot. Called on
+   *  channel switch (where the focused room changes, so the active view
+   *  must update from cache) and on full disconnect (where caches are
+   *  cleared to empty). */
+  private dispatchFocusedRoomHandlers(): void {
+    const room = this.currentRoom;
+    if (!room) {
+      this.hatsHandler?.({});
+      this.authorityHandler?.({});
+      this.presenceHandler?.({});
+      return;
+    }
+    this.hatsHandler?.({ ...this.hatsFor(room) });
+    this.authorityHandler?.({ ...this.authorityFor(room) });
+    this.presenceHandler?.({ ...this.presenceFor(room) });
+  }
   private handlePresence(presence: WasmPresence) {
     const from = presence.from ?? "";
     if ((presence as any).muc_jid !== undefined) {
-      const [room, nick = ""] = from.split("/"); const waiter = this.roomJoinWaiters.get(from); if (waiter && (presence as any).muc_jid) waiter.resolve(); if (!room) return; if (!nick && presence.vcard_avatar) this.roomAvatarHandler?.(room, presence.vcard_avatar); if (room !== this.currentRoom || !nick) return;
+      const [room, nick = ""] = from.split("/");
+      const waiter = this.roomJoinWaiters.get(from);
+      if (waiter && (presence as any).muc_jid) waiter.resolve();
+      if (!room) return;
+      if (!nick && presence.vcard_avatar) this.roomAvatarHandler?.(room, presence.vcard_avatar);
+      // Filter dropped after the auto-join refactor: presence from any
+      // joined MUC (not just the focused one) must update its per-room
+      // cache so the focused-room handler can replay correct state on
+      // channel switch. Handlers themselves only fire for the focused
+      // room — the focused-room snapshot is reconstructed below.
+      if (!nick) return;
       if (presence.presence_type === "unavailable") {
-        delete this.roomHats[nick];
-        this.hatsHandler?.({ ...this.roomHats });
-        delete this.roomAuthority[nick];
-        this.authorityHandler?.({ ...this.roomAuthority });
-        this.roomPresence[nick] = "offline";
-        this.presenceHandler?.({ ...this.roomPresence });
-        delete this.roomMemberJids[nick];
-        this.lastSeenHandler?.(nick, Date.now());
+        delete this.hatsFor(room)[nick];
+        delete this.authorityFor(room)[nick];
+        this.presenceFor(room)[nick] = "offline";
+        delete this.memberJidsFor(room)[nick];
+        if (room === this.currentRoom) {
+          this.hatsHandler?.({ ...this.hatsFor(room) });
+          this.authorityHandler?.({ ...this.authorityFor(room) });
+          this.presenceHandler?.({ ...this.presenceFor(room) });
+          this.lastSeenHandler?.(nick, Date.now());
+        }
         return;
       }
       // XEP-0317 hats are server-emitted descriptive metadata only.
@@ -1865,22 +2020,25 @@ export class BrowserXmppClient {
       // those flow as `roomAuthority` and drive authority chips
       // independently (see `parseMucAffiliation` / `parseMucRole`
       // below).
-      this.roomHats[nick] = ((presence as any).hats ?? []).map((hat: any) => ({
+      this.hatsFor(room)[nick] = ((presence as any).hats ?? []).map((hat: any) => ({
         uri: hat.uri,
         title: hat.title,
       }));
-      this.hatsHandler?.({ ...this.roomHats });
-      this.roomAuthority[nick] = {
+      this.authorityFor(room)[nick] = {
         affiliation: parseMucAffiliation((presence as any).muc_affiliation),
         role: parseMucRole((presence as any).muc_role),
       };
-      this.authorityHandler?.({ ...this.roomAuthority });
-      this.roomPresence[nick] = parsePresenceShow(presence.show);
-      this.presenceHandler?.({ ...this.roomPresence });
+      this.presenceFor(room)[nick] = parsePresenceShow(presence.show);
+      let memberBare: string | null = null;
       if ((presence as any).muc_jid) {
-        const bare = barePeerJid((presence as any).muc_jid);
-        this.roomMemberJids[nick] = bare;
-        this.memberJidHandler?.(nick, bare);
+        memberBare = barePeerJid((presence as any).muc_jid);
+        this.memberJidsFor(room)[nick] = memberBare;
+      }
+      if (room === this.currentRoom) {
+        this.hatsHandler?.({ ...this.hatsFor(room) });
+        this.authorityHandler?.({ ...this.authorityFor(room) });
+        this.presenceHandler?.({ ...this.presenceFor(room) });
+        if (memberBare) this.memberJidHandler?.(nick, memberBare);
       }
       return;
     }

--- a/chat/src/lib/xmpp/discovery.ts
+++ b/chat/src/lib/xmpp/discovery.ts
@@ -144,7 +144,6 @@ interface BookmarkItem {
   jid?: string;
   name?: string;
   autojoin?: boolean;
-  nick?: string;
 }
 
 async function sendPubsubItems(xmpp: HybridClient, to: string, node: string): Promise<BookmarkItem[]> {
@@ -164,16 +163,10 @@ async function sendPubsubItems(xmpp: HybridClient, to: string, node: string): Pr
       const conference =
         item.getElementsByTagNameNS(NS_BOOKMARKS_1, "conference")[0]
         ?? item.getElementsByTagName("conference")[0];
-      const nickEl = conference
-        ? (conference.getElementsByTagNameNS(NS_BOOKMARKS_1, "nick")[0]
-          ?? conference.getElementsByTagName("nick")[0])
-        : null;
-      const nick = nickEl?.textContent?.trim();
       return {
         jid: item.getAttribute("id") ?? conference?.getAttribute("jid") ?? undefined,
         name: conference?.getAttribute("name") ?? undefined,
         autojoin: parseAutojoinAttr(conference?.getAttribute("autojoin")),
-        ...(nick ? { nick } : {}),
       };
     });
 }
@@ -266,7 +259,6 @@ export async function discoverChannels(xmpp: HybridClient, jid: string): Promise
 interface RoomBookmarkInfo {
   spaceId: string;
   autojoin?: boolean;
-  nick?: string;
 }
 
 export async function discoverTopology(xmpp: HybridClient, jid: string): Promise<DiscoveredTopology> {
@@ -299,7 +291,6 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
           roomBookmarkInfo.set(barePeerJid(bookmark.jid), {
             spaceId,
             ...(bookmark.autojoin !== undefined ? { autojoin: bookmark.autojoin } : {}),
-            ...(bookmark.nick ? { nick: bookmark.nick } : {}),
           });
         }
       } catch {}
@@ -311,19 +302,28 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
   const hydrated = await Promise.all(mucRooms.map((room, position) => hydrateRoomInfo(xmpp, channelFromRoom({ jid: room.jid ?? "", name: room.name }, position))));
   rooms = hydrated.map((room, position) => {
     const bookmark = room.jid ? roomBookmarkInfo.get(barePeerJid(room.jid)) : undefined;
+    // Two distinct sources of the auto-join bit, kept honest separately:
+    //
+    //   - A Space-bookmarked room: surface its `<conference autojoin='…'>`
+    //     verbatim. XEP-0402 §3 says omitting `autojoin` means `false`;
+    //     we honor that strictly. Waddle's own publisher in
+    //     `protocol-helpers.ts:publishMucToSpace` always sets the
+    //     attribute explicitly, so the spec default rarely fires in
+    //     practice, but third-party clients that publish without it
+    //     get the standard interpretation.
+    //
+    //   - An orphan room surfaced via MUC service items but absent
+    //     from every Space PubSub node: waddle's UX convention is
+    //     "channels visible in the sidebar are joined". We default
+    //     `autojoin: true` here, which is a *waddle* policy, not a
+    //     reinterpretation of XEP-0402 (the bit isn't sourced from
+    //     `urn:xmpp:bookmarks:1` at all in this branch).
+    const autojoin = bookmark ? (bookmark.autojoin ?? false) : true;
     return {
       ...room,
       position,
       ...(bookmark ? { spaceId: bookmark.spaceId, standalone: false } : {}),
-      // XEP-0402 §3 omitted `autojoin` defaults to false per spec, but
-      // waddle's bookmark publisher always sets it explicitly, AND the
-      // server may surface a channel via MUC service items even when no
-      // Space bookmark exists yet (orphan rooms before a Space publish).
-      // For waddle's UX — "every channel in your sidebar should show its
-      // call indicator after refresh" — we default to true here. Set the
-      // bookmark's `autojoin='false'` to override.
-      autojoin: bookmark?.autojoin ?? true,
-      ...(bookmark?.nick ? { bookmarkNick: bookmark.nick } : {}),
+      autojoin,
     };
   });
 

--- a/chat/src/lib/xmpp/discovery.ts
+++ b/chat/src/lib/xmpp/discovery.ts
@@ -126,7 +126,28 @@ async function sendDiscoItems(xmpp: HybridClient, to: string, node?: string): Pr
     .map((item) => ({ jid: item.getAttribute("jid") ?? undefined, name: item.getAttribute("name") ?? undefined, node: item.getAttribute("node") ?? undefined }));
 }
 
-async function sendPubsubItems(xmpp: HybridClient, to: string, node: string): Promise<Array<{ jid?: string; name?: string }>> {
+const NS_BOOKMARKS_1 = "urn:xmpp:bookmarks:1";
+
+/** XEP-0402 §3: `<conference xmlns='urn:xmpp:bookmarks:1' autojoin='true|false'>`.
+ * Returns `undefined` when the attribute is absent so callers can apply
+ * waddle's "channel surfaced via MUC service items but never bookmarked"
+ * default downstream. */
+function parseAutojoinAttr(value: string | null | undefined): boolean | undefined {
+  if (value == null) return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "true" || normalized === "1") return true;
+  if (normalized === "false" || normalized === "0") return false;
+  return undefined;
+}
+
+interface BookmarkItem {
+  jid?: string;
+  name?: string;
+  autojoin?: boolean;
+  nick?: string;
+}
+
+async function sendPubsubItems(xmpp: HybridClient, to: string, node: string): Promise<BookmarkItem[]> {
   if (!xmpp.send_raw_iq) return [];
   const id = crypto.randomUUID();
   const responseXml = await xmpp.send_raw_iq(`<iq type="get" id="${id}" to="${to}"><pubsub xmlns="${NS_PUBSUB}"><items node="${node}"/></pubsub></iq>`);
@@ -135,11 +156,24 @@ async function sendPubsubItems(xmpp: HybridClient, to: string, node: string): Pr
   if (!items) return [];
   return Array.from(items.getElementsByTagNameNS(NS_PUBSUB, "item"))
     .filter((item) => item.parentNode === items)
-    .map((item) => {
-      const conference = item.getElementsByTagName("conference")[0];
+    .map<BookmarkItem>((item) => {
+      // XEP-0402 §3: the conference element lives in NS_BOOKMARKS_1, but
+      // some implementations forget to set the namespace explicitly on the
+      // child. Tolerate both — the local-name match covers stray namespacing
+      // while the explicit NS_BOOKMARKS_1 lookup wins when both are present.
+      const conference =
+        item.getElementsByTagNameNS(NS_BOOKMARKS_1, "conference")[0]
+        ?? item.getElementsByTagName("conference")[0];
+      const nickEl = conference
+        ? (conference.getElementsByTagNameNS(NS_BOOKMARKS_1, "nick")[0]
+          ?? conference.getElementsByTagName("nick")[0])
+        : null;
+      const nick = nickEl?.textContent?.trim();
       return {
         jid: item.getAttribute("id") ?? conference?.getAttribute("jid") ?? undefined,
         name: conference?.getAttribute("name") ?? undefined,
+        autojoin: parseAutojoinAttr(conference?.getAttribute("autojoin")),
+        ...(nick ? { nick } : {}),
       };
     });
 }
@@ -224,11 +258,22 @@ export async function discoverChannels(xmpp: HybridClient, jid: string): Promise
   return hydrated.map((room, position) => ({ id: room.id, name: room.name, channelType: room.channelType, position }));
 }
 
+/** Bookmark attributes lifted from the Space's PubSub items, keyed by
+ * channel bare JID. Each room can appear in at most one Space (XEP-0503
+ * single-membership) so this is a flat map. Absent entries mean the
+ * room was not bookmarked anywhere; callers default `autojoin` to
+ * `true` in that case (waddle de-facto: visible channel ⇒ joined). */
+interface RoomBookmarkInfo {
+  spaceId: string;
+  autojoin?: boolean;
+  nick?: string;
+}
+
 export async function discoverTopology(xmpp: HybridClient, jid: string): Promise<DiscoveredTopology> {
   const domain = jidDomain(jid);
   const services = await discoverComponentServices(xmpp, domain, jid);
   let rooms: DiscoveredChannel[] = [];
-  const bookmarkedSpaceIds = new Map<string, string>();
+  const roomBookmarkInfo = new Map<string, RoomBookmarkInfo>();
   const spaces: DiscoveredSpace[] = [];
   let serverRole: DiscoveryRole = null;
 
@@ -250,7 +295,12 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
       try {
         const bookmarks = await sendPubsubItems(xmpp, services.spaces, item.node);
         for (const bookmark of bookmarks) {
-          if (bookmark.jid) bookmarkedSpaceIds.set(barePeerJid(bookmark.jid), spaceId);
+          if (!bookmark.jid) continue;
+          roomBookmarkInfo.set(barePeerJid(bookmark.jid), {
+            spaceId,
+            ...(bookmark.autojoin !== undefined ? { autojoin: bookmark.autojoin } : {}),
+            ...(bookmark.nick ? { nick: bookmark.nick } : {}),
+          });
         }
       } catch {}
       spaces.push({ id: spaceId, name: item.name ?? spaceId, role });
@@ -259,7 +309,23 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
 
   const mucRooms = await sendDiscoItems(xmpp, services.muc);
   const hydrated = await Promise.all(mucRooms.map((room, position) => hydrateRoomInfo(xmpp, channelFromRoom({ jid: room.jid ?? "", name: room.name }, position))));
-  rooms = hydrated.map((room, position) => ({ ...room, position, ...(room.jid && bookmarkedSpaceIds.get(barePeerJid(room.jid)) ? { spaceId: bookmarkedSpaceIds.get(barePeerJid(room.jid)), standalone: false } : {}) }));
+  rooms = hydrated.map((room, position) => {
+    const bookmark = room.jid ? roomBookmarkInfo.get(barePeerJid(room.jid)) : undefined;
+    return {
+      ...room,
+      position,
+      ...(bookmark ? { spaceId: bookmark.spaceId, standalone: false } : {}),
+      // XEP-0402 §3 omitted `autojoin` defaults to false per spec, but
+      // waddle's bookmark publisher always sets it explicitly, AND the
+      // server may surface a channel via MUC service items even when no
+      // Space bookmark exists yet (orphan rooms before a Space publish).
+      // For waddle's UX — "every channel in your sidebar should show its
+      // call indicator after refresh" — we default to true here. Set the
+      // bookmark's `autojoin='false'` to override.
+      autojoin: bookmark?.autojoin ?? true,
+      ...(bookmark?.nick ? { bookmarkNick: bookmark.nick } : {}),
+    };
+  });
 
   const roomSpaceIds = new Map(rooms.flatMap((room) => room.jid ? [[barePeerJid(room.jid), room.spaceId]] as const : []));
   return {

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -362,6 +362,20 @@ export interface DiscoveredChannel {
    * can render the Pin action correctly under the `anyone`
    * policy without needing owner-config access. */
   pinPermission?: PinPermission;
+  /** XEP-0402 §3 `autojoin` attribute on the channel's
+   * `<conference xmlns='urn:xmpp:bookmarks:1'>` bookmark item.
+   * `true` means the client should send MUC presence for this room
+   * on session ready so the user receives roster + XEP-0272 Muji
+   * presence and the per-room call indicator can fire even when the
+   * channel is not the active focus. Defaults to `true` for channels
+   * surfaced via the MUC service items but absent from any Space
+   * PubSub bookmark — waddle's de-facto behavior treats them as
+   * joined. */
+  autojoin?: boolean;
+  /** XEP-0402 §3 `<nick/>` child of the bookmark, if the user
+   * configured a custom MUC nick. `null`/absent → use the user's
+   * default (their session username). */
+  bookmarkNick?: string;
 }
 
 export interface DiscoveredSpace {

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -367,15 +367,11 @@ export interface DiscoveredChannel {
    * `true` means the client should send MUC presence for this room
    * on session ready so the user receives roster + XEP-0272 Muji
    * presence and the per-room call indicator can fire even when the
-   * channel is not the active focus. Defaults to `true` for channels
-   * surfaced via the MUC service items but absent from any Space
-   * PubSub bookmark — waddle's de-facto behavior treats them as
-   * joined. */
+   * channel is not the active focus. Bookmarked rooms honor the
+   * XEP-0402 spec default of `false` when omitted; orphan rooms not
+   * present in any Space PubSub default to `true` (waddle UX rule —
+   * channels visible in the sidebar are joined). */
   autojoin?: boolean;
-  /** XEP-0402 §3 `<nick/>` child of the bookmark, if the user
-   * configured a custom MUC nick. `null`/absent → use the user's
-   * default (their session username). */
-  bookmarkNick?: string;
 }
 
 export interface DiscoveredSpace {

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -1548,7 +1548,9 @@ describe("MUC group call", () => {
     // The focus-only switch goes straight into ensureJoined for the
     // new room — no `leave_room` for the old one. Hang the join so a
     // concurrent disconnect can land in the middle of the switch, and
-    // verify the post-disconnect handler clears the focused room.
+    // verify the post-disconnect handler clears the focused room and
+    // does NOT touch the old room (which the focus-only refactor
+    // keeps as a no-op).
     const switched = client.performRoomSwitch("new@muc.test");
     await joinStartedWait;
     const disconnected = client.disconnect();
@@ -1556,7 +1558,12 @@ describe("MUC group call", () => {
     await switched.catch(() => undefined);
     await disconnected;
 
-    expect(leave_room).not.toHaveBeenCalled();
+    // Polite-logout per XEP-0045 §7.14: leave_room fires for the
+    // rooms we had joined, but never for the room we were switching
+    // *away* from (the old room was never added to joinedMucs in
+    // this test setup, so it cannot leak through).
+    const leaveTargets = leave_room.mock.calls.map((call) => call[0] as string);
+    expect(leaveTargets).not.toContain("old@muc.test");
     expect(client.currentRoom).toBe(null);
   });
 

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -1445,7 +1445,7 @@ describe("MUC group call", () => {
     expect($mucCallParticipants.get()["chan@muc.test"]).toBeUndefined();
   });
 
-  test("room switch tears down the old room's active MUC call before leaving", async () => {
+  test("room switch tears down the old room's active MUC call but keeps the user joined to the old room", async () => {
     const events = wireClientEvents();
     const send_muji_session_terminate = mock(async () => undefined);
     const update_muji_presence = mockUpdateMujiPresenceWithEcho(events.emitPresence);
@@ -1466,22 +1466,29 @@ describe("MUC group call", () => {
         operationOrder.push(`presence:${active}:${preparing}`);
         await update_muji_presence(roomJid, nick, active, preparing, video);
       }),
+      // The new focus-only switch must NOT send a leave for the
+      // previous MUC — the user stays joined to every channel in
+      // their spaces so the call indicator (XEP-0272 Muji presence)
+      // keeps flowing while the focus moves. The mock is kept so we
+      // can assert leave_room was never called.
       leave_room: mock(async (roomJid: string, nick: string) => {
         operationOrder.push(`leave:${roomJid}/${nick}`);
         await leave_room(roomJid, nick);
       }),
+      join_room: mock(async () => undefined),
     };
     const client = events.client as unknown as {
       xmpp: typeof xmpp;
       currentRoom: string | null;
-      roomHats: Record<string, unknown>;
-      roomAuthority: Record<string, unknown>;
-      roomPresence: Record<string, unknown>;
-      roomMemberJids: Record<string, string>;
       performRoomSwitch: (roomJid: string) => Promise<void>;
+      session: { username: string };
+      joinedMucs: Map<string, Promise<void>>;
     };
     Object.assign(client.xmpp, xmpp);
     client.currentRoom = "old@muc.test";
+    // Pretend the auto-join already landed the old room — switching
+    // away should leave that entry intact (focus-only refactor).
+    client.joinedMucs.set("old@muc.test", Promise.resolve());
     $callState.set({
       phase: "active",
       peer: "old@muc.test",
@@ -1492,35 +1499,41 @@ describe("MUC group call", () => {
       selfNick: "alice",
     });
 
+    // Pre-seed the new room as already joined so performRoomSwitch's
+    // ensureJoined returns immediately and the test exercises just
+    // the teardown ordering.
+    client.joinedMucs.set("new@muc.test", Promise.resolve());
+
     await client.performRoomSwitch("new@muc.test");
 
     expect(operationOrder).toEqual([
       "presence:false:false",
       "terminate:old@muc.test:old-muc-attempt",
-      "leave:old@muc.test/alice",
     ]);
+    expect(xmpp.leave_room).not.toHaveBeenCalled();
+    expect(client.joinedMucs.has("old@muc.test")).toBe(true);
     expect($callState.get()).toEqual({ phase: "idle" });
   });
 
-  test("room switch does not join the new room after a concurrent disconnect", async () => {
+  test("room switch bails out cleanly when a concurrent disconnect races the join", async () => {
     const events = wireClientEvents();
-    let releaseLeave: (() => void) | null = null;
-    let leaveStarted: (() => void) | null = null;
-    const leaveGate = new Promise<void>((resolve) => {
-      releaseLeave = resolve;
+    let releaseJoin: (() => void) | null = null;
+    let joinStarted: (() => void) | null = null;
+    const joinGate = new Promise<void>((resolve) => {
+      releaseJoin = resolve;
     });
-    const leaveStartedWait = new Promise<void>((resolve) => {
-      leaveStarted = resolve;
+    const joinStartedWait = new Promise<void>((resolve) => {
+      joinStarted = resolve;
     });
-    let leaveCalls = 0;
-    const leave_room = mock(async () => {
-      leaveCalls += 1;
-      if (leaveCalls === 1) {
-        leaveStarted?.();
-        await leaveGate;
+    let joinCalls = 0;
+    const join_room = mock(async () => {
+      joinCalls += 1;
+      if (joinCalls === 1) {
+        joinStarted?.();
+        await joinGate;
       }
     });
-    const join_room = mock(async () => undefined);
+    const leave_room = mock(async () => undefined);
     const disconnect = mock(async () => undefined);
     const xmpp = { leave_room, join_room, disconnect };
     const client = events.client as unknown as {
@@ -1532,14 +1545,18 @@ describe("MUC group call", () => {
     Object.assign(client.xmpp, xmpp);
     client.currentRoom = "old@muc.test";
 
+    // The focus-only switch goes straight into ensureJoined for the
+    // new room — no `leave_room` for the old one. Hang the join so a
+    // concurrent disconnect can land in the middle of the switch, and
+    // verify the post-disconnect handler clears the focused room.
     const switched = client.performRoomSwitch("new@muc.test");
-    await leaveStartedWait;
+    await joinStartedWait;
     const disconnected = client.disconnect();
-    releaseLeave?.();
-    await switched;
+    releaseJoin?.();
+    await switched.catch(() => undefined);
     await disconnected;
 
-    expect(join_room).not.toHaveBeenCalled();
+    expect(leave_room).not.toHaveBeenCalled();
     expect(client.currentRoom).toBe(null);
   });
 
@@ -1595,6 +1612,14 @@ describe("MUC group call", () => {
     const attemptSid = firstMockCallArg(send_muji_session_initiate, 1);
     expect(attemptSid).not.toBe("old@muc.test");
 
+    // Pre-seed the new room as already joined so the switch's
+    // ensureJoined returns immediately and the assertion focuses on
+    // the call-teardown ordering only.
+    (client as unknown as { joinedMucs: Map<string, Promise<void>> }).joinedMucs.set(
+      "new@muc.test",
+      Promise.resolve(),
+    );
+
     await client.performRoomSwitch("new@muc.test");
 
     await expect(pending).rejects.toThrow("cancelled");
@@ -1604,8 +1629,8 @@ describe("MUC group call", () => {
       "initiate:old@muc.test:true",
       "presence:false:false:false",
       `terminate:old@muc.test:${attemptSid}`,
-      "leave:old@muc.test/alice",
     ]);
+    expect(xmpp.leave_room).not.toHaveBeenCalled();
     expect($callState.get()).toEqual({ phase: "idle" });
   });
 
@@ -1654,6 +1679,14 @@ describe("MUC group call", () => {
     expect($callState.get().phase).toBe("muc-pending");
     expect(send_muji_session_initiate).toHaveBeenCalledTimes(0);
 
+    // Pre-seed the new room so the switch's ensureJoined is an
+    // immediate no-op — the assertion below focuses on the
+    // call-cancellation ordering only.
+    (client as unknown as { joinedMucs: Map<string, Promise<void>> }).joinedMucs.set(
+      "new@muc.test",
+      Promise.resolve(),
+    );
+
     await client.performRoomSwitch("new@muc.test");
     await expect(pending).rejects.toThrow("cancelled");
 
@@ -1668,8 +1701,8 @@ describe("MUC group call", () => {
     expect(operationOrder).toEqual([
       "presence:old@muc.test/alice:false:true:false",
       "presence:old@muc.test/alice:false:false:false",
-      "leave:old@muc.test/alice",
     ]);
+    expect(xmpp.leave_room).not.toHaveBeenCalled();
     expect($callState.get()).toEqual({ phase: "idle" });
   });
 });

--- a/chat/tests/discovery-bookmark-autojoin.test.ts
+++ b/chat/tests/discovery-bookmark-autojoin.test.ts
@@ -2,21 +2,20 @@ import { describe, expect, test } from "bun:test";
 import { discoverTopology } from "../src/lib/xmpp/discovery";
 
 /**
- * Discovery extracts the XEP-0402 `autojoin` attribute (and optional
- * `<nick/>`) from `<conference xmlns='urn:xmpp:bookmarks:1'>` items
- * published into a Space's PubSub node. The auto-join fan-out keyed
- * off the resulting topology is what makes XEP-0272 Muji presence —
- * and therefore the per-room call indicator — visible across the
- * whole sidebar after a refresh.
+ * Discovery extracts the XEP-0402 `autojoin` attribute from
+ * `<conference xmlns='urn:xmpp:bookmarks:1'>` items published into a
+ * Space's PubSub node. The auto-join fan-out keyed off the resulting
+ * topology is what makes XEP-0272 Muji presence — and therefore the
+ * per-room call indicator — visible across the whole sidebar after a
+ * refresh.
  *
  * Coverage:
- * - `autojoin='true'` → `room.autojoin === true`
- * - `autojoin='false'` → `room.autojoin === false`
- * - Attribute absent → defaults to `true` (waddle's de-facto: a room
- *   surfaced via MUC service items should be auto-joined unless the
- *   bookmark explicitly opts out).
- * - A room with no Space bookmark at all → defaults to `true`.
- * - `<nick/>` child → surfaced as `room.bookmarkNick`.
+ * - `autojoin='true'` → `room.autojoin === true`.
+ * - `autojoin='false'` → `room.autojoin === false`.
+ * - Bookmarked room with the attribute omitted → defaults to `false`
+ *   per XEP-0402 §3 (canonical spec default).
+ * - Orphan room not bookmarked in any Space → defaults to `true`
+ *   (waddle UX convention: channels visible in the sidebar are joined).
  */
 describe("discoverTopology autojoin parsing", () => {
   test("autojoin=true bookmark surfaces room.autojoin=true", async () => {
@@ -49,21 +48,7 @@ describe("discoverTopology autojoin parsing", () => {
     });
   });
 
-  test("autojoin attribute absent defaults to true", async () => {
-    await withFakeDomParser(async () => {
-      const topology = await discoverTopology(
-        topologyClient({
-          spaceBookmarks: { "space-engineering": [{ jid: "shared@muc.example.test", name: "Shared" }] },
-          mucRooms: [{ jid: "shared@muc.example.test", name: "Shared" }],
-        }),
-        "alice@example.test",
-      );
-
-      expect(topology.rooms.find((r) => r.jid === "shared@muc.example.test")?.autojoin).toBe(true);
-    });
-  });
-
-  test("room with no Space bookmark at all still defaults to autojoin=true", async () => {
+  test("orphan room (not bookmarked anywhere) defaults to autojoin=true — waddle convention", async () => {
     await withFakeDomParser(async () => {
       const topology = await discoverTopology(
         topologyClient({
@@ -79,22 +64,28 @@ describe("discoverTopology autojoin parsing", () => {
     });
   });
 
-  test("bookmark <nick/> child propagates as room.bookmarkNick", async () => {
+  test("XEP-0402 §3 conformance: bookmarked room with omitted autojoin defaults to false (spec)", async () => {
+    // Spec: "If this attribute is omitted from a bookmark, it MUST
+    // be interpreted as 'false'." Waddle's own publisher always sets
+    // it, but the read path must honor the canonical default for
+    // foreign clients that publish without it. The "default true"
+    // policy applies ONLY to orphan rooms not bookmarked in any
+    // Space — exercised in the next test.
     await withFakeDomParser(async () => {
       const topology = await discoverTopology(
         topologyClient({
-          spaceBookmarks: { "space-engineering": [{ jid: "nicked@muc.example.test", name: "Nicked", autojoin: true, nick: "alias42" }] },
-          mucRooms: [{ jid: "nicked@muc.example.test", name: "Nicked" }],
+          spaceBookmarks: { "space-engineering": [{ jid: "shared-spec@muc.example.test", name: "Shared" }] },
+          mucRooms: [{ jid: "shared-spec@muc.example.test", name: "Shared" }],
         }),
         "alice@example.test",
       );
 
-      expect(topology.rooms.find((r) => r.jid === "nicked@muc.example.test")?.bookmarkNick).toBe("alias42");
+      expect(topology.rooms.find((r) => r.jid === "shared-spec@muc.example.test")?.autojoin).toBe(false);
     });
   });
 });
 
-type BookmarkItem = { jid?: string; name?: string; autojoin?: boolean; nick?: string };
+type BookmarkItem = { jid?: string; name?: string; autojoin?: boolean };
 
 type TopologyClientOptions = {
   spaceBookmarks: Record<string, BookmarkItem[]>;
@@ -172,12 +163,11 @@ function discoInfoXml(info: { features?: string[]; identities?: Array<{ category
   }</query></iq>`;
 }
 
-function pubsubItemsXml(items: Array<{ id?: string; jid?: string; name?: string; autojoin?: boolean; nick?: string }>): string {
+function pubsubItemsXml(items: Array<{ id?: string; jid?: string; name?: string; autojoin?: boolean }>): string {
   return `<iq type="result"><pubsub xmlns="http://jabber.org/protocol/pubsub"><items>${items.map((item) => {
     if (!(item.jid || item.name)) return `<item${item.id ? ` id="${item.id}"` : ""}/>`;
     const autojoinAttr = item.autojoin === undefined ? "" : ` autojoin="${item.autojoin ? "true" : "false"}"`;
-    const conferenceChildren = item.nick ? `<nick xmlns="urn:xmpp:bookmarks:1">${item.nick}</nick>` : "";
-    const conferenceTag = `<conference xmlns="urn:xmpp:bookmarks:1"${item.jid ? ` jid="${item.jid}"` : ""}${item.name ? ` name="${item.name}"` : ""}${autojoinAttr}${conferenceChildren ? `>${conferenceChildren}</conference>` : "/>"}`;
+    const conferenceTag = `<conference xmlns="urn:xmpp:bookmarks:1"${item.jid ? ` jid="${item.jid}"` : ""}${item.name ? ` name="${item.name}"` : ""}${autojoinAttr}/>`;
     return `<item${item.id ? ` id="${item.id}"` : ""}>${conferenceTag}</item>`;
   }).join("")}</items></pubsub></iq>`;
 }

--- a/chat/tests/discovery-bookmark-autojoin.test.ts
+++ b/chat/tests/discovery-bookmark-autojoin.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, test } from "bun:test";
+import { discoverTopology } from "../src/lib/xmpp/discovery";
+
+/**
+ * Discovery extracts the XEP-0402 `autojoin` attribute (and optional
+ * `<nick/>`) from `<conference xmlns='urn:xmpp:bookmarks:1'>` items
+ * published into a Space's PubSub node. The auto-join fan-out keyed
+ * off the resulting topology is what makes XEP-0272 Muji presence —
+ * and therefore the per-room call indicator — visible across the
+ * whole sidebar after a refresh.
+ *
+ * Coverage:
+ * - `autojoin='true'` → `room.autojoin === true`
+ * - `autojoin='false'` → `room.autojoin === false`
+ * - Attribute absent → defaults to `true` (waddle's de-facto: a room
+ *   surfaced via MUC service items should be auto-joined unless the
+ *   bookmark explicitly opts out).
+ * - A room with no Space bookmark at all → defaults to `true`.
+ * - `<nick/>` child → surfaced as `room.bookmarkNick`.
+ */
+describe("discoverTopology autojoin parsing", () => {
+  test("autojoin=true bookmark surfaces room.autojoin=true", async () => {
+    await withFakeDomParser(async () => {
+      const topology = await discoverTopology(
+        topologyClient({
+          spaceBookmarks: { "space-engineering": [{ jid: "general@muc.example.test", name: "General", autojoin: true }] },
+          mucRooms: [{ jid: "general@muc.example.test", name: "General" }],
+        }),
+        "alice@example.test",
+      );
+
+      const general = topology.rooms.find((r) => r.jid === "general@muc.example.test");
+      expect(general?.autojoin).toBe(true);
+      expect(general?.spaceId).toBe("space-engineering");
+    });
+  });
+
+  test("autojoin=false bookmark surfaces room.autojoin=false", async () => {
+    await withFakeDomParser(async () => {
+      const topology = await discoverTopology(
+        topologyClient({
+          spaceBookmarks: { "space-engineering": [{ jid: "muted@muc.example.test", name: "Muted", autojoin: false }] },
+          mucRooms: [{ jid: "muted@muc.example.test", name: "Muted" }],
+        }),
+        "alice@example.test",
+      );
+
+      expect(topology.rooms.find((r) => r.jid === "muted@muc.example.test")?.autojoin).toBe(false);
+    });
+  });
+
+  test("autojoin attribute absent defaults to true", async () => {
+    await withFakeDomParser(async () => {
+      const topology = await discoverTopology(
+        topologyClient({
+          spaceBookmarks: { "space-engineering": [{ jid: "shared@muc.example.test", name: "Shared" }] },
+          mucRooms: [{ jid: "shared@muc.example.test", name: "Shared" }],
+        }),
+        "alice@example.test",
+      );
+
+      expect(topology.rooms.find((r) => r.jid === "shared@muc.example.test")?.autojoin).toBe(true);
+    });
+  });
+
+  test("room with no Space bookmark at all still defaults to autojoin=true", async () => {
+    await withFakeDomParser(async () => {
+      const topology = await discoverTopology(
+        topologyClient({
+          spaceBookmarks: {},
+          mucRooms: [{ jid: "orphan@muc.example.test", name: "Orphan" }],
+        }),
+        "alice@example.test",
+      );
+
+      const orphan = topology.rooms.find((r) => r.jid === "orphan@muc.example.test");
+      expect(orphan?.autojoin).toBe(true);
+      expect(orphan?.spaceId).toBeUndefined();
+    });
+  });
+
+  test("bookmark <nick/> child propagates as room.bookmarkNick", async () => {
+    await withFakeDomParser(async () => {
+      const topology = await discoverTopology(
+        topologyClient({
+          spaceBookmarks: { "space-engineering": [{ jid: "nicked@muc.example.test", name: "Nicked", autojoin: true, nick: "alias42" }] },
+          mucRooms: [{ jid: "nicked@muc.example.test", name: "Nicked" }],
+        }),
+        "alice@example.test",
+      );
+
+      expect(topology.rooms.find((r) => r.jid === "nicked@muc.example.test")?.bookmarkNick).toBe("alias42");
+    });
+  });
+});
+
+type BookmarkItem = { jid?: string; name?: string; autojoin?: boolean; nick?: string };
+
+type TopologyClientOptions = {
+  spaceBookmarks: Record<string, BookmarkItem[]>;
+  mucRooms: Array<{ jid: string; name?: string }>;
+};
+
+function topologyClient(options: TopologyClientOptions) {
+  const spaceNodes = Object.keys(options.spaceBookmarks);
+  return {
+    async send_raw_iq(xml: string): Promise<string> {
+      if (xml.includes('xmlns="http://jabber.org/protocol/disco#items"')) {
+        if (xml.includes('to="example.test"')) {
+          return discoItemsXml([
+            { jid: "spaces.example.test", name: "Spaces" },
+            { jid: "muc.example.test", name: "Chatrooms" },
+          ]);
+        }
+        if (xml.includes('to="spaces.example.test"')) {
+          return discoItemsXml(spaceNodes.map((node) => ({ name: titleCase(node), node })));
+        }
+        if (xml.includes('to="muc.example.test"')) {
+          return discoItemsXml(options.mucRooms);
+        }
+        return discoItemsXml([]);
+      }
+      if (xml.includes('xmlns="http://jabber.org/protocol/disco#info"')) {
+        if (xml.includes('to="muc.example.test"')) {
+          return discoInfoXml({
+            identities: [{ category: "conference", type: "text", name: "Chatrooms" }],
+            features: ["http://jabber.org/protocol/muc"],
+          });
+        }
+        if (xml.includes('to="spaces.example.test"')) {
+          return discoInfoXml({
+            identities: [{ category: "pubsub", type: "service", name: "Spaces" }],
+            features: ["http://jabber.org/protocol/pubsub"],
+          });
+        }
+        if (xml.includes('to="example.test"')) {
+          return discoInfoXml({
+            identities: [{ category: "server", type: "im", name: "Waddle" }],
+            features: [],
+          });
+        }
+        return discoInfoXml();
+      }
+      if (xml.includes('xmlns="http://jabber.org/protocol/pubsub"')) {
+        const nodeMatch = /node="([^"]+)"/.exec(xml);
+        const node = nodeMatch?.[1];
+        const bookmarks = node ? options.spaceBookmarks[node] ?? [] : [];
+        return pubsubItemsXml(bookmarks.map((b) => ({ id: b.jid, ...b })));
+      }
+      throw new Error(`Unexpected IQ: ${xml}`);
+    },
+  };
+}
+
+function titleCase(node: string): string {
+  return node.replace(/^space-/, "").replace(/^./, (c) => c.toUpperCase());
+}
+
+function discoItemsXml(items: Array<{ name?: string; node?: string; jid?: string }>): string {
+  return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#items">${items.map((item) =>
+    `<item${item.jid ? ` jid="${item.jid}"` : ""}${item.name ? ` name="${item.name}"` : ""}${item.node ? ` node="${item.node}"` : ""}/>`,
+  ).join("")}</query></iq>`;
+}
+
+function discoInfoXml(info: { features?: string[]; identities?: Array<{ category: string; type: string; name?: string }> } = {}): string {
+  return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#info">${
+    (info.identities ?? []).map((identity) =>
+      `<identity category="${identity.category}" type="${identity.type}"${identity.name ? ` name="${identity.name}"` : ""}/>`,
+    ).join("")
+  }${
+    (info.features ?? []).map((feature) => `<feature var="${feature}"/>`).join("")
+  }</query></iq>`;
+}
+
+function pubsubItemsXml(items: Array<{ id?: string; jid?: string; name?: string; autojoin?: boolean; nick?: string }>): string {
+  return `<iq type="result"><pubsub xmlns="http://jabber.org/protocol/pubsub"><items>${items.map((item) => {
+    if (!(item.jid || item.name)) return `<item${item.id ? ` id="${item.id}"` : ""}/>`;
+    const autojoinAttr = item.autojoin === undefined ? "" : ` autojoin="${item.autojoin ? "true" : "false"}"`;
+    const conferenceChildren = item.nick ? `<nick xmlns="urn:xmpp:bookmarks:1">${item.nick}</nick>` : "";
+    const conferenceTag = `<conference xmlns="urn:xmpp:bookmarks:1"${item.jid ? ` jid="${item.jid}"` : ""}${item.name ? ` name="${item.name}"` : ""}${autojoinAttr}${conferenceChildren ? `>${conferenceChildren}</conference>` : "/>"}`;
+    return `<item${item.id ? ` id="${item.id}"` : ""}>${conferenceTag}</item>`;
+  }).join("")}</items></pubsub></iq>`;
+}
+
+async function withFakeDomParser(run: () => Promise<void>): Promise<void> {
+  const original = globalThis.DOMParser;
+  globalThis.DOMParser = FakeDOMParser as typeof DOMParser;
+  try {
+    await run();
+  } finally {
+    globalThis.DOMParser = original;
+  }
+}
+
+class FakeDOMParser {
+  parseFromString(xml: string): Document {
+    return parseTestXml(xml) as unknown as Document;
+  }
+}
+
+class FakeXmlElement {
+  readonly children: FakeXmlElement[] = [];
+  text = "";
+  parentNode: FakeXmlElement | null = null;
+
+  constructor(
+    readonly localName: string,
+    readonly namespaceURI: string | null,
+    private readonly attrs: Record<string, string>,
+  ) {}
+
+  get textContent(): string {
+    return `${this.text}${this.children.map((child) => child.textContent ?? "").join("")}`;
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attrs[name] ?? null;
+  }
+
+  querySelector(localName: string): FakeXmlElement | null {
+    return this.getElementsByTagName(localName)[0] ?? null;
+  }
+
+  getElementsByTagNameNS(namespace: string, localName: string): FakeXmlElement[] {
+    return this.descendants().filter((node) => node.namespaceURI === namespace && node.localName === localName);
+  }
+
+  getElementsByTagName(localName: string): FakeXmlElement[] {
+    return this.descendants().filter((node) => node.localName === localName);
+  }
+
+  private descendants(): FakeXmlElement[] {
+    return this.children.flatMap((child) => [child, ...child.descendants()]);
+  }
+}
+
+function parseTestXml(xml: string): FakeXmlElement {
+  const root = new FakeXmlElement("#document", null, {});
+  const stack: FakeXmlElement[] = [root];
+  const tokenPattern = /<[^>]+>|[^<]+/g;
+  for (const token of xml.match(tokenPattern) ?? []) {
+    if (token.startsWith("</")) {
+      stack.pop();
+      continue;
+    }
+    if (token.startsWith("<")) {
+      const selfClosing = token.endsWith("/>");
+      const body = token.slice(1, selfClosing ? -2 : -1).trim();
+      const [qualifiedName = ""] = body.split(/\s+/, 1);
+      const attrs = attributesFromTag(body);
+      const parent = stack[stack.length - 1];
+      const node = new FakeXmlElement(
+        qualifiedName.includes(":") ? qualifiedName.split(":").pop()! : qualifiedName,
+        attrs.xmlns ?? parent.namespaceURI,
+        attrs,
+      );
+      node.parentNode = parent;
+      parent.children.push(node);
+      if (!selfClosing) stack.push(node);
+      continue;
+    }
+    stack[stack.length - 1].text += token;
+  }
+  return root;
+}
+
+function attributesFromTag(tagBody: string): Record<string, string> {
+  const attrs: Record<string, string> = {};
+  for (const match of tagBody.matchAll(/([A-Za-z0-9:_-]+)="([^"]*)"/g)) {
+    attrs[match[1]] = match[2];
+  }
+  return attrs;
+}

--- a/chat/tests/discovery-pin-permission.test.ts
+++ b/chat/tests/discovery-pin-permission.test.ts
@@ -225,10 +225,16 @@ function discoInfoXml(info: { features?: string[]; identities?: Array<{ category
   }</query></iq>`;
 }
 
-function pubsubItemsXml(items: Array<{ id?: string; jid?: string; name?: string }>): string {
-  return `<iq type="result"><pubsub xmlns="http://jabber.org/protocol/pubsub"><items>${items.map((item) =>
-    `<item${item.id ? ` id="${item.id}"` : ""}>${item.jid || item.name ? `<conference${item.jid ? ` jid="${item.jid}"` : ""}${item.name ? ` name="${item.name}"` : ""}/>` : ""}</item>`
-  ).join("")}</items></pubsub></iq>`;
+function pubsubItemsXml(items: Array<{ id?: string; jid?: string; name?: string; autojoin?: boolean; nick?: string }>): string {
+  return `<iq type="result"><pubsub xmlns="http://jabber.org/protocol/pubsub"><items>${items.map((item) => {
+    if (!(item.jid || item.name)) {
+      return `<item${item.id ? ` id="${item.id}"` : ""}/>`;
+    }
+    const autojoinAttr = item.autojoin === undefined ? "" : ` autojoin="${item.autojoin ? "true" : "false"}"`;
+    const conferenceChildren = item.nick ? `<nick xmlns="urn:xmpp:bookmarks:1">${item.nick}</nick>` : "";
+    const conferenceTag = `<conference xmlns="urn:xmpp:bookmarks:1"${item.jid ? ` jid="${item.jid}"` : ""}${item.name ? ` name="${item.name}"` : ""}${autojoinAttr}${conferenceChildren ? `>${conferenceChildren}</conference>` : "/>"}`;
+    return `<item${item.id ? ` id="${item.id}"` : ""}>${conferenceTag}</item>`;
+  }).join("")}</items></pubsub></iq>`;
 }
 
 async function withFakeDomParser(run: () => Promise<void>): Promise<void> {

--- a/chat/tests/discovery-pin-permission.test.ts
+++ b/chat/tests/discovery-pin-permission.test.ts
@@ -225,16 +225,10 @@ function discoInfoXml(info: { features?: string[]; identities?: Array<{ category
   }</query></iq>`;
 }
 
-function pubsubItemsXml(items: Array<{ id?: string; jid?: string; name?: string; autojoin?: boolean; nick?: string }>): string {
-  return `<iq type="result"><pubsub xmlns="http://jabber.org/protocol/pubsub"><items>${items.map((item) => {
-    if (!(item.jid || item.name)) {
-      return `<item${item.id ? ` id="${item.id}"` : ""}/>`;
-    }
-    const autojoinAttr = item.autojoin === undefined ? "" : ` autojoin="${item.autojoin ? "true" : "false"}"`;
-    const conferenceChildren = item.nick ? `<nick xmlns="urn:xmpp:bookmarks:1">${item.nick}</nick>` : "";
-    const conferenceTag = `<conference xmlns="urn:xmpp:bookmarks:1"${item.jid ? ` jid="${item.jid}"` : ""}${item.name ? ` name="${item.name}"` : ""}${autojoinAttr}${conferenceChildren ? `>${conferenceChildren}</conference>` : "/>"}`;
-    return `<item${item.id ? ` id="${item.id}"` : ""}>${conferenceTag}</item>`;
-  }).join("")}</items></pubsub></iq>`;
+function pubsubItemsXml(items: Array<{ id?: string; jid?: string; name?: string }>): string {
+  return `<iq type="result"><pubsub xmlns="http://jabber.org/protocol/pubsub"><items>${items.map((item) =>
+    `<item${item.id ? ` id="${item.id}"` : ""}>${item.jid || item.name ? `<conference${item.jid ? ` jid="${item.jid}"` : ""}${item.name ? ` name="${item.name}"` : ""}/>` : ""}</item>`,
+  ).join("")}</items></pubsub></iq>`;
 }
 
 async function withFakeDomParser(run: () => Promise<void>): Promise<void> {

--- a/chat/tests/use-active-muc-call.test.ts
+++ b/chat/tests/use-active-muc-call.test.ts
@@ -5,7 +5,7 @@ import {
   clearMucCallParticipants,
 } from "../src/lib/calls/muc-call-presence";
 import { connectionStore } from "../src/lib/connection-store";
-import { readActiveMucCall } from "../src/lib/calls/use-active-muc-call";
+import { readActiveMucCall, readRoomHasActiveCall } from "../src/lib/calls/use-active-muc-call";
 import type { CallMedia, LiveKitJoin } from "../src/lib/calls/types";
 import type { WaddleSession } from "../src/lib/server-auth";
 
@@ -141,5 +141,86 @@ describe("readActiveMucCall selector", () => {
     });
     $mucCallParticipants.set({ [ROOM]: ["alice"] });
     expect(readActiveMucCall().selfInCall).toBe(false);
+  });
+});
+
+describe("readRoomHasActiveCall selector — populated from Muji presence alone", () => {
+  beforeEach(() => {
+    $callState.set({ phase: "idle" });
+    clearMucCallParticipants();
+    setSession(null);
+  });
+
+  afterEach(() => {
+    $callState.set({ phase: "idle" });
+    clearMucCallParticipants();
+    setSession(null);
+  });
+
+  test("post-refresh discovery: room has a call even though local `$callState` is idle", () => {
+    // This is the exact scenario the user reported: a page refresh
+    // clears `$callState` but the rejoined client receives roster
+    // replay with XEP-0272 Muji extensions from existing occupants.
+    // The pill MUST light up on the strength of that store alone.
+    setSession("carol");
+    $callState.set({ phase: "idle" });
+    $mucCallParticipants.set({ [ROOM]: ["alice", "bob"] });
+
+    expect(readRoomHasActiveCall(ROOM)).toEqual({
+      hasActiveCall: true,
+      selfInCall: false,
+      participantCount: 2,
+    });
+  });
+
+  test("self is in call when the local nick appears in the participants list", () => {
+    setSession("alice");
+    $mucCallParticipants.set({ [ROOM]: ["alice", "bob"] });
+
+    expect(readRoomHasActiveCall(ROOM)).toEqual({
+      hasActiveCall: true,
+      selfInCall: true,
+      participantCount: 2,
+    });
+  });
+
+  test("no call when the room is absent from the store", () => {
+    setSession("alice");
+    $mucCallParticipants.set({});
+
+    expect(readRoomHasActiveCall(ROOM)).toEqual({
+      hasActiveCall: false,
+      selfInCall: false,
+      participantCount: 0,
+    });
+  });
+
+  test("no call when the room's participants list is empty (XEP-0272 §Leaving cleared it)", () => {
+    setSession("alice");
+    $mucCallParticipants.set({ [ROOM]: [] });
+
+    expect(readRoomHasActiveCall(ROOM)).toEqual({
+      hasActiveCall: false,
+      selfInCall: false,
+      participantCount: 0,
+    });
+  });
+
+  test("resource-suffixed roomJid still matches the canonical bare key", () => {
+    setSession("alice");
+    $mucCallParticipants.set({ [ROOM]: ["bob"] });
+
+    expect(readRoomHasActiveCall(`${ROOM}/alice`).hasActiveCall).toBe(true);
+  });
+
+  test("empty roomJid is a no-op", () => {
+    setSession("alice");
+    $mucCallParticipants.set({ [ROOM]: ["alice"] });
+
+    expect(readRoomHasActiveCall("")).toEqual({
+      hasActiveCall: false,
+      selfInCall: false,
+      participantCount: 0,
+    });
   });
 });


### PR DESCRIPTION
## Problem

The call indicator — the green pulsing pill in the channel header (`CallActivePill`) and the per-row badge in the sidebar (`TopicsPanel`) — was added so a user who refreshes mid-call (or opens the app while a call is in progress) can see which rooms have ongoing calls and click to join. After a refresh, every indicator stays dark. Even worse, switching channels mid-session erodes the user's awareness of calls happening elsewhere.

## Root cause

Two independent bugs, both client-side. The server is XEP-0272 + XEP-0045 conformant (`MucRoom::muji_state` deterministically replays existing-occupant Muji presence to fresh joiners; cleanup on disconnect is queued behind the actor and broadcasts unavailable correctly).

1. **`CallActivePill` detection was keyed to local call state.** `useActiveMucCall()` derives `activeRoomJid` from `$callState.phase === 'active'`, which is only set when the local user is in a call. After refresh, `$callState` resets to `idle`, so the pill condition (`activeRoomJid === thisRoom && !selfInCall`) reduced to "you're in this call but somehow not in the participants list" — a transient bug-state, not the intended UX.

2. **The chat client lazy-joined MUCs.** `switchRoom` was the only path that sent `<presence to='room@muc/nick'/>` and it ran only when the user clicked a channel. Non-focused rooms had no MUC presence at all, so no Muji extensions arrived, so `$mucCallParticipants` stayed empty for every channel except the focused one. Worse, `switchRoom` also called `leave_room` on the previously focused room, so even consecutive focus switches eroded awareness.

## Approach

Three coordinated changes:

### 1. `CallActivePill` detection sourced from XEP-0272 presence
New selector `useRoomHasActiveCall(roomJid)` reads `$mucCallParticipants[roomJid]` directly. `selfInCall` is `local nick ∈ participants list`. Independent of `$callState`. The existing `useActiveMucCall()` keeps its current meaning ("which room am _I_ currently calling in?") for split-view ownership.

### 2. Eager MUC auto-join keyed off existing XEP-0402 bookmarks
Waddle already publishes channel-to-space membership as XEP-0402 `<conference xmlns='urn:xmpp:bookmarks:1' autojoin='…'/>` items inside Space PubSub nodes (`protocol-helpers.ts:publishMucToSpace`, server-side typed parser in `xep0402.rs`). `discoverTopology` now parses the `autojoin` attribute and `BrowserXmppClient.discoverTopology()` fans out `ensureJoined(roomJid)` for every `autojoin !== false` room with bounded concurrency (6 in flight). `ensureJoined` is idempotent via `Map<roomJid, Promise<void>>`. The list is cached and replayed by `handleSessionReady("fresh")` so reconnects re-populate Muji presence without waiting for the next bootstrap.

### 3. `switchRoom` is focus-only; per-room state caches replace singletons
`switchRoom` no longer sends `leave_room` — the user stays joined to every channel of their spaces for the session lifetime. Per-room caches (`roomHatsByRoom`, `roomAuthorityByRoom`, `roomPresenceByRoom`, `roomMemberJidsByRoom`) replace the previous singletons; the presence handler always writes to the per-room cache and only fires the focused-room handlers when the room matches `currentRoom`. `dispatchFocusedRoomHandlers` replays hats / authority / presence / `memberJidHandler` from cache on every focus switch.

### XEP conformance

- **XEP-0402 §3 (PEP Native Bookmarks):** discovery honors the spec default of `autojoin='false'` for bookmarked items with the attribute omitted. The "default true" policy applies only to orphan rooms not present in any Space PubSub (a waddle-specific UX convention, not a reinterpretation of XEP-0402's element semantics).
- **XEP-0045 §7.14 (MUC) polite logout:** `disconnect()` now sends `<presence type='unavailable'/>` via `leave_room` for every previously joined MUC, snapshotted before `joinedMucs.clear()`. Server-side WebSocket cleanup still backstops the technical-disconnect case with status code 333.
- **XEP-0272 §3 (Muji Joining):** unchanged — clicking the pill runs the existing `beginMucCall` flow (preparing → content presence + Jingle `session-initiate` to `calls.<domain>`). A late joiner is just a joiner; no "resume" stanza exists in Muji.

## Out of scope (deliberate, follow-up)

- `urn:xmpp:bookmarks:1+notify` subscription for cross-client live updates (would propagate "Alice added you to #X" without a refresh). Not required by the user's complaint; topology refresh on reconnect is sufficient.
- XEP-0198 SM-resume preserving `$callState` across brief network blips. The user's complaint is the full-refresh case; this is a separate, smaller follow-up.

## Test plan

- [x] `chat/tests/discovery-bookmark-autojoin.test.ts` (new) — autojoin attribute parsing, XEP-0402 §3 spec default (`false` for bookmarked items with omitted attribute), waddle's "orphan-default-true" policy.
- [x] `chat/tests/use-active-muc-call.test.ts` — extended with `readRoomHasActiveCall` coverage: the pill lights up purely from `$mucCallParticipants` even when `$callState` is `idle` (the exact post-refresh scenario).
- [x] `chat/tests/call-teardown.test.ts` — switch-room tests updated to reflect focus-only semantics (no `leave_room` on switch); concurrent-disconnect race covered.
- [x] `bun test` → 1120/1120 pass.
- [x] `bunx knip` clean.
- [x] `bunx astro check` clean.

Manual scenarios:
- **A — focused-channel resume:** Alice starts a call in `#general`. Bob is viewing `#general`. Bob refreshes. Pill appears within ~1s.
- **B — sibling-channel discovery:** Alice in `#engineering` call; Bob viewing `#general`; Bob refreshes. Sidebar badge on `#engineering` shows count; clicking opens it and the pill is visible.
- **C — own session mid-call refresh:** Bob in a call in `#general` refreshes. Server cleans up his Muji + SFU registration. Bob sees the indicator with the remaining participants. Clicking initiates a fresh Jingle session — server treats him as a new participant per XEP-0272 §3.
- **D — reconnect mid-session:** Bob's connection drops and reconnects. Sibling-channel indicators come back automatically via `handleSessionReady`'s replay.
- **E — multi-client bookmark add:** New channel added on client A. On client B's next reconnect, the bookmark replays and the new channel is auto-joined. (Live-update across stable connections is a follow-up — see "Out of scope".)

## Adversarial review

Two concurrent adversarial-persona subagents reviewed the diff after the first commit; their P0/P1/P2 findings (`memberJidHandler` not replayed on focus switch, no re-fan-out on reconnect, XEP-0402 default inverted, dead `bookmarkNick`, missing polite leave on logout) are all addressed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)