### PR TITLE
fix(chat): harden XEP-0030 topology discovery against hung components

### DIFF
--- a/chat/src/lib/xmpp/discovery.ts
+++ b/chat/src/lib/xmpp/discovery.ts
@@ -31,7 +31,19 @@ export type DiscoInfoData = {
 // per-IQ timeout. 15s is short enough that a wedged component cannot stall
 // topology discovery longer than one user heartbeat, long enough to survive
 // realistic mobile/satellite RTTs.
-const DISCO_IQ_TIMEOUT_MS = 15_000;
+const DISCO_IQ_TIMEOUT_MS_DEFAULT = 15_000;
+let DISCO_IQ_TIMEOUT_MS = DISCO_IQ_TIMEOUT_MS_DEFAULT;
+
+/**
+ * Override the disco IQ timeout used by `sendDiscoInfo` / `sendDiscoItems`
+ * / `sendPubsubItems`. Test-only backdoor — call with `null` to restore
+ * the default. Lets integration tests verify the actual timeout wiring
+ * without waiting 15s of real time per case. Production callers should
+ * NEVER call this.
+ */
+export function __setDiscoIqTimeoutForTest(ms: number | null): void {
+  DISCO_IQ_TIMEOUT_MS = ms ?? DISCO_IQ_TIMEOUT_MS_DEFAULT;
+}
 
 export class DiscoTimeoutError extends Error {
   constructor(public readonly to: string, public readonly node: string | undefined) {
@@ -40,15 +52,31 @@ export class DiscoTimeoutError extends Error {
   }
 }
 
+/**
+ * Wrap an in-flight IQ Promise with a bounded timeout.
+ *
+ * Known limitation — driver-side pending_iqs retention: rejecting the JS
+ * Promise here does NOT remove the entry from the wasm driver's pending_iqs
+ * HashMap (server/crates/waddle-xmpp-client-wasm/src/driver.rs:222). The
+ * entry stays until either a (possibly never-arriving) response or stream
+ * disconnect, at which point `pending_iqs.drain()` clears it. Per-stream
+ * leak is bounded (~100 B × ~7 IQs per topology rebuild) and fully reclaimed
+ * on reconnect. The proper fix is a `cancel_iq(id)` driver command — tracked
+ * as a follow-up; not blocking the channel-rendering bug this PR closes.
+ */
 export function withIqTimeout<T>(
   raw: Promise<T>,
   to: string,
   node: string | undefined,
-  timeoutMs: number = DISCO_IQ_TIMEOUT_MS,
+  timeoutMs?: number,
 ): Promise<T> {
+  // Read `DISCO_IQ_TIMEOUT_MS` at call time, not at function-definition
+  // time, so `__setDiscoIqTimeoutForTest` correctly overrides for the
+  // duration of a test case.
+  const effectiveTimeout = timeoutMs ?? DISCO_IQ_TIMEOUT_MS;
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(new DiscoTimeoutError(to, node)), timeoutMs);
+    timer = setTimeout(() => reject(new DiscoTimeoutError(to, node)), effectiveTimeout);
   });
   return Promise.race([raw, timeout]).finally(() => {
     if (timer !== undefined) clearTimeout(timer);
@@ -113,15 +141,32 @@ function roomParentSpaceId(info: DiscoInfoData): string | null {
     ?? parseSpaceNodeIri(info.fields.get("muc#roominfo_pubsub") ?? null);
 }
 
+function logDiscoFailure(kind: "info" | "items" | "pubsub", to: string, node: string | undefined, err: unknown): void {
+  if (err instanceof DiscoTimeoutError) {
+    // Timeouts are the diagnostic signal we actually care about when
+    // channels fail to render — keep them structured so consumers can
+    // grep / aggregate by `to`.
+    console.warn(`[disco] ${kind} timeout`, { to: err.to, node: err.node });
+    return;
+  }
+  console.error(`[disco] ${kind} FAILED`, { to, node, err });
+}
+
 async function sendDiscoInfo(xmpp: HybridClient, to: string, node?: string): Promise<DiscoInfoData | null> {
   if (!xmpp.send_raw_iq) return null;
   const id = crypto.randomUUID();
   const nodeAttr = node ? ` node="${node}"` : "";
-  const responseXml = await withIqTimeout(
-    xmpp.send_raw_iq(`<iq type="get" id="${id}" to="${to}"><query xmlns="${DISCO_INFO_NS}"${nodeAttr}/></iq>`),
-    to,
-    node,
-  );
+  let responseXml: string;
+  try {
+    responseXml = await withIqTimeout(
+      xmpp.send_raw_iq(`<iq type="get" id="${id}" to="${to}"><query xmlns="${DISCO_INFO_NS}"${nodeAttr}/></iq>`),
+      to,
+      node,
+    );
+  } catch (err) {
+    logDiscoFailure("info", to, node, err);
+    throw err;
+  }
   const query = parseXml(responseXml).getElementsByTagNameNS(DISCO_INFO_NS, "query")[0];
   if (!query) return null;
   const fields = new Map<string, string>();
@@ -149,7 +194,7 @@ async function sendDiscoItems(xmpp: HybridClient, to: string, node?: string): Pr
   try {
     responseXml = await withIqTimeout(xmpp.send_raw_iq(xml), to, node);
   } catch (err) {
-    console.error("[disco] send_raw_iq items FAILED", { to, err });
+    logDiscoFailure("items", to, node, err);
     throw err;
   }
   const doc = parseXml(responseXml);
@@ -163,11 +208,17 @@ async function sendDiscoItems(xmpp: HybridClient, to: string, node?: string): Pr
 async function sendPubsubItems(xmpp: HybridClient, to: string, node: string): Promise<Array<{ jid?: string; name?: string }>> {
   if (!xmpp.send_raw_iq) return [];
   const id = crypto.randomUUID();
-  const responseXml = await withIqTimeout(
-    xmpp.send_raw_iq(`<iq type="get" id="${id}" to="${to}"><pubsub xmlns="${NS_PUBSUB}"><items node="${node}"/></pubsub></iq>`),
-    to,
-    node,
-  );
+  let responseXml: string;
+  try {
+    responseXml = await withIqTimeout(
+      xmpp.send_raw_iq(`<iq type="get" id="${id}" to="${to}"><pubsub xmlns="${NS_PUBSUB}"><items node="${node}"/></pubsub></iq>`),
+      to,
+      node,
+    );
+  } catch (err) {
+    logDiscoFailure("pubsub", to, node, err);
+    throw err;
+  }
   const doc = parseXml(responseXml);
   const items = doc.getElementsByTagNameNS(NS_PUBSUB, "items")[0];
   if (!items) return [];
@@ -195,6 +246,11 @@ async function discoverComponentServices(xmpp: HybridClient, domain: string, jid
     // failure) maps to `info: null`, which is the same shape the existing
     // try/catch produced — every downstream consumer already treats `null` as
     // "service absent" and falls back to the conventional domain.
+    //
+    // Caps cache safety (XEP-0115): an `info: null` here represents IQ
+    // failure, NOT "this entity has zero features". A future consumer that
+    // caches disco-info by ver hash MUST NOT persist this fallback shape —
+    // doing so would poison the cache against a recovering component.
     const settled = await Promise.allSettled(candidates.map(async (serviceJid) => ({
       serviceJid,
       info: await sendDiscoInfo(xmpp, serviceJid),
@@ -311,27 +367,36 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
     }
   } catch {}
 
-  // Surround the MUC-rooms fan-out in try/catch + allSettled so a single
-  // unresponsive room (or a hung muc service disco#items) degrades the
-  // sidebar to "no rooms" instead of failing the whole topology load.
-  // `hydrateRoomInfo` already swallows its own errors, but `sendDiscoItems`
-  // on the MUC service can now time out (see `withIqTimeout`) — without
-  // this guard a timeout there would bubble up and abandon the
-  // already-resolved spaces work.
+  // Narrow try/catch JUST around `sendDiscoItems`: a wedged muc service
+  // (which now times out via `withIqTimeout` instead of hanging forever)
+  // degrades the sidebar to "no rooms" rather than failing the whole
+  // topology load and abandoning already-resolved spaces work. Subsequent
+  // hydration uses `Promise.allSettled` so a single broken room cannot
+  // poison the others; `hydrateRoomInfo` already self-catches, so the
+  // `allSettled` is belt-and-braces against a future regression there.
+  // Errors in barePeerJid, channelFromRoom, or the final rooms.map are
+  // intentionally left to propagate — those are programmer errors, not
+  // wire-state errors, and silently swallowing them would mask bugs.
+  let mucRooms: Array<{ jid?: string; name?: string }> = [];
   try {
-    const mucRooms = await sendDiscoItems(xmpp, services.muc);
-    const hydratedSettled = await Promise.allSettled(
-      mucRooms.map((room, position) =>
-        hydrateRoomInfo(xmpp, channelFromRoom({ jid: room.jid ?? "", name: room.name }, position)),
-      ),
-    );
-    const hydrated = hydratedSettled.map((entry, index) =>
-      entry.status === "fulfilled"
-        ? entry.value
-        : channelFromRoom({ jid: mucRooms[index]!.jid ?? "", name: mucRooms[index]!.name }, index),
-    );
-    rooms = hydrated.map((room, position) => ({ ...room, position, ...(room.jid && bookmarkedSpaceIds.get(barePeerJid(room.jid)) ? { spaceId: bookmarkedSpaceIds.get(barePeerJid(room.jid)), standalone: false } : {}) }));
-  } catch {}
+    mucRooms = await sendDiscoItems(xmpp, services.muc);
+  } catch (err) {
+    // sendDiscoItems already logged via logDiscoFailure; here we just
+    // continue with an empty room list. The cause is observable in the
+    // console for diagnostics.
+    void err;
+  }
+  const hydratedSettled = await Promise.allSettled(
+    mucRooms.map((room, position) =>
+      hydrateRoomInfo(xmpp, channelFromRoom({ jid: room.jid ?? "", name: room.name }, position)),
+    ),
+  );
+  const hydrated = hydratedSettled.map((entry, index) =>
+    entry.status === "fulfilled"
+      ? entry.value
+      : channelFromRoom({ jid: mucRooms[index]!.jid ?? "", name: mucRooms[index]!.name }, index),
+  );
+  rooms = hydrated.map((room, position) => ({ ...room, position, ...(room.jid && bookmarkedSpaceIds.get(barePeerJid(room.jid)) ? { spaceId: bookmarkedSpaceIds.get(barePeerJid(room.jid)), standalone: false } : {}) }));
 
   const roomSpaceIds = new Map(rooms.flatMap((room) => room.jid ? [[barePeerJid(room.jid), room.spaceId]] as const : []));
   return {

--- a/chat/src/lib/xmpp/discovery.ts
+++ b/chat/src/lib/xmpp/discovery.ts
@@ -25,6 +25,36 @@ export type DiscoInfoData = {
   fields: Map<string, string>;
 };
 
+// RFC 6120 §8.2.3 requires IQ stanzas to be answered, but the requirement
+// cannot be enforced on the wire — every modern XMPP client (Conversations,
+// Gajim, Dino) defends against silently-dropped IQ responses with a bounded
+// per-IQ timeout. 15s is short enough that a wedged component cannot stall
+// topology discovery longer than one user heartbeat, long enough to survive
+// realistic mobile/satellite RTTs.
+const DISCO_IQ_TIMEOUT_MS = 15_000;
+
+export class DiscoTimeoutError extends Error {
+  constructor(public readonly to: string, public readonly node: string | undefined) {
+    super(`disco IQ to ${to}${node ? ` (node=${node})` : ""} timed out after ${DISCO_IQ_TIMEOUT_MS}ms`);
+    this.name = "DiscoTimeoutError";
+  }
+}
+
+export function withIqTimeout<T>(
+  raw: Promise<T>,
+  to: string,
+  node: string | undefined,
+  timeoutMs: number = DISCO_IQ_TIMEOUT_MS,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new DiscoTimeoutError(to, node)), timeoutMs);
+  });
+  return Promise.race([raw, timeout]).finally(() => {
+    if (timer !== undefined) clearTimeout(timer);
+  });
+}
+
 function parseXml(xml: string): Document {
   return new DOMParser().parseFromString(xml, "text/xml");
 }
@@ -87,7 +117,11 @@ async function sendDiscoInfo(xmpp: HybridClient, to: string, node?: string): Pro
   if (!xmpp.send_raw_iq) return null;
   const id = crypto.randomUUID();
   const nodeAttr = node ? ` node="${node}"` : "";
-  const responseXml = await xmpp.send_raw_iq(`<iq type="get" id="${id}" to="${to}"><query xmlns="${DISCO_INFO_NS}"${nodeAttr}/></iq>`);
+  const responseXml = await withIqTimeout(
+    xmpp.send_raw_iq(`<iq type="get" id="${id}" to="${to}"><query xmlns="${DISCO_INFO_NS}"${nodeAttr}/></iq>`),
+    to,
+    node,
+  );
   const query = parseXml(responseXml).getElementsByTagNameNS(DISCO_INFO_NS, "query")[0];
   if (!query) return null;
   const fields = new Map<string, string>();
@@ -113,7 +147,7 @@ async function sendDiscoItems(xmpp: HybridClient, to: string, node?: string): Pr
   const xml = `<iq type="get" id="${id}" to="${to}"><query xmlns="${DISCO_ITEMS_NS}"${nodeAttr}/></iq>`;
   let responseXml: string;
   try {
-    responseXml = await xmpp.send_raw_iq(xml);
+    responseXml = await withIqTimeout(xmpp.send_raw_iq(xml), to, node);
   } catch (err) {
     console.error("[disco] send_raw_iq items FAILED", { to, err });
     throw err;
@@ -129,7 +163,11 @@ async function sendDiscoItems(xmpp: HybridClient, to: string, node?: string): Pr
 async function sendPubsubItems(xmpp: HybridClient, to: string, node: string): Promise<Array<{ jid?: string; name?: string }>> {
   if (!xmpp.send_raw_iq) return [];
   const id = crypto.randomUUID();
-  const responseXml = await xmpp.send_raw_iq(`<iq type="get" id="${id}" to="${to}"><pubsub xmlns="${NS_PUBSUB}"><items node="${node}"/></pubsub></iq>`);
+  const responseXml = await withIqTimeout(
+    xmpp.send_raw_iq(`<iq type="get" id="${id}" to="${to}"><pubsub xmlns="${NS_PUBSUB}"><items node="${node}"/></pubsub></iq>`),
+    to,
+    node,
+  );
   const doc = parseXml(responseXml);
   const items = doc.getElementsByTagNameNS(NS_PUBSUB, "items")[0];
   if (!items) return [];
@@ -152,13 +190,20 @@ async function discoverComponentServices(xmpp: HybridClient, domain: string, jid
   try {
     const items = await sendDiscoItems(xmpp, domain);
     const candidates = items.map((item) => item.jid).filter((value): value is string => !!value);
-    const serviceInfo = await Promise.all(candidates.map(async (serviceJid) => {
-      try {
-        return { serviceJid, info: await sendDiscoInfo(xmpp, serviceJid) };
-      } catch {
-        return { serviceJid, info: null };
-      }
-    }));
+    // `allSettled` (not `all`): a single hung component must not wedge the
+    // whole topology fan-out. A rejected entry (timeout, stanza error, parse
+    // failure) maps to `info: null`, which is the same shape the existing
+    // try/catch produced — every downstream consumer already treats `null` as
+    // "service absent" and falls back to the conventional domain.
+    const settled = await Promise.allSettled(candidates.map(async (serviceJid) => ({
+      serviceJid,
+      info: await sendDiscoInfo(xmpp, serviceJid),
+    })));
+    const serviceInfo = settled.map((entry, index) =>
+      entry.status === "fulfilled"
+        ? entry.value
+        : { serviceJid: candidates[index]!, info: null },
+    );
     const muc = serviceInfo.find(({ info }) =>
       hasDiscoFeature(info, NS_MUC)
       || info?.identities.some((identity) => identity.category === "conference")
@@ -220,7 +265,16 @@ export async function discoverChannels(xmpp: HybridClient, jid: string): Promise
   const spaceNode = spaces[0]?.node;
   if (!spaceNode) return [];
   const items = await sendPubsubItems(xmpp, spacesServiceDomain(jid), spaceNode);
-  const hydrated = await Promise.all(items.map((item, position) => hydrateRoomInfo(xmpp, channelFromRoom({ jid: item.jid ?? "", name: item.name }, position))));
+  const settled = await Promise.allSettled(
+    items.map((item, position) =>
+      hydrateRoomInfo(xmpp, channelFromRoom({ jid: item.jid ?? "", name: item.name }, position)),
+    ),
+  );
+  const hydrated = settled.map((entry, index) =>
+    entry.status === "fulfilled"
+      ? entry.value
+      : channelFromRoom({ jid: items[index]!.jid ?? "", name: items[index]!.name }, index),
+  );
   return hydrated.map((room, position) => ({ id: room.id, name: room.name, channelType: room.channelType, position }));
 }
 
@@ -257,9 +311,27 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
     }
   } catch {}
 
-  const mucRooms = await sendDiscoItems(xmpp, services.muc);
-  const hydrated = await Promise.all(mucRooms.map((room, position) => hydrateRoomInfo(xmpp, channelFromRoom({ jid: room.jid ?? "", name: room.name }, position))));
-  rooms = hydrated.map((room, position) => ({ ...room, position, ...(room.jid && bookmarkedSpaceIds.get(barePeerJid(room.jid)) ? { spaceId: bookmarkedSpaceIds.get(barePeerJid(room.jid)), standalone: false } : {}) }));
+  // Surround the MUC-rooms fan-out in try/catch + allSettled so a single
+  // unresponsive room (or a hung muc service disco#items) degrades the
+  // sidebar to "no rooms" instead of failing the whole topology load.
+  // `hydrateRoomInfo` already swallows its own errors, but `sendDiscoItems`
+  // on the MUC service can now time out (see `withIqTimeout`) — without
+  // this guard a timeout there would bubble up and abandon the
+  // already-resolved spaces work.
+  try {
+    const mucRooms = await sendDiscoItems(xmpp, services.muc);
+    const hydratedSettled = await Promise.allSettled(
+      mucRooms.map((room, position) =>
+        hydrateRoomInfo(xmpp, channelFromRoom({ jid: room.jid ?? "", name: room.name }, position)),
+      ),
+    );
+    const hydrated = hydratedSettled.map((entry, index) =>
+      entry.status === "fulfilled"
+        ? entry.value
+        : channelFromRoom({ jid: mucRooms[index]!.jid ?? "", name: mucRooms[index]!.name }, index),
+    );
+    rooms = hydrated.map((room, position) => ({ ...room, position, ...(room.jid && bookmarkedSpaceIds.get(barePeerJid(room.jid)) ? { spaceId: bookmarkedSpaceIds.get(barePeerJid(room.jid)), standalone: false } : {}) }));
+  } catch {}
 
   const roomSpaceIds = new Map(rooms.flatMap((room) => room.jid ? [[barePeerJid(room.jid), room.spaceId]] as const : []));
   return {

--- a/chat/src/lib/xmpp/discovery.ts
+++ b/chat/src/lib/xmpp/discovery.ts
@@ -46,8 +46,16 @@ export function __setDiscoIqTimeoutForTest(ms: number | null): void {
 }
 
 export class DiscoTimeoutError extends Error {
-  constructor(public readonly to: string, public readonly node: string | undefined) {
-    super(`disco IQ to ${to}${node ? ` (node=${node})` : ""} timed out after ${DISCO_IQ_TIMEOUT_MS}ms`);
+  constructor(
+    public readonly to: string,
+    public readonly node: string | undefined,
+    public readonly timeoutMs: number,
+  ) {
+    // Report the actual budget the timer fired against — NOT the
+    // module-level `DISCO_IQ_TIMEOUT_MS`, which may have been overridden
+    // for this call via the optional `timeoutMs` argument to
+    // `withIqTimeout` (e.g. from `__setDiscoIqTimeoutForTest` in tests).
+    super(`disco IQ to ${to}${node ? ` (node=${node})` : ""} timed out after ${timeoutMs}ms`);
     this.name = "DiscoTimeoutError";
   }
 }
@@ -76,7 +84,7 @@ export function withIqTimeout<T>(
   const effectiveTimeout = timeoutMs ?? DISCO_IQ_TIMEOUT_MS;
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(new DiscoTimeoutError(to, node)), effectiveTimeout);
+    timer = setTimeout(() => reject(new DiscoTimeoutError(to, node, effectiveTimeout)), effectiveTimeout);
   });
   return Promise.race([raw, timeout]).finally(() => {
     if (timer !== undefined) clearTimeout(timer);
@@ -307,13 +315,14 @@ export function applyDiscoInfoToChannel(room: DiscoveredChannel, info: DiscoInfo
 
 async function hydrateRoomInfo(xmpp: HybridClient, room: DiscoveredChannel): Promise<DiscoveredChannel> {
   if (!room.jid) return room;
-  try {
-    const info = await sendDiscoInfo(xmpp, room.jid);
-    if (!info) return room;
-    return applyDiscoInfoToChannel(room, info);
-  } catch {
-    return room;
-  }
+  // No internal try/catch: callers wrap this in `Promise.allSettled` and
+  // map rejected entries to the unhydrated `channelFromRoom` record, so a
+  // local catch here would make the outer rejection branch unreachable
+  // dead code. Single resilience layer (one site to reason about), not
+  // two redundant ones.
+  const info = await sendDiscoInfo(xmpp, room.jid);
+  if (!info) return room;
+  return applyDiscoInfoToChannel(room, info);
 }
 
 export async function discoverChannels(xmpp: HybridClient, jid: string): Promise<DiscoveredChannel[]> {

--- a/chat/tests/discovery-pin-permission.test.ts
+++ b/chat/tests/discovery-pin-permission.test.ts
@@ -6,6 +6,12 @@ import {
   type DiscoInfoData,
 } from "../src/lib/xmpp/discovery";
 import type { DiscoveredChannel } from "../src/lib/xmpp/types";
+import {
+  discoInfoXml,
+  discoItemsXml,
+  pubsubItemsXml,
+  withFakeDomParser,
+} from "./helpers/disco-xml";
 
 describe("pinPermissionFromDiscoFields (#422)", () => {
   test("extracts 'anyone' when the disco field carries that value", () => {
@@ -209,114 +215,3 @@ function topologyClient(options: TopologyClientOptions = {}) {
   };
 }
 
-function discoItemsXml(items: Array<{ name?: string; node?: string; jid?: string }>): string {
-  return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#items">${items.map((item) =>
-    `<item${item.jid ? ` jid="${item.jid}"` : ""}${item.name ? ` name="${item.name}"` : ""}${item.node ? ` node="${item.node}"` : ""}/>`
-  ).join("")}</query></iq>`;
-}
-
-function discoInfoXml(info: { features?: string[]; identities?: Array<{ category: string; type: string; name?: string }> } = {}): string {
-  return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#info">${
-    (info.identities ?? []).map((identity) =>
-      `<identity category="${identity.category}" type="${identity.type}"${identity.name ? ` name="${identity.name}"` : ""}/>`
-    ).join("")
-  }${
-    (info.features ?? []).map((feature) => `<feature var="${feature}"/>`).join("")
-  }</query></iq>`;
-}
-
-function pubsubItemsXml(items: Array<{ id?: string; jid?: string; name?: string }>): string {
-  return `<iq type="result"><pubsub xmlns="http://jabber.org/protocol/pubsub"><items>${items.map((item) =>
-    `<item${item.id ? ` id="${item.id}"` : ""}>${item.jid || item.name ? `<conference${item.jid ? ` jid="${item.jid}"` : ""}${item.name ? ` name="${item.name}"` : ""}/>` : ""}</item>`
-  ).join("")}</items></pubsub></iq>`;
-}
-
-async function withFakeDomParser(run: () => Promise<void>): Promise<void> {
-  const original = globalThis.DOMParser;
-  globalThis.DOMParser = FakeDOMParser as typeof DOMParser;
-  try {
-    await run();
-  } finally {
-    globalThis.DOMParser = original;
-  }
-}
-
-class FakeDOMParser {
-  parseFromString(xml: string): Document {
-    return parseTestXml(xml) as unknown as Document;
-  }
-}
-
-class FakeXmlElement {
-  readonly children: FakeXmlElement[] = [];
-  text = "";
-  parentNode: FakeXmlElement | null = null;
-
-  constructor(
-    readonly localName: string,
-    readonly namespaceURI: string | null,
-    private readonly attrs: Record<string, string>,
-  ) {}
-
-  get textContent(): string {
-    return `${this.text}${this.children.map((child) => child.textContent ?? "").join("")}`;
-  }
-
-  getAttribute(name: string): string | null {
-    return this.attrs[name] ?? null;
-  }
-
-  querySelector(localName: string): FakeXmlElement | null {
-    return this.getElementsByTagName(localName)[0] ?? null;
-  }
-
-  getElementsByTagNameNS(namespace: string, localName: string): FakeXmlElement[] {
-    return this.descendants().filter((node) => node.namespaceURI === namespace && node.localName === localName);
-  }
-
-  getElementsByTagName(localName: string): FakeXmlElement[] {
-    return this.descendants().filter((node) => node.localName === localName);
-  }
-
-  private descendants(): FakeXmlElement[] {
-    return this.children.flatMap((child) => [child, ...child.descendants()]);
-  }
-}
-
-function parseTestXml(xml: string): FakeXmlElement {
-  const root = new FakeXmlElement("#document", null, {});
-  const stack: FakeXmlElement[] = [root];
-  const tokenPattern = /<[^>]+>|[^<]+/g;
-  for (const token of xml.match(tokenPattern) ?? []) {
-    if (token.startsWith("</")) {
-      stack.pop();
-      continue;
-    }
-    if (token.startsWith("<")) {
-      const selfClosing = token.endsWith("/>");
-      const body = token.slice(1, selfClosing ? -2 : -1).trim();
-      const [qualifiedName = ""] = body.split(/\s+/, 1);
-      const attrs = attributesFromTag(body);
-      const parent = stack[stack.length - 1];
-      const node = new FakeXmlElement(
-        qualifiedName.includes(":") ? qualifiedName.split(":").pop()! : qualifiedName,
-        attrs.xmlns ?? parent.namespaceURI,
-        attrs,
-      );
-      node.parentNode = parent;
-      parent.children.push(node);
-      if (!selfClosing) stack.push(node);
-      continue;
-    }
-    stack[stack.length - 1].text += token;
-  }
-  return root;
-}
-
-function attributesFromTag(tagBody: string): Record<string, string> {
-  const attrs: Record<string, string> = {};
-  for (const match of tagBody.matchAll(/([A-Za-z0-9:_-]+)="([^"]*)"/g)) {
-    attrs[match[1]] = match[2];
-  }
-  return attrs;
-}

--- a/chat/tests/discovery-resilience.test.ts
+++ b/chat/tests/discovery-resilience.test.ts
@@ -5,6 +5,12 @@ import {
   discoverTopology,
   withIqTimeout,
 } from "../src/lib/xmpp/discovery";
+import {
+  discoInfoXml,
+  discoItemsXml,
+  pubsubItemsXml,
+  withFakeDomParser,
+} from "./helpers/disco-xml";
 
 afterEach(() => {
   // Belt-and-braces: every test that mutates the disco timeout restores it
@@ -301,114 +307,3 @@ function resilientClient(options: ResilientClientOptions = {}) {
   };
 }
 
-function discoItemsXml(items: Array<{ name?: string; node?: string; jid?: string }>): string {
-  return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#items">${items.map((item) =>
-    `<item${item.jid ? ` jid="${item.jid}"` : ""}${item.name ? ` name="${item.name}"` : ""}${item.node ? ` node="${item.node}"` : ""}/>`
-  ).join("")}</query></iq>`;
-}
-
-function discoInfoXml(info: { features?: string[]; identities?: Array<{ category: string; type: string; name?: string }> } = {}): string {
-  return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#info">${
-    (info.identities ?? []).map((identity) =>
-      `<identity category="${identity.category}" type="${identity.type}"${identity.name ? ` name="${identity.name}"` : ""}/>`
-    ).join("")
-  }${
-    (info.features ?? []).map((feature) => `<feature var="${feature}"/>`).join("")
-  }</query></iq>`;
-}
-
-function pubsubItemsXml(items: Array<{ id?: string; jid?: string; name?: string }>): string {
-  return `<iq type="result"><pubsub xmlns="http://jabber.org/protocol/pubsub"><items>${items.map((item) =>
-    `<item${item.id ? ` id="${item.id}"` : ""}>${item.jid || item.name ? `<conference${item.jid ? ` jid="${item.jid}"` : ""}${item.name ? ` name="${item.name}"` : ""}/>` : ""}</item>`
-  ).join("")}</items></pubsub></iq>`;
-}
-
-async function withFakeDomParser(run: () => Promise<void>): Promise<void> {
-  const original = globalThis.DOMParser;
-  globalThis.DOMParser = FakeDOMParser as typeof DOMParser;
-  try {
-    await run();
-  } finally {
-    globalThis.DOMParser = original;
-  }
-}
-
-class FakeDOMParser {
-  parseFromString(xml: string): Document {
-    return parseTestXml(xml) as unknown as Document;
-  }
-}
-
-class FakeXmlElement {
-  readonly children: FakeXmlElement[] = [];
-  text = "";
-  parentNode: FakeXmlElement | null = null;
-
-  constructor(
-    readonly localName: string,
-    readonly namespaceURI: string | null,
-    private readonly attrs: Record<string, string>,
-  ) {}
-
-  get textContent(): string {
-    return `${this.text}${this.children.map((child) => child.textContent ?? "").join("")}`;
-  }
-
-  getAttribute(name: string): string | null {
-    return this.attrs[name] ?? null;
-  }
-
-  querySelector(localName: string): FakeXmlElement | null {
-    return this.getElementsByTagName(localName)[0] ?? null;
-  }
-
-  getElementsByTagNameNS(namespace: string, localName: string): FakeXmlElement[] {
-    return this.descendants().filter((node) => node.namespaceURI === namespace && node.localName === localName);
-  }
-
-  getElementsByTagName(localName: string): FakeXmlElement[] {
-    return this.descendants().filter((node) => node.localName === localName);
-  }
-
-  private descendants(): FakeXmlElement[] {
-    return this.children.flatMap((child) => [child, ...child.descendants()]);
-  }
-}
-
-function parseTestXml(xml: string): FakeXmlElement {
-  const root = new FakeXmlElement("#document", null, {});
-  const stack: FakeXmlElement[] = [root];
-  const tokenPattern = /<[^>]+>|[^<]+/g;
-  for (const token of xml.match(tokenPattern) ?? []) {
-    if (token.startsWith("</")) {
-      stack.pop();
-      continue;
-    }
-    if (token.startsWith("<")) {
-      const selfClosing = token.endsWith("/>");
-      const body = token.slice(1, selfClosing ? -2 : -1).trim();
-      const [qualifiedName = ""] = body.split(/\s+/, 1);
-      const attrs = attributesFromTag(body);
-      const parent = stack[stack.length - 1];
-      const node = new FakeXmlElement(
-        qualifiedName.includes(":") ? qualifiedName.split(":").pop()! : qualifiedName,
-        attrs.xmlns ?? parent.namespaceURI,
-        attrs,
-      );
-      node.parentNode = parent;
-      parent.children.push(node);
-      if (!selfClosing) stack.push(node);
-      continue;
-    }
-    stack[stack.length - 1].text += token;
-  }
-  return root;
-}
-
-function attributesFromTag(tagBody: string): Record<string, string> {
-  const attrs: Record<string, string> = {};
-  for (const match of tagBody.matchAll(/([A-Za-z0-9:_-]+)="([^"]*)"/g)) {
-    attrs[match[1]] = match[2];
-  }
-  return attrs;
-}

--- a/chat/tests/discovery-resilience.test.ts
+++ b/chat/tests/discovery-resilience.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DiscoTimeoutError,
+  discoverTopology,
+  withIqTimeout,
+} from "../src/lib/xmpp/discovery";
+
+/**
+ * Resilience contract for XEP-0030 topology discovery:
+ *
+ *  - RFC 6120 §8.2.3 requires IQ responses but cannot enforce it; every
+ *    in-flight disco IQ MUST observe a bounded timeout so a wedged
+ *    component cannot stall topology load forever.
+ *  - Multi-component fan-out (`discoverComponentServices`,
+ *    `discoverTopology` room hydration) MUST tolerate a single hung or
+ *    failing component via the conventional-domain / unhydrated-room
+ *    fallbacks. Implementation uses `Promise.allSettled`.
+ *
+ * These tests lock both contracts so we don't accidentally regress to
+ * a `Promise.all` storm or drop the IQ timeout in a refactor.
+ */
+
+describe("withIqTimeout (RFC 6120 §8.2.3 defense)", () => {
+  test("rejects with DiscoTimeoutError when the IQ does not resolve in time", async () => {
+    const hung = new Promise<string>(() => {
+      // intentionally never resolves
+    });
+    let caught: unknown = null;
+    try {
+      await withIqTimeout(hung, "calls.example.test", undefined, 30);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(DiscoTimeoutError);
+    expect((caught as DiscoTimeoutError).to).toBe("calls.example.test");
+  });
+
+  test("forwards the underlying resolution when the IQ answers before the timeout", async () => {
+    const result = await withIqTimeout(Promise.resolve("ok"), "example.test", undefined, 1000);
+    expect(result).toBe("ok");
+  });
+
+  test("clears the timer so a late rejection does not leak", async () => {
+    // If the timer were not cleared on success, this Promise.race would
+    // still hold a pending timeout — but since the test process exits
+    // when all jobs settle, leaking timers would surface as unhandled
+    // rejection warnings or hold the loop open. Bun fails fast on
+    // either, so an assertion-free "resolves cleanly" suffices.
+    await withIqTimeout(Promise.resolve(42), "example.test", "node-1", 5);
+    // Wait past the original timeout window to confirm no late rejection
+    // fires after the success path resolved.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  });
+});
+
+describe("discoverTopology partial-failure resilience", () => {
+  test("falls back to the conventional service when one component disco#info hangs", async () => {
+    await withFakeDomParser(async () => {
+      const topology = await discoverTopology(resilientClient({ hangComponent: "extensions.example.test" }), "alice@example.test");
+
+      // muc.example.test answered → that's the muc service we keep.
+      expect(topology.services.muc).toBe("muc.example.test");
+      // extensions.example.test hung → discoverComponentServices ignores it
+      // and the conventional spaces.<domain> remains the spaces service.
+      expect(topology.services.spaces).toBe("spaces.example.test");
+    });
+  });
+
+  test("returns spaces topology even when the MUC service is wedged", async () => {
+    await withFakeDomParser(async () => {
+      const topology = await discoverTopology(resilientClient({ hangMucItems: true }), "alice@example.test");
+
+      // Spaces discovery succeeded.
+      expect(topology.spaces.map((space) => space.id)).toContain("space-engineering");
+      // MUC items hung → rooms array stays empty rather than the whole
+      // topology call rejecting.
+      expect(topology.rooms).toEqual([]);
+    });
+  });
+
+  test("returns the room list with unhydrated entries when one room disco#info rejects", async () => {
+    await withFakeDomParser(async () => {
+      const topology = await discoverTopology(
+        resilientClient({ rejectRoomInfo: "broken@muc.example.test" }),
+        "alice@example.test",
+      );
+
+      // Both rooms survive — the failing one falls back to a bare
+      // channelFromRoom record without hydrated fields.
+      const ids = topology.rooms.map((room) => room.id).sort();
+      expect(ids).toEqual(["broken", "general"]);
+    });
+  });
+});
+
+type ResilientClientOptions = {
+  hangComponent?: string;
+  hangMucItems?: boolean;
+  rejectRoomInfo?: string;
+};
+
+function resilientClient(options: ResilientClientOptions = {}) {
+  return {
+    async send_raw_iq(xml: string): Promise<string> {
+      if (xml.includes('xmlns="http://jabber.org/protocol/disco#items"')) {
+        if (xml.includes('to="example.test"')) {
+          return discoItemsXml([
+            { jid: "muc.example.test", name: "Chatrooms" },
+            { jid: "spaces.example.test", name: "Spaces" },
+            { jid: "extensions.example.test", name: "Extensions" },
+          ]);
+        }
+        if (xml.includes('to="spaces.example.test"')) {
+          return discoItemsXml([
+            { name: "Engineering", node: "space-engineering" },
+          ]);
+        }
+        if (xml.includes('to="muc.example.test"')) {
+          if (options.hangMucItems) {
+            // Simulates the production stall as a synchronous rejection:
+            // testing the actual wedged-promise + 15s real timeout would
+            // hold the suite for the full timeout window. We bypass the
+            // timer path here and assert that the same try/catch in
+            // discoverTopology degrades the rooms list gracefully when
+            // sendDiscoItems rejects for ANY reason — timeout or stanza
+            // error — which is the contract callers depend on.
+            throw new Error("simulated muc service stall");
+          }
+          return discoItemsXml([
+            { jid: "general@muc.example.test", name: "General" },
+            { jid: "broken@muc.example.test", name: "Broken" },
+          ]);
+        }
+        return discoItemsXml([]);
+      }
+      if (xml.includes('xmlns="http://jabber.org/protocol/disco#info"')) {
+        if (options.hangComponent && xml.includes(`to="${options.hangComponent}"`)) {
+          // Hung component disco#info: tests use a short withIqTimeout
+          // budget via the wrapping helper. Even with the production
+          // 15s default, allSettled in discoverComponentServices means
+          // a single hang cannot wedge the others — so this test does
+          // not need to short-circuit the timer.
+          throw new Error("simulated component disco#info timeout");
+        }
+        if (options.rejectRoomInfo && xml.includes(`to="${options.rejectRoomInfo}"`)) {
+          throw new Error("simulated room disco#info failure");
+        }
+        if (xml.includes('to="muc.example.test"')) {
+          return discoInfoXml({
+            identities: [{ category: "conference", type: "text", name: "Chatrooms" }],
+            features: ["http://jabber.org/protocol/muc"],
+          });
+        }
+        if (xml.includes('to="spaces.example.test"') && !xml.includes(' node=')) {
+          return discoInfoXml({
+            identities: [{ category: "pubsub", type: "service", name: "Spaces" }],
+            features: [
+              "http://jabber.org/protocol/pubsub",
+              "urn:xmpp:spaces:0",
+            ],
+          });
+        }
+        if (xml.includes('to="general@muc.example.test"') || xml.includes('to="broken@muc.example.test"')) {
+          return discoInfoXml({
+            identities: [{ category: "conference", type: "text", name: "Room" }],
+            features: ["http://jabber.org/protocol/muc"],
+          });
+        }
+        if (xml.includes('to="example.test"')) {
+          return discoInfoXml({
+            identities: [{ category: "server", type: "im", name: "Waddle" }],
+            features: [],
+          });
+        }
+        return discoInfoXml();
+      }
+      if (xml.includes('xmlns="http://jabber.org/protocol/pubsub"')) {
+        return pubsubItemsXml([]);
+      }
+      throw new Error(`Unexpected IQ: ${xml}`);
+    },
+  };
+}
+
+function discoItemsXml(items: Array<{ name?: string; node?: string; jid?: string }>): string {
+  return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#items">${items.map((item) =>
+    `<item${item.jid ? ` jid="${item.jid}"` : ""}${item.name ? ` name="${item.name}"` : ""}${item.node ? ` node="${item.node}"` : ""}/>`
+  ).join("")}</query></iq>`;
+}
+
+function discoInfoXml(info: { features?: string[]; identities?: Array<{ category: string; type: string; name?: string }> } = {}): string {
+  return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#info">${
+    (info.identities ?? []).map((identity) =>
+      `<identity category="${identity.category}" type="${identity.type}"${identity.name ? ` name="${identity.name}"` : ""}/>`
+    ).join("")
+  }${
+    (info.features ?? []).map((feature) => `<feature var="${feature}"/>`).join("")
+  }</query></iq>`;
+}
+
+function pubsubItemsXml(items: Array<{ id?: string; jid?: string; name?: string }>): string {
+  return `<iq type="result"><pubsub xmlns="http://jabber.org/protocol/pubsub"><items>${items.map((item) =>
+    `<item${item.id ? ` id="${item.id}"` : ""}>${item.jid || item.name ? `<conference${item.jid ? ` jid="${item.jid}"` : ""}${item.name ? ` name="${item.name}"` : ""}/>` : ""}</item>`
+  ).join("")}</items></pubsub></iq>`;
+}
+
+async function withFakeDomParser(run: () => Promise<void>): Promise<void> {
+  const original = globalThis.DOMParser;
+  globalThis.DOMParser = FakeDOMParser as typeof DOMParser;
+  try {
+    await run();
+  } finally {
+    globalThis.DOMParser = original;
+  }
+}
+
+class FakeDOMParser {
+  parseFromString(xml: string): Document {
+    return parseTestXml(xml) as unknown as Document;
+  }
+}
+
+class FakeXmlElement {
+  readonly children: FakeXmlElement[] = [];
+  text = "";
+  parentNode: FakeXmlElement | null = null;
+
+  constructor(
+    readonly localName: string,
+    readonly namespaceURI: string | null,
+    private readonly attrs: Record<string, string>,
+  ) {}
+
+  get textContent(): string {
+    return `${this.text}${this.children.map((child) => child.textContent ?? "").join("")}`;
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attrs[name] ?? null;
+  }
+
+  querySelector(localName: string): FakeXmlElement | null {
+    return this.getElementsByTagName(localName)[0] ?? null;
+  }
+
+  getElementsByTagNameNS(namespace: string, localName: string): FakeXmlElement[] {
+    return this.descendants().filter((node) => node.namespaceURI === namespace && node.localName === localName);
+  }
+
+  getElementsByTagName(localName: string): FakeXmlElement[] {
+    return this.descendants().filter((node) => node.localName === localName);
+  }
+
+  private descendants(): FakeXmlElement[] {
+    return this.children.flatMap((child) => [child, ...child.descendants()]);
+  }
+}
+
+function parseTestXml(xml: string): FakeXmlElement {
+  const root = new FakeXmlElement("#document", null, {});
+  const stack: FakeXmlElement[] = [root];
+  const tokenPattern = /<[^>]+>|[^<]+/g;
+  for (const token of xml.match(tokenPattern) ?? []) {
+    if (token.startsWith("</")) {
+      stack.pop();
+      continue;
+    }
+    if (token.startsWith("<")) {
+      const selfClosing = token.endsWith("/>");
+      const body = token.slice(1, selfClosing ? -2 : -1).trim();
+      const [qualifiedName = ""] = body.split(/\s+/, 1);
+      const attrs = attributesFromTag(body);
+      const parent = stack[stack.length - 1];
+      const node = new FakeXmlElement(
+        qualifiedName.includes(":") ? qualifiedName.split(":").pop()! : qualifiedName,
+        attrs.xmlns ?? parent.namespaceURI,
+        attrs,
+      );
+      node.parentNode = parent;
+      parent.children.push(node);
+      if (!selfClosing) stack.push(node);
+      continue;
+    }
+    stack[stack.length - 1].text += token;
+  }
+  return root;
+}
+
+function attributesFromTag(tagBody: string): Record<string, string> {
+  const attrs: Record<string, string> = {};
+  for (const match of tagBody.matchAll(/([A-Za-z0-9:_-]+)="([^"]*)"/g)) {
+    attrs[match[1]] = match[2];
+  }
+  return attrs;
+}

--- a/chat/tests/discovery-resilience.test.ts
+++ b/chat/tests/discovery-resilience.test.ts
@@ -1,9 +1,17 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import {
+  __setDiscoIqTimeoutForTest,
   DiscoTimeoutError,
   discoverTopology,
   withIqTimeout,
 } from "../src/lib/xmpp/discovery";
+
+afterEach(() => {
+  // Belt-and-braces: every test that mutates the disco timeout restores it
+  // in its own finally, but if a future test forgets we want the next file
+  // to start from production defaults.
+  __setDiscoIqTimeoutForTest(null);
+});
 
 /**
  * Resilience contract for XEP-0030 topology discovery:
@@ -66,6 +74,45 @@ describe("discoverTopology partial-failure resilience", () => {
     });
   });
 
+  test("integration: real withIqTimeout fires end-to-end when a component disco#info never resolves", async () => {
+    // Verifies the wiring: sendDiscoInfo MUST call withIqTimeout against
+    // the underlying raw IQ promise. If a future refactor drops the
+    // wrapper, this test fails because the never-resolving fixture below
+    // would hang the test runner instead of timing out.
+    __setDiscoIqTimeoutForTest(30);
+    try {
+      await withFakeDomParser(async () => {
+        const topology = await discoverTopology(neverResolvesForComponent("extensions.example.test"), "alice@example.test");
+
+        // muc.example.test still answered → service identity preserved.
+        expect(topology.services.muc).toBe("muc.example.test");
+        // extensions.example.test never resolved → timeout fired and the
+        // conventional spaces.<domain> fallback kicked in.
+        expect(topology.services.spaces).toBe("spaces.example.test");
+      });
+    } finally {
+      __setDiscoIqTimeoutForTest(null);
+    }
+  });
+
+  test("allSettled in discoverComponentServices honors a SURVIVING explicit-identity component when another rejects", async () => {
+    // Distinct-from-fallback coverage: if we regressed to `Promise.all` +
+    // outer `catch { return fallback }`, this assertion would FAIL because
+    // the muc identity would come from the conventional `muc.<domain>`
+    // fallback, NOT from the surviving custom-named component below.
+    await withFakeDomParser(async () => {
+      const topology = await discoverTopology(
+        customMucWithBrokenSibling(),
+        "alice@example.test",
+      );
+
+      // Custom muc JID survived even though the other component threw —
+      // proves allSettled kept the per-entry result instead of collapsing
+      // to the outer catch's fallback.
+      expect(topology.services.muc).toBe("custom-muc.example.test");
+    });
+  });
+
   test("returns spaces topology even when the MUC service is wedged", async () => {
     await withFakeDomParser(async () => {
       const topology = await discoverTopology(resilientClient({ hangMucItems: true }), "alice@example.test");
@@ -98,6 +145,78 @@ type ResilientClientOptions = {
   hangMucItems?: boolean;
   rejectRoomInfo?: string;
 };
+
+function neverResolvesForComponent(jid: string) {
+  return {
+    async send_raw_iq(xml: string): Promise<string> {
+      if (xml.includes('xmlns="http://jabber.org/protocol/disco#items"')) {
+        if (xml.includes('to="example.test"')) {
+          return discoItemsXml([
+            { jid: "muc.example.test", name: "Chatrooms" },
+            { jid: jid, name: "Hung" },
+          ]);
+        }
+        if (xml.includes('to="muc.example.test"')) {
+          return discoItemsXml([]);
+        }
+        return discoItemsXml([]);
+      }
+      if (xml.includes('xmlns="http://jabber.org/protocol/disco#info"')) {
+        if (xml.includes(`to="${jid}"`)) {
+          // Production stall reproduction: never resolves. The wrapping
+          // withIqTimeout in sendDiscoInfo MUST reject this with
+          // DiscoTimeoutError before the test's wall-clock budget; if the
+          // wrapper is missing, bun test will hang past the per-test
+          // timeout instead.
+          return new Promise<string>(() => {});
+        }
+        if (xml.includes('to="muc.example.test"')) {
+          return discoInfoXml({
+            identities: [{ category: "conference", type: "text", name: "Chatrooms" }],
+            features: ["http://jabber.org/protocol/muc"],
+          });
+        }
+        return discoInfoXml();
+      }
+      return discoItemsXml([]);
+    },
+  };
+}
+
+function customMucWithBrokenSibling() {
+  // Two components advertised: one custom-named MUC service and one that
+  // rejects disco#info synchronously. allSettled MUST surface the custom
+  // muc identity even though the sibling threw.
+  return {
+    async send_raw_iq(xml: string): Promise<string> {
+      if (xml.includes('xmlns="http://jabber.org/protocol/disco#items"')) {
+        if (xml.includes('to="example.test"')) {
+          return discoItemsXml([
+            { jid: "custom-muc.example.test", name: "ChatPalace" },
+            { jid: "broken.example.test", name: "Broken" },
+          ]);
+        }
+        if (xml.includes('to="custom-muc.example.test"')) {
+          return discoItemsXml([]);
+        }
+        return discoItemsXml([]);
+      }
+      if (xml.includes('xmlns="http://jabber.org/protocol/disco#info"')) {
+        if (xml.includes('to="broken.example.test"')) {
+          throw new Error("simulated sibling disco#info failure");
+        }
+        if (xml.includes('to="custom-muc.example.test"')) {
+          return discoInfoXml({
+            identities: [{ category: "conference", type: "text", name: "ChatPalace" }],
+            features: ["http://jabber.org/protocol/muc"],
+          });
+        }
+        return discoInfoXml();
+      }
+      return discoItemsXml([]);
+    },
+  };
+}
 
 function resilientClient(options: ResilientClientOptions = {}) {
   return {

--- a/chat/tests/helpers/disco-xml.ts
+++ b/chat/tests/helpers/disco-xml.ts
@@ -1,0 +1,123 @@
+/**
+ * Shared XEP-0030 disco fixture + fake-DOM helpers.
+ *
+ * Both `discovery-pin-permission.test.ts` and `discovery-resilience.test.ts`
+ * exercise `chat/src/lib/xmpp/discovery.ts`, which parses disco IQ
+ * responses via the browser `DOMParser`. bun:test runs without a DOM, so
+ * each suite needs a minimal XML parser substitute. Centralised here so
+ * the two suites can't drift on what shape of XML they emit / parse.
+ */
+
+type DiscoIdentity = { category: string; type: string; name?: string };
+
+export function discoItemsXml(items: Array<{ name?: string; node?: string; jid?: string }>): string {
+  return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#items">${items.map((item) =>
+    `<item${item.jid ? ` jid="${item.jid}"` : ""}${item.name ? ` name="${item.name}"` : ""}${item.node ? ` node="${item.node}"` : ""}/>`
+  ).join("")}</query></iq>`;
+}
+
+export function discoInfoXml(info: { features?: string[]; identities?: DiscoIdentity[] } = {}): string {
+  return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#info">${
+    (info.identities ?? []).map((identity) =>
+      `<identity category="${identity.category}" type="${identity.type}"${identity.name ? ` name="${identity.name}"` : ""}/>`
+    ).join("")
+  }${
+    (info.features ?? []).map((feature) => `<feature var="${feature}"/>`).join("")
+  }</query></iq>`;
+}
+
+export function pubsubItemsXml(items: Array<{ id?: string; jid?: string; name?: string }>): string {
+  return `<iq type="result"><pubsub xmlns="http://jabber.org/protocol/pubsub"><items>${items.map((item) =>
+    `<item${item.id ? ` id="${item.id}"` : ""}>${item.jid || item.name ? `<conference${item.jid ? ` jid="${item.jid}"` : ""}${item.name ? ` name="${item.name}"` : ""}/>` : ""}</item>`
+  ).join("")}</items></pubsub></iq>`;
+}
+
+export async function withFakeDomParser(run: () => Promise<void>): Promise<void> {
+  const original = globalThis.DOMParser;
+  globalThis.DOMParser = FakeDOMParser as typeof DOMParser;
+  try {
+    await run();
+  } finally {
+    globalThis.DOMParser = original;
+  }
+}
+
+class FakeDOMParser {
+  parseFromString(xml: string): Document {
+    return parseTestXml(xml) as unknown as Document;
+  }
+}
+
+class FakeXmlElement {
+  readonly children: FakeXmlElement[] = [];
+  text = "";
+  parentNode: FakeXmlElement | null = null;
+
+  constructor(
+    readonly localName: string,
+    readonly namespaceURI: string | null,
+    private readonly attrs: Record<string, string>,
+  ) {}
+
+  get textContent(): string {
+    return `${this.text}${this.children.map((child) => child.textContent ?? "").join("")}`;
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attrs[name] ?? null;
+  }
+
+  querySelector(localName: string): FakeXmlElement | null {
+    return this.getElementsByTagName(localName)[0] ?? null;
+  }
+
+  getElementsByTagNameNS(namespace: string, localName: string): FakeXmlElement[] {
+    return this.descendants().filter((node) => node.namespaceURI === namespace && node.localName === localName);
+  }
+
+  getElementsByTagName(localName: string): FakeXmlElement[] {
+    return this.descendants().filter((node) => node.localName === localName);
+  }
+
+  private descendants(): FakeXmlElement[] {
+    return this.children.flatMap((child) => [child, ...child.descendants()]);
+  }
+}
+
+function parseTestXml(xml: string): FakeXmlElement {
+  const root = new FakeXmlElement("#document", null, {});
+  const stack: FakeXmlElement[] = [root];
+  const tokenPattern = /<[^>]+>|[^<]+/g;
+  for (const token of xml.match(tokenPattern) ?? []) {
+    if (token.startsWith("</")) {
+      stack.pop();
+      continue;
+    }
+    if (token.startsWith("<")) {
+      const selfClosing = token.endsWith("/>");
+      const body = token.slice(1, selfClosing ? -2 : -1).trim();
+      const [qualifiedName = ""] = body.split(/\s+/, 1);
+      const attrs = attributesFromTag(body);
+      const parent = stack[stack.length - 1];
+      const node = new FakeXmlElement(
+        qualifiedName.includes(":") ? qualifiedName.split(":").pop()! : qualifiedName,
+        attrs.xmlns ?? parent.namespaceURI,
+        attrs,
+      );
+      node.parentNode = parent;
+      parent.children.push(node);
+      if (!selfClosing) stack.push(node);
+      continue;
+    }
+    stack[stack.length - 1].text += token;
+  }
+  return root;
+}
+
+function attributesFromTag(tagBody: string): Record<string, string> {
+  const attrs: Record<string, string> = {};
+  for (const match of tagBody.matchAll(/([A-Za-z0-9:_-]+)="([^"]*)"/g)) {
+    attrs[match[1]] = match[2];
+  }
+  return attrs;
+}


### PR DESCRIPTION
## Summary

`waddle.chat` channel sidebar spins forever when any of the 7 disco#info IQs the client fans out to component services (`muc/upload/spaces/community/extensions/push/calls.<domain>`) goes unanswered. HAR capture confirms the server is silently dropping these — separate server bug, tracked outside this PR. This PR makes the client resilient.

- **Bounded `withIqTimeout` (15s)** on every disco IQ helper — `sendDiscoInfo`, `sendDiscoItems`, `sendPubsubItems`. RFC 6120 §8.2.3 mandates IQ responses but cannot enforce it; XEP-0030 §6.3 and every modern XMPP client (Conversations, Gajim, Dino) defends with a per-IQ timeout. A wedged component can no longer stall topology load past one user heartbeat.
- **`Promise.all` → `Promise.allSettled`** in `discoverComponentServices` (the 7-way fan-out) and the MUC-room hydration inside `discoverTopology` / `discoverChannels`. One failing/timed-out component now degrades via the existing conventional-domain or unhydrated-room fallbacks instead of wedging the whole call.
- **Narrow try/catch** around the muc-rooms `sendDiscoItems` only — the previous broad catch could have swallowed programmer errors (malformed JID, future refactor in `channelFromRoom`) silently. Hydration's own `allSettled` keeps the per-room resilience.
- **Structured logging** via `logDiscoFailure` — `DiscoTimeoutError` now surfaces at warn level with `{to, node}` so a wedged component is immediately visible in the console. Non-timeout errors stay at error level (preserves the existing log on `sendDiscoItems`).
- **Caps-cache guardrail comment** in `discoverComponentServices`: documents that `info: null` represents IQ failure and MUST NOT be persisted as XEP-0115 caps — a forward-looking trip-wire for when caps caching lands.

## Tests

`chat/tests/discovery-resilience.test.ts` (new file, 8 cases):

- `withIqTimeout` unit coverage: timeout reject, raw resolve, no timer leak on success path.
- Topology partial-failure coverage: conventional-service fallback when a component disco#info hangs, spaces survival when MUC service is wedged, room list with unhydrated entry when one room disco#info rejects.
- **Integration test that actually exercises the timeout wire**: a real never-resolving Promise + `__setDiscoIqTimeoutForTest(30)` budget. Locks the wiring — if a future refactor drops `withIqTimeout` from the disco helpers, this test hangs past its budget instead of silently passing.
- **Distinct-from-fallback test for `discoverComponentServices`**: surviving custom-named MUC component MUST be honoured when its sibling rejects. A regression to `Promise.all` + outer-catch fallback would fail this assertion.

`bun test` — 1117 pass / 1 pre-existing fail (unrelated startup-shell test).
`bun run lint` (knip + wasm:build) — clean.

## Adversarial review addressed

Two adversarial reviewer agents flagged:

1. **Wasm `pending_iqs` leak on timeout** — rejected JS Promise abandons the Rust-side `oneshot::Sender` in `pending_iqs` until response or disconnect. Bounded per-stream (~100 B × ~7 IQs per topology rebuild) and reclaimed by `pending_iqs.drain()` on disconnect. Proper fix is a `cancel_iq` driver command — net-new public API across the wasm bridge, deferred to a follow-up. Rationale documented in the `withIqTimeout` JSDoc.
2. **Test gap: real timeout path uncovered** — fixed. New integration test exercises real `withIqTimeout` with a never-resolving fixture.
3. **Test gap: `allSettled` indistinguishable from outer fallback** — fixed. New distinct-from-fallback test asserts a surviving custom muc identity.
4. **Overbroad try/catch swallowing programmer errors** — fixed. Catch now wraps only `sendDiscoItems`; everything else propagates.
5. **`DiscoTimeoutError` exported with no consumer** — fixed. Now consumed by `logDiscoFailure` for structured warn-level diagnostics.

## Out of scope (separate follow-ups)

- **Server fix** for the missing disco#info responses on component domains. Most likely suspect is `room_actor.ask(GetSnapshot).await` in `disco_info/muc.rs:24`, which runs first in the chain for every component target before falling through. Needs server-side tracing.
- **`cancel_iq` driver command** to clean up `pending_iqs` on JS-side timeout (see #1 above).
- **XEP-0402 bookmarks-first channel sidebar.** Today the sidebar enumerates "every MUC on the service" via disco#items. The XMPP-native primitive for "rooms I'm in" is PEP bookmarks at `urn:xmpp:bookmarks:1` (already supported server-side via `xep0402.rs` / `xep0503.rs`). Switching the sidebar source renders the channel list instantly from a single IQ to the user's own JID; topology disco becomes background capability detection.
- **XEP-0115 Entity Capabilities caching** on the client (server already computes caps hashes). With caps caching, the 7 disco#info IQs become 0 on warm starts.
- **Bootstrap dedupe** on session-lifecycle re-fire: every SM-resume-failed reconnect re-runs the entire hydration sequence, causing 4× carbons-enable / 6× inbox / 6× community-pubsub fanout per reconnect (visible in the third HAR session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)