### PR TITLE
chore(chat): upload Faro source maps during deploy

### DIFF
--- a/.github/workflows/waddle-chat-default.yml
+++ b/.github/workflows/waddle-chat-default.yml
@@ -20,6 +20,12 @@ on:
     - chat/schema/**
     - chat/scripts/build-xmpp-wasm.mjs
     - chat/scripts/build-xmpp-wasm.mjs/**
+    - chat/scripts/resolve-commit-sha.mjs
+    - chat/scripts/resolve-commit-sha.mjs/**
+    - chat/scripts/strip-sourcemaps.mjs
+    - chat/scripts/strip-sourcemaps.mjs/**
+    - chat/scripts/upload-faro-sourcemaps.mjs
+    - chat/scripts/upload-faro-sourcemaps.mjs/**
     - chat/src/**
     - chat/tsconfig.json
     - chat/tsconfig.json/**

--- a/bun.lock
+++ b/bun.lock
@@ -44,6 +44,8 @@
         "@cloudflare/workers-types": "^4.20260420.1",
         "@types/node": "^25.6.0",
         "knip": "^6.5.0",
+        "magic-string": "^0.30.21",
+        "tar": "^7.5.16",
         "typescript": "^6.0.3",
       },
       "optionalDependencies": {
@@ -362,6 +364,8 @@
     "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
+    "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -843,6 +847,8 @@
 
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
+    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
+
     "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
 
     "cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
@@ -1187,6 +1193,10 @@
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
+
     "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
 
     "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
@@ -1399,6 +1409,8 @@
 
     "tapable": ["tapable@2.3.2", "", {}, "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA=="],
 
+    "tar": ["tar@7.5.16", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w=="],
+
     "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
 
     "tinyclip": ["tinyclip@0.1.12", "", {}, "sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA=="],
@@ -1557,7 +1569,7 @@
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
-    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+    "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
@@ -1680,6 +1692,8 @@
     "yaml-language-server/yaml": ["yaml@2.7.1", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ=="],
 
     "yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "@cloudflare/vite-plugin/miniflare/workerd": ["workerd@1.20260420.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260420.1", "@cloudflare/workerd-darwin-arm64": "1.20260420.1", "@cloudflare/workerd-linux-64": "1.20260420.1", "@cloudflare/workerd-linux-arm64": "1.20260420.1", "@cloudflare/workerd-windows-64": "1.20260420.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-1AOJgng169u4fiFrEd5WjrAGpdwd3A4ZJtP8PMvf+RF9NUKy+mdwrKdz4qPZ6Tt/Bya99vsLn6UX33fjAEVoaA=="],
 

--- a/chat/astro.config.mjs
+++ b/chat/astro.config.mjs
@@ -1,6 +1,7 @@
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "astro/config";
 import cloudflare from "@astrojs/cloudflare";
+import MagicString from "magic-string";
 import tailwindcss from "@tailwindcss/vite";
 import vue from "@astrojs/vue";
 import { resolveCommitSha } from "./scripts/resolve-commit-sha.mjs";
@@ -14,6 +15,35 @@ const FARO_URL = process.env.PUBLIC_FARO_URL ?? "";
 const FARO_APP_NAME = process.env.PUBLIC_FARO_APP_NAME ?? "waddle-chat";
 const FARO_APP_VERSION = process.env.PUBLIC_FARO_APP_VERSION ?? "1.0.0";
 const FARO_ENVIRONMENT = process.env.PUBLIC_FARO_ENVIRONMENT ?? "";
+const FARO_SOURCEMAP_ENABLED = process.env.FARO_SOURCEMAP_ENABLED === "true";
+const FARO_BUNDLE_ID = process.env.FARO_BUNDLE_ID ?? `${FARO_APP_NAME}-${COMMIT_SHA}`;
+
+function faroBundleIdPlugin() {
+  return {
+    name: "waddle-faro-bundle-id",
+    apply: "build",
+    renderChunk(code, chunk, outputOptions) {
+      const outputDir = outputOptions.dir?.replaceAll("\\", "/") ?? "";
+      if (
+        !FARO_SOURCEMAP_ENABLED
+        || !outputDir.endsWith("/dist/client")
+        || !/\.(?:js|mjs|cjs)$/.test(chunk.fileName)
+        || code.includes(`__faroBundleId_${FARO_APP_NAME}`)
+      ) {
+        return null;
+      }
+
+      const snippet =
+        `(function(){try{var g=typeof window!=="undefined"?window:typeof global!=="undefined"?global:typeof self!=="undefined"?self:{};g[${JSON.stringify(`__faroBundleId_${FARO_APP_NAME}`)}]=${JSON.stringify(FARO_BUNDLE_ID)}}catch(l){}})();\n`;
+      const source = new MagicString(code);
+      source.prepend(snippet);
+      return {
+        code: source.toString(),
+        map: source.generateMap({ hires: true }),
+      };
+    },
+  };
+}
 
 export default defineConfig({
   output: "server",
@@ -24,8 +54,16 @@ export default defineConfig({
   },
 
   vite: {
+    environments: {
+      client: {
+        build: {
+          sourcemap: FARO_SOURCEMAP_ENABLED,
+        },
+      },
+    },
     plugins: [
       tailwindcss(),
+      faroBundleIdPlugin(),
       // Force `Cache-Control: no-store` on every URL containing the WASM
       // package name. Vite's `?v=<optimizer-hash>` URL convention sends
       // `Cache-Control: max-age=31536000, immutable` to the browser, and the

--- a/chat/env.cue
+++ b/chat/env.cue
@@ -201,10 +201,42 @@ schema.#Project & {
 			]
 		}
 
+		uploadFaroSourcemaps: schema.#Task & {
+			command: "bun"
+			args: ["run", "sourcemaps:upload"]
+			dependsOn: [build]
+			inputs: [
+				"../package.json",
+				"../bun.lock",
+				"package.json",
+				"scripts/upload-faro-sourcemaps.mjs",
+				"scripts/strip-sourcemaps.mjs",
+				"scripts/resolve-commit-sha.mjs",
+				"dist/**",
+			]
+			outputs: [
+				"dist/**",
+			]
+		}
+
+		stripSourcemaps: schema.#Task & {
+			command: "bun"
+			args: ["run", "sourcemaps:strip"]
+			dependsOn: [build]
+			inputs: [
+				"package.json",
+				"scripts/strip-sourcemaps.mjs",
+				"dist/**",
+			]
+			outputs: [
+				"dist/**",
+			]
+		}
+
 		preview: schema.#Task & {
 			command: "bun"
 			args: ["x", "wrangler", "versions", "upload"]
-			dependsOn: [build]
+			dependsOn: [stripSourcemaps]
 			captures: previewUrl: {
 				pattern: "Version Preview URL: (.+)"
 			}
@@ -216,7 +248,7 @@ schema.#Project & {
 		deploy: schema.#Task & {
 			command: "bun"
 			args: ["x", "wrangler", "deploy"]
-			dependsOn: [build]
+			dependsOn: [uploadFaroSourcemaps]
 			inputs: [
 				"wrangler.jsonc",
 				"dist/**",

--- a/chat/package.json
+++ b/chat/package.json
@@ -14,7 +14,9 @@
     "preview": "bun run wasm:build && bun run generate-service-worker && astro preview",
     "astro": "astro",
     "generate-types": "wrangler types",
-    "deploy": "bun run wasm:build && bun run generate-service-worker && wrangler deploy",
+    "sourcemaps:upload": "bun run scripts/upload-faro-sourcemaps.mjs",
+    "sourcemaps:strip": "bun run scripts/strip-sourcemaps.mjs",
+    "deploy": "bun run wasm:build && bun run generate-service-worker && bun run sourcemaps:strip && wrangler deploy",
     "lint": "bun run wasm:build && knip",
     "lint:fix": "bun run wasm:build && knip --fix --allow-remove-files"
   },
@@ -57,6 +59,8 @@
     "@cloudflare/workers-types": "^4.20260420.1",
     "@types/node": "^25.6.0",
     "knip": "^6.5.0",
+    "magic-string": "^0.30.21",
+    "tar": "^7.5.16",
     "typescript": "^6.0.3"
   }
 }

--- a/chat/scripts/strip-sourcemaps.mjs
+++ b/chat/scripts/strip-sourcemaps.mjs
@@ -1,0 +1,38 @@
+import { readdirSync, rmSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+
+const sourceMapRoot = resolve("dist", "client");
+let removed = 0;
+
+try {
+  if (!statSync(sourceMapRoot).isDirectory()) {
+    process.exit(0);
+  }
+} catch {
+  process.exit(0);
+}
+
+for (const sourceMap of findSourceMaps(sourceMapRoot)) {
+  rmSync(sourceMap, { force: true });
+  removed += 1;
+}
+
+if (removed > 0) {
+  console.log(`[faro] removed ${removed} source maps from dist/client`);
+}
+
+function findSourceMaps(root) {
+  const files = [];
+  const visit = (directory) => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = resolve(directory, entry.name);
+      if (entry.isDirectory()) {
+        visit(path);
+      } else if (entry.isFile() && entry.name.endsWith(".map")) {
+        files.push(path);
+      }
+    }
+  };
+  visit(root);
+  return files;
+}

--- a/chat/scripts/upload-faro-sourcemaps.mjs
+++ b/chat/scripts/upload-faro-sourcemaps.mjs
@@ -1,0 +1,124 @@
+import { readFileSync, readdirSync, rmSync, statSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { create as createTar } from "tar";
+import { resolveCommitSha } from "./resolve-commit-sha.mjs";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(scriptDir, "..");
+const sourceMapRoot = resolve(projectRoot, "dist", "client");
+const appName =
+  readEnv("FARO_SOURCEMAP_APP_NAME")
+  ?? readEnv("PUBLIC_FARO_APP_NAME")
+  ?? "waddle-chat";
+const commitSha = resolveCommitSha();
+const bundleId = readEnv("FARO_BUNDLE_ID") ?? `${appName}-${commitSha}`;
+ensureSourceMapRoot();
+
+if (commitSha === "unknown" && !readEnv("FARO_BUNDLE_ID")) {
+  fail("missing git commit SHA; set FARO_BUNDLE_ID or run from a Git checkout");
+}
+
+const endpoint = requireEnv("FARO_SOURCEMAP_ENDPOINT");
+const appId = requireEnv("FARO_SOURCEMAP_APP_ID");
+const stackId = requireEnv("FARO_SOURCEMAP_STACK_ID");
+const apiKey = requireEnv("FARO_SOURCEMAP_API_KEY");
+const verbose = readEnv("FARO_SOURCEMAP_VERBOSE") !== "false";
+const sourceMaps = findFiles(sourceMapRoot, (name) => name.endsWith(".map"));
+
+if (sourceMaps.length === 0) {
+  fail(`no source maps found under ${relative(projectRoot, sourceMapRoot)}`);
+}
+
+await uploadSourceMapsArchive(endpoint, appId, stackId, apiKey, bundleId, sourceMaps);
+
+for (const sourceMap of sourceMaps) {
+  // Keep maps private: upload first, then remove them before Wrangler deploys dist.
+  rmSync(sourceMap, { force: true });
+}
+
+console.log(
+  `[faro] uploaded ${sourceMaps.length} source maps for ${appName} bundle ${bundleId}`,
+);
+
+function readEnv(name) {
+  const value = process.env[name];
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function requireEnv(name) {
+  const value = readEnv(name);
+  if (!value) fail(`missing required environment variable ${name}`);
+  return value;
+}
+
+function ensureSourceMapRoot() {
+  try {
+    if (statSync(sourceMapRoot).isDirectory()) return;
+  } catch {
+    // Handled below with the same message as a non-directory path.
+  }
+  fail("missing dist/client output; run bun run build before uploading source maps");
+}
+
+function findFiles(root, predicate) {
+  const files = [];
+  const visit = (directory) => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = resolve(directory, entry.name);
+      if (entry.isDirectory()) {
+        visit(path);
+      } else if (entry.isFile() && predicate(entry.name)) {
+        files.push(path);
+      }
+    }
+  };
+  visit(root);
+  return files.sort();
+}
+
+async function uploadSourceMapsArchive(uploadEndpoint, uploadAppId, uploadStackId, uploadApiKey, uploadBundleId, files) {
+  const archivePath = resolve(sourceMapRoot, `faro-sourcemaps-${Date.now()}.tar.gz`);
+  try {
+    await createTar(
+      {
+        cwd: sourceMapRoot,
+        file: archivePath,
+        gzip: true,
+      },
+      files.map((file) => relative(sourceMapRoot, file)),
+    );
+
+    const url =
+      `${uploadEndpoint.replace(/\/$/, "")}/app/${encodeURIComponent(uploadAppId)}/sourcemaps/${encodeURIComponent(uploadBundleId)}`;
+    if (verbose) {
+      console.log(`[faro] uploading ${files.length} source maps to ${url}`);
+    }
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${uploadStackId}:${uploadApiKey}`,
+        "Content-Type": "application/gzip",
+      },
+      body: readFileSync(archivePath),
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      const details = body.trim().slice(0, 500);
+      fail(
+        `source-map upload failed with HTTP ${response.status}${details ? `: ${details}` : ""}`,
+      );
+    }
+  } finally {
+    rmSync(archivePath, { force: true });
+  }
+}
+
+function fail(message) {
+  console.error(`[faro] ${message}`);
+  process.exit(1);
+}

--- a/env.cue
+++ b/env.cue
@@ -40,7 +40,17 @@ schema.#Base & {
 			// to reach `astro build`. Scoped to production so previews, PR, and
 			// local builds ship telemetry off.
 			PUBLIC_FARO_URL:         "https://faro-collector-prod-eu-west-6.grafana.net/collect/0eab89b00ec9f7cfd5c97e96636a3d20"
+			PUBLIC_FARO_APP_NAME:    "waddle-chat"
 			PUBLIC_FARO_ENVIRONMENT: "production"
+
+			FARO_SOURCEMAP_ENDPOINT: "https://faro-api-prod-eu-west-6.grafana.net/faro/api/v1"
+			FARO_SOURCEMAP_APP_ID:   "92"
+			FARO_SOURCEMAP_APP_NAME: "waddle-chat"
+			FARO_SOURCEMAP_ENABLED:  "true"
+			FARO_SOURCEMAP_STACK_ID: "1602000"
+			FARO_SOURCEMAP_API_KEY: schema.#OnePasswordRef & {
+				ref: "op://waddle-infra/server-runtime-production/grafana-faro-source-maps"
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Emit chat client source maps only when production deploy env sets FARO_SOURCEMAP_ENABLED=true.
- Inject the Faro bundle ID during the Vite client build with a source map, so chunk hashes and uploaded maps describe the deployed bytes.
- Upload dist/client source maps to Grafana Faro after the production build using the configured app/stack IDs and the 1Password-backed API key at op://waddle-infra/server-runtime-production/grafana-faro-source-maps.
- Remove source maps from dist/client after upload, and strip any maps before preview/package deploy paths to avoid publishing private maps.
- Keep the upload path XMPP-neutral: no XMPP wire behavior or protocol namespaces change.

## Plan

- Review local ./xeps and confirm this is deploy/browser observability only, not XMPP control behavior.
- Configure Astro/Vite client source maps behind production deploy env.
- Add build-time Faro bundle ID injection and a deploy upload script.
- Wire chat cuenv deploy to upload maps before wrangler deploy; wire preview/package deploy paths to strip maps.
- Validate build, lint, mock upload behavior, and adversarial reviews.

## Validation

- ./xeps reviewed locally; no XMPP wire behavior changes.
- bun run lint
- bun run build
- FARO_SOURCEMAP_ENABLED=true PUBLIC_FARO_APP_NAME=waddle-chat FARO_BUNDLE_ID=waddle-chat-test-bundle bun run build
- Local mock Faro endpoint accepted POST /app/92/sourcemaps/waddle-chat-test-bundle with application/gzip payload.
- Verified default build emits 0 client/server .map files and no __faroBundleId snippet.
- Verified production-like build emits 319 client maps, injects the bundle ID in hashed client chunks, emits 0 server maps, and upload removes the client maps afterward.
- Two adversarial review personas re-reviewed the updated branch and found no actionable issues.

## Notes

- The source-map upload endpoint is separate from the public Faro collector endpoint.
- The API key is not passed through the Grafana CLI/curl command path; upload uses fetch with the Authorization header and redacted failure output.