### PR TITLE
feat(server): add link preview policy controls

### DIFF
--- a/server/crates/waddle-server/src/config.rs
+++ b/server/crates/waddle-server/src/config.rs
@@ -3,6 +3,7 @@
 use crate::auth::providers::AuthProviderConfig;
 use crate::db::DatabaseDriver;
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 use std::{fmt, str::FromStr};
 use tracing::info;
 use waddle_extensions::ExtensionConfig;
@@ -131,6 +132,8 @@ pub struct ServerConfig {
     pub auth: AuthConfig,
     /// Runtime extension configuration.
     pub extensions: ExtensionConfig,
+    /// Operator controls for server-side link-preview enrichment.
+    pub link_preview: LinkPreviewConfig,
     /// SpiceDB backend configuration.
     /// Runtime startup requires this to be set.
     pub spicedb: Option<SpiceDbConfig>,
@@ -140,6 +143,129 @@ pub struct ServerConfig {
     /// every stamping site reads the same key. Required at startup;
     /// see [`parse_occupant_id_secret`] for the validation rules.
     pub occupant_id_secret: OccupantIdSecret,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkPreviewConfig {
+    pub enabled: bool,
+    pub allowed_hosts: Vec<LinkPreviewHostPattern>,
+    pub blocked_hosts: Vec<LinkPreviewHostPattern>,
+    pub max_fetch_bytes: usize,
+    pub max_cached_image_bytes: usize,
+    pub max_redirects: usize,
+    pub fetch_timeout: Duration,
+    pub video_enabled: bool,
+}
+
+impl Default for LinkPreviewConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            allowed_hosts: Vec::new(),
+            blocked_hosts: Vec::new(),
+            max_fetch_bytes: 256 * 1024,
+            max_cached_image_bytes: 2 * 1024 * 1024,
+            max_redirects: 3,
+            fetch_timeout: Duration::from_millis(1_500),
+            video_enabled: true,
+        }
+    }
+}
+
+impl LinkPreviewConfig {
+    pub fn from_env() -> Result<Self, String> {
+        Self::from_vars(std::env::vars())
+    }
+
+    pub fn from_vars<I, K, V>(vars: I) -> Result<Self, String>
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: AsRef<str>,
+        V: AsRef<str>,
+    {
+        let vars = vars
+            .into_iter()
+            .map(|(key, value)| (key.as_ref().to_string(), value.as_ref().to_string()))
+            .collect::<std::collections::HashMap<_, _>>();
+        Ok(Self {
+            enabled: parse_bool_var(&vars, "WADDLE_LINK_PREVIEW_ENABLED", true)?,
+            allowed_hosts: parse_host_patterns_var(&vars, "WADDLE_LINK_PREVIEW_ALLOWED_HOSTS")?,
+            blocked_hosts: parse_host_patterns_var(&vars, "WADDLE_LINK_PREVIEW_BLOCKED_HOSTS")?,
+            max_fetch_bytes: parse_usize_var(
+                &vars,
+                "WADDLE_LINK_PREVIEW_MAX_FETCH_BYTES",
+                256 * 1024,
+            )?,
+            max_cached_image_bytes: parse_usize_var(
+                &vars,
+                "WADDLE_LINK_PREVIEW_MAX_CACHED_IMAGE_BYTES",
+                2 * 1024 * 1024,
+            )?,
+            max_redirects: parse_usize_var(&vars, "WADDLE_LINK_PREVIEW_MAX_REDIRECTS", 3)?,
+            fetch_timeout: Duration::from_millis(parse_u64_var(
+                &vars,
+                "WADDLE_LINK_PREVIEW_FETCH_TIMEOUT_MS",
+                1_500,
+            )?),
+            video_enabled: parse_bool_var(&vars, "WADDLE_LINK_PREVIEW_VIDEO_ENABLED", true)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LinkPreviewHostPattern {
+    Exact(String),
+    DomainSuffix(String),
+}
+
+impl LinkPreviewHostPattern {
+    pub fn matches(&self, host: &str) -> bool {
+        let host = normalize_host_pattern_value(host);
+        match self {
+            Self::Exact(pattern) => host == *pattern,
+            Self::DomainSuffix(suffix) => {
+                host == *suffix
+                    || host
+                        .strip_suffix(suffix)
+                        .is_some_and(|prefix| prefix.ends_with('.'))
+            }
+        }
+    }
+}
+
+impl FromStr for LinkPreviewHostPattern {
+    type Err = String;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return Err("host pattern must not be empty".to_string());
+        }
+        let suffix = trimmed
+            .strip_prefix("*.")
+            .or_else(|| trimmed.strip_prefix('.'));
+        let (suffix_match, value) = match suffix {
+            Some(value) => (true, value),
+            None => (false, trimmed),
+        };
+        let normalized = normalize_host_pattern_value(value);
+        if normalized.is_empty()
+            || normalized.contains('/')
+            || normalized.contains(':')
+            || normalized.contains(char::is_whitespace)
+        {
+            return Err(format!("invalid host pattern '{raw}'"));
+        }
+        if suffix_match {
+            Ok(Self::DomainSuffix(normalized))
+        } else {
+            Ok(Self::Exact(normalized))
+        }
+    }
+}
+
+fn normalize_host_pattern_value(value: &str) -> String {
+    value.trim().trim_end_matches('.').to_ascii_lowercase()
 }
 
 /// Validate the `WADDLE_OCCUPANT_ID_SECRET` env var into a typed secret.
@@ -177,6 +303,77 @@ fn parse_session_key(raw: Option<&str>) -> Result<String, String> {
     Ok(value.to_string())
 }
 
+fn parse_bool_var(
+    vars: &std::collections::HashMap<String, String>,
+    key: &str,
+    default: bool,
+) -> Result<bool, String> {
+    let Some(value) = vars.get(key).map(|value| value.trim().to_ascii_lowercase()) else {
+        return Ok(default);
+    };
+    match value.as_str() {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "0" | "false" | "no" | "off" => Ok(false),
+        _ => Err(format!(
+            "{key}='{value}' must be a boolean: true/false, yes/no, on/off, or 1/0"
+        )),
+    }
+}
+
+fn parse_usize_var(
+    vars: &std::collections::HashMap<String, String>,
+    key: &str,
+    default: usize,
+) -> Result<usize, String> {
+    vars.get(key)
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .map(|value| {
+            value
+                .parse::<usize>()
+                .map_err(|error| format!("{key}='{value}' must be a positive integer: {error}"))
+        })
+        .unwrap_or(Ok(default))
+}
+
+fn parse_u64_var(
+    vars: &std::collections::HashMap<String, String>,
+    key: &str,
+    default: u64,
+) -> Result<u64, String> {
+    vars.get(key)
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .map(|value| {
+            value
+                .parse::<u64>()
+                .map_err(|error| format!("{key}='{value}' must be a positive integer: {error}"))
+        })
+        .unwrap_or(Ok(default))
+}
+
+fn parse_host_patterns_var(
+    vars: &std::collections::HashMap<String, String>,
+    key: &str,
+) -> Result<Vec<LinkPreviewHostPattern>, String> {
+    let Some(raw) = vars
+        .get(key)
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(Vec::new());
+    };
+    raw.split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .map(|entry| {
+            entry
+                .parse::<LinkPreviewHostPattern>()
+                .map_err(|error| format!("{key}: {error}"))
+        })
+        .collect()
+}
+
 #[cfg(test)]
 const TEST_OCCUPANT_ID_SECRET: &str = "test-occupant-id-secret-32-bytes-long";
 
@@ -201,6 +398,7 @@ impl Default for ServerConfig {
             session_key: "test-session-key-32-bytes-minimum".to_string(),
             auth: AuthConfig::default(),
             extensions: ExtensionConfig::default(),
+            link_preview: LinkPreviewConfig::default(),
             spicedb: None,
             occupant_id_secret: test_occupant_id_secret(),
         }
@@ -220,6 +418,7 @@ impl ServerConfig {
 
         let extensions =
             ExtensionConfig::from_env().map_err(|e| format!("invalid extension config: {e}"))?;
+        let link_preview = LinkPreviewConfig::from_env()?;
         let spicedb = SpiceDbConfig::from_env()?;
 
         let occupant_id_secret =
@@ -231,6 +430,7 @@ impl ServerConfig {
             session_key,
             auth,
             extensions,
+            link_preview,
             spicedb,
             occupant_id_secret,
         })
@@ -262,6 +462,7 @@ impl ServerConfig {
             session_key: "test-key-32-bytes-long-for-aes!".to_string(),
             auth: AuthConfig::default(),
             extensions: ExtensionConfig::default(),
+            link_preview: LinkPreviewConfig::default(),
             spicedb: None,
             occupant_id_secret: test_occupant_id_secret(),
         }
@@ -275,6 +476,7 @@ impl ServerConfig {
             session_key: "test-key-32-bytes-long-for-aes!".to_string(),
             auth: AuthConfig::default(),
             extensions: ExtensionConfig::default(),
+            link_preview: LinkPreviewConfig::default(),
             spicedb: None,
             occupant_id_secret: test_occupant_id_secret(),
         }
@@ -324,6 +526,53 @@ mod tests {
             err.contains("openssl rand"),
             "error must include the generation recipe; got: {err}"
         );
+    }
+
+    #[test]
+    fn link_preview_config_parses_operator_policy_vars() {
+        let config = LinkPreviewConfig::from_vars([
+            ("WADDLE_LINK_PREVIEW_ENABLED", "false"),
+            (
+                "WADDLE_LINK_PREVIEW_ALLOWED_HOSTS",
+                "example.com,*.trusted.example",
+            ),
+            ("WADDLE_LINK_PREVIEW_BLOCKED_HOSTS", "ads.example"),
+            ("WADDLE_LINK_PREVIEW_MAX_FETCH_BYTES", "4096"),
+            ("WADDLE_LINK_PREVIEW_MAX_CACHED_IMAGE_BYTES", "8192"),
+            ("WADDLE_LINK_PREVIEW_MAX_REDIRECTS", "2"),
+            ("WADDLE_LINK_PREVIEW_FETCH_TIMEOUT_MS", "250"),
+            ("WADDLE_LINK_PREVIEW_VIDEO_ENABLED", "0"),
+        ])
+        .expect("config");
+
+        assert!(!config.enabled);
+        assert_eq!(config.allowed_hosts.len(), 2);
+        assert!(config.allowed_hosts[0].matches("example.com"));
+        assert!(config.allowed_hosts[1].matches("cdn.trusted.example"));
+        assert!(config.blocked_hosts[0].matches("ads.example"));
+        assert_eq!(config.max_fetch_bytes, 4096);
+        assert_eq!(config.max_cached_image_bytes, 8192);
+        assert_eq!(config.max_redirects, 2);
+        assert_eq!(config.fetch_timeout, Duration::from_millis(250));
+        assert!(!config.video_enabled);
+    }
+
+    #[test]
+    fn link_preview_host_patterns_reject_non_host_shapes() {
+        let error = "https://example.com"
+            .parse::<LinkPreviewHostPattern>()
+            .expect_err("URL must not parse as host pattern");
+
+        assert!(error.contains("invalid host pattern"));
+    }
+
+    #[test]
+    fn link_preview_config_rejects_invalid_boolean_vars() {
+        let error = LinkPreviewConfig::from_vars([("WADDLE_LINK_PREVIEW_ENABLED", "ture")])
+            .expect_err("typo must fail startup");
+
+        assert!(error.contains("WADDLE_LINK_PREVIEW_ENABLED"));
+        assert!(error.contains("must be a boolean"));
     }
 
     #[test]

