### PR TITLE
fix(chat): deliver Faro collector URL to production builds

### DIFF
--- a/chat/astro.config.mjs
+++ b/chat/astro.config.mjs
@@ -6,21 +6,14 @@ import vue from "@astrojs/vue";
 import { resolveCommitSha } from "./scripts/resolve-commit-sha.mjs";
 
 const COMMIT_SHA = resolveCommitSha();
-// Faro Web SDK config is baked at build time via Vite `define` so the
-// bundled script knows where to POST beacons. The collector URL below
-// is the Grafana Cloud Frontend Observability "Send data" endpoint for
-// waddle-chat. It is enabled automatically for production deploys and
-// can be overridden explicitly for other environments.
-const DEFAULT_FARO_URL =
-  "https://faro-collector-prod-eu-west-6.grafana.net/collect/0eab89b00ec9f7cfd5c97e96636a3d20";
-const isProductionDeploy = process.env.CUENV_ENVIRONMENT === "production";
-const FARO_URL =
-  process.env.PUBLIC_FARO_URL ??
-  (isProductionDeploy ? DEFAULT_FARO_URL : "");
+// Faro Web SDK config is baked at build time via Vite `define`. The
+// PUBLIC_FARO_* values are injected only for production deploys (see
+// env.environment.production in the repo-root env.cue); every other
+// build leaves them empty, which initTelemetry() treats as "off".
+const FARO_URL = process.env.PUBLIC_FARO_URL ?? "";
 const FARO_APP_NAME = process.env.PUBLIC_FARO_APP_NAME ?? "waddle-chat";
 const FARO_APP_VERSION = process.env.PUBLIC_FARO_APP_VERSION ?? "1.0.0";
-const FARO_ENVIRONMENT =
-  process.env.PUBLIC_FARO_ENVIRONMENT ?? (isProductionDeploy ? "production" : "");
+const FARO_ENVIRONMENT = process.env.PUBLIC_FARO_ENVIRONMENT ?? "";
 
 export default defineConfig({
   output: "server",

--- a/env.cue
+++ b/env.cue
@@ -34,6 +34,13 @@ schema.#Base & {
 			CLOUDFLARE_API_TOKEN: schema.#OnePasswordRef & {
 				ref: "op://waddle-production/Cloudflare/password"
 			}
+
+			// Public Grafana Cloud Faro collector for chat RUM. cuenv scrubs
+			// ambient env, so build-time PUBLIC_* values must be declared here
+			// to reach `astro build`. Scoped to production so previews, PR, and
+			// local builds ship telemetry off.
+			PUBLIC_FARO_URL:         "https://faro-collector-prod-eu-west-6.grafana.net/collect/0eab89b00ec9f7cfd5c97e96636a3d20"
+			PUBLIC_FARO_ENVIRONMENT: "production"
 		}
 	}
 }


### PR DESCRIPTION
## Problem

Grafana Faro RUM is **not working on the deployed chat app** even though #846 ("privacy-safe Grafana Faro instrumentation") merged and its production deploy succeeded. The live bundle at `waddle.chat` ships with Faro **tree-shaken out** — no `initializeFaro` call, no collector URL, no beacons.

## Root cause

#846 gates the collector URL in `astro.config.mjs`:

```js
const isProductionDeploy = process.env.CUENV_ENVIRONMENT === "production";
const FARO_URL = process.env.PUBLIC_FARO_URL ?? (isProductionDeploy ? DEFAULT_FARO_URL : "");
```

But **cuenv runs tasks in a scrubbed environment** — ambient vars only reach a task via an explicit `#EnvPassthrough` or a declared `env:` value (see the passthroughs in `server/env.cue`). `CUENV_ENVIRONMENT` is consumed by cuenv to *select* the environment and is never forwarded into the `astro build` subprocess, so `isProductionDeploy` is `false` at build time. `FARO_URL` bakes to `""`, `initTelemetry()` early-returns, and Rollup strips the entire Faro SDK.

### Evidence

Deployed `waddle.chat` bundle:
- `/_astro/AppLayout...js` bootstrap: no `initTelemetry(...)` call; `serverBaseUrl` computed then discarded.
- `/_astro/telemetry...js`: 999 bytes, **zero** occurrences of the collector id, `initializeFaro`, or `getWebInstrumentations`.
- Deploy run `26845999259` for the #846 merge: completed **success** — it just shipped telemetry disabled.

## Fix

Deliver the Faro config through cuenv's **proven** production-env mechanism — the same `env.environment.production` block that already delivers `CLOUDFLARE_API_TOKEN` to the deploy:

- `env.cue`: add `PUBLIC_FARO_URL` and `PUBLIC_FARO_ENVIRONMENT` (plain strings — the collector URL is public and ships in the client bundle) under `env.environment.production`.
- `chat/astro.config.mjs`: drop the broken `CUENV_ENVIRONMENT` gate and the now-duplicate `DEFAULT_FARO_URL`; read `process.env.PUBLIC_FARO_*` directly with empty defaults.

Telemetry stays **off** for previews, PR, and local builds (the `pullRequest` pipeline sets no environment, so the vars are never injected). Production-only privacy intent of #846 is preserved; only the broken delivery is fixed.

## Validation

- `cue vet ./...` passes; `cue export` confirms both vars resolve under `env.environment.production`.
- Locally, `CUENV_ENVIRONMENT=production` is no longer required; with `PUBLIC_FARO_URL` present the define bakes the collector URL into the bundle.
- Post-merge verification plan: after the production deploy, re-fetch the `waddle.chat` telemetry chunk and confirm `initializeFaro` + the collector id are present.

This PR was created with the assistance of a LLM.