### PR TITLE
feat(link-preview): implement safe HTTPS metadata resolver

### DIFF
--- a/chat/src/lib/link-preview-composer.ts
+++ b/chat/src/lib/link-preview-composer.ts
@@ -39,7 +39,7 @@ export function linkPreviewStateFromLookup(
 ): ComposerLinkPreviewState {
   const payload = linkPreviewPayloadFromLookup(result);
   if (payload) return { kind: "ready", url, payload };
-  return result?.status === "not_found" || result?.status === "unsupported" || result?.status === "blocked"
+  return result?.status === "unsupported" || result?.status === "blocked"
     ? { kind: "unsupported", url }
     : { kind: "failed", url };
 }

--- a/chat/src/lib/link-preview-composer.ts
+++ b/chat/src/lib/link-preview-composer.ts
@@ -39,7 +39,7 @@ export function linkPreviewStateFromLookup(
 ): ComposerLinkPreviewState {
   const payload = linkPreviewPayloadFromLookup(result);
   if (payload) return { kind: "ready", url, payload };
-  return result?.status === "not_found"
+  return result?.status === "not_found" || result?.status === "unsupported" || result?.status === "blocked"
     ? { kind: "unsupported", url }
     : { kind: "failed", url };
 }

--- a/chat/src/lib/xmpp/link-preview.ts
+++ b/chat/src/lib/xmpp/link-preview.ts
@@ -12,7 +12,7 @@ export interface LinkPreviewLookupReadyResult {
 
 export interface LinkPreviewLookupUnsupportedResult {
   originalUrl: string;
-  status: "not_found" | "unsupported" | "blocked" | "failed";
+  status: "unsupported" | "blocked" | "failed";
 }
 
 const HTTPS_URL_RE = /https:\/\/[^\s<>"']+/gi;
@@ -68,7 +68,7 @@ function parseLookupResponse(xml: string, requestedUrl: string): LinkPreviewLook
   const lookup = doc.getElementsByTagNameNS(NS_WADDLE_LINK_PREVIEW, "lookup")[0];
   if (!lookup) return null;
   const status = lookup.getAttribute("status");
-  if (status === "not_found" || status === "unsupported" || status === "blocked" || status === "failed") {
+  if (status === "unsupported" || status === "blocked" || status === "failed") {
     return { status, originalUrl: requestedUrl };
   }
   if (status !== "ready") return null;

--- a/chat/src/lib/xmpp/link-preview.ts
+++ b/chat/src/lib/xmpp/link-preview.ts
@@ -12,7 +12,7 @@ export interface LinkPreviewLookupReadyResult {
 
 export interface LinkPreviewLookupUnsupportedResult {
   originalUrl: string;
-  status: "not_found";
+  status: "not_found" | "unsupported" | "blocked" | "failed";
 }
 
 const HTTPS_URL_RE = /https:\/\/[^\s<>"']+/gi;
@@ -67,7 +67,9 @@ function parseLookupResponse(xml: string, requestedUrl: string): LinkPreviewLook
   const lookup = doc.getElementsByTagNameNS(NS_WADDLE_LINK_PREVIEW, "lookup")[0];
   if (!lookup) return null;
   const status = lookup.getAttribute("status");
-  if (status === "not_found") return { status: "not_found", originalUrl: requestedUrl };
+  if (status === "not_found" || status === "unsupported" || status === "blocked" || status === "failed") {
+    return { status, originalUrl: requestedUrl };
+  }
   if (status !== "ready") return null;
   const preview = Array.from(lookup.children).find(
     (child) => child.localName === "preview" && child.namespaceURI === NS_WADDLE_LINK_PREVIEW,

--- a/chat/src/lib/xmpp/link-preview.ts
+++ b/chat/src/lib/xmpp/link-preview.ts
@@ -18,6 +18,7 @@ export interface LinkPreviewLookupUnsupportedResult {
 const HTTPS_URL_RE = /https:\/\/[^\s<>"']+/gi;
 const NS_WADDLE_LINK_PREVIEW = "urn:waddle:link-preview:0";
 const LOOKUP_TIMEOUT_MS = 2_000;
+const MAX_LINK_PREVIEW_TOKEN_BYTES = 4096;
 
 type LinkPreviewIqClient = {
   send_raw_iq?: (xml: string) => Promise<string>;
@@ -80,6 +81,7 @@ function parseLookupResponse(xml: string, requestedUrl: string): LinkPreviewLook
   const normalizedUrl = preview.getAttribute("normalized-url")?.trim();
   const expiresAt = preview.getAttribute("expires-at")?.trim();
   if (!token || !originalUrl || !normalizedUrl || !expiresAt) return null;
+  if (token.length > MAX_LINK_PREVIEW_TOKEN_BYTES) return null;
   if (!urlsMatchSemantically(originalUrl, requestedUrl)) return null;
   if (!isEligiblePreviewUrl(originalUrl) || !isEligiblePreviewUrl(normalizedUrl)) return null;
   return {

--- a/chat/tests/link-preview-composer.test.ts
+++ b/chat/tests/link-preview-composer.test.ts
@@ -39,7 +39,7 @@ describe("composer link preview state", () => {
   });
 
   test("normal unsupported resolver states fail open with no send payload", () => {
-    for (const status of ["not_found", "unsupported", "blocked"] as const) {
+    for (const status of ["unsupported", "blocked"] as const) {
       const unsupported = linkPreviewStateFromLookup("https://example.com/a", {
         status,
         originalUrl: "https://example.com/a",
@@ -94,7 +94,7 @@ describe("composer link preview state", () => {
   });
 
   test("unsupported and failed composer lookup states emit no send payload", async () => {
-    for (const status of ["not_found", "unsupported", "blocked"] as const) {
+    for (const status of ["unsupported", "blocked"] as const) {
       const unsupported = setupComposerPreviewHarness(async () => ({
         status,
         originalUrl: "https://example.com/a",

--- a/chat/tests/link-preview-composer.test.ts
+++ b/chat/tests/link-preview-composer.test.ts
@@ -38,14 +38,19 @@ describe("composer link preview state", () => {
     });
   });
 
-  test("unsupported and dismissed states fail open with no send payload", () => {
-    const unsupported = linkPreviewStateFromLookup("https://example.com/a", {
-      status: "not_found",
-      originalUrl: "https://example.com/a",
-    });
+  test("normal unsupported resolver states fail open with no send payload", () => {
+    for (const status of ["not_found", "unsupported", "blocked"] as const) {
+      const unsupported = linkPreviewStateFromLookup("https://example.com/a", {
+        status,
+        originalUrl: "https://example.com/a",
+      });
 
-    expect(unsupported).toEqual({ kind: "unsupported", url: "https://example.com/a" });
-    expect(sendPayloadFromState(unsupported)).toBeUndefined();
+      expect(unsupported).toEqual({ kind: "unsupported", url: "https://example.com/a" });
+      expect(sendPayloadFromState(unsupported)).toBeUndefined();
+    }
+  });
+
+  test("dismissed states fail open with no send payload", () => {
     expect(sendPayloadFromState({ kind: "dismissed", url: "https://example.com/a" })).toBeUndefined();
   });
 
@@ -89,16 +94,18 @@ describe("composer link preview state", () => {
   });
 
   test("unsupported and failed composer lookup states emit no send payload", async () => {
-    const unsupported = setupComposerPreviewHarness(async () => ({
-      status: "not_found",
-      originalUrl: "https://example.com/a",
-    }));
+    for (const status of ["not_found", "unsupported", "blocked"] as const) {
+      const unsupported = setupComposerPreviewHarness(async () => ({
+        status,
+        originalUrl: "https://example.com/a",
+      }));
 
-    await flushComposerPreview();
+      await flushComposerPreview();
 
-    expect(unsupported.preview.state.value).toEqual({ kind: "unsupported", url: "https://example.com/a" });
-    expect(unsupported.preview.sendPayload.value).toBeUndefined();
-    unsupported.stop();
+      expect(unsupported.preview.state.value).toEqual({ kind: "unsupported", url: "https://example.com/a" });
+      expect(unsupported.preview.sendPayload.value).toBeUndefined();
+      unsupported.stop();
+    }
 
     const failed = setupComposerPreviewHarness(async () => {
       throw new Error("lookup failed");

--- a/chat/tests/link-preview.test.ts
+++ b/chat/tests/link-preview.test.ts
@@ -151,7 +151,7 @@ describe("link preview lookup", () => {
     });
   });
 
-  test("returns unsupported lookup state for not_found responses", async () => {
+  test("rejects legacy not_found lookup responses", async () => {
     const send_raw_iq = async () =>
       `<iq type="result" id="lookup-1"><lookup xmlns="urn:waddle:link-preview:0" status="not_found"/></iq>`;
 
@@ -166,10 +166,7 @@ describe("link preview lookup", () => {
       });
     });
 
-    expect(result).toEqual({
-      status: "not_found",
-      originalUrl: "https://unsupported.example/a",
-    });
+    expect(result).toBeNull();
   });
 
   test("returns typed normal lookup states for resolver blocked, failed, and unsupported responses", async () => {

--- a/chat/tests/link-preview.test.ts
+++ b/chat/tests/link-preview.test.ts
@@ -68,6 +68,25 @@ describe("link preview lookup", () => {
     expect(result).toBeNull();
   });
 
+  test("rejects lookup responses with oversized preview tokens", async () => {
+    const oversizedToken = "x".repeat(4097);
+    const send_raw_iq = async () =>
+      `<iq type="result" id="lookup-1"><lookup xmlns="urn:waddle:link-preview:0" status="ready"><preview token="${oversizedToken}" original-url="https://example.com/a" normalized-url="https://example.com/a" expires-at="2999-01-01T00:00:00.000Z"><title>Example</title></preview></lookup></iq>`;
+
+    let result: Awaited<ReturnType<typeof requestPlaintextLinkPreviewLookup>> = null;
+    await withFakeXmlDocument(async () => {
+      await withFakeDomParser(async () => {
+        result = await requestPlaintextLinkPreviewLookup(
+          { send_raw_iq },
+          "read https://example.com/a",
+          "room@muc.example.com",
+        );
+      });
+    });
+
+    expect(result).toBeNull();
+  });
+
   test("rejects ready lookup responses for a different original URL than requested", async () => {
     const send_raw_iq = async () =>
       `<iq type="result" id="lookup-1"><lookup xmlns="urn:waddle:link-preview:0" status="ready"><preview token="signed-token" original-url="https://other.example/a" normalized-url="https://other.example/a" expires-at="2999-01-01T00:00:00.000Z"><title>Other</title></preview></lookup></iq>`;

--- a/chat/tests/link-preview.test.ts
+++ b/chat/tests/link-preview.test.ts
@@ -153,6 +153,29 @@ describe("link preview lookup", () => {
     });
   });
 
+  test("returns typed normal lookup states for resolver blocked, failed, and unsupported responses", async () => {
+    for (const status of ["blocked", "failed", "unsupported"] as const) {
+      const send_raw_iq = async () =>
+        `<iq type="result" id="lookup-1"><lookup xmlns="urn:waddle:link-preview:0" status="${status}"/></iq>`;
+
+      let result: Awaited<ReturnType<typeof requestPlaintextLinkPreviewLookup>> = null;
+      await withFakeXmlDocument(async () => {
+        await withFakeDomParser(async () => {
+          result = await requestPlaintextLinkPreviewLookup(
+            { send_raw_iq },
+            "read https://unsupported.example/a",
+            "room@muc.example.com",
+          );
+        });
+      });
+
+      expect(result).toEqual({
+        status,
+        originalUrl: "https://unsupported.example/a",
+      });
+    }
+  });
+
   test("lookup failure is a metadata miss instead of a send blocker", async () => {
     const result = await requestPlaintextLinkPreviewLookup(
       { send_raw_iq: async () => { throw new Error("lookup failed"); } },

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
@@ -1,8 +1,7 @@
 //! Waddle plaintext link-preview composer lookup.
 //!
-//! This first tracer bullet deliberately returns text-only metadata derived
-//! from the submitted HTTPS URL. Later resolver slices can replace the lookup
-//! internals without changing the send-time token request or XEP-0511 payload.
+//! The lookup resolves OpenGraph metadata through the bounded HTTPS resolver,
+//! then mints a scoped private token for the send-time XEP-0511 payload.
 
 use super::*;
 use chrono::{Duration, SecondsFormat, Utc};
@@ -11,6 +10,19 @@ use url::Url;
 use waddle_xmpp::xep::{encode_link_preview_token, LinkPreviewTokenData, NS_WADDLE_LINK_PREVIEW};
 use xmpp_parsers::iq::Iq;
 use xmpp_parsers::minidom::Element;
+
+use super::link_preview_resolver::{
+    resolve_link_preview, LinkPreviewResolverOutcome, LinkPreviewResolverPolicy,
+    LinkPreviewResolverStatus,
+};
+
+struct LinkPreviewLookupDeps<'a> {
+    muc_domain: &'a str,
+    response_from: Option<&'a str>,
+    response_to: Option<&'a str>,
+    secret: &'a [u8],
+    resolver_policy: &'a LinkPreviewResolverPolicy,
+}
 
 pub(super) fn is_link_preview_lookup_iq(iq: &Iq) -> bool {
     let Iq::Get { payload, .. } = iq else {
@@ -28,19 +40,41 @@ pub(super) async fn handle_link_preview_lookup_iq(
     response_to: Option<&str>,
     secret: &[u8],
 ) -> Vec<String> {
+    let resolver_policy = LinkPreviewResolverPolicy::default();
+    handle_link_preview_lookup_iq_with_policy(
+        iq,
+        sender_jid,
+        state,
+        LinkPreviewLookupDeps {
+            muc_domain,
+            response_from,
+            response_to,
+            secret,
+            resolver_policy: &resolver_policy,
+        },
+    )
+    .await
+}
+
+async fn handle_link_preview_lookup_iq_with_policy(
+    iq: &Iq,
+    sender_jid: Option<&FullJid>,
+    state: &WebSocketState,
+    deps: LinkPreviewLookupDeps<'_>,
+) -> Vec<String> {
     let Some(sender_jid) = sender_jid else {
         return vec![build_iq_error_xml_typed(
             iq.id(),
-            response_from,
-            response_to,
+            deps.response_from,
+            deps.response_to,
             not_authorized_iq_error("Authentication required."),
         )];
     };
     let Iq::Get { payload, .. } = iq else {
         return vec![build_iq_error_xml_typed(
             iq.id(),
-            response_from,
-            response_to,
+            deps.response_from,
+            deps.response_to,
             bad_request_iq_error("Link preview lookup must be an IQ get."),
         )];
     };
@@ -48,26 +82,26 @@ pub(super) async fn handle_link_preview_lookup_iq(
     let Some(original_url) = lookup_url(payload) else {
         return vec![build_iq_error_xml_typed(
             iq.id(),
-            response_from,
-            response_to,
+            deps.response_from,
+            deps.response_to,
             bad_request_iq_error("Link preview lookup requires a URL."),
         )];
     };
     let Some(scope_jid) = lookup_scope(payload).and_then(|scope| scope.parse().ok()) else {
         return vec![build_iq_error_xml_typed(
             iq.id(),
-            response_from,
-            response_to,
+            deps.response_from,
+            deps.response_to,
             bad_request_iq_error("Link preview lookup requires a conversation scope JID."),
         )];
     };
     if let Some(error) =
-        authorize_link_preview_scope(state, sender_jid, &scope_jid, muc_domain).await
+        authorize_link_preview_scope(state, sender_jid, &scope_jid, deps.muc_domain).await
     {
         return vec![build_iq_error_xml_typed(
             iq.id(),
-            response_from,
-            response_to,
+            deps.response_from,
+            deps.response_to,
             error,
         )];
     }
@@ -75,45 +109,39 @@ pub(super) async fn handle_link_preview_lookup_iq(
     let Ok(original_url) = Url::parse(&original_url) else {
         return vec![build_link_preview_lookup_result(
             iq,
-            response_from,
-            response_to,
+            deps.response_from,
+            deps.response_to,
+            LinkPreviewResolverStatus::Unsupported,
             None,
         )];
     };
-    if original_url.scheme() != "https"
-        || !original_url
-            .host_str()
-            .is_some_and(|host| host.contains('.'))
-    {
+    let outcome = resolve_link_preview(&original_url, deps.resolver_policy).await;
+    let LinkPreviewResolverOutcome::Ready(metadata) = outcome else {
         return vec![build_link_preview_lookup_result(
             iq,
-            response_from,
-            response_to,
+            deps.response_from,
+            deps.response_to,
+            outcome.status(),
             None,
         )];
-    }
-
+    };
     let expires_at = Utc::now() + Duration::minutes(5);
-    let host = original_url
-        .host_str()
-        .unwrap_or_default()
-        .trim_start_matches("www.")
-        .to_string();
     let data = LinkPreviewTokenData {
         sender_jid: sender_jid.to_bare(),
         scope_jid,
-        original_url: original_url.clone(),
-        normalized_url: original_url.clone(),
-        title: Some(host),
-        description: Some(original_url.as_str().to_string()),
+        original_url: metadata.original_url,
+        normalized_url: metadata.normalized_url,
+        title: metadata.title,
+        description: metadata.description,
         expires_at_unix: expires_at.timestamp(),
     };
-    let token = encode_link_preview_token(&data, secret);
+    let token = encode_link_preview_token(&data, deps.secret);
 
     vec![build_link_preview_lookup_result(
         iq,
-        response_from,
-        response_to,
+        deps.response_from,
+        deps.response_to,
+        LinkPreviewResolverStatus::Ready,
         Some((
             data,
             token.as_str(),
@@ -178,6 +206,7 @@ fn build_link_preview_lookup_result(
     iq: &Iq,
     response_from: Option<&str>,
     response_to: Option<&str>,
+    status: LinkPreviewResolverStatus,
     preview: Option<(LinkPreviewTokenData, &str, String)>,
 ) -> String {
     let mut lookup = Element::builder("lookup", NS_WADDLE_LINK_PREVIEW).attr(
@@ -185,7 +214,7 @@ fn build_link_preview_lookup_result(
         if preview.is_some() {
             "ready"
         } else {
-            "not_found"
+            status.as_lookup_status()
         },
     );
     if let Some((data, token, expires_at)) = preview {
@@ -223,6 +252,8 @@ fn append_text(parent: &mut Element, name: &str, value: Option<&str>) {
 mod tests {
     use super::*;
     use crate::server::routes::websocket::tests::create_test_websocket_state;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn iq_get_with_payload(payload: Element) -> Iq {
         Iq::Get {
@@ -243,10 +274,27 @@ mod tests {
 
     #[tokio::test]
     async fn handles_https_lookup_with_scoped_token_and_text_metadata() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/a"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                r#"<html><head>
+                    <meta property="og:title" content="Example Article">
+                    <meta property="og:description" content="Plain text summary">
+                  </head></html>"#,
+                "text/html",
+            ))
+            .mount(&server)
+            .await;
+        let resolver_policy = LinkPreviewResolverPolicy {
+            allow_http_loopback_for_tests: true,
+            ..Default::default()
+        };
+        let lookup_url = format!("{}/a", server.uri());
         let payload = Element::builder("lookup", NS_WADDLE_LINK_PREVIEW)
             .append(
                 Element::builder("url", NS_WADDLE_LINK_PREVIEW)
-                    .append("https://www.example.com/a")
+                    .append(lookup_url.as_str())
                     .build(),
             )
             .append(
@@ -258,14 +306,17 @@ mod tests {
         let iq = iq_get_with_payload(payload);
 
         let state = create_test_websocket_state().await;
-        let response = handle_link_preview_lookup_iq(
+        let response = handle_link_preview_lookup_iq_with_policy(
             &iq,
             Some(&sender()),
             state.as_ref(),
-            "muc.example.com",
-            None,
-            None,
-            secret(),
+            LinkPreviewLookupDeps {
+                muc_domain: "muc.example.com",
+                response_from: None,
+                response_to: None,
+                secret: secret(),
+                resolver_policy: &resolver_policy,
+            },
         )
         .await;
 
@@ -277,14 +328,8 @@ mod tests {
         let preview = lookup
             .get_child("preview", NS_WADDLE_LINK_PREVIEW)
             .expect("preview");
-        assert_eq!(
-            preview.attr("original-url"),
-            Some("https://www.example.com/a")
-        );
-        assert_eq!(
-            preview.attr("normalized-url"),
-            Some("https://www.example.com/a")
-        );
+        assert_eq!(preview.attr("original-url"), Some(lookup_url.as_str()));
+        assert_eq!(preview.attr("normalized-url"), Some(lookup_url.as_str()));
         assert!(preview.attr("token").is_some_and(|token| !token.is_empty()));
         assert!(preview.attr("expires-at").is_some());
         let token = waddle_xmpp::xep::LinkPreviewToken::new(
@@ -300,12 +345,12 @@ mod tests {
                 .get_child("title", NS_WADDLE_LINK_PREVIEW)
                 .map(Element::text)
                 .as_deref(),
-            Some("example.com")
+            Some("Example Article")
         );
     }
 
     #[tokio::test]
-    async fn non_https_lookup_returns_not_found_without_token() {
+    async fn non_https_lookup_returns_unsupported_without_token() {
         let payload = Element::builder("lookup", NS_WADDLE_LINK_PREVIEW)
             .append(
                 Element::builder("url", NS_WADDLE_LINK_PREVIEW)
@@ -336,7 +381,7 @@ mod tests {
         let lookup = elem
             .get_child("lookup", NS_WADDLE_LINK_PREVIEW)
             .expect("lookup result");
-        assert_eq!(lookup.attr("status"), Some("not_found"));
+        assert_eq!(lookup.attr("status"), Some("unsupported"));
         assert!(lookup
             .get_child("preview", NS_WADDLE_LINK_PREVIEW)
             .is_none());

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
@@ -7,7 +7,9 @@ use super::*;
 use chrono::{Duration, SecondsFormat, Utc};
 use minidom::rxml::xml_ncname;
 use url::Url;
-use waddle_xmpp::xep::{encode_link_preview_token, LinkPreviewTokenData, NS_WADDLE_LINK_PREVIEW};
+use waddle_xmpp::xep::{
+    encode_link_preview_token_checked, LinkPreviewTokenData, NS_WADDLE_LINK_PREVIEW,
+};
 use xmpp_parsers::iq::Iq;
 use xmpp_parsers::minidom::Element;
 
@@ -135,7 +137,15 @@ async fn handle_link_preview_lookup_iq_with_policy(
         description: metadata.description,
         expires_at_unix: expires_at.timestamp(),
     };
-    let token = encode_link_preview_token(&data, deps.secret);
+    let Some(token) = encode_link_preview_token_checked(&data, deps.secret) else {
+        return vec![build_link_preview_lookup_result(
+            iq,
+            deps.response_from,
+            deps.response_to,
+            LinkPreviewResolverStatus::Failed,
+            None,
+        )];
+    };
 
     vec![build_link_preview_lookup_result(
         iq,
@@ -347,6 +357,64 @@ mod tests {
                 .as_deref(),
             Some("Example Article")
         );
+    }
+
+    #[tokio::test]
+    async fn oversized_encoded_token_returns_failed_without_preview() {
+        let server = MockServer::start().await;
+        let huge_path = format!("/{}", "a".repeat(8 * 1024));
+        Mock::given(method("GET"))
+            .and(path(huge_path.as_str()))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                r#"<html><head>
+                    <meta property="og:title" content="Example Article">
+                  </head></html>"#,
+                "text/html",
+            ))
+            .mount(&server)
+            .await;
+        let resolver_policy = LinkPreviewResolverPolicy {
+            allow_http_loopback_for_tests: true,
+            ..Default::default()
+        };
+        let lookup_url = format!("{}{}", server.uri(), huge_path);
+        let payload = Element::builder("lookup", NS_WADDLE_LINK_PREVIEW)
+            .append(
+                Element::builder("url", NS_WADDLE_LINK_PREVIEW)
+                    .append(lookup_url.as_str())
+                    .build(),
+            )
+            .append(
+                Element::builder("scope", NS_WADDLE_LINK_PREVIEW)
+                    .append("alice@example.com")
+                    .build(),
+            )
+            .build();
+        let iq = iq_get_with_payload(payload);
+
+        let state = create_test_websocket_state().await;
+        let response = handle_link_preview_lookup_iq_with_policy(
+            &iq,
+            Some(&sender()),
+            state.as_ref(),
+            LinkPreviewLookupDeps {
+                muc_domain: "muc.example.com",
+                response_from: None,
+                response_to: None,
+                secret: secret(),
+                resolver_policy: &resolver_policy,
+            },
+        )
+        .await;
+
+        let elem: Element = response[0].parse().expect("iq result");
+        let lookup = elem
+            .get_child("lookup", NS_WADDLE_LINK_PREVIEW)
+            .expect("lookup result");
+        assert_eq!(lookup.attr("status"), Some("failed"));
+        assert!(lookup
+            .get_child("preview", NS_WADDLE_LINK_PREVIEW)
+            .is_none());
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
@@ -88,11 +88,8 @@ pub(super) async fn resolve_link_preview(
         };
         match fetch {
             FetchOnceResult::Html { final_url, html } => {
-                return extract_metadata_from_html(url, &html)
-                    .map(|mut metadata| {
-                        metadata.normalized_url = final_url;
-                        LinkPreviewResolverOutcome::Ready(Box::new(metadata))
-                    })
+                return extract_metadata_from_html_with_normalized_fallback(url, &html, &final_url)
+                    .map(|metadata| LinkPreviewResolverOutcome::Ready(Box::new(metadata)))
                     .unwrap_or(LinkPreviewResolverOutcome::Unsupported);
             }
             FetchOnceResult::Redirect(next) => {
@@ -347,16 +344,32 @@ fn is_global_ipv6(ip: Ipv6Addr) -> bool {
     true
 }
 
-pub(super) fn extract_metadata_from_html(
+#[cfg(test)]
+fn extract_metadata_from_html(requested_url: &Url, html: &str) -> Option<ResolvedLinkMetadata> {
+    extract_metadata_from_html_with_normalized_fallback(requested_url, html, requested_url)
+}
+
+fn extract_metadata_from_html_with_normalized_fallback(
     requested_url: &Url,
     html: &str,
+    normalized_fallback_url: &Url,
 ) -> Option<ResolvedLinkMetadata> {
     let title = meta_content(html, "og:title", LINK_PREVIEW_TITLE_MAX_BYTES);
     let description = meta_content(html, "og:description", LINK_PREVIEW_DESCRIPTION_MAX_BYTES);
-    let normalized_url = meta_content(html, "og:url", usize::MAX)
+    let canonical_url = meta_content(html, "og:url", usize::MAX)
         .and_then(|url| Url::parse(&url).ok())
-        .unwrap_or_else(|| requested_url.clone());
-    if title.is_none() && description.is_none() && normalized_url == *requested_url {
+        .filter(|url| {
+            classify_url_with_policy(url, &LinkPreviewResolverPolicy::default())
+                == LinkPreviewResolverStatus::Ready
+        });
+    let normalized_url = canonical_url
+        .clone()
+        .unwrap_or_else(|| normalized_fallback_url.clone());
+    if title.is_none()
+        && description.is_none()
+        && canonical_url.is_none()
+        && normalized_url == *requested_url
+    {
         return None;
     }
 
@@ -372,7 +385,15 @@ fn meta_content(html: &str, property: &str, max_bytes: usize) -> Option<String> 
     let mut remaining = html;
     while let Some(start) = find_ascii_case_insensitive(remaining, "<meta") {
         remaining = &remaining[start + "<meta".len()..];
-        let end = remaining.find('>')?;
+        let Some(end) = remaining.find('>') else {
+            break;
+        };
+        if let Some(next_start) = find_ascii_case_insensitive(remaining, "<meta") {
+            if next_start < end {
+                remaining = &remaining[next_start..];
+                continue;
+            }
+        }
         let tag = &remaining[..end];
         remaining = &remaining[end + 1..];
 
@@ -519,10 +540,76 @@ mod tests {
     }
 
     #[test]
+    fn malformed_meta_tag_does_not_abort_later_metadata_extraction() {
+        let requested_url = Url::parse("https://example.com/articles").expect("url");
+        let html = r#"<html><head>
+                <meta property="og:title" content="Broken"
+                <meta property="og:title" content="Recovered title">
+                <meta property="og:description" content="Recovered description">
+              </head></html>"#;
+
+        let metadata = extract_metadata_from_html(&requested_url, html).expect("metadata");
+
+        assert_eq!(metadata.title.as_deref(), Some("Recovered title"));
+        assert_eq!(
+            metadata.description.as_deref(),
+            Some("Recovered description")
+        );
+    }
+
+    #[test]
+    fn ignores_blocked_open_graph_canonical_urls() {
+        let requested_url = Url::parse("https://example.com/articles").expect("url");
+        let html = r#"<html><head>
+                <meta property="og:title" content="Safe title">
+                <meta property="og:url" content="https://Printer.Local/admin">
+              </head></html>"#;
+
+        let metadata = extract_metadata_from_html(&requested_url, html).expect("metadata");
+
+        assert_eq!(metadata.normalized_url, requested_url);
+    }
+
+    #[test]
+    fn preserves_safe_open_graph_canonical_url_over_fetch_url() {
+        let requested_url = Url::parse("https://example.com/articles?utm=keep").expect("url");
+        let final_url = Url::parse("https://example.com/redirected?utm=keep").expect("url");
+        let canonical_url = Url::parse("https://example.com/articles").expect("url");
+        let html = r#"<html><head>
+                <meta property="og:title" content="Safe title">
+                <meta property="og:url" content="https://example.com/articles">
+              </head></html>"#;
+
+        let metadata =
+            extract_metadata_from_html_with_normalized_fallback(&requested_url, html, &final_url)
+                .expect("metadata");
+
+        assert_eq!(metadata.normalized_url, canonical_url);
+    }
+
+    #[test]
+    fn falls_back_to_fetch_url_when_open_graph_canonical_url_is_absent() {
+        let requested_url = Url::parse("https://example.com/articles?utm=keep").expect("url");
+        let final_url = Url::parse("https://example.com/redirected").expect("url");
+        let html = r#"<html><head>
+                <meta property="og:title" content="Safe title">
+              </head></html>"#;
+
+        let metadata =
+            extract_metadata_from_html_with_normalized_fallback(&requested_url, html, &final_url)
+                .expect("metadata");
+
+        assert_eq!(metadata.normalized_url, final_url);
+    }
+
+    #[test]
     fn truncates_decoded_text_metadata_to_field_byte_limits() {
         let requested_url = Url::parse("https://example.com/articles").expect("url");
-        let title = "t".repeat(LINK_PREVIEW_TITLE_MAX_BYTES + 64);
-        let description = "d".repeat(LINK_PREVIEW_DESCRIPTION_MAX_BYTES + 64);
+        let title = format!("{}&eacute;", "t".repeat(LINK_PREVIEW_TITLE_MAX_BYTES - 1));
+        let description = format!(
+            "{}&eacute;",
+            "d".repeat(LINK_PREVIEW_DESCRIPTION_MAX_BYTES - 1)
+        );
         let html = format!(
             r#"<html><head>
                 <meta property="og:title" content="{title}">
@@ -534,11 +621,19 @@ mod tests {
 
         assert_eq!(
             metadata.title.as_deref().map(str::len),
-            Some(LINK_PREVIEW_TITLE_MAX_BYTES)
+            Some(LINK_PREVIEW_TITLE_MAX_BYTES - 1)
         );
         assert_eq!(
             metadata.description.as_deref().map(str::len),
-            Some(LINK_PREVIEW_DESCRIPTION_MAX_BYTES)
+            Some(LINK_PREVIEW_DESCRIPTION_MAX_BYTES - 1)
+        );
+        assert_eq!(
+            metadata.title.as_deref(),
+            Some("t".repeat(LINK_PREVIEW_TITLE_MAX_BYTES - 1).as_str())
+        );
+        assert_eq!(
+            metadata.description.as_deref(),
+            Some("d".repeat(LINK_PREVIEW_DESCRIPTION_MAX_BYTES - 1).as_str())
         );
     }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
@@ -8,6 +8,8 @@ use url::{Host, Url};
 const DEFAULT_MAX_BYTES: usize = 256 * 1024;
 const DEFAULT_MAX_REDIRECTS: usize = 3;
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(3);
+const LINK_PREVIEW_TITLE_MAX_BYTES: usize = 256;
+const LINK_PREVIEW_DESCRIPTION_MAX_BYTES: usize = 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct ResolvedLinkMetadata {
@@ -349,9 +351,9 @@ pub(super) fn extract_metadata_from_html(
     requested_url: &Url,
     html: &str,
 ) -> Option<ResolvedLinkMetadata> {
-    let title = meta_content(html, "og:title");
-    let description = meta_content(html, "og:description");
-    let normalized_url = meta_content(html, "og:url")
+    let title = meta_content(html, "og:title", LINK_PREVIEW_TITLE_MAX_BYTES);
+    let description = meta_content(html, "og:description", LINK_PREVIEW_DESCRIPTION_MAX_BYTES);
+    let normalized_url = meta_content(html, "og:url", usize::MAX)
         .and_then(|url| Url::parse(&url).ok())
         .unwrap_or_else(|| requested_url.clone());
     if title.is_none() && description.is_none() && normalized_url == *requested_url {
@@ -366,7 +368,7 @@ pub(super) fn extract_metadata_from_html(
     })
 }
 
-fn meta_content(html: &str, property: &str) -> Option<String> {
+fn meta_content(html: &str, property: &str, max_bytes: usize) -> Option<String> {
     let mut remaining = html;
     while let Some(start) = find_ascii_case_insensitive(remaining, "<meta") {
         remaining = &remaining[start + "<meta".len()..];
@@ -390,11 +392,22 @@ fn meta_content(html: &str, property: &str) -> Option<String> {
                 .trim()
                 .to_string();
             if !content.is_empty() {
-                return Some(content);
+                return Some(truncate_utf8_to_bytes(&content, max_bytes));
             }
         }
     }
     None
+}
+
+fn truncate_utf8_to_bytes(value: &str, max_bytes: usize) -> String {
+    if value.len() <= max_bytes {
+        return value.to_string();
+    }
+    let mut end = max_bytes;
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    value[..end].to_string()
 }
 
 fn parse_tag_attrs(tag: &str) -> Vec<(String, String)> {
@@ -503,6 +516,41 @@ mod tests {
         let requested_url = Url::parse("https://example.com/articles").expect("url");
 
         assert!(extract_metadata_from_html(&requested_url, "<html><head></head></html>").is_none());
+    }
+
+    #[test]
+    fn truncates_decoded_text_metadata_to_field_byte_limits() {
+        let requested_url = Url::parse("https://example.com/articles").expect("url");
+        let title = "t".repeat(LINK_PREVIEW_TITLE_MAX_BYTES + 64);
+        let description = "d".repeat(LINK_PREVIEW_DESCRIPTION_MAX_BYTES + 64);
+        let html = format!(
+            r#"<html><head>
+                <meta property="og:title" content="{title}">
+                <meta property="og:description" content="{description}">
+              </head></html>"#
+        );
+
+        let metadata = extract_metadata_from_html(&requested_url, &html).expect("metadata");
+
+        assert_eq!(
+            metadata.title.as_deref().map(str::len),
+            Some(LINK_PREVIEW_TITLE_MAX_BYTES)
+        );
+        assert_eq!(
+            metadata.description.as_deref().map(str::len),
+            Some(LINK_PREVIEW_DESCRIPTION_MAX_BYTES)
+        );
+    }
+
+    #[test]
+    fn text_metadata_truncation_preserves_utf8_boundaries() {
+        let requested_url = Url::parse("https://example.com/articles").expect("url");
+        let title = "é".repeat(LINK_PREVIEW_TITLE_MAX_BYTES);
+        let html = format!(r#"<meta property="og:title" content="{title}">"#);
+
+        let metadata = extract_metadata_from_html(&requested_url, &html).expect("metadata");
+
+        assert!(metadata.title.expect("title").len() <= LINK_PREVIEW_TITLE_MAX_BYTES);
     }
 
     #[test]

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
@@ -266,11 +266,16 @@ fn classify_url_with_policy(
         return LinkPreviewResolverStatus::Blocked;
     }
     if let Some(Host::Domain(host)) = url.host() {
-        if host.trim_end_matches('.').ends_with(".local") {
+        if is_dot_local_domain(host) {
             return LinkPreviewResolverStatus::Blocked;
         }
     }
     LinkPreviewResolverStatus::Ready
+}
+
+fn is_dot_local_domain(host: &str) -> bool {
+    let host = host.trim_end_matches('.');
+    host.eq_ignore_ascii_case("local") || host.to_ascii_lowercase().ends_with(".local")
 }
 
 fn host_is_loopback(host: Host<&str>) -> bool {
@@ -532,12 +537,21 @@ mod tests {
 
     #[test]
     fn blocks_dot_local_domains_before_fetch() {
-        let url = Url::parse("https://printer.local/article").expect("url");
+        for raw in [
+            "https://printer.local/article",
+            "https://Printer.Local/article",
+            "https://printer.local./article",
+        ] {
+            let url = Url::parse(raw).expect("url");
 
-        assert_eq!(
-            classify_url_with_policy(&url, &LinkPreviewResolverPolicy::default()),
-            LinkPreviewResolverStatus::Blocked
-        );
+            assert_eq!(
+                classify_url_with_policy(&url, &LinkPreviewResolverPolicy::default()),
+                LinkPreviewResolverStatus::Blocked,
+                "{raw}"
+            );
+        }
+        assert!(is_dot_local_domain("Printer.Local"));
+        assert!(is_dot_local_domain("Printer.Local."));
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
@@ -7,7 +7,7 @@ use url::{Host, Url};
 
 const DEFAULT_MAX_BYTES: usize = 256 * 1024;
 const DEFAULT_MAX_REDIRECTS: usize = 3;
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(3);
+const DEFAULT_TIMEOUT: Duration = Duration::from_millis(1_500);
 const LINK_PREVIEW_TITLE_MAX_BYTES: usize = 256;
 const LINK_PREVIEW_DESCRIPTION_MAX_BYTES: usize = 1024;
 
@@ -123,6 +123,8 @@ async fn fetch_html_once(
     timeout: Duration,
 ) -> Result<FetchOnceResult, LinkPreviewResolverStatus> {
     let target = prepare_target(url, policy).await?;
+    // The client is per-hop because each redirect target needs a fresh DNS pin;
+    // max_redirects keeps the extra TLS/client setup cost bounded.
     let mut builder = Client::builder()
         .timeout(timeout)
         .connect_timeout(timeout)
@@ -407,12 +409,12 @@ fn extract_metadata_from_html_with_normalized_fallback(
 
 fn meta_content(html: &str, property: &str, max_bytes: usize) -> Option<String> {
     let mut remaining = html;
-    while let Some(start) = find_ascii_case_insensitive(remaining, "<meta") {
+    while let Some(start) = find_meta_tag_start(remaining) {
         remaining = &remaining[start + "<meta".len()..];
         let Some(end) = find_meta_tag_end(remaining) else {
             break;
         };
-        if let Some(next_start) = find_ascii_case_insensitive(remaining, "<meta") {
+        if let Some(next_start) = find_meta_tag_start(remaining) {
             if next_start < end {
                 remaining = &remaining[next_start..];
                 continue;
@@ -451,6 +453,20 @@ fn same_domain_host(left: &Url, right: &Url) -> bool {
             .eq_ignore_ascii_case(right.trim_end_matches('.')),
         _ => false,
     }
+}
+
+fn find_meta_tag_start(html: &str) -> Option<usize> {
+    let mut offset = 0;
+    while let Some(start) = find_ascii_case_insensitive(&html[offset..], "<meta") {
+        let absolute_start = offset + start;
+        let after_name = absolute_start + "<meta".len();
+        match html.as_bytes().get(after_name) {
+            None | Some(b'>') | Some(b'/') => return Some(absolute_start),
+            Some(byte) if byte.is_ascii_whitespace() => return Some(absolute_start),
+            _ => offset = after_name,
+        }
+    }
+    None
 }
 
 fn find_meta_tag_end(tag_tail: &str) -> Option<usize> {
@@ -611,6 +627,17 @@ mod tests {
         let metadata = extract_metadata_from_html(&requested_url, html).expect("metadata");
 
         assert_eq!(metadata.title.as_deref(), Some("A>B"));
+    }
+
+    #[test]
+    fn scanner_ignores_non_meta_tag_names_with_meta_prefix() {
+        let requested_url = Url::parse("https://example.com/articles").expect("url");
+        let html = r#"<metadata property="og:title" content="Wrong">
+            <meta property="og:title" content="Right">"#;
+
+        let metadata = extract_metadata_from_html(&requested_url, html).expect("metadata");
+
+        assert_eq!(metadata.title.as_deref(), Some("Right"));
     }
 
     #[test]

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
@@ -1,5 +1,5 @@
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use reqwest::header::{CONTENT_TYPE, LOCATION};
 use reqwest::{redirect, Client, StatusCode};
@@ -81,10 +81,19 @@ pub(super) async fn resolve_link_preview(
     policy: &LinkPreviewResolverPolicy,
 ) -> LinkPreviewResolverOutcome {
     let mut current = url.clone();
+    let deadline = Instant::now() + policy.timeout;
     for redirect_count in 0..=policy.max_redirects {
-        let fetch = match fetch_html_once(&current, policy).await {
+        let Some(timeout) = deadline.checked_duration_since(Instant::now()) else {
+            return LinkPreviewResolverOutcome::Failed;
+        };
+        let fetch = match fetch_html_once(&current, policy, timeout).await {
             Ok(fetch) => fetch,
-            Err(status) => return status.into(),
+            Err(LinkPreviewResolverStatus::Blocked) => return LinkPreviewResolverOutcome::Blocked,
+            Err(LinkPreviewResolverStatus::Failed) => return LinkPreviewResolverOutcome::Failed,
+            Err(LinkPreviewResolverStatus::Unsupported) => {
+                return LinkPreviewResolverOutcome::Unsupported;
+            }
+            Err(LinkPreviewResolverStatus::Ready) => unreachable!("ready is not a fetch error"),
         };
         match fetch {
             FetchOnceResult::Html { final_url, html } => {
@@ -103,17 +112,6 @@ pub(super) async fn resolve_link_preview(
     LinkPreviewResolverOutcome::Failed
 }
 
-impl From<LinkPreviewResolverStatus> for LinkPreviewResolverOutcome {
-    fn from(status: LinkPreviewResolverStatus) -> Self {
-        match status {
-            LinkPreviewResolverStatus::Ready => LinkPreviewResolverOutcome::Failed,
-            LinkPreviewResolverStatus::Blocked => LinkPreviewResolverOutcome::Blocked,
-            LinkPreviewResolverStatus::Failed => LinkPreviewResolverOutcome::Failed,
-            LinkPreviewResolverStatus::Unsupported => LinkPreviewResolverOutcome::Unsupported,
-        }
-    }
-}
-
 enum FetchOnceResult {
     Html { final_url: Url, html: String },
     Redirect(Url),
@@ -122,14 +120,17 @@ enum FetchOnceResult {
 async fn fetch_html_once(
     url: &Url,
     policy: &LinkPreviewResolverPolicy,
+    timeout: Duration,
 ) -> Result<FetchOnceResult, LinkPreviewResolverStatus> {
     let target = prepare_target(url, policy).await?;
     let mut builder = Client::builder()
-        .timeout(policy.timeout)
-        .connect_timeout(policy.timeout)
+        .timeout(timeout)
+        .connect_timeout(timeout)
         .redirect(redirect::Policy::none())
         .https_only(!policy.allow_http_loopback_for_tests);
     if let Host::Domain(host) = target.host {
+        // SSRF defense relies on reqwest dialing only the DNS results validated in
+        // prepare_target; dropping this pin would let reqwest re-resolve the host.
         builder = builder.resolve_to_addrs(host, &target.addrs);
     }
     let client = builder
@@ -184,7 +185,7 @@ async fn fetch_html_once(
         return Err(LinkPreviewResolverStatus::Unsupported);
     }
     if let Some(len) = response.content_length() {
-        if len as usize > policy.max_bytes {
+        if len > policy.max_bytes as u64 {
             return Err(LinkPreviewResolverStatus::Failed);
         }
     }
@@ -328,10 +329,32 @@ fn is_global_ipv6(ip: Ipv6Addr) -> bool {
     {
         return false;
     }
-    if let Some(v4) = ip.to_ipv4() {
+    if let Some(v4) = ip.to_ipv4_mapped().or_else(|| ip.to_ipv4()) {
         return is_global_ipv4(v4);
     }
     let segs = ip.segments();
+    if segs[0] == 0x2002 {
+        return is_global_ipv4(Ipv4Addr::new(
+            (segs[1] >> 8) as u8,
+            segs[1] as u8,
+            (segs[2] >> 8) as u8,
+            segs[2] as u8,
+        ));
+    }
+    if segs[0] == 0x0064
+        && segs[1] == 0xff9b
+        && segs[2] == 0
+        && segs[3] == 0
+        && segs[4] == 0
+        && segs[5] == 0
+    {
+        return is_global_ipv4(Ipv4Addr::new(
+            (segs[6] >> 8) as u8,
+            segs[6] as u8,
+            (segs[7] >> 8) as u8,
+            segs[7] as u8,
+        ));
+    }
     if (segs[0] & 0xffc0) == 0xfec0 {
         return false;
     }
@@ -361,6 +384,7 @@ fn extract_metadata_from_html_with_normalized_fallback(
         .filter(|url| {
             classify_url_with_policy(url, &LinkPreviewResolverPolicy::default())
                 == LinkPreviewResolverStatus::Ready
+                && same_domain_host(url, normalized_fallback_url)
         });
     let normalized_url = canonical_url
         .clone()
@@ -385,7 +409,7 @@ fn meta_content(html: &str, property: &str, max_bytes: usize) -> Option<String> 
     let mut remaining = html;
     while let Some(start) = find_ascii_case_insensitive(remaining, "<meta") {
         remaining = &remaining[start + "<meta".len()..];
-        let Some(end) = remaining.find('>') else {
+        let Some(end) = find_meta_tag_end(remaining) else {
             break;
         };
         if let Some(next_start) = find_ascii_case_insensitive(remaining, "<meta") {
@@ -415,6 +439,28 @@ fn meta_content(html: &str, property: &str, max_bytes: usize) -> Option<String> 
             if !content.is_empty() {
                 return Some(truncate_utf8_to_bytes(&content, max_bytes));
             }
+        }
+    }
+    None
+}
+
+fn same_domain_host(left: &Url, right: &Url) -> bool {
+    match (left.host(), right.host()) {
+        (Some(Host::Domain(left)), Some(Host::Domain(right))) => left
+            .trim_end_matches('.')
+            .eq_ignore_ascii_case(right.trim_end_matches('.')),
+        _ => false,
+    }
+}
+
+fn find_meta_tag_end(tag_tail: &str) -> Option<usize> {
+    let mut quote = None;
+    for (index, byte) in tag_tail.bytes().enumerate() {
+        match (quote, byte) {
+            (Some(open), current) if current == open => quote = None,
+            (None, b'"' | b'\'') => quote = Some(byte),
+            (None, b'>') => return Some(index),
+            _ => {}
         }
     }
     None
@@ -558,6 +604,16 @@ mod tests {
     }
 
     #[test]
+    fn meta_tag_terminator_ignores_greater_than_inside_quoted_attribute_values() {
+        let requested_url = Url::parse("https://example.com/articles").expect("url");
+        let html = r#"<meta property="og:title" content="A&gt;B">"#;
+
+        let metadata = extract_metadata_from_html(&requested_url, html).expect("metadata");
+
+        assert_eq!(metadata.title.as_deref(), Some("A>B"));
+    }
+
+    #[test]
     fn ignores_blocked_open_graph_canonical_urls() {
         let requested_url = Url::parse("https://example.com/articles").expect("url");
         let html = r#"<html><head>
@@ -568,6 +624,22 @@ mod tests {
         let metadata = extract_metadata_from_html(&requested_url, html).expect("metadata");
 
         assert_eq!(metadata.normalized_url, requested_url);
+    }
+
+    #[test]
+    fn ignores_cross_host_open_graph_canonical_urls() {
+        let requested_url = Url::parse("https://attacker.example/articles").expect("url");
+        let final_url = Url::parse("https://attacker.example/final").expect("url");
+        let html = r#"<html><head>
+                <meta property="og:title" content="Safe title">
+                <meta property="og:url" content="https://bank.example/login">
+              </head></html>"#;
+
+        let metadata =
+            extract_metadata_from_html_with_normalized_fallback(&requested_url, html, &final_url)
+                .expect("metadata");
+
+        assert_eq!(metadata.normalized_url, final_url);
     }
 
     #[test]
@@ -668,6 +740,8 @@ mod tests {
             "https://93.184.216.34/article",
             "https://[::1]/article",
             "https://[fc00::1]/article",
+            "https://[2002:0a00:0001::1]/article",
+            "https://[64:ff9b::0a00:0001]/article",
         ] {
             let url = Url::parse(raw).expect("url");
             assert_eq!(
@@ -741,6 +815,32 @@ mod tests {
             ..Default::default()
         };
         let url = Url::parse(&format!("{}/huge", server.uri())).expect("url");
+
+        let outcome = resolve_link_preview(&url, &policy).await;
+
+        assert_eq!(outcome.status(), LinkPreviewResolverStatus::Failed);
+    }
+
+    #[tokio::test]
+    async fn oversized_content_length_returns_failed_before_streaming() {
+        let server = MockServer::start().await;
+        let body = "x".repeat(65);
+        Mock::given(method("GET"))
+            .and(path("/huge-header"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/html")
+                    .insert_header("content-length", body.len().to_string())
+                    .set_body_raw(body, "text/html"),
+            )
+            .mount(&server)
+            .await;
+        let policy = LinkPreviewResolverPolicy {
+            max_bytes: 64,
+            allow_http_loopback_for_tests: true,
+            ..Default::default()
+        };
+        let url = Url::parse(&format!("{}/huge-header", server.uri())).expect("url");
 
         let outcome = resolve_link_preview(&url, &policy).await;
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
@@ -1,0 +1,662 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::time::Duration;
+
+use reqwest::header::{CONTENT_TYPE, LOCATION};
+use reqwest::{redirect, Client, StatusCode};
+use url::{Host, Url};
+
+const DEFAULT_MAX_BYTES: usize = 256 * 1024;
+const DEFAULT_MAX_REDIRECTS: usize = 3;
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(3);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ResolvedLinkMetadata {
+    pub original_url: Url,
+    pub normalized_url: Url,
+    pub title: Option<String>,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct LinkPreviewResolverPolicy {
+    pub max_bytes: usize,
+    pub max_redirects: usize,
+    pub timeout: Duration,
+    pub allow_http_loopback_for_tests: bool,
+}
+
+impl Default for LinkPreviewResolverPolicy {
+    fn default() -> Self {
+        Self {
+            max_bytes: DEFAULT_MAX_BYTES,
+            max_redirects: DEFAULT_MAX_REDIRECTS,
+            timeout: DEFAULT_TIMEOUT,
+            allow_http_loopback_for_tests: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum LinkPreviewResolverStatus {
+    Ready,
+    Blocked,
+    Failed,
+    Unsupported,
+}
+
+impl LinkPreviewResolverStatus {
+    pub(super) fn as_lookup_status(self) -> &'static str {
+        match self {
+            LinkPreviewResolverStatus::Ready => "ready",
+            LinkPreviewResolverStatus::Blocked => "blocked",
+            LinkPreviewResolverStatus::Failed => "failed",
+            LinkPreviewResolverStatus::Unsupported => "unsupported",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum LinkPreviewResolverOutcome {
+    Ready(Box<ResolvedLinkMetadata>),
+    Blocked,
+    Failed,
+    Unsupported,
+}
+
+impl LinkPreviewResolverOutcome {
+    pub(super) fn status(&self) -> LinkPreviewResolverStatus {
+        match self {
+            LinkPreviewResolverOutcome::Ready(_) => LinkPreviewResolverStatus::Ready,
+            LinkPreviewResolverOutcome::Blocked => LinkPreviewResolverStatus::Blocked,
+            LinkPreviewResolverOutcome::Failed => LinkPreviewResolverStatus::Failed,
+            LinkPreviewResolverOutcome::Unsupported => LinkPreviewResolverStatus::Unsupported,
+        }
+    }
+}
+
+pub(super) async fn resolve_link_preview(
+    url: &Url,
+    policy: &LinkPreviewResolverPolicy,
+) -> LinkPreviewResolverOutcome {
+    let mut current = url.clone();
+    for redirect_count in 0..=policy.max_redirects {
+        let fetch = match fetch_html_once(&current, policy).await {
+            Ok(fetch) => fetch,
+            Err(status) => return status.into(),
+        };
+        match fetch {
+            FetchOnceResult::Html { final_url, html } => {
+                return extract_metadata_from_html(url, &html)
+                    .map(|mut metadata| {
+                        metadata.normalized_url = final_url;
+                        LinkPreviewResolverOutcome::Ready(Box::new(metadata))
+                    })
+                    .unwrap_or(LinkPreviewResolverOutcome::Unsupported);
+            }
+            FetchOnceResult::Redirect(next) => {
+                if redirect_count == policy.max_redirects {
+                    return LinkPreviewResolverOutcome::Failed;
+                }
+                current = next;
+            }
+        }
+    }
+    LinkPreviewResolverOutcome::Failed
+}
+
+impl From<LinkPreviewResolverStatus> for LinkPreviewResolverOutcome {
+    fn from(status: LinkPreviewResolverStatus) -> Self {
+        match status {
+            LinkPreviewResolverStatus::Ready => LinkPreviewResolverOutcome::Failed,
+            LinkPreviewResolverStatus::Blocked => LinkPreviewResolverOutcome::Blocked,
+            LinkPreviewResolverStatus::Failed => LinkPreviewResolverOutcome::Failed,
+            LinkPreviewResolverStatus::Unsupported => LinkPreviewResolverOutcome::Unsupported,
+        }
+    }
+}
+
+enum FetchOnceResult {
+    Html { final_url: Url, html: String },
+    Redirect(Url),
+}
+
+async fn fetch_html_once(
+    url: &Url,
+    policy: &LinkPreviewResolverPolicy,
+) -> Result<FetchOnceResult, LinkPreviewResolverStatus> {
+    let target = prepare_target(url, policy).await?;
+    let mut builder = Client::builder()
+        .timeout(policy.timeout)
+        .connect_timeout(policy.timeout)
+        .redirect(redirect::Policy::none())
+        .https_only(!policy.allow_http_loopback_for_tests);
+    if let Host::Domain(host) = target.host {
+        builder = builder.resolve_to_addrs(host, &target.addrs);
+    }
+    let client = builder
+        .build()
+        .map_err(|_| LinkPreviewResolverStatus::Failed)?;
+    let mut response = client
+        .get(url.clone())
+        .send()
+        .await
+        .map_err(|_| LinkPreviewResolverStatus::Failed)?;
+
+    if response.status().is_redirection() {
+        let Some(location) = response
+            .headers()
+            .get(LOCATION)
+            .and_then(|value| value.to_str().ok())
+        else {
+            return Err(LinkPreviewResolverStatus::Failed);
+        };
+        let next = url
+            .join(location)
+            .map_err(|_| LinkPreviewResolverStatus::Failed)?;
+        let status = classify_url_with_policy(&next, policy);
+        if status != LinkPreviewResolverStatus::Ready {
+            return Err(status);
+        }
+        return Ok(FetchOnceResult::Redirect(next));
+    }
+
+    if response.status() == StatusCode::NOT_FOUND {
+        return Err(LinkPreviewResolverStatus::Unsupported);
+    }
+    if !response.status().is_success() {
+        return Err(LinkPreviewResolverStatus::Failed);
+    }
+    let content_type = response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(|value| {
+            value
+                .split(';')
+                .next()
+                .unwrap_or(value)
+                .trim()
+                .to_ascii_lowercase()
+        });
+    if !matches!(
+        content_type.as_deref(),
+        Some("text/html") | Some("application/xhtml+xml")
+    ) {
+        return Err(LinkPreviewResolverStatus::Unsupported);
+    }
+    if let Some(len) = response.content_length() {
+        if len as usize > policy.max_bytes {
+            return Err(LinkPreviewResolverStatus::Failed);
+        }
+    }
+
+    let mut body = Vec::with_capacity(policy.max_bytes.min(64 * 1024));
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|_| LinkPreviewResolverStatus::Failed)?
+    {
+        if body.len() + chunk.len() > policy.max_bytes {
+            return Err(LinkPreviewResolverStatus::Failed);
+        }
+        body.extend_from_slice(&chunk);
+    }
+    let html = String::from_utf8_lossy(&body).into_owned();
+    Ok(FetchOnceResult::Html {
+        final_url: url.clone(),
+        html,
+    })
+}
+
+struct PreparedTarget<'a> {
+    host: Host<&'a str>,
+    addrs: Vec<SocketAddr>,
+}
+
+async fn prepare_target<'a>(
+    url: &'a Url,
+    policy: &LinkPreviewResolverPolicy,
+) -> Result<PreparedTarget<'a>, LinkPreviewResolverStatus> {
+    let status = classify_url_with_policy(url, policy);
+    if status != LinkPreviewResolverStatus::Ready {
+        return Err(status);
+    }
+    let host = url.host().ok_or(LinkPreviewResolverStatus::Unsupported)?;
+    let port = url.port_or_known_default().unwrap_or(443);
+    let addrs = match host {
+        Host::Ipv4(ip) => vec![SocketAddr::new(IpAddr::V4(ip), port)],
+        Host::Ipv6(ip) => vec![SocketAddr::new(IpAddr::V6(ip), port)],
+        Host::Domain(name) => {
+            let ips = tokio::net::lookup_host((name, port))
+                .await
+                .map_err(|_| LinkPreviewResolverStatus::Failed)?
+                .map(|addr| addr.ip())
+                .collect::<Vec<_>>();
+            if ips.is_empty() {
+                return Err(LinkPreviewResolverStatus::Failed);
+            }
+            let test_loopback = policy.allow_http_loopback_for_tests
+                && url.scheme() == "http"
+                && ips.iter().all(|ip| ip.is_loopback());
+            if !test_loopback && ips.iter().any(|ip| !is_global_ip(*ip)) {
+                return Err(LinkPreviewResolverStatus::Blocked);
+            }
+            ips.into_iter()
+                .map(|ip| SocketAddr::new(ip, port))
+                .collect()
+        }
+    };
+    Ok(PreparedTarget { host, addrs })
+}
+
+fn classify_url_with_policy(
+    url: &Url,
+    policy: &LinkPreviewResolverPolicy,
+) -> LinkPreviewResolverStatus {
+    if url.scheme() != "https" {
+        if policy.allow_http_loopback_for_tests
+            && url.scheme() == "http"
+            && url.host().is_some_and(host_is_loopback)
+        {
+            return LinkPreviewResolverStatus::Ready;
+        }
+        return LinkPreviewResolverStatus::Unsupported;
+    }
+    if matches!(url.host(), Some(Host::Ipv4(_)) | Some(Host::Ipv6(_))) {
+        return LinkPreviewResolverStatus::Blocked;
+    }
+    if let Some(Host::Domain(host)) = url.host() {
+        if host.trim_end_matches('.').ends_with(".local") {
+            return LinkPreviewResolverStatus::Blocked;
+        }
+    }
+    LinkPreviewResolverStatus::Ready
+}
+
+fn host_is_loopback(host: Host<&str>) -> bool {
+    match host {
+        Host::Ipv4(ip) => ip.is_loopback(),
+        Host::Ipv6(ip) => ip.is_loopback(),
+        Host::Domain(host) => host.eq_ignore_ascii_case("localhost"),
+    }
+}
+
+fn is_global_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => is_global_ipv4(ip),
+        IpAddr::V6(ip) => is_global_ipv6(ip),
+    }
+}
+
+fn is_global_ipv4(ip: Ipv4Addr) -> bool {
+    if ip.is_loopback()
+        || ip.is_private()
+        || ip.is_link_local()
+        || ip.is_broadcast()
+        || ip.is_documentation()
+        || ip.is_unspecified()
+        || ip.is_multicast()
+    {
+        return false;
+    }
+    let octets = ip.octets();
+    if octets[0] == 0 {
+        return false;
+    }
+    if octets[0] == 100 && (octets[1] & 0xc0) == 0x40 {
+        return false;
+    }
+    if octets[0] == 198 && (octets[1] & 0xfe) == 18 {
+        return false;
+    }
+    if octets[0] >= 240 {
+        return false;
+    }
+    true
+}
+
+fn is_global_ipv6(ip: Ipv6Addr) -> bool {
+    if ip.is_loopback()
+        || ip.is_unspecified()
+        || ip.is_unique_local()
+        || ip.is_unicast_link_local()
+        || ip.is_multicast()
+    {
+        return false;
+    }
+    if let Some(v4) = ip.to_ipv4() {
+        return is_global_ipv4(v4);
+    }
+    let segs = ip.segments();
+    if (segs[0] & 0xffc0) == 0xfec0 {
+        return false;
+    }
+    if segs[0] == 0x2001 && segs[1] == 0x0db8 {
+        return false;
+    }
+    if segs[0] == 0x0100 && segs[1] == 0 && segs[2] == 0 && segs[3] == 0 {
+        return false;
+    }
+    true
+}
+
+pub(super) fn extract_metadata_from_html(
+    requested_url: &Url,
+    html: &str,
+) -> Option<ResolvedLinkMetadata> {
+    let title = meta_content(html, "og:title");
+    let description = meta_content(html, "og:description");
+    let normalized_url = meta_content(html, "og:url")
+        .and_then(|url| Url::parse(&url).ok())
+        .unwrap_or_else(|| requested_url.clone());
+    if title.is_none() && description.is_none() && normalized_url == *requested_url {
+        return None;
+    }
+
+    Some(ResolvedLinkMetadata {
+        original_url: requested_url.clone(),
+        normalized_url,
+        title,
+        description,
+    })
+}
+
+fn meta_content(html: &str, property: &str) -> Option<String> {
+    let mut remaining = html;
+    while let Some(start) = find_ascii_case_insensitive(remaining, "<meta") {
+        remaining = &remaining[start + "<meta".len()..];
+        let end = remaining.find('>')?;
+        let tag = &remaining[..end];
+        remaining = &remaining[end + 1..];
+
+        let attrs = parse_tag_attrs(tag);
+        let name_matches = attrs.iter().any(|(name, value)| {
+            (name.eq_ignore_ascii_case("property") || name.eq_ignore_ascii_case("name"))
+                && value.eq_ignore_ascii_case(property)
+        });
+        if !name_matches {
+            continue;
+        }
+        if let Some((_, content)) = attrs
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case("content"))
+        {
+            let content = html_escape::decode_html_entities(content)
+                .trim()
+                .to_string();
+            if !content.is_empty() {
+                return Some(content);
+            }
+        }
+    }
+    None
+}
+
+fn parse_tag_attrs(tag: &str) -> Vec<(String, String)> {
+    let mut attrs = Vec::new();
+    let bytes = tag.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        let name_start = i;
+        while i < bytes.len()
+            && (bytes[i].is_ascii_alphanumeric() || matches!(bytes[i], b':' | b'_' | b'-'))
+        {
+            i += 1;
+        }
+        if i == name_start {
+            i += 1;
+            continue;
+        }
+        let name = &tag[name_start..i];
+        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        if i >= bytes.len() || bytes[i] != b'=' {
+            continue;
+        }
+        i += 1;
+        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        if i >= bytes.len() {
+            break;
+        }
+        let value = if bytes[i] == b'"' || bytes[i] == b'\'' {
+            let quote = bytes[i];
+            i += 1;
+            let value_start = i;
+            while i < bytes.len() && bytes[i] != quote {
+                i += 1;
+            }
+            let value = &tag[value_start..i];
+            if i < bytes.len() {
+                i += 1;
+            }
+            value
+        } else {
+            let value_start = i;
+            while i < bytes.len() && !bytes[i].is_ascii_whitespace() {
+                i += 1;
+            }
+            &tag[value_start..i]
+        };
+        attrs.push((name.to_string(), value.to_string()));
+    }
+    attrs
+}
+
+fn find_ascii_case_insensitive(haystack: &str, needle: &str) -> Option<usize> {
+    haystack
+        .as_bytes()
+        .windows(needle.len())
+        .position(|window| window.eq_ignore_ascii_case(needle.as_bytes()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn extracts_opengraph_text_metadata_from_html_without_executing_embeds() {
+        let requested_url =
+            Url::parse("https://Example.COM:443/articles?id=42&utm=keep").expect("url");
+        let html = r#"
+            <!doctype html>
+            <html>
+              <head>
+                <title>Fallback title</title>
+                <meta property="og:title" content="The Best Webpage">
+                <meta property="og:description" content="Plain text preview">
+                <meta property="og:url" content="https://example.com/articles?id=42&utm=keep">
+                <script>throw new Error("must not execute")</script>
+                <iframe src="https://embed.example/"></iframe>
+              </head>
+            </html>
+        "#;
+
+        let metadata = extract_metadata_from_html(&requested_url, html).expect("metadata");
+
+        assert_eq!(
+            metadata.original_url.as_str(),
+            "https://example.com/articles?id=42&utm=keep"
+        );
+        assert_eq!(
+            metadata.normalized_url.as_str(),
+            "https://example.com/articles?id=42&utm=keep"
+        );
+        assert_eq!(metadata.title.as_deref(), Some("The Best Webpage"));
+        assert_eq!(metadata.description.as_deref(), Some("Plain text preview"));
+    }
+
+    #[test]
+    fn html_without_usable_metadata_is_unsupported() {
+        let requested_url = Url::parse("https://example.com/articles").expect("url");
+
+        assert!(extract_metadata_from_html(&requested_url, "<html><head></head></html>").is_none());
+    }
+
+    #[test]
+    fn classifies_non_https_urls_as_unsupported_normal_outcomes() {
+        let url = Url::parse("http://example.com/article").expect("url");
+
+        assert_eq!(
+            classify_url_with_policy(&url, &LinkPreviewResolverPolicy::default()),
+            LinkPreviewResolverStatus::Unsupported
+        );
+    }
+
+    #[test]
+    fn blocks_ip_literal_targets_by_default() {
+        for raw in [
+            "https://127.0.0.1/article",
+            "https://10.0.0.1/article",
+            "https://169.254.169.254/latest/meta-data/",
+            "https://224.0.0.1/article",
+            "https://93.184.216.34/article",
+            "https://[::1]/article",
+            "https://[fc00::1]/article",
+        ] {
+            let url = Url::parse(raw).expect("url");
+            assert_eq!(
+                classify_url_with_policy(&url, &LinkPreviewResolverPolicy::default()),
+                LinkPreviewResolverStatus::Blocked,
+                "{raw}"
+            );
+        }
+    }
+
+    #[test]
+    fn blocks_dot_local_domains_before_fetch() {
+        let url = Url::parse("https://printer.local/article").expect("url");
+
+        assert_eq!(
+            classify_url_with_policy(&url, &LinkPreviewResolverPolicy::default()),
+            LinkPreviewResolverStatus::Blocked
+        );
+    }
+
+    #[tokio::test]
+    async fn fetches_html_metadata_with_bounded_test_policy() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/article"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                r#"<html><head>
+                          <meta property="og:title" content="Fetched title">
+                          <meta property="og:description" content="Fetched description">
+                          <meta property="og:url" content="http://127.0.0.1/article">
+                        </head></html>"#,
+                "text/html; charset=utf-8",
+            ))
+            .mount(&server)
+            .await;
+        let policy = LinkPreviewResolverPolicy {
+            allow_http_loopback_for_tests: true,
+            ..Default::default()
+        };
+        let url = Url::parse(&format!("{}/article", server.uri())).expect("url");
+
+        let outcome = resolve_link_preview(&url, &policy).await;
+
+        let LinkPreviewResolverOutcome::Ready(metadata) = outcome else {
+            panic!("expected ready outcome, got {outcome:?}");
+        };
+        assert_eq!(metadata.title.as_deref(), Some("Fetched title"));
+        assert_eq!(metadata.description.as_deref(), Some("Fetched description"));
+    }
+
+    #[tokio::test]
+    async fn oversized_html_response_returns_failed_outcome() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/huge"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw("<html>".repeat(64), "text/html"))
+            .mount(&server)
+            .await;
+        let policy = LinkPreviewResolverPolicy {
+            max_bytes: 64,
+            allow_http_loopback_for_tests: true,
+            ..Default::default()
+        };
+        let url = Url::parse(&format!("{}/huge", server.uri())).expect("url");
+
+        let outcome = resolve_link_preview(&url, &policy).await;
+
+        assert_eq!(outcome.status(), LinkPreviewResolverStatus::Failed);
+    }
+
+    #[tokio::test]
+    async fn redirect_into_blocked_target_returns_blocked_without_following() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/redirect"))
+            .respond_with(
+                ResponseTemplate::new(302).insert_header("location", "https://127.0.0.1/admin"),
+            )
+            .mount(&server)
+            .await;
+        let policy = LinkPreviewResolverPolicy {
+            allow_http_loopback_for_tests: true,
+            ..Default::default()
+        };
+        let url = Url::parse(&format!("{}/redirect", server.uri())).expect("url");
+
+        let outcome = resolve_link_preview(&url, &policy).await;
+
+        assert_eq!(outcome.status(), LinkPreviewResolverStatus::Blocked);
+    }
+
+    #[tokio::test]
+    async fn redirect_count_above_policy_cap_returns_failed() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/one"))
+            .respond_with(ResponseTemplate::new(302).insert_header("location", "/two"))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/two"))
+            .respond_with(ResponseTemplate::new(302).insert_header("location", "/three"))
+            .mount(&server)
+            .await;
+        let policy = LinkPreviewResolverPolicy {
+            max_redirects: 1,
+            allow_http_loopback_for_tests: true,
+            ..Default::default()
+        };
+        let url = Url::parse(&format!("{}/one", server.uri())).expect("url");
+
+        let outcome = resolve_link_preview(&url, &policy).await;
+
+        assert_eq!(outcome.status(), LinkPreviewResolverStatus::Failed);
+    }
+
+    #[tokio::test]
+    async fn fetch_duration_above_policy_timeout_returns_failed() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/slow"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_delay(Duration::from_millis(100))
+                    .set_body_raw("<html></html>", "text/html"),
+            )
+            .mount(&server)
+            .await;
+        let policy = LinkPreviewResolverPolicy {
+            timeout: Duration::from_millis(10),
+            allow_http_loopback_for_tests: true,
+            ..Default::default()
+        };
+        let url = Url::parse(&format!("{}/slow", server.uri())).expect("url");
+
+        let outcome = resolve_link_preview(&url, &policy).await;
+
+        assert_eq!(outcome.status(), LinkPreviewResolverStatus::Failed);
+    }
+}

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
@@ -84,6 +84,7 @@ mod extension_forms;
 mod jingle_muji_gate;
 mod last_activity;
 mod link_preview_lookup;
+mod link_preview_resolver;
 mod mentions_permissions;
 mod misc;
 mod muc_admin;

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -190,6 +190,7 @@ mod tests {
         "alice@example.com/desktop".parse().expect("jid")
     }
     use xmpp_parsers::message::Message;
+    use xmpp_parsers::minidom::rxml::xml_ncname;
     use xmpp_parsers::minidom::Element;
 
     #[test]
@@ -293,6 +294,31 @@ mod tests {
         message
             .payloads
             .push(waddle_xmpp::xep::build_link_preview_request_element(&token));
+
+        consume_link_preview_request(&mut message, &sender(), SECRET, 1_800_000_000);
+
+        assert!(message.payloads.is_empty());
+    }
+
+    #[test]
+    fn oversized_link_preview_request_is_stripped_without_metadata() {
+        let mut message = Message::new(None::<jid::Jid>);
+        message.to = Some("room@muc.example.com".parse().expect("jid"));
+        message.bodies.insert(
+            xmpp_parsers::message::Lang::new(),
+            "read https://example.com/".to_string(),
+        );
+        message.payloads.push(
+            Element::builder(
+                waddle_xmpp::xep::ELEMENT_PREVIEW_REQUEST,
+                waddle_xmpp::xep::NS_WADDLE_LINK_PREVIEW,
+            )
+            .attr(
+                xml_ncname!("token").to_owned(),
+                "x".repeat(waddle_xmpp::xep::MAX_LINK_PREVIEW_TOKEN_BYTES + 1),
+            )
+            .build(),
+        );
 
         consume_link_preview_request(&mut message, &sender(), SECRET, 1_800_000_000);
 

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
@@ -100,7 +100,7 @@ async fn link_preview_lookup_for_test(
 }
 
 #[tokio::test]
-async fn link_preview_lookup_dispatch_returns_scoped_text_metadata() {
+async fn link_preview_lookup_dispatch_returns_typed_unsupported_metadata_outcome() {
     let state = create_test_websocket_state().await;
     let session = create_test_session(state.as_ref(), "alice").await;
     let bound_jid: FullJid = "alice@example.com/desktop".parse().expect("jid");
@@ -125,16 +125,12 @@ async fn link_preview_lookup_dispatch_returns_scoped_text_metadata() {
         "stamps result addressing from request envelope: {response}"
     );
     assert!(
-        response.contains("status='ready'"),
-        "ready lookup: {response}"
+        response.contains("status='unsupported'") || response.contains("status='failed'"),
+        "normal resolver miss/failure is typed in the lookup result: {response}"
     );
     assert!(
-        response.contains("original-url='https://example.com/article'"),
-        "text preview includes original URL: {response}"
-    );
-    assert!(
-        response.contains("token='"),
-        "ready lookup mints scoped token: {response}"
+        !response.contains("type='error'") && !response.contains("token='"),
+        "normal resolver miss/failure is not an IQ transport error and does not mint token: {response}"
     );
 }
 
@@ -173,7 +169,7 @@ async fn link_preview_lookup_for_muc_scope_requires_current_occupant() {
 }
 
 #[tokio::test]
-async fn link_preview_lookup_for_muc_scope_allows_current_occupant_with_room_scoped_token() {
+async fn link_preview_lookup_for_muc_scope_allows_current_occupant_before_resolver_outcome() {
     let state = create_test_websocket_state().await;
     let session = create_test_session(state.as_ref(), "alice").await;
     let bound_jid: FullJid = "alice@example.com/desktop".parse().expect("jid");
@@ -211,21 +207,13 @@ async fn link_preview_lookup_for_muc_scope_allows_current_occupant_with_room_sco
     let lookup = elem
         .get_child("lookup", waddle_xmpp::xep::NS_WADDLE_LINK_PREVIEW)
         .expect("lookup result");
-    assert_eq!(lookup.attr("status"), Some("ready"));
-    let preview = lookup
+    assert!(
+        matches!(lookup.attr("status"), Some("unsupported" | "failed")),
+        "authorized room lookup should reach typed resolver outcome: {response}"
+    );
+    assert!(lookup
         .get_child("preview", waddle_xmpp::xep::NS_WADDLE_LINK_PREVIEW)
-        .expect("preview");
-    let token =
-        waddle_xmpp::xep::LinkPreviewToken::new(preview.attr("token").expect("token").to_string())
-            .expect("token");
-    let decoded = waddle_xmpp::xep::decode_link_preview_token(
-        &token,
-        state.deps.occupant_id_secret.key(),
-        i64::MIN,
-    )
-    .expect("token payload");
-    assert_eq!(decoded.sender_jid.to_string(), "alice@example.com");
-    assert_eq!(decoded.scope_jid, room_jid);
+        .is_none());
 }
 
 /// Build a `<command/>` payload Element addressed at a XEP-0050

--- a/server/crates/waddle-xmpp/src/xep/exports.rs
+++ b/server/crates/waddle-xmpp/src/xep/exports.rs
@@ -422,9 +422,10 @@ pub use super::xep_waddle_forums::{
 
 pub use super::xep_waddle_link_preview::{
     build_link_preview_request_element, decode_link_preview_token, encode_link_preview_token,
-    extract_link_preview_request_from_message, is_link_preview_request_element,
-    parse_link_preview_request_element, strip_link_preview_requests, LinkPreviewToken,
-    LinkPreviewTokenData, WaddleLinkPreviewError, ELEMENT_PREVIEW_REQUEST, NS_WADDLE_LINK_PREVIEW,
+    encode_link_preview_token_checked, extract_link_preview_request_from_message,
+    is_link_preview_request_element, parse_link_preview_request_element,
+    strip_link_preview_requests, LinkPreviewToken, LinkPreviewTokenData, WaddleLinkPreviewError,
+    ELEMENT_PREVIEW_REQUEST, MAX_LINK_PREVIEW_TOKEN_BYTES, NS_WADDLE_LINK_PREVIEW,
 };
 
 pub use super::xep0503::{

--- a/server/crates/waddle-xmpp/src/xep/xep_waddle_link_preview.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep_waddle_link_preview.rs
@@ -32,7 +32,8 @@ impl LinkPreviewToken {
     /// Wrap an already encoded token.
     pub fn new(token: impl Into<String>) -> Option<Self> {
         let token = token.into();
-        (!token.trim().is_empty()).then_some(Self(token))
+        (!token.trim().is_empty() && token.len() <= MAX_LINK_PREVIEW_TOKEN_BYTES)
+            .then_some(Self(token))
     }
 
     /// Borrow the encoded token text.
@@ -160,6 +161,9 @@ pub fn decode_link_preview_token(
     secret: &[u8],
     now_unix: i64,
 ) -> Result<LinkPreviewTokenData, WaddleLinkPreviewError> {
+    if token.as_str().len() > MAX_LINK_PREVIEW_TOKEN_BYTES {
+        return Err(WaddleLinkPreviewError::InvalidTokenEncoding);
+    }
     let (payload, signature) = token
         .as_str()
         .split_once('.')
@@ -289,5 +293,17 @@ mod tests {
         };
 
         assert!(encode_link_preview_token_checked(&data, SECRET).is_none());
+    }
+
+    #[test]
+    fn oversized_tokens_are_rejected_before_decode_work() {
+        assert!(LinkPreviewToken::new("x".repeat(MAX_LINK_PREVIEW_TOKEN_BYTES + 1)).is_none());
+
+        let token = LinkPreviewToken("x".repeat(MAX_LINK_PREVIEW_TOKEN_BYTES + 1));
+
+        assert_eq!(
+            decode_link_preview_token(&token, SECRET, 1_800_000_000),
+            Err(WaddleLinkPreviewError::InvalidTokenEncoding)
+        );
     }
 }

--- a/server/crates/waddle-xmpp/src/xep/xep_waddle_link_preview.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep_waddle_link_preview.rs
@@ -16,6 +16,8 @@ use xmpp_parsers::message::Message;
 
 /// Waddle-private link preview namespace.
 pub const NS_WADDLE_LINK_PREVIEW: &str = "urn:waddle:link-preview:0";
+/// Maximum encoded preview token size accepted for composer lookup responses.
+pub const MAX_LINK_PREVIEW_TOKEN_BYTES: usize = 4096;
 
 /// Root element for a send-time preview token request.
 pub const ELEMENT_PREVIEW_REQUEST: &str = "preview-request";
@@ -143,6 +145,15 @@ pub fn encode_link_preview_token(data: &LinkPreviewTokenData, secret: &[u8]) -> 
     ))
 }
 
+/// Encode preview data only when the resulting token remains bounded.
+pub fn encode_link_preview_token_checked(
+    data: &LinkPreviewTokenData,
+    secret: &[u8],
+) -> Option<LinkPreviewToken> {
+    let token = encode_link_preview_token(data, secret);
+    (token.as_str().len() <= MAX_LINK_PREVIEW_TOKEN_BYTES).then_some(token)
+}
+
 /// Decode and validate an opaque preview token.
 pub fn decode_link_preview_token(
     token: &LinkPreviewToken,
@@ -263,5 +274,20 @@ mod tests {
             decode_link_preview_token(&token, SECRET, 11),
             Err(WaddleLinkPreviewError::Expired)
         );
+    }
+
+    #[test]
+    fn checked_token_encoding_rejects_oversized_tokens() {
+        let data = LinkPreviewTokenData {
+            sender_jid: "alice@example.com".parse().expect("jid"),
+            scope_jid: "room@muc.example.com".parse().expect("jid"),
+            original_url: Url::parse("https://example.com/").expect("url"),
+            normalized_url: Url::parse("https://example.com/").expect("url"),
+            title: Some("t".repeat(MAX_LINK_PREVIEW_TOKEN_BYTES)),
+            description: Some("d".repeat(MAX_LINK_PREVIEW_TOKEN_BYTES)),
+            expires_at_unix: 1_900_000_000,
+        };
+
+        assert!(encode_link_preview_token_checked(&data, SECRET).is_none());
     }
 }


### PR DESCRIPTION
Closes #825.

## Summary

- Adds a bounded server-side link preview resolver for composer lookups.
- Enforces HTTPS-only production fetches, blocks IP literals, private/loopback/link-local/multicast/transition destinations, `.local` hosts case-insensitively, and redirects into blocked targets.
- Pins validated DNS results into reqwest with `resolve_to_addrs`, so the fetch dials only addresses that passed SSRF checks.
- Applies a 1.5s wall-clock resolver deadline across redirect hops, keeping server work below the chat client's 2s IQ timeout.
- Caps redirects, response bytes, decoded OpenGraph text metadata, and encoded preview token size.
- Rejects oversized preview tokens at lookup parsing, `<preview-request/>` parsing, and token decoding boundaries.
- Preserves safe same-host `og:url` canonical URLs, falls back to the fetched URL when canonical metadata is absent, and ignores blocked or cross-host canonical targets.
- Keeps malformed `<meta` tags from aborting later metadata extraction, ignores non-`meta` tags with `meta` prefixes, and handles `>` inside quoted meta attribute values.
- Returns typed normal lookup statuses (`ready`, `blocked`, `failed`, `unsupported`) instead of IQ transport errors for resolver outcomes.
- Updates the chat parser/composer so `blocked` and `unsupported` are unsupported fail-open metadata misses, while `failed` remains failed; legacy `not_found` parsing was removed.

## TDD Plan Completed

1. Added resolver metadata extraction tests for OpenGraph fields and no-JS/no-embed execution assumptions.
2. Added policy tests for non-HTTPS, IP literals, mixed-case `.local`, IPv6 transition addresses, blocked redirects, redirect caps, oversized responses, and timeout failures.
3. Added defensive-size tests for decoded text truncation, UTF-8 boundary preservation, oversized token mint rejection, inbound token rejection, and oversized lookup response rejection.
4. Added malformed-meta, quoted-attribute, exact-tag-name, and canonical-url tests for recovering later metadata, preserving safe same-host `og:url`, and ignoring blocked/cross-host canonical targets.
5. Wired the resolver into the IQ lookup path and covered ready plus unsupported/blocked/failed outcomes.
6. Updated chat lookup parsing and composer projection tests for typed normal resolver statuses.

## XEP Review

Reviewed `xeps/xep-0511.xml`. This keeps the private Waddle lookup/token namespace separate from official XEP wire semantics, and the send-time stamped metadata remains RDF/OpenGraph-shaped for XEP-0511 compatibility.

## Verification

- `cargo fmt --check`
- `cargo test -p waddle-server --lib link_preview -- --nocapture`
- `cargo test -p waddle-xmpp xep_waddle_link_preview -- --nocapture`
- `cargo clippy -p waddle-server --lib -- -D warnings`
- `bun test tests/link-preview.test.ts tests/link-preview-composer.test.ts`
- `bun run lint`
- `git diff --check`

Known unrelated verification gap:

- `bunx vue-tsc --noEmit -p . --ignoreDeprecations 6.0` still fails in existing Vue component type errors outside this change set, including `AdminView.vue`, call/chat component readonly array/ref typing, and existing `ContentArea.vue` / `ThreadPanel.vue` nullability errors.

## Remaining Risks

- Metadata extraction is deliberately limited to HTML `<meta property/name="og:*" content="...">` fields; it is not a browser parser.
- v1 keeps tracking parameters by design per the issue acceptance criteria unless a page provides a safe same-host canonical `og:url`.
- No image/video preview media fetching is added in this slice.