### PR TITLE
fix(infra): publish livekit-sfu chart and gitops on main CI

### DIFF
--- a/infrastructure/waddle.cloud/charts/livekit-sfu/Chart.yaml
+++ b/infrastructure/waddle.cloud/charts/livekit-sfu/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: livekit-sfu
 description: Minimal LiveKit SFU chart for Waddle infrastructure.
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: v1.11.0
 
 sources:

--- a/infrastructure/waddle.cloud/charts/livekit-sfu/templates/validations.yaml
+++ b/infrastructure/waddle.cloud/charts/livekit-sfu/templates/validations.yaml
@@ -67,3 +67,9 @@
 {{- if and .Values.livekit.turn.enabled .Values.livekit.turn.tls_port (not .Values.livekit.turn.external_tls) (not .Values.turn.secretName) -}}
 {{- fail "turn.secretName is required when livekit.turn.tls_port is set and livekit.turn.external_tls=false" -}}
 {{- end -}}
+{{- if and .Values.webhook.enabled (eq (len .Values.webhook.urls) 0) -}}
+{{- fail "webhook.urls is required when webhook.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.webhook.enabled (not .Values.webhook.apiKey) -}}
+{{- fail "webhook.apiKey is required when webhook.enabled=true" -}}
+{{- end -}}

--- a/infrastructure/waddle.cloud/env.cue
+++ b/infrastructure/waddle.cloud/env.cue
@@ -81,7 +81,15 @@ schema.#Project & {
 			args: ["-c", #"""
 					set -euo pipefail
 					echo "${GITHUB_TOKEN}" | helm registry login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin
-					helm lint charts/livekit-sfu --set apiKeys.values.ci=abcdefghijklmnopqrstuvwxyz123456
+					helm lint charts/livekit-sfu \
+					  --set apiKeys.existingSecret=livekit-sfu-api-keys \
+					  --set webhook.enabled=true \
+					  --set webhook.apiKey=ci-key \
+					  --set 'webhook.urls={https://xmpp.waddle.social/api/v1/livekit/webhook}' \
+					  --set turn.secretName=turn-waddle-social-tls \
+					  --set livekit.turn.enabled=true \
+					  --set livekit.turn.domain=turn.waddle.social \
+					  --set nodePorts.turnUdp.enabled=true
 					helm package charts/livekit-sfu -d /tmp/charts
 					chart_version="$(helm show chart charts/livekit-sfu | awk '$1 == "version:" { print $2 }')"
 					if helm show chart oci://ghcr.io/waddle-social/waddle/charts/livekit-sfu --version "${chart_version}" >/dev/null 2>&1; then
@@ -90,7 +98,6 @@ schema.#Project & {
 					  helm push /tmp/charts/livekit-sfu-*.tgz oci://ghcr.io/waddle-social/waddle/charts
 					fi
 				"""#]
-			inputs: ["charts/**"]
 		}
 		"gitops-push": schema.#Task & {
 			command: "bash"
@@ -106,7 +113,6 @@ schema.#Project & {
 					  --source="$(git config --get remote.origin.url)" \
 					  --revision="$(git rev-parse --short HEAD)"
 				"""#]
-			inputs: ["gitops/**"]
 		}
 	}
 }

--- a/infrastructure/waddle.cloud/gitops/waddle-server/livekit-external-secret.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/livekit-external-secret.yaml
@@ -34,7 +34,7 @@ spec:
         LIVEKIT_WS_URL: "wss://sfu.waddle.social"
         LIVEKIT_TURN_HOST: "turn.waddle.social"
         LIVEKIT_TURN_TLS_PORT: "443"
-        LIVEKIT_TURN_UDP_PORT: "3478"
+        LIVEKIT_TURN_UDP_PORT: "30478"
   data:
     # API key + secret for the LiveKit room JWT signer. Stored on
     # the LiveKit SFU side under the `livekit-sfu-api-keys` Secret


### PR DESCRIPTION
## Summary

Fixes LiveKit SFU chart setup so webhook config from #795 actually reaches the cluster:

- Remove cuenv `inputs` filters on `helm-push` / `gitops-push` that caused waddle-cloud CI to skip publishing (chart stuck at 0.1.2, gitops-livekit-sfu stale since April)
- Bump `livekit-sfu` chart to **0.1.4** with webhook fail-fast validations
- Lint the production Helm values path (webhook + TURN TLS) in CI
- Align `LIVEKIT_TURN_UDP_PORT` with SFU NodePort **30478**

## Plan

1. Unblock GHCR publish on every `waddle-cloud-default` main run (idempotent skip for existing chart versions)
2. Ship chart 0.1.4 with webhook template + validations
3. Fix STUN port advertisement mismatch
4. After merge: confirm GHCR + Flux reconcile, then LiveKit webhook smoke test

## Test plan

- [x] `helm lint` with production values path locally
- [x] `helm template` renders `webhook.api_key` + URLs
- [x] Webhook validation rejects `enabled=true` without `apiKey`
- [ ] After merge: GHCR has `livekit-sfu` chart `0.1.4`
- [ ] After merge: `gitops-livekit-sfu:latest` timestamp updates
- [ ] After Flux reconcile: LiveKit pod config includes webhook block
- [ ] Runtime: tab kill clears Muji within ~5s via webhook


Made with [Cursor](https://cursor.com)