### PR TITLE
feat(server): wire XEP-0513 §295 mentions permissions IQ form

### DIFF
--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mentions_permissions.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mentions_permissions.rs
@@ -1,0 +1,205 @@
+//! IQ handler for XEP-0513 §295 room-permissions query.
+//!
+//! Targets `<iq type='get' to='room@muc.example'>
+//!   <query xmlns='urn:xmpp:mentions:0'/>
+//! </iq>` and returns the §303 result form built from the server's
+//! hardcoded policy (slices 3a + 3b — `mentions#count = 5`,
+//! `mentions#channel = moderators`, `mentions#individual = participants`).
+//!
+//! ## Why a dedicated handler
+//!
+//! Slices 3a/3b enforce the policy at T0 candidate classification
+//! without exposing the §295 IQ surface — that's spec-conformant under
+//! §292 ("Mentions MAY be sent in rooms which do not have permissions
+//! set, and/or do not advertise support for them"), but it left the
+//! feature advertised state mismatched with the wire shape. CLAUDE.md
+//! XEP conformance hard rule: "If Waddle advertises an official XEP
+//! feature... the wire shape and behavior MUST conform to that XEP
+//! exactly." This handler closes the loop so `Feature::explicit_mentions`
+//! and `Feature::channel_mentions` can be re-advertised honestly.
+//!
+//! ## Authorization
+//!
+//! GET is open to any participant: §303 says the form is what
+//! "receiving entities SHOULD refer to when deciding whether to notify
+//! the user", so non-occupants legitimately need to read it (e.g. a
+//! client deciding whether to render `@channel` autocompletion). We
+//! still require the target to be a bare room JID — full-JID
+//! addressing here is non-sensical and likely a client bug.
+//!
+//! SET is unconditionally `<feature-not-implemented/>`. XEP §295
+//! reserves `<forbidden/>` for "the user is not an owner", but Waddle
+//! exposes no owner-driven config mutation for the §303 form; the
+//! policy is a server-internal hardcoded default. Returning forbidden
+//! would lie about *why* the set failed.
+
+use super::*;
+use jid::FullJid;
+use std::str::FromStr;
+use waddle_xmpp::xep::{
+    build_mentions_permissions_query, is_mentions_permissions_query, MentionsPermissions,
+};
+use xmpp_parsers::iq::Iq;
+
+/// Detects an XEP-0513 §295 query (`<iq type='get'><query
+/// xmlns='urn:xmpp:mentions:0'/></iq>` targeting a MUC room JID) or a
+/// matching `type='set'` (so the dispatcher routes both to this
+/// handler — the set arm returns `<feature-not-implemented/>` rather
+/// than falling through to the generic "Unhandled IQ" path which
+/// would also return feature-not-implemented but without the typed
+/// `<query/>` echo §295 implies).
+pub(super) fn is_mentions_permissions_iq(iq: &Iq, muc_domain: &str) -> bool {
+    let payload = match iq {
+        Iq::Get { payload, .. } | Iq::Set { payload, .. } => payload,
+        _ => return false,
+    };
+    if !is_mentions_permissions_query(payload) {
+        return false;
+    }
+    iq.to().is_some_and(|to| to.domain().as_str() == muc_domain)
+}
+
+pub(super) async fn handle_mentions_permissions_iq(
+    iq: &Iq,
+    _state: &WebSocketState,
+    _sender_jid: Option<&FullJid>,
+    response_from: Option<&str>,
+    response_to: Option<&str>,
+) -> Vec<String> {
+    let Some(target) = iq.to() else {
+        return vec![build_iq_error_xml_typed(
+            iq.id(),
+            response_from,
+            response_to,
+            bad_request_iq_error("Mentions-permissions query requires a room JID in 'to'."),
+        )];
+    };
+    if target.resource().is_some() {
+        return vec![build_iq_error_xml_typed(
+            iq.id(),
+            response_from,
+            response_to,
+            bad_request_iq_error("Mentions-permissions query 'to' must be a bare room JID."),
+        )];
+    }
+
+    match iq {
+        Iq::Get { .. } => {
+            let permissions = MentionsPermissions::server_default();
+            let query = build_mentions_permissions_query(&permissions);
+            let response = Iq::Result {
+                from: response_from.and_then(|s| jid::Jid::from_str(s).ok()),
+                to: response_to.and_then(|s| jid::Jid::from_str(s).ok()),
+                id: iq.id().to_string(),
+                payload: Some(query),
+            };
+            vec![iq_to_xml(response)]
+        }
+        Iq::Set { .. } => vec![build_iq_error_xml_typed(
+            iq.id(),
+            response_from,
+            response_to,
+            feature_not_implemented_iq_error(
+                "Mentions permissions are server-hardcoded; the §303 form is read-only.",
+            ),
+        )],
+        _ => unreachable!("is_mentions_permissions_iq filters to Get/Set"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use waddle_xmpp::xep::NS_EXPLICIT_MENTIONS;
+    use xmpp_parsers::minidom::Element;
+
+    fn iq_get(payload: Element, to: Option<&str>) -> Iq {
+        Iq::Get {
+            from: None,
+            to: to.and_then(|s| jid::Jid::from_str(s).ok()),
+            id: "perm-get-1".into(),
+            payload,
+        }
+    }
+
+    fn iq_set(payload: Element, to: Option<&str>) -> Iq {
+        Iq::Set {
+            from: None,
+            to: to.and_then(|s| jid::Jid::from_str(s).ok()),
+            id: "perm-set-1".into(),
+            payload,
+        }
+    }
+
+    fn mentions_payload() -> Element {
+        Element::builder("query", NS_EXPLICIT_MENTIONS).build()
+    }
+
+    #[test]
+    fn is_mentions_permissions_iq_accepts_well_formed_get() {
+        let iq = iq_get(mentions_payload(), Some("team@muc.example"));
+        assert!(is_mentions_permissions_iq(&iq, "muc.example"));
+    }
+
+    #[test]
+    fn is_mentions_permissions_iq_accepts_set_for_routing() {
+        // §295 owner-submitted form. Even though we'll answer with
+        // feature-not-implemented, the dispatcher MUST route the IQ
+        // here so we own the wire shape (echoed `<query/>` in the
+        // error response is consistent with §295's error example).
+        let iq = iq_set(mentions_payload(), Some("team@muc.example"));
+        assert!(is_mentions_permissions_iq(&iq, "muc.example"));
+    }
+
+    #[test]
+    fn is_mentions_permissions_iq_rejects_wrong_namespace() {
+        let payload = Element::builder("query", "wrong:ns").build();
+        let iq = iq_get(payload, Some("team@muc.example"));
+        assert!(!is_mentions_permissions_iq(&iq, "muc.example"));
+    }
+
+    #[test]
+    fn is_mentions_permissions_iq_rejects_wrong_element_name() {
+        let payload = Element::builder("permissions", NS_EXPLICIT_MENTIONS).build();
+        let iq = iq_get(payload, Some("team@muc.example"));
+        assert!(!is_mentions_permissions_iq(&iq, "muc.example"));
+    }
+
+    #[test]
+    fn is_mentions_permissions_iq_rejects_missing_to() {
+        let iq = iq_get(mentions_payload(), None);
+        assert!(!is_mentions_permissions_iq(&iq, "muc.example"));
+    }
+
+    #[test]
+    fn is_mentions_permissions_iq_rejects_wrong_domain() {
+        let iq = iq_get(mentions_payload(), Some("team@other.example"));
+        assert!(!is_mentions_permissions_iq(&iq, "muc.example"));
+    }
+
+    #[test]
+    fn is_mentions_permissions_iq_rejects_iq_result_and_error() {
+        let payload = mentions_payload();
+        let result = Iq::Result {
+            from: None,
+            to: jid::Jid::from_str("team@muc.example").ok(),
+            id: "perm-1".into(),
+            payload: Some(payload.clone()),
+        };
+        assert!(!is_mentions_permissions_iq(&result, "muc.example"));
+
+        let error = Iq::Error {
+            from: None,
+            to: jid::Jid::from_str("team@muc.example").ok(),
+            id: "perm-1".into(),
+            error: xmpp_parsers::stanza_error::StanzaError::new(
+                xmpp_parsers::stanza_error::ErrorType::Cancel,
+                xmpp_parsers::stanza_error::DefinedCondition::ServiceUnavailable,
+                "en",
+                "unrelated",
+            ),
+            payload: Some(payload),
+        };
+        assert!(!is_mentions_permissions_iq(&error, "muc.example"));
+    }
+}

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mentions_permissions.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mentions_permissions.rs
@@ -32,6 +32,27 @@
 //! exposes no owner-driven config mutation for the §303 form; the
 //! policy is a server-internal hardcoded default. Returning forbidden
 //! would lie about *why* the set failed.
+//!
+//! ## No room-existence gate
+//!
+//! Sibling room-targeted IQ handlers (`pin_query`, the MUC disco-info
+//! path) look up the room in the registry and return
+//! `<item-not-found/>` for unknown room JIDs. The §295 handler
+//! deliberately does NOT: the §303 form is a **server-wide**
+//! hardcoded policy (`mentions#count = 5`, `mentions#individual =
+//! participants`, `mentions#channel = moderators`) that is identical
+//! for every room and does not read any per-room state. XEP-0513
+//! §292 explicitly contemplates this: "Mentions MAY be sent in rooms
+//! which do not have permissions set, and/or do not advertise support
+//! for them." Answering a §295 query for a never-instantiated room
+//! is therefore both spec-conformant and useful — clients
+//! legitimately need the form to know how to render mention UI
+//! *before* joining a room.
+//!
+//! Because every bare-JID query under `muc_domain` yields the same
+//! form, the handler is not an existence oracle: it cannot
+//! distinguish "exists" from "does not exist" any better than a
+//! client sending the same query twice with different JIDs.
 
 use super::*;
 use jid::FullJid;

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mentions_permissions.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mentions_permissions.rs
@@ -239,6 +239,7 @@ fn mentions_permissions_error(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use waddle_xmpp::ns::STANZAS;
 
     fn iq_get(payload: Element, to: Option<&str>) -> Iq {
         Iq::Get {
@@ -395,7 +396,7 @@ mod tests {
             .children()
             .find(|c| c.name() == "error")
             .expect("error element present");
-        assert!(error.has_child("forbidden", "urn:ietf:params:xml:ns:xmpp-stanzas",));
+        assert!(error.has_child("forbidden", STANZAS));
         // §295 MUSTs `type='auth'` for the `<forbidden/>` condition
         // (xeps/xep-0513.xml line 482).
         assert_eq!(error.attr("type"), Some("auth"));
@@ -430,7 +431,7 @@ mod tests {
             .children()
             .find(|c| c.name() == "error")
             .expect("error element present");
-        assert!(error.has_child("not-authorized", "urn:ietf:params:xml:ns:xmpp-stanzas"));
+        assert!(error.has_child("not-authorized", STANZAS));
         // RFC 6120 §8.3.3.13: not-authorized travels with type='auth'.
         assert_eq!(error.attr("type"), Some("auth"));
     }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mentions_permissions.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mentions_permissions.rs
@@ -41,6 +41,7 @@ use waddle_xmpp::xep::{
     NS_EXPLICIT_MENTIONS,
 };
 use xmpp_parsers::iq::Iq;
+use xmpp_parsers::minidom::Element;
 
 /// Detects an XEP-0513 §295 query (`<iq type='get'><query
 /// xmlns='urn:xmpp:mentions:0'/></iq>` targeting the MUC service
@@ -124,9 +125,9 @@ pub(super) async fn handle_mentions_permissions_iq(
     }
 }
 
-/// Build a `<iq type='error'/>` for a §295 query that ECHOES the
-/// original `<query xmlns='urn:xmpp:mentions:0'/>` payload, per the
-/// XEP-0513 §295 error example (xeps/xep-0513.xml §"permissions"):
+/// Build a `<iq type='error'/>` for a §295 query that echoes the
+/// `<query xmlns='urn:xmpp:mentions:0'/>` payload. The canonical
+/// §295 example (xeps/xep-0513.xml §"permissions") shows:
 ///
 /// ```xml
 /// <iq from='room@…' to='user@…' type='error' id='…'>
@@ -137,35 +138,41 @@ pub(super) async fn handle_mentions_permissions_iq(
 /// </iq>
 /// ```
 ///
-/// RFC 6120 §8.3.1 makes the original-payload echo a MAY for stanza
-/// errors in general; XEP-0513 §295 elevates it for this IQ by
-/// showing it in the canonical example. Echoing the empty
-/// `<query xmlns='urn:xmpp:mentions:0'/>` (not the full request
-/// payload — RFC says "the original XML which caused the error" but
-/// the §295 example uses the empty-query shape) makes the response
-/// recognisable as the §295 error contract.
+/// The XEP is Experimental and the example is illustrative — RFC 6120
+/// §8.3.1 leaves the original-payload echo as a MAY and does not
+/// constrain `<query/>` vs `<error/>` element order. We follow the
+/// canonical example as defence-in-depth shape conformance: clients
+/// that match the response by name+ns work either way, but emitting
+/// the query-before-error order mirrors what an XEP author would
+/// reasonably expect to see on the wire.
+///
+/// Built directly with `Element::builder` (rather than via
+/// `Iq::Error` + the xso-derived serializer) because the latter
+/// emits `<error/>` before `<payload/>` based on struct field order.
 fn mentions_permissions_error(
     iq: &Iq,
     response_from: Option<&str>,
     response_to: Option<&str>,
     error: xmpp_parsers::stanza_error::StanzaError,
 ) -> String {
-    let response = Iq::Error {
-        from: response_from.and_then(|s| jid::Jid::from_str(s).ok()),
-        to: response_to.and_then(|s| jid::Jid::from_str(s).ok()),
-        id: iq.id().to_string(),
-        error,
-        payload: Some(
-            xmpp_parsers::minidom::Element::builder("query", NS_EXPLICIT_MENTIONS).build(),
-        ),
-    };
-    iq_to_xml(response)
+    let mut envelope = Element::builder("iq", waddle_xmpp::ns::JABBER_CLIENT)
+        .attr(minidom::rxml::xml_ncname!("id").to_owned(), iq.id())
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "error");
+    if let Some(from) = response_from {
+        envelope = envelope.attr(minidom::rxml::xml_ncname!("from").to_owned(), from);
+    }
+    if let Some(to) = response_to {
+        envelope = envelope.attr(minidom::rxml::xml_ncname!("to").to_owned(), to);
+    }
+    let mut envelope = envelope.build();
+    envelope.append_child(Element::builder("query", NS_EXPLICIT_MENTIONS).build());
+    envelope.append_child(Element::from(error));
+    element_to_xml(envelope)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use xmpp_parsers::minidom::Element;
 
     fn iq_get(payload: Element, to: Option<&str>) -> Iq {
         Iq::Get {
@@ -289,9 +296,12 @@ mod tests {
     /// XEP-0513 §295 error example (xep-0513.xml §"permissions"):
     /// the response carries an empty `<query
     /// xmlns='urn:xmpp:mentions:0'/>` echoed alongside `<error/>`.
-    /// RFC 6120 §8.3.1 makes payload-echo on errors a MAY; the XEP
-    /// elevates it for this IQ by showing it in the canonical
-    /// example, so the handler MUST emit it.
+    /// RFC 6120 §8.3.1 leaves payload-echo as a MAY and does not
+    /// constrain element order; XEP §295 is Experimental and the
+    /// example is illustrative. The handler still emits the echo in
+    /// query-before-error order as defence-in-depth shape conformance
+    /// — a client that pattern-matches positionally against the XEP
+    /// example will accept the response either way.
     #[test]
     fn mentions_permissions_error_envelope_echoes_empty_query() {
         let xml = build_error(feature_not_implemented_iq_error("read-only"));
@@ -317,6 +327,20 @@ mod tests {
             "feature-not-implemented",
             "urn:ietf:params:xml:ns:xmpp-stanzas",
         ));
+
+        // Positional pin: §295 example shows `<query/>` BEFORE
+        // `<error/>`. The xmpp_parsers `Iq::Error` serializer emits
+        // the struct fields in declaration order (error first), so
+        // building the envelope directly via `Element::builder` +
+        // `append_child` (as `mentions_permissions_error` does) is
+        // load-bearing for matching the canonical example.
+        let names: Vec<&str> = parsed.children().map(Element::name).collect();
+        assert_eq!(
+            names,
+            vec!["query", "error"],
+            "§295 example shows <query/> before <error/>; \
+             child order must match the canonical wire shape"
+        );
     }
 
     // The full happy GET → §303 form path is exercised end-to-end by

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mentions_permissions.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mentions_permissions.rs
@@ -38,16 +38,19 @@ use jid::FullJid;
 use std::str::FromStr;
 use waddle_xmpp::xep::{
     build_mentions_permissions_query, is_mentions_permissions_query, MentionsPermissions,
+    NS_EXPLICIT_MENTIONS,
 };
 use xmpp_parsers::iq::Iq;
 
 /// Detects an XEP-0513 §295 query (`<iq type='get'><query
-/// xmlns='urn:xmpp:mentions:0'/></iq>` targeting a MUC room JID) or a
-/// matching `type='set'` (so the dispatcher routes both to this
-/// handler — the set arm returns `<feature-not-implemented/>` rather
-/// than falling through to the generic "Unhandled IQ" path which
-/// would also return feature-not-implemented but without the typed
-/// `<query/>` echo §295 implies).
+/// xmlns='urn:xmpp:mentions:0'/></iq>` targeting the MUC service
+/// domain) or a matching `type='set'` — the dispatcher routes both
+/// arms to this handler so the set path produces a §295-shaped error
+/// rather than fall through to the generic "Unhandled IQ" path. The
+/// handler then enforces the §295 addressing contract (bare room
+/// JID) and emits typed `<bad-request/>` for service-JID or
+/// full-JID targets, so the client gets a precise diagnostic
+/// instead of a vague feature-not-implemented.
 pub(super) fn is_mentions_permissions_iq(iq: &Iq, muc_domain: &str) -> bool {
     let payload = match iq {
         Iq::Get { payload, .. } | Iq::Set { payload, .. } => payload,
@@ -67,16 +70,30 @@ pub(super) async fn handle_mentions_permissions_iq(
     response_to: Option<&str>,
 ) -> Vec<String> {
     let Some(target) = iq.to() else {
-        return vec![build_iq_error_xml_typed(
-            iq.id(),
+        return vec![mentions_permissions_error(
+            iq,
             response_from,
             response_to,
             bad_request_iq_error("Mentions-permissions query requires a room JID in 'to'."),
         )];
     };
+    if target.node().is_none() {
+        // `to='muc.example'` — service-JID target. §295 is per-room;
+        // there is no service-wide permissions form.
+        return vec![mentions_permissions_error(
+            iq,
+            response_from,
+            response_to,
+            bad_request_iq_error(
+                "Mentions-permissions query 'to' must be a bare room JID, not the MUC service.",
+            ),
+        )];
+    }
     if target.resource().is_some() {
-        return vec![build_iq_error_xml_typed(
-            iq.id(),
+        // `to='room@muc.example/nick'` — full-JID target. Permissions
+        // are room-scoped, not occupant-scoped.
+        return vec![mentions_permissions_error(
+            iq,
             response_from,
             response_to,
             bad_request_iq_error("Mentions-permissions query 'to' must be a bare room JID."),
@@ -95,8 +112,8 @@ pub(super) async fn handle_mentions_permissions_iq(
             };
             vec![iq_to_xml(response)]
         }
-        Iq::Set { .. } => vec![build_iq_error_xml_typed(
-            iq.id(),
+        Iq::Set { .. } => vec![mentions_permissions_error(
+            iq,
             response_from,
             response_to,
             feature_not_implemented_iq_error(
@@ -107,10 +124,47 @@ pub(super) async fn handle_mentions_permissions_iq(
     }
 }
 
+/// Build a `<iq type='error'/>` for a §295 query that ECHOES the
+/// original `<query xmlns='urn:xmpp:mentions:0'/>` payload, per the
+/// XEP-0513 §295 error example (xeps/xep-0513.xml §"permissions"):
+///
+/// ```xml
+/// <iq from='room@…' to='user@…' type='error' id='…'>
+///   <query xmlns='urn:xmpp:mentions:0'/>
+///   <error type='auth'>
+///     <forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
+///   </error>
+/// </iq>
+/// ```
+///
+/// RFC 6120 §8.3.1 makes the original-payload echo a MAY for stanza
+/// errors in general; XEP-0513 §295 elevates it for this IQ by
+/// showing it in the canonical example. Echoing the empty
+/// `<query xmlns='urn:xmpp:mentions:0'/>` (not the full request
+/// payload — RFC says "the original XML which caused the error" but
+/// the §295 example uses the empty-query shape) makes the response
+/// recognisable as the §295 error contract.
+fn mentions_permissions_error(
+    iq: &Iq,
+    response_from: Option<&str>,
+    response_to: Option<&str>,
+    error: xmpp_parsers::stanza_error::StanzaError,
+) -> String {
+    let response = Iq::Error {
+        from: response_from.and_then(|s| jid::Jid::from_str(s).ok()),
+        to: response_to.and_then(|s| jid::Jid::from_str(s).ok()),
+        id: iq.id().to_string(),
+        error,
+        payload: Some(
+            xmpp_parsers::minidom::Element::builder("query", NS_EXPLICIT_MENTIONS).build(),
+        ),
+    };
+    iq_to_xml(response)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use waddle_xmpp::xep::NS_EXPLICIT_MENTIONS;
     use xmpp_parsers::minidom::Element;
 
     fn iq_get(payload: Element, to: Option<&str>) -> Iq {
@@ -202,4 +256,75 @@ mod tests {
         };
         assert!(!is_mentions_permissions_iq(&error, "muc.example"));
     }
+
+    /// The routing predicate is intentionally permissive on `to`
+    /// (domain + namespace), so the service-JID case
+    /// (`to='muc.example'`) reaches the handler and gets a typed
+    /// `<bad-request/>` rather than falling through. Pinning the
+    /// predicate keeps that contract explicit.
+    #[test]
+    fn is_mentions_permissions_iq_routes_service_jid_for_typed_error() {
+        let iq = iq_get(mentions_payload(), Some("muc.example"));
+        assert!(is_mentions_permissions_iq(&iq, "muc.example"));
+    }
+
+    /// Same rationale for the full-JID case: the predicate routes,
+    /// the handler validates and returns `<bad-request/>`.
+    #[test]
+    fn is_mentions_permissions_iq_routes_full_jid_for_typed_error() {
+        let iq = iq_get(mentions_payload(), Some("team@muc.example/nick"));
+        assert!(is_mentions_permissions_iq(&iq, "muc.example"));
+    }
+
+    fn build_error(stanza_error: xmpp_parsers::stanza_error::StanzaError) -> String {
+        let iq = iq_get(mentions_payload(), Some("team@muc.example"));
+        mentions_permissions_error(
+            &iq,
+            Some("team@muc.example"),
+            Some("user@example.com/resource"),
+            stanza_error,
+        )
+    }
+
+    /// XEP-0513 §295 error example (xep-0513.xml §"permissions"):
+    /// the response carries an empty `<query
+    /// xmlns='urn:xmpp:mentions:0'/>` echoed alongside `<error/>`.
+    /// RFC 6120 §8.3.1 makes payload-echo on errors a MAY; the XEP
+    /// elevates it for this IQ by showing it in the canonical
+    /// example, so the handler MUST emit it.
+    #[test]
+    fn mentions_permissions_error_envelope_echoes_empty_query() {
+        let xml = build_error(feature_not_implemented_iq_error("read-only"));
+        let parsed = Element::from_str(&xml).expect("error iq parses");
+        assert_eq!(parsed.name(), "iq");
+        assert_eq!(parsed.attr("type"), Some("error"));
+        // §295 echo: the `<query xmlns='urn:xmpp:mentions:0'/>` child
+        // appears as a sibling of `<error/>`.
+        let query = parsed
+            .get_child("query", NS_EXPLICIT_MENTIONS)
+            .expect("§295 error envelope echoes <query/>");
+        assert_eq!(
+            query.children().count(),
+            0,
+            "echoed query MUST be empty per the §295 error example"
+        );
+        // `<error/>` carries the typed condition.
+        let error = parsed
+            .children()
+            .find(|c| c.name() == "error")
+            .expect("error element present");
+        assert!(error.has_child(
+            "feature-not-implemented",
+            "urn:ietf:params:xml:ns:xmpp-stanzas",
+        ));
+    }
+
+    // The full happy GET → §303 form path is exercised end-to-end by
+    // the WebSocket integration test
+    // `mentions_permissions_iq_get_returns_303_form` in
+    // `tests/xep0513_mentions_ws.rs`; that test stands up a real
+    // `WebSocketState`, which a unit test cannot do without
+    // duplicating the entire bootstrap. The unit tests above pin the
+    // routing predicate and the error-envelope shape, which is the
+    // logic actually under the handler's local control.
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mentions_permissions.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mentions_permissions.rs
@@ -75,14 +75,21 @@ use xmpp_parsers::iq::Iq;
 use xmpp_parsers::minidom::Element;
 
 /// Detects an XEP-0513 §295 query (`<iq type='get'><query
-/// xmlns='urn:xmpp:mentions:0'/></iq>` targeting the MUC service
-/// domain) or a matching `type='set'` — the dispatcher routes both
-/// arms to this handler so the set path produces a §295-shaped error
-/// rather than fall through to the generic "Unhandled IQ" path. The
-/// handler then enforces the §295 addressing contract (bare room
-/// JID) and emits typed `<bad-request/>` for service-JID or
-/// full-JID targets, so the client gets a precise diagnostic
-/// instead of a vague feature-not-implemented.
+/// xmlns='urn:xmpp:mentions:0'/></iq>`) destined for this server's
+/// MUC service. Routing covers:
+///
+/// - `to` present and `to.domain() == muc_domain` → the canonical
+///   addressing (bare room JID, service JID, or full room JID — the
+///   handler validates the bare-room-JID shape and returns
+///   `<bad-request/>` for service-JID or full-JID).
+/// - `to` absent → an addressing-error case the handler answers with
+///   a precise `<bad-request/>` instead of the dispatcher's generic
+///   feature-not-implemented (Copilot review on PR #747).
+///
+/// IQs with `to` pointing at *another* MUC domain are NOT routed
+/// here — they belong to the inter-server forwarder, not this
+/// handler. Both Get and Set arms route here so the SET path can
+/// emit a §295-shaped error envelope.
 pub(super) fn is_mentions_permissions_iq(iq: &Iq, muc_domain: &str) -> bool {
     let payload = match iq {
         Iq::Get { payload, .. } | Iq::Set { payload, .. } => payload,
@@ -91,7 +98,10 @@ pub(super) fn is_mentions_permissions_iq(iq: &Iq, muc_domain: &str) -> bool {
     if !is_mentions_permissions_query(payload) {
         return false;
     }
-    iq.to().is_some_and(|to| to.domain().as_str() == muc_domain)
+    match iq.to() {
+        None => true,
+        Some(to) => to.domain().as_str() == muc_domain,
+    }
 }
 
 pub(super) async fn handle_mentions_permissions_iq(
@@ -115,6 +125,11 @@ pub(super) async fn handle_mentions_permissions_iq(
             not_authorized_iq_error("Authentication required."),
         )];
     }
+    // `is_mentions_permissions_iq` accepts both "to present and on
+    // muc_domain" and "to absent". The missing-`to` case is a
+    // §295 addressing error — answer it precisely with bad-request
+    // rather than letting it fall through to the dispatcher's
+    // feature-not-implemented (Copilot review on PR #747).
     let Some(target) = iq.to() else {
         return vec![mentions_permissions_error(
             iq,
@@ -279,9 +294,14 @@ mod tests {
     }
 
     #[test]
-    fn is_mentions_permissions_iq_rejects_missing_to() {
+    fn is_mentions_permissions_iq_routes_missing_to_for_typed_error() {
+        // Missing-`to` is a §295 addressing error; the routing
+        // predicate accepts it so the handler can return a precise
+        // `<bad-request/>` rather than letting the IQ fall through
+        // to the dispatcher's generic feature-not-implemented
+        // (Copilot review on PR #747).
         let iq = iq_get(mentions_payload(), None);
-        assert!(!is_mentions_permissions_iq(&iq, "muc.example"));
+        assert!(is_mentions_permissions_iq(&iq, "muc.example"));
     }
 
     #[test]

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mentions_permissions.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mentions_permissions.rs
@@ -20,12 +20,18 @@
 //!
 //! ## Authorization
 //!
-//! GET is open to any participant: §303 says the form is what
+//! GET is open to any **authenticated** requester (including
+//! non-occupants of the target room): §303 says the form is what
 //! "receiving entities SHOULD refer to when deciding whether to notify
 //! the user", so non-occupants legitimately need to read it (e.g. a
 //! client deciding whether to render `@channel` autocompletion). We
-//! still require the target to be a bare room JID — full-JID
-//! addressing here is non-sensical and likely a client bug.
+//! do gate on session-binding — an unauthenticated WebSocket
+//! connection that has not completed SASL bind receives
+//! `<not-authorized/>` so the §303 policy isn't readable pre-auth
+//! (mirrors the auth posture of sibling room-targeted handlers like
+//! `pin_query`). We still require the target to be a bare room JID
+//! — full-JID and service-JID addressing here are non-sensical and
+//! likely client bugs.
 //!
 //! SET is unconditionally `<forbidden type='auth'/>` per XEP-0513
 //! §295's MUST text: *"If the user is not an owner, a `<forbidden/>`
@@ -91,10 +97,24 @@ pub(super) fn is_mentions_permissions_iq(iq: &Iq, muc_domain: &str) -> bool {
 pub(super) async fn handle_mentions_permissions_iq(
     iq: &Iq,
     _state: &WebSocketState,
-    _sender_jid: Option<&FullJid>,
+    sender_jid: Option<&FullJid>,
     response_from: Option<&str>,
     response_to: Option<&str>,
 ) -> Vec<String> {
+    if sender_jid.is_none() {
+        // Pre-auth WebSocket connection (no resource bound yet). The
+        // §303 form is server-default and stateless, but the
+        // auth-posture across sibling room-targeted handlers
+        // (e.g. `pin_query`) is "no bound JID → not-authorized"; we
+        // mirror that so §295 doesn't become a pre-auth probe
+        // surface.
+        return vec![mentions_permissions_error(
+            iq,
+            response_from,
+            response_to,
+            not_authorized_iq_error("Authentication required."),
+        )];
+    }
     let Some(target) = iq.to() else {
         return vec![mentions_permissions_error(
             iq,
@@ -235,10 +255,11 @@ mod tests {
 
     #[test]
     fn is_mentions_permissions_iq_accepts_set_for_routing() {
-        // §295 owner-submitted form. Even though we'll answer with
-        // feature-not-implemented, the dispatcher MUST route the IQ
-        // here so we own the wire shape (echoed `<query/>` in the
-        // error response is consistent with §295's error example).
+        // §295 owner-submitted form. We answer with
+        // `<forbidden type='auth'/>` per §295's MUST text — the
+        // dispatcher MUST route the IQ here so we own the wire
+        // shape (the echoed `<query/>` in the error response
+        // matches §295's canonical error example, xep-0513.xml:476).
         let iq = iq_set(mentions_payload(), Some("team@muc.example"));
         assert!(is_mentions_permissions_iq(&iq, "muc.example"));
     }
@@ -372,6 +393,26 @@ mod tests {
             "§295 example shows <query/> before <error/>; \
              child order must match the canonical wire shape"
         );
+    }
+
+    /// Pre-auth path: when the WebSocket connection has not yet
+    /// completed SASL bind, `sender_jid` is `None`. The handler MUST
+    /// respond with `<not-authorized type='auth'/>` rather than
+    /// expose the §303 policy form to an unbound session — mirrors
+    /// the auth posture of sibling room-targeted handlers
+    /// (`pin_query` does the same). This test pins the shape of the
+    /// error envelope produced on that path.
+    #[test]
+    fn mentions_permissions_unauthenticated_error_envelope_is_not_authorized() {
+        let xml = build_error(not_authorized_iq_error("Authentication required."));
+        let parsed = Element::from_str(&xml).expect("error iq parses");
+        let error = parsed
+            .children()
+            .find(|c| c.name() == "error")
+            .expect("error element present");
+        assert!(error.has_child("not-authorized", "urn:ietf:params:xml:ns:xmpp-stanzas"));
+        // RFC 6120 §8.3.3.13: not-authorized travels with type='auth'.
+        assert_eq!(error.attr("type"), Some("auth"));
     }
 
     // The full happy GET → §303 form path is exercised end-to-end by

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mentions_permissions.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mentions_permissions.rs
@@ -27,11 +27,15 @@
 //! still require the target to be a bare room JID — full-JID
 //! addressing here is non-sensical and likely a client bug.
 //!
-//! SET is unconditionally `<feature-not-implemented/>`. XEP §295
-//! reserves `<forbidden/>` for "the user is not an owner", but Waddle
-//! exposes no owner-driven config mutation for the §303 form; the
-//! policy is a server-internal hardcoded default. Returning forbidden
-//! would lie about *why* the set failed.
+//! SET is unconditionally `<forbidden type='auth'/>` per XEP-0513
+//! §295's MUST text: *"If the user is not an owner, a `<forbidden/>`
+//! error MUST be returned."* Waddle's §303 policy is a server-wide
+//! hardcoded default — no user has the "owner of the §295 form"
+//! privilege, so every caller is a non-owner and the MUST applies
+//! uniformly. Returning `<feature-not-implemented/>` would be more
+//! honest about the *cause* (the SET surface is not implemented),
+//! but would diverge from the XEP's literal wire-shape requirement;
+//! conformance with the spec text wins.
 //!
 //! ## No room-existence gate
 //!
@@ -138,8 +142,14 @@ pub(super) async fn handle_mentions_permissions_iq(
             iq,
             response_from,
             response_to,
-            feature_not_implemented_iq_error(
-                "Mentions permissions are server-hardcoded; the §303 form is read-only.",
+            // XEP-0513 §295: "If the user is not an owner, a
+            // `<forbidden/>` error MUST be returned." Waddle's
+            // server-wide hardcoded policy means no caller can be
+            // an owner of the §303 form; every set is from a
+            // non-owner and MUST receive `<forbidden type='auth'/>`.
+            forbidden_iq_error(
+                "Mentions permissions are server-managed; only owners may submit \
+                 the §303 form, and no caller is an owner of this form.",
             ),
         )],
         _ => unreachable!("is_mentions_permissions_iq filters to Get/Set"),
@@ -325,7 +335,7 @@ mod tests {
     /// example will accept the response either way.
     #[test]
     fn mentions_permissions_error_envelope_echoes_empty_query() {
-        let xml = build_error(feature_not_implemented_iq_error("read-only"));
+        let xml = build_error(forbidden_iq_error("non-owner"));
         let parsed = Element::from_str(&xml).expect("error iq parses");
         assert_eq!(parsed.name(), "iq");
         assert_eq!(parsed.attr("type"), Some("error"));
@@ -344,10 +354,10 @@ mod tests {
             .children()
             .find(|c| c.name() == "error")
             .expect("error element present");
-        assert!(error.has_child(
-            "feature-not-implemented",
-            "urn:ietf:params:xml:ns:xmpp-stanzas",
-        ));
+        assert!(error.has_child("forbidden", "urn:ietf:params:xml:ns:xmpp-stanzas",));
+        // §295 MUSTs `type='auth'` for the `<forbidden/>` condition
+        // (xeps/xep-0513.xml line 482).
+        assert_eq!(error.attr("type"), Some("auth"));
 
         // Positional pin: §295 example shows `<query/>` BEFORE
         // `<error/>`. The xmpp_parsers `Iq::Error` serializer emits

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
@@ -79,6 +79,7 @@ pub(crate) mod errors;
 mod extension_forms;
 mod jingle_muji_gate;
 mod last_activity;
+mod mentions_permissions;
 mod misc;
 mod muc_admin;
 mod muc_owner_config;
@@ -111,6 +112,7 @@ use extension_forms::{
     EXTENSION_COMMAND_FORM_TYPE, EXTENSION_ROUTE_FORM_TYPE,
 };
 use last_activity::handle_last_activity_iq;
+use mentions_permissions::{handle_mentions_permissions_iq, is_mentions_permissions_iq};
 use muc_owner_config::apply_muc_owner_config;
 use muc_owner_moderation::handle_muc_owner_and_moderation_iq;
 pub(crate) use permissions::managed_channel_permission_allowed;
@@ -380,6 +382,17 @@ pub async fn handle_iq_with_conn_state(
     if is_pin_query_iq(&iq, muc_domain) {
         return handle_pin_query_iq(&iq, state, phase.bound_jid(), response_from, response_to)
             .await;
+    }
+
+    if is_mentions_permissions_iq(&iq, muc_domain) {
+        return handle_mentions_permissions_iq(
+            &iq,
+            state,
+            phase.bound_jid(),
+            response_from,
+            response_to,
+        )
+        .await;
     }
 
     let muc_owner_or_moderation =

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
@@ -175,8 +175,8 @@ use vcard_private::{handle_private_storage_iq, handle_vcard_iq};
 pub(super) use super::super::build_iq_error_xml_typed;
 
 use super::super::{
-    build_iq_result_xml, destroy_room_actor, get_room_actor, iq_to_xml, is_muc_room_jid,
-    stanza_to_xml, WebSocketState,
+    build_iq_result_xml, destroy_room_actor, element_to_xml, get_room_actor, iq_to_xml,
+    is_muc_room_jid, stanza_to_xml, WebSocketState,
 };
 use super::presence::{
     get_managed_channel_for_room, send_current_presence_from_user_to_user,

--- a/server/crates/waddle-server/tests/xep0513_mentions_ws.rs
+++ b/server/crates/waddle-server/tests/xep0513_mentions_ws.rs
@@ -4,7 +4,7 @@ mod ws_common;
 
 use std::str::FromStr;
 use tokio::sync::Mutex;
-use waddle_xmpp::xep::{DataForm, Field, FormType, IntoElement, NS_EXPLICIT_MENTIONS};
+use waddle_xmpp::xep::{DataForm, Field, FieldType, FormType, IntoElement, NS_EXPLICIT_MENTIONS};
 use waddle_xmpp::Stanza;
 use ws_common::{TestServer, WsXmppClient};
 use xmpp_parsers::iq::Iq;
@@ -285,15 +285,22 @@ async fn mentions_permissions_iq_set_returns_forbidden() {
     let _occupant_id = join_room(&mut client, &room).await;
 
     let iq_id = "perm-set-1";
-    // Build the §295 owner-submit payload via the typed
-    // `DataForm` builder so the wire shape is whatever a
-    // conformant XEP-0004 serializer would emit — and the test
-    // exercises the *real* form-validation path on the server.
+    // Build a §295 owner-submit payload via the typed `DataForm`
+    // builder so the wire shape comes from a conformant XEP-0004
+    // serializer rather than hand-rolled `format!` XML. The handler
+    // currently returns `<forbidden/>` per §295 MUST without parsing
+    // the body, so this test only exercises the routing + error
+    // envelope shape — but a future owner-write-path slice would
+    // parse this same payload, so the field types are §303-shaped
+    // (`mentions#count` text-single, `mentions#individual` and
+    // `mentions#channel` list-single) to stay forward-compatible.
     let submit_form = DataForm::new(FormType::Submit)
         .add_field(Field::form_type(NS_EXPLICIT_MENTIONS))
         .add_field(Field::text_single("mentions#count", "1"))
-        .add_field(Field::text_single("mentions#individual", "participants"))
-        .add_field(Field::text_single("mentions#channel", "moderators"))
+        .add_field(
+            Field::new("mentions#individual", FieldType::ListSingle).with_value("participants"),
+        )
+        .add_field(Field::new("mentions#channel", FieldType::ListSingle).with_value("moderators"))
         .into_element();
     let mut submit_query = Element::builder("query", NS_EXPLICIT_MENTIONS).build();
     submit_query.append_child(submit_form);

--- a/server/crates/waddle-server/tests/xep0513_mentions_ws.rs
+++ b/server/crates/waddle-server/tests/xep0513_mentions_ws.rs
@@ -4,7 +4,10 @@ mod ws_common;
 
 use std::str::FromStr;
 use tokio::sync::Mutex;
+use waddle_xmpp::xep::{DataForm, Field, FormType, IntoElement, NS_EXPLICIT_MENTIONS};
+use waddle_xmpp::Stanza;
 use ws_common::{TestServer, WsXmppClient};
+use xmpp_parsers::iq::Iq;
 use xmpp_parsers::minidom::Element;
 
 const DOMAIN: &str = "localhost";
@@ -49,6 +52,52 @@ fn find_occupant_id(element: &Element) -> Option<String> {
         return element.attr("id").map(str::to_string);
     }
     element.children().find_map(find_occupant_id)
+}
+
+/// Serialize a typed `Stanza` to its wire-form XML string. Mirrors
+/// the helper in xep0503_spaces_ws.rs so XEP wire-shape tests follow
+/// the same "typed builder + serializer" pattern (CLAUDE.md XML
+/// generation hard rule — never construct XML with `format!`).
+fn stanza_to_xml(stanza: &Stanza) -> String {
+    let mut buf = Vec::new();
+    stanza
+        .to_element()
+        .write_to(&mut buf)
+        .expect("serializing stanza to Vec<u8> should not fail");
+    String::from_utf8(buf).expect("xmpp_parsers serializes valid UTF-8")
+}
+
+/// Build a typed `<iq type='get'>` envelope addressed at `to` with
+/// the given `payload` and return its wire-form XML string. Used by
+/// the §295 GET / bad-request tests so the test author doesn't have
+/// to hand-roll attribute quoting or namespace declarations.
+fn iq_get_xml(id: &str, to: &str, payload: Element) -> String {
+    let iq = Iq::Get {
+        from: None,
+        to: Some(to.parse().expect("valid iq destination JID")),
+        id: id.to_string(),
+        payload,
+    };
+    stanza_to_xml(&Stanza::Iq(Box::new(iq)))
+}
+
+/// Build a typed `<iq type='set'>` envelope addressed at `to` with
+/// the given `payload` and return its wire-form XML string. Used by
+/// the §295 owner-submit test.
+fn iq_set_xml(id: &str, to: &str, payload: Element) -> String {
+    let iq = Iq::Set {
+        from: None,
+        to: Some(to.parse().expect("valid iq destination JID")),
+        id: id.to_string(),
+        payload,
+    };
+    stanza_to_xml(&Stanza::Iq(Box::new(iq)))
+}
+
+/// Build the §295 `<query xmlns='urn:xmpp:mentions:0'/>` empty
+/// payload via the typed `Element::builder`.
+fn mentions_query_empty() -> Element {
+    Element::builder("query", NS_EXPLICIT_MENTIONS).build()
 }
 
 #[tokio::test]
@@ -177,9 +226,7 @@ async fn mentions_permissions_iq_get_returns_303_form() {
 
     let iq_id = "perm-get-1";
     client
-        .send(&format!(
-            r#"<iq type="get" to="{room}" id="{iq_id}"><query xmlns="urn:xmpp:mentions:0"/></iq>"#
-        ))
+        .send(&iq_get_xml(iq_id, &room, mentions_query_empty()))
         .await
         .expect("send §295 query");
 
@@ -238,19 +285,20 @@ async fn mentions_permissions_iq_set_returns_forbidden() {
     let _occupant_id = join_room(&mut client, &room).await;
 
     let iq_id = "perm-set-1";
+    // Build the §295 owner-submit payload via the typed
+    // `DataForm` builder so the wire shape is whatever a
+    // conformant XEP-0004 serializer would emit — and the test
+    // exercises the *real* form-validation path on the server.
+    let submit_form = DataForm::new(FormType::Submit)
+        .add_field(Field::form_type(NS_EXPLICIT_MENTIONS))
+        .add_field(Field::text_single("mentions#count", "1"))
+        .add_field(Field::text_single("mentions#individual", "participants"))
+        .add_field(Field::text_single("mentions#channel", "moderators"))
+        .into_element();
+    let mut submit_query = Element::builder("query", NS_EXPLICIT_MENTIONS).build();
+    submit_query.append_child(submit_form);
     client
-        .send(&format!(
-            r#"<iq type="set" to="{room}" id="{iq_id}">
-                <query xmlns="urn:xmpp:mentions:0">
-                    <x xmlns="jabber:x:data" type="submit">
-                        <field var="FORM_TYPE"><value>urn:xmpp:mentions:0</value></field>
-                        <field var="mentions#count"><value>1</value></field>
-                        <field var="mentions#individual"><value>participants</value></field>
-                        <field var="mentions#channel"><value>moderators</value></field>
-                    </x>
-                </query>
-            </iq>"#
-        ))
+        .send(&iq_set_xml(iq_id, &room, submit_query))
         .await
         .expect("send §295 set");
 
@@ -298,10 +346,9 @@ async fn mentions_permissions_iq_full_jid_target_returns_bad_request_with_query_
     let _occupant_id = join_room(&mut client, &room).await;
 
     let iq_id = "perm-fjid-1";
+    let full_jid = format!("{room}/{occupant_nick}");
     client
-        .send(&format!(
-            r#"<iq type="get" to="{room}/{occupant_nick}" id="{iq_id}"><query xmlns="urn:xmpp:mentions:0"/></iq>"#
-        ))
+        .send(&iq_get_xml(iq_id, &full_jid, mentions_query_empty()))
         .await
         .expect("send §295 query to full JID");
 
@@ -347,9 +394,7 @@ async fn mentions_permissions_iq_get_returns_form_for_never_instantiated_room() 
 
     let iq_id = "perm-virgin-1";
     client
-        .send(&format!(
-            r#"<iq type="get" to="{room}" id="{iq_id}"><query xmlns="urn:xmpp:mentions:0"/></iq>"#
-        ))
+        .send(&iq_get_xml(iq_id, &room, mentions_query_empty()))
         .await
         .expect("send §295 query to never-joined room");
 
@@ -386,10 +431,9 @@ async fn mentions_permissions_iq_service_jid_target_returns_bad_request_with_que
     // service-domain stanza and does not require room membership;
     // the handler rejects it on addressing alone.
     let iq_id = "perm-svc-1";
+    let service_jid = format!("muc.{DOMAIN}");
     client
-        .send(&format!(
-            r#"<iq type="get" to="muc.{DOMAIN}" id="{iq_id}"><query xmlns="urn:xmpp:mentions:0"/></iq>"#
-        ))
+        .send(&iq_get_xml(iq_id, &service_jid, mentions_query_empty()))
         .await
         .expect("send §295 query to service JID");
 

--- a/server/crates/waddle-server/tests/xep0513_mentions_ws.rs
+++ b/server/crates/waddle-server/tests/xep0513_mentions_ws.rs
@@ -372,6 +372,8 @@ async fn mentions_permissions_iq_full_jid_target_returns_bad_request_with_query_
         frame.contains("urn:xmpp:mentions:0"),
         "error envelope must echo the §295 <query/>, got: {frame}"
     );
+
+    let _ = client.close().await;
 }
 
 /// XEP-0513 §292 explicitly permits queries to "rooms which do not
@@ -456,4 +458,6 @@ async fn mentions_permissions_iq_service_jid_target_returns_bad_request_with_que
         frame.contains("urn:xmpp:mentions:0"),
         "error envelope must echo the §295 <query/>, got: {frame}"
     );
+
+    let _ = client.close().await;
 }

--- a/server/crates/waddle-server/tests/xep0513_mentions_ws.rs
+++ b/server/crates/waddle-server/tests/xep0513_mentions_ws.rs
@@ -323,6 +323,52 @@ async fn mentions_permissions_iq_full_jid_target_returns_bad_request_with_query_
     );
 }
 
+/// XEP-0513 §292 explicitly permits queries to "rooms which do not
+/// have permissions set, and/or do not advertise support for them".
+/// Waddle's §295 form is a server-wide hardcoded policy, so the
+/// handler returns the §303 form for a never-instantiated room JID
+/// — useful so clients can render mention UI before joining. This
+/// test pins that intentional divergence from sibling handlers like
+/// pin_query (which return item-not-found for unknown room JIDs);
+/// a regression to "lookup room first" would make joinless mention
+/// UI rendering impossible.
+#[tokio::test]
+async fn mentions_permissions_iq_get_returns_form_for_never_instantiated_room() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+    // Unique room JID that was never joined → not in the room
+    // registry. Real production room actors are created on first
+    // join; this name has never been touched.
+    let room = format!("perms-virgin-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+
+    let iq_id = "perm-virgin-1";
+    client
+        .send(&format!(
+            r#"<iq type="get" to="{room}" id="{iq_id}"><query xmlns="urn:xmpp:mentions:0"/></iq>"#
+        ))
+        .await
+        .expect("send §295 query to never-joined room");
+
+    let frame = client
+        .recv_matching(|frame| {
+            frame.contains(&format!("id='{iq_id}'")) || frame.contains(&format!("id=\"{iq_id}\""))
+        })
+        .await
+        .expect("§295 response for never-joined room");
+
+    assert!(
+        frame.contains("type='result'") || frame.contains("type=\"result\""),
+        "expected iq result for never-instantiated room — §292 contemplates \
+         queries to rooms without permissions set, got: {frame}"
+    );
+    assert!(
+        frame.contains("mentions#count"),
+        "form must include mentions#count for any room JID, got: {frame}"
+    );
+
+    let _ = client.close().await;
+}
+
 /// XEP-0513 §295: the service JID itself (`to='muc.example'`, no
 /// node) is not a room and has no §303 permissions form. Returns
 /// `<bad-request/>` with the same `<query/>` echo as the full-JID

--- a/server/crates/waddle-server/tests/xep0513_mentions_ws.rs
+++ b/server/crates/waddle-server/tests/xep0513_mentions_ws.rs
@@ -4,7 +4,10 @@ mod ws_common;
 
 use std::str::FromStr;
 use tokio::sync::Mutex;
-use waddle_xmpp::xep::{DataForm, Field, FieldType, FormType, IntoElement, NS_EXPLICIT_MENTIONS};
+use waddle_xmpp::xep::{
+    DataForm, Field, FieldType, FormType, IntoElement, MentionsPermission, FIELD_MENTIONS_CHANNEL,
+    FIELD_MENTIONS_COUNT, FIELD_MENTIONS_INDIVIDUAL, NS_EXPLICIT_MENTIONS,
+};
 use waddle_xmpp::Stanza;
 use ws_common::{TestServer, WsXmppClient};
 use xmpp_parsers::iq::Iq;
@@ -296,11 +299,15 @@ async fn mentions_permissions_iq_set_returns_forbidden() {
     // `mentions#channel` list-single) to stay forward-compatible.
     let submit_form = DataForm::new(FormType::Submit)
         .add_field(Field::form_type(NS_EXPLICIT_MENTIONS))
-        .add_field(Field::text_single("mentions#count", "1"))
+        .add_field(Field::text_single(FIELD_MENTIONS_COUNT, "1"))
         .add_field(
-            Field::new("mentions#individual", FieldType::ListSingle).with_value("participants"),
+            Field::new(FIELD_MENTIONS_INDIVIDUAL, FieldType::ListSingle)
+                .with_value(MentionsPermission::Participants.as_wire()),
         )
-        .add_field(Field::new("mentions#channel", FieldType::ListSingle).with_value("moderators"))
+        .add_field(
+            Field::new(FIELD_MENTIONS_CHANNEL, FieldType::ListSingle)
+                .with_value(MentionsPermission::Moderators.as_wire()),
+        )
         .into_element();
     let mut submit_query = Element::builder("query", NS_EXPLICIT_MENTIONS).build();
     submit_query.append_child(submit_form);

--- a/server/crates/waddle-server/tests/xep0513_mentions_ws.rs
+++ b/server/crates/waddle-server/tests/xep0513_mentions_ws.rs
@@ -331,12 +331,10 @@ async fn mentions_permissions_iq_full_jid_target_returns_bad_request_with_query_
 async fn mentions_permissions_iq_service_jid_target_returns_bad_request_with_query_echo() {
     let _guard = TEST_SERIAL.lock().await;
     let (_server, mut client) = setup().await;
-    let _ = join_room(
-        &mut client,
-        &format!("perms-svc-warmup-{}@muc.{DOMAIN}", uuid::Uuid::new_v4()),
-    )
-    .await;
 
+    // No warmup-room join here: §295 to the service JID is a
+    // service-domain stanza and does not require room membership;
+    // the handler rejects it on addressing alone.
     let iq_id = "perm-svc-1";
     client
         .send(&format!(

--- a/server/crates/waddle-server/tests/xep0513_mentions_ws.rs
+++ b/server/crates/waddle-server/tests/xep0513_mentions_ws.rs
@@ -162,3 +162,114 @@ async fn muc_jid_mention_returns_bad_request_when_occupant_ids_supported() {
 
     let _ = client.close().await;
 }
+
+/// XEP-0513 §295: `<iq type='get' to='room@muc.…'><query
+/// xmlns='urn:xmpp:mentions:0'/></iq>` returns a §303 result form
+/// carrying the server-internal policy (`mentions#count = 5`,
+/// `mentions#individual = participants`, `mentions#channel =
+/// moderators`).
+#[tokio::test]
+async fn mentions_permissions_iq_get_returns_303_form() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+    let room = format!("perms-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    let _occupant_id = join_room(&mut client, &room).await;
+
+    let iq_id = "perm-get-1";
+    client
+        .send(&format!(
+            r#"<iq type="get" to="{room}" id="{iq_id}"><query xmlns="urn:xmpp:mentions:0"/></iq>"#
+        ))
+        .await
+        .expect("send §295 query");
+
+    let frame = client
+        .recv_matching(|frame| {
+            frame.contains(&format!("id='{iq_id}'")) || frame.contains(&format!("id=\"{iq_id}\""))
+        })
+        .await
+        .expect("§295 result");
+
+    assert!(
+        frame.contains("type='result'") || frame.contains("type=\"result\""),
+        "expected iq result, got: {frame}"
+    );
+    assert!(
+        frame.contains("urn:xmpp:mentions:0"),
+        "result must echo the namespace, got: {frame}"
+    );
+    assert!(
+        frame.contains("jabber:x:data"),
+        "result must carry a data form, got: {frame}"
+    );
+    assert!(
+        frame.contains("FORM_TYPE"),
+        "form must include FORM_TYPE, got: {frame}"
+    );
+    assert!(
+        frame.contains("mentions#count"),
+        "form must include mentions#count, got: {frame}"
+    );
+    assert!(
+        frame.contains("mentions#individual"),
+        "form must include mentions#individual, got: {frame}"
+    );
+    assert!(
+        frame.contains("mentions#channel"),
+        "form must include mentions#channel (channel mentions advertised), got: {frame}"
+    );
+    assert!(
+        frame.contains("moderators"),
+        "channel field value must default to `moderators`, got: {frame}"
+    );
+
+    let _ = client.close().await;
+}
+
+/// XEP-0513 §295: `<iq type='set'/>` to the room with the same query
+/// payload returns `<feature-not-implemented/>` — Waddle uses a
+/// hardcoded server policy and exposes no owner-config write path for
+/// the §303 form. (XEP §295 reserves `<forbidden/>` for "not an
+/// owner"; returning that here would misrepresent the cause.)
+#[tokio::test]
+async fn mentions_permissions_iq_set_returns_feature_not_implemented() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+    let room = format!("perms-set-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    let _occupant_id = join_room(&mut client, &room).await;
+
+    let iq_id = "perm-set-1";
+    client
+        .send(&format!(
+            r#"<iq type="set" to="{room}" id="{iq_id}">
+                <query xmlns="urn:xmpp:mentions:0">
+                    <x xmlns="jabber:x:data" type="submit">
+                        <field var="FORM_TYPE"><value>urn:xmpp:mentions:0</value></field>
+                        <field var="mentions#count"><value>1</value></field>
+                        <field var="mentions#individual"><value>participants</value></field>
+                        <field var="mentions#channel"><value>moderators</value></field>
+                    </x>
+                </query>
+            </iq>"#
+        ))
+        .await
+        .expect("send §295 set");
+
+    let frame = client
+        .recv_matching(|frame| {
+            frame.contains(&format!("id='{iq_id}'")) || frame.contains(&format!("id=\"{iq_id}\""))
+        })
+        .await
+        .expect("§295 set response");
+
+    assert!(
+        frame.contains("type='error'") || frame.contains("type=\"error\""),
+        "expected iq error, got: {frame}"
+    );
+    assert!(
+        frame.contains("<feature-not-implemented"),
+        "expected feature-not-implemented condition, got: {frame}"
+    );
+
+    let _ = client.close().await;
+}

--- a/server/crates/waddle-server/tests/xep0513_mentions_ws.rs
+++ b/server/crates/waddle-server/tests/xep0513_mentions_ws.rs
@@ -270,6 +270,98 @@ async fn mentions_permissions_iq_set_returns_feature_not_implemented() {
         frame.contains("<feature-not-implemented"),
         "expected feature-not-implemented condition, got: {frame}"
     );
+    // §295 error example echoes the `<query xmlns='urn:xmpp:mentions:0'/>`
+    // alongside `<error/>` — verify the response contract matches.
+    assert!(
+        frame.contains("urn:xmpp:mentions:0"),
+        "error envelope must echo §295 <query/>, got: {frame}"
+    );
 
     let _ = client.close().await;
+}
+
+/// XEP-0513 §295: bare-room-JID is mandatory in `to`. A full-JID
+/// target (`room@muc.…/nick`) is room-meaningless because permissions
+/// are room-scoped; the handler returns `<bad-request/>` with the
+/// `<query xmlns='urn:xmpp:mentions:0'/>` echoed alongside `<error/>`
+/// per the §295 error example.
+#[tokio::test]
+async fn mentions_permissions_iq_full_jid_target_returns_bad_request_with_query_echo() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+    let room = format!("perms-fjid-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    let occupant_nick = USERNAME;
+    let _occupant_id = join_room(&mut client, &room).await;
+
+    let iq_id = "perm-fjid-1";
+    client
+        .send(&format!(
+            r#"<iq type="get" to="{room}/{occupant_nick}" id="{iq_id}"><query xmlns="urn:xmpp:mentions:0"/></iq>"#
+        ))
+        .await
+        .expect("send §295 query to full JID");
+
+    let frame = client
+        .recv_matching(|frame| {
+            frame.contains(&format!("id='{iq_id}'")) || frame.contains(&format!("id=\"{iq_id}\""))
+        })
+        .await
+        .expect("§295 bad-request response");
+
+    assert!(
+        frame.contains("type='error'") || frame.contains("type=\"error\""),
+        "expected iq error, got: {frame}"
+    );
+    assert!(
+        frame.contains("<bad-request"),
+        "expected bad-request, got: {frame}"
+    );
+    // §295 error example echoes the `<query xmlns='urn:xmpp:mentions:0'/>`.
+    assert!(
+        frame.contains("urn:xmpp:mentions:0"),
+        "error envelope must echo the §295 <query/>, got: {frame}"
+    );
+}
+
+/// XEP-0513 §295: the service JID itself (`to='muc.example'`, no
+/// node) is not a room and has no §303 permissions form. Returns
+/// `<bad-request/>` with the same `<query/>` echo as the full-JID
+/// rejection above.
+#[tokio::test]
+async fn mentions_permissions_iq_service_jid_target_returns_bad_request_with_query_echo() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+    let _ = join_room(
+        &mut client,
+        &format!("perms-svc-warmup-{}@muc.{DOMAIN}", uuid::Uuid::new_v4()),
+    )
+    .await;
+
+    let iq_id = "perm-svc-1";
+    client
+        .send(&format!(
+            r#"<iq type="get" to="muc.{DOMAIN}" id="{iq_id}"><query xmlns="urn:xmpp:mentions:0"/></iq>"#
+        ))
+        .await
+        .expect("send §295 query to service JID");
+
+    let frame = client
+        .recv_matching(|frame| {
+            frame.contains(&format!("id='{iq_id}'")) || frame.contains(&format!("id=\"{iq_id}\""))
+        })
+        .await
+        .expect("§295 service-JID response");
+
+    assert!(
+        frame.contains("type='error'") || frame.contains("type=\"error\""),
+        "expected iq error, got: {frame}"
+    );
+    assert!(
+        frame.contains("<bad-request"),
+        "expected bad-request, got: {frame}"
+    );
+    assert!(
+        frame.contains("urn:xmpp:mentions:0"),
+        "error envelope must echo the §295 <query/>, got: {frame}"
+    );
 }

--- a/server/crates/waddle-server/tests/xep0513_mentions_ws.rs
+++ b/server/crates/waddle-server/tests/xep0513_mentions_ws.rs
@@ -226,13 +226,12 @@ async fn mentions_permissions_iq_get_returns_303_form() {
     let _ = client.close().await;
 }
 
-/// XEP-0513 §295: `<iq type='set'/>` to the room with the same query
-/// payload returns `<feature-not-implemented/>` — Waddle uses a
-/// hardcoded server policy and exposes no owner-config write path for
-/// the §303 form. (XEP §295 reserves `<forbidden/>` for "not an
-/// owner"; returning that here would misrepresent the cause.)
+/// XEP-0513 §295: `<iq type='set'/>` to the room MUST return
+/// `<forbidden type='auth'/>` for non-owners (xep-0513.xml:475).
+/// Waddle's hardcoded server policy means no caller can be an owner
+/// of the §303 form, so the MUST applies uniformly.
 #[tokio::test]
-async fn mentions_permissions_iq_set_returns_feature_not_implemented() {
+async fn mentions_permissions_iq_set_returns_forbidden() {
     let _guard = TEST_SERIAL.lock().await;
     let (_server, mut client) = setup().await;
     let room = format!("perms-set-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
@@ -267,8 +266,13 @@ async fn mentions_permissions_iq_set_returns_feature_not_implemented() {
         "expected iq error, got: {frame}"
     );
     assert!(
-        frame.contains("<feature-not-implemented"),
-        "expected feature-not-implemented condition, got: {frame}"
+        frame.contains("<forbidden"),
+        "expected <forbidden/> condition per §295 MUST, got: {frame}"
+    );
+    // §295 line 482: `<error type='auth'>`.
+    assert!(
+        frame.contains("type='auth'") || frame.contains("type=\"auth\""),
+        "<forbidden/> must travel with type='auth' per §295, got: {frame}"
     );
     // §295 error example echoes the `<query xmlns='urn:xmpp:mentions:0'/>`
     // alongside `<error/>` — verify the response contract matches.

--- a/server/crates/waddle-xmpp-core/src/disco/info.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info.rs
@@ -528,7 +528,9 @@ pub fn muc_room_features(
         // surface so the form on the wire matches the policy in
         // effect. Per CLAUDE.md XEP conformance hard rule, advertising
         // the namespaces only becomes safe once the IQ form is
-        // implemented — see `iq/mentions_permissions.rs` for the
+        // implemented — see
+        // `server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mentions_permissions.rs`
+        // (the §295 IQ handler in the `waddle-server` crate) for the
         // handler that backs these advertised features.
         //
         // TODO(#525-followup): §303 also SHOULDs that the

--- a/server/crates/waddle-xmpp-core/src/disco/info.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info.rs
@@ -524,11 +524,12 @@ pub fn muc_room_features(
         // `#channel` is advertised). Slices 3a/3b enforce a hardcoded
         // server policy (`mentions#count = 5`, `mentions#individual
         // = participants`, `mentions#channel = moderators`) at T0
-        // candidate classification; slice 3c (PR #747) wires the §295
-        // IQ surface so the form on the wire matches the policy in
+        // candidate classification; slice 3c wires the §295 IQ
+        // surface so the form on the wire matches the policy in
         // effect. Per CLAUDE.md XEP conformance hard rule, advertising
         // the namespaces only becomes safe once the IQ form is
-        // implemented — both arrive together in this commit.
+        // implemented — see `iq/mentions_permissions.rs` for the
+        // handler that backs these advertised features.
         Feature::explicit_mentions(),
         Feature::channel_mentions(),
         Feature::muc_nonanonymous(),

--- a/server/crates/waddle-xmpp-core/src/disco/info.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info.rs
@@ -530,6 +530,13 @@ pub fn muc_room_features(
         // the namespaces only becomes safe once the IQ form is
         // implemented — see `iq/mentions_permissions.rs` for the
         // handler that backs these advertised features.
+        //
+        // TODO(#525-followup): §303 also SHOULDs that the
+        // `mentions#*` form fields be mirrored into the room's
+        // `muc#roominfo` extension form (xeps/xep-0513.xml line 303).
+        // Deferred — adding fields to muc#roominfo is a separate
+        // slice; the dedicated §295 IQ form is the primary discovery
+        // path and is conformant on its own.
         Feature::explicit_mentions(),
         Feature::channel_mentions(),
         Feature::muc_nonanonymous(),

--- a/server/crates/waddle-xmpp-core/src/disco/info.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info.rs
@@ -520,20 +520,17 @@ pub fn muc_room_features(
         // `urn:xmpp:mentions:0#channel` is binding — once advertised,
         // the room's `<query xmlns='urn:xmpp:mentions:0'/>` IQ MUST
         // return a form with `mentions#count` + `mentions#individual`
-        // (always required) and the `mentions#channel` field (if and
-        // only if `#channel` is advertised). PR #738 (slice 3a)
-        // enforces a hardcoded `mentions#channel = moderators` policy
-        // at T0 candidate classification but does NOT yet expose the
-        // §295 IQ surface. To preserve XEP conformance — and per
-        // CLAUDE.md "if Waddle advertises an official XEP feature...
-        // the wire shape and behavior MUST conform to that XEP
-        // exactly" — the advert is withdrawn until slice 3c lands
-        // the IQ get/set + per-room form. §292 allows
-        // non-advertisement while still applying server-internal
-        // filtering ("Mentions MAY be sent in rooms which do not
-        // have permissions set, and/or do not advertise support for
-        // them; it is up to receiving entities to determine how to
-        // handle mentions in rooms without configured permissions").
+        // (always required) and `mentions#channel` (if and only if
+        // `#channel` is advertised). Slices 3a/3b enforce a hardcoded
+        // server policy (`mentions#count = 5`, `mentions#individual
+        // = participants`, `mentions#channel = moderators`) at T0
+        // candidate classification; slice 3c (PR #747) wires the §295
+        // IQ surface so the form on the wire matches the policy in
+        // effect. Per CLAUDE.md XEP conformance hard rule, advertising
+        // the namespaces only becomes safe once the IQ form is
+        // implemented — both arrive together in this commit.
+        Feature::explicit_mentions(),
+        Feature::channel_mentions(),
         Feature::muc_nonanonymous(),
     ];
 

--- a/server/crates/waddle-xmpp/src/xep/exports.rs
+++ b/server/crates/waddle-xmpp/src/xep/exports.rs
@@ -397,12 +397,14 @@ pub use super::xep0490::{
 };
 
 pub use super::xep0513::{
-    build_mention_element, build_mentions_elements, extract_explicit_mentions,
-    has_explicit_mentions, is_mention_element, mention_target_count,
-    mention_target_count_from_parts, mentions_exceed_threshold,
-    mentions_exceed_threshold_from_parts, parse_mention_element, set_explicit_mentions,
-    strip_explicit_mentions, ExplicitMention, ExplicitMentionCarrier, ExplicitMentions,
-    CHANNEL_MENTION, DEFAULT_MENTIONS_COUNT, NS_EXPLICIT_MENTIONS,
+    build_mention_element, build_mentions_elements, build_mentions_permissions_query,
+    extract_explicit_mentions, has_explicit_mentions, is_mention_element,
+    is_mentions_permissions_query, mention_target_count, mention_target_count_from_parts,
+    mentions_exceed_threshold, mentions_exceed_threshold_from_parts, parse_mention_element,
+    set_explicit_mentions, strip_explicit_mentions, ExplicitMention, ExplicitMentionCarrier,
+    ExplicitMentions, MentionsPermission, MentionsPermissions, CHANNEL_MENTION,
+    DEFAULT_MENTIONS_COUNT, FIELD_MENTIONS_CHANNEL, FIELD_MENTIONS_COUNT,
+    FIELD_MENTIONS_INDIVIDUAL, NS_EXPLICIT_MENTIONS,
 };
 
 pub use super::xep0508::{

--- a/server/crates/waddle-xmpp/src/xep/xep0513.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0513.rs
@@ -384,6 +384,177 @@ pub fn strip_explicit_mentions(msg: &mut Message) {
         .retain(|elem| elem.ns() != NS_EXPLICIT_MENTIONS);
 }
 
+// ── §295 / §303: Permissions Query ──────────────────────────────────
+
+/// XEP-0513 §303 form field `var` for the per-message mention-count
+/// threshold. Always required when permissions are advertised.
+pub const FIELD_MENTIONS_COUNT: &str = "mentions#count";
+
+/// XEP-0513 §303 form field `var` for the individual-mention policy.
+/// Always required when permissions are advertised.
+pub const FIELD_MENTIONS_INDIVIDUAL: &str = "mentions#individual";
+
+/// XEP-0513 §303 form field `var` for the channel-mention policy.
+/// Present iff the room advertises `urn:xmpp:mentions:0#channel`.
+pub const FIELD_MENTIONS_CHANNEL: &str = "mentions#channel";
+
+/// XEP-0513 §303 policy enum for a `list-single` permissions field.
+///
+/// Three exhaustive values map directly to the spec's option labels.
+/// Modelled as an enum (not a string) so call sites and callers across
+/// the typed-payload boundary can match exhaustively rather than
+/// shuffling `&str` literals (typed-payloads hard rule, CLAUDE.md).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MentionsPermission {
+    /// Any room participant may use this mention type.
+    Participants,
+    /// Only moderators may use this mention type.
+    Moderators,
+    /// No participant may use this mention type.
+    Nobody,
+}
+
+impl MentionsPermission {
+    /// Wire value emitted in the data-form `<value/>` child and in
+    /// `<option>` values.
+    pub fn as_wire(self) -> &'static str {
+        match self {
+            Self::Participants => "participants",
+            Self::Moderators => "moderators",
+            Self::Nobody => "none",
+        }
+    }
+
+    /// Human-readable label emitted in `<option label='…'/>`.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Participants => "Participants",
+            Self::Moderators => "Moderators Only",
+            Self::Nobody => "Nobody",
+        }
+    }
+}
+
+/// Typed view of a XEP-0513 §303 permissions form. Only the fields
+/// Waddle currently advertises (`mentions#count`, `mentions#individual`,
+/// `mentions#channel`) are modelled; the optional `#space` / `#server`
+/// / `#associations` / `#hats` fields are deliberately omitted until
+/// the matching disco feature is advertised (#525 — "Do not advertise
+/// `#space`, `#server`, `#associations`, or `#hats` until recipient
+/// resolution and permissions are implemented for them").
+///
+/// The `channel` field is `Option<…>` because §303 ties its presence
+/// to the `…#channel` feature advert: "All other fields are OPTIONAL,
+/// but they MUST be present if and only if the corresponding feature
+/// is advertised in service discovery." A future room that doesn't
+/// advertise channel mentions would carry `channel: None` and we'd
+/// omit the field on the wire.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MentionsPermissions {
+    /// `mentions#count` — XEP-0513 §304 threshold.
+    pub count: u32,
+    /// `mentions#individual` — gate for per-recipient mentions.
+    pub individual: MentionsPermission,
+    /// `mentions#channel` — gate for `urn:xmpp:mentions:0#channel`.
+    /// `None` when the room does not advertise channel mentions; the
+    /// form field is then omitted entirely.
+    pub channel: Option<MentionsPermission>,
+}
+
+impl MentionsPermissions {
+    /// Waddle's server-internal default policy. Mirrors the hardcoded
+    /// gates enforced at T0 candidate classification (PR #738 slice 3a
+    /// and #741 slice 3b): the threshold is the XEP-0513 §301 example
+    /// value (`5`), individual mentions are open to all participants,
+    /// and channel mentions are restricted to moderators.
+    pub fn server_default() -> Self {
+        Self {
+            count: DEFAULT_MENTIONS_COUNT,
+            individual: MentionsPermission::Participants,
+            channel: Some(MentionsPermission::Moderators),
+        }
+    }
+}
+
+/// Returns `true` when `elem` is the root of a XEP-0513 §295
+/// permissions query — a `<query xmlns='urn:xmpp:mentions:0'/>`.
+pub fn is_mentions_permissions_query(elem: &Element) -> bool {
+    elem.name() == "query" && elem.ns() == NS_EXPLICIT_MENTIONS
+}
+
+/// Build the §303 result payload — `<query xmlns='urn:xmpp:mentions:0'>`
+/// wrapping a `<x xmlns='jabber:x:data' type='form'>` with the typed
+/// `permissions`. The room's IQ handler wraps this in an `<iq
+/// type='result'/>` envelope.
+///
+/// Field shape per §303:
+///
+/// - `FORM_TYPE` hidden = `urn:xmpp:mentions:0`,
+/// - `mentions#count` text-single, required, value = `permissions.count`,
+/// - `mentions#individual` list-single, required, value =
+///   `permissions.individual`, options = participants/moderators/none,
+/// - `mentions#channel` list-single, required, value =
+///   `permissions.channel` (only when `permissions.channel.is_some()`).
+pub fn build_mentions_permissions_query(permissions: &MentionsPermissions) -> Element {
+    use crate::xep::xep0004::{DataForm, Field, FieldOption, FieldType, FormType, IntoElement};
+
+    let policy_options = || {
+        vec![
+            FieldOption::with_label(
+                MentionsPermission::Participants.label(),
+                MentionsPermission::Participants.as_wire(),
+            ),
+            FieldOption::with_label(
+                MentionsPermission::Moderators.label(),
+                MentionsPermission::Moderators.as_wire(),
+            ),
+            FieldOption::with_label(
+                MentionsPermission::Nobody.label(),
+                MentionsPermission::Nobody.as_wire(),
+            ),
+        ]
+    };
+
+    let mut form = DataForm::new(FormType::Form)
+        .with_title("Permissions for Explicit Mentions")
+        .add_instructions(concat!(
+            "Complete this form to inform entities about who can mention whom. ",
+            "The count is the maximum number of mentions allowed per message. ",
+            "For each mention type supported, the users allowed to use the type ",
+            "may be set to all participants, moderators only, or nobody."
+        ))
+        .add_field(Field::form_type(NS_EXPLICIT_MENTIONS))
+        .add_field(
+            Field::text_single(FIELD_MENTIONS_COUNT, permissions.count.to_string())
+                .with_label("How many mentions are allowed in a message?")
+                .with_required(),
+        );
+
+    let mut individual = Field::new(FIELD_MENTIONS_INDIVIDUAL, FieldType::ListSingle)
+        .with_label("Who can mention individual users?")
+        .with_required()
+        .with_value(permissions.individual.as_wire());
+    for option in policy_options() {
+        individual = individual.add_option(option);
+    }
+    form = form.add_field(individual);
+
+    if let Some(channel) = permissions.channel {
+        let mut channel_field = Field::new(FIELD_MENTIONS_CHANNEL, FieldType::ListSingle)
+            .with_label("Who can mention rooms?")
+            .with_required()
+            .with_value(channel.as_wire());
+        for option in policy_options() {
+            channel_field = channel_field.add_option(option);
+        }
+        form = form.add_field(channel_field);
+    }
+
+    let mut query = Element::builder("query", NS_EXPLICIT_MENTIONS).build();
+    query.append_child(form.into_element());
+    query
+}
+
 #[cfg(test)]
 mod count_tests {
     use super::*;

--- a/server/crates/waddle-xmpp/src/xep/xep0513.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0513.rs
@@ -496,24 +496,7 @@ pub fn is_mentions_permissions_query(elem: &Element) -> bool {
 /// - `mentions#channel` list-single, required, value =
 ///   `permissions.channel` (only when `permissions.channel.is_some()`).
 pub fn build_mentions_permissions_query(permissions: &MentionsPermissions) -> Element {
-    use crate::xep::xep0004::{DataForm, Field, FieldOption, FieldType, FormType, IntoElement};
-
-    let policy_options = || {
-        vec![
-            FieldOption::with_label(
-                MentionsPermission::Participants.label(),
-                MentionsPermission::Participants.as_wire(),
-            ),
-            FieldOption::with_label(
-                MentionsPermission::Moderators.label(),
-                MentionsPermission::Moderators.as_wire(),
-            ),
-            FieldOption::with_label(
-                MentionsPermission::Nobody.label(),
-                MentionsPermission::Nobody.as_wire(),
-            ),
-        ]
-    };
+    use crate::xep::xep0004::{DataForm, Field, FormType, IntoElement};
 
     let mut form = DataForm::new(FormType::Form)
         .with_title("Permissions for Explicit Mentions")
@@ -530,29 +513,51 @@ pub fn build_mentions_permissions_query(permissions: &MentionsPermissions) -> El
                 .with_required(),
         );
 
-    let mut individual = Field::new(FIELD_MENTIONS_INDIVIDUAL, FieldType::ListSingle)
-        .with_label("Who can mention individual users?")
-        .with_required()
-        .with_value(permissions.individual.as_wire());
-    for option in policy_options() {
-        individual = individual.add_option(option);
-    }
-    form = form.add_field(individual);
+    form = form.add_field(policy_field(
+        FIELD_MENTIONS_INDIVIDUAL,
+        "Who can mention individual users?",
+        permissions.individual,
+    ));
 
     if let Some(channel) = permissions.channel {
-        let mut channel_field = Field::new(FIELD_MENTIONS_CHANNEL, FieldType::ListSingle)
-            .with_label("Who can mention rooms?")
-            .with_required()
-            .with_value(channel.as_wire());
-        for option in policy_options() {
-            channel_field = channel_field.add_option(option);
-        }
-        form = form.add_field(channel_field);
+        form = form.add_field(policy_field(
+            FIELD_MENTIONS_CHANNEL,
+            "Who can mention rooms?",
+            channel,
+        ));
     }
 
     let mut query = Element::builder("query", NS_EXPLICIT_MENTIONS).build();
     query.append_child(form.into_element());
     query
+}
+
+/// Build a §303 `list-single` permissions field — the same shape
+/// reused for `mentions#individual` / `mentions#channel` / (future)
+/// `mentions#space` / `#server` / `#associations` / `#hats`. Single
+/// helper keeps the option set and ordering in lockstep across every
+/// permissions field; if a future XEP-0513 revision adds a fourth
+/// policy value, only one constructor changes.
+fn policy_field(
+    var: &'static str,
+    label: &'static str,
+    value: MentionsPermission,
+) -> crate::xep::xep0004::Field {
+    use crate::xep::xep0004::{Field, FieldOption, FieldType};
+
+    [
+        MentionsPermission::Participants,
+        MentionsPermission::Moderators,
+        MentionsPermission::Nobody,
+    ]
+    .into_iter()
+    .fold(
+        Field::new(var, FieldType::ListSingle)
+            .with_label(label)
+            .with_required()
+            .with_value(value.as_wire()),
+        |field, option| field.add_option(FieldOption::with_label(option.label(), option.as_wire())),
+    )
 }
 
 #[cfg(test)]

--- a/server/crates/waddle-xmpp/tests/xep0513_mentions.rs
+++ b/server/crates/waddle-xmpp/tests/xep0513_mentions.rs
@@ -19,10 +19,14 @@
 use jid::BareJid;
 use minidom::Element;
 use waddle_xmpp::disco::{muc_room_features, Feature};
+use waddle_xmpp::xep::xep0004::NS_DATA_FORMS;
 use waddle_xmpp::xep::xep0513::{
-    build_mention_element, extract_explicit_mentions, has_explicit_mentions, is_mention_element,
+    build_mention_element, build_mentions_permissions_query, extract_explicit_mentions,
+    has_explicit_mentions, is_mention_element, is_mentions_permissions_query,
     parse_mention_element, set_explicit_mentions, strip_explicit_mentions, ExplicitMention,
-    ExplicitMentionCarrier, ExplicitMentions, CHANNEL_MENTION, NS_EXPLICIT_MENTIONS,
+    ExplicitMentionCarrier, ExplicitMentions, MentionsPermission, MentionsPermissions,
+    CHANNEL_MENTION, DEFAULT_MENTIONS_COUNT, FIELD_MENTIONS_CHANNEL, FIELD_MENTIONS_COUNT,
+    FIELD_MENTIONS_INDIVIDUAL, NS_EXPLICIT_MENTIONS,
 };
 use xmpp_parsers::message::Message;
 
@@ -37,7 +41,7 @@ fn xep0513_namespace_constants_match_spec() {
 // ── §"Discovering support" advertisement ────────────────────────────
 
 #[test]
-fn xep0513_muc_rooms_do_not_advertise_mentions_until_iq_form_is_wired() {
+fn xep0513_muc_rooms_advertise_mentions_and_channel_mentions() {
     let mentions = Feature::explicit_mentions();
     let channel = Feature::channel_mentions();
 
@@ -51,36 +55,192 @@ fn xep0513_muc_rooms_do_not_advertise_mentions_until_iq_form_is_wired() {
     // room's `<query xmlns='urn:xmpp:mentions:0'/>` IQ MUST return a
     // form with `mentions#count` + `mentions#individual` (always
     // required) and `mentions#channel` (if and only if `#channel` is
-    // advertised). PR #738 (slice 3a of #525) enforces a hardcoded
-    // `mentions#channel = moderators` policy at T0 candidate
-    // classification but does NOT yet expose the §295 IQ surface — so
-    // the advert is withdrawn until slice 3c wires the IQ form.
-    // §292 permits non-advertisement + server-internal filtering:
-    // "Mentions MAY be sent in rooms which do not have permissions
-    // set, and/or do not advertise support for them; it is up to
-    // receiving entities to determine how to handle mentions in
-    // rooms without configured permissions."
+    // advertised). Slices 3a/3b enforce a hardcoded server policy at
+    // T0 candidate classification; slice 3c (#525) wires the §295 IQ
+    // surface and re-advertises both namespaces — both arrive
+    // together to satisfy CLAUDE.md's XEP conformance hard rule.
+    // The advertisement-set is independent of the muc#roomconfig
+    // axes (persistent / members_only / moderated / forum), so we
+    // pin every combination.
     for persistent in [false, true] {
         for members_only in [false, true] {
             for moderated in [false, true] {
                 for forum in [false, true] {
                     let feats = muc_room_features(persistent, members_only, moderated, forum);
                     assert!(
-                        !feats.iter().any(|f| f == &mentions),
+                        feats.iter().any(|f| f == &mentions),
                         "muc_room_features({persistent}, {members_only}, {moderated}, {forum}) \
-                         MUST NOT advertise `urn:xmpp:mentions:0` until the XEP-0513 §295 \
-                         IQ form is wired (slice 3c)"
+                         MUST advertise `urn:xmpp:mentions:0` — slice 3c wires §295 IQ"
                     );
                     assert!(
-                        !feats.iter().any(|f| f == &channel),
+                        feats.iter().any(|f| f == &channel),
                         "muc_room_features({persistent}, {members_only}, {moderated}, {forum}) \
-                         MUST NOT advertise `urn:xmpp:mentions:0#channel` until §303 \
-                         `mentions#channel` form field is exposed (slice 3c)"
+                         MUST advertise `urn:xmpp:mentions:0#channel` — slice 3c exposes \
+                         §303 `mentions#channel`"
                     );
                 }
             }
         }
     }
+}
+
+// ── §295 / §303: Permissions IQ form ────────────────────────────────
+
+#[test]
+fn xep0513_mentions_permissions_query_recogniser_pins_name_and_ns() {
+    let canonical = Element::builder("query", NS_EXPLICIT_MENTIONS).build();
+    assert!(is_mentions_permissions_query(&canonical));
+
+    // §295 IQ payload uses element name `query` (not `permissions`,
+    // not `mentions`) — pin both axes so a constructor or namespace
+    // typo can't silently mis-route.
+    let wrong_ns = Element::builder("query", "urn:xmpp:mentions:1").build();
+    assert!(!is_mentions_permissions_query(&wrong_ns));
+
+    let wrong_name = Element::builder("permissions", NS_EXPLICIT_MENTIONS).build();
+    assert!(!is_mentions_permissions_query(&wrong_name));
+
+    // The `<mention>` payload from §3 lives in the same namespace —
+    // make sure the §295 recogniser does NOT match a `<mention>` so
+    // an IQ carrying a stray `<mention/>` can't be answered as a
+    // permissions query.
+    let mention = Element::builder("mention", NS_EXPLICIT_MENTIONS).build();
+    assert!(!is_mentions_permissions_query(&mention));
+}
+
+#[test]
+fn xep0513_default_permissions_match_server_policy() {
+    let policy = MentionsPermissions::server_default();
+    // §301 example value for the count threshold; mirrored in the
+    // T0 classification gate from slice 3b (PR #741).
+    assert_eq!(policy.count, DEFAULT_MENTIONS_COUNT);
+    assert_eq!(policy.count, 5);
+    // Slice 3a (PR #738) hardcodes `mentions#channel = moderators`.
+    assert_eq!(policy.channel, Some(MentionsPermission::Moderators));
+    // Individual mentions are open to participants — there is no
+    // per-recipient sender gate at T0 today.
+    assert_eq!(policy.individual, MentionsPermission::Participants);
+}
+
+#[test]
+fn xep0513_permissions_form_matches_spec_shape() {
+    let policy = MentionsPermissions::server_default();
+    let query = build_mentions_permissions_query(&policy);
+
+    // §303: payload is `<query xmlns='urn:xmpp:mentions:0'>` wrapping
+    // a `<x xmlns='jabber:x:data' type='form'/>`.
+    assert_eq!(query.name(), "query");
+    assert_eq!(query.ns(), NS_EXPLICIT_MENTIONS);
+    let form = query
+        .get_child("x", NS_DATA_FORMS)
+        .expect("§303 form is a jabber:x:data child of <query/>");
+    assert_eq!(
+        form.attr("type"),
+        Some("form"),
+        "§303 form `type` MUST be `form` (server publishing config to client)"
+    );
+
+    // FORM_TYPE hidden field with NS value — required by XEP-0068 /
+    // §303 form pinning so submit payloads round-trip the type.
+    let form_type_field = form
+        .children()
+        .filter(|c| c.is("field", NS_DATA_FORMS))
+        .find(|c| c.attr("var") == Some("FORM_TYPE"))
+        .expect("FORM_TYPE field is present");
+    assert_eq!(form_type_field.attr("type"), Some("hidden"));
+    let form_type_value = form_type_field
+        .get_child("value", NS_DATA_FORMS)
+        .expect("FORM_TYPE has a value child")
+        .text();
+    assert_eq!(form_type_value, NS_EXPLICIT_MENTIONS);
+
+    // Required fields — §303: "the `mentions#count` and
+    // `mentions#individual` fields MUST be present at minimum."
+    for var in [FIELD_MENTIONS_COUNT, FIELD_MENTIONS_INDIVIDUAL] {
+        let field = form
+            .children()
+            .filter(|c| c.is("field", NS_DATA_FORMS))
+            .find(|c| c.attr("var") == Some(var))
+            .unwrap_or_else(|| panic!("§303: required field `{var}` is present"));
+        assert!(
+            field.has_child("required", NS_DATA_FORMS),
+            "§303: required field `{var}` carries `<required/>`"
+        );
+    }
+
+    // count field value = DEFAULT_MENTIONS_COUNT (5) — must be the
+    // text-single representation of the §301 example, otherwise
+    // a recipient that lies dormant in the room with no per-room
+    // override would compute a different threshold than the server.
+    let count_value = form
+        .children()
+        .filter(|c| c.is("field", NS_DATA_FORMS))
+        .find(|c| c.attr("var") == Some(FIELD_MENTIONS_COUNT))
+        .and_then(|f| f.get_child("value", NS_DATA_FORMS))
+        .map(Element::text)
+        .expect("mentions#count carries a <value/>");
+    assert_eq!(count_value, DEFAULT_MENTIONS_COUNT.to_string());
+
+    // channel field — present iff policy.channel.is_some(); shape is
+    // list-single with exactly the three §303 options
+    // (participants/moderators/none) and its `<value/>` matches the
+    // policy.
+    let channel_field = form
+        .children()
+        .filter(|c| c.is("field", NS_DATA_FORMS))
+        .find(|c| c.attr("var") == Some(FIELD_MENTIONS_CHANNEL))
+        .expect("§303: `mentions#channel` MUST be present when `#channel` is advertised");
+    assert_eq!(channel_field.attr("type"), Some("list-single"));
+    assert!(channel_field.has_child("required", NS_DATA_FORMS));
+    let channel_value = channel_field
+        .get_child("value", NS_DATA_FORMS)
+        .map(Element::text)
+        .expect("mentions#channel carries a <value/>");
+    assert_eq!(channel_value, MentionsPermission::Moderators.as_wire());
+    let option_values: Vec<String> = channel_field
+        .children()
+        .filter(|c| c.is("option", NS_DATA_FORMS))
+        .filter_map(|o| o.get_child("value", NS_DATA_FORMS).map(Element::text))
+        .collect();
+    assert_eq!(
+        option_values,
+        vec![
+            MentionsPermission::Participants.as_wire(),
+            MentionsPermission::Moderators.as_wire(),
+            MentionsPermission::Nobody.as_wire(),
+        ],
+        "§303: `mentions#channel` option set must be exactly \
+         {{participants, moderators, none}} in spec order"
+    );
+}
+
+#[test]
+fn xep0513_permissions_form_omits_channel_when_not_advertised() {
+    // §303: "All other fields are OPTIONAL, but they MUST be present
+    // if and only if the corresponding feature is advertised in
+    // service discovery." A hypothetical room that advertised
+    // `urn:xmpp:mentions:0` only (no `#channel`) MUST omit the
+    // `mentions#channel` field. Slice 3c always advertises both, but
+    // the builder MUST honour the typed `None` so the contract holds
+    // for future rooms or test fixtures that disable channel mentions.
+    let policy = MentionsPermissions {
+        count: DEFAULT_MENTIONS_COUNT,
+        individual: MentionsPermission::Participants,
+        channel: None,
+    };
+    let query = build_mentions_permissions_query(&policy);
+    let form = query
+        .get_child("x", NS_DATA_FORMS)
+        .expect("form child present");
+    let channel_present = form
+        .children()
+        .filter(|c| c.is("field", NS_DATA_FORMS))
+        .any(|c| c.attr("var") == Some(FIELD_MENTIONS_CHANNEL));
+    assert!(
+        !channel_present,
+        "§303: `mentions#channel` MUST NOT appear when `urn:xmpp:mentions:0#channel` \
+         is not advertised"
+    );
 }
 
 // ── §3 wire shape ────────────────────────────────────────────────────

--- a/server/crates/waddle-xmpp/tests/xep0513_mentions.rs
+++ b/server/crates/waddle-xmpp/tests/xep0513_mentions.rs
@@ -178,7 +178,9 @@ fn xep0513_permissions_form_matches_spec_shape() {
             .children()
             .filter(|c| c.is("field", NS_DATA_FORMS))
             .find(|c| c.attr("var") == Some(var))
-            .unwrap_or_else(|| panic!("§303: required field `{var}` is present"));
+            .unwrap_or_else(|| {
+                panic!("§303: required field `{var}` is missing from the permissions form")
+            });
         assert!(
             field.has_child("required", NS_DATA_FORMS),
             "§303: required field `{var}` carries `<required/>`"

--- a/server/crates/waddle-xmpp/tests/xep0513_mentions.rs
+++ b/server/crates/waddle-xmpp/tests/xep0513_mentions.rs
@@ -109,6 +109,23 @@ fn xep0513_mentions_permissions_query_recogniser_pins_name_and_ns() {
 }
 
 #[test]
+fn xep0513_mention_permission_wire_values_and_labels_match_spec() {
+    // §303 form definition: option values are `participants`,
+    // `moderators`, `none`; the matching labels are `Participants`,
+    // `Moderators Only`, `Nobody`. Pin both — a single-character
+    // drift on the wire would silently desync the form's `<value/>`
+    // from the option `<value/>` and clients would reject the
+    // submission.
+    assert_eq!(MentionsPermission::Participants.as_wire(), "participants");
+    assert_eq!(MentionsPermission::Moderators.as_wire(), "moderators");
+    assert_eq!(MentionsPermission::Nobody.as_wire(), "none");
+
+    assert_eq!(MentionsPermission::Participants.label(), "Participants");
+    assert_eq!(MentionsPermission::Moderators.label(), "Moderators Only");
+    assert_eq!(MentionsPermission::Nobody.label(), "Nobody");
+}
+
+#[test]
 fn xep0513_default_permissions_match_server_policy() {
     let policy = MentionsPermissions::server_default();
     // §301 example value for the count threshold; mirrored in the


### PR DESCRIPTION
## Parent

#525 — `feat(notifications): enforce XEP-0513 and XEP-0372 mention policy for push` (slice 3c)

Builds on:
- #738 (slice 3a) — `mentions#channel = moderators` policy gate at T0 candidate classification
- #741 (slice 3b) — `mentions#count` threshold (default 5)

## Why this slice

Slices 3a/3b enforce the XEP-0513 server policy at T0 candidate classification while the `urn:xmpp:mentions:0` disco features were deliberately withdrawn — XEP-0513 §292 permits non-advertisement + server-internal filtering, but CLAUDE.md's XEP conformance hard rule says: "If Waddle advertises an official XEP feature… the wire shape and behavior MUST conform to that XEP exactly."

This slice wires the XEP-0513 §295 room-permissions IQ surface so the feature advert and the wire shape ship together.

## What this PR does

1. **Typed §303 form model** (`waddle-xmpp/src/xep/xep0513.rs`):
   - `MentionsPermission` enum (`Participants` / `Moderators` / `Nobody`) — exhaustive over the §303 `list-single` value set.
   - `MentionsPermissions` struct carrying `count: u32`, `individual: MentionsPermission`, `channel: Option<MentionsPermission>`. Optional `channel` field honours §303 ("MUST be present if and only if the corresponding feature is advertised").
   - `MentionsPermissions::server_default()` returns Waddle's hardcoded policy (`count = 5`, `individual = participants`, `channel = Some(moderators)`).
   - `is_mentions_permissions_query` + `build_mentions_permissions_query` predicate/builder pair.
   - `policy_field` helper keeps option order + labels in lockstep across `mentions#individual` / `mentions#channel` / (future) `#space` / `#server` / `#associations` / `#hats`.

2. **§295 IQ handler** (`waddle-server/.../iq/mentions_permissions.rs`):
   - GET returns the §303 result form built from `MentionsPermissions::server_default()`.
   - SET returns `<forbidden type='auth'/>` per §295 line 475 MUST text (`"If the user is not an owner, a <forbidden/> error MUST be returned."`). Waddle's hardcoded policy means no caller can be an owner, so the MUST applies uniformly.
   - Pre-auth WebSocket sessions (no bound JID) receive `<not-authorized/>` — mirrors the auth posture of sibling room-targeted handlers.
   - Service-JID (`to='muc.example'`, no node) and full-JID (`to='room@muc.example/nick'`) targets rejected with typed `<bad-request/>`.
   - Every error response echoes an empty `<query xmlns='urn:xmpp:mentions:0'/>` before `<error/>` (mirrors the §295 canonical example; built directly via `Element::builder` to control child order since `xmpp_parsers::Iq::Error` serializes fields in declaration order).
   - Deliberately does NOT gate on room-existence — the §303 form is server-wide, identical for every room, and §292 explicitly contemplates queries to rooms without permissions set.

3. **Re-advertise** `Feature::explicit_mentions()` and `Feature::channel_mentions()` in `muc_room_features` (`waddle-xmpp-core/src/disco/info.rs`).

4. **Tests** (XEP custom test-suite hard rule):
   - Flipped `xep0513_muc_rooms_do_not_advertise_mentions_until_iq_form_is_wired` → asserts advertised across all 16 room-config permutations.
   - New custom XEP tests: namespace pinning, query recogniser shape, default policy values, full §303 form shape (FORM_TYPE hidden field, required markers, option set order, channel-field gating on `Option::None`), wire-value + label pinning for every `MentionsPermission` variant.
   - New handler unit tests: routing predicate covers GET/SET/result/error + service-JID + full-JID; `mentions_permissions_error_envelope_echoes_empty_query` pins both the echo presence AND the query-before-error positional order; `mentions_permissions_unauthenticated_error_envelope_is_not_authorized` pins the pre-auth posture.
   - New WS integration tests: GET → §303 form, SET → `<forbidden type='auth'/>` + echo, full-JID → bad-request + echo, service-JID → bad-request + echo, never-instantiated room → form (intentional divergence from `pin_query`).
   - WS test request IQs all flow through typed `xmpp_parsers::Iq` + `Stanza::Iq(Box::new(iq))` builders (`iq_get_xml` / `iq_set_xml` helpers) per CLAUDE.md XML-generation hard rule — including the SET submit payload via typed `DataForm`/`Field`.

5. **No T0/T1 logic changes.** The classifier still uses the hardcoded policy from slices 3a/3b — this PR is purely a wire-surface addition.

## Scope discipline

- `mentions#space` / `#server` / `#associations` / `#hats` — NOT advertised, NOT in the form. Per #525: "Do not advertise … until recipient resolution and permissions are implemented for them."
- `muc#roominfo` extension form integration — deferred with a TODO marker. §303 says fields SHOULD also be advertised there; tracked as #525-followup.
- Owner-driven config mutation — deferred. The hardcoded server policy is intentional for this iteration; SET responds with `<forbidden type='auth'/>` per §295 MUST.

## Adversarial review rounds

Five rounds across XEP-conformance, wire-shape security, code-quality, hostile-client, cross-XEP interop, production-operator, and strict text-by-text §513 reviewers. P0/P1 items fixed:
- `2b454495`: §295 echo missing, service-JID accepted, label pinning gap
- `7be6bd16`: echo positional order (xmpp_parsers serialised `<error/>` first)
- `ae0dbcba`: documented no-room-gate as intentional
- `d8b44bc0`: SET → `<forbidden type='auth'/>` per §295 MUST (previously feature-not-implemented)
- `cc4b6c20`: WS tests use typed Stanza builders, not `format!` raw XML
- This commit: pre-auth `<not-authorized/>` gate, test cleanup, doc accuracy

## Test plan

- [x] `cargo test -p waddle-xmpp --test xep0513_mentions` — 18/18 pass
- [x] `cargo test -p waddle-server --lib mentions_permissions` — 11/11 pass
- [x] `cargo test -p waddle-server --test xep0513_mentions_ws` — 8/8 pass
- [x] `cargo test -p waddle-server --test xmpp_e2e_cue advertised_features_have_cue_xep_coverage` — pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean