### PR TITLE
fix(chat): persist call volume across track churn

### DIFF
--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -50,6 +50,26 @@ export type CallTrackSource =
   | "screen_share"
   | "screen_share_audio";
 
+export type ParticipantAudioVolumeStore = Record<string, number>;
+
+export type ParticipantAudioVolumeIdentity = {
+  participantIdentity: string;
+  source: CallTrackSource;
+};
+
+export function participantAudioVolumeKey(
+  identity: ParticipantAudioVolumeIdentity,
+): string {
+  return `${identity.participantIdentity}:${identity.source}`;
+}
+
+export function resolveParticipantAudioVolume(
+  store: ParticipantAudioVolumeStore,
+  identity: ParticipantAudioVolumeIdentity,
+): number {
+  return store[participantAudioVolumeKey(identity)] ?? 1;
+}
+
 export type CallEngineEvents = {
   trackSubscribed: (track: RemoteMediaTrack) => void;
   trackUnsubscribed: (track: RemoteMediaTrack) => void;

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -302,10 +302,7 @@ export class CallEngine {
   ): void {
     const key = participantAudioVolumeKey(identity);
     const volume = normalizeParticipantAudioVolume(identity.volume);
-    this.participantAudioVolumes = {
-      ...this.participantAudioVolumes,
-      [key]: volume,
-    };
+    this.participantAudioVolumes[key] = volume;
     for (const track of this.subscribedAudioTracks.get(key) ?? []) {
       track.setVolume(volume);
     }
@@ -325,8 +322,8 @@ export class CallEngine {
   async disconnect(): Promise<void> {
     const room = this.room;
     this.room = null;
-    this.clearParticipantAudioVolumes();
     if (!room) return;
+    this.clearParticipantAudioVolumes();
     // Drop subscribers' track caches synchronously. The LiveKit
     // `Disconnected` event is the natural trigger, but we unregister
     // `handleDisconnected` immediately below so the event never reaches
@@ -479,8 +476,9 @@ export class CallEngine {
   }
 
   private forgetParticipantSubscribedAudioTracks(participantIdentity: string): void {
-    for (const key of this.subscribedAudioTracks.keys()) {
-      if (key.startsWith(`${participantIdentity}:`)) this.subscribedAudioTracks.delete(key);
+    const sources: CallAudioTrackSource[] = ["microphone", "screen_share_audio"];
+    for (const source of sources) {
+      this.subscribedAudioTracks.delete(participantAudioVolumeKey({ participantIdentity, source }));
     }
   }
 }

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -50,14 +50,20 @@ export type CallTrackSource =
   | "screen_share"
   | "screen_share_audio";
 
+type CallAudioTrackSource = Extract<CallTrackSource, "microphone" | "screen_share_audio">;
+
 export type ParticipantAudioVolumeStore = Record<string, number>;
 
 export type ParticipantAudioVolumeIdentity = {
   participantIdentity: string;
-  source: CallTrackSource;
+  source: CallAudioTrackSource;
 };
 
-export function participantAudioVolumeKey(
+type VolumeAdjustableTrack = {
+  setVolume(volume: number): unknown;
+};
+
+function participantAudioVolumeKey(
   identity: ParticipantAudioVolumeIdentity,
 ): string {
   return `${identity.participantIdentity}:${identity.source}`;
@@ -124,6 +130,8 @@ export type CallEngineEvents = {
  */
 export class CallEngine {
   private room: Room | null = null;
+  private participantAudioVolumes: ParticipantAudioVolumeStore = {};
+  private subscribedAudioTracks = new Map<string, Set<VolumeAdjustableTrack>>();
   private listeners: { [K in keyof CallEngineEvents]: Set<CallEngineEvents[K]> } = {
     trackSubscribed: new Set(),
     trackUnsubscribed: new Set(),
@@ -289,6 +297,20 @@ export class CallEngine {
     await this.applySpeakerDevice(deviceId);
   }
 
+  setParticipantAudioVolume(
+    identity: ParticipantAudioVolumeIdentity & { volume: number },
+  ): void {
+    const key = participantAudioVolumeKey(identity);
+    const volume = normalizeParticipantAudioVolume(identity.volume);
+    this.participantAudioVolumes = {
+      ...this.participantAudioVolumes,
+      [key]: volume,
+    };
+    for (const track of this.subscribedAudioTracks.get(key) ?? []) {
+      track.setVolume(volume);
+    }
+  }
+
   private async applySpeakerDevice(deviceId: string): Promise<void> {
     if (!this.room) return;
     if (typeof this.room.switchActiveDevice !== "function") return;
@@ -303,6 +325,7 @@ export class CallEngine {
   async disconnect(): Promise<void> {
     const room = this.room;
     this.room = null;
+    this.clearParticipantAudioVolumes();
     if (!room) return;
     // Drop subscribers' track caches synchronously. The LiveKit
     // `Disconnected` event is the natural trigger, but we unregister
@@ -341,11 +364,19 @@ export class CallEngine {
   ) => {
     const kind = mapKind(track.kind);
     if (!kind) return;
+    const source = mapTrackSource(publication.source, kind);
+    if (isCallAudioTrackSource(source)) {
+      this.rememberSubscribedAudioTrack({
+        participantIdentity: participant.identity,
+        source,
+        track,
+      });
+    }
     this.emit("trackSubscribed", {
       participantIdentity: participant.identity,
       publicationSid: publication.trackSid,
       kind,
-      source: mapTrackSource(publication.source, kind),
+      source,
       track,
     });
   };
@@ -357,11 +388,19 @@ export class CallEngine {
   ) => {
     const kind = mapKind(track.kind);
     if (!kind) return;
+    const source = mapTrackSource(publication.source, kind);
+    if (isCallAudioTrackSource(source)) {
+      this.forgetSubscribedAudioTrack({
+        participantIdentity: participant.identity,
+        source,
+        track,
+      });
+    }
     this.emit("trackUnsubscribed", {
       participantIdentity: participant.identity,
       publicationSid: publication.trackSid,
       kind,
-      source: mapTrackSource(publication.source, kind),
+      source,
       track,
     });
   };
@@ -403,12 +442,62 @@ export class CallEngine {
   };
 
   private handleParticipantDisconnected = (participant: RemoteParticipant) => {
+    this.forgetParticipantSubscribedAudioTracks(participant.identity);
     this.emit("participantDisconnected", participant.identity);
   };
 
   private handleDisconnected = (reason?: unknown) => {
+    this.clearParticipantAudioVolumes();
     this.emit("disconnected", typeof reason === "string" ? reason : undefined);
   };
+
+  private clearParticipantAudioVolumes(): void {
+    this.participantAudioVolumes = {};
+    this.subscribedAudioTracks.clear();
+  }
+
+  private rememberSubscribedAudioTrack(
+    identity: ParticipantAudioVolumeIdentity & { track: RemoteTrack },
+  ): void {
+    if (!isVolumeAdjustableTrack(identity.track)) return;
+    const key = participantAudioVolumeKey(identity);
+    const tracks = this.subscribedAudioTracks.get(key) ?? new Set<VolumeAdjustableTrack>();
+    tracks.add(identity.track);
+    this.subscribedAudioTracks.set(key, tracks);
+    identity.track.setVolume(resolveParticipantAudioVolume(this.participantAudioVolumes, identity));
+  }
+
+  private forgetSubscribedAudioTrack(
+    identity: ParticipantAudioVolumeIdentity & { track: RemoteTrack },
+  ): void {
+    if (!isVolumeAdjustableTrack(identity.track)) return;
+    const key = participantAudioVolumeKey(identity);
+    const tracks = this.subscribedAudioTracks.get(key);
+    if (!tracks) return;
+    tracks.delete(identity.track);
+    if (tracks.size === 0) this.subscribedAudioTracks.delete(key);
+  }
+
+  private forgetParticipantSubscribedAudioTracks(participantIdentity: string): void {
+    for (const key of this.subscribedAudioTracks.keys()) {
+      if (key.startsWith(`${participantIdentity}:`)) this.subscribedAudioTracks.delete(key);
+    }
+  }
+}
+
+function isVolumeAdjustableTrack(track: RemoteTrack): track is RemoteTrack & VolumeAdjustableTrack {
+  return "setVolume" in track && typeof track.setVolume === "function";
+}
+
+function isCallAudioTrackSource(source: CallTrackSource): source is CallAudioTrackSource {
+  return source === "microphone" || source === "screen_share_audio";
+}
+
+function normalizeParticipantAudioVolume(volume: number): number {
+  if (!Number.isFinite(volume)) return 1;
+  if (volume < 0) return 0;
+  if (volume > 1) return 1;
+  return volume;
 }
 
 function mapKind(kind: Track.Kind): "audio" | "video" | null {

--- a/chat/tests/call-engine.test.ts
+++ b/chat/tests/call-engine.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from "bun:test";
 import {
   enableRequestedCapture,
   mapTrackSource,
+  resolveParticipantAudioVolume,
   type CallEngineEvents,
+  type ParticipantAudioVolumeStore,
   type LocalMediaTrack,
   type RemoteMediaTrack,
 } from "../src/lib/calls/engine";
@@ -54,6 +56,26 @@ function screenShareStub(opts: { audioThrows?: Error } = {}) {
 // is exercised by manual smoke tests in the browser per the call PR
 // plan, and by the planned `calls_e2e` integration test on the server.
 describe("call-engine module", () => {
+  test("resolves participant audio volume by identity and source with default full volume", () => {
+    const store: ParticipantAudioVolumeStore = {
+      "bob@waddle.test/desktop:microphone": 0.3,
+      "bob@waddle.test/desktop:screen_share_audio": 0.6,
+    };
+
+    expect(resolveParticipantAudioVolume(store, {
+      participantIdentity: "bob@waddle.test/desktop",
+      source: "microphone",
+    })).toBe(0.3);
+    expect(resolveParticipantAudioVolume(store, {
+      participantIdentity: "bob@waddle.test/desktop",
+      source: "screen_share_audio",
+    })).toBe(0.6);
+    expect(resolveParticipantAudioVolume(store, {
+      participantIdentity: "alice@waddle.test/web",
+      source: "microphone",
+    })).toBe(1);
+  });
+
   test("exports CallEngine class with the expected surface", async () => {
     const mod = await import("../src/lib/calls/engine");
     const engine = new mod.CallEngine();

--- a/chat/tests/call-engine.test.ts
+++ b/chat/tests/call-engine.test.ts
@@ -423,6 +423,54 @@ describe("call-engine module", () => {
     expect(setVolume).not.toHaveBeenLastCalledWith(0.25);
   });
 
+  test("participant disconnect only drops exact identity audio track references", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    const disconnectedSetVolume = mock(() => undefined);
+    const activeSetVolume = mock(() => undefined);
+    const { handleTrackSubscribed, handleParticipantDisconnected } = engine as unknown as {
+      handleTrackSubscribed: (track: unknown, publication: unknown, participant: unknown) => void;
+      handleParticipantDisconnected: (participant: unknown) => void;
+    };
+    handleTrackSubscribed(
+      {
+        kind: Track.Kind.Audio,
+        setVolume: disconnectedSetVolume,
+      },
+      {
+        trackSid: "alice-app-mic",
+        source: Track.Source.Microphone,
+      },
+      { identity: "alice@waddle.test/app" },
+    );
+    handleTrackSubscribed(
+      {
+        kind: Track.Kind.Audio,
+        setVolume: activeSetVolume,
+      },
+      {
+        trackSid: "alice-app-phone-mic",
+        source: Track.Source.Microphone,
+      },
+      { identity: "alice@waddle.test/app:phone" },
+    );
+
+    handleParticipantDisconnected({ identity: "alice@waddle.test/app" });
+    engine.setParticipantAudioVolume({
+      participantIdentity: "alice@waddle.test/app:phone",
+      source: "microphone",
+      volume: 0.25,
+    });
+    engine.setParticipantAudioVolume({
+      participantIdentity: "alice@waddle.test/app",
+      source: "microphone",
+      volume: 0.4,
+    });
+
+    expect(activeSetVolume).toHaveBeenLastCalledWith(0.25);
+    expect(disconnectedSetVolume).not.toHaveBeenLastCalledWith(0.4);
+  });
+
   test("disconnect clears stored participant audio volumes for the next call", async () => {
     const { CallEngine } = await import("../src/lib/calls/engine");
     const engine = new CallEngine();
@@ -456,6 +504,36 @@ describe("call-engine module", () => {
     );
 
     expect(setVolume).toHaveBeenCalledWith(1);
+  });
+
+  test("disconnect without a room does not clear pre-connected participant audio volumes", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    const setVolume = mock(() => undefined);
+    engine.setParticipantAudioVolume({
+      participantIdentity: "bob@waddle.test/desktop",
+      source: "microphone",
+      volume: 0.3,
+    });
+
+    await engine.disconnect();
+    (
+      engine as unknown as {
+        handleTrackSubscribed: (track: unknown, publication: unknown, participant: unknown) => void;
+      }
+    ).handleTrackSubscribed(
+      {
+        kind: Track.Kind.Audio,
+        setVolume,
+      },
+      {
+        trackSid: "bob-mic",
+        source: Track.Source.Microphone,
+      },
+      { identity: "bob@waddle.test/desktop" },
+    );
+
+    expect(setVolume).toHaveBeenCalledWith(0.3);
   });
 });
 

--- a/chat/tests/call-engine.test.ts
+++ b/chat/tests/call-engine.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import {
   enableRequestedCapture,
   mapTrackSource,
@@ -243,6 +243,219 @@ describe("call-engine module", () => {
     (engine as unknown as { room: unknown }).room = { localParticipant: participant };
     await expect(engine.setScreenShareEnabled(true, { audio: true })).rejects.toHaveProperty("name", "TypeError");
     expect(participant.calls).toEqual([{ enabled: true, audio: true }]);
+  });
+
+  test("track subscription re-applies the stored participant audio volume", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    const setVolume = mock(() => undefined);
+    engine.setParticipantAudioVolume({
+      participantIdentity: "bob@waddle.test/desktop",
+      source: "microphone",
+      volume: 0.3,
+    });
+
+    (
+      engine as unknown as {
+        handleTrackSubscribed: (track: unknown, publication: unknown, participant: unknown) => void;
+      }
+    ).handleTrackSubscribed(
+      {
+        kind: Track.Kind.Audio,
+        setVolume,
+      },
+      {
+        trackSid: "bob-mic-2",
+        source: Track.Source.Microphone,
+      },
+      { identity: "bob@waddle.test/desktop" },
+    );
+
+    expect(setVolume).toHaveBeenCalledWith(0.3);
+  });
+
+  test("track subscription keeps microphone and screen-share audio volumes independent", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    const setMicVolume = mock(() => undefined);
+    const setShareVolume = mock(() => undefined);
+    engine.setParticipantAudioVolume({
+      participantIdentity: "bob@waddle.test/desktop",
+      source: "microphone",
+      volume: 0.3,
+    });
+    engine.setParticipantAudioVolume({
+      participantIdentity: "bob@waddle.test/desktop",
+      source: "screen_share_audio",
+      volume: 0.6,
+    });
+    const { handleTrackSubscribed } = engine as unknown as {
+      handleTrackSubscribed: (track: unknown, publication: unknown, participant: unknown) => void;
+    };
+
+    handleTrackSubscribed(
+      {
+        kind: Track.Kind.Audio,
+        setVolume: setMicVolume,
+      },
+      {
+        trackSid: "bob-mic",
+        source: Track.Source.Microphone,
+      },
+      { identity: "bob@waddle.test/desktop" },
+    );
+    handleTrackSubscribed(
+      {
+        kind: Track.Kind.Audio,
+        setVolume: setShareVolume,
+      },
+      {
+        trackSid: "bob-share-audio",
+        source: Track.Source.ScreenShareAudio,
+      },
+      { identity: "bob@waddle.test/desktop" },
+    );
+
+    expect(setMicVolume).toHaveBeenCalledWith(0.3);
+    expect(setShareVolume).toHaveBeenCalledWith(0.6);
+  });
+
+  test("setting participant audio volume updates currently subscribed tracks", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    const setVolume = mock(() => undefined);
+    (
+      engine as unknown as {
+        handleTrackSubscribed: (track: unknown, publication: unknown, participant: unknown) => void;
+      }
+    ).handleTrackSubscribed(
+      {
+        kind: Track.Kind.Audio,
+        setVolume,
+      },
+      {
+        trackSid: "bob-mic",
+        source: Track.Source.Microphone,
+      },
+      { identity: "bob@waddle.test/desktop" },
+    );
+
+    engine.setParticipantAudioVolume({
+      participantIdentity: "bob@waddle.test/desktop",
+      source: "microphone",
+      volume: 0.25,
+    });
+
+    expect(setVolume).toHaveBeenLastCalledWith(0.25);
+  });
+
+  test("participant audio volume is clamped before storing and applying", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    const setVolume = mock(() => undefined);
+    engine.setParticipantAudioVolume({
+      participantIdentity: "bob@waddle.test/desktop",
+      source: "microphone",
+      volume: 30,
+    });
+    (
+      engine as unknown as {
+        handleTrackSubscribed: (track: unknown, publication: unknown, participant: unknown) => void;
+      }
+    ).handleTrackSubscribed(
+      {
+        kind: Track.Kind.Audio,
+        setVolume,
+      },
+      {
+        trackSid: "bob-mic",
+        source: Track.Source.Microphone,
+      },
+      { identity: "bob@waddle.test/desktop" },
+    );
+
+    expect(setVolume).toHaveBeenCalledWith(1);
+    engine.setParticipantAudioVolume({
+      participantIdentity: "bob@waddle.test/desktop",
+      source: "microphone",
+      volume: -1,
+    });
+    expect(setVolume).toHaveBeenLastCalledWith(0);
+    engine.setParticipantAudioVolume({
+      participantIdentity: "bob@waddle.test/desktop",
+      source: "microphone",
+      volume: Number.NaN,
+    });
+    expect(setVolume).toHaveBeenLastCalledWith(1);
+  });
+
+  test("participant disconnect drops stale subscribed audio track references", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    const setVolume = mock(() => undefined);
+    (
+      engine as unknown as {
+        handleTrackSubscribed: (track: unknown, publication: unknown, participant: unknown) => void;
+      }
+    ).handleTrackSubscribed(
+      {
+        kind: Track.Kind.Audio,
+        setVolume,
+      },
+      {
+        trackSid: "bob-mic",
+        source: Track.Source.Microphone,
+      },
+      { identity: "bob@waddle.test/desktop" },
+    );
+    (
+      engine as unknown as {
+        handleParticipantDisconnected: (participant: unknown) => void;
+      }
+    ).handleParticipantDisconnected({ identity: "bob@waddle.test/desktop" });
+
+    engine.setParticipantAudioVolume({
+      participantIdentity: "bob@waddle.test/desktop",
+      source: "microphone",
+      volume: 0.25,
+    });
+
+    expect(setVolume).not.toHaveBeenLastCalledWith(0.25);
+  });
+
+  test("disconnect clears stored participant audio volumes for the next call", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    const stubRoom = {
+      off: () => stubRoom,
+      disconnect: async () => undefined,
+    };
+    const setVolume = mock(() => undefined);
+    engine.setParticipantAudioVolume({
+      participantIdentity: "bob@waddle.test/desktop",
+      source: "microphone",
+      volume: 0.3,
+    });
+    (engine as unknown as { room: typeof stubRoom }).room = stubRoom;
+
+    await engine.disconnect();
+    (
+      engine as unknown as {
+        handleTrackSubscribed: (track: unknown, publication: unknown, participant: unknown) => void;
+      }
+    ).handleTrackSubscribed(
+      {
+        kind: Track.Kind.Audio,
+        setVolume,
+      },
+      {
+        trackSid: "bob-mic-next-call",
+        source: Track.Source.Microphone,
+      },
+      { identity: "bob@waddle.test/desktop" },
+    );
+
+    expect(setVolume).toHaveBeenCalledWith(1);
   });
 });
 


### PR DESCRIPTION
## Completed work

- Added a per-call participant audio volume store keyed by LiveKit participant identity plus audio source.
- Added a pure resolver for stored/default volume lookup.
- Re-applies stored volume whenever a replacement remote audio track is subscribed.
- Keeps microphone and screen-share audio independent for the same participant.
- Updates already subscribed tracks when the user changes a participant volume.
- Clears stored choices and subscribed-track references on disconnect so the next call starts at 100%.
- Drops stale track references on participant disconnect in case LiveKit does not emit every unsubscribe first.
- Clamps volume input to the LiveKit gain range before storing/applying it.

## Verification

- `bun test tests/call-engine.test.ts`
- `bun test`
- `bun run lint`

## Notes

- No XMPP/XEP wire shape changes. This is local LiveKit audio state only.
- `knip` required keeping the audio-source helper type module-private; no ignore entries were added.

Closes #899
