### PR TITLE
fix(server): return typed xep-0363 upload errors

### DIFF
--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/archive_inbox_upload.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/archive_inbox_upload.rs
@@ -230,7 +230,7 @@ pub(super) async fn handle_archive_inbox_upload_iq(
             let request = match parse_upload_request(request_iq) {
                 Ok(req) => req,
                 Err(e) => {
-                    return vec![build_upload_error(id, &e)];
+                    return vec![iq_to_xml(build_upload_error(request_iq, &e))];
                 }
             };
 
@@ -239,19 +239,19 @@ pub(super) async fn handle_archive_inbox_upload_iq(
             // so accepted XEP-0363 sizes are stored losslessly.
             let max_size = crate::server::routes::uploads::max_upload_size();
             if request.size > max_size {
-                return vec![build_upload_error(
-                    id,
+                return vec![iq_to_xml(build_upload_error(
+                    request_iq,
                     &UploadError::FileTooLarge { max_size },
-                )];
+                ))];
             }
             let Some(size_bytes) = crate::server::routes::uploads::upload_size_to_i64(request.size)
             else {
-                return vec![build_upload_error(
-                    id,
+                return vec![iq_to_xml(build_upload_error(
+                    request_iq,
                     &UploadError::FileTooLarge {
                         max_size: crate::server::routes::uploads::MAX_DATABASE_UPLOAD_SIZE,
                     },
-                )];
+                ))];
             };
 
             let safe_filename = sanitize_filename(&request.filename);
@@ -285,10 +285,10 @@ pub(super) async fn handle_archive_inbox_upload_iq(
                 .await
             {
                 warn!(error = %e, "Failed to create upload slot in database");
-                return vec![build_upload_error(
-                    id,
-                    &UploadError::InternalError(format!("Database error: {}", e)),
-                )];
+                return vec![iq_to_xml(build_upload_error(
+                    request_iq,
+                    &UploadError::InternalError,
+                ))];
             }
 
             debug!(

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
@@ -3387,6 +3387,96 @@ async fn upload_slot_request_requires_ready_phase() {
 }
 
 #[tokio::test]
+async fn upload_slot_too_large_error_is_typed_xep0363_iq() {
+    let state = create_test_websocket_state().await;
+    let session = create_test_session(state.as_ref(), "alice").await;
+    let bound_jid: FullJid = "alice@example.com/web".parse().expect("bound jid");
+    let ready = ready_phase(&bound_jid);
+    let max_size = crate::server::routes::uploads::max_upload_size();
+    let too_large = max_size
+        .checked_add(1)
+        .expect("test max upload size leaves room for an over-limit request");
+    let request = Element::builder("request", "urn:xmpp:http:upload:0")
+        .attr(
+            minidom::rxml::xml_ncname!("filename").to_owned(),
+            "huge.bin",
+        )
+        .attr(
+            minidom::rxml::xml_ncname!("size").to_owned(),
+            too_large.to_string(),
+        )
+        .attr(
+            minidom::rxml::xml_ncname!("content-type").to_owned(),
+            "application/octet-stream",
+        )
+        .build();
+    let frame = stanza_to_xml(&Stanza::Iq(Box::new(Iq::Get {
+        from: Some(bound_jid.clone().into()),
+        to: Some("upload.example.com".parse().expect("upload jid")),
+        id: "upload-too-big-1".to_string(),
+        payload: request,
+    })));
+
+    let responses = handle_iq(
+        &frame,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(session),
+        &ready,
+    )
+    .await;
+
+    assert_eq!(responses.len(), 1, "expected one response: {responses:?}");
+    let iq = parse_iq_for_test(&responses[0]);
+    let Iq::Error {
+        from,
+        to,
+        id,
+        error,
+        payload,
+    } = iq
+    else {
+        panic!("expected upload too-large IQ error: {}", responses[0]);
+    };
+
+    assert_eq!(id, "upload-too-big-1");
+    assert_eq!(
+        from.as_ref().map(ToString::to_string).as_deref(),
+        Some("upload.example.com")
+    );
+    assert_eq!(
+        to.as_ref().map(ToString::to_string).as_deref(),
+        Some("alice@example.com/web")
+    );
+    assert_eq!(error.type_, xmpp_parsers::stanza_error::ErrorType::Modify);
+    assert_eq!(
+        error.defined_condition,
+        xmpp_parsers::stanza_error::DefinedCondition::NotAcceptable
+    );
+
+    let original_request = payload.expect("original upload request payload");
+    assert_eq!(original_request.name(), "request");
+    assert_eq!(original_request.ns(), "urn:xmpp:http:upload:0");
+    assert_eq!(original_request.attr("filename"), Some("huge.bin"));
+    assert_eq!(
+        original_request.attr("size"),
+        Some(too_large.to_string().as_str())
+    );
+
+    let app_error = error.other.expect("file-too-large app error");
+    assert_eq!(app_error.name(), "file-too-large");
+    assert_eq!(app_error.ns(), "urn:xmpp:http:upload:0");
+    assert_eq!(
+        app_error
+            .get_child("max-file-size", "urn:xmpp:http:upload:0")
+            .expect("max-file-size")
+            .text(),
+        max_size.to_string()
+    );
+}
+
+#[tokio::test]
 async fn handle_iq_pubsub_publish_returns_result() {
     let state = create_test_websocket_state().await;
     let jid: FullJid = "alice@example.com/web".parse().expect("valid jid");

--- a/server/crates/waddle-xmpp/src/xep/exports.rs
+++ b/server/crates/waddle-xmpp/src/xep/exports.rs
@@ -46,8 +46,8 @@ pub use super::xep0249::{
 
 pub use super::xep0363::{
     build_upload_error, build_upload_slot_response, effective_content_type, is_upload_request,
-    parse_upload_request, sanitize_filename, UploadError, UploadRequest, UploadSlot,
-    DEFAULT_MAX_FILE_SIZE, NS_HTTP_UPLOAD,
+    parse_upload_request, sanitize_filename, UploadBadRequest, UploadError, UploadRequest,
+    UploadSlot, DEFAULT_MAX_FILE_SIZE, NS_HTTP_UPLOAD,
 };
 
 pub use super::xep0191::{

--- a/server/crates/waddle-xmpp/src/xep/xep0363.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0363.rs
@@ -55,9 +55,11 @@
 //! </iq>
 //! ```
 
+use chrono::{DateTime, SecondsFormat, Utc};
 use minidom::Element;
 use tracing::debug;
 use xmpp_parsers::iq::Iq;
+use xmpp_parsers::stanza_error::{DefinedCondition, ErrorType, StanzaError};
 
 /// Namespace for XEP-0363 HTTP File Upload.
 pub const NS_HTTP_UPLOAD: &str = "urn:xmpp:http:upload:0";
@@ -95,11 +97,22 @@ pub enum UploadError {
     /// User is not allowed to upload files.
     NotAllowed,
     /// User has exceeded their upload quota.
-    QuotaReached,
+    QuotaReached { retry_at: DateTime<Utc> },
     /// Bad request (missing or invalid attributes).
-    BadRequest(String),
+    BadRequest(UploadBadRequest),
     /// Internal server error.
-    InternalError(String),
+    InternalError,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UploadBadRequest {
+    MissingRequestElement,
+    ExpectedIqGet,
+    MissingFilename,
+    EmptyFilename,
+    MissingSize,
+    InvalidSize,
+    ZeroSize,
 }
 
 impl std::fmt::Display for UploadError {
@@ -109,14 +122,28 @@ impl std::fmt::Display for UploadError {
                 write!(f, "File too large. Maximum size is {} bytes.", max_size)
             }
             UploadError::NotAllowed => write!(f, "Not allowed to upload files"),
-            UploadError::QuotaReached => write!(f, "Upload quota exceeded"),
-            UploadError::BadRequest(msg) => write!(f, "Bad request: {}", msg),
-            UploadError::InternalError(msg) => write!(f, "Internal error: {}", msg),
+            UploadError::QuotaReached { .. } => write!(f, "Upload quota exceeded"),
+            UploadError::BadRequest(error) => write!(f, "Bad request: {}", error),
+            UploadError::InternalError => write!(f, "Internal server error"),
         }
     }
 }
 
 impl std::error::Error for UploadError {}
+
+impl std::fmt::Display for UploadBadRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UploadBadRequest::MissingRequestElement => write!(f, "missing upload request element"),
+            UploadBadRequest::ExpectedIqGet => write!(f, "expected IQ get for upload request"),
+            UploadBadRequest::MissingFilename => write!(f, "missing filename attribute"),
+            UploadBadRequest::EmptyFilename => write!(f, "filename cannot be empty"),
+            UploadBadRequest::MissingSize => write!(f, "missing size attribute"),
+            UploadBadRequest::InvalidSize => write!(f, "invalid size attribute"),
+            UploadBadRequest::ZeroSize => write!(f, "file size cannot be zero"),
+        }
+    }
+}
 
 /// Check if an IQ stanza is an HTTP upload slot request (XEP-0363).
 pub fn is_upload_request(iq: &Iq) -> bool {
@@ -138,42 +165,34 @@ pub fn parse_upload_request(iq: &Iq) -> Result<UploadRequest, UploadError> {
                 elem
             } else {
                 return Err(UploadError::BadRequest(
-                    "Missing upload request element".to_string(),
+                    UploadBadRequest::MissingRequestElement,
                 ));
             }
         }
-        _ => {
-            return Err(UploadError::BadRequest(
-                "Expected IQ get for upload request".to_string(),
-            ))
-        }
+        _ => return Err(UploadError::BadRequest(UploadBadRequest::ExpectedIqGet)),
     };
 
     // Parse required 'filename' attribute
     let filename = elem
         .attr("filename")
-        .ok_or_else(|| UploadError::BadRequest("Missing 'filename' attribute".to_string()))?
+        .ok_or(UploadError::BadRequest(UploadBadRequest::MissingFilename))?
         .to_string();
 
     if filename.is_empty() {
-        return Err(UploadError::BadRequest(
-            "Filename cannot be empty".to_string(),
-        ));
+        return Err(UploadError::BadRequest(UploadBadRequest::EmptyFilename));
     }
 
     // Parse required 'size' attribute
     let size_str = elem
         .attr("size")
-        .ok_or_else(|| UploadError::BadRequest("Missing 'size' attribute".to_string()))?;
+        .ok_or(UploadError::BadRequest(UploadBadRequest::MissingSize))?;
 
     let size: u64 = size_str
         .parse()
-        .map_err(|_| UploadError::BadRequest(format!("Invalid 'size' attribute: {}", size_str)))?;
+        .map_err(|_| UploadError::BadRequest(UploadBadRequest::InvalidSize))?;
 
     if size == 0 {
-        return Err(UploadError::BadRequest(
-            "File size cannot be zero".to_string(),
-        ));
+        return Err(UploadError::BadRequest(UploadBadRequest::ZeroSize));
     }
 
     // Parse optional 'content-type' attribute
@@ -233,62 +252,53 @@ pub fn build_upload_slot_response(original_iq: &Iq, slot: &UploadSlot) -> Iq {
 /// Returns an IQ error with the appropriate XMPP error condition
 /// and XEP-0363-specific app-error elements per §"Error
 /// conditions": `<file-too-large><max-file-size>` for
-/// FileTooLarge, `<retry/>` for QuotaReached.
-///
-/// The result is the serialised XML string ready to write to the
-/// wire — the typed `minidom::Element` is built first and
-/// serialised exactly once at the I/O boundary, satisfying the
-/// project's XML-via-builder hard rule.
-pub fn build_upload_error(request_id: &str, error: &UploadError) -> String {
-    const NS_XMPP_STANZAS: &str = "urn:ietf:params:xml:ns:xmpp-stanzas";
-
-    let (error_type, condition) = match error {
-        UploadError::FileTooLarge { .. } => ("modify", "not-acceptable"),
-        UploadError::NotAllowed => ("auth", "forbidden"),
-        UploadError::QuotaReached => ("wait", "resource-constraint"),
-        UploadError::BadRequest(_) => ("modify", "bad-request"),
-        UploadError::InternalError(_) => ("wait", "internal-server-error"),
+/// FileTooLarge, `<retry stamp='...'/>` for QuotaReached.
+pub fn build_upload_error(original_iq: &Iq, error: &UploadError) -> Iq {
+    let (error_type, defined_condition) = match error {
+        UploadError::FileTooLarge { .. } => (ErrorType::Modify, DefinedCondition::NotAcceptable),
+        UploadError::NotAllowed => (ErrorType::Auth, DefinedCondition::Forbidden),
+        UploadError::QuotaReached { .. } => (ErrorType::Wait, DefinedCondition::ResourceConstraint),
+        UploadError::BadRequest(_) => (ErrorType::Modify, DefinedCondition::BadRequest),
+        UploadError::InternalError => (ErrorType::Wait, DefinedCondition::InternalServerError),
     };
 
-    let mut err_builder = Element::builder("error", "jabber:client")
-        .attr(minidom::rxml::xml_ncname!("type").to_owned(), error_type)
-        .append(Element::builder(condition, NS_XMPP_STANZAS).build())
-        .append(
-            Element::builder("text", NS_XMPP_STANZAS)
-                .append(error.to_string().as_str())
+    let mut stanza_error = StanzaError::new(error_type, defined_condition, "en", error.to_string());
+
+    stanza_error.other = match error {
+        UploadError::FileTooLarge { max_size } => Some(
+            Element::builder("file-too-large", NS_HTTP_UPLOAD)
+                .append(
+                    Element::builder("max-file-size", NS_HTTP_UPLOAD)
+                        .append(max_size.to_string().as_str())
+                        .build(),
+                )
                 .build(),
-        );
-
-    // Append the XEP-0363 §"Error conditions" app-error child for
-    // the variants that have one — minidom's element builder
-    // namespace-qualifies the children so we don't have to
-    // string-template the `xmlns=` attribute.
-    match error {
-        UploadError::FileTooLarge { max_size } => {
-            err_builder = err_builder.append(
-                Element::builder("file-too-large", NS_HTTP_UPLOAD)
-                    .append(
-                        Element::builder("max-file-size", NS_HTTP_UPLOAD)
-                            .append(max_size.to_string().as_str())
-                            .build(),
-                    )
+        ),
+        UploadError::QuotaReached { retry_at } => {
+            let stamp = retry_at.to_rfc3339_opts(SecondsFormat::Secs, true);
+            Some(
+                Element::builder("retry", NS_HTTP_UPLOAD)
+                    .attr(minidom::rxml::xml_ncname!("stamp").to_owned(), stamp)
                     .build(),
-            );
+            )
         }
-        UploadError::QuotaReached => {
-            err_builder = err_builder.append(Element::builder("retry", NS_HTTP_UPLOAD).build());
-        }
-        _ => {}
+        _ => None,
+    };
+
+    Iq::Error {
+        from: original_iq.to().cloned(),
+        to: original_iq.from().cloned(),
+        id: original_iq.id().to_string(),
+        error: stanza_error,
+        payload: upload_error_payload(original_iq),
     }
+}
 
-    let iq = Element::builder("iq", "jabber:client")
-        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "error")
-        .attr(minidom::rxml::xml_ncname!("id").to_owned(), request_id)
-        .append(Element::builder("request", NS_HTTP_UPLOAD).build())
-        .append(err_builder.build())
-        .build();
-
-    String::from(&iq)
+fn upload_error_payload(original_iq: &Iq) -> Option<Element> {
+    match original_iq {
+        Iq::Get { payload, .. } | Iq::Set { payload, .. } => Some(payload.clone()),
+        Iq::Result { .. } | Iq::Error { .. } => None,
+    }
 }
 
 /// Sanitize filename for use in URLs and storage.

--- a/server/crates/waddle-xmpp/src/xep/xep0363/tests.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0363/tests.rs
@@ -1,4 +1,26 @@
 use super::*;
+use xmpp_parsers::stanza_error::{DefinedCondition, ErrorType};
+
+fn upload_request_iq(id: &str, filename: &str, size: u64) -> Iq {
+    Iq::Get {
+        from: None,
+        to: None,
+        id: id.to_string(),
+        payload: Element::builder("request", NS_HTTP_UPLOAD)
+            .attr(minidom::rxml::xml_ncname!("filename").to_owned(), filename)
+            .attr(
+                minidom::rxml::xml_ncname!("size").to_owned(),
+                size.to_string(),
+            )
+            .build(),
+    }
+}
+
+fn fixed_retry_at() -> chrono::DateTime<chrono::Utc> {
+    chrono::DateTime::parse_from_rfc3339("2026-05-31T12:34:56Z")
+        .expect("fixed retry timestamp")
+        .with_timezone(&chrono::Utc)
+}
 
 #[test]
 fn test_is_upload_request() {
@@ -289,35 +311,73 @@ fn test_build_upload_slot_response_no_headers() {
 
 #[test]
 fn test_build_upload_error_file_too_large() {
-    // The builder now produces XML via minidom, so the serialised
-    // attribute quotes are double-quoted (XML semantics are
-    // identical to single-quoted; the literal differs).
+    let request = upload_request_iq("error-1", "large.jpg", 20_000_000);
     let error_response =
-        build_upload_error("error-1", &UploadError::FileTooLarge { max_size: 10485760 });
+        build_upload_error(&request, &UploadError::FileTooLarge { max_size: 10485760 });
 
-    assert!(error_response.contains("type='error'"));
-    assert!(error_response.contains("id='error-1'"));
-    assert!(error_response.contains("<not-acceptable"));
-    assert!(error_response.contains("<file-too-large"));
-    assert!(error_response.contains("<max-file-size>10485760</max-file-size>"));
+    let Iq::Error {
+        id, error, payload, ..
+    } = error_response
+    else {
+        panic!("Expected upload error IQ");
+    };
+    assert_eq!(id, "error-1");
+    assert_eq!(error.type_, ErrorType::Modify);
+    assert_eq!(error.defined_condition, DefinedCondition::NotAcceptable);
+    let app_error = error.other.expect("file-too-large app error");
+    assert_eq!(app_error.name(), "file-too-large");
+    assert_eq!(app_error.ns(), NS_HTTP_UPLOAD);
+    assert_eq!(
+        app_error
+            .get_child("max-file-size", NS_HTTP_UPLOAD)
+            .expect("max-file-size")
+            .text(),
+        "10485760"
+    );
+    assert_eq!(
+        payload.expect("original request").attr("filename"),
+        Some("large.jpg")
+    );
 }
 
 #[test]
 fn test_build_upload_error_not_allowed() {
-    let error_response = build_upload_error("error-2", &UploadError::NotAllowed);
+    let error_response = build_upload_error(
+        &upload_request_iq("error-2", "blocked.jpg", 100),
+        &UploadError::NotAllowed,
+    );
 
-    assert!(error_response.contains("type='error'"));
-    assert!(error_response.contains("id='error-2'"));
-    assert!(error_response.contains("<forbidden"));
+    let Iq::Error { id, error, .. } = error_response else {
+        panic!("Expected upload error IQ");
+    };
+    assert_eq!(id, "error-2");
+    assert_eq!(error.type_, ErrorType::Auth);
+    assert_eq!(error.defined_condition, DefinedCondition::Forbidden);
+    assert!(error.other.is_none());
 }
 
 #[test]
 fn test_build_upload_error_quota_reached() {
-    let error_response = build_upload_error("error-3", &UploadError::QuotaReached);
+    let error_response = build_upload_error(
+        &upload_request_iq("error-3", "quota.jpg", 100),
+        &UploadError::QuotaReached {
+            retry_at: fixed_retry_at(),
+        },
+    );
 
-    assert!(error_response.contains("type='error'"));
-    assert!(error_response.contains("<resource-constraint"));
-    assert!(error_response.contains("<retry"));
+    let Iq::Error { id, error, .. } = error_response else {
+        panic!("Expected upload error IQ");
+    };
+    assert_eq!(id, "error-3");
+    assert_eq!(error.type_, ErrorType::Wait);
+    assert_eq!(
+        error.defined_condition,
+        DefinedCondition::ResourceConstraint
+    );
+    let retry = error.other.expect("retry app error");
+    assert_eq!(retry.name(), "retry");
+    assert_eq!(retry.ns(), NS_HTTP_UPLOAD);
+    assert_eq!(retry.attr("stamp"), Some("2026-05-31T12:34:56Z"));
 }
 
 #[test]
@@ -331,16 +391,19 @@ fn test_upload_error_display() {
         "Not allowed to upload files"
     );
     assert_eq!(
-        UploadError::QuotaReached.to_string(),
+        UploadError::QuotaReached {
+            retry_at: fixed_retry_at(),
+        }
+        .to_string(),
         "Upload quota exceeded"
     );
     assert_eq!(
-        UploadError::BadRequest("test".to_string()).to_string(),
-        "Bad request: test"
+        UploadError::BadRequest(UploadBadRequest::MissingSize).to_string(),
+        "Bad request: missing size attribute"
     );
     assert_eq!(
-        UploadError::InternalError("err".to_string()).to_string(),
-        "Internal error: err"
+        UploadError::InternalError.to_string(),
+        "Internal server error"
     );
 }
 

--- a/server/crates/waddle-xmpp/tests/xep0363_http_upload.rs
+++ b/server/crates/waddle-xmpp/tests/xep0363_http_upload.rs
@@ -10,17 +10,20 @@
 //! - §3.2 slot response shape: `<slot><put url=…/><get url=…/></slot>`
 //!   plus optional `<header>` children on `<put>`,
 //! - §3.3 error responses: `<not-acceptable/>` + `<file-too-large>`
-//!   for FileTooLarge, `<resource-constraint/>` + `<retry/>` for
-//!   QuotaReached, `<forbidden/>` for NotAllowed.
+//!   for FileTooLarge, `<resource-constraint/>` + `<retry stamp='…'/>`
+//!   for QuotaReached, `<forbidden/>` for NotAllowed.
 
+use chrono::{DateTime, FixedOffset};
 use minidom::Element;
+use std::str::FromStr;
 use waddle_xmpp::disco::{server_features, upload_service_features, Feature};
 use waddle_xmpp::xep::xep0363::{
     build_upload_error, build_upload_slot_response, effective_content_type, is_upload_request,
-    parse_upload_request, sanitize_filename, UploadError, UploadRequest, UploadSlot,
-    DEFAULT_MAX_FILE_SIZE, NS_HTTP_UPLOAD,
+    parse_upload_request, sanitize_filename, UploadBadRequest, UploadError, UploadRequest,
+    UploadSlot, DEFAULT_MAX_FILE_SIZE, NS_HTTP_UPLOAD,
 };
 use xmpp_parsers::iq::Iq;
+use xmpp_parsers::stanza_error::{DefinedCondition, ErrorType, StanzaError};
 
 // ── §3 namespace ─────────────────────────────────────────────────────
 
@@ -220,6 +223,40 @@ fn xep0363_slot_response_emits_put_get_and_optional_headers() {
 
 // ── §3.3 error-response shapes ──────────────────────────────────────
 
+fn assert_upload_error_iq(
+    iq: Iq,
+    expected_type: ErrorType,
+    expected_condition: DefinedCondition,
+    expected_id: &str,
+) -> (StanzaError, Element) {
+    let Iq::Error {
+        id, error, payload, ..
+    } = iq
+    else {
+        panic!("expected upload error IQ");
+    };
+
+    assert_eq!(id, expected_id);
+    assert_eq!(error.type_, expected_type);
+    assert_eq!(error.defined_condition, expected_condition);
+
+    let payload = payload.expect("error IQ carries original request payload");
+    assert_eq!(payload.name(), "request");
+    assert_eq!(payload.ns(), NS_HTTP_UPLOAD);
+    (error, payload)
+}
+
+fn fixed_retry_at() -> chrono::DateTime<chrono::Utc> {
+    DateTime::parse_from_rfc3339("2026-05-31T12:34:56Z")
+        .expect("fixed retry timestamp")
+        .with_timezone(&chrono::Utc)
+}
+
+fn serialized_iq_element(iq: Iq) -> Element {
+    let serialized = String::from(&waddle_xmpp::Stanza::Iq(Box::new(iq)).to_element());
+    serialized.parse::<Element>().expect("well-formed XML")
+}
+
 #[test]
 fn xep0363_file_too_large_error_carries_max_file_size_child() {
     // §3.3 FileTooLarge: `<not-acceptable/>` plus a
@@ -227,71 +264,200 @@ fn xep0363_file_too_large_error_carries_max_file_size_child() {
     //   <max-file-size>BYTES</max-file-size>
     // </file-too-large>` app-error child so the client knows the
     // server-enforced limit.
-    let xml = build_upload_error(
-        "err-too-big",
-        &UploadError::FileTooLarge {
-            max_size: 10_485_760,
-        },
+    let request_iq = upload_request_iq("too-big.jpg", 20_000_000, Some("image/jpeg"));
+    let (error, payload) = assert_upload_error_iq(
+        build_upload_error(
+            &request_iq,
+            &UploadError::FileTooLarge {
+                max_size: 10_485_760,
+            },
+        ),
+        ErrorType::Modify,
+        DefinedCondition::NotAcceptable,
+        "u-1",
     );
 
-    assert!(xml.contains("<not-acceptable"));
-    assert!(xml.contains("<file-too-large"));
-    assert!(xml.contains(NS_HTTP_UPLOAD));
-    assert!(xml.contains("<max-file-size>10485760</max-file-size>"));
-    assert!(xml.contains("id='err-too-big'"));
+    assert_eq!(payload.attr("filename"), Some("too-big.jpg"));
+    assert_eq!(payload.attr("size"), Some("20000000"));
+    assert_eq!(payload.attr("content-type"), Some("image/jpeg"));
+
+    let app_error = error.other.expect("file-too-large app error");
+    assert_eq!(app_error.name(), "file-too-large");
+    assert_eq!(app_error.ns(), NS_HTTP_UPLOAD);
+    let max_file_size = app_error
+        .get_child("max-file-size", NS_HTTP_UPLOAD)
+        .expect("max-file-size child");
+    assert_eq!(max_file_size.text(), "10485760");
+    assert_eq!(
+        app_error
+            .children()
+            .filter(|child| child.name() == "max-file-size" && child.ns() == NS_HTTP_UPLOAD)
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn xep0363_upload_error_swaps_request_addresses() {
+    let request_iq = Iq::Get {
+        from: Some(jid::Jid::from_str("romeo@example.test/garden").expect("from JID")),
+        to: Some(jid::Jid::from_str("upload.example.test").expect("to JID")),
+        id: "addr-1".into(),
+        payload: Element::builder("request", NS_HTTP_UPLOAD)
+            .attr(minidom::rxml::xml_ncname!("filename").to_owned(), "a.jpg")
+            .attr(minidom::rxml::xml_ncname!("size").to_owned(), "100")
+            .build(),
+    };
+
+    let Iq::Error { from, to, id, .. } = build_upload_error(&request_iq, &UploadError::NotAllowed)
+    else {
+        panic!("expected upload error IQ");
+    };
+
+    assert_eq!(id, "addr-1");
+    assert_eq!(
+        from.as_ref().map(ToString::to_string).as_deref(),
+        Some("upload.example.test")
+    );
+    assert_eq!(
+        to.as_ref().map(ToString::to_string).as_deref(),
+        Some("romeo@example.test/garden")
+    );
 }
 
 #[test]
 fn xep0363_quota_reached_error_carries_retry_child() {
     // §3.3 QuotaReached: `<resource-constraint/>` plus
-    // `<retry xmlns='urn:xmpp:http:upload:0'/>` so the client
-    // knows the failure is transient and a retry will eventually
-    // succeed.
-    let xml = build_upload_error("err-quota", &UploadError::QuotaReached);
-    assert!(xml.contains("<resource-constraint"));
-    assert!(xml.contains("<retry"));
-    assert!(xml.contains(NS_HTTP_UPLOAD));
+    // `<retry xmlns='urn:xmpp:http:upload:0' stamp='...'/>` so
+    // the client knows the failure is transient and when it may try
+    // again.
+    let (error, _) = assert_upload_error_iq(
+        build_upload_error(
+            &upload_request_iq("quota.jpg", 100, None),
+            &UploadError::QuotaReached {
+                retry_at: fixed_retry_at(),
+            },
+        ),
+        ErrorType::Wait,
+        DefinedCondition::ResourceConstraint,
+        "u-1",
+    );
+    let retry = error.other.expect("retry app error");
+    assert_eq!(retry.name(), "retry");
+    assert_eq!(retry.ns(), NS_HTTP_UPLOAD);
+    let stamp = retry.attr("stamp").expect("retry stamp");
+    assert_eq!(stamp, "2026-05-31T12:34:56Z");
+    assert!(stamp.ends_with('Z'), "retry stamp must be UTC: {stamp}");
+    let parsed: DateTime<FixedOffset> =
+        DateTime::parse_from_rfc3339(stamp).expect("retry stamp is XEP-0082/RFC3339 date-time");
+    assert_eq!(parsed.offset().local_minus_utc(), 0);
+}
+
+#[test]
+fn xep0363_file_too_large_app_error_survives_serialization() {
+    let parsed = serialized_iq_element(build_upload_error(
+        &upload_request_iq("serialise<&>.jpg", 20_000_000, None),
+        &UploadError::FileTooLarge {
+            max_size: 10_485_760,
+        },
+    ));
+    let error = parsed
+        .get_child("error", "jabber:client")
+        .expect("error child");
+    let app_error = error
+        .get_child("file-too-large", NS_HTTP_UPLOAD)
+        .expect("serialized file-too-large app error");
+    assert_eq!(
+        app_error
+            .get_child("max-file-size", NS_HTTP_UPLOAD)
+            .expect("serialized max-file-size")
+            .text(),
+        "10485760"
+    );
+    let request = parsed
+        .get_child("request", NS_HTTP_UPLOAD)
+        .expect("serialized original request");
+    assert_eq!(request.attr("filename"), Some("serialise<&>.jpg"));
+}
+
+#[test]
+fn xep0363_quota_retry_app_error_survives_serialization() {
+    let parsed = serialized_iq_element(build_upload_error(
+        &upload_request_iq("quota.jpg", 100, None),
+        &UploadError::QuotaReached {
+            retry_at: fixed_retry_at(),
+        },
+    ));
+    let error = parsed
+        .get_child("error", "jabber:client")
+        .expect("error child");
+    let retry = error
+        .get_child("retry", NS_HTTP_UPLOAD)
+        .expect("serialized retry app error");
+    assert_eq!(retry.attr("stamp"), Some("2026-05-31T12:34:56Z"));
 }
 
 #[test]
 fn xep0363_not_allowed_error_uses_forbidden_condition() {
     // §3.3 NotAllowed: `<forbidden/>` with no app-error child —
     // there's nothing extra the client can do to recover.
-    let xml = build_upload_error("err-forbidden", &UploadError::NotAllowed);
-    assert!(xml.contains("<forbidden"));
-    assert!(
-        !xml.contains("<retry") && !xml.contains("<file-too-large"),
-        "NotAllowed MUST NOT carry app-error children (would imply recovery)"
+    let (error, _) = assert_upload_error_iq(
+        build_upload_error(
+            &upload_request_iq("blocked.jpg", 100, None),
+            &UploadError::NotAllowed,
+        ),
+        ErrorType::Auth,
+        DefinedCondition::Forbidden,
+        "u-1",
     );
+    assert!(error.other.is_none());
 }
 
 #[test]
 fn xep0363_bad_request_and_internal_error_use_xmpp_stanza_conditions() {
-    let bad = build_upload_error("err-bad", &UploadError::BadRequest("nope".into()));
-    assert!(bad.contains("<bad-request"));
+    let (bad, _) = assert_upload_error_iq(
+        build_upload_error(
+            &upload_request_iq("bad.jpg", 100, None),
+            &UploadError::BadRequest(UploadBadRequest::InvalidSize),
+        ),
+        ErrorType::Modify,
+        DefinedCondition::BadRequest,
+        "u-1",
+    );
+    assert!(bad.other.is_none());
 
-    let internal = build_upload_error("err-internal", &UploadError::InternalError("crash".into()));
-    assert!(internal.contains("<internal-server-error"));
+    let (internal, _) = assert_upload_error_iq(
+        build_upload_error(
+            &upload_request_iq("internal.jpg", 100, None),
+            &UploadError::InternalError,
+        ),
+        ErrorType::Wait,
+        DefinedCondition::InternalServerError,
+        "u-1",
+    );
+    assert!(internal.other.is_none());
 }
 
 #[test]
-fn xep0363_error_xml_is_well_formed_minidom_serialisation() {
-    // The error builder must produce parseable XML — round-trip
-    // through minidom proves there's no manual-format!
-    // string-concat lurking that could emit broken markup.
-    for variant in [
-        UploadError::FileTooLarge { max_size: 1024 },
-        UploadError::NotAllowed,
-        UploadError::QuotaReached,
-        UploadError::BadRequest("nope".into()),
-        UploadError::InternalError("boom".into()),
-    ] {
-        let xml = build_upload_error("err", &variant);
-        let parsed = xml.parse::<Element>().expect("well-formed XML");
-        assert_eq!(parsed.name(), "iq");
-        assert_eq!(parsed.attr("type"), Some("error"));
-        assert_eq!(parsed.attr("id"), Some("err"));
-    }
+fn xep0363_error_serialization_escapes_text_and_stays_well_formed() {
+    let parsed = serialized_iq_element(build_upload_error(
+        &upload_request_iq("bad <name> & \"type\".jpg", 100, None),
+        &UploadError::BadRequest(UploadBadRequest::InvalidSize),
+    ));
+
+    assert_eq!(parsed.name(), "iq");
+    assert_eq!(parsed.attr("type"), Some("error"));
+    let error = parsed
+        .get_child("error", "jabber:client")
+        .expect("error child");
+    let text = error
+        .get_child("text", "urn:ietf:params:xml:ns:xmpp-stanzas")
+        .expect("error text");
+    assert_eq!(text.text(), "Bad request: invalid size attribute");
+    let request = parsed
+        .get_child("request", NS_HTTP_UPLOAD)
+        .expect("original request");
+    assert_eq!(request.attr("filename"), Some("bad <name> & \"type\".jpg"));
 }
 
 // ── Filename sanitisation + content-type defaults ───────────────────


### PR DESCRIPTION
## Summary

- Compared the upload error flow against `xeps/xep-0363.xml`.
- Changed the XEP-0363 upload error builder to return a typed `xmpp_parsers::iq::Iq` error stanza instead of serialized XML.
- Moved upload error serialization to the websocket boundary where the stanza is written back to the client.
- Preserved the original request payload and addressed error IQs from the upload service back to the requester.
- Replaced stringly upload diagnostics with typed `UploadBadRequest` values and avoided leaking internal backend details into protocol payloads.
- Expanded XEP-0363 tests from substring checks to typed stanza/error/app-error assertions plus serializer-managed escaping and round-trip coverage.
- Added server handler coverage for a ready-phase over-size upload request returning the typed XEP-0363 error IQ.

## Plan

- Compare the current XEP-0363 upload error behavior against `xeps/xep-0363.xml`.
- Change the XEP-0363 upload error builder to return typed XMPP/XML values instead of serialized XML strings.
- Move serialization to the websocket/I/O edge with the smallest necessary call-site adjustment.
- Replace substring-focused upload error tests with typed structure assertions and serializer/well-formedness coverage where needed.
- Validate with focused Rust tests for `waddle-xmpp` XEP-0363 behavior and affected server upload handlers, plus clippy with `-D warnings`.
- Rebase onto current `origin/main` after PR #819 and rerun focused validation.

## XEP-0363 Conformance Notes

- `file-too-large` returns `modify` / `not-acceptable` and carries `<file-too-large><max-file-size>`.
- quota exhaustion returns `wait` / `resource-constraint` and carries `<retry stamp='...'/>`.
- malformed upload requests return `modify` / `bad-request`.
- forbidden uploads return `auth` / `forbidden`.
- internal upload failures return `wait` / `internal-server-error` without exposing backend diagnostics.

## Validation

- `cargo test --manifest-path server/crates/waddle-xmpp/Cargo.toml xep0363`
- `cargo test --manifest-path server/crates/waddle-server/Cargo.toml upload_slot`
- `cargo clippy --manifest-path server/crates/waddle-xmpp/Cargo.toml --all-targets -- -D warnings`
- `cargo clippy --manifest-path server/crates/waddle-server/Cargo.toml --all-targets -- -D warnings`
- `git diff --check origin/main...HEAD`

## Review

- Ran adversarial protocol, typed-boundary, and Rust/test adequacy reviews.
- Follow-up review pass found no remaining actionable issues in the typed XEP-0363 upload error scope.

## Scope Boundary

- Existing successful slot response behavior is intentionally unchanged.
