### PR TITLE
feat(chat): complete call volume mixer

### DIFF
--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -23,12 +23,20 @@ import { useCallEngine } from "@/lib/calls/use-call-engine";
 import { useActiveMucCall } from "@/lib/calls/use-active-muc-call";
 import { localScreenSharePresentation } from "@/lib/calls/call-self-share";
 import { normalizeMucCallRoomJid } from "@/lib/calls/muc-call-presence";
+import { $mucCallLiveParticipants } from "@/lib/calls/muc-call-live-participants";
+import {
+  buildCallVolumeMixerRows,
+  resetCallVolumeMixerLevels,
+  type CallVolumeLevelStore,
+  type CallVolumeMixerRow,
+} from "@/lib/calls/call-volume-mixer";
 import { barePeerJid } from "@/lib/xmpp/jid";
 import CallTileGrid from "./CallTileGrid.vue";
 import CallControls from "./CallControls.vue";
 import CallSettingsDialog from "./CallSettingsDialog.vue";
 import CallMediaNotice from "./CallMediaNotice.vue";
 import CallSelfShareNotice from "./CallSelfShareNotice.vue";
+import CallVolumeMixerPanel from "./CallVolumeMixerPanel.vue";
 
 /**
  * "Expanded" call surface — fills the chat content pane while the
@@ -59,10 +67,12 @@ const micEnabled = useStore($callMicEnabled);
 const camEnabled = useStore($callCamEnabled);
 const screenShareEnabled = useStore($callScreenShareEnabled);
 const screenShareSupported = useStore($callScreenShareSupported);
+const liveParticipants = useStore($mucCallLiveParticipants);
 const { remoteTracks, localTracks, engine } = useCallEngine();
 const { activeRoomJid, selfInCall } = useActiveMucCall();
 
 const settingsOpen = ref(false);
+const participantAudioLevels = ref<CallVolumeLevelStore>({});
 
 const normalizedRoomJid = computed(() =>
   normalizeMucCallRoomJid(props.roomJid ?? ""),
@@ -132,6 +142,50 @@ const stageLocalTracks = computed(() =>
   selfSharePresentation.value?.stageLocalTracks ?? localTracks.value,
 );
 
+const remoteParticipantIdentities = computed(() => {
+  if (state.value.phase === "active" && state.value.kind === "muc") {
+    return liveParticipants.value[normalizedRoomJid.value] ?? [];
+  }
+  const identities = new Set<string>();
+  if (state.value.phase === "active" && state.value.kind === "dm") {
+    identities.add(state.value.peer);
+  }
+  for (const track of remoteTracks.value) identities.add(track.participantIdentity);
+  return Array.from(identities);
+});
+
+const volumeRows = computed(() =>
+  buildCallVolumeMixerRows({
+    remoteParticipantIdentities: remoteParticipantIdentities.value,
+    remoteTracks: remoteTracks.value,
+    localIdentity: localIdentity.value,
+    levels: participantAudioLevels.value,
+  }),
+);
+
+function setParticipantVolume(row: CallVolumeMixerRow, level: number): void {
+  participantAudioLevels.value = {
+    ...participantAudioLevels.value,
+    [row.key]: level,
+  };
+  engine.setParticipantAudioVolume({
+    participantIdentity: row.participantIdentity,
+    source: row.source,
+    volume: level,
+  });
+}
+
+function resetParticipantVolumes(): void {
+  participantAudioLevels.value = resetCallVolumeMixerLevels(participantAudioLevels.value);
+  for (const row of volumeRows.value) {
+    engine.setParticipantAudioVolume({
+      participantIdentity: row.participantIdentity,
+      source: row.source,
+      volume: 1,
+    });
+  }
+}
+
 function collapseToSplit(): void {
   $callUiMode.set("split");
 }
@@ -191,12 +245,19 @@ onBeforeUnmount(() => {
       v-if="selfSharePresentation"
       :presentation="selfSharePresentation"
     />
-    <main class="call-expanded__grid">
-      <CallTileGrid
-        :remote-tracks="remoteTracks"
-        :local-tracks="stageLocalTracks"
-        :local-identity="localIdentity"
-        :mic-enabled="micEnabled"
+    <main class="call-expanded__main">
+      <div class="call-expanded__grid">
+        <CallTileGrid
+          :remote-tracks="remoteTracks"
+          :local-tracks="stageLocalTracks"
+          :local-identity="localIdentity"
+          :mic-enabled="micEnabled"
+        />
+      </div>
+      <CallVolumeMixerPanel
+        :rows="volumeRows"
+        @set-volume="setParticipantVolume"
+        @reset-all="resetParticipantVolumes"
       />
     </main>
     <footer class="call-expanded__footer">
@@ -247,8 +308,16 @@ onBeforeUnmount(() => {
   color: var(--destructive);
 }
 
+.call-expanded__main {
+  flex: 1 1 0%;
+  min-height: 0;
+  display: flex;
+  overflow: hidden;
+}
+
 .call-expanded__grid {
   flex: 1 1 0%;
+  min-width: 0;
   min-height: 0;
   display: flex;
   flex-direction: column;
@@ -261,5 +330,11 @@ onBeforeUnmount(() => {
   justify-content: center;
   border-top: 1px solid var(--border);
   padding: 0.75rem 1rem;
+}
+
+@media (max-width: 760px) {
+  .call-expanded__main {
+    flex-direction: column;
+  }
 }
 </style>

--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { useStore } from "@nanostores/vue";
 import {
   $callState,
@@ -73,6 +73,10 @@ const { activeRoomJid, selfInCall } = useActiveMucCall();
 
 const settingsOpen = ref(false);
 const participantAudioLevels = ref<CallVolumeLevelStore>({});
+const participantAudioTargets = ref<Record<string, {
+  participantIdentity: string;
+  source: CallVolumeMixerRow["source"];
+}>>({});
 
 const normalizedRoomJid = computed(() =>
   normalizeMucCallRoomJid(props.roomJid ?? ""),
@@ -163,10 +167,21 @@ const volumeRows = computed(() =>
   }),
 );
 
+const activeCallSid = computed(() =>
+  state.value.phase === "active" ? state.value.sid : null,
+);
+
 function setParticipantVolume(row: CallVolumeMixerRow, level: number): void {
   participantAudioLevels.value = {
     ...participantAudioLevels.value,
     [row.key]: level,
+  };
+  participantAudioTargets.value = {
+    ...participantAudioTargets.value,
+    [row.key]: {
+      participantIdentity: row.participantIdentity,
+      source: row.source,
+    },
   };
   engine.setParticipantAudioVolume({
     participantIdentity: row.participantIdentity,
@@ -176,7 +191,13 @@ function setParticipantVolume(row: CallVolumeMixerRow, level: number): void {
 }
 
 function resetParticipantVolumes(): void {
-  participantAudioLevels.value = resetCallVolumeMixerLevels(participantAudioLevels.value);
+  for (const target of Object.values(participantAudioTargets.value)) {
+    engine.setParticipantAudioVolume({
+      participantIdentity: target.participantIdentity,
+      source: target.source,
+      volume: 1,
+    });
+  }
   for (const row of volumeRows.value) {
     engine.setParticipantAudioVolume({
       participantIdentity: row.participantIdentity,
@@ -184,6 +205,7 @@ function resetParticipantVolumes(): void {
       volume: 1,
     });
   }
+  participantAudioLevels.value = resetCallVolumeMixerLevels(participantAudioLevels.value);
 }
 
 function collapseToSplit(): void {
@@ -211,6 +233,11 @@ onMounted(() => {
   if (typeof window !== "undefined") {
     window.addEventListener("keydown", onKeydown);
   }
+});
+
+watch(activeCallSid, () => {
+  participantAudioLevels.value = {};
+  participantAudioTargets.value = {};
 });
 
 onBeforeUnmount(() => {

--- a/chat/src/components/calls/CallVolumeMixerPanel.vue
+++ b/chat/src/components/calls/CallVolumeMixerPanel.vue
@@ -1,0 +1,195 @@
+<script setup lang="ts">
+import { Volume2, VolumeX } from "lucide-vue-next";
+import type { CallVolumeMixerRow } from "@/lib/calls/call-volume-mixer";
+
+defineProps<{
+  rows: readonly CallVolumeMixerRow[];
+}>();
+
+const emit = defineEmits<{
+  setVolume: [row: CallVolumeMixerRow, level: number];
+  resetAll: [];
+}>();
+
+function onInput(row: CallVolumeMixerRow, event: Event): void {
+  const target = event.target;
+  if (!(target instanceof HTMLInputElement)) return;
+  emit("setVolume", row, Number(target.value) / 100);
+}
+</script>
+
+<template>
+  <aside class="call-volume-mixer" aria-label="Call volume mixer">
+    <div class="call-volume-mixer__header">
+      <h2 class="type-control">Who you hear</h2>
+    </div>
+
+    <ul v-if="rows.length > 0" class="call-volume-mixer__rows">
+      <li
+        v-for="row in rows"
+        :key="row.key"
+        class="call-volume-mixer__row"
+        :class="{ 'call-volume-mixer__row--disabled': row.disabled }"
+      >
+        <div class="call-volume-mixer__meta">
+          <span class="type-caption truncate">{{ row.label }}</span>
+          <span v-if="row.hint" class="call-volume-mixer__hint">{{ row.hint }}</span>
+        </div>
+        <div class="call-volume-mixer__control">
+          <VolumeX
+            v-if="row.muted"
+            class="call-volume-mixer__muted"
+            aria-label="Muted"
+          />
+          <Volume2
+            v-else
+            class="call-volume-mixer__speaker"
+            aria-hidden="true"
+          />
+          <div class="call-volume-mixer__slider-wrap">
+            <input
+              class="call-volume-mixer__slider"
+              type="range"
+              min="0"
+              max="100"
+              step="1"
+              :value="Math.round(row.level * 100)"
+              :disabled="row.disabled"
+              :aria-label="row.ariaLabel"
+              :aria-valuetext="row.ariaValueText"
+              @input="onInput(row, $event)"
+            >
+            <span class="call-volume-mixer__tick" aria-hidden="true" />
+          </div>
+          <span class="call-volume-mixer__percent">{{ Math.round(row.level * 100) }}%</span>
+        </div>
+      </li>
+    </ul>
+    <div v-else class="call-volume-mixer__empty type-caption">
+      No remote audio
+    </div>
+
+    <footer class="call-volume-mixer__footer">
+      <button
+        type="button"
+        class="chat-action-button chat-action-button--secondary"
+        @click="emit('resetAll')"
+      >
+        Reset all
+      </button>
+    </footer>
+  </aside>
+</template>
+
+<style scoped>
+.call-volume-mixer {
+  width: min(18rem, 32vw);
+  min-width: 14rem;
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid var(--border);
+  background: color-mix(in oklab, var(--muted) 20%, var(--background));
+}
+
+.call-volume-mixer__header,
+.call-volume-mixer__footer {
+  flex: 0 0 auto;
+  padding: 0.75rem;
+}
+
+.call-volume-mixer__header {
+  border-bottom: 1px solid var(--border);
+}
+
+.call-volume-mixer__rows {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+  overflow-y: auto;
+  padding: 0.75rem;
+}
+
+.call-volume-mixer__row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.call-volume-mixer__row--disabled {
+  opacity: 0.58;
+}
+
+.call-volume-mixer__meta,
+.call-volume-mixer__control {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.call-volume-mixer__hint {
+  flex: 0 0 auto;
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+}
+
+.call-volume-mixer__muted,
+.call-volume-mixer__speaker {
+  flex: 0 0 auto;
+  width: 1rem;
+  height: 1rem;
+  color: var(--muted-foreground);
+}
+
+.call-volume-mixer__slider-wrap {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 4rem;
+  display: flex;
+  align-items: center;
+}
+
+.call-volume-mixer__slider {
+  width: 100%;
+  accent-color: var(--primary);
+}
+
+.call-volume-mixer__tick {
+  position: absolute;
+  right: 0.3125rem;
+  top: 50%;
+  width: 1px;
+  height: 0.875rem;
+  transform: translateY(-50%);
+  background: color-mix(in oklab, var(--foreground) 28%, transparent);
+  pointer-events: none;
+}
+
+.call-volume-mixer__percent {
+  flex: 0 0 2.25rem;
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+  text-align: right;
+}
+
+.call-volume-mixer__empty {
+  flex: 1 1 auto;
+  padding: 0.75rem;
+  color: var(--muted-foreground);
+}
+
+.call-volume-mixer__footer {
+  border-top: 1px solid var(--border);
+}
+
+@media (max-width: 760px) {
+  .call-volume-mixer {
+    width: 100%;
+    max-height: 16rem;
+    border-left: 0;
+    border-top: 1px solid var(--border);
+  }
+}
+</style>

--- a/chat/src/lib/calls/call-volume-mixer.ts
+++ b/chat/src/lib/calls/call-volume-mixer.ts
@@ -61,7 +61,7 @@ export function buildCallVolumeMixerRows(
   for (const [participantKey, fallbackIdentity] of remoteParticipants) {
     const voiceIdentity = liveAudioIdentities.get(callVolumeMixerKey(participantKey, "microphone"))
       ?? fallbackIdentity;
-    const voiceKey = callVolumeMixerKey(voiceIdentity, "microphone");
+    const voiceKey = callVolumeMixerKey(participantKey, "microphone");
     const voiceLevel = input.levels[voiceKey] ?? 1;
     const voiceLabel = displayNameForIdentity(voiceIdentity);
     const voiceDisabled = !liveAudioSources.has(callVolumeMixerKey(participantKey, "microphone"));
@@ -81,7 +81,7 @@ export function buildCallVolumeMixerRows(
     const screenSourceKey = callVolumeMixerKey(participantKey, "screen_share_audio");
     if (!liveAudioSources.has(screenSourceKey)) continue;
     const screenIdentity = liveAudioIdentities.get(screenSourceKey) ?? fallbackIdentity;
-    const screenKey = callVolumeMixerKey(screenIdentity, "screen_share_audio");
+    const screenKey = screenSourceKey;
     const screenLevel = input.levels[screenKey] ?? 1;
     const screenLabel = `${voiceLabel}'s screen`;
     rows.push({

--- a/chat/src/lib/calls/call-volume-mixer.ts
+++ b/chat/src/lib/calls/call-volume-mixer.ts
@@ -1,0 +1,111 @@
+import type { RemoteMediaTrack } from "./engine";
+
+export type CallVolumeMixerSource = "microphone" | "screen_share_audio";
+
+export type CallVolumeLevelStore = Record<string, number>;
+
+export type CallVolumeMixerRow = {
+  key: string;
+  participantIdentity: string;
+  source: CallVolumeMixerSource;
+  label: string;
+  level: number;
+  disabled: boolean;
+  hint: string | null;
+  muted: boolean;
+  ariaLabel: string;
+  ariaValueText: string;
+};
+
+export type BuildCallVolumeMixerRowsInput = {
+  remoteParticipantIdentities: readonly string[];
+  remoteTracks: readonly RemoteMediaTrack[];
+  localIdentity: string | null;
+  levels: CallVolumeLevelStore;
+};
+
+export function callVolumeMixerKey(
+  participantIdentity: string,
+  source: CallVolumeMixerSource,
+): string {
+  return `${participantIdentity}:${source}`;
+}
+
+export function buildCallVolumeMixerRows(
+  input: BuildCallVolumeMixerRowsInput,
+): CallVolumeMixerRow[] {
+  const localIdentity = input.localIdentity?.toLowerCase() ?? null;
+  const remoteIdentities = new Set<string>();
+  const liveAudioSources = new Set<string>();
+
+  for (const identity of input.remoteParticipantIdentities) {
+    if (isSelfIdentity(identity, localIdentity)) continue;
+    remoteIdentities.add(identity);
+  }
+
+  for (const track of input.remoteTracks) {
+    if (isSelfIdentity(track.participantIdentity, localIdentity)) continue;
+    if (!isMixerAudioSource(track.source)) continue;
+    remoteIdentities.add(track.participantIdentity);
+    liveAudioSources.add(callVolumeMixerKey(track.participantIdentity, track.source));
+  }
+
+  const rows: CallVolumeMixerRow[] = [];
+  for (const participantIdentity of remoteIdentities) {
+    const voiceKey = callVolumeMixerKey(participantIdentity, "microphone");
+    const voiceLevel = input.levels[voiceKey] ?? 1;
+    const voiceLabel = displayNameForIdentity(participantIdentity);
+    const voiceDisabled = !liveAudioSources.has(voiceKey);
+    rows.push({
+      key: voiceKey,
+      participantIdentity,
+      source: "microphone",
+      label: voiceLabel,
+      level: voiceLevel,
+      disabled: voiceDisabled,
+      hint: voiceDisabled ? "mic off" : null,
+      muted: !voiceDisabled && voiceLevel === 0,
+      ariaLabel: `Volume for ${voiceLabel}`,
+      ariaValueText: `${Math.round(voiceLevel * 100)}%`,
+    });
+
+    const screenKey = callVolumeMixerKey(participantIdentity, "screen_share_audio");
+    if (!liveAudioSources.has(screenKey)) continue;
+    const screenLevel = input.levels[screenKey] ?? 1;
+    const screenLabel = `${voiceLabel}'s screen`;
+    rows.push({
+      key: screenKey,
+      participantIdentity,
+      source: "screen_share_audio",
+      label: screenLabel,
+      level: screenLevel,
+      disabled: false,
+      hint: null,
+      muted: screenLevel === 0,
+      ariaLabel: `Volume for ${screenLabel}`,
+      ariaValueText: `${Math.round(screenLevel * 100)}%`,
+    });
+  }
+
+  return rows;
+}
+
+export function resetCallVolumeMixerLevels(
+  levels: CallVolumeLevelStore,
+): CallVolumeLevelStore {
+  return Object.fromEntries(Object.keys(levels).map((key) => [key, 1]));
+}
+
+function displayNameForIdentity(identity: string): string {
+  const at = identity.indexOf("@");
+  if (at <= 0) return identity;
+  return identity.slice(0, at);
+}
+
+function isSelfIdentity(identity: string, localIdentity: string | null): boolean {
+  return localIdentity !== null && identity.toLowerCase() === localIdentity;
+}
+
+function isMixerAudioSource(source: string): source is CallVolumeMixerSource {
+  return source === "microphone" || source === "screen_share_audio";
+}

--- a/chat/src/lib/calls/call-volume-mixer.ts
+++ b/chat/src/lib/calls/call-volume-mixer.ts
@@ -1,6 +1,7 @@
 import type { RemoteMediaTrack } from "./engine";
+import { fullJidIdentityKey } from "@/lib/xmpp/jid";
 
-export type CallVolumeMixerSource = "microphone" | "screen_share_audio";
+type CallVolumeMixerSource = "microphone" | "screen_share_audio";
 
 export type CallVolumeLevelStore = Record<string, number>;
 
@@ -24,7 +25,7 @@ export type BuildCallVolumeMixerRowsInput = {
   levels: CallVolumeLevelStore;
 };
 
-export function callVolumeMixerKey(
+function callVolumeMixerKey(
   participantIdentity: string,
   source: CallVolumeMixerSource,
 ): string {
@@ -34,31 +35,39 @@ export function callVolumeMixerKey(
 export function buildCallVolumeMixerRows(
   input: BuildCallVolumeMixerRowsInput,
 ): CallVolumeMixerRow[] {
-  const localIdentity = input.localIdentity?.toLowerCase() ?? null;
-  const remoteIdentities = new Set<string>();
+  const localIdentity = normalizedIdentityKey(input.localIdentity);
+  const remoteParticipants = new Map<string, string>();
+  const liveAudioIdentities = new Map<string, string>();
   const liveAudioSources = new Set<string>();
 
   for (const identity of input.remoteParticipantIdentities) {
-    if (isSelfIdentity(identity, localIdentity)) continue;
-    remoteIdentities.add(identity);
+    const participantKey = normalizedIdentityKey(identity);
+    if (!participantKey || participantKey === localIdentity) continue;
+    remoteParticipants.set(participantKey, identity);
   }
 
   for (const track of input.remoteTracks) {
-    if (isSelfIdentity(track.participantIdentity, localIdentity)) continue;
+    const participantKey = normalizedIdentityKey(track.participantIdentity);
+    if (!participantKey || participantKey === localIdentity) continue;
     if (!isMixerAudioSource(track.source)) continue;
-    remoteIdentities.add(track.participantIdentity);
-    liveAudioSources.add(callVolumeMixerKey(track.participantIdentity, track.source));
+    if (!remoteParticipants.has(participantKey)) {
+      remoteParticipants.set(participantKey, track.participantIdentity);
+    }
+    liveAudioIdentities.set(callVolumeMixerKey(participantKey, track.source), track.participantIdentity);
+    liveAudioSources.add(callVolumeMixerKey(participantKey, track.source));
   }
 
   const rows: CallVolumeMixerRow[] = [];
-  for (const participantIdentity of remoteIdentities) {
-    const voiceKey = callVolumeMixerKey(participantIdentity, "microphone");
+  for (const [participantKey, fallbackIdentity] of remoteParticipants) {
+    const voiceIdentity = liveAudioIdentities.get(callVolumeMixerKey(participantKey, "microphone"))
+      ?? fallbackIdentity;
+    const voiceKey = callVolumeMixerKey(voiceIdentity, "microphone");
     const voiceLevel = input.levels[voiceKey] ?? 1;
-    const voiceLabel = displayNameForIdentity(participantIdentity);
-    const voiceDisabled = !liveAudioSources.has(voiceKey);
+    const voiceLabel = displayNameForIdentity(voiceIdentity);
+    const voiceDisabled = !liveAudioSources.has(callVolumeMixerKey(participantKey, "microphone"));
     rows.push({
       key: voiceKey,
-      participantIdentity,
+      participantIdentity: voiceIdentity,
       source: "microphone",
       label: voiceLabel,
       level: voiceLevel,
@@ -69,13 +78,15 @@ export function buildCallVolumeMixerRows(
       ariaValueText: `${Math.round(voiceLevel * 100)}%`,
     });
 
-    const screenKey = callVolumeMixerKey(participantIdentity, "screen_share_audio");
-    if (!liveAudioSources.has(screenKey)) continue;
+    const screenSourceKey = callVolumeMixerKey(participantKey, "screen_share_audio");
+    if (!liveAudioSources.has(screenSourceKey)) continue;
+    const screenIdentity = liveAudioIdentities.get(screenSourceKey) ?? fallbackIdentity;
+    const screenKey = callVolumeMixerKey(screenIdentity, "screen_share_audio");
     const screenLevel = input.levels[screenKey] ?? 1;
     const screenLabel = `${voiceLabel}'s screen`;
     rows.push({
       key: screenKey,
-      participantIdentity,
+      participantIdentity: screenIdentity,
       source: "screen_share_audio",
       label: screenLabel,
       level: screenLevel,
@@ -102,8 +113,8 @@ function displayNameForIdentity(identity: string): string {
   return identity.slice(0, at);
 }
 
-function isSelfIdentity(identity: string, localIdentity: string | null): boolean {
-  return localIdentity !== null && identity.toLowerCase() === localIdentity;
+function normalizedIdentityKey(identity: string | null | undefined): string {
+  return fullJidIdentityKey(identity);
 }
 
 function isMixerAudioSource(source: string): source is CallVolumeMixerSource {

--- a/chat/tests/call-volume-mixer.test.ts
+++ b/chat/tests/call-volume-mixer.test.ts
@@ -105,8 +105,8 @@ describe("call volume mixer projection", () => {
       ],
       localIdentity: "me@waddle.test/browser",
       levels: {
-        "Bob@Waddle.Test/Desktop:microphone": 0.25,
-        "Bob@Waddle.Test/Desktop:screen_share_audio": 0.5,
+        "bob@waddle.test/Desktop:microphone": 0.25,
+        "bob@waddle.test/Desktop:screen_share_audio": 0.5,
       },
     });
 
@@ -119,7 +119,7 @@ describe("call volume mixer projection", () => {
       disabled: row.disabled,
     }))).toEqual([
       {
-        key: "Bob@Waddle.Test/Desktop:microphone",
+        key: "bob@waddle.test/Desktop:microphone",
         participantIdentity: "Bob@Waddle.Test/Desktop",
         label: "Bob",
         source: "microphone",
@@ -127,12 +127,39 @@ describe("call volume mixer projection", () => {
         disabled: false,
       },
       {
-        key: "Bob@Waddle.Test/Desktop:screen_share_audio",
+        key: "bob@waddle.test/Desktop:screen_share_audio",
         participantIdentity: "Bob@Waddle.Test/Desktop",
         label: "Bob's screen",
         source: "screen_share_audio",
         level: 0.5,
         disabled: false,
+      },
+    ]);
+  });
+
+  test("keeps remembered mic level visible while a differently-cased LiveKit identity is muted", () => {
+    const rows = buildCallVolumeMixerRows({
+      remoteParticipantIdentities: ["bob@waddle.test/Desktop"],
+      remoteTracks: [],
+      localIdentity: "me@waddle.test/browser",
+      levels: {
+        "bob@waddle.test/Desktop:microphone": 0.25,
+      },
+    });
+
+    expect(rows.map((row) => ({
+      key: row.key,
+      level: row.level,
+      disabled: row.disabled,
+      hint: row.hint,
+      ariaValueText: row.ariaValueText,
+    }))).toEqual([
+      {
+        key: "bob@waddle.test/Desktop:microphone",
+        level: 0.25,
+        disabled: true,
+        hint: "mic off",
+        ariaValueText: "25%",
       },
     ]);
   });
@@ -184,6 +211,20 @@ describe("call volume mixer panel", () => {
     expect(html).toContain('aria-label="Muted"');
     expect(html).toContain('class="call-volume-mixer__tick"');
     expect(html).toContain("Reset all");
+  });
+});
+
+describe("expanded call mixer wiring", () => {
+  test("clears remembered levels on call changes and resets absent engine targets", () => {
+    const source = readFileSync(
+      new URL("../src/components/calls/CallExpandedSurface.vue", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).toContain("const activeCallSid = computed");
+    expect(source).toContain("watch(activeCallSid");
+    expect(source).toContain("participantAudioTargets.value = {}");
+    expect(source).toContain("for (const target of Object.values(participantAudioTargets.value))");
   });
 });
 

--- a/chat/tests/call-volume-mixer.test.ts
+++ b/chat/tests/call-volume-mixer.test.ts
@@ -1,4 +1,13 @@
 import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { createRequire } from "node:module";
+import { createSSRApp, h } from "vue";
+import { renderToString } from "vue/server-renderer";
+import { parse, compileScript } from "vue/compiler-sfc";
+import ts from "typescript";
 import {
   buildCallVolumeMixerRows,
   resetCallVolumeMixerLevels,
@@ -6,6 +15,7 @@ import {
 } from "../src/lib/calls/call-volume-mixer";
 
 const fakeTrack = {} as never;
+const require = createRequire(import.meta.url);
 
 describe("call volume mixer projection", () => {
   test("groups each remote participant's voice before screen-share audio and excludes self", () => {
@@ -85,6 +95,47 @@ describe("call volume mixer projection", () => {
       },
     ]);
   });
+
+  test("dedupes normalized participant snapshots against differently-cased LiveKit track identities", () => {
+    const rows = buildCallVolumeMixerRows({
+      remoteParticipantIdentities: ["bob@waddle.test/Desktop"],
+      remoteTracks: [
+        remoteAudio("bob-mic", "Bob@Waddle.Test/Desktop", "microphone"),
+        remoteAudio("bob-screen", "Bob@Waddle.Test/Desktop", "screen_share_audio"),
+      ],
+      localIdentity: "me@waddle.test/browser",
+      levels: {
+        "Bob@Waddle.Test/Desktop:microphone": 0.25,
+        "Bob@Waddle.Test/Desktop:screen_share_audio": 0.5,
+      },
+    });
+
+    expect(rows.map((row) => ({
+      key: row.key,
+      participantIdentity: row.participantIdentity,
+      label: row.label,
+      source: row.source,
+      level: row.level,
+      disabled: row.disabled,
+    }))).toEqual([
+      {
+        key: "Bob@Waddle.Test/Desktop:microphone",
+        participantIdentity: "Bob@Waddle.Test/Desktop",
+        label: "Bob",
+        source: "microphone",
+        level: 0.25,
+        disabled: false,
+      },
+      {
+        key: "Bob@Waddle.Test/Desktop:screen_share_audio",
+        participantIdentity: "Bob@Waddle.Test/Desktop",
+        label: "Bob's screen",
+        source: "screen_share_audio",
+        level: 0.5,
+        disabled: false,
+      },
+    ]);
+  });
 });
 
 describe("call volume mixer reducer", () => {
@@ -103,6 +154,39 @@ describe("call volume mixer reducer", () => {
   });
 });
 
+describe("call volume mixer panel", () => {
+  test("renders accessible row sliders, muted state, 100% ticks, and reset-all footer", async () => {
+    const rows = buildCallVolumeMixerRows({
+      remoteParticipantIdentities: ["alice@waddle.test/web", "bob@waddle.test/desktop"],
+      remoteTracks: [
+        remoteAudio("alice-mic", "alice@waddle.test/web", "microphone"),
+        remoteAudio("alice-screen", "alice@waddle.test/web", "screen_share_audio"),
+        remoteAudio("bob-screen", "bob@waddle.test/desktop", "screen_share_audio"),
+      ],
+      localIdentity: "me@waddle.test/browser",
+      levels: {
+        "alice@waddle.test/web:screen_share_audio": 0,
+        "bob@waddle.test/desktop:microphone": 0.35,
+      },
+    });
+
+    const html = await renderCallVolumeMixerPanel({ rows });
+
+    expect(html).toContain("Who you hear");
+    expect(html).toContain("alice");
+    expect(html).toContain("alice&#39;s screen");
+    expect(html).toContain("bob&#39;s screen");
+    expect(html).toContain("mic off");
+    expect(html).toContain('aria-label="Volume for alice"');
+    expect(html).toContain('aria-valuetext="100%"');
+    expect(html).toContain('aria-label="Volume for alice&#39;s screen"');
+    expect(html).toContain('aria-valuetext="0%"');
+    expect(html).toContain('aria-label="Muted"');
+    expect(html).toContain('class="call-volume-mixer__tick"');
+    expect(html).toContain("Reset all");
+  });
+});
+
 function remoteAudio(
   publicationSid: string,
   participantIdentity: string,
@@ -115,4 +199,66 @@ function remoteAudio(
     source,
     track: fakeTrack,
   };
+}
+
+async function renderCallVolumeMixerPanel(props: Record<string, unknown>): Promise<string> {
+  const component = await loadVueComponent("../src/components/calls/CallVolumeMixerPanel.vue");
+  return renderToString(createSSRApp({ render: () => h(component, props) }));
+}
+
+async function loadVueComponent(path: string) {
+  const filename = new URL(path, import.meta.url);
+  const source = readFileSync(filename, "utf8");
+  const { descriptor } = parse(source, { filename: filename.pathname });
+  const script = compileScript(descriptor, {
+    id: filename.pathname,
+    inlineTemplate: true,
+  });
+
+  const tempDir = mkdtempSync(join(tmpdir(), "waddle-call-volume-mixer-"));
+  try {
+    const compiled = [
+      rewriteImports(script.content.replace("export default", "const __sfc__ ="), filename),
+      "export default __sfc__;",
+    ].join("\n");
+    const js = ts.transpileModule(compiled, {
+      compilerOptions: {
+        module: ts.ModuleKind.ESNext,
+        target: ts.ScriptTarget.ES2022,
+        verbatimModuleSyntax: false,
+      },
+    }).outputText;
+    const modulePath = join(tempDir, "Component.mjs");
+    writeFileSync(modulePath, js);
+    const component = await import(pathToFileURL(modulePath).href);
+    return component.default;
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function rewriteImports(code: string, importer: URL): string {
+  return code.replace(/from\s+["']([^"']+)["']/g, (_match, specifier: string) =>
+    `from ${JSON.stringify(resolveModuleSpecifier(specifier, importer))}`);
+}
+
+function resolveModuleSpecifier(specifier: string, importer: URL): string {
+  if (specifier.startsWith("@/")) {
+    return moduleUrlForPath(resolveSourcePath(new URL(`../src/${specifier.slice(2)}`, import.meta.url).pathname));
+  }
+  if (specifier.startsWith(".")) {
+    return moduleUrlForPath(new URL(specifier, importer).pathname);
+  }
+  return moduleUrlForPath(require.resolve(specifier));
+}
+
+function resolveSourcePath(path: string): string {
+  if (existsSync(path)) return path;
+  if (existsSync(`${path}.ts`)) return `${path}.ts`;
+  if (existsSync(`${path}.vue`)) return `${path}.vue`;
+  return path;
+}
+
+function moduleUrlForPath(path: string): string {
+  return pathToFileURL(path).href;
 }

--- a/chat/tests/call-volume-mixer.test.ts
+++ b/chat/tests/call-volume-mixer.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildCallVolumeMixerRows,
+  resetCallVolumeMixerLevels,
+  type CallVolumeLevelStore,
+} from "../src/lib/calls/call-volume-mixer";
+
+const fakeTrack = {} as never;
+
+describe("call volume mixer projection", () => {
+  test("groups each remote participant's voice before screen-share audio and excludes self", () => {
+    const rows = buildCallVolumeMixerRows({
+      remoteParticipantIdentities: [
+        "carol@waddle.test/tablet",
+        "alice@waddle.test/web",
+        "bob@waddle.test/desktop",
+      ],
+      remoteTracks: [
+        remoteAudio("bob-mic", "bob@waddle.test/desktop", "microphone"),
+        remoteAudio("bob-screen", "bob@waddle.test/desktop", "screen_share_audio"),
+        remoteAudio("alice-screen", "alice@waddle.test/web", "screen_share_audio"),
+        remoteAudio("self-mic", "me@waddle.test/browser", "microphone"),
+      ],
+      localIdentity: "me@waddle.test/browser",
+      levels: {
+        "bob@waddle.test/desktop:microphone": 0.4,
+        "bob@waddle.test/desktop:screen_share_audio": 0.7,
+        "alice@waddle.test/web:screen_share_audio": 0,
+      },
+    });
+
+    expect(rows.map((row) => ({
+      key: row.key,
+      label: row.label,
+      source: row.source,
+      level: row.level,
+      disabled: row.disabled,
+      hint: row.hint,
+      muted: row.muted,
+    }))).toEqual([
+      {
+        key: "carol@waddle.test/tablet:microphone",
+        label: "carol",
+        source: "microphone",
+        level: 1,
+        disabled: true,
+        hint: "mic off",
+        muted: false,
+      },
+      {
+        key: "alice@waddle.test/web:microphone",
+        label: "alice",
+        source: "microphone",
+        level: 1,
+        disabled: true,
+        hint: "mic off",
+        muted: false,
+      },
+      {
+        key: "alice@waddle.test/web:screen_share_audio",
+        label: "alice's screen",
+        source: "screen_share_audio",
+        level: 0,
+        disabled: false,
+        hint: null,
+        muted: true,
+      },
+      {
+        key: "bob@waddle.test/desktop:microphone",
+        label: "bob",
+        source: "microphone",
+        level: 0.4,
+        disabled: false,
+        hint: null,
+        muted: false,
+      },
+      {
+        key: "bob@waddle.test/desktop:screen_share_audio",
+        label: "bob's screen",
+        source: "screen_share_audio",
+        level: 0.7,
+        disabled: false,
+        hint: null,
+        muted: false,
+      },
+    ]);
+  });
+});
+
+describe("call volume mixer reducer", () => {
+  test("reset all returns every stored participant audio entry to full volume", () => {
+    const levels: CallVolumeLevelStore = {
+      "alice@waddle.test/web:microphone": 0.2,
+      "alice@waddle.test/web:screen_share_audio": 0,
+      "bob@waddle.test/desktop:microphone": 0.8,
+    };
+
+    expect(resetCallVolumeMixerLevels(levels)).toEqual({
+      "alice@waddle.test/web:microphone": 1,
+      "alice@waddle.test/web:screen_share_audio": 1,
+      "bob@waddle.test/desktop:microphone": 1,
+    });
+  });
+});
+
+function remoteAudio(
+  publicationSid: string,
+  participantIdentity: string,
+  source: "microphone" | "screen_share_audio",
+) {
+  return {
+    participantIdentity,
+    publicationSid,
+    kind: "audio" as const,
+    source,
+    track: fakeTrack,
+  };
+}


### PR DESCRIPTION
## Summary

Implements #900.

- Adds a pure call volume mixer row projection for the full who-you-hear surface.
- Groups each remote participant as voice first, then screen-share audio when present, with independent source-specific levels.
- Includes LiveKit participants independently of the grid tile cap and excludes the local participant.
- Keeps disabled mic rows with a mic-off hint when a participant is present without live microphone audio.
- Adds the expanded-call mixer panel with footer Reset all, muted indicator, 100% slider tick, accessible labels, and percentage value text.
- Canonicalizes participant grouping across normalized MUC snapshots and differently-cased LiveKit track identities while preserving live identities for CallEngine volume updates.
- Addresses review feedback: stable canonical UI keys keep disabled rows at remembered levels, Reset All resets remembered engine targets for absent participants, and active call SID changes clear local mixer state.

## XEP review

Local chat UI/model change only. No XMPP wire shape, namespace, or XEP advertisement changed.

## Verification

- bun test ./tests/call-volume-mixer.test.ts
- bun test
- bun run lint
- bunx astro check
- Draft PR body verified with gh pr view after creation.
- Adversarial behavior/model review found one identity-canonicalization issue; fixed with regression coverage.
- Adversarial UI/accessibility review found one mobile flex min-height issue; fixed.
- PR review comments from Copilot, Greptile, and Codex were addressed in commit 604b2d72.

## Not tested

- Manual in-browser call-session interaction. The dev server previously started at http://localhost:4321/, but the Browser plugin Playwright package was unavailable in this environment, so no automated screenshot flow was run.
