### PR TITLE
fix(chat): recover websocket stream management bootstrap

### DIFF
--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -4,10 +4,11 @@ use super::{
     frame::handle_xmpp_frame,
     outbound::handle_outbound_stanza,
     registration::{register_bound_connection_after_frame, RegistrationAfterFrame},
-    send::{send_ws_message, send_ws_text_frames},
+    send::{close_ws_connection, send_ws_message, send_ws_text_frames},
     session_init::build_internal_server_error_stream_error,
     state::WsConnState,
     stream_management::{is_countable_stanza, SmRegistrationFinalization},
+    transport_xml::websocket_stream_close_xml,
 };
 use waddle_xmpp::stream_management::SmRequest;
 
@@ -103,10 +104,15 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
                                 let stream_error = build_internal_server_error_stream_error(
                                     "Session initialization failed; please reconnect.",
                                 );
-                                let _ = send_ws_message(
+                                let _ = send_ws_text_frames(
                                     &mut ws_sender,
-                                    Message::Text(stream_error.into()),
-                                    "Failed to send blocklist-load stream error",
+                                    [stream_error, websocket_stream_close_xml()],
+                                    "Failed to send session-init stream error",
+                                )
+                                .await;
+                                let _ = close_ws_connection(
+                                    &mut ws_sender,
+                                    "Failed to send WebSocket close frame after session-init error",
                                 )
                                 .await;
                                 break;
@@ -129,6 +135,8 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
                                 }
                             }
                         }
+
+                        ensure_websocket_stream_close_for_closing_phase(&conn, &mut responses);
 
                         // Record outbound stanzas for XEP-0198 replay BEFORE
                         // writing them to the socket. If SM is enabled and
@@ -183,6 +191,11 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
                         }
 
                         if matches!(conn.phase, ConnectionPhase::Closing { .. }) {
+                            let _ = close_ws_connection(
+                                &mut ws_sender,
+                                "Failed to send WebSocket close frame after XMPP stream close",
+                            )
+                            .await;
                             break;
                         }
                     }
@@ -265,4 +278,57 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
     cleanup_connection_shutdown(state.as_ref(), &mut outbound_rx, &mut conn, superseded).await;
 
     info!("XMPP WebSocket connection closed");
