### PR TITLE
feat(chat): finalize active call recovery hub

### DIFF
--- a/chat/src/components/calls/CallActivityDock.vue
+++ b/chat/src/components/calls/CallActivityDock.vue
@@ -15,6 +15,7 @@ import {
   buildCallActivityDockEntries,
   canEndRecoveredDmCallActivity,
   callActivityDockSelection,
+  sortCallActivityDockEntries,
   type CallActivityDockEntry,
   type SidebarMode,
 } from "@/lib/calls/call-activity-dock";
@@ -64,20 +65,26 @@ const callParticipantCounts = computed<Record<string, number>>(() => {
   return mucCallParticipantCounts(callParticipants.value);
 });
 
-const entries = computed(() => buildCallActivityDockEntries({
-  channels: props.channels,
-  conversations: props.conversations,
-  activeChannelId: props.activeChannelId,
-  activeChannelRoomJid: props.activeChannelRoomJid ?? null,
-  activePeerJid: props.activePeerJid,
-  sidebarMode: props.sidebarMode,
-  activeChannelJids: props.activeChannelJids,
-  managedMucDomain: props.managedMucDomain ?? null,
-  callParticipantCounts: callParticipantCounts.value,
-  callParticipants: callParticipants.value,
-  callMediaByRoom: props.callMediaByRoom,
-  dmCallActivities: props.showDmCalls === false ? {} : dmCallActivities.value,
-}));
+const entries = computed(() =>
+  sortCallActivityDockEntries(
+    buildCallActivityDockEntries({
+      channels: props.channels,
+      conversations: props.conversations,
+      activeChannelId: props.activeChannelId,
+      activeChannelRoomJid: props.activeChannelRoomJid ?? null,
+      activePeerJid: props.activePeerJid,
+      sidebarMode: props.sidebarMode,
+      activeChannelJids: props.activeChannelJids,
+      managedMucDomain: props.managedMucDomain ?? null,
+      callParticipantCounts: callParticipantCounts.value,
+      callParticipants: callParticipants.value,
+      callMediaByRoom: props.callMediaByRoom,
+      dmCallActivities: props.showDmCalls === false ? {} : dmCallActivities.value,
+    }),
+    callState.value,
+    props.selfFullJid ?? null,
+  )
+);
 const visibleEntries = computed(() =>
   props.hideCurrentCall
     ? entries.value.filter((entry) => !isCurrentCallEntry(entry))

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -203,6 +203,16 @@ const retainedMucCallParticipantsStore = computed<Record<string, string[]>>(() =
   }
   return next;
 });
+const retainedMucCallMediaStore = computed<Record<string, CallMedia>>(() => {
+  const next: Record<string, CallMedia> = { ...mucCallMediaStore.value };
+  const self = selfFullJid.value;
+  if (!self) return next;
+  for (const session of Object.values(mucCallTerminatePendingStore.value)) {
+    if (!session.terminatePending || session.selfFullJid !== self || !session.media) continue;
+    if (!next[session.roomJid]) next[session.roomJid] = session.media;
+  }
+  return next;
+});
 
 const homeDashboardProps = computed(() => buildHomeDashboardProps({
   spaces: waddles.sortedSpaces.value,
@@ -215,7 +225,7 @@ const homeDashboardProps = computed(() => buildHomeDashboardProps({
   dmConversations: dmConversations.conversations.value,
   callParticipantCounts: callParticipantCounts.value,
   callParticipants: retainedMucCallParticipantsStore.value,
-  callMediaByRoom: mucCallMediaStore.value,
+  callMediaByRoom: retainedMucCallMediaStore.value,
   dmCallActivities: dmCallActivitiesStore.value,
   managedMucDomain: managedMucDomain.value,
   selfFullJid: selfFullJid.value,
@@ -409,7 +419,7 @@ onUnmounted(() => {
       :active-dm-call-count="activeDmCallCount"
       :call-participant-counts="callParticipantCounts"
       :call-participants="retainedMucCallParticipantsStore"
-      :call-media-by-room="mucCallMediaStore"
+      :call-media-by-room="retainedMucCallMediaStore"
       :managed-muc-domain="managedMucDomain"
       :self-full-jid="selfFullJid"
       :join-channel-call="joinChannelCallFromActivity"
@@ -438,7 +448,7 @@ onUnmounted(() => {
       :sidebar-mode="ui.sidebarMode.value"
       :active-channel-jids="messaging.activeChannels.value"
       :call-participants="retainedMucCallParticipantsStore"
-      :call-media-by-room="mucCallMediaStore"
+      :call-media-by-room="retainedMucCallMediaStore"
       :managed-muc-domain="managedMucDomain"
       :self-full-jid="selfFullJid"
       hide-current-call
@@ -498,7 +508,7 @@ onUnmounted(() => {
           :channel-unread-map="computedChannelUnreadMap"
           :call-participant-counts="callParticipantCounts"
           :call-participants="retainedMucCallParticipantsStore"
-          :call-media-by-room="mucCallMediaStore"
+          :call-media-by-room="retainedMucCallMediaStore"
           :managed-muc-domain="managedMucDomain"
           :thread-entries-fn="(roomJid: string) => channelUnread.threadEntries(roomJid)"
           :active-community-surface="ui.activeCommunitySurface.value"
@@ -547,7 +557,7 @@ onUnmounted(() => {
           :sidebar-mode="ui.sidebarMode.value"
           :active-channel-jids="messaging.activeChannels.value"
           :call-participants="retainedMucCallParticipantsStore"
-          :call-media-by-room="mucCallMediaStore"
+          :call-media-by-room="retainedMucCallMediaStore"
           :managed-muc-domain="managedMucDomain"
           :self-full-jid="selfFullJid"
           :show-dm-calls="ui.sidebarMode.value !== 'dms'"

--- a/chat/src/components/chat/DmPanel.vue
+++ b/chat/src/components/chat/DmPanel.vue
@@ -8,6 +8,7 @@ import { $callState } from "@/lib/calls/call-store";
 import {
   canEndRecoveredDmCallActivity,
   dmCallActivityAction,
+  dmCallActivitySortPriority,
 } from "@/lib/calls/call-activity-dock";
 import {
   $dmCallActivities,
@@ -63,12 +64,7 @@ const activeCallRows = computed(() =>
       avatarUrl: callActivityAvatarUrl(activity),
     }))
     .filter((row) => row.peerJid && !isCurrentDmActivity(row.activity))
-    .sort((left, right) => {
-      const rightMs = timestampMs(right.activity.updatedAt);
-      const leftMs = timestampMs(left.activity.updatedAt);
-      if (rightMs !== leftMs) return rightMs - leftMs;
-      return left.peerJid.localeCompare(right.peerJid);
-    }),
+    .sort(compareActiveCallRows),
 );
 const activeCallStatusMessage = computed(() => {
   const count = activeCallRows.value.length;
@@ -102,6 +98,19 @@ function compareDmConversations(left: DmConversation, right: DmConversation): nu
   const rightMs = conversationSortMs(right);
   if (leftMs !== rightMs) return rightMs - leftMs;
   return normalizedPeerJid(left.peerJid).localeCompare(normalizedPeerJid(right.peerJid));
+}
+
+function compareActiveCallRows(
+  left: { activity: DmCallActivity; peerJid: string },
+  right: { activity: DmCallActivity; peerJid: string },
+): number {
+  const leftPriority = dmCallActivitySortPriority(left.activity, callState.value, props.selfFullJid ?? null);
+  const rightPriority = dmCallActivitySortPriority(right.activity, callState.value, props.selfFullJid ?? null);
+  if (leftPriority !== rightPriority) return leftPriority - rightPriority;
+  const rightMs = timestampMs(right.activity.updatedAt);
+  const leftMs = timestampMs(left.activity.updatedAt);
+  if (rightMs !== leftMs) return rightMs - leftMs;
+  return left.peerJid.localeCompare(right.peerJid);
 }
 
 function preview(text?: string): string {
@@ -346,12 +355,17 @@ function activeCallRowLabel(row: {
   since: string;
 }): string {
   return [
-    `${row.action} ${row.title} call`,
+    activeCallRowActionPhrase(row),
     row.eyebrow,
     row.meta,
     row.description,
     row.since,
   ].filter(Boolean).join(", ");
+}
+
+function activeCallRowActionPhrase(row: { action: string; title: string }): string {
+  if (row.action === "Open") return `Open ${row.title} conversation`;
+  return `${row.action} ${row.title} call`;
 }
 
 function selectCallActivity(activity: DmCallActivity): void {

--- a/chat/src/components/chat/HomeDashboard.vue
+++ b/chat/src/components/chat/HomeDashboard.vue
@@ -24,6 +24,7 @@ import {
   buildCallActivityDockEntries,
   canEndRecoveredDmCallActivity,
   callActivityDockSelection,
+  sortCallActivityDockEntries,
   type CallActivityDockEntry,
 } from "@/lib/calls/call-activity-dock";
 import { $callState } from "@/lib/calls/call-store";
@@ -153,28 +154,34 @@ const directMessages = computed(() =>
 const channelsBySpace = computed(() =>
   new Map(groups.value.flatMap((group) => group.space ? [[group.space.id, group.channels.length] as const] : [])),
 );
-const discoveredCallEntries = computed<CallActivityDockEntry[]>(() => buildCallActivityDockEntries({
-  channels: props.channels,
-  conversations: props.dmConversations ?? [],
-  activeChannelId: null,
-  activeChannelRoomJid: null,
-  activePeerJid: null,
-  sidebarMode: "channels",
-  activeChannelJids: activeChannelJids.value,
-  managedMucDomain: props.managedMucDomain ?? null,
-  callParticipantCounts: callParticipantCounts.value,
-  callParticipants: callParticipants.value,
-  callMediaByRoom: callMediaByRoom.value,
-  dmCallActivities: dmCallActivities.value,
-}));
+const discoveredCallEntries = computed<CallActivityDockEntry[]>(() =>
+  sortCallActivityDockEntries(
+    buildCallActivityDockEntries({
+      channels: props.channels,
+      conversations: props.dmConversations ?? [],
+      activeChannelId: null,
+      activeChannelRoomJid: null,
+      activePeerJid: null,
+      sidebarMode: "channels",
+      activeChannelJids: activeChannelJids.value,
+      managedMucDomain: props.managedMucDomain ?? null,
+      callParticipantCounts: callParticipantCounts.value,
+      callParticipants: callParticipants.value,
+      callMediaByRoom: callMediaByRoom.value,
+      dmCallActivities: dmCallActivities.value,
+    }),
+    callState.value,
+    props.selfFullJid ?? null,
+  )
+);
 const currentCallFallbackEntry = computed<CallActivityDockEntry | null>(() =>
   buildCurrentCallFallbackEntry(),
 );
 const activeCallEntries = computed<CallActivityDockEntry[]>(() => {
   const entries = discoveredCallEntries.value;
   const currentEntry = currentCallFallbackEntry.value;
-  if (!currentEntry || entries.some(isSameCallEntry(currentEntry))) return entries;
-  return [currentEntry, ...entries];
+  if (!currentEntry) return entries;
+  return [currentEntry, ...entries.filter((entry) => !isSameCallEntry(currentEntry)(entry))];
 });
 const activeCallSummaryCount = computed(() => activeCallEntries.value.length);
 const activeCallStatusMessage = computed(() => {
@@ -617,9 +624,8 @@ function callEntryVisualTone(entry: CallActivityDockEntry): CallEntryVisualTone 
 }
 
 function callEntryLabel(entry: CallActivityDockEntry): string {
-  const action = callEntryActionLabel(entry);
   return [
-    `${action} ${entry.title}`,
+    callEntryActionPhrase(entry),
     callEntryKindLabel(entry),
     callEntryStatus(entry),
     callEntryEyebrow(entry),
@@ -864,7 +870,22 @@ function onHeroCta() {
 function heroCallCtaLabel(entry: CallActivityDockEntry): string {
   const action = callEntryActionLabel(entry);
   if (action === "Return") return `Return to ${entry.title} call`;
+  if (action === "Open") {
+    return entry.kind === "dm"
+      ? `Open ${entry.title} conversation`
+      : `Open ${entry.title} channel`;
+  }
   return `${action} ${entry.title} call`;
+}
+
+function callEntryActionPhrase(entry: CallActivityDockEntry): string {
+  const action = callEntryActionLabel(entry);
+  if (action === "Open") {
+    return entry.kind === "dm"
+      ? `Open ${entry.title} conversation`
+      : `Open ${entry.title} channel`;
+  }
+  return `${action} ${entry.title}`;
 }
 </script>
 

--- a/chat/src/dms/conversations.ts
+++ b/chat/src/dms/conversations.ts
@@ -50,6 +50,8 @@ export function useDirectMessageConversations(
   const pendingMarkRead = new Set<string>();
   const queuedMarkRead = new Set<string>();
   const inboxAccountedMessageIdsByJid = new Map<string, Set<string>>();
+  let lastPeerCallHydrationKey = "";
+  let lastPeerCallHydrationClient: BrowserXmppClient | null = null;
 
   function storageKey() {
     const bare = session.value ? barePeerJid(session.value.jid) : "";
@@ -216,6 +218,25 @@ export function useDirectMessageConversations(
     await currentClient.hydrateRecentDmCallActivities().catch(() => undefined);
   }
 
+  function hydratePeerDmCallActivity(peerJid: string) {
+    const bare = barePeerJid(peerJid);
+    const currentClient = xmppClient.value;
+    const currentSessionJid = session.value?.jid ?? null;
+    if (!bare || !currentClient || !currentSessionJid) return;
+    const hydrateRecentDmCallActivity = currentClient.hydrateRecentDmCallActivity?.bind(currentClient);
+    if (!hydrateRecentDmCallActivity) return;
+    const hydrationKey = `${currentSessionJid}\n${bare}`;
+    if (hydrationKey === lastPeerCallHydrationKey && currentClient === lastPeerCallHydrationClient) return;
+    lastPeerCallHydrationKey = hydrationKey;
+    lastPeerCallHydrationClient = currentClient;
+    void hydrateRecentDmCallActivity(bare).catch(() => {
+      if (lastPeerCallHydrationKey === hydrationKey && lastPeerCallHydrationClient === currentClient) {
+        lastPeerCallHydrationKey = "";
+        lastPeerCallHydrationClient = null;
+      }
+    });
+  }
+
   async function hydrateFromInbox(): Promise<boolean> {
     const currentClient = xmppClient.value;
     const currentSessionJid = session.value?.jid ?? null;
@@ -270,6 +291,7 @@ export function useDirectMessageConversations(
     const bare = barePeerJid(peerJid);
     ensureConversation(bare);
     activePeerJid.value = bare;
+    hydratePeerDmCallActivity(bare);
     try {
       await xmppClient.value?.subscribeToPeerPresence(bare);
     } catch {
@@ -316,6 +338,8 @@ export function useDirectMessageConversations(
     () => session.value?.jid,
     () => {
       inboxRequestId += 1;
+      lastPeerCallHydrationKey = "";
+      lastPeerCallHydrationClient = null;
       pendingMarkRead.clear();
       queuedMarkRead.clear();
       inboxAccountedMessageIdsByJid.clear();
@@ -327,8 +351,16 @@ export function useDirectMessageConversations(
       for (const c of conversations.value) {
         xmppClient.value?.subscribeToPeerPresence(c.peerJid);
       }
+      if (activePeerJid.value) hydratePeerDmCallActivity(activePeerJid.value);
     },
     { immediate: true },
+  );
+
+  watch(
+    [xmppClient, activePeerJid],
+    () => {
+      if (activePeerJid.value) hydratePeerDmCallActivity(activePeerJid.value);
+    },
   );
 
   watch([conversations, activePeerJid], persist, { deep: true });

--- a/chat/src/lib/calls/call-activity-dock.ts
+++ b/chat/src/lib/calls/call-activity-dock.ts
@@ -167,6 +167,71 @@ export function callActivityDockSelection(
   return { kind: "dm-open", peerJid: entry.peerJid };
 }
 
+export function sortCallActivityDockEntries(
+  entries: readonly CallActivityDockEntry[],
+  callState: CallState = { phase: "idle" },
+  selfFullJid?: string | null,
+): CallActivityDockEntry[] {
+  return [...entries].sort((left, right) => compareCallActivityDockEntries(left, right, callState, selfFullJid));
+}
+
+function compareCallActivityDockEntries(
+  left: CallActivityDockEntry,
+  right: CallActivityDockEntry,
+  callState: CallState,
+  selfFullJid?: string | null,
+): number {
+  const leftPriority = callActivityDockPriority(left, callState, selfFullJid);
+  const rightPriority = callActivityDockPriority(right, callState, selfFullJid);
+  if (leftPriority !== rightPriority) return leftPriority - rightPriority;
+
+  const leftUpdatedAt = entryUpdatedAtMs(left);
+  const rightUpdatedAt = entryUpdatedAtMs(right);
+  if (leftUpdatedAt !== rightUpdatedAt) return rightUpdatedAt - leftUpdatedAt;
+
+  return entryTitleForSort(left).localeCompare(entryTitleForSort(right));
+}
+
+function callActivityDockPriority(
+  entry: CallActivityDockEntry,
+  callState: CallState,
+  selfFullJid?: string | null,
+): number {
+  const action = callActivityDockAction(entry, callState, selfFullJid);
+  if (action === "return") return 0;
+  if (entry.kind === "dm") {
+    return dmCallActivitySortPriority(entry, callState, selfFullJid);
+  }
+  if (action === "join") return 35;
+  return 70;
+}
+
+export function dmCallActivitySortPriority(
+  activity: Pick<DmCallActivity, "peerJid" | "remoteFullJid" | "mediaKnown" | "state" | "direction" | "join" | "sid">,
+  callState: CallState,
+  selfFullJid?: string | null,
+): number {
+  const action = dmCallActivityAction(activity, callState, selfFullJid);
+  if (action === "answer") return 10;
+  if (action === "reconnect") return 20;
+  if (canEndRecoveredDmCallActivity(activity, callState, selfFullJid)) return 25;
+  if (activity.state === "ringing" && activity.direction === "incoming") return 30;
+  if (activity.state === "accepted") return 40;
+  if (activity.state === "ringing") return 50;
+  return 60;
+}
+
+function entryUpdatedAtMs(entry: CallActivityDockEntry): number {
+  if (entry.kind !== "dm") return Number.NEGATIVE_INFINITY;
+  const ms = Date.parse(entry.updatedAt);
+  return Number.isFinite(ms) ? ms : Number.NEGATIVE_INFINITY;
+}
+
+function entryTitleForSort(entry: CallActivityDockEntry): string {
+  if (entry.kind === "channel") return `channel:${entry.title}`;
+  return `dm:${entry.title}`;
+}
+
 export function buildCallActivityDockEntries(options: {
   channels: ReadonlyArray<Pick<ChannelSummary, "id" | "name" | "jid">>;
   conversations: ReadonlyArray<Pick<DmConversation, "peerJid" | "peerUsername">>;

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -992,6 +992,7 @@ export async function beginMucCall(
       roomJid: normalizedRoomJid,
       sid: attemptId,
       selfFullJid,
+      media,
     });
     $lastCallError.set(null);
   } catch (err) {

--- a/chat/src/lib/calls/muc-call-actions.ts
+++ b/chat/src/lib/calls/muc-call-actions.ts
@@ -120,6 +120,7 @@ export async function leaveRetainedMucCallAction({
         roomJid: cachedSession.roomJid,
         selfFullJid,
         sid: cachedSession.sid,
+        media: cachedSession.media,
       });
       reportCallError(err);
     }

--- a/chat/src/lib/calls/muc-call-session-cache.ts
+++ b/chat/src/lib/calls/muc-call-session-cache.ts
@@ -2,6 +2,7 @@ import { barePeerJid } from "@/lib/xmpp/jid";
 import { normalizeMucCallRoomJid } from "./muc-call-presence";
 import { reportError } from "@/lib/telemetry";
 import { map } from "nanostores";
+import type { CallMedia } from "./types";
 
 const CACHE_PREFIX = "waddle.chat.muc-call-sessions";
 const CACHE_WINDOW_MS = 24 * 60 * 60 * 1000;
@@ -12,6 +13,7 @@ type CachedMucCallSession = {
   sid: string;
   selfFullJid: string;
   updatedAt: string;
+  media?: CallMedia;
   terminatePending?: boolean;
 };
 
@@ -21,21 +23,28 @@ export function rememberMucCallSession(options: {
   roomJid: string;
   sid: string;
   selfFullJid?: string | null;
+  media?: CallMedia | null;
   now?: Date;
 }): void {
   const entry = normalizeEntry({
     roomJid: options.roomJid,
     sid: options.sid,
     selfFullJid: options.selfFullJid?.trim() ?? "",
+    ...(options.media ? { media: options.media } : {}),
     updatedAt: options.now?.toISOString() ?? new Date().toISOString(),
   });
   if (!entry) return;
-  forgetPendingEntry(entry);
+  forgetPendingEntriesForRoom(entry);
   const selfBare = normalizedBare(entry.selfFullJid);
   if (!selfBare) return;
   const now = options.now ?? new Date();
   const entries = readEntries(selfBare)
     .filter((candidate) => !isExpired(candidate.updatedAt, now))
+    .filter((candidate) =>
+      !candidate.terminatePending ||
+      candidate.roomJid !== entry.roomJid ||
+      candidate.selfFullJid !== entry.selfFullJid
+    )
     .filter((candidate) =>
       candidate.roomJid !== entry.roomJid ||
       candidate.sid !== entry.sid ||
@@ -76,12 +85,14 @@ export function markMucCallSessionTerminatePending(options: {
   roomJid: string;
   sid: string;
   selfFullJid?: string | null;
+  media?: CallMedia | null;
   now?: Date;
 }): void {
   const entry = normalizeEntry({
     roomJid: options.roomJid,
     sid: options.sid,
     selfFullJid: options.selfFullJid?.trim() ?? "",
+    ...(options.media ? { media: options.media } : {}),
     updatedAt: options.now?.toISOString() ?? new Date().toISOString(),
     terminatePending: true,
   });
@@ -95,7 +106,12 @@ export function markMucCallSessionTerminatePending(options: {
       candidate.roomJid === entry.roomJid &&
       candidate.sid === entry.sid &&
       candidate.selfFullJid === entry.selfFullJid
-        ? { ...candidate, terminatePending: true, updatedAt: entry.updatedAt }
+        ? {
+            ...candidate,
+            ...(entry.media ? { media: entry.media } : {}),
+            terminatePending: true,
+            updatedAt: entry.updatedAt,
+          }
         : candidate
     ));
   if (!entries.some((candidate) =>
@@ -159,6 +175,7 @@ function normalizeEntry(entry: CachedMucCallSession): CachedMucCallSession | nul
     sid,
     selfFullJid,
     updatedAt: entry.updatedAt,
+    ...(isCallMedia(entry.media) ? { media: entry.media } : {}),
     ...(entry.terminatePending ? { terminatePending: true } : {}),
   };
 }
@@ -220,19 +237,19 @@ export function hydrateMucCallTerminatePendingSessions(
   ));
 }
 
-export function hasPendingMucCallTerminateSession(
+export function pendingMucCallTerminateSession(
   sessions: Record<string, CachedMucCallSession>,
   roomJid: string,
   selfFullJid?: string | null,
-): boolean {
+): CachedMucCallSession | null {
   const room = normalizeMucCallRoomJid(roomJid);
   const self = selfFullJid?.trim() ?? "";
-  if (!room || !self) return false;
-  return Object.values(sessions).some((entry) =>
+  if (!room || !self) return null;
+  return Object.values(sessions).find((entry) =>
     entry.terminatePending &&
     entry.roomJid === room &&
     entry.selfFullJid === self
-  );
+  ) ?? null;
 }
 
 function syncPendingEntries(entries: CachedMucCallSession[]): void {
@@ -244,12 +261,15 @@ function syncPendingEntries(entries: CachedMucCallSession[]): void {
   $mucCallTerminatePendingSessions.set(next);
 }
 
-function forgetPendingEntry(entry: CachedMucCallSession): void {
+function forgetPendingEntriesForRoom(entry: CachedMucCallSession): void {
   const current = $mucCallTerminatePendingSessions.get();
-  const key = sessionKey(entry);
-  if (!(key in current)) return;
-  const next = { ...current };
-  delete next[key];
+  const next = Object.fromEntries(
+    Object.entries(current).filter(([, candidate]) =>
+      candidate.roomJid !== entry.roomJid ||
+      candidate.selfFullJid !== entry.selfFullJid
+    ),
+  );
+  if (Object.keys(next).length === Object.keys(current).length) return;
   $mucCallTerminatePendingSessions.set(next);
 }
 
@@ -279,6 +299,12 @@ function isCachedMucCallSession(value: unknown): value is CachedMucCallSession {
     typeof candidate.selfFullJid === "string" &&
     typeof candidate.updatedAt === "string"
   );
+}
+
+function isCallMedia(value: unknown): value is CallMedia {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return typeof candidate.audio === "boolean" && typeof candidate.video === "boolean";
 }
 
 function storage(): Storage | null {

--- a/chat/src/lib/calls/use-active-muc-call.ts
+++ b/chat/src/lib/calls/use-active-muc-call.ts
@@ -10,7 +10,7 @@ import {
 } from "./muc-call-presence";
 import {
   $mucCallTerminatePendingSessions,
-  hasPendingMucCallTerminateSession,
+  pendingMucCallTerminateSession,
 } from "./muc-call-session-cache";
 import type { CallMedia } from "./types";
 import { connectionStore } from "@/lib/connection-store";
@@ -108,13 +108,14 @@ export function useRoomHasActiveCall(
     return participants.value[room] ?? [];
   });
 
-  const pendingTerminate = computed<boolean>(() =>
-    hasPendingMucCallTerminateSession(
+  const pendingTerminateSession = computed(() =>
+    pendingMucCallTerminateSession(
       pendingTerminates.value,
       normalizedRoomJid.value ?? "",
       currentClientFullJid(),
     )
   );
+  const pendingTerminate = computed<boolean>(() => !!pendingTerminateSession.value);
 
   const hasActiveCall = computed<boolean>(() => participantList.value.length > 0 || pendingTerminate.value);
 
@@ -134,13 +135,18 @@ export function useRoomHasActiveCall(
     const owners = participantOwners.value[room] ?? [];
     return hasOwnerFullJid(owners, fullJid) ||
       hasUnownedSelfNick(owners, connectionStore.session?.username ?? null, participantList.value) ||
-      hasPendingMucCallTerminateSession(pendingTerminates.value, room, fullJid);
+      !!pendingMucCallTerminateSession(pendingTerminates.value, room, fullJid);
   });
 
   const participantCount = computed<number>(() => Math.max(participantList.value.length, pendingTerminate.value ? 1 : 0));
 
   const media = computed<CallMedia>(() =>
-    mediaForRoom(normalizedRoomJid.value ?? "", state.value, callMedia.value)
+    mediaForRoomWithPendingFallback(
+      normalizedRoomJid.value ?? "",
+      state.value,
+      pendingTerminateSession.value?.media,
+      callMedia.value,
+    )
   );
 
   return { hasActiveCall, selfInCall, localResourceInCall, participantCount, media };
@@ -169,7 +175,8 @@ export function readRoomHasActiveCall(roomJid: string): {
   const nick = connectionStore.session?.username ?? null;
   const fullJid = currentClientFullJid();
   const s = $callState.get();
-  const pendingTerminate = hasPendingMucCallTerminateSession(pendingTerminates, normalized, fullJid);
+  const pendingTerminateSession = pendingMucCallTerminateSession(pendingTerminates, normalized, fullJid);
+  const pendingTerminate = !!pendingTerminateSession;
   return {
     hasActiveCall: participants.length > 0 || pendingTerminate,
     selfInCall: !!nick && (participants.includes(nick) || pendingTerminate),
@@ -183,7 +190,12 @@ export function readRoomHasActiveCall(roomJid: string): {
       hasUnownedSelfNick(participantOwners, nick, participants) ||
       pendingTerminate,
     participantCount: Math.max(participants.length, pendingTerminate ? 1 : 0),
-    media: mediaForRoom(normalized, s),
+    media: mediaForRoomWithPendingFallback(
+      normalized,
+      s,
+      pendingTerminateSession?.media,
+      $mucCallMedia.get(),
+    ),
   };
 }
 
@@ -253,4 +265,24 @@ function mediaForRoom(
     return state.media;
   }
   return mucCallMediaForRoom(normalized, mediaByRoom);
+}
+
+function mediaForRoomWithPendingFallback(
+  roomJid: string,
+  state: ReturnType<typeof $callState.get>,
+  pendingMedia?: CallMedia,
+  mediaByRoom?: Record<string, CallMedia>,
+): CallMedia {
+  const normalized = normalizeMucCallRoomJid(roomJid);
+  if (!normalized) return mucCallMediaForRoom("");
+  const liveMedia = mediaByRoom?.[normalized];
+  if (liveMedia) return liveMedia;
+  if (
+    (state.phase === "active" || state.phase === "muc-pending") &&
+    state.kind === "muc" &&
+    normalizeMucCallRoomJid(state.peer) === normalized
+  ) {
+    return state.media;
+  }
+  return pendingMedia ?? mucCallMediaForRoom(normalized, mediaByRoom);
 }

--- a/chat/tests/call-activity-dock.test.ts
+++ b/chat/tests/call-activity-dock.test.ts
@@ -11,6 +11,7 @@ import {
   buildCallActivityDockEntries,
   callActivityDockAction,
   callActivityDockSelection,
+  sortCallActivityDockEntries,
 } from "../src/lib/calls/call-activity-dock";
 import {
   activeChannelRailCallCount,
@@ -27,6 +28,10 @@ import {
 } from "../src/lib/calls/call-controls";
 import { $callUiMode } from "../src/lib/calls/ui-mode";
 import { applyMucCallPresence, clearMucCallParticipants, $mucCallMedia, $mucCallParticipants } from "../src/lib/calls/muc-call-presence";
+import {
+  clearAllMucCallSessionCacheForTests,
+  markMucCallSessionTerminatePending,
+} from "../src/lib/calls/muc-call-session-cache";
 import { clearDmCallActivities, $dmCallActivities } from "../src/lib/calls/dm-call-activity";
 import type { DmCallActivity } from "../src/lib/calls/dm-call-activity";
 import type { CallState, LiveKitJoin } from "../src/lib/calls/types";
@@ -35,6 +40,7 @@ import { connectionStore } from "../src/lib/connection-store";
 afterEach(() => {
   clearCallState();
   clearMucCallParticipants();
+  clearAllMucCallSessionCacheForTests();
   clearDmCallActivities();
   $callConnecting.set(false);
   $callMicEnabled.set(true);
@@ -170,6 +176,66 @@ describe("call activity dock model", () => {
       peerJid: "carol@example.com",
       isActive: true,
     });
+  });
+
+  test("sorts active-call hub entries by user urgency after refresh", () => {
+    const entries = buildCallActivityDockEntries({
+      channels: [
+        { id: "general", name: "General", jid: "general@conference.example.com" },
+      ],
+      conversations: [
+        { peerJid: "bob@example.com", peerUsername: "Bob" },
+        { peerJid: "carol@example.com", peerUsername: "Carol" },
+        { peerJid: "dana@example.com", peerUsername: "Dana" },
+      ],
+      activeChannelId: null,
+      activePeerJid: null,
+      sidebarMode: "channels",
+      activeChannelJids: new Set(),
+      managedMucDomain: "conference.example.com",
+      callParticipantCounts: {
+        "general@conference.example.com": 3,
+      },
+      dmCallActivities: {
+        "bob@example.com": {
+          peerJid: "bob@example.com",
+          remoteFullJid: "bob@example.com/phone",
+          sid: "incoming",
+          media: { audio: true, video: false },
+          state: "ringing",
+          direction: "incoming",
+          updatedAt: "2026-05-25T10:00:00.000Z",
+        },
+        "carol@example.com": {
+          peerJid: "carol@example.com",
+          remoteFullJid: "carol@example.com/phone",
+          sid: "reconnect",
+          media: { audio: true, video: true },
+          join: liveKitJoinFor(),
+          state: "accepted",
+          direction: "incoming",
+          updatedAt: "2026-05-25T12:00:00.000Z",
+        },
+        "dana@example.com": {
+          peerJid: "dana@example.com",
+          sid: "syncing",
+          media: { audio: true, video: false },
+          mediaKnown: false,
+          state: "accepted",
+          direction: "unknown",
+          updatedAt: "2026-05-25T13:00:00.000Z",
+        },
+      },
+    });
+
+    const sorted = sortCallActivityDockEntries(entries, { phase: "idle" }, "alice@example.com/web");
+
+    expect(sorted.map((entry) => entry.key)).toEqual([
+      "dm:bob@example.com:incoming",
+      "dm:carol@example.com:reconnect",
+      "channel:general",
+      "dm:dana@example.com:syncing",
+    ]);
   });
 
   test("maps active rows to direct join, return, or reconnect actions", () => {
@@ -1129,7 +1195,7 @@ describe("CallActivityDock rendering", () => {
     expect(readyShell).toContain(":active-channel-call-count=\"activeChannelCallCount\"");
     expect(readyShell).toContain(":active-dm-call-count=\"activeDmCallCount\"");
     expect(readyShell).toContain(":call-participants=\"retainedMucCallParticipantsStore\"");
-    expect(readyShell).toContain(":call-media-by-room=\"mucCallMediaStore\"");
+    expect(readyShell).toContain(":call-media-by-room=\"retainedMucCallMediaStore\"");
     expect(readyShell).toContain("@select-channel=\"onSelectChannelFromSidebar\"");
     expect(readyShell).toContain("@join-channel-call=\"joinChannelCallFromActivity\"");
     expect(readyShell.match(/@leave-channel-call="leaveRetainedChannelCall"/g)?.length ?? 0).toBeGreaterThanOrEqual(3);
@@ -1750,6 +1816,46 @@ describe("CallActivityDock rendering", () => {
     expect(html).toContain("Live");
   });
 
+  test("orders direct-call panel rows by action urgency before recency", async () => {
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com",
+        remoteFullJid: "bob@example.com/phone",
+        sid: "incoming",
+        media: { audio: true, video: false },
+        state: "ringing",
+        direction: "incoming",
+        updatedAt: "2026-05-25T09:00:00.000Z",
+      },
+      "carol@example.com": {
+        peerJid: "carol@example.com",
+        remoteFullJid: "carol@example.com/phone",
+        sid: "reconnect",
+        media: { audio: true, video: true },
+        join: liveKitJoinFor(),
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: "2026-05-25T12:00:00.000Z",
+      },
+    });
+
+    const html = await renderVueComponent("../src/components/chat/DmPanel.vue", {
+      conversations: [
+        { peerJid: "bob@example.com", peerUsername: "Bob" },
+        { peerJid: "carol@example.com", peerUsername: "Carol" },
+      ],
+      activePeerJid: null,
+      selfFullJid: "alice@example.com/web",
+    });
+
+    const incomingIndex = html.indexOf("Answer Bob call, Incoming call, Incoming voice call");
+    const reconnectIndex = html.indexOf("Reconnect Carol call, Live now, Live video call");
+
+    expect(incomingIndex).toBeGreaterThanOrEqual(0);
+    expect(reconnectIndex).toBeGreaterThanOrEqual(0);
+    expect(incomingIndex).toBeLessThan(reconnectIndex);
+  });
+
   test("labels non-resumable direct calls in the direct-message panel", async () => {
     $dmCallActivities.set({
       "bob@example.com": {
@@ -1773,7 +1879,7 @@ describe("CallActivityDock rendering", () => {
     expect(html).toContain("Other device");
     expect(html).toContain("Voice call · Other device");
     expect(html).toContain("This call is live on another browser or device.");
-    expect(html).toContain("Open bob call, Other device, Voice call · Other device");
+    expect(html).toContain("Open bob conversation, Other device, Voice call · Other device");
     expect(html).not.toContain("Reconnect bob call");
   });
 
@@ -1803,7 +1909,7 @@ describe("CallActivityDock rendering", () => {
     expect(html).toContain("Recovered after refresh");
     expect(html).toContain("Video call · End available");
     expect(html).toContain("The saved reconnect details expired, but this tab can still end the call.");
-    expect(html).toContain("Open bob call, Recovered after refresh, Video call · End available");
+    expect(html).toContain("Open bob conversation, Recovered after refresh, Video call · End available");
     expect(html).toContain('aria-label="End bob video call"');
     expect(html).not.toContain("Reconnect bob call");
   });
@@ -1927,7 +2033,7 @@ describe("CallActivityDock rendering", () => {
     });
 
     expect(html).toContain("Calling voice call");
-    expect(html).toContain("Open alice call, Calling, Calling voice call");
+    expect(html).toContain("Open alice conversation, Calling, Calling voice call");
     expect(html).not.toContain("Voice call calling");
   });
 
@@ -2630,6 +2736,128 @@ describe("CallActivityDock rendering", () => {
     });
     expect(setupBindingRefValue(bindings, "visibleManagedMucDomain")).toBe("conference.example.com");
     expect(setupBindingRefValue(bindings, "visibleSelfFullJid")).toBe("alice@example.com/web");
+  });
+
+  test("shell surfaces pending retained group-call video media after failed cleanup", async () => {
+    markMucCallSessionTerminatePending({
+      roomJid: "general@conference.example.com",
+      sid: "muc-video-retry",
+      selfFullJid: "alice@example.com/web",
+      media: { audio: true, video: true },
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    });
+
+    const bindings = await suppressVueLifecycleSetupWarnings(() =>
+      setupVueComponent("../src/components/chat/ChatReadyShell.vue", {
+        controller: {
+          ui: { activeCommunitySurface: { value: null } },
+          connectionStore: {
+            client: { fullJid: "alice@example.com/web" },
+            session: { username: "alice", jid: "alice@example.com" },
+          },
+          waddles: {
+            mucServiceJid: { value: "conference.example.com" },
+            sortedSpaces: { value: [] },
+            sortedChannels: { value: [] },
+            isLoadingStructure: { value: false },
+          },
+          selfDomain: { value: "example.com" },
+          rosterContacts: {
+            contacts: { value: [] },
+            isLoadingContacts: { value: false },
+          },
+          messaging: {
+            mentionedChannelCounts: { value: {} },
+            activeChannels: { value: new Set<string>() },
+          },
+          dmConversations: { conversations: { value: [] } },
+          computedChannelUnreadMap: { value: {} },
+          activeRightPanel: { value: null },
+          activeThreadStack: { value: [] },
+          communityEvents: { rsvp: () => undefined },
+          closePinnedPanel: () => undefined,
+          activateRightPanel: () => undefined,
+          selectDm: () => undefined,
+          selectChannel: () => undefined,
+          selectChannelByRoomJid: () => undefined,
+        },
+      })
+    );
+
+    expect(setupBindingRefValue(bindings, "retainedMucCallParticipantsStore")).toEqual({
+      "general@conference.example.com": ["alice"],
+    });
+    expect(setupBindingRefValue(bindings, "retainedMucCallMediaStore")).toEqual({
+      "general@conference.example.com": { audio: true, video: true },
+    });
+    expect(setupBindingRefValue<{ callMediaByRoom: Record<string, CallMedia> }>(
+      bindings,
+      "homeDashboardProps",
+    ).callMediaByRoom).toEqual({
+      "general@conference.example.com": { audio: true, video: true },
+    });
+  });
+
+  test("shell keeps live group-call media authoritative over stale pending cleanup media", async () => {
+    markMucCallSessionTerminatePending({
+      roomJid: "general@conference.example.com",
+      sid: "muc-video-retry",
+      selfFullJid: "alice@example.com/web",
+      media: { audio: true, video: true },
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    });
+    applyMucCallPresence({
+      from: "general@conference.example.com/alice",
+      muc_jid: "alice@example.com/web",
+      muji: { preparing: false, active: true, audio: true, video: false },
+    });
+
+    const bindings = await suppressVueLifecycleSetupWarnings(() =>
+      setupVueComponent("../src/components/chat/ChatReadyShell.vue", {
+        controller: {
+          ui: { activeCommunitySurface: { value: null } },
+          connectionStore: {
+            client: { fullJid: "alice@example.com/web" },
+            session: { username: "alice", jid: "alice@example.com" },
+          },
+          waddles: {
+            mucServiceJid: { value: "conference.example.com" },
+            sortedSpaces: { value: [] },
+            sortedChannels: { value: [] },
+            isLoadingStructure: { value: false },
+          },
+          selfDomain: { value: "example.com" },
+          rosterContacts: {
+            contacts: { value: [] },
+            isLoadingContacts: { value: false },
+          },
+          messaging: {
+            mentionedChannelCounts: { value: {} },
+            activeChannels: { value: new Set<string>() },
+          },
+          dmConversations: { conversations: { value: [] } },
+          computedChannelUnreadMap: { value: {} },
+          activeRightPanel: { value: null },
+          activeThreadStack: { value: [] },
+          communityEvents: { rsvp: () => undefined },
+          closePinnedPanel: () => undefined,
+          activateRightPanel: () => undefined,
+          selectDm: () => undefined,
+          selectChannel: () => undefined,
+          selectChannelByRoomJid: () => undefined,
+        },
+      })
+    );
+
+    expect(setupBindingRefValue(bindings, "retainedMucCallMediaStore")).toEqual({
+      "general@conference.example.com": { audio: true, video: false },
+    });
+    expect(setupBindingRefValue<{ callMediaByRoom: Record<string, CallMedia> }>(
+      bindings,
+      "homeDashboardProps",
+    ).callMediaByRoom).toEqual({
+      "general@conference.example.com": { audio: true, video: false },
+    });
   });
 
   test("mobile drawer routes community surfaces through the controller", async () => {

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -19,6 +19,7 @@ import { leaveRetainedMucCallAction, startMucCallAction } from "../src/lib/calls
 import {
   $mucCallTerminatePendingSessions,
   clearAllMucCallSessionCacheForTests,
+  markMucCallSessionTerminatePending,
   readMucCallSession,
   rememberMucCallSession,
 } from "../src/lib/calls/muc-call-session-cache";
@@ -487,6 +488,7 @@ describe("leaveRetainedMucCallAction", () => {
       roomJid: "chan@muc.test",
       sid: "muc-retry-live",
       selfFullJid: "alice@waddle.test/web",
+      media: { audio: true, video: true },
       now: new Date("2026-05-26T12:00:00.000Z"),
     });
     const sender: RawIqSender = {
@@ -526,6 +528,7 @@ describe("leaveRetainedMucCallAction", () => {
         roomJid: "chan@muc.test",
         sid: "muc-retry-live",
         selfFullJid: "alice@waddle.test/web",
+        media: { audio: true, video: true },
         updatedAt: expect.any(String),
         terminatePending: true,
       },
@@ -567,6 +570,34 @@ describe("leaveRetainedMucCallAction", () => {
       "chan@muc.test": [{ nick: "alice", realJid: "alice@waddle.test/web" }],
     });
     expect($lastCallError.get()).toContain("simulated Muji leave failure");
+  });
+
+  test("remembering a fresh Muji session clears stale pending cleanup for the same room", () => {
+    markMucCallSessionTerminatePending({
+      roomJid: "chan@muc.test",
+      sid: "muc-stale-video",
+      selfFullJid: "alice@waddle.test/web",
+      media: { audio: true, video: true },
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    });
+
+    rememberMucCallSession({
+      roomJid: "chan@muc.test",
+      sid: "muc-fresh-voice",
+      selfFullJid: "alice@waddle.test/web",
+      media: { audio: true, video: false },
+      now: new Date("2026-05-26T12:01:00.000Z"),
+    });
+
+    expect($mucCallTerminatePendingSessions.get()).toEqual({});
+    expect(readMucCallSession({
+      roomJid: "chan@muc.test",
+      selfFullJid: "alice@waddle.test/web",
+      now: new Date("2026-05-26T12:01:00.000Z"),
+    })).toMatchObject({
+      sid: "muc-fresh-voice",
+      media: { audio: true, video: false },
+    });
   });
 });
 

--- a/chat/tests/dm-conversations.test.ts
+++ b/chat/tests/dm-conversations.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, mock } from "bun:test";
-import { ref } from "vue";
+import { nextTick, ref } from "vue";
 import { useDirectMessageConversations } from "../src/dms/conversations";
 import type { WaddleSession } from "../src/lib/server-auth";
 import type { BrowserXmppClient, InboxEntry, LiveDmMessage } from "../src/lib/xmpp-client";
@@ -12,6 +12,7 @@ type MockClient = BrowserXmppClient & {
   fetchInbox: ReturnType<typeof mock>;
   markInboxRead: ReturnType<typeof mock>;
   subscribeToPeerPresence: ReturnType<typeof mock>;
+  hydrateRecentDmCallActivity: ReturnType<typeof mock>;
   hydrateRecentDmCallActivities: ReturnType<typeof mock>;
 };
 
@@ -20,6 +21,7 @@ function makeClient(conversations: InboxEntry[] = []): MockClient {
     fetchInbox: mock(() => Promise.resolve({ totalUnread: conversations.reduce((sum, conversation) => sum + conversation.unread, 0), conversations })),
     markInboxRead: mock(() => Promise.resolve()),
     subscribeToPeerPresence: mock(() => Promise.resolve()),
+    hydrateRecentDmCallActivity: mock(() => Promise.resolve()),
     hydrateRecentDmCallActivities: mock(() => Promise.resolve()),
   } as unknown as MockClient;
 }
@@ -78,6 +80,43 @@ describe("useDirectMessageConversations", () => {
     await composable.openDm("bob@example.com");
     await composable.openDm("bob@example.com");
     expect(composable.conversations.value).toHaveLength(1);
+  });
+
+  test("openDm refreshes per-peer call activity for hard-reload recovery", async () => {
+    const client = makeClient();
+    const { composable } = makeComposable({ client });
+
+    await composable.openDm("bob@example.com/mobile");
+
+    expect(client.hydrateRecentDmCallActivity).toHaveBeenCalledTimes(1);
+    expect(client.hydrateRecentDmCallActivity).toHaveBeenCalledWith("bob@example.com");
+    expect(client.subscribeToPeerPresence).toHaveBeenCalledWith("bob@example.com");
+  });
+
+  test("restored active DM refreshes per-peer call activity when the client attaches", async () => {
+    const client = makeClient();
+    const { composable, client: clientRef } = makeComposable();
+
+    await composable.openDm("bob@example.com");
+    clientRef.value = client;
+    await nextTick();
+
+    expect(client.hydrateRecentDmCallActivity).toHaveBeenCalledTimes(1);
+    expect(client.hydrateRecentDmCallActivity).toHaveBeenCalledWith("bob@example.com");
+  });
+
+  test("active DM refreshes per-peer call activity again after client rotation", async () => {
+    const firstClient = makeClient();
+    const secondClient = makeClient();
+    const { composable, client: clientRef } = makeComposable({ client: firstClient });
+
+    await composable.openDm("bob@example.com");
+    clientRef.value = secondClient;
+    await nextTick();
+
+    expect(firstClient.hydrateRecentDmCallActivity).toHaveBeenCalledTimes(1);
+    expect(secondClient.hydrateRecentDmCallActivity).toHaveBeenCalledTimes(1);
+    expect(secondClient.hydrateRecentDmCallActivity).toHaveBeenCalledWith("bob@example.com");
   });
 
   test("closeDm clears activePeerJid", async () => {

--- a/chat/tests/home-activity.test.ts
+++ b/chat/tests/home-activity.test.ts
@@ -398,7 +398,7 @@ describe("HomeDashboard activity rendering", () => {
     expect(html).toContain("2 people connected in this channel: alice, bob.");
     expect(html).toContain("alice, bob");
     expect(html).toContain("The video call is still live.");
-    expect(buttonForLabel(html, "Join General call")).toContain("Join General call");
+    expect(buttonForLabel(html, "Reconnect Bob call")).toContain("Reconnect Bob call");
     expect(html).toContain('aria-label="Join General, Group call, 2 people, Live now, 2 people connected in this channel: alice, bob., Group call"');
     expect(html).toContain(`aria-label="Reconnect Bob, Video call, Live, Live now, The video call is still live., Live video call · Updated ${updated}"`);
     expect(buttonForLabel(html, "Join General, Group call, 2 people, Live now, 2 people connected in this channel: alice, bob., Group call")).toContain("Join");
@@ -492,7 +492,8 @@ describe("HomeDashboard activity rendering", () => {
     expect(html).toContain("Other device");
     expect(html).toContain("This call is live on another browser or device.");
     expect(html).toContain("Voice call · Other device");
-    expect(html).toContain(`aria-label="Open Bob, Voice call, Live, Other device, This call is live on another browser or device., Voice call · Other device · Updated ${updated}"`);
+    expect(html).toContain("Open Bob conversation");
+    expect(html).toContain(`aria-label="Open Bob conversation, Voice call, Live, Other device, This call is live on another browser or device., Voice call · Other device · Updated ${updated}"`);
     expect(html).not.toContain("Reconnect Bob");
   });
 
@@ -538,7 +539,8 @@ describe("HomeDashboard activity rendering", () => {
     expect(html).toContain("Recovered after refresh");
     expect(html).toContain("The saved reconnect details expired, but this tab can still end the call.");
     expect(html).toContain("Video call · End available");
-    expect(html).toContain(`aria-label="Open Bob, Video call, Live, Recovered after refresh, The saved reconnect details expired, but this tab can still end the call., Video call · End available · Updated ${updated}"`);
+    expect(html).toContain("Open Bob conversation");
+    expect(html).toContain(`aria-label="Open Bob conversation, Video call, Live, Recovered after refresh, The saved reconnect details expired, but this tab can still end the call., Video call · End available · Updated ${updated}"`);
     expect(html).toContain('aria-label="End Bob video call"');
     expect(html).not.toContain("Reconnect Bob");
   });
@@ -586,6 +588,64 @@ describe("HomeDashboard activity rendering", () => {
     expect(html).toContain("Return");
     expect(html).not.toContain("Bob (bob@example.com), direct message");
     expect(html).not.toContain("No active calls.");
+  });
+
+  test("promotes the current call over a refreshed duplicate on the home dashboard", async () => {
+    $callState.set({
+      phase: "active",
+      kind: "dm",
+      peer: "bob@example.com/phone",
+      sid: "dm-current",
+      media: { audio: true, video: true },
+      join: {
+        url: "wss://livekit.example.test",
+        room: "dm-current",
+        identity: "alice@example.com/web",
+        token: liveKitToken(),
+      },
+    });
+
+    const html = await renderHomeDashboard({
+      spaces: [],
+      channels: [],
+      contacts: [],
+      isLoading: false,
+      channelUnreadMap: {},
+      activeChannelJids: new Set<string>(),
+      managedMucDomain: "conference.example.com",
+      callParticipantCounts: {},
+      dmConversations: [
+        {
+          peerJid: "bob@example.com",
+          peerUsername: "Bob",
+          unreadCount: 0,
+          presenceShow: "available",
+        },
+      ],
+      dmCallActivities: {
+        "bob@example.com": {
+          peerJid: "bob@example.com",
+          remoteFullJid: "bob@example.com/phone",
+          sid: "dm-current",
+          media: { audio: true, video: true },
+          join: {
+            url: "wss://livekit.example.test",
+            room: "dm-current",
+            identity: "alice@example.com/web",
+            token: liveKitToken(),
+          },
+          state: "accepted",
+          direction: "incoming",
+          updatedAt: "2026-05-26T00:00:00.000Z",
+        },
+      },
+      selfFullJid: "alice@example.com/web",
+    });
+
+    expect(html).toContain("<strong>1</strong> active call");
+    expect(html).toContain("1 live conversation");
+    expect(buttonForLabel(html, "Return to Bob call")).toContain("Return to Bob call");
+    expect(html).not.toContain("Reconnect Bob call");
   });
 
   test("counts and renders the local current group call before Muji discovery echoes activity", async () => {

--- a/chat/tests/use-active-muc-call.test.ts
+++ b/chat/tests/use-active-muc-call.test.ts
@@ -343,14 +343,21 @@ describe("readRoomHasActiveCall selector", () => {
     expect(readRoomHasActiveCall(ROOM).media).toEqual({ audio: true, video: true });
   });
 
-  test("keeps a cached terminate failure retryable after local Muji presence is cleared", () => {
+  test("keeps live Muji media authoritative over stale pending cleanup media", () => {
     setSession("alice");
     connectionStore.client = { fullJid: "alice@waddle.test/web" } as unknown as typeof connectionStore.client;
     markMucCallSessionTerminatePending({
       roomJid: ROOM,
-      sid: "muc-retry-live",
+      sid: "muc-retry-video",
       selfFullJid: "alice@waddle.test/web",
+      media: { audio: true, video: true },
       now: new Date("2026-05-26T12:00:00.000Z"),
+    });
+    applyMucCallPresence({
+      from: `${ROOM}/alice`,
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/web",
+      muji: { preparing: false, active: true, audio: true, video: false },
     });
 
     expect(readRoomHasActiveCall(ROOM)).toEqual({
@@ -359,6 +366,26 @@ describe("readRoomHasActiveCall selector", () => {
       localResourceInCall: true,
       participantCount: 1,
       media: { audio: true, video: false },
+    });
+  });
+
+  test("keeps a cached terminate failure retryable after local Muji presence is cleared", () => {
+    setSession("alice");
+    connectionStore.client = { fullJid: "alice@waddle.test/web" } as unknown as typeof connectionStore.client;
+    markMucCallSessionTerminatePending({
+      roomJid: ROOM,
+      sid: "muc-retry-live",
+      selfFullJid: "alice@waddle.test/web",
+      media: { audio: true, video: true },
+      now: new Date("2026-05-26T12:00:00.000Z"),
+    });
+
+    expect(readRoomHasActiveCall(ROOM)).toEqual({
+      hasActiveCall: true,
+      selfInCall: true,
+      localResourceInCall: true,
+      participantCount: 1,
+      media: { audio: true, video: true },
     });
   });
 });


### PR DESCRIPTION
## Summary
- Prioritize the active-call hub, Home dashboard, dock, and DM panel by what the user can actually do next after refresh: return, answer, reconnect, end recovered calls, then passive open-only rows.
- Hydrate 1:1 call activity per peer when a restored/open DM becomes active and when the XMPP client attaches or rotates, so hard reload recovery does not rely only on capped inbox-wide hydration.
- Keep retained Muji group calls actionable after reload or failed cleanup by preserving sid/media in pending sessions, clearing stale pending cleanup when a fresh room session is remembered, and feeding retained media into all shell call surfaces without overriding current live Muji media.
- Clean up recovered-call copy so expired/other-resource 1:1 rows open the conversation, while the separate end action remains the actual hangup affordance.
- Address review feedback by making live Muji media authoritative in both reactive and imperative room-call selectors, and by sharing the direct-call priority ladder between the dock and DM panel.

## Plan / Completion Matrix
- [x] 1:1 calls visible after refresh: MAM-backed DM call activity plus per-peer hydration on DM open/client attach.
- [x] 1:1 calls actionable after refresh: answer/reconnect/end/open-only states surfaced in banner, dock, Home, DM panel, and mobile drawer.
- [x] Current call survives discovery echo: current fallback is promoted and duplicate rediscovered rows are filtered.
- [x] Group calls visible after refresh: Muji participant presence, retained local participant overlay, and fallback room rows while channel metadata loads.
- [x] Group calls actionable after refresh: join/rejoin/leave routes through XMPP Muji/Jingle paths with room JID and sid preserved.
- [x] Media fidelity after failed cleanup: pending retained video media feeds Home, TopicsPanel/mobile, and activity docks only when live Muji media is absent.
- [x] UX ordering/labels: return/answer/reconnect/endable rows are prioritized; open-only rows say conversation/channel instead of promising a call action.

## XEP Review
- XEP-0353: 1:1 recovery still derives from archived Jingle Message Initiation markers and sends conformant proceed/finish/session-terminate paths; no non-XMPP recovery API was added.
- XEP-0313: refresh recovery uses personal MAM hydration, including per-peer scans when a restored DM opens or the client attaches.
- XEP-0272: group recovery remains Muji presence-driven, with presence-first leave behavior and preserved per-attempt sid for `send_muji_session_terminate`.
- No new custom `urn:waddle:*` wire shape was introduced.

## Verification
- `bun test`
- `bun run lint`
- `bun run build`
- `git diff --check`
- Adversarial review: 1:1 refresh, group/Muji refresh, and active-call UX/media were re-reviewed; no remaining actionable issues found.
- Review follow-up: Greptile's media-priority and duplicated-priority comments were addressed and re-verified.
