### PR TITLE
feat(chat): polish refreshed DM call activity

### DIFF
--- a/chat/src/components/calls/CallActivityDock.vue
+++ b/chat/src/components/calls/CallActivityDock.vue
@@ -19,7 +19,7 @@ import type { CallMedia } from "@/lib/calls/types";
 import type { ChannelSummary } from "@/lib/chat-types";
 import type { DmConversation } from "@/lib/xmpp-client";
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   channels: ChannelSummary[];
   conversations: DmConversation[];
   activeChannelId: string | null;
@@ -28,9 +28,13 @@ const props = defineProps<{
   sidebarMode: SidebarMode;
   activeChannelJids: Set<string>;
   managedMucDomain?: string | null;
-}>();
+  showDmCalls?: boolean;
+}>(), {
+  showDmCalls: true,
+});
 
 const emit = defineEmits<{
+  answerDm: [peerJid: string, remoteFullJid: string, sid: string, media: CallMedia];
   selectChannel: [channelId: string | null, roomJid: string];
   joinChannelCall: [channelId: string | null, roomJid: string, media: CallMedia];
   selectDm: [peerJid: string];
@@ -55,7 +59,7 @@ const entries = computed(() => buildCallActivityDockEntries({
   activeChannelJids: props.activeChannelJids,
   managedMucDomain: props.managedMucDomain ?? null,
   callParticipantCounts: callParticipantCounts.value,
-  dmCallActivities: dmCallActivities.value,
+  dmCallActivities: props.showDmCalls === false ? {} : dmCallActivities.value,
 }));
 const entryCount = computed(() => entries.value.length);
 
@@ -74,6 +78,7 @@ function entryStatus(entry: CallActivityDockEntry): string {
 
 function entryKindLabel(entry: CallActivityDockEntry): string {
   if (entry.kind === "channel") return entry.isKnownChannel ? "Group call" : "Group call · syncing";
+  if (entry.mediaKnown === false) return "Call";
   return entry.media.video ? "Video call" : "Voice call";
 }
 
@@ -83,6 +88,8 @@ function entryMeta(entry: CallActivityDockEntry): string {
 
 function entryAction(entry: CallActivityDockEntry): string {
   switch (callActivityDockAction(entry, callState.value)) {
+    case "answer":
+      return "Answer";
     case "join":
       return "Join";
     case "return":
@@ -106,6 +113,9 @@ function selectEntry(entry: CallActivityDockEntry): void {
   if (!entryCanSelect(entry)) return;
   const selection = callActivityDockSelection(entry, callState.value);
   switch (selection.kind) {
+    case "dm-answer":
+      emit("answerDm", selection.peerJid, selection.remoteFullJid, selection.sid, selection.media);
+      return;
     case "channel-join":
       emit("joinChannelCall", selection.channelId, selection.roomJid, selection.media);
       return;
@@ -153,7 +163,7 @@ function selectEntry(entry: CallActivityDockEntry): void {
       >
         <span class="call-activity-dock__icon" aria-hidden="true">
           <Hash v-if="entry.kind === 'channel'" class="h-3.5 w-3.5" />
-          <Video v-else-if="entry.media.video" class="h-3.5 w-3.5" />
+          <Video v-else-if="entry.mediaKnown !== false && entry.media.video" class="h-3.5 w-3.5" />
           <PhoneIncoming v-else-if="entry.state === 'ringing' && entry.direction === 'incoming'" class="h-3.5 w-3.5" />
           <PhoneOutgoing v-else-if="entry.state === 'ringing' && entry.direction === 'outgoing'" class="h-3.5 w-3.5" />
           <MessageCircle v-else-if="entry.state === 'ringing'" class="h-3.5 w-3.5" />

--- a/chat/src/components/calls/CallButton.vue
+++ b/chat/src/components/calls/CallButton.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { useStore } from "@nanostores/vue";
-import { Phone, Video } from "lucide-vue-next";
+import { Phone, PhoneIncoming, Video } from "lucide-vue-next";
 import { $callState } from "@/lib/calls/call-store";
-import { useDmCallActivity } from "@/lib/calls/dm-call-activity";
-import { startDmCallAction } from "@/lib/calls/dm-call-actions";
+import { dmCallActivityAction } from "@/lib/calls/call-activity-dock";
+import { hasKnownDmCallMedia, useDmCallActivity } from "@/lib/calls/dm-call-activity";
+import { answerIncomingDmCallActivity, startDmCallAction } from "@/lib/calls/dm-call-actions";
 import type { CallWireSender } from "@/lib/calls/outbound";
 import { connectionStore } from "@/lib/connection-store";
 import type { CallMedia } from "@/lib/calls/types";
@@ -32,16 +33,48 @@ const inCall = computed(
 const hasPeerCallActivity = computed(() => !!peerCallActivity.value);
 const voiceLabel = computed(() => hasPeerCallActivity.value && !inCall.value ? "Reconnect voice call" : "Start voice call");
 const videoLabel = computed(() => hasPeerCallActivity.value && !inCall.value ? "Reconnect video call" : "Start video call");
-const reconnectingPeerCall = computed(() => hasPeerCallActivity.value && !inCall.value);
+const peerActivityAction = computed(() => {
+  const activity = peerCallActivity.value;
+  return activity ? dmCallActivityAction(activity, state.value) : null;
+});
 const activityBannerLabel = computed(() => {
   const activity = peerCallActivity.value;
   if (!activity) return "";
+  if (!hasKnownDmCallMedia(activity)) {
+    if (activity.state === "accepted") return "Call live";
+    if (activity.direction === "incoming") return "Incoming call";
+    if (activity.direction === "outgoing") return "Calling";
+    return "Call ringing";
+  }
   const media = activity.media.video ? "Video" : "Voice";
   if (activity.state === "accepted") return `${media} call live`;
   if (activity.direction === "incoming") return `Incoming ${media.toLowerCase()} call`;
-  if (activity.direction === "outgoing") return `${media} call calling`;
+  if (activity.direction === "outgoing") return `Calling ${media.toLowerCase()} call`;
   return `${media} call ringing`;
 });
+const activityButtonLabel = computed(() => {
+  const activity = peerCallActivity.value;
+  if (!activity) return "";
+  const media = hasKnownDmCallMedia(activity) ? (activity.media.video ? "video" : "voice") : "";
+  const call = media ? `${media} call` : "call";
+  switch (peerActivityAction.value) {
+    case "answer":
+      return `Answer ${call}`;
+    case "reconnect":
+      return `Reconnect ${call}`;
+    case "return":
+      return `Return to ${call}`;
+    case "open":
+      return `Open ${call}`;
+    default:
+      return "";
+  }
+});
+const activityButtonDisabled = computed(() =>
+  !peerActivityAction.value ||
+  peerActivityAction.value === "open" ||
+  peerActivityAction.value === "return",
+);
 
 function getSender(): CallWireSender | null {
   const client = connectionStore.client as unknown as { xmpp?: unknown } | null;
@@ -60,20 +93,61 @@ async function startCall(media: CallMedia): Promise<void> {
     getInitiator,
   });
 }
+
+async function handlePeerCallActivity(): Promise<void> {
+  const activity = peerCallActivity.value;
+  if (!activity) return;
+  switch (peerActivityAction.value) {
+    case "answer":
+      if (!activity.remoteFullJid) return;
+      await answerIncomingDmCallActivity({
+        peerBareJid: props.peerBareJid,
+        proposerFullJid: activity.remoteFullJid,
+        sid: activity.sid,
+        media: activity.media,
+        getSender,
+      });
+      return;
+    case "reconnect":
+      await startCall(activity.media);
+      return;
+    case "open":
+    case "return":
+    default:
+      return;
+  }
+}
 </script>
 
 <template>
   <div
     class="call-button-group"
-    :class="{ 'call-button-group--activity': reconnectingPeerCall }"
+    :class="{ 'call-button-group--activity': hasPeerCallActivity }"
   >
     <span
-      v-if="reconnectingPeerCall"
+      v-if="hasPeerCallActivity"
       class="call-button-group__hint type-meta"
       aria-hidden="true"
     >
       {{ activityBannerLabel }}
     </span>
+    <button
+      v-if="hasPeerCallActivity"
+      class="chat-icon-button chat-icon-button--md transition-all duration-200"
+      :class="activityButtonDisabled
+        ? 'text-muted-foreground opacity-40 cursor-not-allowed'
+        : 'text-success hover:bg-success/10 hover:text-success'"
+      type="button"
+      :title="activityButtonLabel"
+      :aria-label="activityButtonLabel"
+      :disabled="activityButtonDisabled"
+      @click="handlePeerCallActivity"
+    >
+      <PhoneIncoming v-if="peerActivityAction === 'answer'" class="w-3.5 h-3.5" />
+      <Video v-else-if="peerCallActivity && hasKnownDmCallMedia(peerCallActivity) && peerCallActivity.media.video" class="w-3.5 h-3.5" />
+      <Phone v-else class="w-3.5 h-3.5" />
+    </button>
+    <template v-else>
     <button
       class="chat-icon-button chat-icon-button--md transition-all duration-200"
       :class="inCall
@@ -100,6 +174,7 @@ async function startCall(media: CallMedia): Promise<void> {
     >
       <Video class="w-3.5 h-3.5" />
     </button>
+    </template>
   </div>
 </template>
 

--- a/chat/src/components/calls/IncomingCallToast.vue
+++ b/chat/src/components/calls/IncomingCallToast.vue
@@ -40,10 +40,16 @@ const mediaLabel = computed(() => {
 });
 
 const statusLabel = computed(() => {
-  if (accepting.value) return "Connecting…";
+  if (accepting.value || (state.value.phase === "incoming" && state.value.accepting)) return "Connecting…";
   if (declining.value) return "Declining…";
   return "ringing…";
 });
+
+const controlsDisabled = computed(() =>
+  accepting.value ||
+  declining.value ||
+  (state.value.phase === "incoming" && state.value.accepting === true),
+);
 
 function getSender() {
   // BrowserXmppClient stores the wasm client as `xmpp`; cast through unknown
@@ -55,7 +61,7 @@ function getSender() {
 
 async function accept(): Promise<void> {
   if (state.value.phase !== "incoming") return;
-  if (accepting.value || declining.value) return;
+  if (controlsDisabled.value) return;
   const { from, sid } = state.value;
   const sender = getSender();
   if (!sender) return;
@@ -72,7 +78,7 @@ async function accept(): Promise<void> {
 
 async function decline(): Promise<void> {
   if (state.value.phase !== "incoming") return;
-  if (accepting.value || declining.value) return;
+  if (controlsDisabled.value) return;
   const { from, sid } = state.value;
   const sender = getSender();
   declining.value = true;
@@ -116,7 +122,7 @@ async function decline(): Promise<void> {
       <button
         class="chat-action-button chat-action-button--secondary"
         type="button"
-        :disabled="accepting || declining"
+        :disabled="controlsDisabled"
         @click="decline"
       >
         <PhoneOff class="w-4 h-4" />
@@ -125,11 +131,11 @@ async function decline(): Promise<void> {
       <button
         class="chat-action-button chat-action-button--primary"
         type="button"
-        :disabled="accepting || declining"
+        :disabled="controlsDisabled"
         @click="accept"
       >
         <Phone class="w-4 h-4" />
-        <span class="type-control">{{ accepting ? "Connecting…" : "Accept" }}</span>
+        <span class="type-control">{{ controlsDisabled && !declining ? "Connecting…" : "Accept" }}</span>
       </button>
     </div>
   </div>

--- a/chat/src/components/chat/ChatHeader.vue
+++ b/chat/src/components/chat/ChatHeader.vue
@@ -5,7 +5,7 @@ import AppAvatar from "@/components/ui/AppAvatar.vue";
 import CallButton from "@/components/calls/CallButton.vue";
 import MucCallButton from "@/components/calls/MucCallButton.vue";
 import NotifyModeButton from "@/components/chat/NotifyModeButton.vue";
-import { useDmCallActivity } from "@/lib/calls/dm-call-activity";
+import { hasKnownDmCallMedia, useDmCallActivity } from "@/lib/calls/dm-call-activity";
 import type { ChannelSummary, SpaceSummary } from "@/lib/chat-types";
 import type { ConnectionNoticeCopy } from "@/lib/connection-notice";
 import type { BrowserXmppClient } from "@/lib/xmpp-client";
@@ -81,10 +81,16 @@ const { activity: dmCallActivity } = useDmCallActivity(() => props.dmPeer?.peerJ
 const dmCallActivityLabel = computed(() => {
   const activity = dmCallActivity.value;
   if (!activity) return "";
+  if (!hasKnownDmCallMedia(activity)) {
+    if (activity.state === "accepted") return "Call active";
+    if (activity.direction === "incoming") return "Incoming call";
+    if (activity.direction === "outgoing") return "Calling";
+    return "Call ringing";
+  }
   const media = activity.media.video ? "Video" : "Voice";
   if (activity.state === "accepted") return `${media} call active`;
   if (activity.direction === "incoming") return `Incoming ${media.toLowerCase()} call`;
-  if (activity.direction === "outgoing") return `${media} call calling`;
+  if (activity.direction === "outgoing") return `Calling ${media.toLowerCase()} call`;
   return `${media} call ringing`;
 });
 

--- a/chat/src/components/chat/ChatMobileDrawers.vue
+++ b/chat/src/components/chat/ChatMobileDrawers.vue
@@ -21,6 +21,8 @@ import type { ChatAppController } from "@/shell/chat-app-controller";
 const props = defineProps<{
   controller: ChatAppController;
   joinChannelCall?: (channelId: string | null, roomJid: string, media: CallMedia) => void;
+  answerDm?: (peerJid: string, remoteFullJid: string, sid: string, media: CallMedia) => void;
+  reconnectDm?: (peerJid: string, media: CallMedia) => void;
 }>();
 
 const {
@@ -74,6 +76,14 @@ function selectChannelFromMobile(id: string | null, roomJid?: string) {
 
 function joinChannelCallFromMobile(channelId: string | null, roomJid: string, media: CallMedia) {
   props.joinChannelCall?.(channelId, roomJid, media);
+}
+
+function answerDmFromMobile(peerJid: string, remoteFullJid: string, sid: string, media: CallMedia) {
+  props.answerDm?.(peerJid, remoteFullJid, sid, media);
+}
+
+function reconnectDmFromMobile(peerJid: string, media: CallMedia) {
+  props.reconnectDm?.(peerJid, media);
 }
 
 // XEP-0272 Muji participant counts keyed by room JID — same derived
@@ -176,7 +186,9 @@ function openExtensionRoute(route: DiscoveredExtensionRoute) {
           :conversations="dmConversations.conversations.value"
           :active-peer-jid="dmConversations.activePeerJid.value"
           class="!w-full !border-r-0 !flex-1"
+          @answer-dm="answerDmFromMobile"
           @select-dm="selectDm"
+          @reconnect-dm="reconnectDmFromMobile"
           @new-dm="ui.showNewDm.value = true"
         />
         <ProfilePanel

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -6,7 +6,7 @@ import {
   mucCallParticipantCounts,
 } from "@/lib/calls/muc-call-presence";
 import { $dmCallActivities } from "@/lib/calls/dm-call-activity";
-import { startDmCallAction } from "@/lib/calls/dm-call-actions";
+import { answerIncomingDmCallActivity, startDmCallAction } from "@/lib/calls/dm-call-actions";
 import { startMucCallAction } from "@/lib/calls/muc-call-actions";
 import { normalizeMucServiceDomain } from "@/lib/calls/muc-call-indicators";
 import {
@@ -273,6 +273,17 @@ function reconnectDmFromDock(peerJid: string, media: CallMedia): void {
   });
 }
 
+function answerDmFromActivity(peerJid: string, remoteFullJid: string, sid: string, media: CallMedia): void {
+  selectDm(peerJid);
+  void answerIncomingDmCallActivity({
+    peerBareJid: peerJid,
+    proposerFullJid: remoteFullJid,
+    sid,
+    media,
+    getSender: getCallSender,
+  });
+}
+
 function joinChannelCallFromActivity(channelId: string | null, roomJid: string, media: CallMedia): void {
   ui.activeCommunitySurface.value = null;
   if (channelId) {
@@ -337,6 +348,8 @@ onUnmounted(() => {
     <ChatMobileDrawers
       :controller="controller"
       :join-channel-call="joinChannelCallFromActivity"
+      :answer-dm="answerDmFromActivity"
+      :reconnect-dm="reconnectDmFromDock"
     />
     <CallActivityDock
       class="call-activity-dock--mobile"
@@ -350,6 +363,7 @@ onUnmounted(() => {
       :managed-muc-domain="managedMucDomain"
       @select-channel="onSelectChannelFromSidebar"
       @join-channel-call="joinChannelCallFromActivity"
+      @answer-dm="answerDmFromActivity"
       @select-dm="selectDm"
       @reconnect-dm="reconnectDmFromDock"
     />
@@ -422,7 +436,9 @@ onUnmounted(() => {
           v-else
           :conversations="dmConversations.conversations.value"
           :active-peer-jid="dmConversations.activePeerJid.value"
+          @answer-dm="answerDmFromActivity"
           @select-dm="selectDm"
+          @reconnect-dm="reconnectDmFromDock"
           @new-dm="ui.showNewDm.value = true"
         />
         <CallActivityDock
@@ -434,8 +450,10 @@ onUnmounted(() => {
           :sidebar-mode="ui.sidebarMode.value"
           :active-channel-jids="messaging.activeChannels.value"
           :managed-muc-domain="managedMucDomain"
+          :show-dm-calls="ui.sidebarMode.value !== 'dms'"
           @select-channel="onSelectChannelFromSidebar"
           @join-channel-call="joinChannelCallFromActivity"
+          @answer-dm="answerDmFromActivity"
           @select-dm="selectDm"
           @reconnect-dm="reconnectDmFromDock"
         />
@@ -448,6 +466,7 @@ onUnmounted(() => {
         @select-channel="(id: string, roomJid?: string) => selectChannel(id, roomJid ? { roomJid } : undefined)"
         @select-channel-room="selectChannelByRoomJid"
         @join-channel-call="joinChannelCallFromActivity"
+        @answer-dm="answerDmFromActivity"
         @select-contact="handleOpenDm"
         @reconnect-dm="reconnectDmFromDock"
         @open-nav="ui.showMobileNav.value = true"

--- a/chat/src/components/chat/DmPanel.vue
+++ b/chat/src/components/chat/DmPanel.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { useStore } from "@nanostores/vue";
-import { MessageCircle, PhoneCall, Plus } from "lucide-vue-next";
+import { ArrowRight, MessageCircle, Phone, PhoneCall, PhoneIncoming, PhoneOutgoing, Plus, Video } from "lucide-vue-next";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import { formatTimelineStamp } from "@/channels/timeline";
-import { $dmCallActivities } from "@/lib/calls/dm-call-activity";
+import { $callState } from "@/lib/calls/call-store";
+import { dmCallActivityAction } from "@/lib/calls/call-activity-dock";
+import { $dmCallActivities, hasKnownDmCallMedia } from "@/lib/calls/dm-call-activity";
 import type { DmCallActivity } from "@/lib/calls/dm-call-activity";
+import type { CallMedia } from "@/lib/calls/types";
 import { barePeerJid } from "@/lib/xmpp/jid";
 import type { DmConversation } from "@/lib/xmpp-client";
 
@@ -15,25 +18,37 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
+  answerDm: [peerJid: string, remoteFullJid: string, sid: string, media: CallMedia];
   selectDm: [peerJid: string];
+  reconnectDm: [peerJid: string, media: CallMedia];
   newDm: [];
 }>();
 
 const dmCallActivities = useStore($dmCallActivities);
+const callState = useStore($callState);
 const activePeer = computed(() => normalizedPeerJid(props.activePeerJid ?? ""));
+const activeCallRows = computed(() =>
+  Object.values(dmCallActivities.value)
+    .map((activity) => ({
+      activity,
+      peerJid: normalizedPeerJid(activity.peerJid),
+      title: callActivityTitle(activity),
+      meta: callActivityMeta(activity),
+      action: callActivityActionLabel(activity),
+    }))
+    .filter((row) => row.peerJid)
+    .sort((left, right) => {
+      const rightMs = timestampMs(right.activity.updatedAt);
+      const leftMs = timestampMs(left.activity.updatedAt);
+      if (rightMs !== leftMs) return rightMs - leftMs;
+      return left.peerJid.localeCompare(right.peerJid);
+    }),
+);
 const visibleConversations = computed<DmConversation[]>(() => {
-  const seen = new Set<string>();
-  for (const conversation of props.conversations) {
-    const peer = normalizedPeerJid(conversation.peerJid);
-    if (peer) seen.add(peer);
-  }
-  const callOnlyRows = Object.values(dmCallActivities.value)
-    .filter((activity) => {
-      const peer = normalizedPeerJid(activity.peerJid);
-      return !!peer && !seen.has(peer);
-    })
-    .map(callActivityConversation);
-  return [...props.conversations, ...callOnlyRows].sort(compareDmConversations);
+  const activeCallPeers = new Set(activeCallRows.value.map((row) => row.peerJid));
+  return props.conversations
+    .filter((conversation) => !activeCallPeers.has(normalizedPeerJid(conversation.peerJid)))
+    .sort(compareDmConversations);
 });
 
 function normalizedPeerJid(peerJid: string): string {
@@ -85,28 +100,80 @@ function callActivityLabel(peerJid: string): string {
   return activity?.state === "ringing" ? "Ringing" : "Live";
 }
 
-function callActivityDescription(activity: DmCallActivity): string {
-  const media = activity.media.video ? "Video" : "Voice";
-  if (activity.state === "accepted") return `${media} call live`;
-  if (activity.direction === "incoming") return `Incoming ${media.toLowerCase()} call`;
-  if (activity.direction === "outgoing") return `Calling ${media.toLowerCase()} call`;
-  return `${media} call ringing`;
+function callActivityTitle(activity: DmCallActivity): string {
+  const peerJid = normalizedPeerJid(activity.peerJid);
+  const existing = props.conversations.find((conversation) =>
+    normalizedPeerJid(conversation.peerJid) === peerJid
+  );
+  return existing?.peerUsername || peerJid.split("@")[0] || peerJid;
 }
 
-function callActivityConversation(activity: DmCallActivity): DmConversation {
+function callActivityMeta(activity: DmCallActivity): string {
+  if (!hasKnownDmCallMedia(activity)) {
+    if (activity.state === "accepted") return "Live call";
+    if (activity.direction === "incoming") return "Incoming call";
+    if (activity.direction === "outgoing") return "Calling";
+    return "Call ringing";
+  }
+  const media = activity.media.video ? "video" : "voice";
+  if (activity.state === "accepted") return `Live ${media} call`;
+  if (activity.direction === "incoming") return `Incoming ${media} call`;
+  if (activity.direction === "outgoing") return `Calling ${media} call`;
+  return `${media[0]?.toUpperCase() ?? "V"}${media.slice(1)} call ringing`;
+}
+
+function callActivityActionLabel(activity: DmCallActivity): string {
+  switch (dmCallActivityAction(activity, callState.value)) {
+    case "answer":
+      return "Answer";
+    case "reconnect":
+      return "Reconnect";
+    case "return":
+      return "Return";
+    case "open":
+      return "Open";
+  }
+}
+
+function selectCallActivity(activity: DmCallActivity): void {
   const peerJid = normalizedPeerJid(activity.peerJid);
-  return {
-    peerJid,
-    peerUsername: peerJid.split("@")[0] || peerJid,
-    lastMessageBody: callActivityDescription(activity),
-    lastMessageAt: activity.updatedAt,
-    unreadCount: 0,
-  };
+  if (!peerJid) return;
+  switch (dmCallActivityAction(activity, callState.value)) {
+    case "answer":
+      if (activity.remoteFullJid) {
+        emit("answerDm", peerJid, activity.remoteFullJid, activity.sid, activity.media);
+      }
+      return;
+    case "reconnect":
+      emit("reconnectDm", peerJid, activity.media);
+      return;
+    case "open":
+    case "return":
+      emit("selectDm", peerJid);
+      return;
+  }
 }
 
 function isActiveConversation(peerJid: string): boolean {
   const peer = normalizedPeerJid(peerJid);
   return !!peer && activePeer.value === peer;
+}
+
+function conversationRowLabel(conversation: DmConversation): string {
+  const parts = [
+    conversation.peerUsername,
+    isActiveConversation(conversation.peerJid) ? "selected" : "not selected",
+  ];
+  const activity = callActivity(conversation.peerJid);
+  if (activity) {
+    parts.push(callActivityMeta(activity), `${callActivityActionLabel(activity)} call`);
+  } else if (conversation.lastMessageBody) {
+    parts.push(preview(conversation.lastMessageBody));
+  }
+  if (conversation.unreadCount > 0) {
+    parts.push(`${conversation.unreadCount} unread`);
+  }
+  return parts.join(", ");
 }
 </script>
 
@@ -132,7 +199,7 @@ function isActiveConversation(peerJid: string): boolean {
       <!-- Empty state — halo + MessageCircle glyph + caption + hint
            matches the iter-37 / 47 / 48 authored-empty-state pattern
            used elsewhere in the app. -->
-      <div v-if="visibleConversations.length === 0" class="flex flex-col items-center justify-center gap-2 py-10 text-center">
+      <div v-if="visibleConversations.length === 0 && activeCallRows.length === 0" class="flex flex-col items-center justify-center gap-2 py-10 text-center">
         <div class="chat-empty-state__halo">
           <span class="chat-empty-state__halo-glow chat-empty-state__halo-glow--primary" aria-hidden="true" />
           <span class="chat-empty-state__halo-ring chat-empty-state__halo-ring--primary">
@@ -146,6 +213,55 @@ function isActiveConversation(peerJid: string): boolean {
       </div>
 
       <div v-else class="chat-list-stack">
+        <section
+          v-if="activeCallRows.length > 0"
+          class="grid gap-1"
+          aria-label="Active direct calls"
+        >
+          <div class="type-section-label flex items-center gap-1.5 px-2 pt-2 pb-1 text-sidebar-muted">
+            <PhoneCall class="h-3 w-3 text-success" aria-hidden="true" />
+            <span class="flex-1 truncate">Active calls</span>
+            <span
+              class="type-count-badge inline-flex min-w-[18px] h-[18px] px-1 items-center justify-center rounded-full bg-success/15 text-success ring-1 ring-success/30"
+              aria-hidden="true"
+            >
+              {{ activeCallRows.length }}
+            </span>
+          </div>
+          <button
+            v-for="row in activeCallRows"
+            :key="`dm-call:${row.peerJid}:${row.activity.sid}`"
+            class="chat-list-row w-full min-h-11 flex items-center gap-2.5 px-3 py-2 text-left group text-sidebar-muted hover:bg-sidebar-accent/50 hover:text-sidebar-foreground"
+            :class="isActiveConversation(row.peerJid) ? 'chat-list-row--active bg-sidebar-accent text-sidebar-foreground' : ''"
+            type="button"
+            :aria-current="isActiveConversation(row.peerJid) ? 'page' : undefined"
+            :aria-label="`${row.action} ${row.title} call, ${row.meta}`"
+            @click="selectCallActivity(row.activity)"
+          >
+            <span class="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md bg-success/10 text-success">
+              <Video v-if="hasKnownDmCallMedia(row.activity) && row.activity.media.video" class="h-3.5 w-3.5" aria-hidden="true" />
+              <PhoneIncoming v-else-if="row.activity.state === 'ringing' && row.activity.direction === 'incoming'" class="h-3.5 w-3.5" aria-hidden="true" />
+              <PhoneOutgoing v-else-if="row.activity.state === 'ringing' && row.activity.direction === 'outgoing'" class="h-3.5 w-3.5" aria-hidden="true" />
+              <Phone v-else class="h-3.5 w-3.5" aria-hidden="true" />
+            </span>
+            <span class="min-w-0 flex-1">
+              <span class="type-control type-strong block truncate text-sidebar-foreground">
+                {{ row.title }}
+              </span>
+              <span class="type-meta block truncate text-sidebar-muted">
+                {{ row.meta }}
+              </span>
+            </span>
+            <span
+              class="type-meta hidden shrink-0 rounded-md border border-success/25 bg-success/10 px-1.5 py-0.5 text-success xl:inline-flex"
+              aria-hidden="true"
+            >
+              {{ row.action }}
+            </span>
+            <ArrowRight class="h-3.5 w-3.5 shrink-0 text-success" aria-hidden="true" />
+          </button>
+        </section>
+
         <button
           v-for="conversation in visibleConversations"
           :key="conversation.peerJid"
@@ -154,6 +270,7 @@ function isActiveConversation(peerJid: string): boolean {
             ? 'chat-list-row--active bg-sidebar-accent text-sidebar-foreground'
             : 'text-sidebar-muted hover:bg-sidebar-accent/50 hover:text-sidebar-foreground'"
           :aria-current="isActiveConversation(conversation.peerJid) ? 'page' : undefined"
+          :aria-label="conversationRowLabel(conversation)"
           type="button"
           @click="emit('selectDm', conversation.peerJid)"
         >

--- a/chat/src/components/chat/HomeDashboard.vue
+++ b/chat/src/components/chat/HomeDashboard.vue
@@ -25,6 +25,7 @@ import {
   type CallActivityDockEntry,
 } from "@/lib/calls/call-activity-dock";
 import { $callState } from "@/lib/calls/call-store";
+import { hasKnownDmCallMedia } from "@/lib/calls/dm-call-activity";
 import { callParticipantCountForChannel } from "@/lib/calls/muc-call-indicators";
 import { barePeerJid } from "@/lib/xmpp/jid";
 import type { CallMedia } from "@/lib/calls/types";
@@ -51,6 +52,7 @@ const emit = defineEmits<{
   selectChannel: [id: string, roomJid?: string];
   selectChannelRoom: [roomJid: string];
   joinChannelCall: [channelId: string | null, roomJid: string, media: CallMedia];
+  answerDm: [peerJid: string, remoteFullJid: string, sid: string, media: CallMedia];
   selectContact: [jid: string];
   reconnectDm: [peerJid: string, media: CallMedia];
   openNav: [];
@@ -112,16 +114,23 @@ interface HeroSummaryPart {
 const groups = computed(() => groupChannelsBySpace(props.spaces, props.channels));
 const visibleChannelGroups = computed(() => groups.value.filter((group) => group.channels.length > 0));
 const activeChannelJids = computed(() => props.activeChannelJids ?? new Set<string>());
-const directMessages = computed(() => props.dmConversations ?? []);
 const callParticipantCounts = computed(() => props.callParticipantCounts ?? {});
 const dmCallActivities = computed(() => props.dmCallActivities ?? {});
+const activeDmCallPeers = computed(() =>
+  new Set(Object.values(dmCallActivities.value).map((activity) => barePeerJid(activity.peerJid).toLowerCase()).filter(Boolean)),
+);
+const directMessages = computed(() =>
+  (props.dmConversations ?? []).filter((conversation) =>
+    !activeDmCallPeers.value.has(barePeerJid(conversation.peerJid).toLowerCase())
+  ),
+);
 const callState = useStore($callState);
 const channelsBySpace = computed(() =>
   new Map(groups.value.flatMap((group) => group.space ? [[group.space.id, group.channels.length] as const] : [])),
 );
 const activeCallEntries = computed<CallActivityDockEntry[]>(() => buildCallActivityDockEntries({
   channels: props.channels,
-  conversations: directMessages.value,
+  conversations: props.dmConversations ?? [],
   activeChannelId: null,
   activeChannelRoomJid: null,
   activePeerJid: null,
@@ -156,6 +165,9 @@ function selectSpaceChannel(spaceId: string) {
 function selectCallEntry(entry: CallActivityDockEntry) {
   const selection = callActivityDockSelection(entry, callState.value);
   switch (selection.kind) {
+    case "dm-answer":
+      emit("answerDm", selection.peerJid, selection.remoteFullJid, selection.sid, selection.media);
+      return;
     case "channel-join":
       emit("joinChannelCall", selection.channelId, selection.roomJid, selection.media);
       return;
@@ -275,10 +287,16 @@ function dmSecondaryText(conversation: { peerUsername?: string; peerJid: string;
 function dmCallLabel(peerJid: string): string {
   const activity = dmCallActivityFor(peerJid);
   if (!activity) return "";
+  if (!hasKnownDmCallMedia(activity)) {
+    if (activity.state === "accepted") return "Call live";
+    if (activity.direction === "incoming") return "Incoming call";
+    if (activity.direction === "outgoing") return "Calling";
+    return "Call ringing";
+  }
   const media = activity.media.video ? "Video" : "Voice";
   if (activity.state === "accepted") return `${media} call live`;
   if (activity.direction === "incoming") return `Incoming ${media.toLowerCase()} call`;
-  if (activity.direction === "outgoing") return `${media} call calling`;
+  if (activity.direction === "outgoing") return `Calling ${media.toLowerCase()} call`;
   return `${media} call ringing`;
 }
 
@@ -318,6 +336,7 @@ function callEntryStatus(entry: CallActivityDockEntry): string {
 
 function callEntryKindLabel(entry: CallActivityDockEntry): string {
   if (entry.kind === "channel") return entry.isKnownChannel ? "Group call" : "Group call syncing";
+  if (entry.mediaKnown === false) return "Call";
   return entry.media.video ? "Video call" : "Voice call";
 }
 
@@ -328,6 +347,8 @@ function callEntryLabel(entry: CallActivityDockEntry): string {
 
 function callEntryActionLabel(entry: CallActivityDockEntry): string {
   switch (callActivityDockAction(entry, callState.value)) {
+    case "answer":
+      return "Answer";
     case "join":
       return "Join";
     case "return":
@@ -494,7 +515,7 @@ function onHeroCta() {
           >
             <span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-success/10 text-success">
               <Hash v-if="entry.kind === 'channel'" class="h-4 w-4" />
-              <Video v-else-if="entry.media.video" class="h-4 w-4" />
+              <Video v-else-if="entry.mediaKnown !== false && entry.media.video" class="h-4 w-4" />
               <PhoneIncoming v-else-if="entry.state === 'ringing' && entry.direction === 'incoming'" class="h-4 w-4" />
               <PhoneOutgoing v-else-if="entry.state === 'ringing' && entry.direction === 'outgoing'" class="h-4 w-4" />
               <Phone v-else class="h-4 w-4" />

--- a/chat/src/lib/calls/call-activity-dock.ts
+++ b/chat/src/lib/calls/call-activity-dock.ts
@@ -8,7 +8,7 @@ import {
   refreshedMucCallRooms,
 } from "./muc-call-indicators";
 import { normalizeMucCallRoomJid } from "./muc-call-presence";
-import type { DmCallActivity } from "./dm-call-activity";
+import { hasKnownDmCallMedia, type DmCallActivity } from "./dm-call-activity";
 
 export type SidebarMode = "channels" | "dms";
 
@@ -27,8 +27,11 @@ export type CallActivityDockEntry =
       kind: "dm";
       key: string;
       peerJid: string;
+      sid: string;
+      remoteFullJid?: string;
       title: string;
       media: DmCallActivity["media"];
+      mediaKnown?: boolean;
       state: DmCallActivity["state"];
       direction: DmCallActivity["direction"];
       updatedAt: string;
@@ -36,11 +39,12 @@ export type CallActivityDockEntry =
   };
 type DmCallActivityDockEntry = Extract<CallActivityDockEntry, { kind: "dm" }>;
 
-type CallActivityDockAction = "open" | "join" | "return" | "reconnect";
+type CallActivityDockAction = "answer" | "open" | "join" | "return" | "reconnect";
 
 type CallActivityDockSelection =
   | { kind: "channel"; channelId: string | null; roomJid: string }
   | { kind: "channel-join"; channelId: string | null; roomJid: string; media: CallMedia }
+  | { kind: "dm-answer"; peerJid: string; remoteFullJid: string; sid: string; media: DmCallActivity["media"] }
   | { kind: "dm-open"; peerJid: string }
   | { kind: "dm-reconnect"; peerJid: string; media: DmCallActivity["media"] };
 
@@ -50,8 +54,37 @@ function activeMucCallRoomJid(state: CallState): string {
   return normalizeMucCallRoomJid(state.peer);
 }
 
+function activeDmCallPeerJid(state: CallState): string {
+  if (state.phase === "active" && state.kind === "dm") {
+    return barePeerJid(state.peer).toLowerCase();
+  }
+  if (state.phase === "incoming") {
+    return barePeerJid(state.from).toLowerCase();
+  }
+  if (state.phase === "outgoing") {
+    return barePeerJid(state.to).toLowerCase();
+  }
+  return "";
+}
+
 function isBusy(state: CallState): boolean {
   return state.phase !== "idle" && state.phase !== "ended";
+}
+
+export function dmCallActivityAction(
+  activity: Pick<DmCallActivity, "peerJid" | "remoteFullJid" | "mediaKnown" | "state" | "direction">,
+  callState: CallState,
+): Extract<CallActivityDockAction, "answer" | "open" | "return" | "reconnect"> {
+  const peerJid = barePeerJid(activity.peerJid).toLowerCase();
+  if (peerJid && activeDmCallPeerJid(callState) === peerJid) return "return";
+  if (
+    activity.state === "ringing" &&
+    activity.direction === "incoming" &&
+    activity.remoteFullJid &&
+    !isBusy(callState)
+  ) return "answer";
+  if (activity.state === "accepted" && hasKnownDmCallMedia(activity) && !isBusy(callState)) return "reconnect";
+  return "open";
 }
 
 export function callActivityDockAction(
@@ -59,7 +92,7 @@ export function callActivityDockAction(
   callState: CallState,
 ): CallActivityDockAction {
   if (entry.kind === "dm") {
-    return entry.state === "accepted" ? "reconnect" : "open";
+    return dmCallActivityAction(entry, callState);
   }
 
   const roomJid = normalizeMucCallRoomJid(entry.roomJid);
@@ -87,7 +120,17 @@ export function callActivityDockSelection(
       roomJid: entry.roomJid,
     };
   }
-  if (entry.state === "accepted") {
+  const action = callActivityDockAction(entry, callState);
+  if (action === "answer" && entry.remoteFullJid) {
+    return {
+      kind: "dm-answer",
+      peerJid: entry.peerJid,
+      remoteFullJid: entry.remoteFullJid,
+      sid: entry.sid,
+      media: entry.media,
+    };
+  }
+  if (action === "reconnect") {
     return {
       kind: "dm-reconnect",
       peerJid: entry.peerJid,
@@ -170,8 +213,11 @@ export function buildCallActivityDockEntries(options: {
         kind: "dm",
         key: `dm:${peerJid}:${activity.sid}`,
         peerJid,
+        sid: activity.sid,
+        ...(activity.remoteFullJid ? { remoteFullJid: activity.remoteFullJid } : {}),
         title: conversationNames.get(peerJid) ?? fallbackName,
         media: activity.media,
+        ...(hasKnownDmCallMedia(activity) ? {} : { mediaKnown: false }),
         state: activity.state,
         direction: activity.direction,
         updatedAt: activity.updatedAt,

--- a/chat/src/lib/calls/dm-call-actions.ts
+++ b/chat/src/lib/calls/dm-call-actions.ts
@@ -1,16 +1,18 @@
 import {
   $callState,
+  acceptIncomingTieBreakPropose,
   beginOutgoingCall,
   reportCallError,
   scheduleOutgoingTimeout,
 } from "./call-store";
-import { clearDmCallActivity } from "./dm-call-activity";
+import { clearDmCallActivity, readDmCallActivity } from "./dm-call-activity";
 import {
   newCallSid,
   outboundCalls,
   type CallWireSender,
 } from "./outbound";
 import type { CallMedia } from "./types";
+import { barePeerJid } from "../xmpp/jid";
 
 export async function startDmCallAction(options: {
   peerBareJid: string;
@@ -41,6 +43,66 @@ export async function startDmCallAction(options: {
       $callState.set({ phase: "idle" });
     }
     clearDmCallActivity(options.peerBareJid, sid);
+    reportCallError(err);
+  }
+}
+
+export async function answerIncomingDmCallActivity(options: {
+  peerBareJid: string;
+  proposerFullJid: string;
+  sid: string;
+  media: CallMedia;
+  getSender: () => CallWireSender | null;
+}): Promise<void> {
+  const peer = barePeerJid(options.peerBareJid).toLowerCase();
+  const proposer = options.proposerFullJid.trim();
+  if (!peer || barePeerJid(proposer).toLowerCase() !== peer) return;
+
+  const sender = options.getSender();
+  if (!sender) return;
+
+  const current = $callState.get();
+  const canUseCurrentIncoming = current.phase === "incoming" &&
+    current.sid === options.sid &&
+    barePeerJid(current.from).toLowerCase() === peer;
+  const needsHydratedIncoming = current.phase === "idle" || current.phase === "ended";
+  if (!canUseCurrentIncoming && !needsHydratedIncoming) return;
+  const activity = needsHydratedIncoming ? readDmCallActivity(peer) : null;
+  if (needsHydratedIncoming && (
+    !activity ||
+    activity.sid !== options.sid ||
+    activity.state !== "ringing" ||
+    activity.direction !== "incoming" ||
+    !activity.remoteFullJid
+  )) return;
+  const responseTarget = canUseCurrentIncoming ? current.from : activity?.remoteFullJid ?? proposer;
+
+  if (needsHydratedIncoming) {
+    acceptIncomingTieBreakPropose({
+      kind: "propose",
+      from: responseTarget,
+      sid: options.sid,
+      media: activity?.media ?? options.media,
+    });
+  } else if (canUseCurrentIncoming) {
+    $callState.set({ ...current, accepting: true });
+  }
+  if (needsHydratedIncoming) {
+    const next = $callState.get();
+    if (next.phase === "incoming" && next.sid === options.sid) {
+      $callState.set({ ...next, accepting: true });
+    }
+  }
+
+  try {
+    await outboundCalls.proceed(sender, responseTarget, options.sid);
+  } catch (err) {
+    const next = $callState.get();
+    if (needsHydratedIncoming && next.phase === "incoming" && next.sid === options.sid) {
+      $callState.set({ phase: "idle" });
+    } else if (canUseCurrentIncoming && next.phase === "incoming" && next.sid === options.sid) {
+      $callState.set({ ...next, accepting: false });
+    }
     reportCallError(err);
   }
 }

--- a/chat/src/lib/calls/dm-call-activity.ts
+++ b/chat/src/lib/calls/dm-call-activity.ts
@@ -12,8 +12,12 @@ type DmCallActivityState = "ringing" | "accepted";
 
 export interface DmCallActivity {
   peerJid: string;
+  /** Full JID used for XEP-0353 responses when an incoming proposal
+   * is restored from MAM after refresh. */
+  remoteFullJid?: string;
   sid: string;
   media: CallMedia;
+  mediaKnown?: boolean;
   state: DmCallActivityState;
   direction: "incoming" | "outgoing" | "unknown";
   updatedAt: string;
@@ -36,9 +40,19 @@ function normalizedBare(jid?: string | null): string {
   return barePeerJid(jid ?? "").toLowerCase();
 }
 
-function eventMedia(event: CallEvent, previous?: DmCallActivity): CallMedia {
-  if ("media" in event) return event.media;
-  return previous?.media ?? { audio: true, video: false };
+export function hasKnownDmCallMedia(
+  activity: Pick<DmCallActivity, "mediaKnown">,
+): boolean {
+  return activity.mediaKnown !== false;
+}
+
+function eventMedia(
+  event: CallEvent,
+  previous?: DmCallActivity,
+): { media: CallMedia; known: boolean } {
+  if ("media" in event) return { media: event.media, known: true };
+  if (previous) return { media: previous.media, known: hasKnownDmCallMedia(previous) };
+  return { media: { audio: true, video: false }, known: false };
 }
 
 function timestampFromEnvelope(envelope: DmCallEventEnvelope): string {
@@ -171,6 +185,21 @@ function directionForEnvelope(envelope: DmCallEventEnvelope): DmCallActivity["di
   return fromBare === selfBare ? "outgoing" : "incoming";
 }
 
+function remoteFullJidForEnvelope(
+  envelope: DmCallEventEnvelope,
+  peerJid: string,
+): string | undefined {
+  const candidates = [
+    envelope.event.from,
+    envelope.to ?? envelope.event.to,
+  ];
+  for (const candidate of candidates) {
+    if (!candidate || !candidate.includes("/")) continue;
+    if (normalizedBare(candidate) === peerJid) return candidate;
+  }
+  return undefined;
+}
+
 function removeActivity(peerJid: string, sid: string): void {
   const current = $dmCallActivities.get()[peerJid];
   if (!current || current.sid !== sid) return;
@@ -206,14 +235,17 @@ export function applyDmCallEvent(envelope: DmCallEventEnvelope): void {
   const previous = $dmCallActivities.get()[peerJid];
   if (isOlderThanCurrent(timestamp, previous)) return;
   if (!isTerminalEvent(envelope.event) && isOlderThanTerminal(peerJid, envelope.event.sid, timestamp)) return;
+  const direction = directionForEnvelope(envelope);
+  const remoteFullJid = remoteFullJidForEnvelope(envelope, peerJid);
   switch (envelope.event.kind) {
     case "propose":
       $dmCallActivities.setKey(peerJid, {
         peerJid,
+        ...(remoteFullJid ? { remoteFullJid } : {}),
         sid: envelope.event.sid,
         media: envelope.event.media,
         state: "ringing",
-        direction: directionForEnvelope(envelope),
+        direction,
         updatedAt: timestamp,
       });
       scheduleActivityPrune(now);
@@ -221,12 +253,17 @@ export function applyDmCallEvent(envelope: DmCallEventEnvelope): void {
     case "proceed":
     case "session-initiate":
     case "session-accept":
+      const media = eventMedia(envelope.event, previous);
       $dmCallActivities.setKey(peerJid, {
         peerJid,
+        ...(previous?.remoteFullJid || remoteFullJid
+          ? { remoteFullJid: previous?.remoteFullJid ?? remoteFullJid }
+          : {}),
         sid: envelope.event.sid,
-        media: eventMedia(envelope.event, previous),
+        media: media.media,
+        ...(media.known ? {} : { mediaKnown: false }),
         state: "accepted",
-        direction: previous?.direction ?? directionForEnvelope(envelope),
+        direction: previous?.direction ?? direction,
         updatedAt: timestamp,
       });
       scheduleActivityPrune(now);

--- a/chat/src/lib/calls/types.ts
+++ b/chat/src/lib/calls/types.ts
@@ -50,7 +50,7 @@ export type CallEvent =
  */
 export type CallState =
   | { phase: "idle" }
-  | { phase: "incoming"; from: string; sid: string; media: CallMedia }
+  | { phase: "incoming"; from: string; sid: string; media: CallMedia; accepting?: boolean }
   | { phase: "outgoing"; to: string; sid: string; media: CallMedia; initiator?: string }
   | {
       phase: "muc-pending";

--- a/chat/tests/call-activity-dock.test.ts
+++ b/chat/tests/call-activity-dock.test.ts
@@ -74,6 +74,7 @@ describe("call activity dock model", () => {
         kind: "dm",
         key: "dm:bob@example.com:dm-call-1",
         peerJid: "bob@example.com",
+        sid: "dm-call-1",
         title: "Bob",
         media: { audio: true, video: true },
         state: "accepted",
@@ -202,6 +203,31 @@ describe("call activity dock model", () => {
       channelId: "general",
       roomJid: "general@conference.example.com",
     });
+    expect(callActivityDockAction(entries[1], {
+      phase: "active",
+      kind: "dm",
+      peer: "bob@example.com/desktop",
+      sid: "live",
+      media: { audio: true, video: true },
+      join: { url: "wss://livekit.example.test", room: "dm", identity: "alice", token: "token" },
+    })).toBe("return");
+    expect(callActivityDockSelection(entries[1], {
+      phase: "active",
+      kind: "dm",
+      peer: "bob@example.com/desktop",
+      sid: "live",
+      media: { audio: true, video: true },
+      join: { url: "wss://livekit.example.test", room: "dm", identity: "alice", token: "token" },
+    })).toEqual({
+      kind: "dm-open",
+      peerJid: "bob@example.com",
+    });
+    expect(callActivityDockAction(entries[1], {
+      phase: "outgoing",
+      to: "dana@example.com",
+      sid: "other-call",
+      media: { audio: true, video: false },
+    })).toBe("open");
   });
 
   test("surfaces group calls while the channel directory is still loading", () => {
@@ -458,6 +484,37 @@ describe("CallActivityDock rendering", () => {
     expect(html).not.toContain("Answer");
   });
 
+  test("renders hydrated incoming 1:1 calls as answer affordances when the proposer full JID is known", async () => {
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com",
+        remoteFullJid: "bob@example.com/phone",
+        sid: "dm-call-1",
+        media: { audio: true, video: false },
+        state: "ringing",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:00:00.000Z",
+      },
+    });
+
+    const html = await renderCallActivityDock({
+      channels: [],
+      conversations: [
+        { peerJid: "bob@example.com", peerUsername: "Bob", unreadCount: 0 },
+      ],
+      activeChannelId: null,
+      activePeerJid: null,
+      sidebarMode: "dms",
+      activeChannelJids: new Set<string>(),
+    });
+
+    expect(html).toContain("Bob");
+    expect(html).toContain("Voice call");
+    expect(html).toContain("Ringing");
+    expect(html).toContain("Answer");
+    expect(html).toContain('aria-label="Answer Bob call, Ringing"');
+  });
+
   test("is mounted in the desktop sidebar and visible mobile shell", () => {
     const readyShell = readFileSync(new URL("../src/components/chat/ChatReadyShell.vue", import.meta.url), "utf8");
     const mobileDrawers = readFileSync(new URL("../src/components/chat/ChatMobileDrawers.vue", import.meta.url), "utf8");
@@ -466,16 +523,21 @@ describe("CallActivityDock rendering", () => {
     expect(readyShell.match(/<CallActivityDock/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
     expect(readyShell).toContain("class=\"call-activity-dock--mobile\"");
     expect(readyShell).toContain(":join-channel-call=\"joinChannelCallFromActivity\"");
+    expect(readyShell).toContain(":answer-dm=\"answerDmFromActivity\"");
+    expect(readyShell).toContain(":reconnect-dm=\"reconnectDmFromDock\"");
     expect(readyShell).toContain(":active-channel-call-count=\"activeChannelCallCount\"");
     expect(readyShell).toContain(":active-dm-call-count=\"activeDmCallCount\"");
     expect(readyShell).toContain(":call-participants=\"mucCallParticipantsStore\"");
     expect(readyShell).toContain("@select-channel=\"onSelectChannelFromSidebar\"");
     expect(readyShell).toContain("@join-channel-call=\"joinChannelCallFromActivity\"");
+    expect(readyShell).toContain("@answer-dm=\"answerDmFromActivity\"");
     expect(readyShell).toContain("@select-dm=\"selectDm\"");
     expect(readyShell).toContain("@reconnect-dm=\"reconnectDmFromDock\"");
 
     expect(mobileDrawers).not.toContain("CallActivityDock");
     expect(mobileDrawers).toContain("@join-channel-call=\"joinChannelCallFromMobile\"");
+    expect(mobileDrawers).toContain("@answer-dm=\"answerDmFromMobile\"");
+    expect(mobileDrawers).toContain("@reconnect-dm=\"reconnectDmFromMobile\"");
     expect(mobileDrawers).toContain(":active-channel-call-count=\"activeChannelCallCount\"");
     expect(mobileDrawers).toContain(":active-dm-call-count=\"activeDmCallCount\"");
     expect(mobileDrawers).toContain(":call-participants=\"mucCallParticipantsStore\"");
@@ -520,8 +582,10 @@ describe("CallActivityDock rendering", () => {
     });
 
     expect(html).not.toContain("No conversations yet");
+    expect(html).toContain("Active calls");
     expect(html).toContain("bob");
-    expect(html).toContain("Video call live");
+    expect(html).toContain("Live video call");
+    expect(html).toContain("Reconnect bob call, Live video call");
     expect(html).toContain("Live");
   });
 
@@ -548,9 +612,12 @@ describe("CallActivityDock rendering", () => {
       activePeerJid: "BOB@example.com/tablet",
     });
 
-    expect(html).toContain("Existing chat preview");
+    expect(html).toContain("Active calls");
+    expect(html).toContain("Bobby");
+    expect(html).toContain("Live video call");
     expect(html).toContain("Live");
     expect(html).toContain('aria-current="page"');
+    expect(html).not.toContain("Existing chat preview");
     expect(html).not.toContain("Video call live");
   });
 
@@ -572,8 +639,78 @@ describe("CallActivityDock rendering", () => {
     });
 
     expect(html).toContain("Calling voice call");
-    expect(html).toContain("Ringing");
+    expect(html).toContain("Open alice call, Calling voice call");
     expect(html).not.toContain("Voice call calling");
+  });
+
+  test("selects refreshed DM call rows as reconnect or return actions", async () => {
+    const activity: DmCallActivity = {
+      peerJid: "bob@example.com/phone",
+      sid: "dm-call-9",
+      media: { audio: true, video: true },
+      state: "accepted",
+      direction: "incoming",
+      updatedAt: "2026-05-25T12:00:00.000Z",
+    };
+    $dmCallActivities.set({ "bob@example.com": activity });
+    const emitted: unknown[][] = [];
+    const bindings = await setupVueComponent("../src/components/chat/DmPanel.vue", {
+      conversations: [],
+      activePeerJid: null,
+    }, (...args) => {
+      emitted.push(args);
+    });
+
+    setupBindingFunction(bindings, "selectCallActivity")(activity);
+    expect(emitted).toEqual([
+      ["reconnectDm", "bob@example.com", { audio: true, video: true }],
+    ]);
+
+    $callState.set({
+      phase: "active",
+      kind: "dm",
+      peer: "bob@example.com/laptop",
+      sid: "dm-call-9",
+      media: { audio: true, video: true },
+      join: { url: "wss://livekit.example.test", room: "dm", identity: "alice", token: "token" },
+    });
+    const activeEmitted: unknown[][] = [];
+    const activeBindings = await setupVueComponent("../src/components/chat/DmPanel.vue", {
+      conversations: [],
+      activePeerJid: "bob@example.com",
+    }, (...args) => {
+      activeEmitted.push(args);
+    });
+
+    setupBindingFunction(activeBindings, "selectCallActivity")(activity);
+    expect(activeEmitted).toEqual([
+      ["selectDm", "bob@example.com"],
+    ]);
+  });
+
+  test("selects hydrated incoming DM call rows as answer actions", async () => {
+    const activity: DmCallActivity = {
+      peerJid: "bob@example.com/phone",
+      remoteFullJid: "bob@example.com/phone",
+      sid: "dm-call-10",
+      media: { audio: true, video: false },
+      state: "ringing",
+      direction: "incoming",
+      updatedAt: "2026-05-25T12:00:00.000Z",
+    };
+    $dmCallActivities.set({ "bob@example.com": activity });
+    const emitted: unknown[][] = [];
+    const bindings = await setupVueComponent("../src/components/chat/DmPanel.vue", {
+      conversations: [],
+      activePeerJid: null,
+    }, (...args) => {
+      emitted.push(args);
+    });
+
+    setupBindingFunction(bindings, "selectCallActivity")(activity);
+    expect(emitted).toEqual([
+      ["answerDm", "bob@example.com", "bob@example.com/phone", "dm-call-10", { audio: true, video: false }],
+    ]);
   });
 
   test("orders refreshed call-only DMs with real conversations by recency", async () => {
@@ -607,14 +744,14 @@ describe("CallActivityDock rendering", () => {
       activePeerJid: null,
     });
 
-    const carolIndex = html.indexOf("Carol");
-    const bobIndex = html.indexOf("bob");
-    const aliceIndex = html.indexOf("alice");
-    expect(carolIndex).toBeGreaterThanOrEqual(0);
+    const bobIndex = html.indexOf("Live video call");
+    const aliceIndex = html.indexOf("Calling voice call", bobIndex);
+    const carolIndex = html.indexOf("Latest real conversation", aliceIndex);
     expect(bobIndex).toBeGreaterThanOrEqual(0);
     expect(aliceIndex).toBeGreaterThanOrEqual(0);
-    expect(carolIndex).toBeLessThan(bobIndex);
+    expect(carolIndex).toBeGreaterThanOrEqual(0);
     expect(bobIndex).toBeLessThan(aliceIndex);
+    expect(aliceIndex).toBeLessThan(carolIndex);
   });
 
   test("uses call activity recency when sorting an existing refreshed DM conversation", async () => {
@@ -654,7 +791,7 @@ describe("CallActivityDock rendering", () => {
     expect(bobbyIndex).toBeGreaterThanOrEqual(0);
     expect(carolIndex).toBeGreaterThanOrEqual(0);
     expect(bobbyIndex).toBeLessThan(carolIndex);
-    expect(html).toContain("Old message, active call");
+    expect(html).not.toContain("Old message, active call");
     expect(html).toContain("Live");
     expect(html).not.toContain("Video call live");
   });
@@ -737,7 +874,6 @@ describe("CallActivityDock rendering", () => {
     });
 
     expect(html).toContain("Video call ringing");
-    expect(html).toContain("Ringing");
   });
 
   test("renders sidebar channel rows as direct join affordances when idle", async () => {
@@ -1078,8 +1214,69 @@ describe("CallActivityDock rendering", () => {
     });
 
     expect(html).toContain("Video call live");
-    expect(html).toContain("Reconnect voice call");
     expect(html).toContain("Reconnect video call");
+    expect(html).not.toContain("Reconnect voice call");
+    expect(html).not.toContain("Start voice call");
+  });
+
+  test("does not reconnect proceed-only DM call activity with guessed voice media", async () => {
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com",
+        sid: "dm-call-unknown-media",
+        media: { audio: true, video: false },
+        mediaKnown: false,
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:00:00.000Z",
+      },
+    });
+
+    const html = await renderVueComponent("../src/components/calls/CallButton.vue", {
+      peerBareJid: "bob@example.com",
+    });
+
+    expect(html).toContain("Call live");
+    expect(html).toContain("Open call");
+    expect(html).not.toContain("Reconnect voice call");
+    expect(html).not.toContain("Reconnect video call");
+  });
+
+  test("renders activity-answered incoming calls as connecting in the toast", async () => {
+    $callState.set({
+      phase: "incoming",
+      from: "bob@example.com/phone",
+      sid: "dm-call-answering",
+      media: { audio: true, video: false },
+      accepting: true,
+    });
+
+    const html = await renderVueComponent("../src/components/calls/IncomingCallToast.vue", {});
+
+    expect(html).toContain("Connecting");
+    expect(html).toContain("disabled");
+  });
+
+  test("renders hydrated incoming DM call controls as answer context", async () => {
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com",
+        remoteFullJid: "bob@example.com/phone",
+        sid: "dm-call-2",
+        media: { audio: true, video: false },
+        state: "ringing",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:00:00.000Z",
+      },
+    });
+
+    const html = await renderVueComponent("../src/components/calls/CallButton.vue", {
+      peerBareJid: "bob@example.com",
+    });
+
+    expect(html).toContain("Incoming voice call");
+    expect(html).toContain("Answer voice call");
+    expect(html).not.toContain("Reconnect voice call");
   });
 
   test("renders the group call header button when only ContentArea's room JID is known", async () => {

--- a/chat/tests/dm-call-actions.test.ts
+++ b/chat/tests/dm-call-actions.test.ts
@@ -3,9 +3,14 @@ import {
   $callState,
   clearCallState,
 } from "../src/lib/calls/call-store";
-import { startDmCallAction } from "../src/lib/calls/dm-call-actions";
 import {
+  answerIncomingDmCallActivity,
+  startDmCallAction,
+} from "../src/lib/calls/dm-call-actions";
+import {
+  applyDmCallEvent,
   clearDmCallActivities,
+  clearDmCallActivity,
   readDmCallActivity,
 } from "../src/lib/calls/dm-call-activity";
 import type { CallWireSender } from "../src/lib/calls/outbound";
@@ -65,5 +70,122 @@ describe("startDmCallAction", () => {
 
     expect($callState.get()).toEqual({ phase: "idle" });
     expect(readDmCallActivity("bob@waddle.test")).toBeNull();
+  });
+
+  test("answers a hydrated incoming call with the stored proposer full JID", async () => {
+    const sender: CallWireSender = {
+      send_call_proceed: mock(async () => undefined),
+    };
+    applyDmCallEvent({
+      event: {
+        kind: "propose",
+        from: "bob@waddle.test/phone",
+        sid: "hydrated-incoming",
+        media: { audio: true, video: true },
+      },
+      selfBareJid: "alice@waddle.test",
+      to: "alice@waddle.test/web",
+      timestamp: "2026-05-26T12:00:00.000Z",
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    });
+
+    await answerIncomingDmCallActivity({
+      peerBareJid: "bob@waddle.test",
+      proposerFullJid: "bob@waddle.test/phone",
+      sid: "hydrated-incoming",
+      media: { audio: true, video: true },
+      getSender: () => sender,
+    });
+
+    expect(sender.send_call_proceed).toHaveBeenCalledWith(
+      "bob@waddle.test/phone",
+      "hydrated-incoming",
+    );
+    expect($callState.get()).toEqual({
+      phase: "incoming",
+      from: "bob@waddle.test/phone",
+      sid: "hydrated-incoming",
+      media: { audio: true, video: true },
+      accepting: true,
+    });
+  });
+
+  test("does not answer a hydrated incoming call without a matching peer full JID", async () => {
+    const sender: CallWireSender = {
+      send_call_proceed: mock(async () => undefined),
+    };
+
+    await answerIncomingDmCallActivity({
+      peerBareJid: "bob@waddle.test",
+      proposerFullJid: "mallory@waddle.test/phone",
+      sid: "forged",
+      media: { audio: true, video: false },
+      getSender: () => sender,
+    });
+
+    expect(sender.send_call_proceed).not.toHaveBeenCalled();
+    expect($callState.get()).toEqual({ phase: "idle" });
+  });
+
+  test("does not answer when the hydrated incoming activity was already cleared", async () => {
+    const sender: CallWireSender = {
+      send_call_proceed: mock(async () => undefined),
+    };
+    applyDmCallEvent({
+      event: {
+        kind: "propose",
+        from: "bob@waddle.test/phone",
+        sid: "stale-call",
+        media: { audio: true, video: false },
+      },
+      selfBareJid: "alice@waddle.test",
+      to: "alice@waddle.test/web",
+      timestamp: "2026-05-26T12:00:00.000Z",
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    });
+    clearDmCallActivity("bob@waddle.test", "stale-call");
+
+    await answerIncomingDmCallActivity({
+      peerBareJid: "bob@waddle.test",
+      proposerFullJid: "bob@waddle.test/phone",
+      sid: "stale-call",
+      media: { audio: true, video: false },
+      getSender: () => sender,
+    });
+
+    expect(sender.send_call_proceed).not.toHaveBeenCalled();
+    expect($callState.get()).toEqual({ phase: "idle" });
+  });
+
+  test("answers an existing live incoming call through the current full JID", async () => {
+    const sender: CallWireSender = {
+      send_call_proceed: mock(async () => undefined),
+    };
+    $callState.set({
+      phase: "incoming",
+      from: "bob@waddle.test/laptop",
+      sid: "same-call",
+      media: { audio: true, video: false },
+    });
+
+    await answerIncomingDmCallActivity({
+      peerBareJid: "bob@waddle.test",
+      proposerFullJid: "bob@waddle.test/stale-phone",
+      sid: "same-call",
+      media: { audio: true, video: true },
+      getSender: () => sender,
+    });
+
+    expect(sender.send_call_proceed).toHaveBeenCalledWith(
+      "bob@waddle.test/laptop",
+      "same-call",
+    );
+    expect($callState.get()).toEqual({
+      phase: "incoming",
+      from: "bob@waddle.test/laptop",
+      sid: "same-call",
+      media: { audio: true, video: false },
+      accepting: true,
+    });
   });
 });

--- a/chat/tests/dm-call-activity.test.ts
+++ b/chat/tests/dm-call-activity.test.ts
@@ -40,6 +40,7 @@ describe("DM call activity", () => {
 
     expect(readDmCallActivity(bob, now)).toEqual({
       peerJid: bob,
+      remoteFullJid: `${bob}/phone`,
       sid: "call-1",
       media: audio,
       state: "ringing",
@@ -201,6 +202,26 @@ describe("DM call activity", () => {
       sid: "call-7",
       state: "accepted",
       updatedAt: "2026-05-25T10:05:00.000Z",
+    });
+  });
+
+  test("does not treat proceed-only accepted call media as known voice", () => {
+    applyDmCallEvent({
+      event: {
+        kind: "proceed",
+        from: `${bob}/phone`,
+        sid: "call-without-propose",
+      },
+      selfBareJid: self,
+      to: `${self}/web`,
+      timestamp: now.toISOString(),
+      now,
+    });
+
+    expect(readDmCallActivity(bob, now)).toMatchObject({
+      sid: "call-without-propose",
+      state: "accepted",
+      mediaKnown: false,
     });
   });
 

--- a/chat/tests/home-activity.test.ts
+++ b/chat/tests/home-activity.test.ts
@@ -368,7 +368,8 @@ describe("HomeDashboard activity rendering", () => {
     expect(html).toContain('aria-label="Reconnect Bob, Video call, Live"');
     expect(buttonForLabel(html, "Join General, Group call, 2 people")).toContain("Join");
     expect(buttonForLabel(html, "General, channel, no unread activity, active call with 2 people")).toContain("Active call");
-    expect(buttonForLabel(html, "Bob (bob@example.com), direct message, available, no unread activity, Video call live")).toContain("Live");
+    expect(buttonForLabel(html, "Reconnect Bob, Video call, Live")).toContain("Live");
+    expect(html).not.toContain("Bob (bob@example.com), direct message, available, no unread activity, Video call live");
   });
 
   test("pluralizes single thread reply badges", async () => {


### PR DESCRIPTION
## Summary

- Surface refreshed 1:1 call activity as canonical active-call rows in the DM panel and Home, avoiding duplicate direct-message rows.
- Route hydrated incoming XEP-0353 activity to an answer action using the recorded proposer full JID, with stale-state, bare-JID, and duplicate-proceed protection.
- Preserve known call media for reconnects and avoid guessed voice/video reconnects when replayed call activity does not include media.
- Show activity-answered incoming calls as connecting so refreshed tabs cannot send duplicate accepts.

## Plan

- Keep 1:1 call recovery XMPP-native by consuming hydrated XEP-0353/Jingle call activity from MAM, without adding non-XMPP APIs.
- Review the relevant local XEP references before changing UI behavior.
- Make refreshed 1:1 calls visible in DM navigation, the active-call dock, and the Home dashboard.
- Make actions read clearly across ringing, live, open, return, answer, and reconnect states.
- Add focused model, rendering, and action tests for stale answers, forged full JIDs, unknown media, duplicate rows, and refreshed-call actions.
- Run chat package verification before marking ready.

## XEP Review

- Reviewed local `xeps/xep-0353.xml` for Jingle Message Initiation proceed/answer behavior and full-JID responder/proposer handling.
- Reviewed local call-context references including `xeps/xep-0166.xml`, `xeps/xep-0272.xml`, and `xeps/xep-0483.xml`.
- No non-XMPP API was added.

## Verification

- `bun run lint`
- `bun test`
- `bun run build`
- `git diff --check`

## Review Notes

- First adversarial pass found stale hydrated answers, guessed-media reconnects, duplicate DM active rows, and duplicate-proceed UI risk; all were fixed.
- Second adversarial pass found no remaining actionable issues.
- No dev server was started.
- No knip suppressions were added.