+}
+
+fn ensure_websocket_stream_close_for_closing_phase(
+    conn: &WsConnState,
+    responses: &mut Vec<String>,
+) {
+    if !matches!(conn.phase, ConnectionPhase::Closing { .. })
+        || response_batch_ends_with_websocket_stream_close(responses)
+    {
+        return;
+    }
+
+    responses.push(websocket_stream_close_xml());
+}
+
+fn response_batch_ends_with_websocket_stream_close(responses: &[String]) -> bool {
+    let websocket_close = websocket_stream_close_xml();
+    responses
+        .last()
+        .is_some_and(|frame| frame == &websocket_close)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn closing_phase_appends_websocket_stream_close_frame() {
+        let mut conn = WsConnState::new();
+        conn.phase = ConnectionPhase::closing(None);
+        let mut responses = vec![element_to_xml(
+            Element::builder("failed", waddle_xmpp::stream_management::SM_NS).build(),
+        )];
+
+        ensure_websocket_stream_close_for_closing_phase(&conn, &mut responses);
+
+        assert_eq!(responses.len(), 2);
+        let close = Element::from_str(&responses[1]).expect("close frame xml");
+        assert_eq!(close.name(), "close");
+        assert_eq!(close.ns(), "urn:ietf:params:xml:ns:xmpp-framing");
+    }
+
+    #[test]
+    fn closing_phase_does_not_duplicate_websocket_stream_close_frame() {
+        let mut conn = WsConnState::new();
+        conn.phase = ConnectionPhase::closing(None);
+        let mut responses = vec![websocket_stream_close_xml()];
+
+        ensure_websocket_stream_close_for_closing_phase(&conn, &mut responses);
+
+        assert_eq!(responses.len(), 1);
+    }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/frame.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame.rs
@@ -6,7 +6,10 @@ use super::{
     sasl::{handle_sasl_oauthbearer, handle_sasl_scram_client_first, handle_sasl_scram_response},
     state::WsConnState,
     stream_management::{handle_sm_stanza, SmCtx},
-    transport_xml::{build_stream_features_for_phase, sasl_failure_xml},
+    transport_xml::{
+        build_stream_features_for_phase, sasl_failure_xml, websocket_stream_close_xml,
+        websocket_stream_open_xml,
+    },
 };
 
 /// Handle an XMPP frame per RFC 7395
@@ -87,11 +90,7 @@ pub(super) async fn handle_xmpp_frame(
     match inbound {
         InboundFrame::Open => {
             info!("XMPP stream open requested");
-            let open_element = format!(
-                r#"<open xmlns="urn:ietf:params:xml:ns:xmpp-framing" from="{}" id="{}" version="1.0" xml:lang="en"/>"#,
-                domain,
-                uuid::Uuid::new_v4()
-            );
+            let open_element = websocket_stream_open_xml(domain);
             let features_element = build_stream_features_for_phase(phase);
             vec![open_element, features_element]
         }
@@ -99,7 +98,7 @@ pub(super) async fn handle_xmpp_frame(
         InboundFrame::Close => {
             info!("XMPP stream close requested");
             *phase = ConnectionPhase::closing(phase.bound_jid().cloned());
-            vec![r#"<close xmlns="urn:ietf:params:xml:ns:xmpp-framing"/>"#.to_string()]
+            vec![websocket_stream_close_xml()]
         }
 
         InboundFrame::Auth { mechanism, data } => {

--- a/server/crates/waddle-server/src/server/routes/websocket/send.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/send.rs
@@ -37,3 +37,17 @@ where
         }
     }
 }
+
+pub(super) async fn close_ws_connection<S, E>(sender: &mut S, failure_message: &'static str) -> bool
+where
+    S: Sink<Message, Error = E> + Unpin,
+    E: std::fmt::Display,
+{
+    match sender.close().await {
+        Ok(()) => true,
+        Err(error) => {
+            error!(error = %error, "{failure_message}");
+            false
+        }
+    }
+}

--- a/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
@@ -1,4 +1,4 @@
-use super::transport_xml::build_handled_count_too_high_stream_error;
+use super::transport_xml::{build_handled_count_too_high_stream_error, websocket_stream_close_xml};
 use super::*;
 
 mod registration;
@@ -282,10 +282,16 @@ async fn handle_sm_resume(resume: SmResume, state: &WebSocketState, ctx: SmCtx<'
             warn!(stream_id = %resume.previd, error = %error, "Failed to release invalid SM resume claim");
         }
         *phase = ConnectionPhase::closing(None);
-        return vec![build_handled_count_too_high_stream_error(
-            resume.h,
-            detached.outbound_count,
-        )];
+        info!(
+            stream_id = %resume.previd,
+            client_h = resume.h,
+            send_count = detached.outbound_count,
+            "SM resume rejected: handled count too high"
+        );
+        return vec![
+            build_handled_count_too_high_stream_error(resume.h, detached.outbound_count),
+            websocket_stream_close_xml(),
+        ];
     }
 
     if !detached.can_resume_from(resume.h) {

--- a/server/crates/waddle-server/src/server/routes/websocket/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests.rs
@@ -3,8 +3,11 @@ use super::{
     frame::handle_xmpp_frame,
     interpret_loop::build_interpret_deps,
     replay::drive_interpret_loop,
+    session_init::build_internal_server_error_stream_error,
     state::WsConnState,
-    transport_xml::{build_stream_features_xml, sasl_failure_xml, sasl_success_xml},
+    transport_xml::{
+        build_stream_features_xml, sasl_failure_xml, sasl_success_xml, websocket_stream_close_xml,
+    },
 };
 use crate::config::ServerConfig;
 use crate::db::{DatabaseConfig, DatabasePool, MigrationRunner, PoolConfig};

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/frame_parsing.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/frame_parsing.rs
@@ -166,10 +166,7 @@ async fn websocket_close_moves_connection_into_closing_phase() {
     )
     .await;
 
-    assert_eq!(
-        responses,
-        vec![r#"<close xmlns="urn:ietf:params:xml:ns:xmpp-framing"/>"#.to_string()]
-    );
+    assert_single_websocket_close_frame(&responses);
     assert!(matches!(conn.phase, ConnectionPhase::Closing { .. }));
 }
 
@@ -188,10 +185,7 @@ async fn websocket_close_keeps_bound_connection_in_closing_phase() {
     )
     .await;
 
-    assert_eq!(
-        responses,
-        vec![r#"<close xmlns="urn:ietf:params:xml:ns:xmpp-framing"/>"#.to_string()]
-    );
+    assert_single_websocket_close_frame(&responses);
     assert!(matches!(conn.phase, ConnectionPhase::Closing { .. }));
 
     let _ = handle_xmpp_frame(
@@ -202,6 +196,13 @@ async fn websocket_close_keeps_bound_connection_in_closing_phase() {
     )
     .await;
     assert!(matches!(conn.phase, ConnectionPhase::Closing { .. }));
+}
+
+fn assert_single_websocket_close_frame(responses: &[String]) {
+    assert_eq!(responses.len(), 1);
+    let close = Element::from_str(&responses[0]).expect("close frame xml");
+    assert_eq!(close.name(), "close");
+    assert_eq!(close.ns(), "urn:ietf:params:xml:ns:xmpp-framing");
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/send.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/send.rs
@@ -1,4 +1,4 @@
-use super::super::send::{send_ws_message, send_ws_text_frames};
+use super::super::send::{close_ws_connection, send_ws_message, send_ws_text_frames};
 use axum::extract::ws::Message;
 use futures::Sink;
 use std::pin::Pin;
@@ -7,6 +7,7 @@ use std::task::{Context, Poll};
 #[derive(Default)]
 struct TestSink {
     fail_after: Option<usize>,
+    closed: bool,
     sent: Vec<Message>,
 }
 
@@ -18,6 +19,7 @@ impl TestSink {
     fn fails_after(sent_before_failure: usize) -> Self {
         Self {
             fail_after: Some(sent_before_failure),
+            closed: false,
             sent: Vec::new(),
         }
     }
@@ -43,7 +45,11 @@ impl Sink<Message> for TestSink {
         Poll::Ready(Ok(()))
     }
 
-    fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_close(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        self.closed = true;
         Poll::Ready(Ok(()))
     }
 }
@@ -76,4 +82,14 @@ async fn send_ws_message_returns_true_on_success() {
 
     assert!(sent);
     assert_eq!(sink.sent.len(), 1);
+}
+
+#[tokio::test]
+async fn close_ws_connection_closes_sink() {
+    let mut sink = TestSink::succeeds();
+
+    let closed = close_ws_connection(&mut sink, "unexpected failure").await;
+
+    assert!(closed);
+    assert!(sink.closed);
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/stream_features.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/stream_features.rs
@@ -22,3 +22,21 @@ async fn rfc6121_features_advertise_subscription_preapproval() {
         "post-auth features must advertise RFC 6121 subscription pre-approval"
     );
 }
+
+#[test]
+fn session_init_failure_uses_standalone_stream_error_plus_websocket_close() {
+    let stream_error = build_internal_server_error_stream_error(
+        "Session initialization failed; please reconnect.",
+    );
+    let error = Element::from_str(&stream_error).expect("stream error xml");
+    assert_eq!(error.name(), "error");
+    assert_eq!(error.ns(), waddle_xmpp::ns::STREAM);
+    assert!(
+        !stream_error.contains("</stream:stream>"),
+        "RFC 7395 close must be a separate websocket frame"
+    );
+
+    let close = Element::from_str(&websocket_stream_close_xml()).expect("close frame xml");
+    assert_eq!(close.name(), "close");
+    assert_eq!(close.ns(), "urn:ietf:params:xml:ns:xmpp-framing");
+}

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
@@ -741,7 +741,14 @@ async fn sm_resume_rejects_impossible_client_handled_count() {
     let responses =
         handle_xmpp_frame(&resume_frame, "example.com", state.as_ref(), &mut conn).await;
 
-    assert_eq!(responses.len(), 1);
+    assert_eq!(responses.len(), 2);
+    let stream_error = Element::from_str(&responses[0]).expect("stream error xml");
+    assert_eq!(stream_error.name(), "error");
+    assert_eq!(stream_error.ns(), waddle_xmpp::ns::STREAM);
+    assert!(
+        !responses[0].contains("</stream:stream>"),
+        "RFC 7395 WebSocket stream close must be a separate close frame"
+    );
     assert!(
         responses[0].contains("stream:error")
             && responses[0].contains("undefined-condition")
@@ -751,6 +758,9 @@ async fn sm_resume_rejects_impossible_client_handled_count() {
                 || responses[0].contains("send-count=\"2\"")),
         "invalid resume count should be a handled-count-too-high stream error: {responses:?}"
     );
+    let close = Element::from_str(&responses[1]).expect("close frame xml");
+    assert_eq!(close.name(), "close");
+    assert_eq!(close.ns(), "urn:ietf:params:xml:ns:xmpp-framing");
     assert!(
         !conn.sm_state.enabled,
         "rejected resume must not pollute the fresh stream SM state"

--- a/server/crates/waddle-server/src/server/routes/websocket/transport_xml.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/transport_xml.rs
@@ -55,6 +55,27 @@ pub(crate) fn element_to_xml(element: xmpp_parsers::minidom::Element) -> String 
     String::from_utf8(buf).expect("xmpp_parsers serializes valid UTF-8")
 }
 
+pub(super) fn websocket_stream_open_xml(domain: &str) -> String {
+    let open = Element::builder("open", "urn:ietf:params:xml:ns:xmpp-framing")
+        .attr(minidom::rxml::xml_ncname!("from").to_owned(), domain)
+        .attr(
+            minidom::rxml::xml_ncname!("id").to_owned(),
+            uuid::Uuid::new_v4().to_string(),
+        )
+        .attr(minidom::rxml::xml_ncname!("version").to_owned(), "1.0")
+        .attr_ns(
+            minidom::rxml::Namespace::XML,
+            minidom::rxml::xml_ncname!("lang").to_owned(),
+            "en",
+        )
+        .build();
+    element_to_xml(open)
+}
+
+pub(super) fn websocket_stream_close_xml() -> String {
+    element_to_xml(Element::builder("close", "urn:ietf:params:xml:ns:xmpp-framing").build())
+}
+
 pub(crate) fn iq_to_xml(iq: xmpp_parsers::iq::Iq) -> String {
     stanza_to_xml(&Stanza::Iq(Box::new(iq)))
 }
@@ -160,9 +181,6 @@ pub(super) fn build_handled_count_too_high_stream_error(
     writer
         .write_event(Event::End(BytesEnd::new("stream:error")))
         .expect("serializing stream error end should not fail");
-    writer
-        .write_event(Event::End(BytesEnd::new("stream:stream")))
-        .expect("serializing stream close should not fail");
     String::from_utf8(writer.into_inner()).expect("quick-xml serializes valid UTF-8")
 }
 

--- a/server/crates/waddle-server/tests/xep0503_spaces_ws.rs
+++ b/server/crates/waddle-server/tests/xep0503_spaces_ws.rs
@@ -82,6 +82,7 @@ async fn spaces_service_disco_info_advertises_xep0503_features() {
     for feature in [
         "urn:xmpp:spaces:0",
         "http://jabber.org/protocol/pubsub#retrieve-items",
+        "http://jabber.org/protocol/pubsub#multi-items",
         "http://jabber.org/protocol/pubsub#manage-subscriptions",
         "http://jabber.org/protocol/pubsub#modify-affiliations",
         "http://jabber.org/protocol/pubsub#retrieve-affiliations",

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0503_spaces.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0503_spaces.cue
@@ -53,6 +53,7 @@ scenario: #Scenario & {
 				"http://jabber.org/protocol/pubsub#delete-items",
 				"http://jabber.org/protocol/pubsub#retract-items",
 				"http://jabber.org/protocol/pubsub#item-ids",
+				"http://jabber.org/protocol/pubsub#multi-items",
 			]
 		},
 		#SendIq & {

--- a/server/crates/waddle-xmpp-client/src/runtime.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime.rs
@@ -271,6 +271,11 @@ impl XmppRuntime {
             return Ok(());
         }
 
+        if element.name() == "error" && element.ns() == crate::bootstrap::NS_STREAMS {
+            self.handle_stream_error_element(&element, events);
+            return Ok(());
+        }
+
         // Track inbound stanzas for SM once enabled.
         if self.sm_state.enabled && matches!(element.name(), "iq" | "message" | "presence") {
             self.sm_state.record_received(1);

--- a/server/crates/waddle-xmpp-client/src/runtime/sm.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime/sm.rs
@@ -11,6 +11,55 @@ use super::{BootstrapState, XmppRuntime};
 const NS_STREAM_ERRORS: &str = "urn:ietf:params:xml:ns:xmpp-streams";
 
 impl XmppRuntime {
+    pub(super) fn handle_stream_error_element(
+        &mut self,
+        element: &minidom::Element,
+        events: &mut Vec<ClientEvent>,
+    ) {
+        debug_assert_eq!(element.name(), "error");
+        debug_assert_eq!(element.ns(), NS_STREAMS);
+
+        // RFC 6120 defines stream errors as terminal for the current XML
+        // stream. During XEP-0198 resume bootstrap, recoverable resume-specific
+        // failures are represented by `<failed/>`; if the server instead ends
+        // the stream, keeping `previd` would replay the same failed pre-bind
+        // resume on the next WebSocket connection.
+        if matches!(self.bootstrap, BootstrapState::AwaitingResume) {
+            self.discard_failed_prebind_resume(events);
+        }
+
+        if !matches!(self.bootstrap, BootstrapState::Ready | BootstrapState::Idle) {
+            self.discard_fallback_resume_state();
+        }
+    }
+
+    pub(super) fn discard_failed_prebind_resume(&mut self, events: &mut Vec<ClientEvent>) {
+        if !matches!(self.bootstrap, BootstrapState::AwaitingResume) {
+            return;
+        }
+        if self.sm_state.previd.is_none() {
+            return;
+        }
+
+        let failed = self.sm_state.unhandled_message_stanza_ids();
+        self.sm_state.previd = None;
+        self.fallback_resume_state = None;
+        self.pending_fallback_retries.clear();
+        self.fallback_retry_writes_in_flight.clear();
+        events.extend(failed.into_iter().map(|stanza_id| {
+            ClientEvent::MessageDelivery(MessageDeliveryEvent::Failed { stanza_id })
+        }));
+        events.push(ClientEvent::Connection(ConnectionEvent::StreamManagement(
+            StreamManagementEvent::Failed,
+        )));
+    }
+
+    fn discard_fallback_resume_state(&mut self) {
+        self.fallback_resume_state = None;
+        self.pending_fallback_retries.clear();
+        self.fallback_retry_writes_in_flight.clear();
+    }
+
     pub(super) fn handle_sm_element(
         &mut self,
         element: &minidom::Element,

--- a/server/crates/waddle-xmpp-client/src/runtime/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime/tests.rs
@@ -543,9 +543,9 @@ fn runtime_releases_send_barrier_when_fresh_sm_enable_fails() {
 #[test]
 fn runtime_replays_unhandled_stanzas_after_resume_without_recounting_them() {
     let resume_state = resume_state_with_sent_messages(["handled", "unhandled"]);
-    let mut config = config();
-    config.session.stream_management.resume_state = Some(resume_state);
-    let mut runtime = XmppRuntime::new(config).unwrap();
+    let mut resume_config = config();
+    resume_config.session.stream_management.resume_state = Some(resume_state);
+    let mut runtime = XmppRuntime::new(resume_config).unwrap();
     drive_to_authenticated_stream(&mut runtime);
     runtime
         .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
@@ -807,6 +807,176 @@ fn runtime_preserves_failed_resume_snapshot_until_fallback_retry_is_sent() {
             .expect("fallback snapshot should survive fresh enable attempt"),
         "retry-after-drop",
     );
+}
+
+#[test]
+fn runtime_discards_resume_state_after_prebind_stream_error_close() {
+    let resume_state = resume_state_with_sent_messages(["retry-after-stream-error"]);
+    let mut resume_config = config();
+    resume_config.session.stream_management.resume_state = Some(resume_state);
+    let mut runtime = XmppRuntime::new(resume_config).unwrap();
+
+    drive_to_authenticated_stream(&mut runtime);
+    let feature_events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            post_auth_features_with_sm(),
+        )))
+        .unwrap();
+
+    assert!(feature_events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+            TransportMessage::Element(element)
+        )) if element.name() == "resume"
+    )));
+
+    let error_events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            handled_count_too_high_stream_error(3, 2),
+        )))
+        .unwrap();
+
+    assert!(error_events.iter().any(|event| matches!(
+        event,
+        ClientEvent::MessageDelivery(crate::MessageDeliveryEvent::Failed { stanza_id })
+            if stanza_id.as_str() == "retry-after-stream-error"
+    )));
+    assert!(error_events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::StreamManagement(
+            StreamManagementEvent::Failed
+        ))
+    )));
+    assert!(runtime.resume_state().is_none());
+
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Close(
+            StreamClose,
+        )))
+        .unwrap();
+    assert!(runtime.resume_state().is_none());
+
+    let mut next_runtime = XmppRuntime::new(config()).unwrap();
+    drive_to_authenticated_stream(&mut next_runtime);
+    let next_events = next_runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            post_auth_features_with_sm(),
+        )))
+        .unwrap();
+
+    assert!(next_events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::ResourceBindingRequested(_))
+    )));
+    assert!(!next_events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+            TransportMessage::Element(element)
+        )) if element.name() == "resume"
+    )));
+}
+
+#[test]
+fn runtime_discards_resume_state_after_generic_prebind_stream_error() {
+    let resume_state = resume_state_with_sent_messages(["retry-after-generic-stream-error"]);
+    let mut resume_config = config();
+    resume_config.session.stream_management.resume_state = Some(resume_state);
+    let mut runtime = XmppRuntime::new(resume_config).unwrap();
+
+    drive_to_authenticated_stream(&mut runtime);
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            post_auth_features_with_sm(),
+        )))
+        .unwrap();
+
+    let error_events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            internal_server_error_stream_error(),
+        )))
+        .unwrap();
+
+    assert!(error_events.iter().any(|event| matches!(
+        event,
+        ClientEvent::MessageDelivery(crate::MessageDeliveryEvent::Failed { stanza_id })
+            if stanza_id.as_str() == "retry-after-generic-stream-error"
+    )));
+    assert!(error_events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::StreamManagement(
+            StreamManagementEvent::Failed
+        ))
+    )));
+    assert!(runtime.resume_state().is_none());
+}
+
+#[test]
+fn runtime_discards_fallback_resume_state_after_prebind_stream_error() {
+    let resume_state = resume_state_with_sent_messages(["retry-after-fallback-error"]);
+    let mut resume_config = config();
+    resume_config.session.stream_management.resume_state = Some(resume_state);
+    let mut runtime = XmppRuntime::new(resume_config).unwrap();
+
+    drive_to_authenticated_stream(&mut runtime);
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            post_auth_features_with_sm(),
+        )))
+        .unwrap();
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("failed", crate::stream_management::NS_SM)
+                .attr(minidom::rxml::xml_ncname!("h").to_owned(), "0")
+                .build(),
+        )))
+        .unwrap();
+
+    assert!(
+        runtime.resume_state().is_some(),
+        "failed resume should keep fallback retry state until the fresh stream can bind"
+    );
+
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            internal_server_error_stream_error(),
+        )))
+        .unwrap();
+    assert!(runtime.resume_state().is_none());
+
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Close(
+            StreamClose,
+        )))
+        .unwrap();
+    assert!(runtime.resume_state().is_none());
+}
+
+#[test]
+fn runtime_keeps_resume_state_when_transport_fails_during_resume_without_stream_error() {
+    let resume_state = resume_state_with_sent_messages(["retry-after-transport-fail"]);
+    let expected_resume_state = resume_state.clone();
+    let mut resume_config = config();
+    resume_config.session.stream_management.resume_state = Some(resume_state);
+    let mut runtime = XmppRuntime::new(resume_config).unwrap();
+
+    drive_to_authenticated_stream(&mut runtime);
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            post_auth_features_with_sm(),
+        )))
+        .unwrap();
+
+    let events = runtime
+        .apply_transport_event(TransportEvent::StateChanged(TransportState::Failed))
+        .unwrap();
+
+    assert!(!events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::StreamManagement(
+            StreamManagementEvent::Failed
+        ))
+    )));
+    assert_eq!(runtime.resume_state(), Some(expected_resume_state));
 }
 
 #[test]
