### PR TITLE
fix(chat): request audio for screen shares

### DIFF
--- a/chat/src/lib/calls/call-controls.ts
+++ b/chat/src/lib/calls/call-controls.ts
@@ -90,7 +90,7 @@ export async function toggleScreenShare(): Promise<void> {
   $callScreenShareEnabled.set(next);
   try {
     const { engine } = useCallEngine();
-    await engine.setScreenShareEnabled(next, { audio: false });
+    await engine.setScreenShareEnabled(next, { audio: next });
     clearMediaIssue("screen");
   } catch (err) {
     $callScreenShareEnabled.set(!next);

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -410,7 +410,9 @@ export function mapTrackSource(
 function isUnsupportedScreenAudioError(error: unknown): boolean {
   if (!error || typeof error !== "object" || !("name" in error)) return false;
   const name = (error as { name?: unknown }).name;
-  return name === "OverconstrainedError";
+  return name === "OverconstrainedError" ||
+    name === "ConstraintNotSatisfiedError" ||
+    name === "NotSupportedError";
 }
 
 /**

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -230,9 +230,14 @@ export class CallEngine {
     opts: { audio: boolean },
   ): Promise<void> {
     if (!this.room) return;
-    await this.room.localParticipant.setScreenShareEnabled(enabled, {
-      audio: opts.audio,
-    });
+    try {
+      await this.room.localParticipant.setScreenShareEnabled(enabled, {
+        audio: opts.audio,
+      });
+    } catch (error) {
+      if (!enabled || !opts.audio || !isUnsupportedScreenAudioError(error)) throw error;
+      await this.room.localParticipant.setScreenShareEnabled(true, { audio: false });
+    }
   }
 
   /**
@@ -400,6 +405,12 @@ export function mapTrackSource(
   if (source === Track.Source.ScreenShare) return "screen_share";
   if (source === Track.Source.ScreenShareAudio) return "screen_share_audio";
   return fallbackKind === "audio" ? "microphone" : "camera";
+}
+
+function isUnsupportedScreenAudioError(error: unknown): boolean {
+  if (!error || typeof error !== "object" || !("name" in error)) return false;
+  const name = (error as { name?: unknown }).name;
+  return name === "OverconstrainedError";
 }
 
 /**

--- a/chat/tests/call-controls.test.ts
+++ b/chat/tests/call-controls.test.ts
@@ -334,7 +334,7 @@ describe("device-less call controls", () => {
     expect($callMediaIssues.get().mic).toBeNull();
   });
 
-  test("toggleScreenShare publishes screen video with optimistic state", async () => {
+  test("toggleScreenShare requests screen audio with optimistic state", async () => {
     const { engine } = useCallEngine();
     const calls: Array<{ enabled: boolean; audio: boolean }> = [];
     (engine as unknown as { room: unknown }).room = {
@@ -346,7 +346,7 @@ describe("device-less call controls", () => {
     };
     $callScreenShareEnabled.set(false);
     await toggleScreenShare();
-    expect(calls).toEqual([{ enabled: true, audio: false }]);
+    expect(calls).toEqual([{ enabled: true, audio: true }]);
     expect($callScreenShareEnabled.get()).toBe(true);
     expect($callMediaIssues.get().screen).toBeNull();
   });
@@ -367,14 +367,18 @@ describe("device-less call controls", () => {
 
   test("toggleScreenShare stop clears a prior screen notice", async () => {
     const { engine } = useCallEngine();
+    const calls: Array<{ enabled: boolean; audio: boolean }> = [];
     (engine as unknown as { room: unknown }).room = {
       localParticipant: {
-        setScreenShareEnabled: async () => undefined,
+        setScreenShareEnabled: async (enabled: boolean, options?: { audio?: boolean }) => {
+          calls.push({ enabled, audio: options?.audio ?? false });
+        },
       },
     };
     recordMediaIssue("screen", deviceError("NotReadableError"));
     $callScreenShareEnabled.set(true);
     await toggleScreenShare();
+    expect(calls).toEqual([{ enabled: false, audio: false }]);
     expect($callScreenShareEnabled.get()).toBe(false);
     expect($callMediaIssues.get().screen).toBeNull();
   });

--- a/chat/tests/call-engine.test.ts
+++ b/chat/tests/call-engine.test.ts
@@ -197,10 +197,14 @@ describe("call-engine module", () => {
     expect(engine.screenShareEnabled).toBe(true);
   });
 
-  test("setScreenShareEnabled degrades unsupported screen audio to video-only share", async () => {
+  test.each([
+    "OverconstrainedError",
+    "ConstraintNotSatisfiedError",
+    "NotSupportedError",
+  ])("setScreenShareEnabled degrades %s screen audio failure to video-only share", async (errorName) => {
     const { CallEngine } = await import("../src/lib/calls/engine");
     const engine = new CallEngine();
-    const participant = screenShareStub({ audioThrows: deviceError("OverconstrainedError") });
+    const participant = screenShareStub({ audioThrows: deviceError(errorName) });
     (engine as unknown as { room: unknown }).room = { localParticipant: participant };
     await engine.setScreenShareEnabled(true, { audio: true });
     expect(participant.calls).toEqual([
@@ -217,7 +221,6 @@ describe("call-engine module", () => {
     (engine as unknown as { room: unknown }).room = { localParticipant: participant };
     await expect(engine.setScreenShareEnabled(true, { audio: true })).rejects.toHaveProperty("name", "TypeError");
     expect(participant.calls).toEqual([{ enabled: true, audio: true }]);
-    expect(engine.screenShareEnabled).toBe(true);
   });
 });
 

--- a/chat/tests/call-engine.test.ts
+++ b/chat/tests/call-engine.test.ts
@@ -33,7 +33,7 @@ function captureStub(opts: { micThrows?: Error; camThrows?: Error } = {}) {
   };
 }
 
-function screenShareStub() {
+function screenShareStub(opts: { audioThrows?: Error } = {}) {
   const calls: Array<{ enabled: boolean; audio: boolean }> = [];
   return {
     calls,
@@ -42,6 +42,7 @@ function screenShareStub() {
     },
     async setScreenShareEnabled(enabled: boolean, options?: { audio?: boolean }) {
       calls.push({ enabled, audio: options?.audio ?? false });
+      if (enabled && options?.audio && opts.audioThrows) throw opts.audioThrows;
     },
   };
 }
@@ -186,13 +187,36 @@ describe("call-engine module", () => {
     expect(local.source).toBe("screen_share_audio");
   });
 
-  test("setScreenShareEnabled delegates to LiveKit with audio disabled for this slice", async () => {
+  test("setScreenShareEnabled delegates video-only requests to LiveKit", async () => {
     const { CallEngine } = await import("../src/lib/calls/engine");
     const engine = new CallEngine();
     const participant = screenShareStub();
     (engine as unknown as { room: unknown }).room = { localParticipant: participant };
     await engine.setScreenShareEnabled(true, { audio: false });
     expect(participant.calls).toEqual([{ enabled: true, audio: false }]);
+    expect(engine.screenShareEnabled).toBe(true);
+  });
+
+  test("setScreenShareEnabled degrades unsupported screen audio to video-only share", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    const participant = screenShareStub({ audioThrows: deviceError("OverconstrainedError") });
+    (engine as unknown as { room: unknown }).room = { localParticipant: participant };
+    await engine.setScreenShareEnabled(true, { audio: true });
+    expect(participant.calls).toEqual([
+      { enabled: true, audio: true },
+      { enabled: true, audio: false },
+    ]);
+    expect(engine.screenShareEnabled).toBe(true);
+  });
+
+  test("setScreenShareEnabled does not mask unrelated LiveKit failures as screen-audio fallback", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    const participant = screenShareStub({ audioThrows: deviceError("TypeError") });
+    (engine as unknown as { room: unknown }).room = { localParticipant: participant };
+    await expect(engine.setScreenShareEnabled(true, { audio: true })).rejects.toHaveProperty("name", "TypeError");
+    expect(participant.calls).toEqual([{ enabled: true, audio: true }]);
     expect(engine.screenShareEnabled).toBe(true);
   });
 });


### PR DESCRIPTION
## Plan
- Request screen audio when starting a LiveKit screenshare, while leaving stop calls video-only.
- Keep LiveKit's typed `screen_share_audio` source mapping in the remote audio path.
- Degrade unsupported screen-audio capture to a video-only screenshare without surfacing an error.
- Keep non-audio-related LiveKit/browser failures visible instead of masking them as fallback success.
- Address PR review feedback around cross-browser fallback names and misleading stub-state assertions.

## Changes
- `toggleScreenShare` now passes `audio: true` only when enabling screen share.
- `CallEngine.setScreenShareEnabled` retries with `audio: false` for `OverconstrainedError`, `ConstraintNotSatisfiedError`, and `NotSupportedError` from the audio-enabled request.
- Added regression coverage for screen-audio requests, video-only stop, fallback across supported browser error names, and unrelated failure propagation.
- Removed a misleading post-rejection `screenShareEnabled` assertion that reflected test stub behavior rather than LiveKit state.

## Review fixes
- Copilot: included `ConstraintNotSatisfiedError` in the unsupported screen-audio fallback.
- Greptile: included `NotSupportedError` for Firefox/macOS/Linux fallback behavior.
- Copilot/Greptile: removed the misleading post-failure stub-state assertion.

## Verification
- `bun test` in `chat/`: 1770 pass, 0 fail.
- `bun run lint` in `chat/`: passed, including knip.

Closes #890