### PR TITLE
fix(chat): resolve MUC joins via XEP-0045 status 110 (room-self-presence-timeout)

### DIFF
--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -600,7 +600,10 @@ export class BrowserXmppClient {
     outcome: CatchupOutcome;
   }) => void> = [];
   private readonly resumeDrainHooks: Array<(info: { buffered: number; durationMs: number }) => void> = [];
-  private readonly roomJoinWaiters = new Map<string, { resolve: () => void; reject: (error: Error) => void }>();
+  private readonly roomJoinWaiters = new Map<
+    string,
+    { promise: Promise<void>; resolve: () => void; reject: (error: Error) => void }
+  >();
   private readonly carbonDedupIds = new Set<string>();
   readonly catchup: ReconnectCatchup;
   private readonly resumePersistence: ResumePersistence;
@@ -1045,26 +1048,38 @@ export class BrowserXmppClient {
 
   private waitForRoomSelfPresence(roomJid: string): Promise<void> {
     const key = this.roomJoinKey(roomJid);
-    return new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        this.roomJoinWaiters.delete(key);
-        const detail = `Timed out waiting for self-presence in ${roomJid}`;
-        this.emitError({ kind: "connect-timeout", recoverable: true, detail });
-        reject(new Error("Channel presence did not finish syncing. Try again in a moment."));
-      }, ROOM_SELF_PRESENCE_TIMEOUT_MS);
-      this.roomJoinWaiters.set(key, {
-        resolve: () => {
-          clearTimeout(timeout);
-          this.roomJoinWaiters.delete(key);
-          resolve();
-        },
-        reject: (error) => {
-          clearTimeout(timeout);
-          this.roomJoinWaiters.delete(key);
-          reject(error);
-        },
-      });
+    // Concurrent joins for JIDs that normalize to the same room key
+    // (e.g. case variants from topology vs. retained-room replay) must
+    // share one waiter — a second `set` would orphan the first promise,
+    // hanging that join until its timeout.
+    const existing = this.roomJoinWaiters.get(key);
+    if (existing) return existing.promise;
+    let resolveJoin!: () => void;
+    let rejectJoin!: (error: Error) => void;
+    const promise = new Promise<void>((resolve, reject) => {
+      resolveJoin = resolve;
+      rejectJoin = reject;
     });
