### PR TITLE
fix(server): short-circuit MUC disco#info for non-MUC targets (#757)

### DIFF
--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -335,7 +335,10 @@ async fn create_websocket_state(
     let service_domains = XmppServiceDomains::new(
         &xmpp_domain,
         xmpp_config.muc_domain.as_str(),
-        &xmpp_config.spaces_jid.to_string(),
+        // `spaces` is consumed as a plain domain in disco routing
+        // (`target_to == spaces_domain`); take the domain part so a
+        // node-qualified `WADDLE_SPACES_JID` cannot break the comparison.
+        xmpp_config.spaces_jid.domain().as_str(),
     );
     let room_registry = state.room_registry.clone();
     let pubsub_storage = Arc::clone(&state.pubsub_storage);

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -329,7 +329,14 @@ async fn create_websocket_state(
     // `AppState` — both are built in `start_with_config` so admin V2
     // handlers and the WebSocket transport operate on the same handles.
     let xmpp_domain = auth_state.xmpp_domain.clone();
-    let service_domains = XmppServiceDomains::new(&xmpp_domain);
+    // #757: `muc`/`spaces` must match the registry/component domains the rest
+    // of the server is built from, honoring `WADDLE_MUC_DOMAIN` /
+    // `WADDLE_SPACES_JID`, rather than re-deriving `muc.<domain>`.
+    let service_domains = XmppServiceDomains::new(
+        &xmpp_domain,
+        xmpp_config.muc_domain.as_str(),
+        &xmpp_config.spaces_jid.to_string(),
+    );
     let room_registry = state.room_registry.clone();
     let pubsub_storage = Arc::clone(&state.pubsub_storage);
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/disco_info/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/disco_info/muc.rs
@@ -1,24 +1,68 @@
 use super::*;
 
+/// XEP-0030 routing classification for a disco#info target as seen by the
+/// MUC dispatcher.
+///
+/// The MUC handler must only consult the `RoomRegistryActor` for targets that
+/// are actually hosted on the MUC service domain. Any other target (a sibling
+/// component such as `upload.<domain>`, or a JID on a non-MUC domain) is
+/// `NotMuc` and the handler defers to the next handler **without** touching the
+/// room registry — see #757, where a wedged `RoomRegistryActor` froze
+/// disco#info for every component because the MUC handler looked rooms up
+/// unconditionally.
+#[derive(Debug, PartialEq)]
+enum MucDiscoTarget {
+    /// The MUC service JID itself (`muc.<domain>`).
+    Service,
+    /// A room hosted on the MUC service (`<node>@muc.<domain>`).
+    Room(BareJid),
+    /// Not a MUC target — the dispatcher returns `None`.
+    NotMuc,
+}
+
+/// Decide how the MUC dispatcher should treat a disco#info target, without any
+/// I/O. Pure so the routing decision is verifiable in isolation.
+fn classify_muc_disco_target(target_to: Option<&str>, muc_domain: &str) -> MucDiscoTarget {
+    if target_to == Some(muc_domain) {
+        return MucDiscoTarget::Service;
+    }
+    let Some(target) = target_to else {
+        return MucDiscoTarget::NotMuc;
+    };
+    let room_target = target.split('/').next().unwrap_or(target);
+    let Ok(room_jid) = room_target.parse::<BareJid>() else {
+        return MucDiscoTarget::NotMuc;
+    };
+    if room_jid.domain().as_str() != muc_domain {
+        return MucDiscoTarget::NotMuc;
+    }
+    MucDiscoTarget::Room(room_jid)
+}
+
 pub(super) async fn handle_muc_disco_info<'a>(
     req: &'a DiscoInfoRequest<'a>,
     state: &WebSocketState,
 ) -> Option<DiscoInfoResponse<'a>> {
-    if req.target_to == Some(req.muc_domain) {
-        let identities = vec![Identity::muc_service(Some("Waddle Chatrooms"))];
-        let mut features = vec![
-            Feature::muc(),
-            Feature::replies(),
-            Feature::new(NS_CHANNEL_SEARCH),
-        ];
-        features.extend(extension_features_for_disco(state));
-        let response = build_disco_info_response(req.request_iq, &identities, &features, None);
-        return Some(DiscoInfoResponse::iq(response));
-    }
-
-    let target = req.target_to?;
-    let room_target = target.split('/').next().unwrap_or(target);
-    let room_jid = room_target.parse::<BareJid>().ok()?;
+    // #757: only consult the RoomRegistryActor for targets actually on the
+    // MUC service domain. A sibling component (`upload.<domain>`, …) or a JID
+    // on any non-MUC domain is `NotMuc` and we defer to the next handler
+    // without any room-registry I/O — otherwise a wedged actor freezes
+    // disco#info for every component, not just MUC.
+    let room_jid = match classify_muc_disco_target(req.target_to, req.muc_domain) {
+        MucDiscoTarget::Service => {
+            let identities = vec![Identity::muc_service(Some("Waddle Chatrooms"))];
+            let mut features = vec![
+                Feature::muc(),
+                Feature::replies(),
+                Feature::new(NS_CHANNEL_SEARCH),
+            ];
+            features.extend(extension_features_for_disco(state));
+            let response = build_disco_info_response(req.request_iq, &identities, &features, None);
+            return Some(DiscoInfoResponse::iq(response));
+        }
+        MucDiscoTarget::NotMuc => return None,
+        MucDiscoTarget::Room(room_jid) => room_jid,
+    };
 
     if let Some(room_actor) = get_room_actor(state, &room_jid).await {
         let snapshot = match room_actor.ask(GetSnapshot).await {
@@ -124,4 +168,64 @@ pub(super) async fn handle_muc_disco_info<'a>(
     features.extend(extension_features_for_disco(state));
     let response = build_disco_info_response(req.request_iq, &identities, &features, None);
     Some(DiscoInfoResponse::iq(response))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{classify_muc_disco_target, MucDiscoTarget};
+
+    const MUC_DOMAIN: &str = "muc.test.local";
+
+    #[test]
+    fn bare_muc_service_domain_is_service() {
+        assert_eq!(
+            classify_muc_disco_target(Some(MUC_DOMAIN), MUC_DOMAIN),
+            MucDiscoTarget::Service
+        );
+    }
+
+    #[test]
+    fn room_on_muc_domain_is_room() {
+        let target = "general@muc.test.local";
+        assert_eq!(
+            classify_muc_disco_target(Some(target), MUC_DOMAIN),
+            MucDiscoTarget::Room(target.parse().expect("valid room jid"))
+        );
+    }
+
+    #[test]
+    fn room_with_resource_strips_to_bare_room() {
+        assert_eq!(
+            classify_muc_disco_target(Some("general@muc.test.local/alice"), MUC_DOMAIN),
+            MucDiscoTarget::Room("general@muc.test.local".parse().expect("valid room jid"))
+        );
+    }
+
+    // #757: a sibling component domain must NOT be routed through the MUC
+    // handler — otherwise its disco#info is coupled to RoomRegistryActor health.
+    #[test]
+    fn sibling_component_domain_is_not_muc() {
+        assert_eq!(
+            classify_muc_disco_target(Some("upload.test.local"), MUC_DOMAIN),
+            MucDiscoTarget::NotMuc
+        );
+    }
+
+    // #757: a node JID hosted on a non-MUC domain must not reach the room
+    // registry either — the MUC handler only owns the MUC service domain.
+    #[test]
+    fn node_jid_on_other_domain_is_not_muc() {
+        assert_eq!(
+            classify_muc_disco_target(Some("room@chat.test.local"), MUC_DOMAIN),
+            MucDiscoTarget::NotMuc
+        );
+    }
+
+    #[test]
+    fn absent_target_is_not_muc() {
+        assert_eq!(
+            classify_muc_disco_target(None, MUC_DOMAIN),
+            MucDiscoTarget::NotMuc
+        );
+    }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -15,10 +15,17 @@ pub struct XmppServiceDomains {
 }
 
 impl XmppServiceDomains {
-    pub fn new(xmpp_domain: &str) -> Self {
+    /// `muc` and `spaces` are the deployment-authoritative service domains —
+    /// overridable via `WADDLE_MUC_DOMAIN` / `WADDLE_SPACES_JID` — and MUST be
+    /// the exact values the MUC room registry and spaces component are built
+    /// from. disco#info routing compares targets against `muc` (#757); a
+    /// re-derived `muc.<domain>` would diverge from the registry under an
+    /// override and silently break room disco#info. The remaining components
+    /// have no override and are derived from `xmpp_domain`.
+    pub fn new(xmpp_domain: &str, muc: &str, spaces: &str) -> Self {
         Self {
-            muc: format!("muc.{xmpp_domain}"),
-            spaces: format!("spaces.{xmpp_domain}"),
+            muc: muc.to_string(),
+            spaces: spaces.to_string(),
             upload: format!("upload.{xmpp_domain}"),
             extensions: format!("extensions.{xmpp_domain}"),
             push: format!("push.{xmpp_domain}"),

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/misc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/misc.rs
@@ -1,14 +1,21 @@
 use super::*;
 
+// #757: the MUC disco#info router compares a target's domain against
+// `service_domains.muc`, so that value MUST equal the domain the MUC room
+// registry is built from — the deployment-authoritative `WADDLE_MUC_DOMAIN`
+// (and `WADDLE_SPACES_JID`), not a re-derived `muc.<domain>`. The remaining
+// components have no override and are still derived from the base domain.
 #[test]
-fn service_domains_use_xmpp_domain_for_all_components() {
-    let domains = XmppServiceDomains::new("waddle.social");
+fn service_domains_use_authoritative_muc_and_spaces_and_derive_the_rest() {
+    let domains =
+        XmppServiceDomains::new("waddle.social", "chat.waddle.social", "rooms.waddle.social");
 
+    assert_eq!(domains.muc, "chat.waddle.social");
+    assert_eq!(domains.spaces, "rooms.waddle.social");
     assert_eq!(domains.extensions, "extensions.waddle.social");
-    assert_eq!(domains.muc, "muc.waddle.social");
     assert_eq!(domains.push, "push.waddle.social");
-    assert_eq!(domains.spaces, "spaces.waddle.social");
     assert_eq!(domains.upload, "upload.waddle.social");
+    assert_eq!(domains.community, "community.waddle.social");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Issue

Fixes part of #757 (recommended fix #1). Related: #750 (silent-drop symptom).

## Root cause

In the disco#info dispatch chain (`disco_info.rs`), `handle_muc_disco_info`
runs **first**, and unlike every sibling component handler (which guards with
`if req.target_to != Some(req.<x>_domain) { return None }`), the MUC handler
falls through to `get_room_actor(...).await` / `is_muc_room_jid(...).await` for
**any** target that is not the bare MUC service JID — including
`upload.`, `spaces.`, `push.`, `community.`, `extensions.`, `calls.`.

Consequences:
- A wedged `RoomRegistryActor` freezes disco#info for **every** component, not
  just MUC — matching the production HAR (7 silent component disco#info drops)
  and the per-connection frame-loop stall in #757.
- It is also a XEP-0030 routing violation: the MUC entity must not attempt to
  answer disco#info for JIDs it does not host.

## Fix

Short-circuit the MUC handler so it only consults the room registry for
targets actually on the MUC domain. Implemented as a pure, unit-tested
classifier:

```rust
enum MucDiscoTarget { Service, Room(BareJid), NotMuc }
fn classify_muc_disco_target(target_to: Option<&str>, muc_domain: &str) -> MucDiscoTarget
```

`handle_muc_disco_info` becomes a `match`:
- `Service`  → MUC service identity/features
- `Room(jid)`→ existing room-actor snapshot logic (unchanged)
- `NotMuc`   → `return None` (defer to the next handler; **no actor call**)

This isolates the `RoomRegistryActor.ask()` to genuine room JIDs and is correct
independently of whatever wedges the actor.

## Source-of-truth fix (from adversarial review)

Review surfaced a latent divergence the short-circuit would have turned into a
regression: `XmppServiceDomains` re-derived `muc`/`spaces` as
`format!("muc.{domain}")` / `format!("spaces.{domain}")`, ignoring the
`WADDLE_MUC_DOMAIN` / `WADDLE_SPACES_JID` overrides — while the MUC room
registry and spaces component are built from the override-aware `XmppConfig`.
Under an override, a room target on the configured MUC domain would classify
as `NotMuc` and silently defer. `XmppServiceDomains::new` now takes the
authoritative `xmpp_config.muc_domain` / `spaces_jid`; the disco router and the
registry compare against the same domain. Components with no override
(upload/extensions/push/community) are still derived from the base domain.

Non-blocking note (separate ticket-worthy): `RouterConfig`
(`waddle-xmpp/src/routing.rs`) still re-derives `muc.`/`spaces.` but is dead
code relative to the server; left out of scope.

## Tests (TDD)

Pure classifier unit tests in `muc.rs`:
1. `target == muc_domain` → `Service`
2. `room@muc_domain` → `Room`
3. `upload.<domain>` (other component domain) → `NotMuc`
4. `room@other.domain` (room JID off the MUC domain) → `NotMuc`
5. `None` target → `NotMuc`
6. `room@muc_domain/nick` (with resource) → `Room` (resource stripped)

Plus a dedicated XEP-0030 routing integration test asserting a disco#info to
`upload.<domain>` is answered by the upload handler (proving the MUC handler
defers rather than hangs).

## Follow-ups (filed separately from #757)

- #806 — promote PR #755's per-handler disco#info traces from `debug!` to `info!`.
- #807 — instrument `RoomRegistryActor` (mailbox depth, `.ask()` latency warnings,
  bounded mailbox / circuit breaker).
- #808 — design per-IQ `spawn` in the per-connection frame loop (stanza-ordering
  concerns need design).

## Verification

- `cargo test` (server) for the new classifier + routing tests
- `cargo clippy --workspace -D warnings`
- `cargo fmt`
