### PR TITLE
fix(xmpp): harden xep mam paging catch-up

### DIFF
--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -57,6 +57,7 @@ import { prepareEncryptedAttachmentUpload } from "./encrypted-attachments";
 import { discoverChannels, discoverTopology } from "./discovery";
 import { discoverUploadService, uploadFile, type UploadProgress } from "./file-upload";
 import { ReconnectCatchup } from "./reconnect-catchup";
+import { classifyMamError, isMamCursorNotFound } from "./mam";
 import { parseRegisterDeviceResult, type RegisterDeviceResult } from "./push-register-result";
 import {
   createLocalStorageResumePersistence,
@@ -177,6 +178,10 @@ function pageLastArchiveId(page: WasmMamPage | null | undefined): string | undef
 function pageFirstArchiveId(page: WasmMamPage | null | undefined): string | undefined {
   const compat = page as (WasmMamPage & { firstArchiveId?: string }) | null | undefined;
   return compat?.first_id ?? compat?.firstArchiveId;
+}
+
+function pageContainsArchiveId(page: WasmMamPage | null | undefined, archiveId: string): boolean {
+  return (page?.messages ?? []).some((message) => message.mam_id === archiveId);
 }
 
 function compareTimestamps(left: string, right: string): number {
@@ -2686,11 +2691,22 @@ export class BrowserXmppClient {
       while (after) {
         if (seenAfter.has(after)) throw new Error(`Reconnect catch-up repeated archive cursor for ${entry.key}`);
         seenAfter.add(after);
-        const page = await xmpp.fetch_dm_history_page(entry.key, 100, { type: "after", after }) as WasmMamPage;
+        let page: WasmMamPage;
+        try {
+          page = await xmpp.fetch_dm_history_page(entry.key, 100, { type: "after", after }) as WasmMamPage;
+        } catch (error) {
+          if (isMamCursorNotFound(classifyMamError(error))) {
+            const since = entry.since ?? this.catchup.getDmLastSeen(entry.key);
+            if (since) await this.runDmTimestampCatchup(xmpp, entry.key, since, sessionJid, entry.seenIds);
+            return;
+          }
+          throw error;
+        }
         if (!this.isCurrentConnectedXmpp(xmpp, sessionJid)) return;
+        if (pageContainsArchiveId(page, after)) throw new Error(`Reconnect catch-up received non-advancing archive cursor for ${entry.key}`);
         const nextAfter = this.applyDmCatchupPage(page, undefined, entry.seenIds);
         if (isMamPageComplete(page)) return;
-        if (!nextAfter) throw new Error(`Reconnect catch-up could not advance archive cursor for ${entry.key}`);
+        if (!nextAfter || nextAfter === after) throw new Error(`Reconnect catch-up could not advance archive cursor for ${entry.key}`);
         after = nextAfter;
       }
       return;
@@ -2711,11 +2727,22 @@ export class BrowserXmppClient {
       while (after) {
         if (seenAfter.has(after)) throw new Error(`Reconnect catch-up repeated archive cursor for ${entry.key}`);
         seenAfter.add(after);
-        const page = await xmpp.fetch_room_history_page(entry.key, 100, { type: "after", after }) as WasmMamPage;
+        let page: WasmMamPage;
+        try {
+          page = await xmpp.fetch_room_history_page(entry.key, 100, { type: "after", after }) as WasmMamPage;
+        } catch (error) {
+          if (isMamCursorNotFound(classifyMamError(error))) {
+            const since = entry.since ?? this.catchup.getRoomLastSeen(entry.key);
+            if (since) await this.runRoomTimestampCatchup(xmpp, entry.key, since, sessionJid, entry.seenIds);
+            return;
+          }
+          throw error;
+        }
         if (!this.isCurrentConnectedXmpp(xmpp, sessionJid)) return;
+        if (pageContainsArchiveId(page, after)) throw new Error(`Reconnect catch-up received non-advancing archive cursor for ${entry.key}`);
         const nextAfter = this.applyRoomCatchupPage(page, undefined, entry.seenIds);
         if (isMamPageComplete(page)) return;
-        if (!nextAfter) throw new Error(`Reconnect catch-up could not advance archive cursor for ${entry.key}`);
+        if (!nextAfter || nextAfter === after) throw new Error(`Reconnect catch-up could not advance archive cursor for ${entry.key}`);
         after = nextAfter;
       }
       return;

--- a/chat/src/lib/xmpp/reconnect-catchup.ts
+++ b/chat/src/lib/xmpp/reconnect-catchup.ts
@@ -37,6 +37,8 @@ type CatchupEntry =
 type SeenCursor = {
   timestamp: string;
   archiveId?: string;
+  archiveTimestamp?: string;
+  archiveSeenIds?: string[];
   seenIds?: string[];
 };
 
@@ -96,10 +98,10 @@ export class ReconnectCatchup {
 
   private absorbRemoteSnapshot(remote: PersistedReconnectCatchup): void {
     for (const [key, cursor] of remote.dmLastSeen) {
-      advance(this.dmLastSeen, key, cursor.timestamp, cursor.archiveId, cursor.seenIds);
+      advance(this.dmLastSeen, key, cursor.timestamp, cursor.archiveId, cursor.seenIds, cursor.archiveTimestamp, cursor.archiveSeenIds);
     }
     for (const [key, cursor] of remote.roomLastSeen) {
-      advance(this.roomLastSeen, key, cursor.timestamp, cursor.archiveId, cursor.seenIds);
+      advance(this.roomLastSeen, key, cursor.timestamp, cursor.archiveId, cursor.seenIds, cursor.archiveTimestamp, cursor.archiveSeenIds);
     }
   }
 
@@ -168,11 +170,13 @@ function catchupEntry(kind: "dm" | "room", key: string, cursor: SeenCursor): Cat
       ...(cursor.seenIds?.length ? { seenIds: cursor.seenIds } : {}),
     };
   }
+  const seenIds = mergeSeenIds(cursor.archiveSeenIds, cursor.seenIds);
   return {
     kind,
     key,
     after: cursor.archiveId,
-    ...(cursor.seenIds?.length ? { seenIds: cursor.seenIds } : {}),
+    since: cursor.archiveTimestamp ?? cursor.timestamp,
+    ...(seenIds.length ? { seenIds } : {}),
   };
 }
 
@@ -182,27 +186,50 @@ function advance(
   timestamp: string,
   archiveId?: string,
   seenIds?: ReadonlyArray<string>,
+  archiveTimestamp?: string,
+  archiveSeenIds?: ReadonlyArray<string>,
 ): void {
   const normalizedTimestamp = normalizeTimestamp(timestamp);
+  const normalizedArchiveTimestamp = archiveTimestamp ? normalizeTimestamp(archiveTimestamp) : undefined;
   const current = map.get(key);
   const ordering = current ? compareTimestamps(normalizedTimestamp, current.timestamp) : 1;
   if (current === undefined || ordering > 0) {
     const nextArchiveId = archiveId ?? current?.archiveId;
+    const nextArchiveTimestamp = archiveId ? (normalizedArchiveTimestamp ?? normalizedTimestamp) : current?.archiveTimestamp;
+    const preservedArchiveSeenIds = current?.archiveSeenIds ?? (current?.archiveId ? current.seenIds : undefined);
+    const nextArchiveSeenIds = archiveId
+      ? mergeSeenIds(archiveSeenIds, seenIds)
+      : mergeSeenIds(preservedArchiveSeenIds, archiveSeenIds);
+    const nextSeenIds = nextArchiveId && !archiveId
+      ? mergeSeenIds(current?.seenIds, seenIds)
+      : mergeSeenIds(undefined, seenIds);
     map.set(key, {
       timestamp: normalizedTimestamp,
       ...(nextArchiveId ? { archiveId: nextArchiveId } : {}),
-      ...nonEmptySeenIds(seenIds),
+      ...(nextArchiveTimestamp ? { archiveTimestamp: nextArchiveTimestamp } : {}),
+      ...nonEmptyArchiveSeenIds(nextArchiveSeenIds),
+      ...nonEmptySeenIds(nextSeenIds),
     });
     return;
   }
   if (ordering === 0) {
     const nextSeenIds = mergeSeenIds(current.seenIds, seenIds);
+    const nextArchiveSeenIds = archiveId
+      ? mergeSeenIds(current.archiveSeenIds, mergeSeenIds(archiveSeenIds, seenIds))
+      : mergeSeenIds(current.archiveSeenIds, archiveSeenIds);
     map.set(key, {
       ...current,
       ...(archiveId ? { archiveId } : {}),
+      ...(archiveId ? { archiveTimestamp: normalizedArchiveTimestamp ?? normalizedTimestamp } : {}),
+      ...nonEmptyArchiveSeenIds(nextArchiveSeenIds),
       ...nonEmptySeenIds(nextSeenIds),
     });
   }
+}
+
+function nonEmptyArchiveSeenIds(seenIds: ReadonlyArray<string> | undefined): Partial<Pick<SeenCursor, "archiveSeenIds">> {
+  const normalized = mergeSeenIds(undefined, seenIds);
+  return normalized.length > 0 ? { archiveSeenIds: normalized } : {};
 }
 
 function nonEmptySeenIds(seenIds: ReadonlyArray<string> | undefined): Partial<Pick<SeenCursor, "seenIds">> {

--- a/chat/src/lib/xmpp/resume-persistence.ts
+++ b/chat/src/lib/xmpp/resume-persistence.ts
@@ -37,6 +37,8 @@ const OWNER_HANDOFF_PREFIX = `${SM_PREFIX}.owner-handoff`;
 export type PersistedSeenCursor = {
   timestamp: string;
   archiveId?: string;
+  archiveTimestamp?: string;
+  archiveSeenIds?: string[];
   seenIds?: string[];
 };
 
@@ -412,6 +414,11 @@ function isPersistedSeenCursor(value: unknown): value is PersistedSeenCursor {
   const candidate = value as Record<string, unknown>;
   if (typeof candidate.timestamp !== "string") return false;
   if (candidate.archiveId !== undefined && typeof candidate.archiveId !== "string") return false;
+  if (candidate.archiveTimestamp !== undefined && typeof candidate.archiveTimestamp !== "string") return false;
+  if (candidate.archiveSeenIds !== undefined) {
+    if (!Array.isArray(candidate.archiveSeenIds)) return false;
+    if (!candidate.archiveSeenIds.every((id) => typeof id === "string")) return false;
+  }
   if (candidate.seenIds !== undefined) {
     if (!Array.isArray(candidate.seenIds)) return false;
     if (!candidate.seenIds.every((id) => typeof id === "string")) return false;

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -801,7 +801,7 @@ describe("client keepalive lifecycle", () => {
       peerJid: "bob@example.com",
     }));
     expect(catchup.onSessionStarted()).toEqual([
-      { kind: "dm", key: "bob@example.com", after: "mam-newer", seenIds: ["dm-newer"] },
+      { kind: "dm", key: "bob@example.com", after: "mam-newer", since: "2024-01-01T00:00:01.000Z", seenIds: ["dm-newer"] },
     ]);
   });
 
@@ -1269,6 +1269,127 @@ describe("client keepalive lifecycle", () => {
     expect(dmHandler).toHaveBeenCalledTimes(2);
   });
 
+  test("tracked DM catch-up rejects non-advancing after pages before delivery", async () => {
+    const client = new BrowserXmppClient(session());
+    const catchup = (client as unknown as {
+      catchup: {
+        recordDmSeen: (peer: string, ts: string, archiveId?: string, seenIds?: string[]) => void;
+        onSessionStarted: () => unknown[];
+      };
+    }).catchup;
+    catchup.recordDmSeen("bob@example.com", "2024-01-01T00:00:00.000Z", "mam-1", ["dm-1"]);
+    catchup.onSessionStarted();
+    const dmHandler = mock(() => undefined);
+    const errorHandler = mock(() => undefined);
+    client.setDirectMessageHandler(dmHandler);
+    client.onError(errorHandler);
+    const fetchDmHistoryPage = mock(async () => ({
+      messages: [dmWasmMessage({
+        mam_id: "mam-1",
+        id: "dm-duplicate-cursor",
+        body: "duplicate cursor row",
+        timestamp: "2024-01-01T00:00:00.000Z",
+      })],
+      last_id: "mam-1",
+      is_complete: false,
+    }));
+
+    const xmpp = Object.assign(new EventEmitter(), {
+      fetch_dm_history_page: fetchDmHistoryPage,
+    }) as unknown as Agent;
+    (client as unknown as { xmpp: Agent }).xmpp = xmpp;
+    (client as unknown as { wireEvents: (xmpp: Agent) => void }).wireEvents(xmpp);
+
+    xmpp.emit("stream:management:resumed");
+    await settleReconnectCatchup();
+
+    expect(fetchDmHistoryPage).toHaveBeenCalledTimes(1);
+    expect(fetchDmHistoryPage).toHaveBeenCalledWith("bob@example.com", 100, {
+      type: "after",
+      after: "mam-1",
+    });
+    expect(dmHandler).not.toHaveBeenCalled();
+    expect(errorHandler).toHaveBeenCalledWith(expect.objectContaining({
+      kind: "history",
+      recoverable: true,
+      detail: "Reconnect catch-up failed for bob@example.com",
+    }));
+    expect(normalizeError(errorHandler.mock.calls[0]?.[0]?.cause)).toContain("non-advancing archive cursor");
+  });
+
+  test("tracked DM catch-up falls back to timestamp paging when after cursor is gone", async () => {
+    const client = new BrowserXmppClient(session());
+    const catchup = (client as unknown as {
+      catchup: {
+        recordDmSeen: (peer: string, ts: string, archiveId?: string, seenIds?: string[]) => void;
+        onSessionStarted: () => unknown[];
+      };
+    }).catchup;
+    catchup.recordDmSeen("bob@example.com", "2024-01-01T00:00:00.000Z", "mam-stale", ["dm-seen"]);
+    catchup.recordDmSeen("bob@example.com", "2024-01-01T00:00:01.500Z", undefined, ["dm-live-already-seen-1"]);
+    catchup.recordDmSeen("bob@example.com", "2024-01-01T00:00:02.000Z", undefined, ["dm-live-already-seen-2"]);
+    catchup.onSessionStarted();
+    const dmHandler = mock(() => undefined);
+    const errorHandler = mock(() => undefined);
+    client.setDirectMessageHandler(dmHandler);
+    client.onError(errorHandler);
+    const fetchDmHistoryPage = mock(async (_peer: string, _max: number, pageParam: { type: string }) => {
+      if (pageParam.type === "after") throw new Error("stanza error: item-not-found");
+      return {
+        messages: [
+          dmWasmMessage({
+            mam_id: "mam-seen-sibling",
+            id: "dm-seen",
+            body: "already seen at stale archive timestamp",
+            timestamp: "2024-01-01T00:00:00.000Z",
+          }),
+          dmWasmMessage({
+            mam_id: "mam-recovered",
+            id: "dm-recovered",
+            body: "recovered between stale cursor and live watermark",
+            timestamp: "2024-01-01T00:00:01.000Z",
+          }),
+          dmWasmMessage({
+            mam_id: "mam-live-already-seen-1",
+            id: "dm-live-already-seen-1",
+            body: "already delivered live before latest watermark",
+            timestamp: "2024-01-01T00:00:01.500Z",
+          }),
+          dmWasmMessage({
+            mam_id: "mam-live-already-seen-2",
+            id: "dm-live-already-seen-2",
+            body: "already delivered live at latest watermark",
+            timestamp: "2024-01-01T00:00:02.000Z",
+          }),
+        ],
+        first_id: "mam-seen-sibling",
+        last_id: "mam-live-already-seen-2",
+        is_complete: true,
+      };
+    });
+
+    const xmpp = Object.assign(new EventEmitter(), {
+      fetch_dm_history_page: fetchDmHistoryPage,
+    }) as unknown as Agent;
+    (client as unknown as { xmpp: Agent }).xmpp = xmpp;
+    (client as unknown as { wireEvents: (xmpp: Agent) => void }).wireEvents(xmpp);
+
+    xmpp.emit("stream:management:resumed");
+    await settleReconnectCatchup();
+
+    expect(fetchDmHistoryPage).toHaveBeenNthCalledWith(1, "bob@example.com", 100, {
+      type: "after",
+      after: "mam-stale",
+    });
+    expect(fetchDmHistoryPage).toHaveBeenNthCalledWith(2, "bob@example.com", 100, { type: "latest" });
+    expect(errorHandler).not.toHaveBeenCalled();
+    expect(dmHandler).toHaveBeenCalledTimes(1);
+    expect(dmHandler).toHaveBeenCalledWith(expect.objectContaining({
+      id: "dm-recovered",
+      body: "recovered between stale cursor and live watermark",
+    }));
+  });
+
   test("pages tracked DM catch-up forward beyond fifty pages until MAM is complete", async () => {
     const client = new BrowserXmppClient(session());
     const catchup = (client as unknown as {
@@ -1341,7 +1462,7 @@ describe("client keepalive lifecycle", () => {
     await client.queryPersonalMamPage("bob@example.com", 100, { type: "latest" });
 
     expect((client as unknown as { catchup: { onSessionStarted: () => unknown[] } }).catchup.onSessionStarted()).toEqual([
-      { kind: "dm", key: "bob@example.com", after: "mam-loaded-1", seenIds: ["dm-loaded-1"] },
+      { kind: "dm", key: "bob@example.com", after: "mam-loaded-1", since: "2024-01-01T00:00:01.000Z", seenIds: ["dm-loaded-1"] },
     ]);
   });
 
@@ -1372,7 +1493,7 @@ describe("client keepalive lifecycle", () => {
 
     expect(fetchRoomHistoryByThread).toHaveBeenCalledWith(roomJid, "thread-1", 100, null);
     expect((client as unknown as { catchup: { onSessionStarted: () => unknown[] } }).catchup.onSessionStarted()).toEqual([
-      { kind: "room", key: roomJid, after: "mam-thread-1", seenIds: ["room-thread-1"] },
+      { kind: "room", key: roomJid, after: "mam-thread-1", since: "2024-01-01T00:00:01.000Z", seenIds: ["room-thread-1"] },
     ]);
   });
 
@@ -1403,7 +1524,7 @@ describe("client keepalive lifecycle", () => {
 
     expect(fetchRoomHistoryByThread).toHaveBeenCalledWith(roomJid, "thread-1", 100, null);
     expect((client as unknown as { catchup: { onSessionStarted: () => unknown[] } }).catchup.onSessionStarted()).toEqual([
-      { kind: "room", key: roomJid, after: "mam-thread-list-1", seenIds: ["room-thread-list-1"] },
+      { kind: "room", key: roomJid, after: "mam-thread-list-1", since: "2024-01-01T00:00:01.000Z", seenIds: ["room-thread-list-1"] },
     ]);
   });
 
@@ -1455,7 +1576,7 @@ describe("client keepalive lifecycle", () => {
       body: "newer missed room message",
     }));
     expect(catchup.onSessionStarted()).toEqual([
-      { kind: "room", key: roomJid, after: "mam-room-newer", seenIds: ["room-newer"] },
+      { kind: "room", key: roomJid, after: "mam-room-newer", since: "2024-01-01T00:00:01.000Z", seenIds: ["room-newer"] },
     ]);
   });
 
@@ -1696,7 +1817,7 @@ describe("client keepalive lifecycle", () => {
 
     await client.queryMamPage("w1", "c1", 100, { type: "latest" });
     expect(catchup.onSessionStarted()).toEqual([
-      { kind: "room", key: roomJid, after: "mam-room-1", seenIds: ["room-1"] },
+      { kind: "room", key: roomJid, after: "mam-room-1", since: "2024-01-01T00:00:00.000Z", seenIds: ["room-1"] },
     ]);
 
     (client as unknown as { currentRoom: string | null }).currentRoom = roomJid;
@@ -1722,6 +1843,132 @@ describe("client keepalive lifecycle", () => {
       id: "room-3",
       body: "second missed room page",
       roomJid,
+    }));
+  });
+
+  test("tracked room catch-up rejects non-advancing after pages before activity delivery", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    const catchup = (client as unknown as {
+      catchup: {
+        recordRoomSeen: (room: string, ts: string, archiveId?: string, seenIds?: string[]) => void;
+        onSessionStarted: () => unknown[];
+      };
+    }).catchup;
+    catchup.recordRoomSeen(roomJid, "2024-01-01T00:00:00.000Z", "mam-room-1", ["room-1"]);
+    catchup.onSessionStarted();
+    const activityHandler = mock(() => undefined);
+    const errorHandler = mock(() => undefined);
+    client.setActivityHandler(activityHandler);
+    client.onError(errorHandler);
+    const fetchRoomHistoryPage = mock(async () => ({
+      messages: [roomWasmMessage({
+        mam_id: "mam-room-1",
+        id: "room-duplicate-cursor",
+        from: `${roomJid}/bob`,
+        body: "duplicate room cursor row",
+        timestamp: "2024-01-01T00:00:00.000Z",
+      })],
+      last_id: "mam-room-1",
+      is_complete: false,
+    }));
+    const xmpp = Object.assign(new EventEmitter(), {
+      fetch_room_history_page: fetchRoomHistoryPage,
+    }) as unknown as Agent;
+    (client as unknown as { xmpp: Agent }).xmpp = xmpp;
+    (client as unknown as { wireEvents: (xmpp: Agent) => void }).wireEvents(xmpp);
+
+    xmpp.emit("stream:management:resumed");
+    await settleReconnectCatchup();
+
+    expect(fetchRoomHistoryPage).toHaveBeenCalledTimes(1);
+    expect(fetchRoomHistoryPage).toHaveBeenCalledWith(roomJid, 100, {
+      type: "after",
+      after: "mam-room-1",
+    });
+    expect(activityHandler).not.toHaveBeenCalled();
+    expect(errorHandler).toHaveBeenCalledWith(expect.objectContaining({
+      kind: "history",
+      recoverable: true,
+      detail: `Reconnect catch-up failed for ${roomJid}`,
+    }));
+    expect(normalizeError(errorHandler.mock.calls[0]?.[0]?.cause)).toContain("non-advancing archive cursor");
+  });
+
+  test("tracked room catch-up falls back to timestamp paging when after cursor is gone", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    const catchup = (client as unknown as {
+      catchup: {
+        recordRoomSeen: (room: string, ts: string, archiveId?: string, seenIds?: string[]) => void;
+        onSessionStarted: () => unknown[];
+      };
+    }).catchup;
+    catchup.recordRoomSeen(roomJid, "2024-01-01T00:00:00.000Z", "mam-room-stale", ["room-seen"]);
+    catchup.recordRoomSeen(roomJid, "2024-01-01T00:00:01.500Z", undefined, ["room-live-already-seen-1"]);
+    catchup.recordRoomSeen(roomJid, "2024-01-01T00:00:02.000Z", undefined, ["room-live-already-seen-2"]);
+    catchup.onSessionStarted();
+    const activityHandler = mock(() => undefined);
+    const errorHandler = mock(() => undefined);
+    client.setActivityHandler(activityHandler);
+    client.onError(errorHandler);
+    const fetchRoomHistoryPage = mock(async (_room: string, _max: number, pageParam: { type: string }) => {
+      if (pageParam.type === "after") throw new Error("stanza error: item-not-found");
+      return {
+        messages: [
+          roomWasmMessage({
+            mam_id: "mam-room-seen-sibling",
+            id: "room-seen",
+            from: `${roomJid}/bob`,
+            body: "already seen at stale archive timestamp",
+            timestamp: "2024-01-01T00:00:00.000Z",
+          }),
+          roomWasmMessage({
+            mam_id: "mam-room-recovered",
+            id: "room-recovered",
+            from: `${roomJid}/bob`,
+            body: "recovered room activity",
+            timestamp: "2024-01-01T00:00:01.000Z",
+          }),
+          roomWasmMessage({
+            mam_id: "mam-room-live-already-seen-1",
+            id: "room-live-already-seen-1",
+            from: `${roomJid}/bob`,
+            body: "already delivered live before latest watermark",
+            timestamp: "2024-01-01T00:00:01.500Z",
+          }),
+          roomWasmMessage({
+            mam_id: "mam-room-live-already-seen-2",
+            id: "room-live-already-seen-2",
+            from: `${roomJid}/bob`,
+            body: "already delivered live at latest watermark",
+            timestamp: "2024-01-01T00:00:02.000Z",
+          }),
+        ],
+        first_id: "mam-room-seen-sibling",
+        last_id: "mam-room-live-already-seen-2",
+        is_complete: true,
+      };
+    });
+    const xmpp = Object.assign(new EventEmitter(), {
+      fetch_room_history_page: fetchRoomHistoryPage,
+    }) as unknown as Agent;
+    (client as unknown as { xmpp: Agent }).xmpp = xmpp;
+    (client as unknown as { wireEvents: (xmpp: Agent) => void }).wireEvents(xmpp);
+
+    xmpp.emit("stream:management:resumed");
+    await settleReconnectCatchup();
+
+    expect(fetchRoomHistoryPage).toHaveBeenNthCalledWith(1, roomJid, 100, {
+      type: "after",
+      after: "mam-room-stale",
+    });
+    expect(fetchRoomHistoryPage).toHaveBeenNthCalledWith(2, roomJid, 100, { type: "latest" });
+    expect(errorHandler).not.toHaveBeenCalled();
+    expect(activityHandler).toHaveBeenCalledTimes(1);
+    expect(activityHandler).toHaveBeenCalledWith(expect.objectContaining({
+      roomJid,
+      body: "recovered room activity",
     }));
   });
 });