+    const timeout = setTimeout(() => {
+      this.roomJoinWaiters.delete(key);
+      const detail = `Timed out waiting for self-presence in ${roomJid}`;
+      this.emitError({ kind: "connect-timeout", recoverable: true, detail });
+      rejectJoin(new Error("Channel presence did not finish syncing. Try again in a moment."));
+    }, ROOM_SELF_PRESENCE_TIMEOUT_MS);
+    this.roomJoinWaiters.set(key, {
+      promise,
+      resolve: () => {
+        clearTimeout(timeout);
+        this.roomJoinWaiters.delete(key);
+        resolveJoin();
+      },
+      reject: (error) => {
+        clearTimeout(timeout);
+        this.roomJoinWaiters.delete(key);
+        rejectJoin(error);
+      },
+    });
+    return promise;
   }
 
   private clearRoomPresenceCaches(): void {
@@ -2849,7 +2864,12 @@ export class BrowserXmppClient {
       const roomMemberJids = this.memberJidsFor(room);
       const isFocusedRoom = room === this.currentRoom;
       if (presence.presence_type === "unavailable") {
-        if (this.isOwnMucSelfPresence(presence)) {
+        // XEP-0045 §7.6: a nick change sends an unavailable presence for
+        // the old nick carrying our own status 110 *and* 303. That is not
+        // a departure — the available presence for the new nick follows —
+        // so it must NOT revoke room readiness.
+        const isNickChange = presence.muc_status_codes?.includes(303) ?? false;
+        if (this.isOwnMucSelfPresence(presence) && !isNickChange) {
           this.revokeMucReadiness(room, {
             keepPendingJoin: this.roomJoinWaiters.has(this.roomJoinKey(room)),
           });

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -234,6 +234,13 @@ function shouldSkipRawCatchupMessage(
 const DM_CALL_ACTIVITY_PAGE_SIZE = 100;
 const DM_CALL_ACTIVITY_MAX_PAGES = 50;
 
+// Safety-net ceiling for a MUC join. XEP-0045 §7.2.2 has the service
+// send the self-presence (status 110) only AFTER every existing
+// occupant's presence, so a busy room or a slow link can legitimately
+// take several seconds to deliver the roster. 110 is the definitive
+// resolve signal; this timeout only bounds genuinely stuck joins.
+const ROOM_SELF_PRESENCE_TIMEOUT_MS = 15_000;
+
 type CatchupRunStats = { pages: number; messages: number };
 type CatchupOutcome = "completed" | "aborted" | "failed";
 type DmCallActivityHydrationOptions = { since?: string; pageSize?: number; maxPages?: number };
@@ -679,16 +686,52 @@ export class BrowserXmppClient {
     ]);
   }
 
-  private isOwnMucSelfPresence(presence: { muc_jid?: string | null }): boolean {
+  private isOwnMucSelfPresence(presence: {
+    muc_jid?: string | null;
+    muc_status_codes?: number[] | null;
+  }): boolean {
+    // XEP-0045 §7.2.2: status code 110 is the canonical self-presence
+    // marker. It is the only signal that works regardless of room
+    // anonymity (no real JID disclosed) or a service-modified nick.
+    if (presence.muc_status_codes?.includes(110)) return true;
+    // Fallback for any path that doesn't surface status codes: match
+    // the disclosed real JID (non-anonymous rooms only).
     const mucJid = fullJidIdentityKey(presence.muc_jid);
     return !!mucJid && this.ownFullJidCandidates().has(mucJid);
   }
 
   private isOwnAvailableMucSelfPresence(presence: {
     muc_jid?: string | null;
+    muc_status_codes?: number[] | null;
     presence_type?: string;
   }): boolean {
     return this.isOwnMucSelfPresence(presence) && presence.presence_type !== "unavailable";
+  }
+
+  /**
+   * Normalized key under which a room's join waiter is registered.
+   * Keying on the bare room JID (case-folded) — not the full
+   * `room/nick` occupant JID — makes join resolution independent of
+   * the nick the service echoes back and of localpart case.
+   */
+  private roomJoinKey(roomJid: string): string {
+    return roomJid.split("/")[0]?.trim().toLowerCase() ?? "";
+  }
+
+  /**
+   * True when a presence carries an `http://jabber.org/protocol/muc#user`
+   * payload. Every MUC occupant presence includes an affiliation/role
+   * (and self-presence a status code), so we no longer rely on a
+   * disclosed real JID — anonymous rooms omit `muc_jid` yet must still
+   * be routed through MUC handling.
+   */
+  private isMucPresence(presence: WasmPresence): boolean {
+    return (
+      presence.muc_jid !== undefined ||
+      presence.muc_affiliation !== undefined ||
+      presence.muc_role !== undefined ||
+      (presence.muc_status_codes?.length ?? 0) > 0
+    );
   }
 
   private revokeMucReadiness(roomJid: string, options: { keepPendingJoin?: boolean } = {}): void {
@@ -1000,24 +1043,24 @@ export class BrowserXmppClient {
     this.discoveredRoomJids.set(channelId, normalizedRoomJid);
   }
 
-  private waitForRoomSelfPresence(roomJid: string, nick: string): Promise<void> {
-    const fullJid = `${roomJid}/${nick}`;
+  private waitForRoomSelfPresence(roomJid: string): Promise<void> {
+    const key = this.roomJoinKey(roomJid);
     return new Promise((resolve, reject) => {
       const timeout = setTimeout(() => {
-        this.roomJoinWaiters.delete(fullJid);
+        this.roomJoinWaiters.delete(key);
         const detail = `Timed out waiting for self-presence in ${roomJid}`;
         this.emitError({ kind: "connect-timeout", recoverable: true, detail });
         reject(new Error("Channel presence did not finish syncing. Try again in a moment."));
-      }, 4000);
-      this.roomJoinWaiters.set(fullJid, {
+      }, ROOM_SELF_PRESENCE_TIMEOUT_MS);
+      this.roomJoinWaiters.set(key, {
         resolve: () => {
           clearTimeout(timeout);
-          this.roomJoinWaiters.delete(fullJid);
+          this.roomJoinWaiters.delete(key);
           resolve();
         },
         reject: (error) => {
           clearTimeout(timeout);
-          this.roomJoinWaiters.delete(fullJid);
+          this.roomJoinWaiters.delete(key);
           reject(error);
         },
       });
@@ -1136,7 +1179,7 @@ export class BrowserXmppClient {
     if (!xmpp.join_room && !xmpp.joinRoom) {
       throw new Error("XMPP client missing join_room binding");
     }
-    const ready = this.waitForRoomSelfPresence(roomJid, this.session.username);
+    const ready = this.waitForRoomSelfPresence(roomJid);
     if (xmpp.join_room) {
       await Promise.allSettled([xmpp.join_room(roomJid, this.session.username)]);
     } else if (xmpp.joinRoom) {
@@ -2787,10 +2830,16 @@ export class BrowserXmppClient {
   }
   private handlePresence(presence: WasmPresence) {
     const from = presence.from ?? "";
-    if ((presence as any).muc_jid !== undefined) {
+    if (this.isMucPresence(presence)) {
       const [room, nick = ""] = from.split("/");
-      const waiter = this.roomJoinWaiters.get(from);
-      if (waiter && this.isOwnAvailableMucSelfPresence(presence)) waiter.resolve();
+      // XEP-0045 §7.2.2: our own available self-presence (status 110,
+      // or, as a fallback, our disclosed real JID) completes the join.
+      // Resolve by room — not the exact occupant JID — so a
+      // service-modified nick or localpart-case difference still
+      // matches the waiter.
+      if (this.isOwnAvailableMucSelfPresence(presence)) {
+        this.roomJoinWaiters.get(this.roomJoinKey(room))?.resolve();
+      }
       if (!room) return;
       if (!nick && presence.vcard_avatar) this.roomAvatarHandler?.(room, presence.vcard_avatar);
       if (!nick) return;
@@ -2801,7 +2850,9 @@ export class BrowserXmppClient {
       const isFocusedRoom = room === this.currentRoom;
       if (presence.presence_type === "unavailable") {
         if (this.isOwnMucSelfPresence(presence)) {
-          this.revokeMucReadiness(room, { keepPendingJoin: this.roomJoinWaiters.has(from) });
+          this.revokeMucReadiness(room, {
+            keepPendingJoin: this.roomJoinWaiters.has(this.roomJoinKey(room)),
+          });
         }
         delete roomHats[nick];
         delete roomAuthority[nick];

--- a/chat/src/lib/xmpp/wasm-types.ts
+++ b/chat/src/lib/xmpp/wasm-types.ts
@@ -204,6 +204,12 @@ export interface WasmPresence {
   muc_affiliation?: string;
   muc_role?: string;
   muc_jid?: string;
+  /**
+   * XEP-0045 MUC `<status code='…'/>` markers as raw numbers (e.g.
+   * `110` self-presence, `100` non-anonymous). Absent when the
+   * presence carries no status codes.
+   */
+  muc_status_codes?: number[];
   vcard_avatar?: string;
   muji?: WasmMujiPresence;
 }

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -536,6 +536,74 @@ describe("client send readiness", () => {
     );
   });
 
+  test("own unavailable self-presence recognised via status 110 revokes readiness in an anonymous room", async () => {
+    // Anonymous-room leave/kick: no real JID is disclosed, so the only
+    // self marker is status 110. Readiness must still be revoked.
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type?: string;
+      muc_jid?: string;
+      muc_status_codes?: number[];
+    }) => void) | null = null;
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    (client as unknown as { xmpp: typeof xmpp; currentRoom: string | null }).xmpp = xmpp;
+    (client as unknown as { currentRoom: string | null }).currentRoom = roomJid;
+    (client as unknown as { joinedMucs: Map<string, Promise<void>> }).joinedMucs.set(roomJid, Promise.resolve());
+    (client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.add(roomJid);
+    (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "unavailable",
+      muc_status_codes: [110],
+    });
+
+    expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(false);
+    expect((client as unknown as { joinedMucs: Map<string, Promise<void>> }).joinedMucs.has(roomJid)).toBe(false);
+  });
+
+  test("own nick-change unavailable (status 303+110) does NOT revoke room readiness", async () => {
+    // XEP-0045 §7.6: the unavailable presence for the old nick carries
+    // our 110 alongside 303. The room stays ready; the available
+    // presence for the new nick follows.
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type?: string;
+      muc_jid?: string;
+      muc_status_codes?: number[];
+    }) => void) | null = null;
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    (client as unknown as { xmpp: typeof xmpp; currentRoom: string | null }).xmpp = xmpp;
+    (client as unknown as { currentRoom: string | null }).currentRoom = roomJid;
+    (client as unknown as { joinedMucs: Map<string, Promise<void>> }).joinedMucs.set(roomJid, Promise.resolve());
+    (client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.add(roomJid);
+    (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "unavailable",
+      muc_status_codes: [303, 110],
+      muc_jid: (client as unknown as { fullJid: string }).fullJid,
+    });
+
+    expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(true);
+    expect((client as unknown as { joinedMucs: Map<string, Promise<void>> }).joinedMucs.has(roomJid)).toBe(true);
+  });
+
   test("session-ready room queue flush waits for current-room rejoin", async () => {
     const client = new BrowserXmppClient(session());
     const roomJid = roomBareJidFor(session(), "c1");

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -414,6 +414,74 @@ describe("client send readiness", () => {
     expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(true);
   });
 
+  test("room join resolves on XEP-0045 status code 110 in an anonymous room (no real JID disclosed)", async () => {
+    // Semi-/anonymous rooms don't disclose the occupant's real JID, so
+    // self-presence can only be recognised by `<status code='110'/>`
+    // (XEP-0045 §7.2.2). The join must still complete.
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type?: string;
+      muc_jid?: string;
+      muc_status_codes?: number[];
+    }) => void) | null = null;
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+
+    const joined = (client as unknown as { ensureJoined: (roomJid: string) => Promise<void> }).ensureJoined(roomJid);
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+    });
+
+    await joined;
+    expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(true);
+  });
+
+  test("room join resolves when the room assigns a different nick than requested", async () => {
+    // XEP-0045 lockdown can hand the joiner a service-modified nick
+    // (status 210). Self-presence (110) identifies us regardless of the
+    // echoed occupant nick, so keying the join waiter on the exact
+    // requested `room/nick` would wrongly time out.
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type?: string;
+      muc_jid?: string;
+      muc_status_codes?: number[];
+    }) => void) | null = null;
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+
+    const joined = (client as unknown as { ensureJoined: (roomJid: string) => Promise<void> }).ensureJoined(roomJid);
+    onPresence?.({
+      from: `${roomJid}/alice-2`,
+      presence_type: "available",
+      muc_status_codes: [210, 110],
+      muc_jid: (client as unknown as { fullJid: string }).fullJid,
+    });
+
+    await joined;
+    expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(true);
+  });
+
   test("own unavailable self-presence revokes room readiness and forces a fresh join", async () => {
     const client = new BrowserXmppClient(session());
     const roomJid = roomBareJidFor(session(), "c1");

--- a/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
@@ -727,6 +727,7 @@ mod inbound_to_js_tests {
 
     #[test]
     fn presence_to_js_maps_muc_status_codes_to_numbers() {
+        use waddle_xmpp_client::messaging::MucStatus;
         let presence = InboundPresence {
             from: Some("room@muc.test/alice".to_string()),
             to: None,

--- a/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
@@ -602,6 +602,11 @@ pub(crate) fn presence_to_js(presence: InboundPresence) -> WaddlePresence {
         muc_affiliation: presence.muc_affiliation.map(muc_affiliation_to_string),
         muc_role: presence.muc_role.map(muc_role_to_string),
         muc_jid: presence.muc_jid,
+        muc_status_codes: presence
+            .muc_status
+            .iter()
+            .map(|status| status.code())
+            .collect(),
         vcard_avatar: presence.vcard_avatar,
         muji: presence.muji.map(|m| WaddleMujiPresence {
             preparing: m.preparing,
@@ -718,6 +723,30 @@ mod inbound_to_js_tests {
 
         assert_eq!(propose.kind, "propose");
         assert_eq!(propose.to.as_deref(), Some("bob@waddle.test/phone"));
+    }
+
+    #[test]
+    fn presence_to_js_maps_muc_status_codes_to_numbers() {
+        let presence = InboundPresence {
+            from: Some("room@muc.test/alice".to_string()),
+            to: None,
+            presence_type: None,
+            status: None,
+            show: None,
+            hats: vec![],
+            muc_affiliation: None,
+            muc_role: None,
+            muc_jid: None,
+            muc_status: vec![
+                MucStatus::NonAnonymous,
+                MucStatus::SelfPresence,
+                MucStatus::Other(210),
+            ],
+            vcard_avatar: None,
+            muji: None,
+        };
+        let js = presence_to_js(presence);
+        assert_eq!(js.muc_status_codes, vec![100, 110, 210]);
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client-wasm/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/lib.rs
@@ -28,7 +28,7 @@ use waddle_xmpp_client::messaging::{
     build_moderation_message, build_outbound_message, build_pinned_message, build_reaction_message,
     build_retraction_message, build_unpinned_message, InboundCallEvent, InboundMessage,
     InboundPresence, LinkPreviewToken, MarkupSpanData, MarkupSpanType, MucAffiliation, MucRole,
-    MucStatus, ReferenceData, SendMessageOptions, SharedFileDisposition,
+    ReferenceData, SendMessageOptions, SharedFileDisposition,
 };
 use waddle_xmpp_client::pep::{
     build_pep_items_iq, build_publish_activity_iq, build_publish_mood_iq, build_publish_tune_iq,

--- a/server/crates/waddle-xmpp-client-wasm/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/lib.rs
@@ -28,7 +28,7 @@ use waddle_xmpp_client::messaging::{
     build_moderation_message, build_outbound_message, build_pinned_message, build_reaction_message,
     build_retraction_message, build_unpinned_message, InboundCallEvent, InboundMessage,
     InboundPresence, LinkPreviewToken, MarkupSpanData, MarkupSpanType, MucAffiliation, MucRole,
-    ReferenceData, SendMessageOptions, SharedFileDisposition,
+    MucStatus, ReferenceData, SendMessageOptions, SharedFileDisposition,
 };
 use waddle_xmpp_client::pep::{
     build_pep_items_iq, build_publish_activity_iq, build_publish_mood_iq, build_publish_tune_iq,

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -299,6 +299,11 @@ pub struct WaddlePresence {
     pub muc_affiliation: Option<String>,
     pub muc_role: Option<String>,
     pub muc_jid: Option<String>,
+    /// XEP-0045 MUC `<status code='…'/>` markers as raw numbers (e.g.
+    /// `110` self-presence, `100` non-anonymous). Omitted when the
+    /// presence carries none, so the chat side sees `undefined`.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub muc_status_codes: Vec<u16>,
     pub vcard_avatar: Option<String>,
     /// XEP-0272 Muji `<muji xmlns='urn:xmpp:jingle:muji:0'/>`
     /// extension on a MUC occupant's presence, surfaced as

--- a/server/crates/waddle-xmpp-client/src/messaging.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging.rs
@@ -47,8 +47,9 @@ pub use types::{
     ExtensionRoomJid, ExtensionSourceData, ExtensionTextId, ExtensionTimestamp, ExtensionXmlName,
     InboundMessage, InboundPresence, InvalidLinkPreviewToken, LinkPreviewData, LinkPreviewToken,
     MarkupSpan, MarkupSpanData, MarkupSpanType, MdsDisplayedEntry, MessagingEvent,
-    ModerationPayload, MucAffiliation, MucRole, MujiPresence, PresenceHat, ReactionPayload,
-    ReferenceData, RetractionPayload, SendMessageOptions, SharedFile, SharedFileDisposition,
+    ModerationPayload, MucAffiliation, MucRole, MucStatus, MujiPresence, PresenceHat,
+    ReactionPayload, ReferenceData, RetractionPayload, SendMessageOptions, SharedFile,
+    SharedFileDisposition,
 };
 /// Re-export the xmpp-parsers Jingle types Waddle's call surface
 /// owns so downstream crates (notably the wasm bindings, which

--- a/server/crates/waddle-xmpp-client/src/messaging/presence.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/presence.rs
@@ -262,4 +262,22 @@ mod tests {
         let p = parse_presence(&elem);
         assert_eq!(p.muc_status, vec![MucStatus::Other(999)]);
     }
+
+    #[test]
+    fn status_outside_muc_user_x_is_not_collected() {
+        // The top-level <status> is XEP-0045-unrelated presence status
+        // text (jabber:client). Only `<status code>` children of the
+        // muc#user <x> are MUC status codes.
+        let xml = r#"<presence xmlns="jabber:client" from="room@muc.test/alice">
+            <status>Away from keyboard</status>
+            <x xmlns="http://jabber.org/protocol/muc#user">
+                <item affiliation="member" role="participant"/>
+                <status code="110"/>
+            </x>
+        </presence>"#;
+        let elem: Element = xml.parse().unwrap();
+        let p = parse_presence(&elem);
+        assert_eq!(p.muc_status, vec![MucStatus::SelfPresence]);
+        assert_eq!(p.status.as_deref(), Some("Away from keyboard"));
+    }
 }

--- a/server/crates/waddle-xmpp-client/src/messaging/presence.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/presence.rs
@@ -25,9 +25,8 @@ pub(super) fn parse_presence(el: &Element) -> InboundPresence {
                 .collect()
         })
         .unwrap_or_default();
-    let muc_item = el
-        .get_child("x", NS_MUC_USER)
-        .and_then(|x| x.get_child("item", NS_MUC_USER));
+    let muc_x = el.get_child("x", NS_MUC_USER);
+    let muc_item = muc_x.and_then(|x| x.get_child("item", NS_MUC_USER));
     let muc_affiliation = muc_item
         .and_then(|item| item.attr("affiliation"))
         .and_then(MucAffiliation::from_attr);
@@ -37,6 +36,19 @@ pub(super) fn parse_presence(el: &Element) -> InboundPresence {
     let muc_jid = muc_item
         .and_then(|item| item.attr("jid"))
         .map(str::to_string);
+    // XEP-0045 §7.2.2 self-presence (110) and the other muc#user
+    // status codes. Unparseable / unknown codes are preserved via
+    // `MucStatus::Other` rather than dropped.
+    let muc_status = muc_x
+        .map(|x| {
+            x.children()
+                .filter(|child| child.name() == "status" && child.ns() == NS_MUC_USER)
+                .filter_map(|status| status.attr("code"))
+                .filter_map(|code| code.parse::<u16>().ok())
+                .map(MucStatus::from_code)
+                .collect()
+        })
+        .unwrap_or_default();
     let vcard_avatar = el
         .get_child("x", NS_VCARD_UPDATE)
         .and_then(|x| x.get_child("photo", NS_VCARD_UPDATE))
@@ -85,6 +97,7 @@ pub(super) fn parse_presence(el: &Element) -> InboundPresence {
         muc_affiliation,
         muc_role,
         muc_jid,
+        muc_status,
         vcard_avatar,
         muji,
     }
@@ -190,5 +203,63 @@ mod tests {
         </presence>"#;
         let elem: Element = xml.parse().unwrap();
         assert!(parse_presence(&elem).muji.is_none());
+    }
+
+    #[test]
+    fn parses_self_presence_status_code_110() {
+        // XEP-0045 §7.2.2: the room's self-presence to the joining user
+        // MUST carry `<status code='110'/>` so the client knows the
+        // presence refers to itself and the roster is complete.
+        let xml = r#"<presence xmlns="jabber:client" from="room@muc.test/alice">
+            <x xmlns="http://jabber.org/protocol/muc#user">
+                <item affiliation="member" role="participant" jid="alice@test/desktop"/>
+                <status code="110"/>
+            </x>
+        </presence>"#;
+        let elem: Element = xml.parse().unwrap();
+        let p = parse_presence(&elem);
+        assert!(p.muc_status.contains(&MucStatus::SelfPresence));
+    }
+
+    #[test]
+    fn parses_multiple_muc_status_codes() {
+        // Non-anonymous room self-presence carries both 100 and 110.
+        let xml = r#"<presence xmlns="jabber:client" from="room@muc.test/alice">
+            <x xmlns="http://jabber.org/protocol/muc#user">
+                <item affiliation="owner" role="moderator" jid="alice@test/desktop"/>
+                <status code="100"/>
+                <status code="110"/>
+            </x>
+        </presence>"#;
+        let elem: Element = xml.parse().unwrap();
+        let p = parse_presence(&elem);
+        assert_eq!(
+            p.muc_status,
+            vec![MucStatus::NonAnonymous, MucStatus::SelfPresence]
+        );
+    }
+
+    #[test]
+    fn presence_without_status_codes_has_empty_muc_status() {
+        let xml = r#"<presence xmlns="jabber:client" from="room@muc.test/bob">
+            <x xmlns="http://jabber.org/protocol/muc#user">
+                <item affiliation="member" role="participant"/>
+            </x>
+        </presence>"#;
+        let elem: Element = xml.parse().unwrap();
+        assert!(parse_presence(&elem).muc_status.is_empty());
+    }
+
+    #[test]
+    fn unknown_status_code_is_preserved_as_other() {
+        let xml = r#"<presence xmlns="jabber:client" from="room@muc.test/alice">
+            <x xmlns="http://jabber.org/protocol/muc#user">
+                <item affiliation="member" role="participant"/>
+                <status code="999"/>
+            </x>
+        </presence>"#;
+        let elem: Element = xml.parse().unwrap();
+        let p = parse_presence(&elem);
+        assert_eq!(p.muc_status, vec![MucStatus::Other(999)]);
     }
 }

--- a/server/crates/waddle-xmpp-client/src/messaging/types.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/types.rs
@@ -526,6 +526,41 @@ impl MucRole {
     }
 }
 
+/// XEP-0045 MUC status codes carried as `<status code='…'/>` children
+/// of the `http://jabber.org/protocol/muc#user` payload. Only the codes
+/// Waddle's client acts on are named; every other registered code is
+/// preserved losslessly as `Other(u16)` so the typed value never drops
+/// information.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MucStatus {
+    /// 100 — the room is non-anonymous (occupants' real JIDs exposed).
+    NonAnonymous,
+    /// 110 — self-presence: this presence refers to the recipient. On
+    /// join it is sent last and marks the end of the room roster
+    /// (XEP-0045 §7.2.2).
+    SelfPresence,
+    /// Any other registered status code, preserved verbatim.
+    Other(u16),
+}
+
+impl MucStatus {
+    pub fn from_code(code: u16) -> Self {
+        match code {
+            100 => Self::NonAnonymous,
+            110 => Self::SelfPresence,
+            other => Self::Other(other),
+        }
+    }
+
+    pub fn code(self) -> u16 {
+        match self {
+            Self::NonAnonymous => 100,
+            Self::SelfPresence => 110,
+            Self::Other(code) => code,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct InboundPresence {
     pub from: Option<String>,
@@ -537,6 +572,11 @@ pub struct InboundPresence {
     pub muc_affiliation: Option<MucAffiliation>,
     pub muc_role: Option<MucRole>,
     pub muc_jid: Option<String>,
+    /// XEP-0045 `<status code='…'/>` markers from the `muc#user`
+    /// payload. Empty when the presence carries none. `110`
+    /// (`MucStatus::SelfPresence`) identifies the recipient's own
+    /// presence regardless of room anonymity or nick.
+    pub muc_status: Vec<MucStatus>,
     pub vcard_avatar: Option<String>,
     /// XEP-0272 (Muji) presence advertisement —
     /// `<muji xmlns='urn:xmpp:jingle:muji:0'>…</muji>` — carried on


### PR DESCRIPTION
## Problem

Faro surfaced `xmpp.disconnect: room-self-presence-timeout` from production: after joining a room the chat client waited for its own self-presence and timed out, stranding channels.

## Root cause (traced through every layer)

The server sends a conformant self-presence (`<status code='110'/>` + `100` + `jid`, last per XEP-0045 §7.2.2), but the client never read status codes. The Rust parser extracted `muc_affiliation/role/jid` from `muc#user` but not `<status/>`, so self-presence was matched two brittle ways (`client.ts`): exact full-occupant-JID string match, plus `muc_jid === my real JID`. Three independent timeout triggers:

1. **Exact-key match** — waiter keyed `${roomJid}/${nick}`; any case/nick normalization difference missed.
2. **4s timeout** — self-presence is sent *after* the full occupant roster (§7.2.2); busy rooms / slow links exceed it.
3. **`muc_jid !== undefined` gate** — anonymous rooms disclose no real JID, making self-presence undetectable.

Verified against the live bundle: `initializeFaro`/the join never resolved because the client ignored 110.

## Fix — surface XEP-0045 status code 110 end-to-end

**Rust (`waddle-xmpp-client`)**
- Typed `MucStatus` enum (`SelfPresence=110`, `NonAnonymous=100`, lossless `Other(u16)`); `muc_status: Vec<MucStatus>` on `InboundPresence`.
- Parse `<status code='…'/>` from the `muc#user` `<x>` only. Parser tests: self, multi/non-anonymous, none, unknown→Other, and status-outside-`muc#user` ignored.

**WASM (`waddle-xmpp-client-wasm`)**
- Expose `muc_status_codes: number[]` (omitted when empty). Mapping test.

**TS (`chat/src/lib/xmpp/client.ts`)**
- Detect self-presence via `muc_status_codes.includes(110)` (primary), disclosed real JID (fallback).
- Key the join waiter by **room** (`roomJoinKey`), not the exact occupant JID — nick/case independent.
- Broaden the MUC gate (`isMucPresence`: affiliation/role/status/jid) so anonymous-room presences route through MUC handling.
- Raise the join safety-net timeout to 15s (110 is the definitive resolve; the timeout only bounds genuinely stuck joins).

## Adversarial review hardening
Three reviewers (XEP conformance, regression, repo-rules) ran; their real findings were fixed and a fourth pass verified them:
- **Nick change (§7.6):** an unavailable presence for the old nick carries our 110 *and* 303 — guarded so it no longer revokes room readiness.
- **Concurrent same-key joins:** `waitForRoomSelfPresence` now returns the in-flight waiter instead of orphaning the first promise.
- Added tests: anonymous-room leave via 110 revokes readiness; nick-change (303+110) does not.

## Validation
- Rust: `cargo test` (416 + 80 client crates) green; `cargo fmt`; `clippy -D warnings` clean.
- TS: `bun test` 1582 green; `astro check` 0 errors; `knip` clean.
- Reviewed against `xeps/xep-0045.xml` §7.2.2 (110 MUST, sent after full roster) and §7.6 (nick-change 303+110).

This PR was created with the assistance of a LLM.