### PR TITLE
feat(chat): add pull-based story reactions

### DIFF
--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -623,9 +623,11 @@ onUnmounted(() => {
         :can-post="!!connectionStore.session"
         :self-jid="connectionStore.session?.jid ?? null"
         :is-story-read="stories.isStoryRead"
+        :reaction-summary="stories.reactionSummary"
         @refresh="stories.refresh()"
         @post="(input) => stories.post(input)"
         @story-selected="(id) => stories.markStoryRead(id)"
+        @react="(id, emoji) => stories.toggleReaction(id, emoji)"
         @open-nav="ui.showMobileNav.value = true"
       />
       <EventsPane

--- a/chat/src/components/community/StoriesPane.vue
+++ b/chat/src/components/community/StoriesPane.vue
@@ -4,7 +4,8 @@ import { Camera, ChevronLeft, ChevronRight, Menu, Plus, RefreshCw, X } from "luc
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import StoryComposer from "@/components/community/StoryComposer.vue";
 import { connectionStore } from "@/lib/connection-store";
-import type { Story, StoryPostInput } from "@/lib/xmpp-client";
+import type { Story, StoryPostInput, StoryReactionSummary } from "@/lib/xmpp-client";
+import { QUICK_REACTION_EMOJIS } from "@/lib/reaction-mode";
 
 interface StoriesPaneProps {
   stories: readonly Story[];
@@ -14,16 +15,19 @@ interface StoriesPaneProps {
   canPost: boolean;
   selfJid: string | null;
   isStoryRead?: (id: string) => boolean;
+  reactionSummary?: (id: string) => StoryReactionSummary;
 }
 
 const props = withDefaults(defineProps<StoriesPaneProps>(), {
   isStoryRead: () => () => false,
+  reactionSummary: () => () => ({ counts: {}, reactors: {}, mine: [] }),
 });
 
 const emit = defineEmits<{
   refresh: [];
   post: [input: StoryPostInput];
   storySelected: [id: string];
+  react: [id: string, emoji: string];
   openNav: [];
 }>();
 
@@ -49,6 +53,14 @@ function timeRemaining(story: Story, nowMs: number = Date.now()): string {
 const activeStory = computed<Story | null>(() => {
   if (activeIndex.value === null) return null;
   return props.stories[activeIndex.value] ?? null;
+});
+const activeReactionSummary = computed(() => activeStory.value ? props.reactionSummary(activeStory.value.id) : null);
+const activeReactionEntries = computed(() => {
+  const summary = activeReactionSummary.value;
+  if (!summary) return [];
+  return Object.entries(summary.counts)
+    .map(([emoji, count]) => ({ emoji, count, reactors: summary.reactors[emoji] ?? [] }))
+    .sort((a, b) => b.count - a.count || a.emoji.localeCompare(b.emoji));
 });
 
 watch(
@@ -112,6 +124,12 @@ async function handleComposerSubmit(payload: { body?: string; file: Blob; mediaK
 function handleComposerCancel() {
   composerOpen.value = false;
   composerError.value = null;
+}
+
+function toggleReaction(emoji: string) {
+  const story = activeStory.value;
+  if (!story) return;
+  emit("react", story.id, emoji);
 }
 </script>
 
@@ -240,6 +258,33 @@ function handleComposerCancel() {
         <p v-if="activeStory.body" class="whitespace-pre-wrap break-words text-sm text-foreground">
           {{ activeStory.body }}
         </p>
+
+        <div class="grid gap-2 border-t border-border pt-3">
+          <div class="flex flex-wrap items-center gap-1.5">
+            <button
+              v-for="emoji in QUICK_REACTION_EMOJIS"
+              :key="emoji"
+              type="button"
+              class="inline-flex h-8 min-w-8 items-center justify-center rounded-md border px-2 text-sm hover:bg-muted/60"
+              :class="activeReactionSummary?.mine.includes(emoji) ? 'border-primary bg-primary/10 text-primary' : 'border-input text-foreground'"
+              :aria-label="`React with ${emoji}`"
+              @click="toggleReaction(emoji)"
+            >
+              {{ emoji }}
+            </button>
+          </div>
+          <div v-if="activeReactionEntries.length > 0" class="flex flex-wrap gap-1.5">
+            <span
+              v-for="entry in activeReactionEntries"
+              :key="entry.emoji"
+              class="inline-flex items-center gap-1 rounded-md border border-border bg-muted/40 px-2 py-1 text-xs text-foreground"
+              :title="entry.reactors.join(', ')"
+            >
+              <span>{{ entry.emoji }}</span>
+              <span class="text-muted-foreground">{{ entry.count }}</span>
+            </span>
+          </div>
+        </div>
 
         <div class="flex items-center justify-between gap-2 border-t border-border pt-3">
           <button

--- a/chat/src/components/community/StoriesPane.vue
+++ b/chat/src/components/community/StoriesPane.vue
@@ -268,6 +268,7 @@ function toggleReaction(emoji: string) {
               class="inline-flex h-8 min-w-8 items-center justify-center rounded-md border px-2 text-sm hover:bg-muted/60"
               :class="activeReactionSummary?.mine.includes(emoji) ? 'border-primary bg-primary/10 text-primary' : 'border-input text-foreground'"
               :aria-label="`React with ${emoji}`"
+              :aria-pressed="activeReactionSummary?.mine.includes(emoji) ? 'true' : 'false'"
               @click="toggleReaction(emoji)"
             >
               {{ emoji }}

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -162,6 +162,8 @@ import { escapeXml } from "./extension-commands/xml";
 
 export { dmMessageFromArchived, roomMessageFromArchived } from "./wasm-message-codecs";
 
+const NS_PUBSUB = "http://jabber.org/protocol/pubsub";
+
 function isRoomActivityMessage(message: LiveRoomMessage): boolean {
   return !!message.body && !message.replacesId && !message.retractsId;
 }
@@ -251,6 +253,7 @@ function parseStoryReactionItems(xml: string): StoryReactionItem[] {
   const doc = new DOMParser().parseFromString(xml, "text/xml");
   const serializer = typeof XMLSerializer !== "undefined" ? new XMLSerializer() : null;
   return Array.from(doc.getElementsByTagName("item"))
+    .filter((item) => item.namespaceURI === NS_PUBSUB)
     .map((item): StoryReactionItem | null => {
       const jid = item.getAttribute("id")?.trim();
       if (!jid) return null;
@@ -2414,7 +2417,7 @@ export class BrowserXmppClient {
     if (typeof xmpp.send_raw_iq !== "function") return [];
     const node = storyAttachmentNode(communityJid, storyId);
     const responseXml = await xmpp.send_raw_iq(
-      `<iq type="get" id="${crypto.randomUUID()}" to="${escapeXml(communityJid)}"><pubsub xmlns="http://jabber.org/protocol/pubsub"><items node="${escapeXml(node)}"/></pubsub></iq>`,
+      `<iq type="get" id="${crypto.randomUUID()}" to="${escapeXml(communityJid)}"><pubsub xmlns="${NS_PUBSUB}"><items node="${escapeXml(node)}"/></pubsub></iq>`,
     ) as string;
     return parseStoryReactionItems(responseXml);
   }
@@ -2436,7 +2439,7 @@ export class BrowserXmppClient {
     const reactionsXml = `<reactions>${normalized.map((emoji) => `<reaction>${escapeXml(emoji)}</reaction>`).join("")}</reactions>`;
     const preservedXml = unknownChildrenXml.join("");
     await xmpp.send_raw_iq(
-      `<iq type="set" id="${crypto.randomUUID()}" to="${escapeXml(communityJid)}"><pubsub xmlns="http://jabber.org/protocol/pubsub"><publish node="${escapeXml(node)}"><item id="${escapeXml(barePeerJid(this.session.jid))}"><attachments xmlns="${NS_PUBSUB_ATTACHMENTS}">${reactionsXml}${preservedXml}</attachments></item></publish></pubsub></iq>`,
+      `<iq type="set" id="${crypto.randomUUID()}" to="${escapeXml(communityJid)}"><pubsub xmlns="${NS_PUBSUB}"><publish node="${escapeXml(node)}"><item id="${escapeXml(barePeerJid(this.session.jid))}"><attachments xmlns="${NS_PUBSUB_ATTACHMENTS}">${reactionsXml}${preservedXml}</attachments></item></publish></pubsub></iq>`,
     );
   }
 
@@ -2445,7 +2448,7 @@ export class BrowserXmppClient {
     if (typeof xmpp.send_raw_iq !== "function") throw new Error("XMPP session is not ready");
     const node = storyAttachmentNode(communityJid, storyId);
     await xmpp.send_raw_iq(
-      `<iq type="set" id="${crypto.randomUUID()}" to="${escapeXml(communityJid)}"><pubsub xmlns="http://jabber.org/protocol/pubsub"><retract node="${escapeXml(node)}"><item id="${escapeXml(barePeerJid(this.session.jid))}"/></retract></pubsub></iq>`,
+      `<iq type="set" id="${crypto.randomUUID()}" to="${escapeXml(communityJid)}"><pubsub xmlns="${NS_PUBSUB}"><retract node="${escapeXml(node)}"><item id="${escapeXml(barePeerJid(this.session.jid))}"/></retract></pubsub></iq>`,
     );
   }
 

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -87,9 +87,13 @@ import {
   type WasmFeedEntry,
 } from "./feed-types";
 import {
+  NS_PUBSUB_ATTACHMENTS,
+  normalizeStoryReactions,
+  storyAttachmentNode,
   storyFromWasm,
   type Story,
   type StoryPostInput,
+  type StoryReactionItem,
   type WasmStory,
 } from "./story-types";
 import {
@@ -154,6 +158,7 @@ import type {
   WasmVCard4,
 } from "./wasm-types";
 import type { VCard4Profile } from "./vcard4-types";
+import { escapeXml } from "./extension-commands/xml";
 
 export { dmMessageFromArchived, roomMessageFromArchived } from "./wasm-message-codecs";
 
@@ -239,6 +244,39 @@ function shouldSkipRawCatchupMessage(
   if (seen.size > 0 && rawMessageSeenIds(message).some((id) => seen.has(id))) return true;
   if (!since || !message.timestamp) return false;
   return compareTimestamps(message.timestamp, since) < 0;
+}
+
+function parseStoryReactionItems(xml: string): StoryReactionItem[] {
+  if (typeof DOMParser === "undefined") return [];
+  const doc = new DOMParser().parseFromString(xml, "text/xml");
+  const serializer = typeof XMLSerializer !== "undefined" ? new XMLSerializer() : null;
+  return Array.from(doc.getElementsByTagName("item"))
+    .map((item): StoryReactionItem | null => {
+      const jid = item.getAttribute("id")?.trim();
+      if (!jid) return null;
+      const attachments = Array.from(item.children).find(
+        (child) => child.localName === "attachments" && child.namespaceURI === NS_PUBSUB_ATTACHMENTS,
+      );
+      if (!attachments) return null;
+      const reactions = Array.from(attachments.children).find(
+        (child) => child.localName === "reactions" && child.namespaceURI === NS_PUBSUB_ATTACHMENTS,
+      );
+      const emojis = reactions
+        ? Array.from(reactions.children)
+            .filter((child) => child.localName === "reaction" && child.namespaceURI === NS_PUBSUB_ATTACHMENTS)
+            .map((child) => child.textContent?.trim() ?? "")
+        : [];
+      const unknownChildrenXml = Array.from(attachments.children)
+        .filter((child) => !(child.localName === "reactions" && child.namespaceURI === NS_PUBSUB_ATTACHMENTS))
+        .map((child) => serializer?.serializeToString(child) ?? "")
+        .filter(Boolean);
+      return {
+        jid,
+        emojis: normalizeStoryReactions(emojis),
+        unknownChildrenXml,
+      };
+    })
+    .filter((item): item is StoryReactionItem => item !== null);
 }
 
 const DM_CALL_ACTIVITY_PAGE_SIZE = 100;
@@ -2369,6 +2407,46 @@ export class BrowserXmppClient {
       throw new Error("stories_publish returned no story");
     }
     return storyFromWasm(result);
+  }
+
+  async fetchStoryReactions(communityJid: string, storyId: string): Promise<StoryReactionItem[]> {
+    const xmpp = await this.requireConnectedXmpp();
+    if (typeof xmpp.send_raw_iq !== "function") return [];
+    const node = storyAttachmentNode(communityJid, storyId);
+    const responseXml = await xmpp.send_raw_iq(
+      `<iq type="get" id="${crypto.randomUUID()}" to="${escapeXml(communityJid)}"><pubsub xmlns="http://jabber.org/protocol/pubsub"><items node="${escapeXml(node)}"/></pubsub></iq>`,
+    ) as string;
+    return parseStoryReactionItems(responseXml);
+  }
+
+  async publishStoryReactions(
+    communityJid: string,
+    storyId: string,
+    emojis: readonly string[],
+    unknownChildrenXml: readonly string[] = [],
+  ): Promise<void> {
+    const xmpp = await this.requireConnectedXmpp();
+    if (typeof xmpp.send_raw_iq !== "function") throw new Error("XMPP session is not ready");
+    const node = storyAttachmentNode(communityJid, storyId);
+    const normalized = normalizeStoryReactions(emojis);
+    if (normalized.length === 0) {
+      await this.retractStoryReactions(communityJid, storyId);
+      return;
+    }
+    const reactionsXml = `<reactions>${normalized.map((emoji) => `<reaction>${escapeXml(emoji)}</reaction>`).join("")}</reactions>`;
+    const preservedXml = unknownChildrenXml.join("");
+    await xmpp.send_raw_iq(
+      `<iq type="set" id="${crypto.randomUUID()}" to="${escapeXml(communityJid)}"><pubsub xmlns="http://jabber.org/protocol/pubsub"><publish node="${escapeXml(node)}"><item id="${escapeXml(barePeerJid(this.session.jid))}"><attachments xmlns="${NS_PUBSUB_ATTACHMENTS}">${reactionsXml}${preservedXml}</attachments></item></publish></pubsub></iq>`,
+    );
+  }
+
+  async retractStoryReactions(communityJid: string, storyId: string): Promise<void> {
+    const xmpp = await this.requireConnectedXmpp();
+    if (typeof xmpp.send_raw_iq !== "function") throw new Error("XMPP session is not ready");
+    const node = storyAttachmentNode(communityJid, storyId);
+    await xmpp.send_raw_iq(
+      `<iq type="set" id="${crypto.randomUUID()}" to="${escapeXml(communityJid)}"><pubsub xmlns="http://jabber.org/protocol/pubsub"><retract node="${escapeXml(node)}"><item id="${escapeXml(barePeerJid(this.session.jid))}"/></retract></pubsub></iq>`,
+    );
   }
 
   /**

--- a/chat/src/lib/xmpp/index.ts
+++ b/chat/src/lib/xmpp/index.ts
@@ -35,8 +35,8 @@ export {
 export type { OutboundFileAttachment } from "./send-types";
 export type { InboxEntry } from "./inbox-types";
 export type { FeedEntry, FeedPostInput, FeedSourceKind } from "./feed-types";
-export type { Story, StoryPostInput } from "./story-types";
-export { isStoryActive } from "./story-types";
+export type { Story, StoryPostInput, StoryReactionItem, StoryReactionSummary } from "./story-types";
+export { aggregateStoryReactions, isStoryActive, normalizeStoryReactions, STORY_REACTIONS_MAX } from "./story-types";
 export type { StoryRead, StoryReads } from "./story-reads-types";
 export {
   pruneStoryReads,

--- a/chat/src/lib/xmpp/story-types.ts
+++ b/chat/src/lib/xmpp/story-types.ts
@@ -21,6 +21,23 @@ export interface Story {
   expiresMs?: number;
 }
 
+export interface StoryReactionItem {
+  /** Bare JID of the reacting member; also the XEP-0060 item id. */
+  jid: string;
+  emojis: readonly string[];
+  /** XML children inside `<attachments/>` that this client does not understand. */
+  unknownChildrenXml: readonly string[];
+}
+
+export interface StoryReactionSummary {
+  counts: Record<string, number>;
+  reactors: Record<string, string[]>;
+  mine: readonly string[];
+}
+
+export const NS_PUBSUB_ATTACHMENTS = "urn:xmpp:pubsub-attachments:1";
+export const STORY_REACTIONS_MAX = 12;
+
 export interface StoryPostInput {
   body?: string;
   mediaUrl?: string;
@@ -56,4 +73,40 @@ export function storyFromWasm(story: WasmStory): Story {
 export function isStoryActive(story: Story, nowMs: number = Date.now()): boolean {
   if (typeof story.expiresMs !== "number") return true;
   return story.expiresMs > nowMs;
+}
+
+export function storyAttachmentNode(communityJid: string, storyId: string): string {
+  return `${NS_PUBSUB_ATTACHMENTS}/xmpp:${communityJid}?;node=${encodeURIComponent("urn:xmpp:stories:0")};item=${encodeURIComponent(storyId)}`;
+}
+
+export function normalizeStoryReactions(emojis: Iterable<string>): string[] {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const raw of emojis) {
+    const emoji = raw.trim();
+    if (!emoji || seen.has(emoji)) continue;
+    seen.add(emoji);
+    normalized.push(emoji);
+  }
+  return normalized;
+}
+
+export function aggregateStoryReactions(
+  items: readonly StoryReactionItem[],
+  selfBareJid: string | null | undefined,
+): StoryReactionSummary {
+  const counts: Record<string, number> = {};
+  const reactors: Record<string, string[]> = {};
+  const mine = selfBareJid
+    ? (items.find((item) => item.jid.toLowerCase() === selfBareJid.toLowerCase())?.emojis ?? [])
+    : [];
+
+  for (const item of items) {
+    for (const emoji of normalizeStoryReactions(item.emojis)) {
+      counts[emoji] = (counts[emoji] ?? 0) + 1;
+      (reactors[emoji] ??= []).push(item.jid);
+    }
+  }
+
+  return { counts, reactors, mine };
 }

--- a/chat/src/services/stories.ts
+++ b/chat/src/services/stories.ts
@@ -44,6 +44,7 @@ export function useStories(
   const reactionsByStory = ref<Record<string, StoryReactionItem[]>>({});
   const pageSize = options.pageSize ?? 50;
   let fetchRequestId = 0;
+  const reactionMutationVersionsByStory = new Map<string, number>();
   const nowMs = ref(Date.now());
   const tickHandle = setInterval(() => {
     nowMs.value = Date.now();
@@ -140,6 +141,7 @@ export function useStories(
     communityJid: string,
     requestId: number,
   ): Promise<void> {
+    const mutationVersions = new Map(reactionMutationVersionsByStory);
     const entries: Array<readonly [string, StoryReactionItem[]]> = [];
     for (let offset = 0; offset < fetched.length; offset += REACTION_FETCH_BATCH_SIZE) {
       if (requestId !== fetchRequestId || client !== xmppClient.value) return;
@@ -155,7 +157,30 @@ export function useStories(
       ));
     }
     if (requestId !== fetchRequestId || client !== xmppClient.value) return;
-    reactionsByStory.value = Object.fromEntries(entries);
+    reactionsByStory.value = mergedReactionEntries(entries, mutationVersions, client.bareJid);
+  }
+
+  function mergedReactionEntries(
+    entries: Array<readonly [string, StoryReactionItem[]]>,
+    mutationVersions: ReadonlyMap<string, number>,
+    self: string | null | undefined,
+  ): Record<string, StoryReactionItem[]> {
+    if (!self) {
+      return Object.fromEntries(entries);
+    }
+    const selfKey = self.toLowerCase();
+    return Object.fromEntries(
+      entries.map(([storyId, fetchedItems]) => {
+        if (mutationVersions.get(storyId) === reactionMutationVersionsByStory.get(storyId)) {
+          return [storyId, fetchedItems];
+        }
+        const currentSelf = (reactionsByStory.value[storyId] ?? [])
+          .find((item) => item.jid.toLowerCase() === selfKey);
+        const fetchedWithoutSelf = fetchedItems
+          .filter((item) => item.jid.toLowerCase() !== selfKey);
+        return [storyId, currentSelf ? [...fetchedWithoutSelf, currentSelf] : fetchedWithoutSelf];
+      }),
+    );
   }
 
   function reactionSummary(storyId: string): StoryReactionSummary {
@@ -184,6 +209,8 @@ export function useStories(
         ]
       : previousItems.filter((item) => item.jid.toLowerCase() !== self.toLowerCase());
 
+    const mutationVersion = (reactionMutationVersionsByStory.get(storyId) ?? 0) + 1;
+    reactionMutationVersionsByStory.set(storyId, mutationVersion);
     reactionsByStory.value = { ...reactionsByStory.value, [storyId]: nextItems };
     try {
       if (next.length > 0) {
@@ -193,7 +220,9 @@ export function useStories(
       }
       return true;
     } catch (err) {
-      reactionsByStory.value = { ...reactionsByStory.value, [storyId]: previousItems };
+      if (reactionMutationVersionsByStory.get(storyId) === mutationVersion) {
+        reactionsByStory.value = { ...reactionsByStory.value, [storyId]: previousItems };
+      }
       error.value = err instanceof Error ? err.message : String(err);
       return false;
     }
@@ -203,6 +232,7 @@ export function useStories(
     fetchRequestId += 1;
     stories.value = [];
     reactionsByStory.value = {};
+    reactionMutationVersionsByStory.clear();
     error.value = null;
     isLoading.value = false;
     isPosting.value = false;

--- a/chat/src/services/stories.ts
+++ b/chat/src/services/stories.ts
@@ -28,6 +28,7 @@ import {
 } from "@/services/story-read-store";
 
 const TICK_INTERVAL_MS = 60_000;
+const REACTION_FETCH_BATCH_SIZE = 8;
 
 export function useStories(
   xmppClient: Ref<BrowserXmppClient | null>,
@@ -90,7 +91,7 @@ export function useStories(
       const fetched = await client.fetchStories(jid, pageSize);
       if (requestId !== fetchRequestId || client !== xmppClient.value) return false;
       stories.value = fetched;
-      await refreshReactionsFor(fetched, client, jid);
+      await refreshReactionsFor(fetched, client, jid, requestId);
       if (!readStore.loaded()) {
         // Hydrate after the first stories fetch so the rail doesn't
         // pop unread→read on first paint.
@@ -137,16 +138,23 @@ export function useStories(
     fetched: readonly Story[],
     client: BrowserXmppClient,
     communityJid: string,
+    requestId: number,
   ): Promise<void> {
-    const entries = await Promise.all(
-      fetched.map(async (story) => {
-        try {
-          return [story.id, await client.fetchStoryReactions(communityJid, story.id)] as const;
-        } catch {
-          return [story.id, []] as const;
-        }
-      }),
-    );
+    const entries: Array<readonly [string, StoryReactionItem[]]> = [];
+    for (let offset = 0; offset < fetched.length; offset += REACTION_FETCH_BATCH_SIZE) {
+      if (requestId !== fetchRequestId || client !== xmppClient.value) return;
+      const batch = fetched.slice(offset, offset + REACTION_FETCH_BATCH_SIZE);
+      entries.push(...await Promise.all(
+        batch.map(async (story): Promise<readonly [string, StoryReactionItem[]]> => {
+          try {
+            return [story.id, await client.fetchStoryReactions(communityJid, story.id)] as const;
+          } catch {
+            return [story.id, []] as const;
+          }
+        }),
+      ));
+    }
+    if (requestId !== fetchRequestId || client !== xmppClient.value) return;
     reactionsByStory.value = Object.fromEntries(entries);
   }
 

--- a/chat/src/services/stories.ts
+++ b/chat/src/services/stories.ts
@@ -12,10 +12,15 @@
  */
 import { computed, onScopeDispose, ref, type Ref } from "vue";
 import {
+  aggregateStoryReactions,
   isStoryActive,
+  normalizeStoryReactions,
+  STORY_REACTIONS_MAX,
   type BrowserXmppClient,
   type Story,
   type StoryPostInput,
+  type StoryReactionItem,
+  type StoryReactionSummary,
 } from "@/lib/xmpp-client";
 import {
   createStoryReadStore,
@@ -35,6 +40,7 @@ export function useStories(
   const isLoading = ref(false);
   const isPosting = ref(false);
   const error = ref<string | null>(null);
+  const reactionsByStory = ref<Record<string, StoryReactionItem[]>>({});
   const pageSize = options.pageSize ?? 50;
   let fetchRequestId = 0;
   const nowMs = ref(Date.now());
@@ -84,6 +90,7 @@ export function useStories(
       const fetched = await client.fetchStories(jid, pageSize);
       if (requestId !== fetchRequestId || client !== xmppClient.value) return false;
       stories.value = fetched;
+      await refreshReactionsFor(fetched, client, jid);
       if (!readStore.loaded()) {
         // Hydrate after the first stories fetch so the rail doesn't
         // pop unread→read on first paint.
@@ -126,9 +133,68 @@ export function useStories(
     }
   }
 
+  async function refreshReactionsFor(
+    fetched: readonly Story[],
+    client: BrowserXmppClient,
+    communityJid: string,
+  ): Promise<void> {
+    const entries = await Promise.all(
+      fetched.map(async (story) => {
+        try {
+          return [story.id, await client.fetchStoryReactions(communityJid, story.id)] as const;
+        } catch {
+          return [story.id, []] as const;
+        }
+      }),
+    );
+    reactionsByStory.value = Object.fromEntries(entries);
+  }
+
+  function reactionSummary(storyId: string): StoryReactionSummary {
+    return aggregateStoryReactions(
+      reactionsByStory.value[storyId] ?? [],
+      xmppClient.value?.bareJid ?? null,
+    );
+  }
+
+  async function toggleReaction(storyId: string, emoji: string): Promise<boolean> {
+    const client = xmppClient.value;
+    const jid = options.communityJid.value;
+    const self = client?.bareJid;
+    if (!client || !jid || !self || !storyId || !emoji.trim()) return false;
+    const previousItems = reactionsByStory.value[storyId] ?? [];
+    const existing = previousItems.find((item) => item.jid.toLowerCase() === self.toLowerCase());
+    const current = normalizeStoryReactions(existing?.emojis ?? []);
+    const next = current.includes(emoji)
+      ? current.filter((candidate) => candidate !== emoji)
+      : normalizeStoryReactions([...current, emoji]);
+    if (next.length > STORY_REACTIONS_MAX) return false;
+    const nextItems = next.length > 0
+      ? [
+          ...previousItems.filter((item) => item.jid.toLowerCase() !== self.toLowerCase()),
+          { jid: self, emojis: next, unknownChildrenXml: existing?.unknownChildrenXml ?? [] },
+        ]
+      : previousItems.filter((item) => item.jid.toLowerCase() !== self.toLowerCase());
+
+    reactionsByStory.value = { ...reactionsByStory.value, [storyId]: nextItems };
+    try {
+      if (next.length > 0) {
+        await client.publishStoryReactions(jid, storyId, next, existing?.unknownChildrenXml ?? []);
+      } else {
+        await client.retractStoryReactions(jid, storyId);
+      }
+      return true;
+    } catch (err) {
+      reactionsByStory.value = { ...reactionsByStory.value, [storyId]: previousItems };
+      error.value = err instanceof Error ? err.message : String(err);
+      return false;
+    }
+  }
+
   function clear() {
     fetchRequestId += 1;
     stories.value = [];
+    reactionsByStory.value = {};
     error.value = null;
     isLoading.value = false;
     isPosting.value = false;
@@ -147,5 +213,7 @@ export function useStories(
     nowMs,
     isStoryRead,
     markStoryRead,
+    reactionSummary,
+    toggleReaction,
   };
 }

--- a/chat/tests/stories.test.ts
+++ b/chat/tests/stories.test.ts
@@ -153,6 +153,101 @@ describe("useStories", () => {
     expect(story.reactionSummary("s1").counts).toEqual({ "🎉": 1 });
   });
 
+  test("reaction refresh preserves optimistic toggle made while batches are pending", async () => {
+    let resolveReactions!: (items: Array<{ jid: string; emojis: string[]; unknownChildrenXml: string[] }>) => void;
+    const pendingReactions = new Promise<Array<{ jid: string; emojis: string[]; unknownChildrenXml: string[] }>>((resolve) => {
+      resolveReactions = resolve;
+    });
+    const client = makeClient([{ id: "s1", body: "story", postedMs: 1 }]);
+    client.fetchStoryReactions = mock(() => pendingReactions) as unknown as MockClient["fetchStoryReactions"];
+
+    const story = withScope(() =>
+      useStories(ref<BrowserXmppClient | null>(client), { communityJid: ref<string | null>(COMMUNITY) }),
+    );
+    const refresh = story.refresh();
+    await Promise.resolve();
+    await story.toggleReaction("s1", "🎉");
+    expect(story.reactionSummary("s1").counts).toEqual({ "🎉": 1 });
+
+    resolveReactions([{ jid: "bob@example.com", emojis: ["👍"], unknownChildrenXml: [] }]);
+    await refresh;
+
+    expect(story.reactionSummary("s1").counts).toEqual({ "👍": 1, "🎉": 1 });
+    expect(story.reactionSummary("s1").mine).toEqual(["🎉"]);
+  });
+
+  test("failed older reaction publish does not roll back a newer toggle", async () => {
+    let rejectFirst!: (error: Error) => void;
+    const firstPublish = new Promise<void>((_, reject) => {
+      rejectFirst = reject;
+    });
+    let publishCount = 0;
+    const client = makeClient([{ id: "s1", body: "story", postedMs: 1 }]);
+    client.fetchStoryReactions = mock(() => Promise.resolve([])) as unknown as MockClient["fetchStoryReactions"];
+    client.publishStoryReactions = mock(() => {
+      publishCount += 1;
+      return publishCount === 1 ? firstPublish : Promise.resolve();
+    }) as unknown as MockClient["publishStoryReactions"];
+
+    const story = withScope(() =>
+      useStories(ref<BrowserXmppClient | null>(client), { communityJid: ref<string | null>(COMMUNITY) }),
+    );
+    await story.refresh();
+
+    const firstToggle = story.toggleReaction("s1", "🎉");
+    await Promise.resolve();
+    const secondToggle = await story.toggleReaction("s1", "👍");
+    expect(secondToggle).toBe(true);
+    expect(story.reactionSummary("s1").mine).toEqual(["🎉", "👍"]);
+
+    rejectFirst(new Error("older publish failed"));
+    expect(await firstToggle).toBe(false);
+    expect(story.reactionSummary("s1").mine).toEqual(["🎉", "👍"]);
+  });
+
+  test("reaction refresh only preserves locally mutated story reactions", async () => {
+    let phase: "initial" | "pending" = "initial";
+    let resolveS1!: (items: Array<{ jid: string; emojis: string[]; unknownChildrenXml: string[] }>) => void;
+    let resolveS2!: (items: Array<{ jid: string; emojis: string[]; unknownChildrenXml: string[] }>) => void;
+    const pendingByStory = new Map<string, Promise<Array<{ jid: string; emojis: string[]; unknownChildrenXml: string[] }>>>();
+    pendingByStory.set("s1", new Promise((resolve) => {
+      resolveS1 = resolve;
+    }));
+    pendingByStory.set("s2", new Promise((resolve) => {
+      resolveS2 = resolve;
+    }));
+    const client = makeClient([
+      { id: "s1", body: "story 1", postedMs: 2 },
+      { id: "s2", body: "story 2", postedMs: 1 },
+    ]);
+    client.fetchStoryReactions = mock((_: string, storyId: string) => {
+      if (phase === "initial") {
+        return Promise.resolve(storyId === "s2"
+          ? [{ jid: "alice@example.com", emojis: ["❤️"], unknownChildrenXml: [] }]
+          : []);
+      }
+      return pendingByStory.get(storyId) ?? Promise.resolve([]);
+    }) as unknown as MockClient["fetchStoryReactions"];
+
+    const story = withScope(() =>
+      useStories(ref<BrowserXmppClient | null>(client), { communityJid: ref<string | null>(COMMUNITY) }),
+    );
+    await story.refresh();
+    expect(story.reactionSummary("s2").mine).toEqual(["❤️"]);
+
+    phase = "pending";
+    const refresh = story.refresh();
+    await Promise.resolve();
+    await story.toggleReaction("s1", "🎉");
+    resolveS1([{ jid: "bob@example.com", emojis: ["👍"], unknownChildrenXml: [] }]);
+    resolveS2([{ jid: "alice@example.com", emojis: ["🔥"], unknownChildrenXml: [] }]);
+    await refresh;
+
+    expect(story.reactionSummary("s1").mine).toEqual(["🎉"]);
+    expect(story.reactionSummary("s1").counts).toEqual({ "👍": 1, "🎉": 1 });
+    expect(story.reactionSummary("s2").mine).toEqual(["🔥"]);
+  });
+
   test("reaction refresh bounds concurrent IQ fetches", async () => {
     let active = 0;
     let maxActive = 0;

--- a/chat/tests/stories.test.ts
+++ b/chat/tests/stories.test.ts
@@ -125,4 +125,53 @@ describe("useStories", () => {
     await story.toggleReaction("s1", "👍");
     expect(client.retractStoryReactions).toHaveBeenCalledWith(COMMUNITY, "s1");
   });
+
+  test("stale reaction refresh results do not overwrite newer refresh state", async () => {
+    let resolveFirst!: (items: Array<{ jid: string; emojis: string[]; unknownChildrenXml: string[] }>) => void;
+    const firstReactionFetch = new Promise<Array<{ jid: string; emojis: string[]; unknownChildrenXml: string[] }>>((resolve) => {
+      resolveFirst = resolve;
+    });
+    let reactionFetchCount = 0;
+    const client = makeClient([{ id: "s1", body: "story", postedMs: 1 }]);
+    client.fetchStoryReactions = mock(() => {
+      reactionFetchCount += 1;
+      if (reactionFetchCount === 1) return firstReactionFetch;
+      return Promise.resolve([{ jid: "carol@example.com", emojis: ["🎉"], unknownChildrenXml: [] }]);
+    }) as unknown as MockClient["fetchStoryReactions"];
+
+    const story = withScope(() =>
+      useStories(ref<BrowserXmppClient | null>(client), { communityJid: ref<string | null>(COMMUNITY) }),
+    );
+    const first = story.refresh();
+    await Promise.resolve();
+    const second = story.refresh();
+    await second;
+    expect(story.reactionSummary("s1").counts).toEqual({ "🎉": 1 });
+
+    resolveFirst([{ jid: "bob@example.com", emojis: ["👍"], unknownChildrenXml: [] }]);
+    await first;
+    expect(story.reactionSummary("s1").counts).toEqual({ "🎉": 1 });
+  });
+
+  test("reaction refresh bounds concurrent IQ fetches", async () => {
+    let active = 0;
+    let maxActive = 0;
+    const client = makeClient(
+      Array.from({ length: 20 }, (_, index) => ({ id: `s${index}`, body: "story", postedMs: index })),
+    );
+    client.fetchStoryReactions = mock(async () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await Promise.resolve();
+      active -= 1;
+      return [];
+    }) as unknown as MockClient["fetchStoryReactions"];
+
+    const story = withScope(() =>
+      useStories(ref<BrowserXmppClient | null>(client), { communityJid: ref<string | null>(COMMUNITY) }),
+    );
+    await story.refresh();
+
+    expect(maxActive).toBeLessThanOrEqual(8);
+  });
 });

--- a/chat/tests/stories.test.ts
+++ b/chat/tests/stories.test.ts
@@ -8,11 +8,24 @@ const COMMUNITY = "community.example.com";
 type MockClient = BrowserXmppClient & {
   fetchStories: ReturnType<typeof mock>;
   publishStory: ReturnType<typeof mock>;
+  fetchStoryReactions: ReturnType<typeof mock>;
+  publishStoryReactions: ReturnType<typeof mock>;
+  retractStoryReactions: ReturnType<typeof mock>;
+  bareJid: string;
 };
 
 function makeClient(stories: Story[] = []): MockClient {
   return {
+    bareJid: "alice@example.com",
     fetchStories: mock(() => Promise.resolve(stories)),
+    fetchStoryReactions: mock((_: string, storyId: string) =>
+      Promise.resolve(storyId === "s1" ? [
+        { jid: "bob@example.com", emojis: ["👍"], unknownChildrenXml: [] },
+        { jid: "alice@example.com", emojis: ["❤️"], unknownChildrenXml: ["<future xmlns=\"urn:test\"/>"] },
+      ] : []),
+    ),
+    publishStoryReactions: mock(() => Promise.resolve()),
+    retractStoryReactions: mock(() => Promise.resolve()),
     publishStory: mock((_jid: string, input: { body?: string; mediaUrl?: string; author?: string }) =>
       Promise.resolve({
         id: "new-story",
@@ -81,5 +94,35 @@ describe("useStories", () => {
     expect(story.activeStories.value.length).toBe(2);
     story.nowMs.value = t0 + 2 * 60_000;
     expect(story.activeStories.value.map((s) => s.id)).toEqual(["later"]);
+  });
+
+  test("reactions aggregate, toggle optimistically, preserve unknown children, and roll back", async () => {
+    const client = makeClient([{ id: "s1", body: "story", postedMs: 1 }]);
+    const story = withScope(() =>
+      useStories(ref<BrowserXmppClient | null>(client), { communityJid: ref<string | null>(COMMUNITY) }),
+    );
+    await story.refresh();
+
+    expect(story.reactionSummary("s1").counts).toEqual({ "👍": 1, "❤️": 1 });
+    expect(story.reactionSummary("s1").mine).toEqual(["❤️"]);
+
+    await story.toggleReaction("s1", "👍");
+    expect(story.reactionSummary("s1").counts).toEqual({ "👍": 2, "❤️": 1 });
+    expect(client.publishStoryReactions).toHaveBeenLastCalledWith(
+      COMMUNITY,
+      "s1",
+      ["❤️", "👍"],
+      ["<future xmlns=\"urn:test\"/>"],
+    );
+
+    client.publishStoryReactions = mock(() => Promise.reject(new Error("forbidden"))) as unknown as MockClient["publishStoryReactions"];
+    const ok = await story.toggleReaction("s1", "🎉");
+    expect(ok).toBe(false);
+    expect(story.reactionSummary("s1").counts).toEqual({ "👍": 2, "❤️": 1 });
+
+    client.publishStoryReactions = mock(() => Promise.resolve()) as unknown as MockClient["publishStoryReactions"];
+    await story.toggleReaction("s1", "❤️");
+    await story.toggleReaction("s1", "👍");
+    expect(client.retractStoryReactions).toHaveBeenCalledWith(COMMUNITY, "s1");
   });
 });

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -6636,6 +6636,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "unicode-segmentation",
  "url",
  "uuid",
  "waddle-extensions",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -52,6 +52,7 @@ minidom = "0.18"
 rxml = "0.14"
 quick-xml = "0.40.1"
 dashmap = "6.2"
+unicode-segmentation = "1.13"
 
 tokio-tungstenite = { version = "0.29", features = ["native-tls"] }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
@@ -977,17 +977,24 @@ pub(super) async fn handle_community_publish(
 }
 
 fn is_story_attachment_node(node: &str) -> bool {
-    let prefix = format!("{}/", waddle_xmpp::xep::xep0470::PUBSUB_ATTACHMENTS_NODE_PREFIX);
+    let prefix = format!(
+        "{}/",
+        waddle_xmpp::xep::xep0470::PUBSUB_ATTACHMENTS_NODE_PREFIX
+    );
     node.starts_with(&prefix)
-        && (node.contains("node=urn%3Axmpp%3Astories%3A0")
-            || node.contains("node=urn:xmpp:stories:0"))
+        && story_attachment_target_param(node, "node").as_deref()
+            == Some(waddle_xmpp_core::xep0501::PUBSUB_NODE_STORIES)
 }
 
 fn story_attachment_target_item(node: &str) -> Option<String> {
+    story_attachment_target_param(node, "item")
+}
+
+fn story_attachment_target_param(node: &str, name: &str) -> Option<String> {
     let target = node.split_once("?;")?.1;
     target.split(';').find_map(|part| {
         let (key, value) = part.split_once('=')?;
-        if key != "item" {
+        if key != name {
             return None;
         }
         urlencoding::decode(value)
@@ -1060,7 +1067,8 @@ async fn ensure_story_attachment_node(
         .get_or_create_node(community_jid, attachment_node)
         .await
         .map_err(|_| PubSubError::InternalServerError)?;
-    if created || node.config.access_model != stories_node.config.access_model
+    if created
+        || node.config.access_model != stories_node.config.access_model
         || node.config.publish_model != stories_node.config.publish_model
     {
         let mut config = node.config;
@@ -1395,8 +1403,15 @@ pub(super) async fn handle_community_retract(
     session: Option<&Session>,
 ) -> Vec<String> {
     if is_story_attachment_node(node) {
-        return handle_story_attachment_retract(iq, state, community_domain, node, item_id, session)
-            .await;
+        return handle_story_attachment_retract(
+            iq,
+            state,
+            community_domain,
+            node,
+            item_id,
+            session,
+        )
+        .await;
     }
     if node != waddle_xmpp_core::xep0472::PUBSUB_NODE_FEED
         && node != waddle_xmpp_core::xep0501::PUBSUB_NODE_STORIES

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
@@ -950,6 +950,10 @@ pub(super) async fn handle_community_publish(
     item: PubSubItem,
     session: Option<&Session>,
 ) -> Vec<String> {
+    if is_story_attachment_node(node) {
+        return handle_story_attachment_publish(iq, state, community_domain, node, item, session)
+            .await;
+    }
     if node != waddle_xmpp_core::xep0472::PUBSUB_NODE_FEED
         && node != waddle_xmpp_core::xep0501::PUBSUB_NODE_STORIES
         && node != waddle_xmpp_core::xcal::PUBSUB_NODE_EVENTS
@@ -970,6 +974,160 @@ pub(super) async fn handle_community_publish(
         }
     }
     handle_community_non_bookmark_publish(iq, state, community_domain, node, item, session).await
+}
+
+fn is_story_attachment_node(node: &str) -> bool {
+    let prefix = format!("{}/", waddle_xmpp::xep::xep0470::PUBSUB_ATTACHMENTS_NODE_PREFIX);
+    node.starts_with(&prefix)
+        && (node.contains("node=urn%3Axmpp%3Astories%3A0")
+            || node.contains("node=urn:xmpp:stories:0"))
+}
+
+fn story_attachment_target_item(node: &str) -> Option<String> {
+    let target = node.split_once("?;")?.1;
+    target.split(';').find_map(|part| {
+        let (key, value) = part.split_once('=')?;
+        if key != "item" {
+            return None;
+        }
+        urlencoding::decode(value)
+            .ok()
+            .map(|decoded| decoded.into_owned())
+            .filter(|item| !item.is_empty())
+    })
+}
+
+fn validated_story_attachment_item(
+    session: Option<&Session>,
+    user_domain: &str,
+    item: &PubSubItem,
+) -> Result<BareJid, PubSubError> {
+    let Some(session) = session else {
+        return Err(PubSubError::Forbidden);
+    };
+    let publisher = format!(
+        "{}@{}",
+        session.xmpp_localpart.to_ascii_lowercase(),
+        user_domain.to_ascii_lowercase()
+    )
+    .parse::<BareJid>()
+    .map_err(|_| PubSubError::InvalidJid)?;
+    if item.id.as_deref() != Some(publisher.as_str()) {
+        return Err(PubSubError::BadRequest);
+    }
+    let Some(payload) = item.payload.as_ref() else {
+        return Err(PubSubError::BadRequest);
+    };
+    let Some(attachments) = waddle_xmpp::xep::xep0470::parse_attachments_element(payload) else {
+        return Err(PubSubError::BadRequest);
+    };
+    if let Some(reactions) = attachments.reactions_set() {
+        reactions.validate().map_err(|_| PubSubError::BadRequest)?;
+    }
+    Ok(publisher)
+}
+
+async fn ensure_story_attachment_node(
+    state: &WebSocketState,
+    community_jid: &BareJid,
+    attachment_node: &str,
+) -> Result<(), PubSubError> {
+    let storage = &state.deps.protocol.pubsub_storage;
+    let Some(story_item_id) = story_attachment_target_item(attachment_node) else {
+        return Err(PubSubError::BadRequest);
+    };
+    let stories_node = storage
+        .get_node(
+            community_jid,
+            waddle_xmpp_core::xep0501::PUBSUB_NODE_STORIES,
+        )
+        .await
+        .map_err(|_| PubSubError::NodeNotFound)?
+        .ok_or(PubSubError::NodeNotFound)?;
+    let story_items = storage
+        .get_items(
+            community_jid,
+            waddle_xmpp_core::xep0501::PUBSUB_NODE_STORIES,
+            None,
+            &[story_item_id],
+        )
+        .await
+        .map_err(|_| PubSubError::NodeNotFound)?;
+    if story_items.is_empty() {
+        return Err(PubSubError::ItemNotFound);
+    }
+    let (node, created) = storage
+        .get_or_create_node(community_jid, attachment_node)
+        .await
+        .map_err(|_| PubSubError::InternalServerError)?;
+    if created || node.config.access_model != stories_node.config.access_model
+        || node.config.publish_model != stories_node.config.publish_model
+    {
+        let mut config = node.config;
+        config.access_model = stories_node.config.access_model;
+        config.publish_model = stories_node.config.publish_model;
+        storage
+            .update_node_config(community_jid, attachment_node, &config)
+            .await
+            .map_err(|_| PubSubError::InternalServerError)?;
+    }
+    Ok(())
+}
+
+async fn handle_story_attachment_publish(
+    iq: &xmpp_parsers::iq::Iq,
+    state: &WebSocketState,
+    community_domain: &str,
+    node: &str,
+    item: PubSubItem,
+    session: Option<&Session>,
+) -> Vec<String> {
+    let user_domain = state.deps.auth_state.xmpp_domain.as_str();
+    let publisher = match validated_story_attachment_item(session, user_domain, &item) {
+        Ok(publisher) => publisher,
+        Err(error) => return vec![iq_to_xml(build_pubsub_error(iq, error))],
+    };
+    let Ok(community_jid) = community_domain.parse::<BareJid>() else {
+        return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::InvalidJid))];
+    };
+    if let Err(error) = ensure_story_attachment_node(state, &community_jid, node).await {
+        return vec![iq_to_xml(build_pubsub_error(iq, error))];
+    }
+    match state
+        .deps
+        .protocol
+        .pubsub_storage
+        .publish_item(&community_jid, node, &item, Some(&publisher), false)
+        .await
+    {
+        Ok(result) => {
+            pubsub_fanout::fan_out_publish(
+                state,
+                pubsub_fanout::FanOutRequest {
+                    owner: &community_jid,
+                    node,
+                    published_item: &item,
+                    item_id: &result.item_id,
+                    publisher: Some(&publisher),
+                    publisher_full: None,
+                    is_pep: false,
+                },
+            )
+            .await;
+            vec![iq_to_xml(build_pubsub_publish_result(
+                iq,
+                node,
+                &result.item_id,
+            ))]
+        }
+        Err(error) => {
+            warn!(node, error = %error, "Failed to publish story attachment item");
+            vec![iq_to_xml(build_pubsub_error(
+                iq,
+                PubSubError::InternalServerError,
+            ))]
+        }
+    }
 }
 
 /// `true` when `item` is a well-formed RSVP for the publishing
@@ -1177,7 +1335,8 @@ pub(super) async fn handle_community_items(
     max_items: Option<u32>,
     item_ids: &[String],
 ) -> Vec<String> {
-    if node != waddle_xmpp_core::xep0472::PUBSUB_NODE_FEED
+    if !is_story_attachment_node(node)
+        && node != waddle_xmpp_core::xep0472::PUBSUB_NODE_FEED
         && node != waddle_xmpp_core::xep0501::PUBSUB_NODE_STORIES
         && node != waddle_xmpp_core::xcal::PUBSUB_NODE_EVENTS
     {
@@ -1235,6 +1394,10 @@ pub(super) async fn handle_community_retract(
     item_id: &str,
     session: Option<&Session>,
 ) -> Vec<String> {
+    if is_story_attachment_node(node) {
+        return handle_story_attachment_retract(iq, state, community_domain, node, item_id, session)
+            .await;
+    }
     if node != waddle_xmpp_core::xep0472::PUBSUB_NODE_FEED
         && node != waddle_xmpp_core::xep0501::PUBSUB_NODE_STORIES
         && node != waddle_xmpp_core::xcal::PUBSUB_NODE_EVENTS
@@ -1263,6 +1426,48 @@ pub(super) async fn handle_community_retract(
         Ok(false) => vec![iq_to_xml(build_pubsub_error(iq, PubSubError::ItemNotFound))],
         Err(error) => {
             warn!(node, item_id, error = %error, "Failed to retract community item");
+            vec![iq_to_xml(build_pubsub_error(
+                iq,
+                PubSubError::InternalServerError,
+            ))]
+        }
+    }
+}
+
+async fn handle_story_attachment_retract(
+    iq: &xmpp_parsers::iq::Iq,
+    state: &WebSocketState,
+    community_domain: &str,
+    node: &str,
+    item_id: &str,
+    session: Option<&Session>,
+) -> Vec<String> {
+    let user_domain = state.deps.auth_state.xmpp_domain.as_str();
+    let Some(session) = session else {
+        return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))];
+    };
+    let publisher = format!(
+        "{}@{}",
+        session.xmpp_localpart.to_ascii_lowercase(),
+        user_domain.to_ascii_lowercase()
+    );
+    if item_id != publisher {
+        return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::BadRequest))];
+    }
+    let Ok(community_jid) = community_domain.parse::<BareJid>() else {
+        return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::InvalidJid))];
+    };
+    match state
+        .deps
+        .protocol
+        .pubsub_storage
+        .retract_item(&community_jid, node, item_id)
+        .await
+    {
+        Ok(true) => vec![iq_to_xml(build_pubsub_success(iq))],
+        Ok(false) => vec![iq_to_xml(build_pubsub_error(iq, PubSubError::ItemNotFound))],
+        Err(error) => {
+            warn!(node, item_id, error = %error, "Failed to retract story attachment item");
             vec![iq_to_xml(build_pubsub_error(
                 iq,
                 PubSubError::InternalServerError,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
@@ -950,7 +950,7 @@ pub(super) async fn handle_community_publish(
     item: PubSubItem,
     session: Option<&Session>,
 ) -> Vec<String> {
-    if is_story_attachment_node(node) {
+    if is_story_attachment_node(node, community_domain) {
         return handle_story_attachment_publish(iq, state, community_domain, node, item, session)
             .await;
     }
@@ -976,32 +976,68 @@ pub(super) async fn handle_community_publish(
     handle_community_non_bookmark_publish(iq, state, community_domain, node, item, session).await
 }
 
-fn is_story_attachment_node(node: &str) -> bool {
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StoryAttachmentTarget {
+    item_id: String,
+}
+
+fn is_story_attachment_node(node: &str, community_domain: &str) -> bool {
+    parse_story_attachment_target(node, community_domain).is_some()
+}
+
+fn parse_story_attachment_target(
+    node: &str,
+    community_domain: &str,
+) -> Option<StoryAttachmentTarget> {
     let prefix = format!(
         "{}/",
         waddle_xmpp::xep::xep0470::PUBSUB_ATTACHMENTS_NODE_PREFIX
     );
-    node.starts_with(&prefix)
-        && story_attachment_target_param(node, "node").as_deref()
-            == Some(waddle_xmpp_core::xep0501::PUBSUB_NODE_STORIES)
+    let target_uri = node.strip_prefix(&prefix)?;
+    let target_uri = target_uri.strip_prefix("xmpp:")?;
+    let (target_domain, query) = target_uri.split_once("?;")?;
+    if target_domain != community_domain {
+        return None;
+    }
+    let mut parts = query.split(';');
+    let node_param = parts.next()?;
+    let item_param = parts.next()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    let ("node", encoded_node) = node_param.split_once('=')? else {
+        return None;
+    };
+    let ("item", encoded_item) = item_param.split_once('=')? else {
+        return None;
+    };
+    let target_node = urlencoding::decode(encoded_node).ok()?.into_owned();
+    if target_node != waddle_xmpp_core::xep0501::PUBSUB_NODE_STORIES {
+        return None;
+    }
+    let item_id = urlencoding::decode(encoded_item).ok()?.into_owned();
+    if item_id.is_empty() {
+        return None;
+    }
+    let canonical = format!(
+        "{prefix}xmpp:{community_domain}?;node={};item={}",
+        urlencoding::encode(waddle_xmpp_core::xep0501::PUBSUB_NODE_STORIES),
+        urlencoding::encode(&item_id)
+    );
+    if node != canonical {
+        return None;
+    }
+    Some(StoryAttachmentTarget { item_id })
 }
 
-fn story_attachment_target_item(node: &str) -> Option<String> {
-    story_attachment_target_param(node, "item")
-}
-
-fn story_attachment_target_param(node: &str, name: &str) -> Option<String> {
-    let target = node.split_once("?;")?.1;
-    target.split(';').find_map(|part| {
-        let (key, value) = part.split_once('=')?;
-        if key != name {
-            return None;
-        }
-        urlencoding::decode(value)
-            .ok()
-            .map(|decoded| decoded.into_owned())
-            .filter(|item| !item.is_empty())
-    })
+fn session_bare_jid(session: &Session, user_domain: &str) -> Result<BareJid, PubSubError> {
+    format!(
+        "{}@{}",
+        session.xmpp_localpart.to_ascii_lowercase(),
+        user_domain.to_ascii_lowercase()
+    )
+    .parse::<BareJid>()
+    .map_err(|_| PubSubError::InvalidJid)
 }
 
 fn validated_story_attachment_item(
@@ -1012,14 +1048,14 @@ fn validated_story_attachment_item(
     let Some(session) = session else {
         return Err(PubSubError::Forbidden);
     };
-    let publisher = format!(
-        "{}@{}",
-        session.xmpp_localpart.to_ascii_lowercase(),
-        user_domain.to_ascii_lowercase()
-    )
-    .parse::<BareJid>()
-    .map_err(|_| PubSubError::InvalidJid)?;
-    if item.id.as_deref() != Some(publisher.as_str()) {
+    let publisher = session_bare_jid(session, user_domain)?;
+    let Some(item_id) = item.id.as_deref() else {
+        return Err(PubSubError::BadRequest);
+    };
+    let requested_publisher = item_id
+        .parse::<BareJid>()
+        .map_err(|_| PubSubError::BadRequest)?;
+    if requested_publisher != publisher {
         return Err(PubSubError::BadRequest);
     }
     let Some(payload) = item.payload.as_ref() else {
@@ -1037,10 +1073,11 @@ fn validated_story_attachment_item(
 async fn ensure_story_attachment_node(
     state: &WebSocketState,
     community_jid: &BareJid,
+    community_domain: &str,
     attachment_node: &str,
 ) -> Result<(), PubSubError> {
     let storage = &state.deps.protocol.pubsub_storage;
-    let Some(story_item_id) = story_attachment_target_item(attachment_node) else {
+    let Some(target) = parse_story_attachment_target(attachment_node, community_domain) else {
         return Err(PubSubError::BadRequest);
     };
     let stories_node = storage
@@ -1056,7 +1093,7 @@ async fn ensure_story_attachment_node(
             community_jid,
             waddle_xmpp_core::xep0501::PUBSUB_NODE_STORIES,
             None,
-            &[story_item_id],
+            &[target.item_id],
         )
         .await
         .map_err(|_| PubSubError::NodeNotFound)?;
@@ -1098,7 +1135,9 @@ async fn handle_story_attachment_publish(
     let Ok(community_jid) = community_domain.parse::<BareJid>() else {
         return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::InvalidJid))];
     };
-    if let Err(error) = ensure_story_attachment_node(state, &community_jid, node).await {
+    if let Err(error) =
+        ensure_story_attachment_node(state, &community_jid, community_domain, node).await
+    {
         return vec![iq_to_xml(build_pubsub_error(iq, error))];
     }
     match state
@@ -1343,7 +1382,7 @@ pub(super) async fn handle_community_items(
     max_items: Option<u32>,
     item_ids: &[String],
 ) -> Vec<String> {
-    if !is_story_attachment_node(node)
+    if !is_story_attachment_node(node, community_domain)
         && node != waddle_xmpp_core::xep0472::PUBSUB_NODE_FEED
         && node != waddle_xmpp_core::xep0501::PUBSUB_NODE_STORIES
         && node != waddle_xmpp_core::xcal::PUBSUB_NODE_EVENTS
@@ -1402,7 +1441,7 @@ pub(super) async fn handle_community_retract(
     item_id: &str,
     session: Option<&Session>,
 ) -> Vec<String> {
-    if is_story_attachment_node(node) {
+    if is_story_attachment_node(node, community_domain) {
         return handle_story_attachment_retract(
             iq,
             state,
@@ -1461,12 +1500,15 @@ async fn handle_story_attachment_retract(
     let Some(session) = session else {
         return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))];
     };
-    let publisher = format!(
-        "{}@{}",
-        session.xmpp_localpart.to_ascii_lowercase(),
-        user_domain.to_ascii_lowercase()
-    );
-    if item_id != publisher {
+    let publisher = match session_bare_jid(session, user_domain) {
+        Ok(publisher) => publisher,
+        Err(error) => return vec![iq_to_xml(build_pubsub_error(iq, error))],
+    };
+    let requested_publisher = match item_id.parse::<BareJid>() {
+        Ok(requested_publisher) => requested_publisher,
+        Err(_) => return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::BadRequest))],
+    };
+    if requested_publisher != publisher {
         return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::BadRequest))];
     }
     let Ok(community_jid) = community_domain.parse::<BareJid>() else {
@@ -1476,7 +1518,7 @@ async fn handle_story_attachment_retract(
         .deps
         .protocol
         .pubsub_storage
-        .retract_item(&community_jid, node, item_id)
+        .retract_item(&community_jid, node, publisher.as_str())
         .await
     {
         Ok(true) => vec![iq_to_xml(build_pubsub_success(iq))],
@@ -1948,5 +1990,44 @@ pub(super) async fn room_space_metadata_extensions(
             warn!(room = %room_jid, error = %error, "Failed to find Space node for room");
             vec![]
         }
+    }
+}
+
+#[cfg(test)]
+mod story_attachment_target_tests {
+    use super::*;
+
+    const COMMUNITY: &str = "community.localhost";
+    const PREFIX: &str = waddle_xmpp::xep::xep0470::PUBSUB_ATTACHMENTS_NODE_PREFIX;
+
+    #[test]
+    fn parses_only_canonical_story_attachment_target() {
+        let node = format!("{PREFIX}/xmpp:{COMMUNITY}?;node=urn%3Axmpp%3Astories%3A0;item=story-1");
+
+        assert_eq!(
+            parse_story_attachment_target(&node, COMMUNITY),
+            Some(StoryAttachmentTarget {
+                item_id: "story-1".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_lookalike_story_node_target() {
+        let node =
+            format!("{PREFIX}/xmpp:{COMMUNITY}?;node=urn%3Axmpp%3Astories%3A0evil;item=story-1");
+
+        assert_eq!(parse_story_attachment_target(&node, COMMUNITY), None);
+    }
+
+    #[test]
+    fn rejects_non_canonical_story_attachment_target() {
+        let wrong_host =
+            format!("{PREFIX}/xmpp:other.localhost?;node=urn%3Axmpp%3Astories%3A0;item=story-1");
+        let extra_param =
+            format!("{PREFIX}/xmpp:{COMMUNITY}?;node=urn%3Axmpp%3Astories%3A0;item=story-1;x=1");
+
+        assert_eq!(parse_story_attachment_target(&wrong_host, COMMUNITY), None);
+        assert_eq!(parse_story_attachment_target(&extra_param, COMMUNITY), None);
     }
 }

--- a/server/crates/waddle-server/tests/xep0470_story_reactions_ws.rs
+++ b/server/crates/waddle-server/tests/xep0470_story_reactions_ws.rs
@@ -56,14 +56,24 @@ async fn member_can_publish_read_and_retract_story_reaction_attachment() {
     let alice_password = format!("alice-pass-{}", uuid::Uuid::new_v4());
     let server = TestServer::start_with_extra_accounts(&[("alice", &alice_password)]);
     let admin_password = server.fixed_account_password().to_string();
-    let mut admin =
-        WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, "admin", &admin_password, "story-owner")
-            .await
-            .expect("admin connect");
-    let mut alice =
-        WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, "alice", &alice_password, "story-member")
-            .await
-            .expect("alice connect");
+    let mut admin = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "admin",
+        &admin_password,
+        "story-owner",
+    )
+    .await
+    .expect("admin connect");
+    let mut alice = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "alice",
+        &alice_password,
+        "story-member",
+    )
+    .await
+    .expect("alice connect");
 
     let story_id = format!("story-{}", uuid::Uuid::new_v4());
     let owner_story = iq_set_to(
@@ -160,6 +170,31 @@ async fn member_can_publish_read_and_retract_story_reaction_attachment() {
         missing_story_publish.contains("type='error'")
             && missing_story_publish.contains("item-not-found"),
         "reaction attachment for a missing story must fail: {missing_story_publish}"
+    );
+
+    let crafted_node = format!(
+        "{NS_ATTACHMENTS}/xmpp:community.localhost?;node=urn%3Axmpp%3Astories%3A0evil;item={story_id}"
+    );
+    let crafted_publish = iq_set_to(
+        &mut alice,
+        "reaction-crafted-node",
+        COMMUNITY_JID,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}">
+              <publish node="{crafted_node}">
+                <item id="alice@localhost">
+                  <attachments xmlns="{NS_ATTACHMENTS}">
+                    <reactions><reaction>👀</reaction></reactions>
+                  </attachments>
+                </item>
+              </publish>
+            </pubsub>"#
+        ),
+    )
+    .await;
+    assert!(
+        crafted_publish.contains("type='error'") && crafted_publish.contains("item-not-found"),
+        "crafted non-story attachment node must not use story carve-out: {crafted_publish}"
     );
 
     let spoof_publish = iq_set_to(

--- a/server/crates/waddle-server/tests/xep0470_story_reactions_ws.rs
+++ b/server/crates/waddle-server/tests/xep0470_story_reactions_ws.rs
@@ -1,0 +1,238 @@
+//! XEP-0470 Pubsub Attachments on XEP-0501 stories.
+//!
+//! Verifies the pull-based story reaction spine: story publishes remain
+//! owner-gated, while a non-owner member can publish/retract their own
+//! `<attachments/>` item under the story attachment node.
+
+mod ws_common;
+
+use tokio::sync::Mutex;
+use ws_common::{TestServer, WsXmppClient};
+
+const DOMAIN: &str = "localhost";
+const COMMUNITY_JID: &str = "community.localhost";
+const STORIES_NODE: &str = "urn:xmpp:stories:0";
+const NS_PUBSUB: &str = "http://jabber.org/protocol/pubsub";
+const NS_STORIES: &str = "urn:xmpp:stories:0";
+const NS_ATTACHMENTS: &str = "urn:xmpp:pubsub-attachments:1";
+
+static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+async fn iq_set_to(client: &mut WsXmppClient, id: &str, to: &str, body: &str) -> String {
+    client
+        .send(&format!(
+            r#"<iq type="set" id="{id}" to="{to}">{body}</iq>"#
+        ))
+        .await
+        .expect("send iq set");
+    client
+        .recv_matching(|frame| frame.contains(&format!("id='{id}'")) && frame.contains("<iq"))
+        .await
+        .expect("iq set response")
+}
+
+async fn iq_get_to(client: &mut WsXmppClient, id: &str, to: &str, body: &str) -> String {
+    client
+        .send(&format!(
+            r#"<iq type="get" id="{id}" to="{to}">{body}</iq>"#
+        ))
+        .await
+        .expect("send iq get");
+    client
+        .recv_matching(|frame| frame.contains(&format!("id='{id}'")) && frame.contains("<iq"))
+        .await
+        .expect("iq get response")
+}
+
+fn story_attachment_node(story_id: &str) -> String {
+    format!(
+        "{NS_ATTACHMENTS}/xmpp:community.localhost?;node=urn%3Axmpp%3Astories%3A0;item={story_id}"
+    )
+}
+
+#[tokio::test]
+async fn member_can_publish_read_and_retract_story_reaction_attachment() {
+    let _guard = TEST_SERIAL.lock().await;
+    let alice_password = format!("alice-pass-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[("alice", &alice_password)]);
+    let admin_password = server.fixed_account_password().to_string();
+    let mut admin =
+        WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, "admin", &admin_password, "story-owner")
+            .await
+            .expect("admin connect");
+    let mut alice =
+        WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, "alice", &alice_password, "story-member")
+            .await
+            .expect("alice connect");
+
+    let story_id = format!("story-{}", uuid::Uuid::new_v4());
+    let owner_story = iq_set_to(
+        &mut admin,
+        "owner-story",
+        COMMUNITY_JID,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}">
+              <publish node="{STORIES_NODE}">
+                <item id="{story_id}">
+                  <story xmlns="{NS_STORIES}" expires="2030-01-01T12:00:00Z">
+                    <body>story with reactions</body>
+                    <author>admin@localhost</author>
+                  </story>
+                </item>
+              </publish>
+            </pubsub>"#
+        ),
+    )
+    .await;
+    assert!(
+        owner_story.contains("type='result'"),
+        "owner story publish should succeed: {owner_story}"
+    );
+
+    let member_story = iq_set_to(
+        &mut alice,
+        "member-story",
+        COMMUNITY_JID,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}">
+              <publish node="{STORIES_NODE}">
+                <item id="member-{story_id}">
+                  <story xmlns="{NS_STORIES}" expires="2030-01-01T12:00:00Z">
+                    <body>must not publish</body>
+                    <author>alice@localhost</author>
+                  </story>
+                </item>
+              </publish>
+            </pubsub>"#
+        ),
+    )
+    .await;
+    assert!(
+        member_story.contains("type='error'") && member_story.contains("forbidden"),
+        "non-owner story publish must remain forbidden: {member_story}"
+    );
+
+    let attachment_node = story_attachment_node(&story_id);
+    let reaction_publish = iq_set_to(
+        &mut alice,
+        "reaction-publish",
+        COMMUNITY_JID,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}">
+              <publish node="{attachment_node}">
+                <item id="alice@localhost">
+                  <attachments xmlns="{NS_ATTACHMENTS}">
+                    <reactions>
+                      <reaction>👍</reaction>
+                      <reaction>❤️</reaction>
+                    </reactions>
+                  </attachments>
+                </item>
+              </publish>
+            </pubsub>"#
+        ),
+    )
+    .await;
+    assert!(
+        reaction_publish.contains("type='result'"),
+        "member reaction publish should succeed via story carve-out: {reaction_publish}"
+    );
+
+    let missing_node = story_attachment_node("missing-story");
+    let missing_story_publish = iq_set_to(
+        &mut alice,
+        "reaction-missing-story",
+        COMMUNITY_JID,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}">
+              <publish node="{missing_node}">
+                <item id="alice@localhost">
+                  <attachments xmlns="{NS_ATTACHMENTS}">
+                    <reactions><reaction>👀</reaction></reactions>
+                  </attachments>
+                </item>
+              </publish>
+            </pubsub>"#
+        ),
+    )
+    .await;
+    assert!(
+        missing_story_publish.contains("type='error'")
+            && missing_story_publish.contains("item-not-found"),
+        "reaction attachment for a missing story must fail: {missing_story_publish}"
+    );
+
+    let spoof_publish = iq_set_to(
+        &mut alice,
+        "reaction-spoof",
+        COMMUNITY_JID,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}">
+              <publish node="{attachment_node}">
+                <item id="bob@localhost">
+                  <attachments xmlns="{NS_ATTACHMENTS}">
+                    <reactions><reaction>🔥</reaction></reactions>
+                  </attachments>
+                </item>
+              </publish>
+            </pubsub>"#
+        ),
+    )
+    .await;
+    assert!(
+        spoof_publish.contains("type='error'") && spoof_publish.contains("bad-request"),
+        "spoofed attachment item id must be rejected as bad-request: {spoof_publish}"
+    );
+
+    let bad_payload = iq_set_to(
+        &mut alice,
+        "reaction-bad-payload",
+        COMMUNITY_JID,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}">
+              <publish node="{attachment_node}">
+                <item id="alice@localhost">
+                  <not-attachments xmlns="{NS_ATTACHMENTS}"/>
+                </item>
+              </publish>
+            </pubsub>"#
+        ),
+    )
+    .await;
+    assert!(
+        bad_payload.contains("type='error'") && bad_payload.contains("bad-request"),
+        "non-attachments payload must be rejected as bad-request: {bad_payload}"
+    );
+
+    let readback = iq_get_to(
+        &mut alice,
+        "reaction-items",
+        COMMUNITY_JID,
+        &format!(r#"<pubsub xmlns="{NS_PUBSUB}"><items node="{attachment_node}"/></pubsub>"#),
+    )
+    .await;
+    assert!(
+        readback.contains("alice@localhost")
+            && readback.contains("👍")
+            && readback.contains("❤️")
+            && readback.contains(NS_ATTACHMENTS),
+        "reaction attachment should read back from auto-created node: {readback}"
+    );
+
+    let retract = iq_set_to(
+        &mut alice,
+        "reaction-retract",
+        COMMUNITY_JID,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><retract node="{attachment_node}"><item id="alice@localhost"/></retract></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(
+        retract.contains("type='result'"),
+        "member should retract own story reaction item: {retract}"
+    );
+
+    let _ = alice.close().await;
+    let _ = admin.close().await;
+}

--- a/server/crates/waddle-server/tests/xep0470_story_reactions_ws.rs
+++ b/server/crates/waddle-server/tests/xep0470_story_reactions_ws.rs
@@ -18,6 +18,11 @@ const NS_ATTACHMENTS: &str = "urn:xmpp:pubsub-attachments:1";
 
 static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
 
+fn frame_has_iq_id(frame: &str, id: &str) -> bool {
+    frame.contains("<iq")
+        && (frame.contains(&format!("id='{id}'")) || frame.contains(&format!("id=\"{id}\"")))
+}
+
 async fn iq_set_to(client: &mut WsXmppClient, id: &str, to: &str, body: &str) -> String {
     client
         .send(&format!(
@@ -26,7 +31,7 @@ async fn iq_set_to(client: &mut WsXmppClient, id: &str, to: &str, body: &str) ->
         .await
         .expect("send iq set");
     client
-        .recv_matching(|frame| frame.contains(&format!("id='{id}'")) && frame.contains("<iq"))
+        .recv_matching(|frame| frame_has_iq_id(frame, id))
         .await
         .expect("iq set response")
 }
@@ -39,7 +44,7 @@ async fn iq_get_to(client: &mut WsXmppClient, id: &str, to: &str, body: &str) ->
         .await
         .expect("send iq get");
     client
-        .recv_matching(|frame| frame.contains(&format!("id='{id}'")) && frame.contains("<iq"))
+        .recv_matching(|frame| frame_has_iq_id(frame, id))
         .await
         .expect("iq get response")
 }
@@ -197,6 +202,57 @@ async fn member_can_publish_read_and_retract_story_reaction_attachment() {
         "crafted non-story attachment node must not use story carve-out: {crafted_publish}"
     );
 
+    let wrong_host_node = format!(
+        "{NS_ATTACHMENTS}/xmpp:other.localhost?;node=urn%3Axmpp%3Astories%3A0;item={story_id}"
+    );
+    let wrong_host_publish = iq_set_to(
+        &mut alice,
+        "reaction-wrong-host",
+        COMMUNITY_JID,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}">
+              <publish node="{wrong_host_node}">
+                <item id="alice@localhost">
+                  <attachments xmlns="{NS_ATTACHMENTS}">
+                    <reactions><reaction>👀</reaction></reactions>
+                  </attachments>
+                </item>
+              </publish>
+            </pubsub>"#
+        ),
+    )
+    .await;
+    assert!(
+        wrong_host_publish.contains("type='error'") && wrong_host_publish.contains("item-not-found"),
+        "attachment node with non-canonical target host must not use story carve-out: {wrong_host_publish}"
+    );
+
+    let extra_param_node = format!(
+        "{NS_ATTACHMENTS}/xmpp:community.localhost?;node=urn%3Axmpp%3Astories%3A0;item={story_id};foo=bar"
+    );
+    let extra_param_publish = iq_set_to(
+        &mut alice,
+        "reaction-extra-param",
+        COMMUNITY_JID,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}">
+              <publish node="{extra_param_node}">
+                <item id="alice@localhost">
+                  <attachments xmlns="{NS_ATTACHMENTS}">
+                    <reactions><reaction>👀</reaction></reactions>
+                  </attachments>
+                </item>
+              </publish>
+            </pubsub>"#
+        ),
+    )
+    .await;
+    assert!(
+        extra_param_publish.contains("type='error'")
+            && extra_param_publish.contains("item-not-found"),
+        "attachment node with extra target params must not use story carve-out: {extra_param_publish}"
+    );
+
     let spoof_publish = iq_set_to(
         &mut alice,
         "reaction-spoof",
@@ -217,6 +273,28 @@ async fn member_can_publish_read_and_retract_story_reaction_attachment() {
     assert!(
         spoof_publish.contains("type='error'") && spoof_publish.contains("bad-request"),
         "spoofed attachment item id must be rejected as bad-request: {spoof_publish}"
+    );
+
+    let invalid_jid_publish = iq_set_to(
+        &mut alice,
+        "reaction-invalid-jid",
+        COMMUNITY_JID,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}">
+              <publish node="{attachment_node}">
+                <item id="not a jid">
+                  <attachments xmlns="{NS_ATTACHMENTS}">
+                    <reactions><reaction>🔥</reaction></reactions>
+                  </attachments>
+                </item>
+              </publish>
+            </pubsub>"#
+        ),
+    )
+    .await;
+    assert!(
+        invalid_jid_publish.contains("type='error'") && invalid_jid_publish.contains("bad-request"),
+        "invalid attachment item id must be rejected as bad-request: {invalid_jid_publish}"
     );
 
     let bad_payload = iq_set_to(
@@ -252,6 +330,20 @@ async fn member_can_publish_read_and_retract_story_reaction_attachment() {
             && readback.contains("❤️")
             && readback.contains(NS_ATTACHMENTS),
         "reaction attachment should read back from auto-created node: {readback}"
+    );
+
+    let invalid_jid_retract = iq_set_to(
+        &mut alice,
+        "reaction-retract-invalid-jid",
+        COMMUNITY_JID,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><retract node="{attachment_node}"><item id="not a jid"/></retract></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(
+        invalid_jid_retract.contains("type='error'") && invalid_jid_retract.contains("bad-request"),
+        "invalid retract item id must be rejected as bad-request: {invalid_jid_retract}"
     );
 
     let retract = iq_set_to(

--- a/server/crates/waddle-xmpp/Cargo.toml
+++ b/server/crates/waddle-xmpp/Cargo.toml
@@ -49,6 +49,7 @@ chrono = { workspace = true }
 chrono-tz = { workspace = true }
 url = { workspace = true }
 base64 = { workspace = true }
+unicode-segmentation = { workspace = true }
 
 # HTML rendering
 html-escape = "0.2"

--- a/server/crates/waddle-xmpp/src/xep/exports.rs
+++ b/server/crates/waddle-xmpp/src/xep/exports.rs
@@ -339,8 +339,12 @@ pub use waddle_xmpp_core::xcal::{
 };
 
 pub use super::xep0470::{
-    build_attachments_element, is_attachments_element, parse_attachment_target, Attachment,
-    AttachmentPayload, AttachmentTarget, NS_PUBSUB_ATTACHMENTS,
+    build_attachments_element, build_reactions_element as build_attachment_reactions_element,
+    build_summary_element as build_attachment_summary_element, is_attachments_element,
+    parse_attachments_element, Attachment, AttachmentPayload, AttachmentSummary,
+    AttachmentValidationError, ReactionSet as AttachmentReactionSet, ReactionSummary,
+    MAX_REACTIONS_PER_ATTACHMENT, NS_PUBSUB_ATTACHMENTS, NS_PUBSUB_ATTACHMENTS_SUMMARY,
+    PUBSUB_ATTACHMENTS_NODE_PREFIX,
 };
 
 pub use super::xep_waddle_pin::{

--- a/server/crates/waddle-xmpp/src/xep/xep0470.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0470.rs
@@ -8,10 +8,11 @@
 //! Attach a reaction to a post:
 //! ```xml
 //! <item id='attachment-1' xmlns='http://jabber.org/protocol/pubsub'>
-//!   <attachments xmlns='urn:xmpp:pubsub-attachments:0'
-//!                for='urn:xmpp:pubsub-social-feed:0'
-//!                item='post-123'>
-//!     <reaction xmlns='urn:xmpp:reactions:0'>👍</reaction>
+//!   <attachments xmlns='urn:xmpp:pubsub-attachments:1'>
+//!     <reactions>
+//!       <reaction>👍</reaction>
+//!       <reaction>❤️</reaction>
+//!     </reactions>
 //!   </attachments>
 //! </item>
 //! ```
@@ -23,36 +24,30 @@
 //! - Vote/poll responses
 
 use minidom::Element;
+use std::collections::BTreeSet;
 
 /// Namespace for XEP-0470 Pubsub Attachments.
-pub const NS_PUBSUB_ATTACHMENTS: &str = "urn:xmpp:pubsub-attachments:0";
+pub const NS_PUBSUB_ATTACHMENTS: &str = "urn:xmpp:pubsub-attachments:1";
 
-/// An attachment target: which PubSub item this attaches to.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AttachmentTarget {
-    /// The PubSub node (namespace) of the target item.
-    pub node: String,
-    /// The item ID being attached to.
-    pub item_id: String,
-}
+/// Namespace for XEP-0470 Pubsub Attachment summaries.
+pub const NS_PUBSUB_ATTACHMENTS_SUMMARY: &str = "urn:xmpp:pubsub-attachments:summary:1";
 
-impl AttachmentTarget {
-    /// Create a new attachment target.
-    pub fn new(node: impl Into<String>, item_id: impl Into<String>) -> Self {
-        Self {
-            node: node.into(),
-            item_id: item_id.into(),
-        }
-    }
-}
+/// Prefix for an attachment node name. The full node is
+/// `{PUBSUB_ATTACHMENTS_NODE_PREFIX}/<target-item-XMPP-URI>`.
+pub const PUBSUB_ATTACHMENTS_NODE_PREFIX: &str = NS_PUBSUB_ATTACHMENTS;
+
+/// Maximum reaction count accepted for a single publisher's attachment item.
+pub const MAX_REACTIONS_PER_ATTACHMENT: usize = 12;
 
 /// An attachment payload type.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AttachmentPayload {
-    /// A text comment.
-    Comment(String),
-    /// A reaction emoji.
-    Reaction(String),
+    /// A set of reaction emoji attached by one bare JID.
+    Reactions(ReactionSet),
+    /// XEP-0470 `<noticed/>`; used by later slices.
+    Noticed,
+    /// XEP-0470 summary payload; used by later slices.
+    Summary(AttachmentSummary),
     /// A generic XML payload.
     Custom(Element),
 }
@@ -60,48 +55,117 @@ pub enum AttachmentPayload {
 /// A pubsub attachment.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Attachment {
-    /// What this attaches to.
-    pub target: AttachmentTarget,
-    /// The attachment content.
-    pub payload: AttachmentPayload,
-    /// Who created this attachment.
-    pub author: Option<String>,
+    /// Known attachment payloads.
+    pub payloads: Vec<AttachmentPayload>,
+    /// Unknown children preserved across read-modify-publish cycles.
+    pub unknown_children: Vec<Element>,
 }
 
 impl Attachment {
-    /// Create a comment attachment.
-    pub fn comment(target: AttachmentTarget, text: impl Into<String>) -> Self {
+    /// Create an attachment with a reaction set.
+    pub fn reactions(reactions: ReactionSet) -> Self {
         Self {
-            target,
-            payload: AttachmentPayload::Comment(text.into()),
-            author: None,
+            payloads: vec![AttachmentPayload::Reactions(reactions)],
+            unknown_children: Vec::new(),
         }
     }
 
-    /// Create a reaction attachment.
-    pub fn reaction(target: AttachmentTarget, emoji: impl Into<String>) -> Self {
+    /// Create an empty attachment container.
+    pub fn empty() -> Self {
         Self {
-            target,
-            payload: AttachmentPayload::Reaction(emoji.into()),
-            author: None,
+            payloads: Vec::new(),
+            unknown_children: Vec::new(),
         }
     }
 
-    /// Set the author.
-    pub fn with_author(mut self, author: impl Into<String>) -> Self {
-        self.author = Some(author.into());
+    /// Preserve an unknown attachment child.
+    pub fn with_unknown_child(mut self, child: Element) -> Self {
+        self.unknown_children.push(child);
         self
     }
 
-    /// Returns `true` if this is a comment.
-    pub fn is_comment(&self) -> bool {
-        matches!(self.payload, AttachmentPayload::Comment(_))
+    /// Add a known payload.
+    pub fn with_payload(mut self, payload: AttachmentPayload) -> Self {
+        self.payloads.push(payload);
+        self
     }
 
-    /// Returns `true` if this is a reaction.
-    pub fn is_reaction(&self) -> bool {
-        matches!(self.payload, AttachmentPayload::Reaction(_))
+    /// Return the reaction set if present.
+    pub fn reactions_set(&self) -> Option<&ReactionSet> {
+        self.payloads.iter().find_map(|payload| match payload {
+            AttachmentPayload::Reactions(reactions) => Some(reactions),
+            _ => None,
+        })
     }
+}
+
+/// XEP-0470 reaction set attached by one publisher.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReactionSet {
+    pub emojis: Vec<String>,
+    pub timestamp: Option<String>,
+}
+
+impl ReactionSet {
+    pub fn new<I, S>(emojis: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        Self {
+            emojis: normalize_reactions(emojis),
+            timestamp: None,
+        }
+    }
+
+    pub fn with_timestamp(mut self, timestamp: impl Into<String>) -> Self {
+        self.timestamp = Some(timestamp.into());
+        self
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.emojis.is_empty()
+    }
+
+    pub fn validate(&self) -> Result<(), AttachmentValidationError> {
+        if self.emojis.len() > MAX_REACTIONS_PER_ATTACHMENT {
+            return Err(AttachmentValidationError::TooManyReactions {
+                actual: self.emojis.len(),
+                max: MAX_REACTIONS_PER_ATTACHMENT,
+            });
+        }
+
+        if let Some(emoji) = self
+            .emojis
+            .iter()
+            .find(|emoji| !is_single_extended_grapheme_cluster(emoji))
+        {
+            return Err(AttachmentValidationError::ReactionNotSingleGrapheme(
+                emoji.clone(),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+/// Summary reaction count for a single emoji.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReactionSummary {
+    pub emoji: String,
+    pub count: u32,
+}
+
+/// XEP-0470 summary payload. Later slices can populate this from the server.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttachmentSummary {
+    pub reactions: Vec<ReactionSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AttachmentValidationError {
+    TooManyReactions { actual: usize, max: usize },
+    ReactionNotSingleGrapheme(String),
 }
 
 // ── Detection ────────────────────────────────────────────────────────
@@ -113,55 +177,153 @@ pub fn is_attachments_element(elem: &Element) -> bool {
 
 // ── Extraction ───────────────────────────────────────────────────────
 
-/// Parse an attachment target from an `<attachments/>` element.
-pub fn parse_attachment_target(elem: &Element) -> Option<AttachmentTarget> {
+/// Parse an `<attachments/>` element.
+pub fn parse_attachments_element(elem: &Element) -> Option<Attachment> {
     if !is_attachments_element(elem) {
         return None;
     }
-    let node = elem.attr("for").filter(|s| !s.is_empty())?.to_owned();
-    let item_id = elem.attr("item").filter(|s| !s.is_empty())?.to_owned();
-    Some(AttachmentTarget::new(node, item_id))
+
+    let mut attachment = Attachment::empty();
+    for child in elem.children() {
+        let child_ns = child.ns();
+        match (child.name(), child_ns.as_str()) {
+            ("reactions", NS_PUBSUB_ATTACHMENTS) => attachment
+                .payloads
+                .push(AttachmentPayload::Reactions(parse_reactions_element(child))),
+            ("noticed", NS_PUBSUB_ATTACHMENTS) => attachment.payloads.push(AttachmentPayload::Noticed),
+            ("summary", NS_PUBSUB_ATTACHMENTS_SUMMARY) => attachment
+                .payloads
+                .push(AttachmentPayload::Summary(parse_summary_element(child))),
+            _ => attachment.unknown_children.push(child.clone()),
+        }
+    }
+
+    Some(attachment)
+}
+
+fn parse_reactions_element(elem: &Element) -> ReactionSet {
+    let emojis = elem
+        .children()
+        .filter(|child| child.name() == "reaction" && child.ns() == NS_PUBSUB_ATTACHMENTS)
+        .map(Element::text);
+    let mut reactions = ReactionSet::new(emojis);
+    reactions.timestamp = elem.attr("timestamp").map(ToOwned::to_owned);
+    reactions
+}
+
+fn parse_summary_element(elem: &Element) -> AttachmentSummary {
+    let reactions = elem
+        .children()
+        .find(|child| child.name() == "reactions" && child.ns() == NS_PUBSUB_ATTACHMENTS_SUMMARY)
+        .into_iter()
+        .flat_map(Element::children)
+        .filter(|child| child.name() == "reaction" && child.ns() == NS_PUBSUB_ATTACHMENTS_SUMMARY)
+        .map(|child| ReactionSummary {
+            emoji: child.text(),
+            count: child
+                .attr("count")
+                .and_then(|count| count.parse::<u32>().ok())
+                .unwrap_or(1),
+        })
+        .collect();
+
+    AttachmentSummary { reactions }
 }
 
 // ── Building ─────────────────────────────────────────────────────────
 
 /// Build an `<attachments/>` element.
 pub fn build_attachments_element(attachment: &Attachment) -> Element {
-    let mut elem = Element::builder("attachments", NS_PUBSUB_ATTACHMENTS)
-        .attr(
-            minidom::rxml::xml_ncname!("for").to_owned(),
-            attachment.target.node.as_str(),
-        )
-        .attr(
-            minidom::rxml::xml_ncname!("item").to_owned(),
-            attachment.target.item_id.as_str(),
-        )
-        .build();
+    let mut elem = Element::builder("attachments", NS_PUBSUB_ATTACHMENTS).build();
 
-    match &attachment.payload {
-        AttachmentPayload::Comment(text) => {
-            let mut comment = Element::builder("comment", NS_PUBSUB_ATTACHMENTS).build();
-            comment.append_text_node(text.clone());
-            if let Some(ref author) = attachment.author {
-                comment.set_attr(
-                    minidom::rxml::Namespace::NONE,
-                    minidom::rxml::xml_ncname!("author").to_owned(),
-                    author,
-                );
+    for payload in &attachment.payloads {
+        match payload {
+            AttachmentPayload::Reactions(reactions) => {
+                elem.append_child(build_reactions_element(reactions));
             }
-            elem.append_child(comment);
-        }
-        AttachmentPayload::Reaction(emoji) => {
-            let mut reaction = Element::builder("reaction", NS_PUBSUB_ATTACHMENTS).build();
-            reaction.append_text_node(emoji.clone());
-            elem.append_child(reaction);
-        }
-        AttachmentPayload::Custom(child) => {
-            elem.append_child(child.clone());
+            AttachmentPayload::Noticed => {
+                elem.append_child(Element::builder("noticed", NS_PUBSUB_ATTACHMENTS).build());
+            }
+            AttachmentPayload::Summary(summary) => {
+                elem.append_child(build_summary_element(summary));
+            }
+            AttachmentPayload::Custom(child) => {
+                elem.append_child(child.clone());
+            }
         }
     }
 
+    for child in &attachment.unknown_children {
+        elem.append_child(child.clone());
+    }
+
     elem
+}
+
+pub fn build_reactions_element(reactions: &ReactionSet) -> Element {
+    let mut elem = Element::builder("reactions", NS_PUBSUB_ATTACHMENTS).build();
+    if let Some(timestamp) = &reactions.timestamp {
+        elem.set_attr(
+            minidom::rxml::Namespace::NONE,
+            minidom::rxml::xml_ncname!("timestamp").to_owned(),
+            timestamp,
+        );
+    }
+
+    for emoji in &reactions.emojis {
+        let mut reaction = Element::builder("reaction", NS_PUBSUB_ATTACHMENTS).build();
+        reaction.append_text_node(emoji);
+        elem.append_child(reaction);
+    }
+
+    elem
+}
+
+pub fn build_summary_element(summary: &AttachmentSummary) -> Element {
+    let mut root = Element::builder("summary", NS_PUBSUB_ATTACHMENTS_SUMMARY).build();
+    let mut reactions = Element::builder("reactions", NS_PUBSUB_ATTACHMENTS_SUMMARY).build();
+
+    for reaction_summary in &summary.reactions {
+        let mut reaction = Element::builder("reaction", NS_PUBSUB_ATTACHMENTS_SUMMARY).build();
+        if reaction_summary.count > 1 {
+            reaction.set_attr(
+                minidom::rxml::Namespace::NONE,
+                minidom::rxml::xml_ncname!("count").to_owned(),
+                reaction_summary.count.to_string(),
+            );
+        }
+        reaction.append_text_node(reaction_summary.emoji.clone());
+        reactions.append_child(reaction);
+    }
+
+    root.append_child(reactions);
+    root
+}
+
+fn normalize_reactions<I, S>(emojis: I) -> Vec<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut normalized = Vec::new();
+    let mut seen = BTreeSet::new();
+
+    for emoji in emojis {
+        let emoji = emoji.as_ref().trim();
+        if emoji.is_empty() {
+            continue;
+        }
+        if seen.insert(emoji.to_owned()) {
+            normalized.push(emoji.to_owned());
+        }
+    }
+
+    normalized
+}
+
+fn is_single_extended_grapheme_cluster(value: &str) -> bool {
+    let trimmed = value.trim();
+    !trimmed.is_empty() && !trimmed.chars().any(char::is_whitespace) && trimmed.chars().count() <= 8
 }
 
 #[cfg(test)]
@@ -179,67 +341,66 @@ mod tests {
 
     #[test]
     fn test_parse_target() {
-        let elem = Element::builder("attachments", NS_PUBSUB_ATTACHMENTS)
-            .attr(
-                minidom::rxml::xml_ncname!("for").to_owned(),
-                "urn:xmpp:pubsub-social-feed:0",
-            )
-            .attr(minidom::rxml::xml_ncname!("item").to_owned(), "post-123")
-            .build();
+        let mut reactions = Element::builder("reactions", NS_PUBSUB_ATTACHMENTS).build();
+        let mut reaction = Element::builder("reaction", NS_PUBSUB_ATTACHMENTS).build();
+        reaction.append_text_node("👍");
+        reactions.append_child(reaction);
 
-        let target = parse_attachment_target(&elem).expect("parseable");
-        assert_eq!(target.node, "urn:xmpp:pubsub-social-feed:0");
-        assert_eq!(target.item_id, "post-123");
+        let mut elem = Element::builder("attachments", NS_PUBSUB_ATTACHMENTS).build();
+        elem.append_child(reactions);
+
+        let attachment = parse_attachments_element(&elem).expect("parseable");
+        assert_eq!(
+            attachment.reactions_set().expect("reactions").emojis,
+            vec!["👍"]
+        );
     }
 
     #[test]
     fn test_parse_target_missing_attrs() {
         let elem = Element::builder("attachments", NS_PUBSUB_ATTACHMENTS).build();
-        assert!(parse_attachment_target(&elem).is_none());
+        let attachment = parse_attachments_element(&elem).expect("parseable");
+        assert!(attachment.payloads.is_empty());
     }
 
     #[test]
     fn test_build_comment() {
-        let target = AttachmentTarget::new("feed:0", "post-1");
-        let attachment =
-            Attachment::comment(target, "Great post!").with_author("alice@example.com");
+        let attachment = Attachment::empty().with_payload(AttachmentPayload::Noticed);
         let elem = build_attachments_element(&attachment);
 
         assert_eq!(elem.name(), "attachments");
-        assert_eq!(elem.attr("for"), Some("feed:0"));
-        assert_eq!(elem.attr("item"), Some("post-1"));
+        assert_eq!(elem.ns(), NS_PUBSUB_ATTACHMENTS);
 
-        let comment = elem.children().next().expect("has child");
-        assert_eq!(comment.name(), "comment");
-        assert_eq!(comment.text(), "Great post!");
-        assert_eq!(comment.attr("author"), Some("alice@example.com"));
+        let noticed = elem.children().next().expect("has child");
+        assert_eq!(noticed.name(), "noticed");
     }
 
     #[test]
     fn test_build_reaction() {
-        let target = AttachmentTarget::new("feed:0", "post-1");
-        let attachment = Attachment::reaction(target, "👍");
+        let attachment = Attachment::reactions(ReactionSet::new(["👍", "❤️"]));
         let elem = build_attachments_element(&attachment);
 
-        let reaction = elem.children().next().expect("has child");
-        assert_eq!(reaction.name(), "reaction");
-        assert_eq!(reaction.text(), "👍");
+        let reactions = elem.children().next().expect("has child");
+        assert_eq!(reactions.name(), "reactions");
+        assert_eq!(
+            reactions.children().map(Element::text).collect::<Vec<_>>(),
+            vec!["👍", "❤️"]
+        );
     }
 
     #[test]
     fn test_attachment_helpers() {
-        let target = AttachmentTarget::new("n", "i");
-        assert!(Attachment::comment(target.clone(), "hi").is_comment());
-        assert!(!Attachment::comment(target.clone(), "hi").is_reaction());
-        assert!(Attachment::reaction(target.clone(), "👍").is_reaction());
-        assert!(!Attachment::reaction(target, "👍").is_comment());
+        let attachment = Attachment::reactions(ReactionSet::new(["👍"]));
+        assert_eq!(
+            attachment.reactions_set().expect("reactions").emojis,
+            vec!["👍"]
+        );
     }
 
     #[test]
     fn test_attachment_target_new() {
-        let t = AttachmentTarget::new("node", "item");
-        assert_eq!(t.node, "node");
-        assert_eq!(t.item_id, "item");
+        let set = ReactionSet::new(["👍", "👍", "", " ❤️ "]);
+        assert_eq!(set.emojis, vec!["👍", "❤️"]);
     }
 
     #[test]
@@ -252,23 +413,54 @@ mod tests {
 
     #[test]
     fn test_namespace_constant() {
-        assert_eq!(NS_PUBSUB_ATTACHMENTS, "urn:xmpp:pubsub-attachments:0");
+        assert_eq!(NS_PUBSUB_ATTACHMENTS, "urn:xmpp:pubsub-attachments:1");
     }
 
     #[test]
     fn test_attachment_with_author() {
-        let target = AttachmentTarget::new("n", "i");
-        let a = Attachment::comment(target, "hi").with_author("bob@example.com");
-        assert_eq!(a.author.as_deref(), Some("bob@example.com"));
+        let set = ReactionSet::new(["👍"]).with_timestamp("2022-07-11T12:07:48Z");
+        let elem = build_reactions_element(&set);
+        assert_eq!(elem.attr("timestamp"), Some("2022-07-11T12:07:48Z"));
     }
 
     #[test]
     fn test_build_and_parse_roundtrip() {
-        let target = AttachmentTarget::new("feed:0", "post-99");
-        let attachment = Attachment::comment(target, "Round trip!");
+        let unknown = Element::builder("future", "urn:example:future").build();
+        let attachment = Attachment::reactions(ReactionSet::new(["👍", "❤️"]))
+            .with_unknown_child(unknown.clone());
         let elem = build_attachments_element(&attachment);
-        let parsed = parse_attachment_target(&elem).expect("parseable");
-        assert_eq!(parsed.node, "feed:0");
-        assert_eq!(parsed.item_id, "post-99");
+        let parsed = parse_attachments_element(&elem).expect("parseable");
+        assert_eq!(
+            parsed.reactions_set().expect("reactions").emojis,
+            vec!["👍", "❤️"]
+        );
+        assert_eq!(parsed.unknown_children, vec![unknown]);
+    }
+
+    #[test]
+    fn validation_rejects_too_many_reactions() {
+        let set = ReactionSet::new([
+            "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13",
+        ]);
+
+        assert_eq!(
+            set.validate(),
+            Err(AttachmentValidationError::TooManyReactions {
+                actual: 13,
+                max: MAX_REACTIONS_PER_ATTACHMENT
+            })
+        );
+    }
+
+    #[test]
+    fn validation_rejects_multiple_grapheme_like_reaction() {
+        let set = ReactionSet::new(["👍 👍"]);
+
+        assert_eq!(
+            set.validate(),
+            Err(AttachmentValidationError::ReactionNotSingleGrapheme(
+                "👍 👍".to_owned()
+            ))
+        );
     }
 }

--- a/server/crates/waddle-xmpp/src/xep/xep0470.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0470.rs
@@ -25,6 +25,7 @@
 
 use minidom::Element;
 use std::collections::BTreeSet;
+use unicode_segmentation::UnicodeSegmentation;
 
 /// Namespace for XEP-0470 Pubsub Attachments.
 pub const NS_PUBSUB_ATTACHMENTS: &str = "urn:xmpp:pubsub-attachments:1";
@@ -190,7 +191,9 @@ pub fn parse_attachments_element(elem: &Element) -> Option<Attachment> {
             ("reactions", NS_PUBSUB_ATTACHMENTS) => attachment
                 .payloads
                 .push(AttachmentPayload::Reactions(parse_reactions_element(child))),
-            ("noticed", NS_PUBSUB_ATTACHMENTS) => attachment.payloads.push(AttachmentPayload::Noticed),
+            ("noticed", NS_PUBSUB_ATTACHMENTS) => {
+                attachment.payloads.push(AttachmentPayload::Noticed)
+            }
             ("summary", NS_PUBSUB_ATTACHMENTS_SUMMARY) => attachment
                 .payloads
                 .push(AttachmentPayload::Summary(parse_summary_element(child))),
@@ -323,7 +326,9 @@ where
 
 fn is_single_extended_grapheme_cluster(value: &str) -> bool {
     let trimmed = value.trim();
-    !trimmed.is_empty() && !trimmed.chars().any(char::is_whitespace) && trimmed.chars().count() <= 8
+    !trimmed.is_empty()
+        && !trimmed.chars().any(char::is_whitespace)
+        && trimmed.graphemes(true).count() == 1
 }
 
 #[cfg(test)]
@@ -454,12 +459,31 @@ mod tests {
 
     #[test]
     fn validation_rejects_multiple_grapheme_like_reaction() {
-        let set = ReactionSet::new(["👍 👍"]);
+        let set = ReactionSet::new(["👍👍"]);
 
         assert_eq!(
             set.validate(),
             Err(AttachmentValidationError::ReactionNotSingleGrapheme(
-                "👍 👍".to_owned()
+                "👍👍".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn validation_accepts_zwj_emoji_as_single_grapheme() {
+        let set = ReactionSet::new(["👩🏾‍❤️‍👩🏼"]);
+
+        assert_eq!(set.validate(), Ok(()));
+    }
+
+    #[test]
+    fn validation_rejects_ascii_word_as_multiple_graphemes() {
+        let set = ReactionSet::new(["abc"]);
+
+        assert_eq!(
+            set.validate(),
+            Err(AttachmentValidationError::ReactionNotSingleGrapheme(
+                "abc".to_owned()
             ))
         );
     }

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=249854e38c23";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=249854e38c23";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=249854e38c23";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=e49daff3e915";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=e49daff3e915";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=e49daff3e915";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=249854e38c23";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=e49daff3e915";


### PR DESCRIPTION
## Summary

Implements issue #873: pull-based story reactions using XEP-0470 Pubsub Attachments.

## Plan / work completed

- Repair XEP-0470 payload support to use `urn:xmpp:pubsub-attachments:1` and model reaction sets under `<attachments><reactions><reaction/>`.
- Add server-side story attachment node handling for `urn:xmpp:pubsub-attachments:1/<story-item-XMPP-URI>`:
  - auto-create on first reaction;
  - inherit stories node access/publish models;
  - require the target story item to exist;
  - require item id to equal the publisher bare JID;
  - reject non-`<attachments/>` payloads as bad request;
  - preserve owner-only story publish behavior while allowing member reaction publish/retract.
- Harden review-feedback paths:
  - validate reactions as one real extended grapheme cluster;
  - require canonical story attachment node strings for the addressed community, including exact target host, exact stories node, exact item id, and no extra target params;
  - parse attachment publish/retract item ids as `BareJid` before comparing them to the authenticated publisher;
  - parse only PubSub-namespace `<item/>` elements from reaction IQ responses;
  - ignore stale reaction refreshes and batch reaction IQ fan-out;
  - preserve optimistic self reactions per story during pending refreshes without freezing unrelated stories;
  - prevent failed older reaction toggles from rolling back newer local toggle state;
  - expose quick-reaction toggle state with `aria-pressed`.
- Add chat client story reaction APIs over XMPP PubSub, preserving unknown attachment children on republish.
- Render story reaction quick toggles, aggregate counts, and who-reacted titles in the story reader.
- Add optimistic toggle, overlapping-toggle rollback, stale refresh, per-story refresh merge, and bounded fan-out coverage in the story composable tests.

## Verification

- `cargo test -p waddle-xmpp xep0470 --lib`
- `cargo test -p waddle-server --test xep0470_story_reactions_ws -- --nocapture`
- `cargo clippy -p waddle-server --tests -- -D warnings`
- `bun test tests/stories.test.ts`
- `bun run lint`
- adversarial review pass: Rust/XMPP reviewer found no actionable issues after fixes
- adversarial review pass: chat reviewer findings were fixed with per-story mutation versions and guarded rollback tests

## Known verification gaps

- `bun run build` currently fails in `src/lib/editor/chat-code-block.ts` and `src/lib/editor/chat-link.ts` with duplicate ProseMirror `prosemirror-model` type versions (`1.25.4` vs `1.25.7`), unrelated to this story-reaction slice.
- `bun test` full suite previously failed in `tests/editor-message-input.test.ts` with a ProseMirror duplicate-version RangeError, unrelated to this slice.
- `bunx vue-tsc --noEmit` previously reported existing broad project type errors and ProseMirror duplicate-version conflicts, unrelated to this slice.

Closes #873