### PR TITLE
fix(chat): resume blocked call audio

### DIFF
--- a/chat/src/components/calls/CallAudioPlaybackPrompt.vue
+++ b/chat/src/components/calls/CallAudioPlaybackPrompt.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { useStore } from "@nanostores/vue";
+import {
+  $callAudioPlaybackBlocked,
+  resumeCallAudioPlayback,
+} from "@/lib/calls/call-audio-playback";
+import { useCallEngine } from "@/lib/calls/use-call-engine";
+
+const blocked = useStore($callAudioPlaybackBlocked);
+const { engine } = useCallEngine();
+const resumeFailed = ref(false);
+
+async function enableAudio(): Promise<void> {
+  resumeFailed.value = false;
+  await resumeCallAudioPlayback(engine, () => {
+    resumeFailed.value = true;
+  });
+}
+</script>
+
+<template>
+  <div
+    v-if="blocked"
+    class="call-audio-playback-prompt"
+    role="alert"
+  >
+    <span class="call-audio-playback-prompt__message">
+      Audio is paused by your browser.
+      <span v-if="resumeFailed">Try again from this button.</span>
+    </span>
+    <button
+      class="call-audio-playback-prompt__button"
+      type="button"
+      @click="enableAudio"
+    >
+      Tap to enable audio
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.call-audio-playback-prompt {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  border-bottom: 1px solid color-mix(in oklab, var(--accent) 35%, var(--border));
+  background: color-mix(in oklab, var(--accent) 12%, var(--background));
+  padding: 0.5rem 0.75rem;
+  color: var(--foreground);
+}
+
+.call-audio-playback-prompt__message {
+  min-width: 0;
+}
+
+.call-audio-playback-prompt__button {
+  flex: 0 0 auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--background);
+  padding: 0.35rem 0.65rem;
+  font: inherit;
+  color: var(--foreground);
+}
+
+.call-audio-playback-prompt__button:hover {
+  background: var(--muted);
+}
+</style>

--- a/chat/src/components/calls/CallAudioPlaybackPrompt.vue
+++ b/chat/src/components/calls/CallAudioPlaybackPrompt.vue
@@ -10,12 +10,19 @@ import { useCallEngine } from "@/lib/calls/use-call-engine";
 const blocked = useStore($callAudioPlaybackBlocked);
 const { engine } = useCallEngine();
 const resumeFailed = ref(false);
+const resuming = ref(false);
 
 async function enableAudio(): Promise<void> {
+  if (resuming.value) return;
   resumeFailed.value = false;
-  await resumeCallAudioPlayback(engine, () => {
-    resumeFailed.value = true;
-  });
+  resuming.value = true;
+  try {
+    await resumeCallAudioPlayback(engine, () => {
+      resumeFailed.value = true;
+    });
+  } finally {
+    resuming.value = false;
+  }
 }
 </script>
 
