### PR TITLE
feat(chat): add conversation call banner

### DIFF
--- a/chat/src/components/calls/CallButton.vue
+++ b/chat/src/components/calls/CallButton.vue
@@ -10,13 +10,19 @@ import type { CallWireSender } from "@/lib/calls/outbound";
 import { connectionStore } from "@/lib/connection-store";
 import type { CallMedia } from "@/lib/calls/types";
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   /** Peer's bare JID — the `<propose/>` per XEP-0353 §0.2 is
    *  addressed bare so every online resource is rung; whichever
    *  resource accepts becomes the responder full JID stamped on
    *  the inbound `<proceed/>`. */
   peerBareJid: string;
-}>();
+  /** When the conversation owns a larger answer/reconnect banner,
+   *  suppress this compact header activity affordance to avoid
+   *  duplicate controls for the same XEP-0353 call activity. */
+  showActivityControls?: boolean;
+}>(), {
+  showActivityControls: true,
+});
 
 const state = useStore($callState);
 const { activity: peerCallActivity } = useDmCallActivity(() => props.peerBareJid);
@@ -31,8 +37,10 @@ const inCall = computed(
 );
 
 const hasPeerCallActivity = computed(() => !!peerCallActivity.value);
-const voiceLabel = computed(() => hasPeerCallActivity.value && !inCall.value ? "Reconnect voice call" : "Start voice call");
-const videoLabel = computed(() => hasPeerCallActivity.value && !inCall.value ? "Reconnect video call" : "Start video call");
+const showPeerCallActivity = computed(() => props.showActivityControls !== false && hasPeerCallActivity.value);
+const showStartControls = computed(() => !hasPeerCallActivity.value);
+const voiceLabel = computed(() => "Start voice call");
+const videoLabel = computed(() => "Start video call");
 const peerActivityAction = computed(() => {
   const activity = peerCallActivity.value;
   return activity ? dmCallActivityAction(activity, state.value) : null;
@@ -121,18 +129,19 @@ async function handlePeerCallActivity(): Promise<void> {
 
 <template>
   <div
+    v-if="showPeerCallActivity || showStartControls"
     class="call-button-group"
-    :class="{ 'call-button-group--activity': hasPeerCallActivity }"
+    :class="{ 'call-button-group--activity': showPeerCallActivity }"
   >
     <span
-      v-if="hasPeerCallActivity"
+      v-if="showPeerCallActivity"
       class="call-button-group__hint type-meta"
       aria-hidden="true"
     >
       {{ activityBannerLabel }}
     </span>
     <button
-      v-if="hasPeerCallActivity"
+      v-if="showPeerCallActivity"
       class="chat-icon-button chat-icon-button--md transition-all duration-200"
       :class="activityButtonDisabled
         ? 'text-muted-foreground opacity-40 cursor-not-allowed'
@@ -147,7 +156,7 @@ async function handlePeerCallActivity(): Promise<void> {
       <Video v-else-if="peerCallActivity && hasKnownDmCallMedia(peerCallActivity) && peerCallActivity.media.video" class="w-3.5 h-3.5" />
       <Phone v-else class="w-3.5 h-3.5" />
     </button>
-    <template v-else>
+    <template v-else-if="showStartControls">
     <button
       class="chat-icon-button chat-icon-button--md transition-all duration-200"
       :class="inCall

--- a/chat/src/components/calls/ConversationCallBanner.vue
+++ b/chat/src/components/calls/ConversationCallBanner.vue
@@ -1,0 +1,232 @@
+<script setup lang="ts">
+import { computed, type Component } from "vue";
+import { useStore } from "@nanostores/vue";
+import { Phone, PhoneIncoming, PhoneOff, Video } from "lucide-vue-next";
+import { $callState } from "@/lib/calls/call-store";
+import { dmCallActivityAction, isBusy } from "@/lib/calls/call-activity-dock";
+import { $dmCallActivities, hasKnownDmCallMedia, type DmCallActivity } from "@/lib/calls/dm-call-activity";
+import { normalizeMucCallRoomJid } from "@/lib/calls/muc-call-presence";
+import { useRoomHasActiveCall } from "@/lib/calls/use-active-muc-call";
+import type { CallMedia } from "@/lib/calls/types";
+import { barePeerJid } from "@/lib/xmpp/jid";
+
+const props = defineProps<{
+  roomJid?: string | null;
+  channelId?: string | null;
+  channelName?: string | null;
+  dmPeerJid?: string | null;
+  dmPeerName?: string | null;
+}>();
+
+const emit = defineEmits<{
+  joinChannelCall: [channelId: string | null, roomJid: string, media: CallMedia];
+  answerDm: [peerJid: string, remoteFullJid: string, sid: string, media: CallMedia];
+  reconnectDm: [peerJid: string, media: CallMedia];
+}>();
+
+type BannerAction = "answer" | "join" | "reconnect" | "unavailable";
+
+type BannerView = {
+  kind: "group" | "dm";
+  title: string;
+  body: string;
+  action: BannerAction;
+  actionLabel: string;
+  ariaLabel: string;
+  disabled: boolean;
+  icon: Component;
+  actionIcon: Component;
+  channelId?: string | null;
+  roomJid?: string;
+  peerJid?: string;
+  remoteFullJid?: string;
+  sid?: string;
+  media?: CallMedia;
+};
+
+const callState = useStore($callState);
+const dmCallActivities = useStore($dmCallActivities);
+const roomCall = useRoomHasActiveCall(() => props.roomJid ?? "");
+
+const normalizedRoomJid = computed(() => normalizeMucCallRoomJid(props.roomJid ?? ""));
+const normalizedDmPeerJid = computed(() => barePeerJid(props.dmPeerJid ?? "").toLowerCase());
+const dmActivity = computed<DmCallActivity | null>(() => {
+  const peerJid = normalizedDmPeerJid.value;
+  if (!peerJid) return null;
+  return dmCallActivities.value[peerJid] ?? null;
+});
+
+const localGroupCallInThisRoom = computed(() => {
+  const roomJid = normalizedRoomJid.value;
+  const state = callState.value;
+  if (!roomJid) return false;
+  if (state.phase !== "active" && state.phase !== "muc-pending") return false;
+  if (state.kind !== "muc") return false;
+  return normalizeMucCallRoomJid(state.peer) === roomJid;
+});
+
+const banner = computed<BannerView | null>(() => {
+  const groupBanner = groupCallBanner();
+  if (groupBanner) return groupBanner;
+  return dmBanner();
+});
+
+function groupCallBanner(): BannerView | null {
+  const roomJid = normalizedRoomJid.value;
+  if (!roomJid || props.dmPeerJid) return null;
+  if (!roomCall.hasActiveCall.value || localGroupCallInThisRoom.value) return null;
+
+  const participantCount = roomCall.participantCount.value;
+  const participantNoun = participantCount === 1 ? "person" : "people";
+  const title = `${props.channelName || "This channel"} has a live call`;
+  const busy = isBusy(callState.value);
+
+  return {
+    kind: "group",
+    title,
+    body: `${participantCount} ${participantNoun} connected in this channel.`,
+    action: busy ? "unavailable" : "join",
+    actionLabel: busy ? "In another call" : "Join call",
+    ariaLabel: busy ? `${title}; already in another call` : `Join ${props.channelName || "channel"} call`,
+    disabled: busy,
+    icon: Phone,
+    actionIcon: busy ? PhoneOff : Phone,
+    channelId: props.channelId ?? null,
+    roomJid,
+    media: { audio: true, video: false },
+  };
+}
+
+function dmBanner(): BannerView | null {
+  const activity = dmActivity.value;
+  const peerJid = normalizedDmPeerJid.value;
+  if (!activity || !peerJid || props.roomJid) return null;
+
+  const action = dmCallActivityAction(activity, callState.value);
+  if (action === "return") return null;
+
+  const media = activity.media;
+  const peerName = props.dmPeerName || peerJid.split("@")[0] || "this person";
+  const mediaLabel = media.video ? "video call" : "voice call";
+  const title = dmTitle(activity, peerName);
+  const busy = isBusy(callState.value);
+
+  if (action === "answer" && activity.remoteFullJid) {
+    return {
+      kind: "dm",
+      title,
+      body: `${peerName} is calling with a ${mediaLabel}.`,
+      action: "answer",
+      actionLabel: "Answer",
+      ariaLabel: `Answer ${peerName} ${mediaLabel}`,
+      disabled: false,
+      icon: PhoneIncoming,
+      actionIcon: media.video ? Video : PhoneIncoming,
+      peerJid,
+      remoteFullJid: activity.remoteFullJid,
+      sid: activity.sid,
+      media,
+    };
+  }
+
+  if (action === "reconnect" && hasKnownDmCallMedia(activity)) {
+    return {
+      kind: "dm",
+      title,
+      body: `The ${mediaLabel} is still live after refresh.`,
+      action: "reconnect",
+      actionLabel: "Rejoin",
+      ariaLabel: `Rejoin ${peerName} ${mediaLabel}`,
+      disabled: false,
+      icon: media.video ? Video : Phone,
+      actionIcon: media.video ? Video : Phone,
+      peerJid,
+      media,
+    };
+  }
+
+  return {
+    kind: "dm",
+    title,
+    body: busy ? `Finish the current call before joining this ${mediaLabel}.` : "Waiting for call details to finish syncing.",
+    action: "unavailable",
+    actionLabel: busy ? "In another call" : "Unavailable",
+    ariaLabel: busy ? `${title}; already in another call` : `${title}; call details unavailable`,
+    disabled: true,
+    icon: Phone,
+    actionIcon: PhoneOff,
+  };
+}
+
+function dmTitle(activity: DmCallActivity, peerName: string): string {
+  if (activity.state === "ringing" && activity.direction === "incoming") {
+    return `${peerName} is calling`;
+  }
+  if (activity.state === "ringing" && activity.direction === "outgoing") {
+    return `Calling ${peerName}`;
+  }
+  return `Call with ${peerName} is live`;
+}
+
+function activateBanner(): void {
+  const current = banner.value;
+  if (!current || current.disabled) return;
+  if (current.action === "join" && current.roomJid && current.media) {
+    emit("joinChannelCall", current.channelId ?? null, current.roomJid, current.media);
+    return;
+  }
+  if (
+    current.action === "answer" &&
+    current.peerJid &&
+    current.remoteFullJid &&
+    current.sid &&
+    current.media
+  ) {
+    emit("answerDm", current.peerJid, current.remoteFullJid, current.sid, current.media);
+    return;
+  }
+  if (current.action === "reconnect" && current.peerJid && current.media) {
+    emit("reconnectDm", current.peerJid, current.media);
+  }
+}
+</script>
+
+<template>
+  <section
+    role="region"
+    :aria-label="banner ? banner.title : 'Conversation call status'"
+    aria-live="polite"
+    aria-atomic="true"
+  >
+    <div
+      v-if="banner"
+      class="border-b border-primary/15 bg-primary/8 text-foreground"
+    >
+      <div class="chat-message-lane flex flex-col gap-3 px-[var(--chat-content-inline)] py-3 sm:flex-row sm:items-center sm:justify-between">
+        <div class="flex min-w-0 items-start gap-3">
+          <div class="mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full border border-primary/20 bg-background/80 text-primary">
+            <component :is="banner.icon" class="h-4 w-4" aria-hidden="true" />
+          </div>
+          <div class="min-w-0">
+            <p class="type-control truncate">
+              {{ banner.title }}
+            </p>
+            <p class="type-caption chat-copy-measure text-foreground/75">
+              {{ banner.body }}
+            </p>
+          </div>
+        </div>
+        <button
+          type="button"
+          class="type-control inline-flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-full border border-primary/20 bg-background/85 px-3.5 text-primary transition-colors hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/35 disabled:cursor-not-allowed disabled:border-border disabled:text-muted-foreground disabled:hover:bg-background/85"
+          :aria-label="banner.ariaLabel"
+          :disabled="banner.disabled"
+          @click="activateBanner"
+        >
+          <component :is="banner.actionIcon" class="h-3.5 w-3.5" aria-hidden="true" />
+          <span>{{ banner.actionLabel }}</span>
+        </button>
+      </div>
+    </div>
+  </section>
+</template>

--- a/chat/src/components/calls/MucCallButton.vue
+++ b/chat/src/components/calls/MucCallButton.vue
@@ -8,22 +8,38 @@ import {
 } from "@/lib/calls/call-store";
 import { startMucCallAction } from "@/lib/calls/muc-call-actions";
 import { normalizeMucCallRoomJid } from "@/lib/calls/muc-call-presence";
+import { useRoomHasActiveCall } from "@/lib/calls/use-active-muc-call";
 import { connectionStore } from "@/lib/connection-store";
 import type { CallMedia } from "@/lib/calls/types";
 import { jidDomain } from "@/lib/xmpp/jid";
 import CallActivePill from "./CallActivePill.vue";
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   /** MUC room bare JID (`channel@muc.host`). The server uses this
    *  as the SFU `CallId` so every occupant who joins via this
    *  button lands in the same LiveKit room. */
   roomJid: string;
-}>();
+  /** Keep the compact header live-call pill optional so a richer
+   *  conversation-level join surface can replace it without duplicating
+   *  the same action in the same view. */
+  showActivePill?: boolean;
+  /** When the conversation banner owns the refreshed live-call action,
+   *  hide the header's "start call" controls while Muji presence says
+   *  this room already has a call. */
+  hideStartControlsWhenActiveCall?: boolean;
+}>(), {
+  showActivePill: true,
+  hideStartControlsWhenActiveCall: false,
+});
 
 const state = useStore($callState);
 const starting = ref(false);
+const roomCall = useRoomHasActiveCall(() => props.roomJid);
 const inCall = computed(() => state.value.phase !== "idle" && state.value.phase !== "ended");
 const callBusy = computed(() => inCall.value || starting.value);
+const showStartControls = computed(() =>
+  !(props.hideStartControlsWhenActiveCall && roomCall.hasActiveCall.value)
+);
 const normalizedRoomJid = computed(() => normalizeMucCallRoomJid(props.roomJid));
 const callInThisRoom = computed(() => {
   const current = state.value;
@@ -90,7 +106,11 @@ function joinExistingAudio(): void {
 </script>
 
 <template>
-  <div class="flex items-center gap-1.5">
+  <div
+    v-if="showStartControls || showActivePill"
+    class="flex items-center gap-1.5"
+  >
+    <template v-if="showStartControls">
     <button
       class="chat-icon-button chat-icon-button--md transition-all duration-200"
       :class="callBusy
@@ -117,12 +137,14 @@ function joinExistingAudio(): void {
     >
       <Video class="w-3.5 h-3.5" />
     </button>
+    </template>
     <!-- Live-call pill: green dot + participant count, click to
          join. The pill component decides its own visibility (only
          when this room owns the call AND the local user isn't in it),
          which is why we can mount it unconditionally and still keep
          the row spacing tight when no call is in flight. -->
     <CallActivePill
+      v-if="showActivePill !== false"
       :room-jid="roomJid"
       :on-join="joinExistingAudio"
       :disabled="pillDisabled"

--- a/chat/src/components/chat/ChatHeader.vue
+++ b/chat/src/components/chat/ChatHeader.vue
@@ -27,7 +27,7 @@ export interface ChannelHeaderMember {
   presence: OccupantPresence;
 }
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   waddle: SpaceSummary | null;
   channel: ChannelSummary | null;
   dmPeer?: { peerJid?: string; peerUsername: string; presenceShow?: string } | null;
@@ -49,7 +49,20 @@ const props = defineProps<{
   /** Per-controller XEP-0492 settings store — explicit wiring,
    * NOT a module singleton, per the PR-compliance note. */
   notifySettings: NotifySettingsStore;
-}>();
+  /** When a larger in-conversation call banner is mounted, suppress
+   *  the compact header pill so users get one join affordance. */
+  showCallActivePill?: boolean;
+  /** Same suppression for 1:1 answer/reconnect call activity in the
+   *  header; the conversation banner owns that action in ContentArea. */
+  showDmCallActivityControls?: boolean;
+  /** Hide channel start controls while a refreshed live-call banner
+   *  presents the join affordance for this room. */
+  hideMucStartControlsWhenActiveCall?: boolean;
+}>(), {
+  showCallActivePill: true,
+  showDmCallActivityControls: true,
+  hideMucStartControlsWhenActiveCall: false,
+});
 
 const MAX_HEADER_AVATARS = 4;
 
@@ -279,10 +292,13 @@ const memberButtonCopy = computed(() => {
         <CallButton
           v-if="dmPeer?.peerJid"
           :peer-bare-jid="dmPeer.peerJid"
+          :show-activity-controls="showDmCallActivityControls !== false"
         />
         <MucCallButton
           v-else-if="callRoomJid"
           :room-jid="callRoomJid"
+          :show-active-pill="showCallActivePill !== false"
+          :hide-start-controls-when-active-call="hideMucStartControlsWhenActiveCall"
         />
         <!-- Live presence stack — desktop only. The mobile header is
              already crowded with hamburger + channel chip + search/pin/

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -640,6 +640,9 @@ onUnmounted(() => {
               @open-details="ui.showMobileDetails.value = true"
               @open-dm="handleOpenDm"
               @open-thread="openThread"
+              @join-channel-call="joinChannelCallFromActivity"
+              @answer-dm="answerDmFromActivity"
+              @reconnect-dm="reconnectDmFromDock"
               :invoke-extension-action="invokeActiveExtensionAction"
               @refresh-update="refreshAppUpdate"
             />

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -19,6 +19,7 @@ import {
 import { extractFilesFromEvent } from "@/lib/xmpp/file-upload";
 import type { ChannelSummary, SpaceSummary } from "@/lib/chat-types";
 import type { ExtensionAnnotationAction, TimelineMessage, MarkupSpan, MessageReference } from "@/lib/chat-ui";
+import type { CallMedia } from "@/lib/calls/types";
 import type { MentionCandidate } from "@/lib/mentions";
 import type { BrowserXmppClient, MessageSearchResult, XmppStatusSnapshot, RoomAuthority, RoomHats, RoomPresence } from "@/lib/xmpp-client";
 import type { MemberLoadState } from "@/waddles/directory";
@@ -32,6 +33,7 @@ import { ArrowDown, ArrowUp } from "lucide-vue-next";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import ChatHeader, { type ChannelHeaderMember } from "@/components/chat/ChatHeader.vue";
 import CallExpandedSurface from "@/components/calls/CallExpandedSurface.vue";
+import ConversationCallBanner from "@/components/calls/ConversationCallBanner.vue";
 import CallSplitContainer from "@/components/calls/CallSplitContainer.vue";
 import ExtensionPalette from "@/components/chat/ExtensionPalette.vue";
 import MessageCard from "@/components/chat/MessageCard.vue";
@@ -125,6 +127,9 @@ const emit = defineEmits<{
   clearSearch: [];
   openDm: [peerJid: string];
   openThread: [threadId: string, targetMessageId?: string];
+  joinChannelCall: [channelId: string | null, roomJid: string, media: CallMedia];
+  answerDm: [peerJid: string, remoteFullJid: string, sid: string, media: CallMedia];
+  reconnectDm: [peerJid: string, media: CallMedia];
   refreshUpdate: [];
   loadOlder: [];
   retryLoad: [];
@@ -885,10 +890,23 @@ function dayDividerLabel(createdAt: string): string {
       :connection-status-icon="connectionStatusIcon"
       :xmpp-client="xmppClient"
       :notify-settings="notifySettings"
+      :show-call-active-pill="false"
+      :show-dm-call-activity-controls="false"
+      :hide-muc-start-controls-when-active-call="true"
       @open-nav="emit('openNav')"
       @open-details="emit('openDetails')"
       @edit-channel="emit('editChannel')"
       @select-member="(jid: string) => emit('openDm', jid)"
+    />
+    <ConversationCallBanner
+      :room-jid="callRoomJid"
+      :channel-id="channel?.id ?? null"
+      :channel-name="channel?.name ?? null"
+      :dm-peer-jid="dmPeer?.peerJid ?? null"
+      :dm-peer-name="dmPeer?.peerUsername ?? null"
+      @join-channel-call="(channelId, roomJid, media) => emit('joinChannelCall', channelId, roomJid, media)"
+      @answer-dm="(peerJid, remoteFullJid, sid, media) => emit('answerDm', peerJid, remoteFullJid, sid, media)"
+      @reconnect-dm="(peerJid, media) => emit('reconnectDm', peerJid, media)"
     />
     <div
       v-if="connectionNotice && connectionStatusClasses"

--- a/chat/src/lib/calls/call-activity-dock.ts
+++ b/chat/src/lib/calls/call-activity-dock.ts
@@ -67,7 +67,7 @@ function activeDmCallPeerJid(state: CallState): string {
   return "";
 }
 
-function isBusy(state: CallState): boolean {
+export function isBusy(state: CallState): boolean {
   return state.phase !== "idle" && state.phase !== "ended";
 }
 

--- a/chat/tests/call-activity-dock.test.ts
+++ b/chat/tests/call-activity-dock.test.ts
@@ -532,10 +532,228 @@ describe("CallActivityDock rendering", () => {
     expect(html).toContain('aria-label="Answer Bob call, Ringing"');
   });
 
+  test("renders a conversation group call banner and emits join", async () => {
+    $mucCallParticipants.set({
+      "general@conference.example.com": ["alice", "bob"],
+    });
+
+    const props = {
+      roomJid: "general@conference.example.com",
+      channelId: "general",
+      channelName: "General",
+      dmPeerJid: null,
+      dmPeerName: null,
+    };
+    const html = await renderVueComponent("../src/components/calls/ConversationCallBanner.vue", props);
+    expect(html).toContain("General has a live call");
+    expect(html).toContain("2 people connected in this channel.");
+    expect(html).toContain("Join call");
+
+    const emitted: unknown[][] = [];
+    const bindings = await setupVueComponent("../src/components/calls/ConversationCallBanner.vue", props, (...args) => {
+      emitted.push(args);
+    });
+    setupBindingFunction(bindings, "activateBanner")();
+
+    expect(emitted).toEqual([
+      ["joinChannelCall", "general", "general@conference.example.com", { audio: true, video: false }],
+    ]);
+  });
+
+  test("hides the conversation group banner while this resource is already in that call", async () => {
+    $mucCallParticipants.set({
+      "general@conference.example.com": ["alice", "bob"],
+    });
+    $callState.set({
+      phase: "active",
+      kind: "muc",
+      peer: "general@conference.example.com",
+      sid: "muc-live",
+      media: { audio: true, video: false },
+      join: liveKitJoin,
+    });
+
+    const html = await renderVueComponent("../src/components/calls/ConversationCallBanner.vue", {
+      roomJid: "general@conference.example.com",
+      channelId: "general",
+      channelName: "General",
+      dmPeerJid: null,
+      dmPeerName: null,
+    });
+
+    expect(html).not.toContain("General has a live call");
+  });
+
+  test("keeps the conversation call live region mounted before call activity arrives", async () => {
+    const html = await renderVueComponent("../src/components/calls/ConversationCallBanner.vue", {
+      roomJid: "general@conference.example.com",
+      channelId: "general",
+      channelName: "General",
+      dmPeerJid: null,
+      dmPeerName: null,
+    });
+
+    expect(html).toContain('role="region"');
+    expect(html).toContain('aria-label="Conversation call status"');
+    expect(html).toContain('aria-live="polite"');
+    expect(html).toContain('aria-atomic="true"');
+    expect(html).not.toContain("Join call");
+    expect(html).not.toContain("General has a live call");
+  });
+
+  test("renders a conversation DM accepted-call banner and emits reconnect", async () => {
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com/phone",
+        sid: "dm-live",
+        media: { audio: true, video: true },
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:00:00.000Z",
+      },
+    });
+
+    const props = {
+      roomJid: null,
+      channelId: null,
+      channelName: null,
+      dmPeerJid: "bob@example.com",
+      dmPeerName: "Bob",
+    };
+    const html = await renderVueComponent("../src/components/calls/ConversationCallBanner.vue", props);
+    expect(html).toContain("Call with Bob is live");
+    expect(html).toContain("The video call is still live after refresh.");
+    expect(html).toContain("Rejoin");
+
+    const emitted: unknown[][] = [];
+    const bindings = await setupVueComponent("../src/components/calls/ConversationCallBanner.vue", props, (...args) => {
+      emitted.push(args);
+    });
+    setupBindingFunction(bindings, "activateBanner")();
+
+    expect(emitted).toEqual([
+      ["reconnectDm", "bob@example.com", { audio: true, video: true }],
+    ]);
+  });
+
+  test("renders a conversation DM incoming-call banner and emits answer", async () => {
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com/phone",
+        remoteFullJid: "bob@example.com/phone",
+        sid: "dm-ring",
+        media: { audio: true, video: false },
+        state: "ringing",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:00:00.000Z",
+      },
+    });
+
+    const props = {
+      roomJid: null,
+      channelId: null,
+      channelName: null,
+      dmPeerJid: "bob@example.com",
+      dmPeerName: "Bob",
+    };
+    const html = await renderVueComponent("../src/components/calls/ConversationCallBanner.vue", props);
+    expect(html).toContain("Bob is calling");
+    expect(html).toContain("Bob is calling with a voice call.");
+    expect(html).toContain("Answer");
+
+    const emitted: unknown[][] = [];
+    const bindings = await setupVueComponent("../src/components/calls/ConversationCallBanner.vue", props, (...args) => {
+      emitted.push(args);
+    });
+    setupBindingFunction(bindings, "activateBanner")();
+
+    expect(emitted).toEqual([
+      ["answerDm", "bob@example.com", "bob@example.com/phone", "dm-ring", { audio: true, video: false }],
+    ]);
+  });
+
+  test("keeps unavailable conversation DM banners passive", async () => {
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com/phone",
+        sid: "dm-live",
+        media: { audio: true, video: false },
+        mediaKnown: false,
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:00:00.000Z",
+      },
+    });
+
+    const props = {
+      roomJid: null,
+      channelId: null,
+      channelName: null,
+      dmPeerJid: "bob@example.com",
+      dmPeerName: "Bob",
+    };
+    const html = await renderVueComponent("../src/components/calls/ConversationCallBanner.vue", props);
+    expect(html).toContain("Call with Bob is live");
+    expect(html).toContain("Waiting for call details to finish syncing.");
+    expect(html).toContain("Unavailable");
+    expect(html).toContain("disabled");
+
+    const emitted: unknown[][] = [];
+    const bindings = await setupVueComponent("../src/components/calls/ConversationCallBanner.vue", props, (...args) => {
+      emitted.push(args);
+    });
+    setupBindingFunction(bindings, "activateBanner")();
+    expect(emitted).toEqual([]);
+  });
+
+  test("suppresses header DM activity controls when the conversation banner owns them", async () => {
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com/phone",
+        remoteFullJid: "bob@example.com/phone",
+        sid: "dm-ring",
+        media: { audio: true, video: false },
+        state: "ringing",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:00:00.000Z",
+      },
+    });
+
+    const html = await renderVueComponent("../src/components/calls/CallButton.vue", {
+      peerBareJid: "bob@example.com",
+      showActivityControls: false,
+    });
+
+    expect(html).not.toContain("Answer voice call");
+    expect(html).not.toContain("Incoming voice call");
+    expect(html).not.toContain("Start voice call");
+  });
+
+  test("suppresses header MUC start controls when the conversation banner owns the live call", async () => {
+    $mucCallParticipants.set({
+      "general@conference.example.com": ["alice", "bob"],
+    });
+
+    const html = await renderVueComponent("../src/components/calls/MucCallButton.vue", {
+      roomJid: "general@conference.example.com",
+      showActivePill: false,
+      hideStartControlsWhenActiveCall: true,
+    });
+
+    expect(html).not.toContain("Start voice call in this channel");
+    expect(html).not.toContain("Start video call in this channel");
+    expect(html).not.toContain("Live call in this channel");
+  });
+
   test("is mounted in the desktop sidebar and visible mobile shell", () => {
     const readyShell = readFileSync(new URL("../src/components/chat/ChatReadyShell.vue", import.meta.url), "utf8");
     const mobileDrawers = readFileSync(new URL("../src/components/chat/ChatMobileDrawers.vue", import.meta.url), "utf8");
     const callActivityDock = readFileSync(new URL("../src/components/calls/CallActivityDock.vue", import.meta.url), "utf8");
+    const contentArea = readFileSync(new URL("../src/components/chat/ContentArea.vue", import.meta.url), "utf8");
+    const chatHeader = readFileSync(new URL("../src/components/chat/ChatHeader.vue", import.meta.url), "utf8");
+    const callButton = readFileSync(new URL("../src/components/calls/CallButton.vue", import.meta.url), "utf8");
+    const mucCallButton = readFileSync(new URL("../src/components/calls/MucCallButton.vue", import.meta.url), "utf8");
+    const conversationBanner = readFileSync(new URL("../src/components/calls/ConversationCallBanner.vue", import.meta.url), "utf8");
 
     expect(readyShell).toContain("import CallActivityDock");
     expect(readyShell).toContain("import CurrentCallPanel");
@@ -566,6 +784,34 @@ describe("CallActivityDock rendering", () => {
     expect(mobileDrawers).toContain("@toggle-dms=\"openDmList\"");
     expect(mobileDrawers).toContain("hide-current-call");
     expect(callActivityDock).toContain("entry.peerJid.toLowerCase() === barePeerJid(current.peer).toLowerCase()");
+
+    expect(contentArea).toContain("import ConversationCallBanner");
+    expect(contentArea).toContain("<ConversationCallBanner");
+    expect(contentArea).toContain(":show-call-active-pill=\"false\"");
+    expect(contentArea).toContain(":show-dm-call-activity-controls=\"false\"");
+    expect(contentArea).toContain(":hide-muc-start-controls-when-active-call=\"true\"");
+    expect(contentArea).toContain("@join-channel-call=\"(channelId, roomJid, media) => emit('joinChannelCall', channelId, roomJid, media)\"");
+    expect(contentArea).toContain("@answer-dm=\"(peerJid, remoteFullJid, sid, media) => emit('answerDm', peerJid, remoteFullJid, sid, media)\"");
+    expect(contentArea).toContain("@reconnect-dm=\"(peerJid, media) => emit('reconnectDm', peerJid, media)\"");
+    expect(readyShell).toContain("@join-channel-call=\"joinChannelCallFromActivity\"");
+    expect(readyShell).toContain("@answer-dm=\"answerDmFromActivity\"");
+    expect(readyShell).toContain("@reconnect-dm=\"reconnectDmFromDock\"");
+    expect(chatHeader).toContain("showCallActivePill?: boolean");
+    expect(chatHeader).toContain("showDmCallActivityControls?: boolean");
+    expect(chatHeader).toContain("hideMucStartControlsWhenActiveCall?: boolean");
+    expect(chatHeader).toContain(":show-activity-controls=\"showDmCallActivityControls !== false\"");
+    expect(chatHeader).toContain(":show-active-pill=\"showCallActivePill !== false\"");
+    expect(chatHeader).toContain(":hide-start-controls-when-active-call=\"hideMucStartControlsWhenActiveCall\"");
+    expect(callButton).toContain("showActivityControls?: boolean");
+    expect(callButton).toContain("v-if=\"showPeerCallActivity || showStartControls\"");
+    expect(callButton).toContain("v-if=\"showPeerCallActivity\"");
+    expect(mucCallButton).toContain("showActivePill?: boolean");
+    expect(mucCallButton).toContain("hideStartControlsWhenActiveCall?: boolean");
+    expect(mucCallButton).toContain("const roomCall = useRoomHasActiveCall(() => props.roomJid)");
+    expect(mucCallButton).toContain("props.hideStartControlsWhenActiveCall && roomCall.hasActiveCall.value");
+    expect(mucCallButton).toContain("v-if=\"showActivePill !== false\"");
+    expect(conversationBanner).toContain("import { dmCallActivityAction, isBusy }");
+    expect(conversationBanner).not.toContain("function isBusy");
   });
 
   test("renders the persistent current-call panel for an active DM call", async () => {


### PR DESCRIPTION
## Summary

- Add a full-width conversation call banner directly under the chat header for refreshed/running channel and DM calls.
- Derive channel visibility from XEP-0272 Muji presence and DM visibility/actions from XEP-0353/Jingle message activity; no non-XMPP call API was added.
- Route channel join, DM answer, and DM reconnect through the existing shell handlers and LiveKit SFU start/answer paths.
- Suppress duplicate header call affordances while the banner owns the in-conversation action: MUC active pill, MUC start controls for already-live rooms, and DM answer/reconnect controls.
- Keep the banner live region mounted before call activity arrives so screen readers can announce call updates reliably.
- Share the call busy-state helper between the dock model and banner instead of duplicating it.
- Keep current-call split and expanded layouts unchanged.

## Plan

- Keep the call UI XMPP-native: derive group calls from XEP-0272 Muji presence and 1:1 calls from XEP-0353/Jingle message activity; do not add non-XMPP call APIs.
- Add a prominent in-conversation call banner beneath the chat header for channels and DMs that have rediscovered/running calls after refresh.
- Route group join, DM answer, and DM reconnect actions through the existing shell call handlers and LiveKit SFU start paths.
- Keep the existing split/expanded call layout unchanged; this banner is a contextual join/answer/reconnect affordance for the current conversation.
- Avoid duplicate in-view call controls by handing off header activity/start affordances to the full-width banner when it owns the refreshed call action.
- Keep the ARIA live region mounted even before active call content appears.
- Add focused rendering/action tests for group calls, 1:1 incoming/accepted calls, current-call hiding, unavailable states, persistent live-region behavior, shell wiring, and duplicate-control suppression.
- Run chat package verification before marking ready.

## XEP Review

- Reviewed local `xeps/xep-0353.xml` for Jingle Message Initiation and responder full-JID behavior.
- Reviewed local `xeps/xep-0272.xml` for Muji presence-driven group call visibility.
- Reviewed local `xeps/xep-0483.xml` for SFU/online-meeting context.
- No non-XMPP API was added.

## Verification

- `bun test tests/call-activity-dock.test.ts` (57 pass)
- `bun run lint`
- `bun test` (1320 pass)
- `bun run build`
- `git diff --check`

## Review Notes

- Adversarial protocol/state review found no actionable issues.
- Adversarial frontend/accessibility review first found duplicate header call controls for channel and DM calls; both were fixed and covered. Final re-review found no actionable frontend/accessibility issues.
- Greptile flagged a dynamically inserted `aria-live` region and duplicated `isBusy` helper; both were fixed and covered.
- No dev server was started.
- No knip suppressions were added.