### PR TITLE
Live story reaction summary pushes

### DIFF
--- a/.omx/plans/issue-875-live-reaction-push.md
+++ b/.omx/plans/issue-875-live-reaction-push.md
@@ -1,0 +1,8 @@
+# Issue 875 TDD Plan
+
+- Server WS integration: subscribed member receives summary-node fan-out when another member reacts.
+- Server implementation: summary republish flows through normal PubSub fan-out.
+- Rust client/WASM: generic typed pubsub-event parser and callback union, preserving unknown payloads opaquely.
+- Chat client: route summary events by node URI into the story reaction store.
+- Connect bootstrap: fetch summary-node catch-up, then subscribe once service-wide.
+- Verification: focused tests per slice, then chat test/lint and server clippy/tests.

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -153,6 +153,7 @@ import type {
   WasmPepProfile,
   WasmPinEvent,
   WasmPresence,
+  WasmPubsubEvent,
   WasmRoomMember,
   WasmRosterContact,
   WasmServerVersion,
@@ -605,6 +606,7 @@ type XmppClientInstance = Partial<WasmClient> & CompatEmitter & {
   set_on_call?: (cb: (event: CallEvent) => void) => void;
   set_on_session_lifecycle?: (cb: (event: string) => void) => void;
   set_on_mds_displayed?: (cb: (entry: WasmMdsDisplayedEntry) => void) => void;
+  set_on_pubsub_event?: (cb: (event: WasmPubsubEvent) => void) => void;
   get_resume_state?: () => XmppResumeState | null;
   get_resume_state_handle?: () => XmppResumeStateHandle | undefined;
   publish_mds_displayed?: (chatId: string, stanzaId: string, stanzaIdBy: string) => Promise<void>;
@@ -659,6 +661,8 @@ interface MdsDisplayedEntry {
   /** JID that injected the stanza-id (room for MUC, user's server for DM). */
   stanzaIdBy: string;
 }
+
+export type PubsubEvent = WasmPubsubEvent;
 
 export type XmppResumeState = {
   previd: string;
@@ -733,6 +737,7 @@ export class BrowserXmppClient {
   private reactionHandler: ((event: ReactionEvent) => void) | null = null;
   private displayedHandler: ((event: { roomJid: string; nick: string; messageId: string }) => void) | null = null;
   private mdsDisplayedHandler: ((entry: MdsDisplayedEntry) => void) | null = null;
+  private pubsubEventHandlers = new Set<(event: PubsubEvent) => void>();
   private chatStateHandler: ((event: ChatStateEvent) => void) | null = null;
   private dmChatStateHandler: ((event: DmChatStateEvent) => void) | null = null;
   private dmReactionHandler: ((event: DmReactionEvent) => void) | null = null;
@@ -1876,6 +1881,28 @@ export class BrowserXmppClient {
   }
 
   setMdsDisplayedHandler(handler: ((entry: MdsDisplayedEntry) => void) | null) { this.mdsDisplayedHandler = handler; }
+
+  async subscribeStoryReactionSummaries(communityJid: string): Promise<void> {
+    const xmpp = await this.requireConnectedXmpp();
+    if (typeof xmpp.send_raw_iq !== "function") return;
+    try {
+      await xmpp.send_raw_iq(
+        `<iq type="set" id="${crypto.randomUUID()}" to="${escapeXml(communityJid)}"><pubsub xmlns="${NS_PUBSUB}"><subscribe node="${escapeXml(STORY_REACTIONS_SUMMARY_NODE)}" jid="${escapeXml(barePeerJid(this.session.jid))}"/></pubsub></iq>`,
+      );
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  addPubsubEventHandler(handler: (event: PubsubEvent) => void): () => void {
+    this.pubsubEventHandlers.add(handler);
+    return () => this.pubsubEventHandlers.delete(handler);
+  }
+
+  setPubsubEventHandler(handler: ((event: PubsubEvent) => void) | null) {
+    this.pubsubEventHandlers.clear();
+    if (handler) this.pubsubEventHandlers.add(handler);
+  }
 
   private async resolveUploadService(): Promise<string> {
     if (this.uploadServiceJid) return this.uploadServiceJid;
@@ -3564,6 +3591,10 @@ export class BrowserXmppClient {
     xmpp.set_on_mds_displayed?.((entry: WasmMdsDisplayedEntry) => {
       if (!this.isCurrentXmpp(xmpp)) return;
       this.mdsDisplayedHandler?.({ chatId: entry.chat_id, stanzaId: entry.stanza_id, stanzaIdBy: entry.stanza_id_by });
+    });
+    xmpp.set_on_pubsub_event?.((event: WasmPubsubEvent) => {
+      if (!this.isCurrentXmpp(xmpp)) return;
+      for (const handler of this.pubsubEventHandlers) handler(event);
     });
     xmpp.set_on_call?.((event: CallEvent) => {
       if (!this.isCurrentXmpp(xmpp)) return;

--- a/chat/src/lib/xmpp/index.ts
+++ b/chat/src/lib/xmpp/index.ts
@@ -7,6 +7,7 @@ export type {
   AdminUsersPage,
   DmBookmarkItem,
   NotifyMode,
+  PubsubEvent,
   SetDmNotificationModeResult,
   SetRoomNotificationModeOutcome,
   UserBookmarkItem,
@@ -40,6 +41,7 @@ export {
   isStoryActive,
   normalizeStoryReactions,
   STORY_REACTIONS_MAX,
+  STORY_REACTIONS_SUMMARY_NODE,
 } from "./story-types";
 export type { StoryRead, StoryReads } from "./story-reads-types";
 export {

--- a/chat/src/lib/xmpp/wasm-types.ts
+++ b/chat/src/lib/xmpp/wasm-types.ts
@@ -392,6 +392,26 @@ export interface WasmMdsDisplayedEntry {
   stanza_id_by: string;
 }
 
+export interface WasmPubsubEvent {
+  from?: string;
+  node: string;
+  items: WasmPubsubEventItem[];
+}
+
+interface WasmPubsubEventItem {
+  id?: string;
+  payload: WasmPubsubEventPayload;
+}
+
+type WasmPubsubEventPayload =
+  | {
+      kind: "attachmentSummary";
+      reactions: Array<{ emoji: string; count: number; reactors: string[] }>;
+      noticedCount?: number;
+    }
+  | { kind: "opaque"; xml: string }
+  | { kind: "empty" };
+
 /** Options for send_groupchat_message / send_chat_message. */
 export interface WasmSendOptions {
   stanza_id?: string;

--- a/chat/src/services/stories.ts
+++ b/chat/src/services/stories.ts
@@ -10,12 +10,14 @@
  * forget; publishing your own story auto-marks it so other devices
  * don't show it as unread.
  */
-import { computed, onScopeDispose, ref, type Ref } from "vue";
+import { computed, onScopeDispose, ref, watch, type Ref } from "vue";
 import {
   isStoryActive,
   normalizeStoryReactions,
   STORY_REACTIONS_MAX,
+  STORY_REACTIONS_SUMMARY_NODE,
   type BrowserXmppClient,
+  type PubsubEvent,
   type Story,
   type StoryPostInput,
   type StoryReactionItem,
@@ -44,7 +46,9 @@ export function useStories(
   const reactionSummariesByStory = ref<Record<string, StoryReactionSummary>>({});
   const pageSize = options.pageSize ?? 50;
   let fetchRequestId = 0;
+  let removePubsubEventHandler: (() => void) | null = null;
   const reactionMutationVersionsByStory = new Map<string, number>();
+  const pendingReactionMutationVersionsByStory = new Map<string, number>();
   const nowMs = ref(Date.now());
   const tickHandle = setInterval(() => {
     nowMs.value = Date.now();
@@ -58,8 +62,16 @@ export function useStories(
 
   onScopeDispose(() => {
     clearInterval(tickHandle);
+    removePubsubEventHandler?.();
     readStore.dispose();
   });
+
+  watch([xmppClient, options.communityJid], ([client, communityJid]) => {
+    removePubsubEventHandler?.();
+    removePubsubEventHandler = null;
+    if (!client || !communityJid) return;
+    removePubsubEventHandler = client.addPubsubEventHandler?.((event) => applyPubsubEvent(event)) ?? null;
+  }, { immediate: true });
 
   const activeStories = computed(() => {
     const live = stories.value.filter((s) => isStoryActive(s, nowMs.value));
@@ -92,7 +104,9 @@ export function useStories(
       const fetched = await client.fetchStories(jid, pageSize);
       if (requestId !== fetchRequestId || client !== xmppClient.value) return false;
       stories.value = fetched;
-      await refreshReactionSummariesFor(fetched, client, jid, requestId);
+      const mutationVersions = new Map(reactionMutationVersionsByStory);
+      await client.subscribeStoryReactionSummaries?.(jid);
+      await refreshReactionSummariesFor(fetched, client, jid, requestId, mutationVersions);
       if (!readStore.loaded()) {
         // Hydrate after the first stories fetch so the rail doesn't
         // pop unread→read on first paint.
@@ -140,8 +154,8 @@ export function useStories(
     client: BrowserXmppClient,
     communityJid: string,
     requestId: number,
+    mutationVersions: ReadonlyMap<string, number>,
   ): Promise<void> {
-    const mutationVersions = new Map(reactionMutationVersionsByStory);
     const entries: Array<readonly [string, StoryReactionSummary, StoryReactionItem | null]> = [];
     for (let offset = 0; offset < fetched.length; offset += REACTION_FETCH_BATCH_SIZE) {
       if (requestId !== fetchRequestId || client !== xmppClient.value) return;
@@ -221,6 +235,45 @@ export function useStories(
     return reactionSummariesByStory.value[storyId] ?? { counts: {}, reactors: {}, mine: [] };
   }
 
+  function applyPubsubEvent(event: PubsubEvent): void {
+    if (event.node !== STORY_REACTIONS_SUMMARY_NODE) return;
+    const communityJid = options.communityJid.value?.toLowerCase();
+    const eventFrom = event.from?.split("/", 1)[0]?.toLowerCase();
+    if (!communityJid || eventFrom !== communityJid) return;
+    const updates: Record<string, StoryReactionSummary> = {};
+    for (const item of event.items) {
+      if (!item.id || item.payload.kind !== "attachmentSummary") continue;
+      const serverCounts: Record<string, number> = {};
+      const reactors: Record<string, string[]> = {};
+      const serverSelfEmojis: string[] = [];
+      const selfKey = xmppClient.value?.bareJid?.toLowerCase();
+      for (const reaction of item.payload.reactions) {
+        if (!reaction.emoji || reaction.count <= 0) continue;
+        serverCounts[reaction.emoji] = reaction.count;
+        reactors[reaction.emoji] = reaction.reactors;
+        if (selfKey && reaction.reactors.some((reactor) => reactor.toLowerCase() === selfKey)) {
+          serverSelfEmojis.push(reaction.emoji);
+        }
+      }
+      const hasKnownSelfState = Object.prototype.hasOwnProperty.call(reactionsByStory.value, item.id);
+      const hasLocalMutation = pendingReactionMutationVersionsByStory.has(item.id);
+      const currentSelfEmojis = selfKey && hasKnownSelfState && hasLocalMutation
+        ? reactionsByStory.value[item.id]?.find((reaction) => reaction.jid.toLowerCase() === selfKey)?.emojis ?? []
+        : undefined;
+      const mine = currentSelfEmojis ?? reactionSummariesByStory.value[item.id]?.mine ?? [];
+      updates[item.id] = {
+        counts: currentSelfEmojis !== undefined
+          ? applySelfReactionDelta(serverCounts, serverSelfEmojis, currentSelfEmojis)
+          : serverCounts,
+        reactors,
+        mine,
+        ...(typeof item.payload.noticedCount === "number" ? { noticedCount: item.payload.noticedCount } : {}),
+      };
+    }
+    if (Object.keys(updates).length === 0) return;
+    reactionSummariesByStory.value = { ...reactionSummariesByStory.value, ...updates };
+  }
+
   async function toggleReaction(storyId: string, emoji: string): Promise<boolean> {
     const client = xmppClient.value;
     const jid = options.communityJid.value;
@@ -242,6 +295,7 @@ export function useStories(
 
     const mutationVersion = (reactionMutationVersionsByStory.get(storyId) ?? 0) + 1;
     reactionMutationVersionsByStory.set(storyId, mutationVersion);
+    pendingReactionMutationVersionsByStory.set(storyId, mutationVersion);
     const previousSummary = reactionSummariesByStory.value[storyId] ?? { counts: {}, reactors: {}, mine: [] };
     reactionSummariesByStory.value = {
       ...reactionSummariesByStory.value,
@@ -254,8 +308,14 @@ export function useStories(
       } else {
         await client.retractStoryReactions(jid, storyId);
       }
+      if (pendingReactionMutationVersionsByStory.get(storyId) === mutationVersion) {
+        pendingReactionMutationVersionsByStory.delete(storyId);
+      }
       return true;
     } catch (err) {
+      if (pendingReactionMutationVersionsByStory.get(storyId) === mutationVersion) {
+        pendingReactionMutationVersionsByStory.delete(storyId);
+      }
       if (reactionMutationVersionsByStory.get(storyId) === mutationVersion) {
         reactionsByStory.value = { ...reactionsByStory.value, [storyId]: previousItems };
         reactionSummariesByStory.value = {
@@ -274,6 +334,7 @@ export function useStories(
     reactionsByStory.value = {};
     reactionSummariesByStory.value = {};
     reactionMutationVersionsByStory.clear();
+    pendingReactionMutationVersionsByStory.clear();
     error.value = null;
     isLoading.value = false;
     isPosting.value = false;

--- a/chat/src/services/stories.ts
+++ b/chat/src/services/stories.ts
@@ -49,6 +49,7 @@ export function useStories(
   let removePubsubEventHandler: (() => void) | null = null;
   const reactionMutationVersionsByStory = new Map<string, number>();
   const pendingReactionMutationVersionsByStory = new Map<string, number>();
+  const liveSummaryVersionsByStory = new Map<string, number>();
   const nowMs = ref(Date.now());
   const tickHandle = setInterval(() => {
     nowMs.value = Date.now();
@@ -105,8 +106,9 @@ export function useStories(
       if (requestId !== fetchRequestId || client !== xmppClient.value) return false;
       stories.value = fetched;
       const mutationVersions = new Map(reactionMutationVersionsByStory);
+      const liveSummaryVersions = new Map(liveSummaryVersionsByStory);
       await client.subscribeStoryReactionSummaries?.(jid);
-      await refreshReactionSummariesFor(fetched, client, jid, requestId, mutationVersions);
+      await refreshReactionSummariesFor(fetched, client, jid, requestId, mutationVersions, liveSummaryVersions);
       if (!readStore.loaded()) {
         // Hydrate after the first stories fetch so the rail doesn't
         // pop unread→read on first paint.
@@ -155,6 +157,7 @@ export function useStories(
     communityJid: string,
     requestId: number,
     mutationVersions: ReadonlyMap<string, number>,
+    liveSummaryVersions: ReadonlyMap<string, number>,
   ): Promise<void> {
     const entries: Array<readonly [string, StoryReactionSummary, StoryReactionItem | null]> = [];
     for (let offset = 0; offset < fetched.length; offset += REACTION_FETCH_BATCH_SIZE) {
@@ -177,7 +180,7 @@ export function useStories(
       ));
     }
     if (requestId !== fetchRequestId || client !== xmppClient.value) return;
-    const { summaries, selfItems } = mergedReactionSummaryEntries(entries, mutationVersions, client.bareJid);
+    const { summaries, selfItems } = mergedReactionSummaryEntries(entries, mutationVersions, liveSummaryVersions, client.bareJid);
     reactionSummariesByStory.value = summaries;
     reactionsByStory.value = selfItems;
   }
@@ -185,16 +188,29 @@ export function useStories(
   function mergedReactionSummaryEntries(
     entries: Array<readonly [string, StoryReactionSummary, StoryReactionItem | null]>,
     mutationVersions: ReadonlyMap<string, number>,
+    liveSummaryVersions: ReadonlyMap<string, number>,
     self: string | null | undefined,
   ): { summaries: Record<string, StoryReactionSummary>; selfItems: Record<string, StoryReactionItem[]> } {
     if (!self) {
       return {
-        summaries: Object.fromEntries(entries.map(([storyId, fetchedSummary]) => [storyId, fetchedSummary])),
+        summaries: Object.fromEntries(entries.map(([storyId, fetchedSummary]) => [
+          storyId,
+          hasNewerLiveSummary(storyId, liveSummaryVersions)
+            ? reactionSummariesByStory.value[storyId] ?? fetchedSummary
+            : fetchedSummary,
+        ])),
         selfItems: {},
       };
     }
     const selfKey = self.toLowerCase();
     const pairs = entries.map(([storyId, fetchedSummary, fetchedSelf]) => {
+        if (hasNewerLiveSummary(storyId, liveSummaryVersions)) {
+          return [
+            storyId,
+            reactionSummariesByStory.value[storyId] ?? fetchedSummary,
+            reactionsByStory.value[storyId] ?? [],
+          ] satisfies [string, StoryReactionSummary, StoryReactionItem[]];
+        }
         if (mutationVersions.get(storyId) === reactionMutationVersionsByStory.get(storyId)) {
           const selfItems = fetchedSelf ? [fetchedSelf] : [];
           return [storyId, { ...fetchedSummary, mine: fetchedSelf?.emojis ?? [] }, selfItems] satisfies [string, StoryReactionSummary, StoryReactionItem[]];
@@ -212,6 +228,10 @@ export function useStories(
       summaries: Object.fromEntries(pairs.map(([storyId, summary]) => [storyId, summary])),
       selfItems: Object.fromEntries(pairs.map(([storyId, , selfItems]) => [storyId, selfItems])),
     };
+  }
+
+  function hasNewerLiveSummary(storyId: string, liveSummaryVersions: ReadonlyMap<string, number>): boolean {
+    return (liveSummaryVersionsByStory.get(storyId) ?? 0) !== (liveSummaryVersions.get(storyId) ?? 0);
   }
 
   function applySelfReactionDelta(
@@ -260,7 +280,7 @@ export function useStories(
       const currentSelfEmojis = selfKey && hasKnownSelfState && hasLocalMutation
         ? reactionsByStory.value[item.id]?.find((reaction) => reaction.jid.toLowerCase() === selfKey)?.emojis ?? []
         : undefined;
-      const mine = currentSelfEmojis ?? reactionSummariesByStory.value[item.id]?.mine ?? [];
+      const mine = currentSelfEmojis ?? serverSelfEmojis;
       updates[item.id] = {
         counts: currentSelfEmojis !== undefined
           ? applySelfReactionDelta(serverCounts, serverSelfEmojis, currentSelfEmojis)
@@ -269,6 +289,16 @@ export function useStories(
         mine,
         ...(typeof item.payload.noticedCount === "number" ? { noticedCount: item.payload.noticedCount } : {}),
       };
+      liveSummaryVersionsByStory.set(item.id, (liveSummaryVersionsByStory.get(item.id) ?? 0) + 1);
+      if (selfKey && !hasLocalMutation) {
+        const others = (reactionsByStory.value[item.id] ?? []).filter((reaction) => reaction.jid.toLowerCase() !== selfKey);
+        reactionsByStory.value = {
+          ...reactionsByStory.value,
+          [item.id]: mine.length > 0
+            ? [...others, { jid: xmppClient.value?.bareJid ?? selfKey, emojis: mine, unknownChildrenXml: [] }]
+            : others,
+        };
+      }
     }
     if (Object.keys(updates).length === 0) return;
     reactionSummariesByStory.value = { ...reactionSummariesByStory.value, ...updates };
@@ -335,6 +365,7 @@ export function useStories(
     reactionSummariesByStory.value = {};
     reactionMutationVersionsByStory.clear();
     pendingReactionMutationVersionsByStory.clear();
+    liveSummaryVersionsByStory.clear();
     error.value = null;
     isLoading.value = false;
     isPosting.value = false;

--- a/chat/tests/stories.test.ts
+++ b/chat/tests/stories.test.ts
@@ -192,7 +192,7 @@ describe("useStories", () => {
         id: "s1",
         payload: {
           kind: "attachmentSummary",
-          reactions: [{ emoji: "🎉", count: 4, reactors: ["bob@example.com"] }],
+          reactions: [{ emoji: "🎉", count: 4, reactors: ["alice@example.com", "bob@example.com"] }],
           noticedCount: 3,
         },
       }],
@@ -200,8 +200,8 @@ describe("useStories", () => {
 
     expect(story.reactionSummary("s1")).toEqual({
       counts: { "🎉": 4 },
-      reactors: { "🎉": ["bob@example.com"] },
-      mine: ["❤️"],
+      reactors: { "🎉": ["alice@example.com", "bob@example.com"] },
+      mine: ["🎉"],
       noticedCount: 3,
     });
 
@@ -269,7 +269,39 @@ describe("useStories", () => {
     });
 
     expect(story.reactionSummary("s1").counts).toEqual({ "🔥": 1 });
-    expect(story.reactionSummary("s1").mine).toEqual(["❤️", "👍"]);
+    expect(story.reactionSummary("s1").mine).toEqual([]);
+  });
+
+  test("live summary pubsub event is not clobbered by in-flight refresh results", async () => {
+    let resolveSummary!: (summary: StoryReactionSummary) => void;
+    const pendingSummary = new Promise<StoryReactionSummary>((resolve) => {
+      resolveSummary = resolve;
+    });
+    const client = makeClient([{ id: "s1", body: "story", postedMs: 1 }]);
+    client.fetchStoryReactionSummary = mock(() => pendingSummary) as unknown as MockClient["fetchStoryReactionSummary"];
+    client.fetchMyStoryReactions = mock(() => Promise.resolve(null)) as unknown as MockClient["fetchMyStoryReactions"];
+    const story = withScope(() =>
+      useStories(ref<BrowserXmppClient | null>(client), { communityJid: ref<string | null>(COMMUNITY) }),
+    );
+
+    const refresh = story.refresh();
+    await Promise.resolve();
+    client.emitPubsubEvent({
+      from: COMMUNITY,
+      node: "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:stories:0",
+      items: [{
+        id: "s1",
+        payload: {
+          kind: "attachmentSummary",
+          reactions: [{ emoji: "🔥", count: 2, reactors: ["bob@example.com"] }],
+        },
+      }],
+    });
+    resolveSummary({ counts: { "👍": 1 }, reactors: {}, mine: [] });
+    await refresh;
+
+    expect(story.reactionSummary("s1").counts).toEqual({ "🔥": 2 });
+    expect(story.reactionSummary("s1").mine).toEqual([]);
   });
 
   test("pubsub event handlers are additive and scope cleanup removes only its handler", async () => {

--- a/chat/tests/stories.test.ts
+++ b/chat/tests/stories.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import { effectScope, ref } from "vue";
 import { useStories } from "../src/services/stories";
-import type { BrowserXmppClient, Story, StoryReactionItem, StoryReactionSummary } from "../src/lib/xmpp-client";
+import type { BrowserXmppClient, PubsubEvent, Story, StoryReactionItem, StoryReactionSummary } from "../src/lib/xmpp-client";
 
 const COMMUNITY = "community.example.com";
 
@@ -13,6 +13,10 @@ type MockClient = BrowserXmppClient & {
   fetchStoryReactionSummary: ReturnType<typeof mock>;
   publishStoryReactions: ReturnType<typeof mock>;
   retractStoryReactions: ReturnType<typeof mock>;
+  subscribeStoryReactionSummaries: ReturnType<typeof mock>;
+  setPubsubEventHandler: ReturnType<typeof mock>;
+  addPubsubEventHandler: ReturnType<typeof mock>;
+  emitPubsubEvent: (event: PubsubEvent) => void;
   bareJid: string;
 };
 
@@ -24,6 +28,7 @@ function makeClient(stories: Story[] = []): MockClient {
   const reactionSummary = (storyId: string): StoryReactionSummary => storyId === "s1"
     ? { counts: { "👍": 1, "❤️": 1 }, reactors: {}, mine: [] }
     : { counts: {}, reactors: {}, mine: [] };
+  const pubsubEventHandlers = new Set<(event: PubsubEvent) => void>();
   const client = {
     bareJid: "alice@example.com",
     fetchStories: mock(() => Promise.resolve(stories)),
@@ -33,6 +38,18 @@ function makeClient(stories: Story[] = []): MockClient {
     ),
     publishStoryReactions: mock(() => Promise.resolve()),
     retractStoryReactions: mock(() => Promise.resolve()),
+    subscribeStoryReactionSummaries: mock(() => Promise.resolve()),
+    setPubsubEventHandler: mock((handler: ((event: PubsubEvent) => void) | null) => {
+      pubsubEventHandlers.clear();
+      if (handler) pubsubEventHandlers.add(handler);
+    }),
+    addPubsubEventHandler: mock((handler: (event: PubsubEvent) => void) => {
+      pubsubEventHandlers.add(handler);
+      return () => pubsubEventHandlers.delete(handler);
+    }),
+    emitPubsubEvent: (event: PubsubEvent) => {
+      for (const handler of pubsubEventHandlers) handler(event);
+    },
     publishStory: mock((_jid: string, input: { body?: string; mediaUrl?: string; author?: string }) =>
       Promise.resolve({
         id: "new-story",
@@ -151,6 +168,7 @@ describe("useStories", () => {
     await story.refresh();
 
     expect(client.fetchStoryReactionSummary).toHaveBeenCalledWith(COMMUNITY, "s1");
+    expect(client.subscribeStoryReactionSummaries).toHaveBeenCalledWith(COMMUNITY);
     expect(client.fetchStoryReactions).not.toHaveBeenCalled();
     expect(story.reactionSummary("s1")).toEqual({
       counts: { "👍": 3 },
@@ -158,6 +176,166 @@ describe("useStories", () => {
       mine: [],
       noticedCount: 2,
     });
+  });
+
+  test("typed summary pubsub event updates the story reaction store", async () => {
+    const client = makeClient([{ id: "s1", body: "story", postedMs: 1 }]);
+    const story = withScope(() =>
+      useStories(ref<BrowserXmppClient | null>(client), { communityJid: ref<string | null>(COMMUNITY) }),
+    );
+    await story.refresh();
+
+    client.emitPubsubEvent({
+      from: COMMUNITY,
+      node: "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:stories:0",
+      items: [{
+        id: "s1",
+        payload: {
+          kind: "attachmentSummary",
+          reactions: [{ emoji: "🎉", count: 4, reactors: ["bob@example.com"] }],
+          noticedCount: 3,
+        },
+      }],
+    });
+
+    expect(story.reactionSummary("s1")).toEqual({
+      counts: { "🎉": 4 },
+      reactors: { "🎉": ["bob@example.com"] },
+      mine: ["❤️"],
+      noticedCount: 3,
+    });
+
+    client.emitPubsubEvent({
+      from: COMMUNITY,
+      node: "urn:example:unrelated",
+      items: [{ id: "s1", payload: { kind: "opaque", xml: "<future/>" } }],
+    });
+    expect(story.reactionSummary("s1").counts).toEqual({ "🎉": 4 });
+  });
+
+  test("typed summary pubsub event preserves pending optimistic self reactions", async () => {
+    let resolvePublish!: () => void;
+    const pendingPublish = new Promise<void>((resolve) => {
+      resolvePublish = resolve;
+    });
+    const client = makeClient([{ id: "s1", body: "story", postedMs: 1 }]);
+    client.publishStoryReactions = mock(() => pendingPublish) as unknown as MockClient["publishStoryReactions"];
+    const story = withScope(() =>
+      useStories(ref<BrowserXmppClient | null>(client), { communityJid: ref<string | null>(COMMUNITY) }),
+    );
+    await story.refresh();
+    const toggle = story.toggleReaction("s1", "👍");
+    await Promise.resolve();
+
+    client.emitPubsubEvent({
+      from: COMMUNITY,
+      node: "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:stories:0",
+      items: [{
+        id: "s1",
+        payload: {
+          kind: "attachmentSummary",
+          reactions: [
+            { emoji: "❤️", count: 1, reactors: ["alice@example.com"] },
+            { emoji: "🔥", count: 1, reactors: ["bob@example.com"] },
+          ],
+        },
+      }],
+    });
+
+    expect(story.reactionSummary("s1").counts).toEqual({ "❤️": 1, "🔥": 1, "👍": 1 });
+    expect(story.reactionSummary("s1").mine).toEqual(["❤️", "👍"]);
+    resolvePublish();
+    await toggle;
+  });
+
+  test("typed summary pubsub event uses canonical counts after local publish settles", async () => {
+    const client = makeClient([{ id: "s1", body: "story", postedMs: 1 }]);
+    const story = withScope(() =>
+      useStories(ref<BrowserXmppClient | null>(client), { communityJid: ref<string | null>(COMMUNITY) }),
+    );
+    await story.refresh();
+    await story.toggleReaction("s1", "👍");
+
+    client.emitPubsubEvent({
+      from: COMMUNITY,
+      node: "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:stories:0",
+      items: [{
+        id: "s1",
+        payload: {
+          kind: "attachmentSummary",
+          reactions: [{ emoji: "🔥", count: 1, reactors: ["bob@example.com"] }],
+        },
+      }],
+    });
+
+    expect(story.reactionSummary("s1").counts).toEqual({ "🔥": 1 });
+    expect(story.reactionSummary("s1").mine).toEqual(["❤️", "👍"]);
+  });
+
+  test("pubsub event handlers are additive and scope cleanup removes only its handler", async () => {
+    const client = makeClient([{ id: "s1", body: "story", postedMs: 1 }]);
+    const firstScope = effectScope();
+    const secondScope = effectScope();
+    const first = firstScope.run(() =>
+      useStories(ref<BrowserXmppClient | null>(client), { communityJid: ref<string | null>(COMMUNITY) }),
+    )!;
+    const second = secondScope.run(() =>
+      useStories(ref<BrowserXmppClient | null>(client), { communityJid: ref<string | null>(COMMUNITY) }),
+    )!;
+    await first.refresh();
+    await second.refresh();
+
+    client.emitPubsubEvent({
+      from: COMMUNITY,
+      node: "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:stories:0",
+      items: [{
+        id: "s1",
+        payload: {
+          kind: "attachmentSummary",
+          reactions: [{ emoji: "🎉", count: 2, reactors: [] }],
+        },
+      }],
+    });
+    expect(first.reactionSummary("s1").counts).toEqual({ "🎉": 2 });
+    expect(second.reactionSummary("s1").counts).toEqual({ "🎉": 2 });
+
+    firstScope.stop();
+    client.emitPubsubEvent({
+      from: COMMUNITY,
+      node: "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:stories:0",
+      items: [{
+        id: "s1",
+        payload: {
+          kind: "attachmentSummary",
+          reactions: [{ emoji: "🔥", count: 1, reactors: [] }],
+        },
+      }],
+    });
+    expect(first.reactionSummary("s1").counts).toEqual({ "🎉": 2 });
+    expect(second.reactionSummary("s1").counts).toEqual({ "🔥": 1 });
+    secondScope.stop();
+  });
+
+  test("summary pubsub events are scoped to the active community", async () => {
+    const client = makeClient([{ id: "s1", body: "story", postedMs: 1 }]);
+    const story = withScope(() =>
+      useStories(ref<BrowserXmppClient | null>(client), { communityJid: ref<string | null>(COMMUNITY) }),
+    );
+    await story.refresh();
+
+    client.emitPubsubEvent({
+      from: "other.example.com",
+      node: "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:stories:0",
+      items: [{
+        id: "s1",
+        payload: {
+          kind: "attachmentSummary",
+          reactions: [{ emoji: "🔥", count: 9, reactors: [] }],
+        },
+      }],
+    });
+
+    expect(story.reactionSummary("s1").counts).toEqual({ "👍": 1, "❤️": 1 });
   });
 
   test("stale reaction refresh results do not overwrite newer refresh state", async () => {
@@ -178,7 +356,10 @@ describe("useStories", () => {
       useStories(ref<BrowserXmppClient | null>(client), { communityJid: ref<string | null>(COMMUNITY) }),
     );
     const first = story.refresh();
-    await Promise.resolve();
+    for (let i = 0; i < 5 && reactionFetchCount === 0; i += 1) {
+      await Promise.resolve();
+    }
+    expect(reactionFetchCount).toBe(1);
     const second = story.refresh();
     await second;
     expect(story.reactionSummary("s1").counts).toEqual({ "🎉": 1 });

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
@@ -1209,7 +1209,7 @@ async fn update_story_attachment_summary(
         Some(waddle_xmpp::xep::xep0470::build_summary_element(&summary)),
     );
     let summary_node = story_attachment_summary_node();
-    storage
+    let result = storage
         .publish_item(
             community_jid,
             &summary_node,
@@ -1219,6 +1219,19 @@ async fn update_story_attachment_summary(
         )
         .await
         .map_err(|_| PubSubError::InternalServerError)?;
+    pubsub_fanout::fan_out_publish(
+        state,
+        pubsub_fanout::FanOutRequest {
+            owner: community_jid,
+            node: &summary_node,
+            published_item: &summary_item,
+            item_id: &result.item_id,
+            publisher: Some(community_jid),
+            publisher_full: None,
+            is_pep: false,
+        },
+    )
+    .await;
     Ok(())
 }
 
@@ -1704,6 +1717,17 @@ async fn handle_community_non_bookmark_publish(
         .await
     {
         Ok(result) => {
+            if node == waddle_xmpp_core::xep0501::PUBSUB_NODE_STORIES {
+                if let Err(error) =
+                    ensure_story_attachment_summary_node(state, &community_jid).await
+                {
+                    warn!(
+                        node,
+                        error = ?error,
+                        "Failed to ensure story attachment summary node after story publish"
+                    );
+                }
+            }
             pubsub_fanout::fan_out_publish(
                 state,
                 pubsub_fanout::FanOutRequest {

--- a/server/crates/waddle-server/tests/xep0470_story_reactions_ws.rs
+++ b/server/crates/waddle-server/tests/xep0470_story_reactions_ws.rs
@@ -13,6 +13,7 @@ const DOMAIN: &str = "localhost";
 const COMMUNITY_JID: &str = "community.localhost";
 const STORIES_NODE: &str = "urn:xmpp:stories:0";
 const NS_PUBSUB: &str = "http://jabber.org/protocol/pubsub";
+const NS_PUBSUB_EVENT: &str = "http://jabber.org/protocol/pubsub#event";
 const NS_STORIES: &str = "urn:xmpp:stories:0";
 const NS_ATTACHMENTS: &str = "urn:xmpp:pubsub-attachments:1";
 const NS_ATTACHMENTS_SUMMARY: &str = "urn:xmpp:pubsub-attachments:summary:1";
@@ -55,6 +56,32 @@ fn story_attachment_node(story_id: &str) -> String {
     format!(
         "{NS_ATTACHMENTS}/xmpp:community.localhost?;node=urn%3Axmpp%3Astories%3A0;item={story_id}"
     )
+}
+
+async fn wait_for_event_message(
+    client: &mut WsXmppClient,
+    node: &str,
+    dur: std::time::Duration,
+) -> Option<String> {
+    let deadline = std::time::Instant::now() + dur;
+    loop {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            return None;
+        }
+        match client.recv_timeout(remaining).await {
+            Ok(frame) => {
+                let is_event_msg = frame.contains("<message")
+                    && frame.contains(NS_PUBSUB_EVENT)
+                    && (frame.contains(&format!(r#"node='{node}'"#))
+                        || frame.contains(&format!(r#"node="{node}""#)));
+                if is_event_msg {
+                    return Some(frame);
+                }
+            }
+            Err(_) => return None,
+        }
+    }
 }
 
 #[tokio::test]
@@ -106,6 +133,20 @@ async fn member_can_publish_read_and_retract_story_reaction_attachment() {
         "owner story publish should succeed: {owner_story}"
     );
 
+    let subscribe_summary = iq_set_to(
+        &mut alice,
+        "summary-subscribe",
+        COMMUNITY_JID,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><subscribe node="{STORY_SUMMARY_NODE}" jid="alice@localhost"/></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(
+        subscribe_summary.contains("type='result'"),
+        "summary node subscription should succeed for a community member: {subscribe_summary}"
+    );
+
     let member_story = iq_set_to(
         &mut alice,
         "member-story",
@@ -153,6 +194,21 @@ async fn member_can_publish_read_and_retract_story_reaction_attachment() {
     assert!(
         reaction_publish.contains("type='result'"),
         "member reaction publish should succeed via story carve-out: {reaction_publish}"
+    );
+
+    let pushed_summary = wait_for_event_message(
+        &mut alice,
+        STORY_SUMMARY_NODE,
+        std::time::Duration::from_secs(2),
+    )
+    .await
+    .expect("subscriber should receive summary fan-out after a story reaction changes");
+    assert!(
+        pushed_summary.contains(NS_ATTACHMENTS_SUMMARY)
+            && pushed_summary.contains(&format!("id='{story_id}'"))
+            && pushed_summary.contains("<reaction count='1'>👍</reaction>")
+            && pushed_summary.contains("<reaction count='1'>❤️</reaction>"),
+        "pushed summary event should contain per-emoji counts for the story: {pushed_summary}"
     );
 
     let summary = iq_get_to(
@@ -465,6 +521,22 @@ async fn member_can_publish_read_and_retract_story_reaction_attachment() {
     assert!(
         retract.contains("type='result'"),
         "member should retract own story reaction item: {retract}"
+    );
+
+    let pushed_retract_summary = wait_for_event_message(
+        &mut alice,
+        STORY_SUMMARY_NODE,
+        std::time::Duration::from_secs(2),
+    )
+    .await
+    .expect("subscriber should receive summary fan-out after a story reaction retracts");
+    assert!(
+        pushed_retract_summary.contains(NS_ATTACHMENTS_SUMMARY)
+            && pushed_retract_summary.contains(&format!("id='{story_id}'"))
+            && !pushed_retract_summary.contains("<reaction count='1'>👍</reaction>")
+            && !pushed_retract_summary.contains("<reaction count='1'>❤️</reaction>")
+            && pushed_retract_summary.contains("<noticed count='1'/>"),
+        "pushed retract summary should remove Alice's reactions and preserve noticed counts: {pushed_retract_summary}"
     );
 
     let _ = alice.close().await;

--- a/server/crates/waddle-xmpp-client-wasm/src/client_core.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_core.rs
@@ -17,6 +17,7 @@ impl WaddleClient {
                 on_message_delivery_acked: None,
                 on_message_delivery_failed: None,
                 on_mds_displayed: None,
+                on_pubsub_event: None,
                 on_call: None,
                 resume_state: None,
             })),
@@ -77,6 +78,13 @@ impl WaddleClient {
     /// event, with a `WaddleMdsDisplayedEntry`-shaped JS value.
     pub fn set_on_mds_displayed(&mut self, cb: Function) {
         self.inner.borrow_mut().on_mds_displayed = Some(cb);
+    }
+
+    /// Generic XEP-0060 pubsub event handler. Invoked once per
+    /// inbound `<items/>` event with a `WaddlePubsubEvent`-shaped JS
+    /// value.
+    pub fn set_on_pubsub_event(&mut self, cb: Function) {
+        self.inner.borrow_mut().on_pubsub_event = Some(cb);
     }
 
     /// Register a callback for inbound XMPP-native call events

--- a/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
@@ -211,7 +211,58 @@ pub(crate) fn inbound_to_js(message: InboundMessage) -> WaddleMessage {
         pin_event: message.pin_event.map(pin_event_to_js),
         extension_envelope: message.extension_envelope.map(extension_envelope_to_js),
         extension_body_fallback: message.extension_body_fallback,
+        pubsub_events: message
+            .pubsub_events
+            .into_iter()
+            .map(pubsub_event_to_js)
+            .collect(),
         inbox_push: None,
+    }
+}
+
+pub(crate) fn pubsub_event_to_js(event: waddle_xmpp_client::PubsubEvent) -> WaddlePubsubEvent {
+    WaddlePubsubEvent {
+        from: event.from.map(|jid| jid.to_string()),
+        node: event.node,
+        items: event
+            .items
+            .into_iter()
+            .map(|item| WaddlePubsubEventItem {
+                id: item.id,
+                payload: pubsub_payload_to_js(item.payload),
+            })
+            .collect(),
+    }
+}
+
+fn pubsub_payload_to_js(
+    payload: waddle_xmpp_client::PubsubEventPayload,
+) -> WaddlePubsubEventPayload {
+    match payload {
+        waddle_xmpp_client::PubsubEventPayload::AttachmentSummary(summary) => {
+            WaddlePubsubEventPayload::AttachmentSummary {
+                reactions: summary
+                    .reactions
+                    .into_iter()
+                    .map(|reaction| WaddlePubsubReactionSummary {
+                        emoji: reaction.emoji,
+                        count: reaction.count,
+                        reactors: reaction
+                            .reactors
+                            .into_iter()
+                            .map(|reactor| reactor.to_string())
+                            .collect(),
+                    })
+                    .collect(),
+                noticed_count: summary.noticed_count,
+            }
+        }
+        waddle_xmpp_client::PubsubEventPayload::Opaque { element } => {
+            WaddlePubsubEventPayload::Opaque {
+                xml: String::from(&element),
+            }
+        }
+        waddle_xmpp_client::PubsubEventPayload::Empty => WaddlePubsubEventPayload::Empty,
     }
 }
 
@@ -279,6 +330,7 @@ pub(crate) fn inbox_push_to_js(
         pin_event: None,
         extension_envelope: None,
         extension_body_fallback: false,
+        pubsub_events: Vec::new(),
         inbox_push: Some(inbox_entry_to_js(entry)),
     }
 }
@@ -780,6 +832,92 @@ mod inbound_to_js_tests {
         assert_eq!(
             push.get("thread").and_then(serde_json::Value::as_str),
             Some("thread-1")
+        );
+    }
+
+    #[test]
+    fn pubsub_event_to_js_serializes_typed_and_opaque_payloads() {
+        let event = waddle_xmpp_client::PubsubEvent {
+            from: Some("community.example.com".parse().expect("valid event jid")),
+            node: "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:stories:0".to_string(),
+            items: vec![
+                waddle_xmpp_client::PubsubEventItem {
+                    id: Some("story-1".to_string()),
+                    payload: waddle_xmpp_client::PubsubEventPayload::AttachmentSummary(
+                        waddle_xmpp_client::AttachmentSummaryEvent {
+                            reactions: vec![waddle_xmpp_client::ReactionSummaryEvent {
+                                emoji: "👍".to_string(),
+                                count: 2,
+                                reactors: vec!["alice@example.com"
+                                    .parse()
+                                    .expect("valid reactor jid")],
+                            }],
+                            noticed_count: Some(1),
+                        },
+                    ),
+                },
+                waddle_xmpp_client::PubsubEventItem {
+                    id: Some("future".to_string()),
+                    payload: waddle_xmpp_client::PubsubEventPayload::Opaque {
+                        element: Element::builder("future", "urn:example:future")
+                            .append("payload")
+                            .build(),
+                    },
+                },
+                waddle_xmpp_client::PubsubEventItem {
+                    id: Some("empty".to_string()),
+                    payload: waddle_xmpp_client::PubsubEventPayload::Empty,
+                },
+            ],
+        };
+
+        let value = serde_json::to_value(pubsub_event_to_js(event)).expect("serializes");
+        let items = value
+            .get("items")
+            .and_then(serde_json::Value::as_array)
+            .expect("items array");
+        assert_eq!(
+            value.get("from").and_then(serde_json::Value::as_str),
+            Some("community.example.com")
+        );
+        assert_eq!(
+            items[0]
+                .get("payload")
+                .and_then(|payload| payload.get("kind"))
+                .and_then(serde_json::Value::as_str),
+            Some("attachmentSummary")
+        );
+        assert_eq!(
+            items[0]
+                .get("payload")
+                .and_then(|payload| payload.get("noticedCount"))
+                .and_then(serde_json::Value::as_u64),
+            Some(1)
+        );
+        assert_eq!(
+            items[0]
+                .get("payload")
+                .and_then(|payload| payload.get("reactions"))
+                .and_then(serde_json::Value::as_array)
+                .and_then(|reactions| reactions.first())
+                .and_then(|reaction| reaction.get("reactors"))
+                .and_then(serde_json::Value::as_array)
+                .and_then(|reactors| reactors.first())
+                .and_then(serde_json::Value::as_str),
+            Some("alice@example.com")
+        );
+        let opaque_xml = items[1]
+            .get("payload")
+            .and_then(|payload| payload.get("xml"))
+            .and_then(serde_json::Value::as_str)
+            .expect("opaque xml");
+        assert!(opaque_xml.contains("urn:example:future"), "{opaque_xml}");
+        assert_eq!(
+            items[2]
+                .get("payload")
+                .and_then(|payload| payload.get("kind"))
+                .and_then(serde_json::Value::as_str),
+            Some("empty")
         );
     }
 

--- a/server/crates/waddle-xmpp-client-wasm/src/driver.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/driver.rs
@@ -693,6 +693,7 @@ mod tests {
             on_message_delivery_acked: None,
             on_message_delivery_failed: None,
             on_mds_displayed: None,
+            on_pubsub_event: None,
             on_call: None,
             resume_state: None,
         }))

--- a/server/crates/waddle-xmpp-client-wasm/src/events.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/events.rs
@@ -93,6 +93,16 @@ pub(crate) fn dispatch_client_event(inner: &Rc<RefCell<WaddleClientInner>>, even
                     }
                 }
             }
+            if !message.pubsub_events.is_empty() {
+                let callback = inner.borrow().on_pubsub_event.clone();
+                if let Some(callback) = callback {
+                    for event in message.pubsub_events.iter().cloned() {
+                        if let Ok(value) = to_js_value(&pubsub_event_to_js(event)) {
+                            let _ = callback.call1(&JsValue::NULL, &value);
+                        }
+                    }
+                }
+            }
             let callback = inner.borrow().on_message.clone();
             if let Some(callback) = callback {
                 if let Ok(value) = to_js_value(&inbound_to_js(message)) {

--- a/server/crates/waddle-xmpp-client-wasm/src/state.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/state.rs
@@ -185,6 +185,7 @@ pub(crate) struct WaddleClientInner {
     /// inbound PEP event, so the chat layer can apply each one
     /// independently without re-parsing the message.
     pub(crate) on_mds_displayed: Option<Function>,
+    pub(crate) on_pubsub_event: Option<Function>,
     pub(crate) on_call: Option<Function>,
     pub(crate) resume_state: Option<waddle_xmpp_client::SmResumeState>,
 }

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -61,8 +61,46 @@ pub struct WaddleMessage {
     pub pin_event: Option<WaddlePinEvent>,
     pub extension_envelope: Option<WaddleExtensionEnvelope>,
     pub extension_body_fallback: bool,
+    pub pubsub_events: Vec<WaddlePubsubEvent>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inbox_push: Option<WaddleInboxConversation>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct WaddlePubsubEvent {
+    pub from: Option<String>,
+    pub node: String,
+    pub items: Vec<WaddlePubsubEventItem>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct WaddlePubsubEventItem {
+    pub id: Option<String>,
+    pub payload: WaddlePubsubEventPayload,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    tag = "kind"
+)]
+pub enum WaddlePubsubEventPayload {
+    AttachmentSummary {
+        reactions: Vec<WaddlePubsubReactionSummary>,
+        noticed_count: Option<u32>,
+    },
+    Opaque {
+        xml: String,
+    },
+    Empty,
+}
+
+#[derive(Debug, Serialize)]
+pub struct WaddlePubsubReactionSummary {
+    pub emoji: String,
+    pub count: u32,
+    pub reactors: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -61,6 +61,7 @@ pub struct WaddleMessage {
     pub pin_event: Option<WaddlePinEvent>,
     pub extension_envelope: Option<WaddleExtensionEnvelope>,
     pub extension_body_fallback: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub pubsub_events: Vec<WaddlePubsubEvent>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inbox_push: Option<WaddleInboxConversation>,

--- a/server/crates/waddle-xmpp-client/src/lib.rs
+++ b/server/crates/waddle-xmpp-client/src/lib.rs
@@ -17,6 +17,7 @@ pub mod mds;
 pub mod messaging;
 pub mod pep;
 pub mod pin;
+pub mod pubsub_event;
 pub mod push;
 pub mod request;
 pub mod runtime;
@@ -86,6 +87,9 @@ pub use pep::{
     build_retract_activity_iq, build_retract_mood_iq, build_retract_tune_iq, parse_pep_activity,
     parse_pep_mood, parse_pep_tune, PepItem, UserActivity, UserMood, UserTune, NS_ACTIVITY,
     NS_MOOD, NS_TUNE,
+};
+pub use pubsub_event::{
+    AttachmentSummaryEvent, PubsubEvent, PubsubEventItem, PubsubEventPayload, ReactionSummaryEvent,
 };
 pub use request::{
     ClientRequest, PendingRequest, RequestCorrelation, RequestId, RequestKind, RequestTracker,

--- a/server/crates/waddle-xmpp-client/src/messaging/parsing/mod.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/parsing/mod.rs
@@ -127,6 +127,7 @@ fn parse_message(el: &Element) -> Option<InboundMessage> {
             })
             .collect::<Vec<_>>()
     });
+    let pubsub_events = crate::pubsub_event::parse_pubsub_events(el);
 
     let reply_marker = xep_reply::parse_reply(el);
     let reply_to_id = reply_marker.as_ref().map(|m| m.id.clone());
@@ -356,6 +357,7 @@ fn parse_message(el: &Element) -> Option<InboundMessage> {
         extension_envelope,
         extension_body_fallback,
         mds_displayed,
+        pubsub_events,
     })
 }
 

--- a/server/crates/waddle-xmpp-client/src/messaging/types.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/types.rs
@@ -185,6 +185,9 @@ pub struct InboundMessage {
     /// a shape XEP-0490 currently defines but cheap to surface
     /// faithfully).
     pub mds_displayed: Option<Vec<MdsDisplayedEntry>>,
+    /// Generic typed XEP-0060 PubSub event notifications carried by
+    /// `<event xmlns='http://jabber.org/protocol/pubsub#event'/>`.
+    pub pubsub_events: Vec<crate::pubsub_event::PubsubEvent>,
 }
 
 /// XEP-0490 §3 displayed entry as surfaced from a PEP event.

--- a/server/crates/waddle-xmpp-client/src/pubsub_event.rs
+++ b/server/crates/waddle-xmpp-client/src/pubsub_event.rs
@@ -1,0 +1,230 @@
+use jid::{BareJid, Jid};
+use minidom::Element;
+
+const NS_PUBSUB_EVENT: &str = "http://jabber.org/protocol/pubsub#event";
+const NS_PUBSUB_ATTACHMENTS_SUMMARY: &str = "urn:xmpp:pubsub-attachments:summary:1";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PubsubEventItem {
+    pub id: Option<String>,
+    pub payload: PubsubEventPayload,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PubsubEvent {
+    pub from: Option<Jid>,
+    pub node: String,
+    pub items: Vec<PubsubEventItem>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PubsubEventPayload {
+    AttachmentSummary(AttachmentSummaryEvent),
+    Opaque { element: Element },
+    Empty,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttachmentSummaryEvent {
+    pub reactions: Vec<ReactionSummaryEvent>,
+    pub noticed_count: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReactionSummaryEvent {
+    pub emoji: String,
+    pub count: u32,
+    pub reactors: Vec<BareJid>,
+}
+
+pub fn parse_pubsub_events(message: &Element) -> Vec<PubsubEvent> {
+    if message.name() != "message" {
+        return Vec::new();
+    }
+    let Some(event) = message.get_child("event", NS_PUBSUB_EVENT) else {
+        return Vec::new();
+    };
+    let from = message.attr("from").and_then(|value| value.parse().ok());
+    event
+        .children()
+        .filter(|child| child.is("items", NS_PUBSUB_EVENT))
+        .filter_map(|items| parse_items(items, from.clone()))
+        .collect()
+}
+
+fn parse_items(items: &Element, from: Option<Jid>) -> Option<PubsubEvent> {
+    let node = items.attr("node")?.to_owned();
+    let event_items = items
+        .children()
+        .filter(|child| child.is("item", NS_PUBSUB_EVENT))
+        .map(parse_item)
+        .collect::<Vec<_>>();
+    Some(PubsubEvent {
+        from,
+        node,
+        items: event_items,
+    })
+}
+
+fn parse_item(item: &Element) -> PubsubEventItem {
+    let payload = item
+        .children()
+        .next()
+        .map(parse_payload)
+        .unwrap_or(PubsubEventPayload::Empty);
+    PubsubEventItem {
+        id: item.attr("id").map(ToOwned::to_owned),
+        payload,
+    }
+}
+
+fn parse_payload(payload: &Element) -> PubsubEventPayload {
+    if payload.is("summary", NS_PUBSUB_ATTACHMENTS_SUMMARY) {
+        return PubsubEventPayload::AttachmentSummary(parse_attachment_summary(payload));
+    }
+    PubsubEventPayload::Opaque {
+        element: payload.clone(),
+    }
+}
+
+fn parse_attachment_summary(summary: &Element) -> AttachmentSummaryEvent {
+    let reactions = summary
+        .children()
+        .filter(|child| child.is("reaction", NS_PUBSUB_ATTACHMENTS_SUMMARY))
+        .map(|reaction| ReactionSummaryEvent {
+            emoji: reaction.text(),
+            count: reaction
+                .attr("count")
+                .and_then(|value| value.parse::<u32>().ok())
+                .unwrap_or(0),
+            reactors: reaction
+                .children()
+                .filter(|child| child.is("reactor", NS_PUBSUB_ATTACHMENTS_SUMMARY))
+                .filter_map(|reactor| reactor.attr("jid")?.parse::<BareJid>().ok())
+                .collect(),
+        })
+        .collect();
+    let noticed_count = summary
+        .children()
+        .find(|child| child.is("noticed", NS_PUBSUB_ATTACHMENTS_SUMMARY))
+        .and_then(|noticed| noticed.attr("count"))
+        .and_then(|count| count.parse::<u32>().ok());
+    AttachmentSummaryEvent {
+        reactions,
+        noticed_count,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NS_CLIENT: &str = "jabber:client";
+
+    fn event_message(node: &str, item_id: &str, payload: Element) -> Element {
+        Element::builder("message", NS_CLIENT)
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "headline")
+            .append(
+                Element::builder("event", NS_PUBSUB_EVENT)
+                    .append(
+                        Element::builder("items", NS_PUBSUB_EVENT)
+                            .attr(minidom::rxml::xml_ncname!("node").to_owned(), node)
+                            .append(
+                                Element::builder("item", NS_PUBSUB_EVENT)
+                                    .attr(minidom::rxml::xml_ncname!("id").to_owned(), item_id)
+                                    .append(payload)
+                                    .build(),
+                            )
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build()
+    }
+
+    #[test]
+    fn parses_attachment_summary_event() {
+        let message = event_message(
+            "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:stories:0",
+            "story-1",
+            Element::builder("summary", NS_PUBSUB_ATTACHMENTS_SUMMARY)
+                .append(
+                    Element::builder("reaction", NS_PUBSUB_ATTACHMENTS_SUMMARY)
+                        .attr(minidom::rxml::xml_ncname!("count").to_owned(), "2")
+                        .append(
+                            Element::builder("reactor", NS_PUBSUB_ATTACHMENTS_SUMMARY)
+                                .attr(
+                                    minidom::rxml::xml_ncname!("jid").to_owned(),
+                                    "alice@example.com",
+                                )
+                                .build(),
+                        )
+                        .append("👍")
+                        .build(),
+                )
+                .append(
+                    Element::builder("noticed", NS_PUBSUB_ATTACHMENTS_SUMMARY)
+                        .attr(minidom::rxml::xml_ncname!("count").to_owned(), "1")
+                        .build(),
+                )
+                .build(),
+        );
+        let events = parse_pubsub_events(&message);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].from, None);
+        assert_eq!(events[0].items[0].id.as_deref(), Some("story-1"));
+        let PubsubEventPayload::AttachmentSummary(summary) = &events[0].items[0].payload else {
+            panic!("expected attachment summary payload");
+        };
+        assert_eq!(summary.reactions[0].emoji, "👍");
+        assert_eq!(summary.reactions[0].count, 2);
+        assert_eq!(
+            summary.reactions[0].reactors,
+            vec!["alice@example.com".parse::<BareJid>().expect("valid jid")]
+        );
+        assert_eq!(summary.noticed_count, Some(1));
+    }
+
+    #[test]
+    fn preserves_unknown_payload_opaquely() {
+        let message = event_message(
+            "urn:example:unknown",
+            "current",
+            Element::builder("future", "urn:example:future")
+                .append("payload")
+                .build(),
+        );
+        let events = parse_pubsub_events(&message);
+        let PubsubEventPayload::Opaque { element } = &events[0].items[0].payload else {
+            panic!("expected opaque payload");
+        };
+        let xml = String::from(element);
+        assert!(xml.contains("urn:example:future"), "{xml}");
+        assert!(xml.contains("payload"), "{xml}");
+    }
+
+    #[test]
+    fn parses_event_from_as_typed_jid() {
+        let message = Element::builder("message", NS_CLIENT)
+            .attr(
+                minidom::rxml::xml_ncname!("from").to_owned(),
+                "community.example.com",
+            )
+            .append(
+                Element::builder("event", NS_PUBSUB_EVENT)
+                    .append(
+                        Element::builder("items", NS_PUBSUB_EVENT)
+                            .attr(minidom::rxml::xml_ncname!("node").to_owned(), "urn:test")
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build();
+
+        let events = parse_pubsub_events(&message);
+        assert_eq!(
+            events[0].from,
+            Some("community.example.com".parse::<Jid>().expect("valid jid"))
+        );
+    }
+}

--- a/server/crates/waddle-xmpp-client/src/pubsub_event.rs
+++ b/server/crates/waddle-xmpp-client/src/pubsub_event.rs
@@ -88,7 +88,10 @@ fn parse_payload(payload: &Element) -> PubsubEventPayload {
 }
 
 fn parse_attachment_summary(summary: &Element) -> AttachmentSummaryEvent {
-    let reactions = summary
+    let reactions_parent = summary
+        .get_child("reactions", NS_PUBSUB_ATTACHMENTS_SUMMARY)
+        .unwrap_or(summary);
+    let reactions = reactions_parent
         .children()
         .filter(|child| child.is("reaction", NS_PUBSUB_ATTACHMENTS_SUMMARY))
         .map(|reaction| ReactionSummaryEvent {
@@ -149,17 +152,21 @@ mod tests {
             "story-1",
             Element::builder("summary", NS_PUBSUB_ATTACHMENTS_SUMMARY)
                 .append(
-                    Element::builder("reaction", NS_PUBSUB_ATTACHMENTS_SUMMARY)
-                        .attr(minidom::rxml::xml_ncname!("count").to_owned(), "2")
+                    Element::builder("reactions", NS_PUBSUB_ATTACHMENTS_SUMMARY)
                         .append(
-                            Element::builder("reactor", NS_PUBSUB_ATTACHMENTS_SUMMARY)
-                                .attr(
-                                    minidom::rxml::xml_ncname!("jid").to_owned(),
-                                    "alice@example.com",
+                            Element::builder("reaction", NS_PUBSUB_ATTACHMENTS_SUMMARY)
+                                .attr(minidom::rxml::xml_ncname!("count").to_owned(), "2")
+                                .append(
+                                    Element::builder("reactor", NS_PUBSUB_ATTACHMENTS_SUMMARY)
+                                        .attr(
+                                            minidom::rxml::xml_ncname!("jid").to_owned(),
+                                            "alice@example.com",
+                                        )
+                                        .build(),
                                 )
+                                .append("👍")
                                 .build(),
                         )
-                        .append("👍")
                         .build(),
                 )
                 .append(

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -398,6 +398,12 @@ export class WaddleClient {
     set_on_message_delivery_acked(cb: Function): void;
     set_on_message_delivery_failed(cb: Function): void;
     set_on_presence(cb: Function): void;
+    /**
+     * Generic XEP-0060 pubsub event handler. Invoked once per
+     * inbound `<items/>` event with a `WaddlePubsubEvent`-shaped JS
+     * value.
+     */
+    set_on_pubsub_event(cb: Function): void;
     set_on_session_lifecycle(cb: Function): void;
     set_room_affiliation(room_jid: string, jid: string, affiliation: string): Promise<any>;
     /**

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=0a2dc2126b5a";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=0a2dc2126b5a";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=0a2dc2126b5a";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=64eb083207c4";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=64eb083207c4";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=64eb083207c4";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=0a2dc2126b5a";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=64eb083207c4";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=e49daff3e915";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=e49daff3e915";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=e49daff3e915";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=0a2dc2126b5a";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=0a2dc2126b5a";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=0a2dc2126b5a";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=e49daff3e915";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=0a2dc2126b5a";


### PR DESCRIPTION
## Summary

Implements issue #875 by making story reaction summaries update live through XMPP pubsub instead of waiting for the next explicit refresh.

## Plan and implementation

- Fan out updated story attachment summaries from the server whenever a story reaction publish or retract changes the derived summary item.
- Ensure the story summary node exists after story publish so members can subscribe before the first reaction arrives.
- Add typed generic XEP-0060 pubsub event parsing in the Rust XMPP client, including typed JID origins, typed attachment summary payloads, opaque minidom payload preservation, and explicit empty payloads.
- Bridge typed pubsub events through the WASM client and expose set_on_pubsub_event to chat.
- Subscribe chat story views to the summary node and merge live summary pushes into the story reaction store.
- Keep handler registration additive so multiple story scopes do not replace each other.
- Preserve pending local optimistic reactions only while a publish/retract is unresolved; settled live summaries use canonical server counts.

## Changed files

- server pubsub fan-out and XEP-0470 websocket integration test
- Rust XMPP client pubsub event parser/types
- WASM bridge event types, conversion, callback plumbing, and generated package declaration/cachebuster
- chat XMPP client subscription/callback API
- story service live summary handling and regression tests

## Simplifications

- Reused the existing pubsub fan-out path instead of adding a separate notification mechanism.
- Used the existing story attachment summary node as the only live update payload.
- Kept unknown pubsub payloads opaque until the JS/WASM boundary rather than inventing stringly Rust variants.

## Verification

- PASS: cargo test -p waddle-server --test xep0470_story_reactions_ws -- --nocapture
- PASS: cargo clippy -p waddle-server -- -D warnings
- PASS: cargo test -p waddle-xmpp-client
- PASS: cargo test -p waddle-xmpp-client-wasm
- PASS: bun test chat/tests/stories.test.ts
- PASS: bun run lint in chat/
- KNOWN GAP: full bun test in chat/ still fails only the two pre-existing editor-message-input tests related to duplicate prosemirror-model instances:
  - message input editor > lets Tiptap list input rules and list exit run before chat submit
  - message input editor > sends on the Enter after leaving supported block contexts

## Review notes

Adversarial review found and this PR addressed:

- Rust pubsub event origin must be a typed JID in core, not a String.
- Live summary events must preserve pending optimistic self reactions.
- Pending optimistic adjustment must not persist after publish/retract settles.

## Remaining risks

- Full chat suite remains blocked by unrelated editor-message-input failures, so the final chat verification is targeted story tests plus lint.
