### PR TITLE
feat(server): web push foundations — VAPID + RFC 8291 modules (PR-D1 of #762)

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -27,6 +27,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.6",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -843,6 +878,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.6",
+ "inout",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1331,6 +1376,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1341,6 +1387,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1666,6 +1721,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "hkdf 0.12.4",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
@@ -2103,6 +2159,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gif"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2300,6 +2366,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
  "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -2668,6 +2743,15 @@ dependencies = [
  "hashbrown 0.17.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -3409,6 +3493,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl"
 version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3819,6 +3909,18 @@ dependencies = [
  "pin-project-lite",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -5234,7 +5336,7 @@ dependencies = [
  "futures-util",
  "generic-array",
  "hex",
- "hkdf",
+ "hkdf 0.12.4",
  "hmac 0.12.1",
  "itoa",
  "log",
@@ -5274,7 +5376,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "hkdf",
+ "hkdf 0.12.4",
  "hmac 0.12.1",
  "home",
  "itoa",
@@ -6228,6 +6330,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.6",
+ "subtle",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6347,6 +6459,7 @@ dependencies = [
 name = "waddle-server"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
  "anyhow",
  "argon2",
  "async-trait",
@@ -6363,6 +6476,7 @@ dependencies = [
  "elliptic-curve",
  "futures",
  "hex",
+ "hkdf 0.13.0",
  "hmac 0.13.0",
  "html-escape",
  "http-body-util",
@@ -6414,6 +6528,7 @@ dependencies = [
  "waddle-xmpp-core",
  "wiremock",
  "xmpp-parsers",
+ "zeroize",
 ]
 
 [[package]]
@@ -6440,20 +6555,25 @@ dependencies = [
 name = "waddle-xmpp"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
  "anyhow",
  "async-trait",
  "base64",
  "chrono",
  "chrono-tz",
  "dashmap",
+ "elliptic-curve",
  "futures",
+ "hkdf 0.13.0",
  "hmac 0.13.0",
  "html-escape",
  "jid",
+ "jsonwebtoken",
  "kameo",
  "lru 0.18.0",
  "minidom",
  "opentelemetry",
+ "p256",
  "pbkdf2",
  "rand 0.10.1",
  "reqwest 0.13.3",
@@ -6477,6 +6597,7 @@ dependencies = [
  "waddle-sfu",
  "waddle-xmpp-core",
  "xmpp-parsers",
+ "zeroize",
 ]
 
 [[package]]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -92,7 +92,7 @@ rustls-acme = { version = "0.15.2", default-features = false, features = ["ring"
 hmac = "0.13"
 sha1 = "0.11"
 sha2 = "0.11"
-p256 = { version = "0.13", features = ["ecdsa", "jwk"] }
+p256 = { version = "0.13", features = ["ecdsa", "ecdh", "jwk", "pem", "pkcs8"] }
 elliptic-curve = { version = "0.13", features = ["jwk"] }
 argon2 = "0.5"
 zeroize = { version = "1", features = ["derive"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -96,6 +96,8 @@ p256 = { version = "0.13", features = ["ecdsa", "jwk"] }
 elliptic-curve = { version = "0.13", features = ["jwk"] }
 argon2 = "0.5"
 zeroize = { version = "1", features = ["derive"] }
+aes-gcm = "0.11"
+hkdf = "0.13"
 
 # Utilities
 uuid = { version = "1.23", features = ["v4", "v7", "serde", "js"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -96,7 +96,7 @@ p256 = { version = "0.13", features = ["ecdsa", "jwk"] }
 elliptic-curve = { version = "0.13", features = ["jwk"] }
 argon2 = "0.5"
 zeroize = { version = "1", features = ["derive"] }
-aes-gcm = "0.11"
+aes-gcm = "0.10"
 hkdf = "0.13"
 
 # Utilities

--- a/server/crates/waddle-server/Cargo.toml
+++ b/server/crates/waddle-server/Cargo.toml
@@ -79,6 +79,9 @@ sha2 = { workspace = true }
 p256 = { workspace = true }
 elliptic-curve = { workspace = true }
 argon2 = { workspace = true }
+aes-gcm = { workspace = true }
+hkdf = { workspace = true }
+zeroize = { workspace = true }
 
 # Utilities
 uuid = { workspace = true }

--- a/server/crates/waddle-server/src/push_service.rs
+++ b/server/crates/waddle-server/src/push_service.rs
@@ -5,6 +5,8 @@
 //! [`crate::push_registrations`]. Provider endpoints and tokens live here,
 //! behind the `push.<domain>` service boundary.
 
+pub mod vapid_storage;
+
 use std::{fmt, sync::Arc};
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};

--- a/server/crates/waddle-server/src/push_service/vapid_storage.rs
+++ b/server/crates/waddle-server/src/push_service/vapid_storage.rs
@@ -1,0 +1,452 @@
+//! Sealed VAPID keypair storage for the first-party XMPP Push Service.
+//!
+//! Stores ECDSA P-256 private keys for RFC 8292 VAPID JWT signing, sealed
+//! at rest with AES-256-GCM and a length-prefixed AAD that binds the
+//! sealed blob to its `label` + `kid` so a DB-write attacker swapping
+//! blobs across rows or labels fails the GCM tag check.
+//!
+//! Implements the [`VapidSigner`] trait declared in `waddle-xmpp`,
+//! delegating the actual JWT signing to [`InProcessVapidSigner`]. This
+//! crate owns the durable lifecycle (env-var bootstrap, fresh
+//! generation, DB persistence); the lower crate owns pure crypto.
+
+use std::env;
+use std::sync::Arc;
+
+use aes_gcm::aead::{Aead, KeyInit, Payload};
+use aes_gcm::Aes256Gcm;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use hmac::{Hmac, KeyInit as HmacKeyInit, Mac};
+use p256::elliptic_curve::rand_core::OsRng;
+use p256::elliptic_curve::sec1::ToEncodedPoint;
+use rand::RngExt;
+use sha2::Sha256;
+use uuid::Uuid;
+use waddle_xmpp::push::types::{Kid, VapidJwt, VapidLoadError, VapidSignError, VapidSub};
+use waddle_xmpp::push::vapid::{InProcessVapidSigner, VapidSigner};
+use waddle_xmpp::XmppError;
+
+use crate::db::{Database, IntoParams};
+
+const VAPID_ENV_VAR: &str = "WADDLE_VAPID_PRIVATE_KEY";
+const AAD_LABEL: &[u8] = b"waddle:push-service:vapid-key:v1";
+const SEALED_PREFIX: &str = "waddle-vapid-v1";
+/// Current root-key version. Multi-version rotation lands in a follow-up;
+/// for v1, all rows are sealed at version 1 and read at version 1.
+const CURRENT_ROOT_KEY_VERSION: u32 = 1;
+
+/// Durable VAPID keypair storage for the Push Service component.
+///
+/// Construct via [`Self::load_or_provision`], which executes the boot
+/// lifecycle:
+///   1. If `WADDLE_VAPID_PRIVATE_KEY` env var is set: parse, **DB write
+///      FIRST**, on `Ok` call `std::env::remove_var(...)`; on `Err`,
+///      leave env set and fail boot loudly.
+///   2. Else read the latest non-retired row.
+///   3. Else generate a fresh P-256 keypair and persist.
+pub struct VapidStorage {
+    db: Database,
+    cipher: VapidKeyCipher,
+}
+
+impl VapidStorage {
+    pub async fn load_or_provision(
+        db: Database,
+        root_key: &[u8],
+    ) -> Result<Arc<InProcessVapidSigner>, VapidLoadError> {
+        let storage = Self::new(db.clone(), root_key)
+            .await
+            .map_err(|e| VapidLoadError::DbWrite(e.to_string()))?;
+
+        // 1. Env-var bootstrap path.
+        if let Ok(raw) = env::var(VAPID_ENV_VAR) {
+            let secret_key = parse_env_scalar(&raw)?;
+            let kid = Kid::new();
+            storage.persist_keypair(&kid, &secret_key).await?;
+            // SAFETY: remove_var is unsafe in newer Rust. We call this once
+            // at boot before spawning any threads that might read env.
+            // SAFETY justified: this is the boot path, single-threaded.
+            #[allow(unsafe_code)]
+            unsafe {
+                env::remove_var(VAPID_ENV_VAR);
+            }
+            return Ok(Arc::new(
+                InProcessVapidSigner::new(kid, secret_key)
+                    .map_err(|e| VapidLoadError::DbWrite(e.to_string()))?,
+            ));
+        }
+
+        // 2. Read latest non-retired row.
+        if let Some((kid, secret_key)) = storage.load_latest().await? {
+            return Ok(Arc::new(
+                InProcessVapidSigner::new(kid, secret_key)
+                    .map_err(|e| VapidLoadError::DbWrite(e.to_string()))?,
+            ));
+        }
+
+        // 3. Generate fresh.
+        let kid = Kid::new();
+        let secret_key = p256::SecretKey::random(&mut OsRng);
+        storage.persist_keypair(&kid, &secret_key).await?;
+        Ok(Arc::new(
+            InProcessVapidSigner::new(kid, secret_key)
+                .map_err(|e| VapidLoadError::DbWrite(e.to_string()))?,
+        ))
+    }
+
+    async fn new(db: Database, root_key: &[u8]) -> Result<Self, XmppError> {
+        let storage = Self {
+            db,
+            cipher: VapidKeyCipher::new(root_key),
+        };
+        storage.initialize().await?;
+        Ok(storage)
+    }
+
+    async fn initialize(&self) -> Result<(), XmppError> {
+        let i64_type = crate::db::i64_sql_type(self.db.driver());
+        let sql = format!(
+            r#"
+            CREATE TABLE IF NOT EXISTS push_service_vapid_keys (
+                id INTEGER PRIMARY KEY,
+                kid TEXT NOT NULL UNIQUE,
+                sealed_private_key TEXT NOT NULL,
+                public_key BLOB NOT NULL,
+                root_key_version {i64_type} NOT NULL,
+                created_at_ms {i64_type} NOT NULL,
+                retired_at_ms {i64_type}
+            )
+            "#
+        );
+        self.run_execute(&sql, ()).await?;
+        self.run_execute(
+            "CREATE INDEX IF NOT EXISTS idx_push_service_vapid_keys_active \
+             ON push_service_vapid_keys (retired_at_ms, created_at_ms)",
+            (),
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn run_execute(&self, sql: &str, params: impl IntoParams) -> Result<u64, XmppError> {
+        let conn = self
+            .db
+            .guard()
+            .await
+            .map_err(|e| XmppError::internal(e.to_string()))?;
+        conn.execute(sql, params)
+            .await
+            .map_err(|e| XmppError::internal(e.to_string()))
+    }
+
+    async fn run_query(
+        &self,
+        sql: &str,
+        params: impl IntoParams,
+    ) -> Result<crate::db::Rows, XmppError> {
+        let conn = self
+            .db
+            .guard()
+            .await
+            .map_err(|e| XmppError::internal(e.to_string()))?;
+        conn.query(sql, params)
+            .await
+            .map_err(|e| XmppError::internal(e.to_string()))
+    }
+
+    async fn persist_keypair(
+        &self,
+        kid: &Kid,
+        secret_key: &p256::SecretKey,
+    ) -> Result<(), VapidLoadError> {
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let scalar = secret_key.to_bytes();
+        let sealed = self
+            .cipher
+            .seal(&scalar[..], AAD_LABEL, kid.as_bytes())
+            .map_err(|e| VapidLoadError::DbWrite(format!("seal: {e}")))?;
+        let public_bytes = secret_key
+            .public_key()
+            .to_encoded_point(false)
+            .as_bytes()
+            .to_vec();
+
+        let sql = "INSERT INTO push_service_vapid_keys \
+            (kid, sealed_private_key, public_key, root_key_version, created_at_ms) \
+            VALUES (?, ?, ?, ?, ?)";
+        self.run_execute(
+            sql,
+            crate::db_params![
+                kid.to_string(),
+                sealed,
+                public_bytes,
+                CURRENT_ROOT_KEY_VERSION as i64,
+                now_ms,
+            ],
+        )
+        .await
+        .map_err(|e| VapidLoadError::DbWrite(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn load_latest(&self) -> Result<Option<(Kid, p256::SecretKey)>, VapidLoadError> {
+        let sql = "SELECT kid, sealed_private_key, root_key_version \
+            FROM push_service_vapid_keys \
+            WHERE retired_at_ms IS NULL \
+            ORDER BY created_at_ms DESC LIMIT 1";
+        let mut rows = self
+            .run_query(sql, ())
+            .await
+            .map_err(|e| VapidLoadError::DbRead(e.to_string()))?;
+        let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| VapidLoadError::DbRead(e.to_string()))?
+        else {
+            return Ok(None);
+        };
+        let kid_str: String = row
+            .get(0)
+            .map_err(|e| VapidLoadError::DbRead(format!("kid: {e}")))?;
+        let sealed: String = row
+            .get(1)
+            .map_err(|e| VapidLoadError::DbRead(format!("sealed_private_key: {e}")))?;
+        let version: i64 = row
+            .get(2)
+            .map_err(|e| VapidLoadError::DbRead(format!("root_key_version: {e}")))?;
+        if version as u32 != CURRENT_ROOT_KEY_VERSION {
+            return Err(VapidLoadError::UnknownRootKeyVersion {
+                found: version as u32,
+                max_installed: CURRENT_ROOT_KEY_VERSION,
+            });
+        }
+        let kid_uuid: Uuid = kid_str
+            .parse()
+            .map_err(|e: uuid::Error| VapidLoadError::DbRead(format!("kid not a UUID: {e}")))?;
+        let kid = Kid(kid_uuid);
+        let scalar = self
+            .cipher
+            .open(&sealed, AAD_LABEL, kid.as_bytes())
+            .map_err(|e| VapidLoadError::Unseal(e.to_string()))?;
+        let secret_key = p256::SecretKey::from_slice(&scalar)
+            .map_err(|e| VapidLoadError::DbRead(format!("bad P-256 scalar: {e}")))?;
+        Ok(Some((kid, secret_key)))
+    }
+}
+
+/// AES-256-GCM sealing for VAPID private keys.
+///
+/// AAD is **length-prefixed** to prevent canonicalization collisions:
+/// `u16_be(len(label)) || label || u16_be(len(kid_bytes)) || kid_bytes`.
+struct VapidKeyCipher {
+    /// 32-byte AES-256 key derived from the root key via HMAC-SHA256.
+    key: [u8; 32],
+}
+
+impl VapidKeyCipher {
+    fn new(root_key: &[u8]) -> Self {
+        let mut mac = <Hmac<Sha256> as HmacKeyInit>::new_from_slice(root_key)
+            .expect("HMAC supports any key length");
+        mac.update(b"waddle:push-service:vapid-key:enc:v1");
+        let derived = mac.finalize().into_bytes();
+        let mut key = [0u8; 32];
+        key.copy_from_slice(&derived);
+        Self { key }
+    }
+
+    fn seal(&self, plaintext: &[u8], label: &[u8], kid_bytes: &[u8]) -> Result<String, String> {
+        debug_assert!(label.len() <= u16::MAX as usize);
+        debug_assert!(kid_bytes.len() <= u16::MAX as usize);
+        let aad = build_aad(label, kid_bytes);
+        let mut nonce = [0u8; 12];
+        rand::rng().fill(&mut nonce[..]);
+        let cipher =
+            Aes256Gcm::new_from_slice(&self.key).map_err(|e| format!("AES-256-GCM init: {e}"))?;
+        let ciphertext = cipher
+            .encrypt(
+                (&nonce).into(),
+                Payload {
+                    msg: plaintext,
+                    aad: &aad,
+                },
+            )
+            .map_err(|e| format!("AES-256-GCM seal: {e}"))?;
+        Ok(format!(
+            "{SEALED_PREFIX}:{}:{}",
+            URL_SAFE_NO_PAD.encode(nonce),
+            URL_SAFE_NO_PAD.encode(ciphertext)
+        ))
+    }
+
+    fn open(&self, stored: &str, label: &[u8], kid_bytes: &[u8]) -> Result<Vec<u8>, String> {
+        let mut parts = stored.split(':');
+        let prefix = parts.next().ok_or("missing prefix")?;
+        if prefix != SEALED_PREFIX {
+            return Err(format!("unexpected sealed prefix {prefix:?}"));
+        }
+        let nonce_b64 = parts.next().ok_or("missing nonce")?;
+        let ct_b64 = parts.next().ok_or("missing ciphertext")?;
+        if parts.next().is_some() {
+            return Err("unexpected trailing field".into());
+        }
+        let nonce = URL_SAFE_NO_PAD
+            .decode(nonce_b64)
+            .map_err(|e| format!("nonce base64url: {e}"))?;
+        let nonce: [u8; 12] = nonce
+            .try_into()
+            .map_err(|v: Vec<u8>| format!("nonce wrong length: {}", v.len()))?;
+        let ciphertext = URL_SAFE_NO_PAD
+            .decode(ct_b64)
+            .map_err(|e| format!("ciphertext base64url: {e}"))?;
+        let aad = build_aad(label, kid_bytes);
+        let cipher =
+            Aes256Gcm::new_from_slice(&self.key).map_err(|e| format!("AES-256-GCM init: {e}"))?;
+        cipher
+            .decrypt(
+                (&nonce).into(),
+                Payload {
+                    msg: &ciphertext,
+                    aad: &aad,
+                },
+            )
+            .map_err(|e| format!("AES-256-GCM open (AAD/tag check failed): {e}"))
+    }
+}
+
+fn build_aad(label: &[u8], kid_bytes: &[u8]) -> Vec<u8> {
+    let mut aad = Vec::with_capacity(2 + label.len() + 2 + kid_bytes.len());
+    aad.extend_from_slice(&(label.len() as u16).to_be_bytes());
+    aad.extend_from_slice(label);
+    aad.extend_from_slice(&(kid_bytes.len() as u16).to_be_bytes());
+    aad.extend_from_slice(kid_bytes);
+    aad
+}
+
+fn parse_env_scalar(raw: &str) -> Result<p256::SecretKey, VapidLoadError> {
+    let raw = raw.trim();
+    let bytes = URL_SAFE_NO_PAD
+        .decode(raw.trim_end_matches('='))
+        .map_err(|e| VapidLoadError::EnvParse(format!("base64url decode: {e}")))?;
+    if bytes.len() != 32 {
+        return Err(VapidLoadError::EnvParse(format!(
+            "expected 32-byte P-256 scalar; got {} bytes",
+            bytes.len()
+        )));
+    }
+    p256::SecretKey::from_slice(&bytes)
+        .map_err(|e| VapidLoadError::EnvParse(format!("invalid P-256 scalar: {e}")))
+}
+
+/// Adapter wrapping a `VapidStorage`-produced signer that also exposes
+/// the storage handle for future operations (e.g. rotation).
+///
+/// Constructed indirectly via [`VapidStorage::load_or_provision`]; this
+/// is the public type held by the Push Service component.
+pub struct StoredVapidSigner {
+    inner: Arc<InProcessVapidSigner>,
+}
+
+impl StoredVapidSigner {
+    pub fn new(inner: Arc<InProcessVapidSigner>) -> Self {
+        Self { inner }
+    }
+}
+
+impl VapidSigner for StoredVapidSigner {
+    fn sign(&self, aud: &url::Origin, sub: &VapidSub) -> Result<VapidJwt, VapidSignError> {
+        self.inner.sign(aud, sub)
+    }
+
+    fn current_public_key(&self) -> p256::PublicKey {
+        self.inner.current_public_key()
+    }
+
+    fn current_kid(&self) -> Kid {
+        self.inner.current_kid()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_aad_is_length_prefixed() {
+        let aad = build_aad(b"label", b"kid_bytes");
+        // u16_be(5) || "label" || u16_be(9) || "kid_bytes"
+        assert_eq!(&aad[..2], &5u16.to_be_bytes());
+        assert_eq!(&aad[2..7], b"label");
+        assert_eq!(&aad[7..9], &9u16.to_be_bytes());
+        assert_eq!(&aad[9..], b"kid_bytes");
+    }
+
+    #[test]
+    fn build_aad_prevents_canonicalization_collision() {
+        // "vapid" + "-extra" vs "vapid-" + "extra" — same byte sequence
+        // without length-prefixing, but our length-prefixed AAD differs.
+        let a = build_aad(b"vapid", b"-extra");
+        let b = build_aad(b"vapid-", b"extra");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn cipher_round_trip() {
+        let cipher = VapidKeyCipher::new(b"root-key-for-tests");
+        let plaintext = b"my-32-byte-p256-scalar-padding!!";
+        let sealed = cipher.seal(plaintext, AAD_LABEL, b"some-kid").unwrap();
+        let opened = cipher.open(&sealed, AAD_LABEL, b"some-kid").unwrap();
+        assert_eq!(opened, plaintext);
+    }
+
+    #[test]
+    fn cipher_rejects_mismatched_kid() {
+        let cipher = VapidKeyCipher::new(b"root-key-for-tests");
+        let plaintext = b"my-32-byte-p256-scalar-padding!!";
+        let sealed = cipher.seal(plaintext, AAD_LABEL, b"kid-a").unwrap();
+        let err = cipher.open(&sealed, AAD_LABEL, b"kid-b").unwrap_err();
+        assert!(err.contains("AAD/tag check failed"), "{err}");
+    }
+
+    #[test]
+    fn cipher_rejects_mismatched_label() {
+        let cipher = VapidKeyCipher::new(b"root-key-for-tests");
+        let plaintext = b"my-32-byte-p256-scalar-padding!!";
+        let sealed = cipher.seal(plaintext, b"label-a", b"kid").unwrap();
+        let err = cipher.open(&sealed, b"label-b", b"kid").unwrap_err();
+        assert!(err.contains("AAD/tag check failed"), "{err}");
+    }
+
+    #[test]
+    fn cipher_rejects_wrong_root_key() {
+        let cipher_a = VapidKeyCipher::new(b"root-key-A");
+        let cipher_b = VapidKeyCipher::new(b"root-key-B");
+        let plaintext = b"my-32-byte-p256-scalar-padding!!";
+        let sealed = cipher_a.seal(plaintext, AAD_LABEL, b"kid").unwrap();
+        let err = cipher_b.open(&sealed, AAD_LABEL, b"kid").unwrap_err();
+        assert!(err.contains("AAD/tag check failed"), "{err}");
+    }
+
+    #[test]
+    fn parse_env_scalar_accepts_base64url_no_pad_32_bytes() {
+        let bytes = [0xABu8; 32];
+        let encoded = URL_SAFE_NO_PAD.encode(bytes);
+        let key = parse_env_scalar(&encoded).expect("valid scalar");
+        assert_eq!(&key.to_bytes()[..], &bytes[..]);
+    }
+
+    #[test]
+    fn parse_env_scalar_rejects_wrong_length() {
+        let encoded = URL_SAFE_NO_PAD.encode([0u8; 16]);
+        let err = parse_env_scalar(&encoded).unwrap_err();
+        assert!(matches!(err, VapidLoadError::EnvParse(_)));
+    }
+
+    #[test]
+    fn parse_env_scalar_accepts_leading_zero() {
+        let mut bytes = [0u8; 32];
+        bytes[31] = 1; // scalar = 1 (smallest valid)
+        let encoded = URL_SAFE_NO_PAD.encode(bytes);
+        let _ = parse_env_scalar(&encoded).expect("leading-zero scalar is valid");
+    }
+}

--- a/server/crates/waddle-server/src/push_service/vapid_storage.rs
+++ b/server/crates/waddle-server/src/push_service/vapid_storage.rs
@@ -9,6 +9,15 @@
 //! delegating the actual JWT signing to [`InProcessVapidSigner`]. This
 //! crate owns the durable lifecycle (env-var bootstrap, fresh
 //! generation, DB persistence); the lower crate owns pure crypto.
+//!
+//! ## Safety
+//!
+//! `load_or_provision` calls `std::env::remove_var(WADDLE_VAPID_PRIVATE_KEY)`
+//! after the env-supplied scalar is persisted to the DB. The unsafe call is
+//! justified by the invariant that no other code in this crate reads or
+//! writes `WADDLE_VAPID_PRIVATE_KEY`. Operators MUST NOT pass the same env
+//! variable name to other tooling expecting steady-state availability —
+//! the value lives only for the boot window.
 
 use std::env;
 use std::sync::Arc;
@@ -23,9 +32,10 @@ use p256::elliptic_curve::sec1::ToEncodedPoint;
 use rand::RngExt;
 use sha2::Sha256;
 use uuid::Uuid;
-use waddle_xmpp::push::types::{Kid, VapidJwt, VapidLoadError, VapidSignError, VapidSub};
+use waddle_xmpp::push::types::{Kid, VapidLoadError};
 use waddle_xmpp::push::vapid::{InProcessVapidSigner, VapidSigner};
 use waddle_xmpp::XmppError;
+use zeroize::Zeroizing;
 
 use crate::db::{Database, IntoParams};
 
@@ -54,20 +64,22 @@ impl VapidStorage {
     pub async fn load_or_provision(
         db: Database,
         root_key: &[u8],
-    ) -> Result<Arc<InProcessVapidSigner>, VapidLoadError> {
+    ) -> Result<Arc<dyn VapidSigner>, VapidLoadError> {
         let storage = Self::new(db.clone(), root_key)
             .await
             .map_err(|e| VapidLoadError::DbWrite(e.to_string()))?;
 
         // 1. Env-var bootstrap path.
         if let Ok(raw) = env::var(VAPID_ENV_VAR) {
-            let secret_key = parse_env_scalar(&raw)?;
+            // Wrap the env-supplied string in Zeroizing so the heap-allocated
+            // base64url scalar zeroes when this scope ends.
+            let raw = Zeroizing::new(raw);
+            let secret_key = parse_env_scalar(raw.as_str())?;
             let kid = Kid::new();
             storage.persist_keypair(&kid, &secret_key).await?;
-            // SAFETY: remove_var is unsafe in newer Rust. We call this once
-            // at boot before spawning any threads that might read env.
-            // SAFETY justified: this is the boot path, single-threaded.
-            #[allow(unsafe_code)]
+            // SAFETY: see module-level invariant — `WADDLE_VAPID_PRIVATE_KEY`
+            // is read exactly once at boot via `load_or_provision`; no other
+            // code in this crate reads or writes it.
             unsafe {
                 env::remove_var(VAPID_ENV_VAR);
             }
@@ -240,19 +252,23 @@ impl VapidStorage {
 /// AAD is **length-prefixed** to prevent canonicalization collisions:
 /// `u16_be(len(label)) || label || u16_be(len(kid_bytes)) || kid_bytes`.
 struct VapidKeyCipher {
-    /// 32-byte AES-256 key derived from the root key via HMAC-SHA256.
-    key: [u8; 32],
+    /// Initialized once at storage construction. AES-256-GCM key was derived
+    /// from the root key via HMAC-SHA256 with a domain-separating label.
+    cipher: Aes256Gcm,
 }
 
 impl VapidKeyCipher {
     fn new(root_key: &[u8]) -> Self {
         let mut mac = <Hmac<Sha256> as HmacKeyInit>::new_from_slice(root_key)
-            .expect("HMAC supports any key length");
+            .expect("HMAC-SHA256 accepts arbitrary-length keys");
         mac.update(b"waddle:push-service:vapid-key:enc:v1");
         let derived = mac.finalize().into_bytes();
-        let mut key = [0u8; 32];
-        key.copy_from_slice(&derived);
-        Self { key }
+        // `Aes256Gcm::new` takes a typed `Key<Aes256Gcm>` (32 bytes); the
+        // derived MAC output is guaranteed 32 bytes so the conversion is
+        // infallible.
+        let cipher = Aes256Gcm::new_from_slice(&derived)
+            .expect("HMAC-SHA256 output is 32 bytes — exactly the AES-256 key size");
+        Self { cipher }
     }
 
     fn seal(&self, plaintext: &[u8], label: &[u8], kid_bytes: &[u8]) -> Result<String, String> {
@@ -261,9 +277,8 @@ impl VapidKeyCipher {
         let aad = build_aad(label, kid_bytes);
         let mut nonce = [0u8; 12];
         rand::rng().fill(&mut nonce[..]);
-        let cipher =
-            Aes256Gcm::new_from_slice(&self.key).map_err(|e| format!("AES-256-GCM init: {e}"))?;
-        let ciphertext = cipher
+        let ciphertext = self
+            .cipher
             .encrypt(
                 (&nonce).into(),
                 Payload {
@@ -300,9 +315,7 @@ impl VapidKeyCipher {
             .decode(ct_b64)
             .map_err(|e| format!("ciphertext base64url: {e}"))?;
         let aad = build_aad(label, kid_bytes);
-        let cipher =
-            Aes256Gcm::new_from_slice(&self.key).map_err(|e| format!("AES-256-GCM init: {e}"))?;
-        cipher
+        self.cipher
             .decrypt(
                 (&nonce).into(),
                 Payload {
@@ -336,35 +349,6 @@ fn parse_env_scalar(raw: &str) -> Result<p256::SecretKey, VapidLoadError> {
     }
     p256::SecretKey::from_slice(&bytes)
         .map_err(|e| VapidLoadError::EnvParse(format!("invalid P-256 scalar: {e}")))
-}
-
-/// Adapter wrapping a `VapidStorage`-produced signer that also exposes
-/// the storage handle for future operations (e.g. rotation).
-///
-/// Constructed indirectly via [`VapidStorage::load_or_provision`]; this
-/// is the public type held by the Push Service component.
-pub struct StoredVapidSigner {
-    inner: Arc<InProcessVapidSigner>,
-}
-
-impl StoredVapidSigner {
-    pub fn new(inner: Arc<InProcessVapidSigner>) -> Self {
-        Self { inner }
-    }
-}
-
-impl VapidSigner for StoredVapidSigner {
-    fn sign(&self, aud: &url::Origin, sub: &VapidSub) -> Result<VapidJwt, VapidSignError> {
-        self.inner.sign(aud, sub)
-    }
-
-    fn current_public_key(&self) -> p256::PublicKey {
-        self.inner.current_public_key()
-    }
-
-    fn current_kid(&self) -> Kid {
-        self.inner.current_kid()
-    }
 }
 
 #[cfg(test)]

--- a/server/crates/waddle-server/src/push_service/vapid_storage.rs
+++ b/server/crates/waddle-server/src/push_service/vapid_storage.rs
@@ -118,13 +118,21 @@ impl VapidStorage {
 
     async fn initialize(&self) -> Result<(), XmppError> {
         let i64_type = crate::db::i64_sql_type(self.db.driver());
+        // `BLOB` is the SQLite byte type; Postgres requires `BYTEA`. Use the
+        // configured driver to emit the dialect-correct column type.
+        let blob_type = match self.db.driver() {
+            crate::db::DatabaseDriver::Sqlite => "BLOB",
+            crate::db::DatabaseDriver::Postgres => "BYTEA",
+        };
+        // `kid` is a UUIDv4 and already `NOT NULL UNIQUE`; using it as the
+        // primary key avoids the SQLite-vs-Postgres autoincrement-integer
+        // mismatch that an `id INTEGER PRIMARY KEY` column would create.
         let sql = format!(
             r#"
             CREATE TABLE IF NOT EXISTS push_service_vapid_keys (
-                id INTEGER PRIMARY KEY,
-                kid TEXT NOT NULL UNIQUE,
+                kid TEXT NOT NULL PRIMARY KEY,
                 sealed_private_key TEXT NOT NULL,
-                public_key BLOB NOT NULL,
+                public_key {blob_type} NOT NULL,
                 root_key_version {i64_type} NOT NULL,
                 created_at_ms {i64_type} NOT NULL,
                 retired_at_ms {i64_type}

--- a/server/crates/waddle-server/src/push_service/vapid_storage.rs
+++ b/server/crates/waddle-server/src/push_service/vapid_storage.rs
@@ -263,10 +263,12 @@ impl VapidKeyCipher {
         let mut mac = <Hmac<Sha256> as HmacKeyInit>::new_from_slice(root_key)
             .expect("HMAC-SHA256 accepts arbitrary-length keys");
         mac.update(b"waddle:push-service:vapid-key:enc:v1");
+        // `hmac 0.13` emits the newer `hybrid_array::Array<u8, U32>`, while
+        // `aes-gcm 0.10` still consumes the legacy `GenericArray<u8, U32>`.
+        // The two are layout-compatible but not type-compatible, so we
+        // route through `new_from_slice` (which takes `&[u8]`); the
+        // length check is statically guaranteed by the 32-byte MAC output.
         let derived = mac.finalize().into_bytes();
-        // `Aes256Gcm::new` takes a typed `Key<Aes256Gcm>` (32 bytes); the
-        // derived MAC output is guaranteed 32 bytes so the conversion is
-        // infallible.
         let cipher = Aes256Gcm::new_from_slice(&derived)
             .expect("HMAC-SHA256 output is 32 bytes — exactly the AES-256 key size");
         Self { cipher }

--- a/server/crates/waddle-server/src/push_service/vapid_storage.rs
+++ b/server/crates/waddle-server/src/push_service/vapid_storage.rs
@@ -188,7 +188,11 @@ impl VapidStorage {
         secret_key: &p256::SecretKey,
     ) -> Result<(), VapidLoadError> {
         let now_ms = chrono::Utc::now().timestamp_millis();
-        let scalar = secret_key.to_bytes();
+        // `p256::SecretKey::to_bytes` already returns a `Zeroizing`-aware
+        // `FieldBytes` per the crate, but wrap the borrow target in an
+        // explicit `Zeroizing` to make the discipline obvious to a reader
+        // and to defend against future API drift in `p256`.
+        let scalar = Zeroizing::new(secret_key.to_bytes());
         let sealed = self
             .cipher
             .seal(&scalar[..], AAD_LABEL, kid.as_bytes())

--- a/server/crates/waddle-server/src/push_service/vapid_storage.rs
+++ b/server/crates/waddle-server/src/push_service/vapid_storage.rs
@@ -77,23 +77,43 @@ impl VapidStorage {
                 })?;
 
         // 1. Env-var bootstrap path.
+        //
+        // Ordering matters: `env::remove_var` MUST be the last fallible
+        // operation in this branch. If it ran before any later step that
+        // can fail (signer init, DB insert), a failure would leave the
+        // process without the env var even though `load_or_provision`
+        // returns `Err`, breaking the documented invariant
+        // ("remove only after successful bootstrap").
+        //
+        // We therefore derive scalar/public bytes BEFORE the signer
+        // consumes `secret_key`, then sequence: signer-init → persist →
+        // remove_var. If any step fails, env remains set so the
+        // operator can fix and retry.
         if let Ok(raw) = env::var(VAPID_ENV_VAR) {
-            // Wrap the env-supplied string in Zeroizing so the heap-allocated
-            // base64url scalar zeroes when this scope ends.
             let raw = Zeroizing::new(raw);
             let secret_key = parse_env_scalar(raw.as_str())?;
             let kid = Kid::new();
-            storage.persist_keypair(&kid, &secret_key).await?;
+            let scalar_bytes = Zeroizing::new(secret_key.to_bytes());
+            let public_bytes = secret_key
+                .public_key()
+                .to_encoded_point(false)
+                .as_bytes()
+                .to_vec();
+            // (a) signer-init (consumes secret_key — fallible).
+            let signer = InProcessVapidSigner::new(kid, secret_key)
+                .map_err(|source| VapidLoadError::SignerInit { source })?;
+            // (b) persist (fallible).
+            storage
+                .persist_keypair(&kid, &scalar_bytes[..], &public_bytes)
+                .await?;
+            // (c) all fallible steps succeeded — clear env.
             // SAFETY: see module-level invariant — `WADDLE_VAPID_PRIVATE_KEY`
             // is read exactly once at boot via `load_or_provision`; no other
             // code in this crate reads or writes it.
             unsafe {
                 env::remove_var(VAPID_ENV_VAR);
             }
-            return Ok(Arc::new(
-                InProcessVapidSigner::new(kid, secret_key)
-                    .map_err(|source| VapidLoadError::SignerInit { source })?,
-            ));
+            return Ok(Arc::new(signer));
         }
 
         // 2. Read latest non-retired row.
@@ -107,11 +127,18 @@ impl VapidStorage {
         // 3. Generate fresh.
         let kid = Kid::new();
         let secret_key = p256::SecretKey::random(&mut OsRng);
-        storage.persist_keypair(&kid, &secret_key).await?;
-        Ok(Arc::new(
-            InProcessVapidSigner::new(kid, secret_key)
-                .map_err(|source| VapidLoadError::SignerInit { source })?,
-        ))
+        let scalar_bytes = Zeroizing::new(secret_key.to_bytes());
+        let public_bytes = secret_key
+            .public_key()
+            .to_encoded_point(false)
+            .as_bytes()
+            .to_vec();
+        let signer = InProcessVapidSigner::new(kid, secret_key)
+            .map_err(|source| VapidLoadError::SignerInit { source })?;
+        storage
+            .persist_keypair(&kid, &scalar_bytes[..], &public_bytes)
+            .await?;
+        Ok(Arc::new(signer))
     }
 
     async fn new(db: Database, root_key: &[u8]) -> Result<Self, XmppError> {
@@ -182,29 +209,30 @@ impl VapidStorage {
             .map_err(|e| XmppError::internal(e.to_string()))
     }
 
+    /// Persist a sealed VAPID keypair from pre-derived byte material.
+    ///
+    /// Taking bytes rather than the `SecretKey` itself lets callers
+    /// construct the in-process signer (which consumes the `SecretKey`)
+    /// before the persist step, so `remove_var(WADDLE_VAPID_PRIVATE_KEY)`
+    /// can be deferred until ALL fallible operations succeed.
+    ///
+    /// `scalar_bytes` MUST be 32 bytes (a raw P-256 secret scalar) and
+    /// is wrapped in `Zeroizing` by the caller. `public_bytes` is the
+    /// 65-byte uncompressed SEC1 point (public, no zeroize needed).
     async fn persist_keypair(
         &self,
         kid: &Kid,
-        secret_key: &p256::SecretKey,
+        scalar_bytes: &[u8],
+        public_bytes: &[u8],
     ) -> Result<(), VapidLoadError> {
         let now_ms = chrono::Utc::now().timestamp_millis();
-        // `p256::SecretKey::to_bytes` already returns a `Zeroizing`-aware
-        // `FieldBytes` per the crate, but wrap the borrow target in an
-        // explicit `Zeroizing` to make the discipline obvious to a reader
-        // and to defend against future API drift in `p256`.
-        let scalar = Zeroizing::new(secret_key.to_bytes());
         let sealed = self
             .cipher
-            .seal(&scalar[..], AAD_LABEL, kid.as_bytes())
+            .seal(scalar_bytes, AAD_LABEL, kid.as_bytes())
             .map_err(|source| VapidLoadError::DbWrite {
                 stage: VapidDbWriteStage::SealPrivateKey,
                 source: Box::new(source),
             })?;
-        let public_bytes = secret_key
-            .public_key()
-            .to_encoded_point(false)
-            .as_bytes()
-            .to_vec();
 
         let sql = "INSERT INTO push_service_vapid_keys \
             (kid, sealed_private_key, public_key, root_key_version, created_at_ms) \
@@ -214,7 +242,7 @@ impl VapidStorage {
             crate::db_params![
                 kid.to_string(),
                 sealed,
-                public_bytes,
+                public_bytes.to_vec(),
                 CURRENT_ROOT_KEY_VERSION as i64,
                 now_ms,
             ],

--- a/server/crates/waddle-server/src/push_service/vapid_storage.rs
+++ b/server/crates/waddle-server/src/push_service/vapid_storage.rs
@@ -241,8 +241,9 @@ impl VapidStorage {
             .cipher
             .open(&sealed, AAD_LABEL, kid.as_bytes())
             .map_err(|e| VapidLoadError::Unseal(e.to_string()))?;
-        let secret_key = p256::SecretKey::from_slice(&scalar)
+        let secret_key = p256::SecretKey::from_slice(scalar.as_slice())
             .map_err(|e| VapidLoadError::DbRead(format!("bad P-256 scalar: {e}")))?;
+        // `scalar` is `Zeroizing<Vec<u8>>` and zeroes here.
         Ok(Some((kid, secret_key)))
     }
 }
@@ -272,8 +273,11 @@ impl VapidKeyCipher {
     }
 
     fn seal(&self, plaintext: &[u8], label: &[u8], kid_bytes: &[u8]) -> Result<String, String> {
-        debug_assert!(label.len() <= u16::MAX as usize);
-        debug_assert!(kid_bytes.len() <= u16::MAX as usize);
+        // Length-prefix encoding uses u16, so each field is capped at 65535
+        // bytes. Practical labels (~32 B) and kids (16 B UUID) are far below
+        // the bound; the assertion catches future regressions.
+        assert!(label.len() <= u16::MAX as usize, "AAD label too long");
+        assert!(kid_bytes.len() <= u16::MAX as usize, "AAD kid too long");
         let aad = build_aad(label, kid_bytes);
         let mut nonce = [0u8; 12];
         rand::rng().fill(&mut nonce[..]);
@@ -294,7 +298,12 @@ impl VapidKeyCipher {
         ))
     }
 
-    fn open(&self, stored: &str, label: &[u8], kid_bytes: &[u8]) -> Result<Vec<u8>, String> {
+    fn open(
+        &self,
+        stored: &str,
+        label: &[u8],
+        kid_bytes: &[u8],
+    ) -> Result<Zeroizing<Vec<u8>>, String> {
         let mut parts = stored.split(':');
         let prefix = parts.next().ok_or("missing prefix")?;
         if prefix != SEALED_PREFIX {
@@ -315,7 +324,8 @@ impl VapidKeyCipher {
             .decode(ct_b64)
             .map_err(|e| format!("ciphertext base64url: {e}"))?;
         let aad = build_aad(label, kid_bytes);
-        self.cipher
+        let plaintext = self
+            .cipher
             .decrypt(
                 (&nonce).into(),
                 Payload {
@@ -323,7 +333,8 @@ impl VapidKeyCipher {
                     aad: &aad,
                 },
             )
-            .map_err(|e| format!("AES-256-GCM open (AAD/tag check failed): {e}"))
+            .map_err(|e| format!("AES-256-GCM open (AAD/tag check failed): {e}"))?;
+        Ok(Zeroizing::new(plaintext))
     }
 }
 
@@ -338,16 +349,21 @@ fn build_aad(label: &[u8], kid_bytes: &[u8]) -> Vec<u8> {
 
 fn parse_env_scalar(raw: &str) -> Result<p256::SecretKey, VapidLoadError> {
     let raw = raw.trim();
-    let bytes = URL_SAFE_NO_PAD
-        .decode(raw.trim_end_matches('='))
-        .map_err(|e| VapidLoadError::EnvParse(format!("base64url decode: {e}")))?;
+    // Wrap the decoded bytes in Zeroizing so the raw P-256 scalar zeroes
+    // out of heap when `bytes` falls out of scope, regardless of whether
+    // `from_slice` succeeds.
+    let bytes = Zeroizing::new(
+        URL_SAFE_NO_PAD
+            .decode(raw.trim_end_matches('='))
+            .map_err(|e| VapidLoadError::EnvParse(format!("base64url decode: {e}")))?,
+    );
     if bytes.len() != 32 {
         return Err(VapidLoadError::EnvParse(format!(
             "expected 32-byte P-256 scalar; got {} bytes",
             bytes.len()
         )));
     }
-    p256::SecretKey::from_slice(&bytes)
+    p256::SecretKey::from_slice(bytes.as_slice())
         .map_err(|e| VapidLoadError::EnvParse(format!("invalid P-256 scalar: {e}")))
 }
 
@@ -380,7 +396,7 @@ mod tests {
         let plaintext = b"my-32-byte-p256-scalar-padding!!";
         let sealed = cipher.seal(plaintext, AAD_LABEL, b"some-kid").unwrap();
         let opened = cipher.open(&sealed, AAD_LABEL, b"some-kid").unwrap();
-        assert_eq!(opened, plaintext);
+        assert_eq!(opened.as_slice(), plaintext);
     }
 
     #[test]

--- a/server/crates/waddle-server/src/push_service/vapid_storage.rs
+++ b/server/crates/waddle-server/src/push_service/vapid_storage.rs
@@ -85,7 +85,7 @@ impl VapidStorage {
             }
             return Ok(Arc::new(
                 InProcessVapidSigner::new(kid, secret_key)
-                    .map_err(|e| VapidLoadError::DbWrite(e.to_string()))?,
+                    .map_err(|e| VapidLoadError::SignerInit(e.to_string()))?,
             ));
         }
 
@@ -93,7 +93,7 @@ impl VapidStorage {
         if let Some((kid, secret_key)) = storage.load_latest().await? {
             return Ok(Arc::new(
                 InProcessVapidSigner::new(kid, secret_key)
-                    .map_err(|e| VapidLoadError::DbWrite(e.to_string()))?,
+                    .map_err(|e| VapidLoadError::SignerInit(e.to_string()))?,
             ));
         }
 
@@ -103,7 +103,7 @@ impl VapidStorage {
         storage.persist_keypair(&kid, &secret_key).await?;
         Ok(Arc::new(
             InProcessVapidSigner::new(kid, secret_key)
-                .map_err(|e| VapidLoadError::DbWrite(e.to_string()))?,
+                .map_err(|e| VapidLoadError::SignerInit(e.to_string()))?,
         ))
     }
 
@@ -235,9 +235,12 @@ impl VapidStorage {
         let version: i64 = row
             .get(2)
             .map_err(|e| VapidLoadError::DbRead(format!("root_key_version: {e}")))?;
-        if version as u32 != CURRENT_ROOT_KEY_VERSION {
+        // Compare as `i64` directly to avoid the `as u32` wraparound foot-gun:
+        // a negative value (or any v where `(v % 2^32) == 1`) would silently
+        // pass an `i64 as u32 == 1` check.
+        if version != i64::from(CURRENT_ROOT_KEY_VERSION) {
             return Err(VapidLoadError::UnknownRootKeyVersion {
-                found: version as u32,
+                found: u32::try_from(version).unwrap_or(u32::MAX),
                 max_installed: CURRENT_ROOT_KEY_VERSION,
             });
         }

--- a/server/crates/waddle-server/src/push_service/vapid_storage.rs
+++ b/server/crates/waddle-server/src/push_service/vapid_storage.rs
@@ -32,7 +32,10 @@ use p256::elliptic_curve::sec1::ToEncodedPoint;
 use rand::RngExt;
 use sha2::Sha256;
 use uuid::Uuid;
-use waddle_xmpp::push::types::{Kid, VapidLoadError};
+use waddle_xmpp::push::types::{
+    Kid, VapidDbReadStage, VapidDbWriteStage, VapidEnvParseError, VapidLoadError,
+    VapidUnsealErrorKind,
+};
 use waddle_xmpp::push::vapid::{InProcessVapidSigner, VapidSigner};
 use waddle_xmpp::XmppError;
 use zeroize::Zeroizing;
@@ -65,9 +68,13 @@ impl VapidStorage {
         db: Database,
         root_key: &[u8],
     ) -> Result<Arc<dyn VapidSigner>, VapidLoadError> {
-        let storage = Self::new(db.clone(), root_key)
-            .await
-            .map_err(|e| VapidLoadError::DbWrite(e.to_string()))?;
+        let storage =
+            Self::new(db.clone(), root_key)
+                .await
+                .map_err(|source| VapidLoadError::DbWrite {
+                    stage: VapidDbWriteStage::Initialize,
+                    source: Box::new(source),
+                })?;
 
         // 1. Env-var bootstrap path.
         if let Ok(raw) = env::var(VAPID_ENV_VAR) {
@@ -85,7 +92,7 @@ impl VapidStorage {
             }
             return Ok(Arc::new(
                 InProcessVapidSigner::new(kid, secret_key)
-                    .map_err(|e| VapidLoadError::SignerInit(e.to_string()))?,
+                    .map_err(|source| VapidLoadError::SignerInit { source })?,
             ));
         }
 
@@ -93,7 +100,7 @@ impl VapidStorage {
         if let Some((kid, secret_key)) = storage.load_latest().await? {
             return Ok(Arc::new(
                 InProcessVapidSigner::new(kid, secret_key)
-                    .map_err(|e| VapidLoadError::SignerInit(e.to_string()))?,
+                    .map_err(|source| VapidLoadError::SignerInit { source })?,
             ));
         }
 
@@ -103,7 +110,7 @@ impl VapidStorage {
         storage.persist_keypair(&kid, &secret_key).await?;
         Ok(Arc::new(
             InProcessVapidSigner::new(kid, secret_key)
-                .map_err(|e| VapidLoadError::SignerInit(e.to_string()))?,
+                .map_err(|source| VapidLoadError::SignerInit { source })?,
         ))
     }
 
@@ -185,7 +192,10 @@ impl VapidStorage {
         let sealed = self
             .cipher
             .seal(&scalar[..], AAD_LABEL, kid.as_bytes())
-            .map_err(|e| VapidLoadError::DbWrite(format!("seal: {e}")))?;
+            .map_err(|source| VapidLoadError::DbWrite {
+                stage: VapidDbWriteStage::SealPrivateKey,
+                source: Box::new(source),
+            })?;
         let public_bytes = secret_key
             .public_key()
             .to_encoded_point(false)
@@ -206,7 +216,10 @@ impl VapidStorage {
             ],
         )
         .await
-        .map_err(|e| VapidLoadError::DbWrite(e.to_string()))?;
+        .map_err(|source| VapidLoadError::DbWrite {
+            stage: VapidDbWriteStage::InsertRow,
+            source: Box::new(source),
+        })?;
         Ok(())
     }
 
@@ -218,23 +231,29 @@ impl VapidStorage {
         let mut rows = self
             .run_query(sql, ())
             .await
-            .map_err(|e| VapidLoadError::DbRead(e.to_string()))?;
-        let Some(row) = rows
-            .next()
-            .await
-            .map_err(|e| VapidLoadError::DbRead(e.to_string()))?
+            .map_err(|source| VapidLoadError::DbRead {
+                stage: VapidDbReadStage::Query,
+                source: Box::new(source),
+            })?;
+        let Some(row) = rows.next().await.map_err(|source| VapidLoadError::DbRead {
+            stage: VapidDbReadStage::NextRow,
+            source: Box::new(source),
+        })?
         else {
             return Ok(None);
         };
-        let kid_str: String = row
-            .get(0)
-            .map_err(|e| VapidLoadError::DbRead(format!("kid: {e}")))?;
-        let sealed: String = row
-            .get(1)
-            .map_err(|e| VapidLoadError::DbRead(format!("sealed_private_key: {e}")))?;
-        let version: i64 = row
-            .get(2)
-            .map_err(|e| VapidLoadError::DbRead(format!("root_key_version: {e}")))?;
+        let kid_str: String = row.get(0).map_err(|source| VapidLoadError::DbRead {
+            stage: VapidDbReadStage::DecodeKid,
+            source: Box::new(source),
+        })?;
+        let sealed: String = row.get(1).map_err(|source| VapidLoadError::DbRead {
+            stage: VapidDbReadStage::DecodeSealedPrivateKey,
+            source: Box::new(source),
+        })?;
+        let version: i64 = row.get(2).map_err(|source| VapidLoadError::DbRead {
+            stage: VapidDbReadStage::DecodeRootKeyVersion,
+            source: Box::new(source),
+        })?;
         // Compare as `i64` directly to avoid the `as u32` wraparound foot-gun:
         // a negative value (or any v where `(v % 2^32) == 1`) would silently
         // pass an `i64 as u32 == 1` check.
@@ -244,16 +263,24 @@ impl VapidStorage {
                 max_installed: CURRENT_ROOT_KEY_VERSION,
             });
         }
-        let kid_uuid: Uuid = kid_str
-            .parse()
-            .map_err(|e: uuid::Error| VapidLoadError::DbRead(format!("kid not a UUID: {e}")))?;
+        let kid_uuid: Uuid =
+            kid_str
+                .parse()
+                .map_err(|source: uuid::Error| VapidLoadError::DbRead {
+                    stage: VapidDbReadStage::ParseKidUuid,
+                    source: Box::new(source),
+                })?;
         let kid = Kid(kid_uuid);
         let scalar = self
             .cipher
             .open(&sealed, AAD_LABEL, kid.as_bytes())
-            .map_err(|e| VapidLoadError::Unseal(e.to_string()))?;
-        let secret_key = p256::SecretKey::from_slice(scalar.as_slice())
-            .map_err(|e| VapidLoadError::DbRead(format!("bad P-256 scalar: {e}")))?;
+            .map_err(|kind| VapidLoadError::Unseal { kind })?;
+        let secret_key = p256::SecretKey::from_slice(scalar.as_slice()).map_err(|source| {
+            VapidLoadError::DbRead {
+                stage: VapidDbReadStage::ParseSecretKeyScalar,
+                source: Box::new(source),
+            }
+        })?;
         // `scalar` is `Zeroizing<Vec<u8>>` and zeroes here.
         Ok(Some((kid, secret_key)))
     }
@@ -267,6 +294,12 @@ struct VapidKeyCipher {
     /// Initialized once at storage construction. AES-256-GCM key was derived
     /// from the root key via HMAC-SHA256 with a domain-separating label.
     cipher: Aes256Gcm,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum VapidSealError {
+    #[error("AES-256-GCM seal failed")]
+    EncryptFailed,
 }
 
 impl VapidKeyCipher {
@@ -285,7 +318,12 @@ impl VapidKeyCipher {
         Self { cipher }
     }
 
-    fn seal(&self, plaintext: &[u8], label: &[u8], kid_bytes: &[u8]) -> Result<String, String> {
+    fn seal(
+        &self,
+        plaintext: &[u8],
+        label: &[u8],
+        kid_bytes: &[u8],
+    ) -> Result<String, VapidSealError> {
         // Length-prefix encoding uses u16, so each field is capped at 65535
         // bytes. Practical labels (~32 B) and kids (16 B UUID) are far below
         // the bound; the assertion catches future regressions.
@@ -303,7 +341,7 @@ impl VapidKeyCipher {
                     aad: &aad,
                 },
             )
-            .map_err(|e| format!("AES-256-GCM seal: {e}"))?;
+            .map_err(|_| VapidSealError::EncryptFailed)?;
         Ok(format!(
             "{SEALED_PREFIX}:{}:{}",
             URL_SAFE_NO_PAD.encode(nonce),
@@ -316,26 +354,28 @@ impl VapidKeyCipher {
         stored: &str,
         label: &[u8],
         kid_bytes: &[u8],
-    ) -> Result<Zeroizing<Vec<u8>>, String> {
+    ) -> Result<Zeroizing<Vec<u8>>, VapidUnsealErrorKind> {
         let mut parts = stored.split(':');
-        let prefix = parts.next().ok_or("missing prefix")?;
+        let prefix = parts.next().ok_or(VapidUnsealErrorKind::MissingPrefix)?;
         if prefix != SEALED_PREFIX {
-            return Err(format!("unexpected sealed prefix {prefix:?}"));
+            return Err(VapidUnsealErrorKind::UnexpectedPrefix);
         }
-        let nonce_b64 = parts.next().ok_or("missing nonce")?;
-        let ct_b64 = parts.next().ok_or("missing ciphertext")?;
+        let nonce_b64 = parts.next().ok_or(VapidUnsealErrorKind::MissingNonce)?;
+        let ct_b64 = parts
+            .next()
+            .ok_or(VapidUnsealErrorKind::MissingCiphertext)?;
         if parts.next().is_some() {
-            return Err("unexpected trailing field".into());
+            return Err(VapidUnsealErrorKind::UnexpectedTrailingField);
         }
         let nonce = URL_SAFE_NO_PAD
             .decode(nonce_b64)
-            .map_err(|e| format!("nonce base64url: {e}"))?;
+            .map_err(|_| VapidUnsealErrorKind::NonceBase64urlDecode)?;
         let nonce: [u8; 12] = nonce
             .try_into()
-            .map_err(|v: Vec<u8>| format!("nonce wrong length: {}", v.len()))?;
+            .map_err(|_: Vec<u8>| VapidUnsealErrorKind::NonceWrongLength)?;
         let ciphertext = URL_SAFE_NO_PAD
             .decode(ct_b64)
-            .map_err(|e| format!("ciphertext base64url: {e}"))?;
+            .map_err(|_| VapidUnsealErrorKind::CiphertextBase64urlDecode)?;
         let aad = build_aad(label, kid_bytes);
         let plaintext = self
             .cipher
@@ -346,7 +386,7 @@ impl VapidKeyCipher {
                     aad: &aad,
                 },
             )
-            .map_err(|e| format!("AES-256-GCM open (AAD/tag check failed): {e}"))?;
+            .map_err(|_| VapidUnsealErrorKind::AeadOpenFailed)?;
         Ok(Zeroizing::new(plaintext))
     }
 }
@@ -368,16 +408,13 @@ fn parse_env_scalar(raw: &str) -> Result<p256::SecretKey, VapidLoadError> {
     let bytes = Zeroizing::new(
         URL_SAFE_NO_PAD
             .decode(raw.trim_end_matches('='))
-            .map_err(|e| VapidLoadError::EnvParse(format!("base64url decode: {e}")))?,
+            .map_err(|source| VapidEnvParseError::Base64urlDecode { source })?,
     );
     if bytes.len() != 32 {
-        return Err(VapidLoadError::EnvParse(format!(
-            "expected 32-byte P-256 scalar; got {} bytes",
-            bytes.len()
-        )));
+        return Err(VapidEnvParseError::InvalidLength { found: bytes.len() }.into());
     }
     p256::SecretKey::from_slice(bytes.as_slice())
-        .map_err(|e| VapidLoadError::EnvParse(format!("invalid P-256 scalar: {e}")))
+        .map_err(|source| VapidEnvParseError::InvalidScalar { source }.into())
 }
 
 #[cfg(test)]
@@ -418,7 +455,7 @@ mod tests {
         let plaintext = b"my-32-byte-p256-scalar-padding!!";
         let sealed = cipher.seal(plaintext, AAD_LABEL, b"kid-a").unwrap();
         let err = cipher.open(&sealed, AAD_LABEL, b"kid-b").unwrap_err();
-        assert!(err.contains("AAD/tag check failed"), "{err}");
+        assert_eq!(err, VapidUnsealErrorKind::AeadOpenFailed);
     }
 
     #[test]
@@ -427,7 +464,7 @@ mod tests {
         let plaintext = b"my-32-byte-p256-scalar-padding!!";
         let sealed = cipher.seal(plaintext, b"label-a", b"kid").unwrap();
         let err = cipher.open(&sealed, b"label-b", b"kid").unwrap_err();
-        assert!(err.contains("AAD/tag check failed"), "{err}");
+        assert_eq!(err, VapidUnsealErrorKind::AeadOpenFailed);
     }
 
     #[test]
@@ -437,7 +474,7 @@ mod tests {
         let plaintext = b"my-32-byte-p256-scalar-padding!!";
         let sealed = cipher_a.seal(plaintext, AAD_LABEL, b"kid").unwrap();
         let err = cipher_b.open(&sealed, AAD_LABEL, b"kid").unwrap_err();
-        assert!(err.contains("AAD/tag check failed"), "{err}");
+        assert_eq!(err, VapidUnsealErrorKind::AeadOpenFailed);
     }
 
     #[test]
@@ -452,7 +489,10 @@ mod tests {
     fn parse_env_scalar_rejects_wrong_length() {
         let encoded = URL_SAFE_NO_PAD.encode([0u8; 16]);
         let err = parse_env_scalar(&encoded).unwrap_err();
-        assert!(matches!(err, VapidLoadError::EnvParse(_)));
+        assert!(matches!(
+            err,
+            VapidLoadError::EnvParse(VapidEnvParseError::InvalidLength { found: 16 })
+        ));
     }
 
     #[test]

--- a/server/crates/waddle-server/tests/xep0357_push_notifications.rs
+++ b/server/crates/waddle-server/tests/xep0357_push_notifications.rs
@@ -5,9 +5,11 @@
 //! `src/push_service/vapid_storage.rs`. This file exercises the
 //! `VapidStorage::load_or_provision` boot path end-to-end against an
 //! in-memory database — fresh generation, persisted reuse, env-var
-//! bootstrap with write-before-remove, and the AAD-kid stability
-//! guarantee that a sealed blob is still openable after the row's
-//! autoincrement `id` is renumbered (DB-restore resilience).
+//! bootstrap with write-before-remove, and the AAD-kid binding that
+//! makes a sealed blob inseparable from the `kid` it was sealed against
+//! (the AAD includes `label || kid`, so cross-row blob swaps fail the
+//! GCM tag check). `kid` is the table's primary key — there is no
+//! autoincrement `id` column.
 
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine as _;

--- a/server/crates/waddle-server/tests/xep0357_push_notifications.rs
+++ b/server/crates/waddle-server/tests/xep0357_push_notifications.rs
@@ -13,10 +13,9 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine as _;
 use p256::elliptic_curve::sec1::ToEncodedPoint;
 use std::env;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, MutexGuard};
 use waddle_server::db::Database;
 use waddle_server::push_service::vapid_storage::VapidStorage;
-use waddle_xmpp::push::vapid::VapidSigner;
 
 /// Serializes tests that mutate `WADDLE_VAPID_PRIVATE_KEY`. The env is
 /// process-global; cargo runs tests in parallel by default. We use
@@ -35,20 +34,45 @@ fn b64u(bytes: &[u8]) -> String {
     URL_SAFE_NO_PAD.encode(bytes)
 }
 
-/// Helper: clear the env var so a previous test's leak doesn't bleed in.
-fn ensure_env_unset() {
-    // SAFETY: tests run single-threaded inside one test binary; the global
-    // env mutation is exclusively visible to this process.
-    #[allow(unsafe_code)]
-    unsafe {
-        env::remove_var(VAPID_ENV_VAR);
+/// RAII guard: acquires `ENV_MUTATION_LOCK` and clears the env var; on
+/// drop (even via panic) the env var is cleared again so no test sees
+/// state left behind by a previous one.
+struct EnvGuard<'a> {
+    _lock: MutexGuard<'a, ()>,
+}
+
+impl<'a> EnvGuard<'a> {
+    async fn acquire() -> EnvGuard<'a> {
+        let lock = ENV_MUTATION_LOCK.lock().await;
+        // SAFETY: see vapid_storage.rs SAFETY note. The lock guarantees
+        // exclusive env access for the duration of this guard's lifetime.
+        unsafe {
+            env::remove_var(VAPID_ENV_VAR);
+        }
+        EnvGuard { _lock: lock }
+    }
+
+    fn set(&self, value: &str) {
+        // SAFETY: same as above.
+        unsafe {
+            env::set_var(VAPID_ENV_VAR, value);
+        }
+    }
+}
+
+impl Drop for EnvGuard<'_> {
+    fn drop(&mut self) {
+        // SAFETY: same as above; runs unconditionally so a panicking test
+        // does not leak env state into subsequent tests.
+        unsafe {
+            env::remove_var(VAPID_ENV_VAR);
+        }
     }
 }
 
 #[tokio::test]
 async fn fresh_boot_generates_and_persists_keypair() {
-    let _guard = ENV_MUTATION_LOCK.lock().await;
-    ensure_env_unset();
+    let _guard = EnvGuard::acquire().await;
     let db = fresh_db("vapid-fresh-generate").await;
 
     let signer = VapidStorage::load_or_provision(db.clone(), ROOT_KEY)
@@ -80,14 +104,10 @@ async fn fresh_boot_generates_and_persists_keypair() {
 
 #[tokio::test]
 async fn env_var_bootstrap_writes_before_remove() {
-    let _guard = ENV_MUTATION_LOCK.lock().await;
-    ensure_env_unset();
+    let guard = EnvGuard::acquire().await;
     let scalar = [0xAEu8; 32];
     let encoded = b64u(&scalar);
-    #[allow(unsafe_code)]
-    unsafe {
-        env::set_var(VAPID_ENV_VAR, &encoded);
-    }
+    guard.set(&encoded);
 
     let db = fresh_db("vapid-env-bootstrap").await;
 
@@ -132,12 +152,8 @@ async fn env_var_bootstrap_writes_before_remove() {
 
 #[tokio::test]
 async fn env_var_malformed_does_not_brick_boot_silently() {
-    let _guard = ENV_MUTATION_LOCK.lock().await;
-    ensure_env_unset();
-    #[allow(unsafe_code)]
-    unsafe {
-        env::set_var(VAPID_ENV_VAR, "not-base64url-and-also-wrong-length");
-    }
+    let guard = EnvGuard::acquire().await;
+    guard.set("not-base64url-and-also-wrong-length");
 
     let db = fresh_db("vapid-env-malformed").await;
     let result = VapidStorage::load_or_provision(db, ROOT_KEY).await;
@@ -148,13 +164,12 @@ async fn env_var_malformed_does_not_brick_boot_silently() {
         env::var(VAPID_ENV_VAR).is_ok(),
         "env var must NOT be removed on parse error"
     );
-    ensure_env_unset();
+    // EnvGuard's Drop cleans up.
 }
 
 #[tokio::test]
 async fn sign_and_verify_round_trip_under_loaded_key() {
-    let _guard = ENV_MUTATION_LOCK.lock().await;
-    ensure_env_unset();
+    let _guard = EnvGuard::acquire().await;
     let db = fresh_db("vapid-sign-verify").await;
 
     let signer = VapidStorage::load_or_provision(db, ROOT_KEY)

--- a/server/crates/waddle-server/tests/xep0357_push_notifications.rs
+++ b/server/crates/waddle-server/tests/xep0357_push_notifications.rs
@@ -1,0 +1,185 @@
+//! XEP-0357 / Web Push lifecycle integration tests for the
+//! `waddle-server` side of PR-D1.
+//!
+//! Unit tests for the sealing primitives + env-var parsing live in
+//! `src/push_service/vapid_storage.rs`. This file exercises the
+//! `VapidStorage::load_or_provision` boot path end-to-end against an
+//! in-memory database — fresh generation, persisted reuse, env-var
+//! bootstrap with write-before-remove, and the AAD-kid stability
+//! guarantee that a sealed blob is still openable after the row's
+//! autoincrement `id` is renumbered (DB-restore resilience).
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use p256::elliptic_curve::sec1::ToEncodedPoint;
+use std::env;
+use tokio::sync::Mutex;
+use waddle_server::db::Database;
+use waddle_server::push_service::vapid_storage::VapidStorage;
+use waddle_xmpp::push::vapid::VapidSigner;
+
+/// Serializes tests that mutate `WADDLE_VAPID_PRIVATE_KEY`. The env is
+/// process-global; cargo runs tests in parallel by default. We use
+/// `tokio::sync::Mutex` so the guard can be held across the `.await`s
+/// inside `load_or_provision` without triggering `await_holding_lock`.
+static ENV_MUTATION_LOCK: Mutex<()> = Mutex::const_new(());
+
+const ROOT_KEY: &[u8] = b"vapid-test-root-key-32-bytes-min";
+const VAPID_ENV_VAR: &str = "WADDLE_VAPID_PRIVATE_KEY";
+
+async fn fresh_db(name: &str) -> Database {
+    Database::in_memory(name).await.expect("fresh in-memory db")
+}
+
+fn b64u(bytes: &[u8]) -> String {
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// Helper: clear the env var so a previous test's leak doesn't bleed in.
+fn ensure_env_unset() {
+    // SAFETY: tests run single-threaded inside one test binary; the global
+    // env mutation is exclusively visible to this process.
+    #[allow(unsafe_code)]
+    unsafe {
+        env::remove_var(VAPID_ENV_VAR);
+    }
+}
+
+#[tokio::test]
+async fn fresh_boot_generates_and_persists_keypair() {
+    let _guard = ENV_MUTATION_LOCK.lock().await;
+    ensure_env_unset();
+    let db = fresh_db("vapid-fresh-generate").await;
+
+    let signer = VapidStorage::load_or_provision(db.clone(), ROOT_KEY)
+        .await
+        .expect("provisions on fresh DB");
+
+    // A kid was generated.
+    let kid = signer.current_kid();
+    let pk_bytes = signer
+        .current_public_key()
+        .to_encoded_point(false)
+        .as_bytes()
+        .to_vec();
+    assert_eq!(pk_bytes.len(), 65);
+    assert_eq!(pk_bytes[0], 0x04);
+
+    // Second boot reuses the same kid (loaded from DB, not regenerated).
+    let signer2 = VapidStorage::load_or_provision(db, ROOT_KEY)
+        .await
+        .expect("reloads from DB");
+    assert_eq!(signer2.current_kid(), kid);
+    let pk_bytes2 = signer2
+        .current_public_key()
+        .to_encoded_point(false)
+        .as_bytes()
+        .to_vec();
+    assert_eq!(pk_bytes2, pk_bytes);
+}
+
+#[tokio::test]
+async fn env_var_bootstrap_writes_before_remove() {
+    let _guard = ENV_MUTATION_LOCK.lock().await;
+    ensure_env_unset();
+    let scalar = [0xAEu8; 32];
+    let encoded = b64u(&scalar);
+    #[allow(unsafe_code)]
+    unsafe {
+        env::set_var(VAPID_ENV_VAR, &encoded);
+    }
+
+    let db = fresh_db("vapid-env-bootstrap").await;
+
+    let signer = VapidStorage::load_or_provision(db.clone(), ROOT_KEY)
+        .await
+        .expect("env-bootstrap path provisions");
+    let kid = signer.current_kid();
+
+    // The env var MUST be unset after a successful bootstrap.
+    assert!(
+        env::var(VAPID_ENV_VAR).is_err(),
+        "WADDLE_VAPID_PRIVATE_KEY must be removed from process env after DB write"
+    );
+
+    // Second boot (env unset, no env path) loads the same kid from DB —
+    // proves the env-supplied key was actually persisted before the env was
+    // cleared.
+    let signer2 = VapidStorage::load_or_provision(db, ROOT_KEY)
+        .await
+        .expect("reload");
+    assert_eq!(
+        signer2.current_kid(),
+        kid,
+        "env-supplied key survived to the next boot via the DB"
+    );
+
+    // Verify the persisted public key matches what the env-supplied scalar
+    // produces.
+    let expected_pk = p256::SecretKey::from_slice(&scalar)
+        .expect("env scalar")
+        .public_key()
+        .to_encoded_point(false)
+        .as_bytes()
+        .to_vec();
+    let got_pk = signer2
+        .current_public_key()
+        .to_encoded_point(false)
+        .as_bytes()
+        .to_vec();
+    assert_eq!(got_pk, expected_pk);
+}
+
+#[tokio::test]
+async fn env_var_malformed_does_not_brick_boot_silently() {
+    let _guard = ENV_MUTATION_LOCK.lock().await;
+    ensure_env_unset();
+    #[allow(unsafe_code)]
+    unsafe {
+        env::set_var(VAPID_ENV_VAR, "not-base64url-and-also-wrong-length");
+    }
+
+    let db = fresh_db("vapid-env-malformed").await;
+    let result = VapidStorage::load_or_provision(db, ROOT_KEY).await;
+    assert!(result.is_err(), "malformed env scalar must surface as Err");
+    // Env var must still be set so the operator can fix and retry —
+    // write-before-remove ordering protects against silent key loss.
+    assert!(
+        env::var(VAPID_ENV_VAR).is_ok(),
+        "env var must NOT be removed on parse error"
+    );
+    ensure_env_unset();
+}
+
+#[tokio::test]
+async fn sign_and_verify_round_trip_under_loaded_key() {
+    let _guard = ENV_MUTATION_LOCK.lock().await;
+    ensure_env_unset();
+    let db = fresh_db("vapid-sign-verify").await;
+
+    let signer = VapidStorage::load_or_provision(db, ROOT_KEY)
+        .await
+        .expect("provisions");
+
+    use url::Url;
+    use waddle_xmpp::push::types::VapidSub;
+    use waddle_xmpp::push::vapid::aud_for;
+    let endpoint = Url::parse("https://fcm.googleapis.com/fcm/send/abc").unwrap();
+    let aud = aud_for(&endpoint).expect("valid endpoint");
+    let sub = VapidSub::default_for_domain("example.com").unwrap();
+    let jwt = signer.sign(&aud, &sub).expect("sign");
+
+    // Verify the JWT validates under the signer's own public key — proves
+    // the persisted-and-loaded private key actually signs correctly.
+    use p256::pkcs8::EncodePublicKey;
+    let pk_pem = signer
+        .current_public_key()
+        .to_public_key_pem(Default::default())
+        .expect("public-key PEM");
+    let decoding_key =
+        jsonwebtoken::DecodingKey::from_ec_pem(pk_pem.as_bytes()).expect("decoding key");
+    let mut validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::ES256);
+    validation.set_audience(&["https://fcm.googleapis.com"]);
+    let _ = jsonwebtoken::decode::<serde_json::Value>(jwt.as_str(), &decoding_key, &validation)
+        .expect("JWT verifies under loaded public key");
+}

--- a/server/crates/waddle-xmpp/Cargo.toml
+++ b/server/crates/waddle-xmpp/Cargo.toml
@@ -60,6 +60,14 @@ hmac = { workspace = true }
 rand = { workspace = true }
 pbkdf2 = { version = "0.13", features = ["hmac"] }
 
+# Web Push crypto (RFC 8291 aes128gcm + RFC 8292 VAPID JWT signing)
+aes-gcm = { workspace = true }
+hkdf = { workspace = true }
+p256 = { workspace = true }
+elliptic-curve = { workspace = true }
+jsonwebtoken = { workspace = true }
+zeroize = { workspace = true }
+
 # HTTP client (for Web Push notifications)
 reqwest = { workspace = true }
 

--- a/server/crates/waddle-xmpp/src/push/constants.rs
+++ b/server/crates/waddle-xmpp/src/push/constants.rs
@@ -5,9 +5,28 @@
 
 use std::time::Duration;
 
+/// RFC 8188 §2.1 salt length: 16 bytes.
+pub const AES128GCM_SALT_LEN: usize = 16;
+
+/// RFC 8188 §2.1 `rs` field length: u32 in network byte order.
+pub const AES128GCM_RS_LEN: usize = 4;
+
+/// RFC 8188 §2.1 `idlen` field length: u8 indicating keyid byte length.
+pub const AES128GCM_IDLEN_FIELD_LEN: usize = 1;
+
+/// Uncompressed P-256 SEC1 point length: `0x04` prefix + 32-byte X + 32-byte Y.
+pub const P256_UNCOMPRESSED_POINT_LEN: usize = 65;
+
+/// SEC1 uncompressed-point prefix byte.
+pub const P256_UNCOMPRESSED_POINT_PREFIX: u8 = 0x04;
+
+/// RFC 8188 §2.1 last-record padding delimiter byte.
+pub const AES128GCM_LAST_RECORD_DELIM: u8 = 0x02;
+
 /// RFC 8188 §2.1 header length for a Web Push payload:
-/// 16-byte salt + 4-byte rs + 1-byte idlen + 65-byte uncompressed P-256 keyid.
-pub const AES128GCM_HEADER_LEN: usize = 86;
+/// salt + rs + idlen + uncompressed P-256 keyid.
+pub const AES128GCM_HEADER_LEN: usize =
+    AES128GCM_SALT_LEN + AES128GCM_RS_LEN + AES128GCM_IDLEN_FIELD_LEN + P256_UNCOMPRESSED_POINT_LEN;
 
 /// AES-GCM authentication tag length (RFC 5116 §5.1).
 pub const AES128GCM_TAG_LEN: usize = 16;

--- a/server/crates/waddle-xmpp/src/push/constants.rs
+++ b/server/crates/waddle-xmpp/src/push/constants.rs
@@ -1,0 +1,123 @@
+//! Wire constants for RFC 8030, RFC 8188, RFC 8291, RFC 8292.
+//!
+//! Centralized so the `rs`-field round-trip test asserts against named
+//! values instead of inline literals.
+
+use std::time::Duration;
+
+/// RFC 8188 §2.1 header length for a Web Push payload:
+/// 16-byte salt + 4-byte rs + 1-byte idlen + 65-byte uncompressed P-256 keyid.
+pub const AES128GCM_HEADER_LEN: usize = 86;
+
+/// AES-GCM authentication tag length (RFC 5116 §5.1).
+pub const AES128GCM_TAG_LEN: usize = 16;
+
+/// RFC 8188 §2.1 padding delimiter byte (`0x02` for the last record).
+pub const AES128GCM_PAD_DELIMITER_LEN: usize = 1;
+
+/// Conservative cap on the encrypted body sent to the browser push service.
+/// FCM documents a 4KB Web Push message limit; Mozilla autopush and Apple
+/// web push are equal or more permissive. We cap conservatively at 4096 and
+/// surface any vendor's stricter rejection as `WebPushOutcome::PayloadTooLarge`.
+pub const WEB_PUSH_MAX_BODY_LEN: usize = 4096;
+
+/// RFC 8188 `rs` field — **per-record max size** = plaintext + padding + delimiter + AES-GCM tag.
+/// NOT the body length. `body = AES128GCM_HEADER_LEN + actual_record_len ≤ WEB_PUSH_MAX_BODY_LEN`.
+pub const WEB_PUSH_MAX_RS: u32 = (WEB_PUSH_MAX_BODY_LEN - AES128GCM_HEADER_LEN) as u32;
+
+/// Maximum plaintext + zero-padding (RFC 8188 §2.1): `rs − tag − delimiter`.
+pub const WEB_PUSH_MAX_PLAINTEXT: usize =
+    WEB_PUSH_MAX_RS as usize - AES128GCM_TAG_LEN - AES128GCM_PAD_DELIMITER_LEN;
+
+/// HKDF PRK length (SHA-256 output, RFC 5869 §2.3).
+pub const HKDF_PRK_LEN: usize = 32;
+
+/// AES-128 key length (RFC 8291 §3.4 CEK).
+pub const HKDF_CEK_LEN: usize = 16;
+
+/// AES-GCM nonce length (RFC 8291 §3.4 / RFC 5116 §5.1).
+pub const HKDF_NONCE_LEN: usize = 12;
+
+/// VAPID JWT clock-skew tolerance for `ClockSkew` classification: 5 minutes.
+/// On 401/403, if `now() − jwt.iat() < CLOCK_SKEW_THRESHOLD` we classify as
+/// `WebPushOutcome::ClockSkew` rather than `SubscriptionGone`.
+pub const CLOCK_SKEW_THRESHOLD: Duration = Duration::from_secs(5 * 60);
+
+/// VAPID JWT `iat` lag — sign with `iat = now − IAT_LAG` to absorb minor
+/// clock-skew without rejection.
+pub const IAT_LAG: Duration = Duration::from_secs(30);
+
+/// VAPID JWT lifetime — `exp = iat + VAPID_JWT_LIFETIME`.
+/// RFC 8292 §2 mandates ≤ 24h; we use 12h to leave headroom for the
+/// 11h cache reuse window.
+pub const VAPID_JWT_LIFETIME: Duration = Duration::from_secs(12 * 60 * 60);
+
+/// Eviction-before-expiry margin for the JWT cache: drop cached JWTs
+/// when `now() + CACHE_EVICT_MARGIN >= exp`.
+pub const CACHE_EVICT_MARGIN: Duration = Duration::from_secs(60 * 60);
+
+/// LRU JWT cache max capacity. The legitimate browser-push origin set is
+/// small (~3 — FCM, Mozilla autopush, Apple); 32 accommodates multi-`kid`
+/// rotation windows and unknown origins without growing unbounded.
+pub const VAPID_JWT_CACHE_CAPACITY: usize = 32;
+
+/// HKDF `info` string for the IKM combine step (RFC 8291 §3.4).
+/// Format: `"WebPush: info\0" || ua_public || as_public`.
+pub const WEBPUSH_INFO_PREFIX: &[u8] = b"WebPush: info\0";
+
+/// HKDF `info` string for the CEK derivation (RFC 8188 §2.2).
+pub const AES128GCM_KEY_INFO: &[u8] = b"Content-Encoding: aes128gcm\0";
+
+/// HKDF `info` string for the nonce derivation (RFC 8188 §2.2).
+pub const AES128GCM_NONCE_INFO: &[u8] = b"Content-Encoding: nonce\0";
+
+/// Padding bucket for `DirectMessage` / `DirectMessageMention` classes.
+/// Larger bucket covers >P95 of empirical chat-message body lengths while
+/// keeping ciphertext well under 1200 bytes — reduces cadence leakage.
+pub const DM_PLAINTEXT_BUCKET: usize = 1024;
+
+/// Padding bucket for non-DM classes.
+pub const DEFAULT_PLAINTEXT_BUCKET: usize = 256;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn header_size_matches_rfc_8188_serialization() {
+        // 16 salt + 4 rs + 1 idlen + 65 raw P-256 keyid = 86
+        assert_eq!(AES128GCM_HEADER_LEN, 16 + 4 + 1 + 65);
+    }
+
+    #[test]
+    fn rs_plus_header_equals_body_cap() {
+        assert_eq!(
+            AES128GCM_HEADER_LEN + WEB_PUSH_MAX_RS as usize,
+            WEB_PUSH_MAX_BODY_LEN
+        );
+    }
+
+    #[test]
+    fn plaintext_cap_accounts_for_tag_and_delimiter() {
+        assert_eq!(
+            WEB_PUSH_MAX_PLAINTEXT,
+            WEB_PUSH_MAX_RS as usize - AES128GCM_TAG_LEN - AES128GCM_PAD_DELIMITER_LEN
+        );
+        assert_eq!(WEB_PUSH_MAX_PLAINTEXT, 3993);
+    }
+
+    #[test]
+    fn cache_window_invariant_holds() {
+        // Cache must evict before exp, and exp must be within RFC 8292 §2's
+        // 24h cap.
+        assert!(CACHE_EVICT_MARGIN < VAPID_JWT_LIFETIME);
+        assert!(VAPID_JWT_LIFETIME + IAT_LAG <= Duration::from_secs(24 * 60 * 60));
+    }
+
+    #[test]
+    fn hkdf_info_strings_end_in_nul() {
+        assert_eq!(*WEBPUSH_INFO_PREFIX.last().unwrap(), 0u8);
+        assert_eq!(*AES128GCM_KEY_INFO.last().unwrap(), 0u8);
+        assert_eq!(*AES128GCM_NONCE_INFO.last().unwrap(), 0u8);
+    }
+}

--- a/server/crates/waddle-xmpp/src/push/encrypt.rs
+++ b/server/crates/waddle-xmpp/src/push/encrypt.rs
@@ -1,0 +1,293 @@
+//! RFC 8291 `aes128gcm` content encoding for Web Push.
+//!
+//! Hand-rolled on workspace primitives (`aes-gcm`, `hkdf`, `p256`,
+//! `sha2`). All wire constants come from [`super::constants`]; inline
+//! literals are forbidden.
+//!
+//! ## Invariants
+//!
+//! - **Nonce** MUST be HKDF-derived per RFC 8188 §2.2 (`info =
+//!   "Content-Encoding: nonce\0"`), never random.
+//! - **Ephemeral ECDH keypair** is fresh per `encrypt()` call, never
+//!   stored, zeroized on drop.
+//! - **Padding** is `plaintext || 0x02 || 0x00*` inside the single
+//!   AES-GCM record, before encryption. Delimiter is `0x02` (last record).
+//! - **`rs`** is the per-record max size = plaintext + padding + delimiter + AES-GCM tag.
+//!   Body on wire = `AES128GCM_HEADER_LEN + actual_record_len ≤ WEB_PUSH_MAX_BODY_LEN`.
+
+use aes_gcm::aead::{Aead, KeyInit, Payload};
+use aes_gcm::Aes128Gcm;
+use hkdf::Hkdf;
+use p256::ecdh::EphemeralSecret;
+use p256::elliptic_curve::rand_core::OsRng;
+use p256::elliptic_curve::sec1::ToEncodedPoint;
+use rand::RngExt;
+use sha2::Sha256;
+use zeroize::Zeroizing;
+
+use super::constants::{
+    AES128GCM_HEADER_LEN, AES128GCM_KEY_INFO, AES128GCM_NONCE_INFO, AES128GCM_PAD_DELIMITER_LEN,
+    AES128GCM_TAG_LEN, HKDF_CEK_LEN, HKDF_NONCE_LEN, HKDF_PRK_LEN, WEBPUSH_INFO_PREFIX,
+    WEB_PUSH_MAX_PLAINTEXT,
+};
+use super::types::{EncryptedPayload, SubscriptionKeys, WebPushCryptoError};
+
+/// Encrypt `plaintext` for a Web Push `subscription`.
+///
+/// `bucket_size` is the plaintext + zero-padding length BEFORE the
+/// delimiter byte is appended (so the record on the wire is
+/// `bucket_size + 1 (delim) + 16 (tag)` bytes). Pass
+/// [`super::constants::DM_PLAINTEXT_BUCKET`] for `DirectMessage*`,
+/// [`super::constants::DEFAULT_PLAINTEXT_BUCKET`] otherwise.
+///
+/// `bucket_size` MUST be ≥ `plaintext.len()` and the resulting body
+/// MUST NOT exceed [`super::constants::WEB_PUSH_MAX_BODY_LEN`].
+pub fn encrypt(
+    subscription: &SubscriptionKeys,
+    plaintext: &[u8],
+    bucket_size: usize,
+) -> Result<EncryptedPayload, WebPushCryptoError> {
+    if plaintext.len() > bucket_size {
+        return Err(WebPushCryptoError::PayloadTooLarge {
+            plaintext_len: plaintext.len(),
+            limit: bucket_size,
+        });
+    }
+    if bucket_size > WEB_PUSH_MAX_PLAINTEXT {
+        return Err(WebPushCryptoError::PayloadTooLarge {
+            plaintext_len: bucket_size,
+            limit: WEB_PUSH_MAX_PLAINTEXT,
+        });
+    }
+
+    // 1. Fresh ephemeral AS keypair (RFC 8291 §3.1). `EphemeralSecret` zeroes
+    //    on drop; never stored, never copied.
+    let as_secret = EphemeralSecret::random(&mut OsRng);
+    let as_public = as_secret.public_key();
+    let as_public_uncompressed = as_public.to_encoded_point(false);
+    let as_public_bytes = as_public_uncompressed.as_bytes();
+    debug_assert_eq!(
+        as_public_bytes.len(),
+        65,
+        "P-256 uncompressed point must be 65 bytes"
+    );
+
+    let ua_public_uncompressed = subscription.p256dh.to_encoded_point(false);
+    let ua_public_bytes = ua_public_uncompressed.as_bytes();
+    debug_assert_eq!(
+        ua_public_bytes.len(),
+        65,
+        "subscription p256dh must be 65 bytes"
+    );
+
+    // 2. ECDH(as_secret, ua_public). `SharedSecret` is zeroized on drop.
+    let shared = as_secret.diffie_hellman(&subscription.p256dh);
+    let dh = shared.raw_secret_bytes();
+
+    // 3. PRK_key = HKDF-Extract(salt=auth_secret, ikm=dh)
+    //    IKM = HKDF-Expand(PRK_key, "WebPush: info\0" || ua_public || as_public, HKDF_PRK_LEN)
+    let prk_key = Hkdf::<Sha256>::new(Some(subscription.auth.as_bytes()), dh);
+    let mut key_info = Vec::with_capacity(WEBPUSH_INFO_PREFIX.len() + 65 + 65);
+    key_info.extend_from_slice(WEBPUSH_INFO_PREFIX);
+    key_info.extend_from_slice(ua_public_bytes);
+    key_info.extend_from_slice(as_public_bytes);
+    let mut ikm = Zeroizing::new([0u8; HKDF_PRK_LEN]);
+    prk_key
+        .expand(&key_info, ikm.as_mut())
+        .map_err(|_| WebPushCryptoError::HkdfFailed)?;
+
+    // 4. Random 16-byte salt
+    let mut salt = [0u8; 16];
+    rand::rng().fill(&mut salt[..]);
+
+    // 5. PRK = HKDF-Extract(salt=salt, ikm=IKM)
+    let prk = Hkdf::<Sha256>::new(Some(&salt), ikm.as_ref());
+
+    // 6. CEK = HKDF-Expand(PRK, "Content-Encoding: aes128gcm\0", HKDF_CEK_LEN)
+    let mut cek = Zeroizing::new([0u8; HKDF_CEK_LEN]);
+    prk.expand(AES128GCM_KEY_INFO, cek.as_mut())
+        .map_err(|_| WebPushCryptoError::HkdfFailed)?;
+
+    // 7. Nonce = HKDF-Expand(PRK, "Content-Encoding: nonce\0", HKDF_NONCE_LEN)
+    //    Sequence number XOR is identity since we emit exactly one record (seq=0).
+    let mut nonce_bytes = [0u8; HKDF_NONCE_LEN];
+    prk.expand(AES128GCM_NONCE_INFO, &mut nonce_bytes)
+        .map_err(|_| WebPushCryptoError::HkdfFailed)?;
+
+    // 8. Pad plaintext: plaintext || 0x02 || 0x00*(bucket_size - plaintext.len())
+    //    The plaintext-side total after padding = bucket_size + 1 (delimiter).
+    let mut record_plaintext = Vec::with_capacity(bucket_size + AES128GCM_PAD_DELIMITER_LEN);
+    record_plaintext.extend_from_slice(plaintext);
+    record_plaintext.push(0x02); // last-record delimiter
+    record_plaintext.resize(
+        bucket_size + AES128GCM_PAD_DELIMITER_LEN,
+        // Actually wait — RFC 8188 §2.1 says padding zeros come BEFORE the
+        // delimiter, not after. Let me re-read.
+        0x00,
+    );
+
+    // RFC 8188 §2.1 padding format (corrected):
+    //   data = plaintext || 0x02 || 0x00*pad   (for the last/only record)
+    //   so the delimiter goes RIGHT AFTER plaintext, then the zero padding.
+    // The code above already does that — `extend_from_slice(plaintext)`,
+    // `push(0x02)`, then `resize(..., 0)` fills the remaining bucket bytes
+    // with zeros, which sit AFTER the delimiter. Re-reading RFC 8188 §2.1
+    // confirms: data = plaintext || pad_delim || zero_pad. The delimiter
+    // separates plaintext from zero padding.
+
+    // 9. Encrypt: ciphertext = AES-128-GCM(key=CEK, nonce=nonce, plaintext+pad)
+    let cipher =
+        Aes128Gcm::new_from_slice(cek.as_ref()).map_err(|_| WebPushCryptoError::EncryptFailed)?;
+    let ciphertext = cipher
+        .encrypt(
+            (&nonce_bytes).into(),
+            Payload {
+                msg: &record_plaintext,
+                aad: &[],
+            },
+        )
+        .map_err(|_| WebPushCryptoError::EncryptFailed)?;
+
+    // 10. Assemble header: salt(16) || rs(4 BE) || idlen(1) || keyid(65)
+    //     `rs` is the per-record max size (plaintext+pad+delim+tag).
+    let record_len = ciphertext.len(); // = bucket_size + delim + tag
+    debug_assert_eq!(
+        record_len,
+        bucket_size + AES128GCM_PAD_DELIMITER_LEN + AES128GCM_TAG_LEN
+    );
+    let rs: u32 = record_len as u32;
+
+    let mut body = Vec::with_capacity(AES128GCM_HEADER_LEN + ciphertext.len());
+    body.extend_from_slice(&salt);
+    body.extend_from_slice(&rs.to_be_bytes());
+    body.push(as_public_bytes.len() as u8); // idlen
+    body.extend_from_slice(as_public_bytes); // keyid (= as_public)
+    body.extend_from_slice(&ciphertext);
+
+    debug_assert_eq!(
+        body.len(),
+        AES128GCM_HEADER_LEN + record_len,
+        "body shape: {} header + {} record",
+        AES128GCM_HEADER_LEN,
+        record_len
+    );
+
+    Ok(EncryptedPayload(body))
+}
+
+/// Decode the `rs` u32 field from an RFC 8188 header. Test-helper.
+pub fn header_rs(body: &[u8]) -> Option<u32> {
+    if body.len() < AES128GCM_HEADER_LEN {
+        return None;
+    }
+    let mut rs_bytes = [0u8; 4];
+    rs_bytes.copy_from_slice(&body[16..20]);
+    Some(u32::from_be_bytes(rs_bytes))
+}
+
+/// Decode the `keyid` (= AS public key) from an RFC 8188 header. Test-helper.
+pub fn header_keyid(body: &[u8]) -> Option<&[u8]> {
+    if body.len() < AES128GCM_HEADER_LEN {
+        return None;
+    }
+    let idlen = body[20] as usize;
+    if body.len() < 21 + idlen {
+        return None;
+    }
+    Some(&body[21..21 + idlen])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::constants::{
+        DEFAULT_PLAINTEXT_BUCKET, DM_PLAINTEXT_BUCKET, WEB_PUSH_MAX_BODY_LEN,
+    };
+    use super::*;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use base64::Engine as _;
+
+    fn sample_subscription() -> SubscriptionKeys {
+        let secret = p256::SecretKey::random(&mut OsRng);
+        let pk = secret.public_key().to_encoded_point(false);
+        let p256dh = URL_SAFE_NO_PAD.encode(pk.as_bytes());
+        let auth = URL_SAFE_NO_PAD.encode([0xAAu8; 16]);
+        SubscriptionKeys::from_base64url(&p256dh, &auth).expect("valid")
+    }
+
+    #[test]
+    fn encrypt_produces_well_formed_header() {
+        let sub = sample_subscription();
+        let payload = encrypt(&sub, b"hello", DEFAULT_PLAINTEXT_BUCKET).expect("encrypts");
+        let body = payload.as_slice();
+        assert!(body.len() > AES128GCM_HEADER_LEN);
+        let rs = header_rs(body).expect("rs");
+        let keyid = header_keyid(body).expect("keyid");
+        assert_eq!(keyid.len(), 65);
+        assert_eq!(keyid[0], 0x04);
+        // rs equals the actual record length emitted = bucket + delim + tag
+        assert_eq!(
+            rs as usize,
+            DEFAULT_PLAINTEXT_BUCKET + AES128GCM_PAD_DELIMITER_LEN + AES128GCM_TAG_LEN
+        );
+    }
+
+    #[test]
+    fn body_length_is_deterministic_per_bucket() {
+        let sub = sample_subscription();
+        let short = encrypt(&sub, b"hi", DEFAULT_PLAINTEXT_BUCKET).expect("ok");
+        let long = encrypt(&sub, &[0u8; 200], DEFAULT_PLAINTEXT_BUCKET).expect("ok");
+        // Same bucket → same body length on the wire.
+        assert_eq!(short.as_slice().len(), long.as_slice().len());
+    }
+
+    #[test]
+    fn dm_bucket_size_is_larger_than_default() {
+        let sub = sample_subscription();
+        let dm = encrypt(&sub, b"x", DM_PLAINTEXT_BUCKET).expect("ok");
+        let default = encrypt(&sub, b"x", DEFAULT_PLAINTEXT_BUCKET).expect("ok");
+        assert!(dm.as_slice().len() > default.as_slice().len());
+    }
+
+    #[test]
+    fn body_fits_under_web_push_max_body() {
+        let sub = sample_subscription();
+        let dm = encrypt(&sub, &vec![0u8; DM_PLAINTEXT_BUCKET], DM_PLAINTEXT_BUCKET).expect("ok");
+        assert!(dm.as_slice().len() <= WEB_PUSH_MAX_BODY_LEN);
+    }
+
+    #[test]
+    fn ephemeral_keypair_changes_per_call() {
+        let sub = sample_subscription();
+        let a = encrypt(&sub, b"same", DEFAULT_PLAINTEXT_BUCKET).expect("ok");
+        let b = encrypt(&sub, b"same", DEFAULT_PLAINTEXT_BUCKET).expect("ok");
+        // Same plaintext, same subscription — different ephemeral key → different keyid in header.
+        let ka = header_keyid(a.as_slice()).expect("keyid a");
+        let kb = header_keyid(b.as_slice()).expect("keyid b");
+        assert_ne!(ka, kb, "ephemeral key must vary across encrypt() calls");
+    }
+
+    #[test]
+    fn salt_changes_per_call() {
+        let sub = sample_subscription();
+        let a = encrypt(&sub, b"same", DEFAULT_PLAINTEXT_BUCKET).expect("ok");
+        let b = encrypt(&sub, b"same", DEFAULT_PLAINTEXT_BUCKET).expect("ok");
+        let salt_a = &a.as_slice()[..16];
+        let salt_b = &b.as_slice()[..16];
+        assert_ne!(salt_a, salt_b, "salt must vary across encrypt() calls");
+    }
+
+    #[test]
+    fn rejects_plaintext_larger_than_bucket() {
+        let sub = sample_subscription();
+        let err = encrypt(&sub, &vec![0u8; 257], DEFAULT_PLAINTEXT_BUCKET).unwrap_err();
+        assert!(matches!(err, WebPushCryptoError::PayloadTooLarge { .. }));
+    }
+
+    #[test]
+    fn rejects_oversize_bucket() {
+        let sub = sample_subscription();
+        // Bucket larger than WEB_PUSH_MAX_PLAINTEXT is rejected even for empty plaintext.
+        let err = encrypt(&sub, b"", WEB_PUSH_MAX_PLAINTEXT + 1).unwrap_err();
+        assert!(matches!(err, WebPushCryptoError::PayloadTooLarge { .. }));
+    }
+}

--- a/server/crates/waddle-xmpp/src/push/encrypt.rs
+++ b/server/crates/waddle-xmpp/src/push/encrypt.rs
@@ -26,8 +26,9 @@ use sha2::Sha256;
 use zeroize::Zeroizing;
 
 use super::constants::{
-    AES128GCM_HEADER_LEN, AES128GCM_KEY_INFO, AES128GCM_NONCE_INFO, AES128GCM_PAD_DELIMITER_LEN,
-    AES128GCM_TAG_LEN, HKDF_CEK_LEN, HKDF_NONCE_LEN, HKDF_PRK_LEN, WEBPUSH_INFO_PREFIX,
+    AES128GCM_HEADER_LEN, AES128GCM_KEY_INFO, AES128GCM_LAST_RECORD_DELIM, AES128GCM_NONCE_INFO,
+    AES128GCM_PAD_DELIMITER_LEN, AES128GCM_SALT_LEN, AES128GCM_TAG_LEN, HKDF_CEK_LEN,
+    HKDF_NONCE_LEN, HKDF_PRK_LEN, P256_UNCOMPRESSED_POINT_LEN, WEBPUSH_INFO_PREFIX,
     WEB_PUSH_MAX_PLAINTEXT,
 };
 use super::types::{EncryptedPayload, SubscriptionKeys, WebPushCryptoError};
@@ -66,19 +67,11 @@ pub fn encrypt(
     let as_public = as_secret.public_key();
     let as_public_uncompressed = as_public.to_encoded_point(false);
     let as_public_bytes = as_public_uncompressed.as_bytes();
-    debug_assert_eq!(
-        as_public_bytes.len(),
-        65,
-        "P-256 uncompressed point must be 65 bytes"
-    );
+    debug_assert_eq!(as_public_bytes.len(), P256_UNCOMPRESSED_POINT_LEN);
 
     let ua_public_uncompressed = subscription.p256dh.to_encoded_point(false);
     let ua_public_bytes = ua_public_uncompressed.as_bytes();
-    debug_assert_eq!(
-        ua_public_bytes.len(),
-        65,
-        "subscription p256dh must be 65 bytes"
-    );
+    debug_assert_eq!(ua_public_bytes.len(), P256_UNCOMPRESSED_POINT_LEN);
 
     // 2. ECDH(as_secret, ua_public). `SharedSecret` is zeroized on drop.
     let shared = as_secret.diffie_hellman(&subscription.p256dh);
@@ -87,7 +80,8 @@ pub fn encrypt(
     // 3. PRK_key = HKDF-Extract(salt=auth_secret, ikm=dh)
     //    IKM = HKDF-Expand(PRK_key, "WebPush: info\0" || ua_public || as_public, HKDF_PRK_LEN)
     let prk_key = Hkdf::<Sha256>::new(Some(subscription.auth.as_bytes()), dh);
-    let mut key_info = Vec::with_capacity(WEBPUSH_INFO_PREFIX.len() + 65 + 65);
+    let mut key_info =
+        Vec::with_capacity(WEBPUSH_INFO_PREFIX.len() + 2 * P256_UNCOMPRESSED_POINT_LEN);
     key_info.extend_from_slice(WEBPUSH_INFO_PREFIX);
     key_info.extend_from_slice(ua_public_bytes);
     key_info.extend_from_slice(as_public_bytes);
@@ -96,8 +90,8 @@ pub fn encrypt(
         .expand(&key_info, ikm.as_mut())
         .map_err(|_| WebPushCryptoError::HkdfFailed)?;
 
-    // 4. Random 16-byte salt
-    let mut salt = [0u8; 16];
+    // 4. Random salt (RFC 8188 §2.1: 16 bytes).
+    let mut salt = [0u8; AES128GCM_SALT_LEN];
     rand::rng().fill(&mut salt[..]);
 
     // 5. PRK = HKDF-Extract(salt=salt, ikm=IKM)
@@ -126,7 +120,7 @@ pub fn encrypt(
         bucket_size + AES128GCM_PAD_DELIMITER_LEN,
     ));
     record_plaintext.extend_from_slice(plaintext);
-    record_plaintext.push(0x02);
+    record_plaintext.push(AES128GCM_LAST_RECORD_DELIM);
     record_plaintext.resize(bucket_size + AES128GCM_PAD_DELIMITER_LEN, 0x00);
 
     // 9. Encrypt: ciphertext = AES-128-GCM(key=CEK, nonce=nonce, plaintext+pad)
@@ -169,27 +163,11 @@ pub fn encrypt(
     Ok(EncryptedPayload::new(body))
 }
 
-/// Decode the `rs` u32 field from an RFC 8188 header. Test-helper.
-pub fn header_rs(body: &[u8]) -> Option<u32> {
-    if body.len() < AES128GCM_HEADER_LEN {
-        return None;
-    }
-    let mut rs_bytes = [0u8; 4];
-    rs_bytes.copy_from_slice(&body[16..20]);
-    Some(u32::from_be_bytes(rs_bytes))
-}
-
-/// Decode the `keyid` (= AS public key) from an RFC 8188 header. Test-helper.
-pub fn header_keyid(body: &[u8]) -> Option<&[u8]> {
-    if body.len() < AES128GCM_HEADER_LEN {
-        return None;
-    }
-    let idlen = body[20] as usize;
-    if body.len() < 21 + idlen {
-        return None;
-    }
-    Some(&body[21..21 + idlen])
-}
+// `header_rs` / `header_keyid` parsing helpers are intentionally NOT in
+// the public API surface — they're test-only and would otherwise become
+// implicit boundary types. Defined inside the inline `#[cfg(test)]` mod
+// below; tests that need them in other crates can re-implement the
+// parsing trivially against the named header-offset constants.
 
 #[cfg(test)]
 mod tests {
@@ -199,6 +177,121 @@ mod tests {
     use super::*;
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
     use base64::Engine as _;
+
+    fn header_rs(body: &[u8]) -> Option<u32> {
+        use super::super::constants::AES128GCM_RS_LEN;
+        if body.len() < AES128GCM_HEADER_LEN {
+            return None;
+        }
+        let rs_start = AES128GCM_SALT_LEN;
+        let rs_end = rs_start + AES128GCM_RS_LEN;
+        let mut rs_bytes = [0u8; AES128GCM_RS_LEN];
+        rs_bytes.copy_from_slice(&body[rs_start..rs_end]);
+        Some(u32::from_be_bytes(rs_bytes))
+    }
+
+    fn header_keyid(body: &[u8]) -> Option<&[u8]> {
+        use super::super::constants::{AES128GCM_IDLEN_FIELD_LEN, AES128GCM_RS_LEN};
+        if body.len() < AES128GCM_HEADER_LEN {
+            return None;
+        }
+        let idlen_offset = AES128GCM_SALT_LEN + AES128GCM_RS_LEN;
+        let keyid_offset = idlen_offset + AES128GCM_IDLEN_FIELD_LEN;
+        let idlen = body[idlen_offset] as usize;
+        if body.len() < keyid_offset + idlen {
+            return None;
+        }
+        Some(&body[keyid_offset..keyid_offset + idlen])
+    }
+
+    /// RFC 8291 §5 known-answer test: the spec's worked example pins every
+    /// input (UA private/public, AS private/public, auth secret, salt,
+    /// plaintext) and gives the expected ciphertext bytes. Asserting
+    /// against the published vector catches the entire class of
+    /// derivation bugs that an in-process round-trip cannot — e.g.,
+    /// swapping `ua_public` and `as_public` in the `key_info` vector.
+    ///
+    /// The `encrypt()` API derives the AS keypair and salt internally;
+    /// this KAT exercises the deterministic remainder of the pipeline
+    /// (CEK + nonce derivation, padding, AES-GCM seal) by reaching into
+    /// the same primitives directly. RFC 8291 §5:
+    ///
+    /// > as_private = yfWPiYE-n46HLnH0KqZOF1fJJU3MYrct3AELtAQ-oRw
+    /// > as_public  = BP4z9KsN6nGRTbVYI_c7VJSPQTBtkgcy27mlmlMoZIIgDll6e3vCYLocInmYWAmS6TlzAC8wEqKK6PBru3jl7A8
+    /// > auth_secret= BTBZMqHH6r4Tts7J_aSIgg
+    /// > salt       = DGv6ra1nlYgDCS1FRnbzlw
+    /// > plaintext  = "When I grow up, I want to be a watermelon"
+    ///
+    /// Note: this test pins the deterministic crypto math — it does not
+    /// re-execute `encrypt()` (which generates a fresh AS keypair + salt
+    /// every call). Catching swapped HKDF info concatenation is the
+    /// load-bearing assertion.
+    #[test]
+    fn rfc_8291_section_5_known_answer_vector() {
+        use p256::elliptic_curve::sec1::FromEncodedPoint;
+        use p256::EncodedPoint;
+        use sha2::Sha256;
+
+        let ua_public_b64 = "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4";
+        let auth_b64 = "BTBZMqHH6r4Tts7J_aSIgg";
+        let as_private_b64 = "yfWPiYE-n46HLnH0KqZOF1fJJU3MYrct3AELtAQ-oRw";
+        let as_public_b64 = "BP4z9KsN6nGRTbVYI_c7VJSPQTBtkgcy27mlmlMoZIIgDll6e3vCYLocInmYWAmS6TlzAC8wEqKK6PBru3jl7A8";
+        let salt_b64 = "DGv6ra1nlYgDCS1FRnbzlw";
+
+        let ua_public_bytes = URL_SAFE_NO_PAD.decode(ua_public_b64).unwrap();
+        let ua_pub_point = EncodedPoint::from_bytes(&ua_public_bytes).unwrap();
+        let ua_public = p256::PublicKey::from_encoded_point(&ua_pub_point).unwrap();
+        let auth = URL_SAFE_NO_PAD.decode(auth_b64).unwrap();
+        let as_private_scalar = URL_SAFE_NO_PAD.decode(as_private_b64).unwrap();
+        let as_private = p256::SecretKey::from_slice(&as_private_scalar).unwrap();
+        let as_public_bytes = URL_SAFE_NO_PAD.decode(as_public_b64).unwrap();
+        let salt = URL_SAFE_NO_PAD.decode(salt_b64).unwrap();
+
+        // Step 1: ECDH(as_private, ua_public).
+        let shared = elliptic_curve::ecdh::diffie_hellman(
+            as_private.to_nonzero_scalar(),
+            ua_public.as_affine(),
+        );
+        let dh = shared.raw_secret_bytes();
+
+        // Step 2: PRK_key = HKDF-Extract(auth_secret, dh); IKM = HKDF-Expand.
+        let prk_key = Hkdf::<Sha256>::new(Some(&auth), dh);
+        let mut key_info =
+            Vec::with_capacity(WEBPUSH_INFO_PREFIX.len() + 2 * P256_UNCOMPRESSED_POINT_LEN);
+        key_info.extend_from_slice(WEBPUSH_INFO_PREFIX);
+        key_info.extend_from_slice(&ua_public_bytes);
+        key_info.extend_from_slice(&as_public_bytes);
+        let mut ikm = [0u8; HKDF_PRK_LEN];
+        prk_key.expand(&key_info, &mut ikm).unwrap();
+
+        // Step 3: PRK = HKDF-Extract(salt, IKM); derive CEK and nonce.
+        let prk = Hkdf::<Sha256>::new(Some(&salt), &ikm);
+        let mut cek = [0u8; HKDF_CEK_LEN];
+        prk.expand(AES128GCM_KEY_INFO, &mut cek).unwrap();
+        let mut nonce = [0u8; HKDF_NONCE_LEN];
+        prk.expand(AES128GCM_NONCE_INFO, &mut nonce).unwrap();
+
+        // RFC 8291 §5 expected derived values (encoded base64url no-pad):
+        //   IKM = "S4lYMb_L0FxCIaNnIlrqRA"
+        //   PRK = "09_eUZGrsvxChDCGRCdkLQ" (hex: d3dfdef51..., truncated)
+        //   CEK = "oIhVW04MRdy2XN9CiKLxTg"
+        //   nonce = "4h_95klXJ5E_qnoN"
+        // We assert the CEK and nonce bytes — these are the load-bearing
+        // intermediates; if the HKDF info construction has `ua_public` and
+        // `as_public` swapped, both will be wrong.
+        let expected_cek = URL_SAFE_NO_PAD.decode("oIhVW04MRdy2XN9CiKLxTg").unwrap();
+        let expected_nonce = URL_SAFE_NO_PAD.decode("4h_95klXJ5E_qnoN").unwrap();
+        assert_eq!(
+            &cek[..],
+            &expected_cek[..],
+            "CEK mismatch — HKDF derivation drift"
+        );
+        assert_eq!(
+            &nonce[..],
+            &expected_nonce[..],
+            "nonce mismatch — HKDF derivation drift"
+        );
+    }
 
     fn sample_subscription() -> SubscriptionKeys {
         let secret = p256::SecretKey::random(&mut OsRng);

--- a/server/crates/waddle-xmpp/src/push/encrypt.rs
+++ b/server/crates/waddle-xmpp/src/push/encrypt.rs
@@ -116,7 +116,15 @@ pub fn encrypt(
 
     // 8. Pad plaintext per RFC 8188 §2.1: `plaintext || 0x02 || 0x00*`
     //    for the single/last record. Final length = `bucket_size + 1`.
-    let mut record_plaintext = Vec::with_capacity(bucket_size + AES128GCM_PAD_DELIMITER_LEN);
+    //
+    //    Wrapped in `Zeroizing` so the cleartext push body (chat message,
+    //    sender JID, etc.) zeroes out of heap when this scope ends. The
+    //    `with_capacity` matches the final length exactly, so no
+    //    reallocation occurs and no un-zeroized intermediate buffer is
+    //    freed to the allocator.
+    let mut record_plaintext = Zeroizing::new(Vec::with_capacity(
+        bucket_size + AES128GCM_PAD_DELIMITER_LEN,
+    ));
     record_plaintext.extend_from_slice(plaintext);
     record_plaintext.push(0x02);
     record_plaintext.resize(bucket_size + AES128GCM_PAD_DELIMITER_LEN, 0x00);
@@ -128,7 +136,7 @@ pub fn encrypt(
         .encrypt(
             (&nonce_bytes).into(),
             Payload {
-                msg: &record_plaintext,
+                msg: record_plaintext.as_slice(),
                 aad: &[],
             },
         )

--- a/server/crates/waddle-xmpp/src/push/encrypt.rs
+++ b/server/crates/waddle-xmpp/src/push/encrypt.rs
@@ -204,39 +204,47 @@ mod tests {
         Some(&body[keyid_offset..keyid_offset + idlen])
     }
 
-    /// RFC 8291 §5 known-answer test: the spec's worked example pins every
-    /// input (UA private/public, AS private/public, auth secret, salt,
-    /// plaintext) and gives the expected ciphertext bytes. Asserting
-    /// against the published vector catches the entire class of
-    /// derivation bugs that an in-process round-trip cannot — e.g.,
-    /// swapping `ua_public` and `as_public` in the `key_info` vector.
+    /// RFC 8291 §5 full known-answer test: the spec's worked example pins
+    /// every input (UA private/public, AS private/public, auth secret,
+    /// salt, plaintext) AND publishes the expected on-the-wire body
+    /// bytes. Asserts the entire deterministic pipeline end-to-end:
     ///
-    /// The `encrypt()` API derives the AS keypair and salt internally;
-    /// this KAT exercises the deterministic remainder of the pipeline
-    /// (CEK + nonce derivation, padding, AES-GCM seal) by reaching into
-    /// the same primitives directly. RFC 8291 §5:
+    ///   1. HKDF derivation produces the RFC's `IKM`, `CEK`, `nonce`.
+    ///   2. AES-128-GCM encrypt with the RFC's padded plaintext produces
+    ///      a ciphertext matching the RFC's published body, byte-for-byte.
+    ///   3. Header assembly (`salt || rs || idlen || as_public`) +
+    ///      ciphertext reproduces the full RFC body verbatim.
     ///
-    /// > as_private = yfWPiYE-n46HLnH0KqZOF1fJJU3MYrct3AELtAQ-oRw
-    /// > as_public  = BP4z9KsN6nGRTbVYI_c7VJSPQTBtkgcy27mlmlMoZIIgDll6e3vCYLocInmYWAmS6TlzAC8wEqKK6PBru3jl7A8
-    /// > auth_secret= BTBZMqHH6r4Tts7J_aSIgg
-    /// > salt       = DGv6ra1nlYgDCS1FRnbzlw
-    /// > plaintext  = "When I grow up, I want to be a watermelon"
+    /// Catches the entire class of derivation/serialization bugs that an
+    /// in-process round-trip cannot detect — e.g., `ua_public` /
+    /// `as_public` swapped in `key_info`, off-by-one padding, wrong
+    /// AES-GCM nonce or info string, or a header-field order mismatch.
     ///
-    /// Note: this test pins the deterministic crypto math — it does not
-    /// re-execute `encrypt()` (which generates a fresh AS keypair + salt
-    /// every call). Catching swapped HKDF info concatenation is the
-    /// load-bearing assertion.
+    /// `encrypt()` itself generates a fresh AS keypair and salt on every
+    /// call, so this KAT reaches into the same primitives directly with
+    /// the RFC-fixed inputs. The randomness paths are covered by
+    /// `salt_changes_per_call` / `ephemeral_keypair_changes_per_call`.
     #[test]
     fn rfc_8291_section_5_known_answer_vector() {
+        use super::super::constants::AES128GCM_RS_LEN;
         use p256::elliptic_curve::sec1::FromEncodedPoint;
         use p256::EncodedPoint;
         use sha2::Sha256;
 
+        // ---- RFC 8291 §5 inputs ------------------------------------------
         let ua_public_b64 = "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4";
         let auth_b64 = "BTBZMqHH6r4Tts7J_aSIgg";
         let as_private_b64 = "yfWPiYE-n46HLnH0KqZOF1fJJU3MYrct3AELtAQ-oRw";
         let as_public_b64 = "BP4z9KsN6nGRTbVYI_c7VJSPQTBtkgcy27mlmlMoZIIgDll6e3vCYLocInmYWAmS6TlzAC8wEqKK6PBru3jl7A8";
         let salt_b64 = "DGv6ra1nlYgDCS1FRnbzlw";
+        let plaintext = b"When I grow up, I want to be a watermelon";
+        // RFC 8291 §5 expected encrypted body — concatenation of the three
+        // lines as published in the RFC text.
+        let expected_body_b64 = concat!(
+            "DGv6ra1nlYgDCS1FRnbzlwAAEABBBP4z9KsN6nGRTbVYI_c7VJSPQTBtkgcy27ml",
+            "mlMoZIIgDll6e3vCYLocInmYWAmS6TlzAC8wEqKK6PBru3jl7A_yl95bQpu6cVPT",
+            "pK4Mqgkf1CXztLVBSt2Ks3oZwbuwXPXLWyouBWLVWGNWQexSgSxsj_Qulcy4a-fN",
+        );
 
         let ua_public_bytes = URL_SAFE_NO_PAD.decode(ua_public_b64).unwrap();
         let ua_pub_point = EncodedPoint::from_bytes(&ua_public_bytes).unwrap();
@@ -246,15 +254,15 @@ mod tests {
         let as_private = p256::SecretKey::from_slice(&as_private_scalar).unwrap();
         let as_public_bytes = URL_SAFE_NO_PAD.decode(as_public_b64).unwrap();
         let salt = URL_SAFE_NO_PAD.decode(salt_b64).unwrap();
+        let expected_body = URL_SAFE_NO_PAD.decode(expected_body_b64).unwrap();
 
-        // Step 1: ECDH(as_private, ua_public).
+        // ---- HKDF derivation ---------------------------------------------
         let shared = elliptic_curve::ecdh::diffie_hellman(
             as_private.to_nonzero_scalar(),
             ua_public.as_affine(),
         );
         let dh = shared.raw_secret_bytes();
 
-        // Step 2: PRK_key = HKDF-Extract(auth_secret, dh); IKM = HKDF-Expand.
         let prk_key = Hkdf::<Sha256>::new(Some(&auth), dh);
         let mut key_info =
             Vec::with_capacity(WEBPUSH_INFO_PREFIX.len() + 2 * P256_UNCOMPRESSED_POINT_LEN);
@@ -264,32 +272,57 @@ mod tests {
         let mut ikm = [0u8; HKDF_PRK_LEN];
         prk_key.expand(&key_info, &mut ikm).unwrap();
 
-        // Step 3: PRK = HKDF-Extract(salt, IKM); derive CEK and nonce.
         let prk = Hkdf::<Sha256>::new(Some(&salt), &ikm);
         let mut cek = [0u8; HKDF_CEK_LEN];
         prk.expand(AES128GCM_KEY_INFO, &mut cek).unwrap();
         let mut nonce = [0u8; HKDF_NONCE_LEN];
         prk.expand(AES128GCM_NONCE_INFO, &mut nonce).unwrap();
 
-        // RFC 8291 §5 expected derived values (encoded base64url no-pad):
-        //   IKM = "S4lYMb_L0FxCIaNnIlrqRA"
-        //   PRK = "09_eUZGrsvxChDCGRCdkLQ" (hex: d3dfdef51..., truncated)
-        //   CEK = "oIhVW04MRdy2XN9CiKLxTg"
-        //   nonce = "4h_95klXJ5E_qnoN"
-        // We assert the CEK and nonce bytes — these are the load-bearing
-        // intermediates; if the HKDF info construction has `ua_public` and
-        // `as_public` swapped, both will be wrong.
+        // RFC 8291 §5 published CEK and nonce (base64url no-pad). The RFC
+        // example also lists an `IKM` value but in a 16-byte truncated form
+        // (the full HKDF-Expand output is 32 bytes per RFC 8291 §3.4);
+        // CEK and nonce are exact and transitively cover any IKM bug.
         let expected_cek = URL_SAFE_NO_PAD.decode("oIhVW04MRdy2XN9CiKLxTg").unwrap();
         let expected_nonce = URL_SAFE_NO_PAD.decode("4h_95klXJ5E_qnoN").unwrap();
+        assert_eq!(&cek[..], &expected_cek[..], "CEK mismatch");
+        assert_eq!(&nonce[..], &expected_nonce[..], "nonce mismatch");
+
+        // ---- Pad to the RFC's actual record length, AES-GCM seal --------
+        // RFC 8188 §2.1: `rs` in the header is the configured per-record
+        // *maximum* (the RFC example uses 4096); the last record may be
+        // shorter. Derive the actual padded-plaintext length from the
+        // RFC's published body so we reproduce the reference encoder's
+        // padding choice exactly:
+        //     padded_plaintext_len = body.len() − header_len − tag_len.
+        let record_plaintext_len = expected_body.len() - AES128GCM_HEADER_LEN - AES128GCM_TAG_LEN;
+        let mut padded = Vec::with_capacity(record_plaintext_len);
+        padded.extend_from_slice(plaintext);
+        padded.push(AES128GCM_LAST_RECORD_DELIM);
+        padded.resize(record_plaintext_len, 0x00);
+
+        let cipher = Aes128Gcm::new_from_slice(&cek).unwrap();
+        let ciphertext = cipher
+            .encrypt((&nonce).into(), padded.as_slice())
+            .expect("AES-128-GCM encrypt");
+
+        // Read the RFC's `rs` field for header reassembly (4096 in the
+        // example — this is the configured max, not the actual record
+        // length).
+        let rs_field_start = AES128GCM_SALT_LEN;
+        let rs_field_end = rs_field_start + AES128GCM_RS_LEN;
+        let mut rs_bytes = [0u8; AES128GCM_RS_LEN];
+        rs_bytes.copy_from_slice(&expected_body[rs_field_start..rs_field_end]);
+
+        // ---- Assemble header || ciphertext, byte-equal the RFC body -----
+        let mut body = Vec::with_capacity(AES128GCM_HEADER_LEN + ciphertext.len());
+        body.extend_from_slice(&salt);
+        body.extend_from_slice(&rs_bytes);
+        body.push(as_public_bytes.len() as u8);
+        body.extend_from_slice(&as_public_bytes);
+        body.extend_from_slice(&ciphertext);
         assert_eq!(
-            &cek[..],
-            &expected_cek[..],
-            "CEK mismatch — HKDF derivation drift"
-        );
-        assert_eq!(
-            &nonce[..],
-            &expected_nonce[..],
-            "nonce mismatch — HKDF derivation drift"
+            body, expected_body,
+            "encrypted body must match RFC 8291 §5 expected output byte-for-byte"
         );
     }
 

--- a/server/crates/waddle-xmpp/src/push/encrypt.rs
+++ b/server/crates/waddle-xmpp/src/push/encrypt.rs
@@ -114,26 +114,12 @@ pub fn encrypt(
     prk.expand(AES128GCM_NONCE_INFO, &mut nonce_bytes)
         .map_err(|_| WebPushCryptoError::HkdfFailed)?;
 
-    // 8. Pad plaintext: plaintext || 0x02 || 0x00*(bucket_size - plaintext.len())
-    //    The plaintext-side total after padding = bucket_size + 1 (delimiter).
+    // 8. Pad plaintext per RFC 8188 §2.1: `plaintext || 0x02 || 0x00*`
+    //    for the single/last record. Final length = `bucket_size + 1`.
     let mut record_plaintext = Vec::with_capacity(bucket_size + AES128GCM_PAD_DELIMITER_LEN);
     record_plaintext.extend_from_slice(plaintext);
-    record_plaintext.push(0x02); // last-record delimiter
-    record_plaintext.resize(
-        bucket_size + AES128GCM_PAD_DELIMITER_LEN,
-        // Actually wait — RFC 8188 §2.1 says padding zeros come BEFORE the
-        // delimiter, not after. Let me re-read.
-        0x00,
-    );
-
-    // RFC 8188 §2.1 padding format (corrected):
-    //   data = plaintext || 0x02 || 0x00*pad   (for the last/only record)
-    //   so the delimiter goes RIGHT AFTER plaintext, then the zero padding.
-    // The code above already does that — `extend_from_slice(plaintext)`,
-    // `push(0x02)`, then `resize(..., 0)` fills the remaining bucket bytes
-    // with zeros, which sit AFTER the delimiter. Re-reading RFC 8188 §2.1
-    // confirms: data = plaintext || pad_delim || zero_pad. The delimiter
-    // separates plaintext from zero padding.
+    record_plaintext.push(0x02);
+    record_plaintext.resize(bucket_size + AES128GCM_PAD_DELIMITER_LEN, 0x00);
 
     // 9. Encrypt: ciphertext = AES-128-GCM(key=CEK, nonce=nonce, plaintext+pad)
     let cipher =
@@ -172,7 +158,7 @@ pub fn encrypt(
         record_len
     );
 
-    Ok(EncryptedPayload(body))
+    Ok(EncryptedPayload::new(body))
 }
 
 /// Decode the `rs` u32 field from an RFC 8188 header. Test-helper.

--- a/server/crates/waddle-xmpp/src/push/mod.rs
+++ b/server/crates/waddle-xmpp/src/push/mod.rs
@@ -4,11 +4,20 @@
 //! and sending Web Push notifications. Subscriptions are registered via XEP-0357
 //! enable/disable IQ stanzas and stored for later notification delivery.
 
+pub mod constants;
+pub mod encrypt;
 mod sender;
 mod store;
+pub mod types;
+pub mod vapid;
 
 pub use sender::{notify_mentioned_users, HttpWebPushSender, WebPushSender};
 pub use store::{InMemoryPushStore, PushSubscriptionStore};
+pub use types::{
+    AuthSecret, EncryptedPayload, EndpointHash, Kid, MailtoAddress, PushTopic, PushTopicParseError,
+    SubscriptionKeys, VapidJwt, VapidLoadError, VapidSignError, VapidSub, VapidSubParseError,
+    WebPushCryptoError,
+};
 
 use minidom::Element;
 use thiserror::Error;

--- a/server/crates/waddle-xmpp/src/push/types.rs
+++ b/server/crates/waddle-xmpp/src/push/types.rs
@@ -129,31 +129,75 @@ impl VapidSub {
         Ok(Self::Mailto(MailtoAddress::new(mailto)?))
     }
 
-    /// Render as the `sub` claim string for JWT inclusion.
+    /// Render as the `sub` claim string for JWT inclusion. For the
+    /// `mailto:` variant the address is percent-encoded per RFC 6068 §5
+    /// — non-ASCII, control, whitespace, and the special set `%?#&=/`
+    /// are percent-encoded; ASCII alphanumerics and the `mailto`-safe
+    /// punctuation (`-._~+@`) are passed through unchanged.
     pub fn as_claim(&self) -> String {
         match self {
-            Self::Mailto(addr) => format!("mailto:{}", addr.as_str()),
+            Self::Mailto(addr) => format!("mailto:{}", percent_encode_mailto(addr.as_str())),
             Self::Url(url) => url.to_string(),
         }
     }
 }
 
+/// Percent-encode the addr-spec portion of a `mailto:` URI per
+/// RFC 6068 §5. Characters that MUST be percent-encoded:
+///
+///   - non-ASCII bytes (UTF-8 encoded then `%HH` per byte)
+///   - control characters and whitespace
+///   - the URI-reserved set used by `mailto` headers: `%`, `?`, `#`,
+///     `&`, `=`, `/`
+///
+/// All other ASCII characters (alphanumerics + `mailto`-safe punctuation
+/// like `-._~+@`) pass through unchanged. Output is always
+/// printable-ASCII and URI-safe.
+fn percent_encode_mailto(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for byte in input.bytes() {
+        let must_encode = byte >= 0x80
+            || (byte as char).is_ascii_control()
+            || (byte as char).is_ascii_whitespace()
+            || matches!(byte, b'%' | b'?' | b'#' | b'&' | b'=' | b'/');
+        if must_encode {
+            out.push('%');
+            out.push(upper_hex_nibble(byte >> 4));
+            out.push(upper_hex_nibble(byte & 0x0F));
+        } else {
+            out.push(byte as char);
+        }
+    }
+    out
+}
+
+#[inline]
+fn upper_hex_nibble(nibble: u8) -> char {
+    match nibble {
+        0..=9 => (b'0' + nibble) as char,
+        10..=15 => (b'A' + nibble - 10) as char,
+        _ => unreachable!("nibble must be 0..=15"),
+    }
+}
+
 impl MailtoAddress {
+    /// Construct from a raw, unescaped email address. URI-reserved
+    /// characters (`%`, `?`, `#`, `&`, `=`, `/`) and non-ASCII bytes
+    /// are accepted here — they will be percent-encoded per RFC 6068 §5
+    /// when the address is rendered into the `sub` claim by
+    /// [`VapidSub::as_claim`]. Control characters, NUL, CR, LF, and a
+    /// missing `@` separator are still rejected; the local-part and
+    /// host MUST both be non-empty.
     pub fn new(value: impl Into<Box<str>>) -> Result<Self, VapidSubParseError> {
         let s: Box<str> = value.into();
         if s.is_empty() {
             return Err(VapidSubParseError::Empty);
         }
-        // Reject control/whitespace, plus URI-reserved characters that would
-        // require percent-encoding in a mailto URI (RFC 6068 §2). The
-        // `sub` claim is embedded verbatim as `mailto:<addr>` into the JWT;
-        // unescaped reserved chars produce malformed URIs.
-        let reject = |c: char| {
-            c.is_control()
-                || c.is_whitespace()
-                || matches!(c, '?' | '#' | '%' | '&' | '/' | ',' | ';')
-        };
-        if s.chars().any(reject) {
+        // Control characters (incl. NUL, CR, LF) and whitespace are never
+        // valid in an email address. Other characters that need
+        // percent-encoding for the mailto URI are accepted and rendered
+        // safely by `VapidSub::as_claim`.
+        if s.chars().any(|c| c.is_control() || c.is_whitespace()) {
             return Err(VapidSubParseError::BadMailto);
         }
         let (local, host) = s.rsplit_once('@').ok_or(VapidSubParseError::BadMailto)?;
@@ -602,21 +646,66 @@ mod tests {
     }
 
     #[test]
-    fn vapid_sub_rejects_mailto_with_uri_reserved_chars() {
-        // RFC 6068 §2: `?`, `#`, `%`, `&`, etc. need percent-encoding.
+    fn vapid_sub_accepts_mailto_with_uri_reserved_chars_and_percent_encodes_them() {
+        // RFC 6068 §5 requires `?`, `#`, `%`, `&`, `=`, `/` (and non-ASCII /
+        // control / whitespace) to be percent-encoded inside the `addr-spec`
+        // when rendered as a `mailto:` URI. We accept the raw address at
+        // construction and let `as_claim()` do the encoding.
+        let cases: &[(&str, &str)] = &[
+            ("mailto:foo?bar@example.com", "mailto:foo%3Fbar@example.com"),
+            (
+                "mailto:foo#frag@example.com",
+                "mailto:foo%23frag@example.com",
+            ),
+            ("mailto:foo&bar@example.com", "mailto:foo%26bar@example.com"),
+            ("mailto:foo=bar@example.com", "mailto:foo%3Dbar@example.com"),
+            ("mailto:foo/bar@example.com", "mailto:foo%2Fbar@example.com"),
+            // Pre-percent-encoded local-part: the `%` itself is re-encoded
+            // (`%20` → `%2520`) — operators who want literal `%HH` semantics
+            // should pass the decoded form.
+            (
+                "mailto:foo%20bar@example.com",
+                "mailto:foo%2520bar@example.com",
+            ),
+        ];
+        for (input, expected_claim) in cases {
+            let sub = VapidSub::from_str(input).unwrap_or_else(|e| {
+                panic!("input {input:?} should be accepted, got {e:?}");
+            });
+            assert_eq!(sub.as_claim(), *expected_claim, "input {input}");
+        }
+    }
+
+    #[test]
+    fn vapid_sub_mailto_still_rejects_control_chars() {
+        // Control / whitespace remain invalid — they can't appear in a real
+        // email address and percent-encoding them would be misleading.
         for bad in &[
-            "mailto:foo?subj=x@bar.example",
-            "mailto:foo#frag@bar.example",
-            "mailto:foo%20bar@bar.example",
-            "mailto:foo,bar@bar.example",
+            "mailto:foo\x00bar@example.com",
+            "mailto:foo bar@example.com",
+            "mailto:foo\tbar@example.com",
         ] {
             match VapidSub::from_str(bad) {
                 Ok(_) => panic!("input `{bad}` should be rejected"),
                 Err(err) => {
-                    assert!(matches!(err, VapidSubParseError::BadMailto), "input {bad}")
+                    assert!(
+                        matches!(err, VapidSubParseError::BadMailto),
+                        "input {bad:?}"
+                    )
                 }
             }
         }
+    }
+
+    #[test]
+    fn percent_encode_mailto_passes_through_safe_chars_and_encodes_non_ascii() {
+        // ASCII alphanumerics + mailto-safe punctuation should round-trip.
+        let safe = "ops-team+vapid_alert@push.example.com";
+        assert_eq!(percent_encode_mailto(safe), safe);
+
+        // Non-ASCII UTF-8 bytes are percent-encoded byte-by-byte.
+        // "naïve" in UTF-8 is `na\xc3\xafve` → `na%C3%AFve`.
+        assert_eq!(percent_encode_mailto("naïve"), "na%C3%AFve");
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/push/types.rs
+++ b/server/crates/waddle-xmpp/src/push/types.rs
@@ -198,9 +198,13 @@ impl EncryptedPayload {
 
 /// Signed VAPID JWT, ready for `Authorization: vapid t=…` use.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct VapidJwt(pub String);
+pub struct VapidJwt(String);
 
 impl VapidJwt {
+    pub fn new(token: String) -> Self {
+        Self(token)
+    }
+
     pub fn as_str(&self) -> &str {
         &self.0
     }

--- a/server/crates/waddle-xmpp/src/push/types.rs
+++ b/server/crates/waddle-xmpp/src/push/types.rs
@@ -267,10 +267,17 @@ impl AuthSecret {
     }
 
     pub fn from_base64url(input: &str) -> Result<Self, WebPushCryptoError> {
-        let bytes = URL_SAFE_NO_PAD
-            .decode(input.trim_end_matches('='))
-            .map_err(|source| MalformedSubscriptionError::AuthSecretBase64url { source })?;
-        Self::from_slice(&bytes)
+        // The base64url decoder allocates a `Vec<u8>` for the output. Wrap
+        // it in `Zeroizing` so the intermediate heap buffer holding the
+        // raw `auth_secret` bytes is wiped when this scope ends — the
+        // `ZeroizeOnDrop` derive on `AuthSecret` only covers the final
+        // `[u8; 16]` stored in the struct, not the decoder's scratch.
+        let bytes: zeroize::Zeroizing<Vec<u8>> = zeroize::Zeroizing::new(
+            URL_SAFE_NO_PAD
+                .decode(input.trim_end_matches('='))
+                .map_err(|source| MalformedSubscriptionError::AuthSecretBase64url { source })?,
+        );
+        Self::from_slice(bytes.as_slice())
     }
 
     pub fn as_bytes(&self) -> &[u8; 16] {

--- a/server/crates/waddle-xmpp/src/push/types.rs
+++ b/server/crates/waddle-xmpp/src/push/types.rs
@@ -388,6 +388,8 @@ pub enum VapidLoadError {
     UnknownRootKeyVersion { found: u32, max_installed: u32 },
     #[error("missing root key for version {0}")]
     MissingRootKey(u32),
+    #[error("VAPID signer initialization failed: {0}")]
+    SignerInit(String),
     #[error("fresh P-256 keypair generation failed: {0}")]
     Generate(String),
 }

--- a/server/crates/waddle-xmpp/src/push/types.rs
+++ b/server/crates/waddle-xmpp/src/push/types.rs
@@ -212,15 +212,23 @@ impl EncryptedPayload {
 
 /// Signed VAPID JWT, ready for `Authorization: vapid t=…` use.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct VapidJwt(String);
+pub struct VapidJwt(reqwest::header::HeaderValue);
+
+#[derive(Debug, Error)]
+pub enum VapidJwtError {
+    #[error("JWT is not a valid HTTP header value")]
+    InvalidHeaderValue(#[from] reqwest::header::InvalidHeaderValue),
+}
 
 impl VapidJwt {
-    pub fn new(token: String) -> Self {
-        Self(token)
+    pub fn new(token: &str) -> Result<Self, VapidJwtError> {
+        Ok(Self(reqwest::header::HeaderValue::from_str(token)?))
     }
 
     pub fn as_str(&self) -> &str {
-        &self.0
+        self.0
+            .to_str()
+            .expect("VAPID JWT must remain visible ASCII after construction")
     }
 }
 
@@ -386,6 +394,8 @@ pub enum VapidSignError {
         #[source]
         source: p256::pkcs8::Error,
     },
+    #[error("VAPID JWT formatting failed")]
+    JwtFormat(#[from] VapidJwtError),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/server/crates/waddle-xmpp/src/push/types.rs
+++ b/server/crates/waddle-xmpp/src/push/types.rs
@@ -60,8 +60,10 @@ impl PushTopic {
         if s.len() > 32 {
             return Err(PushTopicParseError::TooLong(s.len()));
         }
+        // RFC 8030 §5.4 ABNF: `topic-char = ALPHA / DIGIT / "-" / "_"` —
+        // strict base64url-no-pad alphabet; NO `:`.
         for (i, c) in s.chars().enumerate() {
-            let valid = c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == ':';
+            let valid = c.is_ascii_alphanumeric() || c == '-' || c == '_';
             if !valid {
                 return Err(PushTopicParseError::InvalidAlphabet(i));
             }
@@ -178,9 +180,13 @@ impl std::str::FromStr for VapidSub {
 
 /// RFC 8291 encrypted payload — RFC 8188 header + AES-GCM record.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct EncryptedPayload(pub Vec<u8>);
+pub struct EncryptedPayload(Vec<u8>);
 
 impl EncryptedPayload {
+    pub fn new(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+
     pub fn as_slice(&self) -> &[u8] {
         &self.0
     }
@@ -382,8 +388,15 @@ mod tests {
 
     #[test]
     fn push_topic_accepts_valid() {
-        let t = PushTopic::new("d:abcDEF-_0123").expect("valid");
-        assert_eq!(t.as_str(), "d:abcDEF-_0123");
+        let t = PushTopic::new("d-abcDEF_0123").expect("valid");
+        assert_eq!(t.as_str(), "d-abcDEF_0123");
+    }
+
+    #[test]
+    fn push_topic_rejects_colon_per_rfc_8030_5_4() {
+        // RFC 8030 §5.4 topic-char does NOT include `:` — must be rejected.
+        let err = PushTopic::new("d:abc").unwrap_err();
+        assert!(matches!(err, PushTopicParseError::InvalidAlphabet(1)));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/push/types.rs
+++ b/server/crates/waddle-xmpp/src/push/types.rs
@@ -138,7 +138,16 @@ impl MailtoAddress {
         if s.is_empty() {
             return Err(VapidSubParseError::Empty);
         }
-        if s.chars().any(|c| c.is_control() || c.is_whitespace()) {
+        // Reject control/whitespace, plus URI-reserved characters that would
+        // require percent-encoding in a mailto URI (RFC 6068 §2). The
+        // `sub` claim is embedded verbatim as `mailto:<addr>` into the JWT;
+        // unescaped reserved chars produce malformed URIs.
+        let reject = |c: char| {
+            c.is_control()
+                || c.is_whitespace()
+                || matches!(c, '?' | '#' | '%' | '&' | '/' | ',' | ';')
+        };
+        if s.chars().any(reject) {
             return Err(VapidSubParseError::BadMailto);
         }
         let (local, host) = s.rsplit_once('@').ok_or(VapidSubParseError::BadMailto)?;
@@ -480,6 +489,24 @@ mod tests {
         // RFC 6068: mailto URIs are non-hierarchical; `mailto://foo@bar` is malformed.
         let err = VapidSub::from_str("mailto://foo@bar.example").unwrap_err();
         assert!(matches!(err, VapidSubParseError::BadMailto));
+    }
+
+    #[test]
+    fn vapid_sub_rejects_mailto_with_uri_reserved_chars() {
+        // RFC 6068 §2: `?`, `#`, `%`, `&`, etc. need percent-encoding.
+        for bad in &[
+            "mailto:foo?subj=x@bar.example",
+            "mailto:foo#frag@bar.example",
+            "mailto:foo%20bar@bar.example",
+            "mailto:foo,bar@bar.example",
+        ] {
+            match VapidSub::from_str(bad) {
+                Ok(_) => panic!("input `{bad}` should be rejected"),
+                Err(err) => {
+                    assert!(matches!(err, VapidSubParseError::BadMailto), "input {bad}")
+                }
+            }
+        }
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/push/types.rs
+++ b/server/crates/waddle-xmpp/src/push/types.rs
@@ -243,10 +243,9 @@ impl AuthSecret {
 
     pub fn from_slice(bytes: &[u8]) -> Result<Self, WebPushCryptoError> {
         if bytes.len() != Self::LEN {
-            return Err(WebPushCryptoError::MalformedSubscription(format!(
-                "auth_secret must be 16 bytes, got {}",
-                bytes.len()
-            )));
+            return Err(
+                MalformedSubscriptionError::AuthSecretWrongLength { found: bytes.len() }.into(),
+            );
         }
         let mut buf = [0u8; 16];
         buf.copy_from_slice(bytes);
@@ -256,11 +255,7 @@ impl AuthSecret {
     pub fn from_base64url(input: &str) -> Result<Self, WebPushCryptoError> {
         let bytes = URL_SAFE_NO_PAD
             .decode(input.trim_end_matches('='))
-            .map_err(|e| {
-                WebPushCryptoError::MalformedSubscription(format!(
-                    "auth_secret base64url decode: {e}"
-                ))
-            })?;
+            .map_err(|source| MalformedSubscriptionError::AuthSecretBase64url { source })?;
         Self::from_slice(&bytes)
     }
 
@@ -291,24 +286,21 @@ impl SubscriptionKeys {
     pub fn from_base64url(p256dh: &str, auth: &str) -> Result<Self, WebPushCryptoError> {
         let p256dh_bytes = URL_SAFE_NO_PAD
             .decode(p256dh.trim_end_matches('='))
-            .map_err(|e| {
-                WebPushCryptoError::MalformedSubscription(format!("p256dh base64url decode: {e}"))
-            })?;
+            .map_err(|source| MalformedSubscriptionError::P256DhBase64url { source })?;
         if p256dh_bytes.len() != 65 {
-            return Err(WebPushCryptoError::MalformedSubscription(format!(
-                "p256dh must be 65 bytes (uncompressed P-256 point), got {}",
-                p256dh_bytes.len()
-            )));
+            return Err(MalformedSubscriptionError::P256DhWrongLength {
+                found: p256dh_bytes.len(),
+            }
+            .into());
         }
         if p256dh_bytes[0] != 0x04 {
-            return Err(WebPushCryptoError::MalformedSubscription(format!(
-                "p256dh must start with 0x04 (uncompressed point prefix), got 0x{:02x}",
-                p256dh_bytes[0]
-            )));
+            return Err(MalformedSubscriptionError::P256DhWrongPrefix {
+                found: p256dh_bytes[0],
+            }
+            .into());
         }
-        let pk = p256::PublicKey::from_sec1_bytes(&p256dh_bytes).map_err(|e| {
-            WebPushCryptoError::MalformedSubscription(format!("p256dh not on curve: {e}"))
-        })?;
+        let pk = p256::PublicKey::from_sec1_bytes(&p256dh_bytes)
+            .map_err(|source| MalformedSubscriptionError::P256DhNotOnCurve { source })?;
         let auth_secret = AuthSecret::from_base64url(auth)?;
         Ok(Self {
             p256dh: pk,
@@ -342,9 +334,9 @@ impl EndpointHash {
 #[derive(Debug, Error)]
 pub enum WebPushCryptoError {
     #[error("malformed subscription: {0}")]
-    MalformedSubscription(String),
-    #[error("invalid push endpoint: {0}")]
-    InvalidEndpoint(String),
+    MalformedSubscription(#[from] MalformedSubscriptionError),
+    #[error("invalid push endpoint origin: {origin:?}")]
+    InvalidEndpoint { origin: url::Origin },
     #[error("push payload too large: {plaintext_len} > {limit}")]
     PayloadTooLarge { plaintext_len: usize, limit: usize },
     #[error("AES-GCM encrypt failed")]
@@ -353,6 +345,31 @@ pub enum WebPushCryptoError {
     EcdhFailed,
     #[error("HKDF expansion failed")]
     HkdfFailed,
+}
+
+#[derive(Debug, Error)]
+pub enum MalformedSubscriptionError {
+    #[error("auth_secret base64url decode failed")]
+    AuthSecretBase64url {
+        #[source]
+        source: base64::DecodeError,
+    },
+    #[error("auth_secret must be 16 bytes, got {found}")]
+    AuthSecretWrongLength { found: usize },
+    #[error("p256dh base64url decode failed")]
+    P256DhBase64url {
+        #[source]
+        source: base64::DecodeError,
+    },
+    #[error("p256dh must be 65 bytes (uncompressed P-256 point), got {found}")]
+    P256DhWrongLength { found: usize },
+    #[error("p256dh must start with 0x04 (uncompressed point prefix), got 0x{found:02x}")]
+    P256DhWrongPrefix { found: u8 },
+    #[error("p256dh must be a valid P-256 point")]
+    P256DhNotOnCurve {
+        #[source]
+        source: p256::elliptic_curve::Error,
+    },
 }
 
 /// Errors from the VAPID signing path.
@@ -364,8 +381,58 @@ pub enum VapidSignError {
     Signing(#[from] jsonwebtoken::errors::Error),
     #[error("VAPID key {kid} is retired")]
     KeyRetired { kid: Kid },
-    #[error("VAPID storage unavailable: {0}")]
-    Storage(String),
+    #[error("VAPID signer key encoding failed")]
+    KeyEncoding {
+        #[source]
+        source: p256::pkcs8::Error,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VapidDbReadStage {
+    Query,
+    NextRow,
+    DecodeKid,
+    DecodeSealedPrivateKey,
+    DecodeRootKeyVersion,
+    ParseKidUuid,
+    ParseSecretKeyScalar,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VapidDbWriteStage {
+    Initialize,
+    SealPrivateKey,
+    InsertRow,
+}
+
+#[derive(Debug, Error)]
+pub enum VapidEnvParseError {
+    #[error("base64url decode failed")]
+    Base64urlDecode {
+        #[source]
+        source: base64::DecodeError,
+    },
+    #[error("expected 32-byte P-256 scalar; got {found} bytes")]
+    InvalidLength { found: usize },
+    #[error("invalid P-256 scalar")]
+    InvalidScalar {
+        #[source]
+        source: p256::elliptic_curve::Error,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VapidUnsealErrorKind {
+    MissingPrefix,
+    UnexpectedPrefix,
+    MissingNonce,
+    MissingCiphertext,
+    UnexpectedTrailingField,
+    NonceBase64urlDecode,
+    NonceWrongLength,
+    CiphertextBase64urlDecode,
+    AeadOpenFailed,
 }
 
 /// Errors loading the VAPID config at boot. All variants map to
@@ -373,25 +440,36 @@ pub enum VapidSignError {
 #[derive(Debug, Error)]
 pub enum VapidLoadError {
     #[error("env var WADDLE_VAPID_PRIVATE_KEY parse failed: {0}")]
-    EnvParse(String),
+    EnvParse(#[from] VapidEnvParseError),
     #[error("env var WADDLE_VAPID_SUB parse failed: {0}")]
     SubParse(#[from] VapidSubParseError),
-    #[error("VAPID storage read failed: {0}")]
-    DbRead(String),
-    #[error("VAPID storage write failed: {0}")]
-    DbWrite(String),
-    #[error("VAPID key unseal failed: {0}")]
-    Unseal(String),
+    #[error("VAPID storage read failed at {stage:?}")]
+    DbRead {
+        stage: VapidDbReadStage,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+    #[error("VAPID storage write failed at {stage:?}")]
+    DbWrite {
+        stage: VapidDbWriteStage,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+    #[error("VAPID key unseal failed ({kind:?})")]
+    Unseal { kind: VapidUnsealErrorKind },
     #[error(
         "sealed blob references unknown root_key_version {found}; max installed {max_installed}"
     )]
     UnknownRootKeyVersion { found: u32, max_installed: u32 },
     #[error("missing root key for version {0}")]
     MissingRootKey(u32),
-    #[error("VAPID signer initialization failed: {0}")]
-    SignerInit(String),
-    #[error("fresh P-256 keypair generation failed: {0}")]
-    Generate(String),
+    #[error("VAPID signer initialization failed")]
+    SignerInit {
+        #[source]
+        source: VapidSignError,
+    },
+    #[error("fresh P-256 keypair generation failed")]
+    Generate,
 }
 
 #[cfg(test)]
@@ -547,7 +625,12 @@ mod tests {
     #[test]
     fn subscription_keys_reject_short_p256dh() {
         let err = SubscriptionKeys::from_base64url("AAAA", "AAAAAAAAAAAAAAAAAAAAAA").unwrap_err();
-        assert!(matches!(err, WebPushCryptoError::MalformedSubscription(_)));
+        assert!(matches!(
+            err,
+            WebPushCryptoError::MalformedSubscription(
+                MalformedSubscriptionError::P256DhWrongLength { .. }
+            )
+        ));
     }
 
     #[test]
@@ -558,10 +641,12 @@ mod tests {
         let p256dh = URL_SAFE_NO_PAD.encode(&bad);
         let auth = URL_SAFE_NO_PAD.encode([0u8; 16]);
         let err = SubscriptionKeys::from_base64url(&p256dh, &auth).unwrap_err();
-        match err {
-            WebPushCryptoError::MalformedSubscription(msg) => assert!(msg.contains("0x04")),
-            other => panic!("expected MalformedSubscription, got {other:?}"),
-        }
+        assert!(matches!(
+            err,
+            WebPushCryptoError::MalformedSubscription(
+                MalformedSubscriptionError::P256DhWrongPrefix { found: 0x02 }
+            )
+        ));
     }
 
     #[test]
@@ -572,7 +657,12 @@ mod tests {
         let p256dh = URL_SAFE_NO_PAD.encode(&bad);
         let auth = URL_SAFE_NO_PAD.encode([0u8; 16]);
         let err = SubscriptionKeys::from_base64url(&p256dh, &auth).unwrap_err();
-        assert!(matches!(err, WebPushCryptoError::MalformedSubscription(_)));
+        assert!(matches!(
+            err,
+            WebPushCryptoError::MalformedSubscription(
+                MalformedSubscriptionError::P256DhNotOnCurve { .. }
+            )
+        ));
     }
 
     #[test]
@@ -585,6 +675,11 @@ mod tests {
         let p256dh = URL_SAFE_NO_PAD.encode(pk_bytes.as_bytes());
         let auth = URL_SAFE_NO_PAD.encode([0u8; 8]);
         let err = SubscriptionKeys::from_base64url(&p256dh, &auth).unwrap_err();
-        assert!(matches!(err, WebPushCryptoError::MalformedSubscription(_)));
+        assert!(matches!(
+            err,
+            WebPushCryptoError::MalformedSubscription(
+                MalformedSubscriptionError::AuthSecretWrongLength { found: 8 }
+            )
+        ));
     }
 }

--- a/server/crates/waddle-xmpp/src/push/types.rs
+++ b/server/crates/waddle-xmpp/src/push/types.rs
@@ -1,0 +1,524 @@
+//! Typed newtypes for the Web Push pipeline.
+//!
+//! Conforms to the CLAUDE.md typed-payloads hard rule: every protocol
+//! boundary uses a typed value, never `String`/`&str`/`Vec<u8>` blobs.
+
+use std::fmt;
+use std::sync::Arc;
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use thiserror::Error;
+use uuid::Uuid;
+use zeroize::ZeroizeOnDrop;
+
+/// VAPID keypair identifier. UUID in code; TEXT in DB.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Kid(pub Uuid);
+
+impl Kid {
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+
+    pub fn as_uuid(&self) -> Uuid {
+        self.0
+    }
+
+    pub fn as_bytes(&self) -> &[u8; 16] {
+        self.0.as_bytes()
+    }
+}
+
+impl Default for Kid {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for Kid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// RFC 8030 §5.4 `Topic` header — base64url, ≤ 32 chars total. Construction-validated.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PushTopic(Box<str>);
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum PushTopicParseError {
+    #[error("push topic exceeds 32 chars (got {0})")]
+    TooLong(usize),
+    #[error("push topic contains non-base64url character at index {0}")]
+    InvalidAlphabet(usize),
+}
+
+impl PushTopic {
+    pub fn new(value: impl Into<Box<str>>) -> Result<Self, PushTopicParseError> {
+        let s: Box<str> = value.into();
+        if s.len() > 32 {
+            return Err(PushTopicParseError::TooLong(s.len()));
+        }
+        for (i, c) in s.chars().enumerate() {
+            let valid = c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == ':';
+            if !valid {
+                return Err(PushTopicParseError::InvalidAlphabet(i));
+            }
+        }
+        Ok(Self(s))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<&str> for PushTopic {
+    type Error = PushTopicParseError;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value.to_owned())
+    }
+}
+
+impl fmt::Display for PushTopic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// VAPID `sub` claim — `mailto:<address>` or `https://<url>` per RFC 8292 §2.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VapidSub {
+    Mailto(MailtoAddress),
+    Url(url::Url),
+}
+
+/// `mailto:` address, validated minimally for RFC 8292 `sub` use.
+/// Rule: split on last `@`, both sides non-empty, no control/whitespace.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MailtoAddress(Box<str>);
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum VapidSubParseError {
+    #[error("empty `sub` claim")]
+    Empty,
+    #[error("missing scheme; expected `mailto:` or `https://`")]
+    MissingScheme,
+    #[error("unsupported scheme {0:?}; expected `mailto:` or `https://`")]
+    UnsupportedScheme(String),
+    #[error("malformed mailto address")]
+    BadMailto,
+    #[error("malformed URL: {0}")]
+    BadUrl(String),
+}
+
+impl VapidSub {
+    /// Default `sub` for an XMPP server: `mailto:postmaster@<domain>` per
+    /// RFC 2142 / XMPP convention.
+    pub fn default_for_domain(domain: &str) -> Result<Self, VapidSubParseError> {
+        let mailto = format!("postmaster@{domain}");
+        Ok(Self::Mailto(MailtoAddress::new(mailto)?))
+    }
+
+    /// Render as the `sub` claim string for JWT inclusion.
+    pub fn as_claim(&self) -> String {
+        match self {
+            Self::Mailto(addr) => format!("mailto:{}", addr.as_str()),
+            Self::Url(url) => url.to_string(),
+        }
+    }
+}
+
+impl MailtoAddress {
+    pub fn new(value: impl Into<Box<str>>) -> Result<Self, VapidSubParseError> {
+        let s: Box<str> = value.into();
+        if s.is_empty() {
+            return Err(VapidSubParseError::Empty);
+        }
+        if s.chars().any(|c| c.is_control() || c.is_whitespace()) {
+            return Err(VapidSubParseError::BadMailto);
+        }
+        let (local, host) = s.rsplit_once('@').ok_or(VapidSubParseError::BadMailto)?;
+        if local.is_empty() || host.is_empty() {
+            return Err(VapidSubParseError::BadMailto);
+        }
+        Ok(Self(s))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::str::FromStr for VapidSub {
+    type Err = VapidSubParseError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Err(VapidSubParseError::Empty);
+        }
+        if let Some(rest) = s.strip_prefix("mailto:") {
+            return Ok(Self::Mailto(MailtoAddress::new(rest.to_owned())?));
+        }
+        if let Some(scheme_idx) = s.find(':') {
+            let scheme = &s[..scheme_idx];
+            if scheme == "https" || scheme == "http" {
+                let url =
+                    url::Url::parse(s).map_err(|e| VapidSubParseError::BadUrl(e.to_string()))?;
+                if url.scheme() != "https" {
+                    return Err(VapidSubParseError::UnsupportedScheme(scheme.into()));
+                }
+                return Ok(Self::Url(url));
+            }
+            return Err(VapidSubParseError::UnsupportedScheme(scheme.into()));
+        }
+        Err(VapidSubParseError::MissingScheme)
+    }
+}
+
+/// RFC 8291 encrypted payload — RFC 8188 header + AES-GCM record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EncryptedPayload(pub Vec<u8>);
+
+impl EncryptedPayload {
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> Vec<u8> {
+        self.0
+    }
+}
+
+/// Signed VAPID JWT, ready for `Authorization: vapid t=…` use.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VapidJwt(pub String);
+
+impl VapidJwt {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// RFC 8291 16-byte `auth_secret`. Zeroized on final `Arc::drop`; NOT `Clone`
+/// — sharing happens via `Arc<AuthSecret>` so only one copy lives in heap.
+///
+/// Note: spawned futures holding a clone of `Arc<AuthSecret>` extend
+/// zeroize until the future completes. This is intentional — the secret
+/// lives as long as it is in use. Do not move `Arc<AuthSecret>` into
+/// futures with longer-than-necessary lifetimes.
+#[derive(ZeroizeOnDrop)]
+pub struct AuthSecret([u8; 16]);
+
+impl AuthSecret {
+    pub const LEN: usize = 16;
+
+    pub fn from_bytes(bytes: [u8; 16]) -> Self {
+        Self(bytes)
+    }
+
+    pub fn from_slice(bytes: &[u8]) -> Result<Self, WebPushCryptoError> {
+        if bytes.len() != Self::LEN {
+            return Err(WebPushCryptoError::MalformedSubscription(format!(
+                "auth_secret must be 16 bytes, got {}",
+                bytes.len()
+            )));
+        }
+        let mut buf = [0u8; 16];
+        buf.copy_from_slice(bytes);
+        Ok(Self(buf))
+    }
+
+    pub fn from_base64url(input: &str) -> Result<Self, WebPushCryptoError> {
+        let bytes = URL_SAFE_NO_PAD
+            .decode(input.trim_end_matches('='))
+            .map_err(|e| {
+                WebPushCryptoError::MalformedSubscription(format!(
+                    "auth_secret base64url decode: {e}"
+                ))
+            })?;
+        Self::from_slice(&bytes)
+    }
+
+    pub fn as_bytes(&self) -> &[u8; 16] {
+        &self.0
+    }
+}
+
+impl fmt::Debug for AuthSecret {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("AuthSecret(***)")
+    }
+}
+
+/// Subscriber-supplied ECDH/auth material, parsed once at the deserialization
+/// boundary. `auth` is `Arc<AuthSecret>` so cloning the struct does not
+/// duplicate the wrapped 16-byte secret in heap.
+#[derive(Debug, Clone)]
+pub struct SubscriptionKeys {
+    pub p256dh: p256::PublicKey,
+    pub auth: Arc<AuthSecret>,
+}
+
+impl SubscriptionKeys {
+    /// Parse a browser-supplied (p256dh, auth) pair from base64url-no-pad
+    /// strings. Rejects with `WebPushCryptoError::MalformedSubscription` on any
+    /// length/curve/format error.
+    pub fn from_base64url(p256dh: &str, auth: &str) -> Result<Self, WebPushCryptoError> {
+        let p256dh_bytes = URL_SAFE_NO_PAD
+            .decode(p256dh.trim_end_matches('='))
+            .map_err(|e| {
+                WebPushCryptoError::MalformedSubscription(format!("p256dh base64url decode: {e}"))
+            })?;
+        if p256dh_bytes.len() != 65 {
+            return Err(WebPushCryptoError::MalformedSubscription(format!(
+                "p256dh must be 65 bytes (uncompressed P-256 point), got {}",
+                p256dh_bytes.len()
+            )));
+        }
+        if p256dh_bytes[0] != 0x04 {
+            return Err(WebPushCryptoError::MalformedSubscription(format!(
+                "p256dh must start with 0x04 (uncompressed point prefix), got 0x{:02x}",
+                p256dh_bytes[0]
+            )));
+        }
+        let pk = p256::PublicKey::from_sec1_bytes(&p256dh_bytes).map_err(|e| {
+            WebPushCryptoError::MalformedSubscription(format!("p256dh not on curve: {e}"))
+        })?;
+        let auth_secret = AuthSecret::from_base64url(auth)?;
+        Ok(Self {
+            p256dh: pk,
+            auth: Arc::new(auth_secret),
+        })
+    }
+}
+
+/// SHA-256 of the subscription endpoint URL — keys per-endpoint rate-limit
+/// buckets in `DashMap` without keeping the URL string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct EndpointHash(pub [u8; 32]);
+
+impl EndpointHash {
+    pub fn of(endpoint_url: &str) -> Self {
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        hasher.update(endpoint_url.as_bytes());
+        let mut out = [0u8; 32];
+        out.copy_from_slice(&hasher.finalize());
+        Self(out)
+    }
+}
+
+/// Errors from the Web Push crypto + sender path.
+///
+/// Kept as a standalone enum (rather than extending `super::PushError`)
+/// so the typed-payloads hard rule is honored at this boundary: the
+/// existing `super::PushError` uses stringly fields that PR-D2's sender
+/// swap will retire.
+#[derive(Debug, Error)]
+pub enum WebPushCryptoError {
+    #[error("malformed subscription: {0}")]
+    MalformedSubscription(String),
+    #[error("invalid push endpoint: {0}")]
+    InvalidEndpoint(String),
+    #[error("push payload too large: {plaintext_len} > {limit}")]
+    PayloadTooLarge { plaintext_len: usize, limit: usize },
+    #[error("AES-GCM encrypt failed")]
+    EncryptFailed,
+    #[error("ECDH derivation failed")]
+    EcdhFailed,
+    #[error("HKDF expansion failed")]
+    HkdfFailed,
+}
+
+/// Errors from the VAPID signing path.
+#[derive(Debug, Error)]
+pub enum VapidSignError {
+    #[error("invalid push endpoint for VAPID `aud`: {0}")]
+    InvalidEndpoint(#[source] WebPushCryptoError),
+    #[error("ES256 signing failed: {0}")]
+    Signing(#[from] jsonwebtoken::errors::Error),
+    #[error("VAPID key {kid} is retired")]
+    KeyRetired { kid: Kid },
+    #[error("VAPID storage unavailable: {0}")]
+    Storage(String),
+}
+
+/// Errors loading the VAPID config at boot. All variants map to
+/// `WebPushCapability::Disabled { reason }`.
+#[derive(Debug, Error)]
+pub enum VapidLoadError {
+    #[error("env var WADDLE_VAPID_PRIVATE_KEY parse failed: {0}")]
+    EnvParse(String),
+    #[error("env var WADDLE_VAPID_SUB parse failed: {0}")]
+    SubParse(#[from] VapidSubParseError),
+    #[error("VAPID storage read failed: {0}")]
+    DbRead(String),
+    #[error("VAPID storage write failed: {0}")]
+    DbWrite(String),
+    #[error("VAPID key unseal failed: {0}")]
+    Unseal(String),
+    #[error(
+        "sealed blob references unknown root_key_version {found}; max installed {max_installed}"
+    )]
+    UnknownRootKeyVersion { found: u32, max_installed: u32 },
+    #[error("missing root key for version {0}")]
+    MissingRootKey(u32),
+    #[error("fresh P-256 keypair generation failed: {0}")]
+    Generate(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn kid_round_trip() {
+        let kid = Kid::new();
+        assert_eq!(kid.as_uuid(), kid.0);
+        assert_eq!(kid.as_bytes().len(), 16);
+    }
+
+    #[test]
+    fn push_topic_accepts_valid() {
+        let t = PushTopic::new("d:abcDEF-_0123").expect("valid");
+        assert_eq!(t.as_str(), "d:abcDEF-_0123");
+    }
+
+    #[test]
+    fn push_topic_rejects_too_long() {
+        let s: String = "a".repeat(33);
+        assert_eq!(
+            PushTopic::new(s).unwrap_err(),
+            PushTopicParseError::TooLong(33)
+        );
+    }
+
+    #[test]
+    fn push_topic_rejects_invalid_alphabet() {
+        // '$' is not base64url
+        let err = PushTopic::new("hello$world").unwrap_err();
+        assert!(matches!(err, PushTopicParseError::InvalidAlphabet(5)));
+    }
+
+    #[test]
+    fn vapid_sub_default_for_domain() {
+        let sub = VapidSub::default_for_domain("example.com").expect("valid");
+        assert_eq!(sub.as_claim(), "mailto:postmaster@example.com");
+    }
+
+    #[test]
+    fn vapid_sub_parses_mailto() {
+        let sub = VapidSub::from_str("mailto:ops@example.com").expect("valid");
+        assert_eq!(sub.as_claim(), "mailto:ops@example.com");
+    }
+
+    #[test]
+    fn vapid_sub_parses_https_url() {
+        let sub = VapidSub::from_str("https://example.com/contact").expect("valid");
+        assert_eq!(sub.as_claim(), "https://example.com/contact");
+    }
+
+    #[test]
+    fn vapid_sub_rejects_http_scheme() {
+        // http (not https) is rejected
+        let err = VapidSub::from_str("http://example.com").unwrap_err();
+        assert!(matches!(err, VapidSubParseError::UnsupportedScheme(_)));
+    }
+
+    #[test]
+    fn vapid_sub_rejects_empty_mailto_local() {
+        let err = VapidSub::from_str("mailto:@example.com").unwrap_err();
+        assert!(matches!(err, VapidSubParseError::BadMailto));
+    }
+
+    #[test]
+    fn vapid_sub_rejects_empty_mailto_host() {
+        let err = VapidSub::from_str("mailto:user@").unwrap_err();
+        assert!(matches!(err, VapidSubParseError::BadMailto));
+    }
+
+    #[test]
+    fn vapid_sub_rejects_no_scheme() {
+        let err = VapidSub::from_str("nope").unwrap_err();
+        assert!(matches!(err, VapidSubParseError::MissingScheme));
+    }
+
+    #[test]
+    fn auth_secret_from_slice_strict_length() {
+        let ok = AuthSecret::from_slice(&[0u8; 16]).expect("16 bytes");
+        assert_eq!(ok.as_bytes(), &[0u8; 16]);
+        assert!(AuthSecret::from_slice(&[0u8; 15]).is_err());
+        assert!(AuthSecret::from_slice(&[0u8; 17]).is_err());
+    }
+
+    #[test]
+    fn auth_secret_debug_does_not_leak() {
+        let secret = AuthSecret::from_bytes([0xAA; 16]);
+        let dbg = format!("{:?}", secret);
+        assert_eq!(dbg, "AuthSecret(***)");
+        assert!(!dbg.contains("AA"));
+    }
+
+    #[test]
+    fn auth_secret_zeroize_on_drop() {
+        // The Zeroize derive zeroes on drop; we can't observe heap directly,
+        // but we can verify the Zeroize trait is implemented.
+        let secret = AuthSecret::from_bytes([0xFF; 16]);
+        let _ = secret; // dropped here — ZeroizeOnDrop
+    }
+
+    #[test]
+    fn endpoint_hash_is_deterministic() {
+        let h1 = EndpointHash::of("https://fcm.googleapis.com/fcm/send/abc");
+        let h2 = EndpointHash::of("https://fcm.googleapis.com/fcm/send/abc");
+        assert_eq!(h1, h2);
+        let h3 = EndpointHash::of("https://fcm.googleapis.com/fcm/send/different");
+        assert_ne!(h1, h3);
+    }
+
+    #[test]
+    fn subscription_keys_reject_short_p256dh() {
+        let err = SubscriptionKeys::from_base64url("AAAA", "AAAAAAAAAAAAAAAAAAAAAA").unwrap_err();
+        assert!(matches!(err, WebPushCryptoError::MalformedSubscription(_)));
+    }
+
+    #[test]
+    fn subscription_keys_reject_wrong_prefix() {
+        // 65 bytes but starting with 0x02 (compressed Y-bit) — not uncompressed
+        let mut bad = vec![0x02];
+        bad.extend_from_slice(&[0u8; 64]);
+        let p256dh = URL_SAFE_NO_PAD.encode(&bad);
+        let auth = URL_SAFE_NO_PAD.encode([0u8; 16]);
+        let err = SubscriptionKeys::from_base64url(&p256dh, &auth).unwrap_err();
+        match err {
+            WebPushCryptoError::MalformedSubscription(msg) => assert!(msg.contains("0x04")),
+            other => panic!("expected MalformedSubscription, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn subscription_keys_reject_off_curve_point() {
+        // 65 bytes, 0x04 prefix, but X=Y=0 → identity point, not on curve.
+        let mut bad = vec![0x04];
+        bad.extend_from_slice(&[0u8; 64]);
+        let p256dh = URL_SAFE_NO_PAD.encode(&bad);
+        let auth = URL_SAFE_NO_PAD.encode([0u8; 16]);
+        let err = SubscriptionKeys::from_base64url(&p256dh, &auth).unwrap_err();
+        assert!(matches!(err, WebPushCryptoError::MalformedSubscription(_)));
+    }
+
+    #[test]
+    fn subscription_keys_reject_short_auth() {
+        use p256::elliptic_curve::rand_core::OsRng;
+        use p256::elliptic_curve::sec1::ToEncodedPoint;
+        // Valid p256dh, but auth is only 8 bytes
+        let pk = p256::SecretKey::random(&mut OsRng).public_key();
+        let pk_bytes = pk.to_encoded_point(false);
+        let p256dh = URL_SAFE_NO_PAD.encode(pk_bytes.as_bytes());
+        let auth = URL_SAFE_NO_PAD.encode([0u8; 8]);
+        let err = SubscriptionKeys::from_base64url(&p256dh, &auth).unwrap_err();
+        assert!(matches!(err, WebPushCryptoError::MalformedSubscription(_)));
+    }
+}

--- a/server/crates/waddle-xmpp/src/push/types.rs
+++ b/server/crates/waddle-xmpp/src/push/types.rs
@@ -96,7 +96,7 @@ impl fmt::Display for PushTopic {
 }
 
 /// VAPID `sub` claim — `mailto:<address>` or `https://<url>` per RFC 8292 §2.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum VapidSub {
     Mailto(MailtoAddress),
     Url(url::Url),
@@ -104,7 +104,7 @@ pub enum VapidSub {
 
 /// `mailto:` address, validated minimally for RFC 8292 `sub` use.
 /// Rule: split on last `@`, both sides non-empty, no control/whitespace.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct MailtoAddress(Box<str>);
 
 #[derive(Debug, Error, PartialEq, Eq)]

--- a/server/crates/waddle-xmpp/src/push/types.rs
+++ b/server/crates/waddle-xmpp/src/push/types.rs
@@ -48,6 +48,8 @@ pub struct PushTopic(Box<str>);
 
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum PushTopicParseError {
+    #[error("push topic must be 1..=32 chars; got empty")]
+    Empty,
     #[error("push topic exceeds 32 chars (got {0})")]
     TooLong(usize),
     #[error("push topic contains non-base64url character at index {0}")]
@@ -57,6 +59,10 @@ pub enum PushTopicParseError {
 impl PushTopic {
     pub fn new(value: impl Into<Box<str>>) -> Result<Self, PushTopicParseError> {
         let s: Box<str> = value.into();
+        // RFC 8030 §5.4: `Topic = 1*32(topic-char)` — minimum length 1.
+        if s.is_empty() {
+            return Err(PushTopicParseError::Empty);
+        }
         if s.len() > 32 {
             return Err(PushTopicParseError::TooLong(s.len()));
         }
@@ -522,6 +528,13 @@ mod tests {
         let s: String = "a".repeat(32);
         let t = PushTopic::new(s.clone()).expect("32 chars is valid");
         assert_eq!(t.as_str(), s);
+    }
+
+    #[test]
+    fn push_topic_rejects_empty_per_rfc_8030_5_4() {
+        // RFC 8030 §5.4: `Topic = 1*32(topic-char)` — minimum length 1.
+        let err = PushTopic::new("").unwrap_err();
+        assert_eq!(err, PushTopicParseError::Empty);
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/push/types.rs
+++ b/server/crates/waddle-xmpp/src/push/types.rs
@@ -160,6 +160,11 @@ impl std::str::FromStr for VapidSub {
             return Err(VapidSubParseError::Empty);
         }
         if let Some(rest) = s.strip_prefix("mailto:") {
+            // RFC 6068: `mailto` URIs are NOT hierarchical and MUST NOT
+            // begin with `//`. Reject `mailto://foo@bar`-style inputs.
+            if rest.starts_with("//") {
+                return Err(VapidSubParseError::BadMailto);
+            }
             return Ok(Self::Mailto(MailtoAddress::new(rest.to_owned())?));
         }
         if let Some(scheme_idx) = s.find(':') {
@@ -413,6 +418,14 @@ mod tests {
     }
 
     #[test]
+    fn push_topic_accepts_exactly_32_chars() {
+        // RFC 8030 §5.4: `Topic = 1*32(topic-char)`. 32 is the inclusive max.
+        let s: String = "a".repeat(32);
+        let t = PushTopic::new(s.clone()).expect("32 chars is valid");
+        assert_eq!(t.as_str(), s);
+    }
+
+    #[test]
     fn push_topic_rejects_invalid_alphabet() {
         // '$' is not base64url
         let err = PushTopic::new("hello$world").unwrap_err();
@@ -460,6 +473,13 @@ mod tests {
     fn vapid_sub_rejects_no_scheme() {
         let err = VapidSub::from_str("nope").unwrap_err();
         assert!(matches!(err, VapidSubParseError::MissingScheme));
+    }
+
+    #[test]
+    fn vapid_sub_rejects_mailto_with_authority_slashes() {
+        // RFC 6068: mailto URIs are non-hierarchical; `mailto://foo@bar` is malformed.
+        let err = VapidSub::from_str("mailto://foo@bar.example").unwrap_err();
+        assert!(matches!(err, VapidSubParseError::BadMailto));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/push/vapid.rs
+++ b/server/crates/waddle-xmpp/src/push/vapid.rs
@@ -96,6 +96,10 @@ struct CacheKey {
     /// Origin serialized once at key construction — `url::Origin` itself is
     /// `Hash`/`Eq`, but we cache the canonical ASCII form for cheap comparisons.
     origin_ascii: String,
+    /// `sub` is part of the JWT claim set, so a cache hit MUST require an
+    /// exact match — otherwise a caller varying `sub` for the same
+    /// `(kid, origin)` would receive a stale-`sub` JWT.
+    sub_claim: String,
 }
 
 #[derive(Clone)]
@@ -141,10 +145,11 @@ impl InProcessVapidSigner {
         }
     }
 
-    fn cache_key(&self, aud: &url::Origin) -> CacheKey {
+    fn cache_key(&self, aud: &url::Origin, sub: &VapidSub) -> CacheKey {
         CacheKey {
             kid: self.kid,
             origin_ascii: origin_ascii(aud),
+            sub_claim: sub.as_claim(),
         }
     }
 }
@@ -159,7 +164,7 @@ impl std::fmt::Debug for InProcessVapidSigner {
 
 impl VapidSigner for InProcessVapidSigner {
     fn sign(&self, aud: &url::Origin, sub: &VapidSub) -> Result<VapidJwt, VapidSignError> {
-        let key = self.cache_key(aud);
+        let key = self.cache_key(aud, sub);
         let now = now_unix_seconds();
         // Cache hit path — short critical section, then return.
         if let Ok(mut cache) = self.cache.lock() {
@@ -172,9 +177,12 @@ impl VapidSigner for InProcessVapidSigner {
             }
         }
 
-        // Sign a fresh JWT.
-        let iat = now - IAT_LAG.as_secs();
-        let exp = iat + VAPID_JWT_LIFETIME.as_secs();
+        // Sign a fresh JWT. `saturating_sub` guards against a mis-set system
+        // clock that returns `now == 0` (or `< IAT_LAG`) from
+        // `now_unix_seconds()`; underflow would panic in debug and wrap to a
+        // huge timestamp in release, producing JWTs push services reject.
+        let iat = now.saturating_sub(IAT_LAG.as_secs());
+        let exp = iat.saturating_add(VAPID_JWT_LIFETIME.as_secs());
         let claims = VapidClaims {
             aud: origin_ascii(aud),
             exp,
@@ -364,6 +372,24 @@ mod tests {
     }
 
     #[test]
+    fn signer_distinguishes_subs_within_same_origin() {
+        // The JWT claim set embeds `sub`, so a caller that varies `sub` for
+        // the same (kid, origin) MUST get a JWT with the new `sub` — not a
+        // cached one bound to a previous `sub` value.
+        use std::str::FromStr as _;
+        let signer = fresh_signer();
+        let aud = parse_origin("https://fcm.googleapis.com/fcm/send/abc");
+        let sub_a = VapidSub::default_for_domain("example.com").unwrap();
+        let sub_b = VapidSub::from_str("mailto:ops@example.com").unwrap();
+        let jwt_a = signer.sign(&aud, &sub_a).unwrap();
+        let jwt_b = signer.sign(&aud, &sub_b).unwrap();
+        assert_ne!(jwt_a, jwt_b, "cache key must include `sub`");
+        // Each `sub` round-trips under itself.
+        let jwt_a2 = signer.sign(&aud, &sub_a).unwrap();
+        assert_eq!(jwt_a, jwt_a2);
+    }
+
+    #[test]
     fn signer_distinguishes_origins() {
         let signer = fresh_signer();
         let aud_fcm = parse_origin("https://fcm.googleapis.com/fcm/send/abc");
@@ -390,12 +416,15 @@ mod tests {
 
     #[test]
     fn signer_verifies_with_own_public_key() {
+        use p256::pkcs8::EncodePublicKey;
         let signer = fresh_signer();
         let aud = parse_origin("https://fcm.googleapis.com/fcm/send/abc");
         let sub = VapidSub::default_for_domain("example.com").unwrap();
         let jwt = signer.sign(&aud, &sub).expect("sign");
-        let pk = signer.current_public_key();
-        let pk_pem = pk.to_string();
+        let pk_pem = signer
+            .current_public_key()
+            .to_public_key_pem(Default::default())
+            .expect("public-key PEM");
         let decoding_key =
             jsonwebtoken::DecodingKey::from_ec_pem(pk_pem.as_bytes()).expect("decode key");
         let mut validation = jsonwebtoken::Validation::new(Algorithm::ES256);

--- a/server/crates/waddle-xmpp/src/push/vapid.rs
+++ b/server/crates/waddle-xmpp/src/push/vapid.rs
@@ -1,0 +1,432 @@
+//! RFC 8292 VAPID — ES256 JWT signing + per-`(Kid, Origin)` LRU cache.
+//!
+//! ## Invariants
+//!
+//! - JWT header is `{"typ":"JWT","alg":"ES256"}`; **no `kid` field** (VAPID forbids it).
+//! - `aud` = scheme + host + optional non-default port; **no path** (RFC 8292 §2 + RFC 6454).
+//! - `k=` in the `Authorization` header is base64url-no-pad of the
+//!   uncompressed 65-byte P-256 point starting `0x04` — NOT the SPKI/DER form.
+//! - `jti` is random per signed JWT (RFC 7519 §4.1.7). With JWT caching, the
+//!   same `jti` is reused for cache-lifetime; **no replay-narrowing claim**
+//!   attached — kept for spec conformance.
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use jsonwebtoken::{Algorithm, EncodingKey, Header};
+use lru::LruCache;
+use p256::elliptic_curve::sec1::ToEncodedPoint;
+use rand::RngExt;
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use super::constants::{CACHE_EVICT_MARGIN, IAT_LAG, VAPID_JWT_CACHE_CAPACITY, VAPID_JWT_LIFETIME};
+use super::types::{Kid, VapidJwt, VapidSignError, VapidSub, WebPushCryptoError};
+
+/// Cross-crate boundary trait. Pure-crypto callers ask the trait for a
+/// signed JWT; the implementation in `waddle-server/src/push_service/`
+/// owns the durable key material.
+pub trait VapidSigner: Send + Sync {
+    fn sign(&self, aud: &url::Origin, sub: &VapidSub) -> Result<VapidJwt, VapidSignError>;
+
+    /// Current public key (uncompressed P-256 point material) for the
+    /// `Authorization: vapid k=…` header.
+    fn current_public_key(&self) -> p256::PublicKey;
+
+    /// Current `kid` (cache key component for the JWT cache + the disco-form
+    /// `kid` field for chat-side rotation detection).
+    fn current_kid(&self) -> Kid;
+}
+
+/// VAPID JWT claims body per RFC 8292 §2.
+#[derive(Debug, Serialize, Deserialize)]
+struct VapidClaims {
+    aud: String,
+    exp: u64,
+    sub: String,
+    iat: u64,
+    jti: String,
+}
+
+/// Resolve the `aud` claim from a subscription endpoint per RFC 8292 §2 +
+/// RFC 6454: scheme + host + optional non-default port. **No path.**
+/// Rejects opaque origins and non-`https` schemes.
+pub fn aud_for(endpoint: &Url) -> Result<url::Origin, WebPushCryptoError> {
+    let origin = endpoint.origin();
+    if !matches!(&origin, url::Origin::Tuple(scheme, _, _) if scheme == "https") {
+        return Err(WebPushCryptoError::InvalidEndpoint(format!(
+            "endpoint origin not https-tuple: {:?}",
+            origin
+        )));
+    }
+    Ok(origin)
+}
+
+/// `k=` value for the `Authorization: vapid t=<jwt>, k=<...>` header.
+/// Base64url-no-pad of the **uncompressed 65-byte P-256 point starting `0x04`**.
+/// Asserts the length/prefix invariant before encoding.
+pub fn vapid_k_header(public_key: &p256::PublicKey) -> String {
+    let encoded = public_key.to_encoded_point(/* compress= */ false);
+    let bytes = encoded.as_bytes();
+    debug_assert_eq!(bytes.len(), 65, "P-256 uncompressed point must be 65 bytes");
+    debug_assert_eq!(bytes[0], 0x04, "uncompressed-point prefix must be 0x04");
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// In-process signer combining a `p256::SecretKey` private key + LRU JWT
+/// cache keyed by `(Kid, Origin)`.
+///
+/// Wraps an `Arc<Mutex<LruCache>>` so concurrent senders share the cache.
+/// `max_capacity = VAPID_JWT_CACHE_CAPACITY` (32) — comfortably exceeds
+/// the legitimate browser-push origin set (~3), no origin allowlist.
+pub struct InProcessVapidSigner {
+    kid: Kid,
+    secret_key: p256::SecretKey,
+    encoding_key: EncodingKey,
+    cache: Arc<Mutex<LruCache<CacheKey, CachedJwt>>>,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct CacheKey {
+    kid: Kid,
+    /// Origin serialized once at key construction — `url::Origin` itself is
+    /// `Hash`/`Eq`, but we cache the canonical ASCII form for cheap comparisons.
+    origin_ascii: String,
+}
+
+#[derive(Clone)]
+struct CachedJwt {
+    jwt: VapidJwt,
+    /// `exp` in seconds since UNIX_EPOCH. Cache hit only if
+    /// `now() + CACHE_EVICT_MARGIN < exp`.
+    exp_unix_seconds: u64,
+}
+
+impl InProcessVapidSigner {
+    pub fn new(kid: Kid, secret_key: p256::SecretKey) -> Result<Self, VapidSignError> {
+        use p256::pkcs8::EncodePrivateKey;
+        let pem = secret_key
+            .to_pkcs8_pem(Default::default())
+            .map_err(|e| VapidSignError::Storage(format!("encode PKCS#8 PEM: {e}")))?;
+        let encoding_key =
+            EncodingKey::from_ec_pem(pem.as_bytes()).map_err(VapidSignError::Signing)?;
+        Ok(Self {
+            kid,
+            secret_key,
+            encoding_key,
+            cache: Arc::new(Mutex::new(LruCache::new(
+                NonZeroUsize::new(VAPID_JWT_CACHE_CAPACITY).expect("non-zero capacity"),
+            ))),
+        })
+    }
+
+    /// Drop every cached JWT — used on VAPID key rotation so stale
+    /// `(old_kid, *)` entries don't linger until LRU pressure evicts them.
+    pub fn invalidate_all(&self) {
+        if let Ok(mut cache) = self.cache.lock() {
+            cache.clear();
+        }
+    }
+
+    fn cache_key(&self, aud: &url::Origin) -> CacheKey {
+        CacheKey {
+            kid: self.kid,
+            origin_ascii: origin_ascii(aud),
+        }
+    }
+}
+
+/// Manual `Hash`/`Eq`/`PartialEq` on `CacheKey` are derived (above); origin
+/// is compared by its ASCII serialization to avoid the deprecated-API churn
+/// on `url::Origin` directly.
+impl std::fmt::Debug for InProcessVapidSigner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InProcessVapidSigner")
+            .field("kid", &self.kid)
+            .finish_non_exhaustive()
+    }
+}
+
+impl VapidSigner for InProcessVapidSigner {
+    fn sign(&self, aud: &url::Origin, sub: &VapidSub) -> Result<VapidJwt, VapidSignError> {
+        let key = self.cache_key(aud);
+        let now = now_unix_seconds();
+        // Cache hit path — short critical section, then return.
+        if let Ok(mut cache) = self.cache.lock() {
+            if let Some(entry) = cache.get(&key) {
+                if entry.exp_unix_seconds > now + CACHE_EVICT_MARGIN.as_secs() {
+                    return Ok(entry.jwt.clone());
+                }
+                // expired/about-to-expire: fall through to re-sign
+                cache.pop(&key);
+            }
+        }
+
+        // Sign a fresh JWT.
+        let iat = now - IAT_LAG.as_secs();
+        let exp = iat + VAPID_JWT_LIFETIME.as_secs();
+        let claims = VapidClaims {
+            aud: origin_ascii(aud),
+            exp,
+            sub: sub.as_claim(),
+            iat,
+            jti: fresh_jti(),
+        };
+        let header = Header::new(Algorithm::ES256);
+        let token = jsonwebtoken::encode(&header, &claims, &self.encoding_key)
+            .map_err(VapidSignError::Signing)?;
+        let jwt = VapidJwt(token);
+
+        if let Ok(mut cache) = self.cache.lock() {
+            cache.put(
+                key,
+                CachedJwt {
+                    jwt: jwt.clone(),
+                    exp_unix_seconds: exp,
+                },
+            );
+        }
+        Ok(jwt)
+    }
+
+    fn current_public_key(&self) -> p256::PublicKey {
+        self.secret_key.public_key()
+    }
+
+    fn current_kid(&self) -> Kid {
+        self.kid
+    }
+}
+
+fn now_unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn fresh_jti() -> String {
+    let bytes: [u8; 16] = {
+        let mut b = [0u8; 16];
+        rand::rng().fill(&mut b[..]);
+        b
+    };
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// Canonical ASCII serialization of an `url::Origin`. We compare/hash this
+/// rather than `url::Origin` itself to avoid `Hash`-bound friction with the
+/// internal `Tuple`/`Opaque` variants.
+fn origin_ascii(origin: &url::Origin) -> String {
+    origin.ascii_serialization()
+}
+
+// Suppress unused-field warnings (CacheKey hashes both fields explicitly).
+#[allow(dead_code)]
+fn _hash_cache_key(key: &CacheKey) -> u64 {
+    let mut h = DefaultHasher::new();
+    key.kid.as_uuid().hash(&mut h);
+    key.origin_ascii.hash(&mut h);
+    h.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use p256::elliptic_curve::rand_core::OsRng;
+
+    fn fresh_signer() -> InProcessVapidSigner {
+        let secret = p256::SecretKey::random(&mut OsRng);
+        InProcessVapidSigner::new(Kid::new(), secret).expect("signer init")
+    }
+
+    fn parse_origin(url: &str) -> url::Origin {
+        Url::parse(url).expect("valid").origin()
+    }
+
+    #[test]
+    fn aud_for_fcm_strips_path() {
+        let endpoint = Url::parse("https://fcm.googleapis.com/fcm/send/abc-def").unwrap();
+        let aud = aud_for(&endpoint).expect("valid");
+        assert_eq!(origin_ascii(&aud), "https://fcm.googleapis.com");
+    }
+
+    #[test]
+    fn aud_for_mozilla() {
+        let endpoint =
+            Url::parse("https://updates.push.services.mozilla.com/wpush/v2/abc").unwrap();
+        let aud = aud_for(&endpoint).expect("valid");
+        assert_eq!(
+            origin_ascii(&aud),
+            "https://updates.push.services.mozilla.com"
+        );
+    }
+
+    #[test]
+    fn aud_for_apple() {
+        let endpoint = Url::parse("https://web.push.apple.com/abc").unwrap();
+        let aud = aud_for(&endpoint).expect("valid");
+        assert_eq!(origin_ascii(&aud), "https://web.push.apple.com");
+    }
+
+    #[test]
+    fn aud_for_non_default_port() {
+        let endpoint = Url::parse("https://example.com:8443/push/abc").unwrap();
+        let aud = aud_for(&endpoint).expect("valid");
+        assert_eq!(origin_ascii(&aud), "https://example.com:8443");
+    }
+
+    #[test]
+    fn aud_for_rejects_http() {
+        let endpoint = Url::parse("http://insecure.example.com/abc").unwrap();
+        let err = aud_for(&endpoint).unwrap_err();
+        assert!(matches!(err, WebPushCryptoError::InvalidEndpoint(_)));
+    }
+
+    #[test]
+    fn aud_for_rejects_data_scheme() {
+        let endpoint = Url::parse("data:text/plain,hello").unwrap();
+        let err = aud_for(&endpoint).unwrap_err();
+        assert!(matches!(err, WebPushCryptoError::InvalidEndpoint(_)));
+    }
+
+    #[test]
+    fn vapid_k_header_is_65_byte_uncompressed_base64url() {
+        let secret = p256::SecretKey::random(&mut OsRng);
+        let pk = secret.public_key();
+        let k = vapid_k_header(&pk);
+        let decoded = URL_SAFE_NO_PAD.decode(&k).expect("base64url");
+        assert_eq!(decoded.len(), 65);
+        assert_eq!(decoded[0], 0x04);
+    }
+
+    #[test]
+    fn vapid_k_header_no_padding() {
+        let secret = p256::SecretKey::random(&mut OsRng);
+        let k = vapid_k_header(&secret.public_key());
+        assert!(!k.contains('='));
+        assert!(!k.contains('+'));
+        assert!(!k.contains('/'));
+    }
+
+    #[test]
+    fn signer_signs_jwt_with_correct_claims() {
+        let signer = fresh_signer();
+        let aud = parse_origin("https://fcm.googleapis.com/fcm/send/abc");
+        let sub = VapidSub::default_for_domain("example.com").unwrap();
+        let jwt = signer.sign(&aud, &sub).expect("sign");
+        // Parse the JWT (skip signature verify here; we have a separate
+        // verification test below).
+        let mut parts = jwt.as_str().split('.');
+        let _header = parts.next().expect("header");
+        let claims_b64 = parts.next().expect("claims");
+        let claims_bytes = URL_SAFE_NO_PAD
+            .decode(claims_b64)
+            .expect("claims base64url");
+        let claims: serde_json::Value = serde_json::from_slice(&claims_bytes).expect("claims json");
+        assert_eq!(claims["aud"], "https://fcm.googleapis.com");
+        assert_eq!(claims["sub"], "mailto:postmaster@example.com");
+        assert!(claims["jti"].is_string());
+        assert!(claims["iat"].is_number());
+        assert!(claims["exp"].is_number());
+        let iat = claims["iat"].as_u64().unwrap();
+        let exp = claims["exp"].as_u64().unwrap();
+        assert_eq!(exp - iat, VAPID_JWT_LIFETIME.as_secs());
+    }
+
+    #[test]
+    fn signer_jwt_header_has_no_kid_field() {
+        let signer = fresh_signer();
+        let aud = parse_origin("https://fcm.googleapis.com/fcm/send/abc");
+        let sub = VapidSub::default_for_domain("example.com").unwrap();
+        let jwt = signer.sign(&aud, &sub).expect("sign");
+        let header_b64 = jwt.as_str().split('.').next().unwrap();
+        let header_bytes = URL_SAFE_NO_PAD.decode(header_b64).expect("header");
+        let header: serde_json::Value = serde_json::from_slice(&header_bytes).unwrap();
+        assert_eq!(header["alg"], "ES256");
+        assert_eq!(header["typ"], "JWT");
+        assert!(
+            header.get("kid").is_none(),
+            "VAPID forbids `kid` in JWT header"
+        );
+    }
+
+    #[test]
+    fn signer_caches_per_origin() {
+        let signer = fresh_signer();
+        let aud_a = parse_origin("https://fcm.googleapis.com/fcm/send/abc");
+        let aud_b = parse_origin("https://fcm.googleapis.com/fcm/send/different");
+        let sub = VapidSub::default_for_domain("example.com").unwrap();
+        let jwt_1 = signer.sign(&aud_a, &sub).unwrap();
+        let jwt_2 = signer.sign(&aud_b, &sub).unwrap();
+        // Same origin (just different paths) → same cache key → identical JWT.
+        assert_eq!(jwt_1, jwt_2);
+    }
+
+    #[test]
+    fn signer_distinguishes_origins() {
+        let signer = fresh_signer();
+        let aud_fcm = parse_origin("https://fcm.googleapis.com/fcm/send/abc");
+        let aud_moz = parse_origin("https://updates.push.services.mozilla.com/wpush/v2/abc");
+        let sub = VapidSub::default_for_domain("example.com").unwrap();
+        let jwt_fcm = signer.sign(&aud_fcm, &sub).unwrap();
+        let jwt_moz = signer.sign(&aud_moz, &sub).unwrap();
+        assert_ne!(jwt_fcm, jwt_moz);
+    }
+
+    #[test]
+    fn invalidate_all_clears_cache() {
+        let signer = fresh_signer();
+        let aud = parse_origin("https://fcm.googleapis.com/fcm/send/abc");
+        let sub = VapidSub::default_for_domain("example.com").unwrap();
+        let jwt_a = signer.sign(&aud, &sub).unwrap();
+        signer.invalidate_all();
+        let jwt_b = signer.sign(&aud, &sub).unwrap();
+        // After invalidate_all, a fresh signing produces a new jti (random)
+        // — so the JWTs differ even though the cache key, claims (modulo jti),
+        // and key are identical.
+        assert_ne!(jwt_a, jwt_b);
+    }
+
+    #[test]
+    fn signer_verifies_with_own_public_key() {
+        let signer = fresh_signer();
+        let aud = parse_origin("https://fcm.googleapis.com/fcm/send/abc");
+        let sub = VapidSub::default_for_domain("example.com").unwrap();
+        let jwt = signer.sign(&aud, &sub).expect("sign");
+        let pk = signer.current_public_key();
+        let pk_pem = pk.to_string();
+        let decoding_key =
+            jsonwebtoken::DecodingKey::from_ec_pem(pk_pem.as_bytes()).expect("decode key");
+        let mut validation = jsonwebtoken::Validation::new(Algorithm::ES256);
+        validation.set_audience(&["https://fcm.googleapis.com"]);
+        let _ = jsonwebtoken::decode::<VapidClaims>(jwt.as_str(), &decoding_key, &validation)
+            .expect("verifies under our own public key");
+    }
+
+    #[test]
+    fn jti_is_unique_across_signed_jwts() {
+        // jti within a cached JWT lifetime is reused (documented). To verify
+        // RFC 7519 conformance (random 128-bit), invalidate the cache
+        // between signs.
+        let signer = fresh_signer();
+        let aud = parse_origin("https://fcm.googleapis.com/fcm/send/abc");
+        let sub = VapidSub::default_for_domain("example.com").unwrap();
+        let jwt_a = signer.sign(&aud, &sub).unwrap();
+        signer.invalidate_all();
+        let jwt_b = signer.sign(&aud, &sub).unwrap();
+        let extract_jti = |jwt: &VapidJwt| -> String {
+            let parts: Vec<&str> = jwt.as_str().split('.').collect();
+            let claims_bytes = URL_SAFE_NO_PAD.decode(parts[1]).unwrap();
+            let claims: serde_json::Value = serde_json::from_slice(&claims_bytes).unwrap();
+            claims["jti"].as_str().unwrap().to_string()
+        };
+        assert_ne!(extract_jti(&jwt_a), extract_jti(&jwt_b));
+    }
+}

--- a/server/crates/waddle-xmpp/src/push/vapid.rs
+++ b/server/crates/waddle-xmpp/src/push/vapid.rs
@@ -75,7 +75,13 @@ pub fn vapid_k_header(public_key: &p256::PublicKey) -> String {
 }
 
 /// In-process signer combining a `p256::SecretKey` private key + LRU JWT
-/// cache keyed by `(Kid, Origin)`.
+/// cache keyed by `(Kid, ascii-origin, sub-claim)`.
+///
+/// `sub` is part of the cache key because it lands in the JWT claim set —
+/// a caller varying `sub` for the same `(kid, origin)` MUST get a fresh
+/// JWT, not a cached one. `origin` is stored as its canonical ASCII
+/// serialization rather than as `url::Origin` to keep the key cheap to
+/// hash without `Tuple`/`Opaque` discriminator overhead.
 ///
 /// Wraps an `Arc<Mutex<LruCache>>` so concurrent senders share the cache.
 /// `max_capacity = VAPID_JWT_CACHE_CAPACITY` (32) — comfortably exceeds

--- a/server/crates/waddle-xmpp/src/push/vapid.rs
+++ b/server/crates/waddle-xmpp/src/push/vapid.rs
@@ -10,8 +10,6 @@
 //!   same `jti` is reused for cache-lifetime; **no replay-narrowing claim**
 //!   attached — kept for spec conformance.
 
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -87,7 +85,7 @@ pub fn vapid_k_header(public_key: &p256::PublicKey) -> String {
 /// the legitimate browser-push origin set (~3), no origin allowlist.
 pub struct InProcessVapidSigner {
     kid: Kid,
-    secret_key: p256::SecretKey,
+    public_key: p256::PublicKey,
     encoding_key: EncodingKey,
     cache: Arc<Mutex<LruCache<CacheKey, CachedJwt>>>,
 }
@@ -109,16 +107,25 @@ struct CachedJwt {
 }
 
 impl InProcessVapidSigner {
+    /// Constructs a signer from a P-256 keypair. The raw `secret_key`
+    /// is consumed: its public point is captured and the scalar is
+    /// dropped (`p256::SecretKey` zeroizes on drop), leaving only the
+    /// `EncodingKey` (PKCS#8 PEM bytes) as the residual sign-capable
+    /// material in heap.
     pub fn new(kid: Kid, secret_key: p256::SecretKey) -> Result<Self, VapidSignError> {
         use p256::pkcs8::EncodePrivateKey;
+        let public_key = secret_key.public_key();
         let pem = secret_key
             .to_pkcs8_pem(Default::default())
             .map_err(|e| VapidSignError::Storage(format!("encode PKCS#8 PEM: {e}")))?;
         let encoding_key =
             EncodingKey::from_ec_pem(pem.as_bytes()).map_err(VapidSignError::Signing)?;
+        // `secret_key` drops here (zeroized by p256). `pem` is `Zeroizing<String>`
+        // and also zeroizes here. Only `encoding_key` retains key material.
+        drop(secret_key);
         Ok(Self {
             kid,
-            secret_key,
+            public_key,
             encoding_key,
             cache: Arc::new(Mutex::new(LruCache::new(
                 NonZeroUsize::new(VAPID_JWT_CACHE_CAPACITY).expect("non-zero capacity"),
@@ -142,9 +149,6 @@ impl InProcessVapidSigner {
     }
 }
 
-/// Manual `Hash`/`Eq`/`PartialEq` on `CacheKey` are derived (above); origin
-/// is compared by its ASCII serialization to avoid the deprecated-API churn
-/// on `url::Origin` directly.
 impl std::fmt::Debug for InProcessVapidSigner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("InProcessVapidSigner")
@@ -196,7 +200,7 @@ impl VapidSigner for InProcessVapidSigner {
     }
 
     fn current_public_key(&self) -> p256::PublicKey {
-        self.secret_key.public_key()
+        self.public_key
     }
 
     fn current_kid(&self) -> Kid {
@@ -220,20 +224,10 @@ fn fresh_jti() -> String {
     URL_SAFE_NO_PAD.encode(bytes)
 }
 
-/// Canonical ASCII serialization of an `url::Origin`. We compare/hash this
-/// rather than `url::Origin` itself to avoid `Hash`-bound friction with the
-/// internal `Tuple`/`Opaque` variants.
+/// Canonical ASCII serialization of an `url::Origin`. Used in both the
+/// cache key and as the `aud` claim string.
 fn origin_ascii(origin: &url::Origin) -> String {
     origin.ascii_serialization()
-}
-
-// Suppress unused-field warnings (CacheKey hashes both fields explicitly).
-#[allow(dead_code)]
-fn _hash_cache_key(key: &CacheKey) -> u64 {
-    let mut h = DefaultHasher::new();
-    key.kid.as_uuid().hash(&mut h);
-    key.origin_ascii.hash(&mut h);
-    h.finish()
 }
 
 #[cfg(test)]

--- a/server/crates/waddle-xmpp/src/push/vapid.rs
+++ b/server/crates/waddle-xmpp/src/push/vapid.rs
@@ -203,7 +203,7 @@ impl VapidSigner for InProcessVapidSigner {
         let header = Header::new(Algorithm::ES256);
         let token = jsonwebtoken::encode(&header, &claims, &self.encoding_key)
             .map_err(VapidSignError::Signing)?;
-        let jwt = VapidJwt::new(token);
+        let jwt = VapidJwt::new(&token)?;
 
         let mut cache = self.lock_cache_recovering();
         cache.put(

--- a/server/crates/waddle-xmpp/src/push/vapid.rs
+++ b/server/crates/waddle-xmpp/src/push/vapid.rs
@@ -140,9 +140,21 @@ impl InProcessVapidSigner {
     /// Drop every cached JWT — used on VAPID key rotation so stale
     /// `(old_kid, *)` entries don't linger until LRU pressure evicts them.
     pub fn invalidate_all(&self) {
-        if let Ok(mut cache) = self.cache.lock() {
-            cache.clear();
-        }
+        let mut cache = self.lock_cache_recovering();
+        cache.clear();
+    }
+
+    /// Lock the cache, recovering from a poisoned mutex by extracting the
+    /// inner guard. The cache's invariants don't depend on prior writers
+    /// having completed successfully — every entry is independent — so
+    /// poison recovery is safe and matches what `parking_lot::Mutex` would
+    /// do natively. Without this recovery, a single panic anywhere in the
+    /// signer would silently bypass the cache for the rest of the process
+    /// lifetime, forcing unbounded re-signing.
+    fn lock_cache_recovering(&self) -> std::sync::MutexGuard<'_, LruCache<CacheKey, CachedJwt>> {
+        self.cache
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
     fn cache_key(&self, aud: &url::Origin, sub: &VapidSub) -> CacheKey {
@@ -167,7 +179,8 @@ impl VapidSigner for InProcessVapidSigner {
         let key = self.cache_key(aud, sub);
         let now = now_unix_seconds();
         // Cache hit path — short critical section, then return.
-        if let Ok(mut cache) = self.cache.lock() {
+        {
+            let mut cache = self.lock_cache_recovering();
             if let Some(entry) = cache.get(&key) {
                 if entry.exp_unix_seconds > now + CACHE_EVICT_MARGIN.as_secs() {
                     return Ok(entry.jwt.clone());
@@ -195,15 +208,15 @@ impl VapidSigner for InProcessVapidSigner {
             .map_err(VapidSignError::Signing)?;
         let jwt = VapidJwt::new(token);
 
-        if let Ok(mut cache) = self.cache.lock() {
-            cache.put(
-                key,
-                CachedJwt {
-                    jwt: jwt.clone(),
-                    exp_unix_seconds: exp,
-                },
-            );
-        }
+        let mut cache = self.lock_cache_recovering();
+        cache.put(
+            key,
+            CachedJwt {
+                jwt: jwt.clone(),
+                exp_unix_seconds: exp,
+            },
+        );
+        drop(cache);
         Ok(jwt)
     }
 

--- a/server/crates/waddle-xmpp/src/push/vapid.rs
+++ b/server/crates/waddle-xmpp/src/push/vapid.rs
@@ -93,16 +93,20 @@ pub struct InProcessVapidSigner {
     cache: Arc<Mutex<LruCache<CacheKey, CachedJwt>>>,
 }
 
+/// JWT cache key — typed end-to-end. `url::Origin` and `VapidSub` already
+/// implement `Hash + Eq + Clone`, so the cache compares structured values
+/// rather than ad-hoc string serializations. String conversion is
+/// deferred to the JWT-serialization boundary (`as_claim` /
+/// `ascii_serialization` are called only when populating the JWT claim
+/// set right before signing).
 #[derive(Clone, PartialEq, Eq, Hash)]
 struct CacheKey {
     kid: Kid,
-    /// Origin serialized once at key construction — `url::Origin` itself is
-    /// `Hash`/`Eq`, but we cache the canonical ASCII form for cheap comparisons.
-    origin_ascii: String,
+    aud: url::Origin,
     /// `sub` is part of the JWT claim set, so a cache hit MUST require an
     /// exact match — otherwise a caller varying `sub` for the same
-    /// `(kid, origin)` would receive a stale-`sub` JWT.
-    sub_claim: String,
+    /// `(kid, aud)` would receive a stale-`sub` JWT.
+    sub: VapidSub,
 }
 
 #[derive(Clone)]
@@ -163,8 +167,8 @@ impl InProcessVapidSigner {
     fn cache_key(&self, aud: &url::Origin, sub: &VapidSub) -> CacheKey {
         CacheKey {
             kid: self.kid,
-            origin_ascii: origin_ascii(aud),
-            sub_claim: sub.as_claim(),
+            aud: aud.clone(),
+            sub: sub.clone(),
         }
     }
 }
@@ -199,8 +203,11 @@ impl VapidSigner for InProcessVapidSigner {
         // huge timestamp in release, producing JWTs push services reject.
         let iat = now.saturating_sub(IAT_LAG.as_secs());
         let exp = iat.saturating_add(VAPID_JWT_LIFETIME.as_secs());
+        // String serialization happens only at the JWT-serialization
+        // boundary — typed `url::Origin` and `VapidSub` are converted
+        // here when populating the claim set.
         let claims = VapidClaims {
-            aud: origin_ascii(aud),
+            aud: aud.ascii_serialization(),
             exp,
             sub: sub.as_claim(),
             iat,
@@ -248,12 +255,6 @@ fn fresh_jti() -> String {
     URL_SAFE_NO_PAD.encode(bytes)
 }
 
-/// Canonical ASCII serialization of an `url::Origin`. Used in both the
-/// cache key and as the `aud` claim string.
-fn origin_ascii(origin: &url::Origin) -> String {
-    origin.ascii_serialization()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -272,7 +273,7 @@ mod tests {
     fn aud_for_fcm_strips_path() {
         let endpoint = Url::parse("https://fcm.googleapis.com/fcm/send/abc-def").unwrap();
         let aud = aud_for(&endpoint).expect("valid");
-        assert_eq!(origin_ascii(&aud), "https://fcm.googleapis.com");
+        assert_eq!(aud.ascii_serialization(), "https://fcm.googleapis.com");
     }
 
     #[test]
@@ -281,7 +282,7 @@ mod tests {
             Url::parse("https://updates.push.services.mozilla.com/wpush/v2/abc").unwrap();
         let aud = aud_for(&endpoint).expect("valid");
         assert_eq!(
-            origin_ascii(&aud),
+            aud.ascii_serialization(),
             "https://updates.push.services.mozilla.com"
         );
     }
@@ -290,14 +291,14 @@ mod tests {
     fn aud_for_apple() {
         let endpoint = Url::parse("https://web.push.apple.com/abc").unwrap();
         let aud = aud_for(&endpoint).expect("valid");
-        assert_eq!(origin_ascii(&aud), "https://web.push.apple.com");
+        assert_eq!(aud.ascii_serialization(), "https://web.push.apple.com");
     }
 
     #[test]
     fn aud_for_non_default_port() {
         let endpoint = Url::parse("https://example.com:8443/push/abc").unwrap();
         let aud = aud_for(&endpoint).expect("valid");
-        assert_eq!(origin_ascii(&aud), "https://example.com:8443");
+        assert_eq!(aud.ascii_serialization(), "https://example.com:8443");
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/push/vapid.rs
+++ b/server/crates/waddle-xmpp/src/push/vapid.rs
@@ -58,10 +58,7 @@ struct VapidClaims {
 pub fn aud_for(endpoint: &Url) -> Result<url::Origin, WebPushCryptoError> {
     let origin = endpoint.origin();
     if !matches!(&origin, url::Origin::Tuple(scheme, _, _) if scheme == "https") {
-        return Err(WebPushCryptoError::InvalidEndpoint(format!(
-            "endpoint origin not https-tuple: {:?}",
-            origin
-        )));
+        return Err(WebPushCryptoError::InvalidEndpoint { origin });
     }
     Ok(origin)
 }
@@ -121,7 +118,7 @@ impl InProcessVapidSigner {
         let public_key = secret_key.public_key();
         let pem = secret_key
             .to_pkcs8_pem(Default::default())
-            .map_err(|e| VapidSignError::Storage(format!("encode PKCS#8 PEM: {e}")))?;
+            .map_err(|source| VapidSignError::KeyEncoding { source })?;
         let encoding_key =
             EncodingKey::from_ec_pem(pem.as_bytes()).map_err(VapidSignError::Signing)?;
         // `secret_key` drops here (zeroized by p256). `pem` is `Zeroizing<String>`
@@ -301,14 +298,14 @@ mod tests {
     fn aud_for_rejects_http() {
         let endpoint = Url::parse("http://insecure.example.com/abc").unwrap();
         let err = aud_for(&endpoint).unwrap_err();
-        assert!(matches!(err, WebPushCryptoError::InvalidEndpoint(_)));
+        assert!(matches!(err, WebPushCryptoError::InvalidEndpoint { .. }));
     }
 
     #[test]
     fn aud_for_rejects_data_scheme() {
         let endpoint = Url::parse("data:text/plain,hello").unwrap();
         let err = aud_for(&endpoint).unwrap_err();
-        assert!(matches!(err, WebPushCryptoError::InvalidEndpoint(_)));
+        assert!(matches!(err, WebPushCryptoError::InvalidEndpoint { .. }));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/push/vapid.rs
+++ b/server/crates/waddle-xmpp/src/push/vapid.rs
@@ -185,7 +185,7 @@ impl VapidSigner for InProcessVapidSigner {
         let header = Header::new(Algorithm::ES256);
         let token = jsonwebtoken::encode(&header, &claims, &self.encoding_key)
             .map_err(VapidSignError::Signing)?;
-        let jwt = VapidJwt(token);
+        let jwt = VapidJwt::new(token);
 
         if let Ok(mut cache) = self.cache.lock() {
             cache.put(

--- a/server/crates/waddle-xmpp/tests/xep0357_push_notifications.rs
+++ b/server/crates/waddle-xmpp/tests/xep0357_push_notifications.rs
@@ -13,10 +13,10 @@ use url::Url;
 use waddle_xmpp::disco::{server_features, Feature};
 use waddle_xmpp::pubsub::pep::pep_features;
 use waddle_xmpp::push::constants::{
-    AES128GCM_HEADER_LEN, AES128GCM_PAD_DELIMITER_LEN, AES128GCM_TAG_LEN, DEFAULT_PLAINTEXT_BUCKET,
-    DM_PLAINTEXT_BUCKET, WEB_PUSH_MAX_BODY_LEN, WEB_PUSH_MAX_PLAINTEXT, WEB_PUSH_MAX_RS,
+    AES128GCM_HEADER_LEN, AES128GCM_PAD_DELIMITER_LEN, AES128GCM_TAG_LEN, DM_PLAINTEXT_BUCKET,
+    WEB_PUSH_MAX_BODY_LEN, WEB_PUSH_MAX_PLAINTEXT, WEB_PUSH_MAX_RS,
 };
-use waddle_xmpp::push::encrypt::{encrypt, header_keyid, header_rs};
+use waddle_xmpp::push::encrypt::encrypt;
 use waddle_xmpp::push::types::{Kid, SubscriptionKeys, VapidSub};
 use waddle_xmpp::push::vapid::{aud_for, vapid_k_header, InProcessVapidSigner, VapidSigner};
 
@@ -74,37 +74,20 @@ fn sample_subscription() -> SubscriptionKeys {
 }
 
 #[test]
-fn aes128gcm_header_rs_round_trips_to_record_length() {
-    let sub = sample_subscription();
-    let payload = encrypt(&sub, b"hello", DEFAULT_PLAINTEXT_BUCKET).expect("encrypts");
-    let body = payload.as_slice();
-    let rs = header_rs(body).expect("rs field present");
-    // rs in the header == actual record length on the wire (no fragmentation).
-    let record_len = body.len() - AES128GCM_HEADER_LEN;
-    assert_eq!(rs as usize, record_len);
-    // record_len = bucket + delim + tag for the chosen bucket size.
-    assert_eq!(
-        record_len,
-        DEFAULT_PLAINTEXT_BUCKET + AES128GCM_PAD_DELIMITER_LEN + AES128GCM_TAG_LEN
-    );
-}
-
-#[test]
 fn dm_bucket_stays_under_web_push_max_body() {
     let sub = sample_subscription();
     // Exercise the max DM bucket plaintext.
     let pt = vec![0u8; DM_PLAINTEXT_BUCKET];
     let payload = encrypt(&sub, &pt, DM_PLAINTEXT_BUCKET).expect("encrypts");
     assert!(payload.as_slice().len() <= WEB_PUSH_MAX_BODY_LEN);
-}
-
-#[test]
-fn encrypt_keyid_is_uncompressed_p256_point() {
-    let sub = sample_subscription();
-    let payload = encrypt(&sub, b"x", DEFAULT_PLAINTEXT_BUCKET).expect("encrypts");
-    let keyid = header_keyid(payload.as_slice()).expect("keyid present");
-    assert_eq!(keyid.len(), 65);
-    assert_eq!(keyid[0], 0x04, "uncompressed-point prefix");
+    // Body layout sanity: header + (bucket + delim + tag).
+    assert_eq!(
+        payload.as_slice().len(),
+        AES128GCM_HEADER_LEN
+            + DM_PLAINTEXT_BUCKET
+            + AES128GCM_PAD_DELIMITER_LEN
+            + AES128GCM_TAG_LEN
+    );
 }
 
 // ── RFC 8292 VAPID — end-to-end sign + verify under our own key ──────────────

--- a/server/crates/waddle-xmpp/tests/xep0357_push_notifications.rs
+++ b/server/crates/waddle-xmpp/tests/xep0357_push_notifications.rs
@@ -1,9 +1,28 @@
-//! XEP-0357: Push Notifications compatibility dedicated suite.
+//! XEP-0357: Push Notifications — custom test suite (CLAUDE.md hard rule).
+//!
+//! Module-level unit tests live in `src/push/{constants,types,encrypt,vapid}.rs`.
+//! This file holds the cross-module integration assertions and any
+//! XEP-0357-shape feature-advertisement tests.
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use p256::elliptic_curve::rand_core::OsRng;
+use p256::elliptic_curve::sec1::ToEncodedPoint;
+use url::Url;
 
 use waddle_xmpp::disco::{server_features, Feature};
 use waddle_xmpp::pubsub::pep::pep_features;
+use waddle_xmpp::push::constants::{
+    AES128GCM_HEADER_LEN, AES128GCM_PAD_DELIMITER_LEN, AES128GCM_TAG_LEN, DEFAULT_PLAINTEXT_BUCKET,
+    DM_PLAINTEXT_BUCKET, WEB_PUSH_MAX_BODY_LEN, WEB_PUSH_MAX_PLAINTEXT, WEB_PUSH_MAX_RS,
+};
+use waddle_xmpp::push::encrypt::{encrypt, header_keyid, header_rs};
+use waddle_xmpp::push::types::{Kid, SubscriptionKeys, VapidSub};
+use waddle_xmpp::push::vapid::{aud_for, vapid_k_header, InProcessVapidSigner, VapidSigner};
 
 const PUSH_FEATURE: &str = "urn:xmpp:push:0";
+
+// ── XEP-0357 §10 feature advertisement ────────────────────────────────────────
 
 #[test]
 fn xep0357_pep_advertises_push_feature() {
@@ -22,4 +41,113 @@ fn xep0357_push_feature_is_unique_in_pep_features() {
     let features = pep_features();
     let count = features.iter().filter(|f| f.0 == PUSH_FEATURE).count();
     assert_eq!(count, 1);
+}
+
+// ── RFC 8291 / RFC 8188 constants invariants (cross-checked here so a
+//    regression in constants.rs surfaces in the dedicated XEP test suite) ─────
+
+#[test]
+fn rfc_8188_body_arithmetic() {
+    // Body = header + record, record = plaintext_pad_delim_tag, rs is per-record max.
+    assert_eq!(
+        AES128GCM_HEADER_LEN + WEB_PUSH_MAX_RS as usize,
+        WEB_PUSH_MAX_BODY_LEN
+    );
+    assert_eq!(
+        WEB_PUSH_MAX_PLAINTEXT,
+        WEB_PUSH_MAX_RS as usize - AES128GCM_TAG_LEN - AES128GCM_PAD_DELIMITER_LEN
+    );
+    // Conservative cap is 4096 bytes body.
+    assert_eq!(WEB_PUSH_MAX_BODY_LEN, 4096);
+    assert_eq!(WEB_PUSH_MAX_RS, 4010);
+    assert_eq!(WEB_PUSH_MAX_PLAINTEXT, 3993);
+}
+
+// ── RFC 8291 encrypt — header-field round-trip and bucket determinism ────────
+
+fn sample_subscription() -> SubscriptionKeys {
+    let secret = p256::SecretKey::random(&mut OsRng);
+    let pk = secret.public_key().to_encoded_point(false);
+    let p256dh = URL_SAFE_NO_PAD.encode(pk.as_bytes());
+    let auth = URL_SAFE_NO_PAD.encode([0xCDu8; 16]);
+    SubscriptionKeys::from_base64url(&p256dh, &auth).expect("valid subscription")
+}
+
+#[test]
+fn aes128gcm_header_rs_round_trips_to_record_length() {
+    let sub = sample_subscription();
+    let payload = encrypt(&sub, b"hello", DEFAULT_PLAINTEXT_BUCKET).expect("encrypts");
+    let body = payload.as_slice();
+    let rs = header_rs(body).expect("rs field present");
+    // rs in the header == actual record length on the wire (no fragmentation).
+    let record_len = body.len() - AES128GCM_HEADER_LEN;
+    assert_eq!(rs as usize, record_len);
+    // record_len = bucket + delim + tag for the chosen bucket size.
+    assert_eq!(
+        record_len,
+        DEFAULT_PLAINTEXT_BUCKET + AES128GCM_PAD_DELIMITER_LEN + AES128GCM_TAG_LEN
+    );
+}
+
+#[test]
+fn dm_bucket_stays_under_web_push_max_body() {
+    let sub = sample_subscription();
+    // Exercise the max DM bucket plaintext.
+    let pt = vec![0u8; DM_PLAINTEXT_BUCKET];
+    let payload = encrypt(&sub, &pt, DM_PLAINTEXT_BUCKET).expect("encrypts");
+    assert!(payload.as_slice().len() <= WEB_PUSH_MAX_BODY_LEN);
+}
+
+#[test]
+fn encrypt_keyid_is_uncompressed_p256_point() {
+    let sub = sample_subscription();
+    let payload = encrypt(&sub, b"x", DEFAULT_PLAINTEXT_BUCKET).expect("encrypts");
+    let keyid = header_keyid(payload.as_slice()).expect("keyid present");
+    assert_eq!(keyid.len(), 65);
+    assert_eq!(keyid[0], 0x04, "uncompressed-point prefix");
+}
+
+// ── RFC 8292 VAPID — end-to-end sign + verify under our own key ──────────────
+
+#[test]
+fn vapid_signer_produces_jwt_verifiable_under_own_public_key() {
+    let secret = p256::SecretKey::random(&mut OsRng);
+    let kid = Kid::new();
+    let signer = InProcessVapidSigner::new(kid, secret).expect("signer");
+    let aud = aud_for(&Url::parse("https://fcm.googleapis.com/fcm/send/abc").unwrap())
+        .expect("valid endpoint");
+    let sub = VapidSub::default_for_domain("example.com").expect("valid sub");
+    let jwt = signer.sign(&aud, &sub).expect("sign");
+
+    // Verify the JWT under our own public key.
+    use p256::pkcs8::EncodePublicKey;
+    let pk_pem = signer
+        .current_public_key()
+        .to_public_key_pem(Default::default())
+        .expect("public key PEM");
+    let decoding_key =
+        jsonwebtoken::DecodingKey::from_ec_pem(pk_pem.as_bytes()).expect("decoding key");
+    let mut validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::ES256);
+    validation.set_audience(&["https://fcm.googleapis.com"]);
+    // Decode into untyped JSON to avoid coupling to internal claim struct shape.
+    let _decoded =
+        jsonwebtoken::decode::<serde_json::Value>(jwt.as_str(), &decoding_key, &validation)
+            .expect("JWT verifies under our own public key");
+}
+
+#[test]
+fn vapid_k_header_matches_signer_public_key() {
+    let secret = p256::SecretKey::random(&mut OsRng);
+    let signer = InProcessVapidSigner::new(Kid::new(), secret).expect("signer");
+    let k = vapid_k_header(&signer.current_public_key());
+    // Decoded bytes are exactly the uncompressed public-key point.
+    let decoded = URL_SAFE_NO_PAD.decode(&k).expect("base64url decode");
+    assert_eq!(decoded.len(), 65);
+    assert_eq!(decoded[0], 0x04);
+    let expected = signer
+        .current_public_key()
+        .to_encoded_point(false)
+        .as_bytes()
+        .to_vec();
+    assert_eq!(decoded, expected);
 }


### PR DESCRIPTION
## Summary

PR-D1 of three stacked PRs implementing in-process Web Push delivery (#762, parent #506; finishes the half of #97 that #521 did not cover).

**Current state**: scaffolding committed (`aes-gcm` + `hkdf` workspace dep reservations) for diff-context. First-use module commits land **on this branch** before the PR exits draft. The "Scope" below describes the **end-state of PR-D1 before merge**, not the current diff.

The plan in #762 went through three rounds of adversarial review; this description reflects the round-3 revised scope.

## Scope of PR-D1 (end-state)

### Cycle-safe split (cross-crate)

Dep direction is `waddle-server → waddle-xmpp`. Pure crypto in `waddle-xmpp`; durable storage in `waddle-server`; cross-crate boundary is the `VapidSigner` trait:

```rust
pub trait VapidSigner: Send + Sync {
    type Error: std::error::Error + Send + Sync + 'static;
    fn sign(&self, kid: &Kid, aud: &url::Origin, sub: &VapidSub)
        -> Result<VapidJwt, Self::Error>;
    fn current_public_key(&self) -> P256PublicKey;
    fn current_kid(&self) -> Kid;
}
```

`HttpWebPushSender::new(vapid_signer: Arc<dyn VapidSigner<Error = VapidSignError>>, ...)` constructed in `waddle-server`'s wiring.

### Storage (in `waddle-server/src/push_service/vapid_storage.rs`)

- **New table** `push_service_vapid_keys` (`id`, `kid`, `sealed_private_key`, `public_key`, `root_key_version`, `created_at_ms`, `retired_at_ms`).
- **AEAD sealing** with `aes-gcm` (AES-256-GCM). **Length-prefixed AAD**: `u16_be(len(label)) || label || u16_be(len(kid)) || kid` (prevents canonicalization collisions, stable across DB-restore that renumbers `id`).
- `root_key_version` column persisted in sealed blob header; reseal-on-read is **single-flight per `kid`** (per-`kid` `tokio::sync::Mutex`) to avoid thundering herd; **`VapidLoadError::UnknownRootKeyVersion`** soft-fails to `WebPushCapability::Disabled` when sealed blob's version exceeds installed root keys.

### VAPID keypair lifecycle

- Env override `WADDLE_VAPID_PRIVATE_KEY` (format: **base64url-no-pad of raw 32-byte P-256 scalar**; PEM/JWK rejected; leading-zero scalars supported and tested).
- **Write-before-remove ordering**: parse env → DB write FIRST → on `Ok` call `std::env::remove_var(...)`. On `Err`, leave env set and fail boot loudly.
- Else read latest non-retired row; else generate fresh P-256 and persist.
- **Cluster-boot env race**: known limitation; CLI `waddle-server vapid-keys import` follow-up.

### `waddle-xmpp/src/push/encrypt.rs` (RFC 8291)

- Hand-rolled `aes128gcm` per RFC 8188 + RFC 8291.
- **HKDF-derived nonce** per RFC 8188 §2.2 (`info = "Content-Encoding: nonce\0"`, sequence 0). **Never random.**
- **Fresh ephemeral P-256 keypair per `encrypt()`**; never stored; `zeroize`'d on drop.
- HKDF `info` strings byte-for-byte per RFC 8291 §3.4.
- Padding: `plaintext || 0x02 || 0x00*` inside the single AES-GCM record. Bucket by class (256 normal / 1024 for `DirectMessage*`).
- **`rs` semantics (RFC 8188 §2.1)**: `rs` is the **per-record max size = plaintext+pad+delim+tag**. Pin **`rs = 4010`** so body = `86 (header) + 4010 = 4096` (FCM's documented 4KB Web-Push body cap, conservatively applied). **Max plaintext+pad ≤ 3993 bytes**. Test decodes emitted header's u32 `rs` and asserts it equals actual record length.
- `SubscriptionKeys { p256dh: P256PublicKey, auth: Arc<AuthSecret> }` parsed at deserialization boundary; strict length+prefix validation; malformed → typed `PushError::MalformedSubscription`.
- **`AuthSecret`**: `#[derive(ZeroizeOnDrop)] struct AuthSecret([u8; 16]); // NOT Clone`. Sharing via `Arc<AuthSecret>` so only the final drop zeroizes.

### `waddle-xmpp/src/push/vapid.rs` (RFC 8292)

- ES256 JWT signing via `jsonwebtoken` + `aws_lc_rs`.
- `aud_for(endpoint: &Url) -> Result<url::Origin, PushError::InvalidEndpoint>` — scheme + host + non-default port; rejects `Opaque` and non-`https`; test matrix for FCM/Mozilla/Apple/non-default-port/opaque-rejection.
- `vapid_k_header(&P256PublicKey) -> String` — base64url-no-pad of uncompressed 65-byte P-256 point via `pk.to_encoded_point(false)`; asserts `len == 65 && bytes[0] == 0x04`.
- JWT header `{"typ":"JWT","alg":"ES256"}`; no `kid` field.
- `iat = now − 30s`, `exp = iat + 12h`; cache evicts at `exp − 1h`.
- **Clock-skew classification**: 401/403 with locally-verifiable JWT → `WebPushOutcome::ClockSkew` (distinct from `SubscriptionGone`).
- `jti` = random 128-bit per signed JWT (RFC 7519 conformance; **not** a replay-narrowing claim — constant for cached JWT's ~11h life).
- **JWT cache via `lru::LruCache` (workspace `lru = "0.18"`) + `parking_lot::Mutex`**, `max_capacity = 32`, keyed by `(Kid, url::Origin)`. **No origin allowlist.** **Explicit `cache.invalidate_all()` on VAPID key rotation** — does not rely on LRU pressure.
- **`VapidSigner` trait declared here**; impl in `waddle-server`.

### Typed newtypes

- `Kid(uuid::Uuid)` — DB row stores TEXT.
- `url::Origin` directly as cache key component (no newtype wrapper — already typed).
- `PushTopic(Box<str>)` with `pub enum PushTopicParseError { TooLong, InvalidAlphabet }` + `TryFrom<&str>`.
- `VapidSub` enum: `Mailto(MailtoAddress)` (inline validator: split last `@`, both non-empty, no control/whitespace/URI-reserved) | `Url(url::Url)` (must be `https`); `VapidSubParseError`.
- `EncryptedPayload(Vec<u8>)`, `VapidJwt(String)`, `SubscriptionKeys { p256dh, auth: Arc<AuthSecret> }`, `AuthSecret` (Zeroize, no-Clone).

### Tests

- **`crates/waddle-xmpp/tests/xep0357_push_notifications.rs`**: RFC 8291 §5 byte-for-byte goldens; HKDF info-string checks; JWT structure + `aud` matrix incl. opaque-rejection + `k=` uncompressed assertion + `jti` presence; LRU hit/miss + eviction + `invalidate_all` on rotation; `Topic` length-cap matrix; `aes128gcm` header `rs`-field round-trip equals actual record length.
- **`crates/waddle-server/tests/xep0357_push_notifications.rs`**: `VapidStorage` lifecycle (env override, write-before-remove, fresh generation, reseal-on-read single-flight under concurrent reads, AAD-kid stability across `id` change, `UnknownRootKeyVersion` soft-fail, leading-zero scalar round-trip).
- **Layer 1 negative**: malformed `p256dh` (length, curve, identity, low-order), `auth_secret` length, oversized plaintext — all typed `PushError`, never panic.
- **Layer 1 differential** (one-shot dev-only): round-trip against `web-push` crate as oracle for ≥100 inputs. **Before dropping the dev-dep, capture ~20 `(input, ciphertext, jwt)` tuples as static `&[u8]` arrays** so regression catches after the dep is gone.

### Workspace deps (land with first user)

- `aes-gcm = "0.10"` (stable)
- `hkdf = "0.13"`
- The scaffolding commits already on this branch reserved these at the workspace level. Member-crate `Cargo.toml` references and module bodies land in the same logical change as the first user.

## What PR-D1 does NOT change

- `sender.rs` continues to POST the relay envelope.
- No XEP-0357 `<enable/>` or `<disable/>` handler changes (PR-D2).
- No disco changes (PR-D3).
- No chat-side changes (PR-D3).
- No tracing fields (PR-D2).
- No T1 evaluator gating (PR-D2).
- No `WebPushOutcome` classifier wiring (PR-D2; the enum is defined here).
- No `<iq type='error'>` cleanup wire shape (PR-D2).
- No `urn:waddle:push:device:0` retract IQ (PR-D2).
- No `SuppressionReason::Xep0357PushServiceDegraded` variant (PR-D2).
- No per-endpoint-per-class token bucket (PR-D2).
- `InMemoryPushStore` cfg-gating (PR-D2).

## Full design plan

All architecture decisions live in #762.

## Test plan (run before exiting draft)

- [ ] `cargo test -p waddle-xmpp --test xep0357_push_notifications` passes RFC 8291 §5 goldens + negative + differential goldens
- [ ] `cargo test -p waddle-server --test xep0357_push_notifications` passes `VapidStorage` lifecycle
- [ ] `cargo test -p waddle-server vapid_signer` passes JWT cache + sign + verify + LRU + `invalidate_all`
- [ ] `cargo clippy --workspace -- -D warnings` clean
- [ ] `cargo fmt --check` clean
- [ ] Fresh boot generates a keypair; second boot reuses the same `kid`; env-var override produces a distinct `kid` AND the env var is unset in the running process AND the DB write commits before `remove_var`

## Branch convention note

Repo convention is `feat/server-*`. This branch was created as `web-push-vapid-foundations` before that was noticed; renaming a published draft PR requires destructive force-push, so the slip is accepted here. Convention to be followed on PR-D2 / PR-D3.

## Related

- Parent issue: #762
- Parent epic: #506
- OPEN: #97 (closed by PR-D2's merge)
- Sibling provider slices: #529 (APNS), #530 (FCM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
