### PR TITLE
feat(chat): unify feed create surface

### DIFF
--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -52,6 +52,9 @@ import { buildHomeDashboardProps } from "@/home/dashboard-props";
 import { jidDomain } from "@/lib/xmpp/jid";
 import type { ChatAppController } from "@/shell/chat-app-controller";
 import type { DiscoveredExtensionRoute } from "@/lib/xmpp/extension-commands";
+import type { FeedPostInput, StoryPostInput } from "@/lib/xmpp-client";
+import type { ActivityPublication, MoodPublication, TunePublication } from "@/lib/xmpp/pep-types";
+import type { VCard4Profile } from "@/lib/xmpp/vcard4-types";
 import { installMessageToolbarLifecycleSuppression } from "@/stores/message-toolbar";
 
 const props = defineProps<{
@@ -288,6 +291,60 @@ async function lookupActiveChannelLinkPreview(body: string) {
   const roomJid = activeChannelRoomJid.value;
   if (!client || !roomJid) return null;
   return client.lookupLinkPreview(body, roomJid);
+}
+
+function requireFeedPepClient() {
+  const client = xmppClient.value;
+  if (!client) {
+    throw new Error("Reconnect before publishing this update.");
+  }
+  return client;
+}
+
+async function refreshFeedAfterPepPublish(): Promise<void> {
+  await socialFeed.refresh();
+}
+
+async function publishFeedPost(input: FeedPostInput): Promise<void> {
+  const entry = await socialFeed.post(input);
+  if (!entry) {
+    throw new Error(socialFeed.error.value ?? "Couldn't publish post.");
+  }
+}
+
+async function publishFeedStory(input: StoryPostInput): Promise<void> {
+  const story = await stories.post(input);
+  if (!story) {
+    throw new Error(stories.error.value ?? "Couldn't publish story.");
+  }
+}
+
+async function publishFeedMood(input: MoodPublication): Promise<void> {
+  await requireFeedPepClient().publishMood(input);
+  await refreshFeedAfterPepPublish();
+}
+
+async function publishFeedActivity(input: ActivityPublication): Promise<void> {
+  await requireFeedPepClient().publishActivity(input);
+  await refreshFeedAfterPepPublish();
+}
+
+async function publishFeedTune(input: TunePublication): Promise<void> {
+  await requireFeedPepClient().publishTune(input);
+  await refreshFeedAfterPepPublish();
+}
+
+async function fetchFeedProfile(): Promise<VCard4Profile | null> {
+  const selfJid = connectionStore.session?.jid;
+  if (!selfJid) {
+    throw new Error("Reconnect before loading your profile.");
+  }
+  return requireFeedPepClient().fetchVCard4(selfJid);
+}
+
+async function publishFeedProfile(input: VCard4Profile): Promise<void> {
+  await requireFeedPepClient().publishVCard4(input);
+  await refreshFeedAfterPepPublish();
 }
 
 function getCallSender(): CallWireSender | null {
@@ -615,9 +672,16 @@ onUnmounted(() => {
         :self-jid="connectionStore.session?.jid ?? null"
         :is-story-read="stories.isStoryRead"
         :reaction-summary="stories.reactionSummary"
+        :initial-filter="ui.feedDefaultFilter.value"
+        :initial-composer-mode="ui.feedDefaultComposerMode.value"
+        :publish-post="publishFeedPost"
+        :publish-story="publishFeedStory"
+        :publish-mood="publishFeedMood"
+        :publish-activity="publishFeedActivity"
+        :publish-tune="publishFeedTune"
+        :fetch-profile="fetchFeedProfile"
+        :publish-profile="publishFeedProfile"
         @refresh="socialFeed.refresh(); stories.refresh()"
-        @post="(input) => socialFeed.post(input)"
-        @post-story="(input) => stories.post(input)"
         @story-selected="(id) => stories.markStoryRead(id)"
         @react="(id, emoji) => stories.toggleReaction(id, emoji)"
         @open-nav="ui.showMobileNav.value = true"

--- a/chat/src/components/chat/VCardEditor.vue
+++ b/chat/src/components/chat/VCardEditor.vue
@@ -31,8 +31,10 @@ const secondaryButtonClass = "chat-action-button chat-action-button--secondary t
 const draft = reactive<VCard4Draft>(draftFromProfile(null));
 const loading = ref(false);
 const saving = ref(false);
+const profileLoaded = ref(false);
 /** Last value seen from the server — the rollback target on save failure. */
 const lastPersisted = ref<VCard4Profile>({});
+let profileLoadRequestId = 0;
 const feedback = ref<VCardFeedback>({
   tone: "muted",
   message: "Add your name, nickname, pronouns, bio, and a link — publish to share over XMPP.",
@@ -45,10 +47,15 @@ function applyDraft(profile: VCard4Profile) {
   draft.pronouns = next.pronouns;
   draft.note = next.note;
   draft.url = next.url;
+  draft.photoUri = next.photoUri;
 }
 
 async function loadProfile() {
-  if (!props.xmppClient) {
+  const requestId = ++profileLoadRequestId;
+  const client = props.xmppClient;
+  const selfJid = props.selfJid;
+  if (!client) {
+    profileLoaded.value = false;
     feedback.value = {
       tone: "muted",
       message: "Reconnect to load your profile.",
@@ -57,10 +64,18 @@ async function loadProfile() {
   }
   loading.value = true;
   try {
-    const profile = await props.xmppClient.fetchVCard4(props.selfJid);
+    const profile = await client.fetchVCard4(selfJid);
+    if (
+      requestId !== profileLoadRequestId ||
+      client !== props.xmppClient ||
+      selfJid !== props.selfJid
+    ) {
+      return;
+    }
     const next = profile ?? {};
     lastPersisted.value = next;
     applyDraft(next);
+    profileLoaded.value = true;
     feedback.value = profile
       ? {
           tone: "muted",
@@ -71,6 +86,14 @@ async function loadProfile() {
           message: "No profile saved yet — fill in what you want to share.",
         };
   } catch (error) {
+    if (
+      requestId !== profileLoadRequestId ||
+      client !== props.xmppClient ||
+      selfJid !== props.selfJid
+    ) {
+      return;
+    }
+    profileLoaded.value = false;
     feedback.value = {
       tone: "error",
       message: error instanceof Error
@@ -78,7 +101,13 @@ async function loadProfile() {
         : "Couldn't load your profile.",
     };
   } finally {
-    loading.value = false;
+    if (
+      requestId === profileLoadRequestId &&
+      client === props.xmppClient &&
+      selfJid === props.selfJid
+    ) {
+      loading.value = false;
+    }
   }
 }
 
@@ -87,11 +116,24 @@ onMounted(() => {
 });
 
 watch(
-  () => props.xmppClient,
-  (client, previous) => {
-    if (client && client !== previous) {
-      void loadProfile();
+  () => [props.xmppClient, props.selfJid] as const,
+  ([client, selfJid], [previousClient, previousSelfJid]) => {
+    if (client === previousClient && selfJid === previousSelfJid) {
+      return;
     }
+    profileLoaded.value = false;
+    lastPersisted.value = {};
+    applyDraft({});
+    if (!client) {
+      profileLoadRequestId += 1;
+      loading.value = false;
+      feedback.value = {
+        tone: "muted",
+        message: "Reconnect to load your profile.",
+      };
+      return;
+    }
+    void loadProfile();
   },
 );
 
@@ -100,6 +142,13 @@ async function saveProfile() {
     feedback.value = {
       tone: "error",
       message: "Reconnect before publishing your profile.",
+    };
+    return;
+  }
+  if (!profileLoaded.value) {
+    feedback.value = {
+      tone: "error",
+      message: "Load your saved profile before publishing changes.",
     };
     return;
   }
@@ -252,7 +301,7 @@ function feedbackClass(tone: FeedbackTone): string {
         <button
           type="submit"
           :class="primaryButtonClass"
-          :disabled="loading || saving || !xmppClient"
+          :disabled="loading || saving || !xmppClient || !profileLoaded"
           data-testid="vcard4-save"
         >
           {{ saving ? "Publishing…" : "Save profile" }}

--- a/chat/src/components/community/FeedPane.vue
+++ b/chat/src/components/community/FeedPane.vue
@@ -4,26 +4,23 @@ import {
   Briefcase,
   CalendarCheck,
   Camera,
-  ChevronLeft,
-  ChevronRight,
   Film,
   IdCard,
   Inbox,
   Menu,
   MessageSquareText,
   Music,
-  Plus,
   RefreshCw,
-  Send,
   Smile,
   User,
-  X,
 } from "lucide-vue-next";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import Skeleton from "@/components/ui/Skeleton.vue";
-import StoryComposer from "@/components/community/StoryComposer.vue";
-import { connectionStore } from "@/lib/connection-store";
-import { QUICK_REACTION_EMOJIS } from "@/lib/reaction-mode";
+import FeedUpdateComposer from "@/components/community/FeedUpdateComposer.vue";
+import StoryReaderDialog from "@/components/community/StoryReaderDialog.vue";
+import type { FeedSurfaceComposerMode, FeedSurfaceFilter } from "@/shell/state";
+import type { ActivityPublication, MoodPublication, TunePublication } from "@/lib/xmpp/pep-types";
+import type { VCard4Profile } from "@/lib/xmpp/vcard4-types";
 import type { FeedEntry, FeedPostInput, FeedSourceKind, Story, StoryPostInput, StoryReactionSummary } from "@/lib/xmpp-client";
 
 const SOURCE_ICONS = {
@@ -105,33 +102,47 @@ interface FeedPaneProps {
   selfJid: string | null;
   isStoryRead?: (id: string) => boolean;
   reactionSummary?: (id: string) => StoryReactionSummary;
+  initialFilter?: FeedSurfaceFilter;
+  initialComposerMode?: FeedSurfaceComposerMode;
+  publishPost?: (input: FeedPostInput) => Promise<unknown>;
+  publishStory?: (input: StoryPostInput) => Promise<unknown>;
+  publishMood?: (input: MoodPublication) => Promise<void>;
+  publishActivity?: (input: ActivityPublication) => Promise<void>;
+  publishTune?: (input: TunePublication) => Promise<void>;
+  fetchProfile?: () => Promise<VCard4Profile | null>;
+  publishProfile?: (input: VCard4Profile) => Promise<void>;
 }
 
 const props = withDefaults(defineProps<FeedPaneProps>(), {
   isStoryRead: () => () => false,
   reactionSummary: () => () => ({ counts: {}, reactors: {}, mine: [] }),
+  initialFilter: "all",
+  initialComposerMode: "post",
 });
 const emit = defineEmits<{
   refresh: [];
-  post: [input: FeedPostInput];
-  postStory: [input: StoryPostInput];
   storySelected: [id: string];
   react: [id: string, emoji: string];
   openNav: [];
 }>();
 
-const composerBody = ref("");
-const storyComposerOpen = ref(false);
-const storyComposerError = ref<string | null>(null);
-const storyComposerBusy = ref(false);
-const activeStoryIndex = ref<number | null>(null);
-const activeFilter = ref<"all" | "pep" | "stories" | "posts">("all");
-const COMPOSER_MAX = 500;
+const activeStoryId = ref<string | null>(null);
+const activeFilter = ref<FeedSurfaceFilter>(props.initialFilter);
 
 watch(activeFilter, (filter) => {
   if (filter === "pep" || filter === "posts") {
-    activeStoryIndex.value = null;
-    storyComposerOpen.value = false;
+    activeStoryId.value = null;
+  }
+});
+
+watch(() => props.initialFilter, (filter) => {
+  activeFilter.value = filter;
+});
+
+watch(() => props.stories, (stories) => {
+  const id = activeStoryId.value;
+  if (id && !stories.some((story) => story.id === id)) {
+    activeStoryId.value = null;
   }
 });
 
@@ -164,19 +175,6 @@ function listedAgo(story: Story): string {
 function authorLabel(author: string | undefined): string {
   if (!author) return "Anonymous";
   return author.split("@")[0] ?? author;
-}
-
-const canSubmit = computed(() => {
-  return props.canPost && !props.isPosting && composerBody.value.trim().length > 0;
-});
-
-const composerOver = computed(() => composerBody.value.length > COMPOSER_MAX);
-
-function submit() {
-  const body = composerBody.value.trim();
-  if (!body || composerOver.value) return;
-  emit("post", { body, ...(props.selfJid ? { author: props.selfJid.split("/")[0] } : {}) });
-  composerBody.value = "";
 }
 
 type FeedItem =
@@ -216,9 +214,16 @@ const filters = computed(() => [
   { id: "posts" as const, label: "Posts", count: props.entries.filter((entry) => !entry.source).length },
 ]);
 
+const activeStoryIndex = computed<number | null>(() => {
+  const id = activeStoryId.value;
+  if (!id) return null;
+  const index = props.stories.findIndex((story) => story.id === id);
+  return index >= 0 ? index : null;
+});
+
 const activeStory = computed<Story | null>(() => {
-  if (activeStoryIndex.value === null) return null;
-  return props.stories[activeStoryIndex.value] ?? null;
+  const index = activeStoryIndex.value;
+  return index === null ? null : props.stories[index] ?? null;
 });
 
 const activeReactionSummary = computed(() => activeStory.value ? props.reactionSummary(activeStory.value.id) : null);
@@ -243,46 +248,26 @@ function isVideoStory(story: Story): boolean {
 }
 
 function selectStory(index: number) {
-  activeStoryIndex.value = index;
   const story = props.stories[index];
-  if (story?.id) emit("storySelected", story.id);
+  if (!story?.id) return;
+  activeStoryId.value = story.id;
+  emit("storySelected", story.id);
 }
 
 function closeReader() {
-  activeStoryIndex.value = null;
+  activeStoryId.value = null;
 }
 
 function prevStory() {
-  if (activeStoryIndex.value === null || activeStoryIndex.value <= 0) return;
-  selectStory(activeStoryIndex.value - 1);
+  const index = activeStoryIndex.value;
+  if (index === null || index <= 0) return;
+  selectStory(index - 1);
 }
 
 function nextStory() {
-  if (activeStoryIndex.value === null || activeStoryIndex.value >= props.stories.length - 1) return;
-  selectStory(activeStoryIndex.value + 1);
-}
-
-async function handleStorySubmit(payload: { body?: string; file: Blob; mediaKind: "image" | "video" }) {
-  const client = connectionStore.client;
-  if (!client) {
-    storyComposerError.value = "Not connected.";
-    return;
-  }
-  storyComposerError.value = null;
-  storyComposerBusy.value = true;
-  try {
-    const uploaded = await client.uploadStoryMedia(payload.file);
-    emit("postStory", {
-      ...(payload.body ? { body: payload.body } : {}),
-      mediaUrl: uploaded.url,
-      ...(props.selfJid ? { author: props.selfJid.split("/")[0] } : {}),
-    });
-    storyComposerOpen.value = false;
-  } catch (err) {
-    storyComposerError.value = err instanceof Error ? err.message : "Couldn't upload — please try again.";
-  } finally {
-    storyComposerBusy.value = false;
-  }
+  const index = activeStoryIndex.value;
+  if (index === null || index >= props.stories.length - 1) return;
+  selectStory(index + 1);
 }
 
 function toggleReaction(emoji: string) {
@@ -338,56 +323,19 @@ function toggleReaction(emoji: string) {
         </button>
       </div>
 
-      <form
-        v-if="canPost && activeFilter !== 'stories' && activeFilter !== 'pep'"
-        class="grid gap-3 rounded-xl border border-border bg-card p-4 shadow-sm focus-within:ring-1 focus-within:ring-ring/40"
-        @submit.prevent="submit"
-      >
-        <div class="flex items-start gap-3">
-          <AppAvatar :name="authorLabel(selfJid ?? '')" :src="null" size="md" />
-          <textarea
-            v-model="composerBody"
-            class="min-h-[4rem] w-full resize-y rounded-lg border border-input bg-background px-3 py-2.5 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-            placeholder="Share something with the community…"
-            :disabled="isPosting"
-            aria-label="Feed post body"
-          />
-        </div>
-        <div class="flex items-center justify-between gap-2 pl-[3.25rem]">
-          <span
-            class="type-caption"
-            :class="composerOver ? 'text-destructive' : 'text-muted-foreground'"
-          >
-            {{ composerBody.length }} / {{ COMPOSER_MAX }}
-          </span>
-          <button
-            type="submit"
-            class="inline-flex items-center gap-1.5 rounded-md bg-primary px-3.5 py-1.5 text-xs font-medium text-primary-foreground shadow-sm transition-opacity hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
-            :disabled="!canSubmit || composerOver"
-          >
-            <Send class="h-3.5 w-3.5" aria-hidden="true" />
-            {{ isPosting ? "Posting…" : "Post" }}
-          </button>
-        </div>
-      </form>
-
-      <div v-if="canPost && activeFilter !== 'pep' && activeFilter !== 'posts'" class="rounded-xl border border-dashed border-border bg-card/70 p-3">
-        <button
-          type="button"
-          class="inline-flex items-center gap-2 rounded-md border border-input px-3 py-2 text-sm text-foreground hover:border-primary/60 hover:bg-muted/50 hover:text-primary"
-          :disabled="isStoryPosting"
-          @click="storyComposerOpen = !storyComposerOpen"
-        >
-          <Plus class="h-4 w-4" aria-hidden="true" />
-          {{ storyComposerOpen ? "Close story composer" : "Add story" }}
-        </button>
-      </div>
-
-      <StoryComposer
-        v-if="storyComposerOpen && activeFilter !== 'pep' && activeFilter !== 'posts'"
-        :busy="storyComposerBusy || isStoryPosting"
-        @submit="handleStorySubmit"
-        @cancel="storyComposerOpen = false; storyComposerError = null"
+      <FeedUpdateComposer
+        v-if="canPost"
+        :self-jid="selfJid"
+        :is-posting="isPosting"
+        :is-story-posting="isStoryPosting"
+        :publish-post="publishPost"
+        :publish-story="publishStory"
+        :initial-mode="initialComposerMode"
+        :publish-mood="publishMood"
+        :publish-activity="publishActivity"
+        :publish-tune="publishTune"
+        :fetch-profile="fetchProfile"
+        :publish-profile="publishProfile"
       />
 
       <div
@@ -402,10 +350,6 @@ function toggleReaction(emoji: string) {
       >
         Couldn't load stories: {{ storiesError }}
       </div>
-      <div v-if="storyComposerError" class="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-        {{ storyComposerError }}
-      </div>
-
       <div class="grid gap-3">
         <article
           v-for="item in feedItems"
@@ -556,99 +500,18 @@ function toggleReaction(emoji: string) {
         </div>
       </div>
 
-      <article
-        v-if="activeStory && activeFilter !== 'pep' && activeFilter !== 'posts'"
-        class="grid gap-3 rounded-xl border border-border bg-card p-4"
-      >
-        <header class="flex items-center gap-3">
-          <AppAvatar :name="authorLabel(activeStory.author)" :src="null" size="sm" />
-          <div class="min-w-0 flex-1">
-            <p class="type-control truncate text-foreground">{{ authorLabel(activeStory.author) }}</p>
-            <p v-if="listedAgo(activeStory)" class="type-caption text-muted-foreground">
-              {{ listedAgo(activeStory) }}
-            </p>
-          </div>
-          <button
-            type="button"
-            class="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/70 hover:text-foreground"
-            aria-label="Close story"
-            @click="closeReader"
-          >
-            <X class="h-4 w-4" aria-hidden="true" />
-          </button>
-        </header>
-
-        <video
-          v-if="activeStory.mediaUrl && isVideoStory(activeStory)"
-          :src="activeStory.mediaUrl"
-          class="max-h-[60vh] w-full rounded-md"
-          controls
-          playsinline
-          referrerpolicy="no-referrer"
-        ></video>
-        <img
-          v-else-if="activeStory.mediaUrl"
-          :src="activeStory.mediaUrl"
-          :alt="`Story media from ${authorLabel(activeStory.author)}`"
-          class="max-h-[60vh] w-full rounded-md object-contain"
-          referrerpolicy="no-referrer"
-        />
-        <p v-if="activeStory.body" class="whitespace-pre-wrap break-words text-sm text-foreground">
-          {{ activeStory.body }}
-        </p>
-
-        <div class="grid gap-2 border-t border-border pt-3">
-          <div class="flex flex-wrap items-center gap-1.5">
-            <button
-              v-for="emoji in QUICK_REACTION_EMOJIS"
-              :key="emoji"
-              type="button"
-              class="inline-flex h-8 min-w-8 items-center justify-center rounded-md border px-2 text-sm hover:bg-muted/60"
-              :class="activeReactionSummary?.mine.includes(emoji) ? 'border-primary bg-primary/10 text-primary' : 'border-input text-foreground'"
-              :aria-label="`React with ${emoji}`"
-              :aria-pressed="activeReactionSummary?.mine.includes(emoji) ? 'true' : 'false'"
-              @click="toggleReaction(emoji)"
-            >
-              {{ emoji }}
-            </button>
-          </div>
-          <div v-if="activeReactionEntries.length > 0" class="flex flex-wrap gap-1.5">
-            <span
-              v-for="entry in activeReactionEntries"
-              :key="entry.emoji"
-              class="inline-flex items-center gap-1 rounded-md border border-border bg-muted/40 px-2 py-1 text-xs text-foreground"
-              :title="entry.reactors.join(', ')"
-            >
-              <span>{{ entry.emoji }}</span>
-              <span class="text-muted-foreground">{{ entry.count }}</span>
-            </span>
-          </div>
-        </div>
-
-        <div class="flex items-center justify-between gap-2 border-t border-border pt-3">
-          <button
-            type="button"
-            class="inline-flex items-center gap-1 rounded-md border border-input px-3 py-1.5 text-xs text-muted-foreground hover:bg-muted/50 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
-            :disabled="activeStoryIndex === null || activeStoryIndex <= 0"
-            @click="prevStory"
-          >
-            <ChevronLeft class="h-3.5 w-3.5" aria-hidden="true" />
-            Prev
-          </button>
-          <span class="type-caption text-muted-foreground" v-if="activeStoryIndex !== null">
-            {{ activeStoryIndex + 1 }} / {{ stories.length }}
-          </span>
-          <button
-            type="button"
-            class="inline-flex items-center gap-1 rounded-md border border-input px-3 py-1.5 text-xs text-muted-foreground hover:bg-muted/50 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
-            :disabled="activeStoryIndex === null || activeStoryIndex >= stories.length - 1"
-            @click="nextStory"
-          >
-            Next
-            <ChevronRight class="h-3.5 w-3.5" aria-hidden="true" />
-          </button>
-        </div>
-      </article>
     </div>
   </div>
+
+  <StoryReaderDialog
+    :story="activeStory"
+    :story-index="activeStoryIndex"
+    :story-count="stories.length"
+    :reaction-summary="activeReactionSummary"
+    :reaction-entries="activeReactionEntries"
+    @close="closeReader"
+    @previous="prevStory"
+    @next="nextStory"
+    @react="toggleReaction"
+  />
 </template>

--- a/chat/src/components/community/FeedUpdateComposer.vue
+++ b/chat/src/components/community/FeedUpdateComposer.vue
@@ -1,0 +1,666 @@
+<script setup lang="ts">
+import { computed, reactive, ref, watch, type Component } from "vue";
+import {
+  Briefcase,
+  Camera,
+  IdCard,
+  MessageSquareText,
+  Music,
+  RefreshCw,
+  Send,
+  Smile,
+} from "lucide-vue-next";
+import AppAvatar from "@/components/ui/AppAvatar.vue";
+import StoryComposer from "@/components/community/StoryComposer.vue";
+import { connectionStore } from "@/lib/connection-store";
+import {
+  buildActivityPublication,
+  buildMoodPublication,
+  buildTunePublication,
+  describeActivityPublication,
+  describeMoodPublication,
+  describeTunePublication,
+  formatPepKeyword,
+  GENERAL_ACTIVITIES,
+  MOOD_KINDS,
+  normalizeActivitySpecific,
+  type ActivityStatusDraft,
+  type ActivityValidationErrors,
+  type MoodStatusDraft,
+  type TuneStatusDraft,
+  type TuneValidationErrors,
+} from "@/lib/status-publication-ui";
+import type { FeedPostInput, StoryPostInput } from "@/lib/xmpp-client";
+import type { ActivityPublication, MoodPublication, TunePublication } from "@/lib/xmpp/pep-types";
+import {
+  draftFromProfile,
+  profileFromDraft,
+  profilesEqual,
+  type VCard4Draft,
+  type VCard4Profile,
+} from "@/lib/xmpp/vcard4-types";
+import type { FeedSurfaceComposerMode } from "@/shell/state";
+
+interface FeedUpdateComposerProps {
+  selfJid: string | null;
+  isPosting: boolean;
+  isStoryPosting: boolean;
+  initialMode?: FeedSurfaceComposerMode;
+  publishPost?: (input: FeedPostInput) => Promise<unknown>;
+  publishStory?: (input: StoryPostInput) => Promise<unknown>;
+  publishMood?: (input: MoodPublication) => Promise<void>;
+  publishActivity?: (input: ActivityPublication) => Promise<void>;
+  publishTune?: (input: TunePublication) => Promise<void>;
+  fetchProfile?: () => Promise<VCard4Profile | null>;
+  publishProfile?: (input: VCard4Profile) => Promise<void>;
+}
+
+const props = withDefaults(defineProps<FeedUpdateComposerProps>(), {
+  initialMode: "post",
+});
+
+type ComposerMode = "post" | "story" | "mood" | "activity" | "tune" | "profile";
+type FeedbackTone = "muted" | "success" | "error";
+
+interface ComposerFeedback {
+  tone: FeedbackTone;
+  message: string;
+}
+
+const COMPOSER_MODES: readonly { id: ComposerMode; label: string; icon: Component }[] = [
+  { id: "post", label: "Post", icon: MessageSquareText },
+  { id: "story", label: "Story", icon: Camera },
+  { id: "mood", label: "Mood", icon: Smile },
+  { id: "activity", label: "Activity", icon: Briefcase },
+  { id: "tune", label: "Tune", icon: Music },
+  { id: "profile", label: "Profile", icon: IdCard },
+];
+
+const fieldLabelClass = "type-section-label text-muted-foreground/75";
+const fieldClass = "rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-50";
+const textareaClass = `${fieldClass} min-h-[4rem] resize-y`;
+const COMPOSER_MAX = 500;
+
+const composerMode = ref<ComposerMode>(props.initialMode);
+const composerBody = ref("");
+const composerFeedback = ref<ComposerFeedback | null>(null);
+const postBusy = ref(false);
+const storyComposerError = ref<string | null>(null);
+const storyComposerBusy = ref(false);
+const storyComposerKey = ref(0);
+const pepBusy = ref<ComposerMode | null>(null);
+
+const moodDraft = reactive<MoodStatusDraft>({
+  kind: "",
+  text: "",
+});
+const activityDraft = reactive<ActivityStatusDraft>({
+  general: "",
+  specific: "",
+  text: "",
+});
+const tuneDraft = reactive<TuneStatusDraft>({
+  artist: "",
+  title: "",
+  source: "",
+  length: "",
+  rating: "",
+  track: "",
+  uri: "",
+});
+const activityErrors = ref<ActivityValidationErrors>({});
+const tuneErrors = ref<TuneValidationErrors>({});
+const profileDraft = reactive<VCard4Draft>(draftFromProfile(null));
+const profilePersisted = ref<VCard4Profile>({});
+const profileLoaded = ref(false);
+const profileLoading = ref(false);
+let profileLoadRequestId = 0;
+const normalizedActivitySpecific = computed(() => normalizeActivitySpecific(activityDraft.specific));
+
+const canSubmitPost = computed(() => {
+  return !props.isPosting && !postBusy.value && composerBody.value.trim().length > 0;
+});
+const composerOver = computed(() => composerBody.value.length > COMPOSER_MAX);
+
+watch(composerMode, (mode) => {
+  composerFeedback.value = null;
+  storyComposerError.value = null;
+  if (mode === "profile" && !profileLoaded.value && !profileLoading.value) {
+    void loadProfileDraft();
+  }
+});
+
+watch(() => props.selfJid, () => {
+  profileLoadRequestId += 1;
+  profileLoaded.value = false;
+  profileLoading.value = false;
+  profilePersisted.value = {};
+  applyProfileDraft({});
+  if (composerMode.value === "profile" && props.selfJid) {
+    void loadProfileDraft();
+  }
+});
+
+watch(() => props.initialMode, (mode) => {
+  composerMode.value = mode;
+});
+
+function authorLabel(author: string | undefined): string {
+  if (!author) return "Anonymous";
+  return author.split("@")[0] ?? author;
+}
+
+function feedbackClass(tone: FeedbackTone): string {
+  switch (tone) {
+    case "success":
+      return "text-emerald-700 dark:text-emerald-300";
+    case "error":
+      return "text-destructive";
+    default:
+      return "text-muted-foreground";
+  }
+}
+
+function errorMessage(value: unknown, fallback = "Something went wrong."): string {
+  return value instanceof Error ? value.message : fallback;
+}
+
+function setComposerFeedback(mode: ComposerMode, tone: FeedbackTone, message: string) {
+  if (composerMode.value !== mode) return;
+  composerFeedback.value = { tone, message };
+}
+
+function applyProfileDraft(profile: VCard4Profile) {
+  const next = draftFromProfile(profile);
+  profileDraft.fullName = next.fullName;
+  profileDraft.nickname = next.nickname;
+  profileDraft.pronouns = next.pronouns;
+  profileDraft.note = next.note;
+  profileDraft.url = next.url;
+  profileDraft.photoUri = next.photoUri;
+}
+
+async function loadProfileDraft() {
+  if (!props.fetchProfile) {
+    profileLoaded.value = false;
+    setComposerFeedback("profile", "error", "Reconnect before loading your profile.");
+    return;
+  }
+  const requestId = ++profileLoadRequestId;
+  const selfJid = props.selfJid;
+  profileLoading.value = true;
+  try {
+    const profile = await props.fetchProfile();
+    if (requestId !== profileLoadRequestId || selfJid !== props.selfJid) return;
+    const next = profile ?? {};
+    profilePersisted.value = next;
+    applyProfileDraft(next);
+    profileLoaded.value = true;
+    setComposerFeedback("profile", "muted", profile ? "Profile loaded." : "No profile saved yet.");
+  } catch (err) {
+    if (requestId !== profileLoadRequestId || selfJid !== props.selfJid) return;
+    profileLoaded.value = false;
+    setComposerFeedback("profile", "error", `Couldn't load profile: ${errorMessage(err)}`);
+  } finally {
+    if (requestId === profileLoadRequestId) {
+      profileLoading.value = false;
+    }
+  }
+}
+
+async function submitPost() {
+  const body = composerBody.value.trim();
+  if (!body || composerOver.value) return;
+  if (!props.publishPost) {
+    setComposerFeedback("post", "error", "Reconnect before publishing your post.");
+    return;
+  }
+  postBusy.value = true;
+  try {
+    await props.publishPost({ body, ...(props.selfJid ? { author: props.selfJid.split("/")[0] } : {}) });
+    composerBody.value = "";
+    setComposerFeedback("post", "success", "Post shared.");
+  } catch (err) {
+    setComposerFeedback("post", "error", errorMessage(err, "Couldn't publish your post."));
+  } finally {
+    postBusy.value = false;
+  }
+}
+
+async function handleStorySubmit(payload: { body?: string; file: Blob; mediaKind: "image" | "video" }) {
+  const client = connectionStore.client;
+  if (!client || !props.publishStory) {
+    storyComposerError.value = "Not connected.";
+    return;
+  }
+  storyComposerError.value = null;
+  storyComposerBusy.value = true;
+  try {
+    const uploaded = await client.uploadStoryMedia(payload.file);
+    await props.publishStory({
+      ...(payload.body ? { body: payload.body } : {}),
+      mediaUrl: uploaded.url,
+      ...(props.selfJid ? { author: props.selfJid.split("/")[0] } : {}),
+    });
+    storyComposerKey.value += 1;
+    setComposerFeedback("story", "success", "Story shared.");
+  } catch (err) {
+    if (composerMode.value === "story") {
+      storyComposerError.value = errorMessage(err, "Couldn't upload - please try again.");
+    }
+  } finally {
+    storyComposerBusy.value = false;
+  }
+}
+
+async function publishMood() {
+  const { publication, error } = buildMoodPublication(moodDraft);
+  if (!publication) {
+    setComposerFeedback("mood", "error", error ?? "Choose a mood to share.");
+    return;
+  }
+  if (!props.publishMood) {
+    setComposerFeedback("mood", "error", "Reconnect before publishing your mood.");
+    return;
+  }
+  pepBusy.value = "mood";
+  try {
+    await props.publishMood(publication);
+    moodDraft.text = publication.text ?? "";
+    setComposerFeedback("mood", "success", describeMoodPublication(publication));
+  } catch (err) {
+    setComposerFeedback("mood", "error", errorMessage(err, "Couldn't publish your mood."));
+  } finally {
+    pepBusy.value = null;
+  }
+}
+
+async function publishActivity() {
+  const { publication, errors } = buildActivityPublication(activityDraft);
+  activityErrors.value = errors;
+  if (!publication) {
+    setComposerFeedback("activity", "error", "Check the activity fields and try again.");
+    return;
+  }
+  if (!props.publishActivity) {
+    setComposerFeedback("activity", "error", "Reconnect before publishing your activity.");
+    return;
+  }
+  pepBusy.value = "activity";
+  try {
+    await props.publishActivity(publication);
+    activityDraft.specific = normalizedActivitySpecific.value;
+    activityDraft.text = publication.text ?? "";
+    setComposerFeedback("activity", "success", describeActivityPublication(publication));
+  } catch (err) {
+    setComposerFeedback("activity", "error", errorMessage(err, "Couldn't publish your activity."));
+  } finally {
+    pepBusy.value = null;
+  }
+}
+
+function applyTuneDraft(publication: TunePublication) {
+  tuneDraft.artist = publication.artist ?? "";
+  tuneDraft.title = publication.title ?? "";
+  tuneDraft.source = publication.source ?? "";
+  tuneDraft.length = publication.length?.toString() ?? "";
+  tuneDraft.rating = publication.rating?.toString() ?? "";
+  tuneDraft.track = publication.track ?? "";
+  tuneDraft.uri = publication.uri ?? "";
+}
+
+async function publishTune() {
+  const { publication, errors } = buildTunePublication(tuneDraft);
+  tuneErrors.value = errors;
+  if (!publication) {
+    setComposerFeedback("tune", "error", errors.form ?? "Check the tune fields and try again.");
+    return;
+  }
+  if (!props.publishTune) {
+    setComposerFeedback("tune", "error", "Reconnect before publishing your tune.");
+    return;
+  }
+  pepBusy.value = "tune";
+  try {
+    await props.publishTune(publication);
+    applyTuneDraft(publication);
+    setComposerFeedback("tune", "success", describeTunePublication(publication));
+  } catch (err) {
+    setComposerFeedback("tune", "error", errorMessage(err, "Couldn't publish your tune."));
+  } finally {
+    pepBusy.value = null;
+  }
+}
+
+async function publishProfile() {
+  if (!props.publishProfile) {
+    setComposerFeedback("profile", "error", "Reconnect before publishing your profile.");
+    return;
+  }
+  if (!profileLoaded.value) {
+    setComposerFeedback("profile", "error", "Load your saved profile before publishing changes.");
+    return;
+  }
+  const next = profileFromDraft(profileDraft);
+  if (profilesEqual(next, profilePersisted.value)) {
+    setComposerFeedback("profile", "muted", "Nothing to publish.");
+    return;
+  }
+  const previous = profilePersisted.value;
+  profilePersisted.value = next;
+  pepBusy.value = "profile";
+  try {
+    await props.publishProfile(next);
+    profileLoaded.value = true;
+    setComposerFeedback("profile", "success", "Profile published.");
+  } catch (err) {
+    profilePersisted.value = previous;
+    applyProfileDraft(previous);
+    setComposerFeedback("profile", "error", errorMessage(err, "Couldn't publish your profile."));
+  } finally {
+    pepBusy.value = null;
+  }
+}
+</script>
+
+<template>
+  <section
+    class="grid gap-3 rounded-xl border border-border bg-card p-4 shadow-sm focus-within:ring-1 focus-within:ring-ring/40"
+    aria-label="Create feed update"
+  >
+    <div class="flex items-center gap-3">
+      <AppAvatar :name="authorLabel(selfJid ?? '')" :src="null" size="md" />
+      <div class="min-w-0 flex-1">
+        <div class="flex flex-wrap items-center gap-1" role="tablist" aria-label="Feed update type">
+          <button
+            v-for="mode in COMPOSER_MODES"
+            :key="mode.id"
+            type="button"
+            role="tab"
+            class="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs transition-colors"
+            :class="composerMode === mode.id ? 'border-primary bg-primary/10 text-primary' : 'border-input text-muted-foreground hover:bg-muted/50 hover:text-foreground'"
+            :aria-selected="composerMode === mode.id ? 'true' : 'false'"
+            @click="composerMode = mode.id"
+          >
+            <component :is="mode.icon" class="h-3.5 w-3.5" aria-hidden="true" />
+            {{ mode.label }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <form v-if="composerMode === 'post'" class="grid gap-3" @submit.prevent="submitPost">
+      <textarea
+        v-model="composerBody"
+        :class="textareaClass"
+        placeholder="Share something with the community..."
+        :disabled="isPosting || postBusy"
+        aria-label="Feed post body"
+      />
+      <div class="flex items-center justify-between gap-2">
+        <span class="type-caption" :class="composerOver ? 'text-destructive' : 'text-muted-foreground'">
+          {{ composerBody.length }} / {{ COMPOSER_MAX }}
+        </span>
+        <button
+          type="submit"
+          class="inline-flex items-center gap-1.5 rounded-md bg-primary px-3.5 py-1.5 text-xs font-medium text-primary-foreground shadow-sm transition-opacity hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+          :disabled="!canSubmitPost || composerOver"
+        >
+          <Send class="h-3.5 w-3.5" aria-hidden="true" />
+          {{ isPosting || postBusy ? "Posting..." : "Post" }}
+        </button>
+      </div>
+    </form>
+
+    <StoryComposer
+      v-else-if="composerMode === 'story'"
+      :key="storyComposerKey"
+      embedded
+      :busy="storyComposerBusy || isStoryPosting"
+      @submit="handleStorySubmit"
+      @cancel="storyComposerError = null"
+    />
+
+    <form v-else-if="composerMode === 'mood'" class="grid gap-3" @submit.prevent="publishMood">
+      <div class="grid gap-3 sm:grid-cols-[minmax(0,12rem)_minmax(0,1fr)]">
+        <label class="grid gap-1.5">
+          <span :class="fieldLabelClass">Mood</span>
+          <select v-model="moodDraft.kind" :class="fieldClass" :disabled="pepBusy === 'mood'">
+            <option value="">Choose mood</option>
+            <option v-for="kind in MOOD_KINDS" :key="kind" :value="kind">
+              {{ formatPepKeyword(kind) }}
+            </option>
+          </select>
+        </label>
+        <label class="grid gap-1.5">
+          <span :class="fieldLabelClass">Text</span>
+          <input
+            v-model="moodDraft.text"
+            :class="fieldClass"
+            :disabled="pepBusy === 'mood'"
+            maxlength="180"
+            placeholder="Optional note"
+            type="text"
+          />
+        </label>
+      </div>
+      <div class="flex justify-end">
+        <button
+          type="submit"
+          class="inline-flex items-center gap-1.5 rounded-md bg-primary px-3.5 py-1.5 text-xs font-medium text-primary-foreground shadow-sm hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+          :disabled="pepBusy !== null"
+        >
+          <Smile class="h-3.5 w-3.5" aria-hidden="true" />
+          {{ pepBusy === 'mood' ? "Publishing..." : "Publish mood" }}
+        </button>
+      </div>
+    </form>
+
+    <form v-else-if="composerMode === 'activity'" class="grid gap-3" @submit.prevent="publishActivity">
+      <div class="grid gap-3 sm:grid-cols-[minmax(0,12rem)_minmax(0,1fr)]">
+        <label class="grid gap-1.5">
+          <span :class="fieldLabelClass">Activity</span>
+          <select v-model="activityDraft.general" :class="fieldClass" :disabled="pepBusy === 'activity'">
+            <option value="">Choose activity</option>
+            <option v-for="general in GENERAL_ACTIVITIES" :key="general" :value="general">
+              {{ formatPepKeyword(general) }}
+            </option>
+          </select>
+          <span v-if="activityErrors.general" class="type-caption text-destructive">{{ activityErrors.general }}</span>
+        </label>
+        <label class="grid gap-1.5">
+          <span :class="fieldLabelClass">Specific</span>
+          <input
+            v-model="activityDraft.specific"
+            :class="fieldClass"
+            :disabled="pepBusy === 'activity'"
+            maxlength="80"
+            placeholder="Optional detail"
+            type="text"
+          />
+          <span v-if="activityErrors.specific" class="type-caption text-destructive">{{ activityErrors.specific }}</span>
+        </label>
+      </div>
+      <label class="grid gap-1.5">
+        <span :class="fieldLabelClass">Text</span>
+        <input
+          v-model="activityDraft.text"
+          :class="fieldClass"
+          :disabled="pepBusy === 'activity'"
+          maxlength="180"
+          placeholder="Optional note"
+          type="text"
+        />
+      </label>
+      <div class="flex justify-end">
+        <button
+          type="submit"
+          class="inline-flex items-center gap-1.5 rounded-md bg-primary px-3.5 py-1.5 text-xs font-medium text-primary-foreground shadow-sm hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+          :disabled="pepBusy !== null"
+        >
+          <Briefcase class="h-3.5 w-3.5" aria-hidden="true" />
+          {{ pepBusy === 'activity' ? "Publishing..." : "Publish activity" }}
+        </button>
+      </div>
+    </form>
+
+    <form v-else-if="composerMode === 'tune'" class="grid gap-3" @submit.prevent="publishTune">
+      <div class="grid gap-3 sm:grid-cols-2">
+        <label class="grid gap-1.5">
+          <span :class="fieldLabelClass">Title</span>
+          <input
+            v-model="tuneDraft.title"
+            :class="fieldClass"
+            :disabled="pepBusy === 'tune'"
+            maxlength="160"
+            type="text"
+          />
+        </label>
+        <label class="grid gap-1.5">
+          <span :class="fieldLabelClass">Artist</span>
+          <input
+            v-model="tuneDraft.artist"
+            :class="fieldClass"
+            :disabled="pepBusy === 'tune'"
+            maxlength="160"
+            type="text"
+          />
+        </label>
+        <label class="grid gap-1.5">
+          <span :class="fieldLabelClass">Source</span>
+          <input
+            v-model="tuneDraft.source"
+            :class="fieldClass"
+            :disabled="pepBusy === 'tune'"
+            maxlength="160"
+            type="text"
+          />
+        </label>
+        <label class="grid gap-1.5">
+          <span :class="fieldLabelClass">URI</span>
+          <input
+            v-model="tuneDraft.uri"
+            :class="fieldClass"
+            :disabled="pepBusy === 'tune'"
+            maxlength="240"
+            type="text"
+          />
+          <span v-if="tuneErrors.uri" class="type-caption text-destructive">{{ tuneErrors.uri }}</span>
+        </label>
+        <label class="grid gap-1.5">
+          <span :class="fieldLabelClass">Length</span>
+          <input
+            v-model="tuneDraft.length"
+            :class="fieldClass"
+            :disabled="pepBusy === 'tune'"
+            inputmode="numeric"
+            type="text"
+          />
+          <span v-if="tuneErrors.length" class="type-caption text-destructive">{{ tuneErrors.length }}</span>
+        </label>
+        <label class="grid gap-1.5">
+          <span :class="fieldLabelClass">Rating</span>
+          <input
+            v-model="tuneDraft.rating"
+            :class="fieldClass"
+            :disabled="pepBusy === 'tune'"
+            inputmode="numeric"
+            type="text"
+          />
+          <span v-if="tuneErrors.rating" class="type-caption text-destructive">{{ tuneErrors.rating }}</span>
+        </label>
+      </div>
+      <p v-if="tuneErrors.form" class="type-caption text-destructive">{{ tuneErrors.form }}</p>
+      <div class="flex justify-end">
+        <button
+          type="submit"
+          class="inline-flex items-center gap-1.5 rounded-md bg-primary px-3.5 py-1.5 text-xs font-medium text-primary-foreground shadow-sm hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+          :disabled="pepBusy !== null"
+        >
+          <Music class="h-3.5 w-3.5" aria-hidden="true" />
+          {{ pepBusy === 'tune' ? "Publishing..." : "Publish tune" }}
+        </button>
+      </div>
+    </form>
+
+    <form v-else class="grid gap-3" @submit.prevent="publishProfile">
+      <div class="grid gap-3 sm:grid-cols-2">
+        <label class="grid gap-1.5">
+          <span :class="fieldLabelClass">Full name</span>
+          <input
+            v-model="profileDraft.fullName"
+            :class="fieldClass"
+            :disabled="profileLoading || pepBusy === 'profile'"
+            maxlength="160"
+            type="text"
+          />
+        </label>
+        <label class="grid gap-1.5">
+          <span :class="fieldLabelClass">Nickname</span>
+          <input
+            v-model="profileDraft.nickname"
+            :class="fieldClass"
+            :disabled="profileLoading || pepBusy === 'profile'"
+            maxlength="80"
+            type="text"
+          />
+        </label>
+        <label class="grid gap-1.5">
+          <span :class="fieldLabelClass">Pronouns</span>
+          <input
+            v-model="profileDraft.pronouns"
+            :class="fieldClass"
+            :disabled="profileLoading || pepBusy === 'profile'"
+            maxlength="48"
+            type="text"
+          />
+        </label>
+        <label class="grid gap-1.5">
+          <span :class="fieldLabelClass">URL</span>
+          <input
+            v-model="profileDraft.url"
+            :class="fieldClass"
+            :disabled="profileLoading || pepBusy === 'profile'"
+            maxlength="240"
+            type="url"
+          />
+        </label>
+      </div>
+      <label class="grid gap-1.5">
+        <span :class="fieldLabelClass">Bio</span>
+        <textarea
+          v-model="profileDraft.note"
+          :class="textareaClass"
+          :disabled="profileLoading || pepBusy === 'profile'"
+          maxlength="500"
+        />
+      </label>
+      <div class="flex items-center justify-between gap-2">
+        <button
+          type="button"
+          class="inline-flex items-center gap-1.5 rounded-md border border-input px-3 py-1.5 text-xs text-muted-foreground hover:bg-muted/50 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
+          :disabled="profileLoading || pepBusy !== null"
+          @click="loadProfileDraft"
+        >
+          <RefreshCw class="h-3.5 w-3.5" :class="{ 'animate-spin': profileLoading }" aria-hidden="true" />
+          {{ profileLoading ? "Loading..." : "Reload" }}
+        </button>
+        <button
+          type="submit"
+          class="inline-flex items-center gap-1.5 rounded-md bg-primary px-3.5 py-1.5 text-xs font-medium text-primary-foreground shadow-sm hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+          :disabled="profileLoading || pepBusy !== null || !profileLoaded"
+        >
+          <IdCard class="h-3.5 w-3.5" aria-hidden="true" />
+          {{ pepBusy === 'profile' ? "Publishing..." : "Publish profile" }}
+        </button>
+      </div>
+    </form>
+
+    <p v-if="composerFeedback" class="type-caption" :class="feedbackClass(composerFeedback.tone)" role="status">
+      {{ composerFeedback.message }}
+    </p>
+    <p v-if="composerMode === 'story' && storyComposerError" class="type-caption text-destructive" role="status">
+      {{ storyComposerError }}
+    </p>
+  </section>
+</template>

--- a/chat/src/components/community/StoryComposer.vue
+++ b/chat/src/components/community/StoryComposer.vue
@@ -10,11 +10,14 @@ interface StoryComposerProps {
   busy?: boolean;
   /** Hard size cap from XEP-0363 service. */
   maxBytes?: number;
+  /** Removes the outer card chrome when nested inside a parent composer. */
+  embedded?: boolean;
 }
 
 const props = withDefaults(defineProps<StoryComposerProps>(), {
   busy: false,
   maxBytes: 10 * 1024 * 1024,
+  embedded: false,
 });
 
 const emit = defineEmits<{
@@ -349,7 +352,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <section class="grid gap-3 rounded-lg border border-border bg-card p-3">
+  <section :class="embedded ? 'grid gap-3' : 'grid gap-3 rounded-lg border border-border bg-card p-3'">
     <div role="tablist" aria-label="Composer mode" class="flex gap-1 rounded-md bg-muted/40 p-1">
       <button
         type="button"

--- a/chat/src/components/community/StoryReaderDialog.vue
+++ b/chat/src/components/community/StoryReaderDialog.vue
@@ -1,0 +1,237 @@
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from "vue";
+import { ChevronLeft, ChevronRight, X } from "lucide-vue-next";
+import AppAvatar from "@/components/ui/AppAvatar.vue";
+import { QUICK_REACTION_EMOJIS } from "@/lib/reaction-mode";
+import type { Story, StoryReactionSummary } from "@/lib/xmpp-client";
+
+interface StoryReactionEntry {
+  emoji: string;
+  count: number;
+  reactors: readonly string[];
+}
+
+const props = defineProps<{
+  story: Story | null;
+  storyIndex: number | null;
+  storyCount: number;
+  reactionSummary: StoryReactionSummary | null;
+  reactionEntries: readonly StoryReactionEntry[];
+}>();
+
+const emit = defineEmits<{
+  close: [];
+  previous: [];
+  next: [];
+  react: [emoji: string];
+}>();
+
+const dialogEl = ref<HTMLElement | null>(null);
+const previouslyFocused = ref<HTMLElement | null>(null);
+
+const hasPrevious = computed(() => props.storyIndex !== null && props.storyIndex > 0);
+const hasNext = computed(() => props.storyIndex !== null && props.storyIndex < props.storyCount - 1);
+
+watch(
+  () => props.story,
+  async (story, previous) => {
+    if (story && !previous) {
+      previouslyFocused.value = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      await nextTick();
+      dialogEl.value?.focus();
+    } else if (!story && previous) {
+      previouslyFocused.value?.focus();
+      previouslyFocused.value = null;
+    }
+  },
+);
+
+function listedAgo(story: Story): string {
+  if (typeof story.postedMs !== "number") return "";
+  const delta = Math.max(0, Date.now() - story.postedMs);
+  if (delta < 60_000) return "just now";
+  if (delta < 3_600_000) return `${plural(Math.floor(delta / 60_000), "minute")} ago`;
+  if (delta < 86_400_000) return `${plural(Math.floor(delta / 3_600_000), "hour")} ago`;
+  if (delta < 604_800_000) return `${plural(Math.floor(delta / 86_400_000), "day")} ago`;
+  return new Date(story.postedMs).toLocaleDateString();
+}
+
+function plural(value: number, unit: string): string {
+  return `${value} ${unit}${value === 1 ? "" : "s"}`;
+}
+
+function authorLabel(author: string | undefined): string {
+  if (!author) return "Anonymous";
+  return author.split("@")[0] ?? author;
+}
+
+function isVideoStory(story: Story): boolean {
+  return Boolean(story.mediaUrl && /\.(mp4|webm|mov)(\?|$)/i.test(story.mediaUrl));
+}
+
+function eventTargetUsesArrows(target: EventTarget | null): boolean {
+  return target instanceof HTMLElement && Boolean(target.closest("video,audio,input,textarea,select,[contenteditable='true']"));
+}
+
+function focusableElements(): HTMLElement[] {
+  const root = dialogEl.value;
+  if (!root) return [];
+  return Array.from(root.querySelectorAll<HTMLElement>(
+    "button:not([disabled]), a[href], input:not([disabled]), textarea:not([disabled]), select:not([disabled]), video[controls], [tabindex]:not([tabindex='-1'])",
+  )).filter((el) => !el.hasAttribute("disabled") && el.tabIndex !== -1);
+}
+
+function trapTab(event: KeyboardEvent) {
+  const focusables = focusableElements();
+  if (focusables.length === 0) {
+    event.preventDefault();
+    dialogEl.value?.focus();
+    return;
+  }
+  const first = focusables[0];
+  const last = focusables[focusables.length - 1];
+  if (event.shiftKey && document.activeElement === first) {
+    event.preventDefault();
+    last?.focus();
+  } else if (!event.shiftKey && document.activeElement === last) {
+    event.preventDefault();
+    first?.focus();
+  }
+}
+
+function onKeydown(event: KeyboardEvent) {
+  if (!props.story) return;
+  if (event.key === "Escape") {
+    event.preventDefault();
+    emit("close");
+    return;
+  }
+  if (event.key === "Tab") {
+    trapTab(event);
+    return;
+  }
+  if (eventTargetUsesArrows(event.target)) return;
+  if (event.key === "ArrowLeft" && hasPrevious.value) {
+    event.preventDefault();
+    emit("previous");
+  } else if (event.key === "ArrowRight" && hasNext.value) {
+    event.preventDefault();
+    emit("next");
+  }
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="story"
+      class="z-modal fixed inset-0 flex items-end justify-center p-3 sm:items-center sm:p-6"
+      role="presentation"
+    >
+      <div class="absolute inset-0 bg-background/75 backdrop-blur-md" @click="emit('close')" />
+      <article
+        ref="dialogEl"
+        class="relative grid max-h-[calc(100dvh-1.5rem)] w-full max-w-2xl grid-rows-[auto_minmax(0,1fr)_auto_auto] overflow-hidden rounded-lg border border-border bg-card shadow-2xl animate-slide-up"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Story"
+        tabindex="-1"
+        @click.stop
+        @keydown="onKeydown"
+      >
+        <header class="flex items-center gap-3 border-b border-border px-4 py-3">
+          <AppAvatar :name="authorLabel(story.author)" :src="null" size="sm" />
+          <div class="min-w-0 flex-1">
+            <p class="type-control truncate text-foreground">{{ authorLabel(story.author) }}</p>
+            <p v-if="listedAgo(story)" class="type-caption text-muted-foreground">
+              {{ listedAgo(story) }}
+            </p>
+          </div>
+          <button
+            type="button"
+            class="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/70 hover:text-foreground"
+            aria-label="Close story"
+            @click="emit('close')"
+          >
+            <X class="h-4 w-4" aria-hidden="true" />
+          </button>
+        </header>
+
+        <div class="flex min-h-0 flex-col gap-3 overflow-y-auto px-4 py-3">
+          <div v-if="story.mediaUrl" class="flex min-h-[12rem] items-center justify-center rounded-md bg-muted">
+            <video
+              v-if="isVideoStory(story)"
+              :src="story.mediaUrl"
+              class="max-h-[min(56dvh,34rem)] w-full rounded-md"
+              controls
+              playsinline
+              referrerpolicy="no-referrer"
+            ></video>
+            <img
+              v-else
+              :src="story.mediaUrl"
+              :alt="`Story media from ${authorLabel(story.author)}`"
+              class="max-h-[min(56dvh,34rem)] w-full rounded-md object-contain"
+              referrerpolicy="no-referrer"
+            />
+          </div>
+          <p v-if="story.body" class="whitespace-pre-wrap break-words text-sm text-foreground">
+            {{ story.body }}
+          </p>
+        </div>
+
+        <div class="grid gap-2 border-t border-border px-4 py-3">
+          <div class="flex flex-wrap items-center gap-1.5">
+            <button
+              v-for="emoji in QUICK_REACTION_EMOJIS"
+              :key="emoji"
+              type="button"
+              class="inline-flex h-8 min-w-8 items-center justify-center rounded-md border px-2 text-sm hover:bg-muted/60"
+              :class="reactionSummary?.mine.includes(emoji) ? 'border-primary bg-primary/10 text-primary' : 'border-input text-foreground'"
+              :aria-label="`React with ${emoji}`"
+              :aria-pressed="reactionSummary?.mine.includes(emoji) ? 'true' : 'false'"
+              @click="emit('react', emoji)"
+            >
+              {{ emoji }}
+            </button>
+          </div>
+          <div v-if="reactionEntries.length > 0" class="flex flex-wrap gap-1.5">
+            <span
+              v-for="entry in reactionEntries"
+              :key="entry.emoji"
+              class="inline-flex items-center gap-1 rounded-md border border-border bg-muted/40 px-2 py-1 text-xs text-foreground"
+              :title="entry.reactors.join(', ')"
+            >
+              <span>{{ entry.emoji }}</span>
+              <span class="text-muted-foreground">{{ entry.count }}</span>
+            </span>
+          </div>
+        </div>
+
+        <div class="flex items-center justify-between gap-2 border-t border-border px-4 py-3">
+          <button
+            type="button"
+            class="inline-flex items-center gap-1 rounded-md border border-input px-3 py-1.5 text-xs text-muted-foreground hover:bg-muted/50 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+            :disabled="!hasPrevious"
+            @click="emit('previous')"
+          >
+            <ChevronLeft class="h-3.5 w-3.5" aria-hidden="true" />
+            Prev
+          </button>
+          <span class="type-caption text-muted-foreground" v-if="storyIndex !== null">
+            {{ storyIndex + 1 }} / {{ storyCount }}
+          </span>
+          <button
+            type="button"
+            class="inline-flex items-center gap-1 rounded-md border border-input px-3 py-1.5 text-xs text-muted-foreground hover:bg-muted/50 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+            :disabled="!hasNext"
+            @click="emit('next')"
+          >
+            Next
+            <ChevronRight class="h-3.5 w-3.5" aria-hidden="true" />
+          </button>
+        </div>
+      </article>
+    </div>
+  </Teleport>
+</template>

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -2747,6 +2747,7 @@ export class BrowserXmppClient {
     if (payload.pronouns) profile.pronouns = payload.pronouns;
     if (payload.note) profile.note = payload.note;
     if (payload.url) profile.url = payload.url;
+    if (payload.photo_uri) profile.photoUri = payload.photo_uri;
     return profile;
   }
   async publishVCard4(profile: VCard4Profile): Promise<void> {
@@ -2757,6 +2758,7 @@ export class BrowserXmppClient {
     if (profile.pronouns) payload.pronouns = profile.pronouns;
     if (profile.note) payload.note = profile.note;
     if (profile.url) payload.url = profile.url;
+    if (profile.photoUri) payload.photo_uri = profile.photoUri;
     await xmpp.publish_vcard4?.(payload);
   }
 

--- a/chat/src/lib/xmpp/vcard4-types.ts
+++ b/chat/src/lib/xmpp/vcard4-types.ts
@@ -18,6 +18,8 @@ export interface VCard4Profile {
   pronouns?: string;
   note?: string;
   url?: string;
+  /** Preserved vCard4 PHOTO URI, usually mirrored from XEP-0084 avatar publishing. */
+  photoUri?: string;
 }
 
 /** Mutable draft used by the editor while the user is typing. */
@@ -27,17 +29,20 @@ export interface VCard4Draft {
   pronouns: string;
   note: string;
   url: string;
+  photoUri?: string;
 }
 
 /** Returns a fresh draft seeded from `profile`, defaulting absent fields to "". */
 export function draftFromProfile(profile: VCard4Profile | null): VCard4Draft {
-  return {
+  const draft: VCard4Draft = {
     fullName: profile?.fullName ?? "",
     nickname: profile?.nickname ?? "",
     pronouns: profile?.pronouns ?? "",
     note: profile?.note ?? "",
     url: profile?.url ?? "",
   };
+  if (profile?.photoUri) draft.photoUri = profile.photoUri;
+  return draft;
 }
 
 /** Snapshots a draft as a profile, trimming whitespace and dropping empties. */
@@ -52,6 +57,7 @@ export function profileFromDraft(draft: VCard4Draft): VCard4Profile {
   apply("pronouns", draft.pronouns);
   apply("note", draft.note);
   apply("url", draft.url);
+  if (draft.photoUri) profile.photoUri = draft.photoUri;
   return profile;
 }
 
@@ -62,6 +68,7 @@ export function profilesEqual(a: VCard4Profile, b: VCard4Profile): boolean {
     (a.nickname ?? "") === (b.nickname ?? "") &&
     (a.pronouns ?? "") === (b.pronouns ?? "") &&
     (a.note ?? "") === (b.note ?? "") &&
-    (a.url ?? "") === (b.url ?? "")
+    (a.url ?? "") === (b.url ?? "") &&
+    (a.photoUri ?? "") === (b.photoUri ?? "")
   );
 }

--- a/chat/src/lib/xmpp/wasm-types.ts
+++ b/chat/src/lib/xmpp/wasm-types.ts
@@ -349,6 +349,7 @@ export interface WasmVCard4 {
   pronouns?: string;
   note?: string;
   url?: string;
+  photo_uri?: string;
 }
 
 /** One entry in a urn:waddle:threads:0 response. */

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -1423,6 +1423,10 @@ export function useChatAppController(giphyApiKey: string) {
     ui.showMobileDetails.value = false;
     ui.activePage.value = "chat";
     ui.activeCommunitySurface.value = surface;
+    if (surface === "feed") {
+      ui.feedDefaultFilter.value = "all";
+      ui.feedDefaultComposerMode.value = "post";
+    }
     ui.sidebarMode.value = "channels";
     dmConversations.closeDm();
     waddles.activeChannelId.value = null;
@@ -1529,6 +1533,13 @@ export function useChatAppController(giphyApiKey: string) {
       match.id === "feed" || match.id === "stories" || match.id === "events"
         ? match.id === "stories" ? "feed" : match.id
         : null;
+    if (match.id === "stories") {
+      ui.feedDefaultFilter.value = "stories";
+      ui.feedDefaultComposerMode.value = "story";
+    } else if (match.id === "feed") {
+      ui.feedDefaultFilter.value = "all";
+      ui.feedDefaultComposerMode.value = "post";
+    }
     ui.sidebarMode.value =
       match.id === "dm" || match.id === "dmList" ? "dms" : "channels";
     // #414: only channel-context routes carry the pinned-panel flag;

--- a/chat/src/shell/state.ts
+++ b/chat/src/shell/state.ts
@@ -5,6 +5,8 @@ import type { AdminTab } from "@/lib/chat-ui";
  * Each renders its own content pane when active, rather than the
  * channel timeline. */
 export type CommunitySurface = "feed" | "events";
+export type FeedSurfaceFilter = "all" | "pep" | "stories" | "posts";
+export type FeedSurfaceComposerMode = "post" | "story";
 
 export function useChatShellState() {
   const activePage = ref<"dashboard" | "chat" | "settings" | "admin" | "threads" | "unread">("dashboard");
@@ -14,6 +16,8 @@ export function useChatShellState() {
    * When non-null the content area renders the corresponding
    * surface in place of the channel timeline. */
   const activeCommunitySurface = ref<CommunitySurface | null>(null);
+  const feedDefaultFilter = ref<FeedSurfaceFilter>("all");
+  const feedDefaultComposerMode = ref<FeedSurfaceComposerMode>("post");
   const collapsedSpaceGroupIds = ref<Set<string>>(new Set());
   const createChannelContextSpaceId = ref<string | null>(null);
   const showMobileNav = ref(false);
@@ -43,6 +47,8 @@ export function useChatShellState() {
     adminTab,
     sidebarMode,
     activeCommunitySurface,
+    feedDefaultFilter,
+    feedDefaultComposerMode,
     collapsedSpaceGroupIds,
     createChannelContextSpaceId,
     showMobileNav,

--- a/chat/tests/feed-pane-regression.test.ts
+++ b/chat/tests/feed-pane-regression.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+
+const feedPaneSource = await Bun.file(
+  new URL("../src/components/community/FeedPane.vue", import.meta.url),
+).text();
+const composerSource = await Bun.file(
+  new URL("../src/components/community/FeedUpdateComposer.vue", import.meta.url),
+).text();
+const storyReaderSource = await Bun.file(
+  new URL("../src/components/community/StoryReaderDialog.vue", import.meta.url),
+).text();
+const chatReadyShellSource = await Bun.file(
+  new URL("../src/components/chat/ChatReadyShell.vue", import.meta.url),
+).text();
+const shellStateSource = await Bun.file(
+  new URL("../src/shell/state.ts", import.meta.url),
+).text();
+const shellControllerSource = await Bun.file(
+  new URL("../src/shell/chat-app-controller.ts", import.meta.url),
+).text();
+
+function occurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+describe("FeedPane composer regression", () => {
+  test("renders a single feed create surface with all feed content modes", () => {
+    expect(occurrences(feedPaneSource, "<FeedUpdateComposer")).toBe(1);
+    expect(feedPaneSource).toContain(':publish-post="publishPost"');
+    expect(feedPaneSource).toContain(':publish-story="publishStory"');
+    expect(feedPaneSource).toContain(':initial-mode="initialComposerMode"');
+    expect(composerSource).toContain('aria-label="Create feed update"');
+    expect(composerSource).toContain('role="tablist" aria-label="Feed update type"');
+    for (const mode of ["post", "story", "mood", "activity", "tune", "profile"]) {
+      expect(composerSource).toContain(`id: "${mode}"`);
+    }
+  });
+
+  test("does not keep the old separate story launcher", () => {
+    expect(feedPaneSource).not.toContain("storyComposerOpen");
+    expect(feedPaneSource).not.toContain("Add story");
+    expect(composerSource).toContain("embedded");
+  });
+
+  test("resets the embedded story composer only after publish succeeds", () => {
+    expect(composerSource).toContain(':key="storyComposerKey"');
+    expect(composerSource).toContain("await props.publishStory");
+    expect(composerSource).toContain("storyComposerKey.value += 1");
+  });
+
+  test("syncs /stories route intent into the unified composer", () => {
+    expect(shellStateSource).toContain('feedDefaultFilter = ref<FeedSurfaceFilter>("all")');
+    expect(shellStateSource).toContain('feedDefaultComposerMode = ref<FeedSurfaceComposerMode>("post")');
+    expect(shellControllerSource).toContain('match.id === "stories"');
+    expect(shellControllerSource).toContain('ui.feedDefaultFilter.value = "stories"');
+    expect(shellControllerSource).toContain('ui.feedDefaultComposerMode.value = "story"');
+    expect(chatReadyShellSource).toContain(':initial-filter="ui.feedDefaultFilter.value"');
+    expect(chatReadyShellSource).toContain(':initial-composer-mode="ui.feedDefaultComposerMode.value"');
+    expect(composerSource).toContain('initialMode?: FeedSurfaceComposerMode');
+    expect(composerSource).toContain('const composerMode = ref<ComposerMode>(props.initialMode)');
+  });
+
+  test("does not leak story errors or stale profile loads across composer modes", () => {
+    expect(composerSource).toContain("storyComposerError.value = null");
+    expect(composerSource).toContain('composerMode === \'story\' && storyComposerError');
+    expect(composerSource).toContain("function setComposerFeedback(mode: ComposerMode");
+    expect(composerSource).toContain("if (composerMode.value !== mode) return");
+    expect(composerSource).toContain('setComposerFeedback("story", "success"');
+    expect(composerSource).toContain('if (composerMode.value === "story")');
+    expect(composerSource).toContain("let profileLoadRequestId = 0");
+    expect(composerSource).toContain("requestId !== profileLoadRequestId || selfJid !== props.selfJid");
+    expect(composerSource).toContain("Load your saved profile before publishing changes.");
+  });
+});
+
+describe("FeedPane story reader regression", () => {
+  test("opens stories in a teleported dialog instead of an inline feed article", () => {
+    expect(occurrences(feedPaneSource, "<StoryReaderDialog")).toBe(1);
+    expect(storyReaderSource).toContain('<Teleport to="body">');
+    expect(storyReaderSource).toContain('role="dialog"');
+    expect(storyReaderSource).toContain('aria-modal="true"');
+    expect(storyReaderSource).toContain('aria-label="Story"');
+    expect(storyReaderSource).toContain('tabindex="-1"');
+    expect(storyReaderSource).toContain("trapTab(event)");
+    expect(storyReaderSource).toContain("eventTargetUsesArrows(event.target)");
+    expect(feedPaneSource).not.toContain("v-if=\"activeStory && activeFilter");
+  });
+
+  test("tracks the active story by id so feed refreshes cannot retarget the modal", () => {
+    expect(feedPaneSource).toContain("const activeStoryId = ref<string | null>(null)");
+    expect(feedPaneSource).toContain("props.stories.findIndex((story) => story.id === id)");
+    expect(feedPaneSource).toContain("activeStoryId.value = story.id");
+    expect(feedPaneSource).not.toContain("activeStoryIndex = ref");
+  });
+});

--- a/chat/tests/vcard4-editor.test.ts
+++ b/chat/tests/vcard4-editor.test.ts
@@ -19,6 +19,10 @@ import {
   type VCard4Profile,
 } from "../src/lib/xmpp/vcard4-types";
 
+const vcardEditorSource = await Bun.file(
+  new URL("../src/components/chat/VCardEditor.vue", import.meta.url),
+).text();
+
 // ---------------------------------------------------------------------------
 // vcard4-types unit tests
 // ---------------------------------------------------------------------------
@@ -41,6 +45,7 @@ describe("vcard4-types helpers", () => {
       pronouns: "he/him",
       note: "Star-crossed",
       url: "https://romeo.example.com",
+      photoUri: "cid:avatar-sha1@example.com",
     };
     expect(draftFromProfile(profile)).toEqual({
       fullName: "Romeo Montague",
@@ -48,6 +53,7 @@ describe("vcard4-types helpers", () => {
       pronouns: "he/him",
       note: "Star-crossed",
       url: "https://romeo.example.com",
+      photoUri: "cid:avatar-sha1@example.com",
     });
   });
 
@@ -58,11 +64,13 @@ describe("vcard4-types helpers", () => {
       pronouns: "she/her",
       note: "   ",
       url: " https://juliet.example.com ",
+      photoUri: "cid:juliet-avatar@example.com",
     };
     expect(profileFromDraft(draft)).toEqual({
       fullName: "Juliet",
       pronouns: "she/her",
       url: "https://juliet.example.com",
+      photoUri: "cid:juliet-avatar@example.com",
     });
   });
 
@@ -85,6 +93,21 @@ describe("vcard4-types helpers", () => {
     expect(
       profilesEqual({ pronouns: "they/them" }, { pronouns: "she/they" }),
     ).toBe(false);
+    expect(
+      profilesEqual(
+        { photoUri: "cid:avatar-a@example.com" },
+        { photoUri: "cid:avatar-b@example.com" },
+      ),
+    ).toBe(false);
+  });
+
+  test("photo URI survives a draft round-trip without becoming editable text", () => {
+    const profile: VCard4Profile = {
+      fullName: "Benvolio",
+      photoUri: "cid:sha256-avatar@example.com",
+    };
+
+    expect(profileFromDraft(draftFromProfile(profile))).toEqual(profile);
   });
 });
 
@@ -100,6 +123,7 @@ interface EditorClient {
 interface EditorState {
   draft: VCard4Draft;
   lastPersisted: VCard4Profile;
+  profileLoaded: boolean;
   feedbackTone: "muted" | "success" | "error";
   feedbackMessage: string;
 }
@@ -108,20 +132,33 @@ function createEditor(client: EditorClient, selfJid: string) {
   const state: EditorState = {
     draft: draftFromProfile(null),
     lastPersisted: {},
+    profileLoaded: false,
     feedbackTone: "muted",
     feedbackMessage: "",
   };
 
   async function load() {
-    const profile = await client.fetchVCard4(selfJid);
-    const next = profile ?? {};
-    state.lastPersisted = next;
-    state.draft = draftFromProfile(next);
-    state.feedbackTone = "muted";
-    state.feedbackMessage = profile ? "loaded" : "empty";
+    try {
+      const profile = await client.fetchVCard4(selfJid);
+      const next = profile ?? {};
+      state.lastPersisted = next;
+      state.draft = draftFromProfile(next);
+      state.profileLoaded = true;
+      state.feedbackTone = "muted";
+      state.feedbackMessage = profile ? "loaded" : "empty";
+    } catch (error) {
+      state.profileLoaded = false;
+      state.feedbackTone = "error";
+      state.feedbackMessage = error instanceof Error ? error.message : "failed";
+    }
   }
 
   async function save() {
+    if (!state.profileLoaded) {
+      state.feedbackTone = "error";
+      state.feedbackMessage = "load before publish";
+      return;
+    }
     const next = profileFromDraft(state.draft);
     if (profilesEqual(next, state.lastPersisted)) {
       state.feedbackTone = "muted";
@@ -147,6 +184,16 @@ function createEditor(client: EditorClient, selfJid: string) {
 }
 
 describe("VCardEditor flow", () => {
+  test("invalidates stale profile loads across client or JID changes", () => {
+    expect(vcardEditorSource).toContain("let profileLoadRequestId = 0");
+    expect(vcardEditorSource).toContain("requestId !== profileLoadRequestId");
+    expect(vcardEditorSource).toContain("client !== props.xmppClient");
+    expect(vcardEditorSource).toContain("selfJid !== props.selfJid");
+    expect(vcardEditorSource).toContain("profileLoadRequestId += 1");
+    expect(vcardEditorSource).toContain("lastPersisted.value = {}");
+    expect(vcardEditorSource).toContain("applyDraft({})");
+  });
+
   test("empty PEP node hydrates draft with empty fields", async () => {
     const fetchVCard4 = mock(async () => null);
     const publishVCard4 = mock(async () => undefined);
@@ -164,6 +211,7 @@ describe("VCardEditor flow", () => {
     });
     expect(editor.state.lastPersisted).toEqual({});
     expect(editor.state.feedbackMessage).toBe("empty");
+    expect(editor.state.profileLoaded).toBe(true);
   });
 
   test("existing PEP node round-trips through the editor without data loss", async () => {
@@ -173,6 +221,7 @@ describe("VCardEditor flow", () => {
       pronouns: "he/him",
       note: "Star-crossed",
       url: "https://romeo.example.com",
+      photoUri: "cid:romeo-avatar@example.com",
     };
     const fetchVCard4 = mock(async () => stored);
     const publishVCard4 = mock(async (_profile: VCard4Profile) => undefined);
@@ -195,6 +244,7 @@ describe("VCardEditor flow", () => {
       pronouns: "he/him",
       note: "Updated bio",
       url: "https://romeo.example.com",
+      photoUri: "cid:romeo-avatar@example.com",
     });
     expect(editor.state.feedbackTone).toBe("success");
   });
@@ -235,5 +285,21 @@ describe("VCardEditor flow", () => {
     // Both the persisted snapshot and the draft are reverted.
     expect(editor.state.lastPersisted).toEqual(stored);
     expect(editor.state.draft).toEqual(draftFromProfile(stored));
+  });
+
+  test("does not publish a partial profile after the initial load fails", async () => {
+    const fetchVCard4 = mock(async () => {
+      throw new Error("load failed");
+    });
+    const publishVCard4 = mock(async (_profile: VCard4Profile) => undefined);
+    const editor = createEditor({ fetchVCard4, publishVCard4 }, "benvolio@example.com");
+
+    await editor.load();
+    editor.state.draft.fullName = "Benvolio";
+    await editor.save();
+
+    expect(publishVCard4).not.toHaveBeenCalled();
+    expect(editor.state.feedbackTone).toBe("error");
+    expect(editor.state.feedbackMessage).toBe("load before publish");
   });
 });

--- a/server/crates/waddle-xmpp-client-wasm/src/client_account.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_account.rs
@@ -664,6 +664,7 @@ impl WaddleClient {
                     pronouns: vcard.pronouns,
                     note: vcard.note,
                     url: vcard.url,
+                    photo_uri: vcard.photo_uri,
                 }),
                 None => Ok(JsValue::NULL),
             }
@@ -681,6 +682,7 @@ impl WaddleClient {
                 pronouns: payload.pronouns,
                 note: payload.note,
                 url: payload.url,
+                photo_uri: payload.photo_uri,
             };
             let request_id = uuid::Uuid::new_v4().to_string();
             let iq = build_publish_vcard4_iq(&vcard, &request_id);

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -760,6 +760,8 @@ pub struct WaddleVCard4 {
     pub note: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub photo_uri: Option<String>,
 }
 
 /// One XEP-0490 §3 displayed entry surfaced to the chat client.

--- a/server/crates/waddle-xmpp-client/src/xep/xep0292.rs
+++ b/server/crates/waddle-xmpp-client/src/xep/xep0292.rs
@@ -43,6 +43,8 @@ pub struct VCard4 {
     pub note: Option<String>,
     /// `URL` — website / social link, transmitted as `<uri>`.
     pub url: Option<String>,
+    /// `PHOTO` — URI reference to the avatar image.
+    pub photo_uri: Option<String>,
 }
 
 impl VCard4 {
@@ -58,6 +60,7 @@ impl VCard4 {
             && self.pronouns.is_none()
             && self.note.is_none()
             && self.url.is_none()
+            && self.photo_uri.is_none()
     }
 }
 
@@ -92,6 +95,7 @@ pub fn parse_vcard4_element(elem: &Element) -> VCard4 {
         pronouns: text_prop(elem, "pronouns"),
         note: text_prop(elem, "note"),
         url: uri_or_text_prop(elem, "url"),
+        photo_uri: uri_or_text_prop(elem, "photo"),
     }
 }
 
@@ -129,6 +133,9 @@ pub fn build_vcard4_element(vcard: &VCard4) -> Element {
     }
     if let Some(ref v) = vcard.url {
         append_uri_prop(&mut elem, "url", v);
+    }
+    if let Some(ref v) = vcard.photo_uri {
+        append_uri_prop(&mut elem, "photo", v);
     }
     elem
 }
@@ -208,6 +215,7 @@ mod tests {
                     <pronouns><text>he/him</text></pronouns>\
                     <note><text>Star-crossed lover</text></note>\
                     <url><uri>https://romeo.example.com</uri></url>\
+                    <photo><uri>cid:romeo-avatar@example.com</uri></photo>\
                     </vcard>";
         let elem: Element = xml.parse().expect("valid xml");
         let vcard = parse_vcard4_element(&elem);
@@ -217,6 +225,10 @@ mod tests {
         assert_eq!(vcard.pronouns.as_deref(), Some("he/him"));
         assert_eq!(vcard.note.as_deref(), Some("Star-crossed lover"));
         assert_eq!(vcard.url.as_deref(), Some("https://romeo.example.com"));
+        assert_eq!(
+            vcard.photo_uri.as_deref(),
+            Some("cid:romeo-avatar@example.com")
+        );
         assert!(!vcard.is_empty());
     }
 
@@ -236,6 +248,7 @@ mod tests {
             pronouns: Some("she/her".into()),
             note: Some("Also star-crossed".into()),
             url: Some("https://juliet.example.com".into()),
+            photo_uri: Some("cid:juliet-avatar@example.com".into()),
         };
         let elem = build_vcard4_element(&original);
         let parsed = parse_vcard4_element(&elem);

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=8622fb6cac07";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=8622fb6cac07";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=8622fb6cac07";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=1e3ef6d0668a";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=1e3ef6d0668a";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=1e3ef6d0668a";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=8622fb6cac07";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=1e3ef6d0668a";


### PR DESCRIPTION
## Summary

- Replace the separate post composer and story launcher with one feed create surface.
- Add feed create modes for posts, stories, and PEP-backed mood, activity, tune, and profile updates.
- Open story media in a modal reader instead of inserting the active photo/video below the feed card.
- Preserve vCard4 photo URI through the TypeScript, wasm, and Rust XEP-0292 paths so profile edits do not drop the avatar reference.
- Keep `/stories` routing intent by opening the unified feed on the stories filter with the story composer selected.

## Plan

- Build a single reusable feed composer and wire it from `ChatReadyShell` through XMPP-native publish callbacks.
- Convert story reading from inline feed expansion to a focused dialog with reactions and previous/next controls.
- Add regression coverage for the unified composer, legacy story launcher removal, story dialog behavior, route intent, async feedback scoping, and vCard stale-load guards.
- Run local validation, browser smoke testing, adversarial review, and CI monitoring.

## Validation

- `bun test`
- `bun run lint`
- `bun run astro check`
- `cargo test -p waddle-xmpp-client xep0292`
- `git diff --check`
- Browser smoke: opened `http://localhost:4321/feed`; local unauthenticated state stops at `Checking session`, with only existing Astro dev-toolbar/Vue warning noise observed.

## Review Notes

- Reviewed `./xeps` before implementation; no new non-XMPP APIs or custom namespaces were introduced.
- Two adversarial review passes completed. Follow-up fixes included active-story-by-id tracking, `/stories` route defaults, stale profile load guards, profile load-success publish gates, and mode-scoped async feedback.
