### PR TITLE
fix(infra): publish livekit-sfu chart by scoping cuenv inputs + derivePaths

### DIFF
--- a/.github/workflows/waddle-cloud-default.yml
+++ b/.github/workflows/waddle-cloud-default.yml
@@ -25,10 +25,9 @@ permissions:
   packages: write
   id-token: write
 jobs:
-  build-cuenv:
-    name: build.cuenv
+  waddle-cloud-default:
+    name: waddle-cloud-default
     runs-on: namespace-profile-linux-x86
-    timeout-minutes: 30
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -55,79 +54,8 @@ jobs:
         curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.41.3/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  gitopsPush:
-    name: gitopsPush
-    runs-on: namespace-profile-linux-x86
-    needs:
-    - build-cuenv
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 2
-    - name: Cache /nix on Namespace volume
-      uses: namespacelabs/nscloud-cache-action@v1
-      with:
-        cache: nix
-    - name: Hand /nix to the runner user
-      run: sudo chown -R runner /nix
-    - name: Install Nix
-      uses: cachix/install-nix-action@v31
-      with:
-        extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
-      run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.41.3/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: gitopsPush
-      run: cuenv task gitopsPush --skip-dependencies
-      working-directory: infrastructure/waddle.cloud
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_ACTOR: ${{ github.actor }}
-        GITHUB_REF_TYPE: ${{ github.ref_type }}
-        GITHUB_REF_NAME: ${{ github.ref_name }}
-  helmPush:
-    name: helmPush
-    runs-on: namespace-profile-linux-x86
-    needs:
-    - build-cuenv
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 2
-    - name: Cache /nix on Namespace volume
-      uses: namespacelabs/nscloud-cache-action@v1
-      with:
-        cache: nix
-    - name: Hand /nix to the runner user
-      run: sudo chown -R runner /nix
-    - name: Install Nix
-      uses: cachix/install-nix-action@v31
-      with:
-        extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
-      run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.41.3/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: helmPush
-      run: cuenv task helmPush --skip-dependencies
-      working-directory: infrastructure/waddle.cloud
+    - name: 'Run pipeline: default'
+      run: cuenv ci --pipeline default --path infrastructure/waddle.cloud
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_ACTOR: ${{ github.actor }}

