### PR TITLE
fix(server): conform XEP-0393 message styling parser

### DIFF
--- a/server/crates/waddle-xmpp/src/disco/info.rs
+++ b/server/crates/waddle-xmpp/src/disco/info.rs
@@ -99,6 +99,16 @@ mod tests {
     }
 
     #[test]
+    fn server_features_do_not_advertise_message_styling_parser() {
+        // XEP-0393 discovery is for entities that support rendering
+        // message styling. The server library exposes a conformant body
+        // parser and `<unstyled/>` helper, but routing/archive entities
+        // must not advertise the client-rendering feature from that alone.
+        let features = server_features();
+        assert!(!features.contains(&Feature::new(crate::xep::NS_STYLING)));
+    }
+
+    #[test]
     fn call_features_returns_eight_canonical_namespaces() {
         let features = call_features();
         let expected = [

--- a/server/crates/waddle-xmpp/src/xep/exports.rs
+++ b/server/crates/waddle-xmpp/src/xep/exports.rs
@@ -173,8 +173,9 @@ pub use waddle_xmpp_core::xep0392::{
 };
 
 pub use super::xep0393::{
-    blocks_to_html, blocks_to_plain, parse_blocks, parse_spans, spans_to_html, spans_to_plain,
-    Block, Span, StyledBody,
+    add_unstyled, blocks_to_html, blocks_to_plain, build_unstyled_element, has_unstyled,
+    is_unstyled_element, parse_blocks, parse_message_body, parse_spans, spans_to_html,
+    spans_to_plain, strip_unstyled, Block, Span, StyledBody, StylingCarrier, NS_STYLING,
 };
 
 pub use waddle_xmpp_core::xep0359::{

--- a/server/crates/waddle-xmpp/src/xep/xep0393.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0393.rs
@@ -1,7 +1,8 @@
 //! XEP-0393: Message Styling
 //!
 //! Parses inline text styling directives from XMPP message bodies.
-//! This is a body-level formatting spec (not XML element payloads).
+//! The text styling grammar operates on `<body/>` text; the
+//! `<unstyled/>` payload is the stanza-level opt-out defined by the XEP.
 //!
 //! ## Supported Styles
 //!
@@ -14,11 +15,18 @@
 //!
 //! ## Rules
 //!
-//! - Styling directives must start at a word boundary (start of line,
-//!   or preceded by whitespace/punctuation).
-//! - Closing directive must end at a word boundary.
+//! - Styling directives must start at the beginning of a line, after
+//!   whitespace, or after a different opening styling directive.
+//! - Opening directives must not be followed by whitespace; closing
+//!   directives must not be preceded by whitespace.
 //! - Inline code and preformatted blocks suppress all other formatting.
 //! - Spans cannot cross line boundaries (except preformatted blocks).
+
+use minidom::Element;
+use xmpp_parsers::message::Message;
+
+/// Namespace for XEP-0393 Message Styling.
+pub const NS_STYLING: &str = "urn:xmpp:styling:0";
 
 /// A parsed span of styled text.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -69,6 +77,70 @@ impl StyledBody for String {
     }
 }
 
+/// Trait for XMPP messages whose styling payload can be interpreted.
+pub trait StylingCarrier {
+    /// Returns `true` when the message carries XEP-0393 `<unstyled/>`.
+    fn styling_disabled(&self) -> bool;
+
+    /// Parse the default body, respecting the XEP-0393 `<unstyled/>` opt-out.
+    fn styled_body_blocks(&self) -> Option<Vec<Block>>;
+}
+
+impl StylingCarrier for Message {
+    fn styling_disabled(&self) -> bool {
+        has_unstyled(self)
+    }
+
+    fn styled_body_blocks(&self) -> Option<Vec<Block>> {
+        parse_message_body(self)
+    }
+}
+
+// ── Stanza-level opt-out ────────────────────────────────────────────
+
+/// Check if an element is `<unstyled xmlns='urn:xmpp:styling:0'/>`.
+pub fn is_unstyled_element(elem: &Element) -> bool {
+    elem.ns() == NS_STYLING
+        && elem.name() == "unstyled"
+        && elem.children().next().is_none()
+        && elem.text().is_empty()
+}
+
+/// Check if a message carries the XEP-0393 message-level styling opt-out.
+pub fn has_unstyled(msg: &Message) -> bool {
+    msg.payloads.iter().any(is_unstyled_element)
+}
+
+/// Build an empty `<unstyled xmlns='urn:xmpp:styling:0'/>` element.
+pub fn build_unstyled_element() -> Element {
+    Element::builder("unstyled", NS_STYLING).build()
+}
+
+/// Add the XEP-0393 message-level styling opt-out if it is not present.
+pub fn add_unstyled(msg: &mut Message) {
+    if !has_unstyled(msg) {
+        msg.payloads.push(build_unstyled_element());
+    }
+}
+
+/// Remove all XEP-0393 styling opt-out payloads from a message.
+pub fn strip_unstyled(msg: &mut Message) {
+    msg.payloads.retain(|elem| !is_unstyled_element(elem));
+}
+
+/// Parse the default message body, bypassing styling when `<unstyled/>` exists.
+pub fn parse_message_body(msg: &Message) -> Option<Vec<Block>> {
+    let body = default_body(msg)?;
+    if has_unstyled(msg) {
+        return Some(vec![Block::Paragraph(vec![Span::Plain(body.to_owned())])]);
+    }
+    Some(parse_blocks(body))
+}
+
+fn default_body(msg: &Message) -> Option<&str> {
+    msg.bodies.get("").map(String::as_str)
+}
+
 // ── Block-level parsing ──────────────────────────────────────────────
 
 /// Parse a message body into blocks.
@@ -81,7 +153,7 @@ pub fn parse_blocks(input: &str) -> Vec<Block> {
         if line.starts_with("```") {
             let mut code = String::new();
             for inner in lines.by_ref() {
-                if inner.starts_with("```") {
+                if inner == "```" {
                     break;
                 }
                 if !code.is_empty() {
@@ -94,18 +166,13 @@ pub fn parse_blocks(input: &str) -> Vec<Block> {
         }
 
         // Block quote
-        if line.starts_with("> ") || line == ">" {
+        if let Some(stripped) = quote_line_body(line) {
             let mut quote_lines = Vec::new();
-            let stripped = if line == ">" { "" } else { &line[2..] };
             quote_lines.push(stripped.to_owned());
 
             while let Some(next) = lines.peek() {
-                if next.starts_with("> ") || *next == ">" {
-                    let s = if *next == ">" {
-                        "".to_owned()
-                    } else {
-                        next[2..].to_owned()
-                    };
+                if let Some(stripped) = quote_line_body(next) {
+                    let s = stripped.to_owned();
                     quote_lines.push(s);
                     lines.next();
                 } else {
@@ -132,6 +199,19 @@ pub fn parse_blocks(input: &str) -> Vec<Block> {
     blocks
 }
 
+fn quote_line_body(line: &str) -> Option<&str> {
+    let quoted = line.strip_prefix('>')?;
+    Some(trim_one_leading_whitespace(quoted))
+}
+
+fn trim_one_leading_whitespace(input: &str) -> &str {
+    input
+        .char_indices()
+        .next()
+        .filter(|(_, ch)| ch.is_whitespace())
+        .map_or(input, |(idx, ch)| &input[idx + ch.len_utf8()..])
+}
+
 // ── Inline span parsing ─────────────────────────────────────────────
 
 /// Parse inline styling spans from a single line of text.
@@ -145,8 +225,8 @@ pub fn parse_spans(input: &str) -> Vec<Span> {
         let ch = chars[pos];
 
         // Inline code: ` ... `
-        if ch == '`' {
-            if let Some(end) = find_closing_char(&chars, pos + 1, '`') {
+        if ch == '`' && is_span_start(&chars, pos, ch) {
+            if let Some(end) = find_closing_directive(&chars, pos, ch) {
                 flush_plain(&mut plain, &mut spans);
                 let code: String = chars[pos + 1..end].iter().collect();
                 spans.push(Span::InlineCode(code));
@@ -156,22 +236,20 @@ pub fn parse_spans(input: &str) -> Vec<Span> {
         }
 
         // Styled spans: * _ ~
-        if matches!(ch, '*' | '_' | '~') && is_span_start(&chars, pos) {
-            if let Some(end) = find_closing_char(&chars, pos + 1, ch) {
-                if is_span_end(&chars, end) {
-                    flush_plain(&mut plain, &mut spans);
-                    let inner: String = chars[pos + 1..end].iter().collect();
-                    let inner_spans = parse_spans(&inner);
-                    let styled = match ch {
-                        '*' => Span::Bold(inner_spans),
-                        '_' => Span::Italic(inner_spans),
-                        '~' => Span::Strikethrough(inner_spans),
-                        _ => unreachable!(),
-                    };
-                    spans.push(styled);
-                    pos = end + 1;
-                    continue;
-                }
+        if matches!(ch, '*' | '_' | '~') && is_span_start(&chars, pos, ch) {
+            if let Some(end) = find_closing_directive(&chars, pos, ch) {
+                flush_plain(&mut plain, &mut spans);
+                let inner: String = chars[pos + 1..end].iter().collect();
+                let inner_spans = parse_spans(&inner);
+                let styled = match ch {
+                    '*' => Span::Bold(inner_spans),
+                    '_' => Span::Italic(inner_spans),
+                    '~' => Span::Strikethrough(inner_spans),
+                    _ => unreachable!(),
+                };
+                spans.push(styled);
+                pos = end + 1;
+                continue;
             }
         }
 
@@ -189,31 +267,62 @@ fn flush_plain(plain: &mut String, spans: &mut Vec<Span>) {
     }
 }
 
-fn find_closing_char(chars: &[char], start: usize, closing: char) -> Option<usize> {
-    (start..chars.len()).find(|&i| chars[i] == closing)
+fn find_closing_directive(chars: &[char], opening: usize, closing: char) -> Option<usize> {
+    for pos in opening + 1..chars.len() {
+        if chars[pos] != closing {
+            continue;
+        }
+        if pos == opening + 1 {
+            return None;
+        }
+        if chars[pos - 1].is_whitespace() {
+            continue;
+        }
+        return Some(pos);
+    }
+    None
 }
 
-fn is_span_start(chars: &[char], pos: usize) -> bool {
+fn is_span_start(chars: &[char], pos: usize, directive: char) -> bool {
+    if chars.get(pos + 1).is_none_or(|next| next.is_whitespace()) {
+        return false;
+    }
+
     if pos == 0 {
         return true;
     }
+
     let prev = chars[pos - 1];
-    prev.is_whitespace() || is_punctuation(prev)
+    prev.is_whitespace() || is_after_different_opening_directive(chars, pos - 1, directive)
 }
 
-fn is_span_end(chars: &[char], pos: usize) -> bool {
-    if pos + 1 >= chars.len() {
-        return true;
+fn is_after_different_opening_directive(chars: &[char], mut pos: usize, directive: char) -> bool {
+    let mut current = chars[pos];
+    if !is_styling_directive(current) || current == directive {
+        return false;
     }
-    let next = chars[pos + 1];
-    next.is_whitespace() || is_punctuation(next)
+
+    loop {
+        if pos == 0 {
+            return true;
+        }
+
+        let prev = chars[pos - 1];
+        if prev.is_whitespace() {
+            return true;
+        }
+
+        if !is_styling_directive(prev) || prev == current {
+            return false;
+        }
+
+        pos -= 1;
+        current = prev;
+    }
 }
 
-fn is_punctuation(ch: char) -> bool {
-    matches!(
-        ch,
-        '.' | ',' | ';' | ':' | '!' | '?' | '"' | '\'' | '(' | ')' | '[' | ']' | '{' | '}'
-    )
+fn is_styling_directive(ch: char) -> bool {
+    matches!(ch, '*' | '_' | '~' | '`')
 }
 
 // ── Plain text extraction ────────────────────────────────────────────

--- a/server/crates/waddle-xmpp/src/xep/xep0393/tests.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0393/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use xmpp_parsers::message::{Lang, Message};
 
 // ── Inline span tests ────────────────────────────────────
 
@@ -89,6 +90,93 @@ fn test_styling_at_start_of_line() {
 }
 
 #[test]
+fn xep0393_span_closing_may_be_followed_by_plain_text() {
+    let spans = parse_spans("*strong*plain*");
+    assert_eq!(
+        spans,
+        vec![
+            Span::Bold(vec![Span::Plain("strong".into())]),
+            Span::Plain("plain*".into()),
+        ]
+    );
+}
+
+#[test]
+fn xep0393_empty_directives_are_plain() {
+    for input in ["**", "***", "****", "__", "~~", "``"] {
+        assert_eq!(
+            parse_spans(input),
+            vec![Span::Plain(input.into())],
+            "{input} must not create an empty span"
+        );
+    }
+}
+
+#[test]
+fn xep0393_opening_followed_by_whitespace_is_plain() {
+    for input in ["* strong*", "_ emphasis_", "~ strike~", "` code`"] {
+        assert_eq!(
+            parse_spans(input),
+            vec![Span::Plain(input.into())],
+            "{input} must not style when opener is followed by whitespace"
+        );
+    }
+}
+
+#[test]
+fn xep0393_closing_preceded_by_whitespace_is_plain() {
+    for input in ["*strong *", "_emphasis _", "~strike ~", "`code `"] {
+        assert_eq!(
+            parse_spans(input),
+            vec![Span::Plain(input.into())],
+            "{input} must not style when closer is preceded by whitespace"
+        );
+    }
+}
+
+#[test]
+fn xep0393_opening_after_punctuation_is_not_a_directive() {
+    let spans = parse_spans("a(*strong*)");
+    assert_eq!(spans, vec![Span::Plain("a(*strong*)".into())]);
+}
+
+#[test]
+fn xep0393_nested_opening_after_different_directive_is_valid() {
+    let spans = parse_spans("*_strong emphasis_*");
+    assert_eq!(
+        spans,
+        vec![Span::Bold(vec![Span::Italic(vec![Span::Plain(
+            "strong emphasis".into()
+        )])])]
+    );
+}
+
+#[test]
+fn xep0393_invalid_directives_are_skipped_when_matching() {
+    let spans = parse_spans("*a * b*");
+    assert_eq!(spans, vec![Span::Bold(vec![Span::Plain("a * b".into())])]);
+}
+
+#[test]
+fn xep0393_invalid_opening_does_not_block_later_span() {
+    let spans = parse_spans("* plain *strong*");
+    assert_eq!(
+        spans,
+        vec![
+            Span::Plain("* plain ".into()),
+            Span::Bold(vec![Span::Plain("strong".into())]),
+        ]
+    );
+}
+
+#[test]
+fn xep0393_unclosed_or_invalid_closing_directive_is_plain() {
+    for input in ["not strong*", "*not strong", "*not *strong"] {
+        assert_eq!(parse_spans(input), vec![Span::Plain(input.into())]);
+    }
+}
+
+#[test]
 fn test_unclosed_directive_is_plain() {
     let spans = parse_spans("Hello *world");
     assert_eq!(spans, vec![Span::Plain("Hello *world".into())]);
@@ -109,6 +197,19 @@ fn test_code_block() {
 }
 
 #[test]
+fn xep0393_preformatted_block_closes_only_on_exact_fence() {
+    let input = "```\ncode\n```ignored\nstill code\n```\nplain";
+    let blocks = parse_blocks(input);
+    assert_eq!(
+        blocks,
+        vec![
+            Block::CodeBlock("code\n```ignored\nstill code".into()),
+            Block::Paragraph(vec![Span::Plain("plain".into())]),
+        ]
+    );
+}
+
+#[test]
 fn test_block_quote() {
     let input = "> This is quoted\n> Second line";
     let blocks = parse_blocks(input);
@@ -117,6 +218,18 @@ fn test_block_quote() {
         vec![Block::BlockQuote(vec![
             Block::Paragraph(vec![Span::Plain("This is quoted".into())]),
             Block::Paragraph(vec![Span::Plain("Second line".into())]),
+        ])]
+    );
+}
+
+#[test]
+fn xep0393_quote_line_may_begin_with_greater_than_without_space() {
+    let blocks = parse_blocks(">quoted\n>> nested");
+    assert_eq!(
+        blocks,
+        vec![Block::BlockQuote(vec![
+            Block::Paragraph(vec![Span::Plain("quoted".into())]),
+            Block::BlockQuote(vec![Block::Paragraph(vec![Span::Plain("nested".into())])]),
         ])]
     );
 }
@@ -213,4 +326,101 @@ fn test_empty_quote_line() {
             Span::Plain("text".into())
         ])])]
     );
+}
+
+// ── Stanza-level opt-out ────────────────────────────────
+
+#[test]
+fn xep0393_unstyled_element_uses_canonical_namespace() {
+    let elem = build_unstyled_element();
+    assert_eq!(elem.name(), "unstyled");
+    assert_eq!(elem.ns(), NS_STYLING);
+}
+
+#[test]
+fn xep0393_message_with_unstyled_child_returns_plain_blocks() {
+    let mut msg = message_with_body("> _ <");
+    add_unstyled(&mut msg);
+
+    assert!(msg.styling_disabled());
+    assert_eq!(
+        msg.styled_body_blocks(),
+        Some(vec![Block::Paragraph(vec![Span::Plain("> _ <".into())])])
+    );
+}
+
+#[test]
+fn xep0393_unstyled_wrong_namespace_does_not_disable_styling() {
+    let mut msg = message_with_body("*styled*");
+    msg.payloads
+        .push(Element::builder("unstyled", "urn:example:styling").build());
+
+    assert!(!has_unstyled(&msg));
+    assert_eq!(
+        parse_message_body(&msg),
+        Some(vec![Block::Paragraph(vec![Span::Bold(vec![Span::Plain(
+            "styled".into()
+        )])])])
+    );
+}
+
+#[test]
+fn xep0393_non_empty_unstyled_element_does_not_disable_styling() {
+    let mut msg = message_with_body("*styled*");
+    msg.payloads.push(
+        Element::builder("unstyled", NS_STYLING)
+            .append("not empty")
+            .build(),
+    );
+
+    assert!(!has_unstyled(&msg));
+    assert_eq!(
+        parse_message_body(&msg),
+        Some(vec![Block::Paragraph(vec![Span::Bold(vec![Span::Plain(
+            "styled".into()
+        )])])])
+    );
+}
+
+#[test]
+fn xep0393_message_body_parser_requires_default_language_body() {
+    let mut msg = Message::new(None::<jid::Jid>);
+    msg.bodies.insert(Lang::from("cy"), "*styled*".to_owned());
+
+    assert_eq!(parse_message_body(&msg), None);
+}
+
+#[test]
+fn xep0393_adjacent_directive_chain_is_checked_iteratively() {
+    let mut input = String::with_capacity(10_002);
+    for directive in ['*', '_', '~', '`'].into_iter().cycle().take(10_000) {
+        input.push(directive);
+    }
+    input.push_str("plain");
+    input.push('*');
+
+    let spans = parse_spans(&input);
+
+    assert!(!spans.is_empty());
+    assert!(spans_to_plain(&spans).contains("plain"));
+}
+
+#[test]
+fn xep0393_strip_unstyled_removes_only_styling_opt_out() {
+    let mut msg = message_with_body("*styled*");
+    add_unstyled(&mut msg);
+    msg.payloads
+        .push(Element::builder("unstyled", "urn:example:styling").build());
+
+    strip_unstyled(&mut msg);
+
+    assert!(!has_unstyled(&msg));
+    assert_eq!(msg.payloads.len(), 1);
+    assert_eq!(msg.payloads[0].ns(), "urn:example:styling");
+}
+
+fn message_with_body(body: &str) -> Message {
+    let mut msg = Message::new(None::<jid::Jid>);
+    msg.bodies.insert(Lang::new(), body.to_owned());
+    msg
 }


### PR DESCRIPTION
## Summary

- Tightens the XEP-0393 body parser to follow the current fetched XEP-0393 span and block rules.
- Adds typed XEP-0393 `<unstyled xmlns="urn:xmpp:styling:0"/>` helpers and message-level parsing that respects the empty-element opt-out.
- Pins that server disco does not advertise `urn:xmpp:styling:0` from the parser alone, because the registered feature is support for rendering message styling.

## Plan

- [x] Review XEP-0393 from the fetched XSF corpus and compare it with `waddle-xmpp` parser behavior.
- [x] Fix empty spans, whitespace-adjacent directives, lazy invalid-directive matching, preformatted block closing, and `>` quote parsing.
- [x] Add typed stanza-level helpers for the empty `<unstyled/>` opt-out and keep language handling on the default body only.
- [x] Add dedicated Rust XEP-0393 tests for the conformant parser and opt-out behavior.
- [x] Add a guard that the server feature catalog does not falsely advertise client-rendering support.
- [x] Run adversarial XEP, Rust API, and regression reviews and address real findings.

## Validation

- `cargo test -p waddle-xmpp xep0393 --lib`
- `cargo test -p waddle-xmpp server_features_do_not_advertise_message_styling_parser --lib`
- `cargo clippy -p waddle-xmpp --lib -- -D warnings`

## Review Notes

- The initial copied `./xeps` tree was stale, so XEP-0393 was rechecked from the coordinator checkout's fetched `origin/master:xep-0393.xml`.
- Adversarial review found and this PR fixed two additional issues: arbitrary non-default language body fallback and recursive adjacent-directive validation.
