### PR TITLE
fix(chat): show refreshed dm call rows

### DIFF
--- a/chat/src/components/chat/DmPanel.vue
+++ b/chat/src/components/chat/DmPanel.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
+import { computed } from "vue";
 import { useStore } from "@nanostores/vue";
 import { MessageCircle, PhoneCall, Plus } from "lucide-vue-next";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import { formatTimelineStamp } from "@/channels/timeline";
 import { $dmCallActivities } from "@/lib/calls/dm-call-activity";
+import type { DmCallActivity } from "@/lib/calls/dm-call-activity";
 import { barePeerJid } from "@/lib/xmpp/jid";
 import type { DmConversation } from "@/lib/xmpp-client";
 
@@ -18,6 +20,42 @@ const emit = defineEmits<{
 }>();
 
 const dmCallActivities = useStore($dmCallActivities);
+const activePeer = computed(() => normalizedPeerJid(props.activePeerJid ?? ""));
+const visibleConversations = computed<DmConversation[]>(() => {
+  const seen = new Set<string>();
+  for (const conversation of props.conversations) {
+    const peer = normalizedPeerJid(conversation.peerJid);
+    if (peer) seen.add(peer);
+  }
+  const callOnlyRows = Object.values(dmCallActivities.value)
+    .filter((activity) => {
+      const peer = normalizedPeerJid(activity.peerJid);
+      return !!peer && !seen.has(peer);
+    })
+    .map(callActivityConversation);
+  return [...props.conversations, ...callOnlyRows].sort(compareDmConversations);
+});
+
+function normalizedPeerJid(peerJid: string): string {
+  return barePeerJid(peerJid).toLowerCase();
+}
+
+function timestampMs(timestamp?: string): number {
+  const ms = Date.parse(timestamp ?? "");
+  return Number.isFinite(ms) ? ms : Number.NEGATIVE_INFINITY;
+}
+
+function conversationSortMs(conversation: DmConversation): number {
+  const callUpdatedAt = callActivity(conversation.peerJid)?.updatedAt;
+  return Math.max(timestampMs(conversation.lastMessageAt), timestampMs(callUpdatedAt));
+}
+
+function compareDmConversations(left: DmConversation, right: DmConversation): number {
+  const leftMs = conversationSortMs(left);
+  const rightMs = conversationSortMs(right);
+  if (leftMs !== rightMs) return rightMs - leftMs;
+  return normalizedPeerJid(left.peerJid).localeCompare(normalizedPeerJid(right.peerJid));
+}
 
 function preview(text?: string): string {
   if (!text) return "";
@@ -33,14 +71,42 @@ function dotClass(show?: DmConversation["presenceShow"]): string {
 }
 
 function hasCallActivity(peerJid: string): boolean {
-  const normalized = barePeerJid(peerJid).toLowerCase();
+  const normalized = normalizedPeerJid(peerJid);
   return !!normalized && !!dmCallActivities.value[normalized];
 }
 
+function callActivity(peerJid: string): DmCallActivity | null {
+  const normalized = normalizedPeerJid(peerJid);
+  return normalized ? dmCallActivities.value[normalized] ?? null : null;
+}
+
 function callActivityLabel(peerJid: string): string {
-  const normalized = barePeerJid(peerJid).toLowerCase();
-  const activity = normalized ? dmCallActivities.value[normalized] : null;
+  const activity = callActivity(peerJid);
   return activity?.state === "ringing" ? "Ringing" : "Live";
+}
+
+function callActivityDescription(activity: DmCallActivity): string {
+  const media = activity.media.video ? "Video" : "Voice";
+  if (activity.state === "accepted") return `${media} call live`;
+  if (activity.direction === "incoming") return `Incoming ${media.toLowerCase()} call`;
+  if (activity.direction === "outgoing") return `Calling ${media.toLowerCase()} call`;
+  return `${media} call ringing`;
+}
+
+function callActivityConversation(activity: DmCallActivity): DmConversation {
+  const peerJid = normalizedPeerJid(activity.peerJid);
+  return {
+    peerJid,
+    peerUsername: peerJid.split("@")[0] || peerJid,
+    lastMessageBody: callActivityDescription(activity),
+    lastMessageAt: activity.updatedAt,
+    unreadCount: 0,
+  };
+}
+
+function isActiveConversation(peerJid: string): boolean {
+  const peer = normalizedPeerJid(peerJid);
+  return !!peer && activePeer.value === peer;
 }
 </script>
 
@@ -66,7 +132,7 @@ function callActivityLabel(peerJid: string): string {
       <!-- Empty state — halo + MessageCircle glyph + caption + hint
            matches the iter-37 / 47 / 48 authored-empty-state pattern
            used elsewhere in the app. -->
-      <div v-if="conversations.length === 0" class="flex flex-col items-center justify-center gap-2 py-10 text-center">
+      <div v-if="visibleConversations.length === 0" class="flex flex-col items-center justify-center gap-2 py-10 text-center">
         <div class="chat-empty-state__halo">
           <span class="chat-empty-state__halo-glow chat-empty-state__halo-glow--primary" aria-hidden="true" />
           <span class="chat-empty-state__halo-ring chat-empty-state__halo-ring--primary">
@@ -81,13 +147,13 @@ function callActivityLabel(peerJid: string): string {
 
       <div v-else class="chat-list-stack">
         <button
-          v-for="conversation in conversations"
+          v-for="conversation in visibleConversations"
           :key="conversation.peerJid"
           class="chat-list-row w-full min-h-14 flex items-center gap-3 px-3 py-2 text-left group"
-          :class="activePeerJid === conversation.peerJid
+          :class="isActiveConversation(conversation.peerJid)
             ? 'chat-list-row--active bg-sidebar-accent text-sidebar-foreground'
             : 'text-sidebar-muted hover:bg-sidebar-accent/50 hover:text-sidebar-foreground'"
-          :aria-current="activePeerJid === conversation.peerJid ? 'page' : undefined"
+          :aria-current="isActiveConversation(conversation.peerJid) ? 'page' : undefined"
           type="button"
           @click="emit('selectDm', conversation.peerJid)"
         >

--- a/chat/tests/call-activity-dock.test.ts
+++ b/chat/tests/call-activity-dock.test.ts
@@ -468,6 +468,244 @@ describe("CallActivityDock rendering", () => {
     expect(html).toContain('title="1 active call"');
   });
 
+  test("renders refreshed call-only DMs in the direct-message panel", async () => {
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com",
+        sid: "dm-call-1",
+        media: { audio: true, video: true },
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:00:00.000Z",
+      },
+    });
+
+    const html = await renderVueComponent("../src/components/chat/DmPanel.vue", {
+      conversations: [],
+      activePeerJid: null,
+    });
+
+    expect(html).not.toContain("No conversations yet");
+    expect(html).toContain("bob");
+    expect(html).toContain("Video call live");
+    expect(html).toContain("Live");
+  });
+
+  test("does not duplicate refreshed DM call activity when the conversation already exists", async () => {
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "Bob@Example.com/laptop",
+        sid: "dm-call-1",
+        media: { audio: true, video: true },
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:00:00.000Z",
+      },
+    });
+
+    const html = await renderVueComponent("../src/components/chat/DmPanel.vue", {
+      conversations: [{
+        peerJid: "bob@example.com/phone",
+        peerUsername: "Bobby",
+        lastMessageBody: "Existing chat preview",
+        lastMessageAt: "2026-05-25T11:00:00.000Z",
+        unreadCount: 0,
+      }],
+      activePeerJid: "BOB@example.com/tablet",
+    });
+
+    expect(html).toContain("Existing chat preview");
+    expect(html).toContain("Live");
+    expect(html).toContain('aria-current="page"');
+    expect(html).not.toContain("Video call live");
+  });
+
+  test("renders outgoing refreshed DM call rows with clear ringing copy", async () => {
+    $dmCallActivities.set({
+      "alice@example.com": {
+        peerJid: "alice@example.com",
+        sid: "dm-call-2",
+        media: { audio: true, video: false },
+        state: "ringing",
+        direction: "outgoing",
+        updatedAt: "2026-05-25T12:01:00.000Z",
+      },
+    });
+
+    const html = await renderVueComponent("../src/components/chat/DmPanel.vue", {
+      conversations: [],
+      activePeerJid: null,
+    });
+
+    expect(html).toContain("Calling voice call");
+    expect(html).toContain("Ringing");
+    expect(html).not.toContain("Voice call calling");
+  });
+
+  test("orders refreshed call-only DMs with real conversations by recency", async () => {
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "Bob@example.com/laptop",
+        sid: "dm-call-3",
+        media: { audio: true, video: true },
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:00:00.000Z",
+      },
+      "alice@example.com": {
+        peerJid: "alice@example.com",
+        sid: "dm-call-4",
+        media: { audio: true, video: false },
+        state: "ringing",
+        direction: "outgoing",
+        updatedAt: "2026-05-25T11:00:00.000Z",
+      },
+    });
+
+    const html = await renderVueComponent("../src/components/chat/DmPanel.vue", {
+      conversations: [{
+        peerJid: "carol@example.com",
+        peerUsername: "Carol",
+        lastMessageBody: "Latest real conversation",
+        lastMessageAt: "2026-05-25T12:05:00.000Z",
+        unreadCount: 0,
+      }],
+      activePeerJid: null,
+    });
+
+    const carolIndex = html.indexOf("Carol");
+    const bobIndex = html.indexOf("bob");
+    const aliceIndex = html.indexOf("alice");
+    expect(carolIndex).toBeGreaterThanOrEqual(0);
+    expect(bobIndex).toBeGreaterThanOrEqual(0);
+    expect(aliceIndex).toBeGreaterThanOrEqual(0);
+    expect(carolIndex).toBeLessThan(bobIndex);
+    expect(bobIndex).toBeLessThan(aliceIndex);
+  });
+
+  test("uses call activity recency when sorting an existing refreshed DM conversation", async () => {
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com/laptop",
+        sid: "dm-call-5",
+        media: { audio: true, video: true },
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:10:00.000Z",
+      },
+    });
+
+    const html = await renderVueComponent("../src/components/chat/DmPanel.vue", {
+      conversations: [
+        {
+          peerJid: "bob@example.com/phone",
+          peerUsername: "Bobby",
+          lastMessageBody: "Old message, active call",
+          lastMessageAt: "2026-05-25T10:00:00.000Z",
+          unreadCount: 0,
+        },
+        {
+          peerJid: "carol@example.com",
+          peerUsername: "Carol",
+          lastMessageBody: "Newer text-only conversation",
+          lastMessageAt: "2026-05-25T12:05:00.000Z",
+          unreadCount: 0,
+        },
+      ],
+      activePeerJid: null,
+    });
+
+    const bobbyIndex = html.indexOf("Bobby");
+    const carolIndex = html.indexOf("Carol");
+    expect(bobbyIndex).toBeGreaterThanOrEqual(0);
+    expect(carolIndex).toBeGreaterThanOrEqual(0);
+    expect(bobbyIndex).toBeLessThan(carolIndex);
+    expect(html).toContain("Old message, active call");
+    expect(html).toContain("Live");
+    expect(html).not.toContain("Video call live");
+  });
+
+  test("uses normalized bare JIDs as the equal-recency fallback order", async () => {
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "Bob@example.com/laptop",
+        sid: "dm-call-6",
+        media: { audio: true, video: true },
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:00:00.000Z",
+      },
+      "alice@example.com": {
+        peerJid: "alice@example.com/phone",
+        sid: "dm-call-7",
+        media: { audio: true, video: true },
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:00:00.000Z",
+      },
+    });
+
+    const html = await renderVueComponent("../src/components/chat/DmPanel.vue", {
+      conversations: [],
+      activePeerJid: null,
+    });
+
+    const aliceIndex = html.indexOf("alice");
+    const bobIndex = html.indexOf("bob");
+    expect(aliceIndex).toBeGreaterThanOrEqual(0);
+    expect(bobIndex).toBeGreaterThanOrEqual(0);
+    expect(aliceIndex).toBeLessThan(bobIndex);
+  });
+
+  test("uses normalized bare JIDs as the existing-conversation fallback order", async () => {
+    const html = await renderVueComponent("../src/components/chat/DmPanel.vue", {
+      conversations: [
+        {
+          peerJid: "Same@example.com/a",
+          peerUsername: "Same Upper",
+          lastMessageBody: "Same bare first",
+          lastMessageAt: "2026-05-25T12:00:00.000Z",
+          unreadCount: 0,
+        },
+        {
+          peerJid: "same@example.com/z",
+          peerUsername: "Same Lower",
+          lastMessageBody: "Same bare second",
+          lastMessageAt: "2026-05-25T12:00:00.000Z",
+          unreadCount: 0,
+        },
+      ],
+      activePeerJid: null,
+    });
+
+    const upperIndex = html.indexOf("Same Upper");
+    const lowerIndex = html.indexOf("Same Lower");
+    expect(upperIndex).toBeGreaterThanOrEqual(0);
+    expect(lowerIndex).toBeGreaterThanOrEqual(0);
+    expect(upperIndex).toBeLessThan(lowerIndex);
+  });
+
+  test("renders unknown-direction refreshed DM call rows with fallback ringing copy", async () => {
+    $dmCallActivities.set({
+      "casey@example.com": {
+        peerJid: "casey@example.com",
+        sid: "dm-call-8",
+        media: { audio: true, video: true },
+        state: "ringing",
+        direction: "unknown",
+        updatedAt: "2026-05-25T12:02:00.000Z",
+      },
+    });
+
+    const html = await renderVueComponent("../src/components/chat/DmPanel.vue", {
+      conversations: [],
+      activePeerJid: null,
+    });
+
+    expect(html).toContain("Video call ringing");
+    expect(html).toContain("Ringing");
+  });
+
   test("renders sidebar channel rows as direct join affordances when idle", async () => {
     const html = await renderVueComponent("../src/components/chat/TopicsPanel.vue", {
       ...topicsPanelBaseProps(),


### PR DESCRIPTION
## Plan

- Keep browser-tab refresh call recovery XMPP-native by using hydrated DM call activity already recovered from personal MAM/XEP-0353 state.
- Render direct-message rows when refreshed 1:1 calls exist before the normal DM conversation list has hydrated.
- Avoid duplicate rows by normalizing bare peer JIDs across stored conversations and call activity.
- Preserve existing DM row accessibility and visible message previews.
- Sort refreshed DM rows by effective recency so active call activity can lift an existing conversation row.
- Cover empty, duplicate, normalized, ordering, outgoing-ringing, and unknown-direction refresh paths in tests.

## Current implementation

- `DmPanel` now computes visible conversations from stored conversations plus call-only rows synthesized from `$dmCallActivities`.
- Call-only rows use the peer bare JID, localpart fallback username, call status preview, and activity timestamp.
- Existing conversations win over call-only rows after case/resource-normalized bare-JID matching, while still showing the live/ringing call badge.
- Conversation sorting now uses the newer of message timestamp and call activity timestamp, then falls back to normalized bare-JID order.
- Active DM matching now normalizes bare JIDs, so resource-suffixed routes remain selected after refresh.
- Outgoing refreshed ringing calls render clear `Calling voice/video call` copy, and unknown-direction ringing calls use the generic call-ringing fallback.

## XEP review

- Reviewed local XEP references for XEP-0353, XEP-0313, XEP-0166, and XEP-0272/Muji.
- This UI-only patch does not introduce new wire shapes or non-XMPP APIs; it consumes existing hydrated XMPP call activity.

## Verification

- `bun test tests/call-activity-dock.test.ts tests/dm-call-activity-hydration.test.ts tests/dm-conversations.test.ts tests/home-activity.test.ts`
- `bun test`
- `bun run lint`
- `bun run build`
- `git diff --check`
- Scoped adversarial review rounds found accessibility/copy/test/sort-recency gaps; fixed.
- Final scoped adversarial review found no actionable findings.

No dev server was started.