### PR TITLE
fix(chat): polish call presence dock

### DIFF
--- a/chat/src/components/calls/CallActivePill.vue
+++ b/chat/src/components/calls/CallActivePill.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref } from "vue";
+import { computed } from "vue";
 import { Phone } from "lucide-vue-next";
 import { useRoomHasActiveCall } from "@/lib/calls/use-active-muc-call";
 
@@ -9,9 +9,9 @@ import { useRoomHasActiveCall } from "@/lib/calls/use-active-muc-call";
  *
  * Replaces the previous in-button chip inside `MucCallButton` so the
  * "join" affordance now reads as a single statement: "a call is
- * happening, click to join". The pulsing dot + running duration give
- * the chip enough motion to grab the eye without owning a full row
- * of the header.
+ * happening, click to join". Muji presence proves that a call is live
+ * in the room, but it does not carry a protocol-backed start time, so
+ * this pill intentionally avoids rendering elapsed duration.
  *
  * Hides itself once the local user joins (the split-view surface
  * communicates the state from then on) and when the call ends.
@@ -45,60 +45,16 @@ const {
  */
 const isVisible = computed(() => hasActiveCall.value && !localResourceInCall.value);
 
-/**
- * Running call duration. Pegged to a single shared 1Hz tick so we
- * don't spawn a setInterval per pill on chat shells with many
- * channels open at once. `startedAt` does not exist on the call
- * state today — derive a stable t0 from the moment the call first
- * appeared as active in THIS room, and keep ticking from there.
- */
-const callStartTimestamp = ref<number | null>(null);
-const now = ref(Date.now());
-let tick: ReturnType<typeof setInterval> | null = null;
-
-function ensureStart(): void {
-  if (!hasActiveCall.value) {
-    callStartTimestamp.value = null;
-    return;
-  }
-  if (callStartTimestamp.value === null) {
-    callStartTimestamp.value = Date.now();
-  }
-}
-
-onMounted(() => {
-  ensureStart();
-  tick = setInterval(() => {
-    now.value = Date.now();
-    ensureStart();
-  }, 1000);
-});
-
-onBeforeUnmount(() => {
-  if (tick) {
-    clearInterval(tick);
-    tick = null;
-  }
-});
-
-const durationLabel = computed<string>(() => {
-  if (!callStartTimestamp.value) return "00:00";
-  const seconds = Math.max(0, Math.floor((now.value - callStartTimestamp.value) / 1000));
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  const s = seconds % 60;
-  const mm = m.toString().padStart(2, "0");
-  const ss = s.toString().padStart(2, "0");
-  return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`;
-});
-
 const ariaLabel = computed(() => {
   const count = participantCount.value;
   const noun = count === 1 ? "person" : "people";
   const device = selfInCall.value
     ? " This account is connected on another device."
     : "";
-  return `Live call in this channel, ${count} ${noun}, ${durationLabel.value} elapsed.${device} Click to join from this device.`;
+  if (props.disabled) {
+    return `Live call in this channel, ${count} ${noun}.${device} Join unavailable from this device.`;
+  }
+  return `Live call in this channel, ${count} ${noun}.${device} Click to join from this device.`;
 });
 
 function onClick(): void {
@@ -116,15 +72,13 @@ function onClick(): void {
     :disabled="disabled"
     :aria-label="ariaLabel"
     :title="ariaLabel"
-    role="status"
-    aria-live="polite"
     @click="onClick"
   >
     <span class="call-active-pill__dot" aria-hidden="true" />
     <Phone class="call-active-pill__icon" aria-hidden="true" />
     <span class="call-active-pill__count">{{ participantCount }}</span>
     <span class="call-active-pill__separator" aria-hidden="true">·</span>
-    <span class="call-active-pill__duration tabular-nums">{{ durationLabel }}</span>
+    <span class="call-active-pill__state">Live</span>
   </button>
 </template>
 
@@ -199,7 +153,7 @@ function onClick(): void {
 }
 
 .call-active-pill__count,
-.call-active-pill__duration {
+.call-active-pill__state {
   font-variant-numeric: tabular-nums;
 }
 </style>

--- a/chat/src/components/calls/CallActivityDock.vue
+++ b/chat/src/components/calls/CallActivityDock.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { useStore } from "@nanostores/vue";
-import { Hash, MessageCircle, Phone, Video } from "lucide-vue-next";
+import { ArrowRight, Hash, MessageCircle, Phone, PhoneIncoming, PhoneOutgoing, Video } from "lucide-vue-next";
 import {
   $mucCallParticipants,
   mucCallParticipantCounts,
@@ -23,6 +23,7 @@ const props = defineProps<{
   activePeerJid: string | null;
   sidebarMode: SidebarMode;
   activeChannelJids: Set<string>;
+  managedMucDomain?: string | null;
 }>();
 
 const emit = defineEmits<{
@@ -45,9 +46,11 @@ const entries = computed(() => buildCallActivityDockEntries({
   activePeerJid: props.activePeerJid,
   sidebarMode: props.sidebarMode,
   activeChannelJids: props.activeChannelJids,
+  managedMucDomain: props.managedMucDomain ?? null,
   callParticipantCounts: callParticipantCounts.value,
   dmCallActivities: dmCallActivities.value,
 }));
+const entryCount = computed(() => entries.value.length);
 
 function entryStatus(entry: CallActivityDockEntry): string {
   if (entry.kind === "channel") {
@@ -62,14 +65,30 @@ function entryStatus(entry: CallActivityDockEntry): string {
   return "Live";
 }
 
+function entryKindLabel(entry: CallActivityDockEntry): string {
+  if (entry.kind === "channel") return entry.isKnownChannel ? "Group call" : "Group call · syncing";
+  return entry.media.video ? "Video call" : "Voice call";
+}
+
+function entryMeta(entry: CallActivityDockEntry): string {
+  return `${entryKindLabel(entry)} · ${entryStatus(entry)}`;
+}
+
+function entryAction(entry: CallActivityDockEntry): string {
+  if (entry.kind === "channel") return "Open";
+  return "Open";
+}
+
 function entryTitle(entry: CallActivityDockEntry): string {
-  if (entry.kind === "channel") {
-    return `Join ${entry.title} call, ${entryStatus(entry)}`;
-  }
-  return `Open ${entry.title} call, ${entryStatus(entry)}`;
+  return `${entryAction(entry)} ${entry.title} call, ${entryStatus(entry)}`;
+}
+
+function entryCanSelect(entry: CallActivityDockEntry): boolean {
+  return entry.kind !== "channel" || entry.roomJid.length > 0;
 }
 
 function selectEntry(entry: CallActivityDockEntry): void {
+  if (!entryCanSelect(entry)) return;
   if (entry.kind === "channel") {
     emit("selectChannel", entry.channelId, entry.roomJid);
     return;
@@ -86,7 +105,10 @@ function selectEntry(entry: CallActivityDockEntry): void {
   >
     <div class="call-activity-dock__header">
       <span class="call-activity-dock__pulse" aria-hidden="true" />
-      <span class="type-section-label">Calls</span>
+      <span class="type-section-label">Active calls</span>
+      <span class="call-activity-dock__total type-count-badge" aria-hidden="true">
+        {{ entryCount }}
+      </span>
     </div>
     <div class="call-activity-dock__list">
       <button
@@ -94,21 +116,28 @@ function selectEntry(entry: CallActivityDockEntry): void {
         :key="entry.key"
         type="button"
         class="call-activity-dock__row"
-        :class="{ 'call-activity-dock__row--active': entry.isActive }"
+        :class="{
+          'call-activity-dock__row--active': entry.isActive,
+          'call-activity-dock__row--disabled': !entryCanSelect(entry),
+        }"
+        :disabled="!entryCanSelect(entry)"
         :aria-current="entry.isActive ? 'page' : undefined"
         :title="entryTitle(entry)"
+        :aria-label="entryTitle(entry)"
         @click="selectEntry(entry)"
       >
         <span class="call-activity-dock__icon" aria-hidden="true">
           <Hash v-if="entry.kind === 'channel'" class="h-3.5 w-3.5" />
           <Video v-else-if="entry.media.video" class="h-3.5 w-3.5" />
+          <PhoneIncoming v-else-if="entry.state === 'ringing' && entry.direction === 'incoming'" class="h-3.5 w-3.5" />
+          <PhoneOutgoing v-else-if="entry.state === 'ringing' && entry.direction === 'outgoing'" class="h-3.5 w-3.5" />
           <MessageCircle v-else-if="entry.state === 'ringing'" class="h-3.5 w-3.5" />
           <Phone v-else class="h-3.5 w-3.5" />
         </span>
         <span class="call-activity-dock__copy">
           <span class="call-activity-dock__title type-control">{{ entry.title }}</span>
           <span class="call-activity-dock__status type-meta">
-            {{ entryStatus(entry) }}
+            {{ entryMeta(entry) }}
           </span>
         </span>
         <span
@@ -117,6 +146,10 @@ function selectEntry(entry: CallActivityDockEntry): void {
           aria-hidden="true"
         >
           {{ entry.participantCount }}
+        </span>
+        <span class="call-activity-dock__action type-meta" aria-hidden="true">
+          {{ entryAction(entry) }}
+          <ArrowRight v-if="entryCanSelect(entry)" class="h-3 w-3" />
         </span>
       </button>
     </div>
@@ -150,6 +183,18 @@ function selectEntry(entry: CallActivityDockEntry): void {
   color: var(--sidebar-muted);
 }
 
+.call-activity-dock__total {
+  display: inline-flex;
+  min-width: 1.125rem;
+  height: 1.125rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  background: color-mix(in oklab, var(--sidebar-accent) 76%, transparent);
+  color: var(--sidebar-foreground);
+  font-variant-numeric: tabular-nums;
+}
+
 .call-activity-dock__pulse {
   width: 0.375rem;
   height: 0.375rem;
@@ -167,12 +212,12 @@ function selectEntry(entry: CallActivityDockEntry): void {
 
 .call-activity-dock__row {
   display: grid;
-  grid-template-columns: 1.5rem minmax(0, 1fr) auto;
-  min-height: 2.5rem;
+  grid-template-columns: 1.75rem minmax(0, 1fr) auto auto;
+  min-height: 3rem;
   align-items: center;
   gap: 0.5rem;
   border-radius: var(--radius-sm);
-  padding: 0.25rem 0.5rem;
+  padding: 0.375rem 0.5rem;
   color: var(--sidebar-muted);
   text-align: left;
   transition:
@@ -181,14 +226,26 @@ function selectEntry(entry: CallActivityDockEntry): void {
     transform 160ms ease-out;
 }
 
-.call-activity-dock__row:hover,
+.call-activity-dock__row:hover:not(:disabled),
 .call-activity-dock__row--active {
   background: color-mix(in oklab, var(--sidebar-accent) 72%, transparent);
   color: var(--sidebar-foreground);
 }
 
-.call-activity-dock__row:hover {
+.call-activity-dock__row:hover:not(:disabled) {
   transform: translateY(-1px);
+}
+
+.call-activity-dock__row--disabled,
+.call-activity-dock__row--disabled:hover {
+  cursor: default;
+  opacity: 0.72;
+  transform: none;
+}
+
+.call-activity-dock__row--disabled .call-activity-dock__action {
+  background: color-mix(in oklab, var(--sidebar-accent) 58%, transparent);
+  color: var(--sidebar-muted);
 }
 
 .call-activity-dock__row:focus-visible {
@@ -198,8 +255,8 @@ function selectEntry(entry: CallActivityDockEntry): void {
 
 .call-activity-dock__icon {
   display: inline-flex;
-  width: 1.5rem;
-  height: 1.5rem;
+  width: 1.75rem;
+  height: 1.75rem;
   align-items: center;
   justify-content: center;
   border-radius: var(--radius-sm);
@@ -241,6 +298,31 @@ function selectEntry(entry: CallActivityDockEntry): void {
   font-variant-numeric: tabular-nums;
 }
 
+.call-activity-dock__action {
+  display: inline-flex;
+  min-width: 3.25rem;
+  height: 1.625rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  border-radius: 9999px;
+  background: color-mix(in oklab, oklch(0.7 0.18 145) 16%, transparent);
+  color: oklch(0.46 0.14 145);
+  white-space: nowrap;
+}
+
+.call-activity-dock__row:hover:not(:disabled) .call-activity-dock__action,
+.call-activity-dock__row--active .call-activity-dock__action {
+  background: color-mix(in oklab, oklch(0.7 0.18 145) 26%, transparent);
+  color: oklch(0.38 0.14 145);
+}
+
+:global(.dark) .call-activity-dock__action,
+:global(.dark) .call-activity-dock__row:hover:not(:disabled) .call-activity-dock__action,
+:global(.dark) .call-activity-dock__row--active .call-activity-dock__action {
+  color: oklch(0.86 0.13 145);
+}
+
 .call-activity-dock.call-activity-dock--mobile {
   max-height: none;
   border-top: 0;
@@ -267,7 +349,7 @@ function selectEntry(entry: CallActivityDockEntry): void {
 }
 
 .call-activity-dock.call-activity-dock--mobile .call-activity-dock__row {
-  min-width: min(14rem, 78vw);
+  min-width: min(17rem, 84vw);
 }
 
 @media (min-width: 64rem) {

--- a/chat/src/components/calls/CallButton.vue
+++ b/chat/src/components/calls/CallButton.vue
@@ -31,6 +31,16 @@ const inCall = computed(
 const hasPeerCallActivity = computed(() => !!peerCallActivity.value);
 const voiceLabel = computed(() => hasPeerCallActivity.value && !inCall.value ? "Reconnect voice call" : "Start voice call");
 const videoLabel = computed(() => hasPeerCallActivity.value && !inCall.value ? "Reconnect video call" : "Start video call");
+const reconnectingPeerCall = computed(() => hasPeerCallActivity.value && !inCall.value);
+const activityBannerLabel = computed(() => {
+  const activity = peerCallActivity.value;
+  if (!activity) return "";
+  const media = activity.media.video ? "Video" : "Voice";
+  if (activity.state === "accepted") return `${media} call live`;
+  if (activity.direction === "incoming") return `Incoming ${media.toLowerCase()} call`;
+  if (activity.direction === "outgoing") return `${media} call calling`;
+  return `${media} call ringing`;
+});
 
 function getSender() {
   const client = connectionStore.client as unknown as { xmpp?: unknown } | null;
@@ -66,7 +76,17 @@ async function startCall(media: CallMedia): Promise<void> {
 </script>
 
 <template>
-  <div class="flex items-center gap-1.5">
+  <div
+    class="call-button-group"
+    :class="{ 'call-button-group--activity': reconnectingPeerCall }"
+  >
+    <span
+      v-if="reconnectingPeerCall"
+      class="call-button-group__hint type-meta"
+      aria-hidden="true"
+    >
+      {{ activityBannerLabel }}
+    </span>
     <button
       class="chat-icon-button chat-icon-button--md transition-all duration-200"
       :class="inCall
@@ -95,3 +115,34 @@ async function startCall(media: CallMedia): Promise<void> {
     </button>
   </div>
 </template>
+
+<style scoped>
+.call-button-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.call-button-group--activity {
+  gap: 0.25rem;
+  border: 1px solid color-mix(in oklab, var(--success) 28%, transparent);
+  border-radius: 9999px;
+  background: color-mix(in oklab, var(--success) 10%, transparent);
+  padding: 0.125rem;
+}
+
+.call-button-group__hint {
+  max-width: 8rem;
+  overflow: hidden;
+  padding-inline: 0.375rem 0.125rem;
+  color: var(--success);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 48rem) {
+  .call-button-group__hint {
+    display: none;
+  }
+}
+</style>

--- a/chat/src/components/calls/MucCallButton.vue
+++ b/chat/src/components/calls/MucCallButton.vue
@@ -117,7 +117,7 @@ function joinExistingAudio(): void {
     >
       <Video class="w-3.5 h-3.5" />
     </button>
-    <!-- Live-call pill: green dot + count + running duration, click to
+    <!-- Live-call pill: green dot + participant count, click to
          join. The pill component decides its own visibility (only
          when this room owns the call AND the local user isn't in it),
          which is why we can mount it unconditionally and still keep

--- a/chat/src/components/chat/ChatHeader.vue
+++ b/chat/src/components/chat/ChatHeader.vue
@@ -78,8 +78,13 @@ const showPinnedPanel = defineModel<boolean>("showPinnedPanel", { default: false
 const { activity: dmCallActivity } = useDmCallActivity(() => props.dmPeer?.peerJid);
 
 const dmCallActivityLabel = computed(() => {
-  if (!dmCallActivity.value) return "";
-  return dmCallActivity.value.state === "accepted" ? "Call active" : "Ringing";
+  const activity = dmCallActivity.value;
+  if (!activity) return "";
+  const media = activity.media.video ? "Video" : "Voice";
+  if (activity.state === "accepted") return `${media} call active`;
+  if (activity.direction === "incoming") return `Incoming ${media.toLowerCase()} call`;
+  if (activity.direction === "outgoing") return `${media} call calling`;
+  return `${media} call ringing`;
 });
 
 const emit = defineEmits<{
@@ -175,14 +180,14 @@ const memberButtonCopy = computed(() => {
             </span>
             <span
               v-if="dmCallActivity"
-              class="type-meta inline-flex h-5 shrink-0 items-center gap-1 rounded-full border border-success/25 bg-success/10 px-2 text-success"
+              class="type-meta hidden h-5 max-w-[9rem] shrink-0 items-center gap-1 overflow-hidden rounded-full border border-success/25 bg-success/10 px-2 text-success lg:inline-flex"
             >
               <PhoneCall class="h-3 w-3" />
-              {{ dmCallActivityLabel }}
+              <span class="truncate">{{ dmCallActivityLabel }}</span>
             </span>
           </div>
           <div v-if="dmPeer" class="lg:hidden type-caption text-muted-foreground truncate">
-            {{ presenceText(dmPeer.presenceShow) }}
+            {{ dmCallActivityLabel || presenceText(dmPeer.presenceShow) }}
           </div>
           <!-- Desktop subtitle slot: prefer the channel's own description
                (its "topic") so rooms with a stated subject get character

--- a/chat/src/components/chat/ChatMobileDrawers.vue
+++ b/chat/src/components/chat/ChatMobileDrawers.vue
@@ -5,6 +5,7 @@ import {
   $mucCallParticipants,
   mucCallParticipantCounts,
 } from "@/lib/calls/muc-call-presence";
+import { normalizeMucServiceDomain } from "@/lib/calls/muc-call-indicators";
 import WaddlesSidebar from "@/components/chat/WaddlesSidebar.vue";
 import TopicsPanel from "@/components/chat/TopicsPanel.vue";
 import DmPanel from "@/components/chat/DmPanel.vue";
@@ -35,6 +36,7 @@ const {
   channelExtensionRoutes,
   activeExtensionRouteKey,
   activeRightPanel,
+  selfDomain,
   openUserSettings,
   openHome,
   handleLogout,
@@ -64,6 +66,9 @@ const mucCallParticipantsStore = useStore($mucCallParticipants);
 const callParticipantCounts = computed<Record<string, number>>(() => {
   return mucCallParticipantCounts(mucCallParticipantsStore.value);
 });
+const managedMucDomain = computed(() =>
+  normalizeMucServiceDomain(waddles.mucServiceJid.value) || (selfDomain.value ? `muc.${selfDomain.value}` : ""),
+);
 
 const drawerExtensionRoutes = computed(() =>
   extensionRouteRailItems(
@@ -123,6 +128,7 @@ function openExtensionRoute(route: DiscoveredExtensionRoute) {
           :collapsed-group-ids="ui.collapsedSpaceGroupIds.value"
           :channel-unread-map="computedChannelUnreadMap"
           :call-participant-counts="callParticipantCounts"
+          :managed-muc-domain="managedMucDomain"
           :thread-entries-fn="(roomJid: string) => channelUnread.threadEntries(roomJid)"
           :active-community-surface="ui.activeCommunitySurface.value"
           :stories-active-count="stories.activeStories.value.length"

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -5,6 +5,7 @@ import {
   $mucCallParticipants,
   mucCallParticipantCounts,
 } from "@/lib/calls/muc-call-presence";
+import { normalizeMucServiceDomain } from "@/lib/calls/muc-call-indicators";
 import HomeDashboard from "@/components/chat/HomeDashboard.vue";
 import ThreadsView from "@/components/chat/ThreadsView.vue";
 import FeedPane from "@/components/community/FeedPane.vue";
@@ -157,6 +158,9 @@ const mucCallParticipantsStore = useStore($mucCallParticipants);
 const callParticipantCounts = computed<Record<string, number>>(() => {
   return mucCallParticipantCounts(mucCallParticipantsStore.value);
 });
+const managedMucDomain = computed(() =>
+  normalizeMucServiceDomain(waddles.mucServiceJid.value) || (selfDomain.value ? `muc.${selfDomain.value}` : ""),
+);
 
 const contentPaneClass = computed(() => {
   if (ui.sidebarMode.value !== "channels") return "";
@@ -256,6 +260,7 @@ onUnmounted(() => {
       :active-peer-jid="dmConversations.activePeerJid.value"
       :sidebar-mode="ui.sidebarMode.value"
       :active-channel-jids="messaging.activeChannels.value"
+      :managed-muc-domain="managedMucDomain"
       @select-channel="onSelectChannelFromSidebar"
       @select-dm="selectDm"
     />
@@ -304,6 +309,7 @@ onUnmounted(() => {
           :collapsed-group-ids="ui.collapsedSpaceGroupIds.value"
           :channel-unread-map="computedChannelUnreadMap"
           :call-participant-counts="callParticipantCounts"
+          :managed-muc-domain="managedMucDomain"
           :thread-entries-fn="(roomJid: string) => channelUnread.threadEntries(roomJid)"
           :active-community-surface="ui.activeCommunitySurface.value"
           :stories-active-count="stories.activeStories.value.length"
@@ -334,6 +340,7 @@ onUnmounted(() => {
           :active-peer-jid="dmConversations.activePeerJid.value"
           :sidebar-mode="ui.sidebarMode.value"
           :active-channel-jids="messaging.activeChannels.value"
+          :managed-muc-domain="managedMucDomain"
           @select-channel="onSelectChannelFromSidebar"
           @select-dm="selectDm"
         />

--- a/chat/src/components/chat/TopicsPanel.vue
+++ b/chat/src/components/chat/TopicsPanel.vue
@@ -48,20 +48,23 @@ const props = defineProps<{
    * the channel — matches Slack-Huddle / Discord-voice patterns.
    */
   callParticipantCounts?: Record<string, number>;
+  /** Trusted MUC service domain for id-only channel rows. */
+  managedMucDomain?: string | null;
 }>();
 
 /**
  * Resolve the channel's MUC room JID and look up the live-call
  * count for it. Channel rows in the sidebar may store the JID
  * directly (`channel.jid`) or only the channel id; in the latter
- * case we fall back to searching `activeChannelJids` for a match —
- * same heuristic `hasActivity()` uses for the green dot.
+ * case we combine the id with the managed MUC domain so localpart
+ * fallback cannot cross domains.
  */
 function callParticipantCount(channel: ChannelSummary): number {
   return callParticipantCountForChannel(
     channel,
     props.callParticipantCounts,
     props.activeChannelJids,
+    props.managedMucDomain,
   );
 }
 

--- a/chat/src/lib/calls/call-activity-dock.ts
+++ b/chat/src/lib/calls/call-activity-dock.ts
@@ -4,6 +4,7 @@ import { barePeerJid } from "@/lib/xmpp/jid";
 import {
   callParticipantCountForChannel,
   candidateRoomJidsForChannel,
+  normalizeMucServiceDomain,
 } from "./muc-call-indicators";
 import { normalizeMucCallRoomJid } from "./muc-call-presence";
 import type { DmCallActivity } from "./dm-call-activity";
@@ -42,19 +43,22 @@ export function buildCallActivityDockEntries(options: {
   activePeerJid: string | null;
   sidebarMode: SidebarMode;
   activeChannelJids: Iterable<string>;
+  managedMucDomain?: string | null;
   callParticipantCounts: Record<string, number>;
   dmCallActivities: Record<string, DmCallActivity>;
 }): CallActivityDockEntry[] {
   const matchedRoomJids = new Set<string>();
   const activeChannelRoomJid = normalizeMucCallRoomJid(options.activeChannelRoomJid ?? "");
+  const managedMucDomain = normalizeMucServiceDomain(options.managedMucDomain);
   const channelEntries = options.channels.flatMap((channel): CallActivityDockEntry[] => {
     const participantCount = callParticipantCountForChannel(
       channel,
       options.callParticipantCounts,
       options.activeChannelJids,
+      options.managedMucDomain,
     );
     if (participantCount <= 0) return [];
-    const roomJid = candidateRoomJidsForChannel(channel, options.activeChannelJids)
+    const roomJid = candidateRoomJidsForChannel(channel, options.activeChannelJids, options.managedMucDomain)
       .map(normalizeMucCallRoomJid)
       .find((jid) => (options.callParticipantCounts[jid] ?? 0) > 0) ?? "";
     if (roomJid) matchedRoomJids.add(roomJid);
@@ -75,9 +79,11 @@ export function buildCallActivityDockEntries(options: {
   const fallbackChannelEntries = Object.entries(options.callParticipantCounts)
     .flatMap(([roomJid, participantCount]): CallActivityDockEntry[] => {
       const normalizedRoomJid = normalizeMucCallRoomJid(roomJid);
+      const roomDomain = normalizedRoomJid.split("@")[1] ?? "";
       if (!normalizedRoomJid || participantCount <= 0 || matchedRoomJids.has(normalizedRoomJid)) {
         return [];
       }
+      if (!managedMucDomain || roomDomain !== managedMucDomain) return [];
       const title = normalizedRoomJid.split("@")[0] ?? normalizedRoomJid;
       return [{
         kind: "channel",

--- a/chat/src/lib/calls/muc-call-indicators.ts
+++ b/chat/src/lib/calls/muc-call-indicators.ts
@@ -1,30 +1,45 @@
 import type { ChannelSummary } from "@/lib/chat-types";
 import { normalizeMucCallRoomJid } from "./muc-call-presence";
 
+export function normalizeMucServiceDomain(serviceJid?: string | null): string {
+  const bare = serviceJid?.split("/")[0]?.trim().toLowerCase() ?? "";
+  if (!bare) return "";
+  return bare.includes("@") ? bare.split("@")[1] ?? "" : bare;
+}
+
 export function candidateRoomJidsForChannel(
   channel: Pick<ChannelSummary, "id" | "jid">,
   activeChannelJids: Iterable<string>,
+  managedMucDomain?: string | null,
 ): string[] {
   const candidates: string[] = [];
-  if (channel.jid) candidates.push(channel.jid);
+  const channelRoomJid = normalizeMucCallRoomJid(channel.jid ?? "");
+  const channelRoomDomain = channelRoomJid.split("@")[1] ?? "";
+  const trustedDomain = channelRoomDomain || normalizeMucServiceDomain(managedMucDomain);
+  if (channelRoomJid) candidates.push(channelRoomJid);
+  if (!channelRoomJid && trustedDomain) {
+    candidates.push(`${channel.id.toLowerCase()}@${trustedDomain}`);
+  }
   for (const jid of activeChannelJids) {
     const normalized = normalizeMucCallRoomJid(jid);
     if (!normalized) continue;
     const localpart = normalized.split("@")[0] ?? "";
-    if (localpart === channel.id.toLowerCase()) {
+    const domain = normalized.split("@")[1] ?? "";
+    if (trustedDomain && domain === trustedDomain && localpart === channel.id.toLowerCase()) {
       candidates.push(normalized);
     }
   }
-  return candidates;
+  return [...new Set(candidates)];
 }
 
 export function callParticipantCountForChannel(
   channel: Pick<ChannelSummary, "id" | "jid">,
   callParticipantCounts: Record<string, number> | undefined,
   activeChannelJids: Iterable<string>,
+  managedMucDomain?: string | null,
 ): number {
   if (!callParticipantCounts) return 0;
-  for (const jid of candidateRoomJidsForChannel(channel, activeChannelJids)) {
+  for (const jid of candidateRoomJidsForChannel(channel, activeChannelJids, managedMucDomain)) {
     const count = callParticipantCounts[normalizeMucCallRoomJid(jid)] ?? 0;
     if (count > 0) return count;
   }

--- a/chat/src/waddles/directory.ts
+++ b/chat/src/waddles/directory.ts
@@ -543,6 +543,8 @@ export function useWaddleDirectory(
     memberLoadState.value = "idle";
     memberSnapshotsByChannelId.clear();
     serverRole.value = null;
+    mucServiceJid.value = null;
+    spacesServiceJid.value = null;
     activeChannelId.value = null;
     selectedSpaceId.value = null;
   }
@@ -553,6 +555,7 @@ export function useWaddleDirectory(
     members,
     memberLoadState,
     serverRole,
+    mucServiceJid,
     activeSpaceId,
     activeChannelId,
     isLoadingStructure,

--- a/chat/tests/call-activity-dock.test.ts
+++ b/chat/tests/call-activity-dock.test.ts
@@ -42,6 +42,7 @@ describe("call activity dock model", () => {
       activePeerJid: null,
       sidebarMode: "channels",
       activeChannelJids: new Set(["general@conference.example.com"]),
+      managedMucDomain: "conference.example.com",
       callParticipantCounts: {
         "general@conference.example.com": 3,
       },
@@ -120,6 +121,7 @@ describe("call activity dock model", () => {
       activePeerJid: null,
       sidebarMode: "channels",
       activeChannelJids: new Set(),
+      managedMucDomain: "conference.example.com",
       callParticipantCounts: {
         "general@conference.example.com": 2,
       },
@@ -140,6 +142,79 @@ describe("call activity dock model", () => {
     ]);
   });
 
+  test("resolves id-only known channels through the managed MUC domain", () => {
+    const entries = buildCallActivityDockEntries({
+      channels: [
+        { id: "general", name: "General" },
+      ],
+      conversations: [],
+      activeChannelId: null,
+      activePeerJid: null,
+      sidebarMode: "channels",
+      activeChannelJids: new Set(["general@custom-muc.example.test"]),
+      managedMucDomain: "custom-muc.example.test",
+      callParticipantCounts: {
+        "general@custom-muc.example.test": 3,
+      },
+      dmCallActivities: {},
+    });
+
+    expect(entries).toEqual([
+      {
+        kind: "channel",
+        key: "channel:general",
+        channelId: "general",
+        roomJid: "general@custom-muc.example.test",
+        title: "General",
+        participantCount: 3,
+        isKnownChannel: true,
+        isActive: false,
+      },
+    ]);
+  });
+
+  test("filters fallback group calls to the managed MUC domain", () => {
+    const entries = buildCallActivityDockEntries({
+      channels: [],
+      conversations: [],
+      activeChannelId: null,
+      activePeerJid: null,
+      sidebarMode: "channels",
+      activeChannelJids: new Set(),
+      managedMucDomain: "conference.example.com",
+      callParticipantCounts: {
+        "general@conference.example.com": 2,
+        "general@other-muc.example.com": 4,
+      },
+      dmCallActivities: {},
+    });
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      kind: "channel",
+      roomJid: "general@conference.example.com",
+      participantCount: 2,
+      isKnownChannel: false,
+    });
+  });
+
+  test("does not surface unmatched fallback group calls without a trusted MUC domain", () => {
+    const entries = buildCallActivityDockEntries({
+      channels: [],
+      conversations: [],
+      activeChannelId: null,
+      activePeerJid: null,
+      sidebarMode: "channels",
+      activeChannelJids: new Set(),
+      callParticipantCounts: {
+        "general@conference.example.com": 2,
+      },
+      dmCallActivities: {},
+    });
+
+    expect(entries).toEqual([]);
+  });
+
   test("marks fallback group call active by room JID instead of an inferred channel ID", () => {
     const entries = buildCallActivityDockEntries({
       channels: [],
@@ -149,6 +224,7 @@ describe("call activity dock model", () => {
       activePeerJid: null,
       sidebarMode: "channels",
       activeChannelJids: new Set(),
+      managedMucDomain: "conference.example.com",
       callParticipantCounts: {
         "general@conference.example.com": 2,
       },
@@ -193,11 +269,15 @@ describe("CallActivityDock rendering", () => {
       activeChannelJids: new Set<string>(),
     });
 
-    expect(html).toContain("Calls");
+    expect(html).toContain("Active calls");
     expect(html).toContain("General");
     expect(html).toContain("Bob");
+    expect(html).toContain("Group call");
+    expect(html).toContain("Video call");
     expect(html).toContain("2 people");
     expect(html).toContain("Live");
+    expect(html).toContain("Open");
+    expect(html).not.toContain("Join");
   });
 
   test("renders active group calls before channel metadata hydrates", async () => {
@@ -212,11 +292,46 @@ describe("CallActivityDock rendering", () => {
       activePeerJid: null,
       sidebarMode: "channels",
       activeChannelJids: new Set<string>(),
+      managedMucDomain: "conference.example.com",
     });
 
-    expect(html).toContain("Calls");
+    expect(html).toContain("Active calls");
     expect(html).toContain("general");
+    expect(html).toContain("Group call · syncing");
     expect(html).toContain("2 people");
+    expect(html).toContain("Open");
+    expect(html).toContain("aria-label=\"Open general call, 2 people\"");
+    expect(html).not.toContain("disabled");
+  });
+
+  test("renders incoming 1:1 call activity without a false answer affordance", async () => {
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com",
+        sid: "dm-call-1",
+        media: { audio: true, video: false },
+        state: "ringing",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:00:00.000Z",
+      },
+    });
+
+    const html = await renderCallActivityDock({
+      channels: [],
+      conversations: [
+        { peerJid: "bob@example.com", peerUsername: "Bob", unreadCount: 0 },
+      ],
+      activeChannelId: null,
+      activePeerJid: null,
+      sidebarMode: "dms",
+      activeChannelJids: new Set<string>(),
+    });
+
+    expect(html).toContain("Bob");
+    expect(html).toContain("Voice call");
+    expect(html).toContain("Ringing");
+    expect(html).toContain("Open");
+    expect(html).not.toContain("Answer");
   });
 
   test("is mounted in the desktop sidebar and visible mobile shell", () => {
@@ -232,41 +347,44 @@ describe("CallActivityDock rendering", () => {
     expect(mobileDrawers).not.toContain("CallActivityDock");
   });
 
-  test("keeps the dock bounded and hydrated DM call controls actionable", () => {
-    const dock = readFileSync(new URL("../src/components/calls/CallActivityDock.vue", import.meta.url), "utf8");
-    const callButton = readFileSync(new URL("../src/components/calls/CallButton.vue", import.meta.url), "utf8");
-    const readyShell = readFileSync(new URL("../src/components/chat/ChatReadyShell.vue", import.meta.url), "utf8");
-    const controller = readFileSync(new URL("../src/shell/chat-app-controller.ts", import.meta.url), "utf8");
-    const contentArea = readFileSync(new URL("../src/components/chat/ContentArea.vue", import.meta.url), "utf8");
+  test("renders hydrated DM call controls with reconnect context", async () => {
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com",
+        sid: "dm-call-1",
+        media: { audio: true, video: true },
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:00:00.000Z",
+      },
+    });
 
-    expect(dock).toContain("max-height: min(40dvh, 18rem)");
-    expect(dock).toContain("overflow-y: auto");
-    expect(dock).toContain("emit(\"selectChannel\", entry.channelId, entry.roomJid)");
-    expect(readyShell).toContain("function onSelectChannelFromSidebar(id: string | null, roomJid?: string)");
-    expect(readyShell).toContain("selectChannelByRoomJid(roomJid)");
-    expect(readyShell).toContain("selectChannel(id, roomJid ? { roomJid } : undefined)");
-    expect(readyShell).toContain(":active-channel-room-jid=\"activeChannelRoomJid\"");
-    expect(controller).toContain("void selectChannel(channel.id, { roomJid: normalizedRoomJid })");
-    expect(contentArea).toContain("const callRoomJid = computed(() => props.roomJid ?? props.channel?.jid ?? null)");
-    expect(contentArea).toContain(":room-jid=\"callRoomJid ?? undefined\"");
-    expect(callButton).toContain("Hydrated peer activity alone stays actionable");
-    expect(callButton).toContain("state.value.phase !== \"idle\" && state.value.phase !== \"ended\"");
-    expect(callButton).not.toContain("|| hasPeerCallActivity.value");
+    const html = await renderVueComponent("../src/components/calls/CallButton.vue", {
+      peerBareJid: "bob@example.com",
+    });
+
+    expect(html).toContain("Video call live");
+    expect(html).toContain("Reconnect voice call");
+    expect(html).toContain("Reconnect video call");
   });
 });
 
 async function renderCallActivityDock(props: Record<string, unknown>) {
-  const component = await loadCallActivityDockComponent();
+  return renderVueComponent("../src/components/calls/CallActivityDock.vue", props);
+}
+
+async function renderVueComponent(path: string, props: Record<string, unknown>) {
+  const component = await loadVueComponent(path);
   return renderToString(createSSRApp({ render: () => h(component, props) }));
 }
 
-async function loadCallActivityDockComponent() {
-  const filename = new URL("../src/components/calls/CallActivityDock.vue", import.meta.url);
+async function loadVueComponent(path: string) {
+  const filename = new URL(path, import.meta.url);
   const source = readFileSync(filename, "utf8");
   const { descriptor } = parse(source, { filename: filename.pathname });
-  const script = compileScript(descriptor, { id: "call-activity-dock-test", inlineTemplate: true });
+  const script = compileScript(descriptor, { id: filename.pathname, inlineTemplate: true });
 
-  const tempDir = mkdtempSync(join(tmpdir(), "waddle-call-activity-dock-"));
+  const tempDir = mkdtempSync(join(tmpdir(), "waddle-vue-component-"));
   try {
     const compiled = [
       rewriteImports(script.content.replace("export default", "const __sfc__ ="), filename),
@@ -280,7 +398,7 @@ async function loadCallActivityDockComponent() {
         verbatimModuleSyntax: false,
       },
     }).outputText;
-    const modulePath = join(tempDir, "CallActivityDock.mjs");
+    const modulePath = join(tempDir, "Component.mjs");
     writeFileSync(modulePath, js);
     const component = await import(pathToFileURL(modulePath).href);
     return component.default;

--- a/chat/tests/muc-call-indicators.test.ts
+++ b/chat/tests/muc-call-indicators.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   callParticipantCountForChannel,
   collapsedGroupBadgeModel,
+  normalizeMucServiceDomain,
 } from "../src/lib/calls/muc-call-indicators";
 
 describe("callParticipantCountForChannel", () => {
@@ -13,12 +14,21 @@ describe("callParticipantCountForChannel", () => {
     )).toBe(2);
   });
 
-  test("falls back to active room jids when the channel summary lacks a jid", () => {
+  test("matches id-only channel rows through the managed MUC domain", () => {
     expect(callParticipantCountForChannel(
       { id: "general" },
       { "general@muc.test": 1 },
       new Set(["General@MUC.Test"]),
+      "muc.test",
     )).toBe(1);
+  });
+
+  test("does not guess a channel room from localpart without a trusted domain", () => {
+    expect(callParticipantCountForChannel(
+      { id: "general" },
+      { "general@muc.test": 1 },
+      new Set(["General@MUC.Test"]),
+    )).toBe(0);
   });
 
   test("does not let an unrelated active call hide this channel's count", () => {
@@ -38,6 +48,21 @@ describe("callParticipantCountForChannel", () => {
       { "general@muc.test": 3 },
       new Set(["general@muc.test"]),
     )).toBe(0);
+  });
+
+  test("does not match same-localpart calls from another MUC domain", () => {
+    expect(callParticipantCountForChannel(
+      { id: "general", jid: "general@muc.test" },
+      { "general@other-muc.test": 3 },
+      new Set(["general@other-muc.test"]),
+    )).toBe(0);
+  });
+});
+
+describe("normalizeMucServiceDomain", () => {
+  test("accepts discovered MUC service JIDs and bare domains", () => {
+    expect(normalizeMucServiceDomain("custom-muc.example.test")).toBe("custom-muc.example.test");
+    expect(normalizeMucServiceDomain("rooms@example.test/resource")).toBe("example.test");
   });
 });
 


### PR DESCRIPTION
## Summary

Polish the active call presence surfaces that sit on top of the LiveKit-backed call work, with the focus on refresh-hydrated calls staying visible without misleading protocol affordances.

- Active call dock rows now show richer call type/status/action context while using `Open` for navigation-only rows instead of pretending to directly join or answer calls.
- Group-call matching now scopes id-only fallback rows and unmatched fallback rows to the discovered managed MUC service domain, with `muc.<account-domain>` only as a no-discovery fallback.
- Unknown but trusted group-call rows remain actionable by room JID while cross-domain same-localpart calls are filtered out.
- Group-call header pills no longer show fake elapsed duration derived from local observation time; Muji presence only proves that the call is live.
- Hydrated DM calls now surface reconnect context beside the DM call controls and in the mobile/desktop header status without auto-accepting XEP-0353 calls.
- Tests now cover managed-domain matching, fallback filtering, fallback row rendering, and hydrated DM reconnect context.

## Plan

- [x] Review the current call dock, DM panel badges, header pill, and call layout against the local XEP-0272/XEP-0045/XEP-0313/XEP-0353 flows.
- [x] Improve active call rows so running group and 1:1 calls are more legible and actionable after refresh, including clearer status, media/type hints, and open/reconnect affordances.
- [x] Keep room JID vs channel ID and Muji room identity vs per-attempt Jingle SID boundaries intact.
- [x] Add focused tests for the improved call presence model/rendering.
- [x] Run package-local verification.
- [x] Run adversarial review passes and fold in actionable findings.

## Verification

- `bun test tests/call-activity-dock.test.ts tests/muc-call-indicators.test.ts`
- `bun run lint`
- `bun run build` (passes; existing Astro async-function hint and Vite chunk-size warning)
- `bun test` (1251 pass, 0 fail)
- `git diff --check`

No dev server started.