### PR TITLE
fix(chat): handle room join and stream errors

### DIFF
--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -52,7 +52,7 @@ import type {
   XmppErrorEvent,
   XmppStatusSnapshot,
 } from "./types";
-import { parseMucAffiliation, parseMucRole } from "./types";
+import { parseMucAffiliation, parseMucRole, XMPP_STREAM_ERROR_CONDITIONS } from "./types";
 import { prepareEncryptedAttachmentUpload } from "./encrypted-attachments";
 
 import { discoverChannels, discoverTopology } from "./discovery";
@@ -254,6 +254,39 @@ const ROOM_SELF_PRESENCE_TIMEOUT_MS = 15_000;
 type CatchupRunStats = { pages: number; messages: number };
 type CatchupOutcome = "completed" | "aborted" | "failed";
 type DmCallActivityHydrationOptions = { since?: string; pageSize?: number; maxPages?: number };
+type XmppStreamErrorPayload = string | { detail?: string | null; condition?: string | null };
+
+function streamErrorConditionFromText(text: string | null | undefined): string | undefined {
+  const normalized = text?.trim().toLowerCase();
+  if (!normalized) return undefined;
+  if (XMPP_STREAM_ERROR_CONDITIONS.has(normalized)) return normalized;
+  for (const condition of XMPP_STREAM_ERROR_CONDITIONS) {
+    const escaped = condition.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    if (new RegExp(`(^|[^a-z0-9])${escaped}([^a-z0-9]|$)`).test(normalized)) {
+      return condition;
+    }
+  }
+  return undefined;
+}
+
+function normalizeXmppStreamErrorPayload(payload: XmppStreamErrorPayload): {
+  detail: string;
+  condition?: string;
+} {
+  if (typeof payload === "string") {
+    const condition = streamErrorConditionFromText(payload);
+    return {
+      detail: payload,
+      ...(condition ? { condition } : {}),
+    };
+  }
+  const detail = payload.detail?.trim() || payload.condition?.trim() || "stream error";
+  const condition = payload.condition?.trim() || streamErrorConditionFromText(detail);
+  return {
+    detail,
+    ...(condition ? { condition } : {}),
+  };
+}
 
 async function collectRecentMamPages(
   fetchPage: (max: number, pageParam: MamPageParam) => Promise<WasmMamPage | null | undefined>,
@@ -408,7 +441,7 @@ type XmppClientInstance = Partial<WasmClient> & CompatEmitter & {
   leaveRoom?: (roomJid: string, nick: string) => Promise<void>;
   set_on_connected?: (cb: () => void) => void;
   set_on_disconnected?: (cb: () => void) => void;
-  set_on_error?: (cb: (error: string) => void) => void;
+  set_on_error?: (cb: (error: XmppStreamErrorPayload) => void) => void;
   set_on_message?: (cb: (message: WasmMessage) => void) => void;
   set_on_presence?: (cb: (presence: WasmPresence) => void) => void;
   set_on_message_delivery_acked?: (cb: (id: string) => void) => void;
@@ -735,6 +768,41 @@ export class BrowserXmppClient {
    */
   private roomJoinKey(roomJid: string): string {
     return roomJid.split("/")[0]?.trim().toLowerCase() ?? "";
+  }
+
+  private canonicalJoinedRoomJid(roomJid: string): string {
+    const key = this.roomJoinKey(roomJid);
+    if (!key) return roomJid;
+    if (this.currentRoom && this.roomJoinKey(this.currentRoom) === key) {
+      return this.currentRoom;
+    }
+    for (const joinedRoom of this.joinedMucs.keys()) {
+      if (this.roomJoinKey(joinedRoom) === key) return joinedRoom;
+    }
+    return roomJid;
+  }
+
+  private markMucReadyFromSelfPresence(roomJid: string): void {
+    const room = this.canonicalJoinedRoomJid(roomJid);
+    if (!this.joinedMucs.has(room)) {
+      this.joinedMucs.set(room, Promise.resolve());
+    }
+    this.joinedMucReady.add(room);
+    this.rememberJoinedRoom(room);
+  }
+
+  private handleMucPresenceError(presence: WasmPresence): boolean {
+    if (presence.presence_type !== "error") return false;
+    const room = presence.from?.split("/")[0]?.trim() ?? "";
+    const key = this.roomJoinKey(room);
+    if (!room || !key) return false;
+
+    const waiter = this.roomJoinWaiters.get(key);
+    if (!waiter) return false;
+
+    waiter?.reject(new Error("Channel presence was rejected. Try again in a moment."));
+    this.revokeMucReadiness(this.canonicalJoinedRoomJid(room), { keepPendingJoin: true });
+    return true;
   }
 
   /**
@@ -1211,10 +1279,23 @@ export class BrowserXmppClient {
       throw new Error("XMPP client missing join_room binding");
     }
     const ready = this.waitForRoomSelfPresence(roomJid);
-    if (xmpp.join_room) {
-      await Promise.allSettled([xmpp.join_room(roomJid, this.session.username)]);
-    } else if (xmpp.joinRoom) {
-      await xmpp.joinRoom(roomJid, this.session.username);
+    const joinKey = this.roomJoinKey(roomJid);
+    const joinWaiter = this.roomJoinWaiters.get(joinKey);
+    try {
+      if (xmpp.join_room) {
+        await xmpp.join_room(roomJid, this.session.username);
+      } else if (xmpp.joinRoom) {
+        await xmpp.joinRoom(roomJid, this.session.username);
+      }
+    } catch (error) {
+      const joinError = error instanceof Error
+        ? error
+        : new Error("XMPP room join failed before presence could sync");
+      if (this.isCurrentXmpp(xmpp) && this.roomJoinWaiters.get(joinKey) === joinWaiter) {
+        joinWaiter?.reject(joinError);
+      }
+      await ready.catch(() => undefined);
+      throw joinError;
     }
     if (!this.isCurrentXmpp(xmpp)) {
       await ready.catch(() => undefined);
@@ -2866,6 +2947,7 @@ export class BrowserXmppClient {
     ]);
     this.persistRetainedJoinedRooms();
     this.joinedMucs.clear();
+    this.joinedMucJoinTokens.clear();
     this.joinedMucReady.clear();
     this.clearRoomPresenceCaches();
     if (this.destroying) { this.clearResumeState(); this.emitStatus({ state: "offline", detail: error?.message ?? "Disconnected" }); return; }
@@ -2884,8 +2966,10 @@ export class BrowserXmppClient {
   }
   private handlePresence(presence: WasmPresence) {
     const from = presence.from ?? "";
+    if (this.handleMucPresenceError(presence)) return;
     if (this.isMucPresence(presence)) {
       const [room, nick = ""] = from.split("/");
+      if (!room) return;
       // XEP-0045 §7.2.2: our own available self-presence (status 110,
       // or, as a fallback, our disclosed real JID) completes the join.
       // Resolve by room — not the exact occupant JID — so a
@@ -2893,8 +2977,8 @@ export class BrowserXmppClient {
       // matches the waiter.
       if (this.isOwnAvailableMucSelfPresence(presence)) {
         this.roomJoinWaiters.get(this.roomJoinKey(room))?.resolve();
+        this.markMucReadyFromSelfPresence(room);
       }
-      if (!room) return;
       if (!nick && presence.vcard_avatar) this.roomAvatarHandler?.(room, presence.vcard_avatar);
       if (!nick) return;
       const roomHats = this.hatsFor(room);
@@ -3238,9 +3322,15 @@ export class BrowserXmppClient {
       if (event === "resumed") this.handleSessionReady(xmpp, { type: "resumed" }); else this.handleSessionReady(xmpp, { type: "fresh" });
     });
     xmpp.set_on_disconnected?.(() => this.handleDisconnected(xmpp));
-    xmpp.set_on_error?.((detail: string) => {
+    xmpp.set_on_error?.((payload: XmppStreamErrorPayload) => {
       if (this.xmpp !== xmpp) return;
-      this.emitError({ kind: "stream", recoverable: !this.destroying, detail });
+      const streamError = normalizeXmppStreamErrorPayload(payload);
+      this.emitError({
+        kind: "stream",
+        recoverable: !this.destroying,
+        detail: streamError.detail,
+        ...(streamError.condition ? { condition: streamError.condition } : {}),
+      });
     });
     xmpp.set_on_message?.((message: WasmMessage) => {
       if (!this.isCurrentXmpp(xmpp)) return;

--- a/chat/src/lib/xmpp/hls-player.ts
+++ b/chat/src/lib/xmpp/hls-player.ts
@@ -4,7 +4,7 @@
 // HLS play. Video bytes are never proxied — playback streams from the origin.
 import { isHlsMediaType } from "./native-video";
 
-export type VideoPlaybackStrategy = "native-src" | "hls-js";
+type VideoPlaybackStrategy = "native-src" | "hls-js";
 
 /// Pure decision: an HLS manifest needs hls.js unless the browser plays HLS
 /// natively; everything else (progressive containers) uses the <video> src.

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -62,6 +62,41 @@ export type XmppErrorKind =
   | "history"
   | "member-query";
 
+export const XMPP_STREAM_ERROR_CONDITIONS = new Set([
+  "bad-format",
+  "bad-namespace-prefix",
+  "conflict",
+  "connection-timeout",
+  "host-gone",
+  "host-unknown",
+  "improper-addressing",
+  "internal-server-error",
+  "invalid-from",
+  "invalid-namespace",
+  "invalid-xml",
+  "not-authorized",
+  "not-well-formed",
+  "policy-violation",
+  "remote-connection-failed",
+  "reset",
+  "resource-constraint",
+  "restricted-xml",
+  "see-other-host",
+  "system-shutdown",
+  "undefined-condition",
+  "unsupported-encoding",
+  "unsupported-feature",
+  "unsupported-stanza-type",
+  "unsupported-version",
+]);
+
+export const XMPP_ERROR_CONDITIONS = new Set([
+  ...XMPP_STREAM_ERROR_CONDITIONS,
+  "forbidden",
+  "item-not-found",
+  "service-unavailable",
+]);
+
 export interface XmppErrorEvent {
   kind: XmppErrorKind;
   /** Whether the client expects to recover on its own without UI intervention. */

--- a/chat/src/lib/xmpp/xmpp-instrumentation.ts
+++ b/chat/src/lib/xmpp/xmpp-instrumentation.ts
@@ -8,7 +8,11 @@
  */
 import type { BrowserXmppClient } from "@/lib/xmpp-client";
 import type { ErrorKind } from "@/lib/telemetry";
-import type { XmppErrorKind } from "@/lib/xmpp/types";
+import {
+  XMPP_ERROR_CONDITIONS,
+  XMPP_STREAM_ERROR_CONDITIONS,
+  type XmppErrorKind,
+} from "@/lib/xmpp/types";
 import {
   reportCatchup,
   reportError,
@@ -29,37 +33,6 @@ const ERROR_KIND_MAP: Record<XmppErrorKind, ErrorKind> = {
   "history": "xmpp.stream",
   "member-query": "xmpp.stream",
 };
-const XMPP_ERROR_CONDITIONS = new Set([
-  "bad-format",
-  "bad-namespace-prefix",
-  "conflict",
-  "connection-timeout",
-  "forbidden",
-  "host-gone",
-  "host-unknown",
-  "improper-addressing",
-  "internal-server-error",
-  "invalid-from",
-  "invalid-namespace",
-  "invalid-xml",
-  "item-not-found",
-  "not-authorized",
-  "not-well-formed",
-  "policy-violation",
-  "remote-connection-failed",
-  "reset",
-  "resource-constraint",
-  "restricted-xml",
-  "see-other-host",
-  "service-unavailable",
-  "system-shutdown",
-  "undefined-condition",
-  "unsupported-encoding",
-  "unsupported-feature",
-  "unsupported-stanza-type",
-  "unsupported-version",
-]);
-
 export function installInstrumentation(client: BrowserXmppClient): void {
   client.onMessageAcked((id, meta) => {
     reportMessageAcked({ id, kind: meta.kind, latencyMs: meta.latencyMs });
@@ -84,7 +57,7 @@ export function installInstrumentation(client: BrowserXmppClient): void {
   });
   client.onError((event) => {
     const kind = ERROR_KIND_MAP[event.kind];
-    const condition = telemetryCondition(event.condition);
+    const condition = telemetryCondition(event.kind, event.condition);
     const detail = telemetryErrorDetail(event, condition);
     const cause = new Error(detail);
     reportError(kind, cause, {
@@ -123,9 +96,10 @@ function telemetryErrorDetail(event: {
   }
 }
 
-function telemetryCondition(condition: string | undefined): string | undefined {
+function telemetryCondition(kind: XmppErrorKind, condition: string | undefined): string | undefined {
   if (!condition) return undefined;
   const normalized = condition.trim().toLowerCase();
   if (!normalized) return undefined;
-  return XMPP_ERROR_CONDITIONS.has(normalized) ? normalized : "unknown";
+  const allowed = kind === "stream" ? XMPP_STREAM_ERROR_CONDITIONS : XMPP_ERROR_CONDITIONS;
+  return allowed.has(normalized) ? normalized : "unknown";
 }

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -414,6 +414,179 @@ describe("client send readiness", () => {
     expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(true);
   });
 
+  test("room join rejects immediately when the join stanza cannot be sent", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    const joinError = new Error("websocket transport error");
+    const xmpp = {
+      join_room: mock(async () => {
+        throw joinError;
+      }),
+    };
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+
+    await expect(
+      (client as unknown as { ensureJoined: (roomJid: string) => Promise<void> }).ensureJoined(roomJid),
+    ).rejects.toThrow("websocket transport error");
+
+    expect(xmpp.join_room).toHaveBeenCalledWith(roomJid, "alice");
+    expect((client as unknown as { joinedMucs: Map<string, Promise<void>> }).joinedMucs.has(roomJid)).toBe(false);
+    expect((client as unknown as { joinedMucJoinTokens: Map<string, symbol> }).joinedMucJoinTokens.has(roomJid)).toBe(false);
+    expect((client as unknown as { roomJoinWaiters: Map<string, unknown> }).roomJoinWaiters.size).toBe(0);
+  });
+
+  test("room join rejects on XEP-0045 MUC error presence instead of timing out", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+    }) => void) | null = null;
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+
+    const joined = (client as unknown as { ensureJoined: (roomJid: string) => Promise<void> }).ensureJoined(roomJid);
+    await Promise.resolve();
+    expect((client as unknown as { roomJoinWaiters: Map<string, unknown> }).roomJoinWaiters.size).toBe(1);
+
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "error",
+    });
+
+    await expect(joined).rejects.toThrow("Channel presence was rejected");
+    expect((client as unknown as { joinedMucs: Map<string, Promise<void>> }).joinedMucs.has(roomJid)).toBe(false);
+    expect((client as unknown as { joinedMucJoinTokens: Map<string, symbol> }).joinedMucJoinTokens.has(roomJid)).toBe(false);
+    expect((client as unknown as { roomJoinWaiters: Map<string, unknown> }).roomJoinWaiters.size).toBe(0);
+  });
+
+  test("MUC error presence after a completed join does not revoke readiness", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      muc_status_codes?: number[];
+    }) => void) | null = null;
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+
+    const joined = (client as unknown as { ensureJoined: (roomJid: string) => Promise<void> }).ensureJoined(roomJid);
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+    });
+    await joined;
+
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "error",
+    });
+
+    expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(true);
+    expect((client as unknown as { joinedMucs: Map<string, Promise<void>> }).joinedMucs.has(roomJid)).toBe(true);
+  });
+
+  test("stale room join rejection after reconnect does not reject the fresh join waiter", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    let rejectOldJoin!: (error: Error) => void;
+    const oldXmpp = {
+      join_room: mock(() => new Promise<void>((_resolve, reject) => {
+        rejectOldJoin = reject;
+      })),
+      get_resume_state: () => null,
+      get_resume_state_handle: () => null,
+    };
+    (client as unknown as { xmpp: typeof oldXmpp; connected: boolean }).xmpp = oldXmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+
+    const oldJoin = (client as unknown as { ensureJoined: (roomJid: string) => Promise<void> })
+      .ensureJoined(roomJid)
+      .then(() => "resolved" as const)
+      .catch((error) => error);
+    await Promise.resolve();
+
+    (client as unknown as { handleDisconnected: (xmpp: typeof oldXmpp) => void }).handleDisconnected(oldXmpp);
+    (client as unknown as { clearReconnectTimer: () => void }).clearReconnectTimer();
+
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      muc_status_codes?: number[];
+    }) => void) | null = null;
+    const newXmpp = {
+      join_room: mock(async () => undefined),
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    (client as unknown as { xmpp: typeof newXmpp; connected: boolean }).xmpp = newXmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { wireEvents: (xmpp: typeof newXmpp) => void }).wireEvents(newXmpp);
+
+    const freshJoin = (client as unknown as { ensureJoined: (roomJid: string) => Promise<void> }).ensureJoined(roomJid);
+    await Promise.resolve();
+    rejectOldJoin(new Error("old transport closed"));
+    await Promise.resolve();
+
+    expect((client as unknown as { roomJoinWaiters: Map<string, unknown> }).roomJoinWaiters.size).toBe(1);
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+    });
+
+    await expect(freshJoin).resolves.toBeUndefined();
+    expect(normalizeError(await oldJoin)).toBe("old transport closed");
+    expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(true);
+  });
+
+  test("disconnect clears room join tokens so stale join resolution cannot mark ready", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    let resolveOldJoin!: () => void;
+    const oldXmpp = {
+      join_room: mock(() => new Promise<void>((resolve) => {
+        resolveOldJoin = resolve;
+      })),
+      get_resume_state: () => null,
+      get_resume_state_handle: () => null,
+    };
+    (client as unknown as { xmpp: typeof oldXmpp; connected: boolean }).xmpp = oldXmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+
+    const oldJoin = (client as unknown as { ensureJoined: (roomJid: string) => Promise<void> }).ensureJoined(roomJid);
+    await Promise.resolve();
+    expect((client as unknown as { joinedMucJoinTokens: Map<string, symbol> }).joinedMucJoinTokens.has(roomJid)).toBe(true);
+
+    (client as unknown as { handleDisconnected: (xmpp: typeof oldXmpp) => void }).handleDisconnected(oldXmpp);
+    (client as unknown as { clearReconnectTimer: () => void }).clearReconnectTimer();
+    expect((client as unknown as { joinedMucJoinTokens: Map<string, symbol> }).joinedMucJoinTokens.size).toBe(0);
+
+    resolveOldJoin();
+    await oldJoin;
+
+    expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(false);
+    expect((client as unknown as { joinedMucs: Map<string, Promise<void>> }).joinedMucs.has(roomJid)).toBe(false);
+  });
+
   test("room join resolves on XEP-0045 status code 110 in an anonymous room (no real JID disclosed)", async () => {
     // Semi-/anonymous rooms don't disclose the occupant's real JID, so
     // self-presence can only be recognised by `<status code='110'/>`

--- a/chat/tests/xmpp-telemetry.test.ts
+++ b/chat/tests/xmpp-telemetry.test.ts
@@ -714,6 +714,91 @@ describe("BrowserXmppClient telemetry hooks", () => {
     expect(memberErr.options?.context?.detail).toBe("member-query-unknown");
   });
 
+  test("self-presence join timeout reports a stable room timeout detail", () => {
+    const stub = createFaroStub();
+    __setFaroForTesting(stub as never);
+
+    const client = new BrowserXmppClient(session());
+    installInstrumentation(client);
+
+    const internal = client as unknown as {
+      emitError: (event: {
+        kind: "connect-timeout";
+        recoverable: boolean;
+        detail: string;
+      }) => void;
+    };
+
+    internal.emitError({
+      kind: "connect-timeout",
+      recoverable: true,
+      detail: "Timed out waiting for self-presence in c1@muc.example.com",
+    });
+
+    expect(stub.errors).toHaveLength(1);
+    expect(stub.errors[0].options?.type).toBe("xmpp.disconnect");
+    expect(stub.errors[0].options?.context?.recoverable).toBe("true");
+    expect(stub.errors[0].options?.context?.detail).toBe("room-self-presence-timeout");
+  });
+
+  test("set_on_error bridge preserves stream error conditions for telemetry", () => {
+    const stub = createFaroStub();
+    __setFaroForTesting(stub as never);
+
+    const client = new BrowserXmppClient(session());
+    installInstrumentation(client);
+
+    let onError: ((detail: string | { detail?: string; condition?: string }) => void) | null = null;
+    const xmpp = {
+      set_on_error(cb: NonNullable<typeof onError>) {
+        onError = cb;
+      },
+    };
+    const internal = client as unknown as {
+      xmpp: typeof xmpp;
+      wireEvents: (xmpp: typeof xmpp) => void;
+    };
+    internal.xmpp = xmpp;
+    internal.wireEvents(xmpp);
+
+    onError?.({ detail: "stream error", condition: "not-authorized" });
+
+    expect(stub.errors).toHaveLength(1);
+    expect(stub.errors[0].error.message).toBe("stream-not-authorized");
+    expect(stub.errors[0].options?.type).toBe("xmpp.stream");
+    expect(stub.errors[0].options?.context?.condition).toBe("not-authorized");
+    expect(stub.errors[0].options?.context?.detail).toBe("stream-not-authorized");
+  });
+
+  test("set_on_error bridge keeps stanza-only conditions out of stream telemetry", () => {
+    const stub = createFaroStub();
+    __setFaroForTesting(stub as never);
+
+    const client = new BrowserXmppClient(session());
+    installInstrumentation(client);
+
+    let onError: ((detail: string | { detail?: string; condition?: string }) => void) | null = null;
+    const xmpp = {
+      set_on_error(cb: NonNullable<typeof onError>) {
+        onError = cb;
+      },
+    };
+    const internal = client as unknown as {
+      xmpp: typeof xmpp;
+      wireEvents: (xmpp: typeof xmpp) => void;
+    };
+    internal.xmpp = xmpp;
+    internal.wireEvents(xmpp);
+
+    onError?.("forbidden");
+
+    expect(stub.errors).toHaveLength(1);
+    expect(stub.errors[0].error.message).toBe("stream-error");
+    expect(stub.errors[0].options?.type).toBe("xmpp.stream");
+    expect(stub.errors[0].options?.context?.condition).toBeUndefined();
+    expect(stub.errors[0].options?.context?.detail).toBe("stream-error");
+  });
+
   test("enqueuing a send fires onSendEnqueued + onQueueDepthChange", async () => {
     const client = new BrowserXmppClient(session());
     // Force the slow path: make connect throw so we stay in "no-client" reason.

--- a/server/crates/waddle-xmpp-client-wasm/src/events.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/events.rs
@@ -56,6 +56,9 @@ pub(crate) fn dispatch_client_event(inner: &Rc<RefCell<WaddleClientInner>>, even
                 let _ = callback.call1(&JsValue::NULL, &JsValue::from_str("resumed"));
             }
         }
+        ClientEvent::Connection(ConnectionEvent::StreamError { condition }) => {
+            emit_stream_error_callback(inner, condition);
+        }
         ClientEvent::Messaging(waddle_xmpp_client::MessagingEvent::Message(message)) => {
             let mut message = *message;
             let account_bare_jid = {
@@ -141,5 +144,28 @@ pub(crate) fn emit_error_callback(inner: &Rc<RefCell<WaddleClientInner>>, descri
     let callback = inner.borrow().on_error.clone();
     if let Some(callback) = callback {
         let _ = callback.call1(&JsValue::NULL, &JsValue::from_str(description));
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JsStreamError<'a> {
+    detail: &'a str,
+    condition: &'a str,
+}
+
+fn emit_stream_error_callback(
+    inner: &Rc<RefCell<WaddleClientInner>>,
+    condition: StreamErrorCondition,
+) {
+    let callback = inner.borrow().on_error.clone();
+    if let Some(callback) = callback {
+        let condition = condition.as_str();
+        let payload = JsStreamError {
+            detail: "stream error",
+            condition,
+        };
+        let value = to_js_value(&payload).unwrap_or_else(|_| JsValue::from_str(condition));
+        let _ = callback.call1(&JsValue::NULL, &value);
     }
 }

--- a/server/crates/waddle-xmpp-client-wasm/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/lib.rs
@@ -61,8 +61,8 @@ use waddle_xmpp_client::xep::{
 use waddle_xmpp_client::{
     AccessToken, ArchivedMessage, ClientConfig, ClientError, ClientEvent, ClientRequest,
     ClientResource, ConnectionConfig, ConnectionEvent, LifecycleEvent, MessageDeliveryEvent,
-    OAuthBearerConfig, StanzaId, StreamManagementEvent, WasmTransportEvent, WasmWebSocket,
-    WebSocketConfig, XmppRuntime,
+    OAuthBearerConfig, StanzaId, StreamErrorCondition, StreamManagementEvent, WasmTransportEvent,
+    WasmWebSocket, WebSocketConfig, XmppRuntime,
 };
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::{future_to_promise, spawn_local};

--- a/server/crates/waddle-xmpp-client/src/event.rs
+++ b/server/crates/waddle-xmpp-client/src/event.rs
@@ -65,6 +65,7 @@ pub enum ConnectionEvent {
     OutboundMessage(TransportMessage),
     StreamOpening(StreamOpen),
     StreamOpened(StreamOpen),
+    StreamError { condition: StreamErrorCondition },
     FeaturesAdvertised(StreamFeatures),
     AuthenticationRequested(AuthenticationRequest),
     AuthenticationSucceeded,
@@ -83,6 +84,99 @@ pub enum StreamManagementEvent {
     AckRequested,
     Resumed { h: u32 },
     Failed,
+}
+
+/// RFC 6120 stream-error conditions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamErrorCondition {
+    BadFormat,
+    BadNamespacePrefix,
+    Conflict,
+    ConnectionTimeout,
+    HostGone,
+    HostUnknown,
+    ImproperAddressing,
+    InternalServerError,
+    InvalidFrom,
+    InvalidNamespace,
+    InvalidXml,
+    NotAuthorized,
+    NotWellFormed,
+    PolicyViolation,
+    RemoteConnectionFailed,
+    Reset,
+    ResourceConstraint,
+    RestrictedXml,
+    SeeOtherHost,
+    SystemShutdown,
+    UndefinedCondition,
+    UnsupportedEncoding,
+    UnsupportedFeature,
+    UnsupportedStanzaType,
+    UnsupportedVersion,
+}
+
+impl StreamErrorCondition {
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "bad-format" => Some(Self::BadFormat),
+            "bad-namespace-prefix" => Some(Self::BadNamespacePrefix),
+            "conflict" => Some(Self::Conflict),
+            "connection-timeout" => Some(Self::ConnectionTimeout),
+            "host-gone" => Some(Self::HostGone),
+            "host-unknown" => Some(Self::HostUnknown),
+            "improper-addressing" => Some(Self::ImproperAddressing),
+            "internal-server-error" => Some(Self::InternalServerError),
+            "invalid-from" => Some(Self::InvalidFrom),
+            "invalid-namespace" => Some(Self::InvalidNamespace),
+            "invalid-xml" => Some(Self::InvalidXml),
+            "not-authorized" => Some(Self::NotAuthorized),
+            "not-well-formed" => Some(Self::NotWellFormed),
+            "policy-violation" => Some(Self::PolicyViolation),
+            "remote-connection-failed" => Some(Self::RemoteConnectionFailed),
+            "reset" => Some(Self::Reset),
+            "resource-constraint" => Some(Self::ResourceConstraint),
+            "restricted-xml" => Some(Self::RestrictedXml),
+            "see-other-host" => Some(Self::SeeOtherHost),
+            "system-shutdown" => Some(Self::SystemShutdown),
+            "undefined-condition" => Some(Self::UndefinedCondition),
+            "unsupported-encoding" => Some(Self::UnsupportedEncoding),
+            "unsupported-feature" => Some(Self::UnsupportedFeature),
+            "unsupported-stanza-type" => Some(Self::UnsupportedStanzaType),
+            "unsupported-version" => Some(Self::UnsupportedVersion),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::BadFormat => "bad-format",
+            Self::BadNamespacePrefix => "bad-namespace-prefix",
+            Self::Conflict => "conflict",
+            Self::ConnectionTimeout => "connection-timeout",
+            Self::HostGone => "host-gone",
+            Self::HostUnknown => "host-unknown",
+            Self::ImproperAddressing => "improper-addressing",
+            Self::InternalServerError => "internal-server-error",
+            Self::InvalidFrom => "invalid-from",
+            Self::InvalidNamespace => "invalid-namespace",
+            Self::InvalidXml => "invalid-xml",
+            Self::NotAuthorized => "not-authorized",
+            Self::NotWellFormed => "not-well-formed",
+            Self::PolicyViolation => "policy-violation",
+            Self::RemoteConnectionFailed => "remote-connection-failed",
+            Self::Reset => "reset",
+            Self::ResourceConstraint => "resource-constraint",
+            Self::RestrictedXml => "restricted-xml",
+            Self::SeeOtherHost => "see-other-host",
+            Self::SystemShutdown => "system-shutdown",
+            Self::UndefinedCondition => "undefined-condition",
+            Self::UnsupportedEncoding => "unsupported-encoding",
+            Self::UnsupportedFeature => "unsupported-feature",
+            Self::UnsupportedStanzaType => "unsupported-stanza-type",
+            Self::UnsupportedVersion => "unsupported-version",
+        }
+    }
 }
 
 /// Delivery status for outbound `<message/>` stanzas tracked through

--- a/server/crates/waddle-xmpp-client/src/lib.rs
+++ b/server/crates/waddle-xmpp-client/src/lib.rs
@@ -57,7 +57,8 @@ pub use discovery::{
 };
 pub use error::{ClientError, ClientResult, StanzaError, StanzaErrorType};
 pub use event::{
-    ClientEvent, ConnectionEvent, LifecycleEvent, MessageDeliveryEvent, StreamManagementEvent,
+    ClientEvent, ConnectionEvent, LifecycleEvent, MessageDeliveryEvent, StreamErrorCondition,
+    StreamManagementEvent,
 };
 #[cfg(all(feature = "native", not(target_arch = "wasm32")))]
 pub use mam::MamExt;

--- a/server/crates/waddle-xmpp-client/src/runtime/sm.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime/sm.rs
@@ -1,7 +1,9 @@
 use crate::bootstrap::NS_STREAMS;
 
 use crate::error::{ClientError, ClientResult};
-use crate::event::{ClientEvent, ConnectionEvent, MessageDeliveryEvent, StreamManagementEvent};
+use crate::event::{
+    ClientEvent, ConnectionEvent, MessageDeliveryEvent, StreamErrorCondition, StreamManagementEvent,
+};
 use crate::state::{SessionBinding, StreamId};
 use crate::transport::{StreamClose, TransportMessage};
 use minidom::Element;
@@ -18,6 +20,10 @@ impl XmppRuntime {
     ) {
         debug_assert_eq!(element.name(), "error");
         debug_assert_eq!(element.ns(), NS_STREAMS);
+
+        events.push(ClientEvent::Connection(ConnectionEvent::StreamError {
+            condition: stream_error_condition(element),
+        }));
 
         // RFC 6120 defines stream errors as terminal for the current XML
         // stream. During XEP-0198 resume bootstrap, recoverable resume-specific
@@ -222,4 +228,12 @@ impl XmppRuntime {
             resumable: self.sm_state.previd.is_some(),
         })
     }
+}
+
+fn stream_error_condition(element: &Element) -> StreamErrorCondition {
+    element
+        .children()
+        .filter(|child| child.ns() == NS_STREAM_ERRORS && child.name() != "text")
+        .find_map(|child| StreamErrorCondition::from_name(child.name()))
+        .unwrap_or(StreamErrorCondition::UndefinedCondition)
 }

--- a/server/crates/waddle-xmpp-client/src/runtime/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime/tests.rs
@@ -7,7 +7,9 @@ use url::Url;
 use super::*;
 use crate::bootstrap::{NS_BIND, NS_SASL, NS_STREAMS};
 use crate::config::{AccessToken, ClientResource, OAuthBearerConfig, WebSocketConfig};
-use crate::{ConnectionConfig, SmResumeState, StreamId, StreamManagementEvent};
+use crate::{
+    ConnectionConfig, SmResumeState, StreamErrorCondition, StreamId, StreamManagementEvent,
+};
 
 fn config() -> ClientConfig {
     ClientConfig::new(
@@ -944,6 +946,12 @@ fn runtime_discards_resume_state_after_generic_prebind_stream_error() {
 
     assert!(error_events.iter().any(|event| matches!(
         event,
+        ClientEvent::Connection(ConnectionEvent::StreamError {
+            condition: StreamErrorCondition::InternalServerError
+        })
+    )));
+    assert!(error_events.iter().any(|event| matches!(
+        event,
         ClientEvent::MessageDelivery(crate::MessageDeliveryEvent::Failed { stanza_id })
             if stanza_id.as_str() == "retry-after-generic-stream-error"
     )));
@@ -954,6 +962,44 @@ fn runtime_discards_resume_state_after_generic_prebind_stream_error() {
         ))
     )));
     assert!(runtime.resume_state().is_none());
+}
+
+#[test]
+fn runtime_emits_stream_error_condition_for_browser_telemetry() {
+    let mut runtime = XmppRuntime::new(config()).unwrap();
+    drive_to_authenticated_stream(&mut runtime);
+
+    let events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            not_authorized_stream_error(),
+        )))
+        .unwrap();
+
+    assert!(events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::StreamError {
+            condition: StreamErrorCondition::NotAuthorized
+        })
+    )));
+}
+
+#[test]
+fn runtime_rejects_stanza_only_conditions_in_stream_error_namespace() {
+    let mut runtime = XmppRuntime::new(config()).unwrap();
+    drive_to_authenticated_stream(&mut runtime);
+
+    let events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            invalid_forbidden_stream_error(),
+        )))
+        .unwrap();
+
+    assert!(events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::StreamError {
+            condition: StreamErrorCondition::UndefinedCondition
+        })
+    )));
 }
 
 #[test]
@@ -1387,6 +1433,23 @@ fn internal_server_error_stream_error() -> Element {
             )
             .build(),
         )
+        .build()
+}
+
+fn not_authorized_stream_error() -> Element {
+    Element::builder("error", NS_STREAMS)
+        .append(
+            Element::builder("text", "urn:ietf:params:xml:ns:xmpp-streams")
+                .append("authentication expired")
+                .build(),
+        )
+        .append(Element::builder("not-authorized", "urn:ietf:params:xml:ns:xmpp-streams").build())
+        .build()
+}
+
+fn invalid_forbidden_stream_error() -> Element {
+    Element::builder("error", NS_STREAMS)
+        .append(Element::builder("forbidden", "urn:ietf:params:xml:ns:xmpp-streams").build())
         .build()
 }
 

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -461,6 +461,7 @@ export class WaddleClient {
      */
     subscribe_mds_displayed(): Promise<any>;
     subscribe_to_presence(peer_jid: string): Promise<any>;
+    supports_mds_publish_options(): Promise<any>;
     /**
      * Publish an unpin request (#414). Same authorization rules as
      * [`Self::pin_message`].

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=a9c8857a3c19";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=a9c8857a3c19";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=a9c8857a3c19";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=7a5caa47cbe2";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=7a5caa47cbe2";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=7a5caa47cbe2";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=a9c8857a3c19";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=7a5caa47cbe2";


### PR DESCRIPTION
## Summary

- Reject MUC joins immediately when `join_room`/`joinRoom` fails or when XEP-0045 join error presence arrives, instead of waiting for `room-self-presence-timeout`.
- Guard room join waiters and join tokens across disconnect/reconnect so stale join promises cannot poison a fresh room join or mark a room ready after the old stream is gone.
- Surface RFC 6120 `<stream:error/>` conditions from the Rust runtime through the WASM bridge into chat telemetry, while keeping stanza-only conditions out of stream telemetry.
- Regenerate the local WASM wrapper and narrow one unused HLS player type export so `knip` remains clean.

## Plan

1. Review local `./xeps` for XEP-0045 MUC self-presence and join errors, XEP-0198 reconnect/resume behavior, and RFC 6120 stream-error conditions.
2. Trace the chat `room-self-presence-timeout` and `stream-error` telemetry paths through `BrowserXmppClient`, instrumentation, the Rust runtime, and the WASM event bridge.
3. Fix room join readiness so send failures, join error presence, and stale reconnect joins resolve deterministically without fabricating MUC state.
4. Add typed Rust stream-error condition events and structured WASM callback payloads for browser telemetry.
5. Add focused regression tests for join failure, MUC error presence, stale join races, stream-error condition propagation, and stanza-only condition rejection.
6. Run focused and full validation, then repeat adversarial review until no actionable issues remain.

## Validation

- `bun test tests/client-send-readiness.test.ts`
- `bun test tests/xmpp-telemetry.test.ts`
- `bun test`
- `bun run lint`
- `cargo test -p waddle-xmpp-client --manifest-path server/Cargo.toml` (rerun outside sandbox for the local transport socket test)
- `cargo test -p waddle-xmpp-client-wasm --manifest-path server/Cargo.toml`
- `git diff --check`

## Review Notes

- XEP/MUC reviewer found and I fixed an invalid `forbidden` stream-error condition; stream telemetry now uses an RFC 6120-only condition set and stanza-only conditions stay in the broader stanza/member-query vocabulary.
- TypeScript-state reviewer found and I fixed stale reconnect join races by guarding waiter identity/current handle and clearing pending join tokens on disconnect.
- Final XEP/MUC, TypeScript-state, and Rust/WASM telemetry adversarial reviews reported no actionable issues.
