### PR TITLE
fix(chat): preserve call continuity after refresh

### DIFF
--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -84,6 +84,7 @@ export function useChannelMessages(
   const mentionedChannelCounts = ref<Record<string, number>>({});
   const lastMentionActivity = ref<RoomActivityEvent | null>(null);
   const roomAvatarHashes = ref<Record<string, string>>({});
+  const roomJidOverrides = ref<Record<string, string>>({});
 
   const chatStates = useChannelChatStates({
     xmppClient,
@@ -138,10 +139,20 @@ export function useChannelMessages(
   function roomJidForChannel(channelId: string): string | null {
     const currentSession = session.value;
     if (!currentSession) return null;
-    const channel = currentChannel.value?.id === channelId
-      ? currentChannel.value
-      : { id: channelId };
-    return roomJidForChannelSummary(currentSession, channel);
+    const channel = currentChannel.value?.id === channelId ? currentChannel.value : null;
+    if (channel?.jid) return barePeerJid(channel.jid);
+    const override = roomJidOverrides.value[channelId];
+    if (override) return override;
+    return roomJidForChannelSummary(currentSession, channel ?? { id: channelId });
+  }
+
+  function rememberChannelRoomJid(channelId: string, roomJid: string) {
+    const normalizedRoomJid = barePeerJid(roomJid);
+    if (!channelId || !normalizedRoomJid) return;
+    roomJidOverrides.value = {
+      ...roomJidOverrides.value,
+      [channelId]: normalizedRoomJid,
+    };
   }
 
   function queuedMessagesForRoom(roomJid: string): TimelineMessage[] {
@@ -519,6 +530,7 @@ export function useChannelMessages(
     messageSearch.reset();
     pinnedEdgeScroller.disconnect();
     pendingEchoClientIds.clear();
+    roomJidOverrides.value = {};
     // $xmppStatus is authoritative and owned by XmppProvider; do not write it here.
     clearTypingState();
     clearLiveActivityState();
@@ -637,6 +649,7 @@ export function useChannelMessages(
     roomLastSeen,
     slowModeCooldown,
     loadMessages,
+    rememberChannelRoomJid,
     loadOlderMessages,
     ensureMessageLoaded,
     backfillThread,

--- a/chat/src/components/calls/CallActivityDock.vue
+++ b/chat/src/components/calls/CallActivityDock.vue
@@ -19,13 +19,14 @@ const props = defineProps<{
   channels: ChannelSummary[];
   conversations: DmConversation[];
   activeChannelId: string | null;
+  activeChannelRoomJid?: string | null;
   activePeerJid: string | null;
   sidebarMode: SidebarMode;
   activeChannelJids: Set<string>;
 }>();
 
 const emit = defineEmits<{
-  selectChannel: [channelId: string];
+  selectChannel: [channelId: string | null, roomJid: string];
   selectDm: [peerJid: string];
 }>();
 
@@ -40,6 +41,7 @@ const entries = computed(() => buildCallActivityDockEntries({
   channels: props.channels,
   conversations: props.conversations,
   activeChannelId: props.activeChannelId,
+  activeChannelRoomJid: props.activeChannelRoomJid ?? null,
   activePeerJid: props.activePeerJid,
   sidebarMode: props.sidebarMode,
   activeChannelJids: props.activeChannelJids,
@@ -69,7 +71,7 @@ function entryTitle(entry: CallActivityDockEntry): string {
 
 function selectEntry(entry: CallActivityDockEntry): void {
   if (entry.kind === "channel") {
-    emit("selectChannel", entry.channelId);
+    emit("selectChannel", entry.channelId, entry.roomJid);
     return;
   }
   emit("selectDm", entry.peerJid);

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -99,6 +99,7 @@ const {
   closeUserSettings,
   handleLogout,
   selectChannel,
+  selectChannelByRoomJid,
   onSelectThread,
   selectExtensionRoute,
   handleOpenDm,
@@ -199,9 +200,13 @@ function onSelectCommunitySurface(surface: "feed" | "stories" | "events") {
   openCommunitySurface(surface);
 }
 
-function onSelectChannelFromSidebar(id: string) {
+function onSelectChannelFromSidebar(id: string | null, roomJid?: string) {
   ui.activeCommunitySurface.value = null;
-  selectChannel(id);
+  if (id) {
+    selectChannel(id, roomJid ? { roomJid } : undefined);
+    return;
+  }
+  if (roomJid) selectChannelByRoomJid(roomJid);
 }
 
 // ── Admin route plumbing ────────────────────────────────────────────
@@ -247,6 +252,7 @@ onUnmounted(() => {
       :channels="waddles.sortedChannels.value"
       :conversations="dmConversations.conversations.value"
       :active-channel-id="waddles.activeChannelId.value"
+      :active-channel-room-jid="activeChannelRoomJid"
       :active-peer-jid="dmConversations.activePeerJid.value"
       :sidebar-mode="ui.sidebarMode.value"
       :active-channel-jids="messaging.activeChannels.value"
@@ -324,6 +330,7 @@ onUnmounted(() => {
           :channels="waddles.sortedChannels.value"
           :conversations="dmConversations.conversations.value"
           :active-channel-id="waddles.activeChannelId.value"
+          :active-channel-room-jid="activeChannelRoomJid"
           :active-peer-jid="dmConversations.activePeerJid.value"
           :sidebar-mode="ui.sidebarMode.value"
           :active-channel-jids="messaging.activeChannels.value"

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -396,6 +396,7 @@ async function dispatchSlashCommand(
   return ok;
 }
 const inMucContext = computed(() => !!props.roomJid);
+const callRoomJid = computed(() => props.roomJid ?? props.channel?.jid ?? null);
 
 watch(
   () => props.xmppClient,
@@ -1071,8 +1072,8 @@ function dayDividerLabel(createdAt: string): string {
     <!-- Inline split-view for an active call in this conversation.
          MUC and DM ownership gates live inside the component. -->
     <CallSplitContainer
-      v-if="channel?.jid || dmPeer?.peerJid"
-      :room-jid="channel?.jid"
+      v-if="callRoomJid || dmPeer?.peerJid"
+      :room-jid="callRoomJid ?? undefined"
       :dm-peer-jid="dmPeer?.peerJid"
       :dm-peer-name="dmPeer?.peerUsername"
     />
@@ -1466,8 +1467,8 @@ function dayDividerLabel(createdAt: string): string {
          panel — stays visible. Decides its own visibility based on
          call state + ui mode. -->
     <CallExpandedSurface
-      v-if="channel?.jid || dmPeer?.peerJid"
-      :room-jid="channel?.jid"
+      v-if="callRoomJid || dmPeer?.peerJid"
+      :room-jid="callRoomJid ?? undefined"
       :dm-peer-jid="dmPeer?.peerJid"
       :dm-peer-name="dmPeer?.peerUsername"
     />

--- a/chat/src/dms/conversations.ts
+++ b/chat/src/dms/conversations.ts
@@ -203,12 +203,30 @@ export function useDirectMessageConversations(
     mergeInboxConversations([entry]);
   }
 
+  async function hydrateCurrentDmCallActivities(
+    currentClient: BrowserXmppClient,
+    currentSessionJid: string,
+    requestId: number,
+  ): Promise<void> {
+    if (
+      requestId !== inboxRequestId
+      || currentClient !== xmppClient.value
+      || currentSessionJid !== (session.value?.jid ?? null)
+    ) return;
+    await currentClient.hydrateRecentDmCallActivities().catch(() => undefined);
+  }
+
   async function hydrateFromInbox(): Promise<boolean> {
     const currentClient = xmppClient.value;
     const currentSessionJid = session.value?.jid ?? null;
     if (!currentClient || !currentSessionJid) return false;
 
     const requestId = ++inboxRequestId;
+    const dmCallActivityHydration = hydrateCurrentDmCallActivities(
+      currentClient,
+      currentSessionJid,
+      requestId,
+    );
     try {
       const inbox = await currentClient.fetchInbox();
       if (
@@ -222,9 +240,10 @@ export function useDirectMessageConversations(
       for (const conversation of directConversations) {
         void currentClient.subscribeToPeerPresence(barePeerJid(conversation.partner)).catch(() => undefined);
       }
-      await currentClient.hydrateRecentDmCallActivities().catch(() => undefined);
+      void dmCallActivityHydration;
       return true;
     } catch {
+      void dmCallActivityHydration;
       // best-effort
       return false;
     }

--- a/chat/src/lib/calls/call-activity-dock.ts
+++ b/chat/src/lib/calls/call-activity-dock.ts
@@ -3,7 +3,9 @@ import type { DmConversation } from "@/lib/xmpp/types";
 import { barePeerJid } from "@/lib/xmpp/jid";
 import {
   callParticipantCountForChannel,
+  candidateRoomJidsForChannel,
 } from "./muc-call-indicators";
+import { normalizeMucCallRoomJid } from "./muc-call-presence";
 import type { DmCallActivity } from "./dm-call-activity";
 
 export type SidebarMode = "channels" | "dms";
@@ -12,9 +14,11 @@ export type CallActivityDockEntry =
   | {
       kind: "channel";
       key: string;
-      channelId: string;
+      channelId: string | null;
+      roomJid: string;
       title: string;
       participantCount: number;
+      isKnownChannel: boolean;
       isActive: boolean;
     }
   | {
@@ -34,12 +38,15 @@ export function buildCallActivityDockEntries(options: {
   channels: ReadonlyArray<Pick<ChannelSummary, "id" | "name" | "jid">>;
   conversations: ReadonlyArray<Pick<DmConversation, "peerJid" | "peerUsername">>;
   activeChannelId: string | null;
+  activeChannelRoomJid?: string | null;
   activePeerJid: string | null;
   sidebarMode: SidebarMode;
   activeChannelJids: Iterable<string>;
   callParticipantCounts: Record<string, number>;
   dmCallActivities: Record<string, DmCallActivity>;
 }): CallActivityDockEntry[] {
+  const matchedRoomJids = new Set<string>();
+  const activeChannelRoomJid = normalizeMucCallRoomJid(options.activeChannelRoomJid ?? "");
   const channelEntries = options.channels.flatMap((channel): CallActivityDockEntry[] => {
     const participantCount = callParticipantCountForChannel(
       channel,
@@ -47,15 +54,43 @@ export function buildCallActivityDockEntries(options: {
       options.activeChannelJids,
     );
     if (participantCount <= 0) return [];
+    const roomJid = candidateRoomJidsForChannel(channel, options.activeChannelJids)
+      .map(normalizeMucCallRoomJid)
+      .find((jid) => (options.callParticipantCounts[jid] ?? 0) > 0) ?? "";
+    if (roomJid) matchedRoomJids.add(roomJid);
     return [{
       kind: "channel",
       key: `channel:${channel.id}`,
       channelId: channel.id,
+      roomJid,
       title: channel.name,
       participantCount,
-      isActive: options.sidebarMode === "channels" && options.activeChannelId === channel.id,
+      isKnownChannel: true,
+      isActive: options.sidebarMode === "channels" && (
+        options.activeChannelId === channel.id || activeChannelRoomJid === roomJid
+      ),
     }];
   });
+
+  const fallbackChannelEntries = Object.entries(options.callParticipantCounts)
+    .flatMap(([roomJid, participantCount]): CallActivityDockEntry[] => {
+      const normalizedRoomJid = normalizeMucCallRoomJid(roomJid);
+      if (!normalizedRoomJid || participantCount <= 0 || matchedRoomJids.has(normalizedRoomJid)) {
+        return [];
+      }
+      const title = normalizedRoomJid.split("@")[0] ?? normalizedRoomJid;
+      return [{
+        kind: "channel",
+        key: `channel:${normalizedRoomJid}`,
+        channelId: null,
+        roomJid: normalizedRoomJid,
+        title,
+        participantCount,
+        isKnownChannel: false,
+        isActive: options.sidebarMode === "channels" && activeChannelRoomJid === normalizedRoomJid,
+      }];
+    })
+    .sort((left, right) => left.title.localeCompare(right.title));
 
   const conversationNames = new Map(
     options.conversations.map((conversation) => [
@@ -89,5 +124,5 @@ export function buildCallActivityDockEntries(options: {
       return left.title.localeCompare(right.title);
     });
 
-  return [...channelEntries, ...dmEntries];
+  return [...channelEntries, ...fallbackChannelEntries, ...dmEntries];
 }

--- a/chat/src/lib/calls/muc-call-indicators.ts
+++ b/chat/src/lib/calls/muc-call-indicators.ts
@@ -1,7 +1,7 @@
 import type { ChannelSummary } from "@/lib/chat-types";
 import { normalizeMucCallRoomJid } from "./muc-call-presence";
 
-function candidateRoomJids(
+export function candidateRoomJidsForChannel(
   channel: Pick<ChannelSummary, "id" | "jid">,
   activeChannelJids: Iterable<string>,
 ): string[] {
@@ -24,7 +24,7 @@ export function callParticipantCountForChannel(
   activeChannelJids: Iterable<string>,
 ): number {
   if (!callParticipantCounts) return 0;
-  for (const jid of candidateRoomJids(channel, activeChannelJids)) {
+  for (const jid of candidateRoomJidsForChannel(channel, activeChannelJids)) {
     const count = callParticipantCounts[normalizeMucCallRoomJid(jid)] ?? 0;
     if (count > 0) return count;
   }

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -850,6 +850,12 @@ export class BrowserXmppClient {
     return this.discoveredRoomJids.get(channelId) ?? roomBareJidFor(this.session, channelId);
   }
 
+  rememberRoomJidForChannel(channelId: string, roomJid: string): void {
+    const normalizedRoomJid = barePeerJid(roomJid);
+    if (!channelId || !normalizedRoomJid) return;
+    this.discoveredRoomJids.set(channelId, normalizedRoomJid);
+  }
+
   private waitForRoomSelfPresence(roomJid: string, nick: string): Promise<void> {
     const fullJid = `${roomJid}/${nick}`;
     return new Promise((resolve, reject) => {

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -157,6 +157,7 @@ export function useChatAppController(giphyApiKey: string) {
     ui.sidebarMode.value === "dms" ? dmMessaging.firstUnseenId.value : messaging.firstUnseenId.value,
   );
   const extensionRoutes = ref<DiscoveredExtensionRoute[]>([]);
+  const selectedChannelRoomJids = ref<Record<string, string>>({});
   const activeExtensionRouteKey = ref<{ channelId: string; pluginId: string; routeId: string } | null>(null);
   const activeExtensionRoute = computed(() => {
     const key = activeExtensionRouteKey.value;
@@ -171,10 +172,26 @@ export function useChatAppController(giphyApiKey: string) {
       : [],
   );
   const activeChannelRoomJid = computed(() => {
+    const channelId = waddles.activeChannelId.value;
     const channel = waddles.currentChannel.value;
-    if (!channel || !session.value) return null;
-    return channel.jid ?? resolveRoomJidForChannelId(session.value, waddles.channels.value, channel.id);
+    if (!channelId || !session.value) return null;
+    if (channel?.jid) return barePeerJid(channel.jid);
+    const selectedRoomJid = selectedChannelRoomJids.value[channelId];
+    if (selectedRoomJid) return selectedRoomJid;
+    return resolveRoomJidForChannelId(session.value, waddles.channels.value, channelId);
   });
+  watch(
+    [activeChannelRoomJid, () => waddles.channels.value],
+    ([roomJid]) => {
+      if (ui.sidebarMode.value !== "channels" || !roomJid) return;
+      const normalizedRoomJid = barePeerJid(roomJid);
+      const channel = waddles.channels.value.find((candidate) =>
+        candidate.jid ? barePeerJid(candidate.jid) === normalizedRoomJid : false
+      );
+      if (!channel || channel.id === waddles.activeChannelId.value) return;
+      void selectChannel(channel.id, { roomJid: normalizedRoomJid });
+    },
+  );
 
   // Thread panel state - stack = breadcrumb trail into nested sub-threads.
   // Empty stack = panel closed. Only meaningful for channel messages since DMs
@@ -1623,6 +1640,7 @@ export function useChatAppController(giphyApiKey: string) {
     channelUnread.clearAll();
     rosterContacts.clearRosterContacts();
     extensionRoutes.value = [];
+    selectedChannelRoomJids.value = {};
     activeExtensionRouteKey.value = null;
     activeRightPanel.value = null;
     setupPromptShown = false;
@@ -1641,17 +1659,26 @@ export function useChatAppController(giphyApiKey: string) {
     await connectionStore.logout();
   }
 
-  async function selectChannel(channelId: string) {
+  async function selectChannel(channelId: string, options: { roomJid?: string } = {}) {
     ui.activePage.value = "chat";
     ui.sidebarMode.value = "channels";
     activeExtensionRouteKey.value = null;
     dmConversations.closeDm();
     memberJidByNick.value = {};
+    const selectedRoomJid = options.roomJid ? barePeerJid(options.roomJid) : null;
+    if (selectedRoomJid) {
+      selectedChannelRoomJids.value = {
+        ...selectedChannelRoomJids.value,
+        [channelId]: selectedRoomJid,
+      };
+      xmppClient.value?.rememberRoomJidForChannel(channelId, selectedRoomJid);
+      messaging.rememberChannelRoomJid(channelId, selectedRoomJid);
+    }
     waddles.activeChannelId.value = channelId;
     void waddles.reloadChannelMembers(channelId);
     messaging.clearMessages();
     // XEP-0502: Clear activity indicator for this channel
-    const roomJid = roomJidForChannelId(channelId);
+    const roomJid = selectedRoomJid ?? roomJidForChannelId(channelId);
     if (roomJid) {
       messaging.clearChannelActivity(roomJid);
     }
@@ -1662,6 +1689,18 @@ export function useChatAppController(giphyApiKey: string) {
       unreadAtLoad,
     );
     ui.showMobileNav.value = false;
+  }
+
+  async function selectChannelByRoomJid(roomJid: string) {
+    const normalizedRoomJid = barePeerJid(roomJid);
+    if (!normalizedRoomJid) return;
+    const channel = waddles.channels.value.find((candidate) =>
+      candidate.jid ? barePeerJid(candidate.jid) === normalizedRoomJid : false
+    );
+    const managedRoom = parseManagedRoomBareJid(normalizedRoomJid);
+    const channelId = channel?.id ?? managedRoom?.channelId;
+    if (!channelId) return;
+    await selectChannel(channelId, { roomJid: normalizedRoomJid });
   }
 
   async function selectExtensionRoute(channelId: string, route: DiscoveredExtensionRoute) {
@@ -1901,6 +1940,7 @@ export function useChatAppController(giphyApiKey: string) {
       closeUserSettings,
       handleLogout,
       selectChannel,
+      selectChannelByRoomJid,
       onSelectThread,
       selectExtensionRoute,
       handleOpenDm,

--- a/chat/tests/call-activity-dock.test.ts
+++ b/chat/tests/call-activity-dock.test.ts
@@ -55,8 +55,10 @@ describe("call activity dock model", () => {
         kind: "channel",
         key: "channel:general",
         channelId: "general",
+        roomJid: "general@conference.example.com",
         title: "General",
         participantCount: 3,
+        isKnownChannel: true,
         isActive: true,
       },
       {
@@ -109,6 +111,57 @@ describe("call activity dock model", () => {
       isActive: true,
     });
   });
+
+  test("surfaces group calls while the channel directory is still loading", () => {
+    const entries = buildCallActivityDockEntries({
+      channels: [],
+      conversations: [],
+      activeChannelId: null,
+      activePeerJid: null,
+      sidebarMode: "channels",
+      activeChannelJids: new Set(),
+      callParticipantCounts: {
+        "general@conference.example.com": 2,
+      },
+      dmCallActivities: {},
+    });
+
+    expect(entries).toEqual([
+      {
+        kind: "channel",
+        key: "channel:general@conference.example.com",
+        channelId: null,
+        roomJid: "general@conference.example.com",
+        title: "general",
+        participantCount: 2,
+        isKnownChannel: false,
+        isActive: false,
+      },
+    ]);
+  });
+
+  test("marks fallback group call active by room JID instead of an inferred channel ID", () => {
+    const entries = buildCallActivityDockEntries({
+      channels: [],
+      conversations: [],
+      activeChannelId: "channel-uuid",
+      activeChannelRoomJid: "general@conference.example.com",
+      activePeerJid: null,
+      sidebarMode: "channels",
+      activeChannelJids: new Set(),
+      callParticipantCounts: {
+        "general@conference.example.com": 2,
+      },
+      dmCallActivities: {},
+    });
+
+    expect(entries[0]).toMatchObject({
+      kind: "channel",
+      channelId: null,
+      roomJid: "general@conference.example.com",
+      isActive: true,
+    });
+  });
 });
 
 describe("CallActivityDock rendering", () => {
@@ -147,6 +200,25 @@ describe("CallActivityDock rendering", () => {
     expect(html).toContain("Live");
   });
 
+  test("renders active group calls before channel metadata hydrates", async () => {
+    $mucCallParticipants.set({
+      "general@conference.example.com": ["alice", "bob"],
+    });
+
+    const html = await renderCallActivityDock({
+      channels: [],
+      conversations: [],
+      activeChannelId: null,
+      activePeerJid: null,
+      sidebarMode: "channels",
+      activeChannelJids: new Set<string>(),
+    });
+
+    expect(html).toContain("Calls");
+    expect(html).toContain("general");
+    expect(html).toContain("2 people");
+  });
+
   test("is mounted in the desktop sidebar and visible mobile shell", () => {
     const readyShell = readFileSync(new URL("../src/components/chat/ChatReadyShell.vue", import.meta.url), "utf8");
     const mobileDrawers = readFileSync(new URL("../src/components/chat/ChatMobileDrawers.vue", import.meta.url), "utf8");
@@ -163,9 +235,20 @@ describe("CallActivityDock rendering", () => {
   test("keeps the dock bounded and hydrated DM call controls actionable", () => {
     const dock = readFileSync(new URL("../src/components/calls/CallActivityDock.vue", import.meta.url), "utf8");
     const callButton = readFileSync(new URL("../src/components/calls/CallButton.vue", import.meta.url), "utf8");
+    const readyShell = readFileSync(new URL("../src/components/chat/ChatReadyShell.vue", import.meta.url), "utf8");
+    const controller = readFileSync(new URL("../src/shell/chat-app-controller.ts", import.meta.url), "utf8");
+    const contentArea = readFileSync(new URL("../src/components/chat/ContentArea.vue", import.meta.url), "utf8");
 
     expect(dock).toContain("max-height: min(40dvh, 18rem)");
     expect(dock).toContain("overflow-y: auto");
+    expect(dock).toContain("emit(\"selectChannel\", entry.channelId, entry.roomJid)");
+    expect(readyShell).toContain("function onSelectChannelFromSidebar(id: string | null, roomJid?: string)");
+    expect(readyShell).toContain("selectChannelByRoomJid(roomJid)");
+    expect(readyShell).toContain("selectChannel(id, roomJid ? { roomJid } : undefined)");
+    expect(readyShell).toContain(":active-channel-room-jid=\"activeChannelRoomJid\"");
+    expect(controller).toContain("void selectChannel(channel.id, { roomJid: normalizedRoomJid })");
+    expect(contentArea).toContain("const callRoomJid = computed(() => props.roomJid ?? props.channel?.jid ?? null)");
+    expect(contentArea).toContain(":room-jid=\"callRoomJid ?? undefined\"");
     expect(callButton).toContain("Hydrated peer activity alone stays actionable");
     expect(callButton).toContain("state.value.phase !== \"idle\" && state.value.phase !== \"ended\"");
     expect(callButton).not.toContain("|| hasPeerCallActivity.value");

--- a/chat/tests/dm-conversations.test.ts
+++ b/chat/tests/dm-conversations.test.ts
@@ -193,6 +193,40 @@ describe("useDirectMessageConversations", () => {
     expect(client.hydrateRecentDmCallActivities).toHaveBeenCalledTimes(1);
   });
 
+  test("hydrateFromInbox still refreshes DM call activity when inbox fails", async () => {
+    const client = makeClient();
+    let resolveCallHydration!: () => void;
+    client.fetchInbox = mock(async () => {
+      throw new Error("inbox unavailable");
+    });
+    client.hydrateRecentDmCallActivities = mock(() => new Promise<void>((resolve) => {
+      resolveCallHydration = resolve;
+    }));
+    const { composable } = makeComposable({ client });
+
+    const hydrated = await composable.hydrateFromInbox();
+
+    expect(hydrated).toBe(false);
+    expect(client.hydrateRecentDmCallActivities).toHaveBeenCalledTimes(1);
+    resolveCallHydration();
+  });
+
+  test("hydrateFromInbox starts DM call activity before inbox returns", async () => {
+    const client = makeClient();
+    let resolveInbox!: (value: { totalUnread: number; conversations: InboxEntry[] }) => void;
+    client.fetchInbox = mock(() => new Promise((resolve) => {
+      resolveInbox = resolve;
+    }));
+    const { composable } = makeComposable({ client });
+
+    const hydration = composable.hydrateFromInbox();
+
+    expect(client.hydrateRecentDmCallActivities).toHaveBeenCalledTimes(1);
+
+    resolveInbox({ totalUnread: 0, conversations: [] });
+    expect(await hydration).toBe(true);
+  });
+
   test("receiveIncomingDm creates conversation and increments unread", () => {
     const { composable } = makeComposable();
     composable.receiveIncomingDm(makeDmMessage());

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -206,6 +206,11 @@ pub async fn handle_muc_join(
     };
 
     let occupant_count = join_outcome.occupant_count;
+    let self_muji = join_outcome
+        .existing_occupants
+        .iter()
+        .find(|existing| existing.nick == nick && existing.jid == *sender_jid)
+        .and_then(|existing| existing.muji.as_ref());
 
     info!(room = %room_jid, nick = %nick, occupants = occupant_count, "User joined MUC room");
 
@@ -287,7 +292,7 @@ pub async fn handle_muc_join(
     // Drop accounting is handled inside `try_send_to` (logs + metrics);
     // per-occupant outcome is discarded here because a missed join
     // presence self-heals via the next MUC presence/probe round-trip.
-    if !join_outcome.is_same_bare_multi_session_join {
+    if !join_outcome.is_same_bare_multi_session_join && !join_outcome.is_existing_session_rejoin {
         for existing in &join_outcome.existing_occupants {
             let presence_stanza = create_presence_stanza(
                 state,
@@ -317,7 +322,7 @@ pub async fn handle_muc_join(
         role: join_outcome.new_occupant_role,
         real_jid: sender_jid,
         include_self_status: true,
-        muji: None,
+        muji: self_muji,
     }));
 
     // Same-account sibling resources share one MUC nick. If a

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
@@ -36,6 +36,7 @@ use jid::{BareJid, FullJid};
 use tracing::{debug, warn};
 use waddle_xmpp::muc::{
     build_occupant_presence_update,
+    presence::NS_MUC,
     room_actor::{ClearMujiPresence, UpsertMujiPresence},
 };
 use waddle_xmpp::xep::xep0272::{find_muji, Muji, NS_MUJI};
@@ -57,6 +58,13 @@ pub(super) fn extract_muji(presence: &Presence) -> Option<Muji> {
         .iter()
         .find(|elem| elem.name() == "muji" && elem.ns() == NS_MUJI)
         .and_then(|elem| Muji::try_from(elem).ok())
+}
+
+fn is_muc_join_presence(presence: &Presence) -> bool {
+    presence
+        .payloads
+        .iter()
+        .any(|elem| elem.name() == "x" && elem.ns() == NS_MUC)
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -117,6 +125,15 @@ pub(super) async fn try_handle_muc_presence_update(
 ) -> Option<Vec<String>> {
     let actor = get_room_actor(state, room_jid).await?;
     let muji = extract_muji(incoming);
+    // XEP-0045 join/rejoin presence carries `<x xmlns='.../muc'/>`.
+    // On stream resume the client may replay that autojoin while the
+    // room actor still has the full JID as an occupant. Treating that
+    // as a Muji clear would suppress the join replay that refreshes
+    // active-call state; XEP-0272 leave markers are plain available
+    // presence without this MUC join payload.
+    if muji.is_none() && is_muc_join_presence(incoming) {
+        return None;
+    }
 
     let outcome = match muji {
         Some(muji) => match actor
@@ -309,12 +326,27 @@ mod tests {
 
     #[test]
     fn extract_muji_returns_none_for_missing_payload() {
-        // A presence with no `<muji/>` extension. The dispatcher uses
-        // this as the signal to fall through to the regular join
-        // path — never to silently treat the presence as a call
-        // advertisement.
+        // A presence with no `<muji/>` extension. The update path may
+        // use this as a clear marker, but never as a call advertisement.
         let presence = ParsedPresence::new(PresenceType::None);
         assert!(extract_muji(&presence).is_none());
+    }
+
+    #[test]
+    fn is_muc_join_presence_detects_xep0045_join_payload() {
+        let mut presence = ParsedPresence::new(PresenceType::None);
+        presence
+            .payloads
+            .push(Element::builder("x", NS_MUC).build());
+
+        assert!(is_muc_join_presence(&presence));
+    }
+
+    #[test]
+    fn is_muc_join_presence_ignores_plain_muji_clear_presence() {
+        let presence = ParsedPresence::new(PresenceType::None);
+
+        assert!(!is_muc_join_presence(&presence));
     }
 
     #[test]

--- a/server/crates/waddle-server/src/server/routes/websocket/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests.rs
@@ -26,7 +26,7 @@ use handlers::presence::{handle_muc_join, handle_muc_leave, parse_room_jid_conte
 use waddle_extensions::ExtensionConfig;
 use waddle_xmpp::commands::{CommandContext, CommandResult};
 use waddle_xmpp::muc::room_actor::{
-    ChangeAffiliation, GetSnapshot, JoinWithAffiliation, SetSubject,
+    ChangeAffiliation, GetSnapshot, JoinWithAffiliation, SetSubject, UpdateConfig,
 };
 use waddle_xmpp::registry::BroadcastOutcome;
 use waddle_xmpp::Affiliation;

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -1015,6 +1015,14 @@ fn muc_presence_to(room_jid: &BareJid, nick: &str) -> xmpp_parsers::presence::Pr
     presence
 }
 
+fn muc_join_presence_to(room_jid: &BareJid, nick: &str) -> xmpp_parsers::presence::Presence {
+    let mut presence = muc_presence_to(room_jid, nick);
+    presence
+        .payloads
+        .push(Element::builder("x", waddle_xmpp::muc::presence::NS_MUC).build());
+    presence
+}
+
 #[tokio::test]
 async fn available_presence_without_muji_clears_existing_muji_state() {
     let state = create_test_websocket_state().await;
@@ -1131,6 +1139,247 @@ async fn available_presence_without_muji_clears_existing_muji_state() {
             .get_child("muji", waddle_xmpp::xep::xep0272::NS_MUJI)
             .is_none(),
         "late join replay must not include stale Muji"
+    );
+}
+
+#[tokio::test]
+async fn resumed_muc_join_presence_replays_existing_muji_state() {
+    let state = create_test_websocket_state().await;
+    let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let room_jid: BareJid = "muji-resume-replay@muc.example.com"
+        .parse()
+        .expect("room jid");
+    let alice: FullJid = "alice@example.com/web".parse().expect("alice jid");
+    let bob: FullJid = "bob@example.com/desktop".parse().expect("bob jid");
+
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &alice,
+        "alice",
+        None,
+        &Some(owner_session.clone()),
+    )
+    .await;
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &bob,
+        "bob",
+        None,
+        &None,
+    )
+    .await;
+
+    let bob_phase = waddle_xmpp::protocol::ConnectionPhase::ready(bob.clone(), false);
+    let mut active = muc_presence_to(&room_jid, "bob");
+    active.payloads.push(active_muji().to_element());
+    let _ = handlers::presence::handle_presence(
+        active,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &bob_phase,
+        &None,
+    )
+    .await;
+
+    let alice_phase = waddle_xmpp::protocol::ConnectionPhase::ready(alice.clone(), false);
+    let resumed_autojoin = muc_join_presence_to(&room_jid, "alice");
+    let responses = handlers::presence::handle_presence(
+        resumed_autojoin,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &alice_phase,
+        &Some(owner_session),
+    )
+    .await;
+
+    let bob_replay = responses
+        .iter()
+        .filter_map(|xml| Element::from_str(xml).ok())
+        .find(|element| {
+            element.attr("from") == Some(format!("{room_jid}/bob").as_str())
+                && element.attr("to") == Some(alice.to_string().as_str())
+        })
+        .expect("resumed autojoin receives bob replay");
+    assert!(
+        bob_replay
+            .get_child("muji", waddle_xmpp::xep::xep0272::NS_MUJI)
+            .is_some(),
+        "resumed MUC autojoin must replay existing active-call Muji state"
+    );
+}
+
+#[tokio::test]
+async fn resumed_muc_join_presence_replays_own_muji_without_plain_broadcast() {
+    let state = create_test_websocket_state().await;
+    let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let room_jid: BareJid = "muji-resume-own-replay@muc.example.com"
+        .parse()
+        .expect("room jid");
+    let alice: FullJid = "alice@example.com/web".parse().expect("alice jid");
+    let bob: FullJid = "bob@example.com/desktop".parse().expect("bob jid");
+
+    let (alice_tx, mut alice_rx) = mpsc::channel::<OutboundStanza>(8);
+    state
+        .deps
+        .protocol
+        .connection_registry
+        .register(alice.clone(), alice_tx);
+
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &alice,
+        "alice",
+        None,
+        &Some(owner_session),
+    )
+    .await;
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &bob,
+        "bob",
+        None,
+        &None,
+    )
+    .await;
+    while alice_rx.try_recv().is_ok() {}
+
+    let bob_phase = waddle_xmpp::protocol::ConnectionPhase::ready(bob.clone(), false);
+    let mut active = muc_presence_to(&room_jid, "bob");
+    active.payloads.push(active_muji().to_element());
+    let _ = handlers::presence::handle_presence(
+        active,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &bob_phase,
+        &None,
+    )
+    .await;
+    while alice_rx.try_recv().is_ok() {}
+
+    let resumed_autojoin = muc_join_presence_to(&room_jid, "bob");
+    let responses = handlers::presence::handle_presence(
+        resumed_autojoin,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &bob_phase,
+        &None,
+    )
+    .await;
+
+    let self_replay = responses
+        .iter()
+        .filter_map(|xml| Element::from_str(xml).ok())
+        .find(|element| {
+            element.attr("from") == Some(format!("{room_jid}/bob").as_str())
+                && element.attr("to") == Some(bob.to_string().as_str())
+                && element
+                    .get_child("muji", waddle_xmpp::xep::xep0272::NS_MUJI)
+                    .is_some()
+        })
+        .expect("resumed active participant receives own Muji replay");
+    assert_eq!(
+        muc_user_item_jid(&self_replay).as_deref(),
+        Some(bob.to_string().as_str())
+    );
+
+    while let Ok(outbound) = alice_rx.try_recv() {
+        let xml = stanza_to_xml(&outbound.stanza);
+        let presence = Element::from_str(&xml).expect("broadcast presence XML");
+        if presence.attr("from") == Some(format!("{room_jid}/bob").as_str()) {
+            assert!(
+                presence
+                    .get_child("muji", waddle_xmpp::xep::xep0272::NS_MUJI)
+                    .is_some(),
+                "same-session resumed autojoin must not broadcast a plain no-Muji update for the active participant"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn resumed_muc_join_presence_replays_muji_when_room_is_full() {
+    let state = create_test_websocket_state().await;
+    let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let room_jid: BareJid = "muji-resume-full-room@muc.example.com"
+        .parse()
+        .expect("room jid");
+    let alice: FullJid = "alice@example.com/web".parse().expect("alice jid");
+
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &alice,
+        "alice",
+        None,
+        &Some(owner_session.clone()),
+    )
+    .await;
+    let room_actor = get_room_actor(state.as_ref(), &room_jid)
+        .await
+        .expect("room actor");
+    let mut config = room_actor
+        .ask(GetSnapshot)
+        .await
+        .expect("room snapshot")
+        .room
+        .config;
+    config.max_occupants = 1;
+    room_actor
+        .ask(UpdateConfig { config })
+        .await
+        .expect("room config update");
+
+    let alice_phase = waddle_xmpp::protocol::ConnectionPhase::ready(alice.clone(), false);
+    let mut active = muc_presence_to(&room_jid, "alice");
+    active.payloads.push(active_muji().to_element());
+    let _ = handlers::presence::handle_presence(
+        active,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &alice_phase,
+        &Some(owner_session.clone()),
+    )
+    .await;
+
+    let resumed_autojoin = muc_join_presence_to(&room_jid, "alice");
+    let responses = handlers::presence::handle_presence(
+        resumed_autojoin,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &alice_phase,
+        &Some(owner_session),
+    )
+    .await;
+
+    let self_replay = responses
+        .iter()
+        .filter_map(|xml| Element::from_str(xml).ok())
+        .find(|element| {
+            element.attr("from") == Some(format!("{room_jid}/alice").as_str())
+                && element.attr("to") == Some(alice.to_string().as_str())
+                && element
+                    .get_child("muji", waddle_xmpp::xep::xep0272::NS_MUJI)
+                    .is_some()
+        })
+        .expect("full-room resumed autojoin receives own Muji replay");
+    assert_eq!(
+        muc_user_item_jid(&self_replay).as_deref(),
+        Some(alice.to_string().as_str())
     );
 }
 

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -73,6 +73,7 @@ pub struct JoinOutcome {
     pub occupant_count: usize,
     pub room_jid: BareJid,
     pub is_same_bare_multi_session_join: bool,
+    pub is_existing_session_rejoin: bool,
     /// Snapshot of `MucRoom.subject` at join time. Powers the XEP-0045
     /// §7.2.15 historical-subject emission the WebSocket join handler
     /// builds via `muc::messages::build_subject_message`. Bundled with

--- a/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
@@ -37,11 +37,12 @@ impl kameo::message::Message<JoinWithAffiliation> for RoomActor {
                 members_only: self.room.config.members_only,
             });
         }
-        if self.room.is_full() {
-            return Err(RoomActorError::RoomFull);
-        }
-
         let mut is_same_bare_multi_session_join = false;
+        let is_existing_session_rejoin = self
+            .room
+            .get_occupant_sessions(&msg.nick)
+            .iter()
+            .any(|session| session == &msg.sender_jid);
         if let Some(existing) = self.room.get_occupant(&msg.nick) {
             if existing.real_jid != msg.sender_jid {
                 if existing.real_jid.to_bare() == msg.sender_jid.to_bare() {
@@ -50,6 +51,9 @@ impl kameo::message::Message<JoinWithAffiliation> for RoomActor {
                     return Err(RoomActorError::NickAlreadyInUse(msg.nick));
                 }
             }
+        }
+        if self.room.is_full() && !is_existing_session_rejoin && !is_same_bare_multi_session_join {
+            return Err(RoomActorError::RoomFull);
         }
 
         let existing_occupants: Vec<JoinExistingOccupant> = self
@@ -92,6 +96,7 @@ impl kameo::message::Message<JoinWithAffiliation> for RoomActor {
             occupant_count,
             room_jid,
             is_same_bare_multi_session_join,
+            is_existing_session_rejoin,
             subject_state,
         })
     }

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
@@ -126,6 +126,38 @@ async fn test_join_rejected_when_room_full() {
 }
 
 #[tokio::test]
+async fn test_join_existing_session_allowed_when_room_full() {
+    let actor = spawn_room_actor_with_config(RoomConfig {
+        max_occupants: 1,
+        ..RoomConfig::default()
+    })
+    .await;
+    let alice = test_full_jid("alice");
+
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: alice.clone(),
+            nick: "alice".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+        })
+        .await
+        .expect("first join should succeed");
+
+    let outcome = actor
+        .ask(JoinWithAffiliation {
+            sender_jid: alice,
+            nick: "alice".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+        })
+        .await
+        .expect("existing session rejoin should bypass full-room rejection");
+
+    assert_eq!(outcome.occupant_count, 1);
+}
+
+#[tokio::test]
 async fn test_leave() {
     let actor = spawn_room_actor().await;
 


### PR DESCRIPTION
## Summary

- Keep active group calls visible while channel metadata is still hydrating after refresh.
- Preserve the actual room JID when selecting fallback active-call dock rows, so the call surface and MUC join target stay on the active room.
- Resolve fallback dock selection by room JID instead of fabricating a channel ID, and reconcile to the real channel ID when metadata hydrates.
- Start DM call-activity hydration independently from inbox hydration so a slow or failed inbox does not hide recent 1:1 call activity.
- Treat resumed XEP-0045 MUC autojoin presence as a join/replay snapshot, not as an XEP-0272 Muji clear.
- Replay stored Muji state back to the refreshing same full JID, avoid plain no-Muji broadcasts for same-session rejoins, and allow idempotent rejoins even when the room is full.
- Carry the room actor's same-session rejoin result through `JoinOutcome` so the websocket handler does not re-derive that state.

## Plan

- [x] Re-audit XEP-0272, XEP-0353, XEP-0280, XEP-0313, and XEP-0482 implications for refresh-time call continuity.
- [x] Trace refresh hydration for group Muji presence and 1:1 call activity.
- [x] Improve dock/header/sidebar selection surfaces for active calls during metadata hydration.
- [x] Address PR review comments around fallback channel IDs and duplicated same-session rejoin derivation.
- [x] Add focused tests for fallback dock rows, room-JID active selection, DM hydration ordering/failure, resumed MUC replay, same-session Muji replay, and full-room idempotent rejoin.
- [x] Run package-local verification.

## Verification

- `bun test tests/dm-conversations.test.ts tests/call-activity-dock.test.ts`
- `bun test tests/call-activity-dock.test.ts`
- `bun run lint`
- `bun run build` (existing Astro async-function hint and Vite chunk-size warning remain)
- `cargo fmt --all` from `server/`
- `cargo check -p waddle-server` from `server/`
- `cargo test -p waddle-server --lib --no-run` from `server/`
- `cargo test -p waddle-xmpp --lib --no-run` from `server/`
- `cargo clippy -p waddle-server -p waddle-xmpp -- -D warnings` from `server/`
- `git diff --check`
- `git diff --staged --check`

No dev server started.