### PR TITLE
feat(link-preview): trusted direct-video inline preview

### DIFF
--- a/chat/src/components/chat/MessageBody.vue
+++ b/chat/src/components/chat/MessageBody.vue
@@ -5,7 +5,7 @@
 // suppresses interactive affordances that belong on the timeline only
 // (extension action buttons).
 //
-import { computed, ref, nextTick, watch } from "vue";
+import { computed, reactive, ref, nextTick, watch } from "vue";
 import {
   Lock,
   AlertCircle,
@@ -16,6 +16,7 @@ import {
   FileDown,
   Github,
   ExternalLink,
+  Play,
 } from "lucide-vue-next";
 import {
   extensionPresentation,
@@ -81,6 +82,29 @@ const linkPreviewCards = computed<LinkPreviewCard[]>(() =>
     mediaState: linkPreviewMediaState(preview),
   })),
 );
+// Info cards (text/image/unavailable) keep the whole-card anchor; video cards
+// render separately because they carry an interactive play control that must
+// not also navigate the link.
+const linkInfoCards = computed(() =>
+  linkPreviewCards.value.filter((card) => card.mediaState.kind !== "video"),
+);
+const videoPreviewCards = computed(() =>
+  linkPreviews.value.flatMap((preview) => {
+    const state = linkPreviewMediaState(preview);
+    return state.kind === "video"
+      ? [{ preview, video: state.video, ...(state.poster ? { poster: state.poster } : {}) }]
+      : [];
+  }),
+);
+function videoCardKey(preview: MessageLinkPreview): string {
+  return `${preview.originalUrl}:${preview.normalizedUrl ?? ""}`;
+}
+// Playback is local UI state only — never synchronized over XMPP. Until the
+// user clicks play, no <video> element (and no network fetch) is emitted.
+const playingVideos = reactive(new Set<string>());
+function startVideoPlayback(preview: MessageLinkPreview): void {
+  playingVideos.add(videoCardKey(preview));
+}
 const extensionCards = computed(() =>
   extensionAnnotations.value.map((annotation) => ({
     annotation,
@@ -227,7 +251,7 @@ watch(
          into a single horizontal action-chip strip beneath this block.
          No fat boxes fanning out below the message. -->
     <a
-      v-for="{ preview, mediaState } in linkPreviewCards"
+      v-for="{ preview, mediaState } in linkInfoCards"
       :key="`${preview.originalUrl}:${preview.normalizedUrl ?? ''}`"
       :href="linkPreviewHref(preview.originalUrl) ?? undefined"
       target="_blank"
@@ -259,6 +283,54 @@ watch(
       <span v-if="preview.title" class="type-field text-foreground">{{ preview.title }}</span>
       <span v-if="preview.description" class="type-caption line-clamp-2 text-muted-foreground">{{ preview.description }}</span>
     </a>
+
+    <!-- Trusted direct-video preview cards. Playback is local-only and starts
+         inline only after the user clicks play; the player element (and its
+         network fetch) is emitted only after that action. -->
+    <div
+      v-for="card in videoPreviewCards"
+      :key="`video:${videoCardKey(card.preview)}`"
+      class="flex max-w-xl flex-col gap-1 rounded-md border border-border bg-muted/40 p-3 text-left"
+    >
+      <span class="type-meta flex items-center gap-1 text-muted-foreground">
+        <ExternalLink aria-hidden="true" class="h-3.5 w-3.5" />
+        {{ linkPreviewHost(card.preview.originalUrl) }}
+      </span>
+      <video
+        v-if="playingVideos.has(videoCardKey(card.preview))"
+        :src="card.video.url"
+        class="max-h-72 w-full rounded border border-border bg-black"
+        controls
+        autoplay
+        playsinline
+        @click.stop
+      />
+      <button
+        v-else
+        type="button"
+        class="relative flex aspect-video w-full items-center justify-center overflow-hidden rounded border border-border bg-black/80 text-white transition-colors hover:bg-black"
+        :aria-label="`Play video${card.preview.title ? ': ' + card.preview.title : ''}`"
+        @click.stop.prevent="startVideoPlayback(card.preview)"
+      >
+        <img
+          v-if="card.poster"
+          :src="card.poster.url"
+          :alt="card.poster.alt ?? ''"
+          loading="lazy"
+          decoding="async"
+          class="absolute inset-0 h-full w-full object-cover"
+        />
+        <Play aria-hidden="true" class="relative h-10 w-10 drop-shadow" />
+      </button>
+      <a
+        :href="linkPreviewHref(card.preview.originalUrl) ?? undefined"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="type-field text-foreground hover:underline"
+        @click.stop
+      >{{ card.preview.title ?? card.preview.originalUrl }}</a>
+      <span v-if="card.preview.description" class="type-caption line-clamp-2 text-muted-foreground">{{ card.preview.description }}</span>
+    </div>
 
     <section
       v-for="card in eventCards"

--- a/chat/src/components/chat/MessageBody.vue
+++ b/chat/src/components/chat/MessageBody.vue
@@ -91,11 +91,19 @@ const linkInfoCards = computed(() =>
 const videoPreviewCards = computed(() =>
   linkPreviews.value.flatMap((preview) => {
     const state = linkPreviewMediaState(preview);
-    return state.kind === "video"
-      ? [{ preview, video: state.video, ...(state.poster ? { poster: state.poster } : {}) }]
-      : [];
+    // Defensive: only ever play from an https source, independent of the
+    // upstream host policy that already enforces it server-side.
+    if (state.kind !== "video" || !isHttpsUrl(state.video.url)) return [];
+    return [{ preview, video: state.video, ...(state.poster ? { poster: state.poster } : {}) }];
   }),
 );
+function isHttpsUrl(value: string): boolean {
+  try {
+    return new URL(value).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
 function videoCardKey(preview: MessageLinkPreview): string {
   return `${preview.originalUrl}:${preview.normalizedUrl ?? ""}`;
 }

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -47,6 +47,7 @@ export interface LinkPreview {
   title?: string;
   description?: string;
   image?: LinkPreviewImage;
+  video?: LinkPreviewVideo;
   remoteMediaUnavailable?: boolean;
 }
 
@@ -58,12 +59,23 @@ export interface LinkPreviewImage {
   alt?: string;
 }
 
+/// Trusted direct playable video the client may inline-play on user action.
+export interface LinkPreviewVideo {
+  url: string;
+  mediaType: string;
+  size?: number;
+}
+
 export type LinkPreviewMediaState =
   | { kind: "none" }
   | { kind: "image"; image: LinkPreviewImage }
+  | { kind: "video"; video: LinkPreviewVideo; poster?: LinkPreviewImage }
   | { kind: "remote-unavailable" };
 
 export function linkPreviewMediaState(preview: LinkPreview): LinkPreviewMediaState {
+  if (preview.video) {
+    return { kind: "video", video: preview.video, ...(preview.image ? { poster: preview.image } : {}) };
+  }
   if (preview.image) return { kind: "image", image: preview.image };
   if (preview.remoteMediaUnavailable) return { kind: "remote-unavailable" };
   return { kind: "none" };

--- a/chat/src/lib/xmpp/link-preview-video.ts
+++ b/chat/src/lib/xmpp/link-preview-video.ts
@@ -1,0 +1,57 @@
+import type { LinkPreview, LinkPreviewVideo } from "@/lib/chat-ui";
+import { isVideoFile } from "@/lib/message-media";
+import type { SharedFileInfo } from "./types";
+
+/**
+ * Tie a server-stamped XEP-0447 inline-video file-share to the XEP-0511 link
+ * preview that describes the same URL.
+ *
+ * The server stamps a direct-video link preview as two conformant elements: an
+ * XEP-0511 `<rdf:Description>` link card and an XEP-0447 inline `<file-sharing>`
+ * whose source is the playable URL. The client surfaces these as a `LinkPreview`
+ * and a `SharedFileInfo` respectively. Associating them here lets the dedicated
+ * video preview card own the file-share (play-on-click, no preload) instead of
+ * the generic attachment renderer, which would otherwise show it twice and
+ * auto-fetch its metadata.
+ *
+ * Trust anchor: only the server can stamp the XEP-0511 card (client-authored
+ * link metadata is stripped server-side), so a file-share is only promoted to a
+ * preview video when its URL matches a server-stamped preview.
+ */
+export function associateDirectVideoPreviews(
+  linkPreviews: LinkPreview[],
+  sharedFiles: SharedFileInfo[],
+): { linkPreviews: LinkPreview[]; sharedFiles: SharedFileInfo[] } {
+  const consumed = new Set<SharedFileInfo>();
+
+  const associated = linkPreviews.map((preview) => {
+    if (preview.video) return preview;
+    const match = sharedFiles.find(
+      (file) =>
+        !consumed.has(file)
+        && file.disposition === "inline"
+        && isVideoFile(file.mediaType, file.url)
+        && matchesPreviewUrl(preview, file.url),
+    );
+    if (!match) return preview;
+    consumed.add(match);
+    return { ...preview, video: previewVideoFromShared(match) };
+  });
+
+  return {
+    linkPreviews: associated,
+    sharedFiles: sharedFiles.filter((file) => !consumed.has(file)),
+  };
+}
+
+function matchesPreviewUrl(preview: LinkPreview, url: string): boolean {
+  return url === (preview.normalizedUrl ?? preview.originalUrl) || url === preview.originalUrl;
+}
+
+function previewVideoFromShared(file: SharedFileInfo): LinkPreviewVideo {
+  return {
+    url: file.url,
+    mediaType: file.mediaType ?? "video/mp4",
+    ...(typeof file.size === "number" ? { size: file.size } : {}),
+  };
+}

--- a/chat/src/lib/xmpp/wasm-message-codecs.ts
+++ b/chat/src/lib/xmpp/wasm-message-codecs.ts
@@ -6,6 +6,7 @@ import type { WaddleEncryptedFile } from "./extensions/encrypted-file";
 import { barePeerJid } from "./jid";
 import type { InboxEntry } from "./inbox-types";
 import { isTrustedCachedPreviewImageUrl } from "./link-preview";
+import { associateDirectVideoPreviews } from "./link-preview-video";
 import {
   buildReplyFallbackPrefix,
   shiftMarkupSpans,
@@ -430,6 +431,11 @@ export function roomMessageFromArchived(
   if (!message.body && !message.subject && !sharedFiles.length && !linkPreviews.length && !extensionAnnotations.length && !message.forum_post_kind && !message.is_retracted) {
     return null;
   }
+  const { linkPreviews: associatedLinkPreviews, sharedFiles: associatedSharedFiles } =
+    associateDirectVideoPreviews(
+      linkPreviews.map((preview) => linkPreviewFromWasm(preview, decodeOptions)),
+      sharedFiles.map(sharedFileFromWasm),
+    );
   const base: LiveRoomMessage = {
     id: roomPrimaryId,
     archiveId: message.mam_id,
@@ -460,8 +466,8 @@ export function roomMessageFromArchived(
       ? { markup: markupSpans.flatMap((s) => { const m = wasmSpanToMarkupSpan(s); return m ? [m] : []; }) }
       : {}),
     ...(references.length ? { references: references.map(referenceFromWasm) } : {}),
-    ...(sharedFiles.length ? { sharedFiles: sharedFiles.map(sharedFileFromWasm) } : {}),
-    ...(linkPreviews.length ? { linkPreviews: linkPreviews.map((preview) => linkPreviewFromWasm(preview, decodeOptions)) } : {}),
+    ...(associatedSharedFiles.length ? { sharedFiles: associatedSharedFiles } : {}),
+    ...(associatedLinkPreviews.length ? { linkPreviews: associatedLinkPreviews } : {}),
     ...(extensionAnnotations.length ? { extensionAnnotations } : {}),
     ...(message.extension_body_fallback && extensionAnnotations.length ? { extensionBodyFallback: true } : {}),
     ...(message.is_sticker ? { isSticker: true } : {}),
@@ -538,6 +544,11 @@ export function dmMessageFromArchived(
   // anyway, but the codec stays symmetric with the room path so a stray
   // foreign-server archive row can't manifest a bodyless DM ghost either.
   if (!message.body && !message.subject && !sharedFiles.length && !linkPreviews.length && !extensionAnnotations.length && !message.is_retracted) return null;
+  const { linkPreviews: associatedLinkPreviews, sharedFiles: associatedSharedFiles } =
+    associateDirectVideoPreviews(
+      linkPreviews.map((preview) => linkPreviewFromWasm(preview, decodeOptions)),
+      sharedFiles.map(sharedFileFromWasm),
+    );
   const base: LiveDmMessage = {
     id: dmPrimaryId,
     archiveId: message.mam_id,
@@ -562,8 +573,8 @@ export function dmMessageFromArchived(
       ? { markup: markupSpans.flatMap((s) => { const m = wasmSpanToMarkupSpan(s); return m ? [m] : []; }) }
       : {}),
     ...(references.length ? { references: references.map(referenceFromWasm) } : {}),
-    ...(sharedFiles.length ? { sharedFiles: sharedFiles.map(sharedFileFromWasm) } : {}),
-    ...(linkPreviews.length ? { linkPreviews: linkPreviews.map((preview) => linkPreviewFromWasm(preview, decodeOptions)) } : {}),
+    ...(associatedSharedFiles.length ? { sharedFiles: associatedSharedFiles } : {}),
+    ...(associatedLinkPreviews.length ? { linkPreviews: associatedLinkPreviews } : {}),
     ...(extensionAnnotations.length ? { extensionAnnotations } : {}),
     ...(message.extension_body_fallback && extensionAnnotations.length ? { extensionBodyFallback: true } : {}),
     ...(message.is_sticker ? { isSticker: true } : {}),

--- a/chat/tests/link-preview-video.test.ts
+++ b/chat/tests/link-preview-video.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { associateDirectVideoPreviews } from "../src/lib/xmpp/link-preview-video";
+import type { LinkPreview } from "../src/lib/chat-ui";
+import type { SharedFileInfo } from "../src/lib/xmpp/types";
+
+describe("associateDirectVideoPreviews", () => {
+  test("attaches an inline video file-share to the matching link preview and removes it from shared files", () => {
+    const previews: LinkPreview[] = [
+      { originalUrl: "https://cdn.example.com/clip.mp4", normalizedUrl: "https://cdn.example.com/clip.mp4" },
+    ];
+    const sharedFiles: SharedFileInfo[] = [
+      { url: "https://cdn.example.com/clip.mp4", mediaType: "video/mp4", size: 4096, disposition: "inline" },
+    ];
+
+    const result = associateDirectVideoPreviews(previews, sharedFiles);
+
+    expect(result.linkPreviews[0].video).toEqual({
+      url: "https://cdn.example.com/clip.mp4",
+      mediaType: "video/mp4",
+      size: 4096,
+    });
+    // The file-share is consumed by the preview, so the generic attachment
+    // renderer never shows it (no double render, no preload auto-fetch).
+    expect(result.sharedFiles).toHaveLength(0);
+  });
+
+  test("leaves unrelated inline video attachments untouched", () => {
+    const previews: LinkPreview[] = [
+      { originalUrl: "https://example.com/article", normalizedUrl: "https://example.com/article" },
+    ];
+    const sharedFiles: SharedFileInfo[] = [
+      { url: "https://files.example.com/upload.mp4", mediaType: "video/mp4", disposition: "inline" },
+    ];
+
+    const result = associateDirectVideoPreviews(previews, sharedFiles);
+
+    expect(result.linkPreviews[0].video).toBeUndefined();
+    expect(result.sharedFiles).toHaveLength(1);
+  });
+
+  test("does not associate non-video file shares that happen to match a preview URL", () => {
+    const previews: LinkPreview[] = [
+      { originalUrl: "https://example.com/page", normalizedUrl: "https://example.com/page" },
+    ];
+    const sharedFiles: SharedFileInfo[] = [
+      { url: "https://example.com/page", mediaType: "application/pdf", disposition: "attachment" },
+    ];
+
+    const result = associateDirectVideoPreviews(previews, sharedFiles);
+
+    expect(result.linkPreviews[0].video).toBeUndefined();
+    expect(result.sharedFiles).toHaveLength(1);
+  });
+});

--- a/chat/tests/message-body-link-previews.test.ts
+++ b/chat/tests/message-body-link-previews.test.ts
@@ -42,6 +42,64 @@ describe("MessageBody link previews", () => {
     expect(html).toContain("Remote preview media unavailable");
     expect(html).toContain("Remote article");
   });
+
+  test("renders a direct-video preview as an accessible play control without preloading the video", async () => {
+    const html = await renderMessageBody({
+      message: messageWithPreviews([
+        {
+          originalUrl: "https://cdn.example.com/clip.mp4",
+          normalizedUrl: "https://cdn.example.com/clip.mp4",
+          title: "A short clip",
+          video: { url: "https://cdn.example.com/clip.mp4", mediaType: "video/mp4", size: 4096 },
+        },
+      ]),
+    });
+
+    // Accessible play control exists.
+    expect(html).toContain("aria-label=\"Play video: A short clip\"");
+    // Playback starts only after user action: the <video> element (and its
+    // network-triggering src) MUST NOT be present in the initial render.
+    expect(html).not.toContain("<video");
+    expect(html).not.toContain("src=\"https://cdn.example.com/clip.mp4\"");
+    expect(html).toContain("A short clip");
+  });
+
+  test("renders the cached poster image for a direct-video preview when available", async () => {
+    const html = await renderMessageBody({
+      message: messageWithPreviews([
+        {
+          originalUrl: "https://cdn.example.com/clip.mp4",
+          normalizedUrl: "https://cdn.example.com/clip.mp4",
+          title: "Clip with poster",
+          video: { url: "https://cdn.example.com/clip.mp4", mediaType: "video/mp4" },
+          image: {
+            url: "https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview.png",
+            mediaType: "image/png",
+            alt: "Poster frame",
+          },
+        },
+      ]),
+    });
+
+    expect(html).toContain('src="https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview.png"');
+    expect(html).toContain("aria-label=\"Play video: Clip with poster\"");
+  });
+
+  test("escapes markup in a direct-video preview title — no arbitrary HTML/JS execution", async () => {
+    const html = await renderMessageBody({
+      message: messageWithPreviews([
+        {
+          originalUrl: "https://cdn.example.com/clip.mp4",
+          normalizedUrl: "https://cdn.example.com/clip.mp4",
+          title: "<script>alert('x')</script>",
+          video: { url: "https://cdn.example.com/clip.mp4", mediaType: "video/mp4" },
+        },
+      ]),
+    });
+
+    expect(html).not.toContain("<script>alert('x')</script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
 });
 
 function messageWithPreviews(linkPreviews: TimelineMessage["linkPreviews"]): TimelineMessage {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
@@ -9,7 +9,7 @@ use minidom::rxml::xml_ncname;
 use url::Url;
 use waddle_xmpp::xep::{
     encode_link_preview_token_checked, LinkPreviewTokenData, LinkPreviewTokenImage,
-    NS_WADDLE_LINK_PREVIEW,
+    LinkPreviewTokenVideo, NS_WADDLE_LINK_PREVIEW,
 };
 #[cfg(test)]
 use waddle_xmpp_core::PreviewImageMediaType;
@@ -174,6 +174,11 @@ async fn handle_link_preview_lookup_iq_with_policy(
             height: image.height,
             alt: image.alt,
         }),
+        video: metadata.video.map(|video| LinkPreviewTokenVideo {
+            url: video.url,
+            media_type: video.media_type,
+            size: video.size,
+        }),
         expires_at_unix: expires_at.timestamp(),
     };
     let Some(token) = encode_link_preview_token_checked(&data, deps.secret) else {
@@ -309,6 +314,18 @@ fn build_link_preview_lookup_result(
                 image_elem = image_elem.attr(xml_ncname!("alt").to_owned(), alt.trim());
             }
             preview.append_child(image_elem.build());
+        }
+        if let Some(video) = &data.video {
+            let mut video_elem = Element::builder("video", NS_WADDLE_LINK_PREVIEW)
+                .attr(xml_ncname!("url").to_owned(), video.url.as_str())
+                .attr(
+                    xml_ncname!("media-type").to_owned(),
+                    video.media_type.as_str(),
+                );
+            if let Some(size) = video.size {
+                video_elem = video_elem.attr(xml_ncname!("size").to_owned(), size.to_string());
+            }
+            preview.append_child(video_elem.build());
         }
         lookup = lookup.append(preview);
     }
@@ -480,6 +497,84 @@ mod tests {
             recorded_events::take().contains(&LinkPreviewTelemetryEvent::ResolverReady),
             "ready lookup path must emit ready telemetry"
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn direct_video_lookup_mints_token_and_advertises_video() {
+        let _events_guard = recorded_events::async_lock().await;
+        recorded_events::clear();
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/clip.mp4"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(vec![0u8; 4096], "video/mp4"))
+            .mount(&server)
+            .await;
+        let state = create_test_websocket_state().await;
+        let resolver_policy = LinkPreviewResolverPolicy {
+            allow_http_loopback_for_tests: true,
+            ..Default::default()
+        };
+        let lookup_url = format!("{}/clip.mp4", server.uri());
+        let payload = Element::builder("lookup", NS_WADDLE_LINK_PREVIEW)
+            .append(
+                Element::builder("url", NS_WADDLE_LINK_PREVIEW)
+                    .append(lookup_url.as_str())
+                    .build(),
+            )
+            .append(
+                Element::builder("scope", NS_WADDLE_LINK_PREVIEW)
+                    .append("alice@example.com")
+                    .build(),
+            )
+            .build();
+        let iq = iq_get_with_payload(payload);
+
+        let response = handle_link_preview_lookup_iq_with_policy(
+            &iq,
+            Some(&sender()),
+            state.as_ref(),
+            LinkPreviewLookupDeps {
+                muc_domain: "muc.example.com",
+                response_from: None,
+                response_to: None,
+                secret: secret(),
+                resolver_policy: Some(&resolver_policy),
+            },
+        )
+        .await;
+
+        let elem: Element = response[0].parse().expect("iq result");
+        let lookup = elem
+            .get_child("lookup", NS_WADDLE_LINK_PREVIEW)
+            .expect("lookup result");
+        assert_eq!(lookup.attr("status"), Some("ready"));
+        let preview = lookup
+            .get_child("preview", NS_WADDLE_LINK_PREVIEW)
+            .expect("preview");
+        let video = preview
+            .get_child("video", NS_WADDLE_LINK_PREVIEW)
+            .expect("video element");
+        assert_eq!(video.attr("media-type"), Some("video/mp4"));
+        assert_eq!(video.attr("url"), Some(lookup_url.as_str()));
+        assert_eq!(video.attr("size"), Some("4096"));
+        assert!(
+            preview.get_child("image", NS_WADDLE_LINK_PREVIEW).is_none(),
+            "direct video preview has no cached image"
+        );
+
+        let token = waddle_xmpp::xep::LinkPreviewToken::new(
+            preview.attr("token").expect("token").to_string(),
+        )
+        .expect("token");
+        let decoded =
+            waddle_xmpp::xep::decode_link_preview_token(&token, secret(), i64::MIN).expect("token");
+        let decoded_video = decoded.video.expect("token video");
+        assert_eq!(
+            decoded_video.media_type,
+            waddle_xmpp_core::DirectVideoMediaType::Mp4
+        );
+        assert_eq!(decoded_video.url.as_str(), lookup_url.as_str());
+        assert_eq!(decoded_video.size, Some(4096));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
@@ -11,7 +11,7 @@ use reqwest::{redirect, Client, StatusCode};
 use sha2::{Digest, Sha256};
 use tracing::warn;
 use url::{Host, Url};
-use waddle_xmpp_core::PreviewImageMediaType;
+use waddle_xmpp_core::{DirectVideoMediaType, PreviewImageMediaType};
 
 use crate::config::{LinkPreviewConfig, LinkPreviewHostPattern};
 use crate::db::actor::{DbActor, DbExecute};
@@ -36,6 +36,18 @@ pub(super) struct ResolvedLinkMetadata {
     pub title: Option<String>,
     pub description: Option<String>,
     pub image: Option<ResolvedLinkPreviewImage>,
+    /// Direct playable video discovered when the link itself is a trusted
+    /// direct-media file. Mutually exclusive with HTML-derived previews.
+    pub video: Option<ResolvedDirectVideo>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ResolvedDirectVideo {
+    /// Policy-validated remote URL the client plays from on user action.
+    pub url: Url,
+    pub media_type: DirectVideoMediaType,
+    /// Total byte size when advertised by the origin.
+    pub size: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -207,6 +219,24 @@ pub(super) async fn resolve_link_preview(
                 }
                 return LinkPreviewResolverOutcome::Ready(Box::new(metadata));
             }
+            FetchOnceResult::DirectVideo {
+                final_url,
+                media_type,
+                size,
+            } => {
+                return LinkPreviewResolverOutcome::Ready(Box::new(ResolvedLinkMetadata {
+                    original_url: url.clone(),
+                    normalized_url: final_url.clone(),
+                    title: None,
+                    description: None,
+                    image: None,
+                    video: Some(ResolvedDirectVideo {
+                        url: final_url,
+                        media_type,
+                        size,
+                    }),
+                }));
+            }
             FetchOnceResult::Redirect(next) => {
                 if redirect_count == policy.max_redirects {
                     return LinkPreviewResolverOutcome::Failed;
@@ -229,6 +259,24 @@ fn looks_like_direct_video_url(url: &Url) -> bool {
                 || filename.ends_with(".m4v")
                 || filename.ends_with(".ogv")
     )
+}
+
+/// Best-effort total byte size of a direct-media response.
+///
+/// A `Range` request can yield `206 Partial Content`, whose `Content-Length`
+/// is only the returned slice; the authoritative total lives in the
+/// `Content-Range` `…/<total>` suffix. Returns `None` when unknown.
+fn direct_video_total_size(response: &reqwest::Response) -> Option<u64> {
+    if response.status() == StatusCode::PARTIAL_CONTENT {
+        response
+            .headers()
+            .get(CONTENT_RANGE)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.rsplit('/').next())
+            .and_then(|total| total.trim().parse::<u64>().ok())
+    } else {
+        response.content_length()
+    }
 }
 
 async fn fetch_cached_preview_image(
@@ -461,7 +509,15 @@ async fn fetch_image_once(
 }
 
 enum FetchOnceResult {
-    Html { final_url: Url, html: String },
+    Html {
+        final_url: Url,
+        html: String,
+    },
+    DirectVideo {
+        final_url: Url,
+        media_type: DirectVideoMediaType,
+        size: Option<u64>,
+    },
     Redirect(Url),
 }
 
@@ -531,6 +587,23 @@ async fn fetch_html_once(
                 .trim()
                 .to_ascii_lowercase()
         });
+    if let Some(media_type) = content_type
+        .as_deref()
+        .and_then(|value| value.parse::<DirectVideoMediaType>().ok())
+    {
+        // Direct video is accepted only when policy allows it AND the URL itself
+        // names a direct playable file. This blocks provider endpoints that
+        // return a video content-type for non-file (embed/watch) URLs, and is
+        // defense-in-depth on top of the classify-time `video_enabled` gate.
+        if policy.video_enabled && looks_like_direct_video_url(url) {
+            return Ok(FetchOnceResult::DirectVideo {
+                final_url: url.clone(),
+                media_type,
+                size: direct_video_total_size(&response),
+            });
+        }
+        return Err(LinkPreviewResolverStatus::Unsupported);
+    }
     if !matches!(
         content_type.as_deref(),
         Some("text/html") | Some("application/xhtml+xml")
@@ -924,6 +997,7 @@ fn extract_metadata_parts_from_html(
             title,
             description,
             image: None,
+            video: None,
         },
         image,
     ))
@@ -1679,6 +1753,55 @@ mod tests {
             ..Default::default()
         };
         let url = Url::parse(&format!("{}/clip.mp4", server.uri())).expect("url");
+
+        assert_eq!(
+            resolve_link_preview(&url, &policy).await,
+            LinkPreviewResolverOutcome::Unsupported
+        );
+    }
+
+    #[tokio::test]
+    async fn detects_direct_video_file_and_returns_typed_video_metadata() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/clip.mp4"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(vec![0u8; 4096], "video/mp4"))
+            .mount(&server)
+            .await;
+        let policy = LinkPreviewResolverPolicy {
+            allow_http_loopback_for_tests: true,
+            ..Default::default()
+        };
+        let url = Url::parse(&format!("{}/clip.mp4", server.uri())).expect("url");
+
+        let outcome = resolve_link_preview(&url, &policy).await;
+
+        let LinkPreviewResolverOutcome::Ready(metadata) = outcome else {
+            panic!("expected ready outcome, got {outcome:?}");
+        };
+        let video = metadata.video.expect("direct video metadata");
+        assert_eq!(video.media_type, DirectVideoMediaType::Mp4);
+        assert_eq!(video.url.as_str(), url.as_str());
+        assert_eq!(video.size, Some(4096));
+        assert!(metadata.image.is_none(), "direct video has no preview image");
+        assert!(metadata.title.is_none());
+    }
+
+    #[tokio::test]
+    async fn rejects_video_content_type_at_non_video_path_without_fetching_body() {
+        // A provider endpoint that returns a video content-type for a non-file
+        // URL (e.g. an embed/watch page) must not be treated as a direct video.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/watch"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw("not a file", "video/mp4"))
+            .mount(&server)
+            .await;
+        let policy = LinkPreviewResolverPolicy {
+            allow_http_loopback_for_tests: true,
+            ..Default::default()
+        };
+        let url = Url::parse(&format!("{}/watch", server.uri())).expect("url");
 
         assert_eq!(
             resolve_link_preview(&url, &policy).await,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
@@ -1783,7 +1783,10 @@ mod tests {
         assert_eq!(video.media_type, DirectVideoMediaType::Mp4);
         assert_eq!(video.url.as_str(), url.as_str());
         assert_eq!(video.size, Some(4096));
-        assert!(metadata.image.is_none(), "direct video has no preview image");
+        assert!(
+            metadata.image.is_none(),
+            "direct video has no preview image"
+        );
         assert!(metadata.title.is_none());
     }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
@@ -1791,6 +1791,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn direct_video_total_size_uses_content_range_total_on_partial_response() {
+        // A Range request can return 206 Partial Content whose Content-Length is
+        // only the slice; the authoritative total is the Content-Range suffix.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/clip.mp4"))
+            .respond_with(
+                ResponseTemplate::new(206)
+                    .insert_header("content-range", "bytes 0-255/1048576")
+                    .set_body_raw(vec![0u8; 256], "video/mp4"),
+            )
+            .mount(&server)
+            .await;
+        let policy = LinkPreviewResolverPolicy {
+            allow_http_loopback_for_tests: true,
+            ..Default::default()
+        };
+        let url = Url::parse(&format!("{}/clip.mp4", server.uri())).expect("url");
+
+        let LinkPreviewResolverOutcome::Ready(metadata) = resolve_link_preview(&url, &policy).await
+        else {
+            panic!("expected ready outcome");
+        };
+        let video = metadata.video.expect("direct video metadata");
+        assert_eq!(video.size, Some(1_048_576));
+    }
+
+    #[tokio::test]
     async fn rejects_video_content_type_at_non_video_path_without_fetching_body() {
         // A provider endpoint that returns a video content-type for a non-file
         // URL (e.g. an embed/watch page) must not be treated as a direct video.

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
@@ -1813,6 +1813,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn html_embed_page_at_video_extension_is_never_treated_as_direct_video() {
+        // A provider embed/iframe page (text/html) served at a video-looking URL
+        // must follow the HTML metadata path, never the direct-video path —
+        // content-type is authoritative, so no file-sharing stamping can result.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/clip.mp4"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                r#"<html><head>
+                      <meta property="og:title" content="Embedded player">
+                    </head><body><iframe src="https://provider.example/embed"></iframe></body></html>"#,
+                "text/html; charset=utf-8",
+            ))
+            .mount(&server)
+            .await;
+        let policy = LinkPreviewResolverPolicy {
+            allow_http_loopback_for_tests: true,
+            ..Default::default()
+        };
+        let url = Url::parse(&format!("{}/clip.mp4", server.uri())).expect("url");
+
+        let LinkPreviewResolverOutcome::Ready(metadata) = resolve_link_preview(&url, &policy).await
+        else {
+            panic!("expected html metadata outcome");
+        };
+        assert!(
+            metadata.video.is_none(),
+            "html embed pages must never produce direct-video metadata"
+        );
+        assert_eq!(metadata.title.as_deref(), Some("Embedded player"));
+    }
+
+    #[tokio::test]
     async fn fetches_html_metadata_with_bounded_test_policy() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -8,10 +8,9 @@ use waddle_xmpp::{
     xep::{
         add_reference, build_file_sharing_element, build_link_metadata_element,
         decode_link_preview_token, extract_link_preview_request_from_message,
-        is_file_sharing_element, parse_fallbacks_from_message, parse_file_sharing_element,
-        strip_fallback_ranges, strip_link_metadata, strip_link_preview_requests, Disposition,
-        FallbackRegion, FileMetadata, FileSharing, LinkMetadata, Reference, WaddleLinkPreviewError,
-        NS_DELAY, NS_REPLY,
+        parse_fallbacks_from_message, strip_fallback_ranges, strip_link_metadata,
+        strip_link_preview_requests, Disposition, FallbackRegion, FileMetadata, FileSharing,
+        LinkMetadata, Reference, WaddleLinkPreviewError, NS_DELAY, NS_REPLY,
     },
     Stanza,
 };
@@ -133,14 +132,14 @@ fn consume_link_preview_request(
         strip_link_metadata(message);
         return;
     }
-    // Trust-anchor guard: the server is the sole authority for direct-video
-    // previews. A client must not pre-author an XEP-0447 file-share whose
-    // source is the previewed link and have it promoted to a "trusted" video
-    // card by recipients. Drop any client-authored file-share that targets the
-    // message's first eligible link before the server stamps its own. Genuine
-    // XEP-0363 uploads point at the Waddle media origin, never the external
-    // body link, so this never strips a real attachment.
-    strip_client_file_sharing_for_previewed_link(message);
+    // Trust anchor for direct-video preview cards: a recipient client only
+    // promotes an inline-video file-share to a video card when its URL matches a
+    // server-stamped XEP-0511 link card, and client-authored XEP-0511 metadata is
+    // unconditionally stripped below before the server stamps its own. A client
+    // therefore cannot forge the card. We deliberately do NOT strip client
+    // file-shares whose source equals the body link here — that is the canonical
+    // XEP-0447 shape (body = URL + <file-sharing>) for legitimately sharing a
+    // file whose URL also appears in the body.
     let expected_sender = sender_jid.to_bare();
     let expected_scope = message.to.as_ref().map(|to| to.to_bare());
     let decoded = extract_link_preview_request_from_message(message).and_then(|token| {
@@ -228,24 +227,6 @@ fn link_preview_token_urls_allowed_by_current_policy(
 ) -> bool {
     link_preview_url_allowed_by_current_policy(&preview.original_url, link_preview)
         && link_preview_url_allowed_by_current_policy(&preview.normalized_url, link_preview)
-}
-
-/// Remove client-authored XEP-0447 file-shares whose source is the link this
-/// message previews. See the call site for the trust rationale.
-fn strip_client_file_sharing_for_previewed_link(message: &mut xmpp_parsers::message::Message) {
-    let Some(body_url) = first_eligible_https_url(message) else {
-        return;
-    };
-    message.payloads.retain(|payload| {
-        if !is_file_sharing_element(payload) {
-            return true;
-        }
-        let targets_previewed_link = parse_file_sharing_element(payload)
-            .and_then(|sharing| sharing.first_url().map(str::to_string))
-            .and_then(|raw| url::Url::parse(&raw).ok())
-            .is_some_and(|source| source == body_url);
-        !targets_previewed_link
-    });
 }
 
 fn link_preview_url_allowed_by_current_policy(
@@ -597,59 +578,26 @@ mod tests {
     }
 
     #[test]
-    fn client_authored_file_sharing_for_previewed_link_is_stripped() {
-        // A sender hand-crafts an inline-video file-share whose source is the
-        // very link they posted, hoping recipients promote it to a trusted
-        // direct-video card. The server must drop it; only server-stamped
-        // direct-video file-shares may reach recipients.
+    fn client_authored_inline_video_for_body_link_survives_when_no_server_video_preview() {
+        // The canonical XEP-0447 shape is body = URL plus a <file-sharing> for
+        // that same URL. This is a legitimate file share and MUST survive link
+        // preview consumption. The recipient never promotes it to a trusted
+        // video card unless a server-stamped XEP-0511 card exists for the URL,
+        // which clients cannot forge (client-authored metadata is stripped).
         let mut message = Message::new(None::<jid::Jid>);
         message.to = Some("room@muc.example.com".parse().expect("jid"));
         message.bodies.insert(
             xmpp_parsers::message::Lang::new(),
-            "look https://attacker.example.com/article".to_string(),
+            "https://files.example.com/clip.mp4".to_string(),
         );
-        let forged = FileSharing::new(
-            FileMetadata::new()
-                .with_media_type("video/mp4")
-                .with_size(9000),
-        )
-        .with_url("https://attacker.example.com/article")
-        .with_disposition(Disposition::Inline);
-        message.payloads.push(build_file_sharing_element(&forged));
-
-        consume_link_preview_request(
-            &mut message,
-            &sender(),
-            SECRET,
-            1_800_000_000,
-            "https://waddle.example",
-            &LinkPreviewConfig::default(),
-        );
-
-        assert!(
-            waddle_xmpp::xep::extract_file_sharing_from_message(&message).is_none(),
-            "client-authored file-share targeting the previewed link must be stripped"
-        );
-    }
-
-    #[test]
-    fn genuine_upload_file_sharing_survives_link_preview_consumption() {
-        // A real XEP-0363 upload points at the Waddle media origin, not the
-        // external body link, so it must NOT be stripped.
-        let mut message = Message::new(None::<jid::Jid>);
-        message.to = Some("room@muc.example.com".parse().expect("jid"));
-        message.bodies.insert(
-            xmpp_parsers::message::Lang::new(),
-            "see https://example.com/article and my clip".to_string(),
-        );
-        let upload = FileSharing::new(
+        let shared = FileSharing::new(
             FileMetadata::new()
                 .with_media_type("video/mp4")
                 .with_size(1234),
         )
-        .with_url("https://waddle.example/api/files/abc/clip.mp4")
+        .with_url("https://files.example.com/clip.mp4")
         .with_disposition(Disposition::Inline);
-        message.payloads.push(build_file_sharing_element(&upload));
+        message.payloads.push(build_file_sharing_element(&shared));
 
         consume_link_preview_request(
             &mut message,
@@ -661,10 +609,10 @@ mod tests {
         );
 
         let sharing = waddle_xmpp::xep::extract_file_sharing_from_message(&message)
-            .expect("genuine upload file-share survives");
+            .expect("legitimate XEP-0447 file-share with URL-in-body must survive");
         assert_eq!(
             sharing.first_url(),
-            Some("https://waddle.example/api/files/abc/clip.mp4")
+            Some("https://files.example.com/clip.mp4")
         );
     }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -8,9 +8,10 @@ use waddle_xmpp::{
     xep::{
         add_reference, build_file_sharing_element, build_link_metadata_element,
         decode_link_preview_token, extract_link_preview_request_from_message,
-        parse_fallbacks_from_message, strip_fallback_ranges, strip_link_metadata,
-        strip_link_preview_requests, Disposition, FallbackRegion, FileMetadata, FileSharing,
-        LinkMetadata, Reference, WaddleLinkPreviewError, NS_DELAY, NS_REPLY,
+        is_file_sharing_element, parse_fallbacks_from_message, parse_file_sharing_element,
+        strip_fallback_ranges, strip_link_metadata, strip_link_preview_requests, Disposition,
+        FallbackRegion, FileMetadata, FileSharing, LinkMetadata, Reference, WaddleLinkPreviewError,
+        NS_DELAY, NS_REPLY,
     },
     Stanza,
 };
@@ -132,6 +133,14 @@ fn consume_link_preview_request(
         strip_link_metadata(message);
         return;
     }
+    // Trust-anchor guard: the server is the sole authority for direct-video
+    // previews. A client must not pre-author an XEP-0447 file-share whose
+    // source is the previewed link and have it promoted to a "trusted" video
+    // card by recipients. Drop any client-authored file-share that targets the
+    // message's first eligible link before the server stamps its own. Genuine
+    // XEP-0363 uploads point at the Waddle media origin, never the external
+    // body link, so this never strips a real attachment.
+    strip_client_file_sharing_for_previewed_link(message);
     let expected_sender = sender_jid.to_bare();
     let expected_scope = message.to.as_ref().map(|to| to.to_bare());
     let decoded = extract_link_preview_request_from_message(message).and_then(|token| {
@@ -221,10 +230,31 @@ fn link_preview_token_urls_allowed_by_current_policy(
         && link_preview_url_allowed_by_current_policy(&preview.normalized_url, link_preview)
 }
 
+/// Remove client-authored XEP-0447 file-shares whose source is the link this
+/// message previews. See the call site for the trust rationale.
+fn strip_client_file_sharing_for_previewed_link(message: &mut xmpp_parsers::message::Message) {
+    let Some(body_url) = first_eligible_https_url(message) else {
+        return;
+    };
+    message.payloads.retain(|payload| {
+        if !is_file_sharing_element(payload) {
+            return true;
+        }
+        let targets_previewed_link = parse_file_sharing_element(payload)
+            .and_then(|sharing| sharing.first_url().map(str::to_string))
+            .and_then(|raw| url::Url::parse(&raw).ok())
+            .is_some_and(|source| source == body_url);
+        !targets_previewed_link
+    });
+}
+
 fn link_preview_url_allowed_by_current_policy(
     url: &url::Url,
     link_preview: &LinkPreviewConfig,
 ) -> bool {
+    if url.scheme() != "https" {
+        return false;
+    }
     if !link_preview.video_enabled && looks_like_direct_video_url(url) {
         return false;
     }
@@ -564,6 +594,78 @@ mod tests {
         let parsed = waddle_xmpp::xep::extract_link_metadata_from_message(&message);
         assert_eq!(parsed.len(), 1);
         assert_eq!(parsed[0].about, preview.original_url);
+    }
+
+    #[test]
+    fn client_authored_file_sharing_for_previewed_link_is_stripped() {
+        // A sender hand-crafts an inline-video file-share whose source is the
+        // very link they posted, hoping recipients promote it to a trusted
+        // direct-video card. The server must drop it; only server-stamped
+        // direct-video file-shares may reach recipients.
+        let mut message = Message::new(None::<jid::Jid>);
+        message.to = Some("room@muc.example.com".parse().expect("jid"));
+        message.bodies.insert(
+            xmpp_parsers::message::Lang::new(),
+            "look https://attacker.example.com/article".to_string(),
+        );
+        let forged = FileSharing::new(
+            FileMetadata::new()
+                .with_media_type("video/mp4")
+                .with_size(9000),
+        )
+        .with_url("https://attacker.example.com/article")
+        .with_disposition(Disposition::Inline);
+        message.payloads.push(build_file_sharing_element(&forged));
+
+        consume_link_preview_request(
+            &mut message,
+            &sender(),
+            SECRET,
+            1_800_000_000,
+            "https://waddle.example",
+            &LinkPreviewConfig::default(),
+        );
+
+        assert!(
+            waddle_xmpp::xep::extract_file_sharing_from_message(&message).is_none(),
+            "client-authored file-share targeting the previewed link must be stripped"
+        );
+    }
+
+    #[test]
+    fn genuine_upload_file_sharing_survives_link_preview_consumption() {
+        // A real XEP-0363 upload points at the Waddle media origin, not the
+        // external body link, so it must NOT be stripped.
+        let mut message = Message::new(None::<jid::Jid>);
+        message.to = Some("room@muc.example.com".parse().expect("jid"));
+        message.bodies.insert(
+            xmpp_parsers::message::Lang::new(),
+            "see https://example.com/article and my clip".to_string(),
+        );
+        let upload = FileSharing::new(
+            FileMetadata::new()
+                .with_media_type("video/mp4")
+                .with_size(1234),
+        )
+        .with_url("https://waddle.example/api/files/abc/clip.mp4")
+        .with_disposition(Disposition::Inline);
+        message.payloads.push(build_file_sharing_element(&upload));
+
+        consume_link_preview_request(
+            &mut message,
+            &sender(),
+            SECRET,
+            1_800_000_000,
+            "https://waddle.example",
+            &LinkPreviewConfig::default(),
+        );
+
+        let sharing = waddle_xmpp::xep::extract_file_sharing_from_message(&message)
+            .expect("genuine upload file-share survives");
+        assert_eq!(
+            sharing.first_url(),
+            Some("https://waddle.example/api/files/abc/clip.mp4")
+        );
     }
 
     #[test]

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -6,9 +6,10 @@ use waddle_xmpp::{
     protocol::handlers::errors::bad_request_reply,
     protocol::{frame::InboundFrame, InboundEvent, XmppStateMachine},
     xep::{
-        add_reference, build_link_metadata_element, decode_link_preview_token,
-        extract_link_preview_request_from_message, parse_fallbacks_from_message,
-        strip_fallback_ranges, strip_link_metadata, strip_link_preview_requests, FallbackRegion,
+        add_reference, build_file_sharing_element, build_link_metadata_element,
+        decode_link_preview_token, extract_link_preview_request_from_message,
+        parse_fallbacks_from_message, strip_fallback_ranges, strip_link_metadata,
+        strip_link_preview_requests, Disposition, FallbackRegion, FileMetadata, FileSharing,
         LinkMetadata, Reference, WaddleLinkPreviewError, NS_DELAY, NS_REPLY,
     },
     Stanza,
@@ -156,6 +157,24 @@ fn consume_link_preview_request(
                 && first_eligible_https_url(message).as_ref() == Some(&preview.original_url)
         })
         .map(|preview| {
+            // Direct-video preview source is a remote URL already validated by
+            // the token/host policy above. It is stamped as a conformant
+            // XEP-0447 inline file-share; the client plays it on user action.
+            let video_sharing = preview
+                .video
+                .filter(|video| {
+                    link_preview_url_allowed_by_current_policy(&video.url, link_preview)
+                })
+                .map(|video| {
+                    let mut file = FileMetadata::new().with_media_type(video.media_type.as_str());
+                    if let Some(size) = video.size {
+                        file = file.with_size(size);
+                    }
+                    FileSharing::new(file)
+                        .with_url(video.url.as_str())
+                        .with_disposition(Disposition::Inline)
+                });
+
             let mut metadata =
                 LinkMetadata::new(preview.original_url).with_canonical_url(preview.normalized_url);
             if let Some(title) = preview.title {
@@ -178,14 +197,19 @@ fn consume_link_preview_request(
                 }
                 metadata = metadata.with_image(preview_image);
             }
-            metadata
+            (metadata, video_sharing)
         });
     strip_link_preview_requests(message);
     strip_link_metadata(message);
-    if let Some(metadata) = metadata {
+    if let Some((metadata, video_sharing)) = metadata {
         message
             .payloads
             .push(build_link_metadata_element(&metadata));
+        if let Some(video_sharing) = video_sharing {
+            message
+                .payloads
+                .push(build_file_sharing_element(&video_sharing));
+        }
     }
 }
 
@@ -475,6 +499,101 @@ mod tests {
         assert_eq!(
             references[0].ref_type,
             waddle_xmpp::xep::ReferenceType::Data
+        );
+    }
+
+    fn direct_video_preview_token() -> waddle_xmpp::xep::LinkPreviewTokenData {
+        waddle_xmpp::xep::LinkPreviewTokenData {
+            sender_jid: "alice@example.com".parse().expect("jid"),
+            scope_jid: "room@muc.example.com".parse().expect("jid"),
+            original_url: url::Url::parse("https://cdn.example.com/clip.mp4").expect("url"),
+            normalized_url: url::Url::parse("https://cdn.example.com/clip.mp4").expect("url"),
+            title: None,
+            description: None,
+            image: None,
+            video: Some(waddle_xmpp::xep::LinkPreviewTokenVideo {
+                url: url::Url::parse("https://cdn.example.com/clip.mp4").expect("url"),
+                media_type: waddle_xmpp_core::DirectVideoMediaType::Mp4,
+                size: Some(4096),
+            }),
+            expires_at_unix: 1_900_000_000,
+        }
+    }
+
+    fn message_with_direct_video_request(
+        preview: &waddle_xmpp::xep::LinkPreviewTokenData,
+    ) -> Message {
+        let token = waddle_xmpp::xep::encode_link_preview_token(preview, SECRET);
+        let mut message = Message::new(None::<jid::Jid>);
+        message.to = Some("room@muc.example.com".parse().expect("jid"));
+        message.bodies.insert(
+            xmpp_parsers::message::Lang::new(),
+            "watch https://cdn.example.com/clip.mp4".to_string(),
+        );
+        message
+            .payloads
+            .push(waddle_xmpp::xep::build_link_preview_request_element(&token));
+        message
+    }
+
+    #[test]
+    fn consumes_direct_video_request_and_stamps_xep0447_inline_file_sharing() {
+        let preview = direct_video_preview_token();
+        let mut message = message_with_direct_video_request(&preview);
+
+        consume_link_preview_request(
+            &mut message,
+            &sender(),
+            SECRET,
+            1_800_000_000,
+            "https://waddle.example",
+            &LinkPreviewConfig::default(),
+        );
+
+        let sharing = waddle_xmpp::xep::extract_file_sharing_from_message(&message)
+            .expect("XEP-0447 file-sharing stamped for trusted direct video");
+        assert!(sharing.is_inline(), "direct video preview is inline");
+        assert_eq!(sharing.metadata.media_type.as_deref(), Some("video/mp4"));
+        assert_eq!(sharing.metadata.size, Some(4096));
+        assert_eq!(
+            sharing.first_url(),
+            Some("https://cdn.example.com/clip.mp4")
+        );
+
+        // XEP-0511 link metadata is stamped alongside the direct-media element.
+        let parsed = waddle_xmpp::xep::extract_link_metadata_from_message(&message);
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].about, preview.original_url);
+    }
+
+    #[test]
+    fn disabled_video_policy_suppresses_file_sharing_but_strips_request() {
+        let preview = direct_video_preview_token();
+        let mut message = message_with_direct_video_request(&preview);
+        let config = LinkPreviewConfig {
+            video_enabled: false,
+            ..LinkPreviewConfig::default()
+        };
+
+        consume_link_preview_request(
+            &mut message,
+            &sender(),
+            SECRET,
+            1_800_000_000,
+            "https://waddle.example",
+            &config,
+        );
+
+        assert!(
+            waddle_xmpp::xep::extract_file_sharing_from_message(&message).is_none(),
+            "disable-video policy must not stamp direct-video file sharing"
+        );
+        assert!(
+            message
+                .payloads
+                .iter()
+                .all(|payload| payload.ns() != waddle_xmpp::xep::NS_WADDLE_LINK_PREVIEW),
+            "private preview request is always stripped"
         );
     }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -425,6 +425,7 @@ mod tests {
                 height: Some(360),
                 alt: Some("Article screenshot".to_string()),
             }),
+            video: None,
             expires_at_unix: 1_900_000_000,
         };
         let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
@@ -487,6 +488,7 @@ mod tests {
             title: Some("Example".to_string()),
             description: None,
             image: None,
+            video: None,
             expires_at_unix: 1_900_000_000,
         };
         let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
@@ -529,6 +531,7 @@ mod tests {
             title: Some("Blocked".to_string()),
             description: None,
             image: None,
+            video: None,
             expires_at_unix: 1_900_000_000,
         };
         let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
@@ -577,6 +580,7 @@ mod tests {
                 title: Some("Blocked".to_string()),
                 description: None,
                 image: None,
+                video: None,
                 expires_at_unix: 1_900_000_000,
             };
             let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
@@ -616,6 +620,7 @@ mod tests {
             title: Some("Blocked canonical".to_string()),
             description: None,
             image: None,
+            video: None,
             expires_at_unix: 1_900_000_000,
         };
         let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
@@ -657,6 +662,7 @@ mod tests {
             title: Some("Video".to_string()),
             description: None,
             image: None,
+            video: None,
             expires_at_unix: 1_900_000_000,
         };
         let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
@@ -707,6 +713,7 @@ mod tests {
                 height: Some(360),
                 alt: None,
             }),
+            video: None,
             expires_at_unix: 1_900_000_000,
         };
         let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
@@ -773,6 +780,7 @@ mod tests {
                 height: Some(360),
                 alt: Some("Article screenshot".to_string()),
             }),
+            video: None,
             expires_at_unix: 1_900_000_000,
         };
         let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
@@ -814,6 +822,7 @@ mod tests {
             title: Some("Example".to_string()),
             description: None,
             image: None,
+            video: None,
             expires_at_unix: 10,
         };
         let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
@@ -917,6 +926,7 @@ mod tests {
             title: Some("Example".to_string()),
             description: None,
             image: None,
+            video: None,
             expires_at_unix: 1_900_000_000,
         };
         let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
@@ -952,6 +962,7 @@ mod tests {
             title: Some("Example".to_string()),
             description: None,
             image: None,
+            video: None,
             expires_at_unix: 1_900_000_000,
         };
         let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
@@ -987,6 +998,7 @@ mod tests {
             title: Some("Second".to_string()),
             description: None,
             image: None,
+            video: None,
             expires_at_unix: 1_900_000_000,
         };
         let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
@@ -1022,6 +1034,7 @@ mod tests {
             title: Some("Example".to_string()),
             description: None,
             image: None,
+            video: None,
             expires_at_unix: 1_900_000_000,
         };
         let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
@@ -1060,6 +1073,7 @@ mod tests {
             title: Some("Example".to_string()),
             description: None,
             image: None,
+            video: None,
             expires_at_unix: 1_900_000_000,
         };
         let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
@@ -1098,6 +1112,7 @@ mod tests {
             title: Some("Example".to_string()),
             description: None,
             image: None,
+            video: None,
             expires_at_unix: 1_900_000_000,
         };
         let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);
@@ -1136,6 +1151,7 @@ mod tests {
             title: Some("Current".to_string()),
             description: None,
             image: None,
+            video: None,
             expires_at_unix: 1_900_000_000,
         };
         let token = waddle_xmpp::xep::encode_link_preview_token(&preview, SECRET);

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
@@ -3752,6 +3752,7 @@ async fn groupchat_preview_request_is_stamped_and_archived_without_private_paylo
         title: Some("The Best Webpage".to_string()),
         description: Some("Plain text preview".to_string()),
         image: None,
+        video: None,
         expires_at_unix: chrono::Utc::now().timestamp() + 300,
     };
     let token =

--- a/server/crates/waddle-xmpp-core/src/lib.rs
+++ b/server/crates/waddle-xmpp-core/src/lib.rs
@@ -39,7 +39,9 @@ pub use domain::{
     ChannelInfo, ChannelRoomInfo, ChannelType, UploadSlotInfo, WaddleDetails, WaddleInfo,
 };
 pub use error::{CoreError, CoreResult};
-pub use link_preview::{first_eligible_https_url_text, PreviewImageMediaType};
+pub use link_preview::{
+    first_eligible_https_url_text, DirectVideoMediaType, PreviewImageMediaType,
+};
 pub use mam::{
     build_fin_iq, build_result_messages, is_mam_query, is_mam_query_response_message,
     parse_mam_query, ArchivedMessage, MamQuery, MamResult, DATA_FORMS_NS, FORWARD_NS, MAM_NS,

--- a/server/crates/waddle-xmpp-core/src/link_preview.rs
+++ b/server/crates/waddle-xmpp-core/src/link_preview.rs
@@ -55,6 +55,63 @@ impl fmt::Display for InvalidPreviewImageMediaType {
 
 impl std::error::Error for InvalidPreviewImageMediaType {}
 
+/// Safe direct-video MIME types Waddle accepts for trusted inline previews.
+///
+/// Only single, directly playable container files are listed. Adaptive
+/// streaming manifests (HLS `application/x-mpegurl`, DASH) and provider embed
+/// pages are intentionally excluded — they are not direct playable files.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DirectVideoMediaType {
+    Mp4,
+    Webm,
+    Ogg,
+    QuickTime,
+}
+
+impl DirectVideoMediaType {
+    /// Borrow the canonical MIME text used on the wire.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Mp4 => "video/mp4",
+            Self::Webm => "video/webm",
+            Self::Ogg => "video/ogg",
+            Self::QuickTime => "video/quicktime",
+        }
+    }
+}
+
+impl fmt::Display for DirectVideoMediaType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for DirectVideoMediaType {
+    type Err = InvalidDirectVideoMediaType;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.to_ascii_lowercase().as_str() {
+            "video/mp4" => Ok(Self::Mp4),
+            "video/webm" => Ok(Self::Webm),
+            "video/ogg" => Ok(Self::Ogg),
+            "video/quicktime" => Ok(Self::QuickTime),
+            _ => Err(InvalidDirectVideoMediaType),
+        }
+    }
+}
+
+/// Error returned for unsupported direct-video MIME text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InvalidDirectVideoMediaType;
+
+impl fmt::Display for InvalidDirectVideoMediaType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("unsupported direct video MIME type")
+    }
+}
+
+impl std::error::Error for InvalidDirectVideoMediaType {}
+
 /// Return the first HTTPS URL-like token whose host looks web-addressable.
 ///
 /// This intentionally stays string-based so crates that already parse into
@@ -122,5 +179,38 @@ mod tests {
     #[test]
     fn rejects_unsupported_preview_image_media_type() {
         assert!("image/svg+xml".parse::<PreviewImageMediaType>().is_err());
+    }
+
+    #[test]
+    fn parses_supported_direct_video_media_types_case_insensitively() {
+        assert_eq!(
+            "VIDEO/MP4".parse::<DirectVideoMediaType>(),
+            Ok(DirectVideoMediaType::Mp4)
+        );
+        assert_eq!(
+            "video/webm".parse::<DirectVideoMediaType>(),
+            Ok(DirectVideoMediaType::Webm)
+        );
+        assert_eq!(
+            "video/ogg".parse::<DirectVideoMediaType>(),
+            Ok(DirectVideoMediaType::Ogg)
+        );
+        assert_eq!(
+            "video/quicktime".parse::<DirectVideoMediaType>(),
+            Ok(DirectVideoMediaType::QuickTime)
+        );
+        assert_eq!(DirectVideoMediaType::Mp4.as_str(), "video/mp4");
+    }
+
+    #[test]
+    fn rejects_non_direct_video_media_types() {
+        assert!("text/html".parse::<DirectVideoMediaType>().is_err());
+        // HLS/DASH playlists are not single direct playable files.
+        assert!("application/x-mpegurl"
+            .parse::<DirectVideoMediaType>()
+            .is_err());
+        assert!("application/vnd.apple.mpegurl"
+            .parse::<DirectVideoMediaType>()
+            .is_err());
     }
 }

--- a/server/crates/waddle-xmpp/src/xep/exports.rs
+++ b/server/crates/waddle-xmpp/src/xep/exports.rs
@@ -425,8 +425,8 @@ pub use super::xep_waddle_link_preview::{
     encode_link_preview_token_checked, extract_link_preview_request_from_message,
     is_link_preview_request_element, parse_link_preview_request_element,
     strip_link_preview_requests, LinkPreviewToken, LinkPreviewTokenData, LinkPreviewTokenImage,
-    WaddleLinkPreviewError, ELEMENT_PREVIEW_REQUEST, MAX_LINK_PREVIEW_TOKEN_BYTES,
-    NS_WADDLE_LINK_PREVIEW,
+    LinkPreviewTokenVideo, WaddleLinkPreviewError, ELEMENT_PREVIEW_REQUEST,
+    MAX_LINK_PREVIEW_TOKEN_BYTES, NS_WADDLE_LINK_PREVIEW,
 };
 
 pub use super::xep0503::{

--- a/server/crates/waddle-xmpp/src/xep/xep_waddle_link_preview.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep_waddle_link_preview.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use thiserror::Error;
 use url::Url;
-use waddle_xmpp_core::PreviewImageMediaType;
+use waddle_xmpp_core::{DirectVideoMediaType, PreviewImageMediaType};
 use xmpp_parsers::message::Message;
 
 /// Waddle-private link preview namespace.
@@ -53,6 +53,9 @@ pub struct LinkPreviewTokenData {
     pub title: Option<String>,
     pub description: Option<String>,
     pub image: Option<LinkPreviewTokenImage>,
+    /// Trusted direct playable video sealed inside the token, when the link is
+    /// a direct-media file the client may inline-play on user action.
+    pub video: Option<LinkPreviewTokenVideo>,
     pub expires_at_unix: i64,
 }
 
@@ -66,6 +69,14 @@ pub struct LinkPreviewTokenImage {
     pub alt: Option<String>,
 }
 
+/// Cached direct-video metadata sealed inside a composer preview token.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkPreviewTokenVideo {
+    pub url: Url,
+    pub media_type: DirectVideoMediaType,
+    pub size: Option<u64>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct LinkPreviewTokenWire {
     sender_jid: String,
@@ -75,7 +86,17 @@ struct LinkPreviewTokenWire {
     title: Option<String>,
     description: Option<String>,
     image: Option<LinkPreviewTokenImageWire>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    video: Option<LinkPreviewTokenVideoWire>,
     expires_at_unix: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct LinkPreviewTokenVideoWire {
+    url: String,
+    media_type: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    size: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -164,6 +185,11 @@ pub fn encode_link_preview_token(data: &LinkPreviewTokenData, secret: &[u8]) -> 
             height: image.height,
             alt: image.alt.clone(),
         }),
+        video: data.video.as_ref().map(|video| LinkPreviewTokenVideoWire {
+            url: video.url.as_str().to_string(),
+            media_type: video.media_type.as_str().to_string(),
+            size: video.size,
+        }),
         expires_at_unix: data.expires_at_unix,
     };
     let json = serde_json::to_vec(&wire).expect("wire token is serializable");
@@ -245,6 +271,20 @@ pub fn decode_link_preview_token(
                 })
             })
             .transpose()?,
+        video: wire
+            .video
+            .map(|video| {
+                Ok(LinkPreviewTokenVideo {
+                    url: Url::parse(&video.url)
+                        .map_err(|_| WaddleLinkPreviewError::InvalidTokenUrl)?,
+                    media_type: video
+                        .media_type
+                        .parse()
+                        .map_err(|_| WaddleLinkPreviewError::InvalidTokenMediaType)?,
+                    size: video.size,
+                })
+            })
+            .transpose()?,
         expires_at_unix: wire.expires_at_unix,
     })
 }
@@ -283,6 +323,33 @@ mod tests {
                 height: Some(360),
                 alt: Some("Article screenshot".to_string()),
             }),
+            video: None,
+            expires_at_unix: 1_900_000_000,
+        };
+
+        let token = encode_link_preview_token(&data, SECRET);
+
+        assert_eq!(
+            decode_link_preview_token(&token, SECRET, 1_800_000_000),
+            Ok(data)
+        );
+    }
+
+    #[test]
+    fn token_round_trips_typed_direct_video_data() {
+        let data = LinkPreviewTokenData {
+            sender_jid: "alice@example.com".parse().expect("jid"),
+            scope_jid: "room@muc.example.com".parse().expect("jid"),
+            original_url: Url::parse("https://cdn.example/clip.mp4").expect("url"),
+            normalized_url: Url::parse("https://cdn.example/clip.mp4").expect("url"),
+            title: None,
+            description: None,
+            image: None,
+            video: Some(LinkPreviewTokenVideo {
+                url: Url::parse("https://cdn.example/clip.mp4").expect("url"),
+                media_type: DirectVideoMediaType::Mp4,
+                size: Some(4_823_344),
+            }),
             expires_at_unix: 1_900_000_000,
         };
 
@@ -304,6 +371,7 @@ mod tests {
             title: Some("Example".to_string()),
             description: Some("Plain text preview".to_string()),
             image: None,
+            video: None,
             expires_at_unix: 1_900_000_000,
         };
 
@@ -326,6 +394,7 @@ mod tests {
             title: None,
             description: None,
             image: None,
+            video: None,
             expires_at_unix: 10,
         };
 
@@ -347,6 +416,7 @@ mod tests {
             title: Some("t".repeat(MAX_LINK_PREVIEW_TOKEN_BYTES)),
             description: Some("d".repeat(MAX_LINK_PREVIEW_TOKEN_BYTES)),
             image: None,
+            video: None,
             expires_at_unix: 1_900_000_000,
         };
 


### PR DESCRIPTION
## Issue

Closes #832 — trusted direct-video inline preview.

Inline preview support for **trusted direct playable video files only**. The
resolver detects direct video media that passes policy; the server stamps
conformant XEP-0511 link metadata plus XEP-0446/0447 (Stateless File Sharing)
direct-media metadata; the web client renders a poster/preview card that starts
inline playback with native controls **only on user click**. Provider embeds
(YouTube/Vimeo), arbitrary iframe HTML, and JavaScript execution are out of scope.

## How it works

**Server (Rust)**
- `DirectVideoMediaType` (waddle-xmpp-core): typed safe video MIME (`video/mp4`,
  `webm`, `ogg`, `quicktime`); HLS/DASH manifests and non-video types rejected.
- Resolver: when content-type is a safe video MIME **and** the URL names a direct
  video file **and** policy allows it, returns `Ready` with typed
  `ResolvedDirectVideo { url, media_type, size }` — **without downloading the
  body**. Content-type is authoritative, so embed/iframe HTML pages are never
  treated as video. Size comes from `Content-Length`, or the `Content-Range`
  total on a `206` Range response.
- Token: `LinkPreviewTokenVideo` sealed in the existing HMAC preview token; the
  composer lookup advertises a `<video>` element (url, media-type, size).
- Send-time stamping: emits XEP-0511 link metadata **and** a conformant XEP-0447
  inline `<file-sharing>` (XEP-0446 `<file>` metadata + `<url-data>` source = the
  policy-validated original video URL). The disable-video policy suppresses the
  0447 enrichment; the source URL is re-validated against current host policy,
  https, and the video gate at send time.

**Web (Astro + Vue)**
- `associateDirectVideoPreviews` ties a server-stamped inline-video file-share to
  its XEP-0511 preview (by URL) at decode time and removes it from the generic
  attachment list, so it renders once via the dedicated card (not the
  auto-fetching `preload=metadata` attachment path).
- Dedicated video card: cached poster (when available) + accessible play control
  (`aria-label`). The `<video>` element — and its network fetch — is emitted
  **only after the user clicks play**. Playback state is local UI state, never
  synchronized over XMPP. Source is https-gated client-side.

## Trust model

Promotion to a "trusted" direct-video card requires a **server-stamped XEP-0511
card**, which clients cannot forge (client-authored link metadata is stripped
server-side). As defense-in-depth, the server also strips any client-authored
XEP-0447 file-share whose source is the previewed link before stamping its own;
genuine XEP-0363 uploads (Waddle media origin) are unaffected.

## XEP conformance note

XEP-0447 is stamped as **enrichment** alongside the user's own message body (like
XEP-0511), not as a primary file-transfer whose body is a fallback. Accordingly
no XEP-0428 `<fallback for='urn:xmpp:sfs:0'>` is added — adding one would wrongly
mark the user's real message text as a fallback. The `<file-sharing>` wire shape
(`disposition='inline'`, `<sources><url-data .../></sources>`) matches XEP-0447
exactly and is built via typed structs/builders (no string XML).

## Plan (TDD vertical slices)

1. Typed `DirectVideoMediaType` + safe-MIME parsing.
2. Resolver direct-video detection (no body download).
3. Token carries `LinkPreviewTokenVideo` (HMAC round-trip).
4. Lookup maps resolved video → token + `<video>` advertisement.
5. Send-time XEP-0511 + XEP-0447 stamping; disable-video suppression.
6. Client association + removal from generic attachments.
7. Dedicated video card: accessible play control, play-on-click, local-only state.
8. Guards: embed/iframe never a video; markup escaped; client-authored forgery stripped.

## Acceptance criteria

- [x] Resolver detects direct playable video files only when MIME/type and policy allow it.
- [x] Server-stamped messages include XEP-0511 + XEP-0446/0447 direct-media metadata.
- [x] Video previews use Waddle-cached poster/thumbnail media when available.
- [x] Web UI renders video cards with accessible play controls; inline playback only after user action.
- [x] Playback state is local UI state, not synchronized over XMPP.
- [x] Admin disable-video-preview policy prevents video enrichment while preserving metadata-only link cards.
- [x] Tests cover accepted direct video, rejected provider iframe/embed, no JS/HTML execution, accessible play-label.

## Verification

- `cargo test -p waddle-server link_preview --lib` → **104 passed**
- `cargo test -p waddle-xmpp xep_waddle_link_preview` / `-p waddle-xmpp-core direct_video` → green
- `cargo clippy -p waddle-server -p waddle-xmpp -p waddle-xmpp-core --all-targets -- -D warnings` → clean
- `cargo fmt --check` → clean
- `chat/`: `bun test tests/` → **1590 passed**; `bun run lint` (knip) → clean
- Two adversarial review rounds (server security + client trust); MAJOR finding closed and re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
