### PR TITLE
feat(chat): add protocol-backed threads filters

### DIFF
--- a/chat/src/components/chat/ThreadsListPanel.vue
+++ b/chat/src/components/chat/ThreadsListPanel.vue
@@ -1,85 +1,221 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from "vue";
+import { computed, onMounted } from "vue";
 import type { BrowserXmppClient } from "@/lib/xmpp-client";
-import type { WasmThreadEntry, WasmThreadsPage } from "@/lib/xmpp/wasm-types";
+import type { ChannelSummary } from "@/lib/chat-types";
+import type { WasmThreadEntry } from "@/lib/xmpp/wasm-types";
+import {
+  type ThreadsActiveWindow,
+  type ThreadsSort,
+  type ThreadsStatusFilter,
+} from "@/lib/threads-view-filters";
+import { useThreadsListPanelState } from "@/lib/threads-view-state";
 import ThreadsListRow from "@/components/chat/ThreadsListRow.vue";
+
+const STATUS_OPTIONS: Array<{ value: ThreadsStatusFilter; label: string }> = [
+  { value: "all", label: "All" },
+  { value: "unread", label: "Unread" },
+  { value: "following", label: "Following" },
+];
+
+const ACTIVE_OPTIONS: Array<{ value: ThreadsActiveWindow; label: string }> = [
+  { value: "7d", label: "7d" },
+  { value: "14d", label: "14d" },
+  { value: "30d", label: "30d" },
+  { value: "all", label: "All" },
+];
+
+const SORT_OPTIONS: Array<{ value: ThreadsSort; label: string }> = [
+  { value: "recent", label: "Recently active" },
+  { value: "unread", label: "Most unread" },
+  { value: "replies", label: "Most replies" },
+];
 
 const props = defineProps<{
   xmppClient: BrowserXmppClient | null;
+  channels: readonly ChannelSummary[];
 }>();
 
 const emit = defineEmits<{
   openThread: [entry: WasmThreadEntry];
 }>();
 
-const loading = ref(true);
-const page = ref<WasmThreadsPage | null>(null);
-const error = ref<string | null>(null);
+const browserUrlState = typeof window === "undefined" ? undefined : {
+  readSearch: () => window.location.search,
+  replaceSearch: (encoded: string) => {
+    const next = encoded
+      ? `${window.location.pathname}?${encoded}${window.location.hash}`
+      : `${window.location.pathname}${window.location.hash}`;
+    window.history.replaceState(window.history.state, "", next);
+  },
+};
 
-const unread = computed(
-  () => page.value?.entries.filter((entry) => entry.has_unread) ?? [],
-);
-const following = computed(
-  () => page.value?.entries.filter((entry) => !entry.has_unread) ?? [],
-);
+const state = useThreadsListPanelState({
+  xmppClient: computed(() => props.xmppClient),
+  channels: computed(() => props.channels),
+  urlState: browserUrlState,
+});
 
-onMounted(async () => {
-  if (!props.xmppClient) {
-    loading.value = false;
-    return;
-  }
-  try {
-    page.value = await props.xmppClient.fetchThreads({ pageSize: 50 });
-  } catch (err) {
-    error.value = err instanceof Error ? err.message : String(err);
-  } finally {
-    loading.value = false;
-  }
+const {
+  active,
+  channel,
+  channelFilterMessage,
+  channelFilterOptionLabel,
+  error,
+  fetchThreadsPage,
+  hasEntries,
+  loading,
+  loadingMore,
+  markThreadRead,
+  markingReadKey,
+  nextCursor,
+  resultSummary,
+  search,
+  sections,
+  selectableChannels,
+  sort,
+  status,
+  threadKey,
+} = state;
+
+onMounted(() => {
+  void fetchThreadsPage(false);
 });
 </script>
 
 <template>
   <div class="chat-panel-stack p-4">
-    <h2 class="type-pane-title">Threads</h2>
+    <div class="flex flex-col gap-3 border-b border-border/70 pb-3">
+      <div class="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h2 class="type-pane-title">Threads</h2>
+          <div v-if="resultSummary" class="type-caption text-muted-foreground">
+            {{ resultSummary }}
+          </div>
+        </div>
+        <select
+          v-model="sort"
+          class="type-caption h-8 rounded-md border border-border bg-background px-2 text-foreground"
+          aria-label="Sort threads"
+        >
+          <option
+            v-for="option in SORT_OPTIONS"
+            :key="option.value"
+            :value="option.value"
+          >
+            {{ option.label }}
+          </option>
+        </select>
+      </div>
 
-    <div v-if="loading" class="type-caption text-muted-foreground" aria-busy="true">
+      <div class="flex flex-wrap gap-2" aria-label="Thread status filter">
+        <button
+          v-for="option in STATUS_OPTIONS"
+          :key="option.value"
+          type="button"
+          class="type-caption rounded-md border px-2.5 py-1"
+          :class="status === option.value ? 'border-primary bg-primary text-primary-foreground' : 'border-border text-muted-foreground hover:bg-muted/50 hover:text-foreground'"
+          @click="status = option.value"
+        >
+          {{ option.label }}
+        </button>
+      </div>
+
+      <div class="grid gap-2 md:grid-cols-[auto_minmax(10rem,14rem)_minmax(12rem,1fr)]">
+        <div class="flex flex-wrap gap-1" aria-label="Thread activity window">
+          <button
+            v-for="option in ACTIVE_OPTIONS"
+            :key="option.value"
+            type="button"
+            class="type-caption h-8 rounded-md border px-2"
+            :class="active === option.value ? 'border-primary bg-primary/10 text-primary' : 'border-border text-muted-foreground hover:bg-muted/50 hover:text-foreground'"
+            @click="active = option.value"
+          >
+            {{ option.label }}
+          </button>
+        </div>
+
+        <select
+          v-model="channel"
+          class="type-caption h-8 min-w-0 rounded-md border border-border bg-background px-2 text-foreground"
+          aria-label="Filter by channel"
+        >
+          <option value="all">All channels</option>
+          <option
+            v-if="channelFilterOptionLabel && channel !== 'all'"
+            :value="channel"
+          >
+            {{ channelFilterOptionLabel }}
+          </option>
+          <option
+            v-for="item in selectableChannels"
+            :key="item.id"
+            :value="item.id"
+          >
+            #{{ item.name || item.id }}
+          </option>
+        </select>
+
+        <input
+          v-model="search"
+          type="search"
+          class="type-caption h-8 min-w-0 rounded-md border border-border bg-background px-2 text-foreground placeholder:text-muted-foreground"
+          placeholder="Search threads"
+          aria-label="Search threads"
+        />
+      </div>
+    </div>
+
+    <div v-if="loading && !hasEntries" class="type-caption text-muted-foreground" aria-busy="true">
       Loading threads…
     </div>
 
-    <div v-else-if="error" class="type-caption text-destructive">
+    <div v-else-if="error && !hasEntries" class="type-caption text-destructive">
       Couldn't load threads: {{ error }}
     </div>
 
-    <template v-else-if="page">
-      <section v-if="unread.length > 0" class="chat-panel-stack">
+    <template v-else>
+      <section
+        v-for="section in sections"
+        v-show="section.entries.length > 0"
+        :key="section.id"
+        class="chat-panel-stack"
+      >
         <div class="type-section-label text-muted-foreground/75">
-          Unread · {{ unread.length }}
+          {{ section.label }} · {{ section.entries.length }}
         </div>
         <ThreadsListRow
-          v-for="entry in unread"
-          :key="`${entry.channel}|${entry.thread_id}`"
+          v-for="entry in section.entries"
+          :key="threadKey(entry)"
           :entry="entry"
+          :marking-read="markingReadKey === threadKey(entry)"
           @open="emit('openThread', $event)"
-        />
-      </section>
-
-      <section v-if="following.length > 0" class="chat-panel-stack">
-        <div class="type-section-label text-muted-foreground/75">
-          Following · {{ following.length }}
-        </div>
-        <ThreadsListRow
-          v-for="entry in following"
-          :key="`${entry.channel}|${entry.thread_id}`"
-          :entry="entry"
-          @open="emit('openThread', $event)"
+          @mark-read="markThreadRead"
         />
       </section>
 
       <div
-        v-if="unread.length === 0 && following.length === 0"
+        v-if="!hasEntries"
         class="type-caption text-muted-foreground"
       >
-        No threads yet. Threads you reply to or get mentioned in will show up here.
+        {{ channelFilterMessage || "No threads match these filters." }}
+      </div>
+
+      <div v-if="error && hasEntries" class="type-caption text-destructive">
+        Couldn't refresh threads: {{ error }}
+      </div>
+
+      <button
+        v-if="nextCursor"
+        type="button"
+        class="type-control self-start rounded-md border border-border px-3 py-1.5 text-muted-foreground hover:bg-muted/50 hover:text-foreground disabled:opacity-60"
+        :disabled="loadingMore"
+        @click="fetchThreadsPage(true)"
+      >
+        {{ loadingMore ? "Loading…" : "Load more" }}
+      </button>
+
+      <div v-if="markingReadKey" class="sr-only" aria-live="polite">
+        Marking thread read
       </div>
     </template>
   </div>

--- a/chat/src/components/chat/ThreadsListRow.vue
+++ b/chat/src/components/chat/ThreadsListRow.vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import type { WasmThreadEntry } from "@/lib/xmpp/wasm-types";
+import { threadDisplayTitle } from "@/lib/threads-view-filters";
 
 const props = defineProps<{
   entry: WasmThreadEntry;
+  markingRead?: boolean;
 }>();
 
 const emit = defineEmits<{
   open: [entry: WasmThreadEntry];
+  markRead: [entry: WasmThreadEntry];
 }>();
 
 const recencyLabel = computed(() => {
@@ -25,35 +28,41 @@ const channelLabel = computed(() => {
   return `#${local}`;
 });
 
-const title = computed(
-  () =>
-    props.entry.thread_title ??
-    props.entry.preview ??
-    "Thread",
-);
+const title = computed(() => threadDisplayTitle(props.entry));
 </script>
 
 <template>
-  <button
-    type="button"
-    class="chat-thread-row glass-panel w-full rounded-md px-3 py-2 text-left hover:bg-sidebar-accent/35"
-    @click="emit('open', entry)"
-  >
-    <div class="flex items-center justify-between gap-2">
-      <div class="min-w-0 flex-1">
-        <div class="type-card-title truncate">{{ title }}</div>
-        <div class="type-caption text-muted-foreground truncate">
-          {{ channelLabel }} · {{ recencyLabel }}
-          <span v-if="entry.reply_count > 0"> · {{ entry.reply_count }} replies</span>
+  <div class="chat-thread-row glass-panel flex w-full items-stretch gap-2 rounded-md px-3 py-2 hover:bg-sidebar-accent/35">
+    <button
+      type="button"
+      class="min-w-0 flex-1 text-left"
+      @click="emit('open', entry)"
+    >
+      <div class="flex items-center justify-between gap-2">
+        <div class="min-w-0 flex-1">
+          <div class="type-card-title truncate">{{ title }}</div>
+          <div class="type-caption text-muted-foreground truncate">
+            {{ channelLabel }} · {{ recencyLabel }}
+            <span v-if="entry.reply_count > 0"> · {{ entry.reply_count }} replies</span>
+          </div>
         </div>
+        <span
+          v-if="entry.has_unread"
+          class="type-count-badge inline-flex min-w-[18px] h-[18px] items-center justify-center rounded-full bg-primary px-1 text-primary-foreground"
+          :aria-label="`${entry.unread} unread`"
+        >
+          {{ entry.unread }}
+        </span>
       </div>
-      <span
-        v-if="entry.has_unread"
-        class="type-count-badge inline-flex min-w-[18px] h-[18px] items-center justify-center rounded-full bg-primary px-1 text-primary-foreground"
-        :aria-label="`${entry.unread} unread`"
-      >
-        {{ entry.unread }}
-      </span>
-    </div>
-  </button>
+    </button>
+    <button
+      v-if="entry.has_unread"
+      type="button"
+      class="type-caption shrink-0 self-center rounded-md border border-border px-2 py-1 text-muted-foreground hover:bg-muted/50 hover:text-foreground disabled:opacity-60"
+      :disabled="props.markingRead"
+      @click.stop="emit('markRead', entry)"
+    >
+      {{ props.markingRead ? "Marking..." : "Mark read" }}
+    </button>
+  </div>
 </template>

--- a/chat/src/components/chat/ThreadsView.vue
+++ b/chat/src/components/chat/ThreadsView.vue
@@ -47,6 +47,6 @@ async function openThread(entry: WasmThreadEntry) {
       </span>
       <h1 class="type-pane-title text-foreground leading-tight">Threads</h1>
     </header>
-    <ThreadsListPanel :xmpp-client="xmppClient" @open-thread="openThread" />
+    <ThreadsListPanel :xmpp-client="xmppClient" :channels="channels" @open-thread="openThread" />
   </div>
 </template>

--- a/chat/src/lib/threads-view-filters.ts
+++ b/chat/src/lib/threads-view-filters.ts
@@ -1,0 +1,90 @@
+export type ThreadsStatusFilter = "all" | "unread" | "following";
+export type ThreadsActiveWindow = "7d" | "14d" | "30d" | "all";
+export type ThreadsSort = "recent" | "unread" | "replies";
+
+interface ThreadsFilterState {
+  status: ThreadsStatusFilter;
+  active: ThreadsActiveWindow;
+  channel: string;
+  query: string;
+  sort: ThreadsSort;
+}
+
+const VALID_STATUS = new Set<ThreadsStatusFilter>(["all", "unread", "following"]);
+const VALID_ACTIVE = new Set<ThreadsActiveWindow>(["7d", "14d", "30d", "all"]);
+const VALID_SORT = new Set<ThreadsSort>(["recent", "unread", "replies"]);
+
+const DEFAULT_THREADS_FILTERS: ThreadsFilterState = {
+  status: "all",
+  active: "all",
+  channel: "all",
+  query: "",
+  sort: "recent",
+};
+
+function paramOrDefault<T extends string>(
+  params: URLSearchParams,
+  key: string,
+  allowed: Set<T>,
+  fallback: T,
+): T {
+  const value = params.get(key);
+  return value && allowed.has(value as T) ? (value as T) : fallback;
+}
+
+export function decodeThreadsFilterState(search: string | URLSearchParams): ThreadsFilterState {
+  const params = typeof search === "string" ? new URLSearchParams(search) : search;
+  const channel = params.get("channel")?.trim() || DEFAULT_THREADS_FILTERS.channel;
+  return {
+    status: paramOrDefault(params, "status", VALID_STATUS, DEFAULT_THREADS_FILTERS.status),
+    active: paramOrDefault(params, "active", VALID_ACTIVE, DEFAULT_THREADS_FILTERS.active),
+    channel,
+    query: params.get("q")?.trim() ?? DEFAULT_THREADS_FILTERS.query,
+    sort: paramOrDefault(params, "sort", VALID_SORT, DEFAULT_THREADS_FILTERS.sort),
+  };
+}
+
+export function encodeThreadsFilterState(filters: ThreadsFilterState): string {
+  const params = new URLSearchParams();
+  if (filters.status !== DEFAULT_THREADS_FILTERS.status) params.set("status", filters.status);
+  if (filters.active !== DEFAULT_THREADS_FILTERS.active) params.set("active", filters.active);
+  if (filters.channel !== DEFAULT_THREADS_FILTERS.channel) params.set("channel", filters.channel);
+  const query = filters.query.trim();
+  if (query) params.set("q", query);
+  if (filters.sort !== DEFAULT_THREADS_FILTERS.sort) params.set("sort", filters.sort);
+  return params.toString();
+}
+
+export function activeSinceIso(window: ThreadsActiveWindow, now = new Date()): string | undefined {
+  if (window === "all") return undefined;
+  const days = Number.parseInt(window, 10);
+  if (!Number.isFinite(days)) return undefined;
+  const startOfToday = new Date(Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate(),
+  ));
+  startOfToday.setUTCDate(startOfToday.getUTCDate() - days);
+  return startOfToday.toISOString();
+}
+
+function normalizeThreadPreview(value: string | undefined): string | undefined {
+  const text = value?.trim();
+  if (!text) return undefined;
+  if (/^https?:\/\/\S+\.(gif|webp|png|jpe?g)(\?\S*)?$/i.test(text)) {
+    return "Media attachment";
+  }
+  if (/^https?:\/\/media\d*\.giphy\.com\//i.test(text)) {
+    return "GIF attachment";
+  }
+  return text.replace(/^>\s*/, "").trim();
+}
+
+export function threadDisplayTitle(entry: {
+  thread_title?: string;
+  preview?: string;
+}): string {
+  return normalizeThreadPreview(entry.thread_title)
+    ?? normalizeThreadPreview(entry.preview)
+    ?? "Thread";
+}

--- a/chat/src/lib/threads-view-state.ts
+++ b/chat/src/lib/threads-view-state.ts
@@ -1,0 +1,231 @@
+import { computed, ref, watch, type Ref } from "vue";
+import type { ChannelSummary } from "@/lib/chat-types";
+import type { WasmThreadEntry, WasmThreadsPage } from "@/lib/xmpp/wasm-types";
+import {
+  activeSinceIso,
+  decodeThreadsFilterState,
+  encodeThreadsFilterState,
+  type ThreadsActiveWindow,
+  type ThreadsSort,
+  type ThreadsStatusFilter,
+} from "@/lib/threads-view-filters";
+
+const THREADS_PAGE_SIZE = 50;
+
+export interface ThreadsViewClient {
+  fetchThreads(opts?: {
+    pageSize?: number;
+    afterCursor?: string;
+    status?: ThreadsStatusFilter;
+    activeSince?: string;
+    channel?: string;
+    search?: string;
+    sort?: ThreadsSort;
+  }): Promise<WasmThreadsPage>;
+  markInboxRead(partnerJid: string, threadId?: string): Promise<void>;
+}
+
+interface ThreadsUrlStateAdapter {
+  readSearch(): string;
+  replaceSearch(encoded: string): void;
+}
+
+export function useThreadsListPanelState(options: {
+  xmppClient: Readonly<Ref<ThreadsViewClient | null>>;
+  channels: Readonly<Ref<readonly ChannelSummary[]>>;
+  urlState?: ThreadsUrlStateAdapter;
+  now?: () => Date;
+}) {
+  const initialFilters = decodeThreadsFilterState(options.urlState?.readSearch() ?? "");
+  const now = options.now ?? (() => new Date());
+
+  const status = ref<ThreadsStatusFilter>(initialFilters.status);
+  const active = ref<ThreadsActiveWindow>(initialFilters.active);
+  const channel = ref(initialFilters.channel);
+  const search = ref(initialFilters.query);
+  const sort = ref<ThreadsSort>(initialFilters.sort);
+
+  const entries = ref<WasmThreadEntry[]>([]);
+  const total = ref(0);
+  const unreadThreads = ref(0);
+  const nextCursor = ref<string | null>(null);
+  const loading = ref(true);
+  const loadingMore = ref(false);
+  const error = ref<string | null>(null);
+  const markingReadKey = ref<string | null>(null);
+  let requestSerial = 0;
+
+  const filterState = computed(() => ({
+    status: status.value,
+    active: active.value,
+    channel: channel.value,
+    query: search.value,
+    sort: sort.value,
+  }));
+
+  const selectableChannels = computed(() =>
+    options.channels.value
+      .filter((item) => !!item.jid)
+      .slice()
+      .sort((left, right) => left.name.localeCompare(right.name)),
+  );
+
+  const selectedChannelJid = computed(() => {
+    if (channel.value === "all") return undefined;
+    return selectableChannels.value.find((item) => item.id === channel.value)?.jid;
+  });
+  const channelFilterResolved = computed(
+    () => channel.value === "all" || !!selectedChannelJid.value,
+  );
+  const channelFilterMessage = computed(() => {
+    if (channel.value === "all" || selectedChannelJid.value) return "";
+    return selectableChannels.value.length === 0
+      ? "Waiting for channel metadata before filtering threads."
+      : "Selected channel is no longer available.";
+  });
+  const channelFilterOptionLabel = computed(() => {
+    if (channel.value === "all" || selectedChannelJid.value) return "";
+    return selectableChannels.value.length === 0
+      ? "Loading selected channel"
+      : "Selected channel unavailable";
+  });
+
+  const requestState = computed(() => ({
+    ...filterState.value,
+    channelJid: selectedChannelJid.value ?? "",
+  }));
+
+  const unread = computed(() => entries.value.filter((entry) => entry.has_unread));
+  const following = computed(() => entries.value.filter((entry) => !entry.has_unread));
+  const sections = computed(() => {
+    if (status.value === "unread") {
+      return [{ id: "unread", label: "Unread", entries: unread.value }];
+    }
+    if (status.value === "following") {
+      return [{ id: "following", label: "Following", entries: following.value }];
+    }
+    return [{ id: "all", label: "All", entries: entries.value }];
+  });
+  const hasEntries = computed(() => entries.value.length > 0);
+  const resultSummary = computed(() => {
+    if (loading.value && !hasEntries.value) return "";
+    const threadLabel = total.value === 1 ? "thread" : "threads";
+    if (unreadThreads.value === 0) return `${total.value} ${threadLabel}`;
+    return `${total.value} ${threadLabel} · ${unreadThreads.value} unread`;
+  });
+
+  function threadKey(entry: WasmThreadEntry): string {
+    return `${entry.channel}|${entry.thread_id}`;
+  }
+
+  function updateUrl() {
+    options.urlState?.replaceSearch(encodeThreadsFilterState(filterState.value));
+  }
+
+  async function fetchThreadsPage(append: boolean) {
+    const client = options.xmppClient.value;
+    if (!client) {
+      loading.value = false;
+      loadingMore.value = false;
+      return;
+    }
+    if (!channelFilterResolved.value) {
+      if (!append) {
+        entries.value = [];
+        total.value = 0;
+        unreadThreads.value = 0;
+        nextCursor.value = null;
+      }
+      loading.value = false;
+      loadingMore.value = false;
+      return;
+    }
+    if (append && !nextCursor.value) return;
+
+    const serial = ++requestSerial;
+    if (append) loadingMore.value = true;
+    else {
+      loading.value = true;
+      entries.value = [];
+      nextCursor.value = null;
+    }
+    error.value = null;
+
+    try {
+      const activeSince = activeSinceIso(active.value, now());
+      const page = await client.fetchThreads({
+        pageSize: THREADS_PAGE_SIZE,
+        ...(append && nextCursor.value ? { afterCursor: nextCursor.value } : {}),
+        status: status.value,
+        ...(activeSince ? { activeSince } : {}),
+        ...(selectedChannelJid.value ? { channel: selectedChannelJid.value } : {}),
+        ...(search.value.trim() ? { search: search.value.trim() } : {}),
+        sort: sort.value,
+      });
+      if (serial !== requestSerial) return;
+      entries.value = append ? [...entries.value, ...page.entries] : page.entries;
+      total.value = page.total;
+      unreadThreads.value = page.unread_threads;
+      nextCursor.value = page.next_cursor ?? null;
+    } catch (err) {
+      if (serial !== requestSerial) return;
+      error.value = err instanceof Error ? err.message : String(err);
+    } finally {
+      if (serial === requestSerial) {
+        loading.value = false;
+        loadingMore.value = false;
+      }
+    }
+  }
+
+  async function markThreadRead(entry: WasmThreadEntry) {
+    const client = options.xmppClient.value;
+    if (!client) return;
+    markingReadKey.value = threadKey(entry);
+    try {
+      await client.markInboxRead(entry.channel, entry.thread_id);
+      await fetchThreadsPage(false);
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : String(err);
+    } finally {
+      markingReadKey.value = null;
+    }
+  }
+
+  watch(requestState, () => {
+    updateUrl();
+    void fetchThreadsPage(false);
+  });
+
+  watch(options.xmppClient, (client) => {
+    if (client) void fetchThreadsPage(false);
+  });
+
+  return {
+    active,
+    channel,
+    channelFilterMessage,
+    channelFilterOptionLabel,
+    entries,
+    error,
+    fetchThreadsPage,
+    filterState,
+    following,
+    hasEntries,
+    loading,
+    loadingMore,
+    markThreadRead,
+    markingReadKey,
+    nextCursor,
+    resultSummary,
+    search,
+    sections,
+    selectableChannels,
+    sort,
+    status,
+    threadKey,
+    total,
+    unread,
+    unreadThreads,
+  };
+}

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -1,5 +1,6 @@
 import { withSpan } from "@/lib/telemetry";
 import { inferredFileDisposition } from "@/lib/chat-ui";
+import type { ThreadsSort, ThreadsStatusFilter } from "@/lib/threads-view-filters";
 import type { MemberSummary, UserSearchResult } from "../chat-types";
 import type { WaddleSession } from "../server-auth";
 import {
@@ -2040,11 +2041,24 @@ export class BrowserXmppClient {
    * Returns an empty page when the wasm client lacks the method or the
    * server doesn't respond — callers can render the empty state.
    */
-  async fetchThreads(opts: { pageSize?: number; afterCursor?: string } = {}): Promise<WasmThreadsPage> {
+  async fetchThreads(opts: {
+    pageSize?: number;
+    afterCursor?: string;
+    status?: ThreadsStatusFilter;
+    activeSince?: string;
+    channel?: string;
+    search?: string;
+    sort?: ThreadsSort;
+  } = {}): Promise<WasmThreadsPage> {
     const xmpp = await this.requireConnectedXmpp();
     const payload: WasmFetchThreadsOptions = {
       ...(typeof opts.pageSize === "number" ? { page_size: opts.pageSize } : {}),
       ...(opts.afterCursor ? { after_cursor: opts.afterCursor } : {}),
+      ...(opts.status ? { status: opts.status } : {}),
+      ...(opts.activeSince ? { active_since: opts.activeSince } : {}),
+      ...(opts.channel ? { channel: opts.channel } : {}),
+      ...(opts.search ? { search: opts.search } : {}),
+      ...(opts.sort ? { sort: opts.sort } : {}),
     };
     const raw = await xmpp.fetch_threads?.(payload) as WasmThreadsPage | undefined;
     return raw ?? { total: 0, unread_threads: 0, entries: [] };

--- a/chat/src/lib/xmpp/wasm-types.ts
+++ b/chat/src/lib/xmpp/wasm-types.ts
@@ -357,6 +357,11 @@ export interface WasmThreadsPage {
 export interface WasmFetchThreadsOptions {
   page_size?: number;
   after_cursor?: string;
+  status?: "all" | "unread" | "following";
+  active_since?: string;
+  channel?: string;
+  search?: string;
+  sort?: "recent" | "unread" | "replies";
 }
 
 /** XEP-0490 §3 displayed entry surfaced from the wasm boundary. */

--- a/chat/tests/threads-list-panel.test.ts
+++ b/chat/tests/threads-list-panel.test.ts
@@ -1,85 +1,15 @@
-// Tests for `ThreadsListPanel.vue` — the global Threads view.
-//
-// Mirrors the test pattern used by `user-profile-drawer.test.ts`:
-// a small in-memory model that captures the same fetch + partition
-// decisions the component makes, exercised against a stubbed
-// `BrowserXmppClient.fetchThreads`.
-
 import { describe, expect, mock, test } from "bun:test";
+import { effectScope, nextTick, ref } from "vue";
+import { useThreadsListPanelState, type ThreadsViewClient } from "../src/lib/threads-view-state";
+import type { ChannelSummary } from "../src/lib/chat-types";
 import type { WasmThreadEntry, WasmThreadsPage } from "../src/lib/xmpp/wasm-types";
-
-interface PanelClient {
-  fetchThreads: (opts: { pageSize?: number }) => Promise<WasmThreadsPage>;
-}
-
-interface PanelState {
-  loading: boolean;
-  page: WasmThreadsPage | null;
-  error: string | null;
-}
-
-interface PanelView {
-  unread: WasmThreadEntry[];
-  following: WasmThreadEntry[];
-  isEmpty: boolean;
-  errorText: string | null;
-}
-
-/**
- * Mirrors `ThreadsListPanel.vue`'s on-mount flow: call fetchThreads,
- * record the result, then partition into Unread (has_unread) and
- * Following (!has_unread).
- */
-function createPanel(client: PanelClient | null) {
-  const state: PanelState = {
-    loading: true,
-    page: null,
-    error: null,
-  };
-
-  async function mount() {
-    if (!client) {
-      state.loading = false;
-      return;
-    }
-    try {
-      state.page = await client.fetchThreads({ pageSize: 50 });
-    } catch (err) {
-      state.error = err instanceof Error ? err.message : String(err);
-    } finally {
-      state.loading = false;
-    }
-  }
-
-  function view(): PanelView {
-    const entries = state.page?.entries ?? [];
-    const unread = entries.filter((entry) => entry.has_unread);
-    const following = entries.filter((entry) => !entry.has_unread);
-    return {
-      unread,
-      following,
-      isEmpty: !state.loading && !state.error && unread.length === 0 && following.length === 0,
-      errorText: state.error,
-    };
-  }
-
-  function openThreadEvents() {
-    const captured: Array<{ entry: WasmThreadEntry }> = [];
-    function emit(entry: WasmThreadEntry) {
-      captured.push({ entry });
-    }
-    return { emit, captured };
-  }
-
-  return { state, mount, view, openThreadEvents };
-}
 
 function makeEntry(overrides: Partial<WasmThreadEntry> = {}): WasmThreadEntry {
   return {
     channel: "room@x",
     thread_id: "t",
     last_stanza_id: "S",
-    last_activity: new Date().toISOString(),
+    last_activity: new Date("2026-06-02T10:00:00.000Z").toISOString(),
     unread: 0,
     reply_count: 0,
     has_unread: false,
@@ -87,81 +17,235 @@ function makeEntry(overrides: Partial<WasmThreadEntry> = {}): WasmThreadEntry {
   };
 }
 
-describe("ThreadsListPanel", () => {
-  test("renders empty state when no entries", async () => {
-    const client: PanelClient = {
-      fetchThreads: mock(async () => ({
-        total: 0,
-        unread_threads: 0,
-        entries: [],
-      })),
+function page(entries: WasmThreadEntry[], nextCursor?: string): WasmThreadsPage {
+  return {
+    total: entries.length,
+    unread_threads: entries.filter((entry) => entry.has_unread).length,
+    entries,
+    ...(nextCursor ? { next_cursor: nextCursor } : {}),
+  };
+}
+
+function flushWatchers() {
+  return nextTick().then(() => Promise.resolve());
+}
+
+function createPanel(options: {
+  client?: ThreadsViewClient | null;
+  channels?: ChannelSummary[];
+  search?: string;
+} = {}) {
+  const scope = effectScope();
+  const clientRef = ref<ThreadsViewClient | null>(options.client ?? null);
+  const channelsRef = ref<ChannelSummary[]>(options.channels ?? []);
+  const replacedSearch: string[] = [];
+  let currentSearch = options.search ?? "";
+  const panel = scope.run(() =>
+    useThreadsListPanelState({
+      xmppClient: clientRef,
+      channels: channelsRef,
+      now: () => new Date("2026-06-02T12:00:00.000Z"),
+      urlState: {
+        readSearch: () => currentSearch,
+        replaceSearch: (encoded) => {
+          currentSearch = encoded ? `?${encoded}` : "";
+          replacedSearch.push(encoded);
+        },
+      },
+    }),
+  );
+  if (!panel) throw new Error("failed to create panel state");
+  return { channelsRef, clientRef, currentSearch: () => currentSearch, panel, replacedSearch, scope };
+}
+
+describe("ThreadsListPanel state", () => {
+  test("fetches the default protocol-backed page", async () => {
+    const client: ThreadsViewClient = {
+      fetchThreads: mock(async () => page([])),
+      markInboxRead: mock(async () => {}),
     };
-    const panel = createPanel(client);
-    await panel.mount();
-    const view = panel.view();
-    expect(view.isEmpty).toBe(true);
-    expect(view.unread).toHaveLength(0);
-    expect(view.following).toHaveLength(0);
+    const { panel, scope } = createPanel({ client });
+
+    await panel.fetchThreadsPage(false);
+
+    expect(client.fetchThreads).toHaveBeenCalledTimes(1);
+    expect(client.fetchThreads.mock.calls[0]?.[0]).toEqual({
+      pageSize: 50,
+      status: "all",
+      sort: "recent",
+    });
+    expect(panel.hasEntries.value).toBe(false);
+    scope.stop();
   });
 
-  test("splits unread and following sections", async () => {
-    const client: PanelClient = {
-      fetchThreads: mock(async () => ({
-        total: 3,
-        unread_threads: 2,
-        entries: [
-          makeEntry({ thread_id: "t1", has_unread: true, unread: 2 }),
-          makeEntry({ thread_id: "t2", has_unread: false }),
-          makeEntry({ thread_id: "t3", has_unread: true, unread: 1 }),
-        ],
-      })),
+  test("filter refs drive fetch options, URL state, and cursor reset", async () => {
+    const client: ThreadsViewClient = {
+      fetchThreads: mock(async (opts) =>
+        page([makeEntry({ thread_id: opts?.afterCursor ?? "first" })], "cursor-1"),
+      ),
+      markInboxRead: mock(async () => {}),
     };
-    const panel = createPanel(client);
-    await panel.mount();
-    const view = panel.view();
-    expect(view.unread.map((e) => e.thread_id)).toEqual(["t1", "t3"]);
-    expect(view.following.map((e) => e.thread_id)).toEqual(["t2"]);
-    expect(view.isEmpty).toBe(false);
+    const { panel, replacedSearch, scope } = createPanel({
+      client,
+      channels: [{ id: "chat", name: "Chat", jid: "chat@muc.waddle.chat" }],
+    });
+
+    await panel.fetchThreadsPage(false);
+    await panel.fetchThreadsPage(true);
+
+    panel.status.value = "unread";
+    panel.active.value = "14d";
+    panel.channel.value = "chat";
+    panel.search.value = " notifications ";
+    panel.sort.value = "replies";
+    await flushWatchers();
+
+    expect(client.fetchThreads.mock.calls[1]?.[0]).toMatchObject({
+      afterCursor: "cursor-1",
+    });
+    expect(client.fetchThreads.mock.calls.at(-1)?.[0]).toEqual({
+      pageSize: 50,
+      status: "unread",
+      activeSince: "2026-05-19T00:00:00.000Z",
+      channel: "chat@muc.waddle.chat",
+      search: "notifications",
+      sort: "replies",
+    });
+    expect(replacedSearch.at(-1)).toBe(
+      "status=unread&active=14d&channel=chat&q=notifications&sort=replies",
+    );
+    scope.stop();
   });
 
-  test("openThread captures click target", async () => {
-    const entry = makeEntry({ thread_id: "click-me", has_unread: true, unread: 1 });
-    const client: PanelClient = {
-      fetchThreads: mock(async () => ({
-        total: 1,
-        unread_threads: 1,
-        entries: [entry],
-      })),
+  test("restored channel filters wait for channel metadata before fetching", async () => {
+    const client: ThreadsViewClient = {
+      fetchThreads: mock(async () => page([makeEntry({ thread_id: "chat-thread" })])),
+      markInboxRead: mock(async () => {}),
     };
-    const panel = createPanel(client);
-    await panel.mount();
-    const events = panel.openThreadEvents();
-    // Simulate a click on the first unread row.
-    const target = panel.view().unread[0];
-    expect(target).toBeDefined();
-    if (target) events.emit(target);
-    expect(events.captured).toHaveLength(1);
-    expect(events.captured[0]?.entry.thread_id).toBe("click-me");
+    const { channelsRef, panel, scope } = createPanel({
+      client,
+      search: "?channel=chat",
+    });
+
+    await panel.fetchThreadsPage(false);
+    expect(client.fetchThreads).not.toHaveBeenCalled();
+    expect(panel.hasEntries.value).toBe(false);
+    expect(panel.channelFilterMessage.value).toBe(
+      "Waiting for channel metadata before filtering threads.",
+    );
+    expect(panel.channelFilterOptionLabel.value).toBe("Loading selected channel");
+
+    channelsRef.value = [{ id: "chat", name: "Chat", jid: "chat@muc.waddle.chat" }];
+    await flushWatchers();
+
+    expect(client.fetchThreads).toHaveBeenCalledTimes(1);
+    expect(client.fetchThreads.mock.calls[0]?.[0]).toMatchObject({
+      channel: "chat@muc.waddle.chat",
+    });
+    expect(panel.channelFilterMessage.value).toBe("");
+    expect(panel.channelFilterOptionLabel.value).toBe("");
+    scope.stop();
+  });
+
+  test("unresolved restored channel filters expose an unavailable-channel state", async () => {
+    const client: ThreadsViewClient = {
+      fetchThreads: mock(async () => page([])),
+      markInboxRead: mock(async () => {}),
+    };
+    const { panel, scope } = createPanel({
+      client,
+      channels: [{ id: "chat", name: "Chat", jid: "chat@muc.waddle.chat" }],
+      search: "?channel=missing",
+    });
+
+    await panel.fetchThreadsPage(false);
+
+    expect(client.fetchThreads).not.toHaveBeenCalled();
+    expect(panel.hasEntries.value).toBe(false);
+    expect(panel.channelFilterMessage.value).toBe("Selected channel is no longer available.");
+    expect(panel.channelFilterOptionLabel.value).toBe("Selected channel unavailable");
+    scope.stop();
+  });
+
+  test("sections preserve server order for all results and specialize filtered views", async () => {
+    const following = makeEntry({ thread_id: "f1", has_unread: false });
+    const unread = makeEntry({ thread_id: "u1", has_unread: true, unread: 2 });
+    const client: ThreadsViewClient = {
+      fetchThreads: mock(async (opts) => {
+        if (opts?.status === "unread") return page([unread]);
+        if (opts?.status === "following") return page([following]);
+        return page([following, unread]);
+      }),
+      markInboxRead: mock(async () => {}),
+    };
+    const { panel, scope } = createPanel({ client });
+
+    await panel.fetchThreadsPage(false);
+    expect(panel.sections.value).toHaveLength(1);
+    expect(panel.sections.value[0]?.label).toBe("All");
+    expect(panel.sections.value[0]?.entries.map((entry) => entry.thread_id)).toEqual(["f1", "u1"]);
+
+    panel.status.value = "unread";
+    await flushWatchers();
+    expect(panel.sections.value[0]?.label).toBe("Unread");
+    expect(panel.sections.value[0]?.entries.map((entry) => entry.thread_id)).toEqual(["u1"]);
+
+    panel.status.value = "following";
+    await flushWatchers();
+    expect(panel.sections.value[0]?.label).toBe("Following");
+    expect(panel.sections.value[0]?.entries.map((entry) => entry.thread_id)).toEqual(["f1"]);
+    scope.stop();
+  });
+
+  test("mark read calls the thread-aware inbox API and refetches the first page", async () => {
+    const entry = makeEntry({
+      channel: "chat@muc.waddle.chat",
+      thread_id: "thread-1",
+      has_unread: true,
+      unread: 3,
+    });
+    const client: ThreadsViewClient = {
+      fetchThreads: mock(async () => page([entry])),
+      markInboxRead: mock(async () => {}),
+    };
+    const { panel, scope } = createPanel({ client });
+
+    await panel.fetchThreadsPage(false);
+    await panel.markThreadRead(entry);
+
+    expect(client.markInboxRead).toHaveBeenCalledWith("chat@muc.waddle.chat", "thread-1");
+    expect(client.fetchThreads).toHaveBeenCalledTimes(2);
+    expect(client.fetchThreads.mock.calls[1]?.[0]).toEqual({
+      pageSize: 50,
+      status: "all",
+      sort: "recent",
+    });
+    scope.stop();
   });
 
   test("surfaces fetch errors", async () => {
-    const client: PanelClient = {
+    const client: ThreadsViewClient = {
       fetchThreads: mock(async () => {
         throw new Error("boom");
       }),
+      markInboxRead: mock(async () => {}),
     };
-    const panel = createPanel(client);
-    await panel.mount();
-    const view = panel.view();
-    expect(view.errorText).toBe("boom");
-    expect(view.isEmpty).toBe(false);
+    const { panel, scope } = createPanel({ client });
+
+    await panel.fetchThreadsPage(false);
+
+    expect(panel.error.value).toBe("boom");
+    expect(panel.hasEntries.value).toBe(false);
+    scope.stop();
   });
 
   test("no client renders empty without fetching", async () => {
-    const panel = createPanel(null);
-    await panel.mount();
-    expect(panel.state.loading).toBe(false);
-    expect(panel.state.page).toBeNull();
-    expect(panel.view().isEmpty).toBe(true);
+    const { panel, scope } = createPanel();
+
+    await panel.fetchThreadsPage(false);
+
+    expect(panel.loading.value).toBe(false);
+    expect(panel.hasEntries.value).toBe(false);
+    scope.stop();
   });
 });

--- a/chat/tests/threads-view-filters.test.ts
+++ b/chat/tests/threads-view-filters.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import {
+  activeSinceIso,
+  decodeThreadsFilterState,
+  encodeThreadsFilterState,
+  threadDisplayTitle,
+} from "../src/lib/threads-view-filters";
+
+describe("threads view filters", () => {
+  test("decodes supported URL params and falls back on invalid values", () => {
+    expect(decodeThreadsFilterState("?status=unread&active=14d&channel=chat&q=push&sort=replies")).toEqual({
+      status: "unread",
+      active: "14d",
+      channel: "chat",
+      query: "push",
+      sort: "replies",
+    });
+    expect(decodeThreadsFilterState("?status=stale&active=99d&sort=hot")).toEqual({
+      status: "all",
+      active: "all",
+      channel: "all",
+      query: "",
+      sort: "recent",
+    });
+  });
+
+  test("encodes only non-default URL params", () => {
+    expect(
+      encodeThreadsFilterState({
+        status: "following",
+        active: "30d",
+        channel: "chat",
+        query: " notifications ",
+        sort: "unread",
+      }),
+    ).toBe("status=following&active=30d&channel=chat&q=notifications&sort=unread");
+    expect(
+      encodeThreadsFilterState({
+        status: "all",
+        active: "all",
+        channel: "all",
+        query: "",
+        sort: "recent",
+      }),
+    ).toBe("");
+  });
+
+  test("computes active-since timestamps from fixed windows", () => {
+    const now = new Date("2026-06-02T12:00:00.000Z");
+    expect(activeSinceIso("7d", now)).toBe("2026-05-26T00:00:00.000Z");
+    expect(activeSinceIso("14d", now)).toBe("2026-05-19T00:00:00.000Z");
+    expect(activeSinceIso("30d", now)).toBe("2026-05-03T00:00:00.000Z");
+    expect(activeSinceIso("all", now)).toBeUndefined();
+  });
+
+  test("normalizes noisy previews for thread rows", () => {
+    expect(threadDisplayTitle({ preview: "> Notifications failed" })).toBe("Notifications failed");
+    expect(threadDisplayTitle({ preview: "https://media3.giphy.com/media/example/giphy.gif" })).toBe("Media attachment");
+    expect(threadDisplayTitle({ preview: "https://example.com/cat.webp" })).toBe("Media attachment");
+    expect(threadDisplayTitle({})).toBe("Thread");
+  });
+});

--- a/server/crates/waddle-server/src/threads/handler.rs
+++ b/server/crates/waddle-server/src/threads/handler.rs
@@ -7,8 +7,8 @@ use jid::BareJid;
 use minidom::Element;
 use xmpp_parsers::iq::Iq;
 
-use super::query::{ThreadsError, DEFAULT_PAGE_SIZE, NS_THREADS};
-use super::storage::ThreadsStorage;
+use super::query::{ThreadsError, NS_THREADS};
+use super::storage::{ThreadsStorage, ThreadsStorageError};
 use super::wire::{build_threads_response, parse_threads_query};
 
 /// Discriminator: does this IQ carry the `urn:waddle:threads:0` query?
@@ -58,14 +58,12 @@ pub async fn handle_threads_iq(
         Err(err) => return ThreadsIqOutcome::BadRequest(err),
     };
 
-    let page_size = query.page_size.unwrap_or(DEFAULT_PAGE_SIZE);
-
-    match storage
-        .page(requester, page_size, query.after_cursor.as_deref())
-        .await
-    {
+    match storage.page(requester, &query).await {
         Ok(page) => ThreadsIqOutcome::Result(build_threads_response(&page)),
-        Err(error) => ThreadsIqOutcome::InternalError(error.to_string()),
+        Err(ThreadsStorageError::BadRequest(error)) => ThreadsIqOutcome::BadRequest(error),
+        Err(ThreadsStorageError::Inbox(error)) => {
+            ThreadsIqOutcome::InternalError(error.to_string())
+        }
     }
 }
 

--- a/server/crates/waddle-server/src/threads/query.rs
+++ b/server/crates/waddle-server/src/threads/query.rs
@@ -12,13 +12,85 @@ pub const DEFAULT_PAGE_SIZE: u32 = 50;
 /// Hard cap on `<set><max>` requested by clients. Same cap as inbox.
 pub const MAX_PAGE_SIZE: u32 = 200;
 
+/// Status filter for the global threads view.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ThreadStatusFilter {
+    #[default]
+    All,
+    Unread,
+    Following,
+}
+
+impl ThreadStatusFilter {
+    pub fn parse(raw: &str) -> Result<Self, ThreadsError> {
+        match raw {
+            "all" => Ok(Self::All),
+            "unread" => Ok(Self::Unread),
+            "following" => Ok(Self::Following),
+            other => Err(ThreadsError::InvalidStatus(other.to_string())),
+        }
+    }
+}
+
+/// Sort order for the global threads view.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ThreadSort {
+    #[default]
+    Recent,
+    Unread,
+    Replies,
+}
+
+impl ThreadSort {
+    pub fn parse(raw: &str) -> Result<Self, ThreadsError> {
+        match raw {
+            "recent" => Ok(Self::Recent),
+            "unread" => Ok(Self::Unread),
+            "replies" => Ok(Self::Replies),
+            other => Err(ThreadsError::InvalidSort(other.to_string())),
+        }
+    }
+}
+
 /// A `<query xmlns='urn:waddle:threads:0'/>` request.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ThreadsQuery {
-    /// RSM `<max>` — clamped to `MAX_PAGE_SIZE` at parse time.
+    /// RSM `<max>` requested by the client. Storage clamps this to
+    /// `MAX_PAGE_SIZE` after parsing and treats `0` as a count-only request.
     pub page_size: Option<u32>,
     /// RSM `<after>` cursor — opaque string the server emitted previously.
     pub after_cursor: Option<String>,
+    pub status: ThreadStatusFilter,
+    /// RFC 3339 `active-since` converted to Unix seconds.
+    pub active_since_secs: Option<i64>,
+    pub channel: Option<BareJid>,
+    pub search: Option<String>,
+    pub sort: ThreadSort,
+}
+
+/// Display identity of the thread starter as materialised by the inbox.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ThreadRootAuthor(String);
+
+impl ThreadRootAuthor {
+    pub fn parse(raw: impl Into<String>) -> Option<Self> {
+        let value = raw.into().trim().to_string();
+        if value.is_empty() {
+            None
+        } else {
+            Some(Self(value))
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for ThreadRootAuthor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
 }
 
 /// One row in a `<threads>` response.
@@ -31,7 +103,7 @@ pub struct ThreadEntry {
     pub last_activity_secs: i64,
     pub unread: u32,
     pub reply_count: u32,
-    pub root_author: Option<BareJid>,
+    pub root_author: Option<ThreadRootAuthor>,
     pub preview: Option<String>,
     pub thread_title: Option<String>,
 }
@@ -61,6 +133,16 @@ pub enum ThreadsError {
     ExpectedElement(&'static str),
     #[error("invalid integer '{0}'")]
     InvalidInteger(String),
+    #[error("invalid status filter '{0}'")]
+    InvalidStatus(String),
+    #[error("invalid sort '{0}'")]
+    InvalidSort(String),
+    #[error("invalid active-since timestamp '{0}'")]
+    InvalidTimestamp(String),
+    #[error("invalid channel JID '{0}'")]
+    InvalidChannel(String),
+    #[error("invalid RSM cursor")]
+    InvalidCursor,
     #[error("payload is not the expected IQ type")]
     WrongIqType,
 }

--- a/server/crates/waddle-server/src/threads/storage.rs
+++ b/server/crates/waddle-server/src/threads/storage.rs
@@ -2,6 +2,7 @@
 //! the existing `InboxStorage::list_all_threads` contract — no new
 //! schema, and works with both the SQL and in-memory inbox backends.
 
+use std::cmp::Ordering;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -12,7 +13,18 @@ use serde::{Deserialize, Serialize};
 use waddle_xmpp::inbox::storage::{InboxStorage, InboxStorageError};
 use waddle_xmpp::inbox::InboxEntry;
 
-use super::query::{ThreadEntry, ThreadsPage, MAX_PAGE_SIZE};
+use super::query::{
+    ThreadEntry, ThreadRootAuthor, ThreadSort, ThreadStatusFilter, ThreadsError, ThreadsPage,
+    ThreadsQuery, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE,
+};
+
+#[derive(Debug, thiserror::Error)]
+pub enum ThreadsStorageError {
+    #[error("bad threads query: {0}")]
+    BadRequest(#[from] ThreadsError),
+    #[error(transparent)]
+    Inbox(#[from] InboxStorageError),
+}
 
 /// Read trait for the threads view. Implementations read per-thread
 /// inbox rows from whichever backend the inbox storage is using.
@@ -21,9 +33,8 @@ pub trait ThreadsStorage: Send + Sync {
     async fn page(
         &self,
         user_jid: &BareJid,
-        page_size: u32,
-        after_cursor: Option<&str>,
-    ) -> Result<ThreadsPage, InboxStorageError>;
+        query: &ThreadsQuery,
+    ) -> Result<ThreadsPage, ThreadsStorageError>;
 }
 
 /// Default implementation: layers RSM-style pagination on top of an
@@ -41,52 +52,196 @@ impl InboxBackedThreadsStorage {
     }
 }
 
-/// Opaque RSM cursor — Base64URL-encoded JSON. Stable as long as the
-/// `(last_updated, partner_jid, thread_id)` triple is preserved.
+/// Opaque RSM cursor — Base64URL-encoded JSON. It records the active
+/// sort mode plus the relevant sort keys (`last_updated`, `unread`,
+/// `reply_count`) and stable tiebreakers (`partner_jid`, `thread_id`).
+/// Reusing a cursor with a different sort mode is rejected as invalid.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct Cursor {
+    sort: CursorSort,
     last_updated: i64,
+    unread: u32,
+    reply_count: u32,
     partner_jid: String,
     thread_id: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum CursorSort {
+    Recent,
+    Unread,
+    Replies,
+}
+
+impl From<ThreadSort> for CursorSort {
+    fn from(sort: ThreadSort) -> Self {
+        match sort {
+            ThreadSort::Recent => Self::Recent,
+            ThreadSort::Unread => Self::Unread,
+            ThreadSort::Replies => Self::Replies,
+        }
+    }
+}
+
 impl Cursor {
-    fn from_entry(entry: &ThreadEntry) -> Self {
+    fn from_entry(entry: &ThreadEntry, sort: ThreadSort) -> Self {
         Self {
+            sort: CursorSort::from(sort),
             last_updated: entry.last_activity_secs,
+            unread: entry.unread,
+            reply_count: entry.reply_count,
             partner_jid: entry.channel.to_string(),
             thread_id: entry.thread_id.clone(),
         }
     }
 
-    fn encode(&self) -> Result<String, InboxStorageError> {
+    fn encode(&self) -> Result<String, ThreadsStorageError> {
         let json = serde_json::to_vec(self)
             .map_err(|error| InboxStorageError::Other(format!("cursor encode: {error}")))?;
         Ok(URL_SAFE_NO_PAD.encode(json))
     }
 
-    fn decode(raw: &str) -> Result<Self, InboxStorageError> {
+    fn decode(raw: &str) -> Result<Self, ThreadsError> {
         let bytes = URL_SAFE_NO_PAD
             .decode(raw)
-            .map_err(|error| InboxStorageError::Other(format!("cursor decode: {error}")))?;
-        serde_json::from_slice::<Cursor>(&bytes)
-            .map_err(|error| InboxStorageError::Other(format!("cursor json: {error}")))
+            .map_err(|_| ThreadsError::InvalidCursor)?;
+        serde_json::from_slice::<Cursor>(&bytes).map_err(|_| ThreadsError::InvalidCursor)
     }
 }
 
-/// Sort order: `last_updated DESC`, then `partner_jid ASC`, then
-/// `thread_id ASC`. Inverted because the row with the *greatest*
-/// `last_updated` is considered the "smallest" position in the ordered
-/// list (it appears first).
-fn entry_is_after_cursor(entry: &ThreadEntry, cursor: &Cursor) -> bool {
-    if entry.last_activity_secs != cursor.last_updated {
-        return entry.last_activity_secs < cursor.last_updated;
+fn compare_entry_tiebreakers(
+    left_channel: &BareJid,
+    left_thread_id: &str,
+    right_channel: &BareJid,
+    right_thread_id: &str,
+) -> Ordering {
+    left_channel
+        .cmp(right_channel)
+        .then_with(|| left_thread_id.cmp(right_thread_id))
+}
+
+fn compare_entry_to_cursor_tiebreakers(
+    entry_channel: &BareJid,
+    entry_thread_id: &str,
+    cursor_partner_jid: &str,
+    cursor_thread_id: &str,
+) -> Ordering {
+    entry_channel
+        .as_str()
+        .cmp(cursor_partner_jid)
+        .then_with(|| entry_thread_id.cmp(cursor_thread_id))
+}
+
+fn compare_entries(left: &ThreadEntry, right: &ThreadEntry, sort: ThreadSort) -> Ordering {
+    match sort {
+        ThreadSort::Recent => right.last_activity_secs.cmp(&left.last_activity_secs),
+        ThreadSort::Unread => right
+            .unread
+            .cmp(&left.unread)
+            .then_with(|| right.last_activity_secs.cmp(&left.last_activity_secs)),
+        ThreadSort::Replies => right
+            .reply_count
+            .cmp(&left.reply_count)
+            .then_with(|| right.last_activity_secs.cmp(&left.last_activity_secs)),
     }
-    let partner = entry.channel.to_string();
-    if partner != cursor.partner_jid {
-        return partner > cursor.partner_jid;
+    .then_with(|| {
+        compare_entry_tiebreakers(
+            &left.channel,
+            &left.thread_id,
+            &right.channel,
+            &right.thread_id,
+        )
+    })
+}
+
+fn compare_entry_to_cursor(entry: &ThreadEntry, cursor: &Cursor, sort: ThreadSort) -> Ordering {
+    match sort {
+        ThreadSort::Recent => cursor.last_updated.cmp(&entry.last_activity_secs),
+        ThreadSort::Unread => cursor
+            .unread
+            .cmp(&entry.unread)
+            .then_with(|| cursor.last_updated.cmp(&entry.last_activity_secs)),
+        ThreadSort::Replies => cursor
+            .reply_count
+            .cmp(&entry.reply_count)
+            .then_with(|| cursor.last_updated.cmp(&entry.last_activity_secs)),
     }
-    entry.thread_id > cursor.thread_id
+    .then_with(|| {
+        compare_entry_to_cursor_tiebreakers(
+            &entry.channel,
+            &entry.thread_id,
+            &cursor.partner_jid,
+            &cursor.thread_id,
+        )
+    })
+}
+
+fn entry_is_after_cursor(entry: &ThreadEntry, cursor: &Cursor, sort: ThreadSort) -> bool {
+    compare_entry_to_cursor(entry, cursor, sort).is_gt()
+}
+
+fn channel_localpart(channel: &BareJid) -> String {
+    channel
+        .to_string()
+        .split('@')
+        .next()
+        .unwrap_or("")
+        .to_string()
+}
+
+fn string_matches(haystack: &str, needle: &str) -> bool {
+    haystack.to_lowercase().contains(needle)
+}
+
+fn entry_matches_search(entry: &ThreadEntry, needle: &str) -> bool {
+    entry
+        .thread_title
+        .as_deref()
+        .is_some_and(|title| string_matches(title, needle))
+        || entry
+            .preview
+            .as_deref()
+            .is_some_and(|preview| string_matches(preview, needle))
+        || entry
+            .root_author
+            .as_ref()
+            .is_some_and(|author| string_matches(author.as_str(), needle))
+        || string_matches(&entry.channel.to_string(), needle)
+        || string_matches(&channel_localpart(&entry.channel), needle)
+}
+
+fn entry_matches_query(entry: &ThreadEntry, query: &ThreadsQuery) -> bool {
+    match query.status {
+        ThreadStatusFilter::All => {}
+        ThreadStatusFilter::Unread if entry.unread == 0 => return false,
+        ThreadStatusFilter::Following if entry.unread > 0 => return false,
+        ThreadStatusFilter::Unread | ThreadStatusFilter::Following => {}
+    }
+    if let Some(active_since) = query.active_since_secs {
+        if entry.last_activity_secs < active_since {
+            return false;
+        }
+    }
+    if let Some(ref channel) = query.channel {
+        if &entry.channel != channel {
+            return false;
+        }
+    }
+    if let Some(ref search) = query.search {
+        let needle = search.trim().to_lowercase();
+        if !needle.is_empty() && !entry_matches_search(entry, &needle) {
+            return false;
+        }
+    }
+    true
+}
+
+fn page_size(query: &ThreadsQuery) -> usize {
+    query
+        .page_size
+        .unwrap_or(DEFAULT_PAGE_SIZE)
+        .clamp(0, MAX_PAGE_SIZE) as usize
 }
 
 fn build_thread_entry(row: &InboxEntry) -> Option<ThreadEntry> {
@@ -94,10 +249,7 @@ fn build_thread_entry(row: &InboxEntry) -> Option<ThreadEntry> {
     if thread_id.is_empty() {
         return None;
     }
-    let root_author = row
-        .author
-        .as_ref()
-        .and_then(|author| author.parse::<BareJid>().ok());
+    let root_author = row.author.clone().and_then(ThreadRootAuthor::parse);
     Some(ThreadEntry {
         channel: row.partner.clone(),
         thread_id,
@@ -116,51 +268,67 @@ impl ThreadsStorage for InboxBackedThreadsStorage {
     async fn page(
         &self,
         user_jid: &BareJid,
-        page_size: u32,
-        after_cursor: Option<&str>,
-    ) -> Result<ThreadsPage, InboxStorageError> {
-        let limit = page_size.clamp(1, MAX_PAGE_SIZE) as usize;
-        let cursor = match after_cursor {
-            Some(raw) => Some(Cursor::decode(raw)?),
+        query: &ThreadsQuery,
+    ) -> Result<ThreadsPage, ThreadsStorageError> {
+        let limit = page_size(query);
+        let cursor = match query.after_cursor.as_deref() {
+            Some(raw) => {
+                let cursor = Cursor::decode(raw).map_err(ThreadsStorageError::BadRequest)?;
+                if cursor.sort != CursorSort::from(query.sort) {
+                    return Err(ThreadsStorageError::BadRequest(ThreadsError::InvalidCursor));
+                }
+                Some(cursor)
+            }
             None => None,
         };
 
-        let mut all_rows = self.inbox.list_all_threads(user_jid).await?;
-        // Backend MAY return rows already ordered; re-sort defensively
-        // to make this layer the single source of truth for ordering.
-        all_rows.sort_by(|a, b| {
-            b.last_updated
-                .cmp(&a.last_updated)
-                .then_with(|| a.partner.to_string().cmp(&b.partner.to_string()))
-                .then_with(|| {
-                    a.thread_id
-                        .as_deref()
-                        .unwrap_or("")
-                        .cmp(b.thread_id.as_deref().unwrap_or(""))
-                })
-        });
+        let mut filtered: Vec<ThreadEntry> = self
+            .inbox
+            .list_all_threads(user_jid)
+            .await?
+            .iter()
+            .filter_map(build_thread_entry)
+            .filter(|entry| entry_matches_query(entry, query))
+            .collect();
+        filtered.sort_by(|left, right| compare_entries(left, right, query.sort));
 
-        let total: u64 = all_rows.len() as u64;
-        let unread_threads: u64 = all_rows.iter().filter(|e| e.unread > 0).count() as u64;
+        let total: u64 = filtered.len() as u64;
+        let unread_threads: u64 = filtered.iter().filter(|e| e.unread > 0).count() as u64;
+        if limit == 0 {
+            return Ok(ThreadsPage {
+                entries: Vec::new(),
+                total,
+                unread_threads,
+                first_cursor: None,
+                last_cursor: None,
+            });
+        }
 
         let mut entries: Vec<ThreadEntry> = Vec::with_capacity(limit);
-        for row in all_rows {
-            let Some(entry) = build_thread_entry(&row) else {
-                continue;
-            };
+        let mut has_more = false;
+        for entry in filtered {
             if let Some(ref c) = cursor {
-                if !entry_is_after_cursor(&entry, c) {
+                if !entry_is_after_cursor(&entry, c, query.sort) {
                     continue;
                 }
             }
-            entries.push(entry);
             if entries.len() >= limit {
+                has_more = true;
                 break;
             }
+            entries.push(entry);
         }
 
-        let first_cursor = entries.first().map(Cursor::from_entry);
-        let last_cursor = entries.last().map(Cursor::from_entry);
+        let first_cursor = entries
+            .first()
+            .map(|entry| Cursor::from_entry(entry, query.sort));
+        let last_cursor = has_more
+            .then(|| {
+                entries
+                    .last()
+                    .map(|entry| Cursor::from_entry(entry, query.sort))
+            })
+            .flatten();
         let first_cursor = match first_cursor {
             Some(c) => Some(c.encode()?),
             None => None,
@@ -198,6 +366,21 @@ mod tests {
         );
         let threads = InboxBackedThreadsStorage::new(inbox.clone());
         (inbox, threads)
+    }
+
+    fn threads_query(page_size: u32) -> ThreadsQuery {
+        ThreadsQuery {
+            page_size: Some(page_size),
+            ..Default::default()
+        }
+    }
+
+    fn threads_query_after(page_size: u32, after_cursor: String) -> ThreadsQuery {
+        ThreadsQuery {
+            page_size: Some(page_size),
+            after_cursor: Some(after_cursor),
+            ..Default::default()
+        }
     }
 
     #[tokio::test]
@@ -249,7 +432,7 @@ mod tests {
             .await
             .expect("upsert t2");
 
-        let page = threads.page(&user, 50, None).await.expect("page");
+        let page = threads.page(&user, &threads_query(50)).await.expect("page");
         assert_eq!(page.entries.len(), 2, "expected 2 thread rows");
         assert!(page.entries.iter().all(|e| !e.thread_id.is_empty()));
         assert_eq!(page.total, 2);
@@ -289,7 +472,7 @@ mod tests {
             .await
             .expect("upsert newer");
 
-        let page = threads.page(&user, 50, None).await.expect("page");
+        let page = threads.page(&user, &threads_query(50)).await.expect("page");
         assert_eq!(page.entries.len(), 2);
         assert_eq!(page.entries[0].thread_id, "t-new");
         assert_eq!(page.entries[1].thread_id, "t-old");
@@ -317,7 +500,10 @@ mod tests {
                 .expect("upsert");
         }
 
-        let first = threads.page(&user, 2, None).await.expect("first page");
+        let first = threads
+            .page(&user, &threads_query(2))
+            .await
+            .expect("first page");
         assert_eq!(first.entries.len(), 2);
         assert_eq!(first.entries[0].thread_id, "t-a");
         assert_eq!(first.entries[1].thread_id, "t-b");
@@ -325,12 +511,99 @@ mod tests {
         let cursor = first.last_cursor.clone().expect("last_cursor");
 
         let second = threads
-            .page(&user, 2, Some(&cursor))
+            .page(&user, &threads_query_after(2, cursor))
             .await
             .expect("second page");
         assert_eq!(second.entries.len(), 1);
         assert_eq!(second.entries[0].thread_id, "t-c");
         assert_eq!(second.total, 3);
+        assert!(
+            second.last_cursor.is_none(),
+            "final page should not advertise a continuation cursor"
+        );
+    }
+
+    #[tokio::test]
+    async fn page_size_zero_returns_count_only() {
+        let (inbox, threads) = make_storage_pair().await;
+        let user = jid("me@example.com");
+
+        inbox
+            .upsert(
+                &user,
+                InboxEntry::new(
+                    jid("room@muc.example"),
+                    ConversationKind::MucRoom,
+                    "s1",
+                    100,
+                )
+                .with_thread("t1"),
+                true,
+            )
+            .await
+            .expect("upsert");
+
+        let page = threads.page(&user, &threads_query(0)).await.expect("page");
+        assert!(page.entries.is_empty());
+        assert_eq!(page.total, 1);
+        assert_eq!(page.unread_threads, 1);
+        assert!(page.first_cursor.is_none());
+        assert!(page.last_cursor.is_none());
+    }
+
+    #[tokio::test]
+    async fn malformed_cursor_is_bad_request() {
+        let (_inbox, threads) = make_storage_pair().await;
+        let user = jid("me@example.com");
+
+        let err = threads
+            .page(&user, &threads_query_after(50, "not-a-cursor".into()))
+            .await
+            .expect_err("malformed cursor should fail");
+        assert!(matches!(
+            err,
+            ThreadsStorageError::BadRequest(ThreadsError::InvalidCursor)
+        ));
+    }
+
+    #[tokio::test]
+    async fn cursor_reused_with_different_sort_is_bad_request() {
+        let (inbox, threads) = make_storage_pair().await;
+        let user = jid("me@example.com");
+        let room = jid("room@muc.example");
+
+        upsert_unread_thread(&inbox, &user, &room, "high", 3, 100).await;
+        upsert_unread_thread(&inbox, &user, &room, "low", 1, 300).await;
+
+        let unread_page = threads
+            .page(
+                &user,
+                &ThreadsQuery {
+                    page_size: Some(1),
+                    sort: ThreadSort::Unread,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("unread sorted page");
+        let cursor = unread_page.last_cursor.expect("continuation cursor");
+
+        let err = threads
+            .page(
+                &user,
+                &ThreadsQuery {
+                    page_size: Some(1),
+                    after_cursor: Some(cursor),
+                    sort: ThreadSort::Recent,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("cross-sort cursor reuse should fail");
+        assert!(matches!(
+            err,
+            ThreadsStorageError::BadRequest(ThreadsError::InvalidCursor)
+        ));
     }
 
     #[tokio::test]
@@ -371,9 +644,423 @@ mod tests {
             .await
             .expect("mark read");
 
-        let page = threads.page(&user, 50, None).await.expect("page");
+        let page = threads.page(&user, &threads_query(50)).await.expect("page");
         assert_eq!(page.total, 2);
         assert_eq!(page.unread_threads, 1);
+    }
+
+    #[tokio::test]
+    async fn page_filters_by_status() {
+        let (inbox, threads) = make_storage_pair().await;
+        let user = jid("me@example.com");
+        let room = jid("room@muc.example");
+
+        inbox
+            .upsert(
+                &user,
+                InboxEntry::new(room.clone(), ConversationKind::MucRoom, "s1", 100)
+                    .with_thread("unread"),
+                true,
+            )
+            .await
+            .expect("upsert unread");
+        inbox
+            .upsert(
+                &user,
+                InboxEntry::new(room, ConversationKind::MucRoom, "s2", 200).with_thread("read"),
+                false,
+            )
+            .await
+            .expect("upsert read");
+
+        let unread = threads
+            .page(
+                &user,
+                &ThreadsQuery {
+                    status: ThreadStatusFilter::Unread,
+                    ..threads_query(50)
+                },
+            )
+            .await
+            .expect("unread page");
+        assert_eq!(unread.entries.len(), 1);
+        assert_eq!(unread.entries[0].thread_id, "unread");
+        assert_eq!(unread.total, 1);
+        assert_eq!(unread.unread_threads, 1);
+
+        let following = threads
+            .page(
+                &user,
+                &ThreadsQuery {
+                    status: ThreadStatusFilter::Following,
+                    ..threads_query(50)
+                },
+            )
+            .await
+            .expect("following page");
+        assert_eq!(following.entries.len(), 1);
+        assert_eq!(following.entries[0].thread_id, "read");
+        assert_eq!(following.total, 1);
+        assert_eq!(following.unread_threads, 0);
+    }
+
+    #[tokio::test]
+    async fn page_filters_by_active_since() {
+        let (inbox, threads) = make_storage_pair().await;
+        let user = jid("me@example.com");
+        let room = jid("room@muc.example");
+
+        for (thread_id, ts) in [("old", 100_i64), ("new", 200)] {
+            inbox
+                .upsert(
+                    &user,
+                    InboxEntry::new(room.clone(), ConversationKind::MucRoom, thread_id, ts)
+                        .with_thread(thread_id),
+                    true,
+                )
+                .await
+                .expect("upsert");
+        }
+
+        let page = threads
+            .page(
+                &user,
+                &ThreadsQuery {
+                    active_since_secs: Some(150),
+                    ..threads_query(50)
+                },
+            )
+            .await
+            .expect("page");
+        assert_eq!(page.total, 1);
+        assert_eq!(page.entries[0].thread_id, "new");
+    }
+
+    #[tokio::test]
+    async fn page_filters_by_channel_and_search() {
+        let (inbox, threads) = make_storage_pair().await;
+        let user = jid("me@example.com");
+        let chat = jid("chat@muc.waddle.chat");
+        let other = jid("random@muc.waddle.chat");
+
+        inbox
+            .upsert(
+                &user,
+                InboxEntry::new(chat.clone(), ConversationKind::MucRoom, "s1", 100)
+                    .with_thread("push")
+                    .with_thread_title("Push debugging")
+                    .with_preview("Notifications failed")
+                    .with_author("alice"),
+                true,
+            )
+            .await
+            .expect("upsert push");
+        inbox
+            .upsert(
+                &user,
+                InboxEntry::new(other, ConversationKind::MucRoom, "s2", 200)
+                    .with_thread("deploy")
+                    .with_thread_title("Deploy notes")
+                    .with_preview("Worker release"),
+                true,
+            )
+            .await
+            .expect("upsert deploy");
+
+        let by_channel = threads
+            .page(
+                &user,
+                &ThreadsQuery {
+                    channel: Some(chat),
+                    ..threads_query(50)
+                },
+            )
+            .await
+            .expect("channel page");
+        assert_eq!(by_channel.total, 1);
+        assert_eq!(by_channel.entries[0].thread_id, "push");
+
+        let by_search = threads
+            .page(
+                &user,
+                &ThreadsQuery {
+                    search: Some("ALICE".into()),
+                    ..threads_query(50)
+                },
+            )
+            .await
+            .expect("search page");
+        assert_eq!(by_search.total, 1);
+        assert_eq!(by_search.entries[0].thread_id, "push");
+
+        let by_preview = threads
+            .page(
+                &user,
+                &ThreadsQuery {
+                    search: Some("worker".into()),
+                    ..threads_query(50)
+                },
+            )
+            .await
+            .expect("preview search page");
+        assert_eq!(by_preview.total, 1);
+        assert_eq!(by_preview.entries[0].thread_id, "deploy");
+    }
+
+    #[tokio::test]
+    async fn page_sorts_by_recent_unread_and_replies() {
+        let (inbox, threads) = make_storage_pair().await;
+        let user = jid("me@example.com");
+        let room = jid("room@muc.example");
+
+        inbox
+            .upsert(
+                &user,
+                InboxEntry::new(room.clone(), ConversationKind::MucRoom, "s-recent", 300)
+                    .with_thread("recent")
+                    .with_reply_count(1),
+                true,
+            )
+            .await
+            .expect("upsert recent");
+        inbox
+            .upsert(
+                &user,
+                InboxEntry::new(room.clone(), ConversationKind::MucRoom, "s-unread-1", 100)
+                    .with_thread("unread"),
+                true,
+            )
+            .await
+            .expect("upsert unread 1");
+        inbox
+            .upsert(
+                &user,
+                InboxEntry::new(room.clone(), ConversationKind::MucRoom, "s-unread-2", 110)
+                    .with_thread("unread"),
+                true,
+            )
+            .await
+            .expect("upsert unread 2");
+        inbox
+            .upsert(
+                &user,
+                InboxEntry::new(room, ConversationKind::MucRoom, "s-replies", 200)
+                    .with_thread("replies")
+                    .with_reply_count(12),
+                false,
+            )
+            .await
+            .expect("upsert replies");
+
+        let recent = threads
+            .page(&user, &threads_query(50))
+            .await
+            .expect("recent page");
+        assert_eq!(recent.entries[0].thread_id, "recent");
+
+        let unread = threads
+            .page(
+                &user,
+                &ThreadsQuery {
+                    sort: ThreadSort::Unread,
+                    ..threads_query(50)
+                },
+            )
+            .await
+            .expect("unread sort");
+        assert_eq!(unread.entries[0].thread_id, "unread");
+
+        let replies = threads
+            .page(
+                &user,
+                &ThreadsQuery {
+                    sort: ThreadSort::Replies,
+                    ..threads_query(50)
+                },
+            )
+            .await
+            .expect("replies sort");
+        assert_eq!(replies.entries[0].thread_id, "replies");
+    }
+
+    #[tokio::test]
+    async fn page_cursor_stays_stable_with_filtered_sort() {
+        let (inbox, threads) = make_storage_pair().await;
+        let user = jid("me@example.com");
+        let room = jid("room@muc.example");
+
+        for (thread_id, ts) in [("a", 300_i64), ("b", 200), ("c", 100)] {
+            inbox
+                .upsert(
+                    &user,
+                    InboxEntry::new(room.clone(), ConversationKind::MucRoom, thread_id, ts)
+                        .with_thread(thread_id),
+                    true,
+                )
+                .await
+                .expect("upsert");
+        }
+        inbox
+            .mark_read(&user, &room, Some("b"))
+            .await
+            .expect("mark read b");
+
+        let first_query = ThreadsQuery {
+            page_size: Some(1),
+            status: ThreadStatusFilter::Unread,
+            sort: ThreadSort::Recent,
+            ..Default::default()
+        };
+        let first = threads.page(&user, &first_query).await.expect("first page");
+        assert_eq!(first.entries.len(), 1);
+        assert_eq!(first.entries[0].thread_id, "a");
+        assert_eq!(first.total, 2);
+
+        let second = threads
+            .page(
+                &user,
+                &ThreadsQuery {
+                    after_cursor: first.last_cursor.clone(),
+                    ..first_query
+                },
+            )
+            .await
+            .expect("second page");
+        assert_eq!(second.entries.len(), 1);
+        assert_eq!(second.entries[0].thread_id, "c");
+        assert_eq!(second.total, 2);
+    }
+
+    async fn upsert_unread_thread(
+        inbox: &DatabaseInboxStorage,
+        user: &BareJid,
+        room: &BareJid,
+        thread_id: &str,
+        unread: u32,
+        last_updated: i64,
+    ) {
+        for idx in 0..unread {
+            inbox
+                .upsert(
+                    user,
+                    InboxEntry::new(
+                        room.clone(),
+                        ConversationKind::MucRoom,
+                        format!("s-{thread_id}-{idx}"),
+                        last_updated,
+                    )
+                    .with_thread(thread_id),
+                    true,
+                )
+                .await
+                .expect("upsert unread thread");
+        }
+    }
+
+    #[tokio::test]
+    async fn page_cursor_stays_stable_with_unread_sort() {
+        let (inbox, threads) = make_storage_pair().await;
+        let user = jid("me@example.com");
+        let room = jid("room@muc.example");
+
+        upsert_unread_thread(&inbox, &user, &room, "low", 1, 300).await;
+        upsert_unread_thread(&inbox, &user, &room, "high", 3, 100).await;
+        upsert_unread_thread(&inbox, &user, &room, "mid", 2, 200).await;
+
+        let first_query = ThreadsQuery {
+            page_size: Some(2),
+            sort: ThreadSort::Unread,
+            ..Default::default()
+        };
+        let first = threads.page(&user, &first_query).await.expect("first page");
+        assert_eq!(
+            first
+                .entries
+                .iter()
+                .map(|entry| entry.thread_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["high", "mid"]
+        );
+
+        let second = threads
+            .page(
+                &user,
+                &ThreadsQuery {
+                    after_cursor: first.last_cursor.clone(),
+                    ..first_query
+                },
+            )
+            .await
+            .expect("second page");
+        assert_eq!(
+            second
+                .entries
+                .iter()
+                .map(|entry| entry.thread_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["low"]
+        );
+    }
+
+    #[tokio::test]
+    async fn page_cursor_stays_stable_with_replies_sort() {
+        let (inbox, threads) = make_storage_pair().await;
+        let user = jid("me@example.com");
+        let room = jid("room@muc.example");
+
+        for (thread_id, reply_count, last_updated) in
+            [("few", 1_u32, 300_i64), ("many", 5, 100), ("some", 3, 200)]
+        {
+            inbox
+                .upsert(
+                    &user,
+                    InboxEntry::new(
+                        room.clone(),
+                        ConversationKind::MucRoom,
+                        format!("s-{thread_id}"),
+                        last_updated,
+                    )
+                    .with_thread(thread_id)
+                    .with_reply_count(reply_count),
+                    false,
+                )
+                .await
+                .expect("upsert replies thread");
+        }
+
+        let first_query = ThreadsQuery {
+            page_size: Some(2),
+            sort: ThreadSort::Replies,
+            ..Default::default()
+        };
+        let first = threads.page(&user, &first_query).await.expect("first page");
+        assert_eq!(
+            first
+                .entries
+                .iter()
+                .map(|entry| entry.thread_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["many", "some"]
+        );
+
+        let second = threads
+            .page(
+                &user,
+                &ThreadsQuery {
+                    after_cursor: first.last_cursor.clone(),
+                    ..first_query
+                },
+            )
+            .await
+            .expect("second page");
+        assert_eq!(
+            second
+                .entries
+                .iter()
+                .map(|entry| entry.thread_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["few"]
+        );
     }
 
     #[tokio::test]
@@ -411,7 +1098,7 @@ mod tests {
             .await
             .expect("upsert thread");
 
-        let page = threads.page(&user, 50, None).await.expect("page");
+        let page = threads.page(&user, &threads_query(50)).await.expect("page");
         assert_eq!(page.entries.len(), 1);
         assert_eq!(page.total, 1);
         assert_eq!(page.entries[0].thread_id, "t1");

--- a/server/crates/waddle-server/src/threads/wire.rs
+++ b/server/crates/waddle-server/src/threads/wire.rs
@@ -4,7 +4,10 @@
 use minidom::Element;
 use xmpp_parsers::iq::Iq;
 
-use super::query::{ThreadEntry, ThreadsError, ThreadsPage, ThreadsQuery, NS_THREADS};
+use super::query::{
+    ThreadEntry, ThreadSort, ThreadStatusFilter, ThreadsError, ThreadsPage, ThreadsQuery,
+    NS_THREADS,
+};
 
 /// XEP-0059 Result Set Management namespace.
 const NS_RSM: &str = "http://jabber.org/protocol/rsm";
@@ -21,6 +24,30 @@ pub fn parse_threads_query(iq: &Iq) -> Result<ThreadsQuery, ThreadsError> {
     }
 
     let mut q = ThreadsQuery::default();
+    if let Some(status) = payload.attr("status") {
+        q.status = ThreadStatusFilter::parse(status)?;
+    }
+    if let Some(sort) = payload.attr("sort") {
+        q.sort = ThreadSort::parse(sort)?;
+    }
+    if let Some(active_since) = payload.attr("active-since") {
+        let parsed = chrono::DateTime::parse_from_rfc3339(active_since)
+            .map_err(|_| ThreadsError::InvalidTimestamp(active_since.to_string()))?;
+        q.active_since_secs = Some(parsed.timestamp());
+    }
+    if let Some(channel) = payload.attr("channel") {
+        q.channel = Some(
+            channel
+                .parse()
+                .map_err(|_| ThreadsError::InvalidChannel(channel.to_string()))?,
+        );
+    }
+    if let Some(search) = payload.attr("search") {
+        let trimmed = search.trim();
+        if !trimmed.is_empty() {
+            q.search = Some(trimmed.to_string());
+        }
+    }
     if let Some(rsm) = payload.get_child("set", NS_RSM) {
         if let Some(max_el) = rsm.get_child("max", NS_RSM) {
             let text = max_el.text();
@@ -134,6 +161,7 @@ fn build_thread_entry(entry: &ThreadEntry) -> Element {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::threads::query::ThreadRootAuthor;
     use xmpp_parsers::iq::Iq;
 
     fn make_get_iq(payload: Element) -> Iq {
@@ -152,6 +180,11 @@ mod tests {
         let q = parse_threads_query(&iq).expect("parses");
         assert_eq!(q.page_size, None);
         assert_eq!(q.after_cursor, None);
+        assert_eq!(q.status, ThreadStatusFilter::All);
+        assert_eq!(q.sort, ThreadSort::Recent);
+        assert_eq!(q.active_since_secs, None);
+        assert_eq!(q.channel, None);
+        assert_eq!(q.search, None);
     }
 
     #[test]
@@ -167,6 +200,75 @@ mod tests {
         let q = parse_threads_query(&iq).expect("parses");
         assert_eq!(q.page_size, Some(25));
         assert_eq!(q.after_cursor.as_deref(), Some("CURSOR-1"));
+    }
+
+    #[test]
+    fn parse_query_with_filters() {
+        let xml = "<query xmlns='urn:waddle:threads:0' \
+                          status='unread' \
+                          active-since='2026-05-19T00:00:00Z' \
+                          channel='chat@muc.waddle.chat' \
+                          search=' notifications ' \
+                          sort='replies'/>";
+        let payload: Element = xml.parse().expect("valid XML");
+        let iq = make_get_iq(payload);
+        let q = parse_threads_query(&iq).expect("parses");
+        assert_eq!(q.status, ThreadStatusFilter::Unread);
+        assert_eq!(q.active_since_secs, Some(1_779_148_800));
+        assert_eq!(
+            q.channel.as_ref().map(ToString::to_string).as_deref(),
+            Some("chat@muc.waddle.chat")
+        );
+        assert_eq!(q.search.as_deref(), Some("notifications"));
+        assert_eq!(q.sort, ThreadSort::Replies);
+    }
+
+    #[test]
+    fn parse_rejects_invalid_status() {
+        let payload: Element = "<query xmlns='urn:waddle:threads:0' status='stale'/>"
+            .parse()
+            .expect("valid XML");
+        let iq = make_get_iq(payload);
+        assert!(matches!(
+            parse_threads_query(&iq),
+            Err(ThreadsError::InvalidStatus(value)) if value == "stale"
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_invalid_sort() {
+        let payload: Element = "<query xmlns='urn:waddle:threads:0' sort='hot'/>"
+            .parse()
+            .expect("valid XML");
+        let iq = make_get_iq(payload);
+        assert!(matches!(
+            parse_threads_query(&iq),
+            Err(ThreadsError::InvalidSort(value)) if value == "hot"
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_invalid_active_since() {
+        let payload: Element = "<query xmlns='urn:waddle:threads:0' active-since='not-a-date'/>"
+            .parse()
+            .expect("valid XML");
+        let iq = make_get_iq(payload);
+        assert!(matches!(
+            parse_threads_query(&iq),
+            Err(ThreadsError::InvalidTimestamp(value)) if value == "not-a-date"
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_invalid_channel() {
+        let payload: Element = "<query xmlns='urn:waddle:threads:0' channel='not a jid'/>"
+            .parse()
+            .expect("valid XML");
+        let iq = make_get_iq(payload);
+        assert!(matches!(
+            parse_threads_query(&iq),
+            Err(ThreadsError::InvalidChannel(value)) if value == "not a jid"
+        ));
     }
 
     #[test]
@@ -206,7 +308,7 @@ mod tests {
             last_activity_secs: 1_700_000_000,
             unread: 2,
             reply_count: 5,
-            root_author: Some("juliet@example.com".parse().expect("valid bare JID")),
+            root_author: ThreadRootAuthor::parse("juliet"),
             preview: Some("Anyone reviewed the doc?".into()),
             thread_title: Some("Q3 planning".into()),
         };
@@ -231,7 +333,7 @@ mod tests {
             thread_el
                 .get_child("root-author", NS_THREADS)
                 .map(|e| e.text()),
-            Some("juliet@example.com".into())
+            Some("juliet".into())
         );
     }
 

--- a/server/crates/waddle-server/tests/waddle_threads_query_ws.rs
+++ b/server/crates/waddle-server/tests/waddle_threads_query_ws.rs
@@ -20,6 +20,15 @@ const STANZA_ERROR_NS: &str = "urn:ietf:params:xml:ns:xmpp-stanzas";
 
 static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
 
+#[derive(Default)]
+struct ThreadsQueryAttrs<'a> {
+    status: Option<&'a str>,
+    active_since: Option<&'a str>,
+    channel: Option<&'a str>,
+    search: Option<&'a str>,
+    sort: Option<&'a str>,
+}
+
 async fn admin_client(server: &TestServer, resource: &str) -> WsXmppClient {
     let password = server.fixed_account_password().to_string();
     WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, USERNAME, &password, resource)
@@ -39,7 +48,36 @@ async fn extra_client(
 }
 
 fn threads_query_iq(id: &str, page_size: Option<u32>, after: Option<&str>) -> String {
-    let mut query = Element::builder("query", NS_THREADS).build();
+    threads_query_iq_with_attrs(id, page_size, after, ThreadsQueryAttrs::default())
+}
+
+fn threads_query_iq_with_attrs(
+    id: &str,
+    page_size: Option<u32>,
+    after: Option<&str>,
+    attrs: ThreadsQueryAttrs<'_>,
+) -> String {
+    let mut query_builder = Element::builder("query", NS_THREADS);
+    if let Some(status) = attrs.status {
+        query_builder = query_builder.attr(minidom::rxml::xml_ncname!("status").to_owned(), status);
+    }
+    if let Some(active_since) = attrs.active_since {
+        query_builder = query_builder.attr(
+            minidom::rxml::xml_ncname!("active-since").to_owned(),
+            active_since,
+        );
+    }
+    if let Some(channel) = attrs.channel {
+        query_builder =
+            query_builder.attr(minidom::rxml::xml_ncname!("channel").to_owned(), channel);
+    }
+    if let Some(search) = attrs.search {
+        query_builder = query_builder.attr(minidom::rxml::xml_ncname!("search").to_owned(), search);
+    }
+    if let Some(sort) = attrs.sort {
+        query_builder = query_builder.attr(minidom::rxml::xml_ncname!("sort").to_owned(), sort);
+    }
+    let mut query = query_builder.build();
     if page_size.is_some() || after.is_some() {
         let mut set = Element::builder("set", NS_RSM).build();
         if let Some(max) = page_size {
@@ -243,6 +281,111 @@ async fn populated_inbox_returns_thread_entries() {
 }
 
 #[tokio::test]
+async fn filtered_query_attrs_are_applied_over_websocket() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut client = admin_client(&server, "th-filter").await;
+    let room = format!("threads-filter-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut client, &room).await;
+
+    send_threaded_message(
+        &mut client,
+        &room,
+        "t-filter",
+        "needle notifications",
+        "tm-filter-1",
+    )
+    .await;
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+    let resp = send_iq(
+        &mut client,
+        threads_query_iq_with_attrs(
+            "th-filter-1",
+            Some(50),
+            None,
+            ThreadsQueryAttrs {
+                status: Some("all"),
+                active_since: Some("1970-01-01T00:00:00Z"),
+                channel: Some(&room),
+                search: Some("NOTIFICATIONS"),
+                sort: Some("recent"),
+            },
+        ),
+        "th-filter-1",
+    )
+    .await;
+    let iq = parse_iq_element(&resp, "th-filter-1", "result");
+    let threads = iq
+        .children()
+        .find(|child| child.name() == "threads" && child.ns() == NS_THREADS)
+        .expect("threads element");
+    assert_eq!(threads.attr("total"), Some("1"), "unexpected total: {iq:?}");
+    let entries = thread_children(&iq);
+    assert_eq!(entries.len(), 1, "expected one filtered thread: {iq:?}");
+    assert_eq!(entries[0].attr("thread-id"), Some("t-filter"));
+
+    let _ = client.close().await;
+}
+
+#[tokio::test]
+async fn invalid_filter_attrs_are_bad_request() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut client = admin_client(&server, "th-bad-filter").await;
+
+    for (idx, attrs) in [
+        (
+            0,
+            ThreadsQueryAttrs {
+                status: Some("stale"),
+                ..Default::default()
+            },
+        ),
+        (
+            1,
+            ThreadsQueryAttrs {
+                sort: Some("hot"),
+                ..Default::default()
+            },
+        ),
+        (
+            2,
+            ThreadsQueryAttrs {
+                active_since: Some("not-a-date"),
+                ..Default::default()
+            },
+        ),
+        (
+            3,
+            ThreadsQueryAttrs {
+                channel: Some("not a jid"),
+                ..Default::default()
+            },
+        ),
+    ] {
+        let id = format!("th-bad-filter-{idx}");
+        let resp = send_iq(
+            &mut client,
+            threads_query_iq_with_attrs(&id, None, None, attrs),
+            &id,
+        )
+        .await;
+        assert_error_condition(&resp, "bad-request");
+    }
+
+    let resp = send_iq(
+        &mut client,
+        threads_query_iq("th-bad-filter-cursor", None, Some("not-a-cursor")),
+        "th-bad-filter-cursor",
+    )
+    .await;
+    assert_error_condition(&resp, "bad-request");
+
+    let _ = client.close().await;
+}
+
+#[tokio::test]
 async fn pagination_round_trips_cursor() {
     let _guard = TEST_SERIAL.lock().await;
     let server = TestServer::start();
@@ -304,6 +447,22 @@ async fn pagination_round_trips_cursor() {
         1,
         "second page should return 1 entry: {second_iq:?}"
     );
+
+    let mismatched_sort = send_iq(
+        &mut client,
+        threads_query_iq_with_attrs(
+            "th-page-cross-sort",
+            Some(2),
+            Some(&last_cursor),
+            ThreadsQueryAttrs {
+                sort: Some("unread"),
+                ..Default::default()
+            },
+        ),
+        "th-page-cross-sort",
+    )
+    .await;
+    assert_error_condition(&mismatched_sort, "bad-request");
 
     let _ = client.close().await;
 }
@@ -420,6 +579,37 @@ async fn response_includes_rsm_set_with_count() {
         .map(|el| el.text())
         .expect("rsm count");
     assert_eq!(count, "0");
+
+    let _ = client.close().await;
+}
+
+#[tokio::test]
+async fn max_zero_returns_count_without_thread_entries() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut client = admin_client(&server, "th-count").await;
+    let room = format!("threads-count-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut client, &room).await;
+
+    send_threaded_message(&mut client, &room, "t-count", "count me", "tm-count").await;
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+    let resp = send_iq(
+        &mut client,
+        threads_query_iq("th-count-1", Some(0), None),
+        "th-count-1",
+    )
+    .await;
+    let iq = parse_iq_element(&resp, "th-count-1", "result");
+    let threads = iq
+        .children()
+        .find(|c| c.name() == "threads" && c.ns() == NS_THREADS)
+        .expect("threads element");
+    assert_eq!(threads.attr("total"), Some("1"));
+    assert!(
+        thread_children(&iq).is_empty(),
+        "RSM max=0 must return only the count: {iq:?}"
+    );
 
     let _ = client.close().await;
 }

--- a/server/crates/waddle-xmpp-client-wasm/src/client_account.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_account.rs
@@ -577,8 +577,8 @@ impl WaddleClient {
                 serde_wasm_bindgen::from_value(opts).map_err(|err| js_error(err.to_string()))?
             };
             let request_id = uuid::Uuid::new_v4().to_string();
-            let iq =
-                build_fetch_threads_iq(&request_id, opts.page_size, opts.after_cursor.as_deref());
+            let query = fetch_threads_query_from_options(&opts).map_err(js_error)?;
+            let iq = build_fetch_threads_iq(&request_id, &query);
             let page = match send_iq_command(inner, iq).await {
                 Ok(result) => parse_threads_response(&result).unwrap_or_default(),
                 Err(_) => Default::default(),
@@ -910,6 +910,46 @@ fn parse_dm_bookmarks_response(iq: &Element) -> Vec<WaddleDmBookmarkItem> {
         .collect()
 }
 
+fn fetch_threads_query_from_options(
+    opts: &WaddleFetchThreadsOptions,
+) -> Result<FetchThreadsQuery<'_>, String> {
+    let status = match opts.status {
+        Some(WaddleThreadStatusFilter::All) | None => ThreadStatusFilter::All,
+        Some(WaddleThreadStatusFilter::Unread) => ThreadStatusFilter::Unread,
+        Some(WaddleThreadStatusFilter::Following) => ThreadStatusFilter::Following,
+    };
+    let sort = match opts.sort {
+        Some(WaddleThreadSort::Recent) | None => ThreadSort::Recent,
+        Some(WaddleThreadSort::Unread) => ThreadSort::Unread,
+        Some(WaddleThreadSort::Replies) => ThreadSort::Replies,
+    };
+    let active_since = match opts.active_since.as_deref() {
+        Some(raw) => Some(
+            chrono::DateTime::parse_from_rfc3339(raw)
+                .map_err(|err| format!("invalid active_since: {err}"))?
+                .with_timezone(&chrono::Utc),
+        ),
+        None => None,
+    };
+    let channel = match opts.channel.as_deref() {
+        Some(raw) if !raw.trim().is_empty() => Some(
+            raw.parse::<BareJid>()
+                .map_err(|err| format!("invalid channel: {err}"))?,
+        ),
+        _ => None,
+    };
+
+    Ok(FetchThreadsQuery {
+        page_size: opts.page_size,
+        after_cursor: opts.after_cursor.as_deref(),
+        status,
+        active_since,
+        channel,
+        search: opts.search.as_deref(),
+        sort,
+    })
+}
+
 /// Surface one DM-bookmark `<notify/>` into the JS-facing
 /// [`WaddleDmBookmarkItem`] (issue #720). Used by both
 /// `fetch_dm_bookmarks` (per-item map) and `set_dm_notification_mode`
@@ -999,6 +1039,45 @@ fn verify_iq_from_matches_query(from_attr: Option<&str>, service_jid: &str) -> R
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn fetch_threads_options_build_filtered_iq() {
+        let opts = WaddleFetchThreadsOptions {
+            page_size: Some(50),
+            after_cursor: Some("CUR".to_string()),
+            status: Some(WaddleThreadStatusFilter::Unread),
+            active_since: Some("2026-05-19T00:00:00Z".to_string()),
+            channel: Some("chat@muc.waddle.chat".to_string()),
+            search: Some(" notifications ".to_string()),
+            sort: Some(WaddleThreadSort::Replies),
+        };
+
+        let query = fetch_threads_query_from_options(&opts).expect("valid threads query");
+        let iq = build_fetch_threads_iq("threads-test", &query);
+        let query_el = iq
+            .get_child("query", waddle_xmpp_client::xep::threads::NS_THREADS)
+            .expect("threads query");
+
+        assert_eq!(query_el.attr("status"), Some("unread"));
+        assert_eq!(query_el.attr("active-since"), Some("2026-05-19T00:00:00Z"));
+        assert_eq!(query_el.attr("channel"), Some("chat@muc.waddle.chat"));
+        assert_eq!(query_el.attr("search"), Some("notifications"));
+        assert_eq!(query_el.attr("sort"), Some("replies"));
+
+        let set = query_el
+            .get_child("set", "http://jabber.org/protocol/rsm")
+            .expect("rsm set");
+        assert_eq!(
+            set.get_child("max", "http://jabber.org/protocol/rsm")
+                .map(|el| el.text()),
+            Some("50".to_string())
+        );
+        assert_eq!(
+            set.get_child("after", "http://jabber.org/protocol/rsm")
+                .map(|el| el.text()),
+            Some("CUR".to_string())
+        );
+    }
 
     #[test]
     fn verify_iq_from_accepts_exact_match() {

--- a/server/crates/waddle-xmpp-client-wasm/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/lib.rs
@@ -44,7 +44,10 @@ use waddle_xmpp_client::transport::{
 use waddle_xmpp_client::xep::{
     reply::{FallbackRange, ReplyMarker},
     thread::ThreadRef,
-    threads::{build_fetch_threads_iq, parse_threads_response},
+    threads::{
+        build_fetch_threads_iq, parse_threads_response, FetchThreadsQuery, ThreadSort,
+        ThreadStatusFilter,
+    },
     xep0292::{build_fetch_vcard4_iq, build_publish_vcard4_iq, parse_pep_vcard4, VCard4},
     xep0402::{
         build_fetch_bookmarks_iq, build_publish_bookmark_iq, parse_bookmarks_response, BookmarkItem,

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -798,12 +798,33 @@ pub struct WaddleThreadsPage {
     pub next_cursor: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WaddleThreadStatusFilter {
+    All,
+    Unread,
+    Following,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WaddleThreadSort {
+    Recent,
+    Unread,
+    Replies,
+}
+
 /// Options bag for `fetch_threads`. All fields optional.
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default)]
 pub struct WaddleFetchThreadsOptions {
     pub page_size: Option<u32>,
     pub after_cursor: Option<String>,
+    pub status: Option<WaddleThreadStatusFilter>,
+    pub active_since: Option<String>,
+    pub channel: Option<String>,
+    pub search: Option<String>,
+    pub sort: Option<WaddleThreadSort>,
 }
 
 /// JS-facing shape for one XEP-0402 bookmark item exposed via

--- a/server/crates/waddle-xmpp-client/src/xep/threads.rs
+++ b/server/crates/waddle-xmpp-client/src/xep/threads.rs
@@ -4,6 +4,8 @@
 //! `waddle-server/src/threads/wire.rs`. The chat client uses the IQ
 //! builder/parser to drive the global Threads view.
 
+use chrono::{DateTime, SecondsFormat, Utc};
+use jid::BareJid;
 use minidom::Element;
 
 /// Namespace for the threads-view query and response.
@@ -42,21 +44,94 @@ pub struct ThreadsPage {
     pub next_cursor: Option<String>,
 }
 
+/// Status filter for a threads query.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ThreadStatusFilter {
+    #[default]
+    All,
+    Unread,
+    Following,
+}
+
+impl ThreadStatusFilter {
+    fn as_attr(self) -> Option<&'static str> {
+        match self {
+            Self::All => None,
+            Self::Unread => Some("unread"),
+            Self::Following => Some("following"),
+        }
+    }
+}
+
+/// Sort order for a threads query.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ThreadSort {
+    #[default]
+    Recent,
+    Unread,
+    Replies,
+}
+
+impl ThreadSort {
+    fn as_attr(self) -> Option<&'static str> {
+        match self {
+            Self::Recent => None,
+            Self::Unread => Some("unread"),
+            Self::Replies => Some("replies"),
+        }
+    }
+}
+
+/// Request options for `urn:waddle:threads:0`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FetchThreadsQuery<'a> {
+    pub page_size: Option<u32>,
+    pub after_cursor: Option<&'a str>,
+    pub status: ThreadStatusFilter,
+    pub active_since: Option<DateTime<Utc>>,
+    pub channel: Option<BareJid>,
+    pub search: Option<&'a str>,
+    pub sort: ThreadSort,
+}
+
 /// Build a `<iq type='get'>` requesting the user's threads.
-pub fn build_fetch_threads_iq(
-    request_id: &str,
-    page_size: Option<u32>,
-    after_cursor: Option<&str>,
-) -> Element {
-    let mut query = Element::builder("query", NS_THREADS).build();
-    if page_size.is_some() || after_cursor.is_some() {
+pub fn build_fetch_threads_iq(request_id: &str, opts: &FetchThreadsQuery<'_>) -> Element {
+    let mut query_builder = Element::builder("query", NS_THREADS);
+    if let Some(status) = opts.status.as_attr() {
+        query_builder = query_builder.attr(minidom::rxml::xml_ncname!("status").to_owned(), status);
+    }
+    if let Some(active_since) = opts.active_since {
+        query_builder = query_builder.attr(
+            minidom::rxml::xml_ncname!("active-since").to_owned(),
+            active_since.to_rfc3339_opts(SecondsFormat::Secs, true),
+        );
+    }
+    if let Some(ref channel) = opts.channel {
+        query_builder = query_builder.attr(
+            minidom::rxml::xml_ncname!("channel").to_owned(),
+            channel.to_string(),
+        );
+    }
+    if let Some(search) = opts.search {
+        let trimmed = search.trim();
+        if !trimmed.is_empty() {
+            query_builder =
+                query_builder.attr(minidom::rxml::xml_ncname!("search").to_owned(), trimmed);
+        }
+    }
+    if let Some(sort) = opts.sort.as_attr() {
+        query_builder = query_builder.attr(minidom::rxml::xml_ncname!("sort").to_owned(), sort);
+    }
+
+    let mut query = query_builder.build();
+    if opts.page_size.is_some() || opts.after_cursor.is_some() {
         let mut set = Element::builder("set", NS_RSM).build();
-        if let Some(max) = page_size {
+        if let Some(max) = opts.page_size {
             let mut max_el = Element::builder("max", NS_RSM).build();
             max_el.append_text_node(max.to_string());
             set.append_child(max_el);
         }
-        if let Some(after) = after_cursor {
+        if let Some(after) = opts.after_cursor {
             let mut after_el = Element::builder("after", NS_RSM).build();
             after_el.append_text_node(after);
             set.append_child(after_el);
@@ -133,7 +208,14 @@ mod tests {
 
     #[test]
     fn fetch_iq_has_correct_namespace_and_type() {
-        let iq = build_fetch_threads_iq("r-1", Some(25), Some("CUR"));
+        let iq = build_fetch_threads_iq(
+            "r-1",
+            &FetchThreadsQuery {
+                page_size: Some(25),
+                after_cursor: Some("CUR"),
+                ..Default::default()
+            },
+        );
         assert_eq!(iq.attr("type"), Some("get"));
         assert_eq!(iq.attr("id"), Some("r-1"));
         let query = iq.get_child("query", NS_THREADS).expect("query");
@@ -150,9 +232,38 @@ mod tests {
 
     #[test]
     fn fetch_iq_without_pagination_omits_set() {
-        let iq = build_fetch_threads_iq("r-2", None, None);
+        let iq = build_fetch_threads_iq("r-2", &FetchThreadsQuery::default());
         let query = iq.get_child("query", NS_THREADS).expect("query");
         assert!(query.get_child("set", NS_RSM).is_none());
+        assert_eq!(query.attr("status"), None);
+        assert_eq!(query.attr("sort"), None);
+    }
+
+    #[test]
+    fn fetch_iq_includes_selected_filters() {
+        let iq = build_fetch_threads_iq(
+            "r-3",
+            &FetchThreadsQuery {
+                page_size: Some(50),
+                status: ThreadStatusFilter::Unread,
+                active_since: Some(
+                    "2026-05-19T00:00:00Z"
+                        .parse::<DateTime<Utc>>()
+                        .expect("valid timestamp"),
+                ),
+                channel: Some("chat@muc.waddle.chat".parse().expect("valid JID")),
+                search: Some(" notifications "),
+                sort: ThreadSort::Replies,
+                ..Default::default()
+            },
+        );
+        let query = iq.get_child("query", NS_THREADS).expect("query");
+        assert_eq!(query.attr("status"), Some("unread"));
+        assert_eq!(query.attr("active-since"), Some("2026-05-19T00:00:00Z"));
+        assert_eq!(query.attr("channel"), Some("chat@muc.waddle.chat"));
+        assert_eq!(query.attr("search"), Some("notifications"));
+        assert_eq!(query.attr("sort"), Some("replies"));
+        assert!(query.get_child("set", NS_RSM).is_some());
     }
 
     #[test]

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=b40d8c9c10b2";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=b40d8c9c10b2";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=b40d8c9c10b2";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=56fec47b7f51";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=56fec47b7f51";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=56fec47b7f51";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=b40d8c9c10b2";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=56fec47b7f51";


### PR DESCRIPTION
## Summary

Implements the protocol-backed Threads triage view for the existing followed-or-unread thread population.

- Extends `urn:waddle:threads:0` query parsing/building with Waddle-private `status`, `active-since`, `channel`, `search`, and `sort` attributes while keeping XEP-0059 RSM pagination unchanged.
- Applies filtering and sorting in `InboxBackedThreadsStorage` before pagination, with filtered `total` and `unread-threads` counts.
- Updates Rust client, WASM types, generated package wrapper, and `BrowserXmppClient.fetchThreads` option mapping.
- Replaces the bare Threads panel with a compact triage toolbar, URL-restorable filters, channel/search/sort controls, Load more, thread-aware Mark read, and cleaner media previews.
- Adds focused server, websocket, WASM, and chat state tests for filter behavior, invalid values, RSM max-zero count-only behavior, cursor stability, URL state, mark-read refetch, and unresolved restored channel filters.

## Plan

1. Keep the query in Waddle's private `urn:waddle:threads:0` namespace and keep official XEP-0059 RSM elements unchanged.
2. Extend Rust server query types and XML parser/builder tests for typed Waddle-private filters.
3. Filter and sort in the inbox-backed threads storage before pagination, with bad-request handling for invalid filter values and malformed cursors.
4. Extend Rust client, WASM bridge types, and chat TypeScript fetch options to mirror the protocol fields.
5. Replace `/threads` with a triage toolbar whose state is restorable from query params.
6. Add row-level Mark read, Load more, and media-preview normalization.
7. Validate with targeted Rust/chat tests, full chat tests, lint, build, browser sanity check, and adversarial review findings.

## XEP Review

- Reviewed local `./xeps` for XEP-0059 RSM behavior.
- Preserved `<set xmlns='http://jabber.org/protocol/rsm'>` and cursor semantics.
- Kept all Waddle-specific filters in `urn:waddle:threads:0`; no official namespace was repurposed for Waddle semantics.

## Validation

- `cd server && cargo fmt --all -- --check`
- `cd server && cargo test -p waddle-server threads::`
- `cd server && cargo test -p waddle-server --test waddle_threads_query_ws` (required unsandboxed localhost server spawning)
- `cd server && cargo test -p waddle-xmpp-client xep::threads`
- `cd server && cargo test -p waddle-xmpp-client-wasm fetch_threads`
- `cd server && cargo clippy -p waddle-server -p waddle-xmpp-client -p waddle-xmpp-client-wasm -- -D warnings`
- `cd chat && REBUILD_WASM=1 bun run wasm:build`
- `cd chat && bun test tests/threads-list-panel.test.ts tests/threads-view-filters.test.ts`
- `cd chat && bun run lint`
- `cd chat && bun test`
- `cd chat && bun run build`

## Browser Check

- Local `http://127.0.0.1:4321/threads?status=unread&active=14d&sort=recent&q=notifications` loaded and preserved the filter query params.
- The local app stopped at the expected session gate (`Checking session.`) without console errors, so authenticated thread data was not manually exercised locally.
