### PR TITLE
feat(link-preview): add plaintext XEP-0511 preview path

### DIFF
--- a/chat/src/channels/live-merge.ts
+++ b/chat/src/channels/live-merge.ts
@@ -224,6 +224,9 @@ export function useChannelLiveMerge(deps: UseChannelLiveMergeDeps) {
           createdAt: authoritativeTimestamp.createdAt,
           createdAtSource: authoritativeTimestamp.createdAtSource,
         };
+        if (!Object.prototype.hasOwnProperty.call(msg, "linkPreviews")) {
+          delete updated.linkPreviews;
+        }
         if (mergedIds.wireIds?.length) updated.wireIds = mergedIds.wireIds;
         else delete updated.wireIds;
         if (m.isSelf && msg.isSelf) {

--- a/chat/src/channels/message-timeline-state.ts
+++ b/chat/src/channels/message-timeline-state.ts
@@ -65,6 +65,19 @@ function mergeMissingThreadMetadata(
   return next;
 }
 
+function mergeAuthoritativeLinkPreviews(
+  existing: TimelineMessage,
+  incoming: TimelineMessage,
+): TimelineMessage {
+  if (Object.prototype.hasOwnProperty.call(incoming, "linkPreviews")) {
+    return { ...existing, linkPreviews: incoming.linkPreviews };
+  }
+  if (!existing.linkPreviews) return existing;
+  const next = { ...existing };
+  delete next.linkPreviews;
+  return next;
+}
+
 export function retractChannelTimelineMessage(
   existing: TimelineMessage,
   retractionId?: string,
@@ -78,6 +91,7 @@ export function retractChannelTimelineMessage(
   delete next.markup;
   delete next.references;
   delete next.sharedFiles;
+  delete next.linkPreviews;
   delete next.extensionAnnotations;
   delete next.extensionBodyFallback;
   delete next.isSticker;
@@ -112,7 +126,7 @@ function mergeRetractionTombstone(
       createdAtSource: authoritativeTimestamp.createdAtSource,
     };
   }
-  return result;
+  return incoming.isRetracted ? result : mergeAuthoritativeLinkPreviews(result, incoming);
 }
 
 export interface TimelineBuildOptions {
@@ -313,6 +327,7 @@ export function buildChannelTimelineFromMamResults(params: {
       || msg.isRetracted
       || (msg.sharedFiles && msg.sharedFiles.length > 0)
       || msg.isSticker
+      || (msg.linkPreviews && msg.linkPreviews.length > 0)
       || msg.replyTo
       || msg.forumPostKind
       || (msg.extensionAnnotations && msg.extensionAnnotations.length > 0)

--- a/chat/src/channels/muc-send.ts
+++ b/chat/src/channels/muc-send.ts
@@ -8,6 +8,7 @@ import type { OutboundFileAttachment } from "@/lib/xmpp";
 import {
   inferredFileDisposition,
   type DeliveryStatus,
+  type LinkPreview,
   type MarkupSpan,
   type MessageReference,
   type TimelineMessage,
@@ -161,10 +162,23 @@ export function useMucSend(deps: UseMucSendDeps) {
       const threadReply = channelIsForum && replyTo && threadId
         ? { threadId }
         : undefined;
+      const linkPreview = typeof client.lookupLinkPreview === "function"
+        ? await client.lookupLinkPreview(bodyText, currentRoomJid.value ?? channelId)
+        : null;
+      const linkPreviews: LinkPreview[] = linkPreview && linkPreview.status === "ready"
+        ? [{
+            originalUrl: linkPreview.originalUrl,
+            normalizedUrl: linkPreview.normalizedUrl,
+            ...(linkPreview.title ? { title: linkPreview.title } : {}),
+            ...(linkPreview.description ? { description: linkPreview.description } : {}),
+          }]
+        : [];
       const result = await client.sendGroupMessage(spaceId, channelId, bodyText, {
         markup,
         references,
         files: attachments,
+        ...(linkPreview?.token ? { linkPreviewToken: linkPreview.token } : {}),
+        ...(linkPreview?.expiresAt ? { linkPreviewExpiresAt: linkPreview.expiresAt } : {}),
         ...(wireReplyTo ? { replyTo: wireReplyTo } : {}),
         ...(threadId ? { threadId } : {}),
         ...(parentThreadId ? { parentThreadId } : {}),
@@ -192,6 +206,7 @@ export function useMucSend(deps: UseMucSendDeps) {
           deliveryStatus: (result?.state ?? "sending") as DeliveryStatus,
           ...(markup && markup.length > 0 ? { markup } : {}),
           ...(references && references.length > 0 ? { references } : {}),
+          ...(linkPreviews.length > 0 ? { linkPreviews } : {}),
         };
         if (replyTo && parent && parent.replyableId) {
           // Mirror the wire reply id on the optimistic insert so the local

--- a/chat/src/channels/timeline.ts
+++ b/chat/src/channels/timeline.ts
@@ -29,6 +29,7 @@ export function mapLiveRoomMessageToTimeline(
   if (msg.wireIds && msg.wireIds.length > 0) tm.wireIds = msg.wireIds;
   if (msg.mentions && msg.mentions.length > 0) tm.mentions = msg.mentions;
   if (msg.sharedFiles && msg.sharedFiles.length > 0) tm.sharedFiles = msg.sharedFiles;
+  if (msg.linkPreviews && msg.linkPreviews.length > 0) tm.linkPreviews = msg.linkPreviews;
   if (msg.extensionAnnotations && msg.extensionAnnotations.length > 0) {
     tm.extensionAnnotations = msg.extensionAnnotations;
   }

--- a/chat/src/components/chat/MessageBody.vue
+++ b/chat/src/components/chat/MessageBody.vue
@@ -67,6 +67,7 @@ const {
 } = useMessageAttachments(messageRef);
 
 const extensionAnnotations = computed(() => props.message.extensionAnnotations ?? []);
+const linkPreviews = computed(() => props.message.linkPreviews ?? []);
 const extensionCards = computed(() =>
   extensionAnnotations.value.map((annotation) => ({
     annotation,
@@ -95,6 +96,23 @@ const toolActionChips = computed<ToolActionChip[]>(() => {
   }
   return chips;
 });
+
+function linkPreviewHost(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}
+
+function linkPreviewHref(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" ? parsed.toString() : null;
+  } catch {
+    return null;
+  }
+}
 
 const {
   actionState: extensionActionState,
@@ -195,6 +213,23 @@ watch(
          Tool-intent annotations from ANY number of extensions collapse
          into a single horizontal action-chip strip beneath this block.
          No fat boxes fanning out below the message. -->
+    <a
+      v-for="preview in linkPreviews"
+      :key="`${preview.originalUrl}:${preview.normalizedUrl ?? ''}`"
+      :href="linkPreviewHref(preview.originalUrl) ?? undefined"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="flex max-w-xl flex-col gap-1 rounded-md border border-border bg-muted/40 p-3 text-left transition-colors hover:border-primary/50 hover:bg-muted/60"
+      @click.stop
+    >
+      <span class="type-meta flex items-center gap-1 text-muted-foreground">
+        <ExternalLink aria-hidden="true" class="h-3.5 w-3.5" />
+        {{ linkPreviewHost(preview.originalUrl) }}
+      </span>
+      <span v-if="preview.title" class="type-field text-foreground">{{ preview.title }}</span>
+      <span v-if="preview.description" class="type-caption line-clamp-2 text-muted-foreground">{{ preview.description }}</span>
+    </a>
+
     <section
       v-for="card in eventCards"
       :key="`${card.annotation.extensionId}:${card.annotation.annotationId}`"
@@ -220,7 +255,7 @@ watch(
           v-if="card.presentation.primaryUrl && !compact"
           :href="card.presentation.primaryUrl"
           target="_blank"
-          rel="noreferrer"
+          rel="noopener noreferrer"
           class="chat-system-band__title-link"
           @click.stop
         >

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -794,7 +794,7 @@ onBeforeUnmount(() => {
           v-if="card.presentation.primaryUrl"
           :href="card.presentation.primaryUrl"
           target="_blank"
-          rel="noreferrer"
+          rel="noopener noreferrer"
           class="chat-system-band__title-link"
           @click.stop
         >

--- a/chat/src/dms/chat-send.ts
+++ b/chat/src/dms/chat-send.ts
@@ -6,6 +6,7 @@ import type { OutboundFileAttachment } from "@/lib/xmpp";
 import {
   inferredFileDisposition,
   type DeliveryStatus,
+  type LinkPreview,
   type MarkupSpan,
   type MessageReference,
   type TimelineMessage,
@@ -107,10 +108,23 @@ export function useChatSend(deps: UseChatSendDeps) {
           }
         : undefined;
       const threadId = parent ? (parent.threadId ?? parent.id) : undefined;
+      const linkPreview = typeof client.lookupLinkPreview === "function"
+        ? await client.lookupLinkPreview(bodyText, peerJid)
+        : null;
+      const linkPreviews: LinkPreview[] = linkPreview && linkPreview.status === "ready"
+        ? [{
+            originalUrl: linkPreview.originalUrl,
+            normalizedUrl: linkPreview.normalizedUrl,
+            ...(linkPreview.title ? { title: linkPreview.title } : {}),
+            ...(linkPreview.description ? { description: linkPreview.description } : {}),
+          }]
+        : [];
       const result = await client.sendDirectMessage(peerJid, bodyText, {
         markup,
         references,
         files: attachments,
+        ...(linkPreview?.token ? { linkPreviewToken: linkPreview.token } : {}),
+        ...(linkPreview?.expiresAt ? { linkPreviewExpiresAt: linkPreview.expiresAt } : {}),
         ...(wireReplyTo ? { replyTo: wireReplyTo } : {}),
         ...(threadId ? { threadId } : {}),
       });
@@ -131,6 +145,7 @@ export function useChatSend(deps: UseChatSendDeps) {
             deliveryStatus: (result?.state ?? "sending") as DeliveryStatus,
             ...(markup && markup.length > 0 ? { markup } : {}),
             ...(references && references.length > 0 ? { references } : {}),
+            ...(linkPreviews.length > 0 ? { linkPreviews } : {}),
           };
           if (replyTo && parent) {
             optimistic.replyTo = {

--- a/chat/src/dms/live-merge.ts
+++ b/chat/src/dms/live-merge.ts
@@ -190,6 +190,9 @@ export function useDmLiveMerge(deps: UseDmLiveMergeDeps) {
           createdAt: authoritativeTimestamp.createdAt,
           createdAtSource: authoritativeTimestamp.createdAtSource,
         };
+        if (!Object.prototype.hasOwnProperty.call(msg, "linkPreviews")) {
+          delete updated.linkPreviews;
+        }
         if (mergedIds.wireIds?.length) updated.wireIds = mergedIds.wireIds;
         else delete updated.wireIds;
         if (m.isSelf && msg.isSelf) {

--- a/chat/src/dms/message-timeline-state.ts
+++ b/chat/src/dms/message-timeline-state.ts
@@ -36,6 +36,7 @@ export function fromLiveDmMessage(
   if (msg.markup?.length) tm.markup = msg.markup;
   if (msg.references?.length) tm.references = msg.references;
   if (msg.sharedFiles && msg.sharedFiles.length > 0) tm.sharedFiles = msg.sharedFiles;
+  if (msg.linkPreviews && msg.linkPreviews.length > 0) tm.linkPreviews = msg.linkPreviews;
   if (msg.extensionAnnotations && msg.extensionAnnotations.length > 0) tm.extensionAnnotations = msg.extensionAnnotations;
   if (msg.extensionBodyFallback) tm.extensionBodyFallback = true;
   if (msg.isSticker) tm.isSticker = true;
@@ -110,6 +111,7 @@ export function retractDmTimelineMessage(
   delete next.markup;
   delete next.references;
   delete next.sharedFiles;
+  delete next.linkPreviews;
   delete next.extensionAnnotations;
   delete next.extensionBodyFallback;
   delete next.isSticker;
@@ -146,7 +148,16 @@ function mergeDmRetractionTombstone(
       createdAtSource: authoritativeTimestamp.createdAtSource,
     };
   }
-  return result;
+  if (incoming.isRetracted) return result;
+  if (Object.prototype.hasOwnProperty.call(incoming, "linkPreviews")) {
+    return { ...result, linkPreviews: incoming.linkPreviews };
+  }
+  if (!result.linkPreviews) {
+    return result;
+  }
+  const next = { ...result };
+  delete next.linkPreviews;
+  return next;
 }
 
 export function buildDmTimelineFromMamResults(params: {
@@ -187,6 +198,7 @@ export function buildDmTimelineFromMamResults(params: {
       || msg.isRetracted
       || (msg.sharedFiles && msg.sharedFiles.length > 0)
       || msg.isSticker
+      || (msg.linkPreviews && msg.linkPreviews.length > 0)
       || (msg.extensionAnnotations && msg.extensionAnnotations.length > 0)
     ) {
       regular.push(msg);

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -41,6 +41,13 @@ export interface TimelineSharedFile {
   encrypted?: WaddleEncryptedFile;
 }
 
+export interface LinkPreview {
+  originalUrl: string;
+  normalizedUrl?: string;
+  title?: string;
+  description?: string;
+}
+
 export type ExtensionSurfaceKind =
   | "message-card"
   | "board"
@@ -184,6 +191,8 @@ export interface TimelineMessage {
   isSticker?: boolean;
   /** XEP-0446/0447: Shared files (zero or more attachments). */
   sharedFiles?: TimelineSharedFile[];
+  /** XEP-0511: Link preview metadata stamped into the message payload. */
+  linkPreviews?: LinkPreview[];
   /** Waddle unified extension framework annotations. */
   extensionAnnotations?: ExtensionAnnotation[];
   /** XEP-0428: message body is fallback text for the Waddle extension payload. */

--- a/chat/src/lib/outbound-queue-store.ts
+++ b/chat/src/lib/outbound-queue-store.ts
@@ -95,7 +95,14 @@ function readQueue(accountKey: string): PersistedQueuedMessage[] {
     if (!raw) return [];
     const parsed = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
-    const all = sortQueue(parsed.filter(isPersistedQueuedMessage));
+    const persisted = parsed.filter(isPersistedQueuedMessage);
+    const strippedLegacyPreviewTokens = persisted.some(
+      (entry) =>
+        "linkPreviewToken" in (entry as unknown as Record<string, unknown>)
+        || "linkPreviewExpiresAt" in (entry as unknown as Record<string, unknown>),
+    );
+    const all = sortQueue(persisted.map(stripLegacyPreviewToken));
+    if (strippedLegacyPreviewTokens) writeQueue(accountKey, all);
     return pruneStaleEntries(s, accountKey, all);
   } catch (err) {
     // Storage read failure usually means corrupt JSON or privacy-mode
@@ -108,6 +115,15 @@ function readQueue(accountKey: string): PersistedQueuedMessage[] {
     });
     return [];
   }
+}
+
+function stripLegacyPreviewToken(message: PersistedQueuedMessage): PersistedQueuedMessage {
+  const { linkPreviewToken: _token, linkPreviewExpiresAt: _expiresAt, ...rest } =
+    message as PersistedQueuedMessage & {
+      linkPreviewToken?: unknown;
+      linkPreviewExpiresAt?: unknown;
+    };
+  return rest;
 }
 
 /**

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -112,6 +112,7 @@ import {
   type SendDirectMessageOptions,
   type SendGroupMessageOptions,
 } from "./send-types";
+import { requestPlaintextLinkPreviewLookup, type LinkPreviewLookupResult } from "./link-preview";
 import {
   avatarDataUrl,
   buildWasmSendOptions,
@@ -1335,6 +1336,16 @@ export class BrowserXmppClient {
     throw new Error("XMPP session is not ready");
   }
 
+  private async queuedLinkPreviewOptions(body: string, scopeJid: string): Promise<Pick<SendDirectMessageOptions, "linkPreviewToken" | "linkPreviewExpiresAt">> {
+    const preview = await this.lookupLinkPreview(body, scopeJid);
+    return preview?.token
+      ? {
+          linkPreviewToken: preview.token,
+          ...(preview.expiresAt ? { linkPreviewExpiresAt: preview.expiresAt } : {}),
+        }
+      : {};
+  }
+
   // XEP-0201 §3: chat-states, displayed markers, reactions, retractions, and
   // corrections that relate to a threaded message SHOULD repeat the original
   // `<thread/>`. The wasm bindings accept thread id + optional parent so the
@@ -1393,7 +1404,8 @@ export class BrowserXmppClient {
         if (!this.canUseConnectedSession() || !this.xmpp) break;
         if (this.inflightQueuedIds.has(entry.id)) continue;
         this.queuedMessageStatusHandler?.(entry.id, "sending");
-        const messageId = await this.compatSendDirectMessage(this.xmpp, barePeerJid(entry.peerJid), entry.body, { ...(entry.markup?.length ? { markup: entry.markup } : {}), ...(entry.references?.length ? { references: entry.references } : {}), ...(entry.files?.length ? { files: entry.files } : {}), ...(entry.replyTo ? { replyTo: entry.replyTo } : {}), ...(entry.threadId ? { threadId: entry.threadId } : {}), ...(entry.parentThreadId ? { parentThreadId: entry.parentThreadId } : {}), id: entry.id });
+        const linkPreviewOptions = await this.queuedLinkPreviewOptions(entry.body, barePeerJid(entry.peerJid));
+        const messageId = await this.compatSendDirectMessage(this.xmpp, barePeerJid(entry.peerJid), entry.body, { ...(entry.markup?.length ? { markup: entry.markup } : {}), ...(entry.references?.length ? { references: entry.references } : {}), ...(entry.files?.length ? { files: entry.files } : {}), ...linkPreviewOptions, ...(entry.replyTo ? { replyTo: entry.replyTo } : {}), ...(entry.threadId ? { threadId: entry.threadId } : {}), ...(entry.parentThreadId ? { parentThreadId: entry.parentThreadId } : {}), id: entry.id });
         if (messageId) { this.inflightQueuedIds.add(entry.id); this.recordPendingSend(entry.id, "dm"); }
       }
     })();
@@ -1411,7 +1423,8 @@ export class BrowserXmppClient {
         if (!this.roomIsReady(roomJid) || !this.xmpp) break;
         if (this.inflightQueuedIds.has(entry.id)) continue;
         this.queuedMessageStatusHandler?.(entry.id, "sending");
-        const messageId = await this.compatSendGroupMessage(this.xmpp, roomJid, entry.body, { ...(entry.markup?.length ? { markup: entry.markup } : {}), ...(entry.references?.length ? { references: entry.references } : {}), mentionJidsByNick: { ...(entry.mentionJidsByNick ?? {}), ...this.memberJidsFor(roomJid) }, ...(entry.files?.length ? { files: entry.files } : {}), ...(entry.replyTo ? { replyTo: entry.replyTo } : {}), ...(entry.threadId ? { threadId: entry.threadId } : {}), ...(entry.parentThreadId ? { parentThreadId: entry.parentThreadId } : {}), ...(entry.threadCreate ? { threadCreate: entry.threadCreate } : {}), ...(entry.threadReply ? { threadReply: entry.threadReply } : {}), id: entry.id });
+        const linkPreviewOptions = await this.queuedLinkPreviewOptions(entry.body, roomJid);
+        const messageId = await this.compatSendGroupMessage(this.xmpp, roomJid, entry.body, { ...(entry.markup?.length ? { markup: entry.markup } : {}), ...(entry.references?.length ? { references: entry.references } : {}), mentionJidsByNick: { ...(entry.mentionJidsByNick ?? {}), ...this.memberJidsFor(roomJid) }, ...(entry.files?.length ? { files: entry.files } : {}), ...linkPreviewOptions, ...(entry.replyTo ? { replyTo: entry.replyTo } : {}), ...(entry.threadId ? { threadId: entry.threadId } : {}), ...(entry.parentThreadId ? { parentThreadId: entry.parentThreadId } : {}), ...(entry.threadCreate ? { threadCreate: entry.threadCreate } : {}), ...(entry.threadReply ? { threadReply: entry.threadReply } : {}), id: entry.id });
         if (messageId) { this.inflightQueuedIds.add(entry.id); this.recordPendingSend(entry.id, "room"); }
       }
     })();
@@ -1437,6 +1450,10 @@ export class BrowserXmppClient {
     const queued = this.queueRoomMessage(roomJid, body, opts);
     void this.connect().then(() => this.switchRoom(spaceId, channelId)).then(() => this.flushQueuedRoomMessages(roomJid)).catch(() => undefined);
     return queued;
+  }
+
+  async lookupLinkPreview(body: string, scopeJid: string): Promise<LinkPreviewLookupResult | null> {
+    return requestPlaintextLinkPreviewLookup(this.xmpp, body, scopeJid);
   }
 
   async sendDirectMessage(peerJid: string, body: string, opts: SendDirectMessageOptions = {}): Promise<OutboundSendResult | null> {

--- a/chat/src/lib/xmpp/link-preview.ts
+++ b/chat/src/lib/xmpp/link-preview.ts
@@ -1,0 +1,156 @@
+export type LinkPreviewLookupStatus = "ready" | "not_found";
+
+export interface LinkPreviewLookupResult {
+  token: string;
+  originalUrl: string;
+  normalizedUrl: string;
+  status: LinkPreviewLookupStatus;
+  expiresAt: string;
+  title?: string;
+  description?: string;
+}
+
+const HTTPS_URL_RE = /https:\/\/[^\s<>"']+/gi;
+const NS_WADDLE_LINK_PREVIEW = "urn:waddle:link-preview:0";
+const LOOKUP_TIMEOUT_MS = 2_000;
+
+type LinkPreviewIqClient = {
+  send_raw_iq?: (xml: string) => Promise<string>;
+  cancel_raw_iq?: (id: string) => Promise<void>;
+};
+
+export function firstEligibleHttpsUrl(body: string): string | null {
+  HTTPS_URL_RE.lastIndex = 0;
+  for (const match of body.matchAll(HTTPS_URL_RE)) {
+    const raw = trimTrailingUrlPunctuation(match[0] ?? "");
+    try {
+      const url = new URL(raw);
+      if (url.protocol === "https:" && url.hostname.includes(".")) return raw;
+    } catch {
+      // Keep scanning; malformed URL-like text is not eligible.
+    }
+  }
+  return null;
+}
+
+export async function requestPlaintextLinkPreviewLookup(
+  client: LinkPreviewIqClient | null | undefined,
+  body: string,
+  scopeJid: string,
+): Promise<LinkPreviewLookupResult | null> {
+  const originalUrl = firstEligibleHttpsUrl(body);
+  const trimmedScopeJid = scopeJid.trim();
+  if (!originalUrl || !trimmedScopeJid || typeof client?.send_raw_iq !== "function") return null;
+
+  const id = crypto.randomUUID();
+  const iq = buildLookupIqStanza(id, originalUrl, trimmedScopeJid);
+  if (!iq) return null;
+  let response: string;
+  try {
+    response = await withLookupTimeout(
+      client.send_raw_iq(iq),
+      () => client.cancel_raw_iq?.(id),
+    );
+  } catch {
+    return null;
+  }
+  return parseLookupResponse(response);
+}
+
+function parseLookupResponse(xml: string): LinkPreviewLookupResult | null {
+  const doc = new DOMParser().parseFromString(xml, "text/xml");
+  const lookup = doc.getElementsByTagNameNS(NS_WADDLE_LINK_PREVIEW, "lookup")[0];
+  if (!lookup) return null;
+  const status = lookup.getAttribute("status");
+  if (status !== "ready") return null;
+  const preview = Array.from(lookup.children).find(
+    (child) => child.localName === "preview" && child.namespaceURI === NS_WADDLE_LINK_PREVIEW,
+  );
+  if (!preview) return null;
+  const token = preview.getAttribute("token")?.trim();
+  const originalUrl = preview.getAttribute("original-url")?.trim();
+  const normalizedUrl = preview.getAttribute("normalized-url")?.trim();
+  const expiresAt = preview.getAttribute("expires-at")?.trim();
+  if (!token || !originalUrl || !normalizedUrl || !expiresAt) return null;
+  if (!isEligiblePreviewUrl(originalUrl) || !isEligiblePreviewUrl(normalizedUrl)) return null;
+  return {
+    token,
+    originalUrl,
+    normalizedUrl,
+    status: "ready",
+    expiresAt,
+    ...childText(preview, "title"),
+    ...childText(preview, "description"),
+  };
+}
+
+function isEligiblePreviewUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" && url.hostname.includes(".");
+  } catch {
+    return false;
+  }
+}
+
+function trimTrailingUrlPunctuation(url: string): string {
+  return url.replace(/^[([<{]+/g, "").replace(/[)\]}>.,!?;:]+$/g, "");
+}
+
+function buildLookupIqStanza(id: string, originalUrl: string, scopeJid: string): string | null {
+  const doc = newXmlDocument("iq");
+  if (!doc) return null;
+
+  const iq = doc.documentElement;
+  iq.setAttribute("type", "get");
+  iq.setAttribute("id", id);
+
+  const lookup = doc.createElementNS(NS_WADDLE_LINK_PREVIEW, "lookup");
+  appendTextElement(doc, lookup, "url", originalUrl);
+  appendTextElement(doc, lookup, "scope", scopeJid);
+  iq.appendChild(lookup);
+
+  return new XMLSerializer().serializeToString(iq);
+}
+
+function newXmlDocument(rootName: string): XMLDocument | null {
+  if (typeof document === "undefined" || typeof XMLSerializer === "undefined") return null;
+  return document.implementation.createDocument("", rootName);
+}
+
+function appendTextElement(doc: XMLDocument, parent: Element, name: string, value: string): void {
+  const child = doc.createElementNS(NS_WADDLE_LINK_PREVIEW, name);
+  child.appendChild(doc.createTextNode(value));
+  parent.appendChild(child);
+}
+
+async function withLookupTimeout(raw: Promise<string>, cancel: () => void | Promise<void> | undefined): Promise<string> {
+  let didTimeout = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      didTimeout = true;
+      reject(new Error("link preview lookup timed out"));
+    }, LOOKUP_TIMEOUT_MS);
+  });
+  try {
+    return await Promise.race([raw, timeout]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+    if (didTimeout) {
+      try {
+        await cancel();
+      } catch {
+        // Best effort only; link-preview lookup must never block message send.
+      }
+    }
+  }
+}
+
+function childText(parent: Element, name: "title" | "description"): Partial<LinkPreviewLookupResult> {
+  const value = Array.from(parent.children)
+    .find((child) => child.localName === name && child.namespaceURI === NS_WADDLE_LINK_PREVIEW)
+    ?.textContent
+    ?.trim();
+  return value ? { [name]: value } : {};
+}

--- a/chat/src/lib/xmpp/send-types.ts
+++ b/chat/src/lib/xmpp/send-types.ts
@@ -47,6 +47,8 @@ export interface SendGroupMessageOptions {
   references?: MessageReference[];
   mentionJidsByNick?: Readonly<Record<string, string>>;
   files?: OutboundFileAttachment[];
+  linkPreviewToken?: string;
+  linkPreviewExpiresAt?: string;
   replyTo?: ReplyTarget;
   threadId?: string;
   parentThreadId?: string;
@@ -59,6 +61,8 @@ export interface SendDirectMessageOptions {
   markup?: MarkupSpan[];
   references?: MessageReference[];
   files?: OutboundFileAttachment[];
+  linkPreviewToken?: string;
+  linkPreviewExpiresAt?: string;
   replyTo?: ReplyTarget;
   threadId?: string;
   parentThreadId?: string;

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -127,6 +127,8 @@ export interface LiveRoomMessage {
   references?: import("@/lib/chat-ui").MessageReference[];
   /** XEP-0446/0447 — zero or more attachments. */
   sharedFiles?: SharedFileInfo[];
+  /** XEP-0511 */
+  linkPreviews?: import("@/lib/chat-ui").LinkPreview[];
   /** Waddle unified extension framework annotations. */
   extensionAnnotations?: ExtensionAnnotation[];
   /** XEP-0428: message body is fallback text for the Waddle extension payload. */
@@ -190,6 +192,8 @@ export interface LiveDmMessage {
   /** XEP-0372 */
   references?: import("@/lib/chat-ui").MessageReference[];
   sharedFiles?: SharedFileInfo[];
+  /** XEP-0511 */
+  linkPreviews?: import("@/lib/chat-ui").LinkPreview[];
   extensionAnnotations?: ExtensionAnnotation[];
   extensionBodyFallback?: boolean;
   isSticker?: boolean;

--- a/chat/src/lib/xmpp/wasm-message-codecs.ts
+++ b/chat/src/lib/xmpp/wasm-message-codecs.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAnnotation, ExtensionLaunchDescriptor, ExtensionPayloadElement } from "@/lib/chat-ui";
+import type { ExtensionAnnotation, ExtensionLaunchDescriptor, ExtensionPayloadElement, LinkPreview } from "@/lib/chat-ui";
 import type { MarkupSpan, MessageReference } from "@/lib/rich-message";
 import type { RichInlineStyle } from "@/lib/rich-message/types";
 
@@ -24,6 +24,7 @@ import type {
   WasmPresence,
   WasmReference,
   WasmSendOptions,
+  WasmLinkPreview,
   WasmSharedFile,
 } from "./wasm-types";
 
@@ -144,6 +145,15 @@ function sharedFileFromWasm(file: WasmSharedFile): SharedFileInfo {
     ...(typeof file.width === "number" ? { width: file.width } : {}),
     ...(typeof file.height === "number" ? { height: file.height } : {}),
     ...(file.encrypted ? { encrypted: encryptedFromWasm(file.encrypted) } : {}),
+  };
+}
+
+function linkPreviewFromWasm(preview: WasmLinkPreview): LinkPreview {
+  return {
+    originalUrl: preview.original_url,
+    ...(preview.normalized_url ? { normalizedUrl: preview.normalized_url } : {}),
+    ...(preview.title ? { title: preview.title } : {}),
+    ...(preview.description ? { description: preview.description } : {}),
   };
 }
 
@@ -380,19 +390,20 @@ export function roomMessageFromArchived(
     };
   }
   const sharedFiles = message.shared_files ?? [];
+  const linkPreviews = message.link_previews ?? [];
   const mentionUris = message.mention_uris ?? [];
   const markupSpans = message.markup_spans ?? [];
   const references = message.references ?? [];
   const extensionAnnotations = extensionAnnotationsFromWasm(message.extension_envelope);
   // XEP-0201 `<thread/>` is scope metadata, not content. A stanza that
   // carries only a thread reference (no body, no subject, no attachments,
-  // no extension annotations, no forum-post payload, not a retraction)
+  // no link preview, no extension annotations, no forum-post payload, not a retraction)
   // is a chat-state / displayed-marker / etc. echoed inside a thread per
   // XEP-0201 §3 — it MUST drop here so it never materialises as an empty
   // row inside the thread panel. The server-side `is_archivable` already
   // refuses to persist these; this is the defence-in-depth pass for
   // foreign servers and legacy archive rows.
-  if (!message.body && !message.subject && !sharedFiles.length && !extensionAnnotations.length && !message.forum_post_kind && !message.is_retracted) {
+  if (!message.body && !message.subject && !sharedFiles.length && !linkPreviews.length && !extensionAnnotations.length && !message.forum_post_kind && !message.is_retracted) {
     return null;
   }
   const base: LiveRoomMessage = {
@@ -426,6 +437,7 @@ export function roomMessageFromArchived(
       : {}),
     ...(references.length ? { references: references.map(referenceFromWasm) } : {}),
     ...(sharedFiles.length ? { sharedFiles: sharedFiles.map(sharedFileFromWasm) } : {}),
+    ...(linkPreviews.length ? { linkPreviews: linkPreviews.map(linkPreviewFromWasm) } : {}),
     ...(extensionAnnotations.length ? { extensionAnnotations } : {}),
     ...(message.extension_body_fallback && extensionAnnotations.length ? { extensionBodyFallback: true } : {}),
     ...(message.is_sticker ? { isSticker: true } : {}),
@@ -487,6 +499,7 @@ export function dmMessageFromArchived(
     };
   }
   const sharedFiles = message.shared_files ?? [];
+  const linkPreviews = message.link_previews ?? [];
   const mentionUris = message.mention_uris ?? [];
   const markupSpans = message.markup_spans ?? [];
   const references = message.references ?? [];
@@ -497,7 +510,7 @@ export function dmMessageFromArchived(
   // metadata, not content. DMs don't currently surface threads in the UI
   // anyway, but the codec stays symmetric with the room path so a stray
   // foreign-server archive row can't manifest a bodyless DM ghost either.
-  if (!message.body && !message.subject && !sharedFiles.length && !extensionAnnotations.length && !message.is_retracted) return null;
+  if (!message.body && !message.subject && !sharedFiles.length && !linkPreviews.length && !extensionAnnotations.length && !message.is_retracted) return null;
   const base: LiveDmMessage = {
     id: dmPrimaryId,
     archiveId: message.mam_id,
@@ -523,6 +536,7 @@ export function dmMessageFromArchived(
       : {}),
     ...(references.length ? { references: references.map(referenceFromWasm) } : {}),
     ...(sharedFiles.length ? { sharedFiles: sharedFiles.map(sharedFileFromWasm) } : {}),
+    ...(linkPreviews.length ? { linkPreviews: linkPreviews.map(linkPreviewFromWasm) } : {}),
     ...(extensionAnnotations.length ? { extensionAnnotations } : {}),
     ...(message.extension_body_fallback && extensionAnnotations.length ? { extensionBodyFallback: true } : {}),
     ...(message.is_sticker ? { isSticker: true } : {}),
@@ -576,6 +590,9 @@ export function buildWasmSendOptions(
     wasmOpts.thread = { id: maybeGroupOpts.threadReply.threadId, parent: maybeGroupOpts.parentThreadId };
   } else if (opts.threadId) {
     wasmOpts.thread = { id: opts.threadId, ...(opts.parentThreadId ? { parent: opts.parentThreadId } : {}) };
+  }
+  if (opts.linkPreviewToken?.trim()) {
+    wasmOpts.link_preview_token = opts.linkPreviewToken.trim();
   }
   if (opts.files?.length) {
     wasmOpts.shared_files = opts.files.map((file) => ({

--- a/chat/src/lib/xmpp/wasm-types.ts
+++ b/chat/src/lib/xmpp/wasm-types.ts
@@ -137,11 +137,19 @@ export interface WasmMessage {
   forum_thread_title?: string;
   is_sticker: boolean;
   shared_files: WasmSharedFile[];
+  link_previews: WasmLinkPreview[];
   call_event?: CallEvent;
   extension_envelope?: WasmExtensionEnvelope;
   extension_body_fallback?: boolean;
   /** urn:waddle:pin:0 pin/unpin event surfaced by the room (#414). */
   pin_event?: WasmPinEvent;
+}
+
+export interface WasmLinkPreview {
+  original_url: string;
+  normalized_url?: string | null;
+  title?: string | null;
+  description?: string | null;
 }
 
 /** Pin/unpin event from a room system message (#414). */
@@ -355,6 +363,7 @@ export interface WasmSendOptions {
   reply?: { author_jid: string; message_id: string };
   fallback?: { start: number; end: number };
   thread?: { id: string; parent?: string };
+  link_preview_token?: string;
   shared_files?: Array<{
     url: string;
     name?: string;

--- a/chat/tests/channel-live-merge.test.ts
+++ b/chat/tests/channel-live-merge.test.ts
@@ -368,4 +368,32 @@ describe("mergeLiveMessage self-echo reconciliation", () => {
     expect(h.messages.value[0]?.body).toBe("canonical body");
     expect(h.messages.value[0]?.extensionAnnotations?.[0]?.annotationId).toBe("a1");
   });
+
+  test("clears optimistic link preview when authoritative self-echo has none", () => {
+    const h = harness();
+    h.messages.value = [
+      {
+        id: "client-id",
+        wireIds: ["server-id"],
+        body: "read https://example.com",
+        nick: "alice",
+        isSelf: true,
+        deliveryStatus: "sending",
+        linkPreviews: [{ originalUrl: "https://example.com", title: "Example" }],
+        createdAt: "2026-05-14T10:36:55.000Z",
+      } as TimelineMessage,
+    ];
+
+    h.liveMerge.mergeLiveMessage({
+      id: "server-id",
+      body: "read https://example.com",
+      nick: "alice",
+      isSelf: true,
+      createdAt: "2026-05-14T10:36:56.000Z",
+    } as TimelineMessage);
+
+    expect(h.messages.value).toHaveLength(1);
+    expect(h.messages.value[0]?.deliveryStatus).toBe("delivered");
+    expect(h.messages.value[0]?.linkPreviews).toBeUndefined();
+  });
 });

--- a/chat/tests/chat-send.test.ts
+++ b/chat/tests/chat-send.test.ts
@@ -73,6 +73,34 @@ describe("useChatSend.sendMessage — happy path", () => {
     expect(h.send.isSending.value).toBe(false);
     expect(h.onSendComplete).toHaveBeenCalledTimes(1);
   });
+
+  test("looks up first eligible HTTPS URL and sends scoped preview token", async () => {
+    const sendDirectMessage = mock(async () => ({ id: "dm-link", state: "sending" }));
+    const lookupLinkPreview = mock(async () => ({
+      token: "preview-token-1",
+      originalUrl: "https://example.com/article",
+      normalizedUrl: "https://example.com/article",
+      status: "ready" as const,
+      expiresAt: "2026-06-01T12:05:00.000Z",
+      title: "Example Article",
+      description: "Plain text summary",
+    }));
+    const client = makeClient({ sendDirectMessage, lookupLinkPreview } as Partial<BrowserXmppClient>);
+    const h = harness({ client, draft: "read https://example.com/article" });
+
+    await h.send.sendMessage(undefined, []);
+
+    expect(lookupLinkPreview).toHaveBeenCalledWith("read https://example.com/article", "bob@example.com");
+    const call = (sendDirectMessage as unknown as ReturnType<typeof mock>).mock.calls[0]!;
+    expect(call[2].linkPreviewToken).toBe("preview-token-1");
+    expect(call[2].linkPreviewExpiresAt).toBe("2026-06-01T12:05:00.000Z");
+    expect(h.messages.value[0]?.linkPreviews).toEqual([{
+      originalUrl: "https://example.com/article",
+      normalizedUrl: "https://example.com/article",
+      title: "Example Article",
+      description: "Plain text summary",
+    }]);
+  });
 });
 
 describe("useChatSend.sendMessage — guards", () => {

--- a/chat/tests/dm-live-merge.test.ts
+++ b/chat/tests/dm-live-merge.test.ts
@@ -272,4 +272,32 @@ describe("mergeLiveMessage self-echo reconciliation", () => {
     expect(h.messages.value[0]?.body).toBe("canonical body");
     expect(h.messages.value[0]?.extensionAnnotations?.[0]?.annotationId).toBe("a1");
   });
+
+  test("clears optimistic link preview when authoritative self-echo has none", () => {
+    const h = harness();
+    h.messages.value = [
+      {
+        id: "client-id",
+        wireIds: ["server-id"],
+        body: "read https://example.com",
+        nick: "alice",
+        isSelf: true,
+        deliveryStatus: "sending",
+        linkPreviews: [{ originalUrl: "https://example.com", title: "Example" }],
+        createdAt: "2026-05-14T10:36:55.000Z",
+      } as TimelineMessage,
+    ];
+
+    h.liveMerge.mergeLiveMessage({
+      id: "server-id",
+      body: "read https://example.com",
+      nick: "alice",
+      isSelf: true,
+      createdAt: "2026-05-14T10:36:56.000Z",
+    } as TimelineMessage);
+
+    expect(h.messages.value).toHaveLength(1);
+    expect(h.messages.value[0]?.deliveryStatus).toBe("delivered");
+    expect(h.messages.value[0]?.linkPreviews).toBeUndefined();
+  });
 });

--- a/chat/tests/helpers/disco-xml.ts
+++ b/chat/tests/helpers/disco-xml.ts
@@ -42,6 +42,23 @@ export async function withFakeDomParser(run: () => Promise<void>): Promise<void>
   }
 }
 
+export async function withFakeXmlDocument(run: () => Promise<void>): Promise<void> {
+  const originalDocument = globalThis.document;
+  const originalXmlSerializer = globalThis.XMLSerializer;
+  globalThis.document = {
+    implementation: {
+      createDocument: (_namespace: string, rootName: string) => new FakeStructuredXmlDocument(rootName),
+    },
+  } as unknown as Document;
+  globalThis.XMLSerializer = FakeXmlSerializer as typeof XMLSerializer;
+  try {
+    await run();
+  } finally {
+    globalThis.document = originalDocument;
+    globalThis.XMLSerializer = originalXmlSerializer;
+  }
+}
+
 class FakeDOMParser {
   parseFromString(xml: string): Document {
     return parseTestXml(xml) as unknown as Document;
@@ -120,4 +137,75 @@ function attributesFromTag(tagBody: string): Record<string, string> {
     attrs[match[1]] = match[2];
   }
   return attrs;
+}
+
+class FakeStructuredXmlDocument {
+  readonly documentElement: FakeStructuredXmlElement;
+
+  constructor(rootName: string) {
+    this.documentElement = new FakeStructuredXmlElement(rootName, null);
+  }
+
+  createElementNS(namespaceURI: string, name: string): FakeStructuredXmlElement {
+    return new FakeStructuredXmlElement(name, namespaceURI);
+  }
+
+  createTextNode(value: string): FakeStructuredXmlText {
+    return new FakeStructuredXmlText(value);
+  }
+}
+
+class FakeStructuredXmlElement {
+  readonly attrs: Record<string, string> = {};
+  readonly children: Array<FakeStructuredXmlElement | FakeStructuredXmlText> = [];
+
+  constructor(
+    readonly localName: string,
+    readonly namespaceURI: string | null,
+  ) {}
+
+  setAttribute(name: string, value: string): void {
+    this.attrs[name] = value;
+  }
+
+  appendChild(
+    child: FakeStructuredXmlElement | FakeStructuredXmlText,
+  ): FakeStructuredXmlElement | FakeStructuredXmlText {
+    this.children.push(child);
+    return child;
+  }
+}
+
+class FakeStructuredXmlText {
+  constructor(readonly textContent: string) {}
+}
+
+class FakeXmlSerializer {
+  serializeToString(node: FakeStructuredXmlElement): string {
+    return serializeFakeXmlElement(node, null);
+  }
+}
+
+function serializeFakeXmlElement(node: FakeStructuredXmlElement, parentNamespace: string | null): string {
+  const namespaceAttr = node.namespaceURI && node.namespaceURI !== parentNamespace
+    ? ` xmlns="${escapeTestXml(node.namespaceURI)}"`
+    : "";
+  const attrs = Object.entries(node.attrs)
+    .map(([name, value]) => ` ${name}="${escapeTestXml(value)}"`)
+    .join("");
+  const children = node.children.map((child) =>
+    child instanceof FakeStructuredXmlText
+      ? escapeTestXml(child.textContent)
+      : serializeFakeXmlElement(child, node.namespaceURI),
+  ).join("");
+  return `<${node.localName}${namespaceAttr}${attrs}>${children}</${node.localName}>`;
+}
+
+function escapeTestXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
 }

--- a/chat/tests/inbound-references.test.ts
+++ b/chat/tests/inbound-references.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import type { JSONContent } from "@tiptap/core";
 import { mapLiveRoomMessageToTimeline } from "@/channels/timeline";
+import { buildChannelTimelineFromMamResults } from "@/channels/message-timeline-state";
+import { buildDmTimelineFromMamResults, fromLiveDmMessage } from "@/dms/message-timeline-state";
 import { renderStyledBody } from "@/lib/chat-ui";
 import { tiptapToRichMessage } from "@/lib/rich-message";
 import {
@@ -135,6 +137,81 @@ describe("roomMessageFromArchived", () => {
         anchor: "https://example.com",
       },
     ]);
+  });
+
+  test("maps archived LinkPreview payloads into room timeline messages", () => {
+    const result = roomMessageFromArchived({
+      ...baseArchivedRoom,
+      link_previews: [{
+        original_url: "https://example.com/article",
+        normalized_url: "https://example.com/article",
+        title: "Example Article",
+        description: "Plain text summary",
+      }],
+    });
+
+    expect(result).not.toBeNull();
+    const timeline = mapLiveRoomMessageToTimeline(session, result!);
+    expect(timeline.linkPreviews).toEqual([{
+      originalUrl: "https://example.com/article",
+      normalizedUrl: "https://example.com/article",
+      title: "Example Article",
+      description: "Plain text summary",
+    }]);
+  });
+
+  test("maps bodyless archived LinkPreview payloads into room timeline messages", () => {
+    const result = roomMessageFromArchived({
+      ...baseArchivedRoom,
+      body: undefined,
+      link_previews: [{
+        original_url: "https://example.com/article",
+        normalized_url: "https://example.com/article",
+        title: "Example Article",
+        description: "Plain text summary",
+      }],
+    });
+
+    expect(result).not.toBeNull();
+    const timeline = mapLiveRoomMessageToTimeline(session, result!);
+    expect(timeline.body).toBe("");
+    expect(timeline.linkPreviews).toEqual([{
+      originalUrl: "https://example.com/article",
+      normalizedUrl: "https://example.com/article",
+      title: "Example Article",
+      description: "Plain text summary",
+    }]);
+  });
+
+  test("archive replay clears an optimistic room LinkPreview when payload has none", () => {
+    const archived = roomMessageFromArchived({
+      ...baseArchivedRoom,
+      mam_id: "mam-reload-1",
+      id: "server-1",
+      stanza_id: "room-stanza-1",
+      stanza_id_by: "room@conf.example.com",
+      from: "room@conf.example.com/alice",
+      body: "read https://example.com",
+      link_previews: [],
+    });
+
+    expect(archived).not.toBeNull();
+    const timeline = buildChannelTimelineFromMamResults({
+      session,
+      mamResults: [archived!],
+      existing: [{
+        id: "client-1",
+        wireIds: ["room-stanza-1"],
+        body: "read https://example.com",
+        nick: "alice",
+        isSelf: true,
+        createdAt: "2026-06-01T12:00:00.000Z",
+        linkPreviews: [{ originalUrl: "https://example.com", title: "Example" }],
+      }],
+    });
+
+    expect(timeline).toHaveLength(1);
+    expect(timeline[0]?.linkPreviews).toBeUndefined();
   });
 
   test("omits anchor when absent", () => {
@@ -393,5 +470,80 @@ describe("dmMessageFromArchived", () => {
         end: 23,
       },
     ]);
+  });
+
+  test("maps archived LinkPreview payloads into DM timeline messages", () => {
+    const result = dmMessageFromArchived({
+      ...baseArchivedDm,
+      link_previews: [{
+        original_url: "https://example.com/article",
+        normalized_url: "https://example.com/article",
+        title: "Example Article",
+        description: "Plain text summary",
+      }],
+    }, "bob@example.com");
+
+    expect(result).not.toBeNull();
+    const timeline = fromLiveDmMessage(session, result!);
+    expect(timeline.linkPreviews).toEqual([{
+      originalUrl: "https://example.com/article",
+      normalizedUrl: "https://example.com/article",
+      title: "Example Article",
+      description: "Plain text summary",
+    }]);
+  });
+
+  test("maps bodyless archived LinkPreview payloads into DM timeline messages", () => {
+    const result = dmMessageFromArchived({
+      ...baseArchivedDm,
+      body: undefined,
+      link_previews: [{
+        original_url: "https://example.com/article",
+        normalized_url: "https://example.com/article",
+        title: "Example Article",
+        description: "Plain text summary",
+      }],
+    }, "bob@example.com");
+
+    expect(result).not.toBeNull();
+    const timeline = fromLiveDmMessage(session, result!);
+    expect(timeline.body).toBe("");
+    expect(timeline.linkPreviews).toEqual([{
+      originalUrl: "https://example.com/article",
+      normalizedUrl: "https://example.com/article",
+      title: "Example Article",
+      description: "Plain text summary",
+    }]);
+  });
+
+  test("archive replay clears an optimistic DM LinkPreview when payload has none", () => {
+    const archived = dmMessageFromArchived({
+      ...baseArchivedDm,
+      mam_id: "mam-dm-reload-1",
+      id: "server-1",
+      stanza_id: "dm-stanza-1",
+      from: "alice@example.com/web",
+      to: "bob@example.com",
+      body: "read https://example.com",
+      link_previews: [],
+    }, "bob@example.com");
+
+    expect(archived).not.toBeNull();
+    const timeline = buildDmTimelineFromMamResults({
+      session,
+      mamResults: [archived!],
+      existing: [{
+        id: "client-1",
+        wireIds: ["server-1", "dm-stanza-1", "mam-dm-reload-1"],
+        body: "read https://example.com",
+        nick: "alice",
+        isSelf: true,
+        createdAt: "2026-06-01T12:00:00.000Z",
+        linkPreviews: [{ originalUrl: "https://example.com", title: "Example" }],
+      }],
+    });
+
+    expect(timeline).toHaveLength(1);
+    expect(timeline[0]?.linkPreviews).toBeUndefined();
   });
 });

--- a/chat/tests/link-preview.test.ts
+++ b/chat/tests/link-preview.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import {
+  firstEligibleHttpsUrl,
+  requestPlaintextLinkPreviewLookup,
+} from "../src/lib/xmpp/link-preview";
+import { withFakeDomParser, withFakeXmlDocument } from "./helpers/disco-xml";
+
+describe("link preview lookup", () => {
+  test("selects the first eligible HTTPS URL in body order", () => {
+    expect(firstEligibleHttpsUrl("see http://ignored.example then https://first.example/a, and https://second.example/b"))
+      .toBe("https://first.example/a");
+  });
+
+  test("selects HTTPS URL wrapped in punctuation", () => {
+    expect(firstEligibleHttpsUrl("see (https://example.com/a)."))
+      .toBe("https://example.com/a");
+  });
+
+  test("selects HTTPS URL after inline punctuation", () => {
+    expect(firstEligibleHttpsUrl("see:https://example.com/a then https://second.example/a"))
+      .toBe("https://example.com/a");
+  });
+
+  test("requests XMPP-native composer lookup with URL and scope", async () => {
+    const send_raw_iq = async (xml: string) => {
+      expect(xml).toContain("<url>https://example.com/a?x=1&amp;y=2</url>");
+      expect(xml).toContain("<scope>room@muc.example.com</scope>");
+      return `<iq type="result" id="lookup-1"><lookup xmlns="urn:waddle:link-preview:0" status="ready"><preview token="signed-token" original-url="https://example.com/a" normalized-url="https://example.com/a" expires-at="2026-06-01T12:05:00.000Z"><title>Example</title><description>Plain text</description></preview></lookup></iq>`;
+    };
+
+    let result: Awaited<ReturnType<typeof requestPlaintextLinkPreviewLookup>> = null;
+    await withFakeXmlDocument(async () => {
+      await withFakeDomParser(async () => {
+        result = await requestPlaintextLinkPreviewLookup(
+          { send_raw_iq },
+          "read https://example.com/a?x=1&y=2",
+          "room@muc.example.com",
+        );
+      });
+    });
+
+    expect(result).toEqual({
+      token: "signed-token",
+      originalUrl: "https://example.com/a",
+      normalizedUrl: "https://example.com/a",
+      status: "ready",
+      expiresAt: "2026-06-01T12:05:00.000Z",
+      title: "Example",
+      description: "Plain text",
+    });
+  });
+
+  test("rejects lookup responses with non-HTTPS preview URLs", async () => {
+    const send_raw_iq = async () =>
+      `<iq type="result" id="lookup-1"><lookup xmlns="urn:waddle:link-preview:0" status="ready"><preview token="signed-token" original-url="http://example.com/a" normalized-url="http://example.com/a" expires-at="2026-06-01T12:05:00.000Z"><title>Example</title></preview></lookup></iq>`;
+
+    let result: Awaited<ReturnType<typeof requestPlaintextLinkPreviewLookup>> = null;
+    await withFakeXmlDocument(async () => {
+      await withFakeDomParser(async () => {
+        result = await requestPlaintextLinkPreviewLookup(
+          { send_raw_iq },
+          "read https://example.com/a",
+          "room@muc.example.com",
+        );
+      });
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("lookup failure is a metadata miss instead of a send blocker", async () => {
+    const result = await requestPlaintextLinkPreviewLookup(
+      { send_raw_iq: async () => { throw new Error("lookup failed"); } },
+      "read https://example.com/a",
+      "room@muc.example.com",
+    );
+
+    expect(result).toBeNull();
+  });
+});

--- a/chat/tests/muc-send.test.ts
+++ b/chat/tests/muc-send.test.ts
@@ -88,6 +88,37 @@ describe("useMucSend.sendMessage — happy path", () => {
     expect(h.send.isSending.value).toBe(false);
     expect(h.onSendComplete).toHaveBeenCalledTimes(1);
   });
+
+  test("looks up first eligible HTTPS URL and sends scoped preview token", async () => {
+    const sendGroupMessage = mock(async () => ({ id: "sid-link", state: "sending" }));
+    const lookupLinkPreview = mock(async () => ({
+      token: "preview-token-1",
+      originalUrl: "https://example.com/article",
+      normalizedUrl: "https://example.com/article",
+      status: "ready" as const,
+      expiresAt: "2026-06-01T12:05:00.000Z",
+      title: "Example Article",
+      description: "Plain text summary",
+    }));
+    const client = makeClient({ sendGroupMessage, lookupLinkPreview } as Partial<BrowserXmppClient>);
+    const h = harness({ client, draft: "read https://example.com/article and https://later.example/path" });
+
+    await h.send.sendMessage(undefined, []);
+
+    expect(lookupLinkPreview).toHaveBeenCalledWith(
+      "read https://example.com/article and https://later.example/path",
+      "general@muc.example.com",
+    );
+    const call = (sendGroupMessage as unknown as ReturnType<typeof mock>).mock.calls[0]!;
+    expect(call[3].linkPreviewToken).toBe("preview-token-1");
+    expect(call[3].linkPreviewExpiresAt).toBe("2026-06-01T12:05:00.000Z");
+    expect(h.messages.value[0]?.linkPreviews).toEqual([{
+      originalUrl: "https://example.com/article",
+      normalizedUrl: "https://example.com/article",
+      title: "Example Article",
+      description: "Plain text summary",
+    }]);
+  });
 });
 
 describe("useMucSend.sendMessage — guards", () => {

--- a/chat/tests/offline-queue.test.ts
+++ b/chat/tests/offline-queue.test.ts
@@ -9,6 +9,7 @@ import {
   listQueuedDmMessages,
   listQueuedRoomMessages,
 } from "../src/lib/outbound-queue-store";
+import { withFakeDomParser, withFakeXmlDocument } from "./helpers/disco-xml";
 
 function session(partial: Partial<WaddleSession> = {}): WaddleSession {
   return {
@@ -66,6 +67,55 @@ afterEach(() => {
 });
 
 describe("offline outbound queue replay", () => {
+  test("does not persist decodable link preview tokens for queued sends", async () => {
+    const client = new BrowserXmppClient(session());
+    (client as unknown as { connect: ReturnType<typeof mock> }).connect = mock(async () => {
+      throw new Error("Reconnection timed out");
+    });
+
+    await client.sendDirectMessage("bob@example.com", "read https://example.com", {
+      id: "dm-preview-queued",
+      linkPreviewToken: "plaintext-token",
+      linkPreviewExpiresAt: "2026-06-01T12:05:00.000Z",
+    });
+
+    const raw = localStorage.getItem("waddle.chat.outbound-queue.alice@example.com");
+    expect(raw).toContain("dm-preview-queued");
+    expect(raw).not.toContain("plaintext-token");
+    expect(raw).not.toContain("linkPreviewToken");
+    expect(raw).not.toContain("linkPreviewExpiresAt");
+  });
+
+  test("reacquires a fresh link preview token when replaying queued URL sends", async () => {
+    const client = new BrowserXmppClient(session());
+    enqueueQueuedMessage("alice@example.com", {
+      kind: "dm",
+      id: "dm-preview-replay",
+      createdAt: new Date().toISOString(),
+      peerJid: "bob@example.com",
+      body: "read https://example.com/article",
+    });
+
+    const xmpp = {
+      send_raw_iq: mock(async () =>
+        `<iq type="result" id="lookup-1"><lookup xmlns="urn:waddle:link-preview:0" status="ready"><preview token="fresh-token" original-url="https://example.com/article" normalized-url="https://example.com/article" expires-at="2026-06-01T12:05:00.000Z"><title>Example</title></preview></lookup></iq>`),
+      send_chat_message: mock(async (_peer: string, _body: string, opts: { stanza_id?: string }) => opts.stanza_id),
+      on() {},
+    };
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).connected = true;
+
+    await withFakeXmlDocument(async () => {
+      await withFakeDomParser(async () => {
+        await (client as unknown as { flushQueuedDirectMessages: () => Promise<void> }).flushQueuedDirectMessages();
+      });
+    });
+
+    expect(xmpp.send_raw_iq).toHaveBeenCalled();
+    expect((xmpp.send_chat_message.mock.calls[0]?.[2] as { link_preview_token?: string }).link_preview_token)
+      .toBe("fresh-token");
+  });
+
   test("replays queued DM messages in order when the session returns", async () => {
     const client = new BrowserXmppClient(session());
     (client as unknown as { connect: ReturnType<typeof mock> }).connect = mock(async () => {
@@ -149,7 +199,7 @@ describe("offline outbound queue replay", () => {
       throw new Error("Reconnection timed out");
     });
 
-    await client.sendGroupMessage("w1", "c1", "first", { id: "room-1" });
+    await client.sendGroupMessage("w1", "c1", "first https://example.com/room", { id: "room-1" });
     await client.sendGroupMessage("w1", "c1", "second", { id: "room-2" });
 
     const roomJid = roomBareJidFor(session(), "c1");
@@ -160,6 +210,11 @@ describe("offline outbound queue replay", () => {
 
     const handlers = new Map<string, Array<(payload: unknown) => void>>();
     const xmpp = {
+      send_raw_iq: mock(async (xml: string) => {
+        expect(xml).toContain("<url>https://example.com/room</url>");
+        expect(xml).toContain(`<scope>${roomJid}</scope>`);
+        return `<iq type="result" id="lookup-room-1"><lookup xmlns="urn:waddle:link-preview:0" status="ready"><preview token="fresh-room-token" original-url="https://example.com/room" normalized-url="https://example.com/room" expires-at="2026-06-01T12:05:00.000Z"><title>Example</title></preview></lookup></iq>`;
+      }),
       send_groupchat_message: mock(async (_room: string, _body: string, opts: { stanza_id?: string }) => opts.stanza_id),
       on(event: string, handler: (payload: unknown) => void) {
         const list = handlers.get(event) ?? [];
@@ -179,12 +234,21 @@ describe("offline outbound queue replay", () => {
     (client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.add(roomJid);
     (client as unknown as { wireEvents: (x: typeof xmpp) => void }).wireEvents(xmpp);
 
-    await (client as unknown as { flushQueuedRoomMessages: (roomJid: string) => Promise<void> }).flushQueuedRoomMessages(roomJid);
+    await withFakeXmlDocument(async () => {
+      await withFakeDomParser(async () => {
+        await (client as unknown as { flushQueuedRoomMessages: (roomJid: string) => Promise<void> }).flushQueuedRoomMessages(roomJid);
+      });
+    });
 
+    expect(xmpp.send_raw_iq).toHaveBeenCalledTimes(1);
     expect(xmpp.send_groupchat_message.mock.calls.map((call) => (call[2] as { stanza_id?: string }).stanza_id)).toEqual([
       "room-1",
       "room-2",
     ]);
+    expect((xmpp.send_groupchat_message.mock.calls[0]?.[2] as { link_preview_token?: string }).link_preview_token)
+      .toBe("fresh-room-token");
+    expect((xmpp.send_groupchat_message.mock.calls[1]?.[2] as { link_preview_token?: string }).link_preview_token)
+      .toBeUndefined();
     // Persisted entries stay until ack, same as the DM path.
     expect(
       listQueuedRoomMessages("alice@example.com", roomJid).map((message) => message.id),

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
@@ -1,0 +1,344 @@
+//! Waddle plaintext link-preview composer lookup.
+//!
+//! This first tracer bullet deliberately returns text-only metadata derived
+//! from the submitted HTTPS URL. Later resolver slices can replace the lookup
+//! internals without changing the send-time token request or XEP-0511 payload.
+
+use super::*;
+use chrono::{Duration, SecondsFormat, Utc};
+use minidom::rxml::xml_ncname;
+use url::Url;
+use waddle_xmpp::xep::{encode_link_preview_token, LinkPreviewTokenData, NS_WADDLE_LINK_PREVIEW};
+use xmpp_parsers::iq::Iq;
+use xmpp_parsers::minidom::Element;
+
+pub(super) fn is_link_preview_lookup_iq(iq: &Iq) -> bool {
+    let Iq::Get { payload, .. } = iq else {
+        return false;
+    };
+    payload.name() == "lookup" && payload.ns() == NS_WADDLE_LINK_PREVIEW
+}
+
+pub(super) async fn handle_link_preview_lookup_iq(
+    iq: &Iq,
+    sender_jid: Option<&FullJid>,
+    state: &WebSocketState,
+    muc_domain: &str,
+    response_from: Option<&str>,
+    response_to: Option<&str>,
+    secret: &[u8],
+) -> Vec<String> {
+    let Some(sender_jid) = sender_jid else {
+        return vec![build_iq_error_xml_typed(
+            iq.id(),
+            response_from,
+            response_to,
+            not_authorized_iq_error("Authentication required."),
+        )];
+    };
+    let Iq::Get { payload, .. } = iq else {
+        return vec![build_iq_error_xml_typed(
+            iq.id(),
+            response_from,
+            response_to,
+            bad_request_iq_error("Link preview lookup must be an IQ get."),
+        )];
+    };
+
+    let Some(original_url) = lookup_url(payload) else {
+        return vec![build_iq_error_xml_typed(
+            iq.id(),
+            response_from,
+            response_to,
+            bad_request_iq_error("Link preview lookup requires a URL."),
+        )];
+    };
+    let Some(scope_jid) = lookup_scope(payload).and_then(|scope| scope.parse().ok()) else {
+        return vec![build_iq_error_xml_typed(
+            iq.id(),
+            response_from,
+            response_to,
+            bad_request_iq_error("Link preview lookup requires a conversation scope JID."),
+        )];
+    };
+    if let Some(error) =
+        authorize_link_preview_scope(state, sender_jid, &scope_jid, muc_domain).await
+    {
+        return vec![build_iq_error_xml_typed(
+            iq.id(),
+            response_from,
+            response_to,
+            error,
+        )];
+    }
+
+    let Ok(original_url) = Url::parse(&original_url) else {
+        return vec![build_link_preview_lookup_result(
+            iq,
+            response_from,
+            response_to,
+            None,
+        )];
+    };
+    if original_url.scheme() != "https"
+        || !original_url
+            .host_str()
+            .is_some_and(|host| host.contains('.'))
+    {
+        return vec![build_link_preview_lookup_result(
+            iq,
+            response_from,
+            response_to,
+            None,
+        )];
+    }
+
+    let expires_at = Utc::now() + Duration::minutes(5);
+    let host = original_url
+        .host_str()
+        .unwrap_or_default()
+        .trim_start_matches("www.")
+        .to_string();
+    let data = LinkPreviewTokenData {
+        sender_jid: sender_jid.to_bare(),
+        scope_jid,
+        original_url: original_url.clone(),
+        normalized_url: original_url.clone(),
+        title: Some(host),
+        description: Some(original_url.as_str().to_string()),
+        expires_at_unix: expires_at.timestamp(),
+    };
+    let token = encode_link_preview_token(&data, secret);
+
+    vec![build_link_preview_lookup_result(
+        iq,
+        response_from,
+        response_to,
+        Some((
+            data,
+            token.as_str(),
+            expires_at.to_rfc3339_opts(SecondsFormat::Millis, true),
+        )),
+    )]
+}
+
+async fn authorize_link_preview_scope(
+    state: &WebSocketState,
+    sender_jid: &FullJid,
+    scope_jid: &BareJid,
+    muc_domain: &str,
+) -> Option<xmpp_parsers::stanza_error::StanzaError> {
+    if scope_jid.domain().as_str() != muc_domain {
+        return None;
+    }
+
+    let Some(room_actor) = get_room_actor(state, scope_jid).await else {
+        return Some(forbidden_iq_error(
+            "Link preview lookup is visible only to current room occupants.",
+        ));
+    };
+    match room_actor
+        .ask(GetOccupantByJid {
+            jid: sender_jid.clone(),
+        })
+        .await
+    {
+        Ok(Some(_)) => None,
+        Ok(None) => Some(forbidden_iq_error(
+            "Link preview lookup is visible only to current room occupants.",
+        )),
+        Err(error) => {
+            warn!(
+                scope = %scope_jid,
+                ?error,
+                "Link preview lookup: failed to verify room occupancy"
+            );
+            Some(internal_server_error_iq_error("Internal server error."))
+        }
+    }
+}
+
+fn lookup_url(payload: &Element) -> Option<String> {
+    payload
+        .get_child("url", NS_WADDLE_LINK_PREVIEW)
+        .map(Element::text)
+        .map(|text| text.trim().to_string())
+        .filter(|text| !text.is_empty())
+}
+
+fn lookup_scope(payload: &Element) -> Option<String> {
+    payload
+        .get_child("scope", NS_WADDLE_LINK_PREVIEW)
+        .map(Element::text)
+        .map(|text| text.trim().to_string())
+        .filter(|text| !text.is_empty())
+}
+
+fn build_link_preview_lookup_result(
+    iq: &Iq,
+    response_from: Option<&str>,
+    response_to: Option<&str>,
+    preview: Option<(LinkPreviewTokenData, &str, String)>,
+) -> String {
+    let mut lookup = Element::builder("lookup", NS_WADDLE_LINK_PREVIEW).attr(
+        xml_ncname!("status").to_owned(),
+        if preview.is_some() {
+            "ready"
+        } else {
+            "not_found"
+        },
+    );
+    if let Some((data, token, expires_at)) = preview {
+        let mut preview = Element::builder("preview", NS_WADDLE_LINK_PREVIEW)
+            .attr(xml_ncname!("token").to_owned(), token)
+            .attr(
+                xml_ncname!("original-url").to_owned(),
+                data.original_url.as_str(),
+            )
+            .attr(
+                xml_ncname!("normalized-url").to_owned(),
+                data.normalized_url.as_str(),
+            )
+            .attr(xml_ncname!("expires-at").to_owned(), expires_at)
+            .build();
+        append_text(&mut preview, "title", data.title.as_deref());
+        append_text(&mut preview, "description", data.description.as_deref());
+        lookup = lookup.append(preview);
+    }
+    build_iq_result_xml(iq.id(), response_from, response_to, Some(lookup.build()))
+}
+
+fn append_text(parent: &mut Element, name: &str, value: Option<&str>) {
+    let Some(value) = value.filter(|value| !value.trim().is_empty()) else {
+        return;
+    };
+    parent.append_child(
+        Element::builder(name, NS_WADDLE_LINK_PREVIEW)
+            .append(value.trim())
+            .build(),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::routes::websocket::tests::create_test_websocket_state;
+
+    fn iq_get_with_payload(payload: Element) -> Iq {
+        Iq::Get {
+            from: None,
+            to: None,
+            id: "lookup-1".into(),
+            payload,
+        }
+    }
+
+    fn sender() -> FullJid {
+        "alice@example.com/desktop".parse().expect("jid")
+    }
+
+    fn secret() -> &'static [u8] {
+        b"test-link-preview-secret"
+    }
+
+    #[tokio::test]
+    async fn handles_https_lookup_with_scoped_token_and_text_metadata() {
+        let payload = Element::builder("lookup", NS_WADDLE_LINK_PREVIEW)
+            .append(
+                Element::builder("url", NS_WADDLE_LINK_PREVIEW)
+                    .append("https://www.example.com/a")
+                    .build(),
+            )
+            .append(
+                Element::builder("scope", NS_WADDLE_LINK_PREVIEW)
+                    .append("alice@example.com")
+                    .build(),
+            )
+            .build();
+        let iq = iq_get_with_payload(payload);
+
+        let state = create_test_websocket_state().await;
+        let response = handle_link_preview_lookup_iq(
+            &iq,
+            Some(&sender()),
+            state.as_ref(),
+            "muc.example.com",
+            None,
+            None,
+            secret(),
+        )
+        .await;
+
+        let elem: Element = response[0].parse().expect("iq result");
+        let lookup = elem
+            .get_child("lookup", NS_WADDLE_LINK_PREVIEW)
+            .expect("lookup result");
+        assert_eq!(lookup.attr("status"), Some("ready"));
+        let preview = lookup
+            .get_child("preview", NS_WADDLE_LINK_PREVIEW)
+            .expect("preview");
+        assert_eq!(
+            preview.attr("original-url"),
+            Some("https://www.example.com/a")
+        );
+        assert_eq!(
+            preview.attr("normalized-url"),
+            Some("https://www.example.com/a")
+        );
+        assert!(preview.attr("token").is_some_and(|token| !token.is_empty()));
+        assert!(preview.attr("expires-at").is_some());
+        let token = waddle_xmpp::xep::LinkPreviewToken::new(
+            preview.attr("token").expect("token").to_string(),
+        )
+        .expect("token");
+        let decoded =
+            waddle_xmpp::xep::decode_link_preview_token(&token, secret(), i64::MIN).expect("token");
+        assert_eq!(decoded.sender_jid.to_string(), "alice@example.com");
+        assert_eq!(decoded.scope_jid.to_string(), "alice@example.com");
+        assert_eq!(
+            preview
+                .get_child("title", NS_WADDLE_LINK_PREVIEW)
+                .map(Element::text)
+                .as_deref(),
+            Some("example.com")
+        );
+    }
+
+    #[tokio::test]
+    async fn non_https_lookup_returns_not_found_without_token() {
+        let payload = Element::builder("lookup", NS_WADDLE_LINK_PREVIEW)
+            .append(
+                Element::builder("url", NS_WADDLE_LINK_PREVIEW)
+                    .append("http://example.com/a")
+                    .build(),
+            )
+            .append(
+                Element::builder("scope", NS_WADDLE_LINK_PREVIEW)
+                    .append("alice@example.com")
+                    .build(),
+            )
+            .build();
+        let iq = iq_get_with_payload(payload);
+
+        let state = create_test_websocket_state().await;
+        let response = handle_link_preview_lookup_iq(
+            &iq,
+            Some(&sender()),
+            state.as_ref(),
+            "muc.example.com",
+            None,
+            None,
+            secret(),
+        )
+        .await;
+
+        let elem: Element = response[0].parse().expect("iq result");
+        let lookup = elem
+            .get_child("lookup", NS_WADDLE_LINK_PREVIEW)
+            .expect("lookup result");
+        assert_eq!(lookup.attr("status"), Some("not_found"));
+        assert!(lookup
+            .get_child("preview", NS_WADDLE_LINK_PREVIEW)
+            .is_none());
+    }
+}

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
@@ -23,7 +23,10 @@ use waddle_xmpp::{
             is_role_change_query, parse_admin_query,
         },
         owner::build_config_form,
-        room_actor::{ApplyAdminItems, GetAdminContext, GetSnapshot, PingSelfCheck, UpdateConfig},
+        room_actor::{
+            ApplyAdminItems, GetAdminContext, GetOccupantByJid, GetSnapshot, PingSelfCheck,
+            UpdateConfig,
+        },
         DATA_FORMS_NS,
     },
     presence::subscription::{
@@ -80,6 +83,7 @@ pub(crate) mod errors;
 mod extension_forms;
 mod jingle_muji_gate;
 mod last_activity;
+mod link_preview_lookup;
 mod mentions_permissions;
 mod misc;
 mod muc_admin;
@@ -112,6 +116,7 @@ use extension_forms::{
     CommandBoundary, EXTENSION_COMMAND_FORM_TYPE, EXTENSION_ROUTE_FORM_TYPE,
 };
 use last_activity::handle_last_activity_iq;
+use link_preview_lookup::{handle_link_preview_lookup_iq, is_link_preview_lookup_iq};
 use mentions_permissions::{handle_mentions_permissions_iq, is_mentions_permissions_iq};
 use muc_owner_config::apply_muc_owner_config;
 use muc_owner_moderation::handle_muc_owner_and_moderation_iq;
@@ -274,6 +279,19 @@ pub async fn handle_iq_with_conn_state(
     if is_isr_token_request(&iq) {
         return handle_isr_token_request_iq(&iq, state, authenticated_session, phase.bound_jid())
             .await;
+    }
+
+    if is_link_preview_lookup_iq(&iq) {
+        return handle_link_preview_lookup_iq(
+            &iq,
+            phase.bound_jid(),
+            state,
+            muc_domain,
+            response_from,
+            response_to,
+            state.deps.occupant_id_secret.key(),
+        )
+        .await;
     }
 
     if payload_ns == ROSTER_NS {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -1,11 +1,19 @@
+use std::borrow::Cow;
+
 use tracing::warn;
 use waddle_xmpp::{
     parser::stanza_to_string,
     protocol::handlers::errors::bad_request_reply,
     protocol::{frame::InboundFrame, InboundEvent, XmppStateMachine},
-    xep::NS_DELAY,
+    xep::{
+        build_link_metadata_element, decode_link_preview_token,
+        extract_link_preview_request_from_message, parse_fallbacks_from_message,
+        strip_fallback_ranges, strip_link_metadata, strip_link_preview_requests, FallbackRegion,
+        LinkMetadata, NS_DELAY, NS_REPLY,
+    },
     Stanza,
 };
+use waddle_xmpp_core::first_eligible_https_url_text;
 
 use super::super::{
     interpret_loop::build_interpret_deps, replay::drive_interpret_loop, WebSocketState,
@@ -61,6 +69,12 @@ pub async fn handle_message(
     };
 
     strip_client_authored_delay(&mut incoming);
+    consume_link_preview_request(
+        &mut incoming,
+        &bound_jid,
+        state.deps.occupant_id_secret.key(),
+        chrono::Utc::now().timestamp(),
+    );
 
     if incoming.type_ != xmpp_parsers::message::MessageType::Groupchat
         && incoming.type_ != xmpp_parsers::message::MessageType::Error
@@ -96,6 +110,71 @@ fn strip_client_authored_delay(message: &mut xmpp_parsers::message::Message) {
         .retain(|payload| !(payload.name() == "delay" && payload.ns() == NS_DELAY));
 }
 
+fn consume_link_preview_request(
+    message: &mut xmpp_parsers::message::Message,
+    sender_jid: &jid::FullJid,
+    secret: &[u8],
+    now_unix: i64,
+) {
+    let expected_sender = sender_jid.to_bare();
+    let expected_scope = message.to.as_ref().map(|to| to.to_bare());
+    let metadata = extract_link_preview_request_from_message(message)
+        .and_then(|token| decode_link_preview_token(&token, secret, now_unix).ok())
+        .filter(|preview| {
+            Some(&preview.scope_jid) == expected_scope.as_ref()
+                && preview.sender_jid == expected_sender
+                && preview.original_url.scheme() == "https"
+                && preview.normalized_url.scheme() == "https"
+                && first_eligible_https_url(message).as_ref() == Some(&preview.original_url)
+        })
+        .map(|preview| {
+            let mut metadata =
+                LinkMetadata::new(preview.original_url).with_canonical_url(preview.normalized_url);
+            if let Some(title) = preview.title {
+                metadata = metadata.with_title(title);
+            }
+            if let Some(description) = preview.description {
+                metadata = metadata.with_description(description);
+            }
+            metadata
+        });
+    strip_link_preview_requests(message);
+    strip_link_metadata(message);
+    if let Some(metadata) = metadata {
+        message
+            .payloads
+            .push(build_link_metadata_element(&metadata));
+    }
+}
+
+fn first_eligible_https_url(message: &xmpp_parsers::message::Message) -> Option<url::Url> {
+    let body = message.bodies.get("")?;
+    let body = body_without_reply_fallback(message, body);
+    first_eligible_https_url_text(&body).and_then(|candidate| url::Url::parse(candidate).ok())
+}
+
+fn body_without_reply_fallback<'a>(
+    message: &xmpp_parsers::message::Message,
+    body: &'a str,
+) -> Cow<'a, str> {
+    let mut ranges = Vec::new();
+    for fallback in parse_fallbacks_from_message(message) {
+        if fallback.for_ns.as_deref() != Some(NS_REPLY) {
+            continue;
+        }
+        match fallback.body {
+            Some(FallbackRegion::Whole) => return Cow::Borrowed(""),
+            Some(FallbackRegion::Ranges(body_ranges)) => ranges.extend(body_ranges),
+            None => {}
+        }
+    }
+    if ranges.is_empty() {
+        Cow::Borrowed(body)
+    } else {
+        Cow::Owned(strip_fallback_ranges(body, &ranges))
+    }
+}
+
 fn remove_framework_envelopes(message: &mut xmpp_parsers::message::Message) {
     message
         .payloads
@@ -105,6 +184,11 @@ fn remove_framework_envelopes(message: &mut xmpp_parsers::message::Message) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    const SECRET: &[u8] = b"test-link-preview-secret";
+
+    fn sender() -> jid::FullJid {
+        "alice@example.com/desktop".parse().expect("jid")
+    }
     use xmpp_parsers::message::Message;
     use xmpp_parsers::minidom::Element;
 
@@ -128,5 +212,275 @@ mod tests {
             .payloads
             .iter()
             .any(|payload| payload.ns().starts_with("urn:waddle:")));
+    }
+
+    #[test]
+    fn consumes_link_preview_request_and_stamps_xep0511_metadata() {
+        let preview = waddle_xmpp::xep::LinkPreviewTokenData {
+            sender_jid: "alice@example.com".parse().expect("jid"),
+            scope_jid: "room@muc.example.com".parse().expect("jid"),
+            original_url: url::Url::parse("https://the.link.example.com/what-was-linked-to")
+                .expect("url"),
+            normalized_url: url::Url::parse(
+                "https://example.com/canonical-url/for/what-was-linked-to",
+            )
+            .expect("url"),
+            title: Some("The Best Webpage".to_string()),
+            description: Some("This is a great webpage and you will really like it".to_string()),
+            expires_at_unix: 1_900_000_000,
+        };
+        let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
+        let mut message = Message::new(None::<jid::Jid>);
+        message.to = Some("room@muc.example.com".parse().expect("jid"));
+        message.bodies.insert(
+            xmpp_parsers::message::Lang::new(),
+            "read https://the.link.example.com/what-was-linked-to".to_string(),
+        );
+        message
+            .payloads
+            .push(waddle_xmpp::xep::build_link_preview_request_element(&token));
+
+        consume_link_preview_request(&mut message, &sender(), SECRET, 1_800_000_000);
+
+        assert!(message
+            .payloads
+            .iter()
+            .all(|payload| payload.ns() != waddle_xmpp::xep::NS_WADDLE_LINK_PREVIEW));
+        let parsed = waddle_xmpp::xep::extract_link_metadata_from_message(&message);
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].about, preview.original_url);
+        assert_eq!(parsed[0].canonical_url, Some(preview.normalized_url));
+        assert_eq!(parsed[0].title.as_deref(), Some("The Best Webpage"));
+    }
+
+    #[test]
+    fn expired_link_preview_request_is_stripped_without_metadata() {
+        let preview = waddle_xmpp::xep::LinkPreviewTokenData {
+            sender_jid: "alice@example.com".parse().expect("jid"),
+            scope_jid: "room@muc.example.com".parse().expect("jid"),
+            original_url: url::Url::parse("https://example.com/").expect("url"),
+            normalized_url: url::Url::parse("https://example.com/").expect("url"),
+            title: Some("Example".to_string()),
+            description: None,
+            expires_at_unix: 10,
+        };
+        let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
+        let mut message = Message::new(None::<jid::Jid>);
+        message.to = Some("room@muc.example.com".parse().expect("jid"));
+        message.bodies.insert(
+            xmpp_parsers::message::Lang::new(),
+            "read https://example.com/".to_string(),
+        );
+        message
+            .payloads
+            .push(waddle_xmpp::xep::build_link_preview_request_element(&token));
+
+        consume_link_preview_request(&mut message, &sender(), SECRET, 11);
+
+        assert!(message.payloads.is_empty());
+    }
+
+    #[test]
+    fn wrong_scope_link_preview_request_is_stripped_without_metadata() {
+        let preview = waddle_xmpp::xep::LinkPreviewTokenData {
+            sender_jid: "alice@example.com".parse().expect("jid"),
+            scope_jid: "other@muc.example.com".parse().expect("jid"),
+            original_url: url::Url::parse("https://example.com/").expect("url"),
+            normalized_url: url::Url::parse("https://example.com/").expect("url"),
+            title: Some("Example".to_string()),
+            description: None,
+            expires_at_unix: 1_900_000_000,
+        };
+        let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
+        let mut message = Message::new(None::<jid::Jid>);
+        message.to = Some("room@muc.example.com".parse().expect("jid"));
+        message.bodies.insert(
+            xmpp_parsers::message::Lang::new(),
+            "read https://example.com/".to_string(),
+        );
+        message
+            .payloads
+            .push(waddle_xmpp::xep::build_link_preview_request_element(&token));
+
+        consume_link_preview_request(&mut message, &sender(), SECRET, 1_800_000_000);
+
+        assert!(message.payloads.is_empty());
+    }
+
+    #[test]
+    fn request_for_non_first_body_url_is_stripped_without_metadata() {
+        let preview = waddle_xmpp::xep::LinkPreviewTokenData {
+            sender_jid: "alice@example.com".parse().expect("jid"),
+            scope_jid: "room@muc.example.com".parse().expect("jid"),
+            original_url: url::Url::parse("https://second.example.com/").expect("url"),
+            normalized_url: url::Url::parse("https://second.example.com/").expect("url"),
+            title: Some("Second".to_string()),
+            description: None,
+            expires_at_unix: 1_900_000_000,
+        };
+        let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
+        let mut message = Message::new(None::<jid::Jid>);
+        message.to = Some("room@muc.example.com".parse().expect("jid"));
+        message.bodies.insert(
+            xmpp_parsers::message::Lang::new(),
+            "first https://first.example.com/ then https://second.example.com/".to_string(),
+        );
+        message
+            .payloads
+            .push(waddle_xmpp::xep::build_link_preview_request_element(&token));
+
+        consume_link_preview_request(&mut message, &sender(), SECRET, 1_800_000_000);
+
+        assert!(message.payloads.is_empty());
+    }
+
+    #[test]
+    fn wrapped_first_body_url_is_eligible_for_preview_stamp() {
+        let preview = waddle_xmpp::xep::LinkPreviewTokenData {
+            sender_jid: "alice@example.com".parse().expect("jid"),
+            scope_jid: "room@muc.example.com".parse().expect("jid"),
+            original_url: url::Url::parse("https://example.com/a").expect("url"),
+            normalized_url: url::Url::parse("https://example.com/a").expect("url"),
+            title: Some("Example".to_string()),
+            description: None,
+            expires_at_unix: 1_900_000_000,
+        };
+        let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
+        let mut message = Message::new(None::<jid::Jid>);
+        message.to = Some("room@muc.example.com".parse().expect("jid"));
+        message.bodies.insert(
+            xmpp_parsers::message::Lang::new(),
+            "read (https://example.com/a).".to_string(),
+        );
+        message
+            .payloads
+            .push(waddle_xmpp::xep::build_link_preview_request_element(&token));
+
+        consume_link_preview_request(&mut message, &sender(), SECRET, 1_800_000_000);
+
+        assert_eq!(
+            waddle_xmpp::xep::extract_link_metadata_from_message(&message).len(),
+            1
+        );
+    }
+
+    #[test]
+    fn inline_punctuation_prefixed_body_url_is_eligible_for_preview_stamp() {
+        let preview = waddle_xmpp::xep::LinkPreviewTokenData {
+            sender_jid: "alice@example.com".parse().expect("jid"),
+            scope_jid: "room@muc.example.com".parse().expect("jid"),
+            original_url: url::Url::parse("https://example.com/a").expect("url"),
+            normalized_url: url::Url::parse("https://example.com/a").expect("url"),
+            title: Some("Example".to_string()),
+            description: None,
+            expires_at_unix: 1_900_000_000,
+        };
+        let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
+        let mut message = Message::new(None::<jid::Jid>);
+        message.to = Some("room@muc.example.com".parse().expect("jid"));
+        message.bodies.insert(
+            xmpp_parsers::message::Lang::new(),
+            "read:https://example.com/a".to_string(),
+        );
+        message
+            .payloads
+            .push(waddle_xmpp::xep::build_link_preview_request_element(&token));
+
+        consume_link_preview_request(&mut message, &sender(), SECRET, 1_800_000_000);
+
+        assert_eq!(
+            waddle_xmpp::xep::extract_link_metadata_from_message(&message).len(),
+            1
+        );
+    }
+
+    #[test]
+    fn quoted_host_only_body_url_is_eligible_for_preview_stamp() {
+        let preview = waddle_xmpp::xep::LinkPreviewTokenData {
+            sender_jid: "alice@example.com".parse().expect("jid"),
+            scope_jid: "room@muc.example.com".parse().expect("jid"),
+            original_url: url::Url::parse("https://example.com/").expect("url"),
+            normalized_url: url::Url::parse("https://example.com/").expect("url"),
+            title: Some("Example".to_string()),
+            description: None,
+            expires_at_unix: 1_900_000_000,
+        };
+        let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
+        let mut message = Message::new(None::<jid::Jid>);
+        message.to = Some("room@muc.example.com".parse().expect("jid"));
+        message.bodies.insert(
+            xmpp_parsers::message::Lang::new(),
+            "read \"https://example.com\"".to_string(),
+        );
+        message
+            .payloads
+            .push(waddle_xmpp::xep::build_link_preview_request_element(&token));
+
+        consume_link_preview_request(&mut message, &sender(), SECRET, 1_800_000_000);
+
+        assert_eq!(
+            waddle_xmpp::xep::extract_link_metadata_from_message(&message).len(),
+            1
+        );
+    }
+
+    #[test]
+    fn reply_fallback_url_is_ignored_when_validating_preview_stamp() {
+        let preview = waddle_xmpp::xep::LinkPreviewTokenData {
+            sender_jid: "alice@example.com".parse().expect("jid"),
+            scope_jid: "room@muc.example.com".parse().expect("jid"),
+            original_url: url::Url::parse("https://current.example.com/").expect("url"),
+            normalized_url: url::Url::parse("https://current.example.com/").expect("url"),
+            title: Some("Current".to_string()),
+            description: None,
+            expires_at_unix: 1_900_000_000,
+        };
+        let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
+        let fallback_prefix = "> earlier https://quoted.example.com/\n";
+        let mut message = Message::new(None::<jid::Jid>);
+        message.to = Some("room@muc.example.com".parse().expect("jid"));
+        message.bodies.insert(
+            xmpp_parsers::message::Lang::new(),
+            format!("{fallback_prefix}see https://current.example.com/"),
+        );
+        message
+            .payloads
+            .push(waddle_xmpp::xep::build_fallback_element(
+                &waddle_xmpp::xep::FallbackIndication::for_range(
+                    waddle_xmpp::xep::NS_REPLY,
+                    0,
+                    fallback_prefix.encode_utf16().count(),
+                ),
+            ));
+        message
+            .payloads
+            .push(waddle_xmpp::xep::build_link_preview_request_element(&token));
+
+        consume_link_preview_request(&mut message, &sender(), SECRET, 1_800_000_000);
+
+        let parsed = waddle_xmpp::xep::extract_link_metadata_from_message(&message);
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].about, preview.original_url);
+    }
+
+    #[test]
+    fn client_authored_xep0511_metadata_is_stripped_before_stamp() {
+        let mut message = Message::new(None::<jid::Jid>);
+        message.to = Some("room@muc.example.com".parse().expect("jid"));
+        message.bodies.insert(
+            xmpp_parsers::message::Lang::new(),
+            "read https://example.com/".to_string(),
+        );
+        let forged = waddle_xmpp::xep::LinkMetadata::new(
+            url::Url::parse("https://evil.example/").expect("url"),
+        )
+        .with_title("Forged");
+        message
+            .payloads
+            .push(waddle_xmpp::xep::build_link_metadata_element(&forged));
+
+        consume_link_preview_request(&mut message, &sender(), SECRET, 1_800_000_000);
+
+        assert!(message.payloads.is_empty());
     }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
@@ -72,6 +72,162 @@ fn data_form_value_for_test(frame: &str, var: &str) -> Option<String> {
     Some(value[..close].to_string())
 }
 
+async fn link_preview_lookup_for_test(
+    state: &WebSocketState,
+    session: Session,
+    bound_jid: &FullJid,
+    frame: &str,
+) -> Vec<String> {
+    let mut carbons_enabled = false;
+    let mut roster_interested = false;
+    let mut blocklist_interested = false;
+    let mut conn_state = IqConnState {
+        carbons_enabled: &mut carbons_enabled,
+        roster_interested: &mut roster_interested,
+        blocklist_interested: &mut blocklist_interested,
+        state_machine: None,
+    };
+    handle_iq_with_conn_state(
+        parse_iq_for_test(frame),
+        "example.com",
+        "muc.example.com",
+        state,
+        &Some(session),
+        &ready_phase(bound_jid),
+        &mut conn_state,
+    )
+    .await
+}
+
+#[tokio::test]
+async fn link_preview_lookup_dispatch_returns_scoped_text_metadata() {
+    let state = create_test_websocket_state().await;
+    let session = create_test_session(state.as_ref(), "alice").await;
+    let bound_jid: FullJid = "alice@example.com/desktop".parse().expect("jid");
+    let frame = "\
+        <iq xmlns='jabber:client' type='get' id='preview-1' from='alice@example.com/desktop' to='example.com'>\
+          <lookup xmlns='urn:waddle:link-preview:0'>\
+            <url>https://example.com/article</url>\
+            <scope>bob@example.com</scope>\
+          </lookup>\
+        </iq>";
+
+    let responses = link_preview_lookup_for_test(state.as_ref(), session, &bound_jid, frame).await;
+
+    let response = responses.first().expect("lookup result");
+    assert!(
+        response.contains("id='preview-1'"),
+        "preserves iq id: {response}"
+    );
+    assert!(
+        response.contains("from='example.com'")
+            && response.contains("to='alice@example.com/desktop'"),
+        "stamps result addressing from request envelope: {response}"
+    );
+    assert!(
+        response.contains("status='ready'"),
+        "ready lookup: {response}"
+    );
+    assert!(
+        response.contains("original-url='https://example.com/article'"),
+        "text preview includes original URL: {response}"
+    );
+    assert!(
+        response.contains("token='"),
+        "ready lookup mints scoped token: {response}"
+    );
+}
+
+#[tokio::test]
+async fn link_preview_lookup_for_muc_scope_requires_current_occupant() {
+    let state = create_test_websocket_state().await;
+    let session = create_test_session(state.as_ref(), "alice").await;
+    let bound_jid: FullJid = "alice@example.com/desktop".parse().expect("jid");
+    let frame = "\
+        <iq xmlns='jabber:client' type='get' id='preview-denied-1' from='alice@example.com/desktop' to='example.com'>\
+          <lookup xmlns='urn:waddle:link-preview:0'>\
+            <url>https://example.com/article</url>\
+            <scope>private@muc.example.com</scope>\
+          </lookup>\
+        </iq>";
+
+    let responses = link_preview_lookup_for_test(state.as_ref(), session, &bound_jid, frame).await;
+
+    let response = responses.first().expect("lookup error");
+    assert!(
+        response.contains("id='preview-denied-1'"),
+        "preserves iq id: {response}"
+    );
+    assert!(
+        response.contains("type='error'"),
+        "returns iq error: {response}"
+    );
+    assert!(
+        response.contains("<forbidden"),
+        "non-occupant MUC scope is forbidden: {response}"
+    );
+    assert!(
+        !response.contains("token='"),
+        "forbidden lookup must not mint token: {response}"
+    );
+}
+
+#[tokio::test]
+async fn link_preview_lookup_for_muc_scope_allows_current_occupant_with_room_scoped_token() {
+    let state = create_test_websocket_state().await;
+    let session = create_test_session(state.as_ref(), "alice").await;
+    let bound_jid: FullJid = "alice@example.com/desktop".parse().expect("jid");
+    let room_jid: jid::BareJid = "private@muc.example.com".parse().expect("room jid");
+    let room_actor = get_or_create_room_actor(
+        state.as_ref(),
+        &room_jid,
+        waddle_xmpp::muc::RoomConfig::default(),
+        "space".to_string(),
+        "private".to_string(),
+    )
+    .await
+    .expect("create room");
+    room_actor
+        .ask(JoinWithAffiliation {
+            sender_jid: bound_jid.clone(),
+            nick: "alice".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+        })
+        .await
+        .expect("join room");
+    let frame = "\
+        <iq xmlns='jabber:client' type='get' id='preview-muc-1' from='alice@example.com/desktop' to='example.com'>\
+          <lookup xmlns='urn:waddle:link-preview:0'>\
+            <url>https://example.com/article</url>\
+            <scope>private@muc.example.com</scope>\
+          </lookup>\
+        </iq>";
+
+    let responses = link_preview_lookup_for_test(state.as_ref(), session, &bound_jid, frame).await;
+
+    let response = responses.first().expect("lookup result");
+    let elem: Element = response.parse().expect("lookup xml");
+    let lookup = elem
+        .get_child("lookup", waddle_xmpp::xep::NS_WADDLE_LINK_PREVIEW)
+        .expect("lookup result");
+    assert_eq!(lookup.attr("status"), Some("ready"));
+    let preview = lookup
+        .get_child("preview", waddle_xmpp::xep::NS_WADDLE_LINK_PREVIEW)
+        .expect("preview");
+    let token =
+        waddle_xmpp::xep::LinkPreviewToken::new(preview.attr("token").expect("token").to_string())
+            .expect("token");
+    let decoded = waddle_xmpp::xep::decode_link_preview_token(
+        &token,
+        state.deps.occupant_id_secret.key(),
+        i64::MIN,
+    )
+    .expect("token payload");
+    assert_eq!(decoded.sender_jid.to_string(), "alice@example.com");
+    assert_eq!(decoded.scope_jid, room_jid);
+}
+
 /// Build a `<command/>` payload Element addressed at a XEP-0050
 /// component. Wraps it in a `<x type='submit'>` data form when one is
 /// provided so the call sites stay declarative.

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
@@ -3710,6 +3710,138 @@ async fn groupchat_messages_are_archived_and_returned_via_mam() {
 }
 
 #[tokio::test]
+async fn groupchat_preview_request_is_stamped_and_archived_without_private_payload() {
+    let state = create_test_websocket_state().await;
+    let session = create_test_session(state.as_ref(), "alice").await;
+    let room_jid: BareJid = "preview-pipeline@muc.example.com"
+        .parse()
+        .expect("room jid");
+    let sender_jid: FullJid = format!("{}@example.com/web", session.xmpp_localpart)
+        .parse()
+        .expect("sender jid");
+    let (sender_tx, mut sender_rx) = mpsc::channel(8);
+    state
+        .deps
+        .protocol
+        .connection_registry
+        .register(sender_jid.clone(), sender_tx);
+    let room_actor = get_or_create_room_actor(
+        state.as_ref(),
+        &room_jid,
+        RoomConfig::default(),
+        "waddle-alpha".to_string(),
+        "preview-pipeline".to_string(),
+    )
+    .await
+    .expect("create room");
+    room_actor
+        .ask(JoinWithAffiliation {
+            sender_jid: sender_jid.clone(),
+            nick: "alice".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+        })
+        .await
+        .expect("join room");
+
+    let preview = waddle_xmpp::xep::LinkPreviewTokenData {
+        sender_jid: "alice@example.com".parse().expect("sender bare jid"),
+        scope_jid: room_jid.clone(),
+        original_url: url::Url::parse("https://the.link.example/what-was-linked").expect("url"),
+        normalized_url: url::Url::parse("https://the.link.example/what-was-linked").expect("url"),
+        title: Some("The Best Webpage".to_string()),
+        description: Some("Plain text preview".to_string()),
+        expires_at_unix: chrono::Utc::now().timestamp() + 300,
+    };
+    let token =
+        waddle_xmpp::xep::encode_link_preview_token(&preview, state.deps.occupant_id_secret.key());
+    let mut message = xmpp_parsers::message::Message::new(Some(jid::Jid::from(room_jid.clone())));
+    message.id = Some(xmpp_parsers::message::Id(
+        "preview-pipeline-msg".to_string(),
+    ));
+    message.type_ = XmppMessageType::Groupchat;
+    message.bodies.insert(
+        xmpp_parsers::message::Lang::new(),
+        "read https://the.link.example/what-was-linked".to_string(),
+    );
+    message
+        .payloads
+        .push(waddle_xmpp::xep::build_link_preview_request_element(&token));
+
+    let responses =
+        handle_message_for_test(state.as_ref(), &sender_jid, Some(&session), message).await;
+    assert!(
+        responses.is_empty(),
+        "valid preview request should not produce direct errors: {responses:?}"
+    );
+    let echo_stanza = sender_rx
+        .try_recv()
+        .expect("sender echo queued on outbound channel");
+    let echo_xml = stanza_to_xml(&echo_stanza.stanza);
+    assert!(
+        echo_xml.contains(waddle_xmpp::xep::NS_RDF_SYNTAX) && echo_xml.contains("The Best Webpage"),
+        "echo should include stamped XEP-0511 metadata: {echo_xml}"
+    );
+    assert!(
+        !echo_xml.contains(waddle_xmpp::xep::NS_WADDLE_LINK_PREVIEW),
+        "private preview request must be stripped from echo: {echo_xml}"
+    );
+
+    let form = Element::builder("x", "jabber:x:data")
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "submit")
+        .append(
+            Element::builder("field", "jabber:x:data")
+                .attr(minidom::rxml::xml_ncname!("var").to_owned(), "FORM_TYPE")
+                .attr(minidom::rxml::xml_ncname!("type").to_owned(), "hidden")
+                .append(
+                    Element::builder("value", "jabber:x:data")
+                        .append("urn:xmpp:mam:2")
+                        .build(),
+                )
+                .build(),
+        )
+        .build();
+    let rsm = Element::builder("set", "http://jabber.org/protocol/rsm")
+        .append(
+            Element::builder("max", "http://jabber.org/protocol/rsm")
+                .append("50")
+                .build(),
+        )
+        .build();
+    let query = Element::builder("query", "urn:xmpp:mam:2")
+        .attr(
+            minidom::rxml::xml_ncname!("queryid").to_owned(),
+            "q-preview",
+        )
+        .append(form)
+        .append(rsm)
+        .build();
+    let mam_query = iq_set_frame("mam-preview", room_jid.as_str(), query);
+    let mam_responses = handle_iq(
+        mam_query.as_str(),
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(session),
+        &ready_phase(&sender_jid),
+    )
+    .await;
+
+    let archived_preview = mam_responses
+        .iter()
+        .find(|stanza| stanza.contains("The Best Webpage"))
+        .unwrap_or_else(|| panic!("expected archived preview in MAM result: {mam_responses:?}"));
+    assert!(
+        archived_preview.contains(waddle_xmpp::xep::NS_RDF_SYNTAX),
+        "MAM result should include stamped XEP-0511 metadata: {archived_preview}"
+    );
+    assert!(
+        !archived_preview.contains(waddle_xmpp::xep::NS_WADDLE_LINK_PREVIEW),
+        "private preview request must not be archived: {archived_preview}"
+    );
+}
+
+#[tokio::test]
 async fn personal_mam_query_uses_ready_phase_when_sidecar_session_is_missing() {
     let state = create_test_websocket_state().await;
     let alice_session = create_test_session(state.as_ref(), "alice").await;

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0511_link_metadata.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0511_link_metadata.cue
@@ -1,7 +1,8 @@
 package xmpp_e2e_scenarios
 
 scenario: #Scenario & {
-	name: "xep-0511-link-metadata"
+	name: "xep-0511-client-authored-link-metadata-is-stripped"
+	description: "Client-authored XEP-0511 metadata is not trusted; the server only stamps metadata from signed Waddle preview requests."
 	xeps: ["XEP-0313", "XEP-0511"]
 	users: {
 		alice: devices: phone: #Actor & {
@@ -44,12 +45,11 @@ scenario: #Scenario & {
 		#ExpectMessage & {
 			target: bobPhone
 			body:   linkBody
-			payloads: [
-				#LinkMetadata & {
-					about:       linked
-					title:       "The Best Webpage"
-					description: "This is a great webpage and you will really like it"
-					url:         canonical
+			absent: [canonical, "The Best Webpage", "https://ogp.me/ns#"]
+			absentElements: [
+				#XmlElement & {
+					name: "Description"
+					ns:   "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 				},
 			]
 		},
@@ -60,12 +60,11 @@ scenario: #Scenario & {
 		},
 		#ExpectMamResult & {
 			body: linkBody
-			payloads: [
-				#LinkMetadata & {
-					about:       linked
-					title:       "The Best Webpage"
-					description: "This is a great webpage and you will really like it"
-					url:         canonical
+			absent: [canonical, "The Best Webpage", "https://ogp.me/ns#"]
+			absentElements: [
+				#XmlElement & {
+					name: "Description"
+					ns:   "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 				},
 			]
 		},

--- a/server/crates/waddle-xmpp-client-ffi/src/convert.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/convert.rs
@@ -518,6 +518,11 @@ pub(super) fn send_options_from_ffi(opts: WaddleSendOptions) -> Result<SendMessa
         subject: None,
         markup_spans: vec![],
         references: vec![],
+        link_preview_token: opts
+            .link_preview_token
+            .map(messaging::LinkPreviewToken::new)
+            .transpose()
+            .map_err(|err| err.to_string())?,
     })
 }
 

--- a/server/crates/waddle-xmpp-client-ffi/src/types.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/types.rs
@@ -279,6 +279,7 @@ pub struct WaddleSendOptions {
     pub fallback: Option<WaddleFallbackRange>,
     pub thread: Option<WaddleThreadTarget>,
     pub shared_files: Vec<WaddleSharedFile>,
+    pub link_preview_token: Option<String>,
 }
 
 // ── A/V calls (XEP-0353 JMI + XEP-0166 Jingle) ──────────────────────────────

--- a/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
@@ -206,6 +206,7 @@ pub(crate) fn inbound_to_js(message: InboundMessage) -> WaddleMessage {
             .into_iter()
             .map(shared_file_to_js)
             .collect(),
+        link_previews: link_previews_to_js(message.link_previews),
         pin_event: message.pin_event.map(pin_event_to_js),
         extension_envelope: message.extension_envelope.map(extension_envelope_to_js),
         extension_body_fallback: message.extension_body_fallback,
@@ -362,6 +363,10 @@ pub(crate) fn archived_to_js(archived: ArchivedMessage) -> Option<WaddleArchived
                     .collect()
             })
             .unwrap_or_default(),
+        link_previews: parsed
+            .as_ref()
+            .map(|message| link_previews_to_js(message.link_previews.clone()))
+            .unwrap_or_default(),
         extension_envelope: parsed
             .as_ref()
             .and_then(|message| message.extension_envelope.clone())
@@ -425,6 +430,18 @@ pub(crate) fn shared_file_to_js(file: messaging::SharedFile) -> WaddleSharedFile
         disposition: file.disposition.as_str().to_string(),
         encrypted: file.encrypted.map(encrypted_file_to_js),
     }
+}
+
+fn link_previews_to_js(previews: Vec<messaging::LinkPreviewData>) -> Vec<WaddleLinkPreview> {
+    previews
+        .into_iter()
+        .map(|preview| WaddleLinkPreview {
+            original_url: preview.original_url.to_string(),
+            normalized_url: preview.normalized_url.map(|url| url.to_string()),
+            title: preview.title,
+            description: preview.description,
+        })
+        .collect()
 }
 
 pub(crate) fn call_event_to_js(event: InboundCallEvent) -> WaddleCallEvent {
@@ -788,6 +805,75 @@ mod inbound_to_js_tests {
         assert_eq!(reference.begin, 4);
         assert_eq!(reference.end, 23);
         assert!(reference.anchor.is_none());
+    }
+
+    #[test]
+    fn archived_to_js_propagates_xep0511_link_previews_for_reload_rendering() {
+        let archived = parse_mam_archived(
+            "<message xmlns='jabber:client'>\
+               <result xmlns='urn:xmpp:mam:2' id='mam-link' queryid='q1'>\
+                 <forwarded xmlns='urn:xmpp:forward:0'>\
+                   <delay xmlns='urn:xmpp:delay' stamp='2026-05-06T12:00:00Z'/>\
+                   <message xmlns='jabber:client' type='groupchat' id='m-link' \
+                            from='room@conf.example/alice'>\
+                     <body>see https://the.link.example/what-was-linked</body>\
+                     <rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#' rdf:about='https://the.link.example/what-was-linked'>\
+                       <og:title>The Best Webpage</og:title>\
+                       <og:description>Plain text preview</og:description>\
+                       <og:url>https://the.link.example/what-was-linked</og:url>\
+                     </rdf:Description>\
+                   </message>\
+                 </forwarded>\
+               </result>\
+             </message>",
+        );
+
+        let js = archived_to_js(archived).expect("valid archived message should convert");
+
+        assert_eq!(js.link_previews.len(), 1);
+        let preview = &js.link_previews[0];
+        assert_eq!(
+            preview.original_url,
+            "https://the.link.example/what-was-linked"
+        );
+        assert_eq!(
+            preview.normalized_url.as_deref(),
+            Some("https://the.link.example/what-was-linked")
+        );
+        assert_eq!(preview.title.as_deref(), Some("The Best Webpage"));
+        assert_eq!(preview.description.as_deref(), Some("Plain text preview"));
+    }
+
+    #[test]
+    fn archived_to_js_keeps_bodyless_xep0511_link_preview_rows() {
+        let archived = parse_mam_archived(
+            "<message xmlns='jabber:client'>\
+               <result xmlns='urn:xmpp:mam:2' id='mam-link-bodyless' queryid='q1'>\
+                 <forwarded xmlns='urn:xmpp:forward:0'>\
+                   <delay xmlns='urn:xmpp:delay' stamp='2026-05-06T12:00:00Z'/>\
+                   <message xmlns='jabber:client' type='groupchat' id='m-link' \
+                            from='room@conf.example/alice'>\
+                     <rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#' rdf:about='https://example.com/article'>\
+                       <og:title>Example Article</og:title>\
+                     </rdf:Description>\
+                   </message>\
+                 </forwarded>\
+               </result>\
+             </message>",
+        );
+
+        let js = archived_to_js(archived).expect("bodyless archived preview should convert");
+
+        assert_eq!(js.body, None);
+        assert_eq!(js.link_previews.len(), 1);
+        assert_eq!(
+            js.link_previews[0].original_url,
+            "https://example.com/article"
+        );
+        assert_eq!(
+            js.link_previews[0].title.as_deref(),
+            Some("Example Article")
+        );
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client-wasm/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/lib.rs
@@ -27,8 +27,8 @@ use waddle_xmpp_client::messaging::{
     self, build_chat_state_message, build_correction_message, build_displayed_message,
     build_moderation_message, build_outbound_message, build_pinned_message, build_reaction_message,
     build_retraction_message, build_unpinned_message, InboundCallEvent, InboundMessage,
-    InboundPresence, MarkupSpanData, MarkupSpanType, MucAffiliation, MucRole, ReferenceData,
-    SendMessageOptions, SharedFileDisposition,
+    InboundPresence, LinkPreviewToken, MarkupSpanData, MarkupSpanType, MucAffiliation, MucRole,
+    ReferenceData, SendMessageOptions, SharedFileDisposition,
 };
 use waddle_xmpp_client::pep::{
     build_pep_items_iq, build_publish_activity_iq, build_publish_mood_iq, build_publish_tune_iq,

--- a/server/crates/waddle-xmpp-client-wasm/src/options.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/options.rs
@@ -52,6 +52,11 @@ pub(crate) fn send_options_from_js(options: JsValue) -> Result<SendMessageOption
             id: thread.id,
             parent: thread.parent,
         }),
+        link_preview_token: options
+            .link_preview_token
+            .map(LinkPreviewToken::new)
+            .transpose()
+            .map_err(|err| js_error(err.to_string()))?,
         markup_spans: options
             .markup_spans
             .into_iter()

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -54,11 +54,20 @@ pub struct WaddleMessage {
     pub forum_thread_title: Option<String>,
     pub is_sticker: bool,
     pub shared_files: Vec<WaddleSharedFile>,
+    pub link_previews: Vec<WaddleLinkPreview>,
     /// urn:waddle:pin:0 pin/unpin event surfaced from a system message
     /// (#414). `None` when the message carries no `<pin-event/>`.
     pub pin_event: Option<WaddlePinEvent>,
     pub extension_envelope: Option<WaddleExtensionEnvelope>,
     pub extension_body_fallback: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct WaddleLinkPreview {
+    pub original_url: String,
+    pub normalized_url: Option<String>,
+    pub title: Option<String>,
+    pub description: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -205,6 +214,7 @@ pub struct WaddleArchivedMessage {
     pub is_sticker: bool,
     pub author_real_jid: Option<String>,
     pub shared_files: Vec<WaddleSharedFile>,
+    pub link_previews: Vec<WaddleLinkPreview>,
     pub extension_envelope: Option<WaddleExtensionEnvelope>,
     pub extension_body_fallback: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -741,6 +751,7 @@ pub struct WaddleSendOptions {
     pub reply: Option<WaddleReplyTarget>,
     pub fallback: Option<WaddleFallbackRange>,
     pub thread: Option<WaddleThreadTarget>,
+    pub link_preview_token: Option<String>,
     pub shared_files: Vec<WaddleSharedFile>,
     pub markup_spans: Vec<WaddleMarkupSpanInput>,
     pub references: Vec<WaddleReference>,

--- a/server/crates/waddle-xmpp-client/src/messaging.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging.rs
@@ -45,10 +45,10 @@ pub use types::{
     ExtensionLaunchContextData, ExtensionLaunchData, ExtensionNamespace,
     ExtensionPayloadAttributeData, ExtensionPayloadElementData, ExtensionPluginId,
     ExtensionRoomJid, ExtensionSourceData, ExtensionTextId, ExtensionTimestamp, ExtensionXmlName,
-    InboundMessage, InboundPresence, MarkupSpan, MarkupSpanData, MarkupSpanType, MdsDisplayedEntry,
-    MessagingEvent, ModerationPayload, MucAffiliation, MucRole, MujiPresence, PresenceHat,
-    ReactionPayload, ReferenceData, RetractionPayload, SendMessageOptions, SharedFile,
-    SharedFileDisposition,
+    InboundMessage, InboundPresence, InvalidLinkPreviewToken, LinkPreviewData, LinkPreviewToken,
+    MarkupSpan, MarkupSpanData, MarkupSpanType, MdsDisplayedEntry, MessagingEvent,
+    ModerationPayload, MucAffiliation, MucRole, MujiPresence, PresenceHat, ReactionPayload,
+    ReferenceData, RetractionPayload, SendMessageOptions, SharedFile, SharedFileDisposition,
 };
 /// Re-export the xmpp-parsers Jingle types Waddle's call surface
 /// owns so downstream crates (notably the wasm bindings, which

--- a/server/crates/waddle-xmpp-client/src/messaging/builders.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/builders.rs
@@ -422,6 +422,16 @@ pub fn build_outbound_message(
             }
         }
     }
+    if let Some(token) = options.link_preview_token.as_ref() {
+        builder = builder.append(
+            Element::builder("preview-request", NS_WADDLE_LINK_PREVIEW)
+                .attr(
+                    minidom::rxml::xml_ncname!("token").to_owned(),
+                    token.as_str(),
+                )
+                .build(),
+        );
+    }
     Ok((stanza_id, builder.build()))
 }
 

--- a/server/crates/waddle-xmpp-client/src/messaging/namespaces.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/namespaces.rs
@@ -23,6 +23,9 @@ pub(crate) const NS_URL_DATA: &str = "http://jabber.org/protocol/url-data";
 /// call sites).
 pub const NS_CLIENT: &str = "jabber:client";
 pub(crate) const NS_WADDLE_EXTENSION: &str = "urn:waddle:extension:1";
+pub(crate) const NS_WADDLE_LINK_PREVIEW: &str = "urn:waddle:link-preview:0";
+pub(crate) const NS_RDF_SYNTAX: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+pub(crate) const NS_OPENGRAPH: &str = "https://ogp.me/ns#";
 #[cfg(all(feature = "native", not(target_arch = "wasm32")))]
 pub(crate) const NS_MUC: &str = "http://jabber.org/protocol/muc";
 pub(crate) const NS_MUC_USER: &str = "http://jabber.org/protocol/muc#user";

--- a/server/crates/waddle-xmpp-client/src/messaging/parsing/mod.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/parsing/mod.rs
@@ -2,12 +2,15 @@ mod files;
 mod markup;
 pub(super) mod payloads;
 
+use std::borrow::Cow;
+
 use chrono::{DateTime, Utc};
 use minidom::Element;
 
 use crate::xep::encrypted_file::{self as xep_encrypted_file, NS_ESFS as NS_ENCRYPTED_FILE};
+use crate::xep::fallback::{body_fallbacks_for, strip_fallback_ranges, BodyFallback};
 use crate::xep::{reply as xep_reply, thread as xep_thread};
-use waddle_xmpp_core::xep0359::StanzaId as StableStanzaId;
+use waddle_xmpp_core::{first_eligible_https_url_text, xep0359::StanzaId as StableStanzaId};
 
 use self::files::{parse_file_sharing_element, parse_shared_file};
 use self::markup::parse_markup_spans;
@@ -19,6 +22,7 @@ pub use self::payloads::{
 use super::namespaces::*;
 use super::presence::parse_presence;
 use super::types::*;
+use url::Url;
 
 /// Parse an XMPP element into a [`MessagingEvent`], or return `None` if the
 /// element is not a `<message>` or `<presence>`.
@@ -215,6 +219,10 @@ fn parse_message(el: &Element) -> Option<InboundMessage> {
             shared_files.push(file);
         }
     }
+    let link_preview_body = body
+        .as_deref()
+        .map(|body| body_without_reply_fallback(el, body));
+    let link_previews = parse_link_previews(el, link_preview_body.as_deref());
 
     // XEP-0447 / XEP-0363: also check <sims> children for file sharing
     for sims_el in el.children().filter(|c| c.ns() == NS_SIMS) {
@@ -331,6 +339,7 @@ fn parse_message(el: &Element) -> Option<InboundMessage> {
         chat_state,
         displayed_marker_id,
         shared_files,
+        link_previews,
         broadcast_mention,
         mention_uris,
         references,
@@ -344,6 +353,64 @@ fn parse_message(el: &Element) -> Option<InboundMessage> {
         extension_body_fallback,
         mds_displayed,
     })
+}
+
+fn parse_link_previews(el: &Element, body: Option<&str>) -> Vec<LinkPreviewData> {
+    let first_url = body.and_then(first_eligible_https_url);
+    if body.is_some() && first_url.is_none() {
+        return Vec::new();
+    }
+    el.children()
+        .filter(|child| child.name() == "Description" && child.ns() == NS_RDF_SYNTAX)
+        .filter_map(|child| parse_link_preview(child, first_url.as_ref()))
+        .collect()
+}
+
+fn parse_link_preview(el: &Element, first_url: Option<&Url>) -> Option<LinkPreviewData> {
+    let original_url =
+        parse_web_url(el.attr_ns(&minidom::rxml::Namespace::from(NS_RDF_SYNTAX), "about")?)?;
+    if first_url.is_some() && first_url != Some(&original_url) {
+        return None;
+    }
+    Some(LinkPreviewData {
+        original_url,
+        normalized_url: og_text(el, "url").and_then(|value| parse_web_url(&value)),
+        title: og_text(el, "title"),
+        description: og_text(el, "description"),
+    })
+}
+
+fn parse_web_url(value: &str) -> Option<Url> {
+    let url = Url::parse(value).ok()?;
+    (url.scheme() == "https" && url.host_str().is_some_and(|host| host.contains('.')))
+        .then_some(url)
+}
+
+fn first_eligible_https_url(body: &str) -> Option<Url> {
+    first_eligible_https_url_text(body).and_then(|candidate| Url::parse(candidate).ok())
+}
+
+fn body_without_reply_fallback<'a>(message: &Element, body: &'a str) -> Cow<'a, str> {
+    let mut ranges = Vec::new();
+    for fallback in body_fallbacks_for(message, xep_reply::NS_REPLY) {
+        match fallback {
+            BodyFallback::Whole => return Cow::Borrowed(""),
+            BodyFallback::Ranges(body_ranges) => ranges.extend(body_ranges),
+        }
+    }
+    if ranges.is_empty() {
+        Cow::Borrowed(body)
+    } else {
+        Cow::Owned(strip_fallback_ranges(body, &ranges))
+    }
+}
+
+fn og_text(el: &Element, name: &str) -> Option<String> {
+    el.children()
+        .find(|child| child.name() == name && child.ns() == NS_OPENGRAPH)
+        .map(Element::text)
+        .map(|text| text.trim().to_string())
+        .filter(|text| !text.is_empty())
 }
 
 fn has_moderation_retract(element: &Element) -> bool {

--- a/server/crates/waddle-xmpp-client/src/messaging/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/tests.rs
@@ -457,6 +457,280 @@ fn parse_message_extracts_references_for_data_type() {
 }
 
 #[test]
+fn parse_message_extracts_xep0511_link_preview() {
+    let e = el(
+        "<message xmlns='jabber:client' type='groupchat' id='m-link'>\
+           <body>see https://the.link.example.com/what-was-linked-to</body>\
+           <rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#' rdf:about='https://the.link.example.com/what-was-linked-to'>\
+             <og:title>The Best Webpage</og:title>\
+             <og:description>This is a great webpage and you will really like it</og:description>\
+             <og:url>https://example.com/canonical-url/for/what-was-linked-to</og:url>\
+           </rdf:Description>\
+         </message>",
+    );
+    let MessagingEvent::Message(msg) = parse(&e).unwrap() else {
+        panic!("expected Message");
+    };
+    assert_eq!(msg.link_previews.len(), 1);
+    assert_eq!(
+        msg.link_previews[0].original_url.as_str(),
+        "https://the.link.example.com/what-was-linked-to"
+    );
+    assert_eq!(
+        msg.link_previews[0]
+            .normalized_url
+            .as_ref()
+            .map(url::Url::as_str),
+        Some("https://example.com/canonical-url/for/what-was-linked-to")
+    );
+    assert_eq!(
+        msg.link_previews[0].title.as_deref(),
+        Some("The Best Webpage")
+    );
+}
+
+#[test]
+fn parse_message_rejects_xep0511_link_preview_with_unsafe_scheme() {
+    let e = el(
+        "<message xmlns='jabber:client' type='groupchat' id='m-link'>\
+           <body>see this</body>\
+           <rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#' rdf:about='javascript:alert(1)'>\
+             <og:title>Bad</og:title>\
+           </rdf:Description>\
+         </message>",
+    );
+    let MessagingEvent::Message(msg) = parse(&e).unwrap() else {
+        panic!("expected Message");
+    };
+    assert!(msg.link_previews.is_empty());
+}
+
+#[test]
+fn parse_message_rejects_xep0511_link_preview_for_non_first_body_url() {
+    let e = el(
+        "<message xmlns='jabber:client' type='groupchat' id='m-link'>\
+           <body>first https://first.example.com/ then https://second.example.com/</body>\
+           <rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#' rdf:about='https://second.example.com/'>\
+             <og:title>Second</og:title>\
+           </rdf:Description>\
+         </message>",
+    );
+    let MessagingEvent::Message(msg) = parse(&e).unwrap() else {
+        panic!("expected Message");
+    };
+    assert!(msg.link_previews.is_empty());
+}
+
+#[test]
+fn parse_message_ignores_reply_fallback_url_when_matching_xep0511_preview() {
+    let fallback_prefix = "&gt; quoted \u{1f642} https://quoted.example.com/\n";
+    let fallback_text = "> quoted \u{1f642} https://quoted.example.com/\n";
+    let e = el(&format!(
+        "<message xmlns='jabber:client' type='groupchat' id='m-link'>\
+           <body>{fallback_prefix}see https://current.example.com/</body>\
+           <reply xmlns='urn:xmpp:reply:0' id='orig-id' to='alice@example.com'/>\
+           <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
+             <body start='0' end='{}'/>\
+           </fallback>\
+           <rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#' rdf:about='https://current.example.com/'>\
+             <og:title>Current</og:title>\
+           </rdf:Description>\
+         </message>",
+        fallback_text.encode_utf16().count()
+    ));
+    let MessagingEvent::Message(msg) = parse(&e).unwrap() else {
+        panic!("expected Message");
+    };
+    assert_eq!(msg.link_previews.len(), 1);
+    assert_eq!(
+        msg.link_previews[0].original_url.as_str(),
+        "https://current.example.com/"
+    );
+}
+
+#[test]
+fn parse_message_strips_multiple_reply_fallback_ranges_before_matching_xep0511_preview() {
+    let fallback_prefix = "&gt; quoted https://quoted.example.com/\n";
+    let visible_body = "see https://current.example.com/";
+    let fallback_suffix = "\n&gt; more https://later.example.com/";
+    let body = format!("{fallback_prefix}{visible_body}{fallback_suffix}");
+    let first_end = "> quoted https://quoted.example.com/\n"
+        .encode_utf16()
+        .count();
+    let second_start = first_end + visible_body.encode_utf16().count();
+    let second_end = second_start + "\n> more https://later.example.com/".encode_utf16().count();
+    let e = el(&format!(
+        "<message xmlns='jabber:client' type='groupchat' id='m-link'>\
+           <body>{body}</body>\
+           <reply xmlns='urn:xmpp:reply:0' id='orig-id' to='alice@example.com'/>\
+           <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
+             <body start='0' end='{first_end}'/>\
+             <body start='{second_start}' end='{second_end}'/>\
+           </fallback>\
+           <rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#' rdf:about='https://current.example.com/'>\
+             <og:title>Current</og:title>\
+           </rdf:Description>\
+         </message>"
+    ));
+    let MessagingEvent::Message(msg) = parse(&e).unwrap() else {
+        panic!("expected Message");
+    };
+
+    assert_eq!(msg.link_previews.len(), 1);
+    assert_eq!(
+        msg.link_previews[0].original_url.as_str(),
+        "https://current.example.com/"
+    );
+}
+
+#[test]
+fn parse_message_rejects_xep0511_preview_when_only_body_url_is_reply_fallback() {
+    let e = el(
+        "<message xmlns='jabber:client' type='groupchat' id='m-link'>\
+           <body>https://quoted.example.com/</body>\
+           <reply xmlns='urn:xmpp:reply:0' id='orig-id' to='alice@example.com'/>\
+           <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
+             <body/>\
+           </fallback>\
+           <rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#' rdf:about='https://quoted.example.com/'>\
+             <og:title>Quoted</og:title>\
+           </rdf:Description>\
+         </message>",
+    );
+    let MessagingEvent::Message(msg) = parse(&e).unwrap() else {
+        panic!("expected Message");
+    };
+
+    assert!(msg.link_previews.is_empty());
+}
+
+#[test]
+fn parse_message_extracts_xep0511_link_preview_for_wrapped_first_body_url() {
+    let e = el(
+        "<message xmlns='jabber:client' type='groupchat' id='m-link'>\
+           <body>see (https://the.link.example.com/what-was-linked-to).</body>\
+           <rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#' rdf:about='https://the.link.example.com/what-was-linked-to'>\
+             <og:title>The Best Webpage</og:title>\
+           </rdf:Description>\
+         </message>",
+    );
+    let MessagingEvent::Message(msg) = parse(&e).unwrap() else {
+        panic!("expected Message");
+    };
+    assert_eq!(msg.link_previews.len(), 1);
+    assert_eq!(
+        msg.link_previews[0].original_url.as_str(),
+        "https://the.link.example.com/what-was-linked-to"
+    );
+}
+
+#[test]
+fn parse_message_extracts_xep0511_link_preview_for_inline_punctuation_prefixed_body_url() {
+    let e = el(
+        "<message xmlns='jabber:client' type='groupchat' id='m-link'>\
+           <body>see:https://the.link.example.com/what-was-linked-to</body>\
+           <rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#' rdf:about='https://the.link.example.com/what-was-linked-to'>\
+             <og:title>The Best Webpage</og:title>\
+           </rdf:Description>\
+         </message>",
+    );
+    let MessagingEvent::Message(msg) = parse(&e).unwrap() else {
+        panic!("expected Message");
+    };
+    assert_eq!(msg.link_previews.len(), 1);
+    assert_eq!(
+        msg.link_previews[0].original_url.as_str(),
+        "https://the.link.example.com/what-was-linked-to"
+    );
+}
+
+#[test]
+fn parse_message_extracts_xep0511_link_preview_for_quoted_first_body_url() {
+    let e = el(
+        "<message xmlns='jabber:client' type='groupchat' id='m-link'>\
+           <body>see &quot;https://example.com&quot;</body>\
+           <rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#' rdf:about='https://example.com/'>\
+             <og:title>Example</og:title>\
+           </rdf:Description>\
+         </message>",
+    );
+    let MessagingEvent::Message(msg) = parse(&e).unwrap() else {
+        panic!("expected Message");
+    };
+    assert_eq!(msg.link_previews.len(), 1);
+    assert_eq!(
+        msg.link_previews[0].original_url.as_str(),
+        "https://example.com/"
+    );
+}
+
+#[test]
+fn parse_message_extracts_bodyless_xep0511_link_preview() {
+    let e = el(
+        "<message xmlns='jabber:client' type='groupchat' id='m-link'>\
+           <rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#' rdf:about='https://example.com/article'>\
+             <og:title>Example</og:title>\
+           </rdf:Description>\
+         </message>",
+    );
+    let MessagingEvent::Message(msg) = parse(&e).unwrap() else {
+        panic!("expected Message");
+    };
+    assert_eq!(msg.link_previews.len(), 1);
+    assert_eq!(
+        msg.link_previews[0].original_url.as_str(),
+        "https://example.com/article"
+    );
+}
+
+#[test]
+fn parse_message_rejects_bodyless_xep0511_link_preview_for_host_without_dot() {
+    let e = el(
+        "<message xmlns='jabber:client' type='groupchat' id='m-link'>\
+           <rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#' rdf:about='https://localhost/article'>\
+             <og:title>Localhost</og:title>\
+           </rdf:Description>\
+         </message>",
+    );
+    let MessagingEvent::Message(msg) = parse(&e).unwrap() else {
+        panic!("expected Message");
+    };
+    assert!(msg.link_previews.is_empty());
+}
+
+#[test]
+fn parse_message_rejects_xep0511_link_preview_with_bare_about_attribute() {
+    let e = el(
+        "<message xmlns='jabber:client' type='groupchat' id='m-link'>\
+           <body>see https://example.com/</body>\
+           <rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#' about='https://example.com/'>\
+             <og:title>Example</og:title>\
+           </rdf:Description>\
+         </message>",
+    );
+    let MessagingEvent::Message(msg) = parse(&e).unwrap() else {
+        panic!("expected Message");
+    };
+    assert!(msg.link_previews.is_empty());
+}
+
+#[test]
+fn parse_message_rejects_xep0511_link_preview_without_rdf_about_attribute() {
+    let e = el(
+        "<message xmlns='jabber:client' type='groupchat' id='m-link'>\
+           <body>see https://example.com/</body>\
+           <rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#'>\
+             <og:title>Example</og:title>\
+           </rdf:Description>\
+         </message>",
+    );
+    let MessagingEvent::Message(msg) = parse(&e).unwrap() else {
+        panic!("expected Message");
+    };
+    assert!(msg.link_previews.is_empty());
+}
+
+#[test]
 fn parse_message_extracts_references_for_mention_type() {
     let e = el(
         "<message xmlns='jabber:client' type='groupchat' id='m-mention'>\
@@ -774,6 +1048,27 @@ fn build_outbound_message_with_shared_files() {
             .and_then(|url_data| url_data.attr("target")),
         Some("https://files.example.com/song.ogg")
     );
+}
+
+#[test]
+fn build_outbound_message_with_link_preview_token_request() {
+    let options = SendMessageOptions {
+        link_preview_token: Some(LinkPreviewToken::new("preview-token-1").expect("token")),
+        ..Default::default()
+    };
+
+    let (_stanza_id, stanza) = build_outbound_message(
+        "room@muc.example",
+        "groupchat",
+        "see https://example.com",
+        &options,
+    )
+    .unwrap();
+
+    let request = stanza
+        .get_child("preview-request", NS_WADDLE_LINK_PREVIEW)
+        .expect("preview request");
+    assert_eq!(request.attr("token"), Some("preview-token-1"));
 }
 
 #[test]

--- a/server/crates/waddle-xmpp-client/src/messaging/types.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/types.rs
@@ -1,4 +1,6 @@
 use chrono::{DateTime, Utc};
+use std::fmt;
+use url::Url;
 use waddle_xmpp_core::xep0359::StanzaId as StableStanzaId;
 
 use crate::request::StanzaId;
@@ -146,6 +148,7 @@ pub struct InboundMessage {
     pub chat_state: Option<String>,
     pub displayed_marker_id: Option<String>,
     pub shared_files: Vec<SharedFile>,
+    pub link_previews: Vec<LinkPreviewData>,
     pub broadcast_mention: Option<String>,
     pub mention_uris: Vec<String>,
     /// XEP-0372 references attached to this message. Populated for *every*
@@ -188,6 +191,14 @@ pub struct MdsDisplayedEntry {
     /// JID that injected the stanza-id (the MUC room for group
     /// chats; the user's own server for 1:1 chats).
     pub stanza_id_by: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkPreviewData {
+    pub original_url: Url,
+    pub normalized_url: Option<Url>,
+    pub title: Option<String>,
+    pub description: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -577,7 +588,38 @@ pub struct SendMessageOptions {
     pub references: Vec<ReferenceData>,
     /// XEP-0446 / XEP-0447 shared files attached to the message.
     pub shared_files: Vec<SharedFile>,
+    /// Waddle-private link-preview token request consumed server-side before
+    /// fanout/archive and replaced by conformant XEP-0511 metadata.
+    pub link_preview_token: Option<LinkPreviewToken>,
 }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkPreviewToken(String);
+
+impl LinkPreviewToken {
+    pub fn new(value: impl Into<String>) -> Result<Self, InvalidLinkPreviewToken> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            return Err(InvalidLinkPreviewToken);
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InvalidLinkPreviewToken;
+
+impl fmt::Display for InvalidLinkPreviewToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("link preview token must not be empty")
+    }
+}
+
+impl std::error::Error for InvalidLinkPreviewToken {}
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct MarkupSpanData {

--- a/server/crates/waddle-xmpp-client/src/xep/fallback.rs
+++ b/server/crates/waddle-xmpp-client/src/xep/fallback.rs
@@ -4,6 +4,18 @@ use minidom::Element;
 
 pub const NS_FALLBACK: &str = "urn:xmpp:fallback:0";
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FallbackRange {
+    pub start: usize,
+    pub end: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BodyFallback {
+    Whole,
+    Ranges(Vec<FallbackRange>),
+}
+
 pub fn has_whole_body_fallback_for(message: &Element, feature_ns: &str) -> bool {
     message.children().any(|child| {
         child.name() == "fallback"
@@ -21,6 +33,70 @@ fn fallback_marks_whole_body(fallback: &Element) -> bool {
         return fallback.children().next().is_none();
     };
     body.attr("start").is_none() && body.attr("end").is_none() && body_children.next().is_none()
+}
+
+pub fn body_fallbacks_for(message: &Element, feature_ns: &str) -> Vec<BodyFallback> {
+    message
+        .children()
+        .filter(|child| {
+            child.name() == "fallback"
+                && child.ns() == NS_FALLBACK
+                && child.attr("for") == Some(feature_ns)
+        })
+        .filter_map(parse_body_fallback)
+        .collect()
+}
+
+fn parse_body_fallback(fallback: &Element) -> Option<BodyFallback> {
+    let body_children: Vec<&Element> = fallback
+        .children()
+        .filter(|child| child.name() == "body" && child.ns() == NS_FALLBACK)
+        .collect();
+
+    if body_children.is_empty() {
+        return None;
+    }
+
+    let mut ranges = Vec::new();
+    let body_count = body_children.len();
+    for body in body_children {
+        match (body.attr("start"), body.attr("end")) {
+            (None, None) if body_count == 1 => return Some(BodyFallback::Whole),
+            (None, None) => return None,
+            (Some(start), Some(end)) => {
+                let start = start.parse::<usize>().ok()?;
+                let end = end.parse::<usize>().ok()?;
+                if end < start {
+                    return None;
+                }
+                ranges.push(FallbackRange { start, end });
+            }
+            _ => return None,
+        }
+    }
+    Some(BodyFallback::Ranges(ranges))
+}
+
+pub fn strip_fallback_ranges(body: &str, ranges: &[FallbackRange]) -> String {
+    if ranges.is_empty() {
+        return body.to_string();
+    }
+    let units: Vec<u16> = body.encode_utf16().collect();
+    let total = units.len();
+    let mut keep = vec![true; total];
+    for range in ranges {
+        let start = range.start.min(total);
+        let end = range.end.min(total).max(start);
+        for flag in keep.iter_mut().take(end).skip(start) {
+            *flag = false;
+        }
+    }
+    let kept: Vec<u16> = units
+        .iter()
+        .zip(keep.iter())
+        .filter_map(|(unit, keep)| keep.then_some(*unit))
+        .collect();
+    String::from_utf16_lossy(&kept)
 }
 
 #[cfg(test)]
@@ -42,5 +118,60 @@ mod tests {
             "urn:waddle:extension:1"
         ));
         assert!(!has_whole_body_fallback_for(&message, "urn:xmpp:reply:0"));
+    }
+
+    #[test]
+    fn parses_multiple_body_ranges_for_requested_feature() {
+        let message = "<message xmlns='jabber:client'>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
+              <body start='0' end='4'/>\
+              <body start='9' end='14'/>\
+            </fallback>\
+        </message>"
+            .parse::<Element>()
+            .expect("message");
+
+        assert_eq!(
+            body_fallbacks_for(&message, "urn:xmpp:reply:0"),
+            vec![BodyFallback::Ranges(vec![
+                FallbackRange { start: 0, end: 4 },
+                FallbackRange { start: 9, end: 14 }
+            ])]
+        );
+    }
+
+    #[test]
+    fn rejects_mixed_whole_body_and_ranged_body_fallback() {
+        let message = "<message xmlns='jabber:client'>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
+              <body/>\
+              <body start='9' end='14'/>\
+            </fallback>\
+        </message>"
+            .parse::<Element>()
+            .expect("message");
+
+        assert!(body_fallbacks_for(&message, "urn:xmpp:reply:0").is_empty());
+    }
+
+    #[test]
+    fn ignores_childless_feature_scoped_fallback_for_body_stripping() {
+        let message = "<message xmlns='jabber:client'>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'/>\
+        </message>"
+            .parse::<Element>()
+            .expect("message");
+
+        assert!(body_fallbacks_for(&message, "urn:xmpp:reply:0").is_empty());
+    }
+
+    #[test]
+    fn strips_utf16_fallback_ranges() {
+        let ranges = [FallbackRange { start: 0, end: 4 }];
+
+        assert_eq!(
+            strip_fallback_ranges("\u{1f642}ab visible", &ranges),
+            " visible"
+        );
     }
 }

--- a/server/crates/waddle-xmpp-client/src/xep/reply.rs
+++ b/server/crates/waddle-xmpp-client/src/xep/reply.rs
@@ -21,7 +21,8 @@ pub struct ReplyMarker {
 }
 
 /// A character-offset range identifying the fallback text inside the body.
-/// Per XEP-0428, offsets count Unicode scalar values and `end` is exclusive.
+/// Per the XEP-0426 character-position model referenced by XEP-0428, offsets
+/// count UTF-16 code units and `end` is exclusive.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FallbackRange {
     pub start: u32,

--- a/server/crates/waddle-xmpp-core/src/lib.rs
+++ b/server/crates/waddle-xmpp-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod connection;
 pub mod disco;
 pub mod domain;
 pub mod error;
+pub mod link_preview;
 pub mod mam;
 pub mod parser_utils;
 pub mod presence;
@@ -38,6 +39,7 @@ pub use domain::{
     ChannelInfo, ChannelRoomInfo, ChannelType, UploadSlotInfo, WaddleDetails, WaddleInfo,
 };
 pub use error::{CoreError, CoreResult};
+pub use link_preview::first_eligible_https_url_text;
 pub use mam::{
     build_fin_iq, build_result_messages, is_mam_query, is_mam_query_response_message,
     parse_mam_query, ArchivedMessage, MamQuery, MamResult, DATA_FORMS_NS, FORWARD_NS, MAM_NS,

--- a/server/crates/waddle-xmpp-core/src/link_preview.rs
+++ b/server/crates/waddle-xmpp-core/src/link_preview.rs
@@ -1,0 +1,57 @@
+//! Shared link-preview URL eligibility helpers.
+
+/// Return the first HTTPS URL-like token whose host looks web-addressable.
+///
+/// This intentionally stays string-based so crates that already parse into
+/// their local URL type can do so at the boundary without adding URL parsing
+/// dependencies to `waddle-xmpp-core`.
+pub fn first_eligible_https_url_text(body: &str) -> Option<&str> {
+    body.char_indices().find_map(|(idx, _)| {
+        if !body[idx..]
+            .get(..8)
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case("https://"))
+        {
+            return None;
+        }
+
+        let candidate = body[idx..]
+            .split(|ch: char| ch.is_whitespace() || matches!(ch, '<' | '>' | '"' | '\''))
+            .next()
+            .unwrap_or_default()
+            .trim_end_matches([')', ']', '}', ',', '.', '!', '?', ';', ':']);
+        let rest = candidate.get(8..)?;
+        let host = rest.split(['/', '?', '#']).next().unwrap_or_default();
+        (!host.is_empty() && host.contains('.')).then_some(candidate)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn selects_first_eligible_https_url() {
+        assert_eq!(
+            first_eligible_https_url_text(
+                "see http://ignored.example then https://first.example/a, and https://second.example/b",
+            ),
+            Some("https://first.example/a")
+        );
+    }
+
+    #[test]
+    fn trims_wrapping_trailing_punctuation() {
+        assert_eq!(
+            first_eligible_https_url_text("see (https://example.com/a)."),
+            Some("https://example.com/a")
+        );
+    }
+
+    #[test]
+    fn rejects_host_without_dot() {
+        assert_eq!(
+            first_eligible_https_url_text("see https://localhost/a"),
+            None
+        );
+    }
+}

--- a/server/crates/waddle-xmpp/src/xep/exports.rs
+++ b/server/crates/waddle-xmpp/src/xep/exports.rs
@@ -228,7 +228,8 @@ pub use super::xep0444::{
 
 pub use super::xep0428::{
     build_fallback_element, is_fallback_element, parse_fallbacks_from_message,
-    set_fallback_payloads, strip_fallback_ranges, FallbackIndication, FallbackRange, NS_FALLBACK,
+    set_fallback_payloads, strip_fallback_ranges, FallbackIndication, FallbackRange,
+    FallbackRegion, NS_FALLBACK,
 };
 
 pub use super::xep0430::{
@@ -419,12 +420,25 @@ pub use super::xep_waddle_forums::{
     NS_FORUMS,
 };
 
+pub use super::xep_waddle_link_preview::{
+    build_link_preview_request_element, decode_link_preview_token, encode_link_preview_token,
+    extract_link_preview_request_from_message, is_link_preview_request_element,
+    parse_link_preview_request_element, strip_link_preview_requests, LinkPreviewToken,
+    LinkPreviewTokenData, WaddleLinkPreviewError, ELEMENT_PREVIEW_REQUEST, NS_WADDLE_LINK_PREVIEW,
+};
+
 pub use super::xep0503::{
     build_channel_item, build_muc_roominfo_form, build_muc_roominfo_pubsub_form,
     build_room_metadata_form, build_room_space_metadata_forms,
     build_room_space_metadata_forms_with_description, build_server_role_form, build_space_node_iri,
     build_space_parent_form, build_spaces_metadata_form, build_spaces_metadata_form_for_requester,
     build_spaces_type_form, SpaceAffiliation, NS_SPACES, NS_WADDLE_ROOM_METADATA,
+};
+
+pub use super::xep0511::{
+    build_link_metadata_element, extract_link_metadata_from_message, is_link_metadata_element,
+    parse_link_metadata_element, set_link_metadata, strip_link_metadata, LinkMetadata,
+    LinkMetadataError, NS_OPENGRAPH, NS_OPENGRAPH_IMAGE, NS_RDF_SYNTAX,
 };
 
 // Re-export commonly used items at the xep module level

--- a/server/crates/waddle-xmpp/src/xep/mod.rs
+++ b/server/crates/waddle-xmpp/src/xep/mod.rs
@@ -197,10 +197,12 @@ pub mod xep0492;
 pub mod xep0500;
 pub mod xep0502;
 pub mod xep0503;
+pub mod xep0511;
 pub mod xep0513;
 pub mod xep_waddle_dm_bookmarks;
 pub mod xep_waddle_dnd;
 pub mod xep_waddle_forums;
+pub mod xep_waddle_link_preview;
 pub mod xep_waddle_livekit_transport;
 pub mod xep_waddle_pin;
 

--- a/server/crates/waddle-xmpp/src/xep/xep0511.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0511.rs
@@ -1,0 +1,277 @@
+//! XEP-0511: Link Metadata
+//!
+//! Provides a typed view over the XEP-0511 RDF/OpenGraph message payload:
+//! an `rdf:Description` element with a namespaced `rdf:about` attribute and
+//! optional OpenGraph text properties.
+
+use minidom::{
+    rxml::{xml_ncname, Namespace},
+    Element,
+};
+use thiserror::Error;
+use url::Url;
+use xmpp_parsers::message::Message;
+
+/// RDF syntax namespace used by XEP-0511's `<rdf:Description/>` payload.
+pub const NS_RDF_SYNTAX: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+
+/// OpenGraph namespace recommended by XEP-0511.
+pub const NS_OPENGRAPH: &str = "https://ogp.me/ns#";
+
+/// OpenGraph image structured-property namespace.
+pub const NS_OPENGRAPH_IMAGE: &str = "https://ogp.me/ns#image:";
+
+/// Errors that can occur while parsing XEP-0511 link metadata.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum LinkMetadataError {
+    /// The root was not `<rdf:Description/>`.
+    #[error("expected <Description/> in namespace '{NS_RDF_SYNTAX}'")]
+    WrongRoot,
+    /// The required namespaced `rdf:about` attribute is missing.
+    #[error("missing rdf:about on XEP-0511 link metadata")]
+    MissingAbout,
+    /// A plain, non-RDF `about` attribute was supplied.
+    #[error("XEP-0511 requires rdf:about, not a bare about attribute")]
+    BareAbout,
+    /// The `rdf:about` value was not a valid URL.
+    #[error("invalid rdf:about URL")]
+    InvalidAboutUrl,
+    /// The `og:url` value was not a valid URL.
+    #[error("invalid OpenGraph canonical URL")]
+    InvalidCanonicalUrl,
+}
+
+/// Typed plaintext subset of the OpenGraph metadata used by Waddle's first
+/// XEP-0511 tracer bullet.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkMetadata {
+    /// IRI described by this payload (`rdf:about`).
+    pub about: Url,
+    /// `og:title`, when present.
+    pub title: Option<String>,
+    /// `og:description`, when present.
+    pub description: Option<String>,
+    /// `og:url`, when present.
+    pub canonical_url: Option<Url>,
+    /// `og:site_name`, when present.
+    pub site_name: Option<String>,
+}
+
+impl LinkMetadata {
+    /// Create link metadata for the described URL.
+    pub fn new(about: Url) -> Self {
+        Self {
+            about,
+            title: None,
+            description: None,
+            canonical_url: None,
+            site_name: None,
+        }
+    }
+
+    /// Set `og:title`.
+    pub fn with_title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
+        self
+    }
+
+    /// Set `og:description`.
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Set `og:url`.
+    pub fn with_canonical_url(mut self, canonical_url: Url) -> Self {
+        self.canonical_url = Some(canonical_url);
+        self
+    }
+
+    /// Set `og:site_name`.
+    pub fn with_site_name(mut self, site_name: impl Into<String>) -> Self {
+        self.site_name = Some(site_name.into());
+        self
+    }
+}
+
+/// Check if an element is an XEP-0511 `<rdf:Description/>` payload.
+pub fn is_link_metadata_element(elem: &Element) -> bool {
+    elem.name() == "Description" && elem.ns() == NS_RDF_SYNTAX
+}
+
+/// Parse one XEP-0511 `<rdf:Description/>` payload.
+pub fn parse_link_metadata_element(elem: &Element) -> Result<LinkMetadata, LinkMetadataError> {
+    if !is_link_metadata_element(elem) {
+        return Err(LinkMetadataError::WrongRoot);
+    }
+    if has_bare_about(elem) {
+        return Err(LinkMetadataError::BareAbout);
+    }
+
+    let about = elem
+        .attr_ns(&Namespace::from(NS_RDF_SYNTAX), "about")
+        .ok_or(LinkMetadataError::MissingAbout)
+        .and_then(|raw| Url::parse(raw).map_err(|_| LinkMetadataError::InvalidAboutUrl))?;
+
+    let mut metadata = LinkMetadata::new(about);
+    metadata.title = og_text(elem, "title");
+    metadata.description = og_text(elem, "description");
+    metadata.site_name = og_text(elem, "site_name");
+    metadata.canonical_url = match og_text(elem, "url") {
+        Some(raw) => Some(Url::parse(&raw).map_err(|_| LinkMetadataError::InvalidCanonicalUrl)?),
+        None => None,
+    };
+
+    Ok(metadata)
+}
+
+/// Extract all valid XEP-0511 link metadata payloads from a message.
+///
+/// Individual malformed payloads are ignored so foreign or legacy archive
+/// data cannot make the entire message unreadable. Use
+/// [`parse_link_metadata_element`] directly when strict conformance diagnostics
+/// are required.
+pub fn extract_link_metadata_from_message(msg: &Message) -> Vec<LinkMetadata> {
+    msg.payloads
+        .iter()
+        .filter(|payload| is_link_metadata_element(payload))
+        .filter_map(|payload| parse_link_metadata_element(payload).ok())
+        .collect()
+}
+
+/// Build one XEP-0511 `<rdf:Description/>` payload.
+pub fn build_link_metadata_element(metadata: &LinkMetadata) -> Element {
+    let mut description = Element::builder("Description", NS_RDF_SYNTAX)
+        .prefix(Some("rdf".to_string()), NS_RDF_SYNTAX)
+        .expect("static RDF prefix is unique")
+        .prefix(Some("og".to_string()), NS_OPENGRAPH)
+        .expect("static OpenGraph prefix is unique")
+        .attr_ns(
+            Namespace::from(NS_RDF_SYNTAX),
+            xml_ncname!("about").to_owned(),
+            metadata.about.as_str(),
+        )
+        .build();
+
+    append_og_text(&mut description, "title", metadata.title.as_deref());
+    append_og_text(
+        &mut description,
+        "description",
+        metadata.description.as_deref(),
+    );
+    append_og_text(
+        &mut description,
+        "url",
+        metadata.canonical_url.as_ref().map(Url::as_str),
+    );
+    append_og_text(&mut description, "site_name", metadata.site_name.as_deref());
+
+    description
+}
+
+/// Add link metadata to a message.
+pub fn set_link_metadata(msg: &mut Message, metadata: &[LinkMetadata]) {
+    strip_link_metadata(msg);
+    msg.payloads
+        .extend(metadata.iter().map(build_link_metadata_element));
+}
+
+/// Remove XEP-0511 link metadata payloads from a message.
+pub fn strip_link_metadata(msg: &mut Message) {
+    msg.payloads
+        .retain(|payload| !is_link_metadata_element(payload));
+}
+
+fn has_bare_about(elem: &Element) -> bool {
+    elem.attrs()
+        .iter()
+        .any(|((ns, name), _)| ns.as_str().is_empty() && name.as_str() == "about")
+}
+
+fn og_text(elem: &Element, name: &str) -> Option<String> {
+    elem.children()
+        .find(|child| child.name() == name && child.ns() == NS_OPENGRAPH)
+        .map(Element::text)
+        .map(|text| text.trim().to_string())
+        .filter(|text| !text.is_empty())
+}
+
+fn append_og_text(parent: &mut Element, name: &str, value: Option<&str>) {
+    let Some(value) = value.filter(|value| !value.trim().is_empty()) else {
+        return;
+    };
+    parent.append_child(
+        Element::builder(name, NS_OPENGRAPH)
+            .append(value.trim())
+            .build(),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn element(xml: &str) -> Element {
+        xml.parse::<Element>().expect("valid xml")
+    }
+
+    #[test]
+    fn parses_xep0511_description_with_namespaced_rdf_about() {
+        let payload = element(
+            r#"<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:og="https://ogp.me/ns#" rdf:about="https://the.link.example.com/what-was-linked-to">
+                <og:title>The Best Webpage</og:title>
+                <og:description>This is a great webpage and you will really like it</og:description>
+                <og:url>https://example.com/canonical-url/for/what-was-linked-to</og:url>
+                <og:site_name>Example Website</og:site_name>
+              </rdf:Description>"#,
+        );
+
+        let parsed = parse_link_metadata_element(&payload).expect("valid XEP-0511 metadata");
+
+        assert_eq!(
+            parsed.about.as_str(),
+            "https://the.link.example.com/what-was-linked-to"
+        );
+        assert_eq!(parsed.title.as_deref(), Some("The Best Webpage"));
+        assert_eq!(
+            parsed.description.as_deref(),
+            Some("This is a great webpage and you will really like it")
+        );
+        assert_eq!(
+            parsed.canonical_url.as_ref().map(Url::as_str),
+            Some("https://example.com/canonical-url/for/what-was-linked-to")
+        );
+        assert_eq!(parsed.site_name.as_deref(), Some("Example Website"));
+    }
+
+    #[test]
+    fn rejects_bare_about_attribute() {
+        let payload = element(
+            r#"<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" about="https://example.com/">
+                <title xmlns="https://ogp.me/ns#">Example</title>
+              </rdf:Description>"#,
+        );
+
+        let err = parse_link_metadata_element(&payload).expect_err("bare about must be rejected");
+
+        assert_eq!(err, LinkMetadataError::BareAbout);
+    }
+
+    #[test]
+    fn builds_conformant_metadata_with_rdf_about() {
+        let metadata = LinkMetadata::new(Url::parse("https://example.com/original").expect("url"))
+            .with_title("Example")
+            .with_description("Plain text preview")
+            .with_canonical_url(Url::parse("https://example.com/canonical").expect("url"));
+
+        let elem = build_link_metadata_element(&metadata);
+        let parsed = parse_link_metadata_element(&elem).expect("built metadata parses");
+
+        assert_eq!(parsed, metadata);
+        assert_eq!(
+            elem.attr_ns(&Namespace::from(NS_RDF_SYNTAX), "about"),
+            Some("https://example.com/original")
+        );
+        assert_eq!(elem.attr("about"), None);
+    }
+}

--- a/server/crates/waddle-xmpp/src/xep/xep_waddle_link_preview.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep_waddle_link_preview.rs
@@ -1,0 +1,267 @@
+//! Waddle link-preview request payload.
+//!
+//! This is intentionally not XEP-0511. It is a private request element the
+//! sender includes after an XMPP-native composer lookup. The server consumes
+//! it before fanout/archive and stamps conformant XEP-0511 metadata instead.
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use hmac::{Hmac, KeyInit, Mac};
+use jid::BareJid;
+use minidom::{rxml::xml_ncname, Element};
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use thiserror::Error;
+use url::Url;
+use xmpp_parsers::message::Message;
+
+/// Waddle-private link preview namespace.
+pub const NS_WADDLE_LINK_PREVIEW: &str = "urn:waddle:link-preview:0";
+
+/// Root element for a send-time preview token request.
+pub const ELEMENT_PREVIEW_REQUEST: &str = "preview-request";
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Opaque composer preview token.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkPreviewToken(String);
+
+impl LinkPreviewToken {
+    /// Wrap an already encoded token.
+    pub fn new(token: impl Into<String>) -> Option<Self> {
+        let token = token.into();
+        (!token.trim().is_empty()).then_some(Self(token))
+    }
+
+    /// Borrow the encoded token text.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Typed payload carried inside a preview token for the first tracer bullet.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkPreviewTokenData {
+    pub sender_jid: BareJid,
+    pub scope_jid: BareJid,
+    pub original_url: Url,
+    pub normalized_url: Url,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub expires_at_unix: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct LinkPreviewTokenWire {
+    sender_jid: String,
+    scope_jid: String,
+    original_url: String,
+    normalized_url: String,
+    title: Option<String>,
+    description: Option<String>,
+    expires_at_unix: i64,
+}
+
+/// Errors for private Waddle link-preview request parsing.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum WaddleLinkPreviewError {
+    #[error("expected <preview-request/> in namespace '{NS_WADDLE_LINK_PREVIEW}'")]
+    WrongRoot,
+    #[error("missing preview token")]
+    MissingToken,
+    #[error("invalid preview token encoding")]
+    InvalidTokenEncoding,
+    #[error("invalid preview token JSON")]
+    InvalidTokenJson,
+    #[error("invalid preview token signature")]
+    InvalidTokenSignature,
+    #[error("invalid preview token JID")]
+    InvalidTokenJid,
+    #[error("invalid preview token URL")]
+    InvalidTokenUrl,
+    #[error("preview token expired")]
+    Expired,
+}
+
+/// Check if an element is a Waddle link-preview request.
+pub fn is_link_preview_request_element(elem: &Element) -> bool {
+    elem.name() == ELEMENT_PREVIEW_REQUEST && elem.ns() == NS_WADDLE_LINK_PREVIEW
+}
+
+/// Parse a `<preview-request/>` element into its opaque token.
+pub fn parse_link_preview_request_element(
+    elem: &Element,
+) -> Result<LinkPreviewToken, WaddleLinkPreviewError> {
+    if !is_link_preview_request_element(elem) {
+        return Err(WaddleLinkPreviewError::WrongRoot);
+    }
+    elem.attr("token")
+        .and_then(LinkPreviewToken::new)
+        .ok_or(WaddleLinkPreviewError::MissingToken)
+}
+
+/// Extract the first preview request token from a message.
+pub fn extract_link_preview_request_from_message(msg: &Message) -> Option<LinkPreviewToken> {
+    msg.payloads
+        .iter()
+        .find(|payload| is_link_preview_request_element(payload))
+        .and_then(|payload| parse_link_preview_request_element(payload).ok())
+}
+
+/// Build a private send-time preview request payload.
+pub fn build_link_preview_request_element(token: &LinkPreviewToken) -> Element {
+    Element::builder(ELEMENT_PREVIEW_REQUEST, NS_WADDLE_LINK_PREVIEW)
+        .attr(xml_ncname!("token").to_owned(), token.as_str())
+        .build()
+}
+
+/// Remove private Waddle link-preview requests from a message.
+pub fn strip_link_preview_requests(msg: &mut Message) {
+    msg.payloads
+        .retain(|payload| !is_link_preview_request_element(payload));
+}
+
+/// Encode the narrow plaintext preview data into an opaque token.
+pub fn encode_link_preview_token(data: &LinkPreviewTokenData, secret: &[u8]) -> LinkPreviewToken {
+    let wire = LinkPreviewTokenWire {
+        sender_jid: data.sender_jid.to_string(),
+        scope_jid: data.scope_jid.to_string(),
+        original_url: data.original_url.as_str().to_string(),
+        normalized_url: data.normalized_url.as_str().to_string(),
+        title: data.title.clone(),
+        description: data.description.clone(),
+        expires_at_unix: data.expires_at_unix,
+    };
+    let json = serde_json::to_vec(&wire).expect("wire token is serializable");
+    let mut mac = HmacSha256::new_from_slice(secret).expect("HMAC accepts any key size");
+    mac.update(&json);
+    let signature = mac.finalize().into_bytes();
+    LinkPreviewToken(format!(
+        "{}.{}",
+        URL_SAFE_NO_PAD.encode(json),
+        URL_SAFE_NO_PAD.encode(signature)
+    ))
+}
+
+/// Decode and validate an opaque preview token.
+pub fn decode_link_preview_token(
+    token: &LinkPreviewToken,
+    secret: &[u8],
+    now_unix: i64,
+) -> Result<LinkPreviewTokenData, WaddleLinkPreviewError> {
+    let (payload, signature) = token
+        .as_str()
+        .split_once('.')
+        .ok_or(WaddleLinkPreviewError::InvalidTokenEncoding)?;
+    let json = URL_SAFE_NO_PAD
+        .decode(payload)
+        .map_err(|_| WaddleLinkPreviewError::InvalidTokenEncoding)?;
+    let signature = URL_SAFE_NO_PAD
+        .decode(signature)
+        .map_err(|_| WaddleLinkPreviewError::InvalidTokenEncoding)?;
+    let mut mac = HmacSha256::new_from_slice(secret).expect("HMAC accepts any key size");
+    mac.update(&json);
+    mac.verify_slice(&signature)
+        .map_err(|_| WaddleLinkPreviewError::InvalidTokenSignature)?;
+    let wire: LinkPreviewTokenWire =
+        serde_json::from_slice(&json).map_err(|_| WaddleLinkPreviewError::InvalidTokenJson)?;
+    if wire.expires_at_unix < now_unix {
+        return Err(WaddleLinkPreviewError::Expired);
+    }
+    Ok(LinkPreviewTokenData {
+        sender_jid: wire
+            .sender_jid
+            .parse()
+            .map_err(|_| WaddleLinkPreviewError::InvalidTokenJid)?,
+        scope_jid: wire
+            .scope_jid
+            .parse()
+            .map_err(|_| WaddleLinkPreviewError::InvalidTokenJid)?,
+        original_url: Url::parse(&wire.original_url)
+            .map_err(|_| WaddleLinkPreviewError::InvalidTokenUrl)?,
+        normalized_url: Url::parse(&wire.normalized_url)
+            .map_err(|_| WaddleLinkPreviewError::InvalidTokenUrl)?,
+        title: wire.title,
+        description: wire.description,
+        expires_at_unix: wire.expires_at_unix,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECRET: &[u8] = b"test-link-preview-secret";
+
+    #[test]
+    fn request_element_round_trips_token() {
+        let token = LinkPreviewToken::new("token-1").expect("token");
+        let elem = build_link_preview_request_element(&token);
+
+        assert_eq!(
+            parse_link_preview_request_element(&elem).expect("request"),
+            token
+        );
+    }
+
+    #[test]
+    fn token_round_trips_typed_preview_data() {
+        let data = LinkPreviewTokenData {
+            sender_jid: "alice@example.com".parse().expect("jid"),
+            scope_jid: "room@muc.example.com".parse().expect("jid"),
+            original_url: Url::parse("https://example.com/path").expect("url"),
+            normalized_url: Url::parse("https://example.com/path").expect("url"),
+            title: Some("Example".to_string()),
+            description: Some("Plain text preview".to_string()),
+            expires_at_unix: 1_900_000_000,
+        };
+
+        let token = encode_link_preview_token(&data, SECRET);
+
+        assert_eq!(
+            decode_link_preview_token(&token, SECRET, 1_800_000_000),
+            Ok(data)
+        );
+    }
+
+    #[test]
+    fn tampered_token_signature_is_rejected() {
+        let data = LinkPreviewTokenData {
+            sender_jid: "alice@example.com".parse().expect("jid"),
+            scope_jid: "room@muc.example.com".parse().expect("jid"),
+            original_url: Url::parse("https://example.com/path").expect("url"),
+            normalized_url: Url::parse("https://example.com/path").expect("url"),
+            title: Some("Example".to_string()),
+            description: Some("Plain text preview".to_string()),
+            expires_at_unix: 1_900_000_000,
+        };
+
+        let mut token = encode_link_preview_token(&data, SECRET);
+        token.0.push('x');
+
+        assert_eq!(
+            decode_link_preview_token(&token, SECRET, 1_800_000_000),
+            Err(WaddleLinkPreviewError::InvalidTokenSignature)
+        );
+    }
+
+    #[test]
+    fn expired_token_is_rejected() {
+        let data = LinkPreviewTokenData {
+            sender_jid: "alice@example.com".parse().expect("jid"),
+            scope_jid: "room@muc.example.com".parse().expect("jid"),
+            original_url: Url::parse("https://example.com/").expect("url"),
+            normalized_url: Url::parse("https://example.com/").expect("url"),
+            title: None,
+            description: None,
+            expires_at_unix: 10,
+        };
+
+        let token = encode_link_preview_token(&data, SECRET);
+
+        assert_eq!(
+            decode_link_preview_token(&token, SECRET, 11),
+            Err(WaddleLinkPreviewError::Expired)
+        );
+    }
+}

--- a/server/crates/waddle-xmpp/tests/xep0511_link_metadata.rs
+++ b/server/crates/waddle-xmpp/tests/xep0511_link_metadata.rs
@@ -1,0 +1,109 @@
+//! XEP-0511: Link Metadata — dedicated conformance suite.
+//!
+//! Pins Waddle's public XEP-0511 surface to the RDF/OpenGraph wire
+//! shape that clients render from live messages and MAM replay.
+
+use minidom::Element;
+use url::Url;
+use waddle_xmpp::xep::{
+    build_link_metadata_element, extract_link_metadata_from_message, parse_link_metadata_element,
+    set_link_metadata, strip_link_metadata, LinkMetadata, LinkMetadataError, NS_OPENGRAPH,
+    NS_RDF_SYNTAX,
+};
+use xmpp_parsers::message::Message;
+
+fn element(xml: &str) -> Element {
+    xml.parse().expect("valid xml")
+}
+
+#[test]
+fn xep0511_builds_rdf_description_with_namespaced_about_and_opengraph_children() {
+    let metadata = LinkMetadata::new(Url::parse("https://the.link.example/article").expect("url"))
+        .with_title("The Best Webpage")
+        .with_description("Plain text preview")
+        .with_canonical_url(Url::parse("https://example.com/canonical").expect("url"))
+        .with_site_name("Example");
+
+    let payload = build_link_metadata_element(&metadata);
+
+    assert_eq!(payload.name(), "Description");
+    assert_eq!(payload.ns(), NS_RDF_SYNTAX);
+    assert_eq!(
+        payload.attr_ns(&minidom::rxml::Namespace::from(NS_RDF_SYNTAX), "about"),
+        Some("https://the.link.example/article")
+    );
+    assert_eq!(
+        payload
+            .get_child("title", NS_OPENGRAPH)
+            .map(Element::text)
+            .as_deref(),
+        Some("The Best Webpage")
+    );
+    assert_eq!(
+        payload
+            .get_child("description", NS_OPENGRAPH)
+            .map(Element::text)
+            .as_deref(),
+        Some("Plain text preview")
+    );
+    assert_eq!(
+        payload
+            .get_child("url", NS_OPENGRAPH)
+            .map(Element::text)
+            .as_deref(),
+        Some("https://example.com/canonical")
+    );
+}
+
+#[test]
+fn xep0511_parse_rejects_bare_or_missing_about() {
+    let bare_about = element(
+        "<rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#' about='https://example.com/a'>\
+           <og:title>Example</og:title>\
+         </rdf:Description>",
+    );
+    assert!(matches!(
+        parse_link_metadata_element(&bare_about),
+        Err(LinkMetadataError::BareAbout)
+    ));
+
+    let missing_about = element(
+        "<rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#'>\
+           <og:title>Example</og:title>\
+         </rdf:Description>",
+    );
+    assert!(matches!(
+        parse_link_metadata_element(&missing_about),
+        Err(LinkMetadataError::MissingAbout)
+    ));
+}
+
+#[test]
+fn xep0511_message_helpers_round_trip_and_strip_metadata_payloads() {
+    let mut message = Message::new(None::<jid::Jid>);
+    let metadata =
+        LinkMetadata::new(Url::parse("https://example.com/a").expect("url")).with_title("Example");
+
+    set_link_metadata(&mut message, std::slice::from_ref(&metadata));
+
+    let extracted = extract_link_metadata_from_message(&message);
+    assert_eq!(extracted, vec![metadata]);
+
+    strip_link_metadata(&mut message);
+    assert!(extract_link_metadata_from_message(&message).is_empty());
+}
+
+#[test]
+fn xep0511_message_extraction_skips_malformed_metadata_payloads() {
+    let mut message = Message::new(None::<jid::Jid>);
+    let valid =
+        LinkMetadata::new(Url::parse("https://example.com/valid").expect("url")).with_title("OK");
+    message.payloads.push(element(
+        "<rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#' about='https://example.com/bare'>\
+           <og:title>Invalid</og:title>\
+         </rdf:Description>",
+    ));
+    message.payloads.push(build_link_metadata_element(&valid));
+
+    assert_eq!(extract_link_metadata_from_message(&message), vec![valid]);
+}

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpts4ufv";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpts4ufv";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpts4ufv";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpuxu3ad";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpuxu3ad";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpuxu3ad";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=mpts4ufv";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=mpuxu3ad";


### PR DESCRIPTION
## Issue

Closes #823.

## Summary

- Adds an XMPP-native link preview lookup IQ for the composer, scoped by sender and conversation.
- Mints signed preview tokens for the first eligible HTTPS URL and validates sender, scope, expiry, and body URL before stamping.
- Strips private `urn:waddle:link-preview:0` requests and any client-authored XEP-0511 metadata before fanout/archive, then stamps conformant XEP-0511 RDF/OpenGraph metadata.
- Projects link previews through live messages, MAM archive reload, Rust-to-WASM archive bridge, and native UniFFI send options.
- Keeps queued sends token-free in localStorage and reacquires fresh preview tokens on DM and room replay.
- Addresses PR review hardening: typed preview token boundary, shared URL eligibility scanner, structured DOM-built lookup IQ serialization, no client-minted fallback token, `noopener`, best-effort XEP-0511 message extraction, and reply-fallback-aware URL validation across UTF-16, multi-range, whole-body, mixed, and childless fallback shapes.

## Implementation Plan / Work Done

1. Add typed Rust XEP-0511 and Waddle-private preview-token helpers.
2. Add server lookup IQ handling, MUC occupant authorization for room scopes, and send-time preview stamping.
3. Add Rust client, WASM, and UniFFI DTO support for outbound preview tokens and inbound/archived link previews.
4. Add chat composer lookup, optimistic preview rendering, live/MAM reconciliation, and offline replay reacquisition.
5. Build the plaintext lookup IQ with browser XML document APIs (`createElementNS`, text nodes, `XMLSerializer`) instead of string templates.
6. Make message-level XEP-0511 extraction best-effort while keeping strict element parsing for diagnostics/conformance.
7. Strip XEP-0461 reply fallback text before client/server first-URL matching, including UTF-16, multi-range, whole-body, mixed, and childless fallback coverage aligned with the XEP-0428 parser semantics.
8. Add dedicated Rust XEP-0511 tests plus server, WASM bridge, parser, queue, send, live-merge, and MAM projection regressions.
9. Update CUE E2E coverage to prove client-authored XEP-0511 is stripped unless minted through the signed preview-token path.

## Tests

- `cargo fmt --check`
- `cargo test -p waddle-xmpp-core link_preview`
- `cargo test -p waddle-server preview`
- `cargo test -p waddle-server --test xmpp_e2e_cue`
- `cargo test -p waddle-xmpp xep0511`
- `cargo test -p waddle-xmpp-client link_preview`
- `cargo test -p waddle-xmpp-client xep0511`
- `cargo test -p waddle-xmpp-client reply_fallback`
- `cargo test -p waddle-xmpp-client fallback`
- `cargo test -p waddle-xmpp-client-wasm xep0511`
- `cargo check -p waddle-xmpp-client-wasm -p waddle-xmpp-client-ffi`
- `cargo clippy -p waddle-xmpp -p waddle-xmpp-client -p waddle-server --all-targets -- -D warnings`
- `cargo clippy -p waddle-xmpp-client --all-targets -- -D warnings`
- `cargo clippy --release --locked --workspace --all-features --all-targets -- -D warnings`
- `bun test tests/link-preview.test.ts tests/offline-queue.test.ts tests/muc-send.test.ts tests/chat-send.test.ts`
- `bun test tests/link-preview.test.ts tests/muc-send.test.ts tests/chat-send.test.ts tests/inbound-references.test.ts tests/offline-queue.test.ts tests/dm-live-merge.test.ts tests/channel-live-merge.test.ts`
- `bun run lint`
- `bun run build`
- `git diff --check`
- Final adversarial code, test, and security reviews: no actionable findings.

## Remaining Risks / Out of Scope

- Full resolver hardening, fetched images, video cards, and dismissal UI are intentionally out of scope for this tracer bullet.
- `cargo audit` was not run because `cargo-audit` is not installed in this environment.
- `bun audit` reports pre-existing workspace advisories not introduced by this PR.
- No Knip ignores were added.