### PR TITLE
fix(infra): quote api-key template in livekit-sfu external-secret

### DIFF
--- a/infrastructure/waddle.cloud/gitops/livekit-sfu/external-secret.yaml
+++ b/infrastructure/waddle.cloud/gitops/livekit-sfu/external-secret.yaml
@@ -18,7 +18,7 @@ spec:
           {{ .apiKey }}: {{ .apiSecret | quote }}
         # Exposed separately so the HelmRelease can inject
         # `webhook.api_key` without committing the key name to git.
-        api-key: {{ .apiKey | quote }}
+        api-key: "{{ .apiKey }}"
   data:
     - secretKey: apiKey
       remoteRef:


### PR DESCRIPTION
## Summary

Post-merge of PR #799, `helmPush` and `gitopsPush` both succeed:

- `oci://ghcr.io/waddle-social/waddle/charts/livekit-sfu:0.1.4` published at 13:57:10
- `oci://ghcr.io/waddle-social/waddle/gitops-livekit-sfu:latest` updated at 13:57:17

Flux's `OCIRepository livekit-sfu` is `Ready=True`, but its child `Kustomization infra-livekit-sfu` is `Ready=False`:

```
$ kubectl -n flux-system get kustomization infra-livekit-sfu -o jsonpath='{.status.conditions}'
Ready=False (BuildFailed): kustomize build failed: map[string]interface {}(nil):
  yaml: invalid map key: map[string]interface {}{".apiKey | quote":""}
```

## Root cause

`gitops/livekit-sfu/external-secret.yaml:21` had an unquoted Go-template scalar:

```yaml
api-key: {{ .apiKey | quote }}
```

kustomize parses YAML *before* the ExternalSecret operator's templating step. The unquoted `{{ … }}` looks like a flow mapping; kustomize reads `.apiKey | quote` as a map key with an empty value and bails.

The line above it (`{{ .apiKey }}: {{ .apiSecret | quote }}`) doesn't trip the same parser because it lives inside a `keys.yaml: |` literal block — the `|` makes the body opaque to kustomize.

This file has lived in the repo since the initial livekit-sfu add in April, but Flux never noticed because `gitops-livekit-sfu:latest` hadn't been republished since then. PR #797–799 unblocked the publish path; this is the next downstream failure.

## Fix

Match the working pattern from `gitops/waddle-server/openrouter-external-secret.yaml:20`:

```yaml
api-key: "{{ .apiKey }}"
```

Quote the scalar from the YAML side; drop the redundant `| quote` filter since the outer double quotes already disambiguate the parse. The ExternalSecret operator still substitutes `.apiKey` at runtime.

Verified locally:

```
$ kubectl kustomize infrastructure/waddle.cloud/gitops/livekit-sfu | grep -c kind:
16
$ kubectl kustomize infrastructure/waddle.cloud/gitops/livekit-sfu | grep "api-key:"
        api-key: '{{ .apiKey }}'
```

Templates preserved for ExternalSecret to process at runtime.

## Test plan

- [ ] Branch CI green.
- [ ] After merge: Flux republishes `gitops-livekit-sfu:latest`, `Kustomization infra-livekit-sfu` reconciles `Ready=True`, `HelmRelease livekit-sfu` installs `0.1.4`, SFU pod comes up.
- [ ] Real client connects to `wss://sfu.waddle.social`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)