@@ -1143,6 +1313,35 @@ fn resume_state_with_sent_messages<const N: usize>(ids: [&str; N]) -> SmResumeSt
             .unwrap();
     }
     runtime.resume_state().expect("resume state")
+}
+
+fn handled_count_too_high_stream_error(h: u32, send_count: u32) -> Element {
+    Element::builder("error", NS_STREAMS)
+        .append(
+            Element::builder("undefined-condition", "urn:ietf:params:xml:ns:xmpp-streams").build(),
+        )
+        .append(
+            Element::builder("handled-count-too-high", crate::stream_management::NS_SM)
+                .attr(minidom::rxml::xml_ncname!("h").to_owned(), h.to_string())
+                .attr(
+                    minidom::rxml::xml_ncname!("send-count").to_owned(),
+                    send_count.to_string(),
+                )
+                .build(),
+        )
+        .build()
+}
+
+fn internal_server_error_stream_error() -> Element {
+    Element::builder("error", NS_STREAMS)
+        .append(
+            Element::builder(
+                "internal-server-error",
+                "urn:ietf:params:xml:ns:xmpp-streams",
+            )
+            .build(),
+        )
+        .build()
 }
 
 fn assert_resume_state_replays_id(resume_state: SmResumeState, expected_id: &str) {

--- a/server/crates/waddle-xmpp-client/src/stream_management.rs
+++ b/server/crates/waddle-xmpp-client/src/stream_management.rs
@@ -87,6 +87,13 @@ impl SmResumeState {
     pub fn unhandled_outbound_stanzas(&self) -> impl Iterator<Item = &Element> {
         self.outbound_queue.iter().map(|queued| &queued.element)
     }
+
+    pub fn unhandled_message_stanza_ids(&self) -> Vec<StanzaId> {
+        self.outbound_queue
+            .iter()
+            .filter_map(|queued| queued.message_stanza_id.clone())
+            .collect()
+    }
 }
 
 /// XEP-0198 client-side stream management state.

--- a/server/crates/waddle-xmpp-client/src/transport/codec.rs
+++ b/server/crates/waddle-xmpp-client/src/transport/codec.rs
@@ -82,6 +82,9 @@ pub fn decode_message(frame: &str) -> ClientResult<TransportMessage> {
             max: MAX_FRAME_SIZE,
         });
     }
