### PR TITLE
feat(link-preview): render federated previews conservatively

### DIFF
--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -14,7 +14,7 @@ import {
 import { $xmppStatus } from "@/stores/xmpp-status";
 import { applyPinEvent } from "@/stores/pinned-messages";
 import { hydrateSinglePinnedBody } from "@/services/pinned-message-bodies";
-import { linkPreviewMediaOriginFromWebSocketUrl } from "@/lib/xmpp/link-preview";
+import { trustedLinkPreviewMediaOrigin } from "@/lib/xmpp/link-preview";
 import { roomMessageFromArchived } from "@/lib/xmpp/wasm-message-codecs";
 import {
   type TimelineMessage,
@@ -270,7 +270,7 @@ export function useChannelMessages(
             const convertForTimeline = (a: Parameters<typeof roomMessageFromArchived>[0]) => {
               const live = roomMessageFromArchived(a, {
                 trustedMediaOrigin: session.value
-                  ? linkPreviewMediaOriginFromWebSocketUrl(session.value.xmpp_websocket_url)
+                  ? trustedLinkPreviewMediaOrigin(session.value)
                   : null,
               });
               return live && session.value

--- a/chat/src/components/chat/MessageBody.vue
+++ b/chat/src/components/chat/MessageBody.vue
@@ -20,6 +20,7 @@ import {
 import {
   extensionPresentation,
   extensionSurfaceLabel,
+  linkPreviewMediaState,
   renderStyledBody,
   type TimelineMessage,
   type ExtensionAnnotation,
@@ -112,6 +113,15 @@ function linkPreviewHref(url: string): string | null {
   } catch {
     return null;
   }
+}
+
+function linkPreviewImage(preview: NonNullable<TimelineMessage["linkPreviews"]>[number]) {
+  const state = linkPreviewMediaState(preview);
+  return state.kind === "image" ? state.image : null;
+}
+
+function linkPreviewRemoteMediaUnavailable(preview: NonNullable<TimelineMessage["linkPreviews"]>[number]): boolean {
+  return linkPreviewMediaState(preview).kind === "remote-unavailable";
 }
 
 const {
@@ -227,15 +237,22 @@ watch(
         {{ linkPreviewHost(preview.originalUrl) }}
       </span>
       <img
-        v-if="preview.image"
-        :src="preview.image.url"
-        :alt="preview.image.alt ?? preview.title ?? 'Link preview image'"
-        :width="preview.image.width"
-        :height="preview.image.height"
+        v-if="linkPreviewImage(preview)"
+        :src="linkPreviewImage(preview)!.url"
+        :alt="linkPreviewImage(preview)!.alt ?? preview.title ?? 'Link preview image'"
+        :width="linkPreviewImage(preview)!.width"
+        :height="linkPreviewImage(preview)!.height"
         loading="lazy"
         decoding="async"
         class="max-h-48 w-full rounded border border-border object-cover"
       />
+      <span
+        v-else-if="linkPreviewRemoteMediaUnavailable(preview)"
+        class="type-caption flex items-center gap-1 rounded border border-dashed border-border bg-background/70 px-2 py-1 text-muted-foreground"
+      >
+        <AlertCircle aria-hidden="true" class="h-3.5 w-3.5" />
+        Remote preview media unavailable
+      </span>
       <span v-if="preview.title" class="type-field text-foreground">{{ preview.title }}</span>
       <span v-if="preview.description" class="type-caption line-clamp-2 text-muted-foreground">{{ preview.description }}</span>
     </a>

--- a/chat/src/components/chat/MessageBody.vue
+++ b/chat/src/components/chat/MessageBody.vue
@@ -22,6 +22,7 @@ import {
   extensionSurfaceLabel,
   linkPreviewMediaState,
   renderStyledBody,
+  type LinkPreviewMediaState,
   type TimelineMessage,
   type ExtensionAnnotation,
   type ExtensionAnnotationAction,
@@ -69,6 +70,17 @@ const {
 
 const extensionAnnotations = computed(() => props.message.extensionAnnotations ?? []);
 const linkPreviews = computed(() => props.message.linkPreviews ?? []);
+type MessageLinkPreview = NonNullable<TimelineMessage["linkPreviews"]>[number];
+interface LinkPreviewCard {
+  preview: MessageLinkPreview;
+  mediaState: LinkPreviewMediaState;
+}
+const linkPreviewCards = computed<LinkPreviewCard[]>(() =>
+  linkPreviews.value.map((preview) => ({
+    preview,
+    mediaState: linkPreviewMediaState(preview),
+  })),
+);
 const extensionCards = computed(() =>
   extensionAnnotations.value.map((annotation) => ({
     annotation,
@@ -113,15 +125,6 @@ function linkPreviewHref(url: string): string | null {
   } catch {
     return null;
   }
-}
-
-function linkPreviewImage(preview: NonNullable<TimelineMessage["linkPreviews"]>[number]) {
-  const state = linkPreviewMediaState(preview);
-  return state.kind === "image" ? state.image : null;
-}
-
-function linkPreviewRemoteMediaUnavailable(preview: NonNullable<TimelineMessage["linkPreviews"]>[number]): boolean {
-  return linkPreviewMediaState(preview).kind === "remote-unavailable";
 }
 
 const {
@@ -224,7 +227,7 @@ watch(
          into a single horizontal action-chip strip beneath this block.
          No fat boxes fanning out below the message. -->
     <a
-      v-for="preview in linkPreviews"
+      v-for="{ preview, mediaState } in linkPreviewCards"
       :key="`${preview.originalUrl}:${preview.normalizedUrl ?? ''}`"
       :href="linkPreviewHref(preview.originalUrl) ?? undefined"
       target="_blank"
@@ -237,17 +240,17 @@ watch(
         {{ linkPreviewHost(preview.originalUrl) }}
       </span>
       <img
-        v-if="linkPreviewImage(preview)"
-        :src="linkPreviewImage(preview)!.url"
-        :alt="linkPreviewImage(preview)!.alt ?? preview.title ?? 'Link preview image'"
-        :width="linkPreviewImage(preview)!.width"
-        :height="linkPreviewImage(preview)!.height"
+        v-if="mediaState.kind === 'image'"
+        :src="mediaState.image.url"
+        :alt="mediaState.image.alt ?? preview.title ?? 'Link preview image'"
+        :width="mediaState.image.width"
+        :height="mediaState.image.height"
         loading="lazy"
         decoding="async"
         class="max-h-48 w-full rounded border border-border object-cover"
       />
       <span
-        v-else-if="linkPreviewRemoteMediaUnavailable(preview)"
+        v-else-if="mediaState.kind === 'remote-unavailable'"
         class="type-caption flex items-center gap-1 rounded border border-dashed border-border bg-background/70 px-2 py-1 text-muted-foreground"
       >
         <AlertCircle aria-hidden="true" class="h-3.5 w-3.5" />

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -47,6 +47,7 @@ export interface LinkPreview {
   title?: string;
   description?: string;
   image?: LinkPreviewImage;
+  remoteMediaUnavailable?: boolean;
 }
 
 export interface LinkPreviewImage {
@@ -55,6 +56,17 @@ export interface LinkPreviewImage {
   width?: number;
   height?: number;
   alt?: string;
+}
+
+type LinkPreviewMediaState =
+  | { kind: "none" }
+  | { kind: "image"; image: LinkPreviewImage }
+  | { kind: "remote-unavailable" };
+
+export function linkPreviewMediaState(preview: LinkPreview): LinkPreviewMediaState {
+  if (preview.image) return { kind: "image", image: preview.image };
+  if (preview.remoteMediaUnavailable) return { kind: "remote-unavailable" };
+  return { kind: "none" };
 }
 
 export type ExtensionSurfaceKind =

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -58,7 +58,7 @@ export interface LinkPreviewImage {
   alt?: string;
 }
 
-type LinkPreviewMediaState =
+export type LinkPreviewMediaState =
   | { kind: "none" }
   | { kind: "image"; image: LinkPreviewImage }
   | { kind: "remote-unavailable" };

--- a/chat/src/lib/server-auth.ts
+++ b/chat/src/lib/server-auth.ts
@@ -8,6 +8,7 @@ export interface WaddleSession {
   xmpp_localpart: string;
   jid: string;
   xmpp_websocket_url: string;
+  link_preview_media_origin?: string;
   is_expired: boolean;
   expires_at: string | null;
 }

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -112,7 +112,7 @@ import {
   type SendDirectMessageOptions,
   type SendGroupMessageOptions,
 } from "./send-types";
-import { linkPreviewMediaOriginFromWebSocketUrl, requestPlaintextLinkPreviewLookup, type LinkPreviewLookupResult } from "./link-preview";
+import { requestPlaintextLinkPreviewLookup, trustedLinkPreviewMediaOrigin, type LinkPreviewLookupResult } from "./link-preview";
 import {
   avatarDataUrl,
   buildWasmSendOptions,
@@ -648,6 +648,10 @@ export class BrowserXmppClient {
     this.resource = this.resumeState?.resource || createXmppResource();
     this.seedNativeReplayQueueIds(this.resumeState);
     this.retainedJoinedRoomJids = new Set(this.resumePersistence.loadJoinedRooms());
+  }
+
+  private trustedLinkPreviewMediaOrigin(): string | null {
+    return trustedLinkPreviewMediaOrigin(this.session);
   }
 
   /** Full JID (`bare/resource`) for this session. Needed by the
@@ -1445,7 +1449,7 @@ export class BrowserXmppClient {
       this.xmpp,
       body,
       scopeJid,
-      linkPreviewMediaOriginFromWebSocketUrl(this.session.xmpp_websocket_url),
+      this.trustedLinkPreviewMediaOrigin(),
     );
   }
 
@@ -2260,7 +2264,7 @@ export class BrowserXmppClient {
   }
 
   private roomMamPageToMessages(page: WasmMamPage): MamHistoryPage<LiveRoomMessage> {
-    return { messages: page.messages.map((message) => roomMessageFromArchived(message, { trustedMediaOrigin: linkPreviewMediaOriginFromWebSocketUrl(this.session.xmpp_websocket_url) })).filter((message): message is LiveRoomMessage => !!message), ...(page.first_id ? { firstArchiveId: page.first_id } : {}), ...(page.last_id ? { lastArchiveId: page.last_id } : {}), complete: page.is_complete };
+    return { messages: page.messages.map((message) => roomMessageFromArchived(message, { trustedMediaOrigin: this.trustedLinkPreviewMediaOrigin() })).filter((message): message is LiveRoomMessage => !!message), ...(page.first_id ? { firstArchiveId: page.first_id } : {}), ...(page.last_id ? { lastArchiveId: page.last_id } : {}), complete: page.is_complete };
   }
   private dmMamPageToMessages(
     page: WasmMamPage,
@@ -2270,7 +2274,7 @@ export class BrowserXmppClient {
     if (options.applyCallEvents !== false) {
       this.applyDmCallEventsFromMamPage(page, selfBare);
     }
-    return { messages: page.messages.map((message) => dmMessageFromArchived(message, selfBare, { trustedMediaOrigin: linkPreviewMediaOriginFromWebSocketUrl(this.session.xmpp_websocket_url) })).filter((message): message is LiveDmMessage => !!message), ...(page.first_id ? { firstArchiveId: page.first_id } : {}), ...(page.last_id ? { lastArchiveId: page.last_id } : {}), complete: page.is_complete };
+    return { messages: page.messages.map((message) => dmMessageFromArchived(message, selfBare, { trustedMediaOrigin: this.trustedLinkPreviewMediaOrigin() })).filter((message): message is LiveDmMessage => !!message), ...(page.first_id ? { firstArchiveId: page.first_id } : {}), ...(page.last_id ? { lastArchiveId: page.last_id } : {}), complete: page.is_complete };
   }
   private applyDmCallEventsFromMamPage(
     page: WasmMamPage | null | undefined,
@@ -2883,13 +2887,13 @@ export class BrowserXmppClient {
 
   private dispatchLiveBodyMessage(message: WasmMessage & { carbon?: { sent?: boolean; received?: boolean }; inboxPush?: InboxEntry; _fromCarbon?: boolean }) {
     if (message.is_muc) {
-      const converted = roomMessageFromArchived({ ...message, mam_id: message.id ?? crypto.randomUUID() } as WasmArchivedMessage, "live", { trustedMediaOrigin: linkPreviewMediaOriginFromWebSocketUrl(this.session.xmpp_websocket_url) });
+      const converted = roomMessageFromArchived({ ...message, mam_id: message.id ?? crypto.randomUUID() } as WasmArchivedMessage, "live", { trustedMediaOrigin: this.trustedLinkPreviewMediaOrigin() });
       if (!converted) return;
       this.catchup.recordRoomSeen(converted.roomJid, converted.createdAt, undefined, rawMessageSeenIds(message));
       if (converted.roomJid !== this.currentRoom && isRoomActivityMessage(converted)) { this.activityHandler?.(roomActivityEventFromMessage(converted)); return; }
       this.messageHandler?.(converted); return;
     }
-    const converted = dmMessageFromArchived({ ...message, mam_id: message.id ?? crypto.randomUUID() } as WasmArchivedMessage, barePeerJid(this.session.jid), "live", { trustedMediaOrigin: linkPreviewMediaOriginFromWebSocketUrl(this.session.xmpp_websocket_url) });
+    const converted = dmMessageFromArchived({ ...message, mam_id: message.id ?? crypto.randomUUID() } as WasmArchivedMessage, barePeerJid(this.session.jid), "live", { trustedMediaOrigin: this.trustedLinkPreviewMediaOrigin() });
     if (converted) {
       this.catchup.recordDmSeen(converted.peerJid, converted.createdAt, undefined, rawMessageSeenIds(message));
       this.directMessageHandler?.(converted);
@@ -3093,7 +3097,7 @@ export class BrowserXmppClient {
       this.applyDmCallEventsFromMamPage(page, selfBare, { since, seenIds });
     }
     for (const message of page?.messages ?? []) {
-      const converted = dmMessageFromArchived(message, selfBare, { trustedMediaOrigin: linkPreviewMediaOriginFromWebSocketUrl(this.session.xmpp_websocket_url) });
+      const converted = dmMessageFromArchived(message, selfBare, { trustedMediaOrigin: this.trustedLinkPreviewMediaOrigin() });
       if (!converted || shouldSkipCatchupMessage(converted, since, seenIds)) continue;
       this.catchup.recordDmSeen(converted.peerJid, converted.createdAt, converted.archiveId, messageSeenIds(converted));
       this.directMessageHandler?.(converted);
@@ -3106,7 +3110,7 @@ export class BrowserXmppClient {
     let lastArchiveId = pageLastArchiveId(page);
     if (stats) stats.pages += 1;
     for (const message of page?.messages ?? []) {
-      const converted = roomMessageFromArchived(message, { trustedMediaOrigin: linkPreviewMediaOriginFromWebSocketUrl(this.session.xmpp_websocket_url) });
+      const converted = roomMessageFromArchived(message, { trustedMediaOrigin: this.trustedLinkPreviewMediaOrigin() });
       if (!converted || shouldSkipCatchupMessage(converted, since, seenIds)) continue;
       this.catchup.recordRoomSeen(converted.roomJid, converted.createdAt, converted.archiveId, messageSeenIds(converted));
       if (converted.roomJid !== this.currentRoom && isRoomActivityMessage(converted)) {

--- a/chat/src/lib/xmpp/link-preview.ts
+++ b/chat/src/lib/xmpp/link-preview.ts
@@ -233,6 +233,11 @@ export function linkPreviewMediaOriginFromWebSocketUrl(websocketUrl: string): st
   }
 }
 
+export function trustedLinkPreviewMediaOrigin(session: { link_preview_media_origin?: string | null; xmpp_websocket_url: string }): string | null {
+  const explicit = session.link_preview_media_origin?.trim();
+  return explicit || linkPreviewMediaOriginFromWebSocketUrl(session.xmpp_websocket_url);
+}
+
 export function isTrustedCachedPreviewImageUrl(value: string, trustedMediaOrigin?: string | null): boolean {
   if (!trustedMediaOrigin) return false;
   try {

--- a/chat/src/lib/xmpp/wasm-message-codecs.ts
+++ b/chat/src/lib/xmpp/wasm-message-codecs.ts
@@ -154,22 +154,24 @@ interface LinkPreviewDecodeOptions {
 }
 
 function linkPreviewFromWasm(preview: WasmLinkPreview, options: LinkPreviewDecodeOptions = {}): LinkPreview {
-  const image = preview.image && isTrustedCachedPreviewImageUrl(preview.image.url, options.trustedMediaOrigin)
+  const trustedImage = preview.image && isTrustedCachedPreviewImageUrl(preview.image.url, options.trustedMediaOrigin)
     ? preview.image
     : undefined;
+  const remoteMediaUnavailable = !!preview.remote_media_unavailable || (!!preview.image && !trustedImage);
   return {
     originalUrl: preview.original_url,
     ...(preview.normalized_url ? { normalizedUrl: preview.normalized_url } : {}),
     ...(preview.title ? { title: preview.title } : {}),
     ...(preview.description ? { description: preview.description } : {}),
-    ...(image
+    ...(remoteMediaUnavailable ? { remoteMediaUnavailable: true } : {}),
+    ...(trustedImage
       ? {
           image: {
-            url: image.url,
-            mediaType: image.media_type,
-            ...(typeof image.width === "number" ? { width: image.width } : {}),
-            ...(typeof image.height === "number" ? { height: image.height } : {}),
-            ...(image.alt ? { alt: image.alt } : {}),
+            url: trustedImage.url,
+            mediaType: trustedImage.media_type,
+            ...(typeof trustedImage.width === "number" ? { width: trustedImage.width } : {}),
+            ...(typeof trustedImage.height === "number" ? { height: trustedImage.height } : {}),
+            ...(trustedImage.alt ? { alt: trustedImage.alt } : {}),
           },
         }
       : {}),

--- a/chat/src/lib/xmpp/wasm-types.ts
+++ b/chat/src/lib/xmpp/wasm-types.ts
@@ -151,6 +151,7 @@ export interface WasmLinkPreview {
   title?: string | null;
   description?: string | null;
   image?: WasmLinkPreviewImage | null;
+  remote_media_unavailable?: boolean;
 }
 
 export interface WasmLinkPreviewImage {

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -34,7 +34,7 @@ import { normalizeMucServiceDomain } from "@/lib/calls/muc-call-indicators";
 import { connectionStore } from "@/lib/connection-store";
 import { resetPinnedRooms } from "@/stores/pinned-messages";
 import { hydratePinnedBodiesOnPanelOpen } from "@/services/pinned-message-bodies";
-import { linkPreviewMediaOriginFromWebSocketUrl } from "@/lib/xmpp/link-preview";
+import { trustedLinkPreviewMediaOrigin } from "@/lib/xmpp/link-preview";
 import { roomMessageFromArchived } from "@/lib/xmpp/wasm-message-codecs";
 import { mapLiveRoomMessageToTimeline } from "@/channels/timeline";
 import { orderTimelineForScrollDirection, type ScrollDirectionMode } from "@/lib/scroll-direction";
@@ -1291,7 +1291,7 @@ export function useChatAppController(giphyApiKey: string) {
     const convertForTimeline = (a: Parameters<typeof roomMessageFromArchived>[0]) => {
       const live = roomMessageFromArchived(a, {
         trustedMediaOrigin: session.value
-          ? linkPreviewMediaOriginFromWebSocketUrl(session.value.xmpp_websocket_url)
+          ? trustedLinkPreviewMediaOrigin(session.value)
           : null,
       });
       return live && session.value

--- a/chat/tests/chat-ui-render.test.ts
+++ b/chat/tests/chat-ui-render.test.ts
@@ -7,8 +7,10 @@ import {
   isImageFile,
   isPdfFile,
   isVideoFile,
+  linkPreviewMediaState,
   renderStyledBody,
   type ExtensionAnnotation,
+  type LinkPreview,
   type MarkupSpan,
   type MessageReference,
 } from "../src/lib/chat-ui";
@@ -111,6 +113,35 @@ describe("renderStyledBody", () => {
     expect(isPdfFile(undefined, "notes.pdf")).toBe(true);
     expect(inferredFileDisposition("text/plain", "notes.txt")).toBe("attachment");
     expect(inferredFileDisposition("video/mp4", "clip.mp4")).toBe("inline");
+  });
+
+  test("marks remote link-preview media unavailable without exposing an image URL", () => {
+    const preview: LinkPreview = {
+      originalUrl: "https://example.com/article",
+      title: "Example",
+      remoteMediaUnavailable: true,
+    };
+
+    expect(linkPreviewMediaState(preview)).toEqual({ kind: "remote-unavailable" });
+  });
+
+  test("renders trusted cached link-preview media when an image is present", () => {
+    const preview: LinkPreview = {
+      originalUrl: "https://example.com/article",
+      image: {
+        url: "https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png",
+        mediaType: "image/png",
+        width: 640,
+        height: 360,
+        alt: "Article screenshot",
+      },
+      remoteMediaUnavailable: true,
+    };
+
+    expect(linkPreviewMediaState(preview)).toEqual({
+      kind: "image",
+      image: preview.image,
+    });
   });
 
   test("summarizes generic extension payload cards without sample-specific types", () => {

--- a/chat/tests/inbound-references.test.ts
+++ b/chat/tests/inbound-references.test.ts
@@ -197,6 +197,53 @@ describe("roomMessageFromArchived", () => {
     }]);
   });
 
+  test("maps remote-media-unavailable LinkPreview payloads into room timeline messages", () => {
+    const result = roomMessageFromArchived({
+      ...baseArchivedRoom,
+      link_previews: [{
+        original_url: "https://example.com/article",
+        normalized_url: "https://example.com/article",
+        title: "Example Article",
+        description: "Plain text summary",
+        remote_media_unavailable: true,
+      }],
+    });
+
+    expect(result).not.toBeNull();
+    const timeline = mapLiveRoomMessageToTimeline(session, result!);
+    expect(timeline.linkPreviews).toEqual([{
+      originalUrl: "https://example.com/article",
+      normalizedUrl: "https://example.com/article",
+      title: "Example Article",
+      description: "Plain text summary",
+      remoteMediaUnavailable: true,
+    }]);
+  });
+
+  test("marks attacker-host cached-path LinkPreview images unavailable after trusted-origin stripping", () => {
+    const result = roomMessageFromArchived({
+      ...baseArchivedRoom,
+      link_previews: [{
+        original_url: "https://example.com/article",
+        normalized_url: "https://example.com/article",
+        title: "Example Article",
+        image: {
+          url: "https://attacker.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png",
+          media_type: "image/png",
+        },
+      }],
+    }, { trustedMediaOrigin: "https://waddle.example" });
+
+    expect(result).not.toBeNull();
+    const timeline = mapLiveRoomMessageToTimeline(session, result!);
+    expect(timeline.linkPreviews).toEqual([{
+      originalUrl: "https://example.com/article",
+      normalizedUrl: "https://example.com/article",
+      title: "Example Article",
+      remoteMediaUnavailable: true,
+    }]);
+  });
+
   test("archive replay clears an optimistic room LinkPreview when payload has none", () => {
     const archived = roomMessageFromArchived({
       ...baseArchivedRoom,

--- a/chat/tests/link-preview.test.ts
+++ b/chat/tests/link-preview.test.ts
@@ -4,6 +4,7 @@ import {
   isTrustedCachedPreviewImageUrl,
   linkPreviewMediaOriginFromWebSocketUrl,
   requestPlaintextLinkPreviewLookup,
+  trustedLinkPreviewMediaOrigin,
 } from "../src/lib/xmpp/link-preview";
 import { withFakeDomParser, withFakeXmlDocument } from "./helpers/disco-xml";
 
@@ -88,6 +89,13 @@ describe("link preview lookup", () => {
       "http://localhost:4321/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png",
       origin,
     )).toBe(true);
+  });
+
+  test("prefers explicit session media origin over websocket origin", () => {
+    expect(trustedLinkPreviewMediaOrigin({
+      xmpp_websocket_url: "wss://xmpp.example/ws",
+      link_preview_media_origin: "https://cdn.example",
+    })).toBe("https://cdn.example");
   });
 
   test("accepts trusted cached preview image origins with explicit default ports", () => {

--- a/chat/tests/message-body-link-previews.test.ts
+++ b/chat/tests/message-body-link-previews.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { createSSRApp, h } from "vue";
+import { parse, compileScript } from "vue/compiler-sfc";
+import { renderToString } from "vue/server-renderer";
+import ts from "typescript";
+import type { TimelineMessage } from "../src/lib/chat-ui";
+
+describe("MessageBody link previews", () => {
+  test("renders cached preview images and unavailable remote media states", async () => {
+    const html = await renderMessageBody({
+      message: messageWithPreviews([
+        {
+          originalUrl: "https://example.com/article",
+          title: "Cached article",
+          description: "A preview with trusted cached media",
+          image: {
+            url: "https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview.png",
+            mediaType: "image/png",
+            width: 640,
+            height: 360,
+            alt: "Article preview",
+          },
+          remoteMediaUnavailable: true,
+        },
+        {
+          originalUrl: "https://remote.example/post",
+          title: "Remote article",
+          remoteMediaUnavailable: true,
+        },
+      ]),
+    });
+
+    expect(html).toContain('src="https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview.png"');
+    expect(html).toContain('alt="Article preview"');
+    expect(html).toContain('width="640"');
+    expect(html).toContain('height="360"');
+    expect(html).toContain("Cached article");
+    expect(html).toContain("Remote preview media unavailable");
+    expect(html).toContain("Remote article");
+  });
+});
+
+function messageWithPreviews(linkPreviews: TimelineMessage["linkPreviews"]): TimelineMessage {
+  return {
+    id: "m1",
+    author: "Alice",
+    body: "",
+    createdAt: "2026-06-02T12:00:00.000Z",
+    createdAtSource: "fallback",
+    isSelf: false,
+    linkPreviews,
+  };
+}
+
+async function renderMessageBody(props: { message: TimelineMessage; compact?: boolean }) {
+  const component = await loadMessageBodyComponent();
+  return renderToString(createSSRApp({ render: () => h(component, props) }));
+}
+
+async function loadMessageBodyComponent() {
+  const filename = new URL("../src/components/chat/MessageBody.vue", import.meta.url);
+  const source = readFileSync(filename, "utf8");
+  const { descriptor } = parse(source, { filename: filename.pathname });
+  const script = compileScript(descriptor, {
+    id: "message-body-link-previews-test",
+    inlineTemplate: true,
+  });
+
+  const tempDir = mkdtempSync(join(tmpdir(), "waddle-message-body-"));
+  try {
+    const compiled = [
+      rewriteImports(script.content.replace("export default", "const __sfc__ ="), filename, tempDir),
+      "export default __sfc__;",
+    ].join("\n");
+    const js = ts.transpileModule(compiled, {
+      compilerOptions: {
+        module: ts.ModuleKind.ESNext,
+        target: ts.ScriptTarget.ES2022,
+        verbatimModuleSyntax: false,
+      },
+    }).outputText;
+    const modulePath = join(tempDir, "MessageBody.mjs");
+    writeFileSync(modulePath, js);
+    const component = await import(pathToFileURL(modulePath).href);
+    return component.default;
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function rewriteImports(code: string, importer: URL, tempDir: string): string {
+  return code.replace(/from\s+["']([^"']+)["']/g, (_match, specifier: string) =>
+    `from ${JSON.stringify(resolveModuleSpecifier(specifier, importer, tempDir))}`);
+}
+
+function resolveModuleSpecifier(specifier: string, importer: URL, tempDir: string): string {
+  if (specifier.startsWith("@/")) {
+    return moduleUrlForPath(resolveSourcePath(new URL(`../src/${specifier.slice(2)}`, import.meta.url).pathname), tempDir);
+  }
+  if (specifier.startsWith(".")) {
+    return moduleUrlForPath(resolveSourcePath(new URL(specifier, importer).pathname), tempDir);
+  }
+  return import.meta.resolve(specifier);
+}
+
+function resolveSourcePath(basePath: string): string {
+  const candidates = [
+    basePath,
+    `${basePath}.ts`,
+    `${basePath}.tsx`,
+    `${basePath}.js`,
+    `${basePath}.mjs`,
+    `${basePath}.vue`,
+    `${basePath}.json`,
+    `${basePath}/index.ts`,
+  ];
+  const resolved = candidates.find((candidate) => existsSync(candidate));
+  if (!resolved) throw new Error(`Unable to resolve test SFC import: ${basePath}`);
+  return resolved;
+}
+
+function moduleUrlForPath(resolvedPath: string, tempDir: string): string {
+  if (!resolvedPath.endsWith(".vue")) return pathToFileURL(resolvedPath).href;
+  const stubPath = join(tempDir, `${resolvedPath.replace(/[^a-z0-9]/gi, "_")}.mjs`);
+  writeFileSync(stubPath, [
+    `import { h } from ${JSON.stringify(import.meta.resolve("vue"))};`,
+    "export default { name: 'MessageBodyChildStub', setup(_, { slots }) { return () => h('span', { 'data-vue-stub': 'true' }, slots.default?.()); } };",
+  ].join("\n"));
+  return pathToFileURL(stubPath).href;
+}

--- a/chat/tsconfig.json
+++ b/chat/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "astro/tsconfigs/strict",
   "compilerOptions": {
     "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "paths": {
       "@/*": ["src/*"]
     }

--- a/server/crates/waddle-server/src/server/routes/auth.rs
+++ b/server/crates/waddle-server/src/server/routes/auth.rs
@@ -204,6 +204,7 @@ pub struct SessionResponse {
     pub xmpp_localpart: String,
     pub jid: String,
     pub xmpp_websocket_url: String,
+    pub link_preview_media_origin: String,
     pub is_expired: bool,
     pub expires_at: Option<String>,
 }
@@ -427,6 +428,7 @@ pub async fn session_handler(
                     xmpp_localpart: session.xmpp_localpart,
                     jid,
                     xmpp_websocket_url: state.websocket_url(),
+                    link_preview_media_origin: state.base_url.clone(),
                     is_expired,
                     expires_at,
                 }),

--- a/server/crates/waddle-server/src/server/routes/auth/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/auth/tests.rs
@@ -28,7 +28,7 @@ async fn create_test_auth_state(
 }
 
 #[tokio::test]
-async fn session_response_includes_jid_and_websocket_url() {
+async fn session_response_includes_jid_websocket_url_and_link_preview_media_origin() {
     let server_config = ServerConfig::test_homeserver();
     let (auth_state, actor) = create_test_auth_state(&server_config).await;
     let session = Session::new("user-1", "alice", "alice");
@@ -74,6 +74,10 @@ async fn session_response_includes_jid_and_websocket_url() {
     assert_eq!(
         json["xmpp_websocket_url"].as_str(),
         Some("ws://localhost:3000/ws")
+    );
+    assert_eq!(
+        json["link_preview_media_origin"].as_str(),
+        Some("http://localhost:3000")
     );
 }
 

--- a/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
@@ -440,6 +440,7 @@ fn link_previews_to_js(previews: Vec<messaging::LinkPreviewData>) -> Vec<WaddleL
             normalized_url: preview.normalized_url.map(|url| url.to_string()),
             title: preview.title,
             description: preview.description,
+            remote_media_unavailable: preview.remote_media_unavailable,
             image: preview.image.map(|image| WaddleLinkPreviewImage {
                 url: image.url.to_string(),
                 media_type: image.media_type.as_str().to_string(),
@@ -863,6 +864,37 @@ mod inbound_to_js_tests {
         assert_eq!(image.width, Some(640));
         assert_eq!(image.height, Some(360));
         assert_eq!(image.alt.as_deref(), Some("Article screenshot"));
+        assert!(!preview.remote_media_unavailable);
+    }
+
+    #[test]
+    fn archived_to_js_marks_remote_xep0511_media_unavailable() {
+        let archived = parse_mam_archived(
+            "<message xmlns='jabber:client'>\
+               <result xmlns='urn:xmpp:mam:2' id='mam-link-remote-media' queryid='q1'>\
+                 <forwarded xmlns='urn:xmpp:forward:0'>\
+                   <delay xmlns='urn:xmpp:delay' stamp='2026-05-06T12:00:00Z'/>\
+                   <message xmlns='jabber:client' type='groupchat' id='m-link' \
+                            from='room@conf.example/alice'>\
+                     <body>see https://the.link.example/what-was-linked</body>\
+                     <rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#' xmlns:ogi='https://ogp.me/ns#image:' rdf:about='https://the.link.example/what-was-linked'>\
+                       <og:title>The Best Webpage</og:title>\
+                       <og:image>https://remote.example/preview.png</og:image>\
+                       <ogi:type>image/png</ogi:type>\
+                     </rdf:Description>\
+                   </message>\
+                 </forwarded>\
+               </result>\
+             </message>",
+        );
+
+        let js = archived_to_js(archived).expect("valid archived message should convert");
+
+        assert_eq!(js.link_previews.len(), 1);
+        let preview = &js.link_previews[0];
+        assert_eq!(preview.title.as_deref(), Some("The Best Webpage"));
+        assert!(preview.image.is_none());
+        assert!(preview.remote_media_unavailable);
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -69,6 +69,7 @@ pub struct WaddleLinkPreview {
     pub title: Option<String>,
     pub description: Option<String>,
     pub image: Option<WaddleLinkPreviewImage>,
+    pub remote_media_unavailable: bool,
 }
 
 #[derive(Debug, Serialize)]

--- a/server/crates/waddle-xmpp-client/src/messaging/parsing/mod.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/parsing/mod.rs
@@ -374,8 +374,9 @@ fn parse_link_preview(el: &Element, first_url: Option<&Url>) -> Option<LinkPrevi
     if first_url.is_some() && first_url != Some(&original_url) {
         return None;
     }
-    let has_preview_image = link_preview_image_url(el).is_some();
-    let image = parse_link_preview_image(el);
+    let preview_image_url = link_preview_image_url(el);
+    let has_preview_image = preview_image_url.is_some();
+    let image = parse_link_preview_image(el, preview_image_url.as_deref());
     Some(LinkPreviewData {
         original_url,
         normalized_url: og_text(el, "url").and_then(|value| parse_web_url(&value)),
@@ -386,8 +387,8 @@ fn parse_link_preview(el: &Element, first_url: Option<&Url>) -> Option<LinkPrevi
     })
 }
 
-fn parse_link_preview_image(el: &Element) -> Option<LinkPreviewImageData> {
-    let url = link_preview_image_url(el).and_then(|url| parse_cached_preview_image_url(&url))?;
+fn parse_link_preview_image(el: &Element, image_url: Option<&str>) -> Option<LinkPreviewImageData> {
+    let url = image_url.and_then(parse_cached_preview_image_url)?;
     let media_type =
         og_image_text(el, "type").and_then(|value| value.parse::<PreviewImageMediaType>().ok())?;
     Some(LinkPreviewImageData {

--- a/server/crates/waddle-xmpp-client/src/messaging/parsing/mod.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/parsing/mod.rs
@@ -374,20 +374,20 @@ fn parse_link_preview(el: &Element, first_url: Option<&Url>) -> Option<LinkPrevi
     if first_url.is_some() && first_url != Some(&original_url) {
         return None;
     }
+    let has_preview_image = link_preview_image_url(el).is_some();
+    let image = parse_link_preview_image(el);
     Some(LinkPreviewData {
         original_url,
         normalized_url: og_text(el, "url").and_then(|value| parse_web_url(&value)),
         title: og_text(el, "title"),
         description: og_text(el, "description"),
-        image: parse_link_preview_image(el),
+        remote_media_unavailable: has_preview_image && image.is_none(),
+        image,
     })
 }
 
 fn parse_link_preview_image(el: &Element) -> Option<LinkPreviewImageData> {
-    let url = el
-        .children()
-        .find(|child| child.name() == "image" && child.ns() == NS_OPENGRAPH)
-        .and_then(|child| parse_cached_preview_image_url(child.text().trim()))?;
+    let url = link_preview_image_url(el).and_then(|url| parse_cached_preview_image_url(&url))?;
     let media_type =
         og_image_text(el, "type").and_then(|value| value.parse::<PreviewImageMediaType>().ok())?;
     Some(LinkPreviewImageData {
@@ -397,6 +397,13 @@ fn parse_link_preview_image(el: &Element) -> Option<LinkPreviewImageData> {
         height: og_image_text(el, "height").and_then(|value| value.parse().ok()),
         alt: og_image_text(el, "alt"),
     })
+}
+
+fn link_preview_image_url(el: &Element) -> Option<String> {
+    el.children()
+        .find(|child| child.name() == "image" && child.ns() == NS_OPENGRAPH)
+        .map(|child| child.text().trim().to_string())
+        .filter(|url| !url.is_empty())
 }
 
 fn parse_cached_preview_image_url(value: &str) -> Option<Url> {

--- a/server/crates/waddle-xmpp-client/src/messaging/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/tests.rs
@@ -572,6 +572,7 @@ fn parse_message_ignores_xep0511_link_preview_image_with_unsafe_media_type() {
     };
     assert_eq!(msg.link_previews.len(), 1);
     assert!(msg.link_previews[0].image.is_none());
+    assert!(msg.link_previews[0].remote_media_unavailable);
 }
 
 #[test]
@@ -591,6 +592,27 @@ fn parse_message_ignores_xep0511_link_preview_image_without_cached_media_path() 
     };
     assert_eq!(msg.link_previews.len(), 1);
     assert!(msg.link_previews[0].image.is_none());
+    assert!(msg.link_previews[0].remote_media_unavailable);
+}
+
+#[test]
+fn parse_message_marks_remote_xep0511_link_preview_image_unavailable() {
+    let e = el(
+        "<message xmlns='jabber:client' type='groupchat' id='m-link'>\
+           <body>see https://the.link.example.com/what-was-linked-to</body>\
+           <rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#' xmlns:ogi='https://ogp.me/ns#image:' rdf:about='https://the.link.example.com/what-was-linked-to'>\
+             <og:title>The Best Webpage</og:title>\
+             <og:image>https://remote.example/preview.png</og:image>\
+             <ogi:type>image/png</ogi:type>\
+           </rdf:Description>\
+         </message>",
+    );
+    let MessagingEvent::Message(msg) = parse(&e).unwrap() else {
+        panic!("expected Message");
+    };
+    assert_eq!(msg.link_previews.len(), 1);
+    assert!(msg.link_previews[0].image.is_none());
+    assert!(msg.link_previews[0].remote_media_unavailable);
 }
 
 #[test]

--- a/server/crates/waddle-xmpp-client/src/messaging/types.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/types.rs
@@ -201,6 +201,7 @@ pub struct LinkPreviewData {
     pub title: Option<String>,
     pub description: Option<String>,
     pub image: Option<LinkPreviewImageData>,
+    pub remote_media_unavailable: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=cd2b0aa5d5f0";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=cd2b0aa5d5f0";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=cd2b0aa5d5f0";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=b40d8c9c10b2";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=b40d8c9c10b2";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=b40d8c9c10b2";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=cd2b0aa5d5f0";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=b40d8c9c10b2";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=f2adad46deb8";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=f2adad46deb8";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=f2adad46deb8";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=cd2b0aa5d5f0";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=cd2b0aa5d5f0";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=cd2b0aa5d5f0";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=f2adad46deb8";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=cd2b0aa5d5f0";


### PR DESCRIPTION
## Summary

Implements #830: conservative recipient-side rendering for federated XEP-0511 link metadata.

- Parses inbound XEP-0511 text metadata into the shared `LinkPreview` DTO while preserving body/clickable-link rendering.
- Distinguishes remote/untrusted preview media with `remoteMediaUnavailable` instead of silently treating it like a text-only preview.
- Keeps Waddle-cached preview images renderable only when they pass the configured trusted media origin and XEP-0363 cache-path checks.
- Adds `link_preview_media_origin` to the auth session so cached preview media can be trusted by the server public media origin instead of assuming it matches the XMPP websocket origin.
- Regenerates the checked-in WASM glue hash after Rust WASM/parser changes.
- Adds `ignoreDeprecations: "6.0"` to `chat/tsconfig.json` so the declared TypeScript 6 toolchain can run Astro/Vue checks past the existing `baseUrl` deprecation.
- Adds a repo-native SSR render test for `MessageBody` link-preview media branches without introducing new test dependencies.

## Plan

- Review XEP-0511 wire shape and existing link-preview DTO/rendering paths.
- Add failing behavior tests one slice at a time for remote XEP-0511 text metadata, remote media suppression/unavailability, and trusted Waddle cached media rendering.
- Implement minimal typed DTO/provenance/rendering changes to pass each test.
- Run focused server/chat suites, then broader lint/build/test checks.
- Run adversarial review passes and address actionable trust-boundary findings.
- Address PR review feedback and re-run focused verification.

## Review feedback addressed

- Fixed attacker-host cached-path lookalikes so browser decoding strips the image and still surfaces unavailable media.
- Replaced websocket-derived media trust with explicit session `link_preview_media_origin`, with websocket-origin fallback for older sessions.
- Broadened unavailable-media signaling for any non-empty `og:image` rejected by cached media policy.
- Removed duplicate Rust `<og:image>` extraction in `parse_link_preview` by reusing the raw image URL for the presence check and cached-media parse.
- Avoided repeated Vue template calls to `linkPreviewMediaState` by precomputing per-preview media state in a typed view model.
- Added direct `MessageBody` SSR coverage for cached preview image rendering and remote-media-unavailable rendering.

## Verification

- `cargo test -p waddle-xmpp-client xep0511 -- --nocapture`
- `cargo test -p waddle-server session_response_includes_jid_websocket_url_and_link_preview_media_origin -- --nocapture`
- `bun test tests/inbound-references.test.ts tests/chat-ui-render.test.ts tests/link-preview.test.ts tests/startup-loading.test.ts`
- `cargo fmt`
- `bun run lint`
- `cargo clippy -p waddle-xmpp-client -p waddle-xmpp-client-wasm -p waddle-server -- -D warnings`
- `bun run build`
- `bun test`
- `cargo test -p waddle-xmpp-client -p waddle-xmpp-client-wasm`

Additional review-fix verification:

- `bun test tests/message-body-link-previews.test.ts`
- `bun test tests/chat-ui-render.test.ts tests/message-body-link-previews.test.ts`
- `bun run lint`
- `bun run build`
- `cargo test -p waddle-xmpp-client xep0511 -- --nocapture`
- `cargo test -p waddle-xmpp-client-wasm`
- `cargo clippy -p waddle-xmpp-client -p waddle-xmpp-client-wasm -p waddle-server -- -D warnings`

## Notes

- `bunx vue-tsc --noEmit` now runs past the TypeScript 6 `baseUrl` deprecation after the `tsconfig` update, but the repo still has unrelated pre-existing Vue/TS errors outside this change set. `bun run build`/Astro check passes.
- The `MessageBody` rendering test uses the existing Vue SFC compile + SSR pattern because the repo has no `@vue/test-utils` or DOM mount harness.

Closes #830