### PR TITLE
fix(chat): show local screenshare self banner

### DIFF
--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -21,12 +21,14 @@ import {
 } from "@/lib/calls/call-controls";
 import { useCallEngine } from "@/lib/calls/use-call-engine";
 import { useActiveMucCall } from "@/lib/calls/use-active-muc-call";
+import { localScreenSharePresentation } from "@/lib/calls/call-self-share";
 import { normalizeMucCallRoomJid } from "@/lib/calls/muc-call-presence";
 import { barePeerJid } from "@/lib/xmpp/jid";
 import CallTileGrid from "./CallTileGrid.vue";
 import CallControls from "./CallControls.vue";
 import CallSettingsDialog from "./CallSettingsDialog.vue";
 import CallMediaNotice from "./CallMediaNotice.vue";
+import CallSelfShareNotice from "./CallSelfShareNotice.vue";
 
 /**
  * "Expanded" call surface — fills the chat content pane while the
@@ -120,6 +122,15 @@ const subline = computed(() => {
 });
 
 const localIdentity = computed(() => engine.localIdentity);
+const selfSharePresentation = computed(() =>
+  localScreenSharePresentation({
+    screenShareEnabled: screenShareEnabled.value,
+    localTracks: localTracks.value,
+  }),
+);
+const stageLocalTracks = computed(() =>
+  selfSharePresentation.value?.stageLocalTracks ?? localTracks.value,
+);
 
 function collapseToSplit(): void {
   $callUiMode.set("split");
@@ -176,10 +187,14 @@ onBeforeUnmount(() => {
       {{ lastError }}
     </div>
     <CallMediaNotice />
+    <CallSelfShareNotice
+      v-if="selfSharePresentation"
+      :presentation="selfSharePresentation"
+    />
     <main class="call-expanded__grid">
       <CallTileGrid
         :remote-tracks="remoteTracks"
-        :local-tracks="localTracks"
+        :local-tracks="stageLocalTracks"
         :local-identity="localIdentity"
         :mic-enabled="micEnabled"
       />

--- a/chat/src/components/calls/CallSelfShareNotice.vue
+++ b/chat/src/components/calls/CallSelfShareNotice.vue
@@ -1,0 +1,128 @@
+<script setup lang="ts">
+import { onBeforeUnmount } from "vue";
+import type { LocalScreenSharePresentation } from "@/lib/calls/call-self-share";
+import { TileAttachments, type TileAttachable } from "@/lib/calls/tile-attach";
+import CallTile from "./CallTile.vue";
+
+defineProps<{
+  presentation: LocalScreenSharePresentation;
+  compact?: boolean;
+}>();
+
+const attachments = new TileAttachments();
+
+function attach(
+  key: string,
+  el: HTMLMediaElement | null,
+  track: TileAttachable | null,
+): void {
+  attachments.sync(key, el, track);
+}
+
+onBeforeUnmount(() => {
+  attachments.detachAll();
+});
+</script>
+
+<template>
+  <aside
+    class="call-self-share-notice"
+    :class="{ 'call-self-share-notice--compact': compact }"
+    role="status"
+    aria-live="polite"
+  >
+    <div class="call-self-share-notice__copy">
+      <span class="call-self-share-notice__dot" aria-hidden="true" />
+      <span class="type-control">{{ presentation.message }}</span>
+    </div>
+    <CallTile
+      :label="presentation.thumbnail.label"
+      :attach-key="presentation.thumbnail.attachKey"
+      :is-self="true"
+      :mirror-video="presentation.thumbnail.mirrorVideo"
+      :shows-presenting-glyph="true"
+      :mic-enabled="true"
+      :video-track="presentation.thumbnail.videoTrack"
+      :audio-track="null"
+      :attach="attach"
+      :interactive="false"
+      class="call-self-share-notice__thumb"
+    />
+  </aside>
+</template>
+
+<style scoped>
+.call-self-share-notice {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in oklab, var(--primary) 9%, var(--background));
+  padding: 0.5rem 0.75rem;
+}
+
+.call-self-share-notice__copy {
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--foreground);
+}
+
+.call-self-share-notice__dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  flex: 0 0 auto;
+  border-radius: 9999px;
+  background: var(--primary);
+  box-shadow: 0 0 0 4px color-mix(in oklab, var(--primary) 18%, transparent);
+}
+
+.call-self-share-notice__thumb {
+  width: clamp(6.5rem, 18vw, 9rem);
+  height: auto;
+  aspect-ratio: 16 / 9;
+  flex: 0 0 auto;
+}
+
+.call-self-share-notice--compact {
+  padding-block: 0.35rem;
+}
+
+.call-self-share-notice--compact .call-self-share-notice__thumb {
+  width: clamp(4.5rem, 14vw, 6rem);
+}
+
+@media (max-height: 620px) {
+  .call-self-share-notice--compact .call-self-share-notice__thumb {
+    width: 3.75rem;
+  }
+}
+
+@media (max-width: 520px) {
+  .call-self-share-notice {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .call-self-share-notice__thumb {
+    width: min(100%, 10rem);
+  }
+
+  .call-self-share-notice--compact {
+    align-items: center;
+    flex-direction: row;
+  }
+
+  .call-self-share-notice--compact .call-self-share-notice__thumb {
+    width: 5rem;
+  }
+}
+
+@media (max-width: 360px) {
+  .call-self-share-notice--compact .call-self-share-notice__thumb {
+    width: 3.75rem;
+  }
+}
+</style>

--- a/chat/src/components/calls/CallSplitContainer.vue
+++ b/chat/src/components/calls/CallSplitContainer.vue
@@ -22,12 +22,14 @@ import {
 import { useCallEngine } from "@/lib/calls/use-call-engine";
 import { useActiveMucCall } from "@/lib/calls/use-active-muc-call";
 import { useSplitResize } from "@/lib/calls/use-split-resize";
+import { localScreenSharePresentation } from "@/lib/calls/call-self-share";
 import { normalizeMucCallRoomJid } from "@/lib/calls/muc-call-presence";
 import { barePeerJid } from "@/lib/xmpp/jid";
 import CallTileGrid from "./CallTileGrid.vue";
 import CallControls from "./CallControls.vue";
 import CallSettingsDialog from "./CallSettingsDialog.vue";
 import CallMediaNotice from "./CallMediaNotice.vue";
+import CallSelfShareNotice from "./CallSelfShareNotice.vue";
 import SplitDragHandle from "./SplitDragHandle.vue";
 
 /**
@@ -147,6 +149,15 @@ const callLabel = computed(() => {
 });
 
 const localIdentity = computed(() => engine.localIdentity);
+const selfSharePresentation = computed(() =>
+  localScreenSharePresentation({
+    screenShareEnabled: screenShareEnabled.value,
+    localTracks: localTracks.value,
+  }),
+);
+const stageLocalTracks = computed(() =>
+  selfSharePresentation.value?.stageLocalTracks ?? localTracks.value,
+);
 
 onMounted(() => {
   refreshScreenShareSupported();
@@ -181,10 +192,15 @@ async function onHangup(): Promise<void> {
         {{ lastError }}
       </div>
       <CallMediaNotice />
+      <CallSelfShareNotice
+        v-if="selfSharePresentation"
+        :presentation="selfSharePresentation"
+        compact
+      />
       <div class="call-split__grid">
         <CallTileGrid
           :remote-tracks="remoteTracks"
-          :local-tracks="localTracks"
+          :local-tracks="stageLocalTracks"
           :local-identity="localIdentity"
           :mic-enabled="micEnabled"
         />

--- a/chat/src/components/calls/CallTile.vue
+++ b/chat/src/components/calls/CallTile.vue
@@ -21,7 +21,7 @@ import type { TileAttachable } from "@/lib/calls/tile-attach";
  * callbacks: the parent owns the single `TileAttachments` instance
  * so LiveKit's `attachedElements` array stays consistent.
  */
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   /** Human label rendered in the nameplate and derived into initials. */
   label: string;
   /** Stable identity-derived key namespace for `TileAttachments.sync`.
@@ -47,12 +47,10 @@ const props = defineProps<{
   /** Parent's attach reconciler — see `tile-attach.ts`. The tile
    *  invokes this from its `<video>` / `<audio>` ref callbacks. */
   attach: (key: string, el: HTMLMediaElement | null, track: TileAttachable | null) => void;
-}>();
-
-defineEmits<{
-  /** Click on the tile. Used by the parent to enter / exit speaker focus. */
-  activate: [];
-}>();
+  interactive?: boolean;
+}>(), {
+  interactive: true,
+});
 
 const initials = computed<string>(() => {
   return props.label
@@ -87,17 +85,31 @@ function refAudio(el: Element | null): void {
     props.audioTrack,
   );
 }
+
+const isInteractive = computed(() => props.interactive);
+
+function activate(): void {
+  if (isInteractive.value) emit("activate");
+}
+
+const emit = defineEmits<{
+  /** Click on the tile. Used by the parent to enter / exit speaker focus. */
+  activate: [];
+}>();
 </script>
 
 <template>
   <div
     class="call-tile"
-    :class="{ 'call-tile--has-video': videoTrack !== null }"
-    role="button"
-    tabindex="0"
-    :aria-label="`Open ${label} tile`"
-    @click="$emit('activate')"
-    @keydown.enter="$emit('activate')"
+    :class="{
+      'call-tile--has-video': videoTrack !== null,
+      'call-tile--interactive': isInteractive,
+    }"
+    :role="isInteractive ? 'button' : 'img'"
+    :tabindex="isInteractive ? 0 : undefined"
+    :aria-label="isInteractive ? `Open ${label} tile` : label"
+    @click="activate"
+    @keydown.enter="activate"
   >
     <!-- Placeholder layer — always mounted so the tile never shows a
          bare cell while LiveKit is still subscribing to the track.
@@ -166,7 +178,6 @@ function refAudio(el: Element | null): void {
   border-radius: var(--radius-md);
   border: 1px solid var(--border);
   background: var(--muted);
-  cursor: pointer;
   width: 100%;
   height: 100%;
   min-width: 0;
@@ -186,11 +197,15 @@ function refAudio(el: Element | null): void {
   flex: 0 0 auto;
 }
 
-.call-tile:hover {
+.call-tile--interactive {
+  cursor: pointer;
+}
+
+.call-tile--interactive:hover {
   box-shadow: 0 0 18px var(--glow);
 }
 
-.call-tile:focus-visible {
+.call-tile--interactive:focus-visible {
   outline: 2px solid var(--primary);
   outline-offset: 2px;
 }

--- a/chat/src/components/calls/CallTile.vue
+++ b/chat/src/components/calls/CallTile.vue
@@ -86,10 +86,8 @@ function refAudio(el: Element | null): void {
   );
 }
 
-const isInteractive = computed(() => props.interactive);
-
 function activate(): void {
-  if (isInteractive.value) emit("activate");
+  if (props.interactive) emit("activate");
 }
 
 const emit = defineEmits<{
@@ -103,11 +101,11 @@ const emit = defineEmits<{
     class="call-tile"
     :class="{
       'call-tile--has-video': videoTrack !== null,
-      'call-tile--interactive': isInteractive,
+      'call-tile--interactive': interactive,
     }"
-    :role="isInteractive ? 'button' : 'img'"
-    :tabindex="isInteractive ? 0 : undefined"
-    :aria-label="isInteractive ? `Open ${label} tile` : label"
+    :role="interactive ? 'button' : 'img'"
+    :tabindex="interactive ? 0 : undefined"
+    :aria-label="interactive ? `Open ${label} tile` : label"
     @click="activate"
     @keydown.enter="activate"
   >

--- a/chat/src/lib/calls/call-self-share.ts
+++ b/chat/src/lib/calls/call-self-share.ts
@@ -1,0 +1,38 @@
+import type { LocalMediaTrack } from "./engine";
+import type { TileAttachable } from "./tile-attach";
+
+export type LocalScreenSharePresentation = {
+  message: "You're sharing your screen";
+  thumbnail: {
+    attachKey: string;
+    label: "Your screen";
+    mirrorVideo: false;
+    videoTrack: TileAttachable;
+  };
+  stageLocalTracks: readonly LocalMediaTrack[];
+};
+
+export function localScreenSharePresentation(input: {
+  screenShareEnabled: boolean;
+  localTracks: readonly LocalMediaTrack[];
+}): LocalScreenSharePresentation | null {
+  if (!input.screenShareEnabled) return null;
+  const screenTrack = input.localTracks.find(
+    (track) => track.kind === "video" && track.source === "screen_share",
+  );
+  if (!screenTrack) return null;
+  return {
+    message: "You're sharing your screen",
+    thumbnail: {
+      attachKey: `self:${screenTrack.participantIdentity}:screen_share`,
+      label: "Your screen",
+      mirrorVideo: false,
+      videoTrack: screenTrack.track,
+    },
+    stageLocalTracks: input.localTracks.filter((track) => !isScreenShareSource(track)),
+  };
+}
+
+function isScreenShareSource(track: LocalMediaTrack): boolean {
+  return track.source === "screen_share" || track.source === "screen_share_audio";
+}

--- a/chat/src/lib/calls/tile-attach.ts
+++ b/chat/src/lib/calls/tile-attach.ts
@@ -81,4 +81,16 @@ export class TileAttachments {
   size(): number {
     return this.records.size;
   }
+
+  detachAll(): void {
+    for (const [key, record] of this.records) {
+      try {
+        record.track.detach(record.el);
+      } catch {
+        // detach is idempotent in normal flow; swallow.
+      }
+      record.el.srcObject = null;
+      this.records.delete(key);
+    }
+  }
 }

--- a/chat/src/lib/calls/tile-attach.ts
+++ b/chat/src/lib/calls/tile-attach.ts
@@ -83,14 +83,14 @@ export class TileAttachments {
   }
 
   detachAll(): void {
-    for (const [key, record] of this.records) {
+    for (const record of this.records.values()) {
       try {
         record.track.detach(record.el);
       } catch {
         // detach is idempotent in normal flow; swallow.
       }
       record.el.srcObject = null;
-      this.records.delete(key);
     }
+    this.records.clear();
   }
 }

--- a/chat/tests/call-self-share.test.ts
+++ b/chat/tests/call-self-share.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { localScreenSharePresentation } from "../src/lib/calls/call-self-share";
+import type { LocalMediaTrack } from "../src/lib/calls/engine";
+
+const fakeTrack = {} as LocalMediaTrack["track"];
+
+function localVideo(
+  publicationSid: string,
+  source: LocalMediaTrack["source"],
+): LocalMediaTrack {
+  return {
+    participantIdentity: "alice@waddle.test/web",
+    publicationSid,
+    kind: "video",
+    source,
+    track: fakeTrack,
+  };
+}
+
+function localAudio(
+  publicationSid: string,
+  source: LocalMediaTrack["source"],
+): LocalMediaTrack {
+  return {
+    participantIdentity: "alice@waddle.test/web",
+    publicationSid,
+    kind: "audio",
+    source,
+    track: fakeTrack,
+  };
+}
+
+describe("local screen-share presentation", () => {
+  test("stays absent when screen sharing is not active", () => {
+    expect(localScreenSharePresentation({
+      screenShareEnabled: false,
+      localTracks: [
+        localVideo("screen-pub", "screen_share"),
+      ],
+    })).toBeNull();
+  });
+
+  test("shows a presenter banner and self-thumbnail while keeping that track out of the stage", () => {
+    const camera = localVideo("camera-pub", "camera");
+    const screen = localVideo("screen-pub", "screen_share");
+    const screenAudio = localAudio("screen-audio-pub", "screen_share_audio");
+    const presentation = localScreenSharePresentation({
+      screenShareEnabled: true,
+      localTracks: [
+        camera,
+        screen,
+        screenAudio,
+      ],
+    });
+
+    expect(presentation).toEqual({
+      message: "You're sharing your screen",
+      thumbnail: {
+        attachKey: "self:alice@waddle.test/web:screen_share",
+        label: "Your screen",
+        mirrorVideo: false,
+        videoTrack: fakeTrack,
+      },
+      stageLocalTracks: [camera],
+    });
+  });
+});

--- a/chat/tests/call-self-share.test.ts
+++ b/chat/tests/call-self-share.test.ts
@@ -40,6 +40,13 @@ describe("local screen-share presentation", () => {
     })).toBeNull();
   });
 
+  test("stays absent while screen sharing is enabled before the screen track publishes", () => {
+    expect(localScreenSharePresentation({
+      screenShareEnabled: true,
+      localTracks: [],
+    })).toBeNull();
+  });
+
   test("shows a presenter banner and self-thumbnail while keeping that track out of the stage", () => {
     const camera = localVideo("camera-pub", "camera");
     const screen = localVideo("screen-pub", "screen_share");

--- a/chat/tests/call-tile-projection.test.ts
+++ b/chat/tests/call-tile-projection.test.ts
@@ -148,6 +148,26 @@ describe("call tile projection", () => {
     expect(html).toContain("Open alice&#39;s screen tile");
   });
 
+  test("renders non-interactive thumbnails without a dead button affordance", async () => {
+    const html = await renderCallTile({
+      label: "Your screen",
+      attachKey: "self:alice@example.com/web:screen_share",
+      isSelf: true,
+      mirrorVideo: false,
+      showsPresentingGlyph: true,
+      micEnabled: true,
+      videoTrack: null,
+      audioTrack: null,
+      attach: () => undefined,
+      interactive: false,
+    });
+
+    expect(html).toContain('role="img"');
+    expect(html).toContain('aria-label="Your screen"');
+    expect(html).not.toContain("Open Your screen tile");
+    expect(html).not.toContain("tabindex");
+  });
+
   test("forwards the presenting glyph flag in every grid branch", () => {
     const source = readFileSync(new URL("../src/components/calls/CallTileGrid.vue", import.meta.url), "utf8");
     expect(source.match(/:shows-presenting-glyph=/g)?.length).toBe(3);


### PR DESCRIPTION
## Summary

Implements #891.

- Adds a local screenshare presentation projection that drives a non-blocking "You're sharing your screen" notice and self-thumbnail from the existing screenshare-enabled state plus local LiveKit track descriptors.
- Renders the notice in both split and expanded call surfaces without placing the presenter's own screen on their main stage.
- Filters local screen-share video and screen-share audio tracks out of the stage while the notice owns the thumbnail, avoiding duplicate LiveKit track attachment.
- Adds a non-interactive CallTile mode so notice thumbnails do not expose dead button affordances.
- Keeps split-view presentation compact while preserving the required visible thumbnail.
- Addresses PR review feedback by simplifying attachment cleanup, removing redundant interactivity indirection, and covering the transient enabled-before-track-published state.

## XEP review

No XMPP/Jingle wire-shape changes. This remains a LiveKit web UI projection on media tracks already established by the existing call flow. Reviewed XEP-0167 and XEP-0353 relevance: the slice does not introduce or alter advertised XMPP namespace semantics.

## Verification

- `bun test tests/call-self-share.test.ts tests/call-tile-projection.test.ts tests/call-tile-attach.test.ts` in `chat/` - 14 pass, 0 fail
- `bun test` in `chat/` - 1784 pass, 0 fail
- final repo-level `bun test` from root before review-fix commit - 1795 pass, 0 fail
- `bun run lint` in `chat/` - clean, includes wasm build check + knip
- `bun run build` in `chat/` - success; existing Astro hint for `src/lib/xmpp/discovery.ts:80`, existing Vite chunk-size warning
- Two adversarial subagent review passes repeated until both returned no actionable findings

## Notes

- Manual browser screenshare picker flow was not exercised locally.
- `bun run lint` reused existing wasm artifacts after the initial rebuild.

Closes #891.
