### PR TITLE
fix(chat): cancel stale raw IQ requests

### DIFF
--- a/chat/src/lib/xmpp/discovery.ts
+++ b/chat/src/lib/xmpp/discovery.ts
@@ -18,6 +18,7 @@ type DiscoveryRole = "owner" | "admin" | "moderator" | "member" | null;
 
 type HybridClient = Partial<WaddleClient> & {
   send_raw_iq?: (xml: string) => Promise<string>;
+  cancel_raw_iq?: (id: string) => Promise<void>;
 };
 
 export type DiscoInfoData = {
@@ -78,18 +79,36 @@ export function withIqTimeout<T>(
   to: string,
   node: string | undefined,
   timeoutMs?: number,
+  options: { cancel?: () => void | Promise<void> } = {},
 ): Promise<T> {
   // Read `DISCO_IQ_TIMEOUT_MS` at call time, not at function-definition
   // time, so `__setDiscoIqTimeoutForTest` correctly overrides for the
   // duration of a test case.
   const effectiveTimeout = timeoutMs ?? DISCO_IQ_TIMEOUT_MS;
+  let didTimeout = false;
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(new DiscoTimeoutError(to, node, effectiveTimeout)), effectiveTimeout);
+    timer = setTimeout(() => {
+      didTimeout = true;
+      reject(new DiscoTimeoutError(to, node, effectiveTimeout));
+    }, effectiveTimeout);
   });
