### PR TITLE
feat(chat): speaker control on the call bar opens the volume mixer (split + expanded)

### DIFF
--- a/chat/src/components/calls/CallControls.vue
+++ b/chat/src/components/calls/CallControls.vue
@@ -9,6 +9,7 @@ import {
   Settings,
   Video,
   VideoOff,
+  Volume2,
 } from "lucide-vue-next";
 
 /**
@@ -27,6 +28,9 @@ defineProps<{
   /** True when the parent surface is the expanded variant — flips
    *  the toggle button between "expand" and "collapse". */
   isExpanded: boolean;
+  /** True while the volume mixer dialog is open — drives the speaker
+   *  button's pressed/expanded state. The parent owns the dialog. */
+  volumeOpen: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -34,6 +38,7 @@ const emit = defineEmits<{
   toggleCam: [];
   toggleScreenShare: [];
   toggleExpanded: [];
+  toggleVolume: [];
   openSettings: [];
   hangup: [];
 }>();
@@ -87,6 +92,19 @@ const emit = defineEmits<{
       @click="emit('toggleExpanded')"
     >
       <component :is="isExpanded ? Minimize2 : Maximize2" class="w-4 h-4" />
+    </button>
+    <button
+      type="button"
+      class="chat-icon-button chat-icon-button--md hover:bg-muted"
+      :class="{ 'bg-muted text-foreground': volumeOpen }"
+      :title="volumeOpen ? 'Close volume mixer' : 'Open volume mixer'"
+      :aria-label="volumeOpen ? 'Close volume mixer' : 'Open volume mixer'"
+      :aria-pressed="volumeOpen"
+      :aria-expanded="volumeOpen"
+      aria-haspopup="dialog"
+      @click="emit('toggleVolume')"
+    >
+      <Volume2 class="w-4 h-4" />
     </button>
     <button
       type="button"

--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 import { useStore } from "@nanostores/vue";
 import {
   $callState,
@@ -23,20 +23,14 @@ import { useCallEngine } from "@/lib/calls/use-call-engine";
 import { useActiveMucCall } from "@/lib/calls/use-active-muc-call";
 import { localScreenSharePresentation } from "@/lib/calls/call-self-share";
 import { normalizeMucCallRoomJid } from "@/lib/calls/muc-call-presence";
-import { $mucCallLiveParticipants } from "@/lib/calls/muc-call-live-participants";
-import {
-  buildCallVolumeMixerRows,
-  resetCallVolumeMixerLevels,
-  type CallVolumeLevelStore,
-  type CallVolumeMixerRow,
-} from "@/lib/calls/call-volume-mixer";
+import { useCallVolumeMixer } from "@/lib/calls/use-call-volume-mixer";
 import { barePeerJid } from "@/lib/xmpp/jid";
 import CallTileGrid from "./CallTileGrid.vue";
 import CallControls from "./CallControls.vue";
 import CallSettingsDialog from "./CallSettingsDialog.vue";
 import CallMediaNotice from "./CallMediaNotice.vue";
 import CallSelfShareNotice from "./CallSelfShareNotice.vue";
-import CallVolumeMixerPanel from "./CallVolumeMixerPanel.vue";
+import CallVolumeMixerDialog from "./CallVolumeMixerDialog.vue";
 import CallAudioPlaybackPrompt from "./CallAudioPlaybackPrompt.vue";
 
 /**
@@ -68,16 +62,11 @@ const micEnabled = useStore($callMicEnabled);
 const camEnabled = useStore($callCamEnabled);
 const screenShareEnabled = useStore($callScreenShareEnabled);
 const screenShareSupported = useStore($callScreenShareSupported);
-const liveParticipants = useStore($mucCallLiveParticipants);
 const { remoteTracks, localTracks, engine } = useCallEngine();
 const { activeRoomJid, selfInCall } = useActiveMucCall();
 
 const settingsOpen = ref(false);
-const participantAudioLevels = ref<CallVolumeLevelStore>({});
-const participantAudioTargets = ref<Record<string, {
-  participantIdentity: string;
-  source: CallVolumeMixerRow["source"];
-}>>({});
+const volumeOpen = ref(false);
 
 const normalizedRoomJid = computed(() =>
   normalizeMucCallRoomJid(props.roomJid ?? ""),
@@ -147,67 +136,11 @@ const stageLocalTracks = computed(() =>
   selfSharePresentation.value?.stageLocalTracks ?? localTracks.value,
 );
 
-const remoteParticipantIdentities = computed(() => {
-  if (state.value.phase === "active" && state.value.kind === "muc") {
-    return liveParticipants.value[normalizedRoomJid.value] ?? [];
-  }
-  const identities = new Set<string>();
-  if (state.value.phase === "active" && state.value.kind === "dm") {
-    identities.add(state.value.peer);
-  }
-  for (const track of remoteTracks.value) identities.add(track.participantIdentity);
-  return Array.from(identities);
-});
-
-const volumeRows = computed(() =>
-  buildCallVolumeMixerRows({
-    remoteParticipantIdentities: remoteParticipantIdentities.value,
-    remoteTracks: remoteTracks.value,
-    localIdentity: localIdentity.value,
-    levels: participantAudioLevels.value,
-  }),
-);
-
-const activeCallSid = computed(() =>
-  state.value.phase === "active" ? state.value.sid : null,
-);
-
-function setParticipantVolume(row: CallVolumeMixerRow, level: number): void {
-  participantAudioLevels.value = {
-    ...participantAudioLevels.value,
-    [row.key]: level,
-  };
-  participantAudioTargets.value = {
-    ...participantAudioTargets.value,
-    [row.key]: {
-      participantIdentity: row.participantIdentity,
-      source: row.source,
-    },
-  };
-  engine.setParticipantAudioVolume({
-    participantIdentity: row.participantIdentity,
-    source: row.source,
-    volume: level,
-  });
-}
-
-function resetParticipantVolumes(): void {
-  for (const target of Object.values(participantAudioTargets.value)) {
-    engine.setParticipantAudioVolume({
-      participantIdentity: target.participantIdentity,
-      source: target.source,
-      volume: 1,
-    });
-  }
-  for (const row of volumeRows.value) {
-    engine.setParticipantAudioVolume({
-      participantIdentity: row.participantIdentity,
-      source: row.source,
-      volume: 1,
-    });
-  }
-  participantAudioLevels.value = resetCallVolumeMixerLevels(participantAudioLevels.value);
-}
+const {
+  rows: volumeRows,
+  setVolume: setParticipantVolume,
+  resetAll: resetParticipantVolumes,
+} = useCallVolumeMixer(normalizedRoomJid);
 
 function collapseToSplit(): void {
   $callUiMode.set("split");
@@ -223,10 +156,18 @@ async function onHangup(): Promise<void> {
 
 function onKeydown(event: KeyboardEvent): void {
   if (!isOpen.value) return;
-  if (event.key === "Escape") {
+  if (event.key !== "Escape") return;
+  // A modal (settings or the volume mixer) owns Escape while it is
+  // open: dismiss the dialog rather than collapsing the whole expanded
+  // call out from under it.
+  if (settingsOpen.value || volumeOpen.value) {
     event.preventDefault();
-    collapseToSplit();
+    settingsOpen.value = false;
+    volumeOpen.value = false;
+    return;
   }
+  event.preventDefault();
+  collapseToSplit();
 }
 
 onMounted(() => {
@@ -234,11 +175,6 @@ onMounted(() => {
   if (typeof window !== "undefined") {
     window.addEventListener("keydown", onKeydown);
   }
-});
-
-watch(activeCallSid, () => {
-  participantAudioLevels.value = {};
-  participantAudioTargets.value = {};
 });
 
 onBeforeUnmount(() => {
@@ -283,11 +219,6 @@ onBeforeUnmount(() => {
           :mic-enabled="micEnabled"
         />
       </div>
-      <CallVolumeMixerPanel
-        :rows="volumeRows"
-        @set-volume="setParticipantVolume"
-        @reset-all="resetParticipantVolumes"
-      />
     </main>
     <footer class="call-expanded__footer">
       <CallControls
@@ -296,15 +227,23 @@ onBeforeUnmount(() => {
         :screen-share-enabled="screenShareEnabled"
         :screen-share-supported="screenShareSupported"
         :is-expanded="true"
+        :volume-open="volumeOpen"
         @toggle-mic="toggleMic"
         @toggle-cam="toggleCam"
         @toggle-screen-share="toggleScreenShare"
         @toggle-expanded="collapseToSplit"
+        @toggle-volume="volumeOpen = !volumeOpen"
         @open-settings="settingsOpen = true"
         @hangup="onHangup"
       />
     </footer>
     <CallSettingsDialog v-model:open="settingsOpen" />
+    <CallVolumeMixerDialog
+      v-model:open="volumeOpen"
+      :rows="volumeRows"
+      @set-volume="setParticipantVolume"
+      @reset-all="resetParticipantVolumes"
+    />
   </div>
 </template>
 
@@ -359,11 +298,5 @@ onBeforeUnmount(() => {
   justify-content: center;
   border-top: 1px solid var(--border);
   padding: 0.75rem 1rem;
-}
-
-@media (max-width: 760px) {
-  .call-expanded__main {
-    flex-direction: column;
-  }
 }
 </style>

--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -159,7 +159,10 @@ function onKeydown(event: KeyboardEvent): void {
   if (event.key !== "Escape") return;
   // A modal (settings or the volume mixer) owns Escape while it is
   // open: dismiss the dialog rather than collapsing the whole expanded
-  // call out from under it.
+  // call out from under it. This listener runs in the CAPTURE phase so
+  // it sees the still-open flag before AppDialog's own bubble-phase
+  // Escape handler flips the v-model to false — otherwise a dialog
+  // dismiss from inside the dialog would fall through to collapse.
   if (settingsOpen.value || volumeOpen.value) {
     event.preventDefault();
     settingsOpen.value = false;
@@ -173,13 +176,13 @@ function onKeydown(event: KeyboardEvent): void {
 onMounted(() => {
   refreshScreenShareSupported();
   if (typeof window !== "undefined") {
-    window.addEventListener("keydown", onKeydown);
+    window.addEventListener("keydown", onKeydown, true);
   }
 });
 
 onBeforeUnmount(() => {
   if (typeof window !== "undefined") {
-    window.removeEventListener("keydown", onKeydown);
+    window.removeEventListener("keydown", onKeydown, true);
   }
 });
 </script>

--- a/chat/src/components/calls/CallSplitContainer.vue
+++ b/chat/src/components/calls/CallSplitContainer.vue
@@ -24,12 +24,14 @@ import { useActiveMucCall } from "@/lib/calls/use-active-muc-call";
 import { useSplitResize } from "@/lib/calls/use-split-resize";
 import { localScreenSharePresentation } from "@/lib/calls/call-self-share";
 import { normalizeMucCallRoomJid } from "@/lib/calls/muc-call-presence";
+import { useCallVolumeMixer } from "@/lib/calls/use-call-volume-mixer";
 import { barePeerJid } from "@/lib/xmpp/jid";
 import CallTileGrid from "./CallTileGrid.vue";
 import CallControls from "./CallControls.vue";
 import CallSettingsDialog from "./CallSettingsDialog.vue";
 import CallMediaNotice from "./CallMediaNotice.vue";
 import CallSelfShareNotice from "./CallSelfShareNotice.vue";
+import CallVolumeMixerDialog from "./CallVolumeMixerDialog.vue";
 import CallAudioPlaybackPrompt from "./CallAudioPlaybackPrompt.vue";
 import SplitDragHandle from "./SplitDragHandle.vue";
 
@@ -65,11 +67,18 @@ const { remoteTracks, localTracks, engine } = useCallEngine();
 const { activeRoomJid, selfInCall } = useActiveMucCall();
 
 const settingsOpen = ref(false);
+const volumeOpen = ref(false);
 const containerRef = ref<HTMLElement | null>(null);
 
 const normalizedRoomJid = computed(() =>
   normalizeMucCallRoomJid(props.roomJid ?? ""),
 );
+
+const {
+  rows: volumeRows,
+  setVolume: setParticipantVolume,
+  resetAll: resetParticipantVolumes,
+} = useCallVolumeMixer(normalizedRoomJid);
 
 const normalizedDmPeerJid = computed(() =>
   barePeerJid(props.dmPeerJid ?? "").toLowerCase(),
@@ -214,10 +223,12 @@ async function onHangup(): Promise<void> {
           :screen-share-enabled="screenShareEnabled"
           :screen-share-supported="screenShareSupported"
           :is-expanded="false"
+          :volume-open="volumeOpen"
           @toggle-mic="toggleMic"
           @toggle-cam="toggleCam"
           @toggle-screen-share="toggleScreenShare"
           @toggle-expanded="enterExpanded"
+          @toggle-volume="volumeOpen = !volumeOpen"
           @open-settings="settingsOpen = true"
           @hangup="onHangup"
         />
@@ -229,6 +240,12 @@ async function onHangup(): Promise<void> {
       @press="onHandlePress"
     />
     <CallSettingsDialog v-model:open="settingsOpen" />
+    <CallVolumeMixerDialog
+      v-model:open="volumeOpen"
+      :rows="volumeRows"
+      @set-volume="setParticipantVolume"
+      @reset-all="resetParticipantVolumes"
+    />
   </template>
 </template>
 

--- a/chat/src/components/calls/CallVolumeMixerDialog.vue
+++ b/chat/src/components/calls/CallVolumeMixerDialog.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import { X } from "lucide-vue-next";
+import AppDialog from "@/components/ui/AppDialog.vue";
+import CallVolumeMixerPanel from "./CallVolumeMixerPanel.vue";
+import type { CallVolumeMixerRow } from "@/lib/calls/call-volume-mixer";
+
+/**
+ * Modal wrapper that surfaces the call volume mixer from the control
+ * bar's speaker button (#909). The mixer's row model, sliders, and
+ * reset-all are reused unchanged from `CallVolumeMixerPanel`; this
+ * component only owns the open/close chrome.
+ *
+ * Lives in `<AppDialog>` for the same reason `CallSettingsDialog`
+ * does: shared backdrop blur, Esc-to-close, and focus model. The
+ * panel's own "Who you hear" header serves as the dialog title, so
+ * the chrome adds only an explicit close affordance. A scoped
+ * `:deep` override lets the sidebar-shaped panel fill the modal
+ * without forking the panel component.
+ */
+const open = defineModel<boolean>("open", { required: true });
+
+defineProps<{
+  rows: readonly CallVolumeMixerRow[];
+}>();
+
+const emit = defineEmits<{
+  setVolume: [row: CallVolumeMixerRow, level: number];
+  resetAll: [];
+}>();
+
+function onSetVolume(row: CallVolumeMixerRow, level: number): void {
+  emit("setVolume", row, level);
+}
+
+function onResetAll(): void {
+  emit("resetAll");
+}
+
+function close(): void {
+  open.value = false;
+}
+</script>
+
+<template>
+  <AppDialog v-model:open="open">
+    <div class="call-volume-mixer-dialog">
+      <button
+        type="button"
+        class="call-volume-mixer-dialog__close chat-icon-button chat-icon-button--md hover:bg-muted"
+        aria-label="Close volume mixer"
+        @click="close"
+      >
+        <X class="w-4 h-4" />
+      </button>
+      <CallVolumeMixerPanel
+        :rows="rows"
+        @set-volume="onSetVolume"
+        @reset-all="onResetAll"
+      />
+    </div>
+  </AppDialog>
+</template>
+
+<style scoped>
+.call-volume-mixer-dialog {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  max-height: min(34rem, calc(100dvh - 6rem));
+}
+
+.call-volume-mixer-dialog__close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  z-index: 1;
+}
+
+/* The mixer panel is shaped as an inline sidebar (`border-left`,
+ * clamped width). Inside the modal it should fill the dialog instead;
+ * override its container layout here rather than forking the shared
+ * panel component. */
+.call-volume-mixer-dialog :deep(.call-volume-mixer) {
+  width: 100%;
+  min-width: 0;
+  border-left: 0;
+  background: transparent;
+}
+
+.call-volume-mixer-dialog :deep(.call-volume-mixer__header) {
+  padding-right: 3rem;
+}
+</style>

--- a/chat/src/lib/calls/use-call-volume-mixer.ts
+++ b/chat/src/lib/calls/use-call-volume-mixer.ts
@@ -1,0 +1,120 @@
+import { computed, ref, watch, type ComputedRef, type Ref } from "vue";
+import { useStore } from "@nanostores/vue";
+import { $callState } from "./call-store";
+import { $mucCallLiveParticipants } from "./muc-call-live-participants";
+import { useCallEngine } from "./use-call-engine";
+import {
+  buildCallVolumeMixerRows,
+  resetCallVolumeMixerLevels,
+  type CallVolumeLevelStore,
+  type CallVolumeMixerRow,
+} from "./call-volume-mixer";
+
+/**
+ * Shared "Who you hear" mixer controller for the in-call surfaces
+ * (split + expanded). Both surfaces reach the mixer from the control
+ * bar's speaker button (#909), so the row projection, remembered
+ * levels, and the LiveKit `setParticipantAudioVolume` apply path live
+ * here once instead of being duplicated per surface.
+ *
+ * `remembered levels` are kept per LiveKit participant+source key so a
+ * participant who mutes (dropping their audio track) keeps the volume
+ * the user last set, ready to re-apply when they unmute. The remembered
+ * state is wiped whenever the active call's SID changes so one call's
+ * preferences never bleed into the next.
+ */
+export interface CallVolumeMixerController {
+  rows: ComputedRef<CallVolumeMixerRow[]>;
+  setVolume: (row: CallVolumeMixerRow, level: number) => void;
+  resetAll: () => void;
+}
+
+export function useCallVolumeMixer(
+  normalizedRoomJid: Ref<string> | ComputedRef<string>,
+): CallVolumeMixerController {
+  const state = useStore($callState);
+  const liveParticipants = useStore($mucCallLiveParticipants);
+  const { remoteTracks, engine } = useCallEngine();
+
+  const participantAudioLevels = ref<CallVolumeLevelStore>({});
+  const participantAudioTargets = ref<Record<string, {
+    participantIdentity: string;
+    source: CallVolumeMixerRow["source"];
+  }>>({});
+
+  const localIdentity = computed(() => engine.localIdentity);
+
+  const remoteParticipantIdentities = computed(() => {
+    if (state.value.phase === "active" && state.value.kind === "muc") {
+      return liveParticipants.value[normalizedRoomJid.value] ?? [];
+    }
+    const identities = new Set<string>();
+    if (state.value.phase === "active" && state.value.kind === "dm") {
+      identities.add(state.value.peer);
+    }
+    for (const track of remoteTracks.value) identities.add(track.participantIdentity);
+    return Array.from(identities);
+  });
+
+  const rows = computed(() =>
+    buildCallVolumeMixerRows({
+      remoteParticipantIdentities: remoteParticipantIdentities.value,
+      remoteTracks: remoteTracks.value,
+      localIdentity: localIdentity.value,
+      levels: participantAudioLevels.value,
+    }),
+  );
+
+  const activeCallSid = computed(() =>
+    state.value.phase === "active" ? state.value.sid : null,
+  );
+
+  function setVolume(row: CallVolumeMixerRow, level: number): void {
+    participantAudioLevels.value = {
+      ...participantAudioLevels.value,
+      [row.key]: level,
+    };
+    participantAudioTargets.value = {
+      ...participantAudioTargets.value,
+      [row.key]: {
+        participantIdentity: row.participantIdentity,
+        source: row.source,
+      },
+    };
+    engine.setParticipantAudioVolume({
+      participantIdentity: row.participantIdentity,
+      source: row.source,
+      volume: level,
+    });
+  }
+
+  function resetAll(): void {
+    // Reset both the targets the user has touched this call AND the
+    // currently-projected rows: a participant can be a remembered
+    // target without a live row (muted) or a live row without a
+    // remembered target (default volume), and "Reset all" must land
+    // every audible participant at unity gain.
+    for (const target of Object.values(participantAudioTargets.value)) {
+      engine.setParticipantAudioVolume({
+        participantIdentity: target.participantIdentity,
+        source: target.source,
+        volume: 1,
+      });
+    }
+    for (const row of rows.value) {
+      engine.setParticipantAudioVolume({
+        participantIdentity: row.participantIdentity,
+        source: row.source,
+        volume: 1,
+      });
+    }
+    participantAudioLevels.value = resetCallVolumeMixerLevels(participantAudioLevels.value);
+  }
+
+  watch(activeCallSid, () => {
+    participantAudioLevels.value = {};
+    participantAudioTargets.value = {};
+  });
+
+  return { rows, setVolume, resetAll };
+}

--- a/chat/src/lib/calls/use-call-volume-mixer.ts
+++ b/chat/src/lib/calls/use-call-volume-mixer.ts
@@ -104,8 +104,10 @@ export function useCallVolumeMixer(
     // currently-projected rows: a participant can be a remembered
     // target without a live row (muted) or a live row without a
     // remembered target (default volume), and "Reset all" must land
-    // every audible participant at unity gain.
-    for (const target of Object.values($rememberedTargets.get())) {
+    // every audible participant at unity gain. Rows already covered by
+    // a remembered target are skipped so each participant is reset once.
+    const touched = $rememberedTargets.get();
+    for (const target of Object.values(touched)) {
       engine.setParticipantAudioVolume({
         participantIdentity: target.participantIdentity,
         source: target.source,
@@ -113,6 +115,7 @@ export function useCallVolumeMixer(
       });
     }
     for (const row of rows.value) {
+      if (touched[row.key]) continue;
       engine.setParticipantAudioVolume({
         participantIdentity: row.participantIdentity,
         source: row.source,

--- a/chat/src/lib/calls/use-call-volume-mixer.ts
+++ b/chat/src/lib/calls/use-call-volume-mixer.ts
@@ -1,4 +1,5 @@
-import { computed, ref, watch, type ComputedRef, type Ref } from "vue";
+import { computed, type ComputedRef, type Ref } from "vue";
+import { atom } from "nanostores";
 import { useStore } from "@nanostores/vue";
 import { $callState } from "./call-store";
 import { $mucCallLiveParticipants } from "./muc-call-live-participants";
@@ -10,19 +11,41 @@ import {
   type CallVolumeMixerRow,
 } from "./call-volume-mixer";
 
+type CallVolumeMixerTarget = {
+  participantIdentity: string;
+  source: CallVolumeMixerRow["source"];
+};
+
 /**
  * Shared "Who you hear" mixer controller for the in-call surfaces
  * (split + expanded). Both surfaces reach the mixer from the control
- * bar's speaker button (#909), so the row projection, remembered
- * levels, and the LiveKit `setParticipantAudioVolume` apply path live
- * here once instead of being duplicated per surface.
+ * bar's speaker button (#909), so the row projection and the LiveKit
+ * `setParticipantAudioVolume` apply path live here once instead of
+ * being duplicated per surface.
  *
- * `remembered levels` are kept per LiveKit participant+source key so a
- * participant who mutes (dropping their audio track) keeps the volume
- * the user last set, ready to re-apply when they unmute. The remembered
- * state is wiped whenever the active call's SID changes so one call's
- * preferences never bleed into the next.
+ * The remembered levels are module-scoped, not per-component: split
+ * and expanded are two views of ONE call, so a gain set in one must
+ * read back identically in the other. Holding the state in shared
+ * nanostores keeps that single source of truth (and stays resettable
+ * in tests). Levels are keyed per LiveKit participant+source so a
+ * participant who mutes — dropping their audio track — keeps the
+ * volume the user last chose, ready to re-apply when they unmute.
  */
+const $rememberedLevels = atom<CallVolumeLevelStore>({});
+const $rememberedTargets = atom<Record<string, CallVolumeMixerTarget>>({});
+
+// Wipe remembered state whenever the active call's SID changes so one
+// call's preferences never bleed into the next. Subscribed once at
+// module load, independent of how many surfaces are mounted.
+let lastActiveSid: string | null = null;
+$callState.subscribe((state) => {
+  const sid = state.phase === "active" ? state.sid : null;
+  if (sid === lastActiveSid) return;
+  lastActiveSid = sid;
+  $rememberedLevels.set({});
+  $rememberedTargets.set({});
+});
+
 export interface CallVolumeMixerController {
   rows: ComputedRef<CallVolumeMixerRow[]>;
   setVolume: (row: CallVolumeMixerRow, level: number) => void;
@@ -34,13 +57,8 @@ export function useCallVolumeMixer(
 ): CallVolumeMixerController {
   const state = useStore($callState);
   const liveParticipants = useStore($mucCallLiveParticipants);
+  const rememberedLevels = useStore($rememberedLevels);
   const { remoteTracks, engine } = useCallEngine();
-
-  const participantAudioLevels = ref<CallVolumeLevelStore>({});
-  const participantAudioTargets = ref<Record<string, {
-    participantIdentity: string;
-    source: CallVolumeMixerRow["source"];
-  }>>({});
 
   const localIdentity = computed(() => engine.localIdentity);
 
@@ -61,26 +79,19 @@ export function useCallVolumeMixer(
       remoteParticipantIdentities: remoteParticipantIdentities.value,
       remoteTracks: remoteTracks.value,
       localIdentity: localIdentity.value,
-      levels: participantAudioLevels.value,
+      levels: rememberedLevels.value,
     }),
   );
 
-  const activeCallSid = computed(() =>
-    state.value.phase === "active" ? state.value.sid : null,
-  );
-
   function setVolume(row: CallVolumeMixerRow, level: number): void {
-    participantAudioLevels.value = {
-      ...participantAudioLevels.value,
-      [row.key]: level,
-    };
-    participantAudioTargets.value = {
-      ...participantAudioTargets.value,
+    $rememberedLevels.set({ ...$rememberedLevels.get(), [row.key]: level });
+    $rememberedTargets.set({
+      ...$rememberedTargets.get(),
       [row.key]: {
         participantIdentity: row.participantIdentity,
         source: row.source,
       },
-    };
+    });
     engine.setParticipantAudioVolume({
       participantIdentity: row.participantIdentity,
       source: row.source,
@@ -94,7 +105,7 @@ export function useCallVolumeMixer(
     // target without a live row (muted) or a live row without a
     // remembered target (default volume), and "Reset all" must land
     // every audible participant at unity gain.
-    for (const target of Object.values(participantAudioTargets.value)) {
+    for (const target of Object.values($rememberedTargets.get())) {
       engine.setParticipantAudioVolume({
         participantIdentity: target.participantIdentity,
         source: target.source,
@@ -108,13 +119,8 @@ export function useCallVolumeMixer(
         volume: 1,
       });
     }
-    participantAudioLevels.value = resetCallVolumeMixerLevels(participantAudioLevels.value);
+    $rememberedLevels.set(resetCallVolumeMixerLevels($rememberedLevels.get()));
   }
-
-  watch(activeCallSid, () => {
-    participantAudioLevels.value = {};
-    participantAudioTargets.value = {};
-  });
 
   return { rows, setVolume, resetAll };
 }

--- a/chat/tests/call-controls.test.ts
+++ b/chat/tests/call-controls.test.ts
@@ -513,6 +513,39 @@ describe("device-less call controls", () => {
   });
 });
 
+describe("call control bar volume toggle", () => {
+  test("renders an accessible speaker button reflecting the closed mixer state", async () => {
+    const html = await renderCallControls({ volumeOpen: false });
+
+    expect(html).toContain('aria-label="Open volume mixer"');
+    expect(html).toContain('aria-haspopup="dialog"');
+    expect(html).toContain('aria-pressed="false"');
+    expect(html).toContain('aria-expanded="false"');
+  });
+
+  test("reflects the open mixer state on the speaker button", async () => {
+    const html = await renderCallControls({ volumeOpen: true });
+
+    expect(html).toContain('aria-label="Close volume mixer"');
+    expect(html).toContain('aria-pressed="true"');
+    expect(html).toContain('aria-expanded="true"');
+  });
+});
+
+async function renderCallControls(overrides: Record<string, unknown>): Promise<string> {
+  const component = await loadVueComponent("../src/components/calls/CallControls.vue");
+  const props = {
+    micEnabled: true,
+    camEnabled: true,
+    screenShareEnabled: false,
+    screenShareSupported: true,
+    isExpanded: false,
+    volumeOpen: false,
+    ...overrides,
+  };
+  return renderToString(createSSRApp({ render: () => h(component, props) }));
+}
+
 async function renderVueComponent(component: unknown): Promise<string> {
   return renderToString(createSSRApp({ render: () => h(component as never) }));
 }

--- a/chat/tests/call-volume-mixer-dialog.test.ts
+++ b/chat/tests/call-volume-mixer-dialog.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { createRequire } from "node:module";
+import { createSSRApp, h } from "vue";
+import { renderToString } from "vue/server-renderer";
+import { parse, compileScript } from "vue/compiler-sfc";
+import ts from "typescript";
+import { buildCallVolumeMixerRows } from "../src/lib/calls/call-volume-mixer";
+
+const require = createRequire(import.meta.url);
+const fakeTrack = {} as never;
+
+describe("CallVolumeMixerDialog", () => {
+  test("renders the volume mixer panel and an accessible close control when open", async () => {
+    const rows = buildCallVolumeMixerRows({
+      remoteParticipantIdentities: ["alice@waddle.test/web"],
+      remoteTracks: [remoteAudio("alice-mic", "alice@waddle.test/web", "microphone")],
+      localIdentity: "me@waddle.test/browser",
+      levels: { "alice@waddle.test/web:microphone": 0.5 },
+    });
+
+    const html = await renderVueComponent("../src/components/calls/CallVolumeMixerDialog.vue", {
+      open: true,
+      rows,
+      "onUpdate:open": () => undefined,
+    });
+
+    expect(html).toContain("Who you hear");
+    expect(html).toContain("alice");
+    expect(html).toContain('aria-label="Volume for alice"');
+    expect(html).toContain('aria-label="Close volume mixer"');
+    expect(html).toContain("Reset all");
+  });
+
+  test("forwards the panel's set-volume and reset-all events to the parent", () => {
+    const source = readFileSync(
+      new URL("../src/components/calls/CallVolumeMixerDialog.vue", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).toContain("@set-volume");
+    expect(source).toContain("@reset-all");
+    expect(source).toContain("emit(\"setVolume\"");
+    expect(source).toContain("emit(\"resetAll\")");
+  });
+});
+
+function remoteAudio(
+  publicationSid: string,
+  participantIdentity: string,
+  source: "microphone" | "screen_share_audio",
+) {
+  return {
+    participantIdentity,
+    publicationSid,
+    kind: "audio" as const,
+    source,
+    track: fakeTrack,
+  };
+}
+
+async function renderVueComponent(path: string, props: Record<string, unknown>): Promise<string> {
+  const component = await loadVueComponent(path);
+  return renderToString(createSSRApp({ render: () => h(component, props) }));
+}
+
+async function loadVueComponent(path: string) {
+  const filename = new URL(path, import.meta.url);
+  const tempDir = mkdtempSync(join(tmpdir(), "waddle-call-volume-mixer-dialog-"));
+  try {
+    const modulePath = compileVueModule(filename, tempDir, new Map());
+    const component = await import(pathToFileURL(modulePath).href);
+    return component.default;
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function compileVueModule(filename: URL, tempDir: string, cache: Map<string, string>): string {
+  const cached = cache.get(filename.pathname);
+  if (cached) return cached;
+  const modulePath = join(tempDir, `${cache.size}.mjs`);
+  cache.set(filename.pathname, modulePath);
+
+  const source = readFileSync(filename, "utf8");
+  const { descriptor } = parse(source, { filename: filename.pathname });
+  const script = compileScript(descriptor, {
+    id: filename.pathname,
+    inlineTemplate: true,
+  });
+  const compiled = [
+    rewriteImports(script.content.replace("export default", "const __sfc__ ="), filename, tempDir, cache),
+    "export default __sfc__;",
+  ].join("\n");
+  const js = ts.transpileModule(compiled, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2022,
+      verbatimModuleSyntax: false,
+    },
+  }).outputText;
+  writeFileSync(modulePath, js);
+  return modulePath;
+}
+
+function rewriteImports(
+  code: string,
+  importer: URL,
+  tempDir: string,
+  cache: Map<string, string>,
+): string {
+  return code
+    .replace(/^(\s*import\b(?:(?!;)[\s\S])*?\s+from\s+)["']([^"']+)["']/gm, (
+      _match,
+      prefix: string,
+      specifier: string,
+    ) =>
+      `${prefix}${JSON.stringify(resolveModuleSpecifier(specifier, importer, tempDir, cache))}`)
+    .replace(/^(\s*export\b(?:(?!;)[\s\S])*?\s+from\s+)["']([^"']+)["']/gm, (
+      _match,
+      prefix: string,
+      specifier: string,
+    ) =>
+      `${prefix}${JSON.stringify(resolveModuleSpecifier(specifier, importer, tempDir, cache))}`);
+}
+
+function resolveModuleSpecifier(
+  specifier: string,
+  importer: URL,
+  tempDir: string,
+  cache: Map<string, string>,
+): string {
+  if (specifier.startsWith("@/") && specifier.endsWith(".vue")) {
+    if (specifier === "@/components/ui/AppDialog.vue") {
+      return pathToFileURL(writeAppDialogStub(tempDir)).href;
+    }
+    return pathToFileURL(compileVueModule(resolveImportUrl(specifier, importer), tempDir, cache)).href;
+  }
+  if (specifier.endsWith(".vue")) {
+    return pathToFileURL(compileVueModule(resolveImportUrl(specifier, importer), tempDir, cache)).href;
+  }
+  if (specifier.startsWith("@/")) {
+    return new URL(`../src/${specifier.slice(2)}`, import.meta.url).href;
+  }
+  if (specifier.startsWith(".")) {
+    return new URL(specifier, importer).href;
+  }
+  return require.resolve(specifier);
+}
+
+function writeAppDialogStub(tempDir: string): string {
+  const modulePath = join(tempDir, "AppDialogStub.mjs");
+  writeFileSync(
+    modulePath,
+    [
+      `import { defineComponent, h } from ${JSON.stringify(require.resolve("vue"))};`,
+      "export default defineComponent({",
+      "  props: { open: { type: Boolean, default: false } },",
+      "  setup(props, { slots }) {",
+      "    return () => (props.open ? h('div', { role: 'dialog' }, slots.default?.()) : null);",
+      "  },",
+      "});",
+    ].join("\n"),
+  );
+  return modulePath;
+}
+
+function resolveImportUrl(specifier: string, importer: URL): URL {
+  if (specifier.startsWith("@/")) {
+    return new URL(`../src/${specifier.slice(2)}`, import.meta.url);
+  }
+  return new URL(specifier, importer);
+}

--- a/chat/tests/call-volume-mixer.test.ts
+++ b/chat/tests/call-volume-mixer.test.ts
@@ -341,7 +341,7 @@ describe("call volume mixer panel", () => {
 });
 
 describe("call volume mixer controller apply path", () => {
-  const join = {
+  const callJoin = {
     url: "wss://livekit.test",
     room: "bob@waddle.test::c1",
     identity: "me@waddle.test/browser",
@@ -380,11 +380,15 @@ describe("call volume mixer controller apply path", () => {
 
       captured.calls.length = 0;
       controller.resetAll();
-      expect(captured.calls).toContainEqual({
-        participantIdentity: "bob@waddle.test/desktop",
-        source: "microphone",
-        volume: 1,
-      });
+      // bob is both a remembered target and a projected DM row, but
+      // reset-all must touch the engine once per participant, not twice.
+      expect(captured.calls).toEqual([
+        {
+          participantIdentity: "bob@waddle.test/desktop",
+          source: "microphone",
+          volume: 1,
+        },
+      ]);
     } finally {
       scope.stop();
       captured.restore();
@@ -446,7 +450,7 @@ describe("call volume mixer controller apply path", () => {
       peer: "bob@waddle.test/desktop",
       sid,
       media: { audio: true, video: false },
-      join,
+      join: callJoin,
       kind: "dm",
     });
   }
@@ -457,7 +461,7 @@ describe("call volume mixer controller apply path", () => {
       peer: "room@muc.waddle.test",
       sid,
       media: { audio: true, video: false },
-      join: { ...join, room: "room@muc.waddle.test" },
+      join: { ...callJoin, room: "room@muc.waddle.test" },
       kind: "muc",
       selfNick: "me",
       selfFullJid: "me@waddle.test/browser",
@@ -518,6 +522,9 @@ describe("call volume mixer controller wiring", () => {
     const guard = expanded.slice(start, expanded.indexOf("collapseToSplit()", start));
     expect(guard).toContain("settingsOpen.value");
     expect(guard).toContain("volumeOpen.value");
+    // Capture phase so the guard sees the still-open flag before
+    // AppDialog's bubble-phase Escape flips the v-model to false.
+    expect(expanded).toContain('window.addEventListener("keydown", onKeydown, true)');
   });
 });
 

--- a/chat/tests/call-volume-mixer.test.ts
+++ b/chat/tests/call-volume-mixer.test.ts
@@ -337,10 +337,10 @@ describe("call volume mixer panel", () => {
   });
 });
 
-describe("expanded call mixer wiring", () => {
+describe("call volume mixer controller wiring", () => {
   test("clears remembered levels on call changes and resets absent engine targets", () => {
     const source = readFileSync(
-      new URL("../src/components/calls/CallExpandedSurface.vue", import.meta.url),
+      new URL("../src/lib/calls/use-call-volume-mixer.ts", import.meta.url),
       "utf8",
     );
 
@@ -348,6 +348,60 @@ describe("expanded call mixer wiring", () => {
     expect(source).toContain("watch(activeCallSid");
     expect(source).toContain("participantAudioTargets.value = {}");
     expect(source).toContain("for (const target of Object.values(participantAudioTargets.value))");
+  });
+
+  test("shares one mixer controller across both call surfaces", () => {
+    const split = readFileSync(
+      new URL("../src/components/calls/CallSplitContainer.vue", import.meta.url),
+      "utf8",
+    );
+    const expanded = readFileSync(
+      new URL("../src/components/calls/CallExpandedSurface.vue", import.meta.url),
+      "utf8",
+    );
+
+    for (const source of [split, expanded]) {
+      expect(source).toContain("useCallVolumeMixer");
+    }
+  });
+
+  test("both surfaces toggle the mixer dialog from the control bar speaker button", () => {
+    const split = readFileSync(
+      new URL("../src/components/calls/CallSplitContainer.vue", import.meta.url),
+      "utf8",
+    );
+    const expanded = readFileSync(
+      new URL("../src/components/calls/CallExpandedSurface.vue", import.meta.url),
+      "utf8",
+    );
+
+    for (const source of [split, expanded]) {
+      expect(source).toContain("CallVolumeMixerDialog");
+      expect(source).toContain(":volume-open=\"volumeOpen\"");
+      expect(source).toContain("@toggle-volume=\"volumeOpen = !volumeOpen\"");
+      expect(source).toContain("v-model:open=\"volumeOpen\"");
+    }
+  });
+
+  test("expanded surface drops the always-on sidebar in favour of the toggle dialog", () => {
+    const expanded = readFileSync(
+      new URL("../src/components/calls/CallExpandedSurface.vue", import.meta.url),
+      "utf8",
+    );
+
+    expect(expanded).not.toContain("CallVolumeMixerPanel");
+  });
+
+  test("expanded Escape stays on the dialog instead of collapsing the call", () => {
+    const expanded = readFileSync(
+      new URL("../src/components/calls/CallExpandedSurface.vue", import.meta.url),
+      "utf8",
+    );
+
+    const start = expanded.indexOf("function onKeydown");
+    const guard = expanded.slice(start, expanded.indexOf("collapseToSplit()", start));
+    expect(guard).toContain("settingsOpen.value");
+    expect(guard).toContain("volumeOpen.value");
   });
 });
 

--- a/chat/tests/call-volume-mixer.test.ts
+++ b/chat/tests/call-volume-mixer.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { createRequire } from "node:module";
-import { createSSRApp, h } from "vue";
+import { computed, createSSRApp, effectScope, h } from "vue";
 import { renderToString } from "vue/server-renderer";
 import { parse, compileScript } from "vue/compiler-sfc";
 import ts from "typescript";
@@ -14,6 +14,9 @@ import {
   resetCallVolumeMixerLevels,
   type CallVolumeLevelStore,
 } from "../src/lib/calls/call-volume-mixer";
+import { useCallVolumeMixer } from "../src/lib/calls/use-call-volume-mixer";
+import { useCallEngine } from "../src/lib/calls/use-call-engine";
+import { $callState, clearCallState } from "../src/lib/calls/call-store";
 
 const fakeTrack = {} as never;
 const require = createRequire(import.meta.url);
@@ -337,19 +340,132 @@ describe("call volume mixer panel", () => {
   });
 });
 
-describe("call volume mixer controller wiring", () => {
-  test("clears remembered levels on call changes and resets absent engine targets", () => {
-    const source = readFileSync(
-      new URL("../src/lib/calls/use-call-volume-mixer.ts", import.meta.url),
-      "utf8",
-    );
+describe("call volume mixer controller apply path", () => {
+  const join = {
+    url: "wss://livekit.test",
+    room: "bob@waddle.test::c1",
+    identity: "me@waddle.test/browser",
+    token: "jwt",
+  };
 
-    expect(source).toContain("const activeCallSid = computed");
-    expect(source).toContain("watch(activeCallSid");
-    expect(source).toContain("participantAudioTargets.value = {}");
-    expect(source).toContain("for (const target of Object.values(participantAudioTargets.value))");
+  afterEach(() => {
+    // Idle resets the module-scoped remembered levels via the
+    // controller's own SID-change subscription, isolating each test.
+    clearCallState();
   });
 
+  test("setVolume applies the chosen gain to the engine and resetAll returns it to unity", () => {
+    const captured = captureEngineVolumeCalls();
+    const scope = effectScope();
+    try {
+      activateDmCall("c1");
+      let controller!: ReturnType<typeof useCallVolumeMixer>;
+      scope.run(() => {
+        controller = useCallVolumeMixer(computed(() => ""));
+      });
+
+      controller.setVolume(
+        mixerRow({
+          key: "bob@waddle.test/desktop:microphone",
+          participantIdentity: "bob@waddle.test/desktop",
+          source: "microphone",
+        }),
+        0.5,
+      );
+      expect(captured.calls).toContainEqual({
+        participantIdentity: "bob@waddle.test/desktop",
+        source: "microphone",
+        volume: 0.5,
+      });
+
+      captured.calls.length = 0;
+      controller.resetAll();
+      expect(captured.calls).toContainEqual({
+        participantIdentity: "bob@waddle.test/desktop",
+        source: "microphone",
+        volume: 1,
+      });
+    } finally {
+      scope.stop();
+      captured.restore();
+    }
+  });
+
+  test("remembered gain is shared across surfaces and wiped when the call SID changes", () => {
+    const captured = captureEngineVolumeCalls();
+    const splitScope = effectScope();
+    const expandedScope = effectScope();
+    const bob = mixerRow({
+      key: "bob@waddle.test/desktop:microphone",
+      participantIdentity: "bob@waddle.test/desktop",
+      source: "microphone",
+    });
+    try {
+      // A MUC call with no live participants projects no rows, so
+      // reset-all touches the engine only via the remembered targets —
+      // isolating the shared cross-surface state from row projection.
+      activateMucCall("c1");
+      let split!: ReturnType<typeof useCallVolumeMixer>;
+      let expanded!: ReturnType<typeof useCallVolumeMixer>;
+      splitScope.run(() => {
+        split = useCallVolumeMixer(computed(() => "room@muc.waddle.test"));
+      });
+      expandedScope.run(() => {
+        expanded = useCallVolumeMixer(computed(() => "room@muc.waddle.test"));
+      });
+
+      // A gain set from the split surface is remembered in shared state,
+      // so reset-all from the EXPANDED surface returns that same target
+      // to unity — one source of truth across both surfaces.
+      split.setVolume(bob, 0.5);
+      captured.calls.length = 0;
+      expanded.resetAll();
+      expect(captured.calls).toContainEqual({
+        participantIdentity: "bob@waddle.test/desktop",
+        source: "microphone",
+        volume: 1,
+      });
+
+      // Switching to a different call forgets the remembered target:
+      // reset-all from either surface now touches nothing.
+      split.setVolume(bob, 0.5);
+      activateMucCall("c2");
+      captured.calls.length = 0;
+      expanded.resetAll();
+      expect(captured.calls).toEqual([]);
+    } finally {
+      splitScope.stop();
+      expandedScope.stop();
+      captured.restore();
+    }
+  });
+
+  function activateDmCall(sid: string): void {
+    $callState.set({
+      phase: "active",
+      peer: "bob@waddle.test/desktop",
+      sid,
+      media: { audio: true, video: false },
+      join,
+      kind: "dm",
+    });
+  }
+
+  function activateMucCall(sid: string): void {
+    $callState.set({
+      phase: "active",
+      peer: "room@muc.waddle.test",
+      sid,
+      media: { audio: true, video: false },
+      join: { ...join, room: "room@muc.waddle.test" },
+      kind: "muc",
+      selfNick: "me",
+      selfFullJid: "me@waddle.test/browser",
+    });
+  }
+});
+
+describe("call volume mixer controller wiring", () => {
   test("shares one mixer controller across both call surfaces", () => {
     const split = readFileSync(
       new URL("../src/components/calls/CallSplitContainer.vue", import.meta.url),
@@ -499,6 +615,28 @@ async function loadVueComponentScript(path: string) {
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }
+}
+
+function captureEngineVolumeCalls() {
+  const { engine } = useCallEngine();
+  const calls: Array<{ participantIdentity: string; source: string; volume: number }> = [];
+  const target = engine as unknown as {
+    setParticipantAudioVolume: (input: {
+      participantIdentity: string;
+      source: string;
+      volume: number;
+    }) => void;
+  };
+  const original = target.setParticipantAudioVolume;
+  target.setParticipantAudioVolume = (input) => {
+    calls.push(input);
+  };
+  return {
+    calls,
+    restore() {
+      target.setParticipantAudioVolume = original;
+    },
+  };
 }
 
 function mixerRow(overrides: Partial<CallVolumeMixerRow>): CallVolumeMixerRow {


### PR DESCRIPTION
## What & why

Closes #909. Adds an explicit speaker/volume control to the call control bar that opens (and closes) the volume mixer, making volume controls reachable from **both** call surfaces (split + expanded) and in both DM and MUC calls — without first expanding the call. This closes the last UX gap from the #898 tracer bullet, whose spec was "a speaker button on the call control bar opens a mixer panel" (what shipped was a persistent inline sidebar in the expanded surface only).

Purely local playback/UI — nothing on the XMPP wire, no XEP, no server change.

## Decisions (per the issue)

- **Expanded-surface behavior: unified.** The always-on "Who you hear" sidebar is removed from the expanded surface; both surfaces now open the same mixer via the new control-bar speaker button. One consistent entry point, matching #898's original spec.
- **Presentation: modal dialog.** The mixer opens in `AppDialog`, consistent with `CallSettingsDialog` (same backdrop blur, Esc-to-close, focus model).

## What changed

1. **`CallControls.vue`** — new stateless speaker/volume toggle button (`Volume2`) with a `volumeOpen` prop and `toggleVolume` emit. Exposes `aria-label` (Open/Close volume mixer), `aria-pressed`, `aria-expanded`, `aria-haspopup="dialog"`; it's a native `<button>`, so keyboard-operable.
2. **`CallVolumeMixerDialog.vue`** (new) — wraps the existing `CallVolumeMixerPanel` (reused unchanged) in `AppDialog`, `v-model:open`, forwarding `setVolume`/`resetAll`, with an accessible close control. A scoped `:deep` override lets the sidebar-shaped panel fill the modal without forking it.
3. **`useCallVolumeMixer` composable** (new) — the mixer wiring (row projection, the LiveKit `setParticipantAudioVolume` apply path, reset-all, per-call-SID reset) extracted out of `CallExpandedSurface` and shared by both surfaces. The remembered levels/targets live in **module-scoped nanostores** so split and expanded read one source of truth — a gain set in one surface reads back identically in the other — wiped on call-SID change via a single subscription.
4. **Both surfaces** wire the speaker button to a `volumeOpen` ref and mount the dialog. The expanded surface drops its inline sidebar (and the now-dead responsive CSS), and its window-level Escape handler now dismisses an open dialog instead of collapsing the whole call out from under it.

## Tests

- `CallControls` SSR-renders the speaker button with the correct accessible label and `aria-pressed`/`aria-expanded`/`aria-haspopup` in both open and closed states.
- `CallVolumeMixerDialog` mounts the panel + an accessible close when open and forwards the panel's events.
- Surface wiring: both surfaces toggle the dialog from the speaker button; the expanded surface no longer mounts the inline sidebar; the Escape handler is guarded by the open dialogs.
- `useCallVolumeMixer` behavioral tests: the `setVolume` apply path hits the engine, `resetAll` returns targets to unity, remembered gain is shared across surfaces, and call-SID changes wipe it.
- `bun test` (1820 pass), `astro check` (0 errors), and `bun run lint`/knip all green.

## Review

Reviewed by three adversarial personas (a11y/UX, Vue correctness, standards/spec) plus a final gate review. The one substantive finding — split and expanded each holding independent mixer state, causing the slider to show the wrong gain after switching surfaces — was fixed by the shared module-scoped store above, and re-verified.

### Deferred (pre-existing `AppDialog` limitations, out of scope)

`AppDialog` has no focus-trap / focus-into-dialog and its Escape only fires when focus is already inside; it also carries no `aria-labelledby`/accessible name. These affect the already-shipped `CallSettingsDialog` identically and are not introduced here; this PR reuses the same component faithfully. Worth a follow-up to harden `AppDialog` a11y for all consumers (which would also give the split surface a focus-independent Escape).

## Acceptance criteria

- [x] Speaker/volume button on the control bar in both split and expanded surfaces.
- [x] Activating opens the mixer; activating again / dismissing closes it.
- [x] Available in both DM and MUC calls.
- [x] Volume reachable without expanding the call.
- [x] Accessible label + open/closed state + keyboard operable.
- [x] No regression to mixer rows, sliders, percentage readout, reset-all, or the LiveKit `setVolume` apply path.
- [x] `bun test` and `bun run lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