--- a/chat/tests/reconnect-catchup.test.ts
+++ b/chat/tests/reconnect-catchup.test.ts
@@ -31,11 +31,13 @@ describe("ReconnectCatchup", () => {
       kind: "dm",
       key: "bob@example.com",
       after: "dm-arch-1",
+      since: "2024-01-01T00:00:00.000Z",
     });
     expect(entries).toContainEqual({
       kind: "room",
       key: "general@muc.example.com",
       after: "room-arch-1",
+      since: "2024-01-02T00:00:00.000Z",
     });
   });
 
@@ -100,7 +102,7 @@ describe("ReconnectCatchup", () => {
     c.onSessionStarted();
 
     expect(c.onSessionStarted()).toEqual([
-      { kind: "dm", key: "bob@example.com", after: "dm-arch-2" },
+      { kind: "dm", key: "bob@example.com", after: "dm-arch-2", since: "2024-01-02T00:00:00.000Z" },
     ]);
   });
 
@@ -112,14 +114,15 @@ describe("ReconnectCatchup", () => {
     c.onSessionStarted();
 
     expect(c.onSessionStarted()).toEqual([
-      { kind: "dm", key: "bob@example.com", after: "dm-arch-2" },
+      { kind: "dm", key: "bob@example.com", after: "dm-arch-2", since: "2024-01-02T00:00:00.000Z" },
     ]);
   });
 
   test("newer live timestamps do not discard the last authoritative archive id", () => {
     const c = new ReconnectCatchup();
-    c.recordDmSeen("bob@example.com", "2024-01-02T00:00:00Z", "dm-arch-2");
-    c.recordDmSeen("bob@example.com", "2024-01-02T00:00:01Z", undefined, ["dm-live-3"]);
+    c.recordDmSeen("bob@example.com", "2024-01-02T00:00:00Z", "dm-arch-2", ["dm-arch-message"]);
+    c.recordDmSeen("bob@example.com", "2024-01-02T00:00:01Z", undefined, ["dm-live-1"]);
+    c.recordDmSeen("bob@example.com", "2024-01-02T00:00:02Z", undefined, ["dm-live-2"]);
 
     c.onSessionStarted();
 
@@ -128,7 +131,8 @@ describe("ReconnectCatchup", () => {
         kind: "dm",
         key: "bob@example.com",
         after: "dm-arch-2",
-        seenIds: ["dm-live-3"],
+        since: "2024-01-02T00:00:00.000Z",
+        seenIds: ["dm-arch-message", "dm-live-1", "dm-live-2"],
       },
     ]);
   });
