### PR TITLE
fix(server): type XEP-0049 private XML storage

### DIFF
--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/errors.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/errors.rs
@@ -28,6 +28,18 @@ pub(crate) fn bad_request_iq_error(text: &str) -> StanzaError {
     )
 }
 
+/// `<bad-request/>` (modify) for legacy specs that describe the same
+/// syntax failure as "bad format"; RFC 6120 does not define a
+/// `bad-format` stanza-error condition.
+pub(crate) fn bad_format_iq_error(text: &str) -> StanzaError {
+    StanzaError::new(
+        ErrorType::Modify,
+        DefinedCondition::BadRequest,
+        DEFAULT_LANG,
+        text,
+    )
+}
+
 /// `<jid-malformed/>` (modify) — `<iq to=…>` carried a JID the parser
 /// rejected.
 pub(crate) fn jid_malformed_iq_error(text: &str) -> StanzaError {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
@@ -137,9 +137,10 @@ pub use test_helpers::handle_iq;
 // IQ-error constructors without each having to re-import the
 // `errors` submodule directly.
 pub(super) use errors::{
-    bad_request_iq_error, feature_not_implemented_iq_error, forbidden_iq_error,
-    internal_server_error_iq_error, item_not_found_iq_error, jid_malformed_iq_error,
-    not_acceptable_iq_error, not_authorized_iq_error, service_unavailable_iq_error,
+    bad_format_iq_error, bad_request_iq_error, feature_not_implemented_iq_error,
+    forbidden_iq_error, internal_server_error_iq_error, item_not_found_iq_error,
+    jid_malformed_iq_error, not_acceptable_iq_error, not_authorized_iq_error,
+    service_unavailable_iq_error,
 };
 
 fn push_service_stanza_error(error: XmppError) -> xmpp_parsers::stanza_error::StanzaError {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/vcard_private.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/vcard_private.rs
@@ -1,4 +1,5 @@
 use super::*;
+use waddle_xmpp::xep::xep0049::{self, PrivateStorageError};
 
 pub(super) async fn handle_vcard_iq(
     iq: &xmpp_parsers::iq::Iq,
@@ -115,7 +116,30 @@ pub(super) async fn handle_private_storage_iq(
     };
     let bare_jid = sender_jid.to_bare();
 
-    if let Some(key) = waddle_xmpp::xep::xep0049::parse_private_storage_get(iq) {
+    if let Some(to) = iq.to() {
+        if to.to_bare() != bare_jid {
+            return vec![build_iq_error_xml_typed(
+                iq.id(),
+                response_from,
+                response_to,
+                forbidden_iq_error("Operation not permitted."),
+            )];
+        }
+    }
+
+    if matches!(iq, xmpp_parsers::iq::Iq::Get { .. }) {
+        let key = match xep0049::parse_private_storage_get(iq) {
+            Ok(key) => key,
+            Err(error) => {
+                return vec![build_iq_error_xml_typed(
+                    iq.id(),
+                    response_from,
+                    response_to,
+                    private_storage_request_error(error),
+                )];
+            }
+        };
+
         if waddle_xmpp::xep::xep0048::is_legacy_bookmarks_namespace(&key.namespace) {
             let stored_items = state
                 .deps
@@ -137,11 +161,19 @@ pub(super) async fn handle_private_storage_iq(
                 .map(waddle_xmpp::xep::xep0048::from_native_bookmark)
                 .collect();
             let bookmarks = waddle_xmpp::xep::xep0048::build_legacy_bookmarks_element(&legacy);
-            let response = waddle_xmpp::xep::xep0049::build_private_storage_result(
-                iq,
-                Some(&String::from(&bookmarks)),
-                &key,
-            );
+            let value = match xep0049::PrivateStorageValue::from_element(bookmarks) {
+                Ok(value) => value,
+                Err(error) => {
+                    warn!(jid = %bare_jid, ?error, "Failed to build legacy private XML value");
+                    return vec![build_iq_error_xml_typed(
+                        iq.id(),
+                        response_from,
+                        response_to,
+                        internal_server_error_iq_error("Internal server error."),
+                    )];
+                }
+            };
+            let response = xep0049::build_private_storage_result(iq, Some(&value), &key);
             return vec![iq_to_xml(response)];
         }
 
@@ -187,15 +219,45 @@ pub(super) async fn handle_private_storage_iq(
             },
             None => None,
         };
-        let response =
-            waddle_xmpp::xep::xep0049::build_private_storage_result(iq, stored.as_deref(), &key);
+
+        let stored_value = match stored
+            .as_deref()
+            .map(xep0049::parse_stored_private_storage_value)
+            .transpose()
+        {
+            Ok(value) => value,
+            Err(error) => {
+                warn!(jid = %bare_jid, namespace = %key.namespace, ?error, "Failed to parse stored private XML");
+                return vec![build_iq_error_xml_typed(
+                    iq.id(),
+                    response_from,
+                    response_to,
+                    internal_server_error_iq_error("Stored private XML is malformed."),
+                )];
+            }
+        };
+
+        let response = xep0049::build_private_storage_result(iq, stored_value.as_ref(), &key);
         return vec![iq_to_xml(response)];
     }
 
-    if let Some((key, xml_content)) = waddle_xmpp::xep::xep0049::parse_private_storage_set(iq) {
+    if matches!(iq, xmpp_parsers::iq::Iq::Set { .. }) {
+        let value = match xep0049::parse_private_storage_set(iq) {
+            Ok(value) => value,
+            Err(error) => {
+                return vec![build_iq_error_xml_typed(
+                    iq.id(),
+                    response_from,
+                    response_to,
+                    private_storage_request_error(error),
+                )];
+            }
+        };
+        let key = value.key.clone();
+
         if waddle_xmpp::xep::xep0048::is_legacy_bookmarks_namespace(&key.namespace) {
-            if let Ok(elem) = xml_content.parse::<Element>() {
-                for legacy in waddle_xmpp::xep::xep0048::parse_legacy_bookmarks(&elem) {
+            for element in &value.elements {
+                for legacy in waddle_xmpp::xep::xep0048::parse_legacy_bookmarks(element) {
                     if let Some(native) = waddle_xmpp::xep::xep0048::to_native_bookmark(&legacy) {
                         let bookmark_elem =
                             waddle_xmpp::xep::xep0402::build_bookmark_element(&native);
@@ -216,11 +278,10 @@ pub(super) async fn handle_private_storage_iq(
                     }
                 }
             }
-            return vec![iq_to_xml(
-                waddle_xmpp::xep::xep0049::build_private_storage_success(iq),
-            )];
+            return vec![iq_to_xml(xep0049::build_private_storage_success(iq))];
         }
 
+        let xml_content = value.to_xml_string();
         if let Err(error) = state
             .deps
             .app_state
@@ -245,9 +306,7 @@ pub(super) async fn handle_private_storage_iq(
                             internal_server_error_iq_error("Internal server error."),
                         )];
         }
-        return vec![iq_to_xml(
-            waddle_xmpp::xep::xep0049::build_private_storage_success(iq),
-        )];
+        return vec![iq_to_xml(xep0049::build_private_storage_success(iq))];
     }
 
     vec![build_iq_error_xml_typed(
@@ -256,4 +315,29 @@ pub(super) async fn handle_private_storage_iq(
         response_to,
         bad_request_iq_error("Malformed IQ payload."),
     )]
+}
+
+fn private_storage_request_error(
+    error: PrivateStorageError,
+) -> xmpp_parsers::stanza_error::StanzaError {
+    match error {
+        PrivateStorageError::MissingPayload => {
+            bad_format_iq_error("Private XML query requires one child element.")
+        }
+        PrivateStorageError::MissingNamespace => {
+            bad_format_iq_error("Private XML child element requires a namespace.")
+        }
+        PrivateStorageError::MultiplePayloads => {
+            bad_format_iq_error("Private XML query must not contain multiple child elements.")
+        }
+        PrivateStorageError::MultipleNamespaces => {
+            bad_format_iq_error("Private XML set must use one child namespace.")
+        }
+        PrivateStorageError::UnexpectedIqType | PrivateStorageError::UnexpectedQuery => {
+            bad_request_iq_error("Malformed IQ payload.")
+        }
+        PrivateStorageError::MalformedStoredXml => {
+            internal_server_error_iq_error("Stored private XML is malformed.")
+        }
+    }
 }

--- a/server/crates/waddle-server/tests/xep0054_0049_0191_ws.rs
+++ b/server/crates/waddle-server/tests/xep0054_0049_0191_ws.rs
@@ -12,9 +12,26 @@ const USERNAME: &str = "admin";
 const NS_PUBSUB_PUBLISH_OPTIONS: &str = "http://jabber.org/protocol/pubsub#publish-options";
 const NS_PUSH: &str = "urn:xmpp:push:0";
 const NS_XDATA: &str = "jabber:x:data";
+const NS_PRIVATE: &str = "jabber:iq:private";
+const NS_TEST_PRIVATE: &str = "urn:waddle:test";
 
 async fn setup() -> (TestServer, WsXmppClient) {
     let server = TestServer::start();
+    let password = server.fixed_account_password().to_string();
+    let client = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        USERNAME,
+        &password,
+        &format!("stateful-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("websocket connection");
+    (server, client)
+}
+
+async fn setup_with_database_url(database_url: &str) -> (TestServer, WsXmppClient) {
+    let server = TestServer::start_persistent_with_extra_accounts(database_url, &[]);
     let password = server.fixed_account_password().to_string();
     let client = WsXmppClient::connect_and_auth(
         &server.ws_url(),
@@ -96,6 +113,27 @@ fn element_to_xml(element: Element) -> String {
     let mut buf = Vec::new();
     element.write_to(&mut buf).expect("serialize XML element");
     String::from_utf8(buf).expect("minidom serializes UTF-8")
+}
+
+fn private_storage_iq(
+    id: &str,
+    iq_type: &str,
+    to: Option<&str>,
+    children: impl IntoIterator<Item = Element>,
+) -> String {
+    let mut query = Element::builder("query", NS_PRIVATE);
+    for child in children {
+        query = query.append(child);
+    }
+
+    let mut iq = Element::builder("iq", CLIENT_NS)
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), iq_type)
+        .attr(minidom::rxml::xml_ncname!("id").to_owned(), id);
+    if let Some(to) = to {
+        iq = iq.attr(minidom::rxml::xml_ncname!("to").to_owned(), to);
+    }
+
+    element_to_xml(iq.append(query.build()).build())
 }
 
 fn push_enable_iq(id: &str, jid: &str, node: &str, publish_options: Option<Element>) -> String {
@@ -216,12 +254,15 @@ async fn websocket_vcard_set_then_get_roundtrips() {
 async fn websocket_private_xml_set_then_get_roundtrips() {
     let (_server, mut client) = setup().await;
 
-    client
-        .send(
-            r#"<iq xmlns="jabber:client" type="set" id="ws-private-set"><query xmlns="jabber:iq:private"><prefs xmlns="urn:waddle:test"><theme>dark</theme></prefs></query></iq>"#,
+    let prefs = Element::builder("prefs", NS_TEST_PRIVATE)
+        .append(
+            Element::builder("theme", NS_TEST_PRIVATE)
+                .append("dark")
+                .build(),
         )
-        .await
-        .expect("send private set");
+        .build();
+    let set_iq = private_storage_iq("ws-private-set", "set", None, [prefs]);
+    client.send(&set_iq).await.expect("send private set");
     let set_response = client
         .recv_matching(|frame| frame.contains("ws-private-set"))
         .await
@@ -231,12 +272,9 @@ async fn websocket_private_xml_set_then_get_roundtrips() {
         "expected private XML set result, got: {set_response}"
     );
 
-    client
-        .send(
-            r#"<iq xmlns="jabber:client" type="get" id="ws-private-get"><query xmlns="jabber:iq:private"><prefs xmlns="urn:waddle:test"/></query></iq>"#,
-        )
-        .await
-        .expect("send private get");
+    let requested = Element::builder("prefs", NS_TEST_PRIVATE).build();
+    let get_iq = private_storage_iq("ws-private-get", "get", None, [requested]);
+    client.send(&get_iq).await.expect("send private get");
     let get_response = client
         .recv_matching(|frame| frame.contains("ws-private-get"))
         .await
@@ -244,6 +282,111 @@ async fn websocket_private_xml_set_then_get_roundtrips() {
     assert!(
         get_response.contains("dark"),
         "expected stored private XML, got: {get_response}"
+    );
+
+    let _ = client.close().await;
+}
+
+#[tokio::test]
+async fn websocket_private_xml_get_without_child_returns_bad_format() {
+    let (_server, mut client) = setup().await;
+
+    let get_iq = private_storage_iq("ws-private-empty", "get", None, []);
+    client.send(&get_iq).await.expect("send private empty get");
+    let response = client
+        .recv_matching(|frame| frame.contains("ws-private-empty"))
+        .await
+        .expect("private empty get response");
+    assert!(
+        response.contains("bad-request"),
+        "expected bad-request for empty private get, got: {response}"
+    );
+
+    let _ = client.close().await;
+}
+
+#[tokio::test]
+async fn websocket_private_xml_get_with_duplicate_children_returns_bad_format() {
+    let (_server, mut client) = setup().await;
+
+    let first = Element::builder("prefs", NS_TEST_PRIVATE).build();
+    let second = Element::builder("other", NS_TEST_PRIVATE).build();
+    let get_iq = private_storage_iq("ws-private-duplicate", "get", None, [first, second]);
+    client
+        .send(&get_iq)
+        .await
+        .expect("send private duplicate get");
+    let response = client
+        .recv_matching(|frame| frame.contains("ws-private-duplicate"))
+        .await
+        .expect("private duplicate get response");
+    assert!(
+        response.contains("bad-request"),
+        "expected bad-request for duplicate private get, got: {response}"
+    );
+
+    let _ = client.close().await;
+}
+
+#[tokio::test]
+async fn websocket_private_xml_foreign_to_returns_forbidden() {
+    let (_server, mut alice, _bob) = connect_alice_bob().await;
+
+    let requested = Element::builder("prefs", NS_TEST_PRIVATE).build();
+    let get_iq = private_storage_iq(
+        "ws-private-foreign",
+        "get",
+        Some("bob@localhost"),
+        [requested],
+    );
+    alice.send(&get_iq).await.expect("send private foreign get");
+    let response = alice
+        .recv_matching(|frame| frame.contains("ws-private-foreign"))
+        .await
+        .expect("private foreign get response");
+    assert!(
+        response.contains("forbidden"),
+        "expected forbidden for foreign private XML access, got: {response}"
+    );
+
+    let _ = alice.close().await;
+}
+
+#[tokio::test]
+async fn websocket_private_xml_malformed_stored_xml_returns_error() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let database_url = format!(
+        "sqlite://{}?mode=rwc",
+        tempdir.path().join("waddle.db").display()
+    );
+    let (_server, mut client) = setup_with_database_url(&database_url).await;
+
+    let pool = sqlx::SqlitePool::connect(&database_url)
+        .await
+        .expect("connect sqlite");
+    sqlx::query(
+        "INSERT OR REPLACE INTO private_xml_storage (jid, namespace, xml_content) VALUES (?, ?, ?)",
+    )
+    .bind("admin@localhost")
+    .bind("urn:waddle:test:malformed")
+    .bind("<prefs xmlns='urn:waddle:test:malformed'>")
+    .execute(&pool)
+    .await
+    .expect("insert malformed private XML");
+
+    let requested = Element::builder("prefs", "urn:waddle:test:malformed").build();
+    let get_iq = private_storage_iq("ws-private-malformed", "get", None, [requested]);
+    client
+        .send(&get_iq)
+        .await
+        .expect("send private malformed get");
+    let response = client
+        .recv_matching(|frame| frame.contains("ws-private-malformed"))
+        .await
+        .expect("private malformed get response");
+    assert!(
+        response.contains("internal-server-error"),
+        "expected internal-server-error for malformed stored XML, got: {response}"
     );
 
     let _ = client.close().await;

--- a/server/crates/waddle-xmpp/src/xep/exports.rs
+++ b/server/crates/waddle-xmpp/src/xep/exports.rs
@@ -251,7 +251,8 @@ pub use super::xep0048::{
 
 pub use super::xep0049::{
     build_private_storage_result, build_private_storage_success, is_private_storage_query,
-    parse_private_storage_get, parse_private_storage_set, PrivateStorageKey, NS_PRIVATE,
+    parse_private_storage_get, parse_private_storage_set, parse_stored_private_storage_value,
+    PrivateStorageError, PrivateStorageKey, PrivateStorageValue, NS_PRIVATE,
 };
 
 pub use super::xep0084::{

--- a/server/crates/waddle-xmpp/src/xep/xep0049.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0049.rs
@@ -18,6 +18,81 @@ pub struct PrivateStorageKey {
     pub namespace: String,
 }
 
+impl PrivateStorageKey {
+    fn from_element(element: &Element) -> Self {
+        Self {
+            element_name: element.name().to_string(),
+            namespace: element.ns().to_string(),
+        }
+    }
+}
+
+/// Typed arbitrary XML payload stored by XEP-0049.
+#[derive(Debug, Clone)]
+pub struct PrivateStorageValue {
+    /// The first element name + shared namespace storage key.
+    pub key: PrivateStorageKey,
+    /// The arbitrary XML fragment elements in their original order.
+    pub elements: Vec<Element>,
+}
+
+impl PrivateStorageValue {
+    /// Build a typed storage value from an XML element.
+    pub fn from_element(element: Element) -> Result<Self, PrivateStorageError> {
+        Self::from_elements(vec![element])
+    }
+
+    /// Build a typed storage value from same-namespace XML elements.
+    pub fn from_elements(elements: Vec<Element>) -> Result<Self, PrivateStorageError> {
+        let first = elements
+            .first()
+            .ok_or(PrivateStorageError::MissingPayload)?;
+        let key = PrivateStorageKey::from_element(first);
+        if key.namespace.is_empty() {
+            return Err(PrivateStorageError::MissingNamespace);
+        }
+        if elements
+            .iter()
+            .any(|element| element.ns() != key.namespace.as_str())
+        {
+            return Err(PrivateStorageError::MultipleNamespaces);
+        }
+        Ok(Self { key, elements })
+    }
+
+    /// Serialize only at persistence or transport boundaries.
+    pub fn to_xml_string(&self) -> String {
+        if let [element] = self.elements.as_slice() {
+            return String::from(element);
+        }
+
+        let mut builder = Element::builder("query", NS_PRIVATE);
+        for element in &self.elements {
+            builder = builder.append(element.clone());
+        }
+        String::from(&builder.build())
+    }
+}
+
+/// XEP-0049 query parsing/storage value errors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrivateStorageError {
+    /// The IQ stanza is not the expected get or set shape.
+    UnexpectedIqType,
+    /// The payload is not `<query xmlns='jabber:iq:private'/>`.
+    UnexpectedQuery,
+    /// The query is missing the required private child payload.
+    MissingPayload,
+    /// The private child payload is not scoped by its own namespace.
+    MissingNamespace,
+    /// The request attempted to address more than one private payload.
+    MultiplePayloads,
+    /// A multi-payload SET used more than one child namespace.
+    MultipleNamespaces,
+    /// Stored XML could not be parsed back into a typed element.
+    MalformedStoredXml,
+}
+
 /// Check if an IQ is a private XML storage query (XEP-0049).
 pub fn is_private_storage_query(iq: &Iq) -> bool {
     match iq {
@@ -30,56 +105,58 @@ pub fn is_private_storage_query(iq: &Iq) -> bool {
 
 /// Parse a private storage GET request.
 ///
-/// Returns the namespace of the child element being requested.
-pub fn parse_private_storage_get(iq: &Iq) -> Option<PrivateStorageKey> {
-    if let Iq::Get { payload: elem, .. } = &iq {
-        if elem.name() == "query" && elem.ns() == NS_PRIVATE {
-            if let Some(child) = elem.children().next() {
-                return Some(PrivateStorageKey {
-                    element_name: child.name().to_string(),
-                    namespace: child.ns().to_string(),
-                });
-            }
-        }
+/// Returns the element name + namespace of the child element being requested.
+pub fn parse_private_storage_get(iq: &Iq) -> Result<PrivateStorageKey, PrivateStorageError> {
+    let Iq::Get { payload: elem, .. } = &iq else {
+        return Err(PrivateStorageError::UnexpectedIqType);
+    };
+
+    ensure_private_query(elem)?;
+    let key = PrivateStorageKey::from_element(exactly_one_child(elem)?);
+    if key.namespace.is_empty() {
+        return Err(PrivateStorageError::MissingNamespace);
     }
-    None
+    Ok(key)
 }
 
 /// Parse a private storage SET request.
 ///
-/// Returns the namespace and the full XML content to store.
-pub fn parse_private_storage_set(iq: &Iq) -> Option<(PrivateStorageKey, String)> {
-    if let Iq::Set { payload: elem, .. } = &iq {
-        if elem.name() == "query" && elem.ns() == NS_PRIVATE {
-            if let Some(child) = elem.children().next() {
-                let key = PrivateStorageKey {
-                    element_name: child.name().to_string(),
-                    namespace: child.ns().to_string(),
-                };
-                let xml_content = String::from(child);
-                return Some((key, xml_content));
-            }
-        }
+/// Returns the typed arbitrary XML content to store.
+pub fn parse_private_storage_set(iq: &Iq) -> Result<PrivateStorageValue, PrivateStorageError> {
+    let Iq::Set { payload: elem, .. } = &iq else {
+        return Err(PrivateStorageError::UnexpectedIqType);
+    };
+
+    ensure_private_query(elem)?;
+    PrivateStorageValue::from_elements(elem.children().cloned().collect())
+}
+
+/// Parse serialized storage data back into a typed private XML value.
+pub fn parse_stored_private_storage_value(
+    xml_content: &str,
+) -> Result<PrivateStorageValue, PrivateStorageError> {
+    let element = xml_content
+        .parse::<Element>()
+        .map_err(|_| PrivateStorageError::MalformedStoredXml)?;
+
+    if element.name() == "query" && element.ns() == NS_PRIVATE {
+        return PrivateStorageValue::from_elements(element.children().cloned().collect());
     }
-    None
+
+    PrivateStorageValue::from_element(element)
 }
 
 /// Build a private storage result IQ (response to GET).
 pub fn build_private_storage_result(
     original_iq: &Iq,
-    xml_content: Option<&str>,
+    value: Option<&PrivateStorageValue>,
     key: &PrivateStorageKey,
 ) -> Iq {
     let mut query_builder = Element::builder("query", NS_PRIVATE);
 
-    if let Some(content) = xml_content {
-        // Try to parse the stored XML back into an element
-        if let Ok(elem) = content.parse::<Element>() {
-            query_builder = query_builder.append(elem);
-        } else {
-            // If parsing fails, return empty element with the namespace
-            let empty = Element::builder(&key.element_name, &key.namespace).build();
-            query_builder = query_builder.append(empty);
+    if let Some(value) = value {
+        for element in &value.elements {
+            query_builder = query_builder.append(element.clone());
         }
     } else {
         // No stored data - return empty element with the namespace
@@ -105,6 +182,23 @@ pub fn build_private_storage_success(original_iq: &Iq) -> Iq {
         id: original_iq.id().to_string(),
         payload: None,
     }
+}
+
+fn ensure_private_query(element: &Element) -> Result<(), PrivateStorageError> {
+    if element.name() == "query" && element.ns() == NS_PRIVATE {
+        Ok(())
+    } else {
+        Err(PrivateStorageError::UnexpectedQuery)
+    }
+}
+
+fn exactly_one_child(element: &Element) -> Result<&Element, PrivateStorageError> {
+    let mut children = element.children();
+    let child = children.next().ok_or(PrivateStorageError::MissingPayload)?;
+    if children.next().is_some() {
+        return Err(PrivateStorageError::MultiplePayloads);
+    }
+    Ok(child)
 }
 
 #[cfg(test)]
@@ -147,9 +241,7 @@ mod tests {
             id: "test-3".to_string(),
             payload: query,
         };
-        let key = parse_private_storage_get(&iq);
-        assert!(key.is_some());
-        let key = key.unwrap();
+        let key = parse_private_storage_get(&iq).unwrap();
         assert_eq!(key.element_name, "storage");
         assert_eq!(key.namespace, "storage:bookmarks");
     }
@@ -166,11 +258,9 @@ mod tests {
             id: "test-4".to_string(),
             payload: query,
         };
-        let result = parse_private_storage_set(&iq);
-        assert!(result.is_some());
-        let (key, content) = result.unwrap();
-        assert_eq!(key.element_name, "storage");
-        assert_eq!(key.namespace, "storage:bookmarks");
-        assert!(content.contains("storage:bookmarks"));
+        let result = parse_private_storage_set(&iq).unwrap();
+        assert_eq!(result.key.element_name, "storage");
+        assert_eq!(result.key.namespace, "storage:bookmarks");
+        assert_eq!(result.elements[0].name(), "storage");
     }
 }

--- a/server/crates/waddle-xmpp/tests/xep0049_private_xml_storage.rs
+++ b/server/crates/waddle-xmpp/tests/xep0049_private_xml_storage.rs
@@ -1,0 +1,231 @@
+//! XEP-0049: Private XML Storage — dedicated conformance suite.
+//!
+//! Pins the typed arbitrary-XML boundary for `jabber:iq:private`:
+//! GET identifies one requested child namespace, SET carries typed XML
+//! payload elements, and storage serialization is parsed back into
+//! `minidom::Element` before result construction.
+
+use minidom::{rxml::xml_ncname, Element};
+use waddle_xmpp::xep::xep0049::{
+    build_private_storage_result, parse_private_storage_get, parse_private_storage_set,
+    parse_stored_private_storage_value, PrivateStorageError, PrivateStorageKey,
+    PrivateStorageValue, NS_PRIVATE,
+};
+use xmpp_parsers::iq::Iq;
+
+const NS_PREFS: &str = "urn:waddle:test:prefs";
+
+fn query(children: Vec<Element>) -> Element {
+    let mut builder = Element::builder("query", NS_PRIVATE);
+    for child in children {
+        builder = builder.append(child);
+    }
+    builder.build()
+}
+
+fn get_iq(payload: Element) -> Iq {
+    Iq::Get {
+        from: None,
+        to: None,
+        id: "get-1".into(),
+        payload,
+    }
+}
+
+fn set_iq(payload: Element) -> Iq {
+    Iq::Set {
+        from: None,
+        to: None,
+        id: "set-1".into(),
+        payload,
+    }
+}
+
+fn prefs_key() -> PrivateStorageKey {
+    PrivateStorageKey {
+        element_name: "prefs".into(),
+        namespace: NS_PREFS.into(),
+    }
+}
+
+#[test]
+fn xep0049_get_parses_single_child_key() {
+    let child = Element::builder("prefs", NS_PREFS).build();
+    let key = parse_private_storage_get(&get_iq(query(vec![child]))).expect("valid get");
+
+    assert_eq!(key.element_name, "prefs");
+    assert_eq!(key.namespace, NS_PREFS);
+}
+
+#[test]
+fn xep0049_get_rejects_missing_child() {
+    let error = parse_private_storage_get(&get_iq(query(vec![]))).expect_err("missing child");
+
+    assert_eq!(error, PrivateStorageError::MissingPayload);
+}
+
+#[test]
+fn xep0049_get_rejects_duplicate_children() {
+    let first = Element::builder("prefs", NS_PREFS).build();
+    let second = Element::builder("other", NS_PREFS).build();
+    let error =
+        parse_private_storage_get(&get_iq(query(vec![first, second]))).expect_err("duplicates");
+
+    assert_eq!(error, PrivateStorageError::MultiplePayloads);
+}
+
+#[test]
+fn xep0049_get_rejects_child_without_namespace() {
+    let child = Element::builder("prefs", "").build();
+    let error = parse_private_storage_get(&get_iq(query(vec![child]))).expect_err("missing ns");
+
+    assert_eq!(error, PrivateStorageError::MissingNamespace);
+}
+
+#[test]
+fn xep0049_set_preserves_nested_arbitrary_xml_as_typed_payload() {
+    let theme = Element::builder("theme", NS_PREFS).append("dark").build();
+    let nested = Element::builder("settings", NS_PREFS)
+        .append(Element::builder("compact", NS_PREFS).append("true").build())
+        .build();
+    let prefs = Element::builder("prefs", NS_PREFS)
+        .append(theme)
+        .append(nested)
+        .build();
+
+    let value = parse_private_storage_set(&set_iq(query(vec![prefs]))).expect("valid set");
+
+    assert_eq!(value.key, prefs_key());
+    assert_eq!(value.elements.len(), 1);
+    let children: Vec<&Element> = value.elements[0].children().collect();
+    assert_eq!(children[0].name(), "theme");
+    assert_eq!(children[0].text(), "dark");
+    assert_eq!(children[1].name(), "settings");
+}
+
+#[test]
+fn xep0049_set_accepts_multiple_children_in_one_namespace() {
+    let first = Element::builder("prefs", NS_PREFS).build();
+    let second = Element::builder("profile", NS_PREFS).build();
+
+    let value = parse_private_storage_set(&set_iq(query(vec![first, second]))).expect("valid set");
+
+    assert_eq!(value.key.namespace, NS_PREFS);
+    assert_eq!(
+        value.elements.iter().map(Element::name).collect::<Vec<_>>(),
+        vec!["prefs", "profile"]
+    );
+}
+
+#[test]
+fn xep0049_set_rejects_multiple_child_namespaces() {
+    let first = Element::builder("prefs", NS_PREFS).build();
+    let second = Element::builder("private", "urn:waddle:test:other").build();
+
+    let error =
+        parse_private_storage_set(&set_iq(query(vec![first, second]))).expect_err("mixed ns");
+
+    assert_eq!(error, PrivateStorageError::MultipleNamespaces);
+}
+
+#[test]
+fn xep0049_set_rejects_child_without_namespace() {
+    let child = Element::builder("prefs", "").build();
+    let error = parse_private_storage_set(&set_iq(query(vec![child]))).expect_err("missing ns");
+
+    assert_eq!(error, PrivateStorageError::MissingNamespace);
+}
+
+#[test]
+fn xep0049_value_constructor_rejects_element_without_namespace() {
+    let child = Element::builder("prefs", "").build();
+    let error = PrivateStorageValue::from_element(child).expect_err("missing namespace");
+
+    assert_eq!(error, PrivateStorageError::MissingNamespace);
+}
+
+#[test]
+fn xep0049_stored_xml_must_parse_to_typed_value() {
+    let error = parse_stored_private_storage_value("<prefs xmlns='urn:waddle:test:prefs'>")
+        .expect_err("malformed stored XML");
+
+    assert_eq!(error, PrivateStorageError::MalformedStoredXml);
+}
+
+#[test]
+fn xep0049_stored_xml_without_namespace_is_rejected() {
+    let error = parse_stored_private_storage_value("<prefs/>").expect_err("missing namespace");
+
+    assert!(matches!(
+        error,
+        PrivateStorageError::MalformedStoredXml | PrivateStorageError::MissingNamespace
+    ));
+}
+
+#[test]
+fn xep0049_absent_value_returns_empty_requested_element() {
+    let iq = get_iq(query(vec![Element::builder("prefs", NS_PREFS).build()]));
+    let result = build_private_storage_result(&iq, None, &prefs_key());
+
+    let Iq::Result {
+        payload: Some(payload),
+        ..
+    } = result
+    else {
+        panic!("expected result payload");
+    };
+
+    assert_eq!(payload.name(), "query");
+    assert_eq!(payload.ns(), NS_PRIVATE);
+    let children: Vec<&Element> = payload.children().collect();
+    assert_eq!(children.len(), 1);
+    assert_eq!(children[0].name(), "prefs");
+    assert_eq!(children[0].ns(), NS_PREFS);
+    assert_eq!(children[0].children().count(), 0);
+}
+
+#[test]
+fn xep0049_result_preserves_stored_typed_payloads() {
+    let first = Element::builder("prefs", NS_PREFS)
+        .append(Element::builder("theme", NS_PREFS).append("dark").build())
+        .build();
+    let second = Element::builder("profile", NS_PREFS)
+        .append(
+            Element::builder("display", NS_PREFS)
+                .append("Waddle")
+                .build(),
+        )
+        .build();
+    let value = PrivateStorageValue::from_elements(vec![first, second]).expect("same ns");
+    let iq = get_iq(query(vec![Element::builder("prefs", NS_PREFS).build()]));
+
+    let result = build_private_storage_result(&iq, Some(&value), &prefs_key());
+
+    let Iq::Result {
+        payload: Some(payload),
+        ..
+    } = result
+    else {
+        panic!("expected result payload");
+    };
+    let children: Vec<&Element> = payload.children().collect();
+    assert_eq!(children.len(), 2);
+    assert_eq!(children[0].name(), "prefs");
+    assert_eq!(children[1].name(), "profile");
+}
+
+#[test]
+fn xep0049_storage_serializer_uses_xml_escaping() {
+    let note = Element::builder("note", NS_PREFS)
+        .attr(xml_ncname!("label").to_owned(), "5 > 3 & \"quoted\"")
+        .append("Tom & <Jerry>")
+        .build();
+    let value = PrivateStorageValue::from_element(note).expect("namespaced element");
+
+    let stored = value.to_xml_string();
+    assert!(!stored.contains("Tom & <Jerry>"));
+
+    let parsed = parse_stored_private_storage_value(&stored).expect("serialized XML parses");
+    assert_eq!(parsed.elements[0].attr("label"), Some("5 > 3 & \"quoted\""));
+    assert_eq!(parsed.elements[0].text(), "Tom & <Jerry>");
+}


### PR DESCRIPTION
## Completed Work

- Reviewed `xeps/xep-0049.xml` and kept `jabber:iq:private` behavior XMPP-native.
- Replaced stringly XEP-0049 arbitrary XML helper flow with typed `PrivateStorageValue` values backed by `minidom::Element`.
- Kept serialization at the persistence boundary via `PrivateStorageValue::to_xml_string()` and parsed stored XML back into typed values before building result IQs.
- Enforced private child payload shape: GET requires exactly one namespaced child; SET accepts one or more children only when they share one namespace.
- Stopped silently converting malformed stored XML into an empty element; corrupted persisted XML now fails closed as an IQ error.
- Added the XEP-0049 cross-user `to=` guard for private XML access.
- Added a dedicated Rust XEP-0049 conformance suite covering key parsing, nested payload preservation, missing/duplicate child handling, missing namespaces, malformed stored XML, absent-value result shape, same-namespace multi-child SET/result, and serializer-managed escaping.
- Expanded WebSocket integration coverage for private XML roundtrip, missing/duplicate GET errors, foreign `to=`, and malformed persisted XML.

## Plan

- Compare the current helper and handler behavior against `xeps/xep-0049.xml`, especially one-child GET semantics, arbitrary XML payload preservation, and error behavior. Done.
- Replace stringly arbitrary-XML flow in the XEP-0049 helper boundary with typed `minidom::Element` values, keeping serialization/parsing at the storage persistence edge only. Done.
- Make malformed stored XML fail closed instead of silently returning an empty payload. Done.
- Add or repair a dedicated Rust XEP-0049 test suite covering GET key parsing, SET nested payload preservation, missing/duplicate child handling, malformed stored XML, absent-value responses, and serializer-managed escaping. Done.
- Validate with focused Rust tests and broader relevant gates, run adversarial review, update this PR, mark ready, and monitor CI to green. Done.

## Validation

Local:
- `cargo fmt`
- `cargo test -p waddle-xmpp --test xep0049_private_xml_storage`
- `cargo test -p waddle-xmpp xep0049`
- `cargo test -p waddle-server --test xep0054_0049_0191_ws private_xml -- --test-threads=1`
- `cargo clippy -p waddle-xmpp -p waddle-server --tests -- -D warnings`

CI:
- All PR checks passed, including `nixTest`, `nixClippy`, `nixXmppUnitTests`, `nixXmppXepIntegration`, and `nixXmppServerTests`.

## Review

- Adversarial XEP conformance, typed-boundary/XML-safety, and test/regression reviewers ran.
- Issues found and fixed: missing namespace validation, raw XML in new WebSocket test stanzas, stored XML no-panic handling, and the public `PrivateStorageValue::from_element` panic path.
- Final reviewer pass found no real actionable issues.