### PR TITLE
feat(chat): join active calls from activity surfaces

### DIFF
--- a/chat/src/components/calls/CallActivityDock.vue
+++ b/chat/src/components/calls/CallActivityDock.vue
@@ -6,8 +6,10 @@ import {
   $mucCallParticipants,
   mucCallParticipantCounts,
 } from "@/lib/calls/muc-call-presence";
+import { $callState } from "@/lib/calls/call-store";
 import { $dmCallActivities } from "@/lib/calls/dm-call-activity";
 import {
+  callActivityDockAction,
   buildCallActivityDockEntries,
   callActivityDockSelection,
   type CallActivityDockEntry,
@@ -30,11 +32,13 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   selectChannel: [channelId: string | null, roomJid: string];
+  joinChannelCall: [channelId: string | null, roomJid: string, media: CallMedia];
   selectDm: [peerJid: string];
   reconnectDm: [peerJid: string, media: CallMedia];
 }>();
 
 const mucCallParticipantsStore = useStore($mucCallParticipants);
+const callState = useStore($callState);
 const dmCallActivities = useStore($dmCallActivities);
 
 const callParticipantCounts = computed<Record<string, number>>(() => {
@@ -78,9 +82,16 @@ function entryMeta(entry: CallActivityDockEntry): string {
 }
 
 function entryAction(entry: CallActivityDockEntry): string {
-  if (entry.kind === "channel") return "Open";
-  if (callActivityDockSelection(entry).kind === "dm-reconnect") return "Reconnect";
-  return "Open";
+  switch (callActivityDockAction(entry, callState.value)) {
+    case "join":
+      return "Join";
+    case "return":
+      return "Return";
+    case "reconnect":
+      return "Reconnect";
+    case "open":
+      return "Open";
+  }
 }
 
 function entryTitle(entry: CallActivityDockEntry): string {
@@ -93,8 +104,11 @@ function entryCanSelect(entry: CallActivityDockEntry): boolean {
 
 function selectEntry(entry: CallActivityDockEntry): void {
   if (!entryCanSelect(entry)) return;
-  const selection = callActivityDockSelection(entry);
+  const selection = callActivityDockSelection(entry, callState.value);
   switch (selection.kind) {
+    case "channel-join":
+      emit("joinChannelCall", selection.channelId, selection.roomJid, selection.media);
+      return;
     case "channel":
       emit("selectChannel", selection.channelId, selection.roomJid);
       return;

--- a/chat/src/components/chat/ChatMobileDrawers.vue
+++ b/chat/src/components/chat/ChatMobileDrawers.vue
@@ -5,6 +5,7 @@ import {
   $mucCallParticipants,
   mucCallParticipantCounts,
 } from "@/lib/calls/muc-call-presence";
+import { $dmCallActivities } from "@/lib/calls/dm-call-activity";
 import { normalizeMucServiceDomain } from "@/lib/calls/muc-call-indicators";
 import WaddlesSidebar from "@/components/chat/WaddlesSidebar.vue";
 import TopicsPanel from "@/components/chat/TopicsPanel.vue";
@@ -13,11 +14,13 @@ import SettingsMobileHeader from "@/components/chat/SettingsMobileHeader.vue";
 import ProfilePanel from "@/components/chat/ProfilePanel.vue";
 import AppDrawer from "@/components/ui/AppDrawer.vue";
 import { extensionRouteIconComponent, extensionRouteRailItems } from "./extension-route-rail-model";
+import type { CallMedia } from "@/lib/calls/types";
 import type { DiscoveredExtensionRoute } from "@/lib/xmpp/extension-commands";
 import type { ChatAppController } from "@/shell/chat-app-controller";
 
 const props = defineProps<{
   controller: ChatAppController;
+  joinChannelCall?: (channelId: string | null, roomJid: string, media: CallMedia) => void;
 }>();
 
 const {
@@ -59,13 +62,27 @@ function selectCommunitySurface(surface: "feed" | "stories" | "events") {
   ui.showMobileNav.value = false;
 }
 
+function selectChannelFromMobile(id: string, roomJid?: string) {
+  ui.activeCommunitySurface.value = null;
+  void selectChannel(id, roomJid ? { roomJid } : undefined);
+}
+
+function joinChannelCallFromMobile(channelId: string | null, roomJid: string, media: CallMedia) {
+  props.joinChannelCall?.(channelId, roomJid, media);
+}
+
 // XEP-0272 Muji participant counts keyed by room JID — same derived
 // reactive state as ChatReadyShell uses, so the mobile sidebar shows
 // the same "call ongoing" chip.
 const mucCallParticipantsStore = useStore($mucCallParticipants);
+const dmCallActivitiesStore = useStore($dmCallActivities);
 const callParticipantCounts = computed<Record<string, number>>(() => {
   return mucCallParticipantCounts(mucCallParticipantsStore.value);
 });
+const activeChannelCallCount = computed(() =>
+  Object.values(callParticipantCounts.value).filter((count) => count > 0).length,
+);
+const activeDmCallCount = computed(() => Object.keys(dmCallActivitiesStore.value).length);
 const managedMucDomain = computed(() =>
   normalizeMucServiceDomain(waddles.mucServiceJid.value) || (selfDomain.value ? `muc.${selfDomain.value}` : ""),
 );
@@ -106,6 +123,8 @@ function openExtensionRoute(route: DiscoveredExtensionRoute) {
             :active-sidebar-mode="ui.sidebarMode.value"
             :active-page="ui.activePage.value"
             :has-unread-dms="dmConversations.hasUnread.value"
+            :active-channel-call-count="activeChannelCallCount"
+            :active-dm-call-count="activeDmCallCount"
             :session="null"
             horizontal
             @open-home="openHome"
@@ -135,7 +154,8 @@ function openExtensionRoute(route: DiscoveredExtensionRoute) {
           :upcoming-event-count="communityEvents.events.value.filter((e: { dtstartMs?: number }) => typeof e.dtstartMs === 'number' && e.dtstartMs > Date.now()).length"
           :is-threads-active="ui.activePage.value === 'threads'"
           class="!w-full !border-r-0 !flex-1"
-          @select-channel="(id: string) => { ui.activeCommunitySurface.value = null; selectChannel(id); }"
+          @select-channel="selectChannelFromMobile"
+          @join-channel-call="joinChannelCallFromMobile"
           @select-thread="onSelectThread"
           @select-community-surface="selectCommunitySurface"
           @select-threads-view="openThreads"

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -7,7 +7,12 @@ import {
 } from "@/lib/calls/muc-call-presence";
 import { $dmCallActivities } from "@/lib/calls/dm-call-activity";
 import { startDmCallAction } from "@/lib/calls/dm-call-actions";
+import { startMucCallAction } from "@/lib/calls/muc-call-actions";
 import { normalizeMucServiceDomain } from "@/lib/calls/muc-call-indicators";
+import {
+  $callState,
+  type RawIqSender,
+} from "@/lib/calls/call-store";
 import type { CallWireSender } from "@/lib/calls/outbound";
 import type { CallMedia } from "@/lib/calls/types";
 import HomeDashboard from "@/components/chat/HomeDashboard.vue";
@@ -30,6 +35,7 @@ import AdminView from "@/components/admin/AdminView.vue";
 import CallActivityDock from "@/components/calls/CallActivityDock.vue";
 import { navigate, useRouteMatch, type AdminMatch, type AdminPanel } from "@/router";
 import { buildHomeDashboardProps } from "@/home/dashboard-props";
+import { jidDomain } from "@/lib/xmpp/jid";
 import type { ChatAppController } from "@/shell/chat-app-controller";
 import type { DiscoveredExtensionRoute } from "@/lib/xmpp/extension-commands";
 import { installMessageToolbarLifecycleSuppression } from "@/stores/message-toolbar";
@@ -149,9 +155,14 @@ const {
  */
 const mucCallParticipantsStore = useStore($mucCallParticipants);
 const dmCallActivitiesStore = useStore($dmCallActivities);
+const activityGroupCallStarting = ref(false);
 const callParticipantCounts = computed<Record<string, number>>(() => {
   return mucCallParticipantCounts(mucCallParticipantsStore.value);
 });
+const activeChannelCallCount = computed(() =>
+  Object.values(callParticipantCounts.value).filter((count) => count > 0).length,
+);
+const activeDmCallCount = computed(() => Object.keys(dmCallActivitiesStore.value).length);
 const managedMucDomain = computed(() =>
   normalizeMucServiceDomain(waddles.mucServiceJid.value) || (selfDomain.value ? `muc.${selfDomain.value}` : ""),
 );
@@ -226,8 +237,30 @@ function getCallSender(): CallWireSender | null {
   return (client?.xmpp as CallWireSender | undefined) ?? null;
 }
 
+function getMucCallSender(): RawIqSender | null {
+  const client = connectionStore.client as unknown as { xmpp?: unknown } | null;
+  return (client?.xmpp as RawIqSender | undefined) ?? null;
+}
+
 function getSelfFullJid(): string | undefined {
   return (connectionStore.client as unknown as { fullJid?: string } | null)?.fullJid;
+}
+
+function getExpectedMixerJid(): string | undefined {
+  const accountJid = connectionStore.session?.jid;
+  return accountJid ? `calls.${jidDomain(accountJid)}` : undefined;
+}
+
+function getClientJoiner(): ((roomJid: string) => Promise<void>) | null {
+  const client = connectionStore.client as unknown as {
+    ensureJoined?: (roomJid: string) => Promise<void>;
+  } | null;
+  return client?.ensureJoined?.bind(client) ?? null;
+}
+
+function isGroupCallBusy(): boolean {
+  const current = $callState.get();
+  return activityGroupCallStarting.value || (current.phase !== "idle" && current.phase !== "ended");
 }
 
 function reconnectDmFromDock(peerJid: string, media: CallMedia): void {
@@ -237,6 +270,30 @@ function reconnectDmFromDock(peerJid: string, media: CallMedia): void {
     media,
     getSender: getCallSender,
     getInitiator: getSelfFullJid,
+  });
+}
+
+function joinChannelCallFromActivity(channelId: string | null, roomJid: string, media: CallMedia): void {
+  ui.activeCommunitySurface.value = null;
+  if (channelId) {
+    void selectChannel(channelId, { roomJid });
+  } else {
+    void selectChannelByRoomJid(roomJid);
+  }
+  void startMucCallAction({
+    roomJid,
+    media,
+    isBusy: isGroupCallBusy,
+    setStarting: (next) => {
+      activityGroupCallStarting.value = next;
+    },
+    getSender: getMucCallSender,
+    getSelfNick: () => connectionStore.session?.username ?? undefined,
+    getSelfFullJid,
+    getExpectedMixerJid,
+    ensureJoined: async () => {
+      await getClientJoiner()?.(roomJid);
+    },
   });
 }
 
@@ -277,7 +334,10 @@ onUnmounted(() => {
     @back="onAdminBack"
   />
   <div v-else class="chat-app-shell">
-    <ChatMobileDrawers :controller="controller" />
+    <ChatMobileDrawers
+      :controller="controller"
+      :join-channel-call="joinChannelCallFromActivity"
+    />
     <CallActivityDock
       class="call-activity-dock--mobile"
       :channels="waddles.sortedChannels.value"
@@ -289,6 +349,7 @@ onUnmounted(() => {
       :active-channel-jids="messaging.activeChannels.value"
       :managed-muc-domain="managedMucDomain"
       @select-channel="onSelectChannelFromSidebar"
+      @join-channel-call="joinChannelCallFromActivity"
       @select-dm="selectDm"
       @reconnect-dm="reconnectDmFromDock"
     />
@@ -303,6 +364,8 @@ onUnmounted(() => {
           :active-sidebar-mode="ui.sidebarMode.value"
           :active-page="ui.activePage.value"
           :has-unread-dms="dmConversations.hasUnread.value"
+          :active-channel-call-count="activeChannelCallCount"
+          :active-dm-call-count="activeDmCallCount"
           :session="connectionStore.session"
           :notification-permission="notifications.permissionState.value"
           :notifications-enabled="notifications.notificationsEnabled.value"
@@ -344,6 +407,7 @@ onUnmounted(() => {
           :upcoming-event-count="communityEvents.events.value.filter((e: { dtstartMs?: number }) => typeof e.dtstartMs === 'number' && e.dtstartMs > Date.now()).length"
           :is-threads-active="ui.activePage.value === 'threads'"
           @select-channel="onSelectChannelFromSidebar"
+          @join-channel-call="joinChannelCallFromActivity"
           @select-thread="onSelectThread"
           @select-community-surface="onSelectCommunitySurface"
           @select-threads-view="openThreads"
@@ -370,6 +434,7 @@ onUnmounted(() => {
           :active-channel-jids="messaging.activeChannels.value"
           :managed-muc-domain="managedMucDomain"
           @select-channel="onSelectChannelFromSidebar"
+          @join-channel-call="joinChannelCallFromActivity"
           @select-dm="selectDm"
           @reconnect-dm="reconnectDmFromDock"
         />
@@ -381,6 +446,7 @@ onUnmounted(() => {
         v-bind="homeDashboardProps"
         @select-channel="(id: string, roomJid?: string) => selectChannel(id, roomJid ? { roomJid } : undefined)"
         @select-channel-room="selectChannelByRoomJid"
+        @join-channel-call="joinChannelCallFromActivity"
         @select-contact="handleOpenDm"
         @reconnect-dm="reconnectDmFromDock"
         @open-nav="ui.showMobileNav.value = true"

--- a/chat/src/components/chat/HomeDashboard.vue
+++ b/chat/src/components/chat/HomeDashboard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref } from "vue";
+import { useStore } from "@nanostores/vue";
 import {
   ArrowRight,
   Hash,
@@ -18,10 +19,12 @@ import AppAvatar from "@/components/ui/AppAvatar.vue";
 import Skeleton from "@/components/ui/Skeleton.vue";
 import { isForumChannel } from "@/lib/channel-types";
 import {
+  callActivityDockAction,
   buildCallActivityDockEntries,
   callActivityDockSelection,
   type CallActivityDockEntry,
 } from "@/lib/calls/call-activity-dock";
+import { $callState } from "@/lib/calls/call-store";
 import { callParticipantCountForChannel } from "@/lib/calls/muc-call-indicators";
 import { barePeerJid } from "@/lib/xmpp/jid";
 import type { CallMedia } from "@/lib/calls/types";
@@ -47,6 +50,7 @@ const props = defineProps<HomeDashboardProps>();
 const emit = defineEmits<{
   selectChannel: [id: string, roomJid?: string];
   selectChannelRoom: [roomJid: string];
+  joinChannelCall: [channelId: string | null, roomJid: string, media: CallMedia];
   selectContact: [jid: string];
   reconnectDm: [peerJid: string, media: CallMedia];
   openNav: [];
@@ -111,6 +115,7 @@ const activeChannelJids = computed(() => props.activeChannelJids ?? new Set<stri
 const directMessages = computed(() => props.dmConversations ?? []);
 const callParticipantCounts = computed(() => props.callParticipantCounts ?? {});
 const dmCallActivities = computed(() => props.dmCallActivities ?? {});
+const callState = useStore($callState);
 const channelsBySpace = computed(() =>
   new Map(groups.value.flatMap((group) => group.space ? [[group.space.id, group.channels.length] as const] : [])),
 );
@@ -149,8 +154,11 @@ function selectSpaceChannel(spaceId: string) {
 }
 
 function selectCallEntry(entry: CallActivityDockEntry) {
-  const selection = callActivityDockSelection(entry);
+  const selection = callActivityDockSelection(entry, callState.value);
   switch (selection.kind) {
+    case "channel-join":
+      emit("joinChannelCall", selection.channelId, selection.roomJid, selection.media);
+      return;
     case "channel":
       if (selection.channelId) {
         emit("selectChannel", selection.channelId, selection.roomJid);
@@ -314,8 +322,21 @@ function callEntryKindLabel(entry: CallActivityDockEntry): string {
 }
 
 function callEntryLabel(entry: CallActivityDockEntry): string {
-  const action = callActivityDockSelection(entry).kind === "dm-reconnect" ? "Reconnect" : "Open";
+  const action = callEntryActionLabel(entry);
   return `${action} ${entry.title}, ${callEntryKindLabel(entry)}, ${callEntryStatus(entry)}`;
+}
+
+function callEntryActionLabel(entry: CallActivityDockEntry): string {
+  switch (callActivityDockAction(entry, callState.value)) {
+    case "join":
+      return "Join";
+    case "return":
+      return "Return";
+    case "reconnect":
+      return "Reconnect";
+    case "open":
+      return "Open";
+  }
 }
 
 const heroSummary = computed<HeroSummary>(() => {
@@ -490,6 +511,12 @@ function onHeroCta() {
               aria-hidden="true"
             >
               {{ entry.participantCount }}
+            </span>
+            <span
+              class="type-meta shrink-0 rounded-md border border-success/25 bg-background/70 px-2 py-1 text-success"
+              aria-hidden="true"
+            >
+              {{ callEntryActionLabel(entry) }}
             </span>
             <ArrowRight class="h-4 w-4 shrink-0 text-success" aria-hidden="true" />
           </button>

--- a/chat/src/components/chat/TopicsPanel.vue
+++ b/chat/src/components/chat/TopicsPanel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, watch } from "vue";
+import { useStore } from "@nanostores/vue";
 import { CalendarDays, Camera, Hash, ListTree, MessageSquareText, MessagesSquare, Phone, Plus, Settings, Users, ChevronDown, ChevronRight, MessageCircle } from "lucide-vue-next";
 import { isForumChannel as detectForumChannel } from "@/lib/channel-types";
 import type { ChannelSummary, SpaceSummary } from "@/lib/chat-types";
@@ -7,8 +8,12 @@ import type { ChannelThreadInboxEntry } from "@/channels/inbox";
 import { groupChannelsBySpace } from "@/lib/channel-grouping";
 import {
   callParticipantCountForChannel,
+  candidateRoomJidsForChannel,
   collapsedGroupBadgeModel,
 } from "@/lib/calls/muc-call-indicators";
+import { normalizeMucCallRoomJid } from "@/lib/calls/muc-call-presence";
+import { $callState } from "@/lib/calls/call-store";
+import type { CallMedia } from "@/lib/calls/types";
 import type { MemberLoadState } from "@/waddles/directory";
 import Skeleton from "@/components/ui/Skeleton.vue";
 
@@ -52,6 +57,8 @@ const props = defineProps<{
   managedMucDomain?: string | null;
 }>();
 
+const callState = useStore($callState);
+
 /**
  * Resolve the channel's MUC room JID and look up the live-call
  * count for it. Channel rows in the sidebar may store the JID
@@ -66,6 +73,51 @@ function callParticipantCount(channel: ChannelSummary): number {
     props.activeChannelJids,
     props.managedMucDomain,
   );
+}
+
+function callRoomJid(channel: ChannelSummary): string {
+  if (!props.callParticipantCounts) return "";
+  return candidateRoomJidsForChannel(channel, props.activeChannelJids, props.managedMucDomain)
+    .map(normalizeMucCallRoomJid)
+    .find((jid) => (props.callParticipantCounts?.[jid] ?? 0) > 0) ?? "";
+}
+
+function channelCallAction(channel: ChannelSummary): "join" | "return" | "open" | null {
+  if (callParticipantCount(channel) <= 0) return null;
+  const roomJid = callRoomJid(channel);
+  if (!roomJid) return null;
+  const state = callState.value;
+  if (
+    (state.phase === "active" || state.phase === "muc-pending") &&
+    state.kind === "muc" &&
+    normalizeMucCallRoomJid(state.peer) === roomJid
+  ) {
+    return "return";
+  }
+  if (state.phase !== "idle" && state.phase !== "ended") return "open";
+  return "join";
+}
+
+function channelCallActionLabel(channel: ChannelSummary): string {
+  switch (channelCallAction(channel)) {
+    case "join":
+      return "Join";
+    case "return":
+      return "Return";
+    case "open":
+      return "Open";
+    default:
+      return "";
+  }
+}
+
+function channelCallBadgeLabel(channel: ChannelSummary): string {
+  const count = callParticipantCount(channel);
+  const noun = count === 1 ? "person" : "people";
+  const action = channelCallActionLabel(channel);
+  return action
+    ? `${action} live call, ${count} ${noun}`
+    : `Live call, ${count} ${noun}`;
 }
 
 function hasActivity(channelId: string): boolean {
@@ -141,12 +193,17 @@ function channelRowLabel(
   unread: { unread: number; mentions: number },
   isActive: boolean,
 ) {
-  return `${channel.name}, ${isActive ? "selected" : "not selected"}, ${activityLabel({
+  const label = `${channel.name}, ${isActive ? "selected" : "not selected"}, ${activityLabel({
     unread: unread.unread,
     mentions: unread.mentions,
     hasActivity: hasActivity(channel.id),
     callCount: callParticipantCount(channel),
   })}`;
+  const action = !isActive ? channelCallAction(channel) : null;
+  if (action === "join") return `${label}, click to join call`;
+  if (action === "return") return `${label}, click to return to call`;
+  if (action === "open") return `${label}, click to open call`;
+  return label;
 }
 
 function threadRowLabel(thread: ChannelThreadInboxEntry) {
@@ -182,7 +239,8 @@ function truncateTitle(title: string | undefined, maxLen = 28): string {
 }
 
 const emit = defineEmits<{
-  selectChannel: [id: string];
+  selectChannel: [id: string, roomJid?: string];
+  joinChannelCall: [channelId: string | null, roomJid: string, media: CallMedia];
   selectThread: [channelId: string, threadId: string];
   selectCommunitySurface: [surface: "feed" | "stories" | "events"];
   selectThreadsView: [];
@@ -192,6 +250,15 @@ const emit = defineEmits<{
   openMembers: [];
   updateCollapsedGroupIds: [groupIds: Set<string>];
 }>();
+
+function selectChannelRow(channel: ChannelSummary): void {
+  const roomJid = callRoomJid(channel);
+  if (!isActiveChannelPage(channel) && channelCallAction(channel) === "join" && roomJid) {
+    emit("joinChannelCall", channel.id, roomJid, { audio: true, video: false });
+    return;
+  }
+  emit("selectChannel", channel.id, roomJid || undefined);
+}
 
 function isGroupCollapsed(groupId: string): boolean {
   return props.collapsedGroupIds.has(groupId);
@@ -454,7 +521,7 @@ watch(
                 :aria-current="isActiveChannelPage(channel) ? 'page' : undefined"
                 :aria-label="channelRowLabel(channel, unread, isActiveChannelPage(channel))"
                 type="button"
-                @click="emit('selectChannel', channel.id)"
+                @click="selectChannelRow(channel)"
               >
                 <component
                   :is="channelIcon(channel)"
@@ -489,10 +556,17 @@ watch(
                 <span
                   v-if="callParticipantCount(channel) > 0 && !isActiveChannelPage(channel)"
                   class="chat-badge-glow--primary type-count-badge inline-flex items-center gap-0.5 h-[18px] px-1.5 rounded-full bg-primary/15 text-primary ring-1 ring-primary/30 motion-safe:animate-pulse"
+                  :title="channelCallBadgeLabel(channel)"
                   aria-hidden="true"
                 >
                   <Phone class="w-3 h-3" />
                   <span class="type-numeric leading-none">{{ callParticipantCount(channel) }}</span>
+                  <span
+                    v-if="channelCallActionLabel(channel)"
+                    class="hidden 2xl:inline leading-none"
+                  >
+                    · {{ channelCallActionLabel(channel) }}
+                  </span>
                 </span>
                 <span
                   v-if="unread.mentions > 0 && !isActiveChannelPage(channel)"

--- a/chat/src/components/chat/WaddlesSidebar.vue
+++ b/chat/src/components/chat/WaddlesSidebar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Layers, MessageCircle } from "lucide-vue-next";
+import { Layers, MessageCircle, PhoneCall } from "lucide-vue-next";
 import type { SpaceSummary } from "@/lib/chat-types";
 import type { WaddleSession } from "@/lib/server-auth";
 import type { XmppServerVersion } from "@/shell/version";
@@ -15,6 +15,8 @@ defineProps<{
   notificationsEnabled?: boolean;
   totalUnreadCount?: number;
   totalMentionCount?: number;
+  activeChannelCallCount?: number;
+  activeDmCallCount?: number;
   horizontal?: boolean;
   webCommitSha?: string;
   serverVersion?: XmppServerVersion | null;
@@ -32,6 +34,25 @@ const emit = defineEmits<{
   "request-notifications": [];
   "toggle-notifications": [];
 }>();
+
+function activeCallLabel(count: number | undefined, noun = "call"): string {
+  const value = count ?? 0;
+  if (value <= 0) return "";
+  return `${value} active ${noun}${value === 1 ? "" : "s"}`;
+}
+
+function spacesLabel(activeCallCount?: number): string {
+  const call = activeCallLabel(activeCallCount);
+  return call ? `Spaces, ${call}` : "Spaces";
+}
+
+function directMessagesLabel(hasUnread?: boolean, activeCallCount?: number): string {
+  const parts = ["Direct messages"];
+  if (hasUnread) parts.push("unread messages");
+  const call = activeCallLabel(activeCallCount);
+  if (call) parts.push(call);
+  return parts.join(", ");
+}
 </script>
 
 <template>
@@ -88,21 +109,29 @@ const emit = defineEmits<{
         :class="activeSidebarMode === 'channels'
           ? 'bg-rail-hover text-primary ring-1 ring-primary/40 shadow-[0_0_10px_var(--glow)]'
           : 'text-rail-foreground hover:bg-rail-hover hover:text-primary'"
-        title="Spaces"
-        aria-label="Spaces"
+        :title="spacesLabel(activeChannelCallCount)"
+        :aria-label="spacesLabel(activeChannelCallCount)"
         :aria-pressed="activeSidebarMode === 'channels'"
         type="button"
         @click="emit('toggleChannels')"
       >
         <Layers class="w-4 h-4" />
+        <span
+          v-if="(activeChannelCallCount ?? 0) > 0"
+          class="absolute -bottom-0.5 -right-0.5 flex h-4 w-4 items-center justify-center rounded-full border border-rail bg-background text-success shadow-[0_0_8px_var(--success)]"
+          :title="activeCallLabel(activeChannelCallCount)"
+          aria-hidden="true"
+        >
+          <PhoneCall class="h-2.5 w-2.5" />
+        </span>
       </button>
       <button
         class="relative w-10 h-10 flex items-center justify-center rounded-lg transition-all duration-200 hover:scale-105"
         :class="activeSidebarMode === 'dms'
           ? 'bg-rail-hover text-primary ring-1 ring-primary/40 shadow-[0_0_10px_var(--glow)]'
           : 'text-rail-foreground hover:bg-rail-hover hover:text-primary'"
-        title="Direct messages"
-        aria-label="Direct messages"
+        :title="directMessagesLabel(hasUnreadDms, activeDmCallCount)"
+        :aria-label="directMessagesLabel(hasUnreadDms, activeDmCallCount)"
         :aria-pressed="activeSidebarMode === 'dms'"
         type="button"
         @click="emit('toggleDms')"
@@ -112,6 +141,14 @@ const emit = defineEmits<{
           v-if="hasUnreadDms"
           class="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-primary shadow-[0_0_6px_var(--glow-strong)]"
         />
+        <span
+          v-if="(activeDmCallCount ?? 0) > 0"
+          class="absolute -bottom-0.5 -right-0.5 flex h-4 w-4 items-center justify-center rounded-full border border-rail bg-background text-success shadow-[0_0_8px_var(--success)]"
+          :title="activeCallLabel(activeDmCallCount)"
+          aria-hidden="true"
+        >
+          <PhoneCall class="h-2.5 w-2.5" />
+        </span>
       </button>
     </div>
 

--- a/chat/src/lib/calls/call-activity-dock.ts
+++ b/chat/src/lib/calls/call-activity-dock.ts
@@ -1,6 +1,7 @@
 import type { ChannelSummary } from "@/lib/chat-types";
 import type { DmConversation } from "@/lib/xmpp/types";
 import { barePeerJid } from "@/lib/xmpp/jid";
+import type { CallMedia, CallState } from "./types";
 import {
   callParticipantCountForChannel,
   candidateRoomJidsForChannel,
@@ -35,15 +36,51 @@ export type CallActivityDockEntry =
   };
 type DmCallActivityDockEntry = Extract<CallActivityDockEntry, { kind: "dm" }>;
 
+type CallActivityDockAction = "open" | "join" | "return" | "reconnect";
+
 type CallActivityDockSelection =
   | { kind: "channel"; channelId: string | null; roomJid: string }
+  | { kind: "channel-join"; channelId: string | null; roomJid: string; media: CallMedia }
   | { kind: "dm-open"; peerJid: string }
   | { kind: "dm-reconnect"; peerJid: string; media: DmCallActivity["media"] };
 
+function activeMucCallRoomJid(state: CallState): string {
+  if (state.phase !== "active" && state.phase !== "muc-pending") return "";
+  if (state.kind !== "muc") return "";
+  return normalizeMucCallRoomJid(state.peer);
+}
+
+function isBusy(state: CallState): boolean {
+  return state.phase !== "idle" && state.phase !== "ended";
+}
+
+export function callActivityDockAction(
+  entry: CallActivityDockEntry,
+  callState: CallState,
+): CallActivityDockAction {
+  if (entry.kind === "dm") {
+    return entry.state === "accepted" ? "reconnect" : "open";
+  }
+
+  const roomJid = normalizeMucCallRoomJid(entry.roomJid);
+  if (!roomJid) return "open";
+  if (activeMucCallRoomJid(callState) === roomJid) return "return";
+  return isBusy(callState) ? "open" : "join";
+}
+
 export function callActivityDockSelection(
   entry: CallActivityDockEntry,
+  callState: CallState = { phase: "idle" },
 ): CallActivityDockSelection {
   if (entry.kind === "channel") {
+    if (callActivityDockAction(entry, callState) === "join") {
+      return {
+        kind: "channel-join",
+        channelId: entry.channelId,
+        roomJid: entry.roomJid,
+        media: { audio: true, video: false },
+      };
+    }
     return {
       kind: "channel",
       channelId: entry.channelId,

--- a/chat/tests/call-activity-dock.test.ts
+++ b/chat/tests/call-activity-dock.test.ts
@@ -9,13 +9,20 @@ import { renderToString } from "vue/server-renderer";
 import ts from "typescript";
 import {
   buildCallActivityDockEntries,
+  callActivityDockAction,
   callActivityDockSelection,
 } from "../src/lib/calls/call-activity-dock";
+import {
+  $callState,
+  clearCallState,
+} from "../src/lib/calls/call-store";
 import { clearMucCallParticipants, $mucCallParticipants } from "../src/lib/calls/muc-call-presence";
 import { clearDmCallActivities, $dmCallActivities } from "../src/lib/calls/dm-call-activity";
 import type { DmCallActivity } from "../src/lib/calls/dm-call-activity";
+import type { CallState } from "../src/lib/calls/types";
 
 afterEach(() => {
+  clearCallState();
   clearMucCallParticipants();
   clearDmCallActivities();
 });
@@ -114,7 +121,7 @@ describe("call activity dock model", () => {
     });
   });
 
-  test("maps accepted DM rows to reconnect instead of plain navigation", () => {
+  test("maps active rows to direct join, return, or reconnect actions", () => {
     const entries = buildCallActivityDockEntries({
       channels: [
         { id: "general", name: "General", jid: "general@conference.example.com" },
@@ -151,11 +158,12 @@ describe("call activity dock model", () => {
       },
     });
 
-    expect(entries.map(callActivityDockSelection)).toEqual([
+    expect(entries.map((entry) => callActivityDockSelection(entry))).toEqual([
       {
-        kind: "channel",
+        kind: "channel-join",
         channelId: "general",
         roomJid: "general@conference.example.com",
+        media: { audio: true, video: false },
       },
       {
         kind: "dm-reconnect",
@@ -167,6 +175,33 @@ describe("call activity dock model", () => {
         peerJid: "carol@example.com",
       },
     ]);
+    expect(callActivityDockAction(entries[0], {
+      phase: "active",
+      kind: "muc",
+      peer: "general@conference.example.com",
+      sid: "muc-call",
+      media: { audio: true, video: false },
+      join: { url: "wss://livekit.example.test", room: "general", identity: "alice", token: "token" },
+    })).toBe("return");
+    expect(callActivityDockAction(entries[0], {
+      phase: "muc-pending",
+      kind: "muc",
+      peer: "general@conference.example.com",
+      sid: "muc-call",
+      media: { audio: true, video: false },
+      selfNick: "alice",
+      attemptId: "attempt-1",
+    })).toBe("return");
+    expect(callActivityDockSelection(entries[0], {
+      phase: "outgoing",
+      to: "bob@example.com",
+      sid: "dm-call",
+      media: { audio: true, video: false },
+    })).toEqual({
+      kind: "channel",
+      channelId: "general",
+      roomJid: "general@conference.example.com",
+    });
   });
 
   test("surfaces group calls while the channel directory is still loading", () => {
@@ -332,10 +367,10 @@ describe("CallActivityDock rendering", () => {
     expect(html).toContain("Video call");
     expect(html).toContain("2 people");
     expect(html).toContain("Live");
-    expect(html).toContain("Open");
+    expect(html).toContain("Join");
     expect(html).toContain("Reconnect");
+    expect(html).toContain('aria-label="Join General call, 2 people"');
     expect(html).toContain('aria-label="Reconnect Bob call, Live"');
-    expect(html).not.toContain("Join");
   });
 
   test("renders active group calls before channel metadata hydrates", async () => {
@@ -357,8 +392,8 @@ describe("CallActivityDock rendering", () => {
     expect(html).toContain("general");
     expect(html).toContain("Group call · syncing");
     expect(html).toContain("2 people");
-    expect(html).toContain("Open");
-    expect(html).toContain("aria-label=\"Open general call, 2 people\"");
+    expect(html).toContain("Join");
+    expect(html).toContain("aria-label=\"Join general call, 2 people\"");
     expect(html).not.toContain("disabled");
   });
 
@@ -399,11 +434,226 @@ describe("CallActivityDock rendering", () => {
     expect(readyShell).toContain("import CallActivityDock");
     expect(readyShell.match(/<CallActivityDock/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
     expect(readyShell).toContain("class=\"call-activity-dock--mobile\"");
+    expect(readyShell).toContain(":join-channel-call=\"joinChannelCallFromActivity\"");
+    expect(readyShell).toContain(":active-channel-call-count=\"activeChannelCallCount\"");
+    expect(readyShell).toContain(":active-dm-call-count=\"activeDmCallCount\"");
     expect(readyShell).toContain("@select-channel=\"onSelectChannelFromSidebar\"");
+    expect(readyShell).toContain("@join-channel-call=\"joinChannelCallFromActivity\"");
     expect(readyShell).toContain("@select-dm=\"selectDm\"");
     expect(readyShell).toContain("@reconnect-dm=\"reconnectDmFromDock\"");
 
     expect(mobileDrawers).not.toContain("CallActivityDock");
+    expect(mobileDrawers).toContain("@join-channel-call=\"joinChannelCallFromMobile\"");
+    expect(mobileDrawers).toContain(":active-channel-call-count=\"activeChannelCallCount\"");
+    expect(mobileDrawers).toContain(":active-dm-call-count=\"activeDmCallCount\"");
+  });
+
+  test("renders rail-level active call indicators for spaces and DMs", async () => {
+    const html = await renderVueComponent("../src/components/chat/WaddlesSidebar.vue", {
+      waddles: [],
+      activeSpaceId: null,
+      activeSidebarMode: "channels",
+      activePage: "chat",
+      hasUnreadDms: true,
+      activeChannelCallCount: 2,
+      activeDmCallCount: 1,
+      session: null,
+    });
+
+    expect(html).toContain('aria-label="Spaces, 2 active calls"');
+    expect(html).toContain('title="Spaces, 2 active calls"');
+    expect(html).toContain('aria-label="Direct messages, unread messages, 1 active call"');
+    expect(html).toContain('title="Direct messages, unread messages, 1 active call"');
+    expect(html).toContain('title="2 active calls"');
+    expect(html).toContain('title="1 active call"');
+  });
+
+  test("renders sidebar channel rows as direct join affordances when idle", async () => {
+    const html = await renderVueComponent("../src/components/chat/TopicsPanel.vue", {
+      ...topicsPanelBaseProps(),
+      channels: [
+        { id: "general", name: "General", jid: "general@conference.example.com" },
+      ],
+      callParticipantCounts: {
+        "general@conference.example.com": 2,
+      },
+      managedMucDomain: "conference.example.com",
+    });
+
+    expect(html).toContain("Join live call, 2 people");
+    expect(html).toContain("General, not selected, call ongoing with 2 participants, click to join call");
+  });
+
+  test("keeps sidebar channel call rows navigation-only while another call is active", async () => {
+    $callState.set({
+      phase: "outgoing",
+      to: "bob@example.com",
+      sid: "dm-call",
+      media: { audio: true, video: false },
+    });
+
+    const html = await renderVueComponent("../src/components/chat/TopicsPanel.vue", {
+      ...topicsPanelBaseProps(),
+      channels: [
+        { id: "general", name: "General", jid: "general@conference.example.com" },
+      ],
+      callParticipantCounts: {
+        "general@conference.example.com": 2,
+      },
+      managedMucDomain: "conference.example.com",
+    });
+
+    expect(html).toContain("Open live call, 2 people");
+    expect(html).toContain("General, not selected, call ongoing with 2 participants, click to open call");
+    expect(html).not.toContain("click to join call");
+  });
+
+  test("renders sidebar channel rows as return affordances while the same room is joining", async () => {
+    $callState.set({
+      phase: "muc-pending",
+      kind: "muc",
+      peer: "general@conference.example.com",
+      sid: "muc-call",
+      media: { audio: true, video: false },
+      selfNick: "alice",
+      attemptId: "attempt-1",
+    });
+
+    const html = await renderVueComponent("../src/components/chat/TopicsPanel.vue", {
+      ...topicsPanelBaseProps(),
+      channels: [
+        { id: "general", name: "General", jid: "general@conference.example.com" },
+      ],
+      callParticipantCounts: {
+        "general@conference.example.com": 2,
+      },
+      managedMucDomain: "conference.example.com",
+    });
+
+    expect(html).toContain("Return live call, 2 people");
+    expect(html).toContain("General, not selected, call ongoing with 2 participants, click to return to call");
+  });
+
+  test("activates sidebar channel rows through the join, open, and return event paths", async () => {
+    expect(await emittedTopicChannelRowEvents()).toEqual([
+      ["joinChannelCall", "general", "general@conference.example.com", { audio: true, video: false }],
+    ]);
+
+    expect(await emittedTopicChannelRowEvents({
+      phase: "outgoing",
+      to: "bob@example.com",
+      sid: "dm-call",
+      media: { audio: true, video: false },
+    })).toEqual([
+      ["selectChannel", "general", "general@conference.example.com"],
+    ]);
+
+    expect(await emittedTopicChannelRowEvents({
+      phase: "muc-pending",
+      kind: "muc",
+      peer: "general@conference.example.com",
+      sid: "muc-call",
+      media: { audio: true, video: false },
+      selfNick: "alice",
+      attemptId: "attempt-1",
+    })).toEqual([
+      ["selectChannel", "general", "general@conference.example.com"],
+    ]);
+  });
+
+  test("mobile drawer forwards sidebar join-call events to the shell handler", async () => {
+    const forwarded: unknown[][] = [];
+    const bindings = await setupVueComponent("../src/components/chat/ChatMobileDrawers.vue", {
+      controller: {},
+      joinChannelCall: (...args: unknown[]) => {
+        forwarded.push(args);
+      },
+    });
+
+    setupBindingFunction(bindings, "joinChannelCallFromMobile")(
+      "general",
+      "general@conference.example.com",
+      { audio: true, video: false },
+    );
+
+    expect(forwarded).toEqual([
+      ["general", "general@conference.example.com", { audio: true, video: false }],
+    ]);
+  });
+
+  test("mobile drawer preserves room JID when channel call rows open or return", async () => {
+    const selected: unknown[][] = [];
+    const ui = {
+      activeCommunitySurface: { value: "stories" },
+    };
+    const bindings = await setupVueComponent("../src/components/chat/ChatMobileDrawers.vue", {
+      controller: {
+        ui,
+        selectChannel: (...args: unknown[]) => {
+          selected.push(args);
+        },
+      },
+    });
+
+    setupBindingFunction(bindings, "selectChannelFromMobile")(
+      "general",
+      "general@conference.example.com",
+    );
+
+    expect(ui.activeCommunitySurface.value).toBe(null);
+    expect(selected).toEqual([
+      ["general", { roomJid: "general@conference.example.com" }],
+    ]);
+  });
+
+  test("shell join-call handler clears community surfaces before selecting a channel", async () => {
+    const selected: unknown[][] = [];
+    const ui = {
+      activeCommunitySurface: { value: "feed" },
+    };
+    const bindings = await suppressVueLifecycleSetupWarnings(() =>
+      setupVueComponent("../src/components/chat/ChatReadyShell.vue", {
+        controller: {
+          ui,
+          connectionStore: { client: null, session: null },
+          waddles: { mucServiceJid: { value: "" } },
+          selfDomain: { value: "" },
+          rosterContacts: {
+            contacts: { value: [] },
+            isLoadingContacts: { value: false },
+          },
+          messaging: {
+            mentionedChannelCounts: { value: {} },
+            activeChannels: { value: new Set<string>() },
+          },
+          dmConversations: { conversations: { value: [] } },
+          computedChannelUnreadMap: { value: {} },
+          activeRightPanel: { value: null },
+          activeThreadStack: { value: [] },
+          communityEvents: { rsvp: () => undefined },
+          closePinnedPanel: () => undefined,
+          activateRightPanel: () => undefined,
+          selectDm: () => undefined,
+          selectChannel: (...args: unknown[]) => {
+            selected.push(args);
+          },
+          selectChannelByRoomJid: (...args: unknown[]) => {
+            selected.push(["room", ...args]);
+          },
+        },
+      }),
+    );
+
+    setupBindingFunction(bindings, "joinChannelCallFromActivity")(
+      "general",
+      "general@conference.example.com",
+      { audio: true, video: false },
+    );
+
+    expect(ui.activeCommunitySurface.value).toBe(null);
+    expect(selected).toEqual([
+      ["general", { roomJid: "general@conference.example.com" }],
+    ]);
   });
 
   test("renders hydrated DM call controls with reconnect context", async () => {
@@ -466,6 +716,42 @@ function chatHeaderBaseProps(): Record<string, unknown> {
   };
 }
 
+function topicsPanelBaseProps(): Record<string, unknown> {
+  return {
+    waddle: null,
+    spaces: [],
+    channels: [],
+    activeChannelId: null,
+    canManageChannels: false,
+    canManageCommunity: false,
+    isLoading: false,
+    memberCount: 0,
+    memberState: "ready",
+    activeChannelJids: new Set<string>(),
+    collapsedGroupIds: new Set<string>(),
+  };
+}
+
+async function emittedTopicChannelRowEvents(callState?: CallState): Promise<unknown[][]> {
+  clearCallState();
+  if (callState) $callState.set(callState);
+  const emitted: unknown[][] = [];
+  const channel = { id: "general", name: "General", jid: "general@conference.example.com" };
+  const bindings = await setupVueComponent("../src/components/chat/TopicsPanel.vue", {
+    ...topicsPanelBaseProps(),
+    channels: [channel],
+    callParticipantCounts: {
+      "general@conference.example.com": 2,
+    },
+    managedMucDomain: "conference.example.com",
+  }, (...args) => {
+    emitted.push(args);
+  });
+
+  setupBindingFunction(bindings, "selectChannelRow")(channel);
+  return emitted;
+}
+
 async function renderCallActivityDock(props: Record<string, unknown>) {
   return renderVueComponent("../src/components/calls/CallActivityDock.vue", props);
 }
@@ -475,11 +761,69 @@ async function renderVueComponent(path: string, props: Record<string, unknown>) 
   return renderToString(createSSRApp({ render: () => h(component, props) }));
 }
 
-async function loadVueComponent(path: string) {
+async function setupVueComponent(
+  path: string,
+  props: Record<string, unknown>,
+  emit: (...args: unknown[]) => void = () => undefined,
+): Promise<Record<string, unknown>> {
+  const component = await loadVueComponent(path, { inlineTemplate: false }) as {
+    setup?: (
+      props: Record<string, unknown>,
+      context: {
+        emit: (...args: unknown[]) => void;
+        expose: () => void;
+        attrs: Record<string, unknown>;
+        slots: Record<string, unknown>;
+      },
+    ) => Record<string, unknown>;
+  };
+  if (!component.setup) throw new Error(`${path} has no setup function`);
+  return component.setup(props, {
+    emit,
+    expose: () => undefined,
+    attrs: {},
+    slots: {},
+  });
+}
+
+function setupBindingFunction(
+  bindings: Record<string, unknown>,
+  key: string,
+): (...args: unknown[]) => unknown {
+  const binding = bindings[key];
+  if (typeof binding !== "function") {
+    throw new Error(`Expected setup binding ${key} to be a function`);
+  }
+  return binding as (...args: unknown[]) => unknown;
+}
+
+async function suppressVueLifecycleSetupWarnings<T>(fn: () => Promise<T>): Promise<T> {
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    const message = String(args[0] ?? "");
+    if (
+      message.includes("onMounted is called when there is no active component instance") ||
+      message.includes("onUnmounted is called when there is no active component instance")
+    ) {
+      return;
+    }
+    originalWarn(...args);
+  };
+  try {
+    return await fn();
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
+async function loadVueComponent(path: string, options: { inlineTemplate?: boolean } = {}) {
   const filename = new URL(path, import.meta.url);
   const source = readFileSync(filename, "utf8");
   const { descriptor } = parse(source, { filename: filename.pathname });
-  const script = compileScript(descriptor, { id: filename.pathname, inlineTemplate: true });
+  const script = compileScript(descriptor, {
+    id: filename.pathname,
+    inlineTemplate: options.inlineTemplate ?? true,
+  });
 
   const tempDir = mkdtempSync(join(tmpdir(), "waddle-vue-component-"));
   try {

--- a/chat/tests/home-activity.test.ts
+++ b/chat/tests/home-activity.test.ts
@@ -364,8 +364,9 @@ describe("HomeDashboard activity rendering", () => {
 
     expect(html).toContain("Active calls");
     expect(html).toContain("<strong>2</strong> active calls");
-    expect(html).toContain('aria-label="Open General, Group call, 2 people"');
+    expect(html).toContain('aria-label="Join General, Group call, 2 people"');
     expect(html).toContain('aria-label="Reconnect Bob, Video call, Live"');
+    expect(buttonForLabel(html, "Join General, Group call, 2 people")).toContain("Join");
     expect(buttonForLabel(html, "General, channel, no unread activity, active call with 2 people")).toContain("Active call");
     expect(buttonForLabel(html, "Bob (bob@example.com), direct message, available, no unread activity, Video call live")).toContain("Live");
   });


### PR DESCRIPTION
## Plan

- Make refresh-discovered group calls directly joinable from global activity surfaces.
- Reuse the existing XMPP Muji/Jingle + LiveKit group-call action path.
- Preserve busy-call safeguards and keep navigation-only behavior when joining would be unsafe.
- Carry the same active-call affordance into desktop and mobile channel lists.
- Add rail-level live-call indicators so group and DM calls remain visible before opening the matching sidebar.
- Cover dock, home, sidebar, mobile drawer, rail badges, and pending-join labels in focused tests.

## Current implementation

- Active group call entries now choose an action from current call state: `Join`, `Return`, or `Open`.
- The activity dock and home dashboard emit a direct group-call join action for refresh-discovered calls when the local client is idle.
- Sidebar channel rows now show the live call action and directly join idle refresh-discovered calls; busy or current-call rows navigate/open instead of starting another call.
- The app rail now shows live-call indicators on Spaces and Direct messages so refreshed group/1:1 calls remain visible before the matching sidebar is open.
- Mobile drawers forward the same sidebar join event, preserve the room JID for Open/Return navigation, and mirror the rail live-call badges.
- `muc-pending` for the same room is treated as `Return`, fixing the review gap where the UI briefly labelled the current joining room as `Open`.
- `ChatReadyShell` clears community surfaces before routing channel-call joins through `startMucCallAction`, including room join, mixer JID, self nick/full JID, and the existing busy guard.
- Existing DM activity behavior stays unchanged: accepted calls reconnect with a fresh XEP-0353 proposal, ringing calls open the DM.

## Verification

- `bun test tests/call-activity-dock.test.ts tests/home-activity.test.ts tests/dm-call-activity-hydration.test.ts tests/dm-conversations.test.ts`
- `bun test`
- `bun run lint`
- `bun run build`
- `git diff --check`
- Scoped adversarial UI/accessibility review: no actionable findings.

No dev server was started.