### PR TITLE
fix(chat): preserve previews for quick mobile sends

### DIFF
--- a/chat/src/components/chat/MessageComposer.vue
+++ b/chat/src/components/chat/MessageComposer.vue
@@ -109,6 +109,7 @@ const tiptapEditor = computed(() => {
 });
 
 const pendingAttachments = ref<PendingAttachment[]>([]);
+const isPreparingSend = ref(false);
 const linkPreview = useComposerLinkPreview(
   draft,
   computed(() => props.linkPreviewLookup),
@@ -223,8 +224,9 @@ const autocompleteAction = computed(() =>
 
 /** Whether the composer has nothing sendable (no text and no pending attachments). */
 const isEmpty = computed(() => !draft.value.trim() && pendingAttachments.value.length === 0);
+const isSendBusy = computed(() => props.isSending || isPreparingSend.value);
 const canSend = computed(() =>
-  !props.isSending &&
+  !isSendBusy.value &&
   !props.disabled &&
   props.slowModeCooldown <= 0 &&
   !isEmpty.value &&
@@ -442,7 +444,8 @@ function selectAutocompleteResult(action = autocompleteAction.value): boolean {
   return false;
 }
 
-function onSend(doc: JSONContent) {
+async function onSend(doc: JSONContent) {
+  if (isPreparingSend.value) return;
   const action = autocompleteAction.value;
   if (selectAutocompleteResult(action)) {
     return;
@@ -456,22 +459,28 @@ function onSend(doc: JSONContent) {
   if (showForumTitleInput.value && !forumTitle.value.trim()) return;
   if (!text && attachments.length === 0) return;
 
-  // Detach attachments before emitting so re-entry (e.g. Enter burst) cannot
-  // double-send them. Revoke preview URLs once ownership transfers to the parent.
-  const files = attachments.map((a) => a.file);
-  if (attachments.length > 0) {
-    pendingAttachments.value = [];
-    for (const a of attachments) URL.revokeObjectURL(a.previewUrl);
-  }
+  isPreparingSend.value = true;
+  try {
+    // Detach attachments before emitting so re-entry (e.g. Enter burst) cannot
+    // double-send them. Revoke preview URLs once ownership transfers to the parent.
+    const files = attachments.map((a) => a.file);
+    if (attachments.length > 0) {
+      pendingAttachments.value = [];
+      for (const a of attachments) URL.revokeObjectURL(a.previewUrl);
+    }
+    const previewPayload = await linkPreview.sendPayloadFor(serialized.body);
 
-  emit(
-    "send",
-    serialized.body,
-    serialized.markup,
-    serialized.references,
-    files.length > 0 ? files : undefined,
-    linkPreview.sendPayload.value,
-  );
+    emit(
+      "send",
+      serialized.body,
+      serialized.markup,
+      serialized.references,
+      files.length > 0 ? files : undefined,
+      previewPayload,
+    );
+  } finally {
+    isPreparingSend.value = false;
+  }
 }
 
 function focus() {
@@ -923,12 +932,12 @@ watch(
         class="chat-composer-send chat-composer-input-action h-9 w-9 shrink-0 flex items-center justify-center bg-primary text-primary-foreground transition-all duration-200 disabled:opacity-20 active:scale-[0.94] motion-safe:hover:scale-[1.04] [@media(pointer:coarse)]:h-11 [@media(pointer:coarse)]:w-11"
         :class="canSend ? 'chat-composer-send--armed shadow-[0_0_18px_var(--glow-strong)]' : ''"
         :disabled="!canSend"
-        :aria-label="isSending ? 'Sending message' : 'Send message'"
-        :aria-busy="isSending"
+        :aria-label="isSendBusy ? 'Sending message' : 'Send message'"
+        :aria-busy="isSendBusy"
         @click="onSend(editorRef?.getJSON?.() ?? { type: 'doc', content: [] })"
       >
         <span v-if="slowModeCooldown > 0" class="type-meta type-numeric type-strong">{{ slowModeCooldown }}</span>
-        <Loader2 v-else-if="isSending" class="w-4 h-4 motion-safe:animate-spin" aria-hidden="true" />
+        <Loader2 v-else-if="isSendBusy" class="w-4 h-4 motion-safe:animate-spin" aria-hidden="true" />
         <Send v-else class="w-4 h-4" aria-hidden="true" />
       </button>
     </div>

--- a/chat/src/lib/use-composer-link-preview.ts
+++ b/chat/src/lib/use-composer-link-preview.ts
@@ -4,8 +4,13 @@ import {
   linkPreviewStateFromLookup,
   sendPayloadFromState,
   type ComposerLinkPreviewLookup,
+  type ComposerLinkPreviewSendPayload,
   type ComposerLinkPreviewState,
 } from "@/lib/link-preview-composer";
+
+// The production lookup has its own 2s timeout; keep send fail-open if a
+// replacement lookup implementation ever forgets to bound its promise.
+const SEND_LOOKUP_GRACE_MS = 2_250;
 
 export function useComposerLinkPreview(
   draft: Ref<string>,
@@ -16,6 +21,7 @@ export function useComposerLinkPreview(
   let lookupEpoch = 0;
   let activeKey: string | null = null;
   let activeLookup: ComposerLinkPreviewLookup | null = null;
+  let activeLookupSettled: Promise<void> | null = null;
 
   const showCard = computed(() => state.value.kind !== "idle");
   const host = computed(() => {
@@ -49,7 +55,20 @@ export function useComposerLinkPreview(
     lookupEpoch++;
     activeKey = stateKey(scopeKey.value, state.value.url);
     activeLookup = null;
+    activeLookupSettled = null;
     state.value = { kind: "dismissed", url: state.value.url };
+  }
+
+  async function sendPayloadFor(body: string): Promise<ComposerLinkPreviewSendPayload | undefined> {
+    const url = composerLinkPreviewUrl(body);
+    const key = stateKey(scopeKey.value, url);
+    if (!key) return undefined;
+
+    if (key === activeKey && state.value.kind === "loading" && activeLookupSettled) {
+      await settleWithGrace(activeLookupSettled);
+    }
+
+    return key === activeKey ? sendPayloadFromState(state.value) : undefined;
   }
 
   watch(
@@ -61,6 +80,7 @@ export function useComposerLinkPreview(
         lookupEpoch++;
         activeKey = null;
         activeLookup = null;
+        activeLookupSettled = null;
         state.value = { kind: "idle" };
         return;
       }
@@ -76,15 +96,25 @@ export function useComposerLinkPreview(
       activeKey = key;
       activeLookup = lookupFn;
       state.value = { kind: "loading", url };
-      void lookupFn(body)
-        .then((result) => {
-          if (epoch !== lookupEpoch) return;
-          state.value = linkPreviewStateFromLookup(url, result);
-        })
-        .catch(() => {
-          if (epoch !== lookupEpoch) return;
-          state.value = { kind: "failed", url };
-        });
+      let rawLookup: ReturnType<ComposerLinkPreviewLookup>;
+      try {
+        rawLookup = lookupFn(body);
+      } catch {
+        rawLookup = Promise.reject();
+      }
+      const lookupSettled = rawLookup.then((result) => {
+        if (epoch !== lookupEpoch) return;
+        state.value = linkPreviewStateFromLookup(url, result);
+      }).catch(() => {
+        if (epoch !== lookupEpoch) return;
+        state.value = { kind: "failed", url };
+      });
+      activeLookupSettled = lookupSettled;
+      void lookupSettled.finally(() => {
+        if (epoch === lookupEpoch && activeLookupSettled === lookupSettled) {
+          activeLookupSettled = null;
+        }
+      });
     },
     { immediate: true },
   );
@@ -98,7 +128,19 @@ export function useComposerLinkPreview(
     description,
     dismiss,
     sendPayload: computed(() => sendPayloadFromState(state.value)),
+    sendPayloadFor,
   };
+}
+
+async function settleWithGrace(pending: Promise<void>): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  await Promise.race([
+    pending,
+    new Promise<void>((resolve) => {
+      timer = setTimeout(resolve, SEND_LOOKUP_GRACE_MS);
+    }),
+  ]);
+  if (timer !== undefined) clearTimeout(timer);
 }
 
 function stateKey(scope: string | null | undefined, url: string | null): string | null {

--- a/chat/tests/link-preview-composer.test.ts
+++ b/chat/tests/link-preview-composer.test.ts
@@ -202,6 +202,56 @@ describe("composer link preview state", () => {
     expect(h.preview.sendPayload.value).toBeUndefined();
     h.stop();
   });
+
+  test("sendPayloadFor waits for the active lookup before quick sends", async () => {
+    const resolvers: Array<(result: LinkPreviewLookupResult) => void> = [];
+    const h = setupComposerPreviewHarness(() => (
+      new Promise<LinkPreviewLookupResult>((resolve) => resolvers.push(resolve))
+    ));
+
+    await nextTick();
+    expect(h.preview.state.value).toEqual({ kind: "loading", url: "https://example.com/a" });
+
+    let settled = false;
+    const payloadPromise = h.preview
+      .sendPayloadFor("read https://example.com/a")
+      .then((payload) => {
+        settled = true;
+        return payload;
+      });
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    resolvers[0]?.(readyLookup("token-a"));
+    await flushComposerPreview();
+
+    expect(await payloadPromise).toEqual({
+      token: "token-a",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+      preview: {
+        originalUrl: "https://example.com/a",
+        normalizedUrl: "https://example.com/a",
+        title: "Example",
+      },
+    });
+    h.stop();
+  });
+
+  test("sendPayloadFor ignores in-flight metadata for a different body URL", async () => {
+    const resolvers: Array<(result: LinkPreviewLookupResult) => void> = [];
+    const h = setupComposerPreviewHarness(() => (
+      new Promise<LinkPreviewLookupResult>((resolve) => resolvers.push(resolve))
+    ));
+
+    await nextTick();
+
+    expect(await h.preview.sendPayloadFor("read https://other.example/a")).toBeUndefined();
+
+    resolvers[0]?.(readyLookup("token-a"));
+    await flushComposerPreview();
+    h.stop();
+  });
 });
 
 function setupComposerPreviewHarness(


### PR DESCRIPTION
## Summary

Fixes a quick-send race in the web chat composer where a mobile tap could send a URL message before the in-flight link-preview lookup finished, causing the message to permanently omit preview metadata.

## Root Cause

The composer preview lookup is async and fail-open. The send handler previously read only the current synchronous preview state. If the state was still `loading`, the message sent immediately with no `linkPreviewToken`, even if the lookup resolved moments later.

## Completed Work

- Added a bounded send-time grace wait for the active composer link-preview lookup.
- Keys the wait to the exact body/URL being sent so stale lookup metadata is not reused for a different URL.
- Keeps fail-open behavior when lookup fails, is unsupported, is dismissed, expires, or exceeds the bounded grace window.
- Marks the composer locally busy during the short preparation window so repeated mobile taps cannot duplicate the send.
- Added regression coverage for quick-send timing and mismatched in-flight URLs.

## XEP Review

- Reviewed `./xeps/xep-0511.xml`.
- The wire shape remains unchanged: this PR only improves when the existing composer lookup token is attached before sending.
- XEP-0511 metadata generation, parsing, and Waddle's internal `urn:waddle:link-preview:0` lookup handshake remain as implemented in #837.

## Verification

- `bun test tests/link-preview-composer.test.ts tests/link-preview.test.ts tests/chat-send.test.ts tests/muc-send.test.ts tests/offline-queue.test.ts`
- `bun test`
- `bun run build`
- `bun run lint`
- `git diff --check`

## Notes

- `bun run build` still reports the existing Astro hint in `src/lib/xmpp/discovery.ts` and the existing Vite large-chunk warning; neither is introduced by this PR.
- Manual phone-browser send against a live backend was not run locally.