### PR TITLE
feat(link-preview): HLS og:video previews via lazy hls.js (PR2/2)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,7 @@
         "astro": "^6.4.3",
         "emojilib": "^4.0.3",
         "events": "^3.3.0",
+        "hls.js": "^1.6.16",
         "keystrok": "^0.1.1",
         "livekit-client": "^2.19.1",
         "lucide-vue-next": "^1.0.0",
@@ -983,6 +984,8 @@
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
 
     "hastscript": ["hastscript@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w=="],
+
+    "hls.js": ["hls.js@1.6.16", "", {}, "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA=="],
 
     "hookable": ["hookable@5.5.3", "", {}, "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="],
 

--- a/chat/package.json
+++ b/chat/package.json
@@ -42,6 +42,7 @@
     "astro": "^6.4.3",
     "emojilib": "^4.0.3",
     "events": "^3.3.0",
+    "hls.js": "^1.6.16",
     "keystrok": "^0.1.1",
     "livekit-client": "^2.19.1",
     "lucide-vue-next": "^1.0.0",

--- a/chat/src/components/chat/HlsVideoPlayer.vue
+++ b/chat/src/components/chat/HlsVideoPlayer.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+/**
+ * The actual <video> for a native-video link preview. Mounted only after the
+ * user clicks play (the parent gates it), so no element or network fetch exists
+ * before that. Owns the playback attachment for its lifetime: progressive media
+ * and native-HLS browsers use the <video> src; HLS elsewhere lazily loads
+ * hls.js. A fatal playback error emits `failed` so the parent can show a link.
+ */
+import { onMounted, onUnmounted, ref } from "vue";
+import { attachNativeVideo, type VideoAttachment } from "@/lib/xmpp/hls-player";
+
+const props = defineProps<{ url: string; mediaType: string }>();
+const emit = defineEmits<{ failed: [] }>();
+
+const videoEl = ref<HTMLVideoElement | null>(null);
+let attachment: VideoAttachment | null = null;
+let unmounted = false;
+
+onMounted(async () => {
+  const el = videoEl.value;
+  if (!el) return;
+  const handle = await attachNativeVideo(el, props.url, props.mediaType, () => emit("failed"));
+  // The component may have unmounted while hls.js was importing; never retain a
+  // handle (worker + segment fetches) for a torn-down element.
+  if (unmounted) {
+    handle.destroy();
+    return;
+  }
+  attachment = handle;
+});
+
+onUnmounted(() => {
+  unmounted = true;
+  attachment?.destroy();
+  attachment = null;
+});
+</script>
+
+<template>
+  <video
+    ref="videoEl"
+    class="max-h-72 w-full rounded border border-border bg-black"
+    controls
+    autoplay
+    playsinline
+    @click.stop
+  />
+</template>

--- a/chat/src/components/chat/MessageBody.vue
+++ b/chat/src/components/chat/MessageBody.vue
@@ -5,7 +5,7 @@
 // suppresses interactive affordances that belong on the timeline only
 // (extension action buttons).
 //
-import { computed, reactive, ref, nextTick, watch, type ComponentPublicInstance } from "vue";
+import { computed, reactive, ref, nextTick, watch } from "vue";
 import {
   Lock,
   AlertCircle,
@@ -31,10 +31,10 @@ import {
 import { formatFileSize, useMessageAttachments } from "@/channels/message-attachments";
 import { applyShikiToCodeBlocks } from "@/lib/shiki";
 import { isAllowedPlayerEmbedOrigin } from "@/lib/xmpp/player-embed-allowlist";
-import { attachNativeVideo, type VideoAttachment } from "@/lib/xmpp/hls-player";
 import { useExtensionAnnotationActions } from "@/channels/extension-annotation-actions";
 import type { ExtensionCommandResult } from "@/lib/xmpp/extension-commands";
 import ImageLightbox from "@/components/ui/ImageLightbox.vue";
+import HlsVideoPlayer from "@/components/chat/HlsVideoPlayer.vue";
 
 const props = withDefaults(
   defineProps<{
@@ -112,38 +112,13 @@ function videoCardKey(preview: MessageLinkPreview): string {
   return `${preview.originalUrl}:${preview.normalizedUrl ?? ""}`;
 }
 // Native-video playback is local UI state only — never synchronized over XMPP.
-// Until the user clicks play, no <video> element (and no network fetch) is
-// emitted. On click we attach a progressive/native-HLS src or a lazily-loaded
-// hls.js (see hls-player); a fatal playback error falls back to a link.
+// Until the user clicks play, the <video> (owned by HlsVideoPlayer, mounted only
+// while playing) and its network fetch are not emitted; a fatal playback error
+// flips the card to a link fallback.
 const playingVideos = reactive(new Set<string>());
 const failedVideos = reactive(new Set<string>());
-const videoPlaybackHandles = new Map<string, VideoAttachment>();
 function startVideoPlayback(preview: MessageLinkPreview): void {
   playingVideos.add(videoCardKey(preview));
-}
-function onVideoElement(
-  el: Element | ComponentPublicInstance | null,
-  card: { preview: MessageLinkPreview; video: { url: string; mediaType: string } },
-): void {
-  const key = videoCardKey(card.preview);
-  // Vue invokes the function ref with the element on mount and `null` on
-  // unmount; tear down the attachment in the latter case.
-  if (!(el instanceof HTMLVideoElement)) {
-    videoPlaybackHandles.get(key)?.destroy();
-    videoPlaybackHandles.delete(key);
-    return;
-  }
-  if (videoPlaybackHandles.has(key)) return;
-  void attachNativeVideo(el, card.video.url, card.video.mediaType, () => {
-    failedVideos.add(key);
-  }).then((attachment) => {
-    // The card may have been torn down (or failed) while hls.js loaded.
-    if (playingVideos.has(key) && !failedVideos.has(key)) {
-      videoPlaybackHandles.set(key, attachment);
-    } else {
-      attachment.destroy();
-    }
-  });
 }
 const playerPreviewCards = computed(() =>
   linkPreviews.value.flatMap((preview) => {
@@ -348,14 +323,11 @@ watch(
         <ExternalLink aria-hidden="true" class="h-3.5 w-3.5" />
         {{ linkPreviewHost(card.preview.originalUrl) }}
       </span>
-      <video
+      <HlsVideoPlayer
         v-if="playingVideos.has(videoCardKey(card.preview)) && !failedVideos.has(videoCardKey(card.preview))"
-        :ref="(el) => onVideoElement(el, card)"
-        class="max-h-72 w-full rounded border border-border bg-black"
-        controls
-        autoplay
-        playsinline
-        @click.stop
+        :url="card.video.url"
+        :media-type="card.video.mediaType"
+        @failed="failedVideos.add(videoCardKey(card.preview))"
       />
       <a
         v-else-if="failedVideos.has(videoCardKey(card.preview))"

--- a/chat/src/components/chat/MessageBody.vue
+++ b/chat/src/components/chat/MessageBody.vue
@@ -5,7 +5,7 @@
 // suppresses interactive affordances that belong on the timeline only
 // (extension action buttons).
 //
-import { computed, reactive, ref, nextTick, watch } from "vue";
+import { computed, reactive, ref, nextTick, watch, type ComponentPublicInstance } from "vue";
 import {
   Lock,
   AlertCircle,
@@ -31,6 +31,7 @@ import {
 import { formatFileSize, useMessageAttachments } from "@/channels/message-attachments";
 import { applyShikiToCodeBlocks } from "@/lib/shiki";
 import { isAllowedPlayerEmbedOrigin } from "@/lib/xmpp/player-embed-allowlist";
+import { attachNativeVideo, type VideoAttachment } from "@/lib/xmpp/hls-player";
 import { useExtensionAnnotationActions } from "@/channels/extension-annotation-actions";
 import type { ExtensionCommandResult } from "@/lib/xmpp/extension-commands";
 import ImageLightbox from "@/components/ui/ImageLightbox.vue";
@@ -110,11 +111,39 @@ function isHttpsUrl(value: string): boolean {
 function videoCardKey(preview: MessageLinkPreview): string {
   return `${preview.originalUrl}:${preview.normalizedUrl ?? ""}`;
 }
-// Playback is local UI state only — never synchronized over XMPP. Until the
-// user clicks play, no <video> element (and no network fetch) is emitted.
+// Native-video playback is local UI state only — never synchronized over XMPP.
+// Until the user clicks play, no <video> element (and no network fetch) is
+// emitted. On click we attach a progressive/native-HLS src or a lazily-loaded
+// hls.js (see hls-player); a fatal playback error falls back to a link.
 const playingVideos = reactive(new Set<string>());
+const failedVideos = reactive(new Set<string>());
+const videoPlaybackHandles = new Map<string, VideoAttachment>();
 function startVideoPlayback(preview: MessageLinkPreview): void {
   playingVideos.add(videoCardKey(preview));
+}
+function onVideoElement(
+  el: Element | ComponentPublicInstance | null,
+  card: { preview: MessageLinkPreview; video: { url: string; mediaType: string } },
+): void {
+  const key = videoCardKey(card.preview);
+  // Vue invokes the function ref with the element on mount and `null` on
+  // unmount; tear down the attachment in the latter case.
+  if (!(el instanceof HTMLVideoElement)) {
+    videoPlaybackHandles.get(key)?.destroy();
+    videoPlaybackHandles.delete(key);
+    return;
+  }
+  if (videoPlaybackHandles.has(key)) return;
+  void attachNativeVideo(el, card.video.url, card.video.mediaType, () => {
+    failedVideos.add(key);
+  }).then((attachment) => {
+    // The card may have been torn down (or failed) while hls.js loaded.
+    if (playingVideos.has(key) && !failedVideos.has(key)) {
+      videoPlaybackHandles.set(key, attachment);
+    } else {
+      attachment.destroy();
+    }
+  });
 }
 const playerPreviewCards = computed(() =>
   linkPreviews.value.flatMap((preview) => {
@@ -320,14 +349,25 @@ watch(
         {{ linkPreviewHost(card.preview.originalUrl) }}
       </span>
       <video
-        v-if="playingVideos.has(videoCardKey(card.preview))"
-        :src="card.video.url"
+        v-if="playingVideos.has(videoCardKey(card.preview)) && !failedVideos.has(videoCardKey(card.preview))"
+        :ref="(el) => onVideoElement(el, card)"
         class="max-h-72 w-full rounded border border-border bg-black"
         controls
         autoplay
         playsinline
         @click.stop
       />
+      <a
+        v-else-if="failedVideos.has(videoCardKey(card.preview))"
+        :href="linkPreviewHref(card.preview.originalUrl) ?? undefined"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="relative flex aspect-video w-full items-center justify-center gap-2 overflow-hidden rounded border border-border bg-black/80 text-sm text-white hover:bg-black"
+        @click.stop
+      >
+        <AlertCircle aria-hidden="true" class="h-5 w-5" />
+        Couldn't play here — watch on site
+      </a>
       <button
         v-else
         type="button"

--- a/chat/src/lib/xmpp/hls-player.ts
+++ b/chat/src/lib/xmpp/hls-player.ts
@@ -1,0 +1,73 @@
+// Click-to-play attachment for native-video link previews. Progressive media and
+// native-HLS-capable browsers (Safari/iOS) use the plain <video> src; HLS
+// elsewhere uses a lazily-loaded hls.js so the library is only fetched on first
+// HLS play. Video bytes are never proxied — playback streams from the origin.
+import { isHlsMediaType } from "./native-video";
+
+export type VideoPlaybackStrategy = "native-src" | "hls-js";
+
+/// Pure decision: an HLS manifest needs hls.js unless the browser plays HLS
+/// natively; everything else (progressive containers) uses the <video> src.
+export function videoPlaybackStrategy(
+  mediaType: string,
+  canPlayNativeHls: boolean,
+): VideoPlaybackStrategy {
+  return isHlsMediaType(mediaType) && !canPlayNativeHls ? "hls-js" : "native-src";
+}
+
+export interface VideoAttachment {
+  destroy(): void;
+}
+
+const NOOP_ATTACHMENT: VideoAttachment = { destroy() {} };
+
+/// Attach a playable source to a freshly-mounted <video>. Returns a handle whose
+/// `destroy()` MUST be called on unmount. `onFatalError` fires when playback
+/// cannot start (hls.js unsupported, import failed, or a fatal media error) so
+/// the caller can fall back to the link card.
+export async function attachNativeVideo(
+  video: HTMLVideoElement,
+  url: string,
+  mediaType: string,
+  onFatalError: () => void,
+): Promise<VideoAttachment> {
+  const canPlayNativeHls = video.canPlayType("application/vnd.apple.mpegurl") !== "";
+  if (videoPlaybackStrategy(mediaType, canPlayNativeHls) === "native-src") {
+    video.src = url;
+    return {
+      destroy() {
+        video.removeAttribute("src");
+        try {
+          video.load();
+        } catch {
+          // load() can throw on a detached element; nothing to recover.
+        }
+      },
+    };
+  }
+
+  try {
+    const { default: Hls } = await import("hls.js");
+    if (!Hls.isSupported()) {
+      onFatalError();
+      return NOOP_ATTACHMENT;
+    }
+    const hls = new Hls({ enableWorker: true });
+    hls.on(Hls.Events.ERROR, (_event, data) => {
+      if (data.fatal) onFatalError();
+    });
+    hls.loadSource(url);
+    hls.attachMedia(video);
+    let destroyed = false;
+    return {
+      destroy() {
+        if (destroyed) return;
+        destroyed = true;
+        hls.destroy();
+      },
+    };
+  } catch {
+    onFatalError();
+    return NOOP_ATTACHMENT;
+  }
+}

--- a/chat/src/lib/xmpp/hls-player.ts
+++ b/chat/src/lib/xmpp/hls-player.ts
@@ -33,9 +33,14 @@ export async function attachNativeVideo(
 ): Promise<VideoAttachment> {
   const canPlayNativeHls = video.canPlayType("application/vnd.apple.mpegurl") !== "";
   if (videoPlaybackStrategy(mediaType, canPlayNativeHls) === "native-src") {
+    // Progressive media and Safari/iOS native HLS. A media error (404 manifest,
+    // unsupported codec) has no recovery path, so surface it as fatal.
+    const onError = () => onFatalError();
+    video.addEventListener("error", onError);
     video.src = url;
     return {
       destroy() {
+        video.removeEventListener("error", onError);
         video.removeAttribute("src");
         try {
           video.load();

--- a/chat/src/lib/xmpp/native-video.ts
+++ b/chat/src/lib/xmpp/native-video.ts
@@ -5,22 +5,37 @@
 // <video src>. There is no provider allowlist for native playback (it runs no
 // third-party JS); the boundary is https + a supported direct media type.
 //
-// Mirror of the server-supported direct video MIME set. HLS
-// (application/vnd.apple.mpegurl) plays via a lazily-loaded hls.js player in a
-// follow-up; until then only progressive containers are accepted.
+// Mirror of the server-supported direct video MIME set. Progressive containers
+// play natively in <video>; HLS (application/vnd.apple.mpegurl + aliases) plays
+// natively on Safari and via a lazily-loaded hls.js player elsewhere.
+const HLS_MEDIA_TYPES: ReadonlySet<string> = new Set([
+  "application/vnd.apple.mpegurl",
+  "application/x-mpegurl",
+  "audio/x-mpegurl",
+  "audio/mpegurl",
+  "application/mpegurl",
+]);
 const PLAYABLE_NATIVE_VIDEO_TYPES: ReadonlySet<string> = new Set([
   "video/mp4",
   "video/webm",
   "video/ogg",
   "video/quicktime",
+  ...HLS_MEDIA_TYPES,
 ]);
 
+/// The MIME essence of an og:video:type, stripping media-type parameters
+/// (`video/mp4; codecs="…"`), mirroring the server resolver's `.split(';')`.
+function mediaTypeEssence(mediaType: string): string {
+  return mediaType.split(";")[0]!.trim().toLowerCase();
+}
+
 function isPlayableNativeVideoMediaType(mediaType: string): boolean {
-  // Match on the MIME essence, stripping media-type parameters
-  // (`video/mp4; codecs="…"`), mirroring the server resolver's
-  // `.split(';').next()` treatment.
-  const essence = mediaType.split(";")[0]!.trim().toLowerCase();
-  return PLAYABLE_NATIVE_VIDEO_TYPES.has(essence);
+  return PLAYABLE_NATIVE_VIDEO_TYPES.has(mediaTypeEssence(mediaType));
+}
+
+/** Whether a media type is an HLS manifest (needs native-HLS or hls.js). */
+export function isHlsMediaType(mediaType: string): boolean {
+  return HLS_MEDIA_TYPES.has(mediaTypeEssence(mediaType));
 }
 
 export function isPlayableNativeVideo(url: string, mediaType: string): boolean {

--- a/chat/tests/hls-player.test.ts
+++ b/chat/tests/hls-player.test.ts
@@ -2,9 +2,17 @@ import { describe, expect, test } from "bun:test";
 import { videoPlaybackStrategy } from "@/lib/xmpp/hls-player";
 
 describe("videoPlaybackStrategy", () => {
-  test("HLS without native support uses hls.js", () => {
-    expect(videoPlaybackStrategy("application/vnd.apple.mpegurl", false)).toBe("hls-js");
-    expect(videoPlaybackStrategy("application/x-mpegURL", false)).toBe("hls-js");
+  test("every HLS alias without native support uses hls.js", () => {
+    for (const alias of [
+      "application/vnd.apple.mpegurl",
+      "application/x-mpegURL",
+      "application/x-mpegurl",
+      "audio/x-mpegurl",
+      "audio/mpegurl",
+      "application/mpegurl",
+    ]) {
+      expect(videoPlaybackStrategy(alias, false)).toBe("hls-js");
+    }
   });
 
   test("HLS with native support (Safari) uses the native <video> src", () => {

--- a/chat/tests/hls-player.test.ts
+++ b/chat/tests/hls-player.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { videoPlaybackStrategy } from "@/lib/xmpp/hls-player";
+
+describe("videoPlaybackStrategy", () => {
+  test("HLS without native support uses hls.js", () => {
+    expect(videoPlaybackStrategy("application/vnd.apple.mpegurl", false)).toBe("hls-js");
+    expect(videoPlaybackStrategy("application/x-mpegURL", false)).toBe("hls-js");
+  });
+
+  test("HLS with native support (Safari) uses the native <video> src", () => {
+    expect(videoPlaybackStrategy("application/vnd.apple.mpegurl", true)).toBe("native-src");
+  });
+
+  test("progressive media always uses the native <video> src", () => {
+    expect(videoPlaybackStrategy("video/mp4", false)).toBe("native-src");
+    expect(videoPlaybackStrategy("video/webm", true)).toBe("native-src");
+  });
+});

--- a/chat/tests/link-preview-native-video.test.ts
+++ b/chat/tests/link-preview-native-video.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { linkPreviewFromWasm } from "@/lib/xmpp/wasm-message-codecs";
+import { isHlsMediaType } from "@/lib/xmpp/native-video";
 
 describe("linkPreviewFromWasm native video", () => {
   test("maps an https progressive og:video to preview.video", () => {
@@ -24,6 +25,26 @@ describe("linkPreviewFromWasm native video", () => {
       url: "https://content.rawkode.academy/v/clip.mp4",
       mediaType: 'video/mp4; codecs="avc1.42E01E"',
     });
+  });
+
+  test("maps an HLS og:video to preview.video", () => {
+    const preview = linkPreviewFromWasm({
+      original_url: "https://rawkode.academy/watch/yoke",
+      title: "Hands-on Yoke",
+      video: { url: "https://content.rawkode.academy/v/stream.m3u8", media_type: "application/vnd.apple.mpegurl" },
+    });
+    expect(preview.video).toEqual({
+      url: "https://content.rawkode.academy/v/stream.m3u8",
+      mediaType: "application/vnd.apple.mpegurl",
+    });
+  });
+
+  test("isHlsMediaType recognises HLS aliases, not progressive files", () => {
+    expect(isHlsMediaType("application/vnd.apple.mpegurl")).toBe(true);
+    expect(isHlsMediaType("application/x-mpegURL")).toBe(true);
+    expect(isHlsMediaType("audio/x-mpegurl")).toBe(true);
+    expect(isHlsMediaType("video/mp4")).toBe(false);
+    expect(isHlsMediaType("video/webm")).toBe(false);
   });
 
   test("drops a non-https native video", () => {

--- a/chat/tests/message-body-link-previews.test.ts
+++ b/chat/tests/message-body-link-previews.test.ts
@@ -64,6 +64,33 @@ describe("MessageBody link previews", () => {
     expect(html).toContain("A short clip");
   });
 
+  test("renders an HLS og:video preview as a click-to-load control without loading hls.js or a player", async () => {
+    const html = await renderMessageBody({
+      message: messageWithPreviews([
+        {
+          originalUrl: "https://rawkode.academy/watch/yoke",
+          normalizedUrl: "https://rawkode.academy/watch/yoke",
+          title: "Hands-on Yoke",
+          video: {
+            url: "https://content.rawkode.academy/v/stream.m3u8",
+            mediaType: "application/vnd.apple.mpegurl",
+          },
+          image: {
+            url: "https://waddle.example/api/files/22222222-2222-4222-8222-222222222222/poster.png",
+            mediaType: "image/png",
+          },
+        },
+      ]),
+    });
+
+    // Click-to-load: poster + play control, but no <video> and no stream URL
+    // until the user acts — nothing contacts the CDN on render.
+    expect(html).toContain("aria-label=\"Play video: Hands-on Yoke\"");
+    expect(html).toContain("poster.png");
+    expect(html).not.toContain("<video");
+    expect(html).not.toContain("stream.m3u8");
+  });
+
   test("renders the cached poster image for a direct-video preview when available", async () => {
     const html = await renderMessageBody({
       message: messageWithPreviews([

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
@@ -1772,6 +1772,28 @@ mod tests {
     }
 
     #[test]
+    fn parses_native_video_from_hls_og_video() {
+        // The Rawkode Academy shape: an HLS stream advertised via og:video with
+        // the `application/x-mpegURL` type (one of several mpegurl aliases).
+        let requested_url = Url::parse("https://rawkode.academy/watch/yoke").expect("url");
+        let html = r#"<html><head>
+                <meta property="og:title" content="Hands-on Yoke">
+                <meta property="og:video" content="https://content.rawkode.academy/v/stream.m3u8">
+                <meta property="og:video:type" content="application/x-mpegURL">
+              </head></html>"#;
+
+        let metadata = extract_metadata_from_html(&requested_url, html).expect("metadata");
+
+        assert_eq!(
+            metadata.native_video,
+            Some(ResolvedNativeVideo {
+                url: Url::parse("https://content.rawkode.academy/v/stream.m3u8").expect("url"),
+                media_type: DirectVideoMediaType::Hls,
+            })
+        );
+    }
+
+    #[test]
     fn parses_native_video_with_media_type_parameters() {
         // `og:video:type` legally carries codec parameters, e.g.
         // `video/mp4; codecs="avc1.42E01E"`. The MIME must be matched on its

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
@@ -635,7 +635,13 @@ async fn fetch_html_once(
         // names a direct playable file. This blocks provider endpoints that
         // return a video content-type for non-file (embed/watch) URLs, and is
         // defense-in-depth on top of the classify-time `video_enabled` gate.
-        if policy.video_enabled && looks_like_direct_video_url(url) {
+        // HLS is excluded here: an adaptive-streaming manifest is not a single
+        // downloadable file and only enters via the page-advertised og:video
+        // native path, never as a raw-file (XEP-0447) share.
+        if policy.video_enabled
+            && media_type != DirectVideoMediaType::Hls
+            && looks_like_direct_video_url(url)
+        {
             return Ok(FetchOnceResult::DirectVideo {
                 final_url: url.clone(),
                 media_type,
@@ -1959,6 +1965,32 @@ mod tests {
         let policy = LinkPreviewResolverPolicy {
             allow_http_loopback_for_tests: true,
             video_enabled: false,
+            ..Default::default()
+        };
+        let url = Url::parse(&format!("{}/clip.mp4", server.uri())).expect("url");
+
+        assert_eq!(
+            resolve_link_preview(&url, &policy).await,
+            LinkPreviewResolverOutcome::Unsupported
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_hls_content_type_on_direct_file_url() {
+        // An HLS manifest is not a single downloadable file. Even when a
+        // direct-file URL serves an mpegurl content-type, it must not be
+        // promoted to a raw-file (XEP-0447) video share — HLS only enters via
+        // the page-advertised og:video native path.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/clip.mp4"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_raw("#EXTM3U", "application/x-mpegurl"),
+            )
+            .mount(&server)
+            .await;
+        let policy = LinkPreviewResolverPolicy {
+            allow_http_loopback_for_tests: true,
             ..Default::default()
         };
         let url = Url::parse(&format!("{}/clip.mp4", server.uri())).expect("url");

--- a/server/crates/waddle-xmpp-core/src/link_preview.rs
+++ b/server/crates/waddle-xmpp-core/src/link_preview.rs
@@ -55,17 +55,21 @@ impl fmt::Display for InvalidPreviewImageMediaType {
 
 impl std::error::Error for InvalidPreviewImageMediaType {}
 
-/// Safe direct-video MIME types Waddle accepts for trusted inline previews.
+/// Media types Waddle accepts for trusted inline video previews.
 ///
-/// Only single, directly playable container files are listed. Adaptive
-/// streaming manifests (HLS `application/x-mpegurl`, DASH) and provider embed
-/// pages are intentionally excluded — they are not direct playable files.
+/// Progressive container files (`Mp4`/`Webm`/`Ogg`/`QuickTime`) play natively in
+/// a `<video>` element. `Hls` is an adaptive-streaming manifest
+/// (`application/vnd.apple.mpegurl`) which plays natively on Safari and via a
+/// lazily-loaded `hls.js` player elsewhere; it is accepted for the page-advertised
+/// `og:video` native path (clients fall back gracefully when it cannot play).
+/// DASH and provider embed pages remain excluded.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum DirectVideoMediaType {
     Mp4,
     Webm,
     Ogg,
     QuickTime,
+    Hls,
 }
 
 impl DirectVideoMediaType {
@@ -76,7 +80,15 @@ impl DirectVideoMediaType {
             Self::Webm => "video/webm",
             Self::Ogg => "video/ogg",
             Self::QuickTime => "video/quicktime",
+            Self::Hls => "application/vnd.apple.mpegurl",
         }
+    }
+
+    /// Whether this media type is an adaptive-streaming manifest (HLS) rather
+    /// than a single progressive file. Drives the client's `hls.js`/native-HLS
+    /// playback path.
+    pub const fn is_adaptive_stream(self) -> bool {
+        matches!(self, Self::Hls)
     }
 }
 
@@ -95,6 +107,12 @@ impl FromStr for DirectVideoMediaType {
             "video/webm" => Ok(Self::Webm),
             "video/ogg" => Ok(Self::Ogg),
             "video/quicktime" => Ok(Self::QuickTime),
+            // HLS manifests appear under several historical aliases in the wild.
+            "application/vnd.apple.mpegurl"
+            | "application/x-mpegurl"
+            | "audio/x-mpegurl"
+            | "audio/mpegurl"
+            | "application/mpegurl" => Ok(Self::Hls),
             _ => Err(InvalidDirectVideoMediaType),
         }
     }
@@ -203,13 +221,32 @@ mod tests {
     }
 
     #[test]
+    fn parses_hls_media_type_aliases_to_canonical() {
+        for alias in [
+            "application/vnd.apple.mpegurl",
+            "application/x-mpegURL",
+            "application/x-mpegurl",
+            "audio/x-mpegurl",
+            "audio/mpegurl",
+            "application/mpegurl",
+        ] {
+            assert_eq!(
+                alias.parse::<DirectVideoMediaType>(),
+                Ok(DirectVideoMediaType::Hls),
+                "alias {alias} must map to HLS"
+            );
+        }
+        assert_eq!(
+            DirectVideoMediaType::Hls.as_str(),
+            "application/vnd.apple.mpegurl"
+        );
+    }
+
+    #[test]
     fn rejects_non_direct_video_media_types() {
         assert!("text/html".parse::<DirectVideoMediaType>().is_err());
-        // HLS/DASH playlists are not single direct playable files.
-        assert!("application/x-mpegurl"
-            .parse::<DirectVideoMediaType>()
-            .is_err());
-        assert!("application/vnd.apple.mpegurl"
+        // DASH manifests need a separate player and are not supported.
+        assert!("application/dash+xml"
             .parse::<DirectVideoMediaType>()
             .is_err());
     }

--- a/server/crates/waddle-xmpp-core/src/link_preview.rs
+++ b/server/crates/waddle-xmpp-core/src/link_preview.rs
@@ -83,13 +83,6 @@ impl DirectVideoMediaType {
             Self::Hls => "application/vnd.apple.mpegurl",
         }
     }
-
-    /// Whether this media type is an adaptive-streaming manifest (HLS) rather
-    /// than a single progressive file. Drives the client's `hls.js`/native-HLS
-    /// playback path.
-    pub const fn is_adaptive_stream(self) -> bool {
-        matches!(self, Self::Hls)
-    }
 }
 
 impl fmt::Display for DirectVideoMediaType {

--- a/server/crates/waddle-xmpp/tests/xep0511_link_metadata.rs
+++ b/server/crates/waddle-xmpp/tests/xep0511_link_metadata.rs
@@ -157,6 +157,61 @@ fn xep0511_builds_native_og_video_with_real_media_type() {
 }
 
 #[test]
+fn xep0511_round_trips_hls_native_og_video() {
+    // An HLS stream (e.g. Rawkode Academy) serializes with the canonical mpegurl
+    // `og:video:type` on the wire and round-trips to a native video.
+    let metadata =
+        LinkMetadata::new(Url::parse("https://rawkode.academy/watch/yoke").expect("url"))
+            .with_title("Hands-on Yoke")
+            .with_video(LinkMetadataVideo::Native {
+                url: Url::parse("https://content.rawkode.academy/v/stream.m3u8").expect("url"),
+                media_type: DirectVideoMediaType::Hls,
+            });
+
+    let payload = build_link_metadata_element(&metadata);
+
+    assert_eq!(
+        payload
+            .get_child("type", NS_OPENGRAPH_VIDEO)
+            .map(Element::text)
+            .as_deref(),
+        Some("application/vnd.apple.mpegurl")
+    );
+    assert_eq!(
+        parse_link_metadata_element(&payload)
+            .expect("hls native video round-trips")
+            .video,
+        metadata.video
+    );
+}
+
+#[test]
+fn xep0511_parses_hls_og_video_type_aliases() {
+    // A conformant (e.g. federated) sender may use any of the historical mpegurl
+    // aliases for `og:video:type`; all map to a native HLS video.
+    for alias in [
+        "application/vnd.apple.mpegurl",
+        "application/x-mpegURL",
+        "audio/x-mpegurl",
+    ] {
+        let payload = element(&format!(
+            "<rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:og='https://ogp.me/ns#' xmlns:ogv='https://ogp.me/ns#video:' rdf:about='https://rawkode.academy/watch/yoke'>\
+               <og:video>https://content.rawkode.academy/v/stream.m3u8</og:video>\
+               <ogv:type>{alias}</ogv:type>\
+             </rdf:Description>"
+        ));
+        assert_eq!(
+            parse_link_metadata_element(&payload).expect("parses").video,
+            Some(LinkMetadataVideo::Native {
+                url: Url::parse("https://content.rawkode.academy/v/stream.m3u8").expect("url"),
+                media_type: DirectVideoMediaType::Hls,
+            }),
+            "alias {alias} must parse to native HLS"
+        );
+    }
+}
+
+#[test]
 fn xep0511_builds_player_og_video_with_text_html_type() {
     let metadata = LinkMetadata::new(Url::parse("https://www.youtube.com/watch?v=x").expect("url"))
         .with_video(LinkMetadataVideo::Player {


### PR DESCRIPTION
PR2 of 2 for #864. Makes **Rawkode Academy** (and any HLS `og:video`) actually play. PR1 (#865) shipped progressive `og:video` → native `<video>`; Rawkode is HLS-only (`og:video:type=application/x-mpegURL`), which no browser plays natively except Safari.

## What this does

- **`DirectVideoMediaType::Hls`** — canonical `application/vnd.apple.mpegurl`, `FromStr` accepts the common mpegurl aliases. The PR1 resolver → token → XEP-0511 → recipient pipeline then carries HLS unchanged.
- **Resolver** derives HLS native video from `og:video:type` (Rawkode shape). HLS is **excluded from the raw-`.mp4`-file (XEP-0447) path** — an adaptive manifest is not a single downloadable file; it only enters via the page `og:video` native path.
- **Client playback**: a per-card `HlsVideoPlayer` child component, mounted only after the play click, attaches the right source — `<video src>` for progressive media and native-HLS browsers (Safari/iOS), or a **lazily `import()`-ed hls.js** elsewhere. `hls.js` is only fetched on first HLS play. A fatal playback error (hls.js *or* native) falls back to a "watch on site" link. Video bytes are never proxied.
- **Client guard** (`native-video.ts`) accepts HLS media types; `isHlsMediaType` drives the player decision.

## Security / privacy

- **Click-to-load preserved**: the `<video>` (and hls.js download + manifest/segment fetches) only exist after the user clicks. SSR/initial render emits only the proxied poster + play button — a dedicated test pins this for HLS.
- hls.js uses default credential-less cross-origin fetches (no cookies to the CDN); no `xhrSetup`.
- Server remains the trust anchor (HLS flows through PR1's HMAC token + XEP-0511 re-stamp/re-validate at send).

## Deferred (consistent with PR1)

- Server-side media fetch/verify (`#EXTM3U` sniff): the client falls back gracefully on unreachable/non-CORS/codec failures, and the resolver derives HLS from `og:video:type`, so this stays a robustness-only follow-up.

## Tests

- Rust: HLS `FromStr` aliases + canonical `as_str`; resolver HLS `og:video` parse; HLS-content-type-on-direct-file rejection.
- TS: guard + `isHlsMediaType`; `videoPlaybackStrategy` matrix (hls-js vs native-src); SSR HLS click-to-load (poster + control, no `<video>`/hls.js/stream URL until click).

## Review

Two adversarial passes. The first found 4 real issues — two hls.js instance leaks (unmount-during-import; function-ref double-attach), HLS leaking into the raw-file path, and a missing Safari-native fallback — all fixed (the player moved into a lifecycle-clean child component) and re-verified by a second pass (no new defects).

Gates green locally: `cargo clippy -D warnings`, full lib suites (server/xmpp/client/core), `bun test` link-preview + `bun run lint` (knip), `astro check` clean for touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
