### PR TITLE
fix(server): build xep-0077 registration xml with typed values

### DIFF
--- a/server/crates/waddle-xmpp/src/xep/xep0077.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0077.rs
@@ -6,12 +6,16 @@
 use minidom::Element;
 use tracing::debug;
 use xmpp_parsers::iq::Iq;
+use xmpp_parsers::stanza_error::ErrorType;
 
 /// Namespace for XEP-0077 In-Band Registration IQ queries.
 pub const NS_REGISTER: &str = "jabber:iq:register";
 
 /// Namespace for XEP-0077 stream feature advertisement (per Section 8).
 pub const NS_REGISTER_FEATURE: &str = "http://jabber.org/features/iq-register";
+
+const NS_CLIENT: &str = "jabber:client";
+const NS_XMPP_STANZAS: &str = "urn:ietf:params:xml:ns:xmpp-stanzas";
 
 /// Registration request parsed from an IQ stanza.
 #[derive(Debug, Clone)]
@@ -37,6 +41,51 @@ pub enum RegistrationError {
     BadRequest(String),
     /// Internal server error
     InternalError(String),
+}
+
+/// Typed XEP-0077 registration error response.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RegistrationErrorResponse {
+    request_id: String,
+    error_type: ErrorType,
+    condition: RegistrationErrorCondition,
+    legacy_code: LegacyRegistrationErrorCode,
+    submitted_query: Element,
+    text: Option<String>,
+}
+
+impl RegistrationErrorResponse {
+    /// Convert to XML for the transport boundary.
+    pub fn to_element(&self) -> Element {
+        let mut error_element = Element::builder("error", NS_CLIENT)
+            .attr(
+                minidom::rxml::xml_ncname!("code").to_owned(),
+                self.legacy_code.as_str(),
+            )
+            .attr(
+                minidom::rxml::xml_ncname!("type").to_owned(),
+                error_type_attr(&self.error_type),
+            )
+            .append(Element::builder(self.condition.element_name(), NS_XMPP_STANZAS).build());
+
+        if let Some(text) = &self.text {
+            error_element = error_element.append(
+                Element::builder("text", NS_XMPP_STANZAS)
+                    .append(text.as_str())
+                    .build(),
+            );
+        }
+
+        Element::builder("iq", NS_CLIENT)
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "error")
+            .attr(
+                minidom::rxml::xml_ncname!("id").to_owned(),
+                self.request_id.as_str(),
+            )
+            .append(self.submitted_query.clone())
+            .append(error_element.build())
+            .build()
+    }
 }
 
 impl std::fmt::Display for RegistrationError {
@@ -150,86 +199,164 @@ pub fn build_registration_fields_response(
     request_id: &str,
     instructions: Option<&str>,
     include_email: bool,
-) -> String {
-    let instructions_xml = instructions
-        .map(|i| format!("<instructions>{}</instructions>", escape_xml(i)))
-        .unwrap_or_default();
+) -> Iq {
+    let mut query = Element::builder("query", NS_REGISTER);
 
-    let email_xml = if include_email { "<email/>" } else { "" };
+    if let Some(instructions) = instructions {
+        query = query.append(
+            Element::builder("instructions", NS_REGISTER)
+                .append(instructions)
+                .build(),
+        );
+    }
 
-    format!(
-        "<iq type='result' id='{}'>\
-            <query xmlns='{}'>\
-                {}\
-                <username/>\
-                <password/>\
-                {}\
-            </query>\
-        </iq>",
-        escape_xml(request_id),
-        NS_REGISTER,
-        instructions_xml,
-        email_xml
-    )
+    query = query
+        .append(Element::builder("username", NS_REGISTER).build())
+        .append(Element::builder("password", NS_REGISTER).build());
+
+    if include_email {
+        query = query.append(Element::builder("email", NS_REGISTER).build());
+    }
+
+    Iq::Result {
+        from: None,
+        to: None,
+        id: request_id.to_string(),
+        payload: Some(query.build()),
+    }
 }
 
 /// Build a registration success response.
-pub fn build_registration_success(request_id: &str) -> String {
-    format!("<iq type='result' id='{}'/>", escape_xml(request_id))
+pub fn build_registration_success(request_id: &str) -> Iq {
+    Iq::Result {
+        from: None,
+        to: None,
+        id: request_id.to_string(),
+        payload: None,
+    }
 }
 
 /// Build a registration error response.
-pub fn build_registration_error(request_id: &str, error: &RegistrationError) -> String {
-    let (error_type, condition) = match error {
-        RegistrationError::NotAllowed => ("cancel", "not-allowed"),
-        RegistrationError::Conflict => ("cancel", "conflict"),
-        RegistrationError::NotAcceptable(_) => ("modify", "not-acceptable"),
-        RegistrationError::BadRequest(_) => ("modify", "bad-request"),
-        RegistrationError::InternalError(_) => ("wait", "internal-server-error"),
-    };
+pub fn build_registration_error(
+    request_id: &str,
+    submitted_query: Option<&Element>,
+    error: &RegistrationError,
+) -> RegistrationErrorResponse {
+    let shape = registration_error_shape(error);
+    RegistrationErrorResponse {
+        request_id: request_id.to_string(),
+        error_type: shape.error_type,
+        condition: shape.condition,
+        legacy_code: shape.legacy_code,
+        submitted_query: submitted_query
+            .cloned()
+            .unwrap_or_else(|| Element::builder("query", NS_REGISTER).build()),
+        text: registration_error_text(error).map(str::to_string),
+    }
+}
 
-    let text = match error {
+struct RegistrationErrorShape {
+    error_type: ErrorType,
+    condition: RegistrationErrorCondition,
+    legacy_code: LegacyRegistrationErrorCode,
+}
+
+fn registration_error_shape(error: &RegistrationError) -> RegistrationErrorShape {
+    match error {
+        RegistrationError::NotAllowed => RegistrationErrorShape {
+            error_type: ErrorType::Cancel,
+            condition: RegistrationErrorCondition::ServiceUnavailable,
+            legacy_code: LegacyRegistrationErrorCode::ServiceUnavailable,
+        },
+        RegistrationError::Conflict => RegistrationErrorShape {
+            error_type: ErrorType::Cancel,
+            condition: RegistrationErrorCondition::Conflict,
+            legacy_code: LegacyRegistrationErrorCode::Conflict,
+        },
+        RegistrationError::NotAcceptable(_) => RegistrationErrorShape {
+            error_type: ErrorType::Modify,
+            condition: RegistrationErrorCondition::NotAcceptable,
+            legacy_code: LegacyRegistrationErrorCode::NotAcceptable,
+        },
+        RegistrationError::BadRequest(_) => RegistrationErrorShape {
+            error_type: ErrorType::Modify,
+            condition: RegistrationErrorCondition::BadRequest,
+            legacy_code: LegacyRegistrationErrorCode::BadRequest,
+        },
+        RegistrationError::InternalError(_) => RegistrationErrorShape {
+            error_type: ErrorType::Wait,
+            condition: RegistrationErrorCondition::InternalError,
+            legacy_code: LegacyRegistrationErrorCode::InternalError,
+        },
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RegistrationErrorCondition {
+    BadRequest,
+    Conflict,
+    InternalError,
+    NotAcceptable,
+    ServiceUnavailable,
+}
+
+impl RegistrationErrorCondition {
+    fn element_name(self) -> &'static str {
+        match self {
+            RegistrationErrorCondition::BadRequest => "bad-request",
+            RegistrationErrorCondition::Conflict => "conflict",
+            RegistrationErrorCondition::InternalError => "internal-server-error",
+            RegistrationErrorCondition::NotAcceptable => "not-acceptable",
+            RegistrationErrorCondition::ServiceUnavailable => "service-unavailable",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LegacyRegistrationErrorCode {
+    BadRequest,
+    Conflict,
+    NotAcceptable,
+    ServiceUnavailable,
+    InternalError,
+}
+
+impl LegacyRegistrationErrorCode {
+    fn as_str(self) -> &'static str {
+        match self {
+            LegacyRegistrationErrorCode::BadRequest => "400",
+            LegacyRegistrationErrorCode::NotAcceptable => "406",
+            LegacyRegistrationErrorCode::Conflict => "409",
+            LegacyRegistrationErrorCode::InternalError => "500",
+            LegacyRegistrationErrorCode::ServiceUnavailable => "503",
+        }
+    }
+}
+
+fn error_type_attr(error_type: &ErrorType) -> &'static str {
+    match error_type {
+        ErrorType::Auth => "auth",
+        ErrorType::Cancel => "cancel",
+        ErrorType::Continue => "continue",
+        ErrorType::Modify => "modify",
+        ErrorType::Wait => "wait",
+    }
+}
+
+fn registration_error_text(error: &RegistrationError) -> Option<&str> {
+    match error {
         RegistrationError::NotAcceptable(msg)
         | RegistrationError::BadRequest(msg)
-        | RegistrationError::InternalError(msg) => {
-            format!(
-                "<text xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'>{}</text>",
-                escape_xml(msg)
-            )
-        }
-        _ => String::new(),
-    };
-
-    format!(
-        "<iq type='error' id='{}'>\
-            <query xmlns='{}'/>\
-            <error type='{}'>\
-                <{} xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>\
-                {}\
-            </error>\
-        </iq>",
-        escape_xml(request_id),
-        NS_REGISTER,
-        error_type,
-        condition,
-        text
-    )
+        | RegistrationError::InternalError(msg) => Some(msg),
+        _ => None,
+    }
 }
 
 /// Build registration feature advertisement for stream features.
 ///
 /// Per XEP-0077 Section 8, this uses the feature namespace, not the IQ namespace.
-pub fn build_registration_feature() -> String {
-    format!("<register xmlns='{}'/>", NS_REGISTER_FEATURE)
-}
-
-/// Escape XML special characters.
-fn escape_xml(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&apos;")
+pub fn build_registration_feature() -> Element {
+    Element::builder("register", NS_REGISTER_FEATURE).build()
 }
 
 #[cfg(test)]
@@ -307,86 +434,5 @@ mod tests {
         let result = parse_registration_element(&element, "reg5");
 
         assert!(matches!(result, Err(RegistrationError::NotAcceptable(_))));
-    }
-
-    #[test]
-    fn test_build_registration_fields_response() {
-        let response = build_registration_fields_response(
-            "reg1",
-            Some("Choose a username and password."),
-            true,
-        );
-
-        assert!(response.contains("type='result'"));
-        assert!(response.contains("id='reg1'"));
-        assert!(response.contains(&format!("xmlns='{}'", NS_REGISTER)));
-        assert!(response.contains("<username/>"));
-        assert!(response.contains("<password/>"));
-        assert!(response.contains("<email/>"));
-        assert!(response.contains("<instructions>Choose a username and password.</instructions>"));
-    }
-
-    #[test]
-    fn test_build_registration_fields_response_no_email() {
-        let response = build_registration_fields_response("reg1", None, false);
-
-        assert!(response.contains("<username/>"));
-        assert!(response.contains("<password/>"));
-        assert!(!response.contains("<email/>"));
-        assert!(!response.contains("<instructions>"));
-    }
-
-    #[test]
-    fn test_build_registration_success() {
-        let response = build_registration_success("reg2");
-
-        assert!(response.contains("type='result'"));
-        assert!(response.contains("id='reg2'"));
-    }
-
-    #[test]
-    fn test_build_registration_error_conflict() {
-        let response = build_registration_error("reg3", &RegistrationError::Conflict);
-
-        assert!(response.contains("type='error'"));
-        assert!(response.contains("id='reg3'"));
-        assert!(response.contains("<conflict"));
-    }
-
-    #[test]
-    fn test_build_registration_error_not_allowed() {
-        let response = build_registration_error("reg4", &RegistrationError::NotAllowed);
-
-        assert!(response.contains("type='error'"));
-        assert!(response.contains("<not-allowed"));
-    }
-
-    #[test]
-    fn test_build_registration_error_with_text() {
-        let response = build_registration_error(
-            "reg5",
-            &RegistrationError::NotAcceptable("Username is required".to_string()),
-        );
-
-        assert!(response.contains("type='error'"));
-        assert!(response.contains("<not-acceptable"));
-        assert!(response.contains("<text"));
-        assert!(response.contains("Username is required"));
-    }
-
-    #[test]
-    fn test_build_registration_feature() {
-        let feature = build_registration_feature();
-
-        assert!(feature.contains(&format!("xmlns='{}'", NS_REGISTER_FEATURE)));
-        assert!(feature.contains("<register"));
-    }
-
-    #[test]
-    fn test_escape_xml() {
-        assert_eq!(escape_xml("hello"), "hello");
-        assert_eq!(escape_xml("<script>"), "&lt;script&gt;");
-        assert_eq!(escape_xml("a & b"), "a &amp; b");
-        assert_eq!(escape_xml("\"quoted\""), "&quot;quoted&quot;");
     }
 }

--- a/server/crates/waddle-xmpp/tests/xep0077_in_band_registration.rs
+++ b/server/crates/waddle-xmpp/tests/xep0077_in_band_registration.rs
@@ -1,0 +1,243 @@
+//! XEP-0077: In-Band Registration dedicated conformance suite.
+
+use minidom::Element;
+use waddle_xmpp::xep::xep0077::{
+    build_registration_error, build_registration_feature, build_registration_fields_response,
+    build_registration_success, RegistrationError, NS_REGISTER, NS_REGISTER_FEATURE,
+};
+use xmpp_parsers::{
+    iq::Iq,
+    stanza_error::{DefinedCondition, ErrorType},
+};
+
+fn serialize_element(element: &Element) -> String {
+    let mut buf = Vec::new();
+    element.write_to(&mut buf).expect("serialize element");
+    String::from_utf8(buf).expect("minidom serializes UTF-8")
+}
+
+fn serialize_iq(iq: Iq) -> String {
+    serialize_element(&iq.into())
+}
+
+fn error_child(iq: &Element) -> &Element {
+    iq.get_child("error", "jabber:client").expect("error child")
+}
+
+fn submitted_registration_query() -> Element {
+    Element::builder("query", NS_REGISTER)
+        .append(
+            Element::builder("username", NS_REGISTER)
+                .append("bill")
+                .build(),
+        )
+        .append(
+            Element::builder("password", NS_REGISTER)
+                .append("m1cro$oft")
+                .build(),
+        )
+        .append(
+            Element::builder("email", NS_REGISTER)
+                .append("billg@bigcompany.com")
+                .build(),
+        )
+        .build()
+}
+
+fn parse_iq(xml: &str) -> Iq {
+    Iq::try_from(xml.parse::<Element>().expect("serialized iq is xml"))
+        .expect("serialized iq parses")
+}
+
+#[test]
+fn xep0077_fields_result_uses_register_query_children() {
+    let iq = build_registration_fields_response("reg'&<1", Some("Use <name> & \"password\""), true);
+
+    let xml = serialize_iq(iq);
+    assert!(xml.contains("&amp;&lt;1"));
+    assert!(xml.contains("Use &lt;name&gt; &amp; \"password\""));
+
+    let Iq::Result {
+        id,
+        payload: Some(query),
+        ..
+    } = parse_iq(&xml)
+    else {
+        panic!("registration fields response is an IQ result with query payload");
+    };
+
+    assert_eq!(id, "reg'&<1");
+    assert_eq!(query.name(), "query");
+    assert_eq!(query.ns(), NS_REGISTER);
+    assert_eq!(
+        query
+            .get_child("instructions", NS_REGISTER)
+            .expect("instructions child")
+            .text(),
+        "Use <name> & \"password\""
+    );
+    assert_eq!(
+        query
+            .children()
+            .map(|child| (child.name(), child.ns().to_string(), child.text()))
+            .collect::<Vec<_>>(),
+        vec![
+            (
+                "instructions",
+                NS_REGISTER.to_string(),
+                "Use <name> & \"password\"".to_string()
+            ),
+            ("username", NS_REGISTER.to_string(), String::new()),
+            ("password", NS_REGISTER.to_string(), String::new()),
+            ("email", NS_REGISTER.to_string(), String::new()),
+        ]
+    );
+}
+
+#[test]
+fn xep0077_fields_result_omits_optional_children_when_absent() {
+    let Iq::Result {
+        payload: Some(query),
+        ..
+    } = build_registration_fields_response("reg1", None, false)
+    else {
+        panic!("registration fields response is an IQ result with query payload");
+    };
+
+    assert!(query.get_child("instructions", NS_REGISTER).is_none());
+    assert!(query.get_child("email", NS_REGISTER).is_none());
+    assert!(query.get_child("username", NS_REGISTER).is_some());
+    assert!(query.get_child("password", NS_REGISTER).is_some());
+}
+
+#[test]
+fn xep0077_success_result_has_no_payload() {
+    let xml = serialize_iq(build_registration_success("reg2"));
+
+    let Iq::Result { id, payload, .. } = parse_iq(&xml) else {
+        panic!("registration success is an IQ result");
+    };
+
+    assert_eq!(id, "reg2");
+    assert!(payload.is_none());
+}
+
+#[test]
+fn xep0077_error_maps_conflict_to_cancel_conflict_with_register_query() {
+    let submitted_query = submitted_registration_query();
+    let element =
+        build_registration_error("reg3", Some(&submitted_query), &RegistrationError::Conflict)
+            .to_element();
+    assert_eq!(error_child(&element).attr("code"), Some("409"));
+    let xml = serialize_element(&element);
+
+    let Iq::Error {
+        id,
+        payload: Some(query),
+        error,
+        ..
+    } = parse_iq(&xml)
+    else {
+        panic!("registration failure is an IQ error with original query payload");
+    };
+
+    assert_eq!(id, "reg3");
+    assert_eq!(query.name(), "query");
+    assert_eq!(query.ns(), NS_REGISTER);
+    assert_eq!(
+        query
+            .get_child("username", NS_REGISTER)
+            .expect("username")
+            .text(),
+        "bill"
+    );
+    assert_eq!(
+        query
+            .get_child("password", NS_REGISTER)
+            .expect("password")
+            .text(),
+        "m1cro$oft"
+    );
+    assert_eq!(
+        query.get_child("email", NS_REGISTER).expect("email").text(),
+        "billg@bigcompany.com"
+    );
+    assert_eq!(error.type_, ErrorType::Cancel);
+    assert_eq!(error.defined_condition, DefinedCondition::Conflict);
+    assert!(error.texts.is_empty());
+}
+
+#[test]
+fn xep0077_error_text_is_serialized_by_the_xml_writer() {
+    let message = "Username <taken> & \"invalid\"";
+    let element = build_registration_error(
+        "reg5",
+        None,
+        &RegistrationError::NotAcceptable(message.to_string()),
+    )
+    .to_element();
+    assert_eq!(error_child(&element).attr("code"), Some("406"));
+    let xml = serialize_element(&element);
+
+    assert!(xml.contains("Username &lt;taken&gt; &amp; \"invalid\""));
+
+    let Iq::Error { error, .. } = parse_iq(&xml) else {
+        panic!("registration failure is an IQ error");
+    };
+
+    assert_eq!(error.type_, ErrorType::Modify);
+    assert_eq!(error.defined_condition, DefinedCondition::NotAcceptable);
+    assert_eq!(
+        error.texts.values().next().map(String::as_str),
+        Some(message)
+    );
+}
+
+#[test]
+fn xep0077_error_variants_use_rfc6120_conditions() {
+    let cases = [
+        (
+            RegistrationError::NotAllowed,
+            ErrorType::Cancel,
+            DefinedCondition::ServiceUnavailable,
+            "503",
+        ),
+        (
+            RegistrationError::BadRequest("bad".to_string()),
+            ErrorType::Modify,
+            DefinedCondition::BadRequest,
+            "400",
+        ),
+        (
+            RegistrationError::InternalError("oops".to_string()),
+            ErrorType::Wait,
+            DefinedCondition::InternalServerError,
+            "500",
+        ),
+    ];
+
+    for (registration_error, error_type, condition, legacy_code) in cases {
+        let element = build_registration_error("reg", None, &registration_error).to_element();
+        assert_eq!(error_child(&element).attr("code"), Some(legacy_code));
+
+        let Iq::Error { error, .. } = parse_iq(&serialize_element(&element)) else {
+            panic!("registration failure is an IQ error");
+        };
+
+        assert_eq!(error.type_, error_type);
+        assert_eq!(error.defined_condition, condition);
+    }
+}
+
+#[test]
+fn xep0077_stream_feature_uses_feature_namespace() {
+    let feature = build_registration_feature();
+    let xml = serialize_element(&feature);
+    let reparsed = xml.parse::<Element>().expect("stream feature is xml");
+
+    assert_eq!(reparsed.name(), "register");
+    assert_eq!(reparsed.ns(), NS_REGISTER_FEATURE);
+    assert_ne!(reparsed.ns(), NS_REGISTER);
+    assert_eq!(reparsed.children().count(), 0);
+    assert_eq!(reparsed.text(), "");
+}


### PR DESCRIPTION
## Summary

- Replaced XEP-0077 registration response builders that emitted hand-written XML strings with typed `Iq`, `RegistrationErrorResponse`, and `minidom::Element` builders.
- Preserved XEP-0077 legacy error `code` attributes alongside XMPP stanza error conditions, including `service-unavailable`/`503` for disabled registration.
- Added a dedicated Rust XEP-0077 conformance suite covering registration fields, success, errors, stream feature namespace, serializer escaping, and submitted query preservation.

## Plan

- Compare the existing XEP-0077 helpers against `xeps/xep-0077.xml`.
- Replace manual XML string construction in `waddle-xmpp` XEP-0077 helpers with typed builders.
- Add a dedicated Rust test suite covering registration form, success, error, stream feature, serializer escaping, legacy error codes, and original query preservation.
- Validate with focused and broader `waddle-xmpp` tests.
- Run adversarial review passes and address real issues before marking ready.

## Validation

- `cargo test -p waddle-xmpp --test xep0077_in_band_registration`
- `cargo test -p waddle-xmpp`

## Review

- XEP-0077 conformance reviewer: no actionable issues after fixes.
- Typed-payload/XML-generation reviewer: no actionable issues after fixes.
- Test-quality reviewer: no actionable issues after fixes.
