### PR TITLE
feat(server): web push cutover — real RFC 8030 sender + §6 cleanup (PR-D2 of #762)

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -964,6 +964,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3234,6 +3243,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockito"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "pin-project-lite",
+ "rand 0.9.4",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5148,6 +5182,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6572,6 +6612,7 @@ dependencies = [
  "kameo",
  "lru 0.18.0",
  "minidom",
+ "mockito",
  "opentelemetry",
  "p256",
  "pbkdf2",

--- a/server/crates/waddle-server/src/db/backend.rs
+++ b/server/crates/waddle-server/src/db/backend.rs
@@ -463,8 +463,16 @@ impl<'a> Transaction<'a> {
     /// reader to writer on the first write, which can deadlock when two
     /// pooled connections both start as readers and then both try to
     /// upgrade (SQLITE_LOCKED, not BUSY — `busy_timeout` doesn't help).
-    /// For Postgres the default semantics already serialize writers, so
-    /// this just falls through to `begin`.
+    /// `BEGIN IMMEDIATE` resolves that.
+    ///
+    /// For Postgres this method falls through to plain `begin`: the
+    /// `BEGIN IMMEDIATE` upgrade race is SQLite-specific. Postgres at
+    /// the default READ COMMITTED isolation does NOT prevent two
+    /// concurrent worker phase 1's from both selecting `status='queued'`
+    /// rows simultaneously — serialization on Postgres comes from the
+    /// conditional `UPDATE ... WHERE status='queued'` (only one CAS
+    /// wins; the loser sees 0 rows changed and short-circuits) and the
+    /// `claim_token` interlock checked in phase 3's UPDATE.
     pub(super) async fn begin_immediate(
         backend: &'a DatabaseBackend,
     ) -> Result<Self, DatabaseError> {

--- a/server/crates/waddle-server/src/db/backend.rs
+++ b/server/crates/waddle-server/src/db/backend.rs
@@ -43,10 +43,18 @@ pub struct SqlxSqliteAdapter;
 #[async_trait]
 impl DatabaseAdapter for SqlxSqliteAdapter {
     async fn connect(&self, database_url: &str) -> Result<DatabaseBackend, DatabaseError> {
+        // WAL mode allows concurrent readers + one writer, but two
+        // pooled connections that both want the writer slot can race —
+        // SQLite returns SQLITE_BUSY/LOCKED. `busy_timeout` lets the
+        // engine block briefly and retry instead of surfacing the error
+        // immediately, which keeps concurrent worker pipelines (e.g.
+        // the publish-job drain that splits claim / dispatch / finalize
+        // across three short transactions) from deadlocking.
         let connect_options = SqliteConnectOptions::from_str(database_url)
             .map_err(|e| DatabaseError::ConnectionFailed(e.to_string()))?
             .create_if_missing(true)
             .foreign_keys(true)
+            .busy_timeout(std::time::Duration::from_secs(5))
             .journal_mode(SqliteJournalMode::Wal);
         let pool = SqlitePoolOptions::new()
             .max_connections(10)
@@ -445,6 +453,25 @@ impl<'a> Transaction<'a> {
     pub(super) async fn begin(backend: &'a DatabaseBackend) -> Result<Self, DatabaseError> {
         let inner = match backend {
             DatabaseBackend::Sqlite(pool) => TransactionInner::Sqlite(pool.begin().await?),
+            DatabaseBackend::Postgres(pool) => TransactionInner::Postgres(pool.begin().await?),
+        };
+        Ok(Self { inner })
+    }
+
+    /// Begin a transaction that acquires the database write lock
+    /// immediately. SQLite's default `BEGIN DEFERRED` upgrades from
+    /// reader to writer on the first write, which can deadlock when two
+    /// pooled connections both start as readers and then both try to
+    /// upgrade (SQLITE_LOCKED, not BUSY — `busy_timeout` doesn't help).
+    /// For Postgres the default semantics already serialize writers, so
+    /// this just falls through to `begin`.
+    pub(super) async fn begin_immediate(
+        backend: &'a DatabaseBackend,
+    ) -> Result<Self, DatabaseError> {
+        let inner = match backend {
+            DatabaseBackend::Sqlite(pool) => {
+                TransactionInner::Sqlite(pool.begin_with("BEGIN IMMEDIATE").await?)
+            }
             DatabaseBackend::Postgres(pool) => TransactionInner::Postgres(pool.begin().await?),
         };
         Ok(Self { inner })

--- a/server/crates/waddle-server/src/db/mod.rs
+++ b/server/crates/waddle-server/src/db/mod.rs
@@ -141,6 +141,14 @@ impl Database {
         Transaction::begin(&self.backend).await
     }
 
+    /// Begin a transaction that acquires the database write lock
+    /// immediately. Use this for transactions that perform writes after
+    /// a read, to avoid SQLite deadlocks when two connections both
+    /// start as readers and then try to upgrade to writers.
+    pub async fn begin_immediate(&self) -> Result<Transaction<'_>, DatabaseError> {
+        Transaction::begin_immediate(&self.backend).await
+    }
+
     pub fn name(&self) -> &str {
         &self.name
     }

--- a/server/crates/waddle-server/src/notification_outbox.rs
+++ b/server/crates/waddle-server/src/notification_outbox.rs
@@ -3968,8 +3968,13 @@ pub fn build_xep0357_notification_payload(message_count: u32, context: &Element)
 }
 
 fn build_xep0357_summary_form(message_count: u32) -> Element {
+    // XEP-0357 §4 example shows `<x xmlns='jabber:x:data'>` with NO
+    // `type` attribute — the form is a passively-encapsulated summary,
+    // not the result of a search/query. XEP-0004 §3.2 reserves
+    // `type='result'` for query-response contexts which doesn't apply
+    // here; emitting it confused at least one client we tested
+    // against. Match the §4 example literally.
     Element::builder("x", NS_DATA_FORMS)
-        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
         .append(xdata_hidden_field("FORM_TYPE", XEP0357_SUMMARY_FORM_TYPE))
         .append(xdata_field("message-count", &message_count.to_string()))
         .build()
@@ -6804,7 +6809,10 @@ mod tests {
             .children()
             .find(|child| child.is("x", NS_DATA_FORMS))
             .expect("summary form");
-        assert_eq!(summary.attr("type"), Some("result"));
+        // XEP-0357 §4 example shows `<x xmlns='jabber:x:data'>` with
+        // no `type` attribute — the form is a passively-encapsulated
+        // summary, not a query response.
+        assert_eq!(summary.attr("type"), None);
         assert!(summary.children().any(|field| {
             field.is("field", NS_DATA_FORMS)
                 && field.attr("var") == Some("FORM_TYPE")

--- a/server/crates/waddle-server/src/notification_outbox.rs
+++ b/server/crates/waddle-server/src/notification_outbox.rs
@@ -62,7 +62,7 @@ const NOTIFICATION_OUTBOX_CLASS_VALUES: [&str; 6] = [
 const NOTIFICATION_OUTBOX_CLASS_CHECK_SQL: &str = "class IN ('dm', 'dm_mention', 'personal_mention', 'channel_mention', 'active_channel_mention', 'notify_all')";
 const NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_CHECK_NAME: &str =
     "notification_candidates_suppressed_reason_check";
-const NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_VALUES: [&str; 13] = [
+const NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_VALUES: [&str; 14] = [
     "xep0357_self",
     "xep0357_no_registration",
     "xep0357_registration_disabled",
@@ -76,8 +76,9 @@ const NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_VALUES: [&str; 13] = [
     "waddle_dnd",
     "provider_rejected",
     "provider_token_expired",
+    "xep0357_push_service_degraded",
 ];
-const NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_CHECK_SQL: &str = "suppressed_reason IS NULL OR suppressed_reason IN ('xep0357_self', 'xep0357_no_registration', 'xep0357_registration_disabled', 'xep0492_never', 'xep0492_on_mention_miss', 'xep0191_blocked', 'xep0513_noping', 'xep0513_active_miss', 'xep0334_no_store', 'xep0334_no_permanent_store', 'waddle_dnd', 'provider_rejected', 'provider_token_expired')";
+const NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_CHECK_SQL: &str = "suppressed_reason IS NULL OR suppressed_reason IN ('xep0357_self', 'xep0357_no_registration', 'xep0357_registration_disabled', 'xep0492_never', 'xep0492_on_mention_miss', 'xep0191_blocked', 'xep0513_noping', 'xep0513_active_miss', 'xep0334_no_store', 'xep0334_no_permanent_store', 'waddle_dnd', 'provider_rejected', 'provider_token_expired', 'xep0357_push_service_degraded')";
 const NOTIFICATION_CANDIDATES_INDEXES: [&str; 4] = [
     "idx_notification_candidates_recipient_created",
     "idx_notification_candidates_identity",
@@ -268,6 +269,18 @@ pub(crate) enum SuppressedReason {
     /// Push provider returned an expired-token signal. Reserved
     /// variant; emitted by provider slices.
     ProviderTokenExpired,
+    /// The XEP-0357 push service is degraded — currently means the
+    /// VAPID signer or Web Push transport is not wired (a
+    /// boot-time failure on the
+    /// [`WebPushCapability`](waddle_xmpp::push::WebPushCapability)
+    /// path). Reserved variant: this PR introduces the typed
+    /// suppression reason so a future in-band fallback path
+    /// (e.g. plaintext chat-notify) cannot accidentally leak
+    /// content when the encrypted push path is unavailable. No
+    /// current code path falls back to in-band notify, so today
+    /// this variant is never emitted — the audit shape is in
+    /// place for the day one is added.
+    Xep0357PushServiceDegraded,
 }
 
 impl SuppressedReason {
@@ -293,6 +306,7 @@ impl SuppressedReason {
         Self::WaddleDnd,
         Self::ProviderRejected,
         Self::ProviderTokenExpired,
+        Self::Xep0357PushServiceDegraded,
     ];
 
     pub(crate) fn as_db_value(self) -> &'static str {
@@ -310,6 +324,7 @@ impl SuppressedReason {
             Self::WaddleDnd => "waddle_dnd",
             Self::ProviderRejected => "provider_rejected",
             Self::ProviderTokenExpired => "provider_token_expired",
+            Self::Xep0357PushServiceDegraded => "xep0357_push_service_degraded",
         }
     }
 
@@ -8144,7 +8159,7 @@ mod tests {
 
     #[test]
     fn postgres_suppressed_reason_constraint_match_accepts_current_definition() {
-        let postgres_definition = "CHECK (((suppressed_reason IS NULL) OR ((suppressed_reason)::text = ANY ((ARRAY['xep0357_self'::character varying, 'xep0357_no_registration'::character varying, 'xep0357_registration_disabled'::character varying, 'xep0492_never'::character varying, 'xep0492_on_mention_miss'::character varying, 'xep0191_blocked'::character varying, 'xep0513_noping'::character varying, 'xep0513_active_miss'::character varying, 'xep0334_no_store'::character varying, 'xep0334_no_permanent_store'::character varying, 'waddle_dnd'::character varying, 'provider_rejected'::character varying, 'provider_token_expired'::character varying])::text[]))))";
+        let postgres_definition = "CHECK (((suppressed_reason IS NULL) OR ((suppressed_reason)::text = ANY ((ARRAY['xep0357_self'::character varying, 'xep0357_no_registration'::character varying, 'xep0357_registration_disabled'::character varying, 'xep0492_never'::character varying, 'xep0492_on_mention_miss'::character varying, 'xep0191_blocked'::character varying, 'xep0513_noping'::character varying, 'xep0513_active_miss'::character varying, 'xep0334_no_store'::character varying, 'xep0334_no_permanent_store'::character varying, 'waddle_dnd'::character varying, 'provider_rejected'::character varying, 'provider_token_expired'::character varying, 'xep0357_push_service_degraded'::character varying])::text[]))))";
         assert!(
             notification_candidates_suppressed_reason_constraint_matches_expected(
                 postgres_definition

--- a/server/crates/waddle-server/src/push_service.rs
+++ b/server/crates/waddle-server/src/push_service.rs
@@ -5,6 +5,7 @@
 //! [`crate::push_registrations`]. Provider endpoints and tokens live here,
 //! behind the `push.<domain>` service boundary.
 
+pub(crate) mod dispatch;
 pub mod vapid_storage;
 
 use std::{fmt, sync::Arc};
@@ -15,6 +16,7 @@ use jid::BareJid;
 use minidom::Element;
 use sha2::Sha256;
 use waddle_xmpp::pubsub::{Affiliation, NodeConfig, PubSubItem, PubSubRequest, PubSubStorage};
+use waddle_xmpp::push::types::VapidSub;
 use waddle_xmpp::push::vapid::VapidSigner;
 use waddle_xmpp::push::WebPushSender;
 use waddle_xmpp::push::{PushError, PushSubscription};
@@ -32,7 +34,20 @@ const NODE_STATUS_ACTIVE: &str = "active";
 const NODE_STATUS_DISABLED: &str = "disabled";
 const DEVICE_STATUS_ACTIVE: &str = "active";
 const DEVICE_STATUS_DISABLED: &str = "disabled";
-const ATTEMPT_STATUS_FAKE_SENT: &str = "fake-sent";
+/// Capability-degraded marker: the publish-job worker fired but the
+/// process is missing the VAPID signer, Web Push transport, or `sub`
+/// claim. Treated as transient so the next worker tick will retry once
+/// the operator wires up the missing piece.
+const ATTEMPT_STATUS_WEB_NOT_CONFIGURED: &str = "web-not-configured";
+/// Internal error during Web Push dispatch (encrypt/sign/aud derivation
+/// failure). Treated as transient so an operator can ship a fix and the
+/// next tick will retry.
+const ATTEMPT_STATUS_WEB_INTERNAL_ERROR: &str = "web-internal-error";
+/// Maximum number of characters persisted in
+/// `push_delivery_attempts.last_error`. The column is `TEXT`, but we
+/// keep diagnostics short so a runaway provider body cannot bloat the
+/// table.
+const PUSH_ATTEMPT_LAST_ERROR_MAX_CHARS: usize = 200;
 const PUBLISH_JOB_STATUS_QUEUED: &str = "queued";
 const PUBLISH_JOB_STATUS_IN_PROGRESS: &str = "in-progress";
 const PUBLISH_JOB_STATUS_PUBLISHED: &str = "published";
@@ -70,6 +85,10 @@ pub struct DatabasePushServiceStore {
     /// Transport-layer sender for outbound Web Push HTTPS posts. Paired
     /// with [`Self::vapid_signer`] — both Some or both None.
     web_push_sender: Option<Arc<dyn WebPushSender>>,
+    /// VAPID `sub` claim (RFC 8292 §2) used when minting JWTs for outbound
+    /// Web Push delivery. Set together with [`Self::vapid_signer`] and
+    /// [`Self::web_push_sender`]; all three are Some or all three are None.
+    vapid_sub: Option<VapidSub>,
 }
 
 #[derive(Clone)]
@@ -79,7 +98,7 @@ struct PushServicePubSubBoundary {
 }
 
 #[derive(Clone)]
-struct PushSecretCipher {
+pub(crate) struct PushSecretCipher {
     enc_key: Vec<u8>,
     mac_key: Vec<u8>,
 }
@@ -444,10 +463,101 @@ pub struct PushPublishJobEnqueue {
     queued: bool,
 }
 
+/// Per-device outcome the publish-job worker carries from phase 2
+/// (out-of-tx Web Push dispatch) back into phase 3 (the
+/// `push_delivery_attempts` insert + job finalize). Keeping it typed
+/// here means the dispatcher does not touch the DB and the writer does
+/// not touch the network.
 #[derive(Debug, Clone)]
-struct PushDeliveryTarget {
+struct DispatchedAttempt {
     device_id: String,
     platform: PushDevicePlatform,
+    status: &'static str,
+    last_error: Option<String>,
+}
+
+/// Output of phase 1 of the publish-job worker — the typed pieces
+/// phase 2 needs to fan out Web Push deliveries without holding a DB
+/// transaction.
+struct PublishWorkPhase1 {
+    job: PushPublishJob,
+    sealed_devices: Vec<dispatch::SealedActiveDevice>,
+    payload_xml: String,
+}
+
+/// Phase 1 can either continue into phase 2/3 with a [`PublishWorkPhase1`]
+/// or short-circuit (claim contention, validation failure, no active
+/// devices). The short-circuit variant carries the final
+/// [`PushFanoutResult`] (or `None` when there was nothing to do).
+enum Phase1Outcome {
+    Continue(PublishWorkPhase1),
+    ShortCircuit(Option<PushFanoutResult>),
+}
+
+/// Render a typed [`WebPushOutcome`] as a short diagnostic string for
+/// the `push_delivery_attempts.last_error` column. Kept here next to
+/// the worker so the wire shape of `last_error` matches the typed
+/// outcome 1:1.
+fn web_push_outcome_diagnostic(outcome: &waddle_xmpp::push::types::WebPushOutcome) -> String {
+    use waddle_xmpp::push::types::{TransientFailure, WebPushOutcome};
+    match outcome {
+        WebPushOutcome::Delivered { status } => format!("delivered HTTP {status}"),
+        WebPushOutcome::SubscriptionGone { status } => format!("subscription gone HTTP {status}"),
+        WebPushOutcome::ClockSkew { status } => format!("clock skew HTTP {status}"),
+        WebPushOutcome::RateLimited {
+            status,
+            retry_after,
+        } => match retry_after {
+            Some(duration) => format!(
+                "rate limited HTTP {status} retry-after {}s",
+                duration.as_secs()
+            ),
+            None => format!("rate limited HTTP {status}"),
+        },
+        WebPushOutcome::PayloadTooLarge { status } => format!("payload too large HTTP {status}"),
+        WebPushOutcome::BadRequest { status } => format!("bad request HTTP {status}"),
+        WebPushOutcome::Transient { kind } => match kind {
+            TransientFailure::Network => "transient: network".to_string(),
+            TransientFailure::ServerError { status } => {
+                format!("transient: HTTP {status}")
+            }
+            TransientFailure::Timeout => "transient: timeout".to_string(),
+        },
+    }
+}
+
+/// `true` when an attempt status represents a transient/recoverable
+/// failure that should requeue the publish-job for retry. Permanent
+/// statuses (delivered, gone, payload-too-large, bad-request, invalid
+/// endpoint/keys, missing material, unseal failed, fake-sent) mark the
+/// job as published.
+fn attempt_status_is_transient(status: &str) -> bool {
+    matches!(
+        status,
+        dispatch::ATTEMPT_STATUS_WEB_TRANSIENT
+            | dispatch::ATTEMPT_STATUS_WEB_RATE_LIMITED
+            | dispatch::ATTEMPT_STATUS_WEB_CLOCK_SKEW
+            | ATTEMPT_STATUS_WEB_NOT_CONFIGURED
+            | ATTEMPT_STATUS_WEB_INTERNAL_ERROR
+    )
+}
+
+/// Truncate a free-form diagnostic to fit the
+/// `push_delivery_attempts.last_error` column without bloating the table
+/// when a relay echoes back a multi-KB error body. Splits on a char
+/// boundary so we never store half a UTF-8 sequence.
+fn truncate_last_error(message: &str) -> String {
+    if message.chars().count() <= PUSH_ATTEMPT_LAST_ERROR_MAX_CHARS {
+        return message.to_string();
+    }
+    let mut out = String::with_capacity(PUSH_ATTEMPT_LAST_ERROR_MAX_CHARS);
+    for (idx, ch) in message.chars().enumerate() {
+        if idx >= PUSH_ATTEMPT_LAST_ERROR_MAX_CHARS {
+            break;
+        }
+        out.push(ch);
+    }
+    out
 }
 
 impl PushDeliveryAttempt {
@@ -521,6 +631,7 @@ impl DatabasePushServiceStore {
             pubsub_boundary: None,
             vapid_signer: None,
             web_push_sender: None,
+            vapid_sub: None,
         };
         store.initialize().await?;
         Ok(store)
@@ -541,21 +652,26 @@ impl DatabasePushServiceStore {
             }),
             vapid_signer: None,
             web_push_sender: None,
+            vapid_sub: None,
         };
         store.initialize().await?;
         Ok(store)
     }
 
-    /// Install the VAPID signer + Web Push transport for outbound
-    /// delivery. Called once at boot from `server::http`. Both arguments
-    /// are paired — Web Push cannot dispatch without either.
+    /// Install the VAPID signer + Web Push transport + VAPID `sub` claim
+    /// for outbound delivery. Called once at boot from `server::http`. All
+    /// three arguments are paired — Web Push cannot dispatch without any
+    /// of them, and the publish-job worker treats absence of any one as
+    /// [`waddle_xmpp::push::WebPushCapability::Degraded`].
     pub fn with_web_push_provider(
         mut self,
         vapid_signer: Arc<dyn VapidSigner>,
         web_push_sender: Arc<dyn WebPushSender>,
+        vapid_sub: VapidSub,
     ) -> Self {
         self.vapid_signer = Some(vapid_signer);
         self.web_push_sender = Some(web_push_sender);
+        self.vapid_sub = Some(vapid_sub);
         self
     }
 
@@ -1925,18 +2041,95 @@ impl DatabasePushServiceStore {
         retention_limit: i64,
     ) -> Result<Option<PushFanoutResult>, XmppError> {
         let now_ms = crate::time::now_ms();
+
+        // ---- Phase 1: tx1 — claim + validate + load sealed devices +
+        // read payload_xml. We commit with the job still in
+        // `in-progress` so its 5-minute claim window covers phases 2+3
+        // without holding a DB transaction across the network round-trip.
+        let phase1 = match self.process_publish_phase1(job_id, now_ms).await? {
+            Phase1Outcome::Continue(state) => state,
+            Phase1Outcome::ShortCircuit(result) => return Ok(result),
+        };
+        let PublishWorkPhase1 {
+            job,
+            sealed_devices,
+            payload_xml,
+        } = phase1;
+
+        // ---- Phase 2: outside any tx — encrypt, sign, and send.
+        // The XEP-0357 payload only needs to be parsed when we have a
+        // real Web Push provider wired up. Without one, every device
+        // records the legacy `fake-sent` marker and we never look at
+        // the conversation / class / message-count fields. Parsing
+        // unconditionally would reject test fixtures whose
+        // `<notification>` payload omits the `urn:waddle:push:context:0`
+        // child the chat publisher attaches in production.
+        let parsed = if self.web_push_provider_ready() {
+            match dispatch::parse_publish_payload(&payload_xml) {
+                Ok(parsed) => Some(parsed),
+                Err(error) => {
+                    // Bad payload is permanent: mark the job failed in a
+                    // tiny dedicated tx and return zero attempts.
+                    self.mark_publish_job_failed_after_phase1(
+                        job.job_id(),
+                        job.owner_bare_jid(),
+                        job.node(),
+                        &format!("XEP-0357 payload parse failed: {error}"),
+                        now_ms,
+                    )
+                    .await?;
+                    return Ok(Some(PushFanoutResult {
+                        item_id: job.item_id().to_string(),
+                        attempted_devices: 0,
+                    }));
+                }
+            }
+        } else {
+            None
+        };
+        let attempts = self
+            .dispatch_devices(&sealed_devices, parsed.as_ref(), job.item_id())
+            .await;
+
+        // ---- Phase 3: tx2 — record attempts and finalize the job.
+        let attempted_devices = attempts.len();
+        self.finalize_publish_job(&job, &attempts, retention_limit, now_ms)
+            .await?;
+        Ok(Some(PushFanoutResult {
+            item_id: job.item_id().to_string(),
+            attempted_devices,
+        }))
+    }
+
+    /// Phase 1 of [`Self::process_publish_job_with_retention_limit`]:
+    /// claim the job, validate node/owner/registration, ensure the
+    /// XEP-0060 backing item exists, and load sealed devices + payload.
+    /// Commits tx1 with the job still in
+    /// [`PUBLISH_JOB_STATUS_IN_PROGRESS`] so the 5-minute claim window
+    /// covers the out-of-tx Web Push round-trip.
+    async fn process_publish_phase1(
+        &self,
+        job_id: &str,
+        now_ms: i64,
+    ) -> Result<Phase1Outcome, XmppError> {
+        // `begin_immediate` so the SELECT-then-write sequence below
+        // (read job + claim UPDATE + lock UPSERTs) acquires the SQLite
+        // writer lock up front. With deferred begin, two concurrent
+        // workers can both start as readers and then both try to
+        // upgrade — SQLite returns `SQLITE_LOCKED` for the loser and
+        // `busy_timeout` does not retry that case.
         let mut tx = self
             .db
-            .begin()
+            .begin_immediate()
             .await
             .map_err(|error| XmppError::internal(error.to_string()))?;
         let Some(lock_target) = get_publish_job_tx(&mut tx, job_id).await? else {
-            return Ok(None);
+            return Ok(Phase1Outcome::ShortCircuit(None));
         };
         lock_owner_tx(&mut tx, lock_target.owner_bare_jid(), now_ms).await?;
         lock_node_tx(&mut tx, lock_target.node(), now_ms).await?;
         let Some(job) = claim_publish_job_tx(&mut tx, job_id, now_ms).await? else {
-            return Ok(None);
+            return Ok(Phase1Outcome::ShortCircuit(None));
         };
         let Some(push_node) = get_node_tx(&mut tx, job.node()).await? else {
             mark_publish_job_failed_tx(&mut tx, job.job_id(), "Push node not found", now_ms)
@@ -1944,10 +2137,10 @@ impl DatabasePushServiceStore {
             tx.commit()
                 .await
                 .map_err(|error| XmppError::internal(error.to_string()))?;
-            return Ok(Some(PushFanoutResult {
+            return Ok(Phase1Outcome::ShortCircuit(Some(PushFanoutResult {
                 item_id: job.item_id().to_string(),
                 attempted_devices: 0,
-            }));
+            })));
         };
         if push_node.status != PushNodeStatus::Active {
             mark_publish_job_failed_tx(&mut tx, job.job_id(), "Push node not active", now_ms)
@@ -1955,10 +2148,10 @@ impl DatabasePushServiceStore {
             tx.commit()
                 .await
                 .map_err(|error| XmppError::internal(error.to_string()))?;
-            return Ok(Some(PushFanoutResult {
+            return Ok(Phase1Outcome::ShortCircuit(Some(PushFanoutResult {
                 item_id: job.item_id().to_string(),
                 attempted_devices: 0,
-            }));
+            })));
         }
         if push_node.owner_bare_jid != *job.owner_bare_jid() {
             return Err(XmppError::forbidden(Some(
@@ -1991,18 +2184,19 @@ impl DatabasePushServiceStore {
                     tx.commit()
                         .await
                         .map_err(|error| XmppError::internal(error.to_string()))?;
-                    return Ok(Some(PushFanoutResult {
+                    return Ok(Phase1Outcome::ShortCircuit(Some(PushFanoutResult {
                         item_id: job.item_id().to_string(),
                         attempted_devices: 0,
-                    }));
+                    })));
                 }
                 return Err(error);
             }
         }
         self.ensure_xep0060_publish_item_backing(&job).await?;
 
-        let active_devices = active_devices_for_node_tx(&mut tx, job.node()).await?;
-        if active_devices.is_empty() {
+        let sealed_devices =
+            active_devices_with_subscription_for_node_tx(&mut tx, job.node()).await?;
+        if sealed_devices.is_empty() {
             let retry_at_ms = retry_at_ms(now_ms);
             tx.execute(
                 r#"
@@ -2029,12 +2223,172 @@ impl DatabasePushServiceStore {
             tx.commit()
                 .await
                 .map_err(|error| XmppError::internal(error.to_string()))?;
-            return Ok(Some(PushFanoutResult {
+            return Ok(Phase1Outcome::ShortCircuit(Some(PushFanoutResult {
                 item_id: job.item_id().to_string(),
                 attempted_devices: 0,
-            }));
+            })));
         }
-        for device in &active_devices {
+        let payload_xml = get_publish_job_payload_xml_tx(&mut tx, job.job_id())
+            .await?
+            .ok_or_else(|| {
+                XmppError::internal(format!(
+                    "publish-job {} disappeared between claim and payload read",
+                    job.job_id()
+                ))
+            })?;
+        tx.commit()
+            .await
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        Ok(Phase1Outcome::Continue(PublishWorkPhase1 {
+            job,
+            sealed_devices,
+            payload_xml,
+        }))
+    }
+
+    /// `true` when all three Web Push provider slots are wired
+    /// (`vapid_signer`, `web_push_sender`, `vapid_sub`). The worker only
+    /// parses the XEP-0357 payload + encrypts + signs + sends when this
+    /// returns `true`; otherwise it records the legacy `fake-sent`
+    /// marker for every device.
+    fn web_push_provider_ready(&self) -> bool {
+        self.vapid_signer.is_some() && self.web_push_sender.is_some() && self.vapid_sub.is_some()
+    }
+
+    /// Phase 2 helper: drive each sealed device row through the typed
+    /// Web Push dispatcher and collect typed [`DispatchedAttempt`]
+    /// outcomes. Pure compute + network — never touches the DB.
+    async fn dispatch_devices(
+        &self,
+        sealed_devices: &[dispatch::SealedActiveDevice],
+        parsed: Option<&dispatch::ParsedPushPayload>,
+        item_id: &str,
+    ) -> Vec<DispatchedAttempt> {
+        let mut attempts = Vec::with_capacity(sealed_devices.len());
+        let provider = match (
+            self.vapid_signer.as_ref(),
+            self.web_push_sender.as_ref(),
+            self.vapid_sub.as_ref(),
+            parsed,
+        ) {
+            (Some(signer), Some(sender), Some(sub), Some(parsed)) => {
+                Some((signer, sender, sub, parsed))
+            }
+            _ => None,
+        };
+        for device in sealed_devices {
+            let attempt = match (provider, device.platform) {
+                (Some((signer, sender, sub, parsed)), PushDevicePlatform::Web) => {
+                    self.dispatch_web_device(device, parsed, item_id, signer, sender, sub)
+                        .await
+                }
+                // No Web Push provider wired up (tests, or a degraded
+                // boot that never called `with_web_push_provider`). The
+                // worker continues to record the legacy `fake-sent`
+                // marker for every platform so existing test dashboards
+                // and operator scripts keep working unchanged. The
+                // real-send path lights up only when all three of
+                // (vapid_signer, web_push_sender, vapid_sub) are wired.
+                (None, _) => DispatchedAttempt {
+                    device_id: device.device_id.clone(),
+                    platform: device.platform,
+                    status: dispatch::ATTEMPT_STATUS_FAKE_SENT_NON_WEB,
+                    last_error: None,
+                },
+                // APNS/FCM are stubbed until #529/#530 land their real
+                // senders. Keep the historical `fake-sent` marker so
+                // existing tests / dashboards keep working.
+                (Some(_), PushDevicePlatform::Apns | PushDevicePlatform::Fcm) => {
+                    DispatchedAttempt {
+                        device_id: device.device_id.clone(),
+                        platform: device.platform,
+                        status: dispatch::ATTEMPT_STATUS_FAKE_SENT_NON_WEB,
+                        last_error: None,
+                    }
+                }
+            };
+            attempts.push(attempt);
+        }
+        attempts
+    }
+
+    /// Dispatch one Web Push device row: unseal the subscription, then
+    /// encrypt+sign+POST. Translates typed outcomes into the
+    /// `push_delivery_attempts.status` wire format.
+    async fn dispatch_web_device(
+        &self,
+        device: &dispatch::SealedActiveDevice,
+        parsed: &dispatch::ParsedPushPayload,
+        item_id: &str,
+        signer: &Arc<dyn VapidSigner>,
+        sender: &Arc<dyn WebPushSender>,
+        sub: &VapidSub,
+    ) -> DispatchedAttempt {
+        let target = match dispatch::WebPushTarget::try_from_sealed(device, &self.secrets) {
+            Ok(target) => target,
+            Err(reason) => {
+                return DispatchedAttempt {
+                    device_id: device.device_id.clone(),
+                    platform: device.platform,
+                    status: dispatch::skip_reason_to_attempt_status(reason),
+                    last_error: None,
+                };
+            }
+        };
+        match dispatch::dispatch_one_web_push(&target, parsed, item_id, signer, sub, sender).await {
+            Ok(outcome) => {
+                let status = dispatch::outcome_to_attempt_status(&outcome);
+                let last_error = if matches!(
+                    outcome,
+                    waddle_xmpp::push::types::WebPushOutcome::Delivered { .. }
+                ) {
+                    None
+                } else {
+                    Some(truncate_last_error(&web_push_outcome_diagnostic(&outcome)))
+                };
+                // TODO(#762/PR-D2 follow-up): when `outcome` is
+                // `WebPushOutcome::SubscriptionGone`, hook the XEP-0357
+                // §6 cleanup chain here — emit the IQ-error to the
+                // publisher and `urn:waddle:push-service:0` disable the
+                // device. Until then we persist the typed status
+                // `"web-gone"` so the next commit can find every gone
+                // attempt by SELECT.
+                DispatchedAttempt {
+                    device_id: device.device_id.clone(),
+                    platform: device.platform,
+                    status,
+                    last_error,
+                }
+            }
+            Err(error) => DispatchedAttempt {
+                device_id: device.device_id.clone(),
+                platform: device.platform,
+                status: ATTEMPT_STATUS_WEB_INTERNAL_ERROR,
+                last_error: Some(truncate_last_error(&error.to_string())),
+            },
+        }
+    }
+
+    /// Phase 3: open a fresh tx, record one row per attempt, and either
+    /// requeue the job (any transient outcome) or mark it published.
+    /// Prunes the per-node attempts/jobs tail so retention stays bounded.
+    async fn finalize_publish_job(
+        &self,
+        job: &PushPublishJob,
+        attempts: &[DispatchedAttempt],
+        retention_limit: i64,
+        now_ms: i64,
+    ) -> Result<(), XmppError> {
+        // `begin_immediate` so phase 3 acquires the SQLite writer lock
+        // up front; see the matching comment in `process_publish_phase1`.
+        let mut tx = self
+            .db
+            .begin_immediate()
+            .await
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        lock_owner_tx(&mut tx, job.owner_bare_jid(), now_ms).await?;
+        lock_node_tx(&mut tx, job.node(), now_ms).await?;
+        for attempt in attempts {
             tx.execute(
                 r#"
                 INSERT INTO push_delivery_attempts (
@@ -2046,53 +2400,112 @@ impl DatabasePushServiceStore {
                     status,
                     last_error,
                     created_at_ms
-                ) VALUES (?, ?, ?, ?, ?, ?, NULL, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 "#,
                 crate::db_params![
                     uuid::Uuid::new_v4().to_string(),
                     job.node().to_string(),
-                    device.device_id.clone(),
-                    device.platform.to_string(),
+                    attempt.device_id.clone(),
+                    attempt.platform.to_string(),
                     job.item_id().to_string(),
-                    ATTEMPT_STATUS_FAKE_SENT,
+                    attempt.status,
+                    attempt.last_error.clone(),
                     now_ms,
                 ],
             )
             .await
             .map_err(|error| XmppError::internal(error.to_string()))?;
         }
-        tx.execute(
-            r#"
-            UPDATE push_publish_jobs
-            SET status = ?,
-                attempt_count = attempt_count + 1,
-                last_error = NULL,
-                next_retry_at_ms = NULL,
-                claimed_at_ms = NULL,
-                updated_at_ms = ?,
-                published_at_ms = ?
-            WHERE job_id = ? AND status = ?
-            "#,
-            crate::db_params![
-                PUBLISH_JOB_STATUS_PUBLISHED,
-                now_ms,
-                now_ms,
-                job.job_id().to_string(),
-                PUBLISH_JOB_STATUS_IN_PROGRESS,
-            ],
-        )
-        .await
-        .map_err(|error| XmppError::internal(error.to_string()))?;
+        let any_transient = attempts
+            .iter()
+            .any(|attempt| attempt_status_is_transient(attempt.status));
+        if any_transient {
+            let retry_at_ms = retry_at_ms(now_ms);
+            // Surface the first transient diagnostic so an operator can
+            // see why this job is waiting to retry.
+            let transient_error = attempts
+                .iter()
+                .find(|attempt| attempt_status_is_transient(attempt.status))
+                .and_then(|attempt| attempt.last_error.clone())
+                .unwrap_or_else(|| "Web Push transient failure".to_string());
+            tx.execute(
+                r#"
+                UPDATE push_publish_jobs
+                SET status = ?,
+                    attempt_count = attempt_count + 1,
+                    last_error = ?,
+                    next_retry_at_ms = ?,
+                    claimed_at_ms = NULL,
+                    updated_at_ms = ?
+                WHERE job_id = ? AND status = ?
+                "#,
+                crate::db_params![
+                    PUBLISH_JOB_STATUS_QUEUED,
+                    transient_error,
+                    retry_at_ms,
+                    now_ms,
+                    job.job_id().to_string(),
+                    PUBLISH_JOB_STATUS_IN_PROGRESS,
+                ],
+            )
+            .await
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        } else {
+            tx.execute(
+                r#"
+                UPDATE push_publish_jobs
+                SET status = ?,
+                    attempt_count = attempt_count + 1,
+                    last_error = NULL,
+                    next_retry_at_ms = NULL,
+                    claimed_at_ms = NULL,
+                    updated_at_ms = ?,
+                    published_at_ms = ?
+                WHERE job_id = ? AND status = ?
+                "#,
+                crate::db_params![
+                    PUBLISH_JOB_STATUS_PUBLISHED,
+                    now_ms,
+                    now_ms,
+                    job.job_id().to_string(),
+                    PUBLISH_JOB_STATUS_IN_PROGRESS,
+                ],
+            )
+            .await
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        }
         prune_delivery_attempts_tx(&mut tx, job.node(), retention_limit).await?;
         prune_publish_jobs_tx(&mut tx, job.node(), MAX_PUBLISH_JOBS_PER_NODE).await?;
         tx.commit()
             .await
             .map_err(|error| XmppError::internal(error.to_string()))?;
+        Ok(())
+    }
 
-        Ok(Some(PushFanoutResult {
-            item_id: job.item_id().to_string(),
-            attempted_devices: active_devices.len(),
-        }))
+    /// Mark a job that already passed phase 1 (so the
+    /// `in-progress`/`claimed_at_ms` are set) as permanently failed in
+    /// a tiny dedicated tx. Takes the same advisory locks as phase 3 so
+    /// concurrent operations on the same owner/node serialize cleanly.
+    async fn mark_publish_job_failed_after_phase1(
+        &self,
+        job_id: &str,
+        owner_bare_jid: &BareJid,
+        node: &str,
+        error: &str,
+        now_ms: i64,
+    ) -> Result<(), XmppError> {
+        let mut tx = self
+            .db
+            .begin_immediate()
+            .await
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        lock_owner_tx(&mut tx, owner_bare_jid, now_ms).await?;
+        lock_node_tx(&mut tx, node, now_ms).await?;
+        mark_publish_job_failed_tx(&mut tx, job_id, error, now_ms).await?;
+        tx.commit()
+            .await
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        Ok(())
     }
 
     async fn publish_job_id_for_node_item(
@@ -2460,7 +2873,7 @@ async fn validate_first_party_enable_node_tx(
             "Push node not active".to_string(),
         )));
     }
-    if active_devices_for_node_tx(tx, node).await?.is_empty() {
+    if count_active_devices_for_node_tx(tx, node).await? == 0 {
         return Err(XmppError::bad_request(Some(
             "Push node has no active registered devices".to_string(),
         )));
@@ -2709,14 +3122,14 @@ async fn prune_disabled_devices_for_node_tx(
     Ok(())
 }
 
-async fn active_devices_for_node_tx(
+async fn active_devices_with_subscription_for_node_tx(
     tx: &mut crate::db::Transaction<'_>,
     node: &str,
-) -> Result<Vec<PushDeliveryTarget>, XmppError> {
+) -> Result<Vec<dispatch::SealedActiveDevice>, XmppError> {
     let mut rows = tx
         .query(
             r#"
-            SELECT device_id, platform
+            SELECT device_id, platform, provider_endpoint, provider_token, provider_key_material
             FROM push_devices
             WHERE node = ? AND status = ?
             ORDER BY device_id ASC
@@ -2731,7 +3144,29 @@ async fn active_devices_for_node_tx(
         .await
         .map_err(|error| XmppError::internal(error.to_string()))?
     {
-        devices.push(decode_delivery_target(&row)?);
+        let device_id: String = row
+            .get(0)
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        let platform = PushDevicePlatform::parse(
+            &row.get::<String>(1)
+                .map_err(|error| XmppError::internal(error.to_string()))?,
+        )?;
+        let sealed_endpoint: Option<String> = row
+            .get(2)
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        let sealed_auth: Option<String> = row
+            .get(3)
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        let sealed_key_material: Option<String> = row
+            .get(4)
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        devices.push(dispatch::SealedActiveDevice {
+            device_id,
+            platform,
+            sealed_endpoint,
+            sealed_auth,
+            sealed_key_material,
+        });
     }
     Ok(devices)
 }
@@ -2818,6 +3253,34 @@ async fn get_publish_job_tx(
         return Ok(None);
     };
     Ok(Some(decode_publish_job(&row)?))
+}
+
+/// Read the persisted XEP-0357 `<notification>` payload XML for a
+/// publish-job. The worker uses this between tx1 (claim+load) and tx2
+/// (record attempts) so the actual Web Push dispatch happens outside any
+/// DB transaction.
+async fn get_publish_job_payload_xml_tx(
+    tx: &mut crate::db::Transaction<'_>,
+    job_id: &str,
+) -> Result<Option<String>, XmppError> {
+    let mut rows = tx
+        .query(
+            "SELECT payload_xml FROM push_publish_jobs WHERE job_id = ?",
+            crate::db_params![job_id],
+        )
+        .await
+        .map_err(|error| XmppError::internal(error.to_string()))?;
+    let Some(row) = rows
+        .next()
+        .await
+        .map_err(|error| XmppError::internal(error.to_string()))?
+    else {
+        return Ok(None);
+    };
+    let payload_xml: String = row
+        .get(0)
+        .map_err(|error| XmppError::internal(error.to_string()))?;
+    Ok(Some(payload_xml))
 }
 
 async fn mark_publish_job_failed_tx(
@@ -3066,18 +3529,6 @@ fn decode_attempt(row: &crate::db::Row) -> Result<PushDeliveryAttempt, XmppError
     })
 }
 
-fn decode_delivery_target(row: &crate::db::Row) -> Result<PushDeliveryTarget, XmppError> {
-    Ok(PushDeliveryTarget {
-        device_id: row
-            .get(0)
-            .map_err(|error| XmppError::internal(error.to_string()))?,
-        platform: PushDevicePlatform::parse(
-            &row.get::<String>(1)
-                .map_err(|error| XmppError::internal(error.to_string()))?,
-        )?,
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3287,7 +3738,10 @@ mod tests {
             .expect("attempts");
         assert_eq!(attempts.len(), 1);
         assert_eq!(attempts[0].device_id(), "web-1");
-        assert_eq!(attempts[0].status(), ATTEMPT_STATUS_FAKE_SENT);
+        assert_eq!(
+            attempts[0].status(),
+            dispatch::ATTEMPT_STATUS_FAKE_SENT_NON_WEB
+        );
     }
 
     #[tokio::test]
@@ -4112,7 +4566,10 @@ mod tests {
         assert_eq!(attempts.len(), 1);
         assert_eq!(attempts[0].device_id(), "web-1");
         assert_eq!(attempts[0].item_id(), "durable-attempt");
-        assert_eq!(attempts[0].status(), ATTEMPT_STATUS_FAKE_SENT);
+        assert_eq!(
+            attempts[0].status(),
+            dispatch::ATTEMPT_STATUS_FAKE_SENT_NON_WEB
+        );
     }
 
     #[tokio::test]
@@ -4914,7 +5371,7 @@ mod tests {
                         "web-1",
                         PushDevicePlatform::Web.to_string(),
                         format!("item-{idx}"),
-                        ATTEMPT_STATUS_FAKE_SENT,
+                        dispatch::ATTEMPT_STATUS_FAKE_SENT_NON_WEB,
                         idx as i64,
                     ],
                 )

--- a/server/crates/waddle-server/src/push_service.rs
+++ b/server/crates/waddle-server/src/push_service.rs
@@ -548,6 +548,90 @@ fn web_push_outcome_diagnostic(outcome: &waddle_xmpp::push::types::WebPushOutcom
 /// statuses (delivered, gone, payload-too-large, bad-request, invalid
 /// endpoint/keys, missing material, unseal failed, fake-sent) mark the
 /// job as published.
+/// Dispatch one Web Push device row: unseal the subscription, then
+/// encrypt+sign+POST. Translates typed outcomes into the
+/// `push_delivery_attempts.status` wire format. Free function (not a
+/// method) so the per-device future is `Send + 'static`-compatible
+/// inside the `buffer_unordered` fan-out in `dispatch_devices`.
+async fn dispatch_web_device_owned(
+    device: &dispatch::SealedActiveDevice,
+    parsed: &dispatch::ParsedPushPayload,
+    item_id: &str,
+    signer: &Arc<dyn VapidSigner>,
+    sender: &Arc<dyn WebPushSender>,
+    sub: &VapidSub,
+    secrets: &PushSecretCipher,
+) -> DispatchedAttempt {
+    let target = match dispatch::WebPushTarget::try_from_sealed(device, secrets) {
+        Ok(target) => target,
+        Err(reason) => {
+            return DispatchedAttempt {
+                device_id: device.device_id.clone(),
+                platform: device.platform,
+                status: dispatch::skip_reason_to_attempt_status(reason),
+                last_error: None,
+                retry_after: None,
+            };
+        }
+    };
+    match dispatch::dispatch_one_web_push(&target, parsed, item_id, signer, sub, sender).await {
+        Ok(outcome) => {
+            let status = dispatch::outcome_to_attempt_status(&outcome);
+            let last_error = if matches!(
+                outcome,
+                waddle_xmpp::push::types::WebPushOutcome::Delivered { .. }
+            ) {
+                None
+            } else {
+                Some(truncate_last_error(&web_push_outcome_diagnostic(&outcome)))
+            };
+            // Honor RFC 7231 §7.1.3 `Retry-After` for rate-limited
+            // responses — phase 3 takes `max(default, retry_after)` so
+            // a relay's "back off N seconds" hint is not lost.
+            let retry_after = match &outcome {
+                waddle_xmpp::push::types::WebPushOutcome::RateLimited { retry_after, .. } => {
+                    *retry_after
+                }
+                _ => None,
+            };
+            // XEP-0357 §6 forward cleanup runs in
+            // `finalize_publish_job` — when the persisted status hits
+            // `attempt_status_warrants_device_disable`, the matching
+            // `push_devices` row is flipped to `disabled` in the same
+            // tx.
+            //
+            // TODO(#762 follow-up): emit a server-initiated
+            // `<message><device-disabled xmlns='urn:waddle:push-
+            // service:0'/></message>` to the registering chat client
+            // so it can drop its local subscription and resubscribe
+            // with a fresh device-id. Requires plumbing the connection
+            // router into the publish-job worker; deferred so PR-D2
+            // stays scoped to the server-side cleanup half of §6.
+            DispatchedAttempt {
+                device_id: device.device_id.clone(),
+                platform: device.platform,
+                status,
+                last_error,
+                retry_after,
+            }
+        }
+        // Internal-error path covers encrypt/sign/aud-derive failures.
+        // These are deterministic bugs — a retry on the same
+        // `(subscription, payload)` will fail identically — so we
+        // classify as PERMANENT (not transient) to avoid an unbounded
+        // retry loop. Recorded as `web-internal-error` so an operator
+        // can grep for it and fix the underlying bug; the device stays
+        // active (not a per-device problem).
+        Err(error) => DispatchedAttempt {
+            device_id: device.device_id.clone(),
+            platform: device.platform,
+            status: ATTEMPT_STATUS_WEB_INTERNAL_ERROR,
+            last_error: Some(truncate_last_error(&error.to_string())),
+            retry_after: None,
+        },
+    }
+}
+
 fn attempt_status_is_transient(status: &str) -> bool {
     matches!(
         status,
@@ -2323,148 +2407,84 @@ impl DatabasePushServiceStore {
     /// Phase 2 helper: drive each sealed device row through the typed
     /// Web Push dispatcher and collect typed [`DispatchedAttempt`]
     /// outcomes. Pure compute + network — never touches the DB.
+    ///
+    /// Devices are dispatched concurrently via `buffer_unordered` so a
+    /// large fan-out does not serialize on the per-device HTTPS
+    /// round-trip. The per-(host, urgency) leaky bucket and the global
+    /// semaphore inside `RateLimitedWebPushSender` are the real rate-
+    /// limiters; this cap exists to bound async-task overhead, not to
+    /// rate-limit (cap > global semaphore size means extras simply
+    /// block on the semaphore, which is fine).
     async fn dispatch_devices(
         &self,
         sealed_devices: &[dispatch::SealedActiveDevice],
         parsed: Option<&dispatch::ParsedPushPayload>,
         item_id: &str,
     ) -> Vec<DispatchedAttempt> {
-        let mut attempts = Vec::with_capacity(sealed_devices.len());
-        let provider = match (
+        use futures::stream::{self, StreamExt};
+        const DISPATCH_FAN_OUT: usize = 64;
+
+        let web_provider = match (
             self.vapid_signer.as_ref(),
             self.web_push_sender.as_ref(),
             self.vapid_sub.as_ref(),
             parsed,
         ) {
-            (Some(signer), Some(sender), Some(sub), Some(parsed)) => {
-                Some((signer, sender, sub, parsed))
-            }
+            (Some(signer), Some(sender), Some(sub), Some(parsed)) => Some((
+                Arc::clone(signer),
+                Arc::clone(sender),
+                sub.clone(),
+                parsed.clone(),
+                self.secrets.clone(),
+            )),
             _ => None,
         };
-        for device in sealed_devices {
-            let attempt = match (provider, device.platform) {
-                (Some((signer, sender, sub, parsed)), PushDevicePlatform::Web) => {
-                    self.dispatch_web_device(device, parsed, item_id, signer, sender, sub)
-                        .await
-                }
-                // No Web Push provider wired up. Web devices get the
-                // typed `web-not-configured` marker (transient, so the
-                // job retries once the operator fixes the boot config);
-                // APNS/FCM devices retain the legacy `fake-sent` marker
-                // (their senders ship in #529 / #530).
-                (None, PushDevicePlatform::Web) => DispatchedAttempt {
-                    device_id: device.device_id.clone(),
-                    platform: device.platform,
-                    status: ATTEMPT_STATUS_WEB_NOT_CONFIGURED,
-                    last_error: Some("Web Push provider not configured".to_string()),
-                    retry_after: None,
-                },
-                (None, PushDevicePlatform::Apns | PushDevicePlatform::Fcm) => DispatchedAttempt {
-                    device_id: device.device_id.clone(),
-                    platform: device.platform,
-                    status: dispatch::ATTEMPT_STATUS_FAKE_SENT_NON_WEB,
-                    last_error: None,
-                    retry_after: None,
-                },
-                // APNS/FCM are stubbed until #529/#530 land their real
-                // senders. Keep the historical `fake-sent` marker so
-                // existing tests / dashboards keep working.
-                (Some(_), PushDevicePlatform::Apns | PushDevicePlatform::Fcm) => {
-                    DispatchedAttempt {
-                        device_id: device.device_id.clone(),
-                        platform: device.platform,
-                        status: dispatch::ATTEMPT_STATUS_FAKE_SENT_NON_WEB,
-                        last_error: None,
-                        retry_after: None,
+        let item_id_arc: Arc<str> = Arc::from(item_id);
+
+        stream::iter(sealed_devices.iter().cloned())
+            .map(move |device| {
+                let item_id = Arc::clone(&item_id_arc);
+                let web_provider = web_provider.clone();
+                async move {
+                    match (&web_provider, device.platform) {
+                        (Some((signer, sender, sub, parsed, secrets)), PushDevicePlatform::Web) => {
+                            dispatch_web_device_owned(
+                                &device, parsed, &item_id, signer, sender, sub, secrets,
+                            )
+                            .await
+                        }
+                        // No Web Push provider wired up. Web devices
+                        // get the typed `web-not-configured` marker
+                        // (transient, so the job retries once the
+                        // operator fixes the boot config); APNS/FCM
+                        // devices retain the legacy `fake-sent` marker
+                        // (their senders ship in #529 / #530).
+                        (None, PushDevicePlatform::Web) => DispatchedAttempt {
+                            device_id: device.device_id.clone(),
+                            platform: device.platform,
+                            status: ATTEMPT_STATUS_WEB_NOT_CONFIGURED,
+                            last_error: Some("Web Push provider not configured".to_string()),
+                            retry_after: None,
+                        },
+                        (_, PushDevicePlatform::Apns | PushDevicePlatform::Fcm) => {
+                            // APNS/FCM are stubbed until #529/#530 land
+                            // their real senders. Keep the historical
+                            // `fake-sent` marker so existing tests /
+                            // dashboards keep working.
+                            DispatchedAttempt {
+                                device_id: device.device_id.clone(),
+                                platform: device.platform,
+                                status: dispatch::ATTEMPT_STATUS_FAKE_SENT_NON_WEB,
+                                last_error: None,
+                                retry_after: None,
+                            }
+                        }
                     }
                 }
-            };
-            attempts.push(attempt);
-        }
-        attempts
-    }
-
-    /// Dispatch one Web Push device row: unseal the subscription, then
-    /// encrypt+sign+POST. Translates typed outcomes into the
-    /// `push_delivery_attempts.status` wire format.
-    async fn dispatch_web_device(
-        &self,
-        device: &dispatch::SealedActiveDevice,
-        parsed: &dispatch::ParsedPushPayload,
-        item_id: &str,
-        signer: &Arc<dyn VapidSigner>,
-        sender: &Arc<dyn WebPushSender>,
-        sub: &VapidSub,
-    ) -> DispatchedAttempt {
-        let target = match dispatch::WebPushTarget::try_from_sealed(device, &self.secrets) {
-            Ok(target) => target,
-            Err(reason) => {
-                return DispatchedAttempt {
-                    device_id: device.device_id.clone(),
-                    platform: device.platform,
-                    status: dispatch::skip_reason_to_attempt_status(reason),
-                    last_error: None,
-                    retry_after: None,
-                };
-            }
-        };
-        match dispatch::dispatch_one_web_push(&target, parsed, item_id, signer, sub, sender).await {
-            Ok(outcome) => {
-                let status = dispatch::outcome_to_attempt_status(&outcome);
-                let last_error = if matches!(
-                    outcome,
-                    waddle_xmpp::push::types::WebPushOutcome::Delivered { .. }
-                ) {
-                    None
-                } else {
-                    Some(truncate_last_error(&web_push_outcome_diagnostic(&outcome)))
-                };
-                // Honor RFC 7231 §7.1.3 `Retry-After` for rate-limited
-                // responses — phase 3 takes `max(default, retry_after)`
-                // so a relay's "back off N seconds" hint is not lost.
-                let retry_after = match &outcome {
-                    waddle_xmpp::push::types::WebPushOutcome::RateLimited {
-                        retry_after, ..
-                    } => *retry_after,
-                    _ => None,
-                };
-                // XEP-0357 §6 forward cleanup runs in
-                // `finalize_publish_job` — when the persisted status
-                // hits `attempt_status_warrants_device_disable`, the
-                // matching `push_devices` row is flipped to
-                // `disabled` in the same tx.
-                //
-                // TODO(#762 follow-up): emit a server-initiated
-                // `<message><device-disabled xmlns='urn:waddle:push-
-                // service:0'/></message>` to the registering chat
-                // client so it can drop its local subscription and
-                // resubscribe with a fresh device-id. Requires
-                // plumbing the connection router into the publish-job
-                // worker; deferred so PR-D2 stays scoped to the
-                // server-side cleanup half of §6.
-                DispatchedAttempt {
-                    device_id: device.device_id.clone(),
-                    platform: device.platform,
-                    status,
-                    last_error,
-                    retry_after,
-                }
-            }
-            // Internal-error path covers encrypt/sign/aud-derive
-            // failures. These are deterministic bugs — a retry on the
-            // same `(subscription, payload)` will fail identically — so
-            // we classify as PERMANENT (not transient) to avoid an
-            // unbounded retry loop. Recorded as `web-internal-error`
-            // so an operator can grep for it and fix the underlying
-            // bug; the device stays active (not a per-device problem).
-            Err(error) => DispatchedAttempt {
-                device_id: device.device_id.clone(),
-                platform: device.platform,
-                status: ATTEMPT_STATUS_WEB_INTERNAL_ERROR,
-                last_error: Some(truncate_last_error(&error.to_string())),
-                retry_after: None,
-            },
-        }
+            })
+            .buffer_unordered(DISPATCH_FAN_OUT)
+            .collect::<Vec<_>>()
+            .await
     }
 
     /// Phase 3: open a fresh tx, record one row per attempt, and either

--- a/server/crates/waddle-server/src/push_service.rs
+++ b/server/crates/waddle-server/src/push_service.rs
@@ -23,6 +23,7 @@ use waddle_xmpp::push::{PushError, PushSubscription};
 use waddle_xmpp::xep::xep0357::NS_PUSH;
 use waddle_xmpp::XmppError;
 use xmpp_parsers::iq::Iq;
+use zeroize::ZeroizeOnDrop;
 
 use crate::db::{Database, IntoParams};
 
@@ -96,7 +97,7 @@ const PUBLISH_JOB_MAX_RETRY_AFTER_MS: i64 = 60 * 60 * 1_000;
 #[derive(Clone)]
 pub struct DatabasePushServiceStore {
     db: Database,
-    secrets: PushSecretCipher,
+    secrets: Arc<PushSecretCipher>,
     pubsub_boundary: Option<PushServicePubSubBoundary>,
     /// VAPID signer for outbound Web Push delivery. `None` when the
     /// process boots without a configured push service (legacy test
@@ -119,7 +120,13 @@ struct PushServicePubSubBoundary {
     storage: Arc<dyn PubSubStorage>,
 }
 
-#[derive(Clone)]
+/// Sealing cipher for device provider credentials at rest. Keys are
+/// HMAC-SHA256 derivations of the boot-time root key and are
+/// zeroized on drop so a process panic / shutdown does not leave the
+/// HMAC root-derived keys in heap residue. Wrap in `Arc` for cheap
+/// sharing across the publish-job fan-out; do not `.clone()` directly
+/// — that would duplicate the unzeroized byte buffers.
+#[derive(ZeroizeOnDrop)]
 pub(crate) struct PushSecretCipher {
     enc_key: Vec<u8>,
     mac_key: Vec<u8>,
@@ -477,6 +484,10 @@ pub struct PushPublishJob {
     item_id: String,
     push_service_jid: Option<String>,
     status: String,
+    /// The UUID-string written by phase 1's claim. Phase 3's UPDATE
+    /// gates on this so a stale-claim recovery + concurrent re-claim
+    /// can't persist attempts from the original worker.
+    claim_token: String,
 }
 
 #[derive(Debug, Clone)]
@@ -745,6 +756,10 @@ impl PushPublishJob {
     pub fn status(&self) -> &str {
         &self.status
     }
+
+    fn claim_token(&self) -> &str {
+        &self.claim_token
+    }
 }
 
 impl PushPublishJobEnqueue {
@@ -766,7 +781,7 @@ impl DatabasePushServiceStore {
     pub async fn new_with_secret_key(db: Database, secret_key: &[u8]) -> Result<Self, XmppError> {
         let store = Self {
             db,
-            secrets: PushSecretCipher::new(secret_key),
+            secrets: Arc::new(PushSecretCipher::new(secret_key)),
             pubsub_boundary: None,
             vapid_signer: None,
             web_push_sender: None,
@@ -784,7 +799,7 @@ impl DatabasePushServiceStore {
     ) -> Result<Self, XmppError> {
         let store = Self {
             db,
-            secrets: PushSecretCipher::new(secret_key),
+            secrets: Arc::new(PushSecretCipher::new(secret_key)),
             pubsub_boundary: Some(PushServicePubSubBoundary {
                 service_jid,
                 storage: pubsub_storage,
@@ -977,6 +992,7 @@ impl DatabasePushServiceStore {
                     last_error TEXT,
                     next_retry_at_ms {i64_type},
                     claimed_at_ms {i64_type},
+                    claim_token TEXT,
                     created_at_ms {i64_type} NOT NULL,
                     updated_at_ms {i64_type} NOT NULL,
                     published_at_ms {i64_type},
@@ -1003,6 +1019,12 @@ impl DatabasePushServiceStore {
         self.add_column_if_missing("push_publish_jobs", "publish_options_xml TEXT")
             .await?;
         self.add_column_if_missing("push_publish_jobs", "push_service_jid TEXT")
+            .await?;
+        // `claim_token` is the at-most-once delivery interlock: phase 1
+        // writes a fresh UUID; phase 3's UPDATE checks `claim_token = ?`
+        // so a recovered-and-re-claimed job (which holds a different
+        // token) cannot persist attempts from the original worker.
+        self.add_column_if_missing("push_publish_jobs", "claim_token TEXT")
             .await?;
         Ok(())
     }
@@ -2107,6 +2129,12 @@ impl DatabasePushServiceStore {
     async fn recover_stale_publish_job_claims(&self) -> Result<(), XmppError> {
         let now_ms = crate::time::now_ms();
         let retry_at_ms = retry_at_ms(now_ms);
+        // Clear the `claim_token` as part of recovery: a new claim
+        // will mint a fresh token, and the original worker's stale
+        // token can no longer match in phase 3's gating UPDATE — so
+        // even if the original phase 2 eventually completes its HTTP
+        // round-trip, its attempt-writes and job-state transition
+        // will be silently dropped instead of double-delivering.
         self.execute(
             r#"
             UPDATE push_publish_jobs
@@ -2114,6 +2142,7 @@ impl DatabasePushServiceStore {
                 last_error = ?,
                 next_retry_at_ms = ?,
                 claimed_at_ms = NULL,
+                claim_token = NULL,
                 updated_at_ms = ?
             WHERE status = ?
               AND claimed_at_ms IS NOT NULL
@@ -2141,6 +2170,7 @@ impl DatabasePushServiceStore {
                 last_error = ?,
                 next_retry_at_ms = NULL,
                 claimed_at_ms = NULL,
+                claim_token = NULL,
                 updated_at_ms = ?
             WHERE job_id = ?
               AND status = ?
@@ -2450,7 +2480,7 @@ impl DatabasePushServiceStore {
                 // Wrap the cipher in `Arc` so the per-device fan-out
                 // clones an `Arc` refcount instead of duplicating the
                 // (enc_key, mac_key) byte buffers up to 64× in heap.
-                Arc::new(self.secrets.clone()),
+                Arc::clone(&self.secrets),
             )),
             _ => None,
         };
@@ -2622,6 +2652,15 @@ impl DatabasePushServiceStore {
                 // the job permanently FAILED so it stops occupying the
                 // queue. The operator's audit trail
                 // (`push_delivery_attempts`) preserves every attempt.
+                //
+                // The `claim_token = ?` predicate is the at-most-once
+                // interlock: if a stale-claim recovery + concurrent
+                // re-claim happened between phase 1 and now, the row
+                // holds a different token and this UPDATE matches 0
+                // rows — our attempts insert is still durable, but
+                // the job-state transition is the responsibility of
+                // the worker that holds the *current* claim. Safe
+                // either way.
                 tx.execute(
                     r#"
                     UPDATE push_publish_jobs
@@ -2630,8 +2669,9 @@ impl DatabasePushServiceStore {
                         last_error = ?,
                         next_retry_at_ms = NULL,
                         claimed_at_ms = NULL,
+                        claim_token = NULL,
                         updated_at_ms = ?
-                    WHERE job_id = ? AND status = ?
+                    WHERE job_id = ? AND status = ? AND claim_token = ?
                     "#,
                     crate::db_params![
                         PUBLISH_JOB_STATUS_FAILED,
@@ -2641,6 +2681,7 @@ impl DatabasePushServiceStore {
                         now_ms,
                         job.job_id().to_string(),
                         PUBLISH_JOB_STATUS_IN_PROGRESS,
+                        job.claim_token().to_string(),
                     ],
                 )
                 .await
@@ -2669,8 +2710,9 @@ impl DatabasePushServiceStore {
                         last_error = ?,
                         next_retry_at_ms = ?,
                         claimed_at_ms = NULL,
+                        claim_token = NULL,
                         updated_at_ms = ?
-                    WHERE job_id = ? AND status = ?
+                    WHERE job_id = ? AND status = ? AND claim_token = ?
                     "#,
                     crate::db_params![
                         PUBLISH_JOB_STATUS_QUEUED,
@@ -2679,6 +2721,7 @@ impl DatabasePushServiceStore {
                         now_ms,
                         job.job_id().to_string(),
                         PUBLISH_JOB_STATUS_IN_PROGRESS,
+                        job.claim_token().to_string(),
                     ],
                 )
                 .await
@@ -2693,9 +2736,10 @@ impl DatabasePushServiceStore {
                     last_error = NULL,
                     next_retry_at_ms = NULL,
                     claimed_at_ms = NULL,
+                    claim_token = NULL,
                     updated_at_ms = ?,
                     published_at_ms = ?
-                WHERE job_id = ? AND status = ?
+                WHERE job_id = ? AND status = ? AND claim_token = ?
                 "#,
                 crate::db_params![
                     PUBLISH_JOB_STATUS_PUBLISHED,
@@ -2703,6 +2747,7 @@ impl DatabasePushServiceStore {
                     now_ms,
                     job.job_id().to_string(),
                     PUBLISH_JOB_STATUS_IN_PROGRESS,
+                    job.claim_token().to_string(),
                 ],
             )
             .await
@@ -2813,7 +2858,7 @@ impl DatabasePushServiceStore {
         let mut rows = self
             .query(
                 r#"
-                SELECT job_id, owner_bare_jid, node, item_id, push_service_jid, status
+                SELECT job_id, owner_bare_jid, node, item_id, push_service_jid, status, claim_token
                 FROM push_publish_jobs
                 WHERE status = ?
                 ORDER BY created_at_ms ASC, job_id ASC
@@ -2911,13 +2956,17 @@ impl DatabasePushServiceStore {
 }
 
 fn validate_xep0357_notification(item: &PubSubItem) -> Result<(), XmppError> {
+    // XEP-0060 §7.1.3 publish errors: surface the typed PubSub
+    // extension conditions instead of bare `<bad-request/>` so an
+    // external user-server gets the wire-required hint
+    // (`<payload-required/>` vs `<invalid-payload/>`) per §7.1.3.5.
     let Some(payload) = item.payload.as_ref() else {
-        return Err(XmppError::bad_request(Some(
+        return Err(XmppError::pubsub_payload_required(Some(
             "XEP-0357 PubSub publish requires a notification payload".to_string(),
         )));
     };
     if payload.name() != "notification" || payload.ns() != NS_PUSH {
-        return Err(XmppError::bad_request(Some(
+        return Err(XmppError::pubsub_invalid_payload(Some(
             "XEP-0357 PubSub publish payload must be notification in urn:xmpp:push:0".to_string(),
         )));
     }
@@ -3498,12 +3547,18 @@ async fn claim_publish_job_tx(
     job_id: &str,
     now_ms: i64,
 ) -> Result<Option<PushPublishJob>, XmppError> {
+    // Mint a fresh claim_token on every claim. Phase 3's UPDATE gates
+    // on this token so a stale-claim recovery + concurrent re-claim
+    // can never persist attempts from the original worker — the
+    // original worker's token is no longer the row's token.
+    let claim_token = uuid::Uuid::new_v4().to_string();
     let changed = tx
         .execute(
             r#"
             UPDATE push_publish_jobs
             SET status = ?,
                 claimed_at_ms = ?,
+                claim_token = ?,
                 updated_at_ms = ?
             WHERE job_id = ?
               AND status = ?
@@ -3512,6 +3567,7 @@ async fn claim_publish_job_tx(
             crate::db_params![
                 PUBLISH_JOB_STATUS_IN_PROGRESS,
                 now_ms,
+                claim_token,
                 now_ms,
                 job_id,
                 PUBLISH_JOB_STATUS_QUEUED,
@@ -3533,7 +3589,7 @@ async fn get_publish_job_tx(
     let mut rows = tx
         .query(
             r#"
-            SELECT job_id, owner_bare_jid, node, item_id, push_service_jid, status
+            SELECT job_id, owner_bare_jid, node, item_id, push_service_jid, status, claim_token
             FROM push_publish_jobs
             WHERE job_id = ?
             "#,
@@ -3802,6 +3858,13 @@ fn decode_publish_job(row: &crate::db::Row) -> Result<PushPublishJob, XmppError>
     let owner_bare_jid: String = row
         .get(1)
         .map_err(|error| XmppError::internal(error.to_string()))?;
+    // The `claim_token` column is nullable for legacy / unclaimed
+    // rows; treat NULL as empty string. Phase 3 only uses it for the
+    // gating UPDATE on rows it itself just claimed, so an empty
+    // token never matches a real claim.
+    let claim_token: Option<String> = row
+        .get(6)
+        .map_err(|error| XmppError::internal(error.to_string()))?;
     Ok(PushPublishJob {
         job_id: row
             .get(0)
@@ -3823,6 +3886,7 @@ fn decode_publish_job(row: &crate::db::Row) -> Result<PushPublishJob, XmppError>
         status: row
             .get(5)
             .map_err(|error| XmppError::internal(error.to_string()))?,
+        claim_token: claim_token.unwrap_or_default(),
     })
 }
 
@@ -4118,7 +4182,16 @@ mod tests {
             .publish_notification_from_user_server(node.node(), &item, &owner)
             .await
             .expect_err("reject wrong payload");
-        assert_bad_request(err);
+        // XEP-0060 §7.1.3.4: malformed payload must surface as the
+        // typed `<invalid-payload xmlns='http://jabber.org/protocol/
+        // pubsub#errors'/>` extension condition. The dispatch layer
+        // maps this onto `<bad-request/>` + the extension element on
+        // the wire, but the typed error is the carrier inside the
+        // process.
+        assert!(
+            matches!(err, XmppError::PubSubInvalidPayload(_)),
+            "expected pubsub:invalid-payload, got {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/push_service.rs
+++ b/server/crates/waddle-server/src/push_service.rs
@@ -2920,6 +2920,11 @@ fn validate_device_registration(registration: &PushDeviceRegistration) -> Result
         registration.provider_endpoint.as_deref(),
         MAX_PROVIDER_ENDPOINT_LEN,
     )?;
+    if registration.platform == PushDevicePlatform::Web {
+        if let Some(endpoint) = registration.provider_endpoint.as_deref() {
+            validate_web_push_endpoint(endpoint)?;
+        }
+    }
     validate_optional_len(
         "Push Service provider token",
         registration.provider_token.as_deref(),
@@ -2931,6 +2936,51 @@ fn validate_device_registration(registration: &PushDeviceRegistration) -> Result
         MAX_PROVIDER_KEY_MATERIAL_LEN,
     )?;
     Ok(())
+}
+
+/// Reject Web Push endpoints that would let a registering client
+/// weaponize the publish-job worker as an SSRF probe against
+/// internal-network hosts. Accepted shape: `https://<host>/...` where
+/// `<host>` is a non-IP domain whose lowest label is not
+/// `localhost`. Literal IP addresses (any family) are rejected
+/// outright — legitimate relays use named hosts and DNS handles their
+/// addressing.
+///
+/// Note: this is register-time only; it does not prevent DNS-rebinding
+/// at delivery time. A full mitigation requires inspecting the
+/// resolved peer address inside the reqwest connection callback
+/// (deferred to a follow-up PR).
+fn validate_web_push_endpoint(endpoint: &str) -> Result<(), XmppError> {
+    let parsed = url::Url::parse(endpoint).map_err(|_| {
+        XmppError::bad_request(Some(
+            "Push Service provider endpoint is not a valid URL".to_string(),
+        ))
+    })?;
+    if parsed.scheme() != "https" {
+        return Err(XmppError::bad_request(Some(
+            "Push Service provider endpoint must use https".to_string(),
+        )));
+    }
+    let host = parsed.host_str().ok_or_else(|| {
+        XmppError::bad_request(Some(
+            "Push Service provider endpoint must include a host".to_string(),
+        ))
+    })?;
+    // Reject `localhost` and the IPv6 equivalent regardless of how the
+    // operator's resolver maps them.
+    let host_lower = host.to_ascii_lowercase();
+    if host_lower == "localhost" || host_lower.ends_with(".localhost") {
+        return Err(XmppError::bad_request(Some(
+            "Push Service provider endpoint must not target localhost".to_string(),
+        )));
+    }
+    // Literal IPs: any family. `url::Host` already classifies them.
+    match parsed.host() {
+        Some(url::Host::Ipv4(_)) | Some(url::Host::Ipv6(_)) => Err(XmppError::bad_request(Some(
+            "Push Service provider endpoint must be a hostname, not an IP literal".to_string(),
+        ))),
+        _ => Ok(()),
+    }
 }
 
 fn validate_optional_len(field: &str, value: Option<&str>, max: usize) -> Result<(), XmppError> {
@@ -5634,6 +5684,77 @@ mod tests {
             DEVICE_STATUS_ACTIVE,
             "Transient outcomes must keep the device active — XEP-0357 §6 disable applies only to permanent failures"
         );
+    }
+
+    #[tokio::test]
+    async fn web_push_endpoint_rejects_ssrf_vectors() {
+        let store = store().await;
+        let owner = owner();
+        let node = store.ensure_node(&owner, "web").await.expect("node");
+        for bad in [
+            // Literal IPs in any family must be rejected outright —
+            // legitimate relays use named hosts.
+            "https://127.0.0.1/abc",
+            "https://10.0.0.5/abc",
+            "https://169.254.169.254/latest/meta-data/",
+            "https://[::1]/abc",
+            "https://[fd00::1]/abc",
+            // localhost and any *.localhost subdomain.
+            "https://localhost/abc",
+            "https://foo.localhost/abc",
+            // Non-https schemes.
+            "http://push.example.com/abc",
+            "ftp://push.example.com/abc",
+        ] {
+            let err = store
+                .upsert_device(
+                    &owner,
+                    PushDeviceRegistration::new(
+                        "ssrf",
+                        node.node(),
+                        PushDevicePlatform::Web,
+                        "test",
+                    )
+                    .with_provider_endpoint(Some(bad.to_string())),
+                )
+                .await
+                .expect_err(&format!("must reject {bad}"));
+            match err {
+                XmppError::Stanza {
+                    condition: waddle_xmpp::StanzaErrorCondition::BadRequest,
+                    ..
+                } => {}
+                other => panic!("expected bad-request for {bad}, got {other:?}"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn web_push_endpoint_accepts_real_relay_hosts() {
+        let store = store().await;
+        let owner = owner();
+        let node = store.ensure_node(&owner, "web").await.expect("node");
+        for ok in [
+            "https://fcm.googleapis.com/fcm/send/abc",
+            "https://updates.push.services.mozilla.com/wpush/v1/abc",
+            "https://web.push.apple.com/abc",
+            // Self-hosted relays with named hosts are fine.
+            "https://push.internal.example.com/abc",
+        ] {
+            store
+                .upsert_device(
+                    &owner,
+                    PushDeviceRegistration::new(
+                        "good",
+                        node.node(),
+                        PushDevicePlatform::Web,
+                        "test",
+                    )
+                    .with_provider_endpoint(Some(ok.to_string())),
+                )
+                .await
+                .unwrap_or_else(|err| panic!("legitimate relay {ok} rejected: {err:?}"));
+        }
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/push_service.rs
+++ b/server/crates/waddle-server/src/push_service.rs
@@ -3149,20 +3149,23 @@ fn validate_web_push_endpoint(endpoint: &str) -> Result<(), XmppError> {
             "Push Service provider endpoint must use https".to_string(),
         )));
     }
-    // Reject non-default ports. Web Push relays universally listen on
-    // 443; permitting other ports lets a registering client point the
-    // worker at internal non-HTTPS services that happen to accept a
-    // POST (Redis 6379, Elasticsearch 9200, memcached 11211, etc.)
-    // via a permissive internal DNS record. `url::Url::port_or_known_default()`
-    // resolves to the scheme's default (443 for https) when the URL
-    // omits an explicit port, so `https://host:443/...` and
-    // `https://host/...` both compare equal to `Some(443)` and only
-    // genuinely non-default ports are rejected.
-    if parsed.port_or_known_default() != Some(443) {
-        return Err(XmppError::bad_request(Some(
-            "Push Service provider endpoint must use the default https port".to_string(),
-        )));
-    }
+    // Port restriction intentionally omitted: RFC 8030 / RFC 8292
+    // place no constraint on the Web Push endpoint's port. VAPID
+    // `aud` per RFC 8292 §2 is computed from the URL's origin
+    // (scheme + host + port), so a legitimate self-hosted Mozilla
+    // autopush relay on `:8443` MUST round-trip through this gate
+    // for VAPID signing to produce the right `aud` claim. A
+    // hard-coded `:443` requirement would reject those conformant
+    // deployments. SSRF protection is layered:
+    //
+    //   1. Scheme check above (`https` only) prevents `http://` to
+    //      anything.
+    //   2. The literal-IP and `*.localhost` rejections below block
+    //      the obvious internal targets regardless of port.
+    //   3. Network-level egress policy (out of scope here) is the
+    //      proper defence against SSRF to internal DNS names on
+    //      arbitrary ports — the application layer cannot enumerate
+    //      every internal service.
     let host = parsed.host_str().ok_or_else(|| {
         XmppError::bad_request(Some(
             "Push Service provider endpoint must include a host".to_string(),
@@ -5958,11 +5961,6 @@ mod tests {
             // Non-https schemes.
             "http://push.example.com/abc",
             "ftp://push.example.com/abc",
-            // Non-default ports — would let a registering client point
-            // the worker at Redis (6379), Elasticsearch (9200), etc.
-            "https://push.example.com:6379/",
-            "https://push.example.com:9200/",
-            "https://push.example.com:8443/abc",
         ] {
             let err = store
                 .upsert_device(
@@ -5998,11 +5996,14 @@ mod tests {
             "https://web.push.apple.com/abc",
             // Self-hosted relays with named hosts are fine.
             "https://push.internal.example.com/abc",
-            // Explicit default port `:443` must be accepted — it's
-            // syntactically valid and semantically identical to the
-            // omitted form. (`port_or_known_default()` resolves both
-            // to `Some(443)`.)
+            // Explicit default port `:443` must be accepted.
             "https://fcm.googleapis.com:443/fcm/send/abc",
+            // Non-default ports are also allowed: RFC 8030 / RFC 8292
+            // place no constraint on port, and the VAPID `aud` claim
+            // is computed from the URL origin (scheme + host + port),
+            // so self-hosted Mozilla autopush deployments on `:8443`
+            // must round-trip through this gate cleanly.
+            "https://autopush.self-hosted.example.com:8443/wpush/v1/abc",
         ] {
             store
                 .upsert_device(

--- a/server/crates/waddle-server/src/push_service.rs
+++ b/server/crates/waddle-server/src/push_service.rs
@@ -15,6 +15,8 @@ use jid::BareJid;
 use minidom::Element;
 use sha2::Sha256;
 use waddle_xmpp::pubsub::{Affiliation, NodeConfig, PubSubItem, PubSubRequest, PubSubStorage};
+use waddle_xmpp::push::vapid::VapidSigner;
+use waddle_xmpp::push::WebPushSender;
 use waddle_xmpp::push::{PushError, PushSubscription};
 use waddle_xmpp::xep::xep0357::NS_PUSH;
 use waddle_xmpp::XmppError;
@@ -59,6 +61,15 @@ pub struct DatabasePushServiceStore {
     db: Database,
     secrets: PushSecretCipher,
     pubsub_boundary: Option<PushServicePubSubBoundary>,
+    /// VAPID signer for outbound Web Push delivery. `None` when the
+    /// process boots without a configured push service (legacy test
+    /// path); the publish-job worker treats absence as
+    /// [`waddle_xmpp::push::WebPushCapability::Degraded`] and short-
+    /// circuits Web Push fan-out without falling back to plaintext.
+    vapid_signer: Option<Arc<dyn VapidSigner>>,
+    /// Transport-layer sender for outbound Web Push HTTPS posts. Paired
+    /// with [`Self::vapid_signer`] — both Some or both None.
+    web_push_sender: Option<Arc<dyn WebPushSender>>,
 }
 
 #[derive(Clone)]
@@ -508,6 +519,8 @@ impl DatabasePushServiceStore {
             db,
             secrets: PushSecretCipher::new(secret_key),
             pubsub_boundary: None,
+            vapid_signer: None,
+            web_push_sender: None,
         };
         store.initialize().await?;
         Ok(store)
@@ -526,9 +539,24 @@ impl DatabasePushServiceStore {
                 service_jid,
                 storage: pubsub_storage,
             }),
+            vapid_signer: None,
+            web_push_sender: None,
         };
         store.initialize().await?;
         Ok(store)
+    }
+
+    /// Install the VAPID signer + Web Push transport for outbound
+    /// delivery. Called once at boot from `server::http`. Both arguments
+    /// are paired — Web Push cannot dispatch without either.
+    pub fn with_web_push_provider(
+        mut self,
+        vapid_signer: Arc<dyn VapidSigner>,
+        web_push_sender: Arc<dyn WebPushSender>,
+    ) -> Self {
+        self.vapid_signer = Some(vapid_signer);
+        self.web_push_sender = Some(web_push_sender);
+        self
     }
 
     pub fn database(&self) -> Database {

--- a/server/crates/waddle-server/src/push_service.rs
+++ b/server/crates/waddle-server/src/push_service.rs
@@ -1758,12 +1758,28 @@ impl DatabasePushServiceStore {
                 "XEP-0357 Push Service publish requires an IQ set".to_string(),
             )));
         }
-        if iq.from().is_some_and(|from| from.to_bare() != *publisher) {
+        // RFC 6120 §8.1.1.1: stanzas routed to a peer entity MUST
+        // carry both `from` and `to`. The previous `is_some_and`
+        // shape silently accepted IQs with neither, which would
+        // pass-through an addressed-less stanza into the publish
+        // path. Require both and verify they match the trusted
+        // caller-supplied publisher / service JID.
+        let Some(from) = iq.from() else {
+            return Err(XmppError::bad_request(Some(
+                "XEP-0357 Push Service publish IQ missing `from`".to_string(),
+            )));
+        };
+        if from.to_bare() != *publisher {
             return Err(XmppError::forbidden(Some(
                 "XEP-0357 Push Service publish sender does not match publisher".to_string(),
             )));
         }
-        if iq.to().is_some_and(|to| to.to_string() != push_service_jid) {
+        let Some(to) = iq.to() else {
+            return Err(XmppError::bad_request(Some(
+                "XEP-0357 Push Service publish IQ missing `to`".to_string(),
+            )));
+        };
+        if to.to_string() != push_service_jid {
             return Err(XmppError::bad_request(Some(
                 "XEP-0357 Push Service publish target does not match service".to_string(),
             )));

--- a/server/crates/waddle-server/src/push_service.rs
+++ b/server/crates/waddle-server/src/push_service.rs
@@ -2183,8 +2183,9 @@ impl DatabasePushServiceStore {
 
         // ---- Phase 1: tx1 — claim + validate + load sealed devices +
         // read payload_xml. We commit with the job still in
-        // `in-progress` so its 5-minute claim window covers phases 2+3
-        // without holding a DB transaction across the network round-trip.
+        // `in-progress` so its `PUBLISH_JOB_CLAIM_TIMEOUT_MS` claim
+        // window covers phases 2+3 without holding a DB transaction
+        // across the network round-trip.
         let phase1 = match self.process_publish_phase1(job_id, now_ms).await? {
             Phase1Outcome::Continue(state) => state,
             Phase1Outcome::ShortCircuit(result) => return Ok(result),
@@ -2244,8 +2245,9 @@ impl DatabasePushServiceStore {
     /// claim the job, validate node/owner/registration, ensure the
     /// XEP-0060 backing item exists, and load sealed devices + payload.
     /// Commits tx1 with the job still in
-    /// [`PUBLISH_JOB_STATUS_IN_PROGRESS`] so the 5-minute claim window
-    /// covers the out-of-tx Web Push round-trip.
+    /// [`PUBLISH_JOB_STATUS_IN_PROGRESS`] so the
+    /// [`PUBLISH_JOB_CLAIM_TIMEOUT_MS`] claim window covers the
+    /// out-of-tx Web Push round-trip.
     async fn process_publish_phase1(
         &self,
         job_id: &str,
@@ -2445,7 +2447,10 @@ impl DatabasePushServiceStore {
                 Arc::clone(sender),
                 sub.clone(),
                 parsed.clone(),
-                self.secrets.clone(),
+                // Wrap the cipher in `Arc` so the per-device fan-out
+                // clones an `Arc` refcount instead of duplicating the
+                // (enc_key, mac_key) byte buffers up to 64× in heap.
+                Arc::new(self.secrets.clone()),
             )),
             _ => None,
         };
@@ -2581,7 +2586,7 @@ impl DatabasePushServiceStore {
             //
             // Reverse direction (notifying the chat client so it can
             // re-register a fresh subscription) lands in a follow-up
-            // commit — see `dispatch_web_device`.
+            // commit — see `dispatch_web_device_owned`.
             if attempt_status_warrants_device_disable(attempt.status) {
                 mark_device_disabled_tx(
                     &mut tx,
@@ -3001,6 +3006,18 @@ fn validate_web_push_endpoint(endpoint: &str) -> Result<(), XmppError> {
     if parsed.scheme() != "https" {
         return Err(XmppError::bad_request(Some(
             "Push Service provider endpoint must use https".to_string(),
+        )));
+    }
+    // Reject non-default ports. Web Push relays universally listen on
+    // 443; permitting other ports lets a registering client point the
+    // worker at internal non-HTTPS services that happen to accept a
+    // POST (Redis 6379, Elasticsearch 9200, memcached 11211, etc.)
+    // via a permissive internal DNS record. `url::Url::port()` returns
+    // `None` for the default port of the scheme (443 for https), so
+    // any `Some(_)` here is a non-443 port.
+    if parsed.port().is_some() {
+        return Err(XmppError::bad_request(Some(
+            "Push Service provider endpoint must use the default https port".to_string(),
         )));
     }
     let host = parsed.host_str().ok_or_else(|| {
@@ -5747,6 +5764,11 @@ mod tests {
             // Non-https schemes.
             "http://push.example.com/abc",
             "ftp://push.example.com/abc",
+            // Non-default ports — would let a registering client point
+            // the worker at Redis (6379), Elasticsearch (9200), etc.
+            "https://push.example.com:6379/",
+            "https://push.example.com:9200/",
+            "https://push.example.com:8443/abc",
         ] {
             let err = store
                 .upsert_device(
@@ -5818,6 +5840,45 @@ mod tests {
             store.web_push_capability(),
             waddle_xmpp::push::WebPushCapability::Ready
         );
+    }
+
+    #[tokio::test]
+    async fn attempt_status_is_transient_matches_retry_intent() {
+        // Lock the matrix down so a future enum reorganization can't
+        // silently move `web-internal-error` (or any other permanent
+        // status) back into the transient set. Permanent statuses
+        // would spin in a 60s retry loop forever without the §6.1 cap;
+        // even with the cap, classifying a deterministic bug as
+        // transient burns 24 attempts before surfacing.
+        for transient in [
+            dispatch::ATTEMPT_STATUS_WEB_TRANSIENT,
+            dispatch::ATTEMPT_STATUS_WEB_RATE_LIMITED,
+            dispatch::ATTEMPT_STATUS_WEB_CLOCK_SKEW,
+            ATTEMPT_STATUS_WEB_NOT_CONFIGURED,
+        ] {
+            assert!(
+                attempt_status_is_transient(transient),
+                "{transient} must be classified transient"
+            );
+        }
+        for permanent in [
+            dispatch::ATTEMPT_STATUS_WEB_DELIVERED,
+            dispatch::ATTEMPT_STATUS_WEB_GONE,
+            dispatch::ATTEMPT_STATUS_WEB_BAD_REQUEST,
+            dispatch::ATTEMPT_STATUS_WEB_PAYLOAD_TOO_LARGE,
+            dispatch::ATTEMPT_STATUS_WEB_INVALID_KEYS,
+            dispatch::ATTEMPT_STATUS_WEB_INVALID_ENDPOINT,
+            dispatch::ATTEMPT_STATUS_WEB_UNSEAL_FAILED,
+            dispatch::ATTEMPT_STATUS_WEB_MISSING_MATERIAL,
+            dispatch::ATTEMPT_STATUS_FAKE_SENT_NON_WEB,
+            ATTEMPT_STATUS_WEB_INTERNAL_ERROR,
+        ] {
+            assert!(
+                !attempt_status_is_transient(permanent),
+                "{permanent} must NOT be classified transient — deterministic bugs and \
+                 device-permanent failures should not requeue"
+            );
+        }
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/push_service.rs
+++ b/server/crates/waddle-server/src/push_service.rs
@@ -70,7 +70,17 @@ const MAX_PROVIDER_TOKEN_LEN: usize = 4_096;
 const MAX_PROVIDER_KEY_MATERIAL_LEN: usize = 4_096;
 const MAX_PUBSUB_ITEM_ID_LEN: usize = 256;
 const PUBLISH_JOB_RETRY_DELAY_MS: i64 = 60_000;
-const PUBLISH_JOB_CLAIM_TIMEOUT_MS: i64 = 300_000;
+/// Upper bound on the duration of one publish-job worker pass (phase 1
+/// claim → phase 2 HTTP fan-out → phase 3 record). Sized to comfortably
+/// exceed any realistic phase-2 elapsed time: 1000 same-relay devices ×
+/// 100ms per-bucket spacing = ~100s of best-case throughput, well below
+/// the cap. `recover_stale_publish_job_claims` resets claims older than
+/// this; setting it lower than realistic phase-2 duration risks a
+/// concurrent worker re-claiming and dispatching the same job in
+/// parallel. Until a claim-token UUID column lands (see
+/// `TODO(#762 follow-up)` in `finalize_publish_job`), this constant
+/// is the only mitigation for the at-most-once invariant.
+const PUBLISH_JOB_CLAIM_TIMEOUT_MS: i64 = 30 * 60 * 1_000; // 30 minutes
 /// Ceiling on transient retries before a publish job is marked
 /// `failed`. XEP-0357 §6 explicitly contemplates this: "a server MAY
 /// choose to keep a service enabled if the error is deemed recoverable
@@ -2490,6 +2500,18 @@ impl DatabasePushServiceStore {
     /// Phase 3: open a fresh tx, record one row per attempt, and either
     /// requeue the job (any transient outcome) or mark it published.
     /// Prunes the per-node attempts/jobs tail so retention stays bounded.
+    ///
+    /// TODO(#762 follow-up — at-most-once delivery): the current claim
+    /// model uses a 30-minute lease (`PUBLISH_JOB_CLAIM_TIMEOUT_MS`).
+    /// If a worker's phase 2 somehow exceeds that, a second worker can
+    /// `recover_stale_publish_job_claims` the job and dispatch it in
+    /// parallel — both will then race here in phase 3 and both write
+    /// attempts. The right fix is a `claim_token` UUID column written
+    /// in phase 1 and checked here in the UPDATE's WHERE clause; phase
+    /// 3 of a losing worker would see 0 rows updated and abort the
+    /// attempt writes without persisting. Deferred to keep PR-D2's
+    /// schema surface minimal; the 30-minute window covers any
+    /// realistic phase-2 duration.
     async fn finalize_publish_job(
         &self,
         job: &PushPublishJob,

--- a/server/crates/waddle-server/src/push_service.rs
+++ b/server/crates/waddle-server/src/push_service.rs
@@ -41,8 +41,14 @@ const DEVICE_STATUS_DISABLED: &str = "disabled";
 /// the operator wires up the missing piece.
 const ATTEMPT_STATUS_WEB_NOT_CONFIGURED: &str = "web-not-configured";
 /// Internal error during Web Push dispatch (encrypt/sign/aud derivation
-/// failure). Treated as transient so an operator can ship a fix and the
-/// next tick will retry.
+/// failure). Classified PERMANENT, not transient: encrypt/sign/aud
+/// failures are deterministic on the inputs (same subscription, same
+/// payload, same signer key), so retrying produces the same error
+/// indefinitely. The job is marked PUBLISHED with the failure visible
+/// in `push_delivery_attempts.last_error` so an operator sees the bug
+/// and acts; the next *new* publish job tries the fixed code path.
+/// See `attempt_status_is_transient` — this constant is intentionally
+/// NOT in the transient set.
 const ATTEMPT_STATUS_WEB_INTERNAL_ERROR: &str = "web-internal-error";
 /// Maximum number of characters persisted in
 /// `push_delivery_attempts.last_error`. The column is `TEXT`, but we
@@ -615,6 +621,20 @@ async fn dispatch_web_device_owned(
                 }
                 _ => None,
             };
+            // ClockSkew (401 with WWW-Authenticate: vapid) means the
+            // relay rejected our JWT — likely because its clock
+            // disagrees with ours past the RFC 8292 §2 `exp` skew
+            // tolerance. The cached JWT is now poison: a retry that
+            // re-serves the same JWT will fail identically, exhausting
+            // the §6.1 attempt cap without ever sending a fresh one.
+            // Invalidate the cache so the next attempt mints a new JWT
+            // with a fresh `iat`/`exp` window.
+            if matches!(
+                outcome,
+                waddle_xmpp::push::types::WebPushOutcome::ClockSkew { .. }
+            ) {
+                signer.invalidate_cache();
+            }
             // XEP-0357 §6 forward cleanup runs in
             // `finalize_publish_job` — when the persisted status hits
             // `attempt_status_warrants_device_disable`, the matching
@@ -2552,17 +2572,15 @@ impl DatabasePushServiceStore {
     /// requeue the job (any transient outcome) or mark it published.
     /// Prunes the per-node attempts/jobs tail so retention stays bounded.
     ///
-    /// TODO(#762 follow-up — at-most-once delivery): the current claim
-    /// model uses a 30-minute lease (`PUBLISH_JOB_CLAIM_TIMEOUT_MS`).
-    /// If a worker's phase 2 somehow exceeds that, a second worker can
-    /// `recover_stale_publish_job_claims` the job and dispatch it in
-    /// parallel — both will then race here in phase 3 and both write
-    /// attempts. The right fix is a `claim_token` UUID column written
-    /// in phase 1 and checked here in the UPDATE's WHERE clause; phase
-    /// 3 of a losing worker would see 0 rows updated and abort the
-    /// attempt writes without persisting. Deferred to keep PR-D2's
-    /// schema surface minimal; the 30-minute window covers any
-    /// realistic phase-2 duration.
+    /// At-most-once delivery is enforced via the `claim_token` UUID
+    /// column: phase 1 mints a fresh token; phase 3's state-transition
+    /// UPDATEs gate on `claim_token = ?` so a stale worker (whose
+    /// claim was reset by `recover_stale_publish_job_claims`) sees 0
+    /// rows changed and the *current* claim-holder owns the final
+    /// state. The `push_delivery_attempts` INSERTs that come before
+    /// the gating UPDATE are guarded by a token re-check at the head
+    /// of the phase-3 tx — see the `verify_claim_token_or_abort_tx`
+    /// call below.
     async fn finalize_publish_job(
         &self,
         job: &PushPublishJob,
@@ -2579,6 +2597,22 @@ impl DatabasePushServiceStore {
             .map_err(|error| XmppError::internal(error.to_string()))?;
         lock_owner_tx(&mut tx, job.owner_bare_jid(), now_ms).await?;
         lock_node_tx(&mut tx, job.node(), now_ms).await?;
+        // At-most-once interlock: if our claim was reset by a
+        // stale-claim recovery between phase 1 and now, the row's
+        // current `claim_token` no longer matches the one phase 1
+        // captured. Abort BEFORE writing `push_delivery_attempts`
+        // rows or disabling devices — those side effects belong to
+        // the worker that holds the current claim. We still commit
+        // the empty tx so the locks release cleanly.
+        match read_publish_job_claim_token_tx(&mut tx, job.job_id()).await? {
+            Some(current) if current == job.claim_token() => {}
+            Some(_) | None => {
+                tx.commit()
+                    .await
+                    .map_err(|error| XmppError::internal(error.to_string()))?;
+                return Ok(());
+            }
+        }
         for attempt in attempts {
             tx.execute(
                 r#"
@@ -2743,6 +2777,48 @@ impl DatabasePushServiceStore {
                 .await
                 .map_err(|error| XmppError::internal(error.to_string()))?;
             }
+        } else if !attempts.is_empty()
+            && attempts
+                .iter()
+                .all(|attempt| attempt.status == dispatch::ATTEMPT_STATUS_WEB_BAD_REQUEST)
+        {
+            // Every device returned `web-bad-request` — that means our
+            // payload shape was wrong (encoder bug), not a per-device
+            // failure. Marking PUBLISHED would hide an encoder
+            // regression behind a "successful" job status; mark FAILED
+            // with the diagnostic so monitoring on
+            // `push_publish_jobs.status='failed'` surfaces it without
+            // auditing the attempts table. The device rows stay
+            // active — re-publish succeeds once the bug is fixed.
+            let bad_request_error = attempts
+                .iter()
+                .find_map(|attempt| attempt.last_error.clone())
+                .unwrap_or_else(|| "all devices returned web-bad-request".to_string());
+            tx.execute(
+                r#"
+                UPDATE push_publish_jobs
+                SET status = ?,
+                    attempt_count = attempt_count + 1,
+                    last_error = ?,
+                    next_retry_at_ms = NULL,
+                    claimed_at_ms = NULL,
+                    claim_token = NULL,
+                    updated_at_ms = ?
+                WHERE job_id = ? AND status = ? AND claim_token = ?
+                "#,
+                crate::db_params![
+                    PUBLISH_JOB_STATUS_FAILED,
+                    truncate_last_error(&format!(
+                        "all devices returned web-bad-request; encoder bug suspected: {bad_request_error}"
+                    )),
+                    now_ms,
+                    job.job_id().to_string(),
+                    PUBLISH_JOB_STATUS_IN_PROGRESS,
+                    job.claim_token().to_string(),
+                ],
+            )
+            .await
+            .map_err(|error| XmppError::internal(error.to_string()))?;
         } else {
             tx.execute(
                 r#"
@@ -3077,10 +3153,12 @@ fn validate_web_push_endpoint(endpoint: &str) -> Result<(), XmppError> {
     // 443; permitting other ports lets a registering client point the
     // worker at internal non-HTTPS services that happen to accept a
     // POST (Redis 6379, Elasticsearch 9200, memcached 11211, etc.)
-    // via a permissive internal DNS record. `url::Url::port()` returns
-    // `None` for the default port of the scheme (443 for https), so
-    // any `Some(_)` here is a non-443 port.
-    if parsed.port().is_some() {
+    // via a permissive internal DNS record. `url::Url::port_or_known_default()`
+    // resolves to the scheme's default (443 for https) when the URL
+    // omits an explicit port, so `https://host:443/...` and
+    // `https://host/...` both compare equal to `Some(443)` and only
+    // genuinely non-default ports are rejected.
+    if parsed.port_or_known_default() != Some(443) {
         return Err(XmppError::bad_request(Some(
             "Push Service provider endpoint must use the default https port".to_string(),
         )));
@@ -3649,6 +3727,33 @@ async fn get_publish_job_payload_xml_tx(
         .get(0)
         .map_err(|error| XmppError::internal(error.to_string()))?;
     Ok(Some(payload_xml))
+}
+
+/// Read the row's current `claim_token` so phase 3 can verify the
+/// claim is still ours before persisting any side effects. Returns
+/// `None` when the row was recovered (token cleared) or deleted.
+async fn read_publish_job_claim_token_tx(
+    tx: &mut crate::db::Transaction<'_>,
+    job_id: &str,
+) -> Result<Option<String>, XmppError> {
+    let mut rows = tx
+        .query(
+            "SELECT claim_token FROM push_publish_jobs WHERE job_id = ?",
+            crate::db_params![job_id],
+        )
+        .await
+        .map_err(|error| XmppError::internal(error.to_string()))?;
+    let Some(row) = rows
+        .next()
+        .await
+        .map_err(|error| XmppError::internal(error.to_string()))?
+    else {
+        return Ok(None);
+    };
+    let token: Option<String> = row
+        .get(0)
+        .map_err(|error| XmppError::internal(error.to_string()))?;
+    Ok(token)
 }
 
 /// Read the persisted `attempt_count` for a job. Used by phase 3 to
@@ -5893,6 +5998,11 @@ mod tests {
             "https://web.push.apple.com/abc",
             // Self-hosted relays with named hosts are fine.
             "https://push.internal.example.com/abc",
+            // Explicit default port `:443` must be accepted — it's
+            // syntactically valid and semantically identical to the
+            // omitted form. (`port_or_known_default()` resolves both
+            // to `Some(443)`.)
+            "https://fcm.googleapis.com:443/fcm/send/abc",
         ] {
             store
                 .upsert_device(

--- a/server/crates/waddle-server/src/push_service.rs
+++ b/server/crates/waddle-server/src/push_service.rs
@@ -2279,6 +2279,26 @@ impl DatabasePushServiceStore {
         self.vapid_signer.is_some() && self.web_push_sender.is_some() && self.vapid_sub.is_some()
     }
 
+    /// Public snapshot of the Web Push capability — `Ready` when the
+    /// store has a VAPID signer, transport, and sub all wired;
+    /// `Degraded { Xep0357PushServiceDegraded }` otherwise.
+    ///
+    /// The T1 push-gate (in `notification_outbox`) is expected to
+    /// consult this before falling back to any in-band channel, so a
+    /// degraded push service cannot accidentally leak content over a
+    /// plaintext path. No fallback path exists today, but the typed
+    /// suppression reason is plumbed end-to-end so the day someone
+    /// adds one, the safety invariant holds by construction.
+    pub fn web_push_capability(&self) -> waddle_xmpp::push::WebPushCapability {
+        if self.web_push_provider_ready() {
+            waddle_xmpp::push::WebPushCapability::Ready
+        } else {
+            waddle_xmpp::push::WebPushCapability::Degraded {
+                reason: waddle_xmpp::push::SuppressionReason::Xep0357PushServiceDegraded,
+            }
+        }
+    }
+
     /// Phase 2 helper: drive each sealed device row through the typed
     /// Web Push dispatcher and collect typed [`DispatchedAttempt`]
     /// outcomes. Pure compute + network — never touches the DB.
@@ -5484,6 +5504,27 @@ mod tests {
             device_status(&store, node.node(), "web-1").await,
             DEVICE_STATUS_ACTIVE,
             "Transient outcomes must keep the device active — XEP-0357 §6 disable applies only to permanent failures"
+        );
+    }
+
+    #[tokio::test]
+    async fn web_push_capability_is_degraded_without_provider() {
+        let store = store().await;
+        assert!(matches!(
+            store.web_push_capability(),
+            waddle_xmpp::push::WebPushCapability::Degraded {
+                reason: waddle_xmpp::push::SuppressionReason::Xep0357PushServiceDegraded,
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn web_push_capability_is_ready_when_provider_wired() {
+        let (store, _sender) =
+            store_with_web_push_provider(WebPushOutcome::Delivered { status: 201 }).await;
+        assert_eq!(
+            store.web_push_capability(),
+            waddle_xmpp::push::WebPushCapability::Ready
         );
     }
 

--- a/server/crates/waddle-server/src/push_service.rs
+++ b/server/crates/waddle-server/src/push_service.rs
@@ -559,6 +559,16 @@ fn web_push_outcome_diagnostic(outcome: &waddle_xmpp::push::types::WebPushOutcom
             None => format!("rate limited HTTP {status}"),
         },
         WebPushOutcome::PayloadTooLarge { status } => format!("payload too large HTTP {status}"),
+        // `status = 0` is the sentinel `HttpWebPushSender` returns for
+        // local preflight failures (non-https endpoint reaching the
+        // sender despite registration-time validation, or VAPID
+        // header that fails `HeaderValue::from_str`) — there was no
+        // HTTP exchange so no real status code applies. Render the
+        // diagnostic with that context instead of the misleading
+        // "HTTP 0".
+        WebPushOutcome::BadRequest { status: 0 } => {
+            "bad request (preflight: invalid endpoint or auth header)".to_string()
+        }
         WebPushOutcome::BadRequest { status } => format!("bad request HTTP {status}"),
         WebPushOutcome::Transient { kind } => match kind {
             TransientFailure::Network => "transient: network".to_string(),
@@ -710,6 +720,31 @@ fn attempt_status_warrants_device_disable(status: &str) -> bool {
             | dispatch::ATTEMPT_STATUS_WEB_INVALID_KEYS
             | dispatch::ATTEMPT_STATUS_WEB_INVALID_ENDPOINT
     )
+}
+
+/// If every attempt in the fan-out carries the same encoder/config-bug
+/// status (i.e. all `web-bad-request` or all `web-payload-too-large`),
+/// return that status so the worker can finalize the job as FAILED
+/// instead of silently marking it PUBLISHED. Returns `None` otherwise.
+///
+/// Both statuses are deterministic on the fan-out: every device hits
+/// the same encoder/padding bug, so the job will recur identically on
+/// retry. Surfacing FAILED on `push_publish_jobs.status` lets monitors
+/// alert without auditing the attempts table.
+fn all_attempts_with_encoder_bug_signature(attempts: &[DispatchedAttempt]) -> Option<&'static str> {
+    if attempts.is_empty() {
+        return None;
+    }
+    let first = attempts[0].status;
+    let uniform = matches!(
+        first,
+        dispatch::ATTEMPT_STATUS_WEB_BAD_REQUEST | dispatch::ATTEMPT_STATUS_WEB_PAYLOAD_TOO_LARGE
+    ) && attempts.iter().all(|a| a.status == first);
+    if uniform {
+        Some(first)
+    } else {
+        None
+    }
 }
 
 /// Truncate a free-form diagnostic to fit the
@@ -2777,23 +2812,25 @@ impl DatabasePushServiceStore {
                 .await
                 .map_err(|error| XmppError::internal(error.to_string()))?;
             }
-        } else if !attempts.is_empty()
-            && attempts
-                .iter()
-                .all(|attempt| attempt.status == dispatch::ATTEMPT_STATUS_WEB_BAD_REQUEST)
-        {
-            // Every device returned `web-bad-request` — that means our
-            // payload shape was wrong (encoder bug), not a per-device
-            // failure. Marking PUBLISHED would hide an encoder
-            // regression behind a "successful" job status; mark FAILED
-            // with the diagnostic so monitoring on
-            // `push_publish_jobs.status='failed'` surfaces it without
-            // auditing the attempts table. The device rows stay
-            // active — re-publish succeeds once the bug is fixed.
-            let bad_request_error = attempts
+        } else if let Some(uniform_status) = all_attempts_with_encoder_bug_signature(attempts) {
+            // Every device returned the same encoder-bug status —
+            // either all `web-bad-request` (the relay rejected our
+            // payload shape) or all `web-payload-too-large` (every
+            // device exceeded the relay's per-message ceiling, which
+            // is a padding/bucket-class misconfiguration). Both
+            // recur identically on retry, so the job is a
+            // deterministic failure, not a per-device problem.
+            // Marking PUBLISHED would hide the regression behind a
+            // "successful" job status; mark FAILED with the
+            // diagnostic so monitoring on
+            // `push_publish_jobs.status='failed'` surfaces it
+            // without auditing the attempts table. Device rows
+            // stay active — re-publish succeeds once the bug is
+            // fixed.
+            let uniform_error = attempts
                 .iter()
                 .find_map(|attempt| attempt.last_error.clone())
-                .unwrap_or_else(|| "all devices returned web-bad-request".to_string());
+                .unwrap_or_else(|| format!("all devices returned {uniform_status}"));
             tx.execute(
                 r#"
                 UPDATE push_publish_jobs
@@ -2809,7 +2846,7 @@ impl DatabasePushServiceStore {
                 crate::db_params![
                     PUBLISH_JOB_STATUS_FAILED,
                     truncate_last_error(&format!(
-                        "all devices returned web-bad-request; encoder bug suspected: {bad_request_error}"
+                        "all devices returned {uniform_status}; encoder/config bug suspected: {uniform_error}"
                     )),
                     now_ms,
                     job.job_id().to_string(),
@@ -5939,6 +5976,68 @@ mod tests {
             device_status(&store, node.node(), "web-1").await,
             DEVICE_STATUS_ACTIVE,
             "Transient outcomes must keep the device active — XEP-0357 §6 disable applies only to permanent failures"
+        );
+    }
+
+    #[tokio::test]
+    async fn all_payload_too_large_marks_job_failed_not_published() {
+        // 413 from every device means the padding/bucket-class is
+        // wrong (encoder/config bug), not a per-device problem.
+        // Monitoring on `push_publish_jobs.status` must see FAILED,
+        // not PUBLISHED — otherwise the regression hides behind a
+        // "successful" status.
+        let (store, sender) =
+            store_with_web_push_provider(WebPushOutcome::PayloadTooLarge { status: 413 }).await;
+        let owner = owner();
+        let node = store.ensure_node(&owner, "web").await.expect("node");
+        let (p256dh, auth) = fresh_subscription_material();
+        store
+            .upsert_device(
+                &owner,
+                PushDeviceRegistration::new("web-1", node.node(), PushDevicePlatform::Web, "test")
+                    .with_provider_endpoint(Some(
+                        "https://push.example.com/abc-subscription".to_string(),
+                    ))
+                    .with_provider_token(Some(auth))
+                    .with_provider_key_material(Some(p256dh)),
+            )
+            .await
+            .expect("device");
+        store
+            .publish_notification_from_user_server(
+                node.node(),
+                &web_push_notification_item("ptl-item-1", "alice@example.com", "dm", 1),
+                &owner,
+            )
+            .await
+            .expect("publish");
+        store
+            .drain_queued_notification_publish_jobs(16)
+            .await
+            .expect("drain");
+
+        assert_eq!(sender.call_count(), 1);
+        // Job status must be FAILED, not PUBLISHED — see
+        // `all_attempts_with_encoder_bug_signature`.
+        let mut rows = store
+            .query(
+                "SELECT status FROM push_publish_jobs WHERE item_id = ?",
+                crate::db_params!["ptl-item-1"],
+            )
+            .await
+            .expect("status query");
+        let row = rows.next().await.expect("row stream").expect("row present");
+        let status: String = row.get(0).expect("status col");
+        assert_eq!(
+            status, PUBLISH_JOB_STATUS_FAILED,
+            "all-PayloadTooLarge fan-out must mark the job FAILED, got {status}"
+        );
+        // Device row stays active — re-publish succeeds once the
+        // encoder/config bug is fixed.
+        assert_eq!(
+            device_status(&store, node.node(), "web-1").await,
+            DEVICE_STATUS_ACTIVE,
+            "encoder-bug failure must not disable the device"
         );
     }
 

--- a/server/crates/waddle-server/src/push_service.rs
+++ b/server/crates/waddle-server/src/push_service.rs
@@ -71,6 +71,18 @@ const MAX_PROVIDER_KEY_MATERIAL_LEN: usize = 4_096;
 const MAX_PUBSUB_ITEM_ID_LEN: usize = 256;
 const PUBLISH_JOB_RETRY_DELAY_MS: i64 = 60_000;
 const PUBLISH_JOB_CLAIM_TIMEOUT_MS: i64 = 300_000;
+/// Ceiling on transient retries before a publish job is marked
+/// `failed`. XEP-0357 §6 explicitly contemplates this: "a server MAY
+/// choose to keep a service enabled if the error is deemed recoverable
+/// or transient, until a sufficient number of errors have been received
+/// in a row." 24 attempts × 60s = a 24-minute upper bound on retry
+/// noise per job before the operator's `last_error` audit reveals the
+/// underlying problem.
+const PUBLISH_JOB_MAX_TRANSIENT_ATTEMPTS: i64 = 24;
+/// Hard ceiling on `Retry-After`-derived backoff to prevent a
+/// misbehaving relay from pinning a job into an effectively-forever
+/// requeue. 1 hour comfortably covers any sane rate-limit window.
+const PUBLISH_JOB_MAX_RETRY_AFTER_MS: i64 = 60 * 60 * 1_000;
 #[derive(Clone)]
 pub struct DatabasePushServiceStore {
     db: Database,
@@ -474,6 +486,11 @@ struct DispatchedAttempt {
     platform: PushDevicePlatform,
     status: &'static str,
     last_error: Option<String>,
+    /// `Retry-After` carried by a `WebPushOutcome::RateLimited` response.
+    /// Phase 3 honors the larger of this and the default backoff when
+    /// requeuing, so a relay's explicit "back off N seconds" hint is not
+    /// dropped on the floor.
+    retry_after: Option<std::time::Duration>,
 }
 
 /// Output of phase 1 of the publish-job worker — the typed pieces
@@ -538,8 +555,12 @@ fn attempt_status_is_transient(status: &str) -> bool {
             | dispatch::ATTEMPT_STATUS_WEB_RATE_LIMITED
             | dispatch::ATTEMPT_STATUS_WEB_CLOCK_SKEW
             | ATTEMPT_STATUS_WEB_NOT_CONFIGURED
-            | ATTEMPT_STATUS_WEB_INTERNAL_ERROR
     )
+    // `web-internal-error` is deliberately NOT transient: encrypt /
+    // sign / aud-derive failures are deterministic bugs that recur
+    // identically on retry. Classifying them as permanent means an
+    // operator sees the failure in `push_delivery_attempts` and can
+    // act, instead of the job spinning in a 60s loop forever.
 }
 
 /// XEP-0357 §6: which attempt outcomes mean the underlying device row
@@ -2326,18 +2347,24 @@ impl DatabasePushServiceStore {
                     self.dispatch_web_device(device, parsed, item_id, signer, sender, sub)
                         .await
                 }
-                // No Web Push provider wired up (tests, or a degraded
-                // boot that never called `with_web_push_provider`). The
-                // worker continues to record the legacy `fake-sent`
-                // marker for every platform so existing test dashboards
-                // and operator scripts keep working unchanged. The
-                // real-send path lights up only when all three of
-                // (vapid_signer, web_push_sender, vapid_sub) are wired.
-                (None, _) => DispatchedAttempt {
+                // No Web Push provider wired up. Web devices get the
+                // typed `web-not-configured` marker (transient, so the
+                // job retries once the operator fixes the boot config);
+                // APNS/FCM devices retain the legacy `fake-sent` marker
+                // (their senders ship in #529 / #530).
+                (None, PushDevicePlatform::Web) => DispatchedAttempt {
+                    device_id: device.device_id.clone(),
+                    platform: device.platform,
+                    status: ATTEMPT_STATUS_WEB_NOT_CONFIGURED,
+                    last_error: Some("Web Push provider not configured".to_string()),
+                    retry_after: None,
+                },
+                (None, PushDevicePlatform::Apns | PushDevicePlatform::Fcm) => DispatchedAttempt {
                     device_id: device.device_id.clone(),
                     platform: device.platform,
                     status: dispatch::ATTEMPT_STATUS_FAKE_SENT_NON_WEB,
                     last_error: None,
+                    retry_after: None,
                 },
                 // APNS/FCM are stubbed until #529/#530 land their real
                 // senders. Keep the historical `fake-sent` marker so
@@ -2348,6 +2375,7 @@ impl DatabasePushServiceStore {
                         platform: device.platform,
                         status: dispatch::ATTEMPT_STATUS_FAKE_SENT_NON_WEB,
                         last_error: None,
+                        retry_after: None,
                     }
                 }
             };
@@ -2376,6 +2404,7 @@ impl DatabasePushServiceStore {
                     platform: device.platform,
                     status: dispatch::skip_reason_to_attempt_status(reason),
                     last_error: None,
+                    retry_after: None,
                 };
             }
         };
@@ -2389,6 +2418,15 @@ impl DatabasePushServiceStore {
                     None
                 } else {
                     Some(truncate_last_error(&web_push_outcome_diagnostic(&outcome)))
+                };
+                // Honor RFC 7231 §7.1.3 `Retry-After` for rate-limited
+                // responses — phase 3 takes `max(default, retry_after)`
+                // so a relay's "back off N seconds" hint is not lost.
+                let retry_after = match &outcome {
+                    waddle_xmpp::push::types::WebPushOutcome::RateLimited {
+                        retry_after, ..
+                    } => *retry_after,
+                    _ => None,
                 };
                 // XEP-0357 §6 forward cleanup runs in
                 // `finalize_publish_job` — when the persisted status
@@ -2409,13 +2447,22 @@ impl DatabasePushServiceStore {
                     platform: device.platform,
                     status,
                     last_error,
+                    retry_after,
                 }
             }
+            // Internal-error path covers encrypt/sign/aud-derive
+            // failures. These are deterministic bugs — a retry on the
+            // same `(subscription, payload)` will fail identically — so
+            // we classify as PERMANENT (not transient) to avoid an
+            // unbounded retry loop. Recorded as `web-internal-error`
+            // so an operator can grep for it and fix the underlying
+            // bug; the device stays active (not a per-device problem).
             Err(error) => DispatchedAttempt {
                 device_id: device.device_id.clone(),
                 platform: device.platform,
                 status: ATTEMPT_STATUS_WEB_INTERNAL_ERROR,
                 last_error: Some(truncate_last_error(&error.to_string())),
+                retry_after: None,
             },
         }
     }
@@ -2508,7 +2555,13 @@ impl DatabasePushServiceStore {
             .iter()
             .any(|attempt| attempt_status_is_transient(attempt.status));
         if any_transient {
-            let retry_at_ms = retry_at_ms(now_ms);
+            // Read the current `attempt_count` so we can enforce the
+            // §6.1 "sufficient number of errors" cap. The row is
+            // exclusively held by our claim (IN_PROGRESS); the read is
+            // serializable.
+            let attempt_count_so_far = read_publish_job_attempt_count_tx(&mut tx, job.job_id())
+                .await?
+                .unwrap_or(0);
             // Surface the first transient diagnostic so an operator can
             // see why this job is waiting to retry.
             let transient_error = attempts
@@ -2516,28 +2569,74 @@ impl DatabasePushServiceStore {
                 .find(|attempt| attempt_status_is_transient(attempt.status))
                 .and_then(|attempt| attempt.last_error.clone())
                 .unwrap_or_else(|| "Web Push transient failure".to_string());
-            tx.execute(
-                r#"
-                UPDATE push_publish_jobs
-                SET status = ?,
-                    attempt_count = attempt_count + 1,
-                    last_error = ?,
-                    next_retry_at_ms = ?,
-                    claimed_at_ms = NULL,
-                    updated_at_ms = ?
-                WHERE job_id = ? AND status = ?
-                "#,
-                crate::db_params![
-                    PUBLISH_JOB_STATUS_QUEUED,
-                    transient_error,
-                    retry_at_ms,
-                    now_ms,
-                    job.job_id().to_string(),
-                    PUBLISH_JOB_STATUS_IN_PROGRESS,
-                ],
-            )
-            .await
-            .map_err(|error| XmppError::internal(error.to_string()))?;
+            if attempt_count_so_far + 1 >= PUBLISH_JOB_MAX_TRANSIENT_ATTEMPTS {
+                // XEP-0357 §6.1: "until a sufficient number of errors
+                // have been received in a row." Past the ceiling, mark
+                // the job permanently FAILED so it stops occupying the
+                // queue. The operator's audit trail
+                // (`push_delivery_attempts`) preserves every attempt.
+                tx.execute(
+                    r#"
+                    UPDATE push_publish_jobs
+                    SET status = ?,
+                        attempt_count = attempt_count + 1,
+                        last_error = ?,
+                        next_retry_at_ms = NULL,
+                        claimed_at_ms = NULL,
+                        updated_at_ms = ?
+                    WHERE job_id = ? AND status = ?
+                    "#,
+                    crate::db_params![
+                        PUBLISH_JOB_STATUS_FAILED,
+                        truncate_last_error(&format!(
+                            "transient retry cap exceeded ({PUBLISH_JOB_MAX_TRANSIENT_ATTEMPTS}); last: {transient_error}"
+                        )),
+                        now_ms,
+                        job.job_id().to_string(),
+                        PUBLISH_JOB_STATUS_IN_PROGRESS,
+                    ],
+                )
+                .await
+                .map_err(|error| XmppError::internal(error.to_string()))?;
+            } else {
+                // Honor the largest `Retry-After` carried by any
+                // 429-style attempt. The default 60s floor still
+                // applies — a relay that asks for 1s gets the 60s
+                // backoff anyway — but a relay asking for 5min gets
+                // 5min. Capped at 1h to bound runaway misbehavior.
+                let mut retry_at = retry_at_ms(now_ms);
+                if let Some(retry_after_ms) = attempts
+                    .iter()
+                    .filter_map(|attempt| attempt.retry_after)
+                    .map(|d| d.as_millis().min(PUBLISH_JOB_MAX_RETRY_AFTER_MS as u128) as i64)
+                    .max()
+                {
+                    let relay_deadline = now_ms.saturating_add(retry_after_ms);
+                    retry_at = retry_at.max(relay_deadline);
+                }
+                tx.execute(
+                    r#"
+                    UPDATE push_publish_jobs
+                    SET status = ?,
+                        attempt_count = attempt_count + 1,
+                        last_error = ?,
+                        next_retry_at_ms = ?,
+                        claimed_at_ms = NULL,
+                        updated_at_ms = ?
+                    WHERE job_id = ? AND status = ?
+                    "#,
+                    crate::db_params![
+                        PUBLISH_JOB_STATUS_QUEUED,
+                        transient_error,
+                        retry_at,
+                        now_ms,
+                        job.job_id().to_string(),
+                        PUBLISH_JOB_STATUS_IN_PROGRESS,
+                    ],
+                )
+                .await
+                .map_err(|error| XmppError::internal(error.to_string()))?;
+            }
         } else {
             tx.execute(
                 r#"
@@ -3371,6 +3470,31 @@ async fn get_publish_job_payload_xml_tx(
     Ok(Some(payload_xml))
 }
 
+/// Read the persisted `attempt_count` for a job. Used by phase 3 to
+/// enforce [`PUBLISH_JOB_MAX_TRANSIENT_ATTEMPTS`] (XEP-0357 §6.1).
+async fn read_publish_job_attempt_count_tx(
+    tx: &mut crate::db::Transaction<'_>,
+    job_id: &str,
+) -> Result<Option<i64>, XmppError> {
+    let mut rows = tx
+        .query(
+            "SELECT attempt_count FROM push_publish_jobs WHERE job_id = ?",
+            crate::db_params![job_id],
+        )
+        .await
+        .map_err(|error| XmppError::internal(error.to_string()))?;
+    let Some(row) = rows
+        .next()
+        .await
+        .map_err(|error| XmppError::internal(error.to_string()))?
+    else {
+        return Ok(None);
+    };
+    row.get(0)
+        .map(Some)
+        .map_err(|error| XmppError::internal(error.to_string()))
+}
+
 async fn mark_publish_job_failed_tx(
     tx: &mut crate::db::Transaction<'_>,
     job_id: &str,
@@ -3821,13 +3945,16 @@ mod tests {
 
     #[tokio::test]
     async fn publish_notification_fans_out_to_active_devices_only() {
+        // Queue-mechanics test: uses Apns platform so we don't need a
+        // Web Push provider wired. APNS sender lands in #529; until
+        // then non-Web platforms record the legacy `fake-sent` marker.
         let store = store().await;
         let owner = owner();
         let node = store.ensure_node(&owner, "web").await.expect("push node");
         store
             .upsert_device(
                 &owner,
-                PushDeviceRegistration::new("web-1", node.node(), PushDevicePlatform::Web, "test")
+                PushDeviceRegistration::new("dev-1", node.node(), PushDevicePlatform::Apns, "test")
                     .with_provider_endpoint(Some("https://push.example.com/one".to_string())),
             )
             .await
@@ -3835,13 +3962,13 @@ mod tests {
         store
             .upsert_device(
                 &owner,
-                PushDeviceRegistration::new("web-2", node.node(), PushDevicePlatform::Web, "test")
+                PushDeviceRegistration::new("dev-2", node.node(), PushDevicePlatform::Apns, "test")
                     .with_provider_endpoint(Some("https://push.example.com/two".to_string())),
             )
             .await
             .expect("device two");
         store
-            .disable_device_for_owner(&owner, node.node(), "web-2", Some("expired"))
+            .disable_device_for_owner(&owner, node.node(), "dev-2", Some("expired"))
             .await
             .expect("disable device");
 
@@ -3861,7 +3988,7 @@ mod tests {
             .await
             .expect("attempts");
         assert_eq!(attempts.len(), 1);
-        assert_eq!(attempts[0].device_id(), "web-1");
+        assert_eq!(attempts[0].device_id(), "dev-1");
         assert_eq!(
             attempts[0].status(),
             dispatch::ATTEMPT_STATUS_FAKE_SENT_NON_WEB
@@ -4658,9 +4785,9 @@ mod tests {
                 .upsert_device(
                     &owner,
                     PushDeviceRegistration::new(
-                        "web-1",
+                        "dev-1",
                         node.node(),
-                        PushDevicePlatform::Web,
+                        PushDevicePlatform::Apns,
                         "test",
                     ),
                 )
@@ -4688,7 +4815,7 @@ mod tests {
             .expect("attempts");
 
         assert_eq!(attempts.len(), 1);
-        assert_eq!(attempts[0].device_id(), "web-1");
+        assert_eq!(attempts[0].device_id(), "dev-1");
         assert_eq!(attempts[0].item_id(), "durable-attempt");
         assert_eq!(
             attempts[0].status(),
@@ -4698,6 +4825,8 @@ mod tests {
 
     #[tokio::test]
     async fn queued_publish_job_survives_reopen_and_retries_after_dispatch_failure() {
+        // Queue-mechanics: uses Apns so the fake-sent path applies; the
+        // Web platform now requires a wired provider.
         let dir = tempdir().expect("tempdir");
         let path = dir.path().join("push-service-publish-jobs.sqlite3");
         let owner = owner();
@@ -4713,9 +4842,9 @@ mod tests {
                 .upsert_device(
                     &owner,
                     PushDeviceRegistration::new(
-                        "web-1",
+                        "dev-1",
                         node.node(),
-                        PushDevicePlatform::Web,
+                        PushDevicePlatform::Apns,
                         "test",
                     ),
                 )
@@ -4902,7 +5031,7 @@ mod tests {
         store
             .upsert_device(
                 &owner,
-                PushDeviceRegistration::new("web-1", node.node(), PushDevicePlatform::Web, "test"),
+                PushDeviceRegistration::new("dev-1", node.node(), PushDevicePlatform::Apns, "test"),
             )
             .await
             .expect("device");
@@ -4945,7 +5074,7 @@ mod tests {
         store
             .upsert_device(
                 &owner,
-                PushDeviceRegistration::new("web-1", node.node(), PushDevicePlatform::Web, "test"),
+                PushDeviceRegistration::new("dev-1", node.node(), PushDevicePlatform::Apns, "test"),
             )
             .await
             .expect("device");
@@ -5000,7 +5129,7 @@ mod tests {
         store
             .upsert_device(
                 &owner,
-                PushDeviceRegistration::new("web-1", node.node(), PushDevicePlatform::Web, "test"),
+                PushDeviceRegistration::new("dev-1", node.node(), PushDevicePlatform::Apns, "test"),
             )
             .await
             .expect("device");
@@ -5159,12 +5288,12 @@ mod tests {
         store
             .upsert_device(
                 &owner,
-                PushDeviceRegistration::new("web-1", node.node(), PushDevicePlatform::Web, "test"),
+                PushDeviceRegistration::new("dev-1", node.node(), PushDevicePlatform::Apns, "test"),
             )
             .await
             .expect("device");
         store
-            .disable_device_for_owner(&owner, node.node(), "web-1", None)
+            .disable_device_for_owner(&owner, node.node(), "dev-1", None)
             .await
             .expect("disable device");
 
@@ -5185,7 +5314,7 @@ mod tests {
         store
             .upsert_device(
                 &owner,
-                PushDeviceRegistration::new("web-1", node.node(), PushDevicePlatform::Web, "test"),
+                PushDeviceRegistration::new("dev-1", node.node(), PushDevicePlatform::Apns, "test"),
             )
             .await
             .expect("reenable device");

--- a/server/crates/waddle-server/src/push_service.rs
+++ b/server/crates/waddle-server/src/push_service.rs
@@ -542,6 +542,30 @@ fn attempt_status_is_transient(status: &str) -> bool {
     )
 }
 
+/// XEP-0357 §6: which attempt outcomes mean the underlying device row
+/// should be marked disabled in `push_devices` so future publish jobs
+/// stop fanning out to it.
+///
+/// - `web-gone` is the textbook §6 trigger: the relay returned 404/410
+///   meaning the subscription is permanently dead.
+/// - `web-invalid-keys` / `web-invalid-endpoint` mean the stored
+///   material is structurally unusable; retrying the same row will keep
+///   failing with the same error.
+/// - `web-unseal-failed` is deliberately NOT listed — it usually
+///   signals a root-key drift across boots, which is fixable without
+///   the user re-registering their device. Disabling on that would
+///   compound a configuration mistake into data loss.
+/// - Transient statuses are handled by the retry path; we keep the
+///   device row active so the next attempt has somewhere to land.
+fn attempt_status_warrants_device_disable(status: &str) -> bool {
+    matches!(
+        status,
+        dispatch::ATTEMPT_STATUS_WEB_GONE
+            | dispatch::ATTEMPT_STATUS_WEB_INVALID_KEYS
+            | dispatch::ATTEMPT_STATUS_WEB_INVALID_ENDPOINT
+    )
+}
+
 /// Truncate a free-form diagnostic to fit the
 /// `push_delivery_attempts.last_error` column without bloating the table
 /// when a relay echoes back a multi-KB error body. Splits on a char
@@ -2346,13 +2370,20 @@ impl DatabasePushServiceStore {
                 } else {
                     Some(truncate_last_error(&web_push_outcome_diagnostic(&outcome)))
                 };
-                // TODO(#762/PR-D2 follow-up): when `outcome` is
-                // `WebPushOutcome::SubscriptionGone`, hook the XEP-0357
-                // §6 cleanup chain here — emit the IQ-error to the
-                // publisher and `urn:waddle:push-service:0` disable the
-                // device. Until then we persist the typed status
-                // `"web-gone"` so the next commit can find every gone
-                // attempt by SELECT.
+                // XEP-0357 §6 forward cleanup runs in
+                // `finalize_publish_job` — when the persisted status
+                // hits `attempt_status_warrants_device_disable`, the
+                // matching `push_devices` row is flipped to
+                // `disabled` in the same tx.
+                //
+                // TODO(#762 follow-up): emit a server-initiated
+                // `<message><device-disabled xmlns='urn:waddle:push-
+                // service:0'/></message>` to the registering chat
+                // client so it can drop its local subscription and
+                // resubscribe with a fresh device-id. Requires
+                // plumbing the connection router into the publish-job
+                // worker; deferred so PR-D2 stays scoped to the
+                // server-side cleanup half of §6.
                 DispatchedAttempt {
                     device_id: device.device_id.clone(),
                     platform: device.platform,
@@ -2415,6 +2446,43 @@ impl DatabasePushServiceStore {
             )
             .await
             .map_err(|error| XmppError::internal(error.to_string()))?;
+
+            // XEP-0357 §6 cleanup (forward direction):
+            //
+            //   "If a publish request is returned with an IQ-error,
+            //    then the server SHOULD consider the particular JID
+            //    and node combination to be disabled."
+            //
+            // The XEP frames this from the user-server's perspective,
+            // but in our deployment the push service AND the
+            // user-server are the same process. When the Web Push
+            // relay tells us a subscription is permanently gone
+            // (404/410), we mark the underlying `push_devices` row
+            // disabled inside the same tx that records the gone
+            // attempt — the next publish-job for this node will skip
+            // the device and `count_active_devices_for_node_tx` will
+            // see one fewer subscriber.
+            //
+            // We also disable on `web-invalid-keys` /
+            // `web-invalid-endpoint`: the stored material is
+            // structurally unusable, retrying with the same row is
+            // pointless. `web-unseal-failed` is deliberately NOT
+            // disabled — it usually signals a root-key drift across
+            // boots and is fixable without the user re-registering.
+            //
+            // Reverse direction (notifying the chat client so it can
+            // re-register a fresh subscription) lands in a follow-up
+            // commit — see `dispatch_web_device`.
+            if attempt_status_warrants_device_disable(attempt.status) {
+                mark_device_disabled_tx(
+                    &mut tx,
+                    job.node(),
+                    &attempt.device_id,
+                    attempt.status,
+                    now_ms,
+                )
+                .await?;
+            }
         }
         let any_transient = attempts
             .iter()
@@ -3301,6 +3369,42 @@ async fn mark_publish_job_failed_tx(
         WHERE job_id = ?
         "#,
         crate::db_params![PUBLISH_JOB_STATUS_FAILED, error, now_ms, job_id],
+    )
+    .await
+    .map_err(|error| XmppError::internal(error.to_string()))?;
+    Ok(())
+}
+
+/// XEP-0357 §6 forward cleanup: flip a `push_devices` row from
+/// `active` to `disabled` when its push subscription is permanently
+/// unusable (relay returned 404/410, stored keys are structurally
+/// invalid, etc.). Idempotent — already-disabled rows stay disabled.
+/// `reason` is stored on the row as `last_error` so an operator can
+/// see which permanent-failure outcome triggered the disable.
+async fn mark_device_disabled_tx(
+    tx: &mut crate::db::Transaction<'_>,
+    node: &str,
+    device_id: &str,
+    reason: &str,
+    now_ms: i64,
+) -> Result<(), XmppError> {
+    tx.execute(
+        r#"
+        UPDATE push_devices
+        SET status = ?,
+            failure_count = failure_count + 1,
+            last_error = ?,
+            updated_at_ms = ?
+        WHERE node = ? AND device_id = ? AND status = ?
+        "#,
+        crate::db_params![
+            DEVICE_STATUS_DISABLED,
+            reason,
+            now_ms,
+            node,
+            device_id,
+            DEVICE_STATUS_ACTIVE,
+        ],
     )
     .await
     .map_err(|error| XmppError::internal(error.to_string()))?;
@@ -5080,6 +5184,342 @@ mod tests {
         assert_eq!(attempts.len(), 1);
         assert_eq!(attempts[0].item_id(), "retry-when-device-returns");
         assert!(queued_after.is_empty());
+    }
+
+    // ── XEP-0357 §6 forward cleanup ────────────────────────────────────
+    //
+    // When the Web Push relay reports the subscription is permanently
+    // gone (404/410), the publish-job worker records a `web-gone`
+    // attempt AND marks the underlying `push_devices` row disabled in
+    // the same tx so future publish jobs for the node skip it. These
+    // tests exercise the full path with a mock `WebPushSender` so the
+    // cleanup behavior is locked in without needing a live relay.
+
+    use std::future::Future;
+    use std::pin::Pin;
+    use waddle_xmpp::push::types::{VapidSub, WebPushOutcome};
+    use waddle_xmpp::push::{WebPushRequest, WebPushSender};
+
+    /// A `WebPushSender` that returns the same configured outcome for
+    /// every request. Counts calls so tests can assert the worker
+    /// actually invoked it.
+    #[derive(Clone)]
+    struct FixedOutcomeSender {
+        outcome: WebPushOutcome,
+        calls: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    impl FixedOutcomeSender {
+        fn new(outcome: WebPushOutcome) -> Self {
+            Self {
+                outcome,
+                calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            }
+        }
+
+        fn call_count(&self) -> usize {
+            self.calls.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    impl WebPushSender for FixedOutcomeSender {
+        fn send(
+            &self,
+            _request: WebPushRequest<'_>,
+        ) -> Pin<Box<dyn Future<Output = WebPushOutcome> + Send + '_>> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let outcome = self.outcome.clone();
+            Box::pin(async move { outcome })
+        }
+    }
+
+    /// Build a Web Push-shape `<notification>` payload with the typed
+    /// `urn:waddle:push:context:0` element the chat publisher emits.
+    /// `class` is the db-form value (e.g. `"dm"`, `"personal_mention"`).
+    fn web_push_notification_item(
+        item_id: &str,
+        conversation: &str,
+        class: &str,
+        message_count: u32,
+    ) -> PubSubItem {
+        use waddle_xmpp::xep::xep0004::NS_DATA_FORMS;
+        let summary = Element::builder("x", NS_DATA_FORMS)
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
+            .append(
+                Element::builder("field", NS_DATA_FORMS)
+                    .attr(minidom::rxml::xml_ncname!("var").to_owned(), "FORM_TYPE")
+                    .attr(minidom::rxml::xml_ncname!("type").to_owned(), "hidden")
+                    .append(
+                        Element::builder("value", NS_DATA_FORMS)
+                            .append("urn:xmpp:push:summary")
+                            .build(),
+                    )
+                    .build(),
+            )
+            .append(
+                Element::builder("field", NS_DATA_FORMS)
+                    .attr(
+                        minidom::rxml::xml_ncname!("var").to_owned(),
+                        "message-count",
+                    )
+                    .append(
+                        Element::builder("value", NS_DATA_FORMS)
+                            .append(message_count.to_string())
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build();
+        let context = Element::builder("context", "urn:waddle:push:context:0")
+            .attr(
+                minidom::rxml::xml_ncname!("conversation").to_owned(),
+                conversation,
+            )
+            .attr(minidom::rxml::xml_ncname!("class").to_owned(), class)
+            .build();
+        let notification = Element::builder("notification", NS_PUSH)
+            .append(summary)
+            .append(context)
+            .build();
+        PubSubItem::new(Some(item_id.to_string()), Some(notification))
+    }
+
+    /// Generate a real (p256dh, auth) subscription pair the
+    /// `SubscriptionKeys` parser will accept. The relay-side mock
+    /// sender ignores them, but the worker's encrypt + sign path runs
+    /// for real so the keys must be valid.
+    fn fresh_subscription_material() -> (String, String) {
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        use base64::Engine as _;
+        use p256::elliptic_curve::rand_core::OsRng;
+        use p256::elliptic_curve::sec1::ToEncodedPoint;
+        use rand::RngExt as _;
+        let secret = p256::SecretKey::random(&mut OsRng);
+        let p256dh_bytes = secret.public_key().to_encoded_point(false);
+        let p256dh = URL_SAFE_NO_PAD.encode(p256dh_bytes.as_bytes());
+        let mut auth = [0u8; 16];
+        rand::rng().fill(&mut auth[..]);
+        let auth = URL_SAFE_NO_PAD.encode(auth);
+        (p256dh, auth)
+    }
+
+    /// Build a store wired with a real VAPID signer (from
+    /// `VapidStorage::load_or_provision` against a fresh in-memory db)
+    /// and a [`FixedOutcomeSender`].
+    async fn store_with_web_push_provider(
+        outcome: WebPushOutcome,
+    ) -> (DatabasePushServiceStore, FixedOutcomeSender) {
+        let db = Database::in_memory("push-service-web-push")
+            .await
+            .expect("db");
+        let store = DatabasePushServiceStore::new_with_secret_key(
+            db.clone(),
+            b"waddle-push-service-test-secret-key-32b",
+        )
+        .await
+        .expect("store");
+        let signer =
+            crate::push_service::vapid_storage::VapidStorage::load_or_provision(db, b"root-key")
+                .await
+                .expect("VAPID signer");
+        let sender = FixedOutcomeSender::new(outcome);
+        let sender_arc: Arc<dyn WebPushSender> = Arc::new(sender.clone());
+        let sub = VapidSub::default_for_domain("example.com").expect("vapid sub");
+        let store = store.with_web_push_provider(signer, sender_arc, sub);
+        (store, sender)
+    }
+
+    async fn device_status(
+        store: &DatabasePushServiceStore,
+        node: &str,
+        device_id: &str,
+    ) -> String {
+        let mut rows = store
+            .query(
+                "SELECT status FROM push_devices WHERE node = ? AND device_id = ?",
+                crate::db_params![node, device_id],
+            )
+            .await
+            .expect("status query");
+        let row = rows
+            .next()
+            .await
+            .expect("status query row")
+            .expect("device row present");
+        row.get::<String>(0).expect("status column")
+    }
+
+    #[tokio::test]
+    async fn subscription_gone_marks_device_disabled_per_xep0357_6() {
+        let (store, sender) =
+            store_with_web_push_provider(WebPushOutcome::SubscriptionGone { status: 410 }).await;
+        let owner = owner();
+        let node = store.ensure_node(&owner, "web").await.expect("node");
+        let (p256dh, auth) = fresh_subscription_material();
+        store
+            .upsert_device(
+                &owner,
+                PushDeviceRegistration::new("web-1", node.node(), PushDevicePlatform::Web, "test")
+                    .with_provider_endpoint(Some(
+                        "https://push.example.com/abc-subscription".to_string(),
+                    ))
+                    .with_provider_token(Some(auth))
+                    .with_provider_key_material(Some(p256dh)),
+            )
+            .await
+            .expect("device");
+        store
+            .publish_notification_from_user_server(
+                node.node(),
+                &web_push_notification_item("gone-item-1", "alice@example.com", "dm", 1),
+                &owner,
+            )
+            .await
+            .expect("publish");
+        store
+            .drain_queued_notification_publish_jobs(16)
+            .await
+            .expect("drain");
+
+        assert_eq!(
+            sender.call_count(),
+            1,
+            "real send must run for an active web device with full material"
+        );
+        assert_eq!(
+            device_status(&store, node.node(), "web-1").await,
+            DEVICE_STATUS_DISABLED,
+            "XEP-0357 §6: a `web-gone` outcome must flip the underlying device to disabled"
+        );
+        let attempts = store
+            .delivery_attempts_for_node(node.node())
+            .await
+            .expect("attempts");
+        assert_eq!(attempts.len(), 1);
+        assert_eq!(attempts[0].status(), dispatch::ATTEMPT_STATUS_WEB_GONE);
+    }
+
+    #[tokio::test]
+    async fn delivered_outcome_keeps_device_active() {
+        let (store, sender) =
+            store_with_web_push_provider(WebPushOutcome::Delivered { status: 201 }).await;
+        let owner = owner();
+        let node = store.ensure_node(&owner, "web").await.expect("node");
+        let (p256dh, auth) = fresh_subscription_material();
+        store
+            .upsert_device(
+                &owner,
+                PushDeviceRegistration::new("web-1", node.node(), PushDevicePlatform::Web, "test")
+                    .with_provider_endpoint(Some(
+                        "https://push.example.com/abc-subscription".to_string(),
+                    ))
+                    .with_provider_token(Some(auth))
+                    .with_provider_key_material(Some(p256dh)),
+            )
+            .await
+            .expect("device");
+        store
+            .publish_notification_from_user_server(
+                node.node(),
+                &web_push_notification_item("delivered-item-1", "alice@example.com", "dm", 1),
+                &owner,
+            )
+            .await
+            .expect("publish");
+        store
+            .drain_queued_notification_publish_jobs(16)
+            .await
+            .expect("drain");
+
+        assert_eq!(sender.call_count(), 1);
+        assert_eq!(
+            device_status(&store, node.node(), "web-1").await,
+            DEVICE_STATUS_ACTIVE,
+            "Delivered outcomes must NOT disable the device"
+        );
+        let attempts = store
+            .delivery_attempts_for_node(node.node())
+            .await
+            .expect("attempts");
+        assert_eq!(attempts.len(), 1);
+        assert_eq!(attempts[0].status(), dispatch::ATTEMPT_STATUS_WEB_DELIVERED);
+    }
+
+    #[tokio::test]
+    async fn transient_outcome_keeps_device_active_and_requeues() {
+        let (store, sender) = store_with_web_push_provider(WebPushOutcome::Transient {
+            kind: waddle_xmpp::push::types::TransientFailure::Network,
+        })
+        .await;
+        let owner = owner();
+        let node = store.ensure_node(&owner, "web").await.expect("node");
+        let (p256dh, auth) = fresh_subscription_material();
+        store
+            .upsert_device(
+                &owner,
+                PushDeviceRegistration::new("web-1", node.node(), PushDevicePlatform::Web, "test")
+                    .with_provider_endpoint(Some(
+                        "https://push.example.com/abc-subscription".to_string(),
+                    ))
+                    .with_provider_token(Some(auth))
+                    .with_provider_key_material(Some(p256dh)),
+            )
+            .await
+            .expect("device");
+        store
+            .publish_notification_from_user_server(
+                node.node(),
+                &web_push_notification_item("transient-item-1", "alice@example.com", "dm", 1),
+                &owner,
+            )
+            .await
+            .expect("publish");
+        store
+            .drain_queued_notification_publish_jobs(16)
+            .await
+            .expect("drain");
+
+        assert_eq!(sender.call_count(), 1);
+        assert_eq!(
+            device_status(&store, node.node(), "web-1").await,
+            DEVICE_STATUS_ACTIVE,
+            "Transient outcomes must keep the device active — XEP-0357 §6 disable applies only to permanent failures"
+        );
+    }
+
+    #[tokio::test]
+    async fn warrants_disable_matches_xep0357_section_6_intent() {
+        // §6: permanent unusable subscription → disable. Transient and
+        // unseal-class errors → keep active. Lock the matrix down so a
+        // future enum reorganization can't silently broaden or narrow
+        // the disable trigger.
+        assert!(attempt_status_warrants_device_disable(
+            dispatch::ATTEMPT_STATUS_WEB_GONE
+        ));
+        assert!(attempt_status_warrants_device_disable(
+            dispatch::ATTEMPT_STATUS_WEB_INVALID_KEYS
+        ));
+        assert!(attempt_status_warrants_device_disable(
+            dispatch::ATTEMPT_STATUS_WEB_INVALID_ENDPOINT
+        ));
+        for never_disable in [
+            dispatch::ATTEMPT_STATUS_WEB_DELIVERED,
+            dispatch::ATTEMPT_STATUS_WEB_CLOCK_SKEW,
+            dispatch::ATTEMPT_STATUS_WEB_RATE_LIMITED,
+            dispatch::ATTEMPT_STATUS_WEB_TRANSIENT,
+            dispatch::ATTEMPT_STATUS_WEB_BAD_REQUEST,
+            dispatch::ATTEMPT_STATUS_WEB_PAYLOAD_TOO_LARGE,
+            dispatch::ATTEMPT_STATUS_WEB_UNSEAL_FAILED,
+            dispatch::ATTEMPT_STATUS_WEB_MISSING_MATERIAL,
+            dispatch::ATTEMPT_STATUS_FAKE_SENT_NON_WEB,
+            ATTEMPT_STATUS_WEB_NOT_CONFIGURED,
+            ATTEMPT_STATUS_WEB_INTERNAL_ERROR,
+        ] {
+            assert!(
+                !attempt_status_warrants_device_disable(never_disable),
+                "{never_disable} must not trigger device disable"
+            );
+        }
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/push_service/dispatch.rs
+++ b/server/crates/waddle-server/src/push_service/dispatch.rs
@@ -1,0 +1,435 @@
+//! Web Push dispatch bridge for the publish-job worker.
+//!
+//! Owns the translations between this crate's XMPP-side state (the
+//! XEP-0357 `<notification>` payload XML and sealed `push_devices`
+//! rows) and the typed `waddle_xmpp::push` foundations
+//! (`SubscriptionKeys`, `PushEnvelope`, `encrypt::encrypt`,
+//! `VapidSigner::sign`, `WebPushSender::send`).
+//!
+//! Keeping it as a submodule keeps `push_service.rs` focused on
+//! durable-queue mechanics; the cross-crate seam lives here so a
+//! future reviewer can read the full Web Push delivery flow in one
+//! file.
+
+use std::sync::Arc;
+
+use minidom::Element;
+use url::Url;
+use waddle_xmpp::push::envelope::{push_class_for_db_value, push_topic_for, PushEnvelope};
+use waddle_xmpp::push::types::{SubscriptionKeys, VapidSub, WebPushOutcome};
+use waddle_xmpp::push::vapid::{aud_for, vapid_k_header, VapidSigner};
+use waddle_xmpp::push::{encrypt, WebPushRequest, WebPushSender};
+use waddle_xmpp::xep::xep0357::NS_PUSH;
+use waddle_xmpp::XmppError;
+
+use super::{PushDevicePlatform, PushSecretCipher};
+
+/// `urn:waddle:push:context:0` — the typed routing envelope the chat
+/// notification publisher emits as a child of `<notification>`. Mirrors
+/// the constant defined in [`crate::notification_outbox`].
+const NS_WADDLE_PUSH_CONTEXT: &str = "urn:waddle:push:context:0";
+/// XEP-0357 §4 data-form FORM_TYPE value.
+const XEP0357_SUMMARY_FORM_TYPE: &str = "urn:xmpp:push:summary";
+/// XEP-0004 data-forms namespace.
+const NS_DATA_FORMS: &str = "jabber:x:data";
+
+/// Parsed XEP-0357 §4 notification payload as we emit it on the wire.
+#[derive(Debug, Clone)]
+pub(crate) struct ParsedPushPayload {
+    /// XEP-0357 §4 `message-count` summary form field. `None` if the
+    /// publisher omitted it.
+    pub message_count: Option<u64>,
+    /// `<context conversation='...'/>` — bare JID of the DM peer or
+    /// MUC room.
+    pub conversation: String,
+    /// `<context thread='...'/>` — XEP-0201 thread id, when the
+    /// publisher set one.
+    pub thread: Option<String>,
+    /// `<context class='...'/>` — db-form notification class such as
+    /// `"dm"`, `"personal_mention"`, `"channel_mention"`, etc.
+    pub class: String,
+}
+
+/// Parse the serialized `<notification>` element. Strictly validates
+/// the outer name+namespace (the XEP-0357 §4 envelope) and then
+/// extracts the typed `<context>` and `message-count` fields.
+pub(crate) fn parse_publish_payload(payload_xml: &str) -> Result<ParsedPushPayload, XmppError> {
+    let payload: Element = payload_xml.parse().map_err(|err: minidom::Error| {
+        XmppError::internal(format!("XEP-0357 payload is not valid XML: {err}"))
+    })?;
+    if !payload.is("notification", NS_PUSH) {
+        return Err(XmppError::internal(
+            "XEP-0357 payload is not <notification xmlns='urn:xmpp:push:0'>".to_string(),
+        ));
+    }
+    let context = payload
+        .children()
+        .find(|child| child.is("context", NS_WADDLE_PUSH_CONTEXT))
+        .ok_or_else(|| {
+            XmppError::internal(
+                "XEP-0357 payload missing <context xmlns='urn:waddle:push:context:0'/>".to_string(),
+            )
+        })?;
+    let conversation = context
+        .attr("conversation")
+        .ok_or_else(|| {
+            XmppError::internal("waddle <context> missing conversation attribute".to_string())
+        })?
+        .to_string();
+    let class = context
+        .attr("class")
+        .ok_or_else(|| XmppError::internal("waddle <context> missing class attribute".to_string()))?
+        .to_string();
+    let thread = context
+        .attr("thread")
+        .filter(|t| !t.is_empty())
+        .map(str::to_owned);
+    let message_count = parse_summary_message_count(&payload);
+    Ok(ParsedPushPayload {
+        message_count,
+        conversation,
+        thread,
+        class,
+    })
+}
+
+fn parse_summary_message_count(notification: &Element) -> Option<u64> {
+    let form = notification
+        .children()
+        .find(|child| child.is("x", NS_DATA_FORMS))?;
+    let mut saw_form_type = false;
+    let mut count: Option<u64> = None;
+    for field in form.children().filter(|c| c.is("field", NS_DATA_FORMS)) {
+        let var = field.attr("var").unwrap_or_default();
+        if var == "FORM_TYPE" {
+            let v = field
+                .get_child("value", NS_DATA_FORMS)
+                .map(|el| el.text())
+                .unwrap_or_default();
+            if v == XEP0357_SUMMARY_FORM_TYPE {
+                saw_form_type = true;
+            }
+        } else if var == "message-count" {
+            let v = field
+                .get_child("value", NS_DATA_FORMS)
+                .map(|el| el.text())
+                .unwrap_or_default();
+            count = v.parse().ok();
+        }
+    }
+    if saw_form_type {
+        count
+    } else {
+        None
+    }
+}
+
+/// A `push_devices` row with its sealed provider material — exactly
+/// what the worker needs to materialize a typed Web Push subscription
+/// outside the DB transaction.
+#[derive(Debug, Clone)]
+pub(crate) struct SealedActiveDevice {
+    pub device_id: String,
+    pub platform: PushDevicePlatform,
+    pub sealed_endpoint: Option<String>,
+    pub sealed_auth: Option<String>,
+    pub sealed_key_material: Option<String>,
+}
+
+/// Resolved Web Push target ready for `encrypt` + `send`.
+pub(crate) struct WebPushTarget {
+    pub endpoint: Url,
+    pub keys: SubscriptionKeys,
+}
+
+/// Reason a device row was not converted into a [`WebPushTarget`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DeviceSkipReason {
+    /// Not the Web Push platform (APNS/FCM are handled by sibling
+    /// provider slices #529 / #530).
+    WrongPlatform,
+    /// Missing sealed material (endpoint, p256dh, or auth).
+    MissingProviderMaterial,
+    /// Unseal failed (root key drift or tampering).
+    UnsealFailed,
+    /// Endpoint URL did not parse as `https://...`.
+    InvalidEndpoint,
+    /// `p256dh` / `auth_secret` did not decode/validate.
+    InvalidSubscriptionKeys,
+}
+
+impl WebPushTarget {
+    /// Unseal a `push_devices` row into a typed `WebPushTarget`.
+    /// Returns `Ok(Err(reason))` for rows that are intentionally
+    /// non-deliverable (e.g. wrong platform, missing material), so the
+    /// worker can record a clear typed attempt status without bubbling
+    /// the row up as a hard error.
+    pub fn try_from_sealed(
+        device: &SealedActiveDevice,
+        cipher: &PushSecretCipher,
+    ) -> Result<WebPushTarget, DeviceSkipReason> {
+        if device.platform != PushDevicePlatform::Web {
+            return Err(DeviceSkipReason::WrongPlatform);
+        }
+        let (Some(ep_sealed), Some(auth_sealed), Some(p256dh_sealed)) = (
+            device.sealed_endpoint.as_ref(),
+            device.sealed_auth.as_ref(),
+            device.sealed_key_material.as_ref(),
+        ) else {
+            return Err(DeviceSkipReason::MissingProviderMaterial);
+        };
+        let ep_plain = cipher
+            .open(ep_sealed)
+            .map_err(|_| DeviceSkipReason::UnsealFailed)?;
+        let auth_plain = cipher
+            .open(auth_sealed)
+            .map_err(|_| DeviceSkipReason::UnsealFailed)?;
+        let p256dh_plain = cipher
+            .open(p256dh_sealed)
+            .map_err(|_| DeviceSkipReason::UnsealFailed)?;
+        let endpoint = Url::parse(&ep_plain).map_err(|_| DeviceSkipReason::InvalidEndpoint)?;
+        if endpoint.scheme() != "https" {
+            return Err(DeviceSkipReason::InvalidEndpoint);
+        }
+        let keys = SubscriptionKeys::from_base64url(&p256dh_plain, &auth_plain)
+            .map_err(|_| DeviceSkipReason::InvalidSubscriptionKeys)?;
+        Ok(WebPushTarget { endpoint, keys })
+    }
+}
+
+/// Encrypt + sign + send one Web Push message and return its typed
+/// outcome. Errors only on internal bugs (encrypt/sign failure, aud
+/// derivation failure); transport-layer failures land in
+/// [`WebPushOutcome`] variants.
+pub(crate) async fn dispatch_one_web_push(
+    target: &WebPushTarget,
+    parsed: &ParsedPushPayload,
+    item_id: &str,
+    signer: &Arc<dyn VapidSigner>,
+    sub: &VapidSub,
+    sender: &Arc<dyn WebPushSender>,
+) -> Result<WebPushOutcome, XmppError> {
+    let push_class = push_class_for_db_value(&parsed.class);
+    let envelope = PushEnvelope::new(
+        &parsed.class,
+        &parsed.conversation,
+        parsed.thread.as_deref(),
+        item_id,
+        parsed.message_count,
+    );
+    let plaintext = envelope.to_plaintext();
+    let payload = encrypt::encrypt(&target.keys, &plaintext, push_class.bucket_size())
+        .map_err(|err| XmppError::internal(format!("web push encrypt failed: {err}")))?;
+    let aud = aud_for(&target.endpoint)
+        .map_err(|err| XmppError::internal(format!("web push aud derive failed: {err}")))?;
+    let jwt = signer
+        .sign(&aud, sub)
+        .map_err(|err| XmppError::internal(format!("web push JWT sign failed: {err}")))?;
+    let public_key = signer.current_public_key();
+    let key_b64u = vapid_k_header(&public_key);
+    let topic = push_topic_for(push_class, &parsed.conversation);
+    let outcome = sender
+        .send(WebPushRequest {
+            endpoint: &target.endpoint,
+            payload: &payload,
+            vapid_jwt: &jwt,
+            vapid_public_key_b64u: &key_b64u,
+            topic: Some(&topic),
+            ttl: push_class.ttl(),
+            urgency: push_class.urgency(),
+        })
+        .await;
+    Ok(outcome)
+}
+
+/// Map a typed [`WebPushOutcome`] to the string value persisted in
+/// `push_delivery_attempts.status`. Kept in one place so the worker
+/// and the future XEP-0357 §6 cleanup chain agree on the wire format.
+pub(crate) fn outcome_to_attempt_status(outcome: &WebPushOutcome) -> &'static str {
+    match outcome {
+        WebPushOutcome::Delivered { .. } => ATTEMPT_STATUS_WEB_DELIVERED,
+        WebPushOutcome::SubscriptionGone { .. } => ATTEMPT_STATUS_WEB_GONE,
+        WebPushOutcome::ClockSkew { .. } => ATTEMPT_STATUS_WEB_CLOCK_SKEW,
+        WebPushOutcome::RateLimited { .. } => ATTEMPT_STATUS_WEB_RATE_LIMITED,
+        WebPushOutcome::PayloadTooLarge { .. } => ATTEMPT_STATUS_WEB_PAYLOAD_TOO_LARGE,
+        WebPushOutcome::BadRequest { .. } => ATTEMPT_STATUS_WEB_BAD_REQUEST,
+        WebPushOutcome::Transient { .. } => ATTEMPT_STATUS_WEB_TRANSIENT,
+    }
+}
+
+/// Status string written when a device row was non-deliverable (wrong
+/// platform, missing material, etc.) so an operator can see why.
+pub(crate) fn skip_reason_to_attempt_status(reason: DeviceSkipReason) -> &'static str {
+    match reason {
+        DeviceSkipReason::WrongPlatform => ATTEMPT_STATUS_FAKE_SENT_NON_WEB,
+        DeviceSkipReason::MissingProviderMaterial => ATTEMPT_STATUS_WEB_MISSING_MATERIAL,
+        DeviceSkipReason::UnsealFailed => ATTEMPT_STATUS_WEB_UNSEAL_FAILED,
+        DeviceSkipReason::InvalidEndpoint => ATTEMPT_STATUS_WEB_INVALID_ENDPOINT,
+        DeviceSkipReason::InvalidSubscriptionKeys => ATTEMPT_STATUS_WEB_INVALID_KEYS,
+    }
+}
+
+// Typed attempt-status constants. Kept here next to the
+// outcome-to-status mapper so the wire format and the typed
+// `WebPushOutcome` enum stay in lockstep.
+pub(crate) const ATTEMPT_STATUS_WEB_DELIVERED: &str = "web-delivered";
+pub(crate) const ATTEMPT_STATUS_WEB_GONE: &str = "web-gone";
+pub(crate) const ATTEMPT_STATUS_WEB_CLOCK_SKEW: &str = "web-clock-skew";
+pub(crate) const ATTEMPT_STATUS_WEB_RATE_LIMITED: &str = "web-rate-limited";
+pub(crate) const ATTEMPT_STATUS_WEB_PAYLOAD_TOO_LARGE: &str = "web-payload-too-large";
+pub(crate) const ATTEMPT_STATUS_WEB_BAD_REQUEST: &str = "web-bad-request";
+pub(crate) const ATTEMPT_STATUS_WEB_TRANSIENT: &str = "web-transient";
+pub(crate) const ATTEMPT_STATUS_WEB_MISSING_MATERIAL: &str = "web-missing-material";
+pub(crate) const ATTEMPT_STATUS_WEB_UNSEAL_FAILED: &str = "web-unseal-failed";
+pub(crate) const ATTEMPT_STATUS_WEB_INVALID_ENDPOINT: &str = "web-invalid-endpoint";
+pub(crate) const ATTEMPT_STATUS_WEB_INVALID_KEYS: &str = "web-invalid-keys";
+/// Recorded for non-Web platforms (APNS/FCM) until #529/#530 land
+/// their real senders. Mirrors the historical `fake-sent` marker.
+pub(crate) const ATTEMPT_STATUS_FAKE_SENT_NON_WEB: &str = "fake-sent";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use waddle_xmpp::push::envelope::PushClass;
+
+    fn build_notification_xml(
+        class: &str,
+        conversation: &str,
+        thread: Option<&str>,
+        message_count: Option<u64>,
+    ) -> String {
+        let mut form = format!(
+            r#"<x xmlns='jabber:x:data' type='result'><field var='FORM_TYPE' type='hidden'><value>{XEP0357_SUMMARY_FORM_TYPE}</value></field>"#
+        );
+        if let Some(count) = message_count {
+            form.push_str(&format!(
+                "<field var='message-count'><value>{count}</value></field>"
+            ));
+        }
+        form.push_str("</x>");
+        let thread_attr = thread.map(|t| format!(" thread='{t}'")).unwrap_or_default();
+        let context = format!(
+            "<context xmlns='{NS_WADDLE_PUSH_CONTEXT}' conversation='{conversation}' class='{class}'{thread_attr}/>"
+        );
+        format!("<notification xmlns='{NS_PUSH}'>{form}{context}</notification>")
+    }
+
+    #[test]
+    fn parse_publish_payload_extracts_all_fields() {
+        let xml = build_notification_xml(
+            "personal_mention",
+            "room@conf.example.com",
+            Some("thread-1"),
+            Some(7),
+        );
+        let parsed = parse_publish_payload(&xml).expect("valid payload");
+        assert_eq!(parsed.class, "personal_mention");
+        assert_eq!(parsed.conversation, "room@conf.example.com");
+        assert_eq!(parsed.thread.as_deref(), Some("thread-1"));
+        assert_eq!(parsed.message_count, Some(7));
+    }
+
+    #[test]
+    fn parse_publish_payload_treats_missing_thread_as_none() {
+        let xml = build_notification_xml("dm", "alice@example.com", None, Some(1));
+        let parsed = parse_publish_payload(&xml).expect("valid payload");
+        assert!(parsed.thread.is_none());
+    }
+
+    #[test]
+    fn parse_publish_payload_rejects_wrong_root() {
+        let xml = "<message xmlns='jabber:client'/>";
+        let err = parse_publish_payload(xml).unwrap_err();
+        assert!(err.to_string().contains("not <notification"));
+    }
+
+    #[test]
+    fn parse_publish_payload_requires_context() {
+        let xml = format!("<notification xmlns='{NS_PUSH}'/>");
+        let err = parse_publish_payload(&xml).unwrap_err();
+        assert!(err.to_string().contains("missing <context"));
+    }
+
+    #[test]
+    fn parse_publish_payload_ignores_non_summary_form() {
+        // Form is present but FORM_TYPE doesn't match XEP-0357 §4.
+        // message-count must be ignored — we don't trust counters
+        // from unknown forms.
+        let xml = format!(
+            r#"<notification xmlns='{NS_PUSH}'>
+              <x xmlns='jabber:x:data' type='result'>
+                <field var='FORM_TYPE' type='hidden'><value>some:other:form</value></field>
+                <field var='message-count'><value>42</value></field>
+              </x>
+              <context xmlns='{NS_WADDLE_PUSH_CONTEXT}' conversation='c' class='dm'/>
+            </notification>"#
+        );
+        let parsed = parse_publish_payload(&xml).expect("payload parses");
+        assert_eq!(parsed.message_count, None);
+    }
+
+    #[test]
+    fn outcome_to_attempt_status_covers_every_variant() {
+        // Exhaustive — if a future variant lands the match in
+        // `outcome_to_attempt_status` will not compile.
+        for (outcome, expected) in [
+            (
+                WebPushOutcome::Delivered { status: 201 },
+                ATTEMPT_STATUS_WEB_DELIVERED,
+            ),
+            (
+                WebPushOutcome::SubscriptionGone { status: 410 },
+                ATTEMPT_STATUS_WEB_GONE,
+            ),
+            (
+                WebPushOutcome::ClockSkew { status: 401 },
+                ATTEMPT_STATUS_WEB_CLOCK_SKEW,
+            ),
+            (
+                WebPushOutcome::RateLimited {
+                    status: 429,
+                    retry_after: None,
+                },
+                ATTEMPT_STATUS_WEB_RATE_LIMITED,
+            ),
+            (
+                WebPushOutcome::PayloadTooLarge { status: 413 },
+                ATTEMPT_STATUS_WEB_PAYLOAD_TOO_LARGE,
+            ),
+            (
+                WebPushOutcome::BadRequest { status: 400 },
+                ATTEMPT_STATUS_WEB_BAD_REQUEST,
+            ),
+            (
+                WebPushOutcome::Transient {
+                    kind: waddle_xmpp::push::types::TransientFailure::Network,
+                },
+                ATTEMPT_STATUS_WEB_TRANSIENT,
+            ),
+        ] {
+            assert_eq!(outcome_to_attempt_status(&outcome), expected);
+        }
+    }
+
+    #[test]
+    fn skip_reason_status_uses_fake_sent_for_non_web() {
+        assert_eq!(
+            skip_reason_to_attempt_status(DeviceSkipReason::WrongPlatform),
+            "fake-sent",
+            "non-web platforms continue to record fake-sent until #529/#530"
+        );
+    }
+
+    #[test]
+    fn push_class_for_db_value_routes_dm_classes_to_dm_bucket() {
+        assert_eq!(push_class_for_db_value("dm"), PushClass::DirectMessage);
+        assert_eq!(
+            push_class_for_db_value("dm_mention"),
+            PushClass::DirectMessage
+        );
+        assert_eq!(
+            push_class_for_db_value("personal_mention"),
+            PushClass::Mention
+        );
+    }
+}

--- a/server/crates/waddle-server/src/push_service/dispatch.rs
+++ b/server/crates/waddle-server/src/push_service/dispatch.rs
@@ -337,19 +337,21 @@ mod tests {
     }
 
     fn build_summary_form(message_count: Option<u64>) -> Element {
-        let mut form = Element::builder("x", NS_DATA_FORMS)
-            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
-            .append(
-                Element::builder("field", NS_DATA_FORMS)
-                    .attr(minidom::rxml::xml_ncname!("var").to_owned(), "FORM_TYPE")
-                    .attr(minidom::rxml::xml_ncname!("type").to_owned(), "hidden")
-                    .append(
-                        Element::builder("value", NS_DATA_FORMS)
-                            .append(XEP0357_SUMMARY_FORM_TYPE)
-                            .build(),
-                    )
-                    .build(),
-            );
+        // XEP-0357 §4 example shows `<x xmlns='jabber:x:data'>` with
+        // no `type` attribute; production `build_xep0357_summary_form`
+        // dropped `type='result'` in an earlier review pass and this
+        // test fixture must match the on-wire shape.
+        let mut form = Element::builder("x", NS_DATA_FORMS).append(
+            Element::builder("field", NS_DATA_FORMS)
+                .attr(minidom::rxml::xml_ncname!("var").to_owned(), "FORM_TYPE")
+                .attr(minidom::rxml::xml_ncname!("type").to_owned(), "hidden")
+                .append(
+                    Element::builder("value", NS_DATA_FORMS)
+                        .append(XEP0357_SUMMARY_FORM_TYPE)
+                        .build(),
+                )
+                .build(),
+        );
         if let Some(count) = message_count {
             form = form.append(
                 Element::builder("field", NS_DATA_FORMS)
@@ -450,8 +452,8 @@ mod tests {
         // Form is present but FORM_TYPE doesn't match XEP-0357 §4.
         // message-count must be ignored — we don't trust counters
         // from unknown forms.
+        // Match the production summary form shape (no `type` attr).
         let wrong_form = Element::builder("x", NS_DATA_FORMS)
-            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
             .append(
                 Element::builder("field", NS_DATA_FORMS)
                     .attr(minidom::rxml::xml_ncname!("var").to_owned(), "FORM_TYPE")

--- a/server/crates/waddle-server/src/push_service/dispatch.rs
+++ b/server/crates/waddle-server/src/push_service/dispatch.rs
@@ -316,26 +316,69 @@ mod tests {
     use super::*;
     use waddle_xmpp::push::envelope::{push_class_for_db_value, PushClass};
 
+    /// Build a notification XML payload via structured `minidom`
+    /// builders (per CLAUDE.md "XML generation hard rule": never via
+    /// `format!`/`push_str` — even in tests, because string-built XML
+    /// trivially escapes special characters incorrectly and gives the
+    /// parser the wrong byte sequence for any non-ASCII input).
     fn build_notification_xml(
         class: &str,
         conversation: &str,
         thread: Option<&str>,
         message_count: Option<u64>,
     ) -> String {
-        let mut form = format!(
-            r#"<x xmlns='jabber:x:data' type='result'><field var='FORM_TYPE' type='hidden'><value>{XEP0357_SUMMARY_FORM_TYPE}</value></field>"#
-        );
+        let summary = build_summary_form(message_count);
+        let context = build_context_element(class, conversation, thread);
+        let notification = Element::builder("notification", NS_PUSH)
+            .append(summary)
+            .append(context)
+            .build();
+        String::from(&notification)
+    }
+
+    fn build_summary_form(message_count: Option<u64>) -> Element {
+        let mut form = Element::builder("x", NS_DATA_FORMS)
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
+            .append(
+                Element::builder("field", NS_DATA_FORMS)
+                    .attr(minidom::rxml::xml_ncname!("var").to_owned(), "FORM_TYPE")
+                    .attr(minidom::rxml::xml_ncname!("type").to_owned(), "hidden")
+                    .append(
+                        Element::builder("value", NS_DATA_FORMS)
+                            .append(XEP0357_SUMMARY_FORM_TYPE)
+                            .build(),
+                    )
+                    .build(),
+            );
         if let Some(count) = message_count {
-            form.push_str(&format!(
-                "<field var='message-count'><value>{count}</value></field>"
-            ));
+            form = form.append(
+                Element::builder("field", NS_DATA_FORMS)
+                    .attr(
+                        minidom::rxml::xml_ncname!("var").to_owned(),
+                        "message-count",
+                    )
+                    .append(
+                        Element::builder("value", NS_DATA_FORMS)
+                            .append(count.to_string())
+                            .build(),
+                    )
+                    .build(),
+            );
         }
-        form.push_str("</x>");
-        let thread_attr = thread.map(|t| format!(" thread='{t}'")).unwrap_or_default();
-        let context = format!(
-            "<context xmlns='{NS_WADDLE_PUSH_CONTEXT}' conversation='{conversation}' class='{class}'{thread_attr}/>"
-        );
-        format!("<notification xmlns='{NS_PUSH}'>{form}{context}</notification>")
+        form.build()
+    }
+
+    fn build_context_element(class: &str, conversation: &str, thread: Option<&str>) -> Element {
+        let mut ctx = Element::builder("context", NS_WADDLE_PUSH_CONTEXT)
+            .attr(
+                minidom::rxml::xml_ncname!("conversation").to_owned(),
+                conversation,
+            )
+            .attr(minidom::rxml::xml_ncname!("class").to_owned(), class);
+        if let Some(t) = thread {
+            ctx = ctx.attr(minidom::rxml::xml_ncname!("thread").to_owned(), t);
+        }
+        ctx.build()
     }
 
     #[test]
@@ -362,14 +405,16 @@ mod tests {
 
     #[test]
     fn parse_publish_payload_rejects_wrong_root() {
-        let xml = "<message xmlns='jabber:client'/>";
-        let err = parse_publish_payload(xml).unwrap_err();
+        let wrong = Element::builder("message", "jabber:client").build();
+        let xml = String::from(&wrong);
+        let err = parse_publish_payload(&xml).unwrap_err();
         assert!(err.to_string().contains("not <notification"));
     }
 
     #[test]
     fn parse_publish_payload_requires_context() {
-        let xml = format!("<notification xmlns='{NS_PUSH}'/>");
+        let bare = Element::builder("notification", NS_PUSH).build();
+        let xml = String::from(&bare);
         let err = parse_publish_payload(&xml).unwrap_err();
         assert!(err.to_string().contains("missing <context"));
     }
@@ -405,15 +450,38 @@ mod tests {
         // Form is present but FORM_TYPE doesn't match XEP-0357 §4.
         // message-count must be ignored — we don't trust counters
         // from unknown forms.
-        let xml = format!(
-            r#"<notification xmlns='{NS_PUSH}'>
-              <x xmlns='jabber:x:data' type='result'>
-                <field var='FORM_TYPE' type='hidden'><value>some:other:form</value></field>
-                <field var='message-count'><value>42</value></field>
-              </x>
-              <context xmlns='{NS_WADDLE_PUSH_CONTEXT}' conversation='alice@example.com' class='dm'/>
-            </notification>"#
-        );
+        let wrong_form = Element::builder("x", NS_DATA_FORMS)
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
+            .append(
+                Element::builder("field", NS_DATA_FORMS)
+                    .attr(minidom::rxml::xml_ncname!("var").to_owned(), "FORM_TYPE")
+                    .attr(minidom::rxml::xml_ncname!("type").to_owned(), "hidden")
+                    .append(
+                        Element::builder("value", NS_DATA_FORMS)
+                            .append("some:other:form")
+                            .build(),
+                    )
+                    .build(),
+            )
+            .append(
+                Element::builder("field", NS_DATA_FORMS)
+                    .attr(
+                        minidom::rxml::xml_ncname!("var").to_owned(),
+                        "message-count",
+                    )
+                    .append(
+                        Element::builder("value", NS_DATA_FORMS)
+                            .append("42")
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build();
+        let notification = Element::builder("notification", NS_PUSH)
+            .append(wrong_form)
+            .append(build_context_element("dm", "alice@example.com", None))
+            .build();
+        let xml = String::from(&notification);
         let parsed = parse_publish_payload(&xml).expect("payload parses");
         assert_eq!(parsed.message_count, None);
     }

--- a/server/crates/waddle-server/src/push_service/dispatch.rs
+++ b/server/crates/waddle-server/src/push_service/dispatch.rs
@@ -13,9 +13,10 @@
 
 use std::sync::Arc;
 
+use jid::BareJid;
 use minidom::Element;
 use url::Url;
-use waddle_xmpp::push::envelope::{push_class_for_db_value, push_topic_for, PushEnvelope};
+use waddle_xmpp::push::envelope::{push_topic_for, NotificationClass, PushEnvelope};
 use waddle_xmpp::push::types::{SubscriptionKeys, VapidSub, WebPushOutcome};
 use waddle_xmpp::push::vapid::{aud_for, vapid_k_header, VapidSigner};
 use waddle_xmpp::push::{encrypt, WebPushRequest, WebPushSender};
@@ -34,25 +35,41 @@ const XEP0357_SUMMARY_FORM_TYPE: &str = "urn:xmpp:push:summary";
 const NS_DATA_FORMS: &str = "jabber:x:data";
 
 /// Parsed XEP-0357 §4 notification payload as we emit it on the wire.
+/// Protocol fields are typed at the parsing boundary so downstream
+/// (encrypt + envelope + topic computation) never touches unvalidated
+/// strings — per CLAUDE.md typed-payloads hard rule.
 #[derive(Debug, Clone)]
 pub(crate) struct ParsedPushPayload {
     /// XEP-0357 §4 `message-count` summary form field. `None` if the
     /// publisher omitted it.
     pub message_count: Option<u64>,
     /// `<context conversation='...'/>` — bare JID of the DM peer or
-    /// MUC room.
-    pub conversation: String,
-    /// `<context thread='...'/>` — XEP-0201 thread id, when the
-    /// publisher set one.
+    /// MUC room. Parsed via `jid::BareJid::from_str` at this boundary
+    /// so an invalid JID surfaces here as a typed publish-error and
+    /// never reaches the envelope serializer or topic hash.
+    pub conversation: BareJid,
+    /// `<context thread='...'/>` — XEP-0201 thread id. The XEP
+    /// defines thread as free-form text (any printable string the
+    /// originating client wishes to use), so a typed newtype here
+    /// would only carry "non-empty" — the same invariant the
+    /// `filter(|t| !t.is_empty())` step preserves. Kept as
+    /// `Option<String>` with this comment documenting the choice.
     pub thread: Option<String>,
-    /// `<context class='...'/>` — db-form notification class such as
-    /// `"dm"`, `"personal_mention"`, `"channel_mention"`, etc.
-    pub class: String,
+    /// `<context class='...'/>` — typed closed-set notification
+    /// class. Parsed via `NotificationClass::from_db_value`; unknown
+    /// values are rejected at this boundary, not silently folded to
+    /// `Mention`.
+    pub class: NotificationClass,
 }
 
 /// Parse the serialized `<notification>` element. Strictly validates
 /// the outer name+namespace (the XEP-0357 §4 envelope) and then
-/// extracts the typed `<context>` and `message-count` fields.
+/// parses the typed `<context>` attributes into typed Rust values:
+///
+/// - `conversation` → `BareJid`
+/// - `class` → `NotificationClass`
+/// - `thread` → free-form XEP-0201 id (non-empty `String`)
+/// - summary form `message-count` → `u64`
 pub(crate) fn parse_publish_payload(payload_xml: &str) -> Result<ParsedPushPayload, XmppError> {
     let payload: Element = payload_xml.parse().map_err(|err: minidom::Error| {
         XmppError::internal(format!("XEP-0357 payload is not valid XML: {err}"))
@@ -70,16 +87,20 @@ pub(crate) fn parse_publish_payload(payload_xml: &str) -> Result<ParsedPushPaylo
                 "XEP-0357 payload missing <context xmlns='urn:waddle:push:context:0'/>".to_string(),
             )
         })?;
-    let conversation = context
-        .attr("conversation")
-        .ok_or_else(|| {
-            XmppError::internal("waddle <context> missing conversation attribute".to_string())
-        })?
-        .to_string();
-    let class = context
-        .attr("class")
-        .ok_or_else(|| XmppError::internal("waddle <context> missing class attribute".to_string()))?
-        .to_string();
+    let conversation_str = context.attr("conversation").ok_or_else(|| {
+        XmppError::internal("waddle <context> missing conversation attribute".to_string())
+    })?;
+    let conversation: BareJid = conversation_str.parse().map_err(|err| {
+        XmppError::internal(format!(
+            "waddle <context> conversation is not a valid bare JID ({conversation_str:?}): {err}"
+        ))
+    })?;
+    let class_str = context.attr("class").ok_or_else(|| {
+        XmppError::internal("waddle <context> missing class attribute".to_string())
+    })?;
+    let class = NotificationClass::from_db_value(class_str).map_err(|err| {
+        XmppError::internal(format!("waddle <context> class is not recognized: {err}"))
+    })?;
     let thread = context
         .attr("thread")
         .filter(|t| !t.is_empty())
@@ -209,10 +230,13 @@ pub(crate) async fn dispatch_one_web_push(
     sub: &VapidSub,
     sender: &Arc<dyn WebPushSender>,
 ) -> Result<WebPushOutcome, XmppError> {
-    let push_class = push_class_for_db_value(&parsed.class);
+    let push_class = parsed.class.transport_policy();
+    // Render the typed `BareJid` / `NotificationClass` to the wire
+    // shapes the SW envelope expects exactly once here, at the seam.
+    let conversation_str = parsed.conversation.to_string();
     let envelope = PushEnvelope::new(
-        &parsed.class,
-        &parsed.conversation,
+        parsed.class.as_db_value(),
+        &conversation_str,
         parsed.thread.as_deref(),
         item_id,
         parsed.message_count,
@@ -227,7 +251,7 @@ pub(crate) async fn dispatch_one_web_push(
         .map_err(|err| XmppError::internal(format!("web push JWT sign failed: {err}")))?;
     let public_key = signer.current_public_key();
     let key_b64u = vapid_k_header(&public_key);
-    let topic = push_topic_for(push_class, &parsed.conversation);
+    let topic = push_topic_for(push_class, &conversation_str);
     let outcome = sender
         .send(WebPushRequest {
             endpoint: &target.endpoint,
@@ -290,7 +314,7 @@ pub(crate) const ATTEMPT_STATUS_FAKE_SENT_NON_WEB: &str = "fake-sent";
 #[cfg(test)]
 mod tests {
     use super::*;
-    use waddle_xmpp::push::envelope::PushClass;
+    use waddle_xmpp::push::envelope::{push_class_for_db_value, PushClass};
 
     fn build_notification_xml(
         class: &str,
@@ -323,8 +347,8 @@ mod tests {
             Some(7),
         );
         let parsed = parse_publish_payload(&xml).expect("valid payload");
-        assert_eq!(parsed.class, "personal_mention");
-        assert_eq!(parsed.conversation, "room@conf.example.com");
+        assert_eq!(parsed.class, NotificationClass::PersonalMention);
+        assert_eq!(parsed.conversation.to_string(), "room@conf.example.com");
         assert_eq!(parsed.thread.as_deref(), Some("thread-1"));
         assert_eq!(parsed.message_count, Some(7));
     }
@@ -351,6 +375,32 @@ mod tests {
     }
 
     #[test]
+    fn parse_publish_payload_rejects_invalid_conversation_jid() {
+        // Typed-payloads invariant: an unparseable JID must be rejected
+        // at the boundary, not silently propagated as raw String into
+        // the envelope or the topic hash.
+        let xml = build_notification_xml("dm", "not a jid", None, Some(1));
+        let err = parse_publish_payload(&xml).unwrap_err();
+        assert!(
+            err.to_string().contains("not a valid bare JID"),
+            "expected typed JID parse error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_publish_payload_rejects_unknown_class() {
+        // Closed-set invariant: classes outside `NotificationClass`
+        // must be rejected at the boundary so the envelope and topic
+        // computation never receive an unrecognized value.
+        let xml = build_notification_xml("totally-bogus-class", "alice@example.com", None, None);
+        let err = parse_publish_payload(&xml).unwrap_err();
+        assert!(
+            err.to_string().contains("class is not recognized"),
+            "expected typed class parse error, got: {err}"
+        );
+    }
+
+    #[test]
     fn parse_publish_payload_ignores_non_summary_form() {
         // Form is present but FORM_TYPE doesn't match XEP-0357 §4.
         // message-count must be ignored — we don't trust counters
@@ -361,7 +411,7 @@ mod tests {
                 <field var='FORM_TYPE' type='hidden'><value>some:other:form</value></field>
                 <field var='message-count'><value>42</value></field>
               </x>
-              <context xmlns='{NS_WADDLE_PUSH_CONTEXT}' conversation='c' class='dm'/>
+              <context xmlns='{NS_WADDLE_PUSH_CONTEXT}' conversation='alice@example.com' class='dm'/>
             </notification>"#
         );
         let parsed = parse_publish_payload(&xml).expect("payload parses");

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -434,6 +434,21 @@ async fn create_websocket_state(
         .await
         .map_err(|error| anyhow::anyhow!("failed to initialize XEP-0357 storage: {error}"))?,
     );
+    // Provision (or load) the VAPID signing key once at boot. The
+    // signer is `Arc<dyn VapidSigner>` so the publish-job worker can
+    // sign once per (kid, aud, sub) and share the JWT across the device
+    // fan-out. `load_or_provision` returns `Err` only when the root key
+    // is unusable or the env-bootstrap value is malformed — in that
+    // case the entire push service degrades, so the caller intentionally
+    // fails boot rather than silently dispatching without VAPID.
+    let vapid_signer = crate::push_service::vapid_storage::VapidStorage::load_or_provision(
+        state.db_pool.global().clone(),
+        server_config.session_key.as_bytes(),
+    )
+    .await
+    .map_err(|error| anyhow::anyhow!("failed to load VAPID signer: {error}"))?;
+    let web_push_sender: Arc<dyn waddle_xmpp::push::WebPushSender> =
+        Arc::new(waddle_xmpp::push::HttpWebPushSender::new());
     let push_service = Arc::new(
         crate::push_service::DatabasePushServiceStore::new_with_secret_key_and_pubsub(
             state.db_pool.global().clone(),
@@ -442,7 +457,8 @@ async fn create_websocket_state(
             Arc::clone(&pubsub_storage),
         )
         .await
-        .map_err(|error| anyhow::anyhow!("failed to initialize XMPP Push Service: {error}"))?,
+        .map_err(|error| anyhow::anyhow!("failed to initialize XMPP Push Service: {error}"))?
+        .with_web_push_provider(vapid_signer, web_push_sender),
     );
     let notification_outbox = Arc::new(
         crate::notification_outbox::NotificationOutboxStore::new(state.db_pool.global().clone())

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -447,8 +447,16 @@ async fn create_websocket_state(
     )
     .await
     .map_err(|error| anyhow::anyhow!("failed to load VAPID signer: {error}"))?;
-    let web_push_sender: Arc<dyn waddle_xmpp::push::WebPushSender> =
+    // Rate-limit outbound sends: global semaphore caps concurrent
+    // requests at 64; per-(endpoint, urgency) leaky bucket spaces
+    // same-pair sends to at least 100ms apart so one chatty relay+class
+    // can't monopolize the global cap.
+    let limiter = Arc::new(waddle_xmpp::push::limiter::Limiter::with_defaults());
+    let raw_sender: Arc<dyn waddle_xmpp::push::WebPushSender> =
         Arc::new(waddle_xmpp::push::HttpWebPushSender::new());
+    let web_push_sender: Arc<dyn waddle_xmpp::push::WebPushSender> = Arc::new(
+        waddle_xmpp::push::limiter::RateLimitedWebPushSender::new(raw_sender, limiter),
+    );
     // RFC 8292 §2 — the VAPID `sub` claim identifies this push service
     // operator. We use `mailto:postmaster@<xmpp_domain>` per RFC 2142 so
     // relays (FCM, Mozilla autopush, Apple Web Push) have a reachable

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -449,6 +449,12 @@ async fn create_websocket_state(
     .map_err(|error| anyhow::anyhow!("failed to load VAPID signer: {error}"))?;
     let web_push_sender: Arc<dyn waddle_xmpp::push::WebPushSender> =
         Arc::new(waddle_xmpp::push::HttpWebPushSender::new());
+    // RFC 8292 §2 — the VAPID `sub` claim identifies this push service
+    // operator. We use `mailto:postmaster@<xmpp_domain>` per RFC 2142 so
+    // relays (FCM, Mozilla autopush, Apple Web Push) have a reachable
+    // contact when our deliveries misbehave.
+    let vapid_sub = waddle_xmpp::push::types::VapidSub::default_for_domain(&xmpp_domain)
+        .map_err(|error| anyhow::anyhow!("failed to derive VAPID sub claim: {error}"))?;
     let push_service = Arc::new(
         crate::push_service::DatabasePushServiceStore::new_with_secret_key_and_pubsub(
             state.db_pool.global().clone(),
@@ -458,7 +464,7 @@ async fn create_websocket_state(
         )
         .await
         .map_err(|error| anyhow::anyhow!("failed to initialize XMPP Push Service: {error}"))?
-        .with_web_push_provider(vapid_signer, web_push_sender),
+        .with_web_push_provider(vapid_signer, web_push_sender, vapid_sub),
     );
     let notification_outbox = Arc::new(
         crate::notification_outbox::NotificationOutboxStore::new(state.db_pool.global().clone())

--- a/server/crates/waddle-server/tests/xep0357_push_service_ws.rs
+++ b/server/crates/waddle-server/tests/xep0357_push_service_ws.rs
@@ -412,7 +412,11 @@ async fn xep0357_offline_dm_emits_durable_summary_pubsub_publish_job() {
         .children()
         .find(|child| child.is("x", waddle_xmpp::xep::NS_DATA_FORMS))
         .expect("XEP-0357 summary data form");
-    assert_eq!(summary.attr("type"), Some("result"));
+    // XEP-0357 §4 example shows `<x xmlns='jabber:x:data'>` with no
+    // `type` attribute — XEP-0004 §3.2 reserves `type='result'` for
+    // query-response contexts, which doesn't fit a passively-
+    // encapsulated summary form.
+    assert_eq!(summary.attr("type"), None);
     assert!(summary.children().any(|field| {
         field.is("field", waddle_xmpp::xep::NS_DATA_FORMS)
             && field.attr("var") == Some("FORM_TYPE")

--- a/server/crates/waddle-xmpp/Cargo.toml
+++ b/server/crates/waddle-xmpp/Cargo.toml
@@ -86,6 +86,7 @@ tempfile = "3.27"
 tracing-subscriber = { workspace = true }
 serde_json = { workspace = true }
 waddle-xmpp-core = { path = "../waddle-xmpp-core", features = ["test-utils"] }
+mockito = "1.7"
 
 [features]
 # Exposes `insert_raw_*_for_test` storage helpers (and other test-only

--- a/server/crates/waddle-xmpp/src/prometheus.rs
+++ b/server/crates/waddle-xmpp/src/prometheus.rs
@@ -208,6 +208,7 @@ pub(crate) const PUSH_SUPPRESSED_REASONS: &[&str] = &[
     "waddle_dnd",
     "provider_rejected",
     "provider_token_expired",
+    "xep0357_push_service_degraded",
 ];
 
 const PUSH_SUPPRESSED_COUNTERS_LEN: usize = PUSH_SUPPRESSED_REASONS.len();
@@ -219,6 +220,7 @@ static PUSH_SUPPRESSED_COUNTERS: [AtomicU64; PUSH_SUPPRESSED_COUNTERS_LEN] = {
     // below, so a future reason addition that forgets a slot fails to
     // compile.
     [
+        AtomicU64::new(0),
         AtomicU64::new(0),
         AtomicU64::new(0),
         AtomicU64::new(0),

--- a/server/crates/waddle-xmpp/src/push/encrypt.rs
+++ b/server/crates/waddle-xmpp/src/push/encrypt.rs
@@ -350,13 +350,12 @@ mod tests {
         let salt = &body[..AES128GCM_SALT_LEN];
         let idlen = body[AES128GCM_SALT_LEN + AES128GCM_RS_LEN] as usize;
         assert_eq!(idlen, P256_UNCOMPRESSED_POINT_LEN, "idlen must be 65");
-        let keyid_start =
-            AES128GCM_SALT_LEN + AES128GCM_RS_LEN + AES128GCM_IDLEN_FIELD_LEN;
+        let keyid_start = AES128GCM_SALT_LEN + AES128GCM_RS_LEN + AES128GCM_IDLEN_FIELD_LEN;
         let as_public_bytes = &body[keyid_start..keyid_start + idlen];
         let ciphertext = &body[AES128GCM_HEADER_LEN..];
         let as_pub_point = EncodedPoint::from_bytes(as_public_bytes).expect("as public");
-        let as_public = p256::PublicKey::from_encoded_point(&as_pub_point)
-            .expect("as public valid");
+        let as_public =
+            p256::PublicKey::from_encoded_point(&as_pub_point).expect("as public valid");
 
         let shared = elliptic_curve::ecdh::diffie_hellman(
             ua_private.to_nonzero_scalar(),

--- a/server/crates/waddle-xmpp/src/push/encrypt.rs
+++ b/server/crates/waddle-xmpp/src/push/encrypt.rs
@@ -172,7 +172,8 @@ pub fn encrypt(
 #[cfg(test)]
 mod tests {
     use super::super::constants::{
-        DEFAULT_PLAINTEXT_BUCKET, DM_PLAINTEXT_BUCKET, WEB_PUSH_MAX_BODY_LEN,
+        AES128GCM_IDLEN_FIELD_LEN, AES128GCM_RS_LEN, AES128GCM_TAG_LEN, DEFAULT_PLAINTEXT_BUCKET,
+        DM_PLAINTEXT_BUCKET, WEB_PUSH_MAX_BODY_LEN,
     };
     use super::*;
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
@@ -323,6 +324,117 @@ mod tests {
         assert_eq!(
             body, expected_body,
             "encrypted body must match RFC 8291 §5 expected output byte-for-byte"
+        );
+    }
+
+    /// UA-side RFC 8291 decryption — used to assert that the real
+    /// `encrypt()` function produces output a conformant receiver
+    /// could actually decrypt. A bug in `encrypt()` itself (wrong
+    /// `key_info` order, wrong AES-GCM info string, swapped public-
+    /// key bytes, off-by-one padding) would surface as a decrypt
+    /// failure here. The earlier `rfc_8291_section_5_known_answer_vector`
+    /// test reimplements the pipeline inline; this one drives the
+    /// production code path end-to-end.
+    fn ua_side_decrypt(
+        ua_private: &p256::SecretKey,
+        auth_secret: &[u8; 16],
+        body: &[u8],
+    ) -> Vec<u8> {
+        use p256::elliptic_curve::sec1::FromEncodedPoint;
+        use p256::EncodedPoint;
+        use sha2::Sha256;
+        assert!(
+            body.len() > AES128GCM_HEADER_LEN + AES128GCM_TAG_LEN,
+            "body too short to be a valid aes128gcm record"
+        );
+        let salt = &body[..AES128GCM_SALT_LEN];
+        let idlen = body[AES128GCM_SALT_LEN + AES128GCM_RS_LEN] as usize;
+        assert_eq!(idlen, P256_UNCOMPRESSED_POINT_LEN, "idlen must be 65");
+        let keyid_start =
+            AES128GCM_SALT_LEN + AES128GCM_RS_LEN + AES128GCM_IDLEN_FIELD_LEN;
+        let as_public_bytes = &body[keyid_start..keyid_start + idlen];
+        let ciphertext = &body[AES128GCM_HEADER_LEN..];
+        let as_pub_point = EncodedPoint::from_bytes(as_public_bytes).expect("as public");
+        let as_public = p256::PublicKey::from_encoded_point(&as_pub_point)
+            .expect("as public valid");
+
+        let shared = elliptic_curve::ecdh::diffie_hellman(
+            ua_private.to_nonzero_scalar(),
+            as_public.as_affine(),
+        );
+        let dh = shared.raw_secret_bytes();
+
+        let ua_public_encoded = ua_private.public_key().to_encoded_point(false);
+        let ua_public_bytes = ua_public_encoded.as_bytes();
+        let prk_key = Hkdf::<Sha256>::new(Some(auth_secret), dh);
+        let mut key_info =
+            Vec::with_capacity(WEBPUSH_INFO_PREFIX.len() + 2 * P256_UNCOMPRESSED_POINT_LEN);
+        key_info.extend_from_slice(WEBPUSH_INFO_PREFIX);
+        key_info.extend_from_slice(ua_public_bytes);
+        key_info.extend_from_slice(as_public_bytes);
+        let mut ikm = [0u8; HKDF_PRK_LEN];
+        prk_key.expand(&key_info, &mut ikm).expect("prk_key expand");
+
+        let prk = Hkdf::<Sha256>::new(Some(salt), &ikm);
+        let mut cek = [0u8; HKDF_CEK_LEN];
+        prk.expand(AES128GCM_KEY_INFO, &mut cek).expect("cek");
+        let mut nonce = [0u8; HKDF_NONCE_LEN];
+        prk.expand(AES128GCM_NONCE_INFO, &mut nonce).expect("nonce");
+
+        let cipher = Aes128Gcm::new_from_slice(&cek).expect("cipher");
+        let padded = cipher
+            .decrypt((&nonce).into(), ciphertext)
+            .expect("decrypt");
+
+        // Strip RFC 8188 §2 padding: `plaintext || 0x02 || 0x00*` for
+        // the last record.
+        let mut end = padded.len();
+        while end > 0 && padded[end - 1] == 0 {
+            end -= 1;
+        }
+        assert!(end > 0, "padding had no delimiter");
+        assert_eq!(
+            padded[end - 1],
+            AES128GCM_LAST_RECORD_DELIM,
+            "expected last-record delimiter 0x02 before trailing zeros"
+        );
+        padded[..end - 1].to_vec()
+    }
+
+    /// Drive the production `encrypt()` function with the RFC 8291 §5
+    /// UA keypair and assert the output is decryptable back to the
+    /// original plaintext. Catches any future bug in `encrypt()` that
+    /// would silently ship an undecryptable body (wrong info-string
+    /// order, swapped public-key bytes, etc.) — the inline KAT above
+    /// only validates the inline reimplementation.
+    #[test]
+    fn encrypt_output_decrypts_under_rfc_8291_section_5_ua_keys() {
+        use p256::elliptic_curve::sec1::FromEncodedPoint;
+        use p256::EncodedPoint;
+        let ua_private_b64 = "q1dXpw3UpT5VOmu_cf_v6ih07Aems3njxI-JWgLcM94";
+        let ua_public_b64 = "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4";
+        let auth_b64 = "BTBZMqHH6r4Tts7J_aSIgg";
+
+        let ua_private_bytes = URL_SAFE_NO_PAD.decode(ua_private_b64).unwrap();
+        let ua_private = p256::SecretKey::from_slice(&ua_private_bytes).expect("ua private");
+        let ua_public_bytes = URL_SAFE_NO_PAD.decode(ua_public_b64).unwrap();
+        let ua_pub_point = EncodedPoint::from_bytes(&ua_public_bytes).unwrap();
+        let ua_public = p256::PublicKey::from_encoded_point(&ua_pub_point).unwrap();
+        let auth_bytes = URL_SAFE_NO_PAD.decode(auth_b64).unwrap();
+        let auth: [u8; 16] = auth_bytes.try_into().expect("16-byte auth");
+
+        let subscription = SubscriptionKeys {
+            p256dh: ua_public,
+            auth: std::sync::Arc::new(crate::push::types::AuthSecret::from_bytes(auth)),
+        };
+        let plaintext = b"When I grow up, I want to be a watermelon";
+        let encrypted = encrypt(&subscription, plaintext, DEFAULT_PLAINTEXT_BUCKET)
+            .expect("encrypt() succeeds with the RFC 8291 §5 UA key");
+        let decrypted = ua_side_decrypt(&ua_private, &auth, encrypted.as_slice());
+        assert_eq!(
+            decrypted, plaintext,
+            "encrypt() output must decrypt back to original plaintext under the UA private key — \
+             a regression here means encrypt() is producing undecryptable bodies"
         );
     }
 

--- a/server/crates/waddle-xmpp/src/push/envelope.rs
+++ b/server/crates/waddle-xmpp/src/push/envelope.rs
@@ -1,0 +1,274 @@
+//! Push notification envelope: typed plaintext for the chat service
+//! worker and per-class transport policy (TTL / Urgency / Topic).
+//!
+//! The envelope is the only thing the service worker sees after AES-GCM
+//! decryption. It is JSON-serialized with a `"v": 1` schema discriminator
+//! so the SW can switch on it cleanly when PR-D3 lands.
+//!
+//! Per-class policy is held inside [`PushClass`] (bucket size, TTL,
+//! urgency) so the publish-job worker doesn't have to plumb three
+//! correlated parameters through every call site — picking the class is
+//! enough.
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use super::constants::{DEFAULT_PLAINTEXT_BUCKET, DM_PLAINTEXT_BUCKET};
+use super::sender::Urgency;
+use super::types::{PushTopic, PushTopicParseError};
+
+/// Push notification classes recognized by the chat service worker.
+///
+/// Per-class TTL / Urgency / bucket-size are encapsulated here so the
+/// publish-job worker selects policy by class rather than wiring three
+/// correlated parameters per call site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PushClass {
+    /// One-to-one direct message. Larger plaintext bucket (1024 bytes)
+    /// covers most DM bodies without splitting; `Urgency::High`; longer
+    /// TTL — DMs are user-personal and should survive offline periods.
+    DirectMessage,
+    /// Mention in a multi-user room. Small bucket (256 bytes); high
+    /// urgency; medium TTL — mentions are time-sensitive and shouldn't
+    /// fan out a 1 KiB body for every device.
+    Mention,
+    /// General room notification (non-mention). Small bucket; normal
+    /// urgency; short TTL — coalesce aggressively.
+    Room,
+}
+
+impl PushClass {
+    /// Plaintext bucket size fed to [`super::encrypt::encrypt`] —
+    /// padding target so encrypted body length never leaks plaintext
+    /// length.
+    pub fn bucket_size(self) -> usize {
+        match self {
+            PushClass::DirectMessage => DM_PLAINTEXT_BUCKET,
+            PushClass::Mention | PushClass::Room => DEFAULT_PLAINTEXT_BUCKET,
+        }
+    }
+
+    /// RFC 8030 §5.2 `TTL` header in seconds — how long the relay
+    /// should hold the message if the device is offline.
+    pub fn ttl(self) -> u32 {
+        match self {
+            PushClass::DirectMessage => 7 * 24 * 60 * 60, // 7 days
+            PushClass::Mention => 24 * 60 * 60,           // 1 day
+            PushClass::Room => 4 * 60 * 60,               // 4 hours
+        }
+    }
+
+    /// RFC 8030 §5.3 `Urgency` header. DMs/mentions wake the device;
+    /// general room traffic stays at normal so battery-saver delays it.
+    pub fn urgency(self) -> Urgency {
+        match self {
+            PushClass::DirectMessage | PushClass::Mention => Urgency::High,
+            PushClass::Room => Urgency::Normal,
+        }
+    }
+
+    fn discriminant_byte(self) -> u8 {
+        match self {
+            PushClass::DirectMessage => b'd',
+            PushClass::Mention => b'm',
+            PushClass::Room => b'r',
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            PushClass::DirectMessage => "direct_message",
+            PushClass::Mention => "mention",
+            PushClass::Room => "room",
+        }
+    }
+}
+
+/// `"v": 1` envelope serialized into the encrypted body.
+///
+/// Field names are intentionally short — every byte after padding
+/// counts towards the relay's body-size ceiling.
+#[derive(Debug, Clone, Serialize)]
+pub struct PushEnvelope<'a> {
+    /// Schema version. Always `1` for this PR; PR-D3's SW switches on
+    /// it.
+    pub v: u8,
+    /// Push class (see [`PushClass`]).
+    pub class: &'static str,
+    /// Conversation bare JID (DM peer or MUC room).
+    pub conversation: &'a str,
+    /// Stanza item id of the originating message — lets the SW
+    /// deduplicate against an earlier in-band notification.
+    pub item: &'a str,
+    /// User-facing title (already truncated by the caller).
+    pub title: &'a str,
+    /// User-facing body preview.
+    pub body: &'a str,
+    /// Server-side unread count snapshot (XEP-0357 message-count).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unread: Option<u64>,
+}
+
+impl<'a> PushEnvelope<'a> {
+    pub fn new(
+        class: PushClass,
+        conversation: &'a str,
+        item: &'a str,
+        title: &'a str,
+        body: &'a str,
+        unread: Option<u64>,
+    ) -> Self {
+        Self {
+            v: 1,
+            class: class.as_str(),
+            conversation,
+            item,
+            title,
+            body,
+            unread,
+        }
+    }
+
+    /// Serialize to the byte string that gets fed to
+    /// [`super::encrypt::encrypt`]. JSON is canonical-ish (serde's
+    /// struct order is the declaration order) but the SW does not
+    /// require canonicalization.
+    pub fn to_plaintext(&self) -> Vec<u8> {
+        serde_json::to_vec(self).expect("envelope serializes as JSON")
+    }
+}
+
+/// Build an RFC 8030 §5.4 `Topic` for `(class, conversation)`.
+///
+/// The relay uses `Topic` to coalesce queued messages: a newer push
+/// with the same topic replaces an older one. We hash both inputs to
+/// avoid leaking the bare JID to the relay (and to fit the §5.4 32-char
+/// ceiling regardless of JID length).
+///
+/// Output: 32 base64url-no-pad characters over the first 24 bytes of
+/// `SHA-256(class-discriminant || 0x00 || conversation)`. 192 bits is
+/// plenty of collision resistance for per-(class, conversation)
+/// dedup-keying.
+pub fn push_topic_for(class: PushClass, conversation: &str) -> PushTopic {
+    let mut hasher = Sha256::new();
+    hasher.update([class.discriminant_byte()]);
+    hasher.update([0u8]); // unambiguous separator so `(d, "abc")` ≠ `(da, "bc")`
+    hasher.update(conversation.as_bytes());
+    let digest = hasher.finalize();
+    let encoded = URL_SAFE_NO_PAD.encode(&digest[..24]);
+    debug_assert_eq!(encoded.len(), 32);
+    PushTopic::new(encoded).unwrap_or_else(|err: PushTopicParseError| {
+        // Cannot happen: base64url alphabet is a strict subset of the
+        // RFC 8030 §5.4 topic-char alphabet, and 24 bytes → exactly 32
+        // chars stays at the 32-char ceiling. Surface as an assert so a
+        // future input change is caught loudly rather than silently
+        // truncated.
+        panic!("push_topic_for produced invalid PushTopic: {err:?}");
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn class_bucket_size_picks_dm_vs_default() {
+        assert_eq!(PushClass::DirectMessage.bucket_size(), DM_PLAINTEXT_BUCKET);
+        assert_eq!(PushClass::Mention.bucket_size(), DEFAULT_PLAINTEXT_BUCKET);
+        assert_eq!(PushClass::Room.bucket_size(), DEFAULT_PLAINTEXT_BUCKET);
+    }
+
+    #[test]
+    fn class_ttl_is_per_class() {
+        assert!(PushClass::DirectMessage.ttl() > PushClass::Mention.ttl());
+        assert!(PushClass::Mention.ttl() > PushClass::Room.ttl());
+    }
+
+    #[test]
+    fn class_urgency_is_per_class() {
+        assert_eq!(PushClass::DirectMessage.urgency(), Urgency::High);
+        assert_eq!(PushClass::Mention.urgency(), Urgency::High);
+        assert_eq!(PushClass::Room.urgency(), Urgency::Normal);
+    }
+
+    #[test]
+    fn envelope_serializes_v1_schema() {
+        let env = PushEnvelope::new(
+            PushClass::DirectMessage,
+            "alice@example.com",
+            "item-123",
+            "Alice",
+            "hello",
+            Some(3),
+        );
+        let bytes = env.to_plaintext();
+        let s = std::str::from_utf8(&bytes).unwrap();
+        let json: serde_json::Value = serde_json::from_str(s).unwrap();
+        assert_eq!(json["v"], 1);
+        assert_eq!(json["class"], "direct_message");
+        assert_eq!(json["conversation"], "alice@example.com");
+        assert_eq!(json["item"], "item-123");
+        assert_eq!(json["title"], "Alice");
+        assert_eq!(json["body"], "hello");
+        assert_eq!(json["unread"], 3);
+    }
+
+    #[test]
+    fn envelope_omits_unread_when_absent() {
+        let env = PushEnvelope::new(
+            PushClass::Room,
+            "room@conf.example.com",
+            "item-x",
+            "",
+            "ping",
+            None,
+        );
+        let json: serde_json::Value = serde_json::from_slice(&env.to_plaintext()).unwrap();
+        assert!(json.get("unread").is_none(), "unread must be omitted");
+    }
+
+    #[test]
+    fn topic_is_32_chars_and_alphabet_valid() {
+        let topic = push_topic_for(PushClass::Mention, "room@conf.example.com");
+        assert_eq!(topic.as_str().len(), 32);
+        // Constructor enforces RFC 8030 §5.4 alphabet — the round-trip
+        // proves it.
+        let again = PushTopic::new(topic.as_str().to_string()).expect("alphabet-valid");
+        assert_eq!(again.as_str(), topic.as_str());
+    }
+
+    #[test]
+    fn topic_differs_by_class() {
+        let dm = push_topic_for(PushClass::DirectMessage, "alice@example.com");
+        let mention = push_topic_for(PushClass::Mention, "alice@example.com");
+        let room = push_topic_for(PushClass::Room, "alice@example.com");
+        assert_ne!(dm.as_str(), mention.as_str());
+        assert_ne!(mention.as_str(), room.as_str());
+        assert_ne!(dm.as_str(), room.as_str());
+    }
+
+    #[test]
+    fn topic_is_stable_for_same_inputs() {
+        let a = push_topic_for(PushClass::DirectMessage, "alice@example.com");
+        let b = push_topic_for(PushClass::DirectMessage, "alice@example.com");
+        assert_eq!(a.as_str(), b.as_str());
+    }
+
+    #[test]
+    fn topic_separator_prevents_class_concat_collision() {
+        // Without the 0x00 separator, `(class='d', conv='abc')` and
+        // `(class='da', conv='bc')` would hash to the same bytes. The
+        // explicit separator + single-byte discriminant prevents that.
+        // We can't synthesize a PushClass::DaBC, but we can prove the
+        // hash includes the separator by replicating the construction.
+        let mut h = sha2::Sha256::new();
+        h.update([b'd', 0u8]);
+        h.update(b"abc");
+        let expected = URL_SAFE_NO_PAD.encode(&h.finalize()[..24]);
+        let topic = push_topic_for(PushClass::DirectMessage, "abc");
+        assert_eq!(topic.as_str(), expected);
+    }
+}

--- a/server/crates/waddle-xmpp/src/push/envelope.rs
+++ b/server/crates/waddle-xmpp/src/push/envelope.rs
@@ -79,26 +79,81 @@ impl PushClass {
     }
 }
 
-/// Map a granular notification class (the db-form string emitted by the
-/// chat client into `<context xmlns='urn:waddle:push:context:0' class='...'/>`)
-/// to the transport-policy [`PushClass`].
-///
-/// Unknown values fall through to [`PushClass::Mention`] (small bucket,
-/// high urgency) — the safer side: small bucket can never leak more
-/// than ~256 bytes of plaintext-length, and high urgency wakes the
-/// device. Logging the unknown value is the caller's responsibility.
-pub fn push_class_for_db_value(class: &str) -> PushClass {
-    match class {
-        "dm" | "dm_mention" => PushClass::DirectMessage,
-        "personal_mention" | "channel_mention" | "active_channel_mention" => PushClass::Mention,
-        // `notify_all` is `@everyone`/`@here`-style broadcast — not a
-        // personal ping. Route to `Room` policy (lower urgency,
-        // shorter TTL) so battery-saver can coalesce and the device
-        // doesn't get woken for what is effectively a room
-        // announcement.
-        "notify_all" => PushClass::Room,
-        _ => PushClass::Mention,
+/// Granular notification class emitted by the chat client in
+/// `<context xmlns='urn:waddle:push:context:0' class='...'/>`. Typed
+/// closed enum so the dispatch boundary never carries an unknown
+/// class string into the envelope — XML-parse is the one place this
+/// is validated; downstream sees a typed value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NotificationClass {
+    /// 1:1 direct message.
+    Dm,
+    /// 1:1 direct message that explicitly @-mentions the recipient.
+    DmMention,
+    /// Personal @-mention in a MUC.
+    PersonalMention,
+    /// @-mention scoped to a channel the recipient subscribes to.
+    ChannelMention,
+    /// @-mention in a channel the recipient currently has open.
+    ActiveChannelMention,
+    /// `@everyone` / `@here` broadcast.
+    NotifyAll,
+}
+
+/// Parse error for [`NotificationClass`]. The class string comes from
+/// the typed `<context>` element on the wire — an unknown value is a
+/// publisher protocol violation, not a runtime hazard.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+#[error("unknown notification class: {0:?}")]
+pub struct NotificationClassParseError(pub Box<str>);
+
+impl NotificationClass {
+    pub fn from_db_value(s: &str) -> Result<Self, NotificationClassParseError> {
+        match s {
+            "dm" => Ok(Self::Dm),
+            "dm_mention" => Ok(Self::DmMention),
+            "personal_mention" => Ok(Self::PersonalMention),
+            "channel_mention" => Ok(Self::ChannelMention),
+            "active_channel_mention" => Ok(Self::ActiveChannelMention),
+            "notify_all" => Ok(Self::NotifyAll),
+            other => Err(NotificationClassParseError(other.into())),
+        }
     }
+
+    pub fn as_db_value(self) -> &'static str {
+        match self {
+            Self::Dm => "dm",
+            Self::DmMention => "dm_mention",
+            Self::PersonalMention => "personal_mention",
+            Self::ChannelMention => "channel_mention",
+            Self::ActiveChannelMention => "active_channel_mention",
+            Self::NotifyAll => "notify_all",
+        }
+    }
+
+    /// Fold the granular class onto the transport-policy
+    /// [`PushClass`] (TTL / Urgency / bucket-size). DM-family →
+    /// `DirectMessage`; per-user mentions → `Mention`; `@everyone`
+    /// broadcast → `Room` (lower urgency, shorter TTL).
+    pub fn transport_policy(self) -> PushClass {
+        match self {
+            Self::Dm | Self::DmMention => PushClass::DirectMessage,
+            Self::PersonalMention | Self::ChannelMention | Self::ActiveChannelMention => {
+                PushClass::Mention
+            }
+            Self::NotifyAll => PushClass::Room,
+        }
+    }
+}
+
+/// Compatibility shim for callers that still receive an untyped class
+/// string from somewhere they can't (yet) parse strictly. Prefer
+/// [`NotificationClass::from_db_value`] + [`NotificationClass::transport_policy`]
+/// in new code.
+pub fn push_class_for_db_value(class: &str) -> PushClass {
+    NotificationClass::from_db_value(class)
+        .map(NotificationClass::transport_policy)
+        .unwrap_or(PushClass::Mention)
 }
 
 /// `"v": 1` envelope serialized into the encrypted body.

--- a/server/crates/waddle-xmpp/src/push/envelope.rs
+++ b/server/crates/waddle-xmpp/src/push/envelope.rs
@@ -77,13 +77,23 @@ impl PushClass {
             PushClass::Room => b'r',
         }
     }
+}
 
-    fn as_str(self) -> &'static str {
-        match self {
-            PushClass::DirectMessage => "direct_message",
-            PushClass::Mention => "mention",
-            PushClass::Room => "room",
+/// Map a granular notification class (the db-form string emitted by the
+/// chat client into `<context xmlns='urn:waddle:push:context:0' class='...'/>`)
+/// to the transport-policy [`PushClass`].
+///
+/// Unknown values fall through to [`PushClass::Mention`] (small bucket,
+/// high urgency) — the safer side: small bucket can never leak more
+/// than ~256 bytes of plaintext-length, and high urgency wakes the
+/// device. Logging the unknown value is the caller's responsibility.
+pub fn push_class_for_db_value(class: &str) -> PushClass {
+    match class {
+        "dm" | "dm_mention" => PushClass::DirectMessage,
+        "personal_mention" | "channel_mention" | "active_channel_mention" | "notify_all" => {
+            PushClass::Mention
         }
+        _ => PushClass::Mention,
     }
 }
 
@@ -91,43 +101,47 @@ impl PushClass {
 ///
 /// Field names are intentionally short — every byte after padding
 /// counts towards the relay's body-size ceiling.
+///
+/// XEP-0357 §4 forbids the push service from receiving message
+/// content, so this envelope carries only routing metadata; the chat
+/// service worker uses it to decide *how* to render a generic
+/// "new message" notification and to wake the app for the real body.
 #[derive(Debug, Clone, Serialize)]
 pub struct PushEnvelope<'a> {
     /// Schema version. Always `1` for this PR; PR-D3's SW switches on
     /// it.
     pub v: u8,
-    /// Push class (see [`PushClass`]).
-    pub class: &'static str,
+    /// Granular notification class (e.g. `"dm"`, `"personal_mention"`,
+    /// `"channel_mention"`). Carries finer detail than the transport
+    /// [`PushClass`] so the SW can pick the right localized banner.
+    pub class: &'a str,
     /// Conversation bare JID (DM peer or MUC room).
     pub conversation: &'a str,
+    /// XEP-0201 thread id, if the publishing chat client included one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thread: Option<&'a str>,
     /// Stanza item id of the originating message — lets the SW
     /// deduplicate against an earlier in-band notification.
     pub item: &'a str,
-    /// User-facing title (already truncated by the caller).
-    pub title: &'a str,
-    /// User-facing body preview.
-    pub body: &'a str,
-    /// Server-side unread count snapshot (XEP-0357 message-count).
+    /// Server-side unread count snapshot (XEP-0357 `message-count`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub unread: Option<u64>,
 }
 
 impl<'a> PushEnvelope<'a> {
     pub fn new(
-        class: PushClass,
+        class: &'a str,
         conversation: &'a str,
+        thread: Option<&'a str>,
         item: &'a str,
-        title: &'a str,
-        body: &'a str,
         unread: Option<u64>,
     ) -> Self {
         Self {
             v: 1,
-            class: class.as_str(),
+            class,
             conversation,
+            thread,
             item,
-            title,
-            body,
             unread,
         }
     }
@@ -197,37 +211,53 @@ mod tests {
     #[test]
     fn envelope_serializes_v1_schema() {
         let env = PushEnvelope::new(
-            PushClass::DirectMessage,
+            "dm",
             "alice@example.com",
+            Some("thread-abc"),
             "item-123",
-            "Alice",
-            "hello",
             Some(3),
         );
         let bytes = env.to_plaintext();
         let s = std::str::from_utf8(&bytes).unwrap();
         let json: serde_json::Value = serde_json::from_str(s).unwrap();
         assert_eq!(json["v"], 1);
-        assert_eq!(json["class"], "direct_message");
+        assert_eq!(json["class"], "dm");
         assert_eq!(json["conversation"], "alice@example.com");
+        assert_eq!(json["thread"], "thread-abc");
         assert_eq!(json["item"], "item-123");
-        assert_eq!(json["title"], "Alice");
-        assert_eq!(json["body"], "hello");
         assert_eq!(json["unread"], 3);
     }
 
     #[test]
-    fn envelope_omits_unread_when_absent() {
-        let env = PushEnvelope::new(
-            PushClass::Room,
-            "room@conf.example.com",
-            "item-x",
-            "",
-            "ping",
-            None,
-        );
+    fn envelope_omits_optional_fields_when_absent() {
+        let env = PushEnvelope::new("dm", "alice@example.com", None, "item-x", None);
         let json: serde_json::Value = serde_json::from_slice(&env.to_plaintext()).unwrap();
         assert!(json.get("unread").is_none(), "unread must be omitted");
+        assert!(json.get("thread").is_none(), "thread must be omitted");
+    }
+
+    #[test]
+    fn push_class_for_db_value_maps_granular_classes() {
+        assert_eq!(push_class_for_db_value("dm"), PushClass::DirectMessage);
+        assert_eq!(
+            push_class_for_db_value("dm_mention"),
+            PushClass::DirectMessage
+        );
+        assert_eq!(
+            push_class_for_db_value("personal_mention"),
+            PushClass::Mention
+        );
+        assert_eq!(
+            push_class_for_db_value("channel_mention"),
+            PushClass::Mention
+        );
+        assert_eq!(
+            push_class_for_db_value("active_channel_mention"),
+            PushClass::Mention
+        );
+        assert_eq!(push_class_for_db_value("notify_all"), PushClass::Mention);
+        // Unknown falls through to Mention (safer-side default).
+        assert_eq!(push_class_for_db_value("anything-else"), PushClass::Mention);
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/push/envelope.rs
+++ b/server/crates/waddle-xmpp/src/push/envelope.rs
@@ -90,9 +90,13 @@ impl PushClass {
 pub fn push_class_for_db_value(class: &str) -> PushClass {
     match class {
         "dm" | "dm_mention" => PushClass::DirectMessage,
-        "personal_mention" | "channel_mention" | "active_channel_mention" | "notify_all" => {
-            PushClass::Mention
-        }
+        "personal_mention" | "channel_mention" | "active_channel_mention" => PushClass::Mention,
+        // `notify_all` is `@everyone`/`@here`-style broadcast — not a
+        // personal ping. Route to `Room` policy (lower urgency,
+        // shorter TTL) so battery-saver can coalesce and the device
+        // doesn't get woken for what is effectively a room
+        // announcement.
+        "notify_all" => PushClass::Room,
         _ => PushClass::Mention,
     }
 }
@@ -255,7 +259,9 @@ mod tests {
             push_class_for_db_value("active_channel_mention"),
             PushClass::Mention
         );
-        assert_eq!(push_class_for_db_value("notify_all"), PushClass::Mention);
+        // `notify_all` is @everyone broadcast — routes to Room policy
+        // (lower urgency, shorter TTL).
+        assert_eq!(push_class_for_db_value("notify_all"), PushClass::Room);
         // Unknown falls through to Mention (safer-side default).
         assert_eq!(push_class_for_db_value("anything-else"), PushClass::Mention);
     }

--- a/server/crates/waddle-xmpp/src/push/limiter.rs
+++ b/server/crates/waddle-xmpp/src/push/limiter.rs
@@ -163,8 +163,7 @@ impl WebPushSender for RateLimitedWebPushSender {
         // per-pair rate limit becomes per-device — defeating the
         // "one chatty relay+class can't monopolize the global cap"
         // semantic the doc-comment promises.
-        let endpoint_hash =
-            EndpointHash::of(&request.endpoint.origin().ascii_serialization());
+        let endpoint_hash = EndpointHash::of(&request.endpoint.origin().ascii_serialization());
         let urgency = request.urgency;
         let endpoint = request.endpoint.clone();
         let payload = request.payload.clone();
@@ -357,8 +356,8 @@ mod tests {
         let p = payload();
         let j = jwt();
         let url_fcm = url::Url::parse("https://fcm.googleapis.com/fcm/send/abc").unwrap();
-        let url_moz = url::Url::parse("https://updates.push.services.mozilla.com/wpush/v1/xyz")
-            .unwrap();
+        let url_moz =
+            url::Url::parse("https://updates.push.services.mozilla.com/wpush/v1/xyz").unwrap();
         let start = Instant::now();
         sender
             .send(make_request(&url_fcm, &p, &j, Urgency::Normal))

--- a/server/crates/waddle-xmpp/src/push/limiter.rs
+++ b/server/crates/waddle-xmpp/src/push/limiter.rs
@@ -157,7 +157,14 @@ impl WebPushSender for RateLimitedWebPushSender {
         &self,
         request: WebPushRequest<'_>,
     ) -> Pin<Box<dyn std::future::Future<Output = WebPushOutcome> + Send + '_>> {
-        let endpoint_hash = EndpointHash::of(request.endpoint.as_str());
+        // Bucket key on relay host (scheme + host + port), NOT the
+        // full per-device endpoint URL. Otherwise a 1000-device fan-
+        // out to FCM would key on 1000 distinct buckets and the
+        // per-pair rate limit becomes per-device — defeating the
+        // "one chatty relay+class can't monopolize the global cap"
+        // semantic the doc-comment promises.
+        let endpoint_hash =
+            EndpointHash::of(&request.endpoint.origin().ascii_serialization());
         let urgency = request.urgency;
         let endpoint = request.endpoint.clone();
         let payload = request.payload.clone();
@@ -339,7 +346,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn different_endpoints_dont_share_buckets() {
+    async fn different_relay_hosts_dont_share_buckets() {
         let inner = PeakSender::with_delay(0);
         let inner_arc: Arc<dyn WebPushSender> = Arc::new(inner.clone());
         let limiter = Arc::new(Limiter::new(LimiterConfig {
@@ -349,8 +356,39 @@ mod tests {
         let sender = RateLimitedWebPushSender::new(inner_arc, limiter);
         let p = payload();
         let j = jwt();
-        let url_a = endpoint("/a");
-        let url_b = endpoint("/b");
+        let url_fcm = url::Url::parse("https://fcm.googleapis.com/fcm/send/abc").unwrap();
+        let url_moz = url::Url::parse("https://updates.push.services.mozilla.com/wpush/v1/xyz")
+            .unwrap();
+        let start = Instant::now();
+        sender
+            .send(make_request(&url_fcm, &p, &j, Urgency::Normal))
+            .await;
+        sender
+            .send(make_request(&url_moz, &p, &j, Urgency::Normal))
+            .await;
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < Duration::from_millis(50),
+            "different relay hosts must use independent buckets; elapsed {elapsed:?}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn same_relay_different_paths_share_one_bucket() {
+        // Two devices behind the same relay share one (host, urgency)
+        // bucket — that's the whole point of per-pair rate limiting:
+        // a 1000-device fan-out to FCM should NOT bypass the spacing.
+        let inner = PeakSender::with_delay(0);
+        let inner_arc: Arc<dyn WebPushSender> = Arc::new(inner.clone());
+        let limiter = Arc::new(Limiter::new(LimiterConfig {
+            global_concurrency: 64,
+            per_pair_min_interval: Duration::from_millis(200),
+        }));
+        let sender = RateLimitedWebPushSender::new(inner_arc, limiter);
+        let p = payload();
+        let j = jwt();
+        let url_a = endpoint("/device-a");
+        let url_b = endpoint("/device-b");
         let start = Instant::now();
         sender
             .send(make_request(&url_a, &p, &j, Urgency::Normal))
@@ -360,8 +398,8 @@ mod tests {
             .await;
         let elapsed = start.elapsed();
         assert!(
-            elapsed < Duration::from_millis(50),
-            "different endpoints must use independent buckets; elapsed {elapsed:?}"
+            elapsed >= Duration::from_millis(200),
+            "two devices on the same relay must serialize via one shared bucket; elapsed {elapsed:?}"
         );
     }
 

--- a/server/crates/waddle-xmpp/src/push/limiter.rs
+++ b/server/crates/waddle-xmpp/src/push/limiter.rs
@@ -20,11 +20,12 @@
 //! (publish-job worker, tests) see the same shape; the limiter is
 //! transparent except for the rate it imposes.
 
-use std::collections::HashMap;
+use std::num::NonZeroUsize;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use lru::LruCache;
 use tokio::sync::Semaphore;
 use tokio::time::Instant;
 
@@ -43,12 +44,23 @@ pub const DEFAULT_GLOBAL_CONCURRENCY: usize = 64;
 /// chatty pair from monopolizing the global cap.
 pub const DEFAULT_PER_PAIR_MIN_INTERVAL: Duration = Duration::from_millis(100);
 
+/// Default ceiling on the per-pair bucket cache. Bucket entries are
+/// keyed by `(relay_origin_hash, urgency)`; with four urgency levels
+/// and ~1k distinct relays a server might fan out to in practice, 4096
+/// gives ample headroom while bounding the limiter's heap footprint.
+/// On overflow the LRU evicts the least-recently-acquired pair —
+/// safe, since evicting an entry just means the *next* acquire for
+/// that pair will start with a fresh `next_available` (no spacing
+/// owed), which is exactly the cold-start behavior.
+pub const DEFAULT_PAIR_CACHE_CAPACITY: usize = 4096;
+
 /// Configurable knobs for the limiter. Constructed at boot from
-/// deployment defaults; tests can override either field.
+/// deployment defaults; tests can override any field.
 #[derive(Debug, Clone, Copy)]
 pub struct LimiterConfig {
     pub global_concurrency: usize,
     pub per_pair_min_interval: Duration,
+    pub pair_cache_capacity: usize,
 }
 
 impl Default for LimiterConfig {
@@ -56,6 +68,7 @@ impl Default for LimiterConfig {
         Self {
             global_concurrency: DEFAULT_GLOBAL_CONCURRENCY,
             per_pair_min_interval: DEFAULT_PER_PAIR_MIN_INTERVAL,
+            pair_cache_capacity: DEFAULT_PAIR_CACHE_CAPACITY,
         }
     }
 }
@@ -70,19 +83,29 @@ struct PairState {
 
 /// Rate-limiting state shared by every [`RateLimitedWebPushSender`]
 /// wrapping it. Cheap to clone via `Arc`.
+///
+/// The per-pair bucket map is an `LruCache` rather than a `HashMap`
+/// so a long-running process can't grow its limiter heap forever as
+/// new `(relay_origin, urgency)` pairs are observed. When the cache
+/// hits its capacity ceiling the least-recently-acquired pair is
+/// evicted; that pair's next acquire starts with a fresh
+/// `next_available` (no spacing owed) — the same cold-start behavior
+/// the very first acquire for any pair gets.
 #[derive(Debug)]
 pub struct Limiter {
     global: Arc<Semaphore>,
     config: LimiterConfig,
-    pairs: Mutex<HashMap<(EndpointHash, Urgency), PairState>>,
+    pairs: Mutex<LruCache<(EndpointHash, Urgency), PairState>>,
 }
 
 impl Limiter {
     pub fn new(config: LimiterConfig) -> Self {
+        let capacity = NonZeroUsize::new(config.pair_cache_capacity)
+            .unwrap_or_else(|| NonZeroUsize::new(DEFAULT_PAIR_CACHE_CAPACITY).expect("non-zero"));
         Self {
             global: Arc::new(Semaphore::new(config.global_concurrency)),
             config,
-            pairs: Mutex::new(HashMap::new()),
+            pairs: Mutex::new(LruCache::new(capacity)),
         }
     }
 
@@ -108,11 +131,12 @@ impl Limiter {
                 .pairs
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
-            let entry = pairs
-                .entry((endpoint_hash, urgency))
-                .or_insert_with(|| PairState {
-                    next_available: Instant::now(),
-                });
+            // `LruCache::get_or_insert_mut` looks up + LRU-promotes
+            // an existing entry, or constructs a new one (evicting
+            // the oldest if at capacity).
+            let entry = pairs.get_or_insert_mut((endpoint_hash, urgency), || PairState {
+                next_available: Instant::now(),
+            });
             let now = Instant::now();
             let start = entry.next_available.max(now);
             entry.next_available = start + self.config.per_pair_min_interval;
@@ -276,6 +300,7 @@ mod tests {
         let limiter = Arc::new(Limiter::new(LimiterConfig {
             global_concurrency: 3,
             per_pair_min_interval: Duration::ZERO,
+            ..LimiterConfig::default()
         }));
         let sender = RateLimitedWebPushSender::new(inner_arc, limiter);
 
@@ -302,6 +327,7 @@ mod tests {
         let limiter = Arc::new(Limiter::new(LimiterConfig {
             global_concurrency: 64,
             per_pair_min_interval: Duration::from_millis(50),
+            ..LimiterConfig::default()
         }));
         let sender = RateLimitedWebPushSender::new(inner_arc, limiter);
 
@@ -332,6 +358,7 @@ mod tests {
         let limiter = Arc::new(Limiter::new(LimiterConfig {
             global_concurrency: 64,
             per_pair_min_interval: Duration::from_millis(500),
+            ..LimiterConfig::default()
         }));
         let sender = RateLimitedWebPushSender::new(inner_arc, limiter);
         let p = payload();
@@ -359,6 +386,7 @@ mod tests {
         let limiter = Arc::new(Limiter::new(LimiterConfig {
             global_concurrency: 64,
             per_pair_min_interval: Duration::from_millis(500),
+            ..LimiterConfig::default()
         }));
         let sender = RateLimitedWebPushSender::new(inner_arc, limiter);
         let p = payload();
@@ -390,6 +418,7 @@ mod tests {
         let limiter = Arc::new(Limiter::new(LimiterConfig {
             global_concurrency: 64,
             per_pair_min_interval: Duration::from_millis(200),
+            ..LimiterConfig::default()
         }));
         let sender = RateLimitedWebPushSender::new(inner_arc, limiter);
         let p = payload();
@@ -408,6 +437,64 @@ mod tests {
             elapsed >= Duration::from_millis(200),
             "two devices on the same relay must serialize via one shared bucket; elapsed {elapsed:?}"
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn pair_cache_lru_evicts_oldest_pair_at_capacity() {
+        // Cap at 2 entries; touch three distinct (origin, urgency)
+        // pairs. The third acquire must evict the first — when that
+        // first pair is touched again afterwards, its bucket is
+        // fresh (no spacing owed), proving the LRU bounded the map.
+        let inner = PeakSender::with_delay(0);
+        let inner_arc: Arc<dyn WebPushSender> = Arc::new(inner.clone());
+        let limiter = Arc::new(Limiter::new(LimiterConfig {
+            global_concurrency: 64,
+            per_pair_min_interval: Duration::from_millis(500),
+            pair_cache_capacity: 2,
+        }));
+        let sender = RateLimitedWebPushSender::new(inner_arc, limiter);
+        let p = payload();
+        let j = jwt();
+        let url_a = url::Url::parse("https://a.example.com/x").unwrap();
+        let url_b = url::Url::parse("https://b.example.com/x").unwrap();
+        let url_c = url::Url::parse("https://c.example.com/x").unwrap();
+        sender
+            .send(make_request(&url_a, &p, &j, Urgency::Normal))
+            .await; // A: first-touch
+        sender
+            .send(make_request(&url_b, &p, &j, Urgency::Normal))
+            .await; // B: first-touch
+        sender
+            .send(make_request(&url_c, &p, &j, Urgency::Normal))
+            .await; // C: evicts A (LRU)
+                    // Now A is back at cold-start: no `next_available` to wait
+                    // on, so the next acquire returns immediately (well within
+                    // 50ms despite the 500ms min_interval that WOULD apply if A
+                    // had remained in the cache).
+        let start = Instant::now();
+        sender
+            .send(make_request(&url_a, &p, &j, Urgency::Normal))
+            .await;
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < Duration::from_millis(50),
+            "A's bucket must be cold after LRU eviction (elapsed {elapsed:?})"
+        );
+    }
+
+    #[test]
+    fn pair_cache_capacity_zero_falls_back_to_default() {
+        // Guard against an operator config of `0` accidentally
+        // hitting `NonZeroUsize::new(0)` → panic. The constructor
+        // must fall back to the default, never panic.
+        let limiter = Limiter::new(LimiterConfig {
+            global_concurrency: 1,
+            per_pair_min_interval: Duration::ZERO,
+            pair_cache_capacity: 0,
+        });
+        // Internal sanity — we don't expose `pairs.cap()` so just
+        // assert construction succeeded.
+        let _ = limiter;
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/push/limiter.rs
+++ b/server/crates/waddle-xmpp/src/push/limiter.rs
@@ -99,7 +99,15 @@ impl Limiter {
         // this before the global permit means a backed-up pair waits
         // without holding a slot the rest of the process could use.
         let sleep_until = {
-            let mut pairs = self.pairs.lock().expect("limiter pair map poisoned");
+            // Recover from a poisoned mutex instead of propagating the
+            // panic — each entry's `next_available` is self-contained
+            // (no inter-entry invariant), so a panicking sibling task
+            // cannot leave the map in an inconsistent state. Matches
+            // the pattern used by `InProcessVapidSigner`'s cache lock.
+            let mut pairs = self
+                .pairs
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
             let entry = pairs
                 .entry((endpoint_hash, urgency))
                 .or_insert_with(|| PairState {

--- a/server/crates/waddle-xmpp/src/push/limiter.rs
+++ b/server/crates/waddle-xmpp/src/push/limiter.rs
@@ -1,0 +1,376 @@
+//! Rate limiting for outbound Web Push sends.
+//!
+//! Two complementary controls layered in front of any
+//! [`WebPushSender`]:
+//!
+//! 1. **Global concurrency cap** via [`tokio::sync::Semaphore`] — bounds
+//!    the total number of in-flight HTTP requests so the publish-job
+//!    worker can't drown the host's connection pool when a fan-out hits
+//!    a thousand devices at once.
+//!
+//! 2. **Per-(endpoint, urgency) leaky bucket** — keyed by
+//!    `(EndpointHash, Urgency)` so one chatty relay+class pair can't
+//!    monopolize the global cap. Implemented as a "next-available
+//!    timestamp" map: each acquire either returns immediately and bumps
+//!    the timestamp by `min_interval`, or sleeps until the timestamp
+//!    passes. Strict rate-limit semantics; no burst — keeps the
+//!    implementation tiny.
+//!
+//! The wrapper preserves the [`WebPushSender`] trait so callers
+//! (publish-job worker, tests) see the same shape; the limiter is
+//! transparent except for the rate it imposes.
+
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tokio::sync::Semaphore;
+use tokio::time::Instant;
+
+use super::sender::{Urgency, WebPushRequest, WebPushSender};
+use super::types::{EndpointHash, WebPushOutcome};
+
+/// Default ceiling on concurrent in-flight Web Push HTTPS requests.
+/// Picked to comfortably fit inside the default `reqwest` connection
+/// pool (each request gets its own slot) without starving the rest of
+/// the process.
+pub const DEFAULT_GLOBAL_CONCURRENCY: usize = 64;
+
+/// Default minimum interval between two sends to the same
+/// `(endpoint, urgency)` pair. 100ms ≈ 10 req/sec/pair, comfortably
+/// below any major relay's per-app rate limit while preventing one
+/// chatty pair from monopolizing the global cap.
+pub const DEFAULT_PER_PAIR_MIN_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Configurable knobs for the limiter. Constructed at boot from
+/// deployment defaults; tests can override either field.
+#[derive(Debug, Clone, Copy)]
+pub struct LimiterConfig {
+    pub global_concurrency: usize,
+    pub per_pair_min_interval: Duration,
+}
+
+impl Default for LimiterConfig {
+    fn default() -> Self {
+        Self {
+            global_concurrency: DEFAULT_GLOBAL_CONCURRENCY,
+            per_pair_min_interval: DEFAULT_PER_PAIR_MIN_INTERVAL,
+        }
+    }
+}
+
+/// Per-(endpoint, urgency) leaky-bucket state. `next_available` is the
+/// earliest `Instant` at which the next acquire is allowed; an acquire
+/// updates it to `max(now, next_available) + min_interval`.
+#[derive(Debug)]
+struct PairState {
+    next_available: Instant,
+}
+
+/// Rate-limiting state shared by every [`RateLimitedWebPushSender`]
+/// wrapping it. Cheap to clone via `Arc`.
+#[derive(Debug)]
+pub struct Limiter {
+    global: Arc<Semaphore>,
+    config: LimiterConfig,
+    pairs: Mutex<HashMap<(EndpointHash, Urgency), PairState>>,
+}
+
+impl Limiter {
+    pub fn new(config: LimiterConfig) -> Self {
+        Self {
+            global: Arc::new(Semaphore::new(config.global_concurrency)),
+            config,
+            pairs: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn with_defaults() -> Self {
+        Self::new(LimiterConfig::default())
+    }
+
+    /// Block until both the global cap and the per-pair bucket allow
+    /// the caller to send. The returned guard holds the global permit
+    /// for as long as it is alive — drop it after the HTTP request
+    /// completes.
+    async fn acquire(&self, endpoint_hash: EndpointHash, urgency: Urgency) -> GlobalPermit<'_> {
+        // Per-pair gate first: cheap mutex pop + optional sleep. Doing
+        // this before the global permit means a backed-up pair waits
+        // without holding a slot the rest of the process could use.
+        let sleep_until = {
+            let mut pairs = self.pairs.lock().expect("limiter pair map poisoned");
+            let entry = pairs
+                .entry((endpoint_hash, urgency))
+                .or_insert_with(|| PairState {
+                    next_available: Instant::now(),
+                });
+            let now = Instant::now();
+            let start = entry.next_available.max(now);
+            entry.next_available = start + self.config.per_pair_min_interval;
+            // `start` is when this acquire is permitted; sleep up to
+            // `start` if the bucket is ahead of the clock.
+            if start > now {
+                Some(start)
+            } else {
+                None
+            }
+        };
+        if let Some(deadline) = sleep_until {
+            tokio::time::sleep_until(deadline).await;
+        }
+
+        let permit = self
+            .global
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("limiter semaphore must not close");
+        GlobalPermit {
+            _permit: permit,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+/// RAII handle for the global concurrency slot taken by
+/// [`Limiter::acquire`]. Drop releases the slot for the next waiter.
+struct GlobalPermit<'a> {
+    _permit: tokio::sync::OwnedSemaphorePermit,
+    _phantom: std::marker::PhantomData<&'a Limiter>,
+}
+
+/// Wraps any [`WebPushSender`] with the [`Limiter`] gating.
+pub struct RateLimitedWebPushSender {
+    inner: Arc<dyn WebPushSender>,
+    limiter: Arc<Limiter>,
+}
+
+impl RateLimitedWebPushSender {
+    pub fn new(inner: Arc<dyn WebPushSender>, limiter: Arc<Limiter>) -> Self {
+        Self { inner, limiter }
+    }
+}
+
+impl WebPushSender for RateLimitedWebPushSender {
+    fn send(
+        &self,
+        request: WebPushRequest<'_>,
+    ) -> Pin<Box<dyn std::future::Future<Output = WebPushOutcome> + Send + '_>> {
+        let endpoint_hash = EndpointHash::of(request.endpoint.as_str());
+        let urgency = request.urgency;
+        let endpoint = request.endpoint.clone();
+        let payload = request.payload.clone();
+        let jwt = request.vapid_jwt.clone();
+        let key = request.vapid_public_key_b64u.to_string();
+        let topic = request.topic.cloned();
+        let ttl = request.ttl;
+        Box::pin(async move {
+            let _permit = self.limiter.acquire(endpoint_hash, urgency).await;
+            self.inner
+                .send(WebPushRequest {
+                    endpoint: &endpoint,
+                    payload: &payload,
+                    vapid_jwt: &jwt,
+                    vapid_public_key_b64u: &key,
+                    topic: topic.as_ref(),
+                    ttl,
+                    urgency,
+                })
+                .await
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::push::types::{EncryptedPayload, PushTopic, VapidJwt};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use url::Url;
+
+    /// Test sender that records concurrent in-flight calls so we can
+    /// verify the global cap is enforced.
+    #[derive(Default, Clone)]
+    struct PeakSender {
+        inflight: Arc<AtomicUsize>,
+        peak: Arc<AtomicUsize>,
+        delay_ms: u64,
+    }
+
+    impl PeakSender {
+        fn with_delay(delay_ms: u64) -> Self {
+            Self {
+                inflight: Arc::new(AtomicUsize::new(0)),
+                peak: Arc::new(AtomicUsize::new(0)),
+                delay_ms,
+            }
+        }
+    }
+
+    impl WebPushSender for PeakSender {
+        fn send(
+            &self,
+            _request: WebPushRequest<'_>,
+        ) -> Pin<Box<dyn std::future::Future<Output = WebPushOutcome> + Send + '_>> {
+            let inflight = Arc::clone(&self.inflight);
+            let peak = Arc::clone(&self.peak);
+            let delay_ms = self.delay_ms;
+            Box::pin(async move {
+                let now = inflight.fetch_add(1, Ordering::SeqCst) + 1;
+                peak.fetch_max(now, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                inflight.fetch_sub(1, Ordering::SeqCst);
+                WebPushOutcome::Delivered { status: 201 }
+            })
+        }
+    }
+
+    fn jwt() -> VapidJwt {
+        VapidJwt::new("eyJhbGciOiJFUzI1NiJ9.eyJhdWQiOiJodHRwczovL2EifQ.sig").expect("jwt")
+    }
+
+    fn payload() -> EncryptedPayload {
+        EncryptedPayload::new(vec![0u8; 32])
+    }
+
+    fn endpoint(path: &str) -> Url {
+        Url::parse(&format!("https://relay.example.com{path}")).unwrap()
+    }
+
+    fn make_request<'a>(
+        endpoint: &'a Url,
+        payload: &'a EncryptedPayload,
+        jwt: &'a VapidJwt,
+        urgency: Urgency,
+    ) -> WebPushRequest<'a> {
+        WebPushRequest {
+            endpoint,
+            payload,
+            vapid_jwt: jwt,
+            vapid_public_key_b64u: "BFoo",
+            topic: None,
+            ttl: 60,
+            urgency,
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn global_cap_bounds_concurrent_sends() {
+        let inner = PeakSender::with_delay(100);
+        let inner_arc: Arc<dyn WebPushSender> = Arc::new(inner.clone());
+        let limiter = Arc::new(Limiter::new(LimiterConfig {
+            global_concurrency: 3,
+            per_pair_min_interval: Duration::ZERO,
+        }));
+        let sender = RateLimitedWebPushSender::new(inner_arc, limiter);
+
+        let p = payload();
+        let j = jwt();
+        let urls: Vec<_> = (0..10).map(|i| endpoint(&format!("/{i}"))).collect();
+        let futures: Vec<_> = urls
+            .iter()
+            .map(|u| sender.send(make_request(u, &p, &j, Urgency::Normal)))
+            .collect();
+        let outcomes = futures::future::join_all(futures).await;
+        assert_eq!(outcomes.len(), 10);
+        assert!(
+            inner.peak.load(Ordering::SeqCst) <= 3,
+            "global cap must bound peak concurrency to 3, observed {}",
+            inner.peak.load(Ordering::SeqCst)
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn per_pair_bucket_spaces_same_endpoint_class() {
+        let inner = PeakSender::with_delay(0);
+        let inner_arc: Arc<dyn WebPushSender> = Arc::new(inner.clone());
+        let limiter = Arc::new(Limiter::new(LimiterConfig {
+            global_concurrency: 64,
+            per_pair_min_interval: Duration::from_millis(50),
+        }));
+        let sender = RateLimitedWebPushSender::new(inner_arc, limiter);
+
+        let p = payload();
+        let j = jwt();
+        let url = endpoint("/same");
+        let start = Instant::now();
+        for _ in 0..4 {
+            sender
+                .send(make_request(&url, &p, &j, Urgency::Normal))
+                .await;
+        }
+        let elapsed = start.elapsed();
+        // 4 acquires at 50ms apart → ≥150ms elapsed (the first runs
+        // immediately, the next three each wait at least 50ms).
+        assert!(
+            elapsed >= Duration::from_millis(150),
+            "per-pair bucket must serialize same-(endpoint,urgency); elapsed {elapsed:?}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn per_pair_bucket_keys_by_urgency() {
+        // Same endpoint, two different urgencies → two independent
+        // buckets, so the second urgency doesn't wait on the first.
+        let inner = PeakSender::with_delay(0);
+        let inner_arc: Arc<dyn WebPushSender> = Arc::new(inner.clone());
+        let limiter = Arc::new(Limiter::new(LimiterConfig {
+            global_concurrency: 64,
+            per_pair_min_interval: Duration::from_millis(500),
+        }));
+        let sender = RateLimitedWebPushSender::new(inner_arc, limiter);
+        let p = payload();
+        let j = jwt();
+        let url = endpoint("/dual");
+        let start = Instant::now();
+        // Two sends to the same URL with different urgency — should
+        // both go through with negligible wait (each bucket only sees
+        // one acquire).
+        sender.send(make_request(&url, &p, &j, Urgency::High)).await;
+        sender
+            .send(make_request(&url, &p, &j, Urgency::Normal))
+            .await;
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < Duration::from_millis(50),
+            "different urgencies must use independent buckets; elapsed {elapsed:?}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn different_endpoints_dont_share_buckets() {
+        let inner = PeakSender::with_delay(0);
+        let inner_arc: Arc<dyn WebPushSender> = Arc::new(inner.clone());
+        let limiter = Arc::new(Limiter::new(LimiterConfig {
+            global_concurrency: 64,
+            per_pair_min_interval: Duration::from_millis(500),
+        }));
+        let sender = RateLimitedWebPushSender::new(inner_arc, limiter);
+        let p = payload();
+        let j = jwt();
+        let url_a = endpoint("/a");
+        let url_b = endpoint("/b");
+        let start = Instant::now();
+        sender
+            .send(make_request(&url_a, &p, &j, Urgency::Normal))
+            .await;
+        sender
+            .send(make_request(&url_b, &p, &j, Urgency::Normal))
+            .await;
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < Duration::from_millis(50),
+            "different endpoints must use independent buckets; elapsed {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn topic_clone_through_wrapper() {
+        // Compile-time check: PushTopic must be Clone-able since the
+        // wrapper clones the borrowed Option<&PushTopic> into an owned
+        // Option<PushTopic> before re-borrowing for the inner sender.
+        fn _is_clone<T: Clone>() {}
+        _is_clone::<PushTopic>();
+    }
+}

--- a/server/crates/waddle-xmpp/src/push/mod.rs
+++ b/server/crates/waddle-xmpp/src/push/mod.rs
@@ -7,6 +7,7 @@
 pub mod constants;
 pub mod encrypt;
 pub mod envelope;
+pub mod limiter;
 mod sender;
 mod store;
 pub mod types;

--- a/server/crates/waddle-xmpp/src/push/mod.rs
+++ b/server/crates/waddle-xmpp/src/push/mod.rs
@@ -11,8 +11,15 @@ mod store;
 pub mod types;
 pub mod vapid;
 
-pub use sender::{notify_mentioned_users, HttpWebPushSender, WebPushSender};
-pub use store::{InMemoryPushStore, PushSubscriptionStore};
+pub use sender::{HttpWebPushSender, Urgency, WebPushRequest, WebPushSender};
+/// In-memory push store kept reachable only behind `test-utils` (or
+/// `cfg(test)` within this crate). Production code paths must depend on
+/// a durable `PushSubscriptionStore` impl; PR-D2's cutover narrows the
+/// public surface so accidental wiring against the in-memory fake is
+/// caught at compile time outside of integration-test builds.
+#[cfg(any(test, feature = "test-utils"))]
+pub use store::InMemoryPushStore;
+pub use store::PushSubscriptionStore;
 pub use types::{
     AuthSecret, EncryptedPayload, EndpointHash, Kid, MailtoAddress, PushTopic, PushTopicParseError,
     SubscriptionKeys, SuppressionReason, TransientFailure, VapidJwt, VapidLoadError,

--- a/server/crates/waddle-xmpp/src/push/mod.rs
+++ b/server/crates/waddle-xmpp/src/push/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod constants;
 pub mod encrypt;
+pub mod envelope;
 mod sender;
 mod store;
 pub mod types;

--- a/server/crates/waddle-xmpp/src/push/mod.rs
+++ b/server/crates/waddle-xmpp/src/push/mod.rs
@@ -15,8 +15,9 @@ pub use sender::{notify_mentioned_users, HttpWebPushSender, WebPushSender};
 pub use store::{InMemoryPushStore, PushSubscriptionStore};
 pub use types::{
     AuthSecret, EncryptedPayload, EndpointHash, Kid, MailtoAddress, PushTopic, PushTopicParseError,
-    SubscriptionKeys, VapidJwt, VapidLoadError, VapidSignError, VapidSub, VapidSubParseError,
-    WebPushCryptoError,
+    SubscriptionKeys, SuppressionReason, TransientFailure, VapidJwt, VapidLoadError,
+    VapidSignError, VapidSub, VapidSubParseError, WebPushCapability, WebPushCryptoError,
+    WebPushOutcome,
 };
 
 use minidom::Element;

--- a/server/crates/waddle-xmpp/src/push/sender.rs
+++ b/server/crates/waddle-xmpp/src/push/sender.rs
@@ -172,7 +172,14 @@ async fn classify_response(resp: reqwest::Response) -> WebPushOutcome {
         return WebPushOutcome::Delivered { status: code };
     }
     match code {
-        404 | 410 => WebPushOutcome::SubscriptionGone { status: code },
+        // 404 / 410 are the textbook "subscription gone" signals
+        // (RFC 8030 §6). 403 is added here because FCM and other
+        // relays use 403 to signal "the VAPID key is not authorized
+        // for this endpoint" — the actionable response is identical
+        // (the subscription must be re-registered with fresh keys),
+        // so the publish-job worker treats it as a device-side
+        // permanent failure and disables the row.
+        403 | 404 | 410 => WebPushOutcome::SubscriptionGone { status: code },
         401 => WebPushOutcome::ClockSkew { status: code },
         413 => WebPushOutcome::PayloadTooLarge { status: code },
         429 => {
@@ -186,7 +193,11 @@ async fn classify_response(resp: reqwest::Response) -> WebPushOutcome {
                 retry_after,
             }
         }
-        400 | 403 => WebPushOutcome::BadRequest { status: code },
+        // 400 is "our payload shape is wrong" — encoder bug, not a
+        // per-device problem. Surfaces in attempts for operator
+        // action; the device row stays active so the next publish
+        // succeeds once the bug is fixed.
+        400 => WebPushOutcome::BadRequest { status: code },
         500..=599 => WebPushOutcome::Transient {
             kind: TransientFailure::ServerError { status: code },
         },
@@ -477,6 +488,41 @@ mod tests {
         assert!(matches!(
             outcome,
             WebPushOutcome::BadRequest { status: 400 }
+        ));
+    }
+
+    #[tokio::test]
+    async fn classify_403_is_subscription_gone() {
+        // FCM and other relays return 403 to signal "VAPID key not
+        // authorized for this endpoint" — the subscription needs a
+        // fresh registration. Treated as per-device permanent so the
+        // worker disables the row instead of looping retries.
+        let server = mockito::Server::new_async().await;
+        let mut server = server;
+        let m = server
+            .mock("POST", "/p/forbidden")
+            .with_status(403)
+            .create_async()
+            .await;
+        let url = Url::parse(&format!("{}/p/forbidden", server.url())).unwrap();
+        let sender = HttpWebPushSender::new();
+        let jwt = dummy_jwt();
+        let p = payload();
+        let outcome = sender
+            .send(WebPushRequest {
+                endpoint: &url,
+                payload: &p,
+                vapid_jwt: &jwt,
+                vapid_public_key_b64u: "BFoo",
+                topic: None,
+                ttl: 60,
+                urgency: Urgency::Normal,
+            })
+            .await;
+        m.assert_async().await;
+        assert!(matches!(
+            outcome,
+            WebPushOutcome::SubscriptionGone { status: 403 }
         ));
     }
 

--- a/server/crates/waddle-xmpp/src/push/sender.rs
+++ b/server/crates/waddle-xmpp/src/push/sender.rs
@@ -186,31 +186,58 @@ async fn classify_response(resp: reqwest::Response) -> WebPushOutcome {
     let status = resp.status();
     let code = status.as_u16();
     if status.is_success() {
+        // Drain the body before returning so reqwest's underlying
+        // hyper connection can be returned to the pool — without
+        // this the next per-host send opens a fresh connection.
+        let _ = resp.bytes().await;
         debug!(status = %status, "Web Push delivered");
         return WebPushOutcome::Delivered { status: code };
     }
+    // Snapshot headers used by classification BEFORE draining the
+    // body (which consumes `resp`).
+    let retry_after = resp
+        .headers()
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|v| v.to_str().ok())
+        .and_then(parse_retry_after);
+    let www_authenticate = resp
+        .headers()
+        .get(reqwest::header::WWW_AUTHENTICATE)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_ascii_lowercase());
+    // Drain the body to allow connection reuse. Capping wouldn't
+    // help here — reqwest buffers the whole body anyway; the goal
+    // is to consume it before we return.
+    let _ = resp.bytes().await;
     match code {
         // 404 / 410 are the textbook "subscription gone" signals
-        // (RFC 8030 §6). 403 is added here because FCM and other
-        // relays use 403 to signal "the VAPID key is not authorized
-        // for this endpoint" — the actionable response is identical
-        // (the subscription must be re-registered with fresh keys),
-        // so the publish-job worker treats it as a device-side
-        // permanent failure and disables the row.
-        403 | 404 | 410 => WebPushOutcome::SubscriptionGone { status: code },
-        401 => WebPushOutcome::ClockSkew { status: code },
-        413 => WebPushOutcome::PayloadTooLarge { status: code },
-        429 => {
-            let retry_after = resp
-                .headers()
-                .get(reqwest::header::RETRY_AFTER)
-                .and_then(|v| v.to_str().ok())
-                .and_then(parse_retry_after);
-            WebPushOutcome::RateLimited {
-                status: code,
-                retry_after,
-            }
+        // (RFC 8030 §6). 403 is NOT folded in: while FCM does use 403
+        // for "VAPID key not authorized for this endpoint", it also
+        // uses it for cluster-wide VAPID rejection (wrong `aud`,
+        // expired `exp` past the relay's tolerance, malformed JWT)
+        // which is a deployment bug affecting ALL devices, not a
+        // per-device subscription expiry. Routing every 403 to
+        // SubscriptionGone would mass-disable devices on a
+        // configuration error. Keep 403 as `BadRequest` (permanent,
+        // non-disabling) so the failure surfaces in the operator
+        // audit without bricking the user base.
+        404 | 410 => WebPushOutcome::SubscriptionGone { status: code },
+        // 401 means "VAPID JWT rejected" per RFC 8292 §3. The most
+        // common cause is clock skew (relay rejects our `exp`); we
+        // only label it `ClockSkew` when the relay echoes a vapid
+        // scheme in `WWW-Authenticate` (RFC 7235 §4.1), the canonical
+        // signal that the JWT itself was at fault. Otherwise treat as
+        // a generic permanent auth failure to avoid invalidating the
+        // JWT cache on unrelated 401 conditions.
+        401 if matches!(&www_authenticate, Some(v) if v.contains("vapid")) => {
+            WebPushOutcome::ClockSkew { status: code }
         }
+        401 | 403 => WebPushOutcome::BadRequest { status: code },
+        413 => WebPushOutcome::PayloadTooLarge { status: code },
+        429 => WebPushOutcome::RateLimited {
+            status: code,
+            retry_after,
+        },
         // 400 is "our payload shape is wrong" — encoder bug, not a
         // per-device problem. Surfaces in attempts for operator
         // action; the device row stays active so the next publish
@@ -366,7 +393,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn classify_401_is_clock_skew() {
+    async fn classify_401_with_vapid_www_authenticate_is_clock_skew() {
+        // 401 + `WWW-Authenticate: vapid` is the RFC 8292 §3 signal
+        // that the JWT itself was rejected — clock skew or expired
+        // exp. Worker invalidates the JWT cache on this outcome.
         let server = mockito::Server::new_async().await;
         let mut server = server;
         let m = server
@@ -392,6 +422,41 @@ mod tests {
             .await;
         m.assert_async().await;
         assert!(matches!(outcome, WebPushOutcome::ClockSkew { status: 401 }));
+    }
+
+    #[tokio::test]
+    async fn classify_401_without_vapid_www_authenticate_is_bad_request() {
+        // Generic 401 without the vapid challenge — could be relay
+        // misconfig or rate-limit-style auth gate. Do NOT invalidate
+        // the JWT cache; classify as BadRequest so the operator audit
+        // surfaces the cause without thrashing the cache.
+        let server = mockito::Server::new_async().await;
+        let mut server = server;
+        let m = server
+            .mock("POST", "/p/y")
+            .with_status(401)
+            .create_async()
+            .await;
+        let url = Url::parse(&format!("{}/p/y", server.url())).unwrap();
+        let sender = HttpWebPushSender::new();
+        let jwt = dummy_jwt();
+        let p = payload();
+        let outcome = sender
+            .send(WebPushRequest {
+                endpoint: &url,
+                payload: &p,
+                vapid_jwt: &jwt,
+                vapid_public_key_b64u: "BFoo",
+                topic: None,
+                ttl: 60,
+                urgency: Urgency::Normal,
+            })
+            .await;
+        m.assert_async().await;
+        assert!(matches!(
+            outcome,
+            WebPushOutcome::BadRequest { status: 401 }
+        ));
     }
 
     #[tokio::test]
@@ -527,11 +592,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn classify_403_is_subscription_gone() {
-        // FCM and other relays return 403 to signal "VAPID key not
-        // authorized for this endpoint" — the subscription needs a
-        // fresh registration. Treated as per-device permanent so the
-        // worker disables the row instead of looping retries.
+    async fn classify_403_is_bad_request_not_subscription_gone() {
+        // 403 is overloaded by real relays: it covers "VAPID key not
+        // authorized for this endpoint" (per-device) AND cluster-wide
+        // JWT rejection (wrong aud / expired exp / malformed JWT)
+        // which is a deployment bug affecting all devices. Routing
+        // every 403 to SubscriptionGone would mass-disable on a
+        // config error. Classify as BadRequest (permanent, non-
+        // disabling) so the failure surfaces in the operator audit
+        // without bricking the user base.
         let server = mockito::Server::new_async().await;
         let mut server = server;
         let m = server
@@ -557,7 +626,7 @@ mod tests {
         m.assert_async().await;
         assert!(matches!(
             outcome,
-            WebPushOutcome::SubscriptionGone { status: 403 }
+            WebPushOutcome::BadRequest { status: 403 }
         ));
     }
 

--- a/server/crates/waddle-xmpp/src/push/sender.rs
+++ b/server/crates/waddle-xmpp/src/push/sender.rs
@@ -16,7 +16,9 @@ use reqwest::header::{HeaderName, HeaderValue, AUTHORIZATION, CONTENT_ENCODING, 
 use tracing::{debug, warn};
 use url::Url;
 
-use super::types::{EncryptedPayload, PushTopic, TransientFailure, VapidJwt, WebPushOutcome};
+use super::types::{
+    EncryptedPayload, EndpointHash, PushTopic, TransientFailure, VapidJwt, WebPushOutcome,
+};
 
 /// RFC 8030 `Urgency` header values (§5.3). Carried as a typed enum so
 /// callers can't accidentally emit unknown values.
@@ -121,8 +123,13 @@ impl WebPushSender for HttpWebPushSender {
         let auth_header = match HeaderValue::from_str(&auth_value) {
             Ok(v) => v,
             Err(_) => {
+                // Log only the truncated endpoint hash — the full
+                // endpoint URL is a per-device bearer identifier;
+                // anyone with log access could otherwise replay-send
+                // to it.
                 warn!(
-                    endpoint = %endpoint,
+                    endpoint_hash = %EndpointHash::of(endpoint.as_str()),
+                    origin = endpoint.origin().ascii_serialization(),
                     "VAPID Authorization header is not a valid ASCII HTTP header value",
                 );
                 return Box::pin(async move { WebPushOutcome::BadRequest { status: 0 } });
@@ -188,13 +195,15 @@ async fn classify_response(resp: reqwest::Response) -> WebPushOutcome {
 }
 
 fn classify_transport_error(endpoint: &Url, err: reqwest::Error) -> WebPushOutcome {
+    let endpoint_hash = EndpointHash::of(endpoint.as_str());
+    let origin = endpoint.origin().ascii_serialization();
     if err.is_timeout() {
-        warn!(endpoint = %endpoint, error = %err, "Web Push timeout");
+        warn!(endpoint_hash = %endpoint_hash, origin = origin, error = %err, "Web Push timeout");
         WebPushOutcome::Transient {
             kind: TransientFailure::Timeout,
         }
     } else {
-        warn!(endpoint = %endpoint, error = %err, "Web Push transport failure");
+        warn!(endpoint_hash = %endpoint_hash, origin = origin, error = %err, "Web Push transport failure");
         WebPushOutcome::Transient {
             kind: TransientFailure::Network,
         }

--- a/server/crates/waddle-xmpp/src/push/sender.rs
+++ b/server/crates/waddle-xmpp/src/push/sender.rs
@@ -113,6 +113,24 @@ impl WebPushSender for HttpWebPushSender {
         // bug in the caller's `vapid_public_key_b64u`, surfaced as
         // `BadRequest` rather than a panic.
         let endpoint = request.endpoint.clone();
+        // Defense-in-depth: registration-time validation already
+        // rejects non-https endpoints, but if a future caller bypasses
+        // that path the sender refuses to send a VAPID-signed
+        // `Authorization` header over a plaintext scheme. Loopback
+        // is allowed so mockito-based test fixtures (which serve
+        // `http://127.0.0.1:<port>/`) keep working — registration-time
+        // validation rejects literal IPs in production anyway, so a
+        // non-loopback http URL cannot reach here in a real
+        // deployment.
+        if endpoint.scheme() != "https" && !endpoint_is_loopback(&endpoint) {
+            warn!(
+                endpoint_hash = %EndpointHash::of(endpoint.as_str()),
+                origin = endpoint.origin().ascii_serialization(),
+                scheme = endpoint.scheme(),
+                "Web Push refused: endpoint is not https",
+            );
+            return Box::pin(async move { WebPushOutcome::BadRequest { status: 0 } });
+        }
         let body = request.payload.as_slice().to_vec();
 
         let auth_value = format!(
@@ -218,6 +236,23 @@ fn classify_transport_error(endpoint: &Url, err: reqwest::Error) -> WebPushOutco
         WebPushOutcome::Transient {
             kind: TransientFailure::Network,
         }
+    }
+}
+
+/// Is the endpoint host a loopback address? Used by the HTTPS scheme
+/// guard to permit mockito-based test fixtures (which serve
+/// `http://127.0.0.1:<port>/`) without weakening production security:
+/// real deployments never reach a literal IP here because
+/// registration-time validation rejects them.
+fn endpoint_is_loopback(endpoint: &Url) -> bool {
+    match endpoint.host() {
+        Some(url::Host::Ipv4(addr)) => addr.is_loopback(),
+        Some(url::Host::Ipv6(addr)) => addr.is_loopback(),
+        Some(url::Host::Domain(name)) => {
+            let lower = name.to_ascii_lowercase();
+            lower == "localhost" || lower.ends_with(".localhost")
+        }
+        None => false,
     }
 }
 

--- a/server/crates/waddle-xmpp/src/push/sender.rs
+++ b/server/crates/waddle-xmpp/src/push/sender.rs
@@ -20,7 +20,7 @@ use super::types::{EncryptedPayload, PushTopic, TransientFailure, VapidJwt, WebP
 
 /// RFC 8030 `Urgency` header values (§5.3). Carried as a typed enum so
 /// callers can't accidentally emit unknown values.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Urgency {
     VeryLow,
     Low,

--- a/server/crates/waddle-xmpp/src/push/sender.rs
+++ b/server/crates/waddle-xmpp/src/push/sender.rs
@@ -185,14 +185,45 @@ impl WebPushSender for HttpWebPushSender {
     }
 }
 
+/// Upper bound on the bytes the sender reads from a relay response
+/// body before giving up on connection reuse. Web Push relay error
+/// bodies are tiny (a few hundred bytes max — FCM/Mozilla autopush
+/// return JSON of `{"error":"…"}` shape); 32 KiB is generous headroom
+/// for a typical body while bounding the memory an attacker-controlled
+/// relay can force us to allocate to drain its response.
+const MAX_DRAIN_BYTES: usize = 32 * 1024;
+
+/// Drain a response body up to [`MAX_DRAIN_BYTES`] so the underlying
+/// hyper connection can be returned to the pool. Bounded so an
+/// attacker-controlled relay cannot OOM us by streaming an arbitrarily
+/// large response body. Two early-out paths:
+///
+/// 1. `Content-Length > MAX_DRAIN_BYTES` — drop the response without
+///    draining (sacrifices connection reuse for this single response;
+///    the next send opens a fresh connection).
+/// 2. Cumulative chunks exceed `MAX_DRAIN_BYTES` mid-stream — stop
+///    reading and let `resp` drop on the way out of the function;
+///    reqwest will close the connection rather than reuse it.
+async fn drain_body_bounded(mut resp: reqwest::Response) {
+    if let Some(len) = resp.content_length() {
+        if len > MAX_DRAIN_BYTES as u64 {
+            return;
+        }
+    }
+    let mut total = 0usize;
+    while let Ok(Some(chunk)) = resp.chunk().await {
+        total = total.saturating_add(chunk.len());
+        if total > MAX_DRAIN_BYTES {
+            return;
+        }
+    }
+}
+
 async fn classify_response(resp: reqwest::Response) -> WebPushOutcome {
     let status = resp.status();
     let code = status.as_u16();
     if status.is_success() {
-        // Drain the body before returning so reqwest's underlying
-        // hyper connection can be returned to the pool — without
-        // this the next per-host send opens a fresh connection.
-        let _ = resp.bytes().await;
+        drain_body_bounded(resp).await;
         debug!(status = %status, "Web Push delivered");
         return WebPushOutcome::Delivered { status: code };
     }
@@ -208,10 +239,7 @@ async fn classify_response(resp: reqwest::Response) -> WebPushOutcome {
         .get(reqwest::header::WWW_AUTHENTICATE)
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_ascii_lowercase());
-    // Drain the body to allow connection reuse. Capping wouldn't
-    // help here — reqwest buffers the whole body anyway; the goal
-    // is to consume it before we return.
-    let _ = resp.bytes().await;
+    drain_body_bounded(resp).await;
     match code {
         // 404 / 410 are the textbook "subscription gone" signals
         // (RFC 8030 §6). 403 is NOT folded in: while FCM does use 403
@@ -625,6 +653,50 @@ mod tests {
             })
             .await;
         assert!(matches!(outcome, WebPushOutcome::BadRequest { status: 0 }));
+    }
+
+    #[tokio::test]
+    async fn drain_body_bounded_handles_large_response_without_panic() {
+        // Relay returns a body larger than `MAX_DRAIN_BYTES`. The
+        // sender must classify the response without OOMing or
+        // panicking — `drain_body_bounded` bails on either the
+        // Content-Length fast path or the cumulative-chunk path.
+        // Either way the outcome is correctly classified from the
+        // status code.
+        let server = mockito::Server::new_async().await;
+        let mut server = server;
+        let big_body = vec![b'A'; MAX_DRAIN_BYTES * 2]; // 64 KiB
+        let m = server
+            .mock("POST", "/p/big")
+            .with_status(500)
+            .with_header("content-type", "text/plain")
+            .with_body(big_body)
+            .create_async()
+            .await;
+        let url = Url::parse(&format!("{}/p/big", server.url())).unwrap();
+        let sender = HttpWebPushSender::new();
+        let jwt = dummy_jwt();
+        let p = payload();
+        let outcome = sender
+            .send(WebPushRequest {
+                endpoint: &url,
+                payload: &p,
+                vapid_jwt: &jwt,
+                vapid_public_key_b64u: "BFoo",
+                topic: None,
+                ttl: 60,
+                urgency: Urgency::Normal,
+            })
+            .await;
+        m.assert_async().await;
+        // 5xx → Transient::ServerError. The body was too large for
+        // full drain, but classification proceeded from headers/status.
+        assert!(matches!(
+            outcome,
+            WebPushOutcome::Transient {
+                kind: TransientFailure::ServerError { status: 500 }
+            }
+        ));
     }
 
     #[tokio::test]

--- a/server/crates/waddle-xmpp/src/push/sender.rs
+++ b/server/crates/waddle-xmpp/src/push/sender.rs
@@ -1,40 +1,94 @@
-//! Web Push notification sender.
+//! RFC 8030 Web Push HTTP transport.
+//!
+//! The sender is intentionally narrow: it accepts a fully prepared
+//! [`WebPushRequest`] (encrypted body, signed VAPID JWT, public-key
+//! base64url, topic/TTL/urgency) and returns a typed
+//! [`WebPushOutcome`]. Encryption and JWT signing live in
+//! `super::encrypt` and `super::vapid` respectively — keeping the
+//! transport free of crypto state means the publish-job worker can sign
+//! once per `(kid, aud, sub)` and reuse the JWT across many devices.
 
 use std::future::Future;
 use std::pin::Pin;
+use std::time::Duration;
 
+use reqwest::header::{HeaderName, HeaderValue, AUTHORIZATION, CONTENT_ENCODING, CONTENT_TYPE};
 use tracing::{debug, warn};
+use url::Url;
 
-use super::store::PushSubscriptionStore;
-use super::{PushError, PushSubscription};
+use super::types::{EncryptedPayload, PushTopic, TransientFailure, VapidJwt, WebPushOutcome};
 
-/// Trait for sending Web Push notifications.
-pub trait WebPushSender: Send + Sync + 'static {
-    /// Send a push notification to the given subscription.
-    fn send_notification(
-        &self,
-        subscription: &PushSubscription,
-        title: &str,
-        body: &str,
-        room_jid: &str,
-        unread_count: u64,
-    ) -> Pin<Box<dyn Future<Output = Result<(), PushError>> + Send + '_>>;
+/// RFC 8030 `Urgency` header values (§5.3). Carried as a typed enum so
+/// callers can't accidentally emit unknown values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Urgency {
+    VeryLow,
+    Low,
+    Normal,
+    High,
 }
 
-/// HTTP-based Web Push sender that POSTs JSON to a push relay/gateway.
+impl Urgency {
+    fn as_header(self) -> &'static str {
+        match self {
+            Urgency::VeryLow => "very-low",
+            Urgency::Low => "low",
+            Urgency::Normal => "normal",
+            Urgency::High => "high",
+        }
+    }
+}
+
+/// All inputs needed to make one RFC 8030 POST. Borrowed so callers can
+/// reuse a [`VapidJwt`] across the fan-out without cloning per device.
+pub struct WebPushRequest<'a> {
+    pub endpoint: &'a Url,
+    pub payload: &'a EncryptedPayload,
+    pub vapid_jwt: &'a VapidJwt,
+    /// RFC 8292 `k=` value: uncompressed P-256 public key, base64url
+    /// no-pad. Produced once at boot via
+    /// `super::vapid::vapid_k_header`.
+    pub vapid_public_key_b64u: &'a str,
+    pub topic: Option<&'a PushTopic>,
+    pub ttl: u32,
+    pub urgency: Urgency,
+}
+
+/// Transport-layer Web Push sender.
+///
+/// Implementors translate [`WebPushRequest`] → typed
+/// [`WebPushOutcome`]; they MUST NOT return `Result` because every
+/// failure mode is a `WebPushOutcome` variant. This keeps the
+/// publish-job worker's match arms exhaustive.
+pub trait WebPushSender: Send + Sync + 'static {
+    fn send(
+        &self,
+        request: WebPushRequest<'_>,
+    ) -> Pin<Box<dyn Future<Output = WebPushOutcome> + Send + '_>>;
+}
+
+const TTL_HEADER: HeaderName = HeaderName::from_static("ttl");
+const URGENCY_HEADER: HeaderName = HeaderName::from_static("urgency");
+const TOPIC_HEADER: HeaderName = HeaderName::from_static("topic");
+const AES128GCM: &str = "aes128gcm";
+const OCTET_STREAM: &str = "application/octet-stream";
+
 #[derive(Debug, Clone)]
 pub struct HttpWebPushSender {
     client: reqwest::Client,
 }
 
 impl HttpWebPushSender {
-    /// Create a new HTTP Web Push sender with a 10-second request timeout.
     pub fn new() -> Self {
         let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(10))
+            .timeout(Duration::from_secs(10))
             .redirect(reqwest::redirect::Policy::none())
             .build()
             .expect("failed to build HTTP Web Push client");
+        Self { client }
+    }
+
+    pub fn with_client(client: reqwest::Client) -> Self {
         Self { client }
     }
 }
@@ -46,245 +100,412 @@ impl Default for HttpWebPushSender {
 }
 
 impl WebPushSender for HttpWebPushSender {
-    fn send_notification(
+    fn send(
         &self,
-        subscription: &PushSubscription,
-        title: &str,
-        body: &str,
-        room_jid: &str,
-        unread_count: u64,
-    ) -> Pin<Box<dyn Future<Output = Result<(), PushError>> + Send + '_>> {
-        let endpoint = subscription.endpoint.clone();
-        // This sender targets an application relay/gateway endpoint. The relay is
-        // responsible for performing standards-compliant Web Push (VAPID/encryption)
-        // using the subscription keys supplied below.
-        let payload = relay_payload(subscription, title, body, room_jid, unread_count);
+        request: WebPushRequest<'_>,
+    ) -> Pin<Box<dyn Future<Output = WebPushOutcome> + Send + '_>> {
+        // Build the request synchronously so the spawned future owns
+        // nothing borrowed from the caller. Authorization is the only
+        // header that can fail to construct (length / invisible-char
+        // rejection in `HeaderValue::from_str`); a failure there is a
+        // bug in the caller's `vapid_public_key_b64u`, surfaced as
+        // `BadRequest` rather than a panic.
+        let endpoint = request.endpoint.clone();
+        let body = request.payload.as_slice().to_vec();
+
+        let auth_value = format!(
+            "vapid t={}, k={}",
+            request.vapid_jwt.as_str(),
+            request.vapid_public_key_b64u,
+        );
+        let auth_header = match HeaderValue::from_str(&auth_value) {
+            Ok(v) => v,
+            Err(_) => {
+                warn!(
+                    endpoint = %endpoint,
+                    "VAPID Authorization header is not a valid ASCII HTTP header value",
+                );
+                return Box::pin(async move { WebPushOutcome::BadRequest { status: 0 } });
+            }
+        };
+
+        let topic_value = request
+            .topic
+            .and_then(|t| HeaderValue::from_str(t.as_str()).ok());
+        let ttl_value = HeaderValue::from(request.ttl);
+        let urgency_value = HeaderValue::from_static(request.urgency.as_header());
+
+        let mut builder = self
+            .client
+            .post(endpoint.clone())
+            .header(AUTHORIZATION, auth_header)
+            .header(CONTENT_TYPE, OCTET_STREAM)
+            .header(CONTENT_ENCODING, AES128GCM)
+            .header(TTL_HEADER, ttl_value)
+            .header(URGENCY_HEADER, urgency_value)
+            .body(body);
+        if let Some(topic) = topic_value {
+            builder = builder.header(TOPIC_HEADER, topic);
+        }
+
         Box::pin(async move {
-            let ep = endpoint.as_deref().ok_or(PushError::MissingEndpoint)?;
-            match self.client.post(ep).json(&payload).send().await {
-                Ok(resp) if resp.status().is_success() => {
-                    debug!(endpoint = %ep, "Push notification delivered");
-                    Ok(())
-                }
-                Ok(resp) => {
-                    let status = resp.status();
-                    warn!(endpoint = %ep, status = %status, "Push rejected");
-                    Err(PushError::SendFailed(format!("HTTP {}", status)))
-                }
-                Err(e) => {
-                    warn!(endpoint = %ep, error = %e, "Push delivery failed");
-                    Err(PushError::HttpError(e.to_string()))
-                }
+            match builder.send().await {
+                Ok(resp) => classify_response(resp).await,
+                Err(err) => classify_transport_error(&endpoint, err),
             }
         })
     }
 }
 
-fn room_jid_to_path(room_jid: &str) -> String {
-    let localpart = room_jid.split('@').next().unwrap_or_default();
-    if let Some(channel_id) = crate::parse_managed_room_localpart(localpart) {
-        return format!("/{}", channel_id);
+async fn classify_response(resp: reqwest::Response) -> WebPushOutcome {
+    let status = resp.status();
+    let code = status.as_u16();
+    if status.is_success() {
+        debug!(status = %status, "Web Push delivered");
+        return WebPushOutcome::Delivered { status: code };
     }
-    "/".to_string()
-}
-
-/// Send push notifications for mentioned users.
-pub async fn notify_mentioned_users<S, W>(
-    store: &S,
-    sender: &W,
-    mentioned_jids: &[String],
-    sender_nick: &str,
-    body: &str,
-    room_jid: &str,
-    unread_count: u64,
-) where
-    S: PushSubscriptionStore + ?Sized,
-    W: WebPushSender + ?Sized,
-{
-    for jid in mentioned_jids {
-        let subs = match store.get_for_user(jid).await {
-            Ok(s) => s,
-            Err(e) => {
-                debug!(user_jid = %jid, error = %e, "Failed to get push subs");
-                continue;
-            }
-        };
-        if subs.is_empty() {
-            continue;
-        }
-        let title = format!("@{} mentioned you", sender_nick);
-        let preview = if body.len() > 100 {
-            let end = body.char_indices().nth(100).map_or(body.len(), |(i, _)| i);
-            format!("{}...", &body[..end])
-        } else {
-            body.to_string()
-        };
-        for sub in &subs {
-            if let Err(e) = sender
-                .send_notification(sub, &title, &preview, room_jid, unread_count)
-                .await
-            {
-                debug!(user_jid = %jid, error = %e, "Push notification failed");
+    match code {
+        404 | 410 => WebPushOutcome::SubscriptionGone { status: code },
+        401 => WebPushOutcome::ClockSkew { status: code },
+        413 => WebPushOutcome::PayloadTooLarge { status: code },
+        429 => {
+            let retry_after = resp
+                .headers()
+                .get(reqwest::header::RETRY_AFTER)
+                .and_then(|v| v.to_str().ok())
+                .and_then(parse_retry_after);
+            WebPushOutcome::RateLimited {
+                status: code,
+                retry_after,
             }
         }
-    }
-}
-
-fn relay_payload(
-    subscription: &PushSubscription,
-    title: &str,
-    body: &str,
-    room_jid: &str,
-    unread_count: u64,
-) -> serde_json::Value {
-    serde_json::json!({
-        "title": title,
-        "body": body,
-        "roomJid": room_jid,
-        "url": room_jid_to_path(room_jid),
-        "message-count": unread_count,
-        // Typed routing context for the chat service worker
-        // (#528). Mirrors the `<context xmlns='urn:waddle:push:context:0'/>`
-        // element emitted on the XEP-0357 outbox path. The legacy
-        // relay path here doesn't have thread/class on hand, so the
-        // SW falls through to domain-prefix MUC detection.
-        "context": {
-            "conversation": room_jid,
+        400 | 403 => WebPushOutcome::BadRequest { status: code },
+        500..=599 => WebPushOutcome::Transient {
+            kind: TransientFailure::ServerError { status: code },
         },
-        "endpoint": subscription.endpoint.as_deref(),
-        "p256dh": subscription.p256dh.as_deref(),
-        "auth": subscription.auth_key.as_deref(),
-    })
+        _ => WebPushOutcome::BadRequest { status: code },
+    }
+}
+
+fn classify_transport_error(endpoint: &Url, err: reqwest::Error) -> WebPushOutcome {
+    if err.is_timeout() {
+        warn!(endpoint = %endpoint, error = %err, "Web Push timeout");
+        WebPushOutcome::Transient {
+            kind: TransientFailure::Timeout,
+        }
+    } else {
+        warn!(endpoint = %endpoint, error = %err, "Web Push transport failure");
+        WebPushOutcome::Transient {
+            kind: TransientFailure::Network,
+        }
+    }
+}
+
+/// RFC 7231 §7.1.3 `Retry-After` is either a delta-seconds or an
+/// HTTP-date. Only the delta-seconds form is honored — HTTP-date
+/// parsing would pull in another dep for a value the publish-job
+/// worker already clamps against `next_retry_at_ms` policy.
+fn parse_retry_after(value: &str) -> Option<Duration> {
+    value.trim().parse::<u64>().ok().map(Duration::from_secs)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::super::store::InMemoryPushStore;
     use super::*;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use crate::push::types::{AuthSecret, EncryptedPayload, PushTopic, VapidJwt};
+    use std::sync::Arc;
 
-    struct MockSender(AtomicUsize);
-    impl MockSender {
-        fn new() -> Self {
-            Self(AtomicUsize::new(0))
-        }
-        fn count(&self) -> usize {
-            self.0.load(Ordering::SeqCst)
-        }
+    fn dummy_jwt() -> VapidJwt {
+        // Three-segment ASCII string; jsonwebtoken doesn't validate here.
+        VapidJwt::new("eyJhbGciOiJFUzI1NiJ9.eyJhdWQiOiJodHRwczovL2V4Lm9yZyJ9.sig").expect("jwt")
     }
-    impl WebPushSender for MockSender {
-        fn send_notification(
-            &self,
-            _: &PushSubscription,
-            _: &str,
-            _: &str,
-            _: &str,
-            _: u64,
-        ) -> Pin<Box<dyn Future<Output = Result<(), PushError>> + Send + '_>> {
-            self.0.fetch_add(1, Ordering::SeqCst);
-            Box::pin(async { Ok(()) })
-        }
+
+    fn _ensure_arc_authsecret_compiles() {
+        // Compile-time guard so this file's tests link against the
+        // typed `AuthSecret` API rather than reaching for a `&[u8]`.
+        let _: Arc<AuthSecret> = Arc::new(AuthSecret::from_bytes([0u8; 16]));
+    }
+
+    fn payload() -> EncryptedPayload {
+        EncryptedPayload::new(vec![0xAB; 32])
+    }
+
+    #[test]
+    fn urgency_header_values() {
+        assert_eq!(Urgency::VeryLow.as_header(), "very-low");
+        assert_eq!(Urgency::Low.as_header(), "low");
+        assert_eq!(Urgency::Normal.as_header(), "normal");
+        assert_eq!(Urgency::High.as_header(), "high");
+    }
+
+    #[test]
+    fn parse_retry_after_seconds() {
+        assert_eq!(parse_retry_after("30"), Some(Duration::from_secs(30)));
+        assert_eq!(parse_retry_after(" 30 "), Some(Duration::from_secs(30)));
+    }
+
+    #[test]
+    fn parse_retry_after_rejects_http_date() {
+        // We only honor delta-seconds; HTTP-date returns None.
+        assert_eq!(parse_retry_after("Fri, 31 Dec 1999 23:59:59 GMT"), None);
     }
 
     #[tokio::test]
-    async fn test_notify_sends_to_subscribed() {
-        let store = InMemoryPushStore::new();
-        store
-            .register(PushSubscription {
-                user_jid: "alice@ex".into(),
-                service_jid: "push.ex".into(),
-                node: Some("n1".into()),
-                publish_options: None,
-                endpoint: Some("https://ep".into()),
-                p256dh: None,
-                auth_key: None,
+    async fn classify_2xx_is_delivered() {
+        let server = mockito::Server::new_async().await;
+        let mut server = server;
+        let m = server
+            .mock("POST", "/p/abc")
+            .with_status(201)
+            .create_async()
+            .await;
+        let url = Url::parse(&format!("{}/p/abc", server.url())).unwrap();
+        let sender = HttpWebPushSender::new();
+        let jwt = dummy_jwt();
+        let p = payload();
+        let topic = PushTopic::new("d-test").ok();
+        let outcome = sender
+            .send(WebPushRequest {
+                endpoint: &url,
+                payload: &p,
+                vapid_jwt: &jwt,
+                vapid_public_key_b64u: "BFoo",
+                topic: topic.as_ref(),
+                ttl: 60,
+                urgency: Urgency::Normal,
             })
-            .await
-            .expect("ok");
-
-        let sender = MockSender::new();
-        notify_mentioned_users(
-            &store,
-            &sender,
-            &["alice@ex".into(), "bob@ex".into()],
-            "charlie",
-            "Hey!",
-            "room@muc",
-            3,
-        )
-        .await;
-        assert_eq!(sender.count(), 1); // only alice has a sub
+            .await;
+        m.assert_async().await;
+        assert!(matches!(outcome, WebPushOutcome::Delivered { status: 201 }));
     }
 
     #[tokio::test]
-    async fn test_notify_no_subs() {
-        let store = InMemoryPushStore::new();
-        let sender = MockSender::new();
-        notify_mentioned_users(
-            &store,
-            &sender,
-            &["alice@ex".into()],
-            "bob",
-            "Hi",
-            "room@muc",
-            0,
-        )
-        .await;
-        assert_eq!(sender.count(), 0);
+    async fn classify_410_is_subscription_gone() {
+        let server = mockito::Server::new_async().await;
+        let mut server = server;
+        let m = server
+            .mock("POST", "/p/x")
+            .with_status(410)
+            .create_async()
+            .await;
+        let url = Url::parse(&format!("{}/p/x", server.url())).unwrap();
+        let sender = HttpWebPushSender::new();
+        let jwt = dummy_jwt();
+        let p = payload();
+        let outcome = sender
+            .send(WebPushRequest {
+                endpoint: &url,
+                payload: &p,
+                vapid_jwt: &jwt,
+                vapid_public_key_b64u: "BFoo",
+                topic: None,
+                ttl: 60,
+                urgency: Urgency::Normal,
+            })
+            .await;
+        m.assert_async().await;
+        assert!(matches!(
+            outcome,
+            WebPushOutcome::SubscriptionGone { status: 410 }
+        ));
     }
 
-    #[test]
-    fn relay_payload_includes_xep_0357_message_count() {
-        let subscription = PushSubscription {
-            user_jid: "alice@ex".into(),
-            service_jid: "push.ex".into(),
-            node: Some("n1".into()),
-            publish_options: None,
-            endpoint: Some("https://ep".into()),
-            p256dh: Some("BASE64KEY".into()),
-            auth_key: Some("BASE64AUTH".into()),
-        };
-        let payload = relay_payload(
-            &subscription,
-            "Waddle",
-            "New message",
-            "c2@conference.example.com",
-            6,
-        );
-
-        assert_eq!(payload["message-count"], 6);
-        assert_eq!(payload["url"], "/c2");
-        assert_eq!(payload["endpoint"], "https://ep");
-        assert_eq!(payload["p256dh"], "BASE64KEY");
-        assert_eq!(payload["auth"], "BASE64AUTH");
+    #[tokio::test]
+    async fn classify_401_is_clock_skew() {
+        let server = mockito::Server::new_async().await;
+        let mut server = server;
+        let m = server
+            .mock("POST", "/p/y")
+            .with_status(401)
+            .with_header("www-authenticate", "vapid")
+            .create_async()
+            .await;
+        let url = Url::parse(&format!("{}/p/y", server.url())).unwrap();
+        let sender = HttpWebPushSender::new();
+        let jwt = dummy_jwt();
+        let p = payload();
+        let outcome = sender
+            .send(WebPushRequest {
+                endpoint: &url,
+                payload: &p,
+                vapid_jwt: &jwt,
+                vapid_public_key_b64u: "BFoo",
+                topic: None,
+                ttl: 60,
+                urgency: Urgency::Normal,
+            })
+            .await;
+        m.assert_async().await;
+        assert!(matches!(outcome, WebPushOutcome::ClockSkew { status: 401 }));
     }
 
-    #[test]
-    fn relay_payload_carries_typed_routing_context_for_chat_sw() {
-        // The chat service worker discriminates DM vs MUC routing via
-        // the typed `context` envelope (#528). The legacy relay path
-        // doesn't have thread/class on hand — verify it at least
-        // surfaces `conversation` so the SW's domain-prefix MUC
-        // fallback has the JID to work with.
-        let subscription = PushSubscription {
-            user_jid: "alice@ex".into(),
-            service_jid: "push.ex".into(),
-            node: Some("n1".into()),
-            publish_options: None,
-            endpoint: Some("https://ep".into()),
-            p256dh: Some("BASE64KEY".into()),
-            auth_key: Some("BASE64AUTH".into()),
-        };
-        let payload = relay_payload(&subscription, "Waddle", "", "c2@conference.example.com", 1);
-        assert_eq!(
-            payload["context"]["conversation"],
-            "c2@conference.example.com"
-        );
+    #[tokio::test]
+    async fn classify_413_is_payload_too_large() {
+        let server = mockito::Server::new_async().await;
+        let mut server = server;
+        let m = server
+            .mock("POST", "/p/z")
+            .with_status(413)
+            .create_async()
+            .await;
+        let url = Url::parse(&format!("{}/p/z", server.url())).unwrap();
+        let sender = HttpWebPushSender::new();
+        let jwt = dummy_jwt();
+        let p = payload();
+        let outcome = sender
+            .send(WebPushRequest {
+                endpoint: &url,
+                payload: &p,
+                vapid_jwt: &jwt,
+                vapid_public_key_b64u: "BFoo",
+                topic: None,
+                ttl: 60,
+                urgency: Urgency::Normal,
+            })
+            .await;
+        m.assert_async().await;
+        assert!(matches!(
+            outcome,
+            WebPushOutcome::PayloadTooLarge { status: 413 }
+        ));
     }
 
-    #[test]
-    fn room_jid_to_path_uses_channel_id() {
-        assert_eq!(room_jid_to_path("c2@conference.example.com"), "/c2");
-        assert_eq!(room_jid_to_path("@conference.example.com"), "/");
+    #[tokio::test]
+    async fn classify_429_carries_retry_after() {
+        let server = mockito::Server::new_async().await;
+        let mut server = server;
+        let m = server
+            .mock("POST", "/p/q")
+            .with_status(429)
+            .with_header("retry-after", "45")
+            .create_async()
+            .await;
+        let url = Url::parse(&format!("{}/p/q", server.url())).unwrap();
+        let sender = HttpWebPushSender::new();
+        let jwt = dummy_jwt();
+        let p = payload();
+        let outcome = sender
+            .send(WebPushRequest {
+                endpoint: &url,
+                payload: &p,
+                vapid_jwt: &jwt,
+                vapid_public_key_b64u: "BFoo",
+                topic: None,
+                ttl: 60,
+                urgency: Urgency::Normal,
+            })
+            .await;
+        m.assert_async().await;
+        match outcome {
+            WebPushOutcome::RateLimited {
+                status: 429,
+                retry_after,
+            } => {
+                assert_eq!(retry_after, Some(Duration::from_secs(45)));
+            }
+            other => panic!("expected RateLimited, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn classify_5xx_is_transient_server_error() {
+        let server = mockito::Server::new_async().await;
+        let mut server = server;
+        let m = server
+            .mock("POST", "/p/s")
+            .with_status(503)
+            .create_async()
+            .await;
+        let url = Url::parse(&format!("{}/p/s", server.url())).unwrap();
+        let sender = HttpWebPushSender::new();
+        let jwt = dummy_jwt();
+        let p = payload();
+        let outcome = sender
+            .send(WebPushRequest {
+                endpoint: &url,
+                payload: &p,
+                vapid_jwt: &jwt,
+                vapid_public_key_b64u: "BFoo",
+                topic: None,
+                ttl: 60,
+                urgency: Urgency::Normal,
+            })
+            .await;
+        m.assert_async().await;
+        assert!(matches!(
+            outcome,
+            WebPushOutcome::Transient {
+                kind: TransientFailure::ServerError { status: 503 }
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn classify_400_is_bad_request() {
+        let server = mockito::Server::new_async().await;
+        let mut server = server;
+        let m = server
+            .mock("POST", "/p/b")
+            .with_status(400)
+            .create_async()
+            .await;
+        let url = Url::parse(&format!("{}/p/b", server.url())).unwrap();
+        let sender = HttpWebPushSender::new();
+        let jwt = dummy_jwt();
+        let p = payload();
+        let outcome = sender
+            .send(WebPushRequest {
+                endpoint: &url,
+                payload: &p,
+                vapid_jwt: &jwt,
+                vapid_public_key_b64u: "BFoo",
+                topic: None,
+                ttl: 60,
+                urgency: Urgency::Normal,
+            })
+            .await;
+        m.assert_async().await;
+        assert!(matches!(
+            outcome,
+            WebPushOutcome::BadRequest { status: 400 }
+        ));
+    }
+
+    #[tokio::test]
+    async fn sends_aes128gcm_headers_and_body() {
+        let server = mockito::Server::new_async().await;
+        let mut server = server;
+        let m = server
+            .mock("POST", "/p/h")
+            .match_header("content-encoding", "aes128gcm")
+            .match_header("content-type", "application/octet-stream")
+            .match_header("ttl", "120")
+            .match_header("urgency", "high")
+            .match_header("topic", "d-fingerprint")
+            .match_header(
+                "authorization",
+                "vapid t=eyJhbGciOiJFUzI1NiJ9.eyJhdWQiOiJodHRwczovL2V4Lm9yZyJ9.sig, k=BFoo",
+            )
+            .with_status(201)
+            .create_async()
+            .await;
+        let url = Url::parse(&format!("{}/p/h", server.url())).unwrap();
+        let sender = HttpWebPushSender::new();
+        let jwt = dummy_jwt();
+        let p = payload();
+        let topic = PushTopic::new("d-fingerprint").expect("topic");
+        let outcome = sender
+            .send(WebPushRequest {
+                endpoint: &url,
+                payload: &p,
+                vapid_jwt: &jwt,
+                vapid_public_key_b64u: "BFoo",
+                topic: Some(&topic),
+                ttl: 120,
+                urgency: Urgency::High,
+            })
+            .await;
+        m.assert_async().await;
+        assert!(matches!(outcome, WebPushOutcome::Delivered { status: 201 }));
     }
 }

--- a/server/crates/waddle-xmpp/src/push/sender.rs
+++ b/server/crates/waddle-xmpp/src/push/sender.rs
@@ -113,16 +113,19 @@ impl WebPushSender for HttpWebPushSender {
         // bug in the caller's `vapid_public_key_b64u`, surfaced as
         // `BadRequest` rather than a panic.
         let endpoint = request.endpoint.clone();
-        // Defense-in-depth: registration-time validation already
-        // rejects non-https endpoints, but if a future caller bypasses
-        // that path the sender refuses to send a VAPID-signed
-        // `Authorization` header over a plaintext scheme. Loopback
-        // is allowed so mockito-based test fixtures (which serve
-        // `http://127.0.0.1:<port>/`) keep working — registration-time
-        // validation rejects literal IPs in production anyway, so a
-        // non-loopback http URL cannot reach here in a real
-        // deployment.
-        if endpoint.scheme() != "https" && !endpoint_is_loopback(&endpoint) {
+        // Strict HTTPS-only invariant on the production code path.
+        // Registration-time validation already rejects non-https
+        // endpoints; the sender re-checks at send time so a future
+        // caller bypassing `WebPushTarget::try_from_sealed`, a
+        // legacy stored endpoint, or any other reach-through can
+        // never POST a VAPID-signed `Authorization` header over a
+        // plaintext scheme. No carve-outs in production builds — the
+        // `cfg(test)` exception below is the ONLY way an in-process
+        // mockito test fixture (which serves `http://127.0.0.1:<port>/`)
+        // reaches the sender, and it never compiles into a release
+        // binary.
+        let scheme_ok = endpoint.scheme() == "https" || allow_non_https_for_test(&endpoint);
+        if !scheme_ok {
             warn!(
                 endpoint_hash = %EndpointHash::of(endpoint.as_str()),
                 origin = endpoint.origin().ascii_serialization(),
@@ -266,12 +269,19 @@ fn classify_transport_error(endpoint: &Url, err: reqwest::Error) -> WebPushOutco
     }
 }
 
-/// Is the endpoint host a loopback address? Used by the HTTPS scheme
-/// guard to permit mockito-based test fixtures (which serve
-/// `http://127.0.0.1:<port>/`) without weakening production security:
-/// real deployments never reach a literal IP here because
-/// registration-time validation rejects them.
-fn endpoint_is_loopback(endpoint: &Url) -> bool {
+/// Whether the HTTPS-only invariant accepts this endpoint. Production
+/// builds (`cfg(not(test))`) ALWAYS return false — there is no
+/// carve-out, no loopback exception, no environment override. The
+/// `cfg(test)` build permits loopback hosts so mockito test fixtures
+/// (which serve `http://127.0.0.1:<port>/`) can exercise the
+/// classifier; this branch never compiles into a release binary.
+#[cfg(not(test))]
+fn allow_non_https_for_test(_endpoint: &Url) -> bool {
+    false
+}
+
+#[cfg(test)]
+fn allow_non_https_for_test(endpoint: &Url) -> bool {
     match endpoint.host() {
         Some(url::Host::Ipv4(addr)) => addr.is_loopback(),
         Some(url::Host::Ipv6(addr)) => addr.is_loopback(),
@@ -558,6 +568,63 @@ mod tests {
                 kind: TransientFailure::ServerError { status: 503 }
             }
         ));
+    }
+
+    #[test]
+    fn allow_non_https_for_test_is_false_for_real_relay_hosts() {
+        // Compile-time guard: the test-only carve-out for
+        // `http://` MUST NOT match any host that could appear in
+        // production. Verifies the cfg(test) implementation only
+        // recognizes loopback. If someone adds a non-loopback case
+        // to the cfg(test) branch (e.g., `example.com`), this test
+        // fails and forces a re-think.
+        let urls = [
+            "http://push.example.com/abc",
+            "http://fcm.googleapis.com/fcm/send/abc",
+            "http://updates.push.services.mozilla.com/wpush/v1/abc",
+        ];
+        for raw in urls {
+            let u = Url::parse(raw).unwrap();
+            assert!(
+                !allow_non_https_for_test(&u),
+                "{raw} must not be accepted by the test carve-out"
+            );
+        }
+        // Loopback IS accepted, since mockito fixtures need it.
+        for raw in [
+            "http://127.0.0.1:1234/abc",
+            "http://[::1]:1234/abc",
+            "http://localhost:1234/abc",
+        ] {
+            let u = Url::parse(raw).unwrap();
+            assert!(
+                allow_non_https_for_test(&u),
+                "{raw} must be accepted in cfg(test)"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn refuses_non_https_non_loopback_endpoint() {
+        // Production-shaped non-https URL: the strict invariant must
+        // reject it even in cfg(test) builds (the carve-out only
+        // matches loopback).
+        let url = Url::parse("http://push.example.com/abc").unwrap();
+        let sender = HttpWebPushSender::new();
+        let jwt = dummy_jwt();
+        let p = payload();
+        let outcome = sender
+            .send(WebPushRequest {
+                endpoint: &url,
+                payload: &p,
+                vapid_jwt: &jwt,
+                vapid_public_key_b64u: "BFoo",
+                topic: None,
+                ttl: 60,
+                urgency: Urgency::Normal,
+            })
+            .await;
+        assert!(matches!(outcome, WebPushOutcome::BadRequest { status: 0 }));
     }
 
     #[tokio::test]

--- a/server/crates/waddle-xmpp/src/push/store.rs
+++ b/server/crates/waddle-xmpp/src/push/store.rs
@@ -2,8 +2,10 @@
 
 use std::future::Future;
 use std::pin::Pin;
+#[cfg(any(test, feature = "test-utils"))]
 use std::sync::Arc;
 
+#[cfg(any(test, feature = "test-utils"))]
 use dashmap::DashMap;
 
 use super::{PushError, PushSubscription};
@@ -29,18 +31,22 @@ pub trait PushSubscriptionStore: Send + Sync + 'static {
     ) -> Pin<Box<dyn Future<Output = Result<Vec<PushSubscription>, PushError>> + Send + '_>>;
 }
 
-/// In-memory push subscription store backed by [`DashMap`].
+/// In-memory push subscription store backed by [`DashMap`]. Test-only:
+/// production code must use a durable `PushSubscriptionStore` impl.
+#[cfg(any(test, feature = "test-utils"))]
 #[derive(Debug, Clone)]
 pub struct InMemoryPushStore {
     subs: Arc<DashMap<String, Vec<PushSubscription>>>,
 }
 
+#[cfg(any(test, feature = "test-utils"))]
 impl Default for InMemoryPushStore {
     fn default() -> Self {
         Self::new()
     }
 }
 
+#[cfg(any(test, feature = "test-utils"))]
 impl InMemoryPushStore {
     /// Create a new empty in-memory push store.
     pub fn new() -> Self {
@@ -50,6 +56,7 @@ impl InMemoryPushStore {
     }
 }
 
+#[cfg(any(test, feature = "test-utils"))]
 impl PushSubscriptionStore for InMemoryPushStore {
     fn register(
         &self,

--- a/server/crates/waddle-xmpp/src/push/types.rs
+++ b/server/crates/waddle-xmpp/src/push/types.rs
@@ -262,9 +262,20 @@ impl EncryptedPayload {
     }
     // `into_inner` is intentionally absent: the `ZeroizeOnDrop` impl
     // means the inner `Vec<u8>` can't be moved out without losing the
-    // zeroize-on-drop guarantee. Callers should borrow via
-    // [`Self::as_slice`] instead — the transport layer never needs to
-    // take ownership of the bytes.
+    // zeroize-on-drop guarantee on this side of the boundary. Callers
+    // borrow via [`Self::as_slice`].
+    //
+    // ZeroizeOnDrop scope: this type owns the persistent reference
+    // the publish-job worker holds across the HTTP send; when the
+    // outer scope drops, the bytes are wiped. The transport layer
+    // (`HttpWebPushSender`) does have to copy the slice into a
+    // separate owned `Vec<u8>` to hand to reqwest's request body
+    // (reqwest doesn't expose a hook to zeroize the body buffer after
+    // send). That in-flight copy is encrypted ciphertext + the
+    // aes128gcm header (salt + AS public key); the header is also
+    // visible to the relay in plaintext, so the residual heap
+    // exposure on that copy is bounded to "what the relay already
+    // sees" plus zero plaintext. Documented gap, not a regression.
 }
 
 /// Signed VAPID JWT, ready for `Authorization: vapid t=…` use.
@@ -572,10 +583,15 @@ pub enum WebPushOutcome {
     /// cleanup forward (IQ-error to publisher) and
     /// `urn:waddle:push-service:0` disable-device reverse.
     SubscriptionGone { status: u16 },
-    /// 401 with `WWW-Authenticate: vapid` (or 403 from FCM with a
-    /// JWT-related body) — VAPID JWT was rejected, typically because
-    /// the relay's clock disagrees with ours. The VAPID cache must be
-    /// invalidated for this `(kid, aud, sub)` and a fresh JWT minted.
+    /// 401 with `WWW-Authenticate: vapid` (RFC 7235 §4.1) — the
+    /// canonical signal per RFC 8292 §3 that the VAPID JWT itself was
+    /// rejected, typically because the relay's clock disagrees with
+    /// ours past the `exp` skew tolerance. The publish-job worker
+    /// invalidates the JWT cache on this outcome (`VapidSigner::
+    /// invalidate_cache`) so the next attempt mints a fresh JWT.
+    /// 401 WITHOUT the `vapid` challenge is classified as
+    /// `BadRequest` instead — relay misconfig or rate-limit auth
+    /// gate, where invalidating the cache would just thrash it.
     ClockSkew { status: u16 },
     /// 429 — apply the token-bucket backoff for this endpoint+class.
     RateLimited {

--- a/server/crates/waddle-xmpp/src/push/types.rs
+++ b/server/crates/waddle-xmpp/src/push/types.rs
@@ -243,7 +243,13 @@ impl std::str::FromStr for VapidSub {
 }
 
 /// RFC 8291 encrypted payload — RFC 8188 header + AES-GCM record.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// AES-GCM ciphertext + RFC 8188 header. Zeroizes on drop as
+/// defense-in-depth: the body is already encrypted, but the same
+/// allocation carries the per-message salt and AS public key (header
+/// fields), which are useful symmetric-state context for any heap-
+/// residue attacker. Clearing the buffer when the value is dropped
+/// shrinks that residue window.
+#[derive(Debug, Clone, PartialEq, Eq, ZeroizeOnDrop)]
 pub struct EncryptedPayload(Vec<u8>);
 
 impl EncryptedPayload {
@@ -254,10 +260,11 @@ impl EncryptedPayload {
     pub fn as_slice(&self) -> &[u8] {
         &self.0
     }
-
-    pub fn into_inner(self) -> Vec<u8> {
-        self.0
-    }
+    // `into_inner` is intentionally absent: the `ZeroizeOnDrop` impl
+    // means the inner `Vec<u8>` can't be moved out without losing the
+    // zeroize-on-drop guarantee. Callers should borrow via
+    // [`Self::as_slice`] instead — the transport layer never needs to
+    // take ownership of the bytes.
 }
 
 /// Signed VAPID JWT, ready for `Authorization: vapid t=…` use.

--- a/server/crates/waddle-xmpp/src/push/types.rs
+++ b/server/crates/waddle-xmpp/src/push/types.rs
@@ -390,6 +390,18 @@ impl EndpointHash {
     }
 }
 
+impl fmt::Display for EndpointHash {
+    /// Renders the first 8 bytes as lowercase hex (16 chars). Enough
+    /// to disambiguate endpoints in tracing without leaking the
+    /// per-device bearer URL.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in &self.0[..8] {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
 /// Errors from the Web Push crypto + sender path.
 ///
 /// Kept as a standalone enum (rather than extending `super::PushError`)

--- a/server/crates/waddle-xmpp/src/push/types.rs
+++ b/server/crates/waddle-xmpp/src/push/types.rs
@@ -601,8 +601,17 @@ pub enum WebPushOutcome {
     /// 413 — body exceeded relay's per-message ceiling. Indicates a
     /// padding/bucket-class bug, not a transient condition.
     PayloadTooLarge { status: u16 },
-    /// 400 — relay rejected the body shape (malformed headers, bad
-    /// encryption envelope, etc). Indicates an encoder bug.
+    /// 400 / 403 / generic 401 — the relay rejected the request and
+    /// no other variant fits (subscription is not gone, JWT was not
+    /// the cause).
+    ///
+    /// `status = 0` is reserved as a sentinel for LOCAL preflight
+    /// failures inside `HttpWebPushSender::send` — non-https
+    /// endpoint reaching the sender despite registration-time
+    /// validation, or a VAPID header that fails `HeaderValue::from_str`.
+    /// There is no HTTP exchange in those cases, so no real status
+    /// code applies; downstream diagnostics render `status = 0` as
+    /// "preflight rejected" rather than the misleading "HTTP 0".
     BadRequest { status: u16 },
     /// 5xx, network failure, or anything not matched above. The
     /// publish-job worker retries via the existing

--- a/server/crates/waddle-xmpp/src/push/types.rs
+++ b/server/crates/waddle-xmpp/src/push/types.rs
@@ -539,6 +539,82 @@ pub enum VapidLoadError {
     Generate,
 }
 
+/// Classified outcome of a single Web Push HTTP POST.
+///
+/// Replaces stringly-typed `PushError::SendFailed("HTTP 410")` shapes
+/// with a typed enum the publish-job worker can pattern-match on to
+/// decide cleanup, retry, or alert. Mapped from RFC 8030 response codes
+/// per the table in §6.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WebPushOutcome {
+    /// 2xx — push relay accepted the message.
+    Delivered { status: u16 },
+    /// 404/410 — subscription is permanently gone; trigger XEP-0357 §6
+    /// cleanup forward (IQ-error to publisher) and
+    /// `urn:waddle:push-service:0` disable-device reverse.
+    SubscriptionGone { status: u16 },
+    /// 401 with `WWW-Authenticate: vapid` (or 403 from FCM with a
+    /// JWT-related body) — VAPID JWT was rejected, typically because
+    /// the relay's clock disagrees with ours. The VAPID cache must be
+    /// invalidated for this `(kid, aud, sub)` and a fresh JWT minted.
+    ClockSkew { status: u16 },
+    /// 429 — apply the token-bucket backoff for this endpoint+class.
+    RateLimited {
+        status: u16,
+        retry_after: Option<std::time::Duration>,
+    },
+    /// 413 — body exceeded relay's per-message ceiling. Indicates a
+    /// padding/bucket-class bug, not a transient condition.
+    PayloadTooLarge { status: u16 },
+    /// 400 — relay rejected the body shape (malformed headers, bad
+    /// encryption envelope, etc). Indicates an encoder bug.
+    BadRequest { status: u16 },
+    /// 5xx, network failure, or anything not matched above. The
+    /// publish-job worker retries via the existing
+    /// `push_publish_jobs.next_retry_at_ms` mechanism.
+    Transient { kind: TransientFailure },
+}
+
+/// The narrow set of transient failure shapes the sender produces.
+/// Kept typed instead of stringly to honor the typed-payloads rule.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TransientFailure {
+    /// Network-layer error (DNS, connect, TLS, body).
+    Network,
+    /// HTTP 5xx from the relay.
+    ServerError { status: u16 },
+    /// Request did not complete within the sender's per-attempt
+    /// timeout budget.
+    Timeout,
+}
+
+/// Reason a downstream send path was suppressed.
+///
+/// Extends the existing T1/legacy suppression machinery so a degraded
+/// XEP-0357 push service can prevent in-band fallbacks (e.g., plaintext
+/// chat-notify) from leaking when the encrypted path is unavailable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SuppressionReason {
+    /// XEP-0357 push service is degraded (no VAPID signer, no nodes
+    /// configured, repeated relay outages). Tracked in tandem with
+    /// [`WebPushCapability`].
+    Xep0357PushServiceDegraded,
+}
+
+/// Boot-time capability of the XEP-0357 push service.
+///
+/// Determined once at `VapidStorage::load_or_provision` time and
+/// refreshed by the publish-job worker on sustained failure. Drives
+/// disco advertisement, T1 gating, and the admin-alert path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WebPushCapability {
+    /// VAPID signer loaded; push service is fully operational.
+    Ready,
+    /// VAPID load failed or persistent relay degradation detected.
+    /// `reason` is preserved so disco can surface a typed condition.
+    Degraded { reason: SuppressionReason },
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/server/crates/waddle-xmpp/src/push/vapid.rs
+++ b/server/crates/waddle-xmpp/src/push/vapid.rs
@@ -40,6 +40,12 @@ pub trait VapidSigner: Send + Sync {
     /// Current `kid` (cache key component for the JWT cache + the disco-form
     /// `kid` field for chat-side rotation detection).
     fn current_kid(&self) -> Kid;
+
+    /// Invalidate the JWT cache. Called by the publish-job worker on
+    /// `WebPushOutcome::ClockSkew` so the next sign call re-mints a
+    /// fresh JWT instead of re-serving the cached one that just got
+    /// rejected. Implementations that don't cache JWTs may no-op.
+    fn invalidate_cache(&self);
 }
 
 /// VAPID JWT claims body per RFC 8292 §2.
@@ -236,6 +242,10 @@ impl VapidSigner for InProcessVapidSigner {
 
     fn current_kid(&self) -> Kid {
         self.kid
+    }
+
+    fn invalidate_cache(&self) {
+        self.invalidate_all();
     }
 }
 


### PR DESCRIPTION
## Closes

- Closes #762 (Web Push delivery)
- Closes #97 (the legacy relay placeholder)

PR-D2 of the three-stage Web Push cutover plan tracked in #762. PR-D1 (#763, merged as \`1f849dfd\`) shipped the foundations: RFC 8291 \`encrypt\`, RFC 8292 VAPID signer, sealed VAPID storage, typed newtypes, and 86-byte aes128gcm header constants. PR-D3 follows with the chat-side disco/runtime/SW changes.

## What this PR does

Turns the placeholder \`ATTEMPT_STATUS_FAKE_SENT\` path in \`push_service.rs::process_publish_job_with_retention_limit\` into a real RFC 8030 / 8291 / 8292 delivery pipeline. End-to-end flow:

\`\`\`
notification_outbox  ──┐
                       ▼
push_service::publish_notification_from_user_server
                       │
                       ▼
three-phase publish-job worker
  ├─ tx1: claim + validate + load sealed devices + payload_xml
  ├─ phase 2 (outside any tx, parallel via buffer_unordered(64)):
  │    ├─ dispatch::parse_publish_payload(xml)        → <notification> + <context>
  │    ├─ WebPushTarget::try_from_sealed(device)      → typed SubscriptionKeys
  │    ├─ encrypt::encrypt(...)                       → RFC 8291 EncryptedPayload
  │    ├─ signer.sign(aud, sub)                       → RFC 8292 VAPID JWT (cached)
  │    └─ RateLimitedWebPushSender::send(...)         → RFC 8030 POST → WebPushOutcome
  └─ tx2: write typed attempts + XEP-0357 §6 cleanup + finalize (PUBLISHED / QUEUED / FAILED)
\`\`\`

## Commits

**Implementation (11 commits):**

| # | Commit | What |
|---|---|---|
| 1 | \`529664bf\` | Typed \`WebPushOutcome\` + \`TransientFailure\` + \`SuppressionReason\` + \`WebPushCapability\` enums (typed-payloads hard rule). |
| 2 | \`95e50aa9\` | Rewrite \`HttpWebPushSender\` as real RFC 8030 transport; typed \`WebPushRequest\` + \`Urgency\`; 11 mockito-driven classifier tests; narrow \`InMemoryPushStore\` behind \`cfg(test, feature = "test-utils")\`. |
| 3 | \`0d1170cb\` | \`PushEnvelope\` (\`"v": 1\` JSON, XEP-0357 §4 metadata-only); per-class \`PushClass\` policy (TTL/Urgency/bucket-size); hashed RFC 8030 §5.4 \`Topic\`. |
| 4 | \`1b52c32c\` | Wire \`VapidStorage::load_or_provision\` + \`HttpWebPushSender\` at boot; \`with_web_push_provider\` builder. |
| 5 | \`3818c62e\` | Three-phase publish-job worker (claim → dispatch outside tx → record). \`Database::begin_immediate()\` to serialize SQLite writers across the split. |
| 6 | \`704e5be3\` | XEP-0357 §6 forward cleanup: \`web-gone\` / \`web-invalid-keys\` / \`web-invalid-endpoint\` mark device disabled in the same tx. |
| 7 | \`5fa9cea2\` | \`Limiter\` + \`RateLimitedWebPushSender\` — global semaphore + per-(host, urgency) leaky bucket. |
| 8 | \`a16de276\` | \`SuppressedReason::Xep0357PushServiceDegraded\` typed plumbing + \`web_push_capability()\` getter. |

**Adversarial-review fixes (round 1, 6 commits):**

| # | Commit | Fixes |
|---|---|---|
| 9 | \`46bd2d0d\` | Retry cap (XEP-0357 §6.1) + RFC 7231 \`Retry-After\` honored + \`web-internal-error\` reclassified permanent + \`web-not-configured\` emitted on degraded boot. |
| 10 | \`3802cc20\` | SSRF guard at register time (rejects literal IPs / localhost / non-https) + \`EndpointHash\` in logs instead of full URL (PII). |
| 11 | \`1214cf94\` | 403 → \`SubscriptionGone\` (FCM "VAPID key not authorized"); limiter keys on relay host not per-device URL. |
| 12 | \`98199dfd\` | Parallel fan-out via \`futures::stream::buffer_unordered(64)\` so the limiter's global cap is actually reachable. |
| 13 | \`0f43c32b\` | RFC 8291 §5 UA-decrypt round-trip test drives \`encrypt()\` end-to-end (catches future bugs the inline KAT would miss). |
| 14 | \`3f345d09\` | \`EncryptedPayload\` \`ZeroizeOnDrop\` + 30-min claim window (mitigates concurrent-drain race). |

**Adversarial-review polish (round 2, 1 commit):**

| # | Commit | Fixes |
|---|---|---|
| 15 | \`52d52b56\` | SSRF port guard (reject non-443) + \`Arc<PushSecretCipher>\` (avoid 64× key duplication under fan-out) + \`attempt_status_is_transient\` matrix test + doc drift. |

## Conformance highlights

- **XEP-0357 §4** Notification payload — \`dispatch::parse_publish_payload\` validates outer \`<notification xmlns='urn:xmpp:push:0'>\` + the typed \`<context xmlns='urn:waddle:push:context:0'>\` and the FORM_TYPE-gated \`message-count\` field. No message content in the push body (forbidden by §4).
- **XEP-0357 §6** Publish errors — \`web-gone\` / \`web-invalid-keys\` / \`web-invalid-endpoint\` flip \`push_devices.status\` to \`disabled\` in the same tx2; transient outcomes capped at 24 attempts per §6.1 ("until a sufficient number of errors have been received in a row"). Reverse direction (notify chat client) deferred to a follow-up.
- **RFC 8030** Web Push HTTP — \`Authorization: vapid t=<jwt>, k=<base64url-no-pad-uncompressed-key>\`, \`Content-Encoding: aes128gcm\`, typed \`TTL\` / \`Urgency\` / hashed \`Topic\` (24-byte SHA-256 truncation, exactly 32 chars in §5.4 alphabet).
- **RFC 8291** Encryption — production \`encrypt()\` proven UA-decryptable against the RFC §5 worked example (new round-trip test).
- **RFC 8292** VAPID — origin-only \`aud\`; \`iat = now − 30s\`; \`exp = iat + 12h ≤ 24h\`; \`sub\` is \`mailto:postmaster@<xmpp-domain>\` per RFC 2142; LRU-cached by (kid, aud, sub).
- **RFC 7231 §7.1.3** \`Retry-After\` honored on 429 (clamped to 1h ceiling).

## Security

- **SSRF guard** at device registration: non-https, literal IPs (any family), \`localhost\`, \`*.localhost\`, and non-default ports all rejected with \`<bad-request/>\`.
- **PII protection**: full per-device endpoint URL never logged — only \`EndpointHash\` (first 8 bytes hex) + origin.
- **AuthSecret** zeroized on drop; **EncryptedPayload** zeroized on drop; base64 decode buffers wrapped in \`Zeroizing\`.
- **Sealed VAPID storage** with AAD-bound \`(label, kid, root_key_version)\` prevents blob substitution; env-bootstrap write-before-remove ordering prevents silent key loss on partial failure.

## Tests

- \`waddle-xmpp\`: 96 push:: tests (sender / envelope / limiter / encrypt / vapid / types).
- \`waddle-server\`: 60 push_service:: tests (including 6 §6 / SSRF / capability / classifier-matrix tests added by this PR) + 101 notification_outbox tests + 4 XEP-0357 integration tests.
- RFC 8291 §5 KAT: byte-exact KAT + UA-decrypt round-trip through \`encrypt()\`.
- Two adversarial review rounds; all critical and major findings addressed.

## Out of scope (deferred to PR-D3 or follow-ups)

- Chat-side disco extension for VAPID public key (PR-D3).
- Service-worker switch on \`"v": 1\` envelope (PR-D3).
- Reverse-direction \`<message><device-disabled xmlns='urn:waddle:push-service:0'/></message>\` to chat client (#762 follow-up — TODO in \`dispatch_web_device_owned\`).
- \`claim_token\` UUID column for strict at-most-once delivery (#762 follow-up — 30-min lease window mitigates in practice).
- VAPID key rotation with overlapping kid windows.
- APNS (#529), FCM (#530), observability dashboards (#531).

## Test plan

- [x] \`cargo fmt --check\` passes
- [x] \`cargo clippy -p waddle-server -p waddle-xmpp --all-targets -- -D warnings\` passes
- [x] \`cargo test -p waddle-xmpp\` (~2024+ tests) passes
- [x] \`cargo test -p waddle-server --lib push_service::\` (60 tests) passes
- [x] \`cargo test -p waddle-server --test xep0357_push_notifications\` (4 tests) passes
- [x] Adversarial review (XMPP / crypto / architecture personas) finds no remaining critical or major issues
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)