### PR TITLE
fix(chat): harden XEP-0198 resume delivery

### DIFF
--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -408,6 +408,8 @@ type XmppResumeState = {
   previd: string;
   inboundH: number;
   outboundH: number;
+  hasUnackedOutbound?: boolean;
+  unhandledOutboundStanzas?: string[];
   resource?: string;
 };
 
@@ -423,6 +425,19 @@ let wasmModulePromise: Promise<WasmModule> | null = null;
 function createXmppResource() {
   const randomId = globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
   return `web-${randomId}`;
+}
+
+function messageStanzaIdFromSerializedXml(xml: string): string | null {
+  if (typeof DOMParser !== "undefined") {
+    try {
+      const doc = new DOMParser().parseFromString(xml, "application/xml");
+      const root = doc.documentElement;
+      if (root.localName === "message") return root.getAttribute("id");
+    } catch {}
+  }
+
+  const match = xml.match(/^<message\b[^>]*\sid=(["'])([^"']+)\1/i);
+  return match?.[2] ?? null;
 }
 
 async function loadWasmModule(): Promise<WasmModule> {
@@ -506,6 +521,7 @@ export class BrowserXmppClient {
   private directQueueFlushPromise: Promise<void> | null = null;
   private readonly roomQueueFlushes = new Map<string, Promise<void>>();
   private readonly inflightQueuedIds = new Set<string>();
+  private readonly resumeReplayQueuedIds = new Set<string>();
   private readonly pendingSendAt = new Map<string, { at: number; kind: "room" | "dm" }>();
   private readonly messageAckHooks: Array<(id: string, meta: { kind: "room" | "dm"; latencyMs: number }) => void> = [];
   private readonly messageFailHooks: Array<(id: string, meta: { kind: "room" | "dm" }) => void> = [];
@@ -567,6 +583,7 @@ export class BrowserXmppClient {
     // survives a full page reload, so hydrate it eagerly.
     this.resumeState = this.resumePersistence.consumeSm();
     this.resource = this.resumeState?.resource || createXmppResource();
+    this.seedNativeReplayQueueIds(this.resumeState);
     this.retainedJoinedRoomJids = new Set(this.resumePersistence.loadJoinedRooms());
   }
 
@@ -702,6 +719,16 @@ export class BrowserXmppClient {
     });
   }
 
+  private seedNativeReplayQueueIds(state: XmppResumeState | null | undefined): void {
+    for (const xml of state?.unhandledOutboundStanzas ?? []) {
+      const id = messageStanzaIdFromSerializedXml(xml);
+      if (id) {
+        this.inflightQueuedIds.add(id);
+        this.resumeReplayQueuedIds.add(id);
+      }
+    }
+  }
+
   private recordPendingSend(id: string | null, kind: "room" | "dm") {
     if (!id) return;
     this.pendingSendAt.set(id, { at: performance.now(), kind });
@@ -733,6 +760,12 @@ export class BrowserXmppClient {
     const state = xmpp?.get_resume_state?.() ?? this.resumeState;
     this.resumePersistence.preparePagehideHandoff();
     if (state) {
+      if (state.hasUnackedOutbound && !state.unhandledOutboundStanzas?.length) {
+        this.resumeState = null;
+        this.resumePersistence.clearSm();
+        this.persistRetainedJoinedRooms();
+        return;
+      }
       const snapshot = { ...state, resource: this.resource };
       this.resumeState = snapshot;
       this.resumePersistence.saveSm(snapshot);
@@ -785,11 +818,20 @@ export class BrowserXmppClient {
       (config as any).with_resume_state_handle(handle);
       this.clearResumeState();
     } else if (this.resumeState) {
-      (config as any).with_resume_state?.(
-        this.resumeState.previd,
-        this.resumeState.inboundH,
-        this.resumeState.outboundH,
-      );
+      if (this.resumeState.unhandledOutboundStanzas?.length && typeof (config as any).with_resume_state_stanzas === "function") {
+        (config as any).with_resume_state_stanzas(
+          this.resumeState.previd,
+          this.resumeState.inboundH,
+          this.resumeState.outboundH,
+          this.resumeState.unhandledOutboundStanzas,
+        );
+      } else {
+        (config as any).with_resume_state?.(
+          this.resumeState.previd,
+          this.resumeState.inboundH,
+          this.resumeState.outboundH,
+        );
+      }
       this.resumePersistence.clearSm();
       this.resumeState = null;
     }
@@ -1169,6 +1211,43 @@ export class BrowserXmppClient {
     return { id: queuedId, state: "queued" };
   }
 
+  private persistPendingRoomSend(roomJid: string, body: string, opts: SendGroupMessageOptions & { id: string }): void {
+    enqueueQueuedMessage(this.queueScope, {
+      kind: "room",
+      id: opts.id,
+      createdAt: new Date().toISOString(),
+      roomJid,
+      body,
+      ...(opts.markup?.length ? { markup: opts.markup } : {}),
+      ...(opts.references?.length ? { references: opts.references } : {}),
+      ...(opts.mentionJidsByNick ? { mentionJidsByNick: opts.mentionJidsByNick } : {}),
+      ...(opts.files?.length ? { files: opts.files } : {}),
+      ...(opts.replyTo ? { replyTo: opts.replyTo } : {}),
+      ...(opts.threadId ? { threadId: opts.threadId } : {}),
+      ...(opts.parentThreadId ? { parentThreadId: opts.parentThreadId } : {}),
+      ...(opts.threadCreate ? { threadCreate: opts.threadCreate } : {}),
+      ...(opts.threadReply ? { threadReply: opts.threadReply } : {}),
+    });
+    this.emitQueueDepth();
+  }
+
+  private persistPendingDirectSend(peerJid: string, body: string, opts: SendDirectMessageOptions & { id: string }): void {
+    enqueueQueuedMessage(this.queueScope, {
+      kind: "dm",
+      id: opts.id,
+      createdAt: new Date().toISOString(),
+      peerJid: barePeerJid(peerJid),
+      body,
+      ...(opts.markup?.length ? { markup: opts.markup } : {}),
+      ...(opts.references?.length ? { references: opts.references } : {}),
+      ...(opts.files?.length ? { files: opts.files } : {}),
+      ...(opts.replyTo ? { replyTo: opts.replyTo } : {}),
+      ...(opts.threadId ? { threadId: opts.threadId } : {}),
+      ...(opts.parentThreadId ? { parentThreadId: opts.parentThreadId } : {}),
+    });
+    this.emitQueueDepth();
+  }
+
   private async compatSendGroupMessage(xmpp: XmppClientInstance, roomJid: string, body: string, opts: SendGroupMessageOptions): Promise<string | null> {
     const { effectiveBody, replyFallbackLength, rebasedMarkup, rebasedReferences } = encodeBodyForSend(body, opts.replyTo, opts.markup, opts.references);
     const wasmOpts = buildWasmSendOptions({ ...opts, markup: rebasedMarkup, references: rebasedReferences }, replyFallbackLength);
@@ -1274,7 +1353,11 @@ export class BrowserXmppClient {
     if (!body.trim() && !hasFiles && !hasThreadMetadata && !hasForumMetadata) return null;
     const roomJid = this.roomJidForChannel(channelId);
     if (this.roomIsReady(roomJid) && this.xmpp) {
-      const id = await this.compatSendGroupMessage(this.xmpp, roomJid, body, { ...opts, mentionJidsByNick: { ...(opts.mentionJidsByNick ?? {}), ...this.memberJidsFor(roomJid) } });
+      const outboundId = opts.id ?? crypto.randomUUID();
+      const sendOpts = { ...opts, id: outboundId, mentionJidsByNick: { ...(opts.mentionJidsByNick ?? {}), ...this.memberJidsFor(roomJid) } };
+      this.persistPendingRoomSend(roomJid, body, sendOpts);
+      const id = await this.compatSendGroupMessage(this.xmpp, roomJid, body, sendOpts);
+      if (id) this.inflightQueuedIds.add(id);
       this.recordPendingSend(id, "room");
       return { id, state: "sending" };
     }
@@ -1287,7 +1370,11 @@ export class BrowserXmppClient {
     if (!body.trim() && !opts.files?.length) return null;
     const normalizedPeerJid = barePeerJid(peerJid);
     if (this.canUseConnectedSession() && this.xmpp) {
-      const id = await this.compatSendDirectMessage(this.xmpp, normalizedPeerJid, body, opts);
+      const outboundId = opts.id ?? crypto.randomUUID();
+      const sendOpts = { ...opts, id: outboundId };
+      this.persistPendingDirectSend(normalizedPeerJid, body, sendOpts);
+      const id = await this.compatSendDirectMessage(this.xmpp, normalizedPeerJid, body, sendOpts);
+      if (id) this.inflightQueuedIds.add(id);
       this.recordPendingSend(id, "dm");
       return { id, state: "sending" };
     }
@@ -2354,8 +2441,8 @@ export class BrowserXmppClient {
   private startSelfPing() { this.stopSelfPing(); this.selfPingTimer = setInterval(() => { void this.doSelfPing(); }, 60000); }
   private stopSelfPing() { if (this.selfPingTimer) { clearInterval(this.selfPingTimer); this.selfPingTimer = null; } }
   private async doSelfPing() { if (!this.xmpp?.send_raw_iq || !this.currentRoom) return; try { await this.xmpp.send_raw_iq(`<iq type="get" id="${crypto.randomUUID()}" to="${this.currentRoom}/${this.session.username}"><ping xmlns="urn:xmpp:ping"/></iq>`); } catch { this.roomDisconnectHandler?.(); } }
-  private handleMessageAck(id: string) { const wasQueued = this.inflightQueuedIds.delete(id); if (wasQueued) removeQueuedMessage(this.queueScope, id); this.messageAckHandler?.(id); const pending = this.pendingSendAt.get(id); if (pending) { this.pendingSendAt.delete(id); this.fireHook(this.messageAckHooks, id, { kind: pending.kind, latencyMs: performance.now() - pending.at }); } if (wasQueued) this.emitQueueDepth(); }
-  private handleMessageFailed(id: string) { const wasQueued = this.inflightQueuedIds.delete(id); this.messageDeliveryFailureHandler?.(id); const pending = this.pendingSendAt.get(id); if (pending) { this.pendingSendAt.delete(id); this.fireHook(this.messageFailHooks, id, { kind: pending.kind }); } if (wasQueued) this.emitQueueDepth(); }
+  private handleMessageAck(id: string) { const wasQueued = this.inflightQueuedIds.delete(id); this.resumeReplayQueuedIds.delete(id); if (wasQueued) removeQueuedMessage(this.queueScope, id); this.messageAckHandler?.(id); const pending = this.pendingSendAt.get(id); if (pending) { this.pendingSendAt.delete(id); this.fireHook(this.messageAckHooks, id, { kind: pending.kind, latencyMs: performance.now() - pending.at }); } if (wasQueued) this.emitQueueDepth(); }
+  private handleMessageFailed(id: string) { const wasQueued = this.inflightQueuedIds.delete(id); const wasResumeReplay = this.resumeReplayQueuedIds.delete(id); if (wasResumeReplay) removeQueuedMessage(this.queueScope, id); this.messageDeliveryFailureHandler?.(id); const pending = this.pendingSendAt.get(id); if (pending) { this.pendingSendAt.delete(id); this.fireHook(this.messageFailHooks, id, { kind: pending.kind }); } if (wasQueued || wasResumeReplay) this.emitQueueDepth(); }
   private handleSessionReady(xmpp: XmppClientInstance, lifecycle: SessionLifecycleEvent) {
     void this.runSessionReady(xmpp, lifecycle);
   }
@@ -2531,6 +2618,7 @@ export class BrowserXmppClient {
     this.setResumeStateHandle(xmpp.get_resume_state_handle?.() ?? null);
     const resumeState = xmpp.get_resume_state?.() ?? null;
     this.resumeState = resumeState ? { ...resumeState, resource: this.resource } : null;
+    this.seedNativeReplayQueueIds(this.resumeState);
     // Keep transient reconnect state in this JS context only. The
     // shared per-account persisted SM slot is a pagehide handoff for
     // true tab replacement; writing it during ordinary disconnects

--- a/chat/src/lib/xmpp/resume-persistence.ts
+++ b/chat/src/lib/xmpp/resume-persistence.ts
@@ -16,9 +16,11 @@
  *     (`PersistedSmResumeState`) — the `previd` plus inbound /
  *     outbound stanza counts. The richer "handle" form from the
  *     WASM client is a live JS object that cannot be serialized;
- *     the POD `{previd, inboundH, outboundH}` triple can be, and
- *     the fallback path in `doConnect` already knows how to feed
- *     it back via `with_resume_state`.
+ *     the POD `{previd, inboundH, outboundH}` triple can be. When
+ *     the native XEP-0198 queue still has unhandled outbound stanzas,
+ *     their XML is serialized too so `doConnect` can restore sender
+ *     responsibility after a full reload instead of creating a false
+ *     resume state with an empty replay queue.
  *
  * The shape mirrors `outbound-queue-store.ts` (same `waddle.chat.*`
  * prefix family, same per-account key namespacing, same defensive
@@ -55,6 +57,7 @@ export type PersistedSmResumeState = {
   previd: string;
   inboundH: number;
   outboundH: number;
+  unhandledOutboundStanzas?: string[];
   resource?: string;
 };
 
@@ -153,8 +156,14 @@ export function createLocalStorageResumePersistence(accountKey: string, ownerId?
       }
       if (envelope.ownerId !== owner.ownerId) return null;
       if (envelope.claimId) return null;
-      const { previd, inboundH, outboundH, resource } = envelope;
-      return { previd, inboundH, outboundH, ...(resource ? { resource } : {}) };
+      const { previd, inboundH, outboundH, resource, unhandledOutboundStanzas } = envelope;
+      return {
+        previd,
+        inboundH,
+        outboundH,
+        ...(unhandledOutboundStanzas?.length ? { unhandledOutboundStanzas: [...unhandledOutboundStanzas] } : {}),
+        ...(resource ? { resource } : {}),
+      };
     },
     consumeSm() {
       return consumeSmEnvelope(smKey, owner.ownerId);
@@ -224,8 +233,14 @@ function consumeSmEnvelope(key: string, ownerId: string): PersistedSmResumeState
 
     s.setItem(consumedKey, consumedMarker);
     s.removeItem(key);
-    const { previd, inboundH, outboundH, resource } = claimed;
-    return { previd, inboundH, outboundH, ...(resource ? { resource } : {}) };
+    const { previd, inboundH, outboundH, resource, unhandledOutboundStanzas } = claimed;
+    return {
+      previd,
+      inboundH,
+      outboundH,
+      ...(unhandledOutboundStanzas?.length ? { unhandledOutboundStanzas: [...unhandledOutboundStanzas] } : {}),
+      ...(resource ? { resource } : {}),
+    };
   } catch (err) {
     reportError("storage.read", err, {
       recoverable: true,
@@ -470,6 +485,7 @@ function isPersistedSmEnvelope(value: unknown): value is PersistedSmEnvelope {
     typeof candidate.previd === "string"
     && typeof candidate.inboundH === "number"
     && typeof candidate.outboundH === "number"
+    && (candidate.unhandledOutboundStanzas === undefined || isStringArray(candidate.unhandledOutboundStanzas))
     && (candidate.resource === undefined || typeof candidate.resource === "string")
     && (candidate.ownerId === undefined || typeof candidate.ownerId === "string")
     && (candidate.claimId === undefined || typeof candidate.claimId === "string")

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -282,6 +282,12 @@ describe("client send readiness", () => {
     expect(typeof result?.id).toBe("string");
     expect(result?.state).toBe("sending");
     expect(xmpp.send_groupchat_message).toHaveBeenCalledTimes(1);
+    expect(listQueuedRoomMessages("alice@example.com", roomJid).map((message) => message.id)).toEqual([
+      result?.id,
+    ]);
+
+    (client as unknown as { handleMessageAck: (id: string) => void }).handleMessageAck(result!.id!);
+    expect(listQueuedRoomMessages("alice@example.com", roomJid)).toEqual([]);
   });
 
   test("XEP-0201: BrowserXmppClient.sendGroupMessage accepts bodyless thread metadata sends", async () => {
@@ -608,6 +614,46 @@ describe("client send readiness", () => {
       "Reconnection timed out",
     );
     expect(xmpp.sendMessage).toHaveBeenCalledTimes(0);
+  });
+
+  test("DM sends are durable until XEP-0198 ack confirms server handling", async () => {
+    const xmpp = { send_chat_message: mock(async (_peer: string, _body: string, opts: { stanza_id?: string }) => opts.stanza_id) };
+    const client = new BrowserXmppClient(session());
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+
+    const result = await client.sendDirectMessage("bob@example.com", "hello", { id: "dm-live-1" });
+
+    expect(result).toEqual({ id: "dm-live-1", state: "sending" });
+    expect(listQueuedDmMessages("alice@example.com", "bob@example.com").map((message) => message.id)).toEqual([
+      "dm-live-1",
+    ]);
+
+    (client as unknown as { handleMessageAck: (id: string) => void }).handleMessageAck("dm-live-1");
+    expect(listQueuedDmMessages("alice@example.com", "bob@example.com")).toEqual([]);
+  });
+
+  test("native failed-resume fallback owns resend for live unacked DM sends", async () => {
+    const xmpp = {
+      send_chat_message: mock(async (_peer: string, _body: string, opts: { stanza_id?: string }) => opts.stanza_id),
+      get_resume_state: () => ({
+        previd: "live-sm-id",
+        inboundH: 4,
+        outboundH: 9,
+        hasUnackedOutbound: true,
+        unhandledOutboundStanzas: ["<message xmlns='jabber:client' id='dm-live-1'/>"],
+      }),
+    };
+    const client = new BrowserXmppClient(session());
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+
+    await client.sendDirectMessage("bob@example.com", "hello", { id: "dm-live-1" });
+    (client as unknown as { handleDisconnected: (xmpp: typeof xmpp) => void }).handleDisconnected(xmpp);
+    (client as unknown as { handleMessageFailed: (id: string) => void }).handleMessageFailed("dm-live-1");
+    (client as unknown as { clearReconnectTimer: () => void }).clearReconnectTimer();
+
+    expect(listQueuedDmMessages("alice@example.com", "bob@example.com")).toEqual([]);
   });
 });
 

--- a/chat/tests/resume-persistence.test.ts
+++ b/chat/tests/resume-persistence.test.ts
@@ -13,6 +13,7 @@
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import { ReconnectCatchup } from "../src/lib/xmpp/reconnect-catchup";
 import { BrowserXmppClient } from "../src/lib/xmpp/client";
+import { enqueueQueuedMessage, listQueuedDmMessages } from "../src/lib/outbound-queue-store";
 import type { WaddleSession } from "../src/lib/server-auth";
 import {
   createLocalStorageResumePersistence,
@@ -82,27 +83,33 @@ afterEach(() => {
 function inMemoryPersistence(): ResumePersistence & {
   catchupSnapshot: () => PersistedReconnectCatchup | null;
   smSnapshot: () => PersistedSmResumeState | null;
+  joinedRoomsSnapshot: () => string[];
+  clearSmCount: () => number;
 } {
   let catchup: PersistedReconnectCatchup | null = null;
   let sm: PersistedSmResumeState | null = null;
+  let joinedRooms: string[] = [];
+  let smClears = 0;
   return {
     loadCatchup: () => catchup,
     saveCatchup: (snapshot) => { catchup = snapshot; },
     clearCatchup: () => { catchup = null; },
-  loadSm: () => sm,
+    loadSm: () => sm,
     consumeSm: () => {
       const current = sm;
       sm = null;
       return current;
     },
     saveSm: (state) => { sm = state; },
-    clearSm: () => { sm = null; },
+    clearSm: () => { smClears += 1; sm = null; },
     preparePagehideHandoff: () => undefined,
-    loadJoinedRooms: () => [],
-    saveJoinedRooms: () => undefined,
-    clearJoinedRooms: () => undefined,
+    loadJoinedRooms: () => [...joinedRooms],
+    saveJoinedRooms: (rooms) => { joinedRooms = [...rooms]; },
+    clearJoinedRooms: () => { joinedRooms = []; },
     catchupSnapshot: () => catchup,
     smSnapshot: () => sm,
+    joinedRoomsSnapshot: () => [...joinedRooms],
+    clearSmCount: () => smClears,
   };
 }
 
@@ -232,7 +239,12 @@ describe("createLocalStorageResumePersistence — localStorage adapter", () => {
 
   test("round-trips an SM resume state through localStorage (with internal savedAt)", () => {
     const persistence = createLocalStorageResumePersistence("alice@example.com");
-    const state = { previd: "abc-123", inboundH: 42, outboundH: 7 };
+    const state = {
+      previd: "abc-123",
+      inboundH: 42,
+      outboundH: 7,
+      unhandledOutboundStanzas: ["<message xmlns='jabber:client' id='m1'/>"],
+    };
     persistence.saveSm(state);
     // Round-trip strips the internal `savedAt` so the caller gets
     // the same shape it passed in.
@@ -390,6 +402,146 @@ describe("createLocalStorageResumePersistence — localStorage adapter", () => {
       createLocalStorageResumePersistence("alice@example.com", "tab-a"),
     );
     expect(tabA.fullJid).toBe("alice@example.com/web-existing-resource");
+  });
+
+  test("BrowserXmppClient does not persist lossy SM state while outbound stanzas are unacked", () => {
+    const persistence = inMemoryPersistence();
+    persistence.saveJoinedRooms(["general@conference.example.com"]);
+    const consumedClearCount = persistence.clearSmCount();
+    const client = new BrowserXmppClient(
+      { jid: "alice@example.com", username: "alice" } as WaddleSession,
+      persistence,
+    );
+    (client as unknown as {
+      xmpp: { get_resume_state: () => { previd: string; inboundH: number; outboundH: number; hasUnackedOutbound: boolean } };
+    }).xmpp = {
+      get_resume_state: () => ({
+        previd: "live-sm-id",
+        inboundH: 4,
+        outboundH: 9,
+        hasUnackedOutbound: true,
+      }),
+    };
+
+    client.persistResumeStateForPageHide();
+
+    expect(persistence.smSnapshot()).toBeNull();
+    expect(persistence.clearSmCount()).toBe(consumedClearCount + 1);
+    expect(persistence.joinedRoomsSnapshot()).toEqual(["general@conference.example.com"]);
+  });
+
+  test("BrowserXmppClient persists SM state when unacked outbound stanzas are serializable", () => {
+    const persistence = inMemoryPersistence();
+    const client = new BrowserXmppClient(
+      { jid: "alice@example.com", username: "alice" } as WaddleSession,
+      persistence,
+    );
+    (client as unknown as {
+      xmpp: {
+        get_resume_state: () => {
+          previd: string;
+          inboundH: number;
+          outboundH: number;
+          hasUnackedOutbound: boolean;
+          unhandledOutboundStanzas: string[];
+        };
+      };
+    }).xmpp = {
+      get_resume_state: () => ({
+        previd: "live-sm-id",
+        inboundH: 4,
+        outboundH: 9,
+        hasUnackedOutbound: true,
+        unhandledOutboundStanzas: ["<message xmlns='jabber:client' id='unacked'/>"],
+      }),
+    };
+
+    client.persistResumeStateForPageHide();
+
+    expect(persistence.smSnapshot()).toMatchObject({
+      previd: "live-sm-id",
+      inboundH: 4,
+      outboundH: 9,
+      unhandledOutboundStanzas: ["<message xmlns='jabber:client' id='unacked'/>"],
+    });
+  });
+
+  test("BrowserXmppClient treats restored SM message stanzas as inflight queued sends", () => {
+    const persistence = inMemoryPersistence();
+    persistence.saveSm({
+      previd: "live-sm-id",
+      inboundH: 4,
+      outboundH: 9,
+      unhandledOutboundStanzas: ["<message xmlns='jabber:client' id='dm-live-1'/>"],
+    });
+    enqueueQueuedMessage("alice@example.com", {
+      kind: "dm",
+      id: "dm-live-1",
+      createdAt: new Date().toISOString(),
+      peerJid: "bob@example.com",
+      body: "hello",
+    });
+
+    const client = new BrowserXmppClient(
+      { jid: "alice@example.com", username: "alice" } as WaddleSession,
+      persistence,
+    );
+
+    (client as unknown as { handleMessageAck: (id: string) => void }).handleMessageAck("dm-live-1");
+
+    expect(listQueuedDmMessages("alice@example.com", "bob@example.com")).toEqual([]);
+  });
+
+  test("BrowserXmppClient removes restored SM queue entries when native fallback retry owns resend", () => {
+    const persistence = inMemoryPersistence();
+    persistence.saveSm({
+      previd: "live-sm-id",
+      inboundH: 4,
+      outboundH: 9,
+      unhandledOutboundStanzas: ["<message xmlns='jabber:client' id='dm-live-1'/>"],
+    });
+    enqueueQueuedMessage("alice@example.com", {
+      kind: "dm",
+      id: "dm-live-1",
+      createdAt: new Date().toISOString(),
+      peerJid: "bob@example.com",
+      body: "hello",
+    });
+
+    const client = new BrowserXmppClient(
+      { jid: "alice@example.com", username: "alice" } as WaddleSession,
+      persistence,
+    );
+
+    (client as unknown as { handleMessageFailed: (id: string) => void }).handleMessageFailed("dm-live-1");
+
+    expect(listQueuedDmMessages("alice@example.com", "bob@example.com")).toEqual([]);
+  });
+
+  test("BrowserXmppClient persists SM state when the native replay queue is empty", () => {
+    const persistence = inMemoryPersistence();
+    const client = new BrowserXmppClient(
+      { jid: "alice@example.com", username: "alice" } as WaddleSession,
+      persistence,
+    );
+    (client as unknown as {
+      xmpp: { get_resume_state: () => { previd: string; inboundH: number; outboundH: number; hasUnackedOutbound: boolean } };
+    }).xmpp = {
+      get_resume_state: () => ({
+        previd: "live-sm-id",
+        inboundH: 4,
+        outboundH: 9,
+        hasUnackedOutbound: false,
+      }),
+    };
+
+    client.persistResumeStateForPageHide();
+
+    expect(persistence.smSnapshot()).toMatchObject({
+      previd: "live-sm-id",
+      inboundH: 4,
+      outboundH: 9,
+    });
   });
 
   test("round-trips retained joined rooms for refresh-time group call discovery", () => {

--- a/server/crates/waddle-xmpp-client-wasm/src/client_core.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_core.rs
@@ -107,7 +107,7 @@ impl WaddleClient {
             inner.borrow_mut().cmd_tx = Some(cmd_tx);
 
             spawn_local(event_dispatch_loop(inner.clone(), event_rx));
-            spawn_local(driver_loop(config, ws, cmd_rx, event_tx));
+            spawn_local(driver_loop(config, ws, cmd_rx, event_tx, inner.clone()));
 
             Ok(JsValue::UNDEFINED)
         })

--- a/server/crates/waddle-xmpp-client-wasm/src/driver.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/driver.rs
@@ -5,8 +5,9 @@ pub(crate) async fn driver_loop(
     ws: WasmWebSocket,
     cmd_rx: mpsc::Receiver<WasmCommand>,
     event_tx: mpsc::Sender<DriverEvent>,
+    inner: Rc<RefCell<WaddleClientInner>>,
 ) {
-    let mut task = match WasmDriverTask::new(config, ws, cmd_rx, event_tx.clone()) {
+    let mut task = match WasmDriverTask::new(config, ws, cmd_rx, event_tx.clone(), inner) {
         Ok(task) => task,
         Err(err) => {
             let mut event_tx = event_tx;
@@ -24,12 +25,14 @@ impl WasmDriverTask {
         ws: WasmWebSocket,
         cmd_rx: mpsc::Receiver<WasmCommand>,
         event_tx: mpsc::Sender<DriverEvent>,
+        inner: Rc<RefCell<WaddleClientInner>>,
     ) -> DriverResult<Self> {
         Ok(Self {
             runtime: XmppRuntime::new(config)?,
             ws,
             cmd_rx,
             event_tx,
+            inner,
             pending_iqs: HashMap::new(),
             pending_mam_queries: HashMap::new(),
             pending_inbox_queries: HashMap::new(),
@@ -41,6 +44,7 @@ impl WasmDriverTask {
     async fn run(&mut self) {
         match self.runtime.queue_request(ClientRequest::Connect) {
             Ok(events) => {
+                self.publish_resume_state_snapshot();
                 for event in events {
                     if !self.handle_client_event(event).await {
                         self.finish().await;
@@ -177,6 +181,7 @@ impl WasmDriverTask {
             }
             Some(WasmCommand::Disconnect { responder }) => {
                 self.explicit_disconnect = true;
+                self.publish_resume_state_snapshot();
                 let result = self
                     .send_transport_message(TransportMessage::Close(StreamClose))
                     .await;
@@ -354,6 +359,7 @@ impl WasmDriverTask {
                 return false;
             }
         };
+        self.publish_resume_state_snapshot();
 
         for event in events {
             if !self.handle_client_event(event).await {
@@ -380,6 +386,7 @@ impl WasmDriverTask {
 
     async fn apply_sent_event(&mut self, event: TransportEvent) -> DriverResult<()> {
         let events = self.runtime.apply_transport_event(event)?;
+        self.publish_resume_state_snapshot();
         for event in events {
             if self.dispatch_client_event(event).await.is_some() {
                 return Err(ClientError::Disconnected);
@@ -548,12 +555,13 @@ impl WasmDriverTask {
             .await;
     }
 
+    fn publish_resume_state_snapshot(&self) {
+        publish_resume_state_snapshot(&self.inner, &self.runtime, self.explicit_disconnect);
+    }
+
     async fn finish(&mut self) {
-        let resume_state = if self.explicit_disconnect {
-            None
-        } else {
-            self.runtime.resume_state()
-        };
+        self.publish_resume_state_snapshot();
+        let resume_state = self.inner.borrow().resume_state.clone();
         let _ = self
             .event_tx
             .clone()
@@ -587,5 +595,147 @@ impl WasmDriverTask {
         }
 
         let _ = self.event_tx.clone().send(DriverEvent::Disconnected).await;
+    }
+}
+
+fn publish_resume_state_snapshot(
+    inner: &Rc<RefCell<WaddleClientInner>>,
+    runtime: &XmppRuntime,
+    explicit_disconnect: bool,
+) {
+    let resume_state = if explicit_disconnect {
+        None
+    } else {
+        runtime.resume_state()
+    };
+    inner.borrow_mut().resume_state = resume_state;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_inner() -> Rc<RefCell<WaddleClientInner>> {
+        Rc::new(RefCell::new(WaddleClientInner {
+            config: StoredConfig {
+                server_url: "wss://xmpp.example.test".to_string(),
+                jid: "alice@example.test".to_string(),
+                access_token: "token".to_string(),
+                resource: "web".to_string(),
+                resume_state: None,
+            },
+            cmd_tx: None,
+            on_message: None,
+            on_presence: None,
+            on_connected: None,
+            on_session_lifecycle: None,
+            on_disconnected: None,
+            on_error: None,
+            on_message_delivery_acked: None,
+            on_message_delivery_failed: None,
+            on_mds_displayed: None,
+            on_call: None,
+            resume_state: None,
+        }))
+    }
+
+    #[test]
+    fn publish_resume_state_snapshot_updates_shared_client_state() {
+        let inner = test_inner();
+        let stored = StoredConfig {
+            server_url: "wss://xmpp.example.test".to_string(),
+            jid: "alice@example.test".to_string(),
+            access_token: "token".to_string(),
+            resource: "web".to_string(),
+            resume_state: Some(
+                waddle_xmpp_client::SmResumeState::new("previous-stream", 4, 9)
+                    .expect("resume state"),
+            ),
+        };
+        let runtime =
+            XmppRuntime::new(build_client_config(&stored).expect("config")).expect("runtime");
+
+        publish_resume_state_snapshot(&inner, &runtime, false);
+
+        let borrowed = inner.borrow();
+        let snapshot = borrowed.resume_state.as_ref().expect("snapshot");
+        assert_eq!(snapshot.previd(), "previous-stream");
+        assert_eq!(snapshot.inbound_h(), 4);
+        assert_eq!(snapshot.outbound_h(), 9);
+    }
+
+    #[test]
+    fn publish_resume_state_snapshot_tracks_live_ack_mutations() {
+        let inner = test_inner();
+        let stanza = Element::builder("message", NS_CLIENT)
+            .attr(minidom::rxml::xml_ncname!("id").to_owned(), "unacked")
+            .build();
+        let stored = StoredConfig {
+            server_url: "wss://xmpp.example.test".to_string(),
+            jid: "alice@example.test".to_string(),
+            access_token: "token".to_string(),
+            resource: "web".to_string(),
+            resume_state: None,
+        };
+        let mut runtime =
+            XmppRuntime::new(build_client_config(&stored).expect("config")).expect("runtime");
+        runtime
+            .apply_transport_event(TransportEvent::MessageSent(TransportMessage::Element(
+                waddle_xmpp_client::stream_management::SmState::build_enable(true),
+            )))
+            .expect("enable sent");
+        runtime
+            .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+                Element::builder("enabled", waddle_xmpp_client::stream_management::NS_SM)
+                    .attr(minidom::rxml::xml_ncname!("id").to_owned(), "live-stream")
+                    .attr(minidom::rxml::xml_ncname!("resume").to_owned(), "true")
+                    .build(),
+            )))
+            .expect("enabled");
+        runtime
+            .apply_transport_event(TransportEvent::MessageSent(TransportMessage::Element(
+                stanza,
+            )))
+            .expect("message sent");
+
+        publish_resume_state_snapshot(&inner, &runtime, false);
+        assert!(inner
+            .borrow()
+            .resume_state
+            .as_ref()
+            .expect("snapshot")
+            .has_unhandled_outbound_stanzas());
+
+        let ack = Element::builder("a", waddle_xmpp_client::stream_management::NS_SM)
+            .attr(minidom::rxml::xml_ncname!("h").to_owned(), "1")
+            .build();
+        runtime
+            .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+                ack,
+            )))
+            .expect("ack");
+        publish_resume_state_snapshot(&inner, &runtime, false);
+
+        assert!(!inner
+            .borrow()
+            .resume_state
+            .as_ref()
+            .expect("snapshot")
+            .has_unhandled_outbound_stanzas());
+    }
+
+    #[test]
+    fn publish_resume_state_snapshot_clears_on_explicit_disconnect() {
+        let inner = test_inner();
+        inner.borrow_mut().resume_state = Some(
+            waddle_xmpp_client::SmResumeState::new("previous-stream", 4, 9).expect("resume state"),
+        );
+        let stored = inner.borrow().config.clone();
+        let runtime =
+            XmppRuntime::new(build_client_config(&stored).expect("config")).expect("runtime");
+
+        publish_resume_state_snapshot(&inner, &runtime, true);
+
+        assert!(inner.borrow().resume_state.is_none());
     }
 }

--- a/server/crates/waddle-xmpp-client-wasm/src/state.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/state.rs
@@ -47,6 +47,29 @@ impl WaddleConfig {
         Ok(())
     }
 
+    pub fn with_resume_state_stanzas(
+        &mut self,
+        previd: String,
+        inbound_h: u32,
+        outbound_h: u32,
+        stanzas: Vec<String>,
+    ) -> Result<(), JsValue> {
+        let stanzas = stanzas
+            .into_iter()
+            .map(|xml| {
+                xml.parse::<Element>()
+                    .map_err(|err| js_error(format!("invalid resume stanza XML: {err}")))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        self.resume_state = Some(
+            waddle_xmpp_client::SmResumeState::from_unhandled_outbound_stanzas(
+                previd, inbound_h, outbound_h, stanzas,
+            )
+            .map_err(|err| js_error(err.to_string()))?,
+        );
+        Ok(())
+    }
+
     pub fn with_resume_state_handle(&mut self, state: &WaddleResumeState) {
         self.resume_state = Some(state.inner.clone());
     }
@@ -79,14 +102,22 @@ pub(crate) struct JsResumeState {
     pub(crate) previd: String,
     pub(crate) inbound_h: u32,
     pub(crate) outbound_h: u32,
+    pub(crate) has_unacked_outbound: bool,
+    pub(crate) unhandled_outbound_stanzas: Vec<String>,
 }
 
 impl From<waddle_xmpp_client::SmResumeState> for JsResumeState {
     fn from(value: waddle_xmpp_client::SmResumeState) -> Self {
+        let unhandled_outbound_stanzas = value
+            .unhandled_outbound_stanzas()
+            .filter_map(|element| element_to_xml_string(element).ok())
+            .collect();
         Self {
             previd: value.previd().to_string(),
             inbound_h: value.inbound_h(),
             outbound_h: value.outbound_h(),
+            has_unacked_outbound: value.has_unhandled_outbound_stanzas(),
+            unhandled_outbound_stanzas,
         }
     }
 }
@@ -196,6 +227,7 @@ pub(crate) struct WasmDriverTask {
     pub(crate) ws: WasmWebSocket,
     pub(crate) cmd_rx: mpsc::Receiver<WasmCommand>,
     pub(crate) event_tx: mpsc::Sender<DriverEvent>,
+    pub(crate) inner: Rc<RefCell<WaddleClientInner>>,
     pub(crate) pending_iqs: HashMap<String, oneshot::Sender<DriverResult<Element>>>,
     pub(crate) pending_mam_queries: HashMap<String, PendingMamQuery>,
     pub(crate) pending_inbox_queries: HashMap<String, PendingInboxQuery>,

--- a/server/crates/waddle-xmpp-client/src/stream_management.rs
+++ b/server/crates/waddle-xmpp-client/src/stream_management.rs
@@ -51,6 +51,23 @@ impl SmResumeState {
         Ok(state)
     }
 
+    pub fn from_unhandled_outbound_stanzas(
+        previd: impl Into<String>,
+        inbound_h: u32,
+        outbound_h: u32,
+        stanzas: impl IntoIterator<Item = Element>,
+    ) -> ClientResult<Self> {
+        let outbound_queue = stanzas
+            .into_iter()
+            .map(|element| QueuedOutboundStanza {
+                message_stanza_id: message_delivery_stanza_id(&element),
+                sent_at: existing_delay_stamp(&element).unwrap_or_else(Utc::now),
+                element,
+            })
+            .collect();
+        Self::from_outbound_queue(previd, inbound_h, outbound_h, outbound_queue)
+    }
+
     pub fn previd(&self) -> &str {
         &self.previd
     }
@@ -61,6 +78,14 @@ impl SmResumeState {
 
     pub fn outbound_h(&self) -> u32 {
         self.outbound_h
+    }
+
+    pub fn has_unhandled_outbound_stanzas(&self) -> bool {
+        !self.outbound_queue.is_empty()
+    }
+
+    pub fn unhandled_outbound_stanzas(&self) -> impl Iterator<Item = &Element> {
+        self.outbound_queue.iter().map(|queued| &queued.element)
     }
 }
 
@@ -566,6 +591,48 @@ mod tests {
                 .map(|stanza_id| stanza_id.as_str())
                 .collect::<Vec<_>>(),
             vec!["msg-10"]
+        );
+    }
+
+    #[test]
+    fn resume_state_reports_unhandled_outbound_queue_presence() {
+        let mut state = SmState::new();
+        state.start_outbound();
+        state.previd = Some("previous-stream".to_string());
+        state.record_sent_stanza(
+            &Element::builder("message", "jabber:client")
+                .attr(minidom::rxml::xml_ncname!("id").to_owned(), "unacked")
+                .build(),
+        );
+
+        let resume_state = state.resume_state().expect("resume state");
+        assert!(resume_state.has_unhandled_outbound_stanzas());
+
+        state.process_ack(1);
+        let resume_state = state.resume_state().expect("resume state");
+        assert!(!resume_state.has_unhandled_outbound_stanzas());
+    }
+
+    #[test]
+    fn resume_state_can_restore_serialized_unhandled_stanzas() {
+        let stanza = Element::builder("message", "jabber:client")
+            .attr(minidom::rxml::xml_ncname!("id").to_owned(), "unacked")
+            .build();
+
+        let resume_state = SmResumeState::from_unhandled_outbound_stanzas(
+            "previous-stream",
+            4,
+            9,
+            [stanza.clone()],
+        )
+        .expect("resume state");
+
+        assert!(resume_state.has_unhandled_outbound_stanzas());
+        assert_eq!(
+            resume_state
+                .unhandled_outbound_stanzas()
+                .collect::<Vec<_>>(),
+            vec![&stanza],
         );
     }
 

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -474,6 +474,7 @@ export class WaddleConfig {
     constructor(server_url: string, jid: string, access_token: string, resource: string);
     with_resume_state(previd: string, inbound_h: number, outbound_h: number): void;
     with_resume_state_handle(state: WaddleResumeState): void;
+    with_resume_state_stanzas(previd: string, inbound_h: number, outbound_h: number, stanzas: string[]): void;
 }
 
 export class WaddleResumeState {


### PR DESCRIPTION
## Summary

- Keep pagehide SM handoff XEP-0198-safe by serializing unhandled native outbound stanzas instead of persisting a false resumable state with an empty replay queue.
- Publish the WASM client's live SM resume snapshot after runtime send/receive mutations so `get_resume_state()` reflects current handled counters and unacked outbound state.
- Mirror live room/DM body sends into the existing durable queue until XEP-0198 ack confirms server handling, and reconcile restored/live SM message IDs so native replay/fallback retry owns resend without browser duplicates.
- Add focused chat, Rust SM, and WASM driver tests for serialized unhandled stanzas, live snapshot ack transitions, restored queue ack removal, successful-resume dedupe, and failed-resume fallback dedupe.

## Plan

- Review reconnect/message-delivery behavior against local XEP docs before editing.
- Focus #810 on XEP-0198 false resumability and unacked outbound delivery semantics.
- Avoid MAM cursor/barrier behavior owned by #812.
- Keep stale IQ `pending_iqs` cancellation as a follow-up unless it proves directly higher-value for this scope.
- Validate with focused chat tests, focused Rust/WASM tests, chat lint, clippy with `-D warnings`, and broader affected Rust tests.
- Run adversarial review passes until no real scoped issues remain.

## XEP Grounding

- XEP-0198: unhandled outbound stanzas remain sender responsibility until acknowledged by peer `h`; resume/failure must either replay, resend, or report failure without silently losing them.
- XEP-0203: fallback retry behavior continues to preserve existing delay stamps for delayed message resend.
- XEP-0313, XEP-0280, XEP-0184, and XEP-0359 were reviewed for interaction risk; this PR deliberately avoids changing archive catch-up, carbons, delivery receipts, or stanza-id semantics.

## Validation

- `bun test tests/resume-persistence.test.ts tests/client-send-readiness.test.ts`
- `bun run lint`
- `cargo test -p waddle-xmpp-client stream_management::tests`
- `cargo test -p waddle-xmpp-client-wasm publish_resume_state_snapshot_tracks_live_ack_mutations`
- `cargo test -p waddle-xmpp-client-wasm`
- `cargo test -p waddle-xmpp-client runtime_preserves_failed_resume_snapshot_until_fallback_retry_is_sent`
- `cargo test -p waddle-xmpp-client` (rerun with socket permissions after sandbox blocked the local transport test)
- `cargo clippy -p waddle-xmpp-client -p waddle-xmpp-client-wasm -- -D warnings`
- `git diff --check`

## Adversarial Review

- TS reconnect/delivery review found the local queue durability gap for live sends.
- Rust/WASM review found the lossy pagehide SM handoff when the replay queue was not serializable.
- Protocol review found the stale live resume snapshot and duplicate resend risks; follow-up passes verified live snapshot publishing, successful-resume queue reconciliation, failed-resume fallback dedupe, and in-memory reconnect failed-resume dedupe.
- Final scoped pass found no remaining actionable XEP-0198/unacked-delivery issue.

## Follow-ups

- `chat/src/lib/xmpp/discovery.ts` still documents stale rejected/aborted discovery promises leaving entries in WASM `pending_iqs`; a small XMPP-native `cancel_iq(id)` driver command should be handled in a dedicated PR.
- MAM stale-cursor/timestamp catch-up barrier ordering is intentionally left to #812.
