### PR TITLE
fix(chat): preserve calls across tab refresh

### DIFF
--- a/chat/src/components/calls/CallActivityDock.vue
+++ b/chat/src/components/calls/CallActivityDock.vue
@@ -9,9 +9,11 @@ import {
 import { $dmCallActivities } from "@/lib/calls/dm-call-activity";
 import {
   buildCallActivityDockEntries,
+  callActivityDockSelection,
   type CallActivityDockEntry,
   type SidebarMode,
 } from "@/lib/calls/call-activity-dock";
+import type { CallMedia } from "@/lib/calls/types";
 import type { ChannelSummary } from "@/lib/chat-types";
 import type { DmConversation } from "@/lib/xmpp-client";
 
@@ -29,6 +31,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   selectChannel: [channelId: string | null, roomJid: string];
   selectDm: [peerJid: string];
+  reconnectDm: [peerJid: string, media: CallMedia];
 }>();
 
 const mucCallParticipantsStore = useStore($mucCallParticipants);
@@ -76,6 +79,7 @@ function entryMeta(entry: CallActivityDockEntry): string {
 
 function entryAction(entry: CallActivityDockEntry): string {
   if (entry.kind === "channel") return "Open";
+  if (callActivityDockSelection(entry).kind === "dm-reconnect") return "Reconnect";
   return "Open";
 }
 
@@ -89,11 +93,18 @@ function entryCanSelect(entry: CallActivityDockEntry): boolean {
 
 function selectEntry(entry: CallActivityDockEntry): void {
   if (!entryCanSelect(entry)) return;
-  if (entry.kind === "channel") {
-    emit("selectChannel", entry.channelId, entry.roomJid);
-    return;
+  const selection = callActivityDockSelection(entry);
+  switch (selection.kind) {
+    case "channel":
+      emit("selectChannel", selection.channelId, selection.roomJid);
+      return;
+    case "dm-reconnect":
+      emit("reconnectDm", selection.peerJid, selection.media);
+      return;
+    case "dm-open":
+      emit("selectDm", selection.peerJid);
+      return;
   }
-  emit("selectDm", entry.peerJid);
 }
 </script>
 

--- a/chat/src/components/calls/CallButton.vue
+++ b/chat/src/components/calls/CallButton.vue
@@ -2,9 +2,10 @@
 import { computed } from "vue";
 import { useStore } from "@nanostores/vue";
 import { Phone, Video } from "lucide-vue-next";
-import { $callState, beginOutgoingCall, reportCallError, scheduleOutgoingTimeout } from "@/lib/calls/call-store";
-import { clearDmCallActivity, useDmCallActivity } from "@/lib/calls/dm-call-activity";
-import { newCallSid, outboundCalls } from "@/lib/calls/outbound";
+import { $callState } from "@/lib/calls/call-store";
+import { useDmCallActivity } from "@/lib/calls/dm-call-activity";
+import { startDmCallAction } from "@/lib/calls/dm-call-actions";
+import type { CallWireSender } from "@/lib/calls/outbound";
 import { connectionStore } from "@/lib/connection-store";
 import type { CallMedia } from "@/lib/calls/types";
 
@@ -42,36 +43,22 @@ const activityBannerLabel = computed(() => {
   return `${media} call ringing`;
 });
 
-function getSender() {
+function getSender(): CallWireSender | null {
   const client = connectionStore.client as unknown as { xmpp?: unknown } | null;
-  return (client?.xmpp as Parameters<typeof outboundCalls.propose>[0] | undefined) ?? null;
+  return (client?.xmpp as CallWireSender | undefined) ?? null;
+}
+
+function getInitiator(): string | undefined {
+  return (connectionStore.client as unknown as { fullJid?: string } | null)?.fullJid;
 }
 
 async function startCall(media: CallMedia): Promise<void> {
-  if (inCall.value) return;
-  const sender = getSender();
-  if (!sender) return;
-  const initiator = (connectionStore.client as unknown as { fullJid?: string } | null)?.fullJid;
-  const sid = newCallSid();
-  beginOutgoingCall(props.peerBareJid, sid, media, initiator);
-  try {
-    await outboundCalls.propose(sender, props.peerBareJid, sid, media);
-    // Arm the auto-retract once the propose is on the wire — if we
-    // armed earlier and the propose itself failed, the timer would
-    // race the rollback.
-    scheduleOutgoingTimeout(sender, sid);
-  } catch (err) {
-    // The propose stanza failed at the wire boundary. Snap the slot
-    // back to idle so the UI doesn't strand on an outgoing toast
-    // that never resolves, and surface the error via the global
-    // call-error atom so the user knows the click did something.
-    const current = $callState.get();
-    if (current.phase === "outgoing" && current.sid === sid) {
-      $callState.set({ phase: "idle" });
-    }
-    clearDmCallActivity(props.peerBareJid, sid);
-    reportCallError(err);
-  }
+  await startDmCallAction({
+    peerBareJid: props.peerBareJid,
+    media,
+    getSender,
+    getInitiator,
+  });
 }
 </script>
 

--- a/chat/src/components/calls/CallOverlay.vue
+++ b/chat/src/components/calls/CallOverlay.vue
@@ -12,7 +12,7 @@ import { connectionStore } from "@/lib/connection-store";
 import {
   $callConnecting,
   resetCallControls,
-  teardownForPageHide,
+  suspendCallForPageHide,
 } from "@/lib/calls/call-controls";
 import { $callUiMode } from "@/lib/calls/ui-mode";
 
@@ -84,14 +84,14 @@ watch(
 );
 
 /**
- * Best-effort teardown for the tab-close path. `pagehide` fires
- * earlier in the unload sequence than `onBeforeUnmount` and is the
- * modern documented hook for unload-side networking. The authoritative
- * path is server-side: `cleanup_muc_presence` broadcasts unavailable
- * presence regardless of whether this client managed to send anything.
+ * Release local camera/mic during page lifecycle suspension without
+ * sending XMPP hangup stanzas. Browser refresh must preserve the
+ * remote-visible call so the new tab load can rediscover it through
+ * MAM call markers or MUC presence replay.
  */
-function handlePageHide(): void {
-  teardownForPageHide();
+function handlePageHide(event: PageTransitionEvent): void {
+  if (event.persisted) return;
+  suspendCallForPageHide();
 }
 
 onMounted(() => {
@@ -101,9 +101,9 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
-  // In-app overlay unmounts (route change, etc.) get the same
-  // best-effort cleanup as a tab close.
-  void tearDownActiveCall(getSender(), "gone");
+  // Component lifecycle is not a call lifecycle. Route changes and
+  // browser refreshes must not emit XMPP call-ending stanzas; explicit
+  // hangup/logout own that path.
   void engine.disconnect();
   if (typeof window !== "undefined") {
     window.removeEventListener("pagehide", handlePageHide);

--- a/chat/src/components/chat/ChatHeader.vue
+++ b/chat/src/components/chat/ChatHeader.vue
@@ -31,6 +31,7 @@ const props = defineProps<{
   waddle: SpaceSummary | null;
   channel: ChannelSummary | null;
   dmPeer?: { peerJid?: string; peerUsername: string; presenceShow?: string } | null;
+  callRoomJid?: string | null;
   isForumChannel: boolean;
   canManageChannels: boolean;
   memberCount: number | null;
@@ -274,8 +275,8 @@ const memberButtonCopy = computed(() => {
           :peer-bare-jid="dmPeer.peerJid"
         />
         <MucCallButton
-          v-else-if="channel?.jid"
-          :room-jid="channel.jid"
+          v-else-if="callRoomJid"
+          :room-jid="callRoomJid"
         />
         <!-- Live presence stack — desktop only. The mobile header is
              already crowded with hamburger + channel chip + search/pin/

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -5,7 +5,11 @@ import {
   $mucCallParticipants,
   mucCallParticipantCounts,
 } from "@/lib/calls/muc-call-presence";
+import { $dmCallActivities } from "@/lib/calls/dm-call-activity";
+import { startDmCallAction } from "@/lib/calls/dm-call-actions";
 import { normalizeMucServiceDomain } from "@/lib/calls/muc-call-indicators";
+import type { CallWireSender } from "@/lib/calls/outbound";
+import type { CallMedia } from "@/lib/calls/types";
 import HomeDashboard from "@/components/chat/HomeDashboard.vue";
 import ThreadsView from "@/components/chat/ThreadsView.vue";
 import FeedPane from "@/components/community/FeedPane.vue";
@@ -136,6 +140,22 @@ const {
   jumpToPinnedMessage,
 } = props.controller;
 
+/**
+ * XEP-0272 Muji participant counts keyed by room JID. Derived from
+ * the per-room nick list so the sidebar badge updates as occupants
+ * join and leave the call without any extra round-trip. Computed
+ * once here and threaded through TopicsPanel so per-row lookups
+ * stay O(1).
+ */
+const mucCallParticipantsStore = useStore($mucCallParticipants);
+const dmCallActivitiesStore = useStore($dmCallActivities);
+const callParticipantCounts = computed<Record<string, number>>(() => {
+  return mucCallParticipantCounts(mucCallParticipantsStore.value);
+});
+const managedMucDomain = computed(() =>
+  normalizeMucServiceDomain(waddles.mucServiceJid.value) || (selfDomain.value ? `muc.${selfDomain.value}` : ""),
+);
+
 const homeDashboardProps = computed(() => buildHomeDashboardProps({
   spaces: waddles.sortedSpaces.value,
   channels: waddles.sortedChannels.value,
@@ -145,22 +165,10 @@ const homeDashboardProps = computed(() => buildHomeDashboardProps({
   mentionedRoomJids: messaging.mentionedChannelCounts.value,
   activeChannelJids: messaging.activeChannels.value,
   dmConversations: dmConversations.conversations.value,
+  callParticipantCounts: callParticipantCounts.value,
+  dmCallActivities: dmCallActivitiesStore.value,
+  managedMucDomain: managedMucDomain.value,
 }));
-
-/**
- * XEP-0272 Muji participant counts keyed by room JID. Derived from
- * the per-room nick list so the sidebar badge updates as occupants
- * join and leave the call without any extra round-trip. Computed
- * once here and threaded through TopicsPanel so per-row lookups
- * stay O(1).
- */
-const mucCallParticipantsStore = useStore($mucCallParticipants);
-const callParticipantCounts = computed<Record<string, number>>(() => {
-  return mucCallParticipantCounts(mucCallParticipantsStore.value);
-});
-const managedMucDomain = computed(() =>
-  normalizeMucServiceDomain(waddles.mucServiceJid.value) || (selfDomain.value ? `muc.${selfDomain.value}` : ""),
-);
 
 const contentPaneClass = computed(() => {
   if (ui.sidebarMode.value !== "channels") return "";
@@ -213,6 +221,25 @@ function onSelectChannelFromSidebar(id: string | null, roomJid?: string) {
   if (roomJid) selectChannelByRoomJid(roomJid);
 }
 
+function getCallSender(): CallWireSender | null {
+  const client = connectionStore.client as unknown as { xmpp?: unknown } | null;
+  return (client?.xmpp as CallWireSender | undefined) ?? null;
+}
+
+function getSelfFullJid(): string | undefined {
+  return (connectionStore.client as unknown as { fullJid?: string } | null)?.fullJid;
+}
+
+function reconnectDmFromDock(peerJid: string, media: CallMedia): void {
+  selectDm(peerJid);
+  void startDmCallAction({
+    peerBareJid: peerJid,
+    media,
+    getSender: getCallSender,
+    getInitiator: getSelfFullJid,
+  });
+}
+
 // ── Admin route plumbing ────────────────────────────────────────────
 // The admin view is rendered straight out of ChatReadyShell rather
 // than from a per-route page Vue island, so the panel slug is
@@ -263,6 +290,7 @@ onUnmounted(() => {
       :managed-muc-domain="managedMucDomain"
       @select-channel="onSelectChannelFromSidebar"
       @select-dm="selectDm"
+      @reconnect-dm="reconnectDmFromDock"
     />
 
     <!-- Desktop layout -->
@@ -343,6 +371,7 @@ onUnmounted(() => {
           :managed-muc-domain="managedMucDomain"
           @select-channel="onSelectChannelFromSidebar"
           @select-dm="selectDm"
+          @reconnect-dm="reconnectDmFromDock"
         />
       </div>
 
@@ -350,8 +379,10 @@ onUnmounted(() => {
       <HomeDashboard
         v-if="ui.activePage.value === 'dashboard'"
         v-bind="homeDashboardProps"
-        @select-channel="selectChannel"
+        @select-channel="(id: string, roomJid?: string) => selectChannel(id, roomJid ? { roomJid } : undefined)"
+        @select-channel-room="selectChannelByRoomJid"
         @select-contact="handleOpenDm"
+        @reconnect-dm="reconnectDmFromDock"
         @open-nav="ui.showMobileNav.value = true"
       />
       <FeedPane

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -874,6 +874,7 @@ function dayDividerLabel(createdAt: string): string {
       :waddle="waddle"
       :channel="channel"
       :dm-peer="dmPeer"
+      :call-room-jid="callRoomJid"
       :is-forum-channel="isForumChannel"
       :can-manage-channels="canManageChannels"
       :member-count="memberCount"

--- a/chat/src/components/chat/HomeDashboard.vue
+++ b/chat/src/components/chat/HomeDashboard.vue
@@ -1,11 +1,30 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref } from "vue";
-import { ArrowRight, Hash, MessageCircle, MessagesSquare, Users } from "lucide-vue-next";
+import {
+  ArrowRight,
+  Hash,
+  MessageCircle,
+  MessagesSquare,
+  Phone,
+  PhoneCall,
+  PhoneIncoming,
+  PhoneOutgoing,
+  Users,
+  Video,
+} from "lucide-vue-next";
 import type { ChannelSummary } from "@/lib/chat-types";
 import type { RosterContact } from "@/lib/xmpp/types";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import Skeleton from "@/components/ui/Skeleton.vue";
 import { isForumChannel } from "@/lib/channel-types";
+import {
+  buildCallActivityDockEntries,
+  callActivityDockSelection,
+  type CallActivityDockEntry,
+} from "@/lib/calls/call-activity-dock";
+import { callParticipantCountForChannel } from "@/lib/calls/muc-call-indicators";
+import { barePeerJid } from "@/lib/xmpp/jid";
+import type { CallMedia } from "@/lib/calls/types";
 import { groupChannelsBySpace } from "@/lib/channel-grouping";
 import { formatTimelineStamp } from "@/channels/timeline";
 import type { ChannelActivityState, HomeDashboardProps } from "@/home/dashboard-props";
@@ -26,8 +45,10 @@ import {
 const props = defineProps<HomeDashboardProps>();
 
 const emit = defineEmits<{
-  selectChannel: [id: string];
+  selectChannel: [id: string, roomJid?: string];
+  selectChannelRoom: [roomJid: string];
   selectContact: [jid: string];
+  reconnectDm: [peerJid: string, media: CallMedia];
   openNav: [];
 }>();
 
@@ -74,6 +95,7 @@ interface HeroSummary {
   totalMentions: number;
   totalThreadUnread: number;
   dmUnread: number;
+  activeCalls: number;
   onlineFriends: number;
   hasUnread: boolean;
 }
@@ -87,9 +109,23 @@ const groups = computed(() => groupChannelsBySpace(props.spaces, props.channels)
 const visibleChannelGroups = computed(() => groups.value.filter((group) => group.channels.length > 0));
 const activeChannelJids = computed(() => props.activeChannelJids ?? new Set<string>());
 const directMessages = computed(() => props.dmConversations ?? []);
+const callParticipantCounts = computed(() => props.callParticipantCounts ?? {});
+const dmCallActivities = computed(() => props.dmCallActivities ?? {});
 const channelsBySpace = computed(() =>
   new Map(groups.value.flatMap((group) => group.space ? [[group.space.id, group.channels.length] as const] : [])),
 );
+const activeCallEntries = computed<CallActivityDockEntry[]>(() => buildCallActivityDockEntries({
+  channels: props.channels,
+  conversations: directMessages.value,
+  activeChannelId: null,
+  activeChannelRoomJid: null,
+  activePeerJid: null,
+  sidebarMode: "channels",
+  activeChannelJids: activeChannelJids.value,
+  managedMucDomain: props.managedMucDomain ?? null,
+  callParticipantCounts: callParticipantCounts.value,
+  dmCallActivities: dmCallActivities.value,
+}));
 const activityByChannelId = computed(() =>
   new Map(props.channels.map((channel) => [
     channel.id,
@@ -112,6 +148,25 @@ function selectSpaceChannel(spaceId: string) {
   if (channelId) emit("selectChannel", channelId);
 }
 
+function selectCallEntry(entry: CallActivityDockEntry) {
+  const selection = callActivityDockSelection(entry);
+  switch (selection.kind) {
+    case "channel":
+      if (selection.channelId) {
+        emit("selectChannel", selection.channelId, selection.roomJid);
+        return;
+      }
+      if (selection.roomJid) emit("selectChannelRoom", selection.roomJid);
+      return;
+    case "dm-reconnect":
+      emit("reconnectDm", selection.peerJid, selection.media);
+      return;
+    case "dm-open":
+      emit("selectContact", selection.peerJid);
+      return;
+  }
+}
+
 function channelsForSpace(spaceId: string): ChannelSummary[] {
   return groups.value.find((group) => group.space?.id === spaceId)?.channels ?? [];
 }
@@ -129,6 +184,20 @@ function spaceHasChannels(spaceId: string): boolean {
 function channelActivity(channel: ChannelSummary) {
   return activityByChannelId.value.get(channel.id)
     ?? { unread: 0, mentions: 0, threadUnread: 0, hasActivity: false };
+}
+
+function channelCallCount(channel: ChannelSummary): number {
+  return callParticipantCountForChannel(
+    channel,
+    callParticipantCounts.value,
+    activeChannelJids.value,
+    props.managedMucDomain ?? null,
+  );
+}
+
+function dmCallActivityFor(peerJid: string) {
+  const normalized = barePeerJid(peerJid).toLowerCase();
+  return normalized ? dmCallActivities.value[normalized] ?? null : null;
 }
 
 function groupActivity(groupId: string): HomeActivitySummary {
@@ -195,6 +264,60 @@ function dmSecondaryText(conversation: { peerUsername?: string; peerJid: string;
   return preview || conversation.peerJid;
 }
 
+function dmCallLabel(peerJid: string): string {
+  const activity = dmCallActivityFor(peerJid);
+  if (!activity) return "";
+  const media = activity.media.video ? "Video" : "Voice";
+  if (activity.state === "accepted") return `${media} call live`;
+  if (activity.direction === "incoming") return `Incoming ${media.toLowerCase()} call`;
+  if (activity.direction === "outgoing") return `${media} call calling`;
+  return `${media} call ringing`;
+}
+
+function channelHomeAriaLabel(channel: ChannelSummary): string {
+  const base = channelHomeLabel(channel, channelActivity(channel), activityStamp(channelActivity(channel).lastUpdated));
+  const count = channelCallCount(channel);
+  if (count <= 0) return base;
+  const noun = count === 1 ? "person" : "people";
+  return `${base}, active call with ${count} ${noun}`;
+}
+
+function dmHomeAriaLabel(conversation: {
+  peerUsername?: string;
+  peerJid: string;
+  lastMessageBody?: string;
+  lastMessageAt?: string;
+  unreadCount: number;
+  presenceShow?: "available" | "away" | "xa" | "dnd" | "offline";
+}): string {
+  const base = dmHomeLabel(
+    conversation,
+    conversation.lastMessageAt ? formatTimelineStamp(conversation.lastMessageAt) : "",
+  );
+  const call = dmCallLabel(conversation.peerJid);
+  return call ? `${base}, ${call}` : base;
+}
+
+function callEntryStatus(entry: CallActivityDockEntry): string {
+  if (entry.kind === "channel") {
+    const noun = entry.participantCount === 1 ? "person" : "people";
+    return `${entry.participantCount} ${noun}`;
+  }
+  if (entry.state === "accepted") return "Live";
+  if (entry.direction === "outgoing") return "Calling";
+  return "Ringing";
+}
+
+function callEntryKindLabel(entry: CallActivityDockEntry): string {
+  if (entry.kind === "channel") return entry.isKnownChannel ? "Group call" : "Group call syncing";
+  return entry.media.video ? "Video call" : "Voice call";
+}
+
+function callEntryLabel(entry: CallActivityDockEntry): string {
+  const action = callActivityDockSelection(entry).kind === "dm-reconnect" ? "Reconnect" : "Open";
+  return `${action} ${entry.title}, ${callEntryKindLabel(entry)}, ${callEntryStatus(entry)}`;
+}
+
 const heroSummary = computed<HeroSummary>(() => {
   let totalUnread = 0;
   let totalMentions = 0;
@@ -221,6 +344,7 @@ const heroSummary = computed<HeroSummary>(() => {
     totalMentions,
     totalThreadUnread,
     dmUnread,
+    activeCalls: activeCallEntries.value.length,
     onlineFriends,
     hasUnread: totalUnread + totalMentions + totalThreadUnread + dmUnread > 0,
   };
@@ -238,6 +362,9 @@ const heroSummaryParts = computed<HeroSummaryPart[]>(() => {
   }
   if (s.totalThreadUnread > 0) {
     parts.push({ count: s.totalThreadUnread, label: s.totalThreadUnread === 1 ? "thread reply" : "thread replies" });
+  }
+  if (s.activeCalls > 0) {
+    parts.push({ count: s.activeCalls, label: s.activeCalls === 1 ? "active call" : "active calls" });
   }
   if (s.onlineFriends > 0) {
     parts.push({ count: s.onlineFriends, label: s.onlineFriends === 1 ? "friend online" : "friends online" });
@@ -324,6 +451,49 @@ function onHeroCta() {
         >
           <Hash class="h-4 w-4" />
         </button>
+      </section>
+
+      <section
+        v-if="activeCallEntries.length > 0"
+        class="grid gap-3"
+        aria-label="Active calls"
+      >
+        <div class="flex items-center gap-2">
+          <PhoneCall class="h-4 w-4 text-success" />
+          <h2 class="type-pane-title">Active calls</h2>
+        </div>
+        <div class="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+          <button
+            v-for="entry in activeCallEntries"
+            :key="entry.key"
+            class="chat-list-row flex min-w-0 min-h-16 items-center gap-3 overflow-hidden rounded-lg border border-success/20 bg-success/10 px-4 py-3 text-left text-foreground hover:bg-success/20"
+            type="button"
+            :aria-label="callEntryLabel(entry)"
+            @click="selectCallEntry(entry)"
+          >
+            <span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-success/10 text-success">
+              <Hash v-if="entry.kind === 'channel'" class="h-4 w-4" />
+              <Video v-else-if="entry.media.video" class="h-4 w-4" />
+              <PhoneIncoming v-else-if="entry.state === 'ringing' && entry.direction === 'incoming'" class="h-4 w-4" />
+              <PhoneOutgoing v-else-if="entry.state === 'ringing' && entry.direction === 'outgoing'" class="h-4 w-4" />
+              <Phone v-else class="h-4 w-4" />
+            </span>
+            <span class="min-w-0 flex-1">
+              <span class="type-control block truncate">{{ entry.title }}</span>
+              <span class="type-caption block truncate text-muted-foreground">
+                {{ callEntryKindLabel(entry) }} · {{ callEntryStatus(entry) }}
+              </span>
+            </span>
+            <span
+              v-if="entry.kind === 'channel'"
+              class="type-count-badge inline-flex min-w-[18px] h-[18px] shrink-0 items-center justify-center rounded-full border border-success/25 bg-success/10 px-1 text-success"
+              aria-hidden="true"
+            >
+              {{ entry.participantCount }}
+            </span>
+            <ArrowRight class="h-4 w-4 shrink-0 text-success" aria-hidden="true" />
+          </button>
+        </div>
       </section>
 
       <section class="grid gap-3">
@@ -426,7 +596,7 @@ function onHeroCta() {
                     ? 'chat-list-row--unread'
                     : ''"
                 type="button"
-                :aria-label="channelHomeLabel(channel, channelActivity(channel), activityStamp(channelActivity(channel).lastUpdated))"
+                :aria-label="channelHomeAriaLabel(channel)"
                 @click="emit('selectChannel', channel.id)"
               >
                 <component :is="isForumChannel(channel) ? MessagesSquare : Hash" class="h-3.5 w-3.5 text-primary/70" />
@@ -445,6 +615,15 @@ function onHeroCta() {
                   {{ activityStamp(channelActivity(channel).lastUpdated) }}
                 </span>
                 <span class="flex shrink-0 items-center gap-1">
+                  <span
+                    v-if="channelCallCount(channel) > 0"
+                    class="type-meta inline-flex h-[18px] shrink-0 items-center gap-1 rounded-full border border-success/25 bg-success/10 px-1.5 text-success"
+                    title="Active call"
+                    aria-hidden="true"
+                  >
+                    <PhoneCall class="h-3 w-3" />
+                    <span>{{ channelCallCount(channel) }}</span>
+                  </span>
                   <span
                     v-if="channelActivity(channel).mentions > 0"
                     class="chat-list-row--mention-badge type-count-badge inline-flex min-w-[18px] h-[18px] px-1 items-center justify-center rounded-full bg-destructive text-destructive-foreground"
@@ -512,7 +691,7 @@ function onHeroCta() {
             class="chat-list-row flex min-w-0 min-h-14 items-center gap-3 overflow-hidden rounded-lg border border-border bg-card px-4 py-3 text-left hover:bg-muted/60"
             :class="conversation.unreadCount > 0 ? 'chat-list-row--unread' : ''"
             type="button"
-            :aria-label="dmHomeLabel(conversation, conversation.lastMessageAt ? formatTimelineStamp(conversation.lastMessageAt) : '')"
+            :aria-label="dmHomeAriaLabel(conversation)"
             @click="emit('selectContact', conversation.peerJid)"
           >
             <span class="relative">
@@ -531,6 +710,15 @@ function onHeroCta() {
               <span class="type-meta block text-muted-foreground">
                 {{ dmPresenceLabel(conversation.presenceShow) }}
               </span>
+            </span>
+            <span
+              v-if="dmCallActivityFor(conversation.peerJid)"
+              class="type-meta inline-flex h-[18px] shrink-0 items-center gap-1 rounded-full border border-success/25 bg-success/10 px-1.5 text-success"
+              :title="dmCallLabel(conversation.peerJid)"
+              aria-hidden="true"
+            >
+              <PhoneCall class="h-3 w-3" />
+              <span>{{ dmCallActivityFor(conversation.peerJid)?.state === 'accepted' ? 'Live' : 'Ringing' }}</span>
             </span>
             <span v-if="conversation.lastMessageAt" class="type-meta type-numeric text-muted-foreground">
               {{ formatTimelineStamp(conversation.lastMessageAt) }}

--- a/chat/src/home/dashboard-props.ts
+++ b/chat/src/home/dashboard-props.ts
@@ -2,6 +2,7 @@ import type { ChannelSummary, SpaceSummary } from "@/lib/chat-types";
 import type { RosterContact } from "@/lib/xmpp/types";
 import type { DmConversation } from "@/lib/xmpp-client";
 import type { ChannelUnreadMap } from "@/home/activity";
+import type { DmCallActivity } from "@/lib/calls/dm-call-activity";
 
 export interface HomeDashboardProps {
   spaces: SpaceSummary[];
@@ -11,6 +12,9 @@ export interface HomeDashboardProps {
   channelUnreadMap?: ChannelUnreadMap;
   activeChannelJids?: Set<string>;
   dmConversations?: DmConversation[];
+  callParticipantCounts?: Record<string, number>;
+  dmCallActivities?: Record<string, DmCallActivity>;
+  managedMucDomain?: string | null;
 }
 
 interface HomeDashboardSources extends Omit<HomeDashboardProps, "channelUnreadMap"> {
@@ -31,6 +35,9 @@ export function buildHomeDashboardProps(sources: HomeDashboardSources): HomeDash
     ),
     activeChannelJids: sources.activeChannelJids,
     dmConversations: sources.dmConversations,
+    callParticipantCounts: sources.callParticipantCounts,
+    dmCallActivities: sources.dmCallActivities,
+    managedMucDomain: sources.managedMucDomain,
   };
 }
 

--- a/chat/src/lib/calls/call-activity-dock.ts
+++ b/chat/src/lib/calls/call-activity-dock.ts
@@ -32,8 +32,33 @@ export type CallActivityDockEntry =
       direction: DmCallActivity["direction"];
       updatedAt: string;
       isActive: boolean;
-    };
+  };
 type DmCallActivityDockEntry = Extract<CallActivityDockEntry, { kind: "dm" }>;
+
+type CallActivityDockSelection =
+  | { kind: "channel"; channelId: string | null; roomJid: string }
+  | { kind: "dm-open"; peerJid: string }
+  | { kind: "dm-reconnect"; peerJid: string; media: DmCallActivity["media"] };
+
+export function callActivityDockSelection(
+  entry: CallActivityDockEntry,
+): CallActivityDockSelection {
+  if (entry.kind === "channel") {
+    return {
+      kind: "channel",
+      channelId: entry.channelId,
+      roomJid: entry.roomJid,
+    };
+  }
+  if (entry.state === "accepted") {
+    return {
+      kind: "dm-reconnect",
+      peerJid: entry.peerJid,
+      media: entry.media,
+    };
+  }
+  return { kind: "dm-open", peerJid: entry.peerJid };
+}
 
 export function buildCallActivityDockEntries(options: {
   channels: ReadonlyArray<Pick<ChannelSummary, "id" | "name" | "jid">>;

--- a/chat/src/lib/calls/call-controls.ts
+++ b/chat/src/lib/calls/call-controls.ts
@@ -1,6 +1,7 @@
 import { atom } from "nanostores";
 import {
   $callState,
+  clearCallState,
   reportCallError,
   tearDownActiveCall,
 } from "./call-store";
@@ -71,16 +72,18 @@ export async function hangupActiveCall(): Promise<void> {
 }
 
 /**
- * Best-effort tab-close path. `pagehide` fires earlier than
- * `onBeforeUnmount`, and the WebSocket is torn down before our async
- * stanza chain completes — so this is shortening the gap, not a
- * guarantee. The authoritative cleanup is the server's unclean-
- * disconnect handler (`cleanup_muc_presence`).
+ * Browser page lifecycle path. A full tab refresh emits `pagehide`
+ * before the new JS context reconnects; sending XEP-0166
+ * `<session-terminate/>` or XEP-0272 clearing presence here destroys
+ * the call the refreshed page is about to rediscover. Release local
+ * media only. Explicit hangup/logout still goes through
+ * `tearDownActiveCall` and sends the conformant call-ending stanzas.
  */
-export function teardownForPageHide(): void {
-  const sender = getSender();
-  if (!sender) return;
-  void tearDownActiveCall(sender, "gone");
+export function suspendCallForPageHide(): void {
+  const current = $callState.get();
+  if (current.phase === "idle" || current.phase === "ended") return;
+  clearCallState();
+  void useCallEngine().engine.disconnect();
 }
 
 /**

--- a/chat/src/lib/calls/dm-call-actions.ts
+++ b/chat/src/lib/calls/dm-call-actions.ts
@@ -1,0 +1,46 @@
+import {
+  $callState,
+  beginOutgoingCall,
+  reportCallError,
+  scheduleOutgoingTimeout,
+} from "./call-store";
+import { clearDmCallActivity } from "./dm-call-activity";
+import {
+  newCallSid,
+  outboundCalls,
+  type CallWireSender,
+} from "./outbound";
+import type { CallMedia } from "./types";
+
+export async function startDmCallAction(options: {
+  peerBareJid: string;
+  media: CallMedia;
+  getSender: () => CallWireSender | null;
+  getInitiator?: () => string | undefined;
+}): Promise<void> {
+  const current = $callState.get();
+  if (current.phase !== "idle" && current.phase !== "ended") return;
+
+  const sender = options.getSender();
+  if (!sender) return;
+
+  const sid = newCallSid();
+  beginOutgoingCall(
+    options.peerBareJid,
+    sid,
+    options.media,
+    options.getInitiator?.(),
+  );
+
+  try {
+    await outboundCalls.propose(sender, options.peerBareJid, sid, options.media);
+    scheduleOutgoingTimeout(sender, sid);
+  } catch (err) {
+    const next = $callState.get();
+    if (next.phase === "outgoing" && next.sid === sid) {
+      $callState.set({ phase: "idle" });
+    }
+    clearDmCallActivity(options.peerBareJid, sid);
+    reportCallError(err);
+  }
+}

--- a/chat/tests/call-activity-dock.test.ts
+++ b/chat/tests/call-activity-dock.test.ts
@@ -9,6 +9,7 @@ import { renderToString } from "vue/server-renderer";
 import ts from "typescript";
 import {
   buildCallActivityDockEntries,
+  callActivityDockSelection,
 } from "../src/lib/calls/call-activity-dock";
 import { clearMucCallParticipants, $mucCallParticipants } from "../src/lib/calls/muc-call-presence";
 import { clearDmCallActivities, $dmCallActivities } from "../src/lib/calls/dm-call-activity";
@@ -111,6 +112,61 @@ describe("call activity dock model", () => {
       peerJid: "carol@example.com",
       isActive: true,
     });
+  });
+
+  test("maps accepted DM rows to reconnect instead of plain navigation", () => {
+    const entries = buildCallActivityDockEntries({
+      channels: [
+        { id: "general", name: "General", jid: "general@conference.example.com" },
+      ],
+      conversations: [
+        { peerJid: "bob@example.com", peerUsername: "Bob" },
+        { peerJid: "carol@example.com", peerUsername: "Carol" },
+      ],
+      activeChannelId: null,
+      activePeerJid: null,
+      sidebarMode: "dms",
+      activeChannelJids: new Set(),
+      managedMucDomain: "conference.example.com",
+      callParticipantCounts: {
+        "general@conference.example.com": 2,
+      },
+      dmCallActivities: {
+        "bob@example.com": {
+          peerJid: "bob@example.com",
+          sid: "live",
+          media: { audio: true, video: true },
+          state: "accepted",
+          direction: "incoming",
+          updatedAt: "2026-05-25T12:00:00.000Z",
+        },
+        "carol@example.com": {
+          peerJid: "carol@example.com",
+          sid: "ring",
+          media: { audio: true, video: false },
+          state: "ringing",
+          direction: "incoming",
+          updatedAt: "2026-05-25T11:00:00.000Z",
+        },
+      },
+    });
+
+    expect(entries.map(callActivityDockSelection)).toEqual([
+      {
+        kind: "channel",
+        channelId: "general",
+        roomJid: "general@conference.example.com",
+      },
+      {
+        kind: "dm-reconnect",
+        peerJid: "bob@example.com",
+        media: { audio: true, video: true },
+      },
+      {
+        kind: "dm-open",
+        peerJid: "carol@example.com",
+      },
+    ]);
   });
 
   test("surfaces group calls while the channel directory is still loading", () => {
@@ -277,6 +333,8 @@ describe("CallActivityDock rendering", () => {
     expect(html).toContain("2 people");
     expect(html).toContain("Live");
     expect(html).toContain("Open");
+    expect(html).toContain("Reconnect");
+    expect(html).toContain('aria-label="Reconnect Bob call, Live"');
     expect(html).not.toContain("Join");
   });
 
@@ -343,6 +401,7 @@ describe("CallActivityDock rendering", () => {
     expect(readyShell).toContain("class=\"call-activity-dock--mobile\"");
     expect(readyShell).toContain("@select-channel=\"onSelectChannelFromSidebar\"");
     expect(readyShell).toContain("@select-dm=\"selectDm\"");
+    expect(readyShell).toContain("@reconnect-dm=\"reconnectDmFromDock\"");
 
     expect(mobileDrawers).not.toContain("CallActivityDock");
   });
@@ -367,7 +426,45 @@ describe("CallActivityDock rendering", () => {
     expect(html).toContain("Reconnect voice call");
     expect(html).toContain("Reconnect video call");
   });
+
+  test("renders the group call header button when only ContentArea's room JID is known", async () => {
+    const withoutRoom = await renderVueComponent("../src/components/chat/ChatHeader.vue", {
+      ...chatHeaderBaseProps(),
+      channel: { id: "general", name: "General" },
+      callRoomJid: null,
+    });
+    const withRoom = await renderVueComponent("../src/components/chat/ChatHeader.vue", {
+      ...chatHeaderBaseProps(),
+      channel: { id: "general", name: "General" },
+      callRoomJid: "general@custom-muc.example.test",
+    });
+
+    expect(withoutRoom).not.toContain('data-vue-stub="true"');
+    expect(withRoom).toContain('data-vue-stub="true"');
+  });
 });
+
+function chatHeaderBaseProps(): Record<string, unknown> {
+  return {
+    waddle: { id: "team", name: "Team" },
+    channel: null,
+    dmPeer: null,
+    isForumChannel: false,
+    canManageChannels: false,
+    memberCount: 0,
+    memberState: "ready",
+    members: [],
+    connectionNotice: null,
+    connectionStatusClasses: null,
+    connectionStatusIcon: { name: "StatusIcon", render: () => null },
+    xmppClient: null,
+    notifySettings: {},
+    showSearch: false,
+    "onUpdate:showSearch": () => undefined,
+    showPinnedPanel: false,
+    "onUpdate:showPinnedPanel": () => undefined,
+  };
+}
 
 async function renderCallActivityDock(props: Record<string, unknown>) {
   return renderVueComponent("../src/components/calls/CallActivityDock.vue", props);

--- a/chat/tests/call-controls.test.ts
+++ b/chat/tests/call-controls.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { $callState, clearCallState } from "../src/lib/calls/call-store";
+import { suspendCallForPageHide } from "../src/lib/calls/call-controls";
+import {
+  $dmCallActivities,
+  clearDmCallActivities,
+} from "../src/lib/calls/dm-call-activity";
+import { connectionStore } from "../src/lib/connection-store";
+import type { LiveKitJoin } from "../src/lib/calls/types";
+
+const join: LiveKitJoin = {
+  url: "wss://livekit.test",
+  room: "alice@waddle.test::c1",
+  identity: "alice@waddle.test/web",
+  token: "jwt",
+};
+
+afterEach(() => {
+  clearCallState();
+  clearDmCallActivities();
+  connectionStore.client = null;
+});
+
+describe("call page lifecycle controls", () => {
+  test("pagehide suspension clears only local media state, preserving rediscoverable DM activity", () => {
+    $callState.set({
+      phase: "active",
+      peer: "bob@waddle.test/desktop",
+      sid: "c1",
+      media: { audio: true, video: true },
+      join,
+      kind: "dm",
+    });
+    $dmCallActivities.set({
+      "bob@waddle.test": {
+        peerJid: "bob@waddle.test",
+        sid: "c1",
+        media: { audio: true, video: true },
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: "2026-05-26T00:00:00.000Z",
+      },
+    });
+
+    suspendCallForPageHide();
+
+    expect($callState.get()).toEqual({ phase: "idle" });
+    expect($dmCallActivities.get()["bob@waddle.test"]).toMatchObject({
+      sid: "c1",
+      state: "accepted",
+    });
+  });
+
+  test("pagehide suspension does not emit XMPP call-ending stanzas", () => {
+    const sender = {
+      send_call_session_terminate: mock(async () => undefined),
+      send_call_finish: mock(async () => undefined),
+      update_muji_presence: mock(async () => undefined),
+      send_raw_iq: mock(async () => "<iq type='result'/>"),
+    };
+    connectionStore.client = {
+      xmpp: sender,
+    } as unknown as typeof connectionStore.client;
+    $callState.set({
+      phase: "active",
+      peer: "room@muc.waddle.test",
+      sid: "muc-1",
+      media: { audio: true, video: false },
+      join: { ...join, room: "room@muc.waddle.test" },
+      kind: "muc",
+      selfNick: "alice",
+      selfFullJid: "alice@waddle.test/web",
+    });
+
+    suspendCallForPageHide();
+
+    expect(sender.send_call_session_terminate).not.toHaveBeenCalled();
+    expect(sender.send_call_finish).not.toHaveBeenCalled();
+    expect(sender.update_muji_presence).not.toHaveBeenCalled();
+    expect(sender.send_raw_iq).not.toHaveBeenCalled();
+  });
+
+  test("CallOverlay wires the browser pagehide event to suspension, not hangup", () => {
+    const source = readFileSync(new URL("../src/components/calls/CallOverlay.vue", import.meta.url), "utf8");
+    const unmountBlock = source.slice(source.indexOf("onBeforeUnmount(() => {"));
+
+    expect(source).toContain('window.addEventListener("pagehide", handlePageHide)');
+    expect(source).toContain("suspendCallForPageHide();");
+    expect(unmountBlock).toContain("void engine.disconnect();");
+    expect(unmountBlock).not.toContain("tearDownActiveCall(");
+  });
+});

--- a/chat/tests/dm-call-actions.test.ts
+++ b/chat/tests/dm-call-actions.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  $callState,
+  clearCallState,
+} from "../src/lib/calls/call-store";
+import { startDmCallAction } from "../src/lib/calls/dm-call-actions";
+import {
+  clearDmCallActivities,
+  readDmCallActivity,
+} from "../src/lib/calls/dm-call-activity";
+import type { CallWireSender } from "../src/lib/calls/outbound";
+
+afterEach(() => {
+  clearCallState();
+  clearDmCallActivities();
+});
+
+describe("startDmCallAction", () => {
+  test("sends a fresh XEP-0353 propose and marks the peer as ringing", async () => {
+    const sender: CallWireSender = {
+      send_call_propose: mock(async () => undefined),
+    };
+
+    await startDmCallAction({
+      peerBareJid: "bob@waddle.test",
+      media: { audio: true, video: true },
+      getSender: () => sender,
+      getInitiator: () => "alice@waddle.test/web",
+    });
+
+    expect(sender.send_call_propose).toHaveBeenCalledTimes(1);
+    const [peerJid, sid, audio, video] = (sender.send_call_propose as {
+      mock: { calls: unknown[][] };
+    }).mock.calls[0] ?? [];
+    expect(peerJid).toBe("bob@waddle.test");
+    expect(typeof sid).toBe("string");
+    expect(String(sid)).toMatch(/^c/);
+    expect(audio).toBe(true);
+    expect(video).toBe(true);
+    expect($callState.get()).toMatchObject({
+      phase: "outgoing",
+      to: "bob@waddle.test",
+      sid,
+      initiator: "alice@waddle.test/web",
+    });
+    expect(readDmCallActivity("bob@waddle.test")).toMatchObject({
+      sid,
+      state: "ringing",
+      direction: "outgoing",
+    });
+  });
+
+  test("rolls back optimistic state when the propose fails", async () => {
+    const sender: CallWireSender = {
+      send_call_propose: mock(async () => {
+        throw new Error("wire down");
+      }),
+    };
+
+    await startDmCallAction({
+      peerBareJid: "bob@waddle.test",
+      media: { audio: true, video: false },
+      getSender: () => sender,
+    });
+
+    expect($callState.get()).toEqual({ phase: "idle" });
+    expect(readDmCallActivity("bob@waddle.test")).toBeNull();
+  });
+});

--- a/chat/tests/home-activity.test.ts
+++ b/chat/tests/home-activity.test.ts
@@ -328,6 +328,48 @@ describe("HomeDashboard activity rendering", () => {
     expect(buttonForLabel(html, "Empty, 0 channels, no unread activity")).not.toContain("opacity-75");
   });
 
+  test("renders refresh-discovered active calls on the home dashboard", async () => {
+    const html = await renderHomeDashboard({
+      spaces: [{ id: "team", name: "Team" }],
+      channels: [
+        { id: "general", name: "General", jid: "general@conference.example.com", spaceId: "team" },
+      ],
+      contacts: [],
+      isLoading: false,
+      channelUnreadMap: {},
+      activeChannelJids: new Set<string>(),
+      managedMucDomain: "conference.example.com",
+      callParticipantCounts: {
+        "general@conference.example.com": 2,
+      },
+      dmConversations: [
+        {
+          peerJid: "bob@example.com",
+          peerUsername: "Bob",
+          unreadCount: 0,
+          presenceShow: "available",
+        },
+      ],
+      dmCallActivities: {
+        "bob@example.com": {
+          peerJid: "bob@example.com",
+          sid: "dm-call-1",
+          media: { audio: true, video: true },
+          state: "accepted",
+          direction: "incoming",
+          updatedAt: "2026-05-26T00:00:00.000Z",
+        },
+      },
+    });
+
+    expect(html).toContain("Active calls");
+    expect(html).toContain("<strong>2</strong> active calls");
+    expect(html).toContain('aria-label="Open General, Group call, 2 people"');
+    expect(html).toContain('aria-label="Reconnect Bob, Video call, Live"');
+    expect(buttonForLabel(html, "General, channel, no unread activity, active call with 2 people")).toContain("Active call");
+    expect(buttonForLabel(html, "Bob (bob@example.com), direct message, available, no unread activity, Video call live")).toContain("Live");
+  });
+
   test("pluralizes single thread reply badges", async () => {
     const html = await renderHomeDashboard({
       spaces: [{ id: "team", name: "Team" }],
@@ -373,6 +415,18 @@ describe("HomeDashboard activity rendering", () => {
         unreadCount: 2,
         lastMessageBody: "Can you review the plan?",
       }],
+      callParticipantCounts: { "general@conference.example.com": 2 },
+      dmCallActivities: {
+        "bob@example.com": {
+          peerJid: "bob@example.com",
+          sid: "dm-call-1",
+          media: { audio: true, video: false },
+          state: "accepted",
+          direction: "incoming",
+          updatedAt: "2026-05-26T00:00:00.000Z",
+        },
+      },
+      managedMucDomain: "conference.example.com",
     });
 
     expect(props.channelUnreadMap?.general).toEqual({
@@ -384,6 +438,9 @@ describe("HomeDashboard activity rendering", () => {
     });
     expect(props.activeChannelJids?.has("general@conference.example.com")).toBe(true);
     expect(props.dmConversations?.[0]?.unreadCount).toBe(2);
+    expect(props.callParticipantCounts).toEqual({ "general@conference.example.com": 2 });
+    expect(props.dmCallActivities?.["bob@example.com"]?.state).toBe("accepted");
+    expect(props.managedMucDomain).toBe("conference.example.com");
   });
 });
 


### PR DESCRIPTION
## Plan

- Preserve active call discoverability when the browser tab refreshes.
- Keep explicit hangup/logout as the only paths that send call-ending XMPP stanzas.
- Make refresh-discovered group and 1:1 calls visible and reachable from the dock/home UI.
- Cover the refresh lifecycle, DM reconnect action, and id-only group call header behavior with tests.

## Completed

- Replaced the pagehide/unmount call teardown path with local media suspension so refresh does not send XEP-0166 terminate, XEP-0353 finish, or Muji presence clearing.
- Kept explicit hangup/logout on the existing teardown path.
- Added shared 1:1 call start/reconnect logic that sends a fresh XEP-0353 propose for accepted DM calls discovered after refresh.
- Threaded refreshed call activity into the activity dock and home dashboard, including reconnect/open labels and accessible row names.
- Passed ContentArea's room JID into the chat header so id-only channels can still show the group-call join button.

## Verification

- `bun test tests/call-controls.test.ts tests/dm-call-actions.test.ts tests/call-activity-dock.test.ts tests/home-activity.test.ts tests/dm-call-activity.test.ts tests/dm-call-activity-hydration.test.ts tests/call-store.test.ts tests/call-effects.test.ts tests/use-active-muc-call.test.ts tests/muc-call-indicators.test.ts`
- `bun test`
- `bun run lint`
- `bun run build`
- `git diff --check`

No dev server was started.