### PR TITLE
feat(chat): add persistent call activity dock

### DIFF
--- a/chat/src/components/calls/CallActivityDock.vue
+++ b/chat/src/components/calls/CallActivityDock.vue
@@ -62,7 +62,7 @@ function entryStatus(entry: CallActivityDockEntry): string {
 
 function entryTitle(entry: CallActivityDockEntry): string {
   if (entry.kind === "channel") {
-    return `Open ${entry.title} call, ${entryStatus(entry)}`;
+    return `Join ${entry.title} call, ${entryStatus(entry)}`;
   }
   return `Open ${entry.title} call, ${entryStatus(entry)}`;
 }

--- a/chat/src/components/calls/CallActivityDock.vue
+++ b/chat/src/components/calls/CallActivityDock.vue
@@ -1,0 +1,286 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { useStore } from "@nanostores/vue";
+import { Hash, MessageCircle, Phone, Video } from "lucide-vue-next";
+import {
+  $mucCallParticipants,
+  mucCallParticipantCounts,
+} from "@/lib/calls/muc-call-presence";
+import { $dmCallActivities } from "@/lib/calls/dm-call-activity";
+import {
+  buildCallActivityDockEntries,
+  type CallActivityDockEntry,
+  type SidebarMode,
+} from "@/lib/calls/call-activity-dock";
+import type { ChannelSummary } from "@/lib/chat-types";
+import type { DmConversation } from "@/lib/xmpp-client";
+
+const props = defineProps<{
+  channels: ChannelSummary[];
+  conversations: DmConversation[];
+  activeChannelId: string | null;
+  activePeerJid: string | null;
+  sidebarMode: SidebarMode;
+  activeChannelJids: Set<string>;
+}>();
+
+const emit = defineEmits<{
+  selectChannel: [channelId: string];
+  selectDm: [peerJid: string];
+}>();
+
+const mucCallParticipantsStore = useStore($mucCallParticipants);
+const dmCallActivities = useStore($dmCallActivities);
+
+const callParticipantCounts = computed<Record<string, number>>(() => {
+  return mucCallParticipantCounts(mucCallParticipantsStore.value);
+});
+
+const entries = computed(() => buildCallActivityDockEntries({
+  channels: props.channels,
+  conversations: props.conversations,
+  activeChannelId: props.activeChannelId,
+  activePeerJid: props.activePeerJid,
+  sidebarMode: props.sidebarMode,
+  activeChannelJids: props.activeChannelJids,
+  callParticipantCounts: callParticipantCounts.value,
+  dmCallActivities: dmCallActivities.value,
+}));
+
+function entryStatus(entry: CallActivityDockEntry): string {
+  if (entry.kind === "channel") {
+    const noun = entry.participantCount === 1 ? "person" : "people";
+    return `${entry.participantCount} ${noun}`;
+  }
+  if (entry.state === "ringing") {
+    if (entry.direction === "outgoing") return "Calling";
+    if (entry.direction === "incoming") return "Ringing";
+    return "Ringing";
+  }
+  return "Live";
+}
+
+function entryTitle(entry: CallActivityDockEntry): string {
+  if (entry.kind === "channel") {
+    return `Open ${entry.title} call, ${entryStatus(entry)}`;
+  }
+  return `Open ${entry.title} call, ${entryStatus(entry)}`;
+}
+
+function selectEntry(entry: CallActivityDockEntry): void {
+  if (entry.kind === "channel") {
+    emit("selectChannel", entry.channelId);
+    return;
+  }
+  emit("selectDm", entry.peerJid);
+}
+</script>
+
+<template>
+  <div
+    v-if="entries.length > 0"
+    class="call-activity-dock"
+    aria-label="Active calls"
+  >
+    <div class="call-activity-dock__header">
+      <span class="call-activity-dock__pulse" aria-hidden="true" />
+      <span class="type-section-label">Calls</span>
+    </div>
+    <div class="call-activity-dock__list">
+      <button
+        v-for="entry in entries"
+        :key="entry.key"
+        type="button"
+        class="call-activity-dock__row"
+        :class="{ 'call-activity-dock__row--active': entry.isActive }"
+        :aria-current="entry.isActive ? 'page' : undefined"
+        :title="entryTitle(entry)"
+        @click="selectEntry(entry)"
+      >
+        <span class="call-activity-dock__icon" aria-hidden="true">
+          <Hash v-if="entry.kind === 'channel'" class="h-3.5 w-3.5" />
+          <Video v-else-if="entry.media.video" class="h-3.5 w-3.5" />
+          <MessageCircle v-else-if="entry.state === 'ringing'" class="h-3.5 w-3.5" />
+          <Phone v-else class="h-3.5 w-3.5" />
+        </span>
+        <span class="call-activity-dock__copy">
+          <span class="call-activity-dock__title type-control">{{ entry.title }}</span>
+          <span class="call-activity-dock__status type-meta">
+            {{ entryStatus(entry) }}
+          </span>
+        </span>
+        <span
+          v-if="entry.kind === 'channel'"
+          class="call-activity-dock__count type-count-badge"
+          aria-hidden="true"
+        >
+          {{ entry.participantCount }}
+        </span>
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.call-activity-dock {
+  display: flex;
+  flex-shrink: 0;
+  flex-direction: column;
+  gap: 0.375rem;
+  min-height: 0;
+  max-height: min(40dvh, 18rem);
+  border-top: 1px solid var(--border);
+  border-right: 1px solid var(--border);
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in oklab, var(--card) 92%, transparent),
+      color-mix(in oklab, var(--sidebar-accent) 28%, var(--card))
+    );
+  padding: 0.5rem;
+}
+
+.call-activity-dock__header {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0 0.25rem;
+  color: var(--sidebar-muted);
+}
+
+.call-activity-dock__pulse {
+  width: 0.375rem;
+  height: 0.375rem;
+  border-radius: 9999px;
+  background: oklch(0.7 0.18 145);
+  box-shadow: 0 0 0 3px color-mix(in oklab, oklch(0.7 0.18 145) 24%, transparent);
+}
+
+.call-activity-dock__list {
+  display: grid;
+  gap: 0.25rem;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.call-activity-dock__row {
+  display: grid;
+  grid-template-columns: 1.5rem minmax(0, 1fr) auto;
+  min-height: 2.5rem;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: var(--radius-sm);
+  padding: 0.25rem 0.5rem;
+  color: var(--sidebar-muted);
+  text-align: left;
+  transition:
+    background-color 160ms ease-out,
+    color 160ms ease-out,
+    transform 160ms ease-out;
+}
+
+.call-activity-dock__row:hover,
+.call-activity-dock__row--active {
+  background: color-mix(in oklab, var(--sidebar-accent) 72%, transparent);
+  color: var(--sidebar-foreground);
+}
+
+.call-activity-dock__row:hover {
+  transform: translateY(-1px);
+}
+
+.call-activity-dock__row:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px color-mix(in oklab, var(--primary) 42%, transparent);
+}
+
+.call-activity-dock__icon {
+  display: inline-flex;
+  width: 1.5rem;
+  height: 1.5rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  background: color-mix(in oklab, oklch(0.7 0.18 145) 12%, transparent);
+  color: oklch(0.54 0.15 145);
+}
+
+:global(.dark) .call-activity-dock__icon {
+  color: oklch(0.82 0.14 145);
+}
+
+.call-activity-dock__copy {
+  display: grid;
+  min-width: 0;
+  gap: 0.0625rem;
+}
+
+.call-activity-dock__title,
+.call-activity-dock__status {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.call-activity-dock__status {
+  color: var(--sidebar-muted);
+}
+
+.call-activity-dock__count {
+  display: inline-flex;
+  min-width: 1.125rem;
+  height: 1.125rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  background: color-mix(in oklab, oklch(0.7 0.18 145) 18%, transparent);
+  color: oklch(0.48 0.14 145);
+  font-variant-numeric: tabular-nums;
+}
+
+.call-activity-dock.call-activity-dock--mobile {
+  max-height: none;
+  border-top: 0;
+  border-right: 0;
+  border-bottom: 1px solid var(--border);
+  padding: 0.375rem 0.75rem;
+}
+
+.call-activity-dock.call-activity-dock--mobile .call-activity-dock__header {
+  display: none;
+}
+
+.call-activity-dock.call-activity-dock--mobile .call-activity-dock__list {
+  display: flex;
+  gap: 0.375rem;
+  overflow-x: auto;
+  overflow-y: hidden;
+  overscroll-behavior-x: contain;
+  scrollbar-width: none;
+}
+
+.call-activity-dock.call-activity-dock--mobile .call-activity-dock__list::-webkit-scrollbar {
+  display: none;
+}
+
+.call-activity-dock.call-activity-dock--mobile .call-activity-dock__row {
+  min-width: min(14rem, 78vw);
+}
+
+@media (min-width: 64rem) {
+  .call-activity-dock.call-activity-dock--mobile {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .call-activity-dock__row {
+    transition: none;
+  }
+
+  .call-activity-dock__row:hover {
+    transform: none;
+  }
+}
+</style>

--- a/chat/src/components/calls/CallButton.vue
+++ b/chat/src/components/calls/CallButton.vue
@@ -17,15 +17,20 @@ const props = defineProps<{
 }>();
 
 const state = useStore($callState);
-const { hasActivity: hasPeerCallActivity } = useDmCallActivity(() => props.peerBareJid);
+const { activity: peerCallActivity } = useDmCallActivity(() => props.peerBareJid);
 
 /** A call is already in flight — disable the button so the
  *  caller can't start a parallel call while one is ringing or
- *  active. The store tracks a single slot today (see
- *  `CallState`). */
+ *  active. Hydrated peer activity alone stays actionable: sending
+ *  a fresh XEP-0353 propose lets the peer's active resource migrate
+ *  the call back to this refreshed client. */
 const inCall = computed(
-  () => (state.value.phase !== "idle" && state.value.phase !== "ended") || hasPeerCallActivity.value,
+  () => state.value.phase !== "idle" && state.value.phase !== "ended",
 );
+
+const hasPeerCallActivity = computed(() => !!peerCallActivity.value);
+const voiceLabel = computed(() => hasPeerCallActivity.value && !inCall.value ? "Reconnect voice call" : "Start voice call");
+const videoLabel = computed(() => hasPeerCallActivity.value && !inCall.value ? "Reconnect video call" : "Start video call");
 
 function getSender() {
   const client = connectionStore.client as unknown as { xmpp?: unknown } | null;
@@ -68,8 +73,8 @@ async function startCall(media: CallMedia): Promise<void> {
         ? 'text-muted-foreground opacity-40 cursor-not-allowed'
         : 'text-muted-foreground hover:bg-muted hover:text-foreground'"
       type="button"
-      title="Voice call"
-      aria-label="Start voice call"
+      :title="voiceLabel"
+      :aria-label="voiceLabel"
       :disabled="inCall"
       @click="startCall({ audio: true, video: false })"
     >
@@ -81,8 +86,8 @@ async function startCall(media: CallMedia): Promise<void> {
         ? 'text-muted-foreground opacity-40 cursor-not-allowed'
         : 'text-muted-foreground hover:bg-muted hover:text-foreground'"
       type="button"
-      title="Video call"
-      aria-label="Start video call"
+      :title="videoLabel"
+      :aria-label="videoLabel"
       :disabled="inCall"
       @click="startCall({ audio: true, video: true })"
     >

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -22,6 +22,7 @@ import PinnedPanel from "@/components/chat/PinnedPanel.vue";
 import UserSettingsPage from "@/components/chat/UserSettingsPage.vue";
 import WaddlesSidebar from "@/components/chat/WaddlesSidebar.vue";
 import AdminView from "@/components/admin/AdminView.vue";
+import CallActivityDock from "@/components/calls/CallActivityDock.vue";
 import { navigate, useRouteMatch, type AdminMatch, type AdminPanel } from "@/router";
 import { buildHomeDashboardProps } from "@/home/dashboard-props";
 import type { ChatAppController } from "@/shell/chat-app-controller";
@@ -241,6 +242,17 @@ onUnmounted(() => {
   />
   <div v-else class="chat-app-shell">
     <ChatMobileDrawers :controller="controller" />
+    <CallActivityDock
+      class="call-activity-dock--mobile"
+      :channels="waddles.sortedChannels.value"
+      :conversations="dmConversations.conversations.value"
+      :active-channel-id="waddles.activeChannelId.value"
+      :active-peer-jid="dmConversations.activePeerJid.value"
+      :sidebar-mode="ui.sidebarMode.value"
+      :active-channel-jids="messaging.activeChannels.value"
+      @select-channel="onSelectChannelFromSidebar"
+      @select-dm="selectDm"
+    />
 
     <!-- Desktop layout -->
     <div class="chat-desktop-shell">
@@ -307,6 +319,16 @@ onUnmounted(() => {
           :active-peer-jid="dmConversations.activePeerJid.value"
           @select-dm="selectDm"
           @new-dm="ui.showNewDm.value = true"
+        />
+        <CallActivityDock
+          :channels="waddles.sortedChannels.value"
+          :conversations="dmConversations.conversations.value"
+          :active-channel-id="waddles.activeChannelId.value"
+          :active-peer-jid="dmConversations.activePeerJid.value"
+          :sidebar-mode="ui.sidebarMode.value"
+          :active-channel-jids="messaging.activeChannels.value"
+          @select-channel="onSelectChannelFromSidebar"
+          @select-dm="selectDm"
         />
       </div>
 

--- a/chat/src/dms/conversations.ts
+++ b/chat/src/dms/conversations.ts
@@ -222,10 +222,7 @@ export function useDirectMessageConversations(
       for (const conversation of directConversations) {
         void currentClient.subscribeToPeerPresence(barePeerJid(conversation.partner)).catch(() => undefined);
       }
-      const hydrateDmCallActivities = currentClient.hydrateRecentDmCallActivities?.bind(currentClient);
-      if (hydrateDmCallActivities) {
-        await hydrateDmCallActivities().catch(() => undefined);
-      }
+      await currentClient.hydrateRecentDmCallActivities().catch(() => undefined);
       return true;
     } catch {
       // best-effort

--- a/chat/src/dms/conversations.ts
+++ b/chat/src/dms/conversations.ts
@@ -222,6 +222,10 @@ export function useDirectMessageConversations(
       for (const conversation of directConversations) {
         void currentClient.subscribeToPeerPresence(barePeerJid(conversation.partner)).catch(() => undefined);
       }
+      const hydrateDmCallActivities = currentClient.hydrateRecentDmCallActivities?.bind(currentClient);
+      if (hydrateDmCallActivities) {
+        await hydrateDmCallActivities().catch(() => undefined);
+      }
       return true;
     } catch {
       // best-effort

--- a/chat/src/lib/calls/call-activity-dock.ts
+++ b/chat/src/lib/calls/call-activity-dock.ts
@@ -1,0 +1,93 @@
+import type { ChannelSummary } from "@/lib/chat-types";
+import type { DmConversation } from "@/lib/xmpp/types";
+import { barePeerJid } from "@/lib/xmpp/jid";
+import {
+  callParticipantCountForChannel,
+} from "./muc-call-indicators";
+import type { DmCallActivity } from "./dm-call-activity";
+
+export type SidebarMode = "channels" | "dms";
+
+export type CallActivityDockEntry =
+  | {
+      kind: "channel";
+      key: string;
+      channelId: string;
+      title: string;
+      participantCount: number;
+      isActive: boolean;
+    }
+  | {
+      kind: "dm";
+      key: string;
+      peerJid: string;
+      title: string;
+      media: DmCallActivity["media"];
+      state: DmCallActivity["state"];
+      direction: DmCallActivity["direction"];
+      updatedAt: string;
+      isActive: boolean;
+    };
+type DmCallActivityDockEntry = Extract<CallActivityDockEntry, { kind: "dm" }>;
+
+export function buildCallActivityDockEntries(options: {
+  channels: ReadonlyArray<Pick<ChannelSummary, "id" | "name" | "jid">>;
+  conversations: ReadonlyArray<Pick<DmConversation, "peerJid" | "peerUsername">>;
+  activeChannelId: string | null;
+  activePeerJid: string | null;
+  sidebarMode: SidebarMode;
+  activeChannelJids: Iterable<string>;
+  callParticipantCounts: Record<string, number>;
+  dmCallActivities: Record<string, DmCallActivity>;
+}): CallActivityDockEntry[] {
+  const channelEntries = options.channels.flatMap((channel): CallActivityDockEntry[] => {
+    const participantCount = callParticipantCountForChannel(
+      channel,
+      options.callParticipantCounts,
+      options.activeChannelJids,
+    );
+    if (participantCount <= 0) return [];
+    return [{
+      kind: "channel",
+      key: `channel:${channel.id}`,
+      channelId: channel.id,
+      title: channel.name,
+      participantCount,
+      isActive: options.sidebarMode === "channels" && options.activeChannelId === channel.id,
+    }];
+  });
+
+  const conversationNames = new Map(
+    options.conversations.map((conversation) => [
+      barePeerJid(conversation.peerJid).toLowerCase(),
+      conversation.peerUsername,
+    ]),
+  );
+  const activePeer = barePeerJid(options.activePeerJid ?? "").toLowerCase();
+  const dmEntries = Object.values(options.dmCallActivities)
+    .map((activity): DmCallActivityDockEntry => {
+      const peerJid = barePeerJid(activity.peerJid).toLowerCase();
+      const fallbackName = peerJid.split("@")[0] || peerJid;
+      return {
+        kind: "dm",
+        key: `dm:${peerJid}:${activity.sid}`,
+        peerJid,
+        title: conversationNames.get(peerJid) ?? fallbackName,
+        media: activity.media,
+        state: activity.state,
+        direction: activity.direction,
+        updatedAt: activity.updatedAt,
+        isActive: options.sidebarMode === "dms" && activePeer === peerJid,
+      };
+    })
+    .sort((left, right) => {
+      const rightMs = Date.parse(right.updatedAt);
+      const leftMs = Date.parse(left.updatedAt);
+      if (Number.isFinite(rightMs) && Number.isFinite(leftMs) && rightMs !== leftMs) {
+        return rightMs - leftMs;
+      }
+      return left.title.localeCompare(right.title);
+    });
+
+  return [...channelEntries, ...dmEntries];
+}

--- a/chat/src/lib/calls/dm-call-activity.ts
+++ b/chat/src/lib/calls/dm-call-activity.ts
@@ -51,7 +51,7 @@ function isStale(timestamp: string, now: Date): boolean {
   return now.getTime() - ms > DM_CALL_ACTIVITY_ACTIVE_WINDOW_MS;
 }
 
-function millisecondsUntilStale(timestamp: string, now: Date): number | null {
+function millisecondsUntilStale(timestamp: string, now: Date): number {
   const ms = Date.parse(timestamp);
   if (!Number.isFinite(ms)) return 0;
   return ms + DM_CALL_ACTIVITY_ACTIVE_WINDOW_MS - now.getTime();
@@ -109,7 +109,6 @@ function scheduleActivityPrune(now = new Date()): void {
   let nextDelay: number | null = null;
   for (const activity of Object.values($dmCallActivities.get())) {
     const delay = millisecondsUntilStale(activity.updatedAt, now);
-    if (delay === null) continue;
     nextDelay = nextDelay === null ? delay : Math.min(nextDelay, delay);
   }
   if (nextDelay === null) return;

--- a/chat/src/lib/calls/dm-call-activity.ts
+++ b/chat/src/lib/calls/dm-call-activity.ts
@@ -4,12 +4,13 @@ import { map } from "nanostores";
 import { barePeerJid } from "@/lib/xmpp/jid";
 import type { CallEvent, CallMedia } from "./types";
 
-const ACTIVE_WINDOW_MS = 24 * 60 * 60 * 1000;
+export const DM_CALL_ACTIVITY_ACTIVE_WINDOW_MS = 24 * 60 * 60 * 1000;
 const MAX_TERMINAL_TIMESTAMPS = 1024;
+const PRUNE_TIMER_SLACK_MS = 1_000;
 
 type DmCallActivityState = "ringing" | "accepted";
 
-interface DmCallActivity {
+export interface DmCallActivity {
   peerJid: string;
   sid: string;
   media: CallMedia;
@@ -20,6 +21,7 @@ interface DmCallActivity {
 
 export const $dmCallActivities = map<Record<string, DmCallActivity>>({});
 const dmCallTerminalTimestamps = new Map<string, string>();
+let pruneTimer: ReturnType<typeof setTimeout> | null = null;
 
 interface DmCallEventEnvelope {
   event: CallEvent;
@@ -46,7 +48,13 @@ function timestampFromEnvelope(envelope: DmCallEventEnvelope): string {
 function isStale(timestamp: string, now: Date): boolean {
   const ms = Date.parse(timestamp);
   if (!Number.isFinite(ms)) return false;
-  return now.getTime() - ms > ACTIVE_WINDOW_MS;
+  return now.getTime() - ms > DM_CALL_ACTIVITY_ACTIVE_WINDOW_MS;
+}
+
+function millisecondsUntilStale(timestamp: string, now: Date): number | null {
+  const ms = Date.parse(timestamp);
+  if (!Number.isFinite(ms)) return null;
+  return ms + DM_CALL_ACTIVITY_ACTIVE_WINDOW_MS - now.getTime();
 }
 
 function isOlderThanCurrent(timestamp: string, current?: DmCallActivity): boolean {
@@ -90,6 +98,47 @@ function pruneTerminalTimestamps(now: Date): void {
   }
 }
 
+function clearPruneTimer(): void {
+  if (!pruneTimer) return;
+  clearTimeout(pruneTimer);
+  pruneTimer = null;
+}
+
+function scheduleActivityPrune(now = new Date()): void {
+  clearPruneTimer();
+  let nextDelay: number | null = null;
+  for (const activity of Object.values($dmCallActivities.get())) {
+    const delay = millisecondsUntilStale(activity.updatedAt, now);
+    if (delay === null) continue;
+    nextDelay = nextDelay === null ? delay : Math.min(nextDelay, delay);
+  }
+  if (nextDelay === null) return;
+  pruneTimer = setTimeout(() => {
+    pruneTimer = null;
+    pruneExpiredDmCallActivities();
+  }, Math.max(0, nextDelay) + PRUNE_TIMER_SLACK_MS);
+  (pruneTimer as { unref?: () => void }).unref?.();
+}
+
+export function pruneExpiredDmCallActivities(now = new Date()): void {
+  const current = $dmCallActivities.get();
+  const next: Record<string, DmCallActivity> = {};
+  let changed = false;
+  for (const [peerJid, activity] of Object.entries(current)) {
+    if (isStale(activity.updatedAt, now)) {
+      recordTerminal(peerJid, activity.sid, activity.updatedAt, now);
+      changed = true;
+      continue;
+    }
+    next[peerJid] = activity;
+  }
+  pruneTerminalTimestamps(now);
+  if (changed) {
+    $dmCallActivities.set(next);
+  }
+  scheduleActivityPrune(now);
+}
+
 function recordTerminal(peerJid: string, sid: string, timestamp: string, now = new Date()): void {
   const key = terminalKey(peerJid, sid);
   const previous = dmCallTerminalTimestamps.get(key);
@@ -129,6 +178,7 @@ function removeActivity(peerJid: string, sid: string): void {
   const next = { ...$dmCallActivities.get() };
   delete next[peerJid];
   $dmCallActivities.set(next);
+  scheduleActivityPrune();
 }
 
 export function clearDmCallActivity(peerJid: string, sid?: string): void {
@@ -167,6 +217,7 @@ export function applyDmCallEvent(envelope: DmCallEventEnvelope): void {
         direction: directionForEnvelope(envelope),
         updatedAt: timestamp,
       });
+      scheduleActivityPrune(now);
       return;
     case "proceed":
     case "session-initiate":
@@ -179,6 +230,7 @@ export function applyDmCallEvent(envelope: DmCallEventEnvelope): void {
         direction: previous?.direction ?? directionForEnvelope(envelope),
         updatedAt: timestamp,
       });
+      scheduleActivityPrune(now);
       return;
     case "reject":
     case "retract":
@@ -191,11 +243,13 @@ export function applyDmCallEvent(envelope: DmCallEventEnvelope): void {
 }
 
 export function clearDmCallActivities(): void {
+  clearPruneTimer();
   $dmCallActivities.set({});
   dmCallTerminalTimestamps.clear();
 }
 
-export function readDmCallActivity(peerJid: string): DmCallActivity | null {
+export function readDmCallActivity(peerJid: string, now = new Date()): DmCallActivity | null {
+  pruneExpiredDmCallActivities(now);
   const normalized = normalizedBare(peerJid);
   if (!normalized) return null;
   return $dmCallActivities.get()[normalized] ?? null;

--- a/chat/src/lib/calls/dm-call-activity.ts
+++ b/chat/src/lib/calls/dm-call-activity.ts
@@ -47,13 +47,13 @@ function timestampFromEnvelope(envelope: DmCallEventEnvelope): string {
 
 function isStale(timestamp: string, now: Date): boolean {
   const ms = Date.parse(timestamp);
-  if (!Number.isFinite(ms)) return false;
+  if (!Number.isFinite(ms)) return true;
   return now.getTime() - ms > DM_CALL_ACTIVITY_ACTIVE_WINDOW_MS;
 }
 
 function millisecondsUntilStale(timestamp: string, now: Date): number | null {
   const ms = Date.parse(timestamp);
-  if (!Number.isFinite(ms)) return null;
+  if (!Number.isFinite(ms)) return 0;
   return ms + DM_CALL_ACTIVITY_ACTIVE_WINDOW_MS - now.getTime();
 }
 

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -12,6 +12,7 @@ import {
 } from "../outbound-queue-store";
 import { $callState, applyCallEvent, clearCallState, tearDownActiveCall } from "@/lib/calls/call-store";
 import {
+  DM_CALL_ACTIVITY_ACTIVE_WINDOW_MS,
   applyDmCallEvent,
   clearDmCallActivities,
 } from "@/lib/calls/dm-call-activity";
@@ -221,8 +222,40 @@ function shouldSkipRawCatchupMessage(
   return compareTimestamps(message.timestamp, since) < 0;
 }
 
+const DM_CALL_ACTIVITY_PAGE_SIZE = 100;
+const DM_CALL_ACTIVITY_MAX_PAGES = 50;
+
+type DmCallActivityHydrationOptions = { since?: string; pageSize?: number; maxPages?: number };
+
+async function collectRecentMamPages(
+  fetchPage: (max: number, pageParam: MamPageParam) => Promise<WasmMamPage | null | undefined>,
+  options: DmCallActivityHydrationOptions,
+  shouldContinue: () => boolean,
+): Promise<WasmMamPage[]> {
+  const since = options.since ?? new Date(Date.now() - DM_CALL_ACTIVITY_ACTIVE_WINDOW_MS).toISOString();
+  const pageSize = options.pageSize ?? DM_CALL_ACTIVITY_PAGE_SIZE;
+  const maxPages = options.maxPages ?? DM_CALL_ACTIVITY_MAX_PAGES;
+  const pages: WasmMamPage[] = [];
+  let pageParam: MamPageParam = { type: "latest", start: since };
+  const seenBefore = new Set<string>();
+  for (let pageIndex = 0; pageIndex < maxPages; pageIndex += 1) {
+    if (!shouldContinue()) return [];
+    const page = await fetchPage(pageSize, pageParam);
+    if (!shouldContinue()) return [];
+    if (!page) return pages;
+    pages.push(page);
+    if (isMamPageComplete(page) || pageCrossesSince(page, since)) return pages;
+    const firstArchiveId = pageFirstArchiveId(page);
+    if (!firstArchiveId || seenBefore.has(firstArchiveId)) return pages;
+    seenBefore.add(firstArchiveId);
+    pageParam = { type: "before", before: firstArchiveId, start: since };
+  }
+  return pages;
+}
+
 type WasmModule = typeof import("@waddle/xmpp-client-wasm");
 type WasmClient = import("@waddle/xmpp-client-wasm").WaddleClient & {
+  fetch_personal_history_page?: (max: number, pageParam: MamPageParam) => Promise<WasmMamPage>;
   discover_extension_routes?: () => Promise<unknown>;
   fetch_extension_route_items?: (route: unknown, roomJid: string) => Promise<unknown>;
   admin_users_list?: (
@@ -534,6 +567,10 @@ export class BrowserXmppClient {
 
   private isCurrentXmpp(xmpp: XmppClientInstance): boolean {
     return this.xmpp === xmpp && !this.destroying;
+  }
+
+  private isCurrentConnectedXmpp(xmpp: XmppClientInstance, sessionJid: string): boolean {
+    return this.xmpp === xmpp && this.connected && !this.destroying && this.session.jid === sessionJid;
   }
 
   private rejectRoomJoinWaiters(error: Error): void {
@@ -1934,17 +1971,25 @@ export class BrowserXmppClient {
   ): MamHistoryPage<LiveDmMessage> {
     const selfBare = barePeerJid(this.session.jid);
     if (options.applyCallEvents !== false) {
-      for (const message of page.messages) {
-        if (!message.call_event) continue;
-        applyDmCallEvent({
-          event: message.call_event,
-          selfBareJid: selfBare,
-          to: message.to,
-          timestamp: message.timestamp,
-        });
-      }
+      this.applyDmCallEventsFromMamPage(page, selfBare);
     }
     return { messages: page.messages.map((message) => dmMessageFromArchived(message, selfBare)).filter((message): message is LiveDmMessage => !!message), ...(page.first_id ? { firstArchiveId: page.first_id } : {}), ...(page.last_id ? { lastArchiveId: page.last_id } : {}), complete: page.is_complete };
+  }
+  private applyDmCallEventsFromMamPage(
+    page: WasmMamPage | null | undefined,
+    selfBare = barePeerJid(this.session.jid),
+    options: { since?: string; seenIds?: ReadonlyArray<string> } = {},
+  ): void {
+    for (const message of page?.messages ?? []) {
+      if (!message.call_event) continue;
+      if (shouldSkipRawCatchupMessage(message, options.since, options.seenIds)) continue;
+      applyDmCallEvent({
+        event: message.call_event,
+        selfBareJid: selfBare,
+        to: message.to,
+        timestamp: message.timestamp,
+      });
+    }
   }
   private recordRoomMamWatermarks(messages: ReadonlyArray<LiveRoomMessage>) {
     for (const message of messages) {
@@ -1994,6 +2039,45 @@ export class BrowserXmppClient {
     const result = this.dmMamPageToMessages(page, { applyCallEvents: pageParam.type !== "before" });
     this.recordDmMamWatermarks(result.messages);
     return result;
+  }
+  async hydrateRecentDmCallActivity(
+    peerJid: string,
+    options: DmCallActivityHydrationOptions = {},
+  ): Promise<void> {
+    const xmpp = await this.requireConnectedXmpp();
+    if (!xmpp.fetch_dm_history_page) return;
+    const peer = barePeerJid(peerJid);
+    if (!peer) return;
+    const sessionJid = this.session.jid;
+    const fetchDmHistoryPage = xmpp.fetch_dm_history_page.bind(xmpp);
+    const pages = await collectRecentMamPages(
+      (max, pageParam) => fetchDmHistoryPage(peer, max, pageParam) as Promise<WasmMamPage>,
+      options,
+      () => this.isCurrentConnectedXmpp(xmpp, sessionJid),
+    );
+    if (!this.isCurrentConnectedXmpp(xmpp, sessionJid)) return;
+    const selfBare = barePeerJid(sessionJid);
+    for (const page of [...pages].reverse()) {
+      this.applyDmCallEventsFromMamPage(page, selfBare);
+    }
+  }
+  async hydrateRecentDmCallActivities(
+    options: DmCallActivityHydrationOptions = {},
+  ): Promise<void> {
+    const xmpp = await this.requireConnectedXmpp();
+    if (!xmpp.fetch_personal_history_page) return;
+    const sessionJid = this.session.jid;
+    const fetchPersonalHistoryPage = xmpp.fetch_personal_history_page.bind(xmpp);
+    const pages = await collectRecentMamPages(
+      (max, pageParam) => fetchPersonalHistoryPage(max, pageParam),
+      options,
+      () => this.isCurrentConnectedXmpp(xmpp, sessionJid),
+    );
+    if (!this.isCurrentConnectedXmpp(xmpp, sessionJid)) return;
+    const selfBare = barePeerJid(sessionJid);
+    for (const page of [...pages].reverse()) {
+      this.applyDmCallEventsFromMamPage(page, selfBare);
+    }
   }
   async searchDmMessages(peerJid: string, query: string, max = 20): Promise<MessageSearchResult[]> {
     if (!query.trim()) return [];
@@ -2450,7 +2534,6 @@ export class BrowserXmppClient {
   }
   private handleMessage(message: WasmMessage & { carbon?: { sent?: boolean; received?: boolean }; inboxPush?: InboxEntry; _fromCarbon?: boolean }) {
     if (message.inboxPush) { this.inboxPushHandler?.(message.inboxPush); return; }
-    if (message.carbon?.sent || message.carbon?.received) return;
     if (message.id && this.carbonDedupIds.has(message.id) && !message._fromCarbon) {
       this.carbonDedupIds.delete(message.id);
       return;
@@ -2464,6 +2547,7 @@ export class BrowserXmppClient {
       });
       if (!message.body && !message.subject) return;
     }
+    if (message.carbon?.sent || message.carbon?.received) return;
     if (message.chat_state && !message.body) {
       if (message.is_muc) { const roomJid = barePeerJid(message.from ?? message.to ?? ""); const nick = (message.from ?? "").split("/")[1] ?? "unknown"; if (roomJid === this.currentRoom && nick !== this.session.username) this.chatStateHandler?.({ roomJid, nick, state: message.chat_state as ChatStateType }); }
       else this.dmChatStateHandler?.({ peerJid: barePeerJid(message.from ?? message.to ?? ""), state: message.chat_state as ChatStateType });
@@ -2503,15 +2587,17 @@ export class BrowserXmppClient {
     xmpp: XmppClientInstance,
     entries: Array<{ kind: "dm" | "room"; key: string; after?: string; since?: string; seenIds?: string[] }>,
   ) {
+    const sessionJid = this.session.jid;
     for (const entry of entries) {
-      if (this.xmpp !== xmpp) return;
+      if (!this.isCurrentConnectedXmpp(xmpp, sessionJid)) return;
       try {
         if (entry.kind === "dm") {
-          await this.runDmReconnectCatchup(xmpp, entry);
+          await this.runDmReconnectCatchup(xmpp, entry, sessionJid);
         } else {
-          await this.runRoomReconnectCatchup(xmpp, entry);
+          await this.runRoomReconnectCatchup(xmpp, entry, sessionJid);
         }
       } catch (error) {
+        if (!this.isCurrentConnectedXmpp(xmpp, sessionJid)) return;
         this.emitError({
           kind: "history",
           recoverable: true,
@@ -2524,6 +2610,7 @@ export class BrowserXmppClient {
   private async runDmReconnectCatchup(
     xmpp: XmppClientInstance,
     entry: { key: string; after?: string; since?: string; seenIds?: string[] },
+    sessionJid: string,
   ) {
     if (!xmpp.fetch_dm_history_page) return;
     if (entry.after) {
@@ -2533,6 +2620,7 @@ export class BrowserXmppClient {
         if (seenAfter.has(after)) throw new Error(`Reconnect catch-up repeated archive cursor for ${entry.key}`);
         seenAfter.add(after);
         const page = await xmpp.fetch_dm_history_page(entry.key, 100, { type: "after", after }) as WasmMamPage;
+        if (!this.isCurrentConnectedXmpp(xmpp, sessionJid)) return;
         const nextAfter = this.applyDmCatchupPage(page, undefined, entry.seenIds);
         if (isMamPageComplete(page)) return;
         if (!nextAfter) throw new Error(`Reconnect catch-up could not advance archive cursor for ${entry.key}`);
@@ -2542,11 +2630,12 @@ export class BrowserXmppClient {
     }
     const since = entry.since ?? this.catchup.getDmLastSeen(entry.key);
     if (!since) return;
-    await this.runDmTimestampCatchup(xmpp, entry.key, since, entry.seenIds);
+    await this.runDmTimestampCatchup(xmpp, entry.key, since, sessionJid, entry.seenIds);
   }
   private async runRoomReconnectCatchup(
     xmpp: XmppClientInstance,
     entry: { key: string; after?: string; since?: string; seenIds?: string[] },
+    sessionJid: string,
   ) {
     if (!xmpp.fetch_room_history_page) return;
     if (entry.after) {
@@ -2556,6 +2645,7 @@ export class BrowserXmppClient {
         if (seenAfter.has(after)) throw new Error(`Reconnect catch-up repeated archive cursor for ${entry.key}`);
         seenAfter.add(after);
         const page = await xmpp.fetch_room_history_page(entry.key, 100, { type: "after", after }) as WasmMamPage;
+        if (!this.isCurrentConnectedXmpp(xmpp, sessionJid)) return;
         const nextAfter = this.applyRoomCatchupPage(page, undefined, entry.seenIds);
         if (isMamPageComplete(page)) return;
         if (!nextAfter) throw new Error(`Reconnect catch-up could not advance archive cursor for ${entry.key}`);
@@ -2565,58 +2655,74 @@ export class BrowserXmppClient {
     }
     const since = entry.since ?? this.catchup.getRoomLastSeen(entry.key);
     if (!since) return;
-    await this.runRoomTimestampCatchup(xmpp, entry.key, since, entry.seenIds);
+    await this.runRoomTimestampCatchup(xmpp, entry.key, since, sessionJid, entry.seenIds);
   }
   private async runDmTimestampCatchup(
     xmpp: XmppClientInstance,
     peerJid: string,
     since: string,
+    sessionJid: string,
     seenIds?: ReadonlyArray<string>,
   ) {
     let pageParam: MamPageParam = { type: "latest" };
     const seenBefore = new Set<string>();
+    const pages: WasmMamPage[] = [];
     while (true) {
       const page = await xmpp.fetch_dm_history_page?.(peerJid, 100, pageParam) as WasmMamPage;
-      this.applyDmCatchupPage(page, since, seenIds);
-      if (isMamPageComplete(page) || pageCrossesSince(page, since)) return;
+      if (!this.isCurrentConnectedXmpp(xmpp, sessionJid)) return;
+      if (page) pages.push(page);
+      if (isMamPageComplete(page) || pageCrossesSince(page, since)) break;
       const firstArchiveId = pageFirstArchiveId(page);
       if (!firstArchiveId) throw new Error(`Reconnect catch-up could not page backward for ${peerJid}`);
       if (seenBefore.has(firstArchiveId)) throw new Error(`Reconnect catch-up repeated backward archive cursor for ${peerJid}`);
       seenBefore.add(firstArchiveId);
       pageParam = { type: "before", before: firstArchiveId };
     }
+    const selfBare = barePeerJid(this.session.jid);
+    for (const page of [...pages].reverse()) {
+      this.applyDmCatchupPage(page, since, seenIds, { applyCallEvents: false });
+    }
+    for (const page of [...pages].reverse()) {
+      this.applyDmCallEventsFromMamPage(page, selfBare, { since, seenIds });
+    }
   }
   private async runRoomTimestampCatchup(
     xmpp: XmppClientInstance,
     roomJid: string,
     since: string,
+    sessionJid: string,
     seenIds?: ReadonlyArray<string>,
   ) {
     let pageParam: MamPageParam = { type: "latest" };
     const seenBefore = new Set<string>();
+    const pages: WasmMamPage[] = [];
     while (true) {
       const page = await xmpp.fetch_room_history_page?.(roomJid, 100, pageParam) as WasmMamPage;
-      this.applyRoomCatchupPage(page, since, seenIds);
-      if (isMamPageComplete(page) || pageCrossesSince(page, since)) return;
+      if (!this.isCurrentConnectedXmpp(xmpp, sessionJid)) return;
+      if (page) pages.push(page);
+      if (isMamPageComplete(page) || pageCrossesSince(page, since)) break;
       const firstArchiveId = pageFirstArchiveId(page);
       if (!firstArchiveId) throw new Error(`Reconnect catch-up could not page backward for ${roomJid}`);
       if (seenBefore.has(firstArchiveId)) throw new Error(`Reconnect catch-up repeated backward archive cursor for ${roomJid}`);
       seenBefore.add(firstArchiveId);
       pageParam = { type: "before", before: firstArchiveId };
     }
+    for (const page of [...pages].reverse()) {
+      this.applyRoomCatchupPage(page, since, seenIds);
+    }
   }
-  private applyDmCatchupPage(page: WasmMamPage | null | undefined, since?: string, seenIds?: ReadonlyArray<string>): string | undefined {
+  private applyDmCatchupPage(
+    page: WasmMamPage | null | undefined,
+    since?: string,
+    seenIds?: ReadonlyArray<string>,
+    options: { applyCallEvents?: boolean } = {},
+  ): string | undefined {
     let lastArchiveId = pageLastArchiveId(page);
     const selfBare = barePeerJid(this.session.jid);
+    if (options.applyCallEvents !== false) {
+      this.applyDmCallEventsFromMamPage(page, selfBare, { since, seenIds });
+    }
     for (const message of page?.messages ?? []) {
-      if (message.call_event && !shouldSkipRawCatchupMessage(message, since, seenIds)) {
-        applyDmCallEvent({
-          event: message.call_event,
-          selfBareJid: selfBare,
-          to: message.to,
-          timestamp: message.timestamp,
-        });
-      }
       const converted = dmMessageFromArchived(message, selfBare);
       if (!converted || shouldSkipCatchupMessage(converted, since, seenIds)) continue;
       this.catchup.recordDmSeen(converted.peerJid, converted.createdAt, converted.archiveId, messageSeenIds(converted));

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -20,9 +20,9 @@ export interface XmppStatusSnapshot {
 export type SessionLifecycleEvent = { type: "resumed" } | { type: "fresh" };
 
 export type MamPageParam =
-  | { type: "latest" }
-  | { type: "before"; before: string }
-  | { type: "after"; after: string };
+  | { type: "latest"; start?: string }
+  | { type: "before"; before: string; start?: string }
+  | { type: "after"; after: string; start?: string };
 
 export type MamThreadPageParam =
   | { type: "latest" }

--- a/chat/src/styles/global/shell.css
+++ b/chat/src/styles/global/shell.css
@@ -158,6 +158,7 @@
 
   .chat-sidebar-slot {
     flex-basis: var(--chat-sidebar-width);
+    flex-direction: column;
   }
 }
 
@@ -333,7 +334,8 @@
   width: var(--chat-sidebar-width);
   min-width: 0;
   min-height: 0;
-  flex-shrink: 0;
+  flex: 1 1 0%;
+  flex-shrink: 1;
   flex-direction: column;
   border-right: 1px solid var(--border);
 }

--- a/chat/tests/call-activity-dock.test.ts
+++ b/chat/tests/call-activity-dock.test.ts
@@ -1,0 +1,248 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { createSSRApp, h } from "vue";
+import { parse, compileScript } from "vue/compiler-sfc";
+import { renderToString } from "vue/server-renderer";
+import ts from "typescript";
+import {
+  buildCallActivityDockEntries,
+} from "../src/lib/calls/call-activity-dock";
+import { clearMucCallParticipants, $mucCallParticipants } from "../src/lib/calls/muc-call-presence";
+import { clearDmCallActivities, $dmCallActivities } from "../src/lib/calls/dm-call-activity";
+import type { DmCallActivity } from "../src/lib/calls/dm-call-activity";
+
+afterEach(() => {
+  clearMucCallParticipants();
+  clearDmCallActivities();
+});
+
+describe("call activity dock model", () => {
+  test("surfaces group calls and DM calls across sidebar modes", () => {
+    const dmActivity: DmCallActivity = {
+      peerJid: "bob@example.com",
+      sid: "dm-call-1",
+      media: { audio: true, video: true },
+      state: "accepted",
+      direction: "incoming",
+      updatedAt: "2026-05-25T12:00:00.000Z",
+    };
+
+    const entries = buildCallActivityDockEntries({
+      channels: [
+        { id: "general", name: "General", jid: "general@conference.example.com" },
+        { id: "design", name: "Design", jid: "design@conference.example.com" },
+      ],
+      conversations: [
+        { peerJid: "bob@example.com", peerUsername: "Bob" },
+      ],
+      activeChannelId: "general",
+      activePeerJid: null,
+      sidebarMode: "channels",
+      activeChannelJids: new Set(["general@conference.example.com"]),
+      callParticipantCounts: {
+        "general@conference.example.com": 3,
+      },
+      dmCallActivities: {
+        "bob@example.com": dmActivity,
+      },
+    });
+
+    expect(entries).toEqual([
+      {
+        kind: "channel",
+        key: "channel:general",
+        channelId: "general",
+        title: "General",
+        participantCount: 3,
+        isActive: true,
+      },
+      {
+        kind: "dm",
+        key: "dm:bob@example.com:dm-call-1",
+        peerJid: "bob@example.com",
+        title: "Bob",
+        media: { audio: true, video: true },
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:00:00.000Z",
+        isActive: false,
+      },
+    ]);
+  });
+
+  test("falls back to peer localpart and orders DM calls by recency", () => {
+    const entries = buildCallActivityDockEntries({
+      channels: [],
+      conversations: [],
+      activeChannelId: null,
+      activePeerJid: "carol@example.com",
+      sidebarMode: "dms",
+      activeChannelJids: new Set(),
+      callParticipantCounts: {},
+      dmCallActivities: {
+        "bob@example.com": {
+          peerJid: "bob@example.com",
+          sid: "older",
+          media: { audio: true, video: false },
+          state: "ringing",
+          direction: "outgoing",
+          updatedAt: "2026-05-25T11:00:00.000Z",
+        },
+        "carol@example.com": {
+          peerJid: "carol@example.com",
+          sid: "newer",
+          media: { audio: true, video: false },
+          state: "accepted",
+          direction: "unknown",
+          updatedAt: "2026-05-25T12:00:00.000Z",
+        },
+      },
+    });
+
+    expect(entries.map((entry) => entry.title)).toEqual(["carol", "bob"]);
+    expect(entries[0]).toMatchObject({
+      kind: "dm",
+      peerJid: "carol@example.com",
+      isActive: true,
+    });
+  });
+});
+
+describe("CallActivityDock rendering", () => {
+  test("renders group and DM call entries from the live stores", async () => {
+    $mucCallParticipants.set({
+      "general@conference.example.com": ["alice", "bob"],
+    });
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com",
+        sid: "dm-call-1",
+        media: { audio: true, video: true },
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:00:00.000Z",
+      },
+    });
+
+    const html = await renderCallActivityDock({
+      channels: [
+        { id: "general", name: "General", jid: "general@conference.example.com" },
+      ],
+      conversations: [
+        { peerJid: "bob@example.com", peerUsername: "Bob", unreadCount: 0 },
+      ],
+      activeChannelId: null,
+      activePeerJid: null,
+      sidebarMode: "channels",
+      activeChannelJids: new Set<string>(),
+    });
+
+    expect(html).toContain("Calls");
+    expect(html).toContain("General");
+    expect(html).toContain("Bob");
+    expect(html).toContain("2 people");
+    expect(html).toContain("Live");
+  });
+
+  test("is mounted in the desktop sidebar and visible mobile shell", () => {
+    const readyShell = readFileSync(new URL("../src/components/chat/ChatReadyShell.vue", import.meta.url), "utf8");
+    const mobileDrawers = readFileSync(new URL("../src/components/chat/ChatMobileDrawers.vue", import.meta.url), "utf8");
+
+    expect(readyShell).toContain("import CallActivityDock");
+    expect(readyShell.match(/<CallActivityDock/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+    expect(readyShell).toContain("class=\"call-activity-dock--mobile\"");
+    expect(readyShell).toContain("@select-channel=\"onSelectChannelFromSidebar\"");
+    expect(readyShell).toContain("@select-dm=\"selectDm\"");
+
+    expect(mobileDrawers).not.toContain("CallActivityDock");
+  });
+
+  test("keeps the dock bounded and hydrated DM call controls actionable", () => {
+    const dock = readFileSync(new URL("../src/components/calls/CallActivityDock.vue", import.meta.url), "utf8");
+    const callButton = readFileSync(new URL("../src/components/calls/CallButton.vue", import.meta.url), "utf8");
+
+    expect(dock).toContain("max-height: min(40dvh, 18rem)");
+    expect(dock).toContain("overflow-y: auto");
+    expect(callButton).toContain("Hydrated peer activity alone stays actionable");
+    expect(callButton).toContain("state.value.phase !== \"idle\" && state.value.phase !== \"ended\"");
+    expect(callButton).not.toContain("|| hasPeerCallActivity.value");
+  });
+});
+
+async function renderCallActivityDock(props: Record<string, unknown>) {
+  const component = await loadCallActivityDockComponent();
+  return renderToString(createSSRApp({ render: () => h(component, props) }));
+}
+
+async function loadCallActivityDockComponent() {
+  const filename = new URL("../src/components/calls/CallActivityDock.vue", import.meta.url);
+  const source = readFileSync(filename, "utf8");
+  const { descriptor } = parse(source, { filename: filename.pathname });
+  const script = compileScript(descriptor, { id: "call-activity-dock-test", inlineTemplate: true });
+
+  const tempDir = mkdtempSync(join(tmpdir(), "waddle-call-activity-dock-"));
+  try {
+    const compiled = [
+      rewriteImports(script.content.replace("export default", "const __sfc__ ="), filename, tempDir),
+      "export default __sfc__;",
+    ].join("\n");
+
+    const js = ts.transpileModule(compiled, {
+      compilerOptions: {
+        module: ts.ModuleKind.ESNext,
+        target: ts.ScriptTarget.ES2022,
+        verbatimModuleSyntax: false,
+      },
+    }).outputText;
+    const modulePath = join(tempDir, "CallActivityDock.mjs");
+    writeFileSync(modulePath, js);
+    const component = await import(pathToFileURL(modulePath).href);
+    return component.default;
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function rewriteImports(code: string, importer: URL, tempDir: string): string {
+  return code.replace(/from\s+["']([^"']+)["']/g, (_match, specifier: string) =>
+    `from ${JSON.stringify(resolveModuleSpecifier(specifier, importer, tempDir))}`);
+}
+
+function resolveModuleSpecifier(specifier: string, importer: URL, tempDir: string): string {
+  if (specifier.startsWith("@/")) {
+    return moduleUrlForPath(resolveSourcePath(new URL(`../src/${specifier.slice(2)}`, import.meta.url).pathname), specifier, tempDir);
+  }
+  if (specifier.startsWith(".")) {
+    return moduleUrlForPath(resolveSourcePath(new URL(specifier, importer).pathname), specifier, tempDir);
+  }
+  return import.meta.resolve(specifier);
+}
+
+function resolveSourcePath(basePath: string): string {
+  const candidates = [
+    basePath,
+    `${basePath}.ts`,
+    `${basePath}.tsx`,
+    `${basePath}.js`,
+    `${basePath}.mjs`,
+    `${basePath}.vue`,
+    `${basePath}.json`,
+    `${basePath}/index.ts`,
+  ];
+  const resolved = candidates.find((candidate) => existsSync(candidate));
+  if (!resolved) throw new Error(`Unable to resolve test SFC import: ${basePath}`);
+  return resolved;
+}
+
+function moduleUrlForPath(resolvedPath: string, specifier: string, tempDir: string): string {
+  if (!resolvedPath.endsWith(".vue")) return pathToFileURL(resolvedPath).href;
+  const stubPath = join(tempDir, `${specifier.replace(/[^a-z0-9]/gi, "_")}.mjs`);
+  writeFileSync(stubPath, [
+    `import { h } from ${JSON.stringify(import.meta.resolve("vue"))};`,
+    `export default { name: ${JSON.stringify(`${specifier}Stub`)}, setup(_, { slots }) { return () => h("span", { "data-vue-stub": ${JSON.stringify(specifier)} }, slots.default?.()); } };`,
+  ].join("\n"));
+  return pathToFileURL(stubPath).href;
+}

--- a/chat/tests/call-activity-dock.test.ts
+++ b/chat/tests/call-activity-dock.test.ts
@@ -186,7 +186,7 @@ async function loadCallActivityDockComponent() {
   const tempDir = mkdtempSync(join(tmpdir(), "waddle-call-activity-dock-"));
   try {
     const compiled = [
-      rewriteImports(script.content.replace("export default", "const __sfc__ ="), filename, tempDir),
+      rewriteImports(script.content.replace("export default", "const __sfc__ ="), filename),
       "export default __sfc__;",
     ].join("\n");
 
@@ -206,17 +206,17 @@ async function loadCallActivityDockComponent() {
   }
 }
 
-function rewriteImports(code: string, importer: URL, tempDir: string): string {
+function rewriteImports(code: string, importer: URL): string {
   return code.replace(/from\s+["']([^"']+)["']/g, (_match, specifier: string) =>
-    `from ${JSON.stringify(resolveModuleSpecifier(specifier, importer, tempDir))}`);
+    `from ${JSON.stringify(resolveModuleSpecifier(specifier, importer))}`);
 }
 
-function resolveModuleSpecifier(specifier: string, importer: URL, tempDir: string): string {
+function resolveModuleSpecifier(specifier: string, importer: URL): string {
   if (specifier.startsWith("@/")) {
-    return moduleUrlForPath(resolveSourcePath(new URL(`../src/${specifier.slice(2)}`, import.meta.url).pathname), specifier, tempDir);
+    return moduleUrlForPath(resolveSourcePath(new URL(`../src/${specifier.slice(2)}`, import.meta.url).pathname));
   }
   if (specifier.startsWith(".")) {
-    return moduleUrlForPath(resolveSourcePath(new URL(specifier, importer).pathname), specifier, tempDir);
+    return moduleUrlForPath(resolveSourcePath(new URL(specifier, importer).pathname));
   }
   return import.meta.resolve(specifier);
 }
@@ -237,12 +237,7 @@ function resolveSourcePath(basePath: string): string {
   return resolved;
 }
 
-function moduleUrlForPath(resolvedPath: string, specifier: string, tempDir: string): string {
+function moduleUrlForPath(resolvedPath: string): string {
   if (!resolvedPath.endsWith(".vue")) return pathToFileURL(resolvedPath).href;
-  const stubPath = join(tempDir, `${specifier.replace(/[^a-z0-9]/gi, "_")}.mjs`);
-  writeFileSync(stubPath, [
-    `import { h } from ${JSON.stringify(import.meta.resolve("vue"))};`,
-    `export default { name: ${JSON.stringify(`${specifier}Stub`)}, setup(_, { slots }) { return () => h("span", { "data-vue-stub": ${JSON.stringify(specifier)} }, slots.default?.()); } };`,
-  ].join("\n"));
-  return pathToFileURL(stubPath).href;
+  return new URL("./helpers/vue-sfc-stub.ts", import.meta.url).href;
 }

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -6,6 +6,7 @@ import { useDirectMessages } from "../src/dms/messages";
 import { useChannelMessages } from "../src/channels/messages";
 import { BrowserXmppClient, roomBareJidFor, type InboxEntry, type LiveDmMessage, type RoomActivityEvent } from "../src/lib/xmpp-client";
 import { enqueueQueuedMessage, listQueuedDmMessages, listQueuedRoomMessages } from "../src/lib/outbound-queue-store";
+import { clearDmCallActivities, readDmCallActivity } from "../src/lib/calls/dm-call-activity";
 import { handlerStubs } from "./helpers/xmpp-client-mock";
 
 function session(partial: Partial<WaddleSession> = {}): WaddleSession {
@@ -103,9 +104,11 @@ beforeEach(() => {
     localStorage: storage,
   } as Window & { localStorage: typeof storage };
   localStorage.clear();
+  clearDmCallActivities();
 });
 
 afterEach(() => {
+  clearDmCallActivities();
   localStorage.clear();
   if (originalLocalStorage === undefined) {
     Reflect.deleteProperty(globalThis, "localStorage");
@@ -869,9 +872,147 @@ describe("client keepalive lifecycle", () => {
     });
     expect(fetchDmHistoryPage).toHaveBeenCalledTimes(3);
     expect(dmHandler).toHaveBeenCalledTimes(3);
+    expect(dmHandler.mock.calls.map(([message]) => (message as LiveDmMessage).id)).toEqual([
+      "dm-same-time-missed",
+      "dm-newer-1",
+      "dm-newer-2",
+    ]);
     expect(dmHandler).toHaveBeenCalledWith(expect.objectContaining({ id: "dm-newer-2" }));
     expect(dmHandler).toHaveBeenCalledWith(expect.objectContaining({ id: "dm-newer-1" }));
     expect(dmHandler).toHaveBeenCalledWith(expect.objectContaining({ id: "dm-same-time-missed" }));
+  });
+
+  test("timestamp fallback replays DM call events oldest-to-newest across pages", async () => {
+    const client = new BrowserXmppClient(session());
+    const catchup = (client as unknown as {
+      catchup: {
+        recordDmSeen: (peer: string, ts: string, archiveId?: string, seenIds?: string[]) => void;
+        onSessionStarted: () => unknown[];
+      };
+    }).catchup;
+    catchup.recordDmSeen("bob@example.com", "2024-01-01T00:00:00.000Z");
+    catchup.onSessionStarted();
+    const fetchDmHistoryPage = mock(async (_peer: string, _max: number, pageParam: { type: string; before?: string }) => {
+      if (pageParam.type === "latest") {
+        return {
+          messages: [{
+            mam_id: "mam-proceed",
+            from: "alice@example.com/desktop",
+            to: "bob@example.com/phone",
+            message_type: "chat",
+            timestamp: new Date(Date.now() - 60_000).toISOString(),
+            reaction_emojis: [],
+            shared_files: [],
+            call_event: {
+              kind: "proceed",
+              from: "alice@example.com/desktop",
+              to: "bob@example.com/phone",
+              sid: "call-replay",
+            },
+          }],
+          first_id: "mam-proceed",
+          last_id: "mam-proceed",
+          is_complete: false,
+        };
+      }
+      return {
+        messages: [{
+          mam_id: "mam-propose",
+          from: "bob@example.com/phone",
+          to: "alice@example.com/desktop",
+          message_type: "chat",
+          timestamp: new Date(Date.now() - 120_000).toISOString(),
+          reaction_emojis: [],
+          shared_files: [],
+          call_event: {
+            kind: "propose",
+            from: "bob@example.com/phone",
+            sid: "call-replay",
+            media: { audio: true, video: true },
+          },
+        }],
+        first_id: "mam-propose",
+        last_id: "mam-propose",
+        is_complete: true,
+      };
+    });
+
+    const xmpp = Object.assign(new EventEmitter(), {
+      fetch_dm_history_page: fetchDmHistoryPage,
+    }) as unknown as Agent;
+    (client as unknown as { xmpp: Agent }).xmpp = xmpp;
+    (client as unknown as { wireEvents: (xmpp: Agent) => void }).wireEvents(xmpp);
+
+    xmpp.emit("stream:management:resumed");
+    await settleReconnectCatchup();
+
+    expect(fetchDmHistoryPage).toHaveBeenNthCalledWith(2, "bob@example.com", 100, {
+      type: "before",
+      before: "mam-proceed",
+    });
+    expect(readDmCallActivity("bob@example.com")).toMatchObject({
+      sid: "call-replay",
+      state: "accepted",
+      direction: "incoming",
+      media: { audio: true, video: true },
+    });
+  });
+
+  test("drops DM timestamp catch-up pages after the XMPP handle disconnects while awaiting MAM", async () => {
+    const client = new BrowserXmppClient(session());
+    const catchup = (client as unknown as {
+      catchup: {
+        recordDmSeen: (peer: string, ts: string, archiveId?: string, seenIds?: string[]) => void;
+        onSessionStarted: () => unknown[];
+      };
+    }).catchup;
+    catchup.recordDmSeen("bob@example.com", "2024-01-01T00:00:00.000Z");
+    catchup.onSessionStarted();
+    const dmHandler = mock(() => undefined);
+    client.setDirectMessageHandler(dmHandler);
+    let resolvePage: ((page: unknown) => void) | null = null;
+    const fetchDmHistoryPage = mock(async () => new Promise((resolve) => {
+      resolvePage = resolve;
+    }));
+
+    const xmpp = Object.assign(new EventEmitter(), {
+      fetch_dm_history_page: fetchDmHistoryPage,
+    }) as unknown as Agent;
+    (client as unknown as { xmpp: Agent }).xmpp = xmpp;
+    (client as unknown as { wireEvents: (xmpp: Agent) => void }).wireEvents(xmpp);
+
+    xmpp.emit("stream:management:resumed");
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fetchDmHistoryPage).toHaveBeenCalledTimes(1);
+
+    xmpp.emit("disconnected");
+    resolvePage?.({
+      messages: [{
+        mam_id: "mam-stale",
+        id: "dm-stale",
+        from: "bob@example.com/phone",
+        to: "alice@example.com/desktop",
+        message_type: "chat",
+        body: "stale after disconnect",
+        timestamp: new Date().toISOString(),
+        reaction_emojis: [],
+        shared_files: [],
+        call_event: {
+          kind: "propose",
+          from: "bob@example.com/phone",
+          sid: "stale-after-disconnect",
+          media: { audio: true, video: true },
+        },
+      }],
+      first_id: "mam-stale",
+      last_id: "mam-stale",
+      is_complete: true,
+    });
+    await settleReconnectCatchup();
+
+    expect(dmHandler).toHaveBeenCalledTimes(0);
+    expect(readDmCallActivity("bob@example.com")).toBeNull();
   });
 
   test("timestamp fallback continues beyond fifty pages until it crosses the last seen timestamp", async () => {
@@ -1658,6 +1799,112 @@ describe("carbon forwarding", () => {
     });
 
     expect(dmHandler).toHaveBeenCalledTimes(0);
+  });
+
+  test("applies carbon-wrapped call activity on generic message events", () => {
+    const client = new BrowserXmppClient(session());
+    const xmpp = Object.assign(new EventEmitter(), {}) as unknown as Agent;
+    (client as unknown as { xmpp: Agent }).xmpp = xmpp;
+    (client as unknown as { wireEvents: (xmpp: Agent) => void }).wireEvents(xmpp);
+
+    xmpp.emit("message", {
+      id: "call-carbon-1",
+      type: "chat",
+      from: "alice@example.com/phone",
+      to: "bob@example.com/desktop",
+      timestamp: new Date().toISOString(),
+      carbon: { sent: true },
+      call_event: {
+        kind: "propose",
+        from: "alice@example.com/phone",
+        to: "bob@example.com/desktop",
+        sid: "call-carbon-1",
+        media: { audio: true, video: true },
+      },
+    });
+
+    expect(readDmCallActivity("bob@example.com")).toMatchObject({
+      sid: "call-carbon-1",
+      direction: "outgoing",
+      media: { audio: true, video: true },
+    });
+  });
+
+  test("applies call activity from carbon:sent events", () => {
+    const client = new BrowserXmppClient(session());
+    const xmpp = Object.assign(new EventEmitter(), {}) as unknown as Agent;
+    (client as unknown as { xmpp: Agent }).xmpp = xmpp;
+    (client as unknown as { wireEvents: (xmpp: Agent) => void }).wireEvents(xmpp);
+
+    xmpp.emit("carbon:sent", {
+      carbon: {
+        forward: {
+          message: {
+            id: "call-carbon-sent",
+            type: "chat",
+            from: "alice@example.com/phone",
+            to: "bob@example.com/desktop",
+            timestamp: new Date().toISOString(),
+            call_event: {
+              kind: "propose",
+              from: "alice@example.com/phone",
+              to: "bob@example.com/desktop",
+              sid: "call-carbon-sent",
+              media: { audio: true, video: true },
+            },
+          },
+        },
+      },
+    });
+
+    expect(readDmCallActivity("bob@example.com")).toMatchObject({
+      sid: "call-carbon-sent",
+      direction: "outgoing",
+      media: { audio: true, video: true },
+    });
+  });
+
+  test("deduplicates carbon:received call activity against the forwarded message event", () => {
+    const client = new BrowserXmppClient(session());
+    const xmpp = Object.assign(new EventEmitter(), {}) as unknown as Agent;
+    (client as unknown as { xmpp: Agent }).xmpp = xmpp;
+    (client as unknown as { wireEvents: (xmpp: Agent) => void }).wireEvents(xmpp);
+
+    const forwarded = {
+      id: "call-carbon-received",
+      type: "chat",
+      from: "bob@example.com/phone",
+      to: "alice@example.com/desktop",
+      timestamp: new Date().toISOString(),
+      call_event: {
+        kind: "propose",
+        from: "bob@example.com/phone",
+        sid: "call-carbon-received",
+        media: { audio: true, video: false },
+      },
+    };
+    xmpp.emit("carbon:received", {
+      carbon: {
+        forward: {
+          message: forwarded,
+        },
+      },
+    });
+    xmpp.emit("message", {
+      ...forwarded,
+      call_event: {
+        kind: "finish",
+        from: "bob@example.com/phone",
+        sid: "call-carbon-received",
+        reason: "success",
+      },
+    });
+
+    expect(readDmCallActivity("bob@example.com")).toMatchObject({
+      sid: "call-carbon-received",
+      direction: "incoming",
+      media: { audio: true, video: false },
+    });
   });
 
   test("forwards carbon:sent messages to the DM handler", () => {

--- a/chat/tests/dm-call-activity-hydration.test.ts
+++ b/chat/tests/dm-call-activity-hydration.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { BrowserXmppClient } from "../src/lib/xmpp-client";
+import {
+  clearDmCallActivities,
+  readDmCallActivity,
+} from "../src/lib/calls/dm-call-activity";
+import type { WaddleSession } from "../src/lib/server-auth";
+
+function session(): WaddleSession {
+  return {
+    username: "alice",
+    jid: "alice@example.com",
+    session_id: "tok",
+    xmpp_websocket_url: "wss://example.com/ws",
+  } as WaddleSession;
+}
+
+describe("DM call activity hydration", () => {
+  beforeEach(() => {
+    clearDmCallActivities();
+  });
+
+  afterEach(() => {
+    clearDmCallActivities();
+  });
+
+  test("hydrates active call state from personal MAM pages without loading the DM timeline", async () => {
+    const now = Date.now();
+    const timestamp = (offsetMs: number) => new Date(now + offsetMs).toISOString();
+    const latestPage = {
+      messages: [
+        {
+          mam_id: "mam-proceed",
+          from: "alice@example.com/web",
+          to: "bob@example.com/phone",
+          timestamp: timestamp(-60_000),
+          call_event: {
+            kind: "proceed",
+            from: "alice@example.com/web",
+            to: "bob@example.com/phone",
+            sid: "call-1",
+          },
+        },
+      ],
+      first_id: "mam-proceed",
+      last_id: "mam-proceed",
+      is_complete: false,
+    };
+    const olderPage = {
+      messages: [
+        {
+          mam_id: "mam-propose",
+          from: "bob@example.com/phone",
+          to: "alice@example.com/web",
+          timestamp: timestamp(-300_000),
+          call_event: {
+            kind: "propose",
+            from: "bob@example.com/phone",
+            sid: "call-1",
+            media: { audio: true, video: true },
+          },
+        },
+      ],
+      first_id: "mam-propose",
+      last_id: "mam-propose",
+      is_complete: true,
+    };
+    const fetchPersonalHistoryPage = mock(async (_max: number, pageParam: unknown) => {
+      return (pageParam as { type: string }).type === "latest" ? latestPage : olderPage;
+    });
+    const client = new BrowserXmppClient(session());
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { xmpp: { fetch_personal_history_page: typeof fetchPersonalHistoryPage } }).xmpp = {
+      fetch_personal_history_page: fetchPersonalHistoryPage,
+    };
+
+    const since = timestamp(-60 * 60 * 1000);
+    await client.hydrateRecentDmCallActivities({
+      since,
+      maxPages: 2,
+    });
+
+    expect(fetchPersonalHistoryPage).toHaveBeenNthCalledWith(1, 100, { type: "latest", start: since });
+    expect(fetchPersonalHistoryPage).toHaveBeenNthCalledWith(2, 100, { type: "before", before: "mam-proceed", start: since });
+    expect(readDmCallActivity("bob@example.com")).toMatchObject({
+      peerJid: "bob@example.com",
+      sid: "call-1",
+      state: "accepted",
+      direction: "incoming",
+      media: { audio: true, video: true },
+    });
+  });
+
+  test("does not apply hydrated pages after the connected XMPP session changes", async () => {
+    const now = Date.now();
+    const timestamp = new Date(now - 60_000).toISOString();
+    const page = {
+      messages: [{
+        mam_id: "mam-propose",
+        from: "bob@example.com/phone",
+        to: "alice@example.com/web",
+        timestamp,
+        call_event: {
+          kind: "propose",
+          from: "bob@example.com/phone",
+          sid: "stale-call",
+          media: { audio: true, video: false },
+        },
+      }],
+      first_id: "mam-propose",
+      last_id: "mam-propose",
+      is_complete: true,
+    };
+    let resolveFetch: ((value: typeof page) => void) | null = null;
+    const fetchPersonalHistoryPage = mock(() => new Promise<typeof page>((resolve) => {
+      resolveFetch = resolve;
+    }));
+    const client = new BrowserXmppClient(session());
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { xmpp: { fetch_personal_history_page: typeof fetchPersonalHistoryPage } }).xmpp = {
+      fetch_personal_history_page: fetchPersonalHistoryPage,
+    };
+
+    const since = new Date(now - 60 * 60 * 1000).toISOString();
+    const hydration = client.hydrateRecentDmCallActivities({
+      since,
+      maxPages: 1,
+    });
+    for (let i = 0; i < 5; i += 1) await Promise.resolve();
+    expect(fetchPersonalHistoryPage).toHaveBeenCalledTimes(1);
+
+    (client as unknown as { xmpp: { fetch_personal_history_page: typeof fetchPersonalHistoryPage } }).xmpp = {
+      fetch_personal_history_page: mock(async () => page),
+    };
+    resolveFetch?.(page);
+    await hydration;
+
+    expect(readDmCallActivity("bob@example.com")).toBeNull();
+  });
+
+  test("does not apply hydrated pages after disconnect", async () => {
+    const now = Date.now();
+    const since = new Date(now - 60 * 60 * 1000).toISOString();
+    const page = {
+      messages: [{
+        mam_id: "mam-propose",
+        from: "bob@example.com/phone",
+        to: "alice@example.com/web",
+        timestamp: new Date(now - 60_000).toISOString(),
+        call_event: {
+          kind: "propose",
+          from: "bob@example.com/phone",
+          sid: "disconnected-call",
+          media: { audio: true, video: false },
+        },
+      }],
+      first_id: "mam-propose",
+      last_id: "mam-propose",
+      is_complete: true,
+    };
+    let resolveFetch: ((value: typeof page) => void) | null = null;
+    const fetchPersonalHistoryPage = mock(() => new Promise<typeof page>((resolve) => {
+      resolveFetch = resolve;
+    }));
+    const client = new BrowserXmppClient(session());
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { xmpp: { fetch_personal_history_page: typeof fetchPersonalHistoryPage } }).xmpp = {
+      fetch_personal_history_page: fetchPersonalHistoryPage,
+    };
+
+    const hydration = client.hydrateRecentDmCallActivities({ since, maxPages: 1 });
+    for (let i = 0; i < 5; i += 1) await Promise.resolve();
+    expect(fetchPersonalHistoryPage).toHaveBeenCalledWith(100, { type: "latest", start: since });
+
+    (client as unknown as { connected: boolean }).connected = false;
+    resolveFetch?.(page);
+    await hydration;
+
+    expect(readDmCallActivity("bob@example.com")).toBeNull();
+  });
+});

--- a/chat/tests/dm-call-activity.test.ts
+++ b/chat/tests/dm-call-activity.test.ts
@@ -4,6 +4,7 @@ import {
   applyDmCallEvent,
   clearDmCallActivities,
   clearDmCallActivity,
+  pruneExpiredDmCallActivities,
   readDmCallActivity,
 } from "../src/lib/calls/dm-call-activity";
 import type { CallEvent } from "../src/lib/calls/types";
@@ -36,7 +37,7 @@ describe("DM call activity", () => {
       now,
     });
 
-    expect(readDmCallActivity(bob)).toEqual({
+    expect(readDmCallActivity(bob, now)).toEqual({
       peerJid: bob,
       sid: "call-1",
       media: audio,
@@ -60,8 +61,8 @@ describe("DM call activity", () => {
       now,
     });
 
-    expect(readDmCallActivity(bob)?.direction).toBe("outgoing");
-    expect(readDmCallActivity(bob)?.media.video).toBe(true);
+    expect(readDmCallActivity(bob, now)?.direction).toBe("outgoing");
+    expect(readDmCallActivity(bob, now)?.media.video).toBe(true);
   });
 
   test("marks a call accepted when a peer proceeds on one resource", () => {
@@ -91,7 +92,7 @@ describe("DM call activity", () => {
       now,
     });
 
-    expect(readDmCallActivity(bob)).toMatchObject({
+    expect(readDmCallActivity(bob, now)).toMatchObject({
       peerJid: bob,
       sid: "call-3",
       media: audio,
@@ -127,7 +128,7 @@ describe("DM call activity", () => {
       now,
     });
 
-    expect(readDmCallActivity(bob)).toBeNull();
+    expect(readDmCallActivity(bob, now)).toBeNull();
   });
 
   test("self-sent terminal events can clear by sid when the peer hint is gone", () => {
@@ -166,7 +167,7 @@ describe("DM call activity", () => {
       now,
     });
 
-    expect(readDmCallActivity(bob)).toBeNull();
+    expect(readDmCallActivity(bob, now)).toBeNull();
   });
 
   test("older MAM call events cannot regress a newer activity state", () => {
@@ -195,7 +196,7 @@ describe("DM call activity", () => {
       now,
     });
 
-    expect(readDmCallActivity(bob)).toMatchObject({
+    expect(readDmCallActivity(bob, now)).toMatchObject({
       sid: "call-7",
       state: "accepted",
       updatedAt: "2026-05-25T10:05:00.000Z",
@@ -229,7 +230,7 @@ describe("DM call activity", () => {
       now,
     });
 
-    expect(readDmCallActivity(bob)).toBeNull();
+    expect(readDmCallActivity(bob, now)).toBeNull();
   });
 
   test("self-sent terminal events with a to peer tombstone older sibling proposals", () => {
@@ -259,10 +260,10 @@ describe("DM call activity", () => {
       now,
     });
 
-    expect(readDmCallActivity(bob)).toBeNull();
+    expect(readDmCallActivity(bob, now)).toBeNull();
   });
 
-  test("does not let stale catch-up proposals resurrect old calls", () => {
+  test("does not let 24h-old catch-up proposals resurrect old calls", () => {
     applyDmCallEvent({
       event: {
         kind: "propose",
@@ -272,11 +273,48 @@ describe("DM call activity", () => {
       },
       selfBareJid: self,
       to: `${self}/web`,
-      timestamp: "2026-05-23T09:59:59.000Z",
+      timestamp: "2026-05-24T09:59:59.000Z",
       now,
     });
 
     expect($dmCallActivities.get()).toEqual({});
+  });
+
+  test("does not let 24h-old accepted catch-up events resurrect old calls", () => {
+    applyDmCallEvent({
+      event: {
+        kind: "proceed",
+        from: `${bob}/phone`,
+        sid: "old-call",
+      },
+      selfBareJid: self,
+      to: `${self}/web`,
+      timestamp: "2026-05-24T09:59:59.000Z",
+      now,
+    });
+
+    expect($dmCallActivities.get()).toEqual({});
+  });
+
+  test("prunes visible unresolved activity after the 24h XEP-0353 fallback window", () => {
+    applyDmCallEvent({
+      event: {
+        kind: "propose",
+        from: `${bob}/phone`,
+        sid: "aging-call",
+        media: audio,
+      },
+      selfBareJid: self,
+      to: `${self}/web`,
+      timestamp: now.toISOString(),
+      now,
+    });
+
+    expect(readDmCallActivity(bob, now)?.sid).toBe("aging-call");
+
+    pruneExpiredDmCallActivities(new Date("2026-05-26T10:00:01.000Z"));
+
+    expect(readDmCallActivity(bob, new Date("2026-05-26T10:00:01.000Z"))).toBeNull();
   });
 
   test("local cleanup can clear an optimistic outgoing proposal", () => {
@@ -295,6 +333,6 @@ describe("DM call activity", () => {
 
     clearDmCallActivity(bob, "call-5");
 
-    expect(readDmCallActivity(bob)).toBeNull();
+    expect(readDmCallActivity(bob, now)).toBeNull();
   });
 });

--- a/chat/tests/dm-call-activity.test.ts
+++ b/chat/tests/dm-call-activity.test.ts
@@ -317,6 +317,22 @@ describe("DM call activity", () => {
     expect(readDmCallActivity(bob, new Date("2026-05-26T10:00:01.000Z"))).toBeNull();
   });
 
+  test("treats unparseable activity timestamps as expired", () => {
+    $dmCallActivities.set({
+      [bob]: {
+        peerJid: bob,
+        sid: "invalid-clock-call",
+        media: audio,
+        state: "ringing",
+        direction: "incoming",
+        updatedAt: "not-a-date",
+      },
+    });
+
+    expect(readDmCallActivity(bob, now)).toBeNull();
+    expect($dmCallActivities.get()).toEqual({});
+  });
+
   test("local cleanup can clear an optimistic outgoing proposal", () => {
     applyDmCallEvent({
       event: {

--- a/chat/tests/dm-call-activity.test.ts
+++ b/chat/tests/dm-call-activity.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   $dmCallActivities,
+  DM_CALL_ACTIVITY_ACTIVE_WINDOW_MS,
   applyDmCallEvent,
   clearDmCallActivities,
   clearDmCallActivity,
@@ -315,6 +316,56 @@ describe("DM call activity", () => {
     pruneExpiredDmCallActivities(new Date("2026-05-26T10:00:01.000Z"));
 
     expect(readDmCallActivity(bob, new Date("2026-05-26T10:00:01.000Z"))).toBeNull();
+  });
+
+  test("scheduled prune timer clears subscribed activity after the fallback window", async () => {
+    const originalSetTimeout = globalThis.setTimeout;
+    const originalClearTimeout = globalThis.clearTimeout;
+    const timer = { unref: () => undefined } as unknown as ReturnType<typeof setTimeout>;
+    let scheduledPrune: (() => void) | null = null;
+    let scheduledDelay: number | undefined;
+
+    globalThis.setTimeout = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
+      scheduledDelay = Number(timeout ?? 0);
+      scheduledPrune = () => {
+        if (typeof handler === "function") {
+          handler(...args);
+        }
+      };
+      return timer;
+    }) as typeof setTimeout;
+    globalThis.clearTimeout = (() => {
+      scheduledPrune = null;
+    }) as typeof clearTimeout;
+
+    try {
+      const timerArmedAt = new Date();
+      const timestamp = new Date(timerArmedAt.getTime() - DM_CALL_ACTIVITY_ACTIVE_WINDOW_MS).toISOString();
+      applyDmCallEvent({
+        event: {
+          kind: "propose",
+          from: `${bob}/phone`,
+          sid: "timer-pruned-call",
+          media: audio,
+        },
+        selfBareJid: self,
+        to: `${self}/web`,
+        timestamp,
+        now: timerArmedAt,
+      });
+
+      expect($dmCallActivities.get()[bob]?.sid).toBe("timer-pruned-call");
+      expect(scheduledDelay).toBe(1_000);
+      expect(scheduledPrune).not.toBeNull();
+
+      await new Promise<void>((resolve) => originalSetTimeout(resolve, 5));
+      scheduledPrune?.();
+
+      expect($dmCallActivities.get()).toEqual({});
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+      globalThis.clearTimeout = originalClearTimeout;
+    }
   });
 
   test("treats unparseable activity timestamps as expired", () => {

--- a/chat/tests/dm-conversations.test.ts
+++ b/chat/tests/dm-conversations.test.ts
@@ -12,6 +12,7 @@ type MockClient = BrowserXmppClient & {
   fetchInbox: ReturnType<typeof mock>;
   markInboxRead: ReturnType<typeof mock>;
   subscribeToPeerPresence: ReturnType<typeof mock>;
+  hydrateRecentDmCallActivities: ReturnType<typeof mock>;
 };
 
 function makeClient(conversations: InboxEntry[] = []): MockClient {
@@ -19,6 +20,7 @@ function makeClient(conversations: InboxEntry[] = []): MockClient {
     fetchInbox: mock(() => Promise.resolve({ totalUnread: conversations.reduce((sum, conversation) => sum + conversation.unread, 0), conversations })),
     markInboxRead: mock(() => Promise.resolve()),
     subscribeToPeerPresence: mock(() => Promise.resolve()),
+    hydrateRecentDmCallActivities: mock(() => Promise.resolve()),
   } as unknown as MockClient;
 }
 
@@ -140,6 +142,55 @@ describe("useDirectMessageConversations", () => {
       lastMessageAt: "2026-01-02T00:00:00Z",
       unreadCount: 1,
     });
+  });
+
+  test("hydrateFromInbox refreshes DM call activity from personal MAM", async () => {
+    const client = makeClient([
+      {
+        partner: "bob@example.com",
+        kind: "direct",
+        lastStanzaId: "sid-1",
+        lastUpdated: epochSeconds("2026-01-02T12:00:00Z"),
+        unread: 0,
+        preview: "from inbox",
+      },
+      {
+        partner: "carol@example.com/mobile",
+        kind: "direct",
+        lastStanzaId: "sid-2",
+        lastUpdated: epochSeconds("2026-01-02T12:05:00Z"),
+        unread: 0,
+        preview: "from inbox",
+      },
+    ]);
+    const { composable } = makeComposable({ client });
+
+    await composable.hydrateFromInbox();
+
+    expect(client.hydrateRecentDmCallActivities).toHaveBeenCalledTimes(1);
+  });
+
+  test("hydrateFromInbox keeps inbox results when DM call hydration fails", async () => {
+    const client = makeClient([
+      {
+        partner: "bob@example.com",
+        kind: "direct",
+        lastStanzaId: "sid-1",
+        lastUpdated: epochSeconds("2026-01-02T12:00:00Z"),
+        unread: 0,
+        preview: "from inbox",
+      },
+    ]);
+    client.hydrateRecentDmCallActivities = mock(async () => {
+      throw new Error("MAM unavailable");
+    });
+    const { composable } = makeComposable({ client });
+
+    const hydrated = await composable.hydrateFromInbox();
+
+    expect(hydrated).toBe(true);
+    expect(composable.conversations.value).toHaveLength(1);
+    expect(client.hydrateRecentDmCallActivities).toHaveBeenCalledTimes(1);
   });
 
   test("receiveIncomingDm creates conversation and increments unread", () => {

--- a/chat/tests/helpers/vue-sfc-stub.ts
+++ b/chat/tests/helpers/vue-sfc-stub.ts
@@ -1,0 +1,8 @@
+import { h } from "vue";
+
+export default {
+  name: "VueSfcTestStub",
+  setup(_: unknown, { slots }: { slots: { default?: () => unknown } }) {
+    return () => h("span", { "data-vue-stub": "true" }, slots.default?.());
+  },
+};

--- a/server/crates/waddle-xmpp-client-wasm/src/client_history.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_history.rs
@@ -45,11 +45,12 @@ impl WaddleClient {
         future_to_promise(async move {
             let query_id = uuid::Uuid::new_v4().to_string();
             let iq_id = uuid::Uuid::new_v4().to_string();
-            let iq = MamIqBuilder::new(&iq_id, &query_id, max)
-                .before("")
-                .with_jid(&peer_jid)
-                .fulltext(&query)
-                .build();
+            let account_jid = {
+                let stored = inner.borrow().config.clone();
+                bare_jid(&stored.jid)
+            };
+            let iq =
+                build_dm_search_history_iq(&iq_id, &query_id, max, &account_jid, &peer_jid, &query);
             let page = send_mam_query_command(inner, iq, query_id).await?;
             to_js_value(&mam_page_to_js(page))
         })
@@ -87,9 +88,29 @@ impl WaddleClient {
                 .map_err(|err| js_error(err.to_string()))?;
             let query_id = uuid::Uuid::new_v4().to_string();
             let iq_id = uuid::Uuid::new_v4().to_string();
-            let mut builder = MamIqBuilder::new(&iq_id, &query_id, max).with_jid(&peer_jid);
-            builder = apply_page_param(builder, &page)?;
-            let iq = builder.build();
+            let account_jid = {
+                let stored = inner.borrow().config.clone();
+                bare_jid(&stored.jid)
+            };
+            let iq =
+                build_dm_history_page_iq(&iq_id, &query_id, max, &account_jid, &peer_jid, &page)?;
+            let result = send_mam_query_command(inner, iq, query_id).await?;
+            to_js_value(&mam_page_to_js(result))
+        })
+    }
+
+    pub fn fetch_personal_history_page(&self, max: u32, page_param: JsValue) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let page: WaddleMamPageParam = serde_wasm_bindgen::from_value(page_param)
+                .map_err(|err| js_error(err.to_string()))?;
+            let query_id = uuid::Uuid::new_v4().to_string();
+            let iq_id = uuid::Uuid::new_v4().to_string();
+            let account_jid = {
+                let stored = inner.borrow().config.clone();
+                bare_jid(&stored.jid)
+            };
+            let iq = build_personal_history_page_iq(&iq_id, &query_id, max, &account_jid, &page)?;
             let result = send_mam_query_command(inner, iq, query_id).await?;
             to_js_value(&mam_page_to_js(result))
         })
@@ -164,13 +185,17 @@ impl WaddleClient {
         future_to_promise(async move {
             let query_id = uuid::Uuid::new_v4().to_string();
             let iq_id = uuid::Uuid::new_v4().to_string();
-            let iq = build_mam_iq(
+            let account_jid = {
+                let stored = inner.borrow().config.clone();
+                bare_jid(&stored.jid)
+            };
+            let iq = build_dm_history_iq(
                 &iq_id,
                 &query_id,
                 max,
+                &account_jid,
+                &peer_jid,
                 before_id.as_deref(),
-                Some(&peer_jid),
-                None,
             );
             let page = send_mam_query_command(inner, iq, query_id).await?;
             to_js_value(&mam_page_to_js(page))
@@ -217,7 +242,7 @@ fn apply_page_param<'a>(
     builder: MamIqBuilder<'a>,
     page: &'a WaddleMamPageParam,
 ) -> Result<MamIqBuilder<'a>, JsValue> {
-    Ok(match page.kind.as_str() {
+    let builder = match page.kind.as_str() {
         "latest" => builder.before(""),
         "before" => match page.before.as_deref() {
             Some(before) => builder.before(before),
@@ -228,7 +253,70 @@ fn apply_page_param<'a>(
             None => return Err(js_error("missing after page cursor")),
         },
         _ => return Err(js_error("invalid page param type")),
+    };
+    Ok(match page.start.as_deref() {
+        Some(start) => builder.start(start),
+        None => builder,
     })
+}
+
+fn build_personal_history_page_iq(
+    iq_id: &str,
+    query_id: &str,
+    max: u32,
+    account_jid: &str,
+    page: &WaddleMamPageParam,
+) -> Result<Element, JsValue> {
+    let builder = MamIqBuilder::new(iq_id, query_id, max).to_jid(account_jid);
+    Ok(apply_page_param(builder, page)?.build())
+}
+
+fn build_dm_history_page_iq(
+    iq_id: &str,
+    query_id: &str,
+    max: u32,
+    account_jid: &str,
+    peer_jid: &str,
+    page: &WaddleMamPageParam,
+) -> Result<Element, JsValue> {
+    let builder = MamIqBuilder::new(iq_id, query_id, max)
+        .to_jid(account_jid)
+        .with_jid(peer_jid);
+    Ok(apply_page_param(builder, page)?.build())
+}
+
+fn build_dm_search_history_iq(
+    iq_id: &str,
+    query_id: &str,
+    max: u32,
+    account_jid: &str,
+    peer_jid: &str,
+    query: &str,
+) -> Element {
+    MamIqBuilder::new(iq_id, query_id, max)
+        .before("")
+        .to_jid(account_jid)
+        .with_jid(peer_jid)
+        .fulltext(query)
+        .build()
+}
+
+fn build_dm_history_iq(
+    iq_id: &str,
+    query_id: &str,
+    max: u32,
+    account_jid: &str,
+    peer_jid: &str,
+    before_id: Option<&str>,
+) -> Element {
+    build_mam_iq(
+        iq_id,
+        query_id,
+        max,
+        before_id,
+        Some(peer_jid),
+        Some(account_jid),
+    )
 }
 
 #[cfg(test)]
@@ -238,12 +326,24 @@ mod client_history_tests {
     const TEST_MAM_NS: &str = "urn:xmpp:mam:2";
     const TEST_RSM_NS: &str = "http://jabber.org/protocol/rsm";
 
+    fn mam_form_value(iq: &Element, field_var: &str) -> Option<String> {
+        iq.get_child("query", TEST_MAM_NS)
+            .and_then(|query| query.get_child("x", "jabber:x:data"))
+            .and_then(|form| {
+                form.children()
+                    .find(|field| field.name() == "field" && field.attr("var") == Some(field_var))
+            })
+            .and_then(|field| field.get_child("value", "jabber:x:data"))
+            .map(|element| element.text())
+    }
+
     #[test]
     fn page_param_after_builds_rsm_after_query() {
         let page = WaddleMamPageParam {
             kind: "after".to_string(),
             before: None,
             after: Some("cursor-1".to_string()),
+            start: None,
         };
 
         let iq = apply_page_param(MamIqBuilder::new("iq-1", "query-1", 10), &page)
@@ -256,5 +356,102 @@ mod client_history_tests {
             .and_then(|set| set.get_child("after", TEST_RSM_NS))
             .map(|element| element.text());
         assert_eq!(after.as_deref(), Some("cursor-1"));
+    }
+
+    #[test]
+    fn page_param_start_builds_mam_start_field() {
+        let page = WaddleMamPageParam {
+            kind: "latest".to_string(),
+            before: None,
+            after: None,
+            start: Some("2026-05-25T00:00:00Z".to_string()),
+        };
+
+        let iq = apply_page_param(MamIqBuilder::new("iq-1", "query-1", 10), &page)
+            .expect("start page param should apply")
+            .build();
+
+        let value = mam_form_value(&iq, "start");
+        assert_eq!(value.as_deref(), Some("2026-05-25T00:00:00Z"));
+    }
+
+    #[test]
+    fn personal_history_page_targets_account_archive() {
+        let page = WaddleMamPageParam {
+            kind: "latest".to_string(),
+            before: None,
+            after: None,
+            start: Some("2026-05-25T00:00:00Z".to_string()),
+        };
+
+        let iq = build_personal_history_page_iq("iq-1", "query-1", 10, "alice@example.com", &page)
+            .expect("personal history IQ should build");
+
+        assert_eq!(iq.attr("to"), Some("alice@example.com"));
+        assert!(iq.get_child("query", TEST_MAM_NS).is_some());
+    }
+
+    #[test]
+    fn dm_history_page_targets_account_archive_and_filters_peer() {
+        let page = WaddleMamPageParam {
+            kind: "latest".to_string(),
+            before: None,
+            after: None,
+            start: None,
+        };
+
+        let iq = build_dm_history_page_iq(
+            "iq-1",
+            "query-1",
+            10,
+            "alice@example.com",
+            "bob@example.com",
+            &page,
+        )
+        .expect("DM history IQ should build");
+
+        assert_eq!(iq.attr("to"), Some("alice@example.com"));
+        let with_value = mam_form_value(&iq, "with");
+        assert_eq!(with_value.as_deref(), Some("bob@example.com"));
+    }
+
+    #[test]
+    fn dm_search_history_targets_account_archive_and_filters_peer() {
+        let iq = build_dm_search_history_iq(
+            "iq-1",
+            "query-1",
+            10,
+            "alice@example.com",
+            "bob@example.com",
+            "quarterly report",
+        );
+
+        assert_eq!(iq.attr("to"), Some("alice@example.com"));
+        let with_value = mam_form_value(&iq, "with");
+        assert_eq!(with_value.as_deref(), Some("bob@example.com"));
+        let fulltext_value = mam_form_value(&iq, "{urn:xmpp:fulltext:0}fulltext");
+        assert_eq!(fulltext_value.as_deref(), Some("quarterly report"));
+    }
+
+    #[test]
+    fn dm_legacy_history_targets_account_archive_and_filters_peer() {
+        let iq = build_dm_history_iq(
+            "iq-1",
+            "query-1",
+            10,
+            "alice@example.com",
+            "bob@example.com",
+            Some("cursor-1"),
+        );
+
+        assert_eq!(iq.attr("to"), Some("alice@example.com"));
+        let with_value = mam_form_value(&iq, "with");
+        assert_eq!(with_value.as_deref(), Some("bob@example.com"));
+        let before = iq
+            .get_child("query", TEST_MAM_NS)
+            .and_then(|query| query.get_child("set", TEST_RSM_NS))
+            .and_then(|set| set.get_child("before", TEST_RSM_NS))
+            .map(|element| element.text());
+        assert_eq!(before.as_deref(), Some("cursor-1"));
     }
 }

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -669,6 +669,7 @@ pub struct WaddleMamPageParam {
     pub kind: String,
     pub before: Option<String>,
     pub after: Option<String>,
+    pub start: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -84,6 +84,7 @@ export class WaddleClient {
      * call (no node yet) is normal and not an error.
      */
     fetch_mds_displayed(): Promise<any>;
+    fetch_personal_history_page(max: number, page_param: any): Promise<any>;
     fetch_room_history(room_jid: string, max: number, before_id?: string | null): Promise<any>;
     fetch_room_history_by_thread(room_jid: string, thread_id: string, max: number, before_id?: string | null): Promise<any>;
     fetch_room_history_page(room_jid: string, max: number, page_param: any): Promise<any>;

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mplk106q";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mplk106q";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mplk106q";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mplor8ty";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mplor8ty";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mplor8ty";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=mplk106q";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=mplor8ty";


### PR DESCRIPTION
## Summary

- Add a persistent call activity dock in the chat shell for Muji-backed group calls and XEP-0353 1:1 call activity, visible on mobile and desktop.
- Hydrate 1:1 call activity from addressed personal MAM, carbon-forwarded JMI events, and reconnect catch-up without loading every DM timeline.
- Keep multi-client catch-up ordered and guarded: replay MAM pages oldest-to-newest, drop stale handles after disconnect/account switch, and expire unresolved call activity after the XEP-0353 24h fallback window.
- Keep refreshed DM call buttons actionable by allowing a fresh XEP-0353 propose to migrate the peer's active resource back to this client.
- Address PR review findings around generated Vue test stubs, invalid call-activity timestamps, channel-vs-DM dock labels, direct hydration method typing, and prune-delay cleanup.

## Plan

- Audit merged call presence and DM call activity behavior against XEP-0272, XEP-0353, XEP-0280, XEP-0313, and XEP-0482.
- Add the call dock and wire it into mobile and desktop chat shells.
- Add personal MAM call activity hydration and reconnect/carbon ordering fixes.
- Add focused chat and Rust tests for multi-client, MAM paging, stale handles, pruning, and dock rendering.
- Run local chat/server verification, complete adversarial review loops, and monitor CI to green.

## Verification

- `bun test`
- `bun test tests/dm-call-activity.test.ts`
- `bun run lint`
- `bun run build`
- `cargo fmt --all`
- `cargo test -p waddle-xmpp-client-wasm client_history_tests`
- `git diff --check`

## Notes

- No local dev server was started.
