### PR TITLE
fix(infra): use oras login in gitopsPush so flux push artifact can auth

### DIFF
--- a/infrastructure/waddle.cloud/env.cue
+++ b/infrastructure/waddle.cloud/env.cue
@@ -117,7 +117,7 @@ schema.#Project & {
 					set -euo pipefail
 					GITHUB_TOKEN="${CI_GITHUB_TOKEN:?missing GITHUB_TOKEN}"
 					GITHUB_ACTOR="${CI_GITHUB_ACTOR:?missing GITHUB_ACTOR}"
-					echo "${GITHUB_TOKEN}" | helm registry login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin
+					echo "${GITHUB_TOKEN}" | oras login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
 
 					flux push artifact oci://ghcr.io/waddle-social/waddle/gitops:latest \
 					  --path=./gitops \


### PR DESCRIPTION
## Summary

PR #798 unblocked `helm registry login` for both publish tasks, but `gitopsPush` still 401s because the wrong tool is doing the login:

```
► pushing artifact to ghcr.io/waddle-social/waddle/gitops:latest
✗ pushing artifact failed: POST https://ghcr.io/v2/waddle-social/waddle/gitops/blobs/uploads/:
  UNAUTHORIZED: unauthenticated: User cannot be authenticated with the token provided.
```

(Run [`26579xxxxxx`](https://github.com/waddle-social/waddle/actions/runs/26579xxxxxx) — `cuenv ci` exit 3.)

## Root cause

`helm registry login` writes credentials to `~/.config/helm/registry/config.json` (helm's own registry config). `flux push artifact` reads `~/.docker/config.json`. Different paths, different formats — flux never sees the helm login.

Server's `publishContainerImage` (`server/env.cue:586`, the only task in the repo that currently runs `flux push artifact` against GHCR) does `oras login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin` first; `oras login` writes to `~/.docker/config.json`, so the subsequent `flux push artifact gitops-waddle-server:latest` finds the creds and succeeds.

## Fix

Replace `helm registry login` with `oras login` in `gitopsPush`. `helmPush` keeps `helm registry login` because `helm push` reads helm's own registry config.

## Outstanding — needs a manual GitHub UI step

`gh api '/orgs/waddle-social/packages/container/waddle%2Fcharts%2Flivekit-sfu'` returns `"repository": null` — the package was created by the old (pre-cuenv) manual workflow and is not currently linked to `waddle-social/waddle`, so the workflow's `GITHUB_TOKEN` gets `403 permission_denied: write_package` on push. **Until that package is linked**, `helmPush` will keep failing even with this PR merged.

At https://github.com/orgs/waddle-social/packages/container/package/waddle%2Fcharts%2Flivekit-sfu → package settings → **Manage Actions access** → add `waddle-social/waddle` with `Write`. (Alternative: delete the package and let CI recreate it auto-linked. Versions 0.1.1 and 0.1.2 are pre-cuenv, never referenced by the in-cluster `HelmRelease` (`0.1.x`), and would be safe to drop.)

For comparison, the packages that DO publish from this repo:

| Package | repository |
|---|---|
| `waddle/charts/livekit-sfu` | **null** ← this one |
| `waddle/gitops` | `waddle-social/waddle` ✓ |
| `waddle` | `waddle-social/waddle` ✓ |
| `waddle/gitops-waddle-server` | `waddle-social/waddle` ✓ |

## Test plan

- [ ] Branch CI green (publish step gated to `main`).
- [ ] Package `charts/livekit-sfu` linked to `waddle-social/waddle` in GHCR UI.
- [ ] After merge: `gitopsPush` pushes both `gitops:latest` and `gitops-livekit-sfu:latest`; `helmPush` pushes `livekit-sfu:0.1.4`.
- [ ] Flux reconciles → SFU pod `Running`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)