### PR TITLE
feat(server,chat): client opt-in UI for rich XEP-0357 push summary (#719)

### DIFF
--- a/chat/src/components/chat/NotifyModeButton.vue
+++ b/chat/src/components/chat/NotifyModeButton.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref } from "vue";
-import { AtSign, Bell, BellOff } from "lucide-vue-next";
+import { AtSign, Bell, BellOff, Check } from "lucide-vue-next";
 import type { BrowserXmppClient, NotifyMode } from "@/lib/xmpp-client";
 import {
   effectiveNotifyMode,
@@ -48,17 +48,28 @@ const props = defineProps<{
 
 const open = ref(false);
 const submitting = ref<NotifyMode | null>(null);
+const submittingRich = ref(false);
 const errorMessage = ref<string | null>(null);
 const rootEl = ref<HTMLElement | null>(null);
 const triggerEl = ref<HTMLButtonElement | null>(null);
 const optionRefs = ref<(HTMLButtonElement | null)[]>([]);
 
 const MODES: NotifyMode[] = ["always", "on-mention", "never"];
+// Menu rows participating in arrow-key navigation: the three mode
+// radios plus the rich-payload checkbox at the end.
+const MENU_ITEM_COUNT = MODES.length + 1;
+const RICH_INDEX = MODES.length;
 
 const currentMode = computed<NotifyMode>(() => {
   const bookmark = props.store.bookmarks.value[props.roomJid];
   return effectiveNotifyMode(bookmark, props.conversationKind);
 });
+
+const richOptIn = computed<boolean>(() => props.store.getRichPayloadOptIn(props.roomJid));
+
+// Any in-flight publish (mode or opt-in) freezes the whole menu so two
+// fetch-merge-publish round-trips can't race on the same bookmark.
+const busy = computed(() => submitting.value !== null || submittingRich.value);
 
 const icon = computed(() => {
   switch (currentMode.value) {
@@ -112,7 +123,7 @@ function closeAndReturnFocus() {
 
 async function selectMode(mode: NotifyMode) {
   if (!props.client) return;
-  if (submitting.value !== null) return;
+  if (busy.value) return;
   if (mode === currentMode.value) {
     closeAndReturnFocus();
     return;
@@ -153,17 +164,55 @@ async function selectMode(mode: NotifyMode) {
   }
 }
 
+async function toggleRichPayload() {
+  if (!props.client) return;
+  if (busy.value) return;
+  submittingRich.value = true;
+  errorMessage.value = null;
+  try {
+    let result: Awaited<ReturnType<typeof props.store.setRichPayloadOptIn>>;
+    try {
+      result = await props.store.setRichPayloadOptIn(props.client, {
+        roomJid: props.roomJid,
+        optIn: !richOptIn.value,
+        kind: props.conversationKind,
+        name: props.roomName,
+      });
+    } catch (error) {
+      // Defence-in-depth, mirroring selectMode — a lower-layer
+      // regression that throws surfaces in the banner rather than
+      // leaving the toggle in a silent dead state.
+      console.warn("[NotifyModeButton] props.store.setRichPayloadOptIn threw:", error);
+      errorMessage.value = "Couldn't save the setting. Try again in a moment.";
+      return;
+    }
+    if (result === "ok") {
+      // Keep the popover open — toggling a preference is a stay-put
+      // interaction, unlike picking a mode which dismisses.
+      return;
+    }
+    if (result === "node-config-mismatch") {
+      errorMessage.value =
+        "This room's settings node was created by an older client. Ask a server admin to delete the node so Waddle can re-create it.";
+    } else {
+      errorMessage.value = "Couldn't save the setting. Try again in a moment.";
+    }
+  } finally {
+    submittingRich.value = false;
+  }
+}
+
 function onMenuKeydown(event: KeyboardEvent) {
   switch (event.key) {
     case "ArrowDown":
     case "ArrowRight":
       event.preventDefault();
-      focusOptionAt(nextMenuIndex(focusedIndex(), 1, MODES.length));
+      focusOptionAt(nextMenuIndex(focusedIndex(), 1, MENU_ITEM_COUNT));
       break;
     case "ArrowUp":
     case "ArrowLeft":
       event.preventDefault();
-      focusOptionAt(nextMenuIndex(focusedIndex(), -1, MODES.length));
+      focusOptionAt(nextMenuIndex(focusedIndex(), -1, MENU_ITEM_COUNT));
       break;
     case "Home":
       event.preventDefault();
@@ -171,7 +220,7 @@ function onMenuKeydown(event: KeyboardEvent) {
       break;
     case "End":
       event.preventDefault();
-      focusOptionAt(MODES.length - 1);
+      focusOptionAt(MENU_ITEM_COUNT - 1);
       break;
     case "Escape":
       event.preventDefault();
@@ -250,7 +299,7 @@ onUnmounted(() => {
         type="button"
         role="menuitemradio"
         :aria-checked="currentMode === mode"
-        :disabled="submitting !== null"
+        :disabled="busy"
         class="flex w-full flex-col items-start gap-0.5 rounded-md px-2 py-2 text-left hover:bg-muted focus:bg-muted focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
         :class="{ 'bg-muted/60': currentMode === mode }"
         @click="selectMode(mode)"
@@ -262,6 +311,26 @@ onUnmounted(() => {
         </div>
         <span class="type-meta text-muted-foreground">{{ NOTIFY_MODE_HINT[mode] }}</span>
       </button>
+
+      <div class="my-1 border-t border-border" role="separator" />
+      <button
+        :ref="(el) => optionRefs[RICH_INDEX] = (el as HTMLButtonElement | null)"
+        type="button"
+        role="menuitemcheckbox"
+        :aria-checked="richOptIn"
+        :disabled="busy"
+        class="flex w-full flex-col items-start gap-0.5 rounded-md px-2 py-2 text-left hover:bg-muted focus:bg-muted focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
+        :class="{ 'bg-muted/60': richOptIn }"
+        @click="toggleRichPayload"
+      >
+        <div class="flex w-full items-center justify-between">
+          <span class="type-field text-foreground">Rich notification previews</span>
+          <span v-if="submittingRich" class="type-meta text-muted-foreground">Saving…</span>
+          <Check v-else-if="richOptIn" class="h-3.5 w-3.5 text-primary" aria-hidden="true" />
+        </div>
+        <span class="type-meta text-muted-foreground">Show the sender and a message preview in push notifications for this chat.</span>
+      </button>
+
       <p
         v-if="errorMessage"
         class="type-meta mt-1 rounded-md bg-destructive/10 px-2 py-1.5 text-destructive"

--- a/chat/src/components/chat/NotifyModeButton.vue
+++ b/chat/src/components/chat/NotifyModeButton.vue
@@ -186,19 +186,22 @@ async function toggleRichPayload() {
       errorMessage.value = "Couldn't save the setting. Try again in a moment.";
       return;
     }
-    if (result === "ok") {
-      // Keep the popover open — toggling a preference is a stay-put
-      // interaction, unlike picking a mode which dismisses.
-      return;
-    }
+    // The toggle is a stay-put interaction (unlike picking a mode,
+    // which dismisses), so the popover stays open on success.
     if (result === "node-config-mismatch") {
       errorMessage.value =
         "This room's settings node was created by an older client. Ask a server admin to delete the node so Waddle can re-create it.";
-    } else {
+    } else if (result !== "ok") {
       errorMessage.value = "Couldn't save the setting. Try again in a moment.";
     }
   } finally {
     submittingRich.value = false;
+    // The toggle was `disabled` while busy, which blurs it. Now that
+    // it has re-enabled, re-land focus on it (after the DOM updates)
+    // so keyboard / AT users keep their place in the open menu.
+    if (open.value) {
+      void nextTick().then(() => focusOptionAt(RICH_INDEX));
+    }
   }
 }
 

--- a/chat/src/lib/notify-settings.ts
+++ b/chat/src/lib/notify-settings.ts
@@ -107,6 +107,21 @@ export interface NotifySettingsStore {
   ): Promise<SetModeResult>;
   /** Resolve the effective mode for `roomJid`. */
   getMode(roomJid: string, kind: ConversationKind): NotifyMode;
+  /** Resolve the Waddle rich XEP-0357 push-summary opt-in for
+   * `roomJid` from the cached bookmark. Absence — or an un-opted
+   * bookmark — is `false` (the minimal push payload). #719. */
+  getRichPayloadOptIn(roomJid: string): boolean;
+  /** Publish a new rich-payload opt-in for one conversation while
+   * preserving its current notification mode. The opt-in and the
+   * `<notify>` mode share one XEP-0402 bookmark publish (the opt-in
+   * lives in the `<advanced>` of the fallback setting), so this
+   * resolves the conversation's effective mode (via [[getMode]] with
+   * `kind`) and republishes both. Mirrors [[setMode]]'s typed
+   * outcome. #719. */
+  setRichPayloadOptIn(
+    client: BrowserXmppClient,
+    opts: { roomJid: string; optIn: boolean; kind: ConversationKind; name?: string },
+  ): Promise<SetModeResult>;
   /** Replace the cache wholesale — used by tests to set up fixtures
    * without going through the WASM client. */
   replaceAll(items: UserBookmarkItem[]): void;
@@ -194,9 +209,12 @@ export function createNotifySettingsStore(): NotifySettingsStore {
     }
   }
 
-  async function setMode(
+  // Shared fetch-merge-publish path for both the notify mode and the
+  // rich-payload opt-in — they live in the same XEP-0402 bookmark
+  // `<notify>` element and so travel in one publish. #719.
+  async function publish(
     client: BrowserXmppClient,
-    opts: { roomJid: string; mode: NotifyMode; name?: string },
+    opts: { roomJid: string; mode: NotifyMode; richPayloadOptIn: boolean; name?: string },
   ): Promise<SetModeResult> {
     // Capture the generation at call-start. If `reset()` fires
     // during the await (the user signed out / switched accounts),
@@ -233,8 +251,45 @@ export function createNotifySettingsStore(): NotifySettingsStore {
     return "error";
   }
 
+  async function setMode(
+    client: BrowserXmppClient,
+    opts: { roomJid: string; mode: NotifyMode; name?: string },
+  ): Promise<SetModeResult> {
+    // Changing the mode preserves the conversation's current rich-
+    // payload opt-in: both settings share one bookmark publish, so
+    // re-send the cached opt-in rather than letting the WASM bridge
+    // default it back to false and silently undo the user's choice.
+    // #719.
+    return publish(client, {
+      roomJid: opts.roomJid,
+      mode: opts.mode,
+      name: opts.name,
+      richPayloadOptIn: getRichPayloadOptIn(opts.roomJid),
+    });
+  }
+
+  async function setRichPayloadOptIn(
+    client: BrowserXmppClient,
+    opts: { roomJid: string; optIn: boolean; kind: ConversationKind; name?: string },
+  ): Promise<SetModeResult> {
+    // The opt-in nests in the `<advanced>` of the fallback `<notify>`
+    // setting, so flipping it republishes the conversation's current
+    // effective mode unchanged (XEP-0492 §3 default when no bookmark
+    // covers it yet). #719.
+    return publish(client, {
+      roomJid: opts.roomJid,
+      mode: getMode(opts.roomJid, opts.kind),
+      name: opts.name,
+      richPayloadOptIn: opts.optIn,
+    });
+  }
+
   function getMode(roomJid: string, kind: ConversationKind): NotifyMode {
     return effectiveNotifyMode(bookmarks.value[roomJid], kind);
+  }
+
+  function getRichPayloadOptIn(roomJid: string): boolean {
+    return bookmarks.value[roomJid]?.richPayloadOptIn ?? false;
   }
 
   function replaceAll(items: UserBookmarkItem[]): void {
@@ -247,5 +302,15 @@ export function createNotifySettingsStore(): NotifySettingsStore {
     hydrating.value = false;
   }
 
-  return { bookmarks, hydrating, hydrate, setMode, getMode, replaceAll, reset };
+  return {
+    bookmarks,
+    hydrating,
+    hydrate,
+    setMode,
+    setRichPayloadOptIn,
+    getMode,
+    getRichPayloadOptIn,
+    replaceAll,
+    reset,
+  };
 }

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -320,6 +320,11 @@ export interface UserBookmarkItem {
   name: string | null;
   autojoin: boolean;
   notifyMode: NotifyMode | null;
+  /** Waddle rich XEP-0357 push-summary opt-in, carried in the
+   * XEP-0492 §2.3 `<advanced/>` block of this conversation's
+   * `<notify/>` as `<rich-payload xmlns='urn:waddle:push:rich:0'/>`
+   * (#719). `false` is the default — the minimal push payload. */
+  richPayloadOptIn: boolean;
 }
 
 /** Typed outcome of [[BrowserXmppClient.setRoomNotificationMode]].
@@ -379,6 +384,7 @@ type XmppClientInstance = Partial<WasmClient> & CompatEmitter & {
     roomJid: string;
     mode: NotifyMode;
     name?: string;
+    richPayloadOptIn?: boolean;
   }) => Promise<SetRoomNotificationModeOutcome>;
 };
 
@@ -1728,6 +1734,9 @@ export class BrowserXmppClient {
     roomJid: string;
     mode: "always" | "on-mention" | "never";
     name?: string;
+    /** Waddle rich XEP-0357 push-summary opt-in (#719). When omitted,
+     * the WASM bridge defaults it to `false` (minimal payload). */
+    richPayloadOptIn?: boolean;
   }): Promise<SetRoomNotificationModeOutcome> {
     // Wrap the WHOLE call — including `requireConnectedXmpp()` — so
     // a reconnect/teardown race (the client instance exists but the
@@ -1746,6 +1755,7 @@ export class BrowserXmppClient {
         roomJid: opts.roomJid,
         mode: opts.mode,
         name: opts.name,
+        richPayloadOptIn: opts.richPayloadOptIn,
       })) as SetRoomNotificationModeOutcome;
       if (outcome.kind === "error") {
         console.warn("[xmpp] XEP-0492 bookmark publish rejected");

--- a/chat/tests/notify-settings-store.test.ts
+++ b/chat/tests/notify-settings-store.test.ts
@@ -22,7 +22,12 @@ import type {
 class FakeXmppClient {
   constructor(
     private bookmarks: UserBookmarkItem[],
-    public published: { roomJid: string; mode: NotifyMode; name?: string }[] = [],
+    public published: {
+      roomJid: string;
+      mode: NotifyMode;
+      name?: string;
+      richPayloadOptIn?: boolean;
+    }[] = [],
   ) {}
 
   async fetchUserBookmarks(): Promise<UserBookmarkItem[]> {
@@ -33,17 +38,29 @@ class FakeXmppClient {
     roomJid: string;
     mode: NotifyMode;
     name?: string;
+    richPayloadOptIn?: boolean;
   }): Promise<SetRoomNotificationModeOutcome> {
     this.published.push(opts);
+    // Mirror the WASM bridge: the opt-in defaults to false when the
+    // caller omits it (#719).
+    const richPayloadOptIn = opts.richPayloadOptIn ?? false;
     const updated: UserBookmarkItem = {
       jid: opts.roomJid,
       name: opts.name ?? null,
       autojoin: false,
       notifyMode: opts.mode,
+      richPayloadOptIn,
     };
     const idx = this.bookmarks.findIndex((b) => b.jid === opts.roomJid);
-    if (idx >= 0) this.bookmarks[idx] = { ...this.bookmarks[idx], notifyMode: opts.mode };
-    else this.bookmarks.push(updated);
+    if (idx >= 0) {
+      this.bookmarks[idx] = {
+        ...this.bookmarks[idx],
+        notifyMode: opts.mode,
+        richPayloadOptIn,
+      };
+    } else {
+      this.bookmarks.push(updated);
+    }
     return { kind: "ok", item: updated };
   }
 }
@@ -70,6 +87,7 @@ describe("effectiveNotifyMode", () => {
       name: null,
       autojoin: false,
       notifyMode: "never",
+      richPayloadOptIn: false,
     };
     expect(effectiveNotifyMode(bookmark, "public-group")).toBe("never");
   });
@@ -80,6 +98,7 @@ describe("effectiveNotifyMode", () => {
       name: null,
       autojoin: false,
       notifyMode: null,
+      richPayloadOptIn: false,
     };
     expect(effectiveNotifyMode(bookmark, "public-group")).toBe("on-mention");
     expect(effectiveNotifyMode(bookmark, "private-group")).toBe("always");
@@ -113,7 +132,7 @@ describe("hydrate preserves cache across reconnects (no flicker)", () => {
     const store = createNotifySettingsStore();
     // Initial hydrate.
     await store.hydrate(asClient(new FakeXmppClient([
-      { jid: "a@example.com", name: "A", autojoin: false, notifyMode: "never" },
+      { jid: "a@example.com", name: "A", autojoin: false, notifyMode: "never", richPayloadOptIn: false },
     ])));
     expect(store.bookmarks.value["a@example.com"].notifyMode).toBe("never");
 
@@ -136,8 +155,8 @@ describe("hydrate preserves cache across reconnects (no flicker)", () => {
     expect(store.bookmarks.value["a@example.com"].notifyMode).toBe("never");
 
     resolveFetch([
-      { jid: "a@example.com", name: "A", autojoin: false, notifyMode: "always" },
-      { jid: "b@example.com", name: "B", autojoin: false, notifyMode: "never" },
+      { jid: "a@example.com", name: "A", autojoin: false, notifyMode: "always", richPayloadOptIn: false },
+      { jid: "b@example.com", name: "B", autojoin: false, notifyMode: "never", richPayloadOptIn: false },
     ]);
     await pending;
     expect(store.hydrating.value).toBe(false);
@@ -150,8 +169,8 @@ describe("createNotifySettingsStore", () => {
   test("hydrate populates the cache from fetchUserBookmarks", async () => {
     const store = createNotifySettingsStore();
     const fake = new FakeXmppClient([
-      { jid: "a@example.com", name: "A", autojoin: true, notifyMode: "never" },
-      { jid: "b@example.com", name: "B", autojoin: false, notifyMode: null },
+      { jid: "a@example.com", name: "A", autojoin: true, notifyMode: "never", richPayloadOptIn: false },
+      { jid: "b@example.com", name: "B", autojoin: false, notifyMode: null, richPayloadOptIn: false },
     ]);
 
     expect(store.hydrating.value).toBe(false);
@@ -169,7 +188,7 @@ describe("createNotifySettingsStore", () => {
   test("getMode reads from the cache; falls back to default when absent", () => {
     const store = createNotifySettingsStore();
     store.replaceAll([
-      { jid: "muted@example.com", name: null, autojoin: false, notifyMode: "never" },
+      { jid: "muted@example.com", name: null, autojoin: false, notifyMode: "never", richPayloadOptIn: false },
     ]);
 
     expect(store.getMode("muted@example.com", "private-group")).toBe("never");
@@ -186,8 +205,9 @@ describe("createNotifySettingsStore", () => {
       name: "general",
     });
     expect(result).toBe("ok");
+    // No prior bookmark → the opt-in defaults to false (minimal payload).
     expect(fake.published).toEqual([
-      { roomJid: "general@example.com", mode: "on-mention", name: "general" },
+      { roomJid: "general@example.com", mode: "on-mention", name: "general", richPayloadOptIn: false },
     ]);
     expect(store.bookmarks.value["general@example.com"].notifyMode).toBe("on-mention");
   });
@@ -195,7 +215,7 @@ describe("createNotifySettingsStore", () => {
   test("setMode preserves cached entries for other rooms", async () => {
     const store = createNotifySettingsStore();
     store.replaceAll([
-      { jid: "other@example.com", name: "Other", autojoin: false, notifyMode: "always" },
+      { jid: "other@example.com", name: "Other", autojoin: false, notifyMode: "always", richPayloadOptIn: false },
     ]);
     const fake = new FakeXmppClient([]);
     await store.setMode(asClient(fake), { roomJid: "new@example.com", mode: "never" });
@@ -206,7 +226,7 @@ describe("createNotifySettingsStore", () => {
   test("setMode failure leaves the rest of the cache unchanged (round-8 P2)", async () => {
     const store = createNotifySettingsStore();
     store.replaceAll([
-      { jid: "kept@example.com", name: "Kept", autojoin: false, notifyMode: "never" },
+      { jid: "kept@example.com", name: "Kept", autojoin: false, notifyMode: "never", richPayloadOptIn: false },
     ]);
     const rejecting = {
       async fetchUserBookmarks(): Promise<UserBookmarkItem[]> {
@@ -251,7 +271,7 @@ describe("createNotifySettingsStore", () => {
     // the lifecycle handler's `void` dispatch.
     const store = createNotifySettingsStore();
     store.replaceAll([
-      { jid: "kept@example.com", name: "Kept", autojoin: false, notifyMode: "always" },
+      { jid: "kept@example.com", name: "Kept", autojoin: false, notifyMode: "always", richPayloadOptIn: false },
     ]);
     const throwing = {
       async fetchUserBookmarks(): Promise<UserBookmarkItem[]> {
@@ -289,7 +309,7 @@ describe("createNotifySettingsStore", () => {
 
     // Old account's fetch now resolves.
     resolveFetch([
-      { jid: "stale@example.com", name: "stale", autojoin: false, notifyMode: "always" },
+      { jid: "stale@example.com", name: "stale", autojoin: false, notifyMode: "always", richPayloadOptIn: false },
     ]);
     await pending;
 
@@ -322,7 +342,7 @@ describe("createNotifySettingsStore", () => {
   test("setMode-during-reset: stale publish result is discarded (round-12 P1)", async () => {
     const store = createNotifySettingsStore();
     store.replaceAll([
-      { jid: "kept@example.com", name: "Kept", autojoin: false, notifyMode: "always" },
+      { jid: "kept@example.com", name: "Kept", autojoin: false, notifyMode: "always", richPayloadOptIn: false },
     ]);
     let resolvePublish: (outcome: SetRoomNotificationModeOutcome) => void = () => {};
     const slowClient = {
@@ -345,7 +365,7 @@ describe("createNotifySettingsStore", () => {
     // Old account's publish now resolves successfully.
     resolvePublish({
       kind: "ok",
-      item: { jid: "stale@example.com", name: null, autojoin: false, notifyMode: "never" },
+      item: { jid: "stale@example.com", name: null, autojoin: false, notifyMode: "never", richPayloadOptIn: false },
     });
     await pending;
 
@@ -356,8 +376,8 @@ describe("createNotifySettingsStore", () => {
   test("reset clears the cache for logout / account-switch (round-8 P1)", async () => {
     const store = createNotifySettingsStore();
     store.replaceAll([
-      { jid: "a@example.com", name: "A", autojoin: false, notifyMode: "never" },
-      { jid: "b@example.com", name: "B", autojoin: false, notifyMode: "on-mention" },
+      { jid: "a@example.com", name: "A", autojoin: false, notifyMode: "never", richPayloadOptIn: false },
+      { jid: "b@example.com", name: "B", autojoin: false, notifyMode: "on-mention", richPayloadOptIn: false },
     ]);
     expect(Object.keys(store.bookmarks.value).length).toBe(2);
     store.reset();
@@ -387,8 +407,74 @@ describe("createNotifySettingsStore", () => {
     const second = store.hydrate(slowClient as unknown as BrowserXmppClient);
     expect(calls).toBe(1);
 
-    resolveFetch([{ jid: "x@example.com", name: "X", autojoin: false, notifyMode: "never" }]);
+    resolveFetch([
+      { jid: "x@example.com", name: "X", autojoin: false, notifyMode: "never", richPayloadOptIn: false },
+    ]);
     await Promise.all([first, second]);
     expect(calls).toBe(1);
+  });
+});
+
+describe("rich-payload opt-in (#719)", () => {
+  test("getRichPayloadOptIn defaults to false and reads the cache", () => {
+    const store = createNotifySettingsStore();
+    store.replaceAll([
+      { jid: "rich@example.com", name: "Rich", autojoin: false, notifyMode: "always", richPayloadOptIn: true },
+      { jid: "plain@example.com", name: "Plain", autojoin: false, notifyMode: "always", richPayloadOptIn: false },
+    ]);
+    expect(store.getRichPayloadOptIn("rich@example.com")).toBe(true);
+    expect(store.getRichPayloadOptIn("plain@example.com")).toBe(false);
+    // Absent bookmark — opt-out default (minimal payload).
+    expect(store.getRichPayloadOptIn("unknown@example.com")).toBe(false);
+  });
+
+  test("setRichPayloadOptIn publishes the opt-in while preserving the current mode", async () => {
+    const store = createNotifySettingsStore();
+    store.replaceAll([
+      { jid: "room@example.com", name: "Room", autojoin: false, notifyMode: "on-mention", richPayloadOptIn: false },
+    ]);
+    const fake = new FakeXmppClient([]);
+    const result = await store.setRichPayloadOptIn(asClient(fake), {
+      roomJid: "room@example.com",
+      optIn: true,
+      kind: "private-group",
+    });
+    expect(result).toBe("ok");
+    // The publish carries the EXISTING mode (on-mention), not a reset
+    // to the conversation-kind default — only the opt-in changed.
+    expect(fake.published).toEqual([
+      { roomJid: "room@example.com", mode: "on-mention", name: undefined, richPayloadOptIn: true },
+    ]);
+    expect(store.getRichPayloadOptIn("room@example.com")).toBe(true);
+    expect(store.getMode("room@example.com", "private-group")).toBe("on-mention");
+  });
+
+  test("setRichPayloadOptIn on an unknown room uses the XEP-0492 §3 default mode", async () => {
+    const store = createNotifySettingsStore();
+    const fake = new FakeXmppClient([]);
+    await store.setRichPayloadOptIn(asClient(fake), {
+      roomJid: "fresh@example.com",
+      optIn: true,
+      kind: "public-group",
+      name: "Fresh",
+    });
+    expect(fake.published).toEqual([
+      { roomJid: "fresh@example.com", mode: "on-mention", name: "Fresh", richPayloadOptIn: true },
+    ]);
+    expect(store.getRichPayloadOptIn("fresh@example.com")).toBe(true);
+  });
+
+  test("setMode preserves the existing rich-payload opt-in", async () => {
+    const store = createNotifySettingsStore();
+    store.replaceAll([
+      { jid: "room@example.com", name: "Room", autojoin: false, notifyMode: "always", richPayloadOptIn: true },
+    ]);
+    const fake = new FakeXmppClient([]);
+    await store.setMode(asClient(fake), { roomJid: "room@example.com", mode: "never" });
+    // Changing the mode MUST NOT silently drop the opt-in.
+    expect(fake.published).toEqual([
+      { roomJid: "room@example.com", mode: "never", name: undefined, richPayloadOptIn: true },
+    ]);
+    expect(store.getRichPayloadOptIn("room@example.com")).toBe(true);
   });
 });

--- a/server/crates/waddle-xmpp-client-wasm/src/client_account.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_account.rs
@@ -200,7 +200,10 @@ impl WaddleClient {
     /// * Replace the fallback `<notify/>` child via
     ///   [`merge_notify_into_extensions`] — foreign `<advanced/>`
     ///   children and identity-scoped siblings written by other
-    ///   clients are preserved verbatim (XEP-0492 §3).
+    ///   clients are preserved verbatim (XEP-0492 §3). The same call
+    ///   toggles the Waddle rich XEP-0357 push-summary opt-in
+    ///   (`options.richPayloadOptIn`, #719) inside the fallback's
+    ///   `<advanced/>`.
     /// * Publish the merged item back.
     ///
     /// Resolves to the new [`WaddleBookmarkItem`] so the chat UI can
@@ -250,8 +253,11 @@ impl WaddleClient {
             let existing = items.iter().find(|item| item.jid == room_jid);
             let existing_extensions =
                 existing.map(|item| build_extensions_wrapper(&item.extensions));
-            let merged_extensions =
-                merge_notify_into_extensions(existing_extensions.as_ref(), opts.mode);
+            let merged_extensions = merge_notify_into_extensions(
+                existing_extensions.as_ref(),
+                opts.mode,
+                opts.rich_payload_opt_in,
+            );
             let extensions_children: Vec<Element> = merged_extensions.children().cloned().collect();
 
             let merged_item = BookmarkItem {
@@ -677,21 +683,20 @@ fn build_extensions_wrapper(children: &[Element]) -> Element {
 /// `notify_mode`. Used by both `fetch_user_bookmarks` (per-item map)
 /// and `set_room_notification_mode` (response shaping).
 fn surface_bookmark(item: BookmarkItem) -> WaddleBookmarkItem {
-    let notify_mode = item.extensions.iter().find_map(|ext| {
-        if ext.is(
+    let notify = item.extensions.iter().find(|ext| {
+        ext.is(
             "notify",
             waddle_xmpp_client::xep::xep0492::NS_NOTIFICATION_SETTINGS,
-        ) {
-            read_fallback_mode(ext)
-        } else {
-            None
-        }
+        )
     });
+    let notify_mode = notify.and_then(read_fallback_mode);
+    let rich_payload_opt_in = notify.is_some_and(read_rich_payload_opt_in);
     WaddleBookmarkItem {
         jid: item.jid.to_string(),
         name: item.name,
         autojoin: item.autojoin,
         notify_mode,
+        rich_payload_opt_in,
     }
 }
 
@@ -830,5 +835,56 @@ mod tests {
     fn verify_iq_from_rejects_empty_from() {
         let err = verify_iq_from_matches_query(Some(""), "push.example.com").unwrap_err();
         assert!(err.contains("push.example.com"));
+    }
+
+    #[test]
+    fn surface_bookmark_reads_rich_payload_opt_in() {
+        // #719 — the JS-facing item exposes the XEP-0492 §2.3
+        // `<advanced><rich-payload xmlns='urn:waddle:push:rich:0'/>`
+        // opt-in alongside the fallback notify mode.
+        let extensions: Element = "<extensions xmlns='urn:xmpp:bookmarks:1'>\
+                <notify xmlns='urn:xmpp:notification-settings:1'>\
+                    <always>\
+                        <advanced xmlns='urn:xmpp:notification-settings:1'>\
+                            <rich-payload xmlns='urn:waddle:push:rich:0'/>\
+                        </advanced>\
+                    </always>\
+                </notify>\
+            </extensions>"
+            .parse()
+            .expect("valid extensions");
+        let item = BookmarkItem {
+            jid: "room@muc.example.com".parse().expect("valid jid"),
+            name: None,
+            autojoin: false,
+            nick: None,
+            password: None,
+            extensions: extensions.children().cloned().collect(),
+        };
+        let surfaced = surface_bookmark(item);
+        assert!(surfaced.rich_payload_opt_in);
+        assert_eq!(
+            surfaced.notify_mode,
+            Some(waddle_xmpp_client::xep::xep0492::NotifyMode::Always)
+        );
+    }
+
+    #[test]
+    fn surface_bookmark_opt_in_defaults_off_without_advanced() {
+        let extensions: Element = "<extensions xmlns='urn:xmpp:bookmarks:1'>\
+                <notify xmlns='urn:xmpp:notification-settings:1'><never /></notify>\
+            </extensions>"
+            .parse()
+            .expect("valid extensions");
+        let item = BookmarkItem {
+            jid: "room@muc.example.com".parse().expect("valid jid"),
+            name: None,
+            autojoin: false,
+            nick: None,
+            password: None,
+            extensions: extensions.children().cloned().collect(),
+        };
+        let surfaced = surface_bookmark(item);
+        assert!(!surfaced.rich_payload_opt_in);
     }
 }

--- a/server/crates/waddle-xmpp-client-wasm/src/client_account.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_account.rs
@@ -683,14 +683,24 @@ fn build_extensions_wrapper(children: &[Element]) -> Element {
 /// `notify_mode`. Used by both `fetch_user_bookmarks` (per-item map)
 /// and `set_room_notification_mode` (response shaping).
 fn surface_bookmark(item: BookmarkItem) -> WaddleBookmarkItem {
-    let notify = item.extensions.iter().find(|ext| {
-        ext.is(
-            "notify",
-            waddle_xmpp_client::xep::xep0492::NS_NOTIFICATION_SETTINGS,
-        )
-    });
-    let notify_mode = notify.and_then(read_fallback_mode);
-    let rich_payload_opt_in = notify.is_some_and(read_rich_payload_opt_in);
+    // A bookmark may (malformed-but-possible, folded by the merge code)
+    // carry more than one `<notify/>` sibling, and a `<notify/>` may
+    // hold only identity-scoped settings with no fallback. Scan ALL
+    // notify children rather than stopping at the first: take the first
+    // fallback mode found, and treat the opt-in as set if ANY notify
+    // sibling carries the rich-payload marker — matching how both
+    // `read_fallback_mode` and the server's `parse_rich_payload_opt_in`
+    // resolve across siblings. Round-2 PR #804 review (Codex P2).
+    let notifies = || {
+        item.extensions.iter().filter(|ext| {
+            ext.is(
+                "notify",
+                waddle_xmpp_client::xep::xep0492::NS_NOTIFICATION_SETTINGS,
+            )
+        })
+    };
+    let notify_mode = notifies().find_map(read_fallback_mode);
+    let rich_payload_opt_in = notifies().any(read_rich_payload_opt_in);
     WaddleBookmarkItem {
         jid: item.jid.to_string(),
         name: item.name,
@@ -886,5 +896,42 @@ mod tests {
         };
         let surfaced = surface_bookmark(item);
         assert!(!surfaced.rich_payload_opt_in);
+    }
+
+    #[test]
+    fn surface_bookmark_scans_past_fallbackless_notify_sibling() {
+        // Malformed-but-possible state the merge code explicitly folds:
+        // multiple <notify/> siblings. The first carries only an
+        // identity-scoped setting (no fallback, no rich marker); the
+        // user's real fallback + rich opt-in live in the second. We
+        // must scan ALL notify siblings, not stop at the first.
+        let extensions: Element = "<extensions xmlns='urn:xmpp:bookmarks:1'>\
+                <notify xmlns='urn:xmpp:notification-settings:1'>\
+                    <never identity-category='client' identity-type='pc' />\
+                </notify>\
+                <notify xmlns='urn:xmpp:notification-settings:1'>\
+                    <always>\
+                        <advanced xmlns='urn:xmpp:notification-settings:1'>\
+                            <rich-payload xmlns='urn:waddle:push:rich:0'/>\
+                        </advanced>\
+                    </always>\
+                </notify>\
+            </extensions>"
+            .parse()
+            .expect("valid extensions");
+        let item = BookmarkItem {
+            jid: "room@muc.example.com".parse().expect("valid jid"),
+            name: None,
+            autojoin: false,
+            nick: None,
+            password: None,
+            extensions: extensions.children().cloned().collect(),
+        };
+        let surfaced = surface_bookmark(item);
+        assert_eq!(
+            surfaced.notify_mode,
+            Some(waddle_xmpp_client::xep::xep0492::NotifyMode::Always)
+        );
+        assert!(surfaced.rich_payload_opt_in);
     }
 }

--- a/server/crates/waddle-xmpp-client-wasm/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/lib.rs
@@ -49,7 +49,7 @@ use waddle_xmpp_client::xep::{
     xep0402::{
         build_fetch_bookmarks_iq, build_publish_bookmark_iq, parse_bookmarks_response, BookmarkItem,
     },
-    xep0492::{merge_notify_into_extensions, read_fallback_mode},
+    xep0492::{merge_notify_into_extensions, read_fallback_mode, read_rich_payload_opt_in},
 };
 use waddle_xmpp_client::{
     AccessToken, ArchivedMessage, ClientConfig, ClientError, ClientEvent, ClientRequest,

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -799,6 +799,13 @@ pub struct WaddleBookmarkItem {
     pub name: Option<String>,
     pub autojoin: bool,
     pub notify_mode: Option<waddle_xmpp_client::xep::xep0492::NotifyMode>,
+    /// Waddle rich XEP-0357 push-summary opt-in carried in the
+    /// XEP-0492 §2.3 `<advanced/>` block of this conversation's
+    /// `<notify/>` (see
+    /// [`waddle_xmpp_client::xep::xep0492::read_rich_payload_opt_in`]).
+    /// `false` — the default and absence-of-marker case — keeps the
+    /// minimal XEP-0357 summary payload (#719).
+    pub rich_payload_opt_in: bool,
 }
 
 /// JS-facing tagged outcome of `WaddleClient::set_room_notification_mode`.
@@ -852,6 +859,14 @@ pub struct SetRoomNotificationModeOptions {
     /// bookmark its existing `name` is preserved verbatim regardless
     /// of this field.
     pub name: Option<String>,
+    /// Waddle rich XEP-0357 push-summary opt-in (#719). When `true`,
+    /// the publish writes `<advanced><rich-payload
+    /// xmlns='urn:waddle:push:rich:0'/></advanced>` under the fallback
+    /// `<notify/>` setting; when `false` it strips our marker while
+    /// preserving any foreign `<advanced/>` children. Defaults to
+    /// `false` (minimal payload) when the JS caller omits the field.
+    #[serde(default)]
+    pub rich_payload_opt_in: bool,
 }
 
 #[cfg(test)]

--- a/server/crates/waddle-xmpp-client/src/xep/xep0402.rs
+++ b/server/crates/waddle-xmpp-client/src/xep/xep0402.rs
@@ -326,7 +326,7 @@ mod tests {
 
     #[test]
     fn build_conference_round_trips_extension_children() {
-        let merged = merge_notify_into_extensions(None, NotifyMode::Never);
+        let merged = merge_notify_into_extensions(None, NotifyMode::Never, false);
         let item = BookmarkItem {
             jid: "theplay@conference.example.com".parse().unwrap(),
             name: Some("The Play".into()),

--- a/server/crates/waddle-xmpp-client/src/xep/xep0492.rs
+++ b/server/crates/waddle-xmpp-client/src/xep/xep0492.rs
@@ -280,8 +280,19 @@ fn build_merged_notify_element(
         let has_identity_attr =
             child.attr("identity-category").is_some() || child.attr("identity-type").is_some();
         if is_setting && has_identity_attr {
-            // Identity-scoped sibling — preserve verbatim.
-            identity_scoped.push(child);
+            // Identity-scoped sibling. Foreign rules are preserved
+            // verbatim (§3 ¶1), but our OWN `<rich-payload/>` marker is
+            // ours to manage: on opt-out we strip it here too, so the
+            // opt-in readers (client `read_rich_payload_opt_in` and the
+            // server `parse_rich_payload_opt_in`, both of which honor
+            // the marker on ANY setting) can't keep reporting opted-in
+            // after the user opted out. On opt-in we leave the sibling
+            // untouched — the user's opt-in is recorded on the fallback.
+            identity_scoped.push(if rich_payload_opt_in {
+                child
+            } else {
+                strip_rich_payload_from_setting(child)
+            });
         } else if is_setting {
             // No-attrs fallback (possibly more than one, in
             // malformed input). Salvage any `<advanced/>` child
@@ -365,6 +376,41 @@ fn apply_rich_payload(advanced_blocks: Vec<Element>, opt_in: bool) -> Vec<Elemen
         advanced = advanced.append(child);
     }
     vec![advanced.build()]
+}
+
+/// Return a copy of an identity-scoped setting element with our
+/// `<rich-payload xmlns='urn:waddle:push:rich:0'/>` marker removed from
+/// its `<advanced/>` child, dropping a thereby-emptied `<advanced/>`
+/// (§2.3 SHOULD NOT be empty). All foreign children — including foreign
+/// `<advanced/>` rules and the setting's `identity-*` attributes — are
+/// preserved verbatim (§3 ¶1). Used on opt-out so the marker is cleared
+/// wherever a (cross-client) writer may have placed it, keeping the
+/// write side symmetric with the read side. #719.
+fn strip_rich_payload_from_setting(setting: Element) -> Element {
+    let mut builder = Element::builder(setting.name(), setting.ns());
+    for ((ns, name), value) in setting.attrs().iter() {
+        builder = builder.attr_ns(ns.clone(), name.clone(), value);
+    }
+    for child in setting.children() {
+        if child.is("advanced", NS_NOTIFICATION_SETTINGS) {
+            let kept: Vec<Element> = child
+                .children()
+                .filter(|grandchild| !grandchild.is("rich-payload", NS_PUSH_RICH_PAYLOAD))
+                .cloned()
+                .collect();
+            if kept.is_empty() {
+                continue;
+            }
+            let mut advanced = Element::builder("advanced", NS_NOTIFICATION_SETTINGS);
+            for grandchild in kept {
+                advanced = advanced.append(grandchild);
+            }
+            builder = builder.append(advanced.build());
+        } else {
+            builder = builder.append(child.clone());
+        }
+    }
+    builder.build()
 }
 
 fn sort_key(el: &Element) -> (u8, Option<&str>, Option<&str>) {
@@ -863,6 +909,82 @@ mod tests {
             .filter(|c| c.is("rich-payload", NS_PUSH_RICH_PAYLOAD))
             .count();
         assert_eq!(rich_count, 1);
+    }
+
+    #[test]
+    fn opt_out_strips_rich_payload_from_identity_scoped_setting() {
+        // Cross-client robustness: a `<rich-payload/>` marker placed on
+        // an identity-scoped setting by another writer must also be
+        // cleared on opt-out, since both the client reader and the
+        // server `parse_rich_payload_opt_in` honor the marker on ANY
+        // setting — otherwise the opt-out would be a silent no-op and
+        // the UI checkbox would snap back on. The setting's foreign
+        // `<weekend/>` rule and identity attrs are preserved (§3 ¶1).
+        let extensions_xml = "<extensions xmlns='urn:xmpp:bookmarks:1'>\
+                    <notify xmlns='urn:xmpp:notification-settings:1'>\
+                        <always />\
+                        <never identity-category='client' identity-type='pc'>\
+                            <advanced xmlns='urn:xmpp:notification-settings:1'>\
+                                <weekend xmlns='custom:other-client:1'/>\
+                                <rich-payload xmlns='urn:waddle:push:rich:0'/>\
+                            </advanced>\
+                        </never>\
+                    </notify>\
+                    </extensions>";
+        let extensions: Element = extensions_xml.parse().expect("valid xml");
+        let merged = merge_notify_into_extensions(Some(&extensions), NotifyMode::Always, false);
+        let notify = find_notify_in_extensions(&merged).expect("notify present");
+
+        // The opt-in is now fully cleared — no setting carries it.
+        assert!(!read_rich_payload_opt_in(notify));
+        // The identity-scoped setting survives with its foreign rule
+        // and attrs intact.
+        let never = notify
+            .children()
+            .find(|c| {
+                c.name() == "never"
+                    && c.attr("identity-category") == Some("client")
+                    && c.attr("identity-type") == Some("pc")
+            })
+            .expect("identity-scoped setting preserved");
+        let advanced = never
+            .get_child("advanced", NS_NOTIFICATION_SETTINGS)
+            .expect("advanced kept for the foreign child");
+        assert!(advanced
+            .children()
+            .any(|c| c.ns() == "custom:other-client:1"));
+        assert!(!advanced.has_child("rich-payload", NS_PUSH_RICH_PAYLOAD));
+    }
+
+    #[test]
+    fn opt_in_leaves_identity_scoped_setting_verbatim() {
+        // On opt-in we record the marker on the fallback and do NOT
+        // touch identity-scoped siblings — a foreign rule there is
+        // preserved exactly.
+        let extensions_xml = "<extensions xmlns='urn:xmpp:bookmarks:1'>\
+                    <notify xmlns='urn:xmpp:notification-settings:1'>\
+                        <always />\
+                        <never identity-category='client'>\
+                            <advanced xmlns='urn:xmpp:notification-settings:1'>\
+                                <weekend xmlns='custom:other-client:1'/>\
+                            </advanced>\
+                        </never>\
+                    </notify>\
+                    </extensions>";
+        let extensions: Element = extensions_xml.parse().expect("valid xml");
+        let merged = merge_notify_into_extensions(Some(&extensions), NotifyMode::Always, true);
+        let notify = find_notify_in_extensions(&merged).expect("notify present");
+        assert!(read_rich_payload_opt_in(notify));
+        let never = notify
+            .children()
+            .find(|c| c.name() == "never" && c.attr("identity-category") == Some("client"))
+            .expect("identity-scoped setting preserved");
+        let advanced = never
+            .get_child("advanced", NS_NOTIFICATION_SETTINGS)
+            .expect("foreign advanced preserved");
+        assert!(advanced
+            .children()
+            .any(|c| c.ns() == "custom:other-client:1"));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client/src/xep/xep0492.rs
+++ b/server/crates/waddle-xmpp-client/src/xep/xep0492.rs
@@ -19,6 +19,35 @@ use minidom::Element;
 /// XEP-0492 namespace.
 pub const NS_NOTIFICATION_SETTINGS: &str = "urn:xmpp:notification-settings:1";
 
+/// Waddle rich XEP-0357 push-summary opt-in namespace.
+///
+/// Mirrors `waddle_xmpp::xep::xep0492::NS_PUSH_RICH_PAYLOAD` (the
+/// client crate keeps its own copy — it does not depend on the
+/// server `waddle-xmpp` crate). XEP-0492 §2.3 reserves the optional
+/// `<advanced/>` child for "finer-grained notification settings using
+/// custom namespaces"; `<rich-payload xmlns='urn:waddle:push:rich:0'/>`
+/// is the Waddle opt-in to a rich XEP-0357 summary carrying
+/// `last-message-sender` + `last-message-body` (#719). The read/write
+/// helpers here MUST stay byte-compatible with the server-side
+/// `parse_rich_payload_opt_in`.
+pub const NS_PUSH_RICH_PAYLOAD: &str = "urn:waddle:push:rich:0";
+
+/// Read the Waddle rich-payload opt-in from a XEP-0492 `<notify/>`.
+///
+/// Returns `true` when any setting child (fallback or identity-scoped)
+/// carries an `<advanced/>` holding a
+/// `<rich-payload xmlns='urn:waddle:push:rich:0'/>` child. Mirrors the
+/// server-side `parse_rich_payload_opt_in` so the write side here and
+/// the read side there agree on one wire shape (#719). Absence of the
+/// element is opt-out — the minimal XEP-0357 summary payload.
+pub fn read_rich_payload_opt_in(notify: &Element) -> bool {
+    notify
+        .children()
+        .filter(|child| child.ns() == NS_NOTIFICATION_SETTINGS)
+        .filter_map(|setting| setting.get_child("advanced", NS_NOTIFICATION_SETTINGS))
+        .any(|advanced| advanced.has_child("rich-payload", NS_PUSH_RICH_PAYLOAD))
+}
+
 /// Typed XEP-0492 fallback setting — the single child element under
 /// `<notify/>` carrying no `identity-*` attributes.
 ///
@@ -147,9 +176,23 @@ pub fn read_fallback_mode(notify: &Element) -> Option<NotifyMode> {
 ///   the requested mode), the `<advanced/>` child is preserved
 ///   verbatim — nothing to invalidate.
 ///
+/// * The Waddle rich XEP-0357 push-summary opt-in
+///   (`<advanced><rich-payload xmlns='urn:waddle:push:rich:0'/></advanced>`,
+///   #719) is **ours** to manage, so `rich_payload_opt_in` toggles it
+///   on the new fallback: `true` ensures exactly one `<rich-payload/>`
+///   inside the fallback's `<advanced/>`; `false` removes it. Foreign
+///   `<advanced/>` children are preserved either way (§3 ¶1 MUST NOT
+///   delete/alter unsupported advanced settings); if removing our
+///   `<rich-payload/>` leaves the `<advanced/>` empty it is dropped
+///   (§2.3 `<advanced/>` SHOULD NOT be empty).
+///
 /// The function is pure — it takes a borrowed `extensions` element
 /// and returns an owned new element.
-pub fn merge_notify_into_extensions(extensions: Option<&Element>, mode: NotifyMode) -> Element {
+pub fn merge_notify_into_extensions(
+    extensions: Option<&Element>,
+    mode: NotifyMode,
+    rich_payload_opt_in: bool,
+) -> Element {
     let mut builder = Element::builder("extensions", crate::pep::NS_BOOKMARKS);
     let mut notify_setting_children: Vec<Element> = Vec::new();
 
@@ -178,7 +221,11 @@ pub fn merge_notify_into_extensions(extensions: Option<&Element>, mode: NotifyMo
     }
 
     builder
-        .append(build_merged_notify_element(notify_setting_children, mode))
+        .append(build_merged_notify_element(
+            notify_setting_children,
+            mode,
+            rich_payload_opt_in,
+        ))
         .build()
 }
 
@@ -218,7 +265,11 @@ pub fn merge_notify_into_extensions(extensions: Option<&Element>, mode: NotifyMo
 /// (`always` → `on-mention` → `never`), with identity-scoped
 /// siblings ordered after the no-attrs fallback within each mode
 /// group — round-8 XEP reviewer P2.
-fn build_merged_notify_element(setting_children: Vec<Element>, mode: NotifyMode) -> Element {
+fn build_merged_notify_element(
+    setting_children: Vec<Element>,
+    mode: NotifyMode,
+    rich_payload_opt_in: bool,
+) -> Element {
     let mut identity_scoped: Vec<Element> = Vec::new();
     let mut preserved_advanced: Vec<Element> = Vec::new();
     let mut foreign: Vec<Element> = Vec::new();
@@ -249,9 +300,10 @@ fn build_merged_notify_element(setting_children: Vec<Element>, mode: NotifyMode)
     }
 
     // Build the single output fallback for the user's chosen mode,
-    // re-parenting any preserved `<advanced/>` children under it.
+    // re-parenting any preserved `<advanced/>` children under it and
+    // toggling the Waddle `<rich-payload/>` opt-in (#719).
     let mut new_fallback = Element::builder(mode.as_wire_name(), NS_NOTIFICATION_SETTINGS);
-    for advanced in preserved_advanced {
+    for advanced in apply_rich_payload(preserved_advanced, rich_payload_opt_in) {
         new_fallback = new_fallback.append(advanced);
     }
     let new_fallback = new_fallback.build();
@@ -275,6 +327,44 @@ fn build_merged_notify_element(setting_children: Vec<Element>, mode: NotifyMode)
         builder = builder.append(child);
     }
     builder.build()
+}
+
+/// Normalize the `<advanced/>` blocks salvaged from the prior fallback
+/// onto the new fallback, toggling the Waddle `<rich-payload/>` opt-in.
+///
+/// XEP-0492 forbids more than one `<advanced/>` per setting (the server
+/// validator rejects it), so the salvaged blocks are folded into a
+/// single `<advanced/>` whose foreign children are preserved verbatim
+/// and in order (§3 ¶1 MUST NOT delete or alter unsupported advanced
+/// settings). Our own `<rich-payload xmlns='urn:waddle:push:rich:0'/>`
+/// is stripped first (we own it) and re-added exactly once iff
+/// `opt_in`, so the function is idempotent over repeated merges. When
+/// the result would be empty the `<advanced/>` is omitted entirely
+/// (§2.3 `<advanced/>` SHOULD NOT be empty). Returns at most one
+/// element.
+fn apply_rich_payload(advanced_blocks: Vec<Element>, opt_in: bool) -> Vec<Element> {
+    let mut children: Vec<Element> = Vec::new();
+    for advanced in advanced_blocks {
+        for child in advanced.children() {
+            // Our own opt-in marker — drop here, re-add below so a
+            // repeated merge never accumulates duplicates.
+            if child.is("rich-payload", NS_PUSH_RICH_PAYLOAD) {
+                continue;
+            }
+            children.push(child.clone());
+        }
+    }
+    if opt_in {
+        children.push(Element::builder("rich-payload", NS_PUSH_RICH_PAYLOAD).build());
+    }
+    if children.is_empty() {
+        return Vec::new();
+    }
+    let mut advanced = Element::builder("advanced", NS_NOTIFICATION_SETTINGS);
+    for child in children {
+        advanced = advanced.append(child);
+    }
+    vec![advanced.build()]
 }
 
 fn sort_key(el: &Element) -> (u8, Option<&str>, Option<&str>) {
@@ -355,7 +445,7 @@ mod tests {
 
     #[test]
     fn merge_into_empty_extensions_emits_single_fallback_child() {
-        let extensions = merge_notify_into_extensions(None, NotifyMode::OnMention);
+        let extensions = merge_notify_into_extensions(None, NotifyMode::OnMention, false);
         let elem = find_notify_in_extensions(&extensions).expect("notify present");
         assert_eq!(elem.name(), "notify");
         assert_eq!(elem.ns(), NS_NOTIFICATION_SETTINGS);
@@ -388,7 +478,7 @@ mod tests {
 
     #[test]
     fn merge_inserts_notify_into_empty_extensions() {
-        let merged = merge_notify_into_extensions(None, NotifyMode::Never);
+        let merged = merge_notify_into_extensions(None, NotifyMode::Never, false);
         assert_eq!(merged.name(), "extensions");
         let notify = find_notify_in_extensions(&merged).expect("notify present");
         assert_eq!(read_fallback_mode(notify), Some(NotifyMode::Never));
@@ -403,7 +493,7 @@ mod tests {
                     </notify>\
                     </extensions>";
         let extensions: Element = extensions_xml.parse().expect("valid xml");
-        let merged = merge_notify_into_extensions(Some(&extensions), NotifyMode::OnMention);
+        let merged = merge_notify_into_extensions(Some(&extensions), NotifyMode::OnMention, false);
 
         let notify = find_notify_in_extensions(&merged).expect("notify present");
         // Identity-scoped sibling preserved verbatim.
@@ -445,7 +535,7 @@ mod tests {
                     </notify>\
                     </extensions>";
         let extensions: Element = extensions_xml.parse().expect("valid xml");
-        let merged = merge_notify_into_extensions(Some(&extensions), NotifyMode::Never);
+        let merged = merge_notify_into_extensions(Some(&extensions), NotifyMode::Never, false);
         let notify = find_notify_in_extensions(&merged).expect("notify present");
 
         assert_eq!(read_fallback_mode(notify), Some(NotifyMode::Never));
@@ -472,7 +562,7 @@ mod tests {
         // i.e. children MUST be in a namespace other than
         // `urn:xmpp:bookmarks:1`. Our writer must never produce a
         // child in the bookmarks namespace.
-        let merged = merge_notify_into_extensions(None, NotifyMode::Always);
+        let merged = merge_notify_into_extensions(None, NotifyMode::Always, false);
         for child in merged.children() {
             assert_ne!(
                 child.ns(),
@@ -504,7 +594,7 @@ mod tests {
                     </notify>\
                     </extensions>";
         let extensions: Element = extensions_xml.parse().expect("valid xml");
-        let merged = merge_notify_into_extensions(Some(&extensions), NotifyMode::OnMention);
+        let merged = merge_notify_into_extensions(Some(&extensions), NotifyMode::OnMention, false);
         let notify = find_notify_in_extensions(&merged).expect("notify present");
 
         // Exactly one no-attrs fallback element on output.
@@ -519,8 +609,12 @@ mod tests {
             .count();
         assert_eq!(fallback_count, 1);
 
-        // The single fallback carries both salvaged advanced
-        // children — no rules dropped.
+        // The single fallback carries exactly one `<advanced/>` folding
+        // both salvaged foreign children — no rules dropped. XEP-0492
+        // forbids more than one `<advanced/>` per setting (the server
+        // validator rejects it), so the rich-payload normalizer (#719)
+        // merges the two malformed-input blocks into one while
+        // preserving every foreign child verbatim (§3 ¶1).
         let fallback = notify
             .children()
             .find(|c| c.name() == "on-mention" && c.attr("identity-category").is_none())
@@ -529,16 +623,10 @@ mod tests {
             .children()
             .filter(|c| c.is("advanced", NS_NOTIFICATION_SETTINGS))
             .collect();
-        // Two `<advanced/>` blocks are kept verbatim; we don't try
-        // to merge their inner foreign children (they may not be
-        // commutative).
-        assert_eq!(advanced.len(), 2);
-        assert!(advanced
-            .iter()
-            .any(|a| a.children().any(|c| c.ns() == "custom:a:1")));
-        assert!(advanced
-            .iter()
-            .any(|a| a.children().any(|c| c.ns() == "custom:b:1")));
+        assert_eq!(advanced.len(), 1);
+        let advanced = advanced[0];
+        assert!(advanced.children().any(|c| c.ns() == "custom:a:1"));
+        assert!(advanced.children().any(|c| c.ns() == "custom:b:1"));
     }
 
     #[test]
@@ -555,7 +643,7 @@ mod tests {
                     </notify>\
                     </extensions>";
         let extensions: Element = extensions_xml.parse().expect("valid xml");
-        let merged = merge_notify_into_extensions(Some(&extensions), NotifyMode::Always);
+        let merged = merge_notify_into_extensions(Some(&extensions), NotifyMode::Always, false);
         let notify = find_notify_in_extensions(&merged).expect("notify present");
         let always_elem = notify
             .children()
@@ -587,7 +675,7 @@ mod tests {
                     </notify>\
                     </extensions>";
         let extensions: Element = extensions_xml.parse().expect("valid xml");
-        let merged = merge_notify_into_extensions(Some(&extensions), NotifyMode::Always);
+        let merged = merge_notify_into_extensions(Some(&extensions), NotifyMode::Always, false);
         let notify = find_notify_in_extensions(&merged).expect("notify present");
 
         let names: Vec<&str> = notify.children().map(|c| c.name()).collect();
@@ -611,7 +699,7 @@ mod tests {
                     </notify>\
                     </extensions>";
         let extensions: Element = extensions_xml.parse().expect("valid xml");
-        let merged = merge_notify_into_extensions(Some(&extensions), NotifyMode::OnMention);
+        let merged = merge_notify_into_extensions(Some(&extensions), NotifyMode::OnMention, false);
 
         // Exactly one `<notify/>` wrapper.
         let notify_wrappers: Vec<_> = merged
@@ -658,7 +746,7 @@ mod tests {
                     </notify>\
                     </extensions>";
         let extensions: Element = extensions_xml.parse().expect("valid xml");
-        let merged = merge_notify_into_extensions(Some(&extensions), NotifyMode::OnMention);
+        let merged = merge_notify_into_extensions(Some(&extensions), NotifyMode::OnMention, false);
 
         // Sibling extension preserved.
         assert!(merged
@@ -668,5 +756,123 @@ mod tests {
         // Notify rewritten.
         let notify = find_notify_in_extensions(&merged).expect("notify present");
         assert_eq!(read_fallback_mode(notify), Some(NotifyMode::OnMention));
+    }
+
+    #[test]
+    fn merge_with_opt_in_round_trips_rich_payload() {
+        // Tracer bullet — opting in writes the XEP-0492 §2.3
+        // `<advanced><rich-payload xmlns='urn:waddle:push:rich:0'/>`
+        // under the fallback, and the reader recovers it. This is the
+        // exact wire shape the server's `parse_rich_payload_opt_in`
+        // consumes (#719).
+        let extensions = merge_notify_into_extensions(None, NotifyMode::Always, true);
+        let notify = find_notify_in_extensions(&extensions).expect("notify present");
+        assert!(read_rich_payload_opt_in(notify));
+
+        // §2.3 shape: `<rich-payload/>` nests inside `<advanced/>`
+        // inside the fallback, not directly on the fallback.
+        let fallback = notify
+            .children()
+            .find(|c| c.name() == "always")
+            .expect("fallback present");
+        let advanced = fallback
+            .get_child("advanced", NS_NOTIFICATION_SETTINGS)
+            .expect("advanced present");
+        assert!(advanced.has_child("rich-payload", NS_PUSH_RICH_PAYLOAD));
+    }
+
+    #[test]
+    fn read_rich_payload_opt_in_false_without_advanced() {
+        let notify: Element =
+            "<notify xmlns='urn:xmpp:notification-settings:1'><always /></notify>"
+                .parse()
+                .expect("valid xml");
+        assert!(!read_rich_payload_opt_in(&notify));
+    }
+
+    #[test]
+    fn opt_out_removes_rich_payload_but_keeps_foreign_advanced() {
+        // XEP-0492 §3 ¶1 — opting out drops OUR `<rich-payload/>` but
+        // MUST NOT delete the foreign `<weekend/>` advanced setting.
+        let extensions_xml = "<extensions xmlns='urn:xmpp:bookmarks:1'>\
+                    <notify xmlns='urn:xmpp:notification-settings:1'>\
+                        <always>\
+                            <advanced xmlns='urn:xmpp:notification-settings:1'>\
+                                <weekend xmlns='custom:other-client:1'/>\
+                                <rich-payload xmlns='urn:waddle:push:rich:0'/>\
+                            </advanced>\
+                        </always>\
+                    </notify>\
+                    </extensions>";
+        let extensions: Element = extensions_xml.parse().expect("valid xml");
+        let merged = merge_notify_into_extensions(Some(&extensions), NotifyMode::Always, false);
+        let notify = find_notify_in_extensions(&merged).expect("notify present");
+
+        assert!(!read_rich_payload_opt_in(notify));
+        let advanced = notify
+            .children()
+            .find(|c| c.name() == "always")
+            .and_then(|f| f.get_child("advanced", NS_NOTIFICATION_SETTINGS))
+            .expect("advanced kept for the foreign child");
+        assert!(advanced
+            .children()
+            .any(|c| c.name() == "weekend" && c.ns() == "custom:other-client:1"));
+        assert!(!advanced.has_child("rich-payload", NS_PUSH_RICH_PAYLOAD));
+    }
+
+    #[test]
+    fn opt_out_drops_advanced_left_empty() {
+        // §2.3 `<advanced/>` SHOULD NOT be empty — when our
+        // `<rich-payload/>` was the only child, opting out removes the
+        // now-empty `<advanced/>` entirely.
+        let extensions_xml = "<extensions xmlns='urn:xmpp:bookmarks:1'>\
+                    <notify xmlns='urn:xmpp:notification-settings:1'>\
+                        <always>\
+                            <advanced xmlns='urn:xmpp:notification-settings:1'>\
+                                <rich-payload xmlns='urn:waddle:push:rich:0'/>\
+                            </advanced>\
+                        </always>\
+                    </notify>\
+                    </extensions>";
+        let extensions: Element = extensions_xml.parse().expect("valid xml");
+        let merged = merge_notify_into_extensions(Some(&extensions), NotifyMode::Always, false);
+        let notify = find_notify_in_extensions(&merged).expect("notify present");
+        let fallback = notify
+            .children()
+            .find(|c| c.name() == "always")
+            .expect("fallback present");
+        assert!(fallback
+            .get_child("advanced", NS_NOTIFICATION_SETTINGS)
+            .is_none());
+    }
+
+    #[test]
+    fn opt_in_is_idempotent() {
+        // Re-merging an already-opted-in setting MUST NOT accumulate a
+        // second `<rich-payload/>` (§3 ¶3 — no duplicate elements).
+        let once = merge_notify_into_extensions(None, NotifyMode::Always, true);
+        let twice = merge_notify_into_extensions(Some(&once), NotifyMode::Always, true);
+        let notify = find_notify_in_extensions(&twice).expect("notify present");
+        let advanced = notify
+            .children()
+            .find(|c| c.name() == "always")
+            .and_then(|f| f.get_child("advanced", NS_NOTIFICATION_SETTINGS))
+            .expect("advanced present");
+        let rich_count = advanced
+            .children()
+            .filter(|c| c.is("rich-payload", NS_PUSH_RICH_PAYLOAD))
+            .count();
+        assert_eq!(rich_count, 1);
+    }
+
+    #[test]
+    fn opt_in_carries_through_mode_change() {
+        // Changing the fallback name (always → never) while opting in
+        // re-parents the opt-in under the new fallback (§3 ¶1).
+        let always_opted = merge_notify_into_extensions(None, NotifyMode::Always, true);
+        let now_never = merge_notify_into_extensions(Some(&always_opted), NotifyMode::Never, true);
+        let notify = find_notify_in_extensions(&now_never).expect("notify present");
+        assert_eq!(read_fallback_mode(notify), Some(NotifyMode::Never));
+        assert!(read_rich_payload_opt_in(notify));
     }
 }

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -33,6 +33,10 @@ export class WaddleClient {
      * Single-step `action='execute'` carrying the `node` + `device-id`
      * fields. The Push Service marks the row inactive — no payload
      * shape returned, the caller only cares about success vs. error.
+     *
+     * Verifies the response's `from=` matches `service_jid` before
+     * returning (RFC 6120 §8.1.2.1 / §10.5 defense-in-depth — same
+     * pattern as `fetch_vapid_public_key` above).
      */
     disable_push_device(service_jid: string, node: string, device_id: string): Promise<any>;
     /**
@@ -363,7 +367,10 @@ export class WaddleClient {
      * * Replace the fallback `<notify/>` child via
      *   [`merge_notify_into_extensions`] — foreign `<advanced/>`
      *   children and identity-scoped siblings written by other
-     *   clients are preserved verbatim (XEP-0492 §3).
+     *   clients are preserved verbatim (XEP-0492 §3). The same call
+     *   toggles the Waddle rich XEP-0357 push-summary opt-in
+     *   (`options.richPayloadOptIn`, #719) inside the fallback's
+     *   `<advanced/>`.
      * * Publish the merged item back.
      *
      * Resolves to the new [`WaddleBookmarkItem`] so the chat UI can

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mprbg79w";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mprbg79w";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mprbg79w";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mprbrv0g";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mprbrv0g";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mprbrv0g";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=mprbg79w";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=mprbrv0g";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mprbrv0g";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mprbrv0g";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mprbrv0g";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mprde3zg";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mprde3zg";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mprde3zg";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=mprbrv0g";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=mprde3zg";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpq5mooo";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpq5mooo";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpq5mooo";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mprbg79w";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mprbg79w";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mprbg79w";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=mpq5mooo";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=mprbg79w";


### PR DESCRIPTION
## Summary

Completes #719 by adding the **client write path + UI** for the rich XEP-0357 push-summary opt-in. The server-side wire shape, settings projection, and T1 evaluator landed in #802; this branch lets a user *actually* turn the opt-in on for a room/channel — closing the issue's outstanding "User can opt in (UI + persistence)" acceptance criterion.

Scope is **rooms/channels only**. DMs have no XEP-0492 carrier yet (the server projection ingests the opt-in exclusively from XEP-0402 `<conference>` bookmarks, hardcoded to `ConversationKind::PrivateGroup` in `pubsub/item.rs`), so the DM rich-payload opt-in is split to #803, blocked by the #720 carrier decision.

## Conformance basis

- **XEP-0492 §2.3** — the opt-in lives in the `<advanced/>` child of the conversation's `<notify/>` fallback setting, as `<rich-payload xmlns='urn:waddle:push:rich:0'/>`. This is the exact wire shape the server's `parse_rich_payload_opt_in` already consumes (byte-compatible; verified by adversarial review).
- **XEP-0492 §3 ¶1** — "MUST NOT delete or alter the `<advanced/>` notification settings they do not support": toggling our own `<rich-payload>` preserves any foreign `<advanced>` children verbatim, on both the fallback and identity-scoped settings.
- **XEP-0492 §2.3** — "`<advanced/>` SHOULD NOT be empty": opt-out removes our `<rich-payload>` and drops the `<advanced>` wrapper if nothing else remains.
- Multiple salvaged `<advanced>` blocks fold into one (the server validator rejects >1 `<advanced>` per setting).

## What changed

1. **Rust client (`waddle-xmpp-client/src/xep/xep0492.rs`)** — `read_rich_payload_opt_in()`; `merge_notify_into_extensions` gained a `rich_payload_opt_in: bool` and add/removes our `<rich-payload>` under the fallback via `apply_rich_payload`; opt-out also strips the marker from identity-scoped settings (`strip_rich_payload_from_setting`) so the write side stays symmetric with the readers.
2. **WASM bridge (`waddle-xmpp-client-wasm`)** — `richPayloadOptIn` on `WaddleBookmarkItem` + `surface_bookmark`; threaded through `SetRoomNotificationModeOptions` (`#[serde(default)]`) into the merge.
3. **TS client (`chat/src/lib/xmpp/client.ts`)** — `richPayloadOptIn` on `UserBookmarkItem`; opt-in arg on `setRoomNotificationMode`.
4. **TS store (`chat/src/lib/notify-settings.ts`)** — shared `publish()`; `setMode` preserves the existing opt-in, `setRichPayloadOptIn` republishes the current mode with the new opt-in, `getRichPayloadOptIn()` reader.
5. **UI (`NotifyModeButton.vue`)** — a "Rich notification previews" `menuitemcheckbox` in the per-room popover, in the arrow-key nav loop, with focus restored after a successful toggle.

## Acceptance criteria (#719)

- [x] User can opt in to rich payload (UI + persistence) — **this PR**
- [x] Default remains minimal payload (#802)
- [x] Opt-in rich summary includes `last-message-sender` + `last-message-body` (#802)
- [x] `<no-store/>`/`<no-permanent-store/>` strip body even when opt-in set (#802)
- [x] Per-XEP tests assert hint precedence over opt-in (#802)

## Tests

- Rust `xep0492.rs`: opt-in round-trip + §2.3 nesting, reader negative, opt-out preserves foreign `<advanced>`, drops emptied `<advanced>`, idempotency, mode-change carry-through, identity-scoped strip-on-opt-out + leave-verbatim-on-opt-in.
- Rust `client_account.rs`: `surface_bookmark` reads/defaults the opt-in.
- TS `notify-settings-store.test.ts`: `getRichPayloadOptIn` default/read, `setRichPayloadOptIn` preserves mode, unknown-room §3 default, `setMode` preserves opt-in.

## Verification

- `cargo clippy --workspace --all-targets` clean (no warnings, no new `#[allow]`); `cargo fmt --check` clean.
- `cargo test -p waddle-xmpp-client -p waddle-xmpp-client-wasm` green (359 + 70).
- `chat`: `bunx astro check` 0 errors/0 warnings, `bunx knip` clean, `bun test` 1476 pass / 0 fail.
- Two rounds of independent adversarial review (XEP conformance / correctness / project hard-rules) converged: two P2s fixed (opt-out symmetry, toggle focus), no remaining real findings.

## Related

- Closes #719 (rooms/channels)
- Server side: #802 (merged)
- DM follow-up: #803 (blocked by #720)

🤖 Generated with [Claude Code](https://claude.com/claude-code)