### PR TITLE
feat(chat): add persistent current call panel

### DIFF
--- a/chat/src/components/calls/CallActivityDock.vue
+++ b/chat/src/components/calls/CallActivityDock.vue
@@ -5,6 +5,7 @@ import { ArrowRight, Hash, MessageCircle, Phone, PhoneIncoming, PhoneOutgoing, V
 import {
   $mucCallParticipants,
   mucCallParticipantCounts,
+  normalizeMucCallRoomJid,
 } from "@/lib/calls/muc-call-presence";
 import { $callState } from "@/lib/calls/call-store";
 import { $dmCallActivities } from "@/lib/calls/dm-call-activity";
@@ -18,6 +19,7 @@ import {
 import type { CallMedia } from "@/lib/calls/types";
 import type { ChannelSummary } from "@/lib/chat-types";
 import type { DmConversation } from "@/lib/xmpp-client";
+import { barePeerJid } from "@/lib/xmpp/jid";
 
 const props = withDefaults(defineProps<{
   channels: ChannelSummary[];
@@ -29,8 +31,10 @@ const props = withDefaults(defineProps<{
   activeChannelJids: Set<string>;
   managedMucDomain?: string | null;
   showDmCalls?: boolean;
+  hideCurrentCall?: boolean;
 }>(), {
   showDmCalls: true,
+  hideCurrentCall: false,
 });
 
 const emit = defineEmits<{
@@ -61,7 +65,23 @@ const entries = computed(() => buildCallActivityDockEntries({
   callParticipantCounts: callParticipantCounts.value,
   dmCallActivities: props.showDmCalls === false ? {} : dmCallActivities.value,
 }));
-const entryCount = computed(() => entries.value.length);
+const visibleEntries = computed(() =>
+  props.hideCurrentCall
+    ? entries.value.filter((entry) => !isCurrentCallEntry(entry))
+    : entries.value
+);
+const entryCount = computed(() => visibleEntries.value.length);
+
+function isCurrentCallEntry(entry: CallActivityDockEntry): boolean {
+  const current = callState.value;
+  if (entry.kind === "channel") {
+    if (current.phase !== "active" && current.phase !== "muc-pending") return false;
+    if (current.kind !== "muc") return false;
+    return normalizeMucCallRoomJid(entry.roomJid) === normalizeMucCallRoomJid(current.peer);
+  }
+  if (current.phase !== "active" || current.kind !== "dm") return false;
+  return entry.peerJid.toLowerCase() === barePeerJid(current.peer).toLowerCase();
+}
 
 function entryStatus(entry: CallActivityDockEntry): string {
   if (entry.kind === "channel") {
@@ -134,7 +154,7 @@ function selectEntry(entry: CallActivityDockEntry): void {
 
 <template>
   <div
-    v-if="entries.length > 0"
+    v-if="visibleEntries.length > 0"
     class="call-activity-dock"
     aria-label="Active calls"
   >
@@ -147,7 +167,7 @@ function selectEntry(entry: CallActivityDockEntry): void {
     </div>
     <div class="call-activity-dock__list">
       <button
-        v-for="entry in entries"
+        v-for="entry in visibleEntries"
         :key="entry.key"
         type="button"
         class="call-activity-dock__row"

--- a/chat/src/components/calls/CurrentCallPanel.vue
+++ b/chat/src/components/calls/CurrentCallPanel.vue
@@ -1,0 +1,443 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { useStore } from "@nanostores/vue";
+import {
+  Maximize2,
+  MessageCircle,
+  Mic,
+  MicOff,
+  Phone,
+  PhoneCall,
+  PhoneOff,
+  Settings,
+  Users,
+  Video,
+  VideoOff,
+} from "lucide-vue-next";
+import { $callState } from "@/lib/calls/call-store";
+import {
+  $callCamEnabled,
+  $callConnecting,
+  $callMicEnabled,
+  hangupActiveCall,
+  toggleCam,
+  toggleMic,
+} from "@/lib/calls/call-controls";
+import { $callUiMode } from "@/lib/calls/ui-mode";
+import {
+  $mucCallParticipants,
+  normalizeMucCallRoomJid,
+} from "@/lib/calls/muc-call-presence";
+import { barePeerJid } from "@/lib/xmpp/jid";
+import type { ChannelSummary } from "@/lib/chat-types";
+import type { DmConversation } from "@/lib/xmpp-client";
+import CallSettingsDialog from "./CallSettingsDialog.vue";
+
+const props = defineProps<{
+  channels: Pick<ChannelSummary, "id" | "name" | "jid">[];
+  conversations: Pick<DmConversation, "peerJid" | "peerUsername">[];
+  activeChannelId: string | null;
+  activeChannelRoomJid?: string | null;
+  activePeerJid: string | null;
+}>();
+
+const emit = defineEmits<{
+  selectChannel: [channelId: string | null, roomJid: string];
+  selectDm: [peerJid: string];
+}>();
+
+type CurrentCallPanelState = {
+  kind: "dm" | "muc";
+  title: string;
+  targetJid: string;
+  channelId: string | null;
+  media: { audio: boolean; video: boolean };
+  connected: boolean;
+  viewing: boolean;
+  participantCount: number;
+};
+
+const state = useStore($callState);
+const connecting = useStore($callConnecting);
+const micEnabled = useStore($callMicEnabled);
+const camEnabled = useStore($callCamEnabled);
+const mucParticipants = useStore($mucCallParticipants);
+
+const settingsOpen = ref(false);
+
+const activeChannelRoom = computed(() =>
+  normalizeMucCallRoomJid(props.activeChannelRoomJid ?? ""),
+);
+
+const panel = computed<CurrentCallPanelState | null>(() => {
+  const current = state.value;
+  if (current.phase !== "active" && current.phase !== "muc-pending") return null;
+
+  if (current.kind === "muc") {
+    const roomJid = normalizeMucCallRoomJid(current.peer);
+    if (!roomJid) return null;
+    const channel = props.channels.find((candidate) =>
+      normalizeMucCallRoomJid(candidate.jid ?? "") === roomJid
+    );
+    const participantCount = mucParticipants.value[roomJid]?.length ?? 0;
+    return {
+      kind: "muc",
+      title: channel?.name ?? roomJid.split("@")[0] ?? "Group call",
+      targetJid: roomJid,
+      channelId: channel?.id ?? null,
+      media: current.media,
+      connected: current.phase === "active",
+      viewing: (
+        props.activeChannelId === channel?.id ||
+        (!!activeChannelRoom.value && activeChannelRoom.value === roomJid)
+      ),
+      participantCount,
+    };
+  }
+
+  const peerJid = barePeerJid(current.peer).toLowerCase();
+  if (!peerJid) return null;
+  const conversation = props.conversations.find((candidate) =>
+    barePeerJid(candidate.peerJid).toLowerCase() === peerJid
+  );
+  return {
+    kind: "dm",
+    title: conversation?.peerUsername ?? peerJid.split("@")[0] ?? "Direct call",
+    targetJid: peerJid,
+    channelId: null,
+    media: current.media,
+    connected: true,
+    viewing: barePeerJid(props.activePeerJid ?? "").toLowerCase() === peerJid,
+    participantCount: 2,
+  };
+});
+
+const isConnected = computed(() => panel.value?.connected === true && !connecting.value);
+const callTypeLabel = computed(() => {
+  const current = panel.value;
+  if (!current) return "";
+  if (current.kind === "muc") return "Group call";
+  return current.media.video ? "Video call" : "Voice call";
+});
+const statusLabel = computed(() => {
+  const current = panel.value;
+  if (!current) return "";
+  if (!current.connected) return "Starting call";
+  if (connecting.value) return "Connecting...";
+  return "Connected";
+});
+const participantLabel = computed(() => {
+  const current = panel.value;
+  if (!current) return "";
+  if (current.kind === "dm") return "1:1";
+  const count = current.participantCount;
+  if (count <= 0) return "Group";
+  return `${count} in call`;
+});
+const returnLabel = computed(() => {
+  const current = panel.value;
+  if (!current) return "";
+  return current.viewing ? "Viewing" : "Return";
+});
+const controlsDisabled = computed(() => panel.value?.connected !== true);
+
+function returnToCall(): void {
+  const current = panel.value;
+  if (!current || current.viewing) return;
+  $callUiMode.set("split");
+  if (current.kind === "muc") {
+    emit("selectChannel", current.channelId, current.targetJid);
+    return;
+  }
+  emit("selectDm", current.targetJid);
+}
+
+function expandCall(): void {
+  const current = panel.value;
+  if (!current || !current.connected) return;
+  $callUiMode.set("expanded");
+  if (current.kind === "muc") {
+    emit("selectChannel", current.channelId, current.targetJid);
+    return;
+  }
+  emit("selectDm", current.targetJid);
+}
+</script>
+
+<template>
+  <aside
+    v-if="panel"
+    class="current-call-panel"
+    aria-label="Current call"
+  >
+    <div class="current-call-panel__summary">
+      <span class="current-call-panel__icon" :class="{ 'current-call-panel__icon--connecting': !isConnected }" aria-hidden="true">
+        <Users v-if="panel.kind === 'muc'" class="h-3.5 w-3.5" />
+        <Video v-else-if="panel.media.video" class="h-3.5 w-3.5" />
+        <Phone v-else class="h-3.5 w-3.5" />
+      </span>
+      <span class="current-call-panel__copy">
+        <span class="current-call-panel__title type-control">{{ panel.title }}</span>
+        <span class="current-call-panel__status type-meta">
+          <span class="current-call-panel__live-dot" :class="{ 'current-call-panel__live-dot--muted': !isConnected }" aria-hidden="true" />
+          {{ statusLabel }} · {{ callTypeLabel }} · {{ participantLabel }}
+        </span>
+      </span>
+      <button
+        type="button"
+        class="current-call-panel__return type-meta"
+        :class="{ 'current-call-panel__return--active': panel.viewing }"
+        :disabled="panel.viewing"
+        :aria-label="`${returnLabel} ${panel.title} call`"
+        @click="returnToCall"
+      >
+        <MessageCircle v-if="panel.kind === 'dm'" class="h-3 w-3" />
+        <PhoneCall v-else class="h-3 w-3" />
+        <span>{{ returnLabel }}</span>
+      </button>
+    </div>
+
+    <div class="current-call-panel__controls" aria-label="Current call controls">
+      <button
+        type="button"
+        class="current-call-panel__control"
+        :class="{ 'current-call-panel__control--off': !micEnabled }"
+        :disabled="controlsDisabled"
+        :title="micEnabled ? 'Mute' : 'Unmute'"
+        :aria-label="micEnabled ? 'Mute microphone' : 'Unmute microphone'"
+        @click="toggleMic"
+      >
+        <Mic v-if="micEnabled" class="h-3.5 w-3.5" />
+        <MicOff v-else class="h-3.5 w-3.5" />
+      </button>
+      <button
+        type="button"
+        class="current-call-panel__control"
+        :class="{ 'current-call-panel__control--off': !camEnabled }"
+        :disabled="controlsDisabled"
+        :title="camEnabled ? 'Camera off' : 'Camera on'"
+        :aria-label="camEnabled ? 'Turn camera off' : 'Turn camera on'"
+        @click="toggleCam"
+      >
+        <Video v-if="camEnabled" class="h-3.5 w-3.5" />
+        <VideoOff v-else class="h-3.5 w-3.5" />
+      </button>
+      <button
+        type="button"
+        class="current-call-panel__control"
+        :disabled="controlsDisabled"
+        title="Expand call"
+        aria-label="Expand current call"
+        @click="expandCall"
+      >
+        <Maximize2 class="h-3.5 w-3.5" />
+      </button>
+      <button
+        type="button"
+        class="current-call-panel__control"
+        :disabled="controlsDisabled"
+        title="Call settings"
+        aria-label="Open call settings"
+        @click="settingsOpen = true"
+      >
+        <Settings class="h-3.5 w-3.5" />
+      </button>
+      <button
+        type="button"
+        class="current-call-panel__control current-call-panel__control--danger"
+        title="Hang up"
+        aria-label="Hang up current call"
+        @click="hangupActiveCall"
+      >
+        <PhoneOff class="h-3.5 w-3.5" />
+      </button>
+    </div>
+
+    <CallSettingsDialog v-model:open="settingsOpen" />
+  </aside>
+</template>
+
+<style scoped>
+.current-call-panel {
+  display: flex;
+  flex-shrink: 0;
+  flex-direction: column;
+  gap: 0.5rem;
+  border-top: 1px solid var(--border);
+  border-right: 1px solid var(--border);
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in oklab, var(--sidebar-accent) 38%, var(--card)),
+      color-mix(in oklab, var(--card) 94%, transparent)
+    );
+  padding: 0.625rem;
+}
+
+.current-call-panel__summary {
+  display: grid;
+  grid-template-columns: 1.875rem minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.current-call-panel__icon {
+  display: inline-flex;
+  height: 1.875rem;
+  width: 1.875rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.5rem;
+  background: color-mix(in oklab, oklch(0.7 0.18 145) 18%, transparent);
+  color: oklch(0.46 0.14 145);
+}
+
+.current-call-panel__icon--connecting {
+  background: color-mix(in oklab, var(--primary) 14%, transparent);
+  color: var(--primary);
+}
+
+.current-call-panel__copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.current-call-panel__title,
+.current-call-panel__status {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.current-call-panel__title {
+  color: var(--sidebar-foreground);
+}
+
+.current-call-panel__status {
+  color: var(--sidebar-muted);
+}
+
+.current-call-panel__live-dot {
+  display: inline-block;
+  width: 0.4rem;
+  height: 0.4rem;
+  margin-right: 0.25rem;
+  border-radius: 9999px;
+  background: oklch(0.7 0.18 145);
+  box-shadow: 0 0 0 3px color-mix(in oklab, oklch(0.7 0.18 145) 18%, transparent);
+  vertical-align: 0.05em;
+}
+
+.current-call-panel__live-dot--muted {
+  background: var(--primary);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--primary) 18%, transparent);
+}
+
+.current-call-panel__return,
+.current-call-panel__control {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.5rem;
+  transition:
+    background-color 160ms ease,
+    color 160ms ease,
+    border-color 160ms ease,
+    transform 160ms ease;
+}
+
+.current-call-panel__return {
+  min-width: 4.25rem;
+  height: 1.75rem;
+  gap: 0.25rem;
+  border: 1px solid color-mix(in oklab, var(--primary) 24%, transparent);
+  background: color-mix(in oklab, var(--primary) 10%, transparent);
+  color: var(--primary);
+  padding: 0 0.5rem;
+  white-space: nowrap;
+}
+
+.current-call-panel__return:hover {
+  background: color-mix(in oklab, var(--primary) 16%, transparent);
+}
+
+.current-call-panel__return:disabled {
+  cursor: default;
+}
+
+.current-call-panel__return--active {
+  border-color: color-mix(in oklab, oklch(0.7 0.18 145) 34%, transparent);
+  background: color-mix(in oklab, oklch(0.7 0.18 145) 16%, transparent);
+  color: oklch(0.46 0.14 145);
+}
+
+.current-call-panel__controls {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0.375rem;
+}
+
+.current-call-panel__control {
+  height: 2rem;
+  min-width: 0;
+  border: 1px solid transparent;
+  background: color-mix(in oklab, var(--sidebar-accent) 68%, transparent);
+  color: var(--sidebar-foreground);
+}
+
+.current-call-panel__control:hover:not(:disabled) {
+  transform: translateY(-1px);
+  background: color-mix(in oklab, var(--sidebar-accent) 90%, transparent);
+  color: var(--primary);
+}
+
+.current-call-panel__control:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+}
+
+.current-call-panel__control--off {
+  border-color: color-mix(in oklab, var(--primary) 26%, transparent);
+  background: color-mix(in oklab, var(--primary) 12%, transparent);
+  color: var(--primary);
+}
+
+.current-call-panel__control--danger {
+  background: color-mix(in oklab, var(--destructive) 12%, transparent);
+  color: var(--destructive);
+}
+
+.current-call-panel__control--danger:hover:not(:disabled) {
+  background: color-mix(in oklab, var(--destructive) 18%, transparent);
+  color: var(--destructive);
+}
+
+.current-call-panel.current-call-panel--mobile {
+  border-top: 0;
+  border-right: 0;
+  border-bottom: 1px solid var(--border);
+  padding: 0.5rem 0.75rem;
+}
+
+@media (min-width: 64rem) {
+  .current-call-panel.current-call-panel--mobile {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .current-call-panel__return,
+  .current-call-panel__control {
+    transition: none;
+  }
+
+  .current-call-panel__control:hover:not(:disabled) {
+    transform: none;
+  }
+}
+</style>

--- a/chat/src/components/chat/ChatMobileDrawers.vue
+++ b/chat/src/components/chat/ChatMobileDrawers.vue
@@ -185,6 +185,7 @@ function openExtensionRoute(route: DiscoveredExtensionRoute) {
           v-else
           :conversations="dmConversations.conversations.value"
           :active-peer-jid="dmConversations.activePeerJid.value"
+          hide-current-call
           class="!w-full !border-r-0 !flex-1"
           @answer-dm="answerDmFromMobile"
           @select-dm="selectDm"

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -33,6 +33,7 @@ import UserSettingsPage from "@/components/chat/UserSettingsPage.vue";
 import WaddlesSidebar from "@/components/chat/WaddlesSidebar.vue";
 import AdminView from "@/components/admin/AdminView.vue";
 import CallActivityDock from "@/components/calls/CallActivityDock.vue";
+import CurrentCallPanel from "@/components/calls/CurrentCallPanel.vue";
 import { navigate, useRouteMatch, type AdminMatch, type AdminPanel } from "@/router";
 import { buildHomeDashboardProps } from "@/home/dashboard-props";
 import { jidDomain } from "@/lib/xmpp/jid";
@@ -351,6 +352,16 @@ onUnmounted(() => {
       :answer-dm="answerDmFromActivity"
       :reconnect-dm="reconnectDmFromDock"
     />
+    <CurrentCallPanel
+      class="current-call-panel--mobile"
+      :channels="waddles.sortedChannels.value"
+      :conversations="dmConversations.conversations.value"
+      :active-channel-id="waddles.activeChannelId.value"
+      :active-channel-room-jid="activeChannelRoomJid"
+      :active-peer-jid="dmConversations.activePeerJid.value"
+      @select-channel="onSelectChannelFromSidebar"
+      @select-dm="selectDm"
+    />
     <CallActivityDock
       class="call-activity-dock--mobile"
       :channels="waddles.sortedChannels.value"
@@ -361,6 +372,7 @@ onUnmounted(() => {
       :sidebar-mode="ui.sidebarMode.value"
       :active-channel-jids="messaging.activeChannels.value"
       :managed-muc-domain="managedMucDomain"
+      hide-current-call
       @select-channel="onSelectChannelFromSidebar"
       @join-channel-call="joinChannelCallFromActivity"
       @answer-dm="answerDmFromActivity"
@@ -436,10 +448,20 @@ onUnmounted(() => {
           v-else
           :conversations="dmConversations.conversations.value"
           :active-peer-jid="dmConversations.activePeerJid.value"
+          hide-current-call
           @answer-dm="answerDmFromActivity"
           @select-dm="selectDm"
           @reconnect-dm="reconnectDmFromDock"
           @new-dm="ui.showNewDm.value = true"
+        />
+        <CurrentCallPanel
+          :channels="waddles.sortedChannels.value"
+          :conversations="dmConversations.conversations.value"
+          :active-channel-id="waddles.activeChannelId.value"
+          :active-channel-room-jid="activeChannelRoomJid"
+          :active-peer-jid="dmConversations.activePeerJid.value"
+          @select-channel="onSelectChannelFromSidebar"
+          @select-dm="selectDm"
         />
         <CallActivityDock
           :channels="waddles.sortedChannels.value"
@@ -451,6 +473,7 @@ onUnmounted(() => {
           :active-channel-jids="messaging.activeChannels.value"
           :managed-muc-domain="managedMucDomain"
           :show-dm-calls="ui.sidebarMode.value !== 'dms'"
+          hide-current-call
           @select-channel="onSelectChannelFromSidebar"
           @join-channel-call="joinChannelCallFromActivity"
           @answer-dm="answerDmFromActivity"

--- a/chat/src/components/chat/DmPanel.vue
+++ b/chat/src/components/chat/DmPanel.vue
@@ -12,10 +12,13 @@ import type { CallMedia } from "@/lib/calls/types";
 import { barePeerJid } from "@/lib/xmpp/jid";
 import type { DmConversation } from "@/lib/xmpp-client";
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   conversations: DmConversation[];
   activePeerJid: string | null;
-}>();
+  hideCurrentCall?: boolean;
+}>(), {
+  hideCurrentCall: false,
+});
 
 const emit = defineEmits<{
   answerDm: [peerJid: string, remoteFullJid: string, sid: string, media: CallMedia];
@@ -27,6 +30,11 @@ const emit = defineEmits<{
 const dmCallActivities = useStore($dmCallActivities);
 const callState = useStore($callState);
 const activePeer = computed(() => normalizedPeerJid(props.activePeerJid ?? ""));
+const currentActiveDmPeer = computed(() => {
+  const current = callState.value;
+  if (!props.hideCurrentCall || current.phase !== "active" || current.kind !== "dm") return "";
+  return normalizedPeerJid(current.peer);
+});
 const activeCallRows = computed(() =>
   Object.values(dmCallActivities.value)
     .map((activity) => ({
@@ -36,7 +44,7 @@ const activeCallRows = computed(() =>
       meta: callActivityMeta(activity),
       action: callActivityActionLabel(activity),
     }))
-    .filter((row) => row.peerJid)
+    .filter((row) => row.peerJid && row.peerJid !== currentActiveDmPeer.value)
     .sort((left, right) => {
       const rightMs = timestampMs(right.activity.updatedAt);
       const leftMs = timestampMs(left.activity.updatedAt);

--- a/chat/tests/call-activity-dock.test.ts
+++ b/chat/tests/call-activity-dock.test.ts
@@ -16,16 +16,33 @@ import {
   $callState,
   clearCallState,
 } from "../src/lib/calls/call-store";
+import {
+  $callCamEnabled,
+  $callConnecting,
+  $callMicEnabled,
+} from "../src/lib/calls/call-controls";
+import { $callUiMode } from "../src/lib/calls/ui-mode";
 import { clearMucCallParticipants, $mucCallParticipants } from "../src/lib/calls/muc-call-presence";
 import { clearDmCallActivities, $dmCallActivities } from "../src/lib/calls/dm-call-activity";
 import type { DmCallActivity } from "../src/lib/calls/dm-call-activity";
-import type { CallState } from "../src/lib/calls/types";
+import type { CallState, LiveKitJoin } from "../src/lib/calls/types";
 
 afterEach(() => {
   clearCallState();
   clearMucCallParticipants();
   clearDmCallActivities();
+  $callConnecting.set(false);
+  $callMicEnabled.set(true);
+  $callCamEnabled.set(true);
+  $callUiMode.set("split");
 });
+
+const liveKitJoin: LiveKitJoin = {
+  url: "wss://livekit.example.test",
+  room: "call-room",
+  identity: "alice@example.com/web",
+  token: "token",
+};
 
 describe("call activity dock model", () => {
   test("surfaces group calls and DM calls across sidebar modes", () => {
@@ -518,10 +535,15 @@ describe("CallActivityDock rendering", () => {
   test("is mounted in the desktop sidebar and visible mobile shell", () => {
     const readyShell = readFileSync(new URL("../src/components/chat/ChatReadyShell.vue", import.meta.url), "utf8");
     const mobileDrawers = readFileSync(new URL("../src/components/chat/ChatMobileDrawers.vue", import.meta.url), "utf8");
+    const callActivityDock = readFileSync(new URL("../src/components/calls/CallActivityDock.vue", import.meta.url), "utf8");
 
     expect(readyShell).toContain("import CallActivityDock");
+    expect(readyShell).toContain("import CurrentCallPanel");
     expect(readyShell.match(/<CallActivityDock/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+    expect(readyShell.match(/<CurrentCallPanel/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+    expect(readyShell).toContain("class=\"current-call-panel--mobile\"");
     expect(readyShell).toContain("class=\"call-activity-dock--mobile\"");
+    expect(readyShell.match(/hide-current-call/g)?.length ?? 0).toBeGreaterThanOrEqual(3);
     expect(readyShell).toContain(":join-channel-call=\"joinChannelCallFromActivity\"");
     expect(readyShell).toContain(":answer-dm=\"answerDmFromActivity\"");
     expect(readyShell).toContain(":reconnect-dm=\"reconnectDmFromDock\"");
@@ -542,6 +564,213 @@ describe("CallActivityDock rendering", () => {
     expect(mobileDrawers).toContain(":active-dm-call-count=\"activeDmCallCount\"");
     expect(mobileDrawers).toContain(":call-participants=\"mucCallParticipantsStore\"");
     expect(mobileDrawers).toContain("@toggle-dms=\"openDmList\"");
+    expect(mobileDrawers).toContain("hide-current-call");
+    expect(callActivityDock).toContain("entry.peerJid.toLowerCase() === barePeerJid(current.peer).toLowerCase()");
+  });
+
+  test("renders the persistent current-call panel for an active DM call", async () => {
+    $callState.set({
+      phase: "active",
+      kind: "dm",
+      peer: "bob@example.com/phone",
+      sid: "dm-live",
+      media: { audio: true, video: false },
+      join: liveKitJoin,
+    });
+    $callMicEnabled.set(false);
+
+    const html = await renderVueComponent("../src/components/calls/CurrentCallPanel.vue", {
+      channels: [],
+      conversations: [
+        { peerJid: "bob@example.com", peerUsername: "Bob" },
+      ],
+      activeChannelId: null,
+      activeChannelRoomJid: null,
+      activePeerJid: null,
+    });
+
+    expect(html).toContain('aria-label="Current call"');
+    expect(html).toContain("Bob");
+    expect(html).toContain("Connected");
+    expect(html).toContain("Voice call");
+    expect(html).toContain("1:1");
+    expect(html).toContain("Return");
+    expect(html).toContain('aria-label="Unmute microphone"');
+    expect(html).not.toContain("aria-pressed");
+    expect(html).toContain('aria-label="Hang up current call"');
+  });
+
+  test("renders the persistent current-call panel for a connecting group call", async () => {
+    $callState.set({
+      phase: "active",
+      kind: "muc",
+      peer: "general@conference.example.com",
+      sid: "muc-live",
+      media: { audio: true, video: true },
+      join: liveKitJoin,
+      selfNick: "alice",
+    });
+    $callConnecting.set(true);
+    $mucCallParticipants.set({
+      "general@conference.example.com": ["alice", "bob"],
+    });
+
+    const html = await renderVueComponent("../src/components/calls/CurrentCallPanel.vue", {
+      channels: [
+        { id: "general", name: "General", jid: "general@conference.example.com" },
+      ],
+      conversations: [],
+      activeChannelId: "general",
+      activeChannelRoomJid: "general@conference.example.com",
+      activePeerJid: null,
+    });
+
+    expect(html).toContain("General");
+    expect(html).toContain("Connecting...");
+    expect(html).toContain("Group call");
+    expect(html).toContain("2 in call");
+    expect(html).toContain("Viewing");
+    expect(html).toContain('aria-label="Viewing General call"');
+    expect(html).toContain("disabled");
+  });
+
+  test("routes the persistent current-call panel back to the owning conversation", async () => {
+    $callState.set({
+      phase: "active",
+      kind: "dm",
+      peer: "bob@example.com/phone",
+      sid: "dm-live",
+      media: { audio: true, video: false },
+      join: liveKitJoin,
+    });
+    $callUiMode.set("expanded");
+    const emitted: unknown[][] = [];
+    const bindings = await setupVueComponent("../src/components/calls/CurrentCallPanel.vue", {
+      channels: [],
+      conversations: [
+        { peerJid: "bob@example.com", peerUsername: "Bob" },
+      ],
+      activeChannelId: null,
+      activeChannelRoomJid: null,
+      activePeerJid: null,
+    }, (...args) => {
+      emitted.push(args);
+    });
+
+    setupBindingFunction(bindings, "returnToCall")();
+
+    expect(emitted).toEqual([["selectDm", "bob@example.com"]]);
+    expect($callUiMode.get()).toBe("split");
+  });
+
+  test("keeps the viewing chip passive when already on the current call", async () => {
+    $callState.set({
+      phase: "active",
+      kind: "dm",
+      peer: "bob@example.com/phone",
+      sid: "dm-live",
+      media: { audio: true, video: false },
+      join: liveKitJoin,
+    });
+    $callUiMode.set("expanded");
+    const emitted: unknown[][] = [];
+    const bindings = await setupVueComponent("../src/components/calls/CurrentCallPanel.vue", {
+      channels: [],
+      conversations: [
+        { peerJid: "bob@example.com", peerUsername: "Bob" },
+      ],
+      activeChannelId: null,
+      activeChannelRoomJid: null,
+      activePeerJid: "bob@example.com",
+    }, (...args) => {
+      emitted.push(args);
+    });
+
+    setupBindingFunction(bindings, "returnToCall")();
+
+    expect(emitted).toEqual([]);
+    expect($callUiMode.get()).toBe("expanded");
+  });
+
+  test("filters the current local call out of rediscovery lists", async () => {
+    $callState.set({
+      phase: "active",
+      kind: "dm",
+      peer: "bob@example.com/phone",
+      sid: "dm-live",
+      media: { audio: true, video: true },
+      join: liveKitJoin,
+    });
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com",
+        sid: "dm-live",
+        media: { audio: true, video: true },
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:00:00.000Z",
+      },
+      "carol@example.com": {
+        peerJid: "carol@example.com",
+        sid: "dm-other",
+        media: { audio: true, video: false },
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:02:00.000Z",
+      },
+    });
+
+    const dockHtml = await renderVueComponent("../src/components/calls/CallActivityDock.vue", {
+      channels: [],
+      conversations: [
+        { peerJid: "bob@example.com", peerUsername: "Bob" },
+        { peerJid: "carol@example.com", peerUsername: "Carol" },
+      ],
+      activeChannelId: null,
+      activePeerJid: null,
+      sidebarMode: "dms",
+      activeChannelJids: new Set<string>(),
+      hideCurrentCall: true,
+    });
+    const dmHtml = await renderVueComponent("../src/components/chat/DmPanel.vue", {
+      conversations: [],
+      activePeerJid: null,
+      hideCurrentCall: true,
+    });
+
+    expect(dockHtml).toContain("Carol");
+    expect(dockHtml).not.toContain("Bob");
+    expect(dmHtml).toContain("carol");
+    expect(dmHtml).not.toContain("bob");
+  });
+
+  test("expands the persistent current-call panel into a known group channel", async () => {
+    $callState.set({
+      phase: "active",
+      kind: "muc",
+      peer: "general@conference.example.com",
+      sid: "muc-live",
+      media: { audio: true, video: true },
+      join: liveKitJoin,
+      selfNick: "alice",
+    });
+    const emitted: unknown[][] = [];
+    const bindings = await setupVueComponent("../src/components/calls/CurrentCallPanel.vue", {
+      channels: [
+        { id: "general", name: "General", jid: "general@conference.example.com" },
+      ],
+      conversations: [],
+      activeChannelId: null,
+      activeChannelRoomJid: null,
+      activePeerJid: null,
+    }, (...args) => {
+      emitted.push(args);
+    });
+
+    setupBindingFunction(bindings, "expandCall")();
+
+    expect(emitted).toEqual([["selectChannel", "general", "general@conference.example.com"]]);
+    expect($callUiMode.get()).toBe("expanded");
   });
 
   test("renders rail-level active call indicators for spaces and DMs", async () => {


### PR DESCRIPTION
## Summary

- Add a persistent current-call panel in the app shell for the local active LiveKit call, with return, expand, settings, mute, camera, and hangup controls.
- Keep the current local call out of rediscovered call lists so the panel is the canonical control surface while the dock and DM panel still show other running calls.
- Preserve the existing split and expanded call layouts; this is a compact navigation/control surface for when the user is outside the owning channel or DM.
- Make the already-viewing state passive and keep toggle controls accessible with action labels that do not conflict with pressed state.
- Normalize both sides of the dock DM current-call comparison so mixed-case JIDs do not leave the current call duplicated in the rediscovery dock.

## Plan

- Keep the call UI XMPP-native: this PR only reads existing `$callState`, XEP-0353 DM activity, Muji/MUC presence, and LiveKit control state; it does not add non-XMPP call APIs.
- Add a Discord/Slack-style current-call panel in the app shell so an active LiveKit call stays visible and controllable after navigating away from its channel or DM.
- Reuse the existing call controls store for mute, camera, settings, hangup, and return-to-call routing instead of adding another call lifecycle path.
- Preserve the existing split and expanded call layout; the panel is a compact navigation/control surface, not a replacement for the call layout.
- Add focused rendering and event tests for active MUC calls, active DM calls, connecting state, return routing, accessibility, duplicate filtering, mixed-case DM current-call filtering, and quick controls.
- Run chat package verification before marking ready.

## XEP Review

- Reviewed local `xeps/xep-0353.xml` for Jingle Message Initiation and refreshed DM call state.
- Reviewed local `xeps/xep-0272.xml` for Muji presence semantics.
- Reviewed local `xeps/xep-0483.xml` for SFU/online-meeting context.
- No non-XMPP API was added.

## Verification

- `bun test tests/call-activity-dock.test.ts`
- `bun run lint`
- `bun test`
- `bun run build`
- `git diff --check`

## Review Notes

- Greptile flagged a mixed-case DM JID comparison in `CallActivityDock`; fixed by normalizing both sides and covering the comparison.
- Adversarial call-state/protocol review found no actionable issues.
- Adversarial frontend/accessibility review found duplicate current-call surfaces, conflicting toggle accessibility labels, and an active “Viewing” chip; all were fixed and covered.
- No dev server was started.
- No knip suppressions were added.