### PR TITLE
fix(calls): harden LiveKit/XMPP calling stack (webhook secret, ghost reconciliation, token TTL, indicator/listener fixes, infra)

### DIFF
--- a/chat/src/lib/calls/dm-call-activity.ts
+++ b/chat/src/lib/calls/dm-call-activity.ts
@@ -158,23 +158,71 @@ function eventSelfFullJid(envelope: DmCallEventEnvelope, join?: LiveKitJoin): st
 }
 
 /**
+ * Decode a LiveKit join JWT's payload (the middle segment) into a
+ * plain object, or `null` for malformed/undecodable input. Shared by
+ * the expiry check and the video-grant validation so both parse the
+ * token exactly once per concern without duplicating the base64url +
+ * JSON dance.
+ */
+function decodeLiveKitJwtPayload(token: string): Record<string, unknown> | null {
+  const payload = token.split(".")[1];
+  if (!payload) return null;
+  try {
+    const parsed = JSON.parse(decodeBase64UrlUtf8(payload)) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Decode a LiveKit join JWT and return its `exp` claim as a `Date`,
  * or `null` for malformed input. Exported so the MUC resume path
  * (`resumeMucCallActivity`) can reuse the same expiry check the DM
  * resume path uses without re-implementing JWT decoding.
  */
 export function liveKitJoinTokenExpiresAt(token: string): Date | null {
-  const payload = token.split(".")[1];
-  if (!payload) return null;
-  try {
-    const decoded = decodeBase64UrlUtf8(payload);
-    const parsed = JSON.parse(decoded) as { exp?: unknown };
-    const exp = Number(parsed.exp);
-    if (!Number.isFinite(exp) || exp <= 0) return null;
-    return new Date(exp * 1000);
-  } catch {
-    return null;
+  const parsed = decodeLiveKitJwtPayload(token);
+  if (!parsed) return null;
+  const exp = Number(parsed.exp);
+  if (!Number.isFinite(exp) || exp <= 0) return null;
+  return new Date(exp * 1000);
+}
+
+/**
+ * Outcome of validating a LiveKit join token's `video` grant before
+ * we hand it to the SDK. `ok` is the only success; every failure
+ * names the specific defect so the call surface can surface a clear
+ * error instead of the SDK's opaque late rejection.
+ */
+type LiveKitGrantValidation =
+  | { ok: true }
+  | { ok: false; reason: "malformed-token" | "missing-grant" | "join-not-granted" | "missing-room" };
+
+/**
+ * Defensively validate the `video` grant encoded in a LiveKit join
+ * JWT before `Room.connect`. The server mints camelCase grant fields
+ * (`roomJoin`, `room`, `canPublish`, `canSubscribe`,
+ * `canPublishData`); at minimum a usable join token must grant
+ * `roomJoin === true` for a non-empty `room`. Failing fast here turns
+ * a misconfigured / mismatched token into a clear local error rather
+ * than letting the SDK reject the WebSocket upgrade opaquely.
+ *
+ * Pure: no I/O, no SDK dependency, so it's trivially unit-testable
+ * alongside the other token helpers.
+ */
+export function validateLiveKitGrant(token: string): LiveKitGrantValidation {
+  const parsed = decodeLiveKitJwtPayload(token);
+  if (!parsed) return { ok: false, reason: "malformed-token" };
+  const grant = parsed.video;
+  if (!grant || typeof grant !== "object") return { ok: false, reason: "missing-grant" };
+  const video = grant as Record<string, unknown>;
+  if (video.roomJoin !== true) return { ok: false, reason: "join-not-granted" };
+  if (typeof video.room !== "string" || video.room.trim() === "") {
+    return { ok: false, reason: "missing-room" };
   }
+  return { ok: true };
 }
 
 function decodeBase64UrlUtf8(value: string): string {

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -11,6 +11,7 @@ import {
 } from "livekit-client";
 import type { LiveKitJoin } from "./types";
 import { $devicePrefs } from "./device-prefs";
+import { validateLiveKitGrant } from "./dm-call-activity";
 
 /**
  * Identifies a remote media track surfaced to the UI. The `kind`
@@ -105,6 +106,15 @@ export class CallEngine {
 
   async connect(join: LiveKitJoin, opts: { audio: boolean; video: boolean }): Promise<void> {
     if (this.room) throw new Error("CallEngine already connected");
+    // Defensive pre-flight: confirm the JWT actually carries a usable
+    // `video` grant (roomJoin + a room) before the SDK opens its
+    // WebSocket. A mismatched / misconfigured token otherwise fails
+    // deep inside `room.connect` with an opaque rejection; this turns
+    // it into a clear, actionable local error.
+    const grant = validateLiveKitGrant(join.token);
+    if (!grant.ok) {
+      throw new Error(`Invalid LiveKit join token: ${grant.reason}`);
+    }
     const prefs = $devicePrefs.get();
     const room = new Room({
       adaptiveStream: true,

--- a/chat/src/lib/calls/muc-call-live-participants.ts
+++ b/chat/src/lib/calls/muc-call-live-participants.ts
@@ -32,6 +32,70 @@ import { normalizeMucCallRoomJid } from "./muc-call-presence";
 export const $mucCallLiveParticipants = map<Record<string, string[]>>({});
 
 /**
+ * Transient "we are leaving this room's call" marker, keyed by room
+ * JID and carrying our own MUC nick.
+ *
+ * The flicker this guards against: when the local user disconnects,
+ * `clearLiveCallParticipants` drops the LK projection synchronously,
+ * but the server-authoritative Muji presence (`$mucCallParticipants`)
+ * still lists our own nick for ~1 RTT until the MUC rebroadcasts our
+ * `<muji/>` absence. Without this marker the resolved list falls back
+ * to that stale Muji view and the count bounces 0 → N → 0.
+ *
+ * While a room has a leaving marker, the resolved participant list
+ * excludes the marked self-nick so the count decreases monotonically
+ * to 0 (for other participants the marker is a no-op — server Muji
+ * stays authoritative). The marker is consumed the moment the Muji
+ * view catches up (our nick is no longer present), so it never masks
+ * a genuine re-join.
+ *
+ * Shape: `{ "<roomJid>": "<self-nick>" }`.
+ */
+export const $mucCallLeavingRooms = map<Record<string, string>>({});
+
+/**
+ * Mark `roomJid` as locally leaving, excluding `selfNick` from the
+ * resolved participant list until the Muji view drops it. Used by the
+ * call-teardown path so the indicator can't bounce back to the stale
+ * Muji count for one render cycle. No-op without a nick — there's
+ * nothing to suppress.
+ */
+export function markRoomLeavingCall(roomJid: string, selfNick: string | null | undefined): void {
+  const normalized = normalizeMucCallRoomJid(roomJid);
+  if (!normalized || !selfNick) return;
+  $mucCallLeavingRooms.setKey(normalized, selfNick);
+}
+
+/**
+ * Clear `roomJid`'s leaving marker. Idempotent. Called automatically
+ * once the Muji view catches up (see `mucCallRoomLeavingNick`), and on
+ * a fresh (re)join so a stale marker can't suppress the new call.
+ */
+export function clearRoomLeavingCall(roomJid: string): void {
+  const normalized = normalizeMucCallRoomJid(roomJid);
+  if (!normalized) return;
+  const all = { ...$mucCallLeavingRooms.get() };
+  if (!(normalized in all)) return;
+  delete all[normalized];
+  $mucCallLeavingRooms.set(all);
+}
+
+/**
+ * Read the self-nick that should be suppressed for `roomJid` while it
+ * is locally leaving, or `null` when there is no active marker. Pure
+ * read — callers that resolve participant lists use this to drop our
+ * own stale Muji nick.
+ */
+export function mucCallRoomLeavingNick(
+  leavingByRoom: Readonly<Record<string, string>>,
+  roomJid: string,
+): string | null {
+  const normalized = normalizeMucCallRoomJid(roomJid);
+  if (!normalized) return null;
+  return leavingByRoom[normalized] ?? null;
+}
+
+/**
  * Replace the entire participant set for `roomJid` with the supplied
  * identities. Used at LiveKit `Connected` time to seed the initial
  * remote-participant snapshot — including peers that joined before
@@ -50,6 +114,10 @@ export function setLiveCallParticipants(
     clearLiveCallParticipants(normalized);
     return;
   }
+  // A non-empty live snapshot means we are (re)connected to this
+  // room's call, so any pending leave marker is stale — drop it so the
+  // new participants resolve normally.
+  clearRoomLeavingCall(normalized);
   $mucCallLiveParticipants.setKey(normalized, deduped);
 }
 
@@ -106,4 +174,5 @@ export function clearLiveCallParticipants(roomJid: string): void {
  */
 export function clearAllLiveCallParticipants(): void {
   $mucCallLiveParticipants.set({});
+  $mucCallLeavingRooms.set({});
 }

--- a/chat/src/lib/calls/muc-call-presence.ts
+++ b/chat/src/lib/calls/muc-call-presence.ts
@@ -1,5 +1,10 @@
 import { map } from "nanostores";
 import { fullJidIdentityKey } from "@/lib/xmpp/jid";
+import {
+  $mucCallLeavingRooms,
+  clearRoomLeavingCall,
+  mucCallRoomLeavingNick,
+} from "./muc-call-live-participants";
 import type { CallMedia } from "./types";
 
 /**
@@ -109,7 +114,10 @@ export function clearMucCallParticipant(
   });
   if (realJid) return;
   const current = $mucCallParticipants.get()[normalized] ?? [];
-  if (!current.includes(nick)) return;
+  if (!current.includes(nick)) {
+    clearLeavingMarkerWhenMujiCaughtUp(normalized);
+    return;
+  }
   const next = current.filter((n) => n !== nick);
   if (next.length === 0) {
     const all = { ...$mucCallParticipants.get() };
@@ -118,6 +126,7 @@ export function clearMucCallParticipant(
   } else {
     $mucCallParticipants.setKey(normalized, next);
   }
+  clearLeavingMarkerWhenMujiCaughtUp(normalized);
 }
 
 function syncActiveParticipantsForRoom(roomJid: string): void {
@@ -296,6 +305,23 @@ export function applyMucCallPresence(
       includeAggregate: !presence.muc_jid,
     });
   }
+
+  clearLeavingMarkerWhenMujiCaughtUp(roomJid);
+}
+
+/**
+ * Drop the room's transient "leaving" marker once the
+ * server-authoritative Muji view no longer lists the suppressed
+ * self-nick. Keeping a stale marker would wrongly suppress our nick
+ * from a later observer-side Muji broadcast (e.g. a sibling resource
+ * re-joining the call). No-op when no marker is set or the nick is
+ * still present (the suppression is still doing its job).
+ */
+function clearLeavingMarkerWhenMujiCaughtUp(roomJid: string): void {
+  const leavingNick = mucCallRoomLeavingNick($mucCallLeavingRooms.get(), roomJid);
+  if (!leavingNick) return;
+  const stillPresent = ($mucCallParticipants.get()[roomJid] ?? []).includes(leavingNick);
+  if (!stillPresent) clearRoomLeavingCall(roomJid);
 }
 
 /**
@@ -317,6 +343,9 @@ export function clearMucCallParticipants(): void {
   $mucActiveParticipants.set({});
   $mucPreparingParticipants.set({});
   $mucActiveParticipantMedia.set({});
+  // Full call-presence reset — drop any transient leaving markers so a
+  // fresh login doesn't carry stale self-nick suppression.
+  $mucCallLeavingRooms.set({});
   // Drop any pending preparing-echo waiters too — they'd otherwise
   // resolve when the next presence echo arrives after reconnect,
   // which would race the new login's call setup.
@@ -497,6 +526,30 @@ function rejectNoOtherPreparingWaitersForParticipant(roomJid: string, nick: stri
 }
 
 /**
+ * A pending preparation wait that the originator can cancel directly.
+ *
+ * It is a real `Promise<void>` (so `await wait` and `wait.catch(...)`
+ * keep working for callers that don't care about cancellation) carrying
+ * an extra `cancel` method. Calling `cancel` rejects the promise,
+ * clears the backing timer, and removes the map entry immediately —
+ * so an abandoned call attempt (navigate away, rapid join/leave
+ * toggling) releases its listener and timer right away instead of
+ * lingering until the multi-second join timeout fires.
+ */
+type CancellablePreparation = Promise<void> & {
+  cancel: (err?: Error) => void;
+};
+
+function toCancellablePreparation(
+  promise: Promise<void>,
+  cancel: (err?: Error) => void,
+): CancellablePreparation {
+  return Object.assign(promise, { cancel });
+}
+
+const DEFAULT_PREPARATION_CANCEL_ERROR = "Muji preparation wait cancelled";
+
+/**
  * Wait for the MUC to rebroadcast our preparing-presence echo for
  * `nick` in `roomJid`, then resolve. If no echo arrives within
  * `timeoutMs`, reject: XEP-0272 makes the echoed preparing
@@ -505,17 +558,19 @@ function rejectNoOtherPreparingWaitersForParticipant(roomJid: string, nick: stri
  *
  * Caller must register the listener BEFORE emitting the preparing
  * presence to avoid races where the echo arrives before
- * `applyMucCallPresence` has a listener to fire.
+ * `applyMucCallPresence` has a listener to fire. The returned handle's
+ * `cancel` releases the listener + timer immediately when the attempt
+ * is abandoned.
  */
 export function awaitPreparingEcho(
   roomJid: string,
   nick: string,
   timeoutMs: number,
   selfFullJid?: string | null,
-): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const normalized = normalizeMucCallRoomJid(roomJid);
-    const key = prepareEchoListenerKey(normalized, nick, selfFullJid);
+): CancellablePreparation {
+  const normalized = normalizeMucCallRoomJid(roomJid);
+  const key = prepareEchoListenerKey(normalized, nick, selfFullJid);
+  const promise = new Promise<void>((resolve, reject) => {
     // Replacing an existing listener silently is fine — there's
     // only ever one preparing-echo waiter per (room, nick) at a
     // time because beginMucCall serialises through the call store.
@@ -532,6 +587,9 @@ export function awaitPreparingEcho(
     }, timeoutMs);
     prepareEchoListeners.set(key, { resolve, reject, timer });
   });
+  return toCancellablePreparation(promise, (err) => {
+    rejectPrepareEchoWaiter(key, err ?? new Error(DEFAULT_PREPARATION_CANCEL_ERROR));
+  });
 }
 
 export function awaitNoOtherPreparing(
@@ -539,13 +597,13 @@ export function awaitNoOtherPreparing(
   selfNick: string,
   timeoutMs: number,
   selfFullJid?: string | null,
-): Promise<void> {
+): CancellablePreparation {
   const normalized = normalizeMucCallRoomJid(roomJid);
   if (!hasOtherPreparing(normalized, selfNick, selfFullJid)) {
-    return Promise.resolve();
+    return toCancellablePreparation(Promise.resolve(), () => undefined);
   }
-  return new Promise((resolve, reject) => {
-    const key = prepareEchoListenerKey(normalized, selfNick, selfFullJid);
+  const key = prepareEchoListenerKey(normalized, selfNick, selfFullJid);
+  const promise = new Promise<void>((resolve, reject) => {
     const previous = noOtherPreparingListeners.get(key);
     if (previous) {
       clearTimeout(previous.timer);
@@ -566,4 +624,17 @@ export function awaitNoOtherPreparing(
       timer,
     });
   });
+  return toCancellablePreparation(promise, (err) => {
+    rejectNoOtherPreparingWaiter(key, err ?? new Error(DEFAULT_PREPARATION_CANCEL_ERROR));
+  });
+}
+
+/**
+ * Test-only introspection: total number of preparation waiters still
+ * holding a `resolve`/`reject`/`timer` triple. A correctly cancelled or
+ * resolved attempt must leave this at 0 — leaks here are exactly the
+ * dangling-timer / dangling-closure bug class this module guards.
+ */
+export function pendingMucCallPreparationWaiterCountForTests(): number {
+  return prepareEchoListeners.size + noOtherPreparingListeners.size;
 }

--- a/chat/src/lib/calls/muc-call-presence.ts
+++ b/chat/src/lib/calls/muc-call-presence.ts
@@ -320,7 +320,12 @@ export function applyMucCallPresence(
 function clearLeavingMarkerWhenMujiCaughtUp(roomJid: string): void {
   const leavingNick = mucCallRoomLeavingNick($mucCallLeavingRooms.get(), roomJid);
   if (!leavingNick) return;
-  const stillPresent = ($mucCallParticipants.get()[roomJid] ?? []).includes(leavingNick);
+  // `$mucCallParticipants` is keyed by normalized JIDs, so normalize
+  // the lookup too — an unnormalized caller would otherwise read
+  // `undefined` and clear the marker before the Muji view has actually
+  // caught up. Matches every other map lookup in this file.
+  const normalized = normalizeMucCallRoomJid(roomJid);
+  const stillPresent = ($mucCallParticipants.get()[normalized] ?? []).includes(leavingNick);
   if (!stillPresent) clearRoomLeavingCall(roomJid);
 }
 

--- a/chat/src/lib/calls/outbound.ts
+++ b/chat/src/lib/calls/outbound.ts
@@ -11,7 +11,7 @@ export type CallWireSender = {
   send_call_proceed?: (peer_full_jid: string, sid: string) => Promise<unknown>;
   send_call_reject?: (peer_full_jid: string, sid: string) => Promise<unknown>;
   send_call_reject_tie_break?: (peer_full_jid: string, sid: string) => Promise<unknown>;
-  send_call_retract?: (peer_jid: string, sid: string) => Promise<unknown>;
+  send_call_retract?: (peer_bare_jid: string, sid: string) => Promise<unknown>;
   send_call_retract_tie_break?: (peer_full_jid: string, sid: string) => Promise<unknown>;
   send_call_finish?: (peer_full_jid: string, sid: string) => Promise<unknown>;
   send_call_finish_migrated?: (peer_full_jid: string, old_sid: string, new_sid: string) => Promise<unknown>;
@@ -86,9 +86,9 @@ export const outboundCalls = {
     await client.send_call_reject_tie_break(peerFullJid, sid);
   },
 
-  async retract(client: CallWireSender, peerJid: string, sid: string): Promise<void> {
+  async retract(client: CallWireSender, peerBareJid: string, sid: string): Promise<void> {
     if (!client.send_call_retract) throw new WasmCallApiUnavailable("send_call_retract");
-    await client.send_call_retract(peerJid, sid);
+    await client.send_call_retract(peerBareJid, sid);
   },
 
   async retractTieBreak(client: CallWireSender, peerFullJid: string, sid: string): Promise<void> {

--- a/chat/src/lib/calls/use-active-muc-call.ts
+++ b/chat/src/lib/calls/use-active-muc-call.ts
@@ -8,7 +8,11 @@ import {
   mucCallMediaForRoom,
   normalizeMucCallRoomJid,
 } from "./muc-call-presence";
-import { $mucCallLiveParticipants } from "./muc-call-live-participants";
+import {
+  $mucCallLeavingRooms,
+  $mucCallLiveParticipants,
+  mucCallRoomLeavingNick,
+} from "./muc-call-live-participants";
 import {
   $mucCallTerminatePendingSessions,
   pendingMucCallTerminateSession,
@@ -98,6 +102,7 @@ export function useRoomHasActiveCall(
   const callMedia = useStore($mucCallMedia);
   const pendingTerminates = useStore($mucCallTerminatePendingSessions);
   const liveParticipants = useStore($mucCallLiveParticipants);
+  const leavingRooms = useStore($mucCallLeavingRooms);
 
   const normalizedRoomJid = computed<string | null>(() => {
     const normalized = normalizeMucCallRoomJid(roomJid());
@@ -120,6 +125,7 @@ export function useRoomHasActiveCall(
       participants.value,
       participantOwners.value,
       liveParticipants.value,
+      leavingRooms.value,
     ),
   );
 
@@ -191,6 +197,7 @@ export function readRoomHasActiveCall(roomJid: string): {
     $mucCallParticipants.get(),
     $mucCallParticipantOwners.get(),
     liveParticipants,
+    $mucCallLeavingRooms.get(),
   );
   const pendingTerminates = $mucCallTerminatePendingSessions.get();
   const nick = connectionStore.session?.username ?? null;
@@ -245,12 +252,20 @@ function hasUnownedSelfNick(
  * Resolve the nick list for a room, preferring LiveKit's live
  * participant projection when populated (same semantics as
  * `useRoomHasActiveCall`'s composable path).
+ *
+ * When the room carries a transient "leaving" marker (the local user
+ * just disconnected and the LK projection was cleared), our own stale
+ * Muji nick is excluded from the fallback list so the count decreases
+ * monotonically to 0. The marker is consumed once the Muji view drops
+ * our nick on its own — at which point keeping it would needlessly
+ * mask a genuine re-join.
  */
 function resolveRoomParticipantList(
   roomJid: string | null,
   participantsByRoom: Readonly<Record<string, ReadonlyArray<string>>>,
   ownersByRoom: Readonly<Record<string, ReadonlyArray<{ nick: string; realJid?: string }>>>,
   liveParticipantsByRoom: Readonly<Record<string, ReadonlyArray<string>>>,
+  leavingByRoom: Readonly<Record<string, string>> = {},
 ): string[] {
   const room = roomJid ? normalizeMucCallRoomJid(roomJid) : "";
   if (!room) return [];
@@ -258,7 +273,14 @@ function resolveRoomParticipantList(
   if (liveIdentities.length > 0) {
     return identitiesToNicks(liveIdentities, ownersByRoom[room] ?? []);
   }
-  return [...(participantsByRoom[room] ?? [])];
+  const mujiNicks = participantsByRoom[room] ?? [];
+  const leavingNick = mucCallRoomLeavingNick(leavingByRoom, room);
+  // Pure read: when the room is locally leaving and Muji still lists
+  // our own nick, suppress it. Once Muji drops the nick the marker is
+  // a no-op here; it is cleared by `applyMucCallPresence` (the
+  // server-authoritative drop) or by a fresh (re)join.
+  if (!leavingNick) return [...mujiNicks];
+  return mujiNicks.filter((nick) => nick !== leavingNick);
 }
 
 /**

--- a/chat/src/lib/calls/use-call-engine.ts
+++ b/chat/src/lib/calls/use-call-engine.ts
@@ -4,6 +4,7 @@ import { CallEngine, type LocalMediaTrack, type RemoteMediaTrack } from "./engin
 import {
   addLiveCallParticipant,
   clearLiveCallParticipants,
+  markRoomLeavingCall,
   removeLiveCallParticipant,
   setLiveCallParticipants,
 } from "./muc-call-live-participants";
@@ -76,8 +77,15 @@ export function useCallEngine(): {
       // view. Drop the LK snapshot so the room's UI reverts to the
       // Muji-derived (server-bridged) view, which the LK webhook
       // bridge keeps honest within seconds.
-      const roomJid = activeMucRoomJid();
-      if (roomJid) clearLiveCallParticipants(roomJid);
+      const slot = activeMucCallSlot();
+      if (!slot) return;
+      // Suppress our own stale Muji nick for one render cycle: the
+      // server-authoritative `<muji/>` absence broadcast arrives ~1
+      // RTT after LK fires `disconnected`, so without this marker the
+      // resolved participant list would fall back to a Muji view that
+      // still lists us — bouncing the indicator 0 → N → 0.
+      markRoomLeavingCall(slot.roomJid, slot.selfNick);
+      clearLiveCallParticipants(slot.roomJid);
     });
   }
   return { engine: singletonEngine, remoteTracks, localTracks };
@@ -90,8 +98,18 @@ export function useCallEngine(): {
  * leak into the MUC participant store.
  */
 function activeMucRoomJid(): string | null {
+  return activeMucCallSlot()?.roomJid ?? null;
+}
+
+/**
+ * Read the active MUC call's room JID together with our own MUC nick,
+ * or `null` when no MUC call is bound to the slot. The nick lets the
+ * teardown path suppress our own stale Muji presence until the server
+ * broadcasts our `<muji/>` absence.
+ */
+function activeMucCallSlot(): { roomJid: string; selfNick: string | null } | null {
   const state = $callState.get();
   if (state.phase !== "active" && state.phase !== "muc-pending") return null;
   if (state.kind !== "muc") return null;
-  return state.peer;
+  return { roomJid: state.peer, selfNick: state.selfNick ?? null };
 }

--- a/chat/tests/dm-call-activity.test.ts
+++ b/chat/tests/dm-call-activity.test.ts
@@ -8,6 +8,7 @@ import {
   dmCallResumeBlockReason,
   pruneExpiredDmCallActivities,
   readDmCallActivity,
+  validateLiveKitGrant,
 } from "../src/lib/calls/dm-call-activity";
 import { clearAllDmCallJoinCacheForTests } from "../src/lib/calls/dm-call-join-cache";
 import type { CallEvent } from "../src/lib/calls/types";
@@ -865,5 +866,69 @@ describe("DM call activity", () => {
     clearDmCallActivity(bob, "call-5");
 
     expect(readDmCallActivity(bob, now)).toBeNull();
+  });
+});
+
+describe("validateLiveKitGrant (defensive pre-connect check)", () => {
+  const ROOM = "design@muc.waddle.test";
+
+  function grantToken(video: unknown): string {
+    return jwtWithPayload({ exp: 4_102_444_800, video });
+  }
+
+  test("accepts a server-minted camelCase grant with roomJoin + room", () => {
+    const token = grantToken({
+      roomJoin: true,
+      room: ROOM,
+      canPublish: true,
+      canSubscribe: true,
+      canPublishData: true,
+    });
+    expect(validateLiveKitGrant(token)).toEqual({ ok: true });
+  });
+
+  test("accepts a join-only grant (publish/subscribe flags are not required)", () => {
+    expect(validateLiveKitGrant(grantToken({ roomJoin: true, room: ROOM }))).toEqual({ ok: true });
+  });
+
+  test("rejects a token whose payload segment is not decodable", () => {
+    expect(validateLiveKitGrant("not-a-jwt")).toEqual({ ok: false, reason: "malformed-token" });
+    expect(validateLiveKitGrant("")).toEqual({ ok: false, reason: "malformed-token" });
+  });
+
+  test("rejects a token that carries no video grant", () => {
+    expect(validateLiveKitGrant(jwtWithPayload({ exp: 4_102_444_800 }))).toEqual({
+      ok: false,
+      reason: "missing-grant",
+    });
+    expect(validateLiveKitGrant(grantToken(null))).toEqual({ ok: false, reason: "missing-grant" });
+  });
+
+  test("rejects a grant that does not actually grant roomJoin", () => {
+    expect(validateLiveKitGrant(grantToken({ room: ROOM }))).toEqual({
+      ok: false,
+      reason: "join-not-granted",
+    });
+    expect(validateLiveKitGrant(grantToken({ roomJoin: false, room: ROOM }))).toEqual({
+      ok: false,
+      reason: "join-not-granted",
+    });
+    // A truthy-but-not-true value (e.g. a stringified flag) must not
+    // sneak past — LiveKit grants are strict booleans.
+    expect(validateLiveKitGrant(grantToken({ roomJoin: "true", room: ROOM }))).toEqual({
+      ok: false,
+      reason: "join-not-granted",
+    });
+  });
+
+  test("rejects a grant with a missing or empty room", () => {
+    expect(validateLiveKitGrant(grantToken({ roomJoin: true }))).toEqual({
+      ok: false,
+      reason: "missing-room",
+    });
+    expect(validateLiveKitGrant(grantToken({ roomJoin: true, room: "   " }))).toEqual({
+      ok: false,
+      reason: "missing-room",
+    });
   });
 });

--- a/chat/tests/muc-call-presence.test.ts
+++ b/chat/tests/muc-call-presence.test.ts
@@ -4,10 +4,12 @@ import {
   applyMucCallPresence,
   awaitNoOtherPreparing,
   awaitPreparingEcho,
+  cancelMucCallPreparationWaiters,
   clearMucCallParticipant,
   clearMucCallParticipants,
   mucCallParticipantCounts,
   mucCallParticipantCount,
+  pendingMucCallPreparationWaiterCountForTests,
 } from "../src/lib/calls/muc-call-presence";
 
 afterEach(() => {
@@ -610,5 +612,105 @@ describe("awaitNoOtherPreparing", () => {
 
     await wait;
     expect(resolved).toBe(true);
+  });
+});
+
+describe("preparation waiter lifecycle (no dangling listeners/timers)", () => {
+  test("a resolved echo waiter leaves no live listener", async () => {
+    expect(pendingMucCallPreparationWaiterCountForTests()).toBe(0);
+    const wait = awaitPreparingEcho("room@muc.test", "alice", 5000);
+    expect(pendingMucCallPreparationWaiterCountForTests()).toBe(1);
+    applyMucCallPresence({
+      from: "room@muc.test/alice",
+      presence_type: "available",
+      muji: preparingMuji,
+    });
+    await wait;
+    expect(pendingMucCallPreparationWaiterCountForTests()).toBe(0);
+  });
+
+  test("a timed-out echo waiter leaves no live listener", async () => {
+    const wait = awaitPreparingEcho("room@muc.test", "alice", 20);
+    expect(pendingMucCallPreparationWaiterCountForTests()).toBe(1);
+    await expect(wait).rejects.toThrow("Timed out");
+    expect(pendingMucCallPreparationWaiterCountForTests()).toBe(0);
+  });
+
+  test("cancel() on an abandoned echo waiter rejects and releases it immediately", async () => {
+    const wait = awaitPreparingEcho("room@muc.test", "alice", 60_000);
+    expect(pendingMucCallPreparationWaiterCountForTests()).toBe(1);
+    const settled = wait.then(() => "resolved" as const).catch((err: Error) => err);
+    wait.cancel();
+    const result = await settled;
+    expect(result).toBeInstanceOf(Error);
+    // The map entry AND its 60s timer are gone the instant we cancel —
+    // not parked until the (now-cancelled) timeout would have fired.
+    expect(pendingMucCallPreparationWaiterCountForTests()).toBe(0);
+  });
+
+  test("cancel() on an abandoned no-other-preparing waiter rejects and releases it immediately", async () => {
+    // A real OTHER preparing participant so the waiter actually parks.
+    applyMucCallPresence({
+      from: "room@muc.test/bob",
+      presence_type: "available",
+      muc_jid: "bob@waddle.test/web",
+      muji: preparingMuji,
+    });
+    const wait = awaitNoOtherPreparing(
+      "room@muc.test",
+      "alice",
+      60_000,
+      "alice@waddle.test/web",
+    );
+    expect(pendingMucCallPreparationWaiterCountForTests()).toBe(1);
+    const settled = wait.then(() => "resolved" as const).catch((err: Error) => err);
+    wait.cancel(new Error("attempt abandoned"));
+    const result = await settled;
+    expect(result).toBeInstanceOf(Error);
+    expect((result as Error).message).toContain("attempt abandoned");
+    expect(pendingMucCallPreparationWaiterCountForTests()).toBe(0);
+  });
+
+  test("cancel() is a harmless no-op for an already-resolved no-other-preparing fast path", async () => {
+    // No other preparing participants → resolves synchronously with no
+    // registered listener. cancel() must not throw or leave state.
+    const wait = awaitNoOtherPreparing("room@muc.test", "alice", 5000);
+    await wait;
+    expect(() => wait.cancel()).not.toThrow();
+    expect(pendingMucCallPreparationWaiterCountForTests()).toBe(0);
+  });
+
+  test("cancelMucCallPreparationWaiters releases both waiter kinds for the attempt", async () => {
+    applyMucCallPresence({
+      from: "room@muc.test/bob",
+      presence_type: "available",
+      muc_jid: "bob@waddle.test/web",
+      muji: preparingMuji,
+    });
+    const echo = awaitPreparingEcho("room@muc.test", "alice", 60_000, "alice@waddle.test/web");
+    const noOther = awaitNoOtherPreparing("room@muc.test", "alice", 60_000, "alice@waddle.test/web");
+    const echoSettled = echo.then(() => "resolved" as const).catch((err: Error) => err);
+    const noOtherSettled = noOther.then(() => "resolved" as const).catch((err: Error) => err);
+    expect(pendingMucCallPreparationWaiterCountForTests()).toBe(2);
+
+    cancelMucCallPreparationWaiters("room@muc.test", "alice", new Error("call setup cancelled"));
+
+    expect(await echoSettled).toBeInstanceOf(Error);
+    expect(await noOtherSettled).toBeInstanceOf(Error);
+    expect(pendingMucCallPreparationWaiterCountForTests()).toBe(0);
+  });
+
+  test("rapid re-registration of the same attempt does not accumulate listeners", async () => {
+    const first = awaitPreparingEcho("room@muc.test", "alice", 60_000, "alice@waddle.test/web");
+    const firstSettled = first.then(() => "resolved" as const).catch((err: Error) => err);
+    const second = awaitPreparingEcho("room@muc.test", "alice", 60_000, "alice@waddle.test/web");
+    const secondSettled = second.then(() => "resolved" as const).catch((err: Error) => err);
+    // The second registration replaced the first — exactly one live waiter.
+    expect(pendingMucCallPreparationWaiterCountForTests()).toBe(1);
+    expect(await firstSettled).toBeInstanceOf(Error);
+
+    second.cancel();
+    expect(await secondSettled).toBeInstanceOf(Error);
+    expect(pendingMucCallPreparationWaiterCountForTests()).toBe(0);
   });
 });

--- a/chat/tests/use-active-muc-call.test.ts
+++ b/chat/tests/use-active-muc-call.test.ts
@@ -8,7 +8,13 @@ import {
 } from "../src/lib/calls/muc-call-presence";
 import { connectionStore } from "../src/lib/connection-store";
 import { readActiveMucCall, readRoomHasActiveCall } from "../src/lib/calls/use-active-muc-call";
-import { setLiveCallParticipants, clearAllLiveCallParticipants } from "../src/lib/calls/muc-call-live-participants";
+import {
+  $mucCallLeavingRooms,
+  clearAllLiveCallParticipants,
+  clearRoomLeavingCall,
+  markRoomLeavingCall,
+  setLiveCallParticipants,
+} from "../src/lib/calls/muc-call-live-participants";
 import {
   clearAllMucCallSessionCacheForTests,
   markMucCallSessionTerminatePending,
@@ -409,5 +415,152 @@ describe("readRoomHasActiveCall selector", () => {
       participantCount: 1,
       selfInCall: true,
     });
+  });
+});
+
+describe("local-leave ghost-count suppression", () => {
+  beforeEach(() => {
+    $callState.set({ phase: "idle" });
+    clearMucCallParticipants();
+    clearAllLiveCallParticipants();
+    clearAllMucCallSessionCacheForTests();
+    setSession("alice");
+    connectionStore.client = { fullJid: "alice@waddle.test/web" } as unknown as typeof connectionStore.client;
+  });
+
+  afterEach(() => {
+    $callState.set({ phase: "idle" });
+    clearMucCallParticipants();
+    clearAllLiveCallParticipants();
+    clearAllMucCallSessionCacheForTests();
+    setSession(null);
+  });
+
+  test("count decreases monotonically to 0 on local disconnect with no transient bounce", () => {
+    // In-call: LiveKit projects alice (us) + bob.
+    setLiveCallParticipants(ROOM, ["alice@waddle.test/web", "bob@waddle.test/web"]);
+    $mucCallParticipantOwners.set({
+      [ROOM]: [
+        { nick: "alice", realJid: "alice@waddle.test/web" },
+        { nick: "bob", realJid: "bob@waddle.test/web" },
+      ],
+    });
+    // Server-authoritative Muji still lists everyone, including us.
+    $mucCallParticipants.set({ [ROOM]: ["alice", "bob"] });
+    expect(readRoomHasActiveCall(ROOM).participantCount).toBe(2);
+
+    // Local disconnect: mark leaving (carrying our nick), then drop
+    // the LK snapshot — exactly the `disconnected` engine-event order.
+    markRoomLeavingCall(ROOM, "alice");
+    clearAllLiveCallParticipants(); // wipes LK projection AND markers...
+    // ...so re-establish the marker the way the engine handler does:
+    // clearLiveCallParticipants (single room) preserves the marker.
+    markRoomLeavingCall(ROOM, "alice");
+
+    // The LK view is gone and Muji STILL lists us, but the marker must
+    // suppress our own stale nick — so the count drops straight to 1
+    // (bob only), never bouncing back to 2.
+    expect(readRoomHasActiveCall(ROOM).participantCount).toBe(1);
+    expect(readRoomHasActiveCall(ROOM).selfInCall).toBe(false);
+
+    // When the call had no other participants, the count must hit 0.
+    $mucCallParticipants.set({ [ROOM]: ["alice"] });
+    markRoomLeavingCall(ROOM, "alice");
+    expect(readRoomHasActiveCall(ROOM).participantCount).toBe(0);
+    expect(readRoomHasActiveCall(ROOM).hasActiveCall).toBe(false);
+  });
+
+  test("solo leaver: count is 1 then 0, never 0 → 1 → 0", () => {
+    // Sole occupant in the call.
+    setLiveCallParticipants(ROOM, ["alice@waddle.test/web"]);
+    $mucCallParticipants.set({ [ROOM]: ["alice"] });
+    $mucCallParticipantOwners.set({
+      [ROOM]: [{ nick: "alice", realJid: "alice@waddle.test/web" }],
+    });
+    const counts: number[] = [];
+    counts.push(readRoomHasActiveCall(ROOM).participantCount); // 1
+
+    // Local disconnect order: mark leaving, drop LK snapshot.
+    markRoomLeavingCall(ROOM, "alice");
+    setLiveCallParticipants(ROOM, []); // engine clears the room's LK set
+    // setLiveCallParticipants([]) routes through clearLiveCallParticipants,
+    // which preserves the marker; re-assert to model the engine handler
+    // (which marks then clears).
+    markRoomLeavingCall(ROOM, "alice");
+    counts.push(readRoomHasActiveCall(ROOM).participantCount); // 0 (suppressed)
+
+    // Muji catches up — our absence is broadcast.
+    applyMucCallPresence({
+      from: `${ROOM}/alice`,
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/web",
+    });
+    counts.push(readRoomHasActiveCall(ROOM).participantCount); // 0
+
+    expect(counts).toEqual([1, 0, 0]);
+  });
+
+  test("Muji presence catch-up clears the leaving marker so a later re-join is not masked", () => {
+    // Drive the participant state through the real presence path so
+    // the active-participant aggregation underlying $mucCallParticipants
+    // stays consistent with what applyMucCallPresence later clears.
+    applyMucCallPresence({
+      from: `${ROOM}/alice`,
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/web",
+      muji: { preparing: false, active: true },
+    });
+    markRoomLeavingCall(ROOM, "alice");
+    expect($mucCallLeavingRooms.get()[ROOM]).toBe("alice");
+
+    // Our own Muji absence arrives — applyMucCallPresence must consume
+    // the marker once the server view no longer lists us.
+    applyMucCallPresence({
+      from: `${ROOM}/alice`,
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/web",
+    });
+    expect($mucCallLeavingRooms.get()[ROOM]).toBeUndefined();
+
+    // A subsequent observer-side Muji broadcast (e.g. a sibling
+    // resource re-joins) must NOT be suppressed by a stale marker.
+    applyMucCallPresence({
+      from: `${ROOM}/alice`,
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/mobile",
+      muji: { preparing: false, active: true },
+    });
+    expect(readRoomHasActiveCall(ROOM).participantCount).toBe(1);
+    expect(readRoomHasActiveCall(ROOM).selfInCall).toBe(true);
+  });
+
+  test("the marker only suppresses our OWN nick, leaving other participants authoritative", () => {
+    $mucCallParticipants.set({ [ROOM]: ["alice", "bob", "carol"] });
+    markRoomLeavingCall(ROOM, "alice");
+    const result = readRoomHasActiveCall(ROOM);
+    expect(result.participantCount).toBe(2); // bob + carol
+    expect(result.selfInCall).toBe(false);
+  });
+
+  test("a fresh (re)join via setLiveCallParticipants drops a stale leaving marker", () => {
+    $mucCallParticipants.set({ [ROOM]: ["alice"] });
+    markRoomLeavingCall(ROOM, "alice");
+    expect($mucCallLeavingRooms.get()[ROOM]).toBe("alice");
+
+    // Reconnecting seeds a non-empty LK snapshot — the marker is stale.
+    setLiveCallParticipants(ROOM, ["alice@waddle.test/web"]);
+    expect($mucCallLeavingRooms.get()[ROOM]).toBeUndefined();
+    expect(readRoomHasActiveCall(ROOM).participantCount).toBe(1);
+  });
+
+  test("clearRoomLeavingCall is idempotent and scoped to one room", () => {
+    markRoomLeavingCall(ROOM, "alice");
+    markRoomLeavingCall("other@muc.waddle.test", "alice");
+    clearRoomLeavingCall(ROOM);
+    expect($mucCallLeavingRooms.get()[ROOM]).toBeUndefined();
+    expect($mucCallLeavingRooms.get()["other@muc.waddle.test"]).toBe("alice");
+    // Second clear is a no-op.
+    clearRoomLeavingCall(ROOM);
+    expect($mucCallLeavingRooms.get()["other@muc.waddle.test"]).toBe("alice");
   });
 });

--- a/infrastructure/waddle.cloud/charts/livekit-sfu/templates/deployment.yaml
+++ b/infrastructure/waddle.cloud/charts/livekit-sfu/templates/deployment.yaml
@@ -22,6 +22,19 @@ spec:
         {{- if and (not .Values.apiKeys.existingSecret) (gt (len .Values.apiKeys.values) 0) }}
         checksum/api-keys: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
+        # NOTE: there is intentionally NO checksum annotation for the
+        # cert-manager-issued TURN cert Secret (`turn.secretName`).
+        # Hashing it would force a pod restart on every cert renewal,
+        # and since this is a single-replica SFU (see validations.yaml)
+        # a restart drops every active call. The cert is mounted as a
+        # projected Secret volume, so kubelet syncs the renewed
+        # material into the pod within its sync period (~60s by default,
+        # bounded by `--sync-frequency`). LiveKit reloads the TURN/TLS
+        # certificate from disk, so calls keep running across a renewal
+        # without a restart. The ~60s propagation lag is acceptable
+        # because cert-manager renews well before expiry (default 2/3 of
+        # lifetime). If a future multi-replica setup makes restarts
+        # non-disruptive, re-add a `checksum/turn-cert` here.
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/infrastructure/waddle.cloud/charts/livekit-sfu/templates/validations.yaml
+++ b/infrastructure/waddle.cloud/charts/livekit-sfu/templates/validations.yaml
@@ -6,6 +6,21 @@
 {{- fail (printf "apiKeys.values.%s must be at least 32 characters" $apiKey) -}}
 {{- end -}}
 {{- end -}}
+{{- /*
+  Single-replica is intentional but has NO high availability: there is
+  exactly one SFU pod, so a node drain, kernel/node upgrade, helm
+  rollout, or pod eviction drops every active call (media has no second
+  replica to fail over to, and WebRTC sessions are stateful in-process).
+  Operational guidance:
+    - Schedule node maintenance / upgrades in announced maintenance
+      windows when call volume is lowest.
+    - Cordon + wait for calls to drain rather than hard-draining;
+      `terminationGracePeriodSeconds` (values.yaml, default 18000s = 5h)
+      lets in-flight calls finish before the pod is killed.
+    - Going multi-replica requires a LiveKit setup with Redis-backed
+      room distribution and node selection — not just bumping
+      `replicaCount`; hence this hard guard.
+*/ -}}
 {{- if ne (int .Values.replicaCount) 1 -}}
 {{- fail "livekit-sfu is intentionally single-node for now; replicaCount must be 1" -}}
 {{- end -}}

--- a/infrastructure/waddle.cloud/charts/livekit-sfu/values.yaml
+++ b/infrastructure/waddle.cloud/charts/livekit-sfu/values.yaml
@@ -105,7 +105,21 @@ tmpDir:
   mountPath: /tmp
   sizeLimit: 64Mi
 
-resources: {}
+# Default resource requests/limits. An empty `resources: {}` lets the
+# pod run unbounded and means a single misbehaving SFU can starve the
+# node or get OOM-killed without a guaranteed floor — production must
+# not rely on the Flux HelmRelease override to supply these. These
+# defaults match `gitops/livekit-sfu/helmrelease.yaml`; tune per node
+# size. CPU limit is set well above the request because media muxing is
+# bursty and CPU throttling degrades call quality more than it protects
+# the node.
+resources:
+  requests:
+    cpu: 500m
+    memory: 512Mi
+  limits:
+    cpu: "2"
+    memory: 2Gi
 
 nodeSelector: {}
 tolerations: []

--- a/infrastructure/waddle.cloud/gitops/livekit-sfu/external-secret.yaml
+++ b/infrastructure/waddle.cloud/gitops/livekit-sfu/external-secret.yaml
@@ -14,11 +14,25 @@ spec:
     template:
       engineVersion: v2
       data:
+        # LiveKit's `keys:` map. It MUST contain every API key/secret
+        # pair LiveKit signs or verifies with, including the webhook
+        # signer. Two distinct pairs are published so that a leak of the
+        # room-JWT signing secret (`api-secret`, handed to clients via
+        # the waddle-server join-token path) cannot also forge inbound
+        # webhook deliveries:
+        #   - `api-key`/`api-secret`     → room join-token JWTs
+        #   - `webhook-key`/`webhook-secret` → webhook signing only
+        # `webhook.api_key` (injected by the HelmRelease from the
+        # `webhook-key` field below) selects which pair LiveKit signs
+        # webhook deliveries with; the waddle-server verifier must read
+        # the matching `webhook-secret` (see livekit-external-secret.yaml).
         keys.yaml: |
           {{ .apiKey }}: {{ .apiSecret | quote }}
+          {{ .webhookKey }}: {{ .webhookSecret | quote }}
         # Exposed separately so the HelmRelease can inject
-        # `webhook.api_key` without committing the key name to git.
-        api-key: "{{ .apiKey }}"
+        # `webhook.api_key` (the webhook signer key NAME) without
+        # committing the key name to git.
+        webhook-key: "{{ .webhookKey }}"
   data:
     - secretKey: apiKey
       remoteRef:
@@ -28,3 +42,15 @@ spec:
       remoteRef:
         key: livekit-sfu
         property: api-secret
+    # Dedicated webhook signer pair. `webhook-key` is the key NAME
+    # LiveKit uses as the JWT `iss`/`api_key` for webhook deliveries;
+    # `webhook-secret` is its HMAC-SHA256 signing secret, distinct from
+    # `api-secret` so the two blast radii are isolated.
+    - secretKey: webhookKey
+      remoteRef:
+        key: livekit-sfu
+        property: webhook-key
+    - secretKey: webhookSecret
+      remoteRef:
+        key: livekit-sfu
+        property: webhook-secret

--- a/infrastructure/waddle.cloud/gitops/livekit-sfu/helmrelease.yaml
+++ b/infrastructure/waddle.cloud/gitops/livekit-sfu/helmrelease.yaml
@@ -17,9 +17,14 @@ spec:
         namespace: livekit
       interval: 12h
   valuesFrom:
+    # Inject the dedicated webhook signer key NAME so LiveKit signs
+    # webhook deliveries with the `webhook-key`/`webhook-secret` pair
+    # (not the room-JWT `api-key`/`api-secret` pair). The matching
+    # `webhook-secret` is what waddle-server verifies with, so a leaked
+    # room-JWT secret cannot forge inbound webhooks.
     - kind: Secret
       name: livekit-sfu-api-keys
-      valuesKey: api-key
+      valuesKey: webhook-key
       targetPath: webhook.apiKey
       optional: false
   values:

--- a/infrastructure/waddle.cloud/gitops/livekit-sfu/kustomization.yaml
+++ b/infrastructure/waddle.cloud/gitops/livekit-sfu/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - networkpolicy.yaml
   - turn-certificate.yaml
   - external-secret.yaml
   - helmrepository.yaml

--- a/infrastructure/waddle.cloud/gitops/livekit-sfu/networkpolicy.yaml
+++ b/infrastructure/waddle.cloud/gitops/livekit-sfu/networkpolicy.yaml
@@ -1,0 +1,115 @@
+# Default-deny + targeted-allow isolation for the LiveKit SFU pod.
+#
+# This is a CiliumNetworkPolicy (not a vanilla Kubernetes NetworkPolicy)
+# on purpose: this cluster runs Cilium with the Gateway API enabled
+# (`gatewayAPI.enabled=true`, `gatewayAPI.hostNetwork.enabled=true`).
+# Cilium assigns gateway/ingress-proxy traffic the reserved `ingress`
+# identity and host-sourced traffic the `host`/`remote-node` identities;
+# a plain NetworkPolicy `namespaceSelector` CANNOT match those reserved
+# identities, so it would silently break signaling. `fromEntities` /
+# `toEntities` is the only correct way to express these allows here.
+#
+# An endpoint enters default-deny for a direction as soon as ANY policy
+# selecting it has that direction's section, so the single
+# `ingress:`/`egress:` block below makes the SFU pod default-deny on both
+# directions and then re-opens only what the SFU legitimately needs.
+#
+# IMPORTANT — NodePort / host-level traffic is NOT gated here:
+#   The RTC media (30881/TCP, 30882/UDP) and TURN/UDP (30478/UDP) paths
+#   are exposed as NodePort Services and are internet-facing by design
+#   (WebRTC/ICE/TURN must reach arbitrary client IPs). NodePort packets
+#   are DNAT'd by the host before reaching the pod, so they arrive with
+#   `host`/`remote-node` identity rather than `world`, and Cilium does
+#   not enforce pod policy on the host-network ingestion of NodePort
+#   traffic. NetworkPolicy therefore cannot meaningfully restrict who
+#   reaches those ports — that surface must be defended at the
+#   node/firewall/cloud-LB layer, not here. The ingress allow for
+#   `host`/`remote-node` below keeps that data plane working; it does
+#   not (and cannot) narrow it.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: livekit-sfu
+  namespace: livekit
+spec:
+  # Must match the SFU pod's selector labels (chart `_helpers.tpl`
+  # `livekit-sfu.selectorLabels`; release name is `livekit-sfu`).
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: livekit-sfu
+      app.kubernetes.io/instance: livekit-sfu
+  ingress:
+    # Signaling: the Cilium gateway proxy fronts `sfu.waddle.social`
+    # and forwards to `livekit-sfu:7880`. Gateway traffic carries the
+    # reserved `ingress` identity; with `gatewayAPI.hostNetwork.enabled`
+    # the Envoy proxy runs host-network, so allow `host`/`remote-node`
+    # too. This is the one path NetworkPolicy actually constrains.
+    - fromEntities:
+        - ingress
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "7880"
+              protocol: TCP
+    # RTC + TURN media data plane (NodePort, internet-facing — see the
+    # header note: this allow keeps host-DNAT'd NodePort packets flowing
+    # to the pod; it is not a meaningful access restriction).
+    - fromEntities:
+        - host
+        - remote-node
+        - world
+      toPorts:
+        - ports:
+            - port: "30881"
+              protocol: TCP
+            - port: "30882"
+              protocol: UDP
+            - port: "30478"
+              protocol: UDP
+  egress:
+    # DNS resolution (kube-dns / CoreDNS in kube-system). Needed to
+    # resolve the webhook host (`xmpp.waddle.social`) and ICE/TURN peers.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    # Outbound to the public internet on 443/TCP:
+    #   - LiveKit posts SFU-authoritative MUC-call cleanup webhooks to
+    #     `https://xmpp.waddle.social/api/v1/livekit/webhook` (a public
+    #     hostname that routes back in through the gateway's external IP,
+    #     i.e. `world`, not an in-cluster service).
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    # WebRTC / TURN media egress to participants. The SFU relays RTP and
+    # serves TURN relays to arbitrary client IPs/ports on the internet,
+    # so the media egress target is `world`. Scoped to the relay UDP
+    # range (`livekit.turn.relay_range_start..relay_range_end`, default
+    # 30000-40000) plus the RTC media ports; no TCP egress is opened
+    # beyond 443 above.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "30000"
+              endPort: 40000
+              protocol: UDP
+            - port: "30882"
+              protocol: UDP
+            - port: "30881"
+              protocol: TCP
+    # Signaling responses back to the gateway proxy / host data path.
+    - toEntities:
+        - ingress
+        - host
+        - remote-node

--- a/infrastructure/waddle.cloud/gitops/waddle-server/livekit-external-secret.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/livekit-external-secret.yaml
@@ -49,13 +49,17 @@ spec:
         key: livekit-sfu
         property: api-secret
     # LiveKit webhook JWT verifier (`waddle-sfu::SfuConfig::from_env`).
-    # Mirrors the API secret so LiveKit's signed deliveries validate
-    # without a separate 1Password field; override with a dedicated
-    # secret if webhook signing is rotated independently.
+    # Sourced from a dedicated `webhook-secret` property — NOT the room
+    # JWT `api-secret` — so a leaked join-token secret cannot also forge
+    # inbound webhook deliveries. This MUST match the secret LiveKit
+    # signs webhooks with: the SFU's `livekit-sfu-api-keys` ExternalSecret
+    # puts `webhook-key`/`webhook-secret` into LiveKit's `keys.yaml`, and
+    # the HelmRelease points `webhook.api_key` at `webhook-key`, so
+    # LiveKit signs with this exact `webhook-secret`.
     - secretKey: LIVEKIT_WEBHOOK_SECRET
       remoteRef:
         key: livekit-sfu
-        property: api-secret
+        property: webhook-secret
     # HMAC-SHA1 shared secret for coturn's TURN REST credential
     # mechanism (XEP-0215 entries are minted from this).
     - secretKey: LIVEKIT_TURN_SHARED_SECRET

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -359,14 +359,24 @@ async fn create_websocket_state(
     // showing the user as "in call" until the SFU notices on its
     // own.
     let mut sfu_service: Option<std::sync::Arc<dyn waddle_sfu::SfuService>> = None;
+    // The async reconciliation view of the same concrete SFU, captured
+    // here so a background task can poll LiveKit for ghosts once
+    // `websocket_state` exists (see `spawn_reconciliation_task` below).
+    let mut sfu_reconciler: Option<std::sync::Arc<dyn waddle_sfu::SfuReconciler>> = None;
     match waddle_sfu::SfuConfig::from_env() {
         Ok(Some(sfu_config)) => {
             let turn_tls_port = sfu_config.turn_tls_port;
             let turn_udp_port = sfu_config.turn_udp_port;
             match waddle_sfu::LiveKitSfu::new(sfu_config) {
                 Ok(sfu_impl) => {
-                    let sfu: std::sync::Arc<dyn waddle_sfu::SfuService> =
-                        std::sync::Arc::new(sfu_impl);
+                    // Build the concrete SFU once, then hand out two
+                    // trait-object views of it: the sync `SfuService`
+                    // the XMPP handlers + WebSocket layer consume, and
+                    // the async `SfuReconciler` the webhook route's
+                    // background reconciliation task drives.
+                    let sfu_concrete = std::sync::Arc::new(sfu_impl);
+                    let sfu: std::sync::Arc<dyn waddle_sfu::SfuService> = sfu_concrete.clone();
+                    let reconciler: std::sync::Arc<dyn waddle_sfu::SfuReconciler> = sfu_concrete;
                     waddle_xmpp::protocol::handlers::register_call_handlers(
                         &mut stanza_dispatcher,
                         Arc::clone(&sfu),
@@ -374,6 +384,7 @@ async fn create_websocket_state(
                         turn_udp_port,
                     );
                     sfu_service = Some(sfu);
+                    sfu_reconciler = Some(reconciler);
                     tracing::info!(
                         "LiveKit SFU configured; XEP-0166 Jingle + XEP-0215 extdisco handlers registered"
                     );
@@ -573,6 +584,17 @@ async fn create_websocket_state(
     deferred_extension_host_tools.set(Arc::new(extension_host_adapter::ExtensionHostAdapter::new(
         Arc::clone(&websocket_state),
     )));
+    // Start the SFU ghost-reconciliation backstop: periodically ask
+    // LiveKit who is actually connected and sweep registry entries (and
+    // their MUC Muji presence) left behind by a lost
+    // `participant_left`/`room_finished` webhook delivery. No-op when
+    // A/V calling is unconfigured (`sfu_reconciler` is `None`).
+    if let Some(reconciler) = sfu_reconciler {
+        routes::livekit_webhook::spawn_reconciliation_task(
+            Arc::clone(&websocket_state),
+            reconciler,
+        );
+    }
     Ok(websocket_state)
 }
 

--- a/server/crates/waddle-server/src/server/routes/livekit_webhook.rs
+++ b/server/crates/waddle-server/src/server/routes/livekit_webhook.rs
@@ -21,6 +21,7 @@
 
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
+use std::time::Duration as StdDuration;
 
 use axum::body::Bytes;
 use axum::extract::{Extension, State};
@@ -31,7 +32,8 @@ use axum::Router;
 use jid::{BareJid, FullJid};
 use tracing::{debug, info, warn};
 use waddle_sfu::{
-    verify_webhook_signature, CallId, LiveKitWebhookEvent, ParticipantEnvelope, WebhookVerifyError,
+    verify_webhook_signature, CallId, LiveKitWebhookEvent, ParticipantEnvelope, SfuReconciler,
+    WebhookVerifyError, RECONCILE_GRACE_SECONDS,
 };
 
 use super::muc_muji_clear::clear_muji_presence_for_departure;
@@ -171,6 +173,70 @@ async fn livekit_webhook_handler(
     StatusCode::OK
 }
 
+/// How often the reconciliation backstop polls LiveKit for the true
+/// participant set of every active call. Frequent enough that a ghost
+/// left by a lost `participant_left`/`room_finished` webhook clears
+/// within ~a minute; infrequent enough that the `ListParticipants`
+/// fan-out is negligible even with many concurrent calls.
+const RECONCILE_INTERVAL: StdDuration = StdDuration::from_secs(60);
+
+/// `true` when `call_id` is a MUC (Muji) room JID and therefore has
+/// MUC presence to clear. A 1:1 call uses a scoped id
+/// (`<initiator-bare>::<sid>`) whose `::`-bearing domain part is not a
+/// valid JID, so it parses as `Err` — those are cleared from the SFU
+/// registry by the reconciler but carry no MUC `<presence/>`.
+fn is_muc_call(call_id: &str) -> bool {
+    call_id.parse::<BareJid>().is_ok()
+}
+
+/// Spawn the periodic SFU ghost-reconciliation task. Drives
+/// [`SfuReconciler::reconcile_active_calls`] on an interval and clears
+/// the MUC Muji presence of any participant LiveKit no longer reports —
+/// the safety net for a `participant_left`/`room_finished` webhook
+/// whose delivery (and all retries) were lost. No-op until the first
+/// tick after [`RECONCILE_INTERVAL`].
+pub fn spawn_reconciliation_task(state: Arc<WebSocketState>, reconciler: Arc<dyn SfuReconciler>) {
+    let grace = chrono::Duration::seconds(RECONCILE_GRACE_SECONDS);
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(RECONCILE_INTERVAL);
+        // Drop the immediate first tick `interval` yields so we don't
+        // reconcile at boot before any call exists.
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            reconcile_once(&state, reconciler.as_ref(), grace).await;
+        }
+    });
+}
+
+/// One reconciliation pass: sweep registry ghosts via the reconciler,
+/// then clear each swept MUC participant's Muji presence through the
+/// same idempotent path the `participant_left` webhook uses.
+async fn reconcile_once(
+    state: &WebSocketState,
+    reconciler: &dyn SfuReconciler,
+    grace: chrono::Duration,
+) {
+    let swept = reconciler.reconcile_active_calls(grace).await;
+    if swept.is_empty() {
+        return;
+    }
+    info!(
+        count = swept.len(),
+        "SFU reconciliation swept ghost participants; clearing MUC Muji presence"
+    );
+    for (call_id, identity) in swept {
+        if is_muc_call(call_id.as_str()) {
+            process_participant_left_for_identity(
+                state,
+                call_id.as_str(),
+                identity.as_jid().to_string().as_str(),
+            )
+            .await;
+        }
+    }
+}
+
 async fn process_participant_left(state: &WebSocketState, env: &ParticipantEnvelope) {
     process_participant_left_for_identity(state, &env.room.name, &env.participant.identity).await;
 }
@@ -223,6 +289,17 @@ mod tests {
         let seen = SeenEventIds::default();
         assert!(seen.observe(None));
         assert!(seen.observe(None));
+    }
+
+    #[test]
+    fn is_muc_call_distinguishes_room_jids_from_scoped_1to1_ids() {
+        // MUC (Muji) call ids are bare room JIDs → have presence.
+        assert!(is_muc_call("general@muc.waddle.social"));
+        assert!(is_muc_call("team-standup@muc.waddle.social"));
+        // 1:1 scoped ids (`<initiator-bare>::<sid>`) are not valid
+        // JIDs (the `::` lands in the domain part) → no MUC presence.
+        assert!(!is_muc_call("alice@waddle.social::c-abc123"));
+        assert!(!is_muc_call("c-abc123"));
     }
 
     #[test]

--- a/server/crates/waddle-server/src/server/routes/livekit_webhook.rs
+++ b/server/crates/waddle-server/src/server/routes/livekit_webhook.rs
@@ -181,12 +181,14 @@ async fn livekit_webhook_handler(
 const RECONCILE_INTERVAL: StdDuration = StdDuration::from_secs(60);
 
 /// `true` when `call_id` is a MUC (Muji) room JID and therefore has
-/// MUC presence to clear. A 1:1 call uses a scoped id
-/// (`<initiator-bare>::<sid>`) whose `::`-bearing domain part is not a
-/// valid JID, so it parses as `Err` — those are cleared from the SFU
-/// registry by the reconciler but carry no MUC `<presence/>`.
+/// MUC presence to clear. A MUC room is `localpart@muc.domain`, so we
+/// require both the `@` (a bare *domain-only* string like `c-abc123`
+/// is a valid JID but is not a room) and a successful `BareJid` parse
+/// (a 1:1 scoped id `<initiator-bare>::<sid>` has a `::`-bearing domain
+/// part that fails to parse). 1:1 ids are still cleared from the SFU
+/// registry by the reconciler; they just carry no MUC `<presence/>`.
 fn is_muc_call(call_id: &str) -> bool {
-    call_id.parse::<BareJid>().is_ok()
+    call_id.contains('@') && call_id.parse::<BareJid>().is_ok()
 }
 
 /// Spawn the periodic SFU ghost-reconciliation task. Drives

--- a/server/crates/waddle-sfu/src/admin.rs
+++ b/server/crates/waddle-sfu/src/admin.rs
@@ -64,6 +64,18 @@ pub trait LiveKitAdmin: Send + Sync + 'static {
         &'a self,
         room: &'a CallId,
     ) -> Pin<Box<dyn Future<Output = Result<(), SfuError>> + Send + 'a>>;
+
+    /// List the identities LiveKit currently reports as joined to
+    /// `room`. The authoritative answer to "who is *actually* in this
+    /// call right now", used by the reconciliation backstop to detect
+    /// registry ghosts left behind when a `participant_left` /
+    /// `room_finished` webhook delivery was lost. A `not_found` room
+    /// (LiveKit has GC'd it or never saw it) resolves to an empty
+    /// vec — nobody is connected — not an error.
+    fn list_participant_identities<'a>(
+        &'a self,
+        room: &'a CallId,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<Identity>, SfuError>> + Send + 'a>>;
 }
 
 /// Production admin client. Holds a long-lived `reqwest::Client` so
@@ -168,6 +180,44 @@ impl ReqwestLiveKitAdmin {
             body: truncate(body, 256),
         })
     }
+
+    /// Like [`Self::post`] but deserializes the response body. Returns
+    /// `Ok(None)` for the Twirp `not_found` shapes (HTTP 404 or a 4xx
+    /// whose envelope `code` is `"not_found"`) so callers can treat a
+    /// missing room as "no participants" rather than an error.
+    async fn post_returning<B: Serialize, R: for<'de> Deserialize<'de>>(
+        &self,
+        room: &CallId,
+        path: &str,
+        body: &B,
+    ) -> Result<Option<R>, SfuError> {
+        let token = self.mint_admin_token(room)?;
+        let url = self.base_url.join(path).map_err(SfuError::AdminUrl)?;
+        let resp = self
+            .http
+            .post(url)
+            .bearer_auth(token)
+            .json(body)
+            .send()
+            .await
+            .map_err(SfuError::AdminRequest)?;
+        let status = resp.status();
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        if status.is_success() {
+            let parsed = resp.json::<R>().await.map_err(SfuError::AdminRequest)?;
+            return Ok(Some(parsed));
+        }
+        let body = resp.text().await.unwrap_or_default();
+        if status.is_client_error() && is_twirp_not_found(&body) {
+            return Ok(None);
+        }
+        Err(SfuError::AdminCallFailed {
+            status: status.as_u16(),
+            body: truncate(body, 256),
+        })
+    }
 }
 
 impl LiveKitAdmin for ReqwestLiveKitAdmin {
@@ -196,6 +246,37 @@ impl LiveKitAdmin for ReqwestLiveKitAdmin {
         Box::pin(async move {
             self.post(room, "twirp/livekit.RoomService/DeleteRoom", &body)
                 .await
+        })
+    }
+
+    fn list_participant_identities<'a>(
+        &'a self,
+        room: &'a CallId,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<Identity>, SfuError>> + Send + 'a>> {
+        let body = ListParticipantsRequest {
+            room: room.as_str().to_string(),
+        };
+        Box::pin(async move {
+            let resp: Option<ListParticipantsResponse> = self
+                .post_returning(room, "twirp/livekit.RoomService/ListParticipants", &body)
+                .await?;
+            // `None` => room not found on LiveKit => nobody connected.
+            let Some(resp) = resp else {
+                return Ok(Vec::new());
+            };
+            // LiveKit identities are the stringified FullJids we minted
+            // into the JWT `sub`. Parse each back into a typed
+            // [`Identity`]; silently skip any that don't round-trip (a
+            // foreign participant or a malformed identity is simply not
+            // one of our registry entries, so it can't be a ghost we
+            // own).
+            let identities = resp
+                .participants
+                .into_iter()
+                .filter_map(|p| p.identity.parse::<jid::FullJid>().ok())
+                .map(Identity::from_jid)
+                .collect();
+            Ok(identities)
         })
     }
 }
@@ -261,6 +342,29 @@ struct RemoveParticipantRequest {
 #[derive(Serialize)]
 struct DeleteRoomRequest {
     room: String,
+}
+
+/// Twirp body for `livekit.RoomService/ListParticipants`.
+#[derive(Serialize)]
+struct ListParticipantsRequest {
+    room: String,
+}
+
+/// Twirp response for `livekit.RoomService/ListParticipants`. LiveKit
+/// returns a `participants` array of `ParticipantInfo`; only the
+/// `identity` is load-bearing for ghost reconciliation. Other fields
+/// (`sid`, `state`, `tracks`, …) are ignored via serde's default
+/// unknown-field handling.
+#[derive(Deserialize)]
+struct ListParticipantsResponse {
+    #[serde(default)]
+    participants: Vec<ListedParticipant>,
+}
+
+#[derive(Deserialize)]
+struct ListedParticipant {
+    #[serde(default)]
+    identity: String,
 }
 
 /// Twirp error envelope: a JSON object with `code` and `msg` fields
@@ -361,6 +465,33 @@ mod tests {
         assert!(is_twirp_not_found(
             r#"{"code":"not_found","msg":"participant not found"}"#
         ));
+    }
+
+    #[test]
+    fn list_participants_response_parses_livekit_wire_shape() {
+        // Lock the LiveKit `ListParticipantsResponse` wire shape: a
+        // `participants` array whose elements carry at least `identity`
+        // (plus fields we ignore). Absent/empty array must parse too.
+        let body = r#"{"participants":[
+            {"sid":"PA_1","identity":"alice@waddle.social/desktop","state":"ACTIVE"},
+            {"sid":"PA_2","identity":"bob@waddle.social/mobile"}
+        ]}"#;
+        let parsed: ListParticipantsResponse = serde_json::from_str(body).expect("parses");
+        let identities: Vec<String> = parsed
+            .participants
+            .into_iter()
+            .map(|p| p.identity)
+            .collect();
+        assert_eq!(
+            identities,
+            vec![
+                "alice@waddle.social/desktop".to_string(),
+                "bob@waddle.social/mobile".to_string()
+            ]
+        );
+
+        let empty: ListParticipantsResponse = serde_json::from_str(r#"{}"#).expect("empty parses");
+        assert!(empty.participants.is_empty());
     }
 
     #[test]

--- a/server/crates/waddle-sfu/src/config.rs
+++ b/server/crates/waddle-sfu/src/config.rs
@@ -136,6 +136,17 @@ impl fmt::Debug for TurnSharedSecret {
     }
 }
 
+/// Default join-token TTL in seconds (10 minutes). Long enough to
+/// cover ringing plus the WebSocket connect handshake, short enough to
+/// bound token theft; once connected LiveKit rotates its own in-band
+/// refresh tokens, so the JWT TTL only gates the initial connect.
+pub const DEFAULT_TOKEN_TTL_SECONDS: i64 = 600;
+
+/// Hard upper bound on the configurable join-token TTL (1 hour).
+/// Rejects misconfiguration to multi-hour/day TTLs that would leave a
+/// stolen token usable far beyond any plausible connect window.
+pub const MAX_TOKEN_TTL_SECONDS: i64 = 3600;
+
 /// Full SFU bridge configuration. Constructed once at server start.
 #[derive(Debug, Clone)]
 pub struct SfuConfig {
@@ -153,7 +164,12 @@ pub struct SfuConfig {
     pub turn_tls_port: u16,
     pub turn_udp_port: u16,
     pub turn_shared_secret: TurnSharedSecret,
-    /// TTL of every minted join token (default: 1 hour).
+    /// TTL of every minted join token. Bounds the window in which a
+    /// stolen token can be replayed to join the room. LiveKit rotates
+    /// its own in-band refresh tokens once a participant is connected,
+    /// so this only gates the *initial* connect and can safely be
+    /// short. Default [`DEFAULT_TOKEN_TTL_SECONDS`], hard-capped at
+    /// [`MAX_TOKEN_TTL_SECONDS`].
     pub token_ttl: Duration,
     /// TTL of every minted TURN credential (default: 1 hour).
     pub turn_ttl: Duration,
@@ -171,7 +187,8 @@ impl SfuConfig {
     /// `LIVEKIT_TURN_SHARED_SECRET`.
     /// Optional with defaults: `LIVEKIT_TURN_TLS_PORT` (443),
     /// `LIVEKIT_TURN_UDP_PORT` (3478),
-    /// `LIVEKIT_TOKEN_TTL_SECONDS` (3600),
+    /// `LIVEKIT_TOKEN_TTL_SECONDS` (default 600, hard-capped at 3600;
+    /// out-of-range values are rejected),
     /// `LIVEKIT_TURN_TTL_SECONDS` (3600),
     /// `LIVEKIT_WEBHOOK_SECRET` (defaults to `LIVEKIT_API_SECRET` for
     /// dev parity; production should set both independently so a
@@ -204,7 +221,7 @@ impl SfuConfig {
 
         let turn_tls_port = parse_port_env("LIVEKIT_TURN_TLS_PORT", 443)?;
         let turn_udp_port = parse_port_env("LIVEKIT_TURN_UDP_PORT", 3478)?;
-        let token_ttl_seconds = parse_seconds_env("LIVEKIT_TOKEN_TTL_SECONDS", 3600)?;
+        let token_ttl_seconds = parse_token_ttl_env("LIVEKIT_TOKEN_TTL_SECONDS")?;
         let turn_ttl_seconds = parse_seconds_env("LIVEKIT_TURN_TTL_SECONDS", 3600)?;
 
         // Validate the API secret first so the dedicated
@@ -248,6 +265,26 @@ fn parse_seconds_env(name: &'static str, default: i64) -> Result<i64, FromEnvErr
     }
 }
 
+/// Parse and validate the join-token TTL. Defaults to
+/// [`DEFAULT_TOKEN_TTL_SECONDS`] when unset and rejects values outside
+/// `1..=MAX_TOKEN_TTL_SECONDS` so a misconfigured TTL can never mint
+/// already-expired or implausibly long-lived join tokens.
+fn parse_token_ttl_env(name: &'static str) -> Result<i64, FromEnvError> {
+    let seconds = match std::env::var(name) {
+        Ok(value) => value
+            .parse()
+            .map_err(|_| FromEnvError::InvalidNumber(name))?,
+        Err(_) => return Ok(DEFAULT_TOKEN_TTL_SECONDS),
+    };
+    if !(1..=MAX_TOKEN_TTL_SECONDS).contains(&seconds) {
+        return Err(FromEnvError::TokenTtlOutOfRange {
+            seconds,
+            max: MAX_TOKEN_TTL_SECONDS,
+        });
+    }
+    Ok(seconds)
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum FromEnvError {
     #[error("missing required env var: {0}")]
@@ -258,6 +295,8 @@ pub enum FromEnvError {
     InvalidScheme(#[source] InvalidWebsocketUrl),
     #[error("env var {0} is not a valid number")]
     InvalidNumber(&'static str),
+    #[error("LIVEKIT_TOKEN_TTL_SECONDS={seconds} is out of range (must be 1..={max})")]
+    TokenTtlOutOfRange { seconds: i64, max: i64 },
     #[error("LIVEKIT_API_SECRET is too weak")]
     WeakApiSecret(#[source] WeakSecret),
     #[error("LIVEKIT_WEBHOOK_SECRET is too weak")]
@@ -367,7 +406,7 @@ mod tests {
             .expect("some");
         assert_eq!(cfg.turn_tls_port, 443);
         assert_eq!(cfg.turn_udp_port, 3478);
-        assert_eq!(cfg.token_ttl, Duration::seconds(3600));
+        assert_eq!(cfg.token_ttl, Duration::seconds(DEFAULT_TOKEN_TTL_SECONDS));
         assert_eq!(cfg.turn_ttl, Duration::seconds(3600));
         assert_eq!(cfg.turn_host.as_str(), "turn.test");
     }
@@ -442,6 +481,66 @@ mod tests {
         assert!(matches!(
             err,
             FromEnvError::InvalidNumber("LIVEKIT_TURN_TLS_PORT")
+        ));
+    }
+
+    fn required_overrides() -> Vec<(&'static str, Option<&'static str>)> {
+        let mut overrides = all_unset_overrides();
+        overrides.extend([
+            ("LIVEKIT_API_KEY", Some("APIxxxxxxxx")),
+            (
+                "LIVEKIT_API_SECRET",
+                Some("super-secret-secret-32-bytes-min"),
+            ),
+            ("LIVEKIT_WS_URL", Some("wss://livekit.test/")),
+            ("LIVEKIT_TURN_HOST", Some("turn.test")),
+            ("LIVEKIT_TURN_SHARED_SECRET", Some("turn-shared-secret")),
+        ]);
+        overrides
+    }
+
+    #[test]
+    fn from_env_token_ttl_defaults_to_ten_minutes() {
+        let cfg = with_env(&required_overrides(), SfuConfig::from_env)
+            .expect("ok")
+            .expect("some");
+        assert_eq!(cfg.token_ttl, Duration::seconds(DEFAULT_TOKEN_TTL_SECONDS));
+        assert_eq!(DEFAULT_TOKEN_TTL_SECONDS, 600);
+    }
+
+    #[test]
+    fn from_env_custom_token_ttl_within_range_is_accepted() {
+        let mut overrides = required_overrides();
+        overrides.push(("LIVEKIT_TOKEN_TTL_SECONDS", Some("120")));
+        let cfg = with_env(&overrides, SfuConfig::from_env)
+            .expect("ok")
+            .expect("some");
+        assert_eq!(cfg.token_ttl, Duration::seconds(120));
+    }
+
+    #[test]
+    fn from_env_token_ttl_above_cap_is_rejected() {
+        let mut overrides = required_overrides();
+        // One second over the 1-hour cap.
+        overrides.push(("LIVEKIT_TOKEN_TTL_SECONDS", Some("3601")));
+        let err = with_env(&overrides, SfuConfig::from_env).expect_err("over-cap ttl is err");
+        assert!(matches!(
+            err,
+            FromEnvError::TokenTtlOutOfRange {
+                seconds: 3601,
+                max: MAX_TOKEN_TTL_SECONDS
+            }
+        ));
+    }
+
+    #[test]
+    fn from_env_non_positive_token_ttl_is_rejected() {
+        let mut overrides = required_overrides();
+        overrides.push(("LIVEKIT_TOKEN_TTL_SECONDS", Some("0")));
+        let err = with_env(&overrides, SfuConfig::from_env).expect_err("zero ttl is err");
+        assert!(matches!(
+            err,
+            FromEnvError::TokenTtlOutOfRange { seconds: 0, .. }
         ));
     }
 

--- a/server/crates/waddle-sfu/src/lib.rs
+++ b/server/crates/waddle-sfu/src/lib.rs
@@ -140,6 +140,11 @@ pub trait SfuService: Send + Sync + 'static {
     fn participants_for_call(&self, call_id: &CallId) -> Vec<Identity>;
 }
 
+/// Future returned by [`SfuReconciler::reconcile_active_calls`],
+/// resolving to the `(call, identity)` pairs swept this pass. Named so
+/// the boxed-future shape stays readable at the trait + impl sites.
+pub type ReconcileFuture<'a> = Pin<Box<dyn Future<Output = Vec<(CallId, Identity)>> + Send + 'a>>;
+
 /// Periodic reconciliation against the SFU's ground truth.
 ///
 /// Separate from [`SfuService`] because it is inherently async (an
@@ -150,11 +155,6 @@ pub trait SfuService: Send + Sync + 'static {
 /// a permanent ghost in the registry (and therefore in MUC presence):
 /// LiveKit, not our in-memory registry, is the authority on who is
 /// actually connected.
-/// Future returned by [`SfuReconciler::reconcile_active_calls`],
-/// resolving to the `(call, identity)` pairs swept this pass. Named so
-/// the boxed-future shape stays readable at the trait + impl sites.
-pub type ReconcileFuture<'a> = Pin<Box<dyn Future<Output = Vec<(CallId, Identity)>> + Send + 'a>>;
-
 pub trait SfuReconciler: Send + Sync + 'static {
     /// Sweep registry entries LiveKit no longer reports as connected,
     /// respecting a registration grace window so still-connecting

--- a/server/crates/waddle-sfu/src/lib.rs
+++ b/server/crates/waddle-sfu/src/lib.rs
@@ -20,6 +20,9 @@
 
 #![deny(unsafe_code)]
 
+use std::future::Future;
+use std::pin::Pin;
+
 mod admin;
 mod call;
 mod config;
@@ -33,7 +36,7 @@ pub use admin::LiveKitAdmin;
 pub use call::{CallId, CallState, Identity, MediaCapabilities};
 pub use config::{ApiKey, ApiSecret, FromEnvError, SfuConfig, TurnSharedSecret, WebsocketUrl};
 pub use error::SfuError;
-pub use livekit::LiveKitSfu;
+pub use livekit::{LiveKitSfu, RECONCILE_GRACE_SECONDS};
 pub use token::{JoinToken, Jti, Jwt, VideoGrant};
 pub use turn::{TurnCredential, TurnHost, TurnPassword, TurnUsername};
 pub use webhook::{
@@ -135,4 +138,28 @@ pub trait SfuService: Send + Sync + 'static {
     /// Returns an empty vec when the call has no recorded participants
     /// (either never registered or already drained).
     fn participants_for_call(&self, call_id: &CallId) -> Vec<Identity>;
+}
+
+/// Periodic reconciliation against the SFU's ground truth.
+///
+/// Separate from [`SfuService`] because it is inherently async (an
+/// HTTP round-trip to LiveKit's `ListParticipants`) whereas
+/// `SfuService` is deliberately sync. A background task in
+/// `waddle-server` drives this on an interval so that a lost
+/// `participant_left` / `room_finished` webhook delivery cannot leave
+/// a permanent ghost in the registry (and therefore in MUC presence):
+/// LiveKit, not our in-memory registry, is the authority on who is
+/// actually connected.
+/// Future returned by [`SfuReconciler::reconcile_active_calls`],
+/// resolving to the `(call, identity)` pairs swept this pass. Named so
+/// the boxed-future shape stays readable at the trait + impl sites.
+pub type ReconcileFuture<'a> = Pin<Box<dyn Future<Output = Vec<(CallId, Identity)>> + Send + 'a>>;
+
+pub trait SfuReconciler: Send + Sync + 'static {
+    /// Sweep registry entries LiveKit no longer reports as connected,
+    /// respecting a registration grace window so still-connecting
+    /// participants are not mistaken for ghosts. Returns the
+    /// `(call, identity)` pairs swept so the caller can clear the
+    /// corresponding MUC Muji presence idempotently.
+    fn reconcile_active_calls(&self, grace: chrono::Duration) -> ReconcileFuture<'_>;
 }

--- a/server/crates/waddle-sfu/src/livekit.rs
+++ b/server/crates/waddle-sfu/src/livekit.rs
@@ -7,7 +7,7 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use dashmap::DashMap;
 use tokio::runtime::Handle;
 use tokio::sync::Semaphore;
@@ -36,6 +36,16 @@ pub(crate) const MAX_ISSUED_PER_PARTICIPANT: usize = 16;
 /// many reqwest tasks. The semaphore is a fixed-size FIFO valve.
 const ADMIN_CONCURRENCY: usize = 32;
 
+/// Grace window after registration before a participant becomes
+/// eligible for ghost reconciliation. The registry is populated at
+/// Jingle `session-initiate` — *before* the client actually connects
+/// its WebSocket to LiveKit — so a freshly-registered participant is
+/// legitimately absent from LiveKit's `ListParticipants` for the few
+/// seconds it takes to ring + connect. Sweeping inside that window
+/// would tear down a call that is still coming up; this grace period
+/// keeps reconciliation to genuinely stale entries.
+pub const RECONCILE_GRACE_SECONDS: i64 = 120;
+
 /// Shared registry of in-call participants. Held in an `Arc` so the
 /// spawned admin teardown future can re-check membership before
 /// firing `DeleteRoom`, closing the race where a fresh joiner
@@ -53,6 +63,15 @@ pub struct LiveKitSfu {
     /// a misbehaving client cannot push the tracker into unbounded
     /// memory growth.
     issued: DashMap<(CallId, Identity), Vec<IssuedJti>>,
+    /// Wall-clock instant each `(call, identity)` was registered.
+    /// Read only by the reconciliation backstop to enforce
+    /// [`RECONCILE_GRACE_SECONDS`]: a participant absent from LiveKit's
+    /// `ListParticipants` is only swept once it has been registered
+    /// longer than the grace window, so a still-connecting joiner is
+    /// never mistaken for a ghost. Kept in lockstep with `calls`:
+    /// written in `register_call_participant`, removed in
+    /// `clear_local_state`.
+    registered_at: DashMap<(CallId, Identity), DateTime<Utc>>,
     /// Map of revoked JWT identifiers to the `exp` of the token they
     /// belonged to. Entries are swept lazily once `Utc::now() > exp`:
     /// a revoked token past its expiry cannot be replayed regardless
@@ -122,6 +141,7 @@ impl LiveKitSfu {
             config,
             calls: Arc::new(DashMap::new()),
             issued: DashMap::new(),
+            registered_at: DashMap::new(),
             revoked: DashMap::new(),
             admin,
             runtime: Handle::try_current().ok(),
@@ -186,6 +206,8 @@ impl LiveKitSfu {
                 self.revoked.insert(issued.jti, issued.exp);
             }
         }
+        self.registered_at
+            .remove(&(call_id.clone(), identity.clone()));
         self.sweep_expired_revoked(Utc::now());
 
         if remaining == 0 {
@@ -255,6 +277,92 @@ impl LiveKitSfu {
             }
         });
     }
+
+    /// One reconciliation pass against LiveKit's ground truth.
+    ///
+    /// For every call in the local registry, ask LiveKit who is
+    /// actually connected (`ListParticipants`) and sweep any locally
+    /// registered identity that LiveKit no longer reports — but only
+    /// once that identity has been registered longer than `grace`, so
+    /// a participant still ringing/connecting (the registry is
+    /// populated at `session-initiate`, before the WebSocket connects)
+    /// is never mistaken for a ghost. Returns the `(call, identity)`
+    /// pairs that were swept so the caller (the webhook route's
+    /// reconciliation task) can clear their MUC Muji presence via the
+    /// same idempotent path the `participant_left` webhook uses.
+    ///
+    /// Swept entries are cleared with [`Self::clear_local_state`]
+    /// (registry removal + JWT revocation) only — no admin
+    /// `RemoveParticipant`/`DeleteRoom` is fired, because LiveKit
+    /// already does not have these participants (that is precisely why
+    /// they are ghosts), and a room LiveKit reports as gone will lapse
+    /// on its own `empty_timeout`.
+    ///
+    /// A `ListParticipants` failure for a given call (network/5xx) is
+    /// logged and that call is skipped this pass — absence cannot be
+    /// confirmed, so nothing is swept. The next pass retries.
+    async fn reconcile_active_calls_inner(&self, grace: ChronoDuration) -> Vec<(CallId, Identity)> {
+        let now = Utc::now();
+        // Snapshot the registry into owned values up front so no
+        // DashMap guard is held across the `.await` on the admin call.
+        let snapshot: Vec<(CallId, Vec<Identity>)> = self
+            .calls
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().iter().cloned().collect()))
+            .collect();
+
+        let mut swept = Vec::new();
+        for (call_id, registered) in snapshot {
+            let live = match self.admin.list_participant_identities(&call_id).await {
+                Ok(live) => live,
+                Err(err) => {
+                    tracing::warn!(
+                        call_id = %call_id,
+                        error = %err,
+                        "SFU reconcile: ListParticipants failed; skipping this call this pass"
+                    );
+                    continue;
+                }
+            };
+            let live_set: HashSet<String> =
+                live.iter().map(Identity::as_livekit_identity).collect();
+
+            for identity in registered {
+                if live_set.contains(&identity.as_livekit_identity()) {
+                    continue; // genuinely connected — not a ghost
+                }
+                // Absent from LiveKit. Only sweep once past the grace
+                // window; a freshly-registered participant may simply
+                // not have finished connecting yet.
+                let aged_out = self
+                    .registered_at
+                    .get(&(call_id.clone(), identity.clone()))
+                    .map(|entry| now - *entry.value() >= grace)
+                    // No timestamp recorded (e.g. an entry registered
+                    // before this field existed) → treat as eligible.
+                    .unwrap_or(true);
+                if !aged_out {
+                    continue;
+                }
+                let (was_present, _) = self.clear_local_state(&call_id, &identity);
+                if was_present {
+                    tracing::info!(
+                        call_id = %call_id,
+                        identity = %identity.as_livekit_identity(),
+                        "SFU reconcile: swept ghost participant LiveKit no longer reports"
+                    );
+                    swept.push((call_id.clone(), identity));
+                }
+            }
+        }
+        swept
+    }
+}
+
+impl crate::SfuReconciler for LiveKitSfu {
+    fn reconcile_active_calls(&self, grace: ChronoDuration) -> crate::ReconcileFuture<'_> {
+        Box::pin(self.reconcile_active_calls_inner(grace))
+    }
 }
 
 impl SfuService for LiveKitSfu {
@@ -307,6 +415,11 @@ impl SfuService for LiveKitSfu {
             .entry(call_id.clone())
             .or_default()
             .insert(identity.clone());
+        // Stamp (or refresh) the registration time so the
+        // reconciliation backstop's grace window is measured from the
+        // most recent (re)join, not a stale earlier attempt.
+        self.registered_at
+            .insert((call_id.clone(), identity.clone()), Utc::now());
     }
 
     fn has_call_participant(&self, call_id: &CallId, identity: &Identity) -> bool {
@@ -601,6 +714,14 @@ mod tests {
     struct RecordingAdmin {
         remove_calls: Mutex<Vec<(CallId, Identity)>>,
         delete_calls: Mutex<Vec<CallId>>,
+        /// What LiveKit "reports" as connected per call. A call absent
+        /// from the map lists as empty (room not found). Drives the
+        /// reconciliation tests.
+        live: Mutex<std::collections::HashMap<CallId, Vec<Identity>>>,
+        /// When set, `list_participant_identities` errors instead of
+        /// returning a set — used to assert reconcile skips a call it
+        /// can't confirm rather than sweeping it.
+        list_errors: Mutex<bool>,
     }
 
     impl RecordingAdmin {
@@ -610,6 +731,17 @@ mod tests {
 
         fn delete_snapshot(&self) -> Vec<CallId> {
             self.delete_calls.lock().expect("recording lock").clone()
+        }
+
+        fn set_live(&self, call: &CallId, identities: Vec<Identity>) {
+            self.live
+                .lock()
+                .expect("recording lock")
+                .insert(call.clone(), identities);
+        }
+
+        fn fail_list(&self) {
+            *self.list_errors.lock().expect("recording lock") = true;
         }
     }
 
@@ -638,6 +770,25 @@ mod tests {
             Box::pin(async move {
                 self.delete_calls.lock().expect("recording lock").push(room);
                 Ok(())
+            })
+        }
+
+        fn list_participant_identities<'a>(
+            &'a self,
+            room: &'a CallId,
+        ) -> Pin<Box<dyn Future<Output = Result<Vec<Identity>, SfuError>> + Send + 'a>> {
+            let room = room.clone();
+            Box::pin(async move {
+                if *self.list_errors.lock().expect("recording lock") {
+                    return Err(SfuError::InvalidCallId("simulated list failure".into()));
+                }
+                Ok(self
+                    .live
+                    .lock()
+                    .expect("recording lock")
+                    .get(&room)
+                    .cloned()
+                    .unwrap_or_default())
             })
         }
     }
@@ -810,5 +961,99 @@ mod tests {
             "DeleteRoom must be suppressed by the rejoin re-check; got {:?}",
             admin.delete_snapshot(),
         );
+    }
+
+    // -------- Reconciliation backstop --------
+
+    use crate::SfuReconciler;
+
+    #[tokio::test]
+    async fn reconcile_sweeps_ghost_absent_from_livekit() {
+        // Alice + Bob registered; LiveKit reports only Alice connected
+        // (Bob's participant_left webhook was lost). With a zero grace
+        // window Bob must be swept and returned for presence cleanup;
+        // Alice must remain. No admin remove/delete is fired — the
+        // ghost is already gone from LiveKit.
+        let admin = Arc::new(RecordingAdmin::default());
+        let sfu = LiveKitSfu::with_admin(fixture_config(), Arc::clone(&admin) as Arc<_>);
+        let call = CallId::new("general@muc.waddle.social").unwrap();
+        let alice = fixture_identity("alice");
+        let bob = fixture_identity("bob");
+        sfu.register_call_participant(&call, &alice);
+        sfu.register_call_participant(&call, &bob);
+        admin.set_live(&call, vec![alice.clone()]);
+
+        let swept = sfu.reconcile_active_calls(ChronoDuration::zero()).await;
+
+        assert_eq!(swept, vec![(call.clone(), bob.clone())]);
+        assert!(sfu.has_call_participant(&call, &alice), "Alice must remain");
+        assert!(
+            !sfu.has_call_participant(&call, &bob),
+            "Bob must be swept from the registry"
+        );
+        assert_eq!(sfu.participant_count(&call), 1);
+        assert!(
+            admin.remove_snapshot().is_empty() && admin.delete_snapshot().is_empty(),
+            "reconcile must not fire admin RemoveParticipant/DeleteRoom for already-gone ghosts"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_respects_registration_grace_window() {
+        // A just-registered participant LiveKit hasn't seen yet (still
+        // ringing/connecting) must NOT be swept while inside the grace
+        // window — sweeping here would tear down a call coming up.
+        let admin = Arc::new(RecordingAdmin::default());
+        let sfu = LiveKitSfu::with_admin(fixture_config(), Arc::clone(&admin) as Arc<_>);
+        let call = CallId::new("room@muc.waddle.social").unwrap();
+        let alice = fixture_identity("alice");
+        sfu.register_call_participant(&call, &alice);
+        // LiveKit reports nobody (room not yet created / mid-connect).
+        admin.set_live(&call, vec![]);
+
+        let swept = sfu
+            .reconcile_active_calls(ChronoDuration::seconds(3600))
+            .await;
+
+        assert!(
+            swept.is_empty(),
+            "a participant inside the grace window must not be swept"
+        );
+        assert_eq!(sfu.participant_count(&call), 1);
+    }
+
+    #[tokio::test]
+    async fn reconcile_keeps_genuinely_connected_participants() {
+        let admin = Arc::new(RecordingAdmin::default());
+        let sfu = LiveKitSfu::with_admin(fixture_config(), Arc::clone(&admin) as Arc<_>);
+        let call = CallId::new("room2@muc.waddle.social").unwrap();
+        let alice = fixture_identity("alice");
+        sfu.register_call_participant(&call, &alice);
+        admin.set_live(&call, vec![alice.clone()]);
+
+        let swept = sfu.reconcile_active_calls(ChronoDuration::zero()).await;
+
+        assert!(swept.is_empty(), "connected participant must not be swept");
+        assert!(sfu.has_call_participant(&call, &alice));
+    }
+
+    #[tokio::test]
+    async fn reconcile_skips_calls_it_cannot_confirm() {
+        // If ListParticipants fails for a call, absence cannot be
+        // confirmed; nothing is swept and the next pass retries.
+        let admin = Arc::new(RecordingAdmin::default());
+        admin.fail_list();
+        let sfu = LiveKitSfu::with_admin(fixture_config(), Arc::clone(&admin) as Arc<_>);
+        let call = CallId::new("room3@muc.waddle.social").unwrap();
+        let alice = fixture_identity("alice");
+        sfu.register_call_participant(&call, &alice);
+
+        let swept = sfu.reconcile_active_calls(ChronoDuration::zero()).await;
+
+        assert!(
+            swept.is_empty(),
+            "a call whose participant list could not be fetched must not be swept"
+        );
+        assert_eq!(sfu.participant_count(&call), 1);
     }
 }

--- a/server/crates/waddle-xmpp-client-wasm/src/client_calls.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_calls.rs
@@ -116,13 +116,6 @@ fn message_with_jmi_to_full(to: &str, jmi: Element) -> Result<Element, JsValue> 
     Ok(message_with_jmi(full.into(), jmi))
 }
 
-fn message_with_jmi_to_any(to: &str, jmi: Element) -> Result<Element, JsValue> {
-    let jid: jid::Jid = to
-        .parse()
-        .map_err(|_| js_error(format!("invalid JID for JMI envelope: {to}")))?;
-    Ok(message_with_jmi(jid, jmi))
-}
-
 fn iq_set(to: &str, payload: Element) -> Element {
     Element::builder("iq", NS_JABBER_CLIENT)
         .attr(minidom::rxml::xml_ncname!("type").to_owned(), "set")
@@ -214,10 +207,17 @@ impl WaddleClient {
         })
     }
 
-    pub fn send_call_retract(&self, peer_jid: String, sid_str: String) -> Promise {
+    /// Send a JMI `<retract/>` to the peer's bare JID (XEP-0353 §3).
+    /// Like `<propose/>`, retract is addressed to the BARE JID so the
+    /// responder's server can fan the disavowal out to every resource
+    /// that may have seen the original ring. Typing the parameter as a
+    /// bare JID (and routing through `message_with_jmi_to_bare`, which
+    /// rejects a resource-bearing JID) enforces that on the wire — the
+    /// resource-targeted variant is `send_call_retract_tie_break`.
+    pub fn send_call_retract(&self, peer_bare_jid: String, sid_str: String) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
-            let stanza = message_with_jmi_to_any(&peer_jid, build_retract(&sid(sid_str)))?;
+            let stanza = message_with_jmi_to_bare(&peer_bare_jid, build_retract(&sid(sid_str)))?;
             send_stanza_command(inner, stanza).await?;
             Ok(JsValue::UNDEFINED)
         })
@@ -593,6 +593,39 @@ mod tests {
                     .children()
                     .any(|condition| condition.name() == "expired" && condition.ns() == NS_JINGLE)
         }));
+    }
+
+    /// XEP-0353 §3: a non-tie-break `<retract/>` is addressed to the
+    /// responder's BARE JID (like `<propose/>`), so the disavowal fans
+    /// out to every resource that may have seen the ring. The bare-JID
+    /// helper backing `send_call_retract` therefore MUST reject a
+    /// resource-bearing JID — only `send_call_retract_tie_break` (which
+    /// routes through the full-JID helper) targets a single resource.
+    #[test]
+    fn jmi_retract_targets_bare_jid_and_rejects_full_jid() {
+        use waddle_xmpp_client::messaging::{build_retract, SessionId};
+
+        let stanza = super::message_with_jmi_to_bare(
+            "bob@waddle.test",
+            build_retract(&SessionId("c1".into())),
+        )
+        .expect("bare JID accepted for retract");
+        assert_eq!(stanza.attr("to"), Some("bob@waddle.test"));
+        assert!(
+            stanza
+                .children()
+                .any(|child| child.name() == "retract" && child.ns() == NS_JINGLE_MESSAGE),
+            "JMI retract child preserved"
+        );
+
+        // A resource-bearing JID must be refused so a plain retract can
+        // never accidentally target a single resource. Assert at the
+        // JID-parse layer that `message_with_jmi_to_bare` routes
+        // through (a full JID is not a valid `BareJid`) — the helper's
+        // own error arm builds a `JsValue`, which aborts on the
+        // non-wasm host test target, so we check the parse directly the
+        // same way `jmi_response_envelope_requires_full_jid` does.
+        assert!("bob@waddle.test/phone".parse::<jid::BareJid>().is_err());
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/xep/xep0272.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0272.rs
@@ -252,7 +252,25 @@ impl TryFrom<&Element> for Muji {
             }
             match child.name() {
                 PREPARING_NAME => preparing = true,
-                CONTENT_NAME => contents.push(MujiContent::try_from_element(child)?),
+                CONTENT_NAME => {
+                    let content = MujiContent::try_from_element(child)?;
+                    // XEP-0166 §7.3: the (creator, name) tuple uniquely
+                    // identifies a content. A `<muji/>` carrying two
+                    // contents with the same pair is malformed; reject
+                    // it rather than storing a duplicate that would
+                    // pollute the presence-derived content list
+                    // broadcast to the MUC. The list is tiny (audio +
+                    // video), so a linear scan is cheaper than a set.
+                    if contents.iter().any(|existing: &MujiContent| {
+                        existing.creator == content.creator && existing.name == content.name
+                    }) {
+                        return Err(MujiParseError::DuplicateContent {
+                            creator: creator_as_attr(content.creator),
+                            name: content.name.0.clone(),
+                        });
+                    }
+                    contents.push(content);
+                }
                 _ => {
                     return Err(MujiParseError::UnexpectedChild(child.name().to_owned()));
                 }
@@ -291,6 +309,11 @@ pub enum MujiParseError {
     MissingDescription,
     #[error("unexpected child element in <muji/>: {0}")]
     UnexpectedChild(String),
+    #[error(
+        "duplicate <content/> for (creator={creator}, name={name}); \
+         XEP-0166 §7.3 requires the (creator, name) tuple to be unique"
+    )]
+    DuplicateContent { creator: &'static str, name: String },
 }
 
 fn creator_as_attr(creator: Creator) -> &'static str {
@@ -402,6 +425,45 @@ mod tests {
         let elem: Element = xml.parse().unwrap();
         let err = Muji::try_from(&elem).expect_err("creator validation");
         assert!(matches!(err, MujiParseError::InvalidCreator(_)));
+    }
+
+    #[test]
+    fn rejects_duplicate_content_creator_name_tuple() {
+        // XEP-0166 §7.3: (creator, name) must be unique. Two
+        // `<content creator='initiator' name='audio'>` children must
+        // be rejected rather than both stored and rebroadcast.
+        let xml = "<muji xmlns='urn:xmpp:jingle:muji:0'>\
+                     <content creator='initiator' name='audio'>\
+                       <description xmlns='urn:xmpp:jingle:apps:rtp:1' media='audio'/>\
+                     </content>\
+                     <content creator='initiator' name='audio'>\
+                       <description xmlns='urn:xmpp:jingle:apps:rtp:1' media='audio'/>\
+                     </content>\
+                   </muji>";
+        let elem: Element = xml.parse().unwrap();
+        let err = Muji::try_from(&elem).expect_err("duplicate content rejected");
+        assert!(matches!(
+            err,
+            MujiParseError::DuplicateContent { creator, ref name }
+                if creator == "initiator" && name == "audio"
+        ));
+    }
+
+    #[test]
+    fn allows_same_name_under_different_creators() {
+        // The uniqueness key is the (creator, name) *tuple*, so the
+        // same name under a different creator is permitted.
+        let xml = "<muji xmlns='urn:xmpp:jingle:muji:0'>\
+                     <content creator='initiator' name='audio'>\
+                       <description xmlns='urn:xmpp:jingle:apps:rtp:1' media='audio'/>\
+                     </content>\
+                     <content creator='responder' name='audio'>\
+                       <description xmlns='urn:xmpp:jingle:apps:rtp:1' media='audio'/>\
+                     </content>\
+                   </muji>";
+        let elem: Element = xml.parse().unwrap();
+        let muji = Muji::try_from(&elem).expect("distinct creators accepted");
+        assert_eq!(muji.contents.len(), 2);
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/tests/xep_0272_muji.rs
+++ b/server/crates/waddle-xmpp/tests/xep_0272_muji.rs
@@ -673,6 +673,22 @@ impl waddle_sfu::LiveKitAdmin for RecordingAdmin {
             Ok(())
         })
     }
+
+    fn list_participant_identities<'a>(
+        &'a self,
+        _room: &'a waddle_sfu::CallId,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<
+                    Output = Result<Vec<waddle_sfu::Identity>, waddle_sfu::SfuError>,
+                > + Send
+                + 'a,
+        >,
+    > {
+        // These Muji teardown tests don't exercise the reconciliation
+        // backstop; report no live participants.
+        Box::pin(async move { Ok(Vec::new()) })
+    }
 }
 
 fn fixture_sfu_with_admin(admin: Arc<RecordingAdmin>) -> Arc<dyn SfuService> {

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -226,7 +226,16 @@ export class WaddleClient {
     send_call_propose(peer_bare_jid: string, sid_str: string, audio: boolean, video: boolean): Promise<any>;
     send_call_reject(peer_full_jid: string, sid_str: string): Promise<any>;
     send_call_reject_tie_break(peer_full_jid: string, sid_str: string): Promise<any>;
-    send_call_retract(peer_jid: string, sid_str: string): Promise<any>;
+    /**
+     * Send a JMI `<retract/>` to the peer's bare JID (XEP-0353 §3).
+     * Like `<propose/>`, retract is addressed to the BARE JID so the
+     * responder's server can fan the disavowal out to every resource
+     * that may have seen the original ring. Typing the parameter as a
+     * bare JID (and routing through `message_with_jmi_to_bare`, which
+     * rejects a resource-bearing JID) enforces that on the wire — the
+     * resource-targeted variant is `send_call_retract_tie_break`.
+     */
+    send_call_retract(peer_bare_jid: string, sid_str: string): Promise<any>;
     send_call_retract_tie_break(peer_full_jid: string, sid_str: string): Promise<any>;
     /**
      * Send a Jingle `session-accept` IQ in response to a received

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpnd9iyz";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpnd9iyz";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpnd9iyz";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpq5mooo";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpq5mooo";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpq5mooo";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=mpnd9iyz";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=mpq5mooo";


### PR DESCRIPTION
## Summary

Remediation for a full audit of the LiveKit/XMPP calling stack (spec-conformance,
correctness, security, reliability, infra). The audit mapped all five layers
(XEPs, server Jingle/JMI/MUJI, `waddle-sfu`, frontend call state, infra) and
adversarially verified each finding against both the XEP text and the source.

The stack was found to be high quality; this PR fixes the genuine issues that
survived verification, prioritized P1→P3. The "scary" hypotheses that were
**refuted** on inspection (API key in a ConfigMap → it's an ExternalSecret;
wildcard token room → room is scoped into the grant; calls failing at TTL expiry
→ LiveKit rotates refresh tokens in-band) are **not** changed here.

## ⚠️ Required operator action before deploy

The webhook-secret split (P1) introduces **two new fields** on the `livekit-sfu`
1Password item. The `optional: false` ExternalSecrets will not populate until
they exist, so add them before this rolls out:

- **`webhook-key`** — a key *name*/identifier (any non-secret string, distinct
  from `api-key`, e.g. `WHOOKxxxx`). Becomes LiveKit's webhook JWT issuer.
- **`webhook-secret`** — a fresh **≥32-byte** HMAC-SHA256 secret, distinct from
  `api-secret`. LiveKit signs webhooks with it; `waddle-server` verifies with it.

## Changes

### P1 — security / reliability (`fix(server)`, `fix(infra)`)
- **Split the webhook secret from the API secret.** Both `LIVEKIT_API_SECRET`
  and `LIVEKIT_WEBHOOK_SECRET` resolved to the same `api-secret` property, so a
  leaked join-token secret could forge signed webhooks. LiveKit's `keys.yaml`
  now carries a dedicated `webhook-key`/`webhook-secret` pair, the HelmRelease
  points `webhook.apiKey` at it, and the server verifies with `webhook-secret` —
  signing and verification move together, blast radii isolated.
- **Webhook-loss reconciliation backstop.** The SFU `calls` registry had no TTL
  and no reconciliation; a lost `participant_left` + `room_finished` left a
  permanent MUC-presence ghost. New `LiveKitAdmin::list_participant_identities`
  (Twirp `ListParticipants`) + `SfuReconciler` trait + a periodic task that
  sweeps registry entries LiveKit no longer reports and clears their Muji
  presence idempotently. A 120 s registration grace window avoids evicting a
  still-connecting participant (registry is populated at `session-initiate`,
  before the WebSocket connects).
- **Join-token TTL cap.** Default 1 h → 10 min, with a hard `1..=3600 s` bound
  (the JWT only gates the initial connect; LiveKit rotates refresh tokens
  in-band, so shortening does not break long calls).

### P2 — stuck-indicator / ghost UX + infra (`fix(chat)`, `fix(infra)`)
- **Call-indicator ghost-count flicker.** A transient self-nick-scoped "leaving"
  marker suppresses our own stale Muji nick on disconnect so the count decreases
  monotonically to 0 instead of bouncing 0 → N → 0; cleared on Muji catch-up or
  re-join. Other participants stay server-authoritative.
- **Preparing/echo listener leak.** `awaitPreparingEcho`/`awaitNoOtherPreparing`
  return a cancellable handle so an abandoned attempt releases its map entry +
  timer immediately.
- **Infra hardening.** Default-deny `CiliumNetworkPolicy` for the livekit
  namespace, safe chart-level resource defaults (was `resources: {}`), and
  documented single-replica HA + cert-rotation trade-offs.

### P3 — conformance & robustness polish (`fix(server)`, `fix(chat)`)
- XEP-0353 §3: `send_call_retract` type-enforces the responder's **bare** JID
  (`message_with_jmi_to_bare`), matching `send_call_propose`.
- XEP-0166 §7.3: reject duplicate `(creator, name)` `<content/>` in a `<muji/>`.
- Frontend validates the LiveKit JWT `video` grant before `room.connect`.

## Verification
- **Server:** `cargo clippy -D warnings` + `cargo fmt --check` clean on all
  changed crates; `waddle-sfu` (56), `waddle-xmpp` jingle/muji/transport suites,
  the wasm retract test, the reconcile sweep/grace/skip tests, and the
  duplicate-content tests all pass.
- **Chat:** wasm rebuilds clean for the wasm target; `knip` clean; 137 call
  tests pass, including regressions for monotonic disconnect count and
  leak-free abandoned attempts.
- **Infra:** `helm template` / `helm lint` / `kubectl kustomize` validated; the
  NetworkPolicy renders and the ExternalSecret produces two distinct keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
