### PR TITLE
feat(chat): add privacy-safe Grafana Faro instrumentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,10 @@
 - Always update the PR title and desc to desc the complete work done, with the plan; and remove draft status
 - Our job doesn't stop after we push, we always monitor CI and fix it until all checks are green
 - XMPP Native, Never use out of band non-XMPP APIs.
+  - Exception: browser observability beacons to the configured Grafana Faro
+    collector, plus W3C trace-context headers to configured backend origins,
+    are allowed as operational telemetry only. They must not carry XMPP
+    control semantics, replace XMPP APIs, or alter XMPP wire behavior.
 - XEP conformance hard rule:
   - Prefer conformant XEP/XMPP shapes at all times. Use custom `urn:waddle:*`
     namespaces only when no suitable XEP-defined shape exists.

--- a/chat/astro.config.mjs
+++ b/chat/astro.config.mjs
@@ -6,17 +6,21 @@ import vue from "@astrojs/vue";
 import { resolveCommitSha } from "./scripts/resolve-commit-sha.mjs";
 
 const COMMIT_SHA = resolveCommitSha();
-
 // Faro Web SDK config is baked at build time via Vite `define` so the
-// bundled script knows where to POST beacons. Missing env vars degrade
-// to an empty string, which `initTelemetry()` treats as "telemetry
-// off" — no beacons leave the page. Set these in the Cloudflare Pages
-// build environment (or via `wrangler pages deploy --var ...`). The
-// URL is the "Send data" URL from the Grafana Cloud Frontend
-// Observability app, e.g.
-//   https://faro-collector-prod-eu-west-6.grafana.net/collect/<app-id>
-const FARO_URL = process.env.PUBLIC_FARO_URL ?? "";
+// bundled script knows where to POST beacons. The collector URL below
+// is the Grafana Cloud Frontend Observability "Send data" endpoint for
+// waddle-chat. It is enabled automatically for production deploys and
+// can be overridden explicitly for other environments.
+const DEFAULT_FARO_URL =
+  "https://faro-collector-prod-eu-west-6.grafana.net/collect/0eab89b00ec9f7cfd5c97e96636a3d20";
+const isProductionDeploy = process.env.CUENV_ENVIRONMENT === "production";
+const FARO_URL =
+  process.env.PUBLIC_FARO_URL ??
+  (isProductionDeploy ? DEFAULT_FARO_URL : "");
 const FARO_APP_NAME = process.env.PUBLIC_FARO_APP_NAME ?? "waddle-chat";
