### PR TITLE
fix(infra): pass GITHUB_TOKEN/ACTOR into livekit publish tasks

### DIFF
--- a/infrastructure/waddle.cloud/env.cue
+++ b/infrastructure/waddle.cloud/env.cue
@@ -79,8 +79,14 @@ schema.#Project & {
 	tasks: {
 		helmPush: schema.#Task & {
 			command: "bash"
+			env: {
+				CI_GITHUB_TOKEN: schema.#EnvPassthrough & {name: "GITHUB_TOKEN"}
+				CI_GITHUB_ACTOR: schema.#EnvPassthrough & {name: "GITHUB_ACTOR"}
+			}
 			args: ["-c", #"""
 					set -euo pipefail
+					GITHUB_TOKEN="${CI_GITHUB_TOKEN:?missing GITHUB_TOKEN}"
+					GITHUB_ACTOR="${CI_GITHUB_ACTOR:?missing GITHUB_ACTOR}"
 					echo "${GITHUB_TOKEN}" | helm registry login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin
 					helm lint charts/livekit-sfu \
 					  --set apiKeys.existingSecret=livekit-sfu-api-keys \
@@ -103,8 +109,16 @@ schema.#Project & {
 		}
 		gitopsPush: schema.#Task & {
 			command: "bash"
+			env: {
+				CI_GITHUB_TOKEN: schema.#EnvPassthrough & {name: "GITHUB_TOKEN"}
+				CI_GITHUB_ACTOR: schema.#EnvPassthrough & {name: "GITHUB_ACTOR"}
+			}
 			args: ["-c", #"""
 					set -euo pipefail
+					GITHUB_TOKEN="${CI_GITHUB_TOKEN:?missing GITHUB_TOKEN}"
+					GITHUB_ACTOR="${CI_GITHUB_ACTOR:?missing GITHUB_ACTOR}"
+					echo "${GITHUB_TOKEN}" | helm registry login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin
+
 					flux push artifact oci://ghcr.io/waddle-social/waddle/gitops:latest \
 					  --path=./gitops \
 					  --source="$(git config --get remote.origin.url)" \


### PR DESCRIPTION
## Summary

PR #797's livekit-sfu publish path is dead on arrival: the merge fired the workflow but both `helmPush` and `gitopsPush` failed at the bash subshell:

```
bash: line 2: GITHUB_TOKEN: unbound variable
bash: line 2: GITHUB_ACTOR: unbound variable
► pushing artifact to ghcr.io/waddle-social/waddle/gitops:latest
✗ UNAUTHORIZED: unauthenticated
Task 'helmPush' failed with exit code 1
Task 'gitopsPush' failed with exit code 1
```

(Run [`26578109729`](https://github.com/waddle-social/waddle/actions/runs/26578109729))

## Root cause

cuenv runs tasks hermetically. The workflow's `env:` block sets `GITHUB_TOKEN` / `GITHUB_ACTOR` on the `cuenv ci` step process, but cuenv does **not** propagate those into the per-task bash subshell unless they're declared as `schema.#EnvPassthrough` in the task's `env:` block. The current livekit tasks have no `env:` block at all, so `set -euo pipefail` aborts on the first `${GITHUB_TOKEN}` reference.

Additionally, `gitopsPush` calls `flux push artifact oci://ghcr.io/...` which reads docker auth from `~/.docker/config.json`. The `helm registry login` in `helmPush` writes that file, but the two tasks run in separate hermetic processes — gitopsPush sees no login.

## Fix

Mirror `server/env.cue`'s `publishContainerImage` pattern:

```cue
helmPush: schema.#Task & {
    command: "bash"
    env: {
        CI_GITHUB_TOKEN: schema.#EnvPassthrough & {name: "GITHUB_TOKEN"}
        CI_GITHUB_ACTOR: schema.#EnvPassthrough & {name: "GITHUB_ACTOR"}
    }
    args: ["-c", #"""
        set -euo pipefail
        GITHUB_TOKEN="${CI_GITHUB_TOKEN:?missing GITHUB_TOKEN}"
        GITHUB_ACTOR="${CI_GITHUB_ACTOR:?missing GITHUB_ACTOR}"
        echo "${GITHUB_TOKEN}" | helm registry login ghcr.io ...
        ...
    """#]
}
```

Same env block on `gitopsPush`, plus a `helm registry login` at the top of its script so `flux push artifact` can authenticate.

## Test plan

- [ ] Branch CI green (publish step gated to `main`; branch only runs CodeQL etc.).
- [ ] After merge: `waddle-cloud-default` re-fires (the env.cue change matches its `on.push.paths` filter), `helmPush` publishes `livekit-sfu:0.1.4` to `oci://ghcr.io/waddle-social/waddle/charts`, `gitopsPush` updates both `gitops:latest` and `gitops-livekit-sfu:latest`.
- [ ] Flux reconciles `infra-livekit-sfu` → `HelmRelease livekit-sfu` → SFU pod `Running`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)