### PR TITLE
debug(chat): observe-only telemetry for background-tab RESULT_CODE_HUNG

### DIFF
--- a/chat/src/lib/telemetry.ts
+++ b/chat/src/lib/telemetry.ts
@@ -233,8 +233,7 @@ export function reportMessageAcked(payload: {
   faro.api.pushMeasurement({
     type: "chat.xmpp.message.acked.latency_ms",
     values: { latency_ms: payload.latencyMs },
-    context: { kind: payload.kind },
-  });
+  }, { context: { kind: payload.kind } });
 }
 
 export function reportSendEnqueued(payload: {
@@ -289,11 +288,12 @@ export function reportStatusChange(payload: {
 //
 // Observe-only signals for the background-tab `RESULT_CODE_HUNG`
 // investigation (`docs/planning/hung-tab-investigation.md`). Every
-// signal is tagged with the page's `visibilityState` and how long it
-// has been hidden, so the backend can show what happens **in the
-// background** — escalating long tasks (synchronous-burst hang),
-// reconnect flapping, or unbounded heap growth (leak / GC death-spiral)
-// while `hidden` each name a different root cause. No behavior change.
+// signal is tagged with the page's `visibilityState` and a coarse
+// hidden-duration bucket, with exact hidden milliseconds as a numeric
+// measurement value. That lets the backend show what happens **in the
+// background** — escalating long tasks (synchronous-burst hang), reconnect
+// flapping, or unbounded heap growth (leak / GC death-spiral) while
+// `hidden` each name a different root cause. No behavior change.
 
 /** Sampling cadence for the JS heap. Background timers are clamped to
  * ≥1 min, so a 60 s base interval is the finest useful resolution while
@@ -307,11 +307,33 @@ let hiddenSinceMs: number | null =
   visibility === "hidden" && typeof performance !== "undefined" ? performance.now() : null;
 
 /** Common tags so every health signal can be sliced by foreground vs
- * background and by how deep into a background idle it occurred. */
-function visibilityTags(): { visibility: string; ms_hidden: string } {
+ * background without creating one metric series per millisecond hidden. */
+function visibilityTags(): { visibility: string; hidden_bucket: string } {
+  return { visibility, hidden_bucket: hiddenBucket(hiddenDurationMs()) };
+}
+
+function hiddenDurationMs(): number {
+  if (hiddenSinceMs === null) return 0;
+  if (typeof performance === "undefined") return 0;
+  return Math.max(0, Math.round(performance.now() - hiddenSinceMs));
+}
+
+function hiddenBucket(msHidden: number): string {
+  if (msHidden === 0) return "visible";
+  if (msHidden < 60_000) return "lt_1m";
+  if (msHidden < 5 * 60_000) return "1m_5m";
+  if (msHidden < 15 * 60_000) return "5m_15m";
+  if (msHidden < 60 * 60_000) return "15m_1h";
+  return "gt_1h";
+}
+
+function visibilityMetric(): {
+  context: { visibility: string; hidden_bucket: string };
+  hiddenMs: number;
+} {
   const msHidden =
-    hiddenSinceMs === null ? 0 : Math.round(performance.now() - hiddenSinceMs);
-  return { visibility, ms_hidden: String(msHidden) };
+    hiddenDurationMs();
+  return { context: { visibility, hidden_bucket: hiddenBucket(msHidden) }, hiddenMs: msHidden };
 }
 
 function reportVisibility(): void {
@@ -319,11 +341,11 @@ function reportVisibility(): void {
 }
 
 function reportLongTask(durationMs: number): void {
+  const metric = visibilityMetric();
   faro?.api.pushMeasurement({
     type: "chat.client.longtask.duration_ms",
-    values: { duration_ms: Math.round(durationMs) },
-    context: visibilityTags(),
-  });
+    values: { duration_ms: Math.round(durationMs), hidden_ms: metric.hiddenMs },
+  }, { context: metric.context });
 }
 
 interface ChromeMemory {
@@ -336,23 +358,25 @@ function sampleHeap(): void {
   if (!faro || typeof performance === "undefined") return;
   const mem = (performance as Performance & { memory?: ChromeMemory }).memory;
   if (!mem) return; // Chrome-only API; absent elsewhere
+  const metric = visibilityMetric();
   faro.api.pushMeasurement({
     type: "chat.client.heap",
     values: {
       used_mb: Math.round(mem.usedJSHeapSize / 1_048_576),
       total_mb: Math.round(mem.totalJSHeapSize / 1_048_576),
       limit_mb: Math.round(mem.jsHeapSizeLimit / 1_048_576),
+      hidden_ms: metric.hiddenMs,
     },
-    context: visibilityTags(),
-  });
+  }, { context: metric.context });
 }
 
-/** Background-flapping detector: one event + counter per scheduled
- * reconnect, tagged with visibility/ms-hidden. A burst while `hidden`
+/** Background-flapping detector: one event + one count per scheduled
+ * reconnect, tagged with visibility/hidden bucket. A burst while `hidden`
  * points at keepalive-throttling → server idle timeout → reconnect loops. */
 export function reportReconnectScheduled(payload: { attempt: number; delayMs: number }): void {
   if (!faro) return;
   const tags = visibilityTags();
+  const metric = visibilityMetric();
   faro.api.pushEvent("chat.xmpp.reconnect.scheduled", {
     attempt: String(payload.attempt),
     delay_ms: String(Math.round(payload.delayMs)),
@@ -360,9 +384,13 @@ export function reportReconnectScheduled(payload: { attempt: number; delayMs: nu
   });
   faro.api.pushMeasurement({
     type: "chat.xmpp.reconnect.attempt",
-    values: { attempt: payload.attempt },
-    context: tags,
-  });
+    values: {
+      count: 1,
+      attempt: payload.attempt,
+      delay_ms: Math.round(payload.delayMs),
+      hidden_ms: metric.hiddenMs,
+    },
+  }, { context: metric.context });
 }
 
 /** Catch-up cost: how much work a single reconnect catch-up did. Large
@@ -372,27 +400,31 @@ export function reportCatchup(payload: {
   pages: number;
   messages: number;
   durationMs: number;
+  processedConversations?: number;
+  outcome?: "completed" | "aborted" | "failed";
 }): void {
+  const metric = visibilityMetric();
   faro?.api.pushMeasurement({
     type: "chat.xmpp.catchup",
     values: {
       conversations: payload.conversations,
+      processed_conversations: payload.processedConversations ?? payload.conversations,
       pages: payload.pages,
       messages: payload.messages,
       duration_ms: Math.round(payload.durationMs),
+      hidden_ms: metric.hiddenMs,
     },
-    context: visibilityTags(),
-  });
+  }, { context: { ...metric.context, outcome: payload.outcome ?? "completed" } });
 }
 
 /** Resume live-buffer drain: how many buffered messages were applied
  * synchronously on session-ready, and how long that one task took. */
 export function reportResumeDrain(payload: { buffered: number; durationMs: number }): void {
+  const metric = visibilityMetric();
   faro?.api.pushMeasurement({
     type: "chat.xmpp.resume_drain",
-    values: { buffered: payload.buffered, duration_ms: Math.round(payload.durationMs) },
-    context: visibilityTags(),
-  });
+    values: { buffered: payload.buffered, duration_ms: Math.round(payload.durationMs), hidden_ms: metric.hiddenMs },
+  }, { context: metric.context });
 }
 
 /**

--- a/chat/src/lib/telemetry.ts
+++ b/chat/src/lib/telemetry.ts
@@ -117,6 +117,7 @@ export function initTelemetry(options: InitTelemetryOptions): void {
     console.error("Faro initialization failed", err);
     faro = null;
   }
+  installClientHealthTelemetry();
 }
 
 /**
@@ -282,4 +283,159 @@ export function reportStatusChange(payload: {
       values: { duration_ms: payload.reconnectDurationMs },
     });
   }
+}
+
+// ── Client-health telemetry ─────────────────────────────────────────
+//
+// Observe-only signals for the background-tab `RESULT_CODE_HUNG`
+// investigation (`docs/planning/hung-tab-investigation.md`). Every
+// signal is tagged with the page's `visibilityState` and how long it
+// has been hidden, so the backend can show what happens **in the
+// background** — escalating long tasks (synchronous-burst hang),
+// reconnect flapping, or unbounded heap growth (leak / GC death-spiral)
+// while `hidden` each name a different root cause. No behavior change.
+
+/** Sampling cadence for the JS heap. Background timers are clamped to
+ * ≥1 min, so a 60 s base interval is the finest useful resolution while
+ * backgrounded; foreground samples are exact. */
+const HEAP_SAMPLE_INTERVAL_MS = 60_000;
+
+let healthInstalled = false;
+let visibility: string =
+  typeof document !== "undefined" ? document.visibilityState : "visible";
+let hiddenSinceMs: number | null =
+  visibility === "hidden" && typeof performance !== "undefined" ? performance.now() : null;
+
+/** Common tags so every health signal can be sliced by foreground vs
+ * background and by how deep into a background idle it occurred. */
+function visibilityTags(): { visibility: string; ms_hidden: string } {
+  const msHidden =
+    hiddenSinceMs === null ? 0 : Math.round(performance.now() - hiddenSinceMs);
+  return { visibility, ms_hidden: String(msHidden) };
+}
+
+function reportVisibility(): void {
+  faro?.api.pushEvent("chat.client.visibility", visibilityTags());
+}
+
+function reportLongTask(durationMs: number): void {
+  faro?.api.pushMeasurement({
+    type: "chat.client.longtask.duration_ms",
+    values: { duration_ms: Math.round(durationMs) },
+    context: visibilityTags(),
+  });
+}
+
+interface ChromeMemory {
+  usedJSHeapSize: number;
+  totalJSHeapSize: number;
+  jsHeapSizeLimit: number;
+}
+
+function sampleHeap(): void {
+  if (!faro || typeof performance === "undefined") return;
+  const mem = (performance as Performance & { memory?: ChromeMemory }).memory;
+  if (!mem) return; // Chrome-only API; absent elsewhere
+  faro.api.pushMeasurement({
+    type: "chat.client.heap",
+    values: {
+      used_mb: Math.round(mem.usedJSHeapSize / 1_048_576),
+      total_mb: Math.round(mem.totalJSHeapSize / 1_048_576),
+      limit_mb: Math.round(mem.jsHeapSizeLimit / 1_048_576),
+    },
+    context: visibilityTags(),
+  });
+}
+
+/** Background-flapping detector: one event + counter per scheduled
+ * reconnect, tagged with visibility/ms-hidden. A burst while `hidden`
+ * points at keepalive-throttling → server idle timeout → reconnect loops. */
+export function reportReconnectScheduled(payload: { attempt: number; delayMs: number }): void {
+  if (!faro) return;
+  const tags = visibilityTags();
+  faro.api.pushEvent("chat.xmpp.reconnect.scheduled", {
+    attempt: String(payload.attempt),
+    delay_ms: String(Math.round(payload.delayMs)),
+    ...tags,
+  });
+  faro.api.pushMeasurement({
+    type: "chat.xmpp.reconnect.attempt",
+    values: { attempt: payload.attempt },
+    context: tags,
+  });
+}
+
+/** Catch-up cost: how much work a single reconnect catch-up did. Large
+ * or repeated bursts while `hidden` point at the unbounded resume apply. */
+export function reportCatchup(payload: {
+  conversations: number;
+  pages: number;
+  messages: number;
+  durationMs: number;
+}): void {
+  faro?.api.pushMeasurement({
+    type: "chat.xmpp.catchup",
+    values: {
+      conversations: payload.conversations,
+      pages: payload.pages,
+      messages: payload.messages,
+      duration_ms: Math.round(payload.durationMs),
+    },
+    context: visibilityTags(),
+  });
+}
+
+/** Resume live-buffer drain: how many buffered messages were applied
+ * synchronously on session-ready, and how long that one task took. */
+export function reportResumeDrain(payload: { buffered: number; durationMs: number }): void {
+  faro?.api.pushMeasurement({
+    type: "chat.xmpp.resume_drain",
+    values: { buffered: payload.buffered, duration_ms: Math.round(payload.durationMs) },
+    context: visibilityTags(),
+  });
+}
+
+/**
+ * Install the page-global client-health observers (long tasks, JS heap,
+ * visibility transitions). Idempotent and a no-op without Faro or
+ * outside the browser. Called once from {@link initTelemetry}.
+ */
+function installClientHealthTelemetry(): void {
+  if (healthInstalled) return;
+  if (!faro || typeof window === "undefined" || typeof document === "undefined") return;
+  healthInstalled = true;
+
+  // Visibility transitions — maintain `hidden-since` for tagging and
+  // grab a heap sample on every transition so the bg/fg trajectory is
+  // captured even between timer ticks.
+  document.addEventListener("visibilitychange", () => {
+    const next = document.visibilityState;
+    if (next === visibility) return;
+    visibility = next;
+    hiddenSinceMs = next === "hidden" ? performance.now() : null;
+    reportVisibility();
+    sampleHeap();
+  });
+
+  // Long tasks — the smoking gun for a HUNG renderer. The task that
+  // ultimately wedges the tab won't complete (so won't be reported), but
+  // the escalating tasks before it will, tagged `hidden`.
+  if (
+    "PerformanceObserver" in window &&
+    PerformanceObserver.supportedEntryTypes?.includes("longtask")
+  ) {
+    try {
+      const observer = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) reportLongTask(entry.duration);
+      });
+      observer.observe({ entryTypes: ["longtask"] });
+    } catch {
+      // longtask unsupported in this engine — skip silently.
+    }
+  }
+
+  // JS heap trend (Chrome `performance.memory`). Detects a leak / GC
+  // death-spiral building over a long background idle.
+  window.setInterval(sampleHeap, HEAP_SAMPLE_INTERVAL_MS);
+  sampleHeap();
 }

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -233,6 +233,8 @@ function shouldSkipRawCatchupMessage(
 const DM_CALL_ACTIVITY_PAGE_SIZE = 100;
 const DM_CALL_ACTIVITY_MAX_PAGES = 50;
 
+type CatchupRunStats = { pages: number; messages: number };
+type CatchupOutcome = "completed" | "aborted" | "failed";
 type DmCallActivityHydrationOptions = { since?: string; pageSize?: number; maxPages?: number };
 
 async function collectRecentMamPages(
@@ -581,11 +583,15 @@ export class BrowserXmppClient {
   // client stays telemetry-agnostic; xmpp-instrumentation.ts binds these
   // to the Faro report* sink.
   private readonly reconnectScheduledHooks: Array<(info: { attempt: number; delayMs: number }) => void> = [];
-  private readonly catchupHooks: Array<(info: { conversations: number; pages: number; messages: number; durationMs: number }) => void> = [];
+  private readonly catchupHooks: Array<(info: {
+    conversations: number;
+    processedConversations: number;
+    pages: number;
+    messages: number;
+    durationMs: number;
+    outcome: CatchupOutcome;
+  }) => void> = [];
   private readonly resumeDrainHooks: Array<(info: { buffered: number; durationMs: number }) => void> = [];
-  // Per-catch-up-run accumulator (pages fetched + messages applied),
-  // threaded through the apply/fetch paths without changing signatures.
-  private catchupRunStats: { pages: number; messages: number } | null = null;
   private readonly roomJoinWaiters = new Map<string, { resolve: () => void; reject: (error: Error) => void }>();
   private readonly carbonDedupIds = new Set<string>();
   readonly catchup: ReconnectCatchup;
@@ -734,7 +740,14 @@ export class BrowserXmppClient {
   onQueueDepthChange(hook: (depth: { persisted: number; inflight: number }) => void) { this.queueDepthHooks.push(hook); }
   onError(hook: (event: XmppErrorEvent) => void) { this.errorHooks.push(hook); }
   onReconnectScheduled(hook: (info: { attempt: number; delayMs: number }) => void) { this.reconnectScheduledHooks.push(hook); }
-  onCatchup(hook: (info: { conversations: number; pages: number; messages: number; durationMs: number }) => void) { this.catchupHooks.push(hook); }
+  onCatchup(hook: (info: {
+    conversations: number;
+    processedConversations: number;
+    pages: number;
+    messages: number;
+    durationMs: number;
+    outcome: CatchupOutcome;
+  }) => void) { this.catchupHooks.push(hook); }
   onResumeDrain(hook: (info: { buffered: number; durationMs: number }) => void) { this.resumeDrainHooks.push(hook); }
 
   private fireHook<Args extends unknown[]>(hooks: Array<(...args: Args) => void>, ...args: Args) {
@@ -2878,21 +2891,36 @@ export class BrowserXmppClient {
   ) {
     const sessionJid = this.session.jid;
     // Observe-only: measure how much work a single catch-up did and how
-    // long it took (background-tab HUNG investigation). `catchupRunStats`
-    // is incremented by the fetch/apply paths during the run.
+    // long it took (background-tab HUNG investigation). Keep stats local
+    // because old/new xmpp handles can briefly overlap during reconnects.
     const startedAt = performance.now();
-    this.catchupRunStats = { pages: 0, messages: 0 };
+    const stats: CatchupRunStats = { pages: 0, messages: 0 };
+    let processedConversations = 0;
+    let outcome: CatchupOutcome = "completed";
     try {
       for (const entry of entries) {
-        if (!this.isCurrentConnectedXmpp(xmpp, sessionJid)) return;
+        if (!this.isCurrentConnectedXmpp(xmpp, sessionJid)) {
+          outcome = "aborted";
+          return;
+        }
         try {
           if (entry.kind === "dm") {
-            await this.runDmReconnectCatchup(xmpp, entry, sessionJid);
+            await this.runDmReconnectCatchup(xmpp, entry, sessionJid, stats);
           } else {
-            await this.runRoomReconnectCatchup(xmpp, entry, sessionJid);
+            await this.runRoomReconnectCatchup(xmpp, entry, sessionJid, stats);
           }
+          if (!this.isCurrentConnectedXmpp(xmpp, sessionJid)) {
+            outcome = "aborted";
+            return;
+          }
+          processedConversations += 1;
         } catch (error) {
-          if (!this.isCurrentConnectedXmpp(xmpp, sessionJid)) return;
+          if (!this.isCurrentConnectedXmpp(xmpp, sessionJid)) {
+            outcome = "aborted";
+            return;
+          }
+          outcome = "failed";
+          processedConversations += 1;
           this.emitError({
             kind: "history",
             recoverable: true,
@@ -2902,13 +2930,13 @@ export class BrowserXmppClient {
         }
       }
     } finally {
-      const stats = this.catchupRunStats ?? { pages: 0, messages: 0 };
-      this.catchupRunStats = null;
       this.fireHook(this.catchupHooks, {
         conversations: entries.length,
+        processedConversations,
         pages: stats.pages,
         messages: stats.messages,
         durationMs: performance.now() - startedAt,
+        outcome,
       });
     }
   }
@@ -2916,6 +2944,7 @@ export class BrowserXmppClient {
     xmpp: XmppClientInstance,
     entry: { key: string; after?: string; since?: string; seenIds?: string[] },
     sessionJid: string,
+    stats: CatchupRunStats,
   ) {
     if (!xmpp.fetch_dm_history_page) return;
     if (entry.after) {
@@ -2930,14 +2959,14 @@ export class BrowserXmppClient {
         } catch (error) {
           if (isMamCursorNotFound(classifyMamError(error))) {
             const since = entry.since ?? this.catchup.getDmLastSeen(entry.key);
-            if (since) await this.runDmTimestampCatchup(xmpp, entry.key, since, sessionJid, entry.seenIds);
+            if (since) await this.runDmTimestampCatchup(xmpp, entry.key, since, sessionJid, entry.seenIds, stats);
             return;
           }
           throw error;
         }
         if (!this.isCurrentConnectedXmpp(xmpp, sessionJid)) return;
         if (pageContainsArchiveId(page, after)) throw new Error(`Reconnect catch-up received non-advancing archive cursor for ${entry.key}`);
-        const nextAfter = this.applyDmCatchupPage(page, undefined, entry.seenIds);
+        const nextAfter = this.applyDmCatchupPage(page, undefined, entry.seenIds, { stats });
         if (isMamPageComplete(page)) return;
         if (!nextAfter || nextAfter === after) throw new Error(`Reconnect catch-up could not advance archive cursor for ${entry.key}`);
         after = nextAfter;
@@ -2946,12 +2975,13 @@ export class BrowserXmppClient {
     }
     const since = entry.since ?? this.catchup.getDmLastSeen(entry.key);
     if (!since) return;
-    await this.runDmTimestampCatchup(xmpp, entry.key, since, sessionJid, entry.seenIds);
+    await this.runDmTimestampCatchup(xmpp, entry.key, since, sessionJid, entry.seenIds, stats);
   }
   private async runRoomReconnectCatchup(
     xmpp: XmppClientInstance,
     entry: { key: string; after?: string; since?: string; seenIds?: string[] },
     sessionJid: string,
+    stats: CatchupRunStats,
   ) {
     if (!xmpp.fetch_room_history_page) return;
     if (entry.after) {
@@ -2966,14 +2996,14 @@ export class BrowserXmppClient {
         } catch (error) {
           if (isMamCursorNotFound(classifyMamError(error))) {
             const since = entry.since ?? this.catchup.getRoomLastSeen(entry.key);
-            if (since) await this.runRoomTimestampCatchup(xmpp, entry.key, since, sessionJid, entry.seenIds);
+            if (since) await this.runRoomTimestampCatchup(xmpp, entry.key, since, sessionJid, entry.seenIds, stats);
             return;
           }
           throw error;
         }
         if (!this.isCurrentConnectedXmpp(xmpp, sessionJid)) return;
         if (pageContainsArchiveId(page, after)) throw new Error(`Reconnect catch-up received non-advancing archive cursor for ${entry.key}`);
-        const nextAfter = this.applyRoomCatchupPage(page, undefined, entry.seenIds);
+        const nextAfter = this.applyRoomCatchupPage(page, undefined, entry.seenIds, stats);
         if (isMamPageComplete(page)) return;
         if (!nextAfter || nextAfter === after) throw new Error(`Reconnect catch-up could not advance archive cursor for ${entry.key}`);
         after = nextAfter;
@@ -2982,7 +3012,7 @@ export class BrowserXmppClient {
     }
     const since = entry.since ?? this.catchup.getRoomLastSeen(entry.key);
     if (!since) return;
-    await this.runRoomTimestampCatchup(xmpp, entry.key, since, sessionJid, entry.seenIds);
+    await this.runRoomTimestampCatchup(xmpp, entry.key, since, sessionJid, entry.seenIds, stats);
   }
   private async runDmTimestampCatchup(
     xmpp: XmppClientInstance,
@@ -2990,6 +3020,7 @@ export class BrowserXmppClient {
     since: string,
     sessionJid: string,
     seenIds?: ReadonlyArray<string>,
+    stats?: CatchupRunStats,
   ) {
     let pageParam: MamPageParam = { type: "latest" };
     const seenBefore = new Set<string>();
@@ -3007,7 +3038,7 @@ export class BrowserXmppClient {
     }
     const selfBare = barePeerJid(this.session.jid);
     for (const page of [...pages].reverse()) {
-      this.applyDmCatchupPage(page, since, seenIds, { applyCallEvents: false });
+      this.applyDmCatchupPage(page, since, seenIds, { applyCallEvents: false, stats });
     }
     for (const page of [...pages].reverse()) {
       this.applyDmCallEventsFromMamPage(page, selfBare, { since, seenIds });
@@ -3019,6 +3050,7 @@ export class BrowserXmppClient {
     since: string,
     sessionJid: string,
     seenIds?: ReadonlyArray<string>,
+    stats?: CatchupRunStats,
   ) {
     let pageParam: MamPageParam = { type: "latest" };
     const seenBefore = new Set<string>();
@@ -3035,18 +3067,18 @@ export class BrowserXmppClient {
       pageParam = { type: "before", before: firstArchiveId };
     }
     for (const page of [...pages].reverse()) {
-      this.applyRoomCatchupPage(page, since, seenIds);
+      this.applyRoomCatchupPage(page, since, seenIds, stats);
     }
   }
   private applyDmCatchupPage(
     page: WasmMamPage | null | undefined,
     since?: string,
     seenIds?: ReadonlyArray<string>,
-    options: { applyCallEvents?: boolean } = {},
+    options: { applyCallEvents?: boolean; stats?: CatchupRunStats } = {},
   ): string | undefined {
     let lastArchiveId = pageLastArchiveId(page);
     const selfBare = barePeerJid(this.session.jid);
-    if (this.catchupRunStats) this.catchupRunStats.pages += 1;
+    if (options.stats) options.stats.pages += 1;
     if (options.applyCallEvents !== false) {
       this.applyDmCallEventsFromMamPage(page, selfBare, { since, seenIds });
     }
@@ -3055,14 +3087,14 @@ export class BrowserXmppClient {
       if (!converted || shouldSkipCatchupMessage(converted, since, seenIds)) continue;
       this.catchup.recordDmSeen(converted.peerJid, converted.createdAt, converted.archiveId, messageSeenIds(converted));
       this.directMessageHandler?.(converted);
-      if (this.catchupRunStats) this.catchupRunStats.messages += 1;
+      if (options.stats) options.stats.messages += 1;
       lastArchiveId = converted.archiveId ?? lastArchiveId;
     }
     return lastArchiveId;
   }
-  private applyRoomCatchupPage(page: WasmMamPage | null | undefined, since?: string, seenIds?: ReadonlyArray<string>): string | undefined {
+  private applyRoomCatchupPage(page: WasmMamPage | null | undefined, since?: string, seenIds?: ReadonlyArray<string>, stats?: CatchupRunStats): string | undefined {
     let lastArchiveId = pageLastArchiveId(page);
-    if (this.catchupRunStats) this.catchupRunStats.pages += 1;
+    if (stats) stats.pages += 1;
     for (const message of page?.messages ?? []) {
       const converted = roomMessageFromArchived(message);
       if (!converted || shouldSkipCatchupMessage(converted, since, seenIds)) continue;
@@ -3072,7 +3104,7 @@ export class BrowserXmppClient {
       } else {
         this.messageHandler?.(converted);
       }
-      if (this.catchupRunStats) this.catchupRunStats.messages += 1;
+      if (stats) stats.messages += 1;
       lastArchiveId = converted.archiveId ?? lastArchiveId;
     }
     return lastArchiveId;

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -576,6 +576,16 @@ export class BrowserXmppClient {
   private readonly sendEnqueuedHooks: Array<(info: { kind: "room" | "dm"; reason: string }) => void> = [];
   private readonly queueDepthHooks: Array<(depth: { persisted: number; inflight: number }) => void> = [];
   private readonly errorHooks: Array<(event: XmppErrorEvent) => void> = [];
+  // Observe-only health hooks for the background-tab RESULT_CODE_HUNG
+  // investigation (see docs/planning/hung-tab-investigation.md). The
+  // client stays telemetry-agnostic; xmpp-instrumentation.ts binds these
+  // to the Faro report* sink.
+  private readonly reconnectScheduledHooks: Array<(info: { attempt: number; delayMs: number }) => void> = [];
+  private readonly catchupHooks: Array<(info: { conversations: number; pages: number; messages: number; durationMs: number }) => void> = [];
+  private readonly resumeDrainHooks: Array<(info: { buffered: number; durationMs: number }) => void> = [];
+  // Per-catch-up-run accumulator (pages fetched + messages applied),
+  // threaded through the apply/fetch paths without changing signatures.
+  private catchupRunStats: { pages: number; messages: number } | null = null;
   private readonly roomJoinWaiters = new Map<string, { resolve: () => void; reject: (error: Error) => void }>();
   private readonly carbonDedupIds = new Set<string>();
   readonly catchup: ReconnectCatchup;
@@ -723,6 +733,9 @@ export class BrowserXmppClient {
   onSendEnqueued(hook: (info: { kind: "room" | "dm"; reason: string }) => void) { this.sendEnqueuedHooks.push(hook); }
   onQueueDepthChange(hook: (depth: { persisted: number; inflight: number }) => void) { this.queueDepthHooks.push(hook); }
   onError(hook: (event: XmppErrorEvent) => void) { this.errorHooks.push(hook); }
+  onReconnectScheduled(hook: (info: { attempt: number; delayMs: number }) => void) { this.reconnectScheduledHooks.push(hook); }
+  onCatchup(hook: (info: { conversations: number; pages: number; messages: number; durationMs: number }) => void) { this.catchupHooks.push(hook); }
+  onResumeDrain(hook: (info: { buffered: number; durationMs: number }) => void) { this.resumeDrainHooks.push(hook); }
 
   private fireHook<Args extends unknown[]>(hooks: Array<(...args: Args) => void>, ...args: Args) {
     for (const hook of hooks) {
@@ -836,6 +849,7 @@ export class BrowserXmppClient {
     if (this.destroying || this.reconnectTimer) return;
     const delay = Math.min(2000 * (2 ** this.reconnectAttempt), 60000);
     this.reconnectAttempt += 1;
+    this.fireHook(this.reconnectScheduledHooks, { attempt: this.reconnectAttempt, delayMs: delay });
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;
       void this.connect().catch(() => undefined);
@@ -2646,7 +2660,15 @@ export class BrowserXmppClient {
     // `dispatchLiveBodyMessage` path that a fresh socket arrival
     // would, so cursor advance + downstream `messageHandler` /
     // `directMessageHandler` dedup behave identically.
+    // Observe-only: the buffer drain is a single synchronous task over
+    // everything that arrived during the resume barrier — a prime
+    // background-tab HUNG suspect. Measure its size + wall-clock.
+    const drainStartedAt = performance.now();
     for (const m of buffered) this.dispatchLiveBodyMessage(m);
+    this.fireHook(this.resumeDrainHooks, {
+      buffered: buffered.length,
+      durationMs: performance.now() - drainStartedAt,
+    });
   }
 
   private flushAfterSessionReady(xmpp: XmppClientInstance) {
@@ -2855,23 +2877,39 @@ export class BrowserXmppClient {
     entries: Array<{ kind: "dm" | "room"; key: string; after?: string; since?: string; seenIds?: string[] }>,
   ) {
     const sessionJid = this.session.jid;
-    for (const entry of entries) {
-      if (!this.isCurrentConnectedXmpp(xmpp, sessionJid)) return;
-      try {
-        if (entry.kind === "dm") {
-          await this.runDmReconnectCatchup(xmpp, entry, sessionJid);
-        } else {
-          await this.runRoomReconnectCatchup(xmpp, entry, sessionJid);
-        }
-      } catch (error) {
+    // Observe-only: measure how much work a single catch-up did and how
+    // long it took (background-tab HUNG investigation). `catchupRunStats`
+    // is incremented by the fetch/apply paths during the run.
+    const startedAt = performance.now();
+    this.catchupRunStats = { pages: 0, messages: 0 };
+    try {
+      for (const entry of entries) {
         if (!this.isCurrentConnectedXmpp(xmpp, sessionJid)) return;
-        this.emitError({
-          kind: "history",
-          recoverable: true,
-          detail: `Reconnect catch-up failed for ${entry.key}`,
-          cause: error,
-        });
+        try {
+          if (entry.kind === "dm") {
+            await this.runDmReconnectCatchup(xmpp, entry, sessionJid);
+          } else {
+            await this.runRoomReconnectCatchup(xmpp, entry, sessionJid);
+          }
+        } catch (error) {
+          if (!this.isCurrentConnectedXmpp(xmpp, sessionJid)) return;
+          this.emitError({
+            kind: "history",
+            recoverable: true,
+            detail: `Reconnect catch-up failed for ${entry.key}`,
+            cause: error,
+          });
+        }
       }
+    } finally {
+      const stats = this.catchupRunStats ?? { pages: 0, messages: 0 };
+      this.catchupRunStats = null;
+      this.fireHook(this.catchupHooks, {
+        conversations: entries.length,
+        pages: stats.pages,
+        messages: stats.messages,
+        durationMs: performance.now() - startedAt,
+      });
     }
   }
   private async runDmReconnectCatchup(
@@ -3008,6 +3046,7 @@ export class BrowserXmppClient {
   ): string | undefined {
     let lastArchiveId = pageLastArchiveId(page);
     const selfBare = barePeerJid(this.session.jid);
+    if (this.catchupRunStats) this.catchupRunStats.pages += 1;
     if (options.applyCallEvents !== false) {
       this.applyDmCallEventsFromMamPage(page, selfBare, { since, seenIds });
     }
@@ -3016,12 +3055,14 @@ export class BrowserXmppClient {
       if (!converted || shouldSkipCatchupMessage(converted, since, seenIds)) continue;
       this.catchup.recordDmSeen(converted.peerJid, converted.createdAt, converted.archiveId, messageSeenIds(converted));
       this.directMessageHandler?.(converted);
+      if (this.catchupRunStats) this.catchupRunStats.messages += 1;
       lastArchiveId = converted.archiveId ?? lastArchiveId;
     }
     return lastArchiveId;
   }
   private applyRoomCatchupPage(page: WasmMamPage | null | undefined, since?: string, seenIds?: ReadonlyArray<string>): string | undefined {
     let lastArchiveId = pageLastArchiveId(page);
+    if (this.catchupRunStats) this.catchupRunStats.pages += 1;
     for (const message of page?.messages ?? []) {
       const converted = roomMessageFromArchived(message);
       if (!converted || shouldSkipCatchupMessage(converted, since, seenIds)) continue;
@@ -3031,6 +3072,7 @@ export class BrowserXmppClient {
       } else {
         this.messageHandler?.(converted);
       }
+      if (this.catchupRunStats) this.catchupRunStats.messages += 1;
       lastArchiveId = converted.archiveId ?? lastArchiveId;
     }
     return lastArchiveId;

--- a/chat/src/lib/xmpp/xmpp-instrumentation.ts
+++ b/chat/src/lib/xmpp/xmpp-instrumentation.ts
@@ -10,10 +10,13 @@ import type { BrowserXmppClient } from "@/lib/xmpp-client";
 import type { ErrorKind } from "@/lib/telemetry";
 import type { XmppErrorKind } from "@/lib/xmpp/types";
 import {
+  reportCatchup,
   reportError,
   reportMessageAcked,
   reportMessageFailed,
   reportQueueDepthChange,
+  reportReconnectScheduled,
+  reportResumeDrain,
   reportSendEnqueued,
   reportSessionLifecycle,
   reportStatusChange,
@@ -59,4 +62,10 @@ export function installInstrumentation(client: BrowserXmppClient): void {
       ...(event.condition ? { condition: event.condition } : {}),
     });
   });
+  // Background-tab RESULT_CODE_HUNG investigation (observe-only). These
+  // pair with the page-global longtask/heap/visibility signals installed
+  // by `installClientHealthTelemetry()` in `@/lib/telemetry`.
+  client.onReconnectScheduled((info) => reportReconnectScheduled(info));
+  client.onCatchup((info) => reportCatchup(info));
+  client.onResumeDrain((info) => reportResumeDrain(info));
 }

--- a/chat/tests/xmpp-telemetry.test.ts
+++ b/chat/tests/xmpp-telemetry.test.ts
@@ -4,9 +4,12 @@ import { BrowserXmppClient } from "../src/lib/xmpp-client";
 import {
   __setFaroForTesting,
   initTelemetry,
+  reportCatchup,
   reportMessageAcked,
   reportMessageFailed,
   reportQueueDepthChange,
+  reportReconnectScheduled,
+  reportResumeDrain,
   reportSendEnqueued,
   reportSessionLifecycle,
   reportStatusChange,
@@ -69,8 +72,8 @@ function createFaroStub() {
         type: string;
         values: Record<string, number>;
         context?: Record<string, string>;
-      }) => {
-        measurements.push(payload);
+      }, options?: { context?: Record<string, string> }) => {
+        measurements.push({ ...payload, context: options?.context });
       },
       pushError: (
         error: Error,
@@ -128,6 +131,9 @@ describe("telemetry module no-op behaviour", () => {
       reportQueueDepthChange({ persisted: 0, inflight: 0 });
       reportSessionLifecycle({ type: "fresh" });
       reportStatusChange({ state: "online" });
+      reportReconnectScheduled({ attempt: 1, delayMs: 2_000 });
+      reportCatchup({ conversations: 1, pages: 1, messages: 1, durationMs: 10 });
+      reportResumeDrain({ buffered: 1, durationMs: 10 });
     }).not.toThrow();
   });
 
@@ -142,6 +148,16 @@ describe("telemetry module no-op behaviour", () => {
     reportSessionLifecycle({ type: "resumed" });
     reportStatusChange({ state: "reconnecting", detail: "lost" });
     reportStatusChange({ state: "online", reconnectDurationMs: 4_321 });
+    reportReconnectScheduled({ attempt: 3, delayMs: 8_000 });
+    reportCatchup({
+      conversations: 2,
+      processedConversations: 1,
+      pages: 4,
+      messages: 12,
+      durationMs: 88.6,
+      outcome: "aborted",
+    });
+    reportResumeDrain({ buffered: 5, durationMs: 12.4 });
 
     const eventNames = stub.events.map((e) => e.name);
     expect(eventNames).toEqual([
@@ -151,6 +167,7 @@ describe("telemetry module no-op behaviour", () => {
       "chat.xmpp.session.lifecycle",
       "chat.xmpp.status",
       "chat.xmpp.status",
+      "chat.xmpp.reconnect.scheduled",
     ]);
 
     const measurementTypes = stub.measurements.map((m) => m.type);
@@ -158,6 +175,9 @@ describe("telemetry module no-op behaviour", () => {
       "chat.xmpp.message.acked.latency_ms",
       "chat.xmpp.queue.depth",
       "chat.xmpp.reconnect.duration_ms",
+      "chat.xmpp.reconnect.attempt",
+      "chat.xmpp.catchup",
+      "chat.xmpp.resume_drain",
     ]);
 
     const ackMeasurement = stub.measurements[0];
@@ -169,6 +189,34 @@ describe("telemetry module no-op behaviour", () => {
 
     const reconnectMeasurement = stub.measurements[2];
     expect(reconnectMeasurement.values.duration_ms).toBe(4_321);
+
+    const reconnectAttempt = stub.measurements[3];
+    expect(reconnectAttempt.values).toEqual({
+      count: 1,
+      attempt: 3,
+      delay_ms: 8_000,
+      hidden_ms: 0,
+    });
+    expect(reconnectAttempt.context).toEqual({ visibility: "visible", hidden_bucket: "visible" });
+
+    const catchup = stub.measurements[4];
+    expect(catchup.values).toEqual({
+      conversations: 2,
+      processed_conversations: 1,
+      pages: 4,
+      messages: 12,
+      duration_ms: 89,
+      hidden_ms: 0,
+    });
+    expect(catchup.context).toEqual({
+      visibility: "visible",
+      hidden_bucket: "visible",
+      outcome: "aborted",
+    });
+
+    const resumeDrain = stub.measurements[5];
+    expect(resumeDrain.values).toEqual({ buffered: 5, duration_ms: 12, hidden_ms: 0 });
+    expect(resumeDrain.context).toEqual({ visibility: "visible", hidden_bucket: "visible" });
   });
 });
 
@@ -228,6 +276,17 @@ describe("BrowserXmppClient telemetry hooks", () => {
       wireEvents: (xmpp: unknown) => void;
       emitStatus: (snap: { state: string; detail?: string }) => void;
       emitSessionLifecycle: (evt: { type: "fresh" | "resumed" }) => void;
+      fireHook: <Args extends unknown[]>(hooks: Array<(...args: Args) => void>, ...args: Args) => void;
+      reconnectScheduledHooks: Array<(info: { attempt: number; delayMs: number }) => void>;
+      catchupHooks: Array<(info: {
+        conversations: number;
+        processedConversations: number;
+        pages: number;
+        messages: number;
+        durationMs: number;
+        outcome: "completed" | "aborted" | "failed";
+      }) => void>;
+      resumeDrainHooks: Array<(info: { buffered: number; durationMs: number }) => void>;
     };
     const handlers = new Map<string, Array<(msg: unknown) => void>>();
     const stubXmpp = {
@@ -255,11 +314,23 @@ describe("BrowserXmppClient telemetry hooks", () => {
     internal.emitSessionLifecycle({ type: "resumed" });
     internal.emitStatus({ state: "reconnecting", detail: "ws dropped" });
     internal.emitStatus({ state: "online", detail: "back" });
+    // Background-tab health hooks
+    internal.fireHook(internal.reconnectScheduledHooks, { attempt: 1, delayMs: 2_000 });
+    internal.fireHook(internal.catchupHooks, {
+      conversations: 1,
+      processedConversations: 1,
+      pages: 2,
+      messages: 3,
+      durationMs: 4,
+      outcome: "completed",
+    });
+    internal.fireHook(internal.resumeDrainHooks, { buffered: 7, durationMs: 8 });
 
     const eventNames = stub.events.map((e) => e.name);
     expect(eventNames).toContain("chat.xmpp.message.acked");
     expect(eventNames).toContain("chat.xmpp.message.failed");
     expect(eventNames).toContain("chat.xmpp.session.lifecycle");
+    expect(eventNames).toContain("chat.xmpp.reconnect.scheduled");
     expect(eventNames.filter((n) => n === "chat.xmpp.status")).toHaveLength(2);
 
     const reconnectMeasurement = stub.measurements.find(
@@ -267,6 +338,66 @@ describe("BrowserXmppClient telemetry hooks", () => {
     );
     expect(reconnectMeasurement).toBeDefined();
     expect(reconnectMeasurement?.values.duration_ms).toBeGreaterThanOrEqual(0);
+    expect(stub.measurements.some((m) => m.type === "chat.xmpp.reconnect.attempt")).toBe(true);
+    expect(stub.measurements.some((m) => m.type === "chat.xmpp.catchup")).toBe(true);
+    expect(stub.measurements.some((m) => m.type === "chat.xmpp.resume_drain")).toBe(true);
+  });
+
+  test("catch-up hook reports failed outcomes and processed conversation count", async () => {
+    const client = new BrowserXmppClient(session());
+    const events: Array<{
+      conversations: number;
+      processedConversations: number;
+      pages: number;
+      messages: number;
+      outcome: string;
+    }> = [];
+    client.onCatchup((info) => events.push(info));
+
+    const xmpp = {
+      fetch_dm_history_page: mock(async (peer: string) => {
+        if (peer === "carol@example.com") throw new Error("MAM failed");
+        return {
+          messages: [{
+            mam_id: "mam-2",
+            id: "dm-2",
+            from: "bob@example.com/phone",
+            to: "alice@example.com/desktop",
+            message_type: "chat",
+            body: "missed while suspended",
+            timestamp: "2024-01-01T00:00:01.000Z",
+            reaction_emojis: [],
+            shared_files: [],
+          }],
+          complete: true,
+        };
+      }),
+    };
+
+    const internal = client as unknown as {
+      xmpp: unknown;
+      connected: boolean;
+      runReconnectCatchup: (
+        xmpp: unknown,
+        entries: Array<{ kind: "dm"; key: string; after?: string }>,
+      ) => Promise<void>;
+    };
+    internal.xmpp = xmpp;
+    internal.connected = true;
+
+    await internal.runReconnectCatchup(xmpp, [
+      { kind: "dm", key: "bob@example.com", after: "mam-1" },
+      { kind: "dm", key: "carol@example.com", after: "mam-1" },
+    ]);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      conversations: 2,
+      processedConversations: 2,
+      pages: 1,
+      messages: 1,
+      outcome: "failed",
+    });
   });
 
   test("client.onError forwards XMPP failures to Faro pushError with kind tagging", () => {

--- a/docs/planning/hung-tab-investigation.md
+++ b/docs/planning/hung-tab-investigation.md
@@ -54,17 +54,19 @@ theory (which would hang on return) and favors mechanisms that run
 
 Add evidence-gathering instrumentation via the existing Faro/`@opentelemetry/api`
 stack (`chat/src/lib/telemetry.ts` `report*` + `BrowserXmppClient` hooks wired in
-`xmpp-instrumentation.ts`). Every signal tagged with `visibilityState` + ms-hidden
-so we can see what happens **in the background**:
+`xmpp-instrumentation.ts`). Every signal is tagged with `visibilityState` plus a
+coarse hidden-duration bucket, with exact hidden milliseconds carried as a numeric
+measurement value so we can see what happens **in the background** without creating
+one metric series per millisecond:
 
 | Signal | Discriminates | Where |
 |---|---|---|
 | `longtask` PerformanceObserver (smoking gun) | synchronous-burst hang + when | telemetry health init |
 | JS heap sampling (`usedJSHeapSize`, timer + on visibility change) | leak / GC death-spiral | telemetry health init |
-| Reconnect-attempt counter (visibility, ms-hidden) | background flapping | `scheduleReconnect` hook |
-| Catch-up span (rooms/dms/pages/messages/durationMs) | heavy/repeated catch-up | `runReconnectCatchup` hook |
+| Reconnect-attempt count (visibility, hidden bucket, attempt/delay values) | background flapping | `scheduleReconnect` hook |
+| Catch-up span (rooms/dms/pages/messages/durationMs/outcome) | heavy/repeated catch-up | `runReconnectCatchup` hook |
 | Resume-drain measurement (buffered size, durationMs) | synchronous drain burst | `completeResumeBarrier` hook |
-| Visibility transitions (state, hiddenMs) | correlation backbone | telemetry health init |
+| Visibility transitions (state, hidden bucket) | correlation backbone | telemetry health init |
 
 Deploy → collect telemetry across several background-death occurrences → the
 signal that fires (escalating longtasks `hidden` / reconnect flapping `hidden` /

--- a/docs/planning/hung-tab-investigation.md
+++ b/docs/planning/hung-tab-investigation.md
@@ -1,0 +1,71 @@
+# Web client `RESULT_CODE_HUNG` after background idle — investigation
+
+Status: **Phase 1 (root-cause investigation)** — gathering evidence before any fix.
+Method: `superpowers:systematic-debugging` (no fixes without confirmed root cause).
+
+## Symptom
+
+Chrome desktop web client tabs are **found already dead** with
+`Error code: RESULT_CODE_HUNG` after idling in the background. Longstanding
+(not a recent regression). `RESULT_CODE_HUNG` = Chromium killed the renderer
+because its **main thread stopped responding** to the browser's hang monitor —
+i.e. a long **synchronous** task / microtask spin, or a GC death-spiral. Not OOM,
+not network.
+
+Key qualifier from the reporter: the tab dies **while backgrounded**, not on
+return/foreground.
+
+## Evidence gathered (static)
+
+- **The XMPP runtime runs on the main thread** — no Web Worker (`new Worker`
+  hits were `registerServiceWorker` false positives). Any main-thread block
+  hangs the page.
+- **Resume does unbounded, un-chunked, synchronous work** — `completeResumeBarrier`
+  (`chat/src/lib/xmpp/client.ts:2628`) runs two synchronous loops over
+  background-accumulated data: the MAM catch-up apply
+  (`for (const page of pages.reverse()) applyRoomCatchupPage(...)`, 2999/2971)
+  and the live-buffer drain (`for (const m of buffered) dispatchLiveBodyMessage(m)`,
+  2649). The catch-up paging (2959/2988) is **uncapped** (pages back to `since`,
+  which grows older with idle time); a sibling path caps at
+  `DM_CALL_ACTIVITY_MAX_PAGES = 50` (line 234) — the main path does not.
+
+## Hypotheses ruled OUT
+
+- **Reconnect storm** — `scheduleReconnect` (835) uses real `setTimeout`
+  exponential backoff, capped 60s, single-timer guard. Not a spin.
+- **Wasm driver microtask spin** — driver `run` loop
+  (`server/crates/waddle-xmpp-client-wasm/src/driver.rs:62`) is a `select!`
+  handling one event per iteration, paced by macrotask WS delivery.
+
+## Live hypotheses (given "dies while backgrounded")
+
+The "found already dead in background" detail weakens the one-shot resume-burst
+theory (which would hang on return) and favors mechanisms that run
+**repeatedly/continuously in the background**:
+
+1. **Connection flapping** — keepalive throttled in background → server idle
+   timeout → reconnect → session-ready → catch-up → repeat. Continuous work.
+2. **Memory leak / GC death-spiral** — unbounded growth over background time
+   (per-reconnect handles/listeners, buffers) → GC saturates the main thread.
+3. **Resume-burst (now secondary)** — a single large synchronous catch-up/drain
+   if reconnect+session-ready happens while backgrounded.
+
+## Next step: OpenTelemetry instrumentation (observe-only, no behavior change)
+
+Add evidence-gathering instrumentation via the existing Faro/`@opentelemetry/api`
+stack (`chat/src/lib/telemetry.ts` `report*` + `BrowserXmppClient` hooks wired in
+`xmpp-instrumentation.ts`). Every signal tagged with `visibilityState` + ms-hidden
+so we can see what happens **in the background**:
+
+| Signal | Discriminates | Where |
+|---|---|---|
+| `longtask` PerformanceObserver (smoking gun) | synchronous-burst hang + when | telemetry health init |
+| JS heap sampling (`usedJSHeapSize`, timer + on visibility change) | leak / GC death-spiral | telemetry health init |
+| Reconnect-attempt counter (visibility, ms-hidden) | background flapping | `scheduleReconnect` hook |
+| Catch-up span (rooms/dms/pages/messages/durationMs) | heavy/repeated catch-up | `runReconnectCatchup` hook |
+| Resume-drain measurement (buffered size, durationMs) | synchronous drain burst | `completeResumeBarrier` hook |
+| Visibility transitions (state, hiddenMs) | correlation backbone | telemetry health init |
+
+Deploy → collect telemetry across several background-death occurrences → the
+signal that fires (escalating longtasks `hidden` / reconnect flapping `hidden` /
+unbounded heap growth `hidden`) names the root cause. Then fix in a follow-up.


### PR DESCRIPTION
## Why

Chrome desktop web clients are **found already dead** with `RESULT_CODE_HUNG`
after idling in the background (longstanding). `RESULT_CODE_HUNG` = the renderer's
**main thread** stopped responding — a long synchronous task, microtask spin, or
GC death-spiral.

This PR is **Phase 1 of `systematic-debugging`: observe-only instrumentation to
find the root cause before any fix.** No message-delivery or reconnect behavior
change is intended.

## Investigation

Full record in `docs/planning/hung-tab-investigation.md`. Summary:

- XMPP runtime runs on the **main thread** (no Worker) → any block hangs the page.
- Resume processing (`completeResumeBarrier`, `client.ts`) does **unbounded,
  un-chunked, synchronous** work over background-accumulated data (catch-up apply +
  live-buffer drain); catch-up paging is uncapped (a sibling path caps at 50).
- **Ruled out:** reconnect storm (real-timer backoff, capped) and wasm-driver
  microtask spin (one event/iteration `select!`).
- **Live hypotheses** (tab dies *while backgrounded*): (1) connection **flapping**
  in background → repeated catch-up; (2) **memory leak / GC death-spiral**;
  (3) resume-burst (secondary).

## What this PR adds (observe-only, behavior-neutral)

OTel/Faro signals via the existing `telemetry.ts` `report*` + `BrowserXmppClient`
hook pattern. Signals are tagged with `visibility` and a coarse `hidden_bucket`,
with exact hidden duration carried as numeric `hidden_ms` to avoid high-cardinality
metric dimensions:

- [x] `longtask` PerformanceObserver → `chat.client.longtask.duration_ms` (the HUNG itself)
- [x] JS heap sampling (`performance.memory`, 60s timer + on visibility change) → `chat.client.heap`
- [x] Reconnect scheduling → `chat.xmpp.reconnect.scheduled` event + `chat.xmpp.reconnect.attempt` count
- [x] Catch-up cost (`conversations`, `processedConversations`, pages/messages/duration, `outcome`) → `chat.xmpp.catchup`
- [x] Resume-drain (buffered size, duration) → `chat.xmpp.resume_drain`
- [x] Visibility transitions → `chat.client.visibility` (correlation backbone)

Page-global signals install from `initTelemetry`; the three XMPP signals are
client hooks (`onReconnectScheduled`/`onCatchup`/`onResumeDrain`) wired in
`xmpp-instrumentation.ts`. All no-op without Faro / outside the browser.

## QA fixes added before ready-for-review

- Faro `pushMeasurement` context now uses the SDK options argument, so metric
  context is not silently dropped.
- Exact hidden duration moved out of metric context into numeric `hidden_ms`; the
  tag is now coarse `hidden_bucket`.
- Catch-up stats are local per run, not instance state, so overlapping old/new
  reconnect handles cannot contaminate telemetry.
- Catch-up emits `outcome` (`completed` / `aborted` / `failed`) and
  `processedConversations` so aborted or partial runs do not look like normal
  successful catch-up.
- Added focused telemetry tests for the new health hooks, Faro measurement context
  shape, reconnect attempt count, catch-up outcomes, and instrumentation wiring.

## Verification

- `bunx astro check` — clean (0 errors, 0 warnings; 1 existing hint)
- `bun run build` — clean
- `bun test` — 1500 pass, 0 fail
- `bun run lint` — clean (`wasm:build` + `knip`)
- Adversarial QA subagents: browser telemetry/data quality, XMPP reconnect/message
  delivery semantics, and test/maintainability all reported no real actionable
  findings after the final diff.

## How we use it

Deploy → collect telemetry across several background-death occurrences → the signal
that fires while `hidden` (escalating longtasks / reconnect flapping / unbounded heap
growth) names the root cause. **Fix follows in a separate PR once confirmed.**