--- a/server/crates/waddle-server/src/config.rs
+++ b/server/crates/waddle-server/src/config.rs
@@ -173,6 +173,8 @@ impl Default for LinkPreviewConfig {
 }
 
 impl LinkPreviewConfig {
+    const MAX_FETCH_TIMEOUT: Duration = Duration::from_secs(60);
+
     pub fn from_env() -> Result<Self, String> {
         Self::from_vars(std::env::vars())
     }
@@ -187,6 +189,18 @@ impl LinkPreviewConfig {
             .into_iter()
             .map(|(key, value)| (key.as_ref().to_string(), value.as_ref().to_string()))
             .collect::<std::collections::HashMap<_, _>>();
+        let fetch_timeout = Duration::from_millis(parse_u64_var(
+            &vars,
+            "WADDLE_LINK_PREVIEW_FETCH_TIMEOUT_MS",
+            1_500,
+        )?);
+        if fetch_timeout > Self::MAX_FETCH_TIMEOUT {
+            return Err(format!(
+                "WADDLE_LINK_PREVIEW_FETCH_TIMEOUT_MS must be at most {}ms",
+                Self::MAX_FETCH_TIMEOUT.as_millis()
+            ));
+        }
+
         Ok(Self {
             enabled: parse_bool_var(&vars, "WADDLE_LINK_PREVIEW_ENABLED", true)?,
             allowed_hosts: parse_host_patterns_var(&vars, "WADDLE_LINK_PREVIEW_ALLOWED_HOSTS")?,
@@ -202,11 +216,7 @@ impl LinkPreviewConfig {
                 2 * 1024 * 1024,
             )?,
             max_redirects: parse_usize_var(&vars, "WADDLE_LINK_PREVIEW_MAX_REDIRECTS", 3)?,
-            fetch_timeout: Duration::from_millis(parse_u64_var(
-                &vars,
-                "WADDLE_LINK_PREVIEW_FETCH_TIMEOUT_MS",
-                1_500,
-            )?),
+            fetch_timeout,
             video_enabled: parse_bool_var(&vars, "WADDLE_LINK_PREVIEW_VIDEO_ENABLED", true)?,
         })
     }
@@ -252,6 +262,7 @@ impl FromStr for LinkPreviewHostPattern {
         if normalized.is_empty()
             || normalized.contains('/')
             || normalized.contains(':')
+            || normalized.contains('*')
             || normalized.contains(char::is_whitespace)
         {
             return Err(format!("invalid host pattern '{raw}'"));
@@ -564,6 +575,12 @@ mod tests {
             .expect_err("URL must not parse as host pattern");
 
         assert!(error.contains("invalid host pattern"));
+
+        let error = "ads.*.example"
+            .parse::<LinkPreviewHostPattern>()
+            .expect_err("unsupported wildcard position must not parse");
+
+        assert!(error.contains("invalid host pattern"));
     }
 
     #[test]
@@ -573,6 +590,16 @@ mod tests {
 
         assert!(error.contains("WADDLE_LINK_PREVIEW_ENABLED"));
         assert!(error.contains("must be a boolean"));
+    }
+
+    #[test]
+    fn link_preview_config_rejects_fetch_timeouts_above_startup_cap() {
+        let error =
+            LinkPreviewConfig::from_vars([("WADDLE_LINK_PREVIEW_FETCH_TIMEOUT_MS", "61000")])
+                .expect_err("oversized timeout must fail startup");
+
+        assert!(error.contains("WADDLE_LINK_PREVIEW_FETCH_TIMEOUT_MS"));
+        assert!(error.contains("at most"));
     }
 
     #[test]

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -594,6 +594,7 @@ async fn create_websocket_state(
                 sfu: sfu_service,
             },
             occupant_id_secret: server_config.occupant_id_secret.clone(),
+            link_preview: server_config.link_preview.clone(),
             provider_ingress,
             provider_dispatch_tasks,
         },

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
@@ -20,6 +20,9 @@ use super::link_preview_resolver::{
     resolve_link_preview, LinkPreviewMediaCache, LinkPreviewResolverOutcome,
     LinkPreviewResolverPolicy, LinkPreviewResolverStatus,
 };
+use crate::server::routes::websocket::link_preview_telemetry::{
+    record_link_preview_event, LinkPreviewTelemetryEvent,
+};
 
 struct LinkPreviewLookupDeps<'a> {
     muc_domain: &'a str,
@@ -78,15 +81,15 @@ async fn handle_link_preview_lookup_iq_with_policy(
     let resolver_policy = match deps.resolver_policy {
         Some(policy) => policy,
         None => {
-            owned_resolver_policy = LinkPreviewResolverPolicy {
-                media_cache: Some(LinkPreviewMediaCache::new(
+            owned_resolver_policy = LinkPreviewResolverPolicy::from_config(
+                &state.deps.link_preview,
+                Some(LinkPreviewMediaCache::new(
                     state.deps.app_state.blob_storage.clone(),
                     state.deps.auth_state.base_url.as_str(),
                     state.deps.app_state.db_pool.global_actor().clone(),
                     sender_jid.to_bare(),
                 )),
-                ..Default::default()
-            };
+            );
             &owned_resolver_policy
         }
     };
@@ -135,8 +138,19 @@ async fn handle_link_preview_lookup_iq_with_policy(
             None,
         )];
     };
+    if !resolver_policy.enabled {
+        record_link_preview_event(LinkPreviewTelemetryEvent::ResolverBlocked);
+        return vec![build_link_preview_lookup_result(
+            iq,
+            deps.response_from,
+            deps.response_to,
+            LinkPreviewResolverStatus::Blocked,
+            None,
+        )];
+    }
     let outcome = resolve_link_preview(&original_url, resolver_policy).await;
     let LinkPreviewResolverOutcome::Ready(metadata) = outcome else {
+        record_link_preview_event(telemetry_event_for_status(outcome.status()));
         return vec![build_link_preview_lookup_result(
             iq,
             deps.response_from,
@@ -163,6 +177,7 @@ async fn handle_link_preview_lookup_iq_with_policy(
         expires_at_unix: expires_at.timestamp(),
     };
     let Some(token) = encode_link_preview_token_checked(&data, deps.secret) else {
+        record_link_preview_event(LinkPreviewTelemetryEvent::ResolverFailed);
         return vec![build_link_preview_lookup_result(
             iq,
             deps.response_from,
@@ -172,6 +187,7 @@ async fn handle_link_preview_lookup_iq_with_policy(
         )];
     };
 
+    record_link_preview_event(LinkPreviewTelemetryEvent::ResolverReady);
     vec![build_link_preview_lookup_result(
         iq,
         deps.response_from,
@@ -183,6 +199,15 @@ async fn handle_link_preview_lookup_iq_with_policy(
             expires_at.to_rfc3339_opts(SecondsFormat::Millis, true),
         )),
     )]
+}
+
+fn telemetry_event_for_status(status: LinkPreviewResolverStatus) -> LinkPreviewTelemetryEvent {
+    match status {
+        LinkPreviewResolverStatus::Ready => LinkPreviewTelemetryEvent::ResolverReady,
+        LinkPreviewResolverStatus::Blocked => LinkPreviewTelemetryEvent::ResolverBlocked,
+        LinkPreviewResolverStatus::Failed => LinkPreviewTelemetryEvent::ResolverFailed,
+        LinkPreviewResolverStatus::Unsupported => LinkPreviewTelemetryEvent::ResolverUnsupported,
+    }
 }
 
 async fn authorize_link_preview_scope(
@@ -304,6 +329,7 @@ fn append_text(parent: &mut Element, name: &str, value: Option<&str>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::server::routes::websocket::link_preview_telemetry::recorded_events;
     use crate::server::routes::websocket::tests::create_test_websocket_state;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -325,8 +351,10 @@ mod tests {
         b"test-link-preview-secret"
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn handles_https_lookup_with_scoped_token_text_and_cached_image_metadata() {
+        let _events_guard = recorded_events::async_lock().await;
+        recorded_events::clear();
         let server = MockServer::start().await;
         let image_bytes = bytes::Bytes::from_static(b"\x89PNG\r\n\x1a\nlookup preview");
         Mock::given(method("GET"))
@@ -448,10 +476,16 @@ mod tests {
                 .as_deref(),
             Some("Example Article")
         );
+        assert!(
+            recorded_events::take().contains(&LinkPreviewTelemetryEvent::ResolverReady),
+            "ready lookup path must emit ready telemetry"
+        );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn oversized_encoded_token_returns_failed_without_preview() {
+        let _events_guard = recorded_events::async_lock().await;
+        recorded_events::clear();
         let server = MockServer::start().await;
         let huge_path = format!("/{}", "a".repeat(8 * 1024));
         Mock::given(method("GET"))
@@ -506,10 +540,16 @@ mod tests {
         assert!(lookup
             .get_child("preview", NS_WADDLE_LINK_PREVIEW)
             .is_none());
+        assert!(
+            recorded_events::take().contains(&LinkPreviewTelemetryEvent::ResolverFailed),
+            "token mint failure path must emit failed telemetry"
+        );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn non_https_lookup_returns_unsupported_without_token() {
+        let _events_guard = recorded_events::async_lock().await;
+        recorded_events::clear();
         let payload = Element::builder("lookup", NS_WADDLE_LINK_PREVIEW)
             .append(
                 Element::builder("url", NS_WADDLE_LINK_PREVIEW)
@@ -541,6 +581,104 @@ mod tests {
             .get_child("lookup", NS_WADDLE_LINK_PREVIEW)
             .expect("lookup result");
         assert_eq!(lookup.attr("status"), Some("unsupported"));
+        assert!(lookup
+            .get_child("preview", NS_WADDLE_LINK_PREVIEW)
+            .is_none());
+        assert!(
+            recorded_events::take().contains(&LinkPreviewTelemetryEvent::ResolverUnsupported),
+            "unsupported lookup path must emit unsupported telemetry"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn disabled_policy_returns_blocked_without_token() {
+        let _events_guard = recorded_events::async_lock().await;
+        recorded_events::clear();
+        let payload = Element::builder("lookup", NS_WADDLE_LINK_PREVIEW)
+            .append(
+                Element::builder("url", NS_WADDLE_LINK_PREVIEW)
+                    .append("https://example.com/a")
+                    .build(),
+            )
+            .append(
+                Element::builder("scope", NS_WADDLE_LINK_PREVIEW)
+                    .append("alice@example.com")
+                    .build(),
+            )
+            .build();
+        let iq = iq_get_with_payload(payload);
+
+        let state = create_test_websocket_state().await;
+        let response = handle_link_preview_lookup_iq_with_policy(
+            &iq,
+            Some(&sender()),
+            state.as_ref(),
+            LinkPreviewLookupDeps {
+                muc_domain: "muc.example.com",
+                response_from: None,
+                response_to: None,
+                secret: secret(),
+                resolver_policy: Some(&LinkPreviewResolverPolicy {
+                    enabled: false,
+                    ..Default::default()
+                }),
+            },
+        )
+        .await;
+
+        let elem: Element = response[0].parse().expect("iq result");
+        let lookup = elem
+            .get_child("lookup", NS_WADDLE_LINK_PREVIEW)
+            .expect("lookup result");
+        assert_eq!(lookup.attr("status"), Some("blocked"));
+        assert!(lookup
+            .get_child("preview", NS_WADDLE_LINK_PREVIEW)
+            .is_none());
+        assert!(
+            recorded_events::take().contains(&LinkPreviewTelemetryEvent::ResolverBlocked),
+            "disabled lookup path must emit blocked telemetry"
+        );
+    }
+
+    #[tokio::test]
+    async fn blocked_host_policy_returns_blocked_lookup_without_token() {
+        let payload = Element::builder("lookup", NS_WADDLE_LINK_PREVIEW)
+            .append(
+                Element::builder("url", NS_WADDLE_LINK_PREVIEW)
+                    .append("https://blocked.example/a")
+                    .build(),
+            )
+            .append(
+                Element::builder("scope", NS_WADDLE_LINK_PREVIEW)
+                    .append("alice@example.com")
+                    .build(),
+            )
+            .build();
+        let iq = iq_get_with_payload(payload);
+
+        let state = create_test_websocket_state().await;
+        let response = handle_link_preview_lookup_iq_with_policy(
+            &iq,
+            Some(&sender()),
+            state.as_ref(),
+            LinkPreviewLookupDeps {
+                muc_domain: "muc.example.com",
+                response_from: None,
+                response_to: None,
+                secret: secret(),
+                resolver_policy: Some(&LinkPreviewResolverPolicy {
+                    blocked_hosts: vec!["blocked.example".parse().expect("pattern")],
+                    ..Default::default()
+                }),
+            },
+        )
+        .await;
+
+        let elem: Element = response[0].parse().expect("iq result");
+        let lookup = elem
+            .get_child("lookup", NS_WADDLE_LINK_PREVIEW)
+            .expect("lookup result");
+        assert_eq!(lookup.attr("status"), Some("blocked"));
         assert!(lookup
             .get_child("preview", NS_WADDLE_LINK_PREVIEW)
             .is_none());

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
@@ -13,9 +13,14 @@ use tracing::warn;
 use url::{Host, Url};
 use waddle_xmpp_core::PreviewImageMediaType;
 
+use crate::config::{LinkPreviewConfig, LinkPreviewHostPattern};
 use crate::db::actor::{DbActor, DbExecute};
 use crate::db::Value;
+use crate::server::routes::websocket::link_preview_telemetry::{
+    record_link_preview_event, LinkPreviewTelemetryEvent,
+};
 use crate::storage::BlobStorage;
+use crate::storage::{BlobMeta, StorageError};
 
 const DEFAULT_MAX_BYTES: usize = 256 * 1024;
 const DEFAULT_MAX_IMAGE_BYTES: usize = 2 * 1024 * 1024;
@@ -68,23 +73,51 @@ impl LinkPreviewMediaCache {
 
 #[derive(Clone)]
 pub(super) struct LinkPreviewResolverPolicy {
+    pub enabled: bool,
+    pub allowed_hosts: Vec<LinkPreviewHostPattern>,
+    pub blocked_hosts: Vec<LinkPreviewHostPattern>,
     pub max_bytes: usize,
     pub max_image_bytes: usize,
     pub max_redirects: usize,
     pub timeout: Duration,
     pub allow_http_loopback_for_tests: bool,
     pub media_cache: Option<LinkPreviewMediaCache>,
+    pub video_enabled: bool,
 }
 
 impl Default for LinkPreviewResolverPolicy {
     fn default() -> Self {
         Self {
+            enabled: true,
+            allowed_hosts: Vec::new(),
+            blocked_hosts: Vec::new(),
             max_bytes: DEFAULT_MAX_BYTES,
             max_image_bytes: DEFAULT_MAX_IMAGE_BYTES,
             max_redirects: DEFAULT_MAX_REDIRECTS,
             timeout: DEFAULT_TIMEOUT,
             allow_http_loopback_for_tests: false,
             media_cache: None,
+            video_enabled: true,
+        }
+    }
+}
+
+impl LinkPreviewResolverPolicy {
+    pub(super) fn from_config(
+        config: &LinkPreviewConfig,
+        media_cache: Option<LinkPreviewMediaCache>,
+    ) -> Self {
+        Self {
+            enabled: config.enabled,
+            allowed_hosts: config.allowed_hosts.clone(),
+            blocked_hosts: config.blocked_hosts.clone(),
+            max_bytes: config.max_fetch_bytes,
+            max_image_bytes: config.max_cached_image_bytes,
+            max_redirects: config.max_redirects,
+            timeout: config.fetch_timeout,
+            allow_http_loopback_for_tests: false,
+            media_cache,
+            video_enabled: config.video_enabled,
         }
     }
 }
@@ -185,6 +218,19 @@ pub(super) async fn resolve_link_preview(
     LinkPreviewResolverOutcome::Failed
 }
 
+fn looks_like_direct_video_url(url: &Url) -> bool {
+    let path = url.path().to_ascii_lowercase();
+    matches!(
+        path.rsplit('/').next(),
+        Some(filename)
+            if filename.ends_with(".mp4")
+                || filename.ends_with(".webm")
+                || filename.ends_with(".mov")
+                || filename.ends_with(".m4v")
+                || filename.ends_with(".ogv")
+    )
+}
+
 async fn fetch_cached_preview_image(
     remote: &RemotePreviewImage,
     policy: &LinkPreviewResolverPolicy,
@@ -236,6 +282,29 @@ async fn publish_cached_preview_image_slot(
     media_type: &str,
 ) -> Result<(String, String), LinkPreviewResolverStatus> {
     let key = format!("link-previews/sha256/{hash}");
+    match cache.storage.get(&key).await {
+        Ok((cached_bytes, meta)) => {
+            record_link_preview_event(LinkPreviewTelemetryEvent::CacheHit);
+            let filename = format!(
+                "link-preview-{hash}.{}",
+                preview_image_extension(meta.content_type.as_str())
+            );
+            return record_cached_preview_image_slot(
+                cache,
+                &key,
+                &filename,
+                cached_bytes.len(),
+                &meta,
+            )
+            .await;
+        }
+        Err(StorageError::NotFound(_)) => {
+            record_link_preview_event(LinkPreviewTelemetryEvent::CacheMiss)
+        }
+        Err(StorageError::Internal(_)) => {
+            return Err(LinkPreviewResolverStatus::Failed);
+        }
+    }
     cache
         .storage
         .put(&key, bytes.clone(), media_type)
@@ -245,13 +314,32 @@ async fn publish_cached_preview_image_slot(
             LinkPreviewResolverStatus::Unsupported
         })?;
 
-    let slot_id = uuid::Uuid::new_v4().to_string();
     let filename = format!(
         "link-preview-{hash}.{}",
         preview_image_extension(media_type)
     );
+    record_cached_preview_image_slot(
+        cache,
+        &key,
+        &filename,
+        bytes.len(),
+        &BlobMeta {
+            content_type: media_type.to_string(),
+        },
+    )
+    .await
+}
+
+async fn record_cached_preview_image_slot(
+    cache: &LinkPreviewMediaCache,
+    key: &str,
+    filename: &str,
+    size: usize,
+    meta: &BlobMeta,
+) -> Result<(String, String), LinkPreviewResolverStatus> {
+    let slot_id = uuid::Uuid::new_v4().to_string();
     let now = Utc::now();
-    let size_bytes = i64::try_from(bytes.len()).map_err(|_| LinkPreviewResolverStatus::Failed)?;
+    let size_bytes = i64::try_from(size).map_err(|_| LinkPreviewResolverStatus::Failed)?;
     cache
         .global_db_actor
         .ask(DbExecute {
@@ -259,10 +347,10 @@ async fn publish_cached_preview_image_slot(
             params: vec![
                 Value::from(slot_id.clone()),
                 Value::from(cache.requester_jid.to_string()),
-                Value::from(filename.clone()),
+                Value::from(filename.to_string()),
                 Value::from(size_bytes),
-                Value::from(media_type.to_string()),
-                Value::from(key),
+                Value::from(meta.content_type.clone()),
+                Value::from(key.to_string()),
                 Value::from((now + chrono::Duration::minutes(15)).to_rfc3339()),
                 Value::from(now.to_rfc3339()),
             ],
@@ -272,7 +360,7 @@ async fn publish_cached_preview_image_slot(
             warn!(%error, "failed to record XEP-0363 link preview upload slot");
             LinkPreviewResolverStatus::Unsupported
         })?;
-    Ok((slot_id, filename))
+    Ok((slot_id, filename.to_string()))
 }
 
 fn preview_image_extension(media_type: &str) -> &'static str {
@@ -638,6 +726,9 @@ fn classify_url_with_policy(
     url: &Url,
     policy: &LinkPreviewResolverPolicy,
 ) -> LinkPreviewResolverStatus {
+    if !policy.video_enabled && looks_like_direct_video_url(url) {
+        return LinkPreviewResolverStatus::Unsupported;
+    }
     if url.scheme() != "https" {
         if policy.allow_http_loopback_for_tests
             && url.scheme() == "http"
@@ -652,6 +743,21 @@ fn classify_url_with_policy(
     }
     if let Some(Host::Domain(host)) = url.host() {
         if is_dot_local_domain(host) {
+            return LinkPreviewResolverStatus::Blocked;
+        }
+        if policy
+            .blocked_hosts
+            .iter()
+            .any(|pattern| pattern.matches(host))
+        {
+            return LinkPreviewResolverStatus::Blocked;
+        }
+        if !policy.allowed_hosts.is_empty()
+            && !policy
+                .allowed_hosts
+                .iter()
+                .any(|pattern| pattern.matches(host))
+        {
             return LinkPreviewResolverStatus::Blocked;
         }
     }
@@ -1215,6 +1321,7 @@ fn end_tag_end_index_at(html: &[u8], start: usize, name: &[u8]) -> EndTagMatch {
 mod tests {
     use super::*;
     use crate::db::{DatabaseConfig, DatabasePool, MigrationRunner, PoolConfig};
+    use crate::server::routes::websocket::link_preview_telemetry::recorded_events;
     use std::future::Future;
     use std::pin::Pin;
     use std::sync::Arc;
@@ -1518,6 +1625,65 @@ mod tests {
         }
         assert!(is_dot_local_domain("Printer.Local"));
         assert!(is_dot_local_domain("Printer.Local."));
+    }
+
+    #[test]
+    fn host_block_patterns_override_allowed_https_targets() {
+        let policy = LinkPreviewResolverPolicy {
+            blocked_hosts: vec!["*.example.com".parse().expect("pattern")],
+            ..Default::default()
+        };
+        let blocked = Url::parse("https://news.example.com/article").expect("url");
+        let allowed = Url::parse("https://example.net/article").expect("url");
+
+        assert_eq!(
+            classify_url_with_policy(&blocked, &policy),
+            LinkPreviewResolverStatus::Blocked
+        );
+        assert_eq!(
+            classify_url_with_policy(&allowed, &policy),
+            LinkPreviewResolverStatus::Ready
+        );
+    }
+
+    #[test]
+    fn non_empty_host_allow_patterns_block_unlisted_hosts() {
+        let policy = LinkPreviewResolverPolicy {
+            allowed_hosts: vec!["example.com".parse().expect("pattern")],
+            ..Default::default()
+        };
+        let allowed = Url::parse("https://example.com/article").expect("url");
+        let blocked = Url::parse("https://elsewhere.example/article").expect("url");
+
+        assert_eq!(
+            classify_url_with_policy(&allowed, &policy),
+            LinkPreviewResolverStatus::Ready
+        );
+        assert_eq!(
+            classify_url_with_policy(&blocked, &policy),
+            LinkPreviewResolverStatus::Blocked
+        );
+    }
+
+    #[tokio::test]
+    async fn disabled_video_policy_rejects_direct_video_urls_before_fetch() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/clip.mp4"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw("not fetched", "video/mp4"))
+            .mount(&server)
+            .await;
+        let policy = LinkPreviewResolverPolicy {
+            allow_http_loopback_for_tests: true,
+            video_enabled: false,
+            ..Default::default()
+        };
+        let url = Url::parse(&format!("{}/clip.mp4", server.uri())).expect("url");
+
+        assert_eq!(
+            resolve_link_preview(&url, &policy).await,
+            LinkPreviewResolverOutcome::Unsupported
+        );
     }
 
     #[tokio::test]
@@ -2146,8 +2312,10 @@ mod tests {
         assert_single_range_request(&server, "bytes=0-255").await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn fetches_safe_preview_image_into_content_addressed_waddle_storage() {
+        let _events_guard = recorded_events::async_lock().await;
+        recorded_events::clear();
         let server = MockServer::start().await;
         let image_bytes = bytes::Bytes::from_static(b"\x89PNG\r\n\x1a\nfake png bytes");
         Mock::given(method("GET"))
@@ -2184,7 +2352,7 @@ mod tests {
             test_media_cache_with_base_url(storage.clone(), "https://waddle.example").await;
         let policy = LinkPreviewResolverPolicy {
             allow_http_loopback_for_tests: true,
-            media_cache: Some(media_cache),
+            media_cache: Some(media_cache.clone()),
             ..Default::default()
         };
         let url = Url::parse(&format!("{}/article", server.uri())).expect("url");
@@ -2239,6 +2407,21 @@ mod tests {
         let (stored, meta) = storage.get(&expected_key).await.expect("cached bytes");
         assert_eq!(stored, image_bytes);
         assert_eq!(meta.content_type, "image/png");
+        assert!(
+            recorded_events::take().contains(&LinkPreviewTelemetryEvent::CacheMiss),
+            "first content-addressed image store must emit cache_miss telemetry"
+        );
+
+        recorded_events::clear();
+        let second_outcome = resolve_link_preview(&url, &policy).await;
+        let LinkPreviewResolverOutcome::Ready(second_metadata) = second_outcome else {
+            panic!("expected ready outcome, got {second_outcome:?}");
+        };
+        assert!(second_metadata.image.is_some());
+        assert!(
+            recorded_events::take().contains(&LinkPreviewTelemetryEvent::CacheHit),
+            "reusing an existing content-addressed image must emit cache_hit telemetry"
+        );
     }
 
     #[tokio::test]
@@ -2289,6 +2472,104 @@ mod tests {
             .get("link-previews/sha256/d4dc56669143034f31aa309635d4113d9ad76a02b1739da22c965ed2049be9e6")
             .await
             .is_err());
+    }
+
+    #[tokio::test]
+    async fn oversized_preview_image_content_length_degrades_to_text_metadata() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/article"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                format!(
+                    r#"<html><head>
+                          <meta property="og:title" content="Fetched title">
+                          <meta property="og:image" content="{}/preview.png">
+                        </head></html>"#,
+                    server.uri()
+                ),
+                "text/html; charset=utf-8",
+            ))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/preview.png"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "image/png")
+                    .set_body_bytes({
+                        let mut bytes = vec![b'x'; 1024];
+                        bytes[..8].copy_from_slice(b"\x89PNG\r\n\x1a\n");
+                        bytes
+                    }),
+            )
+            .mount(&server)
+            .await;
+        let storage_dir =
+            std::env::temp_dir().join(format!("waddle-link-preview-{}", uuid::Uuid::new_v4()));
+        let storage: Arc<dyn crate::storage::BlobStorage> =
+            Arc::new(crate::storage::LocalStorage::new(storage_dir));
+        let policy = LinkPreviewResolverPolicy {
+            allow_http_loopback_for_tests: true,
+            media_cache: Some(test_media_cache(storage.clone()).await),
+            max_image_bytes: 16,
+            ..Default::default()
+        };
+        let url = Url::parse(&format!("{}/article", server.uri())).expect("url");
+
+        let outcome = resolve_link_preview(&url, &policy).await;
+
+        let LinkPreviewResolverOutcome::Ready(metadata) = outcome else {
+            panic!("expected ready outcome, got {outcome:?}");
+        };
+        assert_eq!(metadata.title.as_deref(), Some("Fetched title"));
+        assert_eq!(metadata.image, None);
+    }
+
+    #[tokio::test]
+    async fn oversized_preview_image_stream_degrades_to_text_metadata() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/article"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                format!(
+                    r#"<html><head>
+                          <meta property="og:title" content="Fetched title">
+                          <meta property="og:image" content="{}/preview.png">
+                        </head></html>"#,
+                    server.uri()
+                ),
+                "text/html; charset=utf-8",
+            ))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/preview.png"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "image/png")
+                    .set_body_bytes(bytes::Bytes::from_static(b"\x89PNG\r\n\x1a\nbody-over-cap")),
+            )
+            .mount(&server)
+            .await;
+        let storage_dir =
+            std::env::temp_dir().join(format!("waddle-link-preview-{}", uuid::Uuid::new_v4()));
+        let storage: Arc<dyn crate::storage::BlobStorage> =
+            Arc::new(crate::storage::LocalStorage::new(storage_dir));
+        let policy = LinkPreviewResolverPolicy {
+            allow_http_loopback_for_tests: true,
+            media_cache: Some(test_media_cache(storage.clone()).await),
+            max_image_bytes: 8,
+            ..Default::default()
+        };
+        let url = Url::parse(&format!("{}/article", server.uri())).expect("url");
+
+        let outcome = resolve_link_preview(&url, &policy).await;
+
+        let LinkPreviewResolverOutcome::Ready(metadata) = outcome else {
+            panic!("expected ready outcome, got {outcome:?}");
+        };
+        assert_eq!(metadata.title.as_deref(), Some("Fetched title"));
+        assert_eq!(metadata.image, None);
     }
 
     #[tokio::test]
@@ -2728,6 +3009,77 @@ mod tests {
         let outcome = resolve_link_preview(&url, &policy).await;
 
         assert_eq!(outcome.status(), LinkPreviewResolverStatus::Blocked);
+    }
+
+    #[tokio::test]
+    async fn redirect_into_admin_blocked_host_returns_blocked_without_following() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/redirect"))
+            .respond_with(
+                ResponseTemplate::new(302)
+                    .insert_header("location", "https://blocked.example/final"),
+            )
+            .mount(&server)
+            .await;
+        let policy = LinkPreviewResolverPolicy {
+            allow_http_loopback_for_tests: true,
+            blocked_hosts: vec!["blocked.example".parse().expect("pattern")],
+            ..Default::default()
+        };
+        let url = Url::parse(&format!("{}/redirect", server.uri())).expect("url");
+
+        let outcome = resolve_link_preview(&url, &policy).await;
+
+        assert_eq!(outcome.status(), LinkPreviewResolverStatus::Blocked);
+    }
+
+    #[tokio::test]
+    async fn redirect_outside_admin_allowlist_returns_blocked_without_following() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/redirect"))
+            .respond_with(
+                ResponseTemplate::new(302)
+                    .insert_header("location", "https://elsewhere.example/final"),
+            )
+            .mount(&server)
+            .await;
+        let policy = LinkPreviewResolverPolicy {
+            allow_http_loopback_for_tests: true,
+            allowed_hosts: vec!["allowed.example".parse().expect("pattern")],
+            ..Default::default()
+        };
+        let url = Url::parse(&format!("{}/redirect", server.uri())).expect("url");
+
+        let outcome = resolve_link_preview(&url, &policy).await;
+
+        assert_eq!(outcome.status(), LinkPreviewResolverStatus::Blocked);
+    }
+
+    #[tokio::test]
+    async fn disabled_video_policy_rejects_redirected_video_url_before_fetch() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/article"))
+            .respond_with(ResponseTemplate::new(302).insert_header("location", "/clip.mp4"))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/clip.mp4"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw("not fetched", "video/mp4"))
+            .mount(&server)
+            .await;
+        let policy = LinkPreviewResolverPolicy {
+            allow_http_loopback_for_tests: true,
+            video_enabled: false,
+            ..Default::default()
+        };
+        let url = Url::parse(&format!("{}/article", server.uri())).expect("url");
+
+        let outcome = resolve_link_preview(&url, &policy).await;
+
+        assert_eq!(outcome.status(), LinkPreviewResolverStatus::Unsupported);
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -9,7 +9,7 @@ use waddle_xmpp::{
         add_reference, build_link_metadata_element, decode_link_preview_token,
         extract_link_preview_request_from_message, parse_fallbacks_from_message,
         strip_fallback_ranges, strip_link_metadata, strip_link_preview_requests, FallbackRegion,
-        LinkMetadata, Reference, NS_DELAY, NS_REPLY,
+        LinkMetadata, Reference, WaddleLinkPreviewError, NS_DELAY, NS_REPLY,
     },
     Stanza,
 };
@@ -21,6 +21,9 @@ use super::super::{
     interpret_loop::build_interpret_deps, replay::drive_interpret_loop, WebSocketState,
 };
 use crate::auth::Session;
+use crate::server::routes::websocket::link_preview_telemetry::{
+    record_link_preview_event, LinkPreviewTelemetryEvent,
+};
 use waddle_xmpp::protocol::ConnectionPhase;
 
 /// Thin transport adapter that drives the sans-I/O dispatcher
@@ -77,6 +80,7 @@ pub async fn handle_message(
         state.deps.occupant_id_secret.key(),
         chrono::Utc::now().timestamp(),
         state.deps.auth_state.base_url.as_str(),
+        state.deps.link_preview.enabled,
     );
 
     if incoming.type_ != xmpp_parsers::message::MessageType::Groupchat
@@ -119,11 +123,29 @@ fn consume_link_preview_request(
     secret: &[u8],
     now_unix: i64,
     trusted_media_base_url: &str,
+    link_preview_enabled: bool,
 ) {
+    if !link_preview_enabled {
+        strip_link_preview_requests(message);
+        strip_link_metadata(message);
+        return;
+    }
     let expected_sender = sender_jid.to_bare();
     let expected_scope = message.to.as_ref().map(|to| to.to_bare());
-    let metadata = extract_link_preview_request_from_message(message)
-        .and_then(|token| decode_link_preview_token(&token, secret, now_unix).ok())
+    let decoded = extract_link_preview_request_from_message(message).and_then(|token| {
+        match decode_link_preview_token(&token, secret, now_unix) {
+            Ok(preview) => Some(preview),
+            Err(WaddleLinkPreviewError::Expired) => {
+                record_link_preview_event(LinkPreviewTelemetryEvent::TokenExpired);
+                None
+            }
+            Err(_) => {
+                record_link_preview_event(LinkPreviewTelemetryEvent::TokenInvalid);
+                None
+            }
+        }
+    });
+    let metadata = decoded
         .filter(|preview| {
             Some(&preview.scope_jid) == expected_scope.as_ref()
                 && preview.sender_jid == expected_sender
@@ -251,6 +273,7 @@ fn remove_framework_envelopes(message: &mut xmpp_parsers::message::Message) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::server::routes::websocket::link_preview_telemetry::recorded_events;
     const SECRET: &[u8] = b"test-link-preview-secret";
 
     fn sender() -> jid::FullJid {
@@ -366,6 +389,7 @@ mod tests {
             SECRET,
             1_800_000_000,
             "https://waddle.example",
+            true,
         );
 
         assert!(message
@@ -396,6 +420,45 @@ mod tests {
             references[0].ref_type,
             waddle_xmpp::xep::ReferenceType::Data
         );
+    }
+
+    #[test]
+    fn disabled_policy_strips_link_preview_request_without_metadata() {
+        let preview = waddle_xmpp::xep::LinkPreviewTokenData {
+            sender_jid: "alice@example.com".parse().expect("jid"),
+            scope_jid: "room@muc.example.com".parse().expect("jid"),
+            original_url: url::Url::parse("https://example.com/").expect("url"),
+            normalized_url: url::Url::parse("https://example.com/").expect("url"),
+            title: Some("Example".to_string()),
+            description: None,
+            image: None,
+            expires_at_unix: 1_900_000_000,
+        };
+        let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
+        let mut message = Message::new(None::<jid::Jid>);
+        message.to = Some("room@muc.example.com".parse().expect("jid"));
+        message.bodies.insert(
+            xmpp_parsers::message::Lang::new(),
+            "read https://example.com/".to_string(),
+        );
+        message
+            .payloads
+            .push(waddle_xmpp::xep::build_link_preview_request_element(&token));
+
+        consume_link_preview_request(
+            &mut message,
+            &sender(),
+            SECRET,
+            1_800_000_000,
+            "https://waddle.example",
+            false,
+        );
+
+        assert!(message
+            .payloads
+            .iter()
+            .all(|payload| payload.ns() != waddle_xmpp::xep::NS_WADDLE_LINK_PREVIEW));
+        assert!(waddle_xmpp::xep::extract_link_metadata_from_message(&message).is_empty());
     }
 
     #[test]
@@ -441,6 +504,7 @@ mod tests {
             SECRET,
             1_800_000_000,
             "https://waddle.example",
+            true,
         );
 
         assert_eq!(
@@ -501,6 +565,7 @@ mod tests {
             SECRET,
             1_800_000_000,
             "https://waddle.example",
+            true,
         );
 
         let parsed = waddle_xmpp::xep::extract_link_metadata_from_message(&message);
@@ -512,6 +577,8 @@ mod tests {
 
     #[test]
     fn expired_link_preview_request_is_stripped_without_metadata() {
+        let _events_guard = recorded_events::lock();
+        recorded_events::clear();
         let preview = waddle_xmpp::xep::LinkPreviewTokenData {
             sender_jid: "alice@example.com".parse().expect("jid"),
             scope_jid: "room@muc.example.com".parse().expect("jid"),
@@ -539,13 +606,20 @@ mod tests {
             SECRET,
             11,
             "https://waddle.example",
+            true,
         );
 
         assert!(message.payloads.is_empty());
+        assert!(
+            recorded_events::take().contains(&LinkPreviewTelemetryEvent::TokenExpired),
+            "expired send-time token path must emit token_expired telemetry"
+        );
     }
 
     #[test]
     fn invalid_link_preview_request_is_stripped_without_metadata() {
+        let _events_guard = recorded_events::lock();
+        recorded_events::clear();
         let token =
             waddle_xmpp::xep::LinkPreviewToken::new("not-a-signed-preview-token").expect("token");
         let mut message = Message::new(None::<jid::Jid>);
@@ -564,9 +638,14 @@ mod tests {
             SECRET,
             1_800_000_000,
             "https://waddle.example",
+            true,
         );
 
         assert!(message.payloads.is_empty());
+        assert!(
+            recorded_events::take().contains(&LinkPreviewTelemetryEvent::TokenInvalid),
+            "invalid send-time token path must emit token_invalid telemetry"
+        );
     }
 
     #[test]
@@ -595,6 +674,7 @@ mod tests {
             SECRET,
             1_800_000_000,
             "https://waddle.example",
+            true,
         );
 
         assert!(message.payloads.is_empty());
@@ -629,6 +709,7 @@ mod tests {
             SECRET,
             1_800_000_000,
             "https://waddle.example",
+            true,
         );
 
         assert!(message.payloads.is_empty());
@@ -663,6 +744,7 @@ mod tests {
             SECRET,
             1_800_000_000,
             "https://waddle.example",
+            true,
         );
 
         assert!(message.payloads.is_empty());
@@ -697,6 +779,7 @@ mod tests {
             SECRET,
             1_800_000_000,
             "https://waddle.example",
+            true,
         );
 
         assert!(message.payloads.is_empty());
@@ -731,6 +814,7 @@ mod tests {
             SECRET,
             1_800_000_000,
             "https://waddle.example",
+            true,
         );
 
         assert_eq!(
@@ -768,6 +852,7 @@ mod tests {
             SECRET,
             1_800_000_000,
             "https://waddle.example",
+            true,
         );
 
         assert_eq!(
@@ -805,6 +890,7 @@ mod tests {
             SECRET,
             1_800_000_000,
             "https://waddle.example",
+            true,
         );
 
         assert_eq!(
@@ -852,6 +938,7 @@ mod tests {
             SECRET,
             1_800_000_000,
             "https://waddle.example",
+            true,
         );
 
         let parsed = waddle_xmpp::xep::extract_link_metadata_from_message(&message);
@@ -881,6 +968,7 @@ mod tests {
             SECRET,
             1_800_000_000,
             "https://waddle.example",
+            true,
         );
 
         assert!(message.payloads.is_empty());

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -21,6 +21,7 @@ use super::super::{
     interpret_loop::build_interpret_deps, replay::drive_interpret_loop, WebSocketState,
 };
 use crate::auth::Session;
+use crate::config::LinkPreviewConfig;
 use crate::server::routes::websocket::link_preview_telemetry::{
     record_link_preview_event, LinkPreviewTelemetryEvent,
 };
@@ -80,7 +81,7 @@ pub async fn handle_message(
         state.deps.occupant_id_secret.key(),
         chrono::Utc::now().timestamp(),
         state.deps.auth_state.base_url.as_str(),
-        state.deps.link_preview.enabled,
+        &state.deps.link_preview,
     );
 
     if incoming.type_ != xmpp_parsers::message::MessageType::Groupchat
@@ -123,9 +124,9 @@ fn consume_link_preview_request(
     secret: &[u8],
     now_unix: i64,
     trusted_media_base_url: &str,
-    link_preview_enabled: bool,
+    link_preview: &LinkPreviewConfig,
 ) {
-    if !link_preview_enabled {
+    if !link_preview.enabled {
         strip_link_preview_requests(message);
         strip_link_metadata(message);
         return;
@@ -151,6 +152,7 @@ fn consume_link_preview_request(
                 && preview.sender_jid == expected_sender
                 && preview.original_url.scheme() == "https"
                 && preview.normalized_url.scheme() == "https"
+                && link_preview_token_urls_allowed_by_current_policy(preview, link_preview)
                 && first_eligible_https_url(message).as_ref() == Some(&preview.original_url)
         })
         .map(|preview| {
@@ -185,6 +187,59 @@ fn consume_link_preview_request(
             .payloads
             .push(build_link_metadata_element(&metadata));
     }
+}
+
+fn link_preview_token_urls_allowed_by_current_policy(
+    preview: &waddle_xmpp::xep::LinkPreviewTokenData,
+    link_preview: &LinkPreviewConfig,
+) -> bool {
+    link_preview_url_allowed_by_current_policy(&preview.original_url, link_preview)
+        && link_preview_url_allowed_by_current_policy(&preview.normalized_url, link_preview)
+}
+
+fn link_preview_url_allowed_by_current_policy(
+    url: &url::Url,
+    link_preview: &LinkPreviewConfig,
+) -> bool {
+    if !link_preview.video_enabled && looks_like_direct_video_url(url) {
+        return false;
+    }
+    let host = match url.host() {
+        Some(url::Host::Domain(host)) if !is_dot_local_domain(host) => host,
+        Some(url::Host::Domain(_)) | Some(url::Host::Ipv4(_)) | Some(url::Host::Ipv6(_)) | None => {
+            return false;
+        }
+    };
+    if link_preview
+        .blocked_hosts
+        .iter()
+        .any(|pattern| pattern.matches(host))
+    {
+        return false;
+    }
+    link_preview.allowed_hosts.is_empty()
+        || link_preview
+            .allowed_hosts
+            .iter()
+            .any(|pattern| pattern.matches(host))
+}
+
+fn looks_like_direct_video_url(url: &url::Url) -> bool {
+    let path = url.path().to_ascii_lowercase();
+    matches!(
+        path.rsplit('/').next(),
+        Some(filename)
+            if filename.ends_with(".mp4")
+                || filename.ends_with(".webm")
+                || filename.ends_with(".mov")
+                || filename.ends_with(".m4v")
+                || filename.ends_with(".ogv")
+    )
+}
+
+fn is_dot_local_domain(host: &str) -> bool {
+    let host = host.trim_end_matches('.').to_ascii_lowercase();
+    host == "local" || host.ends_with(".local")
 }
 
 fn is_trusted_cached_preview_image_url(url: &url::Url, trusted_media_base_url: &str) -> bool {
@@ -389,7 +444,7 @@ mod tests {
             SECRET,
             1_800_000_000,
             "https://waddle.example",
-            true,
+            &LinkPreviewConfig::default(),
         );
 
         assert!(message
@@ -451,7 +506,10 @@ mod tests {
             SECRET,
             1_800_000_000,
             "https://waddle.example",
-            false,
+            &LinkPreviewConfig {
+                enabled: false,
+                ..LinkPreviewConfig::default()
+            },
         );
 
         assert!(message
@@ -459,6 +517,175 @@ mod tests {
             .iter()
             .all(|payload| payload.ns() != waddle_xmpp::xep::NS_WADDLE_LINK_PREVIEW));
         assert!(waddle_xmpp::xep::extract_link_metadata_from_message(&message).is_empty());
+    }
+
+    #[test]
+    fn tightened_policy_rechecks_token_urls_before_stamping_metadata() {
+        let preview = waddle_xmpp::xep::LinkPreviewTokenData {
+            sender_jid: "alice@example.com".parse().expect("jid"),
+            scope_jid: "room@muc.example.com".parse().expect("jid"),
+            original_url: url::Url::parse("https://blocked.example/article").expect("url"),
+            normalized_url: url::Url::parse("https://blocked.example/article").expect("url"),
+            title: Some("Blocked".to_string()),
+            description: None,
+            image: None,
+            expires_at_unix: 1_900_000_000,
+        };
+        let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
+        let mut message = Message::new(None::<jid::Jid>);
+        message.to = Some("room@muc.example.com".parse().expect("jid"));
+        message.bodies.insert(
+            xmpp_parsers::message::Lang::new(),
+            "read https://blocked.example/article".to_string(),
+        );
+        message
+            .payloads
+            .push(waddle_xmpp::xep::build_link_preview_request_element(&token));
+
+        consume_link_preview_request(
+            &mut message,
+            &sender(),
+            SECRET,
+            1_800_000_000,
+            "https://waddle.example",
+            &LinkPreviewConfig {
+                blocked_hosts: vec!["blocked.example".parse().expect("pattern")],
+                ..LinkPreviewConfig::default()
+            },
+        );
+
+        assert!(
+            waddle_xmpp::xep::extract_link_metadata_from_message(&message).is_empty(),
+            "send-time validation must reject tokens that no longer satisfy current host policy"
+        );
+    }
+
+    #[test]
+    fn send_time_policy_rejects_unconditional_resolver_host_bans() {
+        for blocked_url in [
+            "https://127.0.0.1/article",
+            "https://[::1]/article",
+            "https://internal.local/article",
+            "https://printer.local./article",
+            "https://Mixed.Local/article",
+        ] {
+            let preview = waddle_xmpp::xep::LinkPreviewTokenData {
+                sender_jid: "alice@example.com".parse().expect("jid"),
+                scope_jid: "room@muc.example.com".parse().expect("jid"),
+                original_url: url::Url::parse(blocked_url).expect("url"),
+                normalized_url: url::Url::parse(blocked_url).expect("url"),
+                title: Some("Blocked".to_string()),
+                description: None,
+                image: None,
+                expires_at_unix: 1_900_000_000,
+            };
+            let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
+            let mut message = Message::new(None::<jid::Jid>);
+            message.to = Some("room@muc.example.com".parse().expect("jid"));
+            message.bodies.insert(
+                xmpp_parsers::message::Lang::new(),
+                format!("read {blocked_url}"),
+            );
+            message
+                .payloads
+                .push(waddle_xmpp::xep::build_link_preview_request_element(&token));
+
+            consume_link_preview_request(
+                &mut message,
+                &sender(),
+                SECRET,
+                1_800_000_000,
+                "https://waddle.example",
+                &LinkPreviewConfig::default(),
+            );
+
+            assert!(
+                waddle_xmpp::xep::extract_link_metadata_from_message(&message).is_empty(),
+                "send-time validation must reject resolver-blocked host {blocked_url}"
+            );
+        }
+    }
+
+    #[test]
+    fn send_time_policy_rechecks_normalized_url_before_stamping_metadata() {
+        let preview = waddle_xmpp::xep::LinkPreviewTokenData {
+            sender_jid: "alice@example.com".parse().expect("jid"),
+            scope_jid: "room@muc.example.com".parse().expect("jid"),
+            original_url: url::Url::parse("https://allowed.example/article").expect("url"),
+            normalized_url: url::Url::parse("https://blocked.example/canonical").expect("url"),
+            title: Some("Blocked canonical".to_string()),
+            description: None,
+            image: None,
+            expires_at_unix: 1_900_000_000,
+        };
+        let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
+        let mut message = Message::new(None::<jid::Jid>);
+        message.to = Some("room@muc.example.com".parse().expect("jid"));
+        message.bodies.insert(
+            xmpp_parsers::message::Lang::new(),
+            "read https://allowed.example/article".to_string(),
+        );
+        message
+            .payloads
+            .push(waddle_xmpp::xep::build_link_preview_request_element(&token));
+
+        consume_link_preview_request(
+            &mut message,
+            &sender(),
+            SECRET,
+            1_800_000_000,
+            "https://waddle.example",
+            &LinkPreviewConfig {
+                blocked_hosts: vec!["blocked.example".parse().expect("pattern")],
+                ..LinkPreviewConfig::default()
+            },
+        );
+
+        assert!(
+            waddle_xmpp::xep::extract_link_metadata_from_message(&message).is_empty(),
+            "send-time validation must reject a token with a now-blocked canonical URL"
+        );
+    }
+
+    #[test]
+    fn send_time_policy_rejects_direct_video_tokens_when_video_is_disabled() {
+        let preview = waddle_xmpp::xep::LinkPreviewTokenData {
+            sender_jid: "alice@example.com".parse().expect("jid"),
+            scope_jid: "room@muc.example.com".parse().expect("jid"),
+            original_url: url::Url::parse("https://video.example/clip.mp4").expect("url"),
+            normalized_url: url::Url::parse("https://video.example/clip.mp4").expect("url"),
+            title: Some("Video".to_string()),
+            description: None,
+            image: None,
+            expires_at_unix: 1_900_000_000,
+        };
+        let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
+        let mut message = Message::new(None::<jid::Jid>);
+        message.to = Some("room@muc.example.com".parse().expect("jid"));
+        message.bodies.insert(
+            xmpp_parsers::message::Lang::new(),
+            "watch https://video.example/clip.mp4".to_string(),
+        );
+        message
+            .payloads
+            .push(waddle_xmpp::xep::build_link_preview_request_element(&token));
+
+        consume_link_preview_request(
+            &mut message,
+            &sender(),
+            SECRET,
+            1_800_000_000,
+            "https://waddle.example",
+            &LinkPreviewConfig {
+                video_enabled: false,
+                ..LinkPreviewConfig::default()
+            },
+        );
+
+        assert!(
+            waddle_xmpp::xep::extract_link_metadata_from_message(&message).is_empty(),
+            "send-time validation must reject direct video tokens while video previews are disabled"
+        );
     }
 
     #[test]
@@ -504,7 +731,7 @@ mod tests {
             SECRET,
             1_800_000_000,
             "https://waddle.example",
-            true,
+            &LinkPreviewConfig::default(),
         );
 
         assert_eq!(
@@ -565,7 +792,7 @@ mod tests {
             SECRET,
             1_800_000_000,
             "https://waddle.example",
-            true,
+            &LinkPreviewConfig::default(),
         );
 
         let parsed = waddle_xmpp::xep::extract_link_metadata_from_message(&message);
@@ -606,7 +833,7 @@ mod tests {
             SECRET,
             11,
             "https://waddle.example",
-            true,
+            &LinkPreviewConfig::default(),
         );
 
         assert!(message.payloads.is_empty());
@@ -638,7 +865,7 @@ mod tests {
             SECRET,
             1_800_000_000,
             "https://waddle.example",
-            true,
+            &LinkPreviewConfig::default(),
         );
 
         assert!(message.payloads.is_empty());
@@ -674,7 +901,7 @@ mod tests {
             SECRET,
             1_800_000_000,
             "https://waddle.example",
-            true,
+            &LinkPreviewConfig::default(),
         );
 
         assert!(message.payloads.is_empty());
@@ -709,7 +936,7 @@ mod tests {
             SECRET,
             1_800_000_000,
             "https://waddle.example",
-            true,
+            &LinkPreviewConfig::default(),
         );
 
         assert!(message.payloads.is_empty());
@@ -744,7 +971,7 @@ mod tests {
             SECRET,
             1_800_000_000,
             "https://waddle.example",
-            true,
+            &LinkPreviewConfig::default(),
         );
 
         assert!(message.payloads.is_empty());
@@ -779,7 +1006,7 @@ mod tests {
             SECRET,
             1_800_000_000,
             "https://waddle.example",
-            true,
+            &LinkPreviewConfig::default(),
         );
 
         assert!(message.payloads.is_empty());
@@ -814,7 +1041,7 @@ mod tests {
             SECRET,
             1_800_000_000,
             "https://waddle.example",
-            true,
+            &LinkPreviewConfig::default(),
         );
 
         assert_eq!(
@@ -852,7 +1079,7 @@ mod tests {
             SECRET,
             1_800_000_000,
             "https://waddle.example",
-            true,
+            &LinkPreviewConfig::default(),
         );
 
         assert_eq!(
@@ -890,7 +1117,7 @@ mod tests {
             SECRET,
             1_800_000_000,
             "https://waddle.example",
-            true,
+            &LinkPreviewConfig::default(),
         );
 
         assert_eq!(
@@ -938,7 +1165,7 @@ mod tests {
             SECRET,
             1_800_000_000,
             "https://waddle.example",
-            true,
+            &LinkPreviewConfig::default(),
         );
 
         let parsed = waddle_xmpp::xep::extract_link_metadata_from_message(&message);
@@ -968,7 +1195,7 @@ mod tests {
             SECRET,
             1_800_000_000,
             "https://waddle.example",
-            true,
+            &LinkPreviewConfig::default(),
         );
 
         assert!(message.payloads.is_empty());

--- a/server/crates/waddle-server/src/server/routes/websocket/link_preview_refs.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/link_preview_refs.rs
@@ -79,7 +79,7 @@ pub(crate) async fn clear_current_message_preview_refs(
         .await
     {
         Ok(rows_affected) => {
-            if rows_affected > 0 {
+            for _ in 0..rows_affected {
                 record_link_preview_event(LinkPreviewTelemetryEvent::CleanupReference);
             }
         }
@@ -194,14 +194,18 @@ mod tests {
     fn message_with_preview_ref(slot_id: &str) -> Message {
         let to: BareJid = "bob@example.com".parse().expect("jid");
         let mut message = Message::new(Some(jid::Jid::from(to)));
+        add_preview_ref(&mut message, slot_id);
+        message
+    }
+
+    fn add_preview_ref(message: &mut Message, slot_id: &str) {
         let hash = "86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16";
         waddle_xmpp::xep::add_reference(
-            &mut message,
+            message,
             &waddle_xmpp::xep::Reference::data(format!(
                 "https://waddle.example/api/files/{slot_id}/link-preview-{hash}.png"
             )),
         );
-        message
     }
 
     async fn ref_state(pool: &DatabasePool, slot_id: &str) -> Option<String> {
@@ -296,6 +300,45 @@ mod tests {
         assert!(
             recorded_events::take().contains(&LinkPreviewTelemetryEvent::CleanupReference),
             "cleanup of an existing current ref must emit cleanup_reference telemetry"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cleanup_telemetry_emits_once_per_cleared_ref() {
+        let _events_guard = recorded_events::async_lock().await;
+        recorded_events::clear();
+        let pool = db_pool().await;
+        let first_slot_id = uuid::Uuid::new_v4().to_string();
+        let second_slot_id = uuid::Uuid::new_v4().to_string();
+        seed_uploaded_slot(&pool, &first_slot_id).await;
+        seed_uploaded_slot(&pool, &second_slot_id).await;
+        let archive: BareJid = "alice@example.com".parse().expect("archive");
+        let to: BareJid = "bob@example.com".parse().expect("jid");
+        let mut message = Message::new(Some(jid::Jid::from(to)));
+        add_preview_ref(&mut message, &first_slot_id);
+        add_preview_ref(&mut message, &second_slot_id);
+
+        record_current_message_preview_refs(
+            pool.global_actor(),
+            "https://waddle.example",
+            &archive,
+            "msg-telemetry-count",
+            "archive-telemetry-count",
+            &message,
+        )
+        .await;
+        recorded_events::clear();
+
+        clear_current_message_preview_refs(pool.global_actor(), &archive, "msg-telemetry-count")
+            .await;
+
+        assert_eq!(
+            recorded_events::take()
+                .into_iter()
+                .filter(|event| *event == LinkPreviewTelemetryEvent::CleanupReference)
+                .count(),
+            2,
+            "cleanup_reference telemetry must count every cleared current ref"
         );
     }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/link_preview_refs.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/link_preview_refs.rs
@@ -8,6 +8,9 @@ use crate::db::{
     actor::{DbActor, DbExecute},
     Value,
 };
+use crate::server::routes::websocket::link_preview_telemetry::{
+    record_link_preview_event, LinkPreviewTelemetryEvent,
+};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum LinkPreviewMediaRefState {
@@ -62,7 +65,7 @@ pub(crate) async fn clear_current_message_preview_refs(
     message_id: &str,
 ) {
     let now = chrono::Utc::now().to_rfc3339();
-    if let Err(error) = global_db_actor
+    match global_db_actor
         .ask(DbExecute {
             sql: "UPDATE link_preview_media_refs SET state = ?, updated_at = ? WHERE archive_jid = ? AND message_id = ? AND state = ?".to_string(),
             params: vec![
@@ -75,7 +78,14 @@ pub(crate) async fn clear_current_message_preview_refs(
         })
         .await
     {
-        warn!(%error, archive = %archive_jid, message_id, "failed to clear link preview media refs");
+        Ok(rows_affected) => {
+            if rows_affected > 0 {
+                record_link_preview_event(LinkPreviewTelemetryEvent::CleanupReference);
+            }
+        }
+        Err(error) => {
+            warn!(%error, archive = %archive_jid, message_id, "failed to clear link preview media refs");
+        }
     }
 }
 
@@ -149,6 +159,7 @@ mod tests {
         actor::{DbExecute, DbQueryOne},
         DatabaseConfig, DatabasePool, MigrationRunner, PoolConfig, ValueExt,
     };
+    use crate::server::routes::websocket::link_preview_telemetry::recorded_events;
 
     async fn db_pool() -> DatabasePool {
         let pool = DatabasePool::new(DatabaseConfig::default(), PoolConfig)
@@ -252,6 +263,39 @@ mod tests {
         assert_eq!(
             ref_state(&pool, &slot_id).await.as_deref(),
             Some("unreferenced")
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cleanup_telemetry_only_emits_when_current_ref_is_cleared() {
+        let _events_guard = recorded_events::async_lock().await;
+        recorded_events::clear();
+        let pool = db_pool().await;
+        let slot_id = uuid::Uuid::new_v4().to_string();
+        seed_uploaded_slot(&pool, &slot_id).await;
+        let archive: BareJid = "alice@example.com".parse().expect("archive");
+
+        clear_current_message_preview_refs(pool.global_actor(), &archive, "msg-telemetry").await;
+        assert!(
+            !recorded_events::take().contains(&LinkPreviewTelemetryEvent::CleanupReference),
+            "empty cleanup must not emit cleanup_reference telemetry"
+        );
+
+        recorded_events::clear();
+        record_current_message_preview_refs(
+            pool.global_actor(),
+            "https://waddle.example",
+            &archive,
+            "msg-telemetry",
+            "archive-telemetry",
+            &message_with_preview_ref(&slot_id),
+        )
+        .await;
+        clear_current_message_preview_refs(pool.global_actor(), &archive, "msg-telemetry").await;
+
+        assert!(
+            recorded_events::take().contains(&LinkPreviewTelemetryEvent::CleanupReference),
+            "cleanup of an existing current ref must emit cleanup_reference telemetry"
         );
     }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/link_preview_telemetry.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/link_preview_telemetry.rs
@@ -1,0 +1,157 @@
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum LinkPreviewTelemetryEvent {
+    ResolverReady,
+    ResolverBlocked,
+    ResolverFailed,
+    ResolverUnsupported,
+    CacheHit,
+    CacheMiss,
+    TokenInvalid,
+    TokenExpired,
+    CleanupReference,
+}
+
+impl LinkPreviewTelemetryEvent {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::ResolverReady => "ready",
+            Self::ResolverBlocked => "blocked",
+            Self::ResolverFailed => "failed",
+            Self::ResolverUnsupported => "unsupported",
+            Self::CacheHit => "cache_hit",
+            Self::CacheMiss => "cache_miss",
+            Self::TokenInvalid => "token_invalid",
+            Self::TokenExpired => "token_expired",
+            Self::CleanupReference => "cleanup_reference",
+        }
+    }
+}
+
+pub(crate) fn record_link_preview_event(event: LinkPreviewTelemetryEvent) {
+    #[cfg(test)]
+    recorded_events::push(event);
+    tracing::info!(
+        link_preview.event = event.as_str(),
+        "link preview resolver event"
+    );
+}
+
+#[cfg(test)]
+pub(crate) mod recorded_events {
+    use super::LinkPreviewTelemetryEvent;
+    use std::sync::{Mutex, MutexGuard};
+
+    static EVENTS: Mutex<Vec<LinkPreviewTelemetryEvent>> = Mutex::new(Vec::new());
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+    static ASYNC_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    pub(crate) fn lock() -> MutexGuard<'static, ()> {
+        TEST_LOCK.lock().expect("link preview event test lock")
+    }
+
+    pub(crate) async fn async_lock() -> tokio::sync::MutexGuard<'static, ()> {
+        ASYNC_TEST_LOCK.lock().await
+    }
+
+    pub(crate) fn clear() {
+        EVENTS.lock().expect("link preview event recorder").clear();
+    }
+
+    pub(super) fn push(event: LinkPreviewTelemetryEvent) {
+        EVENTS
+            .lock()
+            .expect("link preview event recorder")
+            .push(event);
+    }
+
+    pub(crate) fn take() -> Vec<LinkPreviewTelemetryEvent> {
+        std::mem::take(&mut *EVENTS.lock().expect("link preview event recorder"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone, Default)]
+    struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl io::Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0
+                .lock()
+                .expect("capture buffer lock")
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+        type Writer = CaptureWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    #[test]
+    fn telemetry_event_labels_cover_issue_829_outcomes() {
+        let labels = [
+            LinkPreviewTelemetryEvent::ResolverReady.as_str(),
+            LinkPreviewTelemetryEvent::ResolverBlocked.as_str(),
+            LinkPreviewTelemetryEvent::ResolverFailed.as_str(),
+            LinkPreviewTelemetryEvent::ResolverUnsupported.as_str(),
+            LinkPreviewTelemetryEvent::CacheHit.as_str(),
+            LinkPreviewTelemetryEvent::CacheMiss.as_str(),
+            LinkPreviewTelemetryEvent::TokenInvalid.as_str(),
+            LinkPreviewTelemetryEvent::TokenExpired.as_str(),
+            LinkPreviewTelemetryEvent::CleanupReference.as_str(),
+        ];
+
+        assert_eq!(
+            labels,
+            [
+                "ready",
+                "blocked",
+                "failed",
+                "unsupported",
+                "cache_hit",
+                "cache_miss",
+                "token_invalid",
+                "token_expired",
+                "cleanup_reference"
+            ]
+        );
+    }
+
+    #[test]
+    fn telemetry_events_emit_stable_info_field() {
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let _guard = tracing::subscriber::set_default(
+            tracing_subscriber::fmt()
+                .json()
+                .with_max_level(tracing::Level::INFO)
+                .with_writer(CaptureWriter(buf.clone()))
+                .finish(),
+        );
+
+        record_link_preview_event(LinkPreviewTelemetryEvent::ResolverBlocked);
+
+        let logs = String::from_utf8(buf.lock().expect("capture buffer lock").clone())
+            .expect("captured logs are valid UTF-8");
+        assert!(
+            logs.contains("\"link_preview.event\":\"blocked\""),
+            "link preview telemetry must expose a stable INFO field for metrics extraction. Captured logs:\n{logs}"
+        );
+        assert!(
+            !logs.contains("message body"),
+            "telemetry must not include message bodies. Captured logs:\n{logs}"
+        );
+    }
+}

--- a/server/crates/waddle-server/src/server/routes/websocket/link_preview_telemetry.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/link_preview_telemetry.rs
@@ -42,15 +42,31 @@ pub(crate) mod recorded_events {
     use std::sync::{Mutex, MutexGuard};
 
     static EVENTS: Mutex<Vec<LinkPreviewTelemetryEvent>> = Mutex::new(Vec::new());
+    static ACTIVE_RECORDERS: Mutex<usize> = Mutex::new(0);
     static TEST_LOCK: Mutex<()> = Mutex::new(());
-    static ASYNC_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
-    pub(crate) fn lock() -> MutexGuard<'static, ()> {
-        TEST_LOCK.lock().expect("link preview event test lock")
+    pub(crate) struct RecordingGuard {
+        _guard: MutexGuard<'static, ()>,
     }
 
-    pub(crate) async fn async_lock() -> tokio::sync::MutexGuard<'static, ()> {
-        ASYNC_TEST_LOCK.lock().await
+    impl Drop for RecordingGuard {
+        fn drop(&mut self) {
+            *ACTIVE_RECORDERS
+                .lock()
+                .expect("link preview event recorder active count") -= 1;
+        }
+    }
+
+    pub(crate) fn lock() -> RecordingGuard {
+        let guard = TEST_LOCK.lock().expect("link preview event test lock");
+        *ACTIVE_RECORDERS
+            .lock()
+            .expect("link preview event recorder active count") += 1;
+        RecordingGuard { _guard: guard }
+    }
+
+    pub(crate) async fn async_lock() -> RecordingGuard {
+        lock()
     }
 
     pub(crate) fn clear() {
@@ -58,6 +74,13 @@ pub(crate) mod recorded_events {
     }
 
     pub(super) fn push(event: LinkPreviewTelemetryEvent) {
+        if *ACTIVE_RECORDERS
+            .lock()
+            .expect("link preview event recorder active count")
+            == 0
+        {
+            return;
+        }
         EVENTS
             .lock()
             .expect("link preview event recorder")

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -73,6 +73,7 @@ mod frame;
 mod frame_backstop;
 mod interpret_loop;
 pub(crate) mod link_preview_refs;
+pub(crate) mod link_preview_telemetry;
 mod muc_call_sfu;
 mod outbound;
 mod parse_errors;

--- a/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
@@ -229,6 +229,7 @@ mod tests {
                     sfu: Some(sfu),
                 },
                 occupant_id_secret: deps.occupant_id_secret.clone(),
+                link_preview: deps.link_preview.clone(),
                 provider_ingress: Arc::clone(&deps.provider_ingress),
                 provider_dispatch_tasks: deps.provider_dispatch_tasks.clone(),
             },

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -52,6 +52,8 @@ pub struct WebSocketDeps {
     /// inner `Arc<[u8]>`; shared with `RoomRegistryActor` so every
     /// stamping site uses the same key.
     pub occupant_id_secret: OccupantIdSecret,
+    /// Operator controls for server-side link preview enrichment.
+    pub link_preview: crate::config::LinkPreviewConfig,
     /// Snapshot of `WADDLE_PROVIDER_*_WEBHOOK_*` env vars, built once at
     /// startup; the extension webhook handler reads from this instead of
     /// re-parsing env on every request.

--- a/server/crates/waddle-server/src/server/routes/websocket/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests.rs
@@ -225,6 +225,7 @@ async fn create_test_websocket_state_with_extension_manager(
                     b"test-occupant-id-secret-32-bytes-long".to_vec(),
                 )
                 .expect("test secret meets length floor"),
+                link_preview: server_config.link_preview.clone(),
                 provider_ingress: Arc::new(
                     crate::server::routes::extension_webhooks::ProviderIngressRegistry::default(),
                 ),


### PR DESCRIPTION
## Summary

Implements #829 for server-side link-preview policy and telemetry.

- Adds operator configuration for link-preview enablement, allowed/blocked hosts, fetch byte cap, cached-image byte cap, redirect cap, fetch timeout, and disabled-video policy.
- Enforces host policy on initial lookup URLs and redirect targets before fetch, including explicit tests for admin blocked hosts and allowlist misses on redirects.
- Revalidates minted preview tokens at message send time against the current policy before stamping XEP-0511 metadata, including blocked/allowed hosts, resolver-blocked IP and `.local` targets, normalized canonical URLs, and disabled direct-video URLs.
- Strips private preview requests and client-authored XEP-0511 metadata when link previews are globally disabled.
- Adds fixed-label link-preview telemetry for ready, blocked, failed, unsupported, cache_hit, cache_miss, token_invalid, token_expired, and cleanup_reference without logging message bodies.
- Records cleanup_reference once per cleared cached-media reference row and uses scoped test recording to avoid cross-test telemetry contamination.
- Records cache_hit/cache_miss for content-addressed cached image blob reuse after safe remote image fetch, not for pre-fetch URL cache avoidance.

## Plan

1. Thread link-preview policy from server config into websocket dependencies.
2. Enforce policy in lookup, resolver, redirect, and send-time paths.
3. Add telemetry events at resolver, token validation, cached image, and cleanup-reference points.
4. Cover acceptance criteria and review feedback with focused link-preview regression tests.

## Verification

- `cargo test -p waddle-server server::routes::websocket::handlers::message::tests --lib -- --nocapture`
- `cargo test -p waddle-server link_preview --lib -- --nocapture`
- `cargo test -p waddle-server --lib`
- `cargo clippy -p waddle-server --all-targets -- -D warnings`
- `git diff --check`

## Notes

- `WADDLE_TEST_POSTGRES_URL` was not set, so the optional Postgres-backed link-preview migration regression was skipped locally.
- Reviewed by adversarial security and test-review subagents; actionable findings were addressed before this update.
- A push-time GitHub notice reported one existing high Dependabot vulnerability on the default branch; this PR does not touch dependencies.