--- a/.github/workflows/waddle-cloud-default.yml
+++ b/.github/workflows/waddle-cloud-default.yml
@@ -9,8 +9,10 @@ on:
     paths:
     - .github/workflows/waddle-cloud-default.yml
     - cue.mod/**
-    - infrastructure/waddle.cloud/**
+    - infrastructure/waddle.cloud/charts/livekit-sfu/**
     - infrastructure/waddle.cloud/env.cue
+    - infrastructure/waddle.cloud/env.cue/**
+    - infrastructure/waddle.cloud/gitops/**
     - infrastructure/waddle.cloud/schema/**
   workflow_dispatch: {}
 concurrency:
@@ -23,9 +25,10 @@ permissions:
   packages: write
   id-token: write
 jobs:
-  waddle-cloud-default:
-    name: waddle-cloud-default
+  build-cuenv:
+    name: build.cuenv
     runs-on: namespace-profile-linux-x86
+    timeout-minutes: 30
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -52,8 +55,79 @@ jobs:
         curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.41.3/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: 'Run pipeline: default'
-      run: cuenv ci --pipeline default --path infrastructure/waddle.cloud
+  gitopsPush:
+    name: gitopsPush
+    runs-on: namespace-profile-linux-x86
+    needs:
+    - build-cuenv
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
+    - name: Cache /nix on Namespace volume
+      uses: namespacelabs/nscloud-cache-action@v1
+      with:
+        cache: nix
+    - name: Hand /nix to the runner user
+      run: sudo chown -R runner /nix
+    - name: Install Nix
+      uses: cachix/install-nix-action@v31
+      with:
+        extra_nix_config: accept-flake-config = true
+    - name: Setup cuenv (release)
+      run: |-
+        arch="$(uname -m)"
+        case "$arch" in
+          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
+          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
+          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
+        esac
+        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.41.3/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: gitopsPush
+      run: cuenv task gitopsPush --skip-dependencies
+      working-directory: infrastructure/waddle.cloud
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_ACTOR: ${{ github.actor }}
+        GITHUB_REF_TYPE: ${{ github.ref_type }}
+        GITHUB_REF_NAME: ${{ github.ref_name }}
+  helmPush:
+    name: helmPush
+    runs-on: namespace-profile-linux-x86
+    needs:
+    - build-cuenv
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
+    - name: Cache /nix on Namespace volume
+      uses: namespacelabs/nscloud-cache-action@v1
+      with:
+        cache: nix
+    - name: Hand /nix to the runner user
+      run: sudo chown -R runner /nix
+    - name: Install Nix
+      uses: cachix/install-nix-action@v31
+      with:
+        extra_nix_config: accept-flake-config = true
+    - name: Setup cuenv (release)
+      run: |-
+        arch="$(uname -m)"
+        case "$arch" in
+          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
+          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
+          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
+        esac
+        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.41.3/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: helmPush
+      run: cuenv task helmPush --skip-dependencies
+      working-directory: infrastructure/waddle.cloud
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_ACTOR: ${{ github.actor }}

--- a/infrastructure/waddle.cloud/charts/livekit-sfu/Chart.yaml
+++ b/infrastructure/waddle.cloud/charts/livekit-sfu/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: livekit-sfu
 description: Minimal LiveKit SFU chart for Waddle infrastructure.
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: v1.11.0
 
 sources:

--- a/infrastructure/waddle.cloud/charts/livekit-sfu/templates/validations.yaml
+++ b/infrastructure/waddle.cloud/charts/livekit-sfu/templates/validations.yaml
@@ -67,3 +67,9 @@
 {{- if and .Values.livekit.turn.enabled .Values.livekit.turn.tls_port (not .Values.livekit.turn.external_tls) (not .Values.turn.secretName) -}}
 {{- fail "turn.secretName is required when livekit.turn.tls_port is set and livekit.turn.external_tls=false" -}}
 {{- end -}}
+{{- if and .Values.webhook.enabled (eq (len .Values.webhook.urls) 0) -}}
+{{- fail "webhook.urls is required when webhook.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.webhook.enabled (not .Values.webhook.apiKey) -}}
+{{- fail "webhook.apiKey is required when webhook.enabled=true" -}}
+{{- end -}}

--- a/infrastructure/waddle.cloud/env.cue
+++ b/infrastructure/waddle.cloud/env.cue
@@ -62,6 +62,7 @@ schema.#Project & {
 
 	ci: pipelines: {
 		default: {
+			mode: "expanded"
 			when: {
 				branch: ["main"]
 				defaultBranch: true
@@ -71,12 +72,12 @@ schema.#Project & {
 				packages:   "write"
 				"id-token": "write"
 			}
-			tasks: [_t["helm-push"], _t["gitops-push"]]
+			tasks: [_t.helmPush, _t.gitopsPush]
 		}
 	}
 
 	tasks: {
-		"helm-push": schema.#Task & {
+		helmPush: schema.#Task & {
 			command: "bash"
 			args: ["-c", #"""
 					set -euo pipefail
@@ -100,7 +101,7 @@ schema.#Project & {
 				"""#]
 			inputs: ["charts/livekit-sfu/**", "env.cue"]
 		}
-		"gitops-push": schema.#Task & {
+		gitopsPush: schema.#Task & {
 			command: "bash"
 			args: ["-c", #"""
 					set -euo pipefail

--- a/infrastructure/waddle.cloud/env.cue
+++ b/infrastructure/waddle.cloud/env.cue
@@ -62,7 +62,7 @@ schema.#Project & {
 
 	ci: pipelines: {
 		default: {
-			mode: "expanded"
+			derivePaths: true
 			when: {
 				branch: ["main"]
 				defaultBranch: true

--- a/infrastructure/waddle.cloud/env.cue
+++ b/infrastructure/waddle.cloud/env.cue
@@ -81,7 +81,15 @@ schema.#Project & {
 			args: ["-c", #"""
 					set -euo pipefail
 					echo "${GITHUB_TOKEN}" | helm registry login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin
-					helm lint charts/livekit-sfu --set apiKeys.values.ci=abcdefghijklmnopqrstuvwxyz123456
+					helm lint charts/livekit-sfu \
+					  --set apiKeys.existingSecret=livekit-sfu-api-keys \
+					  --set webhook.enabled=true \
+					  --set webhook.apiKey=ci-key \
+					  --set 'webhook.urls={https://xmpp.waddle.social/api/v1/livekit/webhook}' \
+					  --set turn.secretName=turn-waddle-social-tls \
+					  --set livekit.turn.enabled=true \
+					  --set livekit.turn.domain=turn.waddle.social \
+					  --set nodePorts.turnUdp.enabled=true
 					helm package charts/livekit-sfu -d /tmp/charts
 					chart_version="$(helm show chart charts/livekit-sfu | awk '$1 == "version:" { print $2 }')"
 					if helm show chart oci://ghcr.io/waddle-social/waddle/charts/livekit-sfu --version "${chart_version}" >/dev/null 2>&1; then
@@ -90,7 +98,7 @@ schema.#Project & {
 					  helm push /tmp/charts/livekit-sfu-*.tgz oci://ghcr.io/waddle-social/waddle/charts
 					fi
 				"""#]
-			inputs: ["charts/**"]
+			inputs: ["charts/livekit-sfu/**", "env.cue"]
 		}
 		"gitops-push": schema.#Task & {
 			command: "bash"
@@ -106,7 +114,7 @@ schema.#Project & {
 					  --source="$(git config --get remote.origin.url)" \
 					  --revision="$(git rev-parse --short HEAD)"
 				"""#]
-			inputs: ["gitops/**"]
+			inputs: ["gitops/**", "env.cue"]
 		}
 	}
 }

--- a/infrastructure/waddle.cloud/gitops/waddle-server/livekit-external-secret.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/livekit-external-secret.yaml
@@ -34,7 +34,7 @@ spec:
         LIVEKIT_WS_URL: "wss://sfu.waddle.social"
         LIVEKIT_TURN_HOST: "turn.waddle.social"
         LIVEKIT_TURN_TLS_PORT: "443"
-        LIVEKIT_TURN_UDP_PORT: "3478"
+        LIVEKIT_TURN_UDP_PORT: "30478"
   data:
     # API key + secret for the LiveKit room JWT signer. Stored on
     # the LiveKit SFU side under the `livekit-sfu-api-keys` Secret


### PR DESCRIPTION
## Summary

- Fix the cuenv `waddle-cloud` `default` pipeline so its `helm-push` / `gitops-push` tasks actually fire on `main`, finally publishing the LiveKit SFU Helm chart to `oci://ghcr.io/waddle-social/waddle/charts`.
- Bundle the chart hardening from PR #796 (chart bump to 0.1.4, webhook validations, enriched `helm lint`, TURN UDP port alignment). Replaces #796.

## Empirical evidence the publish has been dead since the cuenv migration

```
$ gh api '/users/waddle-social/packages/container/waddle%2Fcharts%2Flivekit-sfu/versions'
0.1.2  → 2026-04-23   (pre-cuenv-migration)
0.1.1  → 2026-04-23   (pre-cuenv-migration)
(no 0.1.3 published)

$ gh api '/users/waddle-social/packages/container/waddle%2Fgitops-livekit-sfu/versions'
latest → 2026-04-23 23:44:21   (stuck since the initial livekit add commit)

$ gh run view 26572360003 --log | grep -A 2 "Run pipeline"
Changed files: 20
Found 5 projects
[step ended — zero tasks executed]
```

Despite `df6f26c6` modifying `infrastructure/waddle.cloud/charts/livekit-sfu/Chart.yaml`, the publish step ran zero tasks.

## Root cause

Three compounding bugs in `infrastructure/waddle.cloud/env.cue`:

1. **No `derivePaths: true` on the pipeline.** Without it the workflow's `on.push.paths` filter only covers broad project-dir paths and doesn't surface the task `inputs:` at the GitHub Actions trigger layer. The workflow still fired (because `infrastructure/waddle.cloud/**` is broad), but cuenv's downstream task selection had nothing relevant to match against.
2. **Hyphenated task names (`"helm-push"`, `"gitops-push"`) need bracket-access `_t["helm-push"]` in CUE.** That worked for thin mode but silently expands to `jobs: {}` if anyone ever tries `mode: "expanded"`. Use camelCase + dot-access so both modes work.
3. **`inputs:` didn't include `env.cue`.** Verified via `cuenv -L trace ci --dry-run` that cuenv matches inputs **project-relative** (normalizing `infrastructure/waddle.cloud/env.cue` → `env.cue`), so adding `env.cue` to the input list means any edit to the publish task definition itself retriggers republication — which is exactly what this PR needs to roll out.

## Fix

1. `derivePaths: true` on the `default` pipeline so the workflow's `on.push.paths` is auto-derived from the union of task `inputs:`.
2. Rename `helm-push` / `gitops-push` → `helmPush` / `gitopsPush` (camelCase, dot-accessible).
3. Refine `inputs:` to express real upstream deps:
   ```cue
   helmPush:   { inputs: ["charts/livekit-sfu/**", "env.cue"] }
   gitopsPush: { inputs: ["gitops/**",             "env.cue"] }
   ```
4. Regenerate `.github/workflows/waddle-cloud-default.yml` (now triggers on `infrastructure/waddle.cloud/{charts/livekit-sfu/**, env.cue, gitops/**}`).

Both publish tasks remain internally idempotent (`helm push` skipped if version exists; `gitops-push` overwrites `:latest`), so spurious extra firings are harmless.

Local verification via `cuenv -L trace ci --pipeline default --dry-run --path infrastructure/waddle.cloud`:

```
TRACE cuenv_core::affected: Compared changed file against affected pattern,
  file: infrastructure/waddle.cloud/env.cue, normalized: env.cue,
  pattern: "env.cue", matched: true
INFO  cuenv_ci::executor::orchestrator: Running tasks for project,
  tasks: ["helmPush", "gitopsPush"]
```

(If pinned cuenv `0.41.3` in CI handles affected-detection differently than my local `0.43.0` and the publish no-ops post-merge, fall back to `mode: "expanded"` — that was the previous commit on this branch and is well-tested.)

## Also bundled (from PR #796, excluding its inputs approach)

- Bump chart `0.1.3` → `0.1.4`.
- `templates/validations.yaml`: fail when `webhook.enabled=true` but `webhook.urls` is empty or `webhook.apiKey` is unset.
- `env.cue`: enrich the `helm lint` invocation to cover the production values path (webhook URL, TURN TLS, NodePort UDP) so a broken release fails at CI rather than at HelmRelease reconcile.
- `gitops/waddle-server/livekit-external-secret.yaml`: align `LIVEKIT_TURN_UDP_PORT` (`3478` → `30478`) with the SFU chart's `nodePorts.turnUdp.udp` default so waddle-server hands clients a reachable TURN/UDP port.

## Test plan

- [x] Local: `helm lint infrastructure/waddle.cloud/charts/livekit-sfu --set …` exits clean.
- [x] Local: `cuenv sync ci --path infrastructure/waddle.cloud` produces a workflow with derived `on.push.paths` and a single thin job that runs `cuenv ci`.
- [x] Local: cuenv trace confirms `helmPush` + `gitopsPush` selected as affected when `env.cue` changes.
- [ ] Branch CI green.
- [ ] After merge to main, the regenerated `waddle-cloud-default` workflow fires (merge commit touches `env.cue` which matches the new `paths:`). `cuenv ci` selects both publish tasks; `helmPush` packages `livekit-sfu-0.1.4.tgz` and pushes it to `oci://ghcr.io/waddle-social/waddle/charts`; `gitopsPush` updates both `gitops:latest` and `gitops-livekit-sfu:latest`.
- [ ] `flux get sources oci -n flux-system livekit-sfu` → `Ready=True`.
- [ ] `flux get kustomization infra-livekit-sfu -n flux-system` → `Ready=True`.
- [ ] `flux get helmrelease livekit-sfu -n livekit` → install succeeded, revision `0.1.4`.
- [ ] `kubectl -n livekit get pods,svc,httproute,tlsroute` → SFU pod `Running`, NodePort services bound, routes accepted by Cilium Gateway, TURN certificate `Ready`.
- [ ] Real client resolves `wss://sfu.waddle.social` and a 1:1 call connects through the SFU with the corrected TURN UDP port.

## Outstanding concerns surfaced during adversarial review (not blocking this PR)

- Webhook validation: the chart's new `webhook.apiKey is required when webhook.enabled=true` check renders fine because the HelmRelease's `valuesFrom: Secret` merges the secret-derived value before validation runs. Confirm post-merge.
- `infra-livekit-sfu` Flux Kustomization does not currently `dependsOn: infra-cert-manager-issuer`. If reconcile gets stuck on the `turn-waddle-social-tls` Certificate, add the dep.
- `turn.waddle.social` DNS resolves to one A record while the chart advertises both `:443/tls` (Gateway LB) and `:30478/udp` (NodePort). UDP TURN may not work if DNS points at the LB. Track with a real client.

Replaces #796.

🤖 Generated with [Claude Code](https://claude.com/claude-code)