### PR TITLE
fix(chat): handle stream management resume errors

### DIFF
--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -296,6 +296,74 @@ function normalizeXmppStreamErrorPayload(payload: XmppStreamErrorPayload): {
   };
 }
 
+function validResumeMaxSeconds(value: number | undefined): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 && value <= 0xFFFF_FFFF
+    ? value
+    : undefined;
+}
+
+export function applyResumeStateToWasmConfig(config: unknown, resumeState: XmppResumeState): void {
+  const wasmConfig = config as {
+    with_resume_state_stanzas_with_max?: (
+      previd: string,
+      inboundH: number,
+      outboundH: number,
+      stanzas: string[],
+      maxResumeSeconds: number,
+    ) => void;
+    with_resume_state_stanzas?: (
+      previd: string,
+      inboundH: number,
+      outboundH: number,
+      stanzas: string[],
+    ) => void;
+    with_resume_state_with_max?: (
+      previd: string,
+      inboundH: number,
+      outboundH: number,
+      maxResumeSeconds: number,
+    ) => void;
+    with_resume_state?: (previd: string, inboundH: number, outboundH: number) => void;
+  };
+  const maxResumeSeconds = validResumeMaxSeconds(resumeState.maxResumeSeconds);
+  if (
+    resumeState.unhandledOutboundStanzas?.length
+    && maxResumeSeconds !== undefined
+    && typeof wasmConfig.with_resume_state_stanzas_with_max === "function"
+  ) {
+    wasmConfig.with_resume_state_stanzas_with_max(
+      resumeState.previd,
+      resumeState.inboundH,
+      resumeState.outboundH,
+      resumeState.unhandledOutboundStanzas,
+      maxResumeSeconds,
+    );
+    return;
+  }
+  if (
+    resumeState.unhandledOutboundStanzas?.length
+    && typeof wasmConfig.with_resume_state_stanzas === "function"
+  ) {
+    wasmConfig.with_resume_state_stanzas(
+      resumeState.previd,
+      resumeState.inboundH,
+      resumeState.outboundH,
+      resumeState.unhandledOutboundStanzas,
+    );
+    return;
+  }
+  if (maxResumeSeconds !== undefined && typeof wasmConfig.with_resume_state_with_max === "function") {
+    wasmConfig.with_resume_state_with_max(
+      resumeState.previd,
+      resumeState.inboundH,
+      resumeState.outboundH,
+      maxResumeSeconds,
+    );
+    return;
+  }
+  wasmConfig.with_resume_state?.(resumeState.previd, resumeState.inboundH, resumeState.outboundH);
+}
+
 async function collectRecentMamPages(
   fetchPage: (max: number, pageParam: MamPageParam) => Promise<WasmMamPage | null | undefined>,
   options: DmCallActivityHydrationOptions,
@@ -512,10 +580,11 @@ interface MdsDisplayedEntry {
   stanzaIdBy: string;
 }
 
-type XmppResumeState = {
+export type XmppResumeState = {
   previd: string;
   inboundH: number;
   outboundH: number;
+  maxResumeSeconds?: number;
   hasUnackedOutbound?: boolean;
   unhandledOutboundStanzas?: string[];
   resource?: string;
@@ -1030,20 +1099,7 @@ export class BrowserXmppClient {
       (config as any).with_resume_state_handle(handle);
       this.clearResumeState();
     } else if (this.resumeState) {
-      if (this.resumeState.unhandledOutboundStanzas?.length && typeof (config as any).with_resume_state_stanzas === "function") {
-        (config as any).with_resume_state_stanzas(
-          this.resumeState.previd,
-          this.resumeState.inboundH,
-          this.resumeState.outboundH,
-          this.resumeState.unhandledOutboundStanzas,
-        );
-      } else {
-        (config as any).with_resume_state?.(
-          this.resumeState.previd,
-          this.resumeState.inboundH,
-          this.resumeState.outboundH,
-        );
-      }
+      applyResumeStateToWasmConfig(config, this.resumeState);
       this.resumePersistence.clearSm();
       this.resumeState = null;
     }

--- a/chat/src/lib/xmpp/resume-persistence.ts
+++ b/chat/src/lib/xmpp/resume-persistence.ts
@@ -14,10 +14,10 @@
  *
  *   * XEP-0198 Stream Management resume state
  *     (`PersistedSmResumeState`) — the `previd` plus inbound /
- *     outbound stanza counts. The richer "handle" form from the
- *     WASM client is a live JS object that cannot be serialized;
- *     the POD `{previd, inboundH, outboundH}` triple can be. When
- *     the native XEP-0198 queue still has unhandled outbound stanzas,
+ *     outbound stanza counts and advertised resume window. The richer
+ *     "handle" form from the WASM client is a live JS object that cannot
+ *     be serialized; the POD `{previd, inboundH, outboundH}` triple can be.
+ *     When the native XEP-0198 queue still has unhandled outbound stanzas,
  *     their XML is serialized too so `doConnect` can restore sender
  *     responsibility after a full reload instead of creating a false
  *     resume state with an empty replay queue.
@@ -59,6 +59,7 @@ export type PersistedSmResumeState = {
   previd: string;
   inboundH: number;
   outboundH: number;
+  maxResumeSeconds?: number;
   unhandledOutboundStanzas?: string[];
   resource?: string;
 };
@@ -88,12 +89,12 @@ type OwnerHandoff = {
 };
 
 /**
- * Reject a persisted SM POD older than this window. Servers usually
- * GC the corresponding session much sooner (XEP-0198 §5); 24h is
- * generous but bounds the cost of a guaranteed `<failed/>` on every
- * cold start with a weeks-old POD.
+ * Fallback resumption window for older persisted PODs that predate
+ * `maxResumeSeconds`. This mirrors Waddle server's default XEP-0198
+ * max, so old snapshots fail closed instead of lingering for hours.
  */
-const SM_TTL_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_SM_MAX_RESUME_SECONDS = 300;
+const SM_SAVED_AT_FUTURE_SKEW_MS = 60_000;
 const OWNER_LEASE_TTL_MS = 45_000;
 const OWNER_HEARTBEAT_MS = 15_000;
 const OWNER_HANDOFF_TTL_MS = OWNER_LEASE_TTL_MS;
@@ -148,21 +149,22 @@ export function createLocalStorageResumePersistence(accountKey: string, ownerId?
     loadSm() {
       const envelope = readJson<PersistedSmEnvelope>(smKey, isPersistedSmEnvelope, "sm");
       if (!envelope) return null;
-      // Drop entries past the TTL — the server has GC'd the
+      // Drop entries past the advertised resume window — the server has GC'd the
       // corresponding session, so feeding the POD back to
       // `with_resume_state` is a guaranteed `<failed/>`. Returning
       // null lets `doConnect` fall through to a fresh bind.
-      if (Date.now() - envelope.savedAt > SM_TTL_MS) {
+      if (smEnvelopeExpired(envelope)) {
         removeKey(smKey, "sm");
         return null;
       }
       if (envelope.ownerId !== owner.ownerId) return null;
       if (envelope.claimId) return null;
-      const { previd, inboundH, outboundH, resource, unhandledOutboundStanzas } = envelope;
+      const { previd, inboundH, outboundH, maxResumeSeconds, resource, unhandledOutboundStanzas } = envelope;
       return {
         previd,
         inboundH,
         outboundH,
+        ...(maxResumeSeconds ? { maxResumeSeconds } : {}),
         ...(unhandledOutboundStanzas?.length ? { unhandledOutboundStanzas: [...unhandledOutboundStanzas] } : {}),
         ...(resource ? { resource } : {}),
       };
@@ -209,7 +211,7 @@ function consumeSmEnvelope(key: string, ownerId: string): PersistedSmResumeState
     const parsed: unknown = JSON.parse(raw);
     if (!isPersistedSmEnvelope(parsed)) return null;
     const consumedMarker = smEnvelopeMarker(raw);
-    if (Date.now() - parsed.savedAt > SM_TTL_MS) {
+    if (smEnvelopeExpired(parsed)) {
       s.removeItem(key);
       return null;
     }
@@ -235,11 +237,12 @@ function consumeSmEnvelope(key: string, ownerId: string): PersistedSmResumeState
 
     s.setItem(consumedKey, consumedMarker);
     s.removeItem(key);
-    const { previd, inboundH, outboundH, resource, unhandledOutboundStanzas } = claimed;
+    const { previd, inboundH, outboundH, maxResumeSeconds, resource, unhandledOutboundStanzas } = claimed;
     return {
       previd,
       inboundH,
       outboundH,
+      ...(maxResumeSeconds ? { maxResumeSeconds } : {}),
       ...(unhandledOutboundStanzas?.length ? { unhandledOutboundStanzas: [...unhandledOutboundStanzas] } : {}),
       ...(resource ? { resource } : {}),
     };
@@ -255,6 +258,13 @@ function consumeSmEnvelope(key: string, ownerId: string): PersistedSmResumeState
 
 function randomClaimId(): string {
   return globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
+}
+
+function smEnvelopeExpired(envelope: PersistedSmEnvelope): boolean {
+  const maxResumeSeconds = envelope.maxResumeSeconds ?? DEFAULT_SM_MAX_RESUME_SECONDS;
+  const ageMs = Date.now() - envelope.savedAt;
+  if (ageMs < -SM_SAVED_AT_FUTURE_SKEW_MS) return true;
+  return ageMs > maxResumeSeconds * 1000;
 }
 
 function explicitResumeOwner(ownerId: string): ResumeOwner {
@@ -481,6 +491,14 @@ function isOwnerHandoff(value: unknown): value is OwnerHandoff {
   );
 }
 
+function isU32(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 0xFFFF_FFFF;
+}
+
+function isPositiveU32(value: unknown): value is number {
+  return isU32(value) && value > 0;
+}
+
 function normalizeRoomJid(roomJid: string): string {
   return roomJid.split("/")[0]?.trim().toLowerCase() ?? "";
 }
@@ -490,12 +508,13 @@ function isPersistedSmEnvelope(value: unknown): value is PersistedSmEnvelope {
   const candidate = value as Record<string, unknown>;
   return (
     typeof candidate.previd === "string"
-    && typeof candidate.inboundH === "number"
-    && typeof candidate.outboundH === "number"
+    && isU32(candidate.inboundH)
+    && isU32(candidate.outboundH)
+    && (candidate.maxResumeSeconds === undefined || isPositiveU32(candidate.maxResumeSeconds))
     && (candidate.unhandledOutboundStanzas === undefined || isStringArray(candidate.unhandledOutboundStanzas))
     && (candidate.resource === undefined || typeof candidate.resource === "string")
     && (candidate.ownerId === undefined || typeof candidate.ownerId === "string")
     && (candidate.claimId === undefined || typeof candidate.claimId === "string")
-    && typeof candidate.savedAt === "number"
+    && Number.isFinite(candidate.savedAt)
   );
 }

--- a/chat/src/lib/xmpp/xmpp-instrumentation.ts
+++ b/chat/src/lib/xmpp/xmpp-instrumentation.ts
@@ -60,11 +60,19 @@ export function installInstrumentation(client: BrowserXmppClient): void {
     const kind = ERROR_KIND_MAP[event.kind];
     const condition = telemetryCondition(event.kind, event.condition);
     const detail = telemetryErrorDetail(event, condition);
+    const streamDetail = event.kind === "stream"
+      ? telemetryStreamSourceDetail(event.detail, detail)
+      : undefined;
+    const smCounts = event.kind === "stream"
+      ? telemetryStreamManagementCounts(event)
+      : undefined;
     const cause = new Error(detail);
     reportError(kind, cause, {
       recoverable: event.recoverable,
       detail,
       ...(condition ? { condition } : {}),
+      ...(streamDetail ? { streamDetail } : {}),
+      ...(smCounts ?? {}),
     });
   });
   // Background-tab RESULT_CODE_HUNG investigation (observe-only). These
@@ -95,8 +103,48 @@ function telemetryErrorDetail(event: XmppErrorEvent, condition: string | undefin
       ) {
         return "stream-handled-count-too-high";
       }
-      return condition ? `stream-${condition}` : "stream-error";
+      return condition ? `stream-${condition}` : telemetryStreamFallbackDetail(event.detail);
   }
+}
+
+function telemetryStreamFallbackDetail(detail: string): string {
+  const normalized = detail.trim().toLowerCase();
+  if (!normalized || normalized === "stream error") return "stream-error";
+  if (normalized === "handled-count-too-high") return "stream-handled-count-too-high";
+  if (
+    normalized.includes("websocket transport error") ||
+    normalized.includes("websocket transport failed") ||
+    normalized.includes("websocket transport is already closed") ||
+    normalized.includes("transport closed")
+  ) {
+    return "stream-transport-error";
+  }
+  if (
+    normalized.includes("malformed xmpp framing") ||
+    normalized.includes("invalid transport frame")
+  ) {
+    return "stream-invalid-transport-frame";
+  }
+  if (normalized.includes("empty xmpp frame")) return "stream-empty-transport-frame";
+  if (normalized.includes("unsupported message type")) return "stream-unsupported-websocket-message";
+  if (normalized.includes("disconnected")) return "stream-disconnected";
+  return "stream-error";
+}
+
+function telemetryStreamSourceDetail(detail: string, telemetryDetail: string): string | undefined {
+  const trimmed = detail.trim();
+  if (!trimmed || trimmed.toLowerCase() === "stream error" || trimmed === telemetryDetail) {
+    return undefined;
+  }
+  return trimmed;
+}
+
+function telemetryStreamManagementCounts(event: XmppErrorEvent): Record<string, string> | undefined {
+  if (event.streamManagementError?.kind !== "handled-count-too-high") return undefined;
+  return {
+    smH: String(event.streamManagementError.h),
+    smSendCount: String(event.streamManagementError.sendCount),
+  };
 }
 
 function telemetryCondition(kind: XmppErrorKind, condition: string | undefined): string | undefined {

--- a/chat/tests/resume-persistence.test.ts
+++ b/chat/tests/resume-persistence.test.ts
@@ -12,7 +12,7 @@
  */
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import { ReconnectCatchup } from "../src/lib/xmpp/reconnect-catchup";
-import { BrowserXmppClient } from "../src/lib/xmpp/client";
+import { BrowserXmppClient, applyResumeStateToWasmConfig } from "../src/lib/xmpp/client";
 import { enqueueQueuedMessage, listQueuedDmMessages } from "../src/lib/outbound-queue-store";
 import type { WaddleSession } from "../src/lib/server-auth";
 import {
@@ -230,6 +230,96 @@ describe("ReconnectCatchup persistence — writes back on advance", () => {
   });
 });
 
+describe("applyResumeStateToWasmConfig", () => {
+  function configWith(methods: string[]) {
+    const calls: Array<{ method: string; args: unknown[] }> = [];
+    const config: Record<string, (...args: unknown[]) => void> = {};
+    for (const method of methods) {
+      config[method] = (...args: unknown[]) => calls.push({ method, args });
+    }
+    return { config, calls };
+  }
+
+  test("uses max-aware stanza resume when both unhandled stanzas and max are available", () => {
+    const { config, calls } = configWith([
+      "with_resume_state_stanzas_with_max",
+      "with_resume_state_stanzas",
+      "with_resume_state_with_max",
+      "with_resume_state",
+    ]);
+
+    applyResumeStateToWasmConfig(config, {
+      previd: "prev-1",
+      inboundH: 7,
+      outboundH: 11,
+      maxResumeSeconds: 300,
+      unhandledOutboundStanzas: ["<message/>"],
+    });
+
+    expect(calls).toEqual([
+      {
+        method: "with_resume_state_stanzas_with_max",
+        args: ["prev-1", 7, 11, ["<message/>"], 300],
+      },
+    ]);
+  });
+
+  test("uses max-aware resume when no unhandled stanzas need replay", () => {
+    const { config, calls } = configWith(["with_resume_state_with_max", "with_resume_state"]);
+
+    applyResumeStateToWasmConfig(config, {
+      previd: "prev-2",
+      inboundH: 3,
+      outboundH: 5,
+      maxResumeSeconds: 120,
+    });
+
+    expect(calls).toEqual([
+      {
+        method: "with_resume_state_with_max",
+        args: ["prev-2", 3, 5, 120],
+      },
+    ]);
+  });
+
+  test("falls back to old stanza resume when generated WASM lacks max-aware stanza support", () => {
+    const { config, calls } = configWith(["with_resume_state_stanzas", "with_resume_state"]);
+
+    applyResumeStateToWasmConfig(config, {
+      previd: "prev-3",
+      inboundH: 1,
+      outboundH: 2,
+      maxResumeSeconds: 300,
+      unhandledOutboundStanzas: ["<presence/>"],
+    });
+
+    expect(calls).toEqual([
+      {
+        method: "with_resume_state_stanzas",
+        args: ["prev-3", 1, 2, ["<presence/>"]],
+      },
+    ]);
+  });
+
+  test("falls back to old plain resume when generated WASM has only the legacy method", () => {
+    const { config, calls } = configWith(["with_resume_state"]);
+
+    applyResumeStateToWasmConfig(config, {
+      previd: "prev-4",
+      inboundH: 13,
+      outboundH: 21,
+      maxResumeSeconds: 300,
+    });
+
+    expect(calls).toEqual([
+      {
+        method: "with_resume_state",
+        args: ["prev-4", 13, 21],
+      },
+    ]);
+  });
+});
+
 describe("createLocalStorageResumePersistence — localStorage adapter", () => {
   test("round-trips a catchup snapshot through localStorage", () => {
     const persistence = createLocalStorageResumePersistence("alice@example.com");
@@ -417,12 +507,13 @@ describe("createLocalStorageResumePersistence — localStorage adapter", () => {
       persistence,
     );
     (client as unknown as {
-      xmpp: { get_resume_state: () => { previd: string; inboundH: number; outboundH: number; hasUnackedOutbound: boolean } };
+      xmpp: { get_resume_state: () => { previd: string; inboundH: number; outboundH: number; maxResumeSeconds: number; hasUnackedOutbound: boolean } };
     }).xmpp = {
       get_resume_state: () => ({
         previd: "live-sm-id",
         inboundH: 4,
         outboundH: 9,
+        maxResumeSeconds: 300,
         hasUnackedOutbound: true,
       }),
     };
@@ -446,6 +537,7 @@ describe("createLocalStorageResumePersistence — localStorage adapter", () => {
           previd: string;
           inboundH: number;
           outboundH: number;
+          maxResumeSeconds: number;
           hasUnackedOutbound: boolean;
           unhandledOutboundStanzas: string[];
         };
@@ -455,6 +547,7 @@ describe("createLocalStorageResumePersistence — localStorage adapter", () => {
         previd: "live-sm-id",
         inboundH: 4,
         outboundH: 9,
+        maxResumeSeconds: 300,
         hasUnackedOutbound: true,
         unhandledOutboundStanzas: ["<message xmlns='jabber:client' id='unacked'/>"],
       }),
@@ -466,6 +559,7 @@ describe("createLocalStorageResumePersistence — localStorage adapter", () => {
       previd: "live-sm-id",
       inboundH: 4,
       outboundH: 9,
+      maxResumeSeconds: 300,
       unhandledOutboundStanzas: ["<message xmlns='jabber:client' id='unacked'/>"],
     });
   });
@@ -529,12 +623,13 @@ describe("createLocalStorageResumePersistence — localStorage adapter", () => {
       persistence,
     );
     (client as unknown as {
-      xmpp: { get_resume_state: () => { previd: string; inboundH: number; outboundH: number; hasUnackedOutbound: boolean } };
+      xmpp: { get_resume_state: () => { previd: string; inboundH: number; outboundH: number; maxResumeSeconds: number; hasUnackedOutbound: boolean } };
     }).xmpp = {
       get_resume_state: () => ({
         previd: "live-sm-id",
         inboundH: 4,
         outboundH: 9,
+        maxResumeSeconds: 300,
         hasUnackedOutbound: false,
       }),
     };
@@ -545,6 +640,7 @@ describe("createLocalStorageResumePersistence — localStorage adapter", () => {
       previd: "live-sm-id",
       inboundH: 4,
       outboundH: 9,
+      maxResumeSeconds: 300,
     });
   });
 
@@ -574,6 +670,7 @@ describe("createLocalStorageResumePersistence — localStorage adapter", () => {
       previd: "abc-123",
       inboundH: 42,
       outboundH: 7,
+      maxResumeSeconds: 300,
       resource: "web-existing-resource",
     };
     first.saveSm(state);
@@ -606,19 +703,68 @@ describe("createLocalStorageResumePersistence — localStorage adapter", () => {
     }
   });
 
-  test("SM TTL: a stale envelope is rejected and cleared", () => {
+  test("SM TTL: an old envelope without advertised max uses the default resume window", () => {
     const persistence = createLocalStorageResumePersistence("alice@example.com");
-    // Inject a 30-day-old envelope directly (bypassing saveSm so we
-    // control the timestamp). 30d > the 24h TTL.
-    const thirtyDaysAgo = Date.now() - (30 * 24 * 60 * 60 * 1000);
+    const justOverDefaultResumeWindow = Date.now() - 301_000;
     window.localStorage.setItem(
       "waddle.chat.sm-resume.alice@example.com",
-      JSON.stringify({ previd: "stale", inboundH: 1, outboundH: 1, savedAt: thirtyDaysAgo }),
+      JSON.stringify({ previd: "stale", inboundH: 1, outboundH: 1, savedAt: justOverDefaultResumeWindow }),
     );
     expect(persistence.loadSm()).toBeNull();
     // Stale entries are pruned on read so the next load doesn't
     // pay the validation cost again.
     expect(window.localStorage.getItem("waddle.chat.sm-resume.alice@example.com")).toBeNull();
+  });
+
+  test("SM TTL: advertised maxResumeSeconds controls persisted resume expiry", () => {
+    const persistence = createLocalStorageResumePersistence("alice@example.com");
+    const twoSecondsAgo = Date.now() - 2_000;
+    window.localStorage.setItem(
+      "waddle.chat.sm-resume.alice@example.com",
+      JSON.stringify({
+        previd: "stale",
+        inboundH: 1,
+        outboundH: 1,
+        maxResumeSeconds: 1,
+        savedAt: twoSecondsAgo,
+      }),
+    );
+
+    expect(persistence.consumeSm()).toBeNull();
+    expect(window.localStorage.getItem("waddle.chat.sm-resume.alice@example.com")).toBeNull();
+  });
+
+  test("SM TTL: future-dated envelopes fail closed and are pruned", () => {
+    const persistence = createLocalStorageResumePersistence("alice@example.com");
+    const farFuture = Date.now() + 120_000;
+    window.localStorage.setItem(
+      "waddle.chat.sm-resume.alice@example.com",
+      JSON.stringify({
+        previd: "from-the-future",
+        inboundH: 1,
+        outboundH: 1,
+        maxResumeSeconds: 300,
+        savedAt: farFuture,
+      }),
+    );
+
+    expect(persistence.loadSm()).toBeNull();
+    expect(window.localStorage.getItem("waddle.chat.sm-resume.alice@example.com")).toBeNull();
+  });
+
+  test("SM state rejects non-u32 stanza counters", () => {
+    const persistence = createLocalStorageResumePersistence("alice@example.com");
+    window.localStorage.setItem(
+      "waddle.chat.sm-resume.alice@example.com",
+      JSON.stringify({
+        previd: "bad-counter",
+        inboundH: 1.5,
+        outboundH: 1,
+        savedAt: Date.now(),
+      }),
+    );
+
+    expect(persistence.loadSm()).toBeNull();
   });
 
   test("loadCatchup returns null for malformed JSON", () => {

--- a/chat/tests/xmpp-telemetry.test.ts
+++ b/chat/tests/xmpp-telemetry.test.ts
@@ -776,6 +776,36 @@ describe("BrowserXmppClient telemetry hooks", () => {
     expect(stub.errors[0].options?.context?.detail).toBe("stream-not-authorized");
   });
 
+  test("set_on_error bridge recovers stream condition from object detail", () => {
+    const stub = createFaroStub();
+    __setFaroForTesting(stub as never);
+
+    const client = new BrowserXmppClient(session());
+    installInstrumentation(client);
+
+    let onError: ((detail: TestXmppStreamErrorPayload) => void) | null = null;
+    const xmpp = {
+      set_on_error(cb: NonNullable<typeof onError>) {
+        onError = cb;
+      },
+    };
+    const internal = client as unknown as {
+      xmpp: typeof xmpp;
+      wireEvents: (xmpp: typeof xmpp) => void;
+    };
+    internal.xmpp = xmpp;
+    internal.wireEvents(xmpp);
+
+    onError?.({ detail: "not-authorized" });
+
+    expect(stub.errors).toHaveLength(1);
+    expect(stub.errors[0].error.message).toBe("stream-not-authorized");
+    expect(stub.errors[0].options?.type).toBe("xmpp.stream");
+    expect(stub.errors[0].options?.context?.condition).toBe("not-authorized");
+    expect(stub.errors[0].options?.context?.detail).toBe("stream-not-authorized");
+    expect(stub.errors[0].options?.context?.streamDetail).toBe("not-authorized");
+  });
+
   test("set_on_error bridge keeps stanza-only conditions out of stream telemetry", () => {
     const stub = createFaroStub();
     __setFaroForTesting(stub as never);
@@ -803,6 +833,66 @@ describe("BrowserXmppClient telemetry hooks", () => {
     expect(stub.errors[0].options?.type).toBe("xmpp.stream");
     expect(stub.errors[0].options?.context?.condition).toBeUndefined();
     expect(stub.errors[0].options?.context?.detail).toBe("stream-error");
+  });
+
+  test("set_on_error bridge classifies driver errors without losing stream detail", () => {
+    const stub = createFaroStub();
+    __setFaroForTesting(stub as never);
+
+    const client = new BrowserXmppClient(session());
+    installInstrumentation(client);
+
+    let onError: ((detail: TestXmppStreamErrorPayload) => void) | null = null;
+    const xmpp = {
+      set_on_error(cb: NonNullable<typeof onError>) {
+        onError = cb;
+      },
+    };
+    const internal = client as unknown as {
+      xmpp: typeof xmpp;
+      wireEvents: (xmpp: typeof xmpp) => void;
+    };
+    internal.xmpp = xmpp;
+    internal.wireEvents(xmpp);
+
+    onError?.("websocket transport error");
+
+    expect(stub.errors).toHaveLength(1);
+    expect(stub.errors[0].error.message).toBe("stream-transport-error");
+    expect(stub.errors[0].options?.type).toBe("xmpp.stream");
+    expect(stub.errors[0].options?.context?.condition).toBeUndefined();
+    expect(stub.errors[0].options?.context?.detail).toBe("stream-transport-error");
+    expect(stub.errors[0].options?.context?.streamDetail).toBe("websocket transport error");
+  });
+
+  test("set_on_error bridge names handled-count detail when SM metadata is absent", () => {
+    const stub = createFaroStub();
+    __setFaroForTesting(stub as never);
+
+    const client = new BrowserXmppClient(session());
+    installInstrumentation(client);
+
+    let onError: ((detail: TestXmppStreamErrorPayload) => void) | null = null;
+    const xmpp = {
+      set_on_error(cb: NonNullable<typeof onError>) {
+        onError = cb;
+      },
+    };
+    const internal = client as unknown as {
+      xmpp: typeof xmpp;
+      wireEvents: (xmpp: typeof xmpp) => void;
+    };
+    internal.xmpp = xmpp;
+    internal.wireEvents(xmpp);
+
+    onError?.({ detail: "handled-count-too-high" });
+
+    expect(stub.errors).toHaveLength(1);
+    expect(stub.errors[0].error.message).toBe("stream-handled-count-too-high");
+    expect(stub.errors[0].options?.type).toBe("xmpp.stream");
+    expect(stub.errors[0].options?.context?.condition).toBeUndefined();
+    expect(stub.errors[0].options?.context?.detail).toBe("stream-handled-count-too-high");
+    expect(stub.errors[0].options?.context?.streamDetail).toBe("handled-count-too-high");
   });
 
   test("set_on_error bridge names XEP-0198 handled-count stream failures", () => {
@@ -840,6 +930,8 @@ describe("BrowserXmppClient telemetry hooks", () => {
     expect(stub.errors[0].options?.type).toBe("xmpp.stream");
     expect(stub.errors[0].options?.context?.condition).toBe("undefined-condition");
     expect(stub.errors[0].options?.context?.detail).toBe("stream-handled-count-too-high");
+    expect(stub.errors[0].options?.context?.smH).toBe("3");
+    expect(stub.errors[0].options?.context?.smSendCount).toBe("2");
   });
 
   test("enqueuing a send fires onSendEnqueued + onQueueDepthChange", async () => {

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -8,7 +8,7 @@ use super::{
     session_init::build_internal_server_error_stream_error,
     state::WsConnState,
     stream_management::{is_countable_stanza, SmRegistrationFinalization},
-    transport_xml::websocket_stream_close_xml,
+    transport_xml::{build_handled_count_too_high_stream_error, websocket_stream_close_xml},
 };
 use waddle_xmpp::stream_management::SmRequest;
 
@@ -131,6 +131,18 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
                                     }
                                     SmRegistrationFinalization::ReplaceWithFailed(failed) => {
                                         responses = vec![failed.to_xml()];
+                                    }
+                                    SmRegistrationFinalization::ReplaceWithHandledCountTooHigh {
+                                        acknowledged,
+                                        send_count,
+                                    } => {
+                                        responses = vec![
+                                            build_handled_count_too_high_stream_error(
+                                                acknowledged,
+                                                send_count,
+                                            ),
+                                            websocket_stream_close_xml(),
+                                        ];
                                     }
                                 }
                             }

--- a/server/crates/waddle-server/src/server/routes/websocket/stream_management/registration.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/stream_management/registration.rs
@@ -43,6 +43,10 @@ pub(in crate::server::routes::websocket) enum SmRegistrationFinalization {
         replay_after_h: u32,
     },
     ReplaceWithFailed(SmFailed),
+    ReplaceWithHandledCountTooHigh {
+        acknowledged: u32,
+        send_count: u32,
+    },
 }
 
 async fn complete_pending_resume_claim(
@@ -98,6 +102,22 @@ async fn complete_pending_resume_claim(
                 "resource-constraint",
                 detached.inbound_count,
             ))
+        }
+        Ok(Some(SmClaimCompletion::HandledCountTooHigh(detached))) => {
+            let acknowledged = resume_h.unwrap_or_default();
+            warn!(
+                stream_id = %stream_id,
+                jid = %jid,
+                client_h = acknowledged,
+                send_count = detached.outbound_count,
+                "SM resume claim completed with handled count too high"
+            );
+            close_registered_resume_attempt(state, conn, jid, owner);
+            remove_resumable_sidecar = false;
+            SmRegistrationFinalization::ReplaceWithHandledCountTooHigh {
+                acknowledged,
+                send_count: detached.outbound_count,
+            }
         }
         Ok(Some(SmClaimCompletion::Expired(detached))) => {
             warn!(stream_id = %stream_id, jid = %jid, "SM resume claim expired before completion");

--- a/server/crates/waddle-xmpp-client-wasm/src/driver.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/driver.rs
@@ -708,6 +708,7 @@ mod tests {
             resource: "web".to_string(),
             resume_state: Some(
                 waddle_xmpp_client::SmResumeState::new("previous-stream", 4, 9)
+                    .map(|state| state.with_max_resume_seconds(Some(300)))
                     .expect("resume state"),
             ),
         };
@@ -721,6 +722,7 @@ mod tests {
         assert_eq!(snapshot.previd(), "previous-stream");
         assert_eq!(snapshot.inbound_h(), 4);
         assert_eq!(snapshot.outbound_h(), 9);
+        assert_eq!(snapshot.max_resume_seconds(), Some(300));
     }
 
     #[test]
@@ -748,6 +750,7 @@ mod tests {
                 Element::builder("enabled", waddle_xmpp_client::stream_management::NS_SM)
                     .attr(minidom::rxml::xml_ncname!("id").to_owned(), "live-stream")
                     .attr(minidom::rxml::xml_ncname!("resume").to_owned(), "true")
+                    .attr(minidom::rxml::xml_ncname!("max").to_owned(), "300")
                     .build(),
             )))
             .expect("enabled");
@@ -764,6 +767,15 @@ mod tests {
             .as_ref()
             .expect("snapshot")
             .has_unhandled_outbound_stanzas());
+        assert_eq!(
+            inner
+                .borrow()
+                .resume_state
+                .as_ref()
+                .expect("snapshot")
+                .max_resume_seconds(),
+            Some(300),
+        );
 
         let ack = Element::builder("a", waddle_xmpp_client::stream_management::NS_SM)
             .attr(minidom::rxml::xml_ncname!("h").to_owned(), "1")

--- a/server/crates/waddle-xmpp-client-wasm/src/events.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/events.rs
@@ -171,8 +171,9 @@ fn emit_stream_error_callback(
     if let Some(callback) = callback {
         let condition = condition.as_str();
         let stream_management_error = stream_management_error_to_js(detail);
+        let detail = stream_error_detail_label(condition, stream_management_error.as_ref());
         let payload = JsStreamError {
-            detail: "stream error",
+            detail,
             condition,
             stream_management_error,
         };
@@ -187,4 +188,14 @@ fn stream_management_error_to_js(
     detail.map(|StreamErrorDetail::HandledCountTooHigh { h, send_count }| {
         JsStreamManagementError::HandledCountTooHigh { h, send_count }
     })
+}
+
+fn stream_error_detail_label(
+    condition: &'static str,
+    stream_management_error: Option<&JsStreamManagementError>,
+) -> &'static str {
+    match stream_management_error {
+        Some(JsStreamManagementError::HandledCountTooHigh { .. }) => "handled-count-too-high",
+        None => condition,
+    }
 }

--- a/server/crates/waddle-xmpp-client-wasm/src/state.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/state.rs
@@ -47,6 +47,21 @@ impl WaddleConfig {
         Ok(())
     }
 
+    pub fn with_resume_state_with_max(
+        &mut self,
+        previd: String,
+        inbound_h: u32,
+        outbound_h: u32,
+        max_resume_seconds: u32,
+    ) -> Result<(), JsValue> {
+        self.resume_state = Some(
+            waddle_xmpp_client::SmResumeState::new(previd, inbound_h, outbound_h)
+                .map(|state| state.with_max_resume_seconds(Some(max_resume_seconds)))
+                .map_err(|err| js_error(err.to_string()))?,
+        );
+        Ok(())
+    }
+
     pub fn with_resume_state_stanzas(
         &mut self,
         previd: String,
@@ -65,6 +80,31 @@ impl WaddleConfig {
             waddle_xmpp_client::SmResumeState::from_unhandled_outbound_stanzas(
                 previd, inbound_h, outbound_h, stanzas,
             )
+            .map_err(|err| js_error(err.to_string()))?,
+        );
+        Ok(())
+    }
+
+    pub fn with_resume_state_stanzas_with_max(
+        &mut self,
+        previd: String,
+        inbound_h: u32,
+        outbound_h: u32,
+        stanzas: Vec<String>,
+        max_resume_seconds: u32,
+    ) -> Result<(), JsValue> {
+        let stanzas = stanzas
+            .into_iter()
+            .map(|xml| {
+                xml.parse::<Element>()
+                    .map_err(|err| js_error(format!("invalid resume stanza XML: {err}")))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        self.resume_state = Some(
+            waddle_xmpp_client::SmResumeState::from_unhandled_outbound_stanzas(
+                previd, inbound_h, outbound_h, stanzas,
+            )
+            .map(|state| state.with_max_resume_seconds(Some(max_resume_seconds)))
             .map_err(|err| js_error(err.to_string()))?,
         );
         Ok(())
@@ -104,6 +144,7 @@ pub(crate) struct JsResumeState {
     pub(crate) outbound_h: u32,
     pub(crate) has_unacked_outbound: bool,
     pub(crate) unhandled_outbound_stanzas: Vec<String>,
+    pub(crate) max_resume_seconds: Option<u32>,
 }
 
 impl From<waddle_xmpp_client::SmResumeState> for JsResumeState {
@@ -118,6 +159,7 @@ impl From<waddle_xmpp_client::SmResumeState> for JsResumeState {
             outbound_h: value.outbound_h(),
             has_unacked_outbound: value.has_unhandled_outbound_stanzas(),
             unhandled_outbound_stanzas,
+            max_resume_seconds: value.max_resume_seconds(),
         }
     }
 }

--- a/server/crates/waddle-xmpp-client/src/runtime/sm.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime/sm.rs
@@ -96,7 +96,9 @@ impl XmppRuntime {
             }));
         } else if element.name() == "enabled" {
             let previd = crate::stream_management::SmState::parse_enabled(element);
+            let max_resume_seconds = crate::stream_management::SmState::parse_enabled_max(element);
             self.sm_state.previd = previd.clone();
+            self.sm_state.max_resume_seconds = max_resume_seconds;
             self.sm_state.enabled = true;
             events.push(ClientEvent::Connection(ConnectionEvent::StreamManagement(
                 StreamManagementEvent::Enabled { previd },

--- a/server/crates/waddle-xmpp-client/src/stream_management.rs
+++ b/server/crates/waddle-xmpp-client/src/stream_management.rs
@@ -22,6 +22,7 @@ pub struct SmResumeState {
     previd: String,
     inbound_h: u32,
     outbound_h: u32,
+    max_resume_seconds: Option<u32>,
     outbound_queue: VecDeque<QueuedOutboundStanza>,
 }
 
@@ -36,8 +37,14 @@ impl SmResumeState {
             previd,
             inbound_h,
             outbound_h,
+            max_resume_seconds: None,
             outbound_queue: VecDeque::new(),
         })
+    }
+
+    pub fn with_max_resume_seconds(mut self, max_resume_seconds: Option<u32>) -> Self {
+        self.max_resume_seconds = max_resume_seconds;
+        self
     }
 
     fn from_outbound_queue(
@@ -80,6 +87,10 @@ impl SmResumeState {
         self.outbound_h
     }
 
+    pub fn max_resume_seconds(&self) -> Option<u32> {
+        self.max_resume_seconds
+    }
+
     pub fn has_unhandled_outbound_stanzas(&self) -> bool {
         !self.outbound_queue.is_empty()
     }
@@ -113,6 +124,8 @@ pub struct SmState {
     pub server_h: u32,
     /// Resumption token (`previd`) set after `<enabled/>` or `<resumed/>`.
     pub previd: Option<String>,
+    /// Advertised server resumption window in seconds, when the server supplied one.
+    pub max_resume_seconds: Option<u32>,
     /// Whether the outbound stanza counter has started for this session.
     ///
     /// XEP-0198 starts the sender's own counter immediately after sending
@@ -138,6 +151,7 @@ impl SmState {
             inbound_count: resume_state.inbound_h(),
             server_h: resume_state.outbound_h().wrapping_sub(queue_len),
             previd: Some(resume_state.previd().to_string()),
+            max_resume_seconds: resume_state.max_resume_seconds(),
             outbound_queue: resume_state.outbound_queue.clone(),
             ..Self::default()
         }
@@ -151,6 +165,7 @@ impl SmState {
                 self.outbound_count,
                 self.outbound_queue.clone(),
             )
+            .map(|state| state.with_max_resume_seconds(self.max_resume_seconds))
             .ok()
         })
     }
@@ -178,6 +193,7 @@ impl SmState {
     pub fn start_outbound(&mut self) {
         self.outbound_count = 0;
         self.server_h = 0;
+        self.max_resume_seconds = None;
         self.outbound_enabled = true;
         self.outbound_queue.clear();
         self.replay_in_flight.clear();
@@ -305,6 +321,15 @@ impl SmState {
         }
     }
 
+    /// Extract the advertised resumption window from a resumable `<enabled/>`.
+    pub fn parse_enabled_max(element: &Element) -> Option<u32> {
+        if Self::parse_enabled(element).is_some() {
+            element.attr("max")?.parse().ok()
+        } else {
+            None
+        }
+    }
+
     /// Extract the `h` value from an `<a h='...'/>` ack element.
     pub fn parse_ack_h(element: &Element) -> Option<u32> {
         if element.name() == "a" && element.ns() == NS_SM {
@@ -406,16 +431,20 @@ mod tests {
         let el = Element::builder("enabled", NS_SM)
             .attr(minidom::rxml::xml_ncname!("id").to_owned(), "abc123")
             .attr(minidom::rxml::xml_ncname!("resume").to_owned(), "true")
+            .attr(minidom::rxml::xml_ncname!("max").to_owned(), "300")
             .build();
         assert_eq!(SmState::parse_enabled(&el), Some("abc123".to_string()));
+        assert_eq!(SmState::parse_enabled_max(&el), Some(300));
     }
 
     #[test]
     fn parse_enabled_requires_resumable_response() {
         let el = Element::builder("enabled", NS_SM)
             .attr(minidom::rxml::xml_ncname!("id").to_owned(), "abc123")
+            .attr(minidom::rxml::xml_ncname!("max").to_owned(), "300")
             .build();
         assert_eq!(SmState::parse_enabled(&el), None);
+        assert_eq!(SmState::parse_enabled_max(&el), None);
 
         let el = Element::builder("enabled", NS_SM)
             .attr(minidom::rxml::xml_ncname!("id").to_owned(), "abc123")
@@ -618,6 +647,19 @@ mod tests {
         state.process_ack(1);
         let resume_state = state.resume_state().expect("resume state");
         assert!(!resume_state.has_unhandled_outbound_stanzas());
+    }
+
+    #[test]
+    fn resume_state_carries_advertised_max_resume_window() {
+        let mut state = SmState::new();
+        state.previd = Some("previous-stream".to_string());
+        state.max_resume_seconds = Some(300);
+
+        let resume_state = state.resume_state().expect("resume state");
+        assert_eq!(resume_state.max_resume_seconds(), Some(300));
+
+        let restored = SmState::from_resume_state(&resume_state);
+        assert_eq!(restored.max_resume_seconds, Some(300));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
@@ -272,6 +272,24 @@ impl InMemorySmSessionRegistry {
             return Ok(None);
         };
         if let Some(client_h) = client_h {
+            if !session.is_expired() && client_h > session.outbound_count {
+                let restored = {
+                    let mut claimed = self
+                        .claimed_sessions
+                        .write()
+                        .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+                    claimed.remove(stream_id)
+                };
+                if let Some(restored) = restored {
+                    let mut sessions = self
+                        .sessions
+                        .write()
+                        .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+                    sessions.insert(stream_id.to_string(), restored.clone());
+                    return Ok(Some(SmClaimCompletion::HandledCountTooHigh(restored)));
+                }
+                return Ok(None);
+            }
             if !session.is_expired() && !session.can_resume_from(client_h) {
                 let restored = {
                     let mut claimed = self

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
@@ -509,6 +509,9 @@ async fn test_claimed_session_remains_writable_for_handoff_fanout() {
         SmClaimCompletion::ReplayWindowTruncated(_) => {
             panic!("claim should still have a complete replay window")
         }
+        SmClaimCompletion::HandledCountTooHigh(_) => {
+            panic!("claim should not complete with a too-high client count")
+        }
     }
 }
 
@@ -577,6 +580,9 @@ async fn blocklist_interested_detached_resources_include_claimed_sessions_and_re
         SmClaimCompletion::ReplayWindowTruncated(_) => {
             panic!("claim should still have a complete replay window")
         }
+        SmClaimCompletion::HandledCountTooHigh(_) => {
+            panic!("claim should not complete with a too-high client count")
+        }
     }
 }
 
@@ -629,6 +635,41 @@ async fn complete_claim_releases_when_handoff_creates_replay_gap() {
         !restored.can_resume_from(0),
         "restored session must continue rejecting the stale h value"
     );
+}
+
+#[tokio::test]
+async fn complete_claim_releases_when_client_handled_count_is_too_high() {
+    let registry = InMemorySmSessionRegistry::new();
+    let mut session = make_test_session_with_unacked("stream-h-too-high", Vec::new());
+    session.outbound_count = 2;
+    session.last_acked = 0;
+
+    registry
+        .store_session(session)
+        .await
+        .expect("store session");
+    registry
+        .claim_session("stream-h-too-high")
+        .await
+        .expect("claim")
+        .expect("session exists");
+
+    let completed = registry
+        .complete_claim_if_resumable("stream-h-too-high", 3)
+        .await
+        .expect("complete checked claim")
+        .expect("claim still exists");
+    let SmClaimCompletion::HandledCountTooHigh(restored) = completed else {
+        panic!("client h higher than send-count must fail resume completion")
+    };
+    assert_eq!(restored.outbound_count, 2);
+
+    let restored = registry
+        .peek_session("stream-h-too-high")
+        .await
+        .expect("peek restored session")
+        .expect("invalid claim is restored to detached pool");
+    assert_eq!(restored.outbound_count, 2);
 }
 
 #[tokio::test]

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/traits.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/traits.rs
@@ -91,4 +91,5 @@ pub enum SmClaimCompletion {
     Resumed(DetachedSession),
     Expired(DetachedSession),
     ReplayWindowTruncated(DetachedSession),
+    HandledCountTooHigh(DetachedSession),
 }

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -525,6 +525,8 @@ export class WaddleConfig {
     with_resume_state(previd: string, inbound_h: number, outbound_h: number): void;
     with_resume_state_handle(state: WaddleResumeState): void;
     with_resume_state_stanzas(previd: string, inbound_h: number, outbound_h: number, stanzas: string[]): void;
+    with_resume_state_stanzas_with_max(previd: string, inbound_h: number, outbound_h: number, stanzas: string[], max_resume_seconds: number): void;
+    with_resume_state_with_max(previd: string, inbound_h: number, outbound_h: number, max_resume_seconds: number): void;
 }
 
 export class WaddleResumeState {

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=ac0aef689b4f";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=ac0aef689b4f";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=ac0aef689b4f";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=249854e38c23";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=249854e38c23";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=249854e38c23";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=ac0aef689b4f";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=249854e38c23";


### PR DESCRIPTION
## Summary

- preserve typed XMPP stream-error details through the WASM/client telemetry bridge so Faro reports `stream-handled-count-too-high` instead of a generic `stream-error`
- propagate XEP-0198 `<enabled max>` into browser-persisted SM resume state and expire stale localStorage snapshots using the server resume window instead of the old 24h browser TTL
- reject impossible resume counts during SM registration finalization with the same terminal `<handled-count-too-high/>` stream error as the direct resume path
- harden persisted SM validation for u32 counters and future-dated snapshots, with compatibility coverage for newer and older WASM resume config methods

## Plan

- Review XEP-0198 in `./xeps` before changing resume behavior.
- Trace the browser `xmpp.stream` stream-error path from WASM through `client.ts` and `xmpp-instrumentation.ts`.
- Preserve structured stream-error and stream-management details for observability without adding non-XMPP control semantics.
- Align browser SM persistence with the server-advertised resume window and keep fallback behavior for older generated WASM bundles.
- Harden the server resume-claim finalization race so impossible client handled counts close the stream with the conformant XEP-0198 error.
- Add focused browser, WASM, native client, and server tests.
- Run adversarial protocol and browser/runtime reviews until no real actionable issues remain.

## Validation

- `bun test tests/xmpp-telemetry.test.ts`
- `bun test tests/resume-persistence.test.ts`
- `bun test`
- `nix develop ..#default --command bunx astro check`
- `nix develop ..#default --command bun run lint`
- `nix develop ..#default --command cargo fmt --check`
- `nix develop ..#default --command cargo test -p waddle-xmpp -p waddle-xmpp-client -p waddle-xmpp-client-wasm -p waddle-server --lib`
- `nix develop ..#default --command cargo clippy -p waddle-xmpp -p waddle-xmpp-client -p waddle-xmpp-client-wasm -p waddle-server --all-targets -- -D warnings`
- `nix develop ..#default --command cargo check -p waddle-xmpp-client --target wasm32-unknown-unknown`
- `nix develop ..#default --command cargo check -p waddle-xmpp-client-wasm --target wasm32-unknown-unknown`

## Review

- Protocol/XEP-0198 adversarial review: no real actionable issues remain.
- Browser/runtime adversarial review: no real actionable issues remain.

## Notes

- `bun install --force` was needed locally to refresh stale Tiptap/ProseMirror symlinks before the full chat test suite and Astro check would reflect the lockfile.
- Existing residual protocol cleanup, not part of this regression fix: server-side client `<enable max='0'/>` handling appears permissive even though XEP-0198 defines `max` as positive.
