### PR TITLE
fix(server): #757 IQ-wedge follow-ups — disco traces, RoomRegistry instrumentation, stanza backstop (#806, #807, #808)

### DIFF
--- a/docs/adr/008-stanza-handler-wedge-backstop.md
+++ b/docs/adr/008-stanza-handler-wedge-backstop.md
@@ -1,0 +1,233 @@
+# ADR-008: Frame-Level Stanza-Handler Wedge Backstop
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-30
+
+## Context
+
+Issue #757 documented a recurring production incident: per-connection
+IQ-handling tasks wedge. New XMPP-over-WebSocket connections complete
+SASL + resource bind, then stall before any further IQ activity — the
+web client shows an empty channel list because topology discovery never
+gets a response. A `kubectl rollout restart` clears it; it recurs after
+~3.5 hours.
+
+The per-connection frame loop awaits `handle_xmpp_frame` **inline** with
+no isolation:
+
+```text
+server/crates/waddle-server/src/server/routes/websocket/connection.rs:71
+    let mut responses = handle_xmpp_frame(&text, &domain, &state, &mut conn).await;
+```
+
+Any IQ handler that internally `.await`s a long-lived actor will, if that
+actor wedges, freeze the entire connection's frame-processing loop.
+Subsequent frames buffer at the WebSocket layer; from the outside the
+client looks stuck after bind.
+
+The #757 fix series:
+
+- **Fix 1 (#805, merged):** short-circuit MUC `disco#info` for non-MUC
+  targets, so component disco no longer couples to `RoomRegistryActor`
+  health. This removed the *specific observed* wedge trigger.
+- **Fix 2 (#806):** promote disco#info dispatch traces `debug! → info!`.
+- **Fix 3 (#807):** instrument `RoomRegistryActor` (mailbox depth, ask
+  latency, fail-fast reply timeout).
+- **Fix 4 (#808, this ADR):** the *structural* risk remains — "one slow
+  handler stalls the whole connection" for **any** future wedge source
+  (a different actor, a DB lock, a blocking call), not just the one #805
+  fixed. #808 addresses that residual, source-agnostic risk.
+
+Issue #808 was filed "design-first" because the obvious approach —
+`tokio::spawn` per IQ — introduces stanza-ordering hazards. This ADR
+records the design decision and the reasons the spawn approach was
+rejected.
+
+## Decision
+
+Wrap the per-connection **stanza dispatch** in a bounded timeout that
+acts as a coarse wedge backstop. Processing remains strictly serial; no
+single stanza can freeze the connection indefinitely.
+
+### 1. Mechanism: bounded latency, not concurrency
+
+Wrap the post-parse stanza dispatch (the `InboundFrame::Stanza` arm in
+`frame.rs`) in `tokio::time::timeout(STANZA_HANDLER_WEDGE_TIMEOUT, …)`.
+Because dispatch stays serial, **RFC 6120 §10.1 in-order processing is
+preserved for free** — there is no reordering window.
+
+We explicitly **reject** `tokio::spawn`-per-IQ isolation:
+
+- RFC 6120 §10.1 requires in-order stanza processing per stream. Naive
+  spawn-per-frame reorders responses relative to requests.
+- The frame loop owns `conn: WsConnState` single-threaded; registration,
+  XEP-0198 outbound recording, and the `<r/>` ack cadence
+  (`connection.rs:86–183`) all mutate it after dispatch returns. True
+  per-IQ spawn would require moving `conn` behind a shared lock or a
+  per-connection actor — a large, race-prone rewrite.
+- After #805 (trigger removed) and #807 (actor fails fast), the only
+  residual is "an *unknown* handler hangs *indefinitely*." A coarse
+  backstop addresses that directly; the ownership rewrite is
+  over-engineering against a now-mitigated risk.
+
+### 2. Threshold: wedge backstop, not latency SLO
+
+`const STANZA_HANDLER_WEDGE_TIMEOUT: Duration = Duration::from_secs(15)`.
+
+The backstop must sit **above the slowest legitimate handler's own
+internal budget**, so it fires only on a genuine indefinite hang. The
+slowest legitimate internal budget in-tree is profile/avatar enrichment:
+`profile::fetch::TOTAL_TIMEOUT = 10s` (`profile/fetch.rs:89`). 15s clears
+that with margin and stays well under the wasm client's own IQ timeout
+(~30s), so the synthesized error is actionable before the client gives
+up.
+
+This is deliberately a **coarse backstop**, distinct from #807's tight
+per-`.ask()` `reply_timeout` (the *fast*, cancellation-safe fail-path for
+the known actor wedge). 15s is the *catch-all* for unknown future
+sources.
+
+### 3. Conformance on elapse (RFC 6120 §8.2.3 / §8.3)
+
+The timeout wraps **stanza dispatch inside `frame.rs`** — not the opaque
+`handle_xmpp_frame` at `connection.rs:71` — specifically so the parsed
+IQ's `id`/`from`/`to` are in scope to build a conformant reply.
+
+- **IQ `get`/`set`:** RFC 6120 §8.2.3 requires exactly one `result` or
+  `error` response. On elapse we synthesize
+  `<iq type='error'><resource-constraint/></iq>`. `resource-constraint`
+  (`xmpp_parsers::stanza_error::DefinedCondition::ResourceConstraint`)
+  carries error type **`wait`** per RFC 6120 §8.3.3 — the honest signal
+  for a temporary, retryable server-side condition. Built via the typed
+  `errors.rs` constructors + `build_iq_error_xml_typed` (per the
+  CLAUDE.md XML and typed-payloads hard rules — no `format!` XML).
+  - `id`/`from`/`to` are captured **before** the IQ is moved into
+    `handle_iq_with_conn_state` (it takes the IQ by value).
+- **Message / Presence:** no response is owed; on elapse we log + emit
+  the metric and continue (dropping the timed-out work is conformant).
+- The synthesized error is returned in the `Vec<String>` response set, so
+  the existing XEP-0198 outbound recording in `connection.rs:148–152`
+  (`is_countable_stanza` matches `iq`) records it for replay
+  automatically — no special-casing.
+
+### 4. Cancellation safety
+
+`tokio::time::timeout` drops the handler future mid-`.await` on elapse.
+This is safe at the 15s backstop range:
+
+- DB writes go through `DbActor.ask(DbExecute{…})`
+  (`db/actor.rs:50–61`). The actor runs the `execute`/`commit` to
+  completion on its **own** task once the message is dequeued; dropping
+  the caller's future cancels only the *reply wait*, not the committed
+  statement. The database stays internally consistent.
+- Rust futures yield only at `.await` points, so a dropped dispatch
+  leaves `conn` structurally valid. The worst case is a multi-statement
+  handler dropped between a committed write and its follow-on fanout
+  (e.g. `roster_set`: row committed, XEP-0237 push not yet enqueued).
+  This only occurs if one of those awaits is itself hung for 15s — the
+  very wedge we are surviving — and the conformant `wait` reply tells the
+  client to retry; roster versioning heals the gap.
+
+A sub-second latency SLO was rejected precisely because it would drop
+in-flight legitimate writes routinely and demand a full
+cancellation-safety audit of every handler.
+
+### 5. Observability (all layers, OTEL-native)
+
+The wedge event is the primary diagnostic #757 lacked. On elapse:
+
+- **Log:** `warn!` at the elapse site with stable fields
+  `{ stanza_kind, id, from, to, payload_ns, timeout_secs }`. `warn`
+  (not `error`) — it is a handled, self-healing condition; surfaces at
+  prod's INFO level and rides the existing `OpenTelemetryTracingBridge`
+  into OTLP logs (`telemetry.rs:229`).
+- **Metric:** a new counter `xmpp.stanza.handler.timeout` with helper
+  `record_stanza_handler_timeout(stanza_kind, payload_ns)` in
+  `metrics.rs`, following the existing `record_actor_request_timeout`
+  pattern. Distinct axis from #807's actor-keyed metrics: this is keyed
+  by stanza kind + namespace, so we learn *which handler family* wedged.
+  Exports over OTLP via the global meter provider
+  (`telemetry.rs:193`) — no new wiring.
+- **Trace:** a `#[instrument]` span per stanza dispatch (lean fields
+  `stanza_kind`/`id`/`payload_ns`, heavy args skipped). Becomes an OTEL
+  span automatically via `tracing_opentelemetry::layer()`
+  (`telemetry.rs:223`), parented into the connection trace with the
+  browser-propagated `traceparent`. On elapse: a `timeout` span event
+  and `otel.status_code = ERROR`. Per-stanza spans also give free
+  handler-latency distribution — the SLO visibility #757 lacked.
+
+No changes to `telemetry.rs` and no new dependencies: traces, metrics,
+and logs all ride providers already initialized there.
+
+### 6. Scope guard
+
+The timeout wraps **post-parse stanza dispatch only**. Stream framing
+(`Open`/`Close`), SASL, and resource binding arms are excluded so the
+backstop never interferes with stream setup.
+
+## Relationship to #807
+
+#808's original "land #807 first" gate is **dissolved** by this design.
+That gate assumed spawn-based isolation, which would need #807's
+mailbox/latency signal to choose what to offload. The chosen
+frame-level backstop is **source-agnostic** — it reads no actor state and
+needs nothing from #807 to function or be tested. The two are
+**complementary, independent** layers that may land in any order:
+
+- **#807** — fast, specific fail-path for the *known* actor wedge
+  (per-`.ask()` `reply_timeout` → typed error in ms, no future drop).
+- **#808** — coarse, universal backstop for *unknown/future* wedge
+  sources (15s, defense-in-depth).
+
+## Testing
+
+Per the XEP custom-test-suite and TDD rules:
+
+- A `#[cfg(test)]` fault-injection sentinel forces a single stanza
+  dispatch to `std::future::pending()`, exercising the real
+  `timeout(…)` wrapper and the real conformant error-synthesis path.
+  Driven under `#[tokio::test(start_paused = true)]` with
+  `tokio::time::advance` (precedent: `push/limiter.rs`,
+  `connection_registry/tests.rs`) — deterministic, no real 15s wait.
+- A paired transparency test asserts a fast handler does **not** trip
+  the timeout and its normal response passes through unchanged.
+- Conformance assertions: timed-out IQ get/set yields
+  `<iq type='error'>` with `resource-constraint` + type `wait` and the
+  echoed `id`; timed-out message/presence yields no response frame but
+  records the metric.
+
+## Consequences
+
+**Positive**
+
+- An indefinite wedge becomes a ≤15s-bounded, observable, self-healing
+  event instead of a connection-wide silent hang requiring a pod
+  restart.
+- Strictly serial → zero stanza-ordering risk; no `conn` ownership
+  rewrite.
+- Conformant `resource-constraint`/`wait` replies; clients retry
+  correctly.
+- Full OTEL traces + metrics + logs for any residual wedge, with no new
+  telemetry plumbing.
+
+**Negative / trade-offs**
+
+- A per-stanza span raises baseline trace volume (accepted for the
+  in-context diagnostic value; fields kept lean).
+- The backstop masks rather than roots out a slow handler; the metric +
+  span are how we then find and fix the underlying cause.
+- A multi-statement handler dropped mid-sequence can leave self-healing
+  stale in-memory state (bounded, rare, retryable — see §4).
+
+## References
+
+- #757 (root incident), #805 (fix 1, merged), #806 (fix 2), #807 (fix 3)
+- RFC 6120 §8.2.3 (IQ semantics), §8.3 (stanza errors), §10.1 (in-order
+  processing)
+- `profile/fetch.rs:89` (`TOTAL_TIMEOUT` floor for the threshold)
+- `telemetry.rs` (OTEL trace/metric/log providers reused as-is)

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -8,6 +8,7 @@ mod fixed_account;
 mod health;
 mod http;
 pub(crate) mod profile_publish_route;
+mod room_registry_gauge;
 mod session_janitors;
 mod state;
 pub(crate) mod state_inventory;
@@ -162,12 +163,16 @@ pub async fn start_with_config(
             .map_err(|error| anyhow::anyhow!("Failed to initialize PubSub storage: {}", error))?;
     let pubsub_storage: Arc<dyn waddle_xmpp::pubsub::PubSubStorage> =
         pubsub_database_storage.clone();
-    let room_registry = waddle_xmpp::muc::room_registry_actor::RoomRegistryActor::spawn(
-        waddle_xmpp::muc::room_registry_actor::RoomRegistryActor::new(
-            xmpp_config.muc_domain.to_string(),
-            server_config.occupant_id_secret.clone(),
-        ),
+    // #807: spawn the registry behind the instrumented, explicitly-bounded
+    // handle (named bounded mailbox + per-request reply timeout + typed errors),
+    // and start the periodic mailbox-depth gauge. The shared graph still stores
+    // the underlying `ActorRef`, so existing call sites are unchanged.
+    let room_registry_handle = waddle_xmpp::muc::RoomRegistry::spawn(
+        xmpp_config.muc_domain.to_string(),
+        server_config.occupant_id_secret.clone(),
     );
+    room_registry_gauge::spawn(room_registry_handle.clone(), stop_token.clone());
+    let room_registry = room_registry_handle.actor_ref().clone();
 
     // Create HTTP state (shares db_pool via Arc)
     let blob_storage = crate::storage::build_blob_storage()

--- a/server/crates/waddle-server/src/server/room_registry_gauge.rs
+++ b/server/crates/waddle-server/src/server/room_registry_gauge.rs
@@ -1,0 +1,83 @@
+//! Periodic mailbox-depth gauge for the MUC `RoomRegistry` (#807).
+//!
+//! The #757 incident was a wedged registry actor with no actionable signal.
+//! Besides the per-request reply timeout in
+//! [`waddle_xmpp::muc::RoomRegistry`], this task emits the registry's mailbox
+//! depth on a fixed interval so a backlog (the leading edge of a wedge) is
+//! visible on dashboards/alerts before requests start timing out.
+
+use std::time::Duration;
+
+use tokio::time::interval;
+use tokio_util::sync::CancellationToken;
+use tracing::debug;
+use waddle_xmpp::metrics;
+use waddle_xmpp::muc::RoomRegistry;
+
+/// How often the registry mailbox depth is sampled and recorded.
+///
+/// Matches the cadence of the existing state-inventory publisher (15s): fast
+/// enough to catch a forming backlog, slow enough to be negligible overhead.
+const GAUGE_INTERVAL: Duration = Duration::from_secs(15);
+
+const ACTOR_LABEL: &str = "room_registry";
+
+/// Spawn the mailbox-depth gauge task. It records
+/// [`metrics::record_actor_mailbox_depth`] every [`GAUGE_INTERVAL`] until either
+/// `stop_token` is cancelled or the registry actor stops.
+pub(crate) fn spawn(registry: RoomRegistry, stop_token: CancellationToken) {
+    tokio::spawn(async move {
+        let mut ticker = interval(GAUGE_INTERVAL);
+        let max_capacity = registry.max_capacity();
+        loop {
+            tokio::select! {
+                _ = ticker.tick() => {
+                    if !registry.is_alive() {
+                        debug!("RoomRegistry actor stopped; ending mailbox-depth gauge");
+                        break;
+                    }
+                    if let Some(depth) = registry.mailbox_depth() {
+                        metrics::record_actor_mailbox_depth(
+                            ACTOR_LABEL,
+                            "all",
+                            depth,
+                            max_capacity,
+                        );
+                    }
+                }
+                _ = stop_token.cancelled() => break,
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use waddle_xmpp::xep::xep0421::OccupantIdSecret;
+
+    fn test_registry() -> RoomRegistry {
+        let secret = OccupantIdSecret::new(b"test-occupant-id-secret-32-bytes-long".to_vec())
+            .expect("test occupant-id secret meets length floor");
+        RoomRegistry::spawn("muc.example.com".to_string(), secret)
+    }
+
+    #[tokio::test]
+    async fn gauge_task_runs_then_stops_on_cancel() {
+        let registry = test_registry();
+        let token = CancellationToken::new();
+        spawn(registry.clone(), token.clone());
+        // Let the task reach its select! and register the interval.
+        tokio::task::yield_now().await;
+        token.cancel();
+        // The registry is still alive and usable after the gauge stops.
+        assert!(registry.is_alive());
+    }
+
+    #[tokio::test]
+    async fn gauge_reads_depth_zero_for_idle_registry() {
+        let registry = test_registry();
+        assert_eq!(registry.mailbox_depth(), Some(0));
+        assert_eq!(registry.max_capacity(), 128);
+    }
+}

--- a/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
@@ -3,6 +3,7 @@ use super::{
     replay::drain_outbound_into_replay, state::WsConnState, stream_management::sm_show_from_name,
 };
 use waddle_xmpp::muc::room_actor::LeaveOutcome;
+use waddle_xmpp::muc::RoomRegistry;
 use waddle_xmpp::xep::xep0272::Muji;
 use waddle_xmpp::xep::xep0421::OccupantIdentity;
 
@@ -476,18 +477,13 @@ pub(crate) async fn get_room_actor(
     state: &WebSocketState,
     room_jid: &BareJid,
 ) -> Option<ActorRef<RoomActor>> {
-    match state
-        .deps
-        .protocol
-        .room_registry
-        .ask(GetRoom {
-            room_jid: room_jid.clone(),
-        })
+    match RoomRegistry::wrap(state.deps.protocol.room_registry.clone())
+        .get_room(room_jid.clone())
         .await
     {
         Ok(actor) => actor,
         Err(error) => {
-            warn!(room = %room_jid, error = ?error, "Failed to get room actor");
+            warn!(room = %room_jid, error = %error, "Failed to get room actor");
             None
         }
     }
@@ -500,67 +496,52 @@ pub(crate) async fn get_or_create_room_actor(
     waddle_id: String,
     channel_id: String,
 ) -> Option<ActorRef<RoomActor>> {
-    match state
-        .deps
-        .protocol
-        .room_registry
-        .ask(GetOrCreateRoom {
-            room_jid: room_jid.clone(),
-            waddle_id,
-            channel_id,
-            config,
-        })
+    match RoomRegistry::wrap(state.deps.protocol.room_registry.clone())
+        .get_or_create_room(room_jid.clone(), waddle_id, channel_id, config)
         .await
     {
         Ok(actor) => Some(actor),
         Err(error) => {
-            warn!(room = %room_jid, error = ?error, "Failed to get or create room actor");
+            warn!(room = %room_jid, error = %error, "Failed to get or create room actor");
             None
         }
     }
 }
 
 pub(crate) async fn list_room_jids(state: &WebSocketState) -> Vec<BareJid> {
-    match state.deps.protocol.room_registry.ask(ListRooms).await {
+    match RoomRegistry::wrap(state.deps.protocol.room_registry.clone())
+        .list_rooms()
+        .await
+    {
         Ok(rooms) => rooms,
         Err(error) => {
-            warn!(error = ?error, "Failed to list room actors");
+            warn!(error = %error, "Failed to list room actors");
             Vec::new()
         }
     }
 }
 
 pub(crate) async fn is_muc_room_jid(state: &WebSocketState, room_jid: &BareJid) -> bool {
-    match state
-        .deps
-        .protocol
-        .room_registry
-        .ask(IsMucJid {
-            jid: room_jid.clone(),
-        })
+    match RoomRegistry::wrap(state.deps.protocol.room_registry.clone())
+        .is_muc_jid(room_jid.clone())
         .await
     {
         Ok(is_muc_jid) => is_muc_jid,
         Err(error) => {
-            warn!(room = %room_jid, error = ?error, "Failed to validate MUC JID");
+            warn!(room = %room_jid, error = %error, "Failed to validate MUC JID");
             false
         }
     }
 }
 
 pub(crate) async fn destroy_room_actor(state: &WebSocketState, room_jid: &BareJid) -> bool {
-    match state
-        .deps
-        .protocol
-        .room_registry
-        .ask(DestroyRoom {
-            room_jid: room_jid.clone(),
-        })
+    match RoomRegistry::wrap(state.deps.protocol.room_registry.clone())
+        .destroy_room(room_jid.clone())
         .await
     {
         Ok(destroyed) => destroyed,
         Err(error) => {
-            warn!(room = %room_jid, error = ?error, "Failed to destroy room actor");
+            warn!(room = %room_jid, error = %error, "Failed to destroy room actor");
             false
         }
     }

--- a/server/crates/waddle-server/src/server/routes/websocket/frame.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame.rs
@@ -1,5 +1,6 @@
 use super::*;
 use super::{
+    frame_backstop::{run_with_backstop, StanzaBackstop},
     parse_errors::{is_sasl_parse_failure, parse_error_responses},
     resource_binding::handle_resource_binding,
     sasl::{handle_sasl_oauthbearer, handle_sasl_scram_client_first, handle_sasl_scram_response},
@@ -140,58 +141,73 @@ pub(super) async fn handle_xmpp_frame(
                 sm_state.increment_inbound();
             }
 
-            match *stanza {
-                Stanza::Iq(iq) => {
-                    let is_bind = match &*iq {
-                        xmpp_parsers::iq::Iq::Set { payload: e, .. }
-                        | xmpp_parsers::iq::Iq::Get { payload: e, .. } => {
-                            e.ns() == waddle_xmpp::ns::BIND
-                        }
-                        _ => false,
-                    };
-                    if is_bind {
-                        return handle_resource_binding(&iq, domain, phase);
-                    }
-                    let mut iq_conn_state = handlers::iq::IqConnState {
-                        carbons_enabled,
-                        roster_interested,
-                        state_machine: state_machine.as_mut(),
-                    };
-                    handlers::iq::handle_iq_with_conn_state(
-                        *iq,
-                        domain,
-                        &muc_domain,
-                        state,
-                        authenticated_session,
-                        phase,
-                        &mut iq_conn_state,
-                    )
-                    .await
-                }
-
-                Stanza::Presence(presence) => {
-                    handlers::presence::handle_presence(
-                        presence,
-                        domain,
-                        &muc_domain,
-                        state,
-                        phase,
-                        authenticated_session,
-                    )
-                    .await
-                }
-
-                Stanza::Message(message) => {
-                    handlers::message::handle_message(
-                        message,
-                        state,
-                        phase,
-                        state_machine.as_mut(),
-                        authenticated_session.as_ref(),
-                    )
-                    .await
+            // Resource binding is stream setup, not request processing: handle
+            // it inline and return BEFORE the wedge backstop (#808 ADR-008 scope
+            // guard). It must never be subject to, or delayed by, the timeout.
+            if let Stanza::Iq(iq) = &*stanza {
+                let is_bind = matches!(
+                    &**iq,
+                    xmpp_parsers::iq::Iq::Set { payload: e, .. }
+                        | xmpp_parsers::iq::Iq::Get { payload: e, .. }
+                        if e.ns() == waddle_xmpp::ns::BIND
+                );
+                if is_bind {
+                    return handle_resource_binding(iq, domain, phase);
                 }
             }
+
+            // #808: capture the conformant-reply metadata before the stanza is
+            // moved into the dispatch future, then run dispatch under the
+            // per-connection wedge backstop. A single slow/wedged handler can no
+            // longer freeze the connection's frame loop indefinitely; on elapse
+            // an IQ get/set gets a conformant resource-constraint/wait error and
+            // message/presence are dropped (logged + metered).
+            let backstop = StanzaBackstop::capture(&stanza);
+            let dispatch = async {
+                match *stanza {
+                    Stanza::Iq(iq) => {
+                        let mut iq_conn_state = handlers::iq::IqConnState {
+                            carbons_enabled,
+                            roster_interested,
+                            state_machine: state_machine.as_mut(),
+                        };
+                        handlers::iq::handle_iq_with_conn_state(
+                            *iq,
+                            domain,
+                            &muc_domain,
+                            state,
+                            authenticated_session,
+                            phase,
+                            &mut iq_conn_state,
+                        )
+                        .await
+                    }
+
+                    Stanza::Presence(presence) => {
+                        handlers::presence::handle_presence(
+                            presence,
+                            domain,
+                            &muc_domain,
+                            state,
+                            phase,
+                            authenticated_session,
+                        )
+                        .await
+                    }
+
+                    Stanza::Message(message) => {
+                        handlers::message::handle_message(
+                            message,
+                            state,
+                            phase,
+                            state_machine.as_mut(),
+                            authenticated_session.as_ref(),
+                        )
+                        .await
+                    }
+                }
+            };
+            run_with_backstop(backstop, dispatch).await
         }
     }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/frame_backstop.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame_backstop.rs
@@ -1,0 +1,164 @@
+//! Per-connection stanza-handler **wedge backstop** (#808).
+//!
+//! Fix-4 of the #757 production incident. The per-connection frame loop awaits
+//! stanza dispatch inline; before this, a single handler that blocked forever
+//! (a wedged actor, a stuck lock) froze the whole connection — the #757
+//! symptom. This module wraps stanza dispatch in a bounded
+//! [`tokio::time::timeout`] so no single stanza can stall the connection
+//! indefinitely. Processing stays strictly serial, so RFC 6120 §10.1 in-order
+//! processing is preserved (no spawn-based concurrency — see
+//! `docs/adr/008-stanza-handler-wedge-backstop.md`).
+//!
+//! On elapse the response is **conformant** (RFC 6120 §8.2.3 / §8.3): a timed-out
+//! IQ `get`/`set` still owes exactly one reply, so we synthesize
+//! `<iq type='error'><resource-constraint/></iq>` with error type `wait` (a
+//! temporary, retryable condition). Message/Presence owe no reply, so they are
+//! dropped (logged + metered) on elapse.
+//!
+//! Observability (all OTEL-native via the existing providers): a per-dispatch
+//! `info_span!` (→ OTEL span), a `warn!` with stable fields (→ OTLP log), and
+//! the [`metrics::record_stanza_handler_timeout`] counter (→ OTLP metric).
+
+use std::future::Future;
+use std::time::Duration;
+
+use tracing::{info_span, warn, Instrument, Span};
+use waddle_xmpp::metrics;
+use waddle_xmpp::Stanza;
+
+use super::handlers::iq::errors::resource_constraint_iq_error;
+
+/// Maximum wall-clock a single stanza's dispatch may take before the backstop
+/// fires. This is a coarse *wedge* backstop, not a latency SLO: it sits above
+/// the slowest legitimate handler's own internal budget (the 10s
+/// `profile::fetch::TOTAL_TIMEOUT`) with margin, and below the wasm client's own
+/// ~30s IQ timeout so the synthesized `wait` error is actionable. Complements
+/// the tighter per-`.ask()` reply timeout in `waddle_xmpp::muc::RoomRegistry`
+/// (#807), which is the fast, specific fail-path for the known actor wedge.
+pub(super) const STANZA_HANDLER_WEDGE_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// The conformant reply addressing for a timed-out IQ `get`/`set`. The response
+/// echoes the request `id` and swaps `from`/`to` (RFC 6120 §8.2.3).
+struct IqReply {
+    id: String,
+    /// Response `from` = the request's `to`.
+    from: Option<String>,
+    /// Response `to` = the request's `from`.
+    to: Option<String>,
+}
+
+/// Captured, owned metadata for one inbound stanza: enough to build the
+/// conformant timeout reply and the diagnostic span/log without holding a borrow
+/// on the stanza (which is moved into the dispatch future).
+pub(super) struct StanzaBackstop {
+    /// `"iq"` | `"message"` | `"presence"` — the stanza kind label.
+    kind: &'static str,
+    /// The request payload namespace (empty when absent), for the metric axis.
+    payload_ns: String,
+    /// `Some` only for an IQ `get`/`set`, which owes exactly one response.
+    iq_reply: Option<IqReply>,
+    /// Per-dispatch diagnostic span; becomes an OTEL span via the global bridge.
+    span: Span,
+}
+
+impl StanzaBackstop {
+    /// Capture backstop metadata from a borrowed stanza before it is moved into
+    /// the dispatch future.
+    pub(super) fn capture(stanza: &Stanza) -> Self {
+        match stanza {
+            Stanza::Iq(iq) => {
+                let payload_ns = match &**iq {
+                    xmpp_parsers::iq::Iq::Get { payload, .. }
+                    | xmpp_parsers::iq::Iq::Set { payload, .. } => payload.ns(),
+                    _ => String::new(),
+                };
+                // Only get/set owe a response; result/error do not.
+                let iq_reply = match &**iq {
+                    xmpp_parsers::iq::Iq::Get { .. } | xmpp_parsers::iq::Iq::Set { .. } => {
+                        Some(IqReply {
+                            id: iq.id().to_string(),
+                            from: iq.to().map(|jid| jid.to_string()),
+                            to: iq.from().map(|jid| jid.to_string()),
+                        })
+                    }
+                    _ => None,
+                };
+                Self::build("iq", payload_ns, iq_reply)
+            }
+            Stanza::Presence(_) => Self::build("presence", String::new(), None),
+            Stanza::Message(_) => Self::build("message", String::new(), None),
+        }
+    }
+
+    fn build(kind: &'static str, payload_ns: String, iq_reply: Option<IqReply>) -> Self {
+        // `otel.status_code` is declared Empty and recorded as ERROR on elapse;
+        // `tracing-opentelemetry` maps that field onto the OTEL span status.
+        let span = info_span!(
+            "xmpp.stanza.dispatch",
+            stanza_kind = kind,
+            payload_ns = %payload_ns,
+            otel.status_code = tracing::field::Empty,
+        );
+        Self {
+            kind,
+            payload_ns,
+            iq_reply,
+            span,
+        }
+    }
+
+    /// Build the conformant response set for a dispatch that exceeded
+    /// [`STANZA_HANDLER_WEDGE_TIMEOUT`]: a `resource-constraint`/`wait` IQ error
+    /// for get/set, nothing for everything else. Records the timeout metric and
+    /// a `warn!`, and marks the span errored.
+    fn on_timeout(self) -> Vec<String> {
+        metrics::record_stanza_handler_timeout(self.kind, &self.payload_ns);
+        self.span.record("otel.status_code", "ERROR");
+        let _enter = self.span.enter();
+        match &self.iq_reply {
+            Some(reply) => {
+                warn!(
+                    stanza_kind = self.kind,
+                    id = %reply.id,
+                    payload_ns = %self.payload_ns,
+                    timeout_secs = STANZA_HANDLER_WEDGE_TIMEOUT.as_secs(),
+                    "stanza handler exceeded wedge backstop; returning resource-constraint"
+                );
+                vec![super::build_iq_error_xml_typed(
+                    &reply.id,
+                    reply.from.as_deref(),
+                    reply.to.as_deref(),
+                    resource_constraint_iq_error(
+                        "The server could not process this request in time; please retry.",
+                    ),
+                )]
+            }
+            None => {
+                warn!(
+                    stanza_kind = self.kind,
+                    payload_ns = %self.payload_ns,
+                    timeout_secs = STANZA_HANDLER_WEDGE_TIMEOUT.as_secs(),
+                    "stanza handler exceeded wedge backstop; dropping (no reply owed)"
+                );
+                Vec::new()
+            }
+        }
+    }
+}
+
+/// Drive a stanza's dispatch under the wedge backstop: run `dispatch` within the
+/// backstop span and the [`STANZA_HANDLER_WEDGE_TIMEOUT`]; on elapse, return the
+/// conformant timeout response instead of letting the connection hang.
+pub(super) async fn run_with_backstop<F>(backstop: StanzaBackstop, dispatch: F) -> Vec<String>
+where
+    F: Future<Output = Vec<String>>,
+{
+    let span = backstop.span.clone();
+    match tokio::time::timeout(STANZA_HANDLER_WEDGE_TIMEOUT, dispatch.instrument(span)).await {
+        Ok(responses) => responses,
+        Err(_elapsed) => backstop.on_timeout(),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/server/crates/waddle-server/src/server/routes/websocket/frame_backstop.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame_backstop.rs
@@ -66,25 +66,22 @@ impl StanzaBackstop {
     /// the dispatch future.
     pub(super) fn capture(stanza: &Stanza) -> Self {
         match stanza {
-            Stanza::Iq(iq) => {
-                let payload_ns = match &**iq {
-                    xmpp_parsers::iq::Iq::Get { payload, .. }
-                    | xmpp_parsers::iq::Iq::Set { payload, .. } => payload.ns(),
-                    _ => String::new(),
-                };
-                // Only get/set owe a response; result/error do not.
-                let iq_reply = match &**iq {
-                    xmpp_parsers::iq::Iq::Get { .. } | xmpp_parsers::iq::Iq::Set { .. } => {
-                        Some(IqReply {
-                            id: iq.id().to_string(),
-                            from: iq.to().map(|jid| jid.to_string()),
-                            to: iq.from().map(|jid| jid.to_string()),
-                        })
-                    }
-                    _ => None,
-                };
-                Self::build("iq", payload_ns, iq_reply)
-            }
+            // Only IQ `get`/`set` carry a request payload AND owe a response, so
+            // a single match keeps the namespace and the reply addressing in
+            // lockstep — result/error IQs fall through to "no reply owed".
+            Stanza::Iq(iq) => match &**iq {
+                xmpp_parsers::iq::Iq::Get { payload, .. }
+                | xmpp_parsers::iq::Iq::Set { payload, .. } => Self::build(
+                    "iq",
+                    payload.ns(),
+                    Some(IqReply {
+                        id: iq.id().to_string(),
+                        from: iq.to().map(|jid| jid.to_string()),
+                        to: iq.from().map(|jid| jid.to_string()),
+                    }),
+                ),
+                _ => Self::build("iq", String::new(), None),
+            },
             Stanza::Presence(_) => Self::build("presence", String::new(), None),
             Stanza::Message(_) => Self::build("message", String::new(), None),
         }
@@ -120,6 +117,11 @@ impl StanzaBackstop {
                 warn!(
                     stanza_kind = self.kind,
                     id = %reply.id,
+                    // ADR-008 §5 stable field set; from/to identify the affected
+                    // peer JID for grep/OTLP triage — the primary #757 gap.
+                    // (Response addressing: from = request `to`, to = request `from`.)
+                    from = ?reply.from,
+                    to = ?reply.to,
                     payload_ns = %self.payload_ns,
                     timeout_secs = STANZA_HANDLER_WEDGE_TIMEOUT.as_secs(),
                     "stanza handler exceeded wedge backstop; returning resource-constraint"

--- a/server/crates/waddle-server/src/server/routes/websocket/frame_backstop/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame_backstop/tests.rs
@@ -18,6 +18,18 @@ fn iq_get_stanza(id: &str, from: &str, to: &str) -> Stanza {
     Stanza::Iq(Box::new(iq))
 }
 
+fn iq_result_stanza(id: &str) -> Stanza {
+    // A `result` IQ is a response, not a request — it owes no reply even if it
+    // somehow reaches dispatch and times out.
+    let iq = Iq::Result {
+        id: id.to_string(),
+        from: Some("upload.example.com".parse().expect("from jid")),
+        to: Some("alice@example.com/web".parse().expect("to jid")),
+        payload: None,
+    };
+    Stanza::Iq(Box::new(iq))
+}
+
 fn message_stanza() -> Stanza {
     let to: xmpp_parsers::jid::Jid = "bob@example.com".parse().expect("to jid");
     Stanza::Message(Message::new(Some(to)))
@@ -100,6 +112,24 @@ async fn presence_timeout_yields_no_response() {
     let responses = fut.await;
 
     assert!(responses.is_empty(), "a timed-out presence owes no reply");
+}
+
+#[tokio::test(start_paused = true)]
+async fn iq_result_timeout_yields_no_response() {
+    // RFC 6120 §8.2.3: only `get`/`set` owe a response. A timed-out `result`
+    // IQ must NOT synthesize an error reply (locks the `_ => None` arm in
+    // `capture`).
+    let stanza = iq_result_stanza("ack-1");
+    let backstop = StanzaBackstop::capture(&stanza);
+
+    let fut = run_with_backstop(backstop, pending::<Vec<String>>());
+    tokio::time::advance(STANZA_HANDLER_WEDGE_TIMEOUT + Duration::from_millis(1)).await;
+    let responses = fut.await;
+
+    assert!(
+        responses.is_empty(),
+        "a timed-out IQ result owes no reply: {responses:?}"
+    );
 }
 
 #[tokio::test(start_paused = true)]

--- a/server/crates/waddle-server/src/server/routes/websocket/frame_backstop/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame_backstop/tests.rs
@@ -1,0 +1,121 @@
+use super::*;
+use std::future::pending;
+use std::time::Duration;
+use waddle_xmpp::Stanza;
+use xmpp_parsers::iq::Iq;
+use xmpp_parsers::message::Message;
+use xmpp_parsers::minidom::Element;
+use xmpp_parsers::presence::Presence;
+
+fn iq_get_stanza(id: &str, from: &str, to: &str) -> Stanza {
+    let payload = Element::builder("query", "http://jabber.org/protocol/disco#info").build();
+    let iq = Iq::Get {
+        id: id.to_string(),
+        from: Some(from.parse().expect("from jid")),
+        to: Some(to.parse().expect("to jid")),
+        payload,
+    };
+    Stanza::Iq(Box::new(iq))
+}
+
+fn message_stanza() -> Stanza {
+    let to: xmpp_parsers::jid::Jid = "bob@example.com".parse().expect("to jid");
+    Stanza::Message(Message::new(Some(to)))
+}
+
+fn presence_stanza() -> Stanza {
+    Stanza::Presence(Presence::new(xmpp_parsers::presence::Type::None))
+}
+
+#[tokio::test(start_paused = true)]
+async fn iq_get_timeout_yields_conformant_resource_constraint() {
+    let stanza = iq_get_stanza("disco-1", "alice@example.com/web", "upload.example.com");
+    let backstop = StanzaBackstop::capture(&stanza);
+
+    let mut fut = Box::pin(run_with_backstop(backstop, pending::<Vec<String>>()));
+    assert!(
+        futures::poll!(fut.as_mut()).is_pending(),
+        "must not resolve before the wedge budget elapses"
+    );
+    tokio::time::advance(STANZA_HANDLER_WEDGE_TIMEOUT + Duration::from_millis(1)).await;
+    let responses = fut.await;
+
+    assert_eq!(
+        responses.len(),
+        1,
+        "a timed-out IQ get owes exactly one reply"
+    );
+    let reply = &responses[0];
+    // minidom serializes attributes with single quotes (house style; see the
+    // existing iq.rs assertions).
+    assert!(
+        reply.contains("type='error'"),
+        "must be an IQ error: {reply}"
+    );
+    assert!(
+        reply.contains("resource-constraint"),
+        "must carry resource-constraint: {reply}"
+    );
+    assert!(
+        reply.contains("type='wait'"),
+        "resource-constraint must be a retryable wait error: {reply}"
+    );
+    assert!(
+        reply.contains("id='disco-1'"),
+        "must echo the request id: {reply}"
+    );
+    // RFC 6120 §8.2.3: from/to are swapped on the response.
+    assert!(
+        reply.contains("from='upload.example.com'"),
+        "response from = request to: {reply}"
+    );
+    assert!(
+        reply.contains("to='alice@example.com/web'"),
+        "response to = request from: {reply}"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn message_timeout_yields_no_response() {
+    let stanza = message_stanza();
+    let backstop = StanzaBackstop::capture(&stanza);
+
+    let fut = run_with_backstop(backstop, pending::<Vec<String>>());
+    tokio::time::advance(STANZA_HANDLER_WEDGE_TIMEOUT + Duration::from_millis(1)).await;
+    let responses = fut.await;
+
+    assert!(
+        responses.is_empty(),
+        "a timed-out message owes no reply: {responses:?}"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn presence_timeout_yields_no_response() {
+    let stanza = presence_stanza();
+    let backstop = StanzaBackstop::capture(&stanza);
+
+    let fut = run_with_backstop(backstop, pending::<Vec<String>>());
+    tokio::time::advance(STANZA_HANDLER_WEDGE_TIMEOUT + Duration::from_millis(1)).await;
+    let responses = fut.await;
+
+    assert!(responses.is_empty(), "a timed-out presence owes no reply");
+}
+
+#[tokio::test(start_paused = true)]
+async fn fast_dispatch_passes_through_untouched() {
+    let stanza = iq_get_stanza("disco-2", "alice@example.com/web", "example.com");
+    let backstop = StanzaBackstop::capture(&stanza);
+
+    // A handler that completes immediately must pass its response through
+    // unchanged, with no timeout reply.
+    let responses = run_with_backstop(backstop, async {
+        vec!["<iq id=\"disco-2\" type=\"result\"/>".to_string()]
+    })
+    .await;
+
+    assert_eq!(
+        responses,
+        vec!["<iq id=\"disco-2\" type=\"result\"/>".to_string()]
+    );
+}

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/disco_info.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/disco_info.rs
@@ -127,53 +127,53 @@ pub(super) async fn handle_disco_info_iq(
     };
 
     if let Some(response) = muc::handle_muc_disco_info(&request, state).await {
-        debug!(id = %ctx.id, target = %target, handler = "muc", "disco#info answered");
+        info!(id = %ctx.id, target = %target, handler = "muc", "disco#info answered");
         return disco_info_xml(response);
     }
 
     if let Some(response) = calls_mixer::handle_calls_mixer_disco_info(&request) {
-        debug!(id = %ctx.id, target = %target, handler = "calls_mixer", "disco#info answered");
+        info!(id = %ctx.id, target = %target, handler = "calls_mixer", "disco#info answered");
         return disco_info_xml(response);
     }
 
     if let Some(response) = server_info::handle_command_disco_info(&request, state).await {
-        debug!(id = %ctx.id, target = %target, handler = "commands", "disco#info answered");
+        info!(id = %ctx.id, target = %target, handler = "commands", "disco#info answered");
         return disco_info_xml(response);
     }
 
     if let Some(response) = extensions::handle_extensions_disco_info(&request, state).await {
-        debug!(id = %ctx.id, target = %target, handler = "extensions", "disco#info answered");
+        info!(id = %ctx.id, target = %target, handler = "extensions", "disco#info answered");
         return disco_info_xml(response);
     }
 
     if let Some(response) =
         spaces::handle_spaces_disco_info(&request, state, authenticated_session.as_ref()).await
     {
-        debug!(id = %ctx.id, target = %target, handler = "spaces", "disco#info answered");
+        info!(id = %ctx.id, target = %target, handler = "spaces", "disco#info answered");
         return disco_info_xml(response);
     }
 
     if let Some(response) = community::handle_community_disco_info(&request) {
-        debug!(id = %ctx.id, target = %target, handler = "community", "disco#info answered");
+        info!(id = %ctx.id, target = %target, handler = "community", "disco#info answered");
         return disco_info_xml(response);
     }
 
     if let Some(response) = services::handle_upload_disco_info(&request) {
-        debug!(id = %ctx.id, target = %target, handler = "upload", "disco#info answered");
+        info!(id = %ctx.id, target = %target, handler = "upload", "disco#info answered");
         return disco_info_xml(response);
     }
 
     if let Some(response) = services::handle_push_service_disco_info(&request, state, phase).await {
-        debug!(id = %ctx.id, target = %target, handler = "push", "disco#info answered");
+        info!(id = %ctx.id, target = %target, handler = "push", "disco#info answered");
         return disco_info_xml(response);
     }
 
     if let Some(response) = account::handle_account_disco_info(&request, state, phase).await {
-        debug!(id = %ctx.id, target = %target, handler = "account", "disco#info answered");
+        info!(id = %ctx.id, target = %target, handler = "account", "disco#info answered");
         return disco_info_xml(response);
     }
 
-    debug!(id = %ctx.id, target = %target, handler = "server_fallback", "disco#info answered");
+    info!(id = %ctx.id, target = %target, handler = "server_fallback", "disco#info answered");
     disco_info_xml(
         server_info::handle_server_disco_info(&request, state, authenticated_session.as_ref())
             .await,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/errors.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/errors.rs
@@ -232,6 +232,18 @@ mod tests {
         );
     }
 
+    #[test]
+    fn resource_constraint_typed() {
+        // #808: the wedge backstop must emit a retryable `wait` error so the
+        // client retries rather than treating the IQ as permanently rejected
+        // (RFC 6120 §8.3.3).
+        assert_round_trip(
+            resource_constraint_iq_error("nope"),
+            ErrorType::Wait,
+            DefinedCondition::ResourceConstraint,
+        );
+    }
+
     /// Wire-shape assertion: the typed helper emits the same
     /// `<iq>/<error>/<defined-condition>` shape the previous
     /// stringly-typed builder did. The exact byte-for-byte serialisation

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/errors.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/errors.rs
@@ -116,6 +116,21 @@ pub(crate) fn internal_server_error_iq_error(text: &str) -> StanzaError {
     )
 }
 
+/// `<resource-constraint/>` (wait) — the server could not service the request
+/// within its time budget (the #808 per-connection wedge backstop). RFC 6120
+/// §8.3.3 pairs `resource-constraint` with error type `wait`: a temporary,
+/// retryable condition, which is exactly what a handler that blew its budget
+/// represents. The `wait` type tells the client to retry rather than treat the
+/// request as permanently rejected.
+pub(crate) fn resource_constraint_iq_error(text: &str) -> StanzaError {
+    StanzaError::new(
+        ErrorType::Wait,
+        DefinedCondition::ResourceConstraint,
+        DEFAULT_LANG,
+        text,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
@@ -1,7 +1,7 @@
 use chrono;
 use jid::{BareJid, FullJid, Jid};
 use std::{collections::HashSet, sync::Arc};
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 use waddle_xmpp::{
     carbons::CARBONS_NS,
     commands::{CommandContext, CommandResult},

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -72,6 +72,7 @@ use waddle_xmpp::pubsub::PubSubStorage;
 mod cleanup;
 mod connection;
 mod frame;
+mod frame_backstop;
 mod interpret_loop;
 mod muc_call_sfu;
 mod outbound;

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -32,9 +32,7 @@ use waddle_xmpp::{
     mam::MamStorage,
     muc::{
         room_actor::{LeaveByRealJid, RoomActor},
-        room_registry_actor::{
-            DestroyRoom, GetOrCreateRoom, GetRoom, IsMucJid, ListRooms, RoomRegistryActor,
-        },
+        room_registry_actor::RoomRegistryActor,
         RoomConfig,
     },
     protocol::{

--- a/server/crates/waddle-server/src/server/routes/websocket/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests.rs
@@ -34,6 +34,7 @@ use xmpp_parsers::iq::{Iq, IqPayload};
 use xmpp_parsers::message::MessageType as XmppMessageType;
 
 mod broadcast;
+mod disco_trace;
 mod dispatch;
 mod frame_parsing;
 mod iq;

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/disco_trace.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/disco_trace.rs
@@ -42,7 +42,11 @@ impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
     }
 }
 
-#[tokio::test]
+// Current-thread runtime so the thread-local `set_default` subscriber stays
+// bound for the whole test: on the default multi-thread runtime the future (and
+// any work inside `handle_iq`) can hop worker threads, losing the binding and
+// making the log-capture assertion flaky.
+#[tokio::test(flavor = "current_thread")]
 async fn disco_info_answered_trace_surfaces_at_info_level() {
     // Capture only INFO-and-above so a DEBUG trace is filtered out exactly as
     // it would be in production. `set_default` binds the subscriber to this

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/disco_trace.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/disco_trace.rs
@@ -1,0 +1,91 @@
+//! #806 regression: the per-handler `disco#info answered` dispatch traces
+//! must be emitted at `INFO`, not `DEBUG`.
+//!
+//! Production runs at `INFO`. When a connection wedges (the #757 incident),
+//! these traces are the load-bearing signal for *which* subhandler (or none)
+//! answered each component target. At `DEBUG` they are filtered out in
+//! production and never surface. This test pins the level by capturing the
+//! tracing output through an `INFO`-max subscriber and asserting the trace is
+//! present.
+
+use super::super::handlers::iq::handle_iq;
+use super::super::ConnectionPhase;
+use super::create_test_websocket_state;
+use jid::FullJid;
+use std::io;
+use std::sync::{Arc, Mutex};
+
+/// Minimal in-memory [`tracing_subscriber::fmt::MakeWriter`] that captures
+/// formatted log output into a shared buffer for assertions.
+#[derive(Clone, Default)]
+struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+impl io::Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0
+            .lock()
+            .expect("capture buffer lock")
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+    type Writer = CaptureWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+#[tokio::test]
+async fn disco_info_answered_trace_surfaces_at_info_level() {
+    // Capture only INFO-and-above so a DEBUG trace is filtered out exactly as
+    // it would be in production. `set_default` binds the subscriber to this
+    // (current-thread) test's thread for the duration of the guard, so events
+    // emitted across `.await` points are captured.
+    let buf = Arc::new(Mutex::new(Vec::new()));
+    let _guard = tracing::subscriber::set_default(
+        tracing_subscriber::fmt()
+            .json()
+            .with_max_level(tracing::Level::INFO)
+            .with_writer(CaptureWriter(buf.clone()))
+            .finish(),
+    );
+
+    let state = create_test_websocket_state().await;
+    let full: FullJid = "alice@example.com/web".parse().expect("valid jid");
+    let phase = ConnectionPhase::ready(full, false);
+    let frame = r#"<iq xmlns="jabber:client" id="disco-806" type="get" to="example.com"><query xmlns="http://jabber.org/protocol/disco#info"/></iq>"#;
+
+    let responses = handle_iq(
+        frame,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &None,
+        &phase,
+    )
+    .await;
+    assert!(
+        !responses.is_empty(),
+        "server disco#info must produce a response"
+    );
+
+    let logs = String::from_utf8(buf.lock().expect("capture buffer lock").clone())
+        .expect("captured logs are valid UTF-8");
+    assert!(
+        logs.contains("disco#info answered"),
+        "#806: the per-handler disco#info trace must be emitted at INFO so it \
+         surfaces in production (which filters at INFO). Captured INFO logs:\n{logs}"
+    );
+    assert!(
+        logs.contains("\"handler\""),
+        "#806: the disco#info trace must keep its stable `handler` field for \
+         grep/OTLP. Captured INFO logs:\n{logs}"
+    );
+}

--- a/server/crates/waddle-server/src/server/state_inventory.rs
+++ b/server/crates/waddle-server/src/server/state_inventory.rs
@@ -86,7 +86,8 @@ pub struct RoomInventory {
 /// fail hard on a single hung actor.
 pub async fn collect_snapshot(ws: &WebSocketState) -> StateInventorySnapshot {
     use waddle_xmpp::muc::room_actor::IsDormant;
-    use waddle_xmpp::muc::room_registry_actor::{GetRoom, ListRooms, RoomCount};
+    use waddle_xmpp::muc::room_registry_actor::{GetRoom, ListRooms};
+    use waddle_xmpp::muc::RoomRegistry;
 
     let deps = &ws.deps;
     let auth_state = &deps.auth_state;
@@ -97,7 +98,10 @@ pub async fn collect_snapshot(ws: &WebSocketState) -> StateInventorySnapshot {
         .live_session_ids()
         .map(|ids| ids.len());
 
-    let rooms_total: usize = protocol.room_registry.ask(RoomCount).await.unwrap_or(0);
+    let rooms_total: usize = RoomRegistry::wrap(protocol.room_registry.clone())
+        .room_count()
+        .await
+        .unwrap_or(0);
     let room_list = protocol
         .room_registry
         .ask(ListRooms)

--- a/server/crates/waddle-xmpp/src/metrics.rs
+++ b/server/crates/waddle-xmpp/src/metrics.rs
@@ -134,6 +134,20 @@ pub fn actor_request_timeouts() -> Counter<u64> {
         .build()
 }
 
+/// Counter for per-stanza dispatch wedge-backstop timeouts (#808).
+///
+/// Distinct axis from [`actor_request_timeouts`] (which is keyed by actor): this
+/// counts inbound stanzas whose handler exceeded the per-connection
+/// frame-loop budget, keyed by stanza kind and payload namespace, so the
+/// namespace distribution reveals *which* handler family wedged.
+pub fn stanza_handler_timeouts() -> Counter<u64> {
+    meter()
+        .u64_counter("xmpp.stanza.handler.timeout")
+        .with_description("Inbound stanza handlers that exceeded the per-connection wedge backstop")
+        .with_unit("stanza")
+        .build()
+}
+
 /// Counter for actor restarts.
 pub fn actor_restarts() -> Counter<u64> {
     meter()
@@ -237,6 +251,18 @@ pub fn record_actor_request_timeout(actor: &str, operation: &str, message_class:
             KeyValue::new("actor", actor.to_string()),
             KeyValue::new("operation", operation.to_string()),
             KeyValue::new("class", message_class.to_string()),
+        ],
+    );
+}
+
+/// Record a per-stanza dispatch wedge-backstop timeout (#808), keyed by stanza
+/// kind (`iq`/`message`/`presence`) and the payload namespace.
+pub fn record_stanza_handler_timeout(stanza_kind: &str, payload_ns: &str) {
+    stanza_handler_timeouts().add(
+        1,
+        &[
+            KeyValue::new("kind", stanza_kind.to_string()),
+            KeyValue::new("payload_ns", payload_ns.to_string()),
         ],
     );
 }

--- a/server/crates/waddle-xmpp/src/muc/mod.rs
+++ b/server/crates/waddle-xmpp/src/muc/mod.rs
@@ -51,7 +51,7 @@ pub use room_actor::RoomActorError;
 pub use room_registry::{MucRoomRegistry, RoomHandle, RoomInfo, RoomMessage};
 pub use room_registry_actor::RoomRegistryError;
 pub use room_registry_handle::{
-    RoomRegistry, ROOM_REGISTRY_MAILBOX_CAPACITY, ROOM_REGISTRY_REPLY_TIMEOUT,
-    ROOM_REGISTRY_SLOW_ASK_WARN,
+    RoomRegistry, ROOM_REGISTRY_MAILBOX_CAPACITY, ROOM_REGISTRY_MAILBOX_TIMEOUT,
+    ROOM_REGISTRY_REPLY_TIMEOUT, ROOM_REGISTRY_SLOW_ASK_WARN,
 };
 pub use subject::{RoomSubjectTexts, SubjectState};

--- a/server/crates/waddle-xmpp/src/muc/mod.rs
+++ b/server/crates/waddle-xmpp/src/muc/mod.rs
@@ -21,6 +21,7 @@ mod room_affiliations;
 mod room_broadcast;
 pub mod room_registry;
 pub mod room_registry_actor;
+pub mod room_registry_handle;
 mod subject;
 
 pub use admin::{
@@ -49,4 +50,8 @@ pub use room::{is_remote_jid, MucRoom, Occupant, RoomConfig};
 pub use room_actor::RoomActorError;
 pub use room_registry::{MucRoomRegistry, RoomHandle, RoomInfo, RoomMessage};
 pub use room_registry_actor::RoomRegistryError;
+pub use room_registry_handle::{
+    RoomRegistry, ROOM_REGISTRY_MAILBOX_CAPACITY, ROOM_REGISTRY_REPLY_TIMEOUT,
+    ROOM_REGISTRY_SLOW_ASK_WARN,
+};
 pub use subject::{RoomSubjectTexts, SubjectState};

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -39,6 +39,18 @@ pub enum RoomRegistryError {
     RoomAlreadyExists(BareJid),
     #[error("room actor state for {0} was lost; explicit destroy/recreate is required")]
     RoomActorStateLost(BareJid),
+    /// A request to the registry actor exceeded
+    /// [`ROOM_REGISTRY_REPLY_TIMEOUT`](crate::muc::room_registry_handle::ROOM_REGISTRY_REPLY_TIMEOUT)
+    /// without a reply. Surfaced (instead of hanging the caller indefinitely)
+    /// so a wedged registry produces a visible, typed failure — the #757
+    /// production incident class.
+    #[error("room registry request timed out")]
+    Timeout,
+    /// The registry actor could not be reached (stopped, or its mailbox is
+    /// saturated/closed). Distinct from [`RoomRegistryError::Timeout`]: the
+    /// request never entered processing.
+    #[error("room registry unavailable")]
+    Unavailable,
 }
 
 impl RoomRegistryActor {
@@ -300,6 +312,27 @@ impl kameo::message::Message<RoomCount> for RoomRegistryActor {
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         self.rooms.len()
+    }
+}
+
+/// Test-only message whose handler never returns, used to deterministically
+/// exercise the [`RoomRegistry`](crate::muc::room_registry_handle::RoomRegistry)
+/// reply-timeout path (the #757 wedge) under `tokio::time` pause/advance.
+#[cfg(test)]
+pub(crate) struct HangForever;
+
+#[cfg(test)]
+impl kameo::message::Message<HangForever> for RoomRegistryActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        _msg: HangForever,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        // Park forever: the registry's single-consumer loop is blocked here,
+        // mirroring a wedged handler. The caller must rely on its reply timeout.
+        std::future::pending::<()>().await
     }
 }
 

--- a/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
@@ -304,13 +304,17 @@ impl RoomRegistry {
 }
 
 /// A short, stable reason label for [`metrics::record_actor_request_dropped`].
+///
+/// Only the transport-failure variants reach this helper: [`RoomRegistry::classify`]
+/// matches `HandlerError` and `Timeout` before its `Err(other)` arm calls this,
+/// so those map through the catch-all rather than dedicated arms (which would be
+/// dead code from the sole call site).
 fn send_error_reason<M, E>(error: &SendError<M, E>) -> &'static str {
     match error {
         SendError::ActorNotRunning(_) => "actor_not_running",
         SendError::ActorStopped => "actor_stopped",
         SendError::MailboxFull(_) => "mailbox_full",
-        SendError::HandlerError(_) => "handler_error",
-        SendError::Timeout(_) => "timeout",
+        _ => "unknown",
     }
 }
 

--- a/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
@@ -56,6 +56,17 @@ pub const ROOM_REGISTRY_MAILBOX_CAPACITY: usize = 128;
 /// coarse frame timeout would fire.
 pub const ROOM_REGISTRY_REPLY_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Hard fail-fast budget for *enqueuing* a request into the bounded mailbox.
+///
+/// `reply_timeout` only bounds the wait for the actor's reply — not the wait for
+/// free mailbox capacity. When a wedged actor's 128-slot mailbox saturates, a
+/// caller would otherwise block indefinitely on `send` before its request is
+/// even enqueued. Bounding the enqueue wait too means a saturated mailbox
+/// surfaces as a typed [`RoomRegistryError`] instead of freezing the caller.
+/// Same budget as the reply timeout; worst-case total stays below the #808 15s
+/// frame backstop.
+pub const ROOM_REGISTRY_MAILBOX_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Latency above which a single registry request is logged at `warn!` — a
 /// leading indicator of saturation before the hard [`ROOM_REGISTRY_REPLY_TIMEOUT`].
 pub const ROOM_REGISTRY_SLOW_ASK_WARN: Duration = Duration::from_millis(500);
@@ -92,6 +103,18 @@ impl RoomRegistry {
             inner,
             max_capacity,
         }
+    }
+
+    /// Wrap a shared `ActorRef` with the deployment's default mailbox capacity.
+    ///
+    /// Convenience for production call sites that hold the raw
+    /// `ActorRef<RoomRegistryActor>` from shared state and want the instrumented
+    /// typed methods (reply + mailbox timeout, typed errors, latency metrics) per
+    /// request, without threading the capacity constant through every site. The
+    /// capacity only feeds [`RoomRegistry::mailbox_depth`] (the gauge), so the
+    /// spawn-time default is correct for the ask path.
+    pub fn wrap(inner: ActorRef<RoomRegistryActor>) -> Self {
+        Self::from_actor_ref(inner, ROOM_REGISTRY_MAILBOX_CAPACITY)
     }
 
     /// The underlying actor ref, for the few call sites that still need it
@@ -138,24 +161,37 @@ impl RoomRegistry {
     where
         E: Into<RoomRegistryError>,
     {
+        // A completed round-trip (the actor processed the request and replied,
+        // with a value OR a typed handler error) is a representative latency
+        // sample; record both so a slow handler that *errors* still appears on
+        // P95/P99 dashboards. Only Timeout/transport-drop — where the actor
+        // never replied — are excluded.
+        let record_round_trip = |outcome: &str| {
+            metrics::record_actor_mailbox_latency(
+                ACTOR_LABEL,
+                operation,
+                "ask",
+                elapsed.as_secs_f64() * 1000.0,
+            );
+            if elapsed >= ROOM_REGISTRY_SLOW_ASK_WARN {
+                warn!(
+                    operation,
+                    outcome,
+                    elapsed_ms = elapsed.as_millis() as u64,
+                    "RoomRegistryActor request slow"
+                );
+            }
+        };
+
         match result {
             Ok(reply) => {
-                metrics::record_actor_mailbox_latency(
-                    ACTOR_LABEL,
-                    operation,
-                    "ask",
-                    elapsed.as_secs_f64() * 1000.0,
-                );
-                if elapsed >= ROOM_REGISTRY_SLOW_ASK_WARN {
-                    warn!(
-                        operation,
-                        elapsed_ms = elapsed.as_millis() as u64,
-                        "RoomRegistryActor request slow"
-                    );
-                }
+                record_round_trip("ok");
                 Ok(reply)
             }
-            Err(SendError::HandlerError(error)) => Err(error.into()),
+            Err(SendError::HandlerError(error)) => {
+                record_round_trip("handler_error");
+                Err(error.into())
+            }
             Err(SendError::Timeout(_)) => {
                 metrics::record_actor_request_timeout(ACTOR_LABEL, operation, "ask");
                 warn!(
@@ -207,6 +243,7 @@ macro_rules! registry_method {
             let result = self
                 .inner
                 .ask($msg)
+                .mailbox_timeout(ROOM_REGISTRY_MAILBOX_TIMEOUT)
                 .reply_timeout(ROOM_REGISTRY_REPLY_TIMEOUT)
                 .await;
             Self::classify($op, started.elapsed(), result)
@@ -297,6 +334,7 @@ impl RoomRegistry {
         let result = self
             .inner
             .ask(super::room_registry_actor::HangForever)
+            .mailbox_timeout(ROOM_REGISTRY_MAILBOX_TIMEOUT)
             .reply_timeout(ROOM_REGISTRY_REPLY_TIMEOUT)
             .await;
         Self::classify("hang_forever", started.elapsed(), result)

--- a/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
@@ -1,0 +1,318 @@
+//! Instrumented, bounded handle to the [`RoomRegistryActor`].
+//!
+//! The #757 production incident was a wedged `RoomRegistryActor`: callers that
+//! `.ask()`ed it blocked forever, freezing the per-connection frame loop with no
+//! actionable signal. This handle is fix-3 of that incident series. It wraps a
+//! plain [`ActorRef<RoomRegistryActor>`] and makes every request:
+//!
+//! - **bounded in time** — a [`ROOM_REGISTRY_REPLY_TIMEOUT`] reply timeout turns
+//!   an indefinite hang into a typed [`RoomRegistryError::Timeout`] in seconds;
+//! - **observable** — per-request latency is recorded
+//!   ([`metrics::record_actor_mailbox_latency`]) and a `warn!` fires when a
+//!   request exceeds [`ROOM_REGISTRY_SLOW_ASK_WARN`];
+//! - **typed on failure** — mailbox/transport failures map to typed
+//!   [`RoomRegistryError`] variants rather than stringly-typed diagnostics.
+//!
+//! The actor is spawned with an **explicit named bounded mailbox**
+//! ([`ROOM_REGISTRY_MAILBOX_CAPACITY`]); a saturated mailbox produces a typed
+//! error instead of unbounded growth, and the remaining capacity feeds the
+//! periodic mailbox-depth gauge.
+//!
+//! This handle is the *fast, specific* fail-path for the known actor wedge,
+//! complementary to the coarse per-stanza frame backstop (#808): see
+//! `docs/adr/008-stanza-handler-wedge-backstop.md`.
+
+use std::time::Duration;
+
+use jid::BareJid;
+use kameo::actor::{ActorRef, Spawn};
+use kameo::error::SendError;
+use kameo::mailbox;
+use tokio::time::Instant;
+use tracing::warn;
+
+use super::room_actor::RoomActor;
+use super::room_registry_actor::{
+    CreateInstantRoom, CreateRoom, DestroyRoom, GetOrCreateRoom, GetRoom, IsMucJid, ListRooms,
+    RoomCount, RoomExists, RoomRegistryActor, RoomRegistryError,
+};
+use super::RoomConfig;
+use crate::metrics;
+use crate::xep::xep0421::OccupantIdSecret;
+
+/// Explicit bounded mailbox capacity for the `RoomRegistryActor`.
+///
+/// kameo's implicit default is 64; we name it (and raise it slightly) so the
+/// value is reviewable and the depth gauge has a stable denominator. 128 gives
+/// burst headroom for reconnection storms while keeping a wedged actor's backlog
+/// bounded and observable rather than growing without limit.
+pub const ROOM_REGISTRY_MAILBOX_CAPACITY: usize = 128;
+
+/// Hard fail-fast budget for a single registry request.
+///
+/// Chosen well above normal handler latency (sub-millisecond in practice) so it
+/// never trips on healthy load, yet comfortably below the #808 per-stanza frame
+/// backstop (15s) so a wedged registry surfaces as a typed error long before the
+/// coarse frame timeout would fire.
+pub const ROOM_REGISTRY_REPLY_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Latency above which a single registry request is logged at `warn!` — a
+/// leading indicator of saturation before the hard [`ROOM_REGISTRY_REPLY_TIMEOUT`].
+pub const ROOM_REGISTRY_SLOW_ASK_WARN: Duration = Duration::from_millis(500);
+
+/// Metrics actor label for the registry (kept stable for dashboards/alerts).
+const ACTOR_LABEL: &str = "room_registry";
+
+/// Cheap-clone, instrumented handle to the MUC room registry actor.
+#[derive(Clone)]
+pub struct RoomRegistry {
+    inner: ActorRef<RoomRegistryActor>,
+    max_capacity: usize,
+}
+
+impl RoomRegistry {
+    /// Spawn the registry actor behind an explicit bounded mailbox and return an
+    /// instrumented handle to it.
+    pub fn spawn(muc_domain: String, occupant_id_secret: OccupantIdSecret) -> Self {
+        let actor = RoomRegistryActor::new(muc_domain, occupant_id_secret);
+        let inner = RoomRegistryActor::spawn_with_mailbox(
+            actor,
+            mailbox::bounded(ROOM_REGISTRY_MAILBOX_CAPACITY),
+        );
+        Self {
+            inner,
+            max_capacity: ROOM_REGISTRY_MAILBOX_CAPACITY,
+        }
+    }
+
+    /// Wrap an existing actor ref (e.g. one already stored in shared state) so
+    /// callers can use the instrumented typed methods without re-spawning.
+    pub fn from_actor_ref(inner: ActorRef<RoomRegistryActor>, max_capacity: usize) -> Self {
+        Self {
+            inner,
+            max_capacity,
+        }
+    }
+
+    /// The underlying actor ref, for the few call sites that still need it
+    /// directly (e.g. test fixtures).
+    pub fn actor_ref(&self) -> &ActorRef<RoomRegistryActor> {
+        &self.inner
+    }
+
+    /// Whether the registry actor is still running.
+    pub fn is_alive(&self) -> bool {
+        self.inner.is_alive()
+    }
+
+    /// The mailbox's configured capacity (denominator for the depth gauge).
+    pub fn max_capacity(&self) -> i64 {
+        self.max_capacity as i64
+    }
+
+    /// Current mailbox depth (queued messages), or `None` if the mailbox is
+    /// unbounded (never the case for the spawned registry). Depth is
+    /// `capacity - remaining`, where the bounded `MailboxSender` reports the
+    /// remaining free slots.
+    pub fn mailbox_depth(&self) -> Option<i64> {
+        self.inner
+            .mailbox_sender()
+            .capacity()
+            .map(|remaining| self.max_capacity().saturating_sub(remaining as i64))
+    }
+
+    /// Record latency / slow-warn on success and classify a request outcome into
+    /// a typed [`RoomRegistryError`]. `elapsed` is measured by the caller around
+    /// the `.ask(..).reply_timeout(..).await`.
+    ///
+    /// Generic over the message param `M` and handler error `E`: kameo's
+    /// `ask().reply_timeout()` yields `SendError<Msg, RoomRegistryError>` for the
+    /// `Result`-reply handlers and `SendError<Msg, Infallible>` for the plain-reply
+    /// ones, so `E: Into<RoomRegistryError>` (with the `From<Infallible>` impl
+    /// below) unifies both.
+    fn classify<R, M, E>(
+        operation: &'static str,
+        elapsed: Duration,
+        result: Result<R, SendError<M, E>>,
+    ) -> Result<R, RoomRegistryError>
+    where
+        E: Into<RoomRegistryError>,
+    {
+        match result {
+            Ok(reply) => {
+                metrics::record_actor_mailbox_latency(
+                    ACTOR_LABEL,
+                    operation,
+                    "ask",
+                    elapsed.as_secs_f64() * 1000.0,
+                );
+                if elapsed >= ROOM_REGISTRY_SLOW_ASK_WARN {
+                    warn!(
+                        operation,
+                        elapsed_ms = elapsed.as_millis() as u64,
+                        "RoomRegistryActor request slow"
+                    );
+                }
+                Ok(reply)
+            }
+            Err(SendError::HandlerError(error)) => Err(error.into()),
+            Err(SendError::Timeout(_)) => {
+                metrics::record_actor_request_timeout(ACTOR_LABEL, operation, "ask");
+                warn!(
+                    operation,
+                    timeout_ms = ROOM_REGISTRY_REPLY_TIMEOUT.as_millis() as u64,
+                    "RoomRegistryActor request timed out"
+                );
+                Err(RoomRegistryError::Timeout)
+            }
+            Err(other) => {
+                metrics::record_actor_request_dropped(
+                    ACTOR_LABEL,
+                    operation,
+                    "ask",
+                    send_error_reason(&other),
+                );
+                warn!(operation, "RoomRegistryActor request dropped");
+                Err(RoomRegistryError::Unavailable)
+            }
+        }
+    }
+}
+
+/// Plain-reply registry handlers (`bool`/`usize`/`()`) carry kameo's own
+/// [`kameo::error::Infallible`] (an uninhabited enum, distinct from
+/// `std::convert::Infallible`) as the handler-error type. This lets
+/// [`RoomRegistry::classify`] accept both those and the `Result`-reply handlers
+/// (`RoomRegistryError`) under one `E: Into<RoomRegistryError>` bound.
+impl From<kameo::error::Infallible> for RoomRegistryError {
+    fn from(never: kameo::error::Infallible) -> Self {
+        match never {}
+    }
+}
+
+/// Generates an instrumented async method per registry message: each issues the
+/// `.ask(..)` under [`ROOM_REGISTRY_REPLY_TIMEOUT`], times it, and routes the
+/// outcome through [`RoomRegistry::classify`]. Keeping this declarative avoids a
+/// generic abstraction over kameo's message-specific request builders.
+macro_rules! registry_method {
+    (
+        $(#[$meta:meta])*
+        $name:ident ( $( $arg:ident : $arg_ty:ty ),* ) -> $reply:ty,
+        $op:literal,
+        $msg:expr
+    ) => {
+        $(#[$meta])*
+        pub async fn $name(&self, $( $arg : $arg_ty ),* ) -> Result<$reply, RoomRegistryError> {
+            let started = Instant::now();
+            let result = self
+                .inner
+                .ask($msg)
+                .reply_timeout(ROOM_REGISTRY_REPLY_TIMEOUT)
+                .await;
+            Self::classify($op, started.elapsed(), result)
+        }
+    };
+}
+
+impl RoomRegistry {
+    registry_method!(
+        /// Look up a room actor by JID.
+        get_room(room_jid: BareJid) -> Option<ActorRef<RoomActor>>,
+        "get_room",
+        GetRoom { room_jid }
+    );
+
+    registry_method!(
+        /// Get an existing room or create one if absent.
+        get_or_create_room(
+            room_jid: BareJid,
+            waddle_id: String,
+            channel_id: String,
+            config: RoomConfig
+        ) -> ActorRef<RoomActor>,
+        "get_or_create_room",
+        GetOrCreateRoom { room_jid, waddle_id, channel_id, config }
+    );
+
+    registry_method!(
+        /// Create a room, failing if one with the same JID already exists.
+        create_room(
+            room_jid: BareJid,
+            waddle_id: String,
+            channel_id: String,
+            config: RoomConfig
+        ) -> ActorRef<RoomActor>,
+        "create_room",
+        CreateRoom { room_jid, waddle_id, channel_id, config }
+    );
+
+    registry_method!(
+        /// Create an instant room per XEP-0045.
+        create_instant_room(room_jid: BareJid) -> ActorRef<RoomActor>,
+        "create_instant_room",
+        CreateInstantRoom { room_jid }
+    );
+
+    registry_method!(
+        /// Destroy a room, returning whether it existed.
+        destroy_room(room_jid: BareJid) -> bool,
+        "destroy_room",
+        DestroyRoom { room_jid }
+    );
+
+    registry_method!(
+        /// Whether a room exists.
+        room_exists(room_jid: BareJid) -> bool,
+        "room_exists",
+        RoomExists { room_jid }
+    );
+
+    registry_method!(
+        /// Whether a bare JID belongs to this MUC service domain.
+        is_muc_jid(jid: BareJid) -> bool,
+        "is_muc_jid",
+        IsMucJid { jid }
+    );
+
+    registry_method!(
+        /// List all live room JIDs.
+        list_rooms() -> Vec<BareJid>,
+        "list_rooms",
+        ListRooms
+    );
+
+    registry_method!(
+        /// Count active rooms.
+        room_count() -> usize,
+        "room_count",
+        RoomCount
+    );
+
+    /// Test-only: route a never-returning message through the same instrumented
+    /// path as the public methods, so the reply-timeout → typed-error mapping is
+    /// exercised against real wrapper code rather than a duplicated stub.
+    #[cfg(test)]
+    pub(crate) async fn hang_forever(&self) -> Result<(), RoomRegistryError> {
+        let started = Instant::now();
+        let result = self
+            .inner
+            .ask(super::room_registry_actor::HangForever)
+            .reply_timeout(ROOM_REGISTRY_REPLY_TIMEOUT)
+            .await;
+        Self::classify("hang_forever", started.elapsed(), result)
+    }
+}
+
+/// A short, stable reason label for [`metrics::record_actor_request_dropped`].
+fn send_error_reason<M, E>(error: &SendError<M, E>) -> &'static str {
+    match error {
+        SendError::ActorNotRunning(_) => "actor_not_running",
+        SendError::ActorStopped => "actor_stopped",
+        SendError::MailboxFull(_) => "mailbox_full",
+        SendError::HandlerError(_) => "handler_error",
+        SendError::Timeout(_) => "timeout",
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/server/crates/waddle-xmpp/src/muc/room_registry_handle/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_handle/tests.rs
@@ -1,0 +1,100 @@
+use super::*;
+use crate::xep::xep0421::OccupantIdSecret;
+use std::time::Duration;
+
+fn test_registry() -> RoomRegistry {
+    RoomRegistry::spawn(
+        "muc.example.com".to_string(),
+        OccupantIdSecret::for_testing(b"test-secret".to_vec()),
+    )
+}
+
+fn test_room_jid(name: &str) -> BareJid {
+    format!("{name}@muc.example.com")
+        .parse()
+        .expect("valid test room JID")
+}
+
+#[tokio::test]
+async fn fresh_registry_reports_zero_rooms_and_is_alive() {
+    let registry = test_registry();
+    assert!(registry.is_alive());
+    let count = registry.room_count().await.expect("room_count");
+    assert_eq!(count, 0);
+}
+
+#[tokio::test]
+async fn idle_mailbox_depth_is_zero() {
+    let registry = test_registry();
+    assert_eq!(
+        registry.max_capacity(),
+        ROOM_REGISTRY_MAILBOX_CAPACITY as i64
+    );
+    // A freshly-spawned, idle registry has drained its mailbox: depth 0.
+    assert_eq!(registry.mailbox_depth(), Some(0));
+}
+
+#[tokio::test]
+async fn create_then_room_exists_is_true() {
+    let registry = test_registry();
+    let jid = test_room_jid("general");
+    registry
+        .create_room(
+            jid.clone(),
+            "w-1".to_string(),
+            "c-1".to_string(),
+            RoomConfig::default(),
+        )
+        .await
+        .expect("create_room");
+    assert!(registry.room_exists(jid).await.expect("room_exists"));
+    assert_eq!(registry.room_count().await.expect("count"), 1);
+}
+
+#[tokio::test(start_paused = true)]
+async fn wedged_request_maps_to_typed_timeout_error() {
+    let registry = test_registry();
+
+    // Drive a never-returning handler. Under paused time, advancing past the
+    // reply timeout makes the wrapper's `.reply_timeout(..)` elapse, which must
+    // surface as a typed `RoomRegistryError::Timeout` rather than hanging.
+    let mut pending = Box::pin(registry.hang_forever());
+
+    // Before the budget elapses, the request is still outstanding.
+    assert!(
+        futures::poll!(pending.as_mut()).is_pending(),
+        "request must not resolve before the reply timeout elapses"
+    );
+
+    tokio::time::advance(ROOM_REGISTRY_REPLY_TIMEOUT + Duration::from_millis(1)).await;
+
+    let result = pending.await;
+    assert_eq!(result, Err(RoomRegistryError::Timeout));
+}
+
+#[tokio::test]
+async fn duplicate_create_preserves_typed_handler_error() {
+    let registry = test_registry();
+    let jid = test_room_jid("dup");
+    registry
+        .create_room(
+            jid.clone(),
+            "w-1".to_string(),
+            "c-1".to_string(),
+            RoomConfig::default(),
+        )
+        .await
+        .expect("first create");
+
+    let err = registry
+        .create_room(
+            jid.clone(),
+            "w-1".to_string(),
+            "c-1".to_string(),
+            RoomConfig::default(),
+        )
+        .await
+        .expect_err("duplicate create must fail");
+
+    assert_eq!(err, RoomRegistryError::RoomAlreadyExists(jid));
+}


### PR DESCRIPTION
## Summary

Follow-ups to production incident #757 (per-connection IQ-handling tasks wedge in production; pod-restart workaround, recurs ~3.5h). PR #805 landed **fix 1** (short-circuit MUC `disco#info` for non-MUC targets). This PR carries the remaining three fixes.

## #806 — promote disco#info dispatch traces to `info!` (fix 2)

Production runs at `INFO`; the per-handler "disco#info answered" traces added in #755 sat at `DEBUG` and never surfaced when a connection wedged. Promotes all 10 answered traces (9 handler arms + `server_fallback`) to `info!`, keeping the stable `{id, target, handler}` field shape for grep/OTLP. The absence of any "answered" line for a request id remains the silent-drop signature (#750). Regression test captures the trace through an `INFO`-max subscriber.

## #807 — instrument RoomRegistryActor (fix 3)

A wedged `RoomRegistryActor` produced connection-wide silent hangs with no signal. New typed `RoomRegistry` handle wraps the actor with:
- per-`.ask()` reply timeout (`ROOM_REGISTRY_REPLY_TIMEOUT = 5s`) → typed `RoomRegistryError::Timeout` (mailbox/transport failures → `Unavailable`), so a wedge fails fast instead of hanging;
- explicit named bounded mailbox (`spawn_with_mailbox` + `mailbox::bounded(128)`) — a saturated actor produces typed errors rather than unbounded growth;
- per-request latency metric + `warn!` past `ROOM_REGISTRY_SLOW_ASK_WARN = 500ms`, wiring the previously-uncalled `record_actor_mailbox_latency` / `_request_timeout` / `_request_dropped` helpers;
- a periodic mailbox-depth gauge (`record_actor_mailbox_depth`, 15s) bound to the shutdown token.

This is the fast, specific fail-path for the known actor wedge.

## #808 — per-connection stanza-handler wedge backstop (fix 4)

Design recorded in `docs/adr/008-stanza-handler-wedge-backstop.md`. Wraps stanza dispatch in a coarse 15s `tokio::time::timeout` so no single handler can freeze the connection's frame loop indefinitely — the structural risk behind #757, source-agnostic (any actor, lock, or blocking call). Processing stays **strictly serial**, preserving RFC 6120 §10.1 in-order processing (spawn-per-IQ explicitly rejected — see ADR).

Conformant on elapse (RFC 6120 §8.2.3/§8.3.3): a timed-out IQ get/set still owes one reply, so it returns `<iq type='error'><resource-constraint/></iq>` with error type `wait` (temporary, retryable), echoing the id and swapping from/to. Message/Presence owe no reply and are dropped (logged + metered). Resource binding is handled inline before the backstop (stream setup). Observability is OTEL-native via the existing providers: a per-dispatch `info_span!` (→ OTEL span, `otel.status_code=ERROR` on elapse), a `warn!` (→ OTLP log), and a new `xmpp.stanza.handler.timeout` counter keyed by stanza kind + namespace.

`#807` and `#808` are complementary and independent (the original "#807-first" gate is dissolved by the chosen design).

## Verification

Per commit, independently verified before landing:
- `#806`: disco suite 15/0; new trace test passes.
- `#807`: `room_registry_handle` 5/0 (incl. a `start_paused` reply-timeout test), gauge 2/0, full muc suite 144/0.
- `#808`: `frame_backstop` 4/0 (`start_paused`), errors 10/0, frame regression 64/0.
- Whole branch: `cargo clippy -p waddle-xmpp -p waddle-server --all-targets -- -D warnings` clean; `cargo fmt` clean.

## Plan / status

- [x] #806 trace promotion + regression test
- [x] #807 RoomRegistryActor instrumentation (TDD)
- [x] #808 wedge backstop + ADR-008 (TDD)
- [ ] Adversarial review pass
- [ ] CI green

Refs #757, #806, #807, #808.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