+const FARO_APP_VERSION = process.env.PUBLIC_FARO_APP_VERSION ?? "1.0.0";
+const FARO_ENVIRONMENT =
+  process.env.PUBLIC_FARO_ENVIRONMENT ?? (isProductionDeploy ? "production" : "");
 
 export default defineConfig({
   output: "server",
@@ -63,6 +67,8 @@ export default defineConfig({
       "import.meta.env.PUBLIC_COMMIT_SHA": JSON.stringify(COMMIT_SHA),
       "import.meta.env.PUBLIC_FARO_URL": JSON.stringify(FARO_URL),
       "import.meta.env.PUBLIC_FARO_APP_NAME": JSON.stringify(FARO_APP_NAME),
+      "import.meta.env.PUBLIC_FARO_APP_VERSION": JSON.stringify(FARO_APP_VERSION),
+      "import.meta.env.PUBLIC_FARO_ENVIRONMENT": JSON.stringify(FARO_ENVIRONMENT),
     },
     resolve: {
       alias: {

--- a/chat/src/auth/redirect-session.ts
+++ b/chat/src/auth/redirect-session.ts
@@ -1,0 +1,56 @@
+const SESSION_STORAGE_KEY = "waddle.chat.session";
+
+export function getStoredSessionId() {
+  if (typeof window === "undefined") return null;
+
+  try {
+    return window.localStorage.getItem(SESSION_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function storeSessionId(sessionId: string) {
+  if (typeof window === "undefined") return;
+
+  try {
+    window.localStorage.setItem(SESSION_STORAGE_KEY, sessionId);
+  } catch {
+    // ignore storage failures
+  }
+}
+
+export function clearStoredSessionId() {
+  if (typeof window === "undefined") return;
+
+  try {
+    window.localStorage.removeItem(SESSION_STORAGE_KEY);
+  } catch {
+    // ignore storage failures
+  }
+}
+
+export function consumeRedirectSession() {
+  if (typeof window === "undefined") return getStoredSessionId();
+
+  const url = new URL(window.location.href);
+  const hashParams = new URLSearchParams(url.hash.replace(/^#/, ""));
+  const sessionId = hashParams.get("waddle_session_id");
+
+  url.searchParams.delete("waddle_server");
+
+  if (sessionId) {
+    storeSessionId(sessionId);
+    hashParams.delete("waddle_session_id");
+  }
+
+  const nextSearch = url.searchParams.toString();
+  const nextHash = hashParams.toString();
+  const cleanedUrl = `${url.pathname}${nextSearch ? `?${nextSearch}` : ""}${nextHash ? `#${nextHash}` : ""}`;
+  const currentUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  if (cleanedUrl !== currentUrl) {
+    window.history.replaceState(null, "", cleanedUrl);
+  }
+
+  return sessionId ?? getStoredSessionId();
+}

--- a/chat/src/auth/session.ts
+++ b/chat/src/auth/session.ts
@@ -1,8 +1,12 @@
 import { ref, type Ref } from "vue";
 import { createServerAuth, type WaddleSession, type AuthProvider } from "@/lib/server-auth";
 import type { AppState } from "@/lib/chat-ui";
-
-const SESSION_STORAGE_KEY = "waddle.chat.session";
+import {
+  clearStoredSessionId,
+  consumeRedirectSession,
+  getStoredSessionId,
+  storeSessionId,
+} from "@/auth/redirect-session";
 
 function trimTrailingSlash(value: string) {
   return value.endsWith("/") ? value.slice(0, -1) : value;
@@ -10,61 +14,6 @@ function trimTrailingSlash(value: string) {
 
 function normalizeServerUrl(value: string) {
   return trimTrailingSlash(value.trim());
-}
-
-function getStoredSessionId() {
-  if (typeof window === "undefined") return null;
-
-  try {
-    return window.localStorage.getItem(SESSION_STORAGE_KEY);
-  } catch {
-    return null;
-  }
-}
-
-function storeSessionId(sessionId: string) {
-  if (typeof window === "undefined") return;
-
-  try {
-    window.localStorage.setItem(SESSION_STORAGE_KEY, sessionId);
-  } catch {
-    // ignore storage failures
-  }
-}
-
-function clearStoredSessionId() {
-  if (typeof window === "undefined") return;
-
-  try {
-    window.localStorage.removeItem(SESSION_STORAGE_KEY);
-  } catch {
-    // ignore storage failures
-  }
-}
-
-function consumeRedirectSession() {
-  if (typeof window === "undefined") return getStoredSessionId();
-
-  const url = new URL(window.location.href);
-  const hashParams = new URLSearchParams(url.hash.replace(/^#/, ""));
-  const sessionId = hashParams.get("waddle_session_id");
-
-  url.searchParams.delete("waddle_server");
-
-  if (sessionId) {
-    storeSessionId(sessionId);
-    hashParams.delete("waddle_session_id");
-  }
-
-  const nextSearch = url.searchParams.toString();
-  const nextHash = hashParams.toString();
-  const cleanedUrl = `${url.pathname}${nextSearch ? `?${nextSearch}` : ""}${nextHash ? `#${nextHash}` : ""}`;
-  const currentUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
-  if (cleanedUrl !== currentUrl) {
-    window.history.replaceState(null, "", cleanedUrl);
-  }
-
-  return sessionId ?? getStoredSessionId();
 }
 
 export function useSessionAuth(defaultServerUrl: string) {

--- a/chat/src/env.d.ts
+++ b/chat/src/env.d.ts
@@ -5,6 +5,8 @@ interface ImportMetaEnv {
   readonly PUBLIC_COMMIT_SHA: string;
   readonly PUBLIC_FARO_URL: string;
   readonly PUBLIC_FARO_APP_NAME: string;
+  readonly PUBLIC_FARO_APP_VERSION: string;
+  readonly PUBLIC_FARO_ENVIRONMENT: string;
 }
 
 interface ImportMeta {

--- a/chat/src/layouts/AppLayout.astro
+++ b/chat/src/layouts/AppLayout.astro
@@ -49,18 +49,20 @@ const giphyApiKey = env.GIPHY_API_KEY ?? "";
     </script>
     <title>Waddle</title>
     <script>
-      // Faro RUM bootstrap. `initTelemetry` is a no-op unless
-      // `PUBLIC_FARO_URL` is set, so this ships on every build but
-      // stays silent locally and in tests. Vite inlines
-      // `import.meta.env.PUBLIC_*` at build time. The configured
-      // server origin arrives via the `waddle:server-base-url` meta tag.
+      // Faro RUM bootstrap. Vite inlines `import.meta.env.PUBLIC_*` at
+      // build time, while the configured server origin arrives via the
+      // `waddle:server-base-url` meta tag.
+      import { consumeRedirectSession } from "@/auth/redirect-session";
       import { initTelemetry } from "@/lib/telemetry";
+      consumeRedirectSession();
       const serverBaseUrl = document
         .querySelector('meta[name="waddle:server-base-url"]')
         ?.getAttribute("content") ?? "";
       initTelemetry({
         url: import.meta.env.PUBLIC_FARO_URL,
         appName: import.meta.env.PUBLIC_FARO_APP_NAME,
+        appVersion: import.meta.env.PUBLIC_FARO_APP_VERSION,
+        environment: import.meta.env.PUBLIC_FARO_ENVIRONMENT,
         release: import.meta.env.PUBLIC_COMMIT_SHA,
         propagateTraceHeadersTo: serverBaseUrl ? [serverBaseUrl] : [],
       });

--- a/chat/src/lib/calls/dm-call-join-cache.ts
+++ b/chat/src/lib/calls/dm-call-join-cache.ts
@@ -138,7 +138,7 @@ function readEntries(selfBareJid: string): CachedDmCallJoin[] {
     reportError("storage.read", err, {
       recoverable: true,
       detail: "dm call join cache read failed",
-      key,
+      storage_area: "dm-call-join-cache",
     });
     return [];
   }
@@ -158,7 +158,7 @@ function writeEntries(selfBareJid: string, entries: CachedDmCallJoin[]): void {
     reportError("storage.write", err, {
       recoverable: true,
       detail: "dm call join cache write failed",
-      key,
+      storage_area: "dm-call-join-cache",
     });
   }
 }
@@ -172,7 +172,7 @@ function removeKey(key: string): void {
     reportError("storage.write", err, {
       recoverable: true,
       detail: "dm call join cache clear failed",
-      key,
+      storage_area: "dm-call-join-cache",
     });
   }
 }

--- a/chat/src/lib/calls/muc-call-session-cache.ts
+++ b/chat/src/lib/calls/muc-call-session-cache.ts
@@ -219,7 +219,7 @@ function readEntries(selfBareJid: string): CachedMucCallSession[] {
     reportError("storage.read", err, {
       recoverable: true,
       detail: "muc call session cache read failed",
-      key,
+      storage_area: "muc-call-session-cache",
     });
     return [];
   }
@@ -239,7 +239,7 @@ function writeEntries(selfBareJid: string, entries: CachedMucCallSession[]): voi
     reportError("storage.write", err, {
       recoverable: true,
       detail: "muc call session cache write failed",
-      key,
+      storage_area: "muc-call-session-cache",
     });
   }
 }

--- a/chat/src/lib/outbound-queue-store.ts
+++ b/chat/src/lib/outbound-queue-store.ts
@@ -111,7 +111,7 @@ function readQueue(accountKey: string): PersistedQueuedMessage[] {
     reportError("storage.read", err, {
       recoverable: true,
       detail: "outbound-queue read failed",
-      accountKey,
+      storage_area: "outbound-queue",
     });
     return [];
   }
@@ -163,7 +163,7 @@ function pruneStaleEntries(
     reportError("storage.write", err, {
       recoverable: true,
       detail: "outbound-queue prune failed",
-      accountKey,
+      storage_area: "outbound-queue",
       dropped,
     });
     return fresh;
@@ -176,7 +176,7 @@ function pruneStaleEntries(
   reportError("storage.write", new Error("queue ttl prune"), {
     recoverable: true,
     detail: `pruned ${dropped} stale queued message(s)`,
-    accountKey,
+    storage_area: "outbound-queue",
     dropped,
   });
   return fresh;
@@ -209,7 +209,7 @@ function writeQueue(accountKey: string, messages: PersistedQueuedMessage[]): voi
     reportError(kind, err, {
       recoverable: true,
       detail: "outbound-queue write failed",
-      accountKey,
+      storage_area: "outbound-queue",
       queueSize: messages.length,
     });
   }

--- a/chat/src/lib/telemetry.ts
+++ b/chat/src/lib/telemetry.ts
@@ -1,11 +1,10 @@
 /**
  * Grafana Faro RUM wrapper.
  *
- * All reporting functions are no-ops when Faro isn't initialized, which
- * is the default in local dev and in tests. Initialization is gated on
- * the runtime presence of `PUBLIC_FARO_URL` — there is no "disabled"
- * mode in the SDK itself; we just skip `initializeFaro()` entirely so
- * no beacons leave the page.
+ * All reporting functions are no-ops when Faro isn't initialized.
+ * Initialization is gated on the runtime presence of a Faro collector
+ * URL — there is no "disabled" mode in the SDK itself; we just skip
+ * `initializeFaro()` entirely so no beacons leave the page.
  *
  * Drop-detection signals emitted here all live under the
  * `chat.xmpp.*` event namespace so they're easy to filter in Grafana.
@@ -31,8 +30,15 @@
  * `withSpan` callback IS propagated (via the active context set by
  * `context.with`) and will cross-link into backend spans correctly.
  */
-import { initializeFaro, getWebInstrumentations, type Faro } from "@grafana/faro-web-sdk";
-import { TracingInstrumentation } from "@grafana/faro-web-tracing";
+import {
+  initializeFaro,
+  getWebInstrumentations,
+  type Faro,
+  type MetaAttributes,
+  type MetaPage,
+  type TransportItem,
+} from "@grafana/faro-web-sdk";
+import { getDefaultOTELInstrumentations, TracingInstrumentation } from "@grafana/faro-web-tracing";
 import { context, SpanStatusCode, trace, type Span } from "@opentelemetry/api";
 
 type MessageKind = "room" | "dm";
@@ -55,7 +61,11 @@ interface InitTelemetryOptions {
   url: string;
   /** App name, typically the env-specific identifier e.g. `waddle-chat`. */
   appName: string;
-  /** Commit SHA used as the app version, for Faro release correlation. */
+  /** Semantic application version shown in Faro application metadata. */
+  appVersion?: string;
+  /** Deployment environment shown in Faro application metadata. */
+  environment?: string;
+  /** Commit SHA used as the Faro release, for source/deploy correlation. */
   release?: string;
   /**
    * Cross-origin URLs where the browser should inject W3C trace
@@ -67,8 +77,84 @@ interface InitTelemetryOptions {
 }
 
 let faro: Faro | null = null;
+let configuredTrustedSpanOrigins = new Set<string>();
+const sensitiveSpanUrls = new Set<string>();
 
 const TRACER_NAME = "waddle-chat";
+const UNKNOWN_EXTERNAL_URL = "external:unknown";
+const UNKNOWN_FETCH_URL = "fetch:unknown";
+const UNKNOWN_FILE_TRANSFER_URL = "file-transfer:unknown";
+const UNKNOWN_XHR_URL = "xhr:unknown";
+const REDACTED_SPAN_HOST = ":redacted";
+const REDACTED_SPAN_PATH = ":unknown";
+const REDACTED_SPAN_PORT = 0;
+const FARO_CSP_INSTRUMENTATION = "@grafana/faro-web-sdk:instrumentation-csp";
+const FARO_GLOBAL_ERROR_INSTRUMENTATION = "@grafana/faro-web-sdk:instrumentation-errors";
+const FARO_NAVIGATION_INSTRUMENTATION = "@grafana/faro-web-sdk:instrumentation-navigation";
+const FARO_TRACE_EVENT_PREFIX = "faro.tracing.";
+const SPAN_URL_ATTRIBUTE_KEYS = ["http.url", "url.full"] as const;
+const SPAN_ENDPOINT_ATTRIBUTE_KEYS = [
+  "http.host",
+  "http.target",
+  "server.address",
+  "server.port",
+  "url.path",
+] as const;
+const SPAN_QUERY_ATTRIBUTE_KEYS = ["url.fragment", "url.query"] as const;
+const SPAN_REDACTED_ATTRIBUTE_KEYS = ["http.response.status_text", "http.status_text"] as const;
+const SENSITIVE_TRACE_URL_PATTERNS = [
+  /[?&]session_id=/,
+  /[?&]api_key=/,
+  /\/api\/upload(?:[/?#]|$)/,
+  /\/api\/files(?:[/?#]|$)/,
+  /^https:\/\/api\.giphy\.com\//,
+];
+const SENSITIVE_ERROR_CONTEXT_KEYS = new Set([
+  "accountkey",
+  "barejid",
+  "fulljid",
+  "jid",
+  "key",
+  "storagekey",
+]);
+
+type SpanAttributeValue = string | number;
+type FaroEventPayload = {
+  attributes?: Record<string, string>;
+  name?: string;
+};
+type OtelAnyValue = {
+  stringValue?: string | null;
+  boolValue?: boolean | null;
+  intValue?: number | null;
+  doubleValue?: number | null;
+};
+type OtelKeyValue = {
+  key: string;
+  value: OtelAnyValue;
+};
+type OtelSpan = {
+  attributes?: OtelKeyValue[];
+  events?: Array<{
+    attributes?: OtelKeyValue[];
+  }>;
+  links?: Array<{
+    attributes?: OtelKeyValue[];
+  }>;
+};
+type FaroTracePayload = {
+  resourceSpans?: Array<{
+    resource?: {
+      attributes?: OtelKeyValue[];
+    };
+    scopeSpans?: Array<{
+      scope?: {
+        attributes?: OtelKeyValue[];
+      };
+      spans?: OtelSpan[];
+    }>;
+  }>;
+};
 
 /**
  * Initialize Faro exactly once per page lifetime. Re-invocation is a
@@ -85,28 +171,51 @@ export function initTelemetry(options: InitTelemetryOptions): void {
   try {
     const propagateUrls = (options.propagateTraceHeadersTo ?? [])
       .filter((entry) => entry && entry.trim().length > 0)
-      .map((entry) => normalizePropagationEntry(entry));
+      .map((entry) => normalizeUrlPrefixEntry(entry));
+    const ignoredTraceUrls = [
+      ...SENSITIVE_TRACE_URL_PATTERNS,
+      normalizeUrlPrefixEntry(options.url),
+    ];
+    const trustedSpanOrigins = trustedSpanUrlOrigins(options.propagateTraceHeadersTo ?? []);
+    configuredTrustedSpanOrigins = trustedSpanOrigins;
 
     faro = initializeFaro({
       url: options.url,
       app: {
         name: options.appName || "waddle-chat",
-        version: options.release,
+        version: options.appVersion || "unknown",
+        environment: options.environment || undefined,
+        release: options.release,
       },
+      pageTracking: {
+        page: sanitizedPageMeta(),
+        generatePageId: sanitizePagePathForTelemetry,
+      },
+      beforeSend: sanitizeFaroTransportItem,
       instrumentations: [
-        // Default browser instrumentations: uncaught errors, unhandled
-        // promise rejections, console errors, web vitals, session
-        // tracking, view/route changes.
-        ...getWebInstrumentations(),
+        // Default browser instrumentations, minus global error capture:
+        // explicit app errors go through `reportError()` so messages and
+        // context are sanitized before leaving the page. Console and
+        // resource performance capture stay disabled for the same reason.
+        ...getPrivacySafeWebInstrumentations(),
         // Wraps fetch + XMLHttpRequest in OTel spans and injects
         // traceparent/tracestate on requests whose URL matches one of
         // `propagateTraceHeaderCorsUrls`. Without a matching entry the
         // browser does NOT send those headers cross-origin, so the
         // backend can't join the trace.
         new TracingInstrumentation({
-          instrumentationOptions: {
+          instrumentations: getDefaultOTELInstrumentations({
+            ignoreUrls: ignoredTraceUrls,
             propagateTraceHeaderCorsUrls: propagateUrls,
-          },
+            fetchInstrumentationOptions: {
+              applyCustomAttributesOnSpan: (span, request, result) =>
+                scrubFetchSpanUrl(span, request, result, trustedSpanOrigins),
+            },
+            xhrInstrumentationOptions: {
+              applyCustomAttributesOnSpan: (span, xhr) =>
+                scrubXhrSpanUrl(span, xhr, trustedSpanOrigins),
+            },
+          }),
         }),
       ],
     });
@@ -120,20 +229,529 @@ export function initTelemetry(options: InitTelemetryOptions): void {
   installClientHealthTelemetry();
 }
 
+function sanitizeFaroTransportItem(item: TransportItem): TransportItem {
+  const sanitized = {
+    ...item,
+    meta: {
+      ...item.meta,
+      page: sanitizedPageMeta(item.meta.page),
+    },
+  };
+  sanitizeTransportPayload(sanitized);
+  return sanitized;
+}
+
+function sanitizeTransportPayload(item: TransportItem): void {
+  if (item.type === "trace") {
+    sanitizeTracePayload(item.payload, trustedSpanOriginsForTransport());
+    return;
+  }
+
+  if (item.type === "event") {
+    sanitizeEventPayload(item.payload, trustedSpanOriginsForTransport());
+  }
+}
+
+function sanitizeEventPayload(payload: unknown, trustedOrigins: Set<string>): void {
+  if (!isRecord(payload)) return;
+  const event = payload as FaroEventPayload;
+  const attributes = event.attributes;
+  if (!isStringRecord(attributes)) return;
+
+  if (event.name?.startsWith(FARO_TRACE_EVENT_PREFIX)) {
+    sanitizeFlatSpanAttributes(attributes, trustedOrigins);
+  }
+
+  for (const [key, value] of Object.entries(attributes)) {
+    attributes[key] = sanitizeTelemetryText(value);
+  }
+}
+
+function sanitizeTracePayload(payload: unknown, trustedOrigins: Set<string>): void {
+  if (!isRecord(payload)) return;
+  const tracePayload = payload as FaroTracePayload;
+  for (const resourceSpan of tracePayload.resourceSpans ?? []) {
+    sanitizeOtelAttributeStrings(resourceSpan.resource?.attributes);
+    for (const scopeSpan of resourceSpan.scopeSpans ?? []) {
+      sanitizeOtelAttributeStrings(scopeSpan.scope?.attributes);
+      for (const span of scopeSpan.spans ?? []) {
+        sanitizeOtelSpanAttributes(span.attributes, trustedOrigins);
+        for (const event of span.events ?? []) {
+          sanitizeOtelAttributeStrings(event.attributes);
+        }
+        for (const link of span.links ?? []) {
+          sanitizeOtelAttributeStrings(link.attributes);
+        }
+      }
+    }
+  }
+}
+
+function sanitizeOtelSpanAttributes(attributes: OtelKeyValue[] | undefined, trustedOrigins: Set<string>): void {
+  if (!attributes) return;
+  const url = firstOtelSpanUrl(attributes);
+
+  if (url) {
+    const scrubbed = scrubUrl(url, trustedOrigins);
+    if (scrubbed) setOtelSpanUrlAttributes(attributes, scrubbed);
+  } else {
+    redactOtelEndpointAttributes(attributes);
+  }
+
+  for (const key of SPAN_QUERY_ATTRIBUTE_KEYS) {
+    const attribute = findOtelAttribute(attributes, key);
+    if (attribute) setOtelAttributeValue(attribute, ":redacted");
+  }
+  for (const key of SPAN_REDACTED_ATTRIBUTE_KEYS) {
+    const attribute = findOtelAttribute(attributes, key);
+    if (attribute) setOtelAttributeValue(attribute, ":redacted");
+  }
+
+  for (const attribute of attributes) {
+    if (typeof attribute.value?.stringValue === "string") {
+      setOtelAttributeValue(attribute, sanitizeTelemetryText(attribute.value.stringValue));
+    }
+  }
+}
+
+function sanitizeOtelAttributeStrings(attributes: OtelKeyValue[] | undefined): void {
+  if (!attributes) return;
+  for (const attribute of attributes) {
+    if (typeof attribute.value?.stringValue === "string") {
+      setOtelAttributeValue(attribute, sanitizeTelemetryText(attribute.value.stringValue));
+    }
+  }
+}
+
+function firstOtelSpanUrl(attributes: OtelKeyValue[]): string | undefined {
+  for (const key of SPAN_URL_ATTRIBUTE_KEYS) {
+    const value = readOtelStringAttribute(attributes, key);
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function setOtelSpanUrlAttributes(attributes: OtelKeyValue[], value: string): void {
+  const endpoint = safeSpanEndpoint(value);
+  upsertOtelAttribute(attributes, "http.url", value);
+  upsertOtelAttribute(attributes, "url.full", value);
+  upsertOtelAttribute(attributes, "http.host", endpoint.host);
+  upsertOtelAttribute(attributes, "http.target", endpoint.path);
+  upsertOtelAttribute(attributes, "server.address", endpoint.address);
+  upsertOtelAttribute(attributes, "server.port", endpoint.port);
+  upsertOtelAttribute(attributes, "url.path", endpoint.path);
+}
+
+function redactOtelEndpointAttributes(attributes: OtelKeyValue[]): void {
+  const endpoint = redactedSpanEndpoint();
+  const replacements: Record<typeof SPAN_ENDPOINT_ATTRIBUTE_KEYS[number], SpanAttributeValue> = {
+    "http.host": endpoint.host,
+    "http.target": endpoint.path,
+    "server.address": endpoint.address,
+    "server.port": endpoint.port,
+    "url.path": endpoint.path,
+  };
+
+  for (const key of SPAN_ENDPOINT_ATTRIBUTE_KEYS) {
+    const attribute = findOtelAttribute(attributes, key);
+    if (attribute) setOtelAttributeValue(attribute, replacements[key]);
+  }
+}
+
+function readOtelStringAttribute(attributes: OtelKeyValue[], key: string): string | undefined {
+  const value = findOtelAttribute(attributes, key)?.value?.stringValue;
+  return typeof value === "string" ? value : undefined;
+}
+
+function findOtelAttribute(attributes: OtelKeyValue[], key: string): OtelKeyValue | undefined {
+  return attributes.find((attribute) => attribute.key === key);
+}
+
+function upsertOtelAttribute(attributes: OtelKeyValue[], key: string, value: SpanAttributeValue): void {
+  const existing = findOtelAttribute(attributes, key);
+  if (existing) {
+    setOtelAttributeValue(existing, value);
+    return;
+  }
+  attributes.push({
+    key,
+    value: otelAttributeValue(value),
+  });
+}
+
+function setOtelAttributeValue(attribute: OtelKeyValue, value: SpanAttributeValue): void {
+  attribute.value = otelAttributeValue(value);
+}
+
+function otelAttributeValue(value: SpanAttributeValue): OtelAnyValue {
+  return typeof value === "number" ? { intValue: value } : { stringValue: value };
+}
+
+function sanitizeFlatSpanAttributes(attributes: Record<string, string>, trustedOrigins: Set<string>): void {
+  const url = firstFlatSpanUrl(attributes);
+
+  if (url) {
+    const scrubbed = scrubUrl(url, trustedOrigins);
+    if (scrubbed) setFlatSpanUrlAttributes(attributes, scrubbed);
+  } else {
+    redactFlatEndpointAttributes(attributes);
+  }
+
+  for (const key of SPAN_QUERY_ATTRIBUTE_KEYS) {
+    if (key in attributes) attributes[key] = ":redacted";
+  }
+  for (const key of SPAN_REDACTED_ATTRIBUTE_KEYS) {
+    if (key in attributes) attributes[key] = ":redacted";
+  }
+}
+
+function firstFlatSpanUrl(attributes: Record<string, string>): string | undefined {
+  for (const key of SPAN_URL_ATTRIBUTE_KEYS) {
+    const value = attributes[key];
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function setFlatSpanUrlAttributes(attributes: Record<string, string>, value: string): void {
+  const endpoint = safeSpanEndpoint(value);
+  attributes["http.url"] = value;
+  attributes["url.full"] = value;
+  attributes["http.host"] = endpoint.host;
+  attributes["http.target"] = endpoint.path;
+  attributes["server.address"] = endpoint.address;
+  attributes["server.port"] = String(endpoint.port);
+  attributes["url.path"] = endpoint.path;
+}
+
+function redactFlatEndpointAttributes(attributes: Record<string, string>): void {
+  const endpoint = redactedSpanEndpoint();
+  const replacements: Record<typeof SPAN_ENDPOINT_ATTRIBUTE_KEYS[number], string> = {
+    "http.host": endpoint.host,
+    "http.target": endpoint.path,
+    "server.address": endpoint.address,
+    "server.port": String(endpoint.port),
+    "url.path": endpoint.path,
+  };
+
+  for (const key of SPAN_ENDPOINT_ATTRIBUTE_KEYS) {
+    if (key in attributes) attributes[key] = replacements[key];
+  }
+}
+
+function trustedSpanOriginsForTransport(): Set<string> {
+  const origins = new Set(configuredTrustedSpanOrigins);
+  const pageOrigin = currentPageOrigin();
+  if (pageOrigin) origins.add(pageOrigin);
+  return origins;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  return isRecord(value) && Object.values(value).every((entry) => typeof entry === "string");
+}
+
+function sanitizedPageMeta(page?: MetaPage): MetaPage {
+  const route = sanitizePagePathForTelemetry();
+  return {
+    ...page,
+    attributes: sanitizeMetaAttributes(page?.attributes),
+    id: route,
+    url: `${currentPageOrigin()}${route}`,
+  };
+}
+
+function sanitizeMetaAttributes(attributes: MetaAttributes | undefined): MetaAttributes | undefined {
+  if (!attributes) return undefined;
+  return Object.fromEntries(
+    Object.entries(attributes).map(([key, value]) => [key, sanitizeTelemetryText(value)]),
+  );
+}
+
+function sanitizePagePathForTelemetry(locationOverride?: Location): string {
+  return sanitizeRoutePath(currentPagePath(locationOverride));
+}
+
+function sanitizeRoutePath(path: string): string {
+  const segments = path.split("/").filter(Boolean);
+  if (segments.length === 0) return "/";
+
+  switch (segments[0]) {
+    case "admin":
+      return segments.length > 1 ? "/admin/:panel" : "/admin";
+    case "dm":
+      return segments.length > 1 ? "/dm/:user" : "/dm";
+    case "events":
+    case "feed":
+    case "settings":
+    case "stories":
+    case "threads":
+      return `/${segments[0]}`;
+    case "r":
+      if (segments[2] === "x") return "/r/:room/x/:plugin/:route";
+      return segments.length > 1 ? "/r/:room" : "/r";
+    default:
+      return "/:route";
+  }
+}
+
+function currentPagePath(locationOverride?: Location): string {
+  const pageLocation = locationOverride ?? (typeof window !== "undefined" ? window.location : undefined);
+  const pathname = pageLocation?.pathname || "/";
+  return pathname.startsWith("/") ? pathname : `/${pathname}`;
+}
+
+function currentPageOrigin(): string {
+  if (typeof window === "undefined") return "";
+  if (window.location?.origin) return window.location.origin;
+  try {
+    return new URL(window.location?.href ?? "").origin;
+  } catch {
+    return "";
+  }
+}
+
+function getPrivacySafeWebInstrumentations() {
+  return getWebInstrumentations({
+    captureConsole: false,
+    enableContentSecurityPolicyInstrumentation: false,
+    enablePerformanceInstrumentation: false,
+  }).filter((instrumentation) =>
+    instrumentation.name !== FARO_CSP_INSTRUMENTATION
+    && instrumentation.name !== FARO_GLOBAL_ERROR_INSTRUMENTATION
+    && instrumentation.name !== FARO_NAVIGATION_INSTRUMENTATION
+  );
+}
+
 /**
- * Turn a string into the RegExp or URL-prefix shape
- * `TracingInstrumentation` expects. A plain URL like
- * `https://xmpp.waddle.social` matches as a prefix, which is what we
- * want — every `/api/...` call under that origin joins the trace.
+ * Turn a string into the URL-prefix RegExp `TracingInstrumentation`
+ * expects. A plain string match is exact, so `https://xmpp.waddle.social`
+ * would not match `/api/...`; the escaped prefix regex does.
  */
-function normalizePropagationEntry(entry: string): string | RegExp {
+function normalizeUrlPrefixEntry(entry: string): RegExp {
   const trimmed = entry.trim();
-  return trimmed.endsWith("/") ? trimmed.slice(0, -1) : trimmed;
+  const prefix = trimmed.endsWith("/") ? trimmed.slice(0, -1) : trimmed;
+  return new RegExp(`^${escapeRegExp(prefix)}(?:[/?#]|$)`);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function trustedSpanUrlOrigins(entries: string[]): Set<string> {
+  const origins = new Set<string>();
+  const pageOrigin = currentPageOrigin();
+  if (pageOrigin) origins.add(pageOrigin);
+
+  for (const entry of entries) {
+    try {
+      origins.add(new URL(entry, currentPageHref()).origin);
+    } catch {
+      // Invalid config entry: leave it out rather than widening trust.
+    }
+  }
+  return origins;
+}
+
+function scrubFetchSpanUrl(
+  span: Span,
+  request: unknown,
+  result: unknown,
+  trustedOrigins: Set<string>,
+): void {
+  const url = readResultUrl(result) ?? readRequestUrl(request);
+  if (!url) {
+    setSpanUrlAttributes(span, UNKNOWN_FETCH_URL);
+    return;
+  }
+  scrubSpanUrlAttributes(span, url, trustedOrigins);
+}
+
+function scrubXhrSpanUrl(span: Span, xhr: XMLHttpRequest, trustedOrigins: Set<string>): void {
+  if (!xhr.responseURL) {
+    setSpanUrlAttributes(span, UNKNOWN_XHR_URL);
+    return;
+  }
+  scrubSpanUrlAttributes(span, xhr.responseURL, trustedOrigins);
+}
+
+function readResultUrl(result: unknown): string | undefined {
+  if (result && typeof result === "object" && "url" in result) {
+    const url = (result as { url?: unknown }).url;
+    return typeof url === "string" ? url : undefined;
+  }
+  return undefined;
+}
+
+function readRequestUrl(request: unknown): string | undefined {
+  if (typeof Request !== "undefined" && request instanceof Request) {
+    return request.url;
+  }
+  if (typeof request === "string") return request;
+  if (typeof URL !== "undefined" && request instanceof URL) return request.toString();
+  return undefined;
+}
+
+function scrubSpanUrlAttributes(span: Span, url: string | undefined, trustedOrigins: Set<string>): void {
+  const scrubbed = scrubUrl(url, trustedOrigins);
+  if (!scrubbed) return;
+  setSpanUrlAttributes(span, scrubbed);
+}
+
+function setSpanUrlAttributes(span: Span, value: string): void {
+  const endpoint = safeSpanEndpoint(value);
+  span.setAttribute("http.url", value);
+  span.setAttribute("url.full", value);
+  span.setAttribute("http.host", endpoint.host);
+  span.setAttribute("http.target", endpoint.path);
+  span.setAttribute("server.address", endpoint.address);
+  span.setAttribute("server.port", endpoint.port);
+  span.setAttribute("url.path", endpoint.path);
+}
+
+function safeSpanEndpoint(value: string): {
+  address: string;
+  host: string;
+  path: string;
+  port: number;
+} {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return redactedSpanEndpoint();
+    return {
+      address: url.hostname,
+      host: url.host,
+      path: url.pathname || "/",
+      port: url.port ? Number(url.port) : (url.protocol === "https:" ? 443 : 80),
+    };
+  } catch {
+    return redactedSpanEndpoint();
+  }
+}
+
+function redactedSpanEndpoint(): {
+  address: string;
+  host: string;
+  path: string;
+  port: number;
+} {
+  return {
+    address: REDACTED_SPAN_HOST,
+    host: REDACTED_SPAN_HOST,
+    path: REDACTED_SPAN_PATH,
+    port: REDACTED_SPAN_PORT,
+  };
+}
+
+function scrubUrl(value: string | undefined, trustedOrigins: Set<string>): string | undefined {
+  if (!value) return undefined;
+  try {
+    const url = new URL(value, currentPageHref());
+    if (isSensitiveSpanUrl(url)) return UNKNOWN_FILE_TRANSFER_URL;
+    if (!trustedOrigins.has(url.origin)) return scrubExternalUrl();
+    url.pathname = scrubUrlPath(url.pathname);
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return scrubUrlPath(value.split(/[?#]/, 1)[0] ?? "");
+  }
+}
+
+function currentPageHref(): string {
+  if (typeof window === "undefined") return "http://localhost";
+  return window.location?.href || "http://localhost";
+}
+
+function scrubExternalUrl(): string {
+  return UNKNOWN_EXTERNAL_URL;
+}
+
+function scrubUrlPath(path: string): string {
+  if (path.startsWith("/api/upload/")) return "/api/upload/:slot";
+  if (path === "/api/upload") return path;
+  if (path.startsWith("/api/files/")) return "/api/files/:slot/:file";
+  if (path === "/api/files") return path;
+  if (path.startsWith("/api/")) return "/api/:endpoint";
+  if (isStaticAssetPath(path)) return path;
+  return sanitizeRoutePath(path);
+}
+
+function isStaticAssetPath(path: string): boolean {
+  return path.startsWith("/_astro/")
+    || path === "/favicon.ico"
+    || path === "/manifest.webmanifest"
+    || path === "/waddle-logo.svg"
+    || /^\/(?:apple-touch-icon|favicon-\d+x\d+)\.png$/.test(path);
+}
+
+function isSensitiveSpanUrl(url: URL): boolean {
+  return sensitiveSpanUrls.has(normalizeSensitiveSpanUrl(url));
+}
+
+function normalizeSensitiveSpanUrl(url: URL): string {
+  const copy = new URL(url);
+  copy.search = "";
+  copy.hash = "";
+  return copy.toString();
+}
+
+export function markSensitiveUrlForTelemetry(value: string): void {
+  try {
+    sensitiveSpanUrls.add(normalizeSensitiveSpanUrl(new URL(value, currentPageHref())));
+  } catch {
+    // Invalid URLs never make it to fetch/XHR either; ignore.
+  }
+}
+
+/** For tests only — clear dynamically marked sensitive URLs. */
+export function __clearSensitiveUrlsForTesting(): void {
+  sensitiveSpanUrls.clear();
 }
 
 /** For tests only — inject a stub or clear state between test cases. */
 export function __setFaroForTesting(instance: Faro | null): void {
   faro = instance;
+  if (!instance) configuredTrustedSpanOrigins = new Set();
+}
+
+/** For tests only — exercise the final transport guard without calling Grafana. */
+export function __sanitizeFaroTransportItemForTesting(item: TransportItem): TransportItem {
+  return sanitizeFaroTransportItem(item);
+}
+
+/** For tests only — exercise span URL redaction without real OTel spans. */
+export function __scrubSpanUrlForTesting(value: string, trustedOrigins: string[]): string | undefined {
+  return scrubUrl(value, new Set(trustedOrigins));
+}
+
+/** For tests only — exercise XHR span URL redaction without real XHR instrumentation. */
+export function __scrubXhrSpanUrlForTesting(responseURL: string, trustedOrigins: string[]): Record<string, string | number> {
+  const attributes: Record<string, string | number> = {};
+  const span = {
+    setAttribute: (key: string, value: string | number) => {
+      attributes[key] = value;
+      return span;
+    },
+  } as unknown as Span;
+  scrubXhrSpanUrl(span, { responseURL } as XMLHttpRequest, new Set(trustedOrigins));
+  return attributes;
+}
+
+/** For tests only — exercise fetch span URL fallback without real fetch instrumentation. */
+export function __scrubMissingFetchSpanUrlForTesting(): Record<string, string | number> {
+  const attributes: Record<string, string | number> = {};
+  const span = {
+    setAttribute: (key: string, value: string | number) => {
+      attributes[key] = value;
+      return span;
+    },
+  } as unknown as Span;
+  scrubFetchSpanUrl(span, undefined, undefined, new Set());
+  return attributes;
 }
 
 /**
@@ -150,7 +768,7 @@ export function __setFaroForTesting(instance: Faro | null): void {
  * not an orphaned sibling.
  *
  * The returned span is exposed to the callback so callers can attach
- * domain attributes ("room.jid", "message.kind", etc.) without
+ * low-cardinality domain attributes ("message.kind", etc.) without
  * needing their own tracer handle.
  */
 export async function withSpan<T>(
@@ -168,11 +786,12 @@ export async function withSpan<T>(
       span.setStatus({ code: SpanStatusCode.OK });
       return result;
     } catch (err) {
+      const sanitizedError = sanitizeErrorForTelemetry(err, `${name}.error`);
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: err instanceof Error ? err.message : String(err),
+        message: sanitizedError.message,
       });
-      if (err instanceof Error) span.recordException(err);
+      span.recordException(sanitizedError);
       throw err;
     } finally {
       span.end();
@@ -199,14 +818,37 @@ export function reportError(
   },
 ): void {
   if (!faro) return;
-  const err = error instanceof Error ? error : new Error(String(error));
+  const err = sanitizeErrorForTelemetry(error, kind);
   const contextStrings: Record<string, string> = { kind, recoverable: String(context.recoverable) };
   for (const [k, v] of Object.entries(context)) {
     if (k === "recoverable") continue;
+    if (isSensitiveContextKey(k)) continue;
     if (v === undefined || v === null) continue;
-    contextStrings[k] = typeof v === "string" ? v : JSON.stringify(v);
+    const serialized = typeof v === "string" ? v : JSON.stringify(v);
+    contextStrings[k] = sanitizeTelemetryText(serialized);
   }
   faro.api.pushError(err, { type: kind, context: contextStrings });
+}
+
+function sanitizeErrorForTelemetry(error: unknown, fallbackMessage: string): Error {
+  const source = error instanceof Error ? error : new Error(String(error));
+  const sanitized = new Error(sanitizeTelemetryText(source.message || fallbackMessage));
+  sanitized.name = source.name || "Error";
+  if (source.stack) sanitized.stack = sanitizeTelemetryText(source.stack);
+  return sanitized;
+}
+
+function sanitizeTelemetryText(value: string): string {
+  return value
+    .replace(/([#?&](?:waddle_session_id|session_id|api_key)=)[^\s&#)]+/gi, "$1:redacted")
+    .replace(/\/api\/upload\/[^\s?#)]+/g, "/api/upload/:slot")
+    .replace(/\/api\/files\/[^\s?#)]+(?:\/[^\s?#)]+)?/g, "/api/files/:slot/:file")
+    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+(?:\/[^\s,;)]*)?/gi, ":jid");
+}
+
+function isSensitiveContextKey(key: string): boolean {
+  const normalized = key.replace(/[-_]/g, "").toLowerCase();
+  return SENSITIVE_ERROR_CONTEXT_KEYS.has(normalized) || normalized.endsWith("key");
 }
 
 export function reportMessageFailed(payload: {
@@ -214,7 +856,6 @@ export function reportMessageFailed(payload: {
   kind: MessageKind;
 }): void {
   faro?.api.pushEvent("chat.xmpp.message.failed", {
-    id: payload.id,
     kind: payload.kind,
   });
 }
@@ -226,9 +867,7 @@ export function reportMessageAcked(payload: {
 }): void {
   if (!faro) return;
   faro.api.pushEvent("chat.xmpp.message.acked", {
-    id: payload.id,
     kind: payload.kind,
-    latency_ms: String(Math.round(payload.latencyMs)),
   });
   faro.api.pushMeasurement({
     type: "chat.xmpp.message.acked.latency_ms",
@@ -268,13 +907,11 @@ export function reportSessionLifecycle(payload: {
 
 export function reportStatusChange(payload: {
   state: string;
-  detail?: string;
   reconnectDurationMs?: number;
 }): void {
   if (!faro) return;
   faro.api.pushEvent("chat.xmpp.status", {
     state: payload.state,
-    detail: payload.detail ?? "",
   });
   if (typeof payload.reconnectDurationMs === "number") {
     faro.api.pushMeasurement({
@@ -377,11 +1014,7 @@ export function reportReconnectScheduled(payload: { attempt: number; delayMs: nu
   if (!faro) return;
   const tags = visibilityTags();
   const metric = visibilityMetric();
-  faro.api.pushEvent("chat.xmpp.reconnect.scheduled", {
-    attempt: String(payload.attempt),
-    delay_ms: String(Math.round(payload.delayMs)),
-    ...tags,
-  });
+  faro.api.pushEvent("chat.xmpp.reconnect.scheduled", tags);
   faro.api.pushMeasurement({
     type: "chat.xmpp.reconnect.attempt",
     values: {

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -925,7 +925,7 @@ export class BrowserXmppClient {
     this.clearReconnectTimer();
     this.connectPromise = withSpan(
       "xmpp.connect",
-      { "waddle.xmpp.jid": this.session.jid, "waddle.xmpp.transport": "websocket" },
+      { "waddle.xmpp.transport": "websocket" },
       () => new Promise<void>((resolve, reject) => {
         const timeout = setTimeout(() => {
           this.connectPromise = null;

--- a/chat/src/lib/xmpp/encrypted-attachments.ts
+++ b/chat/src/lib/xmpp/encrypted-attachments.ts
@@ -1,3 +1,4 @@
+import { markSensitiveUrlForTelemetry } from "@/lib/telemetry";
 import type { WaddleEncryptedFile } from "./extensions/encrypted-file";
 
 const AES_GCM_NAME = "AES-GCM";
@@ -172,9 +173,10 @@ export async function decryptEncryptedAttachment(
     let lastError: unknown;
     for (const url of sourceUrls(attachment)) {
       try {
+        markSensitiveUrlForTelemetry(url);
         const response = await fetch(url);
         if (!response.ok) {
-          throw new Error(`Failed to fetch encrypted attachment: ${response.status} ${response.statusText}`);
+          throw new Error(`Failed to fetch encrypted attachment with HTTP ${response.status}`);
         }
         const ciphertext = await response.arrayBuffer();
         const plaintext = await decryptCiphertext(ciphertext, attachment.encrypted);

--- a/chat/src/lib/xmpp/file-upload.ts
+++ b/chat/src/lib/xmpp/file-upload.ts
@@ -1,6 +1,6 @@
 /** XEP-0363: HTTP File Upload for sharing images and files in chat. */
 import type { WaddleClient } from "@waddle/xmpp-client-wasm";
-import { reportError } from "@/lib/telemetry";
+import { markSensitiveUrlForTelemetry, reportError } from "@/lib/telemetry";
 import type { WasmUploadSlot } from "./wasm-types";
 
 export const MAX_FILE_UPLOAD_BYTES = 10 * 1024 * 1024;
@@ -86,6 +86,7 @@ async function uploadToSlot(
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
+    markSensitiveUrlForTelemetry(putUrl);
     xhr.open("PUT", putUrl);
     xhr.setRequestHeader("Content-Type", contentType);
     for (const [name, value] of headers) xhr.setRequestHeader(name, value);
@@ -99,13 +100,20 @@ async function uploadToSlot(
         resolve();
         return;
       }
-      const error = new Error(`Upload failed: ${xhr.status} ${xhr.statusText}`);
-      reportError("upload", error, { recoverable: false, detail: "XEP-0363 PUT failed", status: xhr.status });
+      const error = new Error(`Upload failed with HTTP ${xhr.status}`);
+      reportError("upload", new Error("Upload failed with HTTP status"), {
+        recoverable: false,
+        detail: "xep-0363-put-failed",
+        status: xhr.status,
+      });
       reject(error);
     };
     xhr.onerror = () => {
       const error = new Error("Upload failed: network error");
-      reportError("upload", error, { recoverable: false, detail: "XEP-0363 PUT network error" });
+      reportError("upload", new Error("Upload failed with network error"), {
+        recoverable: false,
+        detail: "xep-0363-put-network-error",
+      });
       reject(error);
     };
     xhr.send(file);

--- a/chat/src/lib/xmpp/resume-persistence.ts
+++ b/chat/src/lib/xmpp/resume-persistence.ts
@@ -247,7 +247,7 @@ function consumeSmEnvelope(key: string, ownerId: string): PersistedSmResumeState
     reportError("storage.read", err, {
       recoverable: true,
       detail: "resume-persistence consume failed (sm)",
-      key,
+      storage_area: "sm-resume",
     });
     return null;
   }
@@ -388,7 +388,7 @@ function readJson<T>(key: string, validate: (value: unknown) => value is T, kind
     reportError("storage.read", err, {
       recoverable: true,
       detail: `resume-persistence read failed (${kind})`,
-      key,
+      storage_area: kind,
     });
     return null;
   }
@@ -405,7 +405,7 @@ function writeJson(key: string, value: unknown, kind: string): void {
     reportError(errorKind, err, {
       recoverable: true,
       detail: `resume-persistence write failed (${kind})`,
-      key,
+      storage_area: kind,
     });
   }
 }
@@ -419,7 +419,7 @@ function removeKey(key: string, kind: string): void {
     reportError("storage.write", err, {
       recoverable: true,
       detail: `resume-persistence clear failed (${kind})`,
-      key,
+      storage_area: kind,
     });
   }
 }

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -66,7 +66,7 @@ export interface XmppErrorEvent {
   kind: XmppErrorKind;
   /** Whether the client expects to recover on its own without UI intervention. */
   recoverable: boolean;
-  /** Short, human-readable reason. Safe to log in cleartext. */
+  /** Short, human-readable reason for local UI/debugging; sanitize before telemetry. */
   detail: string;
   /** Original error object if one was caught. */
   cause?: unknown;

--- a/chat/src/lib/xmpp/xmpp-instrumentation.ts
+++ b/chat/src/lib/xmpp/xmpp-instrumentation.ts
@@ -29,6 +29,36 @@ const ERROR_KIND_MAP: Record<XmppErrorKind, ErrorKind> = {
   "history": "xmpp.stream",
   "member-query": "xmpp.stream",
 };
+const XMPP_ERROR_CONDITIONS = new Set([
+  "bad-format",
+  "bad-namespace-prefix",
+  "conflict",
+  "connection-timeout",
+  "forbidden",
+  "host-gone",
+  "host-unknown",
+  "improper-addressing",
+  "internal-server-error",
+  "invalid-from",
+  "invalid-namespace",
+  "invalid-xml",
+  "item-not-found",
+  "not-authorized",
+  "not-well-formed",
+  "policy-violation",
+  "remote-connection-failed",
+  "reset",
+  "resource-constraint",
+  "restricted-xml",
+  "see-other-host",
+  "service-unavailable",
+  "system-shutdown",
+  "undefined-condition",
+  "unsupported-encoding",
+  "unsupported-feature",
+  "unsupported-stanza-type",
+  "unsupported-version",
+]);
 
 export function installInstrumentation(client: BrowserXmppClient): void {
   client.onMessageAcked((id, meta) => {
@@ -43,7 +73,6 @@ export function installInstrumentation(client: BrowserXmppClient): void {
   client.onStatus((status, meta) => {
     reportStatusChange({
       state: status.state,
-      detail: status.detail,
       reconnectDurationMs: meta.reconnectDurationMs,
     });
   });
@@ -55,11 +84,13 @@ export function installInstrumentation(client: BrowserXmppClient): void {
   });
   client.onError((event) => {
     const kind = ERROR_KIND_MAP[event.kind];
-    const cause = event.cause ?? new Error(event.detail);
+    const condition = telemetryCondition(event.condition);
+    const detail = telemetryErrorDetail(event, condition);
+    const cause = new Error(detail);
     reportError(kind, cause, {
       recoverable: event.recoverable,
-      detail: event.detail,
-      ...(event.condition ? { condition: event.condition } : {}),
+      detail,
+      ...(condition ? { condition } : {}),
     });
   });
   // Background-tab RESULT_CODE_HUNG investigation (observe-only). These
@@ -68,4 +99,33 @@ export function installInstrumentation(client: BrowserXmppClient): void {
   client.onReconnectScheduled((info) => reportReconnectScheduled(info));
   client.onCatchup((info) => reportCatchup(info));
   client.onResumeDrain((info) => reportResumeDrain(info));
+}
+
+function telemetryErrorDetail(event: {
+  kind: XmppErrorKind;
+  detail: string;
+  condition?: string;
+}, condition: string | undefined): string {
+  switch (event.kind) {
+    case "auth":
+      return "auth-error";
+    case "connect-timeout":
+      return event.detail.includes("self-presence")
+        ? "room-self-presence-timeout"
+        : "connect-timeout";
+    case "history":
+      return "reconnect-catchup-failed";
+    case "member-query":
+      if (event.detail === "missing list_room_members") return "missing-list-room-members";
+      return condition ? `member-query-${condition}` : "member-query-failed";
+    case "stream":
+      return condition ? `stream-${condition}` : "stream-error";
+  }
+}
+
+function telemetryCondition(condition: string | undefined): string | undefined {
+  if (!condition) return undefined;
+  const normalized = condition.trim().toLowerCase();
+  if (!normalized) return undefined;
+  return XMPP_ERROR_CONDITIONS.has(normalized) ? normalized : "unknown";
 }

--- a/chat/tests/redirect-session.test.ts
+++ b/chat/tests/redirect-session.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  clearStoredSessionId,
+  consumeRedirectSession,
+  getStoredSessionId,
+} from "../src/auth/redirect-session";
+
+function createStorageMock() {
+  const values = new Map<string, string>();
+  return {
+    getItem(key: string) {
+      return values.get(key) ?? null;
+    },
+    setItem(key: string, value: string) {
+      values.set(key, value);
+    },
+    removeItem(key: string) {
+      values.delete(key);
+    },
+    clear() {
+      values.clear();
+    },
+  };
+}
+
+const originalWindow = globalThis.window;
+const originalLocalStorage = globalThis.localStorage;
+
+afterEach(() => {
+  if (originalLocalStorage === undefined) {
+    Reflect.deleteProperty(globalThis, "localStorage");
+  } else {
+    (globalThis as typeof globalThis & { localStorage: Storage }).localStorage = originalLocalStorage;
+  }
+  if (originalWindow === undefined) {
+    Reflect.deleteProperty(globalThis, "window");
+  } else {
+    (globalThis as typeof globalThis & { window: Window & typeof globalThis }).window = originalWindow;
+  }
+});
+
+describe("consumeRedirectSession", () => {
+  test("stores the redirect token and removes it from the visible URL", () => {
+    const storage = createStorageMock();
+    let currentUrl = new URL("https://chat.example/?waddle_server=https%3A%2F%2Fxmpp.example#view=dm&waddle_session_id=tok");
+    const location = {
+      get href() { return currentUrl.href; },
+      get pathname() { return currentUrl.pathname; },
+      get search() { return currentUrl.search; },
+      get hash() { return currentUrl.hash; },
+    } as Location;
+    const history = {
+      replaceState(_state: unknown, _title: string, url: string) {
+        currentUrl = new URL(url, currentUrl.origin);
+      },
+    } as History;
+    (globalThis as typeof globalThis & { localStorage: typeof storage }).localStorage = storage;
+    (globalThis as typeof globalThis & { window: Window & { localStorage: typeof storage } }).window = {
+      ...(originalWindow ?? {}),
+      history,
+      localStorage: storage,
+      location,
+    } as Window & { localStorage: typeof storage };
+
+    expect(consumeRedirectSession()).toBe("tok");
+    expect(getStoredSessionId()).toBe("tok");
+    expect(window.location.href).toBe("https://chat.example/#view=dm");
+
+    clearStoredSessionId();
+    expect(getStoredSessionId()).toBeNull();
+  });
+});

--- a/chat/tests/xmpp-telemetry.test.ts
+++ b/chat/tests/xmpp-telemetry.test.ts
@@ -2,9 +2,16 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { WaddleSession } from "../src/lib/server-auth";
 import { BrowserXmppClient } from "../src/lib/xmpp-client";
 import {
+  __clearSensitiveUrlsForTesting,
+  __scrubMissingFetchSpanUrlForTesting,
+  __scrubSpanUrlForTesting,
+  __scrubXhrSpanUrlForTesting,
+  __sanitizeFaroTransportItemForTesting,
   __setFaroForTesting,
   initTelemetry,
+  markSensitiveUrlForTelemetry,
   reportCatchup,
+  reportError,
   reportMessageAcked,
   reportMessageFailed,
   reportQueueDepthChange,
@@ -97,11 +104,13 @@ beforeEach(() => {
   } as Window & { localStorage: typeof storage };
   localStorage.clear();
   __setFaroForTesting(null);
+  __clearSensitiveUrlsForTesting();
 });
 
 afterEach(() => {
   localStorage.clear();
   __setFaroForTesting(null);
+  __clearSensitiveUrlsForTesting();
   if (originalLocalStorage === undefined) {
     Reflect.deleteProperty(globalThis, "localStorage");
   } else {
@@ -146,7 +155,7 @@ describe("telemetry module no-op behaviour", () => {
     reportSendEnqueued({ kind: "dm", reason: "offline" });
     reportQueueDepthChange({ persisted: 2, inflight: 1 });
     reportSessionLifecycle({ type: "resumed" });
-    reportStatusChange({ state: "reconnecting", detail: "lost" });
+    reportStatusChange({ state: "reconnecting" });
     reportStatusChange({ state: "online", reconnectDurationMs: 4_321 });
     reportReconnectScheduled({ attempt: 3, delayMs: 8_000 });
     reportCatchup({
@@ -169,6 +178,10 @@ describe("telemetry module no-op behaviour", () => {
       "chat.xmpp.status",
       "chat.xmpp.reconnect.scheduled",
     ]);
+    expect(stub.events[0].attributes).toEqual({ kind: "room" });
+    expect(stub.events[1].attributes).toEqual({ kind: "dm" });
+    expect(stub.events[4].attributes).toEqual({ state: "reconnecting" });
+    expect(stub.events[6].attributes).toEqual({ visibility: "visible", hidden_bucket: "visible" });
 
     const measurementTypes = stub.measurements.map((m) => m.type);
     expect(measurementTypes).toEqual([
@@ -217,6 +230,232 @@ describe("telemetry module no-op behaviour", () => {
     const resumeDrain = stub.measurements[5];
     expect(resumeDrain.values).toEqual({ buffered: 5, duration_ms: 12, hidden_ms: 0 });
     expect(resumeDrain.context).toEqual({ visibility: "visible", hidden_bucket: "visible" });
+  });
+
+  test("reportError drops identifier-bearing context fields", () => {
+    const stub = createFaroStub();
+    __setFaroForTesting(stub as never);
+
+    reportError("storage.read", new Error("boom"), {
+      recoverable: true,
+      detail: "storage failed",
+      accountKey: "alice@example.com",
+      api_key: "secret",
+      jid: "alice@example.com/desktop",
+      key: "waddle.chat.sm-resume.alice@example.com",
+      note: "download /api/files/slot-1/file.png?waddle_session_id=tok",
+      queueSize: 2,
+      storage_area: "outbound-queue",
+      storageKey: "waddle.chat.outbound.alice@example.com",
+    });
+
+    expect(stub.errors).toHaveLength(1);
+    expect(stub.errors[0].options?.context).toEqual({
+      kind: "storage.read",
+      recoverable: "true",
+      detail: "storage failed",
+      note: "download /api/files/:slot/:file?waddle_session_id=:redacted",
+      queueSize: "2",
+      storage_area: "outbound-queue",
+    });
+  });
+
+  test("transport sanitizer replaces Faro page URLs with route templates", () => {
+    let currentUrl = new URL("https://chat.example/dm/alice?thread=secret-thread#waddle_session_id=tok");
+    const location = {
+      get href() { return currentUrl.href; },
+      get origin() { return currentUrl.origin; },
+      get pathname() { return currentUrl.pathname; },
+      get search() { return currentUrl.search; },
+      get hash() { return currentUrl.hash; },
+    } as Location;
+    (globalThis as typeof globalThis & { window: Window }).window = {
+      ...(originalWindow ?? {}),
+      location,
+    } as Window;
+
+    const sanitized = __sanitizeFaroTransportItemForTesting({
+      type: "event",
+      payload: {},
+      meta: {
+        page: {
+          id: currentUrl.href,
+          url: currentUrl.href,
+          attributes: {
+            referrer: "https://chat.example/api/files/slot-1/file.png?waddle_session_id=tok",
+          },
+        },
+      },
+    } as never);
+
+    expect(sanitized.meta.page).toEqual({
+      id: "/dm/:user",
+      url: "https://chat.example/dm/:user",
+      attributes: {
+        referrer: "https://chat.example/api/files/:slot/:file?waddle_session_id=:redacted",
+      },
+    });
+
+    currentUrl = new URL("https://chat.example/r/general/x/polls/results?pinned=1&thread=reply");
+    expect(__sanitizeFaroTransportItemForTesting({ payload: {}, meta: {} } as never).meta.page).toEqual({
+      id: "/r/:room/x/:plugin/:route",
+      url: "https://chat.example/r/:room/x/:plugin/:route",
+      attributes: undefined,
+    });
+  });
+
+  test("span URL scrubber redacts untrusted XEP file-transfer URLs", () => {
+    expect(__scrubSpanUrlForTesting(
+      "https://uploads.example/signed/slot-secret/file.png?token=secret#fragment",
+      ["https://chat.example", "https://xmpp.example"],
+    )).toBe("external:unknown");
+
+    expect(__scrubSpanUrlForTesting(
+      "https://xmpp.example/api/messages?session_id=tok#fragment",
+      ["https://xmpp.example"],
+    )).toBe("https://xmpp.example/api/:endpoint");
+
+    expect(__scrubSpanUrlForTesting(
+      "https://chat.example/api/files/slot-1/file.png?download=1",
+      ["https://chat.example"],
+    )).toBe("https://chat.example/api/files/:slot/:file");
+
+    expect(__scrubSpanUrlForTesting(
+      "https://chat.example/dm/alice?thread=secret-thread",
+      ["https://chat.example"],
+    )).toBe("https://chat.example/dm/:user");
+
+    expect(__scrubSpanUrlForTesting(
+      "https://chat.example/r/general/x/polls/results?pinned=1&thread=reply",
+      ["https://chat.example"],
+    )).toBe("https://chat.example/r/:room/x/:plugin/:route");
+
+    markSensitiveUrlForTelemetry("https://chat.example/signed-upload/slot-secret/file.png?token=secret");
+    expect(__scrubSpanUrlForTesting(
+      "https://chat.example/signed-upload/slot-secret/file.png?token=secret",
+      ["https://chat.example"],
+    )).toBe("file-transfer:unknown");
+
+    expect(__scrubXhrSpanUrlForTesting("", ["https://chat.example"])).toEqual({
+      "http.host": ":redacted",
+      "http.target": ":unknown",
+      "http.url": "xhr:unknown",
+      "server.address": ":redacted",
+      "server.port": 0,
+      "url.full": "xhr:unknown",
+      "url.path": ":unknown",
+    });
+
+    expect(__scrubMissingFetchSpanUrlForTesting()).toEqual({
+      "http.host": ":redacted",
+      "http.target": ":unknown",
+      "http.url": "fetch:unknown",
+      "server.address": ":redacted",
+      "server.port": 0,
+      "url.full": "fetch:unknown",
+      "url.path": ":unknown",
+    });
+  });
+
+  test("transport sanitizer redacts finalized trace span URL attributes", () => {
+    const currentUrl = new URL("https://chat.example/r/general");
+    (globalThis as typeof globalThis & { window: Window }).window = {
+      ...(originalWindow ?? {}),
+      location: {
+        get href() { return currentUrl.href; },
+        get origin() { return currentUrl.origin; },
+        get pathname() { return currentUrl.pathname; },
+      } as Location,
+    } as Window;
+
+    const sanitized = __sanitizeFaroTransportItemForTesting({
+      type: "trace",
+      payload: {
+        resourceSpans: [{
+          scopeSpans: [{
+            spans: [{
+              attributes: [
+                { key: "http.url", value: { stringValue: "https://uploads.example/signed/slot-secret/file.png?token=secret" } },
+                { key: "url.full", value: { stringValue: "https://uploads.example/signed/slot-secret/file.png?token=secret" } },
+                { key: "http.host", value: { stringValue: "uploads.example" } },
+                { key: "http.target", value: { stringValue: "/signed/slot-secret/file.png?token=secret" } },
+                { key: "http.status_text", value: { stringValue: "Signed URL expired for slot-secret" } },
+                { key: "server.address", value: { stringValue: "uploads.example" } },
+                { key: "server.port", value: { intValue: 443 } },
+                { key: "url.path", value: { stringValue: "/signed/slot-secret/file.png" } },
+                { key: "url.query", value: { stringValue: "token=secret" } },
+              ],
+            }],
+          }],
+        }],
+      },
+      meta: {},
+    } as never) as unknown as {
+      payload: {
+        resourceSpans: Array<{
+          scopeSpans: Array<{
+            spans: Array<{
+              attributes: Array<{ key: string; value: { stringValue?: string; intValue?: number } }>;
+            }>;
+          }>;
+        }>;
+      };
+    };
+
+    const attributes = Object.fromEntries(
+      sanitized.payload.resourceSpans[0].scopeSpans[0].spans[0].attributes.map((attr) => [
+        attr.key,
+        attr.value.stringValue ?? attr.value.intValue,
+      ]),
+    );
+    expect(attributes).toEqual({
+      "http.host": ":redacted",
+      "http.status_text": ":redacted",
+      "http.target": ":unknown",
+      "http.url": "external:unknown",
+      "server.address": ":redacted",
+      "server.port": 0,
+      "url.full": "external:unknown",
+      "url.path": ":unknown",
+      "url.query": ":redacted",
+    });
+  });
+
+  test("transport sanitizer redacts synthetic Faro trace event attributes", () => {
+    const sanitized = __sanitizeFaroTransportItemForTesting({
+      type: "event",
+      payload: {
+        name: "faro.tracing.fetch",
+        attributes: {
+          "http.host": "uploads.example",
+          "http.status_text": "Signed URL expired for slot-secret",
+          "http.target": "/signed/slot-secret/file.png?token=secret",
+          "http.url": "https://uploads.example/signed/slot-secret/file.png?token=secret",
+          "server.address": "uploads.example",
+          "server.port": "443",
+          "url.full": "https://uploads.example/signed/slot-secret/file.png?token=secret",
+          "url.path": "/signed/slot-secret/file.png",
+          "url.query": "token=secret",
+          peer: "bob@example.com/phone",
+        },
+      },
+      meta: {},
+    } as never) as unknown as {
+      payload: { attributes: Record<string, string> };
+    };
+
+    expect(sanitized.payload.attributes).toEqual({
+      "http.host": ":redacted",
+      "http.status_text": ":redacted",
+      "http.target": ":unknown",
+      "http.url": "external:unknown",
+      "server.address": ":redacted",
+      "server.port": "0",
+      "url.full": "external:unknown",
+      "url.path": ":unknown",
+      "url.query": ":redacted",
+      peer: ":jid",
+    });
   });
 });
 
@@ -409,7 +648,7 @@ describe("BrowserXmppClient telemetry hooks", () => {
 
     const internal = client as unknown as {
       emitError: (event: {
-        kind: "stream" | "auth" | "connect-timeout";
+        kind: "stream" | "auth" | "connect-timeout" | "member-query";
         recoverable: boolean;
         detail: string;
         cause?: unknown;
@@ -441,23 +680,38 @@ describe("BrowserXmppClient telemetry hooks", () => {
       recoverable: true,
       detail: "Rust client reconnect stalled past 15s; discarding agent",
     });
+    internal.emitError({
+      kind: "member-query",
+      recoverable: true,
+      detail: "affiliation query failed for owner",
+      condition: "room@example.com",
+    });
 
-    expect(stub.errors).toHaveLength(3);
+    expect(stub.errors).toHaveLength(4);
 
     const streamErr = stub.errors[0];
-    expect(streamErr.error).toBe(streamCause);
+    expect(streamErr.error).not.toBe(streamCause);
+    expect(streamErr.error.message).toBe("stream-not-authorized");
     expect(streamErr.options?.type).toBe("xmpp.stream");
     expect(streamErr.options?.context?.kind).toBe("xmpp.stream");
     expect(streamErr.options?.context?.recoverable).toBe("false");
+    expect(streamErr.options?.context?.detail).toBe("stream-not-authorized");
     expect(streamErr.options?.context?.condition).toBe("not-authorized");
 
     const authErr = stub.errors[1];
     expect(authErr.options?.type).toBe("xmpp.auth");
     expect(authErr.options?.context?.recoverable).toBe("false");
+    expect(authErr.options?.context?.detail).toBe("auth-error");
 
     const timeoutErr = stub.errors[2];
     expect(timeoutErr.options?.type).toBe("xmpp.disconnect");
     expect(timeoutErr.options?.context?.recoverable).toBe("true");
+    expect(timeoutErr.options?.context?.detail).toBe("connect-timeout");
+
+    const memberErr = stub.errors[3];
+    expect(memberErr.options?.type).toBe("xmpp.stream");
+    expect(memberErr.options?.context?.condition).toBe("unknown");
+    expect(memberErr.options?.context?.detail).toBe("member-query-unknown");
   });
 
   test("enqueuing a send fires onSendEnqueued + onQueueDepthChange", async () => {


### PR DESCRIPTION
## Summary
- enable Grafana Faro for production chat builds with the requested collector URL and app metadata (`waddle-chat`, `1.0.0`, `production`)
- initialize Faro after redirect-session cleanup so URL tokens are removed before page metadata is captured
- add privacy-safe Faro instrumentation for client health, XMPP lifecycle/drop signals, measurements, and frontend HTTP tracing
- sanitize Faro page metadata, events, errors, synthetic trace events, and raw OTLP trace payloads before transport
- redact JIDs, message IDs, redirect/session/API tokens, signed upload/file-transfer URLs, external hosts, route segments, storage/account keys, status text, and sensitive trace URL attributes
- mark XEP file-transfer URLs before fetch/XHR so trace spans collapse to safe placeholders

## Plan
- Wire build-time Faro config through Astro/Vite with production defaults and environment overrides.
- Initialize Faro from the app layout after redirect-token cleanup.
- Keep XMPP/user identifiers out of events, spans, page metadata, and error contexts.
- Add focused regression tests for redirect cleanup and telemetry sanitization.
- Validate local, production, browser-smoke, XEP-policy, and privacy-review paths.

## Validation
- `nix develop ..#default --command bun test ./tests/xmpp-telemetry.test.ts ./tests/redirect-session.test.ts`
- `nix develop ..#default --command bash -lc 'bun test && bun run lint'` (`1578` pass, `0` fail; `knip` clean)
- `nix develop ..#default --command bun run build`
- `CUENV_ENVIRONMENT=production node --input-type=module -e 'const config=(await import("./astro.config.mjs")).default; console.log(JSON.stringify(config.vite.define, null, 2));'`
- `CUENV_ENVIRONMENT=production nix develop ..#default --command bun run build`
- Browser smoke on `http://127.0.0.1:4324`: redirect params removed, local Faro disabled, no overlay
- Final adversarial reviews: build/config, XMPP conformance, and privacy reviewers reported no real actionable issues

## Notes
- No `knip` ignores were added.
- The remaining build output is pre-existing/non-blocking: Astro hint in `src/lib/xmpp/discovery.ts`, Vite chunk-size warning, and Node deprecation warnings.
