### PR TITLE
fix(server, chat, infra): clear MUC ghost participants and stuck call indicators

### DIFF
--- a/chat/src/components/calls/MucCallButton.vue
+++ b/chat/src/components/calls/MucCallButton.vue
@@ -6,7 +6,7 @@ import {
   $callState,
   type RawIqSender,
 } from "@/lib/calls/call-store";
-import { startMucCallAction } from "@/lib/calls/muc-call-actions";
+import { startMucCallAction, canResumeMucCallActivity } from "@/lib/calls/muc-call-actions";
 import { normalizeMucCallRoomJid } from "@/lib/calls/muc-call-presence";
 import { useRoomHasActiveCall } from "@/lib/calls/use-active-muc-call";
 import { connectionStore } from "@/lib/connection-store";
@@ -97,6 +97,12 @@ async function startCall(media: CallMedia): Promise<void> {
     ensureJoined: async () => {
       await getClientJoiner()?.(props.roomJid);
     },
+    tryResumeFirst:
+      roomCall.localResourceInCall.value ||
+      canResumeMucCallActivity({
+        roomJid: props.roomJid,
+        selfFullJid: getSelfFullJid() ?? null,
+      }),
   });
 }
 

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -339,6 +339,9 @@ export function clearCallState(): void {
       current.selfNick,
       new Error("Muji preparing wait cancelled while clearing call state"),
     );
+    clearLiveCallParticipants(current.peer);
+  } else if (current.phase === "active" && current.kind === "muc") {
+    clearLiveCallParticipants(current.peer);
   }
   $callState.set({ phase: "idle" });
   $lastCallError.set(null);

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -16,6 +16,7 @@ import {
   forgetMucCallSession,
   rememberMucCallSession,
 } from "./muc-call-session-cache";
+import { clearLiveCallParticipants } from "./muc-call-live-participants";
 import { barePeerJid } from "../xmpp/jid";
 
 /**
@@ -594,6 +595,7 @@ export async function tearDownActiveCall(
                 clearMucCallParticipant(s.peer, s.selfNick, s.selfFullJid);
               }
             }
+            clearLiveCallParticipants(s.peer);
             try {
               await sendMujiSessionTerminate(raw, s.peer, s.sid);
               forgetMucCallSession({

--- a/chat/src/lib/calls/use-active-muc-call.ts
+++ b/chat/src/lib/calls/use-active-muc-call.ts
@@ -114,15 +114,14 @@ export function useRoomHasActiveCall(
    * is empty for this room and we fall back to the Muji-derived
    * view (kept honest by the server-side LK→MUC webhook bridge).
    */
