### PR TITLE
fix(chat): keep recovered calls endable after reload

### DIFF
--- a/chat/src/components/calls/CallActivePill.vue
+++ b/chat/src/components/calls/CallActivePill.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import { Phone } from "lucide-vue-next";
+import { Phone, Video } from "lucide-vue-next";
 import { useRoomHasActiveCall } from "@/lib/calls/use-active-muc-call";
 
 /**
@@ -33,6 +33,7 @@ const {
   selfInCall,
   localResourceInCall,
   participantCount,
+  media,
 } = useRoomHasActiveCall(
   () => props.roomJid,
 );
@@ -48,13 +49,14 @@ const isVisible = computed(() => hasActiveCall.value && !localResourceInCall.val
 const ariaLabel = computed(() => {
   const count = participantCount.value;
   const noun = count === 1 ? "person" : "people";
+  const mediaLabel = media.value.video ? "video call" : "call";
   const device = selfInCall.value
     ? " This account is connected on another device."
     : "";
   if (props.disabled) {
-    return `Live call in this channel, ${count} ${noun}.${device} Join unavailable from this device.`;
+    return `Live ${mediaLabel} in this channel, ${count} ${noun}.${device} Join unavailable from this device.`;
   }
-  return `Live call in this channel, ${count} ${noun}.${device} Click to join from this device.`;
+  return `Live ${mediaLabel} in this channel, ${count} ${noun}.${device} Click to join from this device.`;
 });
 
 function onClick(): void {
@@ -75,7 +77,8 @@ function onClick(): void {
     @click="onClick"
   >
     <span class="call-active-pill__dot" aria-hidden="true" />
-    <Phone class="call-active-pill__icon" aria-hidden="true" />
+    <Video v-if="media.video" class="call-active-pill__icon" aria-hidden="true" />
+    <Phone v-else class="call-active-pill__icon" aria-hidden="true" />
     <span class="call-active-pill__count">{{ participantCount }}</span>
     <span class="call-active-pill__separator" aria-hidden="true">·</span>
     <span class="call-active-pill__state">Live</span>

--- a/chat/src/components/calls/CallActivityDock.vue
+++ b/chat/src/components/calls/CallActivityDock.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { useStore } from "@nanostores/vue";
-import { ArrowRight, Hash, MessageCircle, Phone, PhoneIncoming, PhoneOutgoing, Video } from "lucide-vue-next";
+import { ArrowRight, Hash, MessageCircle, Phone, PhoneIncoming, PhoneOff, PhoneOutgoing, Video } from "lucide-vue-next";
 import {
   $mucCallParticipants,
   mucCallParticipantCounts,
@@ -13,10 +13,12 @@ import { mucCallParticipantPreview } from "@/lib/calls/muc-call-indicators";
 import {
   callActivityDockAction,
   buildCallActivityDockEntries,
+  canEndRecoveredDmCallActivity,
   callActivityDockSelection,
   type CallActivityDockEntry,
   type SidebarMode,
 } from "@/lib/calls/call-activity-dock";
+import { readRoomHasActiveCall } from "@/lib/calls/use-active-muc-call";
 import type { CallMedia } from "@/lib/calls/types";
 import type { ChannelSummary } from "@/lib/chat-types";
 import type { DmConversation } from "@/lib/xmpp-client";
@@ -33,6 +35,7 @@ const props = withDefaults(defineProps<{
   sidebarMode: SidebarMode;
   activeChannelJids: Set<string>;
   callParticipants?: Record<string, readonly string[]>;
+  callMediaByRoom?: Record<string, CallMedia>;
   managedMucDomain?: string | null;
   selfFullJid?: string | null;
   showDmCalls?: boolean;
@@ -45,9 +48,11 @@ const props = withDefaults(defineProps<{
 const emit = defineEmits<{
   answerDm: [peerJid: string, remoteFullJid: string, sid: string, media: CallMedia];
   selectChannel: [channelId: string | null, roomJid: string];
+  leaveChannelCall: [roomJid: string];
   joinChannelCall: [channelId: string | null, roomJid: string, media: CallMedia];
   selectDm: [peerJid: string];
   reconnectDm: [peerJid: string, media: CallMedia];
+  endDm: [peerJid: string, sid?: string];
 }>();
 
 const mucCallParticipantsStore = useStore($mucCallParticipants);
@@ -70,6 +75,7 @@ const entries = computed(() => buildCallActivityDockEntries({
   managedMucDomain: props.managedMucDomain ?? null,
   callParticipantCounts: callParticipantCounts.value,
   callParticipants: callParticipants.value,
+  callMediaByRoom: props.callMediaByRoom,
   dmCallActivities: props.showDmCalls === false ? {} : dmCallActivities.value,
 }));
 const visibleEntries = computed(() =>
@@ -104,7 +110,8 @@ function isCurrentCallEntry(entry: CallActivityDockEntry): boolean {
     return normalizeMucCallRoomJid(entry.roomJid) === normalizeMucCallRoomJid(current.peer);
   }
   if (current.phase !== "active" || current.kind !== "dm") return false;
-  return entry.peerJid.toLowerCase() === barePeerJid(current.peer).toLowerCase();
+  return entry.peerJid.toLowerCase() === barePeerJid(current.peer).toLowerCase() &&
+    entry.sid === current.sid;
 }
 
 function entryStatus(entry: CallActivityDockEntry): string {
@@ -125,12 +132,17 @@ function acceptedDmEntryStatus(entry: Extract<CallActivityDockEntry, { kind: "dm
   const reason = dmCallResumeBlockReason(entry, props.selfFullJid ?? null);
   if (reason === null) return "Live";
   if (reason === "other-resource") return "Other device";
-  if (reason === "expired-token" || reason === "invalid-token") return "Expired";
+  if (reason === "expired-token" || reason === "invalid-token") {
+    return entryCanEndDm(entry) ? "End available" : "Expired";
+  }
   return "Details pending";
 }
 
 function entryKindLabel(entry: CallActivityDockEntry): string {
-  if (entry.kind === "channel") return entry.isKnownChannel ? "Group call" : "Group call · syncing";
+  if (entry.kind === "channel") {
+    const media = entry.media.video ? "Group video call" : "Group call";
+    return entry.isKnownChannel ? media : `${media} · syncing`;
+  }
   if (entry.mediaKnown === false) return "Call";
   return entry.media.video ? "Video call" : "Voice call";
 }
@@ -149,7 +161,7 @@ function entryAction(entry: CallActivityDockEntry): string {
     case "answer":
       return "Answer";
     case "join":
-      return "Join";
+      return entry.kind === "channel" && entryCanLeaveChannel(entry) ? "Rejoin" : "Join";
     case "return":
       return "Return";
     case "reconnect":
@@ -167,6 +179,51 @@ function entryTitle(entry: CallActivityDockEntry): string {
 
 function entryCanSelect(entry: CallActivityDockEntry): boolean {
   return entry.kind !== "channel" || entry.roomJid.length > 0;
+}
+
+function entryCanEndDm(entry: CallActivityDockEntry): boolean {
+  return entry.kind === "dm" &&
+    canEndRecoveredDmCallActivity(entry, callState.value, props.selfFullJid ?? null);
+}
+
+function entryCanLeaveChannel(entry: CallActivityDockEntry): boolean {
+  if (entry.kind !== "channel" || !entry.roomJid) return false;
+  if (currentMucCallRoomJid() === normalizeMucCallRoomJid(entry.roomJid)) return false;
+  return readRoomHasActiveCall(entry.roomJid).localResourceInCall;
+}
+
+function currentMucCallRoomJid(): string {
+  const current = callState.value;
+  if (current.phase !== "active" && current.phase !== "muc-pending") return "";
+  if (current.kind !== "muc") return "";
+  return normalizeMucCallRoomJid(current.peer);
+}
+
+function entryCanEnd(entry: CallActivityDockEntry): boolean {
+  return entryCanEndDm(entry) || entryCanLeaveChannel(entry);
+}
+
+function endEntryLabel(entry: CallActivityDockEntry): string {
+  if (entry.kind === "channel") return `Leave ${entry.title} call`;
+  return endDmLabel(entry);
+}
+
+function endEntry(entry: CallActivityDockEntry): void {
+  if (entry.kind === "channel" && entryCanLeaveChannel(entry)) {
+    emit("leaveChannelCall", entry.roomJid);
+    return;
+  }
+  if (entry.kind === "dm" && entryCanEndDm(entry)) {
+    emit("endDm", entry.peerJid, entry.sid);
+  }
+}
+
+function endDmLabel(entry: CallActivityDockEntry): string {
+  if (entry.kind !== "dm") return "";
+  const media = entry.mediaKnown !== false
+    ? `${entry.media.video ? "video" : "voice"} call`
+    : "call";
+  return `End ${entry.title} ${media}`;
 }
 
 function visibleParticipantLabels(entry: CallActivityDockEntry): string[] {
@@ -221,65 +278,80 @@ function selectEntry(entry: CallActivityDockEntry): void {
         </span>
       </div>
       <div class="call-activity-dock__list">
-        <button
+        <div
           v-for="entry in visibleEntries"
           :key="entry.key"
-          type="button"
-          class="call-activity-dock__row"
+          class="call-activity-dock__row-shell"
           :class="{
-            'call-activity-dock__row--active': entry.isActive,
-            'call-activity-dock__row--disabled': !entryCanSelect(entry),
+            'call-activity-dock__row-shell--active': entry.isActive,
+            'call-activity-dock__row-shell--disabled': !entryCanSelect(entry),
           }"
-          :disabled="!entryCanSelect(entry)"
-          :aria-current="entry.isActive ? 'page' : undefined"
-          :title="entryTitle(entry)"
-          :aria-label="entryTitle(entry)"
-          @click="selectEntry(entry)"
         >
-          <span class="call-activity-dock__icon" aria-hidden="true">
-            <Hash v-if="entry.kind === 'channel'" class="h-3.5 w-3.5" />
-            <Video v-else-if="entry.mediaKnown !== false && entry.media.video" class="h-3.5 w-3.5" />
-            <PhoneIncoming v-else-if="entry.state === 'ringing' && entry.direction === 'incoming'" class="h-3.5 w-3.5" />
-            <PhoneOutgoing v-else-if="entry.state === 'ringing' && entry.direction === 'outgoing'" class="h-3.5 w-3.5" />
-            <MessageCircle v-else-if="entry.state === 'ringing'" class="h-3.5 w-3.5" />
-            <Phone v-else class="h-3.5 w-3.5" />
-          </span>
-          <span class="call-activity-dock__copy">
-            <span class="call-activity-dock__title type-control">{{ entry.title }}</span>
-            <span class="call-activity-dock__status type-meta">
-              {{ entryMeta(entry) }}
+          <button
+            type="button"
+            class="call-activity-dock__row"
+            :disabled="!entryCanSelect(entry)"
+            :aria-current="entry.isActive ? 'page' : undefined"
+            :title="entryTitle(entry)"
+            :aria-label="entryTitle(entry)"
+            @click="selectEntry(entry)"
+          >
+            <span class="call-activity-dock__icon" aria-hidden="true">
+              <Video v-if="entry.kind === 'channel' && entry.media.video" class="h-3.5 w-3.5" />
+              <Hash v-else-if="entry.kind === 'channel'" class="h-3.5 w-3.5" />
+              <Video v-else-if="entry.mediaKnown !== false && entry.media.video" class="h-3.5 w-3.5" />
+              <PhoneIncoming v-else-if="entry.state === 'ringing' && entry.direction === 'incoming'" class="h-3.5 w-3.5" />
+              <PhoneOutgoing v-else-if="entry.state === 'ringing' && entry.direction === 'outgoing'" class="h-3.5 w-3.5" />
+              <MessageCircle v-else-if="entry.state === 'ringing'" class="h-3.5 w-3.5" />
+              <Phone v-else class="h-3.5 w-3.5" />
             </span>
-            <span
-              v-if="entryParticipantPreview(entry)"
-              class="call-activity-dock__participants type-meta"
-              :title="`${entryParticipantPreview(entry)} in call`"
-            >
-              <span class="call-activity-dock__participant-stack" aria-hidden="true">
-                <span
-                  v-for="label in visibleParticipantLabels(entry)"
-                  :key="`${entry.key}:${label}`"
-                  class="call-activity-dock__participant"
-                >
-                  {{ participantInitial(label) }}
+            <span class="call-activity-dock__copy">
+              <span class="call-activity-dock__title type-control">{{ entry.title }}</span>
+              <span class="call-activity-dock__status type-meta">
+                {{ entryMeta(entry) }}
+              </span>
+              <span
+                v-if="entryParticipantPreview(entry)"
+                class="call-activity-dock__participants type-meta"
+                :title="`${entryParticipantPreview(entry)} in call`"
+              >
+                <span class="call-activity-dock__participant-stack" aria-hidden="true">
+                  <span
+                    v-for="label in visibleParticipantLabels(entry)"
+                    :key="`${entry.key}:${label}`"
+                    class="call-activity-dock__participant"
+                  >
+                    {{ participantInitial(label) }}
+                  </span>
+                </span>
+                <span class="call-activity-dock__participant-copy">
+                  {{ entryParticipantPreview(entry) }}
                 </span>
               </span>
-              <span class="call-activity-dock__participant-copy">
-                {{ entryParticipantPreview(entry) }}
-              </span>
             </span>
-          </span>
-          <span
-            v-if="entry.kind === 'channel'"
-            class="call-activity-dock__count type-count-badge"
-            aria-hidden="true"
+            <span
+              v-if="entry.kind === 'channel'"
+              class="call-activity-dock__count type-count-badge"
+              aria-hidden="true"
+            >
+              {{ entry.participantCount }}
+            </span>
+            <span class="call-activity-dock__action type-meta" aria-hidden="true">
+              {{ entryAction(entry) }}
+              <ArrowRight v-if="entryCanSelect(entry)" class="h-3 w-3" />
+            </span>
+          </button>
+          <button
+            v-if="entryCanEnd(entry)"
+            type="button"
+            class="call-activity-dock__end"
+            :title="endEntryLabel(entry)"
+            :aria-label="endEntryLabel(entry)"
+            @click="endEntry(entry)"
           >
-            {{ entry.participantCount }}
-          </span>
-          <span class="call-activity-dock__action type-meta" aria-hidden="true">
-            {{ entryAction(entry) }}
-            <ArrowRight v-if="entryCanSelect(entry)" class="h-3 w-3" />
-          </span>
-        </button>
+            <PhoneOff class="h-3.5 w-3.5" aria-hidden="true" />
+          </button>
+        </div>
       </div>
     </section>
   </div>
@@ -343,8 +415,16 @@ function selectEntry(entry: CallActivityDockEntry): void {
   overflow-y: auto;
 }
 
+.call-activity-dock__row-shell {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.25rem;
+  border-radius: var(--radius-sm);
+}
+
 .call-activity-dock__row {
   display: grid;
+  width: 100%;
   grid-template-columns: 1.75rem minmax(0, 1fr) auto auto;
   min-height: 3rem;
   align-items: center;
@@ -360,7 +440,7 @@ function selectEntry(entry: CallActivityDockEntry): void {
 }
 
 .call-activity-dock__row:hover:not(:disabled),
-.call-activity-dock__row--active {
+.call-activity-dock__row-shell--active .call-activity-dock__row {
   background: color-mix(in oklab, var(--sidebar-accent) 72%, transparent);
   color: var(--sidebar-foreground);
 }
@@ -369,14 +449,14 @@ function selectEntry(entry: CallActivityDockEntry): void {
   transform: translateY(-1px);
 }
 
-.call-activity-dock__row--disabled,
-.call-activity-dock__row--disabled:hover {
+.call-activity-dock__row-shell--disabled .call-activity-dock__row,
+.call-activity-dock__row-shell--disabled .call-activity-dock__row:hover {
   cursor: default;
   opacity: 0.72;
   transform: none;
 }
 
-.call-activity-dock__row--disabled .call-activity-dock__action {
+.call-activity-dock__row-shell--disabled .call-activity-dock__action {
   background: color-mix(in oklab, var(--sidebar-accent) 58%, transparent);
   color: var(--sidebar-muted);
 }
@@ -479,15 +559,37 @@ function selectEntry(entry: CallActivityDockEntry): void {
 }
 
 .call-activity-dock__row:hover:not(:disabled) .call-activity-dock__action,
-.call-activity-dock__row--active .call-activity-dock__action {
+.call-activity-dock__row-shell--active .call-activity-dock__action {
   background: color-mix(in oklab, oklch(0.7 0.18 145) 26%, transparent);
   color: var(--success-foreground);
 }
 
 :global(.dark) .call-activity-dock__action,
 :global(.dark) .call-activity-dock__row:hover:not(:disabled) .call-activity-dock__action,
-:global(.dark) .call-activity-dock__row--active .call-activity-dock__action {
+:global(.dark) .call-activity-dock__row-shell--active .call-activity-dock__action {
   color: oklch(0.86 0.13 145);
+}
+
+.call-activity-dock__end {
+  display: inline-flex;
+  width: 2.25rem;
+  min-height: 3rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  color: var(--destructive);
+  transition:
+    background-color 160ms ease-out,
+    color 160ms ease-out;
+}
+
+.call-activity-dock__end:hover {
+  background: color-mix(in oklab, var(--destructive) 10%, transparent);
+}
+
+.call-activity-dock__end:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px color-mix(in oklab, var(--destructive) 32%, transparent);
 }
 
 .call-activity-dock.call-activity-dock--mobile {
@@ -517,6 +619,10 @@ function selectEntry(entry: CallActivityDockEntry): void {
 
 .call-activity-dock.call-activity-dock--mobile .call-activity-dock__row {
   min-width: min(17rem, 84vw);
+}
+
+.call-activity-dock.call-activity-dock--mobile .call-activity-dock__row-shell {
+  min-width: min(20rem, 92vw);
 }
 
 @media (min-width: 64rem) {

--- a/chat/src/components/calls/ConversationCallBanner.vue
+++ b/chat/src/components/calls/ConversationCallBanner.vue
@@ -26,6 +26,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   joinChannelCall: [channelId: string | null, roomJid: string, media: CallMedia];
+  leaveChannelCall: [roomJid: string];
   answerDm: [peerJid: string, remoteFullJid: string, sid: string, media: CallMedia];
   reconnectDm: [peerJid: string, media: CallMedia];
 }>();
@@ -44,6 +45,9 @@ type BannerView = {
   actionLabel: string;
   ariaLabel: string;
   disabled: boolean;
+  secondaryAction?: "leave";
+  secondaryActionLabel?: string;
+  secondaryAriaLabel?: string;
   icon: Component;
   actionIcon: Component;
   channelId?: string | null;
@@ -96,19 +100,31 @@ function groupCallBanner(): BannerView | null {
   const participantNoun = participantCount === 1 ? "person" : "people";
   const title = `${props.channelName || "This channel"} has a live call`;
   const busy = isBusy(callState.value);
+  const retainedLocalResource = roomCall.localResourceInCall.value && !localGroupCallInThisRoom.value;
 
   return {
     kind: "group",
-    tone: busy ? "busy" : "live",
-    eyebrow: "Live now",
+    tone: busy ? "busy" : retainedLocalResource ? "syncing" : "live",
+    eyebrow: retainedLocalResource ? "Recovered after refresh" : "Live now",
     title,
-    body: `${participantCount} ${participantNoun} connected in this channel.`,
-    meta: ["Voice call", "Channel"],
+    body: retainedLocalResource
+      ? "This browser is still listed in the call after reload. Rejoin media or leave to clear your call presence."
+      : `${participantCount} ${participantNoun} connected in this channel.`,
+    meta: retainedLocalResource ? ["Voice call", "This browser"] : ["Voice call", "Channel"],
     avatarLabels: roomParticipantLabels.value,
     action: busy ? "unavailable" : "join",
-    actionLabel: busy ? "In another call" : "Join call",
-    ariaLabel: busy ? `${title}; already in another call` : `Join ${props.channelName || "channel"} call`,
+    actionLabel: busy ? "In another call" : retainedLocalResource ? "Rejoin call" : "Join call",
+    ariaLabel: busy
+      ? `${title}; already in another call`
+      : retainedLocalResource
+        ? `Rejoin ${props.channelName || "channel"} call after refresh`
+        : `Join ${props.channelName || "channel"} call`,
     disabled: busy,
+    ...(retainedLocalResource ? {
+      secondaryAction: "leave" as const,
+      secondaryActionLabel: "Leave call",
+      secondaryAriaLabel: `Leave ${props.channelName || "channel"} call after refresh`,
+    } : {}),
     icon: Phone,
     actionIcon: busy ? PhoneOff : Phone,
     channelId: props.channelId ?? null,
@@ -314,6 +330,12 @@ function activateBanner(): void {
     emit("reconnectDm", current.peerJid, current.media);
   }
 }
+
+function activateSecondaryBanner(): void {
+  const current = banner.value;
+  if (!current || current.secondaryAction !== "leave" || !current.roomJid) return;
+  emit("leaveChannelCall", current.roomJid);
+}
 </script>
 
 <template>
@@ -372,16 +394,28 @@ function activateBanner(): void {
             </div>
           </div>
         </div>
-        <button
-          type="button"
-          class="conversation-call-banner__action type-control"
-          :aria-label="banner.ariaLabel"
-          :disabled="banner.disabled"
-          @click="activateBanner"
-        >
-          <component :is="banner.actionIcon" class="h-3.5 w-3.5" aria-hidden="true" />
-          <span>{{ banner.actionLabel }}</span>
-        </button>
+        <div class="conversation-call-banner__actions">
+          <button
+            type="button"
+            class="conversation-call-banner__action type-control"
+            :aria-label="banner.ariaLabel"
+            :disabled="banner.disabled"
+            @click="activateBanner"
+          >
+            <component :is="banner.actionIcon" class="h-3.5 w-3.5" aria-hidden="true" />
+            <span>{{ banner.actionLabel }}</span>
+          </button>
+          <button
+            v-if="banner.secondaryAction"
+            type="button"
+            class="conversation-call-banner__action conversation-call-banner__action--secondary type-control"
+            :aria-label="banner.secondaryAriaLabel"
+            @click="activateSecondaryBanner"
+          >
+            <PhoneOff class="h-3.5 w-3.5" aria-hidden="true" />
+            <span>{{ banner.secondaryActionLabel }}</span>
+          </button>
+        </div>
       </div>
     </section>
   </div>
@@ -538,6 +572,13 @@ function activateBanner(): void {
   white-space: nowrap;
 }
 
+.conversation-call-banner__actions {
+  display: flex;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
 .conversation-call-banner__action {
   display: inline-flex;
   height: 2.25rem;
@@ -553,8 +594,17 @@ function activateBanner(): void {
   transition: background-color 150ms ease, border-color 150ms ease, color 150ms ease;
 }
 
+.conversation-call-banner__action--secondary {
+  border-color: color-mix(in oklab, var(--destructive) 24%, var(--border));
+  color: var(--destructive);
+}
+
 .conversation-call-banner__action:hover {
   background: color-mix(in oklab, var(--primary) 11%, var(--background));
+}
+
+.conversation-call-banner__action--secondary:hover {
+  background: color-mix(in oklab, var(--destructive) 10%, var(--background));
 }
 
 .conversation-call-banner__action:focus-visible {

--- a/chat/src/components/calls/ConversationCallBanner.vue
+++ b/chat/src/components/calls/ConversationCallBanner.vue
@@ -3,9 +3,14 @@ import { computed, type Component } from "vue";
 import { useStore } from "@nanostores/vue";
 import { Phone, PhoneIncoming, PhoneOff, Video } from "lucide-vue-next";
 import { $callState } from "@/lib/calls/call-store";
-import { dmCallActivityAction, isBusy } from "@/lib/calls/call-activity-dock";
+import {
+  canEndRecoveredDmCallActivity,
+  dmCallActivityAction,
+  isBusy,
+} from "@/lib/calls/call-activity-dock";
 import {
   $dmCallActivities,
+  dmCallActivitiesForPeer,
   dmCallResumeBlockReason,
   hasKnownDmCallMedia,
   type DmCallActivity,
@@ -29,6 +34,7 @@ const emit = defineEmits<{
   leaveChannelCall: [roomJid: string];
   answerDm: [peerJid: string, remoteFullJid: string, sid: string, media: CallMedia];
   reconnectDm: [peerJid: string, media: CallMedia];
+  endDm: [peerJid: string, sid?: string];
 }>();
 
 type BannerAction = "answer" | "join" | "reconnect" | "unavailable";
@@ -45,7 +51,7 @@ type BannerView = {
   actionLabel: string;
   ariaLabel: string;
   disabled: boolean;
-  secondaryAction?: "leave";
+  secondaryAction?: "leave" | "end-dm";
   secondaryActionLabel?: string;
   secondaryAriaLabel?: string;
   icon: Component;
@@ -73,7 +79,7 @@ const roomParticipantLabels = computed(() => {
 const dmActivity = computed<DmCallActivity | null>(() => {
   const peerJid = normalizedDmPeerJid.value;
   if (!peerJid) return null;
-  return dmCallActivities.value[peerJid] ?? null;
+  return dmCallActivitiesForPeer(dmCallActivities.value, peerJid, props.selfFullJid ?? null)[0] ?? null;
 });
 
 const localGroupCallInThisRoom = computed(() => {
@@ -101,6 +107,8 @@ function groupCallBanner(): BannerView | null {
   const title = `${props.channelName || "This channel"} has a live call`;
   const busy = isBusy(callState.value);
   const retainedLocalResource = roomCall.localResourceInCall.value && !localGroupCallInThisRoom.value;
+  const media = roomCall.media.value;
+  const mediaLabel = media.video ? "Video call" : "Voice call";
 
   return {
     kind: "group",
@@ -110,7 +118,7 @@ function groupCallBanner(): BannerView | null {
     body: retainedLocalResource
       ? "This browser is still listed in the call after reload. Rejoin media or leave to clear your call presence."
       : `${participantCount} ${participantNoun} connected in this channel.`,
-    meta: retainedLocalResource ? ["Voice call", "This browser"] : ["Voice call", "Channel"],
+    meta: retainedLocalResource ? [mediaLabel, "This browser"] : [mediaLabel, "Channel"],
     avatarLabels: roomParticipantLabels.value,
     action: busy ? "unavailable" : "join",
     actionLabel: busy ? "In another call" : retainedLocalResource ? "Rejoin call" : "Join call",
@@ -125,11 +133,11 @@ function groupCallBanner(): BannerView | null {
       secondaryActionLabel: "Leave call",
       secondaryAriaLabel: `Leave ${props.channelName || "channel"} call after refresh`,
     } : {}),
-    icon: Phone,
-    actionIcon: busy ? PhoneOff : Phone,
+    icon: media.video ? Video : Phone,
+    actionIcon: busy ? PhoneOff : media.video ? Video : Phone,
     channelId: props.channelId ?? null,
     roomJid,
-    media: { audio: true, video: false },
+    media,
   };
 }
 
@@ -169,22 +177,60 @@ function dmBanner(): BannerView | null {
     };
   }
 
+  const canEndRecoveredCall = canEndRecoveredDmCallActivity(
+    activity,
+    callState.value,
+    props.selfFullJid ?? null,
+  );
+
   if (action === "reconnect" && hasKnownDmCallMedia(activity)) {
     return {
       kind: "dm",
       tone: "live",
-      eyebrow: "Live now",
+      eyebrow: canEndRecoveredCall ? "Recovered after refresh" : "Live now",
       title,
-      body: `The ${mediaLabel} is still live.`,
+      body: canEndRecoveredCall
+        ? `The ${mediaLabel} is still live after reload. Rejoin media or end it from this tab.`
+        : `The ${mediaLabel} is still live.`,
       meta: [capitalizeLabel(mediaLabel), "1:1"],
       avatarLabels: [peerName],
       action: "reconnect",
       actionLabel: "Rejoin",
       ariaLabel: `Rejoin ${peerName} ${mediaLabel}`,
       disabled: false,
+      ...(canEndRecoveredCall ? {
+        secondaryAction: "end-dm" as const,
+        secondaryActionLabel: "End call",
+        secondaryAriaLabel: `End ${peerName} ${mediaLabel} after refresh`,
+      } : {}),
       icon: media.video ? Video : Phone,
       actionIcon: media.video ? Video : Phone,
       peerJid,
+      sid: activity.sid,
+      media,
+    };
+  }
+
+  if (canEndRecoveredCall && activity.state === "accepted") {
+    return {
+      kind: "dm",
+      tone: "syncing",
+      eyebrow: "Recovered after refresh",
+      title,
+      body: `The saved reconnect details for this ${mediaLabel} expired, but this tab can still end the call.`,
+      meta: [capitalizeLabel(mediaLabel), "1:1"],
+      avatarLabels: [peerName],
+      action: "unavailable",
+      actionLabel: "Unavailable",
+      ariaLabel: `${title}; reconnect details expired`,
+      disabled: true,
+      secondaryAction: "end-dm",
+      secondaryActionLabel: "End call",
+      secondaryAriaLabel: `End ${peerName} ${mediaLabel} after refresh`,
+      icon: media.video ? Video : Phone,
+      actionIcon: PhoneOff,
+      peerJid,
+      sid: activity.sid,
       media,
     };
   }
@@ -333,8 +379,14 @@ function activateBanner(): void {
 
 function activateSecondaryBanner(): void {
   const current = banner.value;
-  if (!current || current.secondaryAction !== "leave" || !current.roomJid) return;
-  emit("leaveChannelCall", current.roomJid);
+  if (!current) return;
+  if (current.secondaryAction === "leave" && current.roomJid) {
+    emit("leaveChannelCall", current.roomJid);
+    return;
+  }
+  if (current.secondaryAction === "end-dm" && current.peerJid) {
+    emit("endDm", current.peerJid, current.sid);
+  }
 }
 </script>
 

--- a/chat/src/components/calls/MucCallButton.vue
+++ b/chat/src/components/calls/MucCallButton.vue
@@ -100,8 +100,8 @@ async function startCall(media: CallMedia): Promise<void> {
   });
 }
 
-function joinExistingAudio(): void {
-  void startCall({ audio: true, video: false });
+function joinExistingCall(): void {
+  void startCall(roomCall.media.value);
 }
 </script>
 
@@ -146,7 +146,7 @@ function joinExistingAudio(): void {
     <CallActivePill
       v-if="showActivePill !== false"
       :room-jid="roomJid"
-      :on-join="joinExistingAudio"
+      :on-join="joinExistingCall"
       :disabled="pillDisabled"
     />
   </div>

--- a/chat/src/components/chat/ChatHeader.vue
+++ b/chat/src/components/chat/ChatHeader.vue
@@ -106,6 +106,12 @@ const dmCallActivityLabel = computed(() => {
   if (activity.direction === "outgoing") return `Calling ${media.toLowerCase()} call`;
   return `${media} call ringing`;
 });
+const showDmCallActivityStatus = computed(() =>
+  props.showDmCallActivityControls !== false && !!dmCallActivity.value,
+);
+const dmHeaderSecondaryText = computed(() =>
+  showDmCallActivityStatus.value ? dmCallActivityLabel.value : presenceText(props.dmPeer?.presenceShow),
+);
 
 const emit = defineEmits<{
   openNav: [];
@@ -199,7 +205,7 @@ const memberButtonCopy = computed(() => {
               · {{ presenceText(dmPeer.presenceShow) }}
             </span>
             <span
-              v-if="dmCallActivity"
+              v-if="showDmCallActivityStatus"
               class="type-meta hidden h-5 max-w-[9rem] shrink-0 items-center gap-1 overflow-hidden rounded-full border border-success/25 bg-success/10 px-2 text-success lg:inline-flex"
             >
               <PhoneCall class="h-3 w-3" />
@@ -207,7 +213,7 @@ const memberButtonCopy = computed(() => {
             </span>
           </div>
           <div v-if="dmPeer" class="lg:hidden type-caption text-muted-foreground truncate">
-            {{ dmCallActivityLabel || presenceText(dmPeer.presenceShow) }}
+            {{ dmHeaderSecondaryText }}
           </div>
           <!-- Desktop subtitle slot: prefer the channel's own description
                (its "topic") so rooms with a stated subject get character

--- a/chat/src/components/chat/ChatMobileDrawers.vue
+++ b/chat/src/components/chat/ChatMobileDrawers.vue
@@ -2,6 +2,7 @@
 import { computed } from "vue";
 import { useStore } from "@nanostores/vue";
 import {
+  $mucCallMedia,
   $mucCallParticipants,
   mucCallParticipantCounts,
 } from "@/lib/calls/muc-call-presence";
@@ -26,8 +27,10 @@ import type { ChatAppController } from "@/shell/chat-app-controller";
 const props = defineProps<{
   controller: ChatAppController;
   joinChannelCall?: (channelId: string | null, roomJid: string, media: CallMedia) => void;
+  leaveChannelCall?: (roomJid: string) => void;
   answerDm?: (peerJid: string, remoteFullJid: string, sid: string, media: CallMedia) => void;
   reconnectDm?: (peerJid: string, media: CallMedia) => void;
+  endDm?: (peerJid: string, sid?: string) => void;
 }>();
 
 const {
@@ -83,6 +86,10 @@ function joinChannelCallFromMobile(channelId: string | null, roomJid: string, me
   props.joinChannelCall?.(channelId, roomJid, media);
 }
 
+function leaveChannelCallFromMobile(roomJid: string) {
+  props.leaveChannelCall?.(roomJid);
+}
+
 function answerDmFromMobile(peerJid: string, remoteFullJid: string, sid: string, media: CallMedia) {
   props.answerDm?.(peerJid, remoteFullJid, sid, media);
 }
@@ -91,10 +98,15 @@ function reconnectDmFromMobile(peerJid: string, media: CallMedia) {
   props.reconnectDm?.(peerJid, media);
 }
 
+function endDmFromMobile(peerJid: string, sid?: string) {
+  props.endDm?.(peerJid, sid);
+}
+
 // XEP-0272 Muji participant counts keyed by room JID — same derived
 // reactive state as ChatReadyShell uses, so the mobile sidebar shows
 // the same "call ongoing" chip.
 const mucCallParticipantsStore = useStore($mucCallParticipants);
+const mucCallMediaStore = useStore($mucCallMedia);
 const dmCallActivitiesStore = useStore($dmCallActivities);
 const callStateStore = useStore($callState);
 const callParticipantCounts = computed<Record<string, number>>(() => {
@@ -174,6 +186,7 @@ function openExtensionRoute(route: DiscoveredExtensionRoute) {
           :channel-unread-map="computedChannelUnreadMap"
           :call-participant-counts="callParticipantCounts"
           :call-participants="mucCallParticipantsStore"
+          :call-media-by-room="mucCallMediaStore"
           :managed-muc-domain="managedMucDomain"
           :thread-entries-fn="(roomJid: string) => channelUnread.threadEntries(roomJid)"
           :active-community-surface="ui.activeCommunitySurface.value"
@@ -183,6 +196,7 @@ function openExtensionRoute(route: DiscoveredExtensionRoute) {
           class="!w-full !border-r-0 !flex-1"
           @select-channel="selectChannelFromMobile"
           @join-channel-call="joinChannelCallFromMobile"
+          @leave-channel-call="leaveChannelCallFromMobile"
           @select-thread="onSelectThread"
           @select-community-surface="selectCommunitySurface"
           @select-threads-view="openThreads"
@@ -202,6 +216,7 @@ function openExtensionRoute(route: DiscoveredExtensionRoute) {
           @answer-dm="answerDmFromMobile"
           @select-dm="selectDm"
           @reconnect-dm="reconnectDmFromMobile"
+          @end-dm="endDmFromMobile"
           @new-dm="ui.showNewDm.value = true"
         />
         <ProfilePanel

--- a/chat/src/components/chat/ChatMobileDrawers.vue
+++ b/chat/src/components/chat/ChatMobileDrawers.vue
@@ -26,6 +26,13 @@ import type { ChatAppController } from "@/shell/chat-app-controller";
 
 const props = defineProps<{
   controller: ChatAppController;
+  activeChannelCallCount?: number;
+  activeDmCallCount?: number;
+  callParticipantCounts?: Record<string, number>;
+  callParticipants?: Record<string, string[]>;
+  callMediaByRoom?: Record<string, CallMedia>;
+  managedMucDomain?: string | null;
+  selfFullJid?: string | null;
   joinChannelCall?: (channelId: string | null, roomJid: string, media: CallMedia) => void;
   leaveChannelCall?: (roomJid: string) => void;
   answerDm?: (peerJid: string, remoteFullJid: string, sid: string, media: CallMedia) => void;
@@ -109,20 +116,34 @@ const mucCallParticipantsStore = useStore($mucCallParticipants);
 const mucCallMediaStore = useStore($mucCallMedia);
 const dmCallActivitiesStore = useStore($dmCallActivities);
 const callStateStore = useStore($callState);
-const callParticipantCounts = computed<Record<string, number>>(() => {
+const fallbackCallParticipantCounts = computed<Record<string, number>>(() => {
   return mucCallParticipantCounts(mucCallParticipantsStore.value);
 });
-const activeChannelCallCount = computed(() => {
-  return activeChannelRailCallCount(callParticipantCounts.value, callStateStore.value);
-});
-const activeDmCallCount = computed(() => {
-  return activeDmRailCallCount(dmCallActivitiesStore.value, callStateStore.value);
-});
-const managedMucDomain = computed(() =>
-  normalizeMucServiceDomain(waddles.mucServiceJid.value) || (selfDomain.value ? `muc.${selfDomain.value}` : ""),
+const visibleCallParticipantCounts = computed<Record<string, number>>(() =>
+  props.callParticipantCounts ?? fallbackCallParticipantCounts.value,
 );
-const selfFullJid = computed(() =>
-  (connectionStore.client as unknown as { fullJid?: string } | null)?.fullJid ?? null
+const visibleCallParticipants = computed<Record<string, string[]>>(() =>
+  props.callParticipants ?? mucCallParticipantsStore.value,
+);
+const visibleCallMediaByRoom = computed<Record<string, CallMedia>>(() =>
+  props.callMediaByRoom ?? mucCallMediaStore.value,
+);
+const visibleActiveChannelCallCount = computed(() => {
+  return props.activeChannelCallCount ??
+    activeChannelRailCallCount(visibleCallParticipantCounts.value, callStateStore.value);
+});
+const visibleActiveDmCallCount = computed(() => {
+  return props.activeDmCallCount ??
+    activeDmRailCallCount(dmCallActivitiesStore.value, callStateStore.value);
+});
+const visibleManagedMucDomain = computed(() =>
+  props.managedMucDomain ??
+  (normalizeMucServiceDomain(waddles.mucServiceJid.value) || (selfDomain.value ? `muc.${selfDomain.value}` : "")),
+);
+const visibleSelfFullJid = computed(() =>
+  props.selfFullJid ??
+  (connectionStore.client as unknown as { fullJid?: string } | null)?.fullJid ??
+  null
 );
 
 const drawerExtensionRoutes = computed(() =>
@@ -161,8 +182,8 @@ function openExtensionRoute(route: DiscoveredExtensionRoute) {
             :active-sidebar-mode="ui.sidebarMode.value"
             :active-page="ui.activePage.value"
             :has-unread-dms="dmConversations.hasUnread.value"
-            :active-channel-call-count="activeChannelCallCount"
-            :active-dm-call-count="activeDmCallCount"
+            :active-channel-call-count="visibleActiveChannelCallCount"
+            :active-dm-call-count="visibleActiveDmCallCount"
             :session="null"
             horizontal
             @open-home="openHome"
@@ -184,10 +205,10 @@ function openExtensionRoute(route: DiscoveredExtensionRoute) {
           :active-channel-jids="messaging.activeChannels.value"
           :collapsed-group-ids="ui.collapsedSpaceGroupIds.value"
           :channel-unread-map="computedChannelUnreadMap"
-          :call-participant-counts="callParticipantCounts"
-          :call-participants="mucCallParticipantsStore"
-          :call-media-by-room="mucCallMediaStore"
-          :managed-muc-domain="managedMucDomain"
+          :call-participant-counts="visibleCallParticipantCounts"
+          :call-participants="visibleCallParticipants"
+          :call-media-by-room="visibleCallMediaByRoom"
+          :managed-muc-domain="visibleManagedMucDomain"
           :thread-entries-fn="(roomJid: string) => channelUnread.threadEntries(roomJid)"
           :active-community-surface="ui.activeCommunitySurface.value"
           :stories-active-count="stories.activeStories.value.length"
@@ -210,7 +231,7 @@ function openExtensionRoute(route: DiscoveredExtensionRoute) {
           v-else
           :conversations="dmConversations.conversations.value"
           :active-peer-jid="dmConversations.activePeerJid.value"
-          :self-full-jid="selfFullJid"
+          :self-full-jid="visibleSelfFullJid"
           hide-current-call
           class="!w-full !border-r-0 !flex-1"
           @answer-dm="answerDmFromMobile"

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -11,7 +11,7 @@ import {
   activeDmRailCallCount,
 } from "@/lib/calls/call-rail-counts";
 import { answerIncomingDmCallActivity, resumeDmCallActivity } from "@/lib/calls/dm-call-actions";
-import { startMucCallAction } from "@/lib/calls/muc-call-actions";
+import { leaveRetainedMucCallAction, startMucCallAction } from "@/lib/calls/muc-call-actions";
 import { normalizeMucServiceDomain } from "@/lib/calls/muc-call-indicators";
 import {
   $callState,
@@ -311,6 +311,15 @@ function joinChannelCallFromActivity(channelId: string | null, roomJid: string, 
     ensureJoined: async () => {
       await getClientJoiner()?.(roomJid);
     },
+  });
+}
+
+function leaveRetainedChannelCall(roomJid: string): void {
+  void leaveRetainedMucCallAction({
+    roomJid,
+    getSender: getMucCallSender,
+    getSelfNick: () => connectionStore.session?.username ?? undefined,
+    getSelfFullJid,
   });
 }
 
@@ -652,6 +661,7 @@ onUnmounted(() => {
               @open-dm="handleOpenDm"
               @open-thread="openThread"
               @join-channel-call="joinChannelCallFromActivity"
+              @leave-channel-call="leaveRetainedChannelCall"
               @answer-dm="answerDmFromActivity"
               @reconnect-dm="reconnectDmFromDock"
               :invoke-extension-action="invokeActiveExtensionAction"

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref } from "vue";
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { useStore } from "@nanostores/vue";
 import {
+  $mucCallMedia,
   $mucCallParticipants,
   mucCallParticipantCounts,
 } from "@/lib/calls/muc-call-presence";
@@ -10,8 +11,16 @@ import {
   activeChannelRailCallCount,
   activeDmRailCallCount,
 } from "@/lib/calls/call-rail-counts";
-import { answerIncomingDmCallActivity, resumeDmCallActivity } from "@/lib/calls/dm-call-actions";
+import {
+  answerIncomingDmCallActivity,
+  endRecoveredDmCallAction,
+  resumeDmCallActivity,
+} from "@/lib/calls/dm-call-actions";
 import { leaveRetainedMucCallAction, startMucCallAction } from "@/lib/calls/muc-call-actions";
+import {
+  $mucCallTerminatePendingSessions,
+  hydrateMucCallTerminatePendingSessions,
+} from "@/lib/calls/muc-call-session-cache";
 import { normalizeMucServiceDomain } from "@/lib/calls/muc-call-indicators";
 import {
   $callState,
@@ -159,11 +168,13 @@ const {
  * stay O(1).
  */
 const mucCallParticipantsStore = useStore($mucCallParticipants);
+const mucCallTerminatePendingStore = useStore($mucCallTerminatePendingSessions);
+const mucCallMediaStore = useStore($mucCallMedia);
 const dmCallActivitiesStore = useStore($dmCallActivities);
 const callStateStore = useStore($callState);
 const activityGroupCallStarting = ref(false);
 const callParticipantCounts = computed<Record<string, number>>(() => {
-  return mucCallParticipantCounts(mucCallParticipantsStore.value);
+  return mucCallParticipantCounts(retainedMucCallParticipantsStore.value);
 });
 const activeChannelCallCount = computed(() => {
   return activeChannelRailCallCount(callParticipantCounts.value, callStateStore.value);
@@ -175,6 +186,23 @@ const managedMucDomain = computed(() =>
   normalizeMucServiceDomain(waddles.mucServiceJid.value) || (selfDomain.value ? `muc.${selfDomain.value}` : ""),
 );
 const selfFullJid = computed(() => getSelfFullJid() ?? null);
+const retainedMucCallParticipantsStore = computed<Record<string, string[]>>(() => {
+  const next: Record<string, string[]> = {};
+  for (const [roomJid, nicks] of Object.entries(mucCallParticipantsStore.value)) {
+    next[roomJid] = [...nicks];
+  }
+  const self = selfFullJid.value;
+  const nick = connectionStore.session?.username;
+  if (!self || !nick) return next;
+  for (const session of Object.values(mucCallTerminatePendingStore.value)) {
+    if (!session.terminatePending || session.selfFullJid !== self) continue;
+    const current = next[session.roomJid] ?? [];
+    if (!current.includes(nick)) {
+      next[session.roomJid] = [...current, nick];
+    }
+  }
+  return next;
+});
 
 const homeDashboardProps = computed(() => buildHomeDashboardProps({
   spaces: waddles.sortedSpaces.value,
@@ -186,7 +214,8 @@ const homeDashboardProps = computed(() => buildHomeDashboardProps({
   activeChannelJids: messaging.activeChannels.value,
   dmConversations: dmConversations.conversations.value,
   callParticipantCounts: callParticipantCounts.value,
-  callParticipants: mucCallParticipantsStore.value,
+  callParticipants: retainedMucCallParticipantsStore.value,
+  callMediaByRoom: mucCallMediaStore.value,
   dmCallActivities: dmCallActivitiesStore.value,
   managedMucDomain: managedMucDomain.value,
   selfFullJid: selfFullJid.value,
@@ -290,6 +319,16 @@ function answerDmFromActivity(peerJid: string, remoteFullJid: string, sid: strin
   });
 }
 
+function endRecoveredDmFromActivity(peerJid: string, sid?: string): void {
+  selectDm(peerJid);
+  void endRecoveredDmCallAction({
+    peerBareJid: peerJid,
+    sid,
+    getSender: getCallSender,
+    getSelfFullJid,
+  });
+}
+
 function joinChannelCallFromActivity(channelId: string | null, roomJid: string, media: CallMedia): void {
   ui.activeCommunitySurface.value = null;
   if (channelId) {
@@ -345,6 +384,10 @@ onMounted(() => {
   disconnectMessageToolbarLifecycle = installMessageToolbarLifecycleSuppression();
 });
 
+watch(selfFullJid, (fullJid) => {
+  hydrateMucCallTerminatePendingSessions(fullJid);
+}, { immediate: true });
+
 onUnmounted(() => {
   disconnectMessageToolbarLifecycle?.();
   disconnectMessageToolbarLifecycle = null;
@@ -363,8 +406,10 @@ onUnmounted(() => {
     <ChatMobileDrawers
       :controller="controller"
       :join-channel-call="joinChannelCallFromActivity"
+      :leave-channel-call="leaveRetainedChannelCall"
       :answer-dm="answerDmFromActivity"
       :reconnect-dm="reconnectDmFromDock"
+      :end-dm="endRecoveredDmFromActivity"
     />
     <CurrentCallPanel
       class="current-call-panel--mobile"
@@ -385,15 +430,18 @@ onUnmounted(() => {
       :active-peer-jid="dmConversations.activePeerJid.value"
       :sidebar-mode="ui.sidebarMode.value"
       :active-channel-jids="messaging.activeChannels.value"
-      :call-participants="mucCallParticipantsStore"
+      :call-participants="retainedMucCallParticipantsStore"
+      :call-media-by-room="mucCallMediaStore"
       :managed-muc-domain="managedMucDomain"
       :self-full-jid="selfFullJid"
       hide-current-call
       @select-channel="onSelectChannelFromSidebar"
       @join-channel-call="joinChannelCallFromActivity"
+      @leave-channel-call="leaveRetainedChannelCall"
       @answer-dm="answerDmFromActivity"
       @select-dm="selectDm"
       @reconnect-dm="reconnectDmFromDock"
+      @end-dm="endRecoveredDmFromActivity"
     />
 
     <!-- Desktop layout -->
@@ -442,7 +490,8 @@ onUnmounted(() => {
           :collapsed-group-ids="ui.collapsedSpaceGroupIds.value"
           :channel-unread-map="computedChannelUnreadMap"
           :call-participant-counts="callParticipantCounts"
-          :call-participants="mucCallParticipantsStore"
+          :call-participants="retainedMucCallParticipantsStore"
+          :call-media-by-room="mucCallMediaStore"
           :managed-muc-domain="managedMucDomain"
           :thread-entries-fn="(roomJid: string) => channelUnread.threadEntries(roomJid)"
           :active-community-surface="ui.activeCommunitySurface.value"
@@ -451,6 +500,7 @@ onUnmounted(() => {
           :is-threads-active="ui.activePage.value === 'threads'"
           @select-channel="onSelectChannelFromSidebar"
           @join-channel-call="joinChannelCallFromActivity"
+          @leave-channel-call="leaveRetainedChannelCall"
           @select-thread="onSelectThread"
           @select-community-surface="onSelectCommunitySurface"
           @select-threads-view="openThreads"
@@ -469,6 +519,7 @@ onUnmounted(() => {
           @answer-dm="answerDmFromActivity"
           @select-dm="selectDm"
           @reconnect-dm="reconnectDmFromDock"
+          @end-dm="endRecoveredDmFromActivity"
           @new-dm="ui.showNewDm.value = true"
         />
         <CurrentCallPanel
@@ -488,16 +539,19 @@ onUnmounted(() => {
           :active-peer-jid="dmConversations.activePeerJid.value"
           :sidebar-mode="ui.sidebarMode.value"
           :active-channel-jids="messaging.activeChannels.value"
-          :call-participants="mucCallParticipantsStore"
+          :call-participants="retainedMucCallParticipantsStore"
+          :call-media-by-room="mucCallMediaStore"
           :managed-muc-domain="managedMucDomain"
           :self-full-jid="selfFullJid"
           :show-dm-calls="ui.sidebarMode.value !== 'dms'"
           hide-current-call
           @select-channel="onSelectChannelFromSidebar"
           @join-channel-call="joinChannelCallFromActivity"
+          @leave-channel-call="leaveRetainedChannelCall"
           @answer-dm="answerDmFromActivity"
           @select-dm="selectDm"
           @reconnect-dm="reconnectDmFromDock"
+          @end-dm="endRecoveredDmFromActivity"
         />
       </div>
 
@@ -508,9 +562,11 @@ onUnmounted(() => {
         @select-channel="(id: string, roomJid?: string) => selectChannel(id, roomJid ? { roomJid } : undefined)"
         @select-channel-room="selectChannelByRoomJid"
         @join-channel-call="joinChannelCallFromActivity"
+        @leave-channel-call="leaveRetainedChannelCall"
         @answer-dm="answerDmFromActivity"
         @select-contact="handleOpenDm"
         @reconnect-dm="reconnectDmFromDock"
+        @end-dm="endRecoveredDmFromActivity"
         @open-nav="ui.showMobileNav.value = true"
       />
       <FeedPane
@@ -664,6 +720,7 @@ onUnmounted(() => {
               @leave-channel-call="leaveRetainedChannelCall"
               @answer-dm="answerDmFromActivity"
               @reconnect-dm="reconnectDmFromDock"
+              @end-dm="endRecoveredDmFromActivity"
               :invoke-extension-action="invokeActiveExtensionAction"
               @refresh-update="refreshAppUpdate"
             />

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -405,6 +405,13 @@ onUnmounted(() => {
   <div v-else class="chat-app-shell">
     <ChatMobileDrawers
       :controller="controller"
+      :active-channel-call-count="activeChannelCallCount"
+      :active-dm-call-count="activeDmCallCount"
+      :call-participant-counts="callParticipantCounts"
+      :call-participants="retainedMucCallParticipantsStore"
+      :call-media-by-room="mucCallMediaStore"
+      :managed-muc-domain="managedMucDomain"
+      :self-full-jid="selfFullJid"
       :join-channel-call="joinChannelCallFromActivity"
       :leave-channel-call="leaveRetainedChannelCall"
       :answer-dm="answerDmFromActivity"

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -129,6 +129,7 @@ const emit = defineEmits<{
   openDm: [peerJid: string];
   openThread: [threadId: string, targetMessageId?: string];
   joinChannelCall: [channelId: string | null, roomJid: string, media: CallMedia];
+  leaveChannelCall: [roomJid: string];
   answerDm: [peerJid: string, remoteFullJid: string, sid: string, media: CallMedia];
   reconnectDm: [peerJid: string, media: CallMedia];
   refreshUpdate: [];
@@ -907,6 +908,7 @@ function dayDividerLabel(createdAt: string): string {
       :dm-peer-name="dmPeer?.peerUsername ?? null"
       :self-full-jid="selfFullJid ?? null"
       @join-channel-call="(channelId, roomJid, media) => emit('joinChannelCall', channelId, roomJid, media)"
+      @leave-channel-call="(roomJid) => emit('leaveChannelCall', roomJid)"
       @answer-dm="(peerJid, remoteFullJid, sid, media) => emit('answerDm', peerJid, remoteFullJid, sid, media)"
       @reconnect-dm="(peerJid, media) => emit('reconnectDm', peerJid, media)"
     />

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -132,6 +132,7 @@ const emit = defineEmits<{
   leaveChannelCall: [roomJid: string];
   answerDm: [peerJid: string, remoteFullJid: string, sid: string, media: CallMedia];
   reconnectDm: [peerJid: string, media: CallMedia];
+  endDm: [peerJid: string, sid?: string];
   refreshUpdate: [];
   loadOlder: [];
   retryLoad: [];
@@ -911,6 +912,7 @@ function dayDividerLabel(createdAt: string): string {
       @leave-channel-call="(roomJid) => emit('leaveChannelCall', roomJid)"
       @answer-dm="(peerJid, remoteFullJid, sid, media) => emit('answerDm', peerJid, remoteFullJid, sid, media)"
       @reconnect-dm="(peerJid, media) => emit('reconnectDm', peerJid, media)"
+      @end-dm="(peerJid, sid) => emit('endDm', peerJid, sid)"
     />
     <div
       v-if="connectionNotice && connectionStatusClasses"

--- a/chat/src/components/chat/DmPanel.vue
+++ b/chat/src/components/chat/DmPanel.vue
@@ -1,13 +1,17 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { useStore } from "@nanostores/vue";
-import { ArrowRight, MessageCircle, Phone, PhoneCall, PhoneIncoming, PhoneOutgoing, Plus, Video } from "lucide-vue-next";
+import { ArrowRight, MessageCircle, Phone, PhoneCall, PhoneIncoming, PhoneOff, PhoneOutgoing, Plus, Video } from "lucide-vue-next";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import { formatTimelineStamp } from "@/channels/timeline";
 import { $callState } from "@/lib/calls/call-store";
-import { dmCallActivityAction } from "@/lib/calls/call-activity-dock";
+import {
+  canEndRecoveredDmCallActivity,
+  dmCallActivityAction,
+} from "@/lib/calls/call-activity-dock";
 import {
   $dmCallActivities,
+  dmCallActivitiesForPeer,
   dmCallResumeBlockReason,
   hasKnownDmCallMedia,
 } from "@/lib/calls/dm-call-activity";
@@ -29,6 +33,7 @@ const emit = defineEmits<{
   answerDm: [peerJid: string, remoteFullJid: string, sid: string, media: CallMedia];
   selectDm: [peerJid: string];
   reconnectDm: [peerJid: string, media: CallMedia];
+  endDm: [peerJid: string, sid?: string];
   newDm: [];
 }>();
 
@@ -57,7 +62,7 @@ const activeCallRows = computed(() =>
       since: callActivitySince(activity),
       avatarUrl: callActivityAvatarUrl(activity),
     }))
-    .filter((row) => row.peerJid && row.peerJid !== currentActiveDmPeer.value)
+    .filter((row) => row.peerJid && !isCurrentDmActivity(row.activity))
     .sort((left, right) => {
       const rightMs = timestampMs(right.activity.updatedAt);
       const leftMs = timestampMs(left.activity.updatedAt);
@@ -113,8 +118,7 @@ function dotClass(show?: DmConversation["presenceShow"]): string {
 }
 
 function hasCallActivity(peerJid: string): boolean {
-  const normalized = normalizedPeerJid(peerJid);
-  return !!normalized && !!dmCallActivities.value[normalized];
+  return dmCallActivitiesForPeer(dmCallActivities.value, peerJid, props.selfFullJid ?? null).length > 0;
 }
 
 function isHiddenCurrentCallPeer(peerJid: string): boolean {
@@ -122,9 +126,15 @@ function isHiddenCurrentCallPeer(peerJid: string): boolean {
   return !!normalized && hiddenCurrentCallPeer.value === normalized;
 }
 
+function isCurrentDmActivity(activity: DmCallActivity): boolean {
+  const current = callState.value;
+  if (current.phase !== "active" || current.kind !== "dm") return false;
+  return normalizedPeerJid(activity.peerJid) === normalizedPeerJid(current.peer) &&
+    activity.sid === current.sid;
+}
+
 function callActivity(peerJid: string): DmCallActivity | null {
-  const normalized = normalizedPeerJid(peerJid);
-  return normalized ? dmCallActivities.value[normalized] ?? null : null;
+  return dmCallActivitiesForPeer(dmCallActivities.value, peerJid, props.selfFullJid ?? null)[0] ?? null;
 }
 
 function callActivityLabel(peerJid: string): string {
@@ -181,6 +191,14 @@ function acceptedCallAvailability(activity: DmCallActivity): {
     };
   }
   if (reason === "expired-token" || reason === "invalid-token") {
+    if (canEndRecoveredDmCallActivity(activity, callState.value, props.selfFullJid ?? null)) {
+      return {
+        eyebrow: "Recovered after refresh",
+        meta: `${mediaTitle} · End available`,
+        description: `The saved reconnect details expired, but this tab can still end the call.`,
+        tone: "warning",
+      };
+    }
     return {
       eyebrow: "Expired",
       meta: `${mediaTitle} · Expired`,
@@ -355,6 +373,23 @@ function selectCallActivity(activity: DmCallActivity): void {
   }
 }
 
+function canEndCallActivity(activity: DmCallActivity): boolean {
+  return canEndRecoveredDmCallActivity(activity, callState.value, props.selfFullJid ?? null);
+}
+
+function endCallActivity(activity: DmCallActivity): void {
+  const peerJid = normalizedPeerJid(activity.peerJid);
+  if (!peerJid || !canEndCallActivity(activity)) return;
+  emit("endDm", peerJid, activity.sid);
+}
+
+function endCallActivityLabel(row: { title: string; activity: DmCallActivity }): string {
+  const media = hasKnownDmCallMedia(row.activity)
+    ? `${row.activity.media.video ? "video" : "voice"} call`
+    : "call";
+  return `End ${row.title} ${media}`;
+}
+
 function isActiveConversation(peerJid: string): boolean {
   const peer = normalizedPeerJid(peerJid);
   return !!peer && activePeer.value === peer;
@@ -436,7 +471,7 @@ function conversationRowLabel(conversation: DmConversation): string {
               {{ activeCallRows.length }}
             </span>
           </div>
-          <button
+          <div
             v-for="row in activeCallRows"
             :key="`dm-call:${row.peerJid}:${row.activity.sid}`"
             class="chat-list-row w-full min-h-16 flex items-center gap-3 rounded-lg border px-3 py-2.5 text-left group text-sidebar-muted hover:text-sidebar-foreground"
@@ -444,41 +479,55 @@ function conversationRowLabel(conversation: DmConversation): string {
               callActivityToneClass(row.activity),
               isActiveConversation(row.peerJid) ? `chat-list-row--active ${callActivityActiveToneClass(row.activity)}` : '',
             ]"
-            type="button"
-            :aria-current="isActiveConversation(row.peerJid) ? 'page' : undefined"
-            :aria-label="activeCallRowLabel(row)"
-            @click="selectCallActivity(row.activity)"
           >
-            <span class="relative shrink-0">
-              <AppAvatar :name="row.title" :src="row.avatarUrl" size="sm" />
-              <span class="absolute -right-1 -bottom-1 flex h-4 w-4 items-center justify-center rounded-full border" :class="callActivityIconClass(row.activity)">
-                <Video v-if="hasKnownDmCallMedia(row.activity) && row.activity.media.video" class="h-2.5 w-2.5" aria-hidden="true" />
-                <PhoneIncoming v-else-if="row.activity.state === 'ringing' && row.activity.direction === 'incoming'" class="h-2.5 w-2.5" aria-hidden="true" />
-                <PhoneOutgoing v-else-if="row.activity.state === 'ringing' && row.activity.direction === 'outgoing'" class="h-2.5 w-2.5" aria-hidden="true" />
-                <Phone v-else class="h-2.5 w-2.5" aria-hidden="true" />
-              </span>
-            </span>
-            <span class="min-w-0 flex-1 space-y-0.5">
-              <span class="type-meta flex items-center gap-1" :class="callActivityAccentClass(row.activity)">
-                <span class="h-1.5 w-1.5 rounded-full" :class="callActivityDotClass(row.activity)" aria-hidden="true" />
-                <span class="truncate">{{ row.eyebrow }}</span>
-              </span>
-              <span class="type-control type-strong block truncate text-sidebar-foreground">
-                {{ row.title }}
-              </span>
-              <span class="type-meta block truncate text-sidebar-muted">
-                {{ row.meta }}<template v-if="row.description"> · {{ row.description }}</template><template v-if="row.since"> · {{ row.since }}</template>
-              </span>
-            </span>
-            <span
-              class="type-meta shrink-0 rounded-full border px-2 py-1"
-              :class="callActivityPillClass(row.activity)"
-              aria-hidden="true"
+            <button
+              class="flex min-w-0 flex-1 items-center gap-3 text-left"
+              type="button"
+              :aria-current="isActiveConversation(row.peerJid) ? 'page' : undefined"
+              :aria-label="activeCallRowLabel(row)"
+              @click="selectCallActivity(row.activity)"
             >
-              {{ row.action }}
-            </span>
-            <ArrowRight class="h-3.5 w-3.5 shrink-0" :class="callActivityAccentClass(row.activity)" aria-hidden="true" />
-          </button>
+              <span class="relative shrink-0">
+                <AppAvatar :name="row.title" :src="row.avatarUrl" size="sm" />
+                <span class="absolute -right-1 -bottom-1 flex h-4 w-4 items-center justify-center rounded-full border" :class="callActivityIconClass(row.activity)">
+                  <Video v-if="hasKnownDmCallMedia(row.activity) && row.activity.media.video" class="h-2.5 w-2.5" aria-hidden="true" />
+                  <PhoneIncoming v-else-if="row.activity.state === 'ringing' && row.activity.direction === 'incoming'" class="h-2.5 w-2.5" aria-hidden="true" />
+                  <PhoneOutgoing v-else-if="row.activity.state === 'ringing' && row.activity.direction === 'outgoing'" class="h-2.5 w-2.5" aria-hidden="true" />
+                  <Phone v-else class="h-2.5 w-2.5" aria-hidden="true" />
+                </span>
+              </span>
+              <span class="min-w-0 flex-1 space-y-0.5">
+                <span class="type-meta flex items-center gap-1" :class="callActivityAccentClass(row.activity)">
+                  <span class="h-1.5 w-1.5 rounded-full" :class="callActivityDotClass(row.activity)" aria-hidden="true" />
+                  <span class="truncate">{{ row.eyebrow }}</span>
+                </span>
+                <span class="type-control type-strong block truncate text-sidebar-foreground">
+                  {{ row.title }}
+                </span>
+                <span class="type-meta block truncate text-sidebar-muted">
+                  {{ row.meta }}<template v-if="row.description"> · {{ row.description }}</template><template v-if="row.since"> · {{ row.since }}</template>
+                </span>
+              </span>
+              <span
+                class="type-meta shrink-0 rounded-full border px-2 py-1"
+                :class="callActivityPillClass(row.activity)"
+                aria-hidden="true"
+              >
+                {{ row.action }}
+              </span>
+              <ArrowRight class="h-3.5 w-3.5 shrink-0" :class="callActivityAccentClass(row.activity)" aria-hidden="true" />
+            </button>
+            <button
+              v-if="canEndCallActivity(row.activity)"
+              type="button"
+              class="chat-icon-button shrink-0 text-destructive hover:bg-destructive/10 hover:text-destructive"
+              :title="endCallActivityLabel(row)"
+              :aria-label="endCallActivityLabel(row)"
+              @click="endCallActivity(row.activity)"
+            >
+              <PhoneOff class="h-3.5 w-3.5" aria-hidden="true" />
+            </button>
+          </div>
         </section>
 
         <button

--- a/chat/src/components/chat/HomeDashboard.vue
+++ b/chat/src/components/chat/HomeDashboard.vue
@@ -33,6 +33,7 @@ import {
   hasKnownDmCallMedia,
 } from "@/lib/calls/dm-call-activity";
 import {
+  callRoomJidForChannel,
   callParticipantCountForChannel,
   mucCallParticipantPreview,
 } from "@/lib/calls/muc-call-indicators";
@@ -387,6 +388,36 @@ function channelCallCount(channel: ChannelSummary): number {
   );
 }
 
+function channelCallRoomJid(channel: ChannelSummary): string {
+  return callRoomJidForChannel(
+    channel,
+    callParticipantCounts.value,
+    activeChannelJids.value,
+    props.managedMucDomain ?? null,
+  );
+}
+
+function channelCallEntry(channel: ChannelSummary): Extract<CallActivityDockEntry, { kind: "channel" }> | null {
+  const roomJid = channelCallRoomJid(channel);
+  if (!roomJid) return null;
+  return activeCallEntries.value.find((entry): entry is Extract<CallActivityDockEntry, { kind: "channel" }> =>
+    entry.kind === "channel" &&
+    (
+      entry.channelId === channel.id ||
+      normalizeMucCallRoomJid(entry.roomJid) === roomJid
+    )
+  ) ?? null;
+}
+
+function selectHomeChannel(channel: ChannelSummary): void {
+  const callEntry = channelCallEntry(channel);
+  if (callEntry) {
+    selectCallEntry(callEntry);
+    return;
+  }
+  emit("selectChannel", channel.id);
+}
+
 function dmCallActivityFor(peerJid: string) {
   return dmCallActivitiesForPeer(dmCallActivities.value, peerJid, props.selfFullJid ?? null)[0] ?? null;
 }
@@ -473,10 +504,23 @@ function dmCallLabel(peerJid: string): string {
 
 function channelHomeAriaLabel(channel: ChannelSummary): string {
   const base = channelHomeLabel(channel, channelActivity(channel), activityStamp(channelActivity(channel).lastUpdated));
-  const count = channelCallCount(channel);
+  const callEntry = channelCallEntry(channel);
+  const count = callEntry?.participantCount ?? channelCallCount(channel);
   if (count <= 0) return base;
   const noun = count === 1 ? "person" : "people";
-  return `${base}, active call with ${count} ${noun}`;
+  const action = callEntry ? channelCallActionHint(callEntry) : "click to open call";
+  return `${base}, active call with ${count} ${noun}, ${action}`;
+}
+
+function channelCallActionHint(entry: Extract<CallActivityDockEntry, { kind: "channel" }>): string {
+  switch (callActivityDockAction(entry, callState.value, props.selfFullJid ?? null)) {
+    case "join":
+      return canLeaveRetainedChannelCallEntry(entry) ? "click to rejoin call" : "click to join call";
+    case "return":
+      return "click to return to call";
+    default:
+      return "click to open call";
+  }
 }
 
 function dmHomeAriaLabel(conversation: {
@@ -782,6 +826,7 @@ const heroQuietMessage = computed(() => {
 });
 
 const heroPrimaryChannel = computed<ChannelSummary | undefined>(() => {
+  if (heroPrimaryCall.value) return undefined;
   let best: ChannelSummary | undefined;
   let bestActivity: ChannelActivityState | undefined;
   for (const channel of props.channels) {
@@ -795,14 +840,31 @@ const heroPrimaryChannel = computed<ChannelSummary | undefined>(() => {
   return best;
 });
 
+const heroPrimaryCall = computed<CallActivityDockEntry | null>(() =>
+  activeCallEntries.value[0] ?? null,
+);
+
 const heroCtaLabel = computed(() => {
+  const call = heroPrimaryCall.value;
+  if (call) return heroCallCtaLabel(call);
   const channel = heroPrimaryChannel.value;
   return channel ? `Jump into ${channel.name}` : "Browse channels";
 });
 
 function onHeroCta() {
+  const call = heroPrimaryCall.value;
+  if (call) {
+    selectCallEntry(call);
+    return;
+  }
   const channel = heroPrimaryChannel.value;
   if (channel) emit("selectChannel", channel.id);
+}
+
+function heroCallCtaLabel(entry: CallActivityDockEntry): string {
+  const action = callEntryActionLabel(entry);
+  if (action === "Return") return `Return to ${entry.title} call`;
+  return `${action} ${entry.title} call`;
 }
 </script>
 
@@ -830,9 +892,10 @@ function onHeroCta() {
             <template v-else>{{ heroQuietMessage }}</template>
           </p>
           <button
-            v-if="heroPrimaryChannel"
+            v-if="heroPrimaryCall || heroPrimaryChannel"
             type="button"
             class="home-hero__cta"
+            :aria-label="heroCtaLabel"
             @click="onHeroCta"
           >
             {{ heroCtaLabel }}
@@ -1065,7 +1128,7 @@ function onHeroCta() {
                     : ''"
                 type="button"
                 :aria-label="channelHomeAriaLabel(channel)"
-                @click="emit('selectChannel', channel.id)"
+                @click="selectHomeChannel(channel)"
               >
                 <component :is="isForumChannel(channel) ? MessagesSquare : Hash" class="h-3.5 w-3.5 text-primary/70" />
                 <span class="min-w-0 flex-1">

--- a/chat/src/components/chat/HomeDashboard.vue
+++ b/chat/src/components/chat/HomeDashboard.vue
@@ -9,6 +9,7 @@ import {
   Phone,
   PhoneCall,
   PhoneIncoming,
+  PhoneOff,
   PhoneOutgoing,
   Users,
   Video,
@@ -21,16 +22,22 @@ import { isForumChannel } from "@/lib/channel-types";
 import {
   callActivityDockAction,
   buildCallActivityDockEntries,
+  canEndRecoveredDmCallActivity,
   callActivityDockSelection,
   type CallActivityDockEntry,
 } from "@/lib/calls/call-activity-dock";
 import { $callState } from "@/lib/calls/call-store";
-import { dmCallResumeBlockReason, hasKnownDmCallMedia } from "@/lib/calls/dm-call-activity";
+import {
+  dmCallActivitiesForPeer,
+  dmCallResumeBlockReason,
+  hasKnownDmCallMedia,
+} from "@/lib/calls/dm-call-activity";
 import {
   callParticipantCountForChannel,
   mucCallParticipantPreview,
 } from "@/lib/calls/muc-call-indicators";
 import { normalizeMucCallRoomJid } from "@/lib/calls/muc-call-presence";
+import { readRoomHasActiveCall } from "@/lib/calls/use-active-muc-call";
 import { barePeerJid } from "@/lib/xmpp/jid";
 import type { CallMedia } from "@/lib/calls/types";
 import { groupChannelsBySpace } from "@/lib/channel-grouping";
@@ -57,9 +64,11 @@ const emit = defineEmits<{
   selectChannel: [id: string, roomJid?: string];
   selectChannelRoom: [roomJid: string];
   joinChannelCall: [channelId: string | null, roomJid: string, media: CallMedia];
+  leaveChannelCall: [roomJid: string];
   answerDm: [peerJid: string, remoteFullJid: string, sid: string, media: CallMedia];
   selectContact: [jid: string];
   reconnectDm: [peerJid: string, media: CallMedia];
+  endDm: [peerJid: string, sid?: string];
   openNav: [];
 }>();
 
@@ -121,6 +130,7 @@ const visibleChannelGroups = computed(() => groups.value.filter((group) => group
 const activeChannelJids = computed(() => props.activeChannelJids ?? new Set<string>());
 const callParticipantCounts = computed(() => props.callParticipantCounts ?? {});
 const callParticipants = computed(() => props.callParticipants ?? {});
+const callMediaByRoom = computed(() => props.callMediaByRoom ?? {});
 const dmCallActivities = computed(() => props.dmCallActivities ?? {});
 const callState = useStore($callState);
 const currentActiveDmPeer = computed(() => {
@@ -153,6 +163,7 @@ const discoveredCallEntries = computed<CallActivityDockEntry[]>(() => buildCallA
   managedMucDomain: props.managedMucDomain ?? null,
   callParticipantCounts: callParticipantCounts.value,
   callParticipants: callParticipants.value,
+  callMediaByRoom: callMediaByRoom.value,
   dmCallActivities: dmCallActivities.value,
 }));
 const currentCallFallbackEntry = computed<CallActivityDockEntry | null>(() =>
@@ -217,6 +228,45 @@ function selectCallEntry(entry: CallActivityDockEntry) {
   }
 }
 
+function canEndCallEntry(entry: CallActivityDockEntry): boolean {
+  if (entry.kind === "channel") return canLeaveRetainedChannelCallEntry(entry);
+  return canEndRecoveredDmCallActivity(entry, callState.value, props.selfFullJid ?? null);
+}
+
+function endCallEntry(entry: CallActivityDockEntry): void {
+  if (!canEndCallEntry(entry)) return;
+  if (entry.kind === "channel") {
+    emit("leaveChannelCall", entry.roomJid);
+    return;
+  }
+  emit("endDm", entry.peerJid, entry.sid);
+}
+
+function endCallEntryLabel(entry: CallActivityDockEntry): string {
+  if (entry.kind === "channel") return `Leave ${entry.title} call`;
+  const media = entry.mediaKnown !== false
+    ? `${entry.media.video ? "video" : "voice"} call`
+    : "call";
+  return `End ${entry.title} ${media}`;
+}
+
+function endCallEntryButtonText(entry: CallActivityDockEntry): string {
+  return entry.kind === "channel" ? "Leave call" : "End call";
+}
+
+function canLeaveRetainedChannelCallEntry(entry: Extract<CallActivityDockEntry, { kind: "channel" }>): boolean {
+  const roomJid = normalizeMucCallRoomJid(entry.roomJid);
+  if (!roomJid || currentMucCallRoomJid() === roomJid) return false;
+  return readRoomHasActiveCall(roomJid).localResourceInCall;
+}
+
+function currentMucCallRoomJid(): string {
+  const current = callState.value;
+  if (current.phase !== "active" && current.phase !== "muc-pending") return "";
+  if (current.kind !== "muc") return "";
+  return normalizeMucCallRoomJid(current.peer);
+}
+
 function isCurrentCallEntry(entry: CallActivityDockEntry): boolean {
   const current = callState.value;
   if (current.phase === "muc-pending" || (current.phase === "active" && current.kind === "muc")) {
@@ -224,7 +274,8 @@ function isCurrentCallEntry(entry: CallActivityDockEntry): boolean {
     return normalizeMucCallRoomJid(entry.roomJid) === normalizeMucCallRoomJid(current.peer);
   }
   if (current.phase !== "active" || current.kind !== "dm" || entry.kind !== "dm") return false;
-  return entry.peerJid.toLowerCase() === barePeerJid(current.peer).toLowerCase();
+  return entry.peerJid.toLowerCase() === barePeerJid(current.peer).toLowerCase() &&
+    entry.sid === current.sid;
 }
 
 function isSameCallEntry(target: CallActivityDockEntry): (entry: CallActivityDockEntry) => boolean {
@@ -234,7 +285,8 @@ function isSameCallEntry(target: CallActivityDockEntry): (entry: CallActivityDoc
       return normalizeMucCallRoomJid(target.roomJid) === normalizeMucCallRoomJid(entry.roomJid);
     }
     if (target.kind === "dm" && entry.kind === "dm") {
-      return target.peerJid.toLowerCase() === entry.peerJid.toLowerCase();
+      return target.peerJid.toLowerCase() === entry.peerJid.toLowerCase() &&
+        target.sid === entry.sid;
     }
     return false;
   };
@@ -262,6 +314,7 @@ function buildCurrentCallFallbackEntry(): CallActivityDockEntry | null {
       title: channel?.name ?? roomJid.split("@")[0] ?? "Group call",
       participantCount: Math.max(fallbackLabels.length, 1),
       participantLabels: fallbackLabels,
+      media: current.media,
       isKnownChannel: Boolean(channel),
       isActive: false,
     };
@@ -335,8 +388,7 @@ function channelCallCount(channel: ChannelSummary): number {
 }
 
 function dmCallActivityFor(peerJid: string) {
-  const normalized = barePeerJid(peerJid).toLowerCase();
-  return normalized ? dmCallActivities.value[normalized] ?? null : null;
+  return dmCallActivitiesForPeer(dmCallActivities.value, peerJid, props.selfFullJid ?? null)[0] ?? null;
 }
 
 function groupActivity(groupId: string): HomeActivitySummary {
@@ -454,7 +506,10 @@ function callEntryStatus(entry: CallActivityDockEntry): string {
 }
 
 function callEntryKindLabel(entry: CallActivityDockEntry): string {
-  if (entry.kind === "channel") return entry.isKnownChannel ? "Group call" : "Group call syncing";
+  if (entry.kind === "channel") {
+    const media = entry.media.video ? "Group video call" : "Group call";
+    return entry.isKnownChannel ? media : `${media} syncing`;
+  }
   if (entry.mediaKnown === false) return "Call";
   return entry.media.video ? "Video call" : "Voice call";
 }
@@ -488,6 +543,14 @@ function callEntryAcceptedAvailability(entry: CallActivityDockEntry): {
     };
   }
   if (reason === "expired-token" || reason === "invalid-token") {
+    if (canEndRecoveredDmCallActivity(entry, callState.value, props.selfFullJid ?? null)) {
+      return {
+        eyebrow: "Recovered after refresh",
+        meta: `${mediaTitle} · End available`,
+        description: `The saved reconnect details expired, but this tab can still end the call.`,
+        tone: "warning",
+      };
+    }
     return {
       eyebrow: "Expired",
       meta: `${mediaTitle} · Expired`,
@@ -537,6 +600,10 @@ function callEntryDescription(entry: CallActivityDockEntry): string {
     const noun = entry.participantCount === 1 ? "person" : "people";
     const location = entry.isKnownChannel ? "this channel" : "the channel";
     const preview = callEntryParticipantPreview(entry);
+    if (entry.media.video) {
+      if (preview) return `${entry.participantCount} ${noun} connected to the video call in ${location}: ${preview}.`;
+      return `${entry.participantCount} ${noun} connected to the video call in ${location}.`;
+    }
     if (preview) return `${entry.participantCount} ${noun} connected in ${location}: ${preview}.`;
     return `${entry.participantCount} ${noun} connected in ${location}.`;
   }
@@ -641,7 +708,7 @@ function callEntryActionLabel(entry: CallActivityDockEntry): string {
     case "answer":
       return "Answer";
     case "join":
-      return "Join";
+      return entry.kind === "channel" && canLeaveRetainedChannelCallEntry(entry) ? "Rejoin" : "Join";
     case "return":
       return "Return";
     case "reconnect":
@@ -812,72 +879,88 @@ function onHeroCta() {
           </div>
         </div>
         <div class="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
-          <button
+          <div
             v-for="entry in activeCallEntries"
             :key="entry.key"
             class="chat-list-row flex min-w-0 min-h-24 flex-col items-stretch justify-between gap-3 overflow-hidden rounded-lg border px-4 py-3 text-left text-foreground transition-colors"
             :class="callEntryToneClass(entry)"
-            type="button"
-            :aria-label="callEntryLabel(entry)"
-            @click="selectCallEntry(entry)"
           >
-            <span class="flex min-w-0 items-start gap-3">
-              <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border shadow-sm" :class="callEntryIconClass(entry)">
-                <Hash v-if="entry.kind === 'channel'" class="h-4 w-4" aria-hidden="true" />
-                <Video v-else-if="entry.mediaKnown !== false && entry.media.video" class="h-4 w-4" aria-hidden="true" />
-                <PhoneIncoming v-else-if="entry.state === 'ringing' && entry.direction === 'incoming'" class="h-4 w-4" aria-hidden="true" />
-                <PhoneOutgoing v-else-if="entry.state === 'ringing' && entry.direction === 'outgoing'" class="h-4 w-4" aria-hidden="true" />
-                <Phone v-else class="h-4 w-4" aria-hidden="true" />
-              </span>
-              <span class="min-w-0 flex-1">
-                <span class="type-meta flex items-center gap-1.5" :class="callEntryAccentClass(entry)">
-                  <span class="h-1.5 w-1.5 rounded-full" :class="callEntryDotClass(entry)" aria-hidden="true" />
-                  <span class="truncate">{{ callEntryEyebrow(entry) }}</span>
+            <button
+              class="flex min-w-0 flex-1 flex-col items-stretch justify-between gap-3 text-left"
+              type="button"
+              :aria-label="callEntryLabel(entry)"
+              @click="selectCallEntry(entry)"
+            >
+              <span class="flex min-w-0 items-start gap-3">
+                <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border shadow-sm" :class="callEntryIconClass(entry)">
+                  <Video v-if="entry.kind === 'channel' && entry.media.video" class="h-4 w-4" aria-hidden="true" />
+                  <Hash v-else-if="entry.kind === 'channel'" class="h-4 w-4" aria-hidden="true" />
+                  <Video v-else-if="entry.mediaKnown !== false && entry.media.video" class="h-4 w-4" aria-hidden="true" />
+                  <PhoneIncoming v-else-if="entry.state === 'ringing' && entry.direction === 'incoming'" class="h-4 w-4" aria-hidden="true" />
+                  <PhoneOutgoing v-else-if="entry.state === 'ringing' && entry.direction === 'outgoing'" class="h-4 w-4" aria-hidden="true" />
+                  <Phone v-else class="h-4 w-4" aria-hidden="true" />
                 </span>
-                <span class="type-control type-strong mt-0.5 block truncate">{{ entry.title }}</span>
-                <span class="type-caption mt-0.5 block text-muted-foreground">
-                  {{ callEntryDescription(entry) }}
-                </span>
-                <span
-                  v-if="entry.kind === 'channel' && callEntryParticipantPreview(entry)"
-                  class="mt-2 flex min-w-0 items-center gap-2 text-muted-foreground"
-                  :title="`${callEntryParticipantPreview(entry)} in call`"
-                >
-                  <span class="flex shrink-0 pl-0.5" aria-hidden="true">
-                    <span
-                      v-for="label in callEntryVisibleParticipantLabels(entry)"
-                      :key="`${entry.key}:${label}`"
-                      class="-ml-0.5 flex h-5 w-5 first:ml-0 items-center justify-center rounded-full border border-background bg-success/15 text-[0.625rem] font-bold leading-none text-success-foreground"
-                    >
-                      {{ callEntryParticipantInitial(label) }}
+                <span class="min-w-0 flex-1">
+                  <span class="type-meta flex items-center gap-1.5" :class="callEntryAccentClass(entry)">
+                    <span class="h-1.5 w-1.5 rounded-full" :class="callEntryDotClass(entry)" aria-hidden="true" />
+                    <span class="truncate">{{ callEntryEyebrow(entry) }}</span>
+                  </span>
+                  <span class="type-control type-strong mt-0.5 block truncate">{{ entry.title }}</span>
+                  <span class="type-caption mt-0.5 block text-muted-foreground">
+                    {{ callEntryDescription(entry) }}
+                  </span>
+                  <span
+                    v-if="entry.kind === 'channel' && callEntryParticipantPreview(entry)"
+                    class="mt-2 flex min-w-0 items-center gap-2 text-muted-foreground"
+                    :title="`${callEntryParticipantPreview(entry)} in call`"
+                  >
+                    <span class="flex shrink-0 pl-0.5" aria-hidden="true">
+                      <span
+                        v-for="label in callEntryVisibleParticipantLabels(entry)"
+                        :key="`${entry.key}:${label}`"
+                        class="-ml-0.5 flex h-5 w-5 first:ml-0 items-center justify-center rounded-full border border-background bg-success/15 text-[0.625rem] font-bold leading-none text-success-foreground"
+                      >
+                        {{ callEntryParticipantInitial(label) }}
+                      </span>
+                    </span>
+                    <span class="type-meta min-w-0 truncate">
+                      {{ callEntryParticipantPreview(entry) }}
                     </span>
                   </span>
-                  <span class="type-meta min-w-0 truncate">
-                    {{ callEntryParticipantPreview(entry) }}
-                  </span>
                 </span>
               </span>
-            </span>
-            <span class="flex min-w-0 items-center gap-2">
-              <span class="type-meta min-w-0 flex-1 truncate text-muted-foreground">{{ callEntryDetail(entry) }}</span>
-              <span
-                v-if="entry.kind === 'channel'"
-                class="type-count-badge inline-flex min-w-[18px] h-[18px] shrink-0 items-center justify-center rounded-full border px-1"
-                :class="callEntryPillClass(entry)"
-                aria-hidden="true"
-              >
-                {{ entry.participantCount }}
+              <span class="flex min-w-0 items-center gap-2">
+                <span class="type-meta min-w-0 flex-1 truncate text-muted-foreground">{{ callEntryDetail(entry) }}</span>
+                <span
+                  v-if="entry.kind === 'channel'"
+                  class="type-count-badge inline-flex min-w-[18px] h-[18px] shrink-0 items-center justify-center rounded-full border px-1"
+                  :class="callEntryPillClass(entry)"
+                  aria-hidden="true"
+                >
+                  {{ entry.participantCount }}
+                </span>
+                <span
+                  class="type-meta shrink-0 rounded-full border px-2 py-1"
+                  :class="callEntryPillClass(entry)"
+                  aria-hidden="true"
+                >
+                  {{ callEntryActionLabel(entry) }}
+                </span>
+                <ArrowRight class="h-4 w-4 shrink-0" :class="callEntryAccentClass(entry)" aria-hidden="true" />
               </span>
-              <span
-                class="type-meta shrink-0 rounded-full border px-2 py-1"
-                :class="callEntryPillClass(entry)"
-                aria-hidden="true"
-              >
-                {{ callEntryActionLabel(entry) }}
-              </span>
-              <ArrowRight class="h-4 w-4 shrink-0" :class="callEntryAccentClass(entry)" aria-hidden="true" />
-            </span>
-          </button>
+            </button>
+            <button
+              v-if="canEndCallEntry(entry)"
+              type="button"
+              class="type-meta inline-flex h-8 items-center justify-center gap-1 rounded-full border border-destructive/25 bg-background/70 px-3 text-destructive hover:bg-destructive/10"
+              :title="endCallEntryLabel(entry)"
+              :aria-label="endCallEntryLabel(entry)"
+              @click="endCallEntry(entry)"
+            >
+              <PhoneOff class="h-3.5 w-3.5" aria-hidden="true" />
+              <span>{{ endCallEntryButtonText(entry) }}</span>
+            </button>
+          </div>
         </div>
       </section>
 

--- a/chat/src/components/chat/TopicsPanel.vue
+++ b/chat/src/components/chat/TopicsPanel.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, watch } from "vue";
 import { useStore } from "@nanostores/vue";
-import { CalendarDays, Camera, Hash, ListTree, MessageSquareText, MessagesSquare, Phone, Plus, Settings, Users, ChevronDown, ChevronRight, MessageCircle } from "lucide-vue-next";
+import { CalendarDays, Camera, Hash, ListTree, MessageSquareText, MessagesSquare, Phone, PhoneOff, Plus, Settings, Users, ChevronDown, ChevronRight, MessageCircle, Video } from "lucide-vue-next";
 import { isForumChannel as detectForumChannel } from "@/lib/channel-types";
 import type { ChannelSummary, SpaceSummary } from "@/lib/chat-types";
 import type { ChannelThreadInboxEntry } from "@/channels/inbox";
@@ -14,8 +14,9 @@ import {
   refreshedMucCallRooms,
   type RefreshedMucCallRoom,
 } from "@/lib/calls/muc-call-indicators";
-import { normalizeMucCallRoomJid } from "@/lib/calls/muc-call-presence";
+import { mucCallMediaForRoom, normalizeMucCallRoomJid } from "@/lib/calls/muc-call-presence";
 import { $callState } from "@/lib/calls/call-store";
+import { readRoomHasActiveCall } from "@/lib/calls/use-active-muc-call";
 import type { CallMedia } from "@/lib/calls/types";
 import type { MemberLoadState } from "@/waddles/directory";
 import Skeleton from "@/components/ui/Skeleton.vue";
@@ -60,6 +61,7 @@ const props = defineProps<{
    * richer call affordance copy; counts remain authoritative for
    * visibility. */
   callParticipants?: Record<string, string[]>;
+  callMediaByRoom?: Record<string, CallMedia>;
   /** Trusted MUC service domain for id-only channel rows. */
   managedMucDomain?: string | null;
 }>();
@@ -98,6 +100,14 @@ function channelCallAction(channel: ChannelSummary): "join" | "return" | "open" 
   return groupCallAction(roomJid);
 }
 
+function groupCallMedia(roomJid: string): CallMedia {
+  return mucCallMediaForRoom(roomJid, props.callMediaByRoom);
+}
+
+function groupCallMediaLabel(roomJid: string): string {
+  return groupCallMedia(roomJid).video ? "video call" : "call";
+}
+
 function groupCallAction(roomJid: string): "join" | "return" | "open" {
   const state = callState.value;
   if (
@@ -114,7 +124,7 @@ function groupCallAction(roomJid: string): "join" | "return" | "open" {
 function groupCallActionLabel(roomJid: string): string {
   switch (groupCallAction(roomJid)) {
     case "join":
-      return "Join";
+      return canLeaveRetainedGroupCall(roomJid) ? "Rejoin" : "Join";
     case "return":
       return "Return";
     case "open":
@@ -123,32 +133,26 @@ function groupCallActionLabel(roomJid: string): string {
 }
 
 function channelCallActionLabel(channel: ChannelSummary): string {
-  switch (channelCallAction(channel)) {
-    case "join":
-      return "Join";
-    case "return":
-      return "Return";
-    case "open":
-      return "Open";
-    default:
-      return "";
-  }
+  const roomJid = callRoomJid(channel);
+  if (!roomJid || channelCallAction(channel) === null) return "";
+  return groupCallActionLabel(roomJid);
 }
 
 function channelCallBadgeLabel(channel: ChannelSummary): string {
   const count = callParticipantCount(channel);
   const noun = count === 1 ? "person" : "people";
   const action = channelCallActionLabel(channel);
+  const media = groupCallMediaLabel(callRoomJid(channel));
   const label = action
-    ? `${action} live call, ${count} ${noun}`
-    : `Live call, ${count} ${noun}`;
+    ? `${action} live ${media}, ${count} ${noun}`
+    : `Live ${media}, ${count} ${noun}`;
   const preview = callParticipantPreviewForRoom(callRoomJid(channel));
   return preview ? `${label}: ${preview}` : label;
 }
 
 function refreshedGroupCallBadgeLabel(row: RefreshedMucCallRoom): string {
   const noun = row.participantCount === 1 ? "person" : "people";
-  const label = `${groupCallActionLabel(row.roomJid)} live call, ${row.participantCount} ${noun}`;
+  const label = `${groupCallActionLabel(row.roomJid)} live ${groupCallMediaLabel(row.roomJid)}, ${row.participantCount} ${noun}`;
   const preview = callParticipantPreviewForRoom(row.roomJid);
   return preview ? `${label}: ${preview}` : label;
 }
@@ -158,7 +162,7 @@ function refreshedGroupCallRowLabel(row: RefreshedMucCallRoom): string {
   const action = groupCallAction(row.roomJid);
   const preview = callParticipantPreviewForRoom(row.roomJid);
   const base = [
-    `${row.title}, group call syncing`,
+    `${row.title}, group ${groupCallMediaLabel(row.roomJid)} syncing`,
     `${row.participantCount} ${noun}`,
     ...(preview ? [`${preview} in call`] : []),
   ].join(", ");
@@ -206,6 +210,7 @@ const refreshedGroupCallRows = computed(() =>
     activeChannelJids: props.activeChannelJids,
     managedMucDomain: props.managedMucDomain,
     callParticipantCounts: props.callParticipantCounts,
+    callMediaByRoom: props.callMediaByRoom,
   }),
 );
 
@@ -280,6 +285,33 @@ function channelRowLabel(
   return label;
 }
 
+function canLeaveRetainedGroupCall(roomJid: string): boolean {
+  const normalized = normalizeMucCallRoomJid(roomJid);
+  if (!normalized) return false;
+  const state = callState.value;
+  if (
+    (state.phase === "active" || state.phase === "muc-pending") &&
+    state.kind === "muc" &&
+    normalizeMucCallRoomJid(state.peer) === normalized
+  ) {
+    return false;
+  }
+  return readRoomHasActiveCall(normalized).localResourceInCall;
+}
+
+function canLeaveChannelCall(channel: ChannelSummary): boolean {
+  const roomJid = callRoomJid(channel);
+  return !!roomJid && canLeaveRetainedGroupCall(roomJid);
+}
+
+function leaveChannelCallLabel(channel: ChannelSummary): string {
+  return `Leave ${channel.name} call`;
+}
+
+function leaveRefreshedGroupCallLabel(row: RefreshedMucCallRoom): string {
+  return `Leave ${row.title} call`;
+}
+
 function threadRowLabel(thread: ChannelThreadInboxEntry) {
   const summary = thread.unread > 0 ? `${thread.unread} unread` : "no unread activity";
   const replies = `${thread.replyCount} ${thread.replyCount === 1 ? "reply" : "replies"}`;
@@ -315,6 +347,7 @@ function truncateTitle(title: string | undefined, maxLen = 28): string {
 const emit = defineEmits<{
   selectChannel: [id: string | null, roomJid?: string];
   joinChannelCall: [channelId: string | null, roomJid: string, media: CallMedia];
+  leaveChannelCall: [roomJid: string];
   selectThread: [channelId: string, threadId: string];
   selectCommunitySurface: [surface: "feed" | "stories" | "events"];
   selectThreadsView: [];
@@ -328,18 +361,29 @@ const emit = defineEmits<{
 function selectChannelRow(channel: ChannelSummary): void {
   const roomJid = callRoomJid(channel);
   if (!isActiveChannelPage(channel) && channelCallAction(channel) === "join" && roomJid) {
-    emit("joinChannelCall", channel.id, roomJid, { audio: true, video: false });
+    emit("joinChannelCall", channel.id, roomJid, groupCallMedia(roomJid));
     return;
   }
   emit("selectChannel", channel.id, roomJid || undefined);
 }
 
+function leaveChannelCall(channel: ChannelSummary): void {
+  const roomJid = callRoomJid(channel);
+  if (!roomJid || !canLeaveRetainedGroupCall(roomJid)) return;
+  emit("leaveChannelCall", roomJid);
+}
+
 function selectRefreshedGroupCallRow(row: RefreshedMucCallRoom): void {
   if (groupCallAction(row.roomJid) === "join") {
-    emit("joinChannelCall", null, row.roomJid, { audio: true, video: false });
+    emit("joinChannelCall", null, row.roomJid, row.media);
     return;
   }
   emit("selectChannel", null, row.roomJid);
+}
+
+function leaveRefreshedGroupCall(row: RefreshedMucCallRoom): void {
+  if (!canLeaveRetainedGroupCall(row.roomJid)) return;
+  emit("leaveChannelCall", row.roomJid);
 }
 
 function isGroupCollapsed(groupId: string): boolean {
@@ -420,42 +464,58 @@ watch(
                 {{ refreshedGroupCallRows.length }}
               </span>
             </div>
-            <button
+            <div
               v-for="row in refreshedGroupCallRows"
               :key="row.key"
-              class="chat-list-row w-full min-h-10 flex items-center gap-2.5 px-3 py-2 text-left group text-sidebar-muted hover:bg-sidebar-accent/50 hover:text-sidebar-foreground"
-              :class="isActiveGroupCallRow(row) ? 'chat-list-row--active bg-sidebar-accent text-sidebar-foreground' : ''"
-              type="button"
-              :aria-current="isActiveGroupCallRow(row) ? 'page' : undefined"
-              :aria-label="refreshedGroupCallRowLabel(row)"
-              @click="selectRefreshedGroupCallRow(row)"
+              class="flex items-center gap-1"
             >
-              <span class="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
-                <Phone class="h-3.5 w-3.5" aria-hidden="true" />
-              </span>
-              <span class="min-w-0 flex-1">
-                <span class="type-control type-strong block truncate text-sidebar-foreground">
-                  {{ row.title }}
-                </span>
-                <span class="type-meta block truncate text-sidebar-muted" :title="row.roomJid">
-                  {{ refreshedGroupCallMeta(row) }}
-                </span>
-              </span>
-              <span
-                class="chat-badge-glow--primary type-count-badge inline-flex items-center gap-0.5 h-[18px] px-1.5 rounded-full bg-primary/15 text-primary ring-1 ring-primary/30 motion-safe:animate-pulse"
-                :title="refreshedGroupCallBadgeLabel(row)"
-                aria-hidden="true"
+              <button
+                class="chat-list-row min-h-10 flex min-w-0 flex-1 items-center gap-2.5 px-3 py-2 text-left group text-sidebar-muted hover:bg-sidebar-accent/50 hover:text-sidebar-foreground"
+                :class="isActiveGroupCallRow(row) ? 'chat-list-row--active bg-sidebar-accent text-sidebar-foreground' : ''"
+                type="button"
+                :aria-current="isActiveGroupCallRow(row) ? 'page' : undefined"
+                :aria-label="refreshedGroupCallRowLabel(row)"
+                @click="selectRefreshedGroupCallRow(row)"
               >
-                <Phone class="w-3 h-3" />
-                <span class="type-numeric leading-none">{{ row.participantCount }}</span>
-              </span>
-              <span
-                class="type-meta hidden shrink-0 rounded-md border border-primary/25 bg-primary/10 px-1.5 py-0.5 text-primary xl:inline-flex"
-                aria-hidden="true"
+                <span class="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+                  <Video v-if="row.media.video" class="h-3.5 w-3.5" aria-hidden="true" />
+                  <Phone v-else class="h-3.5 w-3.5" aria-hidden="true" />
+                </span>
+                <span class="min-w-0 flex-1">
+                  <span class="type-control type-strong block truncate text-sidebar-foreground">
+                    {{ row.title }}
+                  </span>
+                  <span class="type-meta block truncate text-sidebar-muted" :title="row.roomJid">
+                    {{ refreshedGroupCallMeta(row) }}
+                  </span>
+                </span>
+                <span
+                  class="chat-badge-glow--primary type-count-badge inline-flex items-center gap-0.5 h-[18px] px-1.5 rounded-full bg-primary/15 text-primary ring-1 ring-primary/30 motion-safe:animate-pulse"
+                  :title="refreshedGroupCallBadgeLabel(row)"
+                  aria-hidden="true"
+                >
+                  <Video v-if="row.media.video" class="w-3 h-3" />
+                  <Phone v-else class="w-3 h-3" />
+                  <span class="type-numeric leading-none">{{ row.participantCount }}</span>
+                </span>
+                <span
+                  class="type-meta hidden shrink-0 rounded-md border border-primary/25 bg-primary/10 px-1.5 py-0.5 text-primary xl:inline-flex"
+                  aria-hidden="true"
+                >
+                  {{ groupCallActionLabel(row.roomJid) }}
+                </span>
+              </button>
+              <button
+                v-if="canLeaveRetainedGroupCall(row.roomJid)"
+                type="button"
+                class="inline-flex h-10 w-9 shrink-0 items-center justify-center rounded-md text-destructive hover:bg-destructive/10"
+                :title="leaveRefreshedGroupCallLabel(row)"
+                :aria-label="leaveRefreshedGroupCallLabel(row)"
+                @click="leaveRefreshedGroupCall(row)"
               >
-                {{ groupCallActionLabel(row.roomJid) }}
-              </span>
-            </button>
+                <PhoneOff class="h-3.5 w-3.5" aria-hidden="true" />
+              </button>
+            </div>
           </section>
         </div>
 
@@ -642,84 +702,97 @@ watch(
                 </button>
               </div>
               <template v-for="{ channel, unread } in group.channels" :key="channel.id">
-              <button
-                class="chat-list-row w-full min-h-10 flex items-center gap-2.5 px-3 py-2 text-left group"
-                :class="[
-                  isActiveChannelPage(channel)
-                    ? 'chat-list-row--active bg-sidebar-accent text-sidebar-foreground'
-                    : 'text-sidebar-muted hover:bg-sidebar-accent/50 hover:text-sidebar-foreground',
-                  !isActiveChannelPage(channel) && unread.mentions > 0
-                    ? 'chat-list-row--unread chat-list-row--mention'
-                    : !isActiveChannelPage(channel) && unread.unread > 0
-                      ? 'chat-list-row--unread'
-                      : '',
-                ]"
-                :aria-current="isActiveChannelPage(channel) ? 'page' : undefined"
-                :aria-label="channelRowLabel(channel, unread, isActiveChannelPage(channel))"
-                type="button"
-                @click="selectChannelRow(channel)"
-              >
-                <component
-                  :is="channelIcon(channel)"
-                  class="w-3.5 h-3.5 flex-shrink-0 transition-colors duration-200"
-                  :class="isActiveChannelPage(channel) ? 'text-primary' : 'opacity-40 group-hover:opacity-70'"
-                />
-                <span
-                  class="type-control truncate flex-1"
+              <div class="flex items-center gap-1">
+                <button
+                  class="chat-list-row min-h-10 flex min-w-0 flex-1 items-center gap-2.5 px-3 py-2 text-left group"
                   :class="[
-                    isActiveChannelPage(channel) ? 'type-emphasis' : '',
-                    (unread.unread > 0 || hasActivity(channel.id)) && !isActiveChannelPage(channel) ? 'type-strong text-sidebar-foreground' : '',
+                    isActiveChannelPage(channel)
+                      ? 'chat-list-row--active bg-sidebar-accent text-sidebar-foreground'
+                      : 'text-sidebar-muted hover:bg-sidebar-accent/50 hover:text-sidebar-foreground',
+                    !isActiveChannelPage(channel) && unread.mentions > 0
+                      ? 'chat-list-row--unread chat-list-row--mention'
+                      : !isActiveChannelPage(channel) && unread.unread > 0
+                        ? 'chat-list-row--unread'
+                        : '',
                   ]"
-                >{{ channel.name }}</span>
-                <span
-                  v-if="detectForumChannel(channel)"
-                  class="type-badge rounded-full border border-primary/12 px-1.5 py-0.5 text-primary/70"
+                  :aria-current="isActiveChannelPage(channel) ? 'page' : undefined"
+                  :aria-label="channelRowLabel(channel, unread, isActiveChannelPage(channel))"
+                  type="button"
+                  @click="selectChannelRow(channel)"
                 >
-                  Forum
-                </span>
-                <!--
-                  XEP-0272 Muji "call ongoing in this channel" indicator.
-                  Sits before the unread/mention badges so it claims the
-                  spot closest to the channel name — Slack-Huddle and
-                  Discord-voice both place the call affordance there.
-                  Suppressed on the active channel (`!isActiveChannelPage`)
-                  since the room header's MucCallButton already shows
-                  participant count when you're inside the room. Visual
-                  language (pulsing primary ring + Phone icon + count)
-                  matches MucCallButton.vue:97-107 so the two reads as
-                  the same affordance.
-                -->
-                <span
-                  v-if="callParticipantCount(channel) > 0 && !isActiveChannelPage(channel)"
-                  class="chat-badge-glow--primary type-count-badge inline-flex items-center gap-0.5 h-[18px] px-1.5 rounded-full bg-primary/15 text-primary ring-1 ring-primary/30 motion-safe:animate-pulse"
+                  <component
+                    :is="channelIcon(channel)"
+                    class="w-3.5 h-3.5 flex-shrink-0 transition-colors duration-200"
+                    :class="isActiveChannelPage(channel) ? 'text-primary' : 'opacity-40 group-hover:opacity-70'"
+                  />
+                  <span
+                    class="type-control truncate flex-1"
+                    :class="[
+                      isActiveChannelPage(channel) ? 'type-emphasis' : '',
+                      (unread.unread > 0 || hasActivity(channel.id)) && !isActiveChannelPage(channel) ? 'type-strong text-sidebar-foreground' : '',
+                    ]"
+                  >{{ channel.name }}</span>
+                  <span
+                    v-if="detectForumChannel(channel)"
+                    class="type-badge rounded-full border border-primary/12 px-1.5 py-0.5 text-primary/70"
+                  >
+                    Forum
+                  </span>
+                  <!--
+                    XEP-0272 Muji "call ongoing in this channel" indicator.
+                    Sits before the unread/mention badges so it claims the
+                    spot closest to the channel name — Slack-Huddle and
+                    Discord-voice both place the call affordance there.
+                    Suppressed on the active channel (`!isActiveChannelPage`)
+                    since the room header's MucCallButton already shows
+                    participant count when you're inside the room. Visual
+                    language (pulsing primary ring + Phone icon + count)
+                    matches MucCallButton.vue:97-107 so the two reads as
+                    the same affordance.
+                  -->
+                  <span
+                    v-if="callParticipantCount(channel) > 0 && !isActiveChannelPage(channel)"
+                    class="chat-badge-glow--primary type-count-badge inline-flex items-center gap-0.5 h-[18px] px-1.5 rounded-full bg-primary/15 text-primary ring-1 ring-primary/30 motion-safe:animate-pulse"
                   :title="channelCallBadgeLabel(channel)"
                   aria-hidden="true"
                 >
-                  <Phone class="w-3 h-3" />
-                  <span class="type-numeric leading-none">{{ callParticipantCount(channel) }}</span>
-                  <span
-                    v-if="channelCallActionLabel(channel)"
-                    class="hidden 2xl:inline leading-none"
-                  >
-                    · {{ channelCallActionLabel(channel) }}
+                  <Video v-if="groupCallMedia(callRoomJid(channel)).video" class="w-3 h-3" />
+                  <Phone v-else class="w-3 h-3" />
+                    <span class="type-numeric leading-none">{{ callParticipantCount(channel) }}</span>
+                    <span
+                      v-if="channelCallActionLabel(channel)"
+                      class="hidden 2xl:inline leading-none"
+                    >
+                      · {{ channelCallActionLabel(channel) }}
+                    </span>
                   </span>
-                </span>
-                <span
-                  v-if="unread.mentions > 0 && !isActiveChannelPage(channel)"
-                  class="chat-list-row--mention-badge type-count-badge inline-flex min-w-[18px] h-[18px] px-1 items-center justify-center rounded-full bg-destructive text-destructive-foreground"
-                  aria-hidden="true"
-                >{{ unread.mentions }}</span>
-                <span
-                  v-else-if="unread.unread > 0 && !isActiveChannelPage(channel)"
-                  class="chat-list-row--unread-badge type-count-badge inline-flex min-w-[18px] h-[18px] px-1 items-center justify-center rounded-full bg-primary text-primary-foreground"
-                  aria-hidden="true"
-                >{{ unread.unread }}</span>
-                <span
-                  v-else-if="hasActivity(channel.id) && !isActiveChannelPage(channel)"
-                  class="w-2 h-2 bg-primary rounded-full flex-shrink-0 shadow-[0_0_6px_var(--glow-strong)]"
-                  aria-hidden="true"
-                />
-              </button>
+                  <span
+                    v-if="unread.mentions > 0 && !isActiveChannelPage(channel)"
+                    class="chat-list-row--mention-badge type-count-badge inline-flex min-w-[18px] h-[18px] px-1 items-center justify-center rounded-full bg-destructive text-destructive-foreground"
+                    aria-hidden="true"
+                  >{{ unread.mentions }}</span>
+                  <span
+                    v-else-if="unread.unread > 0 && !isActiveChannelPage(channel)"
+                    class="chat-list-row--unread-badge type-count-badge inline-flex min-w-[18px] h-[18px] px-1 items-center justify-center rounded-full bg-primary text-primary-foreground"
+                    aria-hidden="true"
+                  >{{ unread.unread }}</span>
+                  <span
+                    v-else-if="hasActivity(channel.id) && !isActiveChannelPage(channel)"
+                    class="w-2 h-2 bg-primary rounded-full flex-shrink-0 shadow-[0_0_6px_var(--glow-strong)]"
+                    aria-hidden="true"
+                  />
+                </button>
+                <button
+                  v-if="canLeaveChannelCall(channel)"
+                  type="button"
+                  class="inline-flex h-10 w-9 shrink-0 items-center justify-center rounded-md text-destructive hover:bg-destructive/10"
+                  :title="leaveChannelCallLabel(channel)"
+                  :aria-label="leaveChannelCallLabel(channel)"
+                  @click="leaveChannelCall(channel)"
+                >
+                  <PhoneOff class="h-3.5 w-3.5" aria-hidden="true" />
+                </button>
+              </div>
 
               <!-- Active threads for this channel -->
               <button

--- a/chat/src/home/dashboard-props.ts
+++ b/chat/src/home/dashboard-props.ts
@@ -3,6 +3,7 @@ import type { RosterContact } from "@/lib/xmpp/types";
 import type { DmConversation } from "@/lib/xmpp-client";
 import type { ChannelUnreadMap } from "@/home/activity";
 import type { DmCallActivity } from "@/lib/calls/dm-call-activity";
+import type { CallMedia } from "@/lib/calls/types";
 
 export interface HomeDashboardProps {
   spaces: SpaceSummary[];
@@ -14,6 +15,7 @@ export interface HomeDashboardProps {
   dmConversations?: DmConversation[];
   callParticipantCounts?: Record<string, number>;
   callParticipants?: Record<string, string[]>;
+  callMediaByRoom?: Record<string, CallMedia>;
   dmCallActivities?: Record<string, DmCallActivity>;
   managedMucDomain?: string | null;
   selfFullJid?: string | null;
@@ -39,6 +41,7 @@ export function buildHomeDashboardProps(sources: HomeDashboardSources): HomeDash
     dmConversations: sources.dmConversations,
     callParticipantCounts: sources.callParticipantCounts,
     callParticipants: sources.callParticipants,
+    callMediaByRoom: sources.callMediaByRoom,
     dmCallActivities: sources.dmCallActivities,
     managedMucDomain: sources.managedMucDomain,
     selfFullJid: sources.selfFullJid,

--- a/chat/src/lib/calls/call-activity-dock.ts
+++ b/chat/src/lib/calls/call-activity-dock.ts
@@ -7,8 +7,13 @@ import {
   callRoomJidForChannel,
   refreshedMucCallRooms,
 } from "./muc-call-indicators";
-import { normalizeMucCallRoomJid } from "./muc-call-presence";
-import { canResumeDmCallActivity, hasKnownDmCallMedia, type DmCallActivity } from "./dm-call-activity";
+import { mucCallMediaForRoom, normalizeMucCallRoomJid } from "./muc-call-presence";
+import {
+  canEndRecoveredDmCallActivity as canEndRecoveredDmCallActivityState,
+  canResumeDmCallActivity,
+  hasKnownDmCallMedia,
+  type DmCallActivity,
+} from "./dm-call-activity";
 
 export type SidebarMode = "channels" | "dms";
 
@@ -21,6 +26,7 @@ export type CallActivityDockEntry =
       title: string;
       participantCount: number;
       participantLabels: string[];
+      media: CallMedia;
       isKnownChannel: boolean;
       isActive: boolean;
     }
@@ -69,17 +75,24 @@ function activeDmCallPeerJid(state: CallState): string {
   return "";
 }
 
+function isActiveDmCall(state: CallState, peerJid: string, sid: string): boolean {
+  const activePeer = activeDmCallPeerJid(state);
+  if (!activePeer || activePeer !== peerJid) return false;
+  if (!("sid" in state)) return false;
+  return state.sid === sid;
+}
+
 export function isBusy(state: CallState): boolean {
   return state.phase !== "idle" && state.phase !== "ended";
 }
 
 export function dmCallActivityAction(
-  activity: Pick<DmCallActivity, "peerJid" | "remoteFullJid" | "mediaKnown" | "state" | "direction" | "join">,
+  activity: Pick<DmCallActivity, "peerJid" | "remoteFullJid" | "mediaKnown" | "state" | "direction" | "join" | "sid">,
   callState: CallState,
   selfFullJid?: string | null,
 ): Extract<CallActivityDockAction, "answer" | "open" | "return" | "reconnect"> {
   const peerJid = barePeerJid(activity.peerJid).toLowerCase();
-  if (peerJid && activeDmCallPeerJid(callState) === peerJid) return "return";
+  if (peerJid && isActiveDmCall(callState, peerJid, activity.sid)) return "return";
   if (
     activity.state === "ringing" &&
     activity.direction === "incoming" &&
@@ -88,6 +101,15 @@ export function dmCallActivityAction(
   ) return "answer";
   if (canResumeDmCallActivity(activity, selfFullJid) && !isBusy(callState)) return "reconnect";
   return "open";
+}
+
+export function canEndRecoveredDmCallActivity(
+  activity: Pick<DmCallActivity, "peerJid" | "remoteFullJid" | "mediaKnown" | "state" | "direction" | "join">,
+  callState: CallState,
+  selfFullJid?: string | null,
+): boolean {
+  void callState;
+  return canEndRecoveredDmCallActivityState(activity, selfFullJid);
 }
 
 export function callActivityDockAction(
@@ -116,7 +138,7 @@ export function callActivityDockSelection(
         kind: "channel-join",
         channelId: entry.channelId,
         roomJid: entry.roomJid,
-        media: { audio: true, video: false },
+        media: entry.media,
       };
     }
     return {
@@ -156,6 +178,7 @@ export function buildCallActivityDockEntries(options: {
   managedMucDomain?: string | null;
   callParticipantCounts: Record<string, number>;
   callParticipants?: Record<string, readonly string[]>;
+  callMediaByRoom?: Record<string, CallMedia>;
   dmCallActivities: Record<string, DmCallActivity>;
 }): CallActivityDockEntry[] {
   const activeChannelRoomJid = normalizeMucCallRoomJid(options.activeChannelRoomJid ?? "");
@@ -182,6 +205,7 @@ export function buildCallActivityDockEntries(options: {
       title: channel.name,
       participantCount,
       participantLabels: participantLabelsByRoom.get(roomJid) ?? [],
+      media: mucCallMediaForRoom(roomJid, options.callMediaByRoom),
       isKnownChannel: true,
       isActive: options.sidebarMode === "channels" && (
         options.activeChannelId === channel.id || activeChannelRoomJid === roomJid
@@ -194,6 +218,7 @@ export function buildCallActivityDockEntries(options: {
     activeChannelJids: options.activeChannelJids,
     managedMucDomain: options.managedMucDomain,
     callParticipantCounts: options.callParticipantCounts,
+    callMediaByRoom: options.callMediaByRoom,
   })
     .map((room): CallActivityDockEntry => ({
       kind: "channel",
@@ -203,6 +228,7 @@ export function buildCallActivityDockEntries(options: {
       title: room.title,
       participantCount: room.participantCount,
       participantLabels: participantLabelsByRoom.get(room.roomJid) ?? [],
+      media: room.media,
       isKnownChannel: false,
       isActive: options.sidebarMode === "channels" && activeChannelRoomJid === room.roomJid,
     }));

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -12,6 +12,10 @@ import {
   applyDmCallEvent,
   clearDmCallActivity,
 } from "./dm-call-activity";
+import {
+  forgetMucCallSession,
+  rememberMucCallSession,
+} from "./muc-call-session-cache";
 import { barePeerJid } from "../xmpp/jid";
 
 /**
@@ -592,6 +596,11 @@ export async function tearDownActiveCall(
             }
             try {
               await sendMujiSessionTerminate(raw, s.peer, s.sid);
+              forgetMucCallSession({
+                roomJid: s.peer,
+                selfFullJid: s.selfFullJid,
+                sid: s.sid,
+              });
             } catch (err) {
               reportCallError(err);
             }
@@ -637,12 +646,17 @@ export async function tearDownActiveCall(
               } catch (err) {
                 reportCallError(err);
               } finally {
-                  clearMucCallParticipant(s.peer, s.selfNick, s.selfFullJid);
+                clearMucCallParticipant(s.peer, s.selfNick, s.selfFullJid);
               }
             }
             if (s.activePresencePublished) {
               try {
                 await sendMujiSessionTerminate(raw, s.peer, s.sid);
+                forgetMucCallSession({
+                  roomJid: s.peer,
+                  selfFullJid: s.selfFullJid,
+                  sid: s.sid,
+                });
               } catch (err) {
                 reportCallError(err);
               }
@@ -774,6 +788,7 @@ async function rollbackMucCallSetup(
         throw new Error("Cannot terminate Muji session without the active Jingle sid");
       }
       await sendMujiSessionTerminate(sender, roomJid, sid);
+      forgetMucCallSession({ roomJid, selfFullJid, sid });
     } catch (err) {
       reportCallError(err);
     }
@@ -971,6 +986,11 @@ export async function beginMucCall(
       join,
       kind: "muc",
       selfNick,
+      selfFullJid,
+    });
+    rememberMucCallSession({
+      roomJid: normalizedRoomJid,
+      sid: attemptId,
       selfFullJid,
     });
     $lastCallError.set(null);

--- a/chat/src/lib/calls/dm-call-actions.ts
+++ b/chat/src/lib/calls/dm-call-actions.ts
@@ -5,7 +5,12 @@ import {
   reportCallError,
   scheduleOutgoingTimeout,
 } from "./call-store";
-import { canResumeDmCallActivity, clearDmCallActivity, readDmCallActivity } from "./dm-call-activity";
+import {
+  canResumeDmCallActivity,
+  clearDmCallActivity,
+  readDmCallActivity,
+  readEndableDmCallActivity,
+} from "./dm-call-activity";
 import {
   newCallSid,
   outboundCalls,
@@ -118,8 +123,8 @@ export function resumeDmCallActivity(options: {
   const peer = barePeerJid(options.peerBareJid).toLowerCase();
   if (!peer) return false;
 
-  const activity = readDmCallActivity(peer, options.now);
   const selfFullJid = options.getSelfFullJid?.()?.trim() ?? "";
+  const activity = readDmCallActivity(peer, options.now, selfFullJid);
   if (!activity || !canResumeDmCallActivity(activity, selfFullJid, options.now)) {
     return false;
   }
@@ -133,5 +138,48 @@ export function resumeDmCallActivity(options: {
     join: activity.join,
     initiator: selfFullJid,
   });
+  return true;
+}
+
+export async function endRecoveredDmCallAction(options: {
+  peerBareJid: string;
+  sid?: string | null;
+  getSender: () => CallWireSender | null;
+  getSelfFullJid?: () => string | undefined;
+  now?: Date;
+}): Promise<boolean> {
+  const peer = barePeerJid(options.peerBareJid).toLowerCase();
+  if (!peer) return false;
+
+  const sender = options.getSender();
+  if (!sender) return false;
+
+  const selfFullJid = options.getSelfFullJid?.()?.trim() ?? "";
+  const activity = readEndableDmCallActivity(peer, selfFullJid, options.sid, options.now);
+  if (!activity) {
+    return false;
+  }
+  const remoteFullJid = activity.remoteFullJid;
+  if (!remoteFullJid) return false;
+
+  try {
+    await outboundCalls.sessionTerminate(
+      sender,
+      remoteFullJid,
+      activity.sid,
+      "success",
+    );
+  } catch (err) {
+    reportCallError(err);
+    return false;
+  }
+
+  try {
+    await outboundCalls.finish(sender, remoteFullJid, activity.sid);
+  } catch (err) {
+    reportCallError(err);
+  }
+
+  clearDmCallActivity(peer, activity.sid);
   return true;
 }

--- a/chat/src/lib/calls/dm-call-activity.ts
+++ b/chat/src/lib/calls/dm-call-activity.ts
@@ -24,6 +24,12 @@ type DmCallResumeBlockReason =
   | "other-resource"
   | "invalid-token"
   | "expired-token";
+type DmCallEndBlockReason =
+  | "missing-self"
+  | "not-accepted"
+  | "missing-peer-resource"
+  | "missing-join"
+  | "other-resource";
 
 export interface DmCallActivity {
   peerJid: string;
@@ -79,6 +85,29 @@ export function canResumeDmCallActivity(
   join: LiveKitJoin;
 } {
   return dmCallResumeBlockReason(activity, selfFullJid, now) === null;
+}
+
+export function canEndRecoveredDmCallActivity(
+  activity: Pick<DmCallActivity, "state" | "remoteFullJid" | "join">,
+  selfFullJid: string | null | undefined,
+): activity is Pick<DmCallActivity, "state" | "remoteFullJid" | "join"> & {
+  remoteFullJid: string;
+  join: LiveKitJoin;
+} {
+  return dmCallEndBlockReason(activity, selfFullJid) === null;
+}
+
+function dmCallEndBlockReason(
+  activity: Pick<DmCallActivity, "state" | "remoteFullJid" | "join">,
+  selfFullJid: string | null | undefined,
+): DmCallEndBlockReason | null {
+  const self = selfFullJid?.trim();
+  if (!self) return "missing-self";
+  if (activity.state !== "accepted") return "not-accepted";
+  if (!activity.remoteFullJid) return "missing-peer-resource";
+  if (!activity.join) return "missing-join";
+  if (activity.join.identity !== self) return "other-resource";
+  return null;
 }
 
 export function dmCallResumeBlockReason(
@@ -186,6 +215,29 @@ function isOlderThanCurrent(timestamp: string, current?: DmCallActivity): boolea
   return nextMs < currentMs;
 }
 
+function activityStorageKey(peerJid: string, sid: string, selfFullJid?: string | null): string {
+  const normalized = normalizedBare(peerJid);
+  const self = selfFullJid?.trim();
+  return self ? `${normalized}\u0000${sid}\u0000${self}` : `${normalized}\u0000${sid}`;
+}
+
+function setActivity(
+  peerJid: string,
+  sid: string,
+  selfFullJid: string | null | undefined,
+  activity: DmCallActivity,
+): void {
+  const key = activityStorageKey(peerJid, sid, selfFullJid);
+  const next = { ...$dmCallActivities.get() };
+  for (const [existingKey, existing] of Object.entries(next)) {
+    if (normalizedBare(existing.peerJid) === normalizedBare(peerJid) && existing.sid === sid && existingKey !== key) {
+      delete next[existingKey];
+    }
+  }
+  next[key] = activity;
+  $dmCallActivities.set(next);
+}
+
 function terminalKey(peerJid: string, sid: string): string {
   return `${peerJid}\u0000${sid}`;
 }
@@ -256,13 +308,14 @@ export function pruneExpiredDmCallActivities(now = new Date()): void {
   const current = $dmCallActivities.get();
   const next: Record<string, DmCallActivity> = {};
   let changed = false;
-  for (const [peerJid, activity] of Object.entries(current)) {
+  for (const [key, activity] of Object.entries(current)) {
+    const peerJid = normalizedBare(activity.peerJid);
     if (isStale(activity.updatedAt, now)) {
       recordTerminal(peerJid, activity.sid, activity.updatedAt, now);
       changed = true;
       continue;
     }
-    next[peerJid] = activity;
+    next[key] = activity;
   }
   pruneTerminalTimestamps(now);
   if (changed) {
@@ -280,8 +333,8 @@ function recordTerminal(peerJid: string, sid: string, timestamp: string, now = n
 }
 
 function peerForSid(sid: string): string {
-  for (const [peerJid, activity] of Object.entries($dmCallActivities.get())) {
-    if (activity.sid === sid) return peerJid;
+  for (const activity of Object.values($dmCallActivities.get())) {
+    if (activity.sid === sid) return normalizedBare(activity.peerJid);
   }
   return "";
 }
@@ -319,13 +372,75 @@ function remoteFullJidForEnvelope(
   return undefined;
 }
 
+function dmCallActivityEntriesForPeer(
+  activities: Record<string, DmCallActivity>,
+  peerJid: string,
+): Array<[string, DmCallActivity]> {
+  const normalized = normalizedBare(peerJid);
+  if (!normalized) return [];
+  return Object.entries(activities)
+    .filter(([, activity]) => normalizedBare(activity.peerJid) === normalized);
+}
+
+export function dmCallActivitiesForPeer(
+  activities: Record<string, DmCallActivity>,
+  peerJid: string,
+  selfFullJid?: string | null,
+): DmCallActivity[] {
+  const self = selfFullJid?.trim();
+  return dmCallActivityEntriesForPeer(activities, peerJid)
+    .map(([, activity]) => activity)
+    .sort((left, right) => compareDmCallActivityPriority(left, right, self));
+}
+
+function compareDmCallActivityPriority(
+  left: DmCallActivity,
+  right: DmCallActivity,
+  selfFullJid?: string,
+): number {
+  if (selfFullJid) {
+    const leftOwnResource = isOwnAcceptedResourceActivity(left, selfFullJid);
+    const rightOwnResource = isOwnAcceptedResourceActivity(right, selfFullJid);
+    if (leftOwnResource !== rightOwnResource) return leftOwnResource ? -1 : 1;
+  }
+  const rightMs = Date.parse(right.updatedAt);
+  const leftMs = Date.parse(left.updatedAt);
+  if (Number.isFinite(rightMs) && Number.isFinite(leftMs) && rightMs !== leftMs) {
+    return rightMs - leftMs;
+  }
+  return right.sid.localeCompare(left.sid);
+}
+
+function isOwnAcceptedResourceActivity(activity: DmCallActivity, selfFullJid: string): boolean {
+  return activity.state === "accepted" &&
+    activity.join?.identity === selfFullJid &&
+    Boolean(activity.remoteFullJid);
+}
+
+function findActivityForSid(peerJid: string, sid: string): [string, DmCallActivity] | null {
+  return dmCallActivityEntriesForPeer($dmCallActivities.get(), peerJid)
+    .find(([, activity]) => activity.sid === sid) ?? null;
+}
+
+function bestActivityForPeer(
+  peerJid: string,
+  selfFullJid?: string | null,
+): DmCallActivity | null {
+  const entries = dmCallActivitiesForPeer($dmCallActivities.get(), peerJid, selfFullJid);
+  if (entries.length === 0) return null;
+  return entries[0] ?? null;
+}
+
 function removeActivity(peerJid: string, sid: string): void {
-  const current = $dmCallActivities.get()[peerJid];
-  if (!current || current.sid !== sid) return;
-  const selfBareJid = current.join ? normalizedBare(current.join.identity) : "";
-  if (selfBareJid) forgetDmCallJoin({ selfBareJid, peerJid, sid });
+  const entries = dmCallActivityEntriesForPeer($dmCallActivities.get(), peerJid)
+    .filter(([, activity]) => activity.sid === sid);
+  if (entries.length === 0) return;
   const next = { ...$dmCallActivities.get() };
-  delete next[peerJid];
+  for (const [key, current] of entries) {
+    const selfBareJid = current.join ? normalizedBare(current.join.identity) : "";
+    if (selfBareJid) forgetDmCallJoin({ selfBareJid, peerJid: normalizedBare(current.peerJid), sid });
+    delete next[key];
+  }
   $dmCallActivities.set(next);
   scheduleActivityPrune();
 }
@@ -333,16 +448,17 @@ function removeActivity(peerJid: string, sid: string): void {
 export function clearDmCallActivity(peerJid: string, sid?: string): void {
   const normalized = normalizedBare(peerJid);
   if (!normalized) return;
-  const current = $dmCallActivities.get()[normalized];
+  const currentEntries = dmCallActivityEntriesForPeer($dmCallActivities.get(), normalized);
   const now = new Date();
   if (sid) recordTerminal(normalized, sid, now.toISOString(), now);
-  if (!current) return;
-  if (sid && current.sid !== sid) return;
-  recordTerminal(normalized, current.sid, now.toISOString(), now);
-  const selfBareJid = current.join ? normalizedBare(current.join.identity) : "";
-  if (selfBareJid) forgetDmCallJoin({ selfBareJid, peerJid: normalized, sid: current.sid });
   const next = { ...$dmCallActivities.get() };
-  delete next[normalized];
+  for (const [key, current] of currentEntries) {
+    if (sid && current.sid !== sid) continue;
+    recordTerminal(normalized, current.sid, now.toISOString(), now);
+    const selfBareJid = current.join ? normalizedBare(current.join.identity) : "";
+    if (selfBareJid) forgetDmCallJoin({ selfBareJid, peerJid: normalized, sid: current.sid });
+    delete next[key];
+  }
   $dmCallActivities.set(next);
 }
 
@@ -355,14 +471,15 @@ export function applyDmCallEvent(envelope: DmCallEventEnvelope): void {
     removeActivity(peerJid, envelope.event.sid);
     return;
   }
-  const previous = $dmCallActivities.get()[peerJid];
-  if (isOlderThanCurrent(timestamp, previous)) return;
+  const previousForSidEntry = findActivityForSid(peerJid, envelope.event.sid);
+  const previousForSid = previousForSidEntry?.[1];
+  if (isOlderThanCurrent(timestamp, previousForSid)) return;
   if (!isTerminalEvent(envelope.event) && isOlderThanTerminal(peerJid, envelope.event.sid, timestamp)) return;
   const direction = directionForEnvelope(envelope);
   const remoteFullJid = remoteFullJidForEnvelope(envelope, peerJid);
   switch (envelope.event.kind) {
     case "propose":
-      $dmCallActivities.setKey(peerJid, {
+      setActivity(peerJid, envelope.event.sid, eventSelfFullJid(envelope), {
         peerJid,
         ...(remoteFullJid ? { remoteFullJid } : {}),
         sid: envelope.event.sid,
@@ -376,7 +493,6 @@ export function applyDmCallEvent(envelope: DmCallEventEnvelope): void {
     case "proceed":
     case "session-initiate":
     case "session-accept":
-      const previousForSid = previous?.sid === envelope.event.sid ? previous : undefined;
       const eventProvidedJoin = "join" in envelope.event ? envelope.event.join : undefined;
       const cachedJoin = eventProvidedJoin
         ? null
@@ -411,7 +527,7 @@ export function applyDmCallEvent(envelope: DmCallEventEnvelope): void {
           });
         }
       }
-      $dmCallActivities.setKey(peerJid, {
+      setActivity(peerJid, envelope.event.sid, join?.identity ?? eventSelfFullJid(envelope), {
         peerJid,
         ...(nextRemoteFullJid
           ? { remoteFullJid: nextRemoteFullJid }
@@ -443,11 +559,36 @@ export function clearDmCallActivities(): void {
   dmCallTerminalTimestamps.clear();
 }
 
-export function readDmCallActivity(peerJid: string, now = new Date()): DmCallActivity | null {
+export function readDmCallActivity(
+  peerJid: string,
+  now = new Date(),
+  selfFullJid?: string | null,
+): DmCallActivity | null {
   pruneExpiredDmCallActivities(now);
-  const normalized = normalizedBare(peerJid);
-  if (!normalized) return null;
-  return $dmCallActivities.get()[normalized] ?? null;
+  return bestActivityForPeer(peerJid, selfFullJid);
+}
+
+function readDmCallActivityForSid(
+  peerJid: string,
+  sid: string | null | undefined,
+  now = new Date(),
+): DmCallActivity | null {
+  pruneExpiredDmCallActivities(now);
+  if (!sid) return readDmCallActivity(peerJid, now);
+  return findActivityForSid(peerJid, sid)?.[1] ?? null;
+}
+
+export function readEndableDmCallActivity(
+  peerJid: string,
+  selfFullJid: string | null | undefined,
+  sid?: string | null,
+  now = new Date(),
+): DmCallActivity | null {
+  pruneExpiredDmCallActivities(now);
+  const candidates = sid
+    ? [readDmCallActivityForSid(peerJid, sid, now)].filter((activity): activity is DmCallActivity => !!activity)
+    : dmCallActivitiesForPeer($dmCallActivities.get(), peerJid);
+  return candidates.find((activity) => canEndRecoveredDmCallActivity(activity, selfFullJid)) ?? null;
 }
 
 export function useDmCallActivity(
@@ -458,9 +599,7 @@ export function useDmCallActivity(
 } {
   const activities = useStore($dmCallActivities);
   const activity = computed<DmCallActivity | null>(() => {
-    const normalized = normalizedBare(peerJid());
-    if (!normalized) return null;
-    return activities.value[normalized] ?? null;
+    return dmCallActivitiesForPeer(activities.value, peerJid() ?? "")[0] ?? null;
   });
   const hasActivity = computed<boolean>(() => activity.value !== null);
   return { activity, hasActivity };

--- a/chat/src/lib/calls/muc-call-actions.ts
+++ b/chat/src/lib/calls/muc-call-actions.ts
@@ -1,5 +1,10 @@
 import { beginMucCall, reportCallError, type RawIqSender } from "./call-store";
 import { clearMucCallParticipant } from "./muc-call-presence";
+import {
+  forgetMucCallSession,
+  markMucCallSessionTerminatePending,
+  readMucCallSession,
+} from "./muc-call-session-cache";
 import type { CallMedia } from "./types";
 
 type MucCallStartActionOptions = {
@@ -63,11 +68,11 @@ export async function startMucCallAction({
 /**
  * Hard-refresh recovery path for a MUC call this browser resource
  * still advertises via Muji presence, but whose local LiveKit/call
- * state was lost with the old JS context. We no longer have the
- * per-attempt Jingle SID, so the conformant thing we can do is clear
- * this occupant's XEP-0272 presence. The server echo will remove the
- * call indicator for everyone; after the leave marker is sent, the
- * local clear makes the refreshed tab responsive immediately.
+ * state was lost with the old JS context. We clear this occupant's
+ * XEP-0272 presence first, then send the cached per-attempt Jingle
+ * `session-terminate` when available. That ordering follows
+ * XEP-0272 §Leaving while still giving the SFU the XEP-0166
+ * termination it expects.
  */
 export async function leaveRetainedMucCallAction({
   roomJid,
@@ -79,6 +84,8 @@ export async function leaveRetainedMucCallAction({
   const selfNick = getSelfNick();
   if (!sender?.update_muji_presence || !selfNick) return false;
   const selfFullJid = getSelfFullJid?.() ?? null;
+  const cachedSession = readMucCallSession({ roomJid, selfFullJid });
+  let terminated = !cachedSession;
   try {
     await sender.update_muji_presence(
       roomJid,
@@ -88,9 +95,32 @@ export async function leaveRetainedMucCallAction({
       false,
     );
     clearMucCallParticipant(roomJid, selfNick, selfFullJid);
-    return true;
   } catch (err) {
     reportCallError(err);
     return false;
   }
+  if (cachedSession) {
+    try {
+      if (!sender.send_muji_session_terminate) {
+        throw new Error(
+          "wasm client does not expose send_muji_session_terminate; rebuild the wasm bundle",
+        );
+      }
+      await sender.send_muji_session_terminate(cachedSession.roomJid, cachedSession.sid);
+      forgetMucCallSession({
+        roomJid: cachedSession.roomJid,
+        selfFullJid,
+        sid: cachedSession.sid,
+      });
+      terminated = true;
+    } catch (err) {
+      markMucCallSessionTerminatePending({
+        roomJid: cachedSession.roomJid,
+        selfFullJid,
+        sid: cachedSession.sid,
+      });
+      reportCallError(err);
+    }
+  }
+  return terminated;
 }

--- a/chat/src/lib/calls/muc-call-actions.ts
+++ b/chat/src/lib/calls/muc-call-actions.ts
@@ -94,7 +94,9 @@ export async function leaveRetainedMucCallAction({
       false,
       false,
     );
-    clearMucCallParticipant(roomJid, selfNick, selfFullJid);
+    clearMucCallParticipant(roomJid, selfNick, selfFullJid, {
+      includeAggregate: true,
+    });
   } catch (err) {
     reportCallError(err);
     return false;

--- a/chat/src/lib/calls/muc-call-actions.ts
+++ b/chat/src/lib/calls/muc-call-actions.ts
@@ -1,4 +1,5 @@
 import { beginMucCall, reportCallError, type RawIqSender } from "./call-store";
+import { clearMucCallParticipant } from "./muc-call-presence";
 import type { CallMedia } from "./types";
 
 type MucCallStartActionOptions = {
@@ -11,6 +12,13 @@ type MucCallStartActionOptions = {
   getSelfFullJid?: () => string | null | undefined;
   getExpectedMixerJid?: () => string | null | undefined;
   ensureJoined?: () => Promise<void>;
+};
+
+type RetainedMucCallLeaveActionOptions = {
+  roomJid: string;
+  getSender: () => RawIqSender | null;
+  getSelfNick: () => string | undefined;
+  getSelfFullJid?: () => string | null | undefined;
 };
 
 /**
@@ -49,5 +57,40 @@ export async function startMucCallAction({
     return false;
   } finally {
     setStarting(false);
+  }
+}
+
+/**
+ * Hard-refresh recovery path for a MUC call this browser resource
+ * still advertises via Muji presence, but whose local LiveKit/call
+ * state was lost with the old JS context. We no longer have the
+ * per-attempt Jingle SID, so the conformant thing we can do is clear
+ * this occupant's XEP-0272 presence. The server echo will remove the
+ * call indicator for everyone; after the leave marker is sent, the
+ * local clear makes the refreshed tab responsive immediately.
+ */
+export async function leaveRetainedMucCallAction({
+  roomJid,
+  getSender,
+  getSelfNick,
+  getSelfFullJid,
+}: RetainedMucCallLeaveActionOptions): Promise<boolean> {
+  const sender = getSender();
+  const selfNick = getSelfNick();
+  if (!sender?.update_muji_presence || !selfNick) return false;
+  const selfFullJid = getSelfFullJid?.() ?? null;
+  try {
+    await sender.update_muji_presence(
+      roomJid,
+      selfNick,
+      false,
+      false,
+      false,
+    );
+    clearMucCallParticipant(roomJid, selfNick, selfFullJid);
+    return true;
+  } catch (err) {
+    reportCallError(err);
+    return false;
   }
 }

--- a/chat/src/lib/calls/muc-call-indicators.ts
+++ b/chat/src/lib/calls/muc-call-indicators.ts
@@ -1,5 +1,6 @@
 import type { ChannelSummary } from "@/lib/chat-types";
-import { normalizeMucCallRoomJid } from "./muc-call-presence";
+import { mucCallMediaForRoom, normalizeMucCallRoomJid } from "./muc-call-presence";
+import type { CallMedia } from "./types";
 
 export function normalizeMucServiceDomain(serviceJid?: string | null): string {
   const bare = serviceJid?.split("/")[0]?.trim().toLowerCase() ?? "";
@@ -65,6 +66,7 @@ export type RefreshedMucCallRoom = {
   roomJid: string;
   title: string;
   participantCount: number;
+  media: CallMedia;
 };
 
 export function refreshedMucCallRooms(options: {
@@ -72,6 +74,7 @@ export function refreshedMucCallRooms(options: {
   activeChannelJids: Iterable<string>;
   managedMucDomain?: string | null;
   callParticipantCounts: Record<string, number> | undefined;
+  callMediaByRoom?: Record<string, CallMedia>;
 }): RefreshedMucCallRoom[] {
   const trustedDomain = normalizeMucServiceDomain(options.managedMucDomain);
   if (!trustedDomain || !options.callParticipantCounts) return [];
@@ -102,6 +105,7 @@ export function refreshedMucCallRooms(options: {
         roomJid,
         title,
         participantCount,
+        media: mucCallMediaForRoom(roomJid, options.callMediaByRoom),
       }];
     })
     .sort((left, right) => left.title.localeCompare(right.title));

--- a/chat/src/lib/calls/muc-call-presence.ts
+++ b/chat/src/lib/calls/muc-call-presence.ts
@@ -1,5 +1,6 @@
 import { map } from "nanostores";
 import { fullJidIdentityKey } from "@/lib/xmpp/jid";
+import type { CallMedia } from "./types";
 
 /**
  * Per-room map of nicks advertising XEP-0272 Muji presence with
@@ -26,9 +27,12 @@ type MucCallParticipantOwner = {
   realJid?: string;
 };
 export const $mucCallParticipantOwners = map<Record<string, MucCallParticipantOwner[]>>({});
+export const $mucCallMedia = map<Record<string, CallMedia>>({});
 const $mucActiveParticipants = map<Record<string, string[]>>({});
 const $mucPreparingParticipants = map<Record<string, string[]>>({});
+const $mucActiveParticipantMedia = map<Record<string, Record<string, CallMedia>>>({});
 const PARTICIPANT_KEY_SEPARATOR = "\u0000";
+const DEFAULT_MUC_CALL_MEDIA: CallMedia = { audio: true, video: false };
 
 export function normalizeMucCallRoomJid(roomJid: string): string {
   return roomJid.split("/")[0]?.trim().toLowerCase() ?? "";
@@ -83,6 +87,15 @@ export function mucCallParticipantCounts(
   return counts;
 }
 
+export function mucCallMediaForRoom(
+  roomJid: string,
+  mediaByRoom: Record<string, CallMedia> = $mucCallMedia.get(),
+): CallMedia {
+  const normalized = normalizeMucCallRoomJid(roomJid);
+  if (!normalized) return { ...DEFAULT_MUC_CALL_MEDIA };
+  return mediaByRoom[normalized] ?? { ...DEFAULT_MUC_CALL_MEDIA };
+}
+
 export function clearMucCallParticipant(
   roomJid: string,
   nick: string,
@@ -116,6 +129,9 @@ function syncActiveParticipantsForRoom(roomJid: string): void {
     const owners = { ...$mucCallParticipantOwners.get() };
     delete owners[roomJid];
     $mucCallParticipantOwners.set(owners);
+    const media = { ...$mucCallMedia.get() };
+    delete media[roomJid];
+    $mucCallMedia.set(media);
   } else {
     $mucCallParticipants.setKey(roomJid, nicks);
     $mucCallParticipantOwners.setKey(
@@ -128,14 +144,58 @@ function syncActiveParticipantsForRoom(roomJid: string): void {
         };
       }),
     );
+    $mucCallMedia.setKey(roomJid, aggregateActiveCallMedia(roomJid, activeOwners));
   }
 }
 
-function addActiveParticipant(roomJid: string, nick: string, realJid?: string | null): void {
+function aggregateActiveCallMedia(roomJid: string, activeOwners: readonly string[]): CallMedia {
+  const mediaByParticipant = $mucActiveParticipantMedia.get()[roomJid] ?? {};
+  let audio = false;
+  let video = false;
+  for (const key of activeOwners) {
+    const media = mediaByParticipant[key] ?? DEFAULT_MUC_CALL_MEDIA;
+    audio ||= media.audio;
+    video ||= media.video;
+  }
+  return { audio: audio || activeOwners.length > 0, video };
+}
+
+function setActiveParticipantMedia(roomJid: string, key: string, media: CallMedia): void {
+  const currentByRoom = $mucActiveParticipantMedia.get()[roomJid] ?? {};
+  $mucActiveParticipantMedia.setKey(roomJid, {
+    ...currentByRoom,
+    [key]: media,
+  });
+}
+
+function removeActiveParticipantMedia(roomJid: string, keys: readonly string[]): void {
+  if (keys.length === 0) return;
+  const currentByRoom = $mucActiveParticipantMedia.get()[roomJid] ?? {};
+  const nextByRoom = { ...currentByRoom };
+  for (const key of keys) {
+    delete nextByRoom[key];
+  }
+  if (Object.keys(nextByRoom).length === 0) {
+    const all = { ...$mucActiveParticipantMedia.get() };
+    delete all[roomJid];
+    $mucActiveParticipantMedia.set(all);
+  } else {
+    $mucActiveParticipantMedia.setKey(roomJid, nextByRoom);
+  }
+}
+
+function addActiveParticipant(
+  roomJid: string,
+  nick: string,
+  realJid?: string | null,
+  media: CallMedia = DEFAULT_MUC_CALL_MEDIA,
+): void {
   const current = $mucActiveParticipants.get()[roomJid] ?? [];
   const key = activeParticipantKey(nick, realJid);
-  if (current.includes(key)) return;
-  $mucActiveParticipants.setKey(roomJid, [...current, key]);
+  if (!current.includes(key)) {
+    $mucActiveParticipants.setKey(roomJid, [...current, key]);
+  }
+  setActiveParticipantMedia(roomJid, key, media);
   syncActiveParticipantsForRoom(roomJid);
 }
 
@@ -156,6 +216,10 @@ function removeActiveParticipant(
     return activeParticipantNick(key) !== nick;
   });
   if (next.length === current.length) return;
+  removeActiveParticipantMedia(
+    roomJid,
+    current.filter((key) => !next.includes(key)),
+  );
   if (next.length === 0) {
     const all = { ...$mucActiveParticipants.get() };
     delete all[roomJid];
@@ -187,7 +251,7 @@ export function applyMucCallPresence(
     from?: string;
     presence_type?: string;
     muc_jid?: string | null;
-    muji?: { preparing: boolean; active: boolean };
+    muji?: { preparing: boolean; active: boolean; audio?: boolean; video?: boolean };
   },
 ): void {
   if (!presence.from) return;
@@ -222,7 +286,10 @@ export function applyMucCallPresence(
   }
 
   if (wantsActive) {
-    addActiveParticipant(roomJid, nick, presence.muc_jid);
+    addActiveParticipant(roomJid, nick, presence.muc_jid, {
+      audio: presence.muji?.audio !== false,
+      video: presence.muji?.video === true,
+    });
   } else if (shouldClear) {
     removeActiveParticipant(roomJid, nick, presence.muc_jid, {
       includeAggregate: !presence.muc_jid,
@@ -245,8 +312,10 @@ export function mucCallParticipantCount(roomJid: string): number {
 export function clearMucCallParticipants(): void {
   $mucCallParticipants.set({});
   $mucCallParticipantOwners.set({});
+  $mucCallMedia.set({});
   $mucActiveParticipants.set({});
   $mucPreparingParticipants.set({});
+  $mucActiveParticipantMedia.set({});
   // Drop any pending preparing-echo waiters too — they'd otherwise
   // resolve when the next presence echo arrives after reconnect,
   // which would race the new login's call setup.

--- a/chat/src/lib/calls/muc-call-presence.ts
+++ b/chat/src/lib/calls/muc-call-presence.ts
@@ -100,11 +100,12 @@ export function clearMucCallParticipant(
   roomJid: string,
   nick: string,
   realJid?: string | null,
+  options: { includeAggregate?: boolean } = {},
 ): void {
   const normalized = normalizeMucCallRoomJid(roomJid);
   if (!normalized || !nick) return;
   removeActiveParticipant(normalized, nick, realJid, {
-    includeAggregate: !realJid,
+    includeAggregate: options.includeAggregate ?? !realJid,
   });
   if (realJid) return;
   const current = $mucCallParticipants.get()[normalized] ?? [];

--- a/chat/src/lib/calls/muc-call-session-cache.ts
+++ b/chat/src/lib/calls/muc-call-session-cache.ts
@@ -1,0 +1,291 @@
+import { barePeerJid } from "@/lib/xmpp/jid";
+import { normalizeMucCallRoomJid } from "./muc-call-presence";
+import { reportError } from "@/lib/telemetry";
+import { map } from "nanostores";
+
+const CACHE_PREFIX = "waddle.chat.muc-call-sessions";
+const CACHE_WINDOW_MS = 24 * 60 * 60 * 1000;
+const MAX_CACHE_ENTRIES = 64;
+
+type CachedMucCallSession = {
+  roomJid: string;
+  sid: string;
+  selfFullJid: string;
+  updatedAt: string;
+  terminatePending?: boolean;
+};
+
+export const $mucCallTerminatePendingSessions = map<Record<string, CachedMucCallSession>>({});
+
+export function rememberMucCallSession(options: {
+  roomJid: string;
+  sid: string;
+  selfFullJid?: string | null;
+  now?: Date;
+}): void {
+  const entry = normalizeEntry({
+    roomJid: options.roomJid,
+    sid: options.sid,
+    selfFullJid: options.selfFullJid?.trim() ?? "",
+    updatedAt: options.now?.toISOString() ?? new Date().toISOString(),
+  });
+  if (!entry) return;
+  forgetPendingEntry(entry);
+  const selfBare = normalizedBare(entry.selfFullJid);
+  if (!selfBare) return;
+  const now = options.now ?? new Date();
+  const entries = readEntries(selfBare)
+    .filter((candidate) => !isExpired(candidate.updatedAt, now))
+    .filter((candidate) =>
+      candidate.roomJid !== entry.roomJid ||
+      candidate.sid !== entry.sid ||
+      candidate.selfFullJid !== entry.selfFullJid
+    );
+  entries.unshift(entry);
+  writeEntries(selfBare, entries.slice(0, MAX_CACHE_ENTRIES));
+}
+
+export function readMucCallSession(options: {
+  roomJid: string;
+  selfFullJid?: string | null;
+  now?: Date;
+}): CachedMucCallSession | null {
+  const roomJid = normalizeMucCallRoomJid(options.roomJid);
+  const selfFullJid = options.selfFullJid?.trim() ?? "";
+  const selfBare = normalizedBare(selfFullJid);
+  if (!roomJid || !selfFullJid || !selfBare) return null;
+
+  const now = options.now ?? new Date();
+  let changed = false;
+  const freshEntries = readEntries(selfBare).filter((entry) => {
+    const keep = !isExpired(entry.updatedAt, now);
+    changed ||= !keep;
+    return keep;
+  });
+  if (changed) writeEntries(selfBare, freshEntries);
+
+  const entry = freshEntries.find((entry) =>
+    entry.roomJid === roomJid &&
+    entry.selfFullJid === selfFullJid
+  ) ?? null;
+  syncPendingEntries(freshEntries.filter((candidate) => candidate.terminatePending));
+  return entry;
+}
+
+export function markMucCallSessionTerminatePending(options: {
+  roomJid: string;
+  sid: string;
+  selfFullJid?: string | null;
+  now?: Date;
+}): void {
+  const entry = normalizeEntry({
+    roomJid: options.roomJid,
+    sid: options.sid,
+    selfFullJid: options.selfFullJid?.trim() ?? "",
+    updatedAt: options.now?.toISOString() ?? new Date().toISOString(),
+    terminatePending: true,
+  });
+  if (!entry) return;
+  const selfBare = normalizedBare(entry.selfFullJid);
+  if (!selfBare) return;
+  const now = options.now ?? new Date();
+  const entries = readEntries(selfBare)
+    .filter((candidate) => !isExpired(candidate.updatedAt, now))
+    .map((candidate) => (
+      candidate.roomJid === entry.roomJid &&
+      candidate.sid === entry.sid &&
+      candidate.selfFullJid === entry.selfFullJid
+        ? { ...candidate, terminatePending: true, updatedAt: entry.updatedAt }
+        : candidate
+    ));
+  if (!entries.some((candidate) =>
+    candidate.roomJid === entry.roomJid &&
+    candidate.sid === entry.sid &&
+    candidate.selfFullJid === entry.selfFullJid
+  )) {
+    entries.unshift(entry);
+  }
+  writeEntries(selfBare, entries.slice(0, MAX_CACHE_ENTRIES));
+  syncPendingEntries(entries.filter((candidate) => candidate.terminatePending));
+}
+
+export function forgetMucCallSession(options: {
+  roomJid: string;
+  selfFullJid?: string | null;
+  sid?: string | null;
+}): void {
+  const roomJid = normalizeMucCallRoomJid(options.roomJid);
+  const selfFullJid = options.selfFullJid?.trim() ?? "";
+  const selfBare = normalizedBare(selfFullJid);
+  if (!roomJid || !selfFullJid || !selfBare) return;
+  const entries = readEntries(selfBare);
+  const next = entries.filter((entry) =>
+    entry.roomJid !== roomJid ||
+    entry.selfFullJid !== selfFullJid ||
+    (options.sid ? entry.sid !== options.sid : false)
+  );
+  if (next.length !== entries.length) writeEntries(selfBare, next);
+  syncPendingEntries(next.filter((entry) => entry.terminatePending));
+}
+
+export function clearAllMucCallSessionCacheForTests(): void {
+  $mucCallTerminatePendingSessions.set({});
+  const s = storage();
+  if (!s) return;
+  try {
+    const keys: string[] = [];
+    for (let index = 0; index < s.length; index += 1) {
+      const key = s.key(index);
+      if (key?.startsWith(`${CACHE_PREFIX}.`)) keys.push(key);
+    }
+    for (const key of keys) s.removeItem(key);
+  } catch (err) {
+    reportError("storage.write", err, {
+      recoverable: true,
+      detail: "muc call session cache clear failed",
+    });
+  }
+}
+
+function normalizeEntry(entry: CachedMucCallSession): CachedMucCallSession | null {
+  const roomJid = normalizeMucCallRoomJid(entry.roomJid);
+  const selfFullJid = entry.selfFullJid.trim();
+  const sid = entry.sid.trim();
+  if (!roomJid || !selfFullJid || !sid) return null;
+  if (!normalizedBare(selfFullJid)) return null;
+  if (Number.isNaN(Date.parse(entry.updatedAt))) return null;
+  return {
+    roomJid,
+    sid,
+    selfFullJid,
+    updatedAt: entry.updatedAt,
+    ...(entry.terminatePending ? { terminatePending: true } : {}),
+  };
+}
+
+function readEntries(selfBareJid: string): CachedMucCallSession[] {
+  const s = storage();
+  if (!s) return [];
+  const key = cacheKey(selfBareJid);
+  try {
+    const raw = s.getItem(key);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map((entry) => isCachedMucCallSession(entry) ? normalizeEntry(entry) : null)
+      .filter((entry): entry is CachedMucCallSession => !!entry);
+  } catch (err) {
+    reportError("storage.read", err, {
+      recoverable: true,
+      detail: "muc call session cache read failed",
+      key,
+    });
+    return [];
+  }
+}
+
+function writeEntries(selfBareJid: string, entries: CachedMucCallSession[]): void {
+  const s = storage();
+  if (!s) return;
+  const key = cacheKey(selfBareJid);
+  try {
+    if (entries.length === 0) {
+      s.removeItem(key);
+      return;
+    }
+    s.setItem(key, JSON.stringify(entries));
+  } catch (err) {
+    reportError("storage.write", err, {
+      recoverable: true,
+      detail: "muc call session cache write failed",
+      key,
+    });
+  }
+}
+
+export function hydrateMucCallTerminatePendingSessions(
+  selfFullJid?: string | null,
+  now = new Date(),
+): void {
+  const selfBare = normalizedBare(selfFullJid?.trim() ?? "");
+  if (!selfBare) {
+    $mucCallTerminatePendingSessions.set({});
+    return;
+  }
+  const entries = readEntries(selfBare).filter((entry) => !isExpired(entry.updatedAt, now));
+  syncPendingEntries(entries.filter((entry) =>
+    entry.terminatePending &&
+    entry.selfFullJid === selfFullJid?.trim()
+  ));
+}
+
+export function hasPendingMucCallTerminateSession(
+  sessions: Record<string, CachedMucCallSession>,
+  roomJid: string,
+  selfFullJid?: string | null,
+): boolean {
+  const room = normalizeMucCallRoomJid(roomJid);
+  const self = selfFullJid?.trim() ?? "";
+  if (!room || !self) return false;
+  return Object.values(sessions).some((entry) =>
+    entry.terminatePending &&
+    entry.roomJid === room &&
+    entry.selfFullJid === self
+  );
+}
+
+function syncPendingEntries(entries: CachedMucCallSession[]): void {
+  const next: Record<string, CachedMucCallSession> = {};
+  for (const entry of entries) {
+    if (!entry.terminatePending) continue;
+    next[sessionKey(entry)] = entry;
+  }
+  $mucCallTerminatePendingSessions.set(next);
+}
+
+function forgetPendingEntry(entry: CachedMucCallSession): void {
+  const current = $mucCallTerminatePendingSessions.get();
+  const key = sessionKey(entry);
+  if (!(key in current)) return;
+  const next = { ...current };
+  delete next[key];
+  $mucCallTerminatePendingSessions.set(next);
+}
+
+function sessionKey(entry: Pick<CachedMucCallSession, "roomJid" | "sid" | "selfFullJid">): string {
+  return `${entry.roomJid}\u0000${entry.sid}\u0000${entry.selfFullJid}`;
+}
+
+function cacheKey(selfBareJid: string): string {
+  return `${CACHE_PREFIX}.${selfBareJid}`;
+}
+
+function normalizedBare(jid: string): string {
+  return barePeerJid(jid).toLowerCase();
+}
+
+function isExpired(timestamp: string, now: Date): boolean {
+  const ms = Date.parse(timestamp);
+  return !Number.isFinite(ms) || now.getTime() - ms > CACHE_WINDOW_MS;
+}
+
+function isCachedMucCallSession(value: unknown): value is CachedMucCallSession {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.roomJid === "string" &&
+    typeof candidate.sid === "string" &&
+    typeof candidate.selfFullJid === "string" &&
+    typeof candidate.updatedAt === "string"
+  );
+}
+
+function storage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}

--- a/chat/src/lib/calls/use-active-muc-call.ts
+++ b/chat/src/lib/calls/use-active-muc-call.ts
@@ -2,10 +2,17 @@ import { computed, type ComputedRef } from "vue";
 import { useStore } from "@nanostores/vue";
 import { $callState } from "./call-store";
 import {
+  $mucCallMedia,
   $mucCallParticipantOwners,
   $mucCallParticipants,
+  mucCallMediaForRoom,
   normalizeMucCallRoomJid,
 } from "./muc-call-presence";
+import {
+  $mucCallTerminatePendingSessions,
+  hasPendingMucCallTerminateSession,
+} from "./muc-call-session-cache";
+import type { CallMedia } from "./types";
 import { connectionStore } from "@/lib/connection-store";
 import { fullJidIdentityKey } from "@/lib/xmpp/jid";
 
@@ -32,9 +39,11 @@ export function useActiveMucCall(): {
   /** Convenience: count of nicks advertising active Muji presence in
    *  the call's room. Mirrors what `MucCallButton` displays. */
   participantCount: ComputedRef<number>;
+  media: ComputedRef<CallMedia>;
 } {
   const state = useStore($callState);
   const participants = useStore($mucCallParticipants);
+  const callMedia = useStore($mucCallMedia);
 
   const activeRoomJid = computed<string | null>(() => {
     const s = state.value;
@@ -58,7 +67,12 @@ export function useActiveMucCall(): {
     return (participants.value[roomJid] ?? []).length;
   });
 
-  return { activeRoomJid, selfInCall, participantCount };
+  const media = computed<CallMedia>(() => {
+    const roomJid = activeRoomJid.value;
+    return mediaForRoom(roomJid ?? "", state.value, callMedia.value);
+  });
+
+  return { activeRoomJid, selfInCall, participantCount, media };
 }
 
 /**
@@ -75,10 +89,13 @@ export function useRoomHasActiveCall(
   selfInCall: ComputedRef<boolean>;
   localResourceInCall: ComputedRef<boolean>;
   participantCount: ComputedRef<number>;
+  media: ComputedRef<CallMedia>;
 } {
   const state = useStore($callState);
   const participants = useStore($mucCallParticipants);
   const participantOwners = useStore($mucCallParticipantOwners);
+  const callMedia = useStore($mucCallMedia);
+  const pendingTerminates = useStore($mucCallTerminatePendingSessions);
 
   const normalizedRoomJid = computed<string | null>(() => {
     const normalized = normalizeMucCallRoomJid(roomJid());
@@ -91,11 +108,19 @@ export function useRoomHasActiveCall(
     return participants.value[room] ?? [];
   });
 
-  const hasActiveCall = computed<boolean>(() => participantList.value.length > 0);
+  const pendingTerminate = computed<boolean>(() =>
+    hasPendingMucCallTerminateSession(
+      pendingTerminates.value,
+      normalizedRoomJid.value ?? "",
+      currentClientFullJid(),
+    )
+  );
+
+  const hasActiveCall = computed<boolean>(() => participantList.value.length > 0 || pendingTerminate.value);
 
   const selfInCall = computed<boolean>(() => {
     const nick = connectionStore.session?.username;
-    return !!nick && participantList.value.includes(nick);
+    return !!nick && (participantList.value.includes(nick) || pendingTerminate.value);
   });
 
   const localResourceInCall = computed<boolean>(() => {
@@ -105,12 +130,18 @@ export function useRoomHasActiveCall(
     if (s.phase === "active" && s.kind === "muc" && normalizeMucCallRoomJid(s.peer) === room) {
       return true;
     }
-    return hasOwnerFullJid(participantOwners.value[room] ?? [], currentClientFullJid());
+    const fullJid = currentClientFullJid();
+    return hasOwnerFullJid(participantOwners.value[room] ?? [], fullJid) ||
+      hasPendingMucCallTerminateSession(pendingTerminates.value, room, fullJid);
   });
 
-  const participantCount = computed<number>(() => participantList.value.length);
+  const participantCount = computed<number>(() => Math.max(participantList.value.length, pendingTerminate.value ? 1 : 0));
 
-  return { hasActiveCall, selfInCall, localResourceInCall, participantCount };
+  const media = computed<CallMedia>(() =>
+    mediaForRoom(normalizedRoomJid.value ?? "", state.value, callMedia.value)
+  );
+
+  return { hasActiveCall, selfInCall, localResourceInCall, participantCount, media };
 }
 
 export function readRoomHasActiveCall(roomJid: string): {
@@ -118,26 +149,38 @@ export function readRoomHasActiveCall(roomJid: string): {
   selfInCall: boolean;
   localResourceInCall: boolean;
   participantCount: number;
+  media: CallMedia;
 } {
   const normalized = normalizeMucCallRoomJid(roomJid);
   if (!normalized) {
-    return { hasActiveCall: false, selfInCall: false, localResourceInCall: false, participantCount: 0 };
+    return {
+      hasActiveCall: false,
+      selfInCall: false,
+      localResourceInCall: false,
+      participantCount: 0,
+      media: mucCallMediaForRoom(""),
+    };
   }
   const participants = $mucCallParticipants.get()[normalized] ?? [];
   const participantOwners = $mucCallParticipantOwners.get()[normalized] ?? [];
+  const pendingTerminates = $mucCallTerminatePendingSessions.get();
   const nick = connectionStore.session?.username ?? null;
+  const fullJid = currentClientFullJid();
   const s = $callState.get();
+  const pendingTerminate = hasPendingMucCallTerminateSession(pendingTerminates, normalized, fullJid);
   return {
-    hasActiveCall: participants.length > 0,
-    selfInCall: !!nick && participants.includes(nick),
+    hasActiveCall: participants.length > 0 || pendingTerminate,
+    selfInCall: !!nick && (participants.includes(nick) || pendingTerminate),
     localResourceInCall:
       (
         s.phase === "active" &&
         s.kind === "muc" &&
         normalizeMucCallRoomJid(s.peer) === normalized
       ) ||
-      hasOwnerFullJid(participantOwners, currentClientFullJid()),
-    participantCount: participants.length,
+      hasOwnerFullJid(participantOwners, fullJid) ||
+      pendingTerminate,
+    participantCount: Math.max(participants.length, pendingTerminate ? 1 : 0),
+    media: mediaForRoom(normalized, s),
   };
 }
 
@@ -163,14 +206,15 @@ export function readActiveMucCall(): {
   activeRoomJid: string | null;
   selfInCall: boolean;
   participantCount: number;
+  media: CallMedia;
 } {
   const s = $callState.get();
   if (s.phase !== "active" || s.kind !== "muc") {
-    return { activeRoomJid: null, selfInCall: false, participantCount: 0 };
+    return { activeRoomJid: null, selfInCall: false, participantCount: 0, media: mucCallMediaForRoom("") };
   }
   const roomJid = normalizeMucCallRoomJid(s.peer) || null;
   if (!roomJid) {
-    return { activeRoomJid: null, selfInCall: false, participantCount: 0 };
+    return { activeRoomJid: null, selfInCall: false, participantCount: 0, media: mucCallMediaForRoom("") };
   }
   const nicks = $mucCallParticipants.get()[roomJid] ?? [];
   const nick = connectionStore.session?.username ?? null;
@@ -178,5 +222,23 @@ export function readActiveMucCall(): {
     activeRoomJid: roomJid,
     selfInCall: nick !== null && nicks.includes(nick),
     participantCount: nicks.length,
+    media: mediaForRoom(roomJid, s),
   };
+}
+
+function mediaForRoom(
+  roomJid: string,
+  state: ReturnType<typeof $callState.get>,
+  mediaByRoom?: Record<string, CallMedia>,
+): CallMedia {
+  const normalized = normalizeMucCallRoomJid(roomJid);
+  if (
+    normalized &&
+    (state.phase === "active" || state.phase === "muc-pending") &&
+    state.kind === "muc" &&
+    normalizeMucCallRoomJid(state.peer) === normalized
+  ) {
+    return state.media;
+  }
+  return mucCallMediaForRoom(normalized, mediaByRoom);
 }

--- a/chat/src/lib/calls/use-active-muc-call.ts
+++ b/chat/src/lib/calls/use-active-muc-call.ts
@@ -131,7 +131,9 @@ export function useRoomHasActiveCall(
       return true;
     }
     const fullJid = currentClientFullJid();
-    return hasOwnerFullJid(participantOwners.value[room] ?? [], fullJid) ||
+    const owners = participantOwners.value[room] ?? [];
+    return hasOwnerFullJid(owners, fullJid) ||
+      hasUnownedSelfNick(owners, connectionStore.session?.username ?? null, participantList.value) ||
       hasPendingMucCallTerminateSession(pendingTerminates.value, room, fullJid);
   });
 
@@ -178,6 +180,7 @@ export function readRoomHasActiveCall(roomJid: string): {
         normalizeMucCallRoomJid(s.peer) === normalized
       ) ||
       hasOwnerFullJid(participantOwners, fullJid) ||
+      hasUnownedSelfNick(participantOwners, nick, participants) ||
       pendingTerminate,
     participantCount: Math.max(participants.length, pendingTerminate ? 1 : 0),
     media: mediaForRoom(normalized, s),
@@ -194,6 +197,15 @@ function hasOwnerFullJid(
 ): boolean {
   if (!fullJid) return false;
   return owners.some((owner) => fullJidIdentityKey(owner.realJid) === fullJid);
+}
+
+function hasUnownedSelfNick(
+  owners: ReadonlyArray<{ nick: string; realJid?: string }>,
+  nick: string | null | undefined,
+  participants: ReadonlyArray<string>,
+): boolean {
+  if (!nick || !participants.includes(nick)) return false;
+  return owners.some((owner) => owner.nick === nick && !fullJidIdentityKey(owner.realJid));
 }
 
 /**

--- a/chat/src/lib/xmpp/resume-persistence.ts
+++ b/chat/src/lib/xmpp/resume-persistence.ts
@@ -91,7 +91,7 @@ type OwnerHandoff = {
 const SM_TTL_MS = 24 * 60 * 60 * 1000;
 const OWNER_LEASE_TTL_MS = 45_000;
 const OWNER_HEARTBEAT_MS = 15_000;
-const OWNER_HANDOFF_TTL_MS = 10_000;
+const OWNER_HANDOFF_TTL_MS = OWNER_LEASE_TTL_MS;
 const liveOwnerInstances = new Map<string, string>();
 const liveOwnerHeartbeats = new Set<string>();
 

--- a/chat/src/lib/xmpp/wasm-types.ts
+++ b/chat/src/lib/xmpp/wasm-types.ts
@@ -194,14 +194,17 @@ export interface WasmPresence {
 /**
  * XEP-0272 Muji presence extension surfaced from the WASM bindings.
  * `active` is true when the presence advertised at least one
- * `<content/>` child; `preparing` is true when a `<preparing/>`
- * sentinel was present (XEP-0272 §Joining two-phase flow).
+ * `<content/>` child; `audio` / `video` mirror the advertised RTP
+ * media content; `preparing` is true when a `<preparing/>` sentinel
+ * was present (XEP-0272 §Joining two-phase flow).
  * Absence of the field (`muji` undefined) means the occupant is NOT
  * in the call — XEP-0272 §Leaving "absence is the leave marker."
  */
 export interface WasmMujiPresence {
   preparing: boolean;
   active: boolean;
+  audio: boolean;
+  video: boolean;
 }
 
 export interface WasmArchivedMessage extends WasmMessage {

--- a/chat/tests/call-activity-dock.test.ts
+++ b/chat/tests/call-activity-dock.test.ts
@@ -26,7 +26,7 @@ import {
   $callMicEnabled,
 } from "../src/lib/calls/call-controls";
 import { $callUiMode } from "../src/lib/calls/ui-mode";
-import { applyMucCallPresence, clearMucCallParticipants, $mucCallParticipants } from "../src/lib/calls/muc-call-presence";
+import { applyMucCallPresence, clearMucCallParticipants, $mucCallMedia, $mucCallParticipants } from "../src/lib/calls/muc-call-presence";
 import { clearDmCallActivities, $dmCallActivities } from "../src/lib/calls/dm-call-activity";
 import type { DmCallActivity } from "../src/lib/calls/dm-call-activity";
 import type { CallState, LiveKitJoin } from "../src/lib/calls/types";
@@ -116,6 +116,7 @@ describe("call activity dock model", () => {
         title: "General",
         participantCount: 3,
         participantLabels: ["alice", "bob", "carol"],
+        media: { audio: true, video: false },
         isKnownChannel: true,
         isActive: true,
       },
@@ -281,6 +282,38 @@ describe("call activity dock model", () => {
     }, "alice@example.com/web")).toBe("open");
   });
 
+  test("maps advertised Muji video media into group-call join selections", () => {
+    const entries = buildCallActivityDockEntries({
+      channels: [
+        { id: "general", name: "General", jid: "general@conference.example.com" },
+      ],
+      conversations: [],
+      activeChannelId: null,
+      activePeerJid: null,
+      sidebarMode: "channels",
+      activeChannelJids: new Set(),
+      managedMucDomain: "conference.example.com",
+      callParticipantCounts: {
+        "general@conference.example.com": 2,
+      },
+      callMediaByRoom: {
+        "general@conference.example.com": { audio: true, video: true },
+      },
+      dmCallActivities: {},
+    });
+
+    expect(entries[0]).toMatchObject({
+      kind: "channel",
+      media: { audio: true, video: true },
+    });
+    expect(callActivityDockSelection(entries[0], { phase: "idle" }, "alice@example.com/web")).toEqual({
+      kind: "channel-join",
+      channelId: "general",
+      roomJid: "general@conference.example.com",
+      media: { audio: true, video: true },
+    });
+  });
+
   test("surfaces group calls while the channel directory is still loading", () => {
     const entries = buildCallActivityDockEntries({
       channels: [],
@@ -305,6 +338,7 @@ describe("call activity dock model", () => {
         title: "general",
         participantCount: 2,
         participantLabels: [],
+        media: { audio: true, video: false },
         isKnownChannel: false,
         isActive: false,
       },
@@ -337,6 +371,7 @@ describe("call activity dock model", () => {
         title: "General",
         participantCount: 3,
         participantLabels: [],
+        media: { audio: true, video: false },
         isKnownChannel: true,
         isActive: false,
       },
@@ -369,6 +404,7 @@ describe("call activity dock model", () => {
         title: "General",
         participantCount: 2,
         participantLabels: [],
+        media: { audio: true, video: false },
         isKnownChannel: true,
         isActive: false,
       },
@@ -486,6 +522,86 @@ describe("CallActivityDock rendering", () => {
     expect(html).toContain("Reconnect");
     expect(html).toContain('aria-label="Join General, Group call · 2 people, alice, bob in call"');
     expect(html).toContain('aria-label="Reconnect Bob, Video call · Live"');
+    expect(html).toContain('aria-label="End Bob video call"');
+  });
+
+  test("renders discovered group video calls with video join media", async () => {
+    $mucCallParticipants.set({
+      "general@conference.example.com": ["alice", "bob"],
+    });
+    $mucCallMedia.set({
+      "general@conference.example.com": { audio: true, video: true },
+    });
+
+    const html = await renderCallActivityDock({
+      channels: [
+        { id: "general", name: "General", jid: "general@conference.example.com" },
+      ],
+      conversations: [],
+      activeChannelId: null,
+      activePeerJid: null,
+      sidebarMode: "channels",
+      activeChannelJids: new Set(["general@conference.example.com"]),
+      managedMucDomain: "conference.example.com",
+    });
+
+    expect(html).toContain("Group video call");
+    expect(html).toContain('aria-label="Join General, Group video call · 2 people, alice, bob in call"');
+  });
+
+  test("lets the activity dock leave a retained local group call after refresh", async () => {
+    connectionStore.session = {
+      username: "alice",
+      jid: "alice@example.com",
+    } as typeof connectionStore.session;
+    connectionStore.client = {
+      fullJid: "alice@example.com/web",
+    } as unknown as typeof connectionStore.client;
+    applyMucCallPresence({
+      from: "general@conference.example.com/alice",
+      muc_jid: "alice@example.com/web",
+      muji: { preparing: false, active: true },
+    });
+    applyMucCallPresence({
+      from: "general@conference.example.com/bob",
+      muc_jid: "bob@example.com/phone",
+      muji: { preparing: false, active: true },
+    });
+    const props = {
+      channels: [{ id: "general", name: "General", jid: "general@conference.example.com" }],
+      conversations: [],
+      activeChannelId: null,
+      activePeerJid: null,
+      sidebarMode: "channels",
+      activeChannelJids: new Set(["general@conference.example.com"]),
+      managedMucDomain: "conference.example.com",
+      selfFullJid: "alice@example.com/web",
+    };
+
+    const html = await renderCallActivityDock(props);
+    expect(html).toContain('aria-label="Leave General call"');
+    expect(html).toContain("Rejoin");
+
+    const emitted: unknown[][] = [];
+    const bindings = await setupVueComponent("../src/components/calls/CallActivityDock.vue", props, (...args) => {
+      emitted.push(args);
+    });
+    setupBindingFunction(bindings, "endEntry")({
+      kind: "channel",
+      key: "channel:general",
+      channelId: "general",
+      roomJid: "general@conference.example.com",
+      title: "General",
+      participantCount: 2,
+      participantLabels: ["alice", "bob"],
+      media: { audio: true, video: false },
+      isKnownChannel: true,
+      isActive: false,
+    });
+
+    expect(emitted).toEqual([
+      ["leaveChannelCall", "general@conference.example.com"],
+    ]);
   });
 
   test("renders active group calls before channel metadata hydrates", async () => {
@@ -713,6 +829,33 @@ describe("CallActivityDock rendering", () => {
     ]);
   });
 
+  test("conversation group banner rejoins advertised video calls as video", async () => {
+    applyMucCallPresence({
+      from: "general@conference.example.com/alice",
+      muc_jid: "alice@example.com/web",
+      muji: { preparing: false, active: true, audio: true, video: true },
+    });
+    const props = {
+      roomJid: "general@conference.example.com",
+      channelId: "general",
+      channelName: "General",
+      dmPeerJid: null,
+      dmPeerName: null,
+    };
+    const html = await renderVueComponent("../src/components/calls/ConversationCallBanner.vue", props);
+    expect(html).toContain("Video call");
+
+    const emitted: unknown[][] = [];
+    const bindings = await setupVueComponent("../src/components/calls/ConversationCallBanner.vue", props, (...args) => {
+      emitted.push(args);
+    });
+    setupBindingFunction(bindings, "activateBanner")();
+
+    expect(emitted).toEqual([
+      ["joinChannelCall", "general", "general@conference.example.com", { audio: true, video: true }],
+    ]);
+  });
+
   test("keeps the conversation call live region mounted before call activity arrives", async () => {
     const html = await renderVueComponent("../src/components/calls/ConversationCallBanner.vue", {
       roomJid: "general@conference.example.com",
@@ -754,20 +897,23 @@ describe("CallActivityDock rendering", () => {
     };
     const html = await renderVueComponent("../src/components/calls/ConversationCallBanner.vue", props);
     expect(html).toContain("Call with Bob is live");
-    expect(html).toContain("Live now");
+    expect(html).toContain("Recovered after refresh");
     expect(html).toContain("Video call");
     expect(html).toContain("1:1");
-    expect(html).toContain("The video call is still live.");
+    expect(html).toContain("The video call is still live after reload.");
     expect(html).toContain("Rejoin");
+    expect(html).toContain("End call");
 
     const emitted: unknown[][] = [];
     const bindings = await setupVueComponent("../src/components/calls/ConversationCallBanner.vue", props, (...args) => {
       emitted.push(args);
     });
     setupBindingFunction(bindings, "activateBanner")();
+    setupBindingFunction(bindings, "activateSecondaryBanner")();
 
     expect(emitted).toEqual([
       ["reconnectDm", "bob@example.com", { audio: true, video: true }],
+      ["endDm", "bob@example.com", "dm-live"],
     ]);
   });
 
@@ -875,7 +1021,7 @@ describe("CallActivityDock rendering", () => {
     expect(html).not.toContain("Waiting for call details to finish syncing.");
   });
 
-  test("labels expired conversation DM banners as passive", async () => {
+  test("lets expired same-resource conversation DM banners still end the call", async () => {
     $dmCallActivities.set({
       "bob@example.com": {
         peerJid: "bob@example.com/phone",
@@ -902,9 +1048,10 @@ describe("CallActivityDock rendering", () => {
     };
     const html = await renderVueComponent("../src/components/calls/ConversationCallBanner.vue", props);
 
-    expect(html).toContain("Expired");
-    expect(html).toContain("The saved reconnect details expired.");
+    expect(html).toContain("Recovered after refresh");
+    expect(html).toContain("The saved reconnect details for this video call expired, but this tab can still end the call.");
     expect(html).toContain("Unavailable");
+    expect(html).toContain("End call");
     expect(html).not.toContain("Rejoin");
 
     const emitted: unknown[][] = [];
@@ -912,7 +1059,10 @@ describe("CallActivityDock rendering", () => {
       emitted.push(args);
     });
     setupBindingFunction(bindings, "activateBanner")();
-    expect(emitted).toEqual([]);
+    setupBindingFunction(bindings, "activateSecondaryBanner")();
+    expect(emitted).toEqual([
+      ["endDm", "bob@example.com", "dm-live-expired"],
+    ]);
   });
 
   test("suppresses header DM activity controls when the conversation banner owns them", async () => {
@@ -972,24 +1122,32 @@ describe("CallActivityDock rendering", () => {
     expect(readyShell).toContain("class=\"call-activity-dock--mobile\"");
     expect(readyShell.match(/hide-current-call/g)?.length ?? 0).toBeGreaterThanOrEqual(3);
     expect(readyShell).toContain(":join-channel-call=\"joinChannelCallFromActivity\"");
+    expect(readyShell).toContain(":leave-channel-call=\"leaveRetainedChannelCall\"");
     expect(readyShell).toContain(":answer-dm=\"answerDmFromActivity\"");
     expect(readyShell).toContain(":reconnect-dm=\"reconnectDmFromDock\"");
+    expect(readyShell).toContain(":end-dm=\"endRecoveredDmFromActivity\"");
     expect(readyShell).toContain(":active-channel-call-count=\"activeChannelCallCount\"");
     expect(readyShell).toContain(":active-dm-call-count=\"activeDmCallCount\"");
-    expect(readyShell).toContain(":call-participants=\"mucCallParticipantsStore\"");
+    expect(readyShell).toContain(":call-participants=\"retainedMucCallParticipantsStore\"");
+    expect(readyShell).toContain(":call-media-by-room=\"mucCallMediaStore\"");
     expect(readyShell).toContain("@select-channel=\"onSelectChannelFromSidebar\"");
     expect(readyShell).toContain("@join-channel-call=\"joinChannelCallFromActivity\"");
+    expect(readyShell.match(/@leave-channel-call="leaveRetainedChannelCall"/g)?.length ?? 0).toBeGreaterThanOrEqual(3);
     expect(readyShell).toContain("@answer-dm=\"answerDmFromActivity\"");
     expect(readyShell).toContain("@select-dm=\"selectDm\"");
     expect(readyShell).toContain("@reconnect-dm=\"reconnectDmFromDock\"");
+    expect(readyShell).toContain("@end-dm=\"endRecoveredDmFromActivity\"");
 
     expect(mobileDrawers).not.toContain("CallActivityDock");
     expect(mobileDrawers).toContain("@join-channel-call=\"joinChannelCallFromMobile\"");
+    expect(mobileDrawers).toContain("@leave-channel-call=\"leaveChannelCallFromMobile\"");
     expect(mobileDrawers).toContain("@answer-dm=\"answerDmFromMobile\"");
     expect(mobileDrawers).toContain("@reconnect-dm=\"reconnectDmFromMobile\"");
+    expect(mobileDrawers).toContain("@end-dm=\"endDmFromMobile\"");
     expect(mobileDrawers).toContain(":active-channel-call-count=\"activeChannelCallCount\"");
     expect(mobileDrawers).toContain(":active-dm-call-count=\"activeDmCallCount\"");
     expect(mobileDrawers).toContain(":call-participants=\"mucCallParticipantsStore\"");
+    expect(mobileDrawers).toContain(":call-media-by-room=\"mucCallMediaStore\"");
     expect(mobileDrawers).toContain("@toggle-dms=\"openDmList\"");
     expect(mobileDrawers).toContain("hide-current-call");
     expect(callActivityDock).toContain("entry.peerJid.toLowerCase() === barePeerJid(current.peer).toLowerCase()");
@@ -1003,10 +1161,12 @@ describe("CallActivityDock rendering", () => {
     expect(contentArea).toContain("@leave-channel-call=\"(roomJid) => emit('leaveChannelCall', roomJid)\"");
     expect(contentArea).toContain("@answer-dm=\"(peerJid, remoteFullJid, sid, media) => emit('answerDm', peerJid, remoteFullJid, sid, media)\"");
     expect(contentArea).toContain("@reconnect-dm=\"(peerJid, media) => emit('reconnectDm', peerJid, media)\"");
+    expect(contentArea).toContain("@end-dm=\"(peerJid, sid) => emit('endDm', peerJid, sid)\"");
     expect(readyShell).toContain("@join-channel-call=\"joinChannelCallFromActivity\"");
     expect(readyShell).toContain("@leave-channel-call=\"leaveRetainedChannelCall\"");
     expect(readyShell).toContain("@answer-dm=\"answerDmFromActivity\"");
     expect(readyShell).toContain("@reconnect-dm=\"reconnectDmFromDock\"");
+    expect(readyShell).toContain("@end-dm=\"endRecoveredDmFromActivity\"");
     expect(chatHeader).toContain("showCallActivePill?: boolean");
     expect(chatHeader).toContain("showDmCallActivityControls?: boolean");
     expect(chatHeader).toContain("hideMucStartControlsWhenActiveCall?: boolean");
@@ -1021,7 +1181,7 @@ describe("CallActivityDock rendering", () => {
     expect(mucCallButton).toContain("const roomCall = useRoomHasActiveCall(() => props.roomJid)");
     expect(mucCallButton).toContain("props.hideStartControlsWhenActiveCall && roomCall.hasActiveCall.value");
     expect(mucCallButton).toContain("v-if=\"showActivePill !== false\"");
-    expect(conversationBanner).toContain("import { dmCallActivityAction, isBusy }");
+    expect(conversationBanner).toContain("canEndRecoveredDmCallActivity");
     expect(conversationBanner).not.toContain("function isBusy");
   });
 
@@ -1047,6 +1207,7 @@ describe("CallActivityDock rendering", () => {
       emit("leaveChannelCall", "general@conference.example.com");
       emit("answerDm", "bob@example.com", "bob@example.com/phone", "sid-1", media);
       emit("reconnectDm", "bob@example.com", media);
+      emit("endDm", "bob@example.com", "sid-2");
     };
 
     try {
@@ -1056,6 +1217,7 @@ describe("CallActivityDock rendering", () => {
         onLeaveChannelCall: (...args: unknown[]) => emitted.push(["leaveChannelCall", ...args]),
         onAnswerDm: (...args: unknown[]) => emitted.push(["answerDm", ...args]),
         onReconnectDm: (...args: unknown[]) => emitted.push(["reconnectDm", ...args]),
+        onEndDm: (...args: unknown[]) => emitted.push(["endDm", ...args]),
       }));
     } finally {
       (globalThis as {
@@ -1071,6 +1233,7 @@ describe("CallActivityDock rendering", () => {
       ["leaveChannelCall", "general@conference.example.com"],
       ["answerDm", "bob@example.com", "bob@example.com/phone", "sid-1", media],
       ["reconnectDm", "bob@example.com", media],
+      ["endDm", "bob@example.com", "sid-2"],
     ]);
   });
 
@@ -1277,6 +1440,63 @@ describe("CallActivityDock rendering", () => {
     expect(dmHtml).not.toContain("bob");
   });
 
+  test("keeps different same-peer recovered call SIDs visible while the current call is hidden", async () => {
+    $callState.set({
+      phase: "active",
+      kind: "dm",
+      peer: "bob@example.com/phone",
+      sid: "dm-current",
+      media: { audio: true, video: true },
+      join: liveKitJoinFor("alice@example.com/web"),
+    });
+    $dmCallActivities.set({
+      "bob@example.com\u0000dm-current\u0000alice@example.com/web": {
+        peerJid: "bob@example.com",
+        remoteFullJid: "bob@example.com/phone",
+        sid: "dm-current",
+        media: { audio: true, video: true },
+        join: liveKitJoinFor("alice@example.com/web"),
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:00:00.000Z",
+      },
+      "bob@example.com\u0000dm-orphan\u0000alice@example.com/web": {
+        peerJid: "bob@example.com",
+        remoteFullJid: "bob@example.com/laptop",
+        sid: "dm-orphan",
+        media: { audio: true, video: false },
+        join: liveKitJoinFor("alice@example.com/web"),
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:02:00.000Z",
+      },
+    });
+
+    const dockHtml = await renderVueComponent("../src/components/calls/CallActivityDock.vue", {
+      channels: [],
+      conversations: [{ peerJid: "bob@example.com", peerUsername: "Bob" }],
+      activeChannelId: null,
+      activePeerJid: null,
+      sidebarMode: "dms",
+      activeChannelJids: new Set<string>(),
+      hideCurrentCall: true,
+      selfFullJid: "alice@example.com/web",
+    });
+    const dmHtml = await renderVueComponent("../src/components/chat/DmPanel.vue", {
+      conversations: [],
+      activePeerJid: null,
+      hideCurrentCall: true,
+      selfFullJid: "alice@example.com/web",
+    });
+
+    expect(dockHtml).toContain("Bob");
+    expect(dockHtml).toContain("Voice call · Live");
+    expect(dockHtml).toContain('aria-label="End Bob voice call"');
+    expect(dmHtml).toContain("bob");
+    expect(dmHtml).toContain("Live voice call");
+    expect(dmHtml).toContain('aria-label="End bob voice call"');
+  });
+
   test("announces no other calls when the current call is filtered out", async () => {
     $callState.set({
       phase: "active",
@@ -1365,7 +1585,7 @@ describe("CallActivityDock rendering", () => {
     expect(html).not.toContain("Video call · Live");
   });
 
-  test("downgrades expired accepted DM calls to open-only copy", async () => {
+  test("keeps expired same-resource DM calls endable in the dock", async () => {
     $dmCallActivities.set({
       "bob@example.com": {
         peerJid: "bob@example.com",
@@ -1392,8 +1612,9 @@ describe("CallActivityDock rendering", () => {
       selfFullJid: "alice@example.com/web",
     });
 
-    expect(html).toContain("Video call · Expired");
-    expect(html).toContain('aria-label="Open Bob, Video call · Expired"');
+    expect(html).toContain("Video call · End available");
+    expect(html).toContain('aria-label="Open Bob, Video call · End available"');
+    expect(html).toContain('aria-label="End Bob video call"');
     expect(html).not.toContain("Reconnect Bob");
   });
 
@@ -1551,7 +1772,7 @@ describe("CallActivityDock rendering", () => {
     expect(html).not.toContain("Reconnect bob call");
   });
 
-  test("labels expired direct calls in the direct-message panel", async () => {
+  test("keeps expired same-resource direct calls endable in the direct-message panel", async () => {
     $dmCallActivities.set({
       "bob@example.com": {
         peerJid: "bob@example.com",
@@ -1574,10 +1795,11 @@ describe("CallActivityDock rendering", () => {
       selfFullJid: "alice@example.com/web",
     });
 
-    expect(html).toContain("Expired");
-    expect(html).toContain("Video call · Expired");
-    expect(html).toContain("The saved reconnect details expired.");
-    expect(html).toContain("Open bob call, Expired, Video call · Expired");
+    expect(html).toContain("Recovered after refresh");
+    expect(html).toContain("Video call · End available");
+    expect(html).toContain("The saved reconnect details expired, but this tab can still end the call.");
+    expect(html).toContain("Open bob call, Recovered after refresh, Video call · End available");
+    expect(html).toContain('aria-label="End bob video call"');
     expect(html).not.toContain("Reconnect bob call");
   });
 
@@ -1726,8 +1948,10 @@ describe("CallActivityDock rendering", () => {
     });
 
     setupBindingFunction(bindings, "selectCallActivity")(activity);
+    setupBindingFunction(bindings, "endCallActivity")(activity);
     expect(emitted).toEqual([
       ["reconnectDm", "bob@example.com", { audio: true, video: true }],
+      ["endDm", "bob@example.com", "dm-call-9"],
     ]);
 
     $callState.set({
@@ -1957,6 +2181,85 @@ describe("CallActivityDock rendering", () => {
     expect(html).toContain("General, not selected, call ongoing with 2 participants, click to join call");
   });
 
+  test("sidebar channel rows rejoin video group calls with video enabled", async () => {
+    const emitted: unknown[][] = [];
+    const channel = { id: "general", name: "General", jid: "general@conference.example.com" };
+    const props = {
+      ...topicsPanelBaseProps(),
+      channels: [channel],
+      callParticipantCounts: {
+        "general@conference.example.com": 2,
+      },
+      callMediaByRoom: {
+        "general@conference.example.com": { audio: true, video: true },
+      },
+      managedMucDomain: "conference.example.com",
+    };
+
+    const html = await renderVueComponent("../src/components/chat/TopicsPanel.vue", props);
+    expect(html).toContain("Join live video call, 2 people");
+
+    const bindings = await setupVueComponent("../src/components/chat/TopicsPanel.vue", props, (...args) => {
+      emitted.push(args);
+    });
+    setupBindingFunction(bindings, "selectChannelRow")(channel);
+
+    expect(emitted).toEqual([
+      ["joinChannelCall", "general", "general@conference.example.com", { audio: true, video: true }],
+    ]);
+  });
+
+  test("renders sidebar leave controls for retained local group calls after refresh", async () => {
+    connectionStore.session = {
+      username: "alice",
+      jid: "alice@example.com",
+    } as typeof connectionStore.session;
+    connectionStore.client = {
+      fullJid: "alice@example.com/web",
+    } as unknown as typeof connectionStore.client;
+    applyMucCallPresence({
+      from: "general@conference.example.com/alice",
+      muc_jid: "alice@example.com/web",
+      muji: { preparing: false, active: true },
+    });
+    applyMucCallPresence({
+      from: "general@conference.example.com/bob",
+      muc_jid: "bob@example.com/phone",
+      muji: { preparing: false, active: true },
+    });
+    const props = {
+      ...topicsPanelBaseProps(),
+      channels: [
+        { id: "general", name: "General", jid: "general@conference.example.com" },
+      ],
+      callParticipantCounts: {
+        "general@conference.example.com": 2,
+      },
+      callParticipants: {
+        "general@conference.example.com": ["alice", "bob"],
+      },
+      managedMucDomain: "conference.example.com",
+    };
+
+    const html = await renderVueComponent("../src/components/chat/TopicsPanel.vue", props);
+    expect(html).toContain("Rejoin live call, 2 people");
+    expect(html).toContain('aria-label="Leave General call"');
+
+    const emitted: unknown[][] = [];
+    const bindings = await setupVueComponent("../src/components/chat/TopicsPanel.vue", props, (...args) => {
+      emitted.push(args);
+    });
+    setupBindingFunction(bindings, "leaveChannelCall")({
+      id: "general",
+      name: "General",
+      jid: "general@conference.example.com",
+    });
+
+    expect(emitted).toEqual([
+      ["leaveChannelCall", "general@conference.example.com"],
+    ]);
+  });
+
   test("renders refreshed group call rows while channel navigation is loading", async () => {
     const html = await renderVueComponent("../src/components/chat/TopicsPanel.vue", {
       ...topicsPanelBaseProps(),
@@ -1976,6 +2279,85 @@ describe("CallActivityDock rendering", () => {
     expect(html).toContain("Join live call, 2 people");
     expect(html).toContain("Join live call, 2 people: alice, bob");
     expect(html).toContain("general, group call syncing, 2 people, alice, bob in call, click to join call");
+  });
+
+  test("renders refreshed group video call rows with video join media", async () => {
+    const emitted: unknown[][] = [];
+    const props = {
+      ...topicsPanelBaseProps(),
+      isLoading: true,
+      callParticipantCounts: {
+        "general@conference.example.com": 2,
+      },
+      callParticipants: {
+        "general@conference.example.com": ["alice", "bob"],
+      },
+      callMediaByRoom: {
+        "general@conference.example.com": { audio: true, video: true },
+      },
+      managedMucDomain: "conference.example.com",
+    };
+
+    const html = await renderVueComponent("../src/components/chat/TopicsPanel.vue", props);
+    expect(html).toContain("Join live video call, 2 people");
+    expect(html).toContain("general, group video call syncing, 2 people, alice, bob in call, click to join call");
+
+    const bindings = await setupVueComponent("../src/components/chat/TopicsPanel.vue", props, (...args) => {
+      emitted.push(args);
+    });
+    const rows = (bindings.refreshedGroupCallRows as { value: Array<{ roomJid: string; media: CallMedia }> }).value;
+    expect(rows[0]?.media).toEqual({ audio: true, video: true });
+    setupBindingFunction(bindings, "selectRefreshedGroupCallRow")(rows[0]);
+
+    expect(emitted).toEqual([
+      ["joinChannelCall", null, "general@conference.example.com", { audio: true, video: true }],
+    ]);
+  });
+
+  test("renders refreshed group call leave controls for retained local resources", async () => {
+    connectionStore.session = {
+      username: "alice",
+      jid: "alice@example.com",
+    } as typeof connectionStore.session;
+    connectionStore.client = {
+      fullJid: "alice@example.com/web",
+    } as unknown as typeof connectionStore.client;
+    applyMucCallPresence({
+      from: "general@conference.example.com/alice",
+      muc_jid: "alice@example.com/web",
+      muji: { preparing: false, active: true },
+    });
+    const props = {
+      ...topicsPanelBaseProps(),
+      isLoading: true,
+      callParticipantCounts: {
+        "general@conference.example.com": 1,
+      },
+      callParticipants: {
+        "general@conference.example.com": ["alice"],
+      },
+      managedMucDomain: "conference.example.com",
+    };
+
+    const html = await renderVueComponent("../src/components/chat/TopicsPanel.vue", props);
+    expect(html).toContain("Rejoin live call, 1 person");
+    expect(html).toContain('aria-label="Leave general call"');
+
+    const emitted: unknown[][] = [];
+    const bindings = await setupVueComponent("../src/components/chat/TopicsPanel.vue", props, (...args) => {
+      emitted.push(args);
+    });
+    setupBindingFunction(bindings, "leaveRefreshedGroupCall")({
+      key: "group-call:general@conference.example.com",
+      roomJid: "general@conference.example.com",
+      title: "general",
+      participantCount: 1,
+      media: { audio: true, video: false },
+    });
+
+    expect(emitted).toEqual([
+      ["leaveChannelCall", "general@conference.example.com"],
+    ]);
   });
 
   test("does not duplicate refreshed group call rows for known channels", async () => {
@@ -2144,6 +2526,24 @@ describe("CallActivityDock rendering", () => {
     ]);
   });
 
+  test("mobile drawer forwards sidebar leave-call events to the shell handler", async () => {
+    const forwarded: unknown[][] = [];
+    const bindings = await setupVueComponent("../src/components/chat/ChatMobileDrawers.vue", {
+      controller: {},
+      leaveChannelCall: (...args: unknown[]) => {
+        forwarded.push(args);
+      },
+    });
+
+    setupBindingFunction(bindings, "leaveChannelCallFromMobile")(
+      "general@conference.example.com",
+    );
+
+    expect(forwarded).toEqual([
+      ["general@conference.example.com"],
+    ]);
+  });
+
   test("mobile drawer forwards DM answer rows to the shell handler", async () => {
     const forwarded: unknown[][] = [];
     const bindings = await setupVueComponent("../src/components/chat/ChatMobileDrawers.vue", {
@@ -2182,6 +2582,20 @@ describe("CallActivityDock rendering", () => {
     expect(forwarded).toEqual([
       ["bob@example.com", { audio: true, video: true }],
     ]);
+  });
+
+  test("mobile drawer forwards recovered DM end actions to the shell handler", async () => {
+    const forwarded: unknown[][] = [];
+    const bindings = await setupVueComponent("../src/components/chat/ChatMobileDrawers.vue", {
+      controller: {},
+      endDm: (...args: unknown[]) => {
+        forwarded.push(args);
+      },
+    });
+
+    setupBindingFunction(bindings, "endDmFromMobile")("bob@example.com");
+
+    expect(forwarded).toEqual([["bob@example.com"]]);
   });
 
   test("mobile drawer routes community surfaces through the controller", async () => {
@@ -2337,6 +2751,64 @@ describe("CallActivityDock rendering", () => {
       ["reconnectDm", "bob@example.com", { audio: true, video: true }],
       ["selectContact", "carol@example.com"],
       ["joinChannelCall", null, "standup@conference.example.com", { audio: true, video: false }],
+    ]);
+  });
+
+  test("home dashboard leaves retained local group calls without rejoining media", async () => {
+    connectionStore.session = {
+      username: "alice",
+      jid: "alice@example.com",
+    } as typeof connectionStore.session;
+    connectionStore.client = {
+      fullJid: "alice@example.com/web",
+    } as unknown as typeof connectionStore.client;
+    applyMucCallPresence({
+      from: "standup@conference.example.com/alice",
+      muc_jid: "alice@example.com/web",
+      muji: { preparing: false, active: true },
+    });
+    const props = {
+      spaces: [],
+      channels: [],
+      contacts: [],
+      isLoading: false,
+      channelUnreadMap: {},
+      activeChannelJids: new Set(["standup@conference.example.com"]),
+      managedMucDomain: "conference.example.com",
+      callParticipantCounts: { "standup@conference.example.com": 1 },
+      callParticipants: { "standup@conference.example.com": ["alice"] },
+      dmConversations: [],
+      selfFullJid: "alice@example.com/web",
+    };
+    const html = await renderVueComponent("../src/components/chat/HomeDashboard.vue", props);
+    expect(html).toContain('aria-label="Leave standup call"');
+    expect(html).toContain("Rejoin");
+    expect(html).toContain("Leave call");
+
+    const fallbackRoomEntry = buildCallActivityDockEntries({
+      channels: [],
+      conversations: [],
+      activeChannelId: null,
+      activePeerJid: null,
+      sidebarMode: "channels",
+      activeChannelJids: new Set(["standup@conference.example.com"]),
+      managedMucDomain: "conference.example.com",
+      callParticipantCounts: { "standup@conference.example.com": 1 },
+      callParticipants: { "standup@conference.example.com": ["alice"] },
+      dmCallActivities: {},
+    })[0];
+    if (!fallbackRoomEntry) throw new Error("expected fallback room entry");
+    const emitted: unknown[][] = [];
+    const bindings = await suppressVueLifecycleSetupWarnings(() =>
+      setupVueComponent("../src/components/chat/HomeDashboard.vue", props, (...args) => {
+        emitted.push(args);
+      })
+    );
+
+    setupBindingFunction(bindings, "endCallEntry")(fallbackRoomEntry);
+
+    expect(emitted).toEqual([
+      ["leaveChannelCall", "standup@conference.example.com"],
     ]);
   });
 
@@ -2521,6 +2993,78 @@ describe("CallActivityDock rendering", () => {
       join: liveKitJoinFor(),
       initiator: "alice@example.com/web",
     });
+  });
+
+  test("shell end action terminates a recovered same-resource DM call", async () => {
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com",
+        remoteFullJid: "bob@example.com/phone",
+        sid: "dm-recovered-end",
+        media: { audio: true, video: true },
+        join: liveKitJoinFor(),
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: new Date().toISOString(),
+      },
+    });
+    const selected: unknown[][] = [];
+    const sendCallSessionTerminate = mock(async () => undefined);
+    const sendCallFinish = mock(async () => undefined);
+    const bindings = await suppressVueLifecycleSetupWarnings(() =>
+      setupVueComponent("../src/components/chat/ChatReadyShell.vue", {
+        controller: {
+          ui: { activeCommunitySurface: { value: null } },
+          connectionStore: {
+            client: {
+              fullJid: "alice@example.com/web",
+              xmpp: {
+                send_call_session_terminate: sendCallSessionTerminate,
+                send_call_finish: sendCallFinish,
+              },
+            },
+            session: null,
+          },
+          waddles: { mucServiceJid: { value: "" } },
+          selfDomain: { value: "" },
+          rosterContacts: {
+            contacts: { value: [] },
+            isLoadingContacts: { value: false },
+          },
+          messaging: {
+            mentionedChannelCounts: { value: {} },
+            activeChannels: { value: new Set<string>() },
+          },
+          dmConversations: { conversations: { value: [] } },
+          computedChannelUnreadMap: { value: {} },
+          activeRightPanel: { value: null },
+          activeThreadStack: { value: [] },
+          communityEvents: { rsvp: () => undefined },
+          closePinnedPanel: () => undefined,
+          activateRightPanel: () => undefined,
+          selectDm: (...args: unknown[]) => {
+            selected.push(args);
+          },
+          selectChannel: () => undefined,
+          selectChannelByRoomJid: () => undefined,
+        },
+      }),
+    );
+
+    setupBindingFunction(bindings, "endRecoveredDmFromActivity")("bob@example.com");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(selected).toEqual([["bob@example.com"]]);
+    expect(sendCallSessionTerminate).toHaveBeenCalledWith(
+      "bob@example.com/phone",
+      "dm-recovered-end",
+      "success",
+    );
+    expect(sendCallFinish).toHaveBeenCalledWith(
+      "bob@example.com/phone",
+      "dm-recovered-end",
+    );
+    expect($dmCallActivities.get()["bob@example.com"]).toBeUndefined();
   });
 
   test("shell reconnect leaves stale accepted activity open-only instead of sending a new propose", async () => {
@@ -2871,6 +3415,7 @@ async function emittedRefreshedGroupCallRowEvents(callState?: CallState): Promis
     roomJid: "general@conference.example.com",
     title: "general",
     participantCount: 2,
+    media: { audio: true, video: false },
   });
   return emitted;
 }

--- a/chat/tests/call-activity-dock.test.ts
+++ b/chat/tests/call-activity-dock.test.ts
@@ -26,7 +26,7 @@ import {
   $callMicEnabled,
 } from "../src/lib/calls/call-controls";
 import { $callUiMode } from "../src/lib/calls/ui-mode";
-import { clearMucCallParticipants, $mucCallParticipants } from "../src/lib/calls/muc-call-presence";
+import { applyMucCallPresence, clearMucCallParticipants, $mucCallParticipants } from "../src/lib/calls/muc-call-presence";
 import { clearDmCallActivities, $dmCallActivities } from "../src/lib/calls/dm-call-activity";
 import type { DmCallActivity } from "../src/lib/calls/dm-call-activity";
 import type { CallState, LiveKitJoin } from "../src/lib/calls/types";
@@ -41,6 +41,7 @@ afterEach(() => {
   $callCamEnabled.set(true);
   $callUiMode.set("split");
   connectionStore.client = null;
+  connectionStore.session = null;
 });
 
 const liveKitJoin: LiveKitJoin = {
@@ -666,6 +667,52 @@ describe("CallActivityDock rendering", () => {
     expect(html).not.toContain("General has a live call");
   });
 
+  test("lets a hard-refreshed tab leave its own retained group-call presence", async () => {
+    connectionStore.session = {
+      username: "alice",
+      jid: "alice@example.com",
+    } as typeof connectionStore.session;
+    connectionStore.client = {
+      fullJid: "alice@example.com/web",
+    } as unknown as typeof connectionStore.client;
+    applyMucCallPresence({
+      from: "general@conference.example.com/alice",
+      muc_jid: "alice@example.com/web",
+      muji: { preparing: false, active: true },
+    });
+    applyMucCallPresence({
+      from: "general@conference.example.com/bob",
+      muc_jid: "bob@example.com/phone",
+      muji: { preparing: false, active: true },
+    });
+
+    const props = {
+      roomJid: "general@conference.example.com",
+      channelId: "general",
+      channelName: "General",
+      dmPeerJid: null,
+      dmPeerName: null,
+    };
+    const html = await renderVueComponent("../src/components/calls/ConversationCallBanner.vue", props);
+    expect(html).toContain("Recovered after refresh");
+    expect(html).toContain("This browser is still listed in the call after reload.");
+    expect(html).toContain("Rejoin call");
+    expect(html).toContain("Leave call");
+    expect(html).toContain('aria-label="Leave General call after refresh"');
+
+    const emitted: unknown[][] = [];
+    const bindings = await setupVueComponent("../src/components/calls/ConversationCallBanner.vue", props, (...args) => {
+      emitted.push(args);
+    });
+    setupBindingFunction(bindings, "activateBanner")();
+    setupBindingFunction(bindings, "activateSecondaryBanner")();
+
+    expect(emitted).toEqual([
+      ["joinChannelCall", "general", "general@conference.example.com", { audio: true, video: false }],
+      ["leaveChannelCall", "general@conference.example.com"],
+    ]);
+  });
+
   test("keeps the conversation call live region mounted before call activity arrives", async () => {
     const html = await renderVueComponent("../src/components/calls/ConversationCallBanner.vue", {
       roomJid: "general@conference.example.com",
@@ -953,9 +1000,11 @@ describe("CallActivityDock rendering", () => {
     expect(contentArea).toContain(":show-dm-call-activity-controls=\"false\"");
     expect(contentArea).toContain(":hide-muc-start-controls-when-active-call=\"true\"");
     expect(contentArea).toContain("@join-channel-call=\"(channelId, roomJid, media) => emit('joinChannelCall', channelId, roomJid, media)\"");
+    expect(contentArea).toContain("@leave-channel-call=\"(roomJid) => emit('leaveChannelCall', roomJid)\"");
     expect(contentArea).toContain("@answer-dm=\"(peerJid, remoteFullJid, sid, media) => emit('answerDm', peerJid, remoteFullJid, sid, media)\"");
     expect(contentArea).toContain("@reconnect-dm=\"(peerJid, media) => emit('reconnectDm', peerJid, media)\"");
     expect(readyShell).toContain("@join-channel-call=\"joinChannelCallFromActivity\"");
+    expect(readyShell).toContain("@leave-channel-call=\"leaveRetainedChannelCall\"");
     expect(readyShell).toContain("@answer-dm=\"answerDmFromActivity\"");
     expect(readyShell).toContain("@reconnect-dm=\"reconnectDmFromDock\"");
     expect(chatHeader).toContain("showCallActivePill?: boolean");
@@ -995,6 +1044,7 @@ describe("CallActivityDock rendering", () => {
       expect(props.channelId).toBe("general");
       expect(props.dmPeerJid).toBe("bob@example.com");
       emit("joinChannelCall", "general", "general@conference.example.com", media);
+      emit("leaveChannelCall", "general@conference.example.com");
       emit("answerDm", "bob@example.com", "bob@example.com/phone", "sid-1", media);
       emit("reconnectDm", "bob@example.com", media);
     };
@@ -1003,6 +1053,7 @@ describe("CallActivityDock rendering", () => {
       await suppressVueLifecycleSetupWarnings(() => renderVueComponent("../src/components/chat/ContentArea.vue", {
         ...contentAreaBaseProps(),
         onJoinChannelCall: (...args: unknown[]) => emitted.push(["joinChannelCall", ...args]),
+        onLeaveChannelCall: (...args: unknown[]) => emitted.push(["leaveChannelCall", ...args]),
         onAnswerDm: (...args: unknown[]) => emitted.push(["answerDm", ...args]),
         onReconnectDm: (...args: unknown[]) => emitted.push(["reconnectDm", ...args]),
       }));
@@ -1017,6 +1068,7 @@ describe("CallActivityDock rendering", () => {
 
     expect(emitted).toEqual([
       ["joinChannelCall", "general", "general@conference.example.com", media],
+      ["leaveChannelCall", "general@conference.example.com"],
       ["answerDm", "bob@example.com", "bob@example.com/phone", "sid-1", media],
       ["reconnectDm", "bob@example.com", media],
     ]);

--- a/chat/tests/call-activity-dock.test.ts
+++ b/chat/tests/call-activity-dock.test.ts
@@ -1144,10 +1144,14 @@ describe("CallActivityDock rendering", () => {
     expect(mobileDrawers).toContain("@answer-dm=\"answerDmFromMobile\"");
     expect(mobileDrawers).toContain("@reconnect-dm=\"reconnectDmFromMobile\"");
     expect(mobileDrawers).toContain("@end-dm=\"endDmFromMobile\"");
-    expect(mobileDrawers).toContain(":active-channel-call-count=\"activeChannelCallCount\"");
-    expect(mobileDrawers).toContain(":active-dm-call-count=\"activeDmCallCount\"");
-    expect(mobileDrawers).toContain(":call-participants=\"mucCallParticipantsStore\"");
-    expect(mobileDrawers).toContain(":call-media-by-room=\"mucCallMediaStore\"");
+    expect(readyShell).toContain(":call-participants=\"retainedMucCallParticipantsStore\"");
+    expect(readyShell).toContain(":active-channel-call-count=\"activeChannelCallCount\"");
+    expect(mobileDrawers).toContain(":active-channel-call-count=\"visibleActiveChannelCallCount\"");
+    expect(mobileDrawers).toContain(":active-dm-call-count=\"visibleActiveDmCallCount\"");
+    expect(mobileDrawers).toContain("visibleCallParticipants");
+    expect(mobileDrawers).toContain(":call-participants=\"visibleCallParticipants\"");
+    expect(mobileDrawers).toContain(":call-media-by-room=\"visibleCallMediaByRoom\"");
+    expect(mobileDrawers).toContain(":managed-muc-domain=\"visibleManagedMucDomain\"");
     expect(mobileDrawers).toContain("@toggle-dms=\"openDmList\"");
     expect(mobileDrawers).toContain("hide-current-call");
     expect(callActivityDock).toContain("entry.peerJid.toLowerCase() === barePeerJid(current.peer).toLowerCase()");
@@ -1170,6 +1174,7 @@ describe("CallActivityDock rendering", () => {
     expect(chatHeader).toContain("showCallActivePill?: boolean");
     expect(chatHeader).toContain("showDmCallActivityControls?: boolean");
     expect(chatHeader).toContain("hideMucStartControlsWhenActiveCall?: boolean");
+    expect(chatHeader).toContain("showDmCallActivityStatus");
     expect(chatHeader).toContain(":show-activity-controls=\"showDmCallActivityControls !== false\"");
     expect(chatHeader).toContain(":show-active-pill=\"showCallActivePill !== false\"");
     expect(chatHeader).toContain(":hide-start-controls-when-active-call=\"hideMucStartControlsWhenActiveCall\"");
@@ -2598,6 +2603,35 @@ describe("CallActivityDock rendering", () => {
     expect(forwarded).toEqual([["bob@example.com"]]);
   });
 
+  test("mobile drawer can receive retained hard-refresh group call state from the shell", async () => {
+    const bindings = await setupVueComponent("../src/components/chat/ChatMobileDrawers.vue", {
+      controller: {
+        connectionStore: { client: null, session: null },
+        waddles: { mucServiceJid: { value: "conference.example.com" } },
+        selfDomain: { value: "example.com" },
+      },
+      activeChannelCallCount: 1,
+      callParticipantCounts: { "general@conference.example.com": 1 },
+      callParticipants: { "general@conference.example.com": ["alice"] },
+      callMediaByRoom: { "general@conference.example.com": { audio: true, video: true } },
+      managedMucDomain: "conference.example.com",
+      selfFullJid: "alice@example.com/web",
+    });
+
+    expect(setupBindingRefValue(bindings, "visibleActiveChannelCallCount")).toBe(1);
+    expect(setupBindingRefValue(bindings, "visibleCallParticipantCounts")).toEqual({
+      "general@conference.example.com": 1,
+    });
+    expect(setupBindingRefValue(bindings, "visibleCallParticipants")).toEqual({
+      "general@conference.example.com": ["alice"],
+    });
+    expect(setupBindingRefValue(bindings, "visibleCallMediaByRoom")).toEqual({
+      "general@conference.example.com": { audio: true, video: true },
+    });
+    expect(setupBindingRefValue(bindings, "visibleManagedMucDomain")).toBe("conference.example.com");
+    expect(setupBindingRefValue(bindings, "visibleSelfFullJid")).toBe("alice@example.com/web");
+  });
+
   test("mobile drawer routes community surfaces through the controller", async () => {
     const selected: unknown[][] = [];
     const bindings = await setupVueComponent("../src/components/chat/ChatMobileDrawers.vue", {
@@ -2809,6 +2843,51 @@ describe("CallActivityDock rendering", () => {
 
     expect(emitted).toEqual([
       ["leaveChannelCall", "standup@conference.example.com"],
+    ]);
+  });
+
+  test("home dashboard channel rows join or open live calls through the call action model", async () => {
+    const emitted: unknown[][] = [];
+    const channel = { id: "general", name: "General", jid: "general@conference.example.com", spaceId: "team" };
+    const props = {
+      spaces: [],
+      channels: [channel],
+      contacts: [],
+      isLoading: false,
+      channelUnreadMap: {},
+      activeChannelJids: new Set<string>(),
+      managedMucDomain: "conference.example.com",
+      callParticipantCounts: { "general@conference.example.com": 2 },
+      callParticipants: { "general@conference.example.com": ["alice", "bob"] },
+      callMediaByRoom: { "general@conference.example.com": { audio: true, video: true } },
+      dmConversations: [],
+      selfFullJid: "alice@example.com/web",
+    };
+    const bindings = await suppressVueLifecycleSetupWarnings(() =>
+      setupVueComponent("../src/components/chat/HomeDashboard.vue", props, (...args) => {
+        emitted.push(args);
+      })
+    );
+
+    setupBindingFunction(bindings, "selectHomeChannel")(channel);
+    $callState.set({
+      phase: "active",
+      kind: "dm",
+      peer: "bob@example.com/phone",
+      sid: "dm-live",
+      media: { audio: true, video: false },
+      join: liveKitJoinFor(),
+    });
+    const busyBindings = await suppressVueLifecycleSetupWarnings(() =>
+      setupVueComponent("../src/components/chat/HomeDashboard.vue", props, (...args) => {
+        emitted.push(args);
+      })
+    );
+    setupBindingFunction(busyBindings, "selectHomeChannel")(channel);
+
+    expect(emitted).toEqual([
+      ["joinChannelCall", "general", "general@conference.example.com", { audio: true, video: true }],
+      ["selectChannel", "general", "general@conference.example.com"],
     ]);
   });
 
@@ -3288,6 +3367,34 @@ describe("CallActivityDock rendering", () => {
     expect(withoutRoom).not.toContain('data-vue-stub="true"');
     expect(withRoom).toContain('data-vue-stub="true"');
   });
+
+  test("suppresses the header DM activity status when the conversation banner owns it", async () => {
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com",
+        remoteFullJid: "bob@example.com/phone",
+        sid: "dm-live",
+        media: { audio: true, video: true },
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:00:00.000Z",
+      },
+    });
+    const props = {
+      ...chatHeaderBaseProps(),
+      dmPeer: { peerJid: "bob@example.com", peerUsername: "Bob", presenceShow: "available" },
+    };
+
+    const visible = await renderVueComponent("../src/components/chat/ChatHeader.vue", props);
+    const suppressed = await renderVueComponent("../src/components/chat/ChatHeader.vue", {
+      ...props,
+      showDmCallActivityControls: false,
+    });
+
+    expect(visible).toContain("Video call active");
+    expect(suppressed).not.toContain("Video call active");
+    expect(suppressed).toContain("online");
+  });
 });
 
 function chatHeaderBaseProps(): Record<string, unknown> {
@@ -3463,6 +3570,17 @@ function setupBindingFunction(
     throw new Error(`Expected setup binding ${key} to be a function`);
   }
   return binding as (...args: unknown[]) => unknown;
+}
+
+function setupBindingRefValue<T = unknown>(
+  bindings: Record<string, unknown>,
+  key: string,
+): T {
+  const binding = bindings[key];
+  if (!binding || typeof binding !== "object" || !("value" in binding)) {
+    throw new Error(`Expected setup binding ${key} to be a ref`);
+  }
+  return (binding as { value: T }).value;
 }
 
 async function suppressVueLifecycleSetupWarnings<T>(fn: () => Promise<T>): Promise<T> {

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
 import {
   $callState,
   $lastCallError,
@@ -16,6 +16,12 @@ import {
   clearMucCallParticipants,
 } from "../src/lib/calls/muc-call-presence";
 import { leaveRetainedMucCallAction, startMucCallAction } from "../src/lib/calls/muc-call-actions";
+import {
+  $mucCallTerminatePendingSessions,
+  clearAllMucCallSessionCacheForTests,
+  readMucCallSession,
+  rememberMucCallSession,
+} from "../src/lib/calls/muc-call-session-cache";
 import type { CallWireSender } from "../src/lib/calls/outbound";
 import type { CallEvent, CallMedia, LiveKitJoin } from "../src/lib/calls/types";
 import { BrowserXmppClient } from "../src/lib/xmpp-client";
@@ -190,6 +196,33 @@ function mockSender(): CallWireSender {
   };
 }
 
+const WINDOW_SENTINEL = Symbol("call-teardown-window");
+type ShimmedGlobal = typeof globalThis & {
+  window?: { localStorage: Storage } & { [WINDOW_SENTINEL]?: true };
+};
+
+beforeAll(() => {
+  const g = globalThis as ShimmedGlobal;
+  if (typeof g.window !== "undefined") return;
+  const store = new Map<string, string>();
+  const storage: Storage = {
+    get length() { return store.size; },
+    clear: () => store.clear(),
+    getItem: (key) => store.get(key) ?? null,
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key) => { store.delete(key); },
+    setItem: (key, value) => { store.set(key, String(value)); },
+  };
+  g.window = Object.assign({ localStorage: storage }, { [WINDOW_SENTINEL]: true as const });
+});
+
+afterAll(() => {
+  const g = globalThis as ShimmedGlobal;
+  if (g.window?.[WINDOW_SENTINEL]) {
+    delete (g as { window?: unknown }).window;
+  }
+});
+
 afterEach(() => {
   clearCallState();
   $lastCallError.set(null);
@@ -198,6 +231,7 @@ afterEach(() => {
   // keeps that state from leaking into other test files (e.g.
   // `muc-call-presence.test.ts`) that expect an empty store.
   clearMucCallParticipants();
+  clearAllMucCallSessionCacheForTests();
 });
 
 describe("tearDownActiveCall", () => {
@@ -373,6 +407,103 @@ describe("leaveRetainedMucCallAction", () => {
     expect($mucCallParticipantOwners.get()).toEqual({
       "chan@muc.test": [{ nick: "alice", realJid: "alice@waddle.test/phone" }],
     });
+  });
+
+  test("terminates the cached Muji Jingle session after clearing retained presence", async () => {
+    const sent: unknown[][] = [];
+    applyMucCallPresence({
+      from: "chan@muc.test/alice",
+      muc_jid: "alice@waddle.test/web",
+      muji: { preparing: false, active: true },
+    });
+    rememberMucCallSession({
+      roomJid: "chan@muc.test",
+      sid: "muc-recovered-live",
+      selfFullJid: "alice@waddle.test/web",
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    });
+    const sender: RawIqSender = {
+      update_muji_presence: mock(async (...args) => {
+        sent.push(["presence", ...args]);
+      }),
+      send_muji_session_terminate: mock(async (...args) => {
+        sent.push(["terminate", ...args]);
+      }),
+    };
+
+    await expect(leaveRetainedMucCallAction({
+      roomJid: "chan@muc.test",
+      getSender: () => sender,
+      getSelfNick: () => "alice",
+      getSelfFullJid: () => "alice@waddle.test/web",
+    })).resolves.toBe(true);
+
+    expect(sent).toEqual([
+      ["presence", "chan@muc.test", "alice", false, false, false],
+      ["terminate", "chan@muc.test", "muc-recovered-live"],
+    ]);
+    expect($mucCallParticipants.get()).toEqual({});
+    expect(readMucCallSession({
+      roomJid: "chan@muc.test",
+      selfFullJid: "alice@waddle.test/web",
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    })).toBeNull();
+  });
+
+  test("reports cached Muji terminate failure after retained presence is cleared", async () => {
+    applyMucCallPresence({
+      from: "chan@muc.test/alice",
+      muc_jid: "alice@waddle.test/web",
+      muji: { preparing: false, active: true },
+    });
+    rememberMucCallSession({
+      roomJid: "chan@muc.test",
+      sid: "muc-retry-live",
+      selfFullJid: "alice@waddle.test/web",
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    });
+    const sender: RawIqSender = {
+      update_muji_presence: mock(async () => undefined),
+      send_muji_session_terminate: mock(async () => {
+        throw new Error("simulated Muji terminate failure");
+      }),
+    };
+
+    const result = await leaveRetainedMucCallAction({
+      roomJid: "chan@muc.test",
+      getSender: () => sender,
+      getSelfNick: () => "alice",
+      getSelfFullJid: () => "alice@waddle.test/web",
+    });
+
+    expect(result).toBe(false);
+    expect(sender.update_muji_presence).toHaveBeenCalledWith(
+      "chan@muc.test",
+      "alice",
+      false,
+      false,
+      false,
+    );
+    expect(sender.send_muji_session_terminate).toHaveBeenCalledWith(
+      "chan@muc.test",
+      "muc-retry-live",
+    );
+    expect($mucCallParticipants.get()).toEqual({});
+    expect(readMucCallSession({
+      roomJid: "chan@muc.test",
+      selfFullJid: "alice@waddle.test/web",
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    })).toMatchObject({ sid: "muc-retry-live" });
+    expect($mucCallTerminatePendingSessions.get()).toEqual({
+      "chan@muc.test\u0000muc-retry-live\u0000alice@waddle.test/web": {
+        roomJid: "chan@muc.test",
+        sid: "muc-retry-live",
+        selfFullJid: "alice@waddle.test/web",
+        updatedAt: expect.any(String),
+        terminatePending: true,
+      },
+    });
+    expect($lastCallError.get()).toContain("simulated Muji terminate failure");
   });
 
   test("keeps retained Muji state visible when the leave marker fails to send", async () => {

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -4,16 +4,18 @@ import {
   $lastCallError,
   beginOutgoingCall,
   clearCallState,
+  type RawIqSender,
   scheduleOutgoingTimeout,
   setSessionAcceptTimeoutMsForTests,
   tearDownActiveCall,
 } from "../src/lib/calls/call-store";
 import {
+  $mucCallParticipantOwners,
   $mucCallParticipants,
   applyMucCallPresence,
   clearMucCallParticipants,
 } from "../src/lib/calls/muc-call-presence";
-import { startMucCallAction } from "../src/lib/calls/muc-call-actions";
+import { leaveRetainedMucCallAction, startMucCallAction } from "../src/lib/calls/muc-call-actions";
 import type { CallWireSender } from "../src/lib/calls/outbound";
 import type { CallEvent, CallMedia, LiveKitJoin } from "../src/lib/calls/types";
 import { BrowserXmppClient } from "../src/lib/xmpp-client";
@@ -332,6 +334,81 @@ describe("tearDownActiveCall", () => {
     });
     await tearDownActiveCall(null, "gone");
     expect($callState.get()).toEqual({ phase: "idle" });
+  });
+});
+
+describe("leaveRetainedMucCallAction", () => {
+  test("clears this refreshed browser resource's Muji presence without dropping same-nick siblings", async () => {
+    applyMucCallPresence({
+      from: "chan@muc.test/alice",
+      muc_jid: "alice@waddle.test/web",
+      muji: { preparing: false, active: true },
+    });
+    applyMucCallPresence({
+      from: "chan@muc.test/alice",
+      muc_jid: "alice@waddle.test/phone",
+      muji: { preparing: false, active: true },
+    });
+    const sender: RawIqSender = {
+      update_muji_presence: mock(async () => undefined),
+    };
+
+    await leaveRetainedMucCallAction({
+      roomJid: "chan@muc.test",
+      getSender: () => sender,
+      getSelfNick: () => "alice",
+      getSelfFullJid: () => "alice@waddle.test/web",
+    });
+
+    expect(sender.update_muji_presence).toHaveBeenCalledWith(
+      "chan@muc.test",
+      "alice",
+      false,
+      false,
+      false,
+    );
+    expect($mucCallParticipants.get()).toEqual({
+      "chan@muc.test": ["alice"],
+    });
+    expect($mucCallParticipantOwners.get()).toEqual({
+      "chan@muc.test": [{ nick: "alice", realJid: "alice@waddle.test/phone" }],
+    });
+  });
+
+  test("keeps retained Muji state visible when the leave marker fails to send", async () => {
+    applyMucCallPresence({
+      from: "chan@muc.test/alice",
+      muc_jid: "alice@waddle.test/web",
+      muji: { preparing: false, active: true },
+    });
+    const sender: RawIqSender = {
+      update_muji_presence: mock(async () => {
+        throw new Error("simulated Muji leave failure");
+      }),
+    };
+
+    const result = await leaveRetainedMucCallAction({
+      roomJid: "chan@muc.test",
+      getSender: () => sender,
+      getSelfNick: () => "alice",
+      getSelfFullJid: () => "alice@waddle.test/web",
+    });
+
+    expect(result).toBe(false);
+    expect(sender.update_muji_presence).toHaveBeenCalledWith(
+      "chan@muc.test",
+      "alice",
+      false,
+      false,
+      false,
+    );
+    expect($mucCallParticipants.get()).toEqual({
+      "chan@muc.test": ["alice"],
+    });
+    expect($mucCallParticipantOwners.get()).toEqual({
+      "chan@muc.test": [{ nick: "alice", realJid: "alice@waddle.test/web" }],
+    });
+    expect($lastCallError.get()).toContain("simulated Muji leave failure");
   });
 });
 

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -409,6 +409,33 @@ describe("leaveRetainedMucCallAction", () => {
     });
   });
 
+  test("clears ownerless retained Muji presence after hard reload", async () => {
+    applyMucCallPresence({
+      from: "chan@muc.test/alice",
+      muji: { preparing: false, active: true },
+    });
+    const sender: RawIqSender = {
+      update_muji_presence: mock(async () => undefined),
+    };
+
+    await leaveRetainedMucCallAction({
+      roomJid: "chan@muc.test",
+      getSender: () => sender,
+      getSelfNick: () => "alice",
+      getSelfFullJid: () => "alice@waddle.test/web",
+    });
+
+    expect(sender.update_muji_presence).toHaveBeenCalledWith(
+      "chan@muc.test",
+      "alice",
+      false,
+      false,
+      false,
+    );
+    expect($mucCallParticipants.get()).toEqual({});
+    expect($mucCallParticipantOwners.get()).toEqual({});
+  });
+
   test("terminates the cached Muji Jingle session after clearing retained presence", async () => {
     const sent: unknown[][] = [];
     applyMucCallPresence({

--- a/chat/tests/dm-call-actions.test.ts
+++ b/chat/tests/dm-call-actions.test.ts
@@ -5,6 +5,7 @@ import {
 } from "../src/lib/calls/call-store";
 import {
   answerIncomingDmCallActivity,
+  endRecoveredDmCallAction,
   resumeDmCallActivity,
   startDmCallAction,
 } from "../src/lib/calls/dm-call-actions";
@@ -348,5 +349,295 @@ describe("startDmCallAction", () => {
       now: new Date("2026-05-26T12:00:00.000Z"),
     })).toBe(false);
     expect($callState.get()).toEqual({ phase: "idle" });
+  });
+
+  test("ends a recovered same-resource DM call without rejoining media", async () => {
+    const sender: CallWireSender = {
+      send_call_session_terminate: mock(async () => undefined),
+      send_call_finish: mock(async () => undefined),
+    };
+    applyDmCallEvent({
+      event: {
+        kind: "session-accept",
+        from: "bob@waddle.test/phone",
+        to: "alice@waddle.test/web",
+        sid: "recovered-live",
+        media: { audio: true, video: true },
+        join: {
+          url: "wss://livekit.waddle.test",
+          room: "dm-call-recovered",
+          identity: "alice@waddle.test/web",
+          token: jwtWithExp(Date.parse("2026-05-26T13:00:00.000Z") / 1000),
+        },
+      },
+      selfBareJid: "alice@waddle.test",
+      timestamp: "2026-05-26T12:00:00.000Z",
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    });
+
+    await expect(endRecoveredDmCallAction({
+      peerBareJid: "bob@waddle.test",
+      getSender: () => sender,
+      getSelfFullJid: () => "alice@waddle.test/web",
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    })).resolves.toBe(true);
+
+    expect(sender.send_call_session_terminate).toHaveBeenCalledWith(
+      "bob@waddle.test/phone",
+      "recovered-live",
+      "success",
+    );
+    expect(sender.send_call_finish).toHaveBeenCalledWith(
+      "bob@waddle.test/phone",
+      "recovered-live",
+    );
+    expect(readDmCallActivity("bob@waddle.test")).toBeNull();
+    expect($callState.get()).toEqual({ phase: "idle" });
+  });
+
+  test("ends a recovered same-resource DM call after its reconnect token expires", async () => {
+    const sender: CallWireSender = {
+      send_call_session_terminate: mock(async () => undefined),
+      send_call_finish: mock(async () => undefined),
+    };
+    applyDmCallEvent({
+      event: {
+        kind: "session-accept",
+        from: "bob@waddle.test/phone",
+        to: "alice@waddle.test/web",
+        sid: "expired-recovered-live",
+        media: { audio: true, video: true },
+        join: {
+          url: "wss://livekit.waddle.test",
+          room: "dm-call-expired",
+          identity: "alice@waddle.test/web",
+          token: jwtWithExp(Date.parse("2026-05-26T11:59:00.000Z") / 1000),
+        },
+      },
+      selfBareJid: "alice@waddle.test",
+      timestamp: "2026-05-26T12:00:00.000Z",
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    });
+
+    await expect(endRecoveredDmCallAction({
+      peerBareJid: "bob@waddle.test",
+      getSender: () => sender,
+      getSelfFullJid: () => "alice@waddle.test/web",
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    })).resolves.toBe(true);
+
+    expect(sender.send_call_session_terminate).toHaveBeenCalledWith(
+      "bob@waddle.test/phone",
+      "expired-recovered-live",
+      "success",
+    );
+    expect(sender.send_call_finish).toHaveBeenCalledWith(
+      "bob@waddle.test/phone",
+      "expired-recovered-live",
+    );
+    expect(readDmCallActivity("bob@waddle.test")).toBeNull();
+  });
+
+  test("ends a recovered DM call even while the local call slot is busy", async () => {
+    const sender: CallWireSender = {
+      send_call_session_terminate: mock(async () => undefined),
+      send_call_finish: mock(async () => undefined),
+    };
+    $callState.set({
+      phase: "active",
+      kind: "muc",
+      peer: "room@muc.waddle.test",
+      sid: "current-room",
+      media: { audio: true, video: false },
+      join: {
+        url: "wss://livekit.waddle.test",
+        room: "room@muc.waddle.test",
+        identity: "alice@waddle.test/web",
+        token: "opaque",
+      },
+    });
+    applyDmCallEvent({
+      event: {
+        kind: "session-accept",
+        from: "bob@waddle.test/phone",
+        to: "alice@waddle.test/web",
+        sid: "busy-recovered-live",
+        media: { audio: true, video: false },
+        join: {
+          url: "wss://livekit.waddle.test",
+          room: "dm-call-busy",
+          identity: "alice@waddle.test/web",
+          token: jwtWithExp(Date.parse("2026-05-26T11:59:00.000Z") / 1000),
+        },
+      },
+      selfBareJid: "alice@waddle.test",
+      timestamp: "2026-05-26T12:00:00.000Z",
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    });
+
+    await expect(endRecoveredDmCallAction({
+      peerBareJid: "bob@waddle.test",
+      getSender: () => sender,
+      getSelfFullJid: () => "alice@waddle.test/web",
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    })).resolves.toBe(true);
+
+    expect(sender.send_call_session_terminate).toHaveBeenCalledWith(
+      "bob@waddle.test/phone",
+      "busy-recovered-live",
+      "success",
+    );
+    expect($callState.get()).toMatchObject({
+      phase: "active",
+      kind: "muc",
+      sid: "current-room",
+    });
+  });
+
+  test("keeps recovered DM activity retryable when no end marker sends", async () => {
+    const sender: CallWireSender = {
+      send_call_session_terminate: mock(async () => {
+        throw new Error("terminate failed");
+      }),
+      send_call_finish: mock(async () => {
+        throw new Error("finish failed");
+      }),
+    };
+    applyDmCallEvent({
+      event: {
+        kind: "session-accept",
+        from: "bob@waddle.test/phone",
+        to: "alice@waddle.test/web",
+        sid: "retry-live",
+        media: { audio: true, video: false },
+        join: {
+          url: "wss://livekit.waddle.test",
+          room: "dm-call-retry",
+          identity: "alice@waddle.test/web",
+          token: jwtWithExp(Date.parse("2026-05-26T13:00:00.000Z") / 1000),
+        },
+      },
+      selfBareJid: "alice@waddle.test",
+      timestamp: "2026-05-26T12:00:00.000Z",
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    });
+
+    await expect(endRecoveredDmCallAction({
+      peerBareJid: "bob@waddle.test",
+      getSender: () => sender,
+      getSelfFullJid: () => "alice@waddle.test/web",
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    })).resolves.toBe(false);
+
+    expect(sender.send_call_finish).not.toHaveBeenCalled();
+    expect(readDmCallActivity("bob@waddle.test")).toMatchObject({
+      sid: "retry-live",
+      state: "accepted",
+    });
+  });
+
+  test("ends the requested same-resource sid without clearing another-resource activity", async () => {
+    const sender: CallWireSender = {
+      send_call_session_terminate: mock(async () => undefined),
+      send_call_finish: mock(async () => undefined),
+    };
+    applyDmCallEvent({
+      event: {
+        kind: "session-accept",
+        from: "bob@waddle.test/phone",
+        to: "alice@waddle.test/web",
+        sid: "own-live",
+        media: { audio: true, video: false },
+        join: {
+          url: "wss://livekit.waddle.test",
+          room: "dm-call-own",
+          identity: "alice@waddle.test/web",
+          token: jwtWithExp(Date.parse("2026-05-26T13:00:00.000Z") / 1000),
+        },
+      },
+      selfBareJid: "alice@waddle.test",
+      timestamp: "2026-05-26T12:00:00.000Z",
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    });
+    applyDmCallEvent({
+      event: {
+        kind: "session-accept",
+        from: "bob@waddle.test/tablet",
+        to: "alice@waddle.test/phone",
+        sid: "other-resource-live",
+        media: { audio: true, video: true },
+        join: {
+          url: "wss://livekit.waddle.test",
+          room: "dm-call-other",
+          identity: "alice@waddle.test/phone",
+          token: jwtWithExp(Date.parse("2026-05-26T13:00:00.000Z") / 1000),
+        },
+      },
+      selfBareJid: "alice@waddle.test",
+      timestamp: "2026-05-26T12:01:00.000Z",
+      now: new Date("2026-05-26T12:01:00.000Z"),
+    });
+
+    expect(readDmCallActivity(
+      "bob@waddle.test",
+      new Date("2026-05-26T12:01:00.000Z"),
+      "alice@waddle.test/web",
+    )).toMatchObject({ sid: "own-live" });
+
+    await expect(endRecoveredDmCallAction({
+      peerBareJid: "bob@waddle.test",
+      sid: "own-live",
+      getSender: () => sender,
+      getSelfFullJid: () => "alice@waddle.test/web",
+      now: new Date("2026-05-26T12:01:00.000Z"),
+    })).resolves.toBe(true);
+
+    expect(sender.send_call_session_terminate).toHaveBeenCalledWith(
+      "bob@waddle.test/phone",
+      "own-live",
+      "success",
+    );
+    expect(readDmCallActivity(
+      "bob@waddle.test",
+      new Date("2026-05-26T12:01:00.000Z"),
+    )).toMatchObject({ sid: "other-resource-live" });
+  });
+
+  test("does not end another resource's recovered DM call", async () => {
+    const sender: CallWireSender = {
+      send_call_session_terminate: mock(async () => undefined),
+      send_call_finish: mock(async () => undefined),
+    };
+    applyDmCallEvent({
+      event: {
+        kind: "session-accept",
+        from: "bob@waddle.test/phone",
+        to: "alice@waddle.test/tablet",
+        sid: "other-resource-live",
+        media: { audio: true, video: false },
+        join: {
+          url: "wss://livekit.waddle.test",
+          room: "dm-call-other-resource",
+          identity: "alice@waddle.test/tablet",
+          token: jwtWithExp(Date.parse("2026-05-26T13:00:00.000Z") / 1000),
+        },
+      },
+      selfBareJid: "alice@waddle.test",
+      timestamp: "2026-05-26T12:00:00.000Z",
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    });
+
+    await expect(endRecoveredDmCallAction({
+      peerBareJid: "bob@waddle.test",
+      getSender: () => sender,
+      getSelfFullJid: () => "alice@waddle.test/web",
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    })).resolves.toBe(false);
+
+    expect(sender.send_call_session_terminate).not.toHaveBeenCalled();
+    expect(sender.send_call_finish).not.toHaveBeenCalled();
+    expect(readDmCallActivity("bob@waddle.test")).toMatchObject({
+      sid: "other-resource-live",
+    });
   });
 });

--- a/chat/tests/dm-call-activity.test.ts
+++ b/chat/tests/dm-call-activity.test.ts
@@ -758,7 +758,7 @@ describe("DM call activity", () => {
         now: timerArmedAt,
       });
 
-      expect($dmCallActivities.get()[bob]?.sid).toBe("timer-pruned-call");
+      expect(readDmCallActivity(bob, timerArmedAt)?.sid).toBe("timer-pruned-call");
       expect(scheduledDelay).toBe(1_000);
       expect(scheduledPrune).not.toBeNull();
 
@@ -822,7 +822,7 @@ describe("DM call activity", () => {
       scheduledRefresh?.();
 
       expect($dmCallActivities.get()).not.toBe(before);
-      expect($dmCallActivities.get()[bob]).toMatchObject({
+      expect(readDmCallActivity(bob)).toMatchObject({
         sid: "expiring-call",
         join,
       });

--- a/chat/tests/home-activity.test.ts
+++ b/chat/tests/home-activity.test.ts
@@ -398,12 +398,56 @@ describe("HomeDashboard activity rendering", () => {
     expect(html).toContain("2 people connected in this channel: alice, bob.");
     expect(html).toContain("alice, bob");
     expect(html).toContain("The video call is still live.");
+    expect(buttonForLabel(html, "Join General call")).toContain("Join General call");
     expect(html).toContain('aria-label="Join General, Group call, 2 people, Live now, 2 people connected in this channel: alice, bob., Group call"');
     expect(html).toContain(`aria-label="Reconnect Bob, Video call, Live, Live now, The video call is still live., Live video call · Updated ${updated}"`);
     expect(buttonForLabel(html, "Join General, Group call, 2 people, Live now, 2 people connected in this channel: alice, bob., Group call")).toContain("Join");
-    expect(buttonForLabel(html, "General, channel, no unread activity, active call with 2 people")).toContain("Active call");
+    expect(buttonForLabel(html, "General, channel, no unread activity, active call with 2 people, click to join call")).toContain("Active call");
     expect(buttonForLabel(html, `Reconnect Bob, Video call, Live, Live now, The video call is still live., Live video call · Updated ${updated}`)).toContain("Live");
     expect(html).not.toContain("Bob (bob@example.com), direct message, available, no unread activity, Video call live");
+  });
+
+  test("promotes refresh-discovered direct calls into the home hero action", async () => {
+    const html = await renderHomeDashboard({
+      spaces: [],
+      channels: [],
+      contacts: [],
+      isLoading: false,
+      channelUnreadMap: {},
+      activeChannelJids: new Set<string>(),
+      managedMucDomain: "conference.example.com",
+      callParticipantCounts: {},
+      dmConversations: [
+        {
+          peerJid: "bob@example.com",
+          peerUsername: "Bob",
+          unreadCount: 0,
+          presenceShow: "available",
+        },
+      ],
+      dmCallActivities: {
+        "bob@example.com": {
+          peerJid: "bob@example.com",
+          remoteFullJid: "bob@example.com/phone",
+          sid: "dm-call-hero",
+          media: { audio: true, video: true },
+          join: {
+            url: "wss://livekit.example.test",
+            room: "dm-call-hero",
+            identity: "alice@example.com/web",
+            token: liveKitToken(),
+          },
+          state: "accepted",
+          direction: "incoming",
+          updatedAt: "2026-05-26T00:00:00.000Z",
+        },
+      },
+      selfFullJid: "alice@example.com/web",
+    });
+
+    expect(html).toContain("<strong>1</strong> active call");
+    expect(buttonForLabel(html, "Reconnect Bob call")).toContain("Reconnect Bob call");
+    expect(html).not.toContain("Browse channels");
   });
 
   test("labels non-resumable active direct calls on the home dashboard", async () => {

--- a/chat/tests/home-activity.test.ts
+++ b/chat/tests/home-activity.test.ts
@@ -491,10 +491,11 @@ describe("HomeDashboard activity rendering", () => {
       selfFullJid: "alice@example.com/web",
     });
 
-    expect(html).toContain("Expired");
-    expect(html).toContain("The saved reconnect details expired.");
-    expect(html).toContain("Video call · Expired");
-    expect(html).toContain(`aria-label="Open Bob, Video call, Live, Expired, The saved reconnect details expired., Video call · Expired · Updated ${updated}"`);
+    expect(html).toContain("Recovered after refresh");
+    expect(html).toContain("The saved reconnect details expired, but this tab can still end the call.");
+    expect(html).toContain("Video call · End available");
+    expect(html).toContain(`aria-label="Open Bob, Video call, Live, Recovered after refresh, The saved reconnect details expired, but this tab can still end the call., Video call · End available · Updated ${updated}"`);
+    expect(html).toContain('aria-label="End Bob video call"');
     expect(html).not.toContain("Reconnect Bob");
   });
 

--- a/chat/tests/muc-call-indicators.test.ts
+++ b/chat/tests/muc-call-indicators.test.ts
@@ -104,6 +104,7 @@ describe("refreshedMucCallRooms", () => {
         roomJid: "general@muc.test",
         title: "general",
         participantCount: 2,
+        media: { audio: true, video: false },
       },
     ]);
   });
@@ -127,6 +128,29 @@ describe("refreshedMucCallRooms", () => {
         roomJid: "random@muc.test",
         title: "random",
         participantCount: 1,
+        media: { audio: true, video: false },
+      },
+    ]);
+  });
+
+  test("carries advertised room media into fallback rows", () => {
+    expect(refreshedMucCallRooms({
+      channels: [],
+      activeChannelJids: new Set(),
+      managedMucDomain: "muc.test",
+      callParticipantCounts: {
+        "general@muc.test": 2,
+      },
+      callMediaByRoom: {
+        "general@muc.test": { audio: true, video: true },
+      },
+    })).toEqual([
+      {
+        key: "group-call:general@muc.test",
+        roomJid: "general@muc.test",
+        title: "general",
+        participantCount: 2,
+        media: { audio: true, video: true },
       },
     ]);
   });

--- a/chat/tests/resume-persistence.test.ts
+++ b/chat/tests/resume-persistence.test.ts
@@ -333,6 +333,43 @@ describe("createLocalStorageResumePersistence — localStorage adapter", () => {
     expect(reloadedPage.consumeSm()).toEqual(state);
   });
 
+  test("a slow same-tab reload keeps the owner until the prior lease expires", () => {
+    const realNow = Date.now;
+    let now = 1_000_000;
+    Date.now = () => now;
+
+    try {
+      const reloadOwner = "slow-reload-owner";
+      const state = {
+        previd: "abc-123",
+        inboundH: 42,
+        outboundH: 7,
+        resource: "web-existing-resource",
+      };
+      const previousPage = createLocalStorageResumePersistence("alice@example.com", reloadOwner);
+      previousPage.saveSm(state);
+      previousPage.saveJoinedRooms(["general@conference.example.com"]);
+      previousPage.preparePagehideHandoff();
+      window.sessionStorage.setItem("waddle.chat.sm-resume.owner", reloadOwner);
+      window.localStorage.setItem(
+        `waddle.chat.sm-resume.owner-lease.${reloadOwner}`,
+        JSON.stringify({
+          ownerId: reloadOwner,
+          instanceId: "previous-page",
+          updatedAt: now,
+        }),
+      );
+
+      now += 15_000;
+      const reloadedPage = createLocalStorageResumePersistence("alice@example.com");
+
+      expect(reloadedPage.loadJoinedRooms()).toEqual(["general@conference.example.com"]);
+      expect(reloadedPage.consumeSm()).toEqual(state);
+    } finally {
+      Date.now = realNow;
+    }
+  });
+
   test("BrowserXmppClient only reuses a refreshed resource for the owning tab", () => {
     const state = {
       previd: "abc-123",

--- a/chat/tests/use-active-muc-call.test.ts
+++ b/chat/tests/use-active-muc-call.test.ts
@@ -256,6 +256,25 @@ describe("readRoomHasActiveCall selector", () => {
     });
   });
 
+  test("treats ownerless self Muji presence as a retained local resource after refresh", () => {
+    setSession("alice");
+    connectionStore.client = { fullJid: "alice@waddle.test/web" } as unknown as typeof connectionStore.client;
+    $callState.set({ phase: "idle" });
+    applyMucCallPresence({
+      from: `${ROOM}/alice`,
+      presence_type: "available",
+      muji: { preparing: false, active: true },
+    });
+
+    expect(readRoomHasActiveCall(ROOM)).toEqual({
+      hasActiveCall: true,
+      selfInCall: true,
+      localResourceInCall: true,
+      participantCount: 1,
+      media: { audio: true, video: false },
+    });
+  });
+
   test("preserves resourcepart case when matching Muji ownership to this browser", () => {
     setSession("alice");
     connectionStore.client = { fullJid: "alice@waddle.test/Web" } as unknown as typeof connectionStore.client;

--- a/chat/tests/use-active-muc-call.test.ts
+++ b/chat/tests/use-active-muc-call.test.ts
@@ -7,6 +7,10 @@ import {
 } from "../src/lib/calls/muc-call-presence";
 import { connectionStore } from "../src/lib/connection-store";
 import { readActiveMucCall, readRoomHasActiveCall } from "../src/lib/calls/use-active-muc-call";
+import {
+  clearAllMucCallSessionCacheForTests,
+  markMucCallSessionTerminatePending,
+} from "../src/lib/calls/muc-call-session-cache";
 import type { CallMedia, LiveKitJoin } from "../src/lib/calls/types";
 import type { WaddleSession } from "../src/lib/server-auth";
 
@@ -42,12 +46,14 @@ describe("readActiveMucCall selector", () => {
   beforeEach(() => {
     $callState.set({ phase: "idle" });
     clearMucCallParticipants();
+    clearAllMucCallSessionCacheForTests();
     setSession(null);
   });
 
   afterEach(() => {
     $callState.set({ phase: "idle" });
     clearMucCallParticipants();
+    clearAllMucCallSessionCacheForTests();
     setSession(null);
   });
 
@@ -56,6 +62,7 @@ describe("readActiveMucCall selector", () => {
       activeRoomJid: null,
       selfInCall: false,
       participantCount: 0,
+      media: { audio: true, video: false },
     });
   });
 
@@ -74,6 +81,7 @@ describe("readActiveMucCall selector", () => {
       activeRoomJid: null,
       selfInCall: false,
       participantCount: 0,
+      media: { audio: true, video: false },
     });
   });
 
@@ -93,6 +101,7 @@ describe("readActiveMucCall selector", () => {
       activeRoomJid: ROOM,
       selfInCall: true,
       participantCount: 2,
+      media: { audio: true, video: true },
     });
   });
 
@@ -112,6 +121,7 @@ describe("readActiveMucCall selector", () => {
       activeRoomJid: ROOM,
       selfInCall: false,
       participantCount: 2,
+      media: { audio: true, video: true },
     });
   });
 
@@ -150,12 +160,14 @@ describe("readRoomHasActiveCall selector", () => {
   beforeEach(() => {
     $callState.set({ phase: "idle" });
     clearMucCallParticipants();
+    clearAllMucCallSessionCacheForTests();
     setSession(null);
   });
 
   afterEach(() => {
     $callState.set({ phase: "idle" });
     clearMucCallParticipants();
+    clearAllMucCallSessionCacheForTests();
     setSession(null);
   });
 
@@ -169,6 +181,7 @@ describe("readRoomHasActiveCall selector", () => {
       selfInCall: false,
       localResourceInCall: false,
       participantCount: 2,
+      media: { audio: true, video: false },
     });
   });
 
@@ -182,6 +195,7 @@ describe("readRoomHasActiveCall selector", () => {
       selfInCall: true,
       localResourceInCall: false,
       participantCount: 2,
+      media: { audio: true, video: false },
     });
   });
 
@@ -203,6 +217,7 @@ describe("readRoomHasActiveCall selector", () => {
       selfInCall: true,
       localResourceInCall: true,
       participantCount: 2,
+      media: { audio: true, video: true },
     });
   });
 
@@ -222,6 +237,7 @@ describe("readRoomHasActiveCall selector", () => {
       selfInCall: true,
       localResourceInCall: false,
       participantCount: 1,
+      media: { audio: true, video: false },
     });
 
     applyMucCallPresence({
@@ -236,6 +252,7 @@ describe("readRoomHasActiveCall selector", () => {
       selfInCall: true,
       localResourceInCall: true,
       participantCount: 1,
+      media: { audio: true, video: false },
     });
   });
 
@@ -271,6 +288,7 @@ describe("readRoomHasActiveCall selector", () => {
       selfInCall: false,
       localResourceInCall: false,
       participantCount: 1,
+      media: { audio: true, video: false },
     });
   });
 
@@ -283,12 +301,45 @@ describe("readRoomHasActiveCall selector", () => {
       selfInCall: false,
       localResourceInCall: false,
       participantCount: 0,
+      media: { audio: true, video: false },
     });
     expect(readRoomHasActiveCall("other@muc.waddle.test")).toEqual({
       hasActiveCall: false,
       selfInCall: false,
       localResourceInCall: false,
       participantCount: 0,
+      media: { audio: true, video: false },
+    });
+  });
+
+  test("reports video media from Muji content presence", () => {
+    setSession("alice");
+    applyMucCallPresence({
+      from: `${ROOM}/alice`,
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/web",
+      muji: { preparing: false, active: true, audio: true, video: true },
+    });
+
+    expect(readRoomHasActiveCall(ROOM).media).toEqual({ audio: true, video: true });
+  });
+
+  test("keeps a cached terminate failure retryable after local Muji presence is cleared", () => {
+    setSession("alice");
+    connectionStore.client = { fullJid: "alice@waddle.test/web" } as unknown as typeof connectionStore.client;
+    markMucCallSessionTerminatePending({
+      roomJid: ROOM,
+      sid: "muc-retry-live",
+      selfFullJid: "alice@waddle.test/web",
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    });
+
+    expect(readRoomHasActiveCall(ROOM)).toEqual({
+      hasActiveCall: true,
+      selfInCall: true,
+      localResourceInCall: true,
+      participantCount: 1,
+      media: { audio: true, video: false },
     });
   });
 });

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
@@ -135,6 +135,7 @@ pub(super) async fn try_handle_muc_presence_update(
         return None;
     }
 
+    let clears_muji_presence = muji.as_ref().is_none_or(Muji::is_empty);
     let outcome = match muji {
         Some(muji) => match actor
             .ask(UpsertMujiPresence {
@@ -176,6 +177,16 @@ pub(super) async fn try_handle_muc_presence_update(
             }
         },
     };
+    if clears_muji_presence {
+        // XEP-0272 §Leaving is the absence of `<muji/>` in in-room
+        // presence. Mirror that XMPP-native leave marker to the SFU
+        // registry just like full MUC leave / unclean disconnect do,
+        // otherwise a hard-refreshed tab can clear the room indicator
+        // while its LiveKit participant and issued token JTIs linger.
+        super::super::super::muc_call_sfu::unregister_participant_from_room(
+            state, room_jid, sender_jid,
+        );
+    }
 
     // XEP-0045 §7.7: a user may change their *own* in-room presence
     // only. The resolved nick comes from the room actor's

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -995,6 +995,82 @@ fn preparing_muji() -> waddle_xmpp::xep::xep0272::Muji {
     waddle_xmpp::xep::xep0272::Muji::preparing()
 }
 
+fn empty_muji() -> waddle_xmpp::xep::xep0272::Muji {
+    waddle_xmpp::xep::xep0272::Muji::default()
+}
+
+#[derive(Default)]
+struct RecordingSfu {
+    calls: std::sync::Mutex<Vec<(waddle_sfu::CallId, waddle_sfu::Identity)>>,
+}
+
+impl RecordingSfu {
+    fn snapshot(&self) -> Vec<(waddle_sfu::CallId, waddle_sfu::Identity)> {
+        self.calls.lock().expect("recording lock").clone()
+    }
+}
+
+impl waddle_sfu::SfuService for RecordingSfu {
+    fn issue_join_token(
+        &self,
+        _: &waddle_sfu::CallId,
+        _: &waddle_sfu::Identity,
+        _: waddle_sfu::MediaCapabilities,
+    ) -> Result<waddle_sfu::JoinToken, waddle_sfu::SfuError> {
+        unimplemented!("not exercised by this test")
+    }
+
+    fn issue_turn_credentials(
+        &self,
+        _: &waddle_sfu::Identity,
+    ) -> Result<waddle_sfu::TurnCredential, waddle_sfu::SfuError> {
+        unimplemented!("not exercised by this test")
+    }
+
+    fn register_call_participant(&self, _: &waddle_sfu::CallId, _: &waddle_sfu::Identity) {}
+
+    fn has_call_participant(&self, _: &waddle_sfu::CallId, _: &waddle_sfu::Identity) -> bool {
+        false
+    }
+
+    fn unregister_call_participant(
+        &self,
+        call_id: &waddle_sfu::CallId,
+        identity: &waddle_sfu::Identity,
+    ) -> waddle_sfu::CallState {
+        self.calls
+            .lock()
+            .expect("recording lock")
+            .push((call_id.clone(), identity.clone()));
+        waddle_sfu::CallState::Ended
+    }
+
+    fn is_revoked(&self, _: &waddle_sfu::Jti) -> bool {
+        false
+    }
+
+    fn ws_url(&self) -> &waddle_sfu::WebsocketUrl {
+        unimplemented!("not exercised by this test")
+    }
+
+    fn turn_host(&self) -> &waddle_sfu::TurnHost {
+        unimplemented!("not exercised by this test")
+    }
+}
+
+async fn state_with_recording_sfu(
+    recorder: std::sync::Arc<RecordingSfu>,
+) -> std::sync::Arc<WebSocketState> {
+    let base = create_test_websocket_state().await;
+    let mut state = match std::sync::Arc::try_unwrap(base) {
+        Ok(state) => state,
+        Err(_) => panic!("test websocket state should be uniquely owned"),
+    };
+    let sfu: std::sync::Arc<dyn waddle_sfu::SfuService> = recorder;
+    state.deps.protocol.sfu = Some(sfu);
+    std::sync::Arc::new(state)
+}
+
 fn muc_user_item_jid(element: &Element) -> Option<String> {
     element
         .get_child("x", "http://jabber.org/protocol/muc#user")
@@ -1025,7 +1101,8 @@ fn muc_join_presence_to(room_jid: &BareJid, nick: &str) -> xmpp_parsers::presenc
 
 #[tokio::test]
 async fn available_presence_without_muji_clears_existing_muji_state() {
-    let state = create_test_websocket_state().await;
+    let recorder = std::sync::Arc::new(RecordingSfu::default());
+    let state = state_with_recording_sfu(std::sync::Arc::clone(&recorder)).await;
     let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
     let room_jid: BareJid = "muji-clear-channel@muc.example.com"
         .parse()
@@ -1086,6 +1163,15 @@ async fn available_presence_without_muji_clears_existing_muji_state() {
         &None,
     )
     .await;
+    let recorded = recorder.snapshot();
+    assert_eq!(
+        recorded.len(),
+        1,
+        "Muji clear must unregister the sender from the SFU"
+    );
+    assert_eq!(recorded[0].0.as_str(), "muji-clear-channel@muc.example.com");
+    assert_eq!(recorded[0].1.as_livekit_identity(), "alice@example.com/web");
+
     assert_eq!(responses.len(), 1, "sender receives reflected clear");
     let self_clear = Element::from_str(&responses[0]).expect("self clear XML");
     assert_eq!(
@@ -1139,6 +1225,69 @@ async fn available_presence_without_muji_clears_existing_muji_state() {
             .get_child("muji", waddle_xmpp::xep::xep0272::NS_MUJI)
             .is_none(),
         "late join replay must not include stale Muji"
+    );
+}
+
+#[tokio::test]
+async fn empty_muji_presence_unregisters_the_sfu_participant() {
+    let recorder = std::sync::Arc::new(RecordingSfu::default());
+    let state = state_with_recording_sfu(std::sync::Arc::clone(&recorder)).await;
+    let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let room_jid: BareJid = "empty-muji-clear@muc.example.com"
+        .parse()
+        .expect("room jid");
+    let alice: FullJid = "alice@example.com/web".parse().expect("alice jid");
+
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &alice,
+        "alice",
+        None,
+        &Some(owner_session.clone()),
+    )
+    .await;
+    let alice_phase = waddle_xmpp::protocol::ConnectionPhase::ready(alice.clone(), false);
+
+    let mut active = muc_presence_to(&room_jid, "alice");
+    active.payloads.push(active_muji().to_element());
+    let _ = handlers::presence::handle_presence(
+        active,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &alice_phase,
+        &Some(owner_session.clone()),
+    )
+    .await;
+
+    let mut empty = muc_presence_to(&room_jid, "alice");
+    empty.payloads.push(empty_muji().to_element());
+    let responses = handlers::presence::handle_presence(
+        empty,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &alice_phase,
+        &Some(owner_session),
+    )
+    .await;
+
+    let recorded = recorder.snapshot();
+    assert_eq!(
+        recorded.len(),
+        1,
+        "empty <muji/> leave marker must unregister the sender from the SFU"
+    );
+    assert_eq!(recorded[0].0.as_str(), "empty-muji-clear@muc.example.com");
+    assert_eq!(recorded[0].1.as_livekit_identity(), "alice@example.com/web");
+    let self_clear = Element::from_str(&responses[0]).expect("self clear XML");
+    assert!(
+        self_clear
+            .get_child("muji", waddle_xmpp::xep::xep0272::NS_MUJI)
+            .is_none(),
+        "empty <muji/> must reflect as a no-Muji leave marker"
     );
 }
 

--- a/server/crates/waddle-xmpp-client-ffi/src/convert.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/convert.rs
@@ -226,6 +226,8 @@ fn muji_presence_to_ffi(muji: MujiPresence) -> WaddleMujiPresence {
     WaddleMujiPresence {
         preparing: muji.preparing,
         active: muji.active,
+        audio: muji.audio,
+        video: muji.video,
     }
 }
 
@@ -886,15 +888,23 @@ mod tests {
         let active = muji_presence_to_ffi(MujiPresence {
             preparing: false,
             active: true,
+            audio: true,
+            video: true,
         });
         assert!(active.active);
         assert!(!active.preparing);
+        assert!(active.audio);
+        assert!(active.video);
 
         let preparing = muji_presence_to_ffi(MujiPresence {
             preparing: true,
             active: false,
+            audio: false,
+            video: false,
         });
         assert!(preparing.preparing);
         assert!(!preparing.active);
+        assert!(!preparing.audio);
+        assert!(!preparing.video);
     }
 }

--- a/server/crates/waddle-xmpp-client-ffi/src/types.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/types.rs
@@ -143,6 +143,10 @@ pub struct WaddleMujiPresence {
     /// True when the presence advertised at least one `<content/>`
     /// child — the occupant is actively participating in the call.
     pub active: bool,
+    /// True when at least one content description advertises audio.
+    pub audio: bool,
+    /// True when at least one content description advertises video.
+    pub video: bool,
 }
 
 #[derive(uniffi::Record, Clone)]

--- a/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
@@ -582,6 +582,8 @@ pub(crate) fn presence_to_js(presence: InboundPresence) -> WaddlePresence {
         muji: presence.muji.map(|m| WaddleMujiPresence {
             preparing: m.preparing,
             active: m.active,
+            audio: m.audio,
+            video: m.video,
         }),
     }
 }

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -282,9 +282,9 @@ pub struct WaddlePresence {
     pub vcard_avatar: Option<String>,
     /// XEP-0272 Muji `<muji xmlns='urn:xmpp:jingle:muji:0'/>`
     /// extension on a MUC occupant's presence, surfaced as
-    /// `{ preparing, active }` for the chat-side participant-tracking
-    /// store. `None` per XEP-0272 §Leaving means the occupant has
-    /// left the call.
+    /// `{ preparing, active, audio, video }` for the chat-side
+    /// participant-tracking store. `None` per XEP-0272 §Leaving
+    /// means the occupant has left the call.
     pub muji: Option<WaddleMujiPresence>,
 }
 
@@ -292,6 +292,8 @@ pub struct WaddlePresence {
 pub struct WaddleMujiPresence {
     pub preparing: bool,
     pub active: bool,
+    pub audio: bool,
+    pub video: bool,
 }
 
 #[derive(Debug, Serialize)]

--- a/server/crates/waddle-xmpp-client/src/messaging/presence.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/presence.rs
@@ -48,9 +48,31 @@ pub(super) fn parse_presence(el: &Element) -> InboundPresence {
     // Active = has at least one `<content/>` (XEP-0272 §Joining).
     // Absent = the occupant has left the call (XEP-0272 §Leaving).
     let muji = el.get_child("muji", NS_MUJI).map(|muji_el| {
-        let preparing = muji_el.children().any(|c| c.name() == "preparing");
-        let active = muji_el.children().any(|c| c.name() == "content");
-        MujiPresence { preparing, active }
+        let preparing = muji_el
+            .children()
+            .any(|c| c.name() == "preparing" && c.ns() == NS_MUJI);
+        let mut active = false;
+        let mut audio = false;
+        let mut video = false;
+        for content in muji_el
+            .children()
+            .filter(|c| c.name() == "content" && c.ns() == NS_MUJI)
+        {
+            active = true;
+            for media in muji_content_media(content) {
+                match media {
+                    "audio" => audio = true,
+                    "video" => video = true,
+                    _ => {}
+                }
+            }
+        }
+        MujiPresence {
+            preparing,
+            active,
+            audio,
+            video,
+        }
     });
 
     InboundPresence {
@@ -66,6 +88,13 @@ pub(super) fn parse_presence(el: &Element) -> InboundPresence {
         vcard_avatar,
         muji,
     }
+}
+
+fn muji_content_media(content: &Element) -> impl Iterator<Item = &str> {
+    content
+        .get_child("description", NS_JINGLE_RTP)
+        .and_then(|description| description.attr("media"))
+        .into_iter()
 }
 
 #[cfg(test)]
@@ -85,7 +114,46 @@ mod tests {
         let p = parse_presence(&elem);
         let muji = p.muji.expect("muji extension parsed");
         assert!(muji.active);
+        assert!(muji.audio);
+        assert!(!muji.video);
         assert!(!muji.preparing);
+    }
+
+    #[test]
+    fn parses_muji_video_content_media() {
+        let xml = r#"<presence xmlns="jabber:client" from="room@muc.test/alice">
+            <muji xmlns="urn:xmpp:jingle:muji:0">
+                <content creator="initiator" name="audio">
+                    <description xmlns="urn:xmpp:jingle:apps:rtp:1" media="audio"/>
+                </content>
+                <content creator="initiator" name="video">
+                    <description xmlns="urn:xmpp:jingle:apps:rtp:1" media="video"/>
+                </content>
+            </muji>
+        </presence>"#;
+        let elem: Element = xml.parse().unwrap();
+        let p = parse_presence(&elem);
+        let muji = p.muji.expect("muji extension parsed");
+        assert!(muji.active);
+        assert!(muji.audio);
+        assert!(muji.video);
+    }
+
+    #[test]
+    fn parses_muji_media_from_rtp_description_not_content_name() {
+        let xml = r#"<presence xmlns="jabber:client" from="room@muc.test/alice">
+            <muji xmlns="urn:xmpp:jingle:muji:0">
+                <content creator="initiator" name="video">
+                    <description xmlns="urn:xmpp:jingle:apps:rtp:1" media="audio"/>
+                </content>
+            </muji>
+        </presence>"#;
+        let elem: Element = xml.parse().unwrap();
+        let p = parse_presence(&elem);
+        let muji = p.muji.expect("muji extension parsed");
+        assert!(muji.active);
+        assert!(muji.audio);
+        assert!(!muji.video);
     }
 
     #[test]
@@ -101,6 +169,8 @@ mod tests {
             !muji.active,
             "preparing-only muji is not yet active (XEP-0272 §Joining two-phase flow)"
         );
+        assert!(!muji.audio);
+        assert!(!muji.video);
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client/src/messaging/types.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/types.rs
@@ -529,7 +529,7 @@ pub struct InboundPresence {
 /// Parsed `<muji xmlns='urn:xmpp:jingle:muji:0'>` extension on a MUC
 /// presence. Wire-typed because chat-side consumers want the
 /// preparing-vs-active distinction without re-parsing the element
-/// shape.
+/// shape or the RTP content descriptions.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MujiPresence {
     /// True when the presence carried a `<preparing/>` child (XEP-0272
@@ -540,6 +540,10 @@ pub struct MujiPresence {
     /// True when the presence advertised at least one `<content/>`
     /// child — the occupant is actively participating in the call.
     pub active: bool,
+    /// True when at least one content description advertises audio.
+    pub audio: bool,
+    /// True when at least one content description advertises video.
+    pub video: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mplor8ty";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mplor8ty";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mplor8ty";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpnd9iyz";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpnd9iyz";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpnd9iyz";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=mplor8ty";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=mpnd9iyz";


### PR DESCRIPTION
## Summary

Finish hard-reload call cleanup so a refreshed browser resource can reliably find, rejoin, or end its own direct or group call without rejoining media first.

## Completed Work

- Added same-resource recovered DM hangup that sends XEP-0166 `session-terminate` before XEP-0353 `finish`, keeps retry state when terminate fails, and does not require fresh LiveKit reconnect credentials.
- Keyed refreshed DM activity by peer, SID, and local full JID so multiple same-peer resources/SIDs do not overwrite or hide each other.
- Threaded recovered DM end actions through the conversation banner, call dock, direct-message panel, mobile drawers, and Home dashboard with SID-aware dispatch.
- Persisted retained Muji session SIDs for group calls, clears XEP-0272 Muji presence first, then sends cached XEP-0166 Muji `session-terminate`.
- Treats ownerless self Muji presence after a hard reload as a retained local resource, so the tab still gets a conformant leave/hangup path instead of a join-only affordance.
- Kept cached group-call terminate failures retryable after local Muji presence is cleared.
- Propagated Muji audio/video media through Rust, WASM, native FFI, TS types, and chat UI so refreshed group video calls stay video.
- Tightened Muji media parsing to use RTP `description@media` instead of inferring from `content@name`.
- Promoted refresh-discovered calls into the Home hero CTA and made live-call channel rows use the same join/open/return action model as the sidebar.
- Threaded retained group-call state into the mobile drawer so mobile navigation shows the same recovered call/leave affordances as desktop.
- Suppressed duplicate DM header activity status when the in-conversation call banner owns the call action.

## XEP Review

- XEP-0353: recovered DM cleanup emits `finish` only after session termination succeeds, so MAM gets an end marker without claiming success after a failed terminate.
- XEP-0166: both recovered DM and Muji group cleanup use typed `session-terminate` with existing session SIDs.
- XEP-0272: retained group-call cleanup clears Muji presence before terminating the related Jingle session; ownerless self presence still leaves by publishing the no-Muji presence marker.
- No custom `urn:waddle:*` namespace was introduced.

## Verification

- `git diff --check`
- `bun test tests/use-active-muc-call.test.ts tests/call-teardown.test.ts` in `chat/`
- `bun test tests/call-activity-dock.test.ts tests/home-activity.test.ts` in `chat/`
- `bun test tests/dm-call-actions.test.ts tests/dm-call-activity.test.ts tests/dm-call-activity-hydration.test.ts tests/call-controls.test.ts` in `chat/`
- `bun run lint` in `chat/`
- `bun run build` in `chat/`
- Earlier PR verification still applies for the Rust/WASM call media and teardown plumbing already in this branch:
  - `bun test` in `chat/`
  - `cargo fmt --all` in `server/`
  - `cargo clippy --workspace --all-features --all-targets -- -D warnings` in `server/`
  - `cargo test -p waddle-xmpp-client-ffi muji_presence_maps_active_and_preparing_flags` in `server/`
  - `cargo test -p waddle-xmpp-client messaging::presence` in `server/`
  - `cargo test -p waddle-xmpp-client-wasm` in `server/`
  - `cargo clippy -p waddle-xmpp-client -p waddle-xmpp-client-wasm --all-targets -- -D warnings` in `server/`

## Review Notes

- No dev server was started.
- Adversarial review found mobile retained-call wiring, Home action routing, and duplicate DM header status gaps; all are addressed with regression coverage in this PR.
