### PR TITLE
feat(chat): surface refreshed group calls in navigation

### DIFF
--- a/chat/src/components/chat/ChatMobileDrawers.vue
+++ b/chat/src/components/chat/ChatMobileDrawers.vue
@@ -42,10 +42,13 @@ const {
   selfDomain,
   openUserSettings,
   openHome,
+  openDmList,
+  openCommunitySurface,
   handleLogout,
   handleRequestNotifications,
   handleToggleNotifications,
   selectChannel,
+  selectChannelByRoomJid,
   onSelectThread,
   selectDm,
   selectExtensionRoute,
@@ -57,14 +60,16 @@ const {
 } = props.controller;
 
 function selectCommunitySurface(surface: "feed" | "stories" | "events") {
-  ui.activePage.value = "chat";
-  ui.activeCommunitySurface.value = surface;
-  ui.showMobileNav.value = false;
+  openCommunitySurface(surface);
 }
 
-function selectChannelFromMobile(id: string, roomJid?: string) {
+function selectChannelFromMobile(id: string | null, roomJid?: string) {
   ui.activeCommunitySurface.value = null;
-  void selectChannel(id, roomJid ? { roomJid } : undefined);
+  if (id) {
+    void selectChannel(id, roomJid ? { roomJid } : undefined);
+    return;
+  }
+  if (roomJid) void selectChannelByRoomJid(roomJid);
 }
 
 function joinChannelCallFromMobile(channelId: string | null, roomJid: string, media: CallMedia) {
@@ -129,7 +134,7 @@ function openExtensionRoute(route: DiscoveredExtensionRoute) {
             horizontal
             @open-home="openHome"
             @toggle-channels="ui.sidebarMode.value = 'channels'"
-            @toggle-dms="ui.sidebarMode.value = 'dms'"
+            @toggle-dms="openDmList"
           />
         </div>
         <TopicsPanel
@@ -147,6 +152,7 @@ function openExtensionRoute(route: DiscoveredExtensionRoute) {
           :collapsed-group-ids="ui.collapsedSpaceGroupIds.value"
           :channel-unread-map="computedChannelUnreadMap"
           :call-participant-counts="callParticipantCounts"
+          :call-participants="mucCallParticipantsStore"
           :managed-muc-domain="managedMucDomain"
           :thread-entries-fn="(roomJid: string) => channelUnread.threadEntries(roomJid)"
           :active-community-surface="ui.activeCommunitySurface.value"

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -400,6 +400,7 @@ onUnmounted(() => {
           :collapsed-group-ids="ui.collapsedSpaceGroupIds.value"
           :channel-unread-map="computedChannelUnreadMap"
           :call-participant-counts="callParticipantCounts"
+          :call-participants="mucCallParticipantsStore"
           :managed-muc-domain="managedMucDomain"
           :thread-entries-fn="(roomJid: string) => channelUnread.threadEntries(roomJid)"
           :active-community-surface="ui.activeCommunitySurface.value"

--- a/chat/src/components/chat/TopicsPanel.vue
+++ b/chat/src/components/chat/TopicsPanel.vue
@@ -8,8 +8,11 @@ import type { ChannelThreadInboxEntry } from "@/channels/inbox";
 import { groupChannelsBySpace } from "@/lib/channel-grouping";
 import {
   callParticipantCountForChannel,
-  candidateRoomJidsForChannel,
+  callRoomJidForChannel,
   collapsedGroupBadgeModel,
+  mucCallParticipantPreview,
+  refreshedMucCallRooms,
+  type RefreshedMucCallRoom,
 } from "@/lib/calls/muc-call-indicators";
 import { normalizeMucCallRoomJid } from "@/lib/calls/muc-call-presence";
 import { $callState } from "@/lib/calls/call-store";
@@ -53,6 +56,10 @@ const props = defineProps<{
    * the channel — matches Slack-Huddle / Discord-voice patterns.
    */
   callParticipantCounts?: Record<string, number>;
+  /** Per-room nick list from XEP-0272 Muji presence. Used only for
+   * richer call affordance copy; counts remain authoritative for
+   * visibility. */
+  callParticipants?: Record<string, string[]>;
   /** Trusted MUC service domain for id-only channel rows. */
   managedMucDomain?: string | null;
 }>();
@@ -76,16 +83,22 @@ function callParticipantCount(channel: ChannelSummary): number {
 }
 
 function callRoomJid(channel: ChannelSummary): string {
-  if (!props.callParticipantCounts) return "";
-  return candidateRoomJidsForChannel(channel, props.activeChannelJids, props.managedMucDomain)
-    .map(normalizeMucCallRoomJid)
-    .find((jid) => (props.callParticipantCounts?.[jid] ?? 0) > 0) ?? "";
+  return callRoomJidForChannel(
+    channel,
+    props.callParticipantCounts,
+    props.activeChannelJids,
+    props.managedMucDomain,
+  );
 }
 
 function channelCallAction(channel: ChannelSummary): "join" | "return" | "open" | null {
   if (callParticipantCount(channel) <= 0) return null;
   const roomJid = callRoomJid(channel);
   if (!roomJid) return null;
+  return groupCallAction(roomJid);
+}
+
+function groupCallAction(roomJid: string): "join" | "return" | "open" {
   const state = callState.value;
   if (
     (state.phase === "active" || state.phase === "muc-pending") &&
@@ -96,6 +109,17 @@ function channelCallAction(channel: ChannelSummary): "join" | "return" | "open" 
   }
   if (state.phase !== "idle" && state.phase !== "ended") return "open";
   return "join";
+}
+
+function groupCallActionLabel(roomJid: string): string {
+  switch (groupCallAction(roomJid)) {
+    case "join":
+      return "Join";
+    case "return":
+      return "Return";
+    case "open":
+      return "Open";
+  }
 }
 
 function channelCallActionLabel(channel: ChannelSummary): string {
@@ -115,9 +139,47 @@ function channelCallBadgeLabel(channel: ChannelSummary): string {
   const count = callParticipantCount(channel);
   const noun = count === 1 ? "person" : "people";
   const action = channelCallActionLabel(channel);
-  return action
+  const label = action
     ? `${action} live call, ${count} ${noun}`
     : `Live call, ${count} ${noun}`;
+  const preview = callParticipantPreviewForRoom(callRoomJid(channel));
+  return preview ? `${label}: ${preview}` : label;
+}
+
+function refreshedGroupCallBadgeLabel(row: RefreshedMucCallRoom): string {
+  const noun = row.participantCount === 1 ? "person" : "people";
+  const label = `${groupCallActionLabel(row.roomJid)} live call, ${row.participantCount} ${noun}`;
+  const preview = callParticipantPreviewForRoom(row.roomJid);
+  return preview ? `${label}: ${preview}` : label;
+}
+
+function refreshedGroupCallRowLabel(row: RefreshedMucCallRoom): string {
+  const noun = row.participantCount === 1 ? "person" : "people";
+  const action = groupCallAction(row.roomJid);
+  const preview = callParticipantPreviewForRoom(row.roomJid);
+  const base = [
+    `${row.title}, group call syncing`,
+    `${row.participantCount} ${noun}`,
+    ...(preview ? [`${preview} in call`] : []),
+  ].join(", ");
+  if (action === "join") return `${base}, click to join call`;
+  if (action === "return") return `${base}, click to return to call`;
+  return `${base}, click to open call`;
+}
+
+function isActiveGroupCallRow(row: RefreshedMucCallRoom): boolean {
+  return groupCallAction(row.roomJid) === "return";
+}
+
+function callParticipantPreviewForRoom(roomJid: string): string {
+  const normalized = normalizeMucCallRoomJid(roomJid);
+  if (!normalized) return "";
+  return mucCallParticipantPreview(props.callParticipants?.[normalized]);
+}
+
+function refreshedGroupCallMeta(row: RefreshedMucCallRoom): string {
+  const preview = callParticipantPreviewForRoom(row.roomJid);
+  return preview ? `${preview} in call` : "Group call syncing";
 }
 
 function hasActivity(channelId: string): boolean {
@@ -137,6 +199,14 @@ const channelGroups = computed(() =>
       unread: props.channelUnreadMap?.[channel.id] ?? { unread: 0, mentions: 0 },
     })),
   })),
+);
+const refreshedGroupCallRows = computed(() =>
+  refreshedMucCallRooms({
+    channels: props.channels,
+    activeChannelJids: props.activeChannelJids,
+    managedMucDomain: props.managedMucDomain,
+    callParticipantCounts: props.callParticipantCounts,
+  }),
 );
 
 function groupUnreadSummary(group: (typeof channelGroups.value)[number]) {
@@ -193,12 +263,16 @@ function channelRowLabel(
   unread: { unread: number; mentions: number },
   isActive: boolean,
 ) {
+  const roomJid = callRoomJid(channel);
+  const preview = callParticipantCount(channel) > 0
+    ? callParticipantPreviewForRoom(roomJid)
+    : "";
   const label = `${channel.name}, ${isActive ? "selected" : "not selected"}, ${activityLabel({
     unread: unread.unread,
     mentions: unread.mentions,
     hasActivity: hasActivity(channel.id),
     callCount: callParticipantCount(channel),
-  })}`;
+  })}${preview ? `, ${preview} in call` : ""}`;
   const action = !isActive ? channelCallAction(channel) : null;
   if (action === "join") return `${label}, click to join call`;
   if (action === "return") return `${label}, click to return to call`;
@@ -239,7 +313,7 @@ function truncateTitle(title: string | undefined, maxLen = 28): string {
 }
 
 const emit = defineEmits<{
-  selectChannel: [id: string, roomJid?: string];
+  selectChannel: [id: string | null, roomJid?: string];
   joinChannelCall: [channelId: string | null, roomJid: string, media: CallMedia];
   selectThread: [channelId: string, threadId: string];
   selectCommunitySurface: [surface: "feed" | "stories" | "events"];
@@ -258,6 +332,14 @@ function selectChannelRow(channel: ChannelSummary): void {
     return;
   }
   emit("selectChannel", channel.id, roomJid || undefined);
+}
+
+function selectRefreshedGroupCallRow(row: RefreshedMucCallRoom): void {
+  if (groupCallAction(row.roomJid) === "join") {
+    emit("joinChannelCall", null, row.roomJid, { audio: true, video: false });
+    return;
+  }
+  emit("selectChannel", null, row.roomJid);
 }
 
 function isGroupCollapsed(groupId: string): boolean {
@@ -323,6 +405,60 @@ watch(
     <!-- Channel list -->
     <div class="chat-pane-scroll chat-sidebar-scroll">
       <div class="chat-panel-stack">
+        <div
+          v-if="refreshedGroupCallRows.length > 0"
+          class="chat-list-stack"
+        >
+          <section class="grid gap-1" aria-label="Active group calls">
+            <div class="type-section-label flex items-center gap-1.5 px-2 pt-2 pb-1 text-sidebar-muted">
+              <Phone class="h-3 w-3 text-primary" aria-hidden="true" />
+              <span class="flex-1 truncate">Active calls</span>
+              <span
+                class="chat-badge-glow--primary type-count-badge inline-flex min-w-[18px] h-[18px] px-1 items-center justify-center rounded-full bg-primary/15 text-primary ring-1 ring-primary/30"
+                aria-hidden="true"
+              >
+                {{ refreshedGroupCallRows.length }}
+              </span>
+            </div>
+            <button
+              v-for="row in refreshedGroupCallRows"
+              :key="row.key"
+              class="chat-list-row w-full min-h-10 flex items-center gap-2.5 px-3 py-2 text-left group text-sidebar-muted hover:bg-sidebar-accent/50 hover:text-sidebar-foreground"
+              :class="isActiveGroupCallRow(row) ? 'chat-list-row--active bg-sidebar-accent text-sidebar-foreground' : ''"
+              type="button"
+              :aria-current="isActiveGroupCallRow(row) ? 'page' : undefined"
+              :aria-label="refreshedGroupCallRowLabel(row)"
+              @click="selectRefreshedGroupCallRow(row)"
+            >
+              <span class="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+                <Phone class="h-3.5 w-3.5" aria-hidden="true" />
+              </span>
+              <span class="min-w-0 flex-1">
+                <span class="type-control type-strong block truncate text-sidebar-foreground">
+                  {{ row.title }}
+                </span>
+                <span class="type-meta block truncate text-sidebar-muted" :title="row.roomJid">
+                  {{ refreshedGroupCallMeta(row) }}
+                </span>
+              </span>
+              <span
+                class="chat-badge-glow--primary type-count-badge inline-flex items-center gap-0.5 h-[18px] px-1.5 rounded-full bg-primary/15 text-primary ring-1 ring-primary/30 motion-safe:animate-pulse"
+                :title="refreshedGroupCallBadgeLabel(row)"
+                aria-hidden="true"
+              >
+                <Phone class="w-3 h-3" />
+                <span class="type-numeric leading-none">{{ row.participantCount }}</span>
+              </span>
+              <span
+                class="type-meta hidden shrink-0 rounded-md border border-primary/25 bg-primary/10 px-1.5 py-0.5 text-primary xl:inline-flex"
+                aria-hidden="true"
+              >
+                {{ groupCallActionLabel(row.roomJid) }}
+              </span>
+            </button>
+          </section>
+        </div>
+
         <div v-if="isLoading" class="chat-list-stack" aria-hidden="true">
           <section
             v-for="i in 2"

--- a/chat/src/lib/calls/call-activity-dock.ts
+++ b/chat/src/lib/calls/call-activity-dock.ts
@@ -4,8 +4,8 @@ import { barePeerJid } from "@/lib/xmpp/jid";
 import type { CallMedia, CallState } from "./types";
 import {
   callParticipantCountForChannel,
-  candidateRoomJidsForChannel,
-  normalizeMucServiceDomain,
+  callRoomJidForChannel,
+  refreshedMucCallRooms,
 } from "./muc-call-indicators";
 import { normalizeMucCallRoomJid } from "./muc-call-presence";
 import type { DmCallActivity } from "./dm-call-activity";
@@ -109,9 +109,7 @@ export function buildCallActivityDockEntries(options: {
   callParticipantCounts: Record<string, number>;
   dmCallActivities: Record<string, DmCallActivity>;
 }): CallActivityDockEntry[] {
-  const matchedRoomJids = new Set<string>();
   const activeChannelRoomJid = normalizeMucCallRoomJid(options.activeChannelRoomJid ?? "");
-  const managedMucDomain = normalizeMucServiceDomain(options.managedMucDomain);
   const channelEntries = options.channels.flatMap((channel): CallActivityDockEntry[] => {
     const participantCount = callParticipantCountForChannel(
       channel,
@@ -120,10 +118,12 @@ export function buildCallActivityDockEntries(options: {
       options.managedMucDomain,
     );
     if (participantCount <= 0) return [];
-    const roomJid = candidateRoomJidsForChannel(channel, options.activeChannelJids, options.managedMucDomain)
-      .map(normalizeMucCallRoomJid)
-      .find((jid) => (options.callParticipantCounts[jid] ?? 0) > 0) ?? "";
-    if (roomJid) matchedRoomJids.add(roomJid);
+    const roomJid = callRoomJidForChannel(
+      channel,
+      options.callParticipantCounts,
+      options.activeChannelJids,
+      options.managedMucDomain,
+    );
     return [{
       kind: "channel",
       key: `channel:${channel.id}`,
@@ -138,27 +138,22 @@ export function buildCallActivityDockEntries(options: {
     }];
   });
 
-  const fallbackChannelEntries = Object.entries(options.callParticipantCounts)
-    .flatMap(([roomJid, participantCount]): CallActivityDockEntry[] => {
-      const normalizedRoomJid = normalizeMucCallRoomJid(roomJid);
-      const roomDomain = normalizedRoomJid.split("@")[1] ?? "";
-      if (!normalizedRoomJid || participantCount <= 0 || matchedRoomJids.has(normalizedRoomJid)) {
-        return [];
-      }
-      if (!managedMucDomain || roomDomain !== managedMucDomain) return [];
-      const title = normalizedRoomJid.split("@")[0] ?? normalizedRoomJid;
-      return [{
-        kind: "channel",
-        key: `channel:${normalizedRoomJid}`,
-        channelId: null,
-        roomJid: normalizedRoomJid,
-        title,
-        participantCount,
-        isKnownChannel: false,
-        isActive: options.sidebarMode === "channels" && activeChannelRoomJid === normalizedRoomJid,
-      }];
-    })
-    .sort((left, right) => left.title.localeCompare(right.title));
+  const fallbackChannelEntries = refreshedMucCallRooms({
+    channels: options.channels,
+    activeChannelJids: options.activeChannelJids,
+    managedMucDomain: options.managedMucDomain,
+    callParticipantCounts: options.callParticipantCounts,
+  })
+    .map((room): CallActivityDockEntry => ({
+      kind: "channel",
+      key: `channel:${room.roomJid}`,
+      channelId: null,
+      roomJid: room.roomJid,
+      title: room.title,
+      participantCount: room.participantCount,
+      isKnownChannel: false,
+      isActive: options.sidebarMode === "channels" && activeChannelRoomJid === room.roomJid,
+    }));
 
   const conversationNames = new Map(
     options.conversations.map((conversation) => [

--- a/chat/src/lib/calls/muc-call-indicators.ts
+++ b/chat/src/lib/calls/muc-call-indicators.ts
@@ -7,7 +7,7 @@ export function normalizeMucServiceDomain(serviceJid?: string | null): string {
   return bare.includes("@") ? bare.split("@")[1] ?? "" : bare;
 }
 
-export function candidateRoomJidsForChannel(
+function candidateRoomJidsForChannel(
   channel: Pick<ChannelSummary, "id" | "jid">,
   activeChannelJids: Iterable<string>,
   managedMucDomain?: string | null,
@@ -39,11 +39,91 @@ export function callParticipantCountForChannel(
   managedMucDomain?: string | null,
 ): number {
   if (!callParticipantCounts) return 0;
+  const countsByRoomJid = normalizedMucCallParticipantCounts(callParticipantCounts);
   for (const jid of candidateRoomJidsForChannel(channel, activeChannelJids, managedMucDomain)) {
-    const count = callParticipantCounts[normalizeMucCallRoomJid(jid)] ?? 0;
+    const count = countsByRoomJid.get(normalizeMucCallRoomJid(jid)) ?? 0;
     if (count > 0) return count;
   }
   return 0;
+}
+
+export function callRoomJidForChannel(
+  channel: Pick<ChannelSummary, "id" | "jid">,
+  callParticipantCounts: Record<string, number> | undefined,
+  activeChannelJids: Iterable<string>,
+  managedMucDomain?: string | null,
+): string {
+  if (!callParticipantCounts) return "";
+  const countsByRoomJid = normalizedMucCallParticipantCounts(callParticipantCounts);
+  return candidateRoomJidsForChannel(channel, activeChannelJids, managedMucDomain)
+    .map(normalizeMucCallRoomJid)
+    .find((jid) => (countsByRoomJid.get(jid) ?? 0) > 0) ?? "";
+}
+
+export type RefreshedMucCallRoom = {
+  key: string;
+  roomJid: string;
+  title: string;
+  participantCount: number;
+};
+
+export function refreshedMucCallRooms(options: {
+  channels: ReadonlyArray<Pick<ChannelSummary, "id" | "jid">>;
+  activeChannelJids: Iterable<string>;
+  managedMucDomain?: string | null;
+  callParticipantCounts: Record<string, number> | undefined;
+}): RefreshedMucCallRoom[] {
+  const trustedDomain = normalizeMucServiceDomain(options.managedMucDomain);
+  if (!trustedDomain || !options.callParticipantCounts) return [];
+
+  const countsByRoomJid = normalizedMucCallParticipantCounts(options.callParticipantCounts);
+
+  const matchedRoomJids = new Set<string>();
+  for (const channel of options.channels) {
+    for (const candidate of candidateRoomJidsForChannel(
+      channel,
+      options.activeChannelJids,
+      trustedDomain,
+    )) {
+      const normalized = normalizeMucCallRoomJid(candidate);
+      if (normalized && (countsByRoomJid.get(normalized) ?? 0) > 0) {
+        matchedRoomJids.add(normalized);
+      }
+    }
+  }
+
+  return [...countsByRoomJid.entries()]
+    .flatMap(([roomJid, participantCount]): RefreshedMucCallRoom[] => {
+      const roomDomain = roomJid.split("@")[1] ?? "";
+      if (roomDomain !== trustedDomain || matchedRoomJids.has(roomJid)) return [];
+      const title = roomJid.split("@")[0] || roomJid;
+      return [{
+        key: `group-call:${roomJid}`,
+        roomJid,
+        title,
+        participantCount,
+      }];
+    })
+    .sort((left, right) => left.title.localeCompare(right.title));
+}
+
+function normalizedMucCallParticipantCounts(
+  callParticipantCounts: Record<string, number>,
+): Map<string, number> {
+  const countsByRoomJid = new Map<string, number>();
+  for (const [roomJid, count] of Object.entries(callParticipantCounts)) {
+    const normalized = normalizeMucCallRoomJid(roomJid);
+    if (!normalized || count <= 0) continue;
+    countsByRoomJid.set(normalized, (countsByRoomJid.get(normalized) ?? 0) + count);
+  }
+  return countsByRoomJid;
+}
+
+export function mucCallParticipantPreview(nicks: readonly string[] | undefined, maxVisible = 2): string {
+  const visible = (nicks ?? []).map((nick) => nick.trim()).filter(Boolean);
+  if (visible.length === 0) return "";
+  if (visible.length <= maxVisible) return visible.join(", ");
+  return `${visible.slice(0, maxVisible).join(", ")} +${visible.length - maxVisible}`;
 }
 
 type CollapsedGroupActivitySummary = {

--- a/chat/src/lib/channel-room.ts
+++ b/chat/src/lib/channel-room.ts
@@ -1,6 +1,6 @@
 import type { ChannelSummary } from "@/lib/chat-types";
 import type { WaddleSession } from "@/lib/server-auth";
-import { barePeerJid, roomBareJidFor } from "@/lib/xmpp-client";
+import { barePeerJid, parseManagedRoomBareJid, roomBareJidFor } from "@/lib/xmpp-client";
 
 export function roomJidForChannelSummary(
   session: WaddleSession,
@@ -16,4 +16,50 @@ export function roomJidForChannelId(
 ): string {
   const channel = channels.find((c) => c.id === channelId);
   return roomJidForChannelSummary(session, channel ?? { id: channelId });
+}
+
+export function knownChannelIdForRoomJid(
+  roomJid: string,
+  channels: readonly Pick<ChannelSummary, "id" | "jid">[],
+  managedMucDomain?: string | null,
+): string | null {
+  const normalizedRoomJid = barePeerJid(roomJid).trim().toLowerCase();
+  if (!normalizedRoomJid) return null;
+
+  const explicit = channels.find((channel) =>
+    channel.jid ? barePeerJid(channel.jid).trim().toLowerCase() === normalizedRoomJid : false
+  );
+  if (explicit) return explicit.id;
+
+  const roomDomain = normalizedRoomJid.split("@")[1] ?? "";
+  const trustedDomain = normalizeManagedMucDomain(managedMucDomain);
+  if (!trustedDomain || roomDomain !== trustedDomain) return null;
+
+  const managedRoom = parseManagedRoomBareJid(normalizedRoomJid);
+  if (!managedRoom) return null;
+  const managedChannelId = managedRoom.channelId.toLowerCase();
+  return channels.find((channel) =>
+    !channel.jid && channel.id.toLowerCase() === managedChannelId
+  )?.id ?? null;
+}
+
+export function isTrustedManagedRoomJid(
+  roomJid: string,
+  managedMucDomain?: string | null,
+): boolean {
+  const normalizedRoomJid = barePeerJid(roomJid).trim().toLowerCase();
+  const roomDomain = normalizedRoomJid.split("@")[1] ?? "";
+  const trustedDomain = normalizeManagedMucDomain(managedMucDomain);
+  return Boolean(
+    roomDomain &&
+    trustedDomain &&
+    roomDomain === trustedDomain &&
+    parseManagedRoomBareJid(normalizedRoomJid)?.channelId,
+  );
+}
+
+function normalizeManagedMucDomain(managedMucDomain?: string | null): string {
+  const bare = barePeerJid(managedMucDomain ?? "").trim().toLowerCase();
+  if (!bare) return "";
+  return bare.includes("@") ? bare.split("@")[1] ?? "" : bare;
 }

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -21,7 +21,12 @@ import { resolveChannelBySlug } from "@/shell/route-helpers";
 import { barePeerJid, jidDomain, parseManagedRoomBareJid } from "@/lib/xmpp-client";
 import { createNotifySettingsStore } from "@/lib/notify-settings";
 import { mdsChatKey, setLastSeen } from "@/lib/last-seen-store";
-import { roomJidForChannelId as resolveRoomJidForChannelId } from "@/lib/channel-room";
+import {
+  isTrustedManagedRoomJid,
+  knownChannelIdForRoomJid,
+  roomJidForChannelId as resolveRoomJidForChannelId,
+} from "@/lib/channel-room";
+import { normalizeMucServiceDomain } from "@/lib/calls/muc-call-indicators";
 import { connectionStore } from "@/lib/connection-store";
 import { resetPinnedRooms } from "@/stores/pinned-messages";
 import { hydratePinnedBodiesOnPanelOpen } from "@/services/pinned-message-bodies";
@@ -158,6 +163,14 @@ export function useChatAppController(giphyApiKey: string) {
   );
   const extensionRoutes = ref<DiscoveredExtensionRoute[]>([]);
   const selectedChannelRoomJids = ref<Record<string, string>>({});
+  const selfDomain = computed(() => (session.value ? jidDomain(session.value.jid) : ""));
+  const managedMucDomain = computed(() =>
+    normalizeMucServiceDomain(waddles.mucServiceJid.value) || (selfDomain.value ? `muc.${selfDomain.value}` : ""),
+  );
+  const pendingChannelRoomJidSelection = ref<string | null>(null);
+  function clearPendingChannelRoomJidSelection() {
+    pendingChannelRoomJidSelection.value = null;
+  }
   const activeExtensionRouteKey = ref<{ channelId: string; pluginId: string; routeId: string } | null>(null);
   const activeExtensionRoute = computed(() => {
     const key = activeExtensionRouteKey.value;
@@ -190,6 +203,21 @@ export function useChatAppController(giphyApiKey: string) {
       );
       if (!channel || channel.id === waddles.activeChannelId.value) return;
       void selectChannel(channel.id, { roomJid: normalizedRoomJid });
+    },
+  );
+  watch(
+    [() => waddles.channels.value, managedMucDomain],
+    () => {
+      const roomJid = pendingChannelRoomJidSelection.value;
+      if (!roomJid) return;
+      const channelId = knownChannelIdForRoomJid(
+        roomJid,
+        waddles.channels.value,
+        managedMucDomain.value,
+      );
+      if (!channelId) return;
+      pendingChannelRoomJidSelection.value = null;
+      void selectChannel(channelId, { roomJid });
     },
   );
 
@@ -448,7 +476,6 @@ export function useChatAppController(giphyApiKey: string) {
     ui.sidebarMode.value === "dms" ? dmMessaging.isSearching.value : messaging.isSearching.value,
   );
 
-  const selfDomain = computed(() => (session.value ? jidDomain(session.value.jid) : ""));
   const members = useWaddleMembers(
     xmppClient,
     waddles.activeSpaceId,
@@ -1303,6 +1330,7 @@ export function useChatAppController(giphyApiKey: string) {
   );
 
   function openUserSettings() {
+    clearPendingChannelRoomJidSelection();
     ui.showMobileNav.value = false;
     ui.showMobileDetails.value = false;
     ui.activePage.value = "settings";
@@ -1314,6 +1342,7 @@ export function useChatAppController(giphyApiKey: string) {
    * page refresh lands back on /threads.
    */
   function openThreads() {
+    clearPendingChannelRoomJidSelection();
     ui.showMobileNav.value = false;
     ui.showMobileDetails.value = false;
     ui.activePage.value = "threads";
@@ -1341,6 +1370,7 @@ export function useChatAppController(giphyApiKey: string) {
    * clicks need to mirror what `applyRouteTarget` would do.
    */
   function openCommunitySurface(surface: "feed" | "stories" | "events") {
+    clearPendingChannelRoomJidSelection();
     ui.showMobileNav.value = false;
     ui.showMobileDetails.value = false;
     ui.activePage.value = "chat";
@@ -1361,6 +1391,7 @@ export function useChatAppController(giphyApiKey: string) {
    * rather than re-entering the last channel.
    */
   function openHome() {
+    clearPendingChannelRoomJidSelection();
     ui.showMobileNav.value = false;
     ui.showMobileDetails.value = false;
     ui.activePage.value = "dashboard";
@@ -1381,6 +1412,7 @@ export function useChatAppController(giphyApiKey: string) {
    * so refresh and back/forward land on the same place.
    */
   function openDmList() {
+    clearPendingChannelRoomJidSelection();
     ui.showMobileNav.value = false;
     ui.showMobileDetails.value = false;
     ui.activePage.value = "chat";
@@ -1473,6 +1505,7 @@ export function useChatAppController(giphyApiKey: string) {
   }
 
   async function applyRouteTarget(match: RouteMatch, requestId: number) {
+    clearPendingChannelRoomJidSelection();
     applyMatchToShellState(match);
     // Routes that don't reference a specific channel/DM target also
     // drop the chat-context state. (Channel/extension/dm routes set
@@ -1633,6 +1666,7 @@ export function useChatAppController(giphyApiKey: string) {
   // --- Actions ---
 
   async function handleLogout() {
+    clearPendingChannelRoomJidSelection();
     ui.activePage.value = "dashboard";
     messaging.disconnect();
     dmMessaging.disconnect();
@@ -1660,6 +1694,7 @@ export function useChatAppController(giphyApiKey: string) {
   }
 
   async function selectChannel(channelId: string, options: { roomJid?: string } = {}) {
+    clearPendingChannelRoomJidSelection();
     ui.activePage.value = "chat";
     ui.sidebarMode.value = "channels";
     activeExtensionRouteKey.value = null;
@@ -1694,16 +1729,30 @@ export function useChatAppController(giphyApiKey: string) {
   async function selectChannelByRoomJid(roomJid: string) {
     const normalizedRoomJid = barePeerJid(roomJid);
     if (!normalizedRoomJid) return;
-    const channel = waddles.channels.value.find((candidate) =>
-      candidate.jid ? barePeerJid(candidate.jid) === normalizedRoomJid : false
+    const channelId = knownChannelIdForRoomJid(
+      normalizedRoomJid,
+      waddles.channels.value,
+      managedMucDomain.value,
     );
-    const managedRoom = parseManagedRoomBareJid(normalizedRoomJid);
-    const channelId = channel?.id ?? managedRoom?.channelId;
-    if (!channelId) return;
+    if (!channelId) {
+      if (isTrustedManagedRoomJid(normalizedRoomJid, managedMucDomain.value)) {
+        pendingChannelRoomJidSelection.value = normalizedRoomJid;
+        ui.activePage.value = "chat";
+        ui.sidebarMode.value = "channels";
+        ui.activeCommunitySurface.value = null;
+        activeExtensionRouteKey.value = null;
+        dmConversations.closeDm();
+        memberJidByNick.value = {};
+        ui.showMobileNav.value = false;
+      }
+      return;
+    }
+    pendingChannelRoomJidSelection.value = null;
     await selectChannel(channelId, { roomJid: normalizedRoomJid });
   }
 
   async function selectExtensionRoute(channelId: string, route: DiscoveredExtensionRoute) {
+    clearPendingChannelRoomJidSelection();
     ui.activePage.value = "chat";
     ui.sidebarMode.value = "channels";
     dmConversations.closeDm();
@@ -1721,6 +1770,7 @@ export function useChatAppController(giphyApiKey: string) {
   }
 
   async function handleOpenDm(peerJid: string) {
+    clearPendingChannelRoomJidSelection();
     ui.activePage.value = "chat";
     ui.sidebarMode.value = "dms";
     activeExtensionRouteKey.value = null;

--- a/chat/tests/call-activity-dock.test.ts
+++ b/chat/tests/call-activity-dock.test.ts
@@ -264,6 +264,37 @@ describe("call activity dock model", () => {
     ]);
   });
 
+  test("resolves known-channel room JIDs from normalized call count keys", () => {
+    const entries = buildCallActivityDockEntries({
+      channels: [
+        { id: "general", name: "General", jid: "general@conference.example.com" },
+      ],
+      conversations: [],
+      activeChannelId: null,
+      activePeerJid: null,
+      sidebarMode: "channels",
+      activeChannelJids: new Set(),
+      managedMucDomain: "conference.example.com",
+      callParticipantCounts: {
+        "General@Conference.Example.com/alice": 2,
+      },
+      dmCallActivities: {},
+    });
+
+    expect(entries).toEqual([
+      {
+        kind: "channel",
+        key: "channel:general",
+        channelId: "general",
+        roomJid: "general@conference.example.com",
+        title: "General",
+        participantCount: 2,
+        isKnownChannel: true,
+        isActive: false,
+      },
+    ]);
+  });
+
   test("filters fallback group calls to the managed MUC domain", () => {
     const entries = buildCallActivityDockEntries({
       channels: [],
@@ -437,6 +468,7 @@ describe("CallActivityDock rendering", () => {
     expect(readyShell).toContain(":join-channel-call=\"joinChannelCallFromActivity\"");
     expect(readyShell).toContain(":active-channel-call-count=\"activeChannelCallCount\"");
     expect(readyShell).toContain(":active-dm-call-count=\"activeDmCallCount\"");
+    expect(readyShell).toContain(":call-participants=\"mucCallParticipantsStore\"");
     expect(readyShell).toContain("@select-channel=\"onSelectChannelFromSidebar\"");
     expect(readyShell).toContain("@join-channel-call=\"joinChannelCallFromActivity\"");
     expect(readyShell).toContain("@select-dm=\"selectDm\"");
@@ -446,6 +478,8 @@ describe("CallActivityDock rendering", () => {
     expect(mobileDrawers).toContain("@join-channel-call=\"joinChannelCallFromMobile\"");
     expect(mobileDrawers).toContain(":active-channel-call-count=\"activeChannelCallCount\"");
     expect(mobileDrawers).toContain(":active-dm-call-count=\"activeDmCallCount\"");
+    expect(mobileDrawers).toContain(":call-participants=\"mucCallParticipantsStore\"");
+    expect(mobileDrawers).toContain("@toggle-dms=\"openDmList\"");
   });
 
   test("renders rail-level active call indicators for spaces and DMs", async () => {
@@ -722,6 +756,47 @@ describe("CallActivityDock rendering", () => {
     expect(html).toContain("General, not selected, call ongoing with 2 participants, click to join call");
   });
 
+  test("renders refreshed group call rows while channel navigation is loading", async () => {
+    const html = await renderVueComponent("../src/components/chat/TopicsPanel.vue", {
+      ...topicsPanelBaseProps(),
+      isLoading: true,
+      callParticipantCounts: {
+        "general@conference.example.com": 2,
+      },
+      callParticipants: {
+        "general@conference.example.com": ["alice", "bob"],
+      },
+      managedMucDomain: "conference.example.com",
+    });
+
+    expect(html).toContain("Active calls");
+    expect(html).toContain("general");
+    expect(html).toContain("alice, bob in call");
+    expect(html).toContain("Join live call, 2 people");
+    expect(html).toContain("Join live call, 2 people: alice, bob");
+    expect(html).toContain("general, group call syncing, 2 people, alice, bob in call, click to join call");
+  });
+
+  test("does not duplicate refreshed group call rows for known channels", async () => {
+    const html = await renderVueComponent("../src/components/chat/TopicsPanel.vue", {
+      ...topicsPanelBaseProps(),
+      channels: [
+        { id: "general", name: "General", jid: "general@conference.example.com" },
+      ],
+      callParticipantCounts: {
+        "general@conference.example.com": 2,
+      },
+      callParticipants: {
+        "general@conference.example.com": ["alice", "bob", "carol"],
+      },
+      managedMucDomain: "conference.example.com",
+    });
+
+    expect(html).toContain("General, not selected, call ongoing with 2 participants, alice, bob +1 in call, click to join call");
+    expect(html).toContain("Join live call, 2 people: alice, bob +1");
+    expect(html).not.toContain("Group call syncing");
+  });
+
   test("keeps sidebar channel call rows navigation-only while another call is active", async () => {
     $callState.set({
       phase: "outgoing",
@@ -799,6 +874,55 @@ describe("CallActivityDock rendering", () => {
     ]);
   });
 
+  test("activates sidebar channel rows with normalized call count keys", async () => {
+    clearCallState();
+    const emitted: unknown[][] = [];
+    const channel = { id: "general", name: "General", jid: "general@conference.example.com" };
+    const bindings = await setupVueComponent("../src/components/chat/TopicsPanel.vue", {
+      ...topicsPanelBaseProps(),
+      channels: [channel],
+      callParticipantCounts: {
+        "General@Conference.Example.com/alice": 2,
+      },
+      managedMucDomain: "conference.example.com",
+    }, (...args) => {
+      emitted.push(args);
+    });
+
+    setupBindingFunction(bindings, "selectChannelRow")(channel);
+
+    expect(emitted).toEqual([
+      ["joinChannelCall", "general", "general@conference.example.com", { audio: true, video: false }],
+    ]);
+  });
+
+  test("activates refreshed group call rows through the join, open, and return event paths", async () => {
+    expect(await emittedRefreshedGroupCallRowEvents()).toEqual([
+      ["joinChannelCall", null, "general@conference.example.com", { audio: true, video: false }],
+    ]);
+
+    expect(await emittedRefreshedGroupCallRowEvents({
+      phase: "outgoing",
+      to: "bob@example.com",
+      sid: "dm-call",
+      media: { audio: true, video: false },
+    })).toEqual([
+      ["selectChannel", null, "general@conference.example.com"],
+    ]);
+
+    expect(await emittedRefreshedGroupCallRowEvents({
+      phase: "muc-pending",
+      kind: "muc",
+      peer: "general@conference.example.com",
+      sid: "muc-call",
+      media: { audio: true, video: false },
+      selfNick: "alice",
+      attemptId: "attempt-1",
+    })).toEqual([
+      ["selectChannel", null, "general@conference.example.com"],
+    ]);
+  });
+
   test("mobile drawer forwards sidebar join-call events to the shell handler", async () => {
     const forwarded: unknown[][] = [];
     const bindings = await setupVueComponent("../src/components/chat/ChatMobileDrawers.vue", {
@@ -817,6 +941,21 @@ describe("CallActivityDock rendering", () => {
     expect(forwarded).toEqual([
       ["general", "general@conference.example.com", { audio: true, video: false }],
     ]);
+  });
+
+  test("mobile drawer routes community surfaces through the controller", async () => {
+    const selected: unknown[][] = [];
+    const bindings = await setupVueComponent("../src/components/chat/ChatMobileDrawers.vue", {
+      controller: {
+        openCommunitySurface: (...args: unknown[]) => {
+          selected.push(args);
+        },
+      },
+    });
+
+    setupBindingFunction(bindings, "selectCommunitySurface")("stories");
+
+    expect(selected).toEqual([["stories"]]);
   });
 
   test("mobile drawer preserves room JID when channel call rows open or return", async () => {
@@ -841,6 +980,34 @@ describe("CallActivityDock rendering", () => {
     expect(ui.activeCommunitySurface.value).toBe(null);
     expect(selected).toEqual([
       ["general", { roomJid: "general@conference.example.com" }],
+    ]);
+  });
+
+  test("mobile drawer opens refreshed group call rows by room JID", async () => {
+    const selected: unknown[][] = [];
+    const ui = {
+      activeCommunitySurface: { value: "stories" },
+    };
+    const bindings = await setupVueComponent("../src/components/chat/ChatMobileDrawers.vue", {
+      controller: {
+        ui,
+        selectChannel: (...args: unknown[]) => {
+          selected.push(args);
+        },
+        selectChannelByRoomJid: (...args: unknown[]) => {
+          selected.push(["room", ...args]);
+        },
+      },
+    });
+
+    setupBindingFunction(bindings, "selectChannelFromMobile")(
+      null,
+      "general@conference.example.com",
+    );
+
+    expect(ui.activeCommunitySurface.value).toBe(null);
+    expect(selected).toEqual([
+      ["room", "general@conference.example.com"],
     ]);
   });
 
@@ -987,6 +1154,29 @@ async function emittedTopicChannelRowEvents(callState?: CallState): Promise<unkn
   });
 
   setupBindingFunction(bindings, "selectChannelRow")(channel);
+  return emitted;
+}
+
+async function emittedRefreshedGroupCallRowEvents(callState?: CallState): Promise<unknown[][]> {
+  clearCallState();
+  if (callState) $callState.set(callState);
+  const emitted: unknown[][] = [];
+  const bindings = await setupVueComponent("../src/components/chat/TopicsPanel.vue", {
+    ...topicsPanelBaseProps(),
+    callParticipantCounts: {
+      "general@conference.example.com": 2,
+    },
+    managedMucDomain: "conference.example.com",
+  }, (...args) => {
+    emitted.push(args);
+  });
+
+  setupBindingFunction(bindings, "selectRefreshedGroupCallRow")({
+    key: "group-call:general@conference.example.com",
+    roomJid: "general@conference.example.com",
+    title: "general",
+    participantCount: 2,
+  });
   return emitted;
 }
 

--- a/chat/tests/channel-room.test.ts
+++ b/chat/tests/channel-room.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { roomJidForChannelId, roomJidForChannelSummary } from "../src/lib/channel-room";
+import {
+  isTrustedManagedRoomJid,
+  knownChannelIdForRoomJid,
+  roomJidForChannelId,
+  roomJidForChannelSummary,
+} from "../src/lib/channel-room";
 import type { WaddleSession } from "../src/lib/server-auth";
 
 const session = {
@@ -34,4 +39,46 @@ describe("roomJidForChannelSummary", () => {
     ], "random")).toBe("random@conference.example.net");
   });
 
+});
+
+describe("knownChannelIdForRoomJid", () => {
+  test("prefers exact discovered room JID matches", () => {
+    expect(knownChannelIdForRoomJid("general@conference.example.net/alice", [
+      { id: "pretty-general", jid: "general@conference.example.net" },
+      { id: "general", jid: "general@muc.example.com" },
+    ])).toBe("pretty-general");
+  });
+
+  test("matches id-only managed channels by room localpart", () => {
+    expect(knownChannelIdForRoomJid("General@MUC.Example.com", [
+      { id: "general" },
+      { id: "random" },
+    ], "muc.example.com")).toBe("general");
+  });
+
+  test("does not map id-only channels from untrusted room domains", () => {
+    expect(knownChannelIdForRoomJid("general@foreign.example.com", [
+      { id: "general" },
+    ], "muc.example.com")).toBeNull();
+  });
+
+  test("does not use id fallback for channels with a mismatched explicit JID", () => {
+    expect(knownChannelIdForRoomJid("general@muc.example.com", [
+      { id: "general", jid: "general@conference.example.net" },
+    ], "muc.example.com")).toBeNull();
+  });
+
+  test("does not infer a channel id when the directory has no known match", () => {
+    expect(knownChannelIdForRoomJid("orphan@muc.example.com", [])).toBeNull();
+    expect(knownChannelIdForRoomJid("orphan@muc.example.com", [
+      { id: "general" },
+    ], "muc.example.com")).toBeNull();
+  });
+});
+
+describe("isTrustedManagedRoomJid", () => {
+  test("checks managed room domains using bare normalized JIDs", () => {
+    expect(isTrustedManagedRoomJid("General@MUC.Example.com/alice", "muc.example.com")).toBe(true);
+    expect(isTrustedManagedRoomJid("general@foreign.example.com", "muc.example.com")).toBe(false);
+  });
 });

--- a/chat/tests/muc-call-indicators.test.ts
+++ b/chat/tests/muc-call-indicators.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import {
   callParticipantCountForChannel,
+  callRoomJidForChannel,
   collapsedGroupBadgeModel,
+  mucCallParticipantPreview,
   normalizeMucServiceDomain,
+  refreshedMucCallRooms,
 } from "../src/lib/calls/muc-call-indicators";
 
 describe("callParticipantCountForChannel", () => {
@@ -12,6 +15,25 @@ describe("callParticipantCountForChannel", () => {
       { "general@muc.test": 2 },
       new Set(),
     )).toBe(2);
+  });
+
+  test("uses the same normalized count aggregation as refreshed fallback rows", () => {
+    expect(callParticipantCountForChannel(
+      { id: "general", jid: "general@muc.test" },
+      {
+        "General@MUC.Test/mobile": 1,
+        "general@muc.test": 2,
+      },
+      new Set(),
+    )).toBe(3);
+  });
+
+  test("resolves channel room JIDs from normalized count keys", () => {
+    expect(callRoomJidForChannel(
+      { id: "general", jid: "general@muc.test" },
+      { "General@MUC.Test/mobile": 2 },
+      new Set(),
+    )).toBe("general@muc.test");
   });
 
   test("matches id-only channel rows through the managed MUC domain", () => {
@@ -63,6 +85,87 @@ describe("normalizeMucServiceDomain", () => {
   test("accepts discovered MUC service JIDs and bare domains", () => {
     expect(normalizeMucServiceDomain("custom-muc.example.test")).toBe("custom-muc.example.test");
     expect(normalizeMucServiceDomain("rooms@example.test/resource")).toBe("example.test");
+  });
+});
+
+describe("refreshedMucCallRooms", () => {
+  test("returns unmatched trusted-domain group calls for refresh navigation", () => {
+    expect(refreshedMucCallRooms({
+      channels: [],
+      activeChannelJids: new Set(),
+      managedMucDomain: "muc.test",
+      callParticipantCounts: {
+        "general@muc.test": 2,
+        "general@other.test": 4,
+      },
+    })).toEqual([
+      {
+        key: "group-call:general@muc.test",
+        roomJid: "general@muc.test",
+        title: "general",
+        participantCount: 2,
+      },
+    ]);
+  });
+
+  test("dedupes rooms already represented by known channel rows", () => {
+    expect(refreshedMucCallRooms({
+      channels: [
+        { id: "general", jid: "General@MUC.Test/desktop" },
+        { id: "planning" },
+      ],
+      activeChannelJids: new Set(),
+      managedMucDomain: "muc.test",
+      callParticipantCounts: {
+        "general@muc.test": 2,
+        "planning@muc.test": 3,
+        "random@muc.test": 1,
+      },
+    })).toEqual([
+      {
+        key: "group-call:random@muc.test",
+        roomJid: "random@muc.test",
+        title: "random",
+        participantCount: 1,
+      },
+    ]);
+  });
+
+  test("does not suppress known-channel badges for mixed-case count keys", () => {
+    expect(refreshedMucCallRooms({
+      channels: [
+        { id: "general", jid: "general@muc.test" },
+      ],
+      activeChannelJids: new Set(),
+      managedMucDomain: "muc.test",
+      callParticipantCounts: {
+        "General@MUC.Test/mobile": 2,
+      },
+    })).toEqual([]);
+    expect(callParticipantCountForChannel(
+      { id: "general", jid: "general@muc.test" },
+      { "General@MUC.Test/mobile": 2 },
+      new Set(),
+    )).toBe(2);
+  });
+
+  test("does not infer unmatched call rooms without a trusted MUC domain", () => {
+    expect(refreshedMucCallRooms({
+      channels: [],
+      activeChannelJids: new Set(),
+      callParticipantCounts: {
+        "general@muc.test": 2,
+      },
+    })).toEqual([]);
+  });
+});
+
+describe("mucCallParticipantPreview", () => {
+  test("formats Muji participant nick previews for call navigation", () => {
+    expect(mucCallParticipantPreview(["alice", "bob"])).toBe("alice, bob");
+    expect(mucCallParticipantPreview(["alice", "bob", "carol"])).toBe("alice, bob +1");
+    expect(mucCallParticipantPreview(["", " alice ", "  "])).toBe("alice");
+    expect(mucCallParticipantPreview([])).toBe("");
   });
 });
 


### PR DESCRIPTION
## Plan

- Keep the integration XMPP-native by consuming existing XEP-0272 Muji participant state from the chat runtime.
- Review the local XEP references before changing UI behavior.
- Promote refresh-discovered group calls into channel navigation when the channel directory has not hydrated or the room is otherwise unmatched.
- Preserve existing known-channel badges and join/return/open behavior.
- Fix review feedback around mobile refresh routing, normalized room keys, and trusted-domain fallback.
- Add focused SSR/model coverage for refreshed group-call rows and mobile/desktop navigation behavior.
- Run focused tests plus the chat package checks before marking ready.

## Current implementation

- `TopicsPanel` renders an `Active calls` section for refreshed Muji rooms that have participant counts but are not represented by a known channel row.
- Fallback rows are constrained to the trusted managed MUC domain, use normalized bare room JIDs, and dedupe against known channel rows including id-only channel rows.
- Fallback group-call rows support `Join`, `Open`, and `Return` behavior without inferring unknown channel ids before the directory hydrates.
- Room-JID routing queues trusted refresh selections until channel metadata is available, and clears that pending selection when the user navigates elsewhere.
- Known channel rows and dock entries now resolve active call rooms through the same normalized participant-count model as fallback rows.
- Mobile navigation opens fallback group-call rows by room JID and routes DM/community navigation through controller actions that clear pending refresh state.
- Channel call affordance copy includes Muji participant nick previews in visible and accessible labels.
- `CallActivityDock` uses the shared refreshed-room model so the dock and channel navigation match.

## Review feedback addressed

- Greptile: mobile open/return could navigate to a blank channel view for unmatched refreshed rooms.
- Greptile: normalized participant counts could suppress known-channel badges while also hiding fallback rows.
- Adversarial review: room-JID action resolution still used raw count keys.
- Adversarial review: id fallback could cross domains or override explicit channel JIDs.
- Adversarial review: queued refresh selection could override later mobile navigation.
- Adversarial review: participant previews for known channel rows needed accessible labels.

## XEP review

- Reviewed `xeps/xep-0272.xml` for Muji joining/leaving semantics.
- This UI-only patch does not add wire shapes or non-XMPP APIs; it consumes existing Muji participant presence state.

## Verification

- `bun test tests/call-activity-dock.test.ts tests/muc-call-indicators.test.ts`
- `bun test tests/channel-room.test.ts tests/muc-call-indicators.test.ts tests/call-activity-dock.test.ts`
- `bun test tests/call-activity-dock.test.ts tests/muc-call-indicators.test.ts tests/home-activity.test.ts tests/use-active-muc-call.test.ts tests/muc-call-presence.test.ts`
- `bun test`
- `bun run lint`
- `bun run build`
- `git diff --check`

No dev server was started.