-  const participantList = computed<ReadonlyArray<string>>(() => {
-    const room = normalizedRoomJid.value;
-    if (!room) return [];
-    const liveIdentities = liveParticipants.value[room] ?? [];
-    if (liveIdentities.length > 0) {
-      return identitiesToNicks(liveIdentities, participantOwners.value[room] ?? []);
-    }
-    return participants.value[room] ?? [];
-  });
+  const participantList = computed<ReadonlyArray<string>>(() =>
+    resolveRoomParticipantList(
+      normalizedRoomJid.value,
+      participants.value,
+      participantOwners.value,
+      liveParticipants.value,
+    ),
+  );
 
   const pendingTerminateSession = computed(() =>
     pendingMucCallTerminateSession(
@@ -187,6 +186,13 @@ export function readRoomHasActiveCall(roomJid: string): {
   }
   const participants = $mucCallParticipants.get()[normalized] ?? [];
   const participantOwners = $mucCallParticipantOwners.get()[normalized] ?? [];
+  const liveParticipants = $mucCallLiveParticipants.get();
+  const participantList = resolveRoomParticipantList(
+    normalized,
+    $mucCallParticipants.get(),
+    $mucCallParticipantOwners.get(),
+    liveParticipants,
+  );
   const pendingTerminates = $mucCallTerminatePendingSessions.get();
   const nick = connectionStore.session?.username ?? null;
   const fullJid = currentClientFullJid();
@@ -194,8 +200,8 @@ export function readRoomHasActiveCall(roomJid: string): {
   const pendingTerminateSession = pendingMucCallTerminateSession(pendingTerminates, normalized, fullJid);
   const pendingTerminate = !!pendingTerminateSession;
   return {
-    hasActiveCall: participants.length > 0 || pendingTerminate,
-    selfInCall: !!nick && (participants.includes(nick) || pendingTerminate),
+    hasActiveCall: participantList.length > 0 || pendingTerminate,
+    selfInCall: !!nick && (participantList.includes(nick) || pendingTerminate),
     localResourceInCall:
       (
         s.phase === "active" &&
@@ -203,9 +209,9 @@ export function readRoomHasActiveCall(roomJid: string): {
         normalizeMucCallRoomJid(s.peer) === normalized
       ) ||
       hasOwnerFullJid(participantOwners, fullJid) ||
-      hasUnownedSelfNick(participantOwners, nick, participants) ||
+      hasUnownedSelfNick(participantOwners, nick, participantList) ||
       pendingTerminate,
-    participantCount: Math.max(participants.length, pendingTerminate ? 1 : 0),
+    participantCount: Math.max(participantList.length, pendingTerminate ? 1 : 0),
     media: mediaForRoomWithPendingFallback(
       normalized,
       s,
@@ -234,6 +240,26 @@ function hasUnownedSelfNick(
 ): boolean {
   if (!nick || !participants.includes(nick)) return false;
   return owners.some((owner) => owner.nick === nick && !fullJidIdentityKey(owner.realJid));
+}
+
+/**
+ * Resolve the nick list for a room, preferring LiveKit's live
+ * participant projection when populated (same semantics as
+ * `useRoomHasActiveCall`'s composable path).
+ */
+function resolveRoomParticipantList(
+  roomJid: string | null,
+  participantsByRoom: Record<string, string[]>,
+  ownersByRoom: Record<string, ReadonlyArray<{ nick: string; realJid?: string }>>,
+  liveParticipantsByRoom: Record<string, string[]>,
+): string[] {
+  const room = roomJid ? normalizeMucCallRoomJid(roomJid) : "";
+  if (!room) return [];
+  const liveIdentities = liveParticipantsByRoom[room] ?? [];
+  if (liveIdentities.length > 0) {
+    return identitiesToNicks(liveIdentities, ownersByRoom[room] ?? []);
+  }
+  return participantsByRoom[room] ?? [];
 }
 
 /**

--- a/chat/src/lib/calls/use-active-muc-call.ts
+++ b/chat/src/lib/calls/use-active-muc-call.ts
@@ -258,7 +258,7 @@ function resolveRoomParticipantList(
   if (liveIdentities.length > 0) {
     return identitiesToNicks(liveIdentities, ownersByRoom[room] ?? []);
   }
-  return participantsByRoom[room] ?? [];
+  return [...(participantsByRoom[room] ?? [])];
 }
 
 /**

--- a/chat/src/lib/calls/use-active-muc-call.ts
+++ b/chat/src/lib/calls/use-active-muc-call.ts
@@ -184,7 +184,6 @@ export function readRoomHasActiveCall(roomJid: string): {
       media: mucCallMediaForRoom(""),
     };
   }
-  const participants = $mucCallParticipants.get()[normalized] ?? [];
   const participantOwners = $mucCallParticipantOwners.get()[normalized] ?? [];
   const liveParticipants = $mucCallLiveParticipants.get();
   const participantList = resolveRoomParticipantList(
@@ -249,9 +248,9 @@ function hasUnownedSelfNick(
  */
 function resolveRoomParticipantList(
   roomJid: string | null,
-  participantsByRoom: Record<string, string[]>,
-  ownersByRoom: Record<string, ReadonlyArray<{ nick: string; realJid?: string }>>,
-  liveParticipantsByRoom: Record<string, string[]>,
+  participantsByRoom: Readonly<Record<string, ReadonlyArray<string>>>,
+  ownersByRoom: Readonly<Record<string, ReadonlyArray<{ nick: string; realJid?: string }>>>,
+  liveParticipantsByRoom: Readonly<Record<string, ReadonlyArray<string>>>,
 ): string[] {
   const room = roomJid ? normalizeMucCallRoomJid(roomJid) : "";
   if (!room) return [];

--- a/chat/tests/call-activity-dock.test.ts
+++ b/chat/tests/call-activity-dock.test.ts
@@ -1180,6 +1180,10 @@ describe("CallActivityDock rendering", () => {
     const mucCallButton = readFileSync(new URL("../src/components/calls/MucCallButton.vue", import.meta.url), "utf8");
     const conversationBanner = readFileSync(new URL("../src/components/calls/ConversationCallBanner.vue", import.meta.url), "utf8");
 
+    expect(mucCallButton).toContain("canResumeMucCallActivity");
+    expect(mucCallButton).toContain("tryResumeFirst:");
+    expect(mucCallButton).toContain("roomCall.localResourceInCall.value");
+
     expect(readyShell).toContain("import CallActivityDock");
     expect(readyShell).toContain("import CurrentCallPanel");
     expect(readyShell.match(/<CallActivityDock/g)?.length ?? 0).toBeGreaterThanOrEqual(2);

--- a/chat/tests/call-controls.test.ts
+++ b/chat/tests/call-controls.test.ts
@@ -9,7 +9,10 @@ import {
   $dmCallActivities,
   clearDmCallActivities,
 } from "../src/lib/calls/dm-call-activity";
-import { connectionStore } from "../src/lib/connection-store";
+import {
+  $mucCallLiveParticipants,
+  setLiveCallParticipants,
+} from "../src/lib/calls/muc-call-live-participants";
 import type { LiveKitJoin } from "../src/lib/calls/types";
 
 const join: LiveKitJoin = {
@@ -44,6 +47,7 @@ class PagehideHarness {
 afterEach(() => {
   clearCallState();
   clearDmCallActivities();
+  $mucCallLiveParticipants.set({});
   connectionStore.client = null;
 });
 
@@ -104,6 +108,27 @@ describe("call page lifecycle controls", () => {
     expect(sender.send_call_finish).not.toHaveBeenCalled();
     expect(sender.update_muji_presence).not.toHaveBeenCalled();
     expect(sender.send_raw_iq).not.toHaveBeenCalled();
+  });
+
+  test("pagehide suspension clears stale LiveKit participant projection for MUC calls", () => {
+    $callState.set({
+      phase: "active",
+      peer: "room@muc.waddle.test",
+      sid: "muc-1",
+      media: { audio: true, video: false },
+      join: { ...join, room: "room@muc.waddle.test" },
+      kind: "muc",
+      selfNick: "alice",
+      selfFullJid: "alice@waddle.test/web",
+    });
+    setLiveCallParticipants("room@muc.waddle.test", [
+      "alice@waddle.test/web",
+      "bob@waddle.test/phone",
+    ]);
+
+    suspendCallForPageHide();
+
+    expect($mucCallLiveParticipants.get()).toEqual({});
   });
 
   test("pagehide suspension persists stream resume state before clearing the local call slot", () => {

--- a/chat/tests/call-controls.test.ts
+++ b/chat/tests/call-controls.test.ts
@@ -13,6 +13,7 @@ import {
   $mucCallLiveParticipants,
   setLiveCallParticipants,
 } from "../src/lib/calls/muc-call-live-participants";
+import { connectionStore } from "../src/lib/connection-store";
 import type { LiveKitJoin } from "../src/lib/calls/types";
 
 const join: LiveKitJoin = {

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -438,6 +438,7 @@ describe("leaveRetainedMucCallAction", () => {
   });
 
   test("terminates the cached Muji Jingle session after clearing retained presence", async () => {
+    const now = new Date();
     const sent: unknown[][] = [];
     applyMucCallPresence({
       from: "chan@muc.test/alice",
@@ -448,7 +449,7 @@ describe("leaveRetainedMucCallAction", () => {
       roomJid: "chan@muc.test",
       sid: "muc-recovered-live",
       selfFullJid: "alice@waddle.test/web",
-      now: new Date("2026-05-26T12:00:00.000Z"),
+      now,
     });
     const sender: RawIqSender = {
       update_muji_presence: mock(async (...args) => {
@@ -474,11 +475,12 @@ describe("leaveRetainedMucCallAction", () => {
     expect(readMucCallSession({
       roomJid: "chan@muc.test",
       selfFullJid: "alice@waddle.test/web",
-      now: new Date("2026-05-26T12:00:00.000Z"),
+      now,
     })).toBeNull();
   });
 
   test("reports cached Muji terminate failure after retained presence is cleared", async () => {
+    const now = new Date();
     applyMucCallPresence({
       from: "chan@muc.test/alice",
       muc_jid: "alice@waddle.test/web",
@@ -489,7 +491,7 @@ describe("leaveRetainedMucCallAction", () => {
       sid: "muc-retry-live",
       selfFullJid: "alice@waddle.test/web",
       media: { audio: true, video: true },
-      now: new Date("2026-05-26T12:00:00.000Z"),
+      now,
     });
     const sender: RawIqSender = {
       update_muji_presence: mock(async () => undefined),
@@ -521,7 +523,7 @@ describe("leaveRetainedMucCallAction", () => {
     expect(readMucCallSession({
       roomJid: "chan@muc.test",
       selfFullJid: "alice@waddle.test/web",
-      now: new Date("2026-05-26T12:00:00.000Z"),
+      now,
     })).toMatchObject({ sid: "muc-retry-live" });
     expect($mucCallTerminatePendingSessions.get()).toEqual({
       "chan@muc.test\u0000muc-retry-live\u0000alice@waddle.test/web": {

--- a/chat/tests/dm-call-actions.test.ts
+++ b/chat/tests/dm-call-actions.test.ts
@@ -87,6 +87,7 @@ describe("startDmCallAction", () => {
   });
 
   test("answers a hydrated incoming call with the stored proposer full JID", async () => {
+    const now = new Date();
     const sender: CallWireSender = {
       send_call_proceed: mock(async () => undefined),
     };
@@ -99,8 +100,8 @@ describe("startDmCallAction", () => {
       },
       selfBareJid: "alice@waddle.test",
       to: "alice@waddle.test/web",
-      timestamp: "2026-05-26T12:00:00.000Z",
-      now: new Date("2026-05-26T12:00:00.000Z"),
+      timestamp: now.toISOString(),
+      now,
     });
 
     await answerIncomingDmCallActivity({
@@ -495,6 +496,8 @@ describe("startDmCallAction", () => {
   });
 
   test("keeps recovered DM activity retryable when no end marker sends", async () => {
+    const now = new Date();
+    const tokenExp = new Date(now.getTime() + 60 * 60 * 1000);
     const sender: CallWireSender = {
       send_call_session_terminate: mock(async () => {
         throw new Error("terminate failed");
@@ -514,23 +517,23 @@ describe("startDmCallAction", () => {
           url: "wss://livekit.waddle.test",
           room: "dm-call-retry",
           identity: "alice@waddle.test/web",
-          token: jwtWithExp(Date.parse("2026-05-26T13:00:00.000Z") / 1000),
+          token: jwtWithExp(tokenExp.getTime() / 1000),
         },
       },
       selfBareJid: "alice@waddle.test",
-      timestamp: "2026-05-26T12:00:00.000Z",
-      now: new Date("2026-05-26T12:00:00.000Z"),
+      timestamp: now.toISOString(),
+      now,
     });
 
     await expect(endRecoveredDmCallAction({
       peerBareJid: "bob@waddle.test",
       getSender: () => sender,
       getSelfFullJid: () => "alice@waddle.test/web",
-      now: new Date("2026-05-26T12:00:00.000Z"),
+      now,
     })).resolves.toBe(false);
 
     expect(sender.send_call_finish).not.toHaveBeenCalled();
-    expect(readDmCallActivity("bob@waddle.test")).toMatchObject({
+    expect(readDmCallActivity("bob@waddle.test", now)).toMatchObject({
       sid: "retry-live",
       state: "accepted",
     });
@@ -604,6 +607,8 @@ describe("startDmCallAction", () => {
   });
 
   test("does not end another resource's recovered DM call", async () => {
+    const now = new Date();
+    const tokenExp = new Date(now.getTime() + 60 * 60 * 1000);
     const sender: CallWireSender = {
       send_call_session_terminate: mock(async () => undefined),
       send_call_finish: mock(async () => undefined),
@@ -619,24 +624,24 @@ describe("startDmCallAction", () => {
           url: "wss://livekit.waddle.test",
           room: "dm-call-other-resource",
           identity: "alice@waddle.test/tablet",
-          token: jwtWithExp(Date.parse("2026-05-26T13:00:00.000Z") / 1000),
+          token: jwtWithExp(tokenExp.getTime() / 1000),
         },
       },
       selfBareJid: "alice@waddle.test",
-      timestamp: "2026-05-26T12:00:00.000Z",
-      now: new Date("2026-05-26T12:00:00.000Z"),
+      timestamp: now.toISOString(),
+      now,
     });
 
     await expect(endRecoveredDmCallAction({
       peerBareJid: "bob@waddle.test",
       getSender: () => sender,
       getSelfFullJid: () => "alice@waddle.test/web",
-      now: new Date("2026-05-26T12:00:00.000Z"),
+      now,
     })).resolves.toBe(false);
 
     expect(sender.send_call_session_terminate).not.toHaveBeenCalled();
     expect(sender.send_call_finish).not.toHaveBeenCalled();
-    expect(readDmCallActivity("bob@waddle.test")).toMatchObject({
+    expect(readDmCallActivity("bob@waddle.test", now)).toMatchObject({
       sid: "other-resource-live",
     });
   });

--- a/chat/tests/muc-call-resume.test.ts
+++ b/chat/tests/muc-call-resume.test.ts
@@ -1,11 +1,16 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
-import { $callState, clearCallState } from "../src/lib/calls/call-store";
+import { $callState, clearCallState, tearDownActiveCall } from "../src/lib/calls/call-store";
 import {
   canResumeMucCallActivity,
   resumeMucCallActivity,
 } from "../src/lib/calls/muc-call-actions";
 import {
+  $mucCallLiveParticipants,
+  setLiveCallParticipants,
+} from "../src/lib/calls/muc-call-live-participants";
+import {
   clearAllMucCallSessionCacheForTests,
+  readMucCallSession,
   rememberMucCallSession,
 } from "../src/lib/calls/muc-call-session-cache";
 import type { CallMedia, LiveKitJoin } from "../src/lib/calls/types";
@@ -292,5 +297,47 @@ describe("resumeMucCallActivity", () => {
 
     expect(ok).toBe(false);
     expect($callState.get().phase).toBe("outgoing");
+  });
+
+  test("reload resume then hangup clears session cache and live participants", async () => {
+    const join = forgeLiveKitJoin({
+      identity: SELF_FULL_JID,
+      secondsFromNow: 600,
+    });
+    rememberMucCallSession({
+      roomJid: ROOM_JID,
+      sid: "sid-resume-hangup",
+      selfFullJid: SELF_FULL_JID,
+      media: AUDIO_CALL,
+      join,
+    });
+
+    const resumed = await resumeMucCallActivity({
+      roomJid: ROOM_JID,
+      getSender: () => ({
+        update_muji_presence: async () => undefined,
+        send_muji_session_terminate: async () => undefined,
+      }),
+      getSelfNick: () => SELF_NICK,
+      getSelfFullJid: () => SELF_FULL_JID,
+    });
+    expect(resumed).toBe(true);
+
+    setLiveCallParticipants(ROOM_JID, [SELF_FULL_JID, "bob@waddle.test/mobile"]);
+
+    await tearDownActiveCall(
+      {
+        update_muji_presence: async () => undefined,
+        send_muji_session_terminate: async () => undefined,
+      } as unknown as Parameters<typeof tearDownActiveCall>[0],
+      "success",
+    );
+
+    expect($callState.get()).toEqual({ phase: "idle" });
+    expect(readMucCallSession({
+      roomJid: ROOM_JID,
+      selfFullJid: SELF_FULL_JID,
+    })).toBeNull();
+    expect($mucCallLiveParticipants.get()[ROOM_JID]).toBeUndefined();
   });
 });

--- a/chat/tests/use-active-muc-call.test.ts
+++ b/chat/tests/use-active-muc-call.test.ts
@@ -1,12 +1,14 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { $callState } from "../src/lib/calls/call-store";
 import {
+  $mucCallParticipantOwners,
   $mucCallParticipants,
   applyMucCallPresence,
   clearMucCallParticipants,
 } from "../src/lib/calls/muc-call-presence";
 import { connectionStore } from "../src/lib/connection-store";
 import { readActiveMucCall, readRoomHasActiveCall } from "../src/lib/calls/use-active-muc-call";
+import { setLiveCallParticipants, clearAllLiveCallParticipants } from "../src/lib/calls/muc-call-live-participants";
 import {
   clearAllMucCallSessionCacheForTests,
   markMucCallSessionTerminatePending,
@@ -160,6 +162,7 @@ describe("readRoomHasActiveCall selector", () => {
   beforeEach(() => {
     $callState.set({ phase: "idle" });
     clearMucCallParticipants();
+    clearAllLiveCallParticipants();
     clearAllMucCallSessionCacheForTests();
     setSession(null);
   });
@@ -167,6 +170,7 @@ describe("readRoomHasActiveCall selector", () => {
   afterEach(() => {
     $callState.set({ phase: "idle" });
     clearMucCallParticipants();
+    clearAllLiveCallParticipants();
     clearAllMucCallSessionCacheForTests();
     setSession(null);
   });
@@ -386,6 +390,24 @@ describe("readRoomHasActiveCall selector", () => {
       localResourceInCall: true,
       participantCount: 1,
       media: { audio: true, video: true },
+    });
+  });
+
+  test("readRoomHasActiveCall prefers LiveKit live participants over stale Muji counts", () => {
+    setSession("alice");
+    $mucCallParticipants.set({ [ROOM]: ["alice", "ghost"] });
+    $mucCallParticipantOwners.set({
+      [ROOM]: [
+        { nick: "alice", realJid: "alice@waddle.test/web" },
+        { nick: "ghost", realJid: "ghost@waddle.test/web" },
+      ],
+    });
+    setLiveCallParticipants(ROOM, ["alice@waddle.test/web"]);
+
+    expect(readRoomHasActiveCall(ROOM)).toMatchObject({
+      hasActiveCall: true,
+      participantCount: 1,
+      selfInCall: true,
     });
   });
 });

--- a/infrastructure/waddle.cloud/charts/livekit-sfu/Chart.yaml
+++ b/infrastructure/waddle.cloud/charts/livekit-sfu/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: livekit-sfu
 description: Minimal LiveKit SFU chart for Waddle infrastructure.
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: v1.11.0
 
 sources:

--- a/infrastructure/waddle.cloud/charts/livekit-sfu/templates/configmap.yaml
+++ b/infrastructure/waddle.cloud/charts/livekit-sfu/templates/configmap.yaml
@@ -2,6 +2,9 @@
 {{- if or .Values.apiKeys.existingSecret (gt (len .Values.apiKeys.values) 0) -}}
 {{- $_ := set $config "key_file" .Values.apiKeys.mountPath -}}
 {{- end -}}
+{{- if and .Values.webhook.enabled .Values.webhook.apiKey (gt (len .Values.webhook.urls) 0) -}}
+{{- $_ := set $config "webhook" (dict "api_key" .Values.webhook.apiKey "urls" .Values.webhook.urls) -}}
+{{- end -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/infrastructure/waddle.cloud/charts/livekit-sfu/values.yaml
+++ b/infrastructure/waddle.cloud/charts/livekit-sfu/values.yaml
@@ -36,6 +36,13 @@ apiKeys:
   mountPath: /etc/livekit/keys/keys.yaml
   values: {}
 
+# LiveKit → waddle-server SFU-authoritative MUC call cleanup.
+# `apiKey` is injected at deploy time (must match a key in keys.yaml).
+webhook:
+  enabled: false
+  apiKey: ""
+  urls: []
+
 livekit:
   port: 7880
   log_level: info

--- a/infrastructure/waddle.cloud/gitops/livekit-sfu/external-secret.yaml
+++ b/infrastructure/waddle.cloud/gitops/livekit-sfu/external-secret.yaml
@@ -16,6 +16,9 @@ spec:
       data:
         keys.yaml: |
           {{ .apiKey }}: {{ .apiSecret | quote }}
+        # Exposed separately so the HelmRelease can inject
+        # `webhook.api_key` without committing the key name to git.
+        api-key: {{ .apiKey | quote }}
   data:
     - secretKey: apiKey
       remoteRef:

--- a/infrastructure/waddle.cloud/gitops/livekit-sfu/helmrelease.yaml
+++ b/infrastructure/waddle.cloud/gitops/livekit-sfu/helmrelease.yaml
@@ -16,12 +16,22 @@ spec:
         name: livekit-sfu
         namespace: livekit
       interval: 12h
+  valuesFrom:
+    - kind: Secret
+      name: livekit-sfu-api-keys
+      valuesKey: api-key
+      targetPath: webhook.apiKey
+      optional: false
   values:
     image:
       repository: livekit/livekit-server
       tag: v1.11.0
     apiKeys:
       existingSecret: livekit-sfu-api-keys
+    webhook:
+      enabled: true
+      urls:
+        - https://xmpp.waddle.social/api/v1/livekit/webhook
     livekit:
       log_level: info
       rtc:

--- a/infrastructure/waddle.cloud/gitops/waddle-server/livekit-external-secret.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/livekit-external-secret.yaml
@@ -48,6 +48,14 @@ spec:
       remoteRef:
         key: livekit-sfu
         property: api-secret
+    # LiveKit webhook JWT verifier (`waddle-sfu::SfuConfig::from_env`).
+    # Mirrors the API secret so LiveKit's signed deliveries validate
+    # without a separate 1Password field; override with a dedicated
+    # secret if webhook signing is rotated independently.
+    - secretKey: LIVEKIT_WEBHOOK_SECRET
+      remoteRef:
+        key: livekit-sfu
+        property: api-secret
     # HMAC-SHA1 shared secret for coturn's TURN REST credential
     # mechanism (XEP-0215 entries are minted from this).
     - secretKey: LIVEKIT_TURN_SHARED_SECRET

--- a/server/crates/waddle-server/src/server/routes/livekit_webhook.rs
+++ b/server/crates/waddle-server/src/server/routes/livekit_webhook.rs
@@ -33,13 +33,9 @@ use tracing::{debug, info, warn};
 use waddle_sfu::{
     verify_webhook_signature, CallId, LiveKitWebhookEvent, ParticipantEnvelope, WebhookVerifyError,
 };
-use waddle_xmpp::muc::build_occupant_presence;
-use waddle_xmpp::muc::room_actor::{ClearMujiPresence, MujiPresenceUpdateOutcome};
-use waddle_xmpp::xep::xep0272::Muji;
-use waddle_xmpp::xep::xep0421::OccupantIdentity;
-use waddle_xmpp_core::Stanza;
 
-use super::websocket::{get_room_actor, note_participant_left_from_webhook, WebSocketState};
+use super::muc_muji_clear::clear_muji_presence_for_departure;
+use super::websocket::WebSocketState;
 
 /// Upper bound on remembered event ids for delivery deduplication.
 /// LiveKit retries up to 5 times per delivery; a small LRU is enough
@@ -206,115 +202,7 @@ async fn process_participant_left_for_identity(
         return;
     };
 
-    debug!(
-        room = %room_jid,
-        identity = %full_jid,
-        "LiveKit webhook: clearing Muji presence for departed participant"
-    );
-
-    // Clear the room-actor's authoritative per-session Muji state for
-    // this participant. The handler is idempotent — a participant that
-    // already left via the XMPP-driven path returns `Ok(None)` and we
-    // skip the broadcast.
-    let Some(actor) = get_room_actor(state, &room_jid).await else {
-        // Room has no active actor (no occupants), nothing to clear.
-        return;
-    };
-    let outcome = match actor
-        .ask(ClearMujiPresence {
-            sender_jid: full_jid.clone(),
-        })
-        .await
-    {
-        Ok(Some(outcome)) => outcome,
-        Ok(None) => {
-            debug!(
-                room = %room_jid,
-                identity = %full_jid,
-                "LiveKit webhook: participant not in MUC actor; SFU registry cleanup only"
-            );
-            note_participant_left_from_webhook(state, &room_jid, &full_jid);
-            return;
-        }
-        Err(error) => {
-            warn!(
-                room = %room_jid,
-                identity = %full_jid,
-                error = ?error,
-                "LiveKit webhook: room actor rejected Muji clear; falling through to SFU unregister"
-            );
-            note_participant_left_from_webhook(state, &room_jid, &full_jid);
-            return;
-        }
-    };
-
-    broadcast_muji_clear_from_sfu(state, &room_jid, &full_jid, &outcome);
-    note_participant_left_from_webhook(state, &room_jid, &full_jid);
-}
-
-/// Broadcast a server-originated Muji-presence clear to every remaining
-/// occupant of the room.
-///
-/// Wire shape mirrors what the client-driven Muji-clear path emits in
-/// `muc_update::try_handle_muc_presence_update`: an in-room
-/// `<presence/>` per recipient per surviving Muji owner, with the
-/// departed participant getting an empty Muji payload (XEP-0272
-/// §Leaving: "absence of the `<muji/>` element is the leave marker").
-/// Sibling sessions with surviving Muji state retain their advertised
-/// `<muji/>` payload so multi-resource participants don't lose
-/// preparing/active state held by a different resource.
-fn broadcast_muji_clear_from_sfu(
-    state: &WebSocketState,
-    room_jid: &BareJid,
-    leaving_real_jid: &FullJid,
-    outcome: &MujiPresenceUpdateOutcome,
-) {
-    let from_room_jid = room_jid
-        .clone()
-        .with_resource_str(&outcome.update.sender_nick)
-        .unwrap_or_else(|_| leaving_real_jid.clone());
-
-    // Owner entries to reflect: the leaving session (no Muji payload =
-    // leave marker) plus every surviving sibling-session Muji.
-    let mut entries: Vec<(FullJid, Option<Muji>)> =
-        Vec::with_capacity(outcome.session_mujis.len() + 1);
-    entries.push((leaving_real_jid.clone(), None));
-    for (owner, muji) in &outcome.session_mujis {
-        if owner == leaving_real_jid {
-            continue;
-        }
-        entries.push((owner.clone(), Some(muji.clone())));
-    }
-
-    for recipient in &outcome.update.recipients {
-        for (owner_jid, muji) in &entries {
-            let owner_bare = owner_jid.to_bare();
-            let identity = OccupantIdentity {
-                bare_jid: &owner_bare,
-                real_jid: Some(owner_jid),
-                secret: &state.deps.occupant_id_secret,
-            };
-            let is_self = recipient.to_bare() == owner_bare;
-            let mut presence = build_occupant_presence(
-                &from_room_jid,
-                recipient,
-                outcome.update.sender_affiliation,
-                outcome.update.sender_role,
-                is_self,
-                &identity,
-            );
-            if let Some(muji_ref) = muji {
-                if !muji_ref.is_empty() {
-                    presence.payloads.push(muji_ref.to_element());
-                }
-            }
-            let _ = state
-                .deps
-                .protocol
-                .connection_registry
-                .try_send_to(recipient, Stanza::Presence(presence));
-        }
-    }
+    clear_muji_presence_for_departure(state, &room_jid, &full_jid).await;
 }
 
 #[cfg(test)]

--- a/server/crates/waddle-server/src/server/routes/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/mod.rs
@@ -5,6 +5,7 @@ pub mod device; // OAuth Device Flow for CLI
 pub mod extension_webhooks; // Extension webhook ingress
 pub mod interpret; // OutboundEvent effect interpreter for sans-I/O protocol
 pub mod livekit_webhook; // LiveKit SFU webhook → MUC Muji-presence bridge
+pub mod muc_muji_clear; // Shared Muji clear + broadcast for SFU/Jingle teardown
 pub mod uploads; // File upload endpoints (XEP-0363)
 pub mod websocket; // XMPP over WebSocket (RFC 7395)
 pub mod well_known; // /.well-known/ endpoints (host-meta, etc.)

--- a/server/crates/waddle-server/src/server/routes/muc_muji_clear.rs
+++ b/server/crates/waddle-server/src/server/routes/muc_muji_clear.rs
@@ -1,0 +1,121 @@
+//! Shared MUC Muji-presence cleanup for SFU-driven and client-driven
+//! call departures.
+//!
+//! Both the LiveKit webhook bridge and the Muji Jingle
+//! `session-terminate` path need to clear the room actor's per-session
+//! Muji state and broadcast the XEP-0272 leave marker to remaining
+//! occupants. Centralising the logic keeps the wire shape identical.
+
+use jid::{BareJid, FullJid};
+use tracing::{debug, warn};
+use waddle_xmpp::muc::build_occupant_presence;
+use waddle_xmpp::muc::room_actor::{ClearMujiPresence, MujiPresenceUpdateOutcome};
+use waddle_xmpp::xep::xep0272::Muji;
+use waddle_xmpp::xep::xep0421::OccupantIdentity;
+use waddle_xmpp_core::Stanza;
+
+use super::websocket::{get_room_actor, note_participant_left_from_webhook, WebSocketState};
+
+/// Clear `full_jid`'s Muji advertisement in `room_jid` and broadcast
+/// the leave marker to remaining occupants. Idempotent: a participant
+/// already cleared via presence-update returns `Ok(None)` and skips
+/// the broadcast.
+pub(crate) async fn clear_muji_presence_for_departure(
+    state: &WebSocketState,
+    room_jid: &BareJid,
+    full_jid: &FullJid,
+) {
+    debug!(
+        room = %room_jid,
+        identity = %full_jid,
+        "Clearing Muji presence for departed participant"
+    );
+
+    let Some(actor) = get_room_actor(state, room_jid).await else {
+        return;
+    };
+    let outcome = match actor
+        .ask(ClearMujiPresence {
+            sender_jid: full_jid.clone(),
+        })
+        .await
+    {
+        Ok(Some(outcome)) => outcome,
+        Ok(None) => {
+            debug!(
+                room = %room_jid,
+                identity = %full_jid,
+                "Participant not in MUC actor; SFU registry cleanup only"
+            );
+            note_participant_left_from_webhook(state, room_jid, full_jid);
+            return;
+        }
+        Err(error) => {
+            warn!(
+                room = %room_jid,
+                identity = %full_jid,
+                error = ?error,
+                "Room actor rejected Muji clear; falling through to SFU unregister"
+            );
+            note_participant_left_from_webhook(state, room_jid, full_jid);
+            return;
+        }
+    };
+
+    broadcast_muji_clear(state, room_jid, full_jid, &outcome);
+    note_participant_left_from_webhook(state, room_jid, full_jid);
+}
+
+/// Broadcast a server-originated Muji-presence clear to every remaining
+/// occupant of the room.
+pub(crate) fn broadcast_muji_clear(
+    state: &WebSocketState,
+    room_jid: &BareJid,
+    leaving_real_jid: &FullJid,
+    outcome: &MujiPresenceUpdateOutcome,
+) {
+    let from_room_jid = room_jid
+        .clone()
+        .with_resource_str(&outcome.update.sender_nick)
+        .unwrap_or_else(|_| leaving_real_jid.clone());
+
+    let mut entries: Vec<(FullJid, Option<Muji>)> =
+        Vec::with_capacity(outcome.session_mujis.len() + 1);
+    entries.push((leaving_real_jid.clone(), None));
+    for (owner, muji) in &outcome.session_mujis {
+        if owner == leaving_real_jid {
+            continue;
+        }
+        entries.push((owner.clone(), Some(muji.clone())));
+    }
+
+    for recipient in &outcome.update.recipients {
+        for (owner_jid, muji) in &entries {
+            let owner_bare = owner_jid.to_bare();
+            let identity = OccupantIdentity {
+                bare_jid: &owner_bare,
+                real_jid: Some(owner_jid),
+                secret: &state.deps.occupant_id_secret,
+            };
+            let is_self = recipient.to_bare() == owner_bare;
+            let mut presence = build_occupant_presence(
+                &from_room_jid,
+                recipient,
+                outcome.update.sender_affiliation,
+                outcome.update.sender_role,
+                is_self,
+                &identity,
+            );
+            if let Some(muji_ref) = muji {
+                if !muji_ref.is_empty() {
+                    presence.payloads.push(muji_ref.to_element());
+                }
+            }
+            let _ = state
+                .deps
+                .protocol
+                .connection_registry
+                .try_send_to(recipient, Stanza::Presence(presence));
+        }
+    }
+}

--- a/server/crates/waddle-server/src/server/routes/muc_muji_clear.rs
+++ b/server/crates/waddle-server/src/server/routes/muc_muji_clear.rs
@@ -32,6 +32,7 @@ pub(crate) async fn clear_muji_presence_for_departure(
     );
 
     let Some(actor) = get_room_actor(state, room_jid).await else {
+        note_participant_left_from_webhook(state, room_jid, full_jid);
         return;
     };
     let outcome = match actor

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/jingle_muji_gate.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/jingle_muji_gate.rs
@@ -382,14 +382,13 @@ mod tests {
     #[test]
     fn muji_session_terminate_room_extracts_target_room() {
         let room: BareJid = "general@muc.example.com".parse().expect("valid room");
-        let iq = build_jingle_muji_iq(Action::SessionTerminate, room.as_str());
+        let iq = build_jingle_muji_iq(Action::SessionTerminate, "test-sid-terminate");
         assert_eq!(super::muji_session_terminate_room(&iq), Some(room));
     }
 
     #[test]
     fn muji_session_terminate_room_ignores_session_initiate() {
-        let room = "general@muc.example.com";
-        let iq = build_jingle_muji_iq(Action::SessionInitiate, room);
+        let iq = build_jingle_muji_iq(Action::SessionInitiate, "test-sid-initiate");
         assert_eq!(super::muji_session_terminate_room(&iq), None);
     }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/jingle_muji_gate.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/jingle_muji_gate.rs
@@ -107,6 +107,27 @@ pub(super) async fn verify_muji_jingle_request(
     verify_room_membership(state, full_jid, &room_jid).await
 }
 
+/// When `iq` is a Muji-bearing Jingle `session-terminate`, return the
+/// target MUC room JID so the websocket adapter can mirror the
+/// LiveKit webhook's Muji-clear broadcast after the sans-I/O handler
+/// unregisters the SFU participant.
+pub(super) fn muji_session_terminate_room(iq: &Iq) -> Option<BareJid> {
+    let Iq::Set { payload, .. } = iq else {
+        return None;
+    };
+    if payload.ns() != NS_JINGLE || payload.name() != "jingle" {
+        return None;
+    }
+    let muji_elem = find_muji(payload)?;
+    let muji = Muji::try_from(muji_elem).ok()?;
+    let room_jid = muji.room?;
+    let jingle = Jingle::try_from(payload.clone()).ok()?;
+    if !matches!(jingle.action, Action::SessionTerminate) {
+        return None;
+    }
+    Some(room_jid)
+}
+
 async fn verify_room_membership(
     state: &WebSocketState,
     full_jid: &FullJid,
@@ -356,5 +377,19 @@ mod tests {
         };
         let outcome = verify_muji_jingle_request(&state, &alice, &iq).await;
         assert!(matches!(outcome, GateOutcome::Allow));
+    }
+
+    #[test]
+    fn muji_session_terminate_room_extracts_target_room() {
+        let room: BareJid = "general@muc.example.com".parse().expect("valid room");
+        let iq = build_jingle_muji_iq(Action::SessionTerminate, room.as_str());
+        assert_eq!(super::muji_session_terminate_room(&iq), Some(room));
+    }
+
+    #[test]
+    fn muji_session_terminate_room_ignores_session_initiate() {
+        let room = "general@muc.example.com";
+        let iq = build_jingle_muji_iq(Action::SessionInitiate, room);
+        assert_eq!(super::muji_session_terminate_room(&iq), None);
     }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/sans_io.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/sans_io.rs
@@ -126,7 +126,8 @@ pub(super) async fn handle_sans_io_iq(
         let ctx = ProtocolStanzaContext { domain, full_jid };
         let muji_terminate_room = super::jingle_muji_gate::muji_session_terminate_room(iq);
         let events = state.deps.protocol.dispatcher.dispatch_iq(iq, &ctx);
-        let should_clear_muji = muji_terminate_room.is_some() && !events_contain_iq_error(&events);
+        let muji_clear_after = muji_terminate_room
+            .filter(|_| !events_contain_iq_error(&events));
         let deps = crate::server::routes::interpret::Deps {
             connection_registry: &state.deps.protocol.connection_registry,
             sm_session_registry: Some(&state.deps.protocol.sm_session_registry),
@@ -142,13 +143,11 @@ pub(super) async fn handle_sans_io_iq(
             pending_delivery_storage: Some(&state.deps.protocol.pending_delivery_storage),
         };
         let outcome = crate::server::routes::interpret::interpret(events, &deps).await;
-        if should_clear_muji {
-            if let Some(room_jid) = muji_terminate_room {
-                crate::server::routes::muc_muji_clear::clear_muji_presence_for_departure(
-                    state, &room_jid, full_jid,
-                )
-                .await;
-            }
+        if let Some(room_jid) = muji_clear_after {
+            crate::server::routes::muc_muji_clear::clear_muji_presence_for_departure(
+                state, &room_jid, full_jid,
+            )
+            .await;
         }
         if outcome.close {
             warn!(

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/sans_io.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/sans_io.rs
@@ -126,8 +126,7 @@ pub(super) async fn handle_sans_io_iq(
         let ctx = ProtocolStanzaContext { domain, full_jid };
         let muji_terminate_room = super::jingle_muji_gate::muji_session_terminate_room(iq);
         let events = state.deps.protocol.dispatcher.dispatch_iq(iq, &ctx);
-        let muji_clear_after = muji_terminate_room
-            .filter(|_| !events_contain_iq_error(&events));
+        let muji_clear_after = muji_terminate_room.filter(|_| !events_contain_iq_error(&events));
         let deps = crate::server::routes::interpret::Deps {
             connection_registry: &state.deps.protocol.connection_registry,
             sm_session_registry: Some(&state.deps.protocol.sm_session_registry),

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/sans_io.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/sans_io.rs
@@ -1,5 +1,19 @@
 use super::*;
 
+fn events_contain_iq_error(events: &[waddle_xmpp::protocol::OutboundEvent]) -> bool {
+    use waddle_xmpp::protocol::OutboundEvent;
+    use waddle_xmpp::Stanza;
+    events.iter().any(|event| {
+        let OutboundEvent::SendStanza(stanza) = event else {
+            return false;
+        };
+        matches!(
+            stanza.as_ref(),
+            Stanza::Iq(iq) if matches!(iq.as_ref(), xmpp_parsers::iq::Iq::Error { .. })
+        )
+    })
+}
+
 pub(super) async fn handle_sans_io_iq(
     ctx: IqHandlerContext<'_>,
     state: &WebSocketState,
@@ -110,7 +124,9 @@ pub(super) async fn handle_sans_io_iq(
             }
         }
         let ctx = ProtocolStanzaContext { domain, full_jid };
+        let muji_terminate_room = super::jingle_muji_gate::muji_session_terminate_room(iq);
         let events = state.deps.protocol.dispatcher.dispatch_iq(iq, &ctx);
+        let should_clear_muji = muji_terminate_room.is_some() && !events_contain_iq_error(&events);
         let deps = crate::server::routes::interpret::Deps {
             connection_registry: &state.deps.protocol.connection_registry,
             sm_session_registry: Some(&state.deps.protocol.sm_session_registry),
@@ -126,6 +142,14 @@ pub(super) async fn handle_sans_io_iq(
             pending_delivery_storage: Some(&state.deps.protocol.pending_delivery_storage),
         };
         let outcome = crate::server::routes::interpret::interpret(events, &deps).await;
+        if should_clear_muji {
+            if let Some(room_jid) = muji_terminate_room {
+                crate::server::routes::muc_muji_clear::clear_muji_presence_for_departure(
+                    state, &room_jid, full_jid,
+                )
+                .await;
+            }
+        }
         if outcome.close {
             warn!(
                 ns = %payload_ns,


### PR DESCRIPTION
## Summary

Fixes ghost MUC call participants and stuck call indicators on staging:

- **Infra:** Wire LiveKit `participant_left` webhooks to `https://xmpp.waddle.social/api/v1/livekit/webhook`; add `LIVEKIT_WEBHOOK_SECRET` to waddle-server gitops; bump `livekit-sfu` chart to 0.1.3.
- **Server:** Shared `clear_muji_presence_for_departure` for webhook + Muji Jingle `session-terminate`; SFU registry cleanup when room actor is unavailable.
- **Client:** Unified LiveKit/Muji participant resolution in `readRoomHasActiveCall`; clear `$mucCallLiveParticipants` on MUC teardown and pagehide suspension; `tryResumeFirst: true` on `MucCallButton` when resumable.

## Plan

1. Wire LiveKit webhooks on staging (tab-death cleanup was falling back to XMPP SM timeouts)
2. Clear Muji on Muji `session-terminate` via shared room-actor path
3. Unify client participant resolution + harden teardown
4. Consistent MUC rejoin entry points (`tryResumeFirst` on header pill)
5. Regression tests (chat + server unit tests)
6. Staging manual verification after merge/deploy

## Test plan

- [x] `cargo clippy -p waddle-server --all-features -- -D warnings`
- [x] `cargo test -p waddle-server`
- [x] `bun test && bun run lint` in `chat/`
- [x] CI green on PR #795
- [x] Pre-deploy: `POST /api/v1/livekit/webhook` returns 401 without signature (route reachable)
- [ ] After Flux reconcile: LiveKit logs show webhook delivery; server logs show `"Clearing Muji presence for departed participant"`
- [ ] MUC voice call → hard reload → Rejoin → hang up → indicator clears for all occupants
- [ ] Force-kill tab → other members see indicator clear within ~5s
- [ ] Two browsers in call; one hangs up → other continues, departed user drops from count