### PR TITLE
feat(server, chat): SFU-authoritative MUC call membership

### DIFF
--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -360,6 +360,10 @@ function joinChannelCallFromActivity(channelId: string | null, roomJid: string, 
     ensureJoined: async () => {
       await getClientJoiner()?.(roomJid);
     },
+    // Rejoining a call we were already in: prefer LiveKit-direct
+    // reconnect via the cached join over a fresh Jingle attempt.
+    // LK identity-uniqueness displaces any orphan session cleanly.
+    tryResumeFirst: true,
   });
 }
 

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -993,6 +993,7 @@ export async function beginMucCall(
       sid: attemptId,
       selfFullJid,
       media,
+      join,
     });
     $lastCallError.set(null);
   } catch (err) {

--- a/chat/src/lib/calls/dm-call-activity.ts
+++ b/chat/src/lib/calls/dm-call-activity.ts
@@ -12,7 +12,7 @@ import type { CallEvent, CallMedia, LiveKitJoin } from "./types";
 export const DM_CALL_ACTIVITY_ACTIVE_WINDOW_MS = 24 * 60 * 60 * 1000;
 const MAX_TERMINAL_TIMESTAMPS = 1024;
 const PRUNE_TIMER_SLACK_MS = 1_000;
-const LIVEKIT_JOIN_EXPIRY_SKEW_MS = 30_000;
+export const LIVEKIT_JOIN_EXPIRY_SKEW_MS = 30_000;
 
 type DmCallActivityState = "ringing" | "accepted";
 type DmCallResumeBlockReason =
@@ -157,7 +157,13 @@ function eventSelfFullJid(envelope: DmCallEventEnvelope, join?: LiveKitJoin): st
   return undefined;
 }
 
-function liveKitJoinTokenExpiresAt(token: string): Date | null {
+/**
+ * Decode a LiveKit join JWT and return its `exp` claim as a `Date`,
+ * or `null` for malformed input. Exported so the MUC resume path
+ * (`resumeMucCallActivity`) can reuse the same expiry check the DM
+ * resume path uses without re-implementing JWT decoding.
+ */
+export function liveKitJoinTokenExpiresAt(token: string): Date | null {
   const payload = token.split(".")[1];
   if (!payload) return null;
   try {

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -56,7 +56,21 @@ export type CallEngineEvents = {
    * mute via unpublish path, etc).
    */
   localTrackUnpublished: (track: LocalMediaTrack) => void;
+  /**
+   * Fires when a remote participant transitions to LiveKit's `active`
+   * state. Source of truth for "this peer is in the call" for the
+   * `$mucCallParticipants` projection in `use-call-engine.ts`.
+   */
+  participantConnected: (identity: string) => void;
   participantDisconnected: (identity: string) => void;
+  /**
+   * Fires once `connect()` resolves and the local participant has
+   * reached the `active` state in LiveKit. Surfaces the initial
+   * remote-participant set so the projection can seed
+   * `$mucCallParticipants` without missing peers that connected
+   * before our event listener attached.
+   */
+  connected: (snapshot: { localIdentity: string; remoteIdentities: string[] }) => void;
   disconnected: (reason?: string) => void;
 };
 
@@ -76,7 +90,9 @@ export class CallEngine {
     trackUnsubscribed: new Set(),
     localTrackPublished: new Set(),
     localTrackUnpublished: new Set(),
+    participantConnected: new Set(),
     participantDisconnected: new Set(),
+    connected: new Set(),
     disconnected: new Set(),
   };
 
@@ -107,6 +123,7 @@ export class CallEngine {
     room.on(RoomEvent.TrackUnsubscribed, this.handleTrackUnsubscribed);
     room.on(RoomEvent.LocalTrackPublished, this.handleLocalTrackPublished);
     room.on(RoomEvent.LocalTrackUnpublished, this.handleLocalTrackUnpublished);
+    room.on(RoomEvent.ParticipantConnected, this.handleParticipantConnected);
     room.on(RoomEvent.ParticipantDisconnected, this.handleParticipantDisconnected);
     room.on(RoomEvent.Disconnected, this.handleDisconnected);
     try {
@@ -121,6 +138,13 @@ export class CallEngine {
       throw err;
     }
     this.room = room;
+    // Emit the initial participant snapshot so subscribers can seed
+    // their projection without missing peers that connected before
+    // our listeners attached.
+    this.emit("connected", {
+      localIdentity: room.localParticipant.identity,
+      remoteIdentities: Array.from(room.remoteParticipants.values()).map((p) => p.identity),
+    });
     // Post-connect setup must be atomic from the caller's POV: if a
     // permission prompt is denied for the mic or cam, throwing without
     // first tearing down the half-initialized room would leave
@@ -209,6 +233,7 @@ export class CallEngine {
     room.off(RoomEvent.TrackUnsubscribed, this.handleTrackUnsubscribed);
     room.off(RoomEvent.LocalTrackPublished, this.handleLocalTrackPublished);
     room.off(RoomEvent.LocalTrackUnpublished, this.handleLocalTrackUnpublished);
+    room.off(RoomEvent.ParticipantConnected, this.handleParticipantConnected);
     room.off(RoomEvent.ParticipantDisconnected, this.handleParticipantDisconnected);
     room.off(RoomEvent.Disconnected, this.handleDisconnected);
     await room.disconnect();
@@ -285,6 +310,10 @@ export class CallEngine {
       kind,
       track,
     });
+  };
+
+  private handleParticipantConnected = (participant: RemoteParticipant) => {
+    this.emit("participantConnected", participant.identity);
   };
 
   private handleParticipantDisconnected = (participant: RemoteParticipant) => {

--- a/chat/src/lib/calls/muc-call-actions.ts
+++ b/chat/src/lib/calls/muc-call-actions.ts
@@ -1,11 +1,12 @@
-import { beginMucCall, reportCallError, type RawIqSender } from "./call-store";
+import { $callState, beginMucCall, reportCallError, type RawIqSender } from "./call-store";
+import { LIVEKIT_JOIN_EXPIRY_SKEW_MS, liveKitJoinTokenExpiresAt } from "./dm-call-activity";
 import { clearMucCallParticipant } from "./muc-call-presence";
 import {
   forgetMucCallSession,
   markMucCallSessionTerminatePending,
   readMucCallSession,
 } from "./muc-call-session-cache";
-import type { CallMedia } from "./types";
+import type { CallMedia, LiveKitJoin } from "./types";
 
 type MucCallStartActionOptions = {
   roomJid: string;
@@ -17,6 +18,14 @@ type MucCallStartActionOptions = {
   getSelfFullJid?: () => string | null | undefined;
   getExpectedMixerJid?: () => string | null | undefined;
   ensureJoined?: () => Promise<void>;
+  /**
+   * When true, attempt a direct LiveKit reconnect via
+   * `resumeMucCallActivity` before falling back to a fresh Jingle
+   * `beginMucCall`. The rejoin affordance after a tab reload sets
+   * this; the "join a call you weren't in" fresh-joiner button
+   * leaves it false.
+   */
+  tryResumeFirst?: boolean;
 };
 
 type RetainedMucCallLeaveActionOptions = {
@@ -41,6 +50,7 @@ export async function startMucCallAction({
   getSelfFullJid,
   getExpectedMixerJid,
   ensureJoined,
+  tryResumeFirst = false,
 }: MucCallStartActionOptions): Promise<boolean> {
   if (isBusy()) return false;
   const sender = getSender();
@@ -48,6 +58,15 @@ export async function startMucCallAction({
   setStarting(true);
   try {
     await ensureJoined?.();
+    if (tryResumeFirst) {
+      const resumed = await resumeMucCallActivity({
+        roomJid,
+        getSender,
+        getSelfNick,
+        getSelfFullJid,
+      });
+      if (resumed) return true;
+    }
     await beginMucCall(
       sender,
       roomJid,
@@ -126,4 +145,132 @@ export async function leaveRetainedMucCallAction({
     }
   }
   return terminated;
+}
+
+/**
+ * Resume options for a recovered MUC group call. Mirror of
+ * `resumeDmCallActivity`'s shape.
+ */
+type ResumeMucCallActionOptions = {
+  roomJid: string;
+  getSender: () => RawIqSender | null;
+  getSelfNick: () => string | undefined;
+  getSelfFullJid?: () => string | null | undefined;
+  now?: Date;
+};
+
+/**
+ * Test whether the cached MUC session for `(roomJid, selfFullJid)`
+ * can be reused for a direct LiveKit reconnect without a fresh
+ * Jingle session-initiate handshake.
+ *
+ * The check is strictly local: a cached entry is usable only when it
+ * carries a `join`, the join's identity matches our current full JID
+ * (LiveKit identity-uniqueness then displaces the pre-reload session
+ * cleanly), and the JWT's `exp` claim sits comfortably ahead of
+ * `now`. Per LiveKit's documented operational behavior the JWT's TTL
+ * only gates the initial connect — once we reconnect, LK auto-rotates
+ * 10-minute refresh tokens in-band — but we still require headroom
+ * so a token that's seconds from expiry doesn't race the reconnect.
+ */
+export function canResumeMucCallActivity(options: {
+  roomJid: string;
+  selfFullJid: string | null | undefined;
+  now?: Date;
+}): boolean {
+  const selfFullJid = options.selfFullJid?.trim() ?? "";
+  if (!selfFullJid) return false;
+  const session = readMucCallSession({
+    roomJid: options.roomJid,
+    selfFullJid,
+    now: options.now,
+  });
+  if (!session || session.terminatePending) return false;
+  if (!session.join) return false;
+  if (session.join.identity !== selfFullJid) return false;
+  const expiresAt = liveKitJoinTokenExpiresAt(session.join.token);
+  const now = options.now ?? new Date();
+  if (!expiresAt) return false;
+  return expiresAt.getTime() > now.getTime() + LIVEKIT_JOIN_EXPIRY_SKEW_MS;
+}
+
+/**
+ * Hard-refresh recovery path for a MUC call this browser resource
+ * was actively in before the tab reload.
+ *
+ * Reads the persisted `LiveKitJoin` from the MUC session cache and
+ * promotes `$callState` directly to `active` with the cached
+ * credentials. The `CallOverlay` watcher (keyed on
+ * `state.value.sid`) then drives `engine.connect(active.join,
+ * active.media)`, which reconnects to the same LiveKit room as the
+ * same identity — LK's identity-uniqueness invariant kicks any
+ * orphan session left behind by the dead pre-reload resource.
+ *
+ * Critically, this path does NOT mint a fresh Jingle attempt: no
+ * new `attemptId`, no new SFU session, no doubled Muji presence.
+ * The pre-reload Muji=active presence is still in the MUC roster
+ * and remains the authoritative advertisement; explicit hangup
+ * clears it via the normal `tearDownActiveCall` path. If the cached
+ * token cannot be used (missing/expired/identity-mismatch) the
+ * caller falls back to `beginMucCall`.
+ *
+ * Best-effort re-publishes our Muji=active presence after promoting
+ * `$callState`: harmless when the server still has our previous
+ * presence (the rebroadcast is a no-op update from the room's
+ * perspective) but useful when SM-resume changed our resource and
+ * the room hasn't yet seen the new resource's Muji.
+ */
+export async function resumeMucCallActivity({
+  roomJid,
+  getSender,
+  getSelfNick,
+  getSelfFullJid,
+  now,
+}: ResumeMucCallActionOptions): Promise<boolean> {
+  const current = $callState.get();
+  if (current.phase !== "idle" && current.phase !== "ended") return false;
+
+  const selfFullJid = getSelfFullJid?.()?.trim() ?? "";
+  if (!selfFullJid) return false;
+  if (!canResumeMucCallActivity({ roomJid, selfFullJid, now })) return false;
+
+  const session = readMucCallSession({ roomJid, selfFullJid, now });
+  if (!session || !session.join || !session.media) return false;
+
+  const selfNick = getSelfNick();
+  if (!selfNick) return false;
+
+  const media: CallMedia = session.media;
+  const join: LiveKitJoin = session.join;
+
+  $callState.set({
+    phase: "active",
+    peer: session.roomJid,
+    sid: session.sid,
+    media,
+    join,
+    kind: "muc",
+    selfNick,
+    selfFullJid,
+  });
+
+  // Best-effort republish of Muji active presence under the current
+  // resource. Non-fatal — the LK→Muji webhook bridge will reconcile
+  // even if this rebroadcast races a transient send failure.
+  const sender = getSender();
+  if (sender?.update_muji_presence) {
+    try {
+      await sender.update_muji_presence(
+        session.roomJid,
+        selfNick,
+        true, // active
+        false, // preparing
+        media.video,
+      );
+    } catch (err) {
+      reportCallError(err);
+    }
+  }
+
+  return true;
 }

--- a/chat/src/lib/calls/muc-call-live-participants.ts
+++ b/chat/src/lib/calls/muc-call-live-participants.ts
@@ -1,0 +1,109 @@
+import { map } from "nanostores";
+import { fullJidIdentityKey } from "@/lib/xmpp/jid";
+import { normalizeMucCallRoomJid } from "./muc-call-presence";
+
+/**
+ * Source-of-truth projection of LiveKit's `RoomEvent.ParticipantConnected`
+ * / `ParticipantDisconnected` stream for the MUC room our local
+ * `$callState.active` slot is currently bound to.
+ *
+ * Why a separate store from `$mucCallParticipants`:
+ *
+ * - `$mucCallParticipants` is derived from inbound XEP-0272 Muji
+ *   presence (now kept honest server-side by the LK→MUC webhook
+ *   bridge). It is the right source for **rooms we are not in** —
+ *   every chat client sees the same Muji broadcast and the indicator
+ *   must agree across observers.
+ * - `$mucCallLiveParticipants` is the LiveKit SDK's first-party
+ *   participant set for the **room we ARE in**. LK fires
+ *   `participantConnected` / `participantDisconnected` within seconds
+ *   of the SFU's truth changing, often before XMPP server-side ping
+ *   detects a dead resource; using it for the in-call view eliminates
+ *   the ghost-while-in-call symptom independent of the webhook
+ *   round-trip latency.
+ *
+ * Shape: `{ "<roomJid>": ["<participant-full-jid>", …] }`. Empty
+ * arrays and missing rooms are equivalent — there is no participant
+ * advertisement for a room we are not currently connected to via
+ * LiveKit, so the absence of an entry means "fall back to the Muji
+ * view." Identities are normalized via `fullJidIdentityKey` for
+ * case-insensitive equality with the rest of the call layer.
+ */
+export const $mucCallLiveParticipants = map<Record<string, string[]>>({});
+
+/**
+ * Replace the entire participant set for `roomJid` with the supplied
+ * identities. Used at LiveKit `Connected` time to seed the initial
+ * remote-participant snapshot — including peers that joined before
+ * our listeners attached.
+ */
+export function setLiveCallParticipants(
+  roomJid: string,
+  identities: ReadonlyArray<string>,
+): void {
+  const normalized = normalizeMucCallRoomJid(roomJid);
+  if (!normalized) return;
+  const deduped = Array.from(
+    new Set(identities.map(fullJidIdentityKey).filter(Boolean)),
+  );
+  if (deduped.length === 0) {
+    clearLiveCallParticipants(normalized);
+    return;
+  }
+  $mucCallLiveParticipants.setKey(normalized, deduped);
+}
+
+/**
+ * Add a single participant to `roomJid`'s live set. Idempotent:
+ * re-adding an already-present identity is a no-op.
+ */
+export function addLiveCallParticipant(roomJid: string, identity: string): void {
+  const normalized = normalizeMucCallRoomJid(roomJid);
+  const normalizedIdentity = fullJidIdentityKey(identity);
+  if (!normalized || !normalizedIdentity) return;
+  const current = $mucCallLiveParticipants.get()[normalized] ?? [];
+  if (current.includes(normalizedIdentity)) return;
+  $mucCallLiveParticipants.setKey(normalized, [...current, normalizedIdentity]);
+}
+
+/**
+ * Drop a single participant from `roomJid`'s live set. Idempotent:
+ * removing an unknown identity is a no-op. When the last identity is
+ * removed the room entry is deleted so `useRoomHasActiveCall`'s
+ * fallback logic re-engages on the Muji-derived view.
+ */
+export function removeLiveCallParticipant(roomJid: string, identity: string): void {
+  const normalized = normalizeMucCallRoomJid(roomJid);
+  const normalizedIdentity = fullJidIdentityKey(identity);
+  if (!normalized || !normalizedIdentity) return;
+  const current = $mucCallLiveParticipants.get()[normalized] ?? [];
+  if (!current.includes(normalizedIdentity)) return;
+  const next = current.filter((existing) => existing !== normalizedIdentity);
+  if (next.length === 0) {
+    clearLiveCallParticipants(normalized);
+    return;
+  }
+  $mucCallLiveParticipants.setKey(normalized, next);
+}
+
+/**
+ * Drop every tracked identity for `roomJid`. Called on
+ * `engine.disconnect()` so the room's UI reverts to the Muji-derived
+ * (server-bridged) view without a stale LK snapshot lingering.
+ */
+export function clearLiveCallParticipants(roomJid: string): void {
+  const normalized = normalizeMucCallRoomJid(roomJid);
+  if (!normalized) return;
+  const all = { ...$mucCallLiveParticipants.get() };
+  if (!(normalized in all)) return;
+  delete all[normalized];
+  $mucCallLiveParticipants.set(all);
+}
+
+/**
+ * Wipe every room's live participant snapshot. Used by logout /
+ * connection teardown so a fresh login doesn't see stale indicators.
+ */
+export function clearAllLiveCallParticipants(): void {
+  $mucCallLiveParticipants.set({});
+}

--- a/chat/src/lib/calls/muc-call-session-cache.ts
+++ b/chat/src/lib/calls/muc-call-session-cache.ts
@@ -2,7 +2,7 @@ import { barePeerJid } from "@/lib/xmpp/jid";
 import { normalizeMucCallRoomJid } from "./muc-call-presence";
 import { reportError } from "@/lib/telemetry";
 import { map } from "nanostores";
-import type { CallMedia } from "./types";
+import type { CallMedia, LiveKitJoin } from "./types";
 
 const CACHE_PREFIX = "waddle.chat.muc-call-sessions";
 const CACHE_WINDOW_MS = 24 * 60 * 60 * 1000;
@@ -14,6 +14,19 @@ type CachedMucCallSession = {
   selfFullJid: string;
   updatedAt: string;
   media?: CallMedia;
+  /**
+   * LiveKit join credentials minted by the SFU during the original
+   * `beginMucCall` flow. Persisting them is what makes the resume
+   * path (`resumeMucCallActivity`) able to reconnect to the same
+   * LiveKit room without going through a fresh Jingle session-initiate
+   * handshake — LK identity-uniqueness then displaces any orphan
+   * session left from the dead pre-reload resource.
+   *
+   * Optional because retained-but-pending teardown entries (from
+   * `markMucCallSessionTerminatePending`) don't need fresh join
+   * credentials — they only carry the sid for the cleanup terminate.
+   */
+  join?: LiveKitJoin;
   terminatePending?: boolean;
 };
 
@@ -24,6 +37,7 @@ export function rememberMucCallSession(options: {
   sid: string;
   selfFullJid?: string | null;
   media?: CallMedia | null;
+  join?: LiveKitJoin | null;
   now?: Date;
 }): void {
   const entry = normalizeEntry({
@@ -31,6 +45,7 @@ export function rememberMucCallSession(options: {
     sid: options.sid,
     selfFullJid: options.selfFullJid?.trim() ?? "",
     ...(options.media ? { media: options.media } : {}),
+    ...(options.join ? { join: options.join } : {}),
     updatedAt: options.now?.toISOString() ?? new Date().toISOString(),
   });
   if (!entry) return;
@@ -170,12 +185,20 @@ function normalizeEntry(entry: CachedMucCallSession): CachedMucCallSession | nul
   if (!roomJid || !selfFullJid || !sid) return null;
   if (!normalizedBare(selfFullJid)) return null;
   if (Number.isNaN(Date.parse(entry.updatedAt))) return null;
+  // Discard a malformed join blob silently rather than dropping the
+  // whole entry — the resume path falls back to a fresh
+  // `beginMucCall` if `join` is missing, so a corrupted cached blob
+  // degrades cleanly instead of breaking the retained-leave path.
+  const validJoin = entry.join && isLiveKitJoin(entry.join) && entry.join.identity === selfFullJid
+    ? entry.join
+    : undefined;
   return {
     roomJid,
     sid,
     selfFullJid,
     updatedAt: entry.updatedAt,
     ...(isCallMedia(entry.media) ? { media: entry.media } : {}),
+    ...(validJoin ? { join: validJoin } : {}),
     ...(entry.terminatePending ? { terminatePending: true } : {}),
   };
 }
@@ -299,12 +322,25 @@ function isCachedMucCallSession(value: unknown): value is CachedMucCallSession {
     typeof candidate.selfFullJid === "string" &&
     typeof candidate.updatedAt === "string"
   );
+  // Optional `media`, `join`, and `terminatePending` are validated
+  // (and silently dropped if malformed) inside `normalizeEntry`.
 }
 
 function isCallMedia(value: unknown): value is CallMedia {
   if (!value || typeof value !== "object") return false;
   const candidate = value as Record<string, unknown>;
   return typeof candidate.audio === "boolean" && typeof candidate.video === "boolean";
+}
+
+function isLiveKitJoin(value: unknown): value is LiveKitJoin {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.url === "string" &&
+    typeof candidate.room === "string" &&
+    typeof candidate.identity === "string" &&
+    typeof candidate.token === "string"
+  );
 }
 
 function storage(): Storage | null {

--- a/chat/src/lib/calls/use-active-muc-call.ts
+++ b/chat/src/lib/calls/use-active-muc-call.ts
@@ -258,7 +258,13 @@ function identitiesToNicks(
   for (const identity of identities) {
     const key = fullJidIdentityKey(identity);
     if (!key) continue;
-    const nick = byRealJid.get(key) ?? identity.split("/").pop()?.split("@")[0] ?? identity;
+    // Fall back to the JID's localpart (everything before `@`) when
+    // the Muji-derived owner map hasn't resolved this resource yet.
+    // Earlier this incorrectly used `identity.split("/").pop()` which
+    // returned the *resource* (e.g. `web` for `alice@host/web`); the
+    // localpart is the correct user-facing label until presence catches
+    // up. After: `alice` for `alice@host/web`.
+    const nick = byRealJid.get(key) ?? identity.split("@")[0] ?? identity;
     if (seen.has(nick)) continue;
     seen.add(nick);
     out.push(nick);

--- a/chat/src/lib/calls/use-active-muc-call.ts
+++ b/chat/src/lib/calls/use-active-muc-call.ts
@@ -8,6 +8,7 @@ import {
   mucCallMediaForRoom,
   normalizeMucCallRoomJid,
 } from "./muc-call-presence";
+import { $mucCallLiveParticipants } from "./muc-call-live-participants";
 import {
   $mucCallTerminatePendingSessions,
   pendingMucCallTerminateSession,
@@ -96,15 +97,30 @@ export function useRoomHasActiveCall(
   const participantOwners = useStore($mucCallParticipantOwners);
   const callMedia = useStore($mucCallMedia);
   const pendingTerminates = useStore($mucCallTerminatePendingSessions);
+  const liveParticipants = useStore($mucCallLiveParticipants);
 
   const normalizedRoomJid = computed<string | null>(() => {
     const normalized = normalizeMucCallRoomJid(roomJid());
     return normalized || null;
   });
 
+  /**
+   * Prefer LiveKit's authoritative participant set when we are
+   * connected to this room's call. The LK projection arrives within
+   * seconds of the SFU's truth changing — typically before the
+   * MUC server's XEP-0198 ping detects a dead resource and the
+   * webhook bridge fires — eliminating the ghost-while-in-call
+   * symptom. When we are NOT in this room's call, the LK projection
+   * is empty for this room and we fall back to the Muji-derived
+   * view (kept honest by the server-side LK→MUC webhook bridge).
+   */
   const participantList = computed<ReadonlyArray<string>>(() => {
     const room = normalizedRoomJid.value;
     if (!room) return [];
+    const liveIdentities = liveParticipants.value[room] ?? [];
+    if (liveIdentities.length > 0) {
+      return identitiesToNicks(liveIdentities, participantOwners.value[room] ?? []);
+    }
     return participants.value[room] ?? [];
   });
 
@@ -218,6 +234,36 @@ function hasUnownedSelfNick(
 ): boolean {
   if (!nick || !participants.includes(nick)) return false;
   return owners.some((owner) => owner.nick === nick && !fullJidIdentityKey(owner.realJid));
+}
+
+/**
+ * Map LiveKit participant identities (full JIDs) to MUC nicks via
+ * the cached owner list, deduplicating identical nicks (the same
+ * person on two LK sessions). Identities without a known owner
+ * mapping degrade to the bare localpart so the UI still has a
+ * sensible label — once the Muji presence catches up the owner
+ * mapping resolves and the next render uses the canonical nick.
+ */
+function identitiesToNicks(
+  identities: ReadonlyArray<string>,
+  owners: ReadonlyArray<{ nick: string; realJid?: string }>,
+): string[] {
+  const byRealJid = new Map<string, string>();
+  for (const owner of owners) {
+    const key = fullJidIdentityKey(owner.realJid);
+    if (key) byRealJid.set(key, owner.nick);
+  }
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const identity of identities) {
+    const key = fullJidIdentityKey(identity);
+    if (!key) continue;
+    const nick = byRealJid.get(key) ?? identity.split("/").pop()?.split("@")[0] ?? identity;
+    if (seen.has(nick)) continue;
+    seen.add(nick);
+    out.push(nick);
+  }
+  return out;
 }
 
 /**

--- a/chat/src/lib/calls/use-call-engine.ts
+++ b/chat/src/lib/calls/use-call-engine.ts
@@ -1,5 +1,12 @@
 import { ref, type Ref } from "vue";
+import { $callState } from "./call-store";
 import { CallEngine, type LocalMediaTrack, type RemoteMediaTrack } from "./engine";
+import {
+  addLiveCallParticipant,
+  clearLiveCallParticipants,
+  removeLiveCallParticipant,
+  setLiveCallParticipants,
+} from "./muc-call-live-participants";
 
 /**
  * Process-wide singleton: only one call engine should ever exist
@@ -42,10 +49,49 @@ export function useCallEngine(): {
         (existing) => existing.publicationSid !== track.publicationSid,
       );
     });
+    singletonEngine.on("connected", ({ localIdentity, remoteIdentities }) => {
+      // Seed the LK-truth projection for the active MUC room with
+      // the initial remote-participant snapshot LK gave us at
+      // connect time. Local identity is included so the room view
+      // shows ourselves alongside peers without waiting for the
+      // (already-true) Muji presence to also broadcast.
+      const roomJid = activeMucRoomJid();
+      if (!roomJid) return;
+      setLiveCallParticipants(roomJid, [localIdentity, ...remoteIdentities]);
+    });
+    singletonEngine.on("participantConnected", (identity) => {
+      const roomJid = activeMucRoomJid();
+      if (!roomJid) return;
+      addLiveCallParticipant(roomJid, identity);
+    });
+    singletonEngine.on("participantDisconnected", (identity) => {
+      const roomJid = activeMucRoomJid();
+      if (!roomJid) return;
+      removeLiveCallParticipant(roomJid, identity);
+    });
     singletonEngine.on("disconnected", () => {
       remoteTracks.value = [];
       localTracks.value = [];
+      // The active call's room — if any — is no longer in our LK
+      // view. Drop the LK snapshot so the room's UI reverts to the
+      // Muji-derived (server-bridged) view, which the LK webhook
+      // bridge keeps honest within seconds.
+      const roomJid = activeMucRoomJid();
+      if (roomJid) clearLiveCallParticipants(roomJid);
     });
   }
   return { engine: singletonEngine, remoteTracks, localTracks };
+}
+
+/**
+ * Read the bare room JID of the MUC call our `$callState` slot is
+ * currently bound to, or `null` when no MUC call is active. The LK
+ * projection key on this so a 1:1 DM call's engine events do not
+ * leak into the MUC participant store.
+ */
+function activeMucRoomJid(): string | null {
+  const state = $callState.get();
+  if (state.phase !== "active" && state.phase !== "muc-pending") return null;
+  if (state.kind !== "muc") return null;
+  return state.peer;
 }

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -21,6 +21,7 @@ import {
   applyMucCallPresence,
   clearMucCallParticipants,
 } from "@/lib/calls/muc-call-presence";
+import { clearAllLiveCallParticipants } from "@/lib/calls/muc-call-live-participants";
 import { useCallEngine } from "@/lib/calls/use-call-engine";
 import type { CallWireSender } from "@/lib/calls/outbound";
 import type { CallEvent } from "@/lib/calls/types";
@@ -848,6 +849,7 @@ export class BrowserXmppClient {
     clearDmCallJoinCacheForAccount(this.session.jid);
     clearDmCallActivities();
     clearMucCallParticipants();
+    clearAllLiveCallParticipants();
     // Best-effort hangup: if we're in a call when the user logs out
     // we want the peer to see session-terminate before the stream
     // closes. `tearDownActiveCall` handles every phase and clears
@@ -2490,6 +2492,7 @@ export class BrowserXmppClient {
     // connected).
     clearCallState();
     clearMucCallParticipants();
+    clearAllLiveCallParticipants();
     void useCallEngine().engine.disconnect();
     this.rejectRoomJoinWaiters(new Error("XMPP disconnected while joining a room"));
     this.retainedJoinedRoomJids = new Set([

--- a/chat/tests/muc-call-live-participants.test.ts
+++ b/chat/tests/muc-call-live-participants.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  $mucCallLiveParticipants,
+  addLiveCallParticipant,
+  clearAllLiveCallParticipants,
+  clearLiveCallParticipants,
+  removeLiveCallParticipant,
+  setLiveCallParticipants,
+} from "../src/lib/calls/muc-call-live-participants";
+
+const ROOM = "general@muc.test";
+const ALICE = "alice@waddle.test/desktop";
+const BOB = "bob@waddle.test/web";
+
+afterEach(() => {
+  clearAllLiveCallParticipants();
+});
+
+describe("muc-call-live-participants", () => {
+  test("setLiveCallParticipants replaces the room's identity set and dedupes", () => {
+    setLiveCallParticipants(ROOM, [ALICE, BOB, ALICE]);
+    expect($mucCallLiveParticipants.get()[ROOM]).toEqual([ALICE, BOB]);
+
+    setLiveCallParticipants(ROOM, [BOB]);
+    expect($mucCallLiveParticipants.get()[ROOM]).toEqual([BOB]);
+  });
+
+  test("setLiveCallParticipants with an empty list clears the room entry entirely", () => {
+    setLiveCallParticipants(ROOM, [ALICE]);
+    setLiveCallParticipants(ROOM, []);
+    expect($mucCallLiveParticipants.get()[ROOM]).toBeUndefined();
+  });
+
+  test("addLiveCallParticipant is idempotent and preserves order", () => {
+    addLiveCallParticipant(ROOM, ALICE);
+    addLiveCallParticipant(ROOM, ALICE);
+    addLiveCallParticipant(ROOM, BOB);
+    expect($mucCallLiveParticipants.get()[ROOM]).toEqual([ALICE, BOB]);
+  });
+
+  test("removeLiveCallParticipant drops a single identity and deletes the room on last removal", () => {
+    setLiveCallParticipants(ROOM, [ALICE, BOB]);
+    removeLiveCallParticipant(ROOM, ALICE);
+    expect($mucCallLiveParticipants.get()[ROOM]).toEqual([BOB]);
+
+    removeLiveCallParticipant(ROOM, BOB);
+    expect($mucCallLiveParticipants.get()[ROOM]).toBeUndefined();
+  });
+
+  test("removeLiveCallParticipant is a no-op for unknown identity", () => {
+    setLiveCallParticipants(ROOM, [ALICE]);
+    removeLiveCallParticipant(ROOM, BOB);
+    expect($mucCallLiveParticipants.get()[ROOM]).toEqual([ALICE]);
+  });
+
+  test("clearLiveCallParticipants wipes one room without touching others", () => {
+    const OTHER_ROOM = "other@muc.test";
+    setLiveCallParticipants(ROOM, [ALICE]);
+    setLiveCallParticipants(OTHER_ROOM, [BOB]);
+    clearLiveCallParticipants(ROOM);
+    expect($mucCallLiveParticipants.get()[ROOM]).toBeUndefined();
+    expect($mucCallLiveParticipants.get()[OTHER_ROOM]).toEqual([BOB]);
+  });
+
+  test("clearAllLiveCallParticipants wipes every room", () => {
+    setLiveCallParticipants(ROOM, [ALICE]);
+    setLiveCallParticipants("other@muc.test", [BOB]);
+    clearAllLiveCallParticipants();
+    expect($mucCallLiveParticipants.get()).toEqual({});
+  });
+});

--- a/chat/tests/muc-call-resume.test.ts
+++ b/chat/tests/muc-call-resume.test.ts
@@ -1,0 +1,296 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { $callState, clearCallState } from "../src/lib/calls/call-store";
+import {
+  canResumeMucCallActivity,
+  resumeMucCallActivity,
+} from "../src/lib/calls/muc-call-actions";
+import {
+  clearAllMucCallSessionCacheForTests,
+  rememberMucCallSession,
+} from "../src/lib/calls/muc-call-session-cache";
+import type { CallMedia, LiveKitJoin } from "../src/lib/calls/types";
+
+/**
+ * Forge a LiveKit join JWT whose `exp` claim sits `secondsFromNow`
+ * ahead of the current wall clock. The signature is irrelevant for
+ * the chat-side expiry check — only `exp` is read — so the test
+ * uses a placeholder signature.
+ */
+function forgeLiveKitJoin(opts: {
+  identity: string;
+  secondsFromNow: number;
+}): LiveKitJoin {
+  const header = base64UrlEncodeJson({ alg: "HS256", typ: "JWT" });
+  const exp = Math.floor(Date.now() / 1000) + opts.secondsFromNow;
+  const payload = base64UrlEncodeJson({ sub: opts.identity, exp });
+  const token = `${header}.${payload}.dGVzdC1zaWduYXR1cmU`;
+  return {
+    url: "wss://livekit.test",
+    room: "general@muc.test",
+    identity: opts.identity,
+    token,
+  };
+}
+
+function base64UrlEncodeJson(value: unknown): string {
+  const json = JSON.stringify(value);
+  const bytes = new TextEncoder().encode(json);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return globalThis
+    .btoa(binary)
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/u, "");
+}
+
+const SELF_FULL_JID = "alice@waddle.test/web";
+const ROOM_JID = "general@muc.test";
+const SELF_NICK = "alice";
+const AUDIO_CALL: CallMedia = { audio: true, video: false };
+
+const WINDOW_SENTINEL = Symbol("muc-call-resume-window");
+type ShimmedGlobal = typeof globalThis & {
+  window?: { localStorage: Storage } & { [WINDOW_SENTINEL]?: true };
+};
+
+beforeAll(() => {
+  const g = globalThis as ShimmedGlobal;
+  if (typeof g.window !== "undefined") return;
+  const store = new Map<string, string>();
+  const storage: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key) => store.get(key) ?? null,
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    setItem: (key, value) => {
+      store.set(key, String(value));
+    },
+  };
+  g.window = Object.assign({ localStorage: storage }, { [WINDOW_SENTINEL]: true as const });
+});
+
+afterAll(() => {
+  const g = globalThis as ShimmedGlobal;
+  if (g.window?.[WINDOW_SENTINEL]) {
+    delete (g as { window?: unknown }).window;
+  }
+});
+
+beforeEach(() => {
+  clearAllMucCallSessionCacheForTests();
+  clearCallState();
+});
+
+afterEach(() => {
+  clearAllMucCallSessionCacheForTests();
+  clearCallState();
+});
+
+describe("canResumeMucCallActivity", () => {
+  test("returns false when no cached session exists", () => {
+    expect(
+      canResumeMucCallActivity({
+        roomJid: ROOM_JID,
+        selfFullJid: SELF_FULL_JID,
+      }),
+    ).toBe(false);
+  });
+
+  test("returns false when cached session has no join (terminate-only entry)", () => {
+    rememberMucCallSession({
+      roomJid: ROOM_JID,
+      sid: "sid-1",
+      selfFullJid: SELF_FULL_JID,
+      media: AUDIO_CALL,
+    });
+    expect(
+      canResumeMucCallActivity({
+        roomJid: ROOM_JID,
+        selfFullJid: SELF_FULL_JID,
+      }),
+    ).toBe(false);
+  });
+
+  test("returns true when cached join is fresh and identity matches", () => {
+    rememberMucCallSession({
+      roomJid: ROOM_JID,
+      sid: "sid-2",
+      selfFullJid: SELF_FULL_JID,
+      media: AUDIO_CALL,
+      join: forgeLiveKitJoin({ identity: SELF_FULL_JID, secondsFromNow: 600 }),
+    });
+    expect(
+      canResumeMucCallActivity({
+        roomJid: ROOM_JID,
+        selfFullJid: SELF_FULL_JID,
+      }),
+    ).toBe(true);
+  });
+
+  test("returns false when the cached join's identity is for a different resource", () => {
+    rememberMucCallSession({
+      roomJid: ROOM_JID,
+      sid: "sid-3",
+      selfFullJid: SELF_FULL_JID,
+      media: AUDIO_CALL,
+      // Cached join was minted for a dead pre-reload resource. The
+      // current XMPP session bound under a new resource cannot reuse
+      // it directly — falling back to beginMucCall is correct.
+      join: forgeLiveKitJoin({
+        identity: "alice@waddle.test/desktop-dead",
+        secondsFromNow: 600,
+      }),
+    });
+    expect(
+      canResumeMucCallActivity({
+        roomJid: ROOM_JID,
+        selfFullJid: SELF_FULL_JID,
+      }),
+    ).toBe(false);
+  });
+
+  test("returns false when the cached JWT's exp is within the skew window", () => {
+    rememberMucCallSession({
+      roomJid: ROOM_JID,
+      sid: "sid-4",
+      selfFullJid: SELF_FULL_JID,
+      media: AUDIO_CALL,
+      // 10 seconds — inside the 30-second LIVEKIT_JOIN_EXPIRY_SKEW_MS
+      // guard. Resume must refuse so a token that's about to lapse
+      // doesn't race the reconnect.
+      join: forgeLiveKitJoin({ identity: SELF_FULL_JID, secondsFromNow: 10 }),
+    });
+    expect(
+      canResumeMucCallActivity({
+        roomJid: ROOM_JID,
+        selfFullJid: SELF_FULL_JID,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("resumeMucCallActivity", () => {
+  test("returns false and leaves $callState idle when no cached session exists", async () => {
+    const ok = await resumeMucCallActivity({
+      roomJid: ROOM_JID,
+      getSender: () => null,
+      getSelfNick: () => SELF_NICK,
+      getSelfFullJid: () => SELF_FULL_JID,
+    });
+    expect(ok).toBe(false);
+    expect($callState.get()).toEqual({ phase: "idle" });
+  });
+
+  test("promotes $callState directly to active with the cached join", async () => {
+    const join = forgeLiveKitJoin({
+      identity: SELF_FULL_JID,
+      secondsFromNow: 600,
+    });
+    rememberMucCallSession({
+      roomJid: ROOM_JID,
+      sid: "sid-resume",
+      selfFullJid: SELF_FULL_JID,
+      media: AUDIO_CALL,
+      join,
+    });
+
+    const ok = await resumeMucCallActivity({
+      roomJid: ROOM_JID,
+      // No sender exposed — best-effort Muji republish should
+      // skip silently rather than fail the resume.
+      getSender: () => null,
+      getSelfNick: () => SELF_NICK,
+      getSelfFullJid: () => SELF_FULL_JID,
+    });
+
+    expect(ok).toBe(true);
+    const state = $callState.get();
+    expect(state.phase).toBe("active");
+    if (state.phase !== "active") return;
+    expect(state.kind).toBe("muc");
+    if (state.kind !== "muc") return;
+    expect(state.peer).toBe(ROOM_JID);
+    expect(state.sid).toBe("sid-resume");
+    expect(state.join).toEqual(join);
+    expect(state.selfNick).toBe(SELF_NICK);
+    expect(state.selfFullJid).toBe(SELF_FULL_JID);
+  });
+
+  test("republishes Muji active presence when a sender is available", async () => {
+    rememberMucCallSession({
+      roomJid: ROOM_JID,
+      sid: "sid-republish",
+      selfFullJid: SELF_FULL_JID,
+      media: { audio: true, video: true },
+      join: forgeLiveKitJoin({
+        identity: SELF_FULL_JID,
+        secondsFromNow: 600,
+      }),
+    });
+
+    const calls: Array<{
+      roomJid: string;
+      nick: string;
+      active: boolean;
+      preparing: boolean;
+      video: boolean;
+    }> = [];
+    const ok = await resumeMucCallActivity({
+      roomJid: ROOM_JID,
+      getSender: () => ({
+        update_muji_presence: async (roomJid, nick, active, preparing, video) => {
+          calls.push({ roomJid, nick, active, preparing, video });
+        },
+      }),
+      getSelfNick: () => SELF_NICK,
+      getSelfFullJid: () => SELF_FULL_JID,
+    });
+
+    expect(ok).toBe(true);
+    expect(calls).toEqual([
+      {
+        roomJid: ROOM_JID,
+        nick: SELF_NICK,
+        active: true,
+        preparing: false,
+        video: true,
+      },
+    ]);
+  });
+
+  test("refuses to resume when $callState is not idle", async () => {
+    rememberMucCallSession({
+      roomJid: ROOM_JID,
+      sid: "sid-busy",
+      selfFullJid: SELF_FULL_JID,
+      media: AUDIO_CALL,
+      join: forgeLiveKitJoin({
+        identity: SELF_FULL_JID,
+        secondsFromNow: 600,
+      }),
+    });
+    // Pretend an outgoing call is already in flight.
+    $callState.set({
+      phase: "outgoing",
+      to: "bob@waddle.test",
+      sid: "other-call",
+      media: AUDIO_CALL,
+    });
+
+    const ok = await resumeMucCallActivity({
+      roomJid: ROOM_JID,
+      getSender: () => null,
+      getSelfNick: () => SELF_NICK,
+      getSelfFullJid: () => SELF_FULL_JID,
+    });
+
+    expect(ok).toBe(false);
+    expect($callState.get().phase).toBe("outgoing");
+  });
+});

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -6585,6 +6585,7 @@ dependencies = [
  "serde_json",
  "sha1 0.11.0",
  "sha2 0.11.0",
+ "subtle",
  "thiserror 2.0.18",
  "tracing",
  "url",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -6584,6 +6584,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1 0.11.0",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tracing",
  "url",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -92,6 +92,7 @@ rustls-acme = { version = "0.15.2", default-features = false, features = ["ring"
 hmac = "0.13"
 sha1 = "0.11"
 sha2 = "0.11"
+subtle = "2"
 p256 = { version = "0.13", features = ["ecdsa", "ecdh", "jwk", "pem", "pkcs8"] }
 elliptic-curve = { version = "0.13", features = ["jwk"] }
 argon2 = "0.5"

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -228,6 +228,7 @@ pub(crate) async fn create_router(deps: RouterDeps) -> Result<Router> {
 
     let extension_webhooks_router =
         routes::extension_webhooks::router(Arc::clone(&websocket_state));
+    let livekit_webhook_router = routes::livekit_webhook::router(Arc::clone(&websocket_state));
     let websocket_router = routes::websocket::router(websocket_state.clone());
 
     // Upload router for XEP-0363 HTTP File Upload
@@ -266,7 +267,8 @@ pub(crate) async fn create_router(deps: RouterDeps) -> Result<Router> {
         .merge(device_router)
         .merge(xmpp_oauth_router)
         .merge(auth_page_router)
-        .merge(extension_webhooks_router);
+        .merge(extension_webhooks_router)
+        .merge(livekit_webhook_router);
 
     // Test-only profile-publish route. Only mounted when:
     // 1. The fixed-account flag is on (the test harness opt-in).

--- a/server/crates/waddle-server/src/server/routes/livekit_webhook.rs
+++ b/server/crates/waddle-server/src/server/routes/livekit_webhook.rs
@@ -31,7 +31,7 @@ use axum::Router;
 use jid::{BareJid, FullJid};
 use tracing::{debug, info, warn};
 use waddle_sfu::{
-    verify_webhook_signature, CallId, LiveKitWebhookEvent, ParticipantEnvelope, WebhookVerifyError,
+    verify_webhook_signature, LiveKitWebhookEvent, ParticipantEnvelope, WebhookVerifyError,
 };
 use waddle_xmpp::muc::build_occupant_presence;
 use waddle_xmpp::muc::room_actor::{ClearMujiPresence, MujiPresenceUpdateOutcome};
@@ -139,20 +139,12 @@ async fn livekit_webhook_handler(
             process_participant_left(&state, env).await;
         }
         LiveKitWebhookEvent::RoomFinished(env) => {
-            info!(room = %env.room.name, "LiveKit reported room finished; clearing SFU registry");
-            // The participant set in the SFU registry is the
-            // best-effort cleanup target. We don't have per-participant
-            // identity here (LK's `room_finished` carries only the
-            // room), so any surviving Muji presence will be cleaned by
-            // the XMPP-side disconnect path once individual sessions
-            // drop. Future enhancement: track participant set in the
-            // SFU registry and iterate here.
-            if let Ok(call_id) = CallId::new(env.room.name.clone()) {
-                // No public iteration API on LiveKitSfu; fall through.
-                // The participant_left events for each occupant will
-                // arrive separately per the LK delivery spec.
-                let _ = (call_id, sfu);
-            }
+            // Informational. LiveKit guarantees an individual
+            // `participant_left` for every still-connected participant
+            // before `room_finished` fires (per the LK delivery spec),
+            // and each of those is handled by the `ParticipantLeft`
+            // arm above. No additional MUC cleanup is required here.
+            info!(room = %env.room.name, "LiveKit reported room finished");
         }
         LiveKitWebhookEvent::ParticipantJoined(_) | LiveKitWebhookEvent::Other => {
             // Informational; the join path already flows through

--- a/server/crates/waddle-server/src/server/routes/livekit_webhook.rs
+++ b/server/crates/waddle-server/src/server/routes/livekit_webhook.rs
@@ -1,0 +1,326 @@
+//! `/api/v1/livekit/webhook` ingestion: LiveKit → MUC Muji-presence bridge.
+//!
+//! LiveKit posts signed webhook deliveries when participant /
+//! room lifecycle events fire (see <https://docs.livekit.io/home/server/webhooks/>).
+//! This handler is the **server-side authority** that makes the chat
+//! UI's XEP-0272 Muji presence state reflect the SFU's truth without
+//! waiting for XMPP-level XEP-0198 SM timeouts (~minutes) to clean
+//! up dead resources.
+//!
+//! Wire shape stays XEP-0272 conformant: the handler dispatches the
+//! same `ClearMujiPresence` room-actor message the existing
+//! client-driven path uses, then broadcasts the resulting per-session
+//! Muji state via `<presence/>` to remaining occupants. Server-
+//! originated MUC presence is XEP-0045 §7.7-permitted when the server
+//! is the MUC service, and is already precedented in the
+//! XMPP-disconnect cleanup path (`cleanup.rs`).
+//!
+//! Signature verification + replay protection live in
+//! [`waddle_sfu::verify_webhook_signature`]; this module composes
+//! that with the MUC dispatch + SFU registry teardown.
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use axum::body::Bytes;
+use axum::extract::{Extension, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::IntoResponse;
+use axum::routing::post;
+use axum::Router;
+use jid::{BareJid, FullJid};
+use tracing::{debug, info, warn};
+use waddle_sfu::{
+    verify_webhook_signature, CallId, LiveKitWebhookEvent, ParticipantEnvelope, WebhookVerifyError,
+};
+use waddle_xmpp::muc::build_occupant_presence;
+use waddle_xmpp::muc::room_actor::{ClearMujiPresence, MujiPresenceUpdateOutcome};
+use waddle_xmpp::xep::xep0272::Muji;
+use waddle_xmpp::xep::xep0421::OccupantIdentity;
+use waddle_xmpp_core::Stanza;
+
+use super::websocket::{get_room_actor, unregister_participant_from_room, WebSocketState};
+
+/// Upper bound on remembered event ids for delivery deduplication.
+/// LiveKit retries up to 5 times per delivery; a small LRU is enough
+/// to absorb the retry storm without paying unbounded memory.
+const SEEN_EVENT_ID_CAPACITY: usize = 1024;
+
+/// Shared, bounded LRU of LiveKit event ids the handler has already
+/// processed. Used so the retries LiveKit sends for the same delivery
+/// (per the LK best-practices field guide: up to 5 retries, include a
+/// dedupe key) collapse into a single MUC broadcast.
+#[derive(Debug, Default)]
+pub struct SeenEventIds {
+    inner: Mutex<SeenEventIdsInner>,
+}
+
+#[derive(Debug, Default)]
+struct SeenEventIdsInner {
+    order: VecDeque<String>,
+    set: std::collections::HashSet<String>,
+}
+
+impl SeenEventIds {
+    /// Returns `true` if `id` was not previously seen and is now
+    /// recorded; `false` if it is a duplicate that should be dropped.
+    /// `None`-id events are always treated as fresh (the caller may
+    /// still log them, but cannot dedupe).
+    pub fn observe(&self, id: Option<&str>) -> bool {
+        let Some(id) = id else {
+            return true;
+        };
+        let mut guard = self.inner.lock().expect("SeenEventIds mutex poisoned");
+        if !guard.set.insert(id.to_string()) {
+            return false;
+        }
+        guard.order.push_back(id.to_string());
+        while guard.order.len() > SEEN_EVENT_ID_CAPACITY {
+            if let Some(stale) = guard.order.pop_front() {
+                guard.set.remove(&stale);
+            }
+        }
+        true
+    }
+}
+
+/// Axum router for the LiveKit webhook endpoint. Mounted under
+/// `/api/v1/livekit/webhook` by [`crate::server::http`].
+pub fn router(websocket_state: Arc<WebSocketState>) -> Router {
+    let seen = Arc::new(SeenEventIds::default());
+    Router::new()
+        .route("/api/v1/livekit/webhook", post(livekit_webhook_handler))
+        .layer(Extension(websocket_state))
+        .with_state(seen)
+}
+
+async fn livekit_webhook_handler(
+    Extension(state): Extension<Arc<WebSocketState>>,
+    State(seen): State<Arc<SeenEventIds>>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> impl IntoResponse {
+    let Some(sfu) = state.deps.protocol.sfu.as_ref() else {
+        warn!("LiveKit webhook received but no SFU is configured; dropping");
+        return StatusCode::SERVICE_UNAVAILABLE;
+    };
+    let secret = sfu.webhook_secret();
+
+    let auth = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok());
+    let event = match verify_webhook_signature(secret, auth, &body) {
+        Ok(event) => event,
+        Err(WebhookVerifyError::MissingAuthorization)
+        | Err(WebhookVerifyError::MalformedAuthorization) => {
+            return StatusCode::UNAUTHORIZED;
+        }
+        Err(WebhookVerifyError::Jwt(error)) => {
+            warn!(error = ?error, "LiveKit webhook JWT validation failed");
+            return StatusCode::UNAUTHORIZED;
+        }
+        Err(WebhookVerifyError::MissingBodyHash) | Err(WebhookVerifyError::BodyHashMismatch) => {
+            return StatusCode::UNAUTHORIZED;
+        }
+        Err(WebhookVerifyError::BodyJson(error)) => {
+            warn!(error = ?error, "LiveKit webhook body JSON parse failed");
+            return StatusCode::BAD_REQUEST;
+        }
+    };
+
+    if !seen.observe(event.event_id()) {
+        debug!(event_id = ?event.event_id(), "LiveKit webhook duplicate; dropping");
+        return StatusCode::OK;
+    }
+
+    match &event {
+        LiveKitWebhookEvent::ParticipantLeft(env)
+        | LiveKitWebhookEvent::ParticipantConnectionAborted(env) => {
+            process_participant_left(&state, env).await;
+        }
+        LiveKitWebhookEvent::RoomFinished(env) => {
+            info!(room = %env.room.name, "LiveKit reported room finished; clearing SFU registry");
+            // The participant set in the SFU registry is the
+            // best-effort cleanup target. We don't have per-participant
+            // identity here (LK's `room_finished` carries only the
+            // room), so any surviving Muji presence will be cleaned by
+            // the XMPP-side disconnect path once individual sessions
+            // drop. Future enhancement: track participant set in the
+            // SFU registry and iterate here.
+            if let Ok(call_id) = CallId::new(env.room.name.clone()) {
+                // No public iteration API on LiveKitSfu; fall through.
+                // The participant_left events for each occupant will
+                // arrive separately per the LK delivery spec.
+                let _ = (call_id, sfu);
+            }
+        }
+        LiveKitWebhookEvent::ParticipantJoined(_) | LiveKitWebhookEvent::Other => {
+            // Informational; the join path already flows through
+            // Jingle session-initiate → `register_call_participant`.
+        }
+    }
+
+    StatusCode::OK
+}
+
+async fn process_participant_left(state: &WebSocketState, env: &ParticipantEnvelope) {
+    let Ok(full_jid) = env.participant.identity.parse::<FullJid>() else {
+        warn!(
+            identity = %env.participant.identity,
+            room = %env.room.name,
+            "LiveKit participant identity is not a valid full JID; skipping cleanup",
+        );
+        return;
+    };
+    let Ok(room_jid) = env.room.name.parse::<BareJid>() else {
+        warn!(
+            room = %env.room.name,
+            identity = %env.participant.identity,
+            "LiveKit room name is not a valid MUC bare JID; skipping cleanup",
+        );
+        return;
+    };
+
+    debug!(
+        room = %room_jid,
+        identity = %full_jid,
+        event_id = ?env.id,
+        "LiveKit webhook: clearing Muji presence for departed participant"
+    );
+
+    // Clear the room-actor's authoritative per-session Muji state for
+    // this participant. The handler is idempotent — a participant that
+    // already left via the XMPP-driven path returns `Ok(None)` and we
+    // skip the broadcast.
+    let Some(actor) = get_room_actor(state, &room_jid).await else {
+        // Room has no active actor (no occupants), nothing to clear.
+        return;
+    };
+    let outcome = match actor
+        .ask(ClearMujiPresence {
+            sender_jid: full_jid.clone(),
+        })
+        .await
+    {
+        Ok(Some(outcome)) => outcome,
+        Ok(None) => {
+            debug!(
+                room = %room_jid,
+                identity = %full_jid,
+                "LiveKit webhook: participant not in MUC actor; SFU registry cleanup only"
+            );
+            unregister_participant_from_room(state, &room_jid, &full_jid);
+            return;
+        }
+        Err(error) => {
+            warn!(
+                room = %room_jid,
+                identity = %full_jid,
+                error = ?error,
+                "LiveKit webhook: room actor rejected Muji clear; falling through to SFU unregister"
+            );
+            unregister_participant_from_room(state, &room_jid, &full_jid);
+            return;
+        }
+    };
+
+    broadcast_muji_clear_from_sfu(state, &room_jid, &full_jid, &outcome);
+    unregister_participant_from_room(state, &room_jid, &full_jid);
+}
+
+/// Broadcast a server-originated Muji-presence clear to every remaining
+/// occupant of the room.
+///
+/// Wire shape mirrors what the client-driven Muji-clear path emits in
+/// `muc_update::try_handle_muc_presence_update`: an in-room
+/// `<presence/>` per recipient per surviving Muji owner, with the
+/// departed participant getting an empty Muji payload (XEP-0272
+/// §Leaving: "absence of the `<muji/>` element is the leave marker").
+/// Sibling sessions with surviving Muji state retain their advertised
+/// `<muji/>` payload so multi-resource participants don't lose
+/// preparing/active state held by a different resource.
+fn broadcast_muji_clear_from_sfu(
+    state: &WebSocketState,
+    room_jid: &BareJid,
+    leaving_real_jid: &FullJid,
+    outcome: &MujiPresenceUpdateOutcome,
+) {
+    let from_room_jid = room_jid
+        .clone()
+        .with_resource_str(&outcome.update.sender_nick)
+        .unwrap_or_else(|_| leaving_real_jid.clone());
+
+    // Owner entries to reflect: the leaving session (no Muji payload =
+    // leave marker) plus every surviving sibling-session Muji.
+    let mut entries: Vec<(FullJid, Option<Muji>)> =
+        Vec::with_capacity(outcome.session_mujis.len() + 1);
+    entries.push((leaving_real_jid.clone(), None));
+    for (owner, muji) in &outcome.session_mujis {
+        if owner == leaving_real_jid {
+            continue;
+        }
+        entries.push((owner.clone(), Some(muji.clone())));
+    }
+
+    for recipient in &outcome.update.recipients {
+        for (owner_jid, muji) in &entries {
+            let owner_bare = owner_jid.to_bare();
+            let identity = OccupantIdentity {
+                bare_jid: &owner_bare,
+                real_jid: Some(owner_jid),
+                secret: &state.deps.occupant_id_secret,
+            };
+            let is_self = recipient.to_bare() == owner_bare;
+            let mut presence = build_occupant_presence(
+                &from_room_jid,
+                recipient,
+                outcome.update.sender_affiliation,
+                outcome.update.sender_role,
+                is_self,
+                &identity,
+            );
+            if let Some(muji_ref) = muji {
+                if !muji_ref.is_empty() {
+                    presence.payloads.push(muji_ref.to_element());
+                }
+            }
+            let _ = state
+                .deps
+                .protocol
+                .connection_registry
+                .try_send_to(recipient, Stanza::Presence(presence));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seen_event_ids_deduplicates_repeat_observations() {
+        let seen = SeenEventIds::default();
+        assert!(seen.observe(Some("EV_1")));
+        assert!(!seen.observe(Some("EV_1")));
+        assert!(seen.observe(Some("EV_2")));
+        assert!(!seen.observe(Some("EV_2")));
+    }
+
+    #[test]
+    fn seen_event_ids_treats_missing_id_as_fresh() {
+        let seen = SeenEventIds::default();
+        assert!(seen.observe(None));
+        assert!(seen.observe(None));
+    }
+
+    #[test]
+    fn seen_event_ids_evicts_oldest_past_capacity() {
+        let seen = SeenEventIds::default();
+        for i in 0..(SEEN_EVENT_ID_CAPACITY + 10) {
+            assert!(seen.observe(Some(&format!("EV_{i}"))));
+        }
+        // The oldest entry should now be evicted, so re-observing it
+        // returns "fresh".
+        assert!(seen.observe(Some("EV_0")));
+    }
+}

--- a/server/crates/waddle-server/src/server/routes/livekit_webhook.rs
+++ b/server/crates/waddle-server/src/server/routes/livekit_webhook.rs
@@ -31,7 +31,7 @@ use axum::Router;
 use jid::{BareJid, FullJid};
 use tracing::{debug, info, warn};
 use waddle_sfu::{
-    verify_webhook_signature, LiveKitWebhookEvent, ParticipantEnvelope, WebhookVerifyError,
+    verify_webhook_signature, CallId, LiveKitWebhookEvent, ParticipantEnvelope, WebhookVerifyError,
 };
 use waddle_xmpp::muc::build_occupant_presence;
 use waddle_xmpp::muc::room_actor::{ClearMujiPresence, MujiPresenceUpdateOutcome};
@@ -139,12 +139,32 @@ async fn livekit_webhook_handler(
             process_participant_left(&state, env).await;
         }
         LiveKitWebhookEvent::RoomFinished(env) => {
-            // Informational. LiveKit guarantees an individual
-            // `participant_left` for every still-connected participant
-            // before `room_finished` fires (per the LK delivery spec),
-            // and each of those is handled by the `ParticipantLeft`
-            // arm above. No additional MUC cleanup is required here.
-            info!(room = %env.room.name, "LiveKit reported room finished");
+            // LiveKit typically emits `participant_left` for every
+            // still-connected participant before `room_finished`, but
+            // each event is retried independently — a brief outage on
+            // our endpoint can exhaust the 5-retry budget for some
+            // participants while later events deliver successfully.
+            // Iterate the SFU registry's surviving identities and
+            // clear each one's MUC state as a safety net so a
+            // straggling participant_left loss can't leave permanent
+            // ghost Muji presence in the room.
+            info!(room = %env.room.name, "LiveKit reported room finished; sweeping surviving participants");
+            if let Ok(call_id) = CallId::new(env.room.name.clone()) {
+                let survivors = sfu.participants_for_call(&call_id);
+                for identity in survivors {
+                    process_participant_left_for_identity(
+                        &state,
+                        &env.room.name,
+                        identity.as_jid().to_string().as_str(),
+                    )
+                    .await;
+                }
+            } else {
+                warn!(
+                    room = %env.room.name,
+                    "LiveKit room_finished room name is not a valid MUC bare JID; cannot sweep survivors",
+                );
+            }
         }
         LiveKitWebhookEvent::ParticipantJoined(_) | LiveKitWebhookEvent::Other => {
             // Informational; the join path already flows through
@@ -156,18 +176,31 @@ async fn livekit_webhook_handler(
 }
 
 async fn process_participant_left(state: &WebSocketState, env: &ParticipantEnvelope) {
-    let Ok(full_jid) = env.participant.identity.parse::<FullJid>() else {
+    process_participant_left_for_identity(state, &env.room.name, &env.participant.identity).await;
+}
+
+/// Shared cleanup implementation used by both the
+/// `ParticipantLeft` / `ParticipantConnectionAborted` arms and the
+/// `RoomFinished` survivor sweep. Takes the raw identity string so
+/// the survivor sweep (which iterates `Identity` values out of the
+/// SFU registry) can call it with the same shape.
+async fn process_participant_left_for_identity(
+    state: &WebSocketState,
+    room_name: &str,
+    identity: &str,
+) {
+    let Ok(full_jid) = identity.parse::<FullJid>() else {
         warn!(
-            identity = %env.participant.identity,
-            room = %env.room.name,
+            identity = %identity,
+            room = %room_name,
             "LiveKit participant identity is not a valid full JID; skipping cleanup",
         );
         return;
     };
-    let Ok(room_jid) = env.room.name.parse::<BareJid>() else {
+    let Ok(room_jid) = room_name.parse::<BareJid>() else {
         warn!(
-            room = %env.room.name,
-            identity = %env.participant.identity,
+            room = %room_name,
+            identity = %identity,
             "LiveKit room name is not a valid MUC bare JID; skipping cleanup",
         );
         return;
@@ -176,7 +209,6 @@ async fn process_participant_left(state: &WebSocketState, env: &ParticipantEnvel
     debug!(
         room = %room_jid,
         identity = %full_jid,
-        event_id = ?env.id,
         "LiveKit webhook: clearing Muji presence for departed participant"
     );
 

--- a/server/crates/waddle-server/src/server/routes/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/mod.rs
@@ -4,6 +4,7 @@ pub mod auth_page; // Web-based auth page for XMPP credentials
 pub mod device; // OAuth Device Flow for CLI
 pub mod extension_webhooks; // Extension webhook ingress
 pub mod interpret; // OutboundEvent effect interpreter for sans-I/O protocol
+pub mod livekit_webhook; // LiveKit SFU webhook → MUC Muji-presence bridge
 pub mod uploads; // File upload endpoints (XEP-0363)
 pub mod websocket; // XMPP over WebSocket (RFC 7395)
 pub mod well_known; // /.well-known/ endpoints (host-meta, etc.)

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -95,6 +95,7 @@ pub use state::{ProtocolServices, WebSocketDeps, WebSocketState, XmppServiceDoma
 pub(crate) use cleanup::{
     destroy_room_actor, get_or_create_room_actor, get_room_actor, is_muc_room_jid,
 };
+pub(crate) use muc_call_sfu::unregister_participant_from_room;
 pub(crate) use transport_xml::{
     build_iq_error_xml_typed, build_iq_result_xml, element_to_xml, iq_to_xml, stanza_to_xml,
 };

--- a/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
@@ -119,6 +119,10 @@ mod tests {
         fn webhook_secret(&self) -> &waddle_sfu::ApiSecret {
             unimplemented!("not exercised by these tests")
         }
+
+        fn participants_for_call(&self, _: &CallId) -> Vec<Identity> {
+            Vec::new()
+        }
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
@@ -33,7 +33,7 @@ use super::state::WebSocketState;
 ///   theoretically reject some MUC bare JIDs — those are rooms with
 ///   no calling capability and there is nothing on the SFU to undo
 ///   for them anyway).
-pub(super) fn unregister_participant_from_room(
+pub(crate) fn unregister_participant_from_room(
     state: &WebSocketState,
     room_jid: &BareJid,
     jid: &FullJid,
@@ -113,6 +113,10 @@ mod tests {
         }
 
         fn turn_host(&self) -> &TurnHost {
+            unimplemented!("not exercised by these tests")
+        }
+
+        fn webhook_secret(&self) -> &waddle_sfu::ApiSecret {
             unimplemented!("not exercised by these tests")
         }
     }

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -1056,6 +1056,10 @@ impl waddle_sfu::SfuService for RecordingSfu {
     fn turn_host(&self) -> &waddle_sfu::TurnHost {
         unimplemented!("not exercised by this test")
     }
+
+    fn webhook_secret(&self) -> &waddle_sfu::ApiSecret {
+        unimplemented!("not exercised by this test")
+    }
 }
 
 async fn state_with_recording_sfu(

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -1060,6 +1060,10 @@ impl waddle_sfu::SfuService for RecordingSfu {
     fn webhook_secret(&self) -> &waddle_sfu::ApiSecret {
         unimplemented!("not exercised by this test")
     }
+
+    fn participants_for_call(&self, _: &waddle_sfu::CallId) -> Vec<waddle_sfu::Identity> {
+        Vec::new()
+    }
 }
 
 async fn state_with_recording_sfu(

--- a/server/crates/waddle-sfu/Cargo.toml
+++ b/server/crates/waddle-sfu/Cargo.toml
@@ -18,6 +18,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sha1 = { workspace = true }
 sha2 = { workspace = true }
+subtle = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }

--- a/server/crates/waddle-sfu/Cargo.toml
+++ b/server/crates/waddle-sfu/Cargo.toml
@@ -15,12 +15,11 @@ hmac = { workspace = true }
 jid = { workspace = true }
 jsonwebtoken = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 sha1 = { workspace = true }
+sha2 = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
 zeroize = { workspace = true }
-
-[dev-dependencies]
-serde_json = { workspace = true }

--- a/server/crates/waddle-sfu/src/config.rs
+++ b/server/crates/waddle-sfu/src/config.rs
@@ -141,6 +141,13 @@ impl fmt::Debug for TurnSharedSecret {
 pub struct SfuConfig {
     pub api_key: ApiKey,
     pub api_secret: ApiSecret,
+    /// Shared secret LiveKit uses to sign webhook deliveries
+    /// (`Authorization` JWT, HS256 over the request body's SHA-256
+    /// claim). Defaults to [`Self::api_secret`] for dev/test parity
+    /// with LiveKit's stock dev configuration; production deployments
+    /// should set `LIVEKIT_WEBHOOK_SECRET` independently so a leaked
+    /// API secret does not also forge inbound webhook deliveries.
+    pub webhook_secret: ApiSecret,
     pub ws_url: WebsocketUrl,
     pub turn_host: crate::turn::TurnHost,
     pub turn_tls_port: u16,
@@ -165,7 +172,10 @@ impl SfuConfig {
     /// Optional with defaults: `LIVEKIT_TURN_TLS_PORT` (443),
     /// `LIVEKIT_TURN_UDP_PORT` (3478),
     /// `LIVEKIT_TOKEN_TTL_SECONDS` (3600),
-    /// `LIVEKIT_TURN_TTL_SECONDS` (3600).
+    /// `LIVEKIT_TURN_TTL_SECONDS` (3600),
+    /// `LIVEKIT_WEBHOOK_SECRET` (defaults to `LIVEKIT_API_SECRET` for
+    /// dev parity; production should set both independently so a
+    /// leaked API secret can't forge webhook deliveries).
     pub fn from_env() -> Result<Option<Self>, FromEnvError> {
         let api_key = std::env::var("LIVEKIT_API_KEY").ok();
         let api_secret = std::env::var("LIVEKIT_API_SECRET").ok();
@@ -197,9 +207,16 @@ impl SfuConfig {
         let token_ttl_seconds = parse_seconds_env("LIVEKIT_TOKEN_TTL_SECONDS", 3600)?;
         let turn_ttl_seconds = parse_seconds_env("LIVEKIT_TURN_TTL_SECONDS", 3600)?;
 
+        let webhook_secret_raw = std::env::var("LIVEKIT_WEBHOOK_SECRET")
+            .ok()
+            .unwrap_or_else(|| api_secret.clone());
+        let webhook_secret =
+            ApiSecret::from_text(&webhook_secret_raw).map_err(FromEnvError::WeakWebhookSecret)?;
+
         Ok(Some(Self {
             api_key: ApiKey::new(api_key),
             api_secret: ApiSecret::from_text(&api_secret).map_err(FromEnvError::WeakApiSecret)?,
+            webhook_secret,
             ws_url,
             turn_host: crate::turn::TurnHost::new(turn_host),
             turn_tls_port,
@@ -237,6 +254,8 @@ pub enum FromEnvError {
     InvalidNumber(&'static str),
     #[error("LIVEKIT_API_SECRET is too weak")]
     WeakApiSecret(#[source] WeakSecret),
+    #[error("LIVEKIT_WEBHOOK_SECRET is too weak")]
+    WeakWebhookSecret(#[source] WeakSecret),
 }
 
 #[cfg(test)]

--- a/server/crates/waddle-sfu/src/config.rs
+++ b/server/crates/waddle-sfu/src/config.rs
@@ -207,15 +207,21 @@ impl SfuConfig {
         let token_ttl_seconds = parse_seconds_env("LIVEKIT_TOKEN_TTL_SECONDS", 3600)?;
         let turn_ttl_seconds = parse_seconds_env("LIVEKIT_TURN_TTL_SECONDS", 3600)?;
 
-        let webhook_secret_raw = std::env::var("LIVEKIT_WEBHOOK_SECRET")
-            .ok()
-            .unwrap_or_else(|| api_secret.clone());
-        let webhook_secret =
-            ApiSecret::from_text(&webhook_secret_raw).map_err(FromEnvError::WeakWebhookSecret)?;
+        // Validate the API secret first so the dedicated
+        // `WeakApiSecret` error still fires when both secrets are
+        // weak and `LIVEKIT_WEBHOOK_SECRET` is unset (it defaults to
+        // the API secret in that case, so checking webhook first
+        // would surface a misleading `WeakWebhookSecret`).
+        let api_secret_value =
+            ApiSecret::from_text(&api_secret).map_err(FromEnvError::WeakApiSecret)?;
+        let webhook_secret = match std::env::var("LIVEKIT_WEBHOOK_SECRET") {
+            Ok(raw) => ApiSecret::from_text(&raw).map_err(FromEnvError::WeakWebhookSecret)?,
+            Err(_) => api_secret_value.clone(),
+        };
 
         Ok(Some(Self {
             api_key: ApiKey::new(api_key),
-            api_secret: ApiSecret::from_text(&api_secret).map_err(FromEnvError::WeakApiSecret)?,
+            api_secret: api_secret_value,
             webhook_secret,
             ws_url,
             turn_host: crate::turn::TurnHost::new(turn_host),

--- a/server/crates/waddle-sfu/src/lib.rs
+++ b/server/crates/waddle-sfu/src/lib.rs
@@ -102,4 +102,10 @@ pub trait SfuService: Send + Sync + 'static {
     /// TURN host advertised via XEP-0215 (e.g.
     /// `turn.waddle.social`).
     fn turn_host(&self) -> &TurnHost;
+
+    /// Shared secret used by [`verify_webhook_signature`] to validate
+    /// inbound LiveKit webhook deliveries. Typically distinct from
+    /// the JWT-signing API secret per LK operational guidance, but
+    /// defaults to the API secret for dev parity.
+    fn webhook_secret(&self) -> &ApiSecret;
 }

--- a/server/crates/waddle-sfu/src/lib.rs
+++ b/server/crates/waddle-sfu/src/lib.rs
@@ -26,6 +26,7 @@ mod error;
 mod livekit;
 mod token;
 mod turn;
+mod webhook;
 
 pub use call::{CallId, CallState, Identity, MediaCapabilities};
 pub use config::{ApiKey, ApiSecret, FromEnvError, SfuConfig, TurnSharedSecret, WebsocketUrl};
@@ -33,6 +34,10 @@ pub use error::SfuError;
 pub use livekit::LiveKitSfu;
 pub use token::{JoinToken, Jti, Jwt, VideoGrant};
 pub use turn::{TurnCredential, TurnHost, TurnPassword, TurnUsername};
+pub use webhook::{
+    verify_webhook_signature, LiveKitWebhookEvent, ParticipantEnvelope, ParticipantInfo,
+    RoomEnvelope, RoomInfo, WebhookVerifyError,
+};
 
 /// Abstract SFU service consumed by the XMPP layer.
 ///

--- a/server/crates/waddle-sfu/src/lib.rs
+++ b/server/crates/waddle-sfu/src/lib.rs
@@ -108,4 +108,12 @@ pub trait SfuService: Send + Sync + 'static {
     /// the JWT-signing API secret per LK operational guidance, but
     /// defaults to the API secret for dev parity.
     fn webhook_secret(&self) -> &ApiSecret;
+
+    /// Snapshot the currently-registered identities for `call_id`.
+    /// Used by the LiveKit webhook handler's `room_finished` arm to
+    /// clean up any per-participant state that an earlier
+    /// `participant_left` retry-exhausted before the room closed.
+    /// Returns an empty vec when the call has no recorded participants
+    /// (either never registered or already drained).
+    fn participants_for_call(&self, call_id: &CallId) -> Vec<Identity>;
 }

--- a/server/crates/waddle-sfu/src/livekit.rs
+++ b/server/crates/waddle-sfu/src/livekit.rs
@@ -218,6 +218,13 @@ impl SfuService for LiveKitSfu {
     fn webhook_secret(&self) -> &crate::config::ApiSecret {
         &self.config.webhook_secret
     }
+
+    fn participants_for_call(&self, call_id: &CallId) -> Vec<Identity> {
+        self.calls
+            .get(call_id)
+            .map(|entry| entry.iter().cloned().collect())
+            .unwrap_or_default()
+    }
 }
 
 #[cfg(test)]

--- a/server/crates/waddle-sfu/src/livekit.rs
+++ b/server/crates/waddle-sfu/src/livekit.rs
@@ -214,6 +214,10 @@ impl SfuService for LiveKitSfu {
     fn turn_host(&self) -> &TurnHost {
         &self.config.turn_host
     }
+
+    fn webhook_secret(&self) -> &crate::config::ApiSecret {
+        &self.config.webhook_secret
+    }
 }
 
 #[cfg(test)]

--- a/server/crates/waddle-sfu/src/livekit.rs
+++ b/server/crates/waddle-sfu/src/livekit.rs
@@ -229,6 +229,8 @@ mod tests {
             api_key: ApiKey::new("APIxxxxxxxx"),
             api_secret: ApiSecret::from_text("super-secret-secret-32-bytes-min")
                 .expect("test secret meets min length"),
+            webhook_secret: ApiSecret::from_text("super-secret-secret-32-bytes-min")
+                .expect("test secret meets min length"),
             ws_url: WebsocketUrl::new(Url::parse("wss://livekit.waddle.social").unwrap()).unwrap(),
             turn_host: TurnHost::new("turn.waddle.social"),
             turn_tls_port: 443,

--- a/server/crates/waddle-sfu/src/webhook.rs
+++ b/server/crates/waddle-sfu/src/webhook.rs
@@ -1,0 +1,384 @@
+//! LiveKit webhook ingestion: typed event payloads and signature
+//! verification.
+//!
+//! LiveKit's webhook signing scheme (per the canonical docs at
+//! <https://docs.livekit.io/home/server/webhooks/>) is a JWT carried in
+//! the `Authorization` header, signed with HS256 using the API secret.
+//! The JWT's payload includes a `sha256` claim that is the
+//! base64-encoded SHA-256 digest of the raw request body. To accept a
+//! webhook, the receiver MUST:
+//!
+//! 1. Verify the JWT signature with HS256 against the shared secret.
+//! 2. Recompute SHA-256 over the raw body bytes and base64-encode the
+//!    digest.
+//! 3. Constant-time compare the recomputed digest against the JWT's
+//!    `sha256` claim. A signature that matches a body the receiver
+//!    didn't see is a replay attempt and MUST be rejected.
+//! 4. Reject events outside the JWT's lifetime window (`iat`/`exp`).
+//!
+//! This module exposes [`verify_webhook_signature`] which performs
+//! steps 1–4 and returns the parsed [`LiveKitWebhookEvent`] on success.
+//! Replay-by-event-id is the caller's responsibility (a small bounded
+//! `seen_event_ids` LRU at the HTTP handler is the canonical place).
+
+use base64::engine::general_purpose::STANDARD as Base64Standard;
+use base64::Engine;
+use jsonwebtoken::{decode, DecodingKey, Validation};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+use crate::config::ApiSecret;
+
+/// Errors that arise while verifying a LiveKit webhook delivery.
+///
+/// Surfaces all of them with explicit variants so the HTTP handler
+/// can map each to the right response code (400 for malformed,
+/// 401 for signature/body mismatch, 408/410 for time-window failure)
+/// without losing the why-it-failed signal in logs.
+#[derive(Debug, Error)]
+pub enum WebhookVerifyError {
+    #[error("missing Authorization header on LiveKit webhook")]
+    MissingAuthorization,
+
+    #[error("malformed Authorization header")]
+    MalformedAuthorization,
+
+    #[error("LiveKit webhook JWT failed signature or claim validation")]
+    Jwt(#[source] jsonwebtoken::errors::Error),
+
+    #[error("LiveKit webhook JWT did not carry a sha256 body-hash claim")]
+    MissingBodyHash,
+
+    #[error("LiveKit webhook JWT body-hash claim did not match the request body")]
+    BodyHashMismatch,
+
+    #[error("LiveKit webhook body failed to parse as JSON event payload")]
+    BodyJson(#[source] serde_json::Error),
+}
+
+/// JWT claims LiveKit signs with the API secret. Only the fields the
+/// verifier actually consumes are typed; LiveKit may add others
+/// (`exp`/`iat`/`nbf` are validated by `jsonwebtoken` and don't need
+/// dedicated fields here).
+#[derive(Debug, Deserialize)]
+struct WebhookClaims {
+    /// Base64-encoded SHA-256 of the request body. Mandatory per the
+    /// LiveKit signing spec.
+    sha256: Option<String>,
+}
+
+/// Verify a LiveKit webhook delivery and return the parsed event.
+///
+/// `auth_header` is the value of the `Authorization` request header.
+/// `body` is the *raw* request body bytes — re-encoded JSON would not
+/// match the hash claim. The handler MUST capture the body before
+/// any framework deserialization that might re-stringify it.
+pub fn verify_webhook_signature(
+    secret: &ApiSecret,
+    auth_header: Option<&str>,
+    body: &[u8],
+) -> Result<LiveKitWebhookEvent, WebhookVerifyError> {
+    let raw = auth_header.ok_or(WebhookVerifyError::MissingAuthorization)?;
+    let token = strip_bearer(raw).ok_or(WebhookVerifyError::MalformedAuthorization)?;
+
+    let mut validation = Validation::new(jsonwebtoken::Algorithm::HS256);
+    // LiveKit's webhook JWT omits `aud` / `iss` requirements; we only
+    // care about signature + lifetime. Disabling required claims keeps
+    // the verifier resilient to LK adding optional claims later.
+    validation.required_spec_claims.clear();
+    validation.validate_exp = true;
+    validation.validate_nbf = true;
+    // `leeway` is in seconds; allow a small clock-skew window so a
+    // few-second drift between LK and our host doesn't bounce
+    // legitimate deliveries.
+    validation.leeway = 30;
+
+    let key = DecodingKey::from_secret(secret.as_bytes());
+    let data =
+        decode::<WebhookClaims>(token, &key, &validation).map_err(WebhookVerifyError::Jwt)?;
+    let claimed = data
+        .claims
+        .sha256
+        .ok_or(WebhookVerifyError::MissingBodyHash)?;
+
+    let mut hasher = Sha256::new();
+    hasher.update(body);
+    let digest = hasher.finalize();
+    let computed = Base64Standard.encode(digest);
+
+    // Constant-time compare to avoid timing oracles on the body hash.
+    if !constant_time_eq(claimed.as_bytes(), computed.as_bytes()) {
+        return Err(WebhookVerifyError::BodyHashMismatch);
+    }
+
+    let event: LiveKitWebhookEvent =
+        serde_json::from_slice(body).map_err(WebhookVerifyError::BodyJson)?;
+    Ok(event)
+}
+
+fn strip_bearer(header: &str) -> Option<&str> {
+    let trimmed = header.trim();
+    if let Some(rest) = trimmed.strip_prefix("Bearer ") {
+        return Some(rest.trim());
+    }
+    if let Some(rest) = trimmed.strip_prefix("bearer ") {
+        return Some(rest.trim());
+    }
+    // LiveKit's own SDKs send the bare JWT without a `Bearer ` prefix
+    // in older versions; accept that form too.
+    if !trimmed.is_empty() && !trimmed.contains(' ') {
+        return Some(trimmed);
+    }
+    None
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut acc: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        acc |= x ^ y;
+    }
+    acc == 0
+}
+
+/// Typed projection of LiveKit's documented webhook payloads.
+///
+/// LiveKit sends an envelope with `event` discriminator plus
+/// event-specific `room` / `participant` / `track` / `egress_info`
+/// children. Only the variants Waddle actually reacts to carry typed
+/// data; the rest are caught by [`LiveKitWebhookEvent::Other`] so an
+/// unrecognised future event type does not fail signature-verified
+/// deliveries.
+///
+/// All variants also expose the envelope-level `id` (per LK docs:
+/// "a unique identifier for the event, useful for deduplication") so
+/// the HTTP handler can keep a bounded `seen_event_ids` LRU and drop
+/// the up-to-five-times retried duplicates.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "event")]
+pub enum LiveKitWebhookEvent {
+    /// A participant has connected and reached the `active` state.
+    /// Used to confirm presence; Waddle's existing
+    /// `register_call_participant` already runs on the Jingle initiate
+    /// path, so this is informational.
+    #[serde(rename = "participant_joined")]
+    ParticipantJoined(ParticipantEnvelope),
+
+    /// A participant has left the room and LiveKit has completed
+    /// cleanup. Source of truth for "this participant is no longer
+    /// in the call." Drives the chat-side Muji presence clear via the
+    /// HTTP handler → MUC room actor path.
+    #[serde(rename = "participant_left")]
+    ParticipantLeft(ParticipantEnvelope),
+
+    /// A participant's signal channel reached `active` but the media
+    /// connection later failed. Treated identically to
+    /// [`Self::ParticipantLeft`] for the purposes of presence cleanup.
+    #[serde(rename = "participant_connection_aborted")]
+    ParticipantConnectionAborted(ParticipantEnvelope),
+
+    /// The room has been closed by LiveKit (last participant left
+    /// past the empty-room timeout, or an explicit `room.close()`).
+    /// Cleans the SFU registry for the whole call and clears any
+    /// surviving Muji presence in the corresponding MUC.
+    #[serde(rename = "room_finished")]
+    RoomFinished(RoomEnvelope),
+
+    /// Unrecognised or informational events (`room_started`,
+    /// `track_published`, `egress_*`, …). Captured so the
+    /// signature-verified payload still parses cleanly; the handler
+    /// can log + drop.
+    #[serde(other)]
+    Other,
+}
+
+impl LiveKitWebhookEvent {
+    /// Envelope-level unique event id, used for deduplication of the
+    /// up-to-5 LiveKit retries per delivery. `None` for events we
+    /// don't react to (their envelopes weren't typed).
+    pub fn event_id(&self) -> Option<&str> {
+        match self {
+            Self::ParticipantJoined(env)
+            | Self::ParticipantLeft(env)
+            | Self::ParticipantConnectionAborted(env) => env.id.as_deref(),
+            Self::RoomFinished(env) => env.id.as_deref(),
+            Self::Other => None,
+        }
+    }
+}
+
+/// Common shape for events that name a specific (room, participant).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ParticipantEnvelope {
+    /// Envelope-level event id per LK's documented webhook shape.
+    /// Optional only because LK has shipped payloads without it
+    /// historically; the dedupe path treats absence as "not
+    /// deduplicable" rather than failing.
+    pub id: Option<String>,
+    pub room: RoomInfo,
+    pub participant: ParticipantInfo,
+}
+
+/// Common shape for events that name a room without a participant
+/// (`room_started`, `room_finished`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RoomEnvelope {
+    pub id: Option<String>,
+    pub room: RoomInfo,
+}
+
+/// LiveKit `Room` projection. Only the fields Waddle actually needs
+/// (the human room name, which is also our [`crate::CallId`]).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RoomInfo {
+    /// Human room name minted by Waddle. For MUC calls this is the
+    /// scoped `<bare-jid>::<sid>` (1:1) or the MUC room JID (group),
+    /// matching [`crate::CallId`].
+    pub name: String,
+    /// LiveKit-internal opaque room sid. Recorded for logs but not
+    /// load-bearing.
+    #[serde(default)]
+    pub sid: Option<String>,
+}
+
+/// LiveKit `ParticipantInfo` projection. Only the identity field is
+/// load-bearing for Waddle's bridge — it round-trips the stringified
+/// [`jid::FullJid`] we minted into the JWT's `sub` claim.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ParticipantInfo {
+    pub identity: String,
+    #[serde(default)]
+    pub sid: Option<String>,
+    #[serde(default)]
+    pub state: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ApiSecret;
+    use jsonwebtoken::{encode, EncodingKey, Header};
+    use serde_json::json;
+
+    fn fixture_secret() -> ApiSecret {
+        ApiSecret::from_text("test-secret-with-at-least-32-bytes-of-entropy")
+            .expect("fixture secret meets length minimum")
+    }
+
+    fn sign_for_body(secret: &ApiSecret, body: &[u8]) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(body);
+        let digest = hasher.finalize();
+        let sha256 = Base64Standard.encode(digest);
+        let claims = json!({
+            "sha256": sha256,
+            "exp": (chrono::Utc::now() + chrono::Duration::seconds(60)).timestamp(),
+            "iat": chrono::Utc::now().timestamp(),
+        });
+        encode(
+            &Header::default(),
+            &claims,
+            &EncodingKey::from_secret(secret.as_bytes()),
+        )
+        .expect("encode test JWT")
+    }
+
+    #[test]
+    fn verifies_a_well_formed_participant_left_payload() {
+        let secret = fixture_secret();
+        let body = serde_json::to_vec(&json!({
+            "event": "participant_left",
+            "id": "EV_test_1",
+            "room": { "name": "general@muc.test", "sid": "RM_xxx" },
+            "participant": {
+                "identity": "alice@waddle.test/desktop",
+                "sid": "PA_xxx",
+                "state": "DISCONNECTED",
+            },
+        }))
+        .unwrap();
+        let auth = format!("Bearer {}", sign_for_body(&secret, &body));
+
+        let event = verify_webhook_signature(&secret, Some(&auth), &body).expect("verify");
+        match event {
+            LiveKitWebhookEvent::ParticipantLeft(env) => {
+                assert_eq!(env.id.as_deref(), Some("EV_test_1"));
+                assert_eq!(env.room.name, "general@muc.test");
+                assert_eq!(env.participant.identity, "alice@waddle.test/desktop");
+            }
+            other => panic!("expected ParticipantLeft, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn accepts_bare_jwt_without_bearer_prefix() {
+        let secret = fixture_secret();
+        let body =
+            serde_json::to_vec(&json!({ "event": "room_finished", "room": { "name": "x" } }))
+                .unwrap();
+        let token = sign_for_body(&secret, &body);
+        verify_webhook_signature(&secret, Some(&token), &body).expect("bare JWT also accepted");
+    }
+
+    #[test]
+    fn rejects_missing_authorization() {
+        let secret = fixture_secret();
+        let body = b"{}";
+        let err = verify_webhook_signature(&secret, None, body).unwrap_err();
+        assert!(matches!(err, WebhookVerifyError::MissingAuthorization));
+    }
+
+    #[test]
+    fn rejects_a_payload_that_does_not_match_the_signed_hash() {
+        let secret = fixture_secret();
+        let signed_for = serde_json::to_vec(&json!({"event": "participant_left", "room": {"name": "a"}, "participant": {"identity": "x"}})).unwrap();
+        let auth = format!("Bearer {}", sign_for_body(&secret, &signed_for));
+        // Send a different body than the one whose hash is in the JWT.
+        let tampered =
+            serde_json::to_vec(&json!({"event": "room_finished", "room": {"name": "b"}})).unwrap();
+        let err = verify_webhook_signature(&secret, Some(&auth), &tampered).unwrap_err();
+        assert!(matches!(err, WebhookVerifyError::BodyHashMismatch));
+    }
+
+    #[test]
+    fn rejects_a_jwt_signed_with_a_different_secret() {
+        let secret = fixture_secret();
+        let other = ApiSecret::from_text("different-test-secret-that-is-also-long-enough").unwrap();
+        let body =
+            serde_json::to_vec(&json!({"event": "room_finished", "room": {"name": "x"}})).unwrap();
+        let auth = format!("Bearer {}", sign_for_body(&other, &body));
+        let err = verify_webhook_signature(&secret, Some(&auth), &body).unwrap_err();
+        assert!(matches!(err, WebhookVerifyError::Jwt(_)));
+    }
+
+    #[test]
+    fn unknown_event_kinds_parse_to_other_variant() {
+        let secret = fixture_secret();
+        let body = serde_json::to_vec(&json!({ "event": "egress_started" })).unwrap();
+        let auth = format!("Bearer {}", sign_for_body(&secret, &body));
+        let event = verify_webhook_signature(&secret, Some(&auth), &body).expect("verify");
+        assert_eq!(event, LiveKitWebhookEvent::Other);
+        assert_eq!(event.event_id(), None);
+    }
+
+    #[test]
+    fn event_id_round_trips_through_typed_variants() {
+        let env = ParticipantEnvelope {
+            id: Some("EV_42".into()),
+            room: RoomInfo {
+                name: "r".into(),
+                sid: None,
+            },
+            participant: ParticipantInfo {
+                identity: "alice@waddle.test/desktop".into(),
+                sid: None,
+                state: None,
+            },
+        };
+        let event = LiveKitWebhookEvent::ParticipantLeft(env);
+        assert_eq!(event.event_id(), Some("EV_42"));
+    }
+}

--- a/server/crates/waddle-sfu/src/webhook.rs
+++ b/server/crates/waddle-sfu/src/webhook.rs
@@ -26,6 +26,7 @@ use base64::Engine;
 use jsonwebtoken::{decode, DecodingKey, Validation};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use subtle::ConstantTimeEq;
 use thiserror::Error;
 
 use crate::config::ApiSecret;
@@ -108,7 +109,12 @@ pub fn verify_webhook_signature(
     let computed = Base64Standard.encode(digest);
 
     // Constant-time compare to avoid timing oracles on the body hash.
-    if !constant_time_eq(claimed.as_bytes(), computed.as_bytes()) {
+    // `subtle::ConstantTimeEq` returns false for mismatched lengths
+    // without a length-leaking early exit, so the comparison is
+    // genuinely fixed-time across both equal- and unequal-length
+    // inputs — robust even if LK ever switches to a non-base64 digest
+    // shape that changes the byte length.
+    if claimed.as_bytes().ct_eq(computed.as_bytes()).unwrap_u8() == 0 {
         return Err(WebhookVerifyError::BodyHashMismatch);
     }
 
@@ -131,17 +137,6 @@ fn strip_bearer(header: &str) -> Option<&str> {
         return Some(trimmed);
     }
     None
-}
-
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    let mut acc: u8 = 0;
-    for (x, y) in a.iter().zip(b.iter()) {
-        acc |= x ^ y;
-    }
-    acc == 0
 }
 
 /// Typed projection of LiveKit's documented webhook payloads.

--- a/server/crates/waddle-xmpp/src/protocol/handlers/extdisco.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/extdisco.rs
@@ -179,6 +179,8 @@ mod tests {
             api_key: ApiKey::new("APIxxxxxxxx"),
             api_secret: ApiSecret::from_text("api-secret-meets-min-length-32!!")
                 .expect("test secret meets min length"),
+            webhook_secret: ApiSecret::from_text("api-secret-meets-min-length-32!!")
+                .expect("test secret meets min length"),
             ws_url: WebsocketUrl::new("wss://livekit.test/".parse().unwrap()).unwrap(),
             turn_host: TurnHost::new("turn.test"),
             turn_tls_port: 443,

--- a/server/crates/waddle-xmpp/src/protocol/handlers/jingle.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/jingle.rs
@@ -839,6 +839,8 @@ mod tests {
             api_key: ApiKey::new("APIxxxxxxxx"),
             api_secret: ApiSecret::from_text("super-secret-secret-32-bytes-min")
                 .expect("test secret meets min length"),
+            webhook_secret: ApiSecret::from_text("super-secret-secret-32-bytes-min")
+                .expect("test secret meets min length"),
             ws_url: WebsocketUrl::new("wss://livekit.test/".parse().unwrap()).unwrap(),
             turn_host: TurnHost::new("turn.test"),
             turn_tls_port: 443,

--- a/server/crates/waddle-xmpp/src/xep/xep0215.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0215.rs
@@ -150,6 +150,8 @@ mod tests {
             api_key: ApiKey::new("k"),
             api_secret: ApiSecret::from_text("api-secret-meets-min-length-32!!")
                 .expect("test secret meets min length"),
+            webhook_secret: ApiSecret::from_text("api-secret-meets-min-length-32!!")
+                .expect("test secret meets min length"),
             ws_url: WebsocketUrl::new("wss://h/".parse().unwrap()).unwrap(),
             turn_host: TurnHost::new("turn.waddle.social"),
             turn_tls_port: 443,

--- a/server/crates/waddle-xmpp/tests/xep0215_external_service_discovery.rs
+++ b/server/crates/waddle-xmpp/tests/xep0215_external_service_discovery.rs
@@ -24,6 +24,8 @@ fn fixture_cred() -> TurnCredential {
         api_key: ApiKey::new("APIxxxxxxxx"),
         api_secret: ApiSecret::from_text("api-secret-meets-min-length-32!!")
             .expect("test secret meets min length"),
+        webhook_secret: ApiSecret::from_text("api-secret-meets-min-length-32!!")
+            .expect("test secret meets min length"),
         ws_url: WebsocketUrl::new("wss://livekit.test/".parse().expect("valid url"))
             .expect("valid ws url"),
         turn_host: TurnHost::new("turn.waddle.social"),

--- a/server/crates/waddle-xmpp/tests/xep_0272_muji.rs
+++ b/server/crates/waddle-xmpp/tests/xep_0272_muji.rs
@@ -307,6 +307,8 @@ fn fixture_sfu() -> Arc<dyn SfuService> {
         api_key: ApiKey::new("APIxxxxxxxx"),
         api_secret: ApiSecret::from_text("super-secret-secret-32-bytes-min")
             .expect("test secret meets min length"),
+        webhook_secret: ApiSecret::from_text("super-secret-secret-32-bytes-min")
+            .expect("test secret meets min length"),
         ws_url: WebsocketUrl::new("wss://livekit.test/".parse().unwrap()).unwrap(),
         turn_host: TurnHost::new("turn.test"),
         turn_tls_port: 443,


### PR DESCRIPTION
## Context

Today the chat reconstructs "who is in a group call" from XEP-0272 Muji presence broadcast by each participant. Muji presence is soft state — the MUC server holds it until the participant explicitly leaves or the session times out (~minutes via XEP-0198 SM / XMPP ping). Every reload that defeats SM resume creates a window where the chat's view of call membership diverges from the SFU's view. Prior PRs (#781→#792) have chipped at downstream symptoms; the bug "rejoin then hangup leaves a ghost participant" is the latest instance of this class.

This PR makes the **LiveKit SFU the source of truth** for call membership while keeping the wire shape XEP-conformant.

## Architecture

Three structural changes shipped together:

### 1. Server: LK→Muji webhook bridge (Rust)

- New `LiveKitWebhookEvent` types in `waddle-sfu`, HMAC-SHA256 signature verifier per LK's signing spec.
- New `/api/v1/livekit/webhook` HTTP route in `waddle-server` (mirrors `extension_webhooks` pattern, mounted in `http.rs`).
- Reuses the existing `ClearMujiPresence` room-actor message — server-originated Muji presence broadcasts are already precedented in `cleanup.rs:36-69, 76-125`. No new room-actor message type needed; the existing one is dispatched from the webhook path with the same semantics.
- Handler dispatches on `participant_left`, `participant_connection_aborted`, `room_finished` → clears Muji presence + unregisters from SFU registry + broadcasts to remaining occupants.
- `LIVEKIT_WEBHOOK_SECRET` env var, defaults to `LIVEKIT_API_SECRET` for dev.

### 2. Chat: LK token persistence + resume path for MUC

- Extend `muc-call-session-cache.ts` with `join: LiveKitJoin` (mirror of `dm-call-join-cache.ts`).
- New `resumeMucCallActivity` + `canResumeMucCallActivity` in `muc-call-actions.ts` — mirror of the DM resume path.
- `startMucCallAction` gains `tryResumeFirst` option; rejoin-after-reload sites (ChatReadyShell `joinChannelCallFromActivity`) opt in.
- Per LK docs ("Expiration time only impacts the initial connection"), cached JWT only needs to outlive the initial reconnect; LK auto-rotates 10-minute refresh tokens in-band after that.
- LK's identity-uniqueness invariant ("second connect with same identity displaces the first") cleanly displaces orphan SFU sessions on rejoin — no more orphan-A1.

### 3. Chat: LK SDK events drive in-call participant view

- `CallEngine` emits `participantConnected` / `participantDisconnected` + a `connected` snapshot from LK's `RoomEvent.*`.
- New `$mucCallLiveParticipants` store (`muc-call-live-participants.ts`) is the LK-truth projection.
- `useRoomHasActiveCall.participantList` prefers the LK projection when populated for the room, falling back to the Muji-derived view (now server-bridged-accurate per §1) otherwise.

## What this fixes

- **Reported bug** (rejoin-then-hangup leaves a ghost): closed in two layers — common reload uses `resumeMucCallActivity` (no new Jingle attempt, no Muji double-publish), and the LK webhook bridge clears any stale Muji presence within seconds.
- **Orphan SFU sessions on rejoin**: gone (LK identity uniqueness).
- **Stale "N in call" indicator across the app**: derived from a hybrid view — LK-direct for the room we're in, server-bridged LK-truth for rooms we're not in.

## XEP conformance

- XEP-0272 Muji: wire shape unchanged. Server-originated presence is XEP-0045-permitted and precedented in `cleanup.rs`.
- XEP-0166 Jingle: `session-terminate` still client-driven on explicit hangup; webhook never fabricates Jingle stanzas, only Muji presence. The pre-reload session is reclaimed by LK identity-uniqueness, not by a new Jingle attempt.
- XEP-0199: existing responder-side handler (`protocol/handlers/ping.rs`) is untouched. Dead XMPP sessions are still detected by the existing `spawn_sm_expiry_janitor`; the LK webhook bridge gives us seconds-grained call-membership truth on top of that.
- No new `urn:waddle:*` namespaces.

## Architectural choices (not deferred work)

- **LK identity stays per-resource** (`Identity::from_jid(FullJid)`). This is correct for multi-device — `alice/desktop` and `alice/mobile` mint distinct LK identities and can both be in the same call. A bare-JID + stable-UUID identity model would break multi-device, so per-resource is deliberate, not a follow-up.
- **Out-of-call participant view is LK-truth via the server bridge**. The Muji wire shape is the conformant XEP-0272 transport for what is, after §1, LK-driven membership data. Migrating the wire shape away from Muji would lose XEP conformance for zero gain.

## References

- [LiveKit webhooks](https://docs.livekit.io/home/server/webhooks/)
- [LiveKit Tokens & grants](https://docs.livekit.io/home/server/generating-tokens/) — "Expiration time only impacts the initial connection."
- [livekit/livekit#3739](https://github.com/livekit/livekit/issues/3739) — identity uniqueness behavior.
- [XEP-0272 Muji](https://xmpp.org/extensions/xep-0272.html) — wire shape we conform to.

## Test plan

- [x] `cargo fmt --all` + `cargo clippy --workspace --all-features --all-targets -- -D warnings` in `server/`
- [x] `cargo test -p waddle-server -p waddle-sfu` — 1052 server tests + 34 sfu tests pass; webhook handler dedupe + signature verifier covered
- [x] `bun test && bun run lint` in `chat/` — 1436 chat tests pass + knip clean; 15 new tests cover `canResumeMucCallActivity` / `resumeMucCallActivity` (no-cache, no-join, fresh-match, wrong-identity, near-expiry, active-promote, Muji republish, busy-guard) and `$mucCallLiveParticipants` (set/add/remove idempotency, room-scoped clear, global clear, dedupe, ordering)
- [ ] Manual: MUC voice call → hard-reload → "Rejoin" → instant reconnect, audio works → hang up → surface gone, banner gone, channel indicator clears
- [ ] Manual: force-kill LK WebSocket to simulate `participant_connection_aborted` → within ~5s other room members see channel indicator clear
- [ ] Manual multi-device: two browsers, both in same call, hang up on one → other continues to see itself in the call and sees the first as left

🤖 Generated with [Claude Code](https://claude.com/claude-code)