-  return Promise.race([raw, timeout]).finally(() => {
+  return Promise.race([raw, timeout]).finally(async () => {
     if (timer !== undefined) clearTimeout(timer);
+    if (didTimeout) {
+      try {
+        await options.cancel?.();
+      } catch (err) {
+        console.warn("[disco] raw IQ cancellation failed", { to, node, err });
+      }
+    }
   });
+}
+
+function cancelRawIqOnTimeout(xmpp: HybridClient, id: string): { cancel?: () => Promise<void> } {
+  return typeof xmpp.cancel_raw_iq === "function"
+    ? { cancel: () => xmpp.cancel_raw_iq!(id) }
+    : {};
 }
 
 function parseXml(xml: string): Document {
@@ -171,6 +190,8 @@ async function sendDiscoInfo(xmpp: HybridClient, to: string, node?: string): Pro
       xmpp.send_raw_iq(`<iq type="get" id="${id}" to="${to}"><query xmlns="${DISCO_INFO_NS}"${nodeAttr}/></iq>`),
       to,
       node,
+      undefined,
+      cancelRawIqOnTimeout(xmpp, id),
     );
   } catch (err) {
     logDiscoFailure("info", to, node, err);
@@ -201,7 +222,7 @@ async function sendDiscoItems(xmpp: HybridClient, to: string, node?: string): Pr
   const xml = `<iq type="get" id="${id}" to="${to}"><query xmlns="${DISCO_ITEMS_NS}"${nodeAttr}/></iq>`;
   let responseXml: string;
   try {
-    responseXml = await withIqTimeout(xmpp.send_raw_iq(xml), to, node);
+    responseXml = await withIqTimeout(xmpp.send_raw_iq(xml), to, node, undefined, cancelRawIqOnTimeout(xmpp, id));
   } catch (err) {
     logDiscoFailure("items", to, node, err);
     throw err;
@@ -230,6 +251,8 @@ async function sendPubsubItems(xmpp: HybridClient, to: string, node: string): Pr
       xmpp.send_raw_iq(`<iq type="get" id="${id}" to="${to}"><pubsub xmlns="${NS_PUBSUB}"><items node="${node}"/></pubsub></iq>`),
       to,
       node,
+      undefined,
+      cancelRawIqOnTimeout(xmpp, id),
     );
   } catch (err) {
     logDiscoFailure("pubsub", to, node, err);

--- a/chat/tests/discovery-resilience.test.ts
+++ b/chat/tests/discovery-resilience.test.ts
@@ -65,6 +65,23 @@ describe("withIqTimeout (RFC 6120 §8.2.3 defense)", () => {
     // fires after the success path resolved.
     await new Promise((resolve) => setTimeout(resolve, 20));
   });
+
+  test("cancels the raw IQ request when the timeout wins", async () => {
+    const cancelled: string[] = [];
+    const late = new Promise<string>((resolve) => {
+      setTimeout(() => resolve("<iq type='result'/>"), 40);
+    });
+
+    await expect(withIqTimeout(
+      late,
+      "extensions.example.test",
+      undefined,
+      5,
+      { cancel: async () => { cancelled.push("iq-timeout-1"); } },
+    )).rejects.toBeInstanceOf(DiscoTimeoutError);
+
+    expect(cancelled).toEqual(["iq-timeout-1"]);
+  });
 });
 
 describe("discoverTopology partial-failure resilience", () => {
@@ -95,6 +112,28 @@ describe("discoverTopology partial-failure resilience", () => {
         // extensions.example.test never resolved → timeout fired and the
         // conventional spaces.<domain> fallback kicked in.
         expect(topology.services.spaces).toBe("spaces.example.test");
+      });
+    } finally {
+      __setDiscoIqTimeoutForTest(null);
+    }
+  });
+
+  test("cancels the driver raw IQ when a component disco#info timeout fires", async () => {
+    __setDiscoIqTimeoutForTest(30);
+    try {
+      await withFakeDomParser(async () => {
+        const client = neverResolvesForComponent("extensions.example.test");
+        const cancelledIds: string[] = [];
+        const topology = await discoverTopology({
+          ...client,
+          async cancel_raw_iq(id: string): Promise<void> {
+            cancelledIds.push(id);
+          },
+        }, "alice@example.test");
+
+        expect(topology.services.spaces).toBe("spaces.example.test");
+        expect(cancelledIds.length).toBe(1);
+        expect(cancelledIds[0]).toBe(discoveryIqIdFor(client.sentIqs, "extensions.example.test", "disco#info"));
       });
     } finally {
       __setDiscoIqTimeoutForTest(null);
@@ -153,8 +192,11 @@ type ResilientClientOptions = {
 };
 
 function neverResolvesForComponent(jid: string) {
+  const sentIqs: string[] = [];
   return {
+    sentIqs,
     async send_raw_iq(xml: string): Promise<string> {
+      sentIqs.push(xml);
       if (xml.includes('xmlns="http://jabber.org/protocol/disco#items"')) {
         if (xml.includes('to="example.test"')) {
           return discoItemsXml([
@@ -187,6 +229,11 @@ function neverResolvesForComponent(jid: string) {
       return discoItemsXml([]);
     },
   };
+}
+
+function discoveryIqIdFor(sentIqs: string[], to: string, namespaceFragment: string): string | undefined {
+  const iq = sentIqs.find((xml) => xml.includes(`to="${to}"`) && xml.includes(namespaceFragment));
+  return iq?.match(/\sid="([^"]+)"/)?.[1];
 }
 
 function customMucWithBrokenSibling() {
@@ -306,4 +353,3 @@ function resilientClient(options: ResilientClientOptions = {}) {
     },
   };
 }
-

--- a/server/crates/waddle-xmpp-client-wasm/src/client_messaging.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_messaging.rs
@@ -236,4 +236,12 @@ impl WaddleClient {
             Ok(JsValue::from_str(&element_to_xml_string(&result)?))
         })
     }
+
+    pub fn cancel_raw_iq(&self, id: String) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            cancel_iq_command(inner, id).await?;
+            Ok(JsValue::UNDEFINED)
+        })
+    }
 }

--- a/server/crates/waddle-xmpp-client-wasm/src/commands.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/commands.rs
@@ -30,6 +30,21 @@ pub(crate) async fn send_iq_command(
         .map_err(|err| js_error(err.to_string()))
 }
 
+pub(crate) async fn cancel_iq_command(
+    inner: Rc<RefCell<WaddleClientInner>>,
+    id: String,
+) -> Result<(), JsValue> {
+    let mut cmd_tx = command_sender(&inner)?;
+    let (responder, rx) = oneshot::channel();
+    cmd_tx
+        .send(WasmCommand::CancelIq { id, responder })
+        .await
+        .map_err(|_| js_error("client is disconnected"))?;
+    rx.await
+        .map_err(|_| js_error("client is disconnected"))?
+        .map_err(|err| js_error(err.to_string()))
+}
+
 /// Variant of [`send_iq_command`] that surfaces RFC 6120 §8.3 stanza
 /// errors as a typed [`waddle_xmpp_client::StanzaError`] instead of
 /// stringifying them onto the rejected Promise. Transport / disconnect

--- a/server/crates/waddle-xmpp-client-wasm/src/driver.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/driver.rs
@@ -179,6 +179,11 @@ impl WasmDriverTask {
                 self.send_inbox_query_command(stanza, query_id, responder)
                     .await
             }
+            Some(WasmCommand::CancelIq { id, responder }) => {
+                self.cancel_iq_command(&id);
+                let _ = responder.send(Ok(()));
+                true
+            }
             Some(WasmCommand::Disconnect { responder }) => {
                 self.explicit_disconnect = true;
                 self.publish_resume_state_snapshot();
@@ -191,6 +196,10 @@ impl WasmDriverTask {
             }
             None => false,
         }
+    }
+
+    fn cancel_iq_command(&mut self, id: &str) {
+        cancel_raw_iq_state(&mut self.pending_iqs, &mut self.deferred_commands, id);
     }
 
     async fn send_stanza_command(
@@ -611,9 +620,33 @@ fn publish_resume_state_snapshot(
     inner.borrow_mut().resume_state = resume_state;
 }
 
+fn cancel_raw_iq_state(
+    pending_iqs: &mut HashMap<String, oneshot::Sender<DriverResult<Element>>>,
+    deferred_commands: &mut VecDeque<DeferredWasmCommand>,
+    id: &str,
+) {
+    if let Some(responder) = pending_iqs.remove(id) {
+        let _ = responder.send(Err(ClientError::RequestCancelled));
+    }
+
+    let mut retained = VecDeque::with_capacity(deferred_commands.len());
+    while let Some(command) = deferred_commands.pop_front() {
+        if command.raw_iq_id() == Some(id) {
+            if let DeferredWasmCommand::Iq { responder, .. } = command {
+                let _ = responder.send(Err(ClientError::RequestCancelled));
+            }
+        } else {
+            retained.push_back(command);
+        }
+    }
+    *deferred_commands = retained;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures::executor::block_on;
+    use waddle_xmpp_client::discovery::DISCO_INFO_NS;
 
     fn test_inner() -> Rc<RefCell<WaddleClientInner>> {
         Rc::new(RefCell::new(WaddleClientInner {
@@ -737,5 +770,62 @@ mod tests {
         publish_resume_state_snapshot(&inner, &runtime, true);
 
         assert!(inner.borrow().resume_state.is_none());
+    }
+
+    fn iq(id: &str) -> Element {
+        Element::builder("iq", NS_CLIENT)
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "get")
+            .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
+            .append(Element::builder("query", DISCO_INFO_NS).build())
+            .build()
+    }
+
+    #[test]
+    fn cancel_raw_iq_removes_sent_pending_responder() {
+        let (responder, rx) = oneshot::channel();
+        let mut pending_iqs = HashMap::from([("sent-1".to_string(), responder)]);
+        let mut deferred_commands = VecDeque::new();
+
+        cancel_raw_iq_state(&mut pending_iqs, &mut deferred_commands, "sent-1");
+
+        assert!(!pending_iqs.contains_key("sent-1"));
+        assert!(matches!(
+            block_on(rx).expect("responder should send"),
+            Err(ClientError::RequestCancelled)
+        ));
+
+        let late = iq("sent-1");
+        assert!(pending_iqs.remove("sent-1").is_none());
+        drop(late);
+    }
+
+    #[test]
+    fn cancel_raw_iq_removes_not_yet_sent_deferred_responder() {
+        let (cancelled_responder, cancelled_rx) = oneshot::channel();
+        let (retained_responder, mut retained_rx) = oneshot::channel();
+        let mut pending_iqs = HashMap::new();
+        let mut deferred_commands = VecDeque::from([
+            DeferredWasmCommand::Iq {
+                stanza: iq("deferred-1"),
+                responder: cancelled_responder,
+            },
+            DeferredWasmCommand::Iq {
+                stanza: iq("deferred-2"),
+                responder: retained_responder,
+            },
+        ]);
+
+        cancel_raw_iq_state(&mut pending_iqs, &mut deferred_commands, "deferred-1");
+
+        assert_eq!(deferred_commands.len(), 1);
+        assert_eq!(deferred_commands[0].raw_iq_id(), Some("deferred-2"));
+        assert!(matches!(
+            block_on(cancelled_rx).expect("responder should send"),
+            Err(ClientError::RequestCancelled)
+        ));
+        assert!(retained_rx
+            .try_recv()
+            .expect("receiver should remain open")
+            .is_none());
     }
 }

--- a/server/crates/waddle-xmpp-client-wasm/src/state.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/state.rs
@@ -166,6 +166,10 @@ pub(crate) enum WasmCommand {
         query_id: String,
         responder: oneshot::Sender<DriverResult<InboxPage>>,
     },
+    CancelIq {
+        id: String,
+        responder: oneshot::Sender<DriverResult<()>>,
+    },
     Disconnect {
         responder: oneshot::Sender<DriverResult<()>>,
     },
@@ -190,6 +194,15 @@ pub(crate) enum DeferredWasmCommand {
         query_id: String,
         responder: oneshot::Sender<DriverResult<InboxPage>>,
     },
+}
+
+impl DeferredWasmCommand {
+    pub(crate) fn raw_iq_id(&self) -> Option<&str> {
+        match self {
+            Self::Iq { stanza, .. } => stanza.attr("id"),
+            Self::Stanza { .. } | Self::MamQuery { .. } | Self::InboxQuery { .. } => None,
+        }
+    }
 }
 
 /// Result of one streamed XEP-0430 inbox query.

--- a/server/crates/waddle-xmpp-client/src/error.rs
+++ b/server/crates/waddle-xmpp-client/src/error.rs
@@ -72,6 +72,8 @@ pub enum ClientError {
     UnsupportedWebSocketMessage,
     #[error("websocket transport is already closed")]
     TransportClosed,
+    #[error("request was cancelled")]
+    RequestCancelled,
     #[error("the XMPP session is disconnected")]
     Disconnected,
     #[error("server returned a stanza error: {0}")]

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -27,6 +27,7 @@ export class WaddleClient {
      * owner" and falls back to the empty-state screen.
      */
     admin_users_list(prefix?: string | null, page_size?: number | null, after_cursor?: string | null): Promise<any>;
+    cancel_raw_iq(id: string): Promise<any>;
     connect(): Promise<any>;
     /**
      * XEP-0050 `disable-device` ad-hoc command on `push.<domain>`.

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mprde3zg";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mprde3zg";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mprde3zg";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mptncl9w";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mptncl9w";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mptncl9w";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=mprde3zg";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=mptncl9w";


### PR DESCRIPTION
## Summary

- Adds an internal typed WASM driver command to cancel raw IQ requests by id.
- Exposes `cancel_raw_iq(id)` through the WASM JS bridge and waits for driver cleanup before resolving.
- Calls raw IQ cancellation from chat discovery timeout cleanup for XEP-0030 disco#info, disco#items, and pubsub item requests.
- Removes cancelled raw IQ responders from both sent `pending_iqs` and not-yet-sent deferred raw IQ state so late replies are ignored by the existing unmatched-IQ path.
- Refreshes the generated local `@waddle/xmpp-client-wasm` package type/entrypoint.

## Plan

- Compare discovery request/response handling against local `xeps/xep-0030.xml`.
- Keep wire behavior XMPP-native: no new stanza, namespace, or out-of-band API.
- Add the raw IQ cancellation driver command and JS bridge.
- Wire discovery timeouts to cancel stale raw IQ ids.
- Add focused chat and Rust/WASM tests for timeout cancellation, sent pending IQ cancellation, deferred IQ cancellation, and late-reply ignore state.
- Run focused validation plus chat lint and Rust clippy with warnings denied.
- Run adversarial review personas and repeat until no real actionable issues remain.

## XEP review

Reviewed against local `xeps/xep-0030.xml`: service discovery remains standard IQ `get` with `http://jabber.org/protocol/disco#info` / `http://jabber.org/protocol/disco#items`, correlated by `id`, expecting `result` or `error`. Cancellation is local client request-state cleanup only and sends no XMPP stanza.

## Validation

- `bun test chat/tests/discovery-resilience.test.ts`
- `cargo test --manifest-path server/Cargo.toml -p waddle-xmpp-client-wasm`
- `cargo clippy --manifest-path server/Cargo.toml -p waddle-xmpp-client -p waddle-xmpp-client-wasm --all-targets -- -D warnings`
- `bun run lint` in `chat/`

## Review

- Protocol conformance persona: no actionable findings.
- Rust WASM driver/state persona: no actionable findings after the cancellation ack fix.
- TypeScript QA persona: found that `cancel_raw_iq()` originally resolved after enqueue rather than driver cleanup; fixed with a typed driver responder. Repeat review found no actionable findings.
