### PR TITLE
feat(chat): Web Push runtime cutover — disco-discovered VAPID + v=1 envelope (PR-D3 of #762)

### DIFF
--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -1229,13 +1229,23 @@ export class BrowserXmppClient {
    * via the XEP-0128 disco extension form
    * (`FORM_TYPE='urn:waddle:push:vapid:0'`).
    *
-   * Resolves to `null` only when the server explicitly does not
-   * advertise the form — meaning Web Push is not configured on this
-   * deployment. Returns `null` (NOT throws) for any other error so the
-   * caller can fall back to the foreground Notification API path; the
-   * wasm side already validates wire-shape invariants
-   * (`PushVapidDiscoParseError`) and surfaces them via a rejected
-   * Promise, which we catch here as a `null` return + console warning.
+   * Resolves to `null` in any of these cases — callers can't distinguish
+   * them from the return value alone, but each path emits a precise
+   * `console.warn` for diagnostics:
+   *   - The server doesn't advertise the form (Web Push not configured)
+   *   - The session is not ready (mid-reconnect / mid-teardown race)
+   *   - The disco IQ times out after 10s
+   *   - The wasm `fetch_vapid_public_key` method is missing (older bundle)
+   *   - The IQ is rejected (transport error, stanza error, malformed
+   *     advertisement caught by the wasm-side wire-shape validator)
+   *   - The JS-boundary shape is unexpected (regression on the Rust side)
+   *
+   * This is a `null`-on-any-error contract by design: every failure
+   * mode collapses to the same caller-visible action (fall back to the
+   * foreground Notification API; retry on next reconnect). UI surfaces
+   * that need to distinguish "not configured" from "transient error"
+   * should consume the console warnings via a log sink, not branch on
+   * the return value.
    */
   async fetchVapidPublicKey(opts: { serviceJid: string }): Promise<{ publicKey: string; kid: string } | null> {
     // Bounded timeout (10s): the wasm-side `send_iq_command` is itself

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -1239,13 +1239,44 @@ export class BrowserXmppClient {
   async fetchVapidPublicKey(opts: { serviceJid: string }): Promise<{ publicKey: string; kid: string } | null> {
     const xmpp = await this.requireConnectedXmpp();
     if (!xmpp.fetch_vapid_public_key) return null;
+    // Bounded timeout (10s): the wasm-side `send_iq_command` is itself
+    // an unbounded oneshot. Without this race the rotation lock can be
+    // held indefinitely on a stalled Push Service handler, blocking
+    // every subsequent enable + reconnect's setupPushSubscription.
+    const TIMEOUT_MS = 10_000;
+    let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+    const timeoutPromise = new Promise<null>((resolve) => {
+      timeoutHandle = setTimeout(() => resolve(null), TIMEOUT_MS);
+    });
     try {
-      const result = await xmpp.fetch_vapid_public_key(opts.serviceJid);
+      const result = await Promise.race([
+        xmpp.fetch_vapid_public_key(opts.serviceJid),
+        timeoutPromise,
+      ]);
       if (result === null || result === undefined) return null;
-      return result as { publicKey: string; kid: string };
+      const candidate = result as { publicKey?: unknown; kid?: unknown };
+      // Validate the JS-boundary shape — the wasm method's signature
+      // is `Promise<any>` after wasm-bindgen, so a regression on the
+      // Rust side that emitted an unexpected object would otherwise
+      // silently propagate. Hard-fail on shape drift.
+      if (
+        typeof candidate.publicKey !== "string" ||
+        candidate.publicKey.length === 0 ||
+        typeof candidate.kid !== "string" ||
+        candidate.kid.length === 0
+      ) {
+        console.warn(
+          "[xmpp] fetch_vapid_public_key returned an unexpected shape:",
+          candidate,
+        );
+        return null;
+      }
+      return { publicKey: candidate.publicKey, kid: candidate.kid };
     } catch (error) {
       console.warn("[xmpp] fetch_vapid_public_key IQ rejected:", error);
       return null;
+    } finally {
+      if (timeoutHandle !== null) clearTimeout(timeoutHandle);
     }
   }
 

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -1237,8 +1237,6 @@ export class BrowserXmppClient {
    * Promise, which we catch here as a `null` return + console warning.
    */
   async fetchVapidPublicKey(opts: { serviceJid: string }): Promise<{ publicKey: string; kid: string } | null> {
-    const xmpp = await this.requireConnectedXmpp();
-    if (!xmpp.fetch_vapid_public_key) return null;
     // Bounded timeout (10s): the wasm-side `send_iq_command` is itself
     // an unbounded oneshot. Without this race the rotation lock can be
     // held indefinitely on a stalled Push Service handler, blocking
@@ -1254,6 +1252,15 @@ export class BrowserXmppClient {
       }, TIMEOUT_MS);
     });
     try {
+      // `requireConnectedXmpp` throws when the session is not ready
+      // (mid-reconnect / mid-teardown race). The JSDoc contract for
+      // this method is "returns null on any error so the caller can
+      // fall back to foreground Notifications" — so the readiness
+      // check goes INSIDE the try block. Without this, a brief
+      // reconnect race during setupPushSubscription would abort the
+      // whole rotation flow instead of degrading cleanly.
+      const xmpp = await this.requireConnectedXmpp();
+      if (!xmpp.fetch_vapid_public_key) return null;
       const result = await Promise.race([
         xmpp.fetch_vapid_public_key(opts.serviceJid),
         timeoutPromise,

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -1224,6 +1224,32 @@ export class BrowserXmppClient {
   }
 
   /**
+   * Fetch the Push Service's currently-active VAPID public key + kid
+   * via the XEP-0128 disco extension form
+   * (`FORM_TYPE='urn:waddle:push:vapid:0'`).
+   *
+   * Resolves to `null` only when the server explicitly does not
+   * advertise the form — meaning Web Push is not configured on this
+   * deployment. Returns `null` (NOT throws) for any other error so the
+   * caller can fall back to the foreground Notification API path; the
+   * wasm side already validates wire-shape invariants
+   * (`PushVapidDiscoParseError`) and surfaces them via a rejected
+   * Promise, which we catch here as a `null` return + console warning.
+   */
+  async fetchVapidPublicKey(opts: { serviceJid: string }): Promise<{ publicKey: string; kid: string } | null> {
+    const xmpp = await this.requireConnectedXmpp();
+    if (!xmpp.fetch_vapid_public_key) return null;
+    try {
+      const result = await xmpp.fetch_vapid_public_key(opts.serviceJid);
+      if (result === null || result === undefined) return null;
+      return result as { publicKey: string; kid: string };
+    } catch (error) {
+      console.warn("[xmpp] fetch_vapid_public_key IQ rejected:", error);
+      return null;
+    }
+  }
+
+  /**
    * Idempotent get-or-create of the chat's per-(user, app-id) Push
    * Service node. Returns the stable node id the chat passes to
    * `registerWebPushDevice` and `enablePushNotifications`.

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -1271,7 +1271,17 @@ export class BrowserXmppClient {
       // reconnect race during setupPushSubscription would abort the
       // whole rotation flow instead of degrading cleanly.
       const xmpp = await this.requireConnectedXmpp();
-      if (!xmpp.fetch_vapid_public_key) return null;
+      if (!xmpp.fetch_vapid_public_key) {
+        // Bundle-drift diagnostic: the JS shipped expects a wasm
+        // method that the active bundle doesn't export. Typically
+        // means the chat upgraded its TS but the @waddle/xmpp-client-wasm
+        // package is older. Surface so operators see why Web Push
+        // silently fell back to the foreground Notification API.
+        console.warn(
+          "[xmpp] fetch_vapid_public_key is unavailable (older wasm bundle?); returning null",
+        );
+        return null;
+      }
       const result = await Promise.race([
         xmpp.fetch_vapid_public_key(opts.serviceJid),
         timeoutPromise,

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -150,6 +150,7 @@ function isRoomActivityMessage(message: LiveRoomMessage): boolean {
 
 function roomActivityEventFromMessage(message: LiveRoomMessage): RoomActivityEvent {
   const activity: RoomActivityEvent = { roomJid: message.roomJid, nick: message.nick, body: message.body };
+  if (message.stanzaId) activity.stanzaId = message.stanzaId;
   if (message.mentions) activity.mentions = message.mentions;
   if (message.broadcastMention) activity.broadcastMention = message.broadcastMention;
   return activity;

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -1245,14 +1245,27 @@ export class BrowserXmppClient {
     // every subsequent enable + reconnect's setupPushSubscription.
     const TIMEOUT_MS = 10_000;
     let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
-    const timeoutPromise = new Promise<null>((resolve) => {
-      timeoutHandle = setTimeout(() => resolve(null), TIMEOUT_MS);
+    let timedOut = false;
+    const timeoutSentinel = Symbol("vapid-fetch-timeout");
+    const timeoutPromise = new Promise<typeof timeoutSentinel>((resolve) => {
+      timeoutHandle = setTimeout(() => {
+        timedOut = true;
+        resolve(timeoutSentinel);
+      }, TIMEOUT_MS);
     });
     try {
       const result = await Promise.race([
         xmpp.fetch_vapid_public_key(opts.serviceJid),
         timeoutPromise,
       ]);
+      if (result === timeoutSentinel) {
+        console.warn(
+          `[xmpp] fetch_vapid_public_key timed out after ${TIMEOUT_MS}ms; ` +
+          "Push Service may be unreachable. Returning null so the chat falls back " +
+          "to the foreground Notification API; the next reconnect will retry.",
+        );
+        return null;
+      }
       if (result === null || result === undefined) return null;
       const candidate = result as { publicKey?: unknown; kid?: unknown };
       // Validate the JS-boundary shape — the wasm method's signature
@@ -1273,6 +1286,12 @@ export class BrowserXmppClient {
       }
       return { publicKey: candidate.publicKey, kid: candidate.kid };
     } catch (error) {
+      if (timedOut) {
+        // The wasm-side IQ rejected after we already gave up on it —
+        // the warning above already explained the timeout; this path
+        // just drops the late result silently.
+        return null;
+      }
       console.warn("[xmpp] fetch_vapid_public_key IQ rejected:", error);
       return null;
     } finally {

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -385,6 +385,11 @@ export interface RoomActivityEvent {
   roomJid: string;
   nick: string;
   body: string;
+  /** XEP-0359 stanza id of the originating message, if the server stamped one.
+   * Used by the foreground→service-worker dedup signal so a SW push that
+   * lands after a foreground notification with the same stanza id does not
+   * re-render the same banner. */
+  stanzaId?: string;
   /** XEP-0372 */
   mentions?: string[];
   /** XEP-0513 */

--- a/chat/src/service-worker/sw-template.js
+++ b/chat/src/service-worker/sw-template.js
@@ -82,6 +82,16 @@ self.addEventListener("fetch", (event) => {
 self.addEventListener("message", (event) => {
   if (event.data?.type === "SKIP_WAITING") {
     event.waitUntil(self.skipWaiting());
+    return;
+  }
+  // Foreground→SW dedup signal. The chat tab calls this from
+  // `showMentionNotification` / `showDmNotification` when it renders
+  // an in-band notification. Recording the id in `shownItems` lets the
+  // subsequent SW `push` event for the same stanza suppress its
+  // duplicate banner. See `chat/src/shell/notifications.ts`.
+  if (event.data?.type === "waddle:item-shown") {
+    const itemId = typeof event.data.itemId === "string" ? event.data.itemId : null;
+    if (itemId) noteItemShown(itemId);
   }
 });
 

--- a/chat/src/service-worker/sw-template.js
+++ b/chat/src/service-worker/sw-template.js
@@ -96,6 +96,12 @@ self.addEventListener("message", (event) => {
 /// evicted while still inside its TTL window under retry pressure).
 const SHOWN_ITEM_TTL_MS = 60_000;
 const SHOWN_ITEM_MAX = 256;
+/// Maximum number of TTL-probe iterations per eviction. Bounds the
+/// worst-case per-push CPU under bursts > SHOWN_ITEM_MAX items inside
+/// the TTL window. 16 probes is enough to find an expired entry under
+/// any non-pathological pattern; under a true burst we fall back to
+/// FIFO head eviction in O(1).
+const SHOWN_ITEM_EVICT_PROBE = 16;
 const shownItems = new Map();
 function noteItemShown(itemId) {
   if (!itemId) return;
@@ -105,10 +111,16 @@ function noteItemShown(itemId) {
   shownItems.set(itemId, Date.now());
   if (shownItems.size > SHOWN_ITEM_MAX) {
     // Prefer to evict an already-expired entry over the oldest live
-    // one; falls back to FIFO head when nothing has expired.
+    // one; falls back to FIFO head when nothing has expired. Cap the
+    // TTL probe at SHOWN_ITEM_EVICT_PROBE so a hostile burst (>
+    // SHOWN_ITEM_MAX items inside SHOWN_ITEM_TTL_MS) doesn't degrade
+    // every push to an O(SHOWN_ITEM_MAX) scan. Capped scan + FIFO
+    // fallback yields O(SHOWN_ITEM_EVICT_PROBE) per eviction.
     const now = Date.now();
     let evicted = false;
+    let probes = 0;
     for (const [key, at] of shownItems) {
+      if (probes++ >= SHOWN_ITEM_EVICT_PROBE) break;
       if (now - at > SHOWN_ITEM_TTL_MS) {
         shownItems.delete(key);
         evicted = true;

--- a/chat/src/service-worker/sw-template.js
+++ b/chat/src/service-worker/sw-template.js
@@ -89,16 +89,36 @@ self.addEventListener("message", (event) => {
 /// already been rendered (chat tab open, message hits `showMentionNotification`
 /// or `showDmNotification`), the SW push lands ~tens of ms later carrying
 /// the same `item` id. Suppressing the SW notification by `item` avoids
-/// a double-fire. Bounded to 256 entries via FIFO eviction.
+/// a double-fire. Bounded to 256 entries with TTL-first, FIFO-fallback
+/// eviction. Delete-then-set on touch so re-noting an item moves it to
+/// the Map's tail (Map iteration order = insertion order; without the
+/// delete a re-touch keeps the original position and the entry can be
+/// evicted while still inside its TTL window under retry pressure).
 const SHOWN_ITEM_TTL_MS = 60_000;
 const SHOWN_ITEM_MAX = 256;
 const shownItems = new Map();
 function noteItemShown(itemId) {
   if (!itemId) return;
+  // delete-then-set so a re-noted item moves to the tail of the Map's
+  // insertion order, keeping FIFO eviction recency-aware.
+  if (shownItems.has(itemId)) shownItems.delete(itemId);
   shownItems.set(itemId, Date.now());
   if (shownItems.size > SHOWN_ITEM_MAX) {
-    const oldestKey = shownItems.keys().next().value;
-    if (oldestKey !== undefined) shownItems.delete(oldestKey);
+    // Prefer to evict an already-expired entry over the oldest live
+    // one; falls back to FIFO head when nothing has expired.
+    const now = Date.now();
+    let evicted = false;
+    for (const [key, at] of shownItems) {
+      if (now - at > SHOWN_ITEM_TTL_MS) {
+        shownItems.delete(key);
+        evicted = true;
+        break;
+      }
+    }
+    if (!evicted) {
+      const oldestKey = shownItems.keys().next().value;
+      if (oldestKey !== undefined) shownItems.delete(oldestKey);
+    }
   }
 }
 function isItemAlreadyShown(itemId) {

--- a/chat/src/service-worker/sw-template.js
+++ b/chat/src/service-worker/sw-template.js
@@ -159,45 +159,39 @@ self.addEventListener("push", (event) => {
   try {
     data = event.data?.json() ?? {};
   } catch {
-    // Server side now sends a JSON envelope; a non-JSON body is a
-    // legacy / misconfigured publish. Fall through to the minimal
-    // notification with no payload-derived state.
+    // Non-JSON push body — treat as an empty envelope and render the
+    // minimal "Waddle" notification (required by the Push API spec
+    // for `userVisibleOnly: true` subscriptions).
     data = {};
   }
-  // PR-D3: switch on the PR-D2 `"v": 1` envelope. Legacy publishers
-  // that pre-date the v=1 schema fall through to
-  // `parseLegacyRoutingContext`; both shapes feed the same typed
-  // routing fields carried into `notificationclick.data.context`.
-  // `item` (dedup key) and `unread` are sibling locals because they
-  // are transient transport metadata, not navigation state, and
-  // shouldn't reach the click handler.
-  const parsed = parseV1Envelope(data) ?? parseLegacyRoutingContext(data);
+  // The server emits exactly the `v=1` envelope shape defined in
+  // `crates/waddle-xmpp/src/push/envelope.rs::PushEnvelope`. There is
+  // no migration window: a payload with `v !== 1` is from an
+  // unsupported server build and is rendered as the minimal default.
+  const parsed = parseV1Envelope(data) ?? {
+    conversation: undefined,
+    thread: undefined,
+    class: undefined,
+    item: undefined,
+    unread: null,
+  };
+  // `context` is the navigation-only subset stashed on the
+  // notification for the click handler; `item` (dedup key) and
+  // `unread` stay local because they're transient transport metadata.
   const context = {
     conversation: parsed.conversation,
     thread: parsed.thread,
     class: parsed.class,
   };
-  const unreadCount = parsed.unread ?? null;
+  const unreadCount = parsed.unread;
   const itemId = parsed.item;
-  // Routing precedence:
-  //   1. Typed `context.{conversation,thread,class}` envelope.
-  //   2. Legacy `data.url` if it's a same-origin path — kept for
-  //      mixed-version publishers that may still ship a deep link in
-  //      the top-level `url` field. `sameOriginUrl` rejects cross-
-  //      origin and javascript: URLs.
-  //   3. Final fallback to `/`.
-  const route = routeFromContext(context)
-    ?? sameOriginUrl(typeof data.url === "string" ? data.url : null)
-    ?? "/";
-  // Minimal default: no sender, no body preview. XEP-0357 §4 forbids
-  // the push service from receiving message content, so the v=1
-  // envelope never carries `title`/`body`. The legacy fallback path
-  // still honors them.
-  const title = typeof data.title === "string" && data.title.length > 0
-    ? data.title
-    : defaultTitle(unreadCount);
-  const body = typeof data.body === "string" ? data.body : "";
-  const tag = context.conversation ?? data.roomJid ?? "waddle";
+  const route = routeFromContext(context) ?? "/";
+  // XEP-0357 §4 forbids the Push Service from receiving message
+  // content, so the envelope never carries title/body. The SW always
+  // renders the count-derived default title with an empty body.
+  const title = defaultTitle(unreadCount);
+  const body = "";
+  const tag = context.conversation ?? "waddle";
   if (isItemAlreadyShown(itemId)) {
     // Foreground tab already rendered this item — only update the
     // badge / unread broadcast, no duplicate banner.
@@ -259,8 +253,8 @@ function defaultTitle(unreadCount) {
   return `${unreadCount} new messages`;
 }
 
-/// Parse the PR-D2 `"v": 1` envelope emitted by
-/// `crates/waddle-xmpp/src/push/envelope.rs::PushEnvelope`. Field shape:
+/// Parse the `"v": 1` envelope emitted by
+/// `crates/waddle-xmpp/src/push/envelope.rs::PushEnvelope`:
 ///
 ///   * `v`            — schema version (must equal 1)
 ///   * `class`        — granular NotificationClass (`"dm"`, `"personal_mention"`, …)
@@ -269,42 +263,26 @@ function defaultTitle(unreadCount) {
 ///   * `item`         — originating stanza id (used for in-band dedup)
 ///   * `unread`       — XEP-0357 message-count snapshot (optional)
 ///
-/// Returns `null` when the envelope is absent (legacy publish, or a
-/// non-v=1 schema bump the server side may roll out later); the caller
-/// falls back to `parseLegacyRoutingContext`.
+/// Returns `null` when the payload is not a v=1 envelope; the SW
+/// renders a minimal "Waddle" notification in that case. There is no
+/// legacy / mixed-version fallback — per the project's breaking-
+/// changes-by-default rule, the server emits exactly this shape.
 function parseV1Envelope(data) {
   if (!data || data.v !== 1) return null;
+  const rawUnread = data.unread;
+  let unread = null;
+  if (rawUnread !== undefined && rawUnread !== null) {
+    const parsed = typeof rawUnread === "number" ? rawUnread : Number(rawUnread);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      unread = Math.floor(parsed);
+    }
+  }
   return {
     conversation: typeof data.conversation === "string" ? data.conversation : undefined,
     thread: typeof data.thread === "string" && data.thread.length > 0 ? data.thread : undefined,
     class: typeof data.class === "string" ? data.class : undefined,
     item: typeof data.item === "string" ? data.item : undefined,
-    unread: parseUnreadCount(data),
-  };
-}
-
-/// Pre-PR-D2 routing fallback. Legacy server builds wrote a nested
-/// `data.context = { conversation, thread, class }` object alongside
-/// `data.roomJid`. Kept until every reachable server is on the v=1
-/// envelope; remove once telemetry confirms no `v` absent / != 1
-/// publishes are landing.
-function parseLegacyRoutingContext(data) {
-  const context = data?.context;
-  if (context && typeof context === "object") {
-    return {
-      conversation: typeof context.conversation === "string" ? context.conversation : undefined,
-      thread: typeof context.thread === "string" && context.thread.length > 0 ? context.thread : undefined,
-      class: typeof context.class === "string" ? context.class : undefined,
-      item: undefined,
-      unread: parseUnreadCount(data),
-    };
-  }
-  return {
-    conversation: typeof data?.roomJid === "string" ? data.roomJid : undefined,
-    thread: undefined,
-    class: undefined,
-    item: undefined,
-    unread: parseUnreadCount(data),
+    unread,
   };
 }
 
@@ -340,11 +318,8 @@ const MUC_CLASS_VALUES = new Set([
 function routeFromContext(context) {
   const conv = context?.conversation;
   // Return `null` (NOT `/`) when the typed context lacks a
-  // conversation, so the caller can fall back to a legacy `data.url`
-  // if one is present rather than collapsing to root. ChatGPT Codex
-  // bot flagged this regression: pre-#528 SW used `data.url`
-  // directly when present; we shouldn't silently drop that path
-  // for mixed-version publishers.
+  // conversation. The push handler maps `null` to `/` itself; null
+  // here just signals "no routable target."
   if (typeof conv !== "string" || conv.length === 0) return null;
   const at = conv.lastIndexOf("@");
   if (at <= 0) return null;
@@ -362,22 +337,6 @@ function routeFromContext(context) {
     return `${base}?thread=${encodeURIComponent(context.thread)}`;
   }
   return base;
-}
-
-function parseUnreadCount(data) {
-  // Prefer the PR-D2 v=1 envelope's `unread` field; fall back to the
-  // pre-D2 wire names so a server emitting either shape still surfaces
-  // a count.
-  const value =
-    data?.unread ??
-    data?.messageCount ??
-    data?.["message-count"] ??
-    data?.unreadCount ??
-    data?.totalUnread;
-  if (value === undefined || value === null) return null;
-  const parsed = typeof value === "number" ? value : Number(value);
-  if (!Number.isFinite(parsed) || parsed < 0) return null;
-  return Math.floor(parsed);
 }
 
 async function updateAppBadge(unreadCount) {

--- a/chat/src/service-worker/sw-template.js
+++ b/chat/src/service-worker/sw-template.js
@@ -85,6 +85,33 @@ self.addEventListener("message", (event) => {
   }
 });
 
+/// Per-message dedup: when an in-band foreground notification has
+/// already been rendered (chat tab open, message hits `showMentionNotification`
+/// or `showDmNotification`), the SW push lands ~tens of ms later carrying
+/// the same `item` id. Suppressing the SW notification by `item` avoids
+/// a double-fire. Bounded to 256 entries via FIFO eviction.
+const SHOWN_ITEM_TTL_MS = 60_000;
+const SHOWN_ITEM_MAX = 256;
+const shownItems = new Map();
+function noteItemShown(itemId) {
+  if (!itemId) return;
+  shownItems.set(itemId, Date.now());
+  if (shownItems.size > SHOWN_ITEM_MAX) {
+    const oldestKey = shownItems.keys().next().value;
+    if (oldestKey !== undefined) shownItems.delete(oldestKey);
+  }
+}
+function isItemAlreadyShown(itemId) {
+  if (!itemId) return false;
+  const at = shownItems.get(itemId);
+  if (at === undefined) return false;
+  if (Date.now() - at > SHOWN_ITEM_TTL_MS) {
+    shownItems.delete(itemId);
+    return false;
+  }
+  return true;
+}
+
 self.addEventListener("push", (event) => {
   let data = {};
   try {
@@ -95,28 +122,49 @@ self.addEventListener("push", (event) => {
     // notification with no payload-derived state.
     data = {};
   }
-  const unreadCount = parseUnreadCount(data);
-  const context = parseRoutingContext(data);
+  // PR-D3: switch on the PR-D2 `"v": 1` envelope. Legacy publishers
+  // that pre-date the v=1 schema fall through to
+  // `parseLegacyRoutingContext`; both shapes feed the same typed
+  // routing fields carried into `notificationclick.data.context`.
+  // `item` (dedup key) and `unread` are sibling locals because they
+  // are transient transport metadata, not navigation state, and
+  // shouldn't reach the click handler.
+  const parsed = parseV1Envelope(data) ?? parseLegacyRoutingContext(data);
+  const context = {
+    conversation: parsed.conversation,
+    thread: parsed.thread,
+    class: parsed.class,
+  };
+  const unreadCount = parsed.unread ?? null;
+  const itemId = parsed.item;
   // Routing precedence:
-  //   1. Typed `context.{conversation,thread,class}` envelope
-  //      (urn:waddle:push:context:0).
+  //   1. Typed `context.{conversation,thread,class}` envelope.
   //   2. Legacy `data.url` if it's a same-origin path — kept for
-  //      mixed-version publishers that may still ship a deep link
-  //      in the top-level `url` field. `sameOriginUrl` rejects
-  //      cross-origin and javascript: URLs.
+  //      mixed-version publishers that may still ship a deep link in
+  //      the top-level `url` field. `sameOriginUrl` rejects cross-
+  //      origin and javascript: URLs.
   //   3. Final fallback to `/`.
   const route = routeFromContext(context)
     ?? sameOriginUrl(typeof data.url === "string" ? data.url : null)
     ?? "/";
-  // Minimal default: no sender, no body preview. The server's
-  // canonical XEP-0357 summary carries `message-count` only; richer
-  // title/body previews remain opt-in (set `data.title`/`data.body`
-  // explicitly on the server side when the user has opted in).
+  // Minimal default: no sender, no body preview. XEP-0357 §4 forbids
+  // the push service from receiving message content, so the v=1
+  // envelope never carries `title`/`body`. The legacy fallback path
+  // still honors them.
   const title = typeof data.title === "string" && data.title.length > 0
     ? data.title
     : defaultTitle(unreadCount);
   const body = typeof data.body === "string" ? data.body : "";
   const tag = context.conversation ?? data.roomJid ?? "waddle";
+  if (isItemAlreadyShown(itemId)) {
+    // Foreground tab already rendered this item — only update the
+    // badge / unread broadcast, no duplicate banner.
+    event.waitUntil(
+      Promise.all([updateAppBadge(unreadCount), postUnreadCountToClients(unreadCount)]),
+    );
+    return;
+  }
+  noteItemShown(itemId);
   event.waitUntil(
     Promise.all([
       updateAppBadge(unreadCount),
@@ -169,25 +217,52 @@ function defaultTitle(unreadCount) {
   return `${unreadCount} new messages`;
 }
 
-/// Extract the typed `urn:waddle:push:context:0` routing context the
-/// server attaches to every published XEP-0357 notification. The
-/// Web Push HTTP dispatcher (server-side) flattens the XML into a
-/// JSON shape on `data.context = { conversation, thread, class }`.
-/// Legacy publishes that lack the typed context fall back to
-/// `data.roomJid` / `data.url` for compatibility.
-function parseRoutingContext(data) {
+/// Parse the PR-D2 `"v": 1` envelope emitted by
+/// `crates/waddle-xmpp/src/push/envelope.rs::PushEnvelope`. Field shape:
+///
+///   * `v`            — schema version (must equal 1)
+///   * `class`        — granular NotificationClass (`"dm"`, `"personal_mention"`, …)
+///   * `conversation` — DM peer bare JID or MUC room bare JID
+///   * `thread`       — XEP-0201 thread id (optional)
+///   * `item`         — originating stanza id (used for in-band dedup)
+///   * `unread`       — XEP-0357 message-count snapshot (optional)
+///
+/// Returns `null` when the envelope is absent (legacy publish, or a
+/// non-v=1 schema bump the server side may roll out later); the caller
+/// falls back to `parseLegacyRoutingContext`.
+function parseV1Envelope(data) {
+  if (!data || data.v !== 1) return null;
+  return {
+    conversation: typeof data.conversation === "string" ? data.conversation : undefined,
+    thread: typeof data.thread === "string" && data.thread.length > 0 ? data.thread : undefined,
+    class: typeof data.class === "string" ? data.class : undefined,
+    item: typeof data.item === "string" ? data.item : undefined,
+    unread: parseUnreadCount(data),
+  };
+}
+
+/// Pre-PR-D2 routing fallback. Legacy server builds wrote a nested
+/// `data.context = { conversation, thread, class }` object alongside
+/// `data.roomJid`. Kept until every reachable server is on the v=1
+/// envelope; remove once telemetry confirms no `v` absent / != 1
+/// publishes are landing.
+function parseLegacyRoutingContext(data) {
   const context = data?.context;
   if (context && typeof context === "object") {
     return {
       conversation: typeof context.conversation === "string" ? context.conversation : undefined,
       thread: typeof context.thread === "string" && context.thread.length > 0 ? context.thread : undefined,
       class: typeof context.class === "string" ? context.class : undefined,
+      item: undefined,
+      unread: parseUnreadCount(data),
     };
   }
   return {
     conversation: typeof data?.roomJid === "string" ? data.roomJid : undefined,
     thread: undefined,
     class: undefined,
+    item: undefined,
+    unread: parseUnreadCount(data),
   };
 }
 
@@ -248,7 +323,15 @@ function routeFromContext(context) {
 }
 
 function parseUnreadCount(data) {
-  const value = data?.messageCount ?? data?.["message-count"] ?? data?.unreadCount ?? data?.totalUnread;
+  // Prefer the PR-D2 v=1 envelope's `unread` field; fall back to the
+  // pre-D2 wire names so a server emitting either shape still surfaces
+  // a count.
+  const value =
+    data?.unread ??
+    data?.messageCount ??
+    data?.["message-count"] ??
+    data?.unreadCount ??
+    data?.totalUnread;
   if (value === undefined || value === null) return null;
   const parsed = typeof value === "number" ? value : Number(value);
   if (!Number.isFinite(parsed) || parsed < 0) return null;

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -644,6 +644,7 @@ export function useChatAppController(giphyApiKey: string) {
         body: event.body,
         roomJid: event.roomJid,
         isBroadcast,
+        stanzaId: event.stanzaId,
         onNavigate: (roomJid) => {
           const managedRoom = parseManagedRoomBareJid(roomJid);
           if (!managedRoom) return;
@@ -668,6 +669,7 @@ export function useChatAppController(giphyApiKey: string) {
           senderUsername: msg.nick,
           peerJid: msg.peerJid,
           body: msg.body,
+          stanzaId: msg.stanzaId,
           onNavigate: (peerJid) => {
             void handleOpenDm(peerJid);
           },

--- a/chat/src/shell/notifications.ts
+++ b/chat/src/shell/notifications.ts
@@ -138,14 +138,37 @@ export function usePushNotifications() {
   ): Promise<PushSubscription | null> {
     const reg = await getOrRegisterServiceWorker();
     if (!reg) return null;
+    let keyBytes: Uint8Array;
     try {
-      const keyBytes = urlBase64ToUint8Array(vapidPublicKey);
-      const sub = await reg.pushManager.subscribe({
+      keyBytes = urlBase64ToUint8Array(vapidPublicKey);
+    } catch (error) {
+      console.warn("[notifications] urlBase64ToUint8Array failed on VAPID key:", error);
+      return null;
+    }
+    // PushManager rejects `applicationServerKey` if the underlying
+    // backing buffer has a non-zero `byteOffset` or extends beyond the
+    // 65-byte uncompressed P-256 point — Firefox and Safari both
+    // surface that as InvalidAccessError. Pass the Uint8Array directly
+    // (PushManager accepts any BufferSource per spec) so the view's
+    // length + offset stay authoritative, instead of leaking the raw
+    // ArrayBuffer that may be larger.
+    if (keyBytes.length !== 65 || keyBytes[0] !== 0x04) {
+      // Belt-and-braces validation: the wasm parser already rejects
+      // malformed keys, but a cache-hit path that bypassed the parser
+      // (older code, race) could still reach this point. Refuse to
+      // subscribe rather than hand the browser garbage.
+      console.warn(
+        "[notifications] VAPID public key is not a 65-byte 0x04-prefixed SEC1 point; refusing to subscribe",
+      );
+      return null;
+    }
+    try {
+      return await reg.pushManager.subscribe({
         userVisibleOnly: true,
-        applicationServerKey: keyBytes.buffer as ArrayBuffer,
+        applicationServerKey: keyBytes,
       });
-      return sub;
-    } catch {
+    } catch (error) {
+      console.warn("[notifications] PushManager.subscribe() failed:", error);
       return null;
     }
   }
@@ -165,10 +188,11 @@ export function usePushNotifications() {
     serviceJid: string,
     reg: ServiceWorkerRegistration,
   ): Promise<{ subscription: PushSubscription; rotated: boolean } | null> {
-    return withVapidRotationLock(async () => {
+    const accountJid = barePart(userJid);
+    return withVapidRotationLock(accountJid, async () => {
       const advertisement = await loadVapidPublicKey({
         client: xmppClient,
-        accountJid: barePart(userJid),
+        accountJid,
         serverJid: serviceJid,
       });
       if (!advertisement) {
@@ -180,13 +204,26 @@ export function usePushNotifications() {
       }
       const existing = await reg.pushManager.getSubscription();
       const persistedKid = loadPersistedKid();
+      // Three rotation triggers:
+      //   1. persistedKid present and differs from the advertised kid
+      //      — server rotated under us.
+      //   2. persistedKid missing while `existing` survives — localStorage
+      //      was cleared (private mode, "Clear site data", new browser
+      //      profile that inherited the SW registration). We can't trust
+      //      the surviving subscription is bound to the current key, so
+      //      verify via `existing.options.applicationServerKey` directly.
+      //   3. The existing subscription's applicationServerKey doesn't
+      //      match the advertised bytes — server-side rotation we missed.
+      const existingKeyMatches =
+        existing === null || subscriptionApplicationKeyMatches(existing, advertisement.publicKey);
       const kidChanged = persistedKid !== null && persistedKid !== advertisement.kid;
-      if (existing && !kidChanged) {
+      if (existing && !kidChanged && existingKeyMatches) {
         persistKid(advertisement.kid);
         return { subscription: existing, rotated: false };
       }
-      // Either no subscription yet, or the server kid changed under us.
-      // Unsubscribe (if any) and re-subscribe under the new key.
+      // Either no subscription yet, server kid changed under us, or the
+      // surviving subscription is bound to a stale key. Unsubscribe (if
+      // any) and re-subscribe under the new key.
       if (existing) {
         try {
           await existing.unsubscribe();
@@ -511,6 +548,37 @@ function clearPersistedKid(): void {
 /// `alice@example.com` as the same logical account.
 function barePart(userJid: string): string {
   return userJid.split("/")[0] ?? userJid;
+}
+
+/// Compare an existing PushSubscription's applicationServerKey (the
+/// 65-byte uncompressed P-256 point the browser stored when the
+/// subscription was created) against the server's currently-advertised
+/// public key (in base64url-no-pad form). Used to detect a stale
+/// subscription whose kid we no longer have a record of — e.g. when
+/// localStorage was wiped but the SW registration survived.
+///
+/// Returns `true` when the subscription has no applicationServerKey
+/// (very old browsers / non-VAPID origin server endpoints) so callers
+/// don't churn the subscription on an irrelevant comparison.
+function subscriptionApplicationKeyMatches(
+  subscription: PushSubscription,
+  advertisedPublicKeyBase64Url: string,
+): boolean {
+  const existingKey = subscription.options.applicationServerKey;
+  if (!existingKey) return true;
+  let advertised: Uint8Array;
+  try {
+    advertised = urlBase64ToUint8Array(advertisedPublicKeyBase64Url);
+  } catch {
+    return false;
+  }
+  const existing =
+    existingKey instanceof ArrayBuffer ? new Uint8Array(existingKey) : new Uint8Array(existingKey);
+  if (existing.length !== advertised.length) return false;
+  for (let i = 0; i < existing.length; i++) {
+    if (existing[i] !== advertised[i]) return false;
+  }
+  return true;
 }
 
 function urlBase64ToUint8Array(base64String: string): Uint8Array {

--- a/chat/src/shell/notifications.ts
+++ b/chat/src/shell/notifications.ts
@@ -531,17 +531,33 @@ function loadPushNodeId(): string | null {
 
 function persistKid(kid: string): void {
   if (typeof window === "undefined") return;
-  window.localStorage.setItem(PUSH_KID_STORAGE_KEY, kid);
+  // Safari Lockdown Mode and some Firefox/Brave privacy configurations
+  // throw a SecurityError on `window.localStorage` access (not just on
+  // get/set). Wrap so a hardened browser doesn't kill the entire
+  // rotation flow on a single persistence call.
+  try {
+    window.localStorage.setItem(PUSH_KID_STORAGE_KEY, kid);
+  } catch (error) {
+    console.warn("[notifications] localStorage unavailable; kid not persisted:", error);
+  }
 }
 
 function loadPersistedKid(): string | null {
   if (typeof window === "undefined") return null;
-  return window.localStorage.getItem(PUSH_KID_STORAGE_KEY);
+  try {
+    return window.localStorage.getItem(PUSH_KID_STORAGE_KEY);
+  } catch {
+    return null;
+  }
 }
 
 function clearPersistedKid(): void {
   if (typeof window === "undefined") return;
-  window.localStorage.removeItem(PUSH_KID_STORAGE_KEY);
+  try {
+    window.localStorage.removeItem(PUSH_KID_STORAGE_KEY);
+  } catch {
+    // best-effort cleanup
+  }
 }
 
 /// Strip the optional `/resource` from a full JID so the cache key is

--- a/chat/src/shell/notifications.ts
+++ b/chat/src/shell/notifications.ts
@@ -162,10 +162,20 @@ export function usePushNotifications() {
       );
       return null;
     }
+    // Re-pack into a fresh `Uint8Array<ArrayBuffer>` view (NOT
+    // `Uint8Array<ArrayBufferLike>`, which TypeScript widens any
+    // `Uint8Array` to and which `PushSubscriptionOptionsInit.applicationServerKey`
+    // rejects because `SharedArrayBuffer` isn't a valid backing
+    // store). The new ArrayBuffer is owned by this view exclusively —
+    // no offset, exact 65-byte length — which is also the shape
+    // Firefox and Safari validate against; passing a wider backing
+    // buffer surfaces as InvalidAccessError in those engines.
+    const exactKey = new Uint8Array(new ArrayBuffer(keyBytes.byteLength));
+    exactKey.set(keyBytes);
     try {
       return await reg.pushManager.subscribe({
         userVisibleOnly: true,
-        applicationServerKey: keyBytes,
+        applicationServerKey: exactKey,
       });
     } catch (error) {
       console.warn("[notifications] PushManager.subscribe() failed:", error);

--- a/chat/src/shell/notifications.ts
+++ b/chat/src/shell/notifications.ts
@@ -145,13 +145,6 @@ export function usePushNotifications() {
       console.warn("[notifications] urlBase64ToUint8Array failed on VAPID key:", error);
       return null;
     }
-    // PushManager rejects `applicationServerKey` if the underlying
-    // backing buffer has a non-zero `byteOffset` or extends beyond the
-    // 65-byte uncompressed P-256 point — Firefox and Safari both
-    // surface that as InvalidAccessError. Pass the Uint8Array directly
-    // (PushManager accepts any BufferSource per spec) so the view's
-    // length + offset stay authoritative, instead of leaking the raw
-    // ArrayBuffer that may be larger.
     if (keyBytes.length !== 65 || keyBytes[0] !== 0x04) {
       // Belt-and-braces validation: the wasm parser already rejects
       // malformed keys, but a cache-hit path that bypassed the parser

--- a/chat/src/shell/notifications.ts
+++ b/chat/src/shell/notifications.ts
@@ -560,8 +560,13 @@ function barePart(userJid: string): string {
 /// Returns `true` when the subscription has no applicationServerKey
 /// (very old browsers / non-VAPID origin server endpoints) so callers
 /// don't churn the subscription on an irrelevant comparison.
-function subscriptionApplicationKeyMatches(
-  subscription: PushSubscription,
+///
+/// Exported so the test suite can pin the comparison semantics
+/// (cleared-localStorage rotation path is the entire point of this
+/// helper; covering it via the full `ensureBrowserSubscriptionWithCurrentKey`
+/// would require stubbing every PushManager + SW surface).
+export function subscriptionApplicationKeyMatches(
+  subscription: { options: { applicationServerKey?: ArrayBuffer | ArrayBufferView | null } },
   advertisedPublicKeyBase64Url: string,
 ): boolean {
   const existingKey = subscription.options.applicationServerKey;
@@ -572,8 +577,9 @@ function subscriptionApplicationKeyMatches(
   } catch {
     return false;
   }
-  const existing =
-    existingKey instanceof ArrayBuffer ? new Uint8Array(existingKey) : new Uint8Array(existingKey);
+  const existing = ArrayBuffer.isView(existingKey)
+    ? new Uint8Array(existingKey.buffer, existingKey.byteOffset, existingKey.byteLength)
+    : new Uint8Array(existingKey);
   if (existing.length !== advertised.length) return false;
   for (let i = 0; i < existing.length; i++) {
     if (existing[i] !== advertised[i]) return false;

--- a/chat/src/shell/notifications.ts
+++ b/chat/src/shell/notifications.ts
@@ -31,6 +31,11 @@ interface MentionNotificationOptions {
   body: string;
   roomJid: string;
   isBroadcast: boolean;
+  /** XEP-0359 stanza id of the originating message. When present, the
+   * foreground tab posts it to the active service worker via
+   * `waddle:item-shown` so a Web Push for the same id (arriving a few
+   * tens of ms later) is suppressed instead of double-firing. */
+  stanzaId?: string;
   onNavigate?: (roomJid: string) => void;
 }
 
@@ -38,7 +43,29 @@ interface DmNotificationOptions {
   senderUsername: string;
   peerJid: string;
   body: string;
+  /** XEP-0359 stanza id; see `MentionNotificationOptions.stanzaId`. */
+  stanzaId?: string;
   onNavigate?: (peerJid: string) => void;
+}
+
+/// Foreground→SW signal: tell the active service worker we just
+/// rendered a notification for this stanza id so it can suppress the
+/// matching Web Push when it lands. Best-effort: a missing controller
+/// (SW not active yet, or never installed) is silently ignored —
+/// without the SW running, there is no push handler to deliver a
+/// duplicate notification either.
+const SW_ITEM_SHOWN_MESSAGE_TYPE = "waddle:item-shown";
+function postItemShownToServiceWorker(itemId: string | undefined): void {
+  if (!itemId) return;
+  if (typeof navigator === "undefined" || !navigator.serviceWorker) return;
+  const controller = navigator.serviceWorker.controller;
+  if (!controller) return;
+  try {
+    controller.postMessage({ type: SW_ITEM_SHOWN_MESSAGE_TYPE, itemId });
+  } catch {
+    // postMessage can throw if the controller transitioned to
+    // redundant between the controller-check and the call.
+  }
 }
 
 export function usePushNotifications() {
@@ -107,6 +134,11 @@ export function usePushNotifications() {
       notification.close();
     };
 
+    // Foreground→SW dedup signal: post BEFORE the setTimeout-close so
+    // the SW Map records the id even if the user dismisses the banner
+    // before the SW push arrives.
+    postItemShownToServiceWorker(opts.stanzaId);
+
     setTimeout(() => notification.close(), 5000);
   }
 
@@ -124,6 +156,7 @@ export function usePushNotifications() {
       opts.onNavigate?.(opts.peerJid);
       notification.close();
     };
+    postItemShownToServiceWorker(opts.stanzaId);
     setTimeout(() => notification.close(), 5000);
   }
 

--- a/chat/src/shell/notifications.ts
+++ b/chat/src/shell/notifications.ts
@@ -2,12 +2,14 @@ import { ref, watch } from "vue";
 import type { BrowserXmppClient } from "@/lib/xmpp-client";
 import { getOrRegisterServiceWorker, registerServiceWorker as registerChatServiceWorker } from "@/lib/service-worker-registration";
 import { createPushFlowLock } from "./push-flow-lock";
+import { clearCachedVapidKey, loadVapidPublicKey } from "./vapid-cache";
+import { withVapidRotationLock } from "./vapid-rotation-lock";
 
 const STORAGE_KEY = "waddle.chat.notifications-enabled";
 const DEVICE_ID_STORAGE_KEY = "waddle.chat.push-device-id";
 const PUSH_NODE_STORAGE_KEY = "waddle.chat.push-node-id";
+const PUSH_KID_STORAGE_KEY = "waddle.chat.push-kid";
 const PUSH_SERVICE_JID = (import.meta.env.PUBLIC_WADDLE_XMPP_PUSH_SERVICE_JID ?? "").trim();
-const VAPID_PUBLIC_KEY = (import.meta.env.PUBLIC_WADDLE_VAPID_PUBLIC_KEY ?? "").trim();
 const NOTIFICATION_ICON_URL = "/android-chrome-192x192.png";
 
 /// Push Service app-id for the browser/PWA chat. APNs ("ios") and
@@ -44,6 +46,12 @@ export function usePushNotifications() {
     hasNotificationApi ? Notification.permission : "denied",
   );
   const notificationsEnabled = ref(loadEnabled());
+  /// Surfaced to the UI as a non-intrusive banner the first time a
+  /// silent kid rotation re-binds the browser PushSubscription to a new
+  /// VAPID key. The UI clears the flag once the banner is dismissed; we
+  /// don't persist this across reloads because the rotation has already
+  /// happened by then and re-showing would be noise.
+  const rotationBannerVisible = ref(false);
 
   // Serialize `syncPushSubscription` and `disablePushSubscription`
   // against each other. Without this, a rapid Enable→Disable toggle
@@ -142,6 +150,68 @@ export function usePushNotifications() {
     }
   }
 
+  /// Ensure the browser's PushSubscription is bound to the current
+  /// server-advertised VAPID public key. Detects rotation (kid change),
+  /// unsubscribes the stale subscription, and re-subscribes under the
+  /// new key. Cross-tab serialized via the rotation lock so a single tab
+  /// drives the re-subscribe sequence per rotation event.
+  ///
+  /// Returns the active subscription (post-rotation if any), or `null`
+  /// when the server doesn't advertise a VAPID form (Web Push not
+  /// configured on this deployment).
+  async function ensureBrowserSubscriptionWithCurrentKey(
+    xmppClient: BrowserXmppClient,
+    userJid: string,
+    serviceJid: string,
+    reg: ServiceWorkerRegistration,
+  ): Promise<{ subscription: PushSubscription; rotated: boolean } | null> {
+    return withVapidRotationLock(async () => {
+      const advertisement = await loadVapidPublicKey({
+        client: xmppClient,
+        accountJid: barePart(userJid),
+        serverJid: serviceJid,
+      });
+      if (!advertisement) {
+        console.warn(
+          "[notifications] Push Service does not advertise a VAPID public key; " +
+          "Web Push subscription skipped. Foreground Notification API still works.",
+        );
+        return null;
+      }
+      const existing = await reg.pushManager.getSubscription();
+      const persistedKid = loadPersistedKid();
+      const kidChanged = persistedKid !== null && persistedKid !== advertisement.kid;
+      if (existing && !kidChanged) {
+        persistKid(advertisement.kid);
+        return { subscription: existing, rotated: false };
+      }
+      // Either no subscription yet, or the server kid changed under us.
+      // Unsubscribe (if any) and re-subscribe under the new key.
+      if (existing) {
+        try {
+          await existing.unsubscribe();
+        } catch (error) {
+          console.warn(
+            "[notifications] PushManager.unsubscribe() failed during VAPID rotation; " +
+            "continuing to re-subscribe under the new key:",
+            error,
+          );
+        }
+      }
+      const fresh = await subscribeToPush(advertisement.publicKey);
+      if (!fresh) {
+        // Subscribe failed — drop the persisted kid + cache entry so the
+        // next attempt re-fetches from the server. The chat can also fall
+        // back to the foreground Notification API in this state.
+        clearPersistedKid();
+        clearCachedVapidKey(barePart(userJid), serviceJid);
+        return null;
+      }
+      persistKid(advertisement.kid);
+      return { subscription: fresh, rotated: kidChanged };
+    });
+  }
+
   /**
    * Full enable flow: ensure-node → register-device → XEP-0357 enable.
    *
@@ -171,32 +241,34 @@ export function usePushNotifications() {
       return false;
     }
 
-    // Get or create a browser-side PushSubscription. Without a VAPID
-    // public key configured at build time the browser will refuse to
-    // subscribe — log and bail so the caller can fall back to the
-    // foreground Notification API.
-    if (!VAPID_PUBLIC_KEY) {
-      console.warn(
-        "[notifications] PUBLIC_WADDLE_VAPID_PUBLIC_KEY is not set; Web Push subscription skipped. " +
-        "Foreground Notification API still works while the chat tab is open.",
-      );
-      return false;
-    }
+    // Resolve the browser-side PushSubscription against the server's
+    // currently-advertised VAPID public key. PR-D3 swapped the build-
+    // time `PUBLIC_WADDLE_VAPID_PUBLIC_KEY` env for a runtime fetch via
+    // the Push Service's XEP-0128 disco extension form so the chat can
+    // ship without provider-specific build secrets and so server-side
+    // VAPID rotations are picked up automatically.
     const reg = await getOrRegisterServiceWorker();
     if (!reg) {
       console.warn("[notifications] Service worker registration failed; push disabled");
       return false;
     }
-    let subscription = await reg.pushManager.getSubscription();
-    if (!subscription) {
-      subscription = await subscribeToPush(VAPID_PUBLIC_KEY);
-    }
-    if (!subscription) {
-      console.warn(
-        "[notifications] PushManager.subscribe() failed (browser may have rejected VAPID key)",
-      );
+    const subscribeResult = await ensureBrowserSubscriptionWithCurrentKey(
+      xmppClient,
+      userJid,
+      serviceJid,
+      reg,
+    );
+    if (!subscribeResult) {
+      // Either the server doesn't advertise a VAPID form, or
+      // pushManager.subscribe() rejected the key. The helper has
+      // already emitted a precise warning; the chat falls back to the
+      // foreground Notification API path.
       return false;
     }
+    if (subscribeResult.rotated) {
+      rotationBannerVisible.value = true;
+    }
+    const subscription = subscribeResult.subscription;
 
     const subJson = subscription.toJSON();
     const endpoint = subscription.endpoint;
@@ -338,12 +410,25 @@ export function usePushNotifications() {
       );
       return false;
     }
+    // Clean up rotation state: drop the persisted kid + cached
+    // advertisement so a re-enable starts from a fresh fetch. The
+    // cache is keyed per `(account, server)` so this only invalidates
+    // the entry for the disabling account, not any other tenant on the
+    // same device.
+    clearPersistedKid();
+    clearCachedVapidKey(barePart(userJid), serviceJid);
     return true;
+  }
+
+  function dismissRotationBanner() {
+    rotationBannerVisible.value = false;
   }
 
   return {
     permissionState,
     notificationsEnabled,
+    rotationBannerVisible,
+    dismissRotationBanner,
     requestPermission,
     showMentionNotification,
     showDmNotification,
@@ -402,6 +487,30 @@ function persistPushNodeId(node: string): void {
 function loadPushNodeId(): string | null {
   if (typeof window === "undefined") return null;
   return window.localStorage.getItem(PUSH_NODE_STORAGE_KEY);
+}
+
+function persistKid(kid: string): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(PUSH_KID_STORAGE_KEY, kid);
+}
+
+function loadPersistedKid(): string | null {
+  if (typeof window === "undefined") return null;
+  return window.localStorage.getItem(PUSH_KID_STORAGE_KEY);
+}
+
+function clearPersistedKid(): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.removeItem(PUSH_KID_STORAGE_KEY);
+}
+
+/// Strip the optional `/resource` from a full JID so the cache key is
+/// stable across reconnect cycles (XMPP resources rotate every
+/// connection). The bare-JID extraction mirrors `resolvePushServiceJid`'s
+/// behavior — both must treat `alice@example.com/abc` and
+/// `alice@example.com` as the same logical account.
+function barePart(userJid: string): string {
+  return userJid.split("/")[0] ?? userJid;
 }
 
 function urlBase64ToUint8Array(base64String: string): Uint8Array {

--- a/chat/src/shell/notifications.ts
+++ b/chat/src/shell/notifications.ts
@@ -8,7 +8,13 @@ import { withVapidRotationLock } from "./vapid-rotation-lock";
 const STORAGE_KEY = "waddle.chat.notifications-enabled";
 const DEVICE_ID_STORAGE_KEY = "waddle.chat.push-device-id";
 const PUSH_NODE_STORAGE_KEY = "waddle.chat.push-node-id";
-const PUSH_KID_STORAGE_KEY = "waddle.chat.push-kid";
+/// Prefix for the per-(account, service) persisted VAPID kid. The
+/// full key is built by `pushKidStorageKey(accountJid, serviceJid)`.
+/// Multi-account sessions MUST NOT share one global kid — without
+/// namespacing, account B's kid would overwrite account A's,
+/// causing spurious rotation triggers when A reconnects and reads
+/// B's kid back as "different from advertised".
+const PUSH_KID_STORAGE_PREFIX = "waddle.chat.push-kid:";
 const PUSH_SERVICE_JID = (import.meta.env.PUBLIC_WADDLE_XMPP_PUSH_SERVICE_JID ?? "").trim();
 const NOTIFICATION_ICON_URL = "/android-chrome-192x192.png";
 
@@ -171,6 +177,19 @@ export function usePushNotifications() {
   ): Promise<PushSubscription | null> {
     const reg = await getOrRegisterServiceWorker();
     if (!reg) return null;
+    return subscribeOnRegistration(reg, vapidPublicKey);
+  }
+
+  /// Subscribe `reg.pushManager` to Web Push for the given VAPID
+  /// public key. Split out from `subscribeToPush` so callers that
+  /// already hold a `ServiceWorkerRegistration` (the rotation path)
+  /// don't pay an extra `getOrRegisterServiceWorker()` round-trip —
+  /// that round-trip can spuriously fail under an SW-update race
+  /// while we hold the rotation lock.
+  async function subscribeOnRegistration(
+    reg: ServiceWorkerRegistration,
+    vapidPublicKey: string,
+  ): Promise<PushSubscription | null> {
     let keyBytes: Uint8Array;
     try {
       keyBytes = urlBase64ToUint8Array(vapidPublicKey);
@@ -226,10 +245,17 @@ export function usePushNotifications() {
   ): Promise<{ subscription: PushSubscription; rotated: boolean } | null> {
     const accountJid = barePart(userJid);
     return withVapidRotationLock(accountJid, async () => {
+      // Force-refresh while holding the rotation lock so a cache-hit
+      // path doesn't mask a real server-side VAPID rotation that
+      // landed inside the cache TTL window. The 1h cache TTL is a
+      // backstop for stale tabs; rotation detection MUST run against
+      // a fresh disco fetch every time the lock is taken (i.e. on
+      // every enable / reconnect).
       const advertisement = await loadVapidPublicKey({
         client: xmppClient,
         accountJid,
         serverJid: serviceJid,
+        forceRefresh: true,
       });
       if (!advertisement) {
         console.warn(
@@ -239,7 +265,7 @@ export function usePushNotifications() {
         return null;
       }
       const existing = await reg.pushManager.getSubscription();
-      const persistedKid = loadPersistedKid();
+      const persistedKid = loadPersistedKid(accountJid, serviceJid);
       // Three rotation triggers:
       //   1. persistedKid present and differs from the advertised kid
       //      — server rotated under us.
@@ -254,7 +280,7 @@ export function usePushNotifications() {
         existing === null || subscriptionApplicationKeyMatches(existing, advertisement.publicKey);
       const kidChanged = persistedKid !== null && persistedKid !== advertisement.kid;
       if (existing && !kidChanged && existingKeyMatches) {
-        persistKid(advertisement.kid);
+        persistKid(accountJid, serviceJid, advertisement.kid);
         return { subscription: existing, rotated: false };
       }
       // Either no subscription yet, server kid changed under us, or the
@@ -271,16 +297,20 @@ export function usePushNotifications() {
           );
         }
       }
-      const fresh = await subscribeToPush(advertisement.publicKey);
+      // Re-use the registration the caller already holds instead of
+      // re-fetching via `getOrRegisterServiceWorker()`. The double
+      // lookup could turn a recoverable state (we have `reg` in hand)
+      // into a `null` if the second async lookup raced an SW update.
+      const fresh = await subscribeOnRegistration(reg, advertisement.publicKey);
       if (!fresh) {
         // Subscribe failed — drop the persisted kid + cache entry so the
         // next attempt re-fetches from the server. The chat can also fall
         // back to the foreground Notification API in this state.
-        clearPersistedKid();
-        clearCachedVapidKey(barePart(userJid), serviceJid);
+        clearPersistedKid(accountJid, serviceJid);
+        clearCachedVapidKey(accountJid, serviceJid);
         return null;
       }
-      persistKid(advertisement.kid);
+      persistKid(accountJid, serviceJid, advertisement.kid);
       return { subscription: fresh, rotated: kidChanged };
     });
   }
@@ -484,12 +514,13 @@ export function usePushNotifications() {
       return false;
     }
     // Clean up rotation state: drop the persisted kid + cached
-    // advertisement so a re-enable starts from a fresh fetch. The
-    // cache is keyed per `(account, server)` so this only invalidates
-    // the entry for the disabling account, not any other tenant on the
-    // same device.
-    clearPersistedKid();
-    clearCachedVapidKey(barePart(userJid), serviceJid);
+    // advertisement so a re-enable starts from a fresh fetch. Both
+    // are keyed per `(account, server)` so this only invalidates the
+    // entry for the disabling account/service pair, not any other
+    // tenant on the same device.
+    const accountJid = barePart(userJid);
+    clearPersistedKid(accountJid, serviceJid);
+    clearCachedVapidKey(accountJid, serviceJid);
     return true;
   }
 
@@ -562,32 +593,41 @@ function loadPushNodeId(): string | null {
   return window.localStorage.getItem(PUSH_NODE_STORAGE_KEY);
 }
 
-function persistKid(kid: string): void {
+/// Build the per-(account, service) localStorage key for the
+/// persisted VAPID kid. `JSON.stringify` on a two-element array gives
+/// an unambiguous encoding regardless of the individual values'
+/// content (JIDs legally contain `:` and most other plausible
+/// separators), matching the namespacing rule used by `vapid-cache.ts`.
+function pushKidStorageKey(accountJid: string, serviceJid: string): string {
+  return `${PUSH_KID_STORAGE_PREFIX}${JSON.stringify([accountJid, serviceJid])}`;
+}
+
+function persistKid(accountJid: string, serviceJid: string, kid: string): void {
   if (typeof window === "undefined") return;
   // Safari Lockdown Mode and some Firefox/Brave privacy configurations
   // throw a SecurityError on `window.localStorage` access (not just on
   // get/set). Wrap so a hardened browser doesn't kill the entire
   // rotation flow on a single persistence call.
   try {
-    window.localStorage.setItem(PUSH_KID_STORAGE_KEY, kid);
+    window.localStorage.setItem(pushKidStorageKey(accountJid, serviceJid), kid);
   } catch (error) {
     console.warn("[notifications] localStorage unavailable; kid not persisted:", error);
   }
 }
 
-function loadPersistedKid(): string | null {
+function loadPersistedKid(accountJid: string, serviceJid: string): string | null {
   if (typeof window === "undefined") return null;
   try {
-    return window.localStorage.getItem(PUSH_KID_STORAGE_KEY);
+    return window.localStorage.getItem(pushKidStorageKey(accountJid, serviceJid));
   } catch {
     return null;
   }
 }
 
-function clearPersistedKid(): void {
+function clearPersistedKid(accountJid: string, serviceJid: string): void {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.removeItem(PUSH_KID_STORAGE_KEY);
+    window.localStorage.removeItem(pushKidStorageKey(accountJid, serviceJid));
   } catch {
     // best-effort cleanup
   }

--- a/chat/src/shell/vapid-cache.ts
+++ b/chat/src/shell/vapid-cache.ts
@@ -1,0 +1,114 @@
+import type { BrowserXmppClient } from "@/lib/xmpp-client";
+
+/// localStorage key prefix for the cached VAPID advertisement, namespaced
+/// per `(account_jid, server_jid)`. localStorage is sufficient here: each
+/// entry is ~120 bytes, all tabs share it, and the cache hit-rate is high
+/// (chat fetches once per (account, server) until the server rotates).
+const CACHE_PREFIX = "waddle.chat.vapid-cache:";
+
+/// Per-entry max age. The chat re-fetches at startup and after the
+/// rotation lock fires; this TTL bounds how stale a cache entry can get
+/// when neither happens (long-running tab on a server that silently
+/// rotated). 12 h is comfortably under the 14-day Web Push subscription
+/// validity window most relays advertise. The kid check still catches a
+/// rotation that lands inside the TTL; the TTL is only a backstop.
+const CACHE_MAX_AGE_MS = 12 * 60 * 60 * 1000;
+
+interface CachedVapidEntry {
+  publicKey: string;
+  kid: string;
+  fetchedAtMs: number;
+}
+
+function storageKey(accountJid: string, serverJid: string): string {
+  return `${CACHE_PREFIX}${accountJid}|${serverJid}`;
+}
+
+function isCachedVapidEntry(value: unknown): value is CachedVapidEntry {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.publicKey === "string" &&
+    candidate.publicKey.length > 0 &&
+    typeof candidate.kid === "string" &&
+    candidate.kid.length > 0 &&
+    typeof candidate.fetchedAtMs === "number" &&
+    Number.isFinite(candidate.fetchedAtMs)
+  );
+}
+
+function readCacheEntry(accountJid: string, serverJid: string): CachedVapidEntry | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(storageKey(accountJid, serverJid));
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!isCachedVapidEntry(parsed)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writeCacheEntry(
+  accountJid: string,
+  serverJid: string,
+  entry: CachedVapidEntry,
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(storageKey(accountJid, serverJid), JSON.stringify(entry));
+  } catch {
+    // Storage quota / private-mode rejection — chat continues without
+    // a cache hit on the next call. Not surfaced to the user.
+  }
+}
+
+export function clearCachedVapidKey(accountJid: string, serverJid: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(storageKey(accountJid, serverJid));
+  } catch {
+    // best-effort
+  }
+}
+
+interface LoadVapidPublicKeyOptions {
+  client: BrowserXmppClient;
+  accountJid: string;
+  serverJid: string;
+  forceRefresh?: boolean;
+  now?: () => number;
+}
+
+/**
+ * Resolve the Push Service's current VAPID public key for `(account, server)`,
+ * fetching via the XEP-0128 disco form when the cache is empty or stale.
+ *
+ * Returns `null` when the server reachably advertises no VAPID form
+ * (Web Push not configured) so the caller can degrade to the foreground
+ * Notification API path without raising a UI error.
+ */
+export async function loadVapidPublicKey(
+  opts: LoadVapidPublicKeyOptions,
+): Promise<CachedVapidEntry | null> {
+  const now = opts.now ?? Date.now;
+  if (!opts.forceRefresh) {
+    const cached = readCacheEntry(opts.accountJid, opts.serverJid);
+    if (cached && now() - cached.fetchedAtMs < CACHE_MAX_AGE_MS) {
+      return cached;
+    }
+  }
+  const fresh = await opts.client.fetchVapidPublicKey({ serviceJid: opts.serverJid });
+  if (!fresh) return null;
+  const entry: CachedVapidEntry = {
+    publicKey: fresh.publicKey,
+    kid: fresh.kid,
+    fetchedAtMs: now(),
+  };
+  writeCacheEntry(opts.accountJid, opts.serverJid, entry);
+  return entry;
+}
+
+/** Exposed for tests so they can pin a deterministic Date.now. */
+export const VAPID_CACHE_MAX_AGE_MS = CACHE_MAX_AGE_MS;

--- a/chat/src/shell/vapid-cache.ts
+++ b/chat/src/shell/vapid-cache.ts
@@ -9,10 +9,13 @@ const CACHE_PREFIX = "waddle.chat.vapid-cache:";
 /// Per-entry max age. The chat re-fetches at startup and after the
 /// rotation lock fires; this TTL bounds how stale a cache entry can get
 /// when neither happens (long-running tab on a server that silently
-/// rotated). 12 h is comfortably under the 14-day Web Push subscription
-/// validity window most relays advertise. The kid check still catches a
-/// rotation that lands inside the TTL; the TTL is only a backstop.
-const CACHE_MAX_AGE_MS = 12 * 60 * 60 * 1000;
+/// rotated). 1 h is a deliberate trade between (a) avoiding a re-fetch
+/// per reconnect on a non-rotated server and (b) shrinking the window
+/// during which a stale-but-cached key keeps the chat from picking up a
+/// rotation that lands inside the TTL. The kid check on every
+/// `ensureBrowserSubscriptionWithCurrentKey` call catches most rotations
+/// regardless of TTL; the TTL is the backstop for long-running tabs.
+const CACHE_MAX_AGE_MS = 60 * 60 * 1000;
 
 interface CachedVapidEntry {
   publicKey: string;
@@ -21,7 +24,11 @@ interface CachedVapidEntry {
 }
 
 function storageKey(accountJid: string, serverJid: string): string {
-  return `${CACHE_PREFIX}${accountJid}|${serverJid}`;
+  // JIDs are UTF-8 with broad allowed characters; a literal separator
+  // could collide if either side legally contained it. `JSON.stringify`
+  // on an array gives an unambiguous two-element encoding regardless of
+  // the individual values.
+  return `${CACHE_PREFIX}${JSON.stringify([accountJid, serverJid])}`;
 }
 
 function isCachedVapidEntry(value: unknown): value is CachedVapidEntry {

--- a/chat/src/shell/vapid-rotation-lock.ts
+++ b/chat/src/shell/vapid-rotation-lock.ts
@@ -68,13 +68,24 @@ function hasWebLocks(): NavigatorWithLocks | null {
   return navigator as unknown as NavigatorWithLocks;
 }
 
-/// In-process Promise chain used when `navigator.locks` is unavailable.
-/// One chain per process (=== one chain per tab); cross-tab races are
-/// handled correctness-wise by the idempotence of PushManager.subscribe.
-let fallbackChain: Promise<unknown> = Promise.resolve();
+/// In-process Promise chains used when `navigator.locks` is
+/// unavailable. One chain per lock name (per account) so different
+/// accounts in the same tab don't serialize through each other —
+/// matching the `navigator.locks` path which uses a distinct lock
+/// name per account. The map is keyed by the resolved lock name
+/// (`lockNameFor(accountJid)`); a missing entry is equivalent to an
+/// already-resolved chain. Cross-tab races on the fallback path
+/// remain best-effort: a concurrent rotation in another tab CAN
+/// produce a transient stale `register-device` row, recovered on
+/// the next `syncPushSubscriptionImpl` (i.e. next reconnect).
+const fallbackChains = new Map<string, Promise<unknown>>();
 
-async function withFallbackLock<T>(callback: RunInLock<T>): Promise<T> {
-  const next = fallbackChain.then(() => callback());
+async function withFallbackLock<T>(
+  lockName: string,
+  callback: RunInLock<T>,
+): Promise<T> {
+  const prev = fallbackChains.get(lockName) ?? Promise.resolve();
+  const next = prev.then(() => callback());
   // Use a single `then(success, failure)` form to register the chain's
   // continuation atomically. The two-step `next.catch(...)` pattern
   // would create a brief window in strict unhandledrejection runtimes
@@ -83,9 +94,12 @@ async function withFallbackLock<T>(callback: RunInLock<T>): Promise<T> {
   // synchronous rejection from `callback()` could fire an
   // unhandledrejection event before the `.catch` registers and swallows
   // it. Using `then(_, _)` attaches both handlers in one step.
-  fallbackChain = next.then(
-    () => undefined,
-    () => undefined,
+  fallbackChains.set(
+    lockName,
+    next.then(
+      () => undefined,
+      () => undefined,
+    ),
   );
   return next;
 }
@@ -102,18 +116,17 @@ export async function withVapidRotationLock<T>(
   accountJid: string | undefined,
   callback: RunInLock<T>,
 ): Promise<T> {
+  const lockName = lockNameFor(accountJid);
   const navWithLocks = hasWebLocks();
   if (!navWithLocks) {
-    return withFallbackLock(callback);
+    return withFallbackLock(lockName, callback);
   }
-  return navWithLocks.locks.request(lockNameFor(accountJid), { mode: "exclusive" }, () =>
-    callback(),
-  );
+  return navWithLocks.locks.request(lockName, { mode: "exclusive" }, () => callback());
 }
 
-/** Exposed for the test suite to reset the fallback chain between tests. */
+/** Exposed for the test suite to reset the fallback chains between tests. */
 export function __resetVapidRotationLockForTests(): void {
-  fallbackChain = Promise.resolve();
+  fallbackChains.clear();
 }
 
 /** Exposed so tests can assert on the lock-name shape used at the platform layer. */

--- a/chat/src/shell/vapid-rotation-lock.ts
+++ b/chat/src/shell/vapid-rotation-lock.ts
@@ -1,0 +1,78 @@
+/// Cross-tab exclusive lock for the VAPID-key rotation flow.
+///
+/// When the chat detects a kid mismatch between the server-advertised
+/// VAPID public key and the locally-cached one, only one tab should
+/// drive the re-subscribe sequence; otherwise multiple tabs would race
+/// to `pushManager.unsubscribe()` and `pushManager.subscribe()` against
+/// the same browser-level push registration, producing log noise and a
+/// brief window where some tabs hold a stale subscription.
+///
+/// `navigator.locks` (Web Locks API) is the canonical mechanism and is
+/// available everywhere the chat targets (Chrome 69+, Firefox 96+,
+/// Safari 15.4+). When absent — older iOS Safari builds, certain SSR
+/// or test environments — we fall back to an in-process Promise-chain
+/// serializer. The fallback is best-effort, but the operation it
+/// guards is itself idempotent (calling `subscribe({ applicationServerKey })`
+/// twice with the same key returns the same browser-level subscription),
+/// so a missed lock just produces redundant work, not incorrect state.
+
+const LOCK_NAME = "waddle:push:vapid-rotate";
+
+type RunInLock<T> = () => Promise<T>;
+
+interface NavigatorWithLocks {
+  locks: {
+    request: <T>(
+      name: string,
+      options: { mode: "exclusive" } | { mode: "shared" },
+      callback: () => Promise<T>,
+    ) => Promise<T>;
+  };
+}
+
+function hasWebLocks(): NavigatorWithLocks | null {
+  if (typeof navigator === "undefined") return null;
+  // `navigator.locks` is the Web Locks API surface — present everywhere
+  // the chat targets except the oldest iOS Safari versions. We probe
+  // existence rather than user-agent sniffing so test environments that
+  // explicitly stub `navigator.locks = undefined` exercise the fallback.
+  const candidate = (navigator as unknown as { locks?: NavigatorWithLocks["locks"] }).locks;
+  if (!candidate || typeof candidate.request !== "function") return null;
+  return navigator as unknown as NavigatorWithLocks;
+}
+
+/// In-process Promise chain used when `navigator.locks` is unavailable.
+/// One chain per process (=== one chain per tab); cross-tab races are
+/// handled correctness-wise by the idempotence of PushManager.subscribe.
+let fallbackChain: Promise<unknown> = Promise.resolve();
+
+async function withFallbackLock<T>(callback: RunInLock<T>): Promise<T> {
+  const next = fallbackChain.then(() => callback());
+  // Swallow rejections in the chain itself so a failing rotation doesn't
+  // permanently block subsequent acquires. The original promise is
+  // returned to the caller so the error still propagates.
+  fallbackChain = next.catch(() => undefined);
+  return next;
+}
+
+/**
+ * Run `callback` while holding the VAPID-rotation lock. The lock is
+ * automatically released when the returned Promise settles. Re-entrant
+ * calls within the same tab are serialized; calls from different tabs
+ * are serialized through `navigator.locks` when available.
+ */
+export async function withVapidRotationLock<T>(callback: RunInLock<T>): Promise<T> {
+  const navWithLocks = hasWebLocks();
+  if (!navWithLocks) {
+    return withFallbackLock(callback);
+  }
+  return navWithLocks.locks.request(LOCK_NAME, { mode: "exclusive" }, callback);
+}
+
+/** Exposed for the test suite to reset the fallback chain between tests. */
+export function __resetVapidRotationLockForTests(): void {
+  fallbackChain = Promise.resolve();
+}
+
+/** Exposed so tests can assert on the lock name used at the platform layer. */
+export const VAPID_ROTATION_LOCK_NAME = LOCK_NAME;

--- a/chat/src/shell/vapid-rotation-lock.ts
+++ b/chat/src/shell/vapid-rotation-lock.ts
@@ -37,12 +37,22 @@ function lockNameFor(accountJid: string | undefined): string {
 
 type RunInLock<T> = () => Promise<T>;
 
+/// Minimal subset of the Web Locks API `Lock` interface — sufficient to
+/// type the callback signature without pulling the full `lib.dom`
+/// type. Callers ignore the argument today; preserved on the
+/// signature so a future caller that needs `lock.mode` / `lock.name`
+/// can read them without re-typing.
+interface WebLock {
+  readonly mode: "exclusive" | "shared";
+  readonly name: string;
+}
+
 interface NavigatorWithLocks {
   locks: {
     request: <T>(
       name: string,
       options: { mode: "exclusive" } | { mode: "shared" },
-      callback: () => Promise<T>,
+      callback: (lock: WebLock | null) => Promise<T>,
     ) => Promise<T>;
   };
 }
@@ -88,7 +98,9 @@ export async function withVapidRotationLock<T>(
   if (!navWithLocks) {
     return withFallbackLock(callback);
   }
-  return navWithLocks.locks.request(lockNameFor(accountJid), { mode: "exclusive" }, callback);
+  return navWithLocks.locks.request(lockNameFor(accountJid), { mode: "exclusive" }, () =>
+    callback(),
+  );
 }
 
 /** Exposed for the test suite to reset the fallback chain between tests. */

--- a/chat/src/shell/vapid-rotation-lock.ts
+++ b/chat/src/shell/vapid-rotation-lock.ts
@@ -75,10 +75,18 @@ let fallbackChain: Promise<unknown> = Promise.resolve();
 
 async function withFallbackLock<T>(callback: RunInLock<T>): Promise<T> {
   const next = fallbackChain.then(() => callback());
-  // Swallow rejections in the chain itself so a failing rotation doesn't
-  // permanently block subsequent acquires. The original promise is
-  // returned to the caller so the error still propagates.
-  fallbackChain = next.catch(() => undefined);
+  // Use a single `then(success, failure)` form to register the chain's
+  // continuation atomically. The two-step `next.catch(...)` pattern
+  // would create a brief window in strict unhandledrejection runtimes
+  // (Node 15+ with `--unhandled-rejections=strict`, some test runners)
+  // where the `.catch` handler hasn't been attached yet — a microtask-
+  // synchronous rejection from `callback()` could fire an
+  // unhandledrejection event before the `.catch` registers and swallows
+  // it. Using `then(_, _)` attaches both handlers in one step.
+  fallbackChain = next.then(
+    () => undefined,
+    () => undefined,
+  );
   return next;
 }
 

--- a/chat/src/shell/vapid-rotation-lock.ts
+++ b/chat/src/shell/vapid-rotation-lock.ts
@@ -9,14 +9,31 @@
 ///
 /// `navigator.locks` (Web Locks API) is the canonical mechanism and is
 /// available everywhere the chat targets (Chrome 69+, Firefox 96+,
-/// Safari 15.4+). When absent — older iOS Safari builds, certain SSR
-/// or test environments — we fall back to an in-process Promise-chain
-/// serializer. The fallback is best-effort, but the operation it
-/// guards is itself idempotent (calling `subscribe({ applicationServerKey })`
-/// twice with the same key returns the same browser-level subscription),
-/// so a missed lock just produces redundant work, not incorrect state.
+/// Safari 15.4+). When absent — SSR, test environments, or older
+/// browsers — we fall back to an in-process Promise-chain serializer.
+/// This is best-effort; the fallback does NOT prevent cross-tab races.
+///
+/// Cross-tab race window when running on the fallback: two tabs may
+/// each call `unsubscribe()` + `subscribe(newKey)` concurrently. Both
+/// tabs end up with valid subscriptions, but the SECOND `subscribe`
+/// call replaces the first inside the browser's push registration —
+/// so the first tab's `register-device` IQ will have written
+/// credentials that are immediately stale. The caller layer
+/// (`syncPushSubscriptionImpl`) re-issues `register-device` on every
+/// reconnect so the stale row gets overwritten on the next sync; the
+/// transient inconsistency is bounded by one reconnect.
 
-const LOCK_NAME = "waddle:push:vapid-rotate";
+const LOCK_NAME_PREFIX = "waddle:push:vapid-rotate";
+
+/// Build the per-account lock name. Different accounts in different
+/// tabs MUST NOT serialize through one global lock — the rotation flows
+/// are independent, and a slow rotation on account A would otherwise
+/// hold up an unrelated subscribe on account B. The account JID is
+/// already validated upstream (bare JID for the active session), so
+/// embedding it verbatim is safe.
+function lockNameFor(accountJid: string | undefined): string {
+  return accountJid ? `${LOCK_NAME_PREFIX}:${accountJid}` : LOCK_NAME_PREFIX;
+}
 
 type RunInLock<T> = () => Promise<T>;
 
@@ -56,17 +73,22 @@ async function withFallbackLock<T>(callback: RunInLock<T>): Promise<T> {
 }
 
 /**
- * Run `callback` while holding the VAPID-rotation lock. The lock is
- * automatically released when the returned Promise settles. Re-entrant
- * calls within the same tab are serialized; calls from different tabs
- * are serialized through `navigator.locks` when available.
+ * Run `callback` while holding the VAPID-rotation lock for `accountJid`.
+ * The lock is automatically released when the returned Promise settles.
+ * Re-entrant calls within the same tab are serialized; calls from
+ * different tabs are serialized through `navigator.locks` when
+ * available. Different accounts use distinct lock names so cross-
+ * account rotations don't block each other.
  */
-export async function withVapidRotationLock<T>(callback: RunInLock<T>): Promise<T> {
+export async function withVapidRotationLock<T>(
+  accountJid: string | undefined,
+  callback: RunInLock<T>,
+): Promise<T> {
   const navWithLocks = hasWebLocks();
   if (!navWithLocks) {
     return withFallbackLock(callback);
   }
-  return navWithLocks.locks.request(LOCK_NAME, { mode: "exclusive" }, callback);
+  return navWithLocks.locks.request(lockNameFor(accountJid), { mode: "exclusive" }, callback);
 }
 
 /** Exposed for the test suite to reset the fallback chain between tests. */
@@ -74,5 +96,7 @@ export function __resetVapidRotationLockForTests(): void {
   fallbackChain = Promise.resolve();
 }
 
-/** Exposed so tests can assert on the lock name used at the platform layer. */
-export const VAPID_ROTATION_LOCK_NAME = LOCK_NAME;
+/** Exposed so tests can assert on the lock-name shape used at the platform layer. */
+export function vapidRotationLockNameForTests(accountJid: string | undefined): string {
+  return lockNameFor(accountJid);
+}

--- a/chat/tests/service-worker-push.test.ts
+++ b/chat/tests/service-worker-push.test.ts
@@ -77,21 +77,21 @@ function makeNotificationClickEvent(data: Record<string, unknown>) {
 }
 
 describe("service worker push handling", () => {
-  test("minimal XEP-0357 payload renders default title + no body preview, updates badge", async () => {
-    // Canonical XEP-0357 publish carries only `message-count` plus
-    // the `urn:waddle:push:context:0` routing context. No sender,
-    // no body — preview is opt-in and out of the default path
-    // (#528 acceptance criterion).
+  test("minimal v=1 payload renders default count title with no body preview, updates badge", async () => {
+    // Canonical v=1 envelope from
+    // `crates/waddle-xmpp/src/push/envelope.rs::PushEnvelope`. XEP-0357
+    // §4 forbids the push service from receiving message content, so
+    // there is never a sender or body preview — the SW always renders
+    // the count-derived default with an empty body.
     const client = { postMessage: mock((_message: unknown) => {}) };
     const worker = loadServiceWorker([client]);
     const event = makePushEvent({
       json: () => ({
-        "message-count": 6,
-        context: {
-          conversation: "space_channel@conference.example.com",
-          thread: "",
-          class: "personal_mention",
-        },
+        v: 1,
+        class: "personal_mention",
+        conversation: "space_channel@conference.example.com",
+        item: "stanza-id-mention-1",
+        unread: 6,
       }),
     });
 
@@ -103,8 +103,6 @@ describe("service worker push handling", () => {
       type: "waddle:unread-count",
       unreadCount: 6,
     });
-    // Default title is count-derived; body is the empty string (no
-    // preview unless the server explicitly populated it).
     expect(worker.showNotification).toHaveBeenCalledWith("6 new messages", {
       body: "",
       tag: "space_channel@conference.example.com",
@@ -124,8 +122,11 @@ describe("service worker push handling", () => {
     const worker = loadServiceWorker();
     const event = makePushEvent({
       json: () => ({
-        "message-count": 1,
-        context: { conversation: "alice@example.com" },
+        v: 1,
+        class: "dm",
+        conversation: "alice@example.com",
+        item: "stanza-id-1msg",
+        unread: 1,
       }),
     });
     worker.dispatch("push", event);
@@ -134,58 +135,19 @@ describe("service worker push handling", () => {
     expect(worker.showNotification.mock.calls[0]?.[0]).toBe("1 new message");
   });
 
-  test("opt-in preview keeps server-provided title/body", async () => {
-    const worker = loadServiceWorker();
-    const event = makePushEvent({
-      json: () => ({
-        title: "Mention from @alice",
-        body: "hello there",
-        "message-count": 1,
-        context: { conversation: "space_channel@conference.example.com" },
-      }),
-    });
-    worker.dispatch("push", event);
-    await event.done();
-
-    const [title, options] = worker.showNotification.mock.calls[0] ?? [];
-    expect(title).toBe("Mention from @alice");
-    expect((options as NotificationOptions).body).toBe("hello there");
-  });
-
-  test("dm conversation routes to /dm/{username}", async () => {
-    const worker = loadServiceWorker();
-    const event = makePushEvent({
-      json: () => ({
-        "message-count": 1,
-        context: { conversation: "alice@example.com", class: "dm" },
-      }),
-    });
-    worker.dispatch("push", event);
-    await event.done();
-
-    const [, options] = worker.showNotification.mock.calls[0] ?? [];
-    expect((options as NotificationOptions & { data: { url: string } }).data.url).toBe("/dm/alice");
-  });
-
   test("dm with underscore in localpart routes as DM, not MUC", async () => {
     // Regression for an MUC heuristic that misrouted `jane_doe@example.com`
     // to `/jane/doe` (the underscore-as-MUC-separator fallback).
     // JIDs legally contain underscores; route on the typed `class`
-    // field or the JID's domain prefix instead. Adversarial review
-    // round-1 finding on PR #760.
+    // field or the JID's domain prefix instead.
     const worker = loadServiceWorker();
     const event = makePushEvent({
       json: () => ({
-        "message-count": 1,
-        context: {
-          conversation: "jane_doe@example.com",
-          // `"dm"` matches DM_CLASS_VALUES exactly so the test is
-          // independent of the domain heuristic. With `"direct"` (a
-          // value the server never emits) the test would pass only
-          // because `example.com` doesn't start with `muc.` — a
-          // silent regression risk.
-          class: "dm",
-        },
+        v: 1,
+        class: "dm",
+        conversation: "jane_doe@example.com",
+        item: "stanza-id-underscore",
+        unread: 1,
       }),
     });
     worker.dispatch("push", event);
@@ -197,18 +159,17 @@ describe("service worker push handling", () => {
     );
   });
 
-
   test("muc conversation routes to /r/{channelId}", async () => {
     // Chat router URL is `/r/{channelId}` where channelId == JID
     // localpart (see chat/src/lib/xmpp/jid.ts::parseManagedRoomBareJid).
     const worker = loadServiceWorker();
     const event = makePushEvent({
       json: () => ({
-        "message-count": 1,
-        context: {
-          conversation: "general@muc.example.com",
-          class: "personal_mention",
-        },
+        v: 1,
+        class: "personal_mention",
+        conversation: "general@muc.example.com",
+        item: "stanza-id-muc",
+        unread: 1,
       }),
     });
     worker.dispatch("push", event);
@@ -220,29 +181,6 @@ describe("service worker push handling", () => {
     );
   });
 
-  test("thread context routes via ?thread= query string, not path segment", async () => {
-    // Chat router carries threads in a search-param codec
-    // (chat/src/router/codecs.ts::threadSearch), NOT a path segment.
-    const worker = loadServiceWorker();
-    const event = makePushEvent({
-      json: () => ({
-        "message-count": 1,
-        context: {
-          conversation: "general@muc.example.com",
-          thread: "thread-42",
-          class: "personal_mention",
-        },
-      }),
-    });
-    worker.dispatch("push", event);
-    await event.done();
-
-    const [, options] = worker.showNotification.mock.calls[0] ?? [];
-    expect((options as NotificationOptions & { data: { url: string } }).data.url).toBe(
-      "/r/general?thread=thread-42",
-    );
-  });
-
   test("class='dm' overrides @muc. domain prefix", async () => {
     // Defense-in-depth: a misconfigured server that issues DMs from
     // a `muc.` subdomain MUST still route as DM when the typed
@@ -250,11 +188,11 @@ describe("service worker push handling", () => {
     const worker = loadServiceWorker();
     const event = makePushEvent({
       json: () => ({
-        "message-count": 1,
-        context: {
-          conversation: "alice@muc.example.com",
-          class: "dm",
-        },
+        v: 1,
+        class: "dm",
+        conversation: "alice@muc.example.com",
+        item: "stanza-id-class-override",
+        unread: 1,
       }),
     });
     worker.dispatch("push", event);
@@ -270,11 +208,11 @@ describe("service worker push handling", () => {
     const worker = loadServiceWorker();
     const event = makePushEvent({
       json: () => ({
-        "message-count": 1,
-        context: {
-          conversation: "general@muc.example.com",
-          class: "notify_all",
-        },
+        v: 1,
+        class: "notify_all",
+        conversation: "general@muc.example.com",
+        item: "stanza-id-notify-all",
+        unread: 1,
       }),
     });
     worker.dispatch("push", event);
@@ -286,52 +224,16 @@ describe("service worker push handling", () => {
     );
   });
 
-  test("legacy data.url is honored when typed context is absent", async () => {
-    // Mixed-version publishers (server pre-#528 emitter that doesn't
-    // carry `context: { conversation }`) ship a deep link in
-    // `data.url`. The SW must preserve that legacy behavior rather
-    // than collapsing to `/`. ChatGPT Codex bot flagged this
-    // regression on round-5.
-    const worker = loadServiceWorker();
-    const event = makePushEvent({
-      json: () => ({
-        "message-count": 1,
-        url: "/r/legacy-channel?thread=abc",
-      }),
-    });
-    worker.dispatch("push", event);
-    await event.done();
-
-    const [, options] = worker.showNotification.mock.calls[0] ?? [];
-    expect((options as NotificationOptions & { data: { url: string } }).data.url).toBe(
-      "/r/legacy-channel?thread=abc",
-    );
-  });
-
-  test("legacy data.url is rejected if cross-origin", async () => {
-    // Defense in depth: even on the legacy path, an off-origin
-    // `data.url` must NOT be accepted. `sameOriginUrl` runs first.
-    const worker = loadServiceWorker();
-    const event = makePushEvent({
-      json: () => ({
-        "message-count": 1,
-        url: "https://evil.example/steal",
-      }),
-    });
-    worker.dispatch("push", event);
-    await event.done();
-
-    const [, options] = worker.showNotification.mock.calls[0] ?? [];
-    expect((options as NotificationOptions & { data: { url: string } }).data.url).toBe("/");
-  });
-
-  test("clears the app badge when push message-count is zero", async () => {
+  test("clears the app badge when v=1 unread is zero", async () => {
     const client = { postMessage: mock((_message: unknown) => {}) };
     const worker = loadServiceWorker([client]);
     const event = makePushEvent({
       json: () => ({
-        "message-count": 0,
-        context: { conversation: "alice@example.com", class: "dm" },
+        v: 1,
+        class: "dm",
+        conversation: "alice@example.com",
+        item: "stanza-id-zero",
+        unread: 0,
       }),
     });
 
@@ -342,6 +244,33 @@ describe("service worker push handling", () => {
     expect(client.postMessage).toHaveBeenCalledWith({
       type: "waddle:unread-count",
       unreadCount: 0,
+    });
+  });
+
+  test("non-v=1 payload collapses to the minimal default banner", async () => {
+    // Breaking-changes-by-default: a payload missing `v: 1` (or with
+    // a future-unknown version) is rendered as the minimal "Waddle"
+    // notification, not auto-routed via legacy heuristics. The chat
+    // upgrades the SW alongside the server; mixed-version publishers
+    // are not supported.
+    const worker = loadServiceWorker();
+    const event = makePushEvent({
+      json: () => ({ "message-count": 5, context: { conversation: "alice@example.com" } }),
+    });
+    worker.dispatch("push", event);
+    await event.done();
+    expect(worker.showNotification).toHaveBeenCalledWith("Waddle", {
+      body: "",
+      tag: "waddle",
+      icon: "/android-chrome-192x192.png",
+      data: {
+        url: "/",
+        context: {
+          conversation: undefined,
+          thread: undefined,
+          class: undefined,
+        },
+      },
     });
   });
 

--- a/chat/tests/service-worker-push.test.ts
+++ b/chat/tests/service-worker-push.test.ts
@@ -420,4 +420,103 @@ describe("service worker push handling", () => {
       "/myspace/general/threads/thread-42",
     );
   });
+
+  test("v=1 envelope: dm class routes to /dm/{username}", async () => {
+    // PR-D3: server emits flat `{ v: 1, class, conversation, thread?, item, unread? }`
+    // — the SW must parse this shape and route the same as the legacy
+    // nested-context shape.
+    const worker = loadServiceWorker();
+    const event = makePushEvent({
+      json: () => ({
+        v: 1,
+        class: "dm",
+        conversation: "alice@example.com",
+        item: "stanza-id-001",
+        unread: 3,
+      }),
+    });
+    worker.dispatch("push", event);
+    await event.done();
+
+    expect(worker.setAppBadge).toHaveBeenCalledWith(3);
+    const [title, options] = worker.showNotification.mock.calls[0] ?? [];
+    expect(title).toBe("3 new messages");
+    expect((options as NotificationOptions & { data: { url: string } }).data.url).toBe(
+      "/dm/alice",
+    );
+  });
+
+  test("v=1 envelope: channel mention routes to /r/{channelId}?thread=…", async () => {
+    const worker = loadServiceWorker();
+    const event = makePushEvent({
+      json: () => ({
+        v: 1,
+        class: "personal_mention",
+        conversation: "general@muc.example.com",
+        thread: "thread-42",
+        item: "stanza-id-002",
+        unread: 1,
+      }),
+    });
+    worker.dispatch("push", event);
+    await event.done();
+
+    const [, options] = worker.showNotification.mock.calls[0] ?? [];
+    expect((options as NotificationOptions & { data: { url: string } }).data.url).toBe(
+      "/r/general?thread=thread-42",
+    );
+  });
+
+  test("v=1 envelope: duplicate item id suppresses the second SW notification", async () => {
+    // In-band dedup: if the chat tab already rendered a foreground
+    // notification for this stanza id, the SW push (arriving a few ms
+    // later) should NOT fire a second banner — it should only refresh
+    // the badge + unread count.
+    const worker = loadServiceWorker();
+    const first = makePushEvent({
+      json: () => ({
+        v: 1,
+        class: "dm",
+        conversation: "alice@example.com",
+        item: "stanza-dedup-1",
+        unread: 1,
+      }),
+    });
+    worker.dispatch("push", first);
+    await first.done();
+    expect(worker.showNotification).toHaveBeenCalledTimes(1);
+
+    const second = makePushEvent({
+      json: () => ({
+        v: 1,
+        class: "dm",
+        conversation: "alice@example.com",
+        item: "stanza-dedup-1",
+        unread: 2,
+      }),
+    });
+    worker.dispatch("push", second);
+    await second.done();
+    // No second showNotification — but badge + broadcast still update.
+    expect(worker.showNotification).toHaveBeenCalledTimes(1);
+    expect(worker.setAppBadge).toHaveBeenLastCalledWith(2);
+  });
+
+  test("v=1 envelope: distinct item ids each render their own notification", async () => {
+    const worker = loadServiceWorker();
+    for (const item of ["a", "b"]) {
+      const event = makePushEvent({
+        json: () => ({
+          v: 1,
+          class: "dm",
+          conversation: "alice@example.com",
+          item,
+          unread: 1,
+        }),
+      });
+      worker.dispatch("push", event);
+      await event.done();
+    }
+    expect(worker.showNotification).toHaveBeenCalledTimes(2);
+  });
 });

--- a/chat/tests/service-worker-push.test.ts
+++ b/chat/tests/service-worker-push.test.ts
@@ -520,6 +520,49 @@ describe("service worker push handling", () => {
     expect(worker.showNotification).toHaveBeenCalledTimes(2);
   });
 
+  test("v=1 envelope: dedup map evicts under overflow without unbounded scan", async () => {
+    // Regression for round-4 perf finding: under a burst of > 256
+    // distinct items inside the TTL window, the eviction scan must
+    // not degrade to O(SHOWN_ITEM_MAX) per push. Capped probe +
+    // FIFO fallback should keep eviction O(1) amortized.
+    //
+    // We can't directly time the SW from outside, but we can pin the
+    // OBSERVABLE consequence: after pushing N > MAX distinct items,
+    // the very first item must no longer be considered "shown" — it
+    // got evicted to make room. The second-to-last must still be
+    // suppressible. This catches a regression that broke eviction
+    // entirely (e.g. forgot to `delete` the head).
+    const worker = loadServiceWorker();
+    const fire = async (item: string) => {
+      const event = makePushEvent({
+        json: () => ({
+          v: 1,
+          class: "dm",
+          conversation: "alice@example.com",
+          item,
+          unread: 1,
+        }),
+      });
+      worker.dispatch("push", event);
+      await event.done();
+    };
+    // 260 distinct items: 4 past the 256 cap so the FIFO-head eviction
+    // fires multiple times.
+    const ITEMS = 260;
+    for (let i = 0; i < ITEMS; i++) {
+      await fire(`burst-${i}`);
+    }
+    // Each was distinct so each rendered. (Sanity check that the
+    // dedup didn't accidentally suppress any.)
+    expect(worker.showNotification).toHaveBeenCalledTimes(ITEMS);
+    // The first item was evicted: re-firing it now must render again.
+    await fire("burst-0");
+    expect(worker.showNotification).toHaveBeenCalledTimes(ITEMS + 1);
+    // A recent item is still in the dedup window: re-firing must NOT render.
+    await fire(`burst-${ITEMS - 1}`);
+    expect(worker.showNotification).toHaveBeenCalledTimes(ITEMS + 1);
+  });
+
   test("v=1 envelope: dedup map is recency-aware (delete-then-set on re-touch)", async () => {
     // Regression for round-3 perf finding: without `delete-then-set` on
     // re-noting an item, the Map's FIFO order is by ORIGINAL insertion,

--- a/chat/tests/service-worker-push.test.ts
+++ b/chat/tests/service-worker-push.test.ts
@@ -519,4 +519,47 @@ describe("service worker push handling", () => {
     }
     expect(worker.showNotification).toHaveBeenCalledTimes(2);
   });
+
+  test("v=1 envelope: dedup map is recency-aware (delete-then-set on re-touch)", async () => {
+    // Regression for round-3 perf finding: without `delete-then-set` on
+    // re-noting an item, the Map's FIFO order is by ORIGINAL insertion,
+    // so a retried push for an early item gets evicted while still
+    // inside its TTL window. The fix re-orders re-touched items to the
+    // tail so eviction tracks recency.
+    //
+    // We can't directly inspect the Map from outside, so we exercise
+    // the observable consequence: an item re-noted after the dedup
+    // window slips suppresses again (recency-update lets the entry
+    // survive eviction pressure long enough to dedup another retry).
+    const worker = loadServiceWorker();
+    const fire = async (item: string) => {
+      const event = makePushEvent({
+        json: () => ({
+          v: 1,
+          class: "dm",
+          conversation: "alice@example.com",
+          item,
+          unread: 1,
+        }),
+      });
+      worker.dispatch("push", event);
+      await event.done();
+    };
+    // First fire: renders.
+    await fire("item-A");
+    expect(worker.showNotification).toHaveBeenCalledTimes(1);
+    // Re-fire same item: suppressed (already shown).
+    await fire("item-A");
+    expect(worker.showNotification).toHaveBeenCalledTimes(1);
+    // Distinct item: renders.
+    await fire("item-B");
+    expect(worker.showNotification).toHaveBeenCalledTimes(2);
+    // Re-fire the FIRST item AGAIN: still suppressed. Without the
+    // delete-then-set, this branch already held under low pressure;
+    // the regression manifests under churn, but pinning the basic
+    // delete-on-touch contract here guards against accidental
+    // simplification.
+    await fire("item-A");
+    expect(worker.showNotification).toHaveBeenCalledTimes(2);
+  });
 });

--- a/chat/tests/service-worker-push.test.ts
+++ b/chat/tests/service-worker-push.test.ts
@@ -520,6 +520,75 @@ describe("service worker push handling", () => {
     expect(worker.showNotification).toHaveBeenCalledTimes(2);
   });
 
+  test("foreground→SW signal: waddle:item-shown message suppresses the subsequent push for the same item", async () => {
+    // The chat tab calls `postMessage({ type: 'waddle:item-shown', itemId })`
+    // from `showMentionNotification` / `showDmNotification` when an
+    // in-band notification renders. The SW must record that id so the
+    // matching Web Push (arriving milliseconds later from the relay)
+    // doesn't double-fire.
+    const worker = loadServiceWorker();
+    worker.dispatch("message", {
+      data: { type: "waddle:item-shown", itemId: "stanza-foreground-1" },
+    });
+    const event = makePushEvent({
+      json: () => ({
+        v: 1,
+        class: "dm",
+        conversation: "alice@example.com",
+        item: "stanza-foreground-1",
+        unread: 1,
+      }),
+    });
+    worker.dispatch("push", event);
+    await event.done();
+    // No banner — the foreground tab already rendered for this id.
+    expect(worker.showNotification).not.toHaveBeenCalled();
+    // Badge + unread broadcast still updated.
+    expect(worker.setAppBadge).toHaveBeenCalledWith(1);
+  });
+
+  test("foreground→SW signal: a different item id is NOT suppressed", async () => {
+    const worker = loadServiceWorker();
+    worker.dispatch("message", {
+      data: { type: "waddle:item-shown", itemId: "stanza-foreground-1" },
+    });
+    const event = makePushEvent({
+      json: () => ({
+        v: 1,
+        class: "dm",
+        conversation: "alice@example.com",
+        item: "stanza-different-2",
+        unread: 1,
+      }),
+    });
+    worker.dispatch("push", event);
+    await event.done();
+    expect(worker.showNotification).toHaveBeenCalledTimes(1);
+  });
+
+  test("foreground→SW signal: malformed message is ignored", async () => {
+    // A non-string itemId, missing itemId, or unknown type must be
+    // tolerated — the SW shouldn't crash on a stray cross-tab message.
+    const worker = loadServiceWorker();
+    worker.dispatch("message", { data: { type: "waddle:item-shown" } });
+    worker.dispatch("message", { data: { type: "waddle:item-shown", itemId: 42 } });
+    worker.dispatch("message", { data: { type: "unknown-type", itemId: "x" } });
+    worker.dispatch("message", {});
+    // None of those should register dedup for an item with this id.
+    const event = makePushEvent({
+      json: () => ({
+        v: 1,
+        class: "dm",
+        conversation: "alice@example.com",
+        item: "x",
+        unread: 1,
+      }),
+    });
+    worker.dispatch("push", event);
+    await event.done();
+    expect(worker.showNotification).toHaveBeenCalledTimes(1);
+  });
+
   test("v=1 envelope: dedup map evicts under overflow without unbounded scan", async () => {
     // Regression for round-4 perf finding: under a burst of > 256
     // distinct items inside the TTL window, the eviction scan must

--- a/chat/tests/subscription-application-key-matches.test.ts
+++ b/chat/tests/subscription-application-key-matches.test.ts
@@ -1,0 +1,85 @@
+// Coverage for the cleared-localStorage rotation guard.
+//
+// `ensureBrowserSubscriptionWithCurrentKey` (chat/src/shell/notifications.ts)
+// triggers re-subscription whenever the existing PushSubscription's
+// `applicationServerKey` bytes don't match the freshly-advertised
+// public key — i.e. when localStorage was wiped (private mode,
+// "Clear site data", inherited SW from a different account) and we
+// can't trust the surviving subscription is bound to the current key.
+// This test pins the byte-level comparison semantics.
+
+import { describe, expect, test } from "bun:test";
+import { subscriptionApplicationKeyMatches } from "../src/shell/notifications";
+
+/** 65-byte uncompressed SEC1 P-256 point — first byte 0x04, rest fill. */
+function samplePointBytes(seed = 0xab): Uint8Array {
+  const bytes = new Uint8Array(65);
+  bytes[0] = 0x04;
+  for (let i = 1; i < bytes.length; i++) {
+    bytes[i] = (seed + i) & 0xff;
+  }
+  return bytes;
+}
+
+function urlBase64NoPad(bytes: Uint8Array): string {
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+}
+
+describe("subscriptionApplicationKeyMatches", () => {
+  test("returns true when both sides hold the same 65-byte SEC1 point (ArrayBuffer)", () => {
+    const bytes = samplePointBytes();
+    const advertised = urlBase64NoPad(bytes);
+    expect(
+      subscriptionApplicationKeyMatches({ options: { applicationServerKey: bytes.buffer } }, advertised),
+    ).toBe(true);
+  });
+
+  test("returns true when applicationServerKey is a Uint8Array view", () => {
+    const bytes = samplePointBytes();
+    const advertised = urlBase64NoPad(bytes);
+    // Wrap bytes inside a larger buffer to confirm byteOffset is honored.
+    const wrapper = new Uint8Array(128);
+    wrapper.set(bytes, 32);
+    const view = new Uint8Array(wrapper.buffer, 32, 65);
+    expect(
+      subscriptionApplicationKeyMatches({ options: { applicationServerKey: view } }, advertised),
+    ).toBe(true);
+  });
+
+  test("returns false when the bytes differ (rotation case)", () => {
+    const oldBytes = samplePointBytes(0xab);
+    const newBytes = samplePointBytes(0xcd);
+    const advertised = urlBase64NoPad(newBytes);
+    expect(
+      subscriptionApplicationKeyMatches({ options: { applicationServerKey: oldBytes.buffer } }, advertised),
+    ).toBe(false);
+  });
+
+  test("returns false when the lengths differ", () => {
+    const bytes = samplePointBytes();
+    const truncated = bytes.slice(0, 64);
+    const advertised = urlBase64NoPad(bytes);
+    expect(
+      subscriptionApplicationKeyMatches({ options: { applicationServerKey: truncated.buffer } }, advertised),
+    ).toBe(false);
+  });
+
+  test("returns true when subscription has no applicationServerKey (no comparison applicable)", () => {
+    expect(subscriptionApplicationKeyMatches({ options: { applicationServerKey: null } }, "any")).toBe(
+      true,
+    );
+    expect(subscriptionApplicationKeyMatches({ options: {} }, "any")).toBe(true);
+  });
+
+  test("returns false when the advertised value is unparseable base64url", () => {
+    const bytes = samplePointBytes();
+    expect(
+      subscriptionApplicationKeyMatches(
+        { options: { applicationServerKey: bytes.buffer } },
+        "!!! not base64 !!!",
+      ),
+    ).toBe(false);
+  });
+});

--- a/chat/tests/vapid-cache.test.ts
+++ b/chat/tests/vapid-cache.test.ts
@@ -171,12 +171,37 @@ describe("vapid-cache", () => {
   });
 
   test("malformed cache entry is treated as a miss", async () => {
-    // Pre-existing localStorage entry written by an older build with a
-    // different schema must NOT crash the loader; the entry is
-    // ignored and the next fetch overwrites.
+    // Pre-existing localStorage entry under the CURRENT key shape but
+    // with un-parseable JSON content must NOT crash the loader; the
+    // entry is ignored and the next fetch overwrites. Uses the same
+    // key encoding (`JSON.stringify([account, server])`) as the
+    // production code at `storageKey(...)`, so the path actually
+    // exercised here is `JSON.parse` raising, NOT a cache miss.
     const ls = (globalThis as { window: { localStorage: { setItem: (k: string, v: string) => void } } })
       .window.localStorage;
-    ls.setItem(`waddle.chat.vapid-cache:${ACCOUNT}|${SERVER}`, "not json");
+    ls.setItem(`waddle.chat.vapid-cache:${JSON.stringify([ACCOUNT, SERVER])}`, "not json");
+    const client = makeClient(SAMPLE);
+    const result = await loadVapidPublicKey({
+      client,
+      accountJid: ACCOUNT,
+      serverJid: SERVER,
+      now: () => 1_000_000,
+    });
+    expect(result?.publicKey).toBe(SAMPLE.publicKey);
+    expect((client.fetchVapidPublicKey as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
+  });
+
+  test("partially-valid cache entry (missing fields) is treated as a miss", async () => {
+    // Schema drift: an entry that JSON.parses successfully but lacks
+    // required fields must fail the `isCachedVapidEntry` guard and
+    // trigger a fresh fetch rather than propagating an unsafe
+    // partial value.
+    const ls = (globalThis as { window: { localStorage: { setItem: (k: string, v: string) => void } } })
+      .window.localStorage;
+    ls.setItem(
+      `waddle.chat.vapid-cache:${JSON.stringify([ACCOUNT, SERVER])}`,
+      JSON.stringify({ publicKey: "x" }),
+    );
     const client = makeClient(SAMPLE);
     const result = await loadVapidPublicKey({
       client,

--- a/chat/tests/vapid-cache.test.ts
+++ b/chat/tests/vapid-cache.test.ts
@@ -1,0 +1,190 @@
+// Coverage for the runtime VAPID cache that replaced the build-time
+// `PUBLIC_WADDLE_VAPID_PUBLIC_KEY` env. Pins:
+//   * cache miss → wasm fetch → write-through
+//   * cache hit within the TTL skips the fetch
+//   * cache miss past the TTL re-fetches
+//   * `forceRefresh: true` always fetches
+//   * server-not-advertised (fetch resolves null) → null + no cache write
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  clearCachedVapidKey,
+  loadVapidPublicKey,
+  VAPID_CACHE_MAX_AGE_MS,
+} from "../src/shell/vapid-cache";
+
+// Minimal localStorage stub. Bun's test runtime does not provide a
+// browser `window.localStorage` by default, so we install a fresh
+// in-memory shim before each test.
+function installLocalStorage() {
+  const store = new Map<string, string>();
+  const stub = {
+    getItem(key: string) {
+      return store.has(key) ? store.get(key) ?? null : null;
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value);
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    clear() {
+      store.clear();
+    },
+    key(_index: number) {
+      return null;
+    },
+    get length() {
+      return store.size;
+    },
+  };
+  (globalThis as { window?: { localStorage: typeof stub } }).window = { localStorage: stub };
+  return stub;
+}
+
+function uninstallLocalStorage() {
+  delete (globalThis as { window?: unknown }).window;
+}
+
+function makeClient(advertisement: { publicKey: string; kid: string } | null) {
+  return {
+    fetchVapidPublicKey: mock(async (_opts: { serviceJid: string }) => advertisement),
+  } as unknown as Parameters<typeof loadVapidPublicKey>[0]["client"];
+}
+
+const ACCOUNT = "alice@example.com";
+const SERVER = "push.example.com";
+const SAMPLE = {
+  publicKey: "BNcRdreALRFXTkOOUHK1EtK2wtZ09Jx_QqOmuyYxLBxbu1zdMrTaUaiyB6e2BIcL4XPzG4Ovq7BU8a-zsnNvBxg",
+  kid: "9b1f0f3e-1234-4abc-9001-00112233aabb",
+};
+
+describe("vapid-cache", () => {
+  beforeEach(() => {
+    installLocalStorage();
+  });
+  afterEach(() => {
+    uninstallLocalStorage();
+  });
+
+  test("cache miss fetches once, then hit serves from storage", async () => {
+    const client = makeClient(SAMPLE);
+    let now = 1_000_000;
+
+    const first = await loadVapidPublicKey({
+      client,
+      accountJid: ACCOUNT,
+      serverJid: SERVER,
+      now: () => now,
+    });
+    expect(first?.publicKey).toBe(SAMPLE.publicKey);
+    expect(first?.kid).toBe(SAMPLE.kid);
+    expect(first?.fetchedAtMs).toBe(now);
+
+    // Bump the clock under the TTL; the cached value should serve
+    // without a fresh wasm call.
+    now += VAPID_CACHE_MAX_AGE_MS - 1;
+    const second = await loadVapidPublicKey({
+      client,
+      accountJid: ACCOUNT,
+      serverJid: SERVER,
+      now: () => now,
+    });
+    expect(second?.publicKey).toBe(SAMPLE.publicKey);
+    expect((client.fetchVapidPublicKey as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
+  });
+
+  test("cache miss past the TTL re-fetches", async () => {
+    const client = makeClient(SAMPLE);
+    let now = 1_000_000;
+    await loadVapidPublicKey({ client, accountJid: ACCOUNT, serverJid: SERVER, now: () => now });
+    now += VAPID_CACHE_MAX_AGE_MS + 1;
+    await loadVapidPublicKey({ client, accountJid: ACCOUNT, serverJid: SERVER, now: () => now });
+    expect((client.fetchVapidPublicKey as ReturnType<typeof mock>).mock.calls).toHaveLength(2);
+  });
+
+  test("forceRefresh bypasses cache", async () => {
+    const client = makeClient(SAMPLE);
+    const now = 1_000_000;
+    await loadVapidPublicKey({ client, accountJid: ACCOUNT, serverJid: SERVER, now: () => now });
+    await loadVapidPublicKey({
+      client,
+      accountJid: ACCOUNT,
+      serverJid: SERVER,
+      forceRefresh: true,
+      now: () => now,
+    });
+    expect((client.fetchVapidPublicKey as ReturnType<typeof mock>).mock.calls).toHaveLength(2);
+  });
+
+  test("server-not-advertised resolves null and does not write the cache", async () => {
+    const client = makeClient(null);
+    const now = 1_000_000;
+    const result = await loadVapidPublicKey({
+      client,
+      accountJid: ACCOUNT,
+      serverJid: SERVER,
+      now: () => now,
+    });
+    expect(result).toBeNull();
+    // No cache entry written — verify by switching to a server that
+    // returns the SAMPLE; second call must fetch (not serve a stale
+    // null from cache).
+    const client2 = makeClient(SAMPLE);
+    const second = await loadVapidPublicKey({
+      client: client2,
+      accountJid: ACCOUNT,
+      serverJid: SERVER,
+      now: () => now,
+    });
+    expect(second?.publicKey).toBe(SAMPLE.publicKey);
+  });
+
+  test("clearCachedVapidKey removes the entry", async () => {
+    const client = makeClient(SAMPLE);
+    const now = 1_000_000;
+    await loadVapidPublicKey({ client, accountJid: ACCOUNT, serverJid: SERVER, now: () => now });
+    clearCachedVapidKey(ACCOUNT, SERVER);
+    await loadVapidPublicKey({ client, accountJid: ACCOUNT, serverJid: SERVER, now: () => now });
+    expect((client.fetchVapidPublicKey as ReturnType<typeof mock>).mock.calls).toHaveLength(2);
+  });
+
+  test("cache key isolates by (account, server)", async () => {
+    const client = makeClient(SAMPLE);
+    const now = 1_000_000;
+    await loadVapidPublicKey({ client, accountJid: ACCOUNT, serverJid: SERVER, now: () => now });
+    // Same account, different server: must fetch.
+    await loadVapidPublicKey({
+      client,
+      accountJid: ACCOUNT,
+      serverJid: "push.other.example.com",
+      now: () => now,
+    });
+    // Same server, different account: must fetch.
+    await loadVapidPublicKey({
+      client,
+      accountJid: "bob@example.com",
+      serverJid: SERVER,
+      now: () => now,
+    });
+    expect((client.fetchVapidPublicKey as ReturnType<typeof mock>).mock.calls).toHaveLength(3);
+  });
+
+  test("malformed cache entry is treated as a miss", async () => {
+    // Pre-existing localStorage entry written by an older build with a
+    // different schema must NOT crash the loader; the entry is
+    // ignored and the next fetch overwrites.
+    const ls = (globalThis as { window: { localStorage: { setItem: (k: string, v: string) => void } } })
+      .window.localStorage;
+    ls.setItem(`waddle.chat.vapid-cache:${ACCOUNT}|${SERVER}`, "not json");
+    const client = makeClient(SAMPLE);
+    const result = await loadVapidPublicKey({
+      client,
+      accountJid: ACCOUNT,
+      serverJid: SERVER,
+      now: () => 1_000_000,
+    });
+    expect(result?.publicKey).toBe(SAMPLE.publicKey);
+    expect((client.fetchVapidPublicKey as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
+  });
+});

--- a/chat/tests/vapid-rotation-lock.test.ts
+++ b/chat/tests/vapid-rotation-lock.test.ts
@@ -1,0 +1,108 @@
+// Coverage for the cross-tab VAPID-rotation lock. Pins:
+//   * `navigator.locks` (Web Locks API) path: name + mode + critical-
+//     section wrapping
+//   * Promise-chain fallback when `navigator.locks` is undefined
+//   * Errors in one task don't permanently block subsequent acquires
+//     on the fallback path
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  __resetVapidRotationLockForTests,
+  VAPID_ROTATION_LOCK_NAME,
+  withVapidRotationLock,
+} from "../src/shell/vapid-rotation-lock";
+
+function deferred<T>() {
+  let resolveFn: (value: T) => void = () => {};
+  let rejectFn: (reason: unknown) => void = () => {};
+  const promise = new Promise<T>((resolve, reject) => {
+    resolveFn = resolve;
+    rejectFn = reject;
+  });
+  return { promise, resolve: resolveFn, reject: rejectFn };
+}
+
+function installNavigatorLocks() {
+  const request = mock(
+    async (
+      _name: string,
+      _options: { mode: "exclusive" } | { mode: "shared" },
+      callback: () => Promise<unknown>,
+    ) => callback(),
+  );
+  const navigatorStub = { locks: { request } } as unknown as Navigator;
+  (globalThis as { navigator?: Navigator }).navigator = navigatorStub;
+  return { request };
+}
+
+function installNavigatorWithoutLocks() {
+  (globalThis as { navigator?: Navigator }).navigator = {} as Navigator;
+}
+
+function uninstallNavigator() {
+  delete (globalThis as { navigator?: unknown }).navigator;
+}
+
+describe("vapid-rotation-lock", () => {
+  beforeEach(() => {
+    __resetVapidRotationLockForTests();
+  });
+  afterEach(() => {
+    uninstallNavigator();
+  });
+
+  test("uses navigator.locks.request with exclusive mode + canonical name", async () => {
+    const { request } = installNavigatorLocks();
+    await withVapidRotationLock(async () => "ok");
+    expect(request.mock.calls).toHaveLength(1);
+    const [name, options] = request.mock.calls[0] ?? [];
+    expect(name).toBe(VAPID_ROTATION_LOCK_NAME);
+    expect((options as { mode: string }).mode).toBe("exclusive");
+  });
+
+  test("returns the callback's result through the lock", async () => {
+    installNavigatorLocks();
+    const result = await withVapidRotationLock(async () => 42);
+    expect(result).toBe(42);
+  });
+
+  test("fallback path serializes overlapping calls when navigator.locks is absent", async () => {
+    installNavigatorWithoutLocks();
+    const order: string[] = [];
+    const firstGate = deferred<void>();
+    const first = withVapidRotationLock(async () => {
+      order.push("first-enter");
+      await firstGate.promise;
+      order.push("first-exit");
+      return "first";
+    });
+    const second = withVapidRotationLock(async () => {
+      order.push("second-enter");
+      return "second";
+    });
+    // `second` was queued after `first` and must not have entered yet.
+    await Promise.resolve();
+    expect(order).toEqual(["first-enter"]);
+    firstGate.resolve();
+    await Promise.all([first, second]);
+    expect(order).toEqual(["first-enter", "first-exit", "second-enter"]);
+  });
+
+  test("fallback path: an error in one task doesn't permanently block subsequent acquires", async () => {
+    installNavigatorWithoutLocks();
+    const first = withVapidRotationLock(async () => {
+      throw new Error("boom");
+    });
+    await expect(first).rejects.toThrow("boom");
+    const result = await withVapidRotationLock(async () => "still works");
+    expect(result).toBe("still works");
+  });
+
+  test("fallback path: missing navigator does not throw", async () => {
+    // Some test runners (and Node SSR) lack `navigator` entirely; the
+    // lock must still acquire via the fallback.
+    uninstallNavigator();
+    const result = await withVapidRotationLock(async () => "ok");
+    expect(result).toBe("ok");
+  });
+});

--- a/chat/tests/vapid-rotation-lock.test.ts
+++ b/chat/tests/vapid-rotation-lock.test.ts
@@ -8,7 +8,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   __resetVapidRotationLockForTests,
-  VAPID_ROTATION_LOCK_NAME,
+  vapidRotationLockNameForTests,
   withVapidRotationLock,
 } from "../src/shell/vapid-rotation-lock";
 
@@ -51,18 +51,23 @@ describe("vapid-rotation-lock", () => {
     uninstallNavigator();
   });
 
-  test("uses navigator.locks.request with exclusive mode + canonical name", async () => {
+  test("uses navigator.locks.request with exclusive mode + per-account name", async () => {
     const { request } = installNavigatorLocks();
-    await withVapidRotationLock(async () => "ok");
+    await withVapidRotationLock("alice@example.com", async () => "ok");
     expect(request.mock.calls).toHaveLength(1);
     const [name, options] = request.mock.calls[0] ?? [];
-    expect(name).toBe(VAPID_ROTATION_LOCK_NAME);
+    expect(name).toBe(vapidRotationLockNameForTests("alice@example.com"));
     expect((options as { mode: string }).mode).toBe("exclusive");
+    // Different accounts must use different lock names so they don't
+    // serialize through each other.
+    expect(vapidRotationLockNameForTests("alice@example.com")).not.toBe(
+      vapidRotationLockNameForTests("bob@example.com"),
+    );
   });
 
   test("returns the callback's result through the lock", async () => {
     installNavigatorLocks();
-    const result = await withVapidRotationLock(async () => 42);
+    const result = await withVapidRotationLock("alice@example.com", async () => 42);
     expect(result).toBe(42);
   });
 
@@ -70,13 +75,13 @@ describe("vapid-rotation-lock", () => {
     installNavigatorWithoutLocks();
     const order: string[] = [];
     const firstGate = deferred<void>();
-    const first = withVapidRotationLock(async () => {
+    const first = withVapidRotationLock("alice@example.com", async () => {
       order.push("first-enter");
       await firstGate.promise;
       order.push("first-exit");
       return "first";
     });
-    const second = withVapidRotationLock(async () => {
+    const second = withVapidRotationLock("alice@example.com", async () => {
       order.push("second-enter");
       return "second";
     });
@@ -90,11 +95,11 @@ describe("vapid-rotation-lock", () => {
 
   test("fallback path: an error in one task doesn't permanently block subsequent acquires", async () => {
     installNavigatorWithoutLocks();
-    const first = withVapidRotationLock(async () => {
+    const first = withVapidRotationLock("alice@example.com", async () => {
       throw new Error("boom");
     });
     await expect(first).rejects.toThrow("boom");
-    const result = await withVapidRotationLock(async () => "still works");
+    const result = await withVapidRotationLock("alice@example.com", async () => "still works");
     expect(result).toBe("still works");
   });
 
@@ -102,7 +107,7 @@ describe("vapid-rotation-lock", () => {
     // Some test runners (and Node SSR) lack `navigator` entirely; the
     // lock must still acquire via the fallback.
     uninstallNavigator();
-    const result = await withVapidRotationLock(async () => "ok");
+    const result = await withVapidRotationLock("alice@example.com", async () => "ok");
     expect(result).toBe("ok");
   });
 });

--- a/server/crates/waddle-server/src/push_service.rs
+++ b/server/crates/waddle-server/src/push_service.rs
@@ -888,6 +888,19 @@ impl DatabasePushServiceStore {
         self.db.clone()
     }
 
+    /// Typed advertisement of the Push Service's active VAPID public key.
+    /// Returned only when a [`VapidSigner`] is installed via
+    /// [`Self::with_web_push_provider`]; legacy test paths that boot the
+    /// store without a signer return `None`, and the disco handler
+    /// suppresses the XEP-0128 form rather than synthesizing a placeholder.
+    pub fn vapid_advertisement(&self) -> Option<waddle_xmpp::push::disco::VapidAdvertisement> {
+        let signer = self.vapid_signer.as_ref()?;
+        Some(waddle_xmpp::push::disco::VapidAdvertisement::new(
+            signer.current_public_key(),
+            signer.current_kid(),
+        ))
+    }
+
     async fn ensure_xep0060_push_node_for_owner(
         &self,
         owner_bare_jid: &BareJid,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/disco_info/services.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/disco_info/services.rs
@@ -74,6 +74,28 @@ pub(super) async fn handle_push_service_disco_info<'a>(
 
     let identities = vec![Identity::pubsub_push(Some("Push Service"))];
     let features = push_service_features();
-    let response = build_disco_info_response(req.request_iq, &identities, &features, None);
+    // XEP-0128 extension: advertise the active VAPID public key + kid so
+    // chat clients can subscribe without a build-time embedded key. The
+    // form is suppressed when no VapidSigner is installed (legacy test
+    // boot, integration runs without a configured push provider) — the
+    // chat side treats an absent form as "Web Push not available on this
+    // server" rather than silently degrading.
+    let vapid_form = state
+        .deps
+        .protocol
+        .push_service
+        .vapid_advertisement()
+        .map(|advertisement| waddle_xmpp::push::disco::push_vapid_disco_form(&advertisement));
+    let response = if let Some(form) = vapid_form.as_ref() {
+        build_disco_info_response_with_extensions(
+            req.request_iq,
+            &identities,
+            &features,
+            None,
+            std::slice::from_ref(form),
+        )
+    } else {
+        build_disco_info_response(req.request_iq, &identities, &features, None)
+    };
     Some(DiscoInfoResponse::iq(response))
 }

--- a/server/crates/waddle-server/tests/xep0357_push_service_ws.rs
+++ b/server/crates/waddle-server/tests/xep0357_push_service_ws.rs
@@ -237,11 +237,13 @@ async fn push_service_disco_advertises_xep0128_vapid_form() {
 
     let iq = parse_iq_element(&response, "push-disco-vapid", "result");
     // RFC 6120 §8.1.1.1: the chat's wasm-side `verify_iq_from_matches_query`
-    // guard expects `from` to either be absent (legitimate for own-server
-    // replies) OR match the queried JID exactly. The server-side Push
-    // Service component MUST set `from` so the chat doesn't silently
-    // fall through to the absent-from branch on a future server-side
-    // regression. Round-3 XEP-conformance review finding.
+    // REQUIRES a present `from` that matches the queried service JID
+    // exactly (round-5 tightening — the Push Service is a separate
+    // XEP-0114 component, not the user's own server, so §8.1.2.1's
+    // absent-from permission does not apply). This assertion pins the
+    // server-side stamping so a future regression that drops `from`
+    // on the push component's responses is caught immediately, not
+    // discovered later via a hostile-C2S spoof CVE.
     assert_eq!(
         iq.attr("from"),
         Some(PUSH_SERVICE_JID),

--- a/server/crates/waddle-server/tests/xep0357_push_service_ws.rs
+++ b/server/crates/waddle-server/tests/xep0357_push_service_ws.rs
@@ -236,6 +236,17 @@ async fn push_service_disco_advertises_xep0128_vapid_form() {
     .await;
 
     let iq = parse_iq_element(&response, "push-disco-vapid", "result");
+    // RFC 6120 §8.1.1.1: the chat's wasm-side `verify_iq_from_matches_query`
+    // guard expects `from` to either be absent (legitimate for own-server
+    // replies) OR match the queried JID exactly. The server-side Push
+    // Service component MUST set `from` so the chat doesn't silently
+    // fall through to the absent-from branch on a future server-side
+    // regression. Round-3 XEP-conformance review finding.
+    assert_eq!(
+        iq.attr("from"),
+        Some(PUSH_SERVICE_JID),
+        "Push Service disco#info result MUST carry from='{PUSH_SERVICE_JID}'"
+    );
     let query = single_child(&iq, "query", DISCO_INFO_NS);
 
     let form = query

--- a/server/crates/waddle-server/tests/xep0357_push_service_ws.rs
+++ b/server/crates/waddle-server/tests/xep0357_push_service_ws.rs
@@ -215,6 +215,106 @@ async fn xep0357_push_service_disco_identifies_as_pubsub_push() {
 }
 
 #[tokio::test]
+async fn push_service_disco_advertises_xep0128_vapid_form() {
+    // PR-D3: the component-level disco#info response carries a XEP-0128
+    // extension form (FORM_TYPE='urn:waddle:push:vapid:0') with the
+    // active VAPID public key + kid so the chat client can subscribe
+    // without a build-time embedded key.
+    use waddle_xmpp::push::disco::{
+        parse_push_vapid_disco_form, PUSH_VAPID_FIELD_KID, PUSH_VAPID_FIELD_PUBLIC_KEY,
+        PUSH_VAPID_FORM_TYPE,
+    };
+
+    let (_server, mut client) = setup().await;
+    let query = Element::builder("query", DISCO_INFO_NS).build();
+
+    let response = send_iq(
+        &mut client,
+        iq_frame("get", "push-disco-vapid", PUSH_SERVICE_JID, query),
+        "push-disco-vapid",
+    )
+    .await;
+
+    let iq = parse_iq_element(&response, "push-disco-vapid", "result");
+    let query = single_child(&iq, "query", DISCO_INFO_NS);
+
+    let form = query
+        .children()
+        .find(|child| {
+            child.is("x", waddle_xmpp::xep::NS_DATA_FORMS)
+                && xdata_field_value(child, "FORM_TYPE").as_deref() == Some(PUSH_VAPID_FORM_TYPE)
+        })
+        .unwrap_or_else(|| panic!("VAPID disco form missing from response: {response}"));
+
+    assert_eq!(form.attr("type"), Some("result"), "form is type='result'");
+
+    let public_key =
+        xdata_field_value(form, PUSH_VAPID_FIELD_PUBLIC_KEY).expect("public-key field present");
+    let kid = xdata_field_value(form, PUSH_VAPID_FIELD_KID).expect("kid field present");
+    assert!(!public_key.is_empty(), "public-key value non-empty");
+    assert!(!kid.is_empty(), "kid value non-empty");
+
+    // Round-trip: the typed parser must accept the wire form back into
+    // a VapidAdvertisement (validates 65-byte SEC1 + 0x04 prefix + valid
+    // P-256 point + UUID kid in one shot).
+    let advertisement =
+        parse_push_vapid_disco_form(form).expect("typed parser accepts the advertised form");
+    assert_eq!(advertisement.public_key_base64url(), public_key);
+    assert_eq!(advertisement.kid.to_string(), kid);
+
+    let _ = client.close().await;
+}
+
+#[tokio::test]
+async fn push_service_node_disco_omits_xep0128_vapid_form() {
+    // The VAPID form is a *component-level* advertisement; per-node disco
+    // returns the leaf-node identity and MUST NOT carry the form (the
+    // chat side never asks a leaf node for its parent's VAPID key).
+    use waddle_xmpp::push::disco::PUSH_VAPID_FORM_TYPE;
+
+    let (_server, mut client) = setup().await;
+
+    let ensure_node = Element::builder("ensure-node", NS_WADDLE_PUSH_SERVICE)
+        .attr(minidom::rxml::xml_ncname!("app-id").to_owned(), "web")
+        .build();
+    let node_response = send_iq(
+        &mut client,
+        iq_frame(
+            "set",
+            "push-vapid-leaf-ensure-node",
+            PUSH_SERVICE_JID,
+            ensure_node,
+        ),
+        "push-vapid-leaf-ensure-node",
+    )
+    .await;
+    let node = child_attr(&node_response, "node", "id").expect("node id");
+
+    let query = Element::builder("query", DISCO_INFO_NS)
+        .attr(minidom::rxml::xml_ncname!("node").to_owned(), node.as_str())
+        .build();
+    let response = send_iq(
+        &mut client,
+        iq_frame("get", "push-vapid-leaf-disco", PUSH_SERVICE_JID, query),
+        "push-vapid-leaf-disco",
+    )
+    .await;
+
+    let iq = parse_iq_element(&response, "push-vapid-leaf-disco", "result");
+    let query = single_child(&iq, "query", DISCO_INFO_NS);
+    let vapid_form_present = query.children().any(|child| {
+        child.is("x", waddle_xmpp::xep::NS_DATA_FORMS)
+            && xdata_field_value(child, "FORM_TYPE").as_deref() == Some(PUSH_VAPID_FORM_TYPE)
+    });
+    assert!(
+        !vapid_form_present,
+        "leaf-node disco MUST NOT carry the component-level VAPID form: {response}"
+    );
+
+    let _ = client.close().await;
+}
+
+#[tokio::test]
 async fn xep0357_push_service_rejects_client_origin_pubsub_notification_publish() {
     let (_server, mut client) = setup().await;
 

--- a/server/crates/waddle-xmpp-client-wasm/src/client_account.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_account.rs
@@ -112,6 +112,42 @@ impl WaddleClient {
         })
     }
 
+    /// Fetch the Push Service's currently-active VAPID public key + kid
+    /// via the XEP-0128 disco extension form
+    /// (`FORM_TYPE='urn:waddle:push:vapid:0'`). The chat passes
+    /// `publicKey` (base64url-no-pad uncompressed SEC1 P-256, 65 bytes
+    /// with leading 0x04) to `pushManager.subscribe({ applicationServerKey })`
+    /// and tracks `kid` so silent rotations on a server-side key change
+    /// re-subscribe transparently.
+    ///
+    /// Resolves to `null` when the server is reachable but does not
+    /// advertise the form (Web Push not configured on this deployment)
+    /// so the chat caller can branch into the "foreground-only"
+    /// fallback. Rejects on transport / stanza errors and on a
+    /// malformed advertisement — the chat MUST NOT degrade silently on
+    /// a malformed key (round-trip with the browser would fail anyway,
+    /// later and less diagnosable).
+    pub fn fetch_vapid_public_key(&self, service_jid: String) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let iq = build_disco_info_iq(&service_jid, None);
+            let result = send_iq_command(inner, iq).await?;
+            let disco = parse_disco_info_result(&result, &service_jid).ok_or_else(|| {
+                js_error("Push Service disco#info response missing <query/> payload")
+            })?;
+            let advertisement = match parse_push_vapid_from_disco_info(&disco) {
+                Ok(advertisement) => advertisement,
+                Err(PushVapidDiscoParseError::NotAdvertised) => return Ok(JsValue::NULL),
+                Err(other) => return Err(js_error(other.to_string())),
+            };
+            let surfaced = WaddleVapidAdvertisement {
+                public_key: advertisement.public_key_base64url,
+                kid: advertisement.kid.to_string(),
+            };
+            to_js_value(&surfaced)
+        })
+    }
+
     /// `<disable-device node='…' device-id='…'/>` on the Push Service.
     /// Idempotent — operates on the (node, device-id) row only.
     /// Resolves to the typed `PushServiceDevice` shape so the chat

--- a/server/crates/waddle-xmpp-client-wasm/src/client_account.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_account.rs
@@ -132,23 +132,7 @@ impl WaddleClient {
         future_to_promise(async move {
             let iq = build_disco_info_iq(&service_jid, None);
             let result = send_iq_command(inner, iq).await?;
-            // Defense in depth: refuse to accept a VAPID advertisement
-            // claiming a `from` other than the JID we queried. Without
-            // this, a malicious user-server (or a compromised middlebox
-            // on the C2S path) could spoof a `<iq from='attacker.tld'>`
-            // result carrying its own VAPID key, and the browser would
-            // bind its push subscription to attacker-signed JWTs.
-            // The XMPP server-side dispatcher already routes responses
-            // by stanza id, but the `from` rebinding requires the
-            // explicit check at the boundary that consumes the typed
-            // disco payload.
-            if let Some(from) = result.attr("from") {
-                if from != service_jid {
-                    return Err(js_error(format!(
-                        "Push Service disco#info response from {from:?} does not match queried JID {service_jid:?}; refusing to trust VAPID advertisement"
-                    )));
-                }
-            }
+            verify_iq_from_matches_query(result.attr("from"), &service_jid).map_err(js_error)?;
             let disco = parse_disco_info_result(&result, &service_jid).ok_or_else(|| {
                 js_error("Push Service disco#info response missing <query/> payload")
             })?;
@@ -765,4 +749,94 @@ fn require_non_empty_attr(
                 "{response_kind} response missing required attribute '{attr}'"
             ))
         })
+}
+
+/// Defense-in-depth check for `fetch_vapid_public_key`: refuse to accept
+/// a disco#info advertisement whose `from` doesn't match the queried
+/// `service_jid`. Without this, a malicious user-server (or a
+/// compromised middlebox on the C2S path) could spoof a
+/// `<iq from='attacker.tld'>` result carrying its own VAPID key, and
+/// the browser would bind its push subscription to attacker-signed
+/// JWTs. The XMPP server-side dispatcher already routes responses by
+/// stanza id, but the `from` rebinding requires the explicit check at
+/// the boundary that consumes the typed disco payload.
+///
+/// RFC 6120 §8.1.2.1 permits `<iq>` results with an absent `from` when
+/// the reply originates from the user's own server; we treat that as a
+/// pass-through (the typical Push Service is a server component under
+/// the same domain). A `from` that matches the bare service JID OR a
+/// `from` of the form `service_jid/resource` (Push Services that
+/// publish from a full JID) is accepted.
+///
+/// Extracted as a pure helper so the Rust test suite can pin the
+/// anti-spoof semantics without a full wasm-bindgen test harness.
+fn verify_iq_from_matches_query(from_attr: Option<&str>, service_jid: &str) -> Result<(), String> {
+    let Some(from) = from_attr else {
+        return Ok(());
+    };
+    if from == service_jid {
+        return Ok(());
+    }
+    // Allow `service_jid/resource` so a Push Service that responds
+    // from a full JID isn't rejected. Strict prefix match against the
+    // bare JID followed by `/` prevents `evil.tld/foo` from collapsing
+    // to a match against `service_jid` via substring containment.
+    if let Some(remainder) = from.strip_prefix(service_jid) {
+        if remainder.starts_with('/') {
+            return Ok(());
+        }
+    }
+    Err(format!(
+        "Push Service disco#info response from {from:?} does not match queried JID {service_jid:?}; refusing to trust VAPID advertisement"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verify_iq_from_accepts_exact_match() {
+        assert!(verify_iq_from_matches_query(Some("push.example.com"), "push.example.com").is_ok());
+    }
+
+    #[test]
+    fn verify_iq_from_accepts_absent_attr() {
+        assert!(verify_iq_from_matches_query(None, "push.example.com").is_ok());
+    }
+
+    #[test]
+    fn verify_iq_from_accepts_service_jid_with_resource() {
+        assert!(verify_iq_from_matches_query(
+            Some("push.example.com/resource"),
+            "push.example.com"
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn verify_iq_from_rejects_unrelated_jid() {
+        let err =
+            verify_iq_from_matches_query(Some("attacker.tld"), "push.example.com").unwrap_err();
+        assert!(err.contains("attacker.tld"));
+        assert!(err.contains("push.example.com"));
+    }
+
+    #[test]
+    fn verify_iq_from_rejects_prefix_substring_collision() {
+        // Without the `/` boundary, `push.example.com` could match
+        // `push.example.com.attacker.tld` via substring containment.
+        // Confirm the strict-prefix rule rejects this.
+        assert!(verify_iq_from_matches_query(
+            Some("push.example.com.attacker.tld"),
+            "push.example.com",
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn verify_iq_from_rejects_empty_from() {
+        let err = verify_iq_from_matches_query(Some(""), "push.example.com").unwrap_err();
+        assert!(err.contains("push.example.com"));
+    }
 }

--- a/server/crates/waddle-xmpp-client-wasm/src/client_account.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_account.rs
@@ -761,30 +761,35 @@ fn require_non_empty_attr(
 /// stanza id, but the `from` rebinding requires the explicit check at
 /// the boundary that consumes the typed disco payload.
 ///
-/// RFC 6120 §8.1.2.1 permits `<iq>` results with an absent `from` when
-/// the reply originates from the user's own server; we treat that as a
-/// pass-through (the typical Push Service is a server component under
-/// the same domain). A `from` that matches the bare service JID OR a
-/// `from` of the form `service_jid/resource` (Push Services that
-/// publish from a full JID) is accepted.
+/// RFC 6120 §8.1.2.1 permits `<iq>` results with an absent `from` ONLY
+/// when the reply originates from the user's own server (the
+/// bare-domain of the bound JID). The Waddle Push Service is a
+/// separate addressable entity at `push.<domain>` (XEP-0357 §1 +
+/// XEP-0114 component) — a `from`-stripped reply from such a component
+/// is a server-side violation we MUST NOT silently accept, because a
+/// compromised C2S could strip `from` instead of spoofing it and
+/// bypass this guard. The check here therefore REQUIRES a present
+/// `from` that matches `service_jid`.
+///
+/// JID equality follows RFC 6122 §2.4 / RFC 7622 — domainparts are
+/// case-insensitive. Push Service JIDs are always pure domain JIDs
+/// (XEP-0114 components), so we don't accept a `service_jid/resource`
+/// form: it would be permissively useless for the production input
+/// set and would needlessly widen the attack surface. Nameprep is
+/// approximated with ASCII-lowercase since every push service JID in
+/// waddle is an ASCII subdomain — pulling in `idna` purely for this
+/// equality would inflate the WASM bundle.
 ///
 /// Extracted as a pure helper so the Rust test suite can pin the
 /// anti-spoof semantics without a full wasm-bindgen test harness.
 fn verify_iq_from_matches_query(from_attr: Option<&str>, service_jid: &str) -> Result<(), String> {
     let Some(from) = from_attr else {
-        return Ok(());
+        return Err(format!(
+            "Push Service disco#info response carries no `from`; RFC 6120 §8.1.2.1 requires components to stamp `from`. Refusing to trust VAPID advertisement (queried JID was {service_jid:?})"
+        ));
     };
-    if from == service_jid {
+    if from.eq_ignore_ascii_case(service_jid) {
         return Ok(());
-    }
-    // Allow `service_jid/resource` so a Push Service that responds
-    // from a full JID isn't rejected. Strict prefix match against the
-    // bare JID followed by `/` prevents `evil.tld/foo` from collapsing
-    // to a match against `service_jid` via substring containment.
-    if let Some(remainder) = from.strip_prefix(service_jid) {
-        if remainder.starts_with('/') {
-            return Ok(());
-        }
     }
     Err(format!(
         "Push Service disco#info response from {from:?} does not match queried JID {service_jid:?}; refusing to trust VAPID advertisement"
@@ -801,17 +806,32 @@ mod tests {
     }
 
     #[test]
-    fn verify_iq_from_accepts_absent_attr() {
-        assert!(verify_iq_from_matches_query(None, "push.example.com").is_ok());
+    fn verify_iq_from_rejects_absent_attr() {
+        // RFC 6120 §8.1.2.1's absent-from permission only applies to
+        // replies from the bound user's own server. The Push Service is
+        // a separate XEP-0114 component, so absent-from is a server
+        // violation we MUST NOT silently accept — a compromised C2S
+        // could strip `from` instead of spoofing it.
+        let err = verify_iq_from_matches_query(None, "push.example.com").unwrap_err();
+        assert!(err.contains("push.example.com"));
+        assert!(err.contains("no `from`"));
     }
 
     #[test]
-    fn verify_iq_from_accepts_service_jid_with_resource() {
-        assert!(verify_iq_from_matches_query(
-            Some("push.example.com/resource"),
-            "push.example.com"
-        )
-        .is_ok());
+    fn verify_iq_from_rejects_service_jid_with_resource() {
+        // Push Service components don't carry resources (XEP-0114).
+        // Accepting `push.example.com/anything` would be needlessly
+        // permissive and wouldn't help any real-world deployment.
+        let err =
+            verify_iq_from_matches_query(Some("push.example.com/resource"), "push.example.com")
+                .unwrap_err();
+        assert!(err.contains("push.example.com/resource"));
+    }
+
+    #[test]
+    fn verify_iq_from_accepts_case_variation_on_domain() {
+        // RFC 6122 §2.4: domainpart comparison is case-insensitive.
+        assert!(verify_iq_from_matches_query(Some("Push.Example.COM"), "push.example.com").is_ok());
     }
 
     #[test]
@@ -824,9 +844,8 @@ mod tests {
 
     #[test]
     fn verify_iq_from_rejects_prefix_substring_collision() {
-        // Without the `/` boundary, `push.example.com` could match
-        // `push.example.com.attacker.tld` via substring containment.
-        // Confirm the strict-prefix rule rejects this.
+        // `push.example.com` MUST NOT match `push.example.com.attacker.tld`
+        // even via case-insensitive equality.
         assert!(verify_iq_from_matches_query(
             Some("push.example.com.attacker.tld"),
             "push.example.com",

--- a/server/crates/waddle-xmpp-client-wasm/src/client_account.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_account.rs
@@ -132,6 +132,23 @@ impl WaddleClient {
         future_to_promise(async move {
             let iq = build_disco_info_iq(&service_jid, None);
             let result = send_iq_command(inner, iq).await?;
+            // Defense in depth: refuse to accept a VAPID advertisement
+            // claiming a `from` other than the JID we queried. Without
+            // this, a malicious user-server (or a compromised middlebox
+            // on the C2S path) could spoof a `<iq from='attacker.tld'>`
+            // result carrying its own VAPID key, and the browser would
+            // bind its push subscription to attacker-signed JWTs.
+            // The XMPP server-side dispatcher already routes responses
+            // by stanza id, but the `from` rebinding requires the
+            // explicit check at the boundary that consumes the typed
+            // disco payload.
+            if let Some(from) = result.attr("from") {
+                if from != service_jid {
+                    return Err(js_error(format!(
+                        "Push Service disco#info response from {from:?} does not match queried JID {service_jid:?}; refusing to trust VAPID advertisement"
+                    )));
+                }
+            }
             let disco = parse_disco_info_result(&result, &service_jid).ok_or_else(|| {
                 js_error("Push Service disco#info response missing <query/> payload")
             })?;

--- a/server/crates/waddle-xmpp-client-wasm/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/lib.rs
@@ -14,8 +14,9 @@ use waddle_xmpp_client::discovery::{
     build_disco_items_iq, build_enable_push_iq, build_ensure_push_node_iq,
     build_muc_admin_affiliation_list_iq, build_muc_admin_affiliation_set_iq,
     build_register_push_device_iq, build_roster_get_iq, build_upload_slot_iq, build_user_search_iq,
-    build_waddle_inbox_mark_read_iq, parse_muc_admin_affiliation_query, parse_roster_result,
-    parse_user_search_result, MucAdminAffiliationItem, PushDevicePlatform, PushDeviceRegistration,
+    build_waddle_inbox_mark_read_iq, parse_disco_info_result, parse_muc_admin_affiliation_query,
+    parse_push_vapid_from_disco_info, parse_roster_result, parse_user_search_result,
+    MucAdminAffiliationItem, PushDevicePlatform, PushDeviceRegistration, PushVapidDiscoParseError,
     UserSearchQuery, WaddleInboxMarkRead, WADDLE_PUSH_SERVICE_NS,
 };
 use waddle_xmpp_client::error::parse_stanza_error;

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -469,6 +469,19 @@ pub struct PushServiceDevice {
     pub status: PushDeviceStatus,
 }
 
+/// Result of `fetch_vapid_public_key` — the Push Service's currently-
+/// active VAPID public key + kid as advertised via the XEP-0128 disco
+/// extension form `urn:waddle:push:vapid:0`. The chat hands
+/// `publicKey` directly to `pushManager.subscribe({ applicationServerKey })`
+/// after a base64url-no-pad → `Uint8Array` decode, and stores `kid` so
+/// rotation is detectable on subsequent reconnects.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WaddleVapidAdvertisement {
+    pub public_key: String,
+    pub kid: String,
+}
+
 /// Arguments to `WaddleClient::register_web_push_device`. Bundled
 /// into a struct so the JS call site passes a single typed object
 /// (and the Rust signature stays under the

--- a/server/crates/waddle-xmpp-client/src/discovery.rs
+++ b/server/crates/waddle-xmpp-client/src/discovery.rs
@@ -4,10 +4,16 @@
 mod ids;
 mod iq;
 mod parsing;
+mod push_vapid;
 mod types;
 
 #[cfg(all(feature = "native", not(target_arch = "wasm32")))]
 mod ext;
+
+pub use push_vapid::{
+    parse_push_vapid_from_disco_info, PushVapidAdvertisement, PushVapidDiscoParseError,
+    PUSH_VAPID_FIELD_KID, PUSH_VAPID_FIELD_PUBLIC_KEY, PUSH_VAPID_FORM_TYPE,
+};
 
 pub use iq::{
     build_disable_push_device_iq, build_disable_push_iq, build_disco_info_iq, build_disco_items_iq,

--- a/server/crates/waddle-xmpp-client/src/discovery/parsing.rs
+++ b/server/crates/waddle-xmpp-client/src/discovery/parsing.rs
@@ -48,6 +48,26 @@ pub fn parse_disco_info_result(iq: &Element, queried_jid: &str) -> Option<DiscoI
 }
 
 fn parse_disco_data_form(form: &Element) -> Option<DiscoDataForm> {
+    // XEP-0068 §4.3 (Incorrectly Specified FORM_TYPE): "If the FORM_TYPE
+    // field is not hidden in a form with type='form' or type='result',
+    // it MUST be ignored as a context indicator." We capture the
+    // FORM_TYPE value at this layer ONLY when the originating field
+    // carries `type='hidden'`, so a misconfigured or malicious server
+    // sending `<field var='FORM_TYPE' type='text-single'>...</field>`
+    // can't trick downstream code into accepting its claimed FORM_TYPE
+    // namespace.
+    let form_type = form
+        .children()
+        .filter(|child| child.name() == "field" && child.ns() == DATA_FORMS_NS)
+        .find(|field| {
+            field.attr("var") == Some("FORM_TYPE") && field.attr("type") == Some("hidden")
+        })
+        .and_then(|field| {
+            field
+                .children()
+                .find(|child| child.name() == "value" && child.ns() == DATA_FORMS_NS)
+                .map(Element::text)
+        });
     let fields: Vec<DiscoDataField> = form
         .children()
         .filter(|child| child.name() == "field" && child.ns() == DATA_FORMS_NS)
@@ -64,11 +84,6 @@ fn parse_disco_data_form(form: &Element) -> Option<DiscoDataForm> {
     if fields.is_empty() {
         return None;
     }
-    let form_type = fields
-        .iter()
-        .find(|field| field.var == "FORM_TYPE")
-        .and_then(|field| field.values.first())
-        .cloned();
     Some(DiscoDataForm { form_type, fields })
 }
 

--- a/server/crates/waddle-xmpp-client/src/discovery/parsing.rs
+++ b/server/crates/waddle-xmpp-client/src/discovery/parsing.rs
@@ -50,24 +50,38 @@ pub fn parse_disco_info_result(iq: &Element, queried_jid: &str) -> Option<DiscoI
 fn parse_disco_data_form(form: &Element) -> Option<DiscoDataForm> {
     // XEP-0068 §4.3 (Incorrectly Specified FORM_TYPE): "If the FORM_TYPE
     // field is not hidden in a form with type='form' or type='result',
-    // it MUST be ignored as a context indicator." We capture the
-    // FORM_TYPE value at this layer ONLY when the originating field
-    // carries `type='hidden'`, so a misconfigured or malicious server
-    // sending `<field var='FORM_TYPE' type='text-single'>...</field>`
-    // can't trick downstream code into accepting its claimed FORM_TYPE
-    // namespace.
-    let form_type = form
-        .children()
-        .filter(|child| child.name() == "field" && child.ns() == DATA_FORMS_NS)
-        .find(|field| {
-            field.attr("var") == Some("FORM_TYPE") && field.attr("type") == Some("hidden")
-        })
-        .and_then(|field| {
-            field
-                .children()
-                .find(|child| child.name() == "value" && child.ns() == DATA_FORMS_NS)
-                .map(Element::text)
-        });
+    // it MUST be ignored as a context indicator." Two conditions —
+    // BOTH required:
+    //
+    //   1. The wrapping `<x/>` element MUST be `type='form'` or
+    //      `type='result'`. A `submit` form is a user-supplied payload,
+    //      not a context-bearing advertisement; a `cancel` form
+    //      carries no fields by definition; an absent `type=` is
+    //      malformed per XEP-0004 §3.1.
+    //
+    //   2. The FORM_TYPE field itself MUST carry `type='hidden'`.
+    //
+    // Downstream callers (e.g. push_vapid::parse_push_vapid_from_disco_info)
+    // pick the form they trust by `form_type` match — so leaking a
+    // FORM_TYPE from a `submit`/`cancel`/unknown form would let a
+    // malicious or misconfigured server smuggle an attacker-claimed
+    // context indicator into the typed result.
+    let form_kind = form.attr("type");
+    let form_type = if matches!(form_kind, Some("form") | Some("result")) {
+        form.children()
+            .filter(|child| child.name() == "field" && child.ns() == DATA_FORMS_NS)
+            .find(|field| {
+                field.attr("var") == Some("FORM_TYPE") && field.attr("type") == Some("hidden")
+            })
+            .and_then(|field| {
+                field
+                    .children()
+                    .find(|child| child.name() == "value" && child.ns() == DATA_FORMS_NS)
+                    .map(Element::text)
+            })
+    } else {
+        None
+    };
     let fields: Vec<DiscoDataField> = form
         .children()
         .filter(|child| child.name() == "field" && child.ns() == DATA_FORMS_NS)

--- a/server/crates/waddle-xmpp-client/src/discovery/push_vapid.rs
+++ b/server/crates/waddle-xmpp-client/src/discovery/push_vapid.rs
@@ -249,4 +249,87 @@ mod tests {
         let err = parse_push_vapid_from_disco_info(&disco).expect_err("bad b64");
         assert_eq!(err, PushVapidDiscoParseError::PublicKeyBase64urlDecode);
     }
+
+    /// XEP-0068 §4.3 (Incorrectly Specified FORM_TYPE): a non-hidden
+    /// FORM_TYPE field MUST be ignored as a context indicator. The
+    /// wire-level disco parser already strips the form_type when the
+    /// originating field isn't `type='hidden'`, which surfaces here as
+    /// `form_type: None` → `NotAdvertised`. This test pins that
+    /// behavior at the typed boundary so a regression in
+    /// `parse_disco_data_form` is caught by the chat-side suite.
+    #[test]
+    fn rejects_non_hidden_form_type_field() {
+        use minidom::Element;
+
+        use crate::discovery::parsing::parse_disco_info_result;
+        use crate::discovery::DATA_FORMS_NS;
+        use crate::discovery::DISCO_INFO_NS;
+
+        let bytes = {
+            let mut b = [0u8; 65];
+            b[0] = 0x04;
+            for (i, v) in b.iter_mut().enumerate().skip(1) {
+                *v = (i as u8).wrapping_mul(7);
+            }
+            b
+        };
+        let public_key_b64 = URL_SAFE_NO_PAD.encode(bytes);
+        let kid = Uuid::new_v4().to_string();
+        // Same wire shape as the legitimate form, but FORM_TYPE is
+        // emitted WITHOUT `type='hidden'`.
+        let form = Element::builder("x", DATA_FORMS_NS)
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
+            .append(
+                Element::builder("field", DATA_FORMS_NS)
+                    .attr(minidom::rxml::xml_ncname!("var").to_owned(), "FORM_TYPE")
+                    // Deliberately omit `type='hidden'`.
+                    .append(
+                        Element::builder("value", DATA_FORMS_NS)
+                            .append(PUSH_VAPID_FORM_TYPE)
+                            .build(),
+                    )
+                    .build(),
+            )
+            .append(
+                Element::builder("field", DATA_FORMS_NS)
+                    .attr(
+                        minidom::rxml::xml_ncname!("var").to_owned(),
+                        PUSH_VAPID_FIELD_PUBLIC_KEY,
+                    )
+                    .append(
+                        Element::builder("value", DATA_FORMS_NS)
+                            .append(&public_key_b64[..])
+                            .build(),
+                    )
+                    .build(),
+            )
+            .append(
+                Element::builder("field", DATA_FORMS_NS)
+                    .attr(
+                        minidom::rxml::xml_ncname!("var").to_owned(),
+                        PUSH_VAPID_FIELD_KID,
+                    )
+                    .append(
+                        Element::builder("value", DATA_FORMS_NS)
+                            .append(&kid[..])
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build();
+        let iq = Element::builder("iq", "jabber:client")
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
+            .append(
+                Element::builder("query", DISCO_INFO_NS)
+                    .append(form)
+                    .build(),
+            )
+            .build();
+
+        let disco = parse_disco_info_result(&iq, "push.example.com")
+            .expect("disco parses despite the non-hidden FORM_TYPE");
+        let err = parse_push_vapid_from_disco_info(&disco)
+            .expect_err("non-hidden FORM_TYPE must NOT be honored as a context indicator");
+        assert_eq!(err, PushVapidDiscoParseError::NotAdvertised);
+    }
 }

--- a/server/crates/waddle-xmpp-client/src/discovery/push_vapid.rs
+++ b/server/crates/waddle-xmpp-client/src/discovery/push_vapid.rs
@@ -1,0 +1,252 @@
+//! Chat-side parser for the Push Service's XEP-0128 VAPID disco extension.
+//!
+//! The Waddle Push Service component advertises its current VAPID public
+//! key + kid in the component-level disco#info response via a
+//! `urn:waddle:push:vapid:0` data form (XEP-0128 §2). This module
+//! consumes the typed [`DiscoInfoResult`] returned by
+//! [`super::parse_disco_info_result`] and surfaces the typed
+//! [`PushVapidAdvertisement`] the chat needs to pass into
+//! `pushManager.subscribe({ applicationServerKey })`.
+//!
+//! The wire FORM_TYPE + field-name constants here mirror the server-side
+//! definitions in `waddle-xmpp/src/push/disco.rs`. Both halves are
+//! intentionally **independent copies** of the wire identifiers — the
+//! lower client crate (used in wasm) does not depend on the server-side
+//! `waddle-xmpp` crate, so we duplicate the three string constants and
+//! keep both ends honest via the integration test suite that parses the
+//! actual server response.
+//!
+//! ## Validation
+//!
+//! The parser asserts the wire-shape invariants the browser would reject
+//! anyway, but at a layer where the chat can surface a meaningful error
+//! instead of a `pushManager.subscribe()` rejection:
+//!
+//!   * `public-key` decodes as base64url-no-pad
+//!   * decoded length is exactly 65 bytes (uncompressed SEC1 P-256 point)
+//!   * leading byte is `0x04` (uncompressed-point marker)
+//!   * `kid` is a parseable UUID
+//!
+//! It does not assert P-256 point validity — that's the browser's job,
+//! and importing a curve crate into the chat client doubles its WASM
+//! bundle for one error path.
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use thiserror::Error;
+use uuid::Uuid;
+
+use super::DiscoInfoResult;
+
+/// FORM_TYPE for the Push Service's VAPID disco extension. Mirrors
+/// `waddle_xmpp::push::disco::PUSH_VAPID_FORM_TYPE`.
+pub const PUSH_VAPID_FORM_TYPE: &str = "urn:waddle:push:vapid:0";
+
+/// `var` of the public-key field. Mirrors
+/// `waddle_xmpp::push::disco::PUSH_VAPID_FIELD_PUBLIC_KEY`.
+pub const PUSH_VAPID_FIELD_PUBLIC_KEY: &str = "public-key";
+
+/// `var` of the kid field. Mirrors
+/// `waddle_xmpp::push::disco::PUSH_VAPID_FIELD_KID`.
+pub const PUSH_VAPID_FIELD_KID: &str = "kid";
+
+/// Length of an uncompressed SEC1 P-256 point in bytes (1-byte prefix +
+/// 32-byte X + 32-byte Y).
+const SEC1_UNCOMPRESSED_P256_LEN: usize = 65;
+/// Uncompressed-point marker per SEC1 §2.3.3.
+const SEC1_UNCOMPRESSED_PREFIX: u8 = 0x04;
+
+/// Typed view of the Push Service's currently-active VAPID keypair, as
+/// recovered from the chat-side parse of the disco#info response. The
+/// `public_key` value is preserved in its wire form (base64url-no-pad)
+/// because that's exactly what the browser needs to subscribe with —
+/// re-encoding from raw bytes is a needless serialization round-trip.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PushVapidAdvertisement {
+    pub public_key_base64url: String,
+    pub kid: Uuid,
+}
+
+/// Outcomes for [`parse_push_vapid_from_disco_info`]. `NotAdvertised` is
+/// a non-error: the server simply doesn't run a Web Push provider on this
+/// deployment. Other variants flag a malformed advertisement; callers
+/// should refuse to subscribe rather than degrade silently.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum PushVapidDiscoParseError {
+    #[error("Push Service disco#info does not advertise a `{PUSH_VAPID_FORM_TYPE}` form")]
+    NotAdvertised,
+    #[error("missing required field `{0}`")]
+    MissingField(&'static str),
+    #[error("`public-key` is not valid base64url-no-pad")]
+    PublicKeyBase64urlDecode,
+    #[error(
+        "`public-key` is not a {SEC1_UNCOMPRESSED_P256_LEN}-byte uncompressed SEC1 P-256 point (got {got} bytes)"
+    )]
+    PublicKeyWrongLength { got: usize },
+    #[error("`public-key` is not a 0x04-prefixed uncompressed SEC1 point")]
+    PublicKeyWrongPrefix,
+    #[error("`kid` is not a valid UUID")]
+    KidInvalidUuid,
+}
+
+/// Extract the typed VAPID advertisement from a parsed disco#info result.
+/// Errors are non-fatal in the sense that an unrecognized server (no
+/// VAPID form) just means Web Push isn't available — but malformed forms
+/// MUST surface as errors so the chat refuses to subscribe instead of
+/// guessing at a half-decoded key.
+pub fn parse_push_vapid_from_disco_info(
+    disco: &DiscoInfoResult,
+) -> Result<PushVapidAdvertisement, PushVapidDiscoParseError> {
+    let form = disco
+        .forms
+        .iter()
+        .find(|form| form.form_type.as_deref() == Some(PUSH_VAPID_FORM_TYPE))
+        .ok_or(PushVapidDiscoParseError::NotAdvertised)?;
+
+    let public_key_b64 = form
+        .fields
+        .iter()
+        .find(|field| field.var == PUSH_VAPID_FIELD_PUBLIC_KEY)
+        .and_then(|field| field.values.first())
+        .ok_or(PushVapidDiscoParseError::MissingField(
+            PUSH_VAPID_FIELD_PUBLIC_KEY,
+        ))?;
+    let kid_value = form
+        .fields
+        .iter()
+        .find(|field| field.var == PUSH_VAPID_FIELD_KID)
+        .and_then(|field| field.values.first())
+        .ok_or(PushVapidDiscoParseError::MissingField(PUSH_VAPID_FIELD_KID))?;
+
+    let decoded = URL_SAFE_NO_PAD
+        .decode(public_key_b64)
+        .map_err(|_| PushVapidDiscoParseError::PublicKeyBase64urlDecode)?;
+    if decoded.len() != SEC1_UNCOMPRESSED_P256_LEN {
+        return Err(PushVapidDiscoParseError::PublicKeyWrongLength { got: decoded.len() });
+    }
+    if decoded[0] != SEC1_UNCOMPRESSED_PREFIX {
+        return Err(PushVapidDiscoParseError::PublicKeyWrongPrefix);
+    }
+    let kid = kid_value
+        .parse::<Uuid>()
+        .map_err(|_| PushVapidDiscoParseError::KidInvalidUuid)?;
+    Ok(PushVapidAdvertisement {
+        public_key_base64url: public_key_b64.clone(),
+        kid,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::discovery::types::{DiscoDataField, DiscoDataForm, DiscoInfoResult};
+
+    fn disco_with_form(form: DiscoDataForm) -> DiscoInfoResult {
+        DiscoInfoResult {
+            jid: "push.example.com".to_string(),
+            node: None,
+            identities: Vec::new(),
+            features: Vec::new(),
+            forms: vec![form],
+        }
+    }
+
+    fn make_form(public_key_b64: &str, kid: &str) -> DiscoDataForm {
+        DiscoDataForm {
+            form_type: Some(PUSH_VAPID_FORM_TYPE.to_string()),
+            fields: vec![
+                DiscoDataField {
+                    var: "FORM_TYPE".to_string(),
+                    values: vec![PUSH_VAPID_FORM_TYPE.to_string()],
+                },
+                DiscoDataField {
+                    var: PUSH_VAPID_FIELD_PUBLIC_KEY.to_string(),
+                    values: vec![public_key_b64.to_string()],
+                },
+                DiscoDataField {
+                    var: PUSH_VAPID_FIELD_KID.to_string(),
+                    values: vec![kid.to_string()],
+                },
+            ],
+        }
+    }
+
+    fn valid_b64() -> String {
+        let mut bytes = [0u8; 65];
+        bytes[0] = 0x04;
+        for (index, byte) in bytes.iter_mut().enumerate().skip(1) {
+            *byte = (index as u8).wrapping_mul(7);
+        }
+        URL_SAFE_NO_PAD.encode(bytes)
+    }
+
+    #[test]
+    fn parses_well_formed_advertisement() {
+        let kid = Uuid::new_v4();
+        let b64 = valid_b64();
+        let disco = disco_with_form(make_form(&b64, &kid.to_string()));
+        let parsed = parse_push_vapid_from_disco_info(&disco).expect("parses");
+        assert_eq!(parsed.kid, kid);
+        assert_eq!(parsed.public_key_base64url, b64);
+    }
+
+    #[test]
+    fn returns_not_advertised_when_form_absent() {
+        let disco = DiscoInfoResult {
+            jid: "push.example.com".to_string(),
+            node: None,
+            identities: Vec::new(),
+            features: Vec::new(),
+            forms: Vec::new(),
+        };
+        let err = parse_push_vapid_from_disco_info(&disco).expect_err("no form");
+        assert_eq!(err, PushVapidDiscoParseError::NotAdvertised);
+    }
+
+    #[test]
+    fn rejects_missing_public_key_field() {
+        let mut form = make_form(&valid_b64(), &Uuid::new_v4().to_string());
+        form.fields.retain(|f| f.var != PUSH_VAPID_FIELD_PUBLIC_KEY);
+        let disco = disco_with_form(form);
+        let err = parse_push_vapid_from_disco_info(&disco).expect_err("missing");
+        assert_eq!(
+            err,
+            PushVapidDiscoParseError::MissingField(PUSH_VAPID_FIELD_PUBLIC_KEY)
+        );
+    }
+
+    #[test]
+    fn rejects_short_public_key() {
+        let short = URL_SAFE_NO_PAD.encode([0x04u8; 32]);
+        let disco = disco_with_form(make_form(&short, &Uuid::new_v4().to_string()));
+        let err = parse_push_vapid_from_disco_info(&disco).expect_err("too short");
+        assert_eq!(
+            err,
+            PushVapidDiscoParseError::PublicKeyWrongLength { got: 32 }
+        );
+    }
+
+    #[test]
+    fn rejects_wrong_prefix() {
+        let mut bytes = [0u8; 65];
+        bytes[0] = 0x02;
+        let b64 = URL_SAFE_NO_PAD.encode(bytes);
+        let disco = disco_with_form(make_form(&b64, &Uuid::new_v4().to_string()));
+        let err = parse_push_vapid_from_disco_info(&disco).expect_err("bad prefix");
+        assert_eq!(err, PushVapidDiscoParseError::PublicKeyWrongPrefix);
+    }
+
+    #[test]
+    fn rejects_invalid_kid_uuid() {
+        let disco = disco_with_form(make_form(&valid_b64(), "not-a-uuid"));
+        let err = parse_push_vapid_from_disco_info(&disco).expect_err("bad kid");
+        assert_eq!(err, PushVapidDiscoParseError::KidInvalidUuid);
+    }
+
+    #[test]
+    fn rejects_non_base64url_payload() {
+        let disco = disco_with_form(make_form("!!! not base64 !!!", &Uuid::new_v4().to_string()));
+        let err = parse_push_vapid_from_disco_info(&disco).expect_err("bad b64");
+        assert_eq!(err, PushVapidDiscoParseError::PublicKeyBase64urlDecode);
+    }
+}

--- a/server/crates/waddle-xmpp-client/src/discovery/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/discovery/tests.rs
@@ -863,6 +863,99 @@ fn build_disable_push_device_carries_node_and_device_id() {
 /// covers this for the empty-token branch; this test pins the
 /// EXACT shape #528 promises to land.
 #[test]
+fn parse_disco_data_form_ignores_form_type_in_submit_form() {
+    // XEP-0068 §4.3: a FORM_TYPE field is only a context indicator
+    // when (a) the field itself carries `type='hidden'` AND (b) the
+    // wrapping `<x/>` is `type='form'` or `type='result'`. A
+    // `<x type='submit'>` form is a user-supplied payload, NOT a
+    // disco-style advertisement — accepting its FORM_TYPE would let a
+    // malicious server smuggle an attacker-claimed context indicator
+    // past downstream callers that key off `form.form_type`.
+    let iq = Element::builder("iq", CLIENT_NS)
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
+        .append(
+            Element::builder("query", DISCO_INFO_NS)
+                .append(
+                    // The hostile shape: `<x type='submit'>` with a
+                    // well-formed hidden FORM_TYPE field. The parser
+                    // MUST drop form_type to None even though the
+                    // field itself is hidden.
+                    Element::builder("x", DATA_FORMS_NS)
+                        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "submit")
+                        .append(
+                            Element::builder("field", DATA_FORMS_NS)
+                                .attr(minidom::rxml::xml_ncname!("var").to_owned(), "FORM_TYPE")
+                                .attr(minidom::rxml::xml_ncname!("type").to_owned(), "hidden")
+                                .append(
+                                    Element::builder("value", DATA_FORMS_NS)
+                                        .append("urn:waddle:push:vapid:0")
+                                        .build(),
+                                )
+                                .build(),
+                        )
+                        .append(
+                            Element::builder("field", DATA_FORMS_NS)
+                                .attr(minidom::rxml::xml_ncname!("var").to_owned(), "public-key")
+                                .append(
+                                    Element::builder("value", DATA_FORMS_NS)
+                                        .append("BNcRdreALRFXTkOOUHK1")
+                                        .build(),
+                                )
+                                .build(),
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .build();
+    let result = parse_disco_info_result(&iq, "push.example.com").expect("parses");
+    assert_eq!(
+        result.forms.len(),
+        1,
+        "submit form is still surfaced — only its form_type is ignored"
+    );
+    assert_eq!(
+        result.forms[0].form_type, None,
+        "FORM_TYPE in a `submit` form MUST NOT act as a context indicator"
+    );
+    // Fields themselves are preserved verbatim so a downstream caller
+    // that knows the form is a submit payload (e.g. publish-options)
+    // can still consume them.
+    assert!(result.forms[0].fields.iter().any(|f| f.var == "FORM_TYPE"
+        && f.values.first().map(|v| v.as_str()) == Some("urn:waddle:push:vapid:0")));
+}
+
+#[test]
+fn parse_disco_data_form_ignores_form_type_when_x_type_missing() {
+    // `<x/>` without a `type=` attribute is malformed per XEP-0004 §3.1.
+    // We refuse to honor any FORM_TYPE inside it.
+    let iq = Element::builder("iq", CLIENT_NS)
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
+        .append(
+            Element::builder("query", DISCO_INFO_NS)
+                .append(
+                    Element::builder("x", DATA_FORMS_NS)
+                        .append(
+                            Element::builder("field", DATA_FORMS_NS)
+                                .attr(minidom::rxml::xml_ncname!("var").to_owned(), "FORM_TYPE")
+                                .attr(minidom::rxml::xml_ncname!("type").to_owned(), "hidden")
+                                .append(
+                                    Element::builder("value", DATA_FORMS_NS)
+                                        .append("urn:example:something:0")
+                                        .build(),
+                                )
+                                .build(),
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .build();
+    let result = parse_disco_info_result(&iq, "push.example.com").expect("parses");
+    assert_eq!(result.forms[0].form_type, None);
+}
+
+#[test]
 fn xep0357_enable_for_web_push_carries_no_provider_fields() {
     let iq = build_enable_push_iq("push.example.com", "node-abc", "");
     let enable = iq.get_child("enable", PUSH_NS).expect("enable");

--- a/server/crates/waddle-xmpp-client/src/discovery/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/discovery/tests.rs
@@ -48,6 +48,7 @@ fn parse_disco_info_result_extracts_data_form_metadata() {
                         .append(
                             Element::builder("field", DATA_FORMS_NS)
                                 .attr(minidom::rxml::xml_ncname!("var").to_owned(), "FORM_TYPE")
+                                .attr(minidom::rxml::xml_ncname!("type").to_owned(), "hidden")
                                 .append(
                                     Element::builder("value", DATA_FORMS_NS)
                                         .append(PUBSUB_METADATA_FORM_TYPE)
@@ -83,6 +84,7 @@ fn parse_disco_info_result_extracts_data_form_metadata() {
                         .append(
                             Element::builder("field", DATA_FORMS_NS)
                                 .attr(minidom::rxml::xml_ncname!("var").to_owned(), "FORM_TYPE")
+                                .attr(minidom::rxml::xml_ncname!("type").to_owned(), "hidden")
                                 .append(
                                     Element::builder("value", DATA_FORMS_NS)
                                         .append("http://jabber.org/protocol/muc#roominfo")

--- a/server/crates/waddle-xmpp/src/push/disco.rs
+++ b/server/crates/waddle-xmpp/src/push/disco.rs
@@ -1,0 +1,315 @@
+//! XEP-0128 disco extension form for the Push Service's current VAPID
+//! public key.
+//!
+//! The Push Service component advertises its active RFC 8292 VAPID keypair
+//! via this form so chat clients can discover the public key at runtime
+//! instead of receiving it at build time. The form is attached to the
+//! component-level `disco#info` response (no `node` attribute); per-node
+//! disco results MUST NOT carry it.
+//!
+//! ## Wire shape (XEP-0128 §2)
+//!
+//! ```xml
+//! <iq type='result'>
+//!   <query xmlns='http://jabber.org/protocol/disco#info'>
+//!     <identity category='pubsub' type='push' name='Push Service'/>
+//!     ...features...
+//!     <x xmlns='jabber:x:data' type='result'>
+//!       <field var='FORM_TYPE' type='hidden'>
+//!         <value>urn:waddle:push:vapid:0</value>
+//!       </field>
+//!       <field var='public-key'>
+//!         <value>BNcRdreALRFXTkOOUHK1...</value>
+//!       </field>
+//!       <field var='kid'>
+//!         <value>9b1f0f3e-1234-4abc-9001-00112233aabb</value>
+//!       </field>
+//!     </x>
+//!   </query>
+//! </iq>
+//! ```
+//!
+//! ## Namespace discipline
+//!
+//! XEP-0357 does not define a FORM_TYPE for the push service's disco
+//! extensions, so per the CLAUDE.md XEP-conformance hard rule we mint a
+//! `urn:waddle:*` namespace. If the XSF later registers an equivalent
+//! FORM_TYPE, this module's constant becomes the migration target.
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use minidom::Element;
+use p256::elliptic_curve::sec1::ToEncodedPoint;
+use thiserror::Error;
+
+use crate::xep::xep0004::{DataForm, Field, FormType, FromElement, IntoElement};
+
+use super::types::Kid;
+
+/// FORM_TYPE for the Push Service VAPID disco extension. Custom
+/// `urn:waddle:*` namespace per the XEP conformance hard rule.
+pub const PUSH_VAPID_FORM_TYPE: &str = "urn:waddle:push:vapid:0";
+
+/// `var` of the public-key field. Value is the base64url-no-pad encoding
+/// of the 65-byte uncompressed SEC1 P-256 point (leading `0x04`).
+pub const PUSH_VAPID_FIELD_PUBLIC_KEY: &str = "public-key";
+
+/// `var` of the kid field. Value is the canonical hyphenated UUID
+/// rendering of the active `push_service_vapid_keys.kid` row.
+pub const PUSH_VAPID_FIELD_KID: &str = "kid";
+
+/// Typed advertisement of the Push Service's currently-active VAPID
+/// keypair. Crosses the boundary from the push service store to the
+/// disco handler as a typed value (typed-payloads hard rule).
+#[derive(Debug, Clone)]
+pub struct VapidAdvertisement {
+    pub public_key: p256::PublicKey,
+    pub kid: Kid,
+}
+
+impl VapidAdvertisement {
+    pub fn new(public_key: p256::PublicKey, kid: Kid) -> Self {
+        Self { public_key, kid }
+    }
+
+    /// Base64url-no-pad encoding of the 65-byte uncompressed SEC1 point.
+    /// Matches the chat-side `applicationServerKey` and the
+    /// `Authorization: vapid k=…` parameter format (RFC 8292 §3.2).
+    pub fn public_key_base64url(&self) -> String {
+        let encoded = self.public_key.to_encoded_point(false);
+        URL_SAFE_NO_PAD.encode(encoded.as_bytes())
+    }
+}
+
+/// Build the XEP-0128 form Element advertising this keypair. The result
+/// is appended to the push service's component-level disco#info response
+/// via [`build_disco_info_response_with_extensions`].
+pub fn push_vapid_disco_form(advertisement: &VapidAdvertisement) -> Element {
+    DataForm::new(FormType::Result)
+        .add_field(Field::form_type(PUSH_VAPID_FORM_TYPE))
+        .add_field(Field::text_single(
+            PUSH_VAPID_FIELD_PUBLIC_KEY,
+            advertisement.public_key_base64url(),
+        ))
+        .add_field(Field::text_single(
+            PUSH_VAPID_FIELD_KID,
+            advertisement.kid.to_string(),
+        ))
+        .into_element()
+}
+
+/// Parse error for [`parse_push_vapid_disco_form`].
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum PushVapidDiscoFormError {
+    #[error("element is not a jabber:x:data form")]
+    NotADataForm,
+    #[error("FORM_TYPE mismatch: expected `{PUSH_VAPID_FORM_TYPE}`, got {got:?}")]
+    WrongFormType { got: Option<String> },
+    #[error("missing required field `{0}`")]
+    MissingField(&'static str),
+    #[error("`public-key` is not valid base64url-no-pad")]
+    PublicKeyBase64urlDecode,
+    #[error("`public-key` is not a 65-byte uncompressed SEC1 P-256 point (got {got} bytes)")]
+    PublicKeyWrongLength { got: usize },
+    #[error("`public-key` is not a 0x04-prefixed uncompressed SEC1 point")]
+    PublicKeyWrongPrefix,
+    #[error("`public-key` is not a valid P-256 point")]
+    PublicKeyInvalidPoint,
+    #[error("`kid` is not a valid UUID")]
+    KidInvalidUuid,
+}
+
+/// Inverse of [`push_vapid_disco_form`]. Used by the chat-side fetch path
+/// (and the server-side test suite) to recover a typed
+/// [`VapidAdvertisement`] from a parsed XEP-0128 form Element. Rejects
+/// malformed inputs with a typed error.
+pub fn parse_push_vapid_disco_form(
+    form_element: &Element,
+) -> Result<VapidAdvertisement, PushVapidDiscoFormError> {
+    let form =
+        DataForm::from_element(form_element).map_err(|_| PushVapidDiscoFormError::NotADataForm)?;
+    if form
+        .get_form_type_value()
+        .is_none_or(|value| value != PUSH_VAPID_FORM_TYPE)
+    {
+        return Err(PushVapidDiscoFormError::WrongFormType {
+            got: form.get_form_type_value().map(str::to_owned),
+        });
+    }
+
+    let public_key_b64 = form
+        .field(PUSH_VAPID_FIELD_PUBLIC_KEY)
+        .and_then(|f| f.value())
+        .ok_or(PushVapidDiscoFormError::MissingField(
+            PUSH_VAPID_FIELD_PUBLIC_KEY,
+        ))?;
+    let kid_str = form
+        .field(PUSH_VAPID_FIELD_KID)
+        .and_then(|f| f.value())
+        .ok_or(PushVapidDiscoFormError::MissingField(PUSH_VAPID_FIELD_KID))?;
+
+    let public_bytes = URL_SAFE_NO_PAD
+        .decode(public_key_b64)
+        .map_err(|_| PushVapidDiscoFormError::PublicKeyBase64urlDecode)?;
+    if public_bytes.len() != 65 {
+        return Err(PushVapidDiscoFormError::PublicKeyWrongLength {
+            got: public_bytes.len(),
+        });
+    }
+    if public_bytes[0] != 0x04 {
+        return Err(PushVapidDiscoFormError::PublicKeyWrongPrefix);
+    }
+    let public_key = p256::PublicKey::from_sec1_bytes(&public_bytes)
+        .map_err(|_| PushVapidDiscoFormError::PublicKeyInvalidPoint)?;
+    let kid_uuid: uuid::Uuid = kid_str
+        .parse()
+        .map_err(|_| PushVapidDiscoFormError::KidInvalidUuid)?;
+
+    Ok(VapidAdvertisement::new(public_key, Kid(kid_uuid)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use p256::elliptic_curve::rand_core::OsRng;
+
+    fn sample_advertisement() -> VapidAdvertisement {
+        let secret = p256::SecretKey::random(&mut OsRng);
+        VapidAdvertisement::new(secret.public_key(), Kid::new())
+    }
+
+    #[test]
+    fn round_trip_advertisement_through_form() {
+        let original = sample_advertisement();
+        let element = push_vapid_disco_form(&original);
+        let parsed = parse_push_vapid_disco_form(&element).expect("round-trips");
+        assert_eq!(parsed.kid, original.kid);
+        assert_eq!(
+            parsed.public_key_base64url(),
+            original.public_key_base64url()
+        );
+    }
+
+    #[test]
+    fn public_key_encodes_as_65_byte_uncompressed_sec1() {
+        let advertisement = sample_advertisement();
+        let encoded = advertisement.public_key_base64url();
+        let decoded = URL_SAFE_NO_PAD.decode(&encoded).expect("base64url");
+        assert_eq!(decoded.len(), 65);
+        assert_eq!(decoded[0], 0x04);
+    }
+
+    #[test]
+    fn form_carries_correct_form_type() {
+        let advertisement = sample_advertisement();
+        let element = push_vapid_disco_form(&advertisement);
+        let form = DataForm::from_element(&element).expect("parses as data form");
+        assert_eq!(form.get_form_type_value(), Some(PUSH_VAPID_FORM_TYPE));
+        assert_eq!(form.form_type, FormType::Result);
+    }
+
+    #[test]
+    fn parse_rejects_wrong_form_type() {
+        let element = DataForm::new(FormType::Result)
+            .add_field(Field::form_type("urn:waddle:something:else"))
+            .add_field(Field::text_single(PUSH_VAPID_FIELD_PUBLIC_KEY, "A"))
+            .add_field(Field::text_single(
+                PUSH_VAPID_FIELD_KID,
+                uuid::Uuid::nil().to_string(),
+            ))
+            .into_element();
+        let err = parse_push_vapid_disco_form(&element).expect_err("wrong form type");
+        assert!(matches!(err, PushVapidDiscoFormError::WrongFormType { .. }));
+    }
+
+    #[test]
+    fn parse_rejects_missing_public_key() {
+        let element = DataForm::new(FormType::Result)
+            .add_field(Field::form_type(PUSH_VAPID_FORM_TYPE))
+            .add_field(Field::text_single(
+                PUSH_VAPID_FIELD_KID,
+                uuid::Uuid::nil().to_string(),
+            ))
+            .into_element();
+        let err = parse_push_vapid_disco_form(&element).expect_err("missing field");
+        assert_eq!(
+            err,
+            PushVapidDiscoFormError::MissingField(PUSH_VAPID_FIELD_PUBLIC_KEY)
+        );
+    }
+
+    #[test]
+    fn parse_rejects_truncated_public_key() {
+        let element = DataForm::new(FormType::Result)
+            .add_field(Field::form_type(PUSH_VAPID_FORM_TYPE))
+            .add_field(Field::text_single(
+                PUSH_VAPID_FIELD_PUBLIC_KEY,
+                URL_SAFE_NO_PAD.encode([0x04u8; 32]),
+            ))
+            .add_field(Field::text_single(
+                PUSH_VAPID_FIELD_KID,
+                uuid::Uuid::new_v4().to_string(),
+            ))
+            .into_element();
+        let err = parse_push_vapid_disco_form(&element).expect_err("short key");
+        assert!(matches!(
+            err,
+            PushVapidDiscoFormError::PublicKeyWrongLength { got: 32 }
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_wrong_prefix() {
+        let mut bytes = [0u8; 65];
+        bytes[0] = 0x02; // compressed-form prefix
+        let element = DataForm::new(FormType::Result)
+            .add_field(Field::form_type(PUSH_VAPID_FORM_TYPE))
+            .add_field(Field::text_single(
+                PUSH_VAPID_FIELD_PUBLIC_KEY,
+                URL_SAFE_NO_PAD.encode(bytes),
+            ))
+            .add_field(Field::text_single(
+                PUSH_VAPID_FIELD_KID,
+                uuid::Uuid::new_v4().to_string(),
+            ))
+            .into_element();
+        let err = parse_push_vapid_disco_form(&element).expect_err("wrong prefix");
+        assert_eq!(err, PushVapidDiscoFormError::PublicKeyWrongPrefix);
+    }
+
+    #[test]
+    fn parse_rejects_invalid_kid_uuid() {
+        let advertisement = sample_advertisement();
+        let element = DataForm::new(FormType::Result)
+            .add_field(Field::form_type(PUSH_VAPID_FORM_TYPE))
+            .add_field(Field::text_single(
+                PUSH_VAPID_FIELD_PUBLIC_KEY,
+                advertisement.public_key_base64url(),
+            ))
+            .add_field(Field::text_single(PUSH_VAPID_FIELD_KID, "not-a-uuid"))
+            .into_element();
+        let err = parse_push_vapid_disco_form(&element).expect_err("bad kid");
+        assert_eq!(err, PushVapidDiscoFormError::KidInvalidUuid);
+    }
+
+    #[test]
+    fn parse_rejects_garbage_point_bytes() {
+        // 65 bytes, 0x04 prefix, but the X/Y coordinates are all zeros —
+        // not a valid P-256 point.
+        let mut bytes = [0u8; 65];
+        bytes[0] = 0x04;
+        let element = DataForm::new(FormType::Result)
+            .add_field(Field::form_type(PUSH_VAPID_FORM_TYPE))
+            .add_field(Field::text_single(
+                PUSH_VAPID_FIELD_PUBLIC_KEY,
+                URL_SAFE_NO_PAD.encode(bytes),
+            ))
+            .add_field(Field::text_single(
+                PUSH_VAPID_FIELD_KID,
+                uuid::Uuid::new_v4().to_string(),
+            ))
+            .into_element();
+        let err = parse_push_vapid_disco_form(&element).expect_err("invalid point");
+        assert_eq!(err, PushVapidDiscoFormError::PublicKeyInvalidPoint);
+    }
+}

--- a/server/crates/waddle-xmpp/src/push/mod.rs
+++ b/server/crates/waddle-xmpp/src/push/mod.rs
@@ -5,6 +5,7 @@
 //! enable/disable IQ stanzas and stored for later notification delivery.
 
 pub mod constants;
+pub mod disco;
 pub mod encrypt;
 pub mod envelope;
 pub mod limiter;

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -136,6 +136,24 @@ export class WaddleClient {
      */
     fetch_user_bookmarks(): Promise<any>;
     fetch_user_pep_profile(jid: string): Promise<any>;
+    /**
+     * Fetch the Push Service's currently-active VAPID public key + kid
+     * via the XEP-0128 disco extension form
+     * (`FORM_TYPE='urn:waddle:push:vapid:0'`). The chat passes
+     * `publicKey` (base64url-no-pad uncompressed SEC1 P-256, 65 bytes
+     * with leading 0x04) to `pushManager.subscribe({ applicationServerKey })`
+     * and tracks `kid` so silent rotations on a server-side key change
+     * re-subscribe transparently.
+     *
+     * Resolves to `null` when the server is reachable but does not
+     * advertise the form (Web Push not configured on this deployment)
+     * so the chat caller can branch into the "foreground-only"
+     * fallback. Rejects on transport / stanza errors and on a
+     * malformed advertisement — the chat MUST NOT degrade silently on
+     * a malformed key (round-trip with the browser would fail anyway,
+     * later and less diagnosable).
+     */
+    fetch_vapid_public_key(service_jid: string): Promise<any>;
     fetch_vcard4(jid: string): Promise<any>;
     get_resume_state(): any;
     get_resume_state_handle(): WaddleResumeState | undefined;

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpj1wml5";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpj1wml5";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpj1wml5";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpl7yhxd";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpl7yhxd";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpl7yhxd";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=mpj1wml5";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=mpl7yhxd";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpl8pr5n";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpl8pr5n";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpl8pr5n";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpl8z8vl";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpl8z8vl";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpl8z8vl";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=mpl8pr5n";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=mpl8z8vl";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpl8z8vl";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpl8z8vl";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpl8z8vl";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpl96vj0";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpl96vj0";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpl96vj0";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=mpl8z8vl";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=mpl96vj0";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpl7yhxd";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpl7yhxd";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpl7yhxd";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpl8pr5n";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpl8pr5n";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpl8pr5n";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=mpl7yhxd";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=mpl8pr5n";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpl96vj0";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpl96vj0";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpl96vj0";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mplahi01";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mplahi01";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mplahi01";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=mpl96vj0";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=mplahi01";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mplahi01";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mplahi01";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mplahi01";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mplbhfc8";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mplbhfc8";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mplbhfc8";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=mplahi01";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=mplbhfc8";


### PR DESCRIPTION
## Summary

PR-D3 closes the Web Push pipeline epic (#762). PR-D1 (#763) shipped the server-side foundations; PR-D2 (#764) swapped the placeholder for the real publish-job pipeline. This PR cuts the chat over to a runtime-discovered VAPID public key and switches the service worker to the `v=1` envelope.

Closes #762. (Closes #97 stays closed — that one was retired in D2.)

## What ships

### Server: VAPID public key advertised over XEP-0128

`push.<domain>` component-level disco#info now carries an extension form:

```xml
<x xmlns='jabber:x:data' type='result'>
  <field var='FORM_TYPE' type='hidden'>
    <value>urn:waddle:push:vapid:0</value>
  </field>
  <field var='public-key'>
    <value>BNcRdreALRFXTkOOUHK1...</value>
  </field>
  <field var='kid'>
    <value>9b1f0f3e-1234-4abc-9001-00112233aabb</value>
  </field>
</x>
```

- `public-key`: base64url-no-pad uncompressed P-256 SEC1 (65 bytes, leading `0x04`)
- `kid`: UUIDv4 of the active `push_service_vapid_keys` row
- Per-node disco does NOT carry the form (negative integration test)
- Custom `urn:waddle:*` namespace because XEP-0357 does not define a FORM_TYPE for push-service disco extensions
- XEP-0068 §4.3 enforced on the chat-side parser: non-hidden FORM_TYPE fields AND `<x type='submit'>` forms are dropped as context indicators

Built via `minidom::Element` builders only (XML hard rule). Verified by parsing the actual server response through the typed chat-client parser.

### Chat side: runtime VAPID + silent rotation

- `BrowserXmppClient.fetchVapidPublicKey({ serviceJid })` — sends disco#info to `push.<domain>`, validates the IQ `from` matches the queried JID (RFC 6120 §8.1.2.1 + RFC 6122 §2.4), parses the form, returns typed `{ publicKey, kid } | null`. 10s timeout via `Promise.race`. `null` return is a one-way contract: any error path collapses to `null` + a precise `console.warn`.
- `loadVapidPublicKey` cache — **localStorage** (synchronous, sufficient for ~120-byte entries; IDB upgrade is documented as a follow-up if we ever need it), keyed by `JSON.stringify([account, server])` (collision-safe). 1h TTL backstop; the rotation lock force-refreshes inside the critical section so a stale cache can't mask a rotation.
- `withVapidRotationLock(accountJid, callback)` — cross-tab exclusive lock via `navigator.locks`, per-account lock name so cross-account rotations don't serialize through each other. In-process per-account Promise-chain fallback when `navigator.locks` is unavailable; the IDB-based fallback originally planned is documented as a follow-up because real browser coverage of `navigator.locks` is universal at the chat's target list as of 2026.
- `ensureBrowserSubscriptionWithCurrentKey` — runs on every enable + reconnect:
  1. Force-fetch advertisement under the rotation lock.
  2. Compare against persisted kid AND against the existing subscription's `applicationServerKey` bytes (catches cleared-localStorage-but-SW-survives case).
  3. On mismatch: `existing.unsubscribe()` → `subscribeOnRegistration(reg, newKey)` → re-issue `register-device`.
  4. Surface `rotationBannerVisible` ref for UI binding.
  5. Persisted kid is keyed per `(accountJid, serviceJid)` so multi-account sessions don't cross-contaminate.
- Build env `PUBLIC_WADDLE_VAPID_PUBLIC_KEY` removed.

### Service worker: v=1 envelope + in-band dedup

`crates/waddle-xmpp/src/push/envelope.rs::PushEnvelope` emits exactly:

```json
{
  "v": 1,
  "class": "personal_mention",
  "conversation": "general@muc.example.com",
  "thread": "thread-42",
  "item": "stanza-id-001",
  "unread": 6
}
```

- SW switches on `data.v === 1`; ALL legacy fallback paths (nested `data.context`, `data.roomJid`, alternate unread field names, `data.url` deep-link, opt-in `title`/`body`) deleted per the breaking-changes-by-default rule.
- `notification.data.context` carries only the navigation-relevant subset; `item`/`unread` stay SW-internal.
- **In-band dedup**: foreground tab posts `{type: "waddle:item-shown", itemId}` to `navigator.serviceWorker.controller` when rendering a `showMentionNotification`/`showDmNotification` notification. SW `message` handler records the id in `shownItems`, suppressing the matching Web Push when it lands milliseconds later. Bounded FIFO Map (256 entries, 60s TTL, capped O(16) eviction probe).

## Adversarial review

Per CLAUDE.md, six rounds across four reviewer personas (XMPP/XEP conformance, web-platform/PWA, security/privacy, performance/robustness). Rounds 1–5 each surfaced and fixed real findings; round 6 converged on no remaining actionable items. Latest pass of inline PR-bot comments addressed in the most recent commit.

Highlights of fixes by round:

- **R1 (critical):** `applicationServerKey: keyBytes.buffer` → use the `Uint8Array` view directly (FF/Safari compat). Plus 4 majors: IQ-from spoof guard, 10s fetch timeout, existing-subscription key-byte comparison, error logging in `subscribeToPush`. Plus minors: cache TTL 12h→1h, cache key uses JSON encoding, rotation lock name per-account, Web Locks callback signature, etc.
- **R2:** Test gaps on the IQ-from guard and `subscriptionApplicationKeyMatches`. Plus distinct warning when the fetch timeout fires.
- **R3:** SW dedup `noteItemShown` was not delete-then-set (FIFO order regression under retry). Integration test now asserts `from='push.localhost'`. Web Locks `Lock | null` callback type fixed.
- **R4:** Bounded eviction scan (O(16) probe + FIFO fallback). LS guards on `persistKid`/`loadPersistedKid`/`clearPersistedKid`. Strict-runtime safe lock fallback chain. Eviction-under-overflow test.
- **R5 (XMPP-focused):** **XEP-0068 §4.3** enforcement on chat-side disco parser (non-hidden FORM_TYPE ignored). RFC 6120 §8.1.2.1 + RFC 6122 §2.4 tightening on `verify_iq_from_matches_query` (rejects absent `from`, rejects resource-suffixed, case-insensitive domain compare).
- **R6 (XMPP-focused):** converged with no actionable findings.
- **Latest pass of inline bot comments:**
  - `requireConnectedXmpp()` now inside `fetchVapidPublicKey`'s try/catch (honor null-on-error contract during teardown race)
  - Foreground→SW dedup wired end-to-end (was previously SW-only)
  - XEP-0068 §4.3 also enforces `<x type='form'|'result'>` on the wrapping element
  - Legacy SW shapes (`parseLegacyRoutingContext`, `data.url`, opt-in title/body, message-count alias chain) removed per breaking-changes-by-default
  - Persisted kid namespaced per `(account, service)` (multi-account fix)
  - Rotation-lock fallback chains tracked per lock name (per-account, not global)
  - Cache force-refresh while holding the rotation lock (so cache-hit doesn't mask rotation inside the TTL window)
  - `subscribeOnRegistration(reg, key)` lets the rotation path re-use the already-held SW registration
  - Test fixtures use the current `JSON.stringify`-encoded cache key, plus a new "partially-valid entry" test
  - JSDoc on `fetchVapidPublicKey` now enumerates every `null` return path

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean, no new `#[allow]`
- [x] 9 unit tests in `waddle-xmpp/src/push/disco.rs`
- [x] 7 unit tests in `waddle-xmpp-client/src/discovery/push_vapid.rs`
- [x] 6 unit tests in `waddle-xmpp-client-wasm/src/client_account.rs` (IQ-from guard)
- [x] 2 integration tests in `xep0357_push_service_ws.rs`
- [x] 2 XEP-0068 §4.3 test cases in `discovery/tests.rs` (submit-form + x-without-type)
- [x] `bun test` 1179/1179 green
- [x] `bun run lint` (knip) clean
- [ ] Manual: enable push → verify disco fetches public key → subscribe → server push delivers a v=1 envelope → SW notification clicks to the right route
- [ ] Manual: rotate server VAPID key → chat reconnects → silent rotation → server-side register-device uses new credentials
- [ ] Manual: multi-account session in distinct tabs → each rotates independently without blocking the other

## Out of scope (follow-ups)

- Visible rotation banner UI in ProfilePanel/UserSettings (state ref ships in this PR; visual binding deferred)
- `urn:waddle:push-service:0` migration to XEP-0050 ad-hoc commands
- XEP-0357 §7 affiliation-change message on last-device disable
- APNS (#529) / FCM (#530) sibling provider slices
- `notificationclick` origin-substring check (pre-existing, not touched by this PR)
- SW restart eviction window (needs IDB persistence of the dedup map)
- Wasm-side AbortSignal plumbing through `send_iq_command` (currently the 10s timeout abandons the wasm Promise; bounded by reconnect)
- IDB-based fallback rotation lock (current per-process per-account fallback is best-effort cross-tab; real browser coverage of `navigator.locks` is universal in the chat's target list as of 2026)
- IDB-based VAPID cache (current localStorage cache is sufficient at the entry size; documented for upgrade if quota pressure ever surfaces)