### PR TITLE
feat(chat): verify call noise cancellation is actually applied

### DIFF
--- a/chat/src/components/calls/CallSettingsDialog.vue
+++ b/chat/src/components/calls/CallSettingsDialog.vue
@@ -224,8 +224,8 @@ function close(): void {
             v-if="micProcessing.kind === 'no-mic'"
             class="type-caption text-muted-foreground"
           >
-            No microphone active — enable your mic to verify noise
-            cancellation.
+            No microphone active — enable your mic to verify audio
+            processing.
           </p>
           <ul v-else class="call-processing__list">
             <li

--- a/chat/src/components/calls/CallSettingsDialog.vue
+++ b/chat/src/components/calls/CallSettingsDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 import { useStore } from "@nanostores/vue";
 import { Check, Mic, Speaker, Video, X } from "lucide-vue-next";
 import AppDialog from "@/components/ui/AppDialog.vue";
@@ -12,6 +12,8 @@ import {
   setSpeakerDevice,
   type EnumeratedDevices,
 } from "@/lib/calls/device-prefs";
+import { $micAudioProcessing } from "@/lib/calls/mic-audio-processing-state";
+import { audioProcessingRows } from "@/lib/calls/mic-audio-processing";
 import { useCallEngine } from "@/lib/calls/use-call-engine";
 import { reportCallError } from "@/lib/calls/call-store";
 
@@ -35,6 +37,16 @@ const open = defineModel<boolean>("open", { required: true });
 const prefs = useStore($devicePrefs);
 const devices = ref<EnumeratedDevices>({ mics: [], cams: [], speakers: [] });
 const speakerSupported = ref(isSpeakerOutputSelectionSupported());
+
+/**
+ * Verified (applied) browser-native audio processing of the local mic.
+ * `no-mic` renders a single neutral line; an active mic renders the
+ * tiered noise-cancellation / echo / auto-gain readout.
+ */
+const micProcessing = useStore($micAudioProcessing);
+const processingRows = computed(() =>
+  micProcessing.value.kind === "active" ? audioProcessingRows(micProcessing.value) : [],
+);
 
 /**
  * Epoch counter incremented on every dialog close. `refresh()` reads
@@ -203,6 +215,42 @@ function close(): void {
             </button>
           </li>
         </ul>
+
+        <!-- Read-only verification of the audio processing the browser
+             actually applied to the live mic (not what we requested). -->
+        <div class="call-processing">
+          <h4 class="type-caption call-processing__title">Audio processing</h4>
+          <p
+            v-if="micProcessing.kind === 'no-mic'"
+            class="type-caption text-muted-foreground"
+          >
+            No microphone active — enable your mic to verify noise
+            cancellation.
+          </p>
+          <ul v-else class="call-processing__list">
+            <li
+              v-for="row in processingRows"
+              :key="row.key"
+              class="call-processing__row"
+            >
+              <div class="call-processing__head">
+                <span class="type-caption">{{ row.label }}</span>
+                <span
+                  class="call-processing__badge"
+                  :class="`call-processing__badge--${row.tone}`"
+                >
+                  {{ row.stateLabel }}
+                </span>
+              </div>
+              <p
+                v-if="row.detail"
+                class="type-caption text-muted-foreground call-processing__detail"
+              >
+                {{ row.detail }}
+              </p>
+            </li>
+          </ul>
+        </div>
       </section>
 
       <!-- Camera -->
@@ -327,5 +375,66 @@ function close(): void {
 .call-device-row--active {
   background: color-mix(in oklab, var(--primary) 12%, transparent);
   color: var(--foreground);
+}
+
+.call-processing {
+  margin-top: var(--space-sm);
+  padding-top: var(--space-sm);
+  border-top: 1px solid var(--muted);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.call-processing__title {
+  color: var(--muted-foreground);
+}
+
+.call-processing__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.call-processing__row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.call-processing__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+}
+
+.call-processing__badge {
+  border-radius: var(--radius-sm);
+  padding: 0.0625rem 0.5rem;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+/* On — calm positive: the requested processing is confirmed applied. */
+.call-processing__badge--on {
+  background: color-mix(in oklab, var(--success) 16%, transparent);
+  color: var(--success-foreground);
+}
+
+/* Off — a genuine degradation the browser reported; worth noticing. */
+.call-processing__badge--warn {
+  background: color-mix(in oklab, var(--warning) 20%, transparent);
+  color: var(--warning-foreground);
+}
+
+/* Unknown — browser doesn't report it; muted, neither pass nor fail. */
+.call-processing__badge--muted {
+  background: var(--muted);
+  color: var(--muted-foreground);
+}
+
+.call-processing__detail {
+  line-height: 1.3;
 }
 </style>

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -12,6 +12,7 @@ import {
 import type { LiveKitJoin } from "./types";
 import { $devicePrefs } from "./device-prefs";
 import { validateLiveKitGrant } from "./dm-call-activity";
+import { activeMicAudioProcessing, type MicAudioProcessing } from "./mic-audio-processing";
 
 /**
  * Identifies a remote media track surfaced to the UI. The `kind`
@@ -123,6 +124,15 @@ export type CallEngineEvents = {
    * `RoomEvent.MediaDevicesError` but carries which capture failed.
    */
   mediaDevicesError: (info: { source: "audio" | "video"; error: unknown }) => void;
+  /**
+   * Fires when the *applied* browser-native audio processing of the
+   * local mic changes — on mic publish, unpublish, or a mid-call mic
+   * device switch. Carries the verified state (read from the live
+   * track's `getSettings()`), NOT the requested constraints, so the UI
+   * can show whether noise suppression / echo cancellation / auto gain
+   * were actually honored. See `mic-audio-processing.ts`.
+   */
+  micAudioProcessingChanged: (state: MicAudioProcessing) => void;
 };
 
 /**
@@ -149,6 +159,7 @@ export class CallEngine {
     disconnected: new Set(),
     audioPlaybackStatusChanged: new Set(),
     mediaDevicesError: new Set(),
+    micAudioProcessingChanged: new Set(),
   };
 
   /** LiveKit identity of the local participant, populated once
@@ -179,6 +190,17 @@ export class CallEngine {
 
   get canPlaybackAudio(): boolean {
     return this.room?.canPlaybackAudio ?? true;
+  }
+
+  /**
+   * The *applied* browser-native audio processing of the local mic right
+   * now, read from the live capture track. `no-mic` when no mic is
+   * publishing (listener / muted-and-stopped / pre-connect). Lets a
+   * late subscriber seed its view without waiting for the next
+   * `micAudioProcessingChanged` emit.
+   */
+  get micAudioProcessing(): MicAudioProcessing {
+    return this.computeMicAudioProcessing();
   }
 
   async connect(join: LiveKitJoin, opts: { audio: boolean; video: boolean }): Promise<void> {
@@ -215,6 +237,7 @@ export class CallEngine {
     room.on(RoomEvent.ParticipantDisconnected, this.handleParticipantDisconnected);
     room.on(RoomEvent.Disconnected, this.handleDisconnected);
     room.on(RoomEvent.AudioPlaybackStatusChanged, this.handleAudioPlaybackStatusChanged);
+    room.on(RoomEvent.ActiveDeviceChanged, this.handleActiveDeviceChanged);
     try {
       await room.connect(join.url, join.token);
     } catch (err) {
@@ -356,6 +379,7 @@ export class CallEngine {
     room.off(RoomEvent.ParticipantDisconnected, this.handleParticipantDisconnected);
     room.off(RoomEvent.Disconnected, this.handleDisconnected);
     room.off(RoomEvent.AudioPlaybackStatusChanged, this.handleAudioPlaybackStatusChanged);
+    room.off(RoomEvent.ActiveDeviceChanged, this.handleActiveDeviceChanged);
     await room.disconnect();
   }
 
@@ -427,13 +451,19 @@ export class CallEngine {
     const track = publication.track;
     const kind = mapKind(publication.kind);
     if (!track || !kind) return;
+    const source = mapTrackSource(publication.source, kind);
     this.emit("localTrackPublished", {
       participantIdentity: participant.identity,
       publicationSid: publication.trackSid,
       kind,
-      source: mapTrackSource(publication.source, kind),
+      source,
       track,
     });
+    // The local mic just started capturing: surface its *applied*
+    // audio processing now that `getSettings()` reflects the real
+    // constraints the browser honored (which can differ from what we
+    // requested in `audioCaptureDefaults`).
+    if (source === "microphone") this.emitMicAudioProcessing();
   };
 
   private handleLocalTrackUnpublished = (
@@ -443,13 +473,17 @@ export class CallEngine {
     const track = publication.track;
     const kind = mapKind(publication.kind);
     if (!track || !kind) return;
+    const source = mapTrackSource(publication.source, kind);
     this.emit("localTrackUnpublished", {
       participantIdentity: participant.identity,
       publicationSid: publication.trackSid,
       kind,
-      source: mapTrackSource(publication.source, kind),
+      source,
       track,
     });
+    // The mic is gone (unpublished / stopped): recompute so the
+    // indicator falls back to `no-mic` instead of holding a stale trio.
+    if (source === "microphone") this.emitMicAudioProcessing();
   };
 
   private handleParticipantConnected = (participant: RemoteParticipant) => {
@@ -469,6 +503,40 @@ export class CallEngine {
   private handleAudioPlaybackStatusChanged = (canPlaybackAudio: boolean) => {
     this.emit("audioPlaybackStatusChanged", canPlaybackAudio);
   };
+
+  /**
+   * A mid-call device switch swaps the underlying capture track in
+   * place via `switchActiveDevice` — it does NOT re-fire
+   * `LocalTrackPublished`, so this is the only signal that the applied
+   * audio processing may have changed (a new mic can support a
+   * different set of constraints). Only `audioinput` matters; speaker /
+   * camera changes can't alter mic processing.
+   */
+  private handleActiveDeviceChanged = (kind: MediaDeviceKind) => {
+    if (kind !== "audioinput") return;
+    this.emitMicAudioProcessing();
+  };
+
+  /**
+   * Read the *applied* audio processing of the local mic from its live
+   * capture track. `no-mic` when nothing is publishing or the track has
+   * already ended (e.g. the mic was stopped on mute), so the indicator
+   * never reports a trio for a track that isn't actually capturing.
+   */
+  private computeMicAudioProcessing(): MicAudioProcessing {
+    const room = this.room;
+    if (!room) return { kind: "no-mic" };
+    const publication = room.localParticipant.getTrackPublication(Track.Source.Microphone);
+    const mediaStreamTrack = publication?.track?.mediaStreamTrack;
+    if (!mediaStreamTrack || mediaStreamTrack.readyState !== "live") {
+      return { kind: "no-mic" };
+    }
+    return activeMicAudioProcessing(mediaStreamTrack.getSettings());
+  }
+
+  private emitMicAudioProcessing(): void {
+    this.emit("micAudioProcessingChanged", this.computeMicAudioProcessing());
+  }
 
   private clearParticipantAudioVolumes(): void {
     this.participantAudioVolumes = {};

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -5,9 +5,11 @@ import {
   type LocalParticipant,
   type LocalTrack,
   type LocalTrackPublication,
+  type Participant,
   type RemoteParticipant,
   type RemoteTrack,
   type RemoteTrackPublication,
+  type TrackPublication,
 } from "livekit-client";
 import type { LiveKitJoin } from "./types";
 import { $devicePrefs } from "./device-prefs";
@@ -227,6 +229,8 @@ export class CallEngine {
     room.on(RoomEvent.Disconnected, this.handleDisconnected);
     room.on(RoomEvent.AudioPlaybackStatusChanged, this.handleAudioPlaybackStatusChanged);
     room.on(RoomEvent.ActiveDeviceChanged, this.handleActiveDeviceChanged);
+    room.on(RoomEvent.TrackMuted, this.handleTrackMuteChanged);
+    room.on(RoomEvent.TrackUnmuted, this.handleTrackMuteChanged);
     try {
       await room.connect(join.url, join.token);
     } catch (err) {
@@ -369,6 +373,8 @@ export class CallEngine {
     room.off(RoomEvent.Disconnected, this.handleDisconnected);
     room.off(RoomEvent.AudioPlaybackStatusChanged, this.handleAudioPlaybackStatusChanged);
     room.off(RoomEvent.ActiveDeviceChanged, this.handleActiveDeviceChanged);
+    room.off(RoomEvent.TrackMuted, this.handleTrackMuteChanged);
+    room.off(RoomEvent.TrackUnmuted, this.handleTrackMuteChanged);
     await room.disconnect();
   }
 
@@ -507,16 +513,37 @@ export class CallEngine {
   };
 
   /**
+   * Recompute when the local mic is muted or unmuted. Muting is the most
+   * common mic transition, and with LiveKit's default
+   * `stopMicTrackOnMute: false` it neither unpublishes nor ends the
+   * capture track — so without this listener the indicator would keep
+   * showing a stale trio for a mic that isn't capturing. Fires for
+   * remote tracks too, hence the local-mic filter.
+   */
+  private handleTrackMuteChanged = (
+    publication: TrackPublication,
+    participant: Participant,
+  ) => {
+    if (!participant.isLocal) return;
+    if (publication.source !== Track.Source.Microphone) return;
+    this.emitMicAudioProcessing();
+  };
+
+  /**
    * Read the *applied* audio processing of the local mic from its live
-   * capture track. `no-mic` when nothing is publishing or the track has
-   * already ended (e.g. the mic was stopped on mute), so the indicator
-   * never reports a trio for a track that isn't actually capturing.
+   * capture track. `no-mic` when nothing is publishing, the mic is muted,
+   * or the track has ended (e.g. the device was unplugged) — so the
+   * indicator never reports a trio for a mic that isn't actually
+   * capturing. A muted mic must be checked explicitly: LiveKit's default
+   * `stopMicTrackOnMute: false` leaves the underlying track `live` while
+   * muted, so the `readyState` guard alone would miss it.
    */
   private computeMicAudioProcessing(): MicAudioProcessing {
     const room = this.room;
     if (!room) return { kind: "no-mic" };
     const publication = room.localParticipant.getTrackPublication(Track.Source.Microphone);
-    const mediaStreamTrack = publication?.track?.mediaStreamTrack;
+    if (!publication || publication.isMuted) return { kind: "no-mic" };
+    const mediaStreamTrack = publication.track?.mediaStreamTrack;
     if (!mediaStreamTrack || mediaStreamTrack.readyState !== "live") {
       return { kind: "no-mic" };
     }

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -465,20 +465,25 @@ export class CallEngine {
     publication: LocalTrackPublication,
     participant: LocalParticipant,
   ) => {
+    // Recompute the mic-processing readout FIRST, decoupled from the
+    // track-dependent event below. LiveKit can deliver an unpublish whose
+    // `publication.track` is already detached (the underlying
+    // MediaStreamTrack ended before the event fired); the `!track` guard
+    // would then skip the reset and leave the indicator on a stale trio
+    // for a mic that is gone. `computeMicAudioProcessing` reads the
+    // participant's current mic publication, not this argument, so it is
+    // safe without `track` and correctly falls back to `no-mic`.
+    if (publication.source === Track.Source.Microphone) this.emitMicAudioProcessing();
     const track = publication.track;
     const kind = mapKind(publication.kind);
     if (!track || !kind) return;
-    const source = mapTrackSource(publication.source, kind);
     this.emit("localTrackUnpublished", {
       participantIdentity: participant.identity,
       publicationSid: publication.trackSid,
       kind,
-      source,
+      source: mapTrackSource(publication.source, kind),
       track,
     });
-    // The mic is gone (unpublished / stopped): recompute so the
-    // indicator falls back to `no-mic` instead of holding a stale trio.
-    if (source === "microphone") this.emitMicAudioProcessing();
   };
 
   private handleParticipantConnected = (participant: RemoteParticipant) => {

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -192,17 +192,6 @@ export class CallEngine {
     return this.room?.canPlaybackAudio ?? true;
   }
 
-  /**
-   * The *applied* browser-native audio processing of the local mic right
-   * now, read from the live capture track. `no-mic` when no mic is
-   * publishing (listener / muted-and-stopped / pre-connect). Lets a
-   * late subscriber seed its view without waiting for the next
-   * `micAudioProcessingChanged` emit.
-   */
-  get micAudioProcessing(): MicAudioProcessing {
-    return this.computeMicAudioProcessing();
-  }
-
   async connect(join: LiveKitJoin, opts: { audio: boolean; video: boolean }): Promise<void> {
     if (this.room) throw new Error("CallEngine already connected");
     // Defensive pre-flight: confirm the JWT actually carries a usable

--- a/chat/src/lib/calls/mic-audio-processing-state.ts
+++ b/chat/src/lib/calls/mic-audio-processing-state.ts
@@ -1,0 +1,22 @@
+import { atom } from "nanostores";
+import type { MicAudioProcessing } from "./mic-audio-processing";
+
+/**
+ * Applied audio-processing state of the local microphone for the active
+ * call. The engine emits `micAudioProcessingChanged` on every transition
+ * that can change it (mic publish / unpublish / device switch) and
+ * `use-call-engine` mirrors it here; the call-settings dialog reads it
+ * reactively. `no-mic` is the resting state — before a call, while a
+ * listener has no mic, or after the call ends.
+ */
+export const $micAudioProcessing = atom<MicAudioProcessing>({ kind: "no-mic" });
+
+export function setMicAudioProcessing(state: MicAudioProcessing): void {
+  $micAudioProcessing.set(state);
+}
+
+/** Reset to `no-mic` — used when a call disconnects. */
+export function resetMicAudioProcessing(): void {
+  if ($micAudioProcessing.get().kind === "no-mic") return;
+  $micAudioProcessing.set({ kind: "no-mic" });
+}

--- a/chat/src/lib/calls/mic-audio-processing-state.ts
+++ b/chat/src/lib/calls/mic-audio-processing-state.ts
@@ -1,5 +1,5 @@
 import { atom } from "nanostores";
-import type { MicAudioProcessing } from "./mic-audio-processing";
+import { sameMicAudioProcessing, type MicAudioProcessing } from "./mic-audio-processing";
 
 /**
  * Applied audio-processing state of the local microphone for the active
@@ -12,11 +12,13 @@ import type { MicAudioProcessing } from "./mic-audio-processing";
 export const $micAudioProcessing = atom<MicAudioProcessing>({ kind: "no-mic" });
 
 export function setMicAudioProcessing(state: MicAudioProcessing): void {
+  // Skip redundant notifications: a recompute often yields an unchanged
+  // value (the initial publish emits twice — see sameMicAudioProcessing).
+  if (sameMicAudioProcessing($micAudioProcessing.get(), state)) return;
   $micAudioProcessing.set(state);
 }
 
 /** Reset to `no-mic` — used when a call disconnects. */
 export function resetMicAudioProcessing(): void {
-  if ($micAudioProcessing.get().kind === "no-mic") return;
-  $micAudioProcessing.set({ kind: "no-mic" });
+  setMicAudioProcessing({ kind: "no-mic" });
 }

--- a/chat/src/lib/calls/mic-audio-processing.ts
+++ b/chat/src/lib/calls/mic-audio-processing.ts
@@ -1,0 +1,154 @@
+/**
+ * Verification of the browser-native audio processing the call engine
+ * *requests* on every connect (`audioCaptureDefaults` in `engine.ts`:
+ * `noiseSuppression`, `echoCancellation`, `autoGainControl`).
+ *
+ * Requesting a constraint and the browser *applying* it are different
+ * things: some capture devices (notably certain Bluetooth headsets)
+ * refuse noise suppression, and some browsers omit the field from
+ * `MediaStreamTrack.getSettings()` entirely even while it is active.
+ * So we read the live track's *applied* settings and model three
+ * honest states per constraint — never claiming "on" we cannot confirm,
+ * never crying "off" for a browser that simply stays quiet.
+ *
+ * This module is pure: it maps a `MediaTrackSettings` snapshot to the
+ * typed state and derives the UI rows. The engine owns the "is there a
+ * live mic track at all?" decision (the `no-mic` case); everything here
+ * is a total function of its inputs and is unit-tested in isolation.
+ */
+
+/**
+ * The applied state of a single audio-processing constraint:
+ *  - `on`      — `getSettings()` reported `true` (requested *and* applied).
+ *  - `off`     — reported `false` (requested, but the device/browser
+ *                refused it — a genuine degradation worth surfacing).
+ *  - `unknown` — the field was absent from `getSettings()`; the browser
+ *                doesn't report it, which usually means "probably applied
+ *                but unconfirmable", NOT "off".
+ */
+export type ConstraintState = "on" | "off" | "unknown";
+
+/**
+ * The applied audio-processing state of the local microphone.
+ *
+ * Discriminated union rather than a flat record so "no microphone is
+ * publishing" is unrepresentable as a per-constraint value: the UI must
+ * handle the `no-mic` case before it can read any constraint, and the
+ * three constraints can never disagree about whether a mic exists.
+ */
+export type MicAudioProcessing =
+  | { kind: "no-mic" }
+  | {
+      kind: "active";
+      noiseSuppression: ConstraintState;
+      echoCancellation: ConstraintState;
+      autoGainControl: ConstraintState;
+    };
+
+/**
+ * Map one `getSettings()` value to a tri-state.
+ *
+ * Most constraints report a plain `boolean`. `echoCancellation` is the
+ * exception: some browsers report it as an *echo-cancellation-mode*
+ * string (`"all"` / `"remote-only"`) instead of a boolean — a present
+ * mode means the processing is active, so a non-empty string reads as
+ * `on`. An absent field stays `unknown` (the browser doesn't report it).
+ */
+export function constraintState(value: boolean | string | undefined): ConstraintState {
+  if (value === true) return "on";
+  if (value === false) return "off";
+  if (typeof value === "string") return value.length > 0 ? "on" : "off";
+  return "unknown";
+}
+
+/**
+ * Read the applied audio-processing trio from a live mic track's
+ * settings. Caller guarantees the track is actually capturing; the
+ * `no-mic` case is decided upstream (in the engine) where the track's
+ * existence and `readyState` are known.
+ */
+export function activeMicAudioProcessing(
+  settings: MediaTrackSettings,
+): Extract<MicAudioProcessing, { kind: "active" }> {
+  return {
+    kind: "active",
+    noiseSuppression: constraintState(settings.noiseSuppression),
+    echoCancellation: constraintState(settings.echoCancellation),
+    autoGainControl: constraintState(settings.autoGainControl),
+  };
+}
+
+/**
+ * Visual weight for a constraint state, matching meaning to prominence:
+ *  - `on`   — calm positive; the requested processing is confirmed.
+ *  - `warn` — the browser told us it is `off`; a real degradation.
+ *  - `muted` — `unknown`; greyed, since we can't confirm either way.
+ */
+type AudioProcessingTone = "on" | "warn" | "muted";
+
+type AudioProcessingRowKey =
+  | "noiseSuppression"
+  | "echoCancellation"
+  | "autoGainControl";
+
+/** One presentational row for the call-settings indicator. */
+export type AudioProcessingRow = {
+  key: AudioProcessingRowKey;
+  label: string;
+  state: ConstraintState;
+  stateLabel: string;
+  tone: AudioProcessingTone;
+  /** Caption shown under non-`on` rows; `null` when the state is `on`. */
+  detail: string | null;
+};
+
+const ROW_LABELS: Readonly<Record<AudioProcessingRowKey, string>> = {
+  noiseSuppression: "Noise cancellation",
+  echoCancellation: "Echo cancellation",
+  autoGainControl: "Automatic gain control",
+};
+
+const STATE_LABELS: Readonly<Record<ConstraintState, string>> = {
+  on: "On",
+  off: "Off",
+  unknown: "Not reported",
+};
+
+const UNKNOWN_DETAIL = "Your browser doesn't report this setting.";
+const OFF_DETAIL = "Your microphone or browser turned this off.";
+
+function toneFor(state: ConstraintState): AudioProcessingTone {
+  if (state === "on") return "on";
+  if (state === "off") return "warn";
+  return "muted";
+}
+
+function detailFor(state: ConstraintState): string | null {
+  if (state === "off") return OFF_DETAIL;
+  if (state === "unknown") return UNKNOWN_DETAIL;
+  return null;
+}
+
+/** Render order: noise cancellation first (the headline), then the rest. */
+const ROW_ORDER: readonly AudioProcessingRowKey[] = [
+  "noiseSuppression",
+  "echoCancellation",
+  "autoGainControl",
+];
+
+/** Derive the indicator's display rows from the active trio. */
+export function audioProcessingRows(
+  state: Extract<MicAudioProcessing, { kind: "active" }>,
+): AudioProcessingRow[] {
+  return ROW_ORDER.map((key) => {
+    const value = state[key];
+    return {
+      key,
+      label: ROW_LABELS[key],
+      state: value,
+      stateLabel: STATE_LABELS[value],
+      tone: toneFor(value),
+      detail: detailFor(value),
+    };
+  });
+}

--- a/chat/src/lib/calls/mic-audio-processing.ts
+++ b/chat/src/lib/calls/mic-audio-processing.ts
@@ -92,7 +92,7 @@ type AudioProcessingRowKey =
   | "autoGainControl";
 
 /** One presentational row for the call-settings indicator. */
-export type AudioProcessingRow = {
+type AudioProcessingRow = {
   key: AudioProcessingRowKey;
   label: string;
   state: ConstraintState;

--- a/chat/src/lib/calls/mic-audio-processing.ts
+++ b/chat/src/lib/calls/mic-audio-processing.ts
@@ -79,6 +79,25 @@ export function activeMicAudioProcessing(
 }
 
 /**
+ * Structural equality of two states. Lets the store skip a redundant
+ * notification when a recompute yields an unchanged value — e.g. the
+ * initial mic publish emits via both `LocalTrackPublished` and the
+ * follow-on `ActiveDeviceChanged`, producing two equal-by-value states.
+ */
+export function sameMicAudioProcessing(
+  a: MicAudioProcessing,
+  b: MicAudioProcessing,
+): boolean {
+  if (a.kind !== b.kind) return false;
+  if (a.kind !== "active" || b.kind !== "active") return true; // both no-mic
+  return (
+    a.noiseSuppression === b.noiseSuppression &&
+    a.echoCancellation === b.echoCancellation &&
+    a.autoGainControl === b.autoGainControl
+  );
+}
+
+/**
  * Visual weight for a constraint state, matching meaning to prominence:
  *  - `on`   — calm positive; the requested processing is confirmed.
  *  - `warn` — the browser told us it is `off`; a real degradation.

--- a/chat/src/lib/calls/use-call-engine.ts
+++ b/chat/src/lib/calls/use-call-engine.ts
@@ -11,6 +11,7 @@ import {
 import { clearAllMediaIssues, recordMediaIssue } from "./call-media-issues";
 import { syncScreenShareEnabled } from "./screen-share-state";
 import { setCallAudioPlaybackBlocked } from "./call-audio-playback";
+import { resetMicAudioProcessing, setMicAudioProcessing } from "./mic-audio-processing-state";
 
 /**
  * Process-wide singleton: only one call engine should ever exist
@@ -76,6 +77,11 @@ export function useCallEngine(): {
     singletonEngine.on("audioPlaybackStatusChanged", (canPlaybackAudio) => {
       setCallAudioPlaybackBlocked(!canPlaybackAudio);
     });
+    singletonEngine.on("micAudioProcessingChanged", (state) => {
+      // Verified (applied) browser-native audio processing of the local
+      // mic — drives the read-only indicator in the call-settings dialog.
+      setMicAudioProcessing(state);
+    });
     singletonEngine.on("participantConnected", (identity) => {
       const roomJid = activeMucRoomJid();
       if (!roomJid) return;
@@ -94,6 +100,9 @@ export function useCallEngine(): {
       // call that just ended, not the next one.
       clearAllMediaIssues();
       setCallAudioPlaybackBlocked(false);
+      // The mic-processing readout belonged to the call that just
+      // ended; reset so the next call's dialog starts from `no-mic`.
+      resetMicAudioProcessing();
       // The active call's room — if any — is no longer in our LK
       // view. Drop the LK snapshot so the room's UI reverts to the
       // Muji-derived (server-bridged) view, which the LK webhook

--- a/chat/tests/call-engine.test.ts
+++ b/chat/tests/call-engine.test.ts
@@ -654,12 +654,17 @@ describe("enableRequestedCapture — best-effort, never ejects", () => {
  */
 function micRoomStub(
   settings: MediaTrackSettings | null,
-  readyState: MediaStreamTrackState = "live",
+  opts: { readyState?: MediaStreamTrackState; isMuted?: boolean } = {},
 ) {
+  const { readyState = "live", isMuted = false } = opts;
   const publication =
     settings === null
       ? undefined
-      : { track: { mediaStreamTrack: { readyState, getSettings: () => settings } } };
+      : {
+          isMuted,
+          source: Track.Source.Microphone,
+          track: { mediaStreamTrack: { readyState, getSettings: () => settings } },
+        };
   return {
     localParticipant: {
       getTrackPublication: (source: Track.Source) =>
@@ -762,19 +767,73 @@ describe("call-engine — verifies applied mic audio processing", () => {
     expect(events.at(-1)).toEqual({ kind: "no-mic" });
   });
 
-  test("an ended capture track reads as no-mic (mic stopped on mute)", async () => {
+  test("a track that has ended (e.g. device unplugged) reads as no-mic", async () => {
     const { CallEngine } = await import("../src/lib/calls/engine");
     const engine = new CallEngine();
     const events: MicAudioProcessing[] = [];
     engine.on("micAudioProcessingChanged", (state) => events.push(state));
     (engine as unknown as { room: unknown }).room = micRoomStub(
       { noiseSuppression: true } as MediaTrackSettings,
-      "ended",
+      { readyState: "ended" },
     );
     (engine as unknown as {
       handleActiveDeviceChanged: (kind: MediaDeviceKind) => void;
     }).handleActiveDeviceChanged("audioinput");
     expect(events.at(-1)).toEqual({ kind: "no-mic" });
+  });
+
+  test("muting the local mic falls back to no-mic; unmuting restores the trio", async () => {
+    // The common case: LiveKit's default `stopMicTrackOnMute: false`
+    // leaves the muted track `live` and published, so without the mute
+    // listener + `isMuted` guard the indicator would show a stale trio
+    // for a mic that isn't capturing.
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    const events: MicAudioProcessing[] = [];
+    engine.on("micAudioProcessingChanged", (state) => events.push(state));
+    const handle = (
+      engine as unknown as {
+        handleTrackMuteChanged: (publication: unknown, participant: unknown) => void;
+      }
+    ).handleTrackMuteChanged;
+
+    (engine as unknown as { room: unknown }).room = micRoomStub(
+      { noiseSuppression: true } as MediaTrackSettings,
+      { isMuted: true },
+    );
+    handle({ source: Track.Source.Microphone }, { isLocal: true });
+    expect(events.at(-1)).toEqual({ kind: "no-mic" });
+
+    (engine as unknown as { room: unknown }).room = micRoomStub(
+      { noiseSuppression: true } as MediaTrackSettings,
+      { isMuted: false },
+    );
+    handle({ source: Track.Source.Microphone }, { isLocal: true });
+    expect(events.at(-1)).toEqual({
+      kind: "active",
+      noiseSuppression: "on",
+      echoCancellation: "unknown",
+      autoGainControl: "unknown",
+    });
+  });
+
+  test("a remote participant's mute (or a local non-mic mute) is ignored", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    const events: MicAudioProcessing[] = [];
+    engine.on("micAudioProcessingChanged", (state) => events.push(state));
+    (engine as unknown as { room: unknown }).room = micRoomStub({
+      noiseSuppression: true,
+    } as MediaTrackSettings);
+    const handle = (
+      engine as unknown as {
+        handleTrackMuteChanged: (publication: unknown, participant: unknown) => void;
+      }
+    ).handleTrackMuteChanged;
+
+    handle({ source: Track.Source.Microphone }, { isLocal: false });
+    handle({ source: Track.Source.ScreenShareAudio }, { isLocal: true });
+    expect(events).toEqual([]);
   });
 
   test("a mid-call mic device switch recomputes; a camera/speaker switch does not", async () => {

--- a/chat/tests/call-engine.test.ts
+++ b/chat/tests/call-engine.test.ts
@@ -9,6 +9,7 @@ import {
   type RemoteMediaTrack,
 } from "../src/lib/calls/engine";
 import { Track } from "livekit-client";
+import type { MicAudioProcessing } from "../src/lib/calls/mic-audio-processing";
 
 function deviceError(name: string): Error {
   const err = new Error(`${name} message`);
@@ -642,5 +643,171 @@ describe("enableRequestedCapture — best-effort, never ejects", () => {
     await enableRequestedCapture(stub, { audio: true, video: false }, (source) => seen.push(source));
     expect(stub.calls).toEqual(["mic:true"]);
     expect(seen).toEqual([]);
+  });
+});
+
+/**
+ * Inject a minimal Room stub whose local mic publication reports the
+ * given `getSettings()` (or no publication at all, for the no-mic
+ * path). Mirrors how the other engine tests stub `room` to avoid
+ * `livekit-client`'s browser-only `Room`.
+ */
+function micRoomStub(
+  settings: MediaTrackSettings | null,
+  readyState: MediaStreamTrackState = "live",
+) {
+  const publication =
+    settings === null
+      ? undefined
+      : { track: { mediaStreamTrack: { readyState, getSettings: () => settings } } };
+  return {
+    localParticipant: {
+      getTrackPublication: (source: Track.Source) =>
+        source === Track.Source.Microphone ? publication : undefined,
+    },
+  };
+}
+
+function publishMic(engine: unknown): void {
+  (
+    engine as {
+      handleLocalTrackPublished: (publication: unknown, participant: unknown) => void;
+    }
+  ).handleLocalTrackPublished(
+    { track: {}, kind: Track.Kind.Audio, trackSid: "self-mic", source: Track.Source.Microphone },
+    { identity: "me@waddle.test/web" },
+  );
+}
+
+describe("call-engine — verifies applied mic audio processing", () => {
+  test("mic publish emits the applied noise/echo/gain trio read from getSettings", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    const events: MicAudioProcessing[] = [];
+    engine.on("micAudioProcessingChanged", (state) => events.push(state));
+    (engine as unknown as { room: unknown }).room = micRoomStub({
+      noiseSuppression: true,
+      echoCancellation: true,
+      autoGainControl: false,
+    } as MediaTrackSettings);
+
+    publishMic(engine);
+
+    expect(events).toEqual([
+      {
+        kind: "active",
+        noiseSuppression: "on",
+        echoCancellation: "on",
+        autoGainControl: "off",
+      },
+    ]);
+  });
+
+  test("a browser that omits a constraint reports it as unknown, not off", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    const events: MicAudioProcessing[] = [];
+    engine.on("micAudioProcessingChanged", (state) => events.push(state));
+    (engine as unknown as { room: unknown }).room = micRoomStub({
+      noiseSuppression: true,
+      // echoCancellation + autoGainControl absent → unknown
+    } as MediaTrackSettings);
+
+    publishMic(engine);
+
+    expect(events.at(-1)).toEqual({
+      kind: "active",
+      noiseSuppression: "on",
+      echoCancellation: "unknown",
+      autoGainControl: "unknown",
+    });
+  });
+
+  test("publishing a non-mic track (camera) does not emit a mic-processing change", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    const events: MicAudioProcessing[] = [];
+    engine.on("micAudioProcessingChanged", (state) => events.push(state));
+    (engine as unknown as { room: unknown }).room = micRoomStub(null);
+
+    (
+      engine as unknown as {
+        handleLocalTrackPublished: (publication: unknown, participant: unknown) => void;
+      }
+    ).handleLocalTrackPublished(
+      { track: {}, kind: Track.Kind.Video, trackSid: "self-cam", source: Track.Source.Camera },
+      { identity: "me@waddle.test/web" },
+    );
+
+    expect(events).toEqual([]);
+  });
+
+  test("mic unpublish falls back to no-mic instead of a stale trio", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    const events: MicAudioProcessing[] = [];
+    engine.on("micAudioProcessingChanged", (state) => events.push(state));
+    // No mic publication present once unpublished.
+    (engine as unknown as { room: unknown }).room = micRoomStub(null);
+
+    (
+      engine as unknown as {
+        handleLocalTrackUnpublished: (publication: unknown, participant: unknown) => void;
+      }
+    ).handleLocalTrackUnpublished(
+      { track: {}, kind: Track.Kind.Audio, trackSid: "self-mic", source: Track.Source.Microphone },
+      { identity: "me@waddle.test/web" },
+    );
+
+    expect(events.at(-1)).toEqual({ kind: "no-mic" });
+  });
+
+  test("an ended capture track reads as no-mic (mic stopped on mute)", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    (engine as unknown as { room: unknown }).room = micRoomStub(
+      { noiseSuppression: true } as MediaTrackSettings,
+      "ended",
+    );
+    expect(engine.micAudioProcessing).toEqual({ kind: "no-mic" });
+  });
+
+  test("a mid-call mic device switch recomputes; a camera/speaker switch does not", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    const events: MicAudioProcessing[] = [];
+    engine.on("micAudioProcessingChanged", (state) => events.push(state));
+    (engine as unknown as { room: unknown }).room = micRoomStub({
+      noiseSuppression: false,
+    } as MediaTrackSettings);
+    const handle = (engine as unknown as {
+      handleActiveDeviceChanged: (kind: MediaDeviceKind) => void;
+    }).handleActiveDeviceChanged;
+
+    handle("videoinput");
+    handle("audiooutput");
+    expect(events).toEqual([]);
+
+    handle("audioinput");
+    expect(events).toEqual([
+      {
+        kind: "active",
+        noiseSuppression: "off",
+        echoCancellation: "unknown",
+        autoGainControl: "unknown",
+      },
+    ]);
+  });
+
+  test("micAudioProcessing getter is no-mic before any room is connected", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    expect(engine.micAudioProcessing).toEqual({ kind: "no-mic" });
+  });
+
+  test("on() exposes micAudioProcessingChanged as a first-class engine event", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    expect(typeof engine.on("micAudioProcessingChanged", () => {})).toBe("function");
   });
 });

--- a/chat/tests/call-engine.test.ts
+++ b/chat/tests/call-engine.test.ts
@@ -765,11 +765,16 @@ describe("call-engine — verifies applied mic audio processing", () => {
   test("an ended capture track reads as no-mic (mic stopped on mute)", async () => {
     const { CallEngine } = await import("../src/lib/calls/engine");
     const engine = new CallEngine();
+    const events: MicAudioProcessing[] = [];
+    engine.on("micAudioProcessingChanged", (state) => events.push(state));
     (engine as unknown as { room: unknown }).room = micRoomStub(
       { noiseSuppression: true } as MediaTrackSettings,
       "ended",
     );
-    expect(engine.micAudioProcessing).toEqual({ kind: "no-mic" });
+    (engine as unknown as {
+      handleActiveDeviceChanged: (kind: MediaDeviceKind) => void;
+    }).handleActiveDeviceChanged("audioinput");
+    expect(events.at(-1)).toEqual({ kind: "no-mic" });
   });
 
   test("a mid-call mic device switch recomputes; a camera/speaker switch does not", async () => {
@@ -799,10 +804,15 @@ describe("call-engine — verifies applied mic audio processing", () => {
     ]);
   });
 
-  test("micAudioProcessing getter is no-mic before any room is connected", async () => {
+  test("a device change with no connected room emits no-mic, not a crash", async () => {
     const { CallEngine } = await import("../src/lib/calls/engine");
     const engine = new CallEngine();
-    expect(engine.micAudioProcessing).toEqual({ kind: "no-mic" });
+    const events: MicAudioProcessing[] = [];
+    engine.on("micAudioProcessingChanged", (state) => events.push(state));
+    (engine as unknown as {
+      handleActiveDeviceChanged: (kind: MediaDeviceKind) => void;
+    }).handleActiveDeviceChanged("audioinput");
+    expect(events).toEqual([{ kind: "no-mic" }]);
   });
 
   test("on() exposes micAudioProcessingChanged as a first-class engine event", async () => {

--- a/chat/tests/call-engine.test.ts
+++ b/chat/tests/call-engine.test.ts
@@ -767,6 +767,40 @@ describe("call-engine — verifies applied mic audio processing", () => {
     expect(events.at(-1)).toEqual({ kind: "no-mic" });
   });
 
+  test("mic unpublish with an already-detached track still falls back to no-mic", async () => {
+    // Regression: LiveKit can fire LocalTrackUnpublished with
+    // `publication.track` already cleared (underlying MediaStreamTrack
+    // ended first). The mic-processing reset must NOT be gated behind the
+    // track-dependent guard, or the indicator holds a stale active trio.
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    const processing: MicAudioProcessing[] = [];
+    const unpublished: unknown[] = [];
+    engine.on("micAudioProcessingChanged", (state) => processing.push(state));
+    engine.on("localTrackUnpublished", (track) => unpublished.push(track));
+    // getTrackPublication no longer returns a mic publication.
+    (engine as unknown as { room: unknown }).room = micRoomStub(null);
+
+    (
+      engine as unknown as {
+        handleLocalTrackUnpublished: (publication: unknown, participant: unknown) => void;
+      }
+    ).handleLocalTrackUnpublished(
+      {
+        track: undefined,
+        kind: Track.Kind.Audio,
+        trackSid: "self-mic",
+        source: Track.Source.Microphone,
+      },
+      { identity: "me@waddle.test/web" },
+    );
+
+    // The mic-processing reset fired despite the missing track…
+    expect(processing.at(-1)).toEqual({ kind: "no-mic" });
+    // …while the track-dependent localTrackUnpublished event did not.
+    expect(unpublished).toEqual([]);
+  });
+
   test("a track that has ended (e.g. device unplugged) reads as no-mic", async () => {
     const { CallEngine } = await import("../src/lib/calls/engine");
     const engine = new CallEngine();

--- a/chat/tests/mic-audio-processing-state.test.ts
+++ b/chat/tests/mic-audio-processing-state.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  $micAudioProcessing,
+  resetMicAudioProcessing,
+  setMicAudioProcessing,
+} from "../src/lib/calls/mic-audio-processing-state";
+
+afterEach(() => {
+  $micAudioProcessing.set({ kind: "no-mic" });
+});
+
+describe("$micAudioProcessing store", () => {
+  test("starts at no-mic before any call", () => {
+    expect($micAudioProcessing.get()).toEqual({ kind: "no-mic" });
+  });
+
+  test("setMicAudioProcessing mirrors the engine's verified state", () => {
+    setMicAudioProcessing({
+      kind: "active",
+      noiseSuppression: "on",
+      echoCancellation: "off",
+      autoGainControl: "unknown",
+    });
+    expect($micAudioProcessing.get()).toEqual({
+      kind: "active",
+      noiseSuppression: "on",
+      echoCancellation: "off",
+      autoGainControl: "unknown",
+    });
+  });
+
+  test("resetMicAudioProcessing returns to no-mic on call end", () => {
+    setMicAudioProcessing({
+      kind: "active",
+      noiseSuppression: "on",
+      echoCancellation: "on",
+      autoGainControl: "on",
+    });
+    resetMicAudioProcessing();
+    expect($micAudioProcessing.get()).toEqual({ kind: "no-mic" });
+  });
+
+  test("resetting an already-no-mic store is a no-op (no redundant emit)", () => {
+    let notifications = 0;
+    const unsubscribe = $micAudioProcessing.listen(() => {
+      notifications += 1;
+    });
+    resetMicAudioProcessing();
+    unsubscribe();
+    expect(notifications).toBe(0);
+  });
+});

--- a/chat/tests/mic-audio-processing-state.test.ts
+++ b/chat/tests/mic-audio-processing-state.test.ts
@@ -49,4 +49,26 @@ describe("$micAudioProcessing store", () => {
     unsubscribe();
     expect(notifications).toBe(0);
   });
+
+  test("setting an unchanged value does not notify (the publish double-emit)", () => {
+    setMicAudioProcessing({
+      kind: "active",
+      noiseSuppression: "on",
+      echoCancellation: "on",
+      autoGainControl: "on",
+    });
+    let notifications = 0;
+    const unsubscribe = $micAudioProcessing.listen(() => {
+      notifications += 1;
+    });
+    // Same value again — e.g. LocalTrackPublished then ActiveDeviceChanged.
+    setMicAudioProcessing({
+      kind: "active",
+      noiseSuppression: "on",
+      echoCancellation: "on",
+      autoGainControl: "on",
+    });
+    unsubscribe();
+    expect(notifications).toBe(0);
+  });
 });

--- a/chat/tests/mic-audio-processing.test.ts
+++ b/chat/tests/mic-audio-processing.test.ts
@@ -3,6 +3,7 @@ import {
   activeMicAudioProcessing,
   audioProcessingRows,
   constraintState,
+  sameMicAudioProcessing,
   type MicAudioProcessing,
 } from "../src/lib/calls/mic-audio-processing";
 
@@ -108,5 +109,32 @@ describe("MicAudioProcessing — discriminated union keeps no-mic distinct", () 
     // constraint. Runtime guard that the union stays a 2-arm shape.
     expect(state.kind).toBe("no-mic");
     expect("noiseSuppression" in state).toBe(false);
+  });
+});
+
+describe("sameMicAudioProcessing — structural equality for dedup", () => {
+  const active: MicAudioProcessing = {
+    kind: "active",
+    noiseSuppression: "on",
+    echoCancellation: "off",
+    autoGainControl: "unknown",
+  };
+
+  test("two no-mic values are equal", () => {
+    expect(sameMicAudioProcessing({ kind: "no-mic" }, { kind: "no-mic" })).toBe(true);
+  });
+
+  test("no-mic and active differ", () => {
+    expect(sameMicAudioProcessing({ kind: "no-mic" }, active)).toBe(false);
+  });
+
+  test("active values with the same trio are equal", () => {
+    expect(sameMicAudioProcessing(active, { ...active })).toBe(true);
+  });
+
+  test("a single differing constraint makes them unequal", () => {
+    expect(
+      sameMicAudioProcessing(active, { ...active, autoGainControl: "on" }),
+    ).toBe(false);
   });
 });

--- a/chat/tests/mic-audio-processing.test.ts
+++ b/chat/tests/mic-audio-processing.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import {
+  activeMicAudioProcessing,
+  audioProcessingRows,
+  constraintState,
+  type MicAudioProcessing,
+} from "../src/lib/calls/mic-audio-processing";
+
+describe("constraintState — honest tri-state from getSettings", () => {
+  test("true maps to on (requested AND applied)", () => {
+    expect(constraintState(true)).toBe("on");
+  });
+
+  test("false maps to off (requested but the device/browser refused)", () => {
+    expect(constraintState(false)).toBe("off");
+  });
+
+  test("an absent field maps to unknown, NOT off", () => {
+    // The headline correctness property: a browser that omits the field
+    // (Safari/Firefox often do) must read as `unknown`, never `off` —
+    // otherwise the indicator cries wolf on a probably-working mic.
+    expect(constraintState(undefined)).toBe("unknown");
+  });
+
+  test("an echo-cancellation mode string ('all'/'remote-only') reads as on", () => {
+    // `MediaTrackSettings.echoCancellation` is `boolean | string`: some
+    // browsers report the active *mode* rather than a bare boolean. A
+    // present mode means echo cancellation is on.
+    expect(constraintState("all")).toBe("on");
+    expect(constraintState("remote-only")).toBe("on");
+    expect(constraintState("")).toBe("off");
+  });
+});
+
+describe("activeMicAudioProcessing — reads the whole APM trio", () => {
+  test("maps each constraint independently from one settings snapshot", () => {
+    const state = activeMicAudioProcessing({
+      noiseSuppression: true,
+      echoCancellation: false,
+      // autoGainControl intentionally absent → unknown
+    } as MediaTrackSettings);
+    expect(state).toEqual({
+      kind: "active",
+      noiseSuppression: "on",
+      echoCancellation: "off",
+      autoGainControl: "unknown",
+    });
+  });
+
+  test("all-applied settings produce an all-on active state", () => {
+    const state = activeMicAudioProcessing({
+      noiseSuppression: true,
+      echoCancellation: true,
+      autoGainControl: true,
+    } as MediaTrackSettings);
+    expect(state.noiseSuppression).toBe("on");
+    expect(state.echoCancellation).toBe("on");
+    expect(state.autoGainControl).toBe("on");
+  });
+});
+
+describe("audioProcessingRows — tiered presentation", () => {
+  const rows = audioProcessingRows({
+    kind: "active",
+    noiseSuppression: "on",
+    echoCancellation: "off",
+    autoGainControl: "unknown",
+  });
+
+  test("renders noise cancellation first as the headline", () => {
+    expect(rows.map((r) => r.key)).toEqual([
+      "noiseSuppression",
+      "echoCancellation",
+      "autoGainControl",
+    ]);
+    expect(rows[0]?.label).toBe("Noise cancellation");
+  });
+
+  test("on → calm tone, 'On' label, no caption", () => {
+    const ns = rows[0];
+    expect(ns?.state).toBe("on");
+    expect(ns?.tone).toBe("on");
+    expect(ns?.stateLabel).toBe("On");
+    expect(ns?.detail).toBeNull();
+  });
+
+  test("off → warn tone with an explanatory caption (a real degradation)", () => {
+    const echo = rows[1];
+    expect(echo?.state).toBe("off");
+    expect(echo?.tone).toBe("warn");
+    expect(echo?.stateLabel).toBe("Off");
+    expect(echo?.detail).toBeTruthy();
+  });
+
+  test("unknown → muted tone, 'Not reported', browser-doesn't-report caption", () => {
+    const agc = rows[2];
+    expect(agc?.state).toBe("unknown");
+    expect(agc?.tone).toBe("muted");
+    expect(agc?.stateLabel).toBe("Not reported");
+    expect(agc?.detail).toContain("browser");
+  });
+});
+
+describe("MicAudioProcessing — discriminated union keeps no-mic distinct", () => {
+  test("a no-mic value carries no constraint fields to misread", () => {
+    const state: MicAudioProcessing = { kind: "no-mic" };
+    // Type-level: the UI must branch on `kind` before reading a
+    // constraint. Runtime guard that the union stays a 2-arm shape.
+    expect(state.kind).toBe("no-mic");
+    expect("noiseSuppression" in state).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Calls request browser-native audio processing on every connect — `noiseSuppression`, `echoCancellation`, `autoGainControl` are hardcoded in `audioCaptureDefaults` (`chat/src/lib/calls/engine.ts`) — but nothing confirmed the browser actually **applied** them, and the user had no way to see it. Requesting a constraint and getting it are different things: some devices (e.g. certain Bluetooth headsets) refuse noise suppression, and some browsers silently omit the field from `getSettings()`.

This PR adds a **read-only verification indicator**: it reads the *applied* settings from the live local microphone track (`MediaStreamTrack.getSettings()`) and surfaces them in the **Call settings dialog → Microphone** section.

Scope is deliberately limited to **verification** — no on/off toggle, no track restart, and no DNN/Krisp upgrade (LiveKit's Krisp filter is LiveKit-Cloud-only and unavailable for our self-hosted `wss://livekit.waddle.social` SFU).

## Why this shape

- **Self-hosted SFU + XMPP-native:** the noise-cancellation processing is a local `getUserMedia` capture concern in the browser. Nothing crosses the Jingle/XMPP wire, so there is **no XEP conformance surface** and **no Rust/server change**. This is purely a `chat/` (TypeScript/Vue) change.
- We verify the *applied* value, never the *requested* one.

## Design

1. **Source of truth:** the live mic track's `mediaStreamTrack.getSettings()` — microphone source only (screen-share audio excluded).
2. **Scope:** all three constraints — noise suppression, echo cancellation, auto gain control.
3. **Honest 4-state, per constraint:**
   - `on` — browser reported `true`
   - `off` — browser reported `false` (a genuine degradation)
   - `unknown` — field absent from `getSettings()` (quiet browser; probably fine)
   - `no-mic` — no live mic track: a listener, a **muted** mic, or an ended/unplugged device
   - `echoCancellation` may report a *mode string* (`"all"`/`"remote-only"`) instead of a boolean; a present mode reads as `on`.
4. **Reactive store:** a new `CallEngine` event (`micAudioProcessingChanged`) feeds a nanostore (`$micAudioProcessing`) that `use-call-engine` mirrors and the dialog reads. The store retains the last emitted value, so a dialog opened mid-call shows current state without an on-demand read. Recomputed on every transition that can change the applied processing:
   - mic `LocalTrackPublished` / `LocalTrackUnpublished`
   - `RoomEvent.ActiveDeviceChanged` (a mid-call mic device switch swaps the track in place and doesn't re-fire publish)
   - `RoomEvent.TrackMuted` / `TrackUnmuted` for the local mic (LiveKit's default `stopMicTrackOnMute: false` keeps a muted track `live` and published, so mute must be tracked explicitly — otherwise the indicator would show a stale trio for a muted mic)
   - reset to `no-mic` on disconnect
5. **Typed model (discriminated union):**
   ```ts
   type ConstraintState = "on" | "off" | "unknown";
   type MicAudioProcessing =
     | { kind: "no-mic" }
     | { kind: "active";
         noiseSuppression: ConstraintState;
         echoCancellation: ConstraintState;
         autoGainControl:  ConstraintState };
   ```
   `no-mic` is unrepresentable as a per-constraint value, so the UI must branch on `kind` before reading any constraint.
6. **Placement & treatment:** a read-only "Audio processing" block under the Microphone picker in `CallSettingsDialog.vue`. Tiered visual weight — **On** calm (success tint), **Off** amber/warning, **Unknown** muted grey + "your browser doesn't report this" caption, **no-mic** a single neutral line. State is conveyed by text label (`On`/`Off`/`Not reported`) as well as colour, so it isn't colour-only.
7. **Tests:** pure `getSettings → ConstraintState` mapper, the presentation rows, the store, and the engine event wiring (publish/unpublish/device-switch/mute/unmute, plus the unknown≠off and no-mic distinctions) as `bun test` specs.

## Files

- `chat/src/lib/calls/mic-audio-processing.ts` — pure tri-state mapper + tiered presentation rows
- `chat/src/lib/calls/mic-audio-processing-state.ts` — `$micAudioProcessing` nanostore
- `chat/src/lib/calls/engine.ts` — `micAudioProcessingChanged` event; recompute on publish/unpublish/device-switch/mute; `computeMicAudioProcessing`
- `chat/src/lib/calls/use-call-engine.ts` — mirror event → store; reset on disconnect
- `chat/src/components/calls/CallSettingsDialog.vue` — the read-only indicator + styles
- `chat/tests/{mic-audio-processing,mic-audio-processing-state,call-engine}.test.ts`

## Verification

- `bun test` — 1845 pass / 0 fail
- `bunx knip` — clean (exit 0)
- `bunx astro check` — 0 errors (1 pre-existing, unrelated hint in `discovery.ts`)
- Three adversarial review passes; the major finding (mute staleness) is fixed in this PR.

## Out of scope (possible follow-ups)

- User toggle to turn processing on/off (needs a track restart with new constraints)
- DNN/AI noise filter via `@livekit/track-processors` (client-side WASM — RNNoise/DTLN), since the Cloud Krisp filter is unavailable self-hosted
- Fleet-wide telemetry of the applied state via the Grafana Faro beacon

🤖 Generated with [Claude Code](https://claude.com/claude-code)
