### PR TITLE
fix(chat): use production Faro source map secret

### DIFF
--- a/.github/workflows/waddle-chat-default.yml
+++ b/.github/workflows/waddle-chat-default.yml
@@ -32,6 +32,8 @@ on:
     - chat/wrangler.jsonc
     - chat/wrangler.jsonc/**
     - cue.mod/**
+    - env.cue
+    - env.cue/**
     - package.json
     - package.json/**
     - server/Cargo.lock

--- a/.github/workflows/waddle-chat-pullrequest.yml
+++ b/.github/workflows/waddle-chat-pullrequest.yml
@@ -28,6 +28,8 @@ on:
     - chat/wrangler.jsonc
     - chat/wrangler.jsonc/**
     - cue.mod/**
+    - env.cue
+    - env.cue/**
     - package.json
     - package.json/**
     - server/Cargo.lock

--- a/chat/env.cue
+++ b/chat/env.cue
@@ -187,6 +187,7 @@ schema.#Project & {
 			args: ["run", "build"]
 			dependsOn: [buildWasm, generateTypes]
 			inputs: [
+				"../env.cue",
 				"../package.json",
 				"../bun.lock",
 				"package.json",
@@ -206,6 +207,7 @@ schema.#Project & {
 			args: ["run", "sourcemaps:upload"]
 			dependsOn: [build]
 			inputs: [
+				"../env.cue",
 				"../package.json",
 				"../bun.lock",
 				"package.json",
@@ -250,6 +252,7 @@ schema.#Project & {
 			args: ["x", "wrangler", "deploy"]
 			dependsOn: [uploadFaroSourcemaps]
 			inputs: [
+				"../env.cue",
 				"wrangler.jsonc",
 				"dist/**",
 			]

--- a/env.cue
+++ b/env.cue
@@ -49,7 +49,7 @@ schema.#Base & {
 			FARO_SOURCEMAP_ENABLED:  "true"
 			FARO_SOURCEMAP_STACK_ID: "1602000"
 			FARO_SOURCEMAP_API_KEY: schema.#OnePasswordRef & {
-				ref: "op://waddle-infra/server-runtime-production/grafana-faro-source-maps"
+				ref: "op://waddle-production/Grafana-Faro/source-maps"
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- Point the Faro source-map upload API key at the waddle-production 1Password item: op://waddle-production/Grafana-Faro/source-maps.
- Add root env.cue to chat build/upload/deploy task inputs so generated chat workflows trigger when production deploy env changes.

## Validation

- git diff --check
- cuenv sync ci