### PR TITLE
fix(chat): normalize unread overview MAM updates

### DIFF
--- a/chat/src/components/chat/ChatMobileDrawers.vue
+++ b/chat/src/components/chat/ChatMobileDrawers.vue
@@ -59,6 +59,7 @@ const {
   selfDomain,
   openUserSettings,
   openHome,
+  openUnread,
   openDmList,
   openCommunitySurface,
   handleLogout,
@@ -214,6 +215,8 @@ function openExtensionRoute(route: DiscoveredExtensionRoute) {
           :stories-active-count="stories.activeStories.value.length"
           :upcoming-event-count="communityEvents.events.value.filter((e: { dtstartMs?: number }) => typeof e.dtstartMs === 'number' && e.dtstartMs > Date.now()).length"
           :is-threads-active="ui.activePage.value === 'threads'"
+          :is-unread-active="ui.activePage.value === 'unread'"
+          :unread-total-count="channelUnread.totalUnreadCount.value + channelUnread.totalThreadUnreadCount.value"
           class="!w-full !border-r-0 !flex-1"
           @select-channel="selectChannelFromMobile"
           @join-channel-call="joinChannelCallFromMobile"
@@ -221,6 +224,7 @@ function openExtensionRoute(route: DiscoveredExtensionRoute) {
           @select-thread="onSelectThread"
           @select-community-surface="selectCommunitySurface"
           @select-threads-view="openThreads"
+          @select-unread-view="openUnread"
           @create-channel="openCreateChannelDialog()"
           @create-channel-in-space="openCreateChannelDialog"
           @open-settings="ui.showWaddleSettings.value = true"

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -30,6 +30,7 @@ import type { CallWireSender } from "@/lib/calls/outbound";
 import type { CallMedia } from "@/lib/calls/types";
 import HomeDashboard from "@/components/chat/HomeDashboard.vue";
 import ThreadsView from "@/components/chat/ThreadsView.vue";
+import UnreadView from "@/components/chat/UnreadView.vue";
 import FeedPane from "@/components/community/FeedPane.vue";
 import StoriesPane from "@/components/community/StoriesPane.vue";
 import EventsPane from "@/components/community/EventsPane.vue";
@@ -120,6 +121,7 @@ const {
   openHome,
   openDmList,
   openThreads,
+  openUnread,
   openCommunitySurface,
   closeUserSettings,
   handleLogout,
@@ -526,12 +528,15 @@ onUnmounted(() => {
           :stories-active-count="stories.activeStories.value.length"
           :upcoming-event-count="communityEvents.events.value.filter((e: { dtstartMs?: number }) => typeof e.dtstartMs === 'number' && e.dtstartMs > Date.now()).length"
           :is-threads-active="ui.activePage.value === 'threads'"
+          :is-unread-active="ui.activePage.value === 'unread'"
+          :unread-total-count="channelUnread.totalUnreadCount.value + channelUnread.totalThreadUnreadCount.value"
           @select-channel="onSelectChannelFromSidebar"
           @join-channel-call="joinChannelCallFromActivity"
           @leave-channel-call="leaveRetainedChannelCall"
           @select-thread="onSelectThread"
           @select-community-surface="onSelectCommunitySurface"
           @select-threads-view="openThreads"
+          @select-unread-view="openUnread"
           @create-channel="openCreateChannelDialog()"
           @create-channel-in-space="openCreateChannelDialog"
           @open-settings="ui.showWaddleSettings.value = true"
@@ -643,6 +648,14 @@ onUnmounted(() => {
       <ThreadsView
         v-else-if="ui.activePage.value === 'threads'"
         :channels="waddles.sortedChannels.value"
+        :on-select-thread="onSelectThread"
+        @open-nav="ui.showMobileNav.value = true"
+      />
+      <UnreadView
+        v-else-if="ui.activePage.value === 'unread'"
+        :channels="waddles.sortedChannels.value"
+        :inbox-state="channelUnread.inboxState.value"
+        :on-select-channel="(id: string) => selectChannel(id)"
         :on-select-thread="onSelectThread"
         @open-nav="ui.showMobileNav.value = true"
       />

--- a/chat/src/components/chat/TopicsPanel.vue
+++ b/chat/src/components/chat/TopicsPanel.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, watch } from "vue";
 import { useStore } from "@nanostores/vue";
-import { CalendarDays, Camera, Hash, ListTree, MessageSquareText, MessagesSquare, Phone, PhoneOff, Plus, Settings, Users, ChevronDown, ChevronRight, MessageCircle, Video } from "lucide-vue-next";
+import { CalendarDays, Camera, Hash, Inbox, ListTree, MessageSquareText, MessagesSquare, Phone, PhoneOff, Plus, Settings, Users, ChevronDown, ChevronRight, MessageCircle, Video } from "lucide-vue-next";
 import { isForumChannel as detectForumChannel } from "@/lib/channel-types";
 import type { ChannelSummary, SpaceSummary } from "@/lib/chat-types";
 import type { ChannelThreadInboxEntry } from "@/channels/inbox";
@@ -48,6 +48,10 @@ const props = defineProps<{
   isThreadsActive?: boolean;
   /** Unread-thread count for the global Threads view badge. */
   threadsUnreadCount?: number;
+  /** True when the global Unread view is currently active. */
+  isUnreadActive?: boolean;
+  /** Total unread count for the global Unread view badge. */
+  unreadTotalCount?: number;
   /**
    * Per-room count of occupants currently advertising an active
    * XEP-0272 Muji presence (i.e. in the room's group call). Keyed
@@ -351,6 +355,7 @@ const emit = defineEmits<{
   selectThread: [channelId: string, threadId: string];
   selectCommunitySurface: [surface: "feed" | "stories" | "events"];
   selectThreadsView: [];
+  selectUnreadView: [];
   createChannel: [];
   createChannelInSpace: [spaceId: string | null];
   openSettings: [];
@@ -561,6 +566,20 @@ watch(
                are NOT real channels. Selecting one swaps the
                content area for that surface's content pane. -->
           <section class="grid gap-1" aria-label="Community surfaces">
+            <button
+              type="button"
+              class="chat-list-row flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left hover:bg-sidebar-accent/35"
+              :class="isUnreadActive ? 'bg-sidebar-accent/60 text-sidebar-foreground' : 'text-sidebar-foreground/85'"
+              @click="emit('selectUnreadView')"
+            >
+              <Inbox class="h-3.5 w-3.5 flex-shrink-0 text-primary" aria-hidden="true" />
+              <span class="flex-1 truncate type-control">Unread</span>
+              <span
+                v-if="(unreadTotalCount ?? 0) > 0"
+                class="type-count-badge inline-flex min-w-[18px] h-[18px] items-center justify-center rounded-full bg-primary px-1 text-primary-foreground"
+                aria-hidden="true"
+              >{{ unreadTotalCount }}</span>
+            </button>
             <button
               type="button"
               class="chat-list-row flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left hover:bg-sidebar-accent/35"

--- a/chat/src/components/chat/UnreadMessageRow.vue
+++ b/chat/src/components/chat/UnreadMessageRow.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import type { TimelineMessage } from "@/lib/chat-ui";
+import { formatTimelineStamp } from "@/channels/timeline";
+import AppAvatar from "@/components/ui/AppAvatar.vue";
+import MessageBody from "@/components/chat/MessageBody.vue";
+
+// Read-only message row for the Unread digest. Reuses `MessageBody`
+// (the same presentational component `PinnedPanel` uses) so unread
+// messages render their full bodies — markup, mentions, attachments,
+// link previews — without any of the live-channel action wiring that
+// `MessageCard` requires.
+defineProps<{
+  message: TimelineMessage;
+}>();
+</script>
+
+<template>
+  <div class="flex gap-2.5 px-2 py-2">
+    <AppAvatar :name="message.author" size="sm" class="mt-0.5 flex-shrink-0" />
+    <div class="min-w-0 flex-1">
+      <div class="flex items-baseline justify-between gap-2">
+        <span class="type-field font-medium truncate">{{ message.author }}</span>
+        <span class="type-field-xs text-muted-foreground shrink-0">
+          {{ formatTimelineStamp(message.createdAt) }}
+        </span>
+      </div>
+      <p
+        v-if="message.isRetracted"
+        class="type-field-sm italic text-muted-foreground"
+      >Message retracted</p>
+      <MessageBody v-else :message="message" compact />
+    </div>
+  </div>
+</template>

--- a/chat/src/components/chat/UnreadView.vue
+++ b/chat/src/components/chat/UnreadView.vue
@@ -1,0 +1,137 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { Hash, Inbox, ListTree, Menu, RefreshCw } from "lucide-vue-next";
+import { connectionStore } from "@/lib/connection-store";
+import type { ChannelSummary } from "@/lib/chat-types";
+import type { InboxState } from "@/services/inbox";
+import { useUnreadOverview } from "@/lib/unread-overview-state";
+import UnreadMessageRow from "@/components/chat/UnreadMessageRow.vue";
+
+const props = defineProps<{
+  channels: readonly ChannelSummary[];
+  inboxState: InboxState;
+  onSelectChannel: (channelId: string) => void | Promise<void>;
+  onSelectThread: (channelId: string, threadId: string) => void | Promise<void>;
+}>();
+
+const emit = defineEmits<{
+  openNav: [];
+}>();
+
+const { groups, isLoading, error, refresh } = useUnreadOverview({
+  xmppClient: computed(() => connectionStore.client),
+  session: computed(() => connectionStore.session),
+  channels: computed(() => props.channels),
+  inboxState: computed(() => props.inboxState),
+});
+
+const hasGroups = computed(() => groups.value.length > 0);
+</script>
+
+<template>
+  <div class="chat-content-pane">
+    <header class="md:hidden flex items-center gap-2 border-b border-border bg-background px-[var(--chat-content-inline)] py-3">
+      <button
+        type="button"
+        class="inline-flex h-8 w-8 items-center justify-center rounded-md border border-transparent text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+        aria-label="Open navigation"
+        @click="emit('openNav')"
+      >
+        <Menu class="h-4 w-4" aria-hidden="true" />
+      </button>
+      <span class="flex h-9 w-9 items-center justify-center rounded-full bg-primary/10 text-primary">
+        <Inbox class="h-4.5 w-4.5" aria-hidden="true" />
+      </span>
+      <h1 class="type-pane-title text-foreground leading-tight">Unread</h1>
+    </header>
+
+    <div class="chat-panel-stack p-4">
+      <div class="flex items-center justify-between gap-2 border-b border-border/70 pb-3">
+        <div>
+          <h2 class="type-pane-title">Unread</h2>
+          <div class="type-caption text-muted-foreground">
+            Everything you haven't read yet, grouped by channel and thread.
+          </div>
+        </div>
+        <button
+          type="button"
+          class="type-caption inline-flex h-8 items-center gap-1.5 rounded-md border border-border px-2.5 text-muted-foreground hover:bg-muted/50 hover:text-foreground disabled:opacity-60"
+          :disabled="isLoading"
+          aria-label="Refresh unread"
+          @click="refresh()"
+        >
+          <RefreshCw class="h-3.5 w-3.5" :class="isLoading ? 'animate-spin' : ''" aria-hidden="true" />
+          Refresh
+        </button>
+      </div>
+
+      <div v-if="isLoading && !hasGroups" class="type-caption text-muted-foreground" aria-busy="true">
+        Loading unread…
+      </div>
+
+      <div v-else-if="error && !hasGroups" class="type-caption text-destructive">
+        Couldn't load unread: {{ error }}
+      </div>
+
+      <div v-else-if="!hasGroups" class="type-caption text-muted-foreground">
+        You're all caught up — nothing unread.
+      </div>
+
+      <template v-else>
+        <section
+          v-for="group in groups"
+          :key="group.roomJid"
+          class="chat-panel-stack rounded-lg border border-border/70"
+        >
+          <button
+            type="button"
+            class="flex w-full items-center gap-2 rounded-t-lg bg-muted/30 px-3 py-2 text-left hover:bg-muted/50"
+            @click="props.onSelectChannel(group.channelId)"
+          >
+            <Hash class="h-4 w-4 flex-shrink-0 text-primary" aria-hidden="true" />
+            <span class="type-card-title flex-1 truncate">{{ group.channelName }}</span>
+            <span
+              v-if="group.channelUnreadCount > 0"
+              class="type-count-badge inline-flex min-w-[18px] h-[18px] items-center justify-center rounded-full bg-primary px-1 text-primary-foreground"
+              :aria-label="`${group.channelUnreadCount} unread`"
+            >{{ group.channelUnreadCount }}</span>
+          </button>
+
+          <div v-if="group.channelMessages.length > 0" class="px-1 py-1">
+            <UnreadMessageRow
+              v-for="message in group.channelMessages"
+              :key="message.id"
+              :message="message"
+            />
+          </div>
+
+          <div
+            v-for="thread in group.threads"
+            :key="thread.threadId"
+            class="border-t border-border/60"
+          >
+            <button
+              type="button"
+              class="flex w-full items-center gap-2 px-3 py-1.5 text-left hover:bg-muted/40"
+              @click="props.onSelectThread(group.channelId, thread.threadId)"
+            >
+              <ListTree class="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" aria-hidden="true" />
+              <span class="type-section-label flex-1 truncate text-muted-foreground">{{ thread.title }}</span>
+              <span
+                class="type-count-badge inline-flex min-w-[18px] h-[18px] items-center justify-center rounded-full bg-primary px-1 text-primary-foreground"
+                :aria-label="`${thread.unreadCount} unread`"
+              >{{ thread.unreadCount }}</span>
+            </button>
+            <div class="px-1 pb-1">
+              <UnreadMessageRow
+                v-for="message in thread.messages"
+                :key="message.id"
+                :message="message"
+              />
+            </div>
+          </div>
+        </section>
+      </template>
+    </div>
+  </div>
+</template>

--- a/chat/src/components/chat/WaddlesSidebar.vue
+++ b/chat/src/components/chat/WaddlesSidebar.vue
@@ -22,7 +22,7 @@ defineProps<{
   serverVersion?: XmppServerVersion | null;
   /** Current top-level page so the Home/logo button can render an
    * "active" treatment when we're already on the dashboard. */
-  activePage?: "dashboard" | "chat" | "settings" | "admin" | "threads";
+  activePage?: "dashboard" | "chat" | "settings" | "admin" | "threads" | "unread";
 }>();
 
 const emit = defineEmits<{

--- a/chat/src/lib/threads-view-filters.ts
+++ b/chat/src/lib/threads-view-filters.ts
@@ -15,8 +15,8 @@ const VALID_ACTIVE = new Set<ThreadsActiveWindow>(["7d", "14d", "30d", "all"]);
 const VALID_SORT = new Set<ThreadsSort>(["recent", "unread", "replies"]);
 
 const DEFAULT_THREADS_FILTERS: ThreadsFilterState = {
-  status: "all",
-  active: "all",
+  status: "unread",
+  active: "7d",
   channel: "all",
   query: "",
   sort: "recent",

--- a/chat/src/lib/unread-overview-state.ts
+++ b/chat/src/lib/unread-overview-state.ts
@@ -1,0 +1,267 @@
+import { ref, watch, type Ref } from "vue";
+import type { BrowserXmppClient, LiveRoomMessage } from "@/lib/xmpp-client";
+import { barePeerJid } from "@/lib/xmpp-client";
+import type { ChannelSummary } from "@/lib/chat-types";
+import type { WaddleSession } from "@/lib/server-auth";
+import type { TimelineMessage } from "@/lib/chat-ui";
+import { type InboxState, threadsForRoom } from "@/services/inbox";
+import { isFeedTimelineMessage, mapLiveRoomMessageToTimeline } from "@/channels/timeline";
+import { resolveChannelIdForRoomJid } from "@/lib/threads-channel-resolve";
+import { threadDisplayTitle } from "@/lib/threads-view-filters";
+
+// How many rooms we fetch in parallel. Each unread room costs one channel
+// MAM page plus one page per unread thread; a flat `Promise.all` over every
+// unread room would blast dozens of IQs at once, so we cap the fan-out.
+const ROOM_FETCH_CONCURRENCY = 4;
+// Headroom above the unread count so the channel page still has enough
+// feed-visible (non-threaded) messages left after filtering, capped at the
+// MAM page ceiling.
+const FETCH_HEADROOM = 20;
+const MAX_PAGE = 100;
+
+// ---------------------------------------------------------------------------
+// Pure helpers (unit-tested without a live client)
+// ---------------------------------------------------------------------------
+
+interface UnreadThreadCandidate {
+  threadId: string;
+  unread: number;
+  title: string;
+  lastUpdated: number;
+}
+
+interface UnreadRoomCandidate {
+  roomJid: string;
+  channelUnread: number;
+  threads: UnreadThreadCandidate[];
+  lastUpdated: number;
+}
+
+/**
+ * Derive the set of MUC rooms that carry any unread — either channel-level
+ * unread or unread threads — from the live inbox state. DMs (`kind: "direct"`)
+ * are excluded. Sorted most-recently-active first.
+ */
+export function selectUnreadRoomCandidates(state: InboxState): UnreadRoomCandidate[] {
+  const roomJids = new Set<string>();
+  for (const entry of state.channels.values()) {
+    if (entry.kind === "muc" && entry.unread > 0) roomJids.add(entry.partner);
+  }
+  for (const entry of state.threads.values()) {
+    if (entry.kind === "muc" && entry.unread > 0) roomJids.add(entry.partner);
+  }
+
+  const candidates: UnreadRoomCandidate[] = [];
+  for (const roomJid of roomJids) {
+    const channelEntry = state.channels.get(roomJid);
+    const channelUnread =
+      channelEntry && channelEntry.kind === "muc" ? channelEntry.unread : 0;
+    const threads: UnreadThreadCandidate[] = threadsForRoom(state, roomJid)
+      .filter((entry) => entry.kind === "muc" && entry.unread > 0 && !!entry.thread)
+      .map((entry) => ({
+        threadId: entry.thread!,
+        unread: entry.unread,
+        title: threadDisplayTitle({
+          ...(entry.threadTitle ? { thread_title: entry.threadTitle } : {}),
+          ...(entry.preview ? { preview: entry.preview } : {}),
+        }),
+        lastUpdated: entry.lastUpdated,
+      }));
+    if (channelUnread === 0 && threads.length === 0) continue;
+    const lastUpdated = Math.max(
+      channelEntry?.lastUpdated ?? 0,
+      ...threads.map((thread) => thread.lastUpdated),
+      0,
+    );
+    candidates.push({ roomJid, channelUnread, threads, lastUpdated });
+  }
+
+  candidates.sort((left, right) => right.lastUpdated - left.lastUpdated);
+  return candidates;
+}
+
+/**
+ * The last `unread` feed-visible (non-threaded) messages of a channel page —
+ * the same boundary the channel timeline uses for its "new messages" divider.
+ */
+export function lastFeedVisibleUnread(
+  messages: readonly TimelineMessage[],
+  unread: number,
+): TimelineMessage[] {
+  if (unread <= 0) return [];
+  const feed = messages.filter(isFeedTimelineMessage);
+  return feed.slice(Math.max(0, feed.length - unread));
+}
+
+/** The last `unread` messages of a thread page. */
+export function lastThreadUnread(
+  messages: readonly TimelineMessage[],
+  unread: number,
+): TimelineMessage[] {
+  if (unread <= 0) return [];
+  return messages.slice(Math.max(0, messages.length - unread));
+}
+
+/** Resolve the topology channel that hosts a room JID, or null if unknown. */
+export function findChannelForRoomJid(
+  roomJid: string,
+  channels: readonly ChannelSummary[],
+): ChannelSummary | null {
+  const matched = channels.find((channel) => channel.jid && barePeerJid(channel.jid) === roomJid);
+  if (matched) return matched;
+  const slug = resolveChannelIdForRoomJid(roomJid, channels);
+  return slug ? channels.find((channel) => channel.id === slug) ?? null : null;
+}
+
+/** Run `worker` over `items` with at most `limit` in flight at a time. */
+async function runWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  worker: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let cursor = 0;
+  async function pump(): Promise<void> {
+    while (cursor < items.length) {
+      const index = cursor++;
+      results[index] = await worker(items[index]!);
+    }
+  }
+  const runners = Array.from({ length: Math.min(limit, items.length) }, () => pump());
+  await Promise.all(runners);
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Composable
+// ---------------------------------------------------------------------------
+
+interface UnreadThreadGroup {
+  threadId: string;
+  title: string;
+  unreadCount: number;
+  messages: TimelineMessage[];
+}
+
+interface UnreadChannelGroup {
+  channelId: string;
+  channelName: string;
+  roomJid: string;
+  channelUnreadCount: number;
+  channelMessages: TimelineMessage[];
+  threads: UnreadThreadGroup[];
+  lastUpdated: number;
+}
+
+interface UnreadOverviewClient {
+  queryMamPage: BrowserXmppClient["queryMamPage"];
+  queryMamThreadPage: BrowserXmppClient["queryMamThreadPage"];
+}
+
+export function useUnreadOverview(deps: {
+  xmppClient: Readonly<Ref<UnreadOverviewClient | null>>;
+  session: Readonly<Ref<WaddleSession | null>>;
+  channels: Readonly<Ref<readonly ChannelSummary[]>>;
+  inboxState: Readonly<Ref<InboxState>>;
+}) {
+  const groups = ref<UnreadChannelGroup[]>([]);
+  const isLoading = ref(false);
+  const error = ref<string | null>(null);
+  let requestSerial = 0;
+
+  function fetchSize(unread: number): number {
+    return Math.min(MAX_PAGE, unread + FETCH_HEADROOM);
+  }
+
+  async function buildGroup(
+    client: UnreadOverviewClient,
+    session: WaddleSession,
+    candidate: UnreadRoomCandidate,
+  ): Promise<UnreadChannelGroup | null> {
+    const channel = findChannelForRoomJid(candidate.roomJid, deps.channels.value);
+    if (!channel) return null;
+    const spaceId = channel.spaceId ?? "";
+    const channelId = channel.id;
+
+    const channelMessages = candidate.channelUnread > 0
+      ? lastFeedVisibleUnread(
+        (await client.queryMamPage(spaceId, channelId, fetchSize(candidate.channelUnread), {
+          type: "latest",
+        })).messages.map((msg: LiveRoomMessage) => mapLiveRoomMessageToTimeline(session, msg)),
+        candidate.channelUnread,
+      )
+      : [];
+
+    const threads = await Promise.all(
+      candidate.threads.map(async (thread): Promise<UnreadThreadGroup> => {
+        const page = await client.queryMamThreadPage(
+          spaceId,
+          channelId,
+          thread.threadId,
+          fetchSize(thread.unread),
+          { type: "latest" },
+        );
+        return {
+          threadId: thread.threadId,
+          title: thread.title,
+          unreadCount: thread.unread,
+          messages: lastThreadUnread(
+            page.messages.map((msg: LiveRoomMessage) => mapLiveRoomMessageToTimeline(session, msg)),
+            thread.unread,
+          ),
+        };
+      }),
+    );
+
+    if (channelMessages.length === 0 && threads.every((thread) => thread.messages.length === 0)) {
+      return null;
+    }
+
+    return {
+      channelId,
+      channelName: channel.name || channelId,
+      roomJid: candidate.roomJid,
+      channelUnreadCount: candidate.channelUnread,
+      channelMessages,
+      threads,
+      lastUpdated: candidate.lastUpdated,
+    };
+  }
+
+  async function refresh(): Promise<void> {
+    const client = deps.xmppClient.value;
+    const session = deps.session.value;
+    const serial = ++requestSerial;
+    if (!client || !session) {
+      groups.value = [];
+      isLoading.value = false;
+      return;
+    }
+
+    const candidates = selectUnreadRoomCandidates(deps.inboxState.value);
+    isLoading.value = true;
+    error.value = null;
+    try {
+      const built = await runWithConcurrency(candidates, ROOM_FETCH_CONCURRENCY, (candidate) =>
+        buildGroup(client, session, candidate),
+      );
+      if (serial !== requestSerial) return;
+      groups.value = built.filter((group): group is UnreadChannelGroup => group !== null);
+    } catch (err) {
+      if (serial !== requestSerial) return;
+      error.value = err instanceof Error ? err.message : String(err);
+    } finally {
+      if (serial === requestSerial) isLoading.value = false;
+    }
+  }
+
+  watch(
+    [deps.inboxState, deps.xmppClient, deps.session],
+    () => {
+      void refresh();
+    },
+    { immediate: true },
+  );
+
+  return { groups, isLoading, error, refresh };
+}

--- a/chat/src/lib/unread-overview-state.ts
+++ b/chat/src/lib/unread-overview-state.ts
@@ -1,11 +1,25 @@
-import { ref, watch, type Ref } from "vue";
+import { onScopeDispose, ref, watch, type Ref } from "vue";
 import type { BrowserXmppClient, LiveRoomMessage } from "@/lib/xmpp-client";
 import { barePeerJid } from "@/lib/xmpp-client";
 import type { ChannelSummary } from "@/lib/chat-types";
+import { isForumChannel } from "@/lib/channel-types";
 import type { WaddleSession } from "@/lib/server-auth";
 import type { TimelineMessage } from "@/lib/chat-ui";
+import type { WasmArchivedMessage } from "@/lib/xmpp/wasm-types";
+import { roomMessageFromArchived } from "@/lib/xmpp/wasm-message-codecs";
+import { trustedLinkPreviewMediaOrigin } from "@/lib/xmpp/link-preview";
+import { findMessageById } from "@/lib/message-ids";
 import { type InboxState, threadsForRoom } from "@/services/inbox";
-import { isFeedTimelineMessage, mapLiveRoomMessageToTimeline } from "@/channels/timeline";
+import { isFeedTimelineMessage } from "@/channels/timeline";
+import {
+  buildChannelTimelineFromMamResults,
+  isMucServiceModeration,
+  isSameMucCorrectionSender,
+  isSameMucRetractionSender,
+  isValidMucModerationTarget,
+  isValidMucRetractionTarget,
+  mucCorrectionSender,
+} from "@/channels/message-timeline-state";
 import { resolveChannelIdForRoomJid } from "@/lib/threads-channel-resolve";
 import { threadDisplayTitle } from "@/lib/threads-view-filters";
 
@@ -13,6 +27,9 @@ import { threadDisplayTitle } from "@/lib/threads-view-filters";
 // MAM page plus one page per unread thread; a flat `Promise.all` over every
 // unread room would blast dozens of IQs at once, so we cap the fan-out.
 const ROOM_FETCH_CONCURRENCY = 4;
+// Thread pages are MAM IQs too. Cap them per room so one busy room cannot
+// fan out an unbounded burst while room-level concurrency is already maxed.
+const THREAD_FETCH_CONCURRENCY = ROOM_FETCH_CONCURRENCY;
 // Headroom above the unread count so the channel page still has enough
 // feed-visible (non-threaded) messages left after filtering, capped at the
 // MAM page ceiling.
@@ -102,6 +119,68 @@ export function lastThreadUnread(
   return messages.slice(Math.max(0, messages.length - unread));
 }
 
+function findTimelineMessageByProtocolId(
+  timeline: readonly TimelineMessage[],
+  id: string | undefined,
+): TimelineMessage | undefined {
+  const normalized = id?.trim();
+  if (!normalized) return undefined;
+  return findMessageById(timeline, normalized)
+    ?? timeline.find((message) =>
+      message.replyableId === normalized
+      || message.reactionTargetId === normalized
+      || message.stanzaId === normalized
+    );
+}
+
+function timelineMessageForMamHit(
+  timeline: readonly TimelineMessage[],
+  msg: LiveRoomMessage,
+): TimelineMessage | undefined {
+  if (msg._reactionTarget) {
+    if (!msg._reactionEmojis) return undefined;
+    return timeline.find((message) => message.reactionTargetId === msg._reactionTarget);
+  }
+  if (msg.retractsId) {
+    const target = findMessageById(timeline, msg.retractsId);
+    if (!target) return undefined;
+    if (msg.moderationTargetId) {
+      return isMucServiceModeration(msg) && isValidMucModerationTarget(target, msg.retractsId)
+        ? target
+        : undefined;
+    }
+    return isValidMucRetractionTarget(target, msg.retractsId)
+      && isSameMucRetractionSender(target, mucCorrectionSender(msg))
+      ? target
+      : undefined;
+  }
+  if (msg.replacesId) {
+    const target = findMessageById(timeline, msg.replacesId);
+    return target && isSameMucCorrectionSender(target, mucCorrectionSender(msg))
+      ? target
+      : undefined;
+  }
+  return findTimelineMessageByProtocolId(timeline, msg.id);
+}
+
+function lastUnreadFromMamHits(
+  timeline: readonly TimelineMessage[],
+  mamResults: readonly LiveRoomMessage[],
+  unread: number,
+  isVisible: (message: TimelineMessage) => boolean,
+): TimelineMessage[] {
+  if (unread <= 0) return [];
+  const selected: TimelineMessage[] = [];
+  const seen = new Set<string>();
+  for (let index = mamResults.length - 1; index >= 0 && selected.length < unread; index -= 1) {
+    const message = timelineMessageForMamHit(timeline, mamResults[index]!);
+    if (!message || !isVisible(message) || seen.has(message.id)) continue;
+    seen.add(message.id);
+    selected.push(message);
+  }
+  return selected.reverse();
+}
+
 /** Resolve the topology channel that hosts a room JID, or null if unknown. */
 export function findChannelForRoomJid(
   roomJid: string,
@@ -111,6 +190,52 @@ export function findChannelForRoomJid(
   if (matched) return matched;
   const slug = resolveChannelIdForRoomJid(roomJid, channels);
   return slug ? channels.find((channel) => channel.id === slug) ?? null : null;
+}
+
+function missingMamUpdateTargets(
+  mamResults: readonly LiveRoomMessage[],
+  timeline: readonly TimelineMessage[],
+): string[] {
+  const targets: string[] = [];
+  const seen = new Set<string>();
+  const add = (targetId: string | undefined, isPresent: (id: string) => boolean) => {
+    const normalized = targetId?.trim();
+    if (!normalized || seen.has(normalized) || isPresent(normalized)) return;
+    seen.add(normalized);
+    targets.push(normalized);
+  };
+
+  for (const msg of mamResults) {
+    add(msg.retractsId, (id) => !!findMessageById(timeline, id));
+    add(msg._reactionTarget, (id) => timeline.some((message) => message.reactionTargetId === id));
+    if (targets.length >= MAX_PAGE) break;
+  }
+  return targets;
+}
+
+function matchesRequestedRoomStanzaId(
+  archived: WasmArchivedMessage,
+  roomJid: string,
+  requested: ReadonlySet<string>,
+): boolean {
+  const roomStamped = archived.stanza_ids?.find((stanzaId) => stanzaId.by === roomJid)?.id;
+  if (roomStamped && requested.has(roomStamped)) return true;
+  return !!archived.stanza_id && archived.stanza_id_by === roomJid && requested.has(archived.stanza_id);
+}
+
+function liveRoomMessagesFromArchived(
+  session: WaddleSession,
+  roomJid: string,
+  requestedStanzaIds: readonly string[],
+  archived: readonly WasmArchivedMessage[],
+): LiveRoomMessage[] {
+  const trustedMediaOrigin = trustedLinkPreviewMediaOrigin(session);
+  const requested = new Set(requestedStanzaIds);
+  return archived.flatMap((message) => {
+    if (!matchesRequestedRoomStanzaId(message, roomJid, requested)) return [];
+    const live = roomMessageFromArchived(message, { trustedMediaOrigin });
+    return live ? [live] : [];
+  });
 }
 
 /** Run `worker` over `items` with at most `limit` in flight at a time. */
@@ -156,6 +281,7 @@ interface UnreadChannelGroup {
 interface UnreadOverviewClient {
   queryMamPage: BrowserXmppClient["queryMamPage"];
   queryMamThreadPage: BrowserXmppClient["queryMamThreadPage"];
+  fetchRoomMessagesByStanzaIds?: BrowserXmppClient["fetchRoomMessagesByStanzaIds"];
 }
 
 export function useUnreadOverview(deps: {
@@ -168,6 +294,7 @@ export function useUnreadOverview(deps: {
   const isLoading = ref(false);
   const error = ref<string | null>(null);
   let requestSerial = 0;
+  let disposed = false;
 
   function fetchSize(unread: number): number {
     return Math.min(MAX_PAGE, unread + FETCH_HEADROOM);
@@ -177,23 +304,79 @@ export function useUnreadOverview(deps: {
     client: UnreadOverviewClient,
     session: WaddleSession,
     candidate: UnreadRoomCandidate,
+    serial: number,
   ): Promise<UnreadChannelGroup | null> {
     const channel = findChannelForRoomJid(candidate.roomJid, deps.channels.value);
     if (!channel) return null;
+    if (serial !== requestSerial) return null;
     const spaceId = channel.spaceId ?? "";
     const channelId = channel.id;
+    const timelineFromMam = async (mamResults: LiveRoomMessage[]): Promise<TimelineMessage[]> => {
+      const timeline = buildChannelTimelineFromMamResults({
+        session,
+        channelIsForum: isForumChannel(channel),
+        mamResults,
+      });
+      const missingTargets = missingMamUpdateTargets(mamResults, timeline);
+      if (
+        missingTargets.length === 0
+        || serial !== requestSerial
+        || !client.fetchRoomMessagesByStanzaIds
+      ) {
+        return timeline;
+      }
 
-    const channelMessages = candidate.channelUnread > 0
-      ? lastFeedVisibleUnread(
-        (await client.queryMamPage(spaceId, channelId, fetchSize(candidate.channelUnread), {
-          type: "latest",
-        })).messages.map((msg: LiveRoomMessage) => mapLiveRoomMessageToTimeline(session, msg)),
+      try {
+        const archivedTargets = await client.fetchRoomMessagesByStanzaIds(
+          spaceId,
+          channelId,
+          missingTargets,
+        );
+        if (serial !== requestSerial) return timeline;
+        const targetMessages = liveRoomMessagesFromArchived(
+          session,
+          candidate.roomJid,
+          missingTargets,
+          archivedTargets,
+        );
+        if (targetMessages.length === 0) return timeline;
+        return buildChannelTimelineFromMamResults({
+          session,
+          channelIsForum: isForumChannel(channel),
+          mamResults: [...targetMessages, ...mamResults],
+        });
+      } catch {
+        return timeline;
+      }
+    };
+
+    let channelMessages: TimelineMessage[] = [];
+    if (candidate.channelUnread > 0) {
+      const page = await client.queryMamPage(spaceId, channelId, fetchSize(candidate.channelUnread), {
+        type: "latest",
+      });
+      channelMessages = lastUnreadFromMamHits(
+        await timelineFromMam(page.messages),
+        page.messages,
         candidate.channelUnread,
-      )
-      : [];
+        isFeedTimelineMessage,
+      );
+    }
 
-    const threads = await Promise.all(
-      candidate.threads.map(async (thread): Promise<UnreadThreadGroup> => {
+    if (serial !== requestSerial) return null;
+
+    const threads = await runWithConcurrency(
+      candidate.threads,
+      THREAD_FETCH_CONCURRENCY,
+      async (thread): Promise<UnreadThreadGroup> => {
+        if (serial !== requestSerial) {
+          return {
+            threadId: thread.threadId,
+            title: thread.title,
+            unreadCount: thread.unread,
+            messages: [],
+          };
+        }
         const page = await client.queryMamThreadPage(
           spaceId,
           channelId,
@@ -205,12 +388,14 @@ export function useUnreadOverview(deps: {
           threadId: thread.threadId,
           title: thread.title,
           unreadCount: thread.unread,
-          messages: lastThreadUnread(
-            page.messages.map((msg: LiveRoomMessage) => mapLiveRoomMessageToTimeline(session, msg)),
+          messages: lastUnreadFromMamHits(
+            await timelineFromMam(page.messages),
+            page.messages,
             thread.unread,
+            () => true,
           ),
         };
-      }),
+      },
     );
 
     if (channelMessages.length === 0 && threads.every((thread) => thread.messages.length === 0)) {
@@ -229,6 +414,7 @@ export function useUnreadOverview(deps: {
   }
 
   async function refresh(): Promise<void> {
+    if (disposed) return;
     const client = deps.xmppClient.value;
     const session = deps.session.value;
     const serial = ++requestSerial;
@@ -243,7 +429,7 @@ export function useUnreadOverview(deps: {
     error.value = null;
     try {
       const built = await runWithConcurrency(candidates, ROOM_FETCH_CONCURRENCY, (candidate) =>
-        buildGroup(client, session, candidate),
+        buildGroup(client, session, candidate, serial),
       );
       if (serial !== requestSerial) return;
       groups.value = built.filter((group): group is UnreadChannelGroup => group !== null);
@@ -256,12 +442,18 @@ export function useUnreadOverview(deps: {
   }
 
   watch(
-    [deps.inboxState, deps.xmppClient, deps.session],
+    [deps.inboxState, deps.xmppClient, deps.session, deps.channels],
     () => {
       void refresh();
     },
     { immediate: true },
   );
+
+  onScopeDispose(() => {
+    disposed = true;
+    requestSerial += 1;
+    isLoading.value = false;
+  });
 
   return { groups, isLoading, error, refresh };
 }

--- a/chat/src/pages/unread.astro
+++ b/chat/src/pages/unread.astro
@@ -1,0 +1,8 @@
+---
+import AppLayout from "@/layouts/AppLayout.astro";
+import RoutePageShell from "@/components/pages/RoutePageShell.vue";
+---
+
+<AppLayout>
+  <RoutePageShell client:only="vue" routeId="unread" />
+</AppLayout>

--- a/chat/src/router/match.ts
+++ b/chat/src/router/match.ts
@@ -9,6 +9,7 @@ import { homeRoute } from "./routes/home";
 import { settingsRoute } from "./routes/settings";
 import { storiesRoute } from "./routes/stories";
 import { threadsRoute } from "./routes/threads";
+import { unreadRoute } from "./routes/unread";
 import type { RouteMatch } from "./registry";
 
 // Order matters: longer-prefix routes must be tried before their
@@ -25,6 +26,7 @@ const ORDER = [
   storiesRoute,
   eventsRoute,
   threadsRoute,
+  unreadRoute,
   settingsRoute,
   adminRoute,
   homeRoute,

--- a/chat/src/router/navigate.ts
+++ b/chat/src/router/navigate.ts
@@ -9,6 +9,7 @@ import { homeRoute } from "./routes/home";
 import { settingsRoute } from "./routes/settings";
 import { storiesRoute } from "./routes/stories";
 import { threadsRoute } from "./routes/threads";
+import { unreadRoute } from "./routes/unread";
 import { currentMatch } from "./use-route-match";
 import type { RouteMatch } from "./registry";
 
@@ -32,6 +33,8 @@ export function buildHref(match: RouteMatch): string {
       return eventsRoute.href();
     case "threads":
       return threadsRoute.href();
+    case "unread":
+      return unreadRoute.href();
     case "settings":
       return settingsRoute.href();
     case "admin":

--- a/chat/src/router/registry.ts
+++ b/chat/src/router/registry.ts
@@ -9,6 +9,7 @@ import type { HomeMatch } from "./routes/home";
 import type { SettingsMatch } from "./routes/settings";
 import type { StoriesMatch } from "./routes/stories";
 import type { ThreadsMatch } from "./routes/threads";
+import type { UnreadMatch } from "./routes/unread";
 
 export type RouteMatch =
   | HomeMatch
@@ -20,6 +21,7 @@ export type RouteMatch =
   | StoriesMatch
   | EventsMatch
   | ThreadsMatch
+  | UnreadMatch
   | SettingsMatch
   | AdminMatch;
 

--- a/chat/src/router/routes/unread.ts
+++ b/chat/src/router/routes/unread.ts
@@ -1,0 +1,7 @@
+import { staticRoute } from "../define";
+
+export interface UnreadMatch {
+  readonly id: "unread";
+}
+
+export const unreadRoute = staticRoute("unread", "/unread");

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -1204,6 +1204,12 @@ export function useChatAppController(giphyApiKey: string) {
       navigate({ id: "threads" });
       return;
     }
+    if (ui.activePage.value === "unread") {
+      // Mirror the threads branch: keep the URL pinned to /unread while
+      // watchers fire, instead of falling through to the home route.
+      navigate({ id: "unread" });
+      return;
+    }
     if (ui.activePage.value === "admin") {
       // Admin owns the entire workspace and is mounted out of
       // ChatReadyShell's own popstate-driven adminPanelRef, but
@@ -1373,6 +1379,26 @@ export function useChatAppController(giphyApiKey: string) {
   }
 
   /**
+   * Navigate to the global Unread view. Mirrors `openThreads()`: clears
+   * any channel/DM selection and local thread-panel state, clears the
+   * active community surface so the `unread` v-else-if branch in
+   * ChatReadyShell wins, and syncs the URL so a refresh lands on /unread.
+   */
+  function openUnread() {
+    clearPendingChannelRoomJidSelection();
+    ui.showMobileNav.value = false;
+    ui.showMobileDetails.value = false;
+    ui.activePage.value = "unread";
+    ui.activeCommunitySurface.value = null;
+    waddles.activeChannelId.value = null;
+    dmConversations.closeDm();
+    activeRightPanel.value = null;
+    activeThreadStack.value = [];
+    activeExtensionRouteKey.value = null;
+    navigate({ id: "unread" });
+  }
+
+  /**
    * Navigate to a community surface — Feed / Stories / Events. These
    * are first-class routes (`/feed`, `/stories`, `/events`) but they
    * also need the in-page state set immediately so the v-else-if
@@ -1485,6 +1511,9 @@ export function useChatAppController(giphyApiKey: string) {
       case "threads":
         ui.activePage.value = "threads";
         break;
+      case "unread":
+        ui.activePage.value = "unread";
+        break;
     }
     ui.activeCommunitySurface.value =
       match.id === "feed" || match.id === "stories" || match.id === "events"
@@ -1539,7 +1568,12 @@ export function useChatAppController(giphyApiKey: string) {
       if (match.id === "home") messaging.clearMessages();
       return;
     }
-    if (match.id === "admin" || match.id === "settings" || match.id === "threads") {
+    if (
+      match.id === "admin"
+      || match.id === "settings"
+      || match.id === "threads"
+      || match.id === "unread"
+    ) {
       activeThreadTargetMessageId.value = null;
       activeThreadStack.value = [];
       activeExtensionRouteKey.value = null;
@@ -2107,6 +2141,7 @@ export function useChatAppController(giphyApiKey: string) {
       openHome,
       openDmList,
       openThreads,
+      openUnread,
       openCommunitySurface,
       closeUserSettings,
       handleLogout,

--- a/chat/src/shell/state.ts
+++ b/chat/src/shell/state.ts
@@ -7,7 +7,7 @@ import type { AdminTab } from "@/lib/chat-ui";
 export type CommunitySurface = "feed" | "stories" | "events";
 
 export function useChatShellState() {
-  const activePage = ref<"dashboard" | "chat" | "settings" | "admin" | "threads">("dashboard");
+  const activePage = ref<"dashboard" | "chat" | "settings" | "admin" | "threads" | "unread">("dashboard");
   const adminTab = ref<AdminTab>("rooms");
   const sidebarMode = ref<"channels" | "dms">("channels");
   /** Which community pseudo-channel is currently active (if any).

--- a/chat/tests/extension-route-rail-ui.test.ts
+++ b/chat/tests/extension-route-rail-ui.test.ts
@@ -67,7 +67,7 @@ describe("extension route rail UI contract", () => {
     const controller = readFileSync(new URL("../src/shell/chat-app-controller.ts", import.meta.url), "utf8");
     const state = readFileSync(new URL("../src/shell/state.ts", import.meta.url), "utf8");
 
-    expect(state).toContain('ref<"dashboard" | "chat" | "settings" | "admin" | "threads">');
+    expect(state).toContain('ref<"dashboard" | "chat" | "settings" | "admin" | "threads" | "unread">');
     expect(readyShell).toContain("<ExtensionRouteRail");
     expect(readyShell).toContain("@close=\"closeExtensionRoutePanel\"");
     expect(readyShell).toContain("@update:pinned-panel-open=\"setPinnedPanelOpen\"");

--- a/chat/tests/threads-list-panel.test.ts
+++ b/chat/tests/threads-list-panel.test.ts
@@ -69,9 +69,11 @@ describe("ThreadsListPanel state", () => {
     await panel.fetchThreadsPage(false);
 
     expect(client.fetchThreads).toHaveBeenCalledTimes(1);
+    // Default view is now Unread over the last 7 days.
     expect(client.fetchThreads.mock.calls[0]?.[0]).toEqual({
       pageSize: 50,
-      status: "all",
+      status: "unread",
+      activeSince: "2026-05-26T00:00:00.000Z",
       sort: "recent",
     });
     expect(panel.hasEntries.value).toBe(false);
@@ -111,8 +113,10 @@ describe("ThreadsListPanel state", () => {
       search: "notifications",
       sort: "replies",
     });
+    // `unread` is the default status now, so it drops out of the URL;
+    // the non-default 14d window and the rest still round-trip.
     expect(replacedSearch.at(-1)).toBe(
-      "status=unread&active=14d&channel=chat&q=notifications&sort=replies",
+      "active=14d&channel=chat&q=notifications&sort=replies",
     );
     scope.stop();
   });
@@ -180,6 +184,9 @@ describe("ThreadsListPanel state", () => {
     };
     const { panel, scope } = createPanel({ client });
 
+    // Default view is Unread now; this case exercises the All view, so
+    // widen the status filter explicitly before fetching.
+    panel.status.value = "all";
     await panel.fetchThreadsPage(false);
     expect(panel.sections.value).toHaveLength(1);
     expect(panel.sections.value[0]?.label).toBe("All");
@@ -217,7 +224,8 @@ describe("ThreadsListPanel state", () => {
     expect(client.fetchThreads).toHaveBeenCalledTimes(2);
     expect(client.fetchThreads.mock.calls[1]?.[0]).toEqual({
       pageSize: 50,
-      status: "all",
+      status: "unread",
+      activeSince: "2026-05-26T00:00:00.000Z",
       sort: "recent",
     });
     scope.stop();

--- a/chat/tests/threads-view-filters.test.ts
+++ b/chat/tests/threads-view-filters.test.ts
@@ -16,8 +16,8 @@ describe("threads view filters", () => {
       sort: "replies",
     });
     expect(decodeThreadsFilterState("?status=stale&active=99d&sort=hot")).toEqual({
-      status: "all",
-      active: "all",
+      status: "unread",
+      active: "7d",
       channel: "all",
       query: "",
       sort: "recent",
@@ -34,6 +34,18 @@ describe("threads view filters", () => {
         sort: "unread",
       }),
     ).toBe("status=following&active=30d&channel=chat&q=notifications&sort=unread");
+    // The default view (unread / 7d) encodes to an empty query string.
+    expect(
+      encodeThreadsFilterState({
+        status: "unread",
+        active: "7d",
+        channel: "all",
+        query: "",
+        sort: "recent",
+      }),
+    ).toBe("");
+    // Widening back to all-statuses / all-time is now non-default, so it
+    // round-trips through the URL.
     expect(
       encodeThreadsFilterState({
         status: "all",
@@ -42,7 +54,7 @@ describe("threads view filters", () => {
         query: "",
         sort: "recent",
       }),
-    ).toBe("");
+    ).toBe("status=all&active=all");
   });
 
   test("computes active-since timestamps from fixed windows", () => {

--- a/chat/tests/unread-overview-state.test.ts
+++ b/chat/tests/unread-overview-state.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
+import { effectScope, nextTick, ref } from "vue";
 import type { TimelineMessage } from "../src/lib/chat-ui";
 import type { ChannelSummary } from "../src/lib/chat-types";
+import type { WaddleSession } from "../src/lib/server-auth";
+import type { LiveRoomMessage, MamHistoryPage } from "../src/lib/xmpp-client";
+import type { WasmArchivedMessage } from "../src/lib/xmpp/wasm-types";
 import type { InboxEntry } from "../src/lib/xmpp/inbox-types";
 import { applyEntries, createInboxState } from "../src/services/inbox";
 import {
@@ -8,7 +12,10 @@ import {
   lastFeedVisibleUnread,
   lastThreadUnread,
   selectUnreadRoomCandidates,
+  useUnreadOverview,
 } from "../src/lib/unread-overview-state";
+
+type TestOverviewClient = NonNullable<Parameters<typeof useUnreadOverview>[0]["xmppClient"]["value"]>;
 
 function makeMessage(
   partial: Partial<TimelineMessage> & { id: string; createdAt: string },
@@ -30,6 +37,94 @@ const ROOM = "general@muc.waddle.example";
 const channels: ChannelSummary[] = [
   { id: "general", name: "General", jid: ROOM, spaceId: "space" },
 ];
+
+const session: WaddleSession = {
+  session_id: "session-1",
+  user_id: "user-1",
+  username: "alice",
+  avatar_url: null,
+  xmpp_localpart: "alice",
+  jid: "alice@waddle.example/web",
+  xmpp_websocket_url: "wss://xmpp.waddle.example/ws",
+  is_expired: false,
+  expires_at: null,
+};
+
+function liveRoomMessage(partial: Partial<LiveRoomMessage> & { id: string }): LiveRoomMessage {
+  return {
+    roomJid: ROOM,
+    nick: "alice",
+    body: "",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    createdAtSource: "archive",
+    type: "message",
+    ...partial,
+  };
+}
+
+function mamPage(messages: LiveRoomMessage[]): MamHistoryPage<LiveRoomMessage> {
+  return { messages, complete: true };
+}
+
+function archivedRoomMessage(
+  partial: Partial<WasmArchivedMessage> & { mam_id: string },
+): WasmArchivedMessage {
+  return {
+    message_type: "groupchat",
+    from: `${ROOM}/alice`,
+    to: ROOM,
+    body: "",
+    timestamp: "2026-01-01T00:00:00.000Z",
+    reaction_emojis: [],
+    is_muc: true,
+    markup_spans: [],
+    mention_uris: [],
+    references: [],
+    is_sticker: false,
+    shared_files: [],
+    link_previews: [],
+    ...partial,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+async function flushOverviewRefresh() {
+  for (let i = 0; i < 4; i += 1) {
+    await nextTick();
+    await Promise.resolve();
+  }
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await nextTick();
+}
+
+function createOverview(options: {
+  state: ReturnType<typeof createInboxState>;
+  channels?: ChannelSummary[];
+  client: TestOverviewClient;
+}) {
+  const scope = effectScope();
+  const xmppClient = ref<TestOverviewClient | null>(options.client);
+  const sessionRef = ref<WaddleSession | null>(session);
+  const channelsRef = ref<ChannelSummary[]>(options.channels ?? channels);
+  const inboxState = ref(options.state);
+  const overview = scope.run(() =>
+    useUnreadOverview({
+      xmppClient,
+      session: sessionRef,
+      channels: channelsRef,
+      inboxState,
+    }),
+  );
+  if (!overview) throw new Error("failed to create unread overview");
+  return { channelsRef, inboxState, overview, scope };
+}
 
 describe("selectUnreadRoomCandidates", () => {
   test("includes channel-level and thread-level unread, excludes DMs and zeros", () => {
@@ -127,5 +222,709 @@ describe("findChannelForRoomJid", () => {
 
   test("returns null when the room is not in the topology", () => {
     expect(findChannelForRoomJid("missing@muc.waddle.example", channels)).toBeNull();
+  });
+});
+
+describe("useUnreadOverview", () => {
+  test("folds XEP-0308 corrections before selecting channel and thread unread rows", async () => {
+    const state = applyEntries(createInboxState(), [
+      muc({ partner: ROOM, unread: 2, lastUpdated: 100 }),
+      muc({
+        partner: ROOM,
+        thread: "thread-1",
+        threadTitle: "Deploys",
+        unread: 1,
+        lastUpdated: 110,
+      }),
+    ]);
+    const queryMamPage = mock(async () =>
+      mamPage([
+        liveRoomMessage({
+          id: "channel-1",
+          body: "uncorrected channel message",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        }),
+        liveRoomMessage({
+          id: "channel-1-edit",
+          replacesId: "channel-1",
+          body: "corrected channel message",
+          createdAt: "2026-01-01T00:01:00.000Z",
+        }),
+        liveRoomMessage({
+          id: "channel-2",
+          body: "next channel message",
+          createdAt: "2026-01-01T00:02:00.000Z",
+        }),
+      ]));
+    const queryMamThreadPage = mock(async () =>
+      mamPage([
+        liveRoomMessage({
+          id: "thread-message-1",
+          threadId: "thread-1",
+          body: "uncorrected thread reply",
+          createdAt: "2026-01-01T00:03:00.000Z",
+        }),
+        liveRoomMessage({
+          id: "thread-message-1-edit",
+          threadId: "thread-1",
+          replacesId: "thread-message-1",
+          body: "corrected thread reply",
+          createdAt: "2026-01-01T00:04:00.000Z",
+        }),
+      ]));
+    const { overview, scope } = createOverview({
+      state,
+      client: { queryMamPage, queryMamThreadPage } as TestOverviewClient,
+    });
+
+    await flushOverviewRefresh();
+
+    const group = overview.groups.value[0]!;
+    expect(overview.error.value).toBeNull();
+    expect(group.channelMessages.map((message) => message.id)).toEqual([
+      "channel-1",
+      "channel-2",
+    ]);
+    expect(group.channelMessages[0]).toMatchObject({
+      body: "corrected channel message",
+      isEdited: true,
+    });
+    expect(group.channelMessages.some((message) => message.id === "channel-1-edit")).toBe(false);
+    expect(group.threads[0]?.messages.map((message) => message.id)).toEqual(["thread-message-1"]);
+    expect(group.threads[0]?.messages[0]).toMatchObject({
+      body: "corrected thread reply",
+      isEdited: true,
+    });
+    scope.stop();
+  });
+
+  test("folds XEP-0424 retractions instead of rendering retraction rows", async () => {
+    const state = applyEntries(createInboxState(), [
+      muc({ partner: ROOM, unread: 1, lastUpdated: 100 }),
+    ]);
+    const queryMamPage = mock(async () =>
+      mamPage([
+        liveRoomMessage({
+          id: "channel-1",
+          wireIds: ["stanza-channel-1"],
+          replyableId: "stanza-channel-1",
+          body: "message to retract",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        }),
+        liveRoomMessage({
+          id: "channel-1-retract",
+          retractsId: "stanza-channel-1",
+          retractionId: "channel-1-retract",
+          createdAt: "2026-01-01T00:01:00.000Z",
+        }),
+      ]));
+    const queryMamThreadPage = mock(async () => mamPage([]));
+    const { overview, scope } = createOverview({
+      state,
+      client: { queryMamPage, queryMamThreadPage } as TestOverviewClient,
+    });
+
+    await flushOverviewRefresh();
+
+    expect(overview.error.value).toBeNull();
+    expect(overview.groups.value[0]?.channelMessages).toHaveLength(1);
+    const retracted = overview.groups.value[0]?.channelMessages[0];
+    expect(retracted?.id).toBe("channel-1");
+    expect(retracted?.body).toBe("");
+    expect(retracted?.isRetracted).toBe(true);
+    expect(
+      overview.groups.value[0]?.channelMessages.some((message) => message.id === "channel-1-retract"),
+    ).toBe(false);
+    scope.stop();
+  });
+
+  test("folds XEP-0444 reactions onto the target before selecting unread rows", async () => {
+    const state = applyEntries(createInboxState(), [
+      muc({ partner: ROOM, unread: 1, lastUpdated: 100 }),
+    ]);
+    const queryMamPage = mock(async () =>
+      mamPage([
+        liveRoomMessage({
+          id: "channel-1",
+          body: "message with reaction",
+          reactionTargetId: "stanza-channel-1",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        }),
+        liveRoomMessage({
+          id: "channel-1-reaction",
+          nick: "bob",
+          _reactionTarget: "stanza-channel-1",
+          _reactionEmojis: ["👍"],
+          _reactionSenderId: "bob@waddle.example",
+          createdAt: "2026-01-01T00:01:00.000Z",
+        }),
+      ]));
+    const queryMamThreadPage = mock(async () => mamPage([]));
+    const { overview, scope } = createOverview({
+      state,
+      client: { queryMamPage, queryMamThreadPage } as TestOverviewClient,
+    });
+
+    await flushOverviewRefresh();
+
+    expect(overview.error.value).toBeNull();
+    expect(overview.groups.value[0]?.channelMessages).toHaveLength(1);
+    const reacted = overview.groups.value[0]?.channelMessages[0];
+    expect(reacted?.id).toBe("channel-1");
+    expect(reacted?.body).toBe("message with reaction");
+    expect(reacted?.reactions).toEqual({ "👍": ["bob"] });
+    expect(reacted?.reactionSenders).toEqual({ "👍": { "bob@waddle.example": "bob" } });
+    expect(
+      overview.groups.value[0]?.channelMessages.some((message) => message.id === "channel-1-reaction"),
+    ).toBe(false);
+    scope.stop();
+  });
+
+  test("backfills stanza-id targets when the unread MAM page only has update rows", async () => {
+    const state = applyEntries(createInboxState(), [
+      muc({ partner: ROOM, unread: 2, lastUpdated: 100 }),
+    ]);
+    const queryMamPage = mock(async () =>
+      mamPage([
+        liveRoomMessage({
+          id: "channel-1-reaction",
+          nick: "bob",
+          _reactionTarget: "stanza-channel-1",
+          _reactionEmojis: ["👍"],
+          _reactionSenderId: "bob@waddle.example",
+          createdAt: "2026-01-01T00:10:00.000Z",
+        }),
+        liveRoomMessage({
+          id: "channel-2-retract",
+          retractsId: "stanza-channel-2",
+          retractionId: "channel-2-retract",
+          createdAt: "2026-01-01T00:11:00.000Z",
+        }),
+      ]));
+    const fetchRoomMessagesByStanzaIds = mock(async (
+      _spaceId: string,
+      _channelId: string,
+      stanzaIds: string[],
+    ) => {
+      expect(stanzaIds).toEqual(["stanza-channel-1", "stanza-channel-2"]);
+      return [
+        archivedRoomMessage({
+          mam_id: "mam-channel-1",
+          id: "channel-1",
+          body: "older reacted target",
+          timestamp: "2026-01-01T00:00:00.000Z",
+          stanza_ids: [{ id: "stanza-channel-1", by: ROOM }],
+        }),
+        archivedRoomMessage({
+          mam_id: "mam-channel-2",
+          id: "channel-2",
+          body: "older retracted target",
+          timestamp: "2026-01-01T00:01:00.000Z",
+          stanza_ids: [{ id: "stanza-channel-2", by: ROOM }],
+        }),
+      ];
+    });
+    const queryMamThreadPage = mock(async () => mamPage([]));
+    const { overview, scope } = createOverview({
+      state,
+      client: {
+        queryMamPage,
+        queryMamThreadPage,
+        fetchRoomMessagesByStanzaIds,
+      } as TestOverviewClient,
+    });
+
+    await flushOverviewRefresh();
+
+    expect(fetchRoomMessagesByStanzaIds).toHaveBeenCalledTimes(1);
+    expect(overview.error.value).toBeNull();
+    expect(overview.groups.value[0]?.channelMessages).toHaveLength(2);
+    const reacted = overview.groups.value[0]?.channelMessages.find((message) =>
+      message.id === "channel-1"
+    );
+    expect(reacted?.body).toBe("older reacted target");
+    expect(reacted?.reactions).toEqual({ "👍": ["bob"] });
+    const retracted = overview.groups.value[0]?.channelMessages.find((message) =>
+      message.id === "channel-2"
+    );
+    expect(retracted?.body).toBe("");
+    expect(retracted?.isRetracted).toBe(true);
+    expect(
+      overview.groups.value[0]?.channelMessages.some((message) =>
+        message.id === "channel-1-reaction" || message.id === "channel-2-retract"
+      ),
+    ).toBe(false);
+    scope.stop();
+  });
+
+  test("selects a folded update target by update recency on mixed headroom pages", async () => {
+    const state = applyEntries(createInboxState(), [
+      muc({ partner: ROOM, unread: 1, lastUpdated: 100 }),
+    ]);
+    const queryMamPage = mock(async () =>
+      mamPage([
+        liveRoomMessage({
+          id: "read-channel-1",
+          body: "already read headroom 1",
+          createdAt: "2026-01-01T00:05:00.000Z",
+        }),
+        liveRoomMessage({
+          id: "read-channel-2",
+          body: "already read headroom 2",
+          createdAt: "2026-01-01T00:06:00.000Z",
+        }),
+        liveRoomMessage({
+          id: "channel-1-reaction",
+          nick: "bob",
+          _reactionTarget: "stanza-channel-1",
+          _reactionEmojis: ["👍"],
+          _reactionSenderId: "bob@waddle.example",
+          createdAt: "2026-01-01T00:10:00.000Z",
+        }),
+      ]));
+    const fetchRoomMessagesByStanzaIds = mock(async () => [
+      archivedRoomMessage({
+        mam_id: "mam-channel-1",
+        id: "channel-1",
+        body: "old reacted target",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        stanza_ids: [{ id: "stanza-channel-1", by: ROOM }],
+      }),
+    ]);
+    const queryMamThreadPage = mock(async () => mamPage([]));
+    const { overview, scope } = createOverview({
+      state,
+      client: {
+        queryMamPage,
+        queryMamThreadPage,
+        fetchRoomMessagesByStanzaIds,
+      } as TestOverviewClient,
+    });
+
+    await flushOverviewRefresh();
+
+    expect(overview.groups.value[0]?.channelMessages.map((message) => message.id)).toEqual([
+      "channel-1",
+    ]);
+    expect(overview.groups.value[0]?.channelMessages[0]?.reactions).toEqual({ "👍": ["bob"] });
+    scope.stop();
+  });
+
+  test("filters stanza-id backfill rows that do not carry a requested room stamp", async () => {
+    const state = applyEntries(createInboxState(), [
+      muc({ partner: ROOM, unread: 1, lastUpdated: 100 }),
+    ]);
+    const queryMamPage = mock(async () =>
+      mamPage([
+        liveRoomMessage({
+          id: "channel-1-reaction",
+          nick: "bob",
+          _reactionTarget: "stanza-channel-1",
+          _reactionEmojis: ["👍"],
+          _reactionSenderId: "bob@waddle.example",
+          createdAt: "2026-01-01T00:10:00.000Z",
+        }),
+      ]));
+    const fetchRoomMessagesByStanzaIds = mock(async () => [
+      archivedRoomMessage({
+        mam_id: "mam-rogue",
+        id: "stanza-channel-1",
+        body: "wrong row",
+        timestamp: "2026-01-01T00:00:00.000Z",
+      }),
+    ]);
+    const queryMamThreadPage = mock(async () => mamPage([]));
+    const { overview, scope } = createOverview({
+      state,
+      client: {
+        queryMamPage,
+        queryMamThreadPage,
+        fetchRoomMessagesByStanzaIds,
+      } as TestOverviewClient,
+    });
+
+    await flushOverviewRefresh();
+
+    expect(fetchRoomMessagesByStanzaIds).toHaveBeenCalledTimes(1);
+    expect(overview.groups.value).toEqual([]);
+    scope.stop();
+  });
+
+  test("does not select fetched retraction context when sender validation rejects the update", async () => {
+    const state = applyEntries(createInboxState(), [
+      muc({ partner: ROOM, unread: 1, lastUpdated: 100 }),
+    ]);
+    const queryMamPage = mock(async () =>
+      mamPage([
+        liveRoomMessage({
+          id: "channel-1-retract",
+          nick: "mallory",
+          retractsId: "stanza-channel-1",
+          retractionId: "channel-1-retract",
+          createdAt: "2026-01-01T00:10:00.000Z",
+        }),
+      ]));
+    const fetchRoomMessagesByStanzaIds = mock(async () => [
+      archivedRoomMessage({
+        mam_id: "mam-channel-1",
+        id: "channel-1",
+        body: "alice target",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        stanza_ids: [{ id: "stanza-channel-1", by: ROOM }],
+      }),
+    ]);
+    const queryMamThreadPage = mock(async () => mamPage([]));
+    const { overview, scope } = createOverview({
+      state,
+      client: {
+        queryMamPage,
+        queryMamThreadPage,
+        fetchRoomMessagesByStanzaIds,
+      } as TestOverviewClient,
+    });
+
+    await flushOverviewRefresh();
+
+    expect(fetchRoomMessagesByStanzaIds).toHaveBeenCalledTimes(1);
+    expect(overview.groups.value).toEqual([]);
+    scope.stop();
+  });
+
+  test("ignores rejected duplicate retractions after a valid fold when choosing last unread", async () => {
+    const state = applyEntries(createInboxState(), [
+      muc({ partner: ROOM, unread: 1, lastUpdated: 100 }),
+    ]);
+    const queryMamPage = mock(async () =>
+      mamPage([
+        liveRoomMessage({
+          id: "channel-1",
+          body: "target",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        }),
+        liveRoomMessage({
+          id: "channel-1-retract",
+          retractsId: "channel-1",
+          retractionId: "channel-1-retract",
+          createdAt: "2026-01-01T00:01:00.000Z",
+        }),
+        liveRoomMessage({
+          id: "channel-2",
+          body: "newer regular unread",
+          createdAt: "2026-01-01T00:02:00.000Z",
+        }),
+        liveRoomMessage({
+          id: "channel-1-retract-invalid",
+          nick: "mallory",
+          retractsId: "channel-1",
+          retractionId: "channel-1-retract-invalid",
+          createdAt: "2026-01-01T00:03:00.000Z",
+        }),
+      ]));
+    const queryMamThreadPage = mock(async () => mamPage([]));
+    const { overview, scope } = createOverview({
+      state,
+      client: { queryMamPage, queryMamThreadPage } as TestOverviewClient,
+    });
+
+    await flushOverviewRefresh();
+
+    expect(overview.error.value).toBeNull();
+    expect(overview.groups.value[0]?.channelMessages.map((message) => message.id)).toEqual([
+      "channel-2",
+    ]);
+    scope.stop();
+  });
+
+  test("ignores rejected duplicate corrections after a valid fold when choosing last unread", async () => {
+    const state = applyEntries(createInboxState(), [
+      muc({ partner: ROOM, unread: 1, lastUpdated: 100 }),
+    ]);
+    const queryMamPage = mock(async () =>
+      mamPage([
+        liveRoomMessage({
+          id: "channel-1",
+          body: "original body",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        }),
+        liveRoomMessage({
+          id: "channel-1-edit",
+          replacesId: "channel-1",
+          body: "corrected body",
+          createdAt: "2026-01-01T00:01:00.000Z",
+        }),
+        liveRoomMessage({
+          id: "channel-2",
+          body: "newer regular unread",
+          createdAt: "2026-01-01T00:02:00.000Z",
+        }),
+        liveRoomMessage({
+          id: "channel-1-edit-invalid",
+          nick: "mallory",
+          replacesId: "channel-1",
+          body: "corrected body",
+          createdAt: "2026-01-01T00:03:00.000Z",
+        }),
+      ]));
+    const queryMamThreadPage = mock(async () => mamPage([]));
+    const { overview, scope } = createOverview({
+      state,
+      client: { queryMamPage, queryMamThreadPage } as TestOverviewClient,
+    });
+
+    await flushOverviewRefresh();
+
+    expect(overview.error.value).toBeNull();
+    expect(overview.groups.value[0]?.channelMessages.map((message) => message.id)).toEqual([
+      "channel-2",
+    ]);
+    scope.stop();
+  });
+
+  test("does not send XEP-0308 origin ids to the stanza-id backfill fetcher", async () => {
+    const state = applyEntries(createInboxState(), [
+      muc({ partner: ROOM, unread: 1, lastUpdated: 100 }),
+    ]);
+    const queryMamPage = mock(async () =>
+      mamPage([
+        liveRoomMessage({
+          id: "channel-1-edit",
+          replacesId: "origin-channel-1",
+          body: "corrected body",
+          createdAt: "2026-01-01T00:10:00.000Z",
+        }),
+      ]));
+    const fetchRoomMessagesByStanzaIds = mock(async () => [
+      archivedRoomMessage({
+        mam_id: "mam-channel-1",
+        id: "channel-1",
+        body: "old target",
+        origin_id: "origin-channel-1",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        stanza_ids: [{ id: "stanza-channel-1", by: ROOM }],
+      }),
+    ]);
+    const queryMamThreadPage = mock(async () => mamPage([]));
+    const { overview, scope } = createOverview({
+      state,
+      client: {
+        queryMamPage,
+        queryMamThreadPage,
+        fetchRoomMessagesByStanzaIds,
+      } as TestOverviewClient,
+    });
+
+    await flushOverviewRefresh();
+
+    expect(fetchRoomMessagesByStanzaIds).not.toHaveBeenCalled();
+    expect(overview.groups.value).toEqual([]);
+    scope.stop();
+  });
+
+  test("refreshes unread groups when channel topology arrives after inbox state", async () => {
+    const state = applyEntries(createInboxState(), [
+      muc({ partner: ROOM, unread: 1, lastUpdated: 100 }),
+    ]);
+    const queryMamPage = mock(async () =>
+      mamPage([
+        liveRoomMessage({
+          id: "channel-1",
+          body: "late topology message",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        }),
+      ]));
+    const queryMamThreadPage = mock(async () => mamPage([]));
+    const { channelsRef, overview, scope } = createOverview({
+      state,
+      channels: [],
+      client: { queryMamPage, queryMamThreadPage } as TestOverviewClient,
+    });
+
+    await flushOverviewRefresh();
+
+    expect(overview.groups.value).toEqual([]);
+    expect(queryMamPage).not.toHaveBeenCalled();
+
+    channelsRef.value = channels;
+    await flushOverviewRefresh();
+
+    expect(queryMamPage).toHaveBeenCalledTimes(1);
+    expect(overview.groups.value[0]?.channelMessages.map((message) => message.id)).toEqual([
+      "channel-1",
+    ]);
+    scope.stop();
+  });
+
+  test("does not launch stale thread MAM fetches after refresh invalidation", async () => {
+    const initialState = applyEntries(createInboxState(), [
+      muc({ partner: ROOM, unread: 1, lastUpdated: 100 }),
+      muc({
+        partner: ROOM,
+        thread: "thread-1",
+        threadTitle: "Deploys",
+        unread: 1,
+        lastUpdated: 110,
+      }),
+    ]);
+    const staleChannelPage = deferred<MamHistoryPage<LiveRoomMessage>>();
+    let channelPageCalls = 0;
+    const queryMamPage = mock(async () => {
+      channelPageCalls += 1;
+      if (channelPageCalls === 1) return staleChannelPage.promise;
+      return mamPage([
+        liveRoomMessage({
+          id: "fresh-channel-1",
+          body: "fresh unread message",
+          createdAt: "2026-01-01T00:02:00.000Z",
+        }),
+      ]);
+    });
+    const queryMamThreadPage = mock(async () =>
+      mamPage([
+        liveRoomMessage({
+          id: "stale-thread-message",
+          threadId: "thread-1",
+          body: "should not fetch",
+          createdAt: "2026-01-01T00:03:00.000Z",
+        }),
+      ]));
+    const { inboxState, overview, scope } = createOverview({
+      state: initialState,
+      client: { queryMamPage, queryMamThreadPage } as TestOverviewClient,
+    });
+
+    await nextTick();
+    await Promise.resolve();
+    expect(queryMamPage).toHaveBeenCalledTimes(1);
+
+    inboxState.value = applyEntries(createInboxState(), [
+      muc({ partner: ROOM, unread: 1, lastUpdated: 200 }),
+    ]);
+    await flushOverviewRefresh();
+    expect(queryMamPage).toHaveBeenCalledTimes(2);
+
+    staleChannelPage.resolve(mamPage([
+      liveRoomMessage({
+        id: "stale-channel-1",
+        body: "stale unread message",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      }),
+    ]));
+    await flushOverviewRefresh();
+
+    expect(queryMamThreadPage).not.toHaveBeenCalled();
+    expect(overview.groups.value[0]?.channelMessages.map((message) => message.id)).toEqual([
+      "fresh-channel-1",
+    ]);
+    scope.stop();
+  });
+
+  test("invalidates an in-flight refresh when the overview scope is disposed", async () => {
+    const state = applyEntries(createInboxState(), [
+      muc({ partner: ROOM, unread: 1, lastUpdated: 100 }),
+      muc({
+        partner: ROOM,
+        thread: "thread-1",
+        threadTitle: "Deploys",
+        unread: 1,
+        lastUpdated: 110,
+      }),
+    ]);
+    const staleChannelPage = deferred<MamHistoryPage<LiveRoomMessage>>();
+    const queryMamPage = mock(async () => staleChannelPage.promise);
+    const queryMamThreadPage = mock(async () =>
+      mamPage([
+        liveRoomMessage({
+          id: "thread-message",
+          threadId: "thread-1",
+          body: "should not fetch after dispose",
+          createdAt: "2026-01-01T00:03:00.000Z",
+        }),
+      ]));
+    const { overview, scope } = createOverview({
+      state,
+      client: { queryMamPage, queryMamThreadPage } as TestOverviewClient,
+    });
+
+    await nextTick();
+    await Promise.resolve();
+    expect(queryMamPage).toHaveBeenCalledTimes(1);
+
+    scope.stop();
+    expect(overview.isLoading.value).toBe(false);
+    staleChannelPage.resolve(mamPage([
+      liveRoomMessage({
+        id: "stale-channel-1",
+        body: "stale unread message",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      }),
+    ]));
+    await flushOverviewRefresh();
+
+    expect(queryMamThreadPage).not.toHaveBeenCalled();
+    expect(overview.groups.value).toEqual([]);
+  });
+
+  test("caps per-room thread MAM fan-out", async () => {
+    const state = applyEntries(
+      createInboxState(),
+      Array.from({ length: 6 }, (_, index) =>
+        muc({
+          partner: ROOM,
+          thread: `thread-${index + 1}`,
+          threadTitle: `Thread ${index + 1}`,
+          unread: 1,
+          lastUpdated: 100 + index,
+        })),
+    );
+    const queryMamPage = mock(async () => mamPage([]));
+    const pending: {
+      threadId: string;
+      resolve: (page: MamHistoryPage<LiveRoomMessage>) => void;
+    }[] = [];
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const queryMamThreadPage = mock((
+      _spaceId: string,
+      _channelId: string,
+      threadId: string,
+    ) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      const page = deferred<MamHistoryPage<LiveRoomMessage>>();
+      pending.push({ threadId, resolve: page.resolve });
+      return page.promise.finally(() => {
+        inFlight -= 1;
+      });
+    });
+    const { overview, scope } = createOverview({
+      state,
+      client: { queryMamPage, queryMamThreadPage } as TestOverviewClient,
+    });
+
+    await flushOverviewRefresh();
+    expect(queryMamThreadPage).toHaveBeenCalledTimes(4);
+
+    let guard = 0;
+    while (queryMamThreadPage.mock.calls.length < 6 || pending.length > 0) {
+      guard += 1;
+      if (guard > 10) throw new Error("thread fan-out test did not settle");
+      if (pending.length === 0) throw new Error("thread fan-out stalled before scheduling all work");
+      const batch = pending.splice(0);
+      for (const item of batch) {
+        item.resolve(mamPage([
+          liveRoomMessage({
+            id: `${item.threadId}-message`,
+            threadId: item.threadId,
+            body: item.threadId,
+            createdAt: "2026-01-01T00:00:00.000Z",
+          }),
+        ]));
+      }
+      await flushOverviewRefresh();
+    }
+
+    expect(maxInFlight).toBeLessThanOrEqual(4);
+    expect(overview.groups.value[0]?.threads).toHaveLength(6);
+    scope.stop();
   });
 });

--- a/chat/tests/unread-overview-state.test.ts
+++ b/chat/tests/unread-overview-state.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import type { TimelineMessage } from "../src/lib/chat-ui";
+import type { ChannelSummary } from "../src/lib/chat-types";
+import type { InboxEntry } from "../src/lib/xmpp/inbox-types";
+import { applyEntries, createInboxState } from "../src/services/inbox";
+import {
+  findChannelForRoomJid,
+  lastFeedVisibleUnread,
+  lastThreadUnread,
+  selectUnreadRoomCandidates,
+} from "../src/lib/unread-overview-state";
+
+function makeMessage(
+  partial: Partial<TimelineMessage> & { id: string; createdAt: string },
+): TimelineMessage {
+  return { author: "alice", body: "", isSelf: false, ...partial };
+}
+
+function muc(partial: Partial<InboxEntry> & { partner: string }): InboxEntry {
+  return {
+    kind: "muc",
+    lastStanzaId: "s",
+    lastUpdated: 0,
+    unread: 0,
+    ...partial,
+  };
+}
+
+const ROOM = "general@muc.waddle.example";
+const channels: ChannelSummary[] = [
+  { id: "general", name: "General", jid: ROOM, spaceId: "space" },
+];
+
+describe("selectUnreadRoomCandidates", () => {
+  test("includes channel-level and thread-level unread, excludes DMs and zeros", () => {
+    const state = applyEntries(createInboxState(), [
+      muc({ partner: ROOM, unread: 3, lastUpdated: 100 }),
+      muc({ partner: ROOM, thread: "t1", threadTitle: "Deploys", unread: 2, lastUpdated: 150 }),
+      muc({ partner: ROOM, thread: "t2", unread: 0, lastUpdated: 90 }), // read thread, skipped
+      { partner: "bob@waddle.example", kind: "direct", lastStanzaId: "s", lastUpdated: 999, unread: 5 },
+      muc({ partner: "quiet@muc.waddle.example", unread: 0, lastUpdated: 10 }), // no unread, skipped
+    ]);
+
+    const candidates = selectUnreadRoomCandidates(state);
+    expect(candidates).toHaveLength(1);
+    const room = candidates[0]!;
+    expect(room.roomJid).toBe(ROOM);
+    expect(room.channelUnread).toBe(3);
+    expect(room.lastUpdated).toBe(150);
+    expect(room.threads).toHaveLength(1);
+    expect(room.threads[0]).toMatchObject({ threadId: "t1", unread: 2, title: "Deploys" });
+  });
+
+  test("surfaces a room that has only unread threads (no channel-level unread)", () => {
+    const state = applyEntries(createInboxState(), [
+      muc({ partner: ROOM, thread: "t1", preview: "hi there", unread: 1, lastUpdated: 50 }),
+    ]);
+    const candidates = selectUnreadRoomCandidates(state);
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]!.channelUnread).toBe(0);
+    expect(candidates[0]!.threads[0]).toMatchObject({ threadId: "t1", title: "hi there" });
+  });
+
+  test("sorts rooms most-recently-active first", () => {
+    const state = applyEntries(createInboxState(), [
+      muc({ partner: "a@muc.x", unread: 1, lastUpdated: 10 }),
+      muc({ partner: "b@muc.x", unread: 1, lastUpdated: 30 }),
+      muc({ partner: "c@muc.x", unread: 1, lastUpdated: 20 }),
+    ]);
+    expect(selectUnreadRoomCandidates(state).map((c) => c.roomJid)).toEqual([
+      "b@muc.x",
+      "c@muc.x",
+      "a@muc.x",
+    ]);
+  });
+});
+
+describe("lastFeedVisibleUnread", () => {
+  const messages = [
+    makeMessage({ id: "m1", createdAt: "2026-01-01T00:00:00Z" }),
+    makeMessage({ id: "r1", createdAt: "2026-01-01T00:01:00Z", threadId: "m1" }), // threaded reply
+    makeMessage({ id: "m2", createdAt: "2026-01-01T00:02:00Z" }),
+    makeMessage({ id: "m3", createdAt: "2026-01-01T00:03:00Z" }),
+  ];
+
+  test("takes the last N feed-visible (non-threaded) messages", () => {
+    expect(lastFeedVisibleUnread(messages, 2).map((m) => m.id)).toEqual(["m2", "m3"]);
+  });
+
+  test("treats a thread root (id === threadId) as feed-visible", () => {
+    const withRoot = [makeMessage({ id: "m1", createdAt: "t", threadId: "m1" })];
+    expect(lastFeedVisibleUnread(withRoot, 1).map((m) => m.id)).toEqual(["m1"]);
+  });
+
+  test("clamps when unread exceeds available feed-visible messages", () => {
+    expect(lastFeedVisibleUnread(messages, 99).map((m) => m.id)).toEqual(["m1", "m2", "m3"]);
+  });
+
+  test("returns nothing for non-positive unread", () => {
+    expect(lastFeedVisibleUnread(messages, 0)).toEqual([]);
+  });
+});
+
+describe("lastThreadUnread", () => {
+  const messages = [
+    makeMessage({ id: "a", createdAt: "t1" }),
+    makeMessage({ id: "b", createdAt: "t2" }),
+    makeMessage({ id: "c", createdAt: "t3" }),
+  ];
+
+  test("takes the last N messages and clamps", () => {
+    expect(lastThreadUnread(messages, 2).map((m) => m.id)).toEqual(["b", "c"]);
+    expect(lastThreadUnread(messages, 99).map((m) => m.id)).toEqual(["a", "b", "c"]);
+    expect(lastThreadUnread(messages, 0)).toEqual([]);
+  });
+});
+
+describe("findChannelForRoomJid", () => {
+  test("matches on the channel JID", () => {
+    expect(findChannelForRoomJid(ROOM, channels)?.id).toBe("general");
+  });
+
+  test("falls back to the JID local-part slug for managed rooms", () => {
+    const slugOnly: ChannelSummary[] = [{ id: "general", name: "General" }];
+    expect(findChannelForRoomJid(ROOM, slugOnly)?.id).toBe("general");
+  });
+
+  test("returns null when the room is not in the topology", () => {
+    expect(findChannelForRoomJid("missing@muc.waddle.example", channels)).toBeNull();
+  });
+});

--- a/chat/tests/unread-route.test.ts
+++ b/chat/tests/unread-route.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { matchLocation } from "../src/router/match";
+import { buildHref } from "../src/router/navigate";
+
+describe("unread route", () => {
+  test("matches /unread to the unread route id", () => {
+    expect(matchLocation("/unread")).toEqual({ id: "unread" });
+  });
+
+  test("builds the canonical /unread href", () => {
+    expect(buildHref({ id: "unread" })).toBe("/unread");
+  });
+
+  test("does not shadow other static routes", () => {
+    expect(matchLocation("/threads")).toEqual({ id: "threads" });
+    expect(matchLocation("/")).toEqual({ id: "home" });
+  });
+});

--- a/chat/tests/update-url-threads.test.ts
+++ b/chat/tests/update-url-threads.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-type ActivePage = "dashboard" | "chat" | "settings" | "admin" | "threads";
+type ActivePage = "dashboard" | "chat" | "settings" | "admin" | "threads" | "unread";
 type SidebarMode = "channels" | "dms";
 type RightPanel = "thread" | "extension" | "pinned" | null;
 
@@ -29,6 +29,7 @@ interface UpdateUrlInputs {
 type Action =
   | { kind: "settings" }
   | { kind: "threads" }
+  | { kind: "unread" }
   | { kind: "admin" }
   | { kind: "dashboard" }
   | { kind: "extension" }
@@ -42,6 +43,7 @@ type Action =
 function decideUpdateUrlAction(inputs: UpdateUrlInputs): Action {
   if (inputs.activePage === "settings") return { kind: "settings" };
   if (inputs.activePage === "threads") return { kind: "threads" };
+  if (inputs.activePage === "unread") return { kind: "unread" };
   if (inputs.activePage === "admin") return { kind: "admin" };
   if (inputs.activePage === "dashboard") return { kind: "dashboard" };
   if (inputs.activePage === "chat" && inputs.activeRightPanel === "extension") {
@@ -88,6 +90,24 @@ describe("updateUrl branching for the global Threads view", () => {
       hasCurrentChannel: true,
     });
     expect(action).toEqual({ kind: "threads" });
+  });
+
+  test("activePage=unread always routes to /unread, mirroring the threads branch", () => {
+    expect(decideUpdateUrlAction({
+      activePage: "unread",
+      activeRightPanel: null,
+      sidebarMode: "channels",
+      hasDmPeer: false,
+      hasCurrentChannel: true,
+    })).toEqual({ kind: "unread" });
+
+    expect(decideUpdateUrlAction({
+      activePage: "unread",
+      activeRightPanel: null,
+      sidebarMode: "dms",
+      hasDmPeer: true,
+      hasCurrentChannel: false,
+    })).toEqual({ kind: "unread" });
   });
 
   test("activePage=admin does not bounce through pushChannelRoute(null)", () => {


### PR DESCRIPTION
## Summary
- Fold unread MAM pages through the shared channel timeline builder before selecting Unread overview rows.
- Backfill missing retraction/reaction targets with the existing XMPP MAM stanza-id fetch, filtering returned archive rows to requested room-scoped stanza IDs.
- Refresh unread groups when channel topology changes and guard stale or disposed refreshes from launching follow-up thread fetches or publishing groups.

## Plan
- Normalize channel and thread MAM results before unread row selection.
- Select unread rows by raw MAM update recency while rendering only folded target messages.
- Reuse existing XEP sender and target validation for corrections, retractions, moderation, and reactions.
- Watch `channels` so late topology hydration can rebuild unread groups.
- Add regressions for XEP updates, late topology, stanza-id backfill filtering, invalid duplicate updates, refresh invalidation, scope disposal, and bounded thread fan-out.

## XEP Review
- XEP-0313: keeps MAM as the retrieval boundary and uses the existing Waddle-specific stanza-id data-form filter over XMPP; no non-XMPP API is introduced.
- XEP-0308: corrections are folded through the timeline builder, and replace IDs are not treated as room stanza IDs for backfill.
- XEP-0424/XEP-0425: retractions and moderation reuse the existing sender and target validation before unread selection.
- XEP-0444: reactions select the folded target row using the same room `reactionTargetId` semantics as the channel timeline.

## Validation
- `nix develop ..#default --command bun test tests/unread-overview-state.test.ts`: 25 pass
- `nix develop ..#default --command bun test`: 1630 pass
- `nix develop ..#default --command bun run lint`
- Final adversarial review pass: protocol, lifecycle/concurrency, and tests/maintainability found no actionable issues.