@@ -145,6 +149,7 @@ describe("ReconnectCatchup", () => {
         kind: "dm",
         key: "bob@example.com",
         after: "dm-arch-2",
+        since: "2024-01-02T00:00:00.000Z",
         seenIds: ["dm-live-same-time"],
       },
     ]);

--- a/chat/tests/resume-persistence.test.ts
+++ b/chat/tests/resume-persistence.test.ts
@@ -146,7 +146,7 @@ describe("ReconnectCatchup persistence — hydrate from snapshot on construct", 
     const c = new ReconnectCatchup(persistence);
     const entries = c.onSessionStarted();
     expect(entries).toEqual([
-      { kind: "dm", key: "bob@example.com", after: "dm-arch-1" },
+      { kind: "dm", key: "bob@example.com", after: "dm-arch-1", since: "2026-05-20T10:00:00.000Z" },
     ]);
   });
 
@@ -177,7 +177,11 @@ describe("ReconnectCatchup persistence — writes back on advance", () => {
     expect(snapshot).not.toBeNull();
     expect(snapshot!.dmLastSeen).toContainEqual([
       "bob@example.com",
-      { timestamp: "2026-05-20T10:00:00.000Z", archiveId: "dm-arch-1" },
+      {
+        timestamp: "2026-05-20T10:00:00.000Z",
+        archiveId: "dm-arch-1",
+        archiveTimestamp: "2026-05-20T10:00:00.000Z",
+      },
     ]);
   });
 

--- a/server/crates/waddle-xmpp/src/mam/storage/in_memory.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/in_memory.rs
@@ -199,7 +199,7 @@ impl MamStorage for InMemoryMamStorage {
         let mut complete = true;
         if messages.len() > actual_limit {
             messages.truncate(actual_limit);
-            complete = false;
+            complete = actual_limit == 0;
         }
 
         if uses_backward_pagination(query) {

--- a/server/crates/waddle-xmpp/src/mam/storage/query_semantics.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/query_semantics.rs
@@ -44,7 +44,7 @@ pub(super) fn finalize_result(
     count: Option<u32>,
 ) -> MamResult {
     let actual_limit = query.max.unwrap_or(100).min(500) as usize;
-    let complete = messages.len() <= actual_limit;
+    let complete = actual_limit == 0 || messages.len() <= actual_limit;
 
     if messages.len() > actual_limit {
         messages.pop();

--- a/server/crates/waddle-xmpp/src/mam/storage/tests.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/tests.rs
@@ -484,6 +484,73 @@ async fn assert_rsm_before_uses_archive_order_not_lexical_id_order(storage: &dyn
 }
 
 #[tokio::test]
+async fn test_sqlite_rsm_cursors_page_same_timestamp_by_archive_id() {
+    let storage = create_test_storage().await;
+    assert_rsm_cursors_page_same_timestamp_by_archive_id(&storage).await;
+}
+
+#[tokio::test]
+async fn test_inmemory_rsm_cursors_page_same_timestamp_by_archive_id() {
+    let storage = InMemoryMamStorage::new();
+    assert_rsm_cursors_page_same_timestamp_by_archive_id(&storage).await;
+}
+
+async fn assert_rsm_cursors_page_same_timestamp_by_archive_id(storage: &dyn MamStorage) {
+    let archive = bare("room@conference.example.com");
+    let timestamp = chrono::DateTime::parse_from_rfc3339("2026-05-01T10:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    for id in ["id-c", "id-a", "id-d", "id-b"] {
+        storage
+            .store_message(
+                &archive,
+                &ArchivedMessage {
+                    id: id.to_string(),
+                    timestamp,
+                    body: Some(id.to_string()),
+                    ..archived_groupchat(&archive)
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    let after = storage
+        .query_messages(
+            &archive,
+            &MamQuery {
+                max: Some(2),
+                after_id: Some("id-b".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    let after_ids: Vec<&str> = after.messages.iter().map(|m| m.id.as_str()).collect();
+    assert_eq!(after_ids, vec!["id-c", "id-d"]);
+    assert_eq!(after.first_id.as_deref(), Some("id-c"));
+    assert_eq!(after.last_id.as_deref(), Some("id-d"));
+    assert!(after.complete);
+
+    let before = storage
+        .query_messages(
+            &archive,
+            &MamQuery {
+                max: Some(2),
+                before_id: Some("id-d".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    let before_ids: Vec<&str> = before.messages.iter().map(|m| m.id.as_str()).collect();
+    assert_eq!(before_ids, vec!["id-b", "id-c"]);
+    assert_eq!(before.first_id.as_deref(), Some("id-b"));
+    assert_eq!(before.last_id.as_deref(), Some("id-c"));
+    assert!(!before.complete);
+}
+
+#[tokio::test]
 async fn test_sqlite_extended_before_id_filters_without_flipping_order() {
     let storage = create_test_storage().await;
     assert_extended_before_id_filters_without_flipping_order(&storage).await;
@@ -706,6 +773,93 @@ async fn assert_rsm_cursor_outside_query_filters_still_pages(storage: &dyn MamSt
         .unwrap();
 
     assert_eq!(bodies(&result), vec!["four", "five"]);
+}
+
+#[tokio::test]
+async fn test_sqlite_rsm_max_zero_returns_count_only() {
+    let storage = create_test_storage().await;
+    assert_rsm_max_zero_returns_count_only(&storage).await;
+}
+
+#[tokio::test]
+async fn test_inmemory_rsm_max_zero_returns_count_only() {
+    let storage = InMemoryMamStorage::new();
+    assert_rsm_max_zero_returns_count_only(&storage).await;
+}
+
+async fn assert_rsm_max_zero_returns_count_only(storage: &dyn MamStorage) {
+    let archive = bare("room@conference.example.com");
+    let base = Utc::now();
+    store_nonlexical_archive_order_messages(storage, &archive, base).await;
+
+    let result = storage
+        .query_messages(
+            &archive,
+            &MamQuery {
+                max: Some(0),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(result.messages.is_empty());
+    assert_eq!(result.first_id, None);
+    assert_eq!(result.last_id, None);
+    assert_eq!(result.count, Some(5));
+    assert!(result.complete);
+}
+
+#[tokio::test]
+async fn test_sqlite_rsm_empty_edge_pages_omit_first_and_last() {
+    let storage = create_test_storage().await;
+    assert_rsm_empty_edge_pages_omit_first_and_last(&storage).await;
+}
+
+#[tokio::test]
+async fn test_inmemory_rsm_empty_edge_pages_omit_first_and_last() {
+    let storage = InMemoryMamStorage::new();
+    assert_rsm_empty_edge_pages_omit_first_and_last(&storage).await;
+}
+
+async fn assert_rsm_empty_edge_pages_omit_first_and_last(storage: &dyn MamStorage) {
+    let archive = bare("room@conference.example.com");
+    let base = Utc::now();
+    store_nonlexical_archive_order_messages(storage, &archive, base).await;
+
+    let after_last = storage
+        .query_messages(
+            &archive,
+            &MamQuery {
+                max: Some(2),
+                after_id: Some("x-fifth".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert!(after_last.messages.is_empty());
+    assert!(after_last.complete);
+    assert_eq!(after_last.first_id, None);
+    assert_eq!(after_last.last_id, None);
+    assert_eq!(after_last.count, Some(5));
+
+    let before_first = storage
+        .query_messages(
+            &archive,
+            &MamQuery {
+                max: Some(2),
+                before_id: Some("z-first".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert!(before_first.messages.is_empty());
+    assert!(before_first.complete);
+    assert_eq!(before_first.first_id, None);
+    assert_eq!(before_first.last_id, None);
+    assert_eq!(before_first.count, Some(5));
 }
 
 fn bodies(result: &MamResult) -> Vec<&str> {


### PR DESCRIPTION
## Summary

- Fix XEP-0059/XEP-0313 MAM storage paging edge cases for same-timestamp archive IDs, empty edge pages, stale cursors, and max=0 count-only requests.
- Harden reconnect catch-up after MAM cursors: stale after cursors fall back to timestamp paging, non-advancing pages fail before delivery, and archive/live seen IDs prevent duplicate delivery across the fallback interval.
- Add focused server and chat regressions for duplicate, skipped, non-advancing, empty-page, max=0/count, same-timestamp, before/after, and filtered-cursor behavior.

## Plan / Validation

- Reviewed local XEP-0059 and XEP-0313 corpus from ./xeps for RSM max=0/count, before/after cursor, and chronological MAM result expectations.
- Server: add storage tests and fix count-only completion semantics in SQL finalization and in-memory storage.
- Chat: add stale cursor fallback and non-advancing page guards for DM and room reconnect catch-up.
- Chat: persist archive cursor timestamp and boundary seen IDs separately from newer live seen IDs so stale fallback remains chronological without duplicates.

## Local checks

- cargo fmt --check
- cargo test -p waddle-xmpp rsm_
- bun test tests/reconnect-catchup.test.ts tests/client-send-readiness.test.ts tests/resume-persistence.test.ts
- bun run lint

## Review

- Adversarial server storage review: no real actionable issues after fixes.
- Adversarial chat reconnect catch-up review: no real actionable issues after fixes.
