### PR TITLE
fix(chat): fail open composer link previews

### DIFF
--- a/chat/src/channels/muc-send.ts
+++ b/chat/src/channels/muc-send.ts
@@ -5,10 +5,10 @@ import type { WaddleSession } from "@/lib/server-auth";
 import type { BrowserXmppClient } from "@/lib/xmpp-client";
 import { MAX_FILE_UPLOAD_BYTES } from "@/lib/xmpp/file-upload";
 import type { OutboundFileAttachment } from "@/lib/xmpp";
+import { composerLinkPreviewPayloadIsFresh, type ComposerLinkPreviewSendPayload } from "@/lib/link-preview-composer";
 import {
   inferredFileDisposition,
   type DeliveryStatus,
-  type LinkPreview,
   type MarkupSpan,
   type MessageReference,
   type TimelineMessage,
@@ -83,6 +83,7 @@ export function useMucSend(deps: UseMucSendDeps) {
     files?: Array<File | Blob>,
     replyTo?: { id: string; author: string; body?: string },
     forumTitleOrThreadOverride?: string | { threadId: string; parentThreadId?: string },
+    linkPreview?: ComposerLinkPreviewSendPayload,
   ) {
     const bodyText = body ?? draft.value;
     // markup !== undefined means this came from the rich editor (composer send)
@@ -162,23 +163,14 @@ export function useMucSend(deps: UseMucSendDeps) {
       const threadReply = channelIsForum && replyTo && threadId
         ? { threadId }
         : undefined;
-      const linkPreview = typeof client.lookupLinkPreview === "function"
-        ? await client.lookupLinkPreview(bodyText, currentRoomJid.value ?? channelId)
-        : null;
-      const linkPreviews: LinkPreview[] = linkPreview && linkPreview.status === "ready"
-        ? [{
-            originalUrl: linkPreview.originalUrl,
-            normalizedUrl: linkPreview.normalizedUrl,
-            ...(linkPreview.title ? { title: linkPreview.title } : {}),
-            ...(linkPreview.description ? { description: linkPreview.description } : {}),
-          }]
-        : [];
+      const freshLinkPreview = composerLinkPreviewPayloadIsFresh(linkPreview) ? linkPreview : undefined;
+      const linkPreviews = freshLinkPreview ? [freshLinkPreview.preview] : [];
       const result = await client.sendGroupMessage(spaceId, channelId, bodyText, {
         markup,
         references,
         files: attachments,
-        ...(linkPreview?.token ? { linkPreviewToken: linkPreview.token } : {}),
-        ...(linkPreview?.expiresAt ? { linkPreviewExpiresAt: linkPreview.expiresAt } : {}),
+        ...(freshLinkPreview ? { linkPreviewToken: freshLinkPreview.token } : {}),
+        ...(freshLinkPreview ? { linkPreviewExpiresAt: freshLinkPreview.expiresAt } : {}),
         ...(wireReplyTo ? { replyTo: wireReplyTo } : {}),
         ...(threadId ? { threadId } : {}),
         ...(parentThreadId ? { parentThreadId } : {}),

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -282,6 +282,13 @@ function onSelectChannelFromSidebar(id: string | null, roomJid?: string) {
   if (roomJid) selectChannelByRoomJid(roomJid);
 }
 
+async function lookupActiveChannelLinkPreview(body: string) {
+  const client = xmppClient.value;
+  const roomJid = activeChannelRoomJid.value;
+  if (!client || !roomJid) return null;
+  return client.lookupLinkPreview(body, roomJid);
+}
+
 function getCallSender(): CallWireSender | null {
   const client = connectionStore.client as unknown as { xmpp?: unknown } | null;
   return (client?.xmpp as CallWireSender | undefined) ?? null;
@@ -887,6 +894,8 @@ onUnmounted(() => {
               :channel-name="waddles.currentChannel.value?.name ?? ''"
               :reaction-mode="reactionModeTarget === 'thread' ? reactionModeState : null"
               :target-message-id="activeThreadTargetMessageId"
+              :link-preview-lookup="lookupActiveChannelLinkPreview"
+              :link-preview-scope="activeChannelRoomJid"
               @close="closeThreadPanel"
               @pop-to="popThreadTo"
               @push-thread="pushThread"

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -24,6 +24,7 @@ import type { MentionCandidate } from "@/lib/mentions";
 import type { BrowserXmppClient, MessageSearchResult, XmppStatusSnapshot, RoomAuthority, RoomHats, RoomPresence } from "@/lib/xmpp-client";
 import type { MemberLoadState } from "@/waddles/directory";
 import type { DiscoveredExtensionCommand, ExtensionCommandAction, ExtensionCommandResult } from "@/lib/xmpp/extension-commands";
+import type { ComposerLinkPreviewLookup, ComposerLinkPreviewSendPayload } from "@/lib/link-preview-composer";
 import { useScrollDirectionPreference } from "@/preferences/scroll-direction";
 import type { MessageThreadIndex } from "@/channels/threads";
 import { formatTimelineStamp, formatTimelineDayDivider, isSameTimelineDay } from "@/channels/timeline";
@@ -116,6 +117,7 @@ const emit = defineEmits<{
     files?: Array<File | Blob>,
     replyTo?: { id: string; author: string; body?: string },
     forumTitle?: string,
+    linkPreview?: ComposerLinkPreviewSendPayload,
   ];
   typing: [];
   editMessage: [messageId: string, newBody: string, markup?: MarkupSpan[], references?: MessageReference[]];
@@ -309,7 +311,13 @@ async function openSearchResult(result: MessageSearchResult) {
   await scrollToMessage(result.id);
 }
 
-function onSend(body: string, markup: MarkupSpan[], references: MessageReference[], files?: Array<File | Blob>) {
+function onSend(
+  body: string,
+  markup: MarkupSpan[],
+  references: MessageReference[],
+  files?: Array<File | Blob>,
+  linkPreview?: ComposerLinkPreviewSendPayload,
+) {
   const pending = replyingTo.value;
   emit(
     "send",
@@ -319,6 +327,7 @@ function onSend(body: string, markup: MarkupSpan[], references: MessageReference
     files,
     pending ? { id: pending.id, author: pending.author, ...(pending.body ? { body: pending.body } : {}) } : undefined,
     !pending && detectForumChannel(props.channel) ? forumTitle.value : undefined,
+    linkPreview,
   );
   // Don't clear replyingTo here — wait for send to complete (success or failure)
 }
@@ -393,6 +402,13 @@ const updateExtensionCommandField = extensionLauncher.updateField;
 const resetExtensionLauncherState = extensionLauncher.reset;
 const submitExtensionCommandForm = extensionLauncher.submitForm;
 const invokeCommandResultAction = extensionLauncher.invokeResultAction;
+const linkPreviewScope = computed(() => props.dmPeer?.peerJid ?? props.roomJid ?? null);
+const linkPreviewLookup = computed<ComposerLinkPreviewLookup | null>(() => {
+  const client = props.xmppClient;
+  const scopeJid = linkPreviewScope.value;
+  if (!client || !scopeJid) return null;
+  return (body: string) => client.lookupLinkPreview(body, scopeJid);
+});
 async function dispatchSlashCommand(
   invocation: Parameters<typeof extensionLauncher.dispatchSlashInvocation>[0],
 ): Promise<boolean> {
@@ -1126,6 +1142,8 @@ function dayDividerLabel(createdAt: string): string {
       :slash-commands="allDiscoveredCommands"
       :in-muc="inMucContext"
       :dispatch-slash-command="dispatchSlashCommand"
+      :link-preview-lookup="linkPreviewLookup"
+      :link-preview-scope="linkPreviewScope"
       @send="onSend"
       @cancel-reply="cancelReply"
       @typing="emit('typing')"
@@ -1453,6 +1471,8 @@ function dayDividerLabel(createdAt: string): string {
       :slash-commands="allDiscoveredCommands"
       :in-muc="inMucContext"
       :dispatch-slash-command="dispatchSlashCommand"
+      :link-preview-lookup="linkPreviewLookup"
+      :link-preview-scope="linkPreviewScope"
       @send="onSend"
       @cancel-reply="cancelReply"
       @typing="emit('typing')"

--- a/chat/src/components/chat/MessageComposer.vue
+++ b/chat/src/components/chat/MessageComposer.vue
@@ -15,6 +15,8 @@ import { parseSlashTrigger } from "@/lib/slash-trigger";
 import { filterSlashCandidates, resolveSlashCommand } from "@/lib/slash-match";
 import { buildSlashInvocation, type SlashInvocation } from "@/lib/slash-dispatch";
 import type { DiscoveredExtensionCommand } from "@/lib/xmpp/extension-commands";
+import { useComposerLinkPreview } from "@/lib/use-composer-link-preview";
+import type { ComposerLinkPreviewLookup, ComposerLinkPreviewSendPayload } from "@/lib/link-preview-composer";
 import {
   isAudioFile,
   isImageFile,
@@ -54,10 +56,18 @@ const props = defineProps<{
   slashCommands?: DiscoveredExtensionCommand[];
   inMuc?: boolean;
   dispatchSlashCommand?: (invocation: SlashInvocation) => Promise<boolean>;
+  linkPreviewLookup?: ComposerLinkPreviewLookup | null;
+  linkPreviewScope?: string | null;
 }>();
 
 const emit = defineEmits<{
-  send: [body: string, markup: MarkupSpan[], references: MessageReference[], files?: Array<File | Blob>];
+  send: [
+    body: string,
+    markup: MarkupSpan[],
+    references: MessageReference[],
+    files?: Array<File | Blob>,
+    linkPreview?: ComposerLinkPreviewSendPayload,
+  ];
   typing: [];
   selectGif: [url: string];
   cancelReply: [];
@@ -99,6 +109,11 @@ const tiptapEditor = computed(() => {
 });
 
 const pendingAttachments = ref<PendingAttachment[]>([]);
+const linkPreview = useComposerLinkPreview(
+  draft,
+  computed(() => props.linkPreviewLookup),
+  computed(() => props.linkPreviewScope),
+);
 
 function attachmentName(file: File | Blob): string {
   return file instanceof File && file.name
@@ -455,6 +470,7 @@ function onSend(doc: JSONContent) {
     serialized.markup,
     serialized.references,
     files.length > 0 ? files : undefined,
+    linkPreview.sendPayload.value,
   );
 }
 
@@ -556,6 +572,7 @@ watch(
     }
   },
 );
+
 </script>
 
 <template>
@@ -565,7 +582,7 @@ watch(
     @keydown.capture="onKeydown"
   >
     <div
-      v-if="replyingTo || showForumTitleInput || pendingAttachments.length > 0 || uploadProgress.uploading"
+      v-if="replyingTo || showForumTitleInput || linkPreview.showCard.value || pendingAttachments.length > 0 || uploadProgress.uploading"
       class="chat-composer-aux-stack"
     >
       <!-- Reply context chip — appears above the composer when the
@@ -594,6 +611,34 @@ watch(
           @click="emit('cancelReply')"
         >
           <X class="w-3.5 h-3.5" />
+        </button>
+      </div>
+
+      <div
+        v-if="linkPreview.showCard.value"
+        class="type-caption flex min-w-0 items-center gap-3 rounded-lg border border-border bg-card/70 px-3 py-2 animate-fade-in"
+        :aria-busy="linkPreview.state.value.kind === 'loading'"
+      >
+        <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+          <Loader2
+            v-if="linkPreview.state.value.kind === 'loading'"
+            class="h-4 w-4 motion-safe:animate-spin"
+            aria-hidden="true"
+          />
+          <FileText v-else class="h-4 w-4" aria-hidden="true" />
+        </div>
+        <div class="min-w-0 flex-1">
+          <div class="type-emphasis truncate text-foreground">{{ linkPreview.title.value }}</div>
+          <div class="truncate text-muted-foreground">{{ linkPreview.description.value }}</div>
+        </div>
+        <button
+          type="button"
+          class="h-8 w-8 flex items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+          title="Remove preview"
+          aria-label="Remove preview"
+          @click="linkPreview.dismiss"
+        >
+          <X class="h-3.5 w-3.5" aria-hidden="true" />
         </button>
       </div>
 

--- a/chat/src/components/chat/MessageComposer.vue
+++ b/chat/src/components/chat/MessageComposer.vue
@@ -632,6 +632,7 @@ watch(
           <div class="truncate text-muted-foreground">{{ linkPreview.description.value }}</div>
         </div>
         <button
+          v-if="linkPreview.canDismiss.value"
           type="button"
           class="h-8 w-8 flex items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
           title="Remove preview"

--- a/chat/src/components/chat/ThreadPanel.vue
+++ b/chat/src/components/chat/ThreadPanel.vue
@@ -8,6 +8,7 @@ import MessageComposer from "@/components/chat/MessageComposer.vue";
 import VirtualTimeline from "@/components/chat/VirtualTimeline.vue";
 import type { ExtensionAnnotationAction, TimelineMessage, MarkupSpan, MessageReference } from "@/lib/chat-ui";
 import type { MentionCandidate } from "@/lib/mentions";
+import type { ComposerLinkPreviewLookup, ComposerLinkPreviewSendPayload } from "@/lib/link-preview-composer";
 import type { OccupantAuthority, OccupantHat, OccupantPresence, RoomAuthority, RoomHats, RoomPresence } from "@/lib/xmpp-client";
 import type { MessageThreadEntry, MessageThreadIndex } from "@/channels/threads";
 import { useScrollDirectionPreference } from "@/preferences/scroll-direction";
@@ -53,6 +54,8 @@ const props = defineProps<{
    */
   hideComposer?: boolean;
   invokeExtensionAction?: (action: ExtensionAnnotationAction) => Promise<unknown>;
+  linkPreviewLookup?: ComposerLinkPreviewLookup | null;
+  linkPreviewScope?: string | null;
 }>();
 
 const emit = defineEmits<{
@@ -66,6 +69,7 @@ const emit = defineEmits<{
     files: Array<File | Blob> | undefined,
     replyTo: { id: string; author: string; body?: string } | undefined,
     threadOverride: { threadId: string; parentThreadId?: string },
+    linkPreview?: ComposerLinkPreviewSendPayload,
   ];
   editMessage: [messageId: string, newBody: string, markup?: MarkupSpan[], references?: MessageReference[]];
   retractMessage: [messageId: string];
@@ -514,7 +518,13 @@ function cancelReplyInThread() {
   replyingTo.value = null;
 }
 
-function onSend(body: string, markup: MarkupSpan[], references: MessageReference[], files?: Array<File | Blob>) {
+function onSend(
+  body: string,
+  markup: MarkupSpan[],
+  references: MessageReference[],
+  files?: Array<File | Blob>,
+  linkPreview?: ComposerLinkPreviewSendPayload,
+) {
   const threadId = activeThreadId.value;
   if (!threadId) return;
   const entry = activeEntry.value;
@@ -529,7 +539,7 @@ function onSend(body: string, markup: MarkupSpan[], references: MessageReference
       : undefined;
   const override: { threadId: string; parentThreadId?: string } = { threadId };
   if (parentThreadId.value) override.parentThreadId = parentThreadId.value;
-  emit("send", body, markup, references, files, effectiveReply, override);
+  emit("send", body, markup, references, files, effectiveReply, override, linkPreview);
   replyingTo.value = null;
   draft.value = "";
 }
@@ -677,6 +687,8 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
         :upload-progress="uploadProgress"
         :replying-to="replyingTo"
         :is-top-pinned="true"
+        :link-preview-lookup="linkPreviewLookup"
+        :link-preview-scope="linkPreviewScope"
         @send="onSend"
         @cancel-reply="cancelReplyInThread"
         @typing="onTyping"
@@ -859,6 +871,8 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
         :upload-progress="uploadProgress"
         :replying-to="replyingTo"
         :is-top-pinned="false"
+        :link-preview-lookup="linkPreviewLookup"
+        :link-preview-scope="linkPreviewScope"
         @send="onSend"
         @cancel-reply="cancelReplyInThread"
         @typing="onTyping"

--- a/chat/src/dms/chat-send.ts
+++ b/chat/src/dms/chat-send.ts
@@ -3,10 +3,10 @@ import type { WaddleSession } from "@/lib/server-auth";
 import type { BrowserXmppClient } from "@/lib/xmpp-client";
 import { MAX_FILE_UPLOAD_BYTES } from "@/lib/xmpp/file-upload";
 import type { OutboundFileAttachment } from "@/lib/xmpp";
+import { composerLinkPreviewPayloadIsFresh, type ComposerLinkPreviewSendPayload } from "@/lib/link-preview-composer";
 import {
   inferredFileDisposition,
   type DeliveryStatus,
-  type LinkPreview,
   type MarkupSpan,
   type MessageReference,
   type TimelineMessage,
@@ -65,6 +65,7 @@ export function useChatSend(deps: UseChatSendDeps) {
     references?: MessageReference[],
     files?: Array<File | Blob>,
     replyTo?: { id: string; author: string; body?: string },
+    linkPreview?: ComposerLinkPreviewSendPayload,
   ) {
     const bodyText = explicitBody ?? draft.value;
     const fromComposer = markup !== undefined;
@@ -108,23 +109,14 @@ export function useChatSend(deps: UseChatSendDeps) {
           }
         : undefined;
       const threadId = parent ? (parent.threadId ?? parent.id) : undefined;
-      const linkPreview = typeof client.lookupLinkPreview === "function"
-        ? await client.lookupLinkPreview(bodyText, peerJid)
-        : null;
-      const linkPreviews: LinkPreview[] = linkPreview && linkPreview.status === "ready"
-        ? [{
-            originalUrl: linkPreview.originalUrl,
-            normalizedUrl: linkPreview.normalizedUrl,
-            ...(linkPreview.title ? { title: linkPreview.title } : {}),
-            ...(linkPreview.description ? { description: linkPreview.description } : {}),
-          }]
-        : [];
+      const freshLinkPreview = composerLinkPreviewPayloadIsFresh(linkPreview) ? linkPreview : undefined;
+      const linkPreviews = freshLinkPreview ? [freshLinkPreview.preview] : [];
       const result = await client.sendDirectMessage(peerJid, bodyText, {
         markup,
         references,
         files: attachments,
-        ...(linkPreview?.token ? { linkPreviewToken: linkPreview.token } : {}),
-        ...(linkPreview?.expiresAt ? { linkPreviewExpiresAt: linkPreview.expiresAt } : {}),
+        ...(freshLinkPreview ? { linkPreviewToken: freshLinkPreview.token } : {}),
+        ...(freshLinkPreview ? { linkPreviewExpiresAt: freshLinkPreview.expiresAt } : {}),
         ...(wireReplyTo ? { replyTo: wireReplyTo } : {}),
         ...(threadId ? { threadId } : {}),
       });

--- a/chat/src/lib/link-preview-composer.ts
+++ b/chat/src/lib/link-preview-composer.ts
@@ -1,0 +1,66 @@
+import type { LinkPreview } from "@/lib/chat-ui";
+import { firstEligibleHttpsUrl, type LinkPreviewLookupResult } from "@/lib/xmpp/link-preview";
+
+export type ComposerLinkPreviewLookup = (body: string) => Promise<LinkPreviewLookupResult | null>;
+
+export interface ComposerLinkPreviewSendPayload {
+  token: string;
+  expiresAt: string;
+  preview: LinkPreview;
+}
+
+export type ComposerLinkPreviewState =
+  | { kind: "idle" }
+  | { kind: "loading"; url: string }
+  | { kind: "ready"; url: string; payload: ComposerLinkPreviewSendPayload }
+  | { kind: "failed"; url: string }
+  | { kind: "unsupported"; url: string }
+  | { kind: "dismissed"; url: string };
+
+export function linkPreviewPayloadFromLookup(
+  result: LinkPreviewLookupResult | null,
+): ComposerLinkPreviewSendPayload | null {
+  if (!result || result.status !== "ready") return null;
+  return {
+    token: result.token,
+    expiresAt: result.expiresAt,
+    preview: {
+      originalUrl: result.originalUrl,
+      normalizedUrl: result.normalizedUrl,
+      ...(result.title ? { title: result.title } : {}),
+      ...(result.description ? { description: result.description } : {}),
+    },
+  };
+}
+
+export function linkPreviewStateFromLookup(
+  url: string,
+  result: LinkPreviewLookupResult | null,
+): ComposerLinkPreviewState {
+  const payload = linkPreviewPayloadFromLookup(result);
+  if (payload) return { kind: "ready", url, payload };
+  return result?.status === "not_found"
+    ? { kind: "unsupported", url }
+    : { kind: "failed", url };
+}
+
+export function composerLinkPreviewUrl(body: string): string | null {
+  return firstEligibleHttpsUrl(body);
+}
+
+export function sendPayloadFromState(
+  state: ComposerLinkPreviewState,
+): ComposerLinkPreviewSendPayload | undefined {
+  return state.kind === "ready" && composerLinkPreviewPayloadIsFresh(state.payload)
+    ? state.payload
+    : undefined;
+}
+
+export function composerLinkPreviewPayloadIsFresh(
+  payload: ComposerLinkPreviewSendPayload | undefined,
+  now = new Date(),
+): payload is ComposerLinkPreviewSendPayload {
+  if (!payload) return false;
+  const expiresAtMs = Date.parse(payload.expiresAt);
+  return Number.isFinite(expiresAtMs) && expiresAtMs > now.getTime();
+}

--- a/chat/src/lib/use-composer-link-preview.ts
+++ b/chat/src/lib/use-composer-link-preview.ts
@@ -92,6 +92,7 @@ export function useComposerLinkPreview(
   return {
     state,
     showCard,
+    canDismiss: computed(() => "url" in state.value && state.value.kind !== "dismissed"),
     host,
     title,
     description,

--- a/chat/src/lib/use-composer-link-preview.ts
+++ b/chat/src/lib/use-composer-link-preview.ts
@@ -1,0 +1,106 @@
+import { computed, ref, watch, type Ref } from "vue";
+import {
+  composerLinkPreviewUrl,
+  linkPreviewStateFromLookup,
+  sendPayloadFromState,
+  type ComposerLinkPreviewLookup,
+  type ComposerLinkPreviewState,
+} from "@/lib/link-preview-composer";
+
+export function useComposerLinkPreview(
+  draft: Ref<string>,
+  lookup: Ref<ComposerLinkPreviewLookup | null | undefined>,
+  scopeKey: Ref<string | null | undefined>,
+) {
+  const state = ref<ComposerLinkPreviewState>({ kind: "idle" });
+  let lookupEpoch = 0;
+  let activeKey: string | null = null;
+  let activeLookup: ComposerLinkPreviewLookup | null = null;
+
+  const showCard = computed(() => state.value.kind !== "idle");
+  const host = computed(() => {
+    const url = "url" in state.value ? state.value.url : "";
+    if (!url) return "";
+    try {
+      return new URL(url).hostname.replace(/^www\./, "");
+    } catch {
+      return url;
+    }
+  });
+  const title = computed(() => {
+    if (state.value.kind === "ready") return state.value.payload.preview.title ?? host.value;
+    if (state.value.kind === "loading") return "Loading preview";
+    if (state.value.kind === "unsupported") return "Preview unavailable";
+    if (state.value.kind === "failed") return "Preview failed";
+    if (state.value.kind === "dismissed") return "Preview removed";
+    return "";
+  });
+  const description = computed(() => {
+    if (state.value.kind === "ready") return state.value.payload.preview.description ?? state.value.payload.preview.originalUrl;
+    if (state.value.kind === "loading") return host.value;
+    if (state.value.kind === "unsupported") return host.value;
+    if (state.value.kind === "failed") return host.value;
+    if (state.value.kind === "dismissed") return host.value;
+    return "";
+  });
+
+  function dismiss() {
+    if (!("url" in state.value)) return;
+    lookupEpoch++;
+    activeKey = stateKey(scopeKey.value, state.value.url);
+    activeLookup = null;
+    state.value = { kind: "dismissed", url: state.value.url };
+  }
+
+  watch(
+    () => [draft.value, lookup.value, scopeKey.value] as const,
+    ([body, lookupFn, scope]) => {
+      const url = composerLinkPreviewUrl(body);
+      const key = stateKey(scope, url);
+      if (!url || !lookupFn || !key) {
+        lookupEpoch++;
+        activeKey = null;
+        activeLookup = null;
+        state.value = { kind: "idle" };
+        return;
+      }
+      if (
+        key === activeKey &&
+        state.value.kind !== "idle" &&
+        (state.value.kind === "dismissed" || activeLookup === lookupFn)
+      ) {
+        return;
+      }
+
+      const epoch = ++lookupEpoch;
+      activeKey = key;
+      activeLookup = lookupFn;
+      state.value = { kind: "loading", url };
+      void lookupFn(body)
+        .then((result) => {
+          if (epoch !== lookupEpoch) return;
+          state.value = linkPreviewStateFromLookup(url, result);
+        })
+        .catch(() => {
+          if (epoch !== lookupEpoch) return;
+          state.value = { kind: "failed", url };
+        });
+    },
+    { immediate: true },
+  );
+
+  return {
+    state,
+    showCard,
+    host,
+    title,
+    description,
+    dismiss,
+    sendPayload: computed(() => sendPayloadFromState(state.value)),
+  };
+}
+
+function stateKey(scope: string | null | undefined, url: string | null): string | null {
+  const trimmedScope = scope?.trim();
+  return trimmedScope && url ? `${trimmedScope}\n${url}` : null;
+}

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -1336,16 +1336,6 @@ export class BrowserXmppClient {
     throw new Error("XMPP session is not ready");
   }
 
-  private async queuedLinkPreviewOptions(body: string, scopeJid: string): Promise<Pick<SendDirectMessageOptions, "linkPreviewToken" | "linkPreviewExpiresAt">> {
-    const preview = await this.lookupLinkPreview(body, scopeJid);
-    return preview?.token
-      ? {
-          linkPreviewToken: preview.token,
-          ...(preview.expiresAt ? { linkPreviewExpiresAt: preview.expiresAt } : {}),
-        }
-      : {};
-  }
-
   // XEP-0201 §3: chat-states, displayed markers, reactions, retractions, and
   // corrections that relate to a threaded message SHOULD repeat the original
   // `<thread/>`. The wasm bindings accept thread id + optional parent so the
@@ -1404,8 +1394,7 @@ export class BrowserXmppClient {
         if (!this.canUseConnectedSession() || !this.xmpp) break;
         if (this.inflightQueuedIds.has(entry.id)) continue;
         this.queuedMessageStatusHandler?.(entry.id, "sending");
-        const linkPreviewOptions = await this.queuedLinkPreviewOptions(entry.body, barePeerJid(entry.peerJid));
-        const messageId = await this.compatSendDirectMessage(this.xmpp, barePeerJid(entry.peerJid), entry.body, { ...(entry.markup?.length ? { markup: entry.markup } : {}), ...(entry.references?.length ? { references: entry.references } : {}), ...(entry.files?.length ? { files: entry.files } : {}), ...linkPreviewOptions, ...(entry.replyTo ? { replyTo: entry.replyTo } : {}), ...(entry.threadId ? { threadId: entry.threadId } : {}), ...(entry.parentThreadId ? { parentThreadId: entry.parentThreadId } : {}), id: entry.id });
+        const messageId = await this.compatSendDirectMessage(this.xmpp, barePeerJid(entry.peerJid), entry.body, { ...(entry.markup?.length ? { markup: entry.markup } : {}), ...(entry.references?.length ? { references: entry.references } : {}), ...(entry.files?.length ? { files: entry.files } : {}), ...(entry.replyTo ? { replyTo: entry.replyTo } : {}), ...(entry.threadId ? { threadId: entry.threadId } : {}), ...(entry.parentThreadId ? { parentThreadId: entry.parentThreadId } : {}), id: entry.id });
         if (messageId) { this.inflightQueuedIds.add(entry.id); this.recordPendingSend(entry.id, "dm"); }
       }
     })();
@@ -1423,8 +1412,7 @@ export class BrowserXmppClient {
         if (!this.roomIsReady(roomJid) || !this.xmpp) break;
         if (this.inflightQueuedIds.has(entry.id)) continue;
         this.queuedMessageStatusHandler?.(entry.id, "sending");
-        const linkPreviewOptions = await this.queuedLinkPreviewOptions(entry.body, roomJid);
-        const messageId = await this.compatSendGroupMessage(this.xmpp, roomJid, entry.body, { ...(entry.markup?.length ? { markup: entry.markup } : {}), ...(entry.references?.length ? { references: entry.references } : {}), mentionJidsByNick: { ...(entry.mentionJidsByNick ?? {}), ...this.memberJidsFor(roomJid) }, ...(entry.files?.length ? { files: entry.files } : {}), ...linkPreviewOptions, ...(entry.replyTo ? { replyTo: entry.replyTo } : {}), ...(entry.threadId ? { threadId: entry.threadId } : {}), ...(entry.parentThreadId ? { parentThreadId: entry.parentThreadId } : {}), ...(entry.threadCreate ? { threadCreate: entry.threadCreate } : {}), ...(entry.threadReply ? { threadReply: entry.threadReply } : {}), id: entry.id });
+        const messageId = await this.compatSendGroupMessage(this.xmpp, roomJid, entry.body, { ...(entry.markup?.length ? { markup: entry.markup } : {}), ...(entry.references?.length ? { references: entry.references } : {}), mentionJidsByNick: { ...(entry.mentionJidsByNick ?? {}), ...this.memberJidsFor(roomJid) }, ...(entry.files?.length ? { files: entry.files } : {}), ...(entry.replyTo ? { replyTo: entry.replyTo } : {}), ...(entry.threadId ? { threadId: entry.threadId } : {}), ...(entry.parentThreadId ? { parentThreadId: entry.parentThreadId } : {}), ...(entry.threadCreate ? { threadCreate: entry.threadCreate } : {}), ...(entry.threadReply ? { threadReply: entry.threadReply } : {}), id: entry.id });
         if (messageId) { this.inflightQueuedIds.add(entry.id); this.recordPendingSend(entry.id, "room"); }
       }
     })();

--- a/chat/src/lib/xmpp/link-preview.ts
+++ b/chat/src/lib/xmpp/link-preview.ts
@@ -78,7 +78,7 @@ function parseLookupResponse(xml: string, requestedUrl: string): LinkPreviewLook
   const normalizedUrl = preview.getAttribute("normalized-url")?.trim();
   const expiresAt = preview.getAttribute("expires-at")?.trim();
   if (!token || !originalUrl || !normalizedUrl || !expiresAt) return null;
-  if (originalUrl !== requestedUrl) return null;
+  if (!urlsMatchSemantically(originalUrl, requestedUrl)) return null;
   if (!isEligiblePreviewUrl(originalUrl) || !isEligiblePreviewUrl(normalizedUrl)) return null;
   return {
     token,
@@ -97,6 +97,22 @@ function isEligiblePreviewUrl(value: string): boolean {
     return url.protocol === "https:" && url.hostname.includes(".");
   } catch {
     return false;
+  }
+}
+
+function urlsMatchSemantically(a: string, b: string): boolean {
+  const canonicalA = canonicalUrl(a);
+  const canonicalB = canonicalUrl(b);
+  return canonicalA && canonicalB
+    ? canonicalA === canonicalB
+    : a === b;
+}
+
+function canonicalUrl(value: string): string | null {
+  try {
+    return new URL(value).href;
+  } catch {
+    return null;
   }
 }
 

--- a/chat/src/lib/xmpp/link-preview.ts
+++ b/chat/src/lib/xmpp/link-preview.ts
@@ -1,13 +1,18 @@
-export type LinkPreviewLookupStatus = "ready" | "not_found";
+export type LinkPreviewLookupResult = LinkPreviewLookupReadyResult | LinkPreviewLookupUnsupportedResult;
 
-export interface LinkPreviewLookupResult {
+export interface LinkPreviewLookupReadyResult {
   token: string;
   originalUrl: string;
   normalizedUrl: string;
-  status: LinkPreviewLookupStatus;
+  status: "ready";
   expiresAt: string;
   title?: string;
   description?: string;
+}
+
+export interface LinkPreviewLookupUnsupportedResult {
+  originalUrl: string;
+  status: "not_found";
 }
 
 const HTTPS_URL_RE = /https:\/\/[^\s<>"']+/gi;
@@ -54,14 +59,15 @@ export async function requestPlaintextLinkPreviewLookup(
   } catch {
     return null;
   }
-  return parseLookupResponse(response);
+  return parseLookupResponse(response, originalUrl);
 }
 
-function parseLookupResponse(xml: string): LinkPreviewLookupResult | null {
+function parseLookupResponse(xml: string, requestedUrl: string): LinkPreviewLookupResult | null {
   const doc = new DOMParser().parseFromString(xml, "text/xml");
   const lookup = doc.getElementsByTagNameNS(NS_WADDLE_LINK_PREVIEW, "lookup")[0];
   if (!lookup) return null;
   const status = lookup.getAttribute("status");
+  if (status === "not_found") return { status: "not_found", originalUrl: requestedUrl };
   if (status !== "ready") return null;
   const preview = Array.from(lookup.children).find(
     (child) => child.localName === "preview" && child.namespaceURI === NS_WADDLE_LINK_PREVIEW,
@@ -72,6 +78,7 @@ function parseLookupResponse(xml: string): LinkPreviewLookupResult | null {
   const normalizedUrl = preview.getAttribute("normalized-url")?.trim();
   const expiresAt = preview.getAttribute("expires-at")?.trim();
   if (!token || !originalUrl || !normalizedUrl || !expiresAt) return null;
+  if (originalUrl !== requestedUrl) return null;
   if (!isEligiblePreviewUrl(originalUrl) || !isEligiblePreviewUrl(normalizedUrl)) return null;
   return {
     token,

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -36,6 +36,7 @@ import { orderTimelineForScrollDirection, type ScrollDirectionMode } from "@/lib
 import { useScrollDirectionPreference } from "@/preferences/scroll-direction";
 import type { MemberSummary } from "@/lib/chat-types";
 import type { ExtensionAnnotationAction, MarkupSpan, MessageReference, TimelineMessage } from "@/lib/chat-ui";
+import type { ComposerLinkPreviewSendPayload } from "@/lib/link-preview-composer";
 import type { DiscoveredExtensionRoute } from "@/lib/xmpp/extension-commands";
 import { avatarLookupCandidatesAcrossContexts, mentionAutocompleteCandidates, mentionMatchesBareJid, mergeMentionMembers } from "@/lib/mentions";
 import {
@@ -892,12 +893,13 @@ export function useChatAppController(giphyApiKey: string) {
     files?: Array<File | Blob>,
     replyTo?: { id: string; author: string; body?: string },
     forumTitle?: string,
+    linkPreview?: ComposerLinkPreviewSendPayload,
   ) {
     if (ui.sidebarMode.value === "dms") {
-      await dmMessaging.sendMessage(body, markup, references, files, replyTo);
+      await dmMessaging.sendMessage(body, markup, references, files, replyTo, linkPreview);
       return;
     }
-    await messaging.sendMessage(body, markup, references, files, replyTo, forumTitle);
+    await messaging.sendMessage(body, markup, references, files, replyTo, forumTitle, linkPreview);
   }
 
   async function sendPublicChannelMessage(body: string) {
@@ -918,8 +920,9 @@ export function useChatAppController(giphyApiKey: string) {
     files: Array<File | Blob> | undefined,
     replyTo: { id: string; author: string; body?: string } | undefined,
     threadOverride: { threadId: string; parentThreadId?: string },
+    linkPreview?: ComposerLinkPreviewSendPayload,
   ) {
-    await messaging.sendMessage(body, markup, references, files, replyTo, threadOverride);
+    await messaging.sendMessage(body, markup, references, files, replyTo, threadOverride, linkPreview);
   }
 
   function sendGif(

--- a/chat/tests/chat-send.test.ts
+++ b/chat/tests/chat-send.test.ts
@@ -80,13 +80,13 @@ describe("useChatSend.sendMessage — happy path", () => {
     const client = makeClient({ sendDirectMessage, lookupLinkPreview } as Partial<BrowserXmppClient>);
     const h = harness({ client, draft: "read https://example.com/article" });
 
-    const sent = await Promise.race([
-      h.send.sendMessage(undefined, []).then(() => true),
-      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 10)),
-    ]);
+    const sendPromise = h.send.sendMessage(undefined, []);
+    await Promise.resolve();
 
-    expect(sent).toBe(true);
+    expect(sendDirectMessage).toHaveBeenCalledTimes(1);
     expect(lookupLinkPreview).not.toHaveBeenCalled();
+    await sendPromise;
+
     const call = (sendDirectMessage as unknown as ReturnType<typeof mock>).mock.calls[0]!;
     expect(call[2].linkPreviewToken).toBeUndefined();
     expect(call[2].linkPreviewExpiresAt).toBeUndefined();

--- a/chat/tests/chat-send.test.ts
+++ b/chat/tests/chat-send.test.ts
@@ -74,32 +74,71 @@ describe("useChatSend.sendMessage — happy path", () => {
     expect(h.onSendComplete).toHaveBeenCalledTimes(1);
   });
 
-  test("looks up first eligible HTTPS URL and sends scoped preview token", async () => {
+  test("sends immediately without preview metadata while composer lookup is still loading", async () => {
     const sendDirectMessage = mock(async () => ({ id: "dm-link", state: "sending" }));
-    const lookupLinkPreview = mock(async () => ({
-      token: "preview-token-1",
-      originalUrl: "https://example.com/article",
-      normalizedUrl: "https://example.com/article",
-      status: "ready" as const,
-      expiresAt: "2026-06-01T12:05:00.000Z",
-      title: "Example Article",
-      description: "Plain text summary",
-    }));
+    const lookupLinkPreview = mock(() => new Promise<never>(() => {}));
     const client = makeClient({ sendDirectMessage, lookupLinkPreview } as Partial<BrowserXmppClient>);
     const h = harness({ client, draft: "read https://example.com/article" });
 
-    await h.send.sendMessage(undefined, []);
+    const sent = await Promise.race([
+      h.send.sendMessage(undefined, []).then(() => true),
+      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 10)),
+    ]);
 
-    expect(lookupLinkPreview).toHaveBeenCalledWith("read https://example.com/article", "bob@example.com");
+    expect(sent).toBe(true);
+    expect(lookupLinkPreview).not.toHaveBeenCalled();
+    const call = (sendDirectMessage as unknown as ReturnType<typeof mock>).mock.calls[0]!;
+    expect(call[2].linkPreviewToken).toBeUndefined();
+    expect(call[2].linkPreviewExpiresAt).toBeUndefined();
+    expect(h.messages.value[0]?.linkPreviews).toBeUndefined();
+  });
+
+  test("uses an already-ready composer preview token when sending", async () => {
+    const sendDirectMessage = mock(async () => ({ id: "dm-link", state: "sending" }));
+    const client = makeClient({ sendDirectMessage } as Partial<BrowserXmppClient>);
+    const h = harness({ client, draft: "read https://example.com/article" });
+
+    await h.send.sendMessage(undefined, [], undefined, undefined, undefined, {
+      token: "preview-token-1",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+      preview: {
+        originalUrl: "https://example.com/article",
+        normalizedUrl: "https://example.com/article",
+        title: "Example Article",
+        description: "Plain text summary",
+      },
+    });
+
     const call = (sendDirectMessage as unknown as ReturnType<typeof mock>).mock.calls[0]!;
     expect(call[2].linkPreviewToken).toBe("preview-token-1");
-    expect(call[2].linkPreviewExpiresAt).toBe("2026-06-01T12:05:00.000Z");
+    expect(call[2].linkPreviewExpiresAt).toBe("2999-01-01T00:00:00.000Z");
     expect(h.messages.value[0]?.linkPreviews).toEqual([{
       originalUrl: "https://example.com/article",
       normalizedUrl: "https://example.com/article",
       title: "Example Article",
       description: "Plain text summary",
     }]);
+  });
+
+  test("expired composer preview payload sends normally without preview metadata", async () => {
+    const sendDirectMessage = mock(async () => ({ id: "dm-link", state: "sending" }));
+    const client = makeClient({ sendDirectMessage } as Partial<BrowserXmppClient>);
+    const h = harness({ client, draft: "read https://example.com/article" });
+
+    await h.send.sendMessage(undefined, [], undefined, undefined, undefined, {
+      token: "expired-token",
+      expiresAt: "2000-01-01T00:00:00.000Z",
+      preview: {
+        originalUrl: "https://example.com/article",
+        normalizedUrl: "https://example.com/article",
+        title: "Example Article",
+      },
+    });
+
+    const call = (sendDirectMessage as unknown as ReturnType<typeof mock>).mock.calls[0]!;
+    expect(call[2].linkPreviewToken).toBeUndefined();
+    expect(call[2].linkPreviewExpiresAt).toBeUndefined();
+    expect(h.messages.value[0]?.linkPreviews).toBeUndefined();
   });
 });
 

--- a/chat/tests/helpers/disco-xml.ts
+++ b/chat/tests/helpers/disco-xml.ts
@@ -134,9 +134,18 @@ function parseTestXml(xml: string): FakeXmlElement {
 function attributesFromTag(tagBody: string): Record<string, string> {
   const attrs: Record<string, string> = {};
   for (const match of tagBody.matchAll(/([A-Za-z0-9:_-]+)="([^"]*)"/g)) {
-    attrs[match[1]] = match[2];
+    attrs[match[1]] = decodeXmlAttribute(match[2]);
   }
   return attrs;
+}
+
+function decodeXmlAttribute(value: string): string {
+  return value
+    .replaceAll("&quot;", "\"")
+    .replaceAll("&apos;", "'")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&amp;", "&");
 }
 
 class FakeStructuredXmlDocument {

--- a/chat/tests/link-preview-composer.test.ts
+++ b/chat/tests/link-preview-composer.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, test } from "bun:test";
+import { effectScope, nextTick, ref } from "vue";
+import {
+  composerLinkPreviewUrl,
+  linkPreviewPayloadFromLookup,
+  linkPreviewStateFromLookup,
+  sendPayloadFromState,
+} from "../src/lib/link-preview-composer";
+import { useComposerLinkPreview } from "../src/lib/use-composer-link-preview";
+import type { LinkPreviewLookupResult } from "../src/lib/xmpp/link-preview";
+
+describe("composer link preview state", () => {
+  test("tracks only the first eligible HTTPS URL", () => {
+    expect(composerLinkPreviewUrl("http://ignored.example then https://first.example/a and https://second.example/b"))
+      .toBe("https://first.example/a");
+  });
+
+  test("projects ready lookup data into a send token and optimistic preview", () => {
+    const payload = linkPreviewPayloadFromLookup({
+      status: "ready",
+      token: "token-1",
+      originalUrl: "https://example.com/a",
+      normalizedUrl: "https://example.com/a",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+      title: "Example",
+      description: "Plain text",
+    });
+
+    expect(payload).toEqual({
+      token: "token-1",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+      preview: {
+        originalUrl: "https://example.com/a",
+        normalizedUrl: "https://example.com/a",
+        title: "Example",
+        description: "Plain text",
+      },
+    });
+  });
+
+  test("unsupported and dismissed states fail open with no send payload", () => {
+    const unsupported = linkPreviewStateFromLookup("https://example.com/a", {
+      status: "not_found",
+      originalUrl: "https://example.com/a",
+    });
+
+    expect(unsupported).toEqual({ kind: "unsupported", url: "https://example.com/a" });
+    expect(sendPayloadFromState(unsupported)).toBeUndefined();
+    expect(sendPayloadFromState({ kind: "dismissed", url: "https://example.com/a" })).toBeUndefined();
+  });
+
+  test("expired ready states fail open with no send payload", () => {
+    expect(sendPayloadFromState({
+      kind: "ready",
+      url: "https://example.com/a",
+      payload: {
+        token: "expired-token",
+        expiresAt: "2000-01-01T00:00:00.000Z",
+        preview: {
+          originalUrl: "https://example.com/a",
+          normalizedUrl: "https://example.com/a",
+        },
+      },
+    })).toBeUndefined();
+  });
+
+  test("failed lookup state fails open with no send payload", () => {
+    const failed = linkPreviewStateFromLookup("https://example.com/a", null);
+
+    expect(failed).toEqual({ kind: "failed", url: "https://example.com/a" });
+    expect(sendPayloadFromState(failed)).toBeUndefined();
+  });
+
+  test("dismissed and loading composer states emit no send payload", async () => {
+    const h = setupComposerPreviewHarness(() => new Promise<never>(() => {}));
+
+    await nextTick();
+
+    expect(h.preview.state.value).toEqual({ kind: "loading", url: "https://example.com/a" });
+    expect(h.preview.sendPayload.value).toBeUndefined();
+
+    h.preview.dismiss();
+
+    expect(h.preview.state.value).toEqual({ kind: "dismissed", url: "https://example.com/a" });
+    expect(h.preview.sendPayload.value).toBeUndefined();
+    h.stop();
+  });
+
+  test("unsupported and failed composer lookup states emit no send payload", async () => {
+    const unsupported = setupComposerPreviewHarness(async () => ({
+      status: "not_found",
+      originalUrl: "https://example.com/a",
+    }));
+
+    await flushComposerPreview();
+
+    expect(unsupported.preview.state.value).toEqual({ kind: "unsupported", url: "https://example.com/a" });
+    expect(unsupported.preview.sendPayload.value).toBeUndefined();
+    unsupported.stop();
+
+    const failed = setupComposerPreviewHarness(async () => {
+      throw new Error("lookup failed");
+    });
+
+    await flushComposerPreview();
+
+    expect(failed.preview.state.value).toEqual({ kind: "failed", url: "https://example.com/a" });
+    expect(failed.preview.sendPayload.value).toBeUndefined();
+    failed.stop();
+  });
+
+  test("scope changes clear stale ready payloads and trigger a fresh lookup", async () => {
+    const lookups: string[] = [];
+    const resolvers: Array<(result: LinkPreviewLookupResult) => void> = [];
+    const h = setupComposerPreviewHarness((_body, scope) => {
+      lookups.push(scope);
+      return new Promise<LinkPreviewLookupResult>((resolve) => resolvers.push(resolve));
+    });
+
+    await nextTick();
+    expect(h.preview.state.value).toEqual({ kind: "loading", url: "https://example.com/a" });
+    resolvers[0]?.(readyLookup("token-a"));
+    await flushComposerPreview();
+
+    expect(h.preview.sendPayload.value?.token).toBe("token-a");
+
+    h.scope.value = "room-b@muc.example.com";
+    await nextTick();
+
+    expect(h.preview.state.value).toEqual({ kind: "loading", url: "https://example.com/a" });
+    expect(h.preview.sendPayload.value).toBeUndefined();
+
+    resolvers[1]?.(readyLookup("token-b"));
+    await flushComposerPreview();
+
+    expect(lookups).toEqual(["room-a@muc.example.com", "room-b@muc.example.com"]);
+    expect(h.preview.sendPayload.value?.token).toBe("token-b");
+    h.stop();
+  });
+
+  test("lookup changes clear stale ready payloads without overriding dismissal", async () => {
+    const resolvers: Array<(result: LinkPreviewLookupResult) => void> = [];
+    const h = setupComposerPreviewHarness(() => (
+      new Promise<LinkPreviewLookupResult>((resolve) => resolvers.push(resolve))
+    ));
+
+    await nextTick();
+    resolvers[0]?.(readyLookup("token-a"));
+    await flushComposerPreview();
+    expect(h.preview.sendPayload.value?.token).toBe("token-a");
+
+    h.lookup.value = () => new Promise<LinkPreviewLookupResult>((resolve) => resolvers.push(resolve));
+    await nextTick();
+
+    expect(h.preview.state.value).toEqual({ kind: "loading", url: "https://example.com/a" });
+    expect(h.preview.sendPayload.value).toBeUndefined();
+
+    resolvers[1]?.(readyLookup("token-b"));
+    await flushComposerPreview();
+    expect(h.preview.sendPayload.value?.token).toBe("token-b");
+
+    h.preview.dismiss();
+    h.lookup.value = async () => readyLookup("token-c");
+    await nextTick();
+
+    expect(h.preview.state.value).toEqual({ kind: "dismissed", url: "https://example.com/a" });
+    expect(h.preview.sendPayload.value).toBeUndefined();
+    h.stop();
+  });
+});
+
+function setupComposerPreviewHarness(
+  lookupImpl: (body: string, scope: string) => Promise<LinkPreviewLookupResult | null>,
+) {
+  const draft = ref("read https://example.com/a");
+  const scope = ref("room-a@muc.example.com");
+  const lookup = ref((body: string) => lookupImpl(body, scope.value));
+  const scopeHandle = effectScope();
+  let preview!: ReturnType<typeof useComposerLinkPreview>;
+  scopeHandle.run(() => {
+    preview = useComposerLinkPreview(draft, lookup, scope);
+  });
+  return {
+    draft,
+    lookup,
+    scope,
+    preview,
+    stop: () => scopeHandle.stop(),
+  };
+}
+
+function readyLookup(token: string): LinkPreviewLookupResult {
+  return {
+    status: "ready",
+    token,
+    originalUrl: "https://example.com/a",
+    normalizedUrl: "https://example.com/a",
+    expiresAt: "2999-01-01T00:00:00.000Z",
+    title: "Example",
+  };
+}
+
+async function flushComposerPreview() {
+  await Promise.resolve();
+  await nextTick();
+}

--- a/chat/tests/link-preview-composer.test.ts
+++ b/chat/tests/link-preview-composer.test.ts
@@ -77,11 +77,13 @@ describe("composer link preview state", () => {
     await nextTick();
 
     expect(h.preview.state.value).toEqual({ kind: "loading", url: "https://example.com/a" });
+    expect(h.preview.canDismiss.value).toBe(true);
     expect(h.preview.sendPayload.value).toBeUndefined();
 
     h.preview.dismiss();
 
     expect(h.preview.state.value).toEqual({ kind: "dismissed", url: "https://example.com/a" });
+    expect(h.preview.canDismiss.value).toBe(false);
     expect(h.preview.sendPayload.value).toBeUndefined();
     h.stop();
   });

--- a/chat/tests/link-preview.test.ts
+++ b/chat/tests/link-preview.test.ts
@@ -86,6 +86,52 @@ describe("link preview lookup", () => {
     expect(result).toBeNull();
   });
 
+  test("accepts ready lookup responses when server normalizes hostname case and implicit path", async () => {
+    const send_raw_iq = async () =>
+      `<iq type="result" id="lookup-1"><lookup xmlns="urn:waddle:link-preview:0" status="ready"><preview token="signed-token" original-url="https://example.com/" normalized-url="https://example.com/" expires-at="2999-01-01T00:00:00.000Z"><title>Example</title></preview></lookup></iq>`;
+
+    let result: Awaited<ReturnType<typeof requestPlaintextLinkPreviewLookup>> = null;
+    await withFakeXmlDocument(async () => {
+      await withFakeDomParser(async () => {
+        result = await requestPlaintextLinkPreviewLookup(
+          { send_raw_iq },
+          "read https://Example.COM",
+          "room@muc.example.com",
+        );
+      });
+    });
+
+    expect(result).toMatchObject({
+      token: "signed-token",
+      originalUrl: "https://example.com/",
+      normalizedUrl: "https://example.com/",
+      status: "ready",
+    });
+  });
+
+  test("accepts ready lookup responses when server removes default HTTPS port", async () => {
+    const send_raw_iq = async () =>
+      `<iq type="result" id="lookup-1"><lookup xmlns="urn:waddle:link-preview:0" status="ready"><preview token="signed-token" original-url="https://example.com/path" normalized-url="https://example.com/path" expires-at="2999-01-01T00:00:00.000Z"><title>Example</title></preview></lookup></iq>`;
+
+    let result: Awaited<ReturnType<typeof requestPlaintextLinkPreviewLookup>> = null;
+    await withFakeXmlDocument(async () => {
+      await withFakeDomParser(async () => {
+        result = await requestPlaintextLinkPreviewLookup(
+          { send_raw_iq },
+          "read https://example.com:443/path",
+          "room@muc.example.com",
+        );
+      });
+    });
+
+    expect(result).toMatchObject({
+      token: "signed-token",
+      originalUrl: "https://example.com/path",
+      normalizedUrl: "https://example.com/path",
+      status: "ready",
+    });
+  });
+
   test("returns unsupported lookup state for not_found responses", async () => {
     const send_raw_iq = async () =>
       `<iq type="result" id="lookup-1"><lookup xmlns="urn:waddle:link-preview:0" status="not_found"/></iq>`;

--- a/chat/tests/link-preview.test.ts
+++ b/chat/tests/link-preview.test.ts
@@ -25,7 +25,7 @@ describe("link preview lookup", () => {
     const send_raw_iq = async (xml: string) => {
       expect(xml).toContain("<url>https://example.com/a?x=1&amp;y=2</url>");
       expect(xml).toContain("<scope>room@muc.example.com</scope>");
-      return `<iq type="result" id="lookup-1"><lookup xmlns="urn:waddle:link-preview:0" status="ready"><preview token="signed-token" original-url="https://example.com/a" normalized-url="https://example.com/a" expires-at="2026-06-01T12:05:00.000Z"><title>Example</title><description>Plain text</description></preview></lookup></iq>`;
+      return `<iq type="result" id="lookup-1"><lookup xmlns="urn:waddle:link-preview:0" status="ready"><preview token="signed-token" original-url="https://example.com/a?x=1&amp;y=2" normalized-url="https://example.com/a" expires-at="2999-01-01T00:00:00.000Z"><title>Example</title><description>Plain text</description></preview></lookup></iq>`;
     };
 
     let result: Awaited<ReturnType<typeof requestPlaintextLinkPreviewLookup>> = null;
@@ -41,10 +41,10 @@ describe("link preview lookup", () => {
 
     expect(result).toEqual({
       token: "signed-token",
-      originalUrl: "https://example.com/a",
+      originalUrl: "https://example.com/a?x=1&y=2",
       normalizedUrl: "https://example.com/a",
       status: "ready",
-      expiresAt: "2026-06-01T12:05:00.000Z",
+      expiresAt: "2999-01-01T00:00:00.000Z",
       title: "Example",
       description: "Plain text",
     });
@@ -52,7 +52,7 @@ describe("link preview lookup", () => {
 
   test("rejects lookup responses with non-HTTPS preview URLs", async () => {
     const send_raw_iq = async () =>
-      `<iq type="result" id="lookup-1"><lookup xmlns="urn:waddle:link-preview:0" status="ready"><preview token="signed-token" original-url="http://example.com/a" normalized-url="http://example.com/a" expires-at="2026-06-01T12:05:00.000Z"><title>Example</title></preview></lookup></iq>`;
+      `<iq type="result" id="lookup-1"><lookup xmlns="urn:waddle:link-preview:0" status="ready"><preview token="signed-token" original-url="http://example.com/a" normalized-url="http://example.com/a" expires-at="2999-01-01T00:00:00.000Z"><title>Example</title></preview></lookup></iq>`;
 
     let result: Awaited<ReturnType<typeof requestPlaintextLinkPreviewLookup>> = null;
     await withFakeXmlDocument(async () => {
@@ -66,6 +66,45 @@ describe("link preview lookup", () => {
     });
 
     expect(result).toBeNull();
+  });
+
+  test("rejects ready lookup responses for a different original URL than requested", async () => {
+    const send_raw_iq = async () =>
+      `<iq type="result" id="lookup-1"><lookup xmlns="urn:waddle:link-preview:0" status="ready"><preview token="signed-token" original-url="https://other.example/a" normalized-url="https://other.example/a" expires-at="2999-01-01T00:00:00.000Z"><title>Other</title></preview></lookup></iq>`;
+
+    let result: Awaited<ReturnType<typeof requestPlaintextLinkPreviewLookup>> = null;
+    await withFakeXmlDocument(async () => {
+      await withFakeDomParser(async () => {
+        result = await requestPlaintextLinkPreviewLookup(
+          { send_raw_iq },
+          "read https://example.com/a",
+          "room@muc.example.com",
+        );
+      });
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("returns unsupported lookup state for not_found responses", async () => {
+    const send_raw_iq = async () =>
+      `<iq type="result" id="lookup-1"><lookup xmlns="urn:waddle:link-preview:0" status="not_found"/></iq>`;
+
+    let result: Awaited<ReturnType<typeof requestPlaintextLinkPreviewLookup>> = null;
+    await withFakeXmlDocument(async () => {
+      await withFakeDomParser(async () => {
+        result = await requestPlaintextLinkPreviewLookup(
+          { send_raw_iq },
+          "read https://unsupported.example/a",
+          "room@muc.example.com",
+        );
+      });
+    });
+
+    expect(result).toEqual({
+      status: "not_found",
+      originalUrl: "https://unsupported.example/a",
+    });
   });
 
   test("lookup failure is a metadata miss instead of a send blocker", async () => {

--- a/chat/tests/muc-send.test.ts
+++ b/chat/tests/muc-send.test.ts
@@ -95,13 +95,13 @@ describe("useMucSend.sendMessage — happy path", () => {
     const client = makeClient({ sendGroupMessage, lookupLinkPreview } as Partial<BrowserXmppClient>);
     const h = harness({ client, draft: "read https://example.com/article and https://later.example/path" });
 
-    const sent = await Promise.race([
-      h.send.sendMessage(undefined, []).then(() => true),
-      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 10)),
-    ]);
+    const sendPromise = h.send.sendMessage(undefined, []);
+    await Promise.resolve();
 
-    expect(sent).toBe(true);
+    expect(sendGroupMessage).toHaveBeenCalledTimes(1);
     expect(lookupLinkPreview).not.toHaveBeenCalled();
+    await sendPromise;
+
     const call = (sendGroupMessage as unknown as ReturnType<typeof mock>).mock.calls[0]!;
     expect(call[3].linkPreviewToken).toBeUndefined();
     expect(call[3].linkPreviewExpiresAt).toBeUndefined();

--- a/chat/tests/muc-send.test.ts
+++ b/chat/tests/muc-send.test.ts
@@ -89,35 +89,71 @@ describe("useMucSend.sendMessage — happy path", () => {
     expect(h.onSendComplete).toHaveBeenCalledTimes(1);
   });
 
-  test("looks up first eligible HTTPS URL and sends scoped preview token", async () => {
+  test("sends immediately without preview metadata while composer lookup is still loading", async () => {
     const sendGroupMessage = mock(async () => ({ id: "sid-link", state: "sending" }));
-    const lookupLinkPreview = mock(async () => ({
-      token: "preview-token-1",
-      originalUrl: "https://example.com/article",
-      normalizedUrl: "https://example.com/article",
-      status: "ready" as const,
-      expiresAt: "2026-06-01T12:05:00.000Z",
-      title: "Example Article",
-      description: "Plain text summary",
-    }));
+    const lookupLinkPreview = mock(() => new Promise<never>(() => {}));
     const client = makeClient({ sendGroupMessage, lookupLinkPreview } as Partial<BrowserXmppClient>);
     const h = harness({ client, draft: "read https://example.com/article and https://later.example/path" });
 
-    await h.send.sendMessage(undefined, []);
+    const sent = await Promise.race([
+      h.send.sendMessage(undefined, []).then(() => true),
+      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 10)),
+    ]);
 
-    expect(lookupLinkPreview).toHaveBeenCalledWith(
-      "read https://example.com/article and https://later.example/path",
-      "general@muc.example.com",
-    );
+    expect(sent).toBe(true);
+    expect(lookupLinkPreview).not.toHaveBeenCalled();
+    const call = (sendGroupMessage as unknown as ReturnType<typeof mock>).mock.calls[0]!;
+    expect(call[3].linkPreviewToken).toBeUndefined();
+    expect(call[3].linkPreviewExpiresAt).toBeUndefined();
+    expect(h.messages.value[0]?.linkPreviews).toBeUndefined();
+  });
+
+  test("uses an already-ready composer preview token when sending", async () => {
+    const sendGroupMessage = mock(async () => ({ id: "sid-link", state: "sending" }));
+    const client = makeClient({ sendGroupMessage } as Partial<BrowserXmppClient>);
+    const h = harness({ client, draft: "read https://example.com/article and https://later.example/path" });
+
+    await h.send.sendMessage(undefined, [], undefined, undefined, undefined, undefined, {
+      token: "preview-token-1",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+      preview: {
+        originalUrl: "https://example.com/article",
+        normalizedUrl: "https://example.com/article",
+        title: "Example Article",
+        description: "Plain text summary",
+      },
+    });
+
     const call = (sendGroupMessage as unknown as ReturnType<typeof mock>).mock.calls[0]!;
     expect(call[3].linkPreviewToken).toBe("preview-token-1");
-    expect(call[3].linkPreviewExpiresAt).toBe("2026-06-01T12:05:00.000Z");
+    expect(call[3].linkPreviewExpiresAt).toBe("2999-01-01T00:00:00.000Z");
     expect(h.messages.value[0]?.linkPreviews).toEqual([{
       originalUrl: "https://example.com/article",
       normalizedUrl: "https://example.com/article",
       title: "Example Article",
       description: "Plain text summary",
     }]);
+  });
+
+  test("expired composer preview payload sends normally without preview metadata", async () => {
+    const sendGroupMessage = mock(async () => ({ id: "sid-link", state: "sending" }));
+    const client = makeClient({ sendGroupMessage } as Partial<BrowserXmppClient>);
+    const h = harness({ client, draft: "read https://example.com/article" });
+
+    await h.send.sendMessage(undefined, [], undefined, undefined, undefined, undefined, {
+      token: "expired-token",
+      expiresAt: "2000-01-01T00:00:00.000Z",
+      preview: {
+        originalUrl: "https://example.com/article",
+        normalizedUrl: "https://example.com/article",
+        title: "Example Article",
+      },
+    });
+
+    const call = (sendGroupMessage as unknown as ReturnType<typeof mock>).mock.calls[0]!;
+    expect(call[3].linkPreviewToken).toBeUndefined();
+    expect(call[3].linkPreviewExpiresAt).toBeUndefined();
+    expect(h.messages.value[0]?.linkPreviews).toBeUndefined();
   });
 });
 

--- a/chat/tests/offline-queue.test.ts
+++ b/chat/tests/offline-queue.test.ts
@@ -9,7 +9,6 @@ import {
   listQueuedDmMessages,
   listQueuedRoomMessages,
 } from "../src/lib/outbound-queue-store";
-import { withFakeDomParser, withFakeXmlDocument } from "./helpers/disco-xml";
 
 function session(partial: Partial<WaddleSession> = {}): WaddleSession {
   return {
@@ -76,7 +75,7 @@ describe("offline outbound queue replay", () => {
     await client.sendDirectMessage("bob@example.com", "read https://example.com", {
       id: "dm-preview-queued",
       linkPreviewToken: "plaintext-token",
-      linkPreviewExpiresAt: "2026-06-01T12:05:00.000Z",
+      linkPreviewExpiresAt: "2999-01-01T00:00:00.000Z",
     });
 
     const raw = localStorage.getItem("waddle.chat.outbound-queue.alice@example.com");
@@ -86,7 +85,7 @@ describe("offline outbound queue replay", () => {
     expect(raw).not.toContain("linkPreviewExpiresAt");
   });
 
-  test("reacquires a fresh link preview token when replaying queued URL sends", async () => {
+  test("does not reacquire link preview metadata when replaying queued URL sends", async () => {
     const client = new BrowserXmppClient(session());
     enqueueQueuedMessage("alice@example.com", {
       kind: "dm",
@@ -97,23 +96,20 @@ describe("offline outbound queue replay", () => {
     });
 
     const xmpp = {
-      send_raw_iq: mock(async () =>
-        `<iq type="result" id="lookup-1"><lookup xmlns="urn:waddle:link-preview:0" status="ready"><preview token="fresh-token" original-url="https://example.com/article" normalized-url="https://example.com/article" expires-at="2026-06-01T12:05:00.000Z"><title>Example</title></preview></lookup></iq>`),
+      send_raw_iq: mock(async () => {
+        throw new Error("queued replay must not perform composer preview lookup");
+      }),
       send_chat_message: mock(async (_peer: string, _body: string, opts: { stanza_id?: string }) => opts.stanza_id),
       on() {},
     };
     (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
     (client as unknown as { xmpp: typeof xmpp; connected: boolean }).connected = true;
 
-    await withFakeXmlDocument(async () => {
-      await withFakeDomParser(async () => {
-        await (client as unknown as { flushQueuedDirectMessages: () => Promise<void> }).flushQueuedDirectMessages();
-      });
-    });
+    await (client as unknown as { flushQueuedDirectMessages: () => Promise<void> }).flushQueuedDirectMessages();
 
-    expect(xmpp.send_raw_iq).toHaveBeenCalled();
+    expect(xmpp.send_raw_iq).not.toHaveBeenCalled();
     expect((xmpp.send_chat_message.mock.calls[0]?.[2] as { link_preview_token?: string }).link_preview_token)
-      .toBe("fresh-token");
+      .toBeUndefined();
   });
 
   test("replays queued DM messages in order when the session returns", async () => {
@@ -210,10 +206,8 @@ describe("offline outbound queue replay", () => {
 
     const handlers = new Map<string, Array<(payload: unknown) => void>>();
     const xmpp = {
-      send_raw_iq: mock(async (xml: string) => {
-        expect(xml).toContain("<url>https://example.com/room</url>");
-        expect(xml).toContain(`<scope>${roomJid}</scope>`);
-        return `<iq type="result" id="lookup-room-1"><lookup xmlns="urn:waddle:link-preview:0" status="ready"><preview token="fresh-room-token" original-url="https://example.com/room" normalized-url="https://example.com/room" expires-at="2026-06-01T12:05:00.000Z"><title>Example</title></preview></lookup></iq>`;
+      send_raw_iq: mock(async () => {
+        throw new Error("queued replay must not perform composer preview lookup");
       }),
       send_groupchat_message: mock(async (_room: string, _body: string, opts: { stanza_id?: string }) => opts.stanza_id),
       on(event: string, handler: (payload: unknown) => void) {
@@ -234,19 +228,15 @@ describe("offline outbound queue replay", () => {
     (client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.add(roomJid);
     (client as unknown as { wireEvents: (x: typeof xmpp) => void }).wireEvents(xmpp);
 
-    await withFakeXmlDocument(async () => {
-      await withFakeDomParser(async () => {
-        await (client as unknown as { flushQueuedRoomMessages: (roomJid: string) => Promise<void> }).flushQueuedRoomMessages(roomJid);
-      });
-    });
+    await (client as unknown as { flushQueuedRoomMessages: (roomJid: string) => Promise<void> }).flushQueuedRoomMessages(roomJid);
 
-    expect(xmpp.send_raw_iq).toHaveBeenCalledTimes(1);
+    expect(xmpp.send_raw_iq).not.toHaveBeenCalled();
     expect(xmpp.send_groupchat_message.mock.calls.map((call) => (call[2] as { stanza_id?: string }).stanza_id)).toEqual([
       "room-1",
       "room-2",
     ]);
     expect((xmpp.send_groupchat_message.mock.calls[0]?.[2] as { link_preview_token?: string }).link_preview_token)
-      .toBe("fresh-room-token");
+      .toBeUndefined();
     expect((xmpp.send_groupchat_message.mock.calls[1]?.[2] as { link_preview_token?: string }).link_preview_token)
       .toBeUndefined();
     // Persisted entries stay until ack, same as the DM path.

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -281,10 +281,56 @@ mod tests {
     }
 
     #[test]
+    fn invalid_link_preview_request_is_stripped_without_metadata() {
+        let token =
+            waddle_xmpp::xep::LinkPreviewToken::new("not-a-signed-preview-token").expect("token");
+        let mut message = Message::new(None::<jid::Jid>);
+        message.to = Some("room@muc.example.com".parse().expect("jid"));
+        message.bodies.insert(
+            xmpp_parsers::message::Lang::new(),
+            "read https://example.com/".to_string(),
+        );
+        message
+            .payloads
+            .push(waddle_xmpp::xep::build_link_preview_request_element(&token));
+
+        consume_link_preview_request(&mut message, &sender(), SECRET, 1_800_000_000);
+
+        assert!(message.payloads.is_empty());
+    }
+
+    #[test]
     fn wrong_scope_link_preview_request_is_stripped_without_metadata() {
         let preview = waddle_xmpp::xep::LinkPreviewTokenData {
             sender_jid: "alice@example.com".parse().expect("jid"),
             scope_jid: "other@muc.example.com".parse().expect("jid"),
+            original_url: url::Url::parse("https://example.com/").expect("url"),
+            normalized_url: url::Url::parse("https://example.com/").expect("url"),
+            title: Some("Example".to_string()),
+            description: None,
+            expires_at_unix: 1_900_000_000,
+        };
+        let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
+        let mut message = Message::new(None::<jid::Jid>);
+        message.to = Some("room@muc.example.com".parse().expect("jid"));
+        message.bodies.insert(
+            xmpp_parsers::message::Lang::new(),
+            "read https://example.com/".to_string(),
+        );
+        message
+            .payloads
+            .push(waddle_xmpp::xep::build_link_preview_request_element(&token));
+
+        consume_link_preview_request(&mut message, &sender(), SECRET, 1_800_000_000);
+
+        assert!(message.payloads.is_empty());
+    }
+
+    #[test]
+    fn wrong_sender_link_preview_request_is_stripped_without_metadata() {
+        let preview = waddle_xmpp::xep::LinkPreviewTokenData {
+            sender_jid: "mallory@example.com".parse().expect("jid"),
+            scope_jid: "room@muc.example.com".parse().expect("jid"),
             original_url: url::Url::parse("https://example.com/").expect("url"),
             normalized_url: url::Url::parse("https://example.com/").expect("url"),
             title: Some("Example".to_string()),


### PR DESCRIPTION
## Summary

- Move link-preview lookup state into the composer so message sends never wait on preview metadata and only include a ready, non-dismissed, fresh token.
- Add composer preview states for loading, ready, failed, unsupported, and dismissed, with dismissal and failed/unsupported lookup sending normally without metadata.
- Preserve sender intent through offline queue replay by not reacquiring link-preview metadata for queued sends.
- Keep XEP-0511 conformance: the web client sends only a private Waddle token request when ready; the server validates sender/scope/token freshness and stamps conformant RDF metadata.
- Address review feedback by comparing lookup URLs semantically, removing timer-based fail-open assertions, and hiding the dismiss control once a preview is already dismissed.

## Tests

- bun test
- bun run lint
- bun run build
- bun test tests/link-preview-composer.test.ts tests/chat-send.test.ts tests/muc-send.test.ts tests/offline-queue.test.ts tests/link-preview.test.ts
- bun test tests/chat-send.test.ts tests/muc-send.test.ts tests/link-preview-composer.test.ts
- cargo test -p waddle-server link_preview
- cargo fmt --check
- cargo clippy -p waddle-server -- -D warnings

## Notes

- Reviewed against xeps/xep-0511.xml.
- Adversarial code/security reviews found queued-replay and expired-token edge cases; both are fixed and covered by tests.
- All actionable PR review threads have been addressed and resolved.
- Existing unrelated untracked docs/planning files were left untouched.