### PR TITLE
feat(chat): auto spotlight remote screenshares

### DIFF
--- a/chat/src/components/calls/CallTileGrid.vue
+++ b/chat/src/components/calls/CallTileGrid.vue
@@ -3,7 +3,8 @@ import { computed, onBeforeUnmount, ref, watch } from "vue";
 import type { LocalMediaTrack, RemoteMediaTrack } from "@/lib/calls/engine";
 import { TileAttachments, type TileAttachable } from "@/lib/calls/tile-attach";
 import { selectGridLayout } from "@/lib/calls/grid-layout";
-import { buildCallTiles, type CallTileModel } from "@/lib/calls/call-tiles";
+import type { CallTileModel } from "@/lib/calls/call-tiles";
+import { projectCallTiles } from "@/lib/calls/call-tile-projection";
 import CallTile from "./CallTile.vue";
 
 /**
@@ -43,19 +44,31 @@ const props = defineProps<{
   micEnabled: boolean;
 }>();
 
-const tiles = computed<Tile[]>(() => {
-  return buildCallTiles({
+const seenRemoteScreenTrackKeys = ref<ReadonlySet<string>>(new Set());
+const manualFocusKey = ref<string | null>(null);
+
+const projection = computed(() => {
+  return projectCallTiles({
     remoteTracks: props.remoteTracks,
     localTracks: props.localTracks,
     localIdentity: props.localIdentity,
     micEnabled: props.micEnabled,
+    seenRemoteScreenTrackKeys: seenRemoteScreenTrackKeys.value,
+    manualFocusKey: manualFocusKey.value,
   });
 });
 
-const focusedKey = ref<string | null>(null);
+watch(projection, (next) => {
+  if (!sameSet(seenRemoteScreenTrackKeys.value, next.seenRemoteScreenTrackKeys)) {
+    seenRemoteScreenTrackKeys.value = next.seenRemoteScreenTrackKeys;
+  }
+}, { immediate: true });
+
+const tiles = computed<Tile[]>(() => projection.value.tiles);
 const focusedTile = computed<Tile | null>(() => {
-  if (!focusedKey.value) return null;
-  return tiles.value.find((t) => t.key === focusedKey.value) ?? null;
+  const spotlightKey = projection.value.spotlightKey;
+  if (!spotlightKey) return null;
+  return tiles.value.find((t) => t.key === spotlightKey) ?? null;
 });
 const otherTiles = computed<Tile[]>(() => {
   if (!focusedTile.value) return [];
@@ -63,7 +76,15 @@ const otherTiles = computed<Tile[]>(() => {
 });
 
 function toggleFocus(tile: Tile): void {
-  focusedKey.value = focusedKey.value === tile.key ? null : tile.key;
+  manualFocusKey.value = manualFocusKey.value === tile.key ? null : tile.key;
+}
+
+function sameSet(left: ReadonlySet<string>, right: ReadonlySet<string>): boolean {
+  if (left.size !== right.size) return false;
+  for (const value of left) {
+    if (!right.has(value)) return false;
+  }
+  return true;
 }
 
 // One `TileAttachments` per grid instance — reconciles (element,

--- a/chat/src/components/calls/CallTileGrid.vue
+++ b/chat/src/components/calls/CallTileGrid.vue
@@ -4,7 +4,7 @@ import type { LocalMediaTrack, RemoteMediaTrack } from "@/lib/calls/engine";
 import { TileAttachments, type TileAttachable } from "@/lib/calls/tile-attach";
 import { selectGridLayout } from "@/lib/calls/grid-layout";
 import type { CallTileModel } from "@/lib/calls/call-tiles";
-import { projectCallTiles } from "@/lib/calls/call-tile-projection";
+import { projectCallTiles, reconcileCallTileProjectionState } from "@/lib/calls/call-tile-projection";
 import CallTile from "./CallTile.vue";
 
 /**
@@ -59,8 +59,17 @@ const projection = computed(() => {
 });
 
 watch(projection, (next) => {
-  if (!sameSet(seenRemoteScreenTrackKeys.value, next.seenRemoteScreenTrackKeys)) {
-    seenRemoteScreenTrackKeys.value = next.seenRemoteScreenTrackKeys;
+  const reconciled = reconcileCallTileProjectionState({
+    tiles: next.tiles,
+    manualFocusKey: manualFocusKey.value,
+    currentSeenRemoteScreenTrackKeys: seenRemoteScreenTrackKeys.value,
+    nextSeenRemoteScreenTrackKeys: next.seenRemoteScreenTrackKeys,
+  });
+  if (seenRemoteScreenTrackKeys.value !== reconciled.seenRemoteScreenTrackKeys) {
+    seenRemoteScreenTrackKeys.value = reconciled.seenRemoteScreenTrackKeys;
+  }
+  if (manualFocusKey.value !== reconciled.manualFocusKey) {
+    manualFocusKey.value = reconciled.manualFocusKey;
   }
 }, { immediate: true });
 
@@ -77,14 +86,6 @@ const otherTiles = computed<Tile[]>(() => {
 
 function toggleFocus(tile: Tile): void {
   manualFocusKey.value = manualFocusKey.value === tile.key ? null : tile.key;
-}
-
-function sameSet(left: ReadonlySet<string>, right: ReadonlySet<string>): boolean {
-  if (left.size !== right.size) return false;
-  for (const value of left) {
-    if (!right.has(value)) return false;
-  }
-  return true;
 }
 
 // One `TileAttachments` per grid instance — reconciles (element,

--- a/chat/src/lib/calls/call-tile-projection.ts
+++ b/chat/src/lib/calls/call-tile-projection.ts
@@ -1,0 +1,41 @@
+import { buildCallTiles, type BuildCallTilesInput, type CallTileModel } from "./call-tiles";
+
+export type ProjectCallTilesInput = BuildCallTilesInput & {
+  seenRemoteScreenTrackKeys: ReadonlySet<string>;
+  manualFocusKey: string | null;
+};
+
+export type CallTileProjection = {
+  tiles: CallTileModel[];
+  spotlightKey: string | null;
+  seenRemoteScreenTrackKeys: ReadonlySet<string>;
+};
+
+export function projectCallTiles(input: ProjectCallTilesInput): CallTileProjection {
+  const tiles = buildCallTiles(input);
+  const remoteScreens = tiles.filter((tile) =>
+    tile.source === "screen_share" && !tile.isSelf && tile.screenTrackKey !== null
+  );
+  const nextSeenRemoteScreenTrackKeys = new Set(input.seenRemoteScreenTrackKeys);
+  const newlyAppearedScreen = remoteScreens.find((tile) =>
+    tile.screenTrackKey !== null && !input.seenRemoteScreenTrackKeys.has(tile.screenTrackKey)
+  ) ?? null;
+
+  for (const tile of remoteScreens) {
+    if (tile.screenTrackKey !== null) nextSeenRemoteScreenTrackKeys.add(tile.screenTrackKey);
+  }
+
+  const manualTile = input.manualFocusKey
+    ? tiles.find((tile) => tile.key === input.manualFocusKey) ?? null
+    : null;
+  const spotlightKey = manualTile?.key
+    ?? newlyAppearedScreen?.key
+    ?? remoteScreens[0]?.key
+    ?? null;
+
+  return {
+    tiles,
+    spotlightKey,
+    seenRemoteScreenTrackKeys: nextSeenRemoteScreenTrackKeys,
+  };
+}

--- a/chat/src/lib/calls/call-tile-projection.ts
+++ b/chat/src/lib/calls/call-tile-projection.ts
@@ -11,6 +11,40 @@ export type CallTileProjection = {
   seenRemoteScreenTrackKeys: ReadonlySet<string>;
 };
 
+export type ReconcileCallTileProjectionStateInput = {
+  tiles: readonly CallTileModel[];
+  manualFocusKey: string | null;
+  currentSeenRemoteScreenTrackKeys: ReadonlySet<string>;
+  nextSeenRemoteScreenTrackKeys: ReadonlySet<string>;
+};
+
+export type ReconciledCallTileProjectionState = {
+  manualFocusKey: string | null;
+  seenRemoteScreenTrackKeys: ReadonlySet<string>;
+};
+
+export function reconcileCallTileProjectionState(
+  input: ReconcileCallTileProjectionStateInput,
+): ReconciledCallTileProjectionState {
+  return {
+    manualFocusKey: retainManualFocusKey(input.tiles, input.manualFocusKey),
+    seenRemoteScreenTrackKeys: sameSet(
+      input.currentSeenRemoteScreenTrackKeys,
+      input.nextSeenRemoteScreenTrackKeys,
+    )
+      ? input.currentSeenRemoteScreenTrackKeys
+      : input.nextSeenRemoteScreenTrackKeys,
+  };
+}
+
+export function retainManualFocusKey(
+  tiles: readonly CallTileModel[],
+  manualFocusKey: string | null,
+): string | null {
+  if (manualFocusKey === null) return null;
+  return tiles.some((tile) => tile.key === manualFocusKey) ? manualFocusKey : null;
+}
+
 export function projectCallTiles(input: ProjectCallTilesInput): CallTileProjection {
   const tiles = buildCallTiles(input);
   const remoteScreens = tiles.filter((tile) =>
@@ -30,7 +64,7 @@ export function projectCallTiles(input: ProjectCallTilesInput): CallTileProjecti
     : null;
   const spotlightKey = manualTile?.key
     ?? newlyAppearedScreen?.key
-    ?? remoteScreens[0]?.key
+    ?? newestSeenRemoteScreen(remoteScreens, nextSeenRemoteScreenTrackKeys)?.key
     ?? null;
 
   return {
@@ -38,4 +72,27 @@ export function projectCallTiles(input: ProjectCallTilesInput): CallTileProjecti
     spotlightKey,
     seenRemoteScreenTrackKeys: nextSeenRemoteScreenTrackKeys,
   };
+}
+
+function newestSeenRemoteScreen(
+  remoteScreens: readonly CallTileModel[],
+  seenRemoteScreenTrackKeys: ReadonlySet<string>,
+): CallTileModel | null {
+  const activeScreensByTrackKey = new Map(
+    remoteScreens.flatMap((tile) => tile.screenTrackKey === null ? [] : [[tile.screenTrackKey, tile]]),
+  );
+  const newestSeenTrackKeys = Array.from(seenRemoteScreenTrackKeys).reverse();
+  for (const screenTrackKey of newestSeenTrackKeys) {
+    const tile = activeScreensByTrackKey.get(screenTrackKey);
+    if (tile) return tile;
+  }
+  return remoteScreens[0] ?? null;
+}
+
+function sameSet(left: ReadonlySet<string>, right: ReadonlySet<string>): boolean {
+  if (left.size !== right.size) return false;
+  for (const value of left) {
+    if (!right.has(value)) return false;
+  }
+  return true;
 }

--- a/chat/src/lib/calls/call-tiles.ts
+++ b/chat/src/lib/calls/call-tiles.ts
@@ -8,6 +8,7 @@ export type CallTileModel = {
   identity: string;
   label: string;
   source: TileSource;
+  screenTrackKey: string | null;
   isSelf: boolean;
   mirrorVideo: boolean;
   showsPresentingGlyph: boolean;
@@ -56,6 +57,7 @@ function newTile(
     identity,
     label: labelFor(identity, isSelf, source),
     source,
+    screenTrackKey: null,
     isSelf,
     mirrorVideo: isSelf && source === "camera",
     showsPresentingGlyph: source === "screen_share",
@@ -74,7 +76,10 @@ export function buildCallTiles(input: BuildCallTilesInput): CallTileModel[] {
     const source = tileSourceForTrack(local.source);
     const key = callTileKey("self", local.participantIdentity, source);
     const existing = byKey.get(key) ?? newTile("self", local.participantIdentity, source, input.micEnabled);
-    if (local.kind === "video") existing.videoTrack = local.track;
+    if (local.kind === "video") {
+      existing.videoTrack = local.track;
+      if (source === "screen_share") existing.screenTrackKey = local.publicationSid;
+    }
     if (local.kind === "audio") existing.audioTrack = local.track;
     byKey.set(key, existing);
   }
@@ -83,7 +88,10 @@ export function buildCallTiles(input: BuildCallTilesInput): CallTileModel[] {
     const source = tileSourceForTrack(remote.source);
     const key = callTileKey("remote", remote.participantIdentity, source);
     const existing = byKey.get(key) ?? newTile("remote", remote.participantIdentity, source, input.micEnabled);
-    if (remote.kind === "video") existing.videoTrack = remote.track;
+    if (remote.kind === "video") {
+      existing.videoTrack = remote.track;
+      if (source === "screen_share") existing.screenTrackKey = remote.publicationSid;
+    }
     if (remote.kind === "audio") existing.audioTrack = remote.track;
     byKey.set(key, existing);
   }

--- a/chat/tests/call-tile-spotlight.test.ts
+++ b/chat/tests/call-tile-spotlight.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from "bun:test";
+import { projectCallTiles } from "../src/lib/calls/call-tile-projection";
+import type { LocalMediaTrack, RemoteMediaTrack } from "../src/lib/calls/engine";
+
+const fakeTrack = {} as never;
+
+describe("call tile spotlight projection", () => {
+  test("promotes a newly appearing remote screen share and records its appear edge", () => {
+    const projection = projectCallTiles({
+      remoteTracks: [
+        remoteVideo("bob@example.com/web", "camera-pub", "camera"),
+        remoteVideo("bob@example.com/web", "screen-pub", "screen_share"),
+      ],
+      localTracks: [],
+      localIdentity: "alice@example.com/web",
+      micEnabled: true,
+      seenRemoteScreenTrackKeys: new Set(),
+      manualFocusKey: null,
+    });
+
+    expect(projection.spotlightKey).toBe("remote:bob@example.com/web:screen_share");
+    expect(Array.from(projection.seenRemoteScreenTrackKeys)).toEqual(["screen-pub"]);
+  });
+
+  test("keeps an already seen remote screen on stage without replaying an appear edge", () => {
+    const seenRemoteScreenTrackKeys = new Set(["screen-pub"]);
+    const projection = projectCallTiles({
+      remoteTracks: [
+        remoteVideo("bob@example.com/web", "camera-pub", "camera"),
+        remoteVideo("bob@example.com/web", "screen-pub", "screen_share"),
+      ],
+      localTracks: [],
+      localIdentity: "alice@example.com/web",
+      micEnabled: true,
+      seenRemoteScreenTrackKeys,
+      manualFocusKey: null,
+    });
+
+    expect(projection.spotlightKey).toBe("remote:bob@example.com/web:screen_share");
+    expect(projection.seenRemoteScreenTrackKeys).not.toBe(seenRemoteScreenTrackKeys);
+    expect(Array.from(projection.seenRemoteScreenTrackKeys)).toEqual(["screen-pub"]);
+  });
+
+  test("lets manual tile focus override a remote screen spotlight", () => {
+    const projection = projectCallTiles({
+      remoteTracks: [
+        remoteVideo("bob@example.com/web", "camera-pub", "camera"),
+        remoteVideo("bob@example.com/web", "screen-pub", "screen_share"),
+      ],
+      localTracks: [],
+      localIdentity: "alice@example.com/web",
+      micEnabled: true,
+      seenRemoteScreenTrackKeys: new Set(["screen-pub"]),
+      manualFocusKey: "remote:bob@example.com/web:camera",
+    });
+
+    expect(projection.spotlightKey).toBe("remote:bob@example.com/web:camera");
+  });
+
+  test("falls back to another remote screen when the spotlighted screen ends", () => {
+    const projection = projectCallTiles({
+      remoteTracks: [
+        remoteVideo("carol@example.com/web", "screen-pub", "screen_share"),
+      ],
+      localTracks: [],
+      localIdentity: "alice@example.com/web",
+      micEnabled: true,
+      seenRemoteScreenTrackKeys: new Set(["bob-screen-pub", "screen-pub"]),
+      manualFocusKey: "remote:bob@example.com/web:screen_share",
+    });
+
+    expect(projection.spotlightKey).toBe("remote:carol@example.com/web:screen_share");
+  });
+
+  test("returns to the equal grid when no remote screens remain", () => {
+    const projection = projectCallTiles({
+      remoteTracks: [remoteVideo("bob@example.com/web", "camera-pub", "camera")],
+      localTracks: [],
+      localIdentity: "alice@example.com/web",
+      micEnabled: true,
+      seenRemoteScreenTrackKeys: new Set(["screen-pub"]),
+      manualFocusKey: "remote:bob@example.com/web:screen_share",
+    });
+
+    expect(projection.spotlightKey).toBeNull();
+  });
+
+  test("does not auto-promote the local participant's own screen share", () => {
+    const projection = projectCallTiles({
+      remoteTracks: [],
+      localTracks: [localVideo("alice@example.com/web", "screen-pub", "screen_share")],
+      localIdentity: "alice@example.com/web",
+      micEnabled: true,
+      seenRemoteScreenTrackKeys: new Set(),
+      manualFocusKey: null,
+    });
+
+    expect(projection.spotlightKey).toBeNull();
+    expect(Array.from(projection.seenRemoteScreenTrackKeys)).toEqual([]);
+  });
+
+  test("treats a restarted same-participant screen publication as a new appear edge", () => {
+    const projection = projectCallTiles({
+      remoteTracks: [
+        remoteVideo("carol@example.com/web", "carol-screen-pub", "screen_share"),
+        remoteVideo("bob@example.com/web", "bob-screen-pub-2", "screen_share"),
+      ],
+      localTracks: [],
+      localIdentity: "alice@example.com/web",
+      micEnabled: true,
+      seenRemoteScreenTrackKeys: new Set([
+        "bob-screen-pub-1",
+        "carol-screen-pub",
+      ]),
+      manualFocusKey: null,
+    });
+
+    expect(projection.spotlightKey).toBe("remote:bob@example.com/web:screen_share");
+    expect(Array.from(projection.seenRemoteScreenTrackKeys)).toEqual([
+      "bob-screen-pub-1",
+      "carol-screen-pub",
+      "bob-screen-pub-2",
+    ]);
+  });
+});
+
+function remoteVideo(
+  participantIdentity: string,
+  publicationSid: string,
+  source: RemoteMediaTrack["source"],
+): RemoteMediaTrack {
+  return {
+    participantIdentity,
+    publicationSid,
+    kind: "video",
+    source,
+    track: fakeTrack,
+  };
+}
+
+function localVideo(
+  participantIdentity: string,
+  publicationSid: string,
+  source: LocalMediaTrack["source"],
+): LocalMediaTrack {
+  return {
+    participantIdentity,
+    publicationSid,
+    kind: "video",
+    source,
+    track: fakeTrack,
+  };
+}

--- a/chat/tests/call-tile-spotlight.test.ts
+++ b/chat/tests/call-tile-spotlight.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { projectCallTiles } from "../src/lib/calls/call-tile-projection";
+import {
+  projectCallTiles,
+  reconcileCallTileProjectionState,
+  retainManualFocusKey,
+} from "../src/lib/calls/call-tile-projection";
 import type { LocalMediaTrack, RemoteMediaTrack } from "../src/lib/calls/engine";
 
 const fakeTrack = {} as never;
@@ -39,6 +43,22 @@ describe("call tile spotlight projection", () => {
     expect(projection.spotlightKey).toBe("remote:bob@example.com/web:screen_share");
     expect(projection.seenRemoteScreenTrackKeys).not.toBe(seenRemoteScreenTrackKeys);
     expect(Array.from(projection.seenRemoteScreenTrackKeys)).toEqual(["screen-pub"]);
+  });
+
+  test("keeps the newest seen active remote screen on stage after recording its appear edge", () => {
+    const projection = projectCallTiles({
+      remoteTracks: [
+        remoteVideo("carol@example.com/web", "carol-screen-pub", "screen_share"),
+        remoteVideo("bob@example.com/web", "bob-screen-pub", "screen_share"),
+      ],
+      localTracks: [],
+      localIdentity: "alice@example.com/web",
+      micEnabled: true,
+      seenRemoteScreenTrackKeys: new Set(["carol-screen-pub", "bob-screen-pub"]),
+      manualFocusKey: null,
+    });
+
+    expect(projection.spotlightKey).toBe("remote:bob@example.com/web:screen_share");
   });
 
   test("lets manual tile focus override a remote screen spotlight", () => {
@@ -121,6 +141,72 @@ describe("call tile spotlight projection", () => {
       "carol-screen-pub",
       "bob-screen-pub-2",
     ]);
+  });
+
+  test("clears stale manual focus before a departed tile key can reapply on reconnect", () => {
+    const focused = projectCallTiles({
+      remoteTracks: [
+        remoteVideo("bob@example.com/web", "camera-pub", "camera"),
+        remoteVideo("carol@example.com/web", "carol-screen-pub", "screen_share"),
+      ],
+      localTracks: [],
+      localIdentity: "alice@example.com/web",
+      micEnabled: true,
+      seenRemoteScreenTrackKeys: new Set(["carol-screen-pub"]),
+      manualFocusKey: "remote:bob@example.com/web:camera",
+    });
+    expect(focused.spotlightKey).toBe("remote:bob@example.com/web:camera");
+
+    const afterBobLeaves = projectCallTiles({
+      remoteTracks: [
+        remoteVideo("carol@example.com/web", "carol-screen-pub", "screen_share"),
+      ],
+      localTracks: [],
+      localIdentity: "alice@example.com/web",
+      micEnabled: true,
+      seenRemoteScreenTrackKeys: new Set(["carol-screen-pub"]),
+      manualFocusKey: "remote:bob@example.com/web:camera",
+    });
+    const reconciled = reconcileCallTileProjectionState({
+      tiles: afterBobLeaves.tiles,
+      manualFocusKey: "remote:bob@example.com/web:camera",
+      currentSeenRemoteScreenTrackKeys: new Set(["carol-screen-pub"]),
+      nextSeenRemoteScreenTrackKeys: afterBobLeaves.seenRemoteScreenTrackKeys,
+    });
+
+    expect(afterBobLeaves.spotlightKey).toBe("remote:carol@example.com/web:screen_share");
+    expect(reconciled.manualFocusKey).toBeNull();
+
+    const afterBobRejoins = projectCallTiles({
+      remoteTracks: [
+        remoteVideo("carol@example.com/web", "carol-screen-pub", "screen_share"),
+        remoteVideo("bob@example.com/web", "camera-pub-2", "camera"),
+      ],
+      localTracks: [],
+      localIdentity: "alice@example.com/web",
+      micEnabled: true,
+      seenRemoteScreenTrackKeys: reconciled.seenRemoteScreenTrackKeys,
+      manualFocusKey: reconciled.manualFocusKey,
+    });
+    expect(afterBobRejoins.spotlightKey).toBe("remote:carol@example.com/web:screen_share");
+  });
+
+  test("retains manual focus while its target tile is still present", () => {
+    const projection = projectCallTiles({
+      remoteTracks: [
+        remoteVideo("bob@example.com/web", "camera-pub", "camera"),
+        remoteVideo("carol@example.com/web", "carol-screen-pub", "screen_share"),
+      ],
+      localTracks: [],
+      localIdentity: "alice@example.com/web",
+      micEnabled: true,
+      seenRemoteScreenTrackKeys: new Set(["carol-screen-pub"]),
+      manualFocusKey: "remote:bob@example.com/web:camera",
+    });
+
+    expect(projection.spotlightKey).toBe("remote:bob@example.com/web:camera");
+    expect(retainManualFocusKey(projection.tiles, "remote:bob@example.com/web:camera"))
+      .toBe("remote:bob@example.com/web:camera");
   });
 });
 


### PR DESCRIPTION
## Plan

- Add a pure call tile projection seam that returns aggregated tiles plus the resolved spotlight key.
- Track remote screenshare appear edges by LiveKit screen publication key, not by rendered participant tile key.
- Wire `CallTileGrid` to consume projection state while reconciling manual focus and seen-track state through a pure helper.
- Cover appear-edge promotion, manual override, fallback on ended screenshares, equal-grid fallback, local self-exclusion, same-participant screenshare restart, newest-seen spotlight retention, and stale manual-focus lifecycle cleanup.

## Review fixes

- Fixed Codex thread: a newly appended remote screenshare remains spotlighted after its publication SID is recorded as seen by preferring the newest active seen screen.
- Fixed Greptile thread: stale `manualFocusKey` is cleared when its target tile disappears, so a reconnecting participant cannot silently override an active screenshare later.
- Fixed Greptile test thread: added a lifecycle regression covering manual focus -> participant leaves -> reconciliation clears focus -> participant rejoins while another screen remains spotlighted.

## Verification

- `bun test tests/call-tile-spotlight.test.ts tests/call-tile-projection.test.ts tests/call-grid-layout.test.ts`
- `bun test`
- `bunx astro check` (0 errors; existing hint in `src/lib/xmpp/discovery.ts`)
- `bun run lint`
- Final adversarial review found no actionable issues after the lifecycle helper change.

Closes #889