### PR TITLE
feat(chat): raise call volume ceiling to 200%

### DIFF
--- a/chat/src/components/calls/CallVolumeMixerPanel.vue
+++ b/chat/src/components/calls/CallVolumeMixerPanel.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ref } from "vue";
 import { Volume2, VolumeX } from "lucide-vue-next";
 import {
   callVolumePercentToGain,
@@ -14,10 +15,18 @@ const emit = defineEmits<{
   resetAll: [];
 }>();
 
+const lastEmittedLevels = ref<Record<string, number>>({});
+
 function onInput(row: CallVolumeMixerRow, event: Event): void {
   const target = event.target;
   if (!(target instanceof HTMLInputElement)) return;
-  emit("setVolume", row, callVolumePercentToGain(Number(target.value), row.level));
+  const currentGain = lastEmittedLevels.value[row.key] ?? row.level;
+  const nextGain = callVolumePercentToGain(Number(target.value), currentGain);
+  lastEmittedLevels.value = {
+    ...lastEmittedLevels.value,
+    [row.key]: nextGain,
+  };
+  emit("setVolume", row, nextGain);
 }
 </script>
 

--- a/chat/src/components/calls/CallVolumeMixerPanel.vue
+++ b/chat/src/components/calls/CallVolumeMixerPanel.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import { ref, watch } from "vue";
 import { Volume2, VolumeX } from "lucide-vue-next";
 import {
   callVolumePercentToGain,
   type CallVolumeMixerRow,
 } from "@/lib/calls/call-volume-mixer";
 
-defineProps<{
+const props = defineProps<{
   rows: readonly CallVolumeMixerRow[];
 }>();
 
@@ -16,6 +16,12 @@ const emit = defineEmits<{
 }>();
 
 const lastEmittedLevels = ref<Record<string, number>>({});
+
+function syncLastEmittedLevels(rows: readonly CallVolumeMixerRow[]): void {
+  lastEmittedLevels.value = Object.fromEntries(rows.map((row) => [row.key, row.level]));
+}
+
+watch(() => props.rows, syncLastEmittedLevels, { deep: true });
 
 function onInput(row: CallVolumeMixerRow, event: Event): void {
   const target = event.target;

--- a/chat/src/components/calls/CallVolumeMixerPanel.vue
+++ b/chat/src/components/calls/CallVolumeMixerPanel.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { Volume2, VolumeX } from "lucide-vue-next";
-import type { CallVolumeMixerRow } from "@/lib/calls/call-volume-mixer";
+import {
+  callVolumePercentToGain,
+  type CallVolumeMixerRow,
+} from "@/lib/calls/call-volume-mixer";
 
 defineProps<{
   rows: readonly CallVolumeMixerRow[];
@@ -14,7 +17,7 @@ const emit = defineEmits<{
 function onInput(row: CallVolumeMixerRow, event: Event): void {
   const target = event.target;
   if (!(target instanceof HTMLInputElement)) return;
-  emit("setVolume", row, Number(target.value) / 100);
+  emit("setVolume", row, callVolumePercentToGain(Number(target.value), row.level));
 }
 </script>
 
@@ -51,7 +54,7 @@ function onInput(row: CallVolumeMixerRow, event: Event): void {
               class="call-volume-mixer__slider"
               type="range"
               min="0"
-              max="100"
+              max="200"
               step="1"
               :value="Math.round(row.level * 100)"
               :disabled="row.disabled"
@@ -59,7 +62,7 @@ function onInput(row: CallVolumeMixerRow, event: Event): void {
               :aria-valuetext="row.ariaValueText"
               @input="onInput(row, $event)"
             >
-            <span class="call-volume-mixer__tick" aria-hidden="true" />
+            <span class="call-volume-mixer__tick" aria-hidden="true" style="left:50%;" />
           </div>
           <span class="call-volume-mixer__percent">{{ Math.round(row.level * 100) }}%</span>
         </div>
@@ -158,7 +161,6 @@ function onInput(row: CallVolumeMixerRow, event: Event): void {
 
 .call-volume-mixer__tick {
   position: absolute;
-  right: 0.3125rem;
   top: 50%;
   width: 1px;
   height: 0.875rem;

--- a/chat/src/components/calls/CallVolumeMixerPanel.vue
+++ b/chat/src/components/calls/CallVolumeMixerPanel.vue
@@ -28,6 +28,11 @@ function onInput(row: CallVolumeMixerRow, event: Event): void {
   };
   emit("setVolume", row, nextGain);
 }
+
+function onResetAll(): void {
+  lastEmittedLevels.value = {};
+  emit("resetAll");
+}
 </script>
 
 <template>
@@ -85,7 +90,7 @@ function onInput(row: CallVolumeMixerRow, event: Event): void {
       <button
         type="button"
         class="chat-action-button chat-action-button--secondary"
-        @click="emit('resetAll')"
+        @click="onResetAll"
       >
         Reset all
       </button>

--- a/chat/src/components/calls/CallVolumeMixerPanel.vue
+++ b/chat/src/components/calls/CallVolumeMixerPanel.vue
@@ -21,7 +21,7 @@ function syncLastEmittedLevels(rows: readonly CallVolumeMixerRow[]): void {
   lastEmittedLevels.value = Object.fromEntries(rows.map((row) => [row.key, row.level]));
 }
 
-watch(() => props.rows, syncLastEmittedLevels, { deep: true });
+watch(() => props.rows, syncLastEmittedLevels);
 
 function onInput(row: CallVolumeMixerRow, event: Event): void {
   const target = event.target;

--- a/chat/src/lib/calls/call-volume-mixer.ts
+++ b/chat/src/lib/calls/call-volume-mixer.ts
@@ -62,7 +62,7 @@ export function buildCallVolumeMixerRows(
     const voiceIdentity = liveAudioIdentities.get(callVolumeMixerKey(participantKey, "microphone"))
       ?? fallbackIdentity;
     const voiceKey = callVolumeMixerKey(participantKey, "microphone");
-    const voiceLevel = input.levels[voiceKey] ?? 1;
+    const voiceLevel = normalizeCallVolumeLevel(input.levels[voiceKey]);
     const voiceLabel = displayNameForIdentity(voiceIdentity);
     const voiceDisabled = !liveAudioSources.has(callVolumeMixerKey(participantKey, "microphone"));
     rows.push({
@@ -82,7 +82,7 @@ export function buildCallVolumeMixerRows(
     if (!liveAudioSources.has(screenSourceKey)) continue;
     const screenIdentity = liveAudioIdentities.get(screenSourceKey) ?? fallbackIdentity;
     const screenKey = screenSourceKey;
-    const screenLevel = input.levels[screenKey] ?? 1;
+    const screenLevel = normalizeCallVolumeLevel(input.levels[screenKey]);
     const screenLabel = `${voiceLabel}'s screen`;
     rows.push({
       key: screenKey,
@@ -105,6 +105,21 @@ export function resetCallVolumeMixerLevels(
   levels: CallVolumeLevelStore,
 ): CallVolumeLevelStore {
   return Object.fromEntries(Object.keys(levels).map((key) => [key, 1]));
+}
+
+export function callVolumePercentToGain(percent: number, currentGain = 1): number {
+  if (!Number.isFinite(percent)) return 1;
+  if (percent === 100) return 1;
+  if (percent === 99 && currentGain < 0.99) return 1;
+  if (percent === 101 && currentGain > 1.01) return 1;
+  return normalizeCallVolumeLevel(percent / 100);
+}
+
+function normalizeCallVolumeLevel(level: number | undefined): number {
+  if (level === undefined || !Number.isFinite(level)) return 1;
+  if (level < 0) return 0;
+  if (level > 2) return 2;
+  return level;
 }
 
 function displayNameForIdentity(identity: string): string {

--- a/chat/src/lib/calls/call-volume-mixer.ts
+++ b/chat/src/lib/calls/call-volume-mixer.ts
@@ -110,8 +110,8 @@ export function resetCallVolumeMixerLevels(
 export function callVolumePercentToGain(percent: number, currentGain = 1): number {
   if (!Number.isFinite(percent)) return 1;
   if (percent === 100) return 1;
-  if (percent === 99 && currentGain < 0.99) return 1;
-  if (percent === 101 && currentGain > 1.01) return 1;
+  if (percent === 99 && currentGain >= 0.98 && currentGain < 0.99) return 1;
+  if (percent === 101 && currentGain > 1.01 && currentGain <= 1.02) return 1;
   return normalizeCallVolumeLevel(percent / 100);
 }
 

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -73,7 +73,7 @@ export function resolveParticipantAudioVolume(
   store: ParticipantAudioVolumeStore,
   identity: ParticipantAudioVolumeIdentity,
 ): number {
-  return store[participantAudioVolumeKey(identity)] ?? 1;
+  return normalizeParticipantAudioVolume(store[participantAudioVolumeKey(identity)]);
 }
 
 export type CallEngineEvents = {
@@ -513,10 +513,10 @@ function isCallAudioTrackSource(source: CallTrackSource): source is CallAudioTra
   return source === "microphone" || source === "screen_share_audio";
 }
 
-function normalizeParticipantAudioVolume(volume: number): number {
-  if (!Number.isFinite(volume)) return 1;
+function normalizeParticipantAudioVolume(volume: number | undefined): number {
+  if (volume === undefined || !Number.isFinite(volume)) return 1;
   if (volume < 0) return 0;
-  if (volume > 1) return 1;
+  if (volume > 2) return 2;
   return volume;
 }
 

--- a/chat/tests/call-engine.test.ts
+++ b/chat/tests/call-engine.test.ts
@@ -76,6 +76,27 @@ describe("call-engine module", () => {
     })).toBe(1);
   });
 
+  test("resolves stored participant audio volume inside the 0-200 percent gain range", () => {
+    const store: ParticipantAudioVolumeStore = {
+      "alice@waddle.test/web:microphone": 3,
+      "bob@waddle.test/desktop:microphone": Number.NaN,
+      "carol@waddle.test/laptop:microphone": -0.5,
+    };
+
+    expect(resolveParticipantAudioVolume(store, {
+      participantIdentity: "alice@waddle.test/web",
+      source: "microphone",
+    })).toBe(2);
+    expect(resolveParticipantAudioVolume(store, {
+      participantIdentity: "bob@waddle.test/desktop",
+      source: "microphone",
+    })).toBe(1);
+    expect(resolveParticipantAudioVolume(store, {
+      participantIdentity: "carol@waddle.test/laptop",
+      source: "microphone",
+    })).toBe(0);
+  });
+
   test("exports CallEngine class with the expected surface", async () => {
     const mod = await import("../src/lib/calls/engine");
     const engine = new mod.CallEngine();
@@ -411,7 +432,7 @@ describe("call-engine module", () => {
       { identity: "bob@waddle.test/desktop" },
     );
 
-    expect(setVolume).toHaveBeenCalledWith(1);
+    expect(setVolume).toHaveBeenCalledWith(2);
     engine.setParticipantAudioVolume({
       participantIdentity: "bob@waddle.test/desktop",
       source: "microphone",

--- a/chat/tests/call-volume-mixer.test.ts
+++ b/chat/tests/call-volume-mixer.test.ts
@@ -10,6 +10,7 @@ import { parse, compileScript } from "vue/compiler-sfc";
 import ts from "typescript";
 import {
   buildCallVolumeMixerRows,
+  callVolumePercentToGain,
   resetCallVolumeMixerLevels,
   type CallVolumeLevelStore,
 } from "../src/lib/calls/call-volume-mixer";
@@ -163,9 +164,61 @@ describe("call volume mixer projection", () => {
       },
     ]);
   });
+
+  test("normalizes remembered levels to the 0-200 percent gain range", () => {
+    const rows = buildCallVolumeMixerRows({
+      remoteParticipantIdentities: ["alice@waddle.test/web", "bob@waddle.test/desktop"],
+      remoteTracks: [
+        remoteAudio("alice-mic", "alice@waddle.test/web", "microphone"),
+        remoteAudio("bob-mic", "bob@waddle.test/desktop", "microphone"),
+        remoteAudio("bob-screen", "bob@waddle.test/desktop", "screen_share_audio"),
+      ],
+      localIdentity: "me@waddle.test/browser",
+      levels: {
+        "alice@waddle.test/web:microphone": 3,
+        "bob@waddle.test/desktop:microphone": Number.NaN,
+        "bob@waddle.test/desktop:screen_share_audio": -0.5,
+      },
+    });
+
+    expect(rows.map((row) => ({
+      key: row.key,
+      level: row.level,
+      ariaValueText: row.ariaValueText,
+    }))).toEqual([
+      {
+        key: "alice@waddle.test/web:microphone",
+        level: 2,
+        ariaValueText: "200%",
+      },
+      {
+        key: "bob@waddle.test/desktop:microphone",
+        level: 1,
+        ariaValueText: "100%",
+      },
+      {
+        key: "bob@waddle.test/desktop:screen_share_audio",
+        level: 0,
+        ariaValueText: "0%",
+      },
+    ]);
+  });
 });
 
 describe("call volume mixer reducer", () => {
+  test("maps slider percentages to gain with a 100 percent snap detent", () => {
+    expect(callVolumePercentToGain(0)).toBe(0);
+    expect(callVolumePercentToGain(88)).toBe(0.88);
+    expect(callVolumePercentToGain(99, 0.98)).toBe(1);
+    expect(callVolumePercentToGain(99, 1)).toBe(0.99);
+    expect(callVolumePercentToGain(100, 0.99)).toBe(1);
+    expect(callVolumePercentToGain(101, 1)).toBe(1.01);
+    expect(callVolumePercentToGain(101, 1.02)).toBe(1);
+    expect(callVolumePercentToGain(150)).toBe(1.5);
+    expect(callVolumePercentToGain(250)).toBe(2);
+    expect(callVolumePercentToGain(Number.NaN)).toBe(1);
+  });
+
   test("reset all returns every stored participant audio entry to full volume", () => {
     const levels: CallVolumeLevelStore = {
       "alice@waddle.test/web:microphone": 0.2,
@@ -193,6 +246,7 @@ describe("call volume mixer panel", () => {
       localIdentity: "me@waddle.test/browser",
       levels: {
         "alice@waddle.test/web:screen_share_audio": 0,
+        "alice@waddle.test/web:microphone": 1.5,
         "bob@waddle.test/desktop:microphone": 0.35,
       },
     });
@@ -205,12 +259,41 @@ describe("call volume mixer panel", () => {
     expect(html).toContain("bob&#39;s screen");
     expect(html).toContain("mic off");
     expect(html).toContain('aria-label="Volume for alice"');
-    expect(html).toContain('aria-valuetext="100%"');
+    expect(html).toContain('max="200"');
+    expect(html).toContain('aria-valuetext="150%"');
     expect(html).toContain('aria-label="Volume for alice&#39;s screen"');
     expect(html).toContain('aria-valuetext="0%"');
     expect(html).toContain('aria-label="Muted"');
     expect(html).toContain('class="call-volume-mixer__tick"');
+    expect(html).toContain('style="left:50%;"');
     expect(html).toContain("Reset all");
+  });
+
+  test("emits directional snap-detent gains from slider input", async () => {
+    const originalHTMLInputElement = globalThis.HTMLInputElement;
+    globalThis.HTMLInputElement = TestInputElement as typeof HTMLInputElement;
+    const setup = await loadCallVolumeMixerPanelSetup();
+    try {
+      const emitted: Array<[string, CallVolumeMixerRow, number]> = [];
+      const bindings = setup({ rows: [] }, {
+        expose: () => undefined,
+        emit: (event: string, row: CallVolumeMixerRow, level: number) => {
+          emitted.push([event, row, level]);
+        },
+      });
+
+      const rowBelow = mixerRow({ level: 0.98 });
+      const rowNeutral = mixerRow({ level: 1 });
+      const rowAbove = mixerRow({ level: 1.02 });
+      bindings.onInput(rowBelow, inputEvent("99"));
+      bindings.onInput(rowNeutral, inputEvent("99"));
+      bindings.onInput(rowNeutral, inputEvent("101"));
+      bindings.onInput(rowAbove, inputEvent("101"));
+
+      expect(emitted.map(([, , level]) => level)).toEqual([1, 0.99, 1.01, 1]);
+    } finally {
+      globalThis.HTMLInputElement = originalHTMLInputElement;
+    }
   });
 });
 
@@ -276,6 +359,74 @@ async function loadVueComponent(path: string) {
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }
+}
+
+async function loadCallVolumeMixerPanelSetup(): Promise<(
+  props: { rows: readonly CallVolumeMixerRow[] },
+  context: {
+    expose: () => void;
+    emit: (event: string, row: CallVolumeMixerRow, level: number) => void;
+  },
+) => { onInput: (row: CallVolumeMixerRow, event: Event) => void }> {
+  const component = await loadVueComponentScript("../src/components/calls/CallVolumeMixerPanel.vue");
+  return component.setup;
+}
+
+async function loadVueComponentScript(path: string) {
+  const filename = new URL(path, import.meta.url);
+  const source = readFileSync(filename, "utf8");
+  const { descriptor } = parse(source, { filename: filename.pathname });
+  const script = compileScript(descriptor, {
+    id: filename.pathname,
+    inlineTemplate: false,
+  });
+
+  const tempDir = mkdtempSync(join(tmpdir(), "waddle-call-volume-mixer-script-"));
+  try {
+    const compiled = [
+      rewriteImports(script.content.replace("export default", "const __sfc__ ="), filename),
+      "export default __sfc__;",
+    ].join("\n");
+    const js = ts.transpileModule(compiled, {
+      compilerOptions: {
+        module: ts.ModuleKind.ESNext,
+        target: ts.ScriptTarget.ES2022,
+        verbatimModuleSyntax: false,
+      },
+    }).outputText;
+    const modulePath = join(tempDir, "Component.mjs");
+    writeFileSync(modulePath, js);
+    const component = await import(pathToFileURL(modulePath).href);
+    return component.default;
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function mixerRow(overrides: Partial<CallVolumeMixerRow>): CallVolumeMixerRow {
+  return {
+    key: "alice@waddle.test/web:microphone",
+    participantIdentity: "alice@waddle.test/web",
+    source: "microphone",
+    label: "alice",
+    level: 1,
+    disabled: false,
+    hint: null,
+    muted: false,
+    ariaLabel: "Volume for alice",
+    ariaValueText: "100%",
+    ...overrides,
+  };
+}
+
+function inputEvent(value: string): Event {
+  return {
+    target: new TestInputElement(value),
+  } as unknown as Event;
+}
+
+class TestInputElement {
+  constructor(readonly value: string) {}
 }
 
 function rewriteImports(code: string, importer: URL): string {

--- a/chat/tests/call-volume-mixer.test.ts
+++ b/chat/tests/call-volume-mixer.test.ts
@@ -272,8 +272,8 @@ describe("call volume mixer panel", () => {
   test("emits directional snap-detent gains from slider input", async () => {
     const originalHTMLInputElement = globalThis.HTMLInputElement;
     globalThis.HTMLInputElement = TestInputElement as typeof HTMLInputElement;
-    const setup = await loadCallVolumeMixerPanelSetup();
     try {
+      const setup = await loadCallVolumeMixerPanelSetup();
       const emitted: Array<[string, CallVolumeMixerRow, number]> = [];
       const bindings = setup({ rows: [] }, {
         expose: () => undefined,

--- a/chat/tests/call-volume-mixer.test.ts
+++ b/chat/tests/call-volume-mixer.test.ts
@@ -209,11 +209,13 @@ describe("call volume mixer reducer", () => {
   test("maps slider percentages to gain with a 100 percent snap detent", () => {
     expect(callVolumePercentToGain(0)).toBe(0);
     expect(callVolumePercentToGain(88)).toBe(0.88);
+    expect(callVolumePercentToGain(99, 0.5)).toBe(0.99);
     expect(callVolumePercentToGain(99, 0.98)).toBe(1);
     expect(callVolumePercentToGain(99, 1)).toBe(0.99);
     expect(callVolumePercentToGain(100, 0.99)).toBe(1);
     expect(callVolumePercentToGain(101, 1)).toBe(1.01);
     expect(callVolumePercentToGain(101, 1.02)).toBe(1);
+    expect(callVolumePercentToGain(101, 1.5)).toBe(1.01);
     expect(callVolumePercentToGain(150)).toBe(1.5);
     expect(callVolumePercentToGain(250)).toBe(2);
     expect(callVolumePercentToGain(Number.NaN)).toBe(1);
@@ -282,15 +284,30 @@ describe("call volume mixer panel", () => {
         },
       });
 
-      const rowBelow = mixerRow({ level: 0.98 });
-      const rowNeutral = mixerRow({ level: 1 });
-      const rowAbove = mixerRow({ level: 1.02 });
+      const rowBelow = mixerRow({ key: "below", level: 0.98 });
+      const rowNeutral = mixerRow({ key: "neutral", level: 1 });
+      const rowAbove = mixerRow({ key: "above", level: 1.02 });
+      const staleRowBelow = mixerRow({ key: "stale-low", level: 0.5 });
+      const staleRowAbove = mixerRow({ key: "stale-high", level: 1.5 });
       bindings.onInput(rowBelow, inputEvent("99"));
       bindings.onInput(rowNeutral, inputEvent("99"));
       bindings.onInput(rowNeutral, inputEvent("101"));
       bindings.onInput(rowAbove, inputEvent("101"));
+      bindings.onInput(staleRowBelow, inputEvent("102"));
+      bindings.onInput(staleRowBelow, inputEvent("101"));
+      bindings.onInput(staleRowAbove, inputEvent("98"));
+      bindings.onInput(staleRowAbove, inputEvent("99"));
 
-      expect(emitted.map(([, , level]) => level)).toEqual([1, 0.99, 1.01, 1]);
+      expect(emitted.map(([, , level]) => level)).toEqual([
+        1,
+        0.99,
+        1.01,
+        1,
+        1.02,
+        1,
+        0.98,
+        1,
+      ]);
     } finally {
       globalThis.HTMLInputElement = originalHTMLInputElement;
     }

--- a/chat/tests/call-volume-mixer.test.ts
+++ b/chat/tests/call-volume-mixer.test.ts
@@ -299,6 +299,9 @@ describe("call volume mixer panel", () => {
       bindings.onInput(staleRowAbove, inputEvent("99"));
       bindings.onResetAll();
       bindings.onInput(staleRowBelow, inputEvent("99"));
+      bindings.onInput(staleRowBelow, inputEvent("102"));
+      bindings.syncLastEmittedLevels([mixerRow({ key: "stale-low", level: 1 })]);
+      bindings.onInput(staleRowBelow, inputEvent("99"));
 
       expect(emitted.map(([event, , level]) => [event, level])).toEqual([
         ["setVolume", 1],
@@ -311,6 +314,8 @@ describe("call volume mixer panel", () => {
         ["setVolume", 1],
         ["resetAll", undefined],
         ["setVolume", 0.99],
+        ["setVolume", 1.02],
+        ["setVolume", 0.99],
       ]);
       expect(emitted.map(([, , level]) => level)).toEqual([
         1,
@@ -322,6 +327,8 @@ describe("call volume mixer panel", () => {
         0.98,
         1,
         undefined,
+        0.99,
+        1.02,
         0.99,
       ]);
     } finally {
@@ -403,6 +410,7 @@ async function loadCallVolumeMixerPanelSetup(): Promise<(
 ) => {
   onInput: (row: CallVolumeMixerRow, event: Event) => void;
   onResetAll: () => void;
+  syncLastEmittedLevels: (rows: readonly CallVolumeMixerRow[]) => void;
 }> {
   const component = await loadVueComponentScript("../src/components/calls/CallVolumeMixerPanel.vue");
   return component.setup;

--- a/chat/tests/call-volume-mixer.test.ts
+++ b/chat/tests/call-volume-mixer.test.ts
@@ -276,10 +276,10 @@ describe("call volume mixer panel", () => {
     globalThis.HTMLInputElement = TestInputElement as typeof HTMLInputElement;
     try {
       const setup = await loadCallVolumeMixerPanelSetup();
-      const emitted: Array<[string, CallVolumeMixerRow, number]> = [];
+      const emitted: Array<[string, CallVolumeMixerRow | undefined, number | undefined]> = [];
       const bindings = setup({ rows: [] }, {
         expose: () => undefined,
-        emit: (event: string, row: CallVolumeMixerRow, level: number) => {
+        emit: (event: string, row?: CallVolumeMixerRow, level?: number) => {
           emitted.push([event, row, level]);
         },
       });
@@ -297,7 +297,21 @@ describe("call volume mixer panel", () => {
       bindings.onInput(staleRowBelow, inputEvent("101"));
       bindings.onInput(staleRowAbove, inputEvent("98"));
       bindings.onInput(staleRowAbove, inputEvent("99"));
+      bindings.onResetAll();
+      bindings.onInput(staleRowBelow, inputEvent("99"));
 
+      expect(emitted.map(([event, , level]) => [event, level])).toEqual([
+        ["setVolume", 1],
+        ["setVolume", 0.99],
+        ["setVolume", 1.01],
+        ["setVolume", 1],
+        ["setVolume", 1.02],
+        ["setVolume", 1],
+        ["setVolume", 0.98],
+        ["setVolume", 1],
+        ["resetAll", undefined],
+        ["setVolume", 0.99],
+      ]);
       expect(emitted.map(([, , level]) => level)).toEqual([
         1,
         0.99,
@@ -307,6 +321,8 @@ describe("call volume mixer panel", () => {
         1,
         0.98,
         1,
+        undefined,
+        0.99,
       ]);
     } finally {
       globalThis.HTMLInputElement = originalHTMLInputElement;
@@ -382,9 +398,12 @@ async function loadCallVolumeMixerPanelSetup(): Promise<(
   props: { rows: readonly CallVolumeMixerRow[] },
   context: {
     expose: () => void;
-    emit: (event: string, row: CallVolumeMixerRow, level: number) => void;
+    emit: (event: string, row?: CallVolumeMixerRow, level?: number) => void;
   },
-) => { onInput: (row: CallVolumeMixerRow, event: Event) => void }> {
+) => {
+  onInput: (row: CallVolumeMixerRow, event: Event) => void;
+  onResetAll: () => void;
+}> {
   const component = await loadVueComponentScript("../src/components/calls/CallVolumeMixerPanel.vue");
   return component.setup;
 }


### PR DESCRIPTION
Implements #902.

Summary:
- Raises participant audio volume controls from 0-100% to 0-200% while preserving 100% as the default neutral gain.
- Clamps mixer-projected, resolver, stored, and applied participant audio gain values to [0.0, 2.0].
- Adds directional snap-detent behavior around 100% that snaps when approaching neutral but still lets keyboard users leave 100% in either direction.
- Tracks the last emitted gain per participant row so rapid drag input does not depend on stale rendered props.
- Synchronizes and clears local detent state after parent-driven row changes and Reset all, so programmatic resets cannot trap the next keyboard step at 100%.
- Uses a shallow row watcher because the parent passes fresh mixer row arrays when levels change.
- Keeps Reset all returning every participant audio target to 100% / gain 1.0.

PR review fixes:
- Restored the test-only HTMLInputElement override inside the async try/finally boundary.
- Limited the 99%/101% snap-detent to adjacent-step approaches so coarse jumps can intentionally land on those values.
- Cleared detent tracking on Reset all.
- Synced detent tracking from rendered rows after external row updates.
- Replaced the deep row watcher with a shallow watcher to avoid unnecessary Vue traversal.
- Resolved all PR review threads.

XEP review:
- This is local Web Audio/LiveKit client volume control only. It does not alter XMPP wire payloads, namespaces, or advertised XEP features.

Tests:
- cd chat && bun test tests/call-volume-mixer.test.ts tests/call-engine.test.ts
- cd chat && bun run lint
- cd chat && bun test
- GitHub checks on commit a7610b0e: CodeQL pass; waddle-chat-pullRequest pass.
- Adversarial audio/media, UI/accessibility, and test-adequacy subagent reviews completed with no remaining actionable issues.

Not tested:
- Manual browser audio boost smoke test with real remote media.
