### PR TITLE
feat(chat): deepen refreshed call continuity

### DIFF
--- a/chat/src/components/calls/CallActivityDock.vue
+++ b/chat/src/components/calls/CallActivityDock.vue
@@ -8,7 +8,8 @@ import {
   normalizeMucCallRoomJid,
 } from "@/lib/calls/muc-call-presence";
 import { $callState } from "@/lib/calls/call-store";
-import { $dmCallActivities } from "@/lib/calls/dm-call-activity";
+import { $dmCallActivities, dmCallResumeBlockReason } from "@/lib/calls/dm-call-activity";
+import { mucCallParticipantPreview } from "@/lib/calls/muc-call-indicators";
 import {
   callActivityDockAction,
   buildCallActivityDockEntries,
@@ -21,6 +22,8 @@ import type { ChannelSummary } from "@/lib/chat-types";
 import type { DmConversation } from "@/lib/xmpp-client";
 import { barePeerJid } from "@/lib/xmpp/jid";
 
+defineOptions({ inheritAttrs: false });
+
 const props = withDefaults(defineProps<{
   channels: ChannelSummary[];
   conversations: DmConversation[];
@@ -29,7 +32,9 @@ const props = withDefaults(defineProps<{
   activePeerJid: string | null;
   sidebarMode: SidebarMode;
   activeChannelJids: Set<string>;
+  callParticipants?: Record<string, readonly string[]>;
   managedMucDomain?: string | null;
+  selfFullJid?: string | null;
   showDmCalls?: boolean;
   hideCurrentCall?: boolean;
 }>(), {
@@ -49,8 +54,9 @@ const mucCallParticipantsStore = useStore($mucCallParticipants);
 const callState = useStore($callState);
 const dmCallActivities = useStore($dmCallActivities);
 
+const callParticipants = computed(() => props.callParticipants ?? mucCallParticipantsStore.value);
 const callParticipantCounts = computed<Record<string, number>>(() => {
-  return mucCallParticipantCounts(mucCallParticipantsStore.value);
+  return mucCallParticipantCounts(callParticipants.value);
 });
 
 const entries = computed(() => buildCallActivityDockEntries({
@@ -63,6 +69,7 @@ const entries = computed(() => buildCallActivityDockEntries({
   activeChannelJids: props.activeChannelJids,
   managedMucDomain: props.managedMucDomain ?? null,
   callParticipantCounts: callParticipantCounts.value,
+  callParticipants: callParticipants.value,
   dmCallActivities: props.showDmCalls === false ? {} : dmCallActivities.value,
 }));
 const visibleEntries = computed(() =>
@@ -71,6 +78,23 @@ const visibleEntries = computed(() =>
     : entries.value
 );
 const entryCount = computed(() => visibleEntries.value.length);
+const currentCallHidden = computed(() => {
+  if (!props.hideCurrentCall) return false;
+  const current = callState.value;
+  if (current.phase === "muc-pending") return current.kind === "muc";
+  if (current.phase !== "active") return false;
+  if (current.kind === "muc") return true;
+  return props.showDmCalls !== false && current.kind === "dm";
+});
+const statusMessage = computed(() => {
+  const count = entryCount.value;
+  const qualifier = props.showDmCalls === false ? "group " : "";
+  const other = currentCallHidden.value ? "other " : "";
+  if (count === 0) {
+    return `No ${other}active ${qualifier}calls.`;
+  }
+  return `${count} ${other}active ${qualifier}${count === 1 ? "call" : "calls"}.`;
+});
 
 function isCurrentCallEntry(entry: CallActivityDockEntry): boolean {
   const current = callState.value;
@@ -88,12 +112,21 @@ function entryStatus(entry: CallActivityDockEntry): string {
     const noun = entry.participantCount === 1 ? "person" : "people";
     return `${entry.participantCount} ${noun}`;
   }
+  if (entry.state === "accepted") return acceptedDmEntryStatus(entry);
   if (entry.state === "ringing") {
     if (entry.direction === "outgoing") return "Calling";
     if (entry.direction === "incoming") return "Ringing";
     return "Ringing";
   }
   return "Live";
+}
+
+function acceptedDmEntryStatus(entry: Extract<CallActivityDockEntry, { kind: "dm" }>): string {
+  const reason = dmCallResumeBlockReason(entry, props.selfFullJid ?? null);
+  if (reason === null) return "Live";
+  if (reason === "other-resource") return "Other device";
+  if (reason === "expired-token" || reason === "invalid-token") return "Expired";
+  return "Details pending";
 }
 
 function entryKindLabel(entry: CallActivityDockEntry): string {
@@ -106,8 +139,13 @@ function entryMeta(entry: CallActivityDockEntry): string {
   return `${entryKindLabel(entry)} · ${entryStatus(entry)}`;
 }
 
+function entryParticipantPreview(entry: CallActivityDockEntry): string {
+  if (entry.kind !== "channel") return "";
+  return mucCallParticipantPreview(entry.participantLabels);
+}
+
 function entryAction(entry: CallActivityDockEntry): string {
-  switch (callActivityDockAction(entry, callState.value)) {
+  switch (callActivityDockAction(entry, callState.value, props.selfFullJid ?? null)) {
     case "answer":
       return "Answer";
     case "join":
@@ -122,16 +160,27 @@ function entryAction(entry: CallActivityDockEntry): string {
 }
 
 function entryTitle(entry: CallActivityDockEntry): string {
-  return `${entryAction(entry)} ${entry.title} call, ${entryStatus(entry)}`;
+  const participants = entryParticipantPreview(entry);
+  const participantPart = participants ? `, ${participants} in call` : "";
+  return `${entryAction(entry)} ${entry.title}, ${entryMeta(entry)}${participantPart}`;
 }
 
 function entryCanSelect(entry: CallActivityDockEntry): boolean {
   return entry.kind !== "channel" || entry.roomJid.length > 0;
 }
 
+function visibleParticipantLabels(entry: CallActivityDockEntry): string[] {
+  if (entry.kind !== "channel") return [];
+  return entry.participantLabels.slice(0, 3);
+}
+
+function participantInitial(label: string): string {
+  return label.trim().charAt(0).toUpperCase() || "?";
+}
+
 function selectEntry(entry: CallActivityDockEntry): void {
   if (!entryCanSelect(entry)) return;
-  const selection = callActivityDockSelection(entry, callState.value);
+  const selection = callActivityDockSelection(entry, callState.value, props.selfFullJid ?? null);
   switch (selection.kind) {
     case "dm-answer":
       emit("answerDm", selection.peerJid, selection.remoteFullJid, selection.sid, selection.media);
@@ -153,65 +202,94 @@ function selectEntry(entry: CallActivityDockEntry): void {
 </script>
 
 <template>
-  <div
-    v-if="visibleEntries.length > 0"
-    class="call-activity-dock"
-    aria-label="Active calls"
-  >
-    <div class="call-activity-dock__header">
-      <span class="call-activity-dock__pulse" aria-hidden="true" />
-      <span class="type-section-label">Active calls</span>
-      <span class="call-activity-dock__total type-count-badge" aria-hidden="true">
-        {{ entryCount }}
-      </span>
-    </div>
-    <div class="call-activity-dock__list">
-      <button
-        v-for="entry in visibleEntries"
-        :key="entry.key"
-        type="button"
-        class="call-activity-dock__row"
-        :class="{
-          'call-activity-dock__row--active': entry.isActive,
-          'call-activity-dock__row--disabled': !entryCanSelect(entry),
-        }"
-        :disabled="!entryCanSelect(entry)"
-        :aria-current="entry.isActive ? 'page' : undefined"
-        :title="entryTitle(entry)"
-        :aria-label="entryTitle(entry)"
-        @click="selectEntry(entry)"
-      >
-        <span class="call-activity-dock__icon" aria-hidden="true">
-          <Hash v-if="entry.kind === 'channel'" class="h-3.5 w-3.5" />
-          <Video v-else-if="entry.mediaKnown !== false && entry.media.video" class="h-3.5 w-3.5" />
-          <PhoneIncoming v-else-if="entry.state === 'ringing' && entry.direction === 'incoming'" class="h-3.5 w-3.5" />
-          <PhoneOutgoing v-else-if="entry.state === 'ringing' && entry.direction === 'outgoing'" class="h-3.5 w-3.5" />
-          <MessageCircle v-else-if="entry.state === 'ringing'" class="h-3.5 w-3.5" />
-          <Phone v-else class="h-3.5 w-3.5" />
+  <div class="call-activity-dock-host">
+    <p class="sr-only" role="status" aria-live="polite" aria-atomic="true">
+      {{ statusMessage }}
+    </p>
+    <section
+      v-if="visibleEntries.length > 0"
+      class="call-activity-dock"
+      :class="$attrs.class"
+      role="region"
+      aria-label="Active calls"
+    >
+      <div class="call-activity-dock__header">
+        <span class="call-activity-dock__pulse" aria-hidden="true" />
+        <span class="type-section-label">Active calls</span>
+        <span class="call-activity-dock__total type-count-badge" aria-hidden="true">
+          {{ entryCount }}
         </span>
-        <span class="call-activity-dock__copy">
-          <span class="call-activity-dock__title type-control">{{ entry.title }}</span>
-          <span class="call-activity-dock__status type-meta">
-            {{ entryMeta(entry) }}
-          </span>
-        </span>
-        <span
-          v-if="entry.kind === 'channel'"
-          class="call-activity-dock__count type-count-badge"
-          aria-hidden="true"
+      </div>
+      <div class="call-activity-dock__list">
+        <button
+          v-for="entry in visibleEntries"
+          :key="entry.key"
+          type="button"
+          class="call-activity-dock__row"
+          :class="{
+            'call-activity-dock__row--active': entry.isActive,
+            'call-activity-dock__row--disabled': !entryCanSelect(entry),
+          }"
+          :disabled="!entryCanSelect(entry)"
+          :aria-current="entry.isActive ? 'page' : undefined"
+          :title="entryTitle(entry)"
+          :aria-label="entryTitle(entry)"
+          @click="selectEntry(entry)"
         >
-          {{ entry.participantCount }}
-        </span>
-        <span class="call-activity-dock__action type-meta" aria-hidden="true">
-          {{ entryAction(entry) }}
-          <ArrowRight v-if="entryCanSelect(entry)" class="h-3 w-3" />
-        </span>
-      </button>
-    </div>
+          <span class="call-activity-dock__icon" aria-hidden="true">
+            <Hash v-if="entry.kind === 'channel'" class="h-3.5 w-3.5" />
+            <Video v-else-if="entry.mediaKnown !== false && entry.media.video" class="h-3.5 w-3.5" />
+            <PhoneIncoming v-else-if="entry.state === 'ringing' && entry.direction === 'incoming'" class="h-3.5 w-3.5" />
+            <PhoneOutgoing v-else-if="entry.state === 'ringing' && entry.direction === 'outgoing'" class="h-3.5 w-3.5" />
+            <MessageCircle v-else-if="entry.state === 'ringing'" class="h-3.5 w-3.5" />
+            <Phone v-else class="h-3.5 w-3.5" />
+          </span>
+          <span class="call-activity-dock__copy">
+            <span class="call-activity-dock__title type-control">{{ entry.title }}</span>
+            <span class="call-activity-dock__status type-meta">
+              {{ entryMeta(entry) }}
+            </span>
+            <span
+              v-if="entryParticipantPreview(entry)"
+              class="call-activity-dock__participants type-meta"
+              :title="`${entryParticipantPreview(entry)} in call`"
+            >
+              <span class="call-activity-dock__participant-stack" aria-hidden="true">
+                <span
+                  v-for="label in visibleParticipantLabels(entry)"
+                  :key="`${entry.key}:${label}`"
+                  class="call-activity-dock__participant"
+                >
+                  {{ participantInitial(label) }}
+                </span>
+              </span>
+              <span class="call-activity-dock__participant-copy">
+                {{ entryParticipantPreview(entry) }}
+              </span>
+            </span>
+          </span>
+          <span
+            v-if="entry.kind === 'channel'"
+            class="call-activity-dock__count type-count-badge"
+            aria-hidden="true"
+          >
+            {{ entry.participantCount }}
+          </span>
+          <span class="call-activity-dock__action type-meta" aria-hidden="true">
+            {{ entryAction(entry) }}
+            <ArrowRight v-if="entryCanSelect(entry)" class="h-3 w-3" />
+          </span>
+        </button>
+      </div>
+    </section>
   </div>
 </template>
 
 <style scoped>
+.call-activity-dock-host {
+  display: contents;
+}
+
 .call-activity-dock {
   display: flex;
   flex-shrink: 0;
@@ -316,7 +394,7 @@ function selectEntry(entry: CallActivityDockEntry): void {
   justify-content: center;
   border-radius: var(--radius-sm);
   background: color-mix(in oklab, oklch(0.7 0.18 145) 12%, transparent);
-  color: oklch(0.54 0.15 145);
+  color: var(--success-foreground);
 }
 
 :global(.dark) .call-activity-dock__icon {
@@ -330,7 +408,9 @@ function selectEntry(entry: CallActivityDockEntry): void {
 }
 
 .call-activity-dock__title,
-.call-activity-dock__status {
+.call-activity-dock__status,
+.call-activity-dock__participants,
+.call-activity-dock__participant-copy {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -341,6 +421,38 @@ function selectEntry(entry: CallActivityDockEntry): void {
   color: var(--sidebar-muted);
 }
 
+.call-activity-dock__participants {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  color: var(--sidebar-muted);
+}
+
+.call-activity-dock__participant-stack {
+  display: inline-flex;
+  flex-shrink: 0;
+  padding-left: 0.125rem;
+}
+
+.call-activity-dock__participant {
+  display: inline-flex;
+  width: 1rem;
+  height: 1rem;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid color-mix(in oklab, var(--sidebar-border) 74%, transparent);
+  border-radius: 9999px;
+  background: color-mix(in oklab, var(--sidebar-accent) 82%, var(--card));
+  color: var(--sidebar-foreground);
+  font-size: 0.5625rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.call-activity-dock__participant + .call-activity-dock__participant {
+  margin-left: -0.25rem;
+}
+
 .call-activity-dock__count {
   display: inline-flex;
   min-width: 1.125rem;
@@ -349,7 +461,7 @@ function selectEntry(entry: CallActivityDockEntry): void {
   justify-content: center;
   border-radius: 9999px;
   background: color-mix(in oklab, oklch(0.7 0.18 145) 18%, transparent);
-  color: oklch(0.48 0.14 145);
+  color: var(--success-foreground);
   font-variant-numeric: tabular-nums;
 }
 
@@ -362,14 +474,14 @@ function selectEntry(entry: CallActivityDockEntry): void {
   gap: 0.25rem;
   border-radius: 9999px;
   background: color-mix(in oklab, oklch(0.7 0.18 145) 16%, transparent);
-  color: oklch(0.46 0.14 145);
+  color: var(--success-foreground);
   white-space: nowrap;
 }
 
 .call-activity-dock__row:hover:not(:disabled) .call-activity-dock__action,
 .call-activity-dock__row--active .call-activity-dock__action {
   background: color-mix(in oklab, oklch(0.7 0.18 145) 26%, transparent);
-  color: oklch(0.38 0.14 145);
+  color: var(--success-foreground);
 }
 
 :global(.dark) .call-activity-dock__action,

--- a/chat/src/components/calls/CallButton.vue
+++ b/chat/src/components/calls/CallButton.vue
@@ -4,8 +4,12 @@ import { useStore } from "@nanostores/vue";
 import { Phone, PhoneIncoming, Video } from "lucide-vue-next";
 import { $callState } from "@/lib/calls/call-store";
 import { dmCallActivityAction } from "@/lib/calls/call-activity-dock";
-import { hasKnownDmCallMedia, useDmCallActivity } from "@/lib/calls/dm-call-activity";
-import { answerIncomingDmCallActivity, startDmCallAction } from "@/lib/calls/dm-call-actions";
+import {
+  hasKnownDmCallMedia,
+  refreshDmCallActivityAffordances,
+  useDmCallActivity,
+} from "@/lib/calls/dm-call-activity";
+import { answerIncomingDmCallActivity, resumeDmCallActivity, startDmCallAction } from "@/lib/calls/dm-call-actions";
 import type { CallWireSender } from "@/lib/calls/outbound";
 import { connectionStore } from "@/lib/connection-store";
 import type { CallMedia } from "@/lib/calls/types";
@@ -29,9 +33,8 @@ const { activity: peerCallActivity } = useDmCallActivity(() => props.peerBareJid
 
 /** A call is already in flight — disable the button so the
  *  caller can't start a parallel call while one is ringing or
- *  active. Hydrated peer activity alone stays actionable: sending
- *  a fresh XEP-0353 propose lets the peer's active resource migrate
- *  the call back to this refreshed client. */
+ *  active. Hydrated peer activity only becomes a reconnect affordance
+ *  when the archived LiveKit credentials still belong to this resource. */
 const inCall = computed(
   () => state.value.phase !== "idle" && state.value.phase !== "ended",
 );
@@ -43,7 +46,7 @@ const voiceLabel = computed(() => "Start voice call");
 const videoLabel = computed(() => "Start video call");
 const peerActivityAction = computed(() => {
   const activity = peerCallActivity.value;
-  return activity ? dmCallActivityAction(activity, state.value) : null;
+  return activity ? dmCallActivityAction(activity, state.value, getInitiator() ?? null) : null;
 });
 const activityBannerLabel = computed(() => {
   const activity = peerCallActivity.value;
@@ -117,7 +120,12 @@ async function handlePeerCallActivity(): Promise<void> {
       });
       return;
     case "reconnect":
-      await startCall(activity.media);
+      if (!resumeDmCallActivity({
+        peerBareJid: props.peerBareJid,
+        getSelfFullJid: getInitiator,
+      })) {
+        refreshDmCallActivityAffordances();
+      }
       return;
     case "open":
     case "return":
@@ -145,7 +153,7 @@ async function handlePeerCallActivity(): Promise<void> {
       class="chat-icon-button chat-icon-button--md transition-all duration-200"
       :class="activityButtonDisabled
         ? 'text-muted-foreground opacity-40 cursor-not-allowed'
-        : 'text-success hover:bg-success/10 hover:text-success'"
+        : 'text-success-foreground hover:bg-success/10 hover:text-success-foreground'"
       type="button"
       :title="activityButtonLabel"
       :aria-label="activityButtonLabel"
@@ -206,7 +214,7 @@ async function handlePeerCallActivity(): Promise<void> {
   max-width: 8rem;
   overflow: hidden;
   padding-inline: 0.375rem 0.125rem;
-  color: var(--success);
+  color: var(--success-foreground);
   text-overflow: ellipsis;
   white-space: nowrap;
 }

--- a/chat/src/components/calls/CallOverlay.vue
+++ b/chat/src/components/calls/CallOverlay.vue
@@ -11,8 +11,8 @@ import { useCallEngine } from "@/lib/calls/use-call-engine";
 import { connectionStore } from "@/lib/connection-store";
 import {
   $callConnecting,
+  installCallPagehideSuspension,
   resetCallControls,
-  suspendCallForPageHide,
 } from "@/lib/calls/call-controls";
 import { $callUiMode } from "@/lib/calls/ui-mode";
 
@@ -34,6 +34,7 @@ import { $callUiMode } from "@/lib/calls/ui-mode";
  */
 const state = useStore($callState);
 const { engine } = useCallEngine();
+let disconnectPagehideSuspension: (() => void) | null = null;
 
 function getSender(): CallWireSender | null {
   const client = connectionStore.client as unknown as { xmpp?: unknown } | null;
@@ -83,20 +84,9 @@ watch(
   { immediate: true },
 );
 
-/**
- * Release local camera/mic during page lifecycle suspension without
- * sending XMPP hangup stanzas. Browser refresh must preserve the
- * remote-visible call so the new tab load can rediscover it through
- * MAM call markers or MUC presence replay.
- */
-function handlePageHide(event: PageTransitionEvent): void {
-  if (event.persisted) return;
-  suspendCallForPageHide();
-}
-
 onMounted(() => {
   if (typeof window !== "undefined") {
-    window.addEventListener("pagehide", handlePageHide);
+    disconnectPagehideSuspension = installCallPagehideSuspension(window);
   }
 });
 
@@ -105,9 +95,8 @@ onBeforeUnmount(() => {
   // browser refreshes must not emit XMPP call-ending stanzas; explicit
   // hangup/logout own that path.
   void engine.disconnect();
-  if (typeof window !== "undefined") {
-    window.removeEventListener("pagehide", handlePageHide);
-  }
+  disconnectPagehideSuspension?.();
+  disconnectPagehideSuspension = null;
 });
 </script>
 

--- a/chat/src/components/calls/ConversationCallBanner.vue
+++ b/chat/src/components/calls/ConversationCallBanner.vue
@@ -4,8 +4,13 @@ import { useStore } from "@nanostores/vue";
 import { Phone, PhoneIncoming, PhoneOff, Video } from "lucide-vue-next";
 import { $callState } from "@/lib/calls/call-store";
 import { dmCallActivityAction, isBusy } from "@/lib/calls/call-activity-dock";
-import { $dmCallActivities, hasKnownDmCallMedia, type DmCallActivity } from "@/lib/calls/dm-call-activity";
-import { normalizeMucCallRoomJid } from "@/lib/calls/muc-call-presence";
+import {
+  $dmCallActivities,
+  dmCallResumeBlockReason,
+  hasKnownDmCallMedia,
+  type DmCallActivity,
+} from "@/lib/calls/dm-call-activity";
+import { $mucCallParticipants, normalizeMucCallRoomJid } from "@/lib/calls/muc-call-presence";
 import { useRoomHasActiveCall } from "@/lib/calls/use-active-muc-call";
 import type { CallMedia } from "@/lib/calls/types";
 import { barePeerJid } from "@/lib/xmpp/jid";
@@ -16,6 +21,7 @@ const props = defineProps<{
   channelName?: string | null;
   dmPeerJid?: string | null;
   dmPeerName?: string | null;
+  selfFullJid?: string | null;
 }>();
 
 const emit = defineEmits<{
@@ -28,8 +34,12 @@ type BannerAction = "answer" | "join" | "reconnect" | "unavailable";
 
 type BannerView = {
   kind: "group" | "dm";
+  tone: "busy" | "incoming" | "live" | "syncing";
+  eyebrow: string;
   title: string;
   body: string;
+  meta: string[];
+  avatarLabels: string[];
   action: BannerAction;
   actionLabel: string;
   ariaLabel: string;
@@ -46,10 +56,16 @@ type BannerView = {
 
 const callState = useStore($callState);
 const dmCallActivities = useStore($dmCallActivities);
+const mucCallParticipants = useStore($mucCallParticipants);
 const roomCall = useRoomHasActiveCall(() => props.roomJid ?? "");
 
 const normalizedRoomJid = computed(() => normalizeMucCallRoomJid(props.roomJid ?? ""));
 const normalizedDmPeerJid = computed(() => barePeerJid(props.dmPeerJid ?? "").toLowerCase());
+const roomParticipantLabels = computed(() => {
+  const roomJid = normalizedRoomJid.value;
+  if (!roomJid) return [];
+  return mucCallParticipants.value[roomJid] ?? [];
+});
 const dmActivity = computed<DmCallActivity | null>(() => {
   const peerJid = normalizedDmPeerJid.value;
   if (!peerJid) return null;
@@ -83,8 +99,12 @@ function groupCallBanner(): BannerView | null {
 
   return {
     kind: "group",
+    tone: busy ? "busy" : "live",
+    eyebrow: "Live now",
     title,
     body: `${participantCount} ${participantNoun} connected in this channel.`,
+    meta: ["Voice call", "Channel"],
+    avatarLabels: roomParticipantLabels.value,
     action: busy ? "unavailable" : "join",
     actionLabel: busy ? "In another call" : "Join call",
     ariaLabel: busy ? `${title}; already in another call` : `Join ${props.channelName || "channel"} call`,
@@ -102,7 +122,7 @@ function dmBanner(): BannerView | null {
   const peerJid = normalizedDmPeerJid.value;
   if (!activity || !peerJid || props.roomJid) return null;
 
-  const action = dmCallActivityAction(activity, callState.value);
+  const action = dmCallActivityAction(activity, callState.value, props.selfFullJid ?? null);
   if (action === "return") return null;
 
   const media = activity.media;
@@ -114,8 +134,12 @@ function dmBanner(): BannerView | null {
   if (action === "answer" && activity.remoteFullJid) {
     return {
       kind: "dm",
+      tone: "incoming",
+      eyebrow: "Incoming call",
       title,
       body: `${peerName} is calling with a ${mediaLabel}.`,
+      meta: [capitalizeLabel(mediaLabel), "Ringing"],
+      avatarLabels: [peerName],
       action: "answer",
       actionLabel: "Answer",
       ariaLabel: `Answer ${peerName} ${mediaLabel}`,
@@ -132,8 +156,12 @@ function dmBanner(): BannerView | null {
   if (action === "reconnect" && hasKnownDmCallMedia(activity)) {
     return {
       kind: "dm",
+      tone: "live",
+      eyebrow: "Live now",
       title,
-      body: `The ${mediaLabel} is still live after refresh.`,
+      body: `The ${mediaLabel} is still live.`,
+      meta: [capitalizeLabel(mediaLabel), "1:1"],
+      avatarLabels: [peerName],
       action: "reconnect",
       actionLabel: "Rejoin",
       ariaLabel: `Rejoin ${peerName} ${mediaLabel}`,
@@ -145,16 +173,100 @@ function dmBanner(): BannerView | null {
     };
   }
 
+  const unavailable = dmUnavailableState(activity, mediaLabel, title, busy);
   return {
     kind: "dm",
+    tone: unavailable.tone,
+    eyebrow: unavailable.eyebrow,
     title,
-    body: busy ? `Finish the current call before joining this ${mediaLabel}.` : "Waiting for call details to finish syncing.",
+    body: unavailable.body,
+    meta: [capitalizeLabel(mediaLabel), unavailable.meta],
+    avatarLabels: [peerName],
     action: "unavailable",
-    actionLabel: busy ? "In another call" : "Unavailable",
-    ariaLabel: busy ? `${title}; already in another call` : `${title}; call details unavailable`,
+    actionLabel: unavailable.actionLabel,
+    ariaLabel: unavailable.ariaLabel,
     disabled: true,
     icon: Phone,
     actionIcon: PhoneOff,
+  };
+}
+
+function dmUnavailableState(
+  activity: DmCallActivity,
+  mediaLabel: string,
+  title: string,
+  busy: boolean,
+): {
+  tone: "busy" | "syncing";
+  eyebrow: string;
+  body: string;
+  meta: string;
+  actionLabel: string;
+  ariaLabel: string;
+} {
+  if (busy) {
+    return {
+      tone: "busy",
+      eyebrow: "Busy",
+      body: `Finish the current call before joining this ${mediaLabel}.`,
+      meta: "Another call",
+      actionLabel: "In another call",
+      ariaLabel: `${title}; already in another call`,
+    };
+  }
+
+  if (activity.state === "accepted") {
+    const reason = dmCallResumeBlockReason(activity, props.selfFullJid ?? null);
+    if (reason === "missing-join" || reason === "missing-self") {
+      return {
+        tone: "syncing",
+        eyebrow: "Syncing",
+        body: "Reconnect details are not available on this tab yet.",
+        meta: "Details pending",
+        actionLabel: "Unavailable",
+        ariaLabel: `${title}; reconnect details unavailable`,
+      };
+    }
+    if (reason === "other-resource") {
+      return {
+        tone: "syncing",
+        eyebrow: "Other device",
+        body: "This call is live on another browser or device.",
+        meta: "Other device",
+        actionLabel: "Unavailable",
+        ariaLabel: `${title}; live on another device`,
+      };
+    }
+    if (reason === "expired-token" || reason === "invalid-token") {
+      return {
+        tone: "syncing",
+        eyebrow: "Expired",
+        body: "The saved reconnect details expired.",
+        meta: "Expired",
+        actionLabel: "Unavailable",
+        ariaLabel: `${title}; reconnect details expired`,
+      };
+    }
+  }
+
+  if (activity.state === "ringing" && activity.direction === "outgoing") {
+    return {
+      tone: "syncing",
+      eyebrow: "Calling",
+      body: `The ${mediaLabel} is still ringing.`,
+      meta: "Ringing",
+      actionLabel: "Waiting",
+      ariaLabel: `${title}; still ringing`,
+    };
+  }
+
+  return {
+    tone: "syncing",
+    eyebrow: "Syncing",
+    body: "Waiting for call details to finish syncing.",
+    meta: "Details pending",
+    actionLabel: "Unavailable",
+    ariaLabel: `${title}; call details unavailable`,
   };
 }
 
@@ -166,6 +278,19 @@ function dmTitle(activity: DmCallActivity, peerName: string): string {
     return `Calling ${peerName}`;
   }
   return `Call with ${peerName} is live`;
+}
+
+function capitalizeLabel(label: string): string {
+  return label.charAt(0).toUpperCase() + label.slice(1);
+}
+
+function avatarInitials(label: string): string {
+  const parts = label
+    .trim()
+    .split(/[\s._-]+/)
+    .filter(Boolean);
+  const initials = parts.slice(0, 2).map((part) => part.charAt(0).toUpperCase()).join("");
+  return initials || "?";
 }
 
 function activateBanner(): void {
@@ -192,33 +317,64 @@ function activateBanner(): void {
 </script>
 
 <template>
-  <section
-    role="region"
-    :aria-label="banner ? banner.title : 'Conversation call status'"
+  <div
     aria-live="polite"
     aria-atomic="true"
   >
-    <div
+    <section
       v-if="banner"
-      class="border-b border-primary/15 bg-primary/8 text-foreground"
+      role="region"
+      :aria-label="banner.title"
+      class="conversation-call-banner"
+      :class="`conversation-call-banner--${banner.tone}`"
     >
-      <div class="chat-message-lane flex flex-col gap-3 px-[var(--chat-content-inline)] py-3 sm:flex-row sm:items-center sm:justify-between">
-        <div class="flex min-w-0 items-start gap-3">
-          <div class="mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full border border-primary/20 bg-background/80 text-primary">
-            <component :is="banner.icon" class="h-4 w-4" aria-hidden="true" />
+      <div class="chat-message-lane conversation-call-banner__lane">
+        <div class="conversation-call-banner__main">
+          <div class="conversation-call-banner__avatars" aria-hidden="true">
+            <span
+              v-for="label in banner.avatarLabels.slice(0, 3)"
+              :key="label"
+              class="conversation-call-banner__avatar type-meta"
+            >
+              {{ avatarInitials(label) }}
+            </span>
+            <span
+              v-if="banner.avatarLabels.length > 3"
+              class="conversation-call-banner__avatar conversation-call-banner__avatar--more type-meta"
+            >
+              +{{ banner.avatarLabels.length - 3 }}
+            </span>
           </div>
-          <div class="min-w-0">
-            <p class="type-control truncate">
-              {{ banner.title }}
-            </p>
-            <p class="type-caption chat-copy-measure text-foreground/75">
+          <div class="conversation-call-banner__copy">
+            <div class="conversation-call-banner__eyebrow type-meta">
+              <span class="conversation-call-banner__pulse" aria-hidden="true" />
+              <span>{{ banner.eyebrow }}</span>
+            </div>
+            <div class="conversation-call-banner__title-row">
+              <span class="conversation-call-banner__icon" aria-hidden="true">
+                <component :is="banner.icon" class="h-3.5 w-3.5" />
+              </span>
+              <p class="type-control truncate">
+                {{ banner.title }}
+              </p>
+            </div>
+            <p class="type-caption chat-copy-measure conversation-call-banner__body">
               {{ banner.body }}
             </p>
+            <div class="conversation-call-banner__meta" aria-hidden="true">
+              <span
+                v-for="item in banner.meta"
+                :key="item"
+                class="conversation-call-banner__chip type-meta"
+              >
+                {{ item }}
+              </span>
+            </div>
           </div>
         </div>
         <button
           type="button"
-          class="type-control inline-flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-full border border-primary/20 bg-background/85 px-3.5 text-primary transition-colors hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/35 disabled:cursor-not-allowed disabled:border-border disabled:text-muted-foreground disabled:hover:bg-background/85"
+          class="conversation-call-banner__action type-control"
           :aria-label="banner.ariaLabel"
           :disabled="banner.disabled"
           @click="activateBanner"
@@ -227,6 +383,206 @@ function activateBanner(): void {
           <span>{{ banner.actionLabel }}</span>
         </button>
       </div>
-    </div>
-  </section>
+    </section>
+  </div>
 </template>
+
+<style scoped>
+.conversation-call-banner {
+  border-bottom: 1px solid color-mix(in oklab, var(--primary) 18%, var(--border));
+  background:
+    linear-gradient(
+      90deg,
+      color-mix(in oklab, var(--primary) 10%, var(--background)),
+      color-mix(in oklab, var(--card) 88%, var(--primary) 12%)
+    );
+  color: var(--foreground);
+}
+
+.conversation-call-banner--incoming {
+  border-bottom-color: color-mix(in oklab, oklch(0.76 0.17 72) 40%, var(--border));
+  background:
+    linear-gradient(
+      90deg,
+      color-mix(in oklab, oklch(0.76 0.17 72) 14%, var(--background)),
+      color-mix(in oklab, var(--card) 88%, oklch(0.76 0.17 72) 12%)
+    );
+}
+
+.conversation-call-banner--busy,
+.conversation-call-banner--syncing {
+  border-bottom-color: var(--border);
+  background:
+    linear-gradient(
+      90deg,
+      color-mix(in oklab, var(--muted) 42%, var(--background)),
+      color-mix(in oklab, var(--card) 92%, var(--muted) 8%)
+    );
+}
+
+.conversation-call-banner__lane {
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+  padding: 0.75rem var(--chat-content-inline);
+}
+
+.conversation-call-banner__main {
+  display: flex;
+  min-width: 0;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.conversation-call-banner__avatars {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  padding-left: 0.25rem;
+}
+
+.conversation-call-banner__avatar {
+  display: inline-flex;
+  width: 2rem;
+  height: 2rem;
+  align-items: center;
+  justify-content: center;
+  margin-left: -0.25rem;
+  border: 2px solid color-mix(in oklab, var(--background) 88%, transparent);
+  border-radius: 9999px;
+  background: color-mix(in oklab, var(--primary) 18%, var(--card));
+  color: var(--primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.conversation-call-banner__avatar--more {
+  background: color-mix(in oklab, var(--foreground) 9%, var(--card));
+  color: var(--muted-foreground);
+}
+
+.conversation-call-banner__copy {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.conversation-call-banner__eyebrow,
+.conversation-call-banner__title-row,
+.conversation-call-banner__meta {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+}
+
+.conversation-call-banner__eyebrow {
+  gap: 0.35rem;
+  color: color-mix(in oklab, var(--primary) 72%, var(--foreground));
+  text-transform: uppercase;
+}
+
+.conversation-call-banner--busy .conversation-call-banner__eyebrow,
+.conversation-call-banner--syncing .conversation-call-banner__eyebrow {
+  color: var(--muted-foreground);
+}
+
+.conversation-call-banner__pulse {
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 9999px;
+  background: oklch(0.68 0.2 145);
+  box-shadow: 0 0 0 3px color-mix(in oklab, oklch(0.68 0.2 145) 24%, transparent);
+}
+
+.conversation-call-banner--incoming .conversation-call-banner__pulse {
+  background: oklch(0.76 0.17 72);
+  box-shadow: 0 0 0 3px color-mix(in oklab, oklch(0.76 0.17 72) 25%, transparent);
+}
+
+.conversation-call-banner--busy .conversation-call-banner__pulse,
+.conversation-call-banner--syncing .conversation-call-banner__pulse {
+  background: var(--muted-foreground);
+  box-shadow: none;
+}
+
+.conversation-call-banner__title-row {
+  gap: 0.4rem;
+}
+
+.conversation-call-banner__icon {
+  display: inline-flex;
+  flex-shrink: 0;
+  color: var(--primary);
+}
+
+.conversation-call-banner__body {
+  color: color-mix(in oklab, var(--foreground) 76%, transparent);
+}
+
+.conversation-call-banner__meta {
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  padding-top: 0.125rem;
+}
+
+.conversation-call-banner__chip {
+  display: inline-flex;
+  min-height: 1.375rem;
+  align-items: center;
+  border: 1px solid color-mix(in oklab, var(--primary) 18%, var(--border));
+  border-radius: 9999px;
+  background: color-mix(in oklab, var(--background) 74%, transparent);
+  color: var(--muted-foreground);
+  padding: 0 0.5rem;
+  white-space: nowrap;
+}
+
+.conversation-call-banner__action {
+  display: inline-flex;
+  height: 2.25rem;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  border: 1px solid color-mix(in oklab, var(--primary) 22%, var(--border));
+  border-radius: 9999px;
+  background: color-mix(in oklab, var(--background) 88%, transparent);
+  color: var(--primary);
+  padding: 0 0.875rem;
+  transition: background-color 150ms ease, border-color 150ms ease, color 150ms ease;
+}
+
+.conversation-call-banner__action:hover {
+  background: color-mix(in oklab, var(--primary) 11%, var(--background));
+}
+
+.conversation-call-banner__action:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px color-mix(in oklab, var(--primary) 35%, transparent);
+}
+
+.conversation-call-banner__action:disabled {
+  cursor: not-allowed;
+  border-color: var(--border);
+  color: var(--muted-foreground);
+}
+
+.conversation-call-banner__action:disabled:hover {
+  background: color-mix(in oklab, var(--background) 88%, transparent);
+}
+
+@media (pointer: coarse) {
+  .conversation-call-banner__action {
+    height: var(--control-touch);
+  }
+}
+
+@media (min-width: 640px) {
+  .conversation-call-banner__lane {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+</style>

--- a/chat/src/components/calls/CurrentCallPanel.vue
+++ b/chat/src/components/calls/CurrentCallPanel.vue
@@ -28,6 +28,7 @@ import {
   $mucCallParticipants,
   normalizeMucCallRoomJid,
 } from "@/lib/calls/muc-call-presence";
+import { mucCallParticipantPreview } from "@/lib/calls/muc-call-indicators";
 import { barePeerJid } from "@/lib/xmpp/jid";
 import type { ChannelSummary } from "@/lib/chat-types";
 import type { DmConversation } from "@/lib/xmpp-client";
@@ -55,6 +56,7 @@ type CurrentCallPanelState = {
   connected: boolean;
   viewing: boolean;
   participantCount: number;
+  participantLabels: string[];
 };
 
 const state = useStore($callState);
@@ -79,7 +81,13 @@ const panel = computed<CurrentCallPanelState | null>(() => {
     const channel = props.channels.find((candidate) =>
       normalizeMucCallRoomJid(candidate.jid ?? "") === roomJid
     );
-    const participantCount = mucParticipants.value[roomJid]?.length ?? 0;
+    const participantLabels = mucParticipants.value[roomJid] ?? [];
+    const fallbackLabels = participantLabels.length > 0
+      ? participantLabels
+      : current.selfNick
+        ? [current.selfNick]
+        : [];
+    const participantCount = Math.max(fallbackLabels.length, current.phase === "muc-pending" ? 1 : 0);
     return {
       kind: "muc",
       title: channel?.name ?? roomJid.split("@")[0] ?? "Group call",
@@ -92,6 +100,7 @@ const panel = computed<CurrentCallPanelState | null>(() => {
         (!!activeChannelRoom.value && activeChannelRoom.value === roomJid)
       ),
       participantCount,
+      participantLabels: fallbackLabels,
     };
   }
 
@@ -109,6 +118,7 @@ const panel = computed<CurrentCallPanelState | null>(() => {
     connected: true,
     viewing: barePeerJid(props.activePeerJid ?? "").toLowerCase() === peerJid,
     participantCount: 2,
+    participantLabels: [],
   };
 });
 
@@ -130,6 +140,8 @@ const participantLabel = computed(() => {
   const current = panel.value;
   if (!current) return "";
   if (current.kind === "dm") return "1:1";
+  const preview = mucCallParticipantPreview(current.participantLabels);
+  if (preview) return preview;
   const count = current.participantCount;
   if (count <= 0) return "Group";
   return `${count} in call`;

--- a/chat/src/components/chat/ChatMobileDrawers.vue
+++ b/chat/src/components/chat/ChatMobileDrawers.vue
@@ -6,6 +6,11 @@ import {
   mucCallParticipantCounts,
 } from "@/lib/calls/muc-call-presence";
 import { $dmCallActivities } from "@/lib/calls/dm-call-activity";
+import { $callState } from "@/lib/calls/call-store";
+import {
+  activeChannelRailCallCount,
+  activeDmRailCallCount,
+} from "@/lib/calls/call-rail-counts";
 import { normalizeMucServiceDomain } from "@/lib/calls/muc-call-indicators";
 import WaddlesSidebar from "@/components/chat/WaddlesSidebar.vue";
 import TopicsPanel from "@/components/chat/TopicsPanel.vue";
@@ -91,15 +96,21 @@ function reconnectDmFromMobile(peerJid: string, media: CallMedia) {
 // the same "call ongoing" chip.
 const mucCallParticipantsStore = useStore($mucCallParticipants);
 const dmCallActivitiesStore = useStore($dmCallActivities);
+const callStateStore = useStore($callState);
 const callParticipantCounts = computed<Record<string, number>>(() => {
   return mucCallParticipantCounts(mucCallParticipantsStore.value);
 });
-const activeChannelCallCount = computed(() =>
-  Object.values(callParticipantCounts.value).filter((count) => count > 0).length,
-);
-const activeDmCallCount = computed(() => Object.keys(dmCallActivitiesStore.value).length);
+const activeChannelCallCount = computed(() => {
+  return activeChannelRailCallCount(callParticipantCounts.value, callStateStore.value);
+});
+const activeDmCallCount = computed(() => {
+  return activeDmRailCallCount(dmCallActivitiesStore.value, callStateStore.value);
+});
 const managedMucDomain = computed(() =>
   normalizeMucServiceDomain(waddles.mucServiceJid.value) || (selfDomain.value ? `muc.${selfDomain.value}` : ""),
+);
+const selfFullJid = computed(() =>
+  (connectionStore.client as unknown as { fullJid?: string } | null)?.fullJid ?? null
 );
 
 const drawerExtensionRoutes = computed(() =>
@@ -185,6 +196,7 @@ function openExtensionRoute(route: DiscoveredExtensionRoute) {
           v-else
           :conversations="dmConversations.conversations.value"
           :active-peer-jid="dmConversations.activePeerJid.value"
+          :self-full-jid="selfFullJid"
           hide-current-call
           class="!w-full !border-r-0 !flex-1"
           @answer-dm="answerDmFromMobile"

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -6,7 +6,11 @@ import {
   mucCallParticipantCounts,
 } from "@/lib/calls/muc-call-presence";
 import { $dmCallActivities } from "@/lib/calls/dm-call-activity";
-import { answerIncomingDmCallActivity, startDmCallAction } from "@/lib/calls/dm-call-actions";
+import {
+  activeChannelRailCallCount,
+  activeDmRailCallCount,
+} from "@/lib/calls/call-rail-counts";
+import { answerIncomingDmCallActivity, resumeDmCallActivity } from "@/lib/calls/dm-call-actions";
 import { startMucCallAction } from "@/lib/calls/muc-call-actions";
 import { normalizeMucServiceDomain } from "@/lib/calls/muc-call-indicators";
 import {
@@ -156,17 +160,21 @@ const {
  */
 const mucCallParticipantsStore = useStore($mucCallParticipants);
 const dmCallActivitiesStore = useStore($dmCallActivities);
+const callStateStore = useStore($callState);
 const activityGroupCallStarting = ref(false);
 const callParticipantCounts = computed<Record<string, number>>(() => {
   return mucCallParticipantCounts(mucCallParticipantsStore.value);
 });
-const activeChannelCallCount = computed(() =>
-  Object.values(callParticipantCounts.value).filter((count) => count > 0).length,
-);
-const activeDmCallCount = computed(() => Object.keys(dmCallActivitiesStore.value).length);
+const activeChannelCallCount = computed(() => {
+  return activeChannelRailCallCount(callParticipantCounts.value, callStateStore.value);
+});
+const activeDmCallCount = computed(() => {
+  return activeDmRailCallCount(dmCallActivitiesStore.value, callStateStore.value);
+});
 const managedMucDomain = computed(() =>
   normalizeMucServiceDomain(waddles.mucServiceJid.value) || (selfDomain.value ? `muc.${selfDomain.value}` : ""),
 );
+const selfFullJid = computed(() => getSelfFullJid() ?? null);
 
 const homeDashboardProps = computed(() => buildHomeDashboardProps({
   spaces: waddles.sortedSpaces.value,
@@ -178,8 +186,10 @@ const homeDashboardProps = computed(() => buildHomeDashboardProps({
   activeChannelJids: messaging.activeChannels.value,
   dmConversations: dmConversations.conversations.value,
   callParticipantCounts: callParticipantCounts.value,
+  callParticipants: mucCallParticipantsStore.value,
   dmCallActivities: dmCallActivitiesStore.value,
   managedMucDomain: managedMucDomain.value,
+  selfFullJid: selfFullJid.value,
 }));
 
 const contentPaneClass = computed(() => {
@@ -264,14 +274,9 @@ function isGroupCallBusy(): boolean {
   return activityGroupCallStarting.value || (current.phase !== "idle" && current.phase !== "ended");
 }
 
-function reconnectDmFromDock(peerJid: string, media: CallMedia): void {
+function reconnectDmFromDock(peerJid: string, _media: CallMedia): void {
   selectDm(peerJid);
-  void startDmCallAction({
-    peerBareJid: peerJid,
-    media,
-    getSender: getCallSender,
-    getInitiator: getSelfFullJid,
-  });
+  resumeDmCallActivity({ peerBareJid: peerJid, getSelfFullJid });
 }
 
 function answerDmFromActivity(peerJid: string, remoteFullJid: string, sid: string, media: CallMedia): void {
@@ -371,7 +376,9 @@ onUnmounted(() => {
       :active-peer-jid="dmConversations.activePeerJid.value"
       :sidebar-mode="ui.sidebarMode.value"
       :active-channel-jids="messaging.activeChannels.value"
+      :call-participants="mucCallParticipantsStore"
       :managed-muc-domain="managedMucDomain"
+      :self-full-jid="selfFullJid"
       hide-current-call
       @select-channel="onSelectChannelFromSidebar"
       @join-channel-call="joinChannelCallFromActivity"
@@ -448,6 +455,7 @@ onUnmounted(() => {
           v-else
           :conversations="dmConversations.conversations.value"
           :active-peer-jid="dmConversations.activePeerJid.value"
+          :self-full-jid="selfFullJid"
           hide-current-call
           @answer-dm="answerDmFromActivity"
           @select-dm="selectDm"
@@ -471,7 +479,9 @@ onUnmounted(() => {
           :active-peer-jid="dmConversations.activePeerJid.value"
           :sidebar-mode="ui.sidebarMode.value"
           :active-channel-jids="messaging.activeChannels.value"
+          :call-participants="mucCallParticipantsStore"
           :managed-muc-domain="managedMucDomain"
+          :self-full-jid="selfFullJid"
           :show-dm-calls="ui.sidebarMode.value !== 'dms'"
           hide-current-call
           @select-channel="onSelectChannelFromSidebar"
@@ -604,6 +614,7 @@ onUnmounted(() => {
               :typing-users="activeTypingUsers"
               :current-user="connectionStore.session?.username"
               :current-user-jid="connectionStore.session?.jid"
+              :self-full-jid="selfFullJid"
               :self-domain="selfDomain"
               :avatar-url-by-author="avatarUrlByAuthor"
               :author-jid-by-nick="authorJidByNick"

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -85,6 +85,7 @@ const props = defineProps<{
   typingUsers: string[];
   currentUser?: string;
   currentUserJid?: string;
+  selfFullJid?: string | null;
   selfDomain?: string;
   avatarUrlByAuthor: Record<string, string | null>;
   authorJidByNick?: Record<string, string>;
@@ -904,6 +905,7 @@ function dayDividerLabel(createdAt: string): string {
       :channel-name="channel?.name ?? null"
       :dm-peer-jid="dmPeer?.peerJid ?? null"
       :dm-peer-name="dmPeer?.peerUsername ?? null"
+      :self-full-jid="selfFullJid ?? null"
       @join-channel-call="(channelId, roomJid, media) => emit('joinChannelCall', channelId, roomJid, media)"
       @answer-dm="(peerJid, remoteFullJid, sid, media) => emit('answerDm', peerJid, remoteFullJid, sid, media)"
       @reconnect-dm="(peerJid, media) => emit('reconnectDm', peerJid, media)"

--- a/chat/src/components/chat/DmPanel.vue
+++ b/chat/src/components/chat/DmPanel.vue
@@ -6,7 +6,11 @@ import AppAvatar from "@/components/ui/AppAvatar.vue";
 import { formatTimelineStamp } from "@/channels/timeline";
 import { $callState } from "@/lib/calls/call-store";
 import { dmCallActivityAction } from "@/lib/calls/call-activity-dock";
-import { $dmCallActivities, hasKnownDmCallMedia } from "@/lib/calls/dm-call-activity";
+import {
+  $dmCallActivities,
+  dmCallResumeBlockReason,
+  hasKnownDmCallMedia,
+} from "@/lib/calls/dm-call-activity";
 import type { DmCallActivity } from "@/lib/calls/dm-call-activity";
 import type { CallMedia } from "@/lib/calls/types";
 import { barePeerJid } from "@/lib/xmpp/jid";
@@ -15,6 +19,7 @@ import type { DmConversation } from "@/lib/xmpp-client";
 const props = withDefaults(defineProps<{
   conversations: DmConversation[];
   activePeerJid: string | null;
+  selfFullJid?: string | null;
   hideCurrentCall?: boolean;
 }>(), {
   hideCurrentCall: false,
@@ -35,6 +40,10 @@ const currentActiveDmPeer = computed(() => {
   if (!props.hideCurrentCall || current.phase !== "active" || current.kind !== "dm") return "";
   return normalizedPeerJid(current.peer);
 });
+const hiddenCurrentCallPeer = computed(() => {
+  const peer = currentActiveDmPeer.value;
+  return peer || "";
+});
 const activeCallRows = computed(() =>
   Object.values(dmCallActivities.value)
     .map((activity) => ({
@@ -42,7 +51,11 @@ const activeCallRows = computed(() =>
       peerJid: normalizedPeerJid(activity.peerJid),
       title: callActivityTitle(activity),
       meta: callActivityMeta(activity),
+      description: callActivityDescription(activity),
       action: callActivityActionLabel(activity),
+      eyebrow: callActivityEyebrow(activity),
+      since: callActivitySince(activity),
+      avatarUrl: callActivityAvatarUrl(activity),
     }))
     .filter((row) => row.peerJid && row.peerJid !== currentActiveDmPeer.value)
     .sort((left, right) => {
@@ -52,6 +65,12 @@ const activeCallRows = computed(() =>
       return left.peerJid.localeCompare(right.peerJid);
     }),
 );
+const activeCallStatusMessage = computed(() => {
+  const count = activeCallRows.value.length;
+  const other = hiddenCurrentCallPeer.value ? "other " : "";
+  if (count === 0) return `No ${other}active direct calls.`;
+  return `${count} ${other}active direct ${count === 1 ? "call" : "calls"}.`;
+});
 const visibleConversations = computed<DmConversation[]>(() => {
   const activeCallPeers = new Set(activeCallRows.value.map((row) => row.peerJid));
   return props.conversations
@@ -98,12 +117,18 @@ function hasCallActivity(peerJid: string): boolean {
   return !!normalized && !!dmCallActivities.value[normalized];
 }
 
+function isHiddenCurrentCallPeer(peerJid: string): boolean {
+  const normalized = normalizedPeerJid(peerJid);
+  return !!normalized && hiddenCurrentCallPeer.value === normalized;
+}
+
 function callActivity(peerJid: string): DmCallActivity | null {
   const normalized = normalizedPeerJid(peerJid);
   return normalized ? dmCallActivities.value[normalized] ?? null : null;
 }
 
 function callActivityLabel(peerJid: string): string {
+  if (isHiddenCurrentCallPeer(peerJid)) return "Current call shown separately";
   const activity = callActivity(peerJid);
   return activity?.state === "ringing" ? "Ringing" : "Live";
 }
@@ -116,7 +141,150 @@ function callActivityTitle(activity: DmCallActivity): string {
   return existing?.peerUsername || peerJid.split("@")[0] || peerJid;
 }
 
+function callActivityAvatarUrl(activity: DmCallActivity): string | null {
+  const peerJid = normalizedPeerJid(activity.peerJid);
+  const existing = props.conversations.find((conversation) =>
+    normalizedPeerJid(conversation.peerJid) === peerJid
+  );
+  return existing?.peerAvatarUrl ?? null;
+}
+
+type CallActivityVisualTone = "primary" | "success" | "warning";
+
+function acceptedCallAvailability(activity: DmCallActivity): {
+  eyebrow: string;
+  meta: string;
+  description: string;
+  tone: CallActivityVisualTone;
+} | null {
+  if (activity.state !== "accepted") return null;
+
+  const mediaLabel = hasKnownDmCallMedia(activity)
+    ? `${activity.media.video ? "video" : "voice"} call`
+    : "call";
+  const mediaTitle = `${mediaLabel.charAt(0).toUpperCase()}${mediaLabel.slice(1)}`;
+  const reason = dmCallResumeBlockReason(activity, props.selfFullJid ?? null);
+  if (reason === null) {
+    return {
+      eyebrow: "Live now",
+      meta: `Live ${mediaLabel}`,
+      description: `The ${mediaLabel} is still live.`,
+      tone: "success",
+    };
+  }
+  if (reason === "other-resource") {
+    return {
+      eyebrow: "Other device",
+      meta: `${mediaTitle} · Other device`,
+      description: "This call is live on another browser or device.",
+      tone: "warning",
+    };
+  }
+  if (reason === "expired-token" || reason === "invalid-token") {
+    return {
+      eyebrow: "Expired",
+      meta: `${mediaTitle} · Expired`,
+      description: "The saved reconnect details expired.",
+      tone: "warning",
+    };
+  }
+  return {
+    eyebrow: "Syncing",
+    meta: `${mediaTitle} · Details pending`,
+    description: "Reconnect details are not available on this tab yet.",
+    tone: "primary",
+  };
+}
+
+function callActivityVisualTone(activity: DmCallActivity): CallActivityVisualTone {
+  if (activity.state === "ringing" && activity.direction === "incoming") return "warning";
+  if (activity.state === "ringing" && activity.direction === "outgoing") return "primary";
+  return acceptedCallAvailability(activity)?.tone ?? "success";
+}
+
+function callActivityEyebrow(activity: DmCallActivity): string {
+  const availability = acceptedCallAvailability(activity);
+  if (availability) return availability.eyebrow;
+  if (activity.state === "accepted") return "Live now";
+  if (activity.direction === "incoming") return "Incoming call";
+  if (activity.direction === "outgoing") return "Calling";
+  return "Ringing";
+}
+
+function callActivityToneClass(activity: DmCallActivity): string {
+  switch (callActivityVisualTone(activity)) {
+    case "warning":
+      return "border-warning/25 bg-warning/10 hover:bg-warning/15";
+    case "primary":
+      return "border-primary/25 bg-primary/8 hover:bg-primary/12";
+    case "success":
+      return "border-success/20 bg-success/10 hover:bg-success/15";
+  }
+}
+
+function callActivityActiveToneClass(activity: DmCallActivity): string {
+  switch (callActivityVisualTone(activity)) {
+    case "warning":
+      return "bg-warning/15 text-sidebar-foreground ring-1 ring-warning/30";
+    case "primary":
+      return "bg-primary/10 text-sidebar-foreground ring-1 ring-primary/30";
+    case "success":
+      return "bg-success/15 text-sidebar-foreground ring-1 ring-success/30";
+  }
+}
+
+function callActivityIconClass(activity: DmCallActivity): string {
+  switch (callActivityVisualTone(activity)) {
+    case "warning":
+      return "border-warning/25 bg-background/90 text-warning-foreground";
+    case "primary":
+      return "border-primary/25 bg-background/90 text-primary";
+    case "success":
+      return "border-success/25 bg-background/90 text-success-foreground";
+  }
+}
+
+function callActivityAccentClass(activity: DmCallActivity): string {
+  switch (callActivityVisualTone(activity)) {
+    case "warning":
+      return "text-warning-foreground";
+    case "primary":
+      return "text-primary";
+    case "success":
+      return "text-success-foreground";
+  }
+}
+
+function callActivityDotClass(activity: DmCallActivity): string {
+  switch (callActivityVisualTone(activity)) {
+    case "warning":
+      return "bg-warning shadow-[0_0_6px_var(--warning)]";
+    case "primary":
+      return "bg-primary shadow-[0_0_6px_var(--primary)]";
+    case "success":
+      return "bg-success shadow-[0_0_6px_var(--success)]";
+  }
+}
+
+function callActivityPillClass(activity: DmCallActivity): string {
+  switch (callActivityVisualTone(activity)) {
+    case "warning":
+      return "border-warning/25 bg-background/70 text-warning-foreground";
+    case "primary":
+      return "border-primary/25 bg-background/70 text-primary";
+    case "success":
+      return "border-success/25 bg-background/70 text-success-foreground";
+  }
+}
+
+function callActivitySince(activity: DmCallActivity): string {
+  const stamp = formatTimelineStamp(activity.updatedAt);
+  return stamp ? `Updated ${stamp}` : "";
+}
+
 function callActivityMeta(activity: DmCallActivity): string {
+  const availability = acceptedCallAvailability(activity);
+  if (availability) return availability.meta;
   if (!hasKnownDmCallMedia(activity)) {
     if (activity.state === "accepted") return "Live call";
     if (activity.direction === "incoming") return "Incoming call";
@@ -130,8 +298,16 @@ function callActivityMeta(activity: DmCallActivity): string {
   return `${media[0]?.toUpperCase() ?? "V"}${media.slice(1)} call ringing`;
 }
 
+function callActivityDescription(activity: DmCallActivity): string {
+  const availability = acceptedCallAvailability(activity);
+  if (availability) return availability.description;
+  if (activity.direction === "incoming") return "Waiting for an answer.";
+  if (activity.direction === "outgoing") return "Still ringing.";
+  return "Call is ringing.";
+}
+
 function callActivityActionLabel(activity: DmCallActivity): string {
-  switch (dmCallActivityAction(activity, callState.value)) {
+  switch (dmCallActivityAction(activity, callState.value, props.selfFullJid ?? null)) {
     case "answer":
       return "Answer";
     case "reconnect":
@@ -143,10 +319,27 @@ function callActivityActionLabel(activity: DmCallActivity): string {
   }
 }
 
+function activeCallRowLabel(row: {
+  action: string;
+  title: string;
+  meta: string;
+  description: string;
+  eyebrow: string;
+  since: string;
+}): string {
+  return [
+    `${row.action} ${row.title} call`,
+    row.eyebrow,
+    row.meta,
+    row.description,
+    row.since,
+  ].filter(Boolean).join(", ");
+}
+
 function selectCallActivity(activity: DmCallActivity): void {
   const peerJid = normalizedPeerJid(activity.peerJid);
   if (!peerJid) return;
-  switch (dmCallActivityAction(activity, callState.value)) {
+  switch (dmCallActivityAction(activity, callState.value, props.selfFullJid ?? null)) {
     case "answer":
       if (activity.remoteFullJid) {
         emit("answerDm", peerJid, activity.remoteFullJid, activity.sid, activity.media);
@@ -174,7 +367,11 @@ function conversationRowLabel(conversation: DmConversation): string {
   ];
   const activity = callActivity(conversation.peerJid);
   if (activity) {
-    parts.push(callActivityMeta(activity), `${callActivityActionLabel(activity)} call`);
+    if (isHiddenCurrentCallPeer(conversation.peerJid)) {
+      parts.push("Current call shown separately", "Open conversation");
+    } else {
+      parts.push(callActivityMeta(activity), `${callActivityActionLabel(activity)} call`);
+    }
   } else if (conversation.lastMessageBody) {
     parts.push(preview(conversation.lastMessageBody));
   }
@@ -204,6 +401,9 @@ function conversationRowLabel(conversation: DmConversation): string {
     </div>
 
     <div class="chat-pane-scroll chat-sidebar-scroll">
+      <p class="sr-only" role="status" aria-live="polite" aria-atomic="true">
+        {{ activeCallStatusMessage }}
+      </p>
       <!-- Empty state — halo + MessageCircle glyph + caption + hint
            matches the iter-37 / 47 / 48 authored-empty-state pattern
            used elsewhere in the app. -->
@@ -227,10 +427,10 @@ function conversationRowLabel(conversation: DmConversation): string {
           aria-label="Active direct calls"
         >
           <div class="type-section-label flex items-center gap-1.5 px-2 pt-2 pb-1 text-sidebar-muted">
-            <PhoneCall class="h-3 w-3 text-success" aria-hidden="true" />
+            <PhoneCall class="h-3 w-3 text-success-foreground" aria-hidden="true" />
             <span class="flex-1 truncate">Active calls</span>
             <span
-              class="type-count-badge inline-flex min-w-[18px] h-[18px] px-1 items-center justify-center rounded-full bg-success/15 text-success ring-1 ring-success/30"
+              class="type-count-badge inline-flex min-w-[18px] h-[18px] px-1 items-center justify-center rounded-full bg-success/15 text-success-foreground ring-1 ring-success/30"
               aria-hidden="true"
             >
               {{ activeCallRows.length }}
@@ -239,34 +439,45 @@ function conversationRowLabel(conversation: DmConversation): string {
           <button
             v-for="row in activeCallRows"
             :key="`dm-call:${row.peerJid}:${row.activity.sid}`"
-            class="chat-list-row w-full min-h-11 flex items-center gap-2.5 px-3 py-2 text-left group text-sidebar-muted hover:bg-sidebar-accent/50 hover:text-sidebar-foreground"
-            :class="isActiveConversation(row.peerJid) ? 'chat-list-row--active bg-sidebar-accent text-sidebar-foreground' : ''"
+            class="chat-list-row w-full min-h-16 flex items-center gap-3 rounded-lg border px-3 py-2.5 text-left group text-sidebar-muted hover:text-sidebar-foreground"
+            :class="[
+              callActivityToneClass(row.activity),
+              isActiveConversation(row.peerJid) ? `chat-list-row--active ${callActivityActiveToneClass(row.activity)}` : '',
+            ]"
             type="button"
             :aria-current="isActiveConversation(row.peerJid) ? 'page' : undefined"
-            :aria-label="`${row.action} ${row.title} call, ${row.meta}`"
+            :aria-label="activeCallRowLabel(row)"
             @click="selectCallActivity(row.activity)"
           >
-            <span class="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md bg-success/10 text-success">
-              <Video v-if="hasKnownDmCallMedia(row.activity) && row.activity.media.video" class="h-3.5 w-3.5" aria-hidden="true" />
-              <PhoneIncoming v-else-if="row.activity.state === 'ringing' && row.activity.direction === 'incoming'" class="h-3.5 w-3.5" aria-hidden="true" />
-              <PhoneOutgoing v-else-if="row.activity.state === 'ringing' && row.activity.direction === 'outgoing'" class="h-3.5 w-3.5" aria-hidden="true" />
-              <Phone v-else class="h-3.5 w-3.5" aria-hidden="true" />
+            <span class="relative shrink-0">
+              <AppAvatar :name="row.title" :src="row.avatarUrl" size="sm" />
+              <span class="absolute -right-1 -bottom-1 flex h-4 w-4 items-center justify-center rounded-full border" :class="callActivityIconClass(row.activity)">
+                <Video v-if="hasKnownDmCallMedia(row.activity) && row.activity.media.video" class="h-2.5 w-2.5" aria-hidden="true" />
+                <PhoneIncoming v-else-if="row.activity.state === 'ringing' && row.activity.direction === 'incoming'" class="h-2.5 w-2.5" aria-hidden="true" />
+                <PhoneOutgoing v-else-if="row.activity.state === 'ringing' && row.activity.direction === 'outgoing'" class="h-2.5 w-2.5" aria-hidden="true" />
+                <Phone v-else class="h-2.5 w-2.5" aria-hidden="true" />
+              </span>
             </span>
-            <span class="min-w-0 flex-1">
+            <span class="min-w-0 flex-1 space-y-0.5">
+              <span class="type-meta flex items-center gap-1" :class="callActivityAccentClass(row.activity)">
+                <span class="h-1.5 w-1.5 rounded-full" :class="callActivityDotClass(row.activity)" aria-hidden="true" />
+                <span class="truncate">{{ row.eyebrow }}</span>
+              </span>
               <span class="type-control type-strong block truncate text-sidebar-foreground">
                 {{ row.title }}
               </span>
               <span class="type-meta block truncate text-sidebar-muted">
-                {{ row.meta }}
+                {{ row.meta }}<template v-if="row.description"> · {{ row.description }}</template><template v-if="row.since"> · {{ row.since }}</template>
               </span>
             </span>
             <span
-              class="type-meta hidden shrink-0 rounded-md border border-success/25 bg-success/10 px-1.5 py-0.5 text-success xl:inline-flex"
+              class="type-meta shrink-0 rounded-full border px-2 py-1"
+              :class="callActivityPillClass(row.activity)"
               aria-hidden="true"
             >
               {{ row.action }}
             </span>
-            <ArrowRight class="h-3.5 w-3.5 shrink-0 text-success" aria-hidden="true" />
+            <ArrowRight class="h-3.5 w-3.5 shrink-0" :class="callActivityAccentClass(row.activity)" aria-hidden="true" />
           </button>
         </section>
 
@@ -297,12 +508,15 @@ function conversationRowLabel(conversation: DmConversation): string {
               <span class="type-caption text-sidebar-muted min-w-0 flex-1 truncate">{{ preview(conversation.lastMessageBody) }}</span>
               <span
                 v-if="hasCallActivity(conversation.peerJid)"
-                class="type-meta inline-flex h-[18px] shrink-0 items-center gap-1 rounded-full border border-success/25 bg-success/10 px-1.5 text-success"
+                class="type-meta inline-flex h-[18px] shrink-0 items-center gap-1 rounded-full border px-1.5"
+                :class="isHiddenCurrentCallPeer(conversation.peerJid)
+                  ? 'border-border bg-muted/60 text-sidebar-muted'
+                  : 'border-success/25 bg-success/10 text-success-foreground'"
                 :title="callActivityLabel(conversation.peerJid)"
                 :aria-label="callActivityLabel(conversation.peerJid)"
               >
                 <PhoneCall class="h-3 w-3" />
-                <span>{{ callActivityLabel(conversation.peerJid) }}</span>
+                <span>{{ isHiddenCurrentCallPeer(conversation.peerJid) ? 'Current call' : callActivityLabel(conversation.peerJid) }}</span>
               </span>
               <span
                 v-if="conversation.unreadCount > 0"

--- a/chat/src/components/chat/HomeDashboard.vue
+++ b/chat/src/components/chat/HomeDashboard.vue
@@ -25,13 +25,17 @@ import {
   type CallActivityDockEntry,
 } from "@/lib/calls/call-activity-dock";
 import { $callState } from "@/lib/calls/call-store";
-import { hasKnownDmCallMedia } from "@/lib/calls/dm-call-activity";
-import { callParticipantCountForChannel } from "@/lib/calls/muc-call-indicators";
+import { dmCallResumeBlockReason, hasKnownDmCallMedia } from "@/lib/calls/dm-call-activity";
+import {
+  callParticipantCountForChannel,
+  mucCallParticipantPreview,
+} from "@/lib/calls/muc-call-indicators";
+import { normalizeMucCallRoomJid } from "@/lib/calls/muc-call-presence";
 import { barePeerJid } from "@/lib/xmpp/jid";
 import type { CallMedia } from "@/lib/calls/types";
 import { groupChannelsBySpace } from "@/lib/channel-grouping";
 import { formatTimelineStamp } from "@/channels/timeline";
-import type { ChannelActivityState, HomeDashboardProps } from "@/home/dashboard-props";
+import type { HomeDashboardProps } from "@/home/dashboard-props";
 import {
   channelActivityPreview,
   channelActivityState,
@@ -43,6 +47,7 @@ import {
   dmPreviewText,
   spaceHomeLabel,
   summarizeHomeActivity,
+  type ChannelActivityState,
   type HomeActivitySummary,
 } from "@/home/activity";
 
@@ -115,20 +120,29 @@ const groups = computed(() => groupChannelsBySpace(props.spaces, props.channels)
 const visibleChannelGroups = computed(() => groups.value.filter((group) => group.channels.length > 0));
 const activeChannelJids = computed(() => props.activeChannelJids ?? new Set<string>());
 const callParticipantCounts = computed(() => props.callParticipantCounts ?? {});
+const callParticipants = computed(() => props.callParticipants ?? {});
 const dmCallActivities = computed(() => props.dmCallActivities ?? {});
-const activeDmCallPeers = computed(() =>
-  new Set(Object.values(dmCallActivities.value).map((activity) => barePeerJid(activity.peerJid).toLowerCase()).filter(Boolean)),
-);
+const callState = useStore($callState);
+const currentActiveDmPeer = computed(() => {
+  const current = callState.value;
+  return current.phase === "active" && current.kind === "dm"
+    ? barePeerJid(current.peer).toLowerCase()
+    : "";
+});
+const activeDmCallPeers = computed(() => {
+  const peers = new Set(Object.values(dmCallActivities.value).map((activity) => barePeerJid(activity.peerJid).toLowerCase()).filter(Boolean));
+  if (currentActiveDmPeer.value) peers.add(currentActiveDmPeer.value);
+  return peers;
+});
 const directMessages = computed(() =>
   (props.dmConversations ?? []).filter((conversation) =>
     !activeDmCallPeers.value.has(barePeerJid(conversation.peerJid).toLowerCase())
   ),
 );
-const callState = useStore($callState);
 const channelsBySpace = computed(() =>
   new Map(groups.value.flatMap((group) => group.space ? [[group.space.id, group.channels.length] as const] : [])),
 );
-const activeCallEntries = computed<CallActivityDockEntry[]>(() => buildCallActivityDockEntries({
+const discoveredCallEntries = computed<CallActivityDockEntry[]>(() => buildCallActivityDockEntries({
   channels: props.channels,
   conversations: props.dmConversations ?? [],
   activeChannelId: null,
@@ -138,8 +152,24 @@ const activeCallEntries = computed<CallActivityDockEntry[]>(() => buildCallActiv
   activeChannelJids: activeChannelJids.value,
   managedMucDomain: props.managedMucDomain ?? null,
   callParticipantCounts: callParticipantCounts.value,
+  callParticipants: callParticipants.value,
   dmCallActivities: dmCallActivities.value,
 }));
+const currentCallFallbackEntry = computed<CallActivityDockEntry | null>(() =>
+  buildCurrentCallFallbackEntry(),
+);
+const activeCallEntries = computed<CallActivityDockEntry[]>(() => {
+  const entries = discoveredCallEntries.value;
+  const currentEntry = currentCallFallbackEntry.value;
+  if (!currentEntry || entries.some(isSameCallEntry(currentEntry))) return entries;
+  return [currentEntry, ...entries];
+});
+const activeCallSummaryCount = computed(() => activeCallEntries.value.length);
+const activeCallStatusMessage = computed(() => {
+  const count = activeCallEntries.value.length;
+  if (count === 0) return "No active calls.";
+  return `${count} active ${count === 1 ? "call" : "calls"}.`;
+});
 const activityByChannelId = computed(() =>
   new Map(props.channels.map((channel) => [
     channel.id,
@@ -163,7 +193,7 @@ function selectSpaceChannel(spaceId: string) {
 }
 
 function selectCallEntry(entry: CallActivityDockEntry) {
-  const selection = callActivityDockSelection(entry, callState.value);
+  const selection = callActivityDockSelection(entry, callState.value, props.selfFullJid ?? null);
   switch (selection.kind) {
     case "dm-answer":
       emit("answerDm", selection.peerJid, selection.remoteFullJid, selection.sid, selection.media);
@@ -185,6 +215,95 @@ function selectCallEntry(entry: CallActivityDockEntry) {
       emit("selectContact", selection.peerJid);
       return;
   }
+}
+
+function isCurrentCallEntry(entry: CallActivityDockEntry): boolean {
+  const current = callState.value;
+  if (current.phase === "muc-pending" || (current.phase === "active" && current.kind === "muc")) {
+    if (entry.kind !== "channel") return false;
+    return normalizeMucCallRoomJid(entry.roomJid) === normalizeMucCallRoomJid(current.peer);
+  }
+  if (current.phase !== "active" || current.kind !== "dm" || entry.kind !== "dm") return false;
+  return entry.peerJid.toLowerCase() === barePeerJid(current.peer).toLowerCase();
+}
+
+function isSameCallEntry(target: CallActivityDockEntry): (entry: CallActivityDockEntry) => boolean {
+  return (entry) => {
+    if (target.kind !== entry.kind) return false;
+    if (target.kind === "channel" && entry.kind === "channel") {
+      return normalizeMucCallRoomJid(target.roomJid) === normalizeMucCallRoomJid(entry.roomJid);
+    }
+    if (target.kind === "dm" && entry.kind === "dm") {
+      return target.peerJid.toLowerCase() === entry.peerJid.toLowerCase();
+    }
+    return false;
+  };
+}
+
+function buildCurrentCallFallbackEntry(): CallActivityDockEntry | null {
+  const current = callState.value;
+  if (current.phase === "muc-pending" || (current.phase === "active" && current.kind === "muc")) {
+    const roomJid = normalizeMucCallRoomJid(current.peer);
+    if (!roomJid) return null;
+    const channel = props.channels.find((candidate) =>
+      normalizeMucCallRoomJid(candidate.jid ?? "") === roomJid
+    );
+    const participantLabels = participantLabelsForRoom(roomJid);
+    const fallbackLabels = participantLabels.length > 0
+      ? participantLabels
+      : current.selfNick
+        ? [current.selfNick]
+        : [];
+    return {
+      kind: "channel",
+      key: `current-channel:${roomJid}:${current.sid}`,
+      channelId: channel?.id ?? null,
+      roomJid,
+      title: channel?.name ?? roomJid.split("@")[0] ?? "Group call",
+      participantCount: Math.max(fallbackLabels.length, 1),
+      participantLabels: fallbackLabels,
+      isKnownChannel: Boolean(channel),
+      isActive: false,
+    };
+  }
+
+  if (current.phase === "active" && current.kind === "dm") {
+    const peerJid = barePeerJid(current.peer).toLowerCase();
+    if (!peerJid) return null;
+    const conversation = props.dmConversations?.find((candidate) =>
+      barePeerJid(candidate.peerJid).toLowerCase() === peerJid
+    );
+    return {
+      kind: "dm",
+      key: `current-dm:${peerJid}:${current.sid}`,
+      peerJid,
+      sid: current.sid,
+      remoteFullJid: current.peer,
+      join: current.join,
+      title: conversation?.peerUsername ?? peerJid.split("@")[0] ?? "Direct call",
+      media: current.media,
+      state: "accepted",
+      direction: "unknown",
+      updatedAt: "",
+      isActive: false,
+    };
+  }
+
+  return null;
+}
+
+function participantLabelsForRoom(roomJid: string): string[] {
+  const normalized = normalizeMucCallRoomJid(roomJid);
+  if (!normalized) return [];
+  const labels = new Set<string>();
+  for (const [candidate, nicks] of Object.entries(callParticipants.value)) {
+    if (normalizeMucCallRoomJid(candidate) !== normalized) continue;
+    for (const nick of nicks) {
+      const label = nick.trim();
+      if (label) labels.add(label);
+    }
+  }
+  return [...labels];
 }
 
 function channelsForSpace(spaceId: string): ChannelSummary[] {
@@ -340,13 +459,185 @@ function callEntryKindLabel(entry: CallActivityDockEntry): string {
   return entry.media.video ? "Video call" : "Voice call";
 }
 
+type CallEntryVisualTone = "primary" | "success" | "warning";
+
+function callEntryAcceptedAvailability(entry: CallActivityDockEntry): {
+  eyebrow: string;
+  meta: string;
+  description: string;
+  tone: CallEntryVisualTone;
+} | null {
+  if (entry.kind !== "dm" || entry.state !== "accepted") return null;
+  const mediaLabel = entry.mediaKnown === false ? "call" : `${entry.media.video ? "video" : "voice"} call`;
+  const mediaTitle = `${mediaLabel.charAt(0).toUpperCase()}${mediaLabel.slice(1)}`;
+  const reason = dmCallResumeBlockReason(entry, props.selfFullJid ?? null);
+  if (reason === null) {
+    return {
+      eyebrow: "Live now",
+      meta: `Live ${mediaLabel}`,
+      description: `The ${mediaLabel} is still live.`,
+      tone: "success",
+    };
+  }
+  if (reason === "other-resource") {
+    return {
+      eyebrow: "Other device",
+      meta: `${mediaTitle} · Other device`,
+      description: "This call is live on another browser or device.",
+      tone: "warning",
+    };
+  }
+  if (reason === "expired-token" || reason === "invalid-token") {
+    return {
+      eyebrow: "Expired",
+      meta: `${mediaTitle} · Expired`,
+      description: "The saved reconnect details expired.",
+      tone: "warning",
+    };
+  }
+  return {
+    eyebrow: "Syncing",
+    meta: `${mediaTitle} · Details pending`,
+    description: "Reconnect details are not available on this tab yet.",
+    tone: "primary",
+  };
+}
+
+function callEntryVisualTone(entry: CallActivityDockEntry): CallEntryVisualTone {
+  if (entry.kind === "dm" && entry.state === "ringing" && entry.direction === "incoming") return "warning";
+  if (entry.kind === "dm" && entry.state === "ringing" && entry.direction === "outgoing") return "primary";
+  return callEntryAcceptedAvailability(entry)?.tone ?? "success";
+}
+
 function callEntryLabel(entry: CallActivityDockEntry): string {
   const action = callEntryActionLabel(entry);
-  return `${action} ${entry.title}, ${callEntryKindLabel(entry)}, ${callEntryStatus(entry)}`;
+  return [
+    `${action} ${entry.title}`,
+    callEntryKindLabel(entry),
+    callEntryStatus(entry),
+    callEntryEyebrow(entry),
+    callEntryDescription(entry),
+    callEntryDetail(entry),
+  ].filter(Boolean).join(", ");
+}
+
+function callEntryEyebrow(entry: CallActivityDockEntry): string {
+  if (entry.kind === "channel") return entry.isActive ? "You're here" : "Live now";
+  if (entry.isActive) return "You're here";
+  const availability = callEntryAcceptedAvailability(entry);
+  if (availability) return availability.eyebrow;
+  if (entry.state === "accepted") return "Live now";
+  if (entry.direction === "incoming") return "Incoming call";
+  if (entry.direction === "outgoing") return "Calling";
+  return "Ringing";
+}
+
+function callEntryDescription(entry: CallActivityDockEntry): string {
+  if (entry.kind === "channel") {
+    const noun = entry.participantCount === 1 ? "person" : "people";
+    const location = entry.isKnownChannel ? "this channel" : "the channel";
+    const preview = callEntryParticipantPreview(entry);
+    if (preview) return `${entry.participantCount} ${noun} connected in ${location}: ${preview}.`;
+    return `${entry.participantCount} ${noun} connected in ${location}.`;
+  }
+
+  const availability = callEntryAcceptedAvailability(entry);
+  if (availability) return availability.description;
+
+  if (entry.mediaKnown === false) {
+    if (entry.state === "accepted") return "Call details are still syncing.";
+    if (entry.direction === "incoming") return "Incoming call details are still syncing.";
+    if (entry.direction === "outgoing") return "Outgoing call details are still syncing.";
+    return "Call details are still syncing.";
+  }
+
+  const media = entry.media.video ? "video" : "voice";
+  if (entry.state === "accepted") return `The ${media} call is still live.`;
+  if (entry.direction === "incoming") return `Incoming ${media} call from this direct message.`;
+  if (entry.direction === "outgoing") return `Outgoing ${media} call is still ringing.`;
+  return `${media.charAt(0).toUpperCase()}${media.slice(1)} call is ringing.`;
+}
+
+function callEntryDetail(entry: CallActivityDockEntry): string {
+  if (entry.kind === "channel") return callEntryKindLabel(entry);
+  const stamp = entry.updatedAt ? formatTimelineStamp(entry.updatedAt) : "";
+  return [
+    callEntryAcceptedAvailability(entry)?.meta ?? callEntryKindLabel(entry),
+    ...(stamp ? [`Updated ${stamp}`] : []),
+  ].join(" · ");
+}
+
+function callEntryParticipantPreview(entry: CallActivityDockEntry): string {
+  if (entry.kind !== "channel") return "";
+  return mucCallParticipantPreview(entry.participantLabels);
+}
+
+function callEntryVisibleParticipantLabels(entry: CallActivityDockEntry): string[] {
+  if (entry.kind !== "channel") return [];
+  return entry.participantLabels.slice(0, 3);
+}
+
+function callEntryParticipantInitial(label: string): string {
+  return label.trim().charAt(0).toUpperCase() || "?";
+}
+
+function callEntryToneClass(entry: CallActivityDockEntry): string {
+  switch (callEntryVisualTone(entry)) {
+    case "warning":
+      return "border-warning/25 bg-warning/10 hover:bg-warning/15";
+    case "primary":
+      return "border-primary/25 bg-primary/8 hover:bg-primary/12";
+    case "success":
+      return "border-success/20 bg-success/10 hover:bg-success/15";
+  }
+}
+
+function callEntryAccentClass(entry: CallActivityDockEntry): string {
+  switch (callEntryVisualTone(entry)) {
+    case "warning":
+      return "text-warning-foreground";
+    case "primary":
+      return "text-primary";
+    case "success":
+      return "text-success-foreground";
+  }
+}
+
+function callEntryIconClass(entry: CallActivityDockEntry): string {
+  switch (callEntryVisualTone(entry)) {
+    case "warning":
+      return "border-warning/25 bg-background/90 text-warning-foreground";
+    case "primary":
+      return "border-primary/25 bg-background/90 text-primary";
+    case "success":
+      return "border-success/25 bg-background/90 text-success-foreground";
+  }
+}
+
+function callEntryDotClass(entry: CallActivityDockEntry): string {
+  switch (callEntryVisualTone(entry)) {
+    case "warning":
+      return "bg-warning shadow-[0_0_6px_var(--warning)]";
+    case "primary":
+      return "bg-primary shadow-[0_0_6px_var(--primary)]";
+    case "success":
+      return "bg-success shadow-[0_0_6px_var(--success)]";
+  }
+}
+
+function callEntryPillClass(entry: CallActivityDockEntry): string {
+  switch (callEntryVisualTone(entry)) {
+    case "warning":
+      return "border-warning/25 bg-background/70 text-warning-foreground";
+    case "primary":
+      return "border-primary/25 bg-background/70 text-primary";
+    case "success":
+      return "border-success/25 bg-background/70 text-success-foreground";
+  }
 }
 
 function callEntryActionLabel(entry: CallActivityDockEntry): string {
-  switch (callActivityDockAction(entry, callState.value)) {
+  switch (callActivityDockAction(entry, callState.value, props.selfFullJid ?? null)) {
     case "answer":
       return "Answer";
     case "join":
@@ -386,7 +677,7 @@ const heroSummary = computed<HeroSummary>(() => {
     totalMentions,
     totalThreadUnread,
     dmUnread,
-    activeCalls: activeCallEntries.value.length,
+    activeCalls: activeCallSummaryCount.value,
     onlineFriends,
     hasUnread: totalUnread + totalMentions + totalThreadUnread + dmUnread > 0,
   };
@@ -496,50 +787,96 @@ function onHeroCta() {
       </section>
 
       <section
+        class="sr-only"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {{ activeCallStatusMessage }}
+      </section>
+
+      <section
         v-if="activeCallEntries.length > 0"
         class="grid gap-3"
         aria-label="Active calls"
       >
-        <div class="flex items-center gap-2">
-          <PhoneCall class="h-4 w-4 text-success" />
-          <h2 class="type-pane-title">Active calls</h2>
+        <div class="flex items-end justify-between gap-3">
+          <div class="min-w-0">
+            <div class="flex items-center gap-2">
+              <PhoneCall class="h-4 w-4 text-success-foreground" aria-hidden="true" />
+              <h2 class="type-pane-title">Active calls</h2>
+            </div>
+            <p class="type-caption mt-0.5 text-muted-foreground">
+              {{ activeCallEntries.length }} {{ activeCallEntries.length === 1 ? "live conversation" : "live conversations" }}
+            </p>
+          </div>
         </div>
         <div class="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
           <button
             v-for="entry in activeCallEntries"
             :key="entry.key"
-            class="chat-list-row flex min-w-0 min-h-16 items-center gap-3 overflow-hidden rounded-lg border border-success/20 bg-success/10 px-4 py-3 text-left text-foreground hover:bg-success/20"
+            class="chat-list-row flex min-w-0 min-h-24 flex-col items-stretch justify-between gap-3 overflow-hidden rounded-lg border px-4 py-3 text-left text-foreground transition-colors"
+            :class="callEntryToneClass(entry)"
             type="button"
             :aria-label="callEntryLabel(entry)"
             @click="selectCallEntry(entry)"
           >
-            <span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-success/10 text-success">
-              <Hash v-if="entry.kind === 'channel'" class="h-4 w-4" />
-              <Video v-else-if="entry.mediaKnown !== false && entry.media.video" class="h-4 w-4" />
-              <PhoneIncoming v-else-if="entry.state === 'ringing' && entry.direction === 'incoming'" class="h-4 w-4" />
-              <PhoneOutgoing v-else-if="entry.state === 'ringing' && entry.direction === 'outgoing'" class="h-4 w-4" />
-              <Phone v-else class="h-4 w-4" />
-            </span>
-            <span class="min-w-0 flex-1">
-              <span class="type-control block truncate">{{ entry.title }}</span>
-              <span class="type-caption block truncate text-muted-foreground">
-                {{ callEntryKindLabel(entry) }} · {{ callEntryStatus(entry) }}
+            <span class="flex min-w-0 items-start gap-3">
+              <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border shadow-sm" :class="callEntryIconClass(entry)">
+                <Hash v-if="entry.kind === 'channel'" class="h-4 w-4" aria-hidden="true" />
+                <Video v-else-if="entry.mediaKnown !== false && entry.media.video" class="h-4 w-4" aria-hidden="true" />
+                <PhoneIncoming v-else-if="entry.state === 'ringing' && entry.direction === 'incoming'" class="h-4 w-4" aria-hidden="true" />
+                <PhoneOutgoing v-else-if="entry.state === 'ringing' && entry.direction === 'outgoing'" class="h-4 w-4" aria-hidden="true" />
+                <Phone v-else class="h-4 w-4" aria-hidden="true" />
+              </span>
+              <span class="min-w-0 flex-1">
+                <span class="type-meta flex items-center gap-1.5" :class="callEntryAccentClass(entry)">
+                  <span class="h-1.5 w-1.5 rounded-full" :class="callEntryDotClass(entry)" aria-hidden="true" />
+                  <span class="truncate">{{ callEntryEyebrow(entry) }}</span>
+                </span>
+                <span class="type-control type-strong mt-0.5 block truncate">{{ entry.title }}</span>
+                <span class="type-caption mt-0.5 block text-muted-foreground">
+                  {{ callEntryDescription(entry) }}
+                </span>
+                <span
+                  v-if="entry.kind === 'channel' && callEntryParticipantPreview(entry)"
+                  class="mt-2 flex min-w-0 items-center gap-2 text-muted-foreground"
+                  :title="`${callEntryParticipantPreview(entry)} in call`"
+                >
+                  <span class="flex shrink-0 pl-0.5" aria-hidden="true">
+                    <span
+                      v-for="label in callEntryVisibleParticipantLabels(entry)"
+                      :key="`${entry.key}:${label}`"
+                      class="-ml-0.5 flex h-5 w-5 first:ml-0 items-center justify-center rounded-full border border-background bg-success/15 text-[0.625rem] font-bold leading-none text-success-foreground"
+                    >
+                      {{ callEntryParticipantInitial(label) }}
+                    </span>
+                  </span>
+                  <span class="type-meta min-w-0 truncate">
+                    {{ callEntryParticipantPreview(entry) }}
+                  </span>
+                </span>
               </span>
             </span>
-            <span
-              v-if="entry.kind === 'channel'"
-              class="type-count-badge inline-flex min-w-[18px] h-[18px] shrink-0 items-center justify-center rounded-full border border-success/25 bg-success/10 px-1 text-success"
-              aria-hidden="true"
-            >
-              {{ entry.participantCount }}
+            <span class="flex min-w-0 items-center gap-2">
+              <span class="type-meta min-w-0 flex-1 truncate text-muted-foreground">{{ callEntryDetail(entry) }}</span>
+              <span
+                v-if="entry.kind === 'channel'"
+                class="type-count-badge inline-flex min-w-[18px] h-[18px] shrink-0 items-center justify-center rounded-full border px-1"
+                :class="callEntryPillClass(entry)"
+                aria-hidden="true"
+              >
+                {{ entry.participantCount }}
+              </span>
+              <span
+                class="type-meta shrink-0 rounded-full border px-2 py-1"
+                :class="callEntryPillClass(entry)"
+                aria-hidden="true"
+              >
+                {{ callEntryActionLabel(entry) }}
+              </span>
+              <ArrowRight class="h-4 w-4 shrink-0" :class="callEntryAccentClass(entry)" aria-hidden="true" />
             </span>
-            <span
-              class="type-meta shrink-0 rounded-md border border-success/25 bg-background/70 px-2 py-1 text-success"
-              aria-hidden="true"
-            >
-              {{ callEntryActionLabel(entry) }}
-            </span>
-            <ArrowRight class="h-4 w-4 shrink-0 text-success" aria-hidden="true" />
           </button>
         </div>
       </section>
@@ -665,7 +1002,7 @@ function onHeroCta() {
                 <span class="flex shrink-0 items-center gap-1">
                   <span
                     v-if="channelCallCount(channel) > 0"
-                    class="type-meta inline-flex h-[18px] shrink-0 items-center gap-1 rounded-full border border-success/25 bg-success/10 px-1.5 text-success"
+                    class="type-meta inline-flex h-[18px] shrink-0 items-center gap-1 rounded-full border border-success/25 bg-success/10 px-1.5 text-success-foreground"
                     title="Active call"
                     aria-hidden="true"
                   >
@@ -761,7 +1098,7 @@ function onHeroCta() {
             </span>
             <span
               v-if="dmCallActivityFor(conversation.peerJid)"
-              class="type-meta inline-flex h-[18px] shrink-0 items-center gap-1 rounded-full border border-success/25 bg-success/10 px-1.5 text-success"
+              class="type-meta inline-flex h-[18px] shrink-0 items-center gap-1 rounded-full border border-success/25 bg-success/10 px-1.5 text-success-foreground"
               :title="dmCallLabel(conversation.peerJid)"
               aria-hidden="true"
             >

--- a/chat/src/home/dashboard-props.ts
+++ b/chat/src/home/dashboard-props.ts
@@ -13,8 +13,10 @@ export interface HomeDashboardProps {
   activeChannelJids?: Set<string>;
   dmConversations?: DmConversation[];
   callParticipantCounts?: Record<string, number>;
+  callParticipants?: Record<string, string[]>;
   dmCallActivities?: Record<string, DmCallActivity>;
   managedMucDomain?: string | null;
+  selfFullJid?: string | null;
 }
 
 interface HomeDashboardSources extends Omit<HomeDashboardProps, "channelUnreadMap"> {
@@ -36,8 +38,10 @@ export function buildHomeDashboardProps(sources: HomeDashboardSources): HomeDash
     activeChannelJids: sources.activeChannelJids,
     dmConversations: sources.dmConversations,
     callParticipantCounts: sources.callParticipantCounts,
+    callParticipants: sources.callParticipants,
     dmCallActivities: sources.dmCallActivities,
     managedMucDomain: sources.managedMucDomain,
+    selfFullJid: sources.selfFullJid,
   };
 }
 

--- a/chat/src/lib/calls/call-activity-dock.ts
+++ b/chat/src/lib/calls/call-activity-dock.ts
@@ -8,7 +8,7 @@ import {
   refreshedMucCallRooms,
 } from "./muc-call-indicators";
 import { normalizeMucCallRoomJid } from "./muc-call-presence";
-import { hasKnownDmCallMedia, type DmCallActivity } from "./dm-call-activity";
+import { canResumeDmCallActivity, hasKnownDmCallMedia, type DmCallActivity } from "./dm-call-activity";
 
 export type SidebarMode = "channels" | "dms";
 
@@ -20,6 +20,7 @@ export type CallActivityDockEntry =
       roomJid: string;
       title: string;
       participantCount: number;
+      participantLabels: string[];
       isKnownChannel: boolean;
       isActive: boolean;
     }
@@ -29,6 +30,7 @@ export type CallActivityDockEntry =
       peerJid: string;
       sid: string;
       remoteFullJid?: string;
+      join?: DmCallActivity["join"];
       title: string;
       media: DmCallActivity["media"];
       mediaKnown?: boolean;
@@ -72,8 +74,9 @@ export function isBusy(state: CallState): boolean {
 }
 
 export function dmCallActivityAction(
-  activity: Pick<DmCallActivity, "peerJid" | "remoteFullJid" | "mediaKnown" | "state" | "direction">,
+  activity: Pick<DmCallActivity, "peerJid" | "remoteFullJid" | "mediaKnown" | "state" | "direction" | "join">,
   callState: CallState,
+  selfFullJid?: string | null,
 ): Extract<CallActivityDockAction, "answer" | "open" | "return" | "reconnect"> {
   const peerJid = barePeerJid(activity.peerJid).toLowerCase();
   if (peerJid && activeDmCallPeerJid(callState) === peerJid) return "return";
@@ -83,16 +86,17 @@ export function dmCallActivityAction(
     activity.remoteFullJid &&
     !isBusy(callState)
   ) return "answer";
-  if (activity.state === "accepted" && hasKnownDmCallMedia(activity) && !isBusy(callState)) return "reconnect";
+  if (canResumeDmCallActivity(activity, selfFullJid) && !isBusy(callState)) return "reconnect";
   return "open";
 }
 
 export function callActivityDockAction(
   entry: CallActivityDockEntry,
   callState: CallState,
+  selfFullJid?: string | null,
 ): CallActivityDockAction {
   if (entry.kind === "dm") {
-    return dmCallActivityAction(entry, callState);
+    return dmCallActivityAction(entry, callState, selfFullJid);
   }
 
   const roomJid = normalizeMucCallRoomJid(entry.roomJid);
@@ -104,9 +108,10 @@ export function callActivityDockAction(
 export function callActivityDockSelection(
   entry: CallActivityDockEntry,
   callState: CallState = { phase: "idle" },
+  selfFullJid?: string | null,
 ): CallActivityDockSelection {
   if (entry.kind === "channel") {
-    if (callActivityDockAction(entry, callState) === "join") {
+    if (callActivityDockAction(entry, callState, selfFullJid) === "join") {
       return {
         kind: "channel-join",
         channelId: entry.channelId,
@@ -120,7 +125,7 @@ export function callActivityDockSelection(
       roomJid: entry.roomJid,
     };
   }
-  const action = callActivityDockAction(entry, callState);
+  const action = callActivityDockAction(entry, callState, selfFullJid);
   if (action === "answer" && entry.remoteFullJid) {
     return {
       kind: "dm-answer",
@@ -150,9 +155,11 @@ export function buildCallActivityDockEntries(options: {
   activeChannelJids: Iterable<string>;
   managedMucDomain?: string | null;
   callParticipantCounts: Record<string, number>;
+  callParticipants?: Record<string, readonly string[]>;
   dmCallActivities: Record<string, DmCallActivity>;
 }): CallActivityDockEntry[] {
   const activeChannelRoomJid = normalizeMucCallRoomJid(options.activeChannelRoomJid ?? "");
+  const participantLabelsByRoom = normalizedParticipantLabels(options.callParticipants ?? {});
   const channelEntries = options.channels.flatMap((channel): CallActivityDockEntry[] => {
     const participantCount = callParticipantCountForChannel(
       channel,
@@ -174,6 +181,7 @@ export function buildCallActivityDockEntries(options: {
       roomJid,
       title: channel.name,
       participantCount,
+      participantLabels: participantLabelsByRoom.get(roomJid) ?? [],
       isKnownChannel: true,
       isActive: options.sidebarMode === "channels" && (
         options.activeChannelId === channel.id || activeChannelRoomJid === roomJid
@@ -194,6 +202,7 @@ export function buildCallActivityDockEntries(options: {
       roomJid: room.roomJid,
       title: room.title,
       participantCount: room.participantCount,
+      participantLabels: participantLabelsByRoom.get(room.roomJid) ?? [],
       isKnownChannel: false,
       isActive: options.sidebarMode === "channels" && activeChannelRoomJid === room.roomJid,
     }));
@@ -215,6 +224,7 @@ export function buildCallActivityDockEntries(options: {
         peerJid,
         sid: activity.sid,
         ...(activity.remoteFullJid ? { remoteFullJid: activity.remoteFullJid } : {}),
+        ...(activity.join ? { join: activity.join } : {}),
         title: conversationNames.get(peerJid) ?? fallbackName,
         media: activity.media,
         ...(hasKnownDmCallMedia(activity) ? {} : { mediaKnown: false }),
@@ -234,4 +244,22 @@ export function buildCallActivityDockEntries(options: {
     });
 
   return [...channelEntries, ...fallbackChannelEntries, ...dmEntries];
+}
+
+function normalizedParticipantLabels(
+  participants: Record<string, readonly string[]>,
+): Map<string, string[]> {
+  const labels = new Map<string, string[]>();
+  for (const [roomJid, nicks] of Object.entries(participants)) {
+    const normalized = normalizeMucCallRoomJid(roomJid);
+    if (!normalized) continue;
+    const current = labels.get(normalized) ?? [];
+    labels.set(normalized, [
+      ...new Set([
+        ...current,
+        ...nicks.map((nick) => nick.trim()).filter(Boolean),
+      ]),
+    ]);
+  }
+  return labels;
 }

--- a/chat/src/lib/calls/call-controls.ts
+++ b/chat/src/lib/calls/call-controls.ts
@@ -80,10 +80,27 @@ export async function hangupActiveCall(): Promise<void> {
  * `tearDownActiveCall` and sends the conformant call-ending stanzas.
  */
 export function suspendCallForPageHide(): void {
+  (connectionStore.client as unknown as {
+    persistResumeStateForPageHide?: () => void;
+  } | null)?.persistResumeStateForPageHide?.();
   const current = $callState.get();
   if (current.phase === "idle" || current.phase === "ended") return;
   clearCallState();
   void useCallEngine().engine.disconnect();
+}
+
+type PagehideTarget = Pick<Window, "addEventListener" | "removeEventListener">;
+
+export function installCallPagehideSuspension(windowTarget: PagehideTarget = window): () => void {
+  const handlePageHide = (event: PageTransitionEvent): void => {
+    if (event.persisted) return;
+    suspendCallForPageHide();
+  };
+
+  windowTarget.addEventListener("pagehide", handlePageHide as EventListener);
+  return () => {
+    windowTarget.removeEventListener("pagehide", handlePageHide as EventListener);
+  };
 }
 
 /**

--- a/chat/src/lib/calls/call-rail-counts.ts
+++ b/chat/src/lib/calls/call-rail-counts.ts
@@ -1,0 +1,44 @@
+import { barePeerJid } from "@/lib/xmpp/jid";
+import type { DmCallActivity } from "./dm-call-activity";
+import { normalizeMucCallRoomJid } from "./muc-call-presence";
+import type { CallState } from "./types";
+
+export function activeChannelRailCallCount(
+  callParticipantCounts: Record<string, number>,
+  callState: CallState,
+): number {
+  const rooms = new Set(
+    Object.entries(callParticipantCounts)
+      .filter(([, count]) => count > 0)
+      .map(([roomJid]) => normalizeMucCallRoomJid(roomJid))
+      .filter(Boolean),
+  );
+  if ((callState.phase === "muc-pending" || callState.phase === "active") && callState.kind === "muc") {
+    const roomJid = normalizeMucCallRoomJid(callState.peer);
+    if (roomJid) rooms.add(roomJid);
+  }
+  return rooms.size;
+}
+
+export function activeDmRailCallCount(
+  dmCallActivities: Record<string, DmCallActivity>,
+  callState: CallState,
+): number {
+  const peers = new Set(
+    Object.values(dmCallActivities)
+      .map((activity) => barePeerJid(activity.peerJid).toLowerCase())
+      .filter(Boolean),
+  );
+  const currentPeer = currentDmCallPeerJid(callState);
+  if (currentPeer) peers.add(currentPeer);
+  return peers.size;
+}
+
+function currentDmCallPeerJid(callState: CallState): string {
+  if (callState.phase === "active" && callState.kind === "dm") {
+    return barePeerJid(callState.peer).toLowerCase();
+  }
+  if (callState.phase === "incoming") return barePeerJid(callState.from).toLowerCase();
+  if (callState.phase === "outgoing") return barePeerJid(callState.to).toLowerCase();
+  return "";
+}

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -384,6 +384,7 @@ export function beginOutgoingCall(
       media,
     },
     selfBareJid: initiator ?? "",
+    selfFullJid: initiator,
     to,
     directionHint: "outgoing",
   });

--- a/chat/src/lib/calls/dm-call-actions.ts
+++ b/chat/src/lib/calls/dm-call-actions.ts
@@ -5,7 +5,7 @@ import {
   reportCallError,
   scheduleOutgoingTimeout,
 } from "./call-store";
-import { clearDmCallActivity, readDmCallActivity } from "./dm-call-activity";
+import { canResumeDmCallActivity, clearDmCallActivity, readDmCallActivity } from "./dm-call-activity";
 import {
   newCallSid,
   outboundCalls,
@@ -105,4 +105,33 @@ export async function answerIncomingDmCallActivity(options: {
     }
     reportCallError(err);
   }
+}
+
+export function resumeDmCallActivity(options: {
+  peerBareJid: string;
+  getSelfFullJid?: () => string | undefined;
+  now?: Date;
+}): boolean {
+  const current = $callState.get();
+  if (current.phase !== "idle" && current.phase !== "ended") return false;
+
+  const peer = barePeerJid(options.peerBareJid).toLowerCase();
+  if (!peer) return false;
+
+  const activity = readDmCallActivity(peer, options.now);
+  const selfFullJid = options.getSelfFullJid?.()?.trim() ?? "";
+  if (!activity || !canResumeDmCallActivity(activity, selfFullJid, options.now)) {
+    return false;
+  }
+
+  $callState.set({
+    phase: "active",
+    kind: "dm",
+    peer: activity.remoteFullJid,
+    sid: activity.sid,
+    media: activity.media,
+    join: activity.join,
+    initiator: selfFullJid,
+  });
+  return true;
 }

--- a/chat/src/lib/calls/dm-call-activity.ts
+++ b/chat/src/lib/calls/dm-call-activity.ts
@@ -2,13 +2,28 @@ import { computed, type ComputedRef } from "vue";
 import { useStore } from "@nanostores/vue";
 import { map } from "nanostores";
 import { barePeerJid } from "@/lib/xmpp/jid";
-import type { CallEvent, CallMedia } from "./types";
+import {
+  forgetDmCallJoin,
+  readDmCallJoin,
+  rememberDmCallJoin,
+} from "./dm-call-join-cache";
+import type { CallEvent, CallMedia, LiveKitJoin } from "./types";
 
 export const DM_CALL_ACTIVITY_ACTIVE_WINDOW_MS = 24 * 60 * 60 * 1000;
 const MAX_TERMINAL_TIMESTAMPS = 1024;
 const PRUNE_TIMER_SLACK_MS = 1_000;
+const LIVEKIT_JOIN_EXPIRY_SKEW_MS = 30_000;
 
 type DmCallActivityState = "ringing" | "accepted";
+type DmCallResumeBlockReason =
+  | "missing-self"
+  | "not-accepted"
+  | "unknown-media"
+  | "missing-peer-resource"
+  | "missing-join"
+  | "other-resource"
+  | "invalid-token"
+  | "expired-token";
 
 export interface DmCallActivity {
   peerJid: string;
@@ -18,6 +33,14 @@ export interface DmCallActivity {
   sid: string;
   media: CallMedia;
   mediaKnown?: boolean;
+  /**
+   * LiveKit credentials recovered from an archived Jingle
+   * session-initiate/session-accept. A resume path may use this only
+   * after checking that the token identity matches the current full
+   * JID; otherwise another browser/resource could consume the wrong
+   * participant identity.
+   */
+  join?: LiveKitJoin;
   state: DmCallActivityState;
   direction: "incoming" | "outgoing" | "unknown";
   updatedAt: string;
@@ -30,6 +53,7 @@ let pruneTimer: ReturnType<typeof setTimeout> | null = null;
 interface DmCallEventEnvelope {
   event: CallEvent;
   selfBareJid: string;
+  selfFullJid?: string | null;
   to?: string | null;
   timestamp?: string | null;
   now?: Date;
@@ -46,6 +70,35 @@ export function hasKnownDmCallMedia(
   return activity.mediaKnown !== false;
 }
 
+export function canResumeDmCallActivity(
+  activity: Pick<DmCallActivity, "state" | "mediaKnown" | "remoteFullJid" | "join">,
+  selfFullJid: string | null | undefined,
+  now = new Date(),
+): activity is Pick<DmCallActivity, "state" | "mediaKnown" | "remoteFullJid" | "join"> & {
+  remoteFullJid: string;
+  join: LiveKitJoin;
+} {
+  return dmCallResumeBlockReason(activity, selfFullJid, now) === null;
+}
+
+export function dmCallResumeBlockReason(
+  activity: Pick<DmCallActivity, "state" | "mediaKnown" | "remoteFullJid" | "join">,
+  selfFullJid: string | null | undefined,
+  now = new Date(),
+): DmCallResumeBlockReason | null {
+  const self = selfFullJid?.trim();
+  if (!self) return "missing-self";
+  if (activity.state !== "accepted") return "not-accepted";
+  if (!hasKnownDmCallMedia(activity)) return "unknown-media";
+  if (!activity.remoteFullJid) return "missing-peer-resource";
+  if (!activity.join) return "missing-join";
+  if (activity.join.identity !== self) return "other-resource";
+  const expiresAt = liveKitJoinTokenExpiresAt(activity.join.token);
+  if (expiresAt === null) return "invalid-token";
+  if (expiresAt.getTime() <= now.getTime() + LIVEKIT_JOIN_EXPIRY_SKEW_MS) return "expired-token";
+  return null;
+}
+
 function eventMedia(
   event: CallEvent,
   previous?: DmCallActivity,
@@ -53,6 +106,52 @@ function eventMedia(
   if ("media" in event) return { media: event.media, known: true };
   if (previous) return { media: previous.media, known: hasKnownDmCallMedia(previous) };
   return { media: { audio: true, video: false }, known: false };
+}
+
+function eventJoin(event: CallEvent, previous?: DmCallActivity): LiveKitJoin | undefined {
+  if ("join" in event) return event.join;
+  return previous?.sid === event.sid ? previous.join : undefined;
+}
+
+function eventSelfFullJid(envelope: DmCallEventEnvelope, join?: LiveKitJoin): string | undefined {
+  const selfBare = normalizedBare(envelope.selfBareJid);
+  const candidates = [
+    join?.identity,
+    envelope.selfFullJid,
+    envelope.event.from,
+    envelope.to ?? envelope.event.to,
+  ];
+  for (const candidate of candidates) {
+    if (!candidate || !candidate.includes("/")) continue;
+    if (normalizedBare(candidate) === selfBare) return candidate.trim();
+  }
+  return undefined;
+}
+
+function liveKitJoinTokenExpiresAt(token: string): Date | null {
+  const payload = token.split(".")[1];
+  if (!payload) return null;
+  try {
+    const decoded = decodeBase64UrlUtf8(payload);
+    const parsed = JSON.parse(decoded) as { exp?: unknown };
+    const exp = Number(parsed.exp);
+    if (!Number.isFinite(exp) || exp <= 0) return null;
+    return new Date(exp * 1000);
+  } catch {
+    return null;
+  }
+}
+
+function decodeBase64UrlUtf8(value: string): string {
+  const binary = globalThis.atob(normalizeBase64Url(value));
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+function normalizeBase64Url(value: string): string {
+  const normalized = value.replaceAll("-", "+").replaceAll("_", "/");
+  const padding = (4 - (normalized.length % 4)) % 4;
+  return `${normalized}${"=".repeat(padding)}`;
 }
 
 function timestampFromEnvelope(envelope: DmCallEventEnvelope): string {
@@ -69,6 +168,14 @@ function millisecondsUntilStale(timestamp: string, now: Date): number {
   const ms = Date.parse(timestamp);
   if (!Number.isFinite(ms)) return 0;
   return ms + DM_CALL_ACTIVITY_ACTIVE_WINDOW_MS - now.getTime();
+}
+
+function millisecondsUntilResumeAffordanceChange(activity: DmCallActivity, now: Date): number | null {
+  if (activity.state !== "accepted" || !activity.join) return null;
+  const expiresAt = liveKitJoinTokenExpiresAt(activity.join.token);
+  if (!expiresAt) return null;
+  const delay = expiresAt.getTime() - LIVEKIT_JOIN_EXPIRY_SKEW_MS - now.getTime();
+  return delay > 0 ? delay : null;
 }
 
 function isOlderThanCurrent(timestamp: string, current?: DmCallActivity): boolean {
@@ -124,13 +231,25 @@ function scheduleActivityPrune(now = new Date()): void {
   for (const activity of Object.values($dmCallActivities.get())) {
     const delay = millisecondsUntilStale(activity.updatedAt, now);
     nextDelay = nextDelay === null ? delay : Math.min(nextDelay, delay);
+    const resumeDelay = millisecondsUntilResumeAffordanceChange(activity, now);
+    if (resumeDelay !== null) {
+      nextDelay = nextDelay === null ? resumeDelay : Math.min(nextDelay, resumeDelay);
+    }
   }
   if (nextDelay === null) return;
   pruneTimer = setTimeout(() => {
     pruneTimer = null;
+    const before = $dmCallActivities.get();
     pruneExpiredDmCallActivities();
+    if ($dmCallActivities.get() === before) {
+      refreshDmCallActivityAffordances();
+    }
   }, Math.max(0, nextDelay) + PRUNE_TIMER_SLACK_MS);
   (pruneTimer as { unref?: () => void }).unref?.();
+}
+
+export function refreshDmCallActivityAffordances(): void {
+  $dmCallActivities.set({ ...$dmCallActivities.get() });
 }
 
 export function pruneExpiredDmCallActivities(now = new Date()): void {
@@ -203,6 +322,8 @@ function remoteFullJidForEnvelope(
 function removeActivity(peerJid: string, sid: string): void {
   const current = $dmCallActivities.get()[peerJid];
   if (!current || current.sid !== sid) return;
+  const selfBareJid = current.join ? normalizedBare(current.join.identity) : "";
+  if (selfBareJid) forgetDmCallJoin({ selfBareJid, peerJid, sid });
   const next = { ...$dmCallActivities.get() };
   delete next[peerJid];
   $dmCallActivities.set(next);
@@ -218,6 +339,8 @@ export function clearDmCallActivity(peerJid: string, sid?: string): void {
   if (!current) return;
   if (sid && current.sid !== sid) return;
   recordTerminal(normalized, current.sid, now.toISOString(), now);
+  const selfBareJid = current.join ? normalizedBare(current.join.identity) : "";
+  if (selfBareJid) forgetDmCallJoin({ selfBareJid, peerJid: normalized, sid: current.sid });
   const next = { ...$dmCallActivities.get() };
   delete next[normalized];
   $dmCallActivities.set(next);
@@ -253,17 +376,52 @@ export function applyDmCallEvent(envelope: DmCallEventEnvelope): void {
     case "proceed":
     case "session-initiate":
     case "session-accept":
-      const media = eventMedia(envelope.event, previous);
+      const previousForSid = previous?.sid === envelope.event.sid ? previous : undefined;
+      const eventProvidedJoin = "join" in envelope.event ? envelope.event.join : undefined;
+      const cachedJoin = eventProvidedJoin
+        ? null
+        : readDmCallJoin({
+          selfBareJid: envelope.selfBareJid,
+          peerJid,
+          sid: envelope.event.sid,
+          selfFullJid: eventSelfFullJid(envelope),
+          now,
+        });
+      const media = eventMedia(envelope.event, previousForSid);
+      const restoredMedia = media.known || !cachedJoin
+        ? media
+        : { media: cachedJoin.media, known: true };
+      const join = eventJoin(envelope.event, previousForSid) ?? cachedJoin?.join;
+      const nextRemoteFullJid = previousForSid?.remoteFullJid ?? remoteFullJid ?? cachedJoin?.remoteFullJid;
+      if (eventProvidedJoin && nextRemoteFullJid) {
+        const selfFullJid = eventSelfFullJid(envelope, eventProvidedJoin);
+        if (selfFullJid && selfFullJid === eventProvidedJoin.identity) {
+          rememberDmCallJoin({
+            selfBareJid: envelope.selfBareJid,
+            entry: {
+              peerJid,
+              sid: envelope.event.sid,
+              selfFullJid,
+              remoteFullJid: nextRemoteFullJid,
+              media: restoredMedia.media,
+              join: eventProvidedJoin,
+              updatedAt: timestamp,
+            },
+            now,
+          });
+        }
+      }
       $dmCallActivities.setKey(peerJid, {
         peerJid,
-        ...(previous?.remoteFullJid || remoteFullJid
-          ? { remoteFullJid: previous?.remoteFullJid ?? remoteFullJid }
+        ...(nextRemoteFullJid
+          ? { remoteFullJid: nextRemoteFullJid }
           : {}),
         sid: envelope.event.sid,
-        media: media.media,
-        ...(media.known ? {} : { mediaKnown: false }),
+        media: restoredMedia.media,
+        ...(restoredMedia.known ? {} : { mediaKnown: false }),
+        ...(join ? { join } : {}),
         state: "accepted",
-        direction: previous?.direction ?? direction,
+        direction: previousForSid?.direction ?? direction,
         updatedAt: timestamp,
       });
       scheduleActivityPrune(now);
@@ -273,6 +431,7 @@ export function applyDmCallEvent(envelope: DmCallEventEnvelope): void {
     case "finish":
     case "session-terminate":
       recordTerminal(peerJid, envelope.event.sid, timestamp, now);
+      forgetDmCallJoin({ selfBareJid: envelope.selfBareJid, peerJid, sid: envelope.event.sid });
       removeActivity(peerJid, envelope.event.sid);
       return;
   }

--- a/chat/src/lib/calls/dm-call-join-cache.ts
+++ b/chat/src/lib/calls/dm-call-join-cache.ts
@@ -1,0 +1,231 @@
+import type { CallMedia, LiveKitJoin } from "./types";
+import { barePeerJid } from "@/lib/xmpp/jid";
+import { reportError } from "@/lib/telemetry";
+
+const CACHE_PREFIX = "waddle.chat.dm-call-joins";
+const MAX_CACHE_ENTRIES = 32;
+const CACHE_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+type CachedDmCallJoin = {
+  peerJid: string;
+  sid: string;
+  selfFullJid: string;
+  remoteFullJid: string;
+  media: CallMedia;
+  join: LiveKitJoin;
+  updatedAt: string;
+};
+
+export function rememberDmCallJoin(options: {
+  selfBareJid: string;
+  entry: CachedDmCallJoin;
+  now?: Date;
+}): void {
+  const selfBare = normalizedBare(options.selfBareJid);
+  const entry = normalizeEntry(options.entry);
+  if (!selfBare || !entry || normalizedBare(entry.selfFullJid) !== selfBare) return;
+
+  const now = options.now ?? new Date();
+  const entries = readEntries(selfBare)
+    .filter((candidate) => !isExpired(candidate.updatedAt, now))
+    .filter((candidate) =>
+      candidate.sid !== entry.sid ||
+      candidate.peerJid !== entry.peerJid ||
+      candidate.selfFullJid !== entry.selfFullJid
+    );
+  entries.unshift(entry);
+  writeEntries(selfBare, entries.slice(0, MAX_CACHE_ENTRIES));
+}
+
+export function readDmCallJoin(options: {
+  selfBareJid: string;
+  peerJid: string;
+  sid: string;
+  selfFullJid?: string | null;
+  now?: Date;
+}): CachedDmCallJoin | null {
+  const selfBare = normalizedBare(options.selfBareJid);
+  const peerJid = normalizedBare(options.peerJid);
+  const selfFullJid = options.selfFullJid?.trim() ?? "";
+  if (!selfBare || !peerJid || !options.sid || !selfFullJid) return null;
+
+  const now = options.now ?? new Date();
+  let changed = false;
+  const freshEntries = readEntries(selfBare).filter((entry) => {
+    const keep = !isExpired(entry.updatedAt, now);
+    changed ||= !keep;
+    return keep;
+  });
+  if (changed) writeEntries(selfBare, freshEntries);
+
+  return freshEntries.find((entry) =>
+    entry.peerJid === peerJid &&
+    entry.sid === options.sid &&
+    entry.selfFullJid === selfFullJid
+  ) ?? null;
+}
+
+export function forgetDmCallJoin(options: {
+  selfBareJid: string;
+  peerJid: string;
+  sid: string;
+}): void {
+  const selfBare = normalizedBare(options.selfBareJid);
+  const peerJid = normalizedBare(options.peerJid);
+  if (!selfBare || !peerJid || !options.sid) return;
+  const entries = readEntries(selfBare);
+  const next = entries.filter((entry) => entry.peerJid !== peerJid || entry.sid !== options.sid);
+  if (next.length !== entries.length) writeEntries(selfBare, next);
+}
+
+export function clearDmCallJoinCacheForAccount(selfBareJid: string): void {
+  const selfBare = normalizedBare(selfBareJid);
+  if (!selfBare) return;
+  removeKey(cacheKey(selfBare));
+}
+
+export function clearAllDmCallJoinCacheForTests(): void {
+  const s = storage();
+  if (!s) return;
+  try {
+    const keys: string[] = [];
+    for (let index = 0; index < s.length; index += 1) {
+      const key = s.key(index);
+      if (key?.startsWith(`${CACHE_PREFIX}.`)) keys.push(key);
+    }
+    for (const key of keys) s.removeItem(key);
+  } catch (err) {
+    reportError("storage.write", err, {
+      recoverable: true,
+      detail: "dm call join cache clear failed",
+    });
+  }
+}
+
+function normalizeEntry(entry: CachedDmCallJoin): CachedDmCallJoin | null {
+  const peerJid = normalizedBare(entry.peerJid);
+  const remoteFullJid = entry.remoteFullJid.trim();
+  const selfFullJid = entry.selfFullJid.trim();
+  if (!peerJid || !entry.sid || !remoteFullJid || !selfFullJid) return null;
+  if (normalizedBare(remoteFullJid) !== peerJid) return null;
+  if (!isCallMedia(entry.media) || !isLiveKitJoin(entry.join)) return null;
+  if (entry.join.identity !== selfFullJid) return null;
+  if (Number.isNaN(Date.parse(entry.updatedAt))) return null;
+  return {
+    peerJid,
+    sid: entry.sid,
+    selfFullJid,
+    remoteFullJid,
+    media: entry.media,
+    join: entry.join,
+    updatedAt: entry.updatedAt,
+  };
+}
+
+function readEntries(selfBareJid: string): CachedDmCallJoin[] {
+  const s = storage();
+  if (!s) return [];
+  const key = cacheKey(selfBareJid);
+  try {
+    const raw = s.getItem(key);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map((entry) => isCachedDmCallJoin(entry) ? normalizeEntry(entry) : null)
+      .filter((entry): entry is CachedDmCallJoin => !!entry);
+  } catch (err) {
+    reportError("storage.read", err, {
+      recoverable: true,
+      detail: "dm call join cache read failed",
+      key,
+    });
+    return [];
+  }
+}
+
+function writeEntries(selfBareJid: string, entries: CachedDmCallJoin[]): void {
+  const s = storage();
+  if (!s) return;
+  const key = cacheKey(selfBareJid);
+  try {
+    if (entries.length === 0) {
+      s.removeItem(key);
+      return;
+    }
+    s.setItem(key, JSON.stringify(entries));
+  } catch (err) {
+    reportError("storage.write", err, {
+      recoverable: true,
+      detail: "dm call join cache write failed",
+      key,
+    });
+  }
+}
+
+function removeKey(key: string): void {
+  const s = storage();
+  if (!s) return;
+  try {
+    s.removeItem(key);
+  } catch (err) {
+    reportError("storage.write", err, {
+      recoverable: true,
+      detail: "dm call join cache clear failed",
+      key,
+    });
+  }
+}
+
+function cacheKey(selfBareJid: string): string {
+  return `${CACHE_PREFIX}.${selfBareJid}`;
+}
+
+function normalizedBare(jid: string): string {
+  return barePeerJid(jid).toLowerCase();
+}
+
+function isExpired(timestamp: string, now: Date): boolean {
+  const ms = Date.parse(timestamp);
+  return !Number.isFinite(ms) || now.getTime() - ms > CACHE_WINDOW_MS;
+}
+
+function isCachedDmCallJoin(value: unknown): value is CachedDmCallJoin {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.peerJid === "string" &&
+    typeof candidate.sid === "string" &&
+    typeof candidate.selfFullJid === "string" &&
+    typeof candidate.remoteFullJid === "string" &&
+    isCallMedia(candidate.media) &&
+    isLiveKitJoin(candidate.join) &&
+    typeof candidate.updatedAt === "string"
+  );
+}
+
+function isCallMedia(value: unknown): value is CallMedia {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return typeof candidate.audio === "boolean" && typeof candidate.video === "boolean";
+}
+
+function isLiveKitJoin(value: unknown): value is LiveKitJoin {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.url === "string" &&
+    typeof candidate.room === "string" &&
+    typeof candidate.identity === "string" &&
+    typeof candidate.token === "string"
+  );
+}
+
+function storage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}

--- a/chat/src/lib/calls/muc-call-presence.ts
+++ b/chat/src/lib/calls/muc-call-presence.ts
@@ -1,4 +1,5 @@
 import { map } from "nanostores";
+import { fullJidIdentityKey } from "@/lib/xmpp/jid";
 
 /**
  * Per-room map of nicks advertising XEP-0272 Muji presence with
@@ -20,6 +21,11 @@ import { map } from "nanostores";
  * change.
  */
 export const $mucCallParticipants = map<Record<string, string[]>>({});
+type MucCallParticipantOwner = {
+  nick: string;
+  realJid?: string;
+};
+export const $mucCallParticipantOwners = map<Record<string, MucCallParticipantOwner[]>>({});
 const $mucActiveParticipants = map<Record<string, string[]>>({});
 const $mucPreparingParticipants = map<Record<string, string[]>>({});
 const PARTICIPANT_KEY_SEPARATOR = "\u0000";
@@ -29,7 +35,7 @@ export function normalizeMucCallRoomJid(roomJid: string): string {
 }
 
 function normalizeFullJid(jid?: string | null): string {
-  return jid?.trim().toLowerCase() ?? "";
+  return fullJidIdentityKey(jid);
 }
 
 function preparingParticipantKey(nick: string, realJid?: string | null): string {
@@ -107,8 +113,21 @@ function syncActiveParticipantsForRoom(roomJid: string): void {
     const all = { ...$mucCallParticipants.get() };
     delete all[roomJid];
     $mucCallParticipants.set(all);
+    const owners = { ...$mucCallParticipantOwners.get() };
+    delete owners[roomJid];
+    $mucCallParticipantOwners.set(owners);
   } else {
     $mucCallParticipants.setKey(roomJid, nicks);
+    $mucCallParticipantOwners.setKey(
+      roomJid,
+      activeOwners.map((key) => {
+        const realJid = activeParticipantRealJid(key);
+        return {
+          nick: activeParticipantNick(key),
+          ...(realJid ? { realJid } : {}),
+        };
+      }),
+    );
   }
 }
 
@@ -225,6 +244,7 @@ export function mucCallParticipantCount(roomJid: string): number {
  */
 export function clearMucCallParticipants(): void {
   $mucCallParticipants.set({});
+  $mucCallParticipantOwners.set({});
   $mucActiveParticipants.set({});
   $mucPreparingParticipants.set({});
   // Drop any pending preparing-echo waiters too — they'd otherwise

--- a/chat/src/lib/calls/use-active-muc-call.ts
+++ b/chat/src/lib/calls/use-active-muc-call.ts
@@ -2,10 +2,12 @@ import { computed, type ComputedRef } from "vue";
 import { useStore } from "@nanostores/vue";
 import { $callState } from "./call-store";
 import {
+  $mucCallParticipantOwners,
   $mucCallParticipants,
   normalizeMucCallRoomJid,
 } from "./muc-call-presence";
 import { connectionStore } from "@/lib/connection-store";
+import { fullJidIdentityKey } from "@/lib/xmpp/jid";
 
 /**
  * Derived view of "is the local user currently in an active MUC group
@@ -76,6 +78,7 @@ export function useRoomHasActiveCall(
 } {
   const state = useStore($callState);
   const participants = useStore($mucCallParticipants);
+  const participantOwners = useStore($mucCallParticipantOwners);
 
   const normalizedRoomJid = computed<string | null>(() => {
     const normalized = normalizeMucCallRoomJid(roomJid());
@@ -98,8 +101,11 @@ export function useRoomHasActiveCall(
   const localResourceInCall = computed<boolean>(() => {
     const room = normalizedRoomJid.value;
     const s = state.value;
-    if (!room || s.phase !== "active" || s.kind !== "muc") return false;
-    return normalizeMucCallRoomJid(s.peer) === room;
+    if (!room) return false;
+    if (s.phase === "active" && s.kind === "muc" && normalizeMucCallRoomJid(s.peer) === room) {
+      return true;
+    }
+    return hasOwnerFullJid(participantOwners.value[room] ?? [], currentClientFullJid());
   });
 
   const participantCount = computed<number>(() => participantList.value.length);
@@ -118,17 +124,33 @@ export function readRoomHasActiveCall(roomJid: string): {
     return { hasActiveCall: false, selfInCall: false, localResourceInCall: false, participantCount: 0 };
   }
   const participants = $mucCallParticipants.get()[normalized] ?? [];
+  const participantOwners = $mucCallParticipantOwners.get()[normalized] ?? [];
   const nick = connectionStore.session?.username ?? null;
   const s = $callState.get();
   return {
     hasActiveCall: participants.length > 0,
     selfInCall: !!nick && participants.includes(nick),
     localResourceInCall:
-      s.phase === "active" &&
-      s.kind === "muc" &&
-      normalizeMucCallRoomJid(s.peer) === normalized,
+      (
+        s.phase === "active" &&
+        s.kind === "muc" &&
+        normalizeMucCallRoomJid(s.peer) === normalized
+      ) ||
+      hasOwnerFullJid(participantOwners, currentClientFullJid()),
     participantCount: participants.length,
   };
+}
+
+function currentClientFullJid(): string {
+  return fullJidIdentityKey((connectionStore.client as unknown as { fullJid?: string } | null)?.fullJid);
+}
+
+function hasOwnerFullJid(
+  owners: ReadonlyArray<{ realJid?: string }>,
+  fullJid: string,
+): boolean {
+  if (!fullJid) return false;
+  return owners.some((owner) => fullJidIdentityKey(owner.realJid) === fullJid);
 }
 
 /**

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -24,7 +24,7 @@ import {
 import { useCallEngine } from "@/lib/calls/use-call-engine";
 import type { CallWireSender } from "@/lib/calls/outbound";
 import type { CallEvent } from "@/lib/calls/types";
-import { barePeerJid, jidDomain, roomBareJidFor } from "./jid";
+import { barePeerJid, fullJidIdentityKey, jidDomain, roomBareJidFor } from "./jid";
 import type {
   ChatStateEvent,
   ChatStateType,
@@ -60,6 +60,7 @@ import {
   createLocalStorageResumePersistence,
   type ResumePersistence,
 } from "./resume-persistence";
+import { clearDmCallJoinCacheForAccount } from "@/lib/calls/dm-call-join-cache";
 import { compareTimelineTimestamps } from "../timeline-timestamps";
 import {
   discoverExtensionCommands,
@@ -399,6 +400,7 @@ type XmppResumeState = {
   previd: string;
   inboundH: number;
   outboundH: number;
+  resource?: string;
 };
 
 type XmppResumeStateHandle = import("@waddle/xmpp-client-wasm").WaddleResumeState;
@@ -443,7 +445,7 @@ export class RoomMemberListUnavailableError extends Error {
 export class BrowserXmppClient {
   private session: WaddleSession;
   private get queueScope() { return barePeerJid(this.session.jid); }
-  private readonly resource = createXmppResource();
+  private readonly resource: string;
   private messageHandler: ((message: LiveRoomMessage) => void) | null = null;
   private pinEventHandler: ((event: { roomJid: string; event: import("./wasm-types").WasmPinEvent }) => void) | null = null;
   private directMessageHandler: ((message: LiveDmMessage) => void) | null = null;
@@ -555,7 +557,9 @@ export class BrowserXmppClient {
     // WASM client (live, same JS context), that takes precedence in
     // `doConnect`. The POD `resumeState` is the only piece that
     // survives a full page reload, so hydrate it eagerly.
-    this.resumeState = this.resumePersistence.loadSm();
+    this.resumeState = this.resumePersistence.consumeSm();
+    this.resource = this.resumeState?.resource || createXmppResource();
+    this.retainedJoinedRoomJids = new Set(this.resumePersistence.loadJoinedRooms());
   }
 
   /** Full JID (`bare/resource`) for this session. Needed by the
@@ -582,13 +586,13 @@ export class BrowserXmppClient {
 
   private ownFullJidCandidates(): Set<string> {
     return new Set([
-      this.fullJid.trim().toLowerCase(),
-      `${barePeerJid(this.session.jid)}/${this.resource}`.trim().toLowerCase(),
+      fullJidIdentityKey(this.fullJid),
+      fullJidIdentityKey(`${barePeerJid(this.session.jid)}/${this.resource}`),
     ]);
   }
 
   private isOwnMucSelfPresence(presence: { muc_jid?: string | null }): boolean {
-    const mucJid = presence.muc_jid?.trim().toLowerCase();
+    const mucJid = fullJidIdentityKey(presence.muc_jid);
     return !!mucJid && this.ownFullJidCandidates().has(mucJid);
   }
 
@@ -706,6 +710,7 @@ export class BrowserXmppClient {
     this.resumeState = null;
     this.setResumeStateHandle(null);
     this.resumePersistence.clearSm();
+    this.resumePersistence.clearJoinedRooms();
     // Only called from the `destroying` path — i.e. intentional
     // logout / shutdown. Drop the catch-up cursors too so a future
     // login on the same account (same browser) doesn't replay
@@ -713,6 +718,18 @@ export class BrowserXmppClient {
     // this method; they intentionally keep cursors so the next
     // resume can fill the gap.)
     this.catchup.reset();
+  }
+
+  persistResumeStateForPageHide(): void {
+    const xmpp = this.xmpp;
+    const state = xmpp?.get_resume_state?.() ?? this.resumeState;
+    this.resumePersistence.preparePagehideHandoff();
+    if (state) {
+      const snapshot = { ...state, resource: this.resource };
+      this.resumeState = snapshot;
+      this.resumePersistence.saveSm(snapshot);
+    }
+    this.persistRetainedJoinedRooms();
   }
 
   private setResumeStateHandle(handle: XmppResumeStateHandle | null | undefined) {
@@ -765,6 +782,7 @@ export class BrowserXmppClient {
         this.resumeState.inboundH,
         this.resumeState.outboundH,
       );
+      this.resumePersistence.clearSm();
       this.resumeState = null;
     }
     const xmpp = new mod.WaddleClient(config) as unknown as XmppClientInstance;
@@ -827,6 +845,7 @@ export class BrowserXmppClient {
     this.joinedMucs.clear();
     this.joinedMucJoinTokens.clear();
     this.joinedMucReady.clear();
+    clearDmCallJoinCacheForAccount(this.session.jid);
     clearDmCallActivities();
     clearMucCallParticipants();
     // Best-effort hangup: if we're in a call when the user logs out
@@ -951,7 +970,7 @@ export class BrowserXmppClient {
       }
       if (!existingToken && !this.joinedMucs.has(roomJid)) return;
       this.joinedMucReady.add(roomJid);
-      this.retainedJoinedRoomJids.add(roomJid);
+      this.rememberJoinedRoom(roomJid);
       return;
     }
     const promise = this.performMucJoin(roomJid);
@@ -962,7 +981,7 @@ export class BrowserXmppClient {
       await promise;
       if (this.joinedMucJoinTokens.get(roomJid) === joinToken) {
         this.joinedMucReady.add(roomJid);
-        this.retainedJoinedRoomJids.add(roomJid);
+        this.rememberJoinedRoom(roomJid);
       }
     } catch (err) {
       if (this.joinedMucJoinTokens.get(roomJid) === joinToken) {
@@ -972,6 +991,18 @@ export class BrowserXmppClient {
       }
       throw err;
     }
+  }
+
+  private rememberJoinedRoom(roomJid: string): void {
+    const normalized = roomJid.split("/")[0]?.trim().toLowerCase() ?? "";
+    if (!normalized) return;
+    const sizeBefore = this.retainedJoinedRoomJids.size;
+    this.retainedJoinedRoomJids.add(normalized);
+    if (this.retainedJoinedRoomJids.size !== sizeBefore) this.persistRetainedJoinedRooms();
+  }
+
+  private persistRetainedJoinedRooms(): void {
+    this.resumePersistence.saveJoinedRooms([...this.retainedJoinedRoomJids]);
   }
 
   private async performMucJoin(roomJid: string): Promise<void> {
@@ -1992,6 +2023,7 @@ export class BrowserXmppClient {
       applyDmCallEvent({
         event: message.call_event,
         selfBareJid: selfBare,
+        selfFullJid: this.fullJid,
         to: message.to,
         timestamp: message.timestamp,
       });
@@ -2462,20 +2494,23 @@ export class BrowserXmppClient {
     this.rejectRoomJoinWaiters(new Error("XMPP disconnected while joining a room"));
     this.retainedJoinedRoomJids = new Set([
       ...this.retainedJoinedRoomJids,
-      ...previouslyJoinedRooms,
+      ...previouslyJoinedRooms
+        .map((roomJid) => roomJid.split("/")[0]?.trim().toLowerCase() ?? "")
+        .filter(Boolean),
     ]);
+    this.persistRetainedJoinedRooms();
     this.joinedMucs.clear();
     this.joinedMucReady.clear();
     this.clearRoomPresenceCaches();
     if (this.destroying) { this.clearResumeState(); this.emitStatus({ state: "offline", detail: error?.message ?? "Disconnected" }); return; }
     this.setResumeStateHandle(xmpp.get_resume_state_handle?.() ?? null);
-    this.resumeState = xmpp.get_resume_state?.() ?? null;
-    // Persist the POD form so the next page-load can resume the
-    // XEP-0198 stream without re-binding. The live handle is a JS
-    // object that can't be serialized, so `doConnect` always tries
-    // the handle first (this JS context only) and falls back to
-    // the persisted POD across reloads.
-    if (this.resumeState) this.resumePersistence.saveSm(this.resumeState);
+    const resumeState = xmpp.get_resume_state?.() ?? null;
+    this.resumeState = resumeState ? { ...resumeState, resource: this.resource } : null;
+    // Keep transient reconnect state in this JS context only. The
+    // shared per-account persisted SM slot is a pagehide handoff for
+    // true tab replacement; writing it during ordinary disconnects
+    // would let another live tab claim this same resource while this
+    // client is still reconnecting with its in-memory handle.
     this.emitStatus({ state: "reconnecting", detail: countQueuedMessages(this.queueScope) > 0 ? "Connection lost — queued messages will send when reconnected" : (error?.message ?? "Connection lost, reconnecting...") });
     if (this.onceConnectFailed) { const fail = this.onceConnectFailed; this.onceConnected = null; this.onceConnectFailed = null; fail(error ?? new Error("XMPP connection failed")); }
     this.scheduleReconnect();
@@ -2548,6 +2583,7 @@ export class BrowserXmppClient {
       applyDmCallEvent({
         event: message.call_event,
         selfBareJid: barePeerJid(this.session.jid),
+        selfFullJid: this.fullJid,
         to: message.to ?? message.call_event.to,
         timestamp: message.timestamp,
       });
@@ -2822,6 +2858,7 @@ export class BrowserXmppClient {
         applyDmCallEvent({
           event,
           selfBareJid: selfBare,
+          selfFullJid: this.fullJid,
           to: event.to ?? currentDmPeer,
         });
       }

--- a/chat/src/lib/xmpp/jid.ts
+++ b/chat/src/lib/xmpp/jid.ts
@@ -10,6 +10,16 @@ export function barePeerJid(fullJid: string): string {
   return fullJid.split("/")[0] ?? "";
 }
 
+export function fullJidIdentityKey(fullJid?: string | null): string {
+  const trimmed = fullJid?.trim() ?? "";
+  if (!trimmed) return "";
+  const separator = trimmed.indexOf("/");
+  if (separator < 0) return trimmed.toLowerCase();
+  const bare = trimmed.slice(0, separator).toLowerCase();
+  const resource = trimmed.slice(separator + 1);
+  return `${bare}/${resource}`;
+}
+
 export function parseManagedRoomBareJid(
   roomJid: string,
 ): { channelId: string } | null {

--- a/chat/src/lib/xmpp/resume-persistence.ts
+++ b/chat/src/lib/xmpp/resume-persistence.ts
@@ -30,6 +30,9 @@ import { reportError } from "@/lib/telemetry";
 
 const CATCHUP_PREFIX = "waddle.chat.resume-cursors";
 const SM_PREFIX = "waddle.chat.sm-resume";
+const JOINED_ROOMS_PREFIX = "waddle.chat.joined-rooms";
+const OWNER_LEASE_PREFIX = `${SM_PREFIX}.owner-lease`;
+const OWNER_HANDOFF_PREFIX = `${SM_PREFIX}.owner-handoff`;
 
 export type PersistedSeenCursor = {
   timestamp: string;
@@ -52,11 +55,32 @@ export type PersistedSmResumeState = {
   previd: string;
   inboundH: number;
   outboundH: number;
+  resource?: string;
 };
 
 interface PersistedSmEnvelope extends PersistedSmResumeState {
   savedAt: number;
+  ownerId?: string;
+  claimId?: string;
 }
+
+type ResumeOwner = {
+  ownerId: string;
+  instanceId: string;
+  explicit: boolean;
+};
+
+type OwnerLease = {
+  ownerId: string;
+  instanceId: string;
+  updatedAt: number;
+};
+
+type OwnerHandoff = {
+  ownerId: string;
+  instanceId: string;
+  expiresAt: number;
+};
 
 /**
  * Reject a persisted SM POD older than this window. Servers usually
@@ -65,14 +89,24 @@ interface PersistedSmEnvelope extends PersistedSmResumeState {
  * cold start with a weeks-old POD.
  */
 const SM_TTL_MS = 24 * 60 * 60 * 1000;
+const OWNER_LEASE_TTL_MS = 45_000;
+const OWNER_HEARTBEAT_MS = 15_000;
+const OWNER_HANDOFF_TTL_MS = 10_000;
+const liveOwnerInstances = new Map<string, string>();
+const liveOwnerHeartbeats = new Set<string>();
 
 export interface ResumePersistence {
   loadCatchup(): PersistedReconnectCatchup | null;
   saveCatchup(snapshot: PersistedReconnectCatchup): void;
   clearCatchup(): void;
   loadSm(): PersistedSmResumeState | null;
+  consumeSm(): PersistedSmResumeState | null;
   saveSm(state: PersistedSmResumeState): void;
   clearSm(): void;
+  preparePagehideHandoff(): void;
+  loadJoinedRooms(): string[];
+  saveJoinedRooms(roomJids: readonly string[]): void;
+  clearJoinedRooms(): void;
 }
 
 /** No-op persistence — used in tests / non-browser contexts. */
@@ -81,13 +115,20 @@ export const nullResumePersistence: ResumePersistence = {
   saveCatchup: () => undefined,
   clearCatchup: () => undefined,
   loadSm: () => null,
+  consumeSm: () => null,
   saveSm: () => undefined,
   clearSm: () => undefined,
+  preparePagehideHandoff: () => undefined,
+  loadJoinedRooms: () => [],
+  saveJoinedRooms: () => undefined,
+  clearJoinedRooms: () => undefined,
 };
 
-export function createLocalStorageResumePersistence(accountKey: string): ResumePersistence {
+export function createLocalStorageResumePersistence(accountKey: string, ownerId?: string): ResumePersistence {
+  const owner = ownerId ? explicitResumeOwner(ownerId) : resumeOwner();
   const catchupKey = `${CATCHUP_PREFIX}.${accountKey}`;
   const smKey = `${SM_PREFIX}.${accountKey}`;
+  const joinedRoomsKey = `${JOINED_ROOMS_PREFIX}.${accountKey}.${owner.ownerId}`;
 
   return {
     loadCatchup() {
@@ -110,23 +151,209 @@ export function createLocalStorageResumePersistence(accountKey: string): ResumeP
         removeKey(smKey, "sm");
         return null;
       }
-      const { previd, inboundH, outboundH } = envelope;
-      return { previd, inboundH, outboundH };
+      if (envelope.ownerId !== owner.ownerId) return null;
+      if (envelope.claimId) return null;
+      const { previd, inboundH, outboundH, resource } = envelope;
+      return { previd, inboundH, outboundH, ...(resource ? { resource } : {}) };
+    },
+    consumeSm() {
+      return consumeSmEnvelope(smKey, owner.ownerId);
     },
     saveSm(state) {
-      const envelope: PersistedSmEnvelope = { ...state, savedAt: Date.now() };
+      const envelope: PersistedSmEnvelope = { ...state, savedAt: Date.now(), ownerId: owner.ownerId };
+      removeKey(`${smKey}.consumed`, "sm-consumed");
       writeJson(smKey, envelope, "sm");
     },
     clearSm() {
       removeKey(smKey, "sm");
+      removeKey(`${smKey}.consumed`, "sm-consumed");
+    },
+    preparePagehideHandoff() {
+      markOwnerHandoff(owner);
+    },
+    loadJoinedRooms() {
+      const stored = readJson<string[]>(joinedRoomsKey, isStringArray, "joined-rooms") ?? [];
+      return [...new Set(stored.map(normalizeRoomJid).filter(Boolean))];
+    },
+    saveJoinedRooms(roomJids) {
+      writeJson(
+        joinedRoomsKey,
+        [...new Set(roomJids.map(normalizeRoomJid).filter(Boolean))],
+        "joined-rooms",
+      );
+    },
+    clearJoinedRooms() {
+      removeKey(joinedRoomsKey, "joined-rooms");
     },
   };
+}
+
+function consumeSmEnvelope(key: string, ownerId: string): PersistedSmResumeState | null {
+  const s = storage();
+  if (!s) return null;
+  const consumedKey = `${key}.consumed`;
+  try {
+    const raw = s.getItem(key);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!isPersistedSmEnvelope(parsed)) return null;
+    const consumedMarker = smEnvelopeMarker(raw);
+    if (Date.now() - parsed.savedAt > SM_TTL_MS) {
+      s.removeItem(key);
+      return null;
+    }
+    if (parsed.ownerId !== ownerId) return null;
+    if (parsed.claimId) return null;
+    if (s.getItem(consumedKey) === consumedMarker) {
+      s.removeItem(key);
+      return null;
+    }
+
+    const claimId = randomClaimId();
+    if (s.getItem(key) !== raw || s.getItem(consumedKey) === consumedMarker) return null;
+    s.setItem(key, JSON.stringify({ ...parsed, claimId }));
+
+    const claimedRaw = s.getItem(key);
+    if (!claimedRaw) return null;
+    const claimed: unknown = JSON.parse(claimedRaw);
+    if (!isPersistedSmEnvelope(claimed) || claimed.claimId !== claimId) return null;
+    if (s.getItem(consumedKey) === consumedMarker) {
+      s.removeItem(key);
+      return null;
+    }
+
+    s.setItem(consumedKey, consumedMarker);
+    s.removeItem(key);
+    const { previd, inboundH, outboundH, resource } = claimed;
+    return { previd, inboundH, outboundH, ...(resource ? { resource } : {}) };
+  } catch (err) {
+    reportError("storage.read", err, {
+      recoverable: true,
+      detail: "resume-persistence consume failed (sm)",
+      key,
+    });
+    return null;
+  }
+}
+
+function randomClaimId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
+}
+
+function explicitResumeOwner(ownerId: string): ResumeOwner {
+  return {
+    ownerId,
+    instanceId: `explicit:${ownerId}`,
+    explicit: true,
+  };
+}
+
+function resumeOwner(): ResumeOwner {
+  const s = sessionStorageForOwner();
+  if (!s) {
+    const ownerId = randomClaimId();
+    return { ownerId, instanceId: ownerInstanceId(ownerId), explicit: false };
+  }
+  const key = `${SM_PREFIX}.owner`;
+  try {
+    let ownerId = s.getItem(key) || randomClaimId();
+    let instanceId = ownerInstanceId(ownerId);
+    if (copiedLiveOwnerNeedsRotation(ownerId, instanceId)) {
+      ownerId = randomClaimId();
+      instanceId = ownerInstanceId(ownerId);
+    }
+    s.setItem(key, ownerId);
+    const owner: ResumeOwner = { ownerId, instanceId, explicit: false };
+    claimOwnerLease(owner);
+    startOwnerHeartbeat(owner);
+    return owner;
+  } catch {
+    const ownerId = randomClaimId();
+    return { ownerId, instanceId: ownerInstanceId(ownerId), explicit: false };
+  }
+}
+
+function ownerInstanceId(ownerId: string): string {
+  const current = liveOwnerInstances.get(ownerId);
+  if (current) return current;
+  const next = randomClaimId();
+  liveOwnerInstances.set(ownerId, next);
+  return next;
+}
+
+function copiedLiveOwnerNeedsRotation(ownerId: string, instanceId: string): boolean {
+  const lease = readOwnerLease(ownerLeaseKey(ownerId));
+  if (!lease || lease.instanceId === instanceId || Date.now() - lease.updatedAt > OWNER_LEASE_TTL_MS) {
+    return false;
+  }
+  const handoff = readOwnerHandoff(ownerHandoffKey(ownerId));
+  return !handoff || handoff.expiresAt <= Date.now();
+}
+
+function claimOwnerLease(owner: ResumeOwner): void {
+  if (owner.explicit) return;
+  writeJson(ownerLeaseKey(owner.ownerId), {
+    ownerId: owner.ownerId,
+    instanceId: owner.instanceId,
+    updatedAt: Date.now(),
+  }, "owner-lease");
+  removeKey(ownerHandoffKey(owner.ownerId), "owner-handoff");
+}
+
+function startOwnerHeartbeat(owner: ResumeOwner): void {
+  if (owner.explicit || liveOwnerHeartbeats.has(owner.ownerId)) return;
+  if (typeof document === "undefined") return;
+  liveOwnerHeartbeats.add(owner.ownerId);
+  const timer = setInterval(() => claimOwnerLease(owner), OWNER_HEARTBEAT_MS);
+  (timer as { unref?: () => void }).unref?.();
+}
+
+function markOwnerHandoff(owner: ResumeOwner): void {
+  writeJson(ownerHandoffKey(owner.ownerId), {
+    ownerId: owner.ownerId,
+    instanceId: owner.instanceId,
+    expiresAt: Date.now() + OWNER_HANDOFF_TTL_MS,
+  }, "owner-handoff");
+}
+
+function ownerLeaseKey(ownerId: string): string {
+  return `${OWNER_LEASE_PREFIX}.${ownerId}`;
+}
+
+function ownerHandoffKey(ownerId: string): string {
+  return `${OWNER_HANDOFF_PREFIX}.${ownerId}`;
+}
+
+function readOwnerLease(key: string): OwnerLease | null {
+  return readJson<OwnerLease>(key, isOwnerLease, "owner-lease");
+}
+
+function readOwnerHandoff(key: string): OwnerHandoff | null {
+  return readJson<OwnerHandoff>(key, isOwnerHandoff, "owner-handoff");
+}
+
+function smEnvelopeMarker(raw: string): string {
+  let hash = 2166136261;
+  for (let i = 0; i < raw.length; i += 1) {
+    hash ^= raw.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash.toString(36);
 }
 
 function storage(): Storage | null {
   if (typeof window === "undefined") return null;
   try {
     return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function sessionStorageForOwner(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.sessionStorage ?? null;
   } catch {
     return null;
   }
@@ -208,6 +435,34 @@ function isPersistedReconnectCatchup(value: unknown): value is PersistedReconnec
   return isCursorMap(candidate.dmLastSeen) && isCursorMap(candidate.roomLastSeen);
 }
 
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function isOwnerLease(value: unknown): value is OwnerLease {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.ownerId === "string" &&
+    typeof candidate.instanceId === "string" &&
+    typeof candidate.updatedAt === "number"
+  );
+}
+
+function isOwnerHandoff(value: unknown): value is OwnerHandoff {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.ownerId === "string" &&
+    typeof candidate.instanceId === "string" &&
+    typeof candidate.expiresAt === "number"
+  );
+}
+
+function normalizeRoomJid(roomJid: string): string {
+  return roomJid.split("/")[0]?.trim().toLowerCase() ?? "";
+}
+
 function isPersistedSmEnvelope(value: unknown): value is PersistedSmEnvelope {
   if (!value || typeof value !== "object") return false;
   const candidate = value as Record<string, unknown>;
@@ -215,6 +470,9 @@ function isPersistedSmEnvelope(value: unknown): value is PersistedSmEnvelope {
     typeof candidate.previd === "string"
     && typeof candidate.inboundH === "number"
     && typeof candidate.outboundH === "number"
+    && (candidate.resource === undefined || typeof candidate.resource === "string")
+    && (candidate.ownerId === undefined || typeof candidate.ownerId === "string")
+    && (candidate.claimId === undefined || typeof candidate.claimId === "string")
     && typeof candidate.savedAt === "number"
   );
 }

--- a/chat/src/styles/global/tokens.css
+++ b/chat/src/styles/global/tokens.css
@@ -37,7 +37,9 @@
   --rail-active: var(--foreground);
   --rail-hover: light-dark(oklch(0.2 0.012 248 / 0.045), oklch(0.98 0.004 230 / 0.065));
   --success: light-dark(oklch(0.63 0.15 158), oklch(0.76 0.15 158));
+  --success-foreground: light-dark(oklch(0.38 0.13 158), oklch(0.84 0.12 158));
   --warning: light-dark(oklch(0.72 0.16 78), oklch(0.82 0.15 78));
+  --warning-foreground: light-dark(oklch(0.43 0.11 78), oklch(0.88 0.11 78));
   --ambient-veil: light-dark(oklch(0.63 0.13 184 / 0.045), oklch(0.78 0.14 184 / 0.05));
   --ambient-shadow: light-dark(oklch(0.42 0.025 248 / 0.035), oklch(0.08 0.012 248 / 0.2));
   --rich-code-bg: light-dark(oklch(0.2 0.012 248 / 0.06), oklch(0.98 0.004 230 / 0.075));
@@ -197,7 +199,9 @@
   --color-rail-active: var(--rail-active);
   --color-rail-hover: var(--rail-hover);
   --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
   --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
 }
 
 @layer base {

--- a/chat/tests/call-activity-dock.test.ts
+++ b/chat/tests/call-activity-dock.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -13,6 +13,10 @@ import {
   callActivityDockSelection,
 } from "../src/lib/calls/call-activity-dock";
 import {
+  activeChannelRailCallCount,
+  activeDmRailCallCount,
+} from "../src/lib/calls/call-rail-counts";
+import {
   $callState,
   clearCallState,
 } from "../src/lib/calls/call-store";
@@ -26,6 +30,7 @@ import { clearMucCallParticipants, $mucCallParticipants } from "../src/lib/calls
 import { clearDmCallActivities, $dmCallActivities } from "../src/lib/calls/dm-call-activity";
 import type { DmCallActivity } from "../src/lib/calls/dm-call-activity";
 import type { CallState, LiveKitJoin } from "../src/lib/calls/types";
+import { connectionStore } from "../src/lib/connection-store";
 
 afterEach(() => {
   clearCallState();
@@ -35,6 +40,7 @@ afterEach(() => {
   $callMicEnabled.set(true);
   $callCamEnabled.set(true);
   $callUiMode.set("split");
+  connectionStore.client = null;
 });
 
 const liveKitJoin: LiveKitJoin = {
@@ -43,6 +49,27 @@ const liveKitJoin: LiveKitJoin = {
   identity: "alice@example.com/web",
   token: "token",
 };
+
+function liveKitJoinFor(identity = "alice@example.com/web"): LiveKitJoin {
+  return {
+    url: "wss://livekit.example.test",
+    room: "call-room",
+    identity,
+    token: jwtWithExp(4_102_444_800),
+  };
+}
+
+function jwtWithExp(exp: number): string {
+  return [
+    base64Url(JSON.stringify({ alg: "none", typ: "JWT" })),
+    base64Url(JSON.stringify({ exp })),
+    "sig",
+  ].join(".");
+}
+
+function base64Url(value: string): string {
+  return btoa(value).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+}
 
 describe("call activity dock model", () => {
   test("surfaces group calls and DM calls across sidebar modes", () => {
@@ -71,6 +98,9 @@ describe("call activity dock model", () => {
       callParticipantCounts: {
         "general@conference.example.com": 3,
       },
+      callParticipants: {
+        "general@conference.example.com": ["alice", "bob", "carol"],
+      },
       dmCallActivities: {
         "bob@example.com": dmActivity,
       },
@@ -84,6 +114,7 @@ describe("call activity dock model", () => {
         roomJid: "general@conference.example.com",
         title: "General",
         participantCount: 3,
+        participantLabels: ["alice", "bob", "carol"],
         isKnownChannel: true,
         isActive: true,
       },
@@ -161,6 +192,8 @@ describe("call activity dock model", () => {
           peerJid: "bob@example.com",
           sid: "live",
           media: { audio: true, video: true },
+          remoteFullJid: "bob@example.com/phone",
+          join: liveKitJoinFor(),
           state: "accepted",
           direction: "incoming",
           updatedAt: "2026-05-25T12:00:00.000Z",
@@ -176,7 +209,7 @@ describe("call activity dock model", () => {
       },
     });
 
-    expect(entries.map((entry) => callActivityDockSelection(entry))).toEqual([
+    expect(entries.map((entry) => callActivityDockSelection(entry, { phase: "idle" }, "alice@example.com/web"))).toEqual([
       {
         kind: "channel-join",
         channelId: "general",
@@ -200,7 +233,7 @@ describe("call activity dock model", () => {
       sid: "muc-call",
       media: { audio: true, video: false },
       join: { url: "wss://livekit.example.test", room: "general", identity: "alice", token: "token" },
-    })).toBe("return");
+    }, "alice@example.com/web")).toBe("return");
     expect(callActivityDockAction(entries[0], {
       phase: "muc-pending",
       kind: "muc",
@@ -209,13 +242,13 @@ describe("call activity dock model", () => {
       media: { audio: true, video: false },
       selfNick: "alice",
       attemptId: "attempt-1",
-    })).toBe("return");
+    }, "alice@example.com/web")).toBe("return");
     expect(callActivityDockSelection(entries[0], {
       phase: "outgoing",
       to: "bob@example.com",
       sid: "dm-call",
       media: { audio: true, video: false },
-    })).toEqual({
+    }, "alice@example.com/web")).toEqual({
       kind: "channel",
       channelId: "general",
       roomJid: "general@conference.example.com",
@@ -227,7 +260,7 @@ describe("call activity dock model", () => {
       sid: "live",
       media: { audio: true, video: true },
       join: { url: "wss://livekit.example.test", room: "dm", identity: "alice", token: "token" },
-    })).toBe("return");
+    }, "alice@example.com/web")).toBe("return");
     expect(callActivityDockSelection(entries[1], {
       phase: "active",
       kind: "dm",
@@ -235,7 +268,7 @@ describe("call activity dock model", () => {
       sid: "live",
       media: { audio: true, video: true },
       join: { url: "wss://livekit.example.test", room: "dm", identity: "alice", token: "token" },
-    })).toEqual({
+    }, "alice@example.com/web")).toEqual({
       kind: "dm-open",
       peerJid: "bob@example.com",
     });
@@ -244,7 +277,7 @@ describe("call activity dock model", () => {
       to: "dana@example.com",
       sid: "other-call",
       media: { audio: true, video: false },
-    })).toBe("open");
+    }, "alice@example.com/web")).toBe("open");
   });
 
   test("surfaces group calls while the channel directory is still loading", () => {
@@ -270,6 +303,7 @@ describe("call activity dock model", () => {
         roomJid: "general@conference.example.com",
         title: "general",
         participantCount: 2,
+        participantLabels: [],
         isKnownChannel: false,
         isActive: false,
       },
@@ -301,6 +335,7 @@ describe("call activity dock model", () => {
         roomJid: "general@custom-muc.example.test",
         title: "General",
         participantCount: 3,
+        participantLabels: [],
         isKnownChannel: true,
         isActive: false,
       },
@@ -332,6 +367,7 @@ describe("call activity dock model", () => {
         roomJid: "general@conference.example.com",
         title: "General",
         participantCount: 2,
+        participantLabels: [],
         isKnownChannel: true,
         isActive: false,
       },
@@ -415,9 +451,11 @@ describe("CallActivityDock rendering", () => {
         peerJid: "bob@example.com",
         sid: "dm-call-1",
         media: { audio: true, video: true },
+        remoteFullJid: "bob@example.com/phone",
+        join: liveKitJoinFor(),
         state: "accepted",
         direction: "incoming",
-        updatedAt: "2026-05-25T12:00:00.000Z",
+        updatedAt: new Date().toISOString(),
       },
     });
 
@@ -432,6 +470,7 @@ describe("CallActivityDock rendering", () => {
       activePeerJid: null,
       sidebarMode: "channels",
       activeChannelJids: new Set<string>(),
+      selfFullJid: "alice@example.com/web",
     });
 
     expect(html).toContain("Active calls");
@@ -440,11 +479,12 @@ describe("CallActivityDock rendering", () => {
     expect(html).toContain("Group call");
     expect(html).toContain("Video call");
     expect(html).toContain("2 people");
+    expect(html).toContain("alice, bob");
     expect(html).toContain("Live");
     expect(html).toContain("Join");
     expect(html).toContain("Reconnect");
-    expect(html).toContain('aria-label="Join General call, 2 people"');
-    expect(html).toContain('aria-label="Reconnect Bob call, Live"');
+    expect(html).toContain('aria-label="Join General, Group call · 2 people, alice, bob in call"');
+    expect(html).toContain('aria-label="Reconnect Bob, Video call · Live"');
   });
 
   test("renders active group calls before channel metadata hydrates", async () => {
@@ -466,9 +506,46 @@ describe("CallActivityDock rendering", () => {
     expect(html).toContain("general");
     expect(html).toContain("Group call · syncing");
     expect(html).toContain("2 people");
+    expect(html).toContain("alice, bob");
     expect(html).toContain("Join");
-    expect(html).toContain("aria-label=\"Join general call, 2 people\"");
+    expect(html).toContain("aria-label=\"Join general, Group call · syncing · 2 people, alice, bob in call\"");
     expect(html).not.toContain("disabled");
+  });
+
+  test("keeps group calls visible when the desktop DM dock suppresses DM rows", async () => {
+    $mucCallParticipants.set({
+      "general@conference.example.com": ["alice", "bob", "carol"],
+    });
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com",
+        sid: "dm-call-1",
+        media: { audio: true, video: true },
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: new Date().toISOString(),
+      },
+    });
+
+    const html = await renderCallActivityDock({
+      channels: [
+        { id: "general", name: "General", jid: "general@conference.example.com" },
+      ],
+      conversations: [
+        { peerJid: "bob@example.com", peerUsername: "Bob", unreadCount: 0 },
+      ],
+      activeChannelId: null,
+      activePeerJid: "bob@example.com",
+      sidebarMode: "dms",
+      activeChannelJids: new Set<string>(),
+      showDmCalls: false,
+    });
+
+    expect(html).toContain("General");
+    expect(html).toContain("alice, bob +1");
+    expect(html).toContain('aria-label="Join General, Group call · 3 people, alice, bob +1 in call"');
+    expect(html).not.toContain("Bob");
+    expect(html).not.toContain("Video call");
   });
 
   test("renders incoming 1:1 call activity without a false answer affordance", async () => {
@@ -479,7 +556,7 @@ describe("CallActivityDock rendering", () => {
         media: { audio: true, video: false },
         state: "ringing",
         direction: "incoming",
-        updatedAt: "2026-05-25T12:00:00.000Z",
+        updatedAt: new Date().toISOString(),
       },
     });
 
@@ -510,7 +587,7 @@ describe("CallActivityDock rendering", () => {
         media: { audio: true, video: false },
         state: "ringing",
         direction: "incoming",
-        updatedAt: "2026-05-25T12:00:00.000Z",
+        updatedAt: new Date().toISOString(),
       },
     });
 
@@ -529,7 +606,7 @@ describe("CallActivityDock rendering", () => {
     expect(html).toContain("Voice call");
     expect(html).toContain("Ringing");
     expect(html).toContain("Answer");
-    expect(html).toContain('aria-label="Answer Bob call, Ringing"');
+    expect(html).toContain('aria-label="Answer Bob, Voice call · Ringing"');
   });
 
   test("renders a conversation group call banner and emits join", async () => {
@@ -545,7 +622,12 @@ describe("CallActivityDock rendering", () => {
       dmPeerName: null,
     };
     const html = await renderVueComponent("../src/components/calls/ConversationCallBanner.vue", props);
+    expect(html).toContain('role="region"');
+    expect(html).toContain('aria-label="General has a live call"');
     expect(html).toContain("General has a live call");
+    expect(html).toContain("Live now");
+    expect(html).toContain("Voice call");
+    expect(html).toContain("Channel");
     expect(html).toContain("2 people connected in this channel.");
     expect(html).toContain("Join call");
 
@@ -593,10 +675,10 @@ describe("CallActivityDock rendering", () => {
       dmPeerName: null,
     });
 
-    expect(html).toContain('role="region"');
-    expect(html).toContain('aria-label="Conversation call status"');
     expect(html).toContain('aria-live="polite"');
     expect(html).toContain('aria-atomic="true"');
+    expect(html).not.toContain('role="region"');
+    expect(html).not.toContain('aria-label="Conversation call status"');
     expect(html).not.toContain("Join call");
     expect(html).not.toContain("General has a live call");
   });
@@ -605,8 +687,10 @@ describe("CallActivityDock rendering", () => {
     $dmCallActivities.set({
       "bob@example.com": {
         peerJid: "bob@example.com/phone",
+        remoteFullJid: "bob@example.com/phone",
         sid: "dm-live",
         media: { audio: true, video: true },
+        join: liveKitJoinFor(),
         state: "accepted",
         direction: "incoming",
         updatedAt: "2026-05-25T12:00:00.000Z",
@@ -619,10 +703,14 @@ describe("CallActivityDock rendering", () => {
       channelName: null,
       dmPeerJid: "bob@example.com",
       dmPeerName: "Bob",
+      selfFullJid: "alice@example.com/web",
     };
     const html = await renderVueComponent("../src/components/calls/ConversationCallBanner.vue", props);
     expect(html).toContain("Call with Bob is live");
-    expect(html).toContain("The video call is still live after refresh.");
+    expect(html).toContain("Live now");
+    expect(html).toContain("Video call");
+    expect(html).toContain("1:1");
+    expect(html).toContain("The video call is still live.");
     expect(html).toContain("Rejoin");
 
     const emitted: unknown[][] = [];
@@ -645,7 +733,7 @@ describe("CallActivityDock rendering", () => {
         media: { audio: true, video: false },
         state: "ringing",
         direction: "incoming",
-        updatedAt: "2026-05-25T12:00:00.000Z",
+        updatedAt: new Date().toISOString(),
       },
     });
 
@@ -657,6 +745,9 @@ describe("CallActivityDock rendering", () => {
       dmPeerName: "Bob",
     };
     const html = await renderVueComponent("../src/components/calls/ConversationCallBanner.vue", props);
+    expect(html).toContain("Incoming call");
+    expect(html).toContain("Voice call");
+    expect(html).toContain("Ringing");
     expect(html).toContain("Bob is calling");
     expect(html).toContain("Bob is calling with a voice call.");
     expect(html).toContain("Answer");
@@ -694,9 +785,80 @@ describe("CallActivityDock rendering", () => {
     };
     const html = await renderVueComponent("../src/components/calls/ConversationCallBanner.vue", props);
     expect(html).toContain("Call with Bob is live");
-    expect(html).toContain("Waiting for call details to finish syncing.");
+    expect(html).toContain("Syncing");
+    expect(html).toContain("Details pending");
+    expect(html).toContain("Reconnect details are not available on this tab yet.");
     expect(html).toContain("Unavailable");
     expect(html).toContain("disabled");
+
+    const emitted: unknown[][] = [];
+    const bindings = await setupVueComponent("../src/components/calls/ConversationCallBanner.vue", props, (...args) => {
+      emitted.push(args);
+    });
+    setupBindingFunction(bindings, "activateBanner")();
+    expect(emitted).toEqual([]);
+  });
+
+  test("labels accepted DM calls that belong to another resource as unavailable here", async () => {
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com/phone",
+        remoteFullJid: "bob@example.com/phone",
+        sid: "dm-live-other-resource",
+        media: { audio: true, video: false },
+        join: liveKitJoinFor("alice@example.com/phone"),
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: new Date().toISOString(),
+      },
+    });
+
+    const html = await renderVueComponent("../src/components/calls/ConversationCallBanner.vue", {
+      roomJid: null,
+      channelId: null,
+      channelName: null,
+      dmPeerJid: "bob@example.com",
+      dmPeerName: "Bob",
+      selfFullJid: "alice@example.com/web",
+    });
+
+    expect(html).toContain("Other device");
+    expect(html).toContain("This call is live on another browser or device.");
+    expect(html).toContain("Unavailable");
+    expect(html).not.toContain("Waiting for call details to finish syncing.");
+  });
+
+  test("labels expired conversation DM banners as passive", async () => {
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com/phone",
+        remoteFullJid: "bob@example.com/phone",
+        sid: "dm-live-expired",
+        media: { audio: true, video: true },
+        join: {
+          ...liveKitJoinFor("alice@example.com/web"),
+          token: jwtWithExp(Math.floor(Date.now() / 1000) + 10),
+        },
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: new Date().toISOString(),
+      },
+    });
+
+    const props = {
+      roomJid: null,
+      channelId: null,
+      channelName: null,
+      dmPeerJid: "bob@example.com",
+      dmPeerName: "Bob",
+      selfFullJid: "alice@example.com/web",
+    };
+    const html = await renderVueComponent("../src/components/calls/ConversationCallBanner.vue", props);
+
+    expect(html).toContain("Expired");
+    expect(html).toContain("The saved reconnect details expired.");
+    expect(html).toContain("Unavailable");
+    expect(html).not.toContain("Rejoin");
 
     const emitted: unknown[][] = [];
     const bindings = await setupVueComponent("../src/components/calls/ConversationCallBanner.vue", props, (...args) => {
@@ -715,7 +877,7 @@ describe("CallActivityDock rendering", () => {
         media: { audio: true, video: false },
         state: "ringing",
         direction: "incoming",
-        updatedAt: "2026-05-25T12:00:00.000Z",
+        updatedAt: new Date().toISOString(),
       },
     });
 
@@ -814,6 +976,52 @@ describe("CallActivityDock rendering", () => {
     expect(conversationBanner).not.toContain("function isBusy");
   });
 
+  test("ContentArea forwards conversation call banner events at runtime", async () => {
+    const emitted: unknown[][] = [];
+    const previousProbe = (globalThis as {
+      __waddleConversationCallBannerProbe?: (
+        props: Record<string, unknown>,
+        emit: (event: string, ...args: unknown[]) => void,
+      ) => void;
+    }).__waddleConversationCallBannerProbe;
+    const media = { audio: true, video: false };
+    (globalThis as {
+      __waddleConversationCallBannerProbe?: (
+        props: Record<string, unknown>,
+        emit: (event: string, ...args: unknown[]) => void,
+      ) => void;
+    }).__waddleConversationCallBannerProbe = (props, emit) => {
+      expect(props.roomJid).toBe("general@conference.example.com");
+      expect(props.channelId).toBe("general");
+      expect(props.dmPeerJid).toBe("bob@example.com");
+      emit("joinChannelCall", "general", "general@conference.example.com", media);
+      emit("answerDm", "bob@example.com", "bob@example.com/phone", "sid-1", media);
+      emit("reconnectDm", "bob@example.com", media);
+    };
+
+    try {
+      await suppressVueLifecycleSetupWarnings(() => renderVueComponent("../src/components/chat/ContentArea.vue", {
+        ...contentAreaBaseProps(),
+        onJoinChannelCall: (...args: unknown[]) => emitted.push(["joinChannelCall", ...args]),
+        onAnswerDm: (...args: unknown[]) => emitted.push(["answerDm", ...args]),
+        onReconnectDm: (...args: unknown[]) => emitted.push(["reconnectDm", ...args]),
+      }));
+    } finally {
+      (globalThis as {
+        __waddleConversationCallBannerProbe?: (
+          props: Record<string, unknown>,
+          emit: (event: string, ...args: unknown[]) => void,
+        ) => void;
+      }).__waddleConversationCallBannerProbe = previousProbe;
+    }
+
+    expect(emitted).toEqual([
+      ["joinChannelCall", "general", "general@conference.example.com", media],
+      ["answerDm", "bob@example.com", "bob@example.com/phone", "sid-1", media],
+      ["reconnectDm", "bob@example.com", media],
+    ]);
+  });
+
   test("renders the persistent current-call panel for an active DM call", async () => {
     $callState.set({
       phase: "active",
@@ -874,10 +1082,37 @@ describe("CallActivityDock rendering", () => {
     expect(html).toContain("General");
     expect(html).toContain("Connecting...");
     expect(html).toContain("Group call");
-    expect(html).toContain("2 in call");
+    expect(html).toContain("alice, bob");
     expect(html).toContain("Viewing");
     expect(html).toContain('aria-label="Viewing General call"');
     expect(html).toContain("disabled");
+  });
+
+  test("renders the local group-call nick before Muji participant replay reaches the current panel", async () => {
+    $callState.set({
+      phase: "muc-pending",
+      kind: "muc",
+      peer: "general@conference.example.com",
+      sid: "muc-live",
+      media: { audio: true, video: false },
+      selfNick: "alice",
+      attemptId: "attempt-1",
+    });
+
+    const html = await renderVueComponent("../src/components/calls/CurrentCallPanel.vue", {
+      channels: [
+        { id: "general", name: "General", jid: "general@conference.example.com" },
+      ],
+      conversations: [],
+      activeChannelId: null,
+      activeChannelRoomJid: null,
+      activePeerJid: null,
+    });
+
+    expect(html).toContain("Starting call");
+    expect(html).toContain("Group call");
+    expect(html).toContain("alice");
+    expect(html).not.toContain("Group</span>");
   });
 
   test("routes the persistent current-call panel back to the owning conversation", async () => {
@@ -990,6 +1225,126 @@ describe("CallActivityDock rendering", () => {
     expect(dmHtml).not.toContain("bob");
   });
 
+  test("announces no other calls when the current call is filtered out", async () => {
+    $callState.set({
+      phase: "active",
+      kind: "dm",
+      peer: "bob@example.com/phone",
+      sid: "dm-live",
+      media: { audio: true, video: true },
+      join: liveKitJoin,
+    });
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com",
+        sid: "dm-live",
+        media: { audio: true, video: true },
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:00:00.000Z",
+      },
+    });
+
+    const html = await renderVueComponent("../src/components/calls/CallActivityDock.vue", {
+      channels: [],
+      conversations: [{ peerJid: "bob@example.com", peerUsername: "Bob" }],
+      activeChannelId: null,
+      activePeerJid: null,
+      sidebarMode: "dms",
+      activeChannelJids: new Set<string>(),
+      hideCurrentCall: true,
+    });
+
+    expect(html).toContain("No other active calls.");
+    expect(html).not.toContain('aria-label="Active calls"');
+  });
+
+  test("announces no other calls while the current call has not echoed into activity yet", async () => {
+    $callState.set({
+      phase: "active",
+      kind: "dm",
+      peer: "bob@example.com/phone",
+      sid: "dm-live",
+      media: { audio: true, video: true },
+      join: liveKitJoinFor(),
+    });
+
+    const html = await renderVueComponent("../src/components/calls/CallActivityDock.vue", {
+      channels: [],
+      conversations: [{ peerJid: "bob@example.com", peerUsername: "Bob" }],
+      activeChannelId: null,
+      activePeerJid: null,
+      sidebarMode: "dms",
+      activeChannelJids: new Set<string>(),
+      hideCurrentCall: true,
+    });
+
+    expect(html).toContain("No other active calls.");
+    expect(html).not.toContain("No active calls.");
+    expect(html).not.toContain('aria-label="Active calls"');
+  });
+
+  test("labels non-resumable accepted DM calls truthfully in the activity dock", async () => {
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com",
+        remoteFullJid: "bob@example.com/phone",
+        sid: "dm-other-device",
+        media: { audio: true, video: true },
+        join: liveKitJoinFor("alice@example.com/phone"),
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:00:00.000Z",
+      },
+    });
+
+    const html = await renderVueComponent("../src/components/calls/CallActivityDock.vue", {
+      channels: [],
+      conversations: [{ peerJid: "bob@example.com", peerUsername: "Bob" }],
+      activeChannelId: null,
+      activePeerJid: null,
+      sidebarMode: "channels",
+      activeChannelJids: new Set<string>(),
+      selfFullJid: "alice@example.com/web",
+    });
+
+    expect(html).toContain("Video call · Other device");
+    expect(html).toContain('aria-label="Open Bob, Video call · Other device"');
+    expect(html).not.toContain("Video call · Live");
+  });
+
+  test("downgrades expired accepted DM calls to open-only copy", async () => {
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com",
+        remoteFullJid: "bob@example.com/phone",
+        sid: "dm-expired",
+        media: { audio: true, video: true },
+        join: {
+          ...liveKitJoinFor("alice@example.com/web"),
+          token: jwtWithExp(Math.floor(Date.now() / 1000) + 10),
+        },
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:00:00.000Z",
+      },
+    });
+
+    const html = await renderVueComponent("../src/components/calls/CallActivityDock.vue", {
+      channels: [],
+      conversations: [{ peerJid: "bob@example.com", peerUsername: "Bob" }],
+      activeChannelId: null,
+      activePeerJid: null,
+      sidebarMode: "channels",
+      activeChannelJids: new Set<string>(),
+      selfFullJid: "alice@example.com/web",
+    });
+
+    expect(html).toContain("Video call · Expired");
+    expect(html).toContain('aria-label="Open Bob, Video call · Expired"');
+    expect(html).not.toContain("Reconnect Bob");
+  });
+
   test("expands the persistent current-call panel into a known group channel", async () => {
     $callState.set({
       phase: "active",
@@ -1039,12 +1394,92 @@ describe("CallActivityDock rendering", () => {
     expect(html).toContain('title="1 active call"');
   });
 
+  test("counts local current calls in the rail before discovery echoes activity", () => {
+    expect(activeChannelRailCallCount({}, {
+      phase: "muc-pending",
+      kind: "muc",
+      peer: "General@Conference.Example.com/alice",
+      sid: "muc-call",
+      media: { audio: true, video: false },
+      selfNick: "alice",
+      attemptId: "attempt-1",
+    })).toBe(1);
+    expect(activeChannelRailCallCount({
+      "general@conference.example.com": 2,
+    }, {
+      phase: "active",
+      kind: "muc",
+      peer: "general@conference.example.com",
+      sid: "muc-call",
+      media: { audio: true, video: false },
+      join: liveKitJoin,
+      selfNick: "alice",
+    })).toBe(1);
+    expect(activeDmRailCallCount({}, {
+      phase: "active",
+      kind: "dm",
+      peer: "bob@example.com/phone",
+      sid: "dm-call",
+      media: { audio: true, video: true },
+      join: liveKitJoin,
+    })).toBe(1);
+    expect(activeDmRailCallCount({
+      "bob@example.com": {
+        peerJid: "bob@example.com",
+        sid: "dm-call",
+        media: { audio: true, video: true },
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:00:00.000Z",
+      },
+    }, {
+      phase: "active",
+      kind: "dm",
+      peer: "bob@example.com/phone",
+      sid: "dm-call",
+      media: { audio: true, video: true },
+      join: liveKitJoin,
+    })).toBe(1);
+  });
+
   test("renders refreshed call-only DMs in the direct-message panel", async () => {
     $dmCallActivities.set({
       "bob@example.com": {
         peerJid: "bob@example.com",
+        remoteFullJid: "bob@example.com/phone",
         sid: "dm-call-1",
         media: { audio: true, video: true },
+        join: liveKitJoinFor(),
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:00:00.000Z",
+      },
+    });
+    connectionStore.client = { fullJid: "alice@example.com/web" } as unknown as typeof connectionStore.client;
+
+    const html = await renderVueComponent("../src/components/chat/DmPanel.vue", {
+      conversations: [],
+      activePeerJid: null,
+      selfFullJid: "alice@example.com/web",
+    });
+
+    expect(html).not.toContain("No conversations yet");
+    expect(html).toContain("Active calls");
+    expect(html).toContain("bob");
+    expect(html).toContain("Live now");
+    expect(html).toContain("Live video call");
+    expect(html).toContain("Reconnect bob call, Live now, Live video call");
+    expect(html).toContain("Live");
+  });
+
+  test("labels non-resumable direct calls in the direct-message panel", async () => {
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com",
+        remoteFullJid: "bob@example.com/phone",
+        sid: "dm-call-other-device",
+        media: { audio: true, video: false },
+        join: liveKitJoinFor("alice@example.com/phone"),
         state: "accepted",
         direction: "incoming",
         updatedAt: "2026-05-25T12:00:00.000Z",
@@ -1054,14 +1489,44 @@ describe("CallActivityDock rendering", () => {
     const html = await renderVueComponent("../src/components/chat/DmPanel.vue", {
       conversations: [],
       activePeerJid: null,
+      selfFullJid: "alice@example.com/web",
     });
 
-    expect(html).not.toContain("No conversations yet");
-    expect(html).toContain("Active calls");
-    expect(html).toContain("bob");
-    expect(html).toContain("Live video call");
-    expect(html).toContain("Reconnect bob call, Live video call");
-    expect(html).toContain("Live");
+    expect(html).toContain("Other device");
+    expect(html).toContain("Voice call · Other device");
+    expect(html).toContain("This call is live on another browser or device.");
+    expect(html).toContain("Open bob call, Other device, Voice call · Other device");
+    expect(html).not.toContain("Reconnect bob call");
+  });
+
+  test("labels expired direct calls in the direct-message panel", async () => {
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com",
+        remoteFullJid: "bob@example.com/phone",
+        sid: "dm-call-expired",
+        media: { audio: true, video: true },
+        join: {
+          ...liveKitJoinFor("alice@example.com/web"),
+          token: jwtWithExp(Math.floor(Date.now() / 1000) + 10),
+        },
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:00:00.000Z",
+      },
+    });
+
+    const html = await renderVueComponent("../src/components/chat/DmPanel.vue", {
+      conversations: [],
+      activePeerJid: null,
+      selfFullJid: "alice@example.com/web",
+    });
+
+    expect(html).toContain("Expired");
+    expect(html).toContain("Video call · Expired");
+    expect(html).toContain("The saved reconnect details expired.");
+    expect(html).toContain("Open bob call, Expired, Video call · Expired");
+    expect(html).not.toContain("Reconnect bob call");
   });
 
   test("does not duplicate refreshed DM call activity when the conversation already exists", async () => {
@@ -1089,11 +1554,80 @@ describe("CallActivityDock rendering", () => {
 
     expect(html).toContain("Active calls");
     expect(html).toContain("Bobby");
-    expect(html).toContain("Live video call");
-    expect(html).toContain("Live");
+    expect(html).toContain("Syncing");
+    expect(html).toContain("Video call · Details pending");
+    expect(html).toContain("Reconnect details are not available on this tab yet.");
     expect(html).toContain('aria-current="page"');
     expect(html).not.toContain("Existing chat preview");
     expect(html).not.toContain("Video call live");
+  });
+
+  test("labels the hidden current call separately in the direct-message panel", async () => {
+    $callState.set({
+      phase: "active",
+      kind: "dm",
+      peer: "bob@example.com/phone",
+      sid: "dm-call-current",
+      media: { audio: true, video: true },
+      join: liveKitJoinFor(),
+    });
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com/phone",
+        remoteFullJid: "bob@example.com/phone",
+        sid: "dm-call-current",
+        media: { audio: true, video: true },
+        join: liveKitJoinFor(),
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:00:00.000Z",
+      },
+    });
+
+    const html = await renderVueComponent("../src/components/chat/DmPanel.vue", {
+      conversations: [{
+        peerJid: "bob@example.com",
+        peerUsername: "Bobby",
+        lastMessageBody: "Existing chat preview",
+        unreadCount: 0,
+      }],
+      activePeerJid: null,
+      selfFullJid: "alice@example.com/web",
+      hideCurrentCall: true,
+    });
+
+    expect(html).toContain("No other active direct calls.");
+    expect(html).toContain("Current call shown separately");
+    expect(html).toContain("Current call");
+    expect(html).toContain('aria-label="Bobby, not selected, Current call shown separately, Open conversation"');
+    expect(html).not.toContain("Return call");
+    expect(html).not.toContain("Reconnect call");
+  });
+
+  test("announces no other direct calls while the current call has not echoed into activity yet", async () => {
+    $callState.set({
+      phase: "active",
+      kind: "dm",
+      peer: "bob@example.com/phone",
+      sid: "dm-call-current",
+      media: { audio: true, video: true },
+      join: liveKitJoinFor(),
+    });
+
+    const html = await renderVueComponent("../src/components/chat/DmPanel.vue", {
+      conversations: [{
+        peerJid: "bob@example.com",
+        peerUsername: "Bobby",
+        lastMessageBody: "Existing chat preview",
+        unreadCount: 0,
+      }],
+      activePeerJid: null,
+      selfFullJid: "alice@example.com/web",
+      hideCurrentCall: true,
+    });
+
+    expect(html).toContain("No other active direct calls.");
+    expect(html).not.toContain("No active direct calls.");
   });
 
   test("renders outgoing refreshed DM call rows with clear ringing copy", async () => {
@@ -1114,15 +1648,17 @@ describe("CallActivityDock rendering", () => {
     });
 
     expect(html).toContain("Calling voice call");
-    expect(html).toContain("Open alice call, Calling voice call");
+    expect(html).toContain("Open alice call, Calling, Calling voice call");
     expect(html).not.toContain("Voice call calling");
   });
 
   test("selects refreshed DM call rows as reconnect or return actions", async () => {
     const activity: DmCallActivity = {
       peerJid: "bob@example.com/phone",
+      remoteFullJid: "bob@example.com/phone",
       sid: "dm-call-9",
       media: { audio: true, video: true },
+      join: liveKitJoinFor(),
       state: "accepted",
       direction: "incoming",
       updatedAt: "2026-05-25T12:00:00.000Z",
@@ -1132,6 +1668,7 @@ describe("CallActivityDock rendering", () => {
     const bindings = await setupVueComponent("../src/components/chat/DmPanel.vue", {
       conversations: [],
       activePeerJid: null,
+      selfFullJid: "alice@example.com/web",
     }, (...args) => {
       emitted.push(args);
     });
@@ -1219,7 +1756,7 @@ describe("CallActivityDock rendering", () => {
       activePeerJid: null,
     });
 
-    const bobIndex = html.indexOf("Live video call");
+    const bobIndex = html.indexOf("Video call · Details pending");
     const aliceIndex = html.indexOf("Calling voice call", bobIndex);
     const carolIndex = html.indexOf("Latest real conversation", aliceIndex);
     expect(bobIndex).toBeGreaterThanOrEqual(0);
@@ -1267,7 +1804,8 @@ describe("CallActivityDock rendering", () => {
     expect(carolIndex).toBeGreaterThanOrEqual(0);
     expect(bobbyIndex).toBeLessThan(carolIndex);
     expect(html).not.toContain("Old message, active call");
-    expect(html).toContain("Live");
+    expect(html).toContain("Syncing");
+    expect(html).toContain("Video call · Details pending");
     expect(html).not.toContain("Video call live");
   });
 
@@ -1554,6 +2092,46 @@ describe("CallActivityDock rendering", () => {
     ]);
   });
 
+  test("mobile drawer forwards DM answer rows to the shell handler", async () => {
+    const forwarded: unknown[][] = [];
+    const bindings = await setupVueComponent("../src/components/chat/ChatMobileDrawers.vue", {
+      controller: {},
+      answerDm: (...args: unknown[]) => {
+        forwarded.push(args);
+      },
+    });
+
+    setupBindingFunction(bindings, "answerDmFromMobile")(
+      "bob@example.com",
+      "bob@example.com/phone",
+      "dm-call-1",
+      { audio: true, video: false },
+    );
+
+    expect(forwarded).toEqual([
+      ["bob@example.com", "bob@example.com/phone", "dm-call-1", { audio: true, video: false }],
+    ]);
+  });
+
+  test("mobile drawer forwards DM reconnect rows to the shell handler", async () => {
+    const forwarded: unknown[][] = [];
+    const bindings = await setupVueComponent("../src/components/chat/ChatMobileDrawers.vue", {
+      controller: {},
+      reconnectDm: (...args: unknown[]) => {
+        forwarded.push(args);
+      },
+    });
+
+    setupBindingFunction(bindings, "reconnectDmFromMobile")(
+      "bob@example.com",
+      { audio: true, video: true },
+    );
+
+    expect(forwarded).toEqual([
+      ["bob@example.com", { audio: true, video: true }],
+    ]);
+  });
+
   test("mobile drawer routes community surfaces through the controller", async () => {
     const selected: unknown[][] = [];
     const bindings = await setupVueComponent("../src/components/chat/ChatMobileDrawers.vue", {
@@ -1622,6 +2200,94 @@ describe("CallActivityDock rendering", () => {
     ]);
   });
 
+  test("home dashboard routes refreshed calls through reconnect, open-only, and fallback room actions", async () => {
+    const emitted: unknown[][] = [];
+    const validDmEntry = buildCallActivityDockEntries({
+      channels: [],
+      conversations: [{ peerJid: "bob@example.com", peerUsername: "Bob" }],
+      activeChannelId: null,
+      activePeerJid: null,
+      sidebarMode: "channels",
+      activeChannelJids: new Set(),
+      managedMucDomain: "conference.example.com",
+      callParticipantCounts: {},
+      dmCallActivities: {
+        "bob@example.com": {
+          peerJid: "bob@example.com",
+          remoteFullJid: "bob@example.com/phone",
+          sid: "dm-live",
+          media: { audio: true, video: true },
+          join: liveKitJoinFor(),
+          state: "accepted",
+          direction: "incoming",
+          updatedAt: "2026-05-25T12:00:00.000Z",
+        },
+      },
+    })[0];
+    const staleDmEntry = buildCallActivityDockEntries({
+      channels: [],
+      conversations: [{ peerJid: "carol@example.com", peerUsername: "Carol" }],
+      activeChannelId: null,
+      activePeerJid: null,
+      sidebarMode: "channels",
+      activeChannelJids: new Set(),
+      managedMucDomain: "conference.example.com",
+      callParticipantCounts: {},
+      dmCallActivities: {
+        "carol@example.com": {
+          peerJid: "carol@example.com",
+          remoteFullJid: "carol@example.com/phone",
+          sid: "dm-stale",
+          media: { audio: true, video: false },
+          join: liveKitJoinFor("alice@example.com/other"),
+          state: "accepted",
+          direction: "incoming",
+          updatedAt: "2026-05-25T12:00:00.000Z",
+        },
+      },
+    })[0];
+    const fallbackRoomEntry = buildCallActivityDockEntries({
+      channels: [],
+      conversations: [],
+      activeChannelId: null,
+      activePeerJid: null,
+      sidebarMode: "channels",
+      activeChannelJids: new Set(["standup@conference.example.com"]),
+      managedMucDomain: "conference.example.com",
+      callParticipantCounts: { "standup@conference.example.com": 2 },
+      dmCallActivities: {},
+    })[0];
+    if (!validDmEntry || !staleDmEntry || !fallbackRoomEntry) {
+      throw new Error("expected call entries for dashboard routing test");
+    }
+    const bindings = await suppressVueLifecycleSetupWarnings(() =>
+      setupVueComponent("../src/components/chat/HomeDashboard.vue", {
+        spaces: [],
+        channels: [],
+        contacts: [],
+        isLoading: false,
+        channelUnreadMap: {},
+        activeChannelJids: new Set(["standup@conference.example.com"]),
+        managedMucDomain: "conference.example.com",
+        callParticipantCounts: { "standup@conference.example.com": 2 },
+        dmConversations: [],
+        selfFullJid: "alice@example.com/web",
+      }, (...args) => {
+        emitted.push(args);
+      })
+    );
+
+    setupBindingFunction(bindings, "selectCallEntry")(validDmEntry);
+    setupBindingFunction(bindings, "selectCallEntry")(staleDmEntry);
+    setupBindingFunction(bindings, "selectCallEntry")(fallbackRoomEntry);
+
+    expect(emitted).toEqual([
+      ["reconnectDm", "bob@example.com", { audio: true, video: true }],
+      ["selectContact", "carol@example.com"],
+      ["joinChannelCall", null, "standup@conference.example.com", { audio: true, video: false }],
+    ]);
+  });
+
   test("shell join-call handler clears community surfaces before selecting a channel", async () => {
     const selected: unknown[][] = [];
     const ui = {
@@ -1672,17 +2338,208 @@ describe("CallActivityDock rendering", () => {
     ]);
   });
 
-  test("renders hydrated DM call controls with reconnect context", async () => {
+  test("shell answer selects the DM and proceeds with the hydrated full JID", async () => {
+    clearCallState();
+    const now = new Date().toISOString();
     $dmCallActivities.set({
       "bob@example.com": {
         peerJid: "bob@example.com",
-        sid: "dm-call-1",
+        remoteFullJid: "bob@example.com/phone",
+        sid: "dm-ring",
+        media: { audio: true, video: false },
+        state: "ringing",
+        direction: "incoming",
+        updatedAt: now,
+      },
+    });
+    const selected: unknown[][] = [];
+    const sendCallProceed = mock(async () => undefined);
+    const bindings = await suppressVueLifecycleSetupWarnings(() =>
+      setupVueComponent("../src/components/chat/ChatReadyShell.vue", {
+        controller: {
+          ui: { activeCommunitySurface: { value: null } },
+          connectionStore: {
+            client: { fullJid: "alice@example.com/web", xmpp: { send_call_proceed: sendCallProceed } },
+            session: null,
+          },
+          waddles: { mucServiceJid: { value: "" } },
+          selfDomain: { value: "" },
+          rosterContacts: {
+            contacts: { value: [] },
+            isLoadingContacts: { value: false },
+          },
+          messaging: {
+            mentionedChannelCounts: { value: {} },
+            activeChannels: { value: new Set<string>() },
+          },
+          dmConversations: { conversations: { value: [] } },
+          computedChannelUnreadMap: { value: {} },
+          activeRightPanel: { value: null },
+          activeThreadStack: { value: [] },
+          communityEvents: { rsvp: () => undefined },
+          closePinnedPanel: () => undefined,
+          activateRightPanel: () => undefined,
+          selectDm: (...args: unknown[]) => {
+            selected.push(args);
+          },
+          selectChannel: () => undefined,
+          selectChannelByRoomJid: () => undefined,
+        },
+      }),
+    );
+
+    setupBindingFunction(bindings, "answerDmFromActivity")(
+      "bob@example.com",
+      "bob@example.com/phone",
+      "dm-ring",
+      { audio: true, video: false },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(selected).toEqual([["bob@example.com"]]);
+    expect(sendCallProceed).toHaveBeenCalledWith("bob@example.com/phone", "dm-ring");
+    expect($callState.get()).toMatchObject({
+      phase: "incoming",
+      from: "bob@example.com/phone",
+      sid: "dm-ring",
+      accepting: true,
+    });
+  });
+
+  test("shell reconnect resumes only same-resource archived LiveKit calls", async () => {
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com",
+        remoteFullJid: "bob@example.com/phone",
+        sid: "dm-resume",
+        media: { audio: true, video: true },
+        join: liveKitJoinFor(),
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: new Date().toISOString(),
+      },
+    });
+    const selected: unknown[][] = [];
+    const bindings = await suppressVueLifecycleSetupWarnings(() =>
+      setupVueComponent("../src/components/chat/ChatReadyShell.vue", {
+        controller: {
+          ui: { activeCommunitySurface: { value: null } },
+          connectionStore: {
+            client: { fullJid: "alice@example.com/web" },
+            session: null,
+          },
+          waddles: { mucServiceJid: { value: "" } },
+          selfDomain: { value: "" },
+          rosterContacts: {
+            contacts: { value: [] },
+            isLoadingContacts: { value: false },
+          },
+          messaging: {
+            mentionedChannelCounts: { value: {} },
+            activeChannels: { value: new Set<string>() },
+          },
+          dmConversations: { conversations: { value: [] } },
+          computedChannelUnreadMap: { value: {} },
+          activeRightPanel: { value: null },
+          activeThreadStack: { value: [] },
+          communityEvents: { rsvp: () => undefined },
+          closePinnedPanel: () => undefined,
+          activateRightPanel: () => undefined,
+          selectDm: (...args: unknown[]) => {
+            selected.push(args);
+          },
+          selectChannel: () => undefined,
+          selectChannelByRoomJid: () => undefined,
+        },
+      }),
+    );
+
+    setupBindingFunction(bindings, "reconnectDmFromDock")(
+      "bob@example.com",
+      { audio: true, video: true },
+    );
+
+    expect(selected).toEqual([["bob@example.com"]]);
+    expect($callState.get()).toEqual({
+      phase: "active",
+      kind: "dm",
+      peer: "bob@example.com/phone",
+      sid: "dm-resume",
+      media: { audio: true, video: true },
+      join: liveKitJoinFor(),
+      initiator: "alice@example.com/web",
+    });
+  });
+
+  test("shell reconnect leaves stale accepted activity open-only instead of sending a new propose", async () => {
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com",
+        sid: "dm-stale",
         media: { audio: true, video: true },
         state: "accepted",
         direction: "incoming",
         updatedAt: "2026-05-25T12:00:00.000Z",
       },
     });
+    const selected: unknown[][] = [];
+    const bindings = await suppressVueLifecycleSetupWarnings(() =>
+      setupVueComponent("../src/components/chat/ChatReadyShell.vue", {
+        controller: {
+          ui: { activeCommunitySurface: { value: null } },
+          connectionStore: {
+            client: { fullJid: "alice@example.com/web" },
+            session: null,
+          },
+          waddles: { mucServiceJid: { value: "" } },
+          selfDomain: { value: "" },
+          rosterContacts: {
+            contacts: { value: [] },
+            isLoadingContacts: { value: false },
+          },
+          messaging: {
+            mentionedChannelCounts: { value: {} },
+            activeChannels: { value: new Set<string>() },
+          },
+          dmConversations: { conversations: { value: [] } },
+          computedChannelUnreadMap: { value: {} },
+          activeRightPanel: { value: null },
+          activeThreadStack: { value: [] },
+          communityEvents: { rsvp: () => undefined },
+          closePinnedPanel: () => undefined,
+          activateRightPanel: () => undefined,
+          selectDm: (...args: unknown[]) => {
+            selected.push(args);
+          },
+          selectChannel: () => undefined,
+          selectChannelByRoomJid: () => undefined,
+        },
+      }),
+    );
+
+    setupBindingFunction(bindings, "reconnectDmFromDock")(
+      "bob@example.com",
+      { audio: true, video: true },
+    );
+
+    expect(selected).toEqual([["bob@example.com"]]);
+    expect($callState.get()).toEqual({ phase: "idle" });
+  });
+
+  test("renders hydrated DM call controls with reconnect context", async () => {
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com",
+        remoteFullJid: "bob@example.com/phone",
+        sid: "dm-call-1",
+        media: { audio: true, video: true },
+        join: liveKitJoinFor(),
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:00:00.000Z",
+      },
+    });
+    connectionStore.client = { fullJid: "alice@example.com/web" } as unknown as typeof connectionStore.client;
 
     const html = await renderVueComponent("../src/components/calls/CallButton.vue", {
       peerBareJid: "bob@example.com",
@@ -1692,6 +2549,72 @@ describe("CallActivityDock rendering", () => {
     expect(html).toContain("Reconnect video call");
     expect(html).not.toContain("Reconnect voice call");
     expect(html).not.toContain("Start voice call");
+  });
+
+  test("CallButton reconnects hydrated same-resource activity without sending a fresh propose", async () => {
+    const updatedAt = new Date().toISOString();
+    const sender = {
+      send_call_propose: mock(async () => undefined),
+    };
+    connectionStore.client = {
+      fullJid: "alice@example.com/web",
+      xmpp: sender,
+    } as unknown as typeof connectionStore.client;
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com",
+        remoteFullJid: "bob@example.com/phone",
+        sid: "dm-call-1",
+        media: { audio: true, video: true },
+        join: liveKitJoinFor(),
+        state: "accepted",
+        direction: "incoming",
+        updatedAt,
+      },
+    });
+    const bindings = await setupVueComponent("../src/components/calls/CallButton.vue", {
+      peerBareJid: "bob@example.com",
+    });
+
+    await setupBindingFunction(bindings, "handlePeerCallActivity")();
+
+    expect(sender.send_call_propose).not.toHaveBeenCalled();
+    expect($callState.get()).toMatchObject({
+      phase: "active",
+      kind: "dm",
+      peer: "bob@example.com/phone",
+      sid: "dm-call-1",
+      join: liveKitJoinFor(),
+    });
+  });
+
+  test("CallButton stale accepted activity stays open-only and never sends a new propose", async () => {
+    const sender = {
+      send_call_propose: mock(async () => undefined),
+    };
+    connectionStore.client = {
+      fullJid: "alice@example.com/web",
+      xmpp: sender,
+    } as unknown as typeof connectionStore.client;
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com",
+        remoteFullJid: "bob@example.com/phone",
+        sid: "dm-call-stale",
+        media: { audio: true, video: true },
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:00:00.000Z",
+      },
+    });
+    const bindings = await setupVueComponent("../src/components/calls/CallButton.vue", {
+      peerBareJid: "bob@example.com",
+    });
+
+    await setupBindingFunction(bindings, "handlePeerCallActivity")();
+
+    expect(sender.send_call_propose).not.toHaveBeenCalled();
+    expect($callState.get()).toEqual({ phase: "idle" });
   });
 
   test("does not reconnect proceed-only DM call activity with guessed voice media", async () => {
@@ -1790,6 +2713,54 @@ function chatHeaderBaseProps(): Record<string, unknown> {
     "onUpdate:showSearch": () => undefined,
     showPinnedPanel: false,
     "onUpdate:showPinnedPanel": () => undefined,
+  };
+}
+
+function contentAreaBaseProps(): Record<string, unknown> {
+  return {
+    draft: "",
+    forumTitle: "",
+    pinnedPanelOpen: false,
+    waddle: { id: "team", name: "Team" },
+    channel: { id: "general", name: "General", jid: "general@conference.example.com", spaceId: "team" },
+    roomJid: null,
+    dmPeer: { peerJid: "bob@example.com", peerUsername: "Bob", presenceShow: "available" },
+    sidebarMode: "channels",
+    messages: [],
+    firstUnseenId: null,
+    xmppStatus: { state: "online" },
+    actionError: "",
+    errorActionLabel: null,
+    updateAvailable: false,
+    isApplyingUpdate: false,
+    isLoadingMessages: false,
+    isLoadingOlderMessages: false,
+    hasOlderMessages: false,
+    isSending: false,
+    canManageChannels: false,
+    memberCount: 0,
+    memberState: "ready",
+    typingUsers: [],
+    currentUser: "alice",
+    currentUserJid: "alice@example.com",
+    selfFullJid: "alice@example.com/web",
+    selfDomain: "example.com",
+    avatarUrlByAuthor: {},
+    authorJidByNick: {},
+    giphyApiKey: "",
+    mentionCandidates: [],
+    roomHats: {},
+    roomAuthority: {},
+    roomPresence: {},
+    roomLastSeen: {},
+    slowModeCooldown: 0,
+    searchResults: [],
+    isSearching: false,
+    uploadProgress: { uploading: false, progress: 0, filename: "" },
+    threadIndex: new Map(),
+    xmppClient: null,
+    notifySettings: {},
+    reactionMode: null,
   };
 }
 
@@ -1903,6 +2874,7 @@ async function suppressVueLifecycleSetupWarnings<T>(fn: () => Promise<T>): Promi
     const message = String(args[0] ?? "");
     if (
       message.includes("onMounted is called when there is no active component instance") ||
+      message.includes("onBeforeUnmount is called when there is no active component instance") ||
       message.includes("onUnmounted is called when there is no active component instance")
     ) {
       return;
@@ -1981,5 +2953,8 @@ function resolveSourcePath(basePath: string): string {
 
 function moduleUrlForPath(resolvedPath: string): string {
   if (!resolvedPath.endsWith(".vue")) return pathToFileURL(resolvedPath).href;
+  if (resolvedPath.endsWith("/components/calls/ConversationCallBanner.vue")) {
+    return new URL("./helpers/conversation-call-banner-stub.ts", import.meta.url).href;
+  }
   return new URL("./helpers/vue-sfc-stub.ts", import.meta.url).href;
 }

--- a/chat/tests/call-controls.test.ts
+++ b/chat/tests/call-controls.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { $callState, clearCallState } from "../src/lib/calls/call-store";
-import { suspendCallForPageHide } from "../src/lib/calls/call-controls";
+import {
+  installCallPagehideSuspension,
+  suspendCallForPageHide,
+} from "../src/lib/calls/call-controls";
 import {
   $dmCallActivities,
   clearDmCallActivities,
@@ -15,6 +18,28 @@ const join: LiveKitJoin = {
   identity: "alice@waddle.test/web",
   token: "jwt",
 };
+
+class PagehideHarness {
+  private readonly listeners = new Set<EventListener>();
+
+  addEventListener(type: string, listener: EventListener) {
+    if (type === "pagehide") this.listeners.add(listener);
+  }
+
+  removeEventListener(type: string, listener: EventListener) {
+    if (type === "pagehide") this.listeners.delete(listener);
+  }
+
+  dispatchPagehide(persisted: boolean) {
+    const event = new Event("pagehide") as PageTransitionEvent;
+    Object.defineProperty(event, "persisted", { value: persisted });
+    for (const listener of this.listeners) listener(event);
+  }
+
+  listenerCount(): number {
+    return this.listeners.size;
+  }
+}
 
 afterEach(() => {
   clearCallState();
@@ -81,12 +106,98 @@ describe("call page lifecycle controls", () => {
     expect(sender.send_raw_iq).not.toHaveBeenCalled();
   });
 
+  test("pagehide suspension persists stream resume state before clearing the local call slot", () => {
+    const persistResumeStateForPageHide = mock(() => undefined);
+    connectionStore.client = {
+      persistResumeStateForPageHide,
+    } as unknown as typeof connectionStore.client;
+    $callState.set({
+      phase: "active",
+      peer: "bob@waddle.test/desktop",
+      sid: "c1",
+      media: { audio: true, video: true },
+      join,
+      kind: "dm",
+    });
+
+    suspendCallForPageHide();
+
+    expect(persistResumeStateForPageHide).toHaveBeenCalledTimes(1);
+    expect($callState.get()).toEqual({ phase: "idle" });
+  });
+
+  test("pagehide persists stream resume state for rediscovered idle DM calls", () => {
+    const persistResumeStateForPageHide = mock(() => undefined);
+    connectionStore.client = {
+      persistResumeStateForPageHide,
+    } as unknown as typeof connectionStore.client;
+    $callState.set({ phase: "idle" });
+    $dmCallActivities.set({
+      "bob@waddle.test": {
+        peerJid: "bob@waddle.test",
+        remoteFullJid: "bob@waddle.test/desktop",
+        sid: "c1",
+        media: { audio: true, video: true },
+        join,
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: "2026-05-26T00:00:00.000Z",
+      },
+    });
+
+    suspendCallForPageHide();
+
+    expect(persistResumeStateForPageHide).toHaveBeenCalledTimes(1);
+    expect($callState.get()).toEqual({ phase: "idle" });
+    expect($dmCallActivities.get()["bob@waddle.test"]?.sid).toBe("c1");
+  });
+
+  test("pagehide listener ignores BFCache restores and suspends refresh unloads", () => {
+    const target = new PagehideHarness();
+    const persistResumeStateForPageHide = mock(() => undefined);
+    connectionStore.client = {
+      persistResumeStateForPageHide,
+    } as unknown as typeof connectionStore.client;
+    $callState.set({
+      phase: "active",
+      peer: "bob@waddle.test/desktop",
+      sid: "c1",
+      media: { audio: true, video: true },
+      join,
+      kind: "dm",
+    });
+
+    const disconnect = installCallPagehideSuspension(target as unknown as Window);
+    expect(target.listenerCount()).toBe(1);
+
+    target.dispatchPagehide(true);
+    expect(persistResumeStateForPageHide).not.toHaveBeenCalled();
+    expect($callState.get()).toMatchObject({ phase: "active", sid: "c1" });
+
+    target.dispatchPagehide(false);
+    expect(persistResumeStateForPageHide).toHaveBeenCalledTimes(1);
+    expect($callState.get()).toEqual({ phase: "idle" });
+
+    $callState.set({
+      phase: "active",
+      peer: "bob@waddle.test/desktop",
+      sid: "c2",
+      media: { audio: true, video: false },
+      join,
+      kind: "dm",
+    });
+    disconnect();
+    expect(target.listenerCount()).toBe(0);
+    target.dispatchPagehide(false);
+    expect(persistResumeStateForPageHide).toHaveBeenCalledTimes(1);
+    expect($callState.get()).toMatchObject({ phase: "active", sid: "c2" });
+  });
+
   test("CallOverlay wires the browser pagehide event to suspension, not hangup", () => {
     const source = readFileSync(new URL("../src/components/calls/CallOverlay.vue", import.meta.url), "utf8");
     const unmountBlock = source.slice(source.indexOf("onBeforeUnmount(() => {"));
 
-    expect(source).toContain('window.addEventListener("pagehide", handlePageHide)');
-    expect(source).toContain("suspendCallForPageHide();");
+    expect(source).toContain("installCallPagehideSuspension(window)");
     expect(unmountBlock).toContain("void engine.disconnect();");
     expect(unmountBlock).not.toContain("tearDownActiveCall(");
   });

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -7,6 +7,7 @@ import { useChannelMessages } from "../src/channels/messages";
 import { BrowserXmppClient, roomBareJidFor, type InboxEntry, type LiveDmMessage, type RoomActivityEvent } from "../src/lib/xmpp-client";
 import { enqueueQueuedMessage, listQueuedDmMessages, listQueuedRoomMessages } from "../src/lib/outbound-queue-store";
 import { clearDmCallActivities, readDmCallActivity } from "../src/lib/calls/dm-call-activity";
+import type { ResumePersistence } from "../src/lib/xmpp/resume-persistence";
 import { handlerStubs } from "./helpers/xmpp-client-mock";
 
 function session(partial: Partial<WaddleSession> = {}): WaddleSession {
@@ -526,6 +527,51 @@ describe("client send readiness", () => {
       retainedJoinedRoomJids: Set<string>;
     }).xmpp = xmpp;
     (client as unknown as { retainedJoinedRoomJids: Set<string> }).retainedJoinedRoomJids = new Set([roomJid]);
+    (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+
+    (client as unknown as {
+      handleSessionReady: (xmpp: typeof xmpp, lifecycle: { type: "resumed" }) => void;
+    }).handleSessionReady(xmpp, { type: "resumed" });
+    await settleReconnectCatchup();
+
+    expect(xmpp.join_room).toHaveBeenCalledWith(roomJid, "alice");
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_jid: (client as unknown as { fullJid: string }).fullJid,
+    });
+    await settleReconnectCatchup();
+    expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(true);
+  });
+
+  test("session-ready rejoins retained rooms restored from refresh persistence", async () => {
+    const roomJid = "muted@muc.example.com";
+    const persistence: ResumePersistence = {
+      loadCatchup: () => null,
+      saveCatchup: () => undefined,
+      clearCatchup: () => undefined,
+      loadSm: () => null,
+      consumeSm: () => null,
+      saveSm: () => undefined,
+      clearSm: () => undefined,
+      preparePagehideHandoff: () => undefined,
+      loadJoinedRooms: () => [roomJid],
+      saveJoinedRooms: () => undefined,
+      clearJoinedRooms: () => undefined,
+    };
+    const client = new BrowserXmppClient(session(), persistence);
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type?: string;
+      muc_jid?: string;
+    }) => void) | null = null;
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    (client as unknown as { xmpp: typeof xmpp }).xmpp = xmpp;
     (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
 
     (client as unknown as {

--- a/chat/tests/dm-call-actions.test.ts
+++ b/chat/tests/dm-call-actions.test.ts
@@ -5,6 +5,7 @@ import {
 } from "../src/lib/calls/call-store";
 import {
   answerIncomingDmCallActivity,
+  resumeDmCallActivity,
   startDmCallAction,
 } from "../src/lib/calls/dm-call-actions";
 import {
@@ -14,6 +15,18 @@ import {
   readDmCallActivity,
 } from "../src/lib/calls/dm-call-activity";
 import type { CallWireSender } from "../src/lib/calls/outbound";
+
+function jwtWithExp(exp: number): string {
+  return [
+    base64Url(JSON.stringify({ alg: "none", typ: "JWT" })),
+    base64Url(JSON.stringify({ exp })),
+    "sig",
+  ].join(".");
+}
+
+function base64Url(value: string): string {
+  return btoa(value).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+}
 
 afterEach(() => {
   clearCallState();
@@ -187,5 +200,153 @@ describe("startDmCallAction", () => {
       media: { audio: true, video: false },
       accepting: true,
     });
+  });
+
+  test("resumes an accepted hydrated DM call when the LiveKit identity matches this resource", () => {
+    const join = {
+      url: "wss://livekit.waddle.test",
+      room: "dm-call-restored",
+      identity: "alice@waddle.test/web",
+      token: jwtWithExp(Date.parse("2026-05-26T13:00:00.000Z") / 1000),
+    };
+    applyDmCallEvent({
+      event: {
+        kind: "session-accept",
+        from: "bob@waddle.test/phone",
+        to: "alice@waddle.test/web",
+        sid: "hydrated-live",
+        media: { audio: true, video: true },
+        join,
+      },
+      selfBareJid: "alice@waddle.test",
+      timestamp: "2026-05-26T12:00:00.000Z",
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    });
+
+    expect(resumeDmCallActivity({
+      peerBareJid: "bob@waddle.test",
+      getSelfFullJid: () => "alice@waddle.test/web",
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    })).toBe(true);
+    expect($callState.get()).toEqual({
+      phase: "active",
+      kind: "dm",
+      peer: "bob@waddle.test/phone",
+      sid: "hydrated-live",
+      media: { audio: true, video: true },
+      join,
+      initiator: "alice@waddle.test/web",
+    });
+  });
+
+  test("does not resume another resource's archived LiveKit identity", () => {
+    applyDmCallEvent({
+      event: {
+        kind: "session-accept",
+        from: "bob@waddle.test/phone",
+        to: "alice@waddle.test/tablet",
+        sid: "other-resource-live",
+        media: { audio: true, video: false },
+        join: {
+          url: "wss://livekit.waddle.test",
+          room: "dm-call-other",
+          identity: "alice@waddle.test/tablet",
+          token: jwtWithExp(Date.parse("2026-05-26T13:00:00.000Z") / 1000),
+        },
+      },
+      selfBareJid: "alice@waddle.test",
+      timestamp: "2026-05-26T12:00:00.000Z",
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    });
+
+    expect(resumeDmCallActivity({
+      peerBareJid: "bob@waddle.test",
+      getSelfFullJid: () => "alice@waddle.test/web",
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    })).toBe(false);
+    expect($callState.get()).toEqual({ phase: "idle" });
+  });
+
+  test("does not resume archived LiveKit credentials before this resource is known", () => {
+    applyDmCallEvent({
+      event: {
+        kind: "session-accept",
+        from: "bob@waddle.test/phone",
+        to: "alice@waddle.test/web",
+        sid: "missing-local-resource",
+        media: { audio: true, video: false },
+        join: {
+          url: "wss://livekit.waddle.test",
+          room: "dm-call-local",
+          identity: "alice@waddle.test/web",
+          token: jwtWithExp(Date.parse("2026-05-26T13:00:00.000Z") / 1000),
+        },
+      },
+      selfBareJid: "alice@waddle.test",
+      timestamp: "2026-05-26T12:00:00.000Z",
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    });
+
+    expect(resumeDmCallActivity({
+      peerBareJid: "bob@waddle.test",
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    })).toBe(false);
+    expect($callState.get()).toEqual({ phase: "idle" });
+  });
+
+  test("does not resume archived LiveKit credentials after their token expires", () => {
+    applyDmCallEvent({
+      event: {
+        kind: "session-accept",
+        from: "bob@waddle.test/phone",
+        to: "alice@waddle.test/web",
+        sid: "expired-livekit-token",
+        media: { audio: true, video: true },
+        join: {
+          url: "wss://livekit.waddle.test",
+          room: "dm-call-expired",
+          identity: "alice@waddle.test/web",
+          token: jwtWithExp(Date.parse("2026-05-26T11:59:00.000Z") / 1000),
+        },
+      },
+      selfBareJid: "alice@waddle.test",
+      timestamp: "2026-05-26T12:00:00.000Z",
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    });
+
+    expect(resumeDmCallActivity({
+      peerBareJid: "bob@waddle.test",
+      getSelfFullJid: () => "alice@waddle.test/web",
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    })).toBe(false);
+    expect($callState.get()).toEqual({ phase: "idle" });
+  });
+
+  test("does not resume archived LiveKit credentials without the peer full JID", () => {
+    applyDmCallEvent({
+      event: {
+        kind: "session-accept",
+        from: "bob@waddle.test",
+        to: "alice@waddle.test/web",
+        sid: "missing-peer-resource",
+        media: { audio: true, video: false },
+        join: {
+          url: "wss://livekit.waddle.test",
+          room: "dm-call-no-peer-resource",
+          identity: "alice@waddle.test/web",
+          token: jwtWithExp(Date.parse("2026-05-26T13:00:00.000Z") / 1000),
+        },
+      },
+      selfBareJid: "alice@waddle.test",
+      timestamp: "2026-05-26T12:00:00.000Z",
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    });
+
+    expect(resumeDmCallActivity({
+      peerBareJid: "bob@waddle.test",
+      getSelfFullJid: () => "alice@waddle.test/web",
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    })).toBe(false);
+    expect($callState.get()).toEqual({ phase: "idle" });
   });
 });

--- a/chat/tests/dm-call-activity-hydration.test.ts
+++ b/chat/tests/dm-call-activity-hydration.test.ts
@@ -5,6 +5,7 @@ import {
   readDmCallActivity,
 } from "../src/lib/calls/dm-call-activity";
 import type { WaddleSession } from "../src/lib/server-auth";
+import type { ResumePersistence } from "../src/lib/xmpp/resume-persistence";
 
 function session(): WaddleSession {
   return {
@@ -22,6 +23,131 @@ describe("DM call activity hydration", () => {
 
   afterEach(() => {
     clearDmCallActivities();
+  });
+
+  test("reuses and consumes the persisted SM resource so same-resource joins remain valid after reload", () => {
+    let sm: ReturnType<ResumePersistence["loadSm"]> = {
+      previd: "prev",
+      inboundH: 1,
+      outboundH: 2,
+      resource: "web-existing-resource",
+    };
+    const consumedStates: NonNullable<typeof sm>[] = [];
+    const persistence: ResumePersistence = {
+      loadCatchup: () => null,
+      saveCatchup: () => undefined,
+      clearCatchup: () => undefined,
+      loadSm: () => sm,
+      consumeSm: () => {
+        const current = sm;
+        sm = null;
+        if (current) consumedStates.push(current);
+        return current;
+      },
+      saveSm: () => undefined,
+      clearSm: () => {
+        sm = null;
+      },
+      preparePagehideHandoff: () => undefined,
+      loadJoinedRooms: () => [],
+      saveJoinedRooms: () => undefined,
+      clearJoinedRooms: () => undefined,
+    };
+
+    const client = new BrowserXmppClient(session(), persistence);
+    const secondClient = new BrowserXmppClient(session(), persistence);
+
+    expect(client.fullJid).toBe("alice@example.com/web-existing-resource");
+    expect(consumedStates).toHaveLength(1);
+    expect(secondClient.fullJid).not.toBe("alice@example.com/web-existing-resource");
+  });
+
+  test("does not publish transient reconnect resources into shared SM persistence", () => {
+    let sm: ReturnType<ResumePersistence["loadSm"]> = null;
+    const savedStates: NonNullable<typeof sm>[] = [];
+    const persistence: ResumePersistence = {
+      loadCatchup: () => null,
+      saveCatchup: () => undefined,
+      clearCatchup: () => undefined,
+      loadSm: () => sm,
+      consumeSm: () => {
+        const current = sm;
+        sm = null;
+        return current;
+      },
+      saveSm: (state) => {
+        savedStates.push(state);
+        sm = state;
+      },
+      clearSm: () => {
+        sm = null;
+      },
+      preparePagehideHandoff: () => undefined,
+      loadJoinedRooms: () => [],
+      saveJoinedRooms: () => undefined,
+      clearJoinedRooms: () => undefined,
+    };
+    const client = new BrowserXmppClient(session(), persistence);
+    const resource = client.fullJid.split("/")[1];
+    const xmpp = {
+      get_resume_state_handle: () => ({ free: () => undefined }),
+      get_resume_state: () => ({ previd: "prev", inboundH: 1, outboundH: 2 }),
+    };
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).connected = true;
+
+    (client as unknown as { handleDisconnected: (xmpp: typeof xmpp) => void }).handleDisconnected(xmpp);
+    (client as unknown as { clearReconnectTimer: () => void }).clearReconnectTimer();
+
+    const secondClient = new BrowserXmppClient(session(), persistence);
+
+    expect(savedStates).toEqual([]);
+    expect(secondClient.fullJid).not.toBe(`alice@example.com/${resource}`);
+  });
+
+  test("pagehide persists real SM state with resource, including reconnect fallback state", () => {
+    let sm: ReturnType<ResumePersistence["loadSm"]> = null;
+    const savedStates: NonNullable<typeof sm>[] = [];
+    const persistence: ResumePersistence = {
+      loadCatchup: () => null,
+      saveCatchup: () => undefined,
+      clearCatchup: () => undefined,
+      loadSm: () => sm,
+      consumeSm: () => {
+        const current = sm;
+        sm = null;
+        return current;
+      },
+      saveSm: (state) => {
+        savedStates.push(state);
+        sm = state;
+      },
+      clearSm: () => {
+        sm = null;
+      },
+      preparePagehideHandoff: () => undefined,
+      loadJoinedRooms: () => [],
+      saveJoinedRooms: () => undefined,
+      clearJoinedRooms: () => undefined,
+    };
+    const client = new BrowserXmppClient(session(), persistence);
+    const resource = client.fullJid.split("/")[1];
+    const xmpp = {
+      get_resume_state_handle: () => ({ free: () => undefined }),
+      get_resume_state: () => ({ previd: "prev-live", inboundH: 7, outboundH: 9 }),
+    };
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).connected = true;
+
+    client.persistResumeStateForPageHide();
+    (client as unknown as { handleDisconnected: (xmpp: typeof xmpp) => void }).handleDisconnected(xmpp);
+    (client as unknown as { clearReconnectTimer: () => void }).clearReconnectTimer();
+    client.persistResumeStateForPageHide();
+
+    expect(savedStates).toEqual([
+      { previd: "prev-live", inboundH: 7, outboundH: 9, resource },
+      { previd: "prev-live", inboundH: 7, outboundH: 9, resource },
+    ]);
   });
 
   test("hydrates active call state from personal MAM pages without loading the DM timeline", async () => {

--- a/chat/tests/dm-call-activity.test.ts
+++ b/chat/tests/dm-call-activity.test.ts
@@ -1,27 +1,76 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import {
   $dmCallActivities,
   DM_CALL_ACTIVITY_ACTIVE_WINDOW_MS,
   applyDmCallEvent,
   clearDmCallActivities,
   clearDmCallActivity,
+  dmCallResumeBlockReason,
   pruneExpiredDmCallActivities,
   readDmCallActivity,
 } from "../src/lib/calls/dm-call-activity";
+import { clearAllDmCallJoinCacheForTests } from "../src/lib/calls/dm-call-join-cache";
 import type { CallEvent } from "../src/lib/calls/types";
 
 const self = "alice@waddle.test";
 const bob = "bob@waddle.test";
 const audio = { audio: true, video: false };
 const now = new Date("2026-05-25T10:00:00.000Z");
+const WINDOW_SENTINEL = Symbol("dm-call-activity-window");
+type ShimmedGlobal = typeof globalThis & {
+  window?: { localStorage: Storage } & { [WINDOW_SENTINEL]?: true };
+};
+
+beforeAll(() => {
+  const g = globalThis as ShimmedGlobal;
+  if (typeof g.window !== "undefined") return;
+  const store = new Map<string, string>();
+  const storage: Storage = {
+    get length() { return store.size; },
+    clear: () => store.clear(),
+    getItem: (key) => store.get(key) ?? null,
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key) => { store.delete(key); },
+    setItem: (key, value) => { store.set(key, String(value)); },
+  };
+  g.window = Object.assign({ localStorage: storage }, { [WINDOW_SENTINEL]: true as const });
+});
+
+afterAll(() => {
+  const g = globalThis as ShimmedGlobal;
+  if (g.window?.[WINDOW_SENTINEL]) {
+    delete (g as { window?: unknown }).window;
+  }
+});
+
+function jwtWithExp(exp: number): string {
+  return jwtWithPayload({ exp });
+}
+
+function jwtWithPayload(payload: Record<string, unknown>): string {
+  return [
+    base64UrlJson({ alg: "none", typ: "JWT" }),
+    base64UrlJson(payload),
+    "sig",
+  ].join(".");
+}
+
+function base64UrlJson(value: Record<string, unknown>): string {
+  const bytes = new TextEncoder().encode(JSON.stringify(value));
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+}
 
 describe("DM call activity", () => {
   beforeEach(() => {
     clearDmCallActivities();
+    clearAllDmCallJoinCacheForTests();
   });
 
   afterEach(() => {
     clearDmCallActivities();
+    clearAllDmCallJoinCacheForTests();
   });
 
   test("tracks an unresolved remote proposal as ringing activity", () => {
@@ -225,6 +274,340 @@ describe("DM call activity", () => {
     });
   });
 
+  test("stores LiveKit join credentials from archived accepted call events", () => {
+    const join = {
+      url: "wss://livekit.waddle.test",
+      room: "dm-call-joined",
+      identity: `${self}/web`,
+      token: "token",
+    };
+
+    applyDmCallEvent({
+      event: {
+        kind: "session-accept",
+        from: `${bob}/phone`,
+        to: `${self}/web`,
+        sid: "call-with-join",
+        media: { audio: true, video: true },
+        join,
+      },
+      selfBareJid: self,
+      timestamp: now.toISOString(),
+      now,
+    });
+
+    expect(readDmCallActivity(bob, now)).toMatchObject({
+      peerJid: bob,
+      remoteFullJid: `${bob}/phone`,
+      sid: "call-with-join",
+      media: { audio: true, video: true },
+      state: "accepted",
+      join,
+    });
+  });
+
+  test("does not carry archived LiveKit join credentials across a newer sid", () => {
+    const join = {
+      url: "wss://livekit.waddle.test",
+      room: "dm-call-old",
+      identity: `${self}/web`,
+      token: "token",
+    };
+
+    applyDmCallEvent({
+      event: {
+        kind: "session-accept",
+        from: `${bob}/phone`,
+        to: `${self}/web`,
+        sid: "old-sid",
+        media: { audio: true, video: true },
+        join,
+      },
+      selfBareJid: self,
+      timestamp: "2026-05-25T10:00:00.000Z",
+      now,
+    });
+    applyDmCallEvent({
+      event: {
+        kind: "proceed",
+        from: `${bob}/phone`,
+        sid: "new-sid",
+      },
+      selfBareJid: self,
+      to: `${self}/web`,
+      timestamp: "2026-05-25T10:01:00.000Z",
+      now,
+    });
+
+    expect(readDmCallActivity(bob, now)).toMatchObject({
+      sid: "new-sid",
+      state: "accepted",
+      mediaKnown: false,
+    });
+    expect(readDmCallActivity(bob, now)?.join).toBeUndefined();
+  });
+
+  test("does not carry archived LiveKit join credentials into a newer proposal", () => {
+    const join = {
+      url: "wss://livekit.waddle.test",
+      room: "dm-call-old",
+      identity: `${self}/web`,
+      token: "token",
+    };
+
+    applyDmCallEvent({
+      event: {
+        kind: "session-accept",
+        from: `${bob}/phone`,
+        to: `${self}/web`,
+        sid: "old-sid",
+        media: { audio: true, video: true },
+        join,
+      },
+      selfBareJid: self,
+      selfFullJid: `${self}/web`,
+      timestamp: "2026-05-25T10:00:00.000Z",
+      now,
+    });
+    applyDmCallEvent({
+      event: {
+        kind: "propose",
+        from: `${bob}/tablet`,
+        sid: "new-sid",
+        media: audio,
+      },
+      selfBareJid: self,
+      selfFullJid: `${self}/web`,
+      to: `${self}/web`,
+      timestamp: "2026-05-25T10:01:00.000Z",
+      now,
+    });
+
+    expect(readDmCallActivity(bob, now)).toMatchObject({
+      sid: "new-sid",
+      state: "ringing",
+      media: audio,
+    });
+    expect(readDmCallActivity(bob, now)?.join).toBeUndefined();
+  });
+
+  test("restores same-resource cached LiveKit joins when refresh MAM replays only message markers", () => {
+    const join = {
+      url: "wss://livekit.waddle.test",
+      room: "dm-call-cached",
+      identity: `${self}/web`,
+      token: jwtWithExp(Math.floor(now.getTime() / 1000) + 3600),
+    };
+
+    applyDmCallEvent({
+      event: {
+        kind: "session-accept",
+        from: `${bob}/phone`,
+        to: `${self}/web`,
+        sid: "cached-sid",
+        media: { audio: true, video: true },
+        join,
+      },
+      selfBareJid: self,
+      selfFullJid: `${self}/web`,
+      timestamp: "2026-05-25T10:00:00.000Z",
+      now,
+    });
+    clearDmCallActivities();
+
+    applyDmCallEvent({
+      event: {
+        kind: "propose",
+        from: `${self}/web`,
+        to: `${bob}/phone`,
+        sid: "cached-sid",
+        media: { audio: true, video: true },
+      },
+      selfBareJid: self,
+      selfFullJid: `${self}/web`,
+      timestamp: "2026-05-25T10:00:01.000Z",
+      now,
+    });
+    applyDmCallEvent({
+      event: {
+        kind: "proceed",
+        from: `${bob}/phone`,
+        to: `${self}/web`,
+        sid: "cached-sid",
+      },
+      selfBareJid: self,
+      selfFullJid: `${self}/web`,
+      timestamp: "2026-05-25T10:00:02.000Z",
+      now,
+    });
+
+    expect(readDmCallActivity(bob, now)).toMatchObject({
+      sid: "cached-sid",
+      state: "accepted",
+      remoteFullJid: `${bob}/phone`,
+      media: { audio: true, video: true },
+      join,
+    });
+  });
+
+  test("parses LiveKit token expiry from UTF-8 JWT payloads", () => {
+    const join = {
+      url: "wss://livekit.waddle.test",
+      room: "dm-call-unicode-token",
+      identity: `${self}/web`,
+      token: jwtWithPayload({
+        exp: Math.floor(now.getTime() / 1000) + 3600,
+        display: "Álice 😀",
+      }),
+    };
+
+    applyDmCallEvent({
+      event: {
+        kind: "session-accept",
+        from: `${bob}/phone`,
+        to: `${self}/web`,
+        sid: "unicode-token",
+        media: audio,
+        join,
+      },
+      selfBareJid: self,
+      selfFullJid: `${self}/web`,
+      timestamp: now.toISOString(),
+      now,
+    });
+
+    const activity = readDmCallActivity(bob, now);
+    expect(activity).not.toBeNull();
+    expect(dmCallResumeBlockReason(activity!, `${self}/web`, now)).toBeNull();
+  });
+
+  test("does not restore cached LiveKit joins for another browser resource", () => {
+    const join = {
+      url: "wss://livekit.waddle.test",
+      room: "dm-call-cached",
+      identity: `${self}/web`,
+      token: jwtWithExp(Math.floor(now.getTime() / 1000) + 3600),
+    };
+
+    applyDmCallEvent({
+      event: {
+        kind: "session-accept",
+        from: `${bob}/phone`,
+        to: `${self}/web`,
+        sid: "cached-sid",
+        media: audio,
+        join,
+      },
+      selfBareJid: self,
+      selfFullJid: `${self}/web`,
+      timestamp: "2026-05-25T10:00:00.000Z",
+      now,
+    });
+    clearDmCallActivities();
+
+    applyDmCallEvent({
+      event: {
+        kind: "propose",
+        from: `${self}/tablet`,
+        to: `${bob}/phone`,
+        sid: "cached-sid",
+        media: audio,
+      },
+      selfBareJid: self,
+      selfFullJid: `${self}/tablet`,
+      timestamp: "2026-05-25T10:00:01.000Z",
+      now,
+    });
+    applyDmCallEvent({
+      event: {
+        kind: "proceed",
+        from: `${bob}/phone`,
+        to: `${self}/tablet`,
+        sid: "cached-sid",
+      },
+      selfBareJid: self,
+      selfFullJid: `${self}/tablet`,
+      timestamp: "2026-05-25T10:00:02.000Z",
+      now,
+    });
+
+    expect(readDmCallActivity(bob, now)).toMatchObject({
+      sid: "cached-sid",
+      state: "accepted",
+    });
+    expect(readDmCallActivity(bob, now)?.join).toBeUndefined();
+  });
+
+  test("terminal call events clear cached LiveKit joins before a same-sid replay", () => {
+    const join = {
+      url: "wss://livekit.waddle.test",
+      room: "dm-call-cached",
+      identity: `${self}/web`,
+      token: jwtWithExp(Math.floor(now.getTime() / 1000) + 3600),
+    };
+
+    applyDmCallEvent({
+      event: {
+        kind: "session-accept",
+        from: `${bob}/phone`,
+        to: `${self}/web`,
+        sid: "cached-terminal-sid",
+        media: { audio: true, video: true },
+        join,
+      },
+      selfBareJid: self,
+      selfFullJid: `${self}/web`,
+      timestamp: "2026-05-25T10:00:00.000Z",
+      now,
+    });
+    applyDmCallEvent({
+      event: {
+        kind: "finish",
+        from: `${bob}/phone`,
+        to: `${self}/web`,
+        sid: "cached-terminal-sid",
+        reason: "success",
+      },
+      selfBareJid: self,
+      selfFullJid: `${self}/web`,
+      timestamp: "2026-05-25T10:01:00.000Z",
+      now,
+    });
+    clearDmCallActivities();
+
+    applyDmCallEvent({
+      event: {
+        kind: "propose",
+        from: `${self}/web`,
+        to: `${bob}/phone`,
+        sid: "cached-terminal-sid",
+        media: { audio: true, video: true },
+      },
+      selfBareJid: self,
+      selfFullJid: `${self}/web`,
+      timestamp: "2026-05-25T10:02:00.000Z",
+      now,
+    });
+    applyDmCallEvent({
+      event: {
+        kind: "proceed",
+        from: `${bob}/phone`,
+        to: `${self}/web`,
+        sid: "cached-terminal-sid",
+      },
+      selfBareJid: self,
+      selfFullJid: `${self}/web`,
+      timestamp: "2026-05-25T10:02:01.000Z",
+      now,
+    });
+
+    expect(readDmCallActivity(bob, now)).toMatchObject({
+      sid: "cached-terminal-sid",
+      state: "accepted",
+    });
+    expect(readDmCallActivity(bob, now)?.join).toBeUndefined();
+  });
+
   test("terminal MAM events prevent older proposals for the same sid from resurrecting activity", () => {
     applyDmCallEvent({
       event: {
@@ -383,6 +766,66 @@ describe("DM call activity", () => {
       scheduledPrune?.();
 
       expect($dmCallActivities.get()).toEqual({});
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+      globalThis.clearTimeout = originalClearTimeout;
+    }
+  });
+
+  test("scheduled expiry timer refreshes accepted call affordances", async () => {
+    const originalSetTimeout = globalThis.setTimeout;
+    const originalClearTimeout = globalThis.clearTimeout;
+    const timer = { unref: () => undefined } as unknown as ReturnType<typeof setTimeout>;
+    let scheduledRefresh: (() => void) | null = null;
+    let scheduledDelay: number | undefined;
+
+    globalThis.setTimeout = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
+      scheduledDelay = Number(timeout ?? 0);
+      scheduledRefresh = () => {
+        if (typeof handler === "function") {
+          handler(...args);
+        }
+      };
+      return timer;
+    }) as typeof setTimeout;
+    globalThis.clearTimeout = (() => {
+      scheduledRefresh = null;
+    }) as typeof clearTimeout;
+
+    try {
+      const timerArmedAt = new Date();
+      const join = {
+        url: "wss://livekit.waddle.test",
+        room: "dm-call-expiring",
+        identity: `${self}/web`,
+        token: jwtWithExp(Math.floor((timerArmedAt.getTime() + 60_000) / 1000)),
+      };
+      applyDmCallEvent({
+        event: {
+          kind: "session-accept",
+          from: `${bob}/phone`,
+          to: `${self}/web`,
+          sid: "expiring-call",
+          media: audio,
+          join,
+        },
+        selfBareJid: self,
+        selfFullJid: `${self}/web`,
+        timestamp: timerArmedAt.toISOString(),
+        now: timerArmedAt,
+      });
+
+      const before = $dmCallActivities.get();
+      expect(scheduledDelay).toBeGreaterThanOrEqual(30_000);
+      expect(scheduledDelay).toBeLessThanOrEqual(31_000);
+      expect(scheduledRefresh).not.toBeNull();
+      scheduledRefresh?.();
+
+      expect($dmCallActivities.get()).not.toBe(before);
+      expect($dmCallActivities.get()[bob]).toMatchObject({
+        sid: "expiring-call",
+        join,
+      });
     } finally {
       globalThis.setTimeout = originalSetTimeout;
       globalThis.clearTimeout = originalClearTimeout;

--- a/chat/tests/helpers/conversation-call-banner-stub.ts
+++ b/chat/tests/helpers/conversation-call-banner-stub.ts
@@ -1,0 +1,33 @@
+import { h } from "vue";
+
+type BannerProbe = (
+  props: Record<string, unknown>,
+  emit: (event: string, ...args: unknown[]) => void,
+) => void;
+
+export default {
+  name: "ConversationCallBannerTestStub",
+  setup(
+    props: Record<string, unknown>,
+    {
+      attrs,
+      emit,
+    }: {
+      attrs: Record<string, unknown>;
+      emit: (event: string, ...args: unknown[]) => void;
+    },
+  ) {
+    const allProps = { ...attrs, ...props };
+    (globalThis as { __waddleConversationCallBannerProbe?: BannerProbe })
+      .__waddleConversationCallBannerProbe?.({
+        ...allProps,
+        roomJid: allProps.roomJid ?? allProps["room-jid"],
+        channelId: allProps.channelId ?? allProps["channel-id"],
+        channelName: allProps.channelName ?? allProps["channel-name"],
+        dmPeerJid: allProps.dmPeerJid ?? allProps["dm-peer-jid"],
+        dmPeerName: allProps.dmPeerName ?? allProps["dm-peer-name"],
+        selfFullJid: allProps.selfFullJid ?? allProps["self-full-jid"],
+      }, emit);
+    return () => h("span", { "data-conversation-call-banner-stub": "true" });
+  },
+};

--- a/chat/tests/home-activity.test.ts
+++ b/chat/tests/home-activity.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -22,6 +22,7 @@ import {
   summarizeHomeActivity,
 } from "../src/home/activity";
 import { buildHomeChannelUnreadMap, buildHomeDashboardProps } from "../src/home/dashboard-props";
+import { $callState, clearCallState } from "../src/lib/calls/call-store";
 import type { ChannelSummary } from "../src/lib/chat-types";
 
 const channels: ChannelSummary[] = [
@@ -29,6 +30,22 @@ const channels: ChannelSummary[] = [
   { id: "planning", name: "Planning", jid: "planning@conference.example.com", spaceId: "team" },
   { id: "quiet", name: "Quiet", jid: "quiet@conference.example.com", spaceId: "team" },
 ];
+
+afterEach(() => {
+  clearCallState();
+});
+
+function liveKitToken(exp = 4_102_444_800): string {
+  return [
+    base64Url(JSON.stringify({ alg: "none", typ: "JWT" })),
+    base64Url(JSON.stringify({ exp })),
+    "sig",
+  ].join(".");
+}
+
+function base64Url(value: string): string {
+  return btoa(value).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+}
 
 describe("home activity summaries", () => {
   test("summarizes unread, mentions, and live room activity for spaces", () => {
@@ -329,6 +346,7 @@ describe("HomeDashboard activity rendering", () => {
   });
 
   test("renders refresh-discovered active calls on the home dashboard", async () => {
+    const updated = formatTimelineStamp("2026-05-26T00:00:00.000Z");
     const html = await renderHomeDashboard({
       spaces: [{ id: "team", name: "Team" }],
       channels: [
@@ -342,6 +360,9 @@ describe("HomeDashboard activity rendering", () => {
       callParticipantCounts: {
         "general@conference.example.com": 2,
       },
+      callParticipants: {
+        "general@conference.example.com": ["alice", "bob"],
+      },
       dmConversations: [
         {
           peerJid: "bob@example.com",
@@ -353,23 +374,206 @@ describe("HomeDashboard activity rendering", () => {
       dmCallActivities: {
         "bob@example.com": {
           peerJid: "bob@example.com",
+          remoteFullJid: "bob@example.com/phone",
           sid: "dm-call-1",
           media: { audio: true, video: true },
+          join: {
+            url: "wss://livekit.example.test",
+            room: "dm-call-1",
+            identity: "alice@example.com/web",
+            token: liveKitToken(),
+          },
           state: "accepted",
           direction: "incoming",
           updatedAt: "2026-05-26T00:00:00.000Z",
         },
       },
+      selfFullJid: "alice@example.com/web",
     });
 
     expect(html).toContain("Active calls");
     expect(html).toContain("<strong>2</strong> active calls");
-    expect(html).toContain('aria-label="Join General, Group call, 2 people"');
-    expect(html).toContain('aria-label="Reconnect Bob, Video call, Live"');
-    expect(buttonForLabel(html, "Join General, Group call, 2 people")).toContain("Join");
+    expect(html).toContain("2 live conversations");
+    expect(html).toContain("Live now");
+    expect(html).toContain("2 people connected in this channel: alice, bob.");
+    expect(html).toContain("alice, bob");
+    expect(html).toContain("The video call is still live.");
+    expect(html).toContain('aria-label="Join General, Group call, 2 people, Live now, 2 people connected in this channel: alice, bob., Group call"');
+    expect(html).toContain(`aria-label="Reconnect Bob, Video call, Live, Live now, The video call is still live., Live video call · Updated ${updated}"`);
+    expect(buttonForLabel(html, "Join General, Group call, 2 people, Live now, 2 people connected in this channel: alice, bob., Group call")).toContain("Join");
     expect(buttonForLabel(html, "General, channel, no unread activity, active call with 2 people")).toContain("Active call");
-    expect(buttonForLabel(html, "Reconnect Bob, Video call, Live")).toContain("Live");
+    expect(buttonForLabel(html, `Reconnect Bob, Video call, Live, Live now, The video call is still live., Live video call · Updated ${updated}`)).toContain("Live");
     expect(html).not.toContain("Bob (bob@example.com), direct message, available, no unread activity, Video call live");
+  });
+
+  test("labels non-resumable active direct calls on the home dashboard", async () => {
+    const updated = formatTimelineStamp("2026-05-26T00:00:00.000Z");
+    const html = await renderHomeDashboard({
+      spaces: [],
+      channels: [],
+      contacts: [],
+      isLoading: false,
+      channelUnreadMap: {},
+      activeChannelJids: new Set<string>(),
+      managedMucDomain: "conference.example.com",
+      callParticipantCounts: {},
+      dmConversations: [
+        {
+          peerJid: "bob@example.com",
+          peerUsername: "Bob",
+          unreadCount: 0,
+          presenceShow: "available",
+        },
+      ],
+      dmCallActivities: {
+        "bob@example.com": {
+          peerJid: "bob@example.com",
+          remoteFullJid: "bob@example.com/phone",
+          sid: "dm-call-other-device",
+          media: { audio: true, video: false },
+          join: {
+            url: "wss://livekit.example.test",
+            room: "dm-call-other-device",
+            identity: "alice@example.com/phone",
+            token: liveKitToken(),
+          },
+          state: "accepted",
+          direction: "incoming",
+          updatedAt: "2026-05-26T00:00:00.000Z",
+        },
+      },
+      selfFullJid: "alice@example.com/web",
+    });
+
+    expect(html).toContain("Other device");
+    expect(html).toContain("This call is live on another browser or device.");
+    expect(html).toContain("Voice call · Other device");
+    expect(html).toContain(`aria-label="Open Bob, Voice call, Live, Other device, This call is live on another browser or device., Voice call · Other device · Updated ${updated}"`);
+    expect(html).not.toContain("Reconnect Bob");
+  });
+
+  test("labels expired active direct calls on the home dashboard", async () => {
+    const updated = formatTimelineStamp("2026-05-26T00:00:00.000Z");
+    const html = await renderHomeDashboard({
+      spaces: [],
+      channels: [],
+      contacts: [],
+      isLoading: false,
+      channelUnreadMap: {},
+      activeChannelJids: new Set<string>(),
+      managedMucDomain: "conference.example.com",
+      callParticipantCounts: {},
+      dmConversations: [
+        {
+          peerJid: "bob@example.com",
+          peerUsername: "Bob",
+          unreadCount: 0,
+          presenceShow: "available",
+        },
+      ],
+      dmCallActivities: {
+        "bob@example.com": {
+          peerJid: "bob@example.com",
+          remoteFullJid: "bob@example.com/phone",
+          sid: "dm-call-expired",
+          media: { audio: true, video: true },
+          join: {
+            url: "wss://livekit.example.test",
+            room: "dm-call-expired",
+            identity: "alice@example.com/web",
+            token: liveKitToken(Math.floor(Date.now() / 1000) + 10),
+          },
+          state: "accepted",
+          direction: "incoming",
+          updatedAt: "2026-05-26T00:00:00.000Z",
+        },
+      },
+      selfFullJid: "alice@example.com/web",
+    });
+
+    expect(html).toContain("Expired");
+    expect(html).toContain("The saved reconnect details expired.");
+    expect(html).toContain("Video call · Expired");
+    expect(html).toContain(`aria-label="Open Bob, Video call, Live, Expired, The saved reconnect details expired., Video call · Expired · Updated ${updated}"`);
+    expect(html).not.toContain("Reconnect Bob");
+  });
+
+  test("counts the local current call before discovery echoes activity on the home dashboard", async () => {
+    $callState.set({
+      phase: "active",
+      kind: "dm",
+      peer: "bob@example.com/phone",
+      sid: "dm-current",
+      media: { audio: true, video: true },
+      join: {
+        url: "wss://livekit.example.test",
+        room: "dm-current",
+        identity: "alice@example.com/web",
+        token: liveKitToken(),
+      },
+    });
+
+    const html = await renderHomeDashboard({
+      spaces: [],
+      channels: [],
+      contacts: [],
+      isLoading: false,
+      channelUnreadMap: {},
+      activeChannelJids: new Set<string>(),
+      managedMucDomain: "conference.example.com",
+      callParticipantCounts: {},
+      dmConversations: [
+        {
+          peerJid: "bob@example.com",
+          peerUsername: "Bob",
+          unreadCount: 0,
+          presenceShow: "available",
+        },
+      ],
+      dmCallActivities: {},
+      selfFullJid: "alice@example.com/web",
+    });
+
+    expect(html).toContain("<strong>1</strong> active call");
+    expect(html).toContain("1 live conversation");
+    expect(html).toContain("Bob");
+    expect(html).toContain("The video call is still live.");
+    expect(html).toContain("Return");
+    expect(html).not.toContain("Bob (bob@example.com), direct message");
+    expect(html).not.toContain("No active calls.");
+  });
+
+  test("counts and renders the local current group call before Muji discovery echoes activity", async () => {
+    $callState.set({
+      phase: "muc-pending",
+      kind: "muc",
+      peer: "general@conference.example.com",
+      sid: "muc-current",
+      media: { audio: true, video: false },
+      selfNick: "alice",
+      attemptId: "attempt-1",
+    });
+
+    const html = await renderHomeDashboard({
+      spaces: [{ id: "team", name: "Team" }],
+      channels: [
+        { id: "general", name: "General", jid: "general@conference.example.com", spaceId: "team" },
+      ],
+      contacts: [],
+      isLoading: false,
+      channelUnreadMap: {},
+      activeChannelJids: new Set<string>(),
+      managedMucDomain: "conference.example.com",
+      callParticipantCounts: {},
+      dmConversations: [],
+    });
+
+    expect(html).toContain("<strong>1</strong> active call");
+    expect(html).toContain("1 live conversation");
+    expect(html).toContain("General");
+    expect(html).toContain("1 person connected in this channel: alice.");
+    expect(html).toContain('aria-label="Return General, Group call, 1 person, Live now, 1 person connected in this channel: alice., Group call"');
+    expect(html).not.toContain("No active calls.");
   });
 
   test("pluralizes single thread reply badges", async () => {
@@ -418,6 +622,7 @@ describe("HomeDashboard activity rendering", () => {
         lastMessageBody: "Can you review the plan?",
       }],
       callParticipantCounts: { "general@conference.example.com": 2 },
+      callParticipants: { "general@conference.example.com": ["alice", "bob"] },
       dmCallActivities: {
         "bob@example.com": {
           peerJid: "bob@example.com",
@@ -429,6 +634,7 @@ describe("HomeDashboard activity rendering", () => {
         },
       },
       managedMucDomain: "conference.example.com",
+      selfFullJid: "alice@example.com/web",
     });
 
     expect(props.channelUnreadMap?.general).toEqual({
@@ -441,8 +647,10 @@ describe("HomeDashboard activity rendering", () => {
     expect(props.activeChannelJids?.has("general@conference.example.com")).toBe(true);
     expect(props.dmConversations?.[0]?.unreadCount).toBe(2);
     expect(props.callParticipantCounts).toEqual({ "general@conference.example.com": 2 });
+    expect(props.callParticipants).toEqual({ "general@conference.example.com": ["alice", "bob"] });
     expect(props.dmCallActivities?.["bob@example.com"]?.state).toBe("accepted");
     expect(props.managedMucDomain).toBe("conference.example.com");
+    expect(props.selfFullJid).toBe("alice@example.com/web");
   });
 });
 

--- a/chat/tests/resume-persistence.test.ts
+++ b/chat/tests/resume-persistence.test.ts
@@ -12,10 +12,13 @@
  */
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import { ReconnectCatchup } from "../src/lib/xmpp/reconnect-catchup";
+import { BrowserXmppClient } from "../src/lib/xmpp/client";
+import type { WaddleSession } from "../src/lib/server-auth";
 import {
   createLocalStorageResumePersistence,
   nullResumePersistence,
   type PersistedReconnectCatchup,
+  type PersistedSmResumeState,
   type ResumePersistence,
 } from "../src/lib/xmpp/resume-persistence";
 
@@ -33,12 +36,13 @@ import {
 // and corrupt state across runs.
 const WINDOW_SENTINEL = Symbol("test-installed-window");
 type ShimmedGlobal = typeof globalThis & {
-  window?: { localStorage: Storage } & { [WINDOW_SENTINEL]?: true };
+  window?: { localStorage: Storage; sessionStorage: Storage } & { [WINDOW_SENTINEL]?: true };
 };
 beforeAll(() => {
   const g = globalThis as ShimmedGlobal;
   if (typeof g.window !== "undefined") return;
   const store = new Map<string, string>();
+  const sessionStore = new Map<string, string>();
   const storage: Storage = {
     get length() { return store.size; },
     clear: () => store.clear(),
@@ -47,7 +51,15 @@ beforeAll(() => {
     removeItem: (key) => { store.delete(key); },
     setItem: (key, value) => { store.set(key, String(value)); },
   };
-  g.window = Object.assign({ localStorage: storage }, { [WINDOW_SENTINEL]: true as const });
+  const sessionStorage: Storage = {
+    get length() { return sessionStore.size; },
+    clear: () => sessionStore.clear(),
+    getItem: (key) => sessionStore.get(key) ?? null,
+    key: (index) => Array.from(sessionStore.keys())[index] ?? null,
+    removeItem: (key) => { sessionStore.delete(key); },
+    setItem: (key, value) => { sessionStore.set(key, String(value)); },
+  };
+  g.window = Object.assign({ localStorage: storage, sessionStorage }, { [WINDOW_SENTINEL]: true as const });
 });
 
 afterAll(() => {
@@ -59,24 +71,36 @@ afterAll(() => {
 
 afterEach(() => {
   const g = globalThis as ShimmedGlobal;
-  if (g.window?.[WINDOW_SENTINEL]) g.window.localStorage.clear();
+  if (g.window?.[WINDOW_SENTINEL]) {
+    g.window.localStorage.clear();
+    g.window.sessionStorage.clear();
+  }
 });
 
 /** In-memory persistence for tests — same shape as the real adapter
  * but without touching localStorage. */
 function inMemoryPersistence(): ResumePersistence & {
   catchupSnapshot: () => PersistedReconnectCatchup | null;
-  smSnapshot: () => { previd: string; inboundH: number; outboundH: number } | null;
+  smSnapshot: () => PersistedSmResumeState | null;
 } {
   let catchup: PersistedReconnectCatchup | null = null;
-  let sm: { previd: string; inboundH: number; outboundH: number } | null = null;
+  let sm: PersistedSmResumeState | null = null;
   return {
     loadCatchup: () => catchup,
     saveCatchup: (snapshot) => { catchup = snapshot; },
     clearCatchup: () => { catchup = null; },
-    loadSm: () => sm,
+  loadSm: () => sm,
+    consumeSm: () => {
+      const current = sm;
+      sm = null;
+      return current;
+    },
     saveSm: (state) => { sm = state; },
     clearSm: () => { sm = null; },
+    preparePagehideHandoff: () => undefined,
+    loadJoinedRooms: () => [],
+    saveJoinedRooms: () => undefined,
+    clearJoinedRooms: () => undefined,
     catchupSnapshot: () => catchup,
     smSnapshot: () => sm,
   };
@@ -213,6 +237,180 @@ describe("createLocalStorageResumePersistence — localStorage adapter", () => {
     // Round-trip strips the internal `savedAt` so the caller gets
     // the same shape it passed in.
     expect(persistence.loadSm()).toEqual(state);
+  });
+
+  test("round-trips the bound resource with SM resume state", () => {
+    const persistence = createLocalStorageResumePersistence("alice@example.com");
+    const state = {
+      previd: "abc-123",
+      inboundH: 42,
+      outboundH: 7,
+      resource: "web-existing-resource",
+    };
+    persistence.saveSm(state);
+    expect(persistence.loadSm()).toEqual(state);
+  });
+
+  test("consumeSm claims and clears the stored resource for only one client", () => {
+    const persistence = createLocalStorageResumePersistence("alice@example.com");
+    const state = {
+      previd: "abc-123",
+      inboundH: 42,
+      outboundH: 7,
+      resource: "web-existing-resource",
+    };
+    persistence.saveSm(state);
+    expect(persistence.consumeSm()).toEqual(state);
+    expect(persistence.consumeSm()).toBeNull();
+    expect(persistence.loadSm()).toBeNull();
+  });
+
+  test("consumeSm is scoped to the tab owner", () => {
+    const tabA = createLocalStorageResumePersistence("alice@example.com", "tab-a");
+    const tabB = createLocalStorageResumePersistence("alice@example.com", "tab-b");
+    const state = {
+      previd: "abc-123",
+      inboundH: 42,
+      outboundH: 7,
+      resource: "web-existing-resource",
+    };
+    tabA.saveSm(state);
+
+    expect(tabB.loadSm()).toBeNull();
+    expect(tabB.consumeSm()).toBeNull();
+    expect(tabA.consumeSm()).toEqual(state);
+    expect(tabA.consumeSm()).toBeNull();
+  });
+
+  test("a duplicated tab rotates a copied live owner before it can claim SM state", () => {
+    const copiedOwner = "copied-live-owner";
+    const state = {
+      previd: "abc-123",
+      inboundH: 42,
+      outboundH: 7,
+      resource: "web-existing-resource",
+    };
+    createLocalStorageResumePersistence("alice@example.com", copiedOwner).saveSm(state);
+    window.sessionStorage.setItem("waddle.chat.sm-resume.owner", copiedOwner);
+    window.localStorage.setItem(
+      `waddle.chat.sm-resume.owner-lease.${copiedOwner}`,
+      JSON.stringify({
+        ownerId: copiedOwner,
+        instanceId: "original-live-tab",
+        updatedAt: Date.now(),
+      }),
+    );
+
+    const duplicatedTab = createLocalStorageResumePersistence("alice@example.com");
+
+    expect(duplicatedTab.consumeSm()).toBeNull();
+    expect(createLocalStorageResumePersistence("alice@example.com", copiedOwner).consumeSm()).toEqual(state);
+  });
+
+  test("a pagehide handoff keeps the copied owner for same-tab reload consumption", () => {
+    const reloadOwner = "reload-owner";
+    const state = {
+      previd: "abc-123",
+      inboundH: 42,
+      outboundH: 7,
+      resource: "web-existing-resource",
+    };
+    const previousPage = createLocalStorageResumePersistence("alice@example.com", reloadOwner);
+    previousPage.saveSm(state);
+    previousPage.preparePagehideHandoff();
+    window.sessionStorage.setItem("waddle.chat.sm-resume.owner", reloadOwner);
+    window.localStorage.setItem(
+      `waddle.chat.sm-resume.owner-lease.${reloadOwner}`,
+      JSON.stringify({
+        ownerId: reloadOwner,
+        instanceId: "previous-page",
+        updatedAt: Date.now(),
+      }),
+    );
+
+    const reloadedPage = createLocalStorageResumePersistence("alice@example.com");
+
+    expect(reloadedPage.consumeSm()).toEqual(state);
+  });
+
+  test("BrowserXmppClient only reuses a refreshed resource for the owning tab", () => {
+    const state = {
+      previd: "abc-123",
+      inboundH: 42,
+      outboundH: 7,
+      resource: "web-existing-resource",
+    };
+    createLocalStorageResumePersistence("alice@example.com", "tab-a").saveSm(state);
+
+    const tabB = new BrowserXmppClient(
+      { jid: "alice@example.com", username: "alice" } as WaddleSession,
+      createLocalStorageResumePersistence("alice@example.com", "tab-b"),
+    );
+    expect(tabB.fullJid).not.toBe("alice@example.com/web-existing-resource");
+
+    const tabA = new BrowserXmppClient(
+      { jid: "alice@example.com", username: "alice" } as WaddleSession,
+      createLocalStorageResumePersistence("alice@example.com", "tab-a"),
+    );
+    expect(tabA.fullJid).toBe("alice@example.com/web-existing-resource");
+  });
+
+  test("round-trips retained joined rooms for refresh-time group call discovery", () => {
+    const persistence = createLocalStorageResumePersistence("alice@example.com", "tab-a");
+    const otherTab = createLocalStorageResumePersistence("alice@example.com", "tab-b");
+    persistence.saveJoinedRooms([
+      "General@Conference.Example.com/alice",
+      "standup@conference.example.com",
+      "standup@conference.example.com",
+      "",
+    ]);
+
+    expect(persistence.loadJoinedRooms()).toEqual([
+      "general@conference.example.com",
+      "standup@conference.example.com",
+    ]);
+    expect(otherTab.loadJoinedRooms()).toEqual([]);
+    persistence.clearJoinedRooms();
+    expect(persistence.loadJoinedRooms()).toEqual([]);
+  });
+
+  test("consumeSm rejects a delayed claimant that observed the same original resource", () => {
+    const first = createLocalStorageResumePersistence("alice@example.com");
+    const second = createLocalStorageResumePersistence("alice@example.com");
+    const state: PersistedSmResumeState = {
+      previd: "abc-123",
+      inboundH: 42,
+      outboundH: 7,
+      resource: "web-existing-resource",
+    };
+    first.saveSm(state);
+
+    const storage = window.localStorage;
+    const originalSetItem = storage.setItem.bind(storage);
+    let reentered = false;
+    let secondResult: PersistedSmResumeState | null | undefined;
+    storage.setItem = ((key: string, value: string) => {
+      if (
+        key === "waddle.chat.sm-resume.alice@example.com"
+        && value.includes('"claimId"')
+        && !reentered
+      ) {
+        reentered = true;
+        secondResult = second.consumeSm();
+      }
+      originalSetItem(key, value);
+    }) as Storage["setItem"];
+
+    try {
+      const firstResult = first.consumeSm();
+
+      expect(secondResult).toEqual(state);
+      expect(firstResult).toBeNull();
+      expect(first.loadSm()).toBeNull();
+      expect(first.consumeSm()).toBeNull();
+    } finally {
+      storage.setItem = originalSetItem;
+    }
   });
 
   test("SM TTL: a stale envelope is rejected and cleared", () => {

--- a/chat/tests/use-active-muc-call.test.ts
+++ b/chat/tests/use-active-muc-call.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { $callState } from "../src/lib/calls/call-store";
 import {
   $mucCallParticipants,
+  applyMucCallPresence,
   clearMucCallParticipants,
 } from "../src/lib/calls/muc-call-presence";
 import { connectionStore } from "../src/lib/connection-store";
@@ -28,6 +29,7 @@ const join: LiveKitJoin = {
 function setSession(username: string | null): void {
   if (username === null) {
     connectionStore.session = null;
+    connectionStore.client = null;
     return;
   }
   connectionStore.session = {
@@ -202,6 +204,62 @@ describe("readRoomHasActiveCall selector", () => {
       localResourceInCall: true,
       participantCount: 2,
     });
+  });
+
+  test("distinguishes same-resource Muji presence after refresh from another resource", () => {
+    setSession("alice");
+    connectionStore.client = { fullJid: "alice@waddle.test/web" } as unknown as typeof connectionStore.client;
+    $callState.set({ phase: "idle" });
+    applyMucCallPresence({
+      from: `${ROOM}/alice`,
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/mobile",
+      muji: { preparing: false, active: true },
+    });
+
+    expect(readRoomHasActiveCall(ROOM)).toEqual({
+      hasActiveCall: true,
+      selfInCall: true,
+      localResourceInCall: false,
+      participantCount: 1,
+    });
+
+    applyMucCallPresence({
+      from: `${ROOM}/alice`,
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/web",
+      muji: { preparing: false, active: true },
+    });
+
+    expect(readRoomHasActiveCall(ROOM)).toEqual({
+      hasActiveCall: true,
+      selfInCall: true,
+      localResourceInCall: true,
+      participantCount: 1,
+    });
+  });
+
+  test("preserves resourcepart case when matching Muji ownership to this browser", () => {
+    setSession("alice");
+    connectionStore.client = { fullJid: "alice@waddle.test/Web" } as unknown as typeof connectionStore.client;
+    $callState.set({ phase: "idle" });
+    applyMucCallPresence({
+      from: `${ROOM}/alice`,
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/web",
+      muji: { preparing: false, active: true },
+    });
+
+    expect(readRoomHasActiveCall(ROOM).localResourceInCall).toBe(false);
+
+    applyMucCallPresence({
+      from: `${ROOM}/alice`,
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/Web",
+      muji: { preparing: false, active: true },
+    });
+
+    expect(readRoomHasActiveCall(ROOM).localResourceInCall).toBe(true);
   });
 
   test("normalizes resource-suffixed room JIDs", () => {


### PR DESCRIPTION
## Summary

- Deepen refreshed-call continuity across the conversation banner, activity dock, DM panel, home dashboard, current-call panel, desktop sidebar, and mobile drawers.
- Preserve same-resource 1:1 call resume across browser refresh while blocking sibling tabs/devices from claiming another tab's XEP-0198 resource.
- Keep group-call discovery participant-aware after refresh, including owner/resource identity for XEP-0272 Muji presence.
- Rejoin only owner-scoped retained MUC rooms after a same-tab refresh; do not leak non-autojoin room state across sibling tabs.

## Plan Completed

- Added local-current call fallbacks so Home, rail badges, and current-call surfaces show a DM/MUC call before activity or Muji echoes arrive.
- Added group-call participant previews in the activity dock, home active-call cards, and current-call panel.
- Added owner-scoped SM and joined-room refresh persistence with duplicate-tab owner rotation plus a short pagehide handoff window for real same-tab reloads.
- Preserved XMPP resourcepart case when comparing full JIDs for Muji ownership, while still normalizing bare JIDs.
- Hardened archived LiveKit token expiry parsing for UTF-8 JWT payloads before offering a resume action.
- Wired owner-scoped retained rooms into session-ready rejoin so refreshed group-call discovery covers rooms that were already joined.
- Added runtime coverage for the ContentArea conversation banner event bridge and routing coverage for desktop/mobile DM answer/reconnect paths.

## XEP Review

- Reviewed `xeps/xep-0198.xml`: refresh handoff remains a local Stream Management resume handoff and now has same-tab ownership checks before reuse.
- Reviewed `xeps/xep-0272.xml`: group-call visibility remains Muji/MUC-presence driven, with resource-aware owner tracking for same-nick multi-resource cases.
- Reviewed `xeps/xep-0402.xml`: retained joined rooms are scoped to the tab that had already joined them; the code does not reinterpret non-autojoin bookmarks as globally autojoinable.
- Reviewed `xeps/xep-0353.xml` and `xeps/xep-0483.xml`: refreshed 1:1 call activity stays message/Jingle based, and no HTTP online-meeting control API was added.

## Verification

- `bun test`
- `bun run lint`
- `bun run build`
- `git diff --check`
- Adversarial protocol/state re-review: no actionable issues found.
- Adversarial UI/routing re-review: no actionable issues found.
- Adversarial test/maintainability re-review: no actionable issues found.

## Notes

- No dev server was started.
- Build still prints the existing Astro async-function hint for `withIqTimeout` and the existing Vite chunk-size warning, with zero build errors.
