### PR TITLE
fix(chat): gate speaker selection on web audio output support

### DIFF
--- a/chat/src/components/calls/CallSettingsDialog.vue
+++ b/chat/src/components/calls/CallSettingsDialog.vue
@@ -6,6 +6,7 @@ import AppDialog from "@/components/ui/AppDialog.vue";
 import {
   $devicePrefs,
   enumerateCallDevices,
+  isSpeakerOutputSelectionSupported,
   setCamDevice,
   setMicDevice,
   setSpeakerDevice,
@@ -25,22 +26,15 @@ import { reportCallError } from "@/lib/calls/call-store";
  * through `$devicePrefs`; switching device while a call is active
  * is applied via the LiveKit engine without disconnecting.
  *
- * Speaker selection requires `HTMLMediaElement.setSinkId`, which
- * is unavailable on Firefox today; we surface that as a disabled
- * picker row with explanatory copy rather than hiding the section.
+ * Speaker selection requires sink routing for both the media element
+ * and the Web Audio context. Browsers without that full path keep the
+ * picker disabled rather than surfacing a broken output switch.
  */
 const open = defineModel<boolean>("open", { required: true });
 
 const prefs = useStore($devicePrefs);
 const devices = ref<EnumeratedDevices>({ mics: [], cams: [], speakers: [] });
-const speakerSupported = ref(true);
-
-function detectSpeakerSupport(): boolean {
-  if (typeof window === "undefined") return false;
-  const audio = document.createElement("audio") as HTMLAudioElement &
-    Partial<{ setSinkId: (id: string) => Promise<void> }>;
-  return typeof audio.setSinkId === "function";
-}
+const speakerSupported = ref(isSpeakerOutputSelectionSupported());
 
 /**
  * Epoch counter incremented on every dialog close. `refresh()` reads
@@ -130,7 +124,7 @@ watch(open, async (isOpen) => {
     teardownDeviceChange();
     return;
   }
-  speakerSupported.value = detectSpeakerSupport();
+  speakerSupported.value = isSpeakerOutputSelectionSupported();
   await refresh();
   // Mount the devicechange listener after the first refresh so the
   // initial enumeration isn't fighting a hot-plug event arriving in

--- a/chat/src/components/calls/CallSettingsDialog.vue
+++ b/chat/src/components/calls/CallSettingsDialog.vue
@@ -124,7 +124,6 @@ watch(open, async (isOpen) => {
     teardownDeviceChange();
     return;
   }
-  speakerSupported.value = isSpeakerOutputSelectionSupported();
   await refresh();
   // Mount the devicechange listener after the first refresh so the
   // initial enumeration isn't fighting a hot-plug event arriving in

--- a/chat/src/lib/calls/device-prefs.ts
+++ b/chat/src/lib/calls/device-prefs.ts
@@ -64,6 +64,33 @@ export function setSpeakerDevice(id: string | null): void {
   $devicePrefs.set({ ...$devicePrefs.get(), speaker: id });
 }
 
+type SpeakerOutputSelectionEnvironment = {
+  document?: Pick<Document, "createElement">;
+  AudioContext?: { prototype?: { setSinkId?: unknown } } | undefined;
+};
+
+type AudioContextSinkConstructor = NonNullable<
+  SpeakerOutputSelectionEnvironment["AudioContext"]
+>;
+
+export function isSpeakerOutputSelectionSupported(
+  env: SpeakerOutputSelectionEnvironment = {
+    document: typeof document === "undefined" ? undefined : document,
+    AudioContext:
+      typeof AudioContext === "undefined"
+        ? undefined
+        : (AudioContext as unknown as AudioContextSinkConstructor),
+  },
+): boolean {
+  if (!env.document) return false;
+  const audio = env.document.createElement("audio") as HTMLAudioElement &
+    Partial<{ setSinkId: (id: string) => Promise<void> }>;
+  return (
+    typeof audio.setSinkId === "function" &&
+    typeof env.AudioContext?.prototype?.setSinkId === "function"
+  );
+}
+
 /**
  * One enumerated media device — narrower than the browser's
  * `MediaDeviceInfo` because we only need `deviceId` + a label to

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -302,9 +302,9 @@ export class CallEngine {
 
   /**
    * Route the room's remote audio through a specific output device.
-   * Uses LiveKit's built-in `audiooutput` switch for browsers that
-   * implement `HTMLMediaElement.setSinkId`; falls back to a no-op on
-   * browsers that don't (Firefox today).
+   * Uses LiveKit's built-in `audiooutput` switch for browsers that can
+   * route Web Audio output sinks; falls back to a no-op on unsupported
+   * browsers.
    */
   async setSpeakerDevice(deviceId: string): Promise<void> {
     await this.applySpeakerDevice(deviceId);

--- a/chat/tests/call-device-prefs.test.ts
+++ b/chat/tests/call-device-prefs.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { isSpeakerOutputSelectionSupported } from "../src/lib/calls/device-prefs";
+
+describe("call speaker output support", () => {
+  test("is disabled during SSR or when media elements cannot switch sinks", () => {
+    expect(isSpeakerOutputSelectionSupported({})).toBe(false);
+    expect(
+      isSpeakerOutputSelectionSupported({
+        document: { createElement: () => ({}) },
+        AudioContext: class AudioContextWithSink {
+          setSinkId(): Promise<void> {
+            return Promise.resolve();
+          }
+        },
+      }),
+    ).toBe(false);
+  });
+
+  test("requires Web Audio sink routing when speaker selection is shown", () => {
+    const documentWithMediaSink = {
+      createElement(tag: string) {
+        if (tag !== "audio") throw new Error(`unexpected element: ${tag}`);
+        return { setSinkId: async () => undefined };
+      },
+    };
+
+    expect(
+      isSpeakerOutputSelectionSupported({
+        document: documentWithMediaSink,
+        AudioContext: undefined,
+      }),
+    ).toBe(false);
+
+    expect(
+      isSpeakerOutputSelectionSupported({
+        document: documentWithMediaSink,
+        AudioContext: class AudioContextWithSink {
+          setSinkId(): Promise<void> {
+            return Promise.resolve();
+          }
+        },
+      }),
+    ).toBe(true);
+  });
+});

--- a/chat/tests/call-settings-dialog.test.ts
+++ b/chat/tests/call-settings-dialog.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { createRequire } from "node:module";
+import { createSSRApp, h } from "vue";
+import { renderToString } from "vue/server-renderer";
+import { parse, compileScript } from "vue/compiler-sfc";
+import ts from "typescript";
+
+const require = createRequire(import.meta.url);
+
+describe("CallSettingsDialog speaker support", () => {
+  test("renders the graceful disabled speaker state when Web Audio sink routing is unavailable", async () => {
+    const html = await renderVueComponent("../src/components/calls/CallSettingsDialog.vue", {
+      open: true,
+      "onUpdate:open": () => undefined,
+    });
+
+    expect(html).toContain("Your browser doesn&#39;t support choosing the speaker device");
+    expect(html).not.toContain('aria-label="Speaker"');
+    expect(html).not.toContain("System default");
+  });
+});
+
+async function renderVueComponent(path: string, props: Record<string, unknown>): Promise<string> {
+  const component = await loadVueComponent(path);
+  return renderToString(createSSRApp({ render: () => h(component, props) }));
+}
+
+async function loadVueComponent(path: string) {
+  const filename = new URL(path, import.meta.url);
+  const tempDir = mkdtempSync(join(tmpdir(), "waddle-call-settings-dialog-"));
+  try {
+    const modulePath = compileVueModule(filename, tempDir, new Map());
+    const component = await import(pathToFileURL(modulePath).href);
+    return component.default;
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function compileVueModule(filename: URL, tempDir: string, cache: Map<string, string>): string {
+  const cached = cache.get(filename.pathname);
+  if (cached) return cached;
+  const modulePath = join(tempDir, `${cache.size}.mjs`);
+  cache.set(filename.pathname, modulePath);
+
+  const source = readFileSync(filename, "utf8");
+  const { descriptor } = parse(source, { filename: filename.pathname });
+  const script = compileScript(descriptor, {
+    id: filename.pathname,
+    inlineTemplate: true,
+  });
+  const compiled = [
+    rewriteImports(script.content.replace("export default", "const __sfc__ ="), filename, tempDir, cache),
+    "export default __sfc__;",
+  ].join("\n");
+  const js = ts.transpileModule(compiled, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2022,
+      verbatimModuleSyntax: false,
+    },
+  }).outputText;
+  writeFileSync(modulePath, js);
+  return modulePath;
+}
+
+function rewriteImports(
+  code: string,
+  importer: URL,
+  tempDir: string,
+  cache: Map<string, string>,
+): string {
+  return code
+    .replace(/from\s+["']([^"']+)["']/g, (_match, specifier: string) =>
+      `from ${JSON.stringify(resolveModuleSpecifier(specifier, importer, tempDir, cache))}`)
+    .replace(/import\s*\(\s*["']([^"']+)["']\s*\)/g, (_match, specifier: string) =>
+      `import(${JSON.stringify(resolveModuleSpecifier(specifier, importer, tempDir, cache))})`);
+}
+
+function resolveModuleSpecifier(
+  specifier: string,
+  importer: URL,
+  tempDir: string,
+  cache: Map<string, string>,
+): string {
+  if (specifier.startsWith("@/") && specifier.endsWith(".vue")) {
+    if (specifier === "@/components/ui/AppDialog.vue") {
+      return pathToFileURL(writeAppDialogStub(tempDir)).href;
+    }
+    return pathToFileURL(compileVueModule(resolveImportUrl(specifier, importer), tempDir, cache)).href;
+  }
+  if (specifier.endsWith(".vue")) {
+    return pathToFileURL(compileVueModule(resolveImportUrl(specifier, importer), tempDir, cache)).href;
+  }
+  if (specifier.startsWith("@/")) {
+    return new URL(`../src/${specifier.slice(2)}`, import.meta.url).href;
+  }
+  if (specifier.startsWith(".")) {
+    return new URL(specifier, importer).href;
+  }
+  return require.resolve(specifier);
+}
+
+function writeAppDialogStub(tempDir: string): string {
+  const modulePath = join(tempDir, "AppDialogStub.mjs");
+  writeFileSync(
+    modulePath,
+    [
+      `import { defineComponent, h } from ${JSON.stringify(require.resolve("vue"))};`,
+      "export default defineComponent({",
+      "  setup(_props, { slots }) {",
+      "    return () => h('div', { role: 'dialog' }, slots.default?.());",
+      "  },",
+      "});",
+    ].join("\n"),
+  );
+  return modulePath;
+}
+
+function resolveImportUrl(specifier: string, importer: URL): URL {
+  if (specifier.startsWith("@/")) {
+    return new URL(`../src/${specifier.slice(2)}`, import.meta.url);
+  }
+  return new URL(specifier, importer);
+}

--- a/chat/tests/call-settings-dialog.test.ts
+++ b/chat/tests/call-settings-dialog.test.ts
@@ -75,10 +75,32 @@ function rewriteImports(
   cache: Map<string, string>,
 ): string {
   return code
-    .replace(/from\s+["']([^"']+)["']/g, (_match, specifier: string) =>
-      `from ${JSON.stringify(resolveModuleSpecifier(specifier, importer, tempDir, cache))}`)
-    .replace(/import\s*\(\s*["']([^"']+)["']\s*\)/g, (_match, specifier: string) =>
-      `import(${JSON.stringify(resolveModuleSpecifier(specifier, importer, tempDir, cache))})`);
+    .replace(/^(\s*import\b(?:(?!;)[\s\S])*?\s+from\s+)["']([^"']+)["']/gm, (
+      _match,
+      prefix: string,
+      specifier: string,
+    ) =>
+      `${prefix}${JSON.stringify(resolveModuleSpecifier(specifier, importer, tempDir, cache))}`)
+    .replace(/^(\s*export\b(?:(?!;)[\s\S])*?\s+from\s+)["']([^"']+)["']/gm, (
+      _match,
+      prefix: string,
+      specifier: string,
+    ) =>
+      `${prefix}${JSON.stringify(resolveModuleSpecifier(specifier, importer, tempDir, cache))}`)
+    .replace(/^(\s*import\s*\(\s*)["']([^"']+)["'](\s*\))/gm, (
+      _match,
+      prefix: string,
+      specifier: string,
+      suffix: string,
+    ) =>
+      `${prefix}${JSON.stringify(resolveModuleSpecifier(specifier, importer, tempDir, cache))}${suffix}`)
+    .replace(/^(\s*const\s+\w+\s*=\s*await\s+import\s*\(\s*)["']([^"']+)["'](\s*\))/gm, (
+      _match,
+      prefix: string,
+      specifier: string,
+      suffix: string,
+    ) =>
+      `${prefix}${JSON.stringify(resolveModuleSpecifier(specifier, importer, tempDir, cache))}${suffix}`);
 }
 
 function resolveModuleSpecifier(


### PR DESCRIPTION
Implements #903.

Summary:
- Gates speaker-output selection on both `HTMLMediaElement.setSinkId` and `AudioContext.prototype.setSinkId`, matching the Web Audio mixed-output path from #901/#902.
- Keeps unsupported browsers in the existing disabled/degraded speaker-picker state instead of exposing a selector that cannot route mixed call audio.
- Moves the capability check into `device-prefs.ts` so it can be tested directly and reused by the settings dialog.
- Initializes `CallSettingsDialog` from the shared detector so unsupported browsers render the disabled speaker state immediately.
- Updates call engine documentation to describe Web Audio output routing instead of media-element-only routing.

TDD evidence:
- RED: `tests/call-device-prefs.test.ts` initially failed because `isSpeakerOutputSelectionSupported` did not exist.
- GREEN: added the detector and wired `CallSettingsDialog` to it.
- REFACTOR: made the detector structural so TypeScript does not require DOM lib support for the experimental `AudioContext.setSinkId` API.
- Review response: added `tests/call-settings-dialog.test.ts` to assert the dialog renders graceful disabled speaker copy and no speaker radio options when Web Audio sink routing is unavailable.

PR review fixes:
- Removed the redundant `isSpeakerOutputSelectionSupported()` re-check from the open watcher.
- Tightened the SFC test import rewriter so it only rewrites actual import/export statements instead of arbitrary `from "..."` text.
- Resolved all review threads.

XEP review:
- This is local browser media-device capability handling only. It does not alter XMPP wire payloads, namespaces, or advertised XEP features.

Tests:
- cd chat && bun test tests/call-device-prefs.test.ts
- cd chat && bun test tests/call-settings-dialog.test.ts tests/call-device-prefs.test.ts tests/call-engine.test.ts
- cd chat && bun run lint
- cd chat && bun test
- cd chat && bun run build
- PR #908 CodeQL and waddle-chat-pullRequest checks pass on commit 963a43ce.
- Adversarial browser/media capability review: no actionable issues.
- Test-adequacy review: dialog-level gap addressed.

Manual/HITL verification still required by #903:
- Chromium: audible boost above 100%, real speaker-output switching, autoplay-resume prompt.
- Safari: 0-200% volume, disabled/no-error speaker picker.
- Firefox: 0-200% volume, disabled/no-op speaker selection.
