### PR TITLE
fix(server): publish XEP-0503 channel bookmarks

### DIFF
--- a/apps/apple/Waddle/App/AppModel.swift
+++ b/apps/apple/Waddle/App/AppModel.swift
@@ -89,6 +89,11 @@ final class AppModel: ObservableObject {
     private var uploadServiceJID: String?
     private var rustClient: RustXmppClient?
     private var xmppEventsTask: Task<Void, Never>?
+    private var isStructureLoadRunning = false
+    private var structureLoadRerunRequested = false
+    private var structureLoadWaiters: [CheckedContinuation<Void, Never>] = []
+    private var structureLoadGeneration = 0
+    private var structureLoadSurfaceError: (title: String, message: String)?
     private var messagesByRoomJID: [String: [ChatTimelineMessage]] = [:]
     private var presenceByRoomJID: [String: [String: ChatPresenceState]] = [:]
     private var hatsByRoomJID: [String: [String: [XMPPPresenceHat]]] = [:]
@@ -1034,72 +1039,136 @@ final class AppModel: ObservableObject {
 
     /// Loads the XEP-0503 spaces topology and member list.
     private func loadRooms() async {
+        if isStructureLoadRunning {
+            structureLoadRerunRequested = true
+            await withCheckedContinuation { continuation in
+                structureLoadWaiters.append(continuation)
+            }
+            return
+        }
+
+        isStructureLoadRunning = true
+        defer {
+            isStructureLoadRunning = false
+            let waiters = structureLoadWaiters
+            structureLoadWaiters.removeAll()
+            waiters.forEach { $0.resume() }
+        }
+
+        repeat {
+            structureLoadRerunRequested = false
+            await performLoadRooms()
+        } while structureLoadRerunRequested
+    }
+
+    private func performLoadRooms() async {
         guard let session, let rustClient else {
             updateChatSurfaceState()
             return
         }
 
+        let loadingSessionID = session.sessionID
+        structureLoadGeneration += 1
+        let loadingGeneration = structureLoadGeneration
         isLoadingStructure = true
         updateChatSurfaceState()
-
-        do {
-            async let xmppTopology = rustClient.discoverTopology()
-            async let loadedMembers = client.listMembers(sessionID: session.sessionID)
-
-            let (topology, loadedMembersValue) = try await (xmppTopology, loadedMembers)
-            dlog(" loadRooms: \(topology.spaces.count) spaces, \(topology.channels.count) rooms, \(loadedMembersValue.count) members")
-
-            spaces = topology.spaces.map { space in
-                SpaceSummary(
-                    id: space.id,
-                    name: space.name,
-                    description: space.description
-                )
+        defer {
+            if structureLoadGeneration == loadingGeneration {
+                isLoadingStructure = false
+                updateChatSurfaceState()
             }
-
-            channels = topology.channels
-                .map { channel in
-                    return ChannelSummary(
-                        id: channel.id,
-                        apiID: parseManagedRoomBareJID(channel.roomJID),
-                        roomJid: channel.roomJID,
-                        name: channel.name,
-                        description: channel.description,
-                        channelType: channel.channelType,
-                        position: channel.position,
-                        spaceID: channel.spaceID
-                    )
-                }
-                .sorted {
-                    ($0.position ?? 0, $0.name.lowercased()) < ($1.position ?? 0, $1.name.lowercased())
-                }
-            members = loadedMembersValue.sorted { $0.username.lowercased() < $1.username.lowercased() }
-
-            if let selectedChannelID,
-               let selectedChannel = channels.first(where: { $0.id == selectedChannelID }) {
-                self.selectedChannelID = selectedChannelID
-                selectedSpaceID = selectedChannel.spaceID
-            } else {
-                self.selectedChannelID = channels.first?.id
-                selectedSpaceID = channels.first?.spaceID ?? spaces.first?.id
-            }
-            spaceName = selectedSpace?.name ?? serverURL.host ?? "Waddle"
-
-            syncChatRooms()
-            syncChatMembers()
-            syncChatMessages()
-            updateChatSurfaceState()
-
-            if let channelID = self.selectedChannelID {
-                await selectChannel(channelID)
-            }
-        } catch {
-            errorMessage = error.localizedDescription
-            chatStore.setSurfaceState(.error(title: "Unable to load channels", message: error.localizedDescription))
         }
 
-        isLoadingStructure = false
+        let topologyResult = await rustClient.discoverTopology()
+        let loadedMembersValue: [MemberSummary]
+        let memberRefreshError: String?
+        do {
+            loadedMembersValue = try await client.listMembers(sessionID: session.sessionID)
+            memberRefreshError = nil
+        } catch {
+            loadedMembersValue = members
+            memberRefreshError = error.localizedDescription
+        }
+        dlog(" loadRooms: \(topologyResult.topology.spaces.count) spaces, \(topologyResult.topology.channels.count) rooms, \(loadedMembersValue.count) members")
+
+        guard self.session?.sessionID == loadingSessionID, self.rustClient === rustClient else {
+            return
+        }
+
+        let discoveredSpaces = topologyResult.topology.spaces.map { space in
+            SpaceSummary(
+                id: space.id,
+                name: space.name,
+                description: space.description
+            )
+        }
+
+        let discoveredChannels = topologyResult.topology.channels
+            .map { channel in
+                return ChannelSummary(
+                    id: channel.id,
+                    apiID: parseManagedRoomBareJID(channel.roomJID),
+                    roomJid: channel.roomJID,
+                    name: channel.name,
+                    description: channel.description,
+                    channelType: channel.channelType,
+                    position: channel.position,
+                    spaceID: channel.spaceID
+                )
+            }
+            .sorted {
+                ($0.position ?? 0, $0.name.lowercased()) < ($1.position ?? 0, $1.name.lowercased())
+            }
+        var loadWarning: String?
+        if let discoveryError = topologyResult.errorDescription {
+            if !spaces.isEmpty || !channels.isEmpty {
+                let message = "Space discovery failed; keeping the current topology."
+                errorMessage = discoveryError
+                loadWarning = message
+                structureLoadSurfaceError = nil
+            } else {
+                errorMessage = discoveryError
+                loadWarning = "Space discovery failed."
+                structureLoadSurfaceError = (
+                    title: "Space discovery failed",
+                    message: "Reconnect to retry loading spaces and channels."
+                )
+                spaces = []
+                channels = []
+            }
+        } else {
+            structureLoadSurfaceError = nil
+            spaces = discoveredSpaces
+            channels = discoveredChannels
+        }
+        if let memberRefreshError {
+            errorMessage = memberRefreshError
+            loadWarning = "Members could not be refreshed: \(memberRefreshError)"
+        }
+        members = loadedMembersValue.sorted { $0.username.lowercased() < $1.username.lowercased() }
+
+        if let selectedChannelID,
+           let selectedChannel = channels.first(where: { $0.id == selectedChannelID }) {
+            self.selectedChannelID = selectedChannelID
+            selectedSpaceID = selectedChannel.spaceID
+        } else {
+            self.selectedChannelID = channels.first?.id
+            selectedSpaceID = channels.first?.spaceID ?? spaces.first?.id
+        }
+        spaceName = selectedSpace?.name ?? serverURL.host ?? "Waddle"
+
+        syncChatRooms()
+        syncChatMembers()
+        syncChatMessages()
         updateChatSurfaceState()
+
+        if let channelID = self.selectedChannelID {
+            await selectChannel(channelID)
+        }
+
+        if let loadWarning {
+            chatStore.setBannerState(.error(message: loadWarning))
+        }
     }
 
     private func joinSelectedChannel() async throws {
@@ -1927,6 +1996,14 @@ final class AppModel: ObservableObject {
             return
         }
 
+        if let structureLoadSurfaceError, channels.isEmpty {
+            chatStore.setSurfaceState(.error(
+                title: structureLoadSurfaceError.title,
+                message: structureLoadSurfaceError.message
+            ))
+            return
+        }
+
         guard !channels.isEmpty || isLoadingStructure else {
             chatStore.setSurfaceState(.empty(title: "Connecting to space", message: "Loading channels…"))
             return
@@ -2033,6 +2110,9 @@ final class AppModel: ObservableObject {
         chatStore.replaceMessages([])
         chatStore.setBannerState(.hidden)
         chatStore.setSurfaceState(.empty(title: "Sign in", message: "Sign in to load the server space and connect to live rooms."))
+        structureLoadGeneration += 1
+        structureLoadSurfaceError = nil
+        isLoadingStructure = false
     }
 
     func handleAppBecameActive() {

--- a/apps/apple/Waddle/App/MobileSlackShellView.swift
+++ b/apps/apple/Waddle/App/MobileSlackShellView.swift
@@ -226,8 +226,8 @@ private struct MobileConversationTab: View {
                 WaddleChatSpaceView(model: model, store: model.chatStore, space: space)
             } else {
                 MobileEmptyCard(
-                    title: "Set up the space first",
-                    message: "Open Space to create or load the server space, then chat will appear here."
+                    title: emptyTitle,
+                    message: emptyMessage
                 )
                 .padding(.horizontal, 20)
                 .padding(.top, 24)
@@ -236,6 +236,30 @@ private struct MobileConversationTab: View {
             }
         }
         .background(MobileShellBackground())
+    }
+
+    private var emptyTitle: String {
+        switch model.chatStore.surfaceState {
+        case .loading:
+            return "Loading space"
+        case .empty(let title, _), .error(let title, _):
+            return title
+        case .idle:
+            return model.session == nil ? "Sign in" : "Loading space"
+        }
+    }
+
+    private var emptyMessage: String {
+        switch model.chatStore.surfaceState {
+        case .loading:
+            return "Fetching spaces and channels from the XMPP server."
+        case .empty(_, let message), .error(_, let message):
+            return message
+        case .idle:
+            return model.session == nil
+                ? "Sign in to load the server space and connect to live rooms."
+                : "Fetching spaces and channels from the XMPP server."
+        }
     }
 }
 

--- a/apps/apple/Waddle/Chat/ChatWorkspaceView.swift
+++ b/apps/apple/Waddle/Chat/ChatWorkspaceView.swift
@@ -311,6 +311,11 @@ struct WaddleChatSpaceView: View {
         ZStack(alignment: .leading) {
             VStack(spacing: 0) {
                 compactChatHeader
+                if store.bannerState.isVisible {
+                    ChatConnectionBannerView(state: store.bannerState, usesOperationalChrome: true)
+                        .padding(.horizontal, 12)
+                        .padding(.bottom, 8)
+                }
                 conversationPane(compactStyle: true)
             }
             .background(WaddleTheme.chatBackground)

--- a/apps/apple/Waddle/RustClient/RustXmppClient.swift
+++ b/apps/apple/Waddle/RustClient/RustXmppClient.swift
@@ -3,6 +3,42 @@ import os
 
 private let logger = Logger(subsystem: "social.waddle.ios", category: "RustXmppClient")
 
+struct XMPPTopologyDiscoveryResult: Sendable, Equatable {
+    let topology: XMPPDiscoveredTopology
+    let errorDescription: String?
+
+    var failed: Bool {
+        errorDescription != nil
+    }
+}
+
+private final class DiscoveryErrorTracker: @unchecked Sendable {
+    private let lock = NSLock()
+    private var latestTopologyError: String?
+
+    func clear() {
+        lock.lock()
+        defer { lock.unlock() }
+        latestTopologyError = nil
+    }
+
+    func record(_ description: String) -> Bool {
+        guard description.hasPrefix("discover_topology failed:") else { return false }
+        lock.lock()
+        defer { lock.unlock() }
+        latestTopologyError = description
+        return true
+    }
+
+    func take() -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        let value = latestTopologyError
+        latestTopologyError = nil
+        return value
+    }
+}
+
 // MARK: - RustXmppClient
 
 /// Thin adapter that bridges `WaddleClient` (generated UniFFI binding) to a Swift-friendly API.
@@ -17,13 +53,14 @@ final class RustXmppClient: ObservableObject {
     private let continuation: AsyncStream<XMPPEvent>.Continuation
     private let waddleClient: WaddleClient
     private let eventListener: _EventListener
+    private let discoveryErrors = DiscoveryErrorTracker()
 
     init(config: WaddleConfig) {
         var continuation: AsyncStream<XMPPEvent>.Continuation!
         self.events = AsyncStream { continuation = $0 }
         self.continuation = continuation
 
-        let listener = _EventListener(continuation: continuation)
+        let listener = _EventListener(continuation: continuation, discoveryErrors: discoveryErrors)
         self.eventListener = listener
         self.waddleClient = WaddleClient(config: config, listener: listener)
         listener.owner = self
@@ -133,28 +170,32 @@ final class RustXmppClient: ObservableObject {
 
     // MARK: - Spaces topology
 
-    func discoverTopology() async -> XMPPDiscoveredTopology {
+    func discoverTopology() async -> XMPPTopologyDiscoveryResult {
+        discoveryErrors.clear()
         let topology = await waddleClient.discoverTopology()
-        return XMPPDiscoveredTopology(
-            spaces: topology.spaces.map {
-                XMPPDiscoveredSpace(
-                    id: $0.id,
-                    serviceJID: $0.serviceJid,
-                    name: $0.name,
-                    description: $0.description
-                )
-            },
-            channels: topology.channels.map {
-                XMPPDiscoveredChannel(
-                    id: $0.id,
-                    roomJID: $0.roomJid,
-                    name: $0.name,
-                    description: $0.description,
-                    channelType: $0.channelType,
-                    position: Int($0.position),
-                    spaceID: $0.spaceId
-                )
-            }
+        return XMPPTopologyDiscoveryResult(
+            topology: XMPPDiscoveredTopology(
+                spaces: topology.spaces.map {
+                    XMPPDiscoveredSpace(
+                        id: $0.id,
+                        serviceJID: $0.serviceJid,
+                        name: $0.name,
+                        description: $0.description
+                    )
+                },
+                channels: topology.channels.map {
+                    XMPPDiscoveredChannel(
+                        id: $0.id,
+                        roomJID: $0.roomJid,
+                        name: $0.name,
+                        description: $0.description,
+                        channelType: $0.channelType,
+                        position: Int($0.position),
+                        spaceID: $0.spaceId
+                    )
+                }
+            ),
+            errorDescription: discoveryErrors.take()
         )
     }
 
@@ -252,14 +293,16 @@ enum RustClientError: LocalizedError {
 /// Must be a class (reference type) to satisfy UniFFI's AnyObject requirement.
 private final class _EventListener: WaddleEventListener {
     private let continuation: AsyncStream<XMPPEvent>.Continuation
+    private let discoveryErrors: DiscoveryErrorTracker
     // Set by `RustXmppClient.init` after the listener is constructed so the
     // listener can drive the owning client's `connectionState` without a
     // retain cycle. Reads on non-main threads are safe — Swift weak references
     // are atomic; the property is only mutated on the MainActor hop below.
     weak var owner: RustXmppClient?
 
-    init(continuation: AsyncStream<XMPPEvent>.Continuation) {
+    init(continuation: AsyncStream<XMPPEvent>.Continuation, discoveryErrors: DiscoveryErrorTracker) {
         self.continuation = continuation
+        self.discoveryErrors = discoveryErrors
     }
 
     func onConnected() {
@@ -281,6 +324,9 @@ private final class _EventListener: WaddleEventListener {
 
     func onError(description: String) {
         print("[RustXmppClient] Rust FFI onError: \(description)")
+        if discoveryErrors.record(description) {
+            return
+        }
         continuation.yield(.error(description))
     }
 

--- a/server/crates/waddle-server/src/admin/channels.rs
+++ b/server/crates/waddle-server/src/admin/channels.rs
@@ -33,13 +33,18 @@ use waddle_xmpp::muc::{
     },
     AdminItem, RoomConfig,
 };
+use waddle_xmpp::pubsub::PubSubItem;
 use waddle_xmpp::registry::ConnectionRegistry;
 use waddle_xmpp::xep::xep0004::{DataForm, Field, FieldType, FormType};
 use waddle_xmpp::XmppError;
-use waddle_xmpp::{Affiliation, Role, Stanza};
+use waddle_xmpp::{Affiliation, ChannelInfo, Role, Stanza};
 
 use crate::admin::is_community_owner;
 use crate::channel_space_links::{ChannelSpaceLink, ChannelSpaceLinkError};
+use crate::permissions::{
+    DeleteTuple, Object, ObjectType, PermissionError, Relation, Subject, SubjectType, Tuple,
+    WriteTuple,
+};
 use crate::server::AppState;
 
 // ---------------------------------------------------------------------------
@@ -882,12 +887,336 @@ fn mint_channel_localpart(name: &str) -> String {
     format!("{base}-{short_tail}")
 }
 
+fn space_node_name(space_jid: &BareJid) -> Option<String> {
+    space_jid.node().map(|n| n.to_string())
+}
+
+async fn existing_space_node(state: &AppState, space_jid: &BareJid) -> Result<String, AdminErr> {
+    if space_jid.domain() != state.spaces_jid.domain() {
+        return Err(bad_request(format!(
+            "space_jid must target {}",
+            state.spaces_jid.domain()
+        )));
+    }
+    let Some(node) = space_node_name(space_jid) else {
+        return Err(bad_request("space_jid must have a localpart"));
+    };
+    let exists = state
+        .pubsub_storage
+        .get_node(&state.spaces_jid, &node)
+        .await
+        .map_err(|e| internal_err(format!("pubsub get_node failed: {e}")))?;
+    if exists.is_none() {
+        return Err(Box::new(CommandResult::Error(XmppError::item_not_found(
+            Some(format!("no space '{}'", space_jid)),
+        ))));
+    }
+    Ok(node)
+}
+
+async fn publish_channel_space_bookmark(
+    state: &AppState,
+    node: &str,
+    channel_id: &str,
+    name: &str,
+    channel_type: &str,
+) -> Result<bool, AdminErr> {
+    let item_id = format!("{}@{}", channel_id, state.muc_domain);
+    let item_filter = [item_id.clone()];
+    let previous_item = state
+        .pubsub_storage
+        .get_items(&state.spaces_jid, node, Some(1), &item_filter)
+        .await
+        .map_err(|e| internal_err(format!("pubsub read existing channel bookmark failed: {e}")))?
+        .into_iter()
+        .next()
+        .map(|stored| stored.to_pubsub_item());
+    let item = waddle_xmpp::xep::build_channel_item(
+        &ChannelInfo {
+            id: channel_id.to_string(),
+            name: name.to_string(),
+            channel_type: channel_type.to_string(),
+        },
+        &state.muc_domain.to_string(),
+    )
+    .map_err(|e| internal_err(format!("failed to build XEP-0503 channel bookmark: {e}")))?;
+    state
+        .pubsub_storage
+        .publish_item(&state.spaces_jid, node, &item, None, false)
+        .await
+        .map_err(|e| internal_err(format!("pubsub publish channel bookmark failed: {e}")))?;
+    match write_channel_parent_tuple_if_absent(state, channel_id, node).await {
+        Ok(created) => Ok(created),
+        Err(error) => {
+            if let Some(previous_item) = previous_item.as_ref() {
+                let _ = state
+                    .pubsub_storage
+                    .publish_item(&state.spaces_jid, node, previous_item, None, false)
+                    .await;
+            } else {
+                let _ = state
+                    .pubsub_storage
+                    .retract_item(&state.spaces_jid, node, &item_id)
+                    .await;
+            }
+            Err(error)
+        }
+    }
+}
+
+async fn restore_channel_space_bookmark(
+    state: &AppState,
+    node: &str,
+    item_id: &str,
+    channel_id: &str,
+    previous_item: Option<&PubSubItem>,
+    parent_tuple_created: bool,
+) {
+    if let Some(previous_item) = previous_item {
+        if parent_tuple_created {
+            match delete_channel_parent_tuple(state, channel_id, node).await {
+                Ok(_) => {}
+                Err(_error) => {
+                    tracing::warn!(
+                        node = %node,
+                        item_id = %item_id,
+                        "channels:update rollback failed to delete operation-created parent tuple; preserving newly-published Spaces bookmark",
+                    );
+                    return;
+                }
+            }
+        }
+        match state
+            .pubsub_storage
+            .publish_item(&state.spaces_jid, node, previous_item, None, false)
+            .await
+        {
+            Ok(_) => {}
+            Err(error) => {
+                if parent_tuple_created {
+                    let _ = write_channel_parent_tuple(state, channel_id, node).await;
+                }
+                tracing::warn!(
+                    node = %node,
+                    item_id = %item_id,
+                    error = %error,
+                    "channels:update rollback failed to restore previous Spaces bookmark",
+                );
+            }
+        }
+    } else {
+        if parent_tuple_created {
+            match delete_channel_parent_tuple(state, channel_id, node).await {
+                Ok(_) => {}
+                Err(_error) => {
+                    tracing::warn!(
+                        node = %node,
+                        item_id = %item_id,
+                        "channels:update rollback failed to delete operation-created parent tuple; preserving newly-published Spaces bookmark",
+                    );
+                    return;
+                }
+            }
+        }
+        if let Err(error) = state
+            .pubsub_storage
+            .retract_item(&state.spaces_jid, node, item_id)
+            .await
+        {
+            if parent_tuple_created {
+                let _ = write_channel_parent_tuple(state, channel_id, node).await;
+            }
+            tracing::warn!(
+                node = %node,
+                item_id = %item_id,
+                error = %error,
+                "channels:update rollback failed to retract newly-published Spaces bookmark",
+            );
+        }
+    }
+}
+
+async fn write_channel_parent_tuple(
+    state: &AppState,
+    channel_id: &str,
+    space_node: &str,
+) -> Result<(), AdminErr> {
+    write_channel_parent_tuple_if_absent(state, channel_id, space_node)
+        .await
+        .map(|_| ())
+}
+
+async fn write_channel_parent_tuple_if_absent(
+    state: &AppState,
+    channel_id: &str,
+    space_node: &str,
+) -> Result<bool, AdminErr> {
+    let tuple = Tuple::new(
+        Object::new(ObjectType::Channel, channel_id),
+        Relation::new("parent"),
+        Subject::userset(SubjectType::Space, space_node, ""),
+    );
+    match state.permission_actor.ask(WriteTuple { tuple }).await {
+        Ok(()) => Ok(true),
+        Err(kameo::error::SendError::HandlerError(PermissionError::TupleAlreadyExists)) => {
+            Ok(false)
+        }
+        Err(error) => Err(internal_err(format!(
+            "permission actor failed writing channel parent tuple: {error}"
+        ))),
+    }
+}
+
+async fn delete_channel_parent_tuple(
+    state: &AppState,
+    channel_id: &str,
+    space_node: &str,
+) -> Result<bool, AdminErr> {
+    let tuple = Tuple::new(
+        Object::new(ObjectType::Channel, channel_id),
+        Relation::new("parent"),
+        Subject::userset(SubjectType::Space, space_node, ""),
+    );
+    match state.permission_actor.ask(DeleteTuple { tuple }).await {
+        Ok(()) => Ok(true),
+        Err(kameo::error::SendError::HandlerError(PermissionError::TupleNotFound)) => Ok(false),
+        Err(error) => Err(internal_err(format!(
+            "permission actor failed deleting channel parent tuple: {error}"
+        ))),
+    }
+}
+
+struct RemovedChannelBookmark {
+    node: String,
+    item: Option<PubSubItem>,
+    fallback_item: Option<PubSubItem>,
+    parent_tuple_deleted: bool,
+}
+
+async fn retract_duplicate_channel_bookmarks(
+    state: &AppState,
+    keep_node: &str,
+    channel_id: &str,
+    channel_jid: &BareJid,
+) -> Result<(), AdminErr> {
+    let item_id = channel_jid.to_string();
+    let nodes = state
+        .pubsub_storage
+        .list_node_names_for_item(&state.spaces_jid, &item_id)
+        .await
+        .map_err(|e| internal_err(format!("pubsub list channel bookmark nodes failed: {e}")))?;
+    let mut removed = Vec::new();
+    for node in nodes.into_iter().filter(|node| node != keep_node) {
+        let snapshot = match snapshot_channel_bookmark(state, &node, &item_id).await {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                restore_removed_channel_bookmarks(state, &removed, &item_id, Some(channel_id))
+                    .await;
+                return Err(error);
+            }
+        };
+        let fallback_item = if snapshot.is_none() {
+            match rollback_channel_bookmark_item(state, channel_jid, channel_id).await {
+                Some(item) => Some(item),
+                None => {
+                    restore_removed_channel_bookmarks(state, &removed, &item_id, Some(channel_id))
+                        .await;
+                    return Err(internal_err(format!(
+                        "could not snapshot missing Spaces bookmark for linked channel {channel_jid}"
+                    )));
+                }
+            }
+        } else {
+            None
+        };
+        match retract_channel_bookmark_and_parent(state, &node, &item_id, Some(channel_id)).await {
+            Ok(parent_tuple_deleted) => removed.push(RemovedChannelBookmark {
+                node,
+                item: snapshot,
+                fallback_item,
+                parent_tuple_deleted,
+            }),
+            Err(error) => {
+                restore_removed_channel_bookmarks(state, &removed, &item_id, Some(channel_id))
+                    .await;
+                return Err(error);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn channel_type_from_config(config: &RoomConfig) -> &'static str {
+    if config.forum {
+        "forum"
+    } else {
+        "text"
+    }
+}
+
+async fn rollback_channel_bookmark_item(
+    state: &AppState,
+    room_jid: &BareJid,
+    channel_id: &str,
+) -> Option<PubSubItem> {
+    let actor = match state
+        .room_registry
+        .ask(GetRoom {
+            room_jid: room_jid.clone(),
+        })
+        .await
+    {
+        Ok(Some(actor)) => actor,
+        Ok(None) => return None,
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                room = %room_jid,
+                "channels rollback could not snapshot room for missing Spaces bookmark",
+            );
+            return None;
+        }
+    };
+    let config = match actor.ask(GetConfig).await {
+        Ok(config) => config,
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                room = %room_jid,
+                "channels rollback could not snapshot room config for missing Spaces bookmark",
+            );
+            return None;
+        }
+    };
+    let channel_type = channel_type_from_config(&config).to_string();
+    waddle_xmpp::xep::build_channel_item(
+        &ChannelInfo {
+            id: channel_id.to_string(),
+            name: config.name,
+            channel_type,
+        },
+        &state.muc_domain.to_string(),
+    )
+    .map_err(|error| {
+        tracing::warn!(
+            error = %error,
+            room = %room_jid,
+            "channels rollback could not build missing Spaces bookmark",
+        );
+    })
+    .ok()
+}
+
 async fn run_create(state: &AppState, args: &ChannelsCreateArgs) -> Result<ChannelRef, AdminErr> {
     let localpart = mint_channel_localpart(&args.name);
     let muc_domain = state.muc_domain.to_string();
     let channel_jid: BareJid = format!("{localpart}@{muc_domain}")
         .parse()
         .map_err(|e| internal_err(format!("constructed channel JID is invalid: {e}")))?;
+    let space_node = match args.space_jid.as_ref() {
+        Some(space_jid) => Some(existing_space_node(state, space_jid).await?),
+        None => None,
+    };
 
     // Spec: public, persistent, not members-only.
     let mut config = RoomConfig {
@@ -917,9 +1246,30 @@ async fn run_create(state: &AppState, args: &ChannelsCreateArgs) -> Result<Chann
     // Persist the channel↔space link when the caller supplied a
     // `space_jid`. The link drives `channels:list` filtering and
     // `spaces:delete` cascade behavior; the room itself lives in the
-    // MUC registry independent of any space.
-    if let Some(space_jid) = args.space_jid.as_ref() {
-        state
+    // MUC registry independent of any space. The matching XEP-0503
+    // bookmark is the public discovery source for native clients.
+    if let (Some(space_jid), Some(node)) = (args.space_jid.as_ref(), space_node.as_deref()) {
+        let parent_tuple_created = match publish_channel_space_bookmark(
+            state,
+            node,
+            &localpart,
+            &args.name,
+            channel_type_from_config(&config),
+        )
+        .await
+        {
+            Ok(created) => created,
+            Err(error) => {
+                let _ = state
+                    .room_registry
+                    .ask(DestroyRoom {
+                        room_jid: channel_jid.clone(),
+                    })
+                    .await;
+                return Err(error);
+            }
+        };
+        if let Err(error) = state
             .channel_space_link_store
             .set(&ChannelSpaceLink {
                 channel_jid: channel_jid.clone(),
@@ -927,7 +1277,51 @@ async fn run_create(state: &AppState, args: &ChannelsCreateArgs) -> Result<Chann
                 created_at: now_unix_seconds(),
             })
             .await
-            .map_err(map_link_err)?;
+        {
+            let tuple_ready_for_retract = if parent_tuple_created {
+                match delete_channel_parent_tuple(state, &localpart, node).await {
+                    Ok(_) => true,
+                    Err(_delete_error) => {
+                        tracing::warn!(
+                            node = %node,
+                            channel = %channel_jid,
+                            "channels:create failed to persist channel-space link and could not delete operation-created parent tuple; preserving room and Spaces bookmark",
+                        );
+                        false
+                    }
+                }
+            } else {
+                true
+            };
+            if tuple_ready_for_retract {
+                match state
+                    .pubsub_storage
+                    .retract_item(&state.spaces_jid, node, &channel_jid.to_string())
+                    .await
+                {
+                    Ok(_) => {
+                        let _ = state
+                            .room_registry
+                            .ask(DestroyRoom {
+                                room_jid: channel_jid.clone(),
+                            })
+                            .await;
+                    }
+                    Err(retract_error) => {
+                        if parent_tuple_created {
+                            let _ = write_channel_parent_tuple(state, &localpart, node).await;
+                        }
+                        tracing::warn!(
+                            node = %node,
+                            channel = %channel_jid,
+                            error = %retract_error,
+                            "channels:create failed to persist channel-space link and could not retract Spaces bookmark; preserving room and parent tuple for consistency",
+                        );
+                    }
+                }
+            }
+            return Err(map_link_err(error));
+        }
     }
 
     Ok(ChannelRef {
@@ -968,14 +1362,77 @@ async fn run_update(state: &AppState, args: &ChannelsUpdateArgs) -> Result<Chann
         name: new_name.clone(),
         description: new_topic.clone(),
         members_only: new_members_only,
-        ..existing
+        ..existing.clone()
     };
+    let linked_bookmark = if let Some(link) = state
+        .channel_space_link_store
+        .get(&args.channel_jid)
+        .await
+        .map_err(map_link_err)?
+    {
+        let Some(node) = space_node_name(&link.space_jid) else {
+            return Err(bad_request("stored space_jid must have a localpart"));
+        };
+        let Some(channel_id) = waddle_xmpp::parse_managed_room_jid(&args.channel_jid) else {
+            return Err(internal_err(format!(
+                "linked channel JID is not managed: {}",
+                args.channel_jid
+            )));
+        };
+        let item_id = args.channel_jid.to_string();
+        let previous_bookmark = snapshot_channel_bookmark(state, &node, &item_id).await?;
+        Some((node, channel_id, item_id, previous_bookmark))
+    } else {
+        None
+    };
+
     actor
         .ask(UpdateConfig {
             config: updated.clone(),
         })
         .await
         .map_err(send_err("room actor UpdateConfig"))?;
+
+    if let Some((node, channel_id, item_id, previous_bookmark)) = linked_bookmark {
+        let parent_tuple_created = match publish_channel_space_bookmark(
+            state,
+            &node,
+            &channel_id,
+            &new_name,
+            channel_type_from_config(&updated),
+        )
+        .await
+        {
+            Ok(created) => created,
+            Err(error) => {
+                let _ = actor
+                    .ask(UpdateConfig {
+                        config: existing.clone(),
+                    })
+                    .await;
+                return Err(error);
+            }
+        };
+        if let Err(error) =
+            retract_duplicate_channel_bookmarks(state, &node, &channel_id, &args.channel_jid).await
+        {
+            let _ = actor
+                .ask(UpdateConfig {
+                    config: existing.clone(),
+                })
+                .await;
+            restore_channel_space_bookmark(
+                state,
+                &node,
+                &item_id,
+                &channel_id,
+                previous_bookmark.as_ref(),
+                parent_tuple_created,
+            )
+            .await;
+            return Err(error);
+        }
+    }
 
     Ok(ChannelRef {
         channel_jid: args.channel_jid.clone(),
@@ -986,22 +1443,322 @@ async fn run_update(state: &AppState, args: &ChannelsUpdateArgs) -> Result<Chann
 }
 
 async fn run_delete(state: &AppState, args: &ChannelsDeleteArgs) -> Result<(), AdminErr> {
-    let _removed = state
+    let link = state
+        .channel_space_link_store
+        .get(&args.channel_jid)
+        .await
+        .map_err(map_link_err)?;
+    let linked_node = link
+        .as_ref()
+        .and_then(|link| space_node_name(&link.space_jid));
+    let item_id = args.channel_jid.to_string();
+    let channel_id = waddle_xmpp::parse_managed_room_jid(&args.channel_jid);
+    let mut bookmark_nodes: std::collections::BTreeSet<String> = state
+        .pubsub_storage
+        .list_node_names_for_item(&state.spaces_jid, &item_id)
+        .await
+        .map_err(|e| internal_err(format!("pubsub list channel bookmark nodes failed: {e}")))?
+        .into_iter()
+        .collect();
+    if let Some(node) = linked_node.as_ref() {
+        bookmark_nodes.insert(node.clone());
+    }
+
+    let mut bookmark_snapshots: std::collections::BTreeMap<String, Option<PubSubItem>> =
+        std::collections::BTreeMap::new();
+    for node in &bookmark_nodes {
+        bookmark_snapshots.insert(
+            node.clone(),
+            snapshot_channel_bookmark(state, node, &item_id).await?,
+        );
+    }
+
+    let mut removed_bookmarks: Vec<RemovedChannelBookmark> = Vec::new();
+
+    for node in bookmark_nodes
+        .iter()
+        .filter(|node| Some(node.as_str()) != linked_node.as_deref())
+    {
+        let snapshot = bookmark_snapshots.get(node).cloned().unwrap_or(None);
+        let fallback_item = if snapshot.is_none() {
+            if let Some(channel_id) = channel_id.as_deref() {
+                match rollback_channel_bookmark_item(state, &args.channel_jid, channel_id).await {
+                    Some(item) => Some(item),
+                    None => {
+                        restore_removed_channel_bookmarks(
+                            state,
+                            &removed_bookmarks,
+                            &item_id,
+                            Some(channel_id),
+                        )
+                        .await;
+                        return Err(internal_err(format!(
+                            "could not snapshot missing Spaces bookmark for linked channel {}",
+                            args.channel_jid
+                        )));
+                    }
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        match retract_channel_bookmark_and_parent(state, node, &item_id, channel_id.as_deref())
+            .await
+        {
+            Ok(parent_tuple_deleted) => removed_bookmarks.push(RemovedChannelBookmark {
+                node: node.clone(),
+                item: snapshot,
+                fallback_item,
+                parent_tuple_deleted,
+            }),
+            Err(error) => {
+                restore_removed_channel_bookmarks(
+                    state,
+                    &removed_bookmarks,
+                    &item_id,
+                    channel_id.as_deref(),
+                )
+                .await;
+                return Err(error);
+            }
+        }
+    }
+
+    if link.is_some() {
+        if let Err(error) = state
+            .channel_space_link_store
+            .clear(&args.channel_jid)
+            .await
+        {
+            restore_removed_channel_bookmarks(
+                state,
+                &removed_bookmarks,
+                &item_id,
+                channel_id.as_deref(),
+            )
+            .await;
+            return Err(map_link_err(error));
+        }
+    }
+
+    if let Some(node) = linked_node.as_ref() {
+        let snapshot = bookmark_snapshots.get(node).cloned().unwrap_or(None);
+        let fallback_item = if snapshot.is_none() {
+            if let Some(channel_id) = channel_id.as_deref() {
+                match rollback_channel_bookmark_item(state, &args.channel_jid, channel_id).await {
+                    Some(item) => Some(item),
+                    None => {
+                        if let Some(link) = link.as_ref() {
+                            if let Err(rollback_error) =
+                                state.channel_space_link_store.set(link).await
+                            {
+                                tracing::warn!(
+                                    error = %rollback_error,
+                                    channel = %args.channel_jid,
+                                    space = %link.space_jid,
+                                    "channels:delete rollback failed to restore channel-space link",
+                                );
+                            }
+                        }
+                        restore_removed_channel_bookmarks(
+                            state,
+                            &removed_bookmarks,
+                            &item_id,
+                            Some(channel_id),
+                        )
+                        .await;
+                        return Err(internal_err(format!(
+                            "could not snapshot missing Spaces bookmark for linked channel {}",
+                            args.channel_jid
+                        )));
+                    }
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        match retract_channel_bookmark_and_parent(state, node, &item_id, channel_id.as_deref())
+            .await
+        {
+            Ok(parent_tuple_deleted) => removed_bookmarks.push(RemovedChannelBookmark {
+                node: node.clone(),
+                item: snapshot,
+                fallback_item,
+                parent_tuple_deleted,
+            }),
+            Err(error) => {
+                if let Some(link) = link.as_ref() {
+                    if let Err(rollback_error) = state.channel_space_link_store.set(link).await {
+                        tracing::warn!(
+                            error = %rollback_error,
+                            channel = %args.channel_jid,
+                            space = %link.space_jid,
+                            "channels:delete rollback failed to restore channel-space link",
+                        );
+                    }
+                }
+                restore_removed_channel_bookmarks(
+                    state,
+                    &removed_bookmarks,
+                    &item_id,
+                    channel_id.as_deref(),
+                )
+                .await;
+                return Err(error);
+            }
+        }
+    }
+
+    match state
         .room_registry
         .ask(DestroyRoom {
             room_jid: args.channel_jid.clone(),
         })
         .await
-        .map_err(send_err("room_registry ask DestroyRoom"))?;
-    // Best-effort: drop the channel↔space link row if any. We
-    // intentionally don't fail the delete on a missing link; the room
-    // is gone, the link projection has nothing left to point at.
-    let _ = state
-        .channel_space_link_store
-        .clear(&args.channel_jid)
-        .await
-        .map_err(map_link_err)?;
+    {
+        Ok(_removed) => {}
+        Err(error) => {
+            restore_removed_channel_bookmarks(
+                state,
+                &removed_bookmarks,
+                &item_id,
+                channel_id.as_deref(),
+            )
+            .await;
+            if let Some(link) = link.as_ref() {
+                if let Err(rollback_error) = state.channel_space_link_store.set(link).await {
+                    tracing::warn!(
+                        error = %rollback_error,
+                        channel = %args.channel_jid,
+                        space = %link.space_jid,
+                        "channels:delete rollback failed to restore channel-space link",
+                    );
+                }
+            }
+            return Err(send_err("room_registry ask DestroyRoom")(error));
+        }
+    }
     Ok(())
+}
+
+async fn snapshot_channel_bookmark(
+    state: &AppState,
+    node: &str,
+    item_id: &str,
+) -> Result<Option<PubSubItem>, AdminErr> {
+    let item_filter = [item_id.to_string()];
+    Ok(state
+        .pubsub_storage
+        .get_items(&state.spaces_jid, node, Some(1), &item_filter)
+        .await
+        .map_err(|e| internal_err(format!("pubsub read channel bookmark failed: {e}")))?
+        .into_iter()
+        .next()
+        .map(|stored| stored.to_pubsub_item()))
+}
+
+async fn restore_removed_channel_bookmarks(
+    state: &AppState,
+    removed: &[RemovedChannelBookmark],
+    item_id: &str,
+    channel_id: Option<&str>,
+) {
+    for removed in removed.iter().rev() {
+        if let Some(item) = removed.item.as_ref() {
+            match state
+                .pubsub_storage
+                .publish_item(&state.spaces_jid, &removed.node, item, None, false)
+                .await
+            {
+                Ok(_) => {
+                    if removed.parent_tuple_deleted {
+                        if let Some(channel_id) = channel_id {
+                            let _ =
+                                write_channel_parent_tuple(state, channel_id, &removed.node).await;
+                        }
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        error = %error,
+                        node = %removed.node,
+                        item_id = %item_id,
+                        "channels:delete failed to restore Spaces bookmark",
+                    );
+                }
+            }
+        } else if removed.parent_tuple_deleted {
+            if let Some(item) = removed.fallback_item.as_ref() {
+                match state
+                    .pubsub_storage
+                    .publish_item(&state.spaces_jid, &removed.node, item, None, false)
+                    .await
+                {
+                    Ok(_) => {
+                        if removed.parent_tuple_deleted {
+                            if let Some(channel_id) = channel_id {
+                                let _ =
+                                    write_channel_parent_tuple(state, channel_id, &removed.node)
+                                        .await;
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            error = %error,
+                            node = %removed.node,
+                            item_id = %item_id,
+                            "channels:delete failed to restore fallback Spaces bookmark",
+                        );
+                    }
+                }
+            } else {
+                tracing::warn!(
+                    node = %removed.node,
+                    item_id = %item_id,
+                    "channels:delete skipped parent tuple restore because no Spaces bookmark item was restored",
+                );
+            }
+        }
+    }
+}
+
+async fn retract_channel_bookmark_and_parent(
+    state: &AppState,
+    node: &str,
+    item_id: &str,
+    channel_id: Option<&str>,
+) -> Result<bool, AdminErr> {
+    let parent_tuple_deleted = if let Some(channel_id) = channel_id {
+        delete_channel_parent_tuple(state, channel_id, node).await?
+    } else {
+        false
+    };
+    if let Err(error) = state
+        .pubsub_storage
+        .retract_item(&state.spaces_jid, node, item_id)
+        .await
+    {
+        if parent_tuple_deleted {
+            if let Some(channel_id) = channel_id {
+                let _ = write_channel_parent_tuple(state, channel_id, node).await;
+            }
+        }
+        tracing::warn!(
+            node = %node,
+            item_id = %item_id,
+            error = %error,
+            "channels:delete failed to retract a Spaces bookmark",
+        );
+        return Err(internal_err(format!(
+            "pubsub retract channel bookmark failed: {error}"
+        )));
+    }
+    Ok(parent_tuple_deleted)
 }
 
 async fn run_occupants(

--- a/server/crates/waddle-server/src/admin/spaces.rs
+++ b/server/crates/waddle-server/src/admin/spaces.rs
@@ -32,11 +32,18 @@ use std::sync::Arc;
 
 use jid::BareJid;
 use waddle_xmpp::commands::{CommandContext, CommandResult};
-use waddle_xmpp::pubsub::Affiliation as PubSubAffiliation;
+use waddle_xmpp::muc::room_actor::GetConfig;
+use waddle_xmpp::muc::room_registry_actor::GetRoom;
+use waddle_xmpp::pubsub::{Affiliation as PubSubAffiliation, PubSubItem};
 use waddle_xmpp::xep::xep0004::{DataForm, Field, FieldType, FormType};
-use waddle_xmpp::XmppError;
+use waddle_xmpp::{ChannelInfo, XmppError};
 
 use crate::admin::is_community_owner;
+use crate::channel_space_links::ChannelSpaceLink;
+use crate::permissions::{
+    DeleteTuple, Object, ObjectType, PermissionError, Relation, Subject, SubjectType, Tuple,
+    WriteTuple,
+};
 use crate::server::AppState;
 use crate::spaces_metadata::{SpaceMetadata, SpacesMetadataError};
 
@@ -633,6 +640,202 @@ async fn counts_for_space(state: &AppState, space_jid: &BareJid) -> Result<(u32,
     Ok((channel_count, member_count))
 }
 
+async fn delete_channel_parent_tuple(
+    state: &AppState,
+    channel_id: &str,
+    space_node: &str,
+) -> Result<bool, AdminErr> {
+    let tuple = Tuple::new(
+        Object::new(ObjectType::Channel, channel_id),
+        Relation::new("parent"),
+        Subject::userset(SubjectType::Space, space_node, ""),
+    );
+    match state.permission_actor.ask(DeleteTuple { tuple }).await {
+        Ok(()) => Ok(true),
+        Err(kameo::error::SendError::HandlerError(PermissionError::TupleNotFound)) => Ok(false),
+        Err(error) => Err(internal_err(format!(
+            "permission actor failed deleting channel parent tuple: {error}"
+        ))),
+    }
+}
+
+async fn write_channel_parent_tuple(
+    state: &AppState,
+    channel_id: &str,
+    space_node: &str,
+) -> Result<(), AdminErr> {
+    let tuple = Tuple::new(
+        Object::new(ObjectType::Channel, channel_id),
+        Relation::new("parent"),
+        Subject::userset(SubjectType::Space, space_node, ""),
+    );
+    match state.permission_actor.ask(WriteTuple { tuple }).await {
+        Ok(()) => Ok(()),
+        Err(kameo::error::SendError::HandlerError(PermissionError::TupleAlreadyExists)) => Ok(()),
+        Err(error) => Err(internal_err(format!(
+            "permission actor failed writing channel parent tuple: {error}"
+        ))),
+    }
+}
+
+struct SpaceDeleteCleanup {
+    room_jid: BareJid,
+    channel_id: Option<String>,
+    parent_tuple_deleted: bool,
+    had_bookmark_item: bool,
+    rollback_bookmark_item: Option<PubSubItem>,
+    removed_link: Option<ChannelSpaceLink>,
+}
+
+async fn rollback_space_delete_cleanups(
+    state: &AppState,
+    cleanups: &[SpaceDeleteCleanup],
+    space_node: &str,
+    skip_rooms: &std::collections::BTreeSet<BareJid>,
+    skip_parent_tuple_rooms: &std::collections::BTreeSet<BareJid>,
+) {
+    for cleanup in cleanups.iter().rev() {
+        if skip_rooms.contains(&cleanup.room_jid) {
+            continue;
+        }
+        let mut bookmark_available =
+            cleanup.had_bookmark_item && !skip_parent_tuple_rooms.contains(&cleanup.room_jid);
+        if !cleanup.had_bookmark_item {
+            if let Some(item) = cleanup.rollback_bookmark_item.as_ref() {
+                match state
+                    .pubsub_storage
+                    .publish_item(&state.spaces_jid, space_node, item, None, false)
+                    .await
+                {
+                    Ok(_) => {
+                        bookmark_available = true;
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            error = %error,
+                            room = %cleanup.room_jid,
+                            space_node = %space_node,
+                            "spaces:delete rollback failed to restore missing channel bookmark",
+                        );
+                    }
+                }
+            }
+        }
+        if cleanup.parent_tuple_deleted && bookmark_available {
+            if let Some(channel_id) = cleanup.channel_id.as_deref() {
+                if write_channel_parent_tuple(state, channel_id, space_node)
+                    .await
+                    .is_err()
+                {
+                    tracing::warn!(
+                        room = %cleanup.room_jid,
+                        space_node = %space_node,
+                        "spaces:delete rollback failed to restore channel parent tuple",
+                    );
+                }
+            }
+        }
+        if let Some(link) = cleanup.removed_link.as_ref() {
+            if let Err(error) = state.channel_space_link_store.set(link).await {
+                tracing::warn!(
+                    error = %error,
+                    room = %cleanup.room_jid,
+                    space = %link.space_jid,
+                    "spaces:delete rollback failed to restore channel-space link",
+                );
+            }
+        }
+    }
+}
+
+async fn restore_space_node_items(
+    state: &AppState,
+    space_node: &str,
+    items: &[(String, PubSubItem)],
+    skip_rooms: &std::collections::BTreeSet<BareJid>,
+) -> std::collections::BTreeSet<BareJid> {
+    let mut failed_rooms = std::collections::BTreeSet::new();
+    for (item_id, item) in items.iter().rev() {
+        if item_id
+            .parse::<BareJid>()
+            .is_ok_and(|room_jid| skip_rooms.contains(&room_jid))
+        {
+            continue;
+        }
+        if let Err(error) = state
+            .pubsub_storage
+            .publish_item(&state.spaces_jid, space_node, item, None, false)
+            .await
+        {
+            tracing::warn!(
+                error = %error,
+                item_id = %item_id,
+                space_node = %space_node,
+                "spaces:delete rollback failed to restore PubSub item",
+            );
+            if let Ok(room_jid) = item_id.parse::<BareJid>() {
+                failed_rooms.insert(room_jid);
+            }
+        }
+    }
+    failed_rooms
+}
+
+async fn rollback_channel_bookmark_item(
+    state: &AppState,
+    room_jid: &BareJid,
+    channel_id: &str,
+) -> Option<PubSubItem> {
+    let actor = match state
+        .room_registry
+        .ask(GetRoom {
+            room_jid: room_jid.clone(),
+        })
+        .await
+    {
+        Ok(Some(actor)) => actor,
+        Ok(None) => return None,
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                room = %room_jid,
+                "spaces:delete rollback could not snapshot room for missing channel bookmark",
+            );
+            return None;
+        }
+    };
+    let config = match actor.ask(GetConfig).await {
+        Ok(config) => config,
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                room = %room_jid,
+                "spaces:delete rollback could not snapshot room config for missing channel bookmark",
+            );
+            return None;
+        }
+    };
+    let channel_type = if config.forum { "forum" } else { "text" };
+    match waddle_xmpp::xep::build_channel_item(
+        &ChannelInfo {
+            id: channel_id.to_string(),
+            name: config.name,
+            channel_type: channel_type.to_string(),
+        },
+        &state.muc_domain.to_string(),
+    ) {
+        Ok(item) => Some(item),
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                room = %room_jid,
+                "spaces:delete rollback could not build missing channel bookmark",
+            );
+            None
+        }
+    }
+}
+
 async fn run_create(state: &AppState, args: &SpacesCreateArgs) -> Result<SpaceRef, AdminErr> {
     // Mint a fresh localpart for this space. Mirror the chat-side
     // convention of slugified-name + short-id by lowercasing+slugifying
@@ -644,26 +847,31 @@ async fn run_create(state: &AppState, args: &SpacesCreateArgs) -> Result<SpaceRe
         .map_err(|e| internal_err(format!("constructed space JID is invalid: {e}")))?;
 
     let now = now_unix_seconds();
-    let metadata = SpaceMetadata {
-        space_jid: space_jid.clone(),
-        name: args.name.clone(),
-        description: args.description.clone(),
-        icon_url: args.icon_url.clone(),
-        created_at: now,
-        updated_at: now,
-    };
-    state
-        .spaces_metadata_store
-        .upsert(&metadata)
-        .await
-        .map_err(map_metadata_err)?;
-
     // Create the pubsub node that backs the space's channel list.
-    state
+    let (_, created_node) = state
         .pubsub_storage
         .get_or_create_node(&state.spaces_jid, &localpart)
         .await
         .map_err(|e| internal_err(format!("pubsub create node failed: {e}")))?;
+    if let Err(error) = state
+        .pubsub_storage
+        .update_node_config(
+            &state.spaces_jid,
+            &localpart,
+            &waddle_xmpp::pubsub::NodeConfig::spaces_public(),
+        )
+        .await
+    {
+        if created_node {
+            let _ = state
+                .pubsub_storage
+                .delete_node(&state.spaces_jid, &localpart)
+                .await;
+        }
+        return Err(internal_err(format!(
+            "pubsub configure space node failed: {error}"
+        )));
+    }
 
     // Seed server-owners as PubSub owners on the new node so they can
     // administer it. Mirrors `spaces_pubsub_seed::seed_owners_on_node`.
@@ -674,6 +882,22 @@ async fn run_create(state: &AppState, args: &SpacesCreateArgs) -> Result<SpaceRe
         &state.server_owner_jids,
     )
     .await;
+
+    let metadata = SpaceMetadata {
+        space_jid: space_jid.clone(),
+        name: args.name.clone(),
+        description: args.description.clone(),
+        icon_url: args.icon_url.clone(),
+        created_at: now,
+        updated_at: now,
+    };
+    if let Err(error) = state.spaces_metadata_store.upsert(&metadata).await {
+        let _ = state
+            .pubsub_storage
+            .delete_node(&state.spaces_jid, &localpart)
+            .await;
+        return Err(map_metadata_err(error));
+    }
 
     Ok(SpaceRef {
         space_jid,
@@ -770,14 +994,168 @@ async fn run_delete(state: &AppState, args: &SpacesDeleteArgs) -> Result<(), Adm
         .get_items(&state.spaces_jid, &node_name, None, &[])
         .await
         .map_err(|e| internal_err(format!("pubsub get_items failed: {e}")))?;
-    for stored in items {
+    for stored in &items {
         if let Ok(room_jid) = stored.id.parse::<BareJid>() {
             targets.insert(room_jid);
         }
     }
+    let bookmarked_rooms: std::collections::BTreeSet<BareJid> = items
+        .iter()
+        .filter_map(|stored| stored.id.parse::<BareJid>().ok())
+        .collect();
 
-    for room_jid in targets {
-        // Best-effort destroy — non-existent rooms are fine.
+    let mut cleanups: Vec<SpaceDeleteCleanup> = Vec::new();
+    let mut destroy_targets: std::collections::BTreeSet<BareJid> =
+        std::collections::BTreeSet::new();
+    for room_jid in &targets {
+        let mut cleanup = SpaceDeleteCleanup {
+            room_jid: room_jid.clone(),
+            channel_id: None,
+            parent_tuple_deleted: false,
+            had_bookmark_item: bookmarked_rooms.contains(room_jid),
+            rollback_bookmark_item: None,
+            removed_link: None,
+        };
+        if let Some(channel_id) = waddle_xmpp::parse_managed_room_jid(room_jid) {
+            cleanup.channel_id = Some(channel_id.clone());
+            match delete_channel_parent_tuple(state, &channel_id, &node_name).await {
+                Ok(true) => {
+                    cleanup.parent_tuple_deleted = true;
+                    if !cleanup.had_bookmark_item {
+                        cleanup.rollback_bookmark_item =
+                            rollback_channel_bookmark_item(state, room_jid, &channel_id).await;
+                        if cleanup.rollback_bookmark_item.is_none() {
+                            let _ =
+                                write_channel_parent_tuple(state, &channel_id, &node_name).await;
+                            rollback_space_delete_cleanups(
+                                state,
+                                &cleanups,
+                                &node_name,
+                                &std::collections::BTreeSet::new(),
+                                &std::collections::BTreeSet::new(),
+                            )
+                            .await;
+                            return Err(internal_err(format!(
+                                "could not snapshot missing Spaces bookmark for linked channel {room_jid}"
+                            )));
+                        }
+                    }
+                }
+                Ok(false) => {}
+                Err(error) => {
+                    tracing::warn!(
+                        room = %room_jid,
+                        space_node = %node_name,
+                        "cascade destroy: clearing channel parent tuple failed",
+                    );
+                    rollback_space_delete_cleanups(
+                        state,
+                        &cleanups,
+                        &node_name,
+                        &std::collections::BTreeSet::new(),
+                        &std::collections::BTreeSet::new(),
+                    )
+                    .await;
+                    return Err(error);
+                }
+            }
+        }
+
+        let existing_link = match state.channel_space_link_store.get(room_jid).await {
+            Ok(link) => link,
+            Err(error) => {
+                cleanups.push(cleanup);
+                rollback_space_delete_cleanups(
+                    state,
+                    &cleanups,
+                    &node_name,
+                    &std::collections::BTreeSet::new(),
+                    &std::collections::BTreeSet::new(),
+                )
+                .await;
+                return Err(internal_err(format!("channel-space link storage: {error}")));
+            }
+        };
+
+        if existing_link
+            .as_ref()
+            .is_some_and(|link| link.space_jid != args.space_jid)
+        {
+            cleanups.push(cleanup);
+            continue;
+        }
+
+        // Drop the link row only after the parent tuple is gone. If this
+        // fails, the link remains so a retry can still find the target.
+        match state.channel_space_link_store.clear(room_jid).await {
+            Ok(true) => {
+                cleanup.removed_link = existing_link.or_else(|| {
+                    Some(ChannelSpaceLink {
+                        channel_jid: room_jid.clone(),
+                        space_jid: args.space_jid.clone(),
+                        created_at: now_unix_seconds(),
+                    })
+                });
+            }
+            Ok(false) => {}
+            Err(error) => {
+                cleanups.push(cleanup);
+                rollback_space_delete_cleanups(
+                    state,
+                    &cleanups,
+                    &node_name,
+                    &std::collections::BTreeSet::new(),
+                    &std::collections::BTreeSet::new(),
+                )
+                .await;
+                tracing::warn!(
+                    error = %error,
+                    room = %room_jid,
+                    "cascade destroy: clearing channel-space link failed",
+                );
+                return Err(internal_err(format!(
+                    "clearing channel-space link failed for {room_jid}: {error}"
+                )));
+            }
+        }
+        destroy_targets.insert(room_jid.clone());
+        cleanups.push(cleanup);
+    }
+
+    let mut retracted_items: Vec<(String, PubSubItem)> = Vec::new();
+    for stored in &items {
+        let item_id = stored.id.clone();
+        let item = stored.to_pubsub_item();
+        if let Err(error) = state
+            .pubsub_storage
+            .retract_item(&state.spaces_jid, &node_name, &item_id)
+            .await
+        {
+            let failed_restores = restore_space_node_items(
+                state,
+                &node_name,
+                &retracted_items,
+                &std::collections::BTreeSet::new(),
+            )
+            .await;
+            rollback_space_delete_cleanups(
+                state,
+                &cleanups,
+                &node_name,
+                &std::collections::BTreeSet::new(),
+                &failed_restores,
+            )
+            .await;
+            return Err(internal_err(format!(
+                "pubsub retract space item failed for {item_id}: {error}"
+            )));
+        }
+        retracted_items.push((item_id, item));
+    }
+
+    let mut destroyed_rooms: std::collections::BTreeSet<BareJid> =
+        std::collections::BTreeSet::new();
+    for room_jid in &destroy_targets {
         if let Err(error) = state
             .room_registry
             .ask(waddle_xmpp::muc::room_registry_actor::DestroyRoom {
@@ -785,24 +1163,34 @@ async fn run_delete(state: &AppState, args: &SpacesDeleteArgs) -> Result<(), Adm
             })
             .await
         {
+            let failed_restores =
+                restore_space_node_items(state, &node_name, &retracted_items, &destroyed_rooms)
+                    .await;
+            rollback_space_delete_cleanups(
+                state,
+                &cleanups,
+                &node_name,
+                &destroyed_rooms,
+                &failed_restores,
+            )
+            .await;
             tracing::warn!(
                 error = %error,
                 room = %room_jid,
                 "cascade destroy: room registry ask failed",
             );
+            return Err(internal_err(format!(
+                "cascade destroy failed for room {room_jid}: {error}"
+            )));
         }
-        // Drop the link row regardless of room-destroy outcome; the
-        // space is being torn down, so leaving the link row dangling
-        // would make `channels:list space_jid=…` keep returning JIDs
-        // for a space that no longer exists.
-        if let Err(error) = state.channel_space_link_store.clear(&room_jid).await {
-            tracing::warn!(
-                error = %error,
-                room = %room_jid,
-                "cascade destroy: clearing channel-space link failed",
-            );
-        }
+        destroyed_rooms.insert(room_jid.clone());
     }
+
+    state
+        .pubsub_storage
+        .purge_node(&state.spaces_jid, &node_name)
+        .await
+        .map_err(|e| internal_err(format!("pubsub purge_node failed: {e}")))?;
 
     let _deleted = state
         .pubsub_storage

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/disco_info/spaces.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/disco_info/spaces.rs
@@ -45,7 +45,19 @@ pub(super) async fn handle_spaces_disco_info<'a>(
             }
         };
 
-        let space = space_details_from_node(&space_node);
+        let Some(space) = space_details_from_node(&space_node) else {
+            warn!(
+                node,
+                access_model = %space_node.config.access_model,
+                "Spaces node has unsupported access model"
+            );
+            return Some(DiscoInfoResponse::error(
+                req.id,
+                None,
+                None,
+                internal_server_error_iq_error("Internal server error."),
+            ));
+        };
         let requester_affiliation =
             space_affiliation_for_requester(state, authenticated_session, node).await;
         let identities = vec![Identity::pubsub_leaf(Some(&space.name))];

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/permissions.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/permissions.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::permissions::DeleteTuple;
 
 pub(super) fn build_xmpp_error_response(
     request_iq: &xmpp_parsers::iq::Iq,
@@ -216,10 +217,10 @@ pub(super) async fn space_affiliation_for_requester(
     None
 }
 
-pub(super) async fn write_tuple_if_absent(
+async fn write_tuple_if_absent_status(
     state: &WebSocketState,
     tuple: Tuple,
-) -> Result<(), String> {
+) -> Result<bool, String> {
     match state
         .deps
         .app_state
@@ -227,10 +228,19 @@ pub(super) async fn write_tuple_if_absent(
         .ask(WriteTuple { tuple })
         .await
     {
-        Ok(()) => Ok(()),
-        Err(kameo::error::SendError::HandlerError(PermissionError::TupleAlreadyExists)) => Ok(()),
+        Ok(()) => Ok(true),
+        Err(kameo::error::SendError::HandlerError(PermissionError::TupleAlreadyExists)) => {
+            Ok(false)
+        }
         Err(error) => Err(format!("permission actor failed writing tuple: {error}")),
     }
+}
+
+pub(super) async fn write_tuple_if_absent(
+    state: &WebSocketState,
+    tuple: Tuple,
+) -> Result<(), String> {
+    write_tuple_if_absent_status(state, tuple).await.map(|_| ())
 }
 
 pub(super) async fn spaces_node_mutation_allowed(
@@ -305,7 +315,17 @@ pub(super) async fn write_channel_parent_tuple(
     channel_id: &str,
     space_node: &str,
 ) -> Result<(), String> {
-    write_tuple_if_absent(
+    write_channel_parent_tuple_if_absent(state, channel_id, space_node)
+        .await
+        .map(|_| ())
+}
+
+pub(super) async fn write_channel_parent_tuple_if_absent(
+    state: &WebSocketState,
+    channel_id: &str,
+    space_node: &str,
+) -> Result<bool, String> {
+    write_tuple_if_absent_status(
         state,
         Tuple::new(
             Object::new(ObjectType::Channel, channel_id),
@@ -314,6 +334,31 @@ pub(super) async fn write_channel_parent_tuple(
         ),
     )
     .await
+}
+
+pub(super) async fn delete_channel_parent_tuple(
+    state: &WebSocketState,
+    channel_id: &str,
+    space_node: &str,
+) -> Result<bool, String> {
+    let tuple = Tuple::new(
+        Object::new(ObjectType::Channel, channel_id),
+        Relation::new("parent"),
+        Subject::userset(SubjectType::Space, space_node, ""),
+    );
+    match state
+        .deps
+        .app_state
+        .permission_actor
+        .ask(DeleteTuple { tuple })
+        .await
+    {
+        Ok(()) => Ok(true),
+        Err(kameo::error::SendError::HandlerError(
+            crate::permissions::PermissionError::TupleNotFound,
+        )) => Ok(false),
+        Err(error) => Err(format!("permission actor failed deleting tuple: {error}")),
+    }
 }
 
 pub(super) async fn muc_owner_authorized(

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_admin.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_admin.rs
@@ -317,7 +317,10 @@ pub(super) async fn handle_pubsub_admin_request(
             }
         }
 
-        PubSubRequest::ConfigureNodeSet { node, config } => {
+        PubSubRequest::ConfigureNodeSet {
+            node,
+            config: config_patch,
+        } => {
             let is_pep = is_pep_self_or_to(iq, target_jid, user_jid);
             if !crate::pubsub_authz::can_administer(
                 &state.deps.protocol.pubsub_storage,
@@ -331,6 +334,46 @@ pub(super) async fn handle_pubsub_admin_request(
             {
                 return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))];
             }
+            let is_spaces_service = matches!(
+                spaces_service_bare_jid(spaces_domain),
+                Ok(spaces_jid) if target_jid == &spaces_jid
+            );
+            let existing_node = match state
+                .deps
+                .protocol
+                .pubsub_storage
+                .get_node(target_jid, &node)
+                .await
+            {
+                Ok(Some(node)) => node,
+                Ok(None) => {
+                    return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::NodeNotFound))];
+                }
+                Err(error) => {
+                    warn!(node = %node, error = %error, "Failed to load PubSub node before configure");
+                    return vec![iq_to_xml(build_pubsub_error(
+                        iq,
+                        PubSubError::InternalServerError,
+                    ))];
+                }
+            };
+            let config = config_patch.apply_to(existing_node.config);
+            let config = if is_spaces_service {
+                let access_model = config.access_model;
+                match normalize_spaces_node_config(config, config_patch.max_items.is_some()) {
+                    Some(config) => config,
+                    None => {
+                        warn!(
+                            node = %node,
+                            access_model = %access_model,
+                            "Rejected Spaces node configuration with unsupported access model"
+                        );
+                        return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::BadRequest))];
+                    }
+                }
+            } else {
+                config
+            };
             match state
                 .deps
                 .protocol
@@ -409,4 +452,31 @@ pub(super) async fn handle_pubsub_admin_request(
         | PubSubRequest::Items { .. }
         | PubSubRequest::Retract { .. } => Vec::new(),
     }
+}
+
+fn normalize_spaces_node_config(
+    mut config: waddle_xmpp::pubsub::NodeConfig,
+    preserve_submitted_max_items: bool,
+) -> Option<waddle_xmpp::pubsub::NodeConfig> {
+    // Waddle currently supports XEP-0503 public Spaces as `open` and private
+    // Spaces as `whitelist`. Reject `authorize` until the XEP-0060
+    // owner-approval subscription flow exists, and keep the required Spaces
+    // durability/notification invariants regardless of generic PubSub form
+    // fields submitted by a client.
+    match config.access_model {
+        waddle_xmpp::pubsub::AccessModel::Open | waddle_xmpp::pubsub::AccessModel::Whitelist => {}
+        waddle_xmpp::pubsub::AccessModel::Presence
+        | waddle_xmpp::pubsub::AccessModel::Roster
+        | waddle_xmpp::pubsub::AccessModel::Authorize => return None,
+    }
+    if !preserve_submitted_max_items {
+        config.max_items = u32::MAX;
+    }
+    config.publish_model = waddle_xmpp::pubsub::PublishModel::Publishers;
+    config.persist_items = true;
+    config.deliver_payloads = true;
+    config.notify_retract = true;
+    config.notify_delete = true;
+    config.send_last_published_item = waddle_xmpp::pubsub::SendLastPublishedItem::OnSub;
+    Some(config)
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_dispatch.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_dispatch.rs
@@ -266,6 +266,7 @@ pub(super) async fn handle_pubsub_iq(
                         iq,
                         state,
                         spaces_domain,
+                        &user_jid,
                         &node,
                         max_items,
                         &item_ids,
@@ -315,17 +316,36 @@ pub(super) async fn handle_pubsub_iq(
                 {
                     Ok(true) => {}
                     Ok(false) => {
-                        let node_exists = state
+                        let node_meta = state
                             .deps
                             .protocol
                             .pubsub_storage
                             .get_node(&target_jid, &node)
                             .await
                             .ok()
-                            .flatten()
-                            .is_some();
-                        let error = if node_exists {
-                            build_pubsub_error(iq, PubSubError::Forbidden)
+                            .flatten();
+                        let is_outcast = crate::pubsub_authz::effective_affiliation(
+                            &state.deps.protocol.pubsub_storage,
+                            &target_jid,
+                            &node,
+                            &user_jid,
+                            is_pep,
+                        )
+                        .await
+                        .is_ok_and(|affiliation| affiliation.is_outcast());
+                        let error = if let Some(node_meta) = node_meta {
+                            if is_outcast {
+                                build_pubsub_error(iq, PubSubError::Forbidden)
+                            } else if !is_pep
+                                && matches!(
+                                    node_meta.config.access_model,
+                                    waddle_xmpp::pubsub::AccessModel::Whitelist
+                                )
+                            {
+                                build_pubsub_error(iq, PubSubError::ClosedNode)
+                            } else {
+                                build_pubsub_error(iq, PubSubError::Forbidden)
+                            }
                         } else {
                             build_pubsub_error(iq, PubSubError::NodeNotFound)
                         };

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
@@ -1,4 +1,7 @@
-use super::permissions::{permission_allowed, write_channel_parent_tuple};
+use super::permissions::{
+    delete_channel_parent_tuple, permission_allowed, write_channel_parent_tuple,
+    write_channel_parent_tuple_if_absent,
+};
 use super::*;
 use crate::server::routes::websocket::handlers::pubsub_fanout;
 
@@ -75,21 +78,32 @@ pub(super) fn spaces_service_bare_jid(spaces_domain: &str) -> Result<BareJid, St
         .map_err(|error| format!("invalid spaces service JID: {error}"))
 }
 
-pub(super) fn space_details_from_node(node: &waddle_xmpp::pubsub::PubSubNode) -> SpaceDetails {
+fn space_jid_for_node(spaces_jid: &BareJid, node: &str) -> Option<BareJid> {
+    format!("{}@{}", node, spaces_jid.domain()).parse().ok()
+}
+
+pub(super) fn space_details_from_node(
+    node: &waddle_xmpp::pubsub::PubSubNode,
+) -> Option<SpaceDetails> {
+    let access_model = waddle_xmpp::SpaceAccessModel::from_pubsub(node.config.access_model)?;
     let name = if node.node_name == "general" {
         "General".to_string()
     } else {
         node.node_name.clone()
     };
-    SpaceDetails {
+    Some(SpaceDetails {
         id: node.node_name.clone(),
         name,
         description: None,
         owner_id: node.owner.to_string(),
         icon_url: None,
-        is_public: true,
+        is_public: matches!(
+            node.config.access_model,
+            waddle_xmpp::pubsub::AccessModel::Open
+        ),
+        access_model,
         created_at: node.created_at.to_rfc3339(),
-    }
+    })
 }
 
 fn channels_to_disco_items(channels: Vec<XmppChannelRecord>, muc_domain: &str) -> Vec<DiscoItem> {
@@ -167,6 +181,7 @@ pub(super) async fn handle_spaces_items(
     iq: &xmpp_parsers::iq::Iq,
     state: &WebSocketState,
     spaces_domain: &str,
+    requester_jid: &BareJid,
     node: &str,
     max_items: Option<u32>,
     item_ids: &[String],
@@ -174,20 +189,61 @@ pub(super) async fn handle_spaces_items(
     let Ok(spaces_jid) = spaces_service_bare_jid(spaces_domain) else {
         return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::InvalidJid))];
     };
-    match state
-        .deps
-        .protocol
-        .pubsub_storage
-        .get_node(&spaces_jid, node)
-        .await
+    match crate::pubsub_authz::can_subscribe(
+        &state.deps.protocol.pubsub_storage,
+        &spaces_jid,
+        node,
+        requester_jid,
+        false,
+    )
+    .await
     {
-        Ok(Some(_)) => {}
-        Ok(None) => return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::NodeNotFound))],
+        Ok(true) => {}
+        Ok(false) => {
+            let node_meta = state
+                .deps
+                .protocol
+                .pubsub_storage
+                .get_node(&spaces_jid, node)
+                .await
+                .ok()
+                .flatten();
+            let is_outcast = crate::pubsub_authz::effective_affiliation(
+                &state.deps.protocol.pubsub_storage,
+                &spaces_jid,
+                node,
+                requester_jid,
+                false,
+            )
+            .await
+            .is_ok_and(|affiliation| affiliation.is_outcast());
+            let error = if let Some(node_meta) = node_meta {
+                if is_outcast {
+                    PubSubError::Forbidden
+                } else if matches!(
+                    node_meta.config.access_model,
+                    waddle_xmpp::pubsub::AccessModel::Whitelist
+                ) {
+                    PubSubError::ClosedNode
+                } else {
+                    PubSubError::Forbidden
+                }
+            } else {
+                PubSubError::NodeNotFound
+            };
+            return vec![iq_to_xml(build_pubsub_error(iq, error))];
+        }
         Err(error) => {
-            warn!(node, error = %error, "Failed to retrieve Spaces node");
-            return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::NodeNotFound))];
+            warn!(
+                node,
+                requester = %requester_jid,
+                error = %error,
+                "Failed to authorize Spaces items access"
+            );
+            return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))];
         }
     }
+    backfill_missing_space_bookmarks(state, &spaces_jid, node, item_ids).await;
     match state
         .deps
         .protocol
@@ -205,6 +261,204 @@ pub(super) async fn handle_spaces_items(
         Err(error) => {
             warn!(node, error = %error, "Failed to retrieve Spaces items");
             vec![iq_to_xml(build_pubsub_error(iq, PubSubError::NodeNotFound))]
+        }
+    }
+}
+
+async fn backfill_missing_space_bookmarks(
+    state: &WebSocketState,
+    spaces_jid: &BareJid,
+    node: &str,
+    item_ids: &[String],
+) {
+    let Some(space_jid) = space_jid_for_node(spaces_jid, node) else {
+        warn!(
+            node,
+            spaces = %spaces_jid,
+            "Skipping channel-space link bookmark backfill for non-JID Space node"
+        );
+        return;
+    };
+    let links = match state
+        .deps
+        .app_state
+        .channel_space_link_store
+        .list_channels_in_space(&space_jid)
+        .await
+    {
+        Ok(links) => links,
+        Err(error) => {
+            warn!(node, error = %error, "Failed to list channel-space links for Spaces bookmark backfill");
+            return;
+        }
+    };
+    if links.is_empty() {
+        return;
+    }
+
+    let existing_ids = match state
+        .deps
+        .protocol
+        .pubsub_storage
+        .get_items(spaces_jid, node, None, &[])
+        .await
+    {
+        Ok(items) => items
+            .into_iter()
+            .map(|item| item.id)
+            .collect::<std::collections::HashSet<_>>(),
+        Err(error) => {
+            warn!(node, error = %error, "Failed to inspect Spaces items before bookmark backfill");
+            return;
+        }
+    };
+
+    for channel_jid in links {
+        let item_id = channel_jid.to_string();
+        if existing_ids.contains(&item_id)
+            || (!item_ids.is_empty() && !item_ids.iter().any(|id| id == &item_id))
+        {
+            continue;
+        }
+        let Some(channel_id) = waddle_xmpp::parse_managed_room_jid(&channel_jid) else {
+            warn!(channel = %channel_jid, "Skipping Spaces bookmark backfill for non-managed room JID");
+            continue;
+        };
+        let room = match state
+            .deps
+            .protocol
+            .room_registry
+            .ask(waddle_xmpp::muc::room_registry_actor::GetRoom {
+                room_jid: channel_jid.clone(),
+            })
+            .await
+        {
+            Ok(Some(room)) => room,
+            Ok(None) => {
+                warn!(channel = %channel_jid, "Skipping Spaces bookmark backfill for missing MUC room");
+                continue;
+            }
+            Err(error) => {
+                warn!(channel = %channel_jid, error = %error, "Failed to load MUC room for Spaces bookmark backfill");
+                continue;
+            }
+        };
+        let config = match room.ask(waddle_xmpp::muc::room_actor::GetConfig).await {
+            Ok(config) => config,
+            Err(error) => {
+                warn!(channel = %channel_jid, error = %error, "Failed to load room config for Spaces bookmark backfill");
+                continue;
+            }
+        };
+        let channel_type = if config.forum { "forum" } else { "text" };
+        let item = match waddle_xmpp::xep::build_channel_item(
+            &waddle_xmpp::ChannelInfo {
+                id: channel_id.clone(),
+                name: config.name,
+                channel_type: channel_type.to_string(),
+            },
+            &state.deps.service_domains.muc,
+        ) {
+            Ok(item) => item,
+            Err(error) => {
+                warn!(channel = %channel_jid, error = %error, "Failed to build Spaces bookmark backfill item");
+                continue;
+            }
+        };
+        let stale_nodes = match state
+            .deps
+            .protocol
+            .pubsub_storage
+            .list_node_names_for_item(spaces_jid, &item_id)
+            .await
+        {
+            Ok(stale_nodes) => stale_nodes,
+            Err(error) => {
+                warn!(channel = %channel_jid, node, error = %error, "Failed to enumerate stale Spaces bookmarks before backfill");
+                continue;
+            }
+        };
+        let publish_result = match state
+            .deps
+            .protocol
+            .pubsub_storage
+            .publish_item(spaces_jid, node, &item, None, false)
+            .await
+        {
+            Ok(result) => result,
+            Err(error) => {
+                warn!(channel = %channel_jid, node, error = %error, "Failed to backfill Spaces bookmark item");
+                continue;
+            }
+        };
+        let parent_tuple_created = match write_channel_parent_tuple_if_absent(
+            state,
+            &channel_id,
+            node,
+        )
+        .await
+        {
+            Ok(created) => created,
+            Err(error) => {
+                let _ = state
+                    .deps
+                    .protocol
+                    .pubsub_storage
+                    .retract_item(spaces_jid, node, &publish_result.item_id)
+                    .await;
+                warn!(channel = %channel_jid, node, error = %error, "Backfilled Spaces bookmark but failed to repair channel parent tuple; retracted backfill item");
+                continue;
+            }
+        };
+        if let Err(error) = cleanup_stale_space_bookmarks(
+            state,
+            spaces_jid,
+            &channel_id,
+            node,
+            &item_id,
+            &stale_nodes,
+        )
+        .await
+        {
+            let tuple_ready_for_retract = if parent_tuple_created {
+                match delete_channel_parent_tuple(state, &channel_id, node).await {
+                    Ok(_) => true,
+                    Err(delete_error) => {
+                        warn!(
+                            channel = %channel_jid,
+                            node,
+                            error = %delete_error,
+                            "Failed to delete operation-created parent tuple after stale cleanup failure; preserving backfilled Spaces bookmark"
+                        );
+                        false
+                    }
+                }
+            } else {
+                true
+            };
+            if tuple_ready_for_retract {
+                match state
+                    .deps
+                    .protocol
+                    .pubsub_storage
+                    .retract_item(spaces_jid, node, &publish_result.item_id)
+                    .await
+                {
+                    Ok(_) => {}
+                    Err(retract_error) => {
+                        if parent_tuple_created {
+                            let _ = write_channel_parent_tuple(state, &channel_id, node).await;
+                        }
+                        warn!(
+                            channel = %channel_jid,
+                            node,
+                            error = %retract_error,
+                            "Failed to retract backfilled Spaces bookmark after stale cleanup failure; preserving repaired parent tuple"
+                        );
+                    }
+                }
+            }
+            warn!(channel = %channel_jid, node, error = %error, "Backfilled Spaces bookmark but failed to clean stale bookmarks");
         }
     }
 }
@@ -395,57 +649,64 @@ pub(super) async fn handle_spaces_publish(
         }
     }
 
-    // XEP-0503 single-space-membership: a channel has exactly one
-    // parent space. If the same bookmark item lives in any other
-    // space node, retract it there first — otherwise we'd ship the
-    // item in two `<items>` listings and `find_node_for_item` would
-    // alphabetically pin the room under whichever space sorted first
-    // (the original "rooms always show up under General" bug).
-    //
-    // Retract failures here are non-fatal: they're logged and the
-    // publish proceeds, since `find_node_for_item` now also tiebreaks
-    // by most-recent `seq` and will route lookups to the new node.
-    // The retract is still attempted so legacy clients listing each
-    // space don't see the room twice.
-    match state
+    let stale_nodes = match state
         .deps
         .protocol
         .pubsub_storage
         .list_node_names_for_item(&spaces_jid, item_id)
         .await
     {
-        Ok(stale_nodes) => {
-            for stale in stale_nodes.iter().filter(|name| name.as_str() != node) {
-                if let Err(error) = state
-                    .deps
-                    .protocol
-                    .pubsub_storage
-                    .retract_item(&spaces_jid, stale, item_id)
-                    .await
-                {
-                    warn!(
-                        channel_id = %channel_id,
-                        from_node = %stale,
-                        to_node = node,
-                        item_id,
-                        error = %error,
-                        "Failed to retract room bookmark from prior Space node before re-publish; \
-                         room may briefly appear in multiple Spaces"
-                    );
-                }
-            }
-        }
+        Ok(stale_nodes) => stale_nodes,
         Err(error) => {
             warn!(
                 channel_id = %channel_id,
                 node,
                 item_id,
                 error = %error,
-                "Failed to enumerate prior Space nodes for room bookmark; \
-                 single-membership invariant may be violated"
+                "Failed to enumerate prior Space nodes for room bookmark"
             );
+            return vec![iq_to_xml(build_pubsub_error(
+                iq,
+                PubSubError::InternalServerError,
+            ))];
         }
-    }
+    };
+    let previous_link = match state
+        .deps
+        .app_state
+        .channel_space_link_store
+        .get(&bookmark.jid)
+        .await
+    {
+        Ok(link) => link,
+        Err(error) => {
+            warn!(item_id, node, error = %error, "Failed to read channel-space link before Spaces publish");
+            return vec![iq_to_xml(build_pubsub_error(
+                iq,
+                PubSubError::InternalServerError,
+            ))];
+        }
+    };
+    let current_item_filter = [item_id.to_string()];
+    let previous_item = match state
+        .deps
+        .protocol
+        .pubsub_storage
+        .get_items(&spaces_jid, node, Some(1), &current_item_filter)
+        .await
+    {
+        Ok(items) => items
+            .into_iter()
+            .next()
+            .map(|stored| stored.to_pubsub_item()),
+        Err(error) => {
+            warn!(item_id, node, error = %error, "Failed to read existing Spaces item before publish");
+            return vec![iq_to_xml(build_pubsub_error(
+                iq,
+                PubSubError::InternalServerError,
+            ))];
+        }
+    };
 
     match state
         .deps
@@ -455,31 +716,178 @@ pub(super) async fn handle_spaces_publish(
         .await
     {
         Ok(result) => {
-            if let Err(error) = write_channel_parent_tuple(state, &channel_id, node).await {
-                warn!(
-                    channel_id = %channel_id,
-                    node,
-                    error = %error,
-                    "Published Spaces item but failed to sync channel parent tuple; \
-                     retracting to keep PubSub and permission graph consistent"
-                );
-                // Compensating retract: remove the just-published bookmark so
-                // the server does not end up in a state where the item is
-                // advertised in PubSub but the channel is not accessible via
-                // Space membership (XEP-0503 §4).
-                if let Err(retract_err) = state
+            let projected_space_jid = space_jid_for_node(&spaces_jid, node);
+            if let Some(space_jid) = projected_space_jid.as_ref() {
+                if let Err(error) = state
                     .deps
-                    .protocol
-                    .pubsub_storage
-                    .retract_item(&spaces_jid, node, &result.item_id)
+                    .app_state
+                    .channel_space_link_store
+                    .set(&crate::channel_space_links::ChannelSpaceLink {
+                        channel_jid: bookmark.jid.clone(),
+                        space_jid: space_jid.clone(),
+                        created_at: chrono::Utc::now().timestamp(),
+                    })
                     .await
                 {
                     warn!(
                         channel_id = %channel_id,
                         node,
-                        item_id = %result.item_id,
-                        error = %retract_err,
-                        "Compensating retract also failed; manual cleanup may be required"
+                        error = %error,
+                        "Published Spaces item but failed to sync channel-space link projection; \
+                         rolling back to keep PubSub and durable discovery state consistent"
+                    );
+                    if let Err(rollback_error) = rollback_spaces_publish(
+                        state,
+                        SpacesPublishRollback {
+                            spaces_jid: &spaces_jid,
+                            node,
+                            item_id: &result.item_id,
+                            previous_item: previous_item.as_ref(),
+                            channel_id: &channel_id,
+                            channel_jid: &bookmark.jid,
+                            previous_link: previous_link.as_ref(),
+                            parent_tuple_created: false,
+                        },
+                    )
+                    .await
+                    {
+                        warn!(
+                            channel_id = %channel_id,
+                            node,
+                            error = %rollback_error,
+                            "Failed to roll back Spaces publish after link projection failure"
+                        );
+                    }
+                    return vec![iq_to_xml(build_pubsub_error(
+                        iq,
+                        PubSubError::InternalServerError,
+                    ))];
+                }
+            } else {
+                warn!(
+                    node,
+                    spaces = %spaces_jid,
+                    "Clearing channel-space link projection for non-JID Space node"
+                );
+                if let Err(error) = state
+                    .deps
+                    .app_state
+                    .channel_space_link_store
+                    .clear(&bookmark.jid)
+                    .await
+                {
+                    warn!(
+                        channel_id = %channel_id,
+                        node,
+                        error = %error,
+                        "Published Spaces item but failed to clear stale channel-space link projection; \
+                         rolling back to keep PubSub and durable discovery state consistent"
+                    );
+                    if let Err(rollback_error) = rollback_spaces_publish(
+                        state,
+                        SpacesPublishRollback {
+                            spaces_jid: &spaces_jid,
+                            node,
+                            item_id: &result.item_id,
+                            previous_item: previous_item.as_ref(),
+                            channel_id: &channel_id,
+                            channel_jid: &bookmark.jid,
+                            previous_link: previous_link.as_ref(),
+                            parent_tuple_created: false,
+                        },
+                    )
+                    .await
+                    {
+                        warn!(
+                            channel_id = %channel_id,
+                            node,
+                            error = %rollback_error,
+                            "Failed to roll back Spaces publish after link projection clear failure"
+                        );
+                    }
+                    return vec![iq_to_xml(build_pubsub_error(
+                        iq,
+                        PubSubError::InternalServerError,
+                    ))];
+                }
+            }
+            let parent_tuple_created =
+                match write_channel_parent_tuple_if_absent(state, &channel_id, node).await {
+                    Ok(created) => created,
+                    Err(error) => {
+                        warn!(
+                            channel_id = %channel_id,
+                            node,
+                            error = %error,
+                            "Published Spaces item but failed to sync channel parent tuple; \
+                             rolling back to keep PubSub and permission graph consistent"
+                        );
+                        if let Err(rollback_error) = rollback_spaces_publish(
+                            state,
+                            SpacesPublishRollback {
+                                spaces_jid: &spaces_jid,
+                                node,
+                                item_id: &result.item_id,
+                                previous_item: previous_item.as_ref(),
+                                channel_id: &channel_id,
+                                channel_jid: &bookmark.jid,
+                                previous_link: previous_link.as_ref(),
+                                parent_tuple_created: false,
+                            },
+                        )
+                        .await
+                        {
+                            warn!(
+                                channel_id = %channel_id,
+                                node,
+                                error = %rollback_error,
+                                "Failed to roll back Spaces publish after parent tuple failure"
+                            );
+                        }
+                        return vec![iq_to_xml(build_pubsub_error(
+                            iq,
+                            PubSubError::InternalServerError,
+                        ))];
+                    }
+                };
+            if let Err(error) = cleanup_stale_space_bookmarks(
+                state,
+                &spaces_jid,
+                &channel_id,
+                node,
+                item_id,
+                &stale_nodes,
+            )
+            .await
+            {
+                warn!(
+                    channel_id = %channel_id,
+                    node,
+                    item_id,
+                    error = %error,
+                    "Published Spaces item but failed to clean stale prior Space bookmarks"
+                );
+                if let Err(rollback_error) = rollback_spaces_publish(
+                    state,
+                    SpacesPublishRollback {
+                        spaces_jid: &spaces_jid,
+                        node,
+                        item_id: &result.item_id,
+                        previous_item: previous_item.as_ref(),
+                        channel_id: &channel_id,
+                        channel_jid: &bookmark.jid,
+                        previous_link: previous_link.as_ref(),
+                        parent_tuple_created,
+                    },
+                )
+                .await
+                {
+                    warn!(
+                        channel_id = %channel_id,
+                        node,
+                        item_id,
+                        error = %rollback_error,
+                        "Failed to roll back Spaces publish after stale cleanup failure"
                     );
                 }
                 return vec![iq_to_xml(build_pubsub_error(
@@ -936,6 +1344,187 @@ async fn handle_community_non_bookmark_publish(
     }
 }
 
+async fn restore_channel_space_link_projection(
+    state: &WebSocketState,
+    channel_jid: &BareJid,
+    previous_link: Option<&crate::channel_space_links::ChannelSpaceLink>,
+) -> Result<(), String> {
+    if let Some(link) = previous_link {
+        state
+            .deps
+            .app_state
+            .channel_space_link_store
+            .set(link)
+            .await
+            .map_err(|error| format!("channel-space link restore failed: {error}"))?;
+    } else {
+        state
+            .deps
+            .app_state
+            .channel_space_link_store
+            .clear(channel_jid)
+            .await
+            .map_err(|error| format!("channel-space link clear failed: {error}"))?;
+    }
+    Ok(())
+}
+
+struct SpacesPublishRollback<'a> {
+    spaces_jid: &'a BareJid,
+    node: &'a str,
+    item_id: &'a str,
+    previous_item: Option<&'a PubSubItem>,
+    channel_id: &'a str,
+    channel_jid: &'a BareJid,
+    previous_link: Option<&'a crate::channel_space_links::ChannelSpaceLink>,
+    parent_tuple_created: bool,
+}
+
+async fn rollback_spaces_publish(
+    state: &WebSocketState,
+    rollback: SpacesPublishRollback<'_>,
+) -> Result<(), String> {
+    if rollback.parent_tuple_created {
+        delete_channel_parent_tuple(state, rollback.channel_id, rollback.node)
+            .await
+            .map_err(|error| format!("parent tuple rollback failed: {error}"))?;
+    }
+    if let Some(item) = rollback.previous_item {
+        if let Err(error) = state
+            .deps
+            .protocol
+            .pubsub_storage
+            .publish_item(rollback.spaces_jid, rollback.node, item, None, false)
+            .await
+        {
+            if rollback.parent_tuple_created {
+                let _ = write_channel_parent_tuple(state, rollback.channel_id, rollback.node).await;
+            }
+            return Err(format!("pubsub restore Spaces item failed: {error}"));
+        }
+    } else {
+        if let Err(error) = state
+            .deps
+            .protocol
+            .pubsub_storage
+            .retract_item(rollback.spaces_jid, rollback.node, rollback.item_id)
+            .await
+        {
+            if rollback.parent_tuple_created {
+                let _ = write_channel_parent_tuple(state, rollback.channel_id, rollback.node).await;
+            }
+            return Err(format!("pubsub rollback Spaces item failed: {error}"));
+        }
+    }
+    restore_channel_space_link_projection(state, rollback.channel_jid, rollback.previous_link)
+        .await?;
+    Ok(())
+}
+
+async fn cleanup_stale_space_bookmarks(
+    state: &WebSocketState,
+    spaces_jid: &BareJid,
+    channel_id: &str,
+    keep_node: &str,
+    item_id: &str,
+    stale_nodes: &[String],
+) -> Result<(), String> {
+    let mut removed_stale: Vec<RemovedStaleSpaceBookmark> = Vec::new();
+    for stale in stale_nodes.iter().filter(|name| name.as_str() != keep_node) {
+        let item_filter = [item_id.to_string()];
+        let previous_item = match state
+            .deps
+            .protocol
+            .pubsub_storage
+            .get_items(spaces_jid, stale, Some(1), &item_filter)
+            .await
+        {
+            Ok(items) => items
+                .into_iter()
+                .next()
+                .map(|stored| stored.to_pubsub_item()),
+            Err(error) => {
+                restore_stale_space_bookmarks(state, spaces_jid, channel_id, &removed_stale).await;
+                return Err(format!(
+                    "pubsub read stale channel bookmark from {stale} failed: {error}"
+                ));
+            }
+        };
+        let parent_tuple_deleted = match delete_channel_parent_tuple(state, channel_id, stale).await
+        {
+            Ok(deleted) => deleted,
+            Err(error) => {
+                restore_stale_space_bookmarks(state, spaces_jid, channel_id, &removed_stale).await;
+                return Err(error);
+            }
+        };
+        match state
+            .deps
+            .protocol
+            .pubsub_storage
+            .retract_item(spaces_jid, stale, item_id)
+            .await
+        {
+            Ok(_) => {
+                removed_stale.push(RemovedStaleSpaceBookmark {
+                    node: stale.clone(),
+                    item: previous_item,
+                    parent_tuple_deleted,
+                });
+            }
+            Err(error) => {
+                if parent_tuple_deleted {
+                    let _ = write_channel_parent_tuple(state, channel_id, stale).await;
+                }
+                restore_stale_space_bookmarks(state, spaces_jid, channel_id, &removed_stale).await;
+                return Err(format!(
+                    "pubsub retract stale channel bookmark from {stale} failed: {error}"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+struct RemovedStaleSpaceBookmark {
+    node: String,
+    item: Option<PubSubItem>,
+    parent_tuple_deleted: bool,
+}
+
+async fn restore_stale_space_bookmarks(
+    state: &WebSocketState,
+    spaces_jid: &BareJid,
+    channel_id: &str,
+    removed_stale: &[RemovedStaleSpaceBookmark],
+) {
+    for removed in removed_stale.iter().rev() {
+        if let Some(item) = removed.item.as_ref() {
+            match state
+                .deps
+                .protocol
+                .pubsub_storage
+                .publish_item(spaces_jid, &removed.node, item, None, false)
+                .await
+            {
+                Ok(_) => {
+                    if removed.parent_tuple_deleted {
+                        let _ = write_channel_parent_tuple(state, channel_id, &removed.node).await;
+                    }
+                }
+                Err(error) => {
+                    warn!(
+                        channel_id = %channel_id,
+                        node = %removed.node,
+                        error = %error,
+                        "Failed to restore stale Space bookmark after cleanup rollback"
+                    );
+                }
+            }
+        }
+    }
+}
+
 pub(super) async fn handle_spaces_retract(
     iq: &xmpp_parsers::iq::Iq,
     state: &WebSocketState,
@@ -960,9 +1549,78 @@ pub(super) async fn handle_spaces_retract(
     if room_jid.domain().as_str() != muc_domain {
         return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::InvalidJid))];
     }
+    let Some(channel_id) = waddle_xmpp::parse_managed_room_jid(&room_jid) else {
+        return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::InvalidJid))];
+    };
     let Ok(spaces_jid) = spaces_service_bare_jid(spaces_domain) else {
         return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::InvalidJid))];
     };
+    let target_space_jid = space_jid_for_node(&spaces_jid, node);
+    let item_filter = [item_id.to_string()];
+    match state
+        .deps
+        .protocol
+        .pubsub_storage
+        .get_items(&spaces_jid, node, Some(1), &item_filter)
+        .await
+    {
+        Ok(items) if items.is_empty() => {
+            return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::ItemNotFound))];
+        }
+        Ok(_) => {}
+        Err(error) => {
+            warn!(item_id, node, error = %error, "Failed to preflight Spaces item before retract");
+            return vec![iq_to_xml(build_pubsub_error(
+                iq,
+                PubSubError::InternalServerError,
+            ))];
+        }
+    }
+    let link_to_restore = match state
+        .deps
+        .app_state
+        .channel_space_link_store
+        .get(&room_jid)
+        .await
+    {
+        Ok(Some(link)) if target_space_jid.as_ref() == Some(&link.space_jid) => Some(link),
+        Ok(_) => None,
+        Err(error) => {
+            warn!(item_id, node, error = %error, "Failed to read channel-space link before Spaces retract");
+            return vec![iq_to_xml(build_pubsub_error(
+                iq,
+                PubSubError::InternalServerError,
+            ))];
+        }
+    };
+    let parent_tuple_deleted = match delete_channel_parent_tuple(state, &channel_id, node).await {
+        Ok(deleted) => deleted,
+        Err(error) => {
+            warn!(item_id, node, error = %error, "Failed to clear channel parent tuple before Spaces retract");
+            return vec![iq_to_xml(build_pubsub_error(
+                iq,
+                PubSubError::InternalServerError,
+            ))];
+        }
+    };
+    if link_to_restore.is_some() {
+        if let Err(error) = state
+            .deps
+            .app_state
+            .channel_space_link_store
+            .clear(&room_jid)
+            .await
+        {
+            if parent_tuple_deleted {
+                let _ = write_channel_parent_tuple(state, &channel_id, node).await;
+            }
+            warn!(item_id, node, error = %error, "Failed to clear channel-space link before Spaces retract");
+            return vec![iq_to_xml(build_pubsub_error(
+                iq,
+                PubSubError::InternalServerError,
+            ))];
+        }
+    }
     match state
         .deps
         .protocol
@@ -971,8 +1629,66 @@ pub(super) async fn handle_spaces_retract(
         .await
     {
         Ok(true) => vec![iq_to_xml(build_pubsub_success(iq))],
-        Ok(false) => vec![iq_to_xml(build_pubsub_error(iq, PubSubError::ItemNotFound))],
+        Ok(false) => {
+            if parent_tuple_deleted {
+                if let Err(restore_error) =
+                    write_channel_parent_tuple(state, &channel_id, node).await
+                {
+                    warn!(
+                        item_id,
+                        node,
+                        error = %restore_error,
+                        "Failed to restore channel parent tuple after Spaces retract returned item-not-found"
+                    );
+                }
+            }
+            if let Some(link) = link_to_restore.as_ref() {
+                if let Err(restore_error) = state
+                    .deps
+                    .app_state
+                    .channel_space_link_store
+                    .set(link)
+                    .await
+                {
+                    warn!(
+                        item_id,
+                        node,
+                        error = %restore_error,
+                        "Failed to restore channel-space link after Spaces retract returned item-not-found"
+                    );
+                }
+            }
+            vec![iq_to_xml(build_pubsub_error(iq, PubSubError::ItemNotFound))]
+        }
         Err(error) => {
+            if parent_tuple_deleted {
+                if let Err(restore_error) =
+                    write_channel_parent_tuple(state, &channel_id, node).await
+                {
+                    warn!(
+                        item_id,
+                        node,
+                        error = %restore_error,
+                        "Failed to restore channel parent tuple after Spaces retract failure"
+                    );
+                }
+            }
+            if let Some(link) = link_to_restore.as_ref() {
+                if let Err(restore_error) = state
+                    .deps
+                    .app_state
+                    .channel_space_link_store
+                    .set(link)
+                    .await
+                {
+                    warn!(
+                        item_id,
+                        node,
+                        error = %restore_error,
+                        "Failed to restore channel-space link after Spaces retract failure"
+                    );
+                }
+            }
             warn!(item_id, node, error = %error, "Failed to retract Spaces item");
             vec![iq_to_xml(build_pubsub_error(
                 iq,

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::permissions::{CheckPermission, SubjectType};
 
 fn disco_feature_vars_for_test(query: &Element) -> std::collections::BTreeSet<String> {
     query
@@ -21,6 +22,54 @@ fn disco_items_for_test(query: &Element) -> Vec<(Option<String>, Option<String>)
             )
         })
         .collect()
+}
+
+async fn grant_space_member_for_test(state: &WebSocketState, space_node: &str, user_id: &str) {
+    state
+        .deps
+        .app_state
+        .permission_actor
+        .ask(WriteTuple {
+            tuple: Tuple::new(
+                Object::new(ObjectType::Space, space_node),
+                Relation::new("member"),
+                Subject::user(user_id),
+            ),
+        })
+        .await
+        .expect("space member tuple");
+}
+
+async fn channel_view_allowed_for_test(
+    state: &WebSocketState,
+    channel_id: &str,
+    user_id: &str,
+) -> bool {
+    state
+        .deps
+        .app_state
+        .permission_actor
+        .ask(CheckPermission {
+            subject: Subject::user(user_id),
+            permission: Permission::View,
+            object: Object::new(ObjectType::Channel, channel_id),
+        })
+        .await
+        .expect("permission actor")
+        .allowed
+}
+
+fn data_form_value_for_test(frame: &str, var: &str) -> Option<String> {
+    let marker_single = format!("var='{var}'");
+    let marker_double = format!("var=\"{var}\"");
+    let idx = frame
+        .find(&marker_single)
+        .or_else(|| frame.find(&marker_double))?;
+    let after = &frame[idx..];
+    let open = after.find("<value>")?;
+    let value = &after[open + "<value>".len()..];
+    let close = value.find("</value>")?;
+    Some(value[..close].to_string())
 }
 
 #[tokio::test]
@@ -1383,6 +1432,17 @@ async fn handle_iq_pubsub_items_spaces_node_lists_published_bookmarks() {
         .get_or_create_node(&spaces_jid, "team")
         .await
         .expect("space node");
+    state
+        .deps
+        .protocol
+        .pubsub_storage
+        .update_node_config(
+            &spaces_jid,
+            "team",
+            &waddle_xmpp::pubsub::NodeConfig::spaces_public(),
+        )
+        .await
+        .expect("space node config");
     let channel = waddle_xmpp::ChannelInfo {
         id: "general".to_string(),
         name: "General".to_string(),
@@ -1439,6 +1499,1132 @@ async fn handle_iq_pubsub_items_spaces_node_lists_published_bookmarks() {
 }
 
 #[tokio::test]
+async fn handle_iq_pubsub_items_spaces_node_backfills_linked_channel_bookmarks() {
+    let state = create_test_websocket_state().await;
+    let session = create_test_session(state.as_ref(), "alice").await;
+
+    let spaces_jid: BareJid = "spaces.example.com".parse().expect("spaces jid");
+    state
+        .deps
+        .protocol
+        .pubsub_storage
+        .get_or_create_node(&spaces_jid, "team")
+        .await
+        .expect("space node");
+    state
+        .deps
+        .protocol
+        .pubsub_storage
+        .update_node_config(
+            &spaces_jid,
+            "team",
+            &waddle_xmpp::pubsub::NodeConfig::spaces_public(),
+        )
+        .await
+        .expect("space node config");
+
+    let channel_jid: BareJid = "legacy@muc.example.com".parse().expect("channel jid");
+    let mut config = waddle_xmpp::muc::RoomConfig {
+        name: "Legacy".to_string(),
+        description: None,
+        persistent: true,
+        members_only: false,
+        ..waddle_xmpp::muc::RoomConfig::default()
+    };
+    config.enable_logging = true;
+    state
+        .deps
+        .protocol
+        .room_registry
+        .ask(waddle_xmpp::muc::room_registry_actor::CreateRoom {
+            room_jid: channel_jid.clone(),
+            waddle_id: "test".to_string(),
+            channel_id: "legacy".to_string(),
+            config,
+        })
+        .await
+        .expect("create room");
+    state
+        .deps
+        .app_state
+        .channel_space_link_store
+        .set(&crate::channel_space_links::ChannelSpaceLink {
+            channel_jid: channel_jid.clone(),
+            space_jid: "team@spaces.example.com".parse().expect("space jid"),
+            created_at: 0,
+        })
+        .await
+        .expect("link channel to space");
+
+    let authenticated_session = Some(session);
+    let authenticated_jid: FullJid = format!(
+        "{}@example.com/web",
+        authenticated_session
+            .as_ref()
+            .expect("session")
+            .xmpp_localpart
+    )
+    .parse()
+    .expect("authenticated jid");
+    let authenticated_phase = ready_phase(&authenticated_jid);
+    let query = r#"<iq xmlns="jabber:client" id="space-node-items-backfill" type="get" to="spaces.example.com"><pubsub xmlns="http://jabber.org/protocol/pubsub"><items node="team"/></pubsub></iq>"#;
+
+    let responses = handle_iq(
+        query,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &authenticated_session,
+        &authenticated_phase,
+    )
+    .await;
+    let response = responses
+        .first()
+        .expect("spaces node pubsub items response");
+
+    assert!(
+        response.contains("legacy@muc.example.com"),
+        "expected linked channel to be backfilled as XEP-0503 bookmark: {response}"
+    );
+    assert!(
+        response.contains("Legacy"),
+        "expected backfilled bookmark to use room config name: {response}"
+    );
+    let stored = state
+        .deps
+        .protocol
+        .pubsub_storage
+        .get_items(&spaces_jid, "team", None, &[])
+        .await
+        .expect("stored backfilled bookmark");
+    assert!(
+        stored.iter().any(|item| item.id == channel_jid.to_string()),
+        "backfill should persist the bookmark item"
+    );
+}
+
+#[tokio::test]
+async fn handle_iq_pubsub_items_spaces_node_requires_authorization_before_backfill() {
+    let state = create_test_websocket_state().await;
+    let session = create_test_session(state.as_ref(), "bob").await;
+
+    let spaces_jid: BareJid = "spaces.example.com".parse().expect("spaces jid");
+    state
+        .deps
+        .protocol
+        .pubsub_storage
+        .get_or_create_node(&spaces_jid, "private-team")
+        .await
+        .expect("space node");
+    state
+        .deps
+        .protocol
+        .pubsub_storage
+        .update_node_config(
+            &spaces_jid,
+            "private-team",
+            &waddle_xmpp::pubsub::NodeConfig::spaces_private(),
+        )
+        .await
+        .expect("private space node config");
+
+    let channel_jid: BareJid = "private-legacy@muc.example.com"
+        .parse()
+        .expect("channel jid");
+    state
+        .deps
+        .protocol
+        .room_registry
+        .ask(waddle_xmpp::muc::room_registry_actor::CreateRoom {
+            room_jid: channel_jid.clone(),
+            waddle_id: "test".to_string(),
+            channel_id: "private-legacy".to_string(),
+            config: waddle_xmpp::muc::RoomConfig {
+                name: "Private Legacy".to_string(),
+                persistent: true,
+                members_only: true,
+                enable_logging: true,
+                ..waddle_xmpp::muc::RoomConfig::default()
+            },
+        })
+        .await
+        .expect("create room");
+    state
+        .deps
+        .app_state
+        .channel_space_link_store
+        .set(&crate::channel_space_links::ChannelSpaceLink {
+            channel_jid: channel_jid.clone(),
+            space_jid: "private-team@spaces.example.com"
+                .parse()
+                .expect("space jid"),
+            created_at: 0,
+        })
+        .await
+        .expect("link channel to space");
+
+    let authenticated_session = Some(session);
+    let authenticated_jid: FullJid = format!(
+        "{}@example.com/web",
+        authenticated_session
+            .as_ref()
+            .expect("session")
+            .xmpp_localpart
+    )
+    .parse()
+    .expect("authenticated jid");
+    let query = r#"<iq xmlns="jabber:client" id="space-node-items-private" type="get" to="spaces.example.com"><pubsub xmlns="http://jabber.org/protocol/pubsub"><items node="private-team"/></pubsub></iq>"#;
+
+    let responses = handle_iq(
+        query,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &authenticated_session,
+        &ready_phase(&authenticated_jid),
+    )
+    .await;
+    let response = responses
+        .first()
+        .expect("spaces node pubsub items response");
+    assert!(
+        response.contains("type='error'")
+            && response.contains("not-allowed")
+            && response.contains("closed-node"),
+        "unauthorized Spaces items read should be closed-node before backfill: {response}"
+    );
+
+    let stored = state
+        .deps
+        .protocol
+        .pubsub_storage
+        .get_items(&spaces_jid, "private-team", None, &[])
+        .await
+        .expect("stored private space bookmarks");
+    assert!(
+        stored.is_empty(),
+        "unauthorized Spaces items read must not backfill bookmarks"
+    );
+}
+
+#[tokio::test]
+async fn handle_iq_pubsub_configure_spaces_node_rejects_unsupported_access_models() {
+    let state = create_test_websocket_state().await;
+    let session = create_test_session(state.as_ref(), "owner").await;
+    let owner_jid: BareJid = "owner@example.com".parse().expect("owner jid");
+    let bound_jid: FullJid = "owner@example.com/web".parse().expect("bound jid");
+    let spaces_jid: BareJid = "spaces.example.com".parse().expect("spaces jid");
+
+    state
+        .deps
+        .protocol
+        .pubsub_storage
+        .get_or_create_node(&spaces_jid, "team")
+        .await
+        .expect("space node");
+    state
+        .deps
+        .protocol
+        .pubsub_storage
+        .update_node_config(
+            &spaces_jid,
+            "team",
+            &waddle_xmpp::pubsub::NodeConfig::spaces_public(),
+        )
+        .await
+        .expect("space node config");
+    state
+        .deps
+        .protocol
+        .pubsub_storage
+        .set_affiliation(
+            &spaces_jid,
+            "team",
+            &owner_jid,
+            waddle_xmpp::pubsub::Affiliation::Owner,
+        )
+        .await
+        .expect("owner affiliation");
+
+    for access_model in ["presence", "roster", "authorize"] {
+        let frame = format!(
+            r#"<iq xmlns="jabber:client" id="spaces-config-{access_model}" type="set" to="spaces.example.com">
+                <pubsub xmlns="http://jabber.org/protocol/pubsub#owner">
+                    <configure node="team">
+                        <x xmlns="jabber:x:data" type="submit">
+                            <field var="FORM_TYPE" type="hidden"><value>http://jabber.org/protocol/pubsub#node_config</value></field>
+                            <field var="pubsub#access_model"><value>{access_model}</value></field>
+                        </x>
+                    </configure>
+                </pubsub>
+            </iq>"#
+        );
+
+        let responses = handle_iq(
+            &frame,
+            "example.com",
+            "muc.example.com",
+            state.as_ref(),
+            &Some(session.clone()),
+            &ready_phase(&bound_jid),
+        )
+        .await;
+        let response = responses.first().expect("configure response");
+        assert!(
+            response.contains("type='error'") && response.contains("bad-request"),
+            "Spaces configure should reject unsupported access_model={access_model}: {response}"
+        );
+        let stored = state
+            .deps
+            .protocol
+            .pubsub_storage
+            .get_node(&spaces_jid, "team")
+            .await
+            .expect("node lookup")
+            .expect("space node");
+        assert_eq!(
+            stored.config.access_model,
+            waddle_xmpp::pubsub::AccessModel::Open,
+            "rejected Spaces configure must not mutate the stored node config"
+        );
+    }
+}
+
+#[tokio::test]
+async fn handle_iq_pubsub_configure_spaces_node_keeps_spaces_defaults() {
+    let state = create_test_websocket_state().await;
+    let session = create_test_session(state.as_ref(), "owner").await;
+    let owner_jid: BareJid = "owner@example.com".parse().expect("owner jid");
+    let bound_jid: FullJid = "owner@example.com/web".parse().expect("bound jid");
+    let spaces_jid: BareJid = "spaces.example.com".parse().expect("spaces jid");
+
+    state
+        .deps
+        .protocol
+        .pubsub_storage
+        .get_or_create_node(&spaces_jid, "team")
+        .await
+        .expect("space node");
+    state
+        .deps
+        .protocol
+        .pubsub_storage
+        .set_affiliation(
+            &spaces_jid,
+            "team",
+            &owner_jid,
+            waddle_xmpp::pubsub::Affiliation::Owner,
+        )
+        .await
+        .expect("owner affiliation");
+
+    for (access_model, expected_config) in [
+        (
+            "whitelist",
+            waddle_xmpp::pubsub::NodeConfig::spaces_private(),
+        ),
+        ("open", waddle_xmpp::pubsub::NodeConfig::spaces_public()),
+    ] {
+        let frame = format!(
+            r#"<iq xmlns="jabber:client" id="spaces-config-ok-{access_model}" type="set" to="spaces.example.com">
+                <pubsub xmlns="http://jabber.org/protocol/pubsub#owner">
+                    <configure node="team">
+                        <x xmlns="jabber:x:data" type="submit">
+                            <field var="FORM_TYPE" type="hidden"><value>http://jabber.org/protocol/pubsub#node_config</value></field>
+                            <field var="pubsub#access_model"><value>{access_model}</value></field>
+                        </x>
+                    </configure>
+                </pubsub>
+            </iq>"#
+        );
+
+        let responses = handle_iq(
+            &frame,
+            "example.com",
+            "muc.example.com",
+            state.as_ref(),
+            &Some(session.clone()),
+            &ready_phase(&bound_jid),
+        )
+        .await;
+        let response = responses.first().expect("configure response");
+        assert!(
+            response.contains("type='result'") || response.contains("type=\"result\""),
+            "Spaces configure should accept supported access_model={access_model}: {response}"
+        );
+        let stored = state
+            .deps
+            .protocol
+            .pubsub_storage
+            .get_node(&spaces_jid, "team")
+            .await
+            .expect("node lookup")
+            .expect("space node");
+        assert_eq!(
+            stored.config, expected_config,
+            "supported Spaces configure should use the canonical Spaces defaults"
+        );
+    }
+}
+
+#[tokio::test]
+async fn handle_iq_pubsub_configure_spaces_node_merges_partial_form_with_existing_config() {
+    let state = create_test_websocket_state().await;
+    let session = create_test_session(state.as_ref(), "owner").await;
+    let owner_jid: BareJid = "owner@example.com".parse().expect("owner jid");
+    let bound_jid: FullJid = "owner@example.com/web".parse().expect("bound jid");
+    let spaces_jid: BareJid = "spaces.example.com".parse().expect("spaces jid");
+
+    state
+        .deps
+        .protocol
+        .pubsub_storage
+        .get_or_create_node(&spaces_jid, "team")
+        .await
+        .expect("space node");
+    state
+        .deps
+        .protocol
+        .pubsub_storage
+        .update_node_config(
+            &spaces_jid,
+            "team",
+            &waddle_xmpp::pubsub::NodeConfig::spaces_public(),
+        )
+        .await
+        .expect("space node config");
+    state
+        .deps
+        .protocol
+        .pubsub_storage
+        .set_affiliation(
+            &spaces_jid,
+            "team",
+            &owner_jid,
+            waddle_xmpp::pubsub::Affiliation::Owner,
+        )
+        .await
+        .expect("owner affiliation");
+
+    let frame = r#"<iq xmlns="jabber:client" id="spaces-config-partial" type="set" to="spaces.example.com">
+        <pubsub xmlns="http://jabber.org/protocol/pubsub#owner">
+            <configure node="team">
+                <x xmlns="jabber:x:data" type="submit">
+                    <field var="FORM_TYPE" type="hidden"><value>http://jabber.org/protocol/pubsub#node_config</value></field>
+                    <field var="pubsub#max_items"><value>200</value></field>
+                </x>
+            </configure>
+        </pubsub>
+    </iq>"#;
+
+    let responses = handle_iq(
+        frame,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(session),
+        &ready_phase(&bound_jid),
+    )
+    .await;
+    let response = responses.first().expect("configure response");
+    assert!(
+        response.contains("type='result'") || response.contains("type=\"result\""),
+        "Spaces configure should accept partial max_items-only form: {response}"
+    );
+    let stored = state
+        .deps
+        .protocol
+        .pubsub_storage
+        .get_node(&spaces_jid, "team")
+        .await
+        .expect("node lookup")
+        .expect("space node");
+    assert_eq!(
+        stored.config.access_model,
+        waddle_xmpp::pubsub::AccessModel::Open,
+        "partial Spaces configure must not synthesize access_model=presence"
+    );
+    assert_eq!(stored.config.max_items, 200);
+    assert_eq!(
+        stored.config.publish_model,
+        waddle_xmpp::pubsub::PublishModel::Publishers,
+        "partial Spaces configure must preserve publisher-gated writes"
+    );
+}
+
+#[tokio::test]
+async fn admin_channels_delete_retracts_duplicate_space_bookmarks() {
+    let state = create_test_websocket_state().await;
+    crate::admin::channels::register(
+        &state.deps.protocol.command_registry,
+        std::sync::Arc::clone(&state.deps.app_state),
+        std::sync::Arc::clone(&state.deps.protocol.connection_registry),
+    )
+    .await;
+
+    let owner_jid: BareJid = "owner@example.com".parse().expect("owner jid");
+    state
+        .deps
+        .app_state
+        .pubsub_storage
+        .get_or_create_node(&state.deps.app_state.spaces_jid, "alpha")
+        .await
+        .expect("alpha space node");
+    state
+        .deps
+        .app_state
+        .pubsub_storage
+        .get_or_create_node(&state.deps.app_state.spaces_jid, "beta")
+        .await
+        .expect("beta space node");
+    state
+        .deps
+        .app_state
+        .pubsub_storage
+        .set_affiliation(
+            &state.deps.app_state.spaces_jid,
+            "alpha",
+            &owner_jid,
+            waddle_xmpp::pubsub::Affiliation::Owner,
+        )
+        .await
+        .expect("owner affiliation");
+
+    let room_jid: BareJid = format!("duplicate@{}", state.deps.app_state.muc_domain)
+        .parse()
+        .expect("room jid");
+    state
+        .deps
+        .app_state
+        .room_registry
+        .ask(waddle_xmpp::muc::room_registry_actor::CreateRoom {
+            room_jid: room_jid.clone(),
+            waddle_id: "test".to_string(),
+            channel_id: "duplicate".to_string(),
+            config: waddle_xmpp::muc::RoomConfig {
+                name: "Duplicated".to_string(),
+                persistent: true,
+                members_only: false,
+                ..waddle_xmpp::muc::RoomConfig::default()
+            },
+        })
+        .await
+        .expect("create room");
+    state
+        .deps
+        .app_state
+        .channel_space_link_store
+        .set(&crate::channel_space_links::ChannelSpaceLink {
+            channel_jid: room_jid.clone(),
+            space_jid: format!("alpha@{}", state.deps.app_state.spaces_jid.domain())
+                .parse()
+                .expect("space jid"),
+            created_at: 0,
+        })
+        .await
+        .expect("link channel");
+
+    let item = waddle_xmpp::xep::build_channel_item(
+        &waddle_xmpp::ChannelInfo {
+            id: "duplicate".to_string(),
+            name: "Duplicated".to_string(),
+            channel_type: "text".to_string(),
+        },
+        &state.deps.app_state.muc_domain.to_string(),
+    )
+    .expect("bookmark item");
+    for node in ["alpha", "beta"] {
+        state
+            .deps
+            .app_state
+            .pubsub_storage
+            .publish_item(&state.deps.app_state.spaces_jid, node, &item, None, false)
+            .await
+            .expect("publish duplicate bookmark");
+    }
+
+    let session = create_test_session(state.as_ref(), "owner").await;
+    let bound_jid: FullJid = "owner@example.com/web".parse().expect("bound jid");
+    let frame = format!(
+        r#"<iq xmlns="jabber:client" id="admin-delete-duplicate" type="set" to="example.com"><command xmlns="http://jabber.org/protocol/commands" node="{}" action="execute"><x xmlns="jabber:x:data" type="submit"><field var="FORM_TYPE" type="hidden"><value>{}</value></field><field var="channel_jid" type="text-single"><value>{}</value></field><field var="confirm" type="text-single"><value>yes</value></field></x></command></iq>"#,
+        crate::admin::channels::NODE_DELETE,
+        crate::admin::channels::NODE_DELETE,
+        room_jid
+    );
+    let responses = handle_iq(
+        &frame,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(session),
+        &ready_phase(&bound_jid),
+    )
+    .await;
+    let response = responses.first().expect("delete command response");
+    assert!(
+        response.contains("status='completed'") || response.contains("status=\"completed\""),
+        "expected completed delete command response: {response}"
+    );
+
+    let remaining_nodes = state
+        .deps
+        .app_state
+        .pubsub_storage
+        .list_node_names_for_item(&state.deps.app_state.spaces_jid, &room_jid.to_string())
+        .await
+        .expect("remaining bookmark nodes");
+    assert!(
+        remaining_nodes.is_empty(),
+        "channels:delete should retract duplicate bookmarks from every space node, got: {remaining_nodes:?}"
+    );
+}
+
+#[tokio::test]
+async fn admin_channels_update_retracts_duplicate_space_bookmarks() {
+    let state = create_test_websocket_state().await;
+    crate::admin::channels::register(
+        &state.deps.protocol.command_registry,
+        std::sync::Arc::clone(&state.deps.app_state),
+        std::sync::Arc::clone(&state.deps.protocol.connection_registry),
+    )
+    .await;
+
+    let owner_jid: BareJid = "owner@example.com".parse().expect("owner jid");
+    for node in ["alpha", "beta"] {
+        state
+            .deps
+            .app_state
+            .pubsub_storage
+            .get_or_create_node(&state.deps.app_state.spaces_jid, node)
+            .await
+            .expect("space node");
+    }
+    state
+        .deps
+        .app_state
+        .pubsub_storage
+        .set_affiliation(
+            &state.deps.app_state.spaces_jid,
+            "alpha",
+            &owner_jid,
+            waddle_xmpp::pubsub::Affiliation::Owner,
+        )
+        .await
+        .expect("owner affiliation");
+
+    let room_jid: BareJid = format!("rename-duplicate@{}", state.deps.app_state.muc_domain)
+        .parse()
+        .expect("room jid");
+    state
+        .deps
+        .app_state
+        .room_registry
+        .ask(waddle_xmpp::muc::room_registry_actor::CreateRoom {
+            room_jid: room_jid.clone(),
+            waddle_id: "test".to_string(),
+            channel_id: "rename-duplicate".to_string(),
+            config: waddle_xmpp::muc::RoomConfig {
+                name: "Old Name".to_string(),
+                persistent: true,
+                members_only: false,
+                ..waddle_xmpp::muc::RoomConfig::default()
+            },
+        })
+        .await
+        .expect("create room");
+    state
+        .deps
+        .app_state
+        .channel_space_link_store
+        .set(&crate::channel_space_links::ChannelSpaceLink {
+            channel_jid: room_jid.clone(),
+            space_jid: format!("alpha@{}", state.deps.app_state.spaces_jid.domain())
+                .parse()
+                .expect("space jid"),
+            created_at: 0,
+        })
+        .await
+        .expect("link channel");
+    let old_item = waddle_xmpp::xep::build_channel_item(
+        &waddle_xmpp::ChannelInfo {
+            id: "rename-duplicate".to_string(),
+            name: "Old Name".to_string(),
+            channel_type: "text".to_string(),
+        },
+        &state.deps.app_state.muc_domain.to_string(),
+    )
+    .expect("old bookmark item");
+    for node in ["alpha", "beta"] {
+        state
+            .deps
+            .app_state
+            .pubsub_storage
+            .publish_item(
+                &state.deps.app_state.spaces_jid,
+                node,
+                &old_item,
+                None,
+                false,
+            )
+            .await
+            .expect("publish duplicate bookmark");
+    }
+
+    let session = create_test_session(state.as_ref(), "owner").await;
+    let bound_jid: FullJid = "owner@example.com/web".parse().expect("bound jid");
+    let frame = format!(
+        r#"<iq xmlns="jabber:client" id="admin-update-duplicate" type="set" to="example.com"><command xmlns="http://jabber.org/protocol/commands" node="{}" action="execute"><x xmlns="jabber:x:data" type="submit"><field var="FORM_TYPE" type="hidden"><value>{}</value></field><field var="channel_jid" type="text-single"><value>{}</value></field><field var="name" type="text-single"><value>New Name</value></field></x></command></iq>"#,
+        crate::admin::channels::NODE_UPDATE,
+        crate::admin::channels::NODE_UPDATE,
+        room_jid
+    );
+    let responses = handle_iq(
+        &frame,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(session),
+        &ready_phase(&bound_jid),
+    )
+    .await;
+    let response = responses.first().expect("update command response");
+    assert!(
+        response.contains("status='completed'") || response.contains("status=\"completed\""),
+        "expected completed update command response: {response}"
+    );
+
+    let alpha_items = state
+        .deps
+        .app_state
+        .pubsub_storage
+        .get_items(&state.deps.app_state.spaces_jid, "alpha", None, &[])
+        .await
+        .expect("alpha items");
+    assert!(
+        alpha_items
+            .iter()
+            .any(|item| item.id == room_jid.to_string()
+                && item
+                    .payload_xml
+                    .as_ref()
+                    .is_some_and(|payload| payload.contains("New Name"))),
+        "linked space should retain updated bookmark with new name"
+    );
+    let bookmark_nodes: std::collections::BTreeSet<_> = state
+        .deps
+        .app_state
+        .pubsub_storage
+        .list_node_names_for_item(&state.deps.app_state.spaces_jid, &room_jid.to_string())
+        .await
+        .expect("bookmark nodes after update")
+        .into_iter()
+        .collect();
+    assert_eq!(
+        bookmark_nodes,
+        std::collections::BTreeSet::from(["alpha".to_string()]),
+        "admin update should retract duplicate bookmarks from stale nodes"
+    );
+}
+
+#[tokio::test]
+async fn admin_channels_create_space_bookmark_grants_space_members_channel_view() {
+    let state = create_test_websocket_state().await;
+    crate::admin::channels::register(
+        &state.deps.protocol.command_registry,
+        std::sync::Arc::clone(&state.deps.app_state),
+        std::sync::Arc::clone(&state.deps.protocol.connection_registry),
+    )
+    .await;
+
+    let spaces_jid = state.deps.app_state.spaces_jid.clone();
+    state
+        .deps
+        .app_state
+        .pubsub_storage
+        .get_or_create_node(&spaces_jid, "alpha")
+        .await
+        .expect("space node");
+    let owner_jid: BareJid = "owner@example.com".parse().expect("owner jid");
+    state
+        .deps
+        .app_state
+        .pubsub_storage
+        .set_affiliation(
+            &spaces_jid,
+            "alpha",
+            &owner_jid,
+            waddle_xmpp::pubsub::Affiliation::Owner,
+        )
+        .await
+        .expect("owner affiliation");
+
+    let viewer = create_test_session(state.as_ref(), "viewer").await;
+    grant_space_member_for_test(state.as_ref(), "alpha", &viewer.user_id).await;
+
+    let session = create_test_server_owner_session(state.as_ref(), "owner").await;
+    let bound_jid: FullJid = "owner@example.com/web".parse().expect("bound jid");
+    let space_jid = format!("alpha@{}", spaces_jid.domain());
+    let frame = format!(
+        r#"<iq xmlns="jabber:client" id="admin-create-parent" type="set" to="example.com"><command xmlns="http://jabber.org/protocol/commands" node="{}" action="execute"><x xmlns="jabber:x:data" type="submit"><field var="FORM_TYPE" type="hidden"><value>{}</value></field><field var="name" type="text-single"><value>Alpha Parent</value></field><field var="space_jid" type="text-single"><value>{}</value></field></x></command></iq>"#,
+        crate::admin::channels::NODE_CREATE,
+        crate::admin::channels::NODE_CREATE,
+        space_jid
+    );
+    let responses = handle_iq(
+        &frame,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(session),
+        &ready_phase(&bound_jid),
+    )
+    .await;
+    let response = responses.first().expect("create command response");
+    assert!(
+        response.contains("status='completed'") || response.contains("status=\"completed\""),
+        "expected completed create command response: {response}"
+    );
+    let channel_jid = data_form_value_for_test(response, "channel_jid").expect("channel_jid value");
+    let channel_jid: BareJid = channel_jid.parse().expect("channel jid");
+    let channel_id = waddle_xmpp::parse_managed_room_jid(&channel_jid).expect("managed channel");
+
+    assert!(
+        channel_view_allowed_for_test(state.as_ref(), &channel_id, &viewer.user_id).await,
+        "admin-created XEP-0503 bookmark should write the channel parent tuple"
+    );
+}
+
+#[tokio::test]
+async fn admin_spaces_delete_clears_channel_parent_tuple() {
+    let state = create_test_websocket_state().await;
+    crate::admin::spaces::register(
+        &state.deps.protocol.command_registry,
+        std::sync::Arc::clone(&state.deps.app_state),
+    )
+    .await;
+
+    let spaces_jid = state.deps.app_state.spaces_jid.clone();
+    state
+        .deps
+        .app_state
+        .pubsub_storage
+        .get_or_create_node(&spaces_jid, "alpha")
+        .await
+        .expect("space node");
+    let owner_jid: BareJid = "owner@example.com".parse().expect("owner jid");
+    state
+        .deps
+        .app_state
+        .pubsub_storage
+        .set_affiliation(
+            &spaces_jid,
+            "alpha",
+            &owner_jid,
+            waddle_xmpp::pubsub::Affiliation::Owner,
+        )
+        .await
+        .expect("owner affiliation");
+
+    let room_jid: BareJid = format!("delete-parent@{}", state.deps.app_state.muc_domain)
+        .parse()
+        .expect("room jid");
+    state
+        .deps
+        .app_state
+        .room_registry
+        .ask(waddle_xmpp::muc::room_registry_actor::CreateRoom {
+            room_jid: room_jid.clone(),
+            waddle_id: "test".to_string(),
+            channel_id: "delete-parent".to_string(),
+            config: waddle_xmpp::muc::RoomConfig {
+                name: "Delete Parent".to_string(),
+                persistent: true,
+                members_only: false,
+                ..waddle_xmpp::muc::RoomConfig::default()
+            },
+        })
+        .await
+        .expect("create room");
+    state
+        .deps
+        .app_state
+        .channel_space_link_store
+        .set(&crate::channel_space_links::ChannelSpaceLink {
+            channel_jid: room_jid.clone(),
+            space_jid: format!("alpha@{}", spaces_jid.domain())
+                .parse()
+                .expect("space jid"),
+            created_at: 0,
+        })
+        .await
+        .expect("link channel");
+    let item = waddle_xmpp::xep::build_channel_item(
+        &waddle_xmpp::ChannelInfo {
+            id: "delete-parent".to_string(),
+            name: "Delete Parent".to_string(),
+            channel_type: "text".to_string(),
+        },
+        &state.deps.app_state.muc_domain.to_string(),
+    )
+    .expect("bookmark item");
+    state
+        .deps
+        .app_state
+        .pubsub_storage
+        .publish_item(&spaces_jid, "alpha", &item, None, false)
+        .await
+        .expect("publish bookmark");
+
+    let viewer = create_test_session(state.as_ref(), "viewer").await;
+    grant_space_member_for_test(state.as_ref(), "alpha", &viewer.user_id).await;
+    state
+        .deps
+        .app_state
+        .permission_actor
+        .ask(WriteTuple {
+            tuple: Tuple::new(
+                Object::new(ObjectType::Channel, "delete-parent"),
+                Relation::new("parent"),
+                Subject::userset(SubjectType::Space, "alpha", ""),
+            ),
+        })
+        .await
+        .expect("channel parent tuple");
+    assert!(
+        channel_view_allowed_for_test(state.as_ref(), "delete-parent", &viewer.user_id).await,
+        "test setup should grant channel view through the space parent tuple"
+    );
+
+    let session = create_test_server_owner_session(state.as_ref(), "owner").await;
+    let bound_jid: FullJid = "owner@example.com/web".parse().expect("bound jid");
+    let space_jid = format!("alpha@{}", spaces_jid.domain());
+    let frame = format!(
+        r#"<iq xmlns="jabber:client" id="admin-delete-space-parent" type="set" to="example.com"><command xmlns="http://jabber.org/protocol/commands" node="{}" action="execute"><x xmlns="jabber:x:data" type="submit"><field var="FORM_TYPE" type="hidden"><value>{}</value></field><field var="space_jid" type="text-single"><value>{}</value></field><field var="confirm" type="text-single"><value>yes</value></field></x></command></iq>"#,
+        crate::admin::spaces::NODE_DELETE,
+        crate::admin::spaces::NODE_DELETE,
+        space_jid
+    );
+    let responses = handle_iq(
+        &frame,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(session),
+        &ready_phase(&bound_jid),
+    )
+    .await;
+    let response = responses.first().expect("delete command response");
+    assert!(
+        response.contains("status='completed'") || response.contains("status=\"completed\""),
+        "expected completed space delete command response: {response}"
+    );
+    assert!(
+        !channel_view_allowed_for_test(state.as_ref(), "delete-parent", &viewer.user_id).await,
+        "spaces:delete should remove the channel parent tuple"
+    );
+}
+
+#[tokio::test]
+async fn spaces_publish_and_retract_sync_channel_space_link_projection() {
+    let state = create_test_websocket_state().await;
+    let conn = state
+        .deps
+        .app_state
+        .db_pool
+        .global()
+        .guard()
+        .await
+        .expect("db connection");
+    conn.execute(
+        "INSERT INTO channels (id, name, description, channel_type, position, is_default) VALUES (?, ?, ?, 'text', 0, 0)",
+        crate::db_params!["linked", "Linked", "Linked channel description"],
+    )
+    .await
+    .expect("insert channel");
+    drop(conn);
+
+    let spaces_jid: BareJid = "spaces.example.com".parse().expect("spaces jid");
+    state
+        .deps
+        .protocol
+        .pubsub_storage
+        .get_or_create_node(&spaces_jid, "team")
+        .await
+        .expect("space node");
+
+    let session = create_test_server_owner_session(state.as_ref(), "owner").await;
+    let bound_jid: FullJid = "owner@example.com/web".parse().expect("bound jid");
+    let room_jid: BareJid = "linked@muc.example.com".parse().expect("room jid");
+
+    let publish = r#"<iq xmlns="jabber:client" id="spaces-link-publish" type="set" to="spaces.example.com">
+        <pubsub xmlns="http://jabber.org/protocol/pubsub">
+            <publish node="team">
+                <item id="linked@muc.example.com">
+                    <conference xmlns="urn:xmpp:bookmarks:1" name="Linked" />
+                </item>
+            </publish>
+        </pubsub>
+    </iq>"#;
+    let publish_responses = handle_iq(
+        publish,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(session.clone()),
+        &ready_phase(&bound_jid),
+    )
+    .await;
+    let publish_response = publish_responses.first().expect("publish response");
+    assert!(
+        publish_response.contains("type='result'") || publish_response.contains("type=\"result\""),
+        "spaces publish should succeed: {publish_response}"
+    );
+    let link = state
+        .deps
+        .app_state
+        .channel_space_link_store
+        .get(&room_jid)
+        .await
+        .expect("channel-space link")
+        .expect("link after spaces publish");
+    assert_eq!(link.space_jid.to_string(), "team@spaces.example.com");
+
+    let retract = r#"<iq xmlns="jabber:client" id="spaces-link-retract" type="set" to="spaces.example.com">
+        <pubsub xmlns="http://jabber.org/protocol/pubsub">
+            <retract node="team">
+                <item id="linked@muc.example.com" />
+            </retract>
+        </pubsub>
+    </iq>"#;
+    let retract_responses = handle_iq(
+        retract,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(session),
+        &ready_phase(&bound_jid),
+    )
+    .await;
+    let retract_response = retract_responses.first().expect("retract response");
+    assert!(
+        retract_response.contains("type='result'") || retract_response.contains("type=\"result\""),
+        "spaces retract should succeed: {retract_response}"
+    );
+    assert!(
+        state
+            .deps
+            .app_state
+            .channel_space_link_store
+            .get(&room_jid)
+            .await
+            .expect("channel-space link after retract")
+            .is_none(),
+        "spaces retract should clear matching channel-space link projection"
+    );
+}
+
+#[tokio::test]
+async fn spaces_publish_accepts_non_jid_node_and_syncs_parent_tuple() {
+    let state = create_test_websocket_state().await;
+    let conn = state
+        .deps
+        .app_state
+        .db_pool
+        .global()
+        .guard()
+        .await
+        .expect("db connection");
+    conn.execute(
+        "INSERT INTO channels (id, name, description, channel_type, position, is_default) VALUES (?, ?, ?, 'text', 0, 0)",
+        crate::db_params!["hierarchical", "Hierarchical", "Hierarchical channel description"],
+    )
+    .await
+    .expect("insert channel");
+    drop(conn);
+
+    let spaces_jid: BareJid = "spaces.example.com".parse().expect("spaces jid");
+    state
+        .deps
+        .protocol
+        .pubsub_storage
+        .get_or_create_node(&spaces_jid, "music/A")
+        .await
+        .expect("space node");
+
+    let viewer = create_test_session(state.as_ref(), "viewer").await;
+    grant_space_member_for_test(state.as_ref(), "music/A", &viewer.user_id).await;
+
+    let session = create_test_server_owner_session(state.as_ref(), "owner").await;
+    let bound_jid: FullJid = "owner@example.com/web".parse().expect("bound jid");
+    let room_jid: BareJid = "hierarchical@muc.example.com".parse().expect("room jid");
+
+    let publish = r#"<iq xmlns="jabber:client" id="spaces-hier-publish" type="set" to="spaces.example.com">
+        <pubsub xmlns="http://jabber.org/protocol/pubsub">
+            <publish node="music/A">
+                <item id="hierarchical@muc.example.com">
+                    <conference xmlns="urn:xmpp:bookmarks:1" name="Hierarchical" />
+                </item>
+            </publish>
+        </pubsub>
+    </iq>"#;
+    let publish_responses = handle_iq(
+        publish,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(session.clone()),
+        &ready_phase(&bound_jid),
+    )
+    .await;
+    let publish_response = publish_responses.first().expect("publish response");
+    assert!(
+        publish_response.contains("type='result'") || publish_response.contains("type=\"result\""),
+        "spaces publish should accept non-JID node ids: {publish_response}"
+    );
+    assert!(
+        state
+            .deps
+            .app_state
+            .channel_space_link_store
+            .get(&room_jid)
+            .await
+            .expect("channel-space link")
+            .is_none(),
+        "non-JID Space nodes should not be forced into the BareJid link projection"
+    );
+    assert!(
+        channel_view_allowed_for_test(state.as_ref(), "hierarchical", &viewer.user_id).await,
+        "publish should still write the channel parent tuple for non-JID Space nodes"
+    );
+
+    let retract = r#"<iq xmlns="jabber:client" id="spaces-hier-retract" type="set" to="spaces.example.com">
+        <pubsub xmlns="http://jabber.org/protocol/pubsub">
+            <retract node="music/A">
+                <item id="hierarchical@muc.example.com" />
+            </retract>
+        </pubsub>
+    </iq>"#;
+    let retract_responses = handle_iq(
+        retract,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(session),
+        &ready_phase(&bound_jid),
+    )
+    .await;
+    let retract_response = retract_responses.first().expect("retract response");
+    assert!(
+        retract_response.contains("type='result'") || retract_response.contains("type=\"result\""),
+        "spaces retract should accept non-JID node ids: {retract_response}"
+    );
+    assert!(
+        !channel_view_allowed_for_test(state.as_ref(), "hierarchical", &viewer.user_id).await,
+        "retract should clear the channel parent tuple for non-JID Space nodes"
+    );
+}
+
+#[tokio::test]
 async fn handle_iq_disco_info_spaces_node_reports_open_for_public_space() {
     let state = create_test_websocket_state().await;
     let viewer = create_test_session(state.as_ref(), "viewer").await;
@@ -1450,6 +2636,17 @@ async fn handle_iq_disco_info_spaces_node_reports_open_for_public_space() {
         .get_or_create_node(&spaces_jid, "team")
         .await
         .expect("space node");
+    state
+        .deps
+        .protocol
+        .pubsub_storage
+        .update_node_config(
+            &spaces_jid,
+            "team",
+            &waddle_xmpp::pubsub::NodeConfig::spaces_public(),
+        )
+        .await
+        .expect("space node config");
 
     let viewer_phase = authenticated_phase_for_session(&viewer, "example.com");
     let query = disco_info_iq_frame("space-node-info", "spaces.example.com", Some("team"));
@@ -1475,6 +2672,61 @@ async fn handle_iq_disco_info_spaces_node_reports_open_for_public_space() {
     assert!(
         response.contains(">open<"),
         "expected public access model=open in metadata: {response}"
+    );
+}
+
+#[tokio::test]
+async fn handle_iq_disco_info_spaces_node_reports_whitelist_for_private_space() {
+    let state = create_test_websocket_state().await;
+    let viewer = create_test_session(state.as_ref(), "viewer").await;
+    let spaces_jid: BareJid = "spaces.example.com".parse().expect("spaces jid");
+    state
+        .deps
+        .protocol
+        .pubsub_storage
+        .get_or_create_node(&spaces_jid, "private-team")
+        .await
+        .expect("space node");
+    state
+        .deps
+        .protocol
+        .pubsub_storage
+        .update_node_config(
+            &spaces_jid,
+            "private-team",
+            &waddle_xmpp::pubsub::NodeConfig::spaces_private(),
+        )
+        .await
+        .expect("private space node config");
+
+    let viewer_phase = authenticated_phase_for_session(&viewer, "example.com");
+    let query = disco_info_iq_frame(
+        "space-node-info-private",
+        "spaces.example.com",
+        Some("private-team"),
+    );
+    let responses = handle_iq(
+        &query,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(viewer),
+        &viewer_phase,
+    )
+    .await;
+    let response = responses.first().expect("spaces node disco info response");
+
+    assert!(
+        response.contains("type='result'") || response.contains("type=\"result\""),
+        "expected successful private node disco#info response: {response}"
+    );
+    assert!(
+        response.contains("pubsub#access_model"),
+        "expected access model metadata in private node disco#info: {response}"
+    );
+    assert!(
+        response.contains(">whitelist<"),
+        "expected private access model=whitelist in metadata: {response}"
     );
 }
 

--- a/server/crates/waddle-server/src/server/xmpp_space_state.rs
+++ b/server/crates/waddle-server/src/server/xmpp_space_state.rs
@@ -1,6 +1,6 @@
 use kameo::actor::ActorRef;
 use tracing::{debug, warn};
-use waddle_xmpp::{ChannelInfo, ChannelRoomInfo, SpaceDetails, XmppError};
+use waddle_xmpp::{ChannelInfo, ChannelRoomInfo, SpaceAccessModel, SpaceDetails, XmppError};
 
 use crate::db::actor::{DbActor, DbQuery, DbQueryOne};
 use crate::db::{row_value, Value, ValueExt};
@@ -130,6 +130,7 @@ pub(crate) fn get_space_details(domain: &str) -> SpaceDetails {
         owner_id: "server".to_string(),
         icon_url: None,
         is_public: true,
+        access_model: SpaceAccessModel::Open,
         created_at: "1970-01-01T00:00:00Z".to_string(),
     }
 }

--- a/server/crates/waddle-server/tests/admin_channel_space_link_ws.rs
+++ b/server/crates/waddle-server/tests/admin_channel_space_link_ws.rs
@@ -30,6 +30,7 @@ const NODE_SPACES_DELETE: &str = "urn:waddle:admin:spaces:delete:0";
 
 const NODE_CHANNELS_LIST: &str = "urn:waddle:admin:channels:list:0";
 const NODE_CHANNELS_CREATE: &str = "urn:waddle:admin:channels:create:0";
+const NODE_CHANNELS_UPDATE: &str = "urn:waddle:admin:channels:update:0";
 const NODE_CHANNELS_DELETE: &str = "urn:waddle:admin:channels:delete:0";
 
 static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
@@ -126,6 +127,25 @@ async fn create_channel_in_space(
     extract_field(&resp, "channel_jid").expect("channel_jid in channels:create response")
 }
 
+async fn update_channel_name(admin: &mut WsXmppClient, channel_jid: &str, name: &str, id: &str) {
+    let extra = format!(
+        "{}{}",
+        text_field("channel_jid", channel_jid),
+        text_field("name", name)
+    );
+    let resp = send_command(
+        admin,
+        NODE_CHANNELS_UPDATE,
+        id,
+        &submit_form(NODE_CHANNELS_UPDATE, &extra),
+    )
+    .await;
+    assert!(
+        is_result(&resp),
+        "expected channels:update result, got: {resp}"
+    );
+}
+
 async fn list_channels(admin: &mut WsXmppClient, space_jid: Option<&str>, id: &str) -> String {
     let extra = match space_jid {
         Some(jid) => text_field("space_jid", jid),
@@ -145,6 +165,31 @@ async fn list_channels(admin: &mut WsXmppClient, space_jid: Option<&str>, id: &s
     resp
 }
 
+async fn space_pubsub_items(admin: &mut WsXmppClient, space_jid: &str, id: &str) -> String {
+    let node = space_jid
+        .split('@')
+        .next()
+        .expect("space JID has localpart");
+    client_send_pubsub_items(admin, node, id).await
+}
+
+async fn client_send_pubsub_items(admin: &mut WsXmppClient, node: &str, id: &str) -> String {
+    admin
+        .send(&format!(
+            r#"<iq type="get" id="{id}" to="spaces.localhost"><pubsub xmlns="http://jabber.org/protocol/pubsub"><items node="{node}"/></pubsub></iq>"#
+        ))
+        .await
+        .expect("send pubsub items iq");
+    admin
+        .recv_matching(|frame| {
+            frame.contains("<iq")
+                && (frame.contains(&format!(r#"id='{id}'"#))
+                    || frame.contains(&format!(r#"id="{id}""#)))
+        })
+        .await
+        .expect("pubsub items response")
+}
+
 #[tokio::test]
 async fn channels_list_space_jid_filter_narrows_results_and_survives_lifecycle() {
     let _serial = TEST_SERIAL.lock().await;
@@ -157,14 +202,51 @@ async fn channels_list_space_jid_filter_narrows_results_and_survives_lifecycle()
 
     let channel_a =
         create_channel_in_space(&mut admin, "alpha-room", &space_a, "csl-mk-chan-a").await;
+    let channel_a_second =
+        create_channel_in_space(&mut admin, "alpha-second", &space_a, "csl-mk-chan-a-second").await;
     let channel_b =
         create_channel_in_space(&mut admin, "beta-room", &space_b, "csl-mk-chan-b").await;
+
+    let space_a_items = space_pubsub_items(&mut admin, &space_a, "csl-space-a-items").await;
+    assert!(
+        space_a_items.contains(&channel_a),
+        "space A PubSub items should include its XEP-0503 channel bookmark '{channel_a}', got: {space_a_items}"
+    );
+    assert!(
+        space_a_items.contains(&channel_a_second),
+        "admin-created space A should retain multiple XEP-0503 channel bookmarks; missing second channel '{channel_a_second}', got: {space_a_items}"
+    );
+    assert!(
+        space_a_items.contains("conference") && space_a_items.contains("urn:xmpp:bookmarks:1"),
+        "space A channel bookmark should use XEP-0402 conference payload, got: {space_a_items}"
+    );
+    assert!(
+        !space_a_items.contains(&channel_b),
+        "space A PubSub items should not include channel B '{channel_b}', got: {space_a_items}"
+    );
+    update_channel_name(
+        &mut admin,
+        &channel_a,
+        "alpha-room-renamed",
+        "csl-rename-chan-a",
+    )
+    .await;
+    let space_a_items_after_rename =
+        space_pubsub_items(&mut admin, &space_a, "csl-space-a-items-after-rename").await;
+    assert!(
+        space_a_items_after_rename.contains("alpha-room-renamed"),
+        "space A PubSub bookmark should be republished with the renamed channel, got: {space_a_items_after_rename}"
+    );
 
     // (2) `channels:list space_jid=A` returns only channel A.
     let only_a = list_channels(&mut admin, Some(&space_a), "csl-list-only-a").await;
     assert!(
         only_a.contains(&channel_a),
         "filter by space A should include channel A '{channel_a}', got: {only_a}"
+    );
+    assert!(
+        only_a.contains(&channel_a_second),
+        "filter by space A should include second channel A '{channel_a_second}', got: {only_a}"
     );
     assert!(
         !only_a.contains(&channel_b),
@@ -176,6 +258,10 @@ async fn channels_list_space_jid_filter_narrows_results_and_survives_lifecycle()
     assert!(
         unfiltered.contains(&channel_a),
         "unfiltered list missing channel A '{channel_a}', got: {unfiltered}"
+    );
+    assert!(
+        unfiltered.contains(&channel_a_second),
+        "unfiltered list missing second channel A '{channel_a_second}', got: {unfiltered}"
     );
     assert!(
         unfiltered.contains(&channel_b),
@@ -208,8 +294,22 @@ async fn channels_list_space_jid_filter_narrows_results_and_survives_lifecycle()
         "deleted channel A '{channel_a}' should not appear in space-A filter, got: {after_delete}"
     );
     assert!(
+        after_delete.contains(&channel_a_second),
+        "space-A filter should retain second channel A '{channel_a_second}' after deleting channel A, got: {after_delete}"
+    );
+    assert!(
         !after_delete.contains(&channel_b),
         "channel B '{channel_b}' is in space B; space-A filter should still exclude it, got: {after_delete}"
+    );
+    let space_a_items_after_delete =
+        space_pubsub_items(&mut admin, &space_a, "csl-space-a-items-after-delete").await;
+    assert!(
+        !space_a_items_after_delete.contains(&channel_a),
+        "deleted channel A '{channel_a}' should be retracted from XEP-0503 PubSub items, got: {space_a_items_after_delete}"
+    );
+    assert!(
+        space_a_items_after_delete.contains(&channel_a_second),
+        "deleting channel A should not evict second channel A '{channel_a_second}' from XEP-0503 PubSub items, got: {space_a_items_after_delete}"
     );
 
     // (5) Delete space B and confirm the cascade tore down channel B
@@ -245,6 +345,10 @@ async fn channels_list_space_jid_filter_narrows_results_and_survives_lifecycle()
     assert!(
         !final_unfiltered.contains(&channel_a),
         "deleted channel A '{channel_a}' should be absent from unfiltered list, got: {final_unfiltered}"
+    );
+    assert!(
+        final_unfiltered.contains(&channel_a_second),
+        "second channel A '{channel_a_second}' should remain after deleting channel A and space B, got: {final_unfiltered}"
     );
     assert!(
         !final_unfiltered.contains(&channel_b),

--- a/server/crates/waddle-server/tests/xep0060_spaces_owner_ws.rs
+++ b/server/crates/waddle-server/tests/xep0060_spaces_owner_ws.rs
@@ -106,6 +106,21 @@ async fn server_owner_can_configure_set_general_space() {
         is_result(&resp),
         "expected configure-set result, got: {resp}"
     );
+    let cfg = iq_get_to(
+        &mut admin,
+        "spaces-cfg-set-readback",
+        SPACES_JID,
+        &format!(r#"<pubsub xmlns="{NS_PUBSUB_OWNER}"><configure node="general"/></pubsub>"#),
+    )
+    .await;
+    assert!(
+        cfg.contains("pubsub#access_model") && cfg.contains(">open<"),
+        "partial configure-set must preserve the public Spaces access model: {cfg}"
+    );
+    assert!(
+        cfg.contains("pubsub#max_items") && cfg.contains(">200<"),
+        "partial configure-set should apply the submitted max_items field: {cfg}"
+    );
     let _ = admin.close().await;
 }
 

--- a/server/crates/waddle-xmpp-client-ffi/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/lib.rs
@@ -343,11 +343,13 @@ impl WaddleClient {
         // space. So a fresh waddle deployment with no XEP-0503 space
         // bookmarks still produces a usable channel list.
         let server_domain = jid_domain(&self.config.jid);
+
         match handle.discover_topology(server_domain).await {
             Ok(topology) => topology_to_ffi(topology),
             Err(e) => {
-                self.listener
-                    .on_error(format!("discover_topology failed: {e}"));
+                self.listener.on_error(format!(
+                    "discover_topology failed: server_domain={server_domain} error={e}"
+                ));
                 empty_topology()
             }
         }

--- a/server/crates/waddle-xmpp-client/src/discovery.rs
+++ b/server/crates/waddle-xmpp-client/src/discovery.rs
@@ -18,7 +18,7 @@ pub use iq::{
 };
 pub use parsing::{
     parse_disco_info_result, parse_disco_items_result, parse_space_channels_result,
-    parse_spaces_from_disco_items, parse_upload_slot, space_from_disco_item,
+    parse_upload_slot, space_from_disco_item,
 };
 pub use types::{
     DiscoDataField, DiscoDataForm, DiscoFeature, DiscoIdentity, DiscoInfoResult, DiscoItem,

--- a/server/crates/waddle-xmpp-client/src/discovery/ext.rs
+++ b/server/crates/waddle-xmpp-client/src/discovery/ext.rs
@@ -163,6 +163,10 @@ impl DiscoveryExt for ClientHandle {
     }
 
     async fn discover_spaces(&self, spaces_jid: &BareJid) -> ClientResult<Vec<DiscoveredSpace>> {
+        // XEP-0503 lists spaces as node-backed disco#items on the Spaces
+        // service, with per-node PubSub metadata declaring
+        // `pubsub#type=urn:xmpp:spaces:0`. Skip entries whose node metadata
+        // cannot be verified as an XEP-0503 Space.
         let items = self.discover_items(&spaces_jid.to_string(), None).await?;
         let mut spaces = Vec::new();
         for item in items {

--- a/server/crates/waddle-xmpp-client/src/discovery/parsing.rs
+++ b/server/crates/waddle-xmpp-client/src/discovery/parsing.rs
@@ -92,25 +92,6 @@ pub fn parse_disco_items_result(iq: &Element) -> Option<Vec<DiscoItem>> {
     Some(items)
 }
 
-pub fn parse_spaces_from_disco_items(
-    spaces_jid: &BareJid,
-    items: Vec<DiscoItem>,
-) -> Vec<DiscoveredSpace> {
-    items
-        .into_iter()
-        .filter(|item| item.jid == spaces_jid.to_string())
-        .filter_map(|item| {
-            let id = SpaceNode::new(item.node?)?;
-            Some(DiscoveredSpace {
-                name: item.name.unwrap_or_else(|| id.as_str().to_string()),
-                id,
-                service_jid: spaces_jid.clone(),
-                description: None,
-            })
-        })
-        .collect()
-}
-
 /// Resolve the MUC and Spaces service JIDs from a server's
 /// `disco#items` items list, hydrated with each item's `disco#info`
 /// where available. The result preserves the supplied fallbacks for
@@ -172,12 +153,16 @@ pub fn space_from_disco_item(
     item: DiscoItem,
     info: &DiscoInfoResult,
 ) -> Option<DiscoveredSpace> {
-    if item.jid != spaces_jid.to_string()
-        || !info.has_form_value(PUBSUB_METADATA_FORM_TYPE, "pubsub#type", SPACES_NS)
-    {
+    if item.jid != spaces_jid.to_string() {
         return None;
     }
     let id = SpaceNode::new(item.node?)?;
+    if info.node.as_deref() != Some(id.as_str()) {
+        return None;
+    }
+    if !info.has_form_value(PUBSUB_METADATA_FORM_TYPE, "pubsub#type", SPACES_NS) {
+        return None;
+    }
     let name = info
         .form_value(PUBSUB_METADATA_FORM_TYPE, "pubsub#title")
         .filter(|name| !name.trim().is_empty())

--- a/server/crates/waddle-xmpp-client/src/discovery/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/discovery/tests.rs
@@ -192,52 +192,11 @@ fn parse_disco_items_result_extracts_items() {
 }
 
 #[test]
-fn root_service_items_are_not_spaces() {
-    let spaces_jid: BareJid = "spaces.example.com".parse().expect("spaces jid");
-    let items = vec![
-        DiscoItem {
-            jid: "muc.example.com".to_string(),
-            name: Some("Chatrooms".to_string()),
-            node: None,
-        },
-        DiscoItem {
-            jid: "spaces.example.com".to_string(),
-            name: Some("Spaces".to_string()),
-            node: None,
-        },
-        DiscoItem {
-            jid: "extensions.example.com".to_string(),
-            name: Some("Extensions".to_string()),
-            node: None,
-        },
-    ];
-
-    assert!(parse_spaces_from_disco_items(&spaces_jid, items).is_empty());
-}
-
-#[test]
-fn spaces_service_items_parse_node_backed_spaces() {
-    let spaces_jid: BareJid = "spaces.example.com".parse().expect("spaces jid");
-    let items = vec![DiscoItem {
-        jid: "spaces.example.com".to_string(),
-        name: Some("General".to_string()),
-        node: Some("general".to_string()),
-    }];
-
-    let spaces = parse_spaces_from_disco_items(&spaces_jid, items);
-
-    assert_eq!(spaces.len(), 1);
-    assert_eq!(spaces[0].id.as_str(), "general");
-    assert_eq!(spaces[0].service_jid, spaces_jid);
-    assert_eq!(spaces[0].name, "General");
-}
-
-#[test]
-fn space_from_disco_item_requires_spaces_metadata_type() {
+fn space_from_disco_item_requires_spaces_metadata() {
     let spaces_jid: BareJid = "spaces.example.com".parse().expect("spaces jid");
     let item = DiscoItem {
         jid: "spaces.example.com".to_string(),
-        name: Some("Ignored Node Name".to_string()),
+        name: Some("Node Name".to_string()),
         node: Some("engineering".to_string()),
     };
     let space_info = DiscoInfoResult {
@@ -271,13 +230,19 @@ fn space_from_disco_item_requires_spaces_metadata_type() {
         forms: vec![],
         ..space_info.clone()
     };
+    let missing_node_info = DiscoInfoResult {
+        node: None,
+        ..space_info.clone()
+    };
 
     let space = space_from_disco_item(&spaces_jid, item.clone(), &space_info).unwrap();
 
     assert_eq!(space.id.as_str(), "engineering");
     assert_eq!(space.name, "Engineering");
     assert_eq!(space.description.as_deref(), Some("Build systems"));
-    assert!(space_from_disco_item(&spaces_jid, item, &other_info).is_none());
+
+    assert!(space_from_disco_item(&spaces_jid, item.clone(), &other_info).is_none());
+    assert!(space_from_disco_item(&spaces_jid, item, &missing_node_info).is_none());
 }
 
 #[test]

--- a/server/crates/waddle-xmpp-core/src/pubsub/mod.rs
+++ b/server/crates/waddle-xmpp-core/src/pubsub/mod.rs
@@ -8,7 +8,8 @@ pub mod subscription;
 
 pub use affiliation::Affiliation;
 pub use node::{
-    AccessModel, NodeConfig, PublishModel, SendLastPublishedItem, PEP_BOOKMARK_MAX_ITEMS,
+    AccessModel, NodeConfig, NodeConfigPatch, PublishModel, SendLastPublishedItem,
+    PEP_BOOKMARK_MAX_ITEMS,
 };
 pub use pep::{
     build_pep_identity, is_pep_request, is_pep_request_to, pep_features, PepHandler,

--- a/server/crates/waddle-xmpp-core/src/pubsub/node.rs
+++ b/server/crates/waddle-xmpp-core/src/pubsub/node.rs
@@ -140,6 +140,49 @@ pub struct NodeConfig {
     pub send_last_published_item: SendLastPublishedItem,
 }
 
+/// Partial node configuration submitted by an XEP-0060 configure form.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct NodeConfigPatch {
+    pub access_model: Option<AccessModel>,
+    pub publish_model: Option<PublishModel>,
+    pub max_items: Option<u32>,
+    pub persist_items: Option<bool>,
+    pub deliver_payloads: Option<bool>,
+    pub notify_retract: Option<bool>,
+    pub notify_delete: Option<bool>,
+    pub send_last_published_item: Option<SendLastPublishedItem>,
+}
+
+impl NodeConfigPatch {
+    pub fn apply_to(&self, mut config: NodeConfig) -> NodeConfig {
+        if let Some(access_model) = self.access_model {
+            config.access_model = access_model;
+        }
+        if let Some(publish_model) = self.publish_model {
+            config.publish_model = publish_model;
+        }
+        if let Some(max_items) = self.max_items {
+            config.max_items = max_items;
+        }
+        if let Some(persist_items) = self.persist_items {
+            config.persist_items = persist_items;
+        }
+        if let Some(deliver_payloads) = self.deliver_payloads {
+            config.deliver_payloads = deliver_payloads;
+        }
+        if let Some(notify_retract) = self.notify_retract {
+            config.notify_retract = notify_retract;
+        }
+        if let Some(notify_delete) = self.notify_delete {
+            config.notify_delete = notify_delete;
+        }
+        if let Some(send_last_published_item) = self.send_last_published_item {
+            config.send_last_published_item = send_last_published_item;
+        }
+        config
+    }
+}
+
 impl Default for NodeConfig {
     fn default() -> Self {
         Self::pep_default()

--- a/server/crates/waddle-xmpp-core/src/pubsub/stanzas.rs
+++ b/server/crates/waddle-xmpp-core/src/pubsub/stanzas.rs
@@ -5,7 +5,7 @@ use minidom::Element;
 use xmpp_parsers::iq::Iq;
 use xmpp_parsers::message::Message;
 
-use crate::pubsub::{Affiliation, NodeConfig};
+use crate::pubsub::{Affiliation, NodeConfigPatch};
 use crate::{CoreError, CoreResult};
 
 mod builders;
@@ -149,7 +149,7 @@ pub enum PubSubRequest {
     /// XEP-0060 §6.4 `<configure node='...'><x.../>` (owner-only, set form).
     ConfigureNodeSet {
         node: String,
-        config: NodeConfig,
+        config: NodeConfigPatch,
     },
     /// XEP-0060 §8.9 `<affiliations node='...'/>` get on owner namespace.
     AffiliationsGet {
@@ -185,6 +185,7 @@ pub enum PubSubError {
     NodeNotFound,
     ItemNotFound,
     Forbidden,
+    ClosedNode,
     NodeExists,
     BadRequest,
     InvalidJid,
@@ -409,8 +410,8 @@ fn required_attr(element: &Element, attr: &str) -> CoreResult<String> {
         .ok_or_else(|| CoreError::bad_request(Some(format!("Missing {attr} attribute"))))
 }
 
-fn parse_configure_form(form: &Element) -> CoreResult<NodeConfig> {
-    let mut config = NodeConfig::default();
+fn parse_configure_form(form: &Element) -> CoreResult<NodeConfigPatch> {
+    let mut config = NodeConfigPatch::default();
     for field in form.children().filter(|c| c.is("field", "jabber:x:data")) {
         let var = field.attr("var").unwrap_or("");
         let value = field
@@ -419,30 +420,30 @@ fn parse_configure_form(form: &Element) -> CoreResult<NodeConfig> {
             .unwrap_or_default();
         match var {
             "pubsub#access_model" => {
-                config.access_model = value.parse().map_err(|_| {
+                config.access_model = Some(value.parse().map_err(|_| {
                     CoreError::bad_request(Some(format!("invalid pubsub#access_model: {value}")))
-                })?;
+                })?);
             }
             "pubsub#publish_model" => {
-                config.publish_model = value.parse().map_err(|_| {
+                config.publish_model = Some(value.parse().map_err(|_| {
                     CoreError::bad_request(Some(format!("invalid pubsub#publish_model: {value}")))
-                })?;
+                })?);
             }
             "pubsub#max_items" => {
                 // XEP-0060 §16.4.3 + XEP-0490 §3 publish-options use the
                 // literal token "max" to mean "no upper bound". Accept it
                 // alongside the numeric form so MDS-style publish-options
                 // round-trip without a precondition-not-met error.
-                config.max_items = if value.eq_ignore_ascii_case("max") {
+                config.max_items = Some(if value.eq_ignore_ascii_case("max") {
                     u32::MAX
                 } else {
                     value.parse::<u32>().map_err(|_| {
                         CoreError::bad_request(Some(format!("invalid pubsub#max_items: {value}")))
                     })?
-                };
+                });
             }
             "pubsub#persist_items" => {
-                config.persist_items = match value.as_str() {
+                config.persist_items = Some(match value.as_str() {
                     "0" | "false" => false,
                     "1" | "true" => true,
                     _ => {
@@ -450,10 +451,10 @@ fn parse_configure_form(form: &Element) -> CoreResult<NodeConfig> {
                             "invalid pubsub#persist_items: {value}"
                         ))))
                     }
-                };
+                });
             }
             "pubsub#deliver_payloads" => {
-                config.deliver_payloads = match value.as_str() {
+                config.deliver_payloads = Some(match value.as_str() {
                     "0" | "false" => false,
                     "1" | "true" => true,
                     _ => {
@@ -461,10 +462,10 @@ fn parse_configure_form(form: &Element) -> CoreResult<NodeConfig> {
                             "invalid pubsub#deliver_payloads: {value}"
                         ))))
                     }
-                };
+                });
             }
             "pubsub#notify_retract" => {
-                config.notify_retract = match value.as_str() {
+                config.notify_retract = Some(match value.as_str() {
                     "0" | "false" => false,
                     "1" | "true" => true,
                     _ => {
@@ -472,10 +473,10 @@ fn parse_configure_form(form: &Element) -> CoreResult<NodeConfig> {
                             "invalid pubsub#notify_retract: {value}"
                         ))))
                     }
-                };
+                });
             }
             "pubsub#notify_delete" => {
-                config.notify_delete = match value.as_str() {
+                config.notify_delete = Some(match value.as_str() {
                     "0" | "false" => false,
                     "1" | "true" => true,
                     _ => {
@@ -483,14 +484,14 @@ fn parse_configure_form(form: &Element) -> CoreResult<NodeConfig> {
                             "invalid pubsub#notify_delete: {value}"
                         ))))
                     }
-                };
+                });
             }
             "pubsub#send_last_published_item" => {
-                config.send_last_published_item = value.parse().map_err(|_| {
+                config.send_last_published_item = Some(value.parse().map_err(|_| {
                     CoreError::bad_request(Some(format!(
                         "invalid pubsub#send_last_published_item: {value}"
                     )))
-                })?;
+                })?);
             }
             _ => {} // Unknown fields ignored per XEP-0060.
         }

--- a/server/crates/waddle-xmpp-core/src/pubsub/stanzas/builders.rs
+++ b/server/crates/waddle-xmpp-core/src/pubsub/stanzas/builders.rs
@@ -87,6 +87,7 @@ pub fn build_pubsub_error(original_iq: &Iq, error: PubSubError) -> Iq {
             (ErrorType::Cancel, DefinedCondition::ItemNotFound)
         }
         PubSubError::Forbidden => (ErrorType::Auth, DefinedCondition::Forbidden),
+        PubSubError::ClosedNode => (ErrorType::Cancel, DefinedCondition::NotAllowed),
         PubSubError::NodeExists | PubSubError::PreconditionNotMet => {
             (ErrorType::Cancel, DefinedCondition::Conflict)
         }
@@ -112,6 +113,8 @@ pub fn build_pubsub_error(original_iq: &Iq, error: PubSubError) -> Iq {
                 )
                 .build(),
         );
+    } else if let PubSubError::ClosedNode = error {
+        stanza_error.other = Some(Element::builder("closed-node", NS_PUBSUB_ERRORS).build());
     }
 
     Iq::Error {

--- a/server/crates/waddle-xmpp-core/src/pubsub/stanzas/tests.rs
+++ b/server/crates/waddle-xmpp-core/src/pubsub/stanzas/tests.rs
@@ -192,6 +192,35 @@ fn parse_configure_request() {
 }
 
 #[test]
+fn parse_configure_set_keeps_partial_fields_partial() {
+    let configure = Element::builder("configure", NS_PUBSUB_OWNER)
+        .attr(minidom::rxml::xml_ncname!("node").to_owned(), "space")
+        .append(
+            Element::builder("x", NS_XDATA)
+                .attr(minidom::rxml::xml_ncname!("type").to_owned(), "submit")
+                .append(xdata_field("pubsub#max_items", "200"))
+                .build(),
+        )
+        .build();
+    let iq = iq_with_payload(
+        "cfg-set1",
+        Some("owner@example.com"),
+        None,
+        TestIqPayload::Set(pubsub_payload(NS_PUBSUB_OWNER, [configure])),
+    );
+    let request = parse_pubsub_iq(&iq).expect("should parse");
+
+    match request {
+        PubSubRequest::ConfigureNodeSet { node, config } => {
+            assert_eq!(node, "space");
+            assert_eq!(config.max_items, Some(200));
+            assert_eq!(config.access_model, None);
+        }
+        other => panic!("Expected configure-set request, got {other:?}"),
+    }
+}
+
+#[test]
 fn parse_owner_subscriptions_as_unsupported_manage_subscriptions() {
     let subscriptions = Element::builder("subscriptions", NS_PUBSUB_OWNER)
         .attr(minidom::rxml::xml_ncname!("node").to_owned(), "space")

--- a/server/crates/waddle-xmpp/src/app_state.rs
+++ b/server/crates/waddle-xmpp/src/app_state.rs
@@ -4,6 +4,32 @@ use xmpp_parsers::minidom::Element;
 
 use crate::{inbox, roster, Affiliation, XmppError};
 
+/// XEP-0503 access models Waddle can currently serve correctly for Spaces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpaceAccessModel {
+    Open,
+    Whitelist,
+}
+
+impl SpaceAccessModel {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Whitelist => "whitelist",
+        }
+    }
+
+    pub fn from_pubsub(access_model: crate::pubsub::AccessModel) -> Option<Self> {
+        match access_model {
+            crate::pubsub::AccessModel::Open => Some(Self::Open),
+            crate::pubsub::AccessModel::Whitelist => Some(Self::Whitelist),
+            crate::pubsub::AccessModel::Presence
+            | crate::pubsub::AccessModel::Roster
+            | crate::pubsub::AccessModel::Authorize => None,
+        }
+    }
+}
+
 /// Detailed canonical space information for XEP-0503.
 #[derive(Debug, Clone)]
 pub struct SpaceDetails {
@@ -19,6 +45,8 @@ pub struct SpaceDetails {
     pub icon_url: Option<String>,
     /// Whether the space is public.
     pub is_public: bool,
+    /// XEP-0060 PubSub access model advertised for the Space node.
+    pub access_model: SpaceAccessModel,
     /// Creation timestamp in ISO 8601 format.
     pub created_at: String,
 }

--- a/server/crates/waddle-xmpp/src/lib.rs
+++ b/server/crates/waddle-xmpp/src/lib.rs
@@ -51,7 +51,9 @@ mod app_state;
 mod error;
 mod types;
 
-pub use app_state::{AppState, ScramCredentials, Session, SpaceDetails, UserDirectoryEntry};
+pub use app_state::{
+    AppState, ScramCredentials, Session, SpaceAccessModel, SpaceDetails, UserDirectoryEntry,
+};
 
 pub use error::{
     generate_iq_error, generate_stream_error, stream_errors, StanzaErrorCondition, StanzaErrorType,

--- a/server/crates/waddle-xmpp/src/pubsub/mod.rs
+++ b/server/crates/waddle-xmpp/src/pubsub/mod.rs
@@ -10,7 +10,8 @@ pub mod stanzas;
 pub mod storage;
 
 pub use node::{
-    AccessModel, NodeConfig, PublishModel, SendLastPublishedItem, PEP_BOOKMARK_MAX_ITEMS,
+    AccessModel, NodeConfig, NodeConfigPatch, PublishModel, SendLastPublishedItem,
+    PEP_BOOKMARK_MAX_ITEMS,
 };
 pub use pep::{
     build_pep_identity, is_pep_request, is_pep_request_to, pep_features, PepHandler,

--- a/server/crates/waddle-xmpp/src/pubsub/node.rs
+++ b/server/crates/waddle-xmpp/src/pubsub/node.rs
@@ -1,5 +1,6 @@
 //! Server-facing re-exports for shared PubSub node configuration types.
 
 pub use waddle_xmpp_core::pubsub::{
-    AccessModel, NodeConfig, PublishModel, SendLastPublishedItem, PEP_BOOKMARK_MAX_ITEMS,
+    AccessModel, NodeConfig, NodeConfigPatch, PublishModel, SendLastPublishedItem,
+    PEP_BOOKMARK_MAX_ITEMS,
 };

--- a/server/crates/waddle-xmpp/src/xep/xep0503.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0503.rs
@@ -117,7 +117,7 @@ pub fn build_spaces_metadata_form_for_requester(
         ))
         .add_field(Field::text_single(
             "pubsub#access_model",
-            if space.is_public { "open" } else { "whitelist" },
+            space.access_model.as_str(),
         ));
 
     if let Some(affiliation) = requester_affiliation {
@@ -242,6 +242,7 @@ mod tests {
             owner_id: "alice".to_string(),
             icon_url: None,
             is_public: true,
+            access_model: crate::SpaceAccessModel::Open,
             created_at: "2026-01-15T10:00:00Z".to_string(),
         }
     }
@@ -461,6 +462,7 @@ mod tests {
     fn test_build_spaces_metadata_form_private_space() {
         let mut space = test_space();
         space.is_public = false;
+        space.access_model = crate::SpaceAccessModel::Whitelist;
         space.description = None;
 
         let form = build_spaces_metadata_form(&space);


### PR DESCRIPTION
## Root Cause

The server had Spaces and channels in admin state, but admin channel lifecycle did not reliably publish the XEP-0503/XEP-0402 bookmark items that native clients discover. Some Spaces PubSub nodes were also using generic PubSub defaults, so multiple channel bookmarks could evict each other. The Apple client then collapsed discovery failures or empty topology into the generic setup empty state.

## Completed

- Configure admin-created Space PubSub nodes with canonical XEP-0503 defaults.
- Publish, update, retract, backfill, and roll back XEP-0402 channel bookmarks during admin channel lifecycle and XMPP publish/retract flows.
- Keep channel-space link projection, PubSub bookmarks, and channel parent permission tuples in sync across admin and websocket paths.
- Support valid non-JID XEP-0503 node IDs without forcing them through BareJid parsing.
- Authorize Spaces `<items/>` reads before backfill and return XEP-0060 `closed-node` for unauthorized whitelist reads.
- Derive Spaces disco metadata from stored node config, with a typed `SpaceAccessModel` instead of stringly protocol state.
- Parse PubSub configure-set forms as typed partial patches, merge them with stored node config, and normalize required Spaces fields so omitted fields cannot synthesize `access_model=presence` or reset bookmark retention.
- Reject unsupported Spaces configure access models (`presence`, `roster`, `authorize`) while accepting supported public/private exposure changes (`open`, `whitelist`).
- Remove the unused empty discovery helper that made generic PubSub items look like Spaces.
- Surface discovery failures and mobile warning banners instead of showing false setup copy.
- Add focused server/client tests for discovery, backfill, admin lifecycle, rollback behavior, non-JID nodes, configure semantics, and permission tuple behavior.

## Verification

- `cargo fmt --manifest-path server/Cargo.toml --all`
- `cargo test --manifest-path server/Cargo.toml -p waddle-xmpp-core pubsub::stanzas::tests::parse_configure_set_keeps_partial_fields_partial`
- `cargo test --manifest-path server/Cargo.toml -p waddle-xmpp-client discovery::tests`
- `cargo test --manifest-path server/Cargo.toml -p waddle-xmpp xep::xep0503`
- `cargo test --manifest-path server/Cargo.toml -p waddle-server handle_iq_pubsub_configure_spaces_node`
- `cargo test --manifest-path server/Cargo.toml -p waddle-server handle_iq_disco_info_spaces_node_reports`
- `cargo test --manifest-path server/Cargo.toml -p waddle-server handle_iq_pubsub_items_spaces_node_requires_authorization_before_backfill`
- `cargo test --manifest-path server/Cargo.toml -p waddle-server handle_iq_pubsub_items_spaces_node_backfills_linked_channel_bookmarks`
- `cargo test --manifest-path server/Cargo.toml -p waddle-server spaces_publish_and_retract_sync_channel_space_link_projection`
- `cargo test --manifest-path server/Cargo.toml -p waddle-server spaces_publish_accepts_non_jid_node_and_syncs_parent_tuple`
- `cargo test --manifest-path server/Cargo.toml -p waddle-server admin_channels_create_space_bookmark_grants_space_members_channel_view`
- `cargo test --manifest-path server/Cargo.toml -p waddle-server admin_channels_update_retracts_duplicate_space_bookmarks`
- `cargo test --manifest-path server/Cargo.toml -p waddle-server admin_channels_delete_retracts_duplicate_space_bookmarks`
- `cargo test --manifest-path server/Cargo.toml -p waddle-server admin_spaces_delete_clears_channel_parent_tuple`
- `cargo test --manifest-path server/Cargo.toml -p waddle-server --test admin_channel_space_link_ws channels_list_space_jid_filter_narrows_results_and_survives_lifecycle`
- `cargo test --manifest-path server/Cargo.toml -p waddle-server --test xep0163_pep_ws`
- `cargo test --manifest-path server/Cargo.toml -p waddle-server --test xep0060_spaces_owner_ws`
- `cargo test --manifest-path server/Cargo.toml -p waddle-server --test xep0503_spaces_ws`
- `cargo clippy --manifest-path server/Cargo.toml -p waddle-xmpp-core -p waddle-server --all-targets -- -D warnings`
- `cargo clippy --manifest-path server/Cargo.toml -p waddle-server -p waddle-xmpp-client --all-targets -- -D warnings`
- `git diff --check`
- XcodeBuildMCP simulator build for `Waddle-iOS`

## Review

- Addressed PR feedback on authorization-before-backfill, XEP-0060 error shape, stale bookmark rollback, tuple rollback ownership, unsupported Spaces access models, typed access metadata, and canonical Spaces configure defaults.
- Adversarial re-review found and fixed the partial configure-set parser bug where omitted `pubsub#access_model` was treated as synthetic `presence`.
- CI caught that the XEP-0060 `closed-node` error shape leaked into PEP bookmark reads; restricted it back to non-PEP whitelist item reads while preserving Spaces `closed-node`.
- Deferred structured Swift discovery error binding changes; the UI now surfaces discovery failure state without changing the generated UniFFI surface in this PR.
- Final adversarial passes from server/XEP, rollback, client, and CI reviewers found no remaining actionable issues.
