### PR TITLE
feat(server): anchor MUC call threads

### DIFF
--- a/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_client.swift
+++ b/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_client.swift
@@ -1744,6 +1744,72 @@ public func FfiConverterTypeWaddleCallMedia_lower(_ value: WaddleCallMedia) -> R
 }
 
 
+public struct WaddleCallThreadAnchor: Equatable, Hashable {
+    public var kind: String
+    public var sid: String
+    public var media: [String]
+    public var initiator: String
+    public var started: String
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(kind: String, sid: String, media: [String], initiator: String, started: String) {
+        self.kind = kind
+        self.sid = sid
+        self.media = media
+        self.initiator = initiator
+        self.started = started
+    }
+
+
+
+
+}
+
+#if compiler(>=6)
+extension WaddleCallThreadAnchor: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeWaddleCallThreadAnchor: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleCallThreadAnchor {
+        return
+            try WaddleCallThreadAnchor(
+                kind: FfiConverterString.read(from: &buf),
+                sid: FfiConverterString.read(from: &buf),
+                media: FfiConverterSequenceString.read(from: &buf),
+                initiator: FfiConverterString.read(from: &buf),
+                started: FfiConverterString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: WaddleCallThreadAnchor, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.kind, into: &buf)
+        FfiConverterString.write(value.sid, into: &buf)
+        FfiConverterSequenceString.write(value.media, into: &buf)
+        FfiConverterString.write(value.initiator, into: &buf)
+        FfiConverterString.write(value.started, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleCallThreadAnchor_lift(_ buf: RustBuffer) throws -> WaddleCallThreadAnchor {
+    return try FfiConverterTypeWaddleCallThreadAnchor.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleCallThreadAnchor_lower(_ value: WaddleCallThreadAnchor) -> RustBuffer {
+    return FfiConverterTypeWaddleCallThreadAnchor.lower(value)
+}
+
+
 public struct WaddleChannel: Equatable, Hashable {
     public var id: String
     public var roomJid: String
@@ -2341,6 +2407,10 @@ public struct WaddleMessage: Equatable, Hashable {
      */
     public var replyFallbackEnd: UInt32?
     /**
+     * urn:waddle:call-thread:0 call-thread anchor marker, if present.
+     */
+    public var callThread: WaddleCallThreadAnchor?
+    /**
      * XEP-0446 / XEP-0447 shared files attached to the message.
      */
     public var sharedFiles: [WaddleSharedFile]
@@ -2371,6 +2441,9 @@ public struct WaddleMessage: Equatable, Hashable {
          * XEP-0428 fallback range end (char offset, exclusive).
          */replyFallbackEnd: UInt32?,
         /**
+         * urn:waddle:call-thread:0 call-thread anchor marker, if present.
+         */callThread: WaddleCallThreadAnchor?,
+        /**
          * XEP-0446 / XEP-0447 shared files attached to the message.
          */sharedFiles: [WaddleSharedFile],
         /**
@@ -2399,6 +2472,7 @@ public struct WaddleMessage: Equatable, Hashable {
         self.replyToSender = replyToSender
         self.replyFallbackStart = replyFallbackStart
         self.replyFallbackEnd = replyFallbackEnd
+        self.callThread = callThread
         self.sharedFiles = sharedFiles
         self.mdsDisplayed = mdsDisplayed
     }
@@ -2439,6 +2513,7 @@ public struct FfiConverterTypeWaddleMessage: FfiConverterRustBuffer {
                 replyToSender: FfiConverterOptionString.read(from: &buf),
                 replyFallbackStart: FfiConverterOptionUInt32.read(from: &buf),
                 replyFallbackEnd: FfiConverterOptionUInt32.read(from: &buf),
+                callThread: FfiConverterOptionTypeWaddleCallThreadAnchor.read(from: &buf),
                 sharedFiles: FfiConverterSequenceTypeWaddleSharedFile.read(from: &buf),
                 mdsDisplayed: FfiConverterOptionSequenceTypeWaddleMdsDisplayedEntry.read(from: &buf)
         )
@@ -2465,6 +2540,7 @@ public struct FfiConverterTypeWaddleMessage: FfiConverterRustBuffer {
         FfiConverterOptionString.write(value.replyToSender, into: &buf)
         FfiConverterOptionUInt32.write(value.replyFallbackStart, into: &buf)
         FfiConverterOptionUInt32.write(value.replyFallbackEnd, into: &buf)
+        FfiConverterOptionTypeWaddleCallThreadAnchor.write(value.callThread, into: &buf)
         FfiConverterSequenceTypeWaddleSharedFile.write(value.sharedFiles, into: &buf)
         FfiConverterOptionSequenceTypeWaddleMdsDisplayedEntry.write(value.mdsDisplayed, into: &buf)
     }
@@ -4576,6 +4652,30 @@ fileprivate struct FfiConverterOptionTypeWaddleCallEvent: FfiConverterRustBuffer
         switch try readInt(&buf) as Int8 {
         case 0: return nil
         case 1: return try FfiConverterTypeWaddleCallEvent.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeWaddleCallThreadAnchor: FfiConverterRustBuffer {
+    typealias SwiftType = WaddleCallThreadAnchor?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeWaddleCallThreadAnchor.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeWaddleCallThreadAnchor.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }

--- a/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_client.swift
+++ b/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_client.swift
@@ -1406,12 +1406,19 @@ public struct WaddleArchivedMessage: Equatable, Hashable {
     public var replyToSender: String?
     public var replyFallbackStart: UInt32?
     public var replyFallbackEnd: UInt32?
+    /**
+     * urn:waddle:call-thread:0 call-thread anchor marker, if present.
+     */
+    public var callThread: WaddleCallThreadAnchor?
     public var sharedFiles: [WaddleSharedFile]
     public var callEvent: WaddleCallEvent?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(mamId: String, queryId: String?, id: String?, stanzaId: String?, originId: String?, timestamp: String?, from: String?, to: String?, messageType: String, body: String?, reactionTargetId: String?, reactionEmojis: [String], thread: String?, parentThreadId: String?, replyToId: String?, replyToSender: String?, replyFallbackStart: UInt32?, replyFallbackEnd: UInt32?, sharedFiles: [WaddleSharedFile], callEvent: WaddleCallEvent?) {
+    public init(mamId: String, queryId: String?, id: String?, stanzaId: String?, originId: String?, timestamp: String?, from: String?, to: String?, messageType: String, body: String?, reactionTargetId: String?, reactionEmojis: [String], thread: String?, parentThreadId: String?, replyToId: String?, replyToSender: String?, replyFallbackStart: UInt32?, replyFallbackEnd: UInt32?,
+        /**
+         * urn:waddle:call-thread:0 call-thread anchor marker, if present.
+         */callThread: WaddleCallThreadAnchor?, sharedFiles: [WaddleSharedFile], callEvent: WaddleCallEvent?) {
         self.mamId = mamId
         self.queryId = queryId
         self.id = id
@@ -1430,6 +1437,7 @@ public struct WaddleArchivedMessage: Equatable, Hashable {
         self.replyToSender = replyToSender
         self.replyFallbackStart = replyFallbackStart
         self.replyFallbackEnd = replyFallbackEnd
+        self.callThread = callThread
         self.sharedFiles = sharedFiles
         self.callEvent = callEvent
     }
@@ -1468,6 +1476,7 @@ public struct FfiConverterTypeWaddleArchivedMessage: FfiConverterRustBuffer {
                 replyToSender: FfiConverterOptionString.read(from: &buf),
                 replyFallbackStart: FfiConverterOptionUInt32.read(from: &buf),
                 replyFallbackEnd: FfiConverterOptionUInt32.read(from: &buf),
+                callThread: FfiConverterOptionTypeWaddleCallThreadAnchor.read(from: &buf),
                 sharedFiles: FfiConverterSequenceTypeWaddleSharedFile.read(from: &buf),
                 callEvent: FfiConverterOptionTypeWaddleCallEvent.read(from: &buf)
         )
@@ -1492,6 +1501,7 @@ public struct FfiConverterTypeWaddleArchivedMessage: FfiConverterRustBuffer {
         FfiConverterOptionString.write(value.replyToSender, into: &buf)
         FfiConverterOptionUInt32.write(value.replyFallbackStart, into: &buf)
         FfiConverterOptionUInt32.write(value.replyFallbackEnd, into: &buf)
+        FfiConverterOptionTypeWaddleCallThreadAnchor.write(value.callThread, into: &buf)
         FfiConverterSequenceTypeWaddleSharedFile.write(value.sharedFiles, into: &buf)
         FfiConverterOptionTypeWaddleCallEvent.write(value.callEvent, into: &buf)
     }

--- a/chat/src/channels/timeline.ts
+++ b/chat/src/channels/timeline.ts
@@ -49,6 +49,7 @@ export function mapLiveRoomMessageToTimeline(
   }
   if (msg.threadId) tm.threadId = msg.threadId;
   if (msg.parentThreadId) tm.parentThreadId = msg.parentThreadId;
+  if (msg.callThread) tm.callThread = msg.callThread;
   if (msg.forumPostKind) tm.forumPostKind = msg.forumPostKind;
   if (msg.forumTitle) tm.forumTitle = msg.forumTitle;
   if (msg.forumThreadTitle) tm.forumThreadTitle = msg.forumThreadTitle;
@@ -102,7 +103,7 @@ export function applyForumContext(list: TimelineMessage[], inferForumReplies = t
 }
 
 export function isFeedTimelineMessage(message: TimelineMessage): boolean {
-  return !message.threadId || message.id === message.threadId;
+  return !message.threadId || message.id === message.threadId || !!message.callThread;
 }
 
 const TIMELINE_STAMP_FORMATTER = new Intl.DateTimeFormat("en", {

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -27,7 +27,7 @@ import type { DiscoveredExtensionCommand, ExtensionCommandAction, ExtensionComma
 import type { ComposerLinkPreviewLookup, ComposerLinkPreviewSendPayload } from "@/lib/link-preview-composer";
 import { useScrollDirectionPreference } from "@/preferences/scroll-direction";
 import type { MessageThreadIndex } from "@/channels/threads";
-import { formatTimelineStamp, formatTimelineDayDivider, isSameTimelineDay } from "@/channels/timeline";
+import { formatTimelineStamp, formatTimelineDayDivider, isFeedTimelineMessage, isSameTimelineDay } from "@/channels/timeline";
 import { useExtensionLauncher } from "@/channels/extension-launcher";
 import { useJumpToLiveEdge } from "@/ui/use-jump-to-live-edge";
 import { ArrowDown, ArrowUp } from "lucide-vue-next";
@@ -143,10 +143,7 @@ const emit = defineEmits<{
 }>();
 
 // Hide thread members from the main feed — they live inside the thread panel.
-// Keep thread roots (id === threadId) and any message with no threadId.
-const feedMessages = computed(() =>
-  props.messages.filter((m) => !m.threadId || m.id === m.threadId),
-);
+const feedMessages = computed(() => props.messages.filter(isFeedTimelineMessage));
 const { mode: scrollDirection, isTopPinned } = useScrollDirectionPreference();
 const orderedFeedMessages = computed(() =>
   orderTimelineForScrollDirection(feedMessages.value, scrollDirection.value),

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -16,6 +16,7 @@ import {
   LayoutDashboard,
   MessageSquare,
   MessagesSquare,
+  PhoneCall,
   Pin,
   PinOff,
   X,
@@ -51,6 +52,7 @@ import {
   clearDesktopToolbarOwner,
 } from "@/stores/message-toolbar";
 import { QUICK_REACTION_EMOJIS } from "@/lib/reaction-mode";
+import { callThreadAnchorLabel, callThreadAnchorThreadId } from "@/lib/call-thread-anchor";
 
 // Two separate badge layers:
 //
@@ -362,6 +364,13 @@ function formatThreadRecency(iso: string | undefined): string {
 }
 
 const threadChipRecency = computed(() => formatThreadRecency(props.threadLastReplyAt));
+const callThreadLabel = computed(() => callThreadAnchorLabel(props.message));
+const callThreadId = computed(() => callThreadAnchorThreadId(props.message));
+
+function openCallThreadAnchor() {
+  if (!callThreadId.value) return;
+  emit("openThread", callThreadId.value);
+}
 
 function togglePinFromMenu() {
   if (!props.message.id) return;
@@ -891,6 +900,28 @@ onBeforeUnmount(() => {
       </div>
     </section>
   </template>
+
+  <div
+    v-else-if="message.callThread"
+    :data-message-id="message.id"
+    :data-message-created-at="message.createdAt"
+    class="chat-message-grid animate-message-in"
+  >
+    <div class="chat-message-avatar-cell flex items-center justify-center text-muted-foreground/60">
+      <PhoneCall class="w-4 h-4" aria-hidden="true" />
+    </div>
+    <div class="chat-message-body-stack">
+      <button
+        type="button"
+        class="type-field-sm inline-flex items-center gap-1.5 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        :disabled="!callThreadId"
+        @click="openCallThreadAnchor"
+      >
+        <span>{{ callThreadLabel }}</span>
+        <span class="type-meta type-numeric">{{ formatTimelineTimeOfDay(message.createdAt) }}</span>
+      </button>
+    </div>
+  </div>
 
   <!-- Retracted tombstone — body is gone but author/time/avatar
        stay for context. Lift the row opacity from 35 % → 55 % so

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -905,7 +905,7 @@ onBeforeUnmount(() => {
     v-else-if="message.callThread"
     :data-message-id="message.id"
     :data-message-created-at="message.createdAt"
-    class="chat-message-grid animate-message-in"
+    class="chat-message-grid relative animate-message-in"
   >
     <div class="chat-message-avatar-cell flex items-center justify-center text-muted-foreground/60">
       <PhoneCall class="w-4 h-4" aria-hidden="true" />

--- a/chat/src/lib/call-thread-anchor.ts
+++ b/chat/src/lib/call-thread-anchor.ts
@@ -1,0 +1,9 @@
+import type { TimelineMessage } from "@/lib/chat-ui";
+
+export function callThreadAnchorLabel(message: Pick<TimelineMessage, "body" | "author" | "callThread">): string {
+  return message.body || `${message.author} started a call`;
+}
+
+export function callThreadAnchorThreadId(message: Pick<TimelineMessage, "threadId" | "callThread">): string | null {
+  return message.callThread && message.threadId ? message.threadId : null;
+}

--- a/chat/src/lib/call-thread-anchor.ts
+++ b/chat/src/lib/call-thread-anchor.ts
@@ -1,6 +1,6 @@
 import type { TimelineMessage } from "@/lib/chat-ui";
 
-export function callThreadAnchorLabel(message: Pick<TimelineMessage, "body" | "author" | "callThread">): string {
+export function callThreadAnchorLabel(message: Pick<TimelineMessage, "body" | "author">): string {
   return message.body || `${message.author} started a call`;
 }
 

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -41,6 +41,14 @@ export interface TimelineSharedFile {
   encrypted?: WaddleEncryptedFile;
 }
 
+export interface CallThreadAnchor {
+  kind: "muc";
+  sid: string;
+  media: readonly ("audio" | "video")[];
+  initiator: string;
+  started: string;
+}
+
 export interface LinkPreview {
   originalUrl: string;
   normalizedUrl?: string;
@@ -255,6 +263,8 @@ export interface TimelineMessage {
   /** RFC 6121 / XEP-0201: Thread identifier + optional parent thread. */
   threadId?: string;
   parentThreadId?: string;
+  /** Waddle call-thread anchor marker (`urn:waddle:call-thread:0`). */
+  callThread?: CallThreadAnchor;
   /** Waddle thread metadata when present. */
   forumPostKind?: "topic" | "reply";
   forumTitle?: string;

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -1,6 +1,6 @@
 import type { WaddleChannelType } from "@/lib/channel-types";
 import type { PinPermission } from "@/lib/chat-types";
-import type { ExtensionAnnotation } from "@/lib/chat-ui";
+import type { CallThreadAnchor, ExtensionAnnotation } from "@/lib/chat-ui";
 import type { TimestampSource } from "@/lib/timeline-timestamps";
 import type { WaddleEncryptedFile } from "./extensions/encrypted-file";
 
@@ -183,6 +183,8 @@ export interface LiveRoomMessage {
   /** RFC 6121 / XEP-0201 */
   threadId?: string;
   parentThreadId?: string;
+  /** Waddle call-thread anchor marker (`urn:waddle:call-thread:0`). */
+  callThread?: CallThreadAnchor;
   /** Waddle thread metadata */
   forumPostKind?: "topic" | "reply";
   forumTitle?: string;

--- a/chat/src/lib/xmpp/wasm-message-codecs.ts
+++ b/chat/src/lib/xmpp/wasm-message-codecs.ts
@@ -473,7 +473,10 @@ export function roomMessageFromArchived(
   const markupSpans = message.markup_spans ?? [];
   const references = message.references ?? [];
   const extensionAnnotations = extensionAnnotationsFromWasm(message.extension_envelope);
-  const callThread = isSupportedRoomCallThread(message.call_thread) ? message.call_thread : undefined;
+  const callThread =
+    message.body && isSupportedRoomCallThread(message.call_thread)
+      ? message.call_thread
+      : undefined;
   // XEP-0201 `<thread/>` is scope metadata, not content. A stanza that
   // carries only a thread reference (no body, no subject, no attachments,
   // no link preview, no extension annotations, no forum-post payload, not a retraction)

--- a/chat/src/lib/xmpp/wasm-message-codecs.ts
+++ b/chat/src/lib/xmpp/wasm-message-codecs.ts
@@ -21,6 +21,7 @@ import type { TimestampSource } from "@/lib/timeline-timestamps";
 import type { LiveDmMessage, LiveRoomMessage, OccupantPresence, PresenceUpdateEvent, SharedFileInfo } from "./types";
 import type {
   WasmArchivedMessage,
+  WasmCallThreadAnchor,
   WasmInboxConversation,
   WasmExtensionEnvelope,
   WasmExtensionPayloadElement,
@@ -81,6 +82,12 @@ function wasmSpanToMarkupSpan(span: WasmMessage["markup_spans"][number]): Markup
   if (span.span_type === "code_block") return { type: "bcode", start: span.start, end: span.end } satisfies MarkupSpan;
   if (span.span_type === "blockquote") return { type: "bquote", start: span.start, end: span.end } satisfies MarkupSpan;
   return null;
+}
+
+function isSupportedRoomCallThread(
+  anchor: WasmCallThreadAnchor | undefined,
+): anchor is WasmCallThreadAnchor & { kind: "muc" } {
+  return anchor?.kind === "muc";
 }
 
 function rebaseOffsetAfterRemoval(offset: number, start: number, end: number): number {
@@ -466,6 +473,7 @@ export function roomMessageFromArchived(
   const markupSpans = message.markup_spans ?? [];
   const references = message.references ?? [];
   const extensionAnnotations = extensionAnnotationsFromWasm(message.extension_envelope);
+  const callThread = isSupportedRoomCallThread(message.call_thread) ? message.call_thread : undefined;
   // XEP-0201 `<thread/>` is scope metadata, not content. A stanza that
   // carries only a thread reference (no body, no subject, no attachments,
   // no link preview, no extension annotations, no forum-post payload, not a retraction)
@@ -474,7 +482,7 @@ export function roomMessageFromArchived(
   // row inside the thread panel. The server-side `is_archivable` already
   // refuses to persist these; this is the defence-in-depth pass for
   // foreign servers and legacy archive rows.
-  if (!message.body && !message.subject && !sharedFiles.length && !linkPreviews.length && !extensionAnnotations.length && !message.forum_post_kind && !message.is_retracted) {
+  if (!message.body && !message.subject && !callThread && !sharedFiles.length && !linkPreviews.length && !extensionAnnotations.length && !message.forum_post_kind && !message.is_retracted) {
     return null;
   }
   const { linkPreviews: associatedLinkPreviews, sharedFiles: associatedSharedFiles } =
@@ -504,6 +512,17 @@ export function roomMessageFromArchived(
     ...(message.forum_post_kind === "topic" || message.forum_post_kind === "reply" ? { forumPostKind: message.forum_post_kind } : {}),
     ...(message.forum_title ? { forumTitle: message.forum_title } : {}),
     ...(message.forum_thread_title ? { forumThreadTitle: message.forum_thread_title } : {}),
+    ...(callThread
+      ? {
+          callThread: {
+            kind: "muc",
+            sid: callThread.sid,
+            media: callThread.media,
+            initiator: callThread.initiator,
+            started: callThread.started,
+          },
+        }
+      : {}),
     ...(message.author_real_jid ? { authorRealJid: message.author_real_jid } : {}),
     ...(stampedByRoom ? { reactionTargetId: stampedByRoom } : {}),
     ...(mentionUris.length ? { mentions: mentionUris.map((uri) => uri.replace(/^xmpp:/, "")) } : {}),

--- a/chat/src/lib/xmpp/wasm-types.ts
+++ b/chat/src/lib/xmpp/wasm-types.ts
@@ -48,6 +48,14 @@ interface WasmStanzaId {
   by: string;
 }
 
+export interface WasmCallThreadAnchor {
+  kind: "muc" | "dm";
+  sid: string;
+  media: Array<"audio" | "video">;
+  initiator: string;
+  started: string;
+}
+
 export interface WasmExtensionEnvelope {
   version: number;
   enrichments: WasmExtensionEnrichment[];
@@ -137,6 +145,7 @@ export interface WasmMessage {
   forum_title?: string;
   forum_thread_title?: string;
   is_sticker: boolean;
+  call_thread?: WasmCallThreadAnchor;
   shared_files: WasmSharedFile[];
   link_previews: WasmLinkPreview[];
   call_event?: CallEvent;

--- a/chat/tests/call-thread-anchor.test.ts
+++ b/chat/tests/call-thread-anchor.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+import { isFeedTimelineMessage, mapLiveRoomMessageToTimeline } from "../src/channels/timeline";
+import { callThreadAnchorLabel, callThreadAnchorThreadId } from "../src/lib/call-thread-anchor";
+import type { WaddleSession } from "../src/lib/server-auth";
+import { roomMessageFromArchived } from "../src/lib/xmpp/wasm-message-codecs";
+import type { LiveRoomMessage } from "../src/lib/xmpp-client";
+
+const session: WaddleSession = {
+  session_id: "session-1",
+  user_id: "alice-id",
+  username: "alice",
+  avatar_url: null,
+  xmpp_localpart: "alice",
+  jid: "alice@example.com/web",
+  xmpp_websocket_url: "wss://example.com/ws",
+  is_expired: false,
+  expires_at: null,
+};
+
+function callAnchor(overrides: Partial<LiveRoomMessage> = {}): LiveRoomMessage {
+  return {
+    id: "anchor-1",
+    roomJid: "general@muc.example.com",
+    nick: "Alice",
+    body: "Alice started a call",
+    createdAt: "2026-06-07T14:30:00Z",
+    createdAtSource: "archive",
+    type: "message",
+    threadId: "call-thread-uuid",
+    callThread: {
+      kind: "muc",
+      sid: "session-uuid",
+      media: ["audio", "video"],
+      initiator: "alice@example",
+      started: "2026-06-07T14:30:00Z",
+    },
+    ...overrides,
+  };
+}
+
+describe("call-thread anchor timeline mapping", () => {
+  test("maps inbound channel call-thread marker onto the unified timeline message", () => {
+    const timelineMessage = mapLiveRoomMessageToTimeline(session, callAnchor());
+
+    expect(timelineMessage.body).toBe("Alice started a call");
+    expect(timelineMessage.threadId).toBe("call-thread-uuid");
+    expect(timelineMessage.callThread).toEqual({
+      kind: "muc",
+      sid: "session-uuid",
+      media: ["audio", "video"],
+      initiator: "alice@example",
+      started: "2026-06-07T14:30:00Z",
+    });
+  });
+
+  test("keeps the call-thread anchor visible in the channel feed", () => {
+    const timelineMessage = mapLiveRoomMessageToTimeline(session, callAnchor());
+
+    expect(timelineMessage.id).toBe("anchor-1");
+    expect(timelineMessage.threadId).toBe("call-thread-uuid");
+    expect(isFeedTimelineMessage(timelineMessage)).toBe(true);
+  });
+
+  test("uses the inbound anchor body as the inline label and opens the call thread", () => {
+    const timelineMessage = mapLiveRoomMessageToTimeline(session, callAnchor());
+
+    expect(callThreadAnchorLabel(timelineMessage)).toBe("Alice started a call");
+    expect(callThreadAnchorThreadId(timelineMessage)).toBe("call-thread-uuid");
+  });
+
+  test("room archive codec maps the WASM call-thread marker onto LiveRoomMessage", () => {
+    const live = roomMessageFromArchived({
+      mam_id: "mam-anchor-1",
+      id: "anchor-1",
+      from: "general@muc.example.com",
+      to: "alice@example.com/web",
+      message_type: "groupchat",
+      body: "Alice started a call",
+      timestamp: "2026-06-07T14:30:00Z",
+      reaction_emojis: [],
+      is_muc: true,
+      thread: "call-thread-uuid",
+      markup_spans: [],
+      mention_uris: [],
+      references: [],
+      is_sticker: false,
+      shared_files: [],
+      link_previews: [],
+      call_thread: {
+        kind: "muc",
+        sid: "session-uuid",
+        media: ["audio", "video"],
+        initiator: "alice@example",
+        started: "2026-06-07T14:30:00Z",
+      },
+    });
+
+    expect(live?.threadId).toBe("call-thread-uuid");
+    expect(live?.callThread).toEqual({
+      kind: "muc",
+      sid: "session-uuid",
+      media: ["audio", "video"],
+      initiator: "alice@example",
+      started: "2026-06-07T14:30:00Z",
+    });
+  });
+
+  test("room archive codec still drops bodyless unsupported call-thread markers", () => {
+    const live = roomMessageFromArchived({
+      mam_id: "mam-anchor-2",
+      id: "anchor-2",
+      from: "general@muc.example.com",
+      to: "alice@example.com/web",
+      message_type: "groupchat",
+      reaction_emojis: [],
+      is_muc: true,
+      thread: "call-thread-uuid",
+      markup_spans: [],
+      mention_uris: [],
+      references: [],
+      is_sticker: false,
+      shared_files: [],
+      link_previews: [],
+      call_thread: {
+        kind: "dm",
+        sid: "session-uuid",
+        media: ["audio"],
+        initiator: "alice@example",
+        started: "2026-06-07T14:30:00Z",
+      },
+    });
+
+    expect(live).toBeNull();
+  });
+});

--- a/chat/tests/call-thread-anchor.test.ts
+++ b/chat/tests/call-thread-anchor.test.ts
@@ -132,4 +132,32 @@ describe("call-thread anchor timeline mapping", () => {
 
     expect(live).toBeNull();
   });
+
+  test("room archive codec drops bodyless call-thread anchors", () => {
+    const live = roomMessageFromArchived({
+      mam_id: "mam-anchor-3",
+      id: "anchor-3",
+      from: "general@muc.example.com",
+      to: "alice@example.com/web",
+      message_type: "groupchat",
+      reaction_emojis: [],
+      is_muc: true,
+      thread: "call-thread-uuid",
+      markup_spans: [],
+      mention_uris: [],
+      references: [],
+      is_sticker: false,
+      shared_files: [],
+      link_previews: [],
+      call_thread: {
+        kind: "muc",
+        sid: "session-uuid",
+        media: ["audio"],
+        initiator: "alice@example",
+        started: "2026-06-07T14:30:00Z",
+      },
+    });
+
+    expect(live).toBeNull();
+  });
 });

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -191,6 +191,21 @@ pub(crate) use notification_activity_ingest::{
     record_presence_available_activity_on_state, record_presence_unavailable_activity_on_state,
 };
 
+pub(crate) async fn broadcast_room_system_message(
+    deps: &Deps<'_>,
+    room: BareJid,
+    message: Box<Message>,
+) {
+    room_system_message::broadcast_room_system_message_event(
+        deps.connection_registry,
+        deps,
+        room,
+        message,
+        0,
+    )
+    .await;
+}
+
 /// Execute the side effects described by `events`.
 ///
 /// The function is `async` because future migration steps add variants

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
@@ -39,13 +39,22 @@ use waddle_xmpp::muc::{
     presence::NS_MUC,
     room_actor::{ClearMujiPresence, UpsertMujiPresence},
 };
+use waddle_xmpp::xep::xep0167::MediaKind;
 use waddle_xmpp::xep::xep0272::{find_muji, Muji, NS_MUJI};
 use waddle_xmpp::xep::xep0421::OccupantIdentity;
+use waddle_xmpp::xep::{
+    build_call_thread_anchor, build_hint_element, CallThreadAnchor, CallThreadKind,
+    CallThreadMedia, Hint,
+};
 use waddle_xmpp::Stanza;
+use waddle_xmpp_core::mam::ThreadId;
+use waddle_xmpp_core::xep0201::{build_thread_element, ThreadInfo, CLIENT_STANZA_NS};
+use xmpp_parsers::jingle::SessionId;
+use xmpp_parsers::message::{Lang, Message, MessageType};
 use xmpp_parsers::presence::Presence;
 
 use super::super::super::{get_room_actor, stanza_to_xml};
-use crate::server::routes::websocket::WebSocketState;
+use crate::server::routes::websocket::{interpret_loop::build_interpret_deps, WebSocketState};
 
 /// Pull out the typed [`Muji`] element from an inbound presence's
 /// payloads if it carries one. Returns `None` when the namespace
@@ -223,6 +232,21 @@ pub(super) async fn try_handle_muc_presence_update(
         outcome.sender_muji.as_ref(),
         &outcome.session_mujis,
     );
+    if outcome.active_call_started {
+        let anchor = build_call_thread_anchor_message(
+            room_jid,
+            &sender_jid.to_bare(),
+            outcome.active_muji.as_ref(),
+            &outcome.update.sender_nick,
+        );
+        let deps = build_interpret_deps(state, None);
+        crate::server::routes::interpret::broadcast_room_system_message(
+            &deps,
+            room_jid.clone(),
+            Box::new(anchor),
+        )
+        .await;
+    }
 
     // Author the canonical presence the server will reflect. Built
     // ONCE here, cloned per recipient for the self vs other status
@@ -285,6 +309,56 @@ pub(super) async fn try_handle_muc_presence_update(
     Some(responses)
 }
 
+fn build_call_thread_anchor_message(
+    room_jid: &BareJid,
+    initiator: &BareJid,
+    active_muji: Option<&Muji>,
+    initiator_nick: &str,
+) -> Message {
+    let thread_id = uuid::Uuid::new_v4().to_string();
+    let sid = SessionId(uuid::Uuid::new_v4().to_string());
+    let media = media_from_muji(active_muji);
+    let body = format!("{initiator_nick} started a call");
+    let mut message = Message::new(Some(jid::Jid::from(room_jid.clone())));
+    message.from = Some(jid::Jid::from(room_jid.clone()));
+    message.type_ = MessageType::Groupchat;
+    message.bodies.insert(Lang(String::new()), body);
+    let thread = ThreadInfo::root(ThreadId::new(thread_id).expect("uuid thread id is non-empty"));
+    message
+        .payloads
+        .push(build_thread_element(&thread, CLIENT_STANZA_NS));
+    message
+        .payloads
+        .push(build_call_thread_anchor(&CallThreadAnchor {
+            kind: CallThreadKind::Muc,
+            sid,
+            media,
+            initiator: initiator.clone(),
+            started: chrono::Utc::now(),
+        }));
+    message.payloads.push(build_hint_element(Hint::Store));
+    message
+}
+
+fn media_from_muji(active_muji: Option<&Muji>) -> CallThreadMedia {
+    let mut media = CallThreadMedia {
+        audio: false,
+        video: false,
+    };
+    if let Some(muji) = active_muji {
+        for content in &muji.contents {
+            match content.media {
+                MediaKind::Audio => media.audio = true,
+                MediaKind::Video => media.video = true,
+            }
+        }
+    }
+    if !media.audio && !media.video {
+        media.audio = true;
+    }
+    media
+}
+
 #[cfg(test)]
 mod tests {
     //! XEP-conformance tests for the `<muji xmlns='urn:xmpp:jingle:muji:0'/>`
@@ -325,6 +399,21 @@ mod tests {
         assert!(muji.is_active());
         assert_eq!(muji.contents.len(), 1);
         assert_eq!(muji.contents[0].name.0, "audio");
+    }
+
+    #[test]
+    fn media_from_muji_uses_typed_rtp_media_not_content_name() {
+        let xml = "<muji xmlns='urn:xmpp:jingle:muji:0'>\
+                     <content creator='initiator' name='0'>\
+                       <description xmlns='urn:xmpp:jingle:apps:rtp:1' media='video'/>\
+                     </content>\
+                   </muji>";
+        let element: Element = xml.parse().expect("muji XML parses");
+        let muji = Muji::try_from(&element).expect("typed video Muji parses");
+        let media = media_from_muji(Some(&muji));
+
+        assert!(!media.audio);
+        assert!(media.video);
     }
 
     #[test]

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
@@ -232,21 +232,16 @@ pub(super) async fn try_handle_muc_presence_update(
         outcome.sender_muji.as_ref(),
         &outcome.session_mujis,
     );
-    if outcome.active_call_started {
-        let anchor = build_call_thread_anchor_message(
+    let call_thread_anchor = if outcome.active_call_started {
+        Some(build_call_thread_anchor_message(
             room_jid,
             &sender_jid.to_bare(),
             outcome.active_muji.as_ref(),
             &outcome.update.sender_nick,
-        );
-        let deps = build_interpret_deps(state, None);
-        crate::server::routes::interpret::broadcast_room_system_message(
-            &deps,
-            room_jid.clone(),
-            Box::new(anchor),
-        )
-        .await;
-    }
+        ))
+    } else {
+        None
+    };
 
     // Author the canonical presence the server will reflect. Built
     // ONCE here, cloned per recipient for the self vs other status
@@ -302,6 +297,16 @@ pub(super) async fn try_handle_muc_presence_update(
                     .try_send_to(recipient, stanza);
             }
         }
+    }
+
+    if let Some(anchor) = call_thread_anchor {
+        let deps = build_interpret_deps(state, None);
+        crate::server::routes::interpret::broadcast_room_system_message(
+            &deps,
+            room_jid.clone(),
+            Box::new(anchor),
+        )
+        .await;
     }
 
     // Silence unused-import warning when feature flags trim the path.

--- a/server/crates/waddle-server/src/server/routes/websocket/interpret_loop.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/interpret_loop.rs
@@ -11,7 +11,7 @@ use super::*;
 /// owners only). Without it the dispatcher path's owner override
 /// would always fail. The recipient-pass path the main loop drives
 /// passes the connection's own session here.
-pub(super) fn build_interpret_deps<'a>(
+pub(crate) fn build_interpret_deps<'a>(
     state: &'a WebSocketState,
     authenticated_session: Option<&'a crate::auth::Session>,
 ) -> crate::server::routes::interpret::Deps<'a> {

--- a/server/crates/waddle-server/tests/calls_e2e_ws.rs
+++ b/server/crates/waddle-server/tests/calls_e2e_ws.rs
@@ -17,6 +17,7 @@ use xmpp_parsers::minidom::Element;
 const NS_MUC: &str = "http://jabber.org/protocol/muc";
 const NS_MUC_USER: &str = "http://jabber.org/protocol/muc#user";
 const NS_MUJI: &str = "urn:xmpp:jingle:muji:0";
+const NS_CALL_THREAD: &str = "urn:waddle:call-thread:0";
 
 const DOMAIN: &str = "localhost";
 const ALICE: &str = "alice";
@@ -386,6 +387,49 @@ fn muji_child(presence: &Element) -> Option<&Element> {
         .find(|c| c.name() == "muji" && c.ns() == NS_MUJI)
 }
 
+fn call_thread_child(message: &Element) -> Option<&Element> {
+    message
+        .children()
+        .find(|c| c.name() == "call-thread" && c.ns() == NS_CALL_THREAD)
+}
+
+async fn recv_until_muji_and_anchor(client: &mut WsXmppClient) -> Vec<String> {
+    let mut frames = Vec::new();
+    loop {
+        let frame = client
+            .recv()
+            .await
+            .expect("receive frame while waiting for muji reflection and call-thread anchor");
+        frames.push(frame);
+        let has_muji = frames.iter().any(|frame| {
+            frame.contains("<presence") && (frame.contains("<muji ") || frame.contains("<muji>"))
+        });
+        let has_anchor = frames
+            .iter()
+            .any(|frame| frame.contains("<call-thread") && frame.contains(NS_CALL_THREAD));
+        if has_muji && has_anchor {
+            return frames;
+        }
+    }
+}
+
+async fn query_room_mam(client: &mut WsXmppClient, room: &str, id: &str) -> Vec<String> {
+    client
+        .send(&format!(
+            r#"<iq type="set" id="{id}" to="{room}">
+                 <query xmlns="urn:xmpp:mam:2">
+                   <set xmlns="http://jabber.org/protocol/rsm"><max>50</max></set>
+                 </query>
+               </iq>"#
+        ))
+        .await
+        .expect("send room MAM query");
+    client
+        .recv_until(|frame| frame.contains("urn:xmpp:mam:2") && frame.contains("<fin"))
+        .await
+        .expect("MAM query completes")
+}
+
 /// XEP-0272 §Joining + XEP-0045 §7.1: when a multi-session occupant
 /// (the user's own bare JID joined twice with two resources) updates
 /// presence with a `<muji/>` content advertisement, the reflection
@@ -459,12 +503,17 @@ async fn muji_presence_reflects_to_senders_sibling_resource() {
     // Match on the `<muji` element start tag, NOT the substring "muji"
     // which could collide with the room JID. Both open-tag forms
     // (with attributes / namespace) are accepted.
-    let mobile_active = mobile
-        .recv_matching(|frame| {
+    let active_frames = recv_until_muji_and_anchor(&mut mobile).await;
+    let mobile_active = active_frames
+        .iter()
+        .find(|frame| {
             frame.contains("<presence") && (frame.contains("<muji ") || frame.contains("<muji>"))
         })
-        .await
-        .expect("mobile receives reflected muji presence on its own WebSocket");
+        .unwrap_or_else(|| {
+            panic!(
+                "mobile must receive reflected muji presence on its own WebSocket: {active_frames:?}"
+            )
+        });
     let element = parse_presence(&mobile_active);
     assert_eq!(
         element.name(),
@@ -485,6 +534,86 @@ async fn muji_presence_reflects_to_senders_sibling_resource() {
     assert!(
         muc_user_has_status_110(&element),
         "XEP-0045 §7.1: sibling session of the sender must receive <status code='110'/>: {mobile_active}"
+    );
+
+    let anchor = active_frames
+        .iter()
+        .find(|frame| frame.contains("<call-thread") && frame.contains(NS_CALL_THREAD))
+        .expect("mobile receives call-thread anchor");
+    let anchor_element: Element = anchor
+        .parse()
+        .unwrap_or_else(|err| panic!("anchor must parse as XML: {err}; frame={anchor}"));
+    assert_eq!(
+        anchor_element.name(),
+        "message",
+        "expected message: {anchor}"
+    );
+    assert_eq!(
+        anchor_element.attr("type"),
+        Some("groupchat"),
+        "anchor must be groupchat: {anchor}"
+    );
+    assert_eq!(
+        anchor_element.attr("from"),
+        Some(room.as_str()),
+        "anchor must be authored by the room bare JID: {anchor}"
+    );
+    assert!(
+        anchor_element
+            .get_child("thread", "jabber:client")
+            .is_some()
+            || anchor_element.get_child("thread", "").is_some(),
+        "anchor must carry XEP-0201 <thread/>: {anchor}"
+    );
+    let marker = call_thread_child(&anchor_element)
+        .unwrap_or_else(|| panic!("anchor must carry typed call-thread marker: {anchor}"));
+    assert_eq!(marker.attr("kind"), Some("muc"));
+    assert_eq!(marker.attr("media"), Some("audio"));
+    assert_eq!(marker.attr("initiator"), Some("admin@localhost"));
+    assert!(
+        marker.attr("sid").is_some(),
+        "marker must carry session id: {anchor}"
+    );
+    assert!(
+        marker.attr("started").is_some(),
+        "marker must carry RFC3339 started timestamp: {anchor}"
+    );
+    assert!(
+        anchor_element
+            .get_child("store", "urn:xmpp:hints")
+            .is_some(),
+        "anchor must carry XEP-0334 <store/> hint: {anchor}"
+    );
+
+    web.send(&muji_active)
+        .await
+        .expect("web repeats active muji presence");
+    mobile
+        .recv_matching(|frame| {
+            frame.contains("<presence") && (frame.contains("<muji ") || frame.contains("<muji>"))
+        })
+        .await
+        .expect("mobile receives repeated active muji reflection");
+
+    let mam_frames = query_room_mam(&mut mobile, &room, "call-thread-mam-1").await;
+    let archived_anchors: Vec<&String> = mam_frames
+        .iter()
+        .filter(|frame| frame.contains("<forwarded") && frame.contains("<call-thread"))
+        .collect();
+    assert_eq!(
+        archived_anchors.len(),
+        1,
+        "MAM must archive exactly one anchor per active call session: {mam_frames:?}"
+    );
+    let archived_anchor = archived_anchors[0];
+    assert!(
+        archived_anchor.contains("<thread>") && archived_anchor.contains("</thread>"),
+        "MAM anchor must round-trip XEP-0201 <thread/>: {archived_anchor}"
+    );
+    assert!(
+        archived_anchor.contains("<store xmlns='urn:xmpp:hints'/>")
+            || archived_anchor.contains("<store xmlns=\"urn:xmpp:hints\"/>"),
+        "MAM anchor must round-trip <store/> hint: {archived_anchor}"
     );
 
     // Web emits the XEP-0272 §Leaving marker — an empty `<muji/>`

--- a/server/crates/waddle-server/tests/calls_e2e_ws.rs
+++ b/server/crates/waddle-server/tests/calls_e2e_ws.rs
@@ -395,22 +395,27 @@ fn call_thread_child(message: &Element) -> Option<&Element> {
 
 async fn recv_until_muji_and_anchor(client: &mut WsXmppClient) -> Vec<String> {
     let mut frames = Vec::new();
-    loop {
-        let frame = client
-            .recv()
-            .await
-            .expect("receive frame while waiting for muji reflection and call-thread anchor");
-        frames.push(frame);
-        let has_muji = frames.iter().any(|frame| {
-            frame.contains("<presence") && (frame.contains("<muji ") || frame.contains("<muji>"))
-        });
-        let has_anchor = frames
-            .iter()
-            .any(|frame| frame.contains("<call-thread") && frame.contains(NS_CALL_THREAD));
-        if has_muji && has_anchor {
-            return frames;
+    tokio::time::timeout(std::time::Duration::from_secs(10), async {
+        loop {
+            let frame = client
+                .recv()
+                .await
+                .expect("receive frame while waiting for muji reflection and call-thread anchor");
+            frames.push(frame);
+            let has_muji = frames.iter().any(|frame| {
+                frame.contains("<presence")
+                    && (frame.contains("<muji ") || frame.contains("<muji>"))
+            });
+            let has_anchor = frames
+                .iter()
+                .any(|frame| frame.contains("<call-thread") && frame.contains(NS_CALL_THREAD));
+            if has_muji && has_anchor {
+                return frames;
+            }
         }
-    }
+    })
+    .await
+    .expect("muji reflection and call-thread anchor arrive before timeout")
 }
 
 async fn query_room_mam(client: &mut WsXmppClient, room: &str, id: &str) -> Vec<String> {
@@ -504,6 +509,20 @@ async fn muji_presence_reflects_to_senders_sibling_resource() {
     // which could collide with the room JID. Both open-tag forms
     // (with attributes / namespace) are accepted.
     let active_frames = recv_until_muji_and_anchor(&mut mobile).await;
+    let muji_frame_index = active_frames
+        .iter()
+        .position(|frame| {
+            frame.contains("<presence") && (frame.contains("<muji ") || frame.contains("<muji>"))
+        })
+        .expect("muji frame index");
+    let anchor_frame_index = active_frames
+        .iter()
+        .position(|frame| frame.contains("<call-thread") && frame.contains(NS_CALL_THREAD))
+        .expect("anchor frame index");
+    assert!(
+        muji_frame_index < anchor_frame_index,
+        "active Muji presence should be queued before the call-thread anchor: {active_frames:?}"
+    );
     let mobile_active = active_frames
         .iter()
         .find(|frame| {

--- a/server/crates/waddle-server/tests/calls_e2e_ws.rs
+++ b/server/crates/waddle-server/tests/calls_e2e_ws.rs
@@ -514,7 +514,7 @@ async fn muji_presence_reflects_to_senders_sibling_resource() {
                 "mobile must receive reflected muji presence on its own WebSocket: {active_frames:?}"
             )
         });
-    let element = parse_presence(&mobile_active);
+    let element = parse_presence(mobile_active);
     assert_eq!(
         element.name(),
         "presence",

--- a/server/crates/waddle-xmpp-client-ffi/src/convert.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/convert.rs
@@ -15,9 +15,10 @@ use waddle_xmpp_client::{
 
 use crate::{
     WaddleArchivedMessage, WaddleCallEvent, WaddleCallEventKind, WaddleCallMedia,
-    WaddleEncryptedFile, WaddleEncryptedFileHash, WaddleEventListener, WaddleJingleReason,
-    WaddleLiveKitJoin, WaddleMdsDisplayedEntry, WaddleMessage, WaddleMucAffiliation, WaddleMucRole,
-    WaddleMujiPresence, WaddlePresence, WaddlePresenceHat, WaddleSendOptions, WaddleSharedFile,
+    WaddleCallThreadAnchor, WaddleEncryptedFile, WaddleEncryptedFileHash, WaddleEventListener,
+    WaddleJingleReason, WaddleLiveKitJoin, WaddleMdsDisplayedEntry, WaddleMessage,
+    WaddleMucAffiliation, WaddleMucRole, WaddleMujiPresence, WaddlePresence, WaddlePresenceHat,
+    WaddleSendOptions, WaddleSharedFile,
 };
 
 // ── Event dispatch ───────────────────────────────────────────────────────────
@@ -323,6 +324,7 @@ fn inbound_to_ffi(msg: InboundMessage) -> WaddleMessage {
         reply_to_sender: msg.reply_to_sender,
         reply_fallback_start: fb_start,
         reply_fallback_end: fb_end,
+        call_thread: msg.call_thread.map(call_thread_to_ffi),
         shared_files: msg
             .shared_files
             .into_iter()
@@ -331,6 +333,30 @@ fn inbound_to_ffi(msg: InboundMessage) -> WaddleMessage {
         mds_displayed: msg
             .mds_displayed
             .map(|entries| entries.into_iter().map(mds_entry_to_ffi).collect()),
+    }
+}
+
+fn call_thread_to_ffi(
+    anchor: waddle_xmpp_client::xep::call_thread::CallThreadAnchor,
+) -> WaddleCallThreadAnchor {
+    let kind = match anchor.kind {
+        waddle_xmpp_client::xep::call_thread::CallThreadKind::Dm => "dm",
+        waddle_xmpp_client::xep::call_thread::CallThreadKind::Muc => "muc",
+    };
+    let mut media = Vec::new();
+    if anchor.media.audio {
+        media.push("audio".to_string());
+    }
+    if anchor.media.video {
+        media.push("video".to_string());
+    }
+
+    WaddleCallThreadAnchor {
+        kind: kind.to_string(),
+        sid: anchor.sid.0,
+        media,
+        initiator: anchor.initiator.to_string(),
+        started: anchor.started.to_rfc3339(),
     }
 }
 

--- a/server/crates/waddle-xmpp-client-ffi/src/convert.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/convert.rs
@@ -401,6 +401,9 @@ pub(crate) fn archived_to_ffi(
         reply_to_sender: parsed.and_then(|m| m.reply_to_sender.clone()),
         reply_fallback_start: fb_start,
         reply_fallback_end: fb_end,
+        call_thread: parsed
+            .and_then(|m| m.call_thread.clone())
+            .map(call_thread_to_ffi),
         shared_files: parsed
             .map(|m| {
                 m.shared_files
@@ -727,6 +730,44 @@ mod tests {
             WaddleCallEventKind::Propose { media } => assert!(media.audio),
             other => panic!("expected Propose, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn archived_to_ffi_preserves_call_thread_anchor_for_room_reload() {
+        let archived = parse_mam_archived(
+            "<message xmlns='jabber:client'>\
+               <result xmlns='urn:xmpp:mam:2' id='mam-anchor' queryid='q1'>\
+                 <forwarded xmlns='urn:xmpp:forward:0'>\
+                   <delay xmlns='urn:xmpp:delay' stamp='2026-06-07T14:30:00Z'/>\
+                   <message xmlns='jabber:client' type='groupchat' id='anchor-1' \
+                            from='general@muc.waddle.test' to='alice@waddle.test/web'>\
+                     <body>Alice started a call</body>\
+                     <thread>call-thread-uuid</thread>\
+                     <call-thread xmlns='urn:waddle:call-thread:0' \
+                                  kind='muc' \
+                                  sid='session-uuid' \
+                                  media='audio video' \
+                                  initiator='alice@waddle.test' \
+                                  started='2026-06-07T14:30:00Z'/>\
+                     <store xmlns='urn:xmpp:hints'/>\
+                   </message>\
+                 </forwarded>\
+               </result>\
+             </message>",
+        );
+
+        let ffi = archived_to_ffi(archived);
+        let anchor = ffi
+            .call_thread
+            .expect("call-thread should survive archive conversion");
+
+        assert_eq!(ffi.mam_id, "mam-anchor");
+        assert_eq!(ffi.thread.as_deref(), Some("call-thread-uuid"));
+        assert_eq!(anchor.kind, "muc");
+        assert_eq!(anchor.sid, "session-uuid");
+        assert_eq!(anchor.media, vec!["audio".to_owned(), "video".to_owned()]);
+        assert_eq!(anchor.initiator, "alice@waddle.test");
+        assert_eq!(anchor.started, "2026-06-07T14:30:00+00:00");
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client-ffi/src/types.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/types.rs
@@ -35,6 +35,8 @@ pub struct WaddleMessage {
     pub reply_fallback_start: Option<u32>,
     /// XEP-0428 fallback range end (char offset, exclusive).
     pub reply_fallback_end: Option<u32>,
+    /// urn:waddle:call-thread:0 call-thread anchor marker, if present.
+    pub call_thread: Option<WaddleCallThreadAnchor>,
     /// XEP-0446 / XEP-0447 shared files attached to the message.
     pub shared_files: Vec<WaddleSharedFile>,
     /// XEP-0490 Message Displayed Synchronization PEP event payload.
@@ -42,6 +44,15 @@ pub struct WaddleMessage {
     /// when it is — including `Some(vec![])` for an MDS event with
     /// zero items (rare but distinct from "not an MDS event").
     pub mds_displayed: Option<Vec<WaddleMdsDisplayedEntry>>,
+}
+
+#[derive(uniffi::Record, Clone)]
+pub struct WaddleCallThreadAnchor {
+    pub kind: String,
+    pub sid: String,
+    pub media: Vec<String>,
+    pub initiator: String,
+    pub started: String,
 }
 
 /// XEP-0490 §3 displayed-marker entry surfaced to Swift. Mirrors

--- a/server/crates/waddle-xmpp-client-ffi/src/types.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/types.rs
@@ -91,6 +91,8 @@ pub struct WaddleArchivedMessage {
     pub reply_to_sender: Option<String>,
     pub reply_fallback_start: Option<u32>,
     pub reply_fallback_end: Option<u32>,
+    /// urn:waddle:call-thread:0 call-thread anchor marker, if present.
+    pub call_thread: Option<WaddleCallThreadAnchor>,
     pub shared_files: Vec<WaddleSharedFile>,
     pub call_event: Option<WaddleCallEvent>,
 }

--- a/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
@@ -474,6 +474,9 @@ pub(crate) fn archived_to_js(archived: ArchivedMessage) -> Option<WaddleArchived
         forum_thread_title,
         is_sticker: parsed.is_some_and(|message| message.is_sticker),
         author_real_jid: archived.author_real_jid,
+        call_thread: parsed
+            .and_then(|message| message.call_thread.clone())
+            .map(call_thread_to_js),
         shared_files: parsed
             .map(|message| {
                 message
@@ -1050,6 +1053,44 @@ mod inbound_to_js_tests {
         assert_eq!(call_event.sid, "call-1");
         assert_eq!(call_event.from, "bob@waddle.test/phone");
         assert!(call_event.media.expect("media").audio);
+    }
+
+    #[test]
+    fn archived_to_js_preserves_call_thread_anchor_for_room_reload() {
+        let archived = parse_mam_archived(
+            "<message xmlns='jabber:client'>\
+               <result xmlns='urn:xmpp:mam:2' id='mam-anchor' queryid='q1'>\
+                 <forwarded xmlns='urn:xmpp:forward:0'>\
+                   <delay xmlns='urn:xmpp:delay' stamp='2026-06-07T14:30:00Z'/>\
+                   <message xmlns='jabber:client' type='groupchat' id='anchor-1' \
+                            from='general@muc.waddle.test' to='alice@waddle.test/web'>\
+                     <body>Alice started a call</body>\
+                     <thread>call-thread-uuid</thread>\
+                     <call-thread xmlns='urn:waddle:call-thread:0' \
+                                  kind='muc' \
+                                  sid='session-uuid' \
+                                  media='audio video' \
+                                  initiator='alice@waddle.test' \
+                                  started='2026-06-07T14:30:00Z'/>\
+                     <store xmlns='urn:xmpp:hints'/>\
+                   </message>\
+                 </forwarded>\
+               </result>\
+             </message>",
+        );
+
+        let js = archived_to_js(archived).expect("call-thread MAM row should convert");
+        let anchor = js
+            .call_thread
+            .expect("call-thread should survive archive conversion");
+
+        assert_eq!(js.mam_id, "mam-anchor");
+        assert_eq!(js.thread.as_deref(), Some("call-thread-uuid"));
+        assert_eq!(anchor.kind, "muc");
+        assert_eq!(anchor.sid, "session-uuid");
+        assert_eq!(anchor.media, vec!["audio".to_owned(), "video".to_owned()]);
+        assert_eq!(anchor.initiator, "alice@waddle.test");
+        assert_eq!(anchor.started, "2026-06-07T14:30:00+00:00");
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
@@ -50,6 +50,30 @@ pub(crate) fn references_to_js(references: Vec<messaging::ReferenceData>) -> Vec
         .collect()
 }
 
+pub(crate) fn call_thread_to_js(
+    anchor: waddle_xmpp_client::xep::call_thread::CallThreadAnchor,
+) -> WaddleCallThreadAnchor {
+    let kind = match anchor.kind {
+        waddle_xmpp_client::xep::call_thread::CallThreadKind::Dm => "dm",
+        waddle_xmpp_client::xep::call_thread::CallThreadKind::Muc => "muc",
+    };
+    let mut media = Vec::new();
+    if anchor.media.audio {
+        media.push("audio".to_string());
+    }
+    if anchor.media.video {
+        media.push("video".to_string());
+    }
+
+    WaddleCallThreadAnchor {
+        kind: kind.to_string(),
+        sid: anchor.sid.0,
+        media,
+        initiator: anchor.initiator.to_string(),
+        started: anchor.started.to_rfc3339(),
+    }
+}
+
 pub(crate) fn extension_envelope_to_js(
     envelope: messaging::ExtensionEnvelopeData,
 ) -> WaddleExtensionEnvelope {
@@ -202,6 +226,7 @@ pub(crate) fn inbound_to_js(message: InboundMessage) -> WaddleMessage {
         forum_title: message.forum_title,
         forum_thread_title,
         is_sticker: message.is_sticker,
+        call_thread: message.call_thread.map(call_thread_to_js),
         shared_files: message
             .shared_files
             .into_iter()
@@ -326,6 +351,7 @@ pub(crate) fn inbox_push_to_js(
         forum_title: None,
         forum_thread_title: None,
         is_sticker: false,
+        call_thread: None,
         shared_files: Vec::new(),
         link_previews: Vec::new(),
         pin_event: None,

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -15,6 +15,15 @@ pub struct WaddleStanzaId {
 }
 
 #[derive(Debug, Serialize)]
+pub struct WaddleCallThreadAnchor {
+    pub kind: String,
+    pub sid: String,
+    pub media: Vec<String>,
+    pub initiator: String,
+    pub started: String,
+}
+
+#[derive(Debug, Serialize)]
 pub struct WaddleMessage {
     pub id: Option<String>,
     pub from: Option<String>,
@@ -54,6 +63,9 @@ pub struct WaddleMessage {
     pub forum_title: Option<String>,
     pub forum_thread_title: Option<String>,
     pub is_sticker: bool,
+    /// urn:waddle:call-thread:0 room call-thread anchor.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub call_thread: Option<WaddleCallThreadAnchor>,
     pub shared_files: Vec<WaddleSharedFile>,
     pub link_previews: Vec<WaddleLinkPreview>,
     /// urn:waddle:pin:0 pin/unpin event surfaced from a system message

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -299,6 +299,9 @@ pub struct WaddleArchivedMessage {
     pub forum_thread_title: Option<String>,
     pub is_sticker: bool,
     pub author_real_jid: Option<String>,
+    /// urn:waddle:call-thread:0 room call-thread anchor.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub call_thread: Option<WaddleCallThreadAnchor>,
     pub shared_files: Vec<WaddleSharedFile>,
     pub link_previews: Vec<WaddleLinkPreview>,
     pub extension_envelope: Option<WaddleExtensionEnvelope>,

--- a/server/crates/waddle-xmpp-client/src/messaging/parsing/mod.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/parsing/mod.rs
@@ -9,7 +9,7 @@ use minidom::Element;
 
 use crate::xep::encrypted_file::{self as xep_encrypted_file, NS_ESFS as NS_ENCRYPTED_FILE};
 use crate::xep::fallback::{body_fallbacks_for, strip_fallback_ranges, BodyFallback};
-use crate::xep::{reply as xep_reply, thread as xep_thread};
+use crate::xep::{call_thread as xep_call_thread, reply as xep_reply, thread as xep_thread};
 use waddle_xmpp_core::{
     first_eligible_https_url_text, xep0359::StanzaId as StableStanzaId, PreviewImageMediaType,
 };
@@ -128,6 +128,7 @@ fn parse_message(el: &Element) -> Option<InboundMessage> {
             .collect::<Vec<_>>()
     });
     let pubsub_events = crate::pubsub_event::parse_pubsub_events(el);
+    let call_thread = xep_call_thread::parse_call_thread_anchor_child(el);
 
     let reply_marker = xep_reply::parse_reply(el);
     let reply_to_id = reply_marker.as_ref().map(|m| m.id.clone());
@@ -352,6 +353,7 @@ fn parse_message(el: &Element) -> Option<InboundMessage> {
         forum_title,
         thread_id,
         parent_thread_id,
+        call_thread,
         is_sticker,
         pin_event,
         extension_envelope,

--- a/server/crates/waddle-xmpp-client/src/messaging/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/tests.rs
@@ -326,6 +326,33 @@ fn parse_message_with_nested_thread() {
 }
 
 #[test]
+fn parse_message_with_call_thread_anchor() {
+    let e = el("<message xmlns='jabber:client' from='room@muc.example' type='groupchat'>\
+         <body>Alice started a call</body>\
+         <thread>call-thread-uuid</thread>\
+         <call-thread xmlns='urn:waddle:call-thread:0' kind='muc' sid='session-uuid' media='audio video' initiator='alice@example.com' started='2026-06-07T14:30:00Z'/>\
+         </message>");
+    let MessagingEvent::Message(msg) = parse(&e).unwrap() else {
+        panic!("expected Message");
+    };
+    let call_thread = msg.call_thread.expect("call-thread marker");
+
+    assert_eq!(msg.thread_id.as_deref(), Some("call-thread-uuid"));
+    assert_eq!(
+        call_thread.kind,
+        crate::xep::call_thread::CallThreadKind::Muc
+    );
+    assert_eq!(call_thread.sid.0, "session-uuid");
+    assert!(call_thread.media.audio);
+    assert!(call_thread.media.video);
+    assert_eq!(call_thread.initiator.to_string(), "alice@example.com");
+    assert_eq!(
+        call_thread.started.to_rfc3339(),
+        "2026-06-07T14:30:00+00:00"
+    );
+}
+
+#[test]
 fn parse_message_with_retract() {
     let e = el("<message xmlns='jabber:client' type='groupchat'>\
          <retract xmlns='urn:xmpp:message-retract:1' id='old-msg-id'/>\

--- a/server/crates/waddle-xmpp-client/src/messaging/types.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/types.rs
@@ -166,6 +166,9 @@ pub struct InboundMessage {
     pub forum_title: Option<String>,
     pub thread_id: Option<String>,
     pub parent_thread_id: Option<String>,
+    /// urn:waddle:call-thread:0 call anchor authored by the room.
+    /// `None` when the message carries no `<call-thread/>` payload.
+    pub call_thread: Option<crate::xep::call_thread::CallThreadAnchor>,
     pub is_sticker: bool,
     /// urn:waddle:pin:0 pin/unpin system event surfaced by the room.
     /// `None` when the message carries no `<pin-event/>` payload.

--- a/server/crates/waddle-xmpp-client/src/xep/call_thread.rs
+++ b/server/crates/waddle-xmpp-client/src/xep/call_thread.rs
@@ -62,15 +62,7 @@ pub fn build_call_thread_anchor(anchor: &CallThreadAnchor) -> Element {
         CallThreadKind::Dm => "dm",
         CallThreadKind::Muc => "muc",
     };
-    let media = if anchor.media.audio && anchor.media.video {
-        "audio video"
-    } else if anchor.media.audio {
-        "audio"
-    } else if anchor.media.video {
-        "video"
-    } else {
-        ""
-    };
+    let media = media_attr(anchor.media).expect("call-thread marker requires audio or video media");
 
     Element::builder("call-thread", NS_WADDLE_CALL_THREAD)
         .attr(minidom::rxml::xml_ncname!("kind").to_owned(), kind)
@@ -129,6 +121,15 @@ pub fn parse_call_thread_anchor_child(message: &Element) -> Option<CallThreadAnc
         .and_then(|child| parse_call_thread_anchor(child).ok())
 }
 
+fn media_attr(media: CallThreadMedia) -> Result<&'static str, CallThreadParseError> {
+    match (media.audio, media.video) {
+        (true, true) => Ok("audio video"),
+        (true, false) => Ok("audio"),
+        (false, true) => Ok("video"),
+        (false, false) => Err(CallThreadParseError::InvalidMedia),
+    }
+}
+
 fn required_attr<'a>(
     element: &'a Element,
     name: &'static str,
@@ -185,6 +186,18 @@ mod tests {
 
         let parsed = parse_call_thread_anchor(&element).expect("marker parses");
         assert_eq!(parsed, original);
+    }
+
+    #[test]
+    #[should_panic(expected = "call-thread marker requires audio or video media")]
+    fn builder_rejects_empty_media() {
+        let mut anchor = anchor();
+        anchor.media = CallThreadMedia {
+            audio: false,
+            video: false,
+        };
+
+        let _ = build_call_thread_anchor(&anchor);
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client/src/xep/call_thread.rs
+++ b/server/crates/waddle-xmpp-client/src/xep/call_thread.rs
@@ -1,0 +1,218 @@
+//! Waddle call-thread anchor marker.
+//!
+//! The thread itself is XEP-0201's `<thread/>`; this marker only links that
+//! thread to the call session that created it.
+
+use chrono::{DateTime, Utc};
+use jid::BareJid;
+use minidom::Element;
+use xmpp_parsers::jingle::SessionId;
+
+pub const NS_WADDLE_CALL_THREAD: &str = "urn:waddle:call-thread:0";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CallThreadKind {
+    Dm,
+    Muc,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CallThreadMedia {
+    pub audio: bool,
+    pub video: bool,
+}
+
+impl CallThreadMedia {
+    pub const fn audio_only() -> Self {
+        Self {
+            audio: true,
+            video: false,
+        }
+    }
+
+    pub const fn audio_video() -> Self {
+        Self {
+            audio: true,
+            video: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CallThreadAnchor {
+    pub kind: CallThreadKind,
+    pub sid: SessionId,
+    pub media: CallThreadMedia,
+    pub initiator: BareJid,
+    pub started: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CallThreadParseError {
+    NotCallThread,
+    MissingAttribute(&'static str),
+    InvalidKind,
+    InvalidMedia,
+    InvalidInitiator,
+    InvalidStarted,
+}
+
+pub fn build_call_thread_anchor(anchor: &CallThreadAnchor) -> Element {
+    let kind = match anchor.kind {
+        CallThreadKind::Dm => "dm",
+        CallThreadKind::Muc => "muc",
+    };
+    let media = if anchor.media.audio && anchor.media.video {
+        "audio video"
+    } else if anchor.media.audio {
+        "audio"
+    } else if anchor.media.video {
+        "video"
+    } else {
+        ""
+    };
+
+    Element::builder("call-thread", NS_WADDLE_CALL_THREAD)
+        .attr(minidom::rxml::xml_ncname!("kind").to_owned(), kind)
+        .attr(
+            minidom::rxml::xml_ncname!("sid").to_owned(),
+            anchor.sid.0.as_str(),
+        )
+        .attr(minidom::rxml::xml_ncname!("media").to_owned(), media)
+        .attr(
+            minidom::rxml::xml_ncname!("initiator").to_owned(),
+            anchor.initiator.as_str(),
+        )
+        .attr(
+            minidom::rxml::xml_ncname!("started").to_owned(),
+            anchor
+                .started
+                .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        )
+        .build()
+}
+
+pub fn parse_call_thread_anchor(
+    element: &Element,
+) -> Result<CallThreadAnchor, CallThreadParseError> {
+    if element.name() != "call-thread" || element.ns() != NS_WADDLE_CALL_THREAD {
+        return Err(CallThreadParseError::NotCallThread);
+    }
+
+    let kind = match required_attr(element, "kind")? {
+        "dm" => CallThreadKind::Dm,
+        "muc" => CallThreadKind::Muc,
+        _ => return Err(CallThreadParseError::InvalidKind),
+    };
+
+    let sid = SessionId(required_attr(element, "sid")?.to_string());
+    let media = parse_media(required_attr(element, "media")?)?;
+    let initiator = required_attr(element, "initiator")?
+        .parse::<BareJid>()
+        .map_err(|_| CallThreadParseError::InvalidInitiator)?;
+    let started = DateTime::parse_from_rfc3339(required_attr(element, "started")?)
+        .map_err(|_| CallThreadParseError::InvalidStarted)?
+        .with_timezone(&Utc);
+
+    Ok(CallThreadAnchor {
+        kind,
+        sid,
+        media,
+        initiator,
+        started,
+    })
+}
+
+pub fn parse_call_thread_anchor_child(message: &Element) -> Option<CallThreadAnchor> {
+    message
+        .get_child("call-thread", NS_WADDLE_CALL_THREAD)
+        .and_then(|child| parse_call_thread_anchor(child).ok())
+}
+
+fn required_attr<'a>(
+    element: &'a Element,
+    name: &'static str,
+) -> Result<&'a str, CallThreadParseError> {
+    element
+        .attr(name)
+        .ok_or(CallThreadParseError::MissingAttribute(name))
+}
+
+fn parse_media(value: &str) -> Result<CallThreadMedia, CallThreadParseError> {
+    let mut audio = false;
+    let mut video = false;
+    for part in value.split_ascii_whitespace() {
+        match part {
+            "audio" => audio = true,
+            "video" => video = true,
+            _ => return Err(CallThreadParseError::InvalidMedia),
+        }
+    }
+    if !audio && !video {
+        return Err(CallThreadParseError::InvalidMedia);
+    }
+    Ok(CallThreadMedia { audio, video })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn anchor() -> CallThreadAnchor {
+        CallThreadAnchor {
+            kind: CallThreadKind::Muc,
+            sid: SessionId("session-123".to_string()),
+            media: CallThreadMedia::audio_video(),
+            initiator: "alice@example.test".parse().expect("initiator"),
+            started: "2026-06-07T14:30:00Z"
+                .parse::<DateTime<Utc>>()
+                .expect("started"),
+        }
+    }
+
+    #[test]
+    fn build_parse_round_trips_call_thread_anchor_marker() {
+        let original = anchor();
+        let element = build_call_thread_anchor(&original);
+
+        assert_eq!(element.name(), "call-thread");
+        assert_eq!(element.ns(), NS_WADDLE_CALL_THREAD);
+        assert_eq!(element.attr("kind"), Some("muc"));
+        assert_eq!(element.attr("sid"), Some("session-123"));
+        assert_eq!(element.attr("media"), Some("audio video"));
+        assert_eq!(element.attr("initiator"), Some("alice@example.test"));
+        assert_eq!(element.attr("started"), Some("2026-06-07T14:30:00Z"));
+
+        let parsed = parse_call_thread_anchor(&element).expect("marker parses");
+        assert_eq!(parsed, original);
+    }
+
+    #[test]
+    fn parses_call_thread_anchor_child_from_message() {
+        let xml = r#"<message xmlns='jabber:client' type='groupchat' from='general@muc.example'>
+            <body>Alice started a call</body>
+            <thread>call-thread-uuid</thread>
+            <call-thread xmlns='urn:waddle:call-thread:0'
+                         kind='muc'
+                         sid='session-uuid'
+                         media='audio'
+                         initiator='alice@example'
+                         started='2026-06-07T14:30:00Z'/>
+            <store xmlns='urn:xmpp:hints'/>
+        </message>"#;
+        let message: Element = xml.parse().expect("message XML");
+
+        let parsed = parse_call_thread_anchor_child(&message).expect("call-thread child");
+
+        assert_eq!(parsed.kind, CallThreadKind::Muc);
+        assert_eq!(parsed.sid.0, "session-uuid");
+        assert_eq!(parsed.media, CallThreadMedia::audio_only());
+        assert_eq!(parsed.initiator.as_str(), "alice@example");
+        assert_eq!(
+            parsed
+                .started
+                .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+            "2026-06-07T14:30:00Z"
+        );
+    }
+}

--- a/server/crates/waddle-xmpp-client/src/xep/mod.rs
+++ b/server/crates/waddle-xmpp-client/src/xep/mod.rs
@@ -5,6 +5,7 @@
 //! namespaces or attribute names at call sites — everything flows through the
 //! typed module.
 
+pub mod call_thread;
 pub mod encrypted_file;
 pub mod fallback;
 pub mod reply;

--- a/server/crates/waddle-xmpp/src/muc/room.rs
+++ b/server/crates/waddle-xmpp/src/muc/room.rs
@@ -158,8 +158,8 @@ pub struct MujiPresenceState {
     /// state, so callers that need to preserve XEP-0272 joining
     /// semantics should prefer this list over the aggregate snapshot.
     pub session_mujis: Vec<(FullJid, Muji)>,
-    /// True when this update changed the nick from no active call to an
-    /// active call advertisement.
+    /// True when this update changed the room from no active Muji call
+    /// to at least one active call advertisement.
     pub active_call_started: bool,
 }
 

--- a/server/crates/waddle-xmpp/src/muc/room.rs
+++ b/server/crates/waddle-xmpp/src/muc/room.rs
@@ -158,6 +158,9 @@ pub struct MujiPresenceState {
     /// state, so callers that need to preserve XEP-0272 joining
     /// semantics should prefer this list over the aggregate snapshot.
     pub session_mujis: Vec<(FullJid, Muji)>,
+    /// True when this update changed the nick from no active call to an
+    /// active call advertisement.
+    pub active_call_started: bool,
 }
 
 impl MucRoom {
@@ -203,6 +206,7 @@ impl MucRoom {
         originator: FullJid,
         muji: Muji,
     ) -> MujiPresenceState {
+        let had_active_call = self.room_has_active_muji();
         if muji.is_empty() {
             if let Some(entries) = self.muji_state.get_mut(nick) {
                 entries.remove(&originator);
@@ -210,20 +214,28 @@ impl MucRoom {
                     self.muji_state.remove(nick);
                 }
             }
+            let room_muji = self.muji_for_nick(nick);
+            let active_call_started =
+                !had_active_call && room_muji.as_ref().is_some_and(Muji::is_active);
             MujiPresenceState {
                 sender_muji: None,
-                room_muji: self.muji_for_nick(nick),
+                room_muji,
                 session_mujis: self.muji_sessions_for_nick(nick),
+                active_call_started,
             }
         } else {
             self.muji_state
                 .entry(nick.to_owned())
                 .or_default()
                 .insert(originator, muji.clone());
+            let room_muji = self.muji_for_nick(nick);
+            let active_call_started =
+                !had_active_call && room_muji.as_ref().is_some_and(Muji::is_active);
             MujiPresenceState {
                 sender_muji: Some(muji),
-                room_muji: self.muji_for_nick(nick),
+                room_muji,
                 session_mujis: self.muji_sessions_for_nick(nick),
+                active_call_started,
             }
         }
     }
@@ -253,6 +265,13 @@ impl MucRoom {
             preparing,
             contents,
         })
+    }
+
+    fn room_has_active_muji(&self) -> bool {
+        self.muji_state
+            .values()
+            .flat_map(|entries| entries.values())
+            .any(Muji::is_active)
     }
 
     /// Currently-advertised Muji payload for one exact session.
@@ -298,6 +317,7 @@ impl MucRoom {
             sender_muji: None,
             room_muji: self.muji_for_nick(nick),
             session_mujis: self.muji_sessions_for_nick(nick),
+            active_call_started: false,
         }
     }
 

--- a/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
@@ -255,6 +255,8 @@ pub struct MujiPresenceUpdateOutcome {
     /// Exact per-session Muji payloads still advertised for this nick
     /// after the update.
     pub session_mujis: Vec<(FullJid, crate::xep::xep0272::Muji)>,
+    /// True when this update starts the room's active call state.
+    pub active_call_started: bool,
 }
 
 impl kameo::message::Message<UpsertMujiPresence> for RoomActor {
@@ -298,6 +300,7 @@ impl kameo::message::Message<UpsertMujiPresence> for RoomActor {
             sender_muji: muji_state.sender_muji,
             active_muji: muji_state.room_muji,
             session_mujis: muji_state.session_mujis,
+            active_call_started: muji_state.active_call_started,
         }))
     }
 }
@@ -337,6 +340,7 @@ impl kameo::message::Message<ClearMujiPresence> for RoomActor {
             sender_muji: muji_state.sender_muji,
             active_muji: muji_state.room_muji,
             session_mujis: muji_state.session_mujis,
+            active_call_started: muji_state.active_call_started,
         }))
     }
 }

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
@@ -1201,6 +1201,25 @@ fn same_nick_active_resources_are_aggregated_for_other_occupants() {
     );
 }
 
+#[test]
+fn active_call_started_is_room_wide_not_per_nick() {
+    let mut room = test_room();
+    let alice: FullJid = "alice@example.com/desktop".parse().expect("alice");
+    let bob: FullJid = "bob@example.com/desktop".parse().expect("bob");
+
+    let alice_start = room.upsert_muji_presence("alice", alice, audio_muji());
+    let bob_join = room.upsert_muji_presence("bob", bob, video_muji());
+
+    assert!(
+        alice_start.active_call_started,
+        "first active Muji in the room starts the call session"
+    );
+    assert!(
+        !bob_join.active_call_started,
+        "another occupant joining the existing active call must not emit a second anchor"
+    );
+}
+
 #[tokio::test]
 async fn upsert_muji_presence_empty_clears_state_and_returns_none() {
     let actor = spawn_room_actor().await;

--- a/server/crates/waddle-xmpp/src/xep/exports.rs
+++ b/server/crates/waddle-xmpp/src/xep/exports.rs
@@ -354,6 +354,11 @@ pub use super::xep_waddle_pin::{
     parse_unpinned_element as parse_unpinned_message_element, PinIntent, NS_WADDLE_PIN_V0,
 };
 
+pub use super::xep_waddle_call_thread::{
+    build_call_thread_anchor, parse_call_thread_anchor, parse_call_thread_anchor_child,
+    CallThreadAnchor, CallThreadKind, CallThreadMedia, CallThreadParseError, NS_WADDLE_CALL_THREAD,
+};
+
 pub use waddle_xmpp_core::xep0472::{
     build_feed_entry_element, is_feed_entry, parse_feed_entry, FeedEntry, NS_SOCIAL_FEED,
     PUBSUB_NODE_FEED,

--- a/server/crates/waddle-xmpp/src/xep/mod.rs
+++ b/server/crates/waddle-xmpp/src/xep/mod.rs
@@ -199,6 +199,7 @@ pub mod xep0502;
 pub mod xep0503;
 pub mod xep0511;
 pub mod xep0513;
+pub mod xep_waddle_call_thread;
 pub mod xep_waddle_dm_bookmarks;
 pub mod xep_waddle_dnd;
 pub mod xep_waddle_forums;

--- a/server/crates/waddle-xmpp/src/xep/xep_waddle_call_thread.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep_waddle_call_thread.rs
@@ -129,7 +129,9 @@ fn media_attr(media: CallThreadMedia) -> &'static str {
         (true, true) => "audio video",
         (true, false) => "audio",
         (false, true) => "video",
-        (false, false) => "",
+        (false, false) => {
+            panic!("call-thread marker requires audio or video media")
+        }
     }
 }
 
@@ -189,5 +191,17 @@ mod tests {
 
         let parsed = parse_call_thread_anchor(&element).expect("marker parses");
         assert_eq!(parsed, original);
+    }
+
+    #[test]
+    #[should_panic(expected = "call-thread marker requires audio or video media")]
+    fn builder_rejects_empty_media() {
+        let mut anchor = anchor();
+        anchor.media = CallThreadMedia {
+            audio: false,
+            video: false,
+        };
+
+        let _ = build_call_thread_anchor(&anchor);
     }
 }

--- a/server/crates/waddle-xmpp/src/xep/xep_waddle_call_thread.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep_waddle_call_thread.rs
@@ -1,0 +1,193 @@
+//! Waddle call-thread anchor marker (`urn:waddle:call-thread:0`).
+//!
+//! The conversation thread remains a standard XEP-0201 `<thread/>`. This
+//! project-local marker only links that thread to the call session.
+
+use chrono::{DateTime, Utc};
+use jid::BareJid;
+use minidom::Element;
+use xmpp_parsers::jingle::SessionId;
+use xmpp_parsers::message::Message;
+
+pub const NS_WADDLE_CALL_THREAD: &str = "urn:waddle:call-thread:0";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CallThreadKind {
+    Dm,
+    Muc,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CallThreadMedia {
+    pub audio: bool,
+    pub video: bool,
+}
+
+impl CallThreadMedia {
+    pub const fn audio_only() -> Self {
+        Self {
+            audio: true,
+            video: false,
+        }
+    }
+
+    pub const fn audio_video() -> Self {
+        Self {
+            audio: true,
+            video: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CallThreadAnchor {
+    pub kind: CallThreadKind,
+    pub sid: SessionId,
+    pub media: CallThreadMedia,
+    pub initiator: BareJid,
+    pub started: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CallThreadParseError {
+    NotCallThread,
+    MissingAttribute(&'static str),
+    InvalidKind,
+    InvalidMedia,
+    InvalidInitiator,
+    InvalidStarted,
+}
+
+pub fn build_call_thread_anchor(anchor: &CallThreadAnchor) -> Element {
+    let kind = match anchor.kind {
+        CallThreadKind::Dm => "dm",
+        CallThreadKind::Muc => "muc",
+    };
+    let media = media_attr(anchor.media);
+
+    Element::builder("call-thread", NS_WADDLE_CALL_THREAD)
+        .attr(minidom::rxml::xml_ncname!("kind").to_owned(), kind)
+        .attr(
+            minidom::rxml::xml_ncname!("sid").to_owned(),
+            anchor.sid.0.as_str(),
+        )
+        .attr(minidom::rxml::xml_ncname!("media").to_owned(), media)
+        .attr(
+            minidom::rxml::xml_ncname!("initiator").to_owned(),
+            anchor.initiator.as_str(),
+        )
+        .attr(
+            minidom::rxml::xml_ncname!("started").to_owned(),
+            anchor
+                .started
+                .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        )
+        .build()
+}
+
+pub fn parse_call_thread_anchor(
+    element: &Element,
+) -> Result<CallThreadAnchor, CallThreadParseError> {
+    if element.name() != "call-thread" || element.ns() != NS_WADDLE_CALL_THREAD {
+        return Err(CallThreadParseError::NotCallThread);
+    }
+
+    let kind = match required_attr(element, "kind")? {
+        "dm" => CallThreadKind::Dm,
+        "muc" => CallThreadKind::Muc,
+        _ => return Err(CallThreadParseError::InvalidKind),
+    };
+
+    let sid = SessionId(required_attr(element, "sid")?.to_owned());
+    let media = parse_media(required_attr(element, "media")?)?;
+    let initiator = required_attr(element, "initiator")?
+        .parse::<BareJid>()
+        .map_err(|_| CallThreadParseError::InvalidInitiator)?;
+    let started = DateTime::parse_from_rfc3339(required_attr(element, "started")?)
+        .map_err(|_| CallThreadParseError::InvalidStarted)?
+        .with_timezone(&Utc);
+
+    Ok(CallThreadAnchor {
+        kind,
+        sid,
+        media,
+        initiator,
+        started,
+    })
+}
+
+pub fn parse_call_thread_anchor_child(message: &Message) -> Option<CallThreadAnchor> {
+    message
+        .payloads
+        .iter()
+        .find(|payload| payload.name() == "call-thread" && payload.ns() == NS_WADDLE_CALL_THREAD)
+        .and_then(|payload| parse_call_thread_anchor(payload).ok())
+}
+
+fn media_attr(media: CallThreadMedia) -> &'static str {
+    match (media.audio, media.video) {
+        (true, true) => "audio video",
+        (true, false) => "audio",
+        (false, true) => "video",
+        (false, false) => "",
+    }
+}
+
+fn required_attr<'a>(
+    element: &'a Element,
+    name: &'static str,
+) -> Result<&'a str, CallThreadParseError> {
+    element
+        .attr(name)
+        .ok_or(CallThreadParseError::MissingAttribute(name))
+}
+
+fn parse_media(value: &str) -> Result<CallThreadMedia, CallThreadParseError> {
+    let mut audio = false;
+    let mut video = false;
+    for part in value.split_ascii_whitespace() {
+        match part {
+            "audio" => audio = true,
+            "video" => video = true,
+            _ => return Err(CallThreadParseError::InvalidMedia),
+        }
+    }
+    if !audio && !video {
+        return Err(CallThreadParseError::InvalidMedia);
+    }
+    Ok(CallThreadMedia { audio, video })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn anchor() -> CallThreadAnchor {
+        CallThreadAnchor {
+            kind: CallThreadKind::Muc,
+            sid: SessionId("session-123".to_owned()),
+            media: CallThreadMedia::audio_video(),
+            initiator: "alice@example.test".parse().expect("initiator"),
+            started: "2026-06-07T14:30:00Z"
+                .parse::<DateTime<Utc>>()
+                .expect("started"),
+        }
+    }
+
+    #[test]
+    fn build_parse_round_trips_call_thread_anchor_marker() {
+        let original = anchor();
+        let element = build_call_thread_anchor(&original);
+
+        assert_eq!(element.name(), "call-thread");
+        assert_eq!(element.ns(), NS_WADDLE_CALL_THREAD);
+        assert_eq!(element.attr("kind"), Some("muc"));
+        assert_eq!(element.attr("sid"), Some("session-123"));
+        assert_eq!(element.attr("media"), Some("audio video"));
+        assert_eq!(element.attr("initiator"), Some("alice@example.test"));
+        assert_eq!(element.attr("started"), Some("2026-06-07T14:30:00Z"));
+
+        let parsed = parse_call_thread_anchor(&element).expect("marker parses");
+        assert_eq!(parsed, original);
+    }
+}

--- a/server/crates/waddle-xmpp/tests/xep_waddle_call_thread.rs
+++ b/server/crates/waddle-xmpp/tests/xep_waddle_call_thread.rs
@@ -1,0 +1,85 @@
+//! `urn:waddle:call-thread:0` — Waddle's call-thread anchor marker.
+//!
+//! The conversation thread remains the standard XEP-0201 `<thread/>`.
+//! This custom marker only links that thread to a typed call session.
+
+use chrono::{DateTime, Utc};
+use minidom::Element;
+use waddle_xmpp::xep::{
+    build_call_thread_anchor, parse_call_thread_anchor, CallThreadAnchor, CallThreadKind,
+    CallThreadMedia, CallThreadParseError, NS_WADDLE_CALL_THREAD,
+};
+use xmpp_parsers::jingle::SessionId;
+
+fn anchor(media: CallThreadMedia) -> CallThreadAnchor {
+    CallThreadAnchor {
+        kind: CallThreadKind::Muc,
+        sid: SessionId("session-123".to_owned()),
+        media,
+        initiator: "alice@example.test".parse().expect("initiator"),
+        started: "2026-06-07T14:30:00Z"
+            .parse::<DateTime<Utc>>()
+            .expect("started"),
+    }
+}
+
+#[test]
+fn call_thread_marker_namespace_is_versioned_zero() {
+    assert_eq!(NS_WADDLE_CALL_THREAD, "urn:waddle:call-thread:0");
+}
+
+#[test]
+fn call_thread_marker_round_trips_audio_video_media() {
+    let original = anchor(CallThreadMedia::audio_video());
+    let element = build_call_thread_anchor(&original);
+
+    assert_eq!(element.name(), "call-thread");
+    assert_eq!(element.ns(), NS_WADDLE_CALL_THREAD);
+    assert_eq!(element.attr("kind"), Some("muc"));
+    assert_eq!(element.attr("sid"), Some("session-123"));
+    assert_eq!(element.attr("media"), Some("audio video"));
+    assert_eq!(element.attr("initiator"), Some("alice@example.test"));
+    assert_eq!(element.attr("started"), Some("2026-06-07T14:30:00Z"));
+
+    let parsed = parse_call_thread_anchor(&element).expect("marker parses");
+    assert_eq!(parsed, original);
+}
+
+#[test]
+fn call_thread_marker_round_trips_video_only_media() {
+    let original = anchor(CallThreadMedia {
+        audio: false,
+        video: true,
+    });
+    let element = build_call_thread_anchor(&original);
+
+    assert_eq!(element.attr("media"), Some("video"));
+    assert_eq!(
+        parse_call_thread_anchor(&element).expect("marker parses"),
+        original
+    );
+}
+
+#[test]
+#[should_panic(expected = "call-thread marker requires audio or video media")]
+fn call_thread_marker_builder_rejects_empty_media() {
+    let _ = build_call_thread_anchor(&anchor(CallThreadMedia {
+        audio: false,
+        video: false,
+    }));
+}
+
+#[test]
+fn call_thread_marker_parser_rejects_empty_media() {
+    let element: Element = "<call-thread xmlns='urn:waddle:call-thread:0' \
+          kind='muc' \
+          sid='session-123' \
+          media='' \
+          initiator='alice@example.test' \
+          started='2026-06-07T14:30:00Z'/>"
+        .parse()
+        .expect("fixture parses");
+
+    let err = parse_call_thread_anchor(&element).expect_err("empty media is invalid");
+    assert!(matches!(err, CallThreadParseError::InvalidMedia));
+}

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=1e3ef6d0668a";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=1e3ef6d0668a";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=1e3ef6d0668a";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=1078ea53fb01";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=1078ea53fb01";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=1078ea53fb01";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=1e3ef6d0668a";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=1078ea53fb01";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=1078ea53fb01";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=1078ea53fb01";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=1078ea53fb01";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=9ccb9b272957";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=9ccb9b272957";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=9ccb9b272957";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=1078ea53fb01";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=9ccb9b272957";


### PR DESCRIPTION
## Summary

Implements #916 by creating a typed call-thread anchor for the first active Muji call in a MUC room.

- Adds `urn:waddle:call-thread:0` typed marker codecs on server/client Rust surfaces.
- Emits one room-bare `groupchat` anchor per active room call session with XEP-0201 `<thread/>` and XEP-0334 `<store/>`.
- Archives the anchor in room MAM and prevents duplicate anchors when later participants advertise active Muji for the same call.
- Decodes the marker through Rust client, WASM, UniFFI, and chat timeline types, including MAM/archive reload paths.
- Renders a minimal inline call-thread anchor in chat and opens the associated thread.

## Plan Completed

1. Lock server behavior around Muji active presence, anchor archival, and one-anchor-per-session semantics.
2. Add typed Waddle call-thread marker builders/parsers without using official namespaces for custom semantics.
3. Thread the marker through Rust client, WASM, FFI, and generated Apple bindings.
4. Map decoded room anchors into `LiveRoomMessage` and `TimelineMessage`.
5. Render a compact inline anchor that opens the call thread.
6. Address review feedback around archived conversion, marker media invariants, dedicated protocol tests, UI positioning, bodyless archive filtering, receive timeouts, and presence-before-anchor ordering.
7. Run adversarial review and fix actionable issues.

## XEP Review

- XEP-0201: the conversation thread remains the standard `<thread/>`.
- XEP-0272 / XEP-0166 / XEP-0167: Muji active state is detected from typed content, and media comes from the RTP `media` field, not arbitrary content names.
- XEP-0313: the room-authored anchor is archived and verified through MAM.
- XEP-0334: anchor carries `<store/>`.
- Custom call metadata uses `urn:waddle:call-thread:0`, not an official XMPP namespace.

## Review Feedback Addressed

- Preserved `call_thread` through archived WASM and UniFFI DTO conversion so MAM reloads keep call anchors visible.
- Rejected empty-media marker construction on both server and client codec surfaces.
- Added `server/crates/waddle-xmpp/tests/xep_waddle_call_thread.rs` as the dedicated custom protocol suite.
- Clarified `active_call_started` as room-wide state.
- Dropped bodyless call-thread archive rows unless a valid body is present.
- Anchored the call-thread row pseudo-element with `relative`.
- Added timeout and ordering assertions to the WebSocket Muji/call-thread e2e helper.
- Left call-thread codec definitions in their current crate-local surfaces for this PR; introducing a shared protocol crate would be a broader dependency-boundary refactor than the review fix requires.

## Verification

- `bun test tests/call-thread-anchor.test.ts tests/bodyless-thread-only-not-content.test.ts`
- `bun run lint`
- `bunx astro check` (0 errors; existing hint in `src/lib/xmpp/discovery.ts`)
- `bash server/scripts/check-xmpp-client-ffi-bindings.sh`
- `cargo test -p waddle-xmpp --test xep_waddle_call_thread`
- `cargo test -p waddle-xmpp-client call_thread`
- `cargo test -p waddle-xmpp-client-wasm archived_to_js_preserves_call_thread_anchor_for_room_reload`
- `cargo test -p waddle-xmpp-client-ffi archived_to_ffi_preserves_call_thread_anchor_for_room_reload`
- `cargo test -p waddle-server --test calls_e2e_ws muji_presence_reflects_to_senders_sibling_resource -- --nocapture`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- Earlier full workspace verification on this PR: `cargo test --workspace`
- Adversarial review pass x2

## Notes

- `scripts/build-xcframework.sh` could not complete locally because the `x86_64-apple-darwin` Rust target is not installed. The UniFFI binding drift check passes after regenerating the Swift/header files with the repository bindgen path.
- In-app Browser visual smoke could not run because the `iab` browser backend was unavailable, and the local dev server port was not reachable from a separate shell in this environment.
- `docs/prd/004-call-chat.md` remains an untracked local file and is not part of this PR.
