### PR TITLE
feat(chat): cache link preview images

### DIFF
--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -14,6 +14,7 @@ import {
 import { $xmppStatus } from "@/stores/xmpp-status";
 import { applyPinEvent } from "@/stores/pinned-messages";
 import { hydrateSinglePinnedBody } from "@/services/pinned-message-bodies";
+import { linkPreviewMediaOriginFromWebSocketUrl } from "@/lib/xmpp/link-preview";
 import { roomMessageFromArchived } from "@/lib/xmpp/wasm-message-codecs";
 import {
   type TimelineMessage,
@@ -267,7 +268,11 @@ export function useChannelMessages(
             const spaceId = activeSpaceId.value ?? "";
             const channelId = activeChannelId.value ?? "";
             const convertForTimeline = (a: Parameters<typeof roomMessageFromArchived>[0]) => {
-              const live = roomMessageFromArchived(a);
+              const live = roomMessageFromArchived(a, {
+                trustedMediaOrigin: session.value
+                  ? linkPreviewMediaOriginFromWebSocketUrl(session.value.xmpp_websocket_url)
+                  : null,
+              });
               return live && session.value
                 ? mapLiveRoomMessageToTimeline(session.value, live)
                 : null;

--- a/chat/src/components/chat/MessageBody.vue
+++ b/chat/src/components/chat/MessageBody.vue
@@ -226,6 +226,16 @@ watch(
         <ExternalLink aria-hidden="true" class="h-3.5 w-3.5" />
         {{ linkPreviewHost(preview.originalUrl) }}
       </span>
+      <img
+        v-if="preview.image"
+        :src="preview.image.url"
+        :alt="preview.image.alt ?? preview.title ?? 'Link preview image'"
+        :width="preview.image.width"
+        :height="preview.image.height"
+        loading="lazy"
+        decoding="async"
+        class="max-h-48 w-full rounded border border-border object-cover"
+      />
       <span v-if="preview.title" class="type-field text-foreground">{{ preview.title }}</span>
       <span v-if="preview.description" class="type-caption line-clamp-2 text-muted-foreground">{{ preview.description }}</span>
     </a>

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -46,6 +46,15 @@ export interface LinkPreview {
   normalizedUrl?: string;
   title?: string;
   description?: string;
+  image?: LinkPreviewImage;
+}
+
+export interface LinkPreviewImage {
+  url: string;
+  mediaType: string;
+  width?: number;
+  height?: number;
+  alt?: string;
 }
 
 export type ExtensionSurfaceKind =

--- a/chat/src/lib/link-preview-composer.ts
+++ b/chat/src/lib/link-preview-composer.ts
@@ -29,6 +29,7 @@ export function linkPreviewPayloadFromLookup(
       normalizedUrl: result.normalizedUrl,
       ...(result.title ? { title: result.title } : {}),
       ...(result.description ? { description: result.description } : {}),
+      ...(result.image ? { image: result.image } : {}),
     },
   };
 }

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -112,7 +112,7 @@ import {
   type SendDirectMessageOptions,
   type SendGroupMessageOptions,
 } from "./send-types";
-import { requestPlaintextLinkPreviewLookup, type LinkPreviewLookupResult } from "./link-preview";
+import { linkPreviewMediaOriginFromWebSocketUrl, requestPlaintextLinkPreviewLookup, type LinkPreviewLookupResult } from "./link-preview";
 import {
   avatarDataUrl,
   buildWasmSendOptions,
@@ -1441,7 +1441,12 @@ export class BrowserXmppClient {
   }
 
   async lookupLinkPreview(body: string, scopeJid: string): Promise<LinkPreviewLookupResult | null> {
-    return requestPlaintextLinkPreviewLookup(this.xmpp, body, scopeJid);
+    return requestPlaintextLinkPreviewLookup(
+      this.xmpp,
+      body,
+      scopeJid,
+      linkPreviewMediaOriginFromWebSocketUrl(this.session.xmpp_websocket_url),
+    );
   }
 
   async sendDirectMessage(peerJid: string, body: string, opts: SendDirectMessageOptions = {}): Promise<OutboundSendResult | null> {
@@ -2255,7 +2260,7 @@ export class BrowserXmppClient {
   }
 
   private roomMamPageToMessages(page: WasmMamPage): MamHistoryPage<LiveRoomMessage> {
-    return { messages: page.messages.map((message) => roomMessageFromArchived(message)).filter((message): message is LiveRoomMessage => !!message), ...(page.first_id ? { firstArchiveId: page.first_id } : {}), ...(page.last_id ? { lastArchiveId: page.last_id } : {}), complete: page.is_complete };
+    return { messages: page.messages.map((message) => roomMessageFromArchived(message, { trustedMediaOrigin: linkPreviewMediaOriginFromWebSocketUrl(this.session.xmpp_websocket_url) })).filter((message): message is LiveRoomMessage => !!message), ...(page.first_id ? { firstArchiveId: page.first_id } : {}), ...(page.last_id ? { lastArchiveId: page.last_id } : {}), complete: page.is_complete };
   }
   private dmMamPageToMessages(
     page: WasmMamPage,
@@ -2265,7 +2270,7 @@ export class BrowserXmppClient {
     if (options.applyCallEvents !== false) {
       this.applyDmCallEventsFromMamPage(page, selfBare);
     }
-    return { messages: page.messages.map((message) => dmMessageFromArchived(message, selfBare)).filter((message): message is LiveDmMessage => !!message), ...(page.first_id ? { firstArchiveId: page.first_id } : {}), ...(page.last_id ? { lastArchiveId: page.last_id } : {}), complete: page.is_complete };
+    return { messages: page.messages.map((message) => dmMessageFromArchived(message, selfBare, { trustedMediaOrigin: linkPreviewMediaOriginFromWebSocketUrl(this.session.xmpp_websocket_url) })).filter((message): message is LiveDmMessage => !!message), ...(page.first_id ? { firstArchiveId: page.first_id } : {}), ...(page.last_id ? { lastArchiveId: page.last_id } : {}), complete: page.is_complete };
   }
   private applyDmCallEventsFromMamPage(
     page: WasmMamPage | null | undefined,
@@ -2878,13 +2883,13 @@ export class BrowserXmppClient {
 
   private dispatchLiveBodyMessage(message: WasmMessage & { carbon?: { sent?: boolean; received?: boolean }; inboxPush?: InboxEntry; _fromCarbon?: boolean }) {
     if (message.is_muc) {
-      const converted = roomMessageFromArchived({ ...message, mam_id: message.id ?? crypto.randomUUID() } as WasmArchivedMessage, "live");
+      const converted = roomMessageFromArchived({ ...message, mam_id: message.id ?? crypto.randomUUID() } as WasmArchivedMessage, "live", { trustedMediaOrigin: linkPreviewMediaOriginFromWebSocketUrl(this.session.xmpp_websocket_url) });
       if (!converted) return;
       this.catchup.recordRoomSeen(converted.roomJid, converted.createdAt, undefined, rawMessageSeenIds(message));
       if (converted.roomJid !== this.currentRoom && isRoomActivityMessage(converted)) { this.activityHandler?.(roomActivityEventFromMessage(converted)); return; }
       this.messageHandler?.(converted); return;
     }
-    const converted = dmMessageFromArchived({ ...message, mam_id: message.id ?? crypto.randomUUID() } as WasmArchivedMessage, barePeerJid(this.session.jid), "live");
+    const converted = dmMessageFromArchived({ ...message, mam_id: message.id ?? crypto.randomUUID() } as WasmArchivedMessage, barePeerJid(this.session.jid), "live", { trustedMediaOrigin: linkPreviewMediaOriginFromWebSocketUrl(this.session.xmpp_websocket_url) });
     if (converted) {
       this.catchup.recordDmSeen(converted.peerJid, converted.createdAt, undefined, rawMessageSeenIds(message));
       this.directMessageHandler?.(converted);
@@ -3088,7 +3093,7 @@ export class BrowserXmppClient {
       this.applyDmCallEventsFromMamPage(page, selfBare, { since, seenIds });
     }
     for (const message of page?.messages ?? []) {
-      const converted = dmMessageFromArchived(message, selfBare);
+      const converted = dmMessageFromArchived(message, selfBare, { trustedMediaOrigin: linkPreviewMediaOriginFromWebSocketUrl(this.session.xmpp_websocket_url) });
       if (!converted || shouldSkipCatchupMessage(converted, since, seenIds)) continue;
       this.catchup.recordDmSeen(converted.peerJid, converted.createdAt, converted.archiveId, messageSeenIds(converted));
       this.directMessageHandler?.(converted);
@@ -3101,7 +3106,7 @@ export class BrowserXmppClient {
     let lastArchiveId = pageLastArchiveId(page);
     if (stats) stats.pages += 1;
     for (const message of page?.messages ?? []) {
-      const converted = roomMessageFromArchived(message);
+      const converted = roomMessageFromArchived(message, { trustedMediaOrigin: linkPreviewMediaOriginFromWebSocketUrl(this.session.xmpp_websocket_url) });
       if (!converted || shouldSkipCatchupMessage(converted, since, seenIds)) continue;
       this.catchup.recordRoomSeen(converted.roomJid, converted.createdAt, converted.archiveId, messageSeenIds(converted));
       if (converted.roomJid !== this.currentRoom && isRoomActivityMessage(converted)) {

--- a/chat/src/lib/xmpp/link-preview.ts
+++ b/chat/src/lib/xmpp/link-preview.ts
@@ -8,6 +8,15 @@ export interface LinkPreviewLookupReadyResult {
   expiresAt: string;
   title?: string;
   description?: string;
+  image?: LinkPreviewLookupImage;
+}
+
+export interface LinkPreviewLookupImage {
+  url: string;
+  mediaType: string;
+  width?: number;
+  height?: number;
+  alt?: string;
 }
 
 export interface LinkPreviewLookupUnsupportedResult {
@@ -43,6 +52,7 @@ export async function requestPlaintextLinkPreviewLookup(
   client: LinkPreviewIqClient | null | undefined,
   body: string,
   scopeJid: string,
+  trustedMediaOrigin?: string | null,
 ): Promise<LinkPreviewLookupResult | null> {
   const originalUrl = firstEligibleHttpsUrl(body);
   const trimmedScopeJid = scopeJid.trim();
@@ -60,10 +70,10 @@ export async function requestPlaintextLinkPreviewLookup(
   } catch {
     return null;
   }
-  return parseLookupResponse(response, originalUrl);
+  return parseLookupResponse(response, originalUrl, trustedMediaOrigin);
 }
 
-function parseLookupResponse(xml: string, requestedUrl: string): LinkPreviewLookupResult | null {
+function parseLookupResponse(xml: string, requestedUrl: string, trustedMediaOrigin?: string | null): LinkPreviewLookupResult | null {
   const doc = new DOMParser().parseFromString(xml, "text/xml");
   const lookup = doc.getElementsByTagNameNS(NS_WADDLE_LINK_PREVIEW, "lookup")[0];
   if (!lookup) return null;
@@ -92,6 +102,7 @@ function parseLookupResponse(xml: string, requestedUrl: string): LinkPreviewLook
     expiresAt,
     ...childText(preview, "title"),
     ...childText(preview, "description"),
+    ...previewImage(preview, trustedMediaOrigin),
   };
 }
 
@@ -180,4 +191,79 @@ function childText(parent: Element, name: "title" | "description"): Partial<Link
     ?.textContent
     ?.trim();
   return value ? { [name]: value } : {};
+}
+
+function previewImage(parent: Element, trustedMediaOrigin?: string | null): Partial<LinkPreviewLookupReadyResult> {
+  const image = Array.from(parent.children).find(
+    (child) => child.localName === "image" && child.namespaceURI === NS_WADDLE_LINK_PREVIEW,
+  );
+  if (!image) return {};
+  const url = image.getAttribute("url")?.trim();
+  const mediaType = image.getAttribute("media-type")?.trim();
+  if (!url || !mediaType || !isTrustedCachedPreviewImageUrl(url, trustedMediaOrigin) || !safePreviewImageMediaType(mediaType)) {
+    return {};
+  }
+  const width = optionalPositiveInteger(image.getAttribute("width"));
+  const height = optionalPositiveInteger(image.getAttribute("height"));
+  const alt = image.getAttribute("alt")?.trim();
+  return {
+    image: {
+      url,
+      mediaType: mediaType.toLowerCase(),
+      ...(width ? { width } : {}),
+      ...(height ? { height } : {}),
+      ...(alt ? { alt } : {}),
+    },
+  };
+}
+
+export function linkPreviewMediaOriginFromWebSocketUrl(websocketUrl: string): string | null {
+  try {
+    const url = new URL(websocketUrl);
+    if (url.protocol === "wss:") {
+      url.protocol = "https:";
+    } else if (url.protocol === "ws:") {
+      url.protocol = "http:";
+    } else {
+      return null;
+    }
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+export function isTrustedCachedPreviewImageUrl(value: string, trustedMediaOrigin?: string | null): boolean {
+  if (!trustedMediaOrigin) return false;
+  try {
+    const url = new URL(value);
+    const trusted = new URL(trustedMediaOrigin);
+    return trustedPreviewProtocolsMatch(url, trusted)
+      && url.origin === trusted.origin
+      && /^\/api\/link-preview-media\/sha256\/[a-f0-9]{64}$/i.test(url.pathname);
+  } catch {
+    return false;
+  }
+}
+
+function trustedPreviewProtocolsMatch(url: URL, trusted: URL): boolean {
+  if (url.protocol === "https:" && trusted.protocol === "https:") return true;
+  return url.protocol === "http:" && trusted.protocol === "http:" && isLoopbackHost(url.hostname);
+}
+
+function isLoopbackHost(hostname: string): boolean {
+  return hostname === "localhost"
+    || hostname === "127.0.0.1"
+    || hostname === "::1"
+    || hostname === "[::1]";
+}
+
+function safePreviewImageMediaType(value: string): boolean {
+  return ["image/png", "image/jpeg", "image/gif", "image/webp"].includes(value.toLowerCase());
+}
+
+function optionalPositiveInteger(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
 }

--- a/chat/src/lib/xmpp/link-preview.ts
+++ b/chat/src/lib/xmpp/link-preview.ts
@@ -240,10 +240,14 @@ export function isTrustedCachedPreviewImageUrl(value: string, trustedMediaOrigin
     const trusted = new URL(trustedMediaOrigin);
     return trustedPreviewProtocolsMatch(url, trusted)
       && url.origin === trusted.origin
-      && /^\/api\/link-preview-media\/sha256\/[a-f0-9]{64}$/i.test(url.pathname);
+      && isLinkPreviewXep0363FilePath(url.pathname);
   } catch {
     return false;
   }
+}
+
+function isLinkPreviewXep0363FilePath(pathname: string): boolean {
+  return /^\/api\/files\/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/link-preview-[a-f0-9]{64}\.(png|jpg|gif|webp)$/i.test(pathname);
 }
 
 function trustedPreviewProtocolsMatch(url: URL, trusted: URL): boolean {

--- a/chat/src/lib/xmpp/link-preview.ts
+++ b/chat/src/lib/xmpp/link-preview.ts
@@ -239,11 +239,19 @@ export function isTrustedCachedPreviewImageUrl(value: string, trustedMediaOrigin
     const url = new URL(value);
     const trusted = new URL(trustedMediaOrigin);
     return trustedPreviewProtocolsMatch(url, trusted)
-      && url.origin === trusted.origin
+      && url.hostname === trusted.hostname
+      && effectivePort(url) === effectivePort(trusted)
       && isLinkPreviewXep0363FilePath(url.pathname);
   } catch {
     return false;
   }
+}
+
+function effectivePort(url: URL): string {
+  if (url.port) return url.port;
+  if (url.protocol === "https:") return "443";
+  if (url.protocol === "http:") return "80";
+  return "";
 }
 
 function isLinkPreviewXep0363FilePath(pathname: string): boolean {

--- a/chat/src/lib/xmpp/wasm-message-codecs.ts
+++ b/chat/src/lib/xmpp/wasm-message-codecs.ts
@@ -5,6 +5,7 @@ import type { RichInlineStyle } from "@/lib/rich-message/types";
 import type { WaddleEncryptedFile } from "./extensions/encrypted-file";
 import { barePeerJid } from "./jid";
 import type { InboxEntry } from "./inbox-types";
+import { isTrustedCachedPreviewImageUrl } from "./link-preview";
 import {
   buildReplyFallbackPrefix,
   shiftMarkupSpans,
@@ -148,12 +149,30 @@ function sharedFileFromWasm(file: WasmSharedFile): SharedFileInfo {
   };
 }
 
-function linkPreviewFromWasm(preview: WasmLinkPreview): LinkPreview {
+interface LinkPreviewDecodeOptions {
+  trustedMediaOrigin?: string | null;
+}
+
+function linkPreviewFromWasm(preview: WasmLinkPreview, options: LinkPreviewDecodeOptions = {}): LinkPreview {
+  const image = preview.image && isTrustedCachedPreviewImageUrl(preview.image.url, options.trustedMediaOrigin)
+    ? preview.image
+    : undefined;
   return {
     originalUrl: preview.original_url,
     ...(preview.normalized_url ? { normalizedUrl: preview.normalized_url } : {}),
     ...(preview.title ? { title: preview.title } : {}),
     ...(preview.description ? { description: preview.description } : {}),
+    ...(image
+      ? {
+          image: {
+            url: image.url,
+            mediaType: image.media_type,
+            ...(typeof image.width === "number" ? { width: image.width } : {}),
+            ...(typeof image.height === "number" ? { height: image.height } : {}),
+            ...(image.alt ? { alt: image.alt } : {}),
+          },
+        }
+      : {}),
   };
 }
 
@@ -325,8 +344,11 @@ function roomAssignedStanzaId(message: WasmArchivedMessage, roomJid: string): st
 
 export function roomMessageFromArchived(
   message: WasmArchivedMessage,
-  source: CodecSource = "archive",
+  sourceOrOptions: CodecSource | LinkPreviewDecodeOptions = "archive",
+  maybeOptions: LinkPreviewDecodeOptions = {},
 ): LiveRoomMessage | null {
+  const source = typeof sourceOrOptions === "string" ? sourceOrOptions : "archive";
+  const decodeOptions = typeof sourceOrOptions === "string" ? maybeOptions : sourceOrOptions;
   const fromJid = message.from ?? "";
   const roomJid = barePeerJid(fromJid || message.to || "");
   const nick = fromJid.split("/")[1] ?? "unknown";
@@ -437,7 +459,7 @@ export function roomMessageFromArchived(
       : {}),
     ...(references.length ? { references: references.map(referenceFromWasm) } : {}),
     ...(sharedFiles.length ? { sharedFiles: sharedFiles.map(sharedFileFromWasm) } : {}),
-    ...(linkPreviews.length ? { linkPreviews: linkPreviews.map(linkPreviewFromWasm) } : {}),
+    ...(linkPreviews.length ? { linkPreviews: linkPreviews.map((preview) => linkPreviewFromWasm(preview, decodeOptions)) } : {}),
     ...(extensionAnnotations.length ? { extensionAnnotations } : {}),
     ...(message.extension_body_fallback && extensionAnnotations.length ? { extensionBodyFallback: true } : {}),
     ...(message.is_sticker ? { isSticker: true } : {}),
@@ -457,8 +479,11 @@ export function roomMessageFromArchived(
 export function dmMessageFromArchived(
   message: WasmArchivedMessage,
   selfBareJid: string,
-  source: CodecSource = "archive",
+  sourceOrOptions: CodecSource | LinkPreviewDecodeOptions = "archive",
+  maybeOptions: LinkPreviewDecodeOptions = {},
 ): LiveDmMessage | null {
+  const source = typeof sourceOrOptions === "string" ? sourceOrOptions : "archive";
+  const decodeOptions = typeof sourceOrOptions === "string" ? maybeOptions : sourceOrOptions;
   const fromBare = barePeerJid(message.from ?? "");
   const toBare = barePeerJid(message.to ?? "");
   const isSelf = fromBare === selfBareJid;
@@ -536,7 +561,7 @@ export function dmMessageFromArchived(
       : {}),
     ...(references.length ? { references: references.map(referenceFromWasm) } : {}),
     ...(sharedFiles.length ? { sharedFiles: sharedFiles.map(sharedFileFromWasm) } : {}),
-    ...(linkPreviews.length ? { linkPreviews: linkPreviews.map(linkPreviewFromWasm) } : {}),
+    ...(linkPreviews.length ? { linkPreviews: linkPreviews.map((preview) => linkPreviewFromWasm(preview, decodeOptions)) } : {}),
     ...(extensionAnnotations.length ? { extensionAnnotations } : {}),
     ...(message.extension_body_fallback && extensionAnnotations.length ? { extensionBodyFallback: true } : {}),
     ...(message.is_sticker ? { isSticker: true } : {}),

--- a/chat/src/lib/xmpp/wasm-types.ts
+++ b/chat/src/lib/xmpp/wasm-types.ts
@@ -150,6 +150,15 @@ export interface WasmLinkPreview {
   normalized_url?: string | null;
   title?: string | null;
   description?: string | null;
+  image?: WasmLinkPreviewImage | null;
+}
+
+export interface WasmLinkPreviewImage {
+  url: string;
+  media_type: string;
+  width?: number | null;
+  height?: number | null;
+  alt?: string | null;
 }
 
 /** Pin/unpin event from a room system message (#414). */

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -30,6 +30,7 @@ import { normalizeMucServiceDomain } from "@/lib/calls/muc-call-indicators";
 import { connectionStore } from "@/lib/connection-store";
 import { resetPinnedRooms } from "@/stores/pinned-messages";
 import { hydratePinnedBodiesOnPanelOpen } from "@/services/pinned-message-bodies";
+import { linkPreviewMediaOriginFromWebSocketUrl } from "@/lib/xmpp/link-preview";
 import { roomMessageFromArchived } from "@/lib/xmpp/wasm-message-codecs";
 import { mapLiveRoomMessageToTimeline } from "@/channels/timeline";
 import { orderTimelineForScrollDirection, type ScrollDirectionMode } from "@/lib/scroll-direction";
@@ -1284,7 +1285,11 @@ export function useChatAppController(giphyApiKey: string) {
     if (!client || !spaceId || !channelId || !roomJid) return;
     if (!("fetchRoomMessagesByStanzaIds" in client)) return;
     const convertForTimeline = (a: Parameters<typeof roomMessageFromArchived>[0]) => {
-      const live = roomMessageFromArchived(a);
+      const live = roomMessageFromArchived(a, {
+        trustedMediaOrigin: session.value
+          ? linkPreviewMediaOriginFromWebSocketUrl(session.value.xmpp_websocket_url)
+          : null,
+      });
       return live && session.value
         ? mapLiveRoomMessageToTimeline(session.value, live)
         : null;

--- a/chat/tests/inbound-references.test.ts
+++ b/chat/tests/inbound-references.test.ts
@@ -148,7 +148,7 @@ describe("roomMessageFromArchived", () => {
         title: "Example Article",
         description: "Plain text summary",
         image: {
-          url: "https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16",
+          url: "https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png",
           media_type: "image/png",
           width: 640,
           height: 360,
@@ -165,7 +165,7 @@ describe("roomMessageFromArchived", () => {
       title: "Example Article",
       description: "Plain text summary",
       image: {
-        url: "https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16",
+        url: "https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png",
         mediaType: "image/png",
         width: 640,
         height: 360,
@@ -495,7 +495,7 @@ describe("dmMessageFromArchived", () => {
         title: "Example Article",
         description: "Plain text summary",
         image: {
-          url: "https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16",
+          url: "https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png",
           media_type: "image/png",
           width: 640,
           height: 360,
@@ -512,7 +512,7 @@ describe("dmMessageFromArchived", () => {
       title: "Example Article",
       description: "Plain text summary",
       image: {
-        url: "https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16",
+        url: "https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png",
         mediaType: "image/png",
         width: 640,
         height: 360,

--- a/chat/tests/inbound-references.test.ts
+++ b/chat/tests/inbound-references.test.ts
@@ -147,8 +147,15 @@ describe("roomMessageFromArchived", () => {
         normalized_url: "https://example.com/article",
         title: "Example Article",
         description: "Plain text summary",
+        image: {
+          url: "https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16",
+          media_type: "image/png",
+          width: 640,
+          height: 360,
+          alt: "Article screenshot",
+        },
       }],
-    });
+    }, { trustedMediaOrigin: "https://waddle.example" });
 
     expect(result).not.toBeNull();
     const timeline = mapLiveRoomMessageToTimeline(session, result!);
@@ -157,6 +164,13 @@ describe("roomMessageFromArchived", () => {
       normalizedUrl: "https://example.com/article",
       title: "Example Article",
       description: "Plain text summary",
+      image: {
+        url: "https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16",
+        mediaType: "image/png",
+        width: 640,
+        height: 360,
+        alt: "Article screenshot",
+      },
     }]);
   });
 
@@ -480,8 +494,15 @@ describe("dmMessageFromArchived", () => {
         normalized_url: "https://example.com/article",
         title: "Example Article",
         description: "Plain text summary",
+        image: {
+          url: "https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16",
+          media_type: "image/png",
+          width: 640,
+          height: 360,
+          alt: "Article screenshot",
+        },
       }],
-    }, "bob@example.com");
+    }, "bob@example.com", { trustedMediaOrigin: "https://waddle.example" });
 
     expect(result).not.toBeNull();
     const timeline = fromLiveDmMessage(session, result!);
@@ -490,6 +511,13 @@ describe("dmMessageFromArchived", () => {
       normalizedUrl: "https://example.com/article",
       title: "Example Article",
       description: "Plain text summary",
+      image: {
+        url: "https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16",
+        mediaType: "image/png",
+        width: 640,
+        height: 360,
+        alt: "Article screenshot",
+      },
     }]);
   });
 

--- a/chat/tests/link-preview-composer.test.ts
+++ b/chat/tests/link-preview-composer.test.ts
@@ -38,6 +38,32 @@ describe("composer link preview state", () => {
     });
   });
 
+  test("projects cached image metadata into the optimistic preview", () => {
+    const payload = linkPreviewPayloadFromLookup({
+      status: "ready",
+      token: "token-1",
+      originalUrl: "https://example.com/a",
+      normalizedUrl: "https://example.com/a",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+      title: "Example",
+      image: {
+        url: "https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16",
+        mediaType: "image/png",
+        width: 640,
+        height: 360,
+        alt: "Article screenshot",
+      },
+    });
+
+    expect(payload?.preview.image).toEqual({
+      url: "https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16",
+      mediaType: "image/png",
+      width: 640,
+      height: 360,
+      alt: "Article screenshot",
+    });
+  });
+
   test("normal unsupported resolver states fail open with no send payload", () => {
     for (const status of ["unsupported", "blocked"] as const) {
       const unsupported = linkPreviewStateFromLookup("https://example.com/a", {

--- a/chat/tests/link-preview-composer.test.ts
+++ b/chat/tests/link-preview-composer.test.ts
@@ -47,7 +47,7 @@ describe("composer link preview state", () => {
       expiresAt: "2999-01-01T00:00:00.000Z",
       title: "Example",
       image: {
-        url: "https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16",
+        url: "https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png",
         mediaType: "image/png",
         width: 640,
         height: 360,
@@ -56,7 +56,7 @@ describe("composer link preview state", () => {
     });
 
     expect(payload?.preview.image).toEqual({
-      url: "https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16",
+      url: "https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png",
       mediaType: "image/png",
       width: 640,
       height: 360,

--- a/chat/tests/link-preview.test.ts
+++ b/chat/tests/link-preview.test.ts
@@ -54,7 +54,7 @@ describe("link preview lookup", () => {
 
   test("accepts cached Waddle preview image metadata from ready lookup responses", async () => {
     const send_raw_iq = async () =>
-      `<iq type="result" id="lookup-1"><lookup xmlns="urn:waddle:link-preview:0" status="ready"><preview token="signed-token" original-url="https://example.com/a" normalized-url="https://example.com/a" expires-at="2999-01-01T00:00:00.000Z"><title>Example</title><description>Plain text</description><image url="https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16" media-type="image/png" width="640" height="360" alt="Article screenshot"/></preview></lookup></iq>`;
+      `<iq type="result" id="lookup-1"><lookup xmlns="urn:waddle:link-preview:0" status="ready"><preview token="signed-token" original-url="https://example.com/a" normalized-url="https://example.com/a" expires-at="2999-01-01T00:00:00.000Z"><title>Example</title><description>Plain text</description><image url="https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png" media-type="image/png" width="640" height="360" alt="Article screenshot"/></preview></lookup></iq>`;
 
     let result: Awaited<ReturnType<typeof requestPlaintextLinkPreviewLookup>> = null;
     await withFakeXmlDocument(async () => {
@@ -71,7 +71,7 @@ describe("link preview lookup", () => {
     expect(result).toMatchObject({
       status: "ready",
       image: {
-        url: "https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16",
+        url: "https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png",
         mediaType: "image/png",
         width: 640,
         height: 360,
@@ -85,21 +85,21 @@ describe("link preview lookup", () => {
 
     expect(origin).toBe("http://localhost:4321");
     expect(isTrustedCachedPreviewImageUrl(
-      "http://localhost:4321/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16",
+      "http://localhost:4321/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png",
       origin,
     )).toBe(true);
   });
 
   test("rejects non-loopback HTTP cached preview image origins", () => {
     expect(isTrustedCachedPreviewImageUrl(
-      "http://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16",
+      "http://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png",
       "http://waddle.example",
     )).toBe(false);
   });
 
   test("drops lookup preview images from a foreign cached-media origin", async () => {
     const send_raw_iq = async () =>
-      `<iq type="result" id="lookup-1"><lookup xmlns="urn:waddle:link-preview:0" status="ready"><preview token="signed-token" original-url="https://example.com/a" normalized-url="https://example.com/a" expires-at="2999-01-01T00:00:00.000Z"><title>Example</title><image url="https://attacker.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16" media-type="image/png"/></preview></lookup></iq>`;
+      `<iq type="result" id="lookup-1"><lookup xmlns="urn:waddle:link-preview:0" status="ready"><preview token="signed-token" original-url="https://example.com/a" normalized-url="https://example.com/a" expires-at="2999-01-01T00:00:00.000Z"><title>Example</title><image url="https://attacker.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png" media-type="image/png"/></preview></lookup></iq>`;
 
     let result: Awaited<ReturnType<typeof requestPlaintextLinkPreviewLookup>> = null;
     await withFakeXmlDocument(async () => {
@@ -119,7 +119,7 @@ describe("link preview lookup", () => {
 
   test("drops lookup preview images with unsafe media types", async () => {
     const send_raw_iq = async () =>
-      `<iq type="result" id="lookup-1"><lookup xmlns="urn:waddle:link-preview:0" status="ready"><preview token="signed-token" original-url="https://example.com/a" normalized-url="https://example.com/a" expires-at="2999-01-01T00:00:00.000Z"><title>Example</title><image url="https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16" media-type="image/svg+xml"/></preview></lookup></iq>`;
+      `<iq type="result" id="lookup-1"><lookup xmlns="urn:waddle:link-preview:0" status="ready"><preview token="signed-token" original-url="https://example.com/a" normalized-url="https://example.com/a" expires-at="2999-01-01T00:00:00.000Z"><title>Example</title><image url="https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png" media-type="image/svg+xml"/></preview></lookup></iq>`;
 
     let result: Awaited<ReturnType<typeof requestPlaintextLinkPreviewLookup>> = null;
     await withFakeXmlDocument(async () => {

--- a/chat/tests/link-preview.test.ts
+++ b/chat/tests/link-preview.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import {
   firstEligibleHttpsUrl,
+  isTrustedCachedPreviewImageUrl,
+  linkPreviewMediaOriginFromWebSocketUrl,
   requestPlaintextLinkPreviewLookup,
 } from "../src/lib/xmpp/link-preview";
 import { withFakeDomParser, withFakeXmlDocument } from "./helpers/disco-xml";
@@ -48,6 +50,91 @@ describe("link preview lookup", () => {
       title: "Example",
       description: "Plain text",
     });
+  });
+
+  test("accepts cached Waddle preview image metadata from ready lookup responses", async () => {
+    const send_raw_iq = async () =>
+      `<iq type="result" id="lookup-1"><lookup xmlns="urn:waddle:link-preview:0" status="ready"><preview token="signed-token" original-url="https://example.com/a" normalized-url="https://example.com/a" expires-at="2999-01-01T00:00:00.000Z"><title>Example</title><description>Plain text</description><image url="https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16" media-type="image/png" width="640" height="360" alt="Article screenshot"/></preview></lookup></iq>`;
+
+    let result: Awaited<ReturnType<typeof requestPlaintextLinkPreviewLookup>> = null;
+    await withFakeXmlDocument(async () => {
+      await withFakeDomParser(async () => {
+        result = await requestPlaintextLinkPreviewLookup(
+          { send_raw_iq },
+          "read https://example.com/a",
+          "room@muc.example.com",
+          "https://waddle.example",
+        );
+      });
+    });
+
+    expect(result).toMatchObject({
+      status: "ready",
+      image: {
+        url: "https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16",
+        mediaType: "image/png",
+        width: 640,
+        height: 360,
+        alt: "Article screenshot",
+      },
+    });
+  });
+
+  test("accepts cached preview images for trusted loopback HTTP development sessions", () => {
+    const origin = linkPreviewMediaOriginFromWebSocketUrl("ws://localhost:4321/xmpp");
+
+    expect(origin).toBe("http://localhost:4321");
+    expect(isTrustedCachedPreviewImageUrl(
+      "http://localhost:4321/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16",
+      origin,
+    )).toBe(true);
+  });
+
+  test("rejects non-loopback HTTP cached preview image origins", () => {
+    expect(isTrustedCachedPreviewImageUrl(
+      "http://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16",
+      "http://waddle.example",
+    )).toBe(false);
+  });
+
+  test("drops lookup preview images from a foreign cached-media origin", async () => {
+    const send_raw_iq = async () =>
+      `<iq type="result" id="lookup-1"><lookup xmlns="urn:waddle:link-preview:0" status="ready"><preview token="signed-token" original-url="https://example.com/a" normalized-url="https://example.com/a" expires-at="2999-01-01T00:00:00.000Z"><title>Example</title><image url="https://attacker.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16" media-type="image/png"/></preview></lookup></iq>`;
+
+    let result: Awaited<ReturnType<typeof requestPlaintextLinkPreviewLookup>> = null;
+    await withFakeXmlDocument(async () => {
+      await withFakeDomParser(async () => {
+        result = await requestPlaintextLinkPreviewLookup(
+          { send_raw_iq },
+          "read https://example.com/a",
+          "room@muc.example.com",
+          "https://waddle.example",
+        );
+      });
+    });
+
+    expect(result).toMatchObject({ status: "ready" });
+    expect(result && "image" in result ? result.image : undefined).toBeUndefined();
+  });
+
+  test("drops lookup preview images with unsafe media types", async () => {
+    const send_raw_iq = async () =>
+      `<iq type="result" id="lookup-1"><lookup xmlns="urn:waddle:link-preview:0" status="ready"><preview token="signed-token" original-url="https://example.com/a" normalized-url="https://example.com/a" expires-at="2999-01-01T00:00:00.000Z"><title>Example</title><image url="https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16" media-type="image/svg+xml"/></preview></lookup></iq>`;
+
+    let result: Awaited<ReturnType<typeof requestPlaintextLinkPreviewLookup>> = null;
+    await withFakeXmlDocument(async () => {
+      await withFakeDomParser(async () => {
+        result = await requestPlaintextLinkPreviewLookup(
+          { send_raw_iq },
+          "read https://example.com/a",
+          "room@muc.example.com",
+          "https://waddle.example",
+        );
+      });
+    });
+
+    expect(result).toMatchObject({ status: "ready" });
+    expect(result && "image" in result ? result.image : undefined).toBeUndefined();
   });
 
   test("rejects lookup responses with non-HTTPS preview URLs", async () => {

--- a/chat/tests/link-preview.test.ts
+++ b/chat/tests/link-preview.test.ts
@@ -90,6 +90,17 @@ describe("link preview lookup", () => {
     )).toBe(true);
   });
 
+  test("accepts trusted cached preview image origins with explicit default ports", () => {
+    expect(isTrustedCachedPreviewImageUrl(
+      "https://waddle.example:443/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png",
+      "https://waddle.example",
+    )).toBe(true);
+    expect(isTrustedCachedPreviewImageUrl(
+      "http://localhost:80/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png",
+      "http://localhost",
+    )).toBe(true);
+  });
+
   test("rejects non-loopback HTTP cached preview image origins", () => {
     expect(isTrustedCachedPreviewImageUrl(
       "http://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png",

--- a/server/crates/waddle-server/src/server/routes/uploads.rs
+++ b/server/crates/waddle-server/src/server/routes/uploads.rs
@@ -15,7 +15,7 @@ use crate::server::AppState;
 use axum::{
     body::Bytes,
     extract::{DefaultBodyLimit, Path, State},
-    http::{header, HeaderMap, StatusCode},
+    http::{header, HeaderMap, HeaderName, HeaderValue, StatusCode},
     response::IntoResponse,
     routing::{get, put},
     Json, Router,
@@ -89,8 +89,46 @@ pub fn router(upload_state: Arc<UploadState>) -> Router {
         )
         // Download endpoint (GET /api/files/{slot_id}/{filename})
         .route("/api/files/{slot_id}/{filename}", get(download_handler))
+        // Cached link-preview media (GET /api/link-preview-media/sha256/{hash})
+        .route(
+            "/api/link-preview-media/sha256/{hash}",
+            get(link_preview_media_handler),
+        )
         .layer(upload_body_limit())
         .with_state(upload_state)
+}
+
+async fn link_preview_media_handler(
+    State(state): State<Arc<UploadState>>,
+    Path(hash): Path<String>,
+) -> impl IntoResponse {
+    if hash.len() != 64 || !hash.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return (StatusCode::BAD_REQUEST, "invalid media hash").into_response();
+    }
+    let key = format!("link-previews/sha256/{}", hash.to_ascii_lowercase());
+    let (bytes, blob_meta) = match state.app_state.blob_storage.get(&key).await {
+        Ok(found) => found,
+        Err(crate::storage::StorageError::NotFound(_)) => {
+            return (StatusCode::NOT_FOUND, "media not found").into_response();
+        }
+        Err(error) => {
+            error!(key = %key, %error, "Failed to read cached link preview media");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "failed to read media").into_response();
+        }
+    };
+    let mut headers = HeaderMap::new();
+    if let Ok(content_type) = blob_meta.content_type.parse() {
+        headers.insert(header::CONTENT_TYPE, content_type);
+    }
+    headers.insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("private, max-age=300"),
+    );
+    headers.insert(
+        HeaderName::from_static("x-content-type-options"),
+        HeaderValue::from_static("nosniff"),
+    );
+    (StatusCode::OK, headers, bytes).into_response()
 }
 
 /// OPTIONS /api/upload/{slot_id}

--- a/server/crates/waddle-server/src/server/routes/uploads.rs
+++ b/server/crates/waddle-server/src/server/routes/uploads.rs
@@ -15,7 +15,7 @@ use crate::server::AppState;
 use axum::{
     body::Bytes,
     extract::{DefaultBodyLimit, Path, State},
-    http::{header, HeaderMap, HeaderName, HeaderValue, StatusCode},
+    http::{header, HeaderMap, StatusCode},
     response::IntoResponse,
     routing::{get, put},
     Json, Router,
@@ -89,46 +89,8 @@ pub fn router(upload_state: Arc<UploadState>) -> Router {
         )
         // Download endpoint (GET /api/files/{slot_id}/{filename})
         .route("/api/files/{slot_id}/{filename}", get(download_handler))
-        // Cached link-preview media (GET /api/link-preview-media/sha256/{hash})
-        .route(
-            "/api/link-preview-media/sha256/{hash}",
-            get(link_preview_media_handler),
-        )
         .layer(upload_body_limit())
         .with_state(upload_state)
-}
-
-async fn link_preview_media_handler(
-    State(state): State<Arc<UploadState>>,
-    Path(hash): Path<String>,
-) -> impl IntoResponse {
-    if hash.len() != 64 || !hash.bytes().all(|byte| byte.is_ascii_hexdigit()) {
-        return (StatusCode::BAD_REQUEST, "invalid media hash").into_response();
-    }
-    let key = format!("link-previews/sha256/{}", hash.to_ascii_lowercase());
-    let (bytes, blob_meta) = match state.app_state.blob_storage.get(&key).await {
-        Ok(found) => found,
-        Err(crate::storage::StorageError::NotFound(_)) => {
-            return (StatusCode::NOT_FOUND, "media not found").into_response();
-        }
-        Err(error) => {
-            error!(key = %key, %error, "Failed to read cached link preview media");
-            return (StatusCode::INTERNAL_SERVER_ERROR, "failed to read media").into_response();
-        }
-    };
-    let mut headers = HeaderMap::new();
-    if let Ok(content_type) = blob_meta.content_type.parse() {
-        headers.insert(header::CONTENT_TYPE, content_type);
-    }
-    headers.insert(
-        header::CACHE_CONTROL,
-        HeaderValue::from_static("private, max-age=300"),
-    );
-    headers.insert(
-        HeaderName::from_static("x-content-type-options"),
-        HeaderValue::from_static("nosniff"),
-    );
-    (StatusCode::OK, headers, bytes).into_response()
 }
 
 /// OPTIONS /api/upload/{slot_id}

--- a/server/crates/waddle-server/src/server/routes/uploads/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/uploads/tests.rs
@@ -3,7 +3,7 @@ use crate::db::{DatabaseConfig, DatabasePool, MigrationRunner, PoolConfig};
 use crate::permissions::PermissionActor;
 use crate::server::AppStateDeps;
 use axum::body::Body;
-use axum::http::Request;
+use axum::http::{header, Request};
 use http_body_util::BodyExt;
 use kameo::actor::Spawn;
 use std::str::FromStr;
@@ -97,6 +97,89 @@ async fn create_expired_slot(state: &UploadState, slot_id: &str) {
     conn.execute(query, crate::db_params![slot_id, expires_at])
         .await
         .unwrap();
+}
+
+#[tokio::test]
+async fn serves_cached_link_preview_media_by_content_hash() {
+    let (state, upload_dir) = create_test_upload_state().await;
+    let key =
+        "link-previews/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16";
+    let bytes = bytes::Bytes::from_static(b"\x89PNG\r\n\x1a\ncached preview");
+    state
+        .app_state
+        .blob_storage
+        .put(key, bytes.clone(), "image/png")
+        .await
+        .expect("stored preview media");
+    let app = router(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get(header::CONTENT_TYPE).unwrap(),
+        "image/png"
+    );
+    assert_eq!(
+        response.headers().get(header::CACHE_CONTROL).unwrap(),
+        "private, max-age=300"
+    );
+    assert_eq!(
+        response.headers().get("x-content-type-options").unwrap(),
+        "nosniff"
+    );
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(body, bytes);
+    std::fs::remove_dir_all(upload_dir).ok();
+}
+
+#[tokio::test]
+async fn rejects_invalid_cached_link_preview_media_hash() {
+    let (state, upload_dir) = create_test_upload_state().await;
+    let app = router(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/link-preview-media/sha256/not-a-hash")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    std::fs::remove_dir_all(upload_dir).ok();
+}
+
+#[tokio::test]
+async fn returns_not_found_for_missing_cached_link_preview_media() {
+    let (state, upload_dir) = create_test_upload_state().await;
+    let app = router(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    std::fs::remove_dir_all(upload_dir).ok();
 }
 
 #[test]

--- a/server/crates/waddle-server/src/server/routes/uploads/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/uploads/tests.rs
@@ -3,7 +3,7 @@ use crate::db::{DatabaseConfig, DatabasePool, MigrationRunner, PoolConfig};
 use crate::permissions::PermissionActor;
 use crate::server::AppStateDeps;
 use axum::body::Body;
-use axum::http::{header, Request};
+use axum::http::Request;
 use http_body_util::BodyExt;
 use kameo::actor::Spawn;
 use std::str::FromStr;
@@ -100,70 +100,7 @@ async fn create_expired_slot(state: &UploadState, slot_id: &str) {
 }
 
 #[tokio::test]
-async fn serves_cached_link_preview_media_by_content_hash() {
-    let (state, upload_dir) = create_test_upload_state().await;
-    let key =
-        "link-previews/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16";
-    let bytes = bytes::Bytes::from_static(b"\x89PNG\r\n\x1a\ncached preview");
-    state
-        .app_state
-        .blob_storage
-        .put(key, bytes.clone(), "image/png")
-        .await
-        .expect("stored preview media");
-    let app = router(state);
-
-    let response = app
-        .oneshot(
-            Request::builder()
-                .method("GET")
-                .uri("/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16")
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(response.status(), StatusCode::OK);
-    assert_eq!(
-        response.headers().get(header::CONTENT_TYPE).unwrap(),
-        "image/png"
-    );
-    assert_eq!(
-        response.headers().get(header::CACHE_CONTROL).unwrap(),
-        "private, max-age=300"
-    );
-    assert_eq!(
-        response.headers().get("x-content-type-options").unwrap(),
-        "nosniff"
-    );
-    let body = response.into_body().collect().await.unwrap().to_bytes();
-    assert_eq!(body, bytes);
-    std::fs::remove_dir_all(upload_dir).ok();
-}
-
-#[tokio::test]
-async fn rejects_invalid_cached_link_preview_media_hash() {
-    let (state, upload_dir) = create_test_upload_state().await;
-    let app = router(state);
-
-    let response = app
-        .oneshot(
-            Request::builder()
-                .method("GET")
-                .uri("/api/link-preview-media/sha256/not-a-hash")
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    std::fs::remove_dir_all(upload_dir).ok();
-}
-
-#[tokio::test]
-async fn returns_not_found_for_missing_cached_link_preview_media() {
+async fn link_preview_media_has_no_dedicated_http_route() {
     let (state, upload_dir) = create_test_upload_state().await;
     let app = router(state);
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
@@ -8,14 +8,15 @@ use chrono::{Duration, SecondsFormat, Utc};
 use minidom::rxml::xml_ncname;
 use url::Url;
 use waddle_xmpp::xep::{
-    encode_link_preview_token_checked, LinkPreviewTokenData, NS_WADDLE_LINK_PREVIEW,
+    encode_link_preview_token_checked, LinkPreviewTokenData, LinkPreviewTokenImage,
+    NS_WADDLE_LINK_PREVIEW,
 };
 use xmpp_parsers::iq::Iq;
 use xmpp_parsers::minidom::Element;
 
 use super::link_preview_resolver::{
-    resolve_link_preview, LinkPreviewResolverOutcome, LinkPreviewResolverPolicy,
-    LinkPreviewResolverStatus,
+    resolve_link_preview, LinkPreviewMediaCache, LinkPreviewResolverOutcome,
+    LinkPreviewResolverPolicy, LinkPreviewResolverStatus,
 };
 
 struct LinkPreviewLookupDeps<'a> {
@@ -42,7 +43,13 @@ pub(super) async fn handle_link_preview_lookup_iq(
     response_to: Option<&str>,
     secret: &[u8],
 ) -> Vec<String> {
-    let resolver_policy = LinkPreviewResolverPolicy::default();
+    let resolver_policy = LinkPreviewResolverPolicy {
+        media_cache: Some(LinkPreviewMediaCache::new(
+            state.deps.app_state.blob_storage.clone(),
+            state.deps.auth_state.base_url.as_str(),
+        )),
+        ..Default::default()
+    };
     handle_link_preview_lookup_iq_with_policy(
         iq,
         sender_jid,
@@ -135,6 +142,13 @@ async fn handle_link_preview_lookup_iq_with_policy(
         normalized_url: metadata.normalized_url,
         title: metadata.title,
         description: metadata.description,
+        image: metadata.image.map(|image| LinkPreviewTokenImage {
+            url: image.url,
+            media_type: image.media_type,
+            width: image.width,
+            height: image.height,
+            alt: image.alt,
+        }),
         expires_at_unix: expires_at.timestamp(),
     };
     let Some(token) = encode_link_preview_token_checked(&data, deps.secret) else {
@@ -242,6 +256,24 @@ fn build_link_preview_lookup_result(
             .build();
         append_text(&mut preview, "title", data.title.as_deref());
         append_text(&mut preview, "description", data.description.as_deref());
+        if let Some(image) = &data.image {
+            let mut image_elem = Element::builder("image", NS_WADDLE_LINK_PREVIEW)
+                .attr(xml_ncname!("url").to_owned(), image.url.as_str())
+                .attr(
+                    xml_ncname!("media-type").to_owned(),
+                    image.media_type.as_str(),
+                );
+            if let Some(width) = image.width {
+                image_elem = image_elem.attr(xml_ncname!("width").to_owned(), width.to_string());
+            }
+            if let Some(height) = image.height {
+                image_elem = image_elem.attr(xml_ncname!("height").to_owned(), height.to_string());
+            }
+            if let Some(alt) = image.alt.as_deref().filter(|alt| !alt.trim().is_empty()) {
+                image_elem = image_elem.attr(xml_ncname!("alt").to_owned(), alt.trim());
+            }
+            preview.append_child(image_elem.build());
+        }
         lookup = lookup.append(preview);
     }
     build_iq_result_xml(iq.id(), response_from, response_to, Some(lookup.build()))
@@ -283,21 +315,46 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn handles_https_lookup_with_scoped_token_and_text_metadata() {
+    async fn handles_https_lookup_with_scoped_token_text_and_cached_image_metadata() {
         let server = MockServer::start().await;
+        let image_bytes = bytes::Bytes::from_static(b"\x89PNG\r\n\x1a\nlookup preview");
         Mock::given(method("GET"))
             .and(path("/a"))
             .respond_with(ResponseTemplate::new(200).set_body_raw(
-                r#"<html><head>
+                format!(
+                    r#"<html><head>
                     <meta property="og:title" content="Example Article">
                     <meta property="og:description" content="Plain text summary">
+                    <meta property="og:image" content="{}/preview.png">
+                    <meta property="og:image:width" content="640">
+                    <meta property="og:image:height" content="360">
+                    <meta property="og:image:alt" content="Article screenshot">
                   </head></html>"#,
+                    server.uri()
+                ),
                 "text/html",
             ))
             .mount(&server)
             .await;
+        Mock::given(method("GET"))
+            .and(path("/preview.png"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "image/png")
+                    .set_body_bytes(image_bytes),
+            )
+            .mount(&server)
+            .await;
+        let storage_dir =
+            std::env::temp_dir().join(format!("waddle-link-preview-{}", uuid::Uuid::new_v4()));
+        let storage: std::sync::Arc<dyn crate::storage::BlobStorage> =
+            std::sync::Arc::new(crate::storage::LocalStorage::new(storage_dir));
         let resolver_policy = LinkPreviewResolverPolicy {
             allow_http_loopback_for_tests: true,
+            media_cache: Some(LinkPreviewMediaCache::new(
+                storage,
+                "https://waddle.example",
+            )),
             ..Default::default()
         };
         let lookup_url = format!("{}/a", server.uri());
@@ -342,6 +399,16 @@ mod tests {
         assert_eq!(preview.attr("normalized-url"), Some(lookup_url.as_str()));
         assert!(preview.attr("token").is_some_and(|token| !token.is_empty()));
         assert!(preview.attr("expires-at").is_some());
+        let image = preview
+            .get_child("image", NS_WADDLE_LINK_PREVIEW)
+            .expect("image");
+        assert_eq!(image.attr("media-type"), Some("image/png"));
+        assert_eq!(image.attr("width"), Some("640"));
+        assert_eq!(image.attr("height"), Some("360"));
+        assert_eq!(image.attr("alt"), Some("Article screenshot"));
+        assert!(image.attr("url").is_some_and(|url| {
+            url.starts_with("https://waddle.example/api/link-preview-media/sha256/")
+        }));
         let token = waddle_xmpp::xep::LinkPreviewToken::new(
             preview.attr("token").expect("token").to_string(),
         )
@@ -350,6 +417,15 @@ mod tests {
             waddle_xmpp::xep::decode_link_preview_token(&token, secret(), i64::MIN).expect("token");
         assert_eq!(decoded.sender_jid.to_string(), "alice@example.com");
         assert_eq!(decoded.scope_jid.to_string(), "alice@example.com");
+        let decoded_image = decoded.image.expect("token image");
+        assert_eq!(decoded_image.media_type, "image/png");
+        assert_eq!(decoded_image.width, Some(640));
+        assert_eq!(decoded_image.height, Some(360));
+        assert_eq!(decoded_image.alt.as_deref(), Some("Article screenshot"));
+        assert!(decoded_image
+            .url
+            .as_str()
+            .starts_with("https://waddle.example/api/link-preview-media/sha256/"));
         assert_eq!(
             preview
                 .get_child("title", NS_WADDLE_LINK_PREVIEW)

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
@@ -24,7 +24,7 @@ struct LinkPreviewLookupDeps<'a> {
     response_from: Option<&'a str>,
     response_to: Option<&'a str>,
     secret: &'a [u8],
-    resolver_policy: &'a LinkPreviewResolverPolicy,
+    resolver_policy: Option<&'a LinkPreviewResolverPolicy>,
 }
 
 pub(super) fn is_link_preview_lookup_iq(iq: &Iq) -> bool {
@@ -43,13 +43,6 @@ pub(super) async fn handle_link_preview_lookup_iq(
     response_to: Option<&str>,
     secret: &[u8],
 ) -> Vec<String> {
-    let resolver_policy = LinkPreviewResolverPolicy {
-        media_cache: Some(LinkPreviewMediaCache::new(
-            state.deps.app_state.blob_storage.clone(),
-            state.deps.auth_state.base_url.as_str(),
-        )),
-        ..Default::default()
-    };
     handle_link_preview_lookup_iq_with_policy(
         iq,
         sender_jid,
@@ -59,7 +52,7 @@ pub(super) async fn handle_link_preview_lookup_iq(
             response_from,
             response_to,
             secret,
-            resolver_policy: &resolver_policy,
+            resolver_policy: None,
         },
     )
     .await
@@ -78,6 +71,22 @@ async fn handle_link_preview_lookup_iq_with_policy(
             deps.response_to,
             not_authorized_iq_error("Authentication required."),
         )];
+    };
+    let owned_resolver_policy;
+    let resolver_policy = match deps.resolver_policy {
+        Some(policy) => policy,
+        None => {
+            owned_resolver_policy = LinkPreviewResolverPolicy {
+                media_cache: Some(LinkPreviewMediaCache::new(
+                    state.deps.app_state.blob_storage.clone(),
+                    state.deps.auth_state.base_url.as_str(),
+                    state.deps.app_state.db_pool.global_actor().clone(),
+                    sender_jid.to_bare(),
+                )),
+                ..Default::default()
+            };
+            &owned_resolver_policy
+        }
     };
     let Iq::Get { payload, .. } = iq else {
         return vec![build_iq_error_xml_typed(
@@ -124,7 +133,7 @@ async fn handle_link_preview_lookup_iq_with_policy(
             None,
         )];
     };
-    let outcome = resolve_link_preview(&original_url, deps.resolver_policy).await;
+    let outcome = resolve_link_preview(&original_url, resolver_policy).await;
     let LinkPreviewResolverOutcome::Ready(metadata) = outcome else {
         return vec![build_link_preview_lookup_result(
             iq,
@@ -349,11 +358,14 @@ mod tests {
             std::env::temp_dir().join(format!("waddle-link-preview-{}", uuid::Uuid::new_v4()));
         let storage: std::sync::Arc<dyn crate::storage::BlobStorage> =
             std::sync::Arc::new(crate::storage::LocalStorage::new(storage_dir));
+        let state = create_test_websocket_state().await;
         let resolver_policy = LinkPreviewResolverPolicy {
             allow_http_loopback_for_tests: true,
             media_cache: Some(LinkPreviewMediaCache::new(
                 storage,
                 "https://waddle.example",
+                state.deps.app_state.db_pool.global_actor().clone(),
+                "alice@example.com".parse().expect("jid"),
             )),
             ..Default::default()
         };
@@ -372,7 +384,6 @@ mod tests {
             .build();
         let iq = iq_get_with_payload(payload);
 
-        let state = create_test_websocket_state().await;
         let response = handle_link_preview_lookup_iq_with_policy(
             &iq,
             Some(&sender()),
@@ -382,7 +393,7 @@ mod tests {
                 response_from: None,
                 response_to: None,
                 secret: secret(),
-                resolver_policy: &resolver_policy,
+                resolver_policy: Some(&resolver_policy),
             },
         )
         .await;
@@ -407,7 +418,9 @@ mod tests {
         assert_eq!(image.attr("height"), Some("360"));
         assert_eq!(image.attr("alt"), Some("Article screenshot"));
         assert!(image.attr("url").is_some_and(|url| {
-            url.starts_with("https://waddle.example/api/link-preview-media/sha256/")
+            url.starts_with("https://waddle.example/api/files/")
+                && url.ends_with(".png")
+                && url.contains("/link-preview-")
         }));
         let token = waddle_xmpp::xep::LinkPreviewToken::new(
             preview.attr("token").expect("token").to_string(),
@@ -425,7 +438,7 @@ mod tests {
         assert!(decoded_image
             .url
             .as_str()
-            .starts_with("https://waddle.example/api/link-preview-media/sha256/"));
+            .starts_with("https://waddle.example/api/files/"));
         assert_eq!(
             preview
                 .get_child("title", NS_WADDLE_LINK_PREVIEW)
@@ -478,7 +491,7 @@ mod tests {
                 response_from: None,
                 response_to: None,
                 secret: secret(),
-                resolver_policy: &resolver_policy,
+                resolver_policy: Some(&resolver_policy),
             },
         )
         .await;

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
@@ -11,6 +11,8 @@ use waddle_xmpp::xep::{
     encode_link_preview_token_checked, LinkPreviewTokenData, LinkPreviewTokenImage,
     NS_WADDLE_LINK_PREVIEW,
 };
+#[cfg(test)]
+use waddle_xmpp_core::PreviewImageMediaType;
 use xmpp_parsers::iq::Iq;
 use xmpp_parsers::minidom::Element;
 
@@ -431,7 +433,7 @@ mod tests {
         assert_eq!(decoded.sender_jid.to_string(), "alice@example.com");
         assert_eq!(decoded.scope_jid.to_string(), "alice@example.com");
         let decoded_image = decoded.image.expect("token image");
-        assert_eq!(decoded_image.media_type, "image/png");
+        assert_eq!(decoded_image.media_type, PreviewImageMediaType::Png);
         assert_eq!(decoded_image.width, Some(640));
         assert_eq!(decoded_image.height, Some(360));
         assert_eq!(decoded_image.alt.as_deref(), Some("Article screenshot"));

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
@@ -1,11 +1,18 @@
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use bytes::Bytes;
 use reqwest::header::{CONTENT_TYPE, LOCATION};
 use reqwest::{redirect, Client, StatusCode};
+use sha2::{Digest, Sha256};
+use tracing::warn;
 use url::{Host, Url};
 
+use crate::storage::BlobStorage;
+
 const DEFAULT_MAX_BYTES: usize = 256 * 1024;
+const DEFAULT_MAX_IMAGE_BYTES: usize = 2 * 1024 * 1024;
 const DEFAULT_MAX_REDIRECTS: usize = 3;
 const DEFAULT_TIMEOUT: Duration = Duration::from_millis(1_500);
 const LINK_PREVIEW_TITLE_MAX_BYTES: usize = 256;
@@ -17,23 +24,52 @@ pub(super) struct ResolvedLinkMetadata {
     pub normalized_url: Url,
     pub title: Option<String>,
     pub description: Option<String>,
+    pub image: Option<ResolvedLinkPreviewImage>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ResolvedLinkPreviewImage {
+    pub url: Url,
+    pub media_type: String,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub alt: Option<String>,
+}
+
+#[derive(Clone)]
+pub(super) struct LinkPreviewMediaCache {
+    storage: Arc<dyn BlobStorage>,
+    public_base_url: String,
+}
+
+impl LinkPreviewMediaCache {
+    pub(super) fn new(storage: Arc<dyn BlobStorage>, public_base_url: impl Into<String>) -> Self {
+        Self {
+            storage,
+            public_base_url: public_base_url.into().trim_end_matches('/').to_string(),
+        }
+    }
+}
+
+#[derive(Clone)]
 pub(super) struct LinkPreviewResolverPolicy {
     pub max_bytes: usize,
+    pub max_image_bytes: usize,
     pub max_redirects: usize,
     pub timeout: Duration,
     pub allow_http_loopback_for_tests: bool,
+    pub media_cache: Option<LinkPreviewMediaCache>,
 }
 
 impl Default for LinkPreviewResolverPolicy {
     fn default() -> Self {
         Self {
             max_bytes: DEFAULT_MAX_BYTES,
+            max_image_bytes: DEFAULT_MAX_IMAGE_BYTES,
             max_redirects: DEFAULT_MAX_REDIRECTS,
             timeout: DEFAULT_TIMEOUT,
             allow_http_loopback_for_tests: false,
+            media_cache: None,
         }
     }
 }
@@ -97,9 +133,31 @@ pub(super) async fn resolve_link_preview(
         };
         match fetch {
             FetchOnceResult::Html { final_url, html } => {
-                return extract_metadata_from_html_with_normalized_fallback(url, &html, &final_url)
-                    .map(|metadata| LinkPreviewResolverOutcome::Ready(Box::new(metadata)))
-                    .unwrap_or(LinkPreviewResolverOutcome::Unsupported);
+                let Some((mut metadata, remote_image)) =
+                    extract_metadata_parts_from_html(url, &html, &final_url, policy)
+                else {
+                    return LinkPreviewResolverOutcome::Unsupported;
+                };
+                if let (Some(cache), Some(remote_image)) =
+                    (policy.media_cache.as_ref(), remote_image)
+                {
+                    match fetch_cached_preview_image(&remote_image, policy, cache, deadline).await {
+                        Ok(image) => metadata.image = Some(image),
+                        Err(LinkPreviewResolverStatus::Blocked) => warn!(
+                            url = %remote_image.url,
+                            "dropping blocked link preview image after metadata resolved"
+                        ),
+                        Err(LinkPreviewResolverStatus::Failed) => warn!(
+                            url = %remote_image.url,
+                            "dropping failed link preview image after metadata resolved"
+                        ),
+                        Err(LinkPreviewResolverStatus::Unsupported) => {}
+                        Err(LinkPreviewResolverStatus::Ready) => {
+                            unreachable!("ready is not an image fetch error")
+                        }
+                    }
+                }
+                return LinkPreviewResolverOutcome::Ready(Box::new(metadata));
             }
             FetchOnceResult::Redirect(next) => {
                 if redirect_count == policy.max_redirects {
@@ -110,6 +168,145 @@ pub(super) async fn resolve_link_preview(
         }
     }
     LinkPreviewResolverOutcome::Failed
+}
+
+async fn fetch_cached_preview_image(
+    remote: &RemotePreviewImage,
+    policy: &LinkPreviewResolverPolicy,
+    cache: &LinkPreviewMediaCache,
+    deadline: Instant,
+) -> Result<ResolvedLinkPreviewImage, LinkPreviewResolverStatus> {
+    let mut current = remote.url.clone();
+    for redirect_count in 0..=policy.max_redirects {
+        let Some(timeout) = deadline.checked_duration_since(Instant::now()) else {
+            return Err(LinkPreviewResolverStatus::Failed);
+        };
+        match fetch_image_once(&current, policy, timeout).await? {
+            FetchImageOnceResult::Image { bytes, media_type } => {
+                let digest = Sha256::digest(bytes.as_ref());
+                let hash = digest
+                    .iter()
+                    .map(|byte| format!("{byte:02x}"))
+                    .collect::<String>();
+                let key = format!("link-previews/sha256/{hash}");
+                cache
+                    .storage
+                    .put(&key, bytes, &media_type)
+                    .await
+                    .map_err(|error| {
+                        warn!(%error, key = %key, "failed to cache link preview image");
+                        LinkPreviewResolverStatus::Unsupported
+                    })?;
+                let url = Url::parse(&format!(
+                    "{}/api/link-preview-media/sha256/{hash}",
+                    cache.public_base_url
+                ))
+                .map_err(|error| {
+                    warn!(%error, "failed to build cached link preview image URL");
+                    LinkPreviewResolverStatus::Unsupported
+                })?;
+                return Ok(ResolvedLinkPreviewImage {
+                    url,
+                    media_type,
+                    width: remote.width,
+                    height: remote.height,
+                    alt: remote.alt.clone(),
+                });
+            }
+            FetchImageOnceResult::Redirect(next) => {
+                if redirect_count == policy.max_redirects {
+                    return Err(LinkPreviewResolverStatus::Failed);
+                }
+                current = next;
+            }
+        }
+    }
+    Err(LinkPreviewResolverStatus::Failed)
+}
+
+enum FetchImageOnceResult {
+    Image { bytes: Bytes, media_type: String },
+    Redirect(Url),
+}
+
+async fn fetch_image_once(
+    url: &Url,
+    policy: &LinkPreviewResolverPolicy,
+    timeout: Duration,
+) -> Result<FetchImageOnceResult, LinkPreviewResolverStatus> {
+    let target = prepare_target(url, policy).await?;
+    let mut builder = Client::builder()
+        .timeout(timeout)
+        .connect_timeout(timeout)
+        .redirect(redirect::Policy::none())
+        .https_only(!policy.allow_http_loopback_for_tests);
+    if let Host::Domain(host) = target.host {
+        builder = builder.resolve_to_addrs(host, &target.addrs);
+    }
+    let client = builder
+        .build()
+        .map_err(|_| LinkPreviewResolverStatus::Failed)?;
+    let mut response = client
+        .get(url.clone())
+        .send()
+        .await
+        .map_err(|_| LinkPreviewResolverStatus::Failed)?;
+
+    if response.status().is_redirection() {
+        let Some(location) = response
+            .headers()
+            .get(LOCATION)
+            .and_then(|value| value.to_str().ok())
+        else {
+            return Err(LinkPreviewResolverStatus::Failed);
+        };
+        let next = url
+            .join(location)
+            .map_err(|_| LinkPreviewResolverStatus::Failed)?;
+        let status = classify_url_with_policy(&next, policy);
+        if status != LinkPreviewResolverStatus::Ready {
+            return Err(status);
+        }
+        return Ok(FetchImageOnceResult::Redirect(next));
+    }
+
+    if response.status() == StatusCode::NOT_FOUND {
+        return Err(LinkPreviewResolverStatus::Unsupported);
+    }
+    if !response.status().is_success() {
+        return Err(LinkPreviewResolverStatus::Failed);
+    }
+    let header_media_type = response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(safe_preview_image_media_type)
+        .ok_or(LinkPreviewResolverStatus::Unsupported)?;
+    if let Some(len) = response.content_length() {
+        if len > policy.max_image_bytes as u64 {
+            return Err(LinkPreviewResolverStatus::Failed);
+        }
+    }
+    let mut body = Vec::with_capacity(policy.max_image_bytes.min(128 * 1024));
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|_| LinkPreviewResolverStatus::Failed)?
+    {
+        if body.len() + chunk.len() > policy.max_image_bytes {
+            return Err(LinkPreviewResolverStatus::Failed);
+        }
+        body.extend_from_slice(&chunk);
+    }
+    let media_type =
+        sniff_safe_preview_image_media_type(&body).ok_or(LinkPreviewResolverStatus::Unsupported)?;
+    if header_media_type != media_type {
+        return Err(LinkPreviewResolverStatus::Unsupported);
+    }
+    Ok(FetchImageOnceResult::Image {
+        bytes: Bytes::from(body),
+        media_type,
+    })
 }
 
 enum FetchOnceResult {
@@ -374,18 +571,37 @@ fn extract_metadata_from_html(requested_url: &Url, html: &str) -> Option<Resolve
     extract_metadata_from_html_with_normalized_fallback(requested_url, html, requested_url)
 }
 
+#[cfg(test)]
 fn extract_metadata_from_html_with_normalized_fallback(
     requested_url: &Url,
     html: &str,
     normalized_fallback_url: &Url,
 ) -> Option<ResolvedLinkMetadata> {
+    let policy = LinkPreviewResolverPolicy::default();
+    extract_metadata_parts_from_html(requested_url, html, normalized_fallback_url, &policy)
+        .map(|(metadata, _)| metadata)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RemotePreviewImage {
+    url: Url,
+    width: Option<u32>,
+    height: Option<u32>,
+    alt: Option<String>,
+}
+
+fn extract_metadata_parts_from_html(
+    requested_url: &Url,
+    html: &str,
+    normalized_fallback_url: &Url,
+    policy: &LinkPreviewResolverPolicy,
+) -> Option<(ResolvedLinkMetadata, Option<RemotePreviewImage>)> {
     let title = meta_content(html, "og:title", LINK_PREVIEW_TITLE_MAX_BYTES);
     let description = meta_content(html, "og:description", LINK_PREVIEW_DESCRIPTION_MAX_BYTES);
     let canonical_url = meta_content(html, "og:url", usize::MAX)
         .and_then(|url| Url::parse(&url).ok())
         .filter(|url| {
-            classify_url_with_policy(url, &LinkPreviewResolverPolicy::default())
-                == LinkPreviewResolverStatus::Ready
+            classify_url_with_policy(url, policy) == LinkPreviewResolverStatus::Ready
                 && same_domain_host(url, normalized_fallback_url)
         });
     let normalized_url = canonical_url
@@ -399,12 +615,56 @@ fn extract_metadata_from_html_with_normalized_fallback(
         return None;
     }
 
-    Some(ResolvedLinkMetadata {
-        original_url: requested_url.clone(),
-        normalized_url,
-        title,
-        description,
-    })
+    let image = meta_content(html, "og:image", usize::MAX)
+        .and_then(|url| Url::parse(&url).ok())
+        .filter(|url| classify_url_with_policy(url, policy) == LinkPreviewResolverStatus::Ready)
+        .map(|url| RemotePreviewImage {
+            url,
+            width: meta_content(html, "og:image:width", 16).and_then(|raw| raw.parse().ok()),
+            height: meta_content(html, "og:image:height", 16).and_then(|raw| raw.parse().ok()),
+            alt: meta_content(html, "og:image:alt", LINK_PREVIEW_DESCRIPTION_MAX_BYTES),
+        });
+
+    Some((
+        ResolvedLinkMetadata {
+            original_url: requested_url.clone(),
+            normalized_url,
+            title,
+            description,
+            image: None,
+        },
+        image,
+    ))
+}
+
+fn safe_preview_image_media_type(value: &str) -> Option<String> {
+    let media_type = value
+        .split(';')
+        .next()
+        .unwrap_or(value)
+        .trim()
+        .to_ascii_lowercase();
+    matches!(
+        media_type.as_str(),
+        "image/png" | "image/jpeg" | "image/gif" | "image/webp"
+    )
+    .then_some(media_type)
+}
+
+fn sniff_safe_preview_image_media_type(bytes: &[u8]) -> Option<String> {
+    if bytes.starts_with(b"\x89PNG\r\n\x1a\n") {
+        return Some("image/png".to_string());
+    }
+    if bytes.starts_with(b"\xff\xd8\xff") {
+        return Some("image/jpeg".to_string());
+    }
+    if bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a") {
+        return Some("image/gif".to_string());
+    }
+    if bytes.len() >= 12 && &bytes[..4] == b"RIFF" && &bytes[8..12] == b"WEBP" {
+        return Some("image/webp".to_string());
+    }
+    None
 }
 
 fn meta_content(html: &str, property: &str, max_bytes: usize) -> Option<String> {
@@ -559,8 +819,47 @@ fn find_ascii_case_insensitive(haystack: &str, needle: &str) -> Option<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::Arc;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    struct FailingPutStorage;
+
+    impl crate::storage::BlobStorage for FailingPutStorage {
+        fn put(
+            &self,
+            _key: &str,
+            _data: bytes::Bytes,
+            _content_type: &str,
+        ) -> Pin<Box<dyn Future<Output = Result<(), crate::storage::StorageError>> + Send + '_>>
+        {
+            Box::pin(async {
+                Err(crate::storage::StorageError::Internal(
+                    "forced put failure".to_string(),
+                ))
+            })
+        }
+
+        fn get(
+            &self,
+            key: &str,
+        ) -> Pin<
+            Box<
+                dyn Future<
+                        Output = Result<
+                            (bytes::Bytes, crate::storage::BlobMeta),
+                            crate::storage::StorageError,
+                        >,
+                    > + Send
+                    + '_,
+            >,
+        > {
+            let key = key.to_string();
+            Box::pin(async { Err(crate::storage::StorageError::NotFound(key)) })
+        }
+    }
 
     #[test]
     fn extracts_opengraph_text_metadata_from_html_without_executing_embeds() {
@@ -826,6 +1125,517 @@ mod tests {
         };
         assert_eq!(metadata.title.as_deref(), Some("Fetched title"));
         assert_eq!(metadata.description.as_deref(), Some("Fetched description"));
+    }
+
+    #[tokio::test]
+    async fn fetches_safe_preview_image_into_content_addressed_waddle_storage() {
+        let server = MockServer::start().await;
+        let image_bytes = bytes::Bytes::from_static(b"\x89PNG\r\n\x1a\nfake png bytes");
+        Mock::given(method("GET"))
+            .and(path("/article"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                format!(
+                    r#"<html><head>
+                          <meta property="og:title" content="Fetched title">
+                          <meta property="og:image" content="{}/preview.png">
+                          <meta property="og:image:width" content="640">
+                          <meta property="og:image:height" content="360">
+                          <meta property="og:image:alt" content="Article screenshot">
+                        </head></html>"#,
+                    server.uri()
+                ),
+                "text/html; charset=utf-8",
+            ))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/preview.png"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "image/png")
+                    .set_body_bytes(image_bytes.clone()),
+            )
+            .mount(&server)
+            .await;
+        let storage_dir =
+            std::env::temp_dir().join(format!("waddle-link-preview-{}", uuid::Uuid::new_v4()));
+        let storage: Arc<dyn crate::storage::BlobStorage> =
+            Arc::new(crate::storage::LocalStorage::new(storage_dir));
+        let policy = LinkPreviewResolverPolicy {
+            allow_http_loopback_for_tests: true,
+            media_cache: Some(LinkPreviewMediaCache::new(
+                storage.clone(),
+                "https://waddle.example",
+            )),
+            ..Default::default()
+        };
+        let url = Url::parse(&format!("{}/article", server.uri())).expect("url");
+
+        let outcome = resolve_link_preview(&url, &policy).await;
+
+        let LinkPreviewResolverOutcome::Ready(metadata) = outcome else {
+            panic!("expected ready outcome, got {outcome:?}");
+        };
+        let expected_hash = hex::encode(Sha256::digest(image_bytes.as_ref()));
+        let expected_key = format!("link-previews/sha256/{expected_hash}");
+        let image = metadata.image.expect("cached image metadata");
+        assert_eq!(image.url.scheme(), "https");
+        assert_eq!(image.url.domain(), Some("waddle.example"));
+        assert_eq!(
+            image.url.path(),
+            format!("/api/link-preview-media/sha256/{expected_hash}")
+        );
+        assert_eq!(image.media_type, "image/png");
+        assert_eq!(image.width, Some(640));
+        assert_eq!(image.height, Some(360));
+        assert_eq!(image.alt.as_deref(), Some("Article screenshot"));
+        let (stored, meta) = storage.get(&expected_key).await.expect("cached bytes");
+        assert_eq!(stored, image_bytes);
+        assert_eq!(meta.content_type, "image/png");
+    }
+
+    #[tokio::test]
+    async fn rejects_unsafe_preview_image_media_types_without_caching_image() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/article"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                format!(
+                    r#"<html><head>
+                          <meta property="og:title" content="Fetched title">
+                          <meta property="og:image" content="{}/preview.svg">
+                        </head></html>"#,
+                    server.uri()
+                ),
+                "text/html; charset=utf-8",
+            ))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/preview.svg"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "image/svg+xml")
+                    .set_body_raw("<svg/>", "image/svg+xml"),
+            )
+            .mount(&server)
+            .await;
+        let storage_dir =
+            std::env::temp_dir().join(format!("waddle-link-preview-{}", uuid::Uuid::new_v4()));
+        let storage: Arc<dyn crate::storage::BlobStorage> =
+            Arc::new(crate::storage::LocalStorage::new(storage_dir));
+        let policy = LinkPreviewResolverPolicy {
+            allow_http_loopback_for_tests: true,
+            media_cache: Some(LinkPreviewMediaCache::new(
+                storage.clone(),
+                "https://waddle.example",
+            )),
+            ..Default::default()
+        };
+        let url = Url::parse(&format!("{}/article", server.uri())).expect("url");
+
+        let outcome = resolve_link_preview(&url, &policy).await;
+
+        let LinkPreviewResolverOutcome::Ready(metadata) = outcome else {
+            panic!("expected ready outcome, got {outcome:?}");
+        };
+        assert_eq!(metadata.title.as_deref(), Some("Fetched title"));
+        assert_eq!(metadata.image, None);
+        assert!(storage
+            .get("link-previews/sha256/d4dc56669143034f31aa309635d4113d9ad76a02b1739da22c965ed2049be9e6")
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn follows_safe_preview_image_redirects_before_caching() {
+        let server = MockServer::start().await;
+        let image_bytes = bytes::Bytes::from_static(b"\x89PNG\r\n\x1a\nredirected png");
+        Mock::given(method("GET"))
+            .and(path("/article"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                format!(
+                    r#"<html><head>
+                          <meta property="og:title" content="Fetched title">
+                          <meta property="og:image" content="{}/preview">
+                        </head></html>"#,
+                    server.uri()
+                ),
+                "text/html; charset=utf-8",
+            ))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/preview"))
+            .respond_with(
+                ResponseTemplate::new(302)
+                    .insert_header("location", format!("{}/final.png", server.uri())),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/final.png"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "image/png")
+                    .set_body_bytes(image_bytes.clone()),
+            )
+            .mount(&server)
+            .await;
+        let storage_dir =
+            std::env::temp_dir().join(format!("waddle-link-preview-{}", uuid::Uuid::new_v4()));
+        let storage: Arc<dyn crate::storage::BlobStorage> =
+            Arc::new(crate::storage::LocalStorage::new(storage_dir));
+        let policy = LinkPreviewResolverPolicy {
+            allow_http_loopback_for_tests: true,
+            media_cache: Some(LinkPreviewMediaCache::new(
+                storage.clone(),
+                "https://waddle.example",
+            )),
+            ..Default::default()
+        };
+        let url = Url::parse(&format!("{}/article", server.uri())).expect("url");
+
+        let outcome = resolve_link_preview(&url, &policy).await;
+
+        let LinkPreviewResolverOutcome::Ready(metadata) = outcome else {
+            panic!("expected ready outcome, got {outcome:?}");
+        };
+        let expected_hash = hex::encode(Sha256::digest(image_bytes.as_ref()));
+        assert_eq!(
+            metadata.image.expect("cached image").url.path(),
+            format!("/api/link-preview-media/sha256/{expected_hash}")
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_preview_image_degrades_to_text_metadata() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/article"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                format!(
+                    r#"<html><head>
+                          <meta property="og:title" content="Fetched title">
+                          <meta property="og:image" content="{}/missing.png">
+                        </head></html>"#,
+                    server.uri()
+                ),
+                "text/html; charset=utf-8",
+            ))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/missing.png"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        let storage_dir =
+            std::env::temp_dir().join(format!("waddle-link-preview-{}", uuid::Uuid::new_v4()));
+        let storage: Arc<dyn crate::storage::BlobStorage> =
+            Arc::new(crate::storage::LocalStorage::new(storage_dir));
+        let policy = LinkPreviewResolverPolicy {
+            allow_http_loopback_for_tests: true,
+            media_cache: Some(LinkPreviewMediaCache::new(
+                storage,
+                "https://waddle.example",
+            )),
+            ..Default::default()
+        };
+        let url = Url::parse(&format!("{}/article", server.uri())).expect("url");
+
+        let outcome = resolve_link_preview(&url, &policy).await;
+
+        let LinkPreviewResolverOutcome::Ready(metadata) = outcome else {
+            panic!("expected ready outcome, got {outcome:?}");
+        };
+        assert_eq!(metadata.title.as_deref(), Some("Fetched title"));
+        assert_eq!(metadata.image, None);
+    }
+
+    #[tokio::test]
+    async fn mismatched_preview_image_header_and_bytes_degrades_to_text_metadata() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/article"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                format!(
+                    r#"<html><head>
+                          <meta property="og:title" content="Fetched title">
+                          <meta property="og:image" content="{}/preview.png">
+                        </head></html>"#,
+                    server.uri()
+                ),
+                "text/html; charset=utf-8",
+            ))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/preview.png"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "image/png")
+                    .set_body_bytes(bytes::Bytes::from_static(b"\xff\xd8\xffjpeg")),
+            )
+            .mount(&server)
+            .await;
+        let storage_dir =
+            std::env::temp_dir().join(format!("waddle-link-preview-{}", uuid::Uuid::new_v4()));
+        let storage: Arc<dyn crate::storage::BlobStorage> =
+            Arc::new(crate::storage::LocalStorage::new(storage_dir));
+        let policy = LinkPreviewResolverPolicy {
+            allow_http_loopback_for_tests: true,
+            media_cache: Some(LinkPreviewMediaCache::new(
+                storage,
+                "https://waddle.example",
+            )),
+            ..Default::default()
+        };
+        let url = Url::parse(&format!("{}/article", server.uri())).expect("url");
+
+        let outcome = resolve_link_preview(&url, &policy).await;
+
+        let LinkPreviewResolverOutcome::Ready(metadata) = outcome else {
+            panic!("expected ready outcome, got {outcome:?}");
+        };
+        assert_eq!(metadata.title.as_deref(), Some("Fetched title"));
+        assert_eq!(metadata.image, None);
+    }
+
+    #[tokio::test]
+    async fn cached_image_url_construction_failure_degrades_to_text_metadata() {
+        let server = MockServer::start().await;
+        let image_bytes = bytes::Bytes::from_static(b"\x89PNG\r\n\x1a\nvalid png");
+        Mock::given(method("GET"))
+            .and(path("/article"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                format!(
+                    r#"<html><head>
+                          <meta property="og:title" content="Fetched title">
+                          <meta property="og:image" content="{}/preview.png">
+                        </head></html>"#,
+                    server.uri()
+                ),
+                "text/html; charset=utf-8",
+            ))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/preview.png"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "image/png")
+                    .set_body_bytes(image_bytes),
+            )
+            .mount(&server)
+            .await;
+        let storage_dir =
+            std::env::temp_dir().join(format!("waddle-link-preview-{}", uuid::Uuid::new_v4()));
+        let storage: Arc<dyn crate::storage::BlobStorage> =
+            Arc::new(crate::storage::LocalStorage::new(storage_dir));
+        let policy = LinkPreviewResolverPolicy {
+            allow_http_loopback_for_tests: true,
+            media_cache: Some(LinkPreviewMediaCache::new(storage, "not a url")),
+            ..Default::default()
+        };
+        let url = Url::parse(&format!("{}/article", server.uri())).expect("url");
+
+        let outcome = resolve_link_preview(&url, &policy).await;
+
+        let LinkPreviewResolverOutcome::Ready(metadata) = outcome else {
+            panic!("expected ready outcome, got {outcome:?}");
+        };
+        assert_eq!(metadata.title.as_deref(), Some("Fetched title"));
+        assert_eq!(metadata.image, None);
+    }
+
+    #[tokio::test]
+    async fn cached_image_storage_failure_degrades_to_text_metadata() {
+        let server = MockServer::start().await;
+        let image_bytes = bytes::Bytes::from_static(b"\x89PNG\r\n\x1a\nvalid png");
+        Mock::given(method("GET"))
+            .and(path("/article"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                format!(
+                    r#"<html><head>
+                          <meta property="og:title" content="Fetched title">
+                          <meta property="og:image" content="{}/preview.png">
+                        </head></html>"#,
+                    server.uri()
+                ),
+                "text/html; charset=utf-8",
+            ))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/preview.png"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "image/png")
+                    .set_body_bytes(image_bytes),
+            )
+            .mount(&server)
+            .await;
+        let policy = LinkPreviewResolverPolicy {
+            allow_http_loopback_for_tests: true,
+            media_cache: Some(LinkPreviewMediaCache::new(
+                Arc::new(FailingPutStorage),
+                "https://waddle.example",
+            )),
+            ..Default::default()
+        };
+        let url = Url::parse(&format!("{}/article", server.uri())).expect("url");
+
+        let outcome = resolve_link_preview(&url, &policy).await;
+
+        let LinkPreviewResolverOutcome::Ready(metadata) = outcome else {
+            panic!("expected ready outcome, got {outcome:?}");
+        };
+        assert_eq!(metadata.title.as_deref(), Some("Fetched title"));
+        assert_eq!(metadata.image, None);
+    }
+
+    #[tokio::test]
+    async fn blocked_preview_image_redirect_degrades_to_text_metadata() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/article"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                format!(
+                    r#"<html><head>
+                          <meta property="og:title" content="Fetched title">
+                          <meta property="og:image" content="{}/preview">
+                        </head></html>"#,
+                    server.uri()
+                ),
+                "text/html; charset=utf-8",
+            ))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/preview"))
+            .respond_with(
+                ResponseTemplate::new(302).insert_header("location", "https://127.0.0.1/admin"),
+            )
+            .mount(&server)
+            .await;
+        let storage_dir =
+            std::env::temp_dir().join(format!("waddle-link-preview-{}", uuid::Uuid::new_v4()));
+        let storage: Arc<dyn crate::storage::BlobStorage> =
+            Arc::new(crate::storage::LocalStorage::new(storage_dir));
+        let policy = LinkPreviewResolverPolicy {
+            allow_http_loopback_for_tests: true,
+            media_cache: Some(LinkPreviewMediaCache::new(
+                storage,
+                "https://waddle.example",
+            )),
+            ..Default::default()
+        };
+        let url = Url::parse(&format!("{}/article", server.uri())).expect("url");
+
+        let outcome = resolve_link_preview(&url, &policy).await;
+
+        let LinkPreviewResolverOutcome::Ready(metadata) = outcome else {
+            panic!("expected ready outcome, got {outcome:?}");
+        };
+        assert_eq!(metadata.title.as_deref(), Some("Fetched title"));
+        assert_eq!(metadata.image, None);
+    }
+
+    #[tokio::test]
+    async fn failed_preview_image_response_degrades_to_text_metadata() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/article"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                format!(
+                    r#"<html><head>
+                          <meta property="og:title" content="Fetched title">
+                          <meta property="og:image" content="{}/preview.png">
+                        </head></html>"#,
+                    server.uri()
+                ),
+                "text/html; charset=utf-8",
+            ))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/preview.png"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+        let storage_dir =
+            std::env::temp_dir().join(format!("waddle-link-preview-{}", uuid::Uuid::new_v4()));
+        let storage: Arc<dyn crate::storage::BlobStorage> =
+            Arc::new(crate::storage::LocalStorage::new(storage_dir));
+        let policy = LinkPreviewResolverPolicy {
+            allow_http_loopback_for_tests: true,
+            media_cache: Some(LinkPreviewMediaCache::new(
+                storage,
+                "https://waddle.example",
+            )),
+            ..Default::default()
+        };
+        let url = Url::parse(&format!("{}/article", server.uri())).expect("url");
+
+        let outcome = resolve_link_preview(&url, &policy).await;
+
+        let LinkPreviewResolverOutcome::Ready(metadata) = outcome else {
+            panic!("expected ready outcome, got {outcome:?}");
+        };
+        assert_eq!(metadata.title.as_deref(), Some("Fetched title"));
+        assert_eq!(metadata.image, None);
+    }
+
+    #[tokio::test]
+    async fn timed_out_preview_image_degrades_to_text_metadata() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/article"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                format!(
+                    r#"<html><head>
+                          <meta property="og:title" content="Fetched title">
+                          <meta property="og:image" content="{}/preview.png">
+                        </head></html>"#,
+                    server.uri()
+                ),
+                "text/html; charset=utf-8",
+            ))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/preview.png"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_delay(Duration::from_millis(100))
+                    .insert_header("content-type", "image/png")
+                    .set_body_bytes(bytes::Bytes::from_static(b"\x89PNG\r\n\x1a\nslow png")),
+            )
+            .mount(&server)
+            .await;
+        let storage_dir =
+            std::env::temp_dir().join(format!("waddle-link-preview-{}", uuid::Uuid::new_v4()));
+        let storage: Arc<dyn crate::storage::BlobStorage> =
+            Arc::new(crate::storage::LocalStorage::new(storage_dir));
+        let policy = LinkPreviewResolverPolicy {
+            timeout: Duration::from_millis(20),
+            allow_http_loopback_for_tests: true,
+            media_cache: Some(LinkPreviewMediaCache::new(
+                storage,
+                "https://waddle.example",
+            )),
+            ..Default::default()
+        };
+        let url = Url::parse(&format!("{}/article", server.uri())).expect("url");
+
+        let outcome = resolve_link_preview(&url, &policy).await;
+
+        let LinkPreviewResolverOutcome::Ready(metadata) = outcome else {
+            panic!("expected ready outcome, got {outcome:?}");
+        };
+        assert_eq!(metadata.title.as_deref(), Some("Fetched title"));
+        assert_eq!(metadata.image, None);
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
@@ -3,12 +3,17 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use bytes::Bytes;
+use chrono::Utc;
+use jid::BareJid;
+use kameo::actor::ActorRef;
 use reqwest::header::{CONTENT_TYPE, LOCATION};
 use reqwest::{redirect, Client, StatusCode};
 use sha2::{Digest, Sha256};
 use tracing::warn;
 use url::{Host, Url};
 
+use crate::db::actor::{DbActor, DbExecute};
+use crate::db::Value;
 use crate::storage::BlobStorage;
 
 const DEFAULT_MAX_BYTES: usize = 256 * 1024;
@@ -40,13 +45,22 @@ pub(super) struct ResolvedLinkPreviewImage {
 pub(super) struct LinkPreviewMediaCache {
     storage: Arc<dyn BlobStorage>,
     public_base_url: String,
+    global_db_actor: ActorRef<DbActor>,
+    requester_jid: BareJid,
 }
 
 impl LinkPreviewMediaCache {
-    pub(super) fn new(storage: Arc<dyn BlobStorage>, public_base_url: impl Into<String>) -> Self {
+    pub(super) fn new(
+        storage: Arc<dyn BlobStorage>,
+        public_base_url: impl Into<String>,
+        global_db_actor: ActorRef<DbActor>,
+        requester_jid: BareJid,
+    ) -> Self {
         Self {
             storage,
             public_base_url: public_base_url.into().trim_end_matches('/').to_string(),
+            global_db_actor,
+            requester_jid,
         }
     }
 }
@@ -188,21 +202,14 @@ async fn fetch_cached_preview_image(
                     .iter()
                     .map(|byte| format!("{byte:02x}"))
                     .collect::<String>();
-                let key = format!("link-previews/sha256/{hash}");
-                cache
-                    .storage
-                    .put(&key, bytes, &media_type)
-                    .await
-                    .map_err(|error| {
-                        warn!(%error, key = %key, "failed to cache link preview image");
-                        LinkPreviewResolverStatus::Unsupported
-                    })?;
+                let (slot_id, filename) =
+                    publish_cached_preview_image_slot(cache, &hash, bytes, &media_type).await?;
                 let url = Url::parse(&format!(
-                    "{}/api/link-preview-media/sha256/{hash}",
-                    cache.public_base_url
+                    "{}/api/files/{}/{}",
+                    cache.public_base_url, slot_id, filename
                 ))
                 .map_err(|error| {
-                    warn!(%error, "failed to build cached link preview image URL");
+                    warn!(%error, "failed to build XEP-0363 cached link preview image URL");
                     LinkPreviewResolverStatus::Unsupported
                 })?;
                 return Ok(ResolvedLinkPreviewImage {
@@ -222,6 +229,61 @@ async fn fetch_cached_preview_image(
         }
     }
     Err(LinkPreviewResolverStatus::Failed)
+}
+
+async fn publish_cached_preview_image_slot(
+    cache: &LinkPreviewMediaCache,
+    hash: &str,
+    bytes: Bytes,
+    media_type: &str,
+) -> Result<(String, String), LinkPreviewResolverStatus> {
+    let key = format!("link-previews/sha256/{hash}");
+    cache
+        .storage
+        .put(&key, bytes.clone(), media_type)
+        .await
+        .map_err(|error| {
+            warn!(%error, key = %key, "failed to cache link preview image");
+            LinkPreviewResolverStatus::Unsupported
+        })?;
+
+    let slot_id = uuid::Uuid::new_v4().to_string();
+    let filename = format!(
+        "link-preview-{hash}.{}",
+        preview_image_extension(media_type)
+    );
+    let now = Utc::now();
+    let size_bytes = i64::try_from(bytes.len()).map_err(|_| LinkPreviewResolverStatus::Failed)?;
+    cache
+        .global_db_actor
+        .ask(DbExecute {
+            sql: "INSERT INTO upload_slots (id, requester_jid, filename, size_bytes, content_type, status, storage_key, expires_at, uploaded_at) VALUES (?, ?, ?, ?, ?, 'uploaded', ?, ?, ?)".to_string(),
+            params: vec![
+                Value::from(slot_id.clone()),
+                Value::from(cache.requester_jid.to_string()),
+                Value::from(filename.clone()),
+                Value::from(size_bytes),
+                Value::from(media_type.to_string()),
+                Value::from(key),
+                Value::from((now + chrono::Duration::minutes(15)).to_rfc3339()),
+                Value::from(now.to_rfc3339()),
+            ],
+        })
+        .await
+        .map_err(|error| {
+            warn!(%error, "failed to record XEP-0363 link preview upload slot");
+            LinkPreviewResolverStatus::Unsupported
+        })?;
+    Ok((slot_id, filename))
+}
+
+fn preview_image_extension(media_type: &str) -> &'static str {
+    match media_type {
+        "image/jpeg" => "jpg",
+        "image/gif" => "gif",
+        "image/webp" => "webp",
+        _ => "png",
+    }
 }
 
 enum FetchImageOnceResult {
@@ -819,6 +881,7 @@ fn find_ascii_case_insensitive(haystack: &str, needle: &str) -> Option<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db::{DatabaseConfig, DatabasePool, MigrationRunner, PoolConfig};
     use std::future::Future;
     use std::pin::Pin;
     use std::sync::Arc;
@@ -859,6 +922,33 @@ mod tests {
             let key = key.to_string();
             Box::pin(async { Err(crate::storage::StorageError::NotFound(key)) })
         }
+    }
+
+    async fn test_media_cache(
+        storage: Arc<dyn crate::storage::BlobStorage>,
+    ) -> LinkPreviewMediaCache {
+        let (cache, _) = test_media_cache_with_base_url(storage, "https://waddle.example").await;
+        cache
+    }
+
+    async fn test_media_cache_with_base_url(
+        storage: Arc<dyn crate::storage::BlobStorage>,
+        base_url: &str,
+    ) -> (LinkPreviewMediaCache, DatabasePool) {
+        let db_pool = DatabasePool::new(DatabaseConfig::default(), PoolConfig)
+            .await
+            .expect("db pool");
+        MigrationRunner::global()
+            .run(db_pool.global())
+            .await
+            .expect("migrations");
+        let cache = LinkPreviewMediaCache::new(
+            storage,
+            base_url,
+            db_pool.global_actor().clone(),
+            "alice@example.com".parse().expect("jid"),
+        );
+        (cache, db_pool)
     }
 
     #[test]
@@ -1161,12 +1251,11 @@ mod tests {
             std::env::temp_dir().join(format!("waddle-link-preview-{}", uuid::Uuid::new_v4()));
         let storage: Arc<dyn crate::storage::BlobStorage> =
             Arc::new(crate::storage::LocalStorage::new(storage_dir));
+        let (media_cache, db_pool) =
+            test_media_cache_with_base_url(storage.clone(), "https://waddle.example").await;
         let policy = LinkPreviewResolverPolicy {
             allow_http_loopback_for_tests: true,
-            media_cache: Some(LinkPreviewMediaCache::new(
-                storage.clone(),
-                "https://waddle.example",
-            )),
+            media_cache: Some(media_cache),
             ..Default::default()
         };
         let url = Url::parse(&format!("{}/article", server.uri())).expect("url");
@@ -1181,14 +1270,43 @@ mod tests {
         let image = metadata.image.expect("cached image metadata");
         assert_eq!(image.url.scheme(), "https");
         assert_eq!(image.url.domain(), Some("waddle.example"));
-        assert_eq!(
-            image.url.path(),
-            format!("/api/link-preview-media/sha256/{expected_hash}")
-        );
+        assert!(image.url.path().starts_with("/api/files/"));
+        assert!(image
+            .url
+            .path()
+            .ends_with(&format!("/link-preview-{expected_hash}.png")));
         assert_eq!(image.media_type, "image/png");
         assert_eq!(image.width, Some(640));
         assert_eq!(image.height, Some(360));
         assert_eq!(image.alt.as_deref(), Some("Article screenshot"));
+        let slot_id = image
+            .url
+            .path_segments()
+            .and_then(|mut segments| segments.nth(2))
+            .expect("slot id");
+        let db = db_pool.global().guard().await.expect("db");
+        let mut rows = db
+            .query(
+                "SELECT filename, status, storage_key FROM upload_slots WHERE id = ?",
+                crate::db_params![slot_id],
+            )
+            .await
+            .expect("slot row");
+        let row = rows
+            .next()
+            .await
+            .expect("next row")
+            .expect("slot row exists");
+        assert_eq!(
+            row.get::<String>(0).expect("filename"),
+            format!("link-preview-{expected_hash}.png")
+        );
+        assert_eq!(row.get::<String>(1).expect("status"), "uploaded");
+        assert_eq!(
+            row.get::<Option<String>>(2).expect("storage_key"),
+            Some(expected_key.clone())
+        );
+        assert!(rows.next().await.expect("next row").is_none());
         let (stored, meta) = storage.get(&expected_key).await.expect("cached bytes");
         assert_eq!(stored, image_bytes);
         assert_eq!(meta.content_type, "image/png");
@@ -1226,10 +1344,7 @@ mod tests {
             Arc::new(crate::storage::LocalStorage::new(storage_dir));
         let policy = LinkPreviewResolverPolicy {
             allow_http_loopback_for_tests: true,
-            media_cache: Some(LinkPreviewMediaCache::new(
-                storage.clone(),
-                "https://waddle.example",
-            )),
+            media_cache: Some(test_media_cache(storage.clone()).await),
             ..Default::default()
         };
         let url = Url::parse(&format!("{}/article", server.uri())).expect("url");
@@ -1288,10 +1403,7 @@ mod tests {
             Arc::new(crate::storage::LocalStorage::new(storage_dir));
         let policy = LinkPreviewResolverPolicy {
             allow_http_loopback_for_tests: true,
-            media_cache: Some(LinkPreviewMediaCache::new(
-                storage.clone(),
-                "https://waddle.example",
-            )),
+            media_cache: Some(test_media_cache(storage.clone()).await),
             ..Default::default()
         };
         let url = Url::parse(&format!("{}/article", server.uri())).expect("url");
@@ -1302,10 +1414,12 @@ mod tests {
             panic!("expected ready outcome, got {outcome:?}");
         };
         let expected_hash = hex::encode(Sha256::digest(image_bytes.as_ref()));
-        assert_eq!(
-            metadata.image.expect("cached image").url.path(),
-            format!("/api/link-preview-media/sha256/{expected_hash}")
-        );
+        let image = metadata.image.expect("cached image");
+        assert!(image.url.path().starts_with("/api/files/"));
+        assert!(image
+            .url
+            .path()
+            .ends_with(&format!("/link-preview-{expected_hash}.png")));
     }
 
     #[tokio::test]
@@ -1336,10 +1450,7 @@ mod tests {
             Arc::new(crate::storage::LocalStorage::new(storage_dir));
         let policy = LinkPreviewResolverPolicy {
             allow_http_loopback_for_tests: true,
-            media_cache: Some(LinkPreviewMediaCache::new(
-                storage,
-                "https://waddle.example",
-            )),
+            media_cache: Some(test_media_cache(storage).await),
             ..Default::default()
         };
         let url = Url::parse(&format!("{}/article", server.uri())).expect("url");
@@ -1385,10 +1496,7 @@ mod tests {
             Arc::new(crate::storage::LocalStorage::new(storage_dir));
         let policy = LinkPreviewResolverPolicy {
             allow_http_loopback_for_tests: true,
-            media_cache: Some(LinkPreviewMediaCache::new(
-                storage,
-                "https://waddle.example",
-            )),
+            media_cache: Some(test_media_cache(storage).await),
             ..Default::default()
         };
         let url = Url::parse(&format!("{}/article", server.uri())).expect("url");
@@ -1435,7 +1543,7 @@ mod tests {
             Arc::new(crate::storage::LocalStorage::new(storage_dir));
         let policy = LinkPreviewResolverPolicy {
             allow_http_loopback_for_tests: true,
-            media_cache: Some(LinkPreviewMediaCache::new(storage, "not a url")),
+            media_cache: Some(test_media_cache_with_base_url(storage, "not a url").await.0),
             ..Default::default()
         };
         let url = Url::parse(&format!("{}/article", server.uri())).expect("url");
@@ -1478,10 +1586,7 @@ mod tests {
             .await;
         let policy = LinkPreviewResolverPolicy {
             allow_http_loopback_for_tests: true,
-            media_cache: Some(LinkPreviewMediaCache::new(
-                Arc::new(FailingPutStorage),
-                "https://waddle.example",
-            )),
+            media_cache: Some(test_media_cache(Arc::new(FailingPutStorage)).await),
             ..Default::default()
         };
         let url = Url::parse(&format!("{}/article", server.uri())).expect("url");
@@ -1525,10 +1630,7 @@ mod tests {
             Arc::new(crate::storage::LocalStorage::new(storage_dir));
         let policy = LinkPreviewResolverPolicy {
             allow_http_loopback_for_tests: true,
-            media_cache: Some(LinkPreviewMediaCache::new(
-                storage,
-                "https://waddle.example",
-            )),
+            media_cache: Some(test_media_cache(storage).await),
             ..Default::default()
         };
         let url = Url::parse(&format!("{}/article", server.uri())).expect("url");
@@ -1570,10 +1672,7 @@ mod tests {
             Arc::new(crate::storage::LocalStorage::new(storage_dir));
         let policy = LinkPreviewResolverPolicy {
             allow_http_loopback_for_tests: true,
-            media_cache: Some(LinkPreviewMediaCache::new(
-                storage,
-                "https://waddle.example",
-            )),
+            media_cache: Some(test_media_cache(storage).await),
             ..Default::default()
         };
         let url = Url::parse(&format!("{}/article", server.uri())).expect("url");
@@ -1621,10 +1720,7 @@ mod tests {
         let policy = LinkPreviewResolverPolicy {
             timeout: Duration::from_millis(20),
             allow_http_loopback_for_tests: true,
-            media_cache: Some(LinkPreviewMediaCache::new(
-                storage,
-                "https://waddle.example",
-            )),
+            media_cache: Some(test_media_cache(storage).await),
             ..Default::default()
         };
         let url = Url::parse(&format!("{}/article", server.uri())).expect("url");

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
@@ -11,6 +11,7 @@ use reqwest::{redirect, Client, StatusCode};
 use sha2::{Digest, Sha256};
 use tracing::warn;
 use url::{Host, Url};
+use waddle_xmpp_core::PreviewImageMediaType;
 
 use crate::db::actor::{DbActor, DbExecute};
 use crate::db::Value;
@@ -35,7 +36,7 @@ pub(super) struct ResolvedLinkMetadata {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct ResolvedLinkPreviewImage {
     pub url: Url,
-    pub media_type: String,
+    pub media_type: PreviewImageMediaType,
     pub width: Option<u32>,
     pub height: Option<u32>,
     pub alt: Option<String>,
@@ -197,13 +198,10 @@ async fn fetch_cached_preview_image(
         };
         match fetch_image_once(&current, policy, timeout).await? {
             FetchImageOnceResult::Image { bytes, media_type } => {
-                let digest = Sha256::digest(bytes.as_ref());
-                let hash = digest
-                    .iter()
-                    .map(|byte| format!("{byte:02x}"))
-                    .collect::<String>();
+                let hash = hex::encode(Sha256::digest(bytes.as_ref()));
                 let (slot_id, filename) =
-                    publish_cached_preview_image_slot(cache, &hash, bytes, &media_type).await?;
+                    publish_cached_preview_image_slot(cache, &hash, bytes, media_type.as_str())
+                        .await?;
                 let url = Url::parse(&format!(
                     "{}/api/files/{}/{}",
                     cache.public_base_url, slot_id, filename
@@ -287,7 +285,10 @@ fn preview_image_extension(media_type: &str) -> &'static str {
 }
 
 enum FetchImageOnceResult {
-    Image { bytes: Bytes, media_type: String },
+    Image {
+        bytes: Bytes,
+        media_type: PreviewImageMediaType,
+    },
     Redirect(Url),
 }
 
@@ -699,32 +700,29 @@ fn extract_metadata_parts_from_html(
     ))
 }
 
-fn safe_preview_image_media_type(value: &str) -> Option<String> {
+fn safe_preview_image_media_type(value: &str) -> Option<PreviewImageMediaType> {
     let media_type = value
         .split(';')
         .next()
         .unwrap_or(value)
         .trim()
-        .to_ascii_lowercase();
-    matches!(
-        media_type.as_str(),
-        "image/png" | "image/jpeg" | "image/gif" | "image/webp"
-    )
-    .then_some(media_type)
+        .parse()
+        .ok()?;
+    Some(media_type)
 }
 
-fn sniff_safe_preview_image_media_type(bytes: &[u8]) -> Option<String> {
+fn sniff_safe_preview_image_media_type(bytes: &[u8]) -> Option<PreviewImageMediaType> {
     if bytes.starts_with(b"\x89PNG\r\n\x1a\n") {
-        return Some("image/png".to_string());
+        return Some(PreviewImageMediaType::Png);
     }
     if bytes.starts_with(b"\xff\xd8\xff") {
-        return Some("image/jpeg".to_string());
+        return Some(PreviewImageMediaType::Jpeg);
     }
     if bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a") {
-        return Some("image/gif".to_string());
+        return Some(PreviewImageMediaType::Gif);
     }
     if bytes.len() >= 12 && &bytes[..4] == b"RIFF" && &bytes[8..12] == b"WEBP" {
-        return Some("image/webp".to_string());
+        return Some(PreviewImageMediaType::Webp);
     }
     None
 }
@@ -1275,7 +1273,7 @@ mod tests {
             .url
             .path()
             .ends_with(&format!("/link-preview-{expected_hash}.png")));
-        assert_eq!(image.media_type, "image/png");
+        assert_eq!(image.media_type, PreviewImageMediaType::Png);
         assert_eq!(image.width, Some(640));
         assert_eq!(image.height, Some(360));
         assert_eq!(image.alt.as_deref(), Some("Article screenshot"));

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -14,6 +14,8 @@ use waddle_xmpp::{
     Stanza,
 };
 use waddle_xmpp_core::first_eligible_https_url_text;
+#[cfg(test)]
+use waddle_xmpp_core::PreviewImageMediaType;
 
 use super::super::{
     interpret_loop::build_interpret_deps, replay::drive_interpret_loop, WebSocketState,
@@ -170,7 +172,6 @@ fn is_trusted_cached_preview_image_url(url: &url::Url, trusted_media_base_url: &
     trusted_preview_schemes_match(url, &trusted)
         && url.host_str() == trusted.host_str()
         && url.port_or_known_default() == trusted.port_or_known_default()
-        && trusted.port() == url.port()
         && is_link_preview_xep0363_file_path(url.path())
 }
 
@@ -303,6 +304,27 @@ mod tests {
     }
 
     #[test]
+    fn trusts_cached_preview_image_urls_with_explicit_default_ports() {
+        let https_with_default_port = url::Url::parse(
+            "https://waddle.example:443/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png",
+        )
+        .expect("url");
+        let loopback_with_default_port = url::Url::parse(
+            "http://localhost:80/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png",
+        )
+        .expect("url");
+
+        assert!(is_trusted_cached_preview_image_url(
+            &https_with_default_port,
+            "https://waddle.example"
+        ));
+        assert!(is_trusted_cached_preview_image_url(
+            &loopback_with_default_port,
+            "http://localhost"
+        ));
+    }
+
+    #[test]
     fn consumes_link_preview_request_and_stamps_xep0511_metadata() {
         let preview = waddle_xmpp::xep::LinkPreviewTokenData {
             sender_jid: "alice@example.com".parse().expect("jid"),
@@ -320,7 +342,7 @@ mod tests {
                     "https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png",
                 )
                 .expect("url"),
-                media_type: "image/png".to_string(),
+                media_type: PreviewImageMediaType::Png,
                 width: Some(640),
                 height: Some(360),
                 alt: Some("Article screenshot".to_string()),
@@ -360,7 +382,10 @@ mod tests {
             parsed[0].images[0].url.as_str(),
             "https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png"
         );
-        assert_eq!(parsed[0].images[0].media_type.as_deref(), Some("image/png"));
+        assert_eq!(
+            parsed[0].images[0].media_type,
+            Some(PreviewImageMediaType::Png)
+        );
         let references = waddle_xmpp::xep::extract_references_from_message(&message);
         assert_eq!(references.len(), 1);
         assert_eq!(
@@ -391,7 +416,7 @@ mod tests {
                     "https://attacker.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png",
                 )
                 .expect("url"),
-                media_type: "image/png".to_string(),
+                media_type: PreviewImageMediaType::Png,
                 width: Some(640),
                 height: Some(360),
                 alt: Some("Article screenshot".to_string()),

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -6,10 +6,10 @@ use waddle_xmpp::{
     protocol::handlers::errors::bad_request_reply,
     protocol::{frame::InboundFrame, InboundEvent, XmppStateMachine},
     xep::{
-        build_link_metadata_element, decode_link_preview_token,
+        add_reference, build_link_metadata_element, decode_link_preview_token,
         extract_link_preview_request_from_message, parse_fallbacks_from_message,
         strip_fallback_ranges, strip_link_metadata, strip_link_preview_requests, FallbackRegion,
-        LinkMetadata, NS_DELAY, NS_REPLY,
+        LinkMetadata, Reference, NS_DELAY, NS_REPLY,
     },
     Stanza,
 };
@@ -74,6 +74,7 @@ pub async fn handle_message(
         &bound_jid,
         state.deps.occupant_id_secret.key(),
         chrono::Utc::now().timestamp(),
+        state.deps.auth_state.base_url.as_str(),
     );
 
     if incoming.type_ != xmpp_parsers::message::MessageType::Groupchat
@@ -115,6 +116,7 @@ fn consume_link_preview_request(
     sender_jid: &jid::FullJid,
     secret: &[u8],
     now_unix: i64,
+    trusted_media_base_url: &str,
 ) {
     let expected_sender = sender_jid.to_bare();
     let expected_scope = message.to.as_ref().map(|to| to.to_bare());
@@ -136,6 +138,20 @@ fn consume_link_preview_request(
             if let Some(description) = preview.description {
                 metadata = metadata.with_description(description);
             }
+            if let Some(image) = preview.image.filter(|image| {
+                is_trusted_cached_preview_image_url(&image.url, trusted_media_base_url)
+            }) {
+                add_reference(message, &Reference::data(image.url.as_str()));
+                let mut preview_image = waddle_xmpp::xep::LinkPreviewImage::new(image.url)
+                    .with_media_type(image.media_type);
+                if let (Some(width), Some(height)) = (image.width, image.height) {
+                    preview_image = preview_image.with_dimensions(width, height);
+                }
+                if let Some(alt) = image.alt {
+                    preview_image = preview_image.with_alt(alt);
+                }
+                metadata = metadata.with_image(preview_image);
+            }
             metadata
         });
     strip_link_preview_requests(message);
@@ -145,6 +161,38 @@ fn consume_link_preview_request(
             .payloads
             .push(build_link_metadata_element(&metadata));
     }
+}
+
+fn is_trusted_cached_preview_image_url(url: &url::Url, trusted_media_base_url: &str) -> bool {
+    let Ok(trusted) = url::Url::parse(trusted_media_base_url) else {
+        return false;
+    };
+    trusted_preview_schemes_match(url, &trusted)
+        && url.host_str() == trusted.host_str()
+        && url.port_or_known_default() == trusted.port_or_known_default()
+        && trusted.port() == url.port()
+        && is_link_preview_media_hash_path(url.path())
+}
+
+fn trusted_preview_schemes_match(url: &url::Url, trusted: &url::Url) -> bool {
+    if url.scheme() == "https" && trusted.scheme() == "https" {
+        return true;
+    }
+    url.scheme() == "http" && trusted.scheme() == "http" && is_loopback_host(url.host_str())
+}
+
+fn is_loopback_host(host: Option<&str>) -> bool {
+    matches!(host, Some("localhost"))
+        || host
+            .and_then(|host| host.parse::<std::net::IpAddr>().ok())
+            .is_some_and(|ip| ip.is_loopback())
+}
+
+fn is_link_preview_media_hash_path(path: &str) -> bool {
+    let Some(hash) = path.strip_prefix("/api/link-preview-media/sha256/") else {
+        return false;
+    };
+    hash.len() == 64 && hash.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
 fn first_eligible_https_url(message: &xmpp_parsers::message::Message) -> Option<url::Url> {
@@ -216,6 +264,27 @@ mod tests {
     }
 
     #[test]
+    fn cached_preview_image_url_trust_allows_loopback_http_only_for_matching_origin() {
+        let loopback = url::Url::parse(
+            "http://localhost:3000/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16",
+        )
+        .expect("url");
+        let non_loopback = url::Url::parse(
+            "http://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16",
+        )
+        .expect("url");
+
+        assert!(is_trusted_cached_preview_image_url(
+            &loopback,
+            "http://localhost:3000"
+        ));
+        assert!(!is_trusted_cached_preview_image_url(
+            &non_loopback,
+            "http://waddle.example"
+        ));
+    }
+
+    #[test]
     fn consumes_link_preview_request_and_stamps_xep0511_metadata() {
         let preview = waddle_xmpp::xep::LinkPreviewTokenData {
             sender_jid: "alice@example.com".parse().expect("jid"),
@@ -228,6 +297,16 @@ mod tests {
             .expect("url"),
             title: Some("The Best Webpage".to_string()),
             description: Some("This is a great webpage and you will really like it".to_string()),
+            image: Some(waddle_xmpp::xep::LinkPreviewTokenImage {
+                url: url::Url::parse(
+                    "https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16",
+                )
+                .expect("url"),
+                media_type: "image/png".to_string(),
+                width: Some(640),
+                height: Some(360),
+                alt: Some("Article screenshot".to_string()),
+            }),
             expires_at_unix: 1_900_000_000,
         };
         let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
@@ -241,7 +320,13 @@ mod tests {
             .payloads
             .push(waddle_xmpp::xep::build_link_preview_request_element(&token));
 
-        consume_link_preview_request(&mut message, &sender(), SECRET, 1_800_000_000);
+        consume_link_preview_request(
+            &mut message,
+            &sender(),
+            SECRET,
+            1_800_000_000,
+            "https://waddle.example",
+        );
 
         assert!(message
             .payloads
@@ -252,6 +337,73 @@ mod tests {
         assert_eq!(parsed[0].about, preview.original_url);
         assert_eq!(parsed[0].canonical_url, Some(preview.normalized_url));
         assert_eq!(parsed[0].title.as_deref(), Some("The Best Webpage"));
+        assert_eq!(parsed[0].images.len(), 1);
+        assert_eq!(
+            parsed[0].images[0].url.as_str(),
+            "https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16"
+        );
+        assert_eq!(parsed[0].images[0].media_type.as_deref(), Some("image/png"));
+        let references = waddle_xmpp::xep::extract_references_from_message(&message);
+        assert_eq!(references.len(), 1);
+        assert_eq!(
+            references[0].uri,
+            "https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16"
+        );
+        assert_eq!(
+            references[0].ref_type,
+            waddle_xmpp::xep::ReferenceType::Data
+        );
+    }
+
+    #[test]
+    fn link_preview_request_with_foreign_cached_image_origin_stamps_text_metadata_only() {
+        let preview = waddle_xmpp::xep::LinkPreviewTokenData {
+            sender_jid: "alice@example.com".parse().expect("jid"),
+            scope_jid: "room@muc.example.com".parse().expect("jid"),
+            original_url: url::Url::parse("https://the.link.example.com/what-was-linked-to")
+                .expect("url"),
+            normalized_url: url::Url::parse(
+                "https://example.com/canonical-url/for/what-was-linked-to",
+            )
+            .expect("url"),
+            title: Some("The Best Webpage".to_string()),
+            description: Some("This is a great webpage and you will really like it".to_string()),
+            image: Some(waddle_xmpp::xep::LinkPreviewTokenImage {
+                url: url::Url::parse(
+                    "https://attacker.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16",
+                )
+                .expect("url"),
+                media_type: "image/png".to_string(),
+                width: Some(640),
+                height: Some(360),
+                alt: Some("Article screenshot".to_string()),
+            }),
+            expires_at_unix: 1_900_000_000,
+        };
+        let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
+        let mut message = Message::new(None::<jid::Jid>);
+        message.to = Some("room@muc.example.com".parse().expect("jid"));
+        message.bodies.insert(
+            xmpp_parsers::message::Lang::new(),
+            "read https://the.link.example.com/what-was-linked-to".to_string(),
+        );
+        message
+            .payloads
+            .push(waddle_xmpp::xep::build_link_preview_request_element(&token));
+
+        consume_link_preview_request(
+            &mut message,
+            &sender(),
+            SECRET,
+            1_800_000_000,
+            "https://waddle.example",
+        );
+
+        let parsed = waddle_xmpp::xep::extract_link_metadata_from_message(&message);
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].title.as_deref(), Some("The Best Webpage"));
+        assert!(parsed[0].images.is_empty());
+        assert!(waddle_xmpp::xep::extract_references_from_message(&message).is_empty());
     }
 
     #[test]
@@ -263,6 +415,7 @@ mod tests {
             normalized_url: url::Url::parse("https://example.com/").expect("url"),
             title: Some("Example".to_string()),
             description: None,
+            image: None,
             expires_at_unix: 10,
         };
         let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
@@ -276,7 +429,13 @@ mod tests {
             .payloads
             .push(waddle_xmpp::xep::build_link_preview_request_element(&token));
 
-        consume_link_preview_request(&mut message, &sender(), SECRET, 11);
+        consume_link_preview_request(
+            &mut message,
+            &sender(),
+            SECRET,
+            11,
+            "https://waddle.example",
+        );
 
         assert!(message.payloads.is_empty());
     }
@@ -295,7 +454,13 @@ mod tests {
             .payloads
             .push(waddle_xmpp::xep::build_link_preview_request_element(&token));
 
-        consume_link_preview_request(&mut message, &sender(), SECRET, 1_800_000_000);
+        consume_link_preview_request(
+            &mut message,
+            &sender(),
+            SECRET,
+            1_800_000_000,
+            "https://waddle.example",
+        );
 
         assert!(message.payloads.is_empty());
     }
@@ -320,7 +485,13 @@ mod tests {
             .build(),
         );
 
-        consume_link_preview_request(&mut message, &sender(), SECRET, 1_800_000_000);
+        consume_link_preview_request(
+            &mut message,
+            &sender(),
+            SECRET,
+            1_800_000_000,
+            "https://waddle.example",
+        );
 
         assert!(message.payloads.is_empty());
     }
@@ -334,6 +505,7 @@ mod tests {
             normalized_url: url::Url::parse("https://example.com/").expect("url"),
             title: Some("Example".to_string()),
             description: None,
+            image: None,
             expires_at_unix: 1_900_000_000,
         };
         let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
@@ -347,7 +519,13 @@ mod tests {
             .payloads
             .push(waddle_xmpp::xep::build_link_preview_request_element(&token));
 
-        consume_link_preview_request(&mut message, &sender(), SECRET, 1_800_000_000);
+        consume_link_preview_request(
+            &mut message,
+            &sender(),
+            SECRET,
+            1_800_000_000,
+            "https://waddle.example",
+        );
 
         assert!(message.payloads.is_empty());
     }
@@ -361,6 +539,7 @@ mod tests {
             normalized_url: url::Url::parse("https://example.com/").expect("url"),
             title: Some("Example".to_string()),
             description: None,
+            image: None,
             expires_at_unix: 1_900_000_000,
         };
         let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
@@ -374,7 +553,13 @@ mod tests {
             .payloads
             .push(waddle_xmpp::xep::build_link_preview_request_element(&token));
 
-        consume_link_preview_request(&mut message, &sender(), SECRET, 1_800_000_000);
+        consume_link_preview_request(
+            &mut message,
+            &sender(),
+            SECRET,
+            1_800_000_000,
+            "https://waddle.example",
+        );
 
         assert!(message.payloads.is_empty());
     }
@@ -388,6 +573,7 @@ mod tests {
             normalized_url: url::Url::parse("https://second.example.com/").expect("url"),
             title: Some("Second".to_string()),
             description: None,
+            image: None,
             expires_at_unix: 1_900_000_000,
         };
         let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
@@ -401,7 +587,13 @@ mod tests {
             .payloads
             .push(waddle_xmpp::xep::build_link_preview_request_element(&token));
 
-        consume_link_preview_request(&mut message, &sender(), SECRET, 1_800_000_000);
+        consume_link_preview_request(
+            &mut message,
+            &sender(),
+            SECRET,
+            1_800_000_000,
+            "https://waddle.example",
+        );
 
         assert!(message.payloads.is_empty());
     }
@@ -415,6 +607,7 @@ mod tests {
             normalized_url: url::Url::parse("https://example.com/a").expect("url"),
             title: Some("Example".to_string()),
             description: None,
+            image: None,
             expires_at_unix: 1_900_000_000,
         };
         let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
@@ -428,7 +621,13 @@ mod tests {
             .payloads
             .push(waddle_xmpp::xep::build_link_preview_request_element(&token));
 
-        consume_link_preview_request(&mut message, &sender(), SECRET, 1_800_000_000);
+        consume_link_preview_request(
+            &mut message,
+            &sender(),
+            SECRET,
+            1_800_000_000,
+            "https://waddle.example",
+        );
 
         assert_eq!(
             waddle_xmpp::xep::extract_link_metadata_from_message(&message).len(),
@@ -445,6 +644,7 @@ mod tests {
             normalized_url: url::Url::parse("https://example.com/a").expect("url"),
             title: Some("Example".to_string()),
             description: None,
+            image: None,
             expires_at_unix: 1_900_000_000,
         };
         let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
@@ -458,7 +658,13 @@ mod tests {
             .payloads
             .push(waddle_xmpp::xep::build_link_preview_request_element(&token));
 
-        consume_link_preview_request(&mut message, &sender(), SECRET, 1_800_000_000);
+        consume_link_preview_request(
+            &mut message,
+            &sender(),
+            SECRET,
+            1_800_000_000,
+            "https://waddle.example",
+        );
 
         assert_eq!(
             waddle_xmpp::xep::extract_link_metadata_from_message(&message).len(),
@@ -475,6 +681,7 @@ mod tests {
             normalized_url: url::Url::parse("https://example.com/").expect("url"),
             title: Some("Example".to_string()),
             description: None,
+            image: None,
             expires_at_unix: 1_900_000_000,
         };
         let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
@@ -488,7 +695,13 @@ mod tests {
             .payloads
             .push(waddle_xmpp::xep::build_link_preview_request_element(&token));
 
-        consume_link_preview_request(&mut message, &sender(), SECRET, 1_800_000_000);
+        consume_link_preview_request(
+            &mut message,
+            &sender(),
+            SECRET,
+            1_800_000_000,
+            "https://waddle.example",
+        );
 
         assert_eq!(
             waddle_xmpp::xep::extract_link_metadata_from_message(&message).len(),
@@ -505,6 +718,7 @@ mod tests {
             normalized_url: url::Url::parse("https://current.example.com/").expect("url"),
             title: Some("Current".to_string()),
             description: None,
+            image: None,
             expires_at_unix: 1_900_000_000,
         };
         let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
@@ -528,7 +742,13 @@ mod tests {
             .payloads
             .push(waddle_xmpp::xep::build_link_preview_request_element(&token));
 
-        consume_link_preview_request(&mut message, &sender(), SECRET, 1_800_000_000);
+        consume_link_preview_request(
+            &mut message,
+            &sender(),
+            SECRET,
+            1_800_000_000,
+            "https://waddle.example",
+        );
 
         let parsed = waddle_xmpp::xep::extract_link_metadata_from_message(&message);
         assert_eq!(parsed.len(), 1);
@@ -551,7 +771,13 @@ mod tests {
             .payloads
             .push(waddle_xmpp::xep::build_link_metadata_element(&forged));
 
-        consume_link_preview_request(&mut message, &sender(), SECRET, 1_800_000_000);
+        consume_link_preview_request(
+            &mut message,
+            &sender(),
+            SECRET,
+            1_800_000_000,
+            "https://waddle.example",
+        );
 
         assert!(message.payloads.is_empty());
     }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -171,7 +171,7 @@ fn is_trusted_cached_preview_image_url(url: &url::Url, trusted_media_base_url: &
         && url.host_str() == trusted.host_str()
         && url.port_or_known_default() == trusted.port_or_known_default()
         && trusted.port() == url.port()
-        && is_link_preview_media_hash_path(url.path())
+        && is_link_preview_xep0363_file_path(url.path())
 }
 
 fn trusted_preview_schemes_match(url: &url::Url, trusted: &url::Url) -> bool {
@@ -188,11 +188,29 @@ fn is_loopback_host(host: Option<&str>) -> bool {
             .is_some_and(|ip| ip.is_loopback())
 }
 
-fn is_link_preview_media_hash_path(path: &str) -> bool {
-    let Some(hash) = path.strip_prefix("/api/link-preview-media/sha256/") else {
+fn is_link_preview_xep0363_file_path(path: &str) -> bool {
+    let Some(rest) = path.strip_prefix("/api/files/") else {
         return false;
     };
-    hash.len() == 64 && hash.bytes().all(|byte| byte.is_ascii_hexdigit())
+    let mut parts = rest.split('/');
+    let Some(slot_id) = parts.next() else {
+        return false;
+    };
+    let Some(filename) = parts.next() else {
+        return false;
+    };
+    if parts.next().is_some() || uuid::Uuid::parse_str(slot_id).is_err() {
+        return false;
+    }
+    let Some(name) = filename.strip_prefix("link-preview-") else {
+        return false;
+    };
+    let Some((hash, extension)) = name.rsplit_once('.') else {
+        return false;
+    };
+    matches!(extension, "png" | "jpg" | "gif" | "webp")
+        && hash.len() == 64
+        && hash.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
 fn first_eligible_https_url(message: &xmpp_parsers::message::Message) -> Option<url::Url> {
@@ -266,11 +284,11 @@ mod tests {
     #[test]
     fn cached_preview_image_url_trust_allows_loopback_http_only_for_matching_origin() {
         let loopback = url::Url::parse(
-            "http://localhost:3000/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16",
+            "http://localhost:3000/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png",
         )
         .expect("url");
         let non_loopback = url::Url::parse(
-            "http://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16",
+            "http://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png",
         )
         .expect("url");
 
@@ -299,7 +317,7 @@ mod tests {
             description: Some("This is a great webpage and you will really like it".to_string()),
             image: Some(waddle_xmpp::xep::LinkPreviewTokenImage {
                 url: url::Url::parse(
-                    "https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16",
+                    "https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png",
                 )
                 .expect("url"),
                 media_type: "image/png".to_string(),
@@ -340,14 +358,14 @@ mod tests {
         assert_eq!(parsed[0].images.len(), 1);
         assert_eq!(
             parsed[0].images[0].url.as_str(),
-            "https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16"
+            "https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png"
         );
         assert_eq!(parsed[0].images[0].media_type.as_deref(), Some("image/png"));
         let references = waddle_xmpp::xep::extract_references_from_message(&message);
         assert_eq!(references.len(), 1);
         assert_eq!(
             references[0].uri,
-            "https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16"
+            "https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png"
         );
         assert_eq!(
             references[0].ref_type,
@@ -370,7 +388,7 @@ mod tests {
             description: Some("This is a great webpage and you will really like it".to_string()),
             image: Some(waddle_xmpp::xep::LinkPreviewTokenImage {
                 url: url::Url::parse(
-                    "https://attacker.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16",
+                    "https://attacker.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png",
                 )
                 .expect("url"),
                 media_type: "image/png".to_string(),

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
@@ -3751,6 +3751,7 @@ async fn groupchat_preview_request_is_stamped_and_archived_without_private_paylo
         normalized_url: url::Url::parse("https://the.link.example/what-was-linked").expect("url"),
         title: Some("The Best Webpage".to_string()),
         description: Some("Plain text preview".to_string()),
+        image: None,
         expires_at_unix: chrono::Utc::now().timestamp() + 300,
     };
     let token =

--- a/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
@@ -442,7 +442,7 @@ fn link_previews_to_js(previews: Vec<messaging::LinkPreviewData>) -> Vec<WaddleL
             description: preview.description,
             image: preview.image.map(|image| WaddleLinkPreviewImage {
                 url: image.url.to_string(),
-                media_type: image.media_type,
+                media_type: image.media_type.as_str().to_string(),
                 width: image.width,
                 height: image.height,
                 alt: image.alt,

--- a/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
@@ -828,7 +828,7 @@ mod inbound_to_js_tests {
                        <og:title>The Best Webpage</og:title>\
                        <og:description>Plain text preview</og:description>\
                        <og:url>https://the.link.example/what-was-linked</og:url>\
-                       <og:image>https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16</og:image>\
+                       <og:image>https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png</og:image>\
                        <ogi:type>image/png</ogi:type>\
                        <ogi:width>640</ogi:width>\
                        <ogi:height>360</ogi:height>\
@@ -857,7 +857,7 @@ mod inbound_to_js_tests {
         let image = preview.image.as_ref().expect("cached image");
         assert_eq!(
             image.url,
-            "https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16"
+            "https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png"
         );
         assert_eq!(image.media_type, "image/png");
         assert_eq!(image.width, Some(640));

--- a/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
@@ -440,6 +440,13 @@ fn link_previews_to_js(previews: Vec<messaging::LinkPreviewData>) -> Vec<WaddleL
             normalized_url: preview.normalized_url.map(|url| url.to_string()),
             title: preview.title,
             description: preview.description,
+            image: preview.image.map(|image| WaddleLinkPreviewImage {
+                url: image.url.to_string(),
+                media_type: image.media_type,
+                width: image.width,
+                height: image.height,
+                alt: image.alt,
+            }),
         })
         .collect()
 }
@@ -817,10 +824,15 @@ mod inbound_to_js_tests {
                    <message xmlns='jabber:client' type='groupchat' id='m-link' \
                             from='room@conf.example/alice'>\
                      <body>see https://the.link.example/what-was-linked</body>\
-                     <rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#' rdf:about='https://the.link.example/what-was-linked'>\
+                     <rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#' xmlns:ogi='https://ogp.me/ns#image:' rdf:about='https://the.link.example/what-was-linked'>\
                        <og:title>The Best Webpage</og:title>\
                        <og:description>Plain text preview</og:description>\
                        <og:url>https://the.link.example/what-was-linked</og:url>\
+                       <og:image>https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16</og:image>\
+                       <ogi:type>image/png</ogi:type>\
+                       <ogi:width>640</ogi:width>\
+                       <ogi:height>360</ogi:height>\
+                       <ogi:alt>Article screenshot</ogi:alt>\
                      </rdf:Description>\
                    </message>\
                  </forwarded>\
@@ -842,6 +854,15 @@ mod inbound_to_js_tests {
         );
         assert_eq!(preview.title.as_deref(), Some("The Best Webpage"));
         assert_eq!(preview.description.as_deref(), Some("Plain text preview"));
+        let image = preview.image.as_ref().expect("cached image");
+        assert_eq!(
+            image.url,
+            "https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16"
+        );
+        assert_eq!(image.media_type, "image/png");
+        assert_eq!(image.width, Some(640));
+        assert_eq!(image.height, Some(360));
+        assert_eq!(image.alt.as_deref(), Some("Article screenshot"));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -68,6 +68,16 @@ pub struct WaddleLinkPreview {
     pub normalized_url: Option<String>,
     pub title: Option<String>,
     pub description: Option<String>,
+    pub image: Option<WaddleLinkPreviewImage>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct WaddleLinkPreviewImage {
+    pub url: String,
+    pub media_type: String,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub alt: Option<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/server/crates/waddle-xmpp-client/src/messaging/namespaces.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/namespaces.rs
@@ -26,6 +26,7 @@ pub(crate) const NS_WADDLE_EXTENSION: &str = "urn:waddle:extension:1";
 pub(crate) const NS_WADDLE_LINK_PREVIEW: &str = "urn:waddle:link-preview:0";
 pub(crate) const NS_RDF_SYNTAX: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
 pub(crate) const NS_OPENGRAPH: &str = "https://ogp.me/ns#";
+pub(crate) const NS_OPENGRAPH_IMAGE: &str = "https://ogp.me/ns#image:";
 #[cfg(all(feature = "native", not(target_arch = "wasm32")))]
 pub(crate) const NS_MUC: &str = "http://jabber.org/protocol/muc";
 pub(crate) const NS_MUC_USER: &str = "http://jabber.org/protocol/muc#user";

--- a/server/crates/waddle-xmpp-client/src/messaging/parsing/mod.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/parsing/mod.rs
@@ -377,7 +377,31 @@ fn parse_link_preview(el: &Element, first_url: Option<&Url>) -> Option<LinkPrevi
         normalized_url: og_text(el, "url").and_then(|value| parse_web_url(&value)),
         title: og_text(el, "title"),
         description: og_text(el, "description"),
+        image: parse_link_preview_image(el),
     })
+}
+
+fn parse_link_preview_image(el: &Element) -> Option<LinkPreviewImageData> {
+    let url = el
+        .children()
+        .find(|child| child.name() == "image" && child.ns() == NS_OPENGRAPH)
+        .and_then(|child| parse_cached_preview_image_url(child.text().trim()))?;
+    let media_type =
+        og_image_text(el, "type").filter(|value| safe_preview_image_media_type(value))?;
+    Some(LinkPreviewImageData {
+        url,
+        media_type,
+        width: og_image_text(el, "width").and_then(|value| value.parse().ok()),
+        height: og_image_text(el, "height").and_then(|value| value.parse().ok()),
+        alt: og_image_text(el, "alt"),
+    })
+}
+
+fn parse_cached_preview_image_url(value: &str) -> Option<Url> {
+    let url = parse_web_url(value)?;
+    let path = url.path();
+    let hash = path.strip_prefix("/api/link-preview-media/sha256/")?;
+    (hash.len() == 64 && hash.bytes().all(|byte| byte.is_ascii_hexdigit())).then_some(url)
 }
 
 fn parse_web_url(value: &str) -> Option<Url> {
@@ -411,6 +435,21 @@ fn og_text(el: &Element, name: &str) -> Option<String> {
         .map(Element::text)
         .map(|text| text.trim().to_string())
         .filter(|text| !text.is_empty())
+}
+
+fn og_image_text(el: &Element, name: &str) -> Option<String> {
+    el.children()
+        .find(|child| child.name() == name && child.ns() == NS_OPENGRAPH_IMAGE)
+        .map(Element::text)
+        .map(|text| text.trim().to_string())
+        .filter(|text| !text.is_empty())
+}
+
+fn safe_preview_image_media_type(value: &str) -> bool {
+    matches!(
+        value.to_ascii_lowercase().as_str(),
+        "image/png" | "image/jpeg" | "image/gif" | "image/webp"
+    )
 }
 
 fn has_moderation_retract(element: &Element) -> bool {

--- a/server/crates/waddle-xmpp-client/src/messaging/parsing/mod.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/parsing/mod.rs
@@ -10,7 +10,9 @@ use minidom::Element;
 use crate::xep::encrypted_file::{self as xep_encrypted_file, NS_ESFS as NS_ENCRYPTED_FILE};
 use crate::xep::fallback::{body_fallbacks_for, strip_fallback_ranges, BodyFallback};
 use crate::xep::{reply as xep_reply, thread as xep_thread};
-use waddle_xmpp_core::{first_eligible_https_url_text, xep0359::StanzaId as StableStanzaId};
+use waddle_xmpp_core::{
+    first_eligible_https_url_text, xep0359::StanzaId as StableStanzaId, PreviewImageMediaType,
+};
 
 use self::files::{parse_file_sharing_element, parse_shared_file};
 use self::markup::parse_markup_spans;
@@ -387,7 +389,7 @@ fn parse_link_preview_image(el: &Element) -> Option<LinkPreviewImageData> {
         .find(|child| child.name() == "image" && child.ns() == NS_OPENGRAPH)
         .and_then(|child| parse_cached_preview_image_url(child.text().trim()))?;
     let media_type =
-        og_image_text(el, "type").filter(|value| safe_preview_image_media_type(value))?;
+        og_image_text(el, "type").and_then(|value| value.parse::<PreviewImageMediaType>().ok())?;
     Some(LinkPreviewImageData {
         url,
         media_type,
@@ -482,13 +484,6 @@ fn og_image_text(el: &Element, name: &str) -> Option<String> {
         .map(Element::text)
         .map(|text| text.trim().to_string())
         .filter(|text| !text.is_empty())
-}
-
-fn safe_preview_image_media_type(value: &str) -> bool {
-    matches!(
-        value.to_ascii_lowercase().as_str(),
-        "image/png" | "image/jpeg" | "image/gif" | "image/webp"
-    )
 }
 
 fn has_moderation_retract(element: &Element) -> bool {

--- a/server/crates/waddle-xmpp-client/src/messaging/parsing/mod.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/parsing/mod.rs
@@ -398,9 +398,24 @@ fn parse_link_preview_image(el: &Element) -> Option<LinkPreviewImageData> {
 }
 
 fn parse_cached_preview_image_url(value: &str) -> Option<Url> {
-    let url = parse_web_url(value)?;
+    let url = Url::parse(value).ok()?;
+    if !cached_preview_media_origin_allowed(&url) {
+        return None;
+    }
     let path = url.path();
     is_link_preview_xep0363_file_path(path).then_some(url)
+}
+
+fn cached_preview_media_origin_allowed(url: &Url) -> bool {
+    match url.scheme() {
+        "https" => url.host().is_some(),
+        "http" => url.host().is_some_and(|host| match host {
+            url::Host::Domain(domain) => domain == "localhost",
+            url::Host::Ipv4(addr) => addr.is_loopback(),
+            url::Host::Ipv6(addr) => addr.is_loopback(),
+        }),
+        _ => false,
+    }
 }
 
 fn is_link_preview_xep0363_file_path(path: &str) -> bool {

--- a/server/crates/waddle-xmpp-client/src/messaging/parsing/mod.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/parsing/mod.rs
@@ -400,8 +400,32 @@ fn parse_link_preview_image(el: &Element) -> Option<LinkPreviewImageData> {
 fn parse_cached_preview_image_url(value: &str) -> Option<Url> {
     let url = parse_web_url(value)?;
     let path = url.path();
-    let hash = path.strip_prefix("/api/link-preview-media/sha256/")?;
-    (hash.len() == 64 && hash.bytes().all(|byte| byte.is_ascii_hexdigit())).then_some(url)
+    is_link_preview_xep0363_file_path(path).then_some(url)
+}
+
+fn is_link_preview_xep0363_file_path(path: &str) -> bool {
+    let Some(rest) = path.strip_prefix("/api/files/") else {
+        return false;
+    };
+    let mut parts = rest.split('/');
+    let Some(slot_id) = parts.next() else {
+        return false;
+    };
+    let Some(filename) = parts.next() else {
+        return false;
+    };
+    if parts.next().is_some() || uuid::Uuid::parse_str(slot_id).is_err() {
+        return false;
+    }
+    let Some(name) = filename.strip_prefix("link-preview-") else {
+        return false;
+    };
+    let Some((hash, extension)) = name.rsplit_once('.') else {
+        return false;
+    };
+    matches!(extension, "png" | "jpg" | "gif" | "webp")
+        && hash.len() == 64
+        && hash.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
 fn parse_web_url(value: &str) -> Option<Url> {

--- a/server/crates/waddle-xmpp-client/src/messaging/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/tests.rs
@@ -504,6 +504,55 @@ fn parse_message_extracts_xep0511_link_preview() {
 }
 
 #[test]
+fn parse_message_accepts_loopback_http_xep0511_link_preview_image() {
+    for cached_url in [
+        "http://localhost:3000/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png",
+        "http://127.0.0.1:3000/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png",
+    ] {
+        let e = el(&format!(
+            "<message xmlns='jabber:client' type='groupchat' id='m-link'>\
+               <body>see https://the.link.example.com/what-was-linked-to</body>\
+               <rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#' xmlns:ogi='https://ogp.me/ns#image:' rdf:about='https://the.link.example.com/what-was-linked-to'>\
+                 <og:title>The Best Webpage</og:title>\
+                 <og:image>{cached_url}</og:image>\
+                 <ogi:type>image/png</ogi:type>\
+               </rdf:Description>\
+             </message>"
+        ));
+        let MessagingEvent::Message(msg) = parse(&e).unwrap() else {
+            panic!("expected Message");
+        };
+        assert_eq!(msg.link_previews.len(), 1);
+        assert_eq!(
+            msg.link_previews[0]
+                .image
+                .as_ref()
+                .map(|image| image.url.as_str()),
+            Some(cached_url)
+        );
+    }
+}
+
+#[test]
+fn parse_message_rejects_non_loopback_http_xep0511_link_preview_image() {
+    let e = el(
+        "<message xmlns='jabber:client' type='groupchat' id='m-link'>\
+           <body>see https://the.link.example.com/what-was-linked-to</body>\
+           <rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#' xmlns:ogi='https://ogp.me/ns#image:' rdf:about='https://the.link.example.com/what-was-linked-to'>\
+             <og:title>The Best Webpage</og:title>\
+             <og:image>http://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png</og:image>\
+             <ogi:type>image/png</ogi:type>\
+           </rdf:Description>\
+         </message>",
+    );
+    let MessagingEvent::Message(msg) = parse(&e).unwrap() else {
+        panic!("expected Message");
+    };
+    assert_eq!(msg.link_previews.len(), 1);
+    assert!(msg.link_previews[0].image.is_none());
+}
+
+#[test]
 fn parse_message_ignores_xep0511_link_preview_image_with_unsafe_media_type() {
     let e = el(
         "<message xmlns='jabber:client' type='groupchat' id='m-link'>\

--- a/server/crates/waddle-xmpp-client/src/messaging/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/tests.rs
@@ -465,7 +465,7 @@ fn parse_message_extracts_xep0511_link_preview() {
              <og:title>The Best Webpage</og:title>\
              <og:description>This is a great webpage and you will really like it</og:description>\
              <og:url>https://example.com/canonical-url/for/what-was-linked-to</og:url>\
-             <og:image>https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16</og:image>\
+             <og:image>https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png</og:image>\
              <ogi:type>image/png</ogi:type>\
              <ogi:width>640</ogi:width>\
              <ogi:height>360</ogi:height>\
@@ -495,7 +495,7 @@ fn parse_message_extracts_xep0511_link_preview() {
     let image = msg.link_previews[0].image.as_ref().expect("cached image");
     assert_eq!(
         image.url.as_str(),
-        "https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16"
+        "https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png"
     );
     assert_eq!(image.media_type, "image/png");
     assert_eq!(image.width, Some(640));
@@ -510,7 +510,7 @@ fn parse_message_ignores_xep0511_link_preview_image_with_unsafe_media_type() {
            <body>see https://the.link.example.com/what-was-linked-to</body>\
            <rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#' xmlns:ogi='https://ogp.me/ns#image:' rdf:about='https://the.link.example.com/what-was-linked-to'>\
              <og:title>The Best Webpage</og:title>\
-             <og:image>https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16</og:image>\
+             <og:image>https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png</og:image>\
              <ogi:type>image/svg+xml</ogi:type>\
            </rdf:Description>\
          </message>",

--- a/server/crates/waddle-xmpp-client/src/messaging/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/tests.rs
@@ -461,10 +461,15 @@ fn parse_message_extracts_xep0511_link_preview() {
     let e = el(
         "<message xmlns='jabber:client' type='groupchat' id='m-link'>\
            <body>see https://the.link.example.com/what-was-linked-to</body>\
-           <rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#' rdf:about='https://the.link.example.com/what-was-linked-to'>\
+           <rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#' xmlns:ogi='https://ogp.me/ns#image:' rdf:about='https://the.link.example.com/what-was-linked-to'>\
              <og:title>The Best Webpage</og:title>\
              <og:description>This is a great webpage and you will really like it</og:description>\
              <og:url>https://example.com/canonical-url/for/what-was-linked-to</og:url>\
+             <og:image>https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16</og:image>\
+             <ogi:type>image/png</ogi:type>\
+             <ogi:width>640</ogi:width>\
+             <ogi:height>360</ogi:height>\
+             <ogi:alt>Article screenshot</ogi:alt>\
            </rdf:Description>\
          </message>",
     );
@@ -487,6 +492,53 @@ fn parse_message_extracts_xep0511_link_preview() {
         msg.link_previews[0].title.as_deref(),
         Some("The Best Webpage")
     );
+    let image = msg.link_previews[0].image.as_ref().expect("cached image");
+    assert_eq!(
+        image.url.as_str(),
+        "https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16"
+    );
+    assert_eq!(image.media_type, "image/png");
+    assert_eq!(image.width, Some(640));
+    assert_eq!(image.height, Some(360));
+    assert_eq!(image.alt.as_deref(), Some("Article screenshot"));
+}
+
+#[test]
+fn parse_message_ignores_xep0511_link_preview_image_with_unsafe_media_type() {
+    let e = el(
+        "<message xmlns='jabber:client' type='groupchat' id='m-link'>\
+           <body>see https://the.link.example.com/what-was-linked-to</body>\
+           <rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#' xmlns:ogi='https://ogp.me/ns#image:' rdf:about='https://the.link.example.com/what-was-linked-to'>\
+             <og:title>The Best Webpage</og:title>\
+             <og:image>https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16</og:image>\
+             <ogi:type>image/svg+xml</ogi:type>\
+           </rdf:Description>\
+         </message>",
+    );
+    let MessagingEvent::Message(msg) = parse(&e).unwrap() else {
+        panic!("expected Message");
+    };
+    assert_eq!(msg.link_previews.len(), 1);
+    assert!(msg.link_previews[0].image.is_none());
+}
+
+#[test]
+fn parse_message_ignores_xep0511_link_preview_image_without_cached_media_path() {
+    let e = el(
+        "<message xmlns='jabber:client' type='groupchat' id='m-link'>\
+           <body>see https://the.link.example.com/what-was-linked-to</body>\
+           <rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#' xmlns:ogi='https://ogp.me/ns#image:' rdf:about='https://the.link.example.com/what-was-linked-to'>\
+             <og:title>The Best Webpage</og:title>\
+             <og:image>https://attacker.example/not-the-cache.png</og:image>\
+             <ogi:type>image/png</ogi:type>\
+           </rdf:Description>\
+         </message>",
+    );
+    let MessagingEvent::Message(msg) = parse(&e).unwrap() else {
+        panic!("expected Message");
+    };
+    assert_eq!(msg.link_previews.len(), 1);
+    assert!(msg.link_previews[0].image.is_none());
 }
 
 #[test]

--- a/server/crates/waddle-xmpp-client/src/messaging/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/tests.rs
@@ -497,7 +497,10 @@ fn parse_message_extracts_xep0511_link_preview() {
         image.url.as_str(),
         "https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png"
     );
-    assert_eq!(image.media_type, "image/png");
+    assert_eq!(
+        image.media_type,
+        waddle_xmpp_core::PreviewImageMediaType::Png
+    );
     assert_eq!(image.width, Some(640));
     assert_eq!(image.height, Some(360));
     assert_eq!(image.alt.as_deref(), Some("Article screenshot"));

--- a/server/crates/waddle-xmpp-client/src/messaging/types.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/types.rs
@@ -2,6 +2,7 @@ use chrono::{DateTime, Utc};
 use std::fmt;
 use url::Url;
 use waddle_xmpp_core::xep0359::StanzaId as StableStanzaId;
+use waddle_xmpp_core::PreviewImageMediaType;
 
 use crate::request::StanzaId;
 use crate::xep::encrypted_file::EncryptedFile;
@@ -205,7 +206,7 @@ pub struct LinkPreviewData {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LinkPreviewImageData {
     pub url: Url,
-    pub media_type: String,
+    pub media_type: PreviewImageMediaType,
     pub width: Option<u32>,
     pub height: Option<u32>,
     pub alt: Option<String>,

--- a/server/crates/waddle-xmpp-client/src/messaging/types.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/types.rs
@@ -199,6 +199,16 @@ pub struct LinkPreviewData {
     pub normalized_url: Option<Url>,
     pub title: Option<String>,
     pub description: Option<String>,
+    pub image: Option<LinkPreviewImageData>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkPreviewImageData {
+    pub url: Url,
+    pub media_type: String,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub alt: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/server/crates/waddle-xmpp-core/src/lib.rs
+++ b/server/crates/waddle-xmpp-core/src/lib.rs
@@ -39,7 +39,7 @@ pub use domain::{
     ChannelInfo, ChannelRoomInfo, ChannelType, UploadSlotInfo, WaddleDetails, WaddleInfo,
 };
 pub use error::{CoreError, CoreResult};
-pub use link_preview::first_eligible_https_url_text;
+pub use link_preview::{first_eligible_https_url_text, PreviewImageMediaType};
 pub use mam::{
     build_fin_iq, build_result_messages, is_mam_query, is_mam_query_response_message,
     parse_mam_query, ArchivedMessage, MamQuery, MamResult, DATA_FORMS_NS, FORWARD_NS, MAM_NS,

--- a/server/crates/waddle-xmpp-core/src/link_preview.rs
+++ b/server/crates/waddle-xmpp-core/src/link_preview.rs
@@ -1,4 +1,59 @@
-//! Shared link-preview URL eligibility helpers.
+//! Shared link-preview protocol helpers.
+
+use std::{fmt, str::FromStr};
+
+/// Safe image MIME types Waddle accepts for cached link-preview media.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PreviewImageMediaType {
+    Png,
+    Jpeg,
+    Gif,
+    Webp,
+}
+
+impl PreviewImageMediaType {
+    /// Borrow the canonical MIME text used on the wire.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Png => "image/png",
+            Self::Jpeg => "image/jpeg",
+            Self::Gif => "image/gif",
+            Self::Webp => "image/webp",
+        }
+    }
+}
+
+impl fmt::Display for PreviewImageMediaType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for PreviewImageMediaType {
+    type Err = InvalidPreviewImageMediaType;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.to_ascii_lowercase().as_str() {
+            "image/png" => Ok(Self::Png),
+            "image/jpeg" => Ok(Self::Jpeg),
+            "image/gif" => Ok(Self::Gif),
+            "image/webp" => Ok(Self::Webp),
+            _ => Err(InvalidPreviewImageMediaType),
+        }
+    }
+}
+
+/// Error returned for unsupported preview-image MIME text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InvalidPreviewImageMediaType;
+
+impl fmt::Display for InvalidPreviewImageMediaType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("unsupported preview image MIME type")
+    }
+}
+
+impl std::error::Error for InvalidPreviewImageMediaType {}
 
 /// Return the first HTTPS URL-like token whose host looks web-addressable.
 ///
@@ -53,5 +108,19 @@ mod tests {
             first_eligible_https_url_text("see https://localhost/a"),
             None
         );
+    }
+
+    #[test]
+    fn parses_supported_preview_image_media_types_case_insensitively() {
+        assert_eq!(
+            "IMAGE/PNG".parse::<PreviewImageMediaType>(),
+            Ok(PreviewImageMediaType::Png)
+        );
+        assert_eq!(PreviewImageMediaType::Webp.as_str(), "image/webp");
+    }
+
+    #[test]
+    fn rejects_unsupported_preview_image_media_type() {
+        assert!("image/svg+xml".parse::<PreviewImageMediaType>().is_err());
     }
 }

--- a/server/crates/waddle-xmpp/src/xep/exports.rs
+++ b/server/crates/waddle-xmpp/src/xep/exports.rs
@@ -424,8 +424,9 @@ pub use super::xep_waddle_link_preview::{
     build_link_preview_request_element, decode_link_preview_token, encode_link_preview_token,
     encode_link_preview_token_checked, extract_link_preview_request_from_message,
     is_link_preview_request_element, parse_link_preview_request_element,
-    strip_link_preview_requests, LinkPreviewToken, LinkPreviewTokenData, WaddleLinkPreviewError,
-    ELEMENT_PREVIEW_REQUEST, MAX_LINK_PREVIEW_TOKEN_BYTES, NS_WADDLE_LINK_PREVIEW,
+    strip_link_preview_requests, LinkPreviewToken, LinkPreviewTokenData, LinkPreviewTokenImage,
+    WaddleLinkPreviewError, ELEMENT_PREVIEW_REQUEST, MAX_LINK_PREVIEW_TOKEN_BYTES,
+    NS_WADDLE_LINK_PREVIEW,
 };
 
 pub use super::xep0503::{
@@ -439,7 +440,7 @@ pub use super::xep0503::{
 pub use super::xep0511::{
     build_link_metadata_element, extract_link_metadata_from_message, is_link_metadata_element,
     parse_link_metadata_element, set_link_metadata, strip_link_metadata, LinkMetadata,
-    LinkMetadataError, NS_OPENGRAPH, NS_OPENGRAPH_IMAGE, NS_RDF_SYNTAX,
+    LinkMetadataError, LinkPreviewImage, NS_OPENGRAPH, NS_OPENGRAPH_IMAGE, NS_RDF_SYNTAX,
 };
 
 // Re-export commonly used items at the xep module level

--- a/server/crates/waddle-xmpp/src/xep/xep0511.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0511.rs
@@ -41,6 +41,53 @@ pub enum LinkMetadataError {
     InvalidCanonicalUrl,
 }
 
+/// OpenGraph preview image metadata carried inside XEP-0511.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkPreviewImage {
+    /// Waddle-controlled image URL clients may dereference.
+    pub url: Url,
+    /// Safe MIME type observed when Waddle cached the image.
+    pub media_type: Option<String>,
+    /// Image width in pixels, when available from metadata.
+    pub width: Option<u32>,
+    /// Image height in pixels, when available from metadata.
+    pub height: Option<u32>,
+    /// Human-readable alt text, when available.
+    pub alt: Option<String>,
+}
+
+impl LinkPreviewImage {
+    /// Create preview image metadata for a cached Waddle media URL.
+    pub fn new(url: Url) -> Self {
+        Self {
+            url,
+            media_type: None,
+            width: None,
+            height: None,
+            alt: None,
+        }
+    }
+
+    /// Set the safe MIME type.
+    pub fn with_media_type(mut self, media_type: impl Into<String>) -> Self {
+        self.media_type = Some(media_type.into());
+        self
+    }
+
+    /// Set image dimensions.
+    pub fn with_dimensions(mut self, width: u32, height: u32) -> Self {
+        self.width = Some(width);
+        self.height = Some(height);
+        self
+    }
+
+    /// Set image alt text.
+    pub fn with_alt(mut self, alt: impl Into<String>) -> Self {
+        self.alt = Some(alt.into());
+        self
+    }
+}
+
 /// Typed plaintext subset of the OpenGraph metadata used by Waddle's first
 /// XEP-0511 tracer bullet.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -55,6 +102,8 @@ pub struct LinkMetadata {
     pub canonical_url: Option<Url>,
     /// `og:site_name`, when present.
     pub site_name: Option<String>,
+    /// Cached preview images referenced through Waddle-controlled media URLs.
+    pub images: Vec<LinkPreviewImage>,
 }
 
 impl LinkMetadata {
@@ -66,6 +115,7 @@ impl LinkMetadata {
             description: None,
             canonical_url: None,
             site_name: None,
+            images: Vec::new(),
         }
     }
 
@@ -90,6 +140,12 @@ impl LinkMetadata {
     /// Set `og:site_name`.
     pub fn with_site_name(mut self, site_name: impl Into<String>) -> Self {
         self.site_name = Some(site_name.into());
+        self
+    }
+
+    /// Add cached preview image metadata.
+    pub fn with_image(mut self, image: LinkPreviewImage) -> Self {
+        self.images.push(image);
         self
     }
 }
@@ -121,6 +177,7 @@ pub fn parse_link_metadata_element(elem: &Element) -> Result<LinkMetadata, LinkM
         Some(raw) => Some(Url::parse(&raw).map_err(|_| LinkMetadataError::InvalidCanonicalUrl)?),
         None => None,
     };
+    metadata.images = parse_og_images(elem);
 
     Ok(metadata)
 }
@@ -146,6 +203,8 @@ pub fn build_link_metadata_element(metadata: &LinkMetadata) -> Element {
         .expect("static RDF prefix is unique")
         .prefix(Some("og".to_string()), NS_OPENGRAPH)
         .expect("static OpenGraph prefix is unique")
+        .prefix(Some("ogi".to_string()), NS_OPENGRAPH_IMAGE)
+        .expect("static OpenGraph image prefix is unique")
         .attr_ns(
             Namespace::from(NS_RDF_SYNTAX),
             xml_ncname!("about").to_owned(),
@@ -165,6 +224,13 @@ pub fn build_link_metadata_element(metadata: &LinkMetadata) -> Element {
         metadata.canonical_url.as_ref().map(Url::as_str),
     );
     append_og_text(&mut description, "site_name", metadata.site_name.as_deref());
+    for image in &metadata.images {
+        append_og_text(&mut description, "image", Some(image.url.as_str()));
+        append_og_image_text(&mut description, "type", image.media_type.as_deref());
+        append_og_number(&mut description, "width", image.width);
+        append_og_number(&mut description, "height", image.height);
+        append_og_image_text(&mut description, "alt", image.alt.as_deref());
+    }
 
     description
 }
@@ -202,6 +268,65 @@ fn append_og_text(parent: &mut Element, name: &str, value: Option<&str>) {
     };
     parent.append_child(
         Element::builder(name, NS_OPENGRAPH)
+            .append(value.trim())
+            .build(),
+    );
+}
+
+fn parse_og_images(elem: &Element) -> Vec<LinkPreviewImage> {
+    let mut images = Vec::new();
+    let mut current: Option<LinkPreviewImage> = None;
+    for child in elem.children() {
+        if child.ns() == NS_OPENGRAPH && child.name() == "image" {
+            if let Some(image) = current.take() {
+                images.push(image);
+            }
+            current = Url::parse(child.text().trim())
+                .ok()
+                .map(LinkPreviewImage::new);
+            continue;
+        }
+        if child.ns() != NS_OPENGRAPH_IMAGE {
+            continue;
+        }
+        let Some(image) = current.as_mut() else {
+            continue;
+        };
+        let value = child.text().trim().to_string();
+        if value.is_empty() {
+            continue;
+        }
+        match child.name() {
+            "type" => image.media_type = Some(value),
+            "width" => image.width = value.parse().ok(),
+            "height" => image.height = value.parse().ok(),
+            "alt" => image.alt = Some(value),
+            _ => {}
+        }
+    }
+    if let Some(image) = current {
+        images.push(image);
+    }
+    images
+}
+
+fn append_og_number(parent: &mut Element, name: &str, value: Option<u32>) {
+    let Some(value) = value else {
+        return;
+    };
+    parent.append_child(
+        Element::builder(name, NS_OPENGRAPH_IMAGE)
+            .append(value.to_string())
+            .build(),
+    );
+}
+
+fn append_og_image_text(parent: &mut Element, name: &str, value: Option<&str>) {
+    let Some(value) = value.filter(|value| !value.trim().is_empty()) else {
+        return;
+    };
+    parent.append_child(
+        Element::builder(name, NS_OPENGRAPH_IMAGE)
             .append(value.trim())
             .build(),
     );

--- a/server/crates/waddle-xmpp/src/xep/xep0511.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0511.rs
@@ -10,6 +10,7 @@ use minidom::{
 };
 use thiserror::Error;
 use url::Url;
+use waddle_xmpp_core::PreviewImageMediaType;
 use xmpp_parsers::message::Message;
 
 /// RDF syntax namespace used by XEP-0511's `<rdf:Description/>` payload.
@@ -47,7 +48,7 @@ pub struct LinkPreviewImage {
     /// Waddle-controlled image URL clients may dereference.
     pub url: Url,
     /// Safe MIME type observed when Waddle cached the image.
-    pub media_type: Option<String>,
+    pub media_type: Option<PreviewImageMediaType>,
     /// Image width in pixels, when available from metadata.
     pub width: Option<u32>,
     /// Image height in pixels, when available from metadata.
@@ -69,8 +70,8 @@ impl LinkPreviewImage {
     }
 
     /// Set the safe MIME type.
-    pub fn with_media_type(mut self, media_type: impl Into<String>) -> Self {
-        self.media_type = Some(media_type.into());
+    pub fn with_media_type(mut self, media_type: PreviewImageMediaType) -> Self {
+        self.media_type = Some(media_type);
         self
     }
 
@@ -226,7 +227,11 @@ pub fn build_link_metadata_element(metadata: &LinkMetadata) -> Element {
     append_og_text(&mut description, "site_name", metadata.site_name.as_deref());
     for image in &metadata.images {
         append_og_text(&mut description, "image", Some(image.url.as_str()));
-        append_og_image_text(&mut description, "type", image.media_type.as_deref());
+        append_og_image_text(
+            &mut description,
+            "type",
+            image.media_type.map(PreviewImageMediaType::as_str),
+        );
         append_og_number(&mut description, "width", image.width);
         append_og_number(&mut description, "height", image.height);
         append_og_image_text(&mut description, "alt", image.alt.as_deref());
@@ -297,7 +302,11 @@ fn parse_og_images(elem: &Element) -> Vec<LinkPreviewImage> {
             continue;
         }
         match child.name() {
-            "type" => image.media_type = Some(value),
+            "type" => {
+                if let Ok(media_type) = value.parse() {
+                    image.media_type = Some(media_type);
+                }
+            }
             "width" => image.width = value.parse().ok(),
             "height" => image.height = value.parse().ok(),
             "alt" => image.alt = Some(value),

--- a/server/crates/waddle-xmpp/src/xep/xep_waddle_link_preview.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep_waddle_link_preview.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use thiserror::Error;
 use url::Url;
+use waddle_xmpp_core::PreviewImageMediaType;
 use xmpp_parsers::message::Message;
 
 /// Waddle-private link preview namespace.
@@ -59,7 +60,7 @@ pub struct LinkPreviewTokenData {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LinkPreviewTokenImage {
     pub url: Url,
-    pub media_type: String,
+    pub media_type: PreviewImageMediaType,
     pub width: Option<u32>,
     pub height: Option<u32>,
     pub alt: Option<String>,
@@ -103,6 +104,8 @@ pub enum WaddleLinkPreviewError {
     InvalidTokenJid,
     #[error("invalid preview token URL")]
     InvalidTokenUrl,
+    #[error("invalid preview image MIME type")]
+    InvalidTokenMediaType,
     #[error("preview token expired")]
     Expired,
 }
@@ -156,7 +159,7 @@ pub fn encode_link_preview_token(data: &LinkPreviewTokenData, secret: &[u8]) -> 
         description: data.description.clone(),
         image: data.image.as_ref().map(|image| LinkPreviewTokenImageWire {
             url: image.url.as_str().to_string(),
-            media_type: image.media_type.clone(),
+            media_type: image.media_type.as_str().to_string(),
             width: image.width,
             height: image.height,
             alt: image.alt.clone(),
@@ -232,7 +235,10 @@ pub fn decode_link_preview_token(
                 Ok(LinkPreviewTokenImage {
                     url: Url::parse(&image.url)
                         .map_err(|_| WaddleLinkPreviewError::InvalidTokenUrl)?,
-                    media_type: image.media_type,
+                    media_type: image
+                        .media_type
+                        .parse()
+                        .map_err(|_| WaddleLinkPreviewError::InvalidTokenMediaType)?,
                     width: image.width,
                     height: image.height,
                     alt: image.alt,
@@ -272,7 +278,7 @@ mod tests {
             image: Some(LinkPreviewTokenImage {
                 url: Url::parse("https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png")
                     .expect("url"),
-                media_type: "image/png".to_string(),
+                media_type: PreviewImageMediaType::Png,
                 width: Some(640),
                 height: Some(360),
                 alt: Some("Article screenshot".to_string()),

--- a/server/crates/waddle-xmpp/src/xep/xep_waddle_link_preview.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep_waddle_link_preview.rs
@@ -51,7 +51,18 @@ pub struct LinkPreviewTokenData {
     pub normalized_url: Url,
     pub title: Option<String>,
     pub description: Option<String>,
+    pub image: Option<LinkPreviewTokenImage>,
     pub expires_at_unix: i64,
+}
+
+/// Cached preview image metadata sealed inside a composer preview token.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkPreviewTokenImage {
+    pub url: Url,
+    pub media_type: String,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub alt: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -62,7 +73,17 @@ struct LinkPreviewTokenWire {
     normalized_url: String,
     title: Option<String>,
     description: Option<String>,
+    image: Option<LinkPreviewTokenImageWire>,
     expires_at_unix: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct LinkPreviewTokenImageWire {
+    url: String,
+    media_type: String,
+    width: Option<u32>,
+    height: Option<u32>,
+    alt: Option<String>,
 }
 
 /// Errors for private Waddle link-preview request parsing.
@@ -133,6 +154,13 @@ pub fn encode_link_preview_token(data: &LinkPreviewTokenData, secret: &[u8]) -> 
         normalized_url: data.normalized_url.as_str().to_string(),
         title: data.title.clone(),
         description: data.description.clone(),
+        image: data.image.as_ref().map(|image| LinkPreviewTokenImageWire {
+            url: image.url.as_str().to_string(),
+            media_type: image.media_type.clone(),
+            width: image.width,
+            height: image.height,
+            alt: image.alt.clone(),
+        }),
         expires_at_unix: data.expires_at_unix,
     };
     let json = serde_json::to_vec(&wire).expect("wire token is serializable");
@@ -198,6 +226,19 @@ pub fn decode_link_preview_token(
             .map_err(|_| WaddleLinkPreviewError::InvalidTokenUrl)?,
         title: wire.title,
         description: wire.description,
+        image: wire
+            .image
+            .map(|image| {
+                Ok(LinkPreviewTokenImage {
+                    url: Url::parse(&image.url)
+                        .map_err(|_| WaddleLinkPreviewError::InvalidTokenUrl)?,
+                    media_type: image.media_type,
+                    width: image.width,
+                    height: image.height,
+                    alt: image.alt,
+                })
+            })
+            .transpose()?,
         expires_at_unix: wire.expires_at_unix,
     })
 }
@@ -228,6 +269,14 @@ mod tests {
             normalized_url: Url::parse("https://example.com/path").expect("url"),
             title: Some("Example".to_string()),
             description: Some("Plain text preview".to_string()),
+            image: Some(LinkPreviewTokenImage {
+                url: Url::parse("https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16")
+                    .expect("url"),
+                media_type: "image/png".to_string(),
+                width: Some(640),
+                height: Some(360),
+                alt: Some("Article screenshot".to_string()),
+            }),
             expires_at_unix: 1_900_000_000,
         };
 
@@ -248,6 +297,7 @@ mod tests {
             normalized_url: Url::parse("https://example.com/path").expect("url"),
             title: Some("Example".to_string()),
             description: Some("Plain text preview".to_string()),
+            image: None,
             expires_at_unix: 1_900_000_000,
         };
 
@@ -269,6 +319,7 @@ mod tests {
             normalized_url: Url::parse("https://example.com/").expect("url"),
             title: None,
             description: None,
+            image: None,
             expires_at_unix: 10,
         };
 
@@ -289,6 +340,7 @@ mod tests {
             normalized_url: Url::parse("https://example.com/").expect("url"),
             title: Some("t".repeat(MAX_LINK_PREVIEW_TOKEN_BYTES)),
             description: Some("d".repeat(MAX_LINK_PREVIEW_TOKEN_BYTES)),
+            image: None,
             expires_at_unix: 1_900_000_000,
         };
 

--- a/server/crates/waddle-xmpp/src/xep/xep_waddle_link_preview.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep_waddle_link_preview.rs
@@ -270,7 +270,7 @@ mod tests {
             title: Some("Example".to_string()),
             description: Some("Plain text preview".to_string()),
             image: Some(LinkPreviewTokenImage {
-                url: Url::parse("https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16")
+                url: Url::parse("https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png")
                     .expect("url"),
                 media_type: "image/png".to_string(),
                 width: Some(640),

--- a/server/crates/waddle-xmpp/tests/xep0511_link_metadata.rs
+++ b/server/crates/waddle-xmpp/tests/xep0511_link_metadata.rs
@@ -10,6 +10,7 @@ use waddle_xmpp::xep::{
     set_link_metadata, strip_link_metadata, LinkMetadata, LinkMetadataError, LinkPreviewImage,
     NS_OPENGRAPH, NS_OPENGRAPH_IMAGE, NS_RDF_SYNTAX,
 };
+use waddle_xmpp_core::PreviewImageMediaType;
 use xmpp_parsers::message::Message;
 
 fn element(xml: &str) -> Element {
@@ -60,7 +61,7 @@ fn xep0511_builds_cached_image_metadata_with_opengraph_structured_properties() {
     let image = LinkPreviewImage::new(
         Url::parse("https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png").expect("url"),
     )
-    .with_media_type("image/png")
+    .with_media_type(PreviewImageMediaType::Png)
     .with_dimensions(640, 360)
     .with_alt("Screenshot of the article");
     let metadata = LinkMetadata::new(Url::parse("https://the.link.example/article").expect("url"))

--- a/server/crates/waddle-xmpp/tests/xep0511_link_metadata.rs
+++ b/server/crates/waddle-xmpp/tests/xep0511_link_metadata.rs
@@ -7,8 +7,8 @@ use minidom::Element;
 use url::Url;
 use waddle_xmpp::xep::{
     build_link_metadata_element, extract_link_metadata_from_message, parse_link_metadata_element,
-    set_link_metadata, strip_link_metadata, LinkMetadata, LinkMetadataError, NS_OPENGRAPH,
-    NS_RDF_SYNTAX,
+    set_link_metadata, strip_link_metadata, LinkMetadata, LinkMetadataError, LinkPreviewImage,
+    NS_OPENGRAPH, NS_OPENGRAPH_IMAGE, NS_RDF_SYNTAX,
 };
 use xmpp_parsers::message::Message;
 
@@ -52,6 +52,63 @@ fn xep0511_builds_rdf_description_with_namespaced_about_and_opengraph_children()
             .map(Element::text)
             .as_deref(),
         Some("https://example.com/canonical")
+    );
+}
+
+#[test]
+fn xep0511_builds_cached_image_metadata_with_opengraph_structured_properties() {
+    let image = LinkPreviewImage::new(
+        Url::parse("https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16").expect("url"),
+    )
+    .with_media_type("image/png")
+    .with_dimensions(640, 360)
+    .with_alt("Screenshot of the article");
+    let metadata = LinkMetadata::new(Url::parse("https://the.link.example/article").expect("url"))
+        .with_title("The Best Webpage")
+        .with_image(image.clone());
+
+    let payload = build_link_metadata_element(&metadata);
+
+    assert_eq!(
+        payload
+            .get_child("image", NS_OPENGRAPH)
+            .map(Element::text)
+            .as_deref(),
+        Some("https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16")
+    );
+    assert_eq!(
+        payload
+            .get_child("type", NS_OPENGRAPH_IMAGE)
+            .map(Element::text)
+            .as_deref(),
+        Some("image/png")
+    );
+    assert_eq!(
+        payload
+            .get_child("width", NS_OPENGRAPH_IMAGE)
+            .map(Element::text)
+            .as_deref(),
+        Some("640")
+    );
+    assert_eq!(
+        payload
+            .get_child("height", NS_OPENGRAPH_IMAGE)
+            .map(Element::text)
+            .as_deref(),
+        Some("360")
+    );
+    assert_eq!(
+        payload
+            .get_child("alt", NS_OPENGRAPH_IMAGE)
+            .map(Element::text)
+            .as_deref(),
+        Some("Screenshot of the article")
+    );
+    assert_eq!(
+        parse_link_metadata_element(&payload)
+            .expect("image metadata parses")
+            .images,
+        vec![image]
     );
 }
 

--- a/server/crates/waddle-xmpp/tests/xep0511_link_metadata.rs
+++ b/server/crates/waddle-xmpp/tests/xep0511_link_metadata.rs
@@ -58,7 +58,7 @@ fn xep0511_builds_rdf_description_with_namespaced_about_and_opengraph_children()
 #[test]
 fn xep0511_builds_cached_image_metadata_with_opengraph_structured_properties() {
     let image = LinkPreviewImage::new(
-        Url::parse("https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16").expect("url"),
+        Url::parse("https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png").expect("url"),
     )
     .with_media_type("image/png")
     .with_dimensions(640, 360)
@@ -74,7 +74,7 @@ fn xep0511_builds_cached_image_metadata_with_opengraph_structured_properties() {
             .get_child("image", NS_OPENGRAPH)
             .map(Element::text)
             .as_deref(),
-        Some("https://waddle.example/api/link-preview-media/sha256/86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16")
+        Some("https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png")
     );
     assert_eq!(
         payload

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpuxu3ad";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpuxu3ad";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpuxu3ad";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpvq05pa";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpvq05pa";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpvq05pa";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=mpuxu3ad";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=mpvq05pa";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpvq05pa";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpvq05pa";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpvq05pa";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpvua2nx";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpvua2nx";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpvua2nx";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=mpvq05pa";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=mpvua2nx";


### PR DESCRIPTION
## Summary

Implements #826 by caching safe link-preview images through Waddle before any preview image is returned to the composer, stamped into messages, or rendered from live/archive message data.

## Completed Work

- Resolves `og:image` metadata during link preview lookup and fetches image bytes through the server-side SSRF policy.
- Accepts only safe raster image types (`image/png`, `image/jpeg`, `image/gif`, `image/webp`) when both the response header and byte sniffing agree.
- Stores preview images as content-addressed Waddle blobs under `link-previews/sha256/{hash}` and publishes them as uploaded XEP-0363 file slots using the existing `/api/files/{slot}/link-preview-{hash}.{ext}` media route.
- Removes the dedicated `/api/link-preview-media/sha256/{hash}` endpoint and adds a regression test that it is not routable.
- Returns cached image URL, MIME type, dimensions, and alt text in the Waddle link-preview lookup token.
- Stamps server-authenticated messages with XEP-0511 OpenGraph/RDF image metadata only when the cached image URL matches the configured Waddle media origin and XEP-0363 file-slot shape.
- Parses cached preview media URLs with dedicated media trust rules, allowing HTTPS media and HTTP loopback media (`localhost` / loopback IPs) without weakening linked-site URL parsing.
- Compares trusted cached-media origins using effective default ports, so explicit `:443` / `:80` formatting does not drop equivalent Waddle media URLs.
- Threads the session-derived trusted media origin through pinned-message hydration paths so pinned previews preserve cached media.
- Models safe preview-image MIME values as typed Rust protocol data across XEP-0511, preview tokens, resolver output, client parsing, and WASM conversion boundaries.
- Uses `hex::encode` for cached preview image SHA-256 filenames.
- Adds XEP-0372 `data` references for stamped cached media so retention/audit logic has logical media references while physical deletion remains deferred.
- Renders composer, live, MAM, and pinned link previews using Waddle-hosted cached media only; foreign-origin, unsafe-MIME, or non-slot-path image metadata is dropped to text-only previews.
- Keeps image enrichment fail-open after HTML metadata succeeds, so missing, blocked, timed out, 5xx, MIME-mismatched, URL-construction, storage-write, or slot-recording failures still return title/description preview metadata.

## XEP Review

- Reviewed `./xeps/xep-0511.xml`.
- XEP-0511 preview metadata remains OpenGraph/RDF shaped.
- XEP-0363 is reused for cached preview media access through existing uploaded file slots; no dedicated link-preview HTTP API remains.
- XEP-0372 references are used for logical cached-media references.
- The custom `urn:waddle:link-preview:0` image element is limited to the internal lookup/token handshake where no XEP-defined shape exists for the composer request payload.

## Verification

- `cargo test -p waddle-xmpp-client link_preview -- --nocapture`
- `cargo test -p waddle-xmpp-client-wasm link_preview -- --nocapture`
- `cargo test -p waddle-server link_preview -- --nocapture`
- `cargo test -p waddle-xmpp xep0511 -- --nocapture`
- `cargo test -p waddle-xmpp token_round_trips_typed_preview_data -- --nocapture`
- `cargo clippy -p waddle-xmpp-core -p waddle-xmpp -p waddle-xmpp-client -p waddle-xmpp-client-wasm -p waddle-server --tests -- -D warnings`
- `bun test tests/link-preview.test.ts`
- `bun run lint`
- Not run: `bunx vue-tsc --noEmit` is currently blocked by existing `tsconfig.json` TS5101 `baseUrl` deprecation.

## Review Notes

- Multiple review passes were run; the final local pass found no remaining real actionable issue.
- `og:image` is not pinned to the linked page host because CDN-backed OpenGraph images are common. The resolver instead keeps SSRF checks, redirect checks, safe MIME allowlisting, byte sniffing, and size limits before rehosting.
- Cached preview media is now reachable only through the existing XEP-0363-backed file route after the XMPP lookup flow records an uploaded slot. The previous bespoke link-preview media route has been removed.

Fixes #826