### PR TITLE
fix(chat): snapshot preview metadata during send prep

### DIFF
--- a/chat/src/components/chat/MessageComposer.vue
+++ b/chat/src/components/chat/MessageComposer.vue
@@ -16,6 +16,7 @@ import { filterSlashCandidates, resolveSlashCommand } from "@/lib/slash-match";
 import { buildSlashInvocation, type SlashInvocation } from "@/lib/slash-dispatch";
 import type { DiscoveredExtensionCommand } from "@/lib/xmpp/extension-commands";
 import { useComposerLinkPreview } from "@/lib/use-composer-link-preview";
+import { prepareComposerSendEvent } from "@/lib/composer-send-preparation";
 import type { ComposerLinkPreviewLookup, ComposerLinkPreviewSendPayload } from "@/lib/link-preview-composer";
 import {
   isAudioFile,
@@ -138,6 +139,7 @@ function formatFileSize(bytes: number): string {
 }
 
 function addAttachments(files: Array<File | Blob>) {
+  if (isPreparingSend.value) return;
   const next = pendingAttachments.value.slice();
   for (const file of files) {
     const name = attachmentName(file);
@@ -468,15 +470,19 @@ async function onSend(doc: JSONContent) {
       pendingAttachments.value = [];
       for (const a of attachments) URL.revokeObjectURL(a.previewUrl);
     }
-    const previewPayload = await linkPreview.sendPayloadFor(serialized.body);
+    const prepared = await prepareComposerSendEvent({
+      serialized,
+      files,
+      linkPreviewForBody: linkPreview.sendPayloadFor,
+    });
 
     emit(
       "send",
-      serialized.body,
-      serialized.markup,
-      serialized.references,
-      files.length > 0 ? files : undefined,
-      previewPayload,
+      prepared.body,
+      prepared.markup,
+      prepared.references,
+      prepared.files,
+      prepared.linkPreview,
     );
   } finally {
     isPreparingSend.value = false;
@@ -499,6 +505,10 @@ function openFilePicker() {
 
 function onFileInputChange(e: Event) {
   const input = e.target as HTMLInputElement | null;
+  if (isPreparingSend.value) {
+    if (input) input.value = "";
+    return;
+  }
   if (!input?.files?.length) return;
   addAttachments(Array.from(input.files));
   input.value = "";
@@ -523,7 +533,7 @@ function onEditorCancel() {
     return;
   }
 
-  if (action === "cancel-reply") {
+  if (action === "cancel-reply" && !isPreparingSend.value) {
     emit("cancelReply");
   }
 }
@@ -559,6 +569,7 @@ function onKeydown(e: KeyboardEvent) {
 }
 
 function onGifSelected(url: string) {
+  if (isPreparingSend.value) return;
   showGifPicker.value = false;
   emit("selectGif", url);
 }
@@ -581,6 +592,10 @@ watch(
     }
   },
 );
+
+watch(isPreparingSend, (preparing) => {
+  if (preparing) showGifPicker.value = false;
+});
 
 </script>
 
@@ -617,6 +632,7 @@ watch(
           class="ml-auto h-8 w-8 flex items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
           title="Cancel reply"
           aria-label="Cancel reply"
+          :disabled="isPreparingSend"
           @click="emit('cancelReply')"
         >
           <X class="w-3.5 h-3.5" />
@@ -646,6 +662,7 @@ watch(
           class="h-8 w-8 flex items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
           title="Remove preview"
           aria-label="Remove preview"
+          :disabled="isPreparingSend"
           @click="linkPreview.dismiss"
         >
           <X class="h-3.5 w-3.5" aria-hidden="true" />
@@ -663,7 +680,7 @@ watch(
           v-model="forumTitle"
           type="text"
           class="type-card-title w-full bg-transparent placeholder:text-muted-foreground/45 focus:outline-none"
-          :disabled="disabled || isSending"
+          :disabled="disabled || isSendBusy"
           placeholder="Add a clear title"
           aria-label="Topic title"
         />
@@ -871,6 +888,7 @@ watch(
         type="file"
         multiple
         class="hidden"
+        :disabled="disabled || isPreparingSend"
         @change="onFileInputChange"
       />
       <!-- LEFT cluster: content-add actions (attach, GIF). The picker
@@ -882,7 +900,7 @@ watch(
         class="chat-composer-input-action h-9 w-9 shrink-0 flex items-center justify-center transition-all duration-200 text-muted-foreground hover:bg-background/70 hover:text-primary active:scale-[0.94] disabled:opacity-40 disabled:active:scale-100 [@media(pointer:coarse)]:h-11 [@media(pointer:coarse)]:w-11"
         title="Attach files"
         aria-label="Attach files"
-        :disabled="disabled"
+        :disabled="disabled || isPreparingSend"
         @click="openFilePicker"
       >
         <Paperclip class="w-4 h-4" aria-hidden="true" />
@@ -894,7 +912,7 @@ watch(
         title="Search GIFs"
         aria-label="Search GIFs"
         :aria-expanded="showGifPicker"
-        :disabled="disabled"
+        :disabled="disabled || isPreparingSend"
         @click="showGifPicker = !showGifPicker"
       >
         <span class="chat-composer-gif-badge" aria-hidden="true">GIF</span>
@@ -904,7 +922,7 @@ watch(
         class="min-w-0"
         embedded
         :placeholder="editorPlaceholder"
-        :disabled="disabled || slowModeCooldown > 0"
+        :disabled="disabled || slowModeCooldown > 0 || isPreparingSend"
         @send="onSend"
         @update="onEditorUpdate"
         @selection-update="checkAutocompleteFromEditor"
@@ -922,7 +940,7 @@ watch(
         title="Extensions"
         aria-label="Extensions"
         :aria-expanded="extensionsOpen"
-        :disabled="disabled"
+        :disabled="disabled || isPreparingSend"
         @click="emit('openExtensions')"
       >
         <Puzzle class="w-4 h-4" aria-hidden="true" />

--- a/chat/src/lib/composer-send-preparation.ts
+++ b/chat/src/lib/composer-send-preparation.ts
@@ -1,0 +1,26 @@
+import type { ComposerLinkPreviewSendPayload } from "@/lib/link-preview-composer";
+import type { RichMessage } from "@/lib/rich-message/types";
+
+interface PreparedComposerSend extends RichMessage {
+  files?: Array<File | Blob>;
+  linkPreview?: ComposerLinkPreviewSendPayload;
+}
+
+export async function prepareComposerSendEvent({
+  serialized,
+  files,
+  linkPreviewForBody,
+}: {
+  serialized: RichMessage;
+  files: Array<File | Blob>;
+  linkPreviewForBody: (body: string) => Promise<ComposerLinkPreviewSendPayload | undefined>;
+}): Promise<PreparedComposerSend> {
+  const linkPreview = await linkPreviewForBody(serialized.body);
+  return {
+    body: serialized.body,
+    markup: serialized.markup,
+    references: serialized.references,
+    files: files.length > 0 ? files : undefined,
+    linkPreview,
+  };
+}

--- a/chat/src/lib/use-composer-link-preview.ts
+++ b/chat/src/lib/use-composer-link-preview.ts
@@ -10,7 +10,7 @@ import {
 
 // The production lookup has its own 2s timeout; keep send fail-open if a
 // replacement lookup implementation ever forgets to bound its promise.
-const SEND_LOOKUP_GRACE_MS = 2_250;
+export const SEND_LOOKUP_GRACE_MS = 2_250;
 
 export function useComposerLinkPreview(
   draft: Ref<string>,
@@ -21,7 +21,7 @@ export function useComposerLinkPreview(
   let lookupEpoch = 0;
   let activeKey: string | null = null;
   let activeLookup: ComposerLinkPreviewLookup | null = null;
-  let activeLookupSettled: Promise<void> | null = null;
+  let activeLookupSettled: Promise<ComposerLinkPreviewState> | null = null;
 
   const showCard = computed(() => state.value.kind !== "idle");
   const host = computed(() => {
@@ -64,11 +64,15 @@ export function useComposerLinkPreview(
     const key = stateKey(scopeKey.value, url);
     if (!key) return undefined;
 
-    if (key === activeKey && state.value.kind === "loading" && activeLookupSettled) {
-      await settleWithGrace(activeLookupSettled);
+    if (key !== activeKey) return undefined;
+
+    const pending = state.value.kind === "loading" ? activeLookupSettled : null;
+    if (pending) {
+      const settledState = await settleWithGrace(pending);
+      return settledState ? sendPayloadFromState(settledState) : undefined;
     }
 
-    return key === activeKey ? sendPayloadFromState(state.value) : undefined;
+    return sendPayloadFromState(state.value);
   }
 
   watch(
@@ -103,11 +107,17 @@ export function useComposerLinkPreview(
         rawLookup = Promise.reject();
       }
       const lookupSettled = rawLookup.then((result) => {
-        if (epoch !== lookupEpoch) return;
-        state.value = linkPreviewStateFromLookup(url, result);
+        const nextState = linkPreviewStateFromLookup(url, result);
+        if (epoch === lookupEpoch) {
+          state.value = nextState;
+        }
+        return nextState;
       }).catch(() => {
-        if (epoch !== lookupEpoch) return;
-        state.value = { kind: "failed", url };
+        const nextState: ComposerLinkPreviewState = { kind: "failed", url };
+        if (epoch === lookupEpoch) {
+          state.value = nextState;
+        }
+        return nextState;
       });
       activeLookupSettled = lookupSettled;
       void lookupSettled.finally(() => {
@@ -132,15 +142,16 @@ export function useComposerLinkPreview(
   };
 }
 
-async function settleWithGrace(pending: Promise<void>): Promise<void> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  await Promise.race([
+async function settleWithGrace<T>(pending: Promise<T>): Promise<T | undefined> {
+  let timer: Parameters<typeof clearTimeout>[0] | undefined;
+  const result = await Promise.race<T | undefined>([
     pending,
-    new Promise<void>((resolve) => {
+    new Promise<undefined>((resolve) => {
       timer = setTimeout(resolve, SEND_LOOKUP_GRACE_MS);
     }),
   ]);
   if (timer !== undefined) clearTimeout(timer);
+  return result;
 }
 
 function stateKey(scope: string | null | undefined, url: string | null): string | null {

--- a/chat/tests/link-preview-composer.test.ts
+++ b/chat/tests/link-preview-composer.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
 import { effectScope, nextTick, ref } from "vue";
 import {
   composerLinkPreviewUrl,
@@ -6,7 +7,8 @@ import {
   linkPreviewStateFromLookup,
   sendPayloadFromState,
 } from "../src/lib/link-preview-composer";
-import { useComposerLinkPreview } from "../src/lib/use-composer-link-preview";
+import { prepareComposerSendEvent } from "../src/lib/composer-send-preparation";
+import { SEND_LOOKUP_GRACE_MS, useComposerLinkPreview } from "../src/lib/use-composer-link-preview";
 import type { LinkPreviewLookupResult } from "../src/lib/xmpp/link-preview";
 
 describe("composer link preview state", () => {
@@ -238,6 +240,53 @@ describe("composer link preview state", () => {
     h.stop();
   });
 
+  test("sendPayloadFor keeps the send-time preview when the draft changes while waiting", async () => {
+    const resolvers: Array<(result: LinkPreviewLookupResult) => void> = [];
+    const h = setupComposerPreviewHarness(() => (
+      new Promise<LinkPreviewLookupResult>((resolve) => resolvers.push(resolve))
+    ));
+
+    await nextTick();
+    expect(h.preview.state.value).toEqual({ kind: "loading", url: "https://example.com/a" });
+
+    const payloadPromise = h.preview.sendPayloadFor("read https://example.com/a");
+    h.draft.value = "read https://other.example/a";
+    await nextTick();
+    expect(resolvers).toHaveLength(2);
+    expect(h.preview.state.value).toEqual({ kind: "loading", url: "https://other.example/a" });
+
+    resolvers[0]?.(readyLookup("token-a"));
+    await flushComposerPreview();
+    expect(h.preview.state.value).toEqual({ kind: "loading", url: "https://other.example/a" });
+
+    expect(await payloadPromise).toEqual({
+      token: "token-a",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+      preview: {
+        originalUrl: "https://example.com/a",
+        normalizedUrl: "https://example.com/a",
+        title: "Example",
+      },
+    });
+
+    resolvers[1]?.(readyLookup("token-b", "https://other.example/a"));
+    await flushComposerPreview();
+    expect(h.preview.state.value).toEqual({
+      kind: "ready",
+      url: "https://other.example/a",
+      payload: {
+        token: "token-b",
+        expiresAt: "2999-01-01T00:00:00.000Z",
+        preview: {
+          originalUrl: "https://other.example/a",
+          normalizedUrl: "https://other.example/a",
+          title: "Example",
+        },
+      },
+    });
+    h.stop();
+  });
+
   test("sendPayloadFor ignores in-flight metadata for a different body URL", async () => {
     const resolvers: Array<(result: LinkPreviewLookupResult) => void> = [];
     const h = setupComposerPreviewHarness(() => (
@@ -251,6 +300,93 @@ describe("composer link preview state", () => {
     resolvers[0]?.(readyLookup("token-a"));
     await flushComposerPreview();
     h.stop();
+  });
+
+  test("sendPayloadFor fails open when the active lookup never settles", async () => {
+    const h = setupComposerPreviewHarness(() => new Promise<never>(() => {}));
+
+    await nextTick();
+    const timers = installFakeTimeouts();
+
+    try {
+      let settled = false;
+      const payloadPromise = h.preview.sendPayloadFor("read https://example.com/a").then((payload) => {
+        settled = true;
+        return payload;
+      });
+
+      await Promise.resolve();
+      expect(timers.delays).toEqual([SEND_LOOKUP_GRACE_MS]);
+      expect(settled).toBe(false);
+
+      timers.runNext();
+      expect(await payloadPromise).toBeUndefined();
+      expect(settled).toBe(true);
+    } finally {
+      timers.restore();
+      h.stop();
+    }
+  });
+
+  test("prepareComposerSendEvent forwards the awaited preview payload with the send body", async () => {
+    let resolvePreview: (payload: LinkPreviewLookupResult) => void = () => {};
+    const bodies: string[] = [];
+    const file = new Blob(["hello"], { type: "text/plain" });
+    const serialized = {
+      body: "read https://example.com/a",
+      markup: [{ type: "span" as const, start: 0, end: 4, styles: ["strong" as const] }],
+      references: [{ type: "data", uri: "https://example.com/a", begin: 5, end: 26 }],
+    };
+
+    const preparedPromise = prepareComposerSendEvent({
+      serialized,
+      files: [file],
+      linkPreviewForBody: async (body) => {
+        bodies.push(body);
+        const lookup = await new Promise<LinkPreviewLookupResult>((resolve) => {
+          resolvePreview = resolve;
+        });
+        return linkPreviewPayloadFromLookup(lookup) ?? undefined;
+      },
+    });
+
+    await Promise.resolve();
+    expect(bodies).toEqual(["read https://example.com/a"]);
+
+    resolvePreview(readyLookup("token-a"));
+
+    expect(await preparedPromise).toEqual({
+      ...serialized,
+      files: [file],
+      linkPreview: {
+        token: "token-a",
+        expiresAt: "2999-01-01T00:00:00.000Z",
+        preview: {
+          originalUrl: "https://example.com/a",
+          normalizedUrl: "https://example.com/a",
+          title: "Example",
+        },
+      },
+    });
+  });
+
+  test("MessageComposer disables mutable controls while preparing a send", () => {
+    const source = readFileSync(
+      new URL("../src/components/chat/MessageComposer.vue", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).toContain(":disabled=\"disabled || isSendBusy\"");
+    expect(source).toContain(":disabled=\"disabled || slowModeCooldown > 0 || isPreparingSend\"");
+    expect(source).toContain("prepareComposerSendEvent({");
+    expect(source).toContain("linkPreviewForBody: linkPreview.sendPayloadFor");
+    expect(source).toContain("prepared.linkPreview");
+    expect(source).toContain("if (action === \"cancel-reply\" && !isPreparingSend.value)");
+    expect(source).toContain("function addAttachments(files: Array<File | Blob>) {\n  if (isPreparingSend.value) return;");
+    expect(source).toContain("function onGifSelected(url: string) {\n  if (isPreparingSend.value) return;");
+    expect(source).toContain("watch(isPreparingSend, (preparing) => {\n  if (preparing) showGifPicker.value = false;");
+    expect(source.match(/:disabled="disabled \|\| isPreparingSend"/g)?.length ?? 0).toBeGreaterThanOrEqual(4);
+    expect(source.match(/:disabled="isPreparingSend"/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
   });
 });
 
@@ -274,12 +410,12 @@ function setupComposerPreviewHarness(
   };
 }
 
-function readyLookup(token: string): LinkPreviewLookupResult {
+function readyLookup(token: string, url = "https://example.com/a"): LinkPreviewLookupResult {
   return {
     status: "ready",
     token,
-    originalUrl: "https://example.com/a",
-    normalizedUrl: "https://example.com/a",
+    originalUrl: url,
+    normalizedUrl: url,
     expiresAt: "2999-01-01T00:00:00.000Z",
     title: "Example",
   };
@@ -288,4 +424,38 @@ function readyLookup(token: string): LinkPreviewLookupResult {
 async function flushComposerPreview() {
   await Promise.resolve();
   await nextTick();
+}
+
+function installFakeTimeouts() {
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  const delays: number[] = [];
+  const pending = new Map<number, () => void>();
+  let nextId = 1;
+
+  globalThis.setTimeout = ((handler: (...args: unknown[]) => void, timeout?: number, ...args: unknown[]) => {
+    const id = nextId++;
+    delays.push(timeout ?? 0);
+    pending.set(id, () => handler(...args));
+    return id as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout;
+
+  globalThis.clearTimeout = ((id?: Parameters<typeof clearTimeout>[0]) => {
+    pending.delete(id as unknown as number);
+  }) as typeof clearTimeout;
+
+  return {
+    delays,
+    runNext() {
+      const id = pending.keys().next().value as number | undefined;
+      if (id === undefined) return;
+      const callback = pending.get(id);
+      pending.delete(id);
+      callback?.();
+    },
+    restore() {
+      globalThis.setTimeout = originalSetTimeout;
+      globalThis.clearTimeout = originalClearTimeout;
+    },
+  };
 }


### PR DESCRIPTION
## Summary

Follow-up to #838. The composer now preserves XEP-0511 link-preview metadata for the exact body being sent during the bounded quick-send lookup wait, even if live composer state changes before the lookup settles.

## Completed Work

- Changed `sendPayloadFor()` to resolve against the send-time lookup result instead of re-reading mutable live preview state after the wait.
- Added `prepareComposerSendEvent()` so the async body/payload pairing is directly tested without adding a Vue mounting dependency.
- Froze mutation paths while `isPreparingSend` is true: editor, topic title, preview dismissal, reply cancel, file picker/paste/exposed attachment add, extension button, GIF toggle, already-open GIF picker, and GIF selection.
- Added regression coverage for send-time preview snapshots, stale live-state suppression, precise grace-timeout fail-open behavior, send event payload forwarding, and the preparation-window mutation guards.

## XEP Review

- Reviewed the link-preview path against `./xeps/xep-0511.xml`.
- No wire-shape change: this PR only changes composer timing/state handling around the existing XEP-0511 metadata emission path.

## Verification

- `bun test tests/link-preview-composer.test.ts tests/link-preview.test.ts tests/chat-send.test.ts tests/muc-send.test.ts tests/offline-queue.test.ts` — 72 pass
- `bun test` — 1551 pass
- `bun run build` — pass; existing Astro hint in `src/lib/xmpp/discovery.ts:77` and existing large chunk warning still present
- `bun run lint` — pass
- `git diff --check` — pass
- Adversarial subagent review after final guards — no actionable issues found

## Notes

- The repo does not currently use a Vue component mounting harness, so component behavior around send preparation is covered through a small extracted helper plus source-level guard assertions.
- Remaining untracked planning docs in `docs/planning/` were left untouched.