### PR TITLE
feat(chat): video quality — 1080p capture, self connection indicator, diagnostics

### DIFF
--- a/chat/src/components/calls/CallConnectionIndicator.vue
+++ b/chat/src/components/calls/CallConnectionIndicator.vue
@@ -37,7 +37,11 @@ const bars = [1, 2, 3] as const;
 const statusText = computed(() => {
   const c = chip.value;
   if (c.label) return c.label;
-  return c.bars === 3 ? "Excellent connection" : "Good connection";
+  if (c.bars === 3) return "Excellent connection";
+  if (c.bars === 2) return "Good connection";
+  // 0 bars, no label → the quiet `unknown` start state before the first
+  // quality sample. Don't claim "Good" — say what it's actually doing.
+  return "Measuring…";
 });
 
 /** Spoken text: only the degraded label, empty (silent) when healthy. */

--- a/chat/src/components/calls/CallConnectionIndicator.vue
+++ b/chat/src/components/calls/CallConnectionIndicator.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { useStore } from "@nanostores/vue";
+import {
+  $callConnectionPhase,
+  $callConnectionQuality,
+  qualityToChip,
+} from "@/lib/calls/connection-quality";
+
+/**
+ * Ambient self-connection indicator for the call bar. Reads the
+ * engine-fed quality + transport-phase atoms and renders a three-bar
+ * signal glyph that stays quiet when healthy (bars only, no text) and
+ * escalates to an amber "Poor connection" / red "Reconnecting…" label as
+ * the local connection degrades. Self-contained and store-connected so
+ * the stateless `CallControls` bar can embed it without threading props.
+ *
+ * Hidden entirely (`v-if`) until the first real quality sample arrives,
+ * so a fresh call doesn't flash an empty "no signal" glyph.
+ */
+const quality = useStore($callConnectionQuality);
+const phase = useStore($callConnectionPhase);
+
+const chip = computed(() => qualityToChip(quality.value, phase.value));
+
+/** Three ascending bars; each is "filled" up to `chip.bars`. */
+const bars = [1, 2, 3] as const;
+
+const ariaLabel = computed(() => {
+  const c = chip.value;
+  if (!c) return "";
+  if (c.label) return `Connection: ${c.label}`;
+  return c.bars === 3 ? "Connection: excellent" : "Connection: good";
+});
+</script>
+
+<template>
+  <div
+    v-if="chip"
+    class="call-connection"
+    :class="`call-connection--${chip.tone}`"
+    role="status"
+    aria-live="polite"
+    :aria-label="ariaLabel"
+    :title="ariaLabel"
+  >
+    <span class="call-connection__bars" aria-hidden="true">
+      <span
+        v-for="bar in bars"
+        :key="bar"
+        class="call-connection__bar"
+        :class="bar <= chip.bars ? 'call-connection__bar--on' : 'call-connection__bar--off'"
+        :style="{ height: `${bar * 33}%` }"
+      />
+    </span>
+    <span v-if="chip.label" class="type-control call-connection__label">{{ chip.label }}</span>
+  </div>
+</template>
+
+<style scoped>
+.call-connection {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  color: var(--muted-foreground);
+}
+
+/* Warn / danger tint the whole chip (bars + label) together. */
+.call-connection--warn {
+  color: var(--warning);
+}
+
+.call-connection--danger {
+  color: var(--destructive);
+}
+
+.call-connection__bars {
+  display: inline-flex;
+  align-items: flex-end;
+  gap: 2px;
+  width: 1rem;
+  height: 1rem;
+}
+
+.call-connection__bar {
+  flex: 1;
+  border-radius: 1px;
+  align-self: flex-end;
+}
+
+/* Filled segments take the chip's current color. */
+.call-connection__bar--on {
+  background: currentColor;
+}
+
+/* Empty segments are a faint ghost of it, so the bar count reads at a
+   glance without a hard background box. */
+.call-connection__bar--off {
+  background: color-mix(in oklab, currentColor 25%, transparent);
+}
+
+.call-connection__label {
+  white-space: nowrap;
+}
+</style>

--- a/chat/src/components/calls/CallConnectionIndicator.vue
+++ b/chat/src/components/calls/CallConnectionIndicator.vue
@@ -11,12 +11,19 @@ import {
  * Ambient self-connection indicator for the call bar. Reads the
  * engine-fed quality + transport-phase atoms and renders a three-bar
  * signal glyph that stays quiet when healthy (bars only, no text) and
- * escalates to an amber "Poor connection" / red "Reconnecting…" label as
- * the local connection degrades. Self-contained and store-connected so
- * the stateless `CallControls` bar can embed it without threading props.
+ * escalates to an amber "Poor connection" / red "Connection lost" /
+ * "Reconnecting…" label as the local connection degrades. Self-contained
+ * and store-connected so the stateless `CallControls` bar can embed it
+ * without threading props.
  *
- * Hidden entirely (`v-if`) until the first real quality sample arrives,
- * so a fresh call doesn't flash an empty "no signal" glyph.
+ * Always rendered during a call (a quiet, empty "measuring" glyph at the
+ * `unknown` start state) so the centered control row keeps a stable
+ * footprint instead of reflowing when the first sample lands.
+ *
+ * Accessibility: the visual glyph is `aria-hidden`; a separate
+ * visually-hidden live region announces ONLY the degraded label, so
+ * healthy↔healthy transitions (Excellent↔Good) stay silent for screen
+ * readers and don't spam announcements.
  */
 const quality = useStore($callConnectionQuality);
 const phase = useStore($callConnectionPhase);
@@ -26,23 +33,22 @@ const chip = computed(() => qualityToChip(quality.value, phase.value));
 /** Three ascending bars; each is "filled" up to `chip.bars`. */
 const bars = [1, 2, 3] as const;
 
-const ariaLabel = computed(() => {
+/** Full status, for the sighted hover tooltip (covers the no-label states). */
+const statusText = computed(() => {
   const c = chip.value;
-  if (!c) return "";
-  if (c.label) return `Connection: ${c.label}`;
-  return c.bars === 3 ? "Connection: excellent" : "Connection: good";
+  if (c.label) return c.label;
+  return c.bars === 3 ? "Excellent connection" : "Good connection";
 });
+
+/** Spoken text: only the degraded label, empty (silent) when healthy. */
+const announcement = computed(() => chip.value.label ?? "");
 </script>
 
 <template>
   <div
-    v-if="chip"
     class="call-connection"
     :class="`call-connection--${chip.tone}`"
-    role="status"
-    aria-live="polite"
-    :aria-label="ariaLabel"
-    :title="ariaLabel"
+    :title="statusText"
   >
     <span class="call-connection__bars" aria-hidden="true">
       <span
@@ -54,6 +60,7 @@ const ariaLabel = computed(() => {
       />
     </span>
     <span v-if="chip.label" class="type-control call-connection__label">{{ chip.label }}</span>
+    <span class="sr-only" role="status" aria-live="polite">{{ announcement }}</span>
   </div>
 </template>
 

--- a/chat/src/components/calls/CallControls.vue
+++ b/chat/src/components/calls/CallControls.vue
@@ -83,8 +83,8 @@ const emit = defineEmits<{
     </button>
 
     <!-- Ambient self-connection quality. Self-contained/store-connected,
-         so it adds no props to this otherwise stateless bar. Hides itself
-         until the first quality sample arrives. -->
+         so it adds no props to this otherwise stateless bar. Shows quiet
+         measuring bars until the first quality sample arrives. -->
     <CallConnectionIndicator />
 
     <span class="call-controls__divider" aria-hidden="true" />

--- a/chat/src/components/calls/CallControls.vue
+++ b/chat/src/components/calls/CallControls.vue
@@ -11,6 +11,7 @@ import {
   VideoOff,
   Volume2,
 } from "lucide-vue-next";
+import CallConnectionIndicator from "./CallConnectionIndicator.vue";
 
 /**
  * Shared control bar for the in-call surfaces (split + expanded).
@@ -80,6 +81,11 @@ const emit = defineEmits<{
       <MonitorUp class="w-4 h-4" />
       <span class="type-control sr-only sm:not-sr-only">{{ screenShareEnabled ? "Stop" : "Share" }}</span>
     </button>
+
+    <!-- Ambient self-connection quality. Self-contained/store-connected,
+         so it adds no props to this otherwise stateless bar. Hides itself
+         until the first quality sample arrives. -->
+    <CallConnectionIndicator />
 
     <span class="call-controls__divider" aria-hidden="true" />
 

--- a/chat/src/components/calls/CallSettingsDialog.vue
+++ b/chat/src/components/calls/CallSettingsDialog.vue
@@ -91,6 +91,10 @@ const { engine, remoteTracks, localTracks } = useCallEngine();
 const statRows = ref<CallStatRow[]>([]);
 const statSamples = new Map<string, CallStatSample>();
 let statsTimer: ReturnType<typeof setInterval> | null = null;
+// Guards against overlapping ticks: a slow `getStats()` must not let the
+// next interval fire a second concurrent pass (which would diff against a
+// half-updated sample map and could write rows out of order).
+let statsSampling = false;
 
 const statDisplayRows = computed(() =>
   statRows.value.map((row) => ({
@@ -104,57 +108,73 @@ const statDisplayRows = computed(() =>
 function participantShortLabel(identity: string): string {
   const at = identity.indexOf("@");
   const local = at > 0 ? identity.slice(0, at) : identity;
-  return local || identity;
+  return local || identity || "Participant";
 }
 
 function sourceLabel(source: string): string {
   return source === "screen_share" ? "Screen" : "Camera";
 }
 
+/**
+ * Read and summarize one video track's stats into a row, or `null` when
+ * the report is unavailable. `getRTCStatsReport()` rejects when a
+ * sender/receiver is mid-teardown (track unpublished, ICE restart, peer
+ * leaving) — common exactly while a poll is running — so a failure drops
+ * that single row rather than rejecting the whole tick.
+ */
+async function rowForTrack(
+  track: { track: { getRTCStatsReport(): Promise<RTCStatsReport | undefined> } },
+  key: string,
+  direction: "send" | "recv",
+  label: string,
+  source: string,
+): Promise<CallStatRow | null> {
+  try {
+    const report = await track.track.getRTCStatsReport();
+    if (!report) return null;
+    const { summary, sample } = summarizeVideoStats(report, direction, statSamples.get(key));
+    if (sample) statSamples.set(key, sample);
+    return { ...summary, key, label, sourceLabel: sourceLabel(source), direction };
+  } catch {
+    return null;
+  }
+}
+
 async function sampleStats(): Promise<void> {
-  const local = localTracks.value.filter((track) => track.kind === "video");
-  const remote = remoteTracks.value.filter((track) => track.kind === "video");
-  const rows: CallStatRow[] = [];
-  await Promise.all([
-    ...local.map(async (track) => {
-      const key = `local:${track.source}:${track.publicationSid}`;
-      const report = await track.track.getRTCStatsReport();
-      if (!report) return;
-      const { summary, sample } = summarizeVideoStats(report, "send", statSamples.get(key));
-      if (sample) statSamples.set(key, sample);
-      rows.push({
-        ...summary,
-        key,
-        label: "You",
-        sourceLabel: sourceLabel(track.source),
-        direction: "send",
-      });
-    }),
-    ...remote.map(async (track) => {
-      const key = `remote:${track.participantIdentity}:${track.source}:${track.publicationSid}`;
-      const report = await track.track.getRTCStatsReport();
-      if (!report) return;
-      const { summary, sample } = summarizeVideoStats(report, "recv", statSamples.get(key));
-      if (sample) statSamples.set(key, sample);
-      rows.push({
-        ...summary,
-        key,
-        label: participantShortLabel(track.participantIdentity),
-        sourceLabel: sourceLabel(track.source),
-        direction: "recv",
-      });
-    }),
-  ]);
-  // Stable order: self first, then remotes alphabetically, so rows don't
-  // jump between polls.
-  rows.sort((a, b) =>
-    a.direction === b.direction
-      ? a.label.localeCompare(b.label)
-      : a.direction === "send"
-        ? -1
-        : 1,
-  );
-  statRows.value = rows;
+  if (statsSampling) return;
+  statsSampling = true;
+  try {
+    const local = localTracks.value.filter((track) => track.kind === "video");
+    const remote = remoteTracks.value.filter((track) => track.kind === "video");
+    const rows = (
+      await Promise.all([
+        ...local.map((track) =>
+          rowForTrack(track, `local:${track.source}:${track.publicationSid}`, "send", "You", track.source),
+        ),
+        ...remote.map((track) =>
+          rowForTrack(
+            track,
+            `remote:${track.participantIdentity}:${track.source}:${track.publicationSid}`,
+            "recv",
+            participantShortLabel(track.participantIdentity),
+            track.source,
+          ),
+        ),
+      ])
+    ).filter((row): row is CallStatRow => row !== null);
+    // Stable order: self first, then remotes alphabetically, so rows don't
+    // jump between polls.
+    rows.sort((a, b) =>
+      a.direction === b.direction
+        ? a.label.localeCompare(b.label)
+        : a.direction === "send"
+          ? -1
+          : 1,
+    );
+    statRows.value = rows;
+  } finally {
+    statsSampling = false;
+  }
 }
 
 function startStatsPolling(): void {
@@ -168,6 +188,7 @@ function stopStatsPolling(): void {
     clearInterval(statsTimer);
     statsTimer = null;
   }
+  statsSampling = false;
   statSamples.clear();
   statRows.value = [];
 }
@@ -238,6 +259,11 @@ watch(open, async (isOpen) => {
     return;
   }
   await refresh();
+  // `refresh()` awaited device enumeration; if the dialog was closed in
+  // the meantime, bail before wiring up listeners/polling — otherwise a
+  // closed dialog would keep a 1s `getStats()` interval (and the
+  // devicechange listener) running until the next open→close cycle.
+  if (!open.value) return;
   // Begin the 1s diagnostics poll now that the dialog is visible; it
   // tears down again on close / unmount.
   startStatsPolling();

--- a/chat/src/components/calls/CallSettingsDialog.vue
+++ b/chat/src/components/calls/CallSettingsDialog.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { computed, onScopeDispose, ref, watch } from "vue";
 import { useStore } from "@nanostores/vue";
-import { Check, Mic, Speaker, Video, X } from "lucide-vue-next";
+import { Activity, Check, Mic, Speaker, Video, X } from "lucide-vue-next";
 import AppDialog from "@/components/ui/AppDialog.vue";
 import {
   $devicePrefs,
@@ -16,6 +16,12 @@ import { $micAudioProcessing } from "@/lib/calls/mic-audio-processing-state";
 import { audioProcessingRows } from "@/lib/calls/mic-audio-processing";
 import { useCallEngine } from "@/lib/calls/use-call-engine";
 import { reportCallError } from "@/lib/calls/call-store";
+import {
+  describeVideoStats,
+  summarizeVideoStats,
+  type CallStatRow,
+  type CallStatSample,
+} from "@/lib/calls/call-stats";
 
 /**
  * Settings dialog the call surface opens for mic/camera/output
@@ -73,7 +79,101 @@ async function refresh(): Promise<void> {
   devices.value = next;
 }
 
-const { engine } = useCallEngine();
+const { engine, remoteTracks, localTracks } = useCallEngine();
+
+/**
+ * Live call diagnostics. Polls `getRTCStatsReport()` for every published
+ * (send) and subscribed (recv) video track once per second — but ONLY
+ * while this dialog is open (started/stopped in the `open` watcher), so a
+ * normal call pays zero stats cost. `statSamples` carries the previous
+ * byte/timestamp pair per track so bitrate can be derived as a rate.
+ */
+const statRows = ref<CallStatRow[]>([]);
+const statSamples = new Map<string, CallStatSample>();
+let statsTimer: ReturnType<typeof setInterval> | null = null;
+
+const statDisplayRows = computed(() =>
+  statRows.value.map((row) => ({
+    key: row.key,
+    label: row.label,
+    sourceLabel: row.sourceLabel,
+    ...describeVideoStats(row),
+  })),
+);
+
+function participantShortLabel(identity: string): string {
+  const at = identity.indexOf("@");
+  const local = at > 0 ? identity.slice(0, at) : identity;
+  return local || identity;
+}
+
+function sourceLabel(source: string): string {
+  return source === "screen_share" ? "Screen" : "Camera";
+}
+
+async function sampleStats(): Promise<void> {
+  const local = localTracks.value.filter((track) => track.kind === "video");
+  const remote = remoteTracks.value.filter((track) => track.kind === "video");
+  const rows: CallStatRow[] = [];
+  await Promise.all([
+    ...local.map(async (track) => {
+      const key = `local:${track.source}:${track.publicationSid}`;
+      const report = await track.track.getRTCStatsReport();
+      if (!report) return;
+      const { summary, sample } = summarizeVideoStats(report, "send", statSamples.get(key));
+      if (sample) statSamples.set(key, sample);
+      rows.push({
+        ...summary,
+        key,
+        label: "You",
+        sourceLabel: sourceLabel(track.source),
+        direction: "send",
+      });
+    }),
+    ...remote.map(async (track) => {
+      const key = `remote:${track.participantIdentity}:${track.source}:${track.publicationSid}`;
+      const report = await track.track.getRTCStatsReport();
+      if (!report) return;
+      const { summary, sample } = summarizeVideoStats(report, "recv", statSamples.get(key));
+      if (sample) statSamples.set(key, sample);
+      rows.push({
+        ...summary,
+        key,
+        label: participantShortLabel(track.participantIdentity),
+        sourceLabel: sourceLabel(track.source),
+        direction: "recv",
+      });
+    }),
+  ]);
+  // Stable order: self first, then remotes alphabetically, so rows don't
+  // jump between polls.
+  rows.sort((a, b) =>
+    a.direction === b.direction
+      ? a.label.localeCompare(b.label)
+      : a.direction === "send"
+        ? -1
+        : 1,
+  );
+  statRows.value = rows;
+}
+
+function startStatsPolling(): void {
+  stopStatsPolling();
+  void sampleStats();
+  statsTimer = setInterval(() => void sampleStats(), 1000);
+}
+
+function stopStatsPolling(): void {
+  if (statsTimer) {
+    clearInterval(statsTimer);
+    statsTimer = null;
+  }
+  statSamples.clear();
+  statRows.value = [];
+}
+
+// A dialog unmounted while still open must not leak its interval.
+onScopeDispose(stopStatsPolling);
 
 async function selectMic(id: string | null): Promise<void> {
   setMicDevice(id);
@@ -134,9 +234,13 @@ watch(open, async (isOpen) => {
     // gets dropped on resolve, and detach the devicechange listener.
     enumerateEpoch += 1;
     teardownDeviceChange();
+    stopStatsPolling();
     return;
   }
   await refresh();
+  // Begin the 1s diagnostics poll now that the dialog is visible; it
+  // tears down again on close / unmount.
+  startStatsPolling();
   // Mount the devicechange listener after the first refresh so the
   // initial enumeration isn't fighting a hot-plug event arriving in
   // the same tick. Debounced 200ms because hot-plugs commonly fire
@@ -345,6 +449,39 @@ function close(): void {
           </li>
         </ul>
       </section>
+
+      <!-- Diagnostics: live per-track WebRTC stats. Polled only while
+           this dialog is open (see the `open` watcher). -->
+      <section class="chat-section-card">
+        <div class="flex items-center gap-2 mb-2">
+          <Activity class="w-4 h-4 text-muted-foreground" />
+          <h3 class="type-control">Diagnostics</h3>
+        </div>
+        <p
+          v-if="statDisplayRows.length === 0"
+          class="type-caption text-muted-foreground"
+        >
+          No active video. Start your camera or screen share to see live
+          resolution, bitrate, and packet-loss stats.
+        </p>
+        <ul v-else class="call-stats">
+          <li v-for="row in statDisplayRows" :key="row.key" class="call-stats__row">
+            <div class="call-stats__head">
+              <span class="type-caption call-stats__peer">
+                {{ row.label }} · {{ row.sourceLabel }}
+              </span>
+              <span class="type-caption text-muted-foreground call-stats__res">
+                {{ row.resolution }} · {{ row.fps }}
+              </span>
+            </div>
+            <div class="call-stats__metrics type-caption text-muted-foreground">
+              <span>{{ row.bitrate }}</span>
+              <span>loss {{ row.loss }}</span>
+              <span>{{ row.rtt }}</span>
+            </div>
+          </li>
+        </ul>
+      </section>
     </div>
 
     <footer class="chat-dialog-footer">
@@ -436,5 +573,39 @@ function close(): void {
 
 .call-processing__detail {
   line-height: 1.3;
+}
+
+.call-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.call-stats__row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.call-stats__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-sm);
+}
+
+.call-stats__peer {
+  color: var(--foreground);
+}
+
+.call-stats__res {
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.call-stats__metrics {
+  display: flex;
+  gap: var(--space-sm);
+  font-variant-numeric: tabular-nums;
 }
 </style>

--- a/chat/src/components/calls/CallSettingsDialog.vue
+++ b/chat/src/components/calls/CallSettingsDialog.vue
@@ -82,8 +82,8 @@ async function refresh(): Promise<void> {
 const { engine, remoteTracks, localTracks } = useCallEngine();
 
 /**
- * Live call diagnostics. Polls `getRTCStatsReport()` for every published
- * (send) and subscribed (recv) video track once per second — but ONLY
+ * Live call diagnostics. Polls each published (send) and subscribed
+ * (recv) video track's `getRTCStatsReport()` once per second — but ONLY
  * while this dialog is open (started/stopped in the `open` watcher), so a
  * normal call pays zero stats cost. `statSamples` carries the previous
  * byte/timestamp pair per track so bitrate can be derived as a rate.
@@ -95,6 +95,11 @@ let statsTimer: ReturnType<typeof setInterval> | null = null;
 // next interval fire a second concurrent pass (which would diff against a
 // half-updated sample map and could write rows out of order).
 let statsSampling = false;
+// Bumped every start/stop. A tick captures the generation at launch and
+// re-checks it after its awaits before committing any sample or row, so an
+// in-flight pass that outlives a close/reopen (or a switch to another call)
+// can never repopulate state for a session that has already torn down.
+let statsGeneration = 0;
 
 const statDisplayRows = computed(() =>
   statRows.value.map((row) => ({
@@ -115,44 +120,50 @@ function sourceLabel(source: string): string {
   return source === "screen_share" ? "Screen" : "Camera";
 }
 
+/** One track's sampled row plus the fresh byte/timestamp sample to retain. */
+type TrackSample = { row: CallStatRow; key: string; sample: CallStatSample | null };
+
 /**
- * Read and summarize one video track's stats into a row, or `null` when
- * the report is unavailable. `getRTCStatsReport()` rejects when a
- * sender/receiver is mid-teardown (track unpublished, ICE restart, peer
- * leaving) — common exactly while a poll is running — so a failure drops
- * that single row rather than rejecting the whole tick.
+ * Read and summarize one video track's stats, or `null` when the report
+ * is unavailable. `getRTCStatsReport()` rejects when a sender/receiver is
+ * mid-teardown (track unpublished, ICE restart, peer leaving) — common
+ * exactly while a poll is running — so a failure drops that single row
+ * rather than rejecting the whole tick.
+ *
+ * Pure read: the fresh `sample` is RETURNED, not written to `statSamples`
+ * here, so the caller can commit it atomically only after re-checking the
+ * polling generation (a stale in-flight pass must not mutate the map).
  */
-async function rowForTrack(
+async function sampleTrack(
   track: { track: { getRTCStatsReport(): Promise<RTCStatsReport | undefined> } },
   key: string,
   direction: "send" | "recv",
   label: string,
   source: string,
-): Promise<CallStatRow | null> {
+): Promise<TrackSample | null> {
   try {
     const report = await track.track.getRTCStatsReport();
     if (!report) return null;
     const { summary, sample } = summarizeVideoStats(report, direction, statSamples.get(key));
-    if (sample) statSamples.set(key, sample);
-    return { ...summary, key, label, sourceLabel: sourceLabel(source), direction };
+    return { row: { ...summary, key, label, sourceLabel: sourceLabel(source), direction }, key, sample };
   } catch {
     return null;
   }
 }
 
-async function sampleStats(): Promise<void> {
+async function sampleStats(generation: number): Promise<void> {
   if (statsSampling) return;
   statsSampling = true;
   try {
     const local = localTracks.value.filter((track) => track.kind === "video");
     const remote = remoteTracks.value.filter((track) => track.kind === "video");
-    const rows = (
+    const results = (
       await Promise.all([
         ...local.map((track) =>
-          rowForTrack(track, `local:${track.source}:${track.publicationSid}`, "send", "You", track.source),
+          sampleTrack(track, `local:${track.source}:${track.publicationSid}`, "send", "You", track.source),
         ),
         ...remote.map((track) =>
-          rowForTrack(
+          sampleTrack(
             track,
             `remote:${track.participantIdentity}:${track.source}:${track.publicationSid}`,
             "recv",
@@ -161,7 +172,15 @@ async function sampleStats(): Promise<void> {
           ),
         ),
       ])
-    ).filter((row): row is CallStatRow => row !== null);
+    ).filter((result): result is TrackSample => result !== null);
+    // Bail if polling was stopped/restarted while we awaited: this pass
+    // belongs to a torn-down session and must not touch live state.
+    if (generation !== statsGeneration) return;
+    // Commit samples + rows together, now that the generation is confirmed.
+    for (const result of results) {
+      if (result.sample) statSamples.set(result.key, result.sample);
+    }
+    const rows = results.map((result) => result.row);
     // Stable order: self first, then remotes alphabetically, so rows don't
     // jump between polls.
     rows.sort((a, b) =>
@@ -179,16 +198,18 @@ async function sampleStats(): Promise<void> {
 
 function startStatsPolling(): void {
   stopStatsPolling();
-  void sampleStats();
-  statsTimer = setInterval(() => void sampleStats(), 1000);
+  const generation = ++statsGeneration;
+  statsTimer = setInterval(() => void sampleStats(generation), 1000);
+  void sampleStats(generation);
 }
 
 function stopStatsPolling(): void {
+  // Invalidate any in-flight tick so its post-await commit no-ops.
+  statsGeneration += 1;
   if (statsTimer) {
     clearInterval(statsTimer);
     statsTimer = null;
   }
-  statsSampling = false;
   statSamples.clear();
   statRows.value = [];
 }

--- a/chat/src/lib/calls/call-stats.ts
+++ b/chat/src/lib/calls/call-stats.ts
@@ -1,0 +1,159 @@
+/**
+ * Pure WebRTC-stats parsing for the call diagnostics section.
+ *
+ * LiveKit exposes `publication.getRTCStatsReport()` per track; this
+ * module turns one such `RTCStatsReport` into a small, display-ready
+ * summary. Bitrate is a rate, so it needs two samples — the caller keeps
+ * the previous `CallStatSample` per track and passes it back in.
+ *
+ * Everything here is pure (no timers, no LiveKit, no DOM beyond the
+ * standard `RTCStatsReport` shape) so it is unit-testable in isolation;
+ * the polling lifecycle lives in the dialog that owns it.
+ */
+
+export type CallStatDirection = "send" | "recv";
+
+/** Byte/timestamp pair carried between polls to derive a bitrate. */
+export type CallStatSample = { bytes: number; timestampMs: number };
+
+export type VideoStatsSummary = {
+  /** "1920×1080", or null when the track isn't reporting frames yet. */
+  resolution: string | null;
+  fps: number | null;
+  bitrateKbps: number | null;
+  packetLossPct: number | null;
+  rttMs: number | null;
+};
+
+/** A single diagnostics row: one video track of one participant. */
+export type CallStatRow = VideoStatsSummary & {
+  key: string;
+  label: string;
+  sourceLabel: string;
+  direction: CallStatDirection;
+};
+
+/** Display-ready strings for a row; null metrics render as an em dash. */
+export type VideoStatsDisplay = {
+  resolution: string;
+  fps: string;
+  bitrate: string;
+  loss: string;
+  rtt: string;
+};
+
+/**
+ * Loose view over the RTCStats entries we read. The DOM lib types don't
+ * cover every field consistently across browsers (e.g. `framesPerSecond`,
+ * `frameWidth`), so we read through optional numbers rather than fight
+ * the partial typings — values that are absent simply stay null.
+ */
+type RtpLike = {
+  type?: string;
+  kind?: string;
+  mediaType?: string;
+  frameWidth?: number;
+  frameHeight?: number;
+  framesPerSecond?: number;
+  bytesSent?: number;
+  bytesReceived?: number;
+  packetsSent?: number;
+  packetsReceived?: number;
+  packetsLost?: number;
+  roundTripTime?: number;
+  currentRoundTripTime?: number;
+  timestamp?: number;
+};
+
+function isVideo(stat: RtpLike): boolean {
+  return stat.kind === "video" || stat.mediaType === "video";
+}
+
+function clampPercent(value: number): number {
+  if (!Number.isFinite(value) || value < 0) return 0;
+  if (value > 100) return 100;
+  return Math.round(value * 10) / 10;
+}
+
+/**
+ * Reduce one track's `RTCStatsReport` to a `VideoStatsSummary` plus the
+ * fresh `CallStatSample` to retain for next time. `direction` selects the
+ * outbound (local publish) vs inbound (remote subscribe) RTP stream.
+ *
+ * Bitrate is computed by diffing byte counters against `prev`; on the
+ * first poll (`prev` undefined) it is null and fills in on the next tick.
+ */
+export function summarizeVideoStats(
+  report: RTCStatsReport,
+  direction: CallStatDirection,
+  prev?: CallStatSample,
+): { summary: VideoStatsSummary; sample: CallStatSample | null } {
+  const mainType = direction === "send" ? "outbound-rtp" : "inbound-rtp";
+  let main: RtpLike | undefined;
+  let remoteInbound: RtpLike | undefined;
+  let candidatePair: RtpLike | undefined;
+
+  report.forEach((raw: unknown) => {
+    const stat = raw as RtpLike;
+    if (stat.type === mainType && isVideo(stat)) {
+      main = stat;
+    } else if (stat.type === "remote-inbound-rtp" && isVideo(stat)) {
+      remoteInbound = stat;
+    } else if (stat.type === "candidate-pair" && stat.currentRoundTripTime !== undefined) {
+      candidatePair = stat;
+    }
+  });
+
+  const resolution =
+    main?.frameWidth && main?.frameHeight ? `${main.frameWidth}×${main.frameHeight}` : null;
+  const fps =
+    main?.framesPerSecond !== undefined ? Math.round(main.framesPerSecond) : null;
+
+  const bytes = direction === "send" ? main?.bytesSent : main?.bytesReceived;
+  const timestampMs = main?.timestamp;
+  const sample: CallStatSample | null =
+    bytes !== undefined && timestampMs !== undefined ? { bytes, timestampMs } : null;
+
+  let bitrateKbps: number | null = null;
+  if (sample && prev && sample.timestampMs > prev.timestampMs) {
+    const deltaBits = (sample.bytes - prev.bytes) * 8;
+    const deltaSec = (sample.timestampMs - prev.timestampMs) / 1000;
+    const kbps = deltaBits / deltaSec / 1000;
+    bitrateKbps = kbps > 0 ? Math.round(kbps) : 0;
+  }
+
+  let packetLossPct: number | null = null;
+  if (direction === "recv" && main?.packetsLost !== undefined && main?.packetsReceived !== undefined) {
+    const total = main.packetsLost + main.packetsReceived;
+    packetLossPct = total > 0 ? clampPercent((main.packetsLost / total) * 100) : 0;
+  } else if (direction === "send" && remoteInbound?.packetsLost !== undefined && main?.packetsSent) {
+    packetLossPct = clampPercent((remoteInbound.packetsLost / main.packetsSent) * 100);
+  }
+
+  let rttMs: number | null = null;
+  const rttSec =
+    direction === "send" && remoteInbound?.roundTripTime !== undefined
+      ? remoteInbound.roundTripTime
+      : candidatePair?.currentRoundTripTime;
+  if (rttSec !== undefined) rttMs = Math.round(rttSec * 1000);
+
+  return { summary: { resolution, fps, bitrateKbps, packetLossPct, rttMs }, sample };
+}
+
+/** Format kbps as a compact "x.y Mbps" / "n kbps" string. */
+export function formatBitrate(bitrateKbps: number | null): string {
+  if (bitrateKbps === null) return "—";
+  if (bitrateKbps >= 1000) return `${(bitrateKbps / 1000).toFixed(1)} Mbps`;
+  return `${bitrateKbps} kbps`;
+}
+
+/** Turn a numeric summary into display strings (null → em dash). */
+export function describeVideoStats(summary: VideoStatsSummary): VideoStatsDisplay {
+  return {
+    resolution: summary.resolution ?? "—",
+    fps: summary.fps !== null ? `${summary.fps} fps` : "—",
+    bitrate: formatBitrate(summary.bitrateKbps),
+    loss: summary.packetLossPct !== null ? `${summary.packetLossPct}%` : "—",
+    rtt: summary.rttMs !== null ? `${summary.rttMs} ms` : "—",
+  };
+}

--- a/chat/src/lib/calls/call-stats.ts
+++ b/chat/src/lib/calls/call-stats.ts
@@ -1,7 +1,8 @@
 /**
  * Pure WebRTC-stats parsing for the call diagnostics section.
  *
- * LiveKit exposes `publication.getRTCStatsReport()` per track; this
+ * LiveKit exposes `getRTCStatsReport()` on each `LocalTrack` /
+ * `RemoteTrack` (the diagnostics poller calls it on the track); this
  * module turns one such `RTCStatsReport` into a small, display-ready
  * summary. Bitrate is a rate, so it needs two samples — the caller keeps
  * the previous `CallStatSample` per track and passes it back in.

--- a/chat/src/lib/calls/call-stats.ts
+++ b/chat/src/lib/calls/call-stats.ts
@@ -62,6 +62,7 @@ type RtpLike = {
   packetsLost?: number;
   roundTripTime?: number;
   currentRoundTripTime?: number;
+  nominated?: boolean;
   timestamp?: number;
 };
 
@@ -80,8 +81,16 @@ function clampPercent(value: number): number {
  * fresh `CallStatSample` to retain for next time. `direction` selects the
  * outbound (local publish) vs inbound (remote subscribe) RTP stream.
  *
- * Bitrate is computed by diffing byte counters against `prev`; on the
- * first poll (`prev` undefined) it is null and fills in on the next tick.
+ * Simulcast matters here: a published camera/screen with simulcast on
+ * produces ONE `outbound-rtp` entry per layer, so the byte/packet
+ * counters are aggregated across layers (sum) and the resolution/fps are
+ * taken from the largest active layer — picking a single arbitrary entry
+ * would under-report bitrate and show a random layer's size. A receiver
+ * decodes one forwarded layer, so the inbound side is naturally a single
+ * entry, but the same aggregation handles it correctly.
+ *
+ * Bitrate is computed by diffing the summed byte counter against `prev`;
+ * on the first poll (`prev` undefined) it is null and fills in next tick.
  */
 export function summarizeVideoStats(
   report: RTCStatsReport,
@@ -89,28 +98,46 @@ export function summarizeVideoStats(
   prev?: CallStatSample,
 ): { summary: VideoStatsSummary; sample: CallStatSample | null } {
   const mainType = direction === "send" ? "outbound-rtp" : "inbound-rtp";
-  let main: RtpLike | undefined;
-  let remoteInbound: RtpLike | undefined;
+  const mains: RtpLike[] = [];
+  const remoteInbounds: RtpLike[] = [];
   let candidatePair: RtpLike | undefined;
 
   report.forEach((raw: unknown) => {
     const stat = raw as RtpLike;
     if (stat.type === mainType && isVideo(stat)) {
-      main = stat;
+      mains.push(stat);
     } else if (stat.type === "remote-inbound-rtp" && isVideo(stat)) {
-      remoteInbound = stat;
+      remoteInbounds.push(stat);
     } else if (stat.type === "candidate-pair" && stat.currentRoundTripTime !== undefined) {
-      candidatePair = stat;
+      // Prefer the nominated/selected pair; a failed pair can also carry
+      // an RTT, so don't let it shadow the active path.
+      if (!candidatePair || stat.nominated) candidatePair = stat;
     }
   });
 
+  // Resolution + fps from the top (largest-area) active layer.
+  let top: RtpLike | undefined;
+  for (const main of mains) {
+    if (!main.frameWidth || !main.frameHeight) continue;
+    const area = main.frameWidth * main.frameHeight;
+    const topArea = top?.frameWidth && top?.frameHeight ? top.frameWidth * top.frameHeight : 0;
+    if (area > topArea) top = main;
+  }
   const resolution =
-    main?.frameWidth && main?.frameHeight ? `${main.frameWidth}×${main.frameHeight}` : null;
-  const fps =
-    main?.framesPerSecond !== undefined ? Math.round(main.framesPerSecond) : null;
+    top?.frameWidth && top?.frameHeight ? `${top.frameWidth}×${top.frameHeight}` : null;
+  const fps = top?.framesPerSecond !== undefined ? Math.round(top.framesPerSecond) : null;
 
-  const bytes = direction === "send" ? main?.bytesSent : main?.bytesReceived;
-  const timestampMs = main?.timestamp;
+  // Bytes summed across all layers; timestamp is the newest layer's.
+  const bytesField = direction === "send" ? "bytesSent" : "bytesReceived";
+  let bytes: number | undefined;
+  let timestampMs: number | undefined;
+  for (const main of mains) {
+    const layerBytes = main[bytesField];
+    if (layerBytes !== undefined) bytes = (bytes ?? 0) + layerBytes;
+    if (main.timestamp !== undefined && (timestampMs === undefined || main.timestamp > timestampMs)) {
+      timestampMs = main.timestamp;
+    }
+  }
   const sample: CallStatSample | null =
     bytes !== undefined && timestampMs !== undefined ? { bytes, timestampMs } : null;
 
@@ -122,22 +149,63 @@ export function summarizeVideoStats(
     bitrateKbps = kbps > 0 ? Math.round(kbps) : 0;
   }
 
-  let packetLossPct: number | null = null;
-  if (direction === "recv" && main?.packetsLost !== undefined && main?.packetsReceived !== undefined) {
-    const total = main.packetsLost + main.packetsReceived;
-    packetLossPct = total > 0 ? clampPercent((main.packetsLost / total) * 100) : 0;
-  } else if (direction === "send" && remoteInbound?.packetsLost !== undefined && main?.packetsSent) {
-    packetLossPct = clampPercent((remoteInbound.packetsLost / main.packetsSent) * 100);
-  }
+  const packetLossPct =
+    direction === "recv"
+      ? recvPacketLoss(mains)
+      : sendPacketLoss(mains, remoteInbounds);
 
-  let rttMs: number | null = null;
-  const rttSec =
-    direction === "send" && remoteInbound?.roundTripTime !== undefined
-      ? remoteInbound.roundTripTime
-      : candidatePair?.currentRoundTripTime;
-  if (rttSec !== undefined) rttMs = Math.round(rttSec * 1000);
+  let rttSec: number | undefined;
+  if (direction === "send") {
+    // RTT is a path property (≈equal across layers); take the largest
+    // reported remote-inbound RTT, falling back to the candidate pair.
+    for (const remote of remoteInbounds) {
+      if (remote.roundTripTime !== undefined) {
+        rttSec = rttSec === undefined ? remote.roundTripTime : Math.max(rttSec, remote.roundTripTime);
+      }
+    }
+  }
+  if (rttSec === undefined) rttSec = candidatePair?.currentRoundTripTime;
+  const rttMs = rttSec !== undefined ? Math.round(rttSec * 1000) : null;
 
   return { summary: { resolution, fps, bitrateKbps, packetLossPct, rttMs }, sample };
+}
+
+/** Inbound loss: summed lost / (lost + received) across decoded entries. */
+function recvPacketLoss(mains: RtpLike[]): number | null {
+  let lost = 0;
+  let received = 0;
+  let have = false;
+  for (const main of mains) {
+    if (main.packetsLost !== undefined) {
+      lost += main.packetsLost;
+      have = true;
+    }
+    if (main.packetsReceived !== undefined) {
+      received += main.packetsReceived;
+      have = true;
+    }
+  }
+  if (!have) return null;
+  const total = lost + received;
+  return total > 0 ? clampPercent((lost / total) * 100) : 0;
+}
+
+/** Outbound loss: summed remote-reported lost / summed packets sent. */
+function sendPacketLoss(mains: RtpLike[], remoteInbounds: RtpLike[]): number | null {
+  let lost = 0;
+  let haveLost = false;
+  for (const remote of remoteInbounds) {
+    if (remote.packetsLost !== undefined) {
+      lost += remote.packetsLost;
+      haveLost = true;
+    }
+  }
+  let sent = 0;
+  for (const main of mains) {
+    if (main.packetsSent !== undefined) sent += main.packetsSent;
+  }
+  if (!haveLost || sent <= 0) return null;
+  return clampPercent((lost / sent) * 100);
 }
 
 /** Format kbps as a compact "x.y Mbps" / "n kbps" string. */

--- a/chat/src/lib/calls/connection-quality.ts
+++ b/chat/src/lib/calls/connection-quality.ts
@@ -42,8 +42,8 @@ export type ConnectionChip = {
 /**
  * Live inputs for the self-quality indicator. Set by the engine
  * subscription in `use-call-engine`; read by `CallConnectionIndicator`.
- * Defaults describe "no call / nothing known yet" so the indicator stays
- * hidden until the first real quality sample arrives.
+ * Defaults describe "no call / nothing known yet" so the indicator shows
+ * quiet measuring bars until the first real quality sample arrives.
  */
 export const $callConnectionQuality = atom<CallConnectionQuality>("unknown");
 export const $callConnectionPhase = atom<CallConnectionPhase>("disconnected");
@@ -67,15 +67,22 @@ export function resetCallConnectionQuality(): void {
 }
 
 /**
- * Pure mapping from (quality, phase) to the chip rendering model, or
- * `null` when the indicator should be hidden entirely (nothing known
- * yet, or no active call). A reconnecting transport overrides the last
- * quality sample — the bars are meaningless while the path is down.
+ * Pure mapping from (quality, phase) to the chip rendering model. Always
+ * returns a chip so the indicator holds a stable footprint in the call
+ * bar — `unknown` renders quiet, empty "measuring" bars rather than
+ * vanishing, which would reflow the centered control row when the first
+ * sample lands.
+ *
+ * A reconnecting transport overrides the last quality sample with
+ * "Reconnecting…" — the bars are meaningless while the path is down.
+ * `lost` is a per-participant quality score independent of the transport
+ * phase, so it gets its own "Connection lost" label rather than falsely
+ * claiming a reconnection is underway.
  */
 export function qualityToChip(
   quality: CallConnectionQuality,
   phase: CallConnectionPhase,
-): ConnectionChip | null {
+): ConnectionChip {
   if (phase === "reconnecting") {
     return { bars: 0, tone: "danger", label: "Reconnecting…" };
   }
@@ -87,8 +94,8 @@ export function qualityToChip(
     case "poor":
       return { bars: 1, tone: "warn", label: "Poor connection" };
     case "lost":
-      return { bars: 0, tone: "danger", label: "Reconnecting…" };
+      return { bars: 0, tone: "danger", label: "Connection lost" };
     case "unknown":
-      return null;
+      return { bars: 0, tone: "neutral", label: null };
   }
 }

--- a/chat/src/lib/calls/connection-quality.ts
+++ b/chat/src/lib/calls/connection-quality.ts
@@ -1,0 +1,94 @@
+import { atom } from "nanostores";
+
+/**
+ * The local participant's call connection health, as a domain union
+ * decoupled from LiveKit's `ConnectionQuality` enum. The engine (the
+ * boundary to LiveKit) translates the SDK enum into these values via
+ * `mapLiveKitConnectionQuality`, so this module — and the UI that reads
+ * it — never imports `livekit-client`, stays trivially unit-testable,
+ * and is insulated from SDK enum churn.
+ */
+export type CallConnectionQuality =
+  | "excellent"
+  | "good"
+  | "poor"
+  | "lost"
+  | "unknown";
+
+/**
+ * The room transport phase, distilled from LiveKit's `ConnectionState`.
+ * `reconnecting` covers both ICE and signal reconnection — either way
+ * the indicator should say so. Distinct from quality because a transport
+ * that is re-establishing should override whatever the last quality
+ * sample said.
+ */
+export type CallConnectionPhase = "connected" | "reconnecting" | "disconnected";
+
+/** Visual tone of the indicator, mapped to the badge color tokens. */
+type ConnectionChipTone = "neutral" | "warn" | "danger";
+
+/**
+ * Rendering model for the ambient signal-bars chip. `bars` is how many
+ * of the three segments are filled; `label` is `null` when the
+ * connection is healthy (bars alone, no nagging text) and a short string
+ * when it has degraded.
+ */
+export type ConnectionChip = {
+  bars: 0 | 1 | 2 | 3;
+  tone: ConnectionChipTone;
+  label: string | null;
+};
+
+/**
+ * Live inputs for the self-quality indicator. Set by the engine
+ * subscription in `use-call-engine`; read by `CallConnectionIndicator`.
+ * Defaults describe "no call / nothing known yet" so the indicator stays
+ * hidden until the first real quality sample arrives.
+ */
+export const $callConnectionQuality = atom<CallConnectionQuality>("unknown");
+export const $callConnectionPhase = atom<CallConnectionPhase>("disconnected");
+
+export function setCallConnectionQuality(quality: CallConnectionQuality): void {
+  $callConnectionQuality.set(quality);
+}
+
+export function setCallConnectionPhase(phase: CallConnectionPhase): void {
+  $callConnectionPhase.set(phase);
+}
+
+/**
+ * Reset to the "no call" baseline. Called on engine disconnect so a
+ * stale `poor`/`reconnecting` from the call that just ended cannot bleed
+ * into the next call's first render.
+ */
+export function resetCallConnectionQuality(): void {
+  $callConnectionQuality.set("unknown");
+  $callConnectionPhase.set("disconnected");
+}
+
+/**
+ * Pure mapping from (quality, phase) to the chip rendering model, or
+ * `null` when the indicator should be hidden entirely (nothing known
+ * yet, or no active call). A reconnecting transport overrides the last
+ * quality sample — the bars are meaningless while the path is down.
+ */
+export function qualityToChip(
+  quality: CallConnectionQuality,
+  phase: CallConnectionPhase,
+): ConnectionChip | null {
+  if (phase === "reconnecting") {
+    return { bars: 0, tone: "danger", label: "Reconnecting…" };
+  }
+  switch (quality) {
+    case "excellent":
+      return { bars: 3, tone: "neutral", label: null };
+    case "good":
+      return { bars: 2, tone: "neutral", label: null };
+    case "poor":
+      return { bars: 1, tone: "warn", label: "Poor connection" };
+    case "lost":
+      return { bars: 0, tone: "danger", label: "Reconnecting…" };
+    case "unknown":
+      return null;
+  }
+}

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -1,7 +1,9 @@
 import {
   Room,
   RoomEvent,
+  ScreenSharePresets,
   Track,
+  VideoPresets,
   type LocalParticipant,
   type LocalTrack,
   type LocalTrackPublication,
@@ -10,11 +12,43 @@ import {
   type RemoteTrack,
   type RemoteTrackPublication,
   type TrackPublication,
+  type TrackPublishOptions,
+  type VideoCaptureOptions,
 } from "livekit-client";
 import type { LiveKitJoin } from "./types";
 import { $devicePrefs } from "./device-prefs";
 import { validateLiveKitGrant } from "./dm-call-activity";
 import { activeMicAudioProcessing, type MicAudioProcessing } from "./mic-audio-processing";
+
+/**
+ * Camera capture ceiling. AdaptiveStream (`adaptiveStream: true`) and
+ * simulcast still scale each subscriber DOWN to the layer matching its
+ * rendered tile, so this only governs the maximum a large/expanded tile
+ * can pull — it is not the bandwidth every viewer pays. h1080 lifts the
+ * per-publisher upstream ceiling to ~3 Mbps (vs. 720p's 1.7 Mbps).
+ */
+const CAMERA_CAPTURE_RESOLUTION = VideoPresets.h1080.resolution;
+
+/**
+ * Screen-share encoding. 1080p@15fps keeps shared code/text crisp at a
+ * modest 2.5 Mbps; 15fps is plenty for slides, docs, and scrolling.
+ */
+const SCREEN_SHARE_ENCODING = ScreenSharePresets.h1080fps15.encoding;
+
+/**
+ * Per-source degradation under CPU / bandwidth pressure. A camera is a
+ * talking head: keep motion smooth and shed resolution
+ * (`maintain-framerate`). A screen share is usually text: keep it
+ * readable and shed frames (`maintain-resolution`). Passed per-publish
+ * because the two sources want opposite tradeoffs and `publishDefaults`
+ * is a single global value.
+ */
+const CAMERA_PUBLISH_OPTIONS: TrackPublishOptions = {
+  degradationPreference: "maintain-framerate",
+};
+const SCREEN_SHARE_PUBLISH_OPTIONS: TrackPublishOptions = {
+  degradationPreference: "maintain-resolution",
+};
 
 /**
  * Identifies a remote media track surfaced to the UI. The `kind`
@@ -218,6 +252,10 @@ export class CallEngine {
       },
       videoCaptureDefaults: {
         deviceId: prefs.cam ?? undefined,
+        resolution: CAMERA_CAPTURE_RESOLUTION,
+      },
+      publishDefaults: {
+        screenShareEncoding: SCREEN_SHARE_ENCODING,
       },
     });
     room.on(RoomEvent.TrackSubscribed, this.handleTrackSubscribed);
@@ -279,7 +317,11 @@ export class CallEngine {
 
   async setCameraEnabled(enabled: boolean): Promise<void> {
     if (!this.room) return;
-    await this.room.localParticipant.setCameraEnabled(enabled);
+    await this.room.localParticipant.setCameraEnabled(
+      enabled,
+      undefined,
+      CAMERA_PUBLISH_OPTIONS,
+    );
   }
 
   async setScreenShareEnabled(
@@ -288,12 +330,18 @@ export class CallEngine {
   ): Promise<void> {
     if (!this.room) return;
     try {
-      await this.room.localParticipant.setScreenShareEnabled(enabled, {
-        audio: opts.audio,
-      });
+      await this.room.localParticipant.setScreenShareEnabled(
+        enabled,
+        { audio: opts.audio },
+        SCREEN_SHARE_PUBLISH_OPTIONS,
+      );
     } catch (error) {
       if (!enabled || !opts.audio || !isUnsupportedScreenAudioError(error)) throw error;
-      await this.room.localParticipant.setScreenShareEnabled(true, { audio: false });
+      await this.room.localParticipant.setScreenShareEnabled(
+        true,
+        { audio: false },
+        SCREEN_SHARE_PUBLISH_OPTIONS,
+      );
     }
   }
 
@@ -641,7 +689,11 @@ function isUnsupportedScreenAudioError(error: unknown): boolean {
  */
 type CapturableParticipant = {
   setMicrophoneEnabled(enabled: boolean): Promise<unknown>;
-  setCameraEnabled(enabled: boolean): Promise<unknown>;
+  setCameraEnabled(
+    enabled: boolean,
+    options?: VideoCaptureOptions,
+    publishOptions?: TrackPublishOptions,
+  ): Promise<unknown>;
 };
 
 /**
@@ -668,7 +720,7 @@ export async function enableRequestedCapture(
   }
   if (opts.video) {
     try {
-      await participant.setCameraEnabled(true);
+      await participant.setCameraEnabled(true, undefined, CAMERA_PUBLISH_OPTIONS);
     } catch (error) {
       onError("video", error);
     }

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -1,4 +1,6 @@
 import {
+  ConnectionQuality,
+  ConnectionState,
   Room,
   RoomEvent,
   ScreenSharePresets,
@@ -16,6 +18,7 @@ import {
   type VideoCaptureOptions,
 } from "livekit-client";
 import type { LiveKitJoin } from "./types";
+import type { CallConnectionPhase, CallConnectionQuality } from "./connection-quality";
 import { $devicePrefs } from "./device-prefs";
 import { validateLiveKitGrant } from "./dm-call-activity";
 import { activeMicAudioProcessing, type MicAudioProcessing } from "./mic-audio-processing";
@@ -169,6 +172,19 @@ export type CallEngineEvents = {
    * were actually honored. See `mic-audio-processing.ts`.
    */
   micAudioProcessingChanged: (state: MicAudioProcessing) => void;
+  /**
+   * Fires when LiveKit re-scores the LOCAL participant's connection
+   * quality (`excellent` → `lost`). Remote participants' quality is
+   * intentionally not surfaced — the indicator is self-only. Push-based:
+   * no polling, no `getStats`.
+   */
+  connectionQualityChanged: (quality: CallConnectionQuality) => void;
+  /**
+   * Fires when the room transport phase changes (connected ↔
+   * reconnecting ↔ disconnected). Drives the "Reconnecting…" label,
+   * which must override the last quality sample while the path is down.
+   */
+  connectionPhaseChanged: (phase: CallConnectionPhase) => void;
 };
 
 /**
@@ -196,6 +212,8 @@ export class CallEngine {
     audioPlaybackStatusChanged: new Set(),
     mediaDevicesError: new Set(),
     micAudioProcessingChanged: new Set(),
+    connectionQualityChanged: new Set(),
+    connectionPhaseChanged: new Set(),
   };
 
   /** LiveKit identity of the local participant, populated once
@@ -269,6 +287,8 @@ export class CallEngine {
     room.on(RoomEvent.ActiveDeviceChanged, this.handleActiveDeviceChanged);
     room.on(RoomEvent.TrackMuted, this.handleTrackMuteChanged);
     room.on(RoomEvent.TrackUnmuted, this.handleTrackMuteChanged);
+    room.on(RoomEvent.ConnectionQualityChanged, this.handleConnectionQualityChanged);
+    room.on(RoomEvent.ConnectionStateChanged, this.handleConnectionStateChanged);
     try {
       await room.connect(join.url, join.token);
     } catch (err) {
@@ -423,6 +443,8 @@ export class CallEngine {
     room.off(RoomEvent.ActiveDeviceChanged, this.handleActiveDeviceChanged);
     room.off(RoomEvent.TrackMuted, this.handleTrackMuteChanged);
     room.off(RoomEvent.TrackUnmuted, this.handleTrackMuteChanged);
+    room.off(RoomEvent.ConnectionQualityChanged, this.handleConnectionQualityChanged);
+    room.off(RoomEvent.ConnectionStateChanged, this.handleConnectionStateChanged);
     await room.disconnect();
   }
 
@@ -607,6 +629,24 @@ export class CallEngine {
     this.emit("micAudioProcessingChanged", this.computeMicAudioProcessing());
   }
 
+  /**
+   * LiveKit re-scores connection quality for every participant; the
+   * self-only indicator cares about the local one. Remote participants'
+   * scores are dropped here rather than filtered downstream so the engine
+   * surface stays self-scoped.
+   */
+  private handleConnectionQualityChanged = (
+    quality: ConnectionQuality,
+    participant: Participant,
+  ) => {
+    if (!participant.isLocal) return;
+    this.emit("connectionQualityChanged", mapLiveKitConnectionQuality(quality));
+  };
+
+  private handleConnectionStateChanged = (state: ConnectionState) => {
+    this.emit("connectionPhaseChanged", mapLiveKitConnectionState(state));
+  };
+
   private clearParticipantAudioVolumes(): void {
     this.participantAudioVolumes = {};
     this.subscribedAudioTracks.clear();
@@ -671,6 +711,48 @@ export function mapTrackSource(
   if (source === Track.Source.ScreenShare) return "screen_share";
   if (source === Track.Source.ScreenShareAudio) return "screen_share_audio";
   return fallbackKind === "audio" ? "microphone" : "camera";
+}
+
+/**
+ * Translate LiveKit's `ConnectionQuality` enum into the SDK-free domain
+ * union the UI consumes. The boundary lives here (the engine wraps the
+ * `Room`), so `connection-quality.ts` stays free of `livekit-client`.
+ */
+export function mapLiveKitConnectionQuality(
+  quality: ConnectionQuality,
+): CallConnectionQuality {
+  switch (quality) {
+    case ConnectionQuality.Excellent:
+      return "excellent";
+    case ConnectionQuality.Good:
+      return "good";
+    case ConnectionQuality.Poor:
+      return "poor";
+    case ConnectionQuality.Lost:
+      return "lost";
+    default:
+      return "unknown";
+  }
+}
+
+/**
+ * Distil LiveKit's `ConnectionState` into the transport phase the
+ * indicator cares about. Both ICE (`Reconnecting`) and signal
+ * (`SignalReconnecting`) recovery collapse to `reconnecting`; everything
+ * pre-`Connected` is `disconnected` (the chip hides).
+ */
+export function mapLiveKitConnectionState(
+  state: ConnectionState,
+): CallConnectionPhase {
+  switch (state) {
+    case ConnectionState.Connected:
+      return "connected";
+    case ConnectionState.Reconnecting:
+    case ConnectionState.SignalReconnecting:
+      return "reconnecting";
+    default:
+      return "disconnected";
+  }
 }
 
 function isUnsupportedScreenAudioError(error: unknown): boolean {

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -739,7 +739,8 @@ export function mapLiveKitConnectionQuality(
  * Distil LiveKit's `ConnectionState` into the transport phase the
  * indicator cares about. Both ICE (`Reconnecting`) and signal
  * (`SignalReconnecting`) recovery collapse to `reconnecting`; everything
- * pre-`Connected` is `disconnected` (the chip hides).
+ * pre-`Connected` is `disconnected`, which pairs with the `unknown`
+ * quality to render the chip's quiet "measuring" bars.
  */
 export function mapLiveKitConnectionState(
   state: ConnectionState,

--- a/chat/src/lib/calls/use-call-engine.ts
+++ b/chat/src/lib/calls/use-call-engine.ts
@@ -12,6 +12,11 @@ import { clearAllMediaIssues, recordMediaIssue } from "./call-media-issues";
 import { syncScreenShareEnabled } from "./screen-share-state";
 import { setCallAudioPlaybackBlocked } from "./call-audio-playback";
 import { resetMicAudioProcessing, setMicAudioProcessing } from "./mic-audio-processing-state";
+import {
+  resetCallConnectionQuality,
+  setCallConnectionPhase,
+  setCallConnectionQuality,
+} from "./connection-quality";
 
 /**
  * Process-wide singleton: only one call engine should ever exist
@@ -82,6 +87,16 @@ export function useCallEngine(): {
       // mic — drives the read-only indicator in the call-settings dialog.
       setMicAudioProcessing(state);
     });
+    singletonEngine.on("connectionQualityChanged", (quality) => {
+      // LiveKit re-scored the local participant's connection — drives the
+      // ambient signal-bars chip on the call bar.
+      setCallConnectionQuality(quality);
+    });
+    singletonEngine.on("connectionPhaseChanged", (phase) => {
+      // Transport phase (connected ↔ reconnecting) — overrides the quality
+      // bars with a "Reconnecting…" label while the path is re-establishing.
+      setCallConnectionPhase(phase);
+    });
     singletonEngine.on("participantConnected", (identity) => {
       const roomJid = activeMucRoomJid();
       if (!roomJid) return;
@@ -103,6 +118,9 @@ export function useCallEngine(): {
       // The mic-processing readout belonged to the call that just
       // ended; reset so the next call's dialog starts from `no-mic`.
       resetMicAudioProcessing();
+      // Drop the connection-quality chip so a stale `poor`/`reconnecting`
+      // from the call that just ended can't bleed into the next call.
+      resetCallConnectionQuality();
       // The active call's room — if any — is no longer in our LK
       // view. Drop the LK snapshot so the room's UI reverts to the
       // Muji-derived (server-bridged) view, which the LK webhook

--- a/chat/tests/call-engine.test.ts
+++ b/chat/tests/call-engine.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, mock, test } from "bun:test";
 import {
   enableRequestedCapture,
+  mapLiveKitConnectionQuality,
+  mapLiveKitConnectionState,
   mapTrackSource,
   resolveParticipantAudioVolume,
   type CallEngineEvents,
@@ -8,7 +10,7 @@ import {
   type LocalMediaTrack,
   type RemoteMediaTrack,
 } from "../src/lib/calls/engine";
-import { Track } from "livekit-client";
+import { ConnectionQuality, ConnectionState, Track } from "livekit-client";
 import type { MicAudioProcessing } from "../src/lib/calls/mic-audio-processing";
 
 function deviceError(name: string): Error {
@@ -912,5 +914,117 @@ describe("call-engine — verifies applied mic audio processing", () => {
     const { CallEngine } = await import("../src/lib/calls/engine");
     const engine = new CallEngine();
     expect(typeof engine.on("micAudioProcessingChanged", () => {})).toBe("function");
+  });
+});
+
+describe("call-engine — 1080p capture ceiling + per-source degradation", () => {
+  function videoRoomStub() {
+    const camera: Array<{ enabled: boolean; options: unknown; publishOptions: unknown }> = [];
+    const screen: Array<{ enabled: boolean; options: unknown; publishOptions: unknown }> = [];
+    return {
+      camera,
+      screen,
+      room: {
+        localParticipant: {
+          async setCameraEnabled(enabled: boolean, options?: unknown, publishOptions?: unknown) {
+            camera.push({ enabled, options, publishOptions });
+          },
+          async setScreenShareEnabled(enabled: boolean, options?: unknown, publishOptions?: unknown) {
+            screen.push({ enabled, options, publishOptions });
+          },
+        },
+      },
+    };
+  }
+
+  test("setCameraEnabled publishes the camera with maintain-framerate degradation", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    const stub = videoRoomStub();
+    (engine as unknown as { room: unknown }).room = stub.room;
+    await engine.setCameraEnabled(true);
+    expect(stub.camera).toEqual([
+      {
+        enabled: true,
+        options: undefined,
+        publishOptions: { degradationPreference: "maintain-framerate" },
+      },
+    ]);
+  });
+
+  test("setScreenShareEnabled publishes the share with maintain-resolution degradation", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    const stub = videoRoomStub();
+    (engine as unknown as { room: unknown }).room = stub.room;
+    await engine.setScreenShareEnabled(true, { audio: false });
+    expect(stub.screen).toEqual([
+      {
+        enabled: true,
+        options: { audio: false },
+        publishOptions: { degradationPreference: "maintain-resolution" },
+      },
+    ]);
+  });
+
+  test("enableRequestedCapture publishes the camera with maintain-framerate degradation", async () => {
+    const camera: Array<{ enabled: boolean; publishOptions: unknown }> = [];
+    const stub = {
+      async setMicrophoneEnabled() {},
+      async setCameraEnabled(enabled: boolean, _options?: unknown, publishOptions?: unknown) {
+        camera.push({ enabled, publishOptions });
+      },
+    };
+    await enableRequestedCapture(stub, { audio: false, video: true }, () => {});
+    expect(camera).toEqual([
+      { enabled: true, publishOptions: { degradationPreference: "maintain-framerate" } },
+    ]);
+  });
+});
+
+describe("call-engine — self connection quality", () => {
+  test("maps every LiveKit ConnectionQuality into the domain union", () => {
+    expect(mapLiveKitConnectionQuality(ConnectionQuality.Excellent)).toBe("excellent");
+    expect(mapLiveKitConnectionQuality(ConnectionQuality.Good)).toBe("good");
+    expect(mapLiveKitConnectionQuality(ConnectionQuality.Poor)).toBe("poor");
+    expect(mapLiveKitConnectionQuality(ConnectionQuality.Lost)).toBe("lost");
+    expect(mapLiveKitConnectionQuality(ConnectionQuality.Unknown)).toBe("unknown");
+  });
+
+  test("collapses ICE and signal reconnection into a single reconnecting phase", () => {
+    expect(mapLiveKitConnectionState(ConnectionState.Connected)).toBe("connected");
+    expect(mapLiveKitConnectionState(ConnectionState.Reconnecting)).toBe("reconnecting");
+    expect(mapLiveKitConnectionState(ConnectionState.SignalReconnecting)).toBe("reconnecting");
+    expect(mapLiveKitConnectionState(ConnectionState.Connecting)).toBe("disconnected");
+    expect(mapLiveKitConnectionState(ConnectionState.Disconnected)).toBe("disconnected");
+  });
+
+  test("only the LOCAL participant's quality drives the self indicator", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    const events: string[] = [];
+    engine.on("connectionQualityChanged", (q) => events.push(q));
+    const handle = (
+      engine as unknown as {
+        handleConnectionQualityChanged: (q: ConnectionQuality, p: { isLocal: boolean }) => void;
+      }
+    ).handleConnectionQualityChanged;
+
+    handle(ConnectionQuality.Excellent, { isLocal: true });
+    handle(ConnectionQuality.Poor, { isLocal: false }); // remote — ignored
+    expect(events).toEqual(["excellent"]);
+  });
+
+  test("connection state changes emit the mapped transport phase", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    const phases: string[] = [];
+    engine.on("connectionPhaseChanged", (p) => phases.push(p));
+    (
+      engine as unknown as {
+        handleConnectionStateChanged: (s: ConnectionState) => void;
+      }
+    ).handleConnectionStateChanged(ConnectionState.Reconnecting);
+    expect(phases).toEqual(["reconnecting"]);
   });
 });

--- a/chat/tests/call-stats.test.ts
+++ b/chat/tests/call-stats.test.ts
@@ -53,6 +53,30 @@ describe("summarizeVideoStats — outbound (send) video", () => {
     expect(summary.bitrateKbps).toBe(3000);
     expect(describeVideoStats(summary).bitrate).toBe("3.0 Mbps");
   });
+
+  test("aggregates simulcast layers: summed bitrate/loss, top-layer resolution", () => {
+    // A 1080p simulcast publish reports one outbound-rtp PER layer; the
+    // summary must sum byte/packet counters and show the TOP layer's size,
+    // not whichever entry happens to be iterated last.
+    const layers = [
+      { type: "outbound-rtp", kind: "video", frameWidth: 480, frameHeight: 270, framesPerSecond: 30, bytesSent: 100_000, packetsSent: 100, timestamp: 11_000 },
+      { type: "outbound-rtp", kind: "video", frameWidth: 960, frameHeight: 540, framesPerSecond: 30, bytesSent: 300_000, packetsSent: 300, timestamp: 11_000 },
+      { type: "outbound-rtp", kind: "video", frameWidth: 1920, frameHeight: 1080, framesPerSecond: 30, bytesSent: 800_000, packetsSent: 800, timestamp: 11_000 },
+    ];
+    const remoteInbounds = [
+      { type: "remote-inbound-rtp", kind: "video", packetsLost: 10 },
+      { type: "remote-inbound-rtp", kind: "video", packetsLost: 5 },
+    ];
+    // Summed bytes = 1,200,000; prev summed = 1,050,000 → +150,000 bytes =
+    // 1,200,000 bits over 1.0s = 1200 kbps. Loss = 15 / 1200 sent = 1.25%,
+    // rounded to 1 decimal → 1.3%.
+    const prev: CallStatSample = { bytes: 1_050_000, timestampMs: 10_000 };
+    const { summary, sample } = summarizeVideoStats(report([...layers, ...remoteInbounds]), "send", prev);
+    expect(summary.resolution).toBe("1920×1080");
+    expect(summary.bitrateKbps).toBe(1200);
+    expect(summary.packetLossPct).toBe(1.3);
+    expect(sample).toEqual({ bytes: 1_200_000, timestampMs: 11_000 });
+  });
 });
 
 describe("summarizeVideoStats — inbound (recv) video", () => {

--- a/chat/tests/call-stats.test.ts
+++ b/chat/tests/call-stats.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import {
+  describeVideoStats,
+  formatBitrate,
+  summarizeVideoStats,
+  type CallStatSample,
+} from "../src/lib/calls/call-stats";
+
+/**
+ * Build a stand-in `RTCStatsReport`. The real report is a
+ * `ReadonlyMap<string, any>`, and `summarizeVideoStats` only uses
+ * `forEach`, so a plain `Map` is a faithful structural stub.
+ */
+function report(entries: Array<Record<string, unknown>>): RTCStatsReport {
+  const map = new Map<string, unknown>();
+  entries.forEach((entry, index) => map.set(`${entry.type}-${index}`, entry));
+  return map as unknown as RTCStatsReport;
+}
+
+describe("summarizeVideoStats — outbound (send) video", () => {
+  const outbound = {
+    type: "outbound-rtp",
+    kind: "video",
+    frameWidth: 1920,
+    frameHeight: 1080,
+    framesPerSecond: 30,
+    bytesSent: 1_000_000,
+    packetsSent: 1000,
+    timestamp: 10_000,
+  };
+  const remoteInbound = {
+    type: "remote-inbound-rtp",
+    kind: "video",
+    packetsLost: 5,
+    roundTripTime: 0.024,
+  };
+
+  test("reads resolution, fps, loss and rtt; bitrate is null on the first sample", () => {
+    const { summary, sample } = summarizeVideoStats(report([outbound, remoteInbound]), "send");
+    expect(summary.resolution).toBe("1920×1080");
+    expect(summary.fps).toBe(30);
+    expect(summary.bitrateKbps).toBeNull(); // needs two samples
+    expect(summary.packetLossPct).toBe(0.5); // 5 / 1000 * 100
+    expect(summary.rttMs).toBe(24); // 0.024s prefers the remote-inbound RTT
+    expect(sample).toEqual({ bytes: 1_000_000, timestampMs: 10_000 });
+  });
+
+  test("derives bitrate from the byte/timestamp delta against the previous sample", () => {
+    const prev: CallStatSample = { bytes: 1_000_000, timestampMs: 10_000 };
+    const next = { ...outbound, bytesSent: 1_375_000, timestamp: 11_000 };
+    // +375,000 bytes = 3,000,000 bits over 1.0s = 3000 kbps.
+    const { summary } = summarizeVideoStats(report([next, remoteInbound]), "send", prev);
+    expect(summary.bitrateKbps).toBe(3000);
+    expect(describeVideoStats(summary).bitrate).toBe("3.0 Mbps");
+  });
+});
+
+describe("summarizeVideoStats — inbound (recv) video", () => {
+  test("computes packet loss from received vs lost and rtt from the candidate pair", () => {
+    const inbound = {
+      type: "inbound-rtp",
+      kind: "video",
+      frameWidth: 1280,
+      frameHeight: 720,
+      framesPerSecond: 30,
+      bytesReceived: 500_000,
+      packetsReceived: 990,
+      packetsLost: 10,
+      timestamp: 5_000,
+    };
+    const candidatePair = { type: "candidate-pair", currentRoundTripTime: 0.06 };
+    const { summary } = summarizeVideoStats(report([inbound, candidatePair]), "recv");
+    expect(summary.resolution).toBe("1280×720");
+    expect(summary.packetLossPct).toBe(1); // 10 / (10 + 990) * 100
+    expect(summary.rttMs).toBe(60);
+  });
+
+  test("a track not yet reporting frames yields nulls, rendered as em dashes", () => {
+    const { summary } = summarizeVideoStats(report([]), "recv");
+    expect(summary).toEqual({
+      resolution: null,
+      fps: null,
+      bitrateKbps: null,
+      packetLossPct: null,
+      rttMs: null,
+    });
+    expect(describeVideoStats(summary)).toEqual({
+      resolution: "—",
+      fps: "—",
+      bitrate: "—",
+      loss: "—",
+      rtt: "—",
+    });
+  });
+});
+
+describe("formatBitrate", () => {
+  test("switches to Mbps at/above 1000 kbps and renders null as an em dash", () => {
+    expect(formatBitrate(null)).toBe("—");
+    expect(formatBitrate(0)).toBe("0 kbps");
+    expect(formatBitrate(450)).toBe("450 kbps");
+    expect(formatBitrate(1000)).toBe("1.0 Mbps");
+    expect(formatBitrate(2800)).toBe("2.8 Mbps");
+  });
+});

--- a/chat/tests/connection-quality.test.ts
+++ b/chat/tests/connection-quality.test.ts
@@ -34,17 +34,29 @@ describe("qualityToChip — ambient self-quality rendering model", () => {
     });
   });
 
-  test("lost shows empty red bars labelled Reconnecting…", () => {
+  test("lost gets its own 'Connection lost' label — NOT 'Reconnecting…', which it isn't", () => {
+    // `lost` is a per-participant quality score, independent of the
+    // transport phase; only an actual reconnecting transport says so.
     expect(qualityToChip("lost", "connected")).toEqual({
       bars: 0,
       tone: "danger",
-      label: "Reconnecting…",
+      label: "Connection lost",
     });
   });
 
-  test("unknown hides the indicator entirely (null), so a fresh call never flashes empty bars", () => {
-    expect(qualityToChip("unknown", "connected")).toBeNull();
-    expect(qualityToChip("unknown", "disconnected")).toBeNull();
+  test("unknown renders quiet empty bars (stable footprint), no label", () => {
+    // Always-present so the call bar doesn't reflow when the first
+    // quality sample lands mid-call.
+    expect(qualityToChip("unknown", "connected")).toEqual({
+      bars: 0,
+      tone: "neutral",
+      label: null,
+    });
+    expect(qualityToChip("unknown", "disconnected")).toEqual({
+      bars: 0,
+      tone: "neutral",
+      label: null,
+    });
   });
 
   test("a reconnecting transport overrides the last quality sample", () => {
@@ -73,7 +85,12 @@ describe("connection-quality atoms", () => {
     resetCallConnectionQuality();
     expect($callConnectionQuality.get()).toBe("unknown");
     expect($callConnectionPhase.get()).toBe("disconnected");
-    // …and the chip is hidden again, so nothing bleeds into the next call.
-    expect(qualityToChip($callConnectionQuality.get(), $callConnectionPhase.get())).toBeNull();
+    // …and the chip is back to quiet measuring bars (no degraded label),
+    // so nothing bleeds into the next call.
+    expect(qualityToChip($callConnectionQuality.get(), $callConnectionPhase.get())).toEqual({
+      bars: 0,
+      tone: "neutral",
+      label: null,
+    });
   });
 });

--- a/chat/tests/connection-quality.test.ts
+++ b/chat/tests/connection-quality.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  $callConnectionPhase,
+  $callConnectionQuality,
+  qualityToChip,
+  resetCallConnectionQuality,
+  setCallConnectionPhase,
+  setCallConnectionQuality,
+} from "../src/lib/calls/connection-quality";
+
+afterEach(() => {
+  resetCallConnectionQuality();
+});
+
+describe("qualityToChip — ambient self-quality rendering model", () => {
+  test("excellent and good show full/strong bars with no nagging label", () => {
+    expect(qualityToChip("excellent", "connected")).toEqual({
+      bars: 3,
+      tone: "neutral",
+      label: null,
+    });
+    expect(qualityToChip("good", "connected")).toEqual({
+      bars: 2,
+      tone: "neutral",
+      label: null,
+    });
+  });
+
+  test("poor escalates to a single amber bar with a label", () => {
+    expect(qualityToChip("poor", "connected")).toEqual({
+      bars: 1,
+      tone: "warn",
+      label: "Poor connection",
+    });
+  });
+
+  test("lost shows empty red bars labelled Reconnecting…", () => {
+    expect(qualityToChip("lost", "connected")).toEqual({
+      bars: 0,
+      tone: "danger",
+      label: "Reconnecting…",
+    });
+  });
+
+  test("unknown hides the indicator entirely (null), so a fresh call never flashes empty bars", () => {
+    expect(qualityToChip("unknown", "connected")).toBeNull();
+    expect(qualityToChip("unknown", "disconnected")).toBeNull();
+  });
+
+  test("a reconnecting transport overrides the last quality sample", () => {
+    // Even if the last score was excellent, a re-establishing path must
+    // read as Reconnecting… — the bars are meaningless while it's down.
+    expect(qualityToChip("excellent", "reconnecting")).toEqual({
+      bars: 0,
+      tone: "danger",
+      label: "Reconnecting…",
+    });
+    expect(qualityToChip("poor", "reconnecting")).toEqual({
+      bars: 0,
+      tone: "danger",
+      label: "Reconnecting…",
+    });
+  });
+});
+
+describe("connection-quality atoms", () => {
+  test("setters update the atoms and reset returns to the no-call baseline", () => {
+    setCallConnectionQuality("poor");
+    setCallConnectionPhase("reconnecting");
+    expect($callConnectionQuality.get()).toBe("poor");
+    expect($callConnectionPhase.get()).toBe("reconnecting");
+
+    resetCallConnectionQuality();
+    expect($callConnectionQuality.get()).toBe("unknown");
+    expect($callConnectionPhase.get()).toBe("disconnected");
+    // …and the chip is hidden again, so nothing bleeds into the next call.
+    expect(qualityToChip($callConnectionQuality.get(), $callConnectionPhase.get())).toBeNull();
+  });
+});


### PR DESCRIPTION
## Video quality: capture ceiling, connection indicator, diagnostics

Make video-call quality both **better** and **legible to users**. Three
cohesive parts, all client-local — no new XMPP wire traffic (remote
quality already rides LiveKit's own signaling; `getRTCStatsReport` reads
the browser's local stats and sends nothing off-box).

### 1. Capture & encoding (foundation)
- Camera capture ceiling raised from an implicit 720p to **1080p**
  (`VideoPresets.h1080`). AdaptiveStream + simulcast still scale each
  subscriber down to its rendered tile, so only expanded/pinned tiles
  pull the full layer; per-publisher upstream ceiling goes 1.7 → 3.0 Mbps.
- Screen share pinned to **1080p@15fps** (`ScreenSharePresets.h1080fps15`,
  2.5 Mbps) — crisp text, modest bandwidth.
- **Per-source degradation:** camera `maintain-framerate` (shed
  resolution, keep motion smooth); screen share `maintain-resolution`
  (shed fps, keep text readable). Passed per-publish since the two want
  opposite tradeoffs.

### 2. Self connection-quality indicator
- Ambient signal-bars chip in the shared `CallControls` bar (rides both
  split + expanded surfaces), driven by `RoomEvent.ConnectionQualityChanged`
  on the local participant + room `ConnectionState` — push events, **zero
  polling**.
- Escalates visually: quiet "measuring" bars at the unknown start state
  and at Excellent/Good (no label, stable footprint, no reflow), amber
  "Poor connection" at Poor, red "Connection lost" at Lost, red
  "Reconnecting…" while the transport is actually re-establishing. Lost
  (a per-participant score) and reconnecting (a transport phase) are kept
  semantically distinct.
- Accessibility: the visual glyph is `aria-hidden`; a dedicated
  visually-hidden live region announces only the degraded label, so
  Excellent↔Good transitions stay silent for screen readers.
- The engine translates LiveKit's `ConnectionQuality`/`ConnectionState`
  enums into an SDK-free typed domain union at the boundary, so the store
  and UI never import `livekit-client` and the pure `qualityToChip`
  mapper is unit-tested in isolation.

### 3. Diagnostics (resolution / bitrate readout)
- New "Diagnostics" section in `CallSettingsDialog` showing self + each
  remote video track: resolution, fps, bitrate, packet loss, RTT.
- Source: `publication.getRTCStatsReport()`; bitrate computed by diffing
  byte counters. **Simulcast-aware**: a published track reports one
  `outbound-rtp` per layer, so byte/packet counters are summed and the
  top layer's resolution is shown.
- **Polling runs only while the section is open (~1s)** and tears down on
  close/unmount — normal calls pay no stats cost. Per-track `getStats()`
  is fault-tolerant (drops one row on mid-teardown rejection), ticks
  can't overlap, and a fast open→close can't leak the interval.

### What LiveKit supports (for reference)
`VideoPresets` 16:9: h180/h360/h540/**h720**/h1080/h1440/h2160.
`ScreenSharePresets`: 360p@3fps … 1080p@30fps … `original`@7Mbps.
Default (before this PR) was 720p simulcast (≈180/360/720 layers).

### Constraints honored
- **XMPP-native:** all data is client-local LiveKit/WebRTC; nothing new
  on the wire.
- **Tests:** pure mappers (`qualityToChip`, `summarizeVideoStats`,
  `formatBitrate`, the LiveKit→domain enum maps, capture publish-option
  wiring) covered by `bun test` — incl. a simulcast-aggregation
  regression test. Full suite: 1870 pass / 0 fail.
- **Typecheck:** `astro check` 0 errors. **Knip:** clean.

### Review
Four adversarial-persona reviews (LiveKit/WebRTC correctness, Vue
lifecycle/reactivity, CLAUDE.md conformance, UX/a11y) ran against the
diff; a second focused round verified the fixes. Issues found and fixed:
simulcast stats aggregation, the Lost-vs-reconnecting label, indicator
pop-in/reflow, aria-live spam, an unhandled `getStats()` rejection, an
open→close poller leak, and overlapping stat ticks. Final round: clean.

### Plan / checklist
- [x] Capture ceiling + screen-share encoding + per-source degradation
- [x] Connection-quality store + pure `qualityToChip` mapper + engine events
- [x] `CallConnectionIndicator.vue` embedded in `CallControls`
- [x] Stats poller + pure simulcast-aware `call-stats` + Diagnostics section
- [x] Unit tests for the pure mappers (incl. simulcast regression)
- [x] Adversarial review passes; `astro check` + `bun test` + `knip` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