+    if !has_single_top_level_element(trimmed) {
+        return Err(ClientError::InvalidTransportFrame);
+    }
 
     match peek_root_name(trimmed) {
         Some("open") => parse_stream_open(trimmed),
@@ -144,6 +147,88 @@ fn parse_element_frame(frame: &str) -> ClientResult<TransportMessage> {
     Element::from_str(frame)
         .map(TransportMessage::Element)
         .map_err(|_| ClientError::InvalidTransportFrame)
+}
+
+fn has_single_top_level_element(xml: &str) -> bool {
+    let Some(end) = top_level_element_end(xml) else {
+        return false;
+    };
+    xml[end..].trim().is_empty()
+}
+
+fn top_level_element_end(xml: &str) -> Option<usize> {
+    let bytes = xml.as_bytes();
+    if bytes.first().copied()? != b'<' || matches!(bytes.get(1), Some(b'/' | b'!' | b'?')) {
+        return None;
+    }
+
+    let mut idx = 0;
+    let mut depth = 0usize;
+    while idx < bytes.len() {
+        if bytes[idx] != b'<' {
+            idx += 1;
+            continue;
+        }
+
+        if xml[idx..].starts_with("<!--") {
+            idx += xml[idx..].find("-->")? + "-->".len();
+            continue;
+        }
+        if xml[idx..].starts_with("<![CDATA[") {
+            idx += xml[idx..].find("]]>")? + "]]>".len();
+            continue;
+        }
+        if xml[idx..].starts_with("<?") {
+            idx += xml[idx..].find("?>")? + "?>".len();
+            continue;
+        }
+
+        let end = find_tag_end(xml, idx)?;
+        if xml[idx..].starts_with("</") {
+            depth = depth.checked_sub(1)?;
+            idx = end + 1;
+            if depth == 0 {
+                return Some(idx);
+            }
+            continue;
+        }
+
+        depth += 1;
+        let mut before_end = end;
+        while before_end > idx && bytes[before_end - 1].is_ascii_whitespace() {
+            before_end -= 1;
+        }
+        if before_end > idx && bytes[before_end - 1] == b'/' {
+            depth = depth.checked_sub(1)?;
+            idx = end + 1;
+            if depth == 0 {
+                return Some(idx);
+            }
+            continue;
+        }
+
+        idx = end + 1;
+    }
+
+    None
+}
+
+fn find_tag_end(xml: &str, start: usize) -> Option<usize> {
+    let bytes = xml.as_bytes();
+    let mut quote = None;
+    let mut idx = start + 1;
+    while idx < bytes.len() {
+        let byte = bytes[idx];
+        match quote {
+            Some(q) if byte == q => quote = None,
+            Some(_) => {}
+            None if byte == b'"' || byte == b'\'' => quote = Some(byte),
+            None if byte == b'>' => return Some(idx),
+            None => {}
+        }
+        idx += 1;
+    }
+    None
 }
 
 fn peek_root_name(xml: &str) -> Option<&str> {

--- a/server/crates/waddle-xmpp-client/src/transport/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/transport/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::bootstrap::NS_CLIENT;
+use crate::ClientError;
 use std::str::FromStr;
 
 #[cfg(all(feature = "native", not(target_arch = "wasm32")))]
@@ -95,6 +96,59 @@ fn decode_injects_client_namespace_for_stanzas() {
 
     assert_eq!(element.name(), "iq");
     assert_eq!(element.ns(), NS_CLIENT);
+}
+
+#[test]
+fn decode_accepts_stream_error_as_single_websocket_frame() {
+    let message = decode_message(
+        r#"<stream:error xmlns:stream="http://etherx.jabber.org/streams"><undefined-condition xmlns="urn:ietf:params:xml:ns:xmpp-streams"/><handled-count-too-high xmlns="urn:xmpp:sm:3" h="3" send-count="2"/></stream:error>"#,
+    )
+    .unwrap();
+
+    let TransportMessage::Element(element) = message else {
+        panic!("expected stream error element");
+    };
+
+    assert_eq!(element.name(), "error");
+    assert_eq!(element.ns(), "http://etherx.jabber.org/streams");
+    assert!(element
+        .get_child("handled-count-too-high", "urn:xmpp:sm:3")
+        .is_some());
+}
+
+#[test]
+fn decode_rejects_tcp_style_stream_close_in_websocket_frame() {
+    let error = decode_message(
+        r#"<stream:error xmlns:stream="http://etherx.jabber.org/streams"><undefined-condition xmlns="urn:ietf:params:xml:ns:xmpp-streams"/><handled-count-too-high xmlns="urn:xmpp:sm:3" h="3" send-count="2"/></stream:error></stream:stream>"#,
+    )
+    .unwrap_err();
+
+    assert!(matches!(error, ClientError::InvalidTransportFrame));
+}
+
+#[test]
+fn decode_allows_stream_close_literal_inside_message_cdata() {
+    let message = decode_message(
+        r#"<message xmlns="jabber:client"><body><![CDATA[</stream:stream>]]></body></message>"#,
+    )
+    .unwrap();
+
+    let TransportMessage::Element(element) = message else {
+        panic!("expected message element");
+    };
+
+    assert_eq!(element.name(), "message");
+    let body = element.get_child("body", NS_CLIENT).expect("message body");
+    assert_eq!(body.text(), "</stream:stream>");
+}
+
+#[test]
+fn decode_rejects_multiple_top_level_websocket_elements() {
+    let error =
+        decode_message(r#"<message xmlns="jabber:client"/><presence xmlns="jabber:client"/>"#)
+            .unwrap_err();
+
+    assert!(matches!(error, ClientError::InvalidTransportFrame));
 }
 
 #[cfg(all(feature = "native", not(target_arch = "wasm32")))]

--- a/server/crates/waddle-xmpp-core/src/disco/info.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info.rs
@@ -451,6 +451,7 @@ pub fn spaces_service_features() -> Vec<Feature> {
         Feature::new("http://jabber.org/protocol/pubsub#delete-items"),
         Feature::new("http://jabber.org/protocol/pubsub#retract-items"),
         Feature::new("http://jabber.org/protocol/pubsub#item-ids"),
+        Feature::new("http://jabber.org/protocol/pubsub#multi-items"),
         Feature::new("http://jabber.org/protocol/pubsub#manage-subscriptions"),
         Feature::new("http://jabber.org/protocol/pubsub#modify-affiliations"),
         Feature::new("http://jabber.org/protocol/pubsub#retrieve-affiliations"),

--- a/server/crates/waddle-xmpp-core/src/disco/info/tests.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info/tests.rs
@@ -140,6 +140,7 @@ fn test_spaces_service_features_include_xep0503_required_features() {
         "http://jabber.org/protocol/pubsub#delete-items",
         "http://jabber.org/protocol/pubsub#retract-items",
         "http://jabber.org/protocol/pubsub#item-ids",
+        "http://jabber.org/protocol/pubsub#multi-items",
         "http://jabber.org/protocol/pubsub#manage-subscriptions",
         "http://jabber.org/protocol/pubsub#retrieve-items",
         "http://jabber.org/protocol/pubsub#modify-affiliations",


### PR DESCRIPTION
## Plan

1. Confirm the failure mode from the HAR and production behavior.
2. Review the fix against the local XEP corpus and RFC 7395 WebSocket framing.
3. Fix the server so WebSocket stream errors and framing close are emitted as conformant RFC 7395 frames.
4. Fix the client so fatal pre-bind resume stream errors clear stale XEP-0198 resume state instead of reconnect-looping.
5. Keep Spaces discovery conformant with XEP-0503.
6. Add protocol-focused tests, run local verification, adversarial review, and CI before merge.

## Completed

- Server now builds RFC 7395 `<open/>` and `<close/>` frames through XML builders and sends stream errors separately from the WebSocket framing close.
- Server now initiates the WebSocket close handshake after sending stream-close frames for fatal close paths.
- Client now rejects multi-root WebSocket XML frames, including TCP-style `</stream:stream>` framing in WebSocket mode.
- Client now handles top-level `<stream:error/>` during pre-bind XEP-0198 resume as terminal for that resume attempt, clears stale `previd` and fallback retry state, and proceeds to fresh bind on the next connection.
- Spaces service discovery now advertises the XEP-0503-required `http://jabber.org/protocol/pubsub#multi-items` feature.
- Reviewer follow-up: documented why RFC 6120 stream errors are terminal during pre-bind resume, and replaced the closing-frame guard's XML reparse with an exact typed close-frame comparison.

## Verification

- `cargo fmt`
- `git diff --check`
- `cargo test -p waddle-xmpp-client runtime_discards_resume_state_after_generic_prebind_stream_error`
- `cargo test -p waddle-server closing_phase`
- Earlier full local verification on this PR head lineage:
  - `cargo test -p waddle-server`
  - `cargo test -p waddle-xmpp-client`
  - `cargo test -p waddle-xmpp-core`
  - `cargo clippy --all-targets --all-features -- -D warnings`