@@ -32,9 +39,10 @@ async function enableAudio(): Promise<void> {
     <button
       class="call-audio-playback-prompt__button"
       type="button"
+      :disabled="resuming"
       @click="enableAudio"
     >
-      Tap to enable audio
+      {{ resuming ? "Enabling audio…" : "Tap to enable audio" }}
     </button>
   </div>
 </template>
@@ -68,5 +76,10 @@ async function enableAudio(): Promise<void> {
 
 .call-audio-playback-prompt__button:hover {
   background: var(--muted);
+}
+
+.call-audio-playback-prompt__button:disabled {
+  cursor: wait;
+  opacity: 0.72;
 }
 </style>

--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -37,6 +37,7 @@ import CallSettingsDialog from "./CallSettingsDialog.vue";
 import CallMediaNotice from "./CallMediaNotice.vue";
 import CallSelfShareNotice from "./CallSelfShareNotice.vue";
 import CallVolumeMixerPanel from "./CallVolumeMixerPanel.vue";
+import CallAudioPlaybackPrompt from "./CallAudioPlaybackPrompt.vue";
 
 /**
  * "Expanded" call surface — fills the chat content pane while the
@@ -268,6 +269,7 @@ onBeforeUnmount(() => {
       {{ lastError }}
     </div>
     <CallMediaNotice />
+    <CallAudioPlaybackPrompt />
     <CallSelfShareNotice
       v-if="selfSharePresentation"
       :presentation="selfSharePresentation"

--- a/chat/src/components/calls/CallSplitContainer.vue
+++ b/chat/src/components/calls/CallSplitContainer.vue
@@ -30,6 +30,7 @@ import CallControls from "./CallControls.vue";
 import CallSettingsDialog from "./CallSettingsDialog.vue";
 import CallMediaNotice from "./CallMediaNotice.vue";
 import CallSelfShareNotice from "./CallSelfShareNotice.vue";
+import CallAudioPlaybackPrompt from "./CallAudioPlaybackPrompt.vue";
 import SplitDragHandle from "./SplitDragHandle.vue";
 
 /**
@@ -192,6 +193,7 @@ async function onHangup(): Promise<void> {
         {{ lastError }}
       </div>
       <CallMediaNotice />
+      <CallAudioPlaybackPrompt />
       <CallSelfShareNotice
         v-if="selfSharePresentation"
         :presentation="selfSharePresentation"

--- a/chat/src/lib/calls/call-audio-playback.ts
+++ b/chat/src/lib/calls/call-audio-playback.ts
@@ -1,0 +1,22 @@
+import { atom } from "nanostores";
+
+export const $callAudioPlaybackBlocked = atom(false);
+
+export type CallAudioResumeTarget = {
+  startAudio(): Promise<unknown>;
+};
+
+export function setCallAudioPlaybackBlocked(blocked: boolean): void {
+  $callAudioPlaybackBlocked.set(blocked);
+}
+
+export async function resumeCallAudioPlayback(
+  target: CallAudioResumeTarget,
+  onFailure: () => void,
+): Promise<void> {
+  try {
+    await target.startAudio();
+  } catch {
+    onFailure();
+  }
+}

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -108,6 +108,12 @@ export type CallEngineEvents = {
   connected: (snapshot: { localIdentity: string; remoteIdentities: string[] }) => void;
   disconnected: (reason?: string) => void;
   /**
+   * Fires when LiveKit reports whether remote audio can currently
+   * play. Browser autoplay policy can suspend Web Audio playback until
+   * a user gesture calls `startAudio()`.
+   */
+  audioPlaybackStatusChanged: (canPlaybackAudio: boolean) => void;
+  /**
    * Fires when a best-effort capture (mic / cam enable) fails —
    * typically a missing device (`NotFoundError`) or a denied
    * permission (`NotAllowedError`). NON-FATAL: the room stays
@@ -141,6 +147,7 @@ export class CallEngine {
     participantDisconnected: new Set(),
     connected: new Set(),
     disconnected: new Set(),
+    audioPlaybackStatusChanged: new Set(),
     mediaDevicesError: new Set(),
   };
 
@@ -170,6 +177,10 @@ export class CallEngine {
     return this.room?.localParticipant.isScreenShareEnabled ?? false;
   }
 
+  get canPlaybackAudio(): boolean {
+    return this.room?.canPlaybackAudio ?? true;
+  }
+
   async connect(join: LiveKitJoin, opts: { audio: boolean; video: boolean }): Promise<void> {
     if (this.room) throw new Error("CallEngine already connected");
     // Defensive pre-flight: confirm the JWT actually carries a usable
@@ -185,6 +196,7 @@ export class CallEngine {
     const room = new Room({
       adaptiveStream: true,
       dynacast: true,
+      webAudioMix: true,
       audioCaptureDefaults: {
         autoGainControl: true,
         echoCancellation: true,
@@ -202,6 +214,7 @@ export class CallEngine {
     room.on(RoomEvent.ParticipantConnected, this.handleParticipantConnected);
     room.on(RoomEvent.ParticipantDisconnected, this.handleParticipantDisconnected);
     room.on(RoomEvent.Disconnected, this.handleDisconnected);
+    room.on(RoomEvent.AudioPlaybackStatusChanged, this.handleAudioPlaybackStatusChanged);
     try {
       await room.connect(join.url, join.token);
     } catch (err) {
@@ -297,6 +310,10 @@ export class CallEngine {
     await this.applySpeakerDevice(deviceId);
   }
 
+  async startAudio(): Promise<void> {
+    await this.room?.startAudio();
+  }
+
   setParticipantAudioVolume(
     identity: ParticipantAudioVolumeIdentity & { volume: number },
   ): void {
@@ -338,6 +355,7 @@ export class CallEngine {
     room.off(RoomEvent.ParticipantConnected, this.handleParticipantConnected);
     room.off(RoomEvent.ParticipantDisconnected, this.handleParticipantDisconnected);
     room.off(RoomEvent.Disconnected, this.handleDisconnected);
+    room.off(RoomEvent.AudioPlaybackStatusChanged, this.handleAudioPlaybackStatusChanged);
     await room.disconnect();
   }
 
@@ -446,6 +464,10 @@ export class CallEngine {
   private handleDisconnected = (reason?: unknown) => {
     this.clearParticipantAudioVolumes();
     this.emit("disconnected", typeof reason === "string" ? reason : undefined);
+  };
+
+  private handleAudioPlaybackStatusChanged = (canPlaybackAudio: boolean) => {
+    this.emit("audioPlaybackStatusChanged", canPlaybackAudio);
   };
 
   private clearParticipantAudioVolumes(): void {

--- a/chat/src/lib/calls/use-call-engine.ts
+++ b/chat/src/lib/calls/use-call-engine.ts
@@ -10,6 +10,7 @@ import {
 } from "./muc-call-live-participants";
 import { clearAllMediaIssues, recordMediaIssue } from "./call-media-issues";
 import { syncScreenShareEnabled } from "./screen-share-state";
+import { setCallAudioPlaybackBlocked } from "./call-audio-playback";
 
 /**
  * Process-wide singleton: only one call engine should ever exist
@@ -72,6 +73,9 @@ export function useCallEngine(): {
       // notice is the single channel, avoiding a double-surfaced error.
       recordMediaIssue(source === "audio" ? "mic" : "cam", error);
     });
+    singletonEngine.on("audioPlaybackStatusChanged", (canPlaybackAudio) => {
+      setCallAudioPlaybackBlocked(!canPlaybackAudio);
+    });
     singletonEngine.on("participantConnected", (identity) => {
       const roomJid = activeMucRoomJid();
       if (!roomJid) return;
@@ -89,6 +93,7 @@ export function useCallEngine(): {
       // Drop any "joined without mic/camera" notice — it belongs to the
       // call that just ended, not the next one.
       clearAllMediaIssues();
+      setCallAudioPlaybackBlocked(false);
       // The active call's room — if any — is no longer in our LK
       // view. Drop the LK snapshot so the room's UI reverts to the
       // Muji-derived (server-bridged) view, which the LK webhook

--- a/chat/tests/call-controls.test.ts
+++ b/chat/tests/call-controls.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join as joinPath } from "node:path";
+import { pathToFileURL } from "node:url";
+import { createRequire } from "node:module";
+import { createSSRApp, h } from "vue";
+import { renderToString } from "vue/server-renderer";
+import { parse, compileScript } from "vue/compiler-sfc";
+import ts from "typescript";
 import { $callState, clearCallState } from "../src/lib/calls/call-store";
 import {
   $callCamEnabled,
@@ -19,6 +27,10 @@ import {
   clearAllMediaIssues,
   recordMediaIssue,
 } from "../src/lib/calls/call-media-issues";
+import {
+  $callAudioPlaybackBlocked,
+  resumeCallAudioPlayback,
+} from "../src/lib/calls/call-audio-playback";
 import { useCallEngine } from "../src/lib/calls/use-call-engine";
 import {
   $dmCallActivities,
@@ -31,6 +43,8 @@ import {
 import { connectionStore } from "../src/lib/connection-store";
 import type { LiveKitJoin } from "../src/lib/calls/types";
 import { Track } from "livekit-client";
+
+const require = createRequire(import.meta.url);
 
 const join: LiveKitJoin = {
   url: "wss://livekit.test",
@@ -73,6 +87,7 @@ afterEach(() => {
   $mucCallLiveParticipants.set({});
   connectionStore.client = null;
   clearAllMediaIssues();
+  $callAudioPlaybackBlocked.set(false);
   $callScreenShareEnabled.set(false);
   $callScreenShareSupported.set(false);
   // The engine is a process-wide singleton; drop any injected room
@@ -433,4 +448,123 @@ describe("device-less call controls", () => {
     expect($callScreenShareEnabled.get()).toBe(false);
     expect($callMediaIssues.get().screen).toBeNull();
   });
+
+  test("LiveKit audio playback status drives the tap-to-enable prompt state", () => {
+    const { engine } = useCallEngine();
+    (
+      engine as unknown as {
+        handleAudioPlaybackStatusChanged: (canPlaybackAudio: boolean) => void;
+      }
+    ).handleAudioPlaybackStatusChanged(false);
+    expect($callAudioPlaybackBlocked.get()).toBe(true);
+
+    (
+      engine as unknown as {
+        handleAudioPlaybackStatusChanged: (canPlaybackAudio: boolean) => void;
+      }
+    ).handleAudioPlaybackStatusChanged(true);
+    expect($callAudioPlaybackBlocked.get()).toBe(false);
+  });
+
+  test("call audio playback prompt renders only while playback is blocked", async () => {
+    const component = await loadVueComponent("../src/components/calls/CallAudioPlaybackPrompt.vue");
+
+    $callAudioPlaybackBlocked.set(false);
+    expect(await renderVueComponent(component)).not.toContain("Tap to enable audio");
+
+    $callAudioPlaybackBlocked.set(true);
+    const html = await renderVueComponent(component);
+    expect(html).toContain("Audio is paused by your browser.");
+    expect(html).toContain("Tap to enable audio");
+  });
+
+  test("call audio resume helper reports failed browser resume without throwing", async () => {
+    const failures: string[] = [];
+    const target = {
+      async startAudio() {
+        throw new Error("blocked");
+      },
+    };
+
+    await resumeCallAudioPlayback(target, () => {
+      failures.push("failed");
+    });
+
+    expect(failures).toEqual(["failed"]);
+  });
+
+  test("call surfaces mount the tap-to-enable audio affordance", () => {
+    const splitSource = readFileSync(
+      new URL("../src/components/calls/CallSplitContainer.vue", import.meta.url),
+      "utf8",
+    );
+    const expandedSource = readFileSync(
+      new URL("../src/components/calls/CallExpandedSurface.vue", import.meta.url),
+      "utf8",
+    );
+
+    expect(splitSource).toContain("<CallAudioPlaybackPrompt />");
+    expect(expandedSource).toContain("<CallAudioPlaybackPrompt />");
+  });
 });
+
+async function renderVueComponent(component: unknown): Promise<string> {
+  return renderToString(createSSRApp({ render: () => h(component as never) }));
+}
+
+async function loadVueComponent(path: string) {
+  const filename = new URL(path, import.meta.url);
+  const source = readFileSync(filename, "utf8");
+  const { descriptor } = parse(source, { filename: filename.pathname });
+  const script = compileScript(descriptor, {
+    id: filename.pathname,
+    inlineTemplate: true,
+  });
+
+  const tempDir = mkdtempSync(joinPath(tmpdir(), "waddle-call-audio-playback-"));
+  try {
+    const compiled = [
+      rewriteImports(script.content.replace("export default", "const __sfc__ ="), filename),
+      "export default __sfc__;",
+    ].join("\n");
+    const js = ts.transpileModule(compiled, {
+      compilerOptions: {
+        module: ts.ModuleKind.ESNext,
+        target: ts.ScriptTarget.ES2022,
+        verbatimModuleSyntax: false,
+      },
+    }).outputText;
+    const modulePath = joinPath(tempDir, "Component.mjs");
+    writeFileSync(modulePath, js);
+    const component = await import(pathToFileURL(modulePath).href);
+    return component.default;
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function rewriteImports(code: string, importer: URL): string {
+  return code.replace(/from\s+["']([^"']+)["']/g, (_match, specifier: string) =>
+    `from ${JSON.stringify(resolveModuleSpecifier(specifier, importer))}`);
+}
+
+function resolveModuleSpecifier(specifier: string, importer: URL): string {
+  if (specifier.startsWith("@/")) {
+    return moduleUrlForPath(resolveSourcePath(new URL(`../src/${specifier.slice(2)}`, import.meta.url).pathname));
+  }
+  if (specifier.startsWith(".")) {
+    return moduleUrlForPath(resolveSourcePath(new URL(specifier, importer).pathname));
+  }
+  return moduleUrlForPath(require.resolve(specifier));
+}
+
+function resolveSourcePath(path: string): string {
+  if (existsSync(path)) return path;
+  if (existsSync(`${path}.ts`)) return `${path}.ts`;
+  if (existsSync(`${path}.vue`)) return `${path}.vue`;
+  return path;
+}
+
+function moduleUrlForPath(path: string): string {
+  return pathToFileURL(path).href;
+}

--- a/chat/tests/call-controls.test.ts
+++ b/chat/tests/call-controls.test.ts
@@ -494,6 +494,10 @@ describe("device-less call controls", () => {
   });
 
   test("call surfaces mount the tap-to-enable audio affordance", () => {
+    const promptSource = readFileSync(
+      new URL("../src/components/calls/CallAudioPlaybackPrompt.vue", import.meta.url),
+      "utf8",
+    );
     const splitSource = readFileSync(
       new URL("../src/components/calls/CallSplitContainer.vue", import.meta.url),
       "utf8",
@@ -503,6 +507,7 @@ describe("device-less call controls", () => {
       "utf8",
     );
 
+    expect(promptSource).toContain(":disabled=\"resuming\"");
     expect(splitSource).toContain("<CallAudioPlaybackPrompt />");
     expect(expandedSource).toContain("<CallAudioPlaybackPrompt />");
   });
@@ -544,6 +549,10 @@ async function loadVueComponent(path: string) {
 }
 
 function rewriteImports(code: string, importer: URL): string {
+  // This SFC test helper only supports the static import shapes emitted by
+  // vue/compiler-sfc for these components today. If compiler output starts
+  // using dynamic/template-literal imports, prefer a shared component-test
+  // harness over broadening this regex.
   return code.replace(/from\s+["']([^"']+)["']/g, (_match, specifier: string) =>
     `from ${JSON.stringify(resolveModuleSpecifier(specifier, importer))}`);
 }

--- a/chat/tests/call-engine.test.ts
+++ b/chat/tests/call-engine.test.ts
@@ -118,6 +118,43 @@ describe("call-engine module", () => {
     expect(typeof engine.on("localTrackUnpublished", () => {})).toBe("function");
   });
 
+  test("audio playback status exposes blocked state and resume calls LiveKit startAudio", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    const statuses: boolean[] = [];
+    let startAudioCalls = 0;
+    engine.on("audioPlaybackStatusChanged", (canPlaybackAudio) => {
+      statuses.push(canPlaybackAudio);
+    });
+    const stub = {
+      get canPlaybackAudio() {
+        return statuses.at(-1) ?? true;
+      },
+      async startAudio() {
+        startAudioCalls += 1;
+      },
+    };
+    (engine as unknown as { room: typeof stub }).room = stub;
+
+    (
+      engine as unknown as {
+        handleAudioPlaybackStatusChanged: (canPlaybackAudio: boolean) => void;
+      }
+    ).handleAudioPlaybackStatusChanged(false);
+    expect(engine.canPlaybackAudio).toBe(false);
+
+    await engine.startAudio();
+    (
+      engine as unknown as {
+        handleAudioPlaybackStatusChanged: (canPlaybackAudio: boolean) => void;
+      }
+    ).handleAudioPlaybackStatusChanged(true);
+
+    expect(startAudioCalls).toBe(1);
+    expect(statuses).toEqual([false, true]);
+    expect(engine.canPlaybackAudio).toBe(true);
+  });
+
   test("RemoteMediaTrack discriminates audio vs video by `kind`", () => {
     // Pure type-level assertion: the field is a "audio" | "video"
     // literal union, so a switch covers both arms exhaustively.


### PR DESCRIPTION
## Summary

Implements issue #901: remote call audio now runs through LiveKit Web Audio mixing, and browser-blocked autoplay is surfaced as a visible call prompt that resumes audio from a user gesture.

## Changes

- Construct call rooms with `webAudioMix: true`.
- Forward LiveKit `AudioPlaybackStatusChanged` through `CallEngine`.
- Add `CallEngine.startAudio()` and `canPlaybackAudio` for the resume path.
- Add call audio playback prompt state and a `Tap to enable audio` affordance.
- Mount the prompt in both split and expanded call surfaces.
- Preserve the existing 0-100% participant volume flow through LiveKit track `setVolume`.
- Preserve speaker-output switching through the existing `switchActiveDevice("audiooutput", ...)` path; with Web Audio enabled, LiveKit routes this via `AudioContext.setSinkId` where supported and degrades where unsupported.

## XEP review

Reviewed XEP-0166, XEP-0272, and XEP-0353. This is local browser audio playback plumbing after the LiveKit room is joined; it does not alter XMPP/Jingle/Muji wire shapes or namespaces.

## Tests

- `bun test`
- `bun run lint`
- `bun run build`

`bun run build` reports the existing Astro hint in `src/lib/xmpp/discovery.ts:80` and the existing Vite chunk-size warning, with zero errors.

## Review notes

- Addressed adversarial UI review findings by allowing the prompt to wrap on narrow call surfaces and by handling failed resume attempts without an unhandled rejection.
- Addressed adversarial test review by replacing source-string prompt assertions with SSR prompt rendering and pure resume-helper coverage where the repo has no DOM mounting harness.

## Not covered

- Manual Chromium speaker-output device switching is intentionally left to the dedicated verification slice in #903.
