### PR TITLE
fix(chat): harden call presence across clients

### DIFF
--- a/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_client.swift
+++ b/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_client.swift
@@ -1297,10 +1297,11 @@ public struct WaddleArchivedMessage: Equatable, Hashable {
     public var replyFallbackStart: UInt32?
     public var replyFallbackEnd: UInt32?
     public var sharedFiles: [WaddleSharedFile]
+    public var callEvent: WaddleCallEvent?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(mamId: String, queryId: String?, id: String?, stanzaId: String?, originId: String?, timestamp: String?, from: String?, to: String?, messageType: String, body: String?, reactionTargetId: String?, reactionEmojis: [String], thread: String?, parentThreadId: String?, replyToId: String?, replyToSender: String?, replyFallbackStart: UInt32?, replyFallbackEnd: UInt32?, sharedFiles: [WaddleSharedFile]) {
+    public init(mamId: String, queryId: String?, id: String?, stanzaId: String?, originId: String?, timestamp: String?, from: String?, to: String?, messageType: String, body: String?, reactionTargetId: String?, reactionEmojis: [String], thread: String?, parentThreadId: String?, replyToId: String?, replyToSender: String?, replyFallbackStart: UInt32?, replyFallbackEnd: UInt32?, sharedFiles: [WaddleSharedFile], callEvent: WaddleCallEvent?) {
         self.mamId = mamId
         self.queryId = queryId
         self.id = id
@@ -1320,6 +1321,7 @@ public struct WaddleArchivedMessage: Equatable, Hashable {
         self.replyFallbackStart = replyFallbackStart
         self.replyFallbackEnd = replyFallbackEnd
         self.sharedFiles = sharedFiles
+        self.callEvent = callEvent
     }
 
 
@@ -1356,7 +1358,8 @@ public struct FfiConverterTypeWaddleArchivedMessage: FfiConverterRustBuffer {
                 replyToSender: FfiConverterOptionString.read(from: &buf),
                 replyFallbackStart: FfiConverterOptionUInt32.read(from: &buf),
                 replyFallbackEnd: FfiConverterOptionUInt32.read(from: &buf),
-                sharedFiles: FfiConverterSequenceTypeWaddleSharedFile.read(from: &buf)
+                sharedFiles: FfiConverterSequenceTypeWaddleSharedFile.read(from: &buf),
+                callEvent: FfiConverterOptionTypeWaddleCallEvent.read(from: &buf)
         )
     }
 
@@ -1380,6 +1383,7 @@ public struct FfiConverterTypeWaddleArchivedMessage: FfiConverterRustBuffer {
         FfiConverterOptionUInt32.write(value.replyFallbackStart, into: &buf)
         FfiConverterOptionUInt32.write(value.replyFallbackEnd, into: &buf)
         FfiConverterSequenceTypeWaddleSharedFile.write(value.sharedFiles, into: &buf)
+        FfiConverterOptionTypeWaddleCallEvent.write(value.callEvent, into: &buf)
     }
 }
 
@@ -1505,18 +1509,21 @@ public func FfiConverterTypeWaddleAvatar_lower(_ value: WaddleAvatar) -> RustBuf
 /**
  * Typed A/V call event surfaced to Swift via `on_call(...)`.
  * `from` is the stamped sender JID (a *full* JID for propose /
- * session-initiate per XEP-0353 §0.6); `sid` is the Jingle
- * session id used to correlate every later event in the call.
+ * session-initiate per XEP-0353 §0.6); `to` is the stamped stanza
+ * recipient when available; `sid` is the Jingle session id used to
+ * correlate every later event in the call.
  */
 public struct WaddleCallEvent: Equatable, Hashable {
     public var from: String
+    public var to: String?
     public var sid: String
     public var kind: WaddleCallEventKind
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(from: String, sid: String, kind: WaddleCallEventKind) {
+    public init(from: String, to: String?, sid: String, kind: WaddleCallEventKind) {
         self.from = from
+        self.to = to
         self.sid = sid
         self.kind = kind
     }
@@ -1538,6 +1545,7 @@ public struct FfiConverterTypeWaddleCallEvent: FfiConverterRustBuffer {
         return
             try WaddleCallEvent(
                 from: FfiConverterString.read(from: &buf),
+                to: FfiConverterOptionString.read(from: &buf),
                 sid: FfiConverterString.read(from: &buf),
                 kind: FfiConverterTypeWaddleCallEventKind.read(from: &buf)
         )
@@ -1545,6 +1553,7 @@ public struct FfiConverterTypeWaddleCallEvent: FfiConverterRustBuffer {
 
     public static func write(_ value: WaddleCallEvent, into buf: inout [UInt8]) {
         FfiConverterString.write(value.from, into: &buf)
+        FfiConverterOptionString.write(value.to, into: &buf)
         FfiConverterString.write(value.sid, into: &buf)
         FfiConverterTypeWaddleCallEventKind.write(value.kind, into: &buf)
     }
@@ -4059,6 +4068,30 @@ fileprivate struct FfiConverterOptionTypeWaddleAvatar: FfiConverterRustBuffer {
         switch try readInt(&buf) as Int8 {
         case 0: return nil
         case 1: return try FfiConverterTypeWaddleAvatar.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeWaddleCallEvent: FfiConverterRustBuffer {
+    typealias SwiftType = WaddleCallEvent?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeWaddleCallEvent.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeWaddleCallEvent.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }

--- a/apps/apple/Waddle/RustClient/RustXmppClient.swift
+++ b/apps/apple/Waddle/RustClient/RustXmppClient.swift
@@ -512,7 +512,7 @@ private func makeCallEvent(_ event: WaddleCallEvent) -> XMPPCallEvent {
             return .sessionTerminate(reason: reason.map(makeJingleReason))
         }
     }()
-    return XMPPCallEvent(from: event.from, sid: event.sid, kind: kind)
+    return XMPPCallEvent(from: event.from, to: event.to, sid: event.sid, kind: kind)
 }
 
 private func makeSharedFile(_ file: WaddleSharedFile) -> XMPPSharedFile {
@@ -579,7 +579,8 @@ private extension WaddleMamPage {
                 queryID: archived.queryId,
                 stanzaID: archived.stanzaId,
                 delayedDeliveryTimestamp: timestamp,
-                message: msgEvent
+                message: msgEvent,
+                callEvent: archived.callEvent.map(makeCallEvent)
             )
         }
 

--- a/apps/apple/Waddle/XMPP/XMPPTypes.swift
+++ b/apps/apple/Waddle/XMPP/XMPPTypes.swift
@@ -330,6 +330,10 @@ struct XMPPCallEvent: Sendable, Equatable {
     /// propose / session-initiate (XEP-0353 §0.6) so responses can
     /// be addressed back to the originating resource.
     let from: String
+    /// Stanza recipient stamped by the parser when available. This
+    /// lets multi-resource clients distinguish self-originated
+    /// carbons without guessing from the sender alone.
+    let to: String?
     /// Jingle session id correlating every stanza for this call.
     let sid: String
     let kind: XMPPCallEventKind
@@ -355,6 +359,7 @@ struct XMPPArchiveMessage: Sendable, Equatable {
     let stanzaID: String?
     let delayedDeliveryTimestamp: Date?
     let message: XMPPMessageEvent
+    let callEvent: XMPPCallEvent?
 }
 
 struct XMPPArchivePage: Sendable, Equatable {

--- a/chat/src/components/calls/CallActivePill.vue
+++ b/chat/src/components/calls/CallActivePill.vue
@@ -1,13 +1,7 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref } from "vue";
-import { useStore } from "@nanostores/vue";
 import { Phone } from "lucide-vue-next";
-import { $callState } from "@/lib/calls/call-store";
-import {
-  $mucCallParticipants,
-  normalizeMucCallRoomJid,
-} from "@/lib/calls/muc-call-presence";
-import { useActiveMucCall } from "@/lib/calls/use-active-muc-call";
+import { useRoomHasActiveCall } from "@/lib/calls/use-active-muc-call";
 
 /**
  * Live-call indicator shown in the channel header when the room owns
@@ -34,31 +28,22 @@ const props = defineProps<{
   disabled?: boolean;
 }>();
 
-const state = useStore($callState);
-const participants = useStore($mucCallParticipants);
-const { selfInCall, activeRoomJid } = useActiveMucCall();
-
-const normalizedRoomJid = computed(() => normalizeMucCallRoomJid(props.roomJid));
-
-const callInThisRoom = computed(() => {
-  return (
-    activeRoomJid.value !== null &&
-    activeRoomJid.value === normalizedRoomJid.value
-  );
-});
+const {
+  hasActiveCall,
+  selfInCall,
+  localResourceInCall,
+  participantCount,
+} = useRoomHasActiveCall(
+  () => props.roomJid,
+);
 
 /**
  * The pill is visible only when:
- *   - There is an active MUC call in THIS room.
- *   - The local user is not currently joined to it (otherwise the
- *     split surface is already painting the state for them).
+ *   - There is an active MUC call in THIS room per Muji presence.
+ *   - This browser resource is not currently joined to it (otherwise
+ *     the split surface is already painting the state for them).
  */
-const isVisible = computed(() => callInThisRoom.value && !selfInCall.value);
-
-const participantCount = computed<number>(() => {
-  if (!callInThisRoom.value) return 0;
-  return (participants.value[normalizedRoomJid.value] ?? []).length;
-});
+const isVisible = computed(() => hasActiveCall.value && !localResourceInCall.value);
 
 /**
  * Running call duration. Pegged to a single shared 1Hz tick so we
@@ -72,7 +57,7 @@ const now = ref(Date.now());
 let tick: ReturnType<typeof setInterval> | null = null;
 
 function ensureStart(): void {
-  if (!callInThisRoom.value) {
+  if (!hasActiveCall.value) {
     callStartTimestamp.value = null;
     return;
   }
@@ -110,7 +95,10 @@ const durationLabel = computed<string>(() => {
 const ariaLabel = computed(() => {
   const count = participantCount.value;
   const noun = count === 1 ? "person" : "people";
-  return `Live call in this channel, ${count} ${noun}, ${durationLabel.value} elapsed. Click to join.`;
+  const device = selfInCall.value
+    ? " This account is connected on another device."
+    : "";
+  return `Live call in this channel, ${count} ${noun}, ${durationLabel.value} elapsed.${device} Click to join from this device.`;
 });
 
 function onClick(): void {

--- a/chat/src/components/calls/CallButton.vue
+++ b/chat/src/components/calls/CallButton.vue
@@ -3,6 +3,7 @@ import { computed } from "vue";
 import { useStore } from "@nanostores/vue";
 import { Phone, Video } from "lucide-vue-next";
 import { $callState, beginOutgoingCall, reportCallError, scheduleOutgoingTimeout } from "@/lib/calls/call-store";
+import { clearDmCallActivity, useDmCallActivity } from "@/lib/calls/dm-call-activity";
 import { newCallSid, outboundCalls } from "@/lib/calls/outbound";
 import { connectionStore } from "@/lib/connection-store";
 import type { CallMedia } from "@/lib/calls/types";
@@ -16,12 +17,15 @@ const props = defineProps<{
 }>();
 
 const state = useStore($callState);
+const { hasActivity: hasPeerCallActivity } = useDmCallActivity(() => props.peerBareJid);
 
 /** A call is already in flight — disable the button so the
  *  caller can't start a parallel call while one is ringing or
  *  active. The store tracks a single slot today (see
  *  `CallState`). */
-const inCall = computed(() => state.value.phase !== "idle" && state.value.phase !== "ended");
+const inCall = computed(
+  () => (state.value.phase !== "idle" && state.value.phase !== "ended") || hasPeerCallActivity.value,
+);
 
 function getSender() {
   const client = connectionStore.client as unknown as { xmpp?: unknown } | null;
@@ -50,6 +54,7 @@ async function startCall(media: CallMedia): Promise<void> {
     if (current.phase === "outgoing" && current.sid === sid) {
       $callState.set({ phase: "idle" });
     }
+    clearDmCallActivity(props.peerBareJid, sid);
     reportCallError(err);
   }
 }

--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -18,6 +18,7 @@ import {
 import { useCallEngine } from "@/lib/calls/use-call-engine";
 import { useActiveMucCall } from "@/lib/calls/use-active-muc-call";
 import { normalizeMucCallRoomJid } from "@/lib/calls/muc-call-presence";
+import { barePeerJid } from "@/lib/xmpp/jid";
 import CallTileGrid from "./CallTileGrid.vue";
 import CallControls from "./CallControls.vue";
 import CallSettingsDialog from "./CallSettingsDialog.vue";
@@ -34,14 +35,13 @@ import CallSettingsDialog from "./CallSettingsDialog.vue";
  * header + banners + split + timeline + composer in one paint, so
  * the user sees only the call.
  *
- * Renders only when:
- *   - There is an active MUC call (`kind === "muc"`).
- *   - The call's room matches the channel currently being viewed.
- *   - The local user is a participant.
- *   - `$callUiMode === "expanded"`.
+ * MUC calls match the current room and require the local user to be
+ * present in Muji. 1:1 calls match the current DM peer's bare JID.
  */
 const props = defineProps<{
-  roomJid: string;
+  roomJid?: string;
+  dmPeerJid?: string;
+  dmPeerName?: string;
 }>();
 
 const state = useStore($callState);
@@ -56,23 +56,34 @@ const { activeRoomJid, selfInCall } = useActiveMucCall();
 const settingsOpen = ref(false);
 
 const normalizedRoomJid = computed(() =>
-  normalizeMucCallRoomJid(props.roomJid),
+  normalizeMucCallRoomJid(props.roomJid ?? ""),
 );
 
-const ownsThisCall = computed(() => {
+const normalizedDmPeerJid = computed(() =>
+  barePeerJid(props.dmPeerJid ?? "").toLowerCase(),
+);
+
+const ownsMucCall = computed(() => {
   return (
+    state.value.phase === "active" &&
+    state.value.kind === "muc" &&
     activeRoomJid.value !== null &&
     activeRoomJid.value === normalizedRoomJid.value
   );
 });
 
+const ownsDmCall = computed(() => {
+  if (state.value.phase !== "active" || state.value.kind !== "dm") return false;
+  const peer = barePeerJid(state.value.peer).toLowerCase();
+  return !!peer && peer === normalizedDmPeerJid.value;
+});
+
 const isOpen = computed(() => {
   return (
     state.value.phase === "active" &&
-    state.value.kind === "muc" &&
     uiMode.value === "expanded" &&
-    ownsThisCall.value &&
-    selfInCall.value
+    ((state.value.kind === "muc" && ownsMucCall.value && selfInCall.value) ||
+      (state.value.kind === "dm" && ownsDmCall.value))
   );
 });
 
@@ -82,7 +93,12 @@ const remoteParticipantCount = computed(() => {
   return ids.size;
 });
 
-const peerLabel = computed(() => peerLabelFromState());
+const peerLabel = computed(() => {
+  if (state.value.phase === "active" && state.value.kind === "dm") {
+    return props.dmPeerName || peerLabelFromState();
+  }
+  return peerLabelFromState();
+});
 
 const subline = computed(() => {
   if (state.value.phase !== "active") return "";

--- a/chat/src/components/calls/CallSplitContainer.vue
+++ b/chat/src/components/calls/CallSplitContainer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, toRef } from "vue";
+import { computed, ref } from "vue";
 import { useStore } from "@nanostores/vue";
 import {
   $callState,
@@ -11,6 +11,7 @@ import {
   $callMicEnabled,
   $callCamEnabled,
   hangupActiveCall,
+  peerLabelFromState,
   toggleCam,
   toggleMic,
 } from "@/lib/calls/call-controls";
@@ -18,22 +19,20 @@ import { useCallEngine } from "@/lib/calls/use-call-engine";
 import { useActiveMucCall } from "@/lib/calls/use-active-muc-call";
 import { useSplitResize } from "@/lib/calls/use-split-resize";
 import { normalizeMucCallRoomJid } from "@/lib/calls/muc-call-presence";
+import { barePeerJid } from "@/lib/xmpp/jid";
 import CallTileGrid from "./CallTileGrid.vue";
 import CallControls from "./CallControls.vue";
 import CallSettingsDialog from "./CallSettingsDialog.vue";
 import SplitDragHandle from "./SplitDragHandle.vue";
 
 /**
- * Inline split-view surface for an active MUC group call.
+ * Inline split-view surface for an active call in the current
+ * conversation.
  *
  * Mounted by `ContentArea.vue` between the channel header/banners
  * and the message timeline. Renders only when ALL of the following
- * hold:
- *   - There is an active call in `$callState` with `kind === "muc"`.
- *   - The room hosting the call matches the channel currently being
- *     viewed (props.roomJid).
- *   - The local user's nick is in that room's Muji-active list.
- *   - `$callUiMode` is `"split"` (not `"fullscreen"`).
+ * MUC calls also require the local user's nick to be in that room's
+ * Muji-active list; 1:1 calls are keyed by the peer's bare JID.
  *
  * The split lives ABOVE the timeline so the chat is always visible
  * beneath; the drag handle resizes the two regions inside the parent
@@ -41,7 +40,9 @@ import SplitDragHandle from "./SplitDragHandle.vue";
  * contract.
  */
 const props = defineProps<{
-  roomJid: string;
+  roomJid?: string;
+  dmPeerJid?: string;
+  dmPeerName?: string;
 }>();
 
 const state = useStore($callState);
@@ -57,28 +58,41 @@ const settingsOpen = ref(false);
 const containerRef = ref<HTMLElement | null>(null);
 
 const normalizedRoomJid = computed(() =>
-  normalizeMucCallRoomJid(props.roomJid),
+  normalizeMucCallRoomJid(props.roomJid ?? ""),
 );
 
-const ownsThisCall = computed(() => {
+const normalizedDmPeerJid = computed(() =>
+  barePeerJid(props.dmPeerJid ?? "").toLowerCase(),
+);
+
+const ownsMucCall = computed(() => {
   return (
+    state.value.phase === "active" &&
+    state.value.kind === "muc" &&
     activeRoomJid.value !== null &&
     activeRoomJid.value === normalizedRoomJid.value
   );
 });
 
+const ownsDmCall = computed(() => {
+  if (state.value.phase !== "active" || state.value.kind !== "dm") return false;
+  const peer = barePeerJid(state.value.peer).toLowerCase();
+  return !!peer && peer === normalizedDmPeerJid.value;
+});
+
 const shouldRender = computed(() => {
   return (
     state.value.phase === "active" &&
-    state.value.kind === "muc" &&
     uiMode.value === "split" &&
-    ownsThisCall.value &&
-    selfInCall.value
+    ((state.value.kind === "muc" && ownsMucCall.value && selfInCall.value) ||
+      (state.value.kind === "dm" && ownsDmCall.value))
   );
 });
 
-const roomJidRef = toRef(props, "roomJid");
-const { isDragging, percent, beginDrag } = useSplitResize(roomJidRef);
+const splitKey = computed(() =>
+  normalizedRoomJid.value || normalizedDmPeerJid.value,
+);
+const { isDragging, percent, beginDrag } = useSplitResize(splitKey);
 
 function getColumnRect(): DOMRect | null {
   // The flex column we resize within is `containerRef`'s offsetParent
@@ -109,10 +123,20 @@ const remoteParticipantCount = computed(() => {
 const subline = computed(() => {
   if (state.value.phase !== "active") return "";
   if (connecting.value) return "Connecting…";
+  if (state.value.kind === "dm") {
+    return state.value.media.video ? "Video call" : "Audio call";
+  }
   const others = remoteParticipantCount.value;
   return others === 0
     ? "Waiting for others to join…"
     : `${others} other${others === 1 ? "" : "s"} in call`;
+});
+
+const callLabel = computed(() => {
+  if (state.value.phase === "active" && state.value.kind === "dm") {
+    return props.dmPeerName || peerLabelFromState();
+  }
+  return peerLabelFromState();
 });
 
 const localIdentity = computed(() => engine.localIdentity);
@@ -135,7 +159,7 @@ async function onHangup(): Promise<void> {
       <header class="call-split__header">
         <div class="call-split__title">
           <span class="call-split__live-dot" aria-hidden="true" />
-          <span class="type-control">Live · {{ subline }}</span>
+          <span class="type-control">Live · {{ callLabel }} · {{ subline }}</span>
         </div>
       </header>
       <div

--- a/chat/src/components/calls/IncomingCallToast.vue
+++ b/chat/src/components/calls/IncomingCallToast.vue
@@ -3,6 +3,7 @@ import { computed, ref, watch } from "vue";
 import { useStore } from "@nanostores/vue";
 import { Phone, PhoneOff, Video } from "lucide-vue-next";
 import { $callState, $lastCallError, clearCallState, reportCallError } from "@/lib/calls/call-store";
+import { clearDmCallActivity } from "@/lib/calls/dm-call-activity";
 import { outboundCalls } from "@/lib/calls/outbound";
 import { connectionStore } from "@/lib/connection-store";
 
@@ -82,6 +83,7 @@ async function decline(): Promise<void> {
       reportCallError(err);
     }
   }
+  clearDmCallActivity(from, sid);
   clearCallState();
 }
 </script>

--- a/chat/src/components/calls/MucCallButton.vue
+++ b/chat/src/components/calls/MucCallButton.vue
@@ -42,6 +42,18 @@ function getSender(): RawIqSender | null {
   return (client?.xmpp as RawIqSender | undefined) ?? null;
 }
 
+function getClientJoiner(): ((roomJid: string) => Promise<void>) | null {
+  const client = connectionStore.client as unknown as {
+    ensureJoined?: (roomJid: string) => Promise<void>;
+  } | null;
+  return client?.ensureJoined?.bind(client) ?? null;
+}
+
+function getSelfFullJid(): string | undefined {
+  const client = connectionStore.client as unknown as { fullJid?: string } | null;
+  return client?.fullJid;
+}
+
 function getExpectedMixerJid(): string | undefined {
   const accountJid = connectionStore.session?.jid;
   return accountJid ? `calls.${jidDomain(accountJid)}` : undefined;
@@ -64,7 +76,11 @@ async function startCall(media: CallMedia): Promise<void> {
     },
     getSender,
     getSelfNick: () => connectionStore.session?.username ?? undefined,
+    getSelfFullJid,
     getExpectedMixerJid,
+    ensureJoined: async () => {
+      await getClientJoiner()?.(props.roomJid);
+    },
   });
 }
 

--- a/chat/src/components/calls/OutgoingCallToast.vue
+++ b/chat/src/components/calls/OutgoingCallToast.vue
@@ -3,6 +3,7 @@ import { computed } from "vue";
 import { useStore } from "@nanostores/vue";
 import { Phone, PhoneOff, Video } from "lucide-vue-next";
 import { $callState, $lastCallError, clearCallState, reportCallError } from "@/lib/calls/call-store";
+import { clearDmCallActivity } from "@/lib/calls/dm-call-activity";
 import { outboundCalls } from "@/lib/calls/outbound";
 import { connectionStore } from "@/lib/connection-store";
 
@@ -69,6 +70,7 @@ async function cancel(): Promise<void> {
       reportCallError(err);
     }
   }
+  clearDmCallActivity(to, sid);
   clearCallState();
 }
 

--- a/chat/src/components/chat/ChatHeader.vue
+++ b/chat/src/components/chat/ChatHeader.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { computed, type Component } from "vue";
-import { Hash, Menu, MessageCircle, MessagesSquare, Pin, Search, Settings, Users } from "lucide-vue-next";
+import { Hash, Menu, MessageCircle, MessagesSquare, PhoneCall, Pin, Search, Settings, Users } from "lucide-vue-next";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import CallButton from "@/components/calls/CallButton.vue";
 import MucCallButton from "@/components/calls/MucCallButton.vue";
 import NotifyModeButton from "@/components/chat/NotifyModeButton.vue";
+import { useDmCallActivity } from "@/lib/calls/dm-call-activity";
 import type { ChannelSummary, SpaceSummary } from "@/lib/chat-types";
 import type { ConnectionNoticeCopy } from "@/lib/connection-notice";
 import type { BrowserXmppClient } from "@/lib/xmpp-client";
@@ -74,6 +75,12 @@ const onlineCount = computed(() => sortedMembers.value.filter((m) => m.presence 
 
 const showSearch = defineModel<boolean>("showSearch", { required: true });
 const showPinnedPanel = defineModel<boolean>("showPinnedPanel", { default: false });
+const { activity: dmCallActivity } = useDmCallActivity(() => props.dmPeer?.peerJid);
+
+const dmCallActivityLabel = computed(() => {
+  if (!dmCallActivity.value) return "";
+  return dmCallActivity.value.state === "accepted" ? "Call active" : "Ringing";
+});
 
 const emit = defineEmits<{
   openNav: [];
@@ -165,6 +172,13 @@ const memberButtonCopy = computed(() => {
             </span>
             <span v-if="dmPeer" class="hidden lg:inline type-meta text-muted-foreground">
               · {{ presenceText(dmPeer.presenceShow) }}
+            </span>
+            <span
+              v-if="dmCallActivity"
+              class="type-meta inline-flex h-5 shrink-0 items-center gap-1 rounded-full border border-success/25 bg-success/10 px-2 text-success"
+            >
+              <PhoneCall class="h-3 w-3" />
+              {{ dmCallActivityLabel }}
             </span>
           </div>
           <div v-if="dmPeer" class="lg:hidden type-caption text-muted-foreground truncate">

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -1068,17 +1068,13 @@ function dayDividerLabel(createdAt: string): string {
       </div>
     </div>
 
-    <!-- Inline split-view for an active group call in this channel.
-         Renders ONLY when (a) a MUC call is active, (b) the call's
-         room matches this channel, (c) the local user is a
-         participant, and (d) the call UI mode is "split" (not
-         "fullscreen"). All of that gating is inside the component;
-         we mount it unconditionally and let it decide. The handle is
-         emitted as a sibling so it sits between the call region and
-         the timeline in the parent flex column. -->
+    <!-- Inline split-view for an active call in this conversation.
+         MUC and DM ownership gates live inside the component. -->
     <CallSplitContainer
-      v-if="channel?.jid"
-      :room-jid="channel.jid"
+      v-if="channel?.jid || dmPeer?.peerJid"
+      :room-jid="channel?.jid"
+      :dm-peer-jid="dmPeer?.peerJid"
+      :dm-peer-name="dmPeer?.peerUsername"
     />
 
     <!-- Composer (social / top-pinned mode) -->
@@ -1470,8 +1466,10 @@ function dayDividerLabel(createdAt: string): string {
          panel — stays visible. Decides its own visibility based on
          call state + ui mode. -->
     <CallExpandedSurface
-      v-if="channel?.jid"
-      :room-jid="channel.jid"
+      v-if="channel?.jid || dmPeer?.peerJid"
+      :room-jid="channel?.jid"
+      :dm-peer-jid="dmPeer?.peerJid"
+      :dm-peer-name="dmPeer?.peerUsername"
     />
   </div>
 </template>

--- a/chat/src/components/chat/DmPanel.vue
+++ b/chat/src/components/chat/DmPanel.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
-import { MessageCircle, Plus } from "lucide-vue-next";
+import { useStore } from "@nanostores/vue";
+import { MessageCircle, PhoneCall, Plus } from "lucide-vue-next";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import { formatTimelineStamp } from "@/channels/timeline";
+import { $dmCallActivities } from "@/lib/calls/dm-call-activity";
+import { barePeerJid } from "@/lib/xmpp/jid";
 import type { DmConversation } from "@/lib/xmpp-client";
 
 const props = defineProps<{
@@ -14,6 +17,8 @@ const emit = defineEmits<{
   newDm: [];
 }>();
 
+const dmCallActivities = useStore($dmCallActivities);
+
 function preview(text?: string): string {
   if (!text) return "";
   return text.length > 44 ? `${text.slice(0, 44)}…` : text;
@@ -25,6 +30,17 @@ function dotClass(show?: DmConversation["presenceShow"]): string {
   if (show === "xa") return "bg-warning/55";
   if (show === "available") return "bg-success/75";
   return "bg-muted-foreground/25";
+}
+
+function hasCallActivity(peerJid: string): boolean {
+  const normalized = barePeerJid(peerJid).toLowerCase();
+  return !!normalized && !!dmCallActivities.value[normalized];
+}
+
+function callActivityLabel(peerJid: string): string {
+  const normalized = barePeerJid(peerJid).toLowerCase();
+  const activity = normalized ? dmCallActivities.value[normalized] : null;
+  return activity?.state === "ringing" ? "Ringing" : "Live";
 }
 </script>
 
@@ -87,10 +103,19 @@ function dotClass(show?: DmConversation["presenceShow"]): string {
               </span>
             </div>
             <div class="flex items-center gap-1.5">
-              <span class="type-caption text-sidebar-muted truncate">{{ preview(conversation.lastMessageBody) }}</span>
+              <span class="type-caption text-sidebar-muted min-w-0 flex-1 truncate">{{ preview(conversation.lastMessageBody) }}</span>
+              <span
+                v-if="hasCallActivity(conversation.peerJid)"
+                class="type-meta inline-flex h-[18px] shrink-0 items-center gap-1 rounded-full border border-success/25 bg-success/10 px-1.5 text-success"
+                :title="callActivityLabel(conversation.peerJid)"
+                :aria-label="callActivityLabel(conversation.peerJid)"
+              >
+                <PhoneCall class="h-3 w-3" />
+                <span>{{ callActivityLabel(conversation.peerJid) }}</span>
+              </span>
               <span
                 v-if="conversation.unreadCount > 0"
-                class="chat-badge-glow--primary type-count-badge ml-auto inline-flex min-w-[18px] h-[18px] px-1 items-center justify-center rounded-full bg-primary text-primary-foreground"
+                class="chat-badge-glow--primary type-count-badge inline-flex min-w-[18px] h-[18px] shrink-0 items-center justify-center rounded-full bg-primary px-1 text-primary-foreground"
               >
                 {{ conversation.unreadCount }}
               </span>

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -8,6 +8,10 @@ import {
   clearMucCallParticipant,
   normalizeMucCallRoomJid,
 } from "./muc-call-presence";
+import {
+  applyDmCallEvent,
+  clearDmCallActivity,
+} from "./dm-call-activity";
 import { barePeerJid } from "../xmpp/jid";
 
 /**
@@ -192,6 +196,9 @@ export function reduceCallState(current: CallState, event: CallEvent): CallState
       // is session-initiate. The reducer keeps the call in
       // `outgoing`; `call-effects.ts` reads `proceed.from` and
       // emits the session-initiate stanza.
+      if (current.phase === "incoming" && current.sid === event.sid) {
+        return { phase: "idle" };
+      }
       return current;
     case "reject":
     case "retract":
@@ -262,7 +269,7 @@ export function reduceCallState(current: CallState, event: CallEvent): CallState
         return {
           phase: "ended",
           sid: event.sid,
-          reason: event.kind === "session-terminate" ? event.reason : event.reason ?? null,
+          reason: event.reason ?? null,
         };
       }
       return current;
@@ -369,6 +376,17 @@ export function beginOutgoingCall(
       ? { phase: "outgoing", to, sid, media, initiator }
       : { phase: "outgoing", to, sid, media },
   );
+  applyDmCallEvent({
+    event: {
+      kind: "propose",
+      from: initiator ?? "",
+      sid,
+      media,
+    },
+    selfBareJid: initiator ?? "",
+    to,
+    directionHint: "outgoing",
+  });
   $lastCallError.set(null);
 }
 
@@ -410,6 +428,7 @@ export function scheduleOutgoingTimeout(
     void outboundCalls
       .retract(sender, s.to, s.sid)
       .catch((err) => reportCallError(err));
+    clearDmCallActivity(s.to, sid);
     $callState.set({
       phase: "ended",
       sid,
@@ -440,6 +459,7 @@ export function scheduleSessionAcceptTimeout(
     void outboundCalls
       .sessionTerminate(sender, peerFullJid, sid, "timeout")
       .catch((err) => reportCallError(err));
+    clearDmCallActivity(peerFullJid, sid);
     $callState.set({
       phase: "ended",
       sid,
@@ -526,17 +546,21 @@ export async function tearDownActiveCall(
       switch (s.phase) {
         case "active":
           if (s.kind === "dm") {
-            await outboundCalls.sessionTerminate(sender, s.peer, s.sid, reason);
-            // XEP-0353 §3.5: both parties SHOULD send `<finish/>` after
-            // the call ends so MAM archives both sides consistently
-            // (the JMI message stack uses the finish marker to bookend
-            // the call record). Best-effort: a wasm bundle that
-            // doesn't expose `send_call_finish` shouldn't keep the
-            // terminate from clearing the local slot.
             try {
-              await outboundCalls.finish(sender, s.peer, s.sid);
-            } catch (err) {
-              reportCallError(err);
+              await outboundCalls.sessionTerminate(sender, s.peer, s.sid, reason);
+              // XEP-0353 §3.5: both parties SHOULD send `<finish/>` after
+              // the call ends so MAM archives both sides consistently
+              // (the JMI message stack uses the finish marker to bookend
+              // the call record). Best-effort: a wasm bundle that
+              // doesn't expose `send_call_finish` shouldn't keep the
+              // terminate from clearing the local slot.
+              try {
+                await outboundCalls.finish(sender, s.peer, s.sid);
+              } catch (err) {
+                reportCallError(err);
+              }
+            } finally {
+              clearDmCallActivity(s.peer, s.sid);
             }
           } else {
             // MUC group call: clear our Muji presence AND leave via
@@ -562,7 +586,7 @@ export async function tearDownActiveCall(
               } catch (err) {
                 reportCallError(err);
               } finally {
-                clearMucCallParticipant(s.peer, s.selfNick);
+                clearMucCallParticipant(s.peer, s.selfNick, s.selfFullJid);
               }
             }
             try {
@@ -573,10 +597,18 @@ export async function tearDownActiveCall(
           }
           break;
         case "outgoing":
-          await outboundCalls.retract(sender, s.to, s.sid);
+          try {
+            await outboundCalls.retract(sender, s.to, s.sid);
+          } finally {
+            clearDmCallActivity(s.to, s.sid);
+          }
           break;
         case "incoming":
-          await outboundCalls.reject(sender, s.from, s.sid);
+          try {
+            await outboundCalls.reject(sender, s.from, s.sid);
+          } finally {
+            clearDmCallActivity(s.from, s.sid);
+          }
           break;
         case "muc-pending":
           rejectPendingMujiAccept(
@@ -604,7 +636,7 @@ export async function tearDownActiveCall(
               } catch (err) {
                 reportCallError(err);
               } finally {
-                clearMucCallParticipant(s.peer, s.selfNick);
+                  clearMucCallParticipant(s.peer, s.selfNick, s.selfFullJid);
               }
             }
             if (s.activePresencePublished) {
@@ -716,6 +748,7 @@ async function rollbackMucCallSetup(
   sender: RawIqSender,
   roomJid: string,
   selfNick: string,
+  selfFullJid: string | null | undefined,
   terminateSfu: boolean,
   sid?: string,
 ): Promise<void> {
@@ -731,7 +764,7 @@ async function rollbackMucCallSetup(
     } catch (err) {
       reportCallError(err);
     } finally {
-      clearMucCallParticipant(roomJid, selfNick);
+      clearMucCallParticipant(roomJid, selfNick, selfFullJid);
     }
   }
   if (terminateSfu) {
@@ -816,6 +849,7 @@ export async function beginMucCall(
   media: CallMedia,
   selfNick?: string,
   expectedMixerJid?: string | null,
+  selfFullJid?: string | null,
 ): Promise<void> {
   const normalizedRoomJid = normalizeMucCallRoomJid(roomJid);
   if (!normalizedRoomJid) {
@@ -842,6 +876,7 @@ export async function beginMucCall(
     media,
     kind: "muc",
     selfNick,
+    selfFullJid,
     attemptId,
   });
   $lastCallError.set(null);
@@ -858,6 +893,7 @@ export async function beginMucCall(
       normalizedRoomJid,
       selfNick,
       PREPARING_ECHO_TIMEOUT_MS,
+      selfFullJid,
     );
     await sender.update_muji_presence(
       normalizedRoomJid,
@@ -877,6 +913,7 @@ export async function beginMucCall(
       normalizedRoomJid,
       selfNick,
       PREPARING_PEERS_TIMEOUT_MS,
+      selfFullJid,
     );
     assertMucSetupStillPending(normalizedRoomJid, selfNick, attemptId);
 
@@ -891,7 +928,14 @@ export async function beginMucCall(
       media.video, // video
     );
     if (!mucSetupStillPending(normalizedRoomJid, selfNick, attemptId)) {
-      await rollbackMucCallSetup(sender, normalizedRoomJid, selfNick, false, attemptId);
+      await rollbackMucCallSetup(
+        sender,
+        normalizedRoomJid,
+        selfNick,
+        selfFullJid,
+        false,
+        attemptId,
+      );
       throw new Error(`Muji call setup for ${normalizedRoomJid} was cancelled`);
     }
     activePresencePublished = true;
@@ -902,6 +946,7 @@ export async function beginMucCall(
       media,
       kind: "muc",
       selfNick,
+      selfFullJid,
       attemptId,
       activePresencePublished: true,
     });
@@ -925,6 +970,7 @@ export async function beginMucCall(
       join,
       kind: "muc",
       selfNick,
+      selfFullJid,
     });
     $lastCallError.set(null);
   } catch (err) {
@@ -940,6 +986,7 @@ export async function beginMucCall(
         sender,
         normalizedRoomJid,
         selfNick,
+        selfFullJid,
         activePresencePublished,
         attemptId,
       );

--- a/chat/src/lib/calls/dm-call-activity.ts
+++ b/chat/src/lib/calls/dm-call-activity.ts
@@ -1,0 +1,218 @@
+import { computed, type ComputedRef } from "vue";
+import { useStore } from "@nanostores/vue";
+import { map } from "nanostores";
+import { barePeerJid } from "@/lib/xmpp/jid";
+import type { CallEvent, CallMedia } from "./types";
+
+const ACTIVE_WINDOW_MS = 24 * 60 * 60 * 1000;
+const MAX_TERMINAL_TIMESTAMPS = 1024;
+
+type DmCallActivityState = "ringing" | "accepted";
+
+interface DmCallActivity {
+  peerJid: string;
+  sid: string;
+  media: CallMedia;
+  state: DmCallActivityState;
+  direction: "incoming" | "outgoing" | "unknown";
+  updatedAt: string;
+}
+
+export const $dmCallActivities = map<Record<string, DmCallActivity>>({});
+const dmCallTerminalTimestamps = new Map<string, string>();
+
+interface DmCallEventEnvelope {
+  event: CallEvent;
+  selfBareJid: string;
+  to?: string | null;
+  timestamp?: string | null;
+  now?: Date;
+  directionHint?: DmCallActivity["direction"];
+}
+
+function normalizedBare(jid?: string | null): string {
+  return barePeerJid(jid ?? "").toLowerCase();
+}
+
+function eventMedia(event: CallEvent, previous?: DmCallActivity): CallMedia {
+  if ("media" in event) return event.media;
+  return previous?.media ?? { audio: true, video: false };
+}
+
+function timestampFromEnvelope(envelope: DmCallEventEnvelope): string {
+  return envelope.timestamp || envelope.now?.toISOString() || new Date().toISOString();
+}
+
+function isStale(timestamp: string, now: Date): boolean {
+  const ms = Date.parse(timestamp);
+  if (!Number.isFinite(ms)) return false;
+  return now.getTime() - ms > ACTIVE_WINDOW_MS;
+}
+
+function isOlderThanCurrent(timestamp: string, current?: DmCallActivity): boolean {
+  if (!current) return false;
+  const nextMs = Date.parse(timestamp);
+  const currentMs = Date.parse(current.updatedAt);
+  if (!Number.isFinite(nextMs) || !Number.isFinite(currentMs)) return false;
+  return nextMs < currentMs;
+}
+
+function terminalKey(peerJid: string, sid: string): string {
+  return `${peerJid}\u0000${sid}`;
+}
+
+function isTerminalEvent(event: CallEvent): boolean {
+  return event.kind === "reject" ||
+    event.kind === "retract" ||
+    event.kind === "finish" ||
+    event.kind === "session-terminate";
+}
+
+function isOlderThanTerminal(peerJid: string, sid: string, timestamp: string): boolean {
+  const terminalTimestamp = dmCallTerminalTimestamps.get(terminalKey(peerJid, sid));
+  if (!terminalTimestamp) return false;
+  const nextMs = Date.parse(timestamp);
+  const terminalMs = Date.parse(terminalTimestamp);
+  if (!Number.isFinite(nextMs) || !Number.isFinite(terminalMs)) return false;
+  return nextMs <= terminalMs;
+}
+
+function pruneTerminalTimestamps(now: Date): void {
+  for (const [key, timestamp] of dmCallTerminalTimestamps) {
+    if (isStale(timestamp, now)) {
+      dmCallTerminalTimestamps.delete(key);
+    }
+  }
+  while (dmCallTerminalTimestamps.size > MAX_TERMINAL_TIMESTAMPS) {
+    const oldest = dmCallTerminalTimestamps.keys().next().value;
+    if (!oldest) break;
+    dmCallTerminalTimestamps.delete(oldest);
+  }
+}
+
+function recordTerminal(peerJid: string, sid: string, timestamp: string, now = new Date()): void {
+  const key = terminalKey(peerJid, sid);
+  const previous = dmCallTerminalTimestamps.get(key);
+  if (previous && isOlderThanTerminal(peerJid, sid, timestamp)) return;
+  dmCallTerminalTimestamps.set(key, timestamp);
+  pruneTerminalTimestamps(now);
+}
+
+function peerForSid(sid: string): string {
+  for (const [peerJid, activity] of Object.entries($dmCallActivities.get())) {
+    if (activity.sid === sid) return peerJid;
+  }
+  return "";
+}
+
+function peerForEnvelope(envelope: DmCallEventEnvelope): string {
+  const selfBare = normalizedBare(envelope.selfBareJid);
+  const fromBare = normalizedBare(envelope.event.from);
+  const toBare = normalizedBare(envelope.to ?? envelope.event.to);
+  if (fromBare && fromBare !== selfBare) return fromBare;
+  if (toBare && toBare !== selfBare) return toBare;
+  if (fromBare && fromBare === selfBare) return peerForSid(envelope.event.sid);
+  return "";
+}
+
+function directionForEnvelope(envelope: DmCallEventEnvelope): DmCallActivity["direction"] {
+  if (envelope.directionHint) return envelope.directionHint;
+  const selfBare = normalizedBare(envelope.selfBareJid);
+  const fromBare = normalizedBare(envelope.event.from);
+  if (!selfBare || !fromBare) return "unknown";
+  return fromBare === selfBare ? "outgoing" : "incoming";
+}
+
+function removeActivity(peerJid: string, sid: string): void {
+  const current = $dmCallActivities.get()[peerJid];
+  if (!current || current.sid !== sid) return;
+  const next = { ...$dmCallActivities.get() };
+  delete next[peerJid];
+  $dmCallActivities.set(next);
+}
+
+export function clearDmCallActivity(peerJid: string, sid?: string): void {
+  const normalized = normalizedBare(peerJid);
+  if (!normalized) return;
+  const current = $dmCallActivities.get()[normalized];
+  const now = new Date();
+  if (sid) recordTerminal(normalized, sid, now.toISOString(), now);
+  if (!current) return;
+  if (sid && current.sid !== sid) return;
+  recordTerminal(normalized, current.sid, now.toISOString(), now);
+  const next = { ...$dmCallActivities.get() };
+  delete next[normalized];
+  $dmCallActivities.set(next);
+}
+
+export function applyDmCallEvent(envelope: DmCallEventEnvelope): void {
+  const peerJid = peerForEnvelope(envelope);
+  if (!peerJid) return;
+  const timestamp = timestampFromEnvelope(envelope);
+  const now = envelope.now ?? new Date();
+  if (isStale(timestamp, now)) {
+    removeActivity(peerJid, envelope.event.sid);
+    return;
+  }
+  const previous = $dmCallActivities.get()[peerJid];
+  if (isOlderThanCurrent(timestamp, previous)) return;
+  if (!isTerminalEvent(envelope.event) && isOlderThanTerminal(peerJid, envelope.event.sid, timestamp)) return;
+  switch (envelope.event.kind) {
+    case "propose":
+      $dmCallActivities.setKey(peerJid, {
+        peerJid,
+        sid: envelope.event.sid,
+        media: envelope.event.media,
+        state: "ringing",
+        direction: directionForEnvelope(envelope),
+        updatedAt: timestamp,
+      });
+      return;
+    case "proceed":
+    case "session-initiate":
+    case "session-accept":
+      $dmCallActivities.setKey(peerJid, {
+        peerJid,
+        sid: envelope.event.sid,
+        media: eventMedia(envelope.event, previous),
+        state: "accepted",
+        direction: previous?.direction ?? directionForEnvelope(envelope),
+        updatedAt: timestamp,
+      });
+      return;
+    case "reject":
+    case "retract":
+    case "finish":
+    case "session-terminate":
+      recordTerminal(peerJid, envelope.event.sid, timestamp, now);
+      removeActivity(peerJid, envelope.event.sid);
+      return;
+  }
+}
+
+export function clearDmCallActivities(): void {
+  $dmCallActivities.set({});
+  dmCallTerminalTimestamps.clear();
+}
+
+export function readDmCallActivity(peerJid: string): DmCallActivity | null {
+  const normalized = normalizedBare(peerJid);
+  if (!normalized) return null;
+  return $dmCallActivities.get()[normalized] ?? null;
+}
+
+export function useDmCallActivity(
+  peerJid: () => string | null | undefined,
+): {
+  activity: ComputedRef<DmCallActivity | null>;
+  hasActivity: ComputedRef<boolean>;
+} {
+  const activities = useStore($dmCallActivities);
+  const activity = computed<DmCallActivity | null>(() => {
+    const normalized = normalizedBare(peerJid());
+    if (!normalized) return null;
+    return activities.value[normalized] ?? null;
+  });
+  const hasActivity = computed<boolean>(() => activity.value !== null);
+  return { activity, hasActivity };
+}

--- a/chat/src/lib/calls/muc-call-actions.ts
+++ b/chat/src/lib/calls/muc-call-actions.ts
@@ -8,7 +8,9 @@ type MucCallStartActionOptions = {
   setStarting: (starting: boolean) => void;
   getSender: () => RawIqSender | null;
   getSelfNick: () => string | undefined;
+  getSelfFullJid?: () => string | null | undefined;
   getExpectedMixerJid?: () => string | null | undefined;
+  ensureJoined?: () => Promise<void>;
 };
 
 /**
@@ -23,19 +25,23 @@ export async function startMucCallAction({
   setStarting,
   getSender,
   getSelfNick,
+  getSelfFullJid,
   getExpectedMixerJid,
+  ensureJoined,
 }: MucCallStartActionOptions): Promise<boolean> {
   if (isBusy()) return false;
   const sender = getSender();
   if (!sender) return false;
   setStarting(true);
   try {
+    await ensureJoined?.();
     await beginMucCall(
       sender,
       roomJid,
       media,
       getSelfNick(),
       getExpectedMixerJid?.(),
+      getSelfFullJid?.(),
     );
     return true;
   } catch (err) {

--- a/chat/src/lib/calls/muc-call-presence.ts
+++ b/chat/src/lib/calls/muc-call-presence.ts
@@ -20,10 +20,43 @@ import { map } from "nanostores";
  * change.
  */
 export const $mucCallParticipants = map<Record<string, string[]>>({});
+const $mucActiveParticipants = map<Record<string, string[]>>({});
 const $mucPreparingParticipants = map<Record<string, string[]>>({});
+const PARTICIPANT_KEY_SEPARATOR = "\u0000";
 
 export function normalizeMucCallRoomJid(roomJid: string): string {
   return roomJid.split("/")[0]?.trim().toLowerCase() ?? "";
+}
+
+function normalizeFullJid(jid?: string | null): string {
+  return jid?.trim().toLowerCase() ?? "";
+}
+
+function preparingParticipantKey(nick: string, realJid?: string | null): string {
+  const normalizedRealJid = normalizeFullJid(realJid);
+  return normalizedRealJid ? `${nick}${PARTICIPANT_KEY_SEPARATOR}${normalizedRealJid}` : nick;
+}
+
+function preparingParticipantNick(key: string): string {
+  return key.split(PARTICIPANT_KEY_SEPARATOR)[0] ?? key;
+}
+
+function preparingParticipantRealJid(key: string): string {
+  return key.includes(PARTICIPANT_KEY_SEPARATOR)
+    ? key.slice(key.indexOf(PARTICIPANT_KEY_SEPARATOR) + PARTICIPANT_KEY_SEPARATOR.length)
+    : "";
+}
+
+const activeParticipantKey = preparingParticipantKey;
+const activeParticipantNick = preparingParticipantNick;
+const activeParticipantRealJid = preparingParticipantRealJid;
+
+function samePreparingParticipant(key: string, nick: string, realJid?: string | null): boolean {
+  if (preparingParticipantNick(key) !== nick) return false;
+  const normalizedRealJid = normalizeFullJid(realJid);
+  const keyRealJid = preparingParticipantRealJid(key);
+  if (normalizedRealJid || keyRealJid) return normalizedRealJid === keyRealJid;
+  return true;
 }
 
 function mucCallParticipantsForRoom(roomJid: string): string[] {
@@ -44,9 +77,17 @@ export function mucCallParticipantCounts(
   return counts;
 }
 
-export function clearMucCallParticipant(roomJid: string, nick: string): void {
+export function clearMucCallParticipant(
+  roomJid: string,
+  nick: string,
+  realJid?: string | null,
+): void {
   const normalized = normalizeMucCallRoomJid(roomJid);
   if (!normalized || !nick) return;
+  removeActiveParticipant(normalized, nick, realJid, {
+    includeAggregate: !realJid,
+  });
+  if (realJid) return;
   const current = $mucCallParticipants.get()[normalized] ?? [];
   if (!current.includes(nick)) return;
   const next = current.filter((n) => n !== nick);
@@ -59,12 +100,61 @@ export function clearMucCallParticipant(roomJid: string, nick: string): void {
   }
 }
 
+function syncActiveParticipantsForRoom(roomJid: string): void {
+  const activeOwners = $mucActiveParticipants.get()[roomJid] ?? [];
+  const nicks = Array.from(new Set(activeOwners.map(activeParticipantNick).filter(Boolean)));
+  if (nicks.length === 0) {
+    const all = { ...$mucCallParticipants.get() };
+    delete all[roomJid];
+    $mucCallParticipants.set(all);
+  } else {
+    $mucCallParticipants.setKey(roomJid, nicks);
+  }
+}
+
+function addActiveParticipant(roomJid: string, nick: string, realJid?: string | null): void {
+  const current = $mucActiveParticipants.get()[roomJid] ?? [];
+  const key = activeParticipantKey(nick, realJid);
+  if (current.includes(key)) return;
+  $mucActiveParticipants.setKey(roomJid, [...current, key]);
+  syncActiveParticipantsForRoom(roomJid);
+}
+
+function removeActiveParticipant(
+  roomJid: string,
+  nick: string,
+  realJid?: string | null,
+  options: { includeAggregate?: boolean } = {},
+): void {
+  const current = $mucActiveParticipants.get()[roomJid] ?? [];
+  const normalizedRealJid = normalizeFullJid(realJid);
+  const next = current.filter((key) => {
+    if (activeParticipantNick(key) !== nick) return true;
+    if (normalizedRealJid) {
+      if (activeParticipantRealJid(key) === normalizedRealJid) return false;
+      return !(options.includeAggregate && !activeParticipantRealJid(key));
+    }
+    return activeParticipantNick(key) !== nick;
+  });
+  if (next.length === current.length) return;
+  if (next.length === 0) {
+    const all = { ...$mucActiveParticipants.get() };
+    delete all[roomJid];
+    $mucActiveParticipants.set(all);
+  } else {
+    $mucActiveParticipants.setKey(roomJid, next);
+  }
+  syncActiveParticipantsForRoom(roomJid);
+}
+
 /**
  * Apply an inbound presence update to the participants store. The
  * cases (XEP-0272 §Joining and §Leaving):
  * - Available presence + `muji.active === true` → add nick.
- * - Available presence + `muji.preparing === true` (but not active)
- *   → no-op; preparing alone does not count as in-call.
+ * - Available presence + `muji.preparing === true` → setup signal
+ *   only; preparing does not add OR clear active call membership,
+ *   even when a separate resource is already active under the same
+ *   nick.
  * - Available presence WITHOUT `muji` → remove nick (XEP-0272
  *   §Leaving: absence of the element is the leave marker).
  * - Unavailable presence → remove nick (occupant left the room).
@@ -77,6 +167,7 @@ export function applyMucCallPresence(
   presence: {
     from?: string;
     presence_type?: string;
+    muc_jid?: string | null;
     muji?: { preparing: boolean; active: boolean };
   },
 ): void {
@@ -87,39 +178,36 @@ export function applyMucCallPresence(
   const nick = presence.from.slice(slash + 1);
   if (!roomJid || !nick) return;
 
-  const wantsActive =
-    presence.presence_type !== "unavailable" &&
-    presence.muji?.active === true;
+  const isUnavailable = presence.presence_type === "unavailable";
+  const hasPreparing = !isUnavailable && presence.muji?.preparing === true;
+  const wantsActive = !isUnavailable && presence.muji?.active === true;
+  const shouldClear =
+    isUnavailable ||
+    !presence.muji ||
+    (presence.muji.preparing === false && presence.muji.active === false);
 
-  // XEP-0272 §Joining: a preparing-only presence echoed back from
-  // the MUC is the signal a waiting client uses to proceed to its
-  // content-declaring presence. Fire any registered one-shot
+  // XEP-0272 §Joining: a presence containing `<preparing/>` echoed
+  // back from the MUC is the signal a waiting client uses to proceed
+  // to its content-declaring presence. Some conformant stanzas can
+  // contain both `<preparing/>` and `<content/>`; preparing remains
+  // the setup signal in that case. Fire any registered one-shot
   // listener BEFORE we touch the participant store so the
   // beginMucCall flow unblocks deterministically.
-  if (presence.muji?.preparing && presence.muji?.active === false) {
-    addPreparingParticipant(roomJid, nick);
-    notifyPrepareEcho(roomJid, nick);
+  if (hasPreparing) {
+    addPreparingParticipant(roomJid, nick, presence.muc_jid);
+    notifyPrepareEcho(roomJid, nick, presence.muc_jid);
   } else {
-    removePreparingParticipant(roomJid, nick);
+    removePreparingParticipant(roomJid, nick, presence.muc_jid, {
+      includeAggregate: !presence.muc_jid,
+    });
   }
 
-  const current = mucCallParticipantsForRoom(roomJid);
-  const has = current.includes(nick);
-
-  if (wantsActive && !has) {
-    $mucCallParticipants.setKey(roomJid, [...current, nick]);
-  } else if (!wantsActive && has) {
-    const next = current.filter((n) => n !== nick);
-    if (next.length === 0) {
-      // Drop the room key entirely so consumers can read
-      // `$mucCallParticipants.get()[room] ?? []` and treat absence
-      // as "nobody in call" — same as the initial state.
-      const all = { ...$mucCallParticipants.get() };
-      delete all[roomJid];
-      $mucCallParticipants.set(all);
-    } else {
-      $mucCallParticipants.setKey(roomJid, next);
-    }
+  if (wantsActive) {
+    addActiveParticipant(roomJid, nick, presence.muc_jid);
+  } else if (shouldClear) {
+    removeActiveParticipant(roomJid, nick, presence.muc_jid, {
+      includeAggregate: !presence.muc_jid,
+    });
   }
 }
 
@@ -137,6 +225,7 @@ export function mucCallParticipantCount(roomJid: string): number {
  */
 export function clearMucCallParticipants(): void {
   $mucCallParticipants.set({});
+  $mucActiveParticipants.set({});
   $mucPreparingParticipants.set({});
   // Drop any pending preparing-echo waiters too — they'd otherwise
   // resolve when the next presence echo arrives after reconnect,
@@ -156,21 +245,35 @@ export function cancelMucCallPreparationWaiters(
 ): void {
   const normalized = normalizeMucCallRoomJid(roomJid);
   if (!normalized || !nick) return;
-  rejectPrepareEchoWaiter(`${normalized}/${nick}`, err);
-  rejectNoOtherPreparingWaiter(`${normalized}/${nick}`, err);
+  rejectPrepareEchoWaitersForParticipant(normalized, nick, err);
+  rejectNoOtherPreparingWaitersForParticipant(normalized, nick, err);
 }
 
-function addPreparingParticipant(roomJid: string, nick: string): void {
+function addPreparingParticipant(roomJid: string, nick: string, realJid?: string | null): void {
   const current = $mucPreparingParticipants.get()[roomJid] ?? [];
-  if (current.includes(nick)) return;
-  $mucPreparingParticipants.setKey(roomJid, [...current, nick]);
+  const key = preparingParticipantKey(nick, realJid);
+  if (current.includes(key)) return;
+  $mucPreparingParticipants.setKey(roomJid, [...current, key]);
   notifyPreparingChanged(roomJid);
 }
 
-function removePreparingParticipant(roomJid: string, nick: string): void {
+function removePreparingParticipant(
+  roomJid: string,
+  nick: string,
+  realJid?: string | null,
+  options: { includeAggregate?: boolean } = {},
+): void {
   const current = $mucPreparingParticipants.get()[roomJid] ?? [];
-  if (!current.includes(nick)) return;
-  const next = current.filter((n) => n !== nick);
+  const normalizedRealJid = normalizeFullJid(realJid);
+  const next = current.filter((key) => {
+    if (preparingParticipantNick(key) !== nick) return true;
+    if (normalizedRealJid) {
+      if (samePreparingParticipant(key, nick, normalizedRealJid)) return false;
+      return !(options.includeAggregate && !preparingParticipantRealJid(key));
+    }
+    return preparingParticipantNick(key) !== nick;
+  });
+  if (next.length === current.length) return;
   if (next.length === 0) {
     const all = { ...$mucPreparingParticipants.get() };
     delete all[roomJid];
@@ -183,8 +286,9 @@ function removePreparingParticipant(roomJid: string, nick: string): void {
 
 /**
  * Pending listeners awaiting a XEP-0272 §Joining preparing-presence
- * echo. Keyed by `<room-jid>/<nick>` so two calls in different rooms
- * (or with different nicks) get distinct one-shot resolvers.
+ * echo. Keyed by `<room-jid>/<nick>/<real-jid>` when the room exposes
+ * the occupant's real full JID, so same-account resources sharing a
+ * MUC nick cannot consume each other's XEP-0272 preparing echo.
  *
  * The XEP MANDATES that a client wait for the MUC to rebroadcast
  * its preparing presence before proceeding to the content-declaring
@@ -207,19 +311,37 @@ const noOtherPreparingListeners = new Map<
   {
     roomJid: string;
     selfNick: string;
+    selfFullJid?: string | null;
     resolve: () => void;
     reject: (err: Error) => void;
     timer: ReturnType<typeof setTimeout>;
   }
 >();
 
-function notifyPrepareEcho(roomJid: string, nick: string): void {
-  const key = `${roomJid}/${nick}`;
+function prepareEchoListenerKey(roomJid: string, nick: string, realJid?: string | null): string {
+  return `${roomJid}/${preparingParticipantKey(nick, realJid)}`;
+}
+
+function notifyPrepareEcho(roomJid: string, nick: string, realJid?: string | null): void {
+  const key = prepareEchoListenerKey(roomJid, nick, realJid);
   const listener = prepareEchoListeners.get(key);
   if (listener) {
     prepareEchoListeners.delete(key);
     clearTimeout(listener.timer);
     listener.resolve();
+  }
+}
+
+function listenerMatchesParticipant(key: string, roomJid: string, nick: string): boolean {
+  if (!key.startsWith(`${roomJid}/`)) return false;
+  const participantKey = key.slice(roomJid.length + 1);
+  return preparingParticipantNick(participantKey) === nick;
+}
+
+function rejectPrepareEchoWaitersForParticipant(roomJid: string, nick: string, err: Error): void {
+  for (const key of [...prepareEchoListeners.keys()]) {
+    if (!listenerMatchesParticipant(key, roomJid, nick)) continue;
+    rejectPrepareEchoWaiter(key, err);
   }
 }
 
@@ -239,14 +361,22 @@ function rejectPrepareEchoWaiter(key: string, err: Error): void {
   listener.reject(err);
 }
 
-function hasOtherPreparing(roomJid: string, selfNick: string): boolean {
-  return ($mucPreparingParticipants.get()[roomJid] ?? []).some((nick) => nick !== selfNick);
+function isSelfPreparingParticipant(key: string, selfNick: string, selfFullJid?: string | null): boolean {
+  if (preparingParticipantNick(key) !== selfNick) return false;
+  const normalizedSelfFullJid = normalizeFullJid(selfFullJid);
+  const realJid = preparingParticipantRealJid(key);
+  if (normalizedSelfFullJid && realJid) return normalizedSelfFullJid === realJid;
+  return !normalizedSelfFullJid && !realJid;
+}
+
+function hasOtherPreparing(roomJid: string, selfNick: string, selfFullJid?: string | null): boolean {
+  return ($mucPreparingParticipants.get()[roomJid] ?? []).some((key) => !isSelfPreparingParticipant(key, selfNick, selfFullJid));
 }
 
 function notifyPreparingChanged(roomJid: string): void {
   for (const [key, listener] of noOtherPreparingListeners) {
     if (listener.roomJid !== roomJid) continue;
-    if (hasOtherPreparing(listener.roomJid, listener.selfNick)) continue;
+    if (hasOtherPreparing(listener.roomJid, listener.selfNick, listener.selfFullJid)) continue;
     noOtherPreparingListeners.delete(key);
     clearTimeout(listener.timer);
     listener.resolve();
@@ -269,6 +399,13 @@ function rejectNoOtherPreparingWaiter(key: string, err: Error): void {
   listener.reject(err);
 }
 
+function rejectNoOtherPreparingWaitersForParticipant(roomJid: string, nick: string, err: Error): void {
+  for (const key of [...noOtherPreparingListeners.keys()]) {
+    if (!listenerMatchesParticipant(key, roomJid, nick)) continue;
+    rejectNoOtherPreparingWaiter(key, err);
+  }
+}
+
 /**
  * Wait for the MUC to rebroadcast our preparing-presence echo for
  * `nick` in `roomJid`, then resolve. If no echo arrives within
@@ -284,10 +421,11 @@ export function awaitPreparingEcho(
   roomJid: string,
   nick: string,
   timeoutMs: number,
+  selfFullJid?: string | null,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const normalized = normalizeMucCallRoomJid(roomJid);
-    const key = `${normalized}/${nick}`;
+    const key = prepareEchoListenerKey(normalized, nick, selfFullJid);
     // Replacing an existing listener silently is fine — there's
     // only ever one preparing-echo waiter per (room, nick) at a
     // time because beginMucCall serialises through the call store.
@@ -310,13 +448,14 @@ export function awaitNoOtherPreparing(
   roomJid: string,
   selfNick: string,
   timeoutMs: number,
+  selfFullJid?: string | null,
 ): Promise<void> {
   const normalized = normalizeMucCallRoomJid(roomJid);
-  if (!hasOtherPreparing(normalized, selfNick)) {
+  if (!hasOtherPreparing(normalized, selfNick, selfFullJid)) {
     return Promise.resolve();
   }
   return new Promise((resolve, reject) => {
-    const key = `${normalized}/${selfNick}`;
+    const key = prepareEchoListenerKey(normalized, selfNick, selfFullJid);
     const previous = noOtherPreparingListeners.get(key);
     if (previous) {
       clearTimeout(previous.timer);
@@ -331,6 +470,7 @@ export function awaitNoOtherPreparing(
     noOtherPreparingListeners.set(key, {
       roomJid: normalized,
       selfNick,
+      selfFullJid,
       resolve,
       reject,
       timer,

--- a/chat/src/lib/calls/types.ts
+++ b/chat/src/lib/calls/types.ts
@@ -16,29 +16,31 @@ export type LiveKitJoin = {
   token: string;
 };
 
+type CallEventEnvelope = {
+  from: string;
+  to?: string | null;
+  sid: string;
+};
+
 export type CallEvent =
   // `from` is the sender's full JID for every inbound event. The
   // only bare-addressed send path is outbound `<propose/>`.
-  | { kind: "propose"; from: string; sid: string; media: CallMedia }
-  | { kind: "proceed"; from: string; sid: string }
-  | { kind: "reject"; from: string; sid: string; reason?: string | null; tieBreak?: boolean }
-  | { kind: "retract"; from: string; sid: string; reason?: string | null; tieBreak?: boolean }
-  | { kind: "finish"; from: string; sid: string; reason?: string | null; migratedTo?: string | null }
-  | {
+  | (CallEventEnvelope & { kind: "propose"; media: CallMedia })
+  | (CallEventEnvelope & { kind: "proceed" })
+  | (CallEventEnvelope & { kind: "reject"; reason?: string | null; tieBreak?: boolean })
+  | (CallEventEnvelope & { kind: "retract"; reason?: string | null; tieBreak?: boolean })
+  | (CallEventEnvelope & { kind: "finish"; reason?: string | null; migratedTo?: string | null })
+  | (CallEventEnvelope & {
       kind: "session-initiate";
-      from: string;
-      sid: string;
       media: CallMedia;
       join: LiveKitJoin;
-    }
-  | {
+    })
+  | (CallEventEnvelope & {
       kind: "session-accept";
-      from: string;
-      sid: string;
       media: CallMedia;
       join: LiveKitJoin;
-    }
-  | { kind: "session-terminate"; from: string; sid: string; reason: string | null };
+    })
+  | (CallEventEnvelope & { kind: "session-terminate"; reason?: string | null });
 
 /**
  * The chat-side reduced state representing the lifecycle of a
@@ -57,6 +59,7 @@ export type CallState =
       media: CallMedia;
       kind: "muc";
       selfNick: string;
+      selfFullJid?: string | null;
       attemptId: string;
       activePresencePublished?: boolean;
     }
@@ -74,5 +77,6 @@ export type CallState =
        *  Stored so `tearDownActiveCall` can emit the matching
        *  Muji-clearing presence update for XEP-0272 §Leaving. */
       selfNick?: string;
+      selfFullJid?: string | null;
     }
   | { phase: "ended"; sid: string; reason: string | null };

--- a/chat/src/lib/calls/use-active-muc-call.ts
+++ b/chat/src/lib/calls/use-active-muc-call.ts
@@ -12,15 +12,13 @@ import { connectionStore } from "@/lib/connection-store";
  * call, and which room owns it?"
  *
  * Drives:
- * - `CallSplitContainer` (renders only when the viewed channel owns
- *   the call AND the local user is a participant).
- * - `CallActivePill` (hides itself when the local user has joined).
+ * - MUC ownership gates in the split/expanded call surfaces.
+ * - `CallActivePill` local-resource visibility checks.
  * - `ChatHeader` indicator wiring.
  *
  * The selector intentionally treats DM calls (`kind: "dm"`) as
- * out-of-scope: the split-view surface only ever covers MUC group
- * calls because that's where the channel-vs-call ownership question
- * exists. DM calls keep their toast-based UX.
+ * out-of-scope: DM call surfaces match directly on peer JID, while
+ * MUC calls need room ownership plus Muji participant state.
  */
 export function useActiveMucCall(): {
   /** Bare room JID of the active MUC call, or null when no MUC call
@@ -59,6 +57,78 @@ export function useActiveMucCall(): {
   });
 
   return { activeRoomJid, selfInCall, participantCount };
+}
+
+/**
+ * Per-room view of whether XEP-0272 Muji presence says a room has
+ * an active call, independent of whether this local client is already
+ * in that call. This is the selector for "click to join" affordances
+ * after refresh: `$callState` starts idle on a fresh page load, while
+ * `$mucCallParticipants` is repopulated by MUC roster/presence replay.
+ */
+export function useRoomHasActiveCall(
+  roomJid: () => string,
+): {
+  hasActiveCall: ComputedRef<boolean>;
+  selfInCall: ComputedRef<boolean>;
+  localResourceInCall: ComputedRef<boolean>;
+  participantCount: ComputedRef<number>;
+} {
+  const state = useStore($callState);
+  const participants = useStore($mucCallParticipants);
+
+  const normalizedRoomJid = computed<string | null>(() => {
+    const normalized = normalizeMucCallRoomJid(roomJid());
+    return normalized || null;
+  });
+
+  const participantList = computed<ReadonlyArray<string>>(() => {
+    const room = normalizedRoomJid.value;
+    if (!room) return [];
+    return participants.value[room] ?? [];
+  });
+
+  const hasActiveCall = computed<boolean>(() => participantList.value.length > 0);
+
+  const selfInCall = computed<boolean>(() => {
+    const nick = connectionStore.session?.username;
+    return !!nick && participantList.value.includes(nick);
+  });
+
+  const localResourceInCall = computed<boolean>(() => {
+    const room = normalizedRoomJid.value;
+    const s = state.value;
+    if (!room || s.phase !== "active" || s.kind !== "muc") return false;
+    return normalizeMucCallRoomJid(s.peer) === room;
+  });
+
+  const participantCount = computed<number>(() => participantList.value.length);
+
+  return { hasActiveCall, selfInCall, localResourceInCall, participantCount };
+}
+
+export function readRoomHasActiveCall(roomJid: string): {
+  hasActiveCall: boolean;
+  selfInCall: boolean;
+  localResourceInCall: boolean;
+  participantCount: number;
+} {
+  const normalized = normalizeMucCallRoomJid(roomJid);
+  if (!normalized) {
+    return { hasActiveCall: false, selfInCall: false, localResourceInCall: false, participantCount: 0 };
+  }
+  const participants = $mucCallParticipants.get()[normalized] ?? [];
+  const nick = connectionStore.session?.username ?? null;
+  const s = $callState.get();
+  return {
+    hasActiveCall: participants.length > 0,
+    selfInCall: !!nick && participants.includes(nick),
+    localResourceInCall:
+      s.phase === "active" &&
+      s.kind === "muc" &&
+      normalizeMucCallRoomJid(s.peer) === normalized,
+    participantCount: participants.length,
+  };
 }
 
 /**

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -11,6 +11,10 @@ import {
   type PersistedQueuedDmMessage,
 } from "../outbound-queue-store";
 import { $callState, applyCallEvent, clearCallState, tearDownActiveCall } from "@/lib/calls/call-store";
+import {
+  applyDmCallEvent,
+  clearDmCallActivities,
+} from "@/lib/calls/dm-call-activity";
 import { handleCallEventSideEffect } from "@/lib/calls/call-effects";
 import {
   applyMucCallPresence,
@@ -206,6 +210,17 @@ function shouldSkipCatchupMessage(
   return false;
 }
 
+function shouldSkipRawCatchupMessage(
+  message: WasmMessage,
+  since?: string,
+  seenIds?: ReadonlyArray<string>,
+): boolean {
+  const seen = new Set(seenIds ?? []);
+  if (seen.size > 0 && rawMessageSeenIds(message).some((id) => seen.has(id))) return true;
+  if (!since || !message.timestamp) return false;
+  return compareTimestamps(message.timestamp, since) < 0;
+}
+
 type WasmModule = typeof import("@waddle/xmpp-client-wasm");
 type WasmClient = import("@waddle/xmpp-client-wasm").WaddleClient & {
   discover_extension_routes?: () => Promise<unknown>;
@@ -305,6 +320,30 @@ type XmppClientInstance = Partial<WasmClient> & CompatEmitter & {
   publish_mds_displayed?: (chatId: string, stanzaId: string, stanzaIdBy: string) => Promise<void>;
   fetch_mds_displayed?: () => Promise<ReadonlyArray<WasmMdsDisplayedEntry>>;
   subscribe_mds_displayed?: () => Promise<void>;
+  ensure_push_node?: (
+    serviceJid: string,
+    appId: string,
+  ) => Promise<{ id: string; jid: string; appId: string }>;
+  register_web_push_device?: (options: {
+    serviceJid: string;
+    node: string;
+    deviceId: string;
+    environment: string;
+    providerEndpoint: string;
+    providerToken: string;
+    providerKeyMaterial: string;
+  }) => Promise<{ id: string; node: string; status: "active" | "disabled" }>;
+  disable_push_device?: (
+    serviceJid: string,
+    node: string,
+    deviceId: string,
+  ) => Promise<{ id: string; node: string; status: "active" | "disabled" }>;
+  fetch_user_bookmarks?: () => Promise<UserBookmarkItem[] | null>;
+  set_room_notification_mode?: (options: {
+    roomJid: string;
+    mode: NotifyMode;
+    name?: string;
+  }) => Promise<SetRoomNotificationModeOutcome>;
 };
 
 /**
@@ -384,7 +423,7 @@ export class BrowserXmppClient {
   private dmReactionHandler: ((event: DmReactionEvent) => void) | null = null;
   private dmDisplayedHandler: ((event: DmDisplayedEvent) => void) | null = null;
   private presenceUpdateHandler: ((event: PresenceUpdateEvent) => void) | null = null;
-  private roomMemberJids: Record<string, string> = {};
+  private roomMemberJidsByRoom = new Map<string, Record<string, string>>();
   private memberJidHandler: ((nick: string, bareJid: string) => void) | null = null;
   private hatsHandler: ((hats: RoomHats) => void) | null = null;
   private authorityHandler: ((authority: RoomAuthority) => void) | null = null;
@@ -406,9 +445,14 @@ export class BrowserXmppClient {
   private roomSwitchPromise: Promise<void> | null = null;
   private roomSwitchTarget: string | null = null;
   private selfPingTimer: ReturnType<typeof setInterval> | null = null;
-  private roomHats: RoomHats = {};
-  private roomAuthority: RoomAuthority = {};
-  private roomPresence: RoomPresence = {};
+  private roomHatsByRoom = new Map<string, RoomHats>();
+  private roomAuthorityByRoom = new Map<string, RoomAuthority>();
+  private roomPresenceByRoom = new Map<string, RoomPresence>();
+  private readonly joinedMucs = new Map<string, Promise<void>>();
+  private readonly joinedMucJoinTokens = new Map<string, symbol>();
+  private readonly joinedMucReady = new Set<string>();
+  private retainedJoinedRoomJids = new Set<string>();
+  private autoJoinRoomJids: ReadonlyArray<string> = [];
   private uploadServiceJid: string | null = null;
   private discoveredRoomJids = new Map<string, string>();
   private reconnectStartedAt: number | null = null;
@@ -497,6 +541,41 @@ export class BrowserXmppClient {
       waiter.reject(error);
     }
     this.roomJoinWaiters.clear();
+  }
+
+  private ownFullJidCandidates(): Set<string> {
+    return new Set([
+      this.fullJid.trim().toLowerCase(),
+      `${barePeerJid(this.session.jid)}/${this.resource}`.trim().toLowerCase(),
+    ]);
+  }
+
+  private isOwnMucSelfPresence(presence: { muc_jid?: string | null }): boolean {
+    const mucJid = presence.muc_jid?.trim().toLowerCase();
+    return !!mucJid && this.ownFullJidCandidates().has(mucJid);
+  }
+
+  private isOwnAvailableMucSelfPresence(presence: {
+    muc_jid?: string | null;
+    presence_type?: string;
+  }): boolean {
+    return this.isOwnMucSelfPresence(presence) && presence.presence_type !== "unavailable";
+  }
+
+  private revokeMucReadiness(roomJid: string, options: { keepPendingJoin?: boolean } = {}): void {
+    const normalized = roomJid.trim().toLowerCase();
+    if (!options.keepPendingJoin) {
+      this.joinedMucs.delete(roomJid);
+      this.joinedMucJoinTokens.delete(roomJid);
+    }
+    this.joinedMucReady.delete(roomJid);
+    if (normalized && normalized !== roomJid) {
+      if (!options.keepPendingJoin) {
+        this.joinedMucs.delete(normalized);
+        this.joinedMucJoinTokens.delete(normalized);
+      }
+      this.joinedMucReady.delete(normalized);
+    }
   }
 
   setMessageHandler(h: (message: LiveRoomMessage) => void) { this.messageHandler = h; }
@@ -697,7 +776,7 @@ export class BrowserXmppClient {
     this.clearReconnectTimer();
     this.clearResumeState();
     const xmpp = this.xmpp;
-    const roomBefore = this.currentRoom;
+    const joinedRooms = [...this.joinedMucs.keys()];
     this.stopSelfPing();
     this.connected = false;
     this.connectPromise = null;
@@ -706,10 +785,12 @@ export class BrowserXmppClient {
     this.roomSwitchTarget = null;
     this.rejectRoomJoinWaiters(new Error("XMPP disconnected while joining a room"));
     this.uploadServiceJid = null;
-    this.roomHats = {};
-    this.roomAuthority = {};
-    this.roomPresence = {};
-    this.roomMemberJids = {};
+    this.clearRoomPresenceCaches();
+    this.retainedJoinedRoomJids.clear();
+    this.joinedMucs.clear();
+    this.joinedMucJoinTokens.clear();
+    this.joinedMucReady.clear();
+    clearDmCallActivities();
     clearMucCallParticipants();
     // Best-effort hangup: if we're in a call when the user logs out
     // we want the peer to see session-terminate before the stream
@@ -717,11 +798,13 @@ export class BrowserXmppClient {
     // `$callState`.
     await tearDownActiveCall(xmpp as unknown as CallWireSender | null, "success");
     this.xmpp = null;
-    try {
-      if (xmpp && roomBefore && xmpp.leave_room) {
-        await xmpp.leave_room(roomBefore, this.session.username);
+    if (xmpp?.leave_room) {
+      for (const roomJid of joinedRooms) {
+        try {
+          await xmpp.leave_room(roomJid, this.session.username);
+        } catch {}
       }
-    } catch {}
+    }
     await xmpp?.disconnect?.();
     this.emitStatus({ state: "offline", detail: "Disconnected" });
   }
@@ -754,6 +837,137 @@ export class BrowserXmppClient {
     });
   }
 
+  private clearRoomPresenceCaches(): void {
+    this.roomHatsByRoom.clear();
+    this.roomAuthorityByRoom.clear();
+    this.roomPresenceByRoom.clear();
+    this.roomMemberJidsByRoom.clear();
+  }
+
+  private hatsFor(roomJid: string): RoomHats {
+    let cached = this.roomHatsByRoom.get(roomJid);
+    if (!cached) {
+      cached = {};
+      this.roomHatsByRoom.set(roomJid, cached);
+    }
+    return cached;
+  }
+
+  private authorityFor(roomJid: string): RoomAuthority {
+    let cached = this.roomAuthorityByRoom.get(roomJid);
+    if (!cached) {
+      cached = {};
+      this.roomAuthorityByRoom.set(roomJid, cached);
+    }
+    return cached;
+  }
+
+  private presenceFor(roomJid: string): RoomPresence {
+    let cached = this.roomPresenceByRoom.get(roomJid);
+    if (!cached) {
+      cached = {};
+      this.roomPresenceByRoom.set(roomJid, cached);
+    }
+    return cached;
+  }
+
+  private memberJidsFor(roomJid: string): Record<string, string> {
+    let cached = this.roomMemberJidsByRoom.get(roomJid);
+    if (!cached) {
+      cached = {};
+      this.roomMemberJidsByRoom.set(roomJid, cached);
+    }
+    return cached;
+  }
+
+  private dispatchFocusedRoomHandlers(): void {
+    const roomJid = this.currentRoom;
+    if (!roomJid) {
+      this.hatsHandler?.({});
+      this.authorityHandler?.({});
+      this.presenceHandler?.({});
+      return;
+    }
+    this.hatsHandler?.({ ...(this.roomHatsByRoom.get(roomJid) ?? {}) });
+    this.authorityHandler?.({ ...(this.roomAuthorityByRoom.get(roomJid) ?? {}) });
+    this.presenceHandler?.({ ...(this.roomPresenceByRoom.get(roomJid) ?? {}) });
+    const memberJids = this.roomMemberJidsByRoom.get(roomJid) ?? {};
+    for (const [nick, bare] of Object.entries(memberJids)) {
+      this.memberJidHandler?.(nick, bare);
+    }
+  }
+
+  async ensureJoined(roomJid: string): Promise<void> {
+    if (this.joinedMucReady.has(roomJid)) return;
+    const existing = this.joinedMucs.get(roomJid);
+    if (existing) {
+      const existingToken = this.joinedMucJoinTokens.get(roomJid);
+      await existing;
+      if (existingToken && this.joinedMucJoinTokens.get(roomJid) !== existingToken) {
+        return;
+      }
+      if (!existingToken && !this.joinedMucs.has(roomJid)) return;
+      this.joinedMucReady.add(roomJid);
+      this.retainedJoinedRoomJids.add(roomJid);
+      return;
+    }
+    const promise = this.performMucJoin(roomJid);
+    const joinToken = Symbol(roomJid);
+    this.joinedMucs.set(roomJid, promise);
+    this.joinedMucJoinTokens.set(roomJid, joinToken);
+    try {
+      await promise;
+      if (this.joinedMucJoinTokens.get(roomJid) === joinToken) {
+        this.joinedMucReady.add(roomJid);
+        this.retainedJoinedRoomJids.add(roomJid);
+      }
+    } catch (err) {
+      if (this.joinedMucJoinTokens.get(roomJid) === joinToken) {
+        this.joinedMucs.delete(roomJid);
+        this.joinedMucJoinTokens.delete(roomJid);
+        this.joinedMucReady.delete(roomJid);
+      }
+      throw err;
+    }
+  }
+
+  private async performMucJoin(roomJid: string): Promise<void> {
+    const xmpp = this.xmpp;
+    if (!xmpp) throw new Error("XMPP session is not ready");
+    if (!xmpp.join_room && !xmpp.joinRoom) {
+      throw new Error("XMPP client missing join_room binding");
+    }
+    const ready = this.waitForRoomSelfPresence(roomJid, this.session.username);
+    if (xmpp.join_room) {
+      await Promise.allSettled([xmpp.join_room(roomJid, this.session.username)]);
+    } else if (xmpp.joinRoom) {
+      await xmpp.joinRoom(roomJid, this.session.username);
+    }
+    if (!this.isCurrentXmpp(xmpp)) {
+      await ready.catch(() => undefined);
+      return;
+    }
+    await ready;
+  }
+
+  async fanOutAutoJoin(roomJids: ReadonlyArray<string>, concurrency = 6): Promise<void> {
+    if (!this.xmpp) return;
+    const queue = [...new Set(roomJids.filter(Boolean))];
+    const workers = Array.from({ length: Math.max(1, concurrency) }, async () => {
+      while (queue.length > 0) {
+        const roomJid = queue.shift();
+        if (!roomJid) continue;
+        try {
+          await this.ensureJoined(roomJid);
+        } catch {
+          // Failed joins drop their tracker entry inside ensureJoined.
+          // The next topology refresh or reconnect replay can retry.
+        }
+      }
+    });
+    await Promise.allSettled(workers);
+  }
+
   async switchRoom(_spaceId: string, channelId: string) {
     await this.connect();
     const nextRoom = this.roomJidForChannel(channelId);
@@ -761,7 +975,12 @@ export class BrowserXmppClient {
       if (this.roomSwitchTarget === nextRoom) return this.roomSwitchPromise;
       await this.roomSwitchPromise.catch(() => undefined);
     }
-    if (this.currentRoom === nextRoom) return;
+    if (this.currentRoom === nextRoom) {
+      await this.ensureJoined(nextRoom);
+      this.dispatchFocusedRoomHandlers();
+      await this.flushQueuedRoomMessages(nextRoom);
+      return;
+    }
     const promise = this.performRoomSwitch(nextRoom);
     this.roomSwitchPromise = promise;
     this.roomSwitchTarget = nextRoom;
@@ -775,54 +994,19 @@ export class BrowserXmppClient {
     }
   }
 
-  private async tearDownMucCallForRoom(roomJid: string, xmpp: XmppClientInstance | null): Promise<void> {
-    const current = $callState.get();
-    if (
-      (current.phase === "active" || current.phase === "muc-pending") &&
-      current.kind === "muc" &&
-      barePeerJid(current.peer) === barePeerJid(roomJid)
-    ) {
-      await tearDownActiveCall(xmpp as unknown as CallWireSender | null, "success");
-    }
-  }
-
   private async performRoomSwitch(nextRoom: string) {
     const xmpp = this.xmpp;
     if (!xmpp) return;
-    if (this.currentRoom) {
-      await this.tearDownMucCallForRoom(this.currentRoom, xmpp);
-      if (!this.isCurrentXmpp(xmpp)) return;
-    }
-    if (this.currentRoom && xmpp.leave_room) {
-      try { await xmpp.leave_room(this.currentRoom, this.session.username); } catch {}
-      if (!this.isCurrentXmpp(xmpp)) return;
-    }
     this.currentRoom = nextRoom;
-    this.roomHats = {};
-    this.roomAuthority = {};
-    this.roomPresence = {};
-    this.roomMemberJids = {};
-    this.hatsHandler?.({});
-    this.authorityHandler?.({});
-    this.presenceHandler?.({});
-    if (xmpp.join_room) {
-      const ready = this.waitForRoomSelfPresence(nextRoom, this.session.username);
-      await Promise.allSettled([xmpp.join_room(nextRoom, this.session.username)]);
-      if (!this.isCurrentXmpp(xmpp)) {
-        await ready.catch(() => undefined);
-        return;
-      }
-      try {
-        await ready;
-      } catch (err) {
-        if (!this.isCurrentXmpp(xmpp)) return;
-        throw err;
-      }
+    this.dispatchFocusedRoomHandlers();
+    try {
+      await this.ensureJoined(nextRoom);
+    } catch (err) {
       if (!this.isCurrentXmpp(xmpp)) return;
-    } else if (xmpp.joinRoom) {
-      await xmpp.joinRoom(nextRoom, this.session.username);
-      if (!this.isCurrentXmpp(xmpp)) return;
+      throw err;
     }
+    if (!this.isCurrentXmpp(xmpp)) return;
+    this.dispatchFocusedRoomHandlers();
     this.startSelfPing();
     await this.flushQueuedRoomMessages(nextRoom);
   }
@@ -836,7 +1020,7 @@ export class BrowserXmppClient {
   }
 
   private roomIsReady(roomJid: string): boolean {
-    return this.canUseConnectedSession() && this.currentRoom === roomJid;
+    return this.canUseConnectedSession() && this.currentRoom === roomJid && this.joinedMucReady.has(roomJid);
   }
 
   private enqueueReason(): string {
@@ -992,7 +1176,7 @@ export class BrowserXmppClient {
         if (!this.roomIsReady(roomJid) || !this.xmpp) break;
         if (this.inflightQueuedIds.has(entry.id)) continue;
         this.queuedMessageStatusHandler?.(entry.id, "sending");
-        const messageId = await this.compatSendGroupMessage(this.xmpp, roomJid, entry.body, { ...(entry.markup?.length ? { markup: entry.markup } : {}), ...(entry.references?.length ? { references: entry.references } : {}), mentionJidsByNick: { ...(entry.mentionJidsByNick ?? {}), ...this.roomMemberJids }, ...(entry.files?.length ? { files: entry.files } : {}), ...(entry.replyTo ? { replyTo: entry.replyTo } : {}), ...(entry.threadId ? { threadId: entry.threadId } : {}), ...(entry.parentThreadId ? { parentThreadId: entry.parentThreadId } : {}), ...(entry.threadCreate ? { threadCreate: entry.threadCreate } : {}), ...(entry.threadReply ? { threadReply: entry.threadReply } : {}), id: entry.id });
+        const messageId = await this.compatSendGroupMessage(this.xmpp, roomJid, entry.body, { ...(entry.markup?.length ? { markup: entry.markup } : {}), ...(entry.references?.length ? { references: entry.references } : {}), mentionJidsByNick: { ...(entry.mentionJidsByNick ?? {}), ...this.memberJidsFor(roomJid) }, ...(entry.files?.length ? { files: entry.files } : {}), ...(entry.replyTo ? { replyTo: entry.replyTo } : {}), ...(entry.threadId ? { threadId: entry.threadId } : {}), ...(entry.parentThreadId ? { parentThreadId: entry.parentThreadId } : {}), ...(entry.threadCreate ? { threadCreate: entry.threadCreate } : {}), ...(entry.threadReply ? { threadReply: entry.threadReply } : {}), id: entry.id });
         if (messageId) { this.inflightQueuedIds.add(entry.id); this.recordPendingSend(entry.id, "room"); }
       }
     })();
@@ -1007,7 +1191,7 @@ export class BrowserXmppClient {
     if (!body.trim() && !hasFiles && !hasThreadMetadata && !hasForumMetadata) return null;
     const roomJid = this.roomJidForChannel(channelId);
     if (this.roomIsReady(roomJid) && this.xmpp) {
-      const id = await this.compatSendGroupMessage(this.xmpp, roomJid, body, { ...opts, mentionJidsByNick: { ...(opts.mentionJidsByNick ?? {}), ...this.roomMemberJids } });
+      const id = await this.compatSendGroupMessage(this.xmpp, roomJid, body, { ...opts, mentionJidsByNick: { ...(opts.mentionJidsByNick ?? {}), ...this.memberJidsFor(roomJid) } });
       this.recordPendingSend(id, "room");
       return { id, state: "sending" };
     }
@@ -1744,8 +1928,22 @@ export class BrowserXmppClient {
   private roomMamPageToMessages(page: WasmMamPage): MamHistoryPage<LiveRoomMessage> {
     return { messages: page.messages.map((message) => roomMessageFromArchived(message)).filter((message): message is LiveRoomMessage => !!message), ...(page.first_id ? { firstArchiveId: page.first_id } : {}), ...(page.last_id ? { lastArchiveId: page.last_id } : {}), complete: page.is_complete };
   }
-  private dmMamPageToMessages(page: WasmMamPage): MamHistoryPage<LiveDmMessage> {
+  private dmMamPageToMessages(
+    page: WasmMamPage,
+    options: { applyCallEvents?: boolean } = {},
+  ): MamHistoryPage<LiveDmMessage> {
     const selfBare = barePeerJid(this.session.jid);
+    if (options.applyCallEvents !== false) {
+      for (const message of page.messages) {
+        if (!message.call_event) continue;
+        applyDmCallEvent({
+          event: message.call_event,
+          selfBareJid: selfBare,
+          to: message.to,
+          timestamp: message.timestamp,
+        });
+      }
+    }
     return { messages: page.messages.map((message) => dmMessageFromArchived(message, selfBare)).filter((message): message is LiveDmMessage => !!message), ...(page.first_id ? { firstArchiveId: page.first_id } : {}), ...(page.last_id ? { lastArchiveId: page.last_id } : {}), complete: page.is_complete };
   }
   private recordRoomMamWatermarks(messages: ReadonlyArray<LiveRoomMessage>) {
@@ -1793,7 +1991,7 @@ export class BrowserXmppClient {
   async queryPersonalMamPage(peerJid: string, max = 100, pageParam: MamPageParam = { type: "latest" }): Promise<MamHistoryPage<LiveDmMessage>> {
     const xmpp = await this.requireConnectedXmpp(); const page = await xmpp.fetch_dm_history_page?.(barePeerJid(peerJid), max, pageParam) as WasmMamPage;
     if (!page) return { messages: [], complete: true };
-    const result = this.dmMamPageToMessages(page);
+    const result = this.dmMamPageToMessages(page, { applyCallEvents: pageParam.type !== "before" });
     this.recordDmMamWatermarks(result.messages);
     return result;
   }
@@ -1801,14 +1999,24 @@ export class BrowserXmppClient {
     if (!query.trim()) return [];
     const xmpp = await this.requireConnectedXmpp();
     const page = await xmpp.search_dm_history?.(barePeerJid(peerJid), query, max) as WasmMamPage;
-    const parsed = page ? this.dmMamPageToMessages(page).messages : [];
+    const parsed = page ? this.dmMamPageToMessages(page, { applyCallEvents: false }).messages : [];
     return parsed.filter((message) => !!message.body).map((message, index) => ({ id: message.id, ...(page?.messages[index]?.mam_id ? { archiveId: page.messages[index].mam_id } : {}), nick: message.nick, body: message.body, createdAt: message.createdAt, ...(message.threadId ? { threadId: message.threadId } : {}), ...(message.parentThreadId ? { parentThreadId: message.parentThreadId } : {}), peerJid: message.peerJid }));
   }
   async subscribeToPeerPresence(peerJid: string): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await xmpp.subscribe_to_presence?.(barePeerJid(peerJid)); }
   async listRosterContacts(): Promise<RosterContact[]> { const xmpp = await this.requireConnectedXmpp(); const roster = await xmpp.list_roster_contacts?.() as WasmRosterContact[]; return (roster ?? []).map((item) => { const jid = barePeerJid(item.jid); return { jid, name: item.name, username: item.name?.trim() || jid.split("@")[0] || jid, subscription: (item.subscription ?? "none") as RosterContact["subscription"], groups: item.groups ?? [] }; }); }
   async getServerVersion(): Promise<WasmServerVersion | null> { const xmpp = await this.requireConnectedXmpp(); return await xmpp.get_server_version?.() as WasmServerVersion | null; }
   async discoverSpaceChannels(): Promise<any[]> { const xmpp = await this.requireConnectedXmpp(); return discoverChannels(xmpp as WasmClient, this.session.jid); }
-  async discoverTopology(): Promise<DiscoveredTopology> { const xmpp = await this.requireConnectedXmpp(); const topology = await discoverTopology(xmpp as WasmClient, this.session.jid); this.discoveredRoomJids = new Map(topology.rooms.flatMap((room) => room.jid ? [[room.id, room.jid] as const] : [])); return topology; }
+  async discoverTopology(): Promise<DiscoveredTopology> {
+    const xmpp = await this.requireConnectedXmpp();
+    const topology = await discoverTopology(xmpp as WasmClient, this.session.jid);
+    this.discoveredRoomJids = new Map(topology.rooms.flatMap((room) => room.jid ? [[room.id, room.jid] as const] : []));
+    const autoJoinRoomJids = topology.rooms
+      .filter((room) => room.autojoin !== false && !!room.jid)
+      .map((room) => room.jid!);
+    this.autoJoinRoomJids = autoJoinRoomJids;
+    if (autoJoinRoomJids.length > 0) void this.fanOutAutoJoin(autoJoinRoomJids);
+    return topology;
+  }
   async listRoomMembers(channelId: string, options?: ListRoomMembersOptions): Promise<MemberSummary[]> {
     const xmpp = await this.requireConnectedXmpp(); const roomJid = options?.roomJid ?? this.roomJidForChannel(channelId);
     const listMembers = xmpp.list_room_members
@@ -2032,6 +2240,11 @@ export class BrowserXmppClient {
       // disconnects before the catch-up IQ resolves.
       void this.bootstrapMdsDisplayed(xmpp);
     }
+    const roomsToJoin = new Set([...this.retainedJoinedRoomJids, ...this.autoJoinRoomJids]);
+    if (this.currentRoom) roomsToJoin.add(this.currentRoom);
+    if (roomsToJoin.size > 0) {
+      void this.fanOutAutoJoin([...roomsToJoin]);
+    }
     this.emitSessionLifecycle(lifecycle);
     const catchupEntries = this.catchup.onSessionStarted();
     if (catchupEntries.length === 0) {
@@ -2094,7 +2307,18 @@ export class BrowserXmppClient {
   private flushAfterSessionReady(xmpp: XmppClientInstance) {
     if (this.xmpp !== xmpp) return;
     void this.flushQueuedDirectMessages();
-    if (this.currentRoom) void this.flushQueuedRoomMessages(this.currentRoom);
+    const roomJid = this.currentRoom;
+    if (roomJid) void this.flushQueuedRoomAfterJoin(xmpp, roomJid);
+  }
+
+  private async flushQueuedRoomAfterJoin(xmpp: XmppClientInstance, roomJid: string): Promise<void> {
+    try {
+      await this.ensureJoined(roomJid);
+      if (this.xmpp !== xmpp) return;
+      await this.flushQueuedRoomMessages(roomJid);
+    } catch {
+      // Join retry is driven by reconnect/session-ready and explicit sends.
+    }
   }
 
   private fulfillOnceConnected() {
@@ -2127,6 +2351,7 @@ export class BrowserXmppClient {
   }
   private handleDisconnected(xmpp: XmppClientInstance, error?: Error) {
     if (this.xmpp !== xmpp) return;
+    const previouslyJoinedRooms = [...this.joinedMucs.keys()];
     this.connected = false; this.stopSelfPing(); this.xmpp = null;
     // The wire is gone — no point trying to send session-terminate.
     // Clear the local call slot so the UI doesn't strand on a stale
@@ -2144,6 +2369,14 @@ export class BrowserXmppClient {
     clearCallState();
     clearMucCallParticipants();
     void useCallEngine().engine.disconnect();
+    this.rejectRoomJoinWaiters(new Error("XMPP disconnected while joining a room"));
+    this.retainedJoinedRoomJids = new Set([
+      ...this.retainedJoinedRoomJids,
+      ...previouslyJoinedRooms,
+    ]);
+    this.joinedMucs.clear();
+    this.joinedMucReady.clear();
+    this.clearRoomPresenceCaches();
     if (this.destroying) { this.clearResumeState(); this.emitStatus({ state: "offline", detail: error?.message ?? "Disconnected" }); return; }
     this.setResumeStateHandle(xmpp.get_resume_state_handle?.() ?? null);
     this.resumeState = xmpp.get_resume_state?.() ?? null;
@@ -2160,16 +2393,31 @@ export class BrowserXmppClient {
   private handlePresence(presence: WasmPresence) {
     const from = presence.from ?? "";
     if ((presence as any).muc_jid !== undefined) {
-      const [room, nick = ""] = from.split("/"); const waiter = this.roomJoinWaiters.get(from); if (waiter && (presence as any).muc_jid) waiter.resolve(); if (!room) return; if (!nick && presence.vcard_avatar) this.roomAvatarHandler?.(room, presence.vcard_avatar); if (room !== this.currentRoom || !nick) return;
+      const [room, nick = ""] = from.split("/");
+      const waiter = this.roomJoinWaiters.get(from);
+      if (waiter && this.isOwnAvailableMucSelfPresence(presence)) waiter.resolve();
+      if (!room) return;
+      if (!nick && presence.vcard_avatar) this.roomAvatarHandler?.(room, presence.vcard_avatar);
+      if (!nick) return;
+      const roomHats = this.hatsFor(room);
+      const roomAuthority = this.authorityFor(room);
+      const roomPresence = this.presenceFor(room);
+      const roomMemberJids = this.memberJidsFor(room);
+      const isFocusedRoom = room === this.currentRoom;
       if (presence.presence_type === "unavailable") {
-        delete this.roomHats[nick];
-        this.hatsHandler?.({ ...this.roomHats });
-        delete this.roomAuthority[nick];
-        this.authorityHandler?.({ ...this.roomAuthority });
-        this.roomPresence[nick] = "offline";
-        this.presenceHandler?.({ ...this.roomPresence });
-        delete this.roomMemberJids[nick];
-        this.lastSeenHandler?.(nick, Date.now());
+        if (this.isOwnMucSelfPresence(presence)) {
+          this.revokeMucReadiness(room, { keepPendingJoin: this.roomJoinWaiters.has(from) });
+        }
+        delete roomHats[nick];
+        delete roomAuthority[nick];
+        roomPresence[nick] = "offline";
+        delete roomMemberJids[nick];
+        if (isFocusedRoom) {
+          this.hatsHandler?.({ ...roomHats });
+          this.authorityHandler?.({ ...roomAuthority });
+          this.presenceHandler?.({ ...roomPresence });
+          this.lastSeenHandler?.(nick, Date.now());
+        }
         return;
       }
       // XEP-0317 hats are server-emitted descriptive metadata only.
@@ -2177,22 +2425,24 @@ export class BrowserXmppClient {
       // those flow as `roomAuthority` and drive authority chips
       // independently (see `parseMucAffiliation` / `parseMucRole`
       // below).
-      this.roomHats[nick] = ((presence as any).hats ?? []).map((hat: any) => ({
+      roomHats[nick] = ((presence as any).hats ?? []).map((hat: any) => ({
         uri: hat.uri,
         title: hat.title,
       }));
-      this.hatsHandler?.({ ...this.roomHats });
-      this.roomAuthority[nick] = {
+      roomAuthority[nick] = {
         affiliation: parseMucAffiliation((presence as any).muc_affiliation),
         role: parseMucRole((presence as any).muc_role),
       };
-      this.authorityHandler?.({ ...this.roomAuthority });
-      this.roomPresence[nick] = parsePresenceShow(presence.show);
-      this.presenceHandler?.({ ...this.roomPresence });
+      roomPresence[nick] = parsePresenceShow(presence.show);
       if ((presence as any).muc_jid) {
         const bare = barePeerJid((presence as any).muc_jid);
-        this.roomMemberJids[nick] = bare;
-        this.memberJidHandler?.(nick, bare);
+        roomMemberJids[nick] = bare;
+        if (isFocusedRoom) this.memberJidHandler?.(nick, bare);
+      }
+      if (isFocusedRoom) {
+        this.hatsHandler?.({ ...roomHats });
+        this.authorityHandler?.({ ...roomAuthority });
+        this.presenceHandler?.({ ...roomPresence });
       }
       return;
     }
@@ -2204,6 +2454,15 @@ export class BrowserXmppClient {
     if (message.id && this.carbonDedupIds.has(message.id) && !message._fromCarbon) {
       this.carbonDedupIds.delete(message.id);
       return;
+    }
+    if (message.call_event) {
+      applyDmCallEvent({
+        event: message.call_event,
+        selfBareJid: barePeerJid(this.session.jid),
+        to: message.to ?? message.call_event.to,
+        timestamp: message.timestamp,
+      });
+      if (!message.body && !message.subject) return;
     }
     if (message.chat_state && !message.body) {
       if (message.is_muc) { const roomJid = barePeerJid(message.from ?? message.to ?? ""); const nick = (message.from ?? "").split("/")[1] ?? "unknown"; if (roomJid === this.currentRoom && nick !== this.session.username) this.chatStateHandler?.({ roomJid, nick, state: message.chat_state as ChatStateType }); }
@@ -2348,8 +2607,17 @@ export class BrowserXmppClient {
   }
   private applyDmCatchupPage(page: WasmMamPage | null | undefined, since?: string, seenIds?: ReadonlyArray<string>): string | undefined {
     let lastArchiveId = pageLastArchiveId(page);
+    const selfBare = barePeerJid(this.session.jid);
     for (const message of page?.messages ?? []) {
-      const converted = dmMessageFromArchived(message, barePeerJid(this.session.jid));
+      if (message.call_event && !shouldSkipRawCatchupMessage(message, since, seenIds)) {
+        applyDmCallEvent({
+          event: message.call_event,
+          selfBareJid: selfBare,
+          to: message.to,
+          timestamp: message.timestamp,
+        });
+      }
+      const converted = dmMessageFromArchived(message, selfBare);
       if (!converted || shouldSkipCatchupMessage(converted, since, seenIds)) continue;
       this.catchup.recordDmSeen(converted.peerJid, converted.createdAt, converted.archiveId, messageSeenIds(converted));
       this.directMessageHandler?.(converted);
@@ -2412,8 +2680,59 @@ export class BrowserXmppClient {
     xmpp.set_on_call?.((event: CallEvent) => {
       if (!this.isCurrentXmpp(xmpp)) return;
       const prev = $callState.get();
-      applyCallEvent(event);
-      void handleCallEventSideEffect(event, prev, xmpp as unknown as CallWireSender, this.fullJid);
+      const selfBare = barePeerJid(this.session.jid);
+      const isSelfOriginated = barePeerJid(event.from) === selfBare;
+      const currentDmPeer =
+        prev.phase === "incoming"
+          ? prev.from
+          : prev.phase === "outgoing"
+            ? prev.to
+            : prev.phase === "active" && prev.kind === "dm"
+              ? prev.peer
+              : undefined;
+      if (
+        event.kind === "propose" ||
+        event.kind === "proceed" ||
+        event.kind === "reject" ||
+        event.kind === "retract" ||
+        event.kind === "finish" ||
+        (event.kind === "session-initiate" &&
+          prev.phase === "incoming" &&
+          prev.sid === event.sid) ||
+        (event.kind === "session-accept" &&
+          prev.phase === "outgoing" &&
+          prev.sid === event.sid) ||
+        (event.kind === "session-terminate" &&
+          prev.phase === "active" &&
+          prev.kind === "dm" &&
+          prev.sid === event.sid)
+      ) {
+        applyDmCallEvent({
+          event,
+          selfBareJid: selfBare,
+          to: event.to ?? currentDmPeer,
+        });
+      }
+      const eventMatchesCurrentCall =
+        "sid" in prev &&
+        prev.sid === event.sid &&
+        event.kind !== "propose";
+      const selfOriginatedEventShouldTouchCurrentCall =
+        eventMatchesCurrentCall &&
+        (
+          event.kind === "proceed" ||
+          (event.kind === "reject" && prev.phase === "incoming") ||
+          (event.kind === "session-initiate" && prev.phase === "incoming") ||
+          (event.kind === "session-accept" && prev.phase === "outgoing") ||
+          (event.kind === "session-terminate" && prev.phase === "active" && prev.kind === "dm") ||
+          (event.kind === "finish" && prev.phase === "active" && prev.kind === "dm")
+        );
+      if (!isSelfOriginated || selfOriginatedEventShouldTouchCurrentCall) {
+        applyCallEvent(event);
+      }
+      if (!isSelfOriginated) {
+        void handleCallEventSideEffect(event, prev, xmpp as unknown as CallWireSender, this.fullJid);
+      }
     });
     xmpp.on?.("session:started", () => {
       if (!this.isCurrentXmpp(xmpp)) return;

--- a/chat/src/lib/xmpp/discovery.ts
+++ b/chat/src/lib/xmpp/discovery.ts
@@ -8,6 +8,7 @@ const NS_FORUMS_0 = "urn:xmpp:forums:0";
 const NS_MUC = "http://jabber.org/protocol/muc";
 const NS_SPACES_0 = "urn:xmpp:spaces:0";
 const NS_PUBSUB = "http://jabber.org/protocol/pubsub";
+const NS_BOOKMARKS_1 = "urn:xmpp:bookmarks:1";
 const DISCO_INFO_NS = "http://jabber.org/protocol/disco#info";
 const DISCO_ITEMS_NS = "http://jabber.org/protocol/disco#items";
 const DATAFORM_NS = "jabber:x:data";
@@ -213,7 +214,14 @@ async function sendDiscoItems(xmpp: HybridClient, to: string, node?: string): Pr
     .map((item) => ({ jid: item.getAttribute("jid") ?? undefined, name: item.getAttribute("name") ?? undefined, node: item.getAttribute("node") ?? undefined }));
 }
 
-async function sendPubsubItems(xmpp: HybridClient, to: string, node: string): Promise<Array<{ jid?: string; name?: string }>> {
+type PubsubBookmarkItem = {
+  jid?: string;
+  name?: string;
+  /** XEP-0402 `autojoin`; omitted attribute means false for bookmarks. */
+  autojoin?: boolean;
+};
+
+async function sendPubsubItems(xmpp: HybridClient, to: string, node: string): Promise<PubsubBookmarkItem[]> {
   if (!xmpp.send_raw_iq) return [];
   const id = crypto.randomUUID();
   let responseXml: string;
@@ -233,10 +241,14 @@ async function sendPubsubItems(xmpp: HybridClient, to: string, node: string): Pr
   return Array.from(items.getElementsByTagNameNS(NS_PUBSUB, "item"))
     .filter((item) => item.parentNode === items)
     .map((item) => {
-      const conference = item.getElementsByTagName("conference")[0];
+      const conference = Array.from(item.getElementsByTagName("conference"))
+        .find((candidate) => !candidate.namespaceURI || candidate.namespaceURI === NS_BOOKMARKS_1);
       return {
         jid: item.getAttribute("id") ?? conference?.getAttribute("jid") ?? undefined,
         name: conference?.getAttribute("name") ?? undefined,
+        ...(conference
+          ? { autojoin: parseBooleanValue(conference.getAttribute("autojoin")) ?? false }
+          : {}),
       };
     });
 }
@@ -347,7 +359,7 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
   const domain = jidDomain(jid);
   const services = await discoverComponentServices(xmpp, domain, jid);
   let rooms: DiscoveredChannel[] = [];
-  const bookmarkedSpaceIds = new Map<string, string>();
+  const bookmarkedRooms = new Map<string, { spaceId: string; autojoin: boolean }>();
   const spaces: DiscoveredSpace[] = [];
   let serverRole: DiscoveryRole = null;
 
@@ -369,7 +381,12 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
       try {
         const bookmarks = await sendPubsubItems(xmpp, services.spaces, item.node);
         for (const bookmark of bookmarks) {
-          if (bookmark.jid) bookmarkedSpaceIds.set(barePeerJid(bookmark.jid), spaceId);
+          if (bookmark.jid) {
+            bookmarkedRooms.set(barePeerJid(bookmark.jid), {
+              spaceId,
+              autojoin: bookmark.autojoin ?? false,
+            });
+          }
         }
       } catch {}
       spaces.push({ id: spaceId, name: item.name ?? spaceId, role });
@@ -405,7 +422,16 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
       ? entry.value
       : channelFromRoom({ jid: mucRooms[index]!.jid ?? "", name: mucRooms[index]!.name }, index),
   );
-  rooms = hydrated.map((room, position) => ({ ...room, position, ...(room.jid && bookmarkedSpaceIds.get(barePeerJid(room.jid)) ? { spaceId: bookmarkedSpaceIds.get(barePeerJid(room.jid)), standalone: false } : {}) }));
+  rooms = hydrated.map((room, position) => {
+    const bookmark = room.jid ? bookmarkedRooms.get(barePeerJid(room.jid)) : undefined;
+    return {
+      ...room,
+      position,
+      ...(bookmark
+        ? { spaceId: bookmark.spaceId, standalone: false, autojoin: bookmark.autojoin }
+        : { autojoin: true }),
+    };
+  });
 
   const roomSpaceIds = new Map(rooms.flatMap((room) => room.jid ? [[barePeerJid(room.jid), room.spaceId]] as const : []));
   return {

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -357,6 +357,13 @@ export interface DiscoveredChannel {
   spaceId?: string;
   standalone?: boolean;
   features?: string[];
+  /**
+   * XEP-0402 bookmark `autojoin` value. Bookmarked rooms with the
+   * attribute omitted are `false` per spec; rooms discovered outside
+   * bookmark PubSub nodes may set this to `true` as Waddle's sidebar
+   * membership convention.
+   */
+  autojoin?: boolean;
   /** #422: room's current pin permission, hydrated from the
    * `urn:waddle:room-metadata` extended-disco form so non-owners
    * can render the Pin action correctly under the `anyone`

--- a/chat/src/lib/xmpp/wasm-types.ts
+++ b/chat/src/lib/xmpp/wasm-types.ts
@@ -1,3 +1,5 @@
+import type { CallEvent } from "@/lib/calls/types";
+
 /** TypeScript interfaces for Rust/WASM callback payload shapes.
  * All fields are snake_case (serde serialization convention).
  */
@@ -135,6 +137,7 @@ export interface WasmMessage {
   forum_thread_title?: string;
   is_sticker: boolean;
   shared_files: WasmSharedFile[];
+  call_event?: CallEvent;
   extension_envelope?: WasmExtensionEnvelope;
   extension_body_fallback?: boolean;
   /** urn:waddle:pin:0 pin/unpin event surfaced by the room (#414). */
@@ -205,6 +208,7 @@ export interface WasmArchivedMessage extends WasmMessage {
   mam_id: string;
   query_id?: string;
   author_real_jid?: string;
+  call_event?: CallEvent;
 }
 
 export interface WasmMamPage {

--- a/chat/tests/call-store.test.ts
+++ b/chat/tests/call-store.test.ts
@@ -9,6 +9,10 @@ import {
   reduceCallState,
   reportCallError,
 } from "../src/lib/calls/call-store";
+import {
+  clearDmCallActivities,
+  readDmCallActivity,
+} from "../src/lib/calls/dm-call-activity";
 import type { CallMedia, LiveKitJoin } from "../src/lib/calls/types";
 
 const audioVideo: CallMedia = { audio: true, video: true };
@@ -100,6 +104,21 @@ describe("call-store reducer", () => {
     expect(next).toEqual({ phase: "ended", sid: "c1", reason: "success" });
   });
 
+  test("session-terminate without serialized reason ends with null reason", () => {
+    const next = reduceCallState(
+      {
+        phase: "active",
+        peer: "alice@waddle.test/desktop",
+        sid: "c1",
+        media: audioVideo,
+        join,
+        kind: "dm",
+      },
+      { kind: "session-terminate", from: "alice@waddle.test/desktop", sid: "c1" },
+    );
+    expect(next).toEqual({ phase: "ended", sid: "c1", reason: null });
+  });
+
   test("finish ends the call without a reason", () => {
     const next = reduceCallState(
       {
@@ -156,6 +175,7 @@ describe("call-store reducer", () => {
 
   test("beginOutgoingCall transitions to the outgoing phase", () => {
     clearCallState();
+    clearDmCallActivities();
     beginOutgoingCall("bob@waddle.test", "c9", audioVideo);
     expect($callState.get()).toEqual({
       phase: "outgoing",
@@ -163,7 +183,14 @@ describe("call-store reducer", () => {
       sid: "c9",
       media: audioVideo,
     });
+    expect(readDmCallActivity("bob@waddle.test")).toMatchObject({
+      peerJid: "bob@waddle.test",
+      sid: "c9",
+      state: "ringing",
+      direction: "outgoing",
+    });
     clearCallState();
+    clearDmCallActivities();
   });
 
   test("proceed leaves outgoing intact (side-effect emits session-initiate)", () => {
@@ -179,6 +206,24 @@ describe("call-store reducer", () => {
       sid: "c9",
     });
     expect(next).toBe(current);
+  });
+
+  test("proceed clears sibling responder ringing for the same sid", () => {
+    const next = reduceCallState(
+      {
+        phase: "incoming",
+        from: "alice@waddle.test/laptop",
+        sid: "c9",
+        media: audioVideo,
+      },
+      {
+        kind: "proceed",
+        from: "bob@waddle.test/phone",
+        sid: "c9",
+      },
+    );
+
+    expect(next).toEqual({ phase: "idle" });
   });
 
   test("session-accept transitions outgoing to active", () => {

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../src/lib/calls/call-store";
 import {
   $mucCallParticipants,
+  applyMucCallPresence,
   clearMucCallParticipants,
 } from "../src/lib/calls/muc-call-presence";
 import { startMucCallAction } from "../src/lib/calls/muc-call-actions";
@@ -32,6 +33,7 @@ function wireClientEvents(sender: Partial<CallWireSender> = {}) {
   let onPresence: ((presence: {
     from?: string;
     presence_type?: string;
+    muc_jid?: string | null;
     muji?: { preparing: boolean; active: boolean };
   }) => void) | null = null;
   let onCall: ((event: CallEvent) => void) | null = null;
@@ -105,6 +107,7 @@ function wireEmitterPresenceEvents() {
  */
 function mockUpdateMujiPresenceWithEcho(
   emitPresence: ReturnType<typeof wireClientEvents>["emitPresence"],
+  mucJid?: string | null,
 ) {
   return mock(
     async (
@@ -118,6 +121,7 @@ function mockUpdateMujiPresenceWithEcho(
         emitPresence({
           from: `${roomJid}/${nick}`,
           presence_type: "available",
+          muc_jid: mucJid,
           muji: { preparing: true, active: false },
         });
       }
@@ -125,6 +129,7 @@ function mockUpdateMujiPresenceWithEcho(
         emitPresence({
           from: `${roomJid}/${nick}`,
           presence_type: "available",
+          muc_jid: mucJid,
           muji: { preparing: false, active: true },
         });
       }
@@ -331,6 +336,82 @@ describe("tearDownActiveCall", () => {
 });
 
 describe("1:1 call event wiring", () => {
+  test("self-originated sibling propose does not surface as an incoming call", async () => {
+    const sender = mockSender();
+    const events = wireClientEvents(sender);
+
+    events.emitCall({
+      kind: "propose",
+      from: "alice@waddle.test/phone",
+      to: "bob@waddle.test/desktop",
+      sid: "sibling-started",
+      media: audioVideo,
+    });
+    await flushCallSideEffects();
+
+    expect($callState.get()).toEqual({ phase: "idle" });
+    expect(sender.send_call_reject).not.toHaveBeenCalled();
+  });
+
+  test("self-originated sibling reject does not end this resource's active DM call", async () => {
+    const events = wireClientEvents();
+    $callState.set({
+      phase: "active",
+      peer: "bob@waddle.test/desktop",
+      sid: "shared-call",
+      media: audioVideo,
+      join,
+      kind: "dm",
+      initiator: "alice@waddle.test/web",
+    });
+
+    events.emitCall({
+      kind: "reject",
+      from: "alice@waddle.test/phone",
+      to: "bob@waddle.test/desktop",
+      sid: "shared-call",
+      reason: "decline",
+    });
+    await flushCallSideEffects();
+
+    expect($callState.get()).toEqual({
+      phase: "active",
+      peer: "bob@waddle.test/desktop",
+      sid: "shared-call",
+      media: audioVideo,
+      join,
+      kind: "dm",
+      initiator: "alice@waddle.test/web",
+    });
+  });
+
+  test("self-originated sibling reject clears this resource's incoming DM ring", async () => {
+    const sender = mockSender();
+    const events = wireClientEvents(sender);
+    $callState.set({
+      phase: "incoming",
+      from: "bob@waddle.test/desktop",
+      sid: "shared-call",
+      media: audioVideo,
+    });
+
+    events.emitCall({
+      kind: "reject",
+      from: "alice@waddle.test/phone",
+      to: "bob@waddle.test/desktop",
+      sid: "shared-call",
+      reason: "decline",
+    });
+    await flushCallSideEffects();
+
+    expect($callState.get()).toEqual({
+      phase: "ended",
+      sid: "shared-call",
+      reason: "reject",
+    });
+    expect(sender.send_call_reject).not.toHaveBeenCalled();
+  });
+
   test("real on_call propose event applies lower-sid tie-break and surfaces incoming UI", async () => {
     const send_call_retract_tie_break = mock(async () => undefined);
     const events = wireClientEvents({ send_call_retract_tie_break });
@@ -764,14 +845,25 @@ describe("MUC group call", () => {
       identity: "alice@waddle.test/web",
       token: "jwt.payload.sig",
     };
-    const update_muji_presence = mockUpdateMujiPresenceWithEcho(events.emitPresence);
+    const selfFullJid = "alice@waddle.test/web";
+    const update_muji_presence = mockUpdateMujiPresenceWithEcho(
+      events.emitPresence,
+      selfFullJid,
+    );
     const sender = {
       send_muji_session_initiate:
         mockSendMujiSessionInitiateWithAccept(expectedJoin, events.emitCall),
       update_muji_presence,
     };
     const { beginMucCall } = await import("../src/lib/calls/call-store");
-    await beginMucCall(sender, "chan@muc.test", audioVideo, "alice");
+    await beginMucCall(
+      sender,
+      "chan@muc.test",
+      audioVideo,
+      "alice",
+      undefined,
+      selfFullJid,
+    );
     const state = $callState.get();
     expect(state).toMatchObject({
       phase: "active",
@@ -780,6 +872,7 @@ describe("MUC group call", () => {
       join: expectedJoin,
       kind: "muc",
       selfNick: "alice",
+      selfFullJid,
     });
     expect(typeof (state as { sid?: unknown }).sid).toBe("string");
     expect((state as { sid: string }).sid).not.toBe("chan@muc.test");
@@ -1396,6 +1489,45 @@ describe("MUC group call", () => {
     expect($callState.get()).toEqual({ phase: "idle" });
   });
 
+  test("tearDownActiveCall clears only this MUC resource's active owner", async () => {
+    applyMucCallPresence({
+      from: "chan@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/desktop",
+      muji: { preparing: false, active: true },
+    });
+    applyMucCallPresence({
+      from: "chan@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/mobile",
+      muji: { preparing: false, active: true },
+    });
+    $callState.set({
+      phase: "active",
+      peer: "chan@muc.test",
+      sid: "muc-attempt",
+      media: audioVideo,
+      join,
+      kind: "muc",
+      selfNick: "alice",
+      selfFullJid: "alice@waddle.test/desktop",
+    });
+    const update_muji_presence = mock(async () => {});
+    const send_muji_session_terminate = mock(async () => {});
+
+    await tearDownActiveCall(
+      {
+        update_muji_presence,
+        send_muji_session_terminate,
+      } as unknown as Parameters<typeof tearDownActiveCall>[0],
+      "success",
+    );
+
+    expect(update_muji_presence).toHaveBeenCalledTimes(1);
+    expect(send_muji_session_terminate).toHaveBeenCalledTimes(1);
+    expect($mucCallParticipants.get()["chan@muc.test"]).toEqual(["alice"]);
+  });
+
   test("beginMucCall treats active Muji presence failure as fatal and rolls back SFU/session work", async () => {
     const events = wireClientEvents();
     const send_muji_session_terminate = mock(async () => undefined);
@@ -1445,7 +1577,7 @@ describe("MUC group call", () => {
     expect($mucCallParticipants.get()["chan@muc.test"]).toBeUndefined();
   });
 
-  test("room switch tears down the old room's active MUC call before leaving", async () => {
+  test("room switch preserves the old room's active MUC call and keeps MUC membership", async () => {
     const events = wireClientEvents();
     const send_muji_session_terminate = mock(async () => undefined);
     const update_muji_presence = mockUpdateMujiPresenceWithEcho(events.emitPresence);
@@ -1466,6 +1598,7 @@ describe("MUC group call", () => {
         operationOrder.push(`presence:${active}:${preparing}`);
         await update_muji_presence(roomJid, nick, active, preparing, video);
       }),
+      join_room: mock(async () => undefined),
       leave_room: mock(async (roomJid: string, nick: string) => {
         operationOrder.push(`leave:${roomJid}/${nick}`);
         await leave_room(roomJid, nick);
@@ -1474,14 +1607,12 @@ describe("MUC group call", () => {
     const client = events.client as unknown as {
       xmpp: typeof xmpp;
       currentRoom: string | null;
-      roomHats: Record<string, unknown>;
-      roomAuthority: Record<string, unknown>;
-      roomPresence: Record<string, unknown>;
-      roomMemberJids: Record<string, string>;
+      joinedMucs: Map<string, Promise<void>>;
       performRoomSwitch: (roomJid: string) => Promise<void>;
     };
     Object.assign(client.xmpp, xmpp);
     client.currentRoom = "old@muc.test";
+    client.joinedMucs.set("new@muc.test", Promise.resolve());
     $callState.set({
       phase: "active",
       peer: "old@muc.test",
@@ -1494,33 +1625,35 @@ describe("MUC group call", () => {
 
     await client.performRoomSwitch("new@muc.test");
 
-    expect(operationOrder).toEqual([
-      "presence:false:false",
-      "terminate:old@muc.test:old-muc-attempt",
-      "leave:old@muc.test/alice",
-    ]);
-    expect($callState.get()).toEqual({ phase: "idle" });
+    expect(operationOrder).toEqual([]);
+    expect(xmpp.leave_room).not.toHaveBeenCalled();
+    expect($callState.get()).toMatchObject({
+      phase: "active",
+      peer: "old@muc.test",
+      sid: "old-muc-attempt",
+      kind: "muc",
+    });
   });
 
-  test("room switch does not join the new room after a concurrent disconnect", async () => {
+  test("room switch bails out cleanly when a concurrent disconnect races the join", async () => {
     const events = wireClientEvents();
-    let releaseLeave: (() => void) | null = null;
-    let leaveStarted: (() => void) | null = null;
-    const leaveGate = new Promise<void>((resolve) => {
-      releaseLeave = resolve;
+    let releaseJoin: (() => void) | null = null;
+    let joinStarted: (() => void) | null = null;
+    const joinGate = new Promise<void>((resolve) => {
+      releaseJoin = resolve;
     });
-    const leaveStartedWait = new Promise<void>((resolve) => {
-      leaveStarted = resolve;
+    const joinStartedWait = new Promise<void>((resolve) => {
+      joinStarted = resolve;
     });
-    let leaveCalls = 0;
-    const leave_room = mock(async () => {
-      leaveCalls += 1;
-      if (leaveCalls === 1) {
-        leaveStarted?.();
-        await leaveGate;
+    let joinCalls = 0;
+    const join_room = mock(async () => {
+      joinCalls += 1;
+      if (joinCalls === 1) {
+        joinStarted?.();
+        await joinGate;
       }
     });
-    const join_room = mock(async () => undefined);
+    const leave_room = mock(async () => undefined);
     const disconnect = mock(async () => undefined);
     const xmpp = { leave_room, join_room, disconnect };
     const client = events.client as unknown as {
@@ -1533,17 +1666,18 @@ describe("MUC group call", () => {
     client.currentRoom = "old@muc.test";
 
     const switched = client.performRoomSwitch("new@muc.test");
-    await leaveStartedWait;
+    await joinStartedWait;
     const disconnected = client.disconnect();
-    releaseLeave?.();
+    releaseJoin?.();
     await switched;
     await disconnected;
 
-    expect(join_room).not.toHaveBeenCalled();
+    expect(join_room).toHaveBeenCalledTimes(1);
+    expect(leave_room.mock.calls.map((call) => call[0] as string)).not.toContain("old@muc.test");
     expect(client.currentRoom).toBe(null);
   });
 
-  test("room switch cancels the old room's pending MUC call before leaving", async () => {
+  test("room switch preserves the old room's pending MUC call without leaving the MUC", async () => {
     const events = wireClientEvents();
     const send_muji_session_initiate = mock(async () => undefined);
     const send_muji_session_terminate = mock(async () => undefined);
@@ -1569,6 +1703,7 @@ describe("MUC group call", () => {
         operationOrder.push(`presence:${active}:${preparing}:${video}`);
         await update_muji_presence(roomJid, nick, active, preparing, video);
       }),
+      join_room: mock(async () => undefined),
       leave_room: mock(async (roomJid: string, nick: string) => {
         operationOrder.push(`leave:${roomJid}/${nick}`);
         await leave_room(roomJid, nick);
@@ -1577,10 +1712,7 @@ describe("MUC group call", () => {
     const client = events.client as unknown as {
       xmpp: typeof xmpp;
       currentRoom: string | null;
-      roomHats: Record<string, unknown>;
-      roomAuthority: Record<string, unknown>;
-      roomPresence: Record<string, unknown>;
-      roomMemberJids: Record<string, string>;
+      joinedMucs: Map<string, Promise<void>>;
       performRoomSwitch: (roomJid: string) => Promise<void>;
     };
     Object.assign(client.xmpp, xmpp);
@@ -1594,22 +1726,33 @@ describe("MUC group call", () => {
     expect(send_muji_session_initiate).toHaveBeenCalledTimes(1);
     const attemptSid = firstMockCallArg(send_muji_session_initiate, 1);
     expect(attemptSid).not.toBe("old@muc.test");
+    client.joinedMucs.set("new@muc.test", Promise.resolve());
 
     await client.performRoomSwitch("new@muc.test");
 
-    await expect(pending).rejects.toThrow("cancelled");
+    events.emitCall({
+      kind: "session-accept",
+      from: "calls.waddle.test",
+      sid: attemptSid,
+      media: audioVideo,
+      join: { ...join, room: "old@muc.test" },
+    });
+    await expect(pending).resolves.toBeUndefined();
     expect(operationOrder).toEqual([
       "presence:false:true:false",
       "presence:true:false:true",
       "initiate:old@muc.test:true",
-      "presence:false:false:false",
-      `terminate:old@muc.test:${attemptSid}`,
-      "leave:old@muc.test/alice",
     ]);
-    expect($callState.get()).toEqual({ phase: "idle" });
+    expect(xmpp.leave_room).not.toHaveBeenCalled();
+    expect($callState.get()).toMatchObject({
+      phase: "active",
+      peer: "old@muc.test",
+      sid: attemptSid,
+      kind: "muc",
+    });
   });
 
-  test("room switch cancels a MUC start waiting for the old room's preparing echo", async () => {
+  test("room switch preserves a MUC start waiting for the old room's preparing echo", async () => {
     const events = wireClientEvents();
     const send_muji_session_initiate = mock(async () => undefined);
     const update_muji_presence = mock(async () => undefined);
@@ -1630,6 +1773,7 @@ describe("MUC group call", () => {
         operationOrder.push(`presence:${roomJid}/${nick}:${active}:${preparing}:${video}`);
         await update_muji_presence(roomJid, nick, active, preparing, video);
       }),
+      join_room: mock(async () => undefined),
       leave_room: mock(async (roomJid: string, nick: string) => {
         operationOrder.push(`leave:${roomJid}/${nick}`);
         await leave_room(roomJid, nick);
@@ -1638,10 +1782,7 @@ describe("MUC group call", () => {
     const client = events.client as unknown as {
       xmpp: typeof xmpp;
       currentRoom: string | null;
-      roomHats: Record<string, unknown>;
-      roomAuthority: Record<string, unknown>;
-      roomPresence: Record<string, unknown>;
-      roomMemberJids: Record<string, string>;
+      joinedMucs: Map<string, Promise<void>>;
       performRoomSwitch: (roomJid: string) => Promise<void>;
     };
     Object.assign(client.xmpp, xmpp);
@@ -1653,9 +1794,9 @@ describe("MUC group call", () => {
     await flushCallSideEffects();
     expect($callState.get().phase).toBe("muc-pending");
     expect(send_muji_session_initiate).toHaveBeenCalledTimes(0);
+    client.joinedMucs.set("new@muc.test", Promise.resolve());
 
     await client.performRoomSwitch("new@muc.test");
-    await expect(pending).rejects.toThrow("cancelled");
 
     events.emitPresence({
       from: "old@muc.test/alice",
@@ -1664,13 +1805,28 @@ describe("MUC group call", () => {
     });
     await flushCallSideEffects();
 
-    expect(send_muji_session_initiate).toHaveBeenCalledTimes(0);
+    expect(send_muji_session_initiate).toHaveBeenCalledTimes(1);
+    const attemptSid = firstMockCallArg(send_muji_session_initiate, 1);
+    events.emitCall({
+      kind: "session-accept",
+      from: "calls.waddle.test",
+      sid: attemptSid,
+      media: audioVideo,
+      join: { ...join, room: "old@muc.test" },
+    });
+    await expect(pending).resolves.toBeUndefined();
     expect(operationOrder).toEqual([
       "presence:old@muc.test/alice:false:true:false",
-      "presence:old@muc.test/alice:false:false:false",
-      "leave:old@muc.test/alice",
+      "presence:old@muc.test/alice:true:false:true",
+      "initiate:old@muc.test:true",
     ]);
-    expect($callState.get()).toEqual({ phase: "idle" });
+    expect(xmpp.leave_room).not.toHaveBeenCalled();
+    expect($callState.get()).toMatchObject({
+      phase: "active",
+      peer: "old@muc.test",
+      sid: attemptSid,
+      kind: "muc",
+    });
   });
 });
 

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -269,7 +269,9 @@ describe("client send readiness", () => {
       xmpp: typeof xmpp;
       connected: boolean;
       currentRoom: string | null;
+      joinedMucReady: Set<string>;
     }).currentRoom = roomJid;
+    (client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.add(roomJid);
 
     const result = await client.sendGroupMessage("w1", "c1", "hello room");
 
@@ -292,6 +294,7 @@ describe("client send readiness", () => {
     }).xmpp = xmpp;
     (client as unknown as { connected: boolean }).connected = true;
     (client as unknown as { currentRoom: string | null }).currentRoom = roomJid;
+    (client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.add(roomJid);
 
     const result = await client.sendGroupMessage("w1", "c1", "", {
       threadId: "thread-root",
@@ -325,6 +328,216 @@ describe("client send readiness", () => {
     await expect(client.sendDisplayed("w1", "c1", "msg-1")).rejects.toThrow("Reconnection timed out");
     await expect(client.sendChatState("w1", "c1", "composing")).rejects.toThrow("Reconnection timed out");
     expect(xmpp.sendMessage).toHaveBeenCalledTimes(0);
+  });
+
+  test("room join readiness waits for this resource's MUC self-presence", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type?: string;
+      muc_jid?: string;
+    }) => void) | null = null;
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).connected = true;
+    (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+
+    const joined = (client as unknown as { ensureJoined: (roomJid: string) => Promise<void> }).ensureJoined(roomJid);
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_jid: "alice@example.com/phone",
+    });
+    await Promise.resolve();
+    expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(false);
+
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_jid: (client as unknown as { fullJid: string }).fullJid,
+    });
+
+    await joined;
+    expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(true);
+  });
+
+  test("room join readiness ignores unavailable self-presence", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type?: string;
+      muc_jid?: string;
+    }) => void) | null = null;
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).connected = true;
+    (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+
+    const joined = (client as unknown as { ensureJoined: (roomJid: string) => Promise<void> }).ensureJoined(roomJid);
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "unavailable",
+      muc_jid: (client as unknown as { fullJid: string }).fullJid,
+    });
+    await Promise.resolve();
+    expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(false);
+
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_jid: (client as unknown as { fullJid: string }).fullJid,
+    });
+
+    await joined;
+    expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(true);
+  });
+
+  test("own unavailable self-presence revokes room readiness and forces a fresh join", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type?: string;
+      muc_jid?: string;
+    }) => void) | null = null;
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      send_groupchat_message: mock(async (_room: string, _body: string, opts: { stanza_id?: string }) => opts.stanza_id),
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    (client as unknown as {
+      xmpp: typeof xmpp;
+      connected: boolean;
+      currentRoom: string | null;
+    }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { currentRoom: string | null }).currentRoom = roomJid;
+    (client as unknown as { joinedMucs: Map<string, Promise<void>> }).joinedMucs.set(roomJid, Promise.resolve());
+    (client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.add(roomJid);
+    (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "unavailable",
+      muc_jid: (client as unknown as { fullJid: string }).fullJid,
+    });
+
+    expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(false);
+    expect((client as unknown as { joinedMucs: Map<string, Promise<void>> }).joinedMucs.has(roomJid)).toBe(false);
+
+    const sent = await client.sendGroupMessage("w1", "c1", "after unavailable");
+    expect(sent?.state).toBe("queued");
+    expect(xmpp.send_groupchat_message).toHaveBeenCalledTimes(0);
+    await settleReconnectCatchup();
+    expect(xmpp.join_room).toHaveBeenCalledWith(roomJid, "alice");
+
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_jid: (client as unknown as { fullJid: string }).fullJid,
+    });
+    await settleReconnectCatchup();
+    expect(xmpp.send_groupchat_message).toHaveBeenCalledWith(
+      roomJid,
+      "after unavailable",
+      expect.any(Object),
+    );
+  });
+
+  test("session-ready room queue flush waits for current-room rejoin", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    enqueueQueuedMessage("alice@example.com", {
+      kind: "room",
+      id: "queued-room-after-resume",
+      createdAt: new Date().toISOString(),
+      roomJid,
+      body: "queued while reconnecting",
+    });
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type?: string;
+      muc_jid?: string;
+    }) => void) | null = null;
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      send_groupchat_message: mock(async (_room: string, _body: string, opts: { stanza_id?: string }) => opts.stanza_id),
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    (client as unknown as { xmpp: typeof xmpp; currentRoom: string | null }).xmpp = xmpp;
+    (client as unknown as { currentRoom: string | null }).currentRoom = roomJid;
+    (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+
+    (client as unknown as {
+      handleSessionReady: (xmpp: typeof xmpp, lifecycle: { type: "resumed" }) => void;
+    }).handleSessionReady(xmpp, { type: "resumed" });
+    await settleReconnectCatchup();
+    expect(xmpp.send_groupchat_message).toHaveBeenCalledTimes(0);
+
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_jid: (client as unknown as { fullJid: string }).fullJid,
+    });
+    await settleReconnectCatchup();
+
+    expect(xmpp.send_groupchat_message).toHaveBeenCalledWith(
+      roomJid,
+      "queued while reconnecting",
+      expect.objectContaining({ stanza_id: "queued-room-after-resume" }),
+    );
+  });
+
+  test("session-ready rejoins retained non-current rooms", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = "side@muc.example.com";
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type?: string;
+      muc_jid?: string;
+    }) => void) | null = null;
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    (client as unknown as {
+      xmpp: typeof xmpp;
+      retainedJoinedRoomJids: Set<string>;
+    }).xmpp = xmpp;
+    (client as unknown as { retainedJoinedRoomJids: Set<string> }).retainedJoinedRoomJids = new Set([roomJid]);
+    (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+
+    (client as unknown as {
+      handleSessionReady: (xmpp: typeof xmpp, lifecycle: { type: "resumed" }) => void;
+    }).handleSessionReady(xmpp, { type: "resumed" });
+    await settleReconnectCatchup();
+
+    expect(xmpp.join_room).toHaveBeenCalledWith(roomJid, "alice");
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_jid: (client as unknown as { fullJid: string }).fullJid,
+    });
+    await settleReconnectCatchup();
+    expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(true);
   });
 
   test("DM send queues when the session is unavailable", async () => {

--- a/chat/tests/discovery-bookmark-autojoin.test.ts
+++ b/chat/tests/discovery-bookmark-autojoin.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+import { discoverTopology } from "../src/lib/xmpp/discovery";
+import {
+  discoInfoXml,
+  discoItemsXml,
+  pubsubItemsXml,
+  withFakeDomParser,
+} from "./helpers/disco-xml";
+
+describe("discoverTopology XEP-0402 bookmark autojoin", () => {
+  test("surfaces explicit autojoin=true bookmarks", async () => {
+    await withFakeDomParser(async () => {
+      const topology = await discoverTopology(
+        topologyClient({
+          bookmarks: [
+            { id: "general@muc.example.test", jid: "general@muc.example.test", name: "General", autojoin: true },
+          ],
+          rooms: [{ jid: "general@muc.example.test", name: "General" }],
+        }),
+        "alice@example.test",
+      );
+
+      expect(topology.rooms.find((room) => room.jid === "general@muc.example.test")?.autojoin).toBe(true);
+    });
+  });
+
+  test("surfaces explicit autojoin=false bookmarks", async () => {
+    await withFakeDomParser(async () => {
+      const topology = await discoverTopology(
+        topologyClient({
+          bookmarks: [
+            { id: "muted@muc.example.test", jid: "muted@muc.example.test", name: "Muted", autojoin: false },
+          ],
+          rooms: [{ jid: "muted@muc.example.test", name: "Muted" }],
+        }),
+        "alice@example.test",
+      );
+
+      expect(topology.rooms.find((room) => room.jid === "muted@muc.example.test")?.autojoin).toBe(false);
+    });
+  });
+
+  test("defaults omitted bookmark autojoin to false per XEP-0402", async () => {
+    await withFakeDomParser(async () => {
+      const topology = await discoverTopology(
+        topologyClient({
+          bookmarks: [
+            { id: "foreign@muc.example.test", jid: "foreign@muc.example.test", name: "Foreign" },
+          ],
+          rooms: [{ jid: "foreign@muc.example.test", name: "Foreign" }],
+        }),
+        "alice@example.test",
+      );
+
+      expect(topology.rooms.find((room) => room.jid === "foreign@muc.example.test")?.autojoin).toBe(false);
+    });
+  });
+
+  test("defaults orphan sidebar rooms to autojoin=true as Waddle membership convention", async () => {
+    await withFakeDomParser(async () => {
+      const topology = await discoverTopology(
+        topologyClient({
+          bookmarks: [],
+          rooms: [{ jid: "orphan@muc.example.test", name: "Orphan" }],
+        }),
+        "alice@example.test",
+      );
+
+      expect(topology.rooms.find((room) => room.jid === "orphan@muc.example.test")?.autojoin).toBe(true);
+    });
+  });
+});
+
+type Bookmark = {
+  id?: string;
+  jid?: string;
+  name?: string;
+  autojoin?: boolean;
+};
+
+function topologyClient(options: {
+  bookmarks: Bookmark[];
+  rooms: Array<{ jid: string; name?: string }>;
+}) {
+  return {
+    async send_raw_iq(xml: string): Promise<string> {
+      if (xml.includes('xmlns="http://jabber.org/protocol/disco#items"')) {
+        if (xml.includes('to="example.test"')) {
+          return discoItemsXml([
+            { jid: "spaces.example.test", name: "Spaces" },
+            { jid: "muc.example.test", name: "Chatrooms" },
+          ]);
+        }
+        if (xml.includes('to="spaces.example.test"')) {
+          return discoItemsXml([{ name: "Engineering", node: "space-engineering" }]);
+        }
+        if (xml.includes('to="muc.example.test"')) {
+          return discoItemsXml(options.rooms);
+        }
+        return discoItemsXml([]);
+      }
+
+      if (xml.includes('xmlns="http://jabber.org/protocol/disco#info"')) {
+        if (xml.includes('to="muc.example.test"')) {
+          return discoInfoXml({
+            identities: [{ category: "conference", type: "text", name: "Chatrooms" }],
+            features: ["http://jabber.org/protocol/muc"],
+          });
+        }
+        if (xml.includes('to="spaces.example.test"')) {
+          return discoInfoXml({
+            identities: [{ category: "pubsub", type: "service", name: "Spaces" }],
+            features: ["urn:xmpp:spaces:0"],
+          });
+        }
+        return discoInfoXml({
+          identities: [{ category: "server", type: "im", name: "Waddle" }],
+          features: [],
+        });
+      }
+
+      if (xml.includes('xmlns="http://jabber.org/protocol/pubsub"')) {
+        return pubsubItemsXml(options.bookmarks);
+      }
+
+      throw new Error(`Unexpected IQ: ${xml}`);
+    },
+  };
+}

--- a/chat/tests/dm-call-activity.test.ts
+++ b/chat/tests/dm-call-activity.test.ts
@@ -1,0 +1,300 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  $dmCallActivities,
+  applyDmCallEvent,
+  clearDmCallActivities,
+  clearDmCallActivity,
+  readDmCallActivity,
+} from "../src/lib/calls/dm-call-activity";
+import type { CallEvent } from "../src/lib/calls/types";
+
+const self = "alice@waddle.test";
+const bob = "bob@waddle.test";
+const audio = { audio: true, video: false };
+const now = new Date("2026-05-25T10:00:00.000Z");
+
+describe("DM call activity", () => {
+  beforeEach(() => {
+    clearDmCallActivities();
+  });
+
+  afterEach(() => {
+    clearDmCallActivities();
+  });
+
+  test("tracks an unresolved remote proposal as ringing activity", () => {
+    applyDmCallEvent({
+      event: {
+        kind: "propose",
+        from: `${bob}/phone`,
+        sid: "call-1",
+        media: audio,
+      },
+      selfBareJid: self,
+      to: `${self}/web`,
+      timestamp: now.toISOString(),
+      now,
+    });
+
+    expect(readDmCallActivity(bob)).toEqual({
+      peerJid: bob,
+      sid: "call-1",
+      media: audio,
+      state: "ringing",
+      direction: "incoming",
+      updatedAt: now.toISOString(),
+    });
+  });
+
+  test("uses the to JID for self-sent carbon events from another resource", () => {
+    applyDmCallEvent({
+      event: {
+        kind: "propose",
+        from: `${self}/phone`,
+        to: `${bob}/desktop`,
+        sid: "call-2",
+        media: { audio: true, video: true },
+      },
+      selfBareJid: self,
+      timestamp: now.toISOString(),
+      now,
+    });
+
+    expect(readDmCallActivity(bob)?.direction).toBe("outgoing");
+    expect(readDmCallActivity(bob)?.media.video).toBe(true);
+  });
+
+  test("marks a call accepted when a peer proceeds on one resource", () => {
+    const propose: CallEvent = {
+      kind: "propose",
+      from: `${self}/web`,
+      sid: "call-3",
+      media: audio,
+    };
+    applyDmCallEvent({
+      event: propose,
+      selfBareJid: self,
+      to: bob,
+      timestamp: now.toISOString(),
+      now,
+    });
+
+    applyDmCallEvent({
+      event: {
+        kind: "proceed",
+        from: `${bob}/phone`,
+        sid: "call-3",
+      },
+      selfBareJid: self,
+      to: `${self}/web`,
+      timestamp: "2026-05-25T10:00:10.000Z",
+      now,
+    });
+
+    expect(readDmCallActivity(bob)).toMatchObject({
+      peerJid: bob,
+      sid: "call-3",
+      media: audio,
+      state: "accepted",
+      direction: "outgoing",
+    });
+  });
+
+  test("removes activity when finish arrives for the same sid", () => {
+    applyDmCallEvent({
+      event: {
+        kind: "propose",
+        from: `${bob}/phone`,
+        sid: "call-4",
+        media: audio,
+      },
+      selfBareJid: self,
+      to: `${self}/web`,
+      timestamp: now.toISOString(),
+      now,
+    });
+
+    applyDmCallEvent({
+      event: {
+        kind: "finish",
+        from: `${bob}/phone`,
+        sid: "call-4",
+        reason: "success",
+      },
+      selfBareJid: self,
+      to: `${self}/web`,
+      timestamp: "2026-05-25T10:05:00.000Z",
+      now,
+    });
+
+    expect(readDmCallActivity(bob)).toBeNull();
+  });
+
+  test("self-sent terminal events can clear by sid when the peer hint is gone", () => {
+    applyDmCallEvent({
+      event: {
+        kind: "propose",
+        from: `${self}/web`,
+        to: `${bob}/phone`,
+        sid: "call-6",
+        media: audio,
+      },
+      selfBareJid: self,
+      timestamp: now.toISOString(),
+      now,
+    });
+    applyDmCallEvent({
+      event: {
+        kind: "proceed",
+        from: `${bob}/phone`,
+        sid: "call-6",
+      },
+      selfBareJid: self,
+      timestamp: "2026-05-25T10:00:10.000Z",
+      now,
+    });
+
+    applyDmCallEvent({
+      event: {
+        kind: "finish",
+        from: `${self}/other`,
+        sid: "call-6",
+        reason: "success",
+      },
+      selfBareJid: self,
+      timestamp: "2026-05-25T10:05:00.000Z",
+      now,
+    });
+
+    expect(readDmCallActivity(bob)).toBeNull();
+  });
+
+  test("older MAM call events cannot regress a newer activity state", () => {
+    applyDmCallEvent({
+      event: {
+        kind: "proceed",
+        from: `${bob}/phone`,
+        sid: "call-7",
+      },
+      selfBareJid: self,
+      to: `${self}/web`,
+      timestamp: "2026-05-25T10:05:00.000Z",
+      now,
+    });
+
+    applyDmCallEvent({
+      event: {
+        kind: "propose",
+        from: `${bob}/phone`,
+        sid: "call-7",
+        media: audio,
+      },
+      selfBareJid: self,
+      to: `${self}/web`,
+      timestamp: "2026-05-25T10:00:00.000Z",
+      now,
+    });
+
+    expect(readDmCallActivity(bob)).toMatchObject({
+      sid: "call-7",
+      state: "accepted",
+      updatedAt: "2026-05-25T10:05:00.000Z",
+    });
+  });
+
+  test("terminal MAM events prevent older proposals for the same sid from resurrecting activity", () => {
+    applyDmCallEvent({
+      event: {
+        kind: "finish",
+        from: `${bob}/phone`,
+        sid: "call-8",
+        reason: "success",
+      },
+      selfBareJid: self,
+      to: `${self}/web`,
+      timestamp: "2026-05-25T10:05:00.000Z",
+      now,
+    });
+
+    applyDmCallEvent({
+      event: {
+        kind: "propose",
+        from: `${bob}/phone`,
+        sid: "call-8",
+        media: audio,
+      },
+      selfBareJid: self,
+      to: `${self}/web`,
+      timestamp: "2026-05-25T10:00:00.000Z",
+      now,
+    });
+
+    expect(readDmCallActivity(bob)).toBeNull();
+  });
+
+  test("self-sent terminal events with a to peer tombstone older sibling proposals", () => {
+    applyDmCallEvent({
+      event: {
+        kind: "finish",
+        from: `${self}/phone`,
+        to: `${bob}/desktop`,
+        sid: "call-9",
+        reason: "success",
+      },
+      selfBareJid: self,
+      timestamp: "2026-05-25T10:05:00.000Z",
+      now,
+    });
+
+    applyDmCallEvent({
+      event: {
+        kind: "propose",
+        from: `${self}/phone`,
+        to: `${bob}/desktop`,
+        sid: "call-9",
+        media: audio,
+      },
+      selfBareJid: self,
+      timestamp: "2026-05-25T10:00:00.000Z",
+      now,
+    });
+
+    expect(readDmCallActivity(bob)).toBeNull();
+  });
+
+  test("does not let stale catch-up proposals resurrect old calls", () => {
+    applyDmCallEvent({
+      event: {
+        kind: "propose",
+        from: `${bob}/phone`,
+        sid: "old-call",
+        media: audio,
+      },
+      selfBareJid: self,
+      to: `${self}/web`,
+      timestamp: "2026-05-23T09:59:59.000Z",
+      now,
+    });
+
+    expect($dmCallActivities.get()).toEqual({});
+  });
+
+  test("local cleanup can clear an optimistic outgoing proposal", () => {
+    applyDmCallEvent({
+      event: {
+        kind: "propose",
+        from: `${self}/web`,
+        sid: "call-5",
+        media: audio,
+      },
+      selfBareJid: self,
+      to: bob,
+      timestamp: now.toISOString(),
+      now,
+    });
+
+    clearDmCallActivity(bob, "call-5");
+
+    expect(readDmCallActivity(bob)).toBeNull();
+  });
+});

--- a/chat/tests/helpers/disco-xml.ts
+++ b/chat/tests/helpers/disco-xml.ts
@@ -26,9 +26,9 @@ export function discoInfoXml(info: { features?: string[]; identities?: DiscoIden
   }</query></iq>`;
 }
 
-export function pubsubItemsXml(items: Array<{ id?: string; jid?: string; name?: string }>): string {
+export function pubsubItemsXml(items: Array<{ id?: string; jid?: string; name?: string; autojoin?: boolean }>): string {
   return `<iq type="result"><pubsub xmlns="http://jabber.org/protocol/pubsub"><items>${items.map((item) =>
-    `<item${item.id ? ` id="${item.id}"` : ""}>${item.jid || item.name ? `<conference${item.jid ? ` jid="${item.jid}"` : ""}${item.name ? ` name="${item.name}"` : ""}/>` : ""}</item>`
+    `<item${item.id ? ` id="${item.id}"` : ""}>${item.jid || item.name ? `<conference xmlns="urn:xmpp:bookmarks:1"${item.jid ? ` jid="${item.jid}"` : ""}${item.name ? ` name="${item.name}"` : ""}${item.autojoin === undefined ? "" : ` autojoin="${item.autojoin ? "true" : "false"}"`}/>` : ""}</item>`
   ).join("")}</items></pubsub></iq>`;
 }
 

--- a/chat/tests/muc-call-presence.test.ts
+++ b/chat/tests/muc-call-presence.test.ts
@@ -2,7 +2,9 @@ import { afterEach, describe, expect, test } from "bun:test";
 import {
   $mucCallParticipants,
   applyMucCallPresence,
+  awaitNoOtherPreparing,
   awaitPreparingEcho,
+  clearMucCallParticipant,
   clearMucCallParticipants,
   mucCallParticipantCounts,
   mucCallParticipantCount,
@@ -18,6 +20,7 @@ afterEach(() => {
 // boolean pair that the WASM parser surfaces in `WasmMujiPresence`.
 const activeMuji = { preparing: false, active: true } as const;
 const preparingMuji = { preparing: true, active: false } as const;
+const activePreparingMuji = { preparing: true, active: true } as const;
 
 describe("applyMucCallPresence", () => {
   test("available presence with active Muji registers the nick", () => {
@@ -59,7 +62,7 @@ describe("applyMucCallPresence", () => {
     expect($mucCallParticipants.get()["room@muc.test"]).toBeUndefined();
   });
 
-  test("transitioning from active → preparing-only clears the nick", () => {
+  test("preparing-only Muji preserves an existing active nick for same-nick sibling joins", () => {
     applyMucCallPresence({
       from: "room@muc.test/alice",
       presence_type: "available",
@@ -70,7 +73,118 @@ describe("applyMucCallPresence", () => {
       presence_type: "available",
       muji: preparingMuji,
     });
+    expect($mucCallParticipants.get()["room@muc.test"]).toEqual(["alice"]);
+  });
+
+  test("plain same-nick sibling clear preserves the exact active owner", () => {
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/desktop",
+      muji: activeMuji,
+    });
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/mobile",
+    });
+    expect($mucCallParticipants.get()["room@muc.test"]).toEqual(["alice"]);
+
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/desktop",
+    });
     expect($mucCallParticipants.get()["room@muc.test"]).toBeUndefined();
+  });
+
+  test("clearing one active same-nick owner preserves another active owner", () => {
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/desktop",
+      muji: activeMuji,
+    });
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/mobile",
+      muji: activeMuji,
+    });
+
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/desktop",
+    });
+    expect($mucCallParticipants.get()["room@muc.test"]).toEqual(["alice"]);
+
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/mobile",
+    });
+    expect($mucCallParticipants.get()["room@muc.test"]).toBeUndefined();
+  });
+
+  test("local exact clear preserves active same-nick siblings", () => {
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/desktop",
+      muji: activeMuji,
+    });
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/mobile",
+      muji: activeMuji,
+    });
+
+    clearMucCallParticipant("room@muc.test", "alice", "alice@waddle.test/desktop");
+    expect($mucCallParticipants.get()["room@muc.test"]).toEqual(["alice"]);
+
+    clearMucCallParticipant("room@muc.test", "alice", "alice@waddle.test/mobile");
+    expect($mucCallParticipants.get()["room@muc.test"]).toBeUndefined();
+  });
+
+  test("departed active same-nick resource clears before preparing sibling replay", () => {
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/desktop",
+      muji: activeMuji,
+    });
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/mobile",
+      muji: preparingMuji,
+    });
+    expect($mucCallParticipants.get()["room@muc.test"]).toEqual(["alice"]);
+
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/desktop",
+    });
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/mobile",
+      muji: preparingMuji,
+    });
+
+    expect($mucCallParticipants.get()["room@muc.test"]).toBeUndefined();
+  });
+
+  test("active+preparing Muji counts as active while preserving the setup signal", () => {
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muji: activePreparingMuji,
+    });
+    expect($mucCallParticipants.get()["room@muc.test"]).toEqual(["alice"]);
   });
 
   test("available presence WITHOUT the Muji extension removes a previously-registered nick (XEP-0272 §Leaving)", () => {
@@ -265,9 +379,40 @@ describe("awaitPreparingEcho (XEP-0272 §Joining MUST)", () => {
     expect(aliceResolved).toBe(true);
   });
 
-  test("does NOT resolve on a content (active) presence — preparing-only is the trigger", async () => {
-    // A content presence is NOT a preparing echo; the waiter must
-    // continue to block until the MUC echoes preparing.
+  test("does NOT resolve on a same-nick sibling resource's preparing echo", async () => {
+    const aliceWait = awaitPreparingEcho(
+      "room@muc.test",
+      "alice",
+      200,
+      "alice@waddle.test/web",
+    );
+    let aliceResolved = false;
+    void aliceWait.then(() => {
+      aliceResolved = true;
+    }).catch(() => undefined);
+
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/mobile",
+      muji: preparingMuji,
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(aliceResolved).toBe(false);
+
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/web",
+      muji: preparingMuji,
+    });
+    await aliceWait;
+    expect(aliceResolved).toBe(true);
+  });
+
+  test("does NOT resolve on a content-only presence", async () => {
+    // A content-only presence is NOT a preparing echo; the waiter
+    // must continue to block until the MUC echoes preparing.
     const wait = awaitPreparingEcho("room@muc.test", "alice", 200);
     let resolved = false;
     void wait.then(() => {
@@ -283,11 +428,187 @@ describe("awaitPreparingEcho (XEP-0272 §Joining MUST)", () => {
     await expect(wait).rejects.toThrow("Timed out waiting for Muji preparing presence echo");
   });
 
+  test("resolves on active+preparing presence because preparing remains the setup signal", async () => {
+    const wait = awaitPreparingEcho(
+      "room@muc.test",
+      "alice",
+      200,
+      "alice@waddle.test/web",
+    );
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/web",
+      muji: activePreparingMuji,
+    });
+    await wait;
+  });
+
   test("rejects on timeout when no echo arrives", async () => {
     // Missing preparing echo is fatal for strict XEP-0272 setup:
     // beginMucCall must roll back instead of proceeding with room
     // state the MUC never reflected.
     await expect(awaitPreparingEcho("room@muc.test/nobody", "alice", 50))
       .rejects.toThrow("Timed out waiting for Muji preparing presence echo");
+  });
+});
+
+describe("awaitNoOtherPreparing", () => {
+  test("same-nick sibling resources still count as other preparing participants", async () => {
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/mobile",
+      muji: preparingMuji,
+    });
+
+    const wait = awaitNoOtherPreparing(
+      "room@muc.test",
+      "alice",
+      200,
+      "alice@waddle.test/web",
+    );
+    let resolved = false;
+    void wait.then(() => {
+      resolved = true;
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(resolved).toBe(false);
+
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/mobile",
+      muji: activeMuji,
+    });
+
+    await wait;
+    expect(resolved).toBe(true);
+  });
+
+  test("active+preparing same-nick sibling remains a blocker until preparing clears", async () => {
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/mobile",
+      muji: activePreparingMuji,
+    });
+
+    const wait = awaitNoOtherPreparing(
+      "room@muc.test",
+      "alice",
+      200,
+      "alice@waddle.test/web",
+    );
+    let resolved = false;
+    void wait.then(() => {
+      resolved = true;
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(resolved).toBe(false);
+    expect($mucCallParticipants.get()["room@muc.test"]).toEqual(["alice"]);
+
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/mobile",
+      muji: activeMuji,
+    });
+
+    await wait;
+    expect(resolved).toBe(true);
+  });
+
+  test("plain same-nick sibling presence does not clear active+preparing owner", async () => {
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/mobile",
+      muji: activePreparingMuji,
+    });
+
+    const wait = awaitNoOtherPreparing(
+      "room@muc.test",
+      "carol",
+      200,
+      "carol@waddle.test/web",
+    );
+    let resolved = false;
+    void wait.then(() => {
+      resolved = true;
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(resolved).toBe(false);
+
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/desktop",
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(resolved).toBe(false);
+
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/mobile",
+      muji: activeMuji,
+    });
+
+    await wait;
+    expect(resolved).toBe(true);
+  });
+
+  test("active+preparing exact owner leaves sibling preparing blockers intact", async () => {
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/mobile",
+      muji: preparingMuji,
+    });
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/tablet",
+      muji: preparingMuji,
+    });
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/mobile",
+      muji: activePreparingMuji,
+    });
+
+    const wait = awaitNoOtherPreparing(
+      "room@muc.test",
+      "carol",
+      200,
+      "carol@waddle.test/web",
+    );
+    let resolved = false;
+    void wait.then(() => {
+      resolved = true;
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(resolved).toBe(false);
+
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/tablet",
+      muji: activeMuji,
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(resolved).toBe(false);
+
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/mobile",
+      muji: activeMuji,
+    });
+
+    await wait;
+    expect(resolved).toBe(true);
   });
 });

--- a/chat/tests/offline-queue.test.ts
+++ b/chat/tests/offline-queue.test.ts
@@ -176,6 +176,7 @@ describe("offline outbound queue replay", () => {
     (client as unknown as { xmpp: typeof xmpp; connected: boolean; currentRoom: string | null }).connected = true;
     (client as unknown as { xmpp: typeof xmpp; connected: boolean; currentRoom: string | null }).currentRoom =
       roomJid;
+    (client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.add(roomJid);
     (client as unknown as { wireEvents: (x: typeof xmpp) => void }).wireEvents(xmpp);
 
     await (client as unknown as { flushQueuedRoomMessages: (roomJid: string) => Promise<void> }).flushQueuedRoomMessages(roomJid);

--- a/chat/tests/use-active-muc-call.test.ts
+++ b/chat/tests/use-active-muc-call.test.ts
@@ -5,7 +5,7 @@ import {
   clearMucCallParticipants,
 } from "../src/lib/calls/muc-call-presence";
 import { connectionStore } from "../src/lib/connection-store";
-import { readActiveMucCall } from "../src/lib/calls/use-active-muc-call";
+import { readActiveMucCall, readRoomHasActiveCall } from "../src/lib/calls/use-active-muc-call";
 import type { CallMedia, LiveKitJoin } from "../src/lib/calls/types";
 import type { WaddleSession } from "../src/lib/server-auth";
 
@@ -141,5 +141,96 @@ describe("readActiveMucCall selector", () => {
     });
     $mucCallParticipants.set({ [ROOM]: ["alice"] });
     expect(readActiveMucCall().selfInCall).toBe(false);
+  });
+});
+
+describe("readRoomHasActiveCall selector", () => {
+  beforeEach(() => {
+    $callState.set({ phase: "idle" });
+    clearMucCallParticipants();
+    setSession(null);
+  });
+
+  afterEach(() => {
+    $callState.set({ phase: "idle" });
+    clearMucCallParticipants();
+    setSession(null);
+  });
+
+  test("reports a room call from Muji presence even when local call state is idle", () => {
+    setSession("carol");
+    $callState.set({ phase: "idle" });
+    $mucCallParticipants.set({ [ROOM]: ["alice", "bob"] });
+
+    expect(readRoomHasActiveCall(ROOM)).toEqual({
+      hasActiveCall: true,
+      selfInCall: false,
+      localResourceInCall: false,
+      participantCount: 2,
+    });
+  });
+
+  test("distinguishes same-nick presence from this browser resource being in media", () => {
+    setSession("alice");
+    $callState.set({ phase: "idle" });
+    $mucCallParticipants.set({ [ROOM]: ["alice", "bob"] });
+
+    expect(readRoomHasActiveCall(ROOM)).toEqual({
+      hasActiveCall: true,
+      selfInCall: true,
+      localResourceInCall: false,
+      participantCount: 2,
+    });
+  });
+
+  test("reports localResourceInCall when this browser owns the active MUC call", () => {
+    setSession("alice");
+    $callState.set({
+      phase: "active",
+      kind: "muc",
+      peer: ROOM,
+      sid: "c1",
+      media: audioVideo,
+      join,
+      selfNick: "alice",
+    });
+    $mucCallParticipants.set({ [ROOM]: ["alice", "bob"] });
+
+    expect(readRoomHasActiveCall(ROOM)).toEqual({
+      hasActiveCall: true,
+      selfInCall: true,
+      localResourceInCall: true,
+      participantCount: 2,
+    });
+  });
+
+  test("normalizes resource-suffixed room JIDs", () => {
+    setSession("alice");
+    $mucCallParticipants.set({ [ROOM]: ["bob"] });
+
+    expect(readRoomHasActiveCall(`${ROOM}/alice`)).toEqual({
+      hasActiveCall: true,
+      selfInCall: false,
+      localResourceInCall: false,
+      participantCount: 1,
+    });
+  });
+
+  test("treats missing or empty rooms as no active call", () => {
+    setSession("alice");
+    $mucCallParticipants.set({ [ROOM]: ["alice"] });
+
+    expect(readRoomHasActiveCall("")).toEqual({
+      hasActiveCall: false,
+      selfInCall: false,
+      localResourceInCall: false,
+      participantCount: 0,
+    });
+    expect(readRoomHasActiveCall("other@muc.waddle.test")).toEqual({
+      hasActiveCall: false,
+      selfInCall: false,
+      localResourceInCall: false,
+      participantCount: 0,
+    });
   });
 });

--- a/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
@@ -3,7 +3,18 @@ use super::{
     replay::drain_outbound_into_replay, state::WsConnState, stream_management::sm_show_from_name,
 };
 use waddle_xmpp::muc::room_actor::LeaveOutcome;
+use waddle_xmpp::xep::xep0272::Muji;
 use waddle_xmpp::xep::xep0421::OccupantIdentity;
+
+fn muji_reflection_rank(muji: &Muji) -> u8 {
+    if muji.is_empty() {
+        0
+    } else if muji.is_active() {
+        2
+    } else {
+        1
+    }
+}
 
 /// Broadcast a `<presence type='unavailable'/>` from the leaving
 /// occupant's room-nick JID to every remaining occupant when their
@@ -57,45 +68,59 @@ pub(crate) fn broadcast_muc_leave_to_remaining(
     }
 }
 
-/// Broadcast a canonical available room/nick presence without
-/// `<muji/>` after the resource that owned the Muji state leaves
-/// while another same-nick session remains.
+/// Broadcast canonical available room/nick presence after one
+/// resource's Muji state changes while another same-nick session
+/// remains. Sibling Muji state is emitted under the exact full JID
+/// that owns it so resource-scoped XEP-0272 preparing state stays
+/// attributable.
 pub(crate) fn broadcast_muc_muji_clear_to_remaining(
     state: &WebSocketState,
     room_jid: &BareJid,
+    leaving_real_jid: &FullJid,
     outcome: &LeaveOutcome,
 ) {
     if outcome.removed_last_session || !outcome.cleared_muji_state {
         return;
     }
-    let Some(real_jid) = outcome.remaining_nick_real_jid.as_ref() else {
-        return;
-    };
     let from_jid = room_jid
         .clone()
         .with_resource_str(&outcome.nick)
-        .unwrap_or_else(|_| real_jid.clone());
-    let real_bare = real_jid.to_bare();
-    let identity = OccupantIdentity {
-        bare_jid: &real_bare,
-        real_jid: Some(real_jid),
-        secret: &state.deps.occupant_id_secret,
-    };
+        .unwrap_or_else(|_| {
+            outcome
+                .remaining_nick_real_jid
+                .clone()
+                .unwrap_or_else(|| outcome.leaving_room_jid.clone())
+        });
+    let mut entries = Vec::with_capacity(outcome.remaining_muji_sessions.len() + 1);
+    entries.push((leaving_real_jid.clone(), Muji::default()));
+    entries.extend(outcome.remaining_muji_sessions.iter().cloned());
+    entries.sort_by_key(|(owner_jid, muji)| (muji_reflection_rank(muji), owner_jid.to_string()));
     for occupant_jid in &outcome.remaining_occupants {
-        let is_self = occupant_jid.to_bare() == real_bare;
-        let presence = waddle_xmpp::muc::build_occupant_presence(
-            &from_jid,
-            occupant_jid,
-            outcome.affiliation,
-            outcome.role,
-            is_self,
-            &identity,
-        );
-        let _ = state
-            .deps
-            .protocol
-            .connection_registry
-            .try_send_to(occupant_jid, Stanza::Presence(presence));
+        for (owner_jid, muji) in &entries {
+            let owner_bare = owner_jid.to_bare();
+            let identity = OccupantIdentity {
+                bare_jid: &owner_bare,
+                real_jid: Some(owner_jid),
+                secret: &state.deps.occupant_id_secret,
+            };
+            let is_self = occupant_jid.to_bare() == owner_bare;
+            let mut presence = waddle_xmpp::muc::build_occupant_presence(
+                &from_jid,
+                occupant_jid,
+                outcome.affiliation,
+                outcome.role,
+                is_self,
+                &identity,
+            );
+            if !muji.is_empty() {
+                presence.payloads.push(muji.to_element());
+            }
+            let _ = state
+                .deps
+                .protocol
+                .connection_registry
+                .try_send_to(occupant_jid, Stanza::Presence(presence));
+        }
     }
 }
 
@@ -388,7 +413,7 @@ async fn cleanup_muc_presence(state: &WebSocketState, jid: &FullJid) {
                 // wire shape is identical regardless of how the
                 // session ended.
                 broadcast_muc_leave_to_remaining(state, &room_jid, jid, &outcome);
-                broadcast_muc_muji_clear_to_remaining(state, &room_jid, &outcome);
+                broadcast_muc_muji_clear_to_remaining(state, &room_jid, jid, &outcome);
                 maybe_evict_empty_room(state, &room_jid, &outcome).await;
             }
             Ok(None) => {}

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -227,13 +227,20 @@ pub async fn handle_muc_join(
 
     let mut responses = Vec::new();
 
-    // Replay one occupant presence per nick to the joiner. Same-bare multi-session
-    // joins must not turn into duplicate room occupants on the wire.
+    // Replay one base occupant presence per nick to the joiner, then
+    // append extra same-nick Muji payloads for additional sessions
+    // that own call state. Active call membership is nick-level, but
+    // XEP-0272 preparing is resource-owned coordination state, so the
+    // joiner needs the exact full JID that advertised it.
     let mut replayed_nicks = std::collections::HashSet::new();
-    for existing in join_outcome
+    let replay_occupants: Vec<_> = join_outcome
         .existing_occupants
         .iter()
         .filter(|existing| existing.nick != nick)
+        .collect();
+    for existing in replay_occupants
+        .iter()
+        .copied()
         .filter(|existing| replayed_nicks.insert(existing.nick.clone()))
     {
         // XEP-0045 §7.2 conformant occupant-list replay, plus the
@@ -254,6 +261,24 @@ pub async fn handle_muc_join(
             include_self_status: false,
             muji: existing.muji.as_ref(),
         }));
+
+        for extra in replay_occupants.iter().copied().filter(|candidate| {
+            candidate.nick == existing.nick
+                && candidate.jid != existing.jid
+                && candidate.muji.is_some()
+        }) {
+            responses.push(build_muc_join_presence_xml(MucJoinPresence {
+                occupant_id_secret: &state.deps.occupant_id_secret,
+                room_jid,
+                nick: &extra.nick,
+                to_jid: sender_jid,
+                affiliation: extra.affiliation,
+                role: extra.role,
+                real_jid: &extra.jid,
+                include_self_status: false,
+                muji: extra.muji.as_ref(),
+            }));
+        }
     }
 
     // Broadcast the new occupant's presence to all existing occupants.
@@ -292,10 +317,33 @@ pub async fn handle_muc_join(
         role: join_outcome.new_occupant_role,
         real_jid: sender_jid,
         include_self_status: true,
-        // Fresh join has no active call advertisement of its own —
-        // the joiner has not yet asserted one.
         muji: None,
     }));
+
+    // Same-account sibling resources share one MUC nick. If a
+    // sibling already advertised Muji for this nick, reflect exact
+    // per-session snapshots after the new session's own plain
+    // self-presence so a refresh/new tab can show "call active on
+    // another device" without misattributing `<preparing/>` to the
+    // joining resource.
+    for existing in join_outcome.existing_occupants.iter().filter(|existing| {
+        existing.nick == nick
+            && existing.jid.to_bare() == sender_jid.to_bare()
+            && existing.jid != *sender_jid
+            && existing.muji.is_some()
+    }) {
+        responses.push(build_muc_join_presence_xml(MucJoinPresence {
+            occupant_id_secret: &state.deps.occupant_id_secret,
+            room_jid,
+            nick,
+            to_jid: sender_jid,
+            affiliation: existing.affiliation,
+            role: existing.role,
+            real_jid: &existing.jid,
+            include_self_status: true,
+            muji: existing.muji.as_ref(),
+        }));
+    }
 
     // XEP-0045 §7.2.15 historical room subject. The typed builder
     // produces the conformant envelope: nick-form `from` + `<delay/>`
@@ -394,7 +442,9 @@ pub async fn handle_muc_leave(
     super::super::super::cleanup::broadcast_muc_leave_to_remaining(
         state, room_jid, sender_jid, &outcome,
     );
-    super::super::super::cleanup::broadcast_muc_muji_clear_to_remaining(state, room_jid, &outcome);
+    super::super::super::cleanup::broadcast_muc_muji_clear_to_remaining(
+        state, room_jid, sender_jid, &outcome,
+    );
 
     let response = vec![build_muc_self_unavailable_xml(
         state,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
@@ -59,6 +59,48 @@ pub(super) fn extract_muji(presence: &Presence) -> Option<Muji> {
         .and_then(|elem| Muji::try_from(elem).ok())
 }
 
+#[derive(Debug, Clone, Copy)]
+struct ReflectedMujiEntry<'a> {
+    owner_jid: &'a FullJid,
+    muji: Option<&'a Muji>,
+}
+
+fn muji_reflection_rank(muji: Option<&Muji>) -> u8 {
+    match muji {
+        None => 0,
+        Some(muji) if muji.is_empty() => 0,
+        Some(muji) if muji.is_active() => 2,
+        Some(_) => 1,
+    }
+}
+
+fn reflected_muji_entries<'a>(
+    sender_jid: &'a FullJid,
+    sender_muji: Option<&'a Muji>,
+    session_mujis: &'a [(FullJid, Muji)],
+) -> Vec<ReflectedMujiEntry<'a>> {
+    let mut entries = vec![ReflectedMujiEntry {
+        owner_jid: sender_jid,
+        muji: sender_muji,
+    }];
+    entries.extend(
+        session_mujis
+            .iter()
+            .filter(|(owner_jid, _)| owner_jid != sender_jid)
+            .map(|(owner_jid, muji)| ReflectedMujiEntry {
+                owner_jid,
+                muji: Some(muji),
+            }),
+    );
+    entries.sort_by_key(|entry| {
+        (
+            muji_reflection_rank(entry.muji),
+            entry.owner_jid.to_string(),
+        )
+    });
+    entries
+}
+
 /// Try to broadcast an in-room presence update for an existing
 /// occupant. Returns `Some(replies)` when the room actor confirmed
 /// the sender is already an occupant — even if there's nothing to
@@ -139,6 +181,7 @@ pub(super) async fn try_handle_muc_presence_update(
         room = %room_jid,
         nick = %outcome.update.sender_nick,
         active = outcome.active_muji.is_some(),
+        session_mujis = outcome.session_mujis.len(),
         recipients = outcome.update.recipients.len(),
         "Broadcasting MUC Muji presence update"
     );
@@ -147,12 +190,11 @@ pub(super) async fn try_handle_muc_presence_update(
         .clone()
         .with_resource_str(&outcome.update.sender_nick)
         .unwrap_or_else(|_| sender_jid.clone());
-    let real_bare = sender_jid.to_bare();
-    let identity = OccupantIdentity {
-        bare_jid: &real_bare,
-        real_jid: Some(sender_jid),
-        secret: &state.deps.occupant_id_secret,
-    };
+    let reflected_entries = reflected_muji_entries(
+        sender_jid,
+        outcome.sender_muji.as_ref(),
+        &outcome.session_mujis,
+    );
 
     // Author the canonical presence the server will reflect. Built
     // ONCE here, cloned per recipient for the self vs other status
@@ -163,56 +205,50 @@ pub(super) async fn try_handle_muc_presence_update(
     // bogus `<x xmlns='muc#user'>` items.
     let mut responses = Vec::new();
     for recipient in &outcome.update.recipients {
-        // XEP-0045 §7.1: every session sharing the sender's occupant
-        // nick must receive a presence stamped with `<status code='110'/>`,
-        // not just the exact full JID that emitted the stanza. The
-        // occupant_sessions table is keyed by nick and holds every
-        // active full JID under that nick, so a same-bare multi-
-        // session join (Alice on web AND mobile) needs `is_self` for
-        // BOTH recipients when Alice updates her presence from web.
-        let is_self = recipient.to_bare() == sender_jid.to_bare();
-        // `is_self` covers stanza SHAPE (status-110 stamping). The
-        // delivery CHANNEL is a separate question: only the exact
-        // full JID that emitted this presence shares the inbound
-        // WebSocket, so only that recipient can be returned via the
-        // `responses` vec. Every other recipient — including a
-        // sibling resource of the same bare JID, which is on a
-        // different WebSocket — must be dispatched through the
-        // cross-session connection registry, otherwise the sibling
-        // never receives the Muji reflection and its "call ongoing"
-        // indicator never lights up.
-        let is_sender_session = recipient == sender_jid;
-        let mut presence = build_occupant_presence_update(
-            incoming,
-            &from_room_jid,
-            recipient,
-            outcome.update.sender_affiliation,
-            outcome.update.sender_role,
-            is_self,
-            &identity,
-        );
+        for entry in &reflected_entries {
+            // XEP-0045 §7.1: sessions sharing the owner bare JID
+            // receive status-110 for that occupant presence. Muji
+            // preparing state remains resource-owned, so reflections
+            // use the exact session JID that owns each `<muji/>`.
+            let owner_bare = entry.owner_jid.to_bare();
+            let identity = OccupantIdentity {
+                bare_jid: &owner_bare,
+                real_jid: Some(entry.owner_jid),
+                secret: &state.deps.occupant_id_secret,
+            };
+            let is_self = recipient.to_bare() == owner_bare;
+            let mut presence = build_occupant_presence_update(
+                incoming,
+                &from_room_jid,
+                recipient,
+                outcome.update.sender_affiliation,
+                outcome.update.sender_role,
+                is_self,
+                &identity,
+            );
 
-        // If the actor cleared the Muji state (participant left the
-        // call), the client's `<muji/>` element WAS preserved by
-        // `build_occupant_presence_update`'s clone — but the room's
-        // authoritative view says no call is active. Strip the
-        // extension so the wire reflects the persisted state, not
-        // the client's transitional message.
-        if outcome.active_muji.is_none() {
+            // Replace the client-authored `<muji/>` with the room
+            // actor's authoritative per-session state. A `None` entry
+            // is still the sender's exact clear marker; sibling Muji
+            // entries then preserve any remaining preparing/active
+            // state under their real full JID.
             presence
                 .payloads
                 .retain(|payload| !(payload.name() == "muji" && payload.ns() == NS_MUJI));
-        }
+            if let Some(muji) = entry.muji {
+                presence.payloads.push(muji.to_element());
+            }
 
-        if is_sender_session {
-            responses.push(stanza_to_xml(&Stanza::Presence(presence)));
-        } else {
-            let stanza = Stanza::Presence(presence);
-            let _ = state
-                .deps
-                .protocol
-                .connection_registry
-                .try_send_to(recipient, stanza);
+            if recipient == sender_jid {
+                responses.push(stanza_to_xml(&Stanza::Presence(presence)));
+            } else {
+                let stanza = Stanza::Presence(presence);
+                let _ = state
+                    .deps
+                    .protocol
+                    .connection_registry
+                    .try_send_to(recipient, stanza);
+            }
         }
     }
 
@@ -290,5 +326,56 @@ mod tests {
         presence.payloads.push(muji);
         assert!(extract_muji(&presence).is_none());
         let _ = NS_MUJI; // import sanity
+    }
+
+    #[test]
+    fn reflected_muji_entries_preserve_sibling_preparing_after_sender_clear() {
+        let sender: FullJid = "alice@example.com/mobile".parse().expect("sender");
+        let sibling: FullJid = "alice@example.com/desktop".parse().expect("sibling");
+        let session_mujis = vec![(sibling.clone(), Muji::preparing())];
+        let entries = reflected_muji_entries(&sender, None, &session_mujis);
+
+        assert_eq!(entries.len(), 2);
+        assert!(
+            entries[0].owner_jid == &sender && entries[0].muji.is_none(),
+            "the sender's exact clear is emitted first"
+        );
+        assert!(
+            entries[1].owner_jid == &sibling
+                && entries[1]
+                    .muji
+                    .is_some_and(|muji| muji.preparing && !muji.is_active()),
+            "remaining sibling preparing state is preserved with its exact owner"
+        );
+    }
+
+    #[test]
+    fn reflected_muji_entries_preserve_sender_and_sibling_state() {
+        let sender: FullJid = "alice@example.com/mobile".parse().expect("sender");
+        let sibling: FullJid = "alice@example.com/desktop".parse().expect("sibling");
+        let preparing = Muji::preparing();
+        let active = extract_muji(&presence_with_muji_contents()).expect("active fixture parses");
+        let session_mujis = vec![(sender.clone(), preparing.clone()), (sibling, active)];
+        let entries = reflected_muji_entries(&sender, Some(&preparing), &session_mujis);
+
+        assert_eq!(entries.len(), 2);
+        assert!(entries[0].muji.is_some_and(|muji| muji.preparing));
+        assert!(entries[1].muji.is_some_and(Muji::is_active));
+    }
+
+    #[test]
+    fn reflected_muji_entries_emit_active_state_last_for_legacy_clients() {
+        let sender: FullJid = "alice@example.com/web".parse().expect("sender");
+        let sibling: FullJid = "alice@example.com/zphone".parse().expect("sibling");
+        let active = extract_muji(&presence_with_muji_contents()).expect("active fixture parses");
+        let preparing = Muji::preparing();
+        let session_mujis = vec![(sender.clone(), active.clone()), (sibling, preparing)];
+        let entries = reflected_muji_entries(&sender, Some(&active), &session_mujis);
+
+        assert_eq!(entries.len(), 2);
+        assert!(
+            entries.last().is_some_and(|entry| entry.muji.is_some_and(Muji::is_active)),
+            "the final same-nick stanza must carry active Muji so non-occupant-id clients do not settle on preparing"
+        );
     }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -991,6 +991,18 @@ fn active_muji() -> waddle_xmpp::xep::xep0272::Muji {
     )])
 }
 
+fn preparing_muji() -> waddle_xmpp::xep::xep0272::Muji {
+    waddle_xmpp::xep::xep0272::Muji::preparing()
+}
+
+fn muc_user_item_jid(element: &Element) -> Option<String> {
+    element
+        .get_child("x", "http://jabber.org/protocol/muc#user")
+        .and_then(|x| x.get_child("item", "http://jabber.org/protocol/muc#user"))
+        .and_then(|item| item.attr("jid"))
+        .map(ToOwned::to_owned)
+}
+
 fn muc_presence_to(room_jid: &BareJid, nick: &str) -> xmpp_parsers::presence::Presence {
     let mut presence = xmpp_parsers::presence::Presence::new(xmpp_parsers::presence::Type::None);
     presence.to = Some(
@@ -1123,6 +1135,244 @@ async fn available_presence_without_muji_clears_existing_muji_state() {
 }
 
 #[tokio::test]
+async fn same_nick_late_join_replays_existing_muji_with_exact_owner() {
+    let state = create_test_websocket_state().await;
+    let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let room_jid: BareJid = "same-nick-muji-replay@muc.example.com"
+        .parse()
+        .expect("room jid");
+    let desktop: FullJid = "alice@example.com/desktop".parse().expect("desktop jid");
+    let mobile: FullJid = "alice@example.com/mobile".parse().expect("mobile jid");
+
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &desktop,
+        "alice",
+        None,
+        &Some(owner_session.clone()),
+    )
+    .await;
+
+    let desktop_phase = waddle_xmpp::protocol::ConnectionPhase::ready(desktop.clone(), false);
+    let mut active = muc_presence_to(&room_jid, "alice");
+    active.payloads.push(active_muji().to_element());
+    let _ = handlers::presence::handle_presence(
+        active,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &desktop_phase,
+        &Some(owner_session),
+    )
+    .await;
+
+    let responses = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &mobile,
+        "alice",
+        None,
+        &None,
+    )
+    .await;
+
+    let sibling_muji_presence = responses
+        .iter()
+        .filter_map(|xml| Element::from_str(xml).ok())
+        .find(|element| {
+            element.attr("from") == Some(format!("{room_jid}/alice").as_str())
+                && element.attr("to") == Some(mobile.to_string().as_str())
+                && muc_user_item_jid(element).as_deref() == Some(desktop.to_string().as_str())
+                && element
+                    .get_child("muji", waddle_xmpp::xep::xep0272::NS_MUJI)
+                    .is_some()
+        })
+        .expect("mobile receives sibling Muji presence");
+
+    assert!(
+        sibling_muji_presence
+            .get_child("muji", waddle_xmpp::xep::xep0272::NS_MUJI)
+            .is_some(),
+        "same-nick sibling join must replay the existing Muji advertisement under the sibling JID"
+    );
+}
+
+#[tokio::test]
+async fn same_nick_late_join_replays_preparing_only_muji_with_exact_owner() {
+    let state = create_test_websocket_state().await;
+    let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let room_jid: BareJid = "same-nick-preparing-replay@muc.example.com"
+        .parse()
+        .expect("room jid");
+    let desktop: FullJid = "alice@example.com/desktop".parse().expect("desktop jid");
+    let mobile: FullJid = "alice@example.com/mobile".parse().expect("mobile jid");
+    let bob: FullJid = "bob@example.com/desktop".parse().expect("bob jid");
+
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &desktop,
+        "alice",
+        None,
+        &Some(owner_session.clone()),
+    )
+    .await;
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &mobile,
+        "alice",
+        None,
+        &None,
+    )
+    .await;
+
+    let mobile_phase = waddle_xmpp::protocol::ConnectionPhase::ready(mobile.clone(), false);
+    let mut preparing = muc_presence_to(&room_jid, "alice");
+    preparing.payloads.push(preparing_muji().to_element());
+    let _ = handlers::presence::handle_presence(
+        preparing,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &mobile_phase,
+        &Some(owner_session),
+    )
+    .await;
+
+    let responses = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &bob,
+        "bob",
+        None,
+        &None,
+    )
+    .await;
+
+    let replay = responses
+        .iter()
+        .filter_map(|xml| Element::from_str(xml).ok())
+        .find(|element| {
+            element.attr("from") == Some(format!("{room_jid}/alice").as_str())
+                && element.attr("to") == Some(bob.to_string().as_str())
+                && muc_user_item_jid(element).as_deref() == Some(mobile.to_string().as_str())
+                && element
+                    .get_child("muji", waddle_xmpp::xep::xep0272::NS_MUJI)
+                    .is_some()
+        })
+        .expect("bob receives mobile's preparing replay");
+
+    let muji = replay
+        .get_child("muji", waddle_xmpp::xep::xep0272::NS_MUJI)
+        .and_then(|element| waddle_xmpp::xep::xep0272::Muji::try_from(element).ok())
+        .expect("Muji parses");
+    assert!(muji.preparing);
+    assert!(!muji.is_active());
+}
+
+#[tokio::test]
+async fn same_nick_plain_presence_preserves_sibling_preparing_owner() {
+    let state = create_test_websocket_state().await;
+    let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let room_jid: BareJid = "same-nick-preparing-clear@muc.example.com"
+        .parse()
+        .expect("room jid");
+    let desktop: FullJid = "alice@example.com/desktop".parse().expect("desktop jid");
+    let mobile: FullJid = "alice@example.com/mobile".parse().expect("mobile jid");
+    let bob: FullJid = "bob@example.com/desktop".parse().expect("bob jid");
+
+    let (bob_tx, mut bob_rx) = mpsc::channel::<OutboundStanza>(8);
+    state
+        .deps
+        .protocol
+        .connection_registry
+        .register(bob.clone(), bob_tx);
+
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &desktop,
+        "alice",
+        None,
+        &Some(owner_session.clone()),
+    )
+    .await;
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &mobile,
+        "alice",
+        None,
+        &None,
+    )
+    .await;
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &bob,
+        "bob",
+        None,
+        &None,
+    )
+    .await;
+    while bob_rx.try_recv().is_ok() {}
+
+    let desktop_phase = waddle_xmpp::protocol::ConnectionPhase::ready(desktop.clone(), false);
+    let mut preparing = muc_presence_to(&room_jid, "alice");
+    preparing.payloads.push(preparing_muji().to_element());
+    let _ = handlers::presence::handle_presence(
+        preparing,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &desktop_phase,
+        &Some(owner_session),
+    )
+    .await;
+    while bob_rx.try_recv().is_ok() {}
+
+    let mobile_phase = waddle_xmpp::protocol::ConnectionPhase::ready(mobile.clone(), false);
+    let plain_available = muc_presence_to(&room_jid, "alice");
+    let _ = handlers::presence::handle_presence(
+        plain_available,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &mobile_phase,
+        &None,
+    )
+    .await;
+
+    let mut saw_desktop_preparing = false;
+    while let Ok(outbound) = bob_rx.try_recv() {
+        let xml = stanza_to_xml(&outbound.stanza);
+        let presence = Element::from_str(&xml).expect("presence XML");
+        if muc_user_item_jid(&presence).as_deref() == Some(desktop.to_string().as_str())
+            && presence
+                .get_child("muji", waddle_xmpp::xep::xep0272::NS_MUJI)
+                .is_some()
+        {
+            saw_desktop_preparing = true;
+        }
+    }
+
+    assert!(
+        saw_desktop_preparing,
+        "plain presence from one same-nick resource must preserve a sibling's preparing state under the sibling JID"
+    );
+}
+
+#[tokio::test]
 async fn same_nick_originator_leave_broadcasts_muji_clear() {
     let state = create_test_websocket_state().await;
     let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
@@ -1221,6 +1471,127 @@ async fn same_nick_originator_leave_broadcasts_muji_clear() {
     assert_eq!(room.find_nick_by_real_jid(&mobile), Some("alice"));
     assert!(room.find_nick_by_real_jid(&desktop).is_none());
     assert!(room.muji_for_nick("alice").is_none());
+}
+
+#[tokio::test]
+async fn same_nick_active_leave_broadcasts_departed_clear_before_preparing_sibling() {
+    let state = create_test_websocket_state().await;
+    let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let room_jid: BareJid = "same-nick-active-preparing-leave@muc.example.com"
+        .parse()
+        .expect("room jid");
+    let desktop: FullJid = "alice@example.com/desktop".parse().expect("desktop jid");
+    let mobile: FullJid = "alice@example.com/mobile".parse().expect("mobile jid");
+    let bob: FullJid = "bob@example.com/desktop".parse().expect("bob jid");
+
+    let (bob_tx, mut bob_rx) = mpsc::channel::<OutboundStanza>(8);
+    state
+        .deps
+        .protocol
+        .connection_registry
+        .register(bob.clone(), bob_tx);
+
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &desktop,
+        "alice",
+        None,
+        &Some(owner_session.clone()),
+    )
+    .await;
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &mobile,
+        "alice",
+        None,
+        &None,
+    )
+    .await;
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &bob,
+        "bob",
+        None,
+        &None,
+    )
+    .await;
+    while bob_rx.try_recv().is_ok() {}
+
+    let desktop_phase = waddle_xmpp::protocol::ConnectionPhase::ready(desktop.clone(), false);
+    let mut active = muc_presence_to(&room_jid, "alice");
+    active.payloads.push(active_muji().to_element());
+    let _ = handlers::presence::handle_presence(
+        active,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &desktop_phase,
+        &Some(owner_session.clone()),
+    )
+    .await;
+    while bob_rx.try_recv().is_ok() {}
+
+    let mobile_phase = waddle_xmpp::protocol::ConnectionPhase::ready(mobile.clone(), false);
+    let mut preparing = muc_presence_to(&room_jid, "alice");
+    preparing.payloads.push(preparing_muji().to_element());
+    let _ = handlers::presence::handle_presence(
+        preparing,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &mobile_phase,
+        &Some(owner_session),
+    )
+    .await;
+    while bob_rx.try_recv().is_ok() {}
+
+    let _ = handle_muc_leave(state.as_ref(), &room_jid, &desktop, "alice").await;
+
+    let clear_xml = stanza_to_xml(
+        &bob_rx
+            .try_recv()
+            .expect("Bob receives departed desktop clear")
+            .stanza,
+    );
+    let clear = Element::from_str(&clear_xml).expect("desktop clear presence XML");
+    assert_eq!(
+        muc_user_item_jid(&clear).as_deref(),
+        Some(desktop.to_string().as_str())
+    );
+    assert!(
+        clear
+            .get_child("muji", waddle_xmpp::xep::xep0272::NS_MUJI)
+            .is_none(),
+        "departed active resource must be explicitly cleared before sibling replay"
+    );
+
+    let preparing_xml = stanza_to_xml(
+        &bob_rx
+            .try_recv()
+            .expect("Bob receives remaining mobile preparing replay")
+            .stanza,
+    );
+    let preparing = Element::from_str(&preparing_xml).expect("mobile preparing presence XML");
+    assert_eq!(
+        muc_user_item_jid(&preparing).as_deref(),
+        Some(mobile.to_string().as_str())
+    );
+    let muji = preparing
+        .get_child("muji", waddle_xmpp::xep::xep0272::NS_MUJI)
+        .and_then(|element| waddle_xmpp::xep::xep0272::Muji::try_from(element).ok())
+        .expect("remaining sibling Muji parses");
+    assert!(muji.preparing);
+    assert!(!muji.is_active());
+    assert!(
+        bob_rx.try_recv().is_err(),
+        "only departed clear plus remaining sibling replay should be broadcast"
+    );
 }
 
 /// XEP-0045 slice-2b ingest: a successful `handle_muc_join` MUST

--- a/server/crates/waddle-xmpp-client-ffi/src/convert.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/convert.rs
@@ -337,6 +337,7 @@ pub(super) fn call_event_to_ffi(event: InboundCallEvent) -> WaddleCallEvent {
     };
     WaddleCallEvent {
         from: event.from.to_string(),
+        to: event.to.map(|jid| jid.to_string()),
         sid: event.sid.0,
         kind,
     }
@@ -394,6 +395,7 @@ fn archived_to_ffi(archived: waddle_xmpp_client::ArchivedMessage) -> WaddleArchi
         Some(MessagingEvent::Message(m)) => Some(m),
         _ => None,
     };
+    let call_event = messaging::parse_call_event(&archived.inner).map(call_event_to_ffi);
     let (fb_start, fb_end) = parsed
         .as_ref()
         .and_then(|m| m.reply_fallback)
@@ -431,6 +433,7 @@ fn archived_to_ffi(archived: waddle_xmpp_client::ArchivedMessage) -> WaddleArchi
                     .collect()
             })
             .unwrap_or_default(),
+        call_event,
     }
 }
 
@@ -555,6 +558,7 @@ mod tests {
         let parsed = messaging::parse_call_event(&stanza).expect("propose parses");
         let ffi = call_event_to_ffi(parsed);
         assert_eq!(ffi.from, "alice@waddle.test/desktop");
+        assert_eq!(ffi.to.as_deref(), Some("bob@waddle.test"));
         assert_eq!(ffi.sid, "c1");
         match ffi.kind {
             WaddleCallEventKind::Propose { media } => assert_audio_video(&media),
@@ -710,6 +714,44 @@ mod tests {
         match messaging::parse(&stanza) {
             Some(MessagingEvent::Message(msg)) => *msg,
             other => panic!("expected Message variant, got {other:?}"),
+        }
+    }
+
+    fn parse_mam_archived(xml: &str) -> waddle_xmpp_client::ArchivedMessage {
+        let stanza: Element = xml.parse().expect("fixture parses");
+        waddle_xmpp_client::mam::parse_mam_result(&stanza).expect("expected MAM result")
+    }
+
+    #[test]
+    fn archived_to_ffi_preserves_jmi_only_call_events_for_dm_reload() {
+        let archived = parse_mam_archived(
+            "<message xmlns='jabber:client'>\
+               <result xmlns='urn:xmpp:mam:2' id='mam-call' queryid='q1'>\
+                 <forwarded xmlns='urn:xmpp:forward:0'>\
+                   <delay xmlns='urn:xmpp:delay' stamp='2026-05-25T10:00:00Z'/>\
+                   <message xmlns='jabber:client' type='chat' id='call-propose' \
+                            from='bob@waddle.test/phone' to='alice@waddle.test/web'>\
+                     <propose xmlns='urn:xmpp:jingle-message:0' id='call-1'>\
+                       <description xmlns='urn:xmpp:jingle:apps:rtp:1' media='audio'/>\
+                     </propose>\
+                     <store xmlns='urn:xmpp:hints'/>\
+                   </message>\
+                 </forwarded>\
+               </result>\
+             </message>",
+        );
+
+        let ffi = archived_to_ffi(archived);
+        let call_event = ffi.call_event.expect("call event should be present");
+
+        assert_eq!(ffi.mam_id, "mam-call");
+        assert_eq!(ffi.body, None);
+        assert_eq!(call_event.from, "bob@waddle.test/phone");
+        assert_eq!(call_event.to.as_deref(), Some("alice@waddle.test/web"));
+        assert_eq!(call_event.sid, "call-1");
+        match call_event.kind {
+            WaddleCallEventKind::Propose { media } => assert!(media.audio),
+            other => panic!("expected Propose, got {other:?}"),
         }
     }
 

--- a/server/crates/waddle-xmpp-client-ffi/src/types.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/types.rs
@@ -79,6 +79,7 @@ pub struct WaddleArchivedMessage {
     pub reply_fallback_start: Option<u32>,
     pub reply_fallback_end: Option<u32>,
     pub shared_files: Vec<WaddleSharedFile>,
+    pub call_event: Option<WaddleCallEvent>,
 }
 
 #[derive(uniffi::Record, Clone)]
@@ -374,11 +375,13 @@ pub enum WaddleJingleReason {
 
 /// Typed A/V call event surfaced to Swift via `on_call(...)`.
 /// `from` is the stamped sender JID (a *full* JID for propose /
-/// session-initiate per XEP-0353 §0.6); `sid` is the Jingle
-/// session id used to correlate every later event in the call.
+/// session-initiate per XEP-0353 §0.6); `to` is the stamped stanza
+/// recipient when available; `sid` is the Jingle session id used to
+/// correlate every later event in the call.
 #[derive(uniffi::Record, Clone)]
 pub struct WaddleCallEvent {
     pub from: String,
+    pub to: Option<String>,
     pub sid: String,
     pub kind: WaddleCallEventKind,
 }

--- a/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
@@ -255,8 +255,12 @@ pub(crate) fn archived_to_js(archived: ArchivedMessage) -> Option<WaddleArchived
         .collect();
     let parsed = match messaging::parse(&archived.inner) {
         Some(waddle_xmpp_client::MessagingEvent::Message(message)) => Some(message),
-        _ => return None,
+        _ => None,
     };
+    let call_event = messaging::parse_call_event(&archived.inner).map(call_event_to_js);
+    if parsed.is_none() && call_event.is_none() {
+        return None;
+    }
     let (reply_fallback_start, reply_fallback_end) = parsed
         .as_ref()
         .and_then(|message| message.reply_fallback)
@@ -365,6 +369,7 @@ pub(crate) fn archived_to_js(archived: ArchivedMessage) -> Option<WaddleArchived
         extension_body_fallback: parsed
             .as_ref()
             .is_some_and(|message| message.extension_body_fallback),
+        call_event,
     })
 }
 
@@ -425,6 +430,7 @@ pub(crate) fn shared_file_to_js(file: messaging::SharedFile) -> WaddleSharedFile
 pub(crate) fn call_event_to_js(event: InboundCallEvent) -> WaddleCallEvent {
     use waddle_xmpp_client::messaging::CallEventKind;
     let from = event.from.to_string();
+    let to = event.to.map(|jid| jid.to_string());
     // The JS surface keeps `sid` as a plain string — boundary
     // serialization is the explicit I/O exception to the typed-
     // payloads rule. Convert the typed `SessionId` once here.
@@ -432,6 +438,7 @@ pub(crate) fn call_event_to_js(event: InboundCallEvent) -> WaddleCallEvent {
     match event.kind {
         CallEventKind::Propose { media } => WaddleCallEvent {
             from,
+            to,
             sid,
             kind: "propose",
             media: Some(WaddleCallMedia {
@@ -445,6 +452,7 @@ pub(crate) fn call_event_to_js(event: InboundCallEvent) -> WaddleCallEvent {
         },
         CallEventKind::Proceed => WaddleCallEvent {
             from,
+            to,
             sid,
             kind: "proceed",
             media: None,
@@ -455,6 +463,7 @@ pub(crate) fn call_event_to_js(event: InboundCallEvent) -> WaddleCallEvent {
         },
         CallEventKind::Reject { reason, tie_break } => WaddleCallEvent {
             from,
+            to,
             sid,
             kind: "reject",
             media: None,
@@ -466,6 +475,7 @@ pub(crate) fn call_event_to_js(event: InboundCallEvent) -> WaddleCallEvent {
         },
         CallEventKind::Retract { reason, tie_break } => WaddleCallEvent {
             from,
+            to,
             sid,
             kind: "retract",
             media: None,
@@ -480,6 +490,7 @@ pub(crate) fn call_event_to_js(event: InboundCallEvent) -> WaddleCallEvent {
             migrated_to,
         } => WaddleCallEvent {
             from,
+            to,
             sid,
             kind: "finish",
             media: None,
@@ -491,6 +502,7 @@ pub(crate) fn call_event_to_js(event: InboundCallEvent) -> WaddleCallEvent {
         },
         CallEventKind::SessionInitiate { join, media } => WaddleCallEvent {
             from,
+            to,
             sid,
             kind: "session-initiate",
             media: Some(WaddleCallMedia {
@@ -509,6 +521,7 @@ pub(crate) fn call_event_to_js(event: InboundCallEvent) -> WaddleCallEvent {
         },
         CallEventKind::SessionAccept { join, media } => WaddleCallEvent {
             from,
+            to,
             sid,
             kind: "session-accept",
             media: Some(WaddleCallMedia {
@@ -527,6 +540,7 @@ pub(crate) fn call_event_to_js(event: InboundCallEvent) -> WaddleCallEvent {
         },
         CallEventKind::SessionTerminate { reason } => WaddleCallEvent {
             from,
+            to,
             sid,
             kind: "session-terminate",
             media: None,
@@ -621,6 +635,18 @@ mod inbound_to_js_tests {
         messaging::parse_call_event(&stanza).expect("JMI event parses")
     }
 
+    fn parse_jmi_to(jmi: Element, to: &str) -> messaging::InboundCallEvent {
+        let stanza = Element::builder("message", "jabber:client")
+            .attr(
+                minidom::rxml::xml_ncname!("from").to_owned(),
+                "alice@waddle.test/desktop",
+            )
+            .attr(minidom::rxml::xml_ncname!("to").to_owned(), to)
+            .append(jmi)
+            .build();
+        messaging::parse_call_event(&stanza).expect("JMI event parses")
+    }
+
     fn parse_message_element(xml: &str) -> InboundMessage {
         let el: Element = xml.parse().expect("invalid XML");
         match messaging::parse(&el).expect("expected message") {
@@ -658,6 +684,17 @@ mod inbound_to_js_tests {
     }
 
     #[test]
+    fn call_event_to_js_preserves_jmi_to_peer() {
+        let propose = call_event_to_js(parse_jmi_to(
+            messaging::build_propose(&sid("c1"), messaging::CallMedia::audio_only()),
+            "bob@waddle.test/phone",
+        ));
+
+        assert_eq!(propose.kind, "propose");
+        assert_eq!(propose.to.as_deref(), Some("bob@waddle.test/phone"));
+    }
+
+    #[test]
     fn call_event_to_js_preserves_finish_migration_metadata() {
         let finish = call_event_to_js(parse_jmi(messaging::build_finish_migrated(
             &sid("old"),
@@ -668,6 +705,36 @@ mod inbound_to_js_tests {
         assert_eq!(finish.reason.as_deref(), Some("expired"));
         assert_eq!(finish.tie_break, None);
         assert_eq!(finish.migrated_to.as_deref(), Some("new"));
+    }
+
+    #[test]
+    fn archived_to_js_preserves_jmi_only_call_events_for_dm_reload() {
+        let archived = parse_mam_archived(
+            "<message xmlns='jabber:client'>\
+               <result xmlns='urn:xmpp:mam:2' id='mam-call' queryid='q1'>\
+                 <forwarded xmlns='urn:xmpp:forward:0'>\
+                   <delay xmlns='urn:xmpp:delay' stamp='2026-05-25T10:00:00Z'/>\
+                   <message xmlns='jabber:client' type='chat' id='call-propose' \
+                            from='bob@waddle.test/phone' to='alice@waddle.test/web'>\
+                     <propose xmlns='urn:xmpp:jingle-message:0' id='call-1'>\
+                       <description xmlns='urn:xmpp:jingle:apps:rtp:1' media='audio'/>\
+                     </propose>\
+                     <store xmlns='urn:xmpp:hints'/>\
+                   </message>\
+                 </forwarded>\
+               </result>\
+             </message>",
+        );
+
+        let js = archived_to_js(archived).expect("JMI-only MAM row should convert");
+
+        assert_eq!(js.mam_id, "mam-call");
+        assert_eq!(js.body, None);
+        let call_event = js.call_event.expect("call event should be present");
+        assert_eq!(call_event.kind, "propose");
+        assert_eq!(call_event.sid, "call-1");
+        assert_eq!(call_event.from, "bob@waddle.test/phone");
+        assert!(call_event.media.expect("media").audio);
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -207,6 +207,8 @@ pub struct WaddleArchivedMessage {
     pub shared_files: Vec<WaddleSharedFile>,
     pub extension_envelope: Option<WaddleExtensionEnvelope>,
     pub extension_body_fallback: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub call_event: Option<WaddleCallEvent>,
 }
 
 #[derive(Debug, Serialize)]
@@ -250,6 +252,8 @@ pub struct WaddleLiveKitJoin {
 #[derive(Debug, Serialize)]
 pub struct WaddleCallEvent {
     pub from: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to: Option<String>,
     pub sid: String,
     pub kind: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/server/crates/waddle-xmpp-client/src/messaging/call.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/call.rs
@@ -115,6 +115,10 @@ pub struct InboundCallEvent {
     /// to be addressed to that full JID so the originating resource
     /// receives the answer, not every resource of the bare JID.
     pub from: Jid,
+    /// The original stanza recipient, when present. Message carbons
+    /// need this to let sibling resources associate self-originated
+    /// JMI events with the peer conversation.
+    pub to: Option<Jid>,
     pub sid: SessionId,
     pub kind: CallEventKind,
 }
@@ -136,6 +140,7 @@ pub fn parse_jmi_message(stanza: &Element) -> Option<InboundCallEvent> {
         return None;
     }
     let from = stanza.attr("from").and_then(|s| s.parse::<Jid>().ok())?;
+    let to = stanza.attr("to").and_then(|s| s.parse::<Jid>().ok());
 
     for child in stanza.children() {
         if child.ns() != NS_JINGLE_MESSAGE {
@@ -161,7 +166,12 @@ pub fn parse_jmi_message(stanza: &Element) -> Option<InboundCallEvent> {
             },
             _ => continue,
         };
-        return Some(InboundCallEvent { from, sid, kind });
+        return Some(InboundCallEvent {
+            from,
+            to: to.clone(),
+            sid,
+            kind,
+        });
     }
     None
 }
@@ -173,6 +183,7 @@ pub fn parse_jingle_iq(stanza: &Element) -> Option<InboundCallEvent> {
         return None;
     }
     let from = stanza.attr("from").and_then(|s| s.parse::<Jid>().ok())?;
+    let to = stanza.attr("to").and_then(|s| s.parse::<Jid>().ok());
     let jingle = stanza
         .children()
         .find(|c| c.name() == "jingle" && c.ns() == NS_JINGLE)?;
@@ -194,7 +205,12 @@ pub fn parse_jingle_iq(stanza: &Element) -> Option<InboundCallEvent> {
         },
         _ => return None,
     };
-    Some(InboundCallEvent { from, sid, kind })
+    Some(InboundCallEvent {
+        from,
+        to,
+        sid,
+        kind,
+    })
 }
 
 /// Convenience dispatcher: try JMI first, then Jingle.

--- a/server/crates/waddle-xmpp-client/src/runtime/app_stanza.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime/app_stanza.rs
@@ -2,6 +2,7 @@ use minidom::Element;
 
 use crate::event::{ClientEvent, ConnectionEvent};
 use crate::transport::TransportMessage;
+use crate::AuthenticationConfig;
 
 use super::XmppRuntime;
 
@@ -45,6 +46,10 @@ impl XmppRuntime {
             if let Some(pep_item) = pep::parse(element) {
                 return vec![ClientEvent::PepEvent(pep_item)];
             }
+
+            if let Some(call_event) = parse_carbon_call_event(element, self.account_bare_jid()) {
+                return vec![ClientEvent::Call(Box::new(call_event))];
+            }
         }
 
         if let Some(call_event) = messaging::parse_call_event(element) {
@@ -64,6 +69,49 @@ impl XmppRuntime {
 
         vec![ClientEvent::UnhandledStanza(element.clone())]
     }
+}
+
+impl XmppRuntime {
+    fn account_bare_jid(&self) -> &jid::BareJid {
+        match &self.config.auth {
+            AuthenticationConfig::OAuthBearer(config) => &config.account,
+        }
+    }
+}
+
+fn parse_carbon_call_event(
+    element: &Element,
+    account: &jid::BareJid,
+) -> Option<crate::messaging::InboundCallEvent> {
+    const NS_CARBONS: &str = "urn:xmpp:carbons:2";
+    const NS_FORWARD: &str = "urn:xmpp:forward:0";
+
+    if element.name() != "message" {
+        return None;
+    }
+    let outer_from = element.attr("from")?.parse::<jid::Jid>().ok()?.to_bare();
+    if &outer_from != account {
+        return None;
+    }
+
+    for carbon in element.children().filter(|child| {
+        child.ns() == NS_CARBONS && (child.name() == "sent" || child.name() == "received")
+    }) {
+        let Some(forwarded) = carbon.get_child("forwarded", NS_FORWARD) else {
+            continue;
+        };
+        let Some(inner_message) = forwarded
+            .children()
+            .find(|child| child.name() == "message" && child.ns() == "jabber:client")
+        else {
+            continue;
+        };
+        if let Some(call_event) = crate::messaging::parse_call_event(inner_message) {
+            return Some(call_event);
+        }
+    }
+
+    None
 }
 
 fn jingle_iq_set_ack(inbound: &Element) -> Option<Element> {

--- a/server/crates/waddle-xmpp-client/src/runtime/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime/tests.rs
@@ -73,6 +73,60 @@ fn app_stanza_routes_jmi_message_to_typed_call_event() {
 }
 
 #[test]
+fn app_stanza_routes_carbon_wrapped_jmi_to_typed_call_event() {
+    let mut runtime = XmppRuntime::new(config()).unwrap();
+    let stanza: Element =
+        r#"<message xmlns='jabber:client' from='alice@example.com' to='alice@example.com/macbook'>
+        <sent xmlns='urn:xmpp:carbons:2'>
+          <forwarded xmlns='urn:xmpp:forward:0'>
+            <message xmlns='jabber:client' from='alice@example.com/phone' to='bob@example.com/desktop'>
+              <finish xmlns='urn:xmpp:jingle-message:0' id='call-1'/>
+            </message>
+          </forwarded>
+        </sent>
+    </message>"#
+            .parse()
+            .unwrap();
+
+    let events = runtime.handle_app_stanza(&stanza);
+
+    assert_eq!(events.len(), 1);
+    assert!(matches!(
+        &events[0],
+        ClientEvent::Call(call)
+            if call.sid.0 == "call-1"
+                && call.from.to_string() == "alice@example.com/phone"
+                && call.to.as_ref().map(ToString::to_string).as_deref() == Some("bob@example.com/desktop")
+    ));
+}
+
+#[test]
+fn app_stanza_ignores_forged_carbon_wrapped_call_from_peer() {
+    let mut runtime = XmppRuntime::new(config()).unwrap();
+    let stanza: Element =
+        r#"<message xmlns='jabber:client' from='bob@example.com' to='alice@example.com/macbook'>
+        <sent xmlns='urn:xmpp:carbons:2'>
+          <forwarded xmlns='urn:xmpp:forward:0'>
+            <message xmlns='jabber:client' from='alice@example.com/phone' to='bob@example.com/desktop'>
+              <finish xmlns='urn:xmpp:jingle-message:0' id='call-1'/>
+            </message>
+          </forwarded>
+        </sent>
+    </message>"#
+            .parse()
+            .unwrap();
+
+    let events = runtime.handle_app_stanza(&stanza);
+
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, ClientEvent::Call(_))),
+        "XEP-0280 carbon copies must come from the authenticated account bare JID"
+    );
+}
+
+#[test]
 fn app_stanza_acknowledges_jingle_iq_set_and_surfaces_call_event() {
     let mut runtime = XmppRuntime::new(config()).unwrap();
     let stanza: Element = r#"<iq xmlns='jabber:client' type='set' id='j1' from='alice@waddle.test/desktop' to='bob@waddle.test/phone'>

--- a/server/crates/waddle-xmpp/src/muc/room.rs
+++ b/server/crates/waddle-xmpp/src/muc/room.rs
@@ -121,8 +121,8 @@ pub struct MucRoom {
     /// room-actor shutdown by design (#414); persistence is a follow-up
     /// concern. Bounded by [`super::pin::MAX_PINNED_ENTRIES`].
     pub(super) pinned_entries: Vec<PinnedEntry>,
-    /// Per-occupant `<muji xmlns='urn:xmpp:jingle:muji:0'/>` advertised
-    /// state (XEP-0272), keyed by nick. Mirrors the client-emitted
+    /// Per-session `<muji xmlns='urn:xmpp:jingle:muji:0'/>` advertised
+    /// state (XEP-0272), keyed by nick and then by full JID. Mirrors the client-emitted
     /// presence extension so:
     ///
     /// 1. Joining occupants see existing call indicators when their
@@ -133,29 +133,28 @@ pub struct MucRoom {
     ///    the source of truth rather than echoing a possibly-stale
     ///    payload from the client.
     ///
-    /// Each entry records the originating `FullJid` so that when a
-    /// user has multiple sessions sharing the same nick (web + mobile),
-    /// the call advertisement is tied to the specific session that
-    /// joined the call. When that session leaves — clean hangup OR
-    /// unclean disconnect — its `<muji/>` advertisement is cleared
-    /// even if the user's other sessions are still in the room. Without
-    /// this per-session keying, alice's mobile staying in the channel
-    /// after her desktop (which was on the call) drops would keep the
-    /// chip lit forever for late joiners.
-    pub(super) muji_state: HashMap<String, MujiStateEntry>,
+    /// Each full-JID entry is independent so that when a user has
+    /// multiple sessions sharing the same nick (web + mobile), one
+    /// resource can join or leave the call without overwriting the
+    /// sibling resource's advertisement. The room-level wire shape is
+    /// still one occupant presence per nick; `muji_for_nick` aggregates
+    /// these session entries, preferring active contents over preparing.
+    pub(super) muji_state: HashMap<String, HashMap<FullJid, Muji>>,
 }
 
-/// One advertised `<muji/>` entry plus the session that owns it.
-///
-/// The `originator` field is the `FullJid` of the session that emitted
-/// the Muji presence update. When that exact session leaves the room
-/// (or its WebSocket drops), the entry is removed regardless of whether
-/// other sessions for the same nick remain — preventing ghost call
-/// advertisements on multi-resource occupants.
+/// Result of applying one session's Muji presence update.
 #[derive(Debug, Clone)]
-pub(super) struct MujiStateEntry {
-    pub originator: FullJid,
-    pub muji: Muji,
+pub struct MujiPresenceState {
+    /// The exact payload that should be reflected to the sender session.
+    pub sender_muji: Option<Muji>,
+    /// The aggregate payload that represents the occupant nick to every
+    /// other session in the room.
+    pub room_muji: Option<Muji>,
+    /// Exact per-session Muji payloads still advertised for this nick
+    /// after the update. Preparing is a resource-owned coordination
+    /// state, so callers that need to preserve XEP-0272 joining
+    /// semantics should prefer this list over the aggregate snapshot.
+    pub session_mujis: Vec<(FullJid, Muji)>,
 }
 
 impl MucRoom {
@@ -191,38 +190,90 @@ impl MucRoom {
     /// means the participant has left the call; we mirror that by
     /// clearing the entry when [`Muji::is_empty`] is true.
     ///
-    /// Returns the post-update state for `nick`: `Some(muji)` if a
-    /// live advertisement (preparing OR active contents) is now
-    /// present, `None` if cleared. The presence broadcaster uses the
-    /// return value to decide what to put on the wire — `None` means
-    /// "rebroadcast a presence WITHOUT the `<muji/>` child" so other
-    /// occupants stop seeing the indicator.
+    /// Returns the sender reflection and the post-update aggregate
+    /// state for `nick`. The presence broadcaster uses the aggregate
+    /// state for other occupants so one same-nick resource cannot hide
+    /// active or preparing state owned by another resource.
     pub fn upsert_muji_presence(
         &mut self,
         nick: &str,
         originator: FullJid,
         muji: Muji,
-    ) -> Option<Muji> {
+    ) -> MujiPresenceState {
         if muji.is_empty() {
-            self.muji_state.remove(nick);
-            None
+            if let Some(entries) = self.muji_state.get_mut(nick) {
+                entries.remove(&originator);
+                if entries.is_empty() {
+                    self.muji_state.remove(nick);
+                }
+            }
+            MujiPresenceState {
+                sender_muji: None,
+                room_muji: self.muji_for_nick(nick),
+                session_mujis: self.muji_sessions_for_nick(nick),
+            }
         } else {
-            self.muji_state.insert(
-                nick.to_owned(),
-                MujiStateEntry {
-                    originator,
-                    muji: muji.clone(),
-                },
-            );
-            Some(muji)
+            self.muji_state
+                .entry(nick.to_owned())
+                .or_default()
+                .insert(originator, muji.clone());
+            MujiPresenceState {
+                sender_muji: Some(muji),
+                room_muji: self.muji_for_nick(nick),
+                session_mujis: self.muji_sessions_for_nick(nick),
+            }
         }
     }
 
     /// Currently-advertised `<muji/>` element for `nick`, if any.
     /// Used by the join handler to enrich the replayed occupant
     /// presence list with active-call indicators for late joiners.
-    pub fn muji_for_nick(&self, nick: &str) -> Option<&Muji> {
-        self.muji_state.get(nick).map(|entry| &entry.muji)
+    pub fn muji_for_nick(&self, nick: &str) -> Option<Muji> {
+        let entries = self.muji_state.get(nick)?;
+        let mut preparing = false;
+        let mut contents = Vec::new();
+        let mut ordered_entries: Vec<_> = entries.iter().collect();
+        ordered_entries.sort_by_key(|(jid, _)| jid.to_string());
+        for (_, muji) in ordered_entries {
+            preparing |= muji.preparing;
+            for content in &muji.contents {
+                if !contents.contains(content) {
+                    contents.push(content.clone());
+                }
+            }
+        }
+        if !preparing && contents.is_empty() {
+            return None;
+        }
+        Some(Muji {
+            room: None,
+            preparing,
+            contents,
+        })
+    }
+
+    /// Currently-advertised Muji payload for one exact session.
+    pub fn muji_for_session(&self, nick: &str, jid: &FullJid) -> Option<Muji> {
+        self.muji_state
+            .get(nick)
+            .and_then(|entries| entries.get(jid))
+            .filter(|muji| !muji.is_empty())
+            .cloned()
+    }
+
+    /// Exact per-session Muji payloads for `nick`, sorted by full JID
+    /// for deterministic replay and broadcast ordering.
+    pub fn muji_sessions_for_nick(&self, nick: &str) -> Vec<(FullJid, Muji)> {
+        let Some(entries) = self.muji_state.get(nick) else {
+            return Vec::new();
+        };
+        let mut entries: Vec<_> = entries
+            .iter()
+            .filter(|(_, muji)| !muji.is_empty())
+            .map(|(jid, muji)| (jid.clone(), muji.clone()))
+            .collect();
+        entries.sort_by_key(|(jid, _)| jid.to_string());
+        entries
     }
 
     /// Clear a nickname's stored Muji advertisement if `originator`
@@ -233,14 +284,18 @@ impl MucRoom {
     /// A regular available presence without `<muji/>` is therefore a
     /// canonical clear signal for an occupant that previously
     /// advertised Muji state.
-    pub fn clear_muji_presence(&mut self, nick: &str, originator: &FullJid) -> bool {
-        let Some(entry) = self.muji_state.get(nick) else {
-            return false;
-        };
-        if &entry.originator != originator {
-            return false;
+    pub fn clear_muji_presence(&mut self, nick: &str, originator: &FullJid) -> MujiPresenceState {
+        if let Some(entries) = self.muji_state.get_mut(nick) {
+            entries.remove(originator);
+            if entries.is_empty() {
+                self.muji_state.remove(nick);
+            }
         }
-        self.muji_state.remove(nick).is_some()
+        MujiPresenceState {
+            sender_muji: None,
+            room_muji: self.muji_for_nick(nick),
+            session_mujis: self.muji_sessions_for_nick(nick),
+        }
     }
 
     /// Add an occupant to the room.
@@ -324,12 +379,11 @@ impl MucRoom {
         // even if peer sessions for the same nick remain. Without this
         // clause the chip would stay lit (and replay to late joiners)
         // until the user's LAST session for this nick departs.
-        if self
-            .muji_state
-            .get(nick)
-            .is_some_and(|entry| entry.originator == *jid)
-        {
-            self.muji_state.remove(nick);
+        if let Some(entries) = self.muji_state.get_mut(nick) {
+            entries.remove(jid);
+            if entries.is_empty() {
+                self.muji_state.remove(nick);
+            }
         }
 
         if sessions.is_empty() {

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -57,13 +57,11 @@ pub struct JoinExistingOccupant {
     pub nick: String,
     pub affiliation: Affiliation,
     pub role: Role,
-    /// Snapshot of this occupant's currently-advertised XEP-0272
+    /// Snapshot of this exact session's currently-advertised XEP-0272
     /// `<muji xmlns='urn:xmpp:jingle:muji:0'/>` element at the moment
-    /// the new joiner asked to enter. The replay path appends this
-    /// to the occupant's reflected presence so the joiner immediately
-    /// sees the "in call" chip light up — no separate discovery
-    /// round-trip. `None` when the occupant has no live Muji
-    /// advertisement.
+    /// the new joiner asked to enter. Preparing is resource-owned
+    /// coordination state, so join replay must not stamp an aggregate
+    /// same-nick Muji payload onto an arbitrary full JID.
     pub muji: Option<crate::xep::xep0272::Muji>,
 }
 
@@ -92,6 +90,8 @@ pub struct LeaveOutcome {
     pub remaining_occupants: Vec<FullJid>,
     pub removed_last_session: bool,
     pub cleared_muji_state: bool,
+    pub remaining_muji: Option<crate::xep::xep0272::Muji>,
+    pub remaining_muji_sessions: Vec<(FullJid, crate::xep::xep0272::Muji)>,
     pub remaining_nick_real_jid: Option<FullJid>,
     pub occupant_count: usize,
     /// Mirrors `MucRoom.config.persistent`. Surfaced so the leave

--- a/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
@@ -57,17 +57,19 @@ impl kameo::message::Message<JoinWithAffiliation> for RoomActor {
             .occupants
             .values()
             .flat_map(|o| {
-                let muji = self.room.muji_for_nick(&o.nick).cloned();
-                self.room.get_occupant_sessions(&o.nick).into_iter().map({
-                    let muji = muji.clone();
-                    move |jid| JoinExistingOccupant {
-                        jid,
-                        nick: o.nick.clone(),
-                        affiliation: o.affiliation,
-                        role: o.role,
-                        muji: muji.clone(),
-                    }
-                })
+                self.room
+                    .get_occupant_sessions(&o.nick)
+                    .into_iter()
+                    .map(|jid| {
+                        let muji = self.room.muji_for_session(&o.nick, &jid);
+                        JoinExistingOccupant {
+                            jid,
+                            nick: o.nick.clone(),
+                            affiliation: o.affiliation,
+                            role: o.role,
+                            muji,
+                        }
+                    })
             })
             .collect();
 
@@ -136,11 +138,21 @@ impl kameo::message::Message<LeaveByRealJid> for RoomActor {
             .room
             .muji_state
             .get(&nick)
-            .is_some_and(|entry| entry.originator == msg.sender_jid);
+            .is_some_and(|entries| entries.contains_key(&msg.sender_jid));
         let removed_last_session = self
             .room
             .remove_occupant_session(&nick, &msg.sender_jid)
             .unwrap_or(false);
+        let remaining_muji = if removed_last_session {
+            None
+        } else {
+            self.room.muji_for_nick(&nick)
+        };
+        let remaining_muji_sessions = if removed_last_session {
+            Vec::new()
+        } else {
+            self.room.muji_sessions_for_nick(&nick)
+        };
         let remaining_nick_real_jid = if removed_last_session {
             None
         } else {
@@ -158,6 +170,8 @@ impl kameo::message::Message<LeaveByRealJid> for RoomActor {
             remaining_occupants,
             removed_last_session,
             cleared_muji_state,
+            remaining_muji,
+            remaining_muji_sessions,
             remaining_nick_real_jid,
             occupant_count,
             is_persistent,
@@ -225,11 +239,17 @@ pub struct ClearMujiPresence {
 #[derive(Debug, Clone)]
 pub struct MujiPresenceUpdateOutcome {
     pub update: PresenceUpdateOutcome,
-    /// `Some(muji)` if the call indicator should be broadcast (the
-    /// session is preparing OR has active contents); `None` if the
-    /// participant left the call — the broadcast omits the `<muji/>`
-    /// child entirely per XEP-0272 §Leaving.
+    /// Exact Muji payload to reflect to the sending session. This
+    /// preserves the XEP-0272 preparing echo even when another
+    /// same-nick resource already has active contents.
+    pub sender_muji: Option<crate::xep::xep0272::Muji>,
+    /// Aggregate Muji payload for the occupant nick. Other occupants
+    /// receive this authoritative state so one resource's preparing
+    /// update cannot hide a sibling resource's active call.
     pub active_muji: Option<crate::xep::xep0272::Muji>,
+    /// Exact per-session Muji payloads still advertised for this nick
+    /// after the update.
+    pub session_mujis: Vec<(FullJid, crate::xep::xep0272::Muji)>,
 }
 
 impl kameo::message::Message<UpsertMujiPresence> for RoomActor {
@@ -258,7 +278,7 @@ impl kameo::message::Message<UpsertMujiPresence> for RoomActor {
         // emitted it so a partial-session leave (one resource of a
         // multi-resource occupant) clears the chip even when the
         // user's other sessions remain in the room.
-        let active_muji =
+        let muji_state =
             self.room
                 .upsert_muji_presence(&sender_nick, msg.sender_jid.clone(), msg.muji);
         Ok(Some(MujiPresenceUpdateOutcome {
@@ -270,7 +290,9 @@ impl kameo::message::Message<UpsertMujiPresence> for RoomActor {
                 room_jid,
                 recipients,
             },
-            active_muji,
+            sender_muji: muji_state.sender_muji,
+            active_muji: muji_state.room_muji,
+            session_mujis: muji_state.session_mujis,
         }))
     }
 }
@@ -290,9 +312,7 @@ impl kameo::message::Message<ClearMujiPresence> for RoomActor {
         let sender_real_jid = sender_occupant.real_jid.clone();
         let sender_role = sender_occupant.role;
         let sender_affiliation = sender_occupant.affiliation;
-        if !self.room.clear_muji_presence(&sender_nick, &msg.sender_jid) {
-            return Ok(None);
-        }
+        let muji_state = self.room.clear_muji_presence(&sender_nick, &msg.sender_jid);
         let room_jid = self.room.room_jid.clone();
         let recipients = self
             .room
@@ -309,7 +329,9 @@ impl kameo::message::Message<ClearMujiPresence> for RoomActor {
                 room_jid,
                 recipients,
             },
-            active_muji: None,
+            sender_muji: muji_state.sender_muji,
+            active_muji: muji_state.room_muji,
+            session_mujis: muji_state.session_mujis,
         }))
     }
 }

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
@@ -850,10 +850,24 @@ fn audio_muji() -> crate::xep::xep0272::Muji {
     )])
 }
 
+fn video_muji() -> crate::xep::xep0272::Muji {
+    use crate::xep::xep0167::MediaKind;
+    use crate::xep::xep0272::{Creator, Muji, MujiContent};
+    Muji::with_contents(vec![MujiContent::new(
+        "video",
+        Creator::Initiator,
+        MediaKind::Video,
+    )])
+}
+
 fn empty_muji() -> crate::xep::xep0272::Muji {
     // No `<preparing/>`, no `<content/>` → XEP-0272 §Leaving "absence
     // marker": the participant has exited the call.
     crate::xep::xep0272::Muji::default()
+}
+
+fn preparing_muji() -> crate::xep::xep0272::Muji {
+    crate::xep::xep0272::Muji::preparing()
 }
 
 #[tokio::test]
@@ -972,6 +986,190 @@ async fn upsert_muji_presence_recipients_include_every_sibling_session_of_sender
 }
 
 #[tokio::test]
+async fn same_nick_sibling_preparing_does_not_clobber_active_muji_snapshot() {
+    let actor = spawn_room_actor().await;
+    let desktop: FullJid = "alice@example.com/desktop".parse().expect("desktop");
+    let mobile: FullJid = "alice@example.com/mobile".parse().expect("mobile");
+    let bob: FullJid = "bob@example.com/desktop".parse().expect("bob");
+
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: desktop.clone(),
+            nick: "alice".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+        })
+        .await
+        .expect("desktop join");
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: mobile.clone(),
+            nick: "alice".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+        })
+        .await
+        .expect("mobile join");
+
+    actor
+        .ask(crate::muc::room_actor::UpsertMujiPresence {
+            sender_jid: desktop.clone(),
+            muji: audio_muji(),
+        })
+        .await
+        .expect("active ask")
+        .expect("desktop is an occupant");
+
+    let preparing = actor
+        .ask(crate::muc::room_actor::UpsertMujiPresence {
+            sender_jid: mobile.clone(),
+            muji: preparing_muji(),
+        })
+        .await
+        .expect("preparing ask")
+        .expect("mobile is an occupant");
+
+    assert!(
+        preparing
+            .sender_muji
+            .as_ref()
+            .is_some_and(|muji| muji.preparing && !muji.is_active()),
+        "mobile still receives its preparing reflection"
+    );
+    assert!(
+        preparing
+            .active_muji
+            .as_ref()
+            .is_some_and(|muji| muji.is_active() && muji.preparing),
+        "other occupants see both desktop's active advertisement and mobile's preparing state"
+    );
+
+    let replay = actor
+        .ask(JoinWithAffiliation {
+            sender_jid: bob,
+            nick: "bob".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+        })
+        .await
+        .expect("bob join");
+
+    let desktop_replay = replay
+        .existing_occupants
+        .iter()
+        .find(|occupant| occupant.nick == "alice" && occupant.jid == desktop)
+        .expect("bob sees alice desktop");
+    let mobile_replay = replay
+        .existing_occupants
+        .iter()
+        .find(|occupant| occupant.nick == "alice" && occupant.jid == mobile)
+        .expect("bob sees alice mobile");
+    assert!(
+        desktop_replay
+            .muji
+            .as_ref()
+            .is_some_and(|muji| muji.is_active() && !muji.preparing),
+        "late join replay keeps desktop's active advertisement on the desktop JID"
+    );
+    assert!(
+        mobile_replay
+            .muji
+            .as_ref()
+            .is_some_and(|muji| muji.preparing && !muji.is_active()),
+        "late join replay keeps mobile's preparing advertisement on the mobile JID"
+    );
+}
+
+#[tokio::test]
+async fn late_join_replay_includes_preparing_only_same_nick_muji_with_exact_owner() {
+    let actor = spawn_room_actor().await;
+    let desktop: FullJid = "alice@example.com/desktop".parse().expect("desktop");
+    let mobile: FullJid = "alice@example.com/mobile".parse().expect("mobile");
+    let bob: FullJid = "bob@example.com/desktop".parse().expect("bob");
+
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: desktop.clone(),
+            nick: "alice".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+        })
+        .await
+        .expect("desktop join");
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: mobile.clone(),
+            nick: "alice".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+        })
+        .await
+        .expect("mobile join");
+
+    actor
+        .ask(crate::muc::room_actor::UpsertMujiPresence {
+            sender_jid: mobile.clone(),
+            muji: preparing_muji(),
+        })
+        .await
+        .expect("preparing ask")
+        .expect("mobile is an occupant");
+
+    let replay = actor
+        .ask(JoinWithAffiliation {
+            sender_jid: bob,
+            nick: "bob".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+        })
+        .await
+        .expect("bob join");
+
+    let desktop_replay = replay
+        .existing_occupants
+        .iter()
+        .find(|occupant| occupant.nick == "alice" && occupant.jid == desktop)
+        .expect("bob sees alice desktop");
+    let mobile_replay = replay
+        .existing_occupants
+        .iter()
+        .find(|occupant| occupant.nick == "alice" && occupant.jid == mobile)
+        .expect("bob sees alice mobile");
+    assert!(
+        desktop_replay.muji.is_none(),
+        "desktop has no Muji state to replay"
+    );
+    assert!(
+        mobile_replay
+            .muji
+            .as_ref()
+            .is_some_and(|muji| muji.preparing && !muji.is_active()),
+        "late join replay preserves preparing-only state on its exact full JID"
+    );
+}
+
+#[test]
+fn same_nick_active_resources_are_aggregated_for_other_occupants() {
+    let mut room = test_room();
+    let desktop: FullJid = "alice@example.com/desktop".parse().expect("desktop");
+    let mobile: FullJid = "alice@example.com/mobile".parse().expect("mobile");
+
+    room.upsert_muji_presence("alice", desktop, audio_muji());
+    let video = room.upsert_muji_presence("alice", mobile, video_muji());
+
+    let aggregate = video
+        .room_muji
+        .as_ref()
+        .expect("other occupants see same-nick aggregate Muji");
+    assert!(aggregate.is_active(), "aggregate has content");
+    assert_eq!(
+        aggregate.contents.len(),
+        2,
+        "aggregate carries all same-nick active resources instead of choosing one"
+    );
+}
+
+#[tokio::test]
 async fn upsert_muji_presence_empty_clears_state_and_returns_none() {
     let actor = spawn_room_actor().await;
     let alice = test_full_jid("alice");
@@ -1085,7 +1283,7 @@ async fn clear_muji_presence_clears_existing_state_without_muji_payload() {
 }
 
 #[tokio::test]
-async fn clear_muji_presence_returns_none_when_no_state_exists() {
+async fn clear_muji_presence_reflects_plain_presence_when_no_state_exists() {
     let actor = spawn_room_actor().await;
     let alice = test_full_jid("alice");
     actor
@@ -1103,10 +1301,10 @@ async fn clear_muji_presence_returns_none_when_no_state_exists() {
         .await
         .expect("ask");
 
-    assert!(
-        outcome.is_none(),
-        "plain available presence without prior Muji state stays on the existing join/update path"
-    );
+    let outcome = outcome.expect("existing occupant presence update is reflected");
+    assert_eq!(outcome.update.sender_nick, "alice");
+    assert!(outcome.sender_muji.is_none());
+    assert!(outcome.active_muji.is_none());
 }
 
 #[tokio::test]
@@ -1362,4 +1560,85 @@ async fn leaving_non_originator_session_preserves_muji_state() {
         .as_ref()
         .expect("Muji preserved when non-originator session leaves");
     assert!(muji.is_active());
+}
+
+#[tokio::test]
+async fn leaving_one_active_same_nick_session_preserves_sibling_active_muji_state() {
+    let actor = spawn_room_actor().await;
+    let desktop: FullJid = "alice@example.com/desktop".parse().expect("desktop");
+    let mobile: FullJid = "alice@example.com/mobile".parse().expect("mobile");
+
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: desktop.clone(),
+            nick: "alice".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+        })
+        .await
+        .expect("desktop join");
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: mobile.clone(),
+            nick: "alice".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+        })
+        .await
+        .expect("mobile join");
+
+    actor
+        .ask(crate::muc::room_actor::UpsertMujiPresence {
+            sender_jid: desktop.clone(),
+            muji: audio_muji(),
+        })
+        .await
+        .expect("desktop active")
+        .expect("desktop is an occupant");
+    actor
+        .ask(crate::muc::room_actor::UpsertMujiPresence {
+            sender_jid: mobile.clone(),
+            muji: audio_muji(),
+        })
+        .await
+        .expect("mobile active")
+        .expect("mobile is an occupant");
+
+    let leave_outcome = actor
+        .ask(crate::muc::room_actor::LeaveByRealJid { sender_jid: mobile })
+        .await
+        .expect("mobile leave")
+        .expect("alice present");
+
+    assert!(leave_outcome.cleared_muji_state);
+    assert!(
+        leave_outcome
+            .remaining_muji
+            .as_ref()
+            .is_some_and(|muji| muji.is_active()),
+        "desktop's active Muji must remain after mobile hangs up"
+    );
+
+    let carol = test_full_jid("carol");
+    let join_outcome = actor
+        .ask(JoinWithAffiliation {
+            sender_jid: carol,
+            nick: "carol".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+        })
+        .await
+        .expect("carol join");
+    let alice_replay = join_outcome
+        .existing_occupants
+        .iter()
+        .find(|o| o.nick == "alice")
+        .expect("alice still in room via desktop");
+    assert!(
+        alice_replay
+            .muji
+            .as_ref()
+            .is_some_and(|muji| muji.is_active()),
+        "late join replay preserves the remaining active sibling"
+    );
 }

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mplbhfc8";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mplbhfc8";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mplbhfc8";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mplk106q";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mplk106q";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mplk106q";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=mplbhfc8";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=mplk106q";


### PR DESCRIPTION
## Summary

- keep MUC join/readiness and XEP-0402 autojoin state stable across refresh and reconnect
- make XEP-0272 Muji state exact per resource so same-nick clients do not clear one another active/preparing call state
- harden 1:1 call activity across sibling resources, MAM reloads, XEP-0280 carbons, WASM/FFI, and Apple bindings
- reject forged carbon-wrapped call events whose outer carbon is not from the authenticated account
- address PR review follow-ups for MUC join Promise guards, outgoing DM activity direction, terminal tombstone bounds, and legacy same-nick Muji reflection ordering

## Completed plan

1. Reviewed the relevant local XEPs: XEP-0045, XEP-0166, XEP-0272, XEP-0280, XEP-0313, XEP-0353, and XEP-0402.
2. Repaired chat MUC readiness, retained/autojoin room handling, and room-send queue flushing around this resource joined state.
3. Reworked server Muji storage, replay, broadcast, clear, and leave handling to preserve exact full-JID ownership for same-nick multi-client sessions.
4. Reworked chat MUC call presence so active and preparing ownership are exact per `muc_jid`, with the public nick list derived from remaining active owners.
5. Added DM call activity tracking so sibling devices and archive reloads keep the UI aligned without starting duplicate calls.
6. Carried typed call events through archived WASM rows, FFI, and Apple types.
7. Rebased onto fetched `origin/main` at `aeb56ff2ccee65b74b669dee79da6609e1350d05` and re-ran local gates.
8. Re-ran adversarial review until there were no actionable findings.
9. Fixed PR review comments and re-ran affected local checks.

## Verification

- `bun test`
- `bun run lint`
- `bun run build`
- `cargo fmt --all --check`
- `cargo clippy -p waddle-server --all-targets -- -D warnings`
- `cargo clippy -p waddle-server -p waddle-xmpp -p waddle-xmpp-client -p waddle-xmpp-client-wasm -p waddle-xmpp-client-ffi --all-targets -- -D warnings`
- `cargo test -p waddle-server reflected_muji_entries -- --nocapture`
- `cargo test -p waddle-server same_nick_ -- --nocapture`
- `cargo test -p waddle-xmpp --test xep_0272_muji -- --nocapture`
- `cargo test -p waddle-xmpp-client -p waddle-xmpp-client-wasm -p waddle-xmpp-client-ffi --lib -- --nocapture`
- `git diff --check`
- `xcodebuild -version` blocked locally because only Command Line Tools are active: `/Library/Developer/CommandLineTools`

Notes:
- `bun run build` reports the existing Astro `withIqTimeout` async-conversion hint and Vite chunk-size warning, with 0 errors.
