### PR TITLE
feat(chat): ungate DM threading

### DIFF
--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -49,6 +49,7 @@ import CallActivityDock from "@/components/calls/CallActivityDock.vue";
 import CurrentCallPanel from "@/components/calls/CurrentCallPanel.vue";
 import { navigate, useRouteMatch, type AdminMatch, type AdminPanel } from "@/router";
 import { buildHomeDashboardProps } from "@/home/dashboard-props";
+import type { MessageThreadEntry } from "@/channels/threads";
 import { jidDomain } from "@/lib/xmpp/jid";
 import type { ChatAppController } from "@/shell/chat-app-controller";
 import type { DiscoveredExtensionRoute } from "@/lib/xmpp/extension-commands";
@@ -236,15 +237,27 @@ const homeDashboardProps = computed(() => buildHomeDashboardProps({
 }));
 
 const contentPaneClass = computed(() => {
-  if (ui.sidebarMode.value !== "channels") return "";
   if (activeRightPanel.value === "thread") {
     if (activeThreadStack.value.length === 0) return "";
     return activeThreadStack.value.length === 1
       ? "chat-content-pane--desktop-split"
       : "chat-content-pane--hidden";
   }
-  return activeRightPanel.value ? "chat-content-pane--desktop-split" : "";
+  if (ui.sidebarMode.value === "channels") {
+    return activeRightPanel.value ? "chat-content-pane--desktop-split" : "";
+  }
+  return "";
 });
+const activeDmThreadEntries = computed<MessageThreadEntry[]>(() => {
+  if (ui.sidebarMode.value !== "dms" || !activeDmPeer.value) return [];
+  return [...threads.index.value.values()].sort((left, right) => right.lastTs.localeCompare(left.lastTs));
+});
+const threadPanelIsDm = computed(() => ui.sidebarMode.value === "dms");
+const threadPanelConversationActive = computed(() =>
+  (ui.sidebarMode.value === "channels" || ui.sidebarMode.value === "dms") &&
+  activeRightPanel.value === "thread" &&
+  activeThreadStack.value.length >= 1
+);
 
 function onCommunityRsvp(
   event: { uid: string },
@@ -286,11 +299,13 @@ function onSelectChannelFromSidebar(id: string | null, roomJid?: string) {
   if (roomJid) selectChannelByRoomJid(roomJid);
 }
 
-async function lookupActiveChannelLinkPreview(body: string) {
+async function lookupActiveConversationLinkPreview(body: string) {
   const client = xmppClient.value;
-  const roomJid = activeChannelRoomJid.value;
-  if (!client || !roomJid) return null;
-  return client.lookupLinkPreview(body, roomJid);
+  const scope = ui.sidebarMode.value === "dms"
+    ? activeDmPeer.value?.peerJid
+    : activeChannelRoomJid.value;
+  if (!client || !scope) return null;
+  return client.lookupLinkPreview(body, scope);
 }
 
 function requireFeedPepClient() {
@@ -603,10 +618,12 @@ onUnmounted(() => {
           v-else
           :conversations="dmConversations.conversations.value"
           :active-peer-jid="dmConversations.activePeerJid.value"
+          :thread-entries="activeDmThreadEntries"
           :self-full-jid="selfFullJid"
           hide-current-call
           @answer-dm="answerDmFromActivity"
           @select-dm="selectDm"
+          @select-thread="openThread"
           @reconnect-dm="reconnectDmFromDock"
           @end-dm="endRecoveredDmFromActivity"
           @new-dm="ui.showNewDm.value = true"
@@ -828,7 +845,7 @@ onUnmounted(() => {
 
           <!-- Collapsed accordion bars: one per inactive right-side panel. -->
           <button
-            v-if="ui.sidebarMode.value === 'channels'
+            v-if="(ui.sidebarMode.value === 'channels' || ui.sidebarMode.value === 'dms')
               && activeRightPanel !== 'thread'
               && activeThreadStack.length >= 1"
             type="button"
@@ -841,7 +858,7 @@ onUnmounted(() => {
             </span>
           </button>
 
-          <template v-if="ui.sidebarMode.value === 'channels' && activeRightPanel === 'thread' && activeThreadStack.length >= 2">
+          <template v-if="threadPanelConversationActive && activeThreadStack.length >= 2">
             <!-- Channel / main-feed bar -->
             <button
               type="button"
@@ -850,7 +867,7 @@ onUnmounted(() => {
               @click="closeThreadPanel"
             >
               <span class="accordion-bar-label text-muted-foreground/80">
-                {{ waddles.currentChannel.value?.name ?? 'Channel' }}
+                {{ threadPanelIsDm ? (activeDmPeer?.peerUsername ?? 'Direct message') : (waddles.currentChannel.value?.name ?? 'Channel') }}
               </span>
             </button>
             <!-- Ancestor thread bars: levels older than the parent (skip last 2 = parent + active) -->
@@ -901,7 +918,7 @@ onUnmounted(() => {
           <!-- Parent thread pane: desktop-only context when depth >= 2.
                Shows the second-to-last thread in read-only mode (no composer). -->
           <div
-            v-if="ui.sidebarMode.value === 'channels' && activeRightPanel === 'thread' && activeThreadStack.length >= 2"
+            v-if="threadPanelConversationActive && activeThreadStack.length >= 2"
             class="chat-parent-thread-pane"
           >
             <ThreadPanel
@@ -914,20 +931,20 @@ onUnmounted(() => {
               :author-jid-by-nick="authorJidByNick"
               :room-hats="authorHatsByNick"
               :room-authority="authorAuthorityByNick"
-              :room-presence="messaging.roomPresence.value"
-              :room-last-seen="messaging.roomLastSeen.value"
+              :room-presence="threadPanelIsDm ? {} : messaging.roomPresence.value"
+              :room-last-seen="threadPanelIsDm ? {} : messaging.roomLastSeen.value"
               :giphy-api-key="giphyApiKey"
               :mention-candidates="mentionCandidates"
-              :slow-mode-cooldown="messaging.slowModeCooldown.value"
+              :slow-mode-cooldown="threadPanelIsDm ? 0 : messaging.slowModeCooldown.value"
               :is-sending="false"
-              :is-loading-older-replies="messaging.loadingOlderThreadIds.value.has(activeThreadStack[activeThreadStack.length - 2] ?? '')"
-              :has-older-replies="messaging.threadHasOlder.value[activeThreadStack[activeThreadStack.length - 2] ?? ''] ?? false"
+              :is-loading-older-replies="threadPanelIsDm ? false : messaging.loadingOlderThreadIds.value.has(activeThreadStack[activeThreadStack.length - 2] ?? '')"
+              :has-older-replies="threadPanelIsDm ? false : (messaging.threadHasOlder.value[activeThreadStack[activeThreadStack.length - 2] ?? ''] ?? false)"
               :upload-progress="{ uploading: false, progress: 0, filename: '' }"
-              :channel-name="waddles.currentChannel.value?.name ?? ''"
+              :channel-name="threadPanelIsDm ? (activeDmPeer?.peerUsername ?? '') : (waddles.currentChannel.value?.name ?? '')"
               :hide-composer="true"
               :reaction-mode="null"
-              :link-preview-lookup="lookupActiveChannelLinkPreview"
-              :link-preview-scope="activeChannelRoomJid"
+              :link-preview-lookup="lookupActiveConversationLinkPreview"
+              :link-preview-scope="threadPanelIsDm ? activeDmPeer?.peerJid ?? null : activeChannelRoomJid"
               @close="closeThreadPanel"
               @pop-to="popThreadTo"
               @push-thread="pushThread"
@@ -943,7 +960,7 @@ onUnmounted(() => {
           <!-- Active thread pane: shown when any thread is open.
                Full-width on mobile; shares space with parent context on desktop. -->
           <div
-            v-if="ui.sidebarMode.value === 'channels' && activeRightPanel === 'thread' && activeThreadStack.length >= 1"
+            v-if="threadPanelConversationActive"
             class="chat-active-thread-pane"
           >
             <ThreadPanel
@@ -956,20 +973,20 @@ onUnmounted(() => {
               :author-jid-by-nick="authorJidByNick"
               :room-hats="authorHatsByNick"
               :room-authority="authorAuthorityByNick"
-              :room-presence="messaging.roomPresence.value"
-              :room-last-seen="messaging.roomLastSeen.value"
+              :room-presence="threadPanelIsDm ? {} : messaging.roomPresence.value"
+              :room-last-seen="threadPanelIsDm ? {} : messaging.roomLastSeen.value"
               :giphy-api-key="giphyApiKey"
               :mention-candidates="mentionCandidates"
-              :slow-mode-cooldown="messaging.slowModeCooldown.value"
-              :is-sending="messaging.isSending.value"
-              :is-loading-older-replies="messaging.loadingOlderThreadIds.value.has(activeThreadStack[activeThreadStack.length - 1] ?? '')"
-              :has-older-replies="messaging.threadHasOlder.value[activeThreadStack[activeThreadStack.length - 1] ?? ''] ?? false"
-              :upload-progress="messaging.uploadProgress.value"
-              :channel-name="waddles.currentChannel.value?.name ?? ''"
+              :slow-mode-cooldown="threadPanelIsDm ? 0 : messaging.slowModeCooldown.value"
+              :is-sending="activeIsSending"
+              :is-loading-older-replies="threadPanelIsDm ? false : messaging.loadingOlderThreadIds.value.has(activeThreadStack[activeThreadStack.length - 1] ?? '')"
+              :has-older-replies="threadPanelIsDm ? false : (messaging.threadHasOlder.value[activeThreadStack[activeThreadStack.length - 1] ?? ''] ?? false)"
+              :upload-progress="activeUploadProgress"
+              :channel-name="threadPanelIsDm ? (activeDmPeer?.peerUsername ?? '') : (waddles.currentChannel.value?.name ?? '')"
               :reaction-mode="reactionModeTarget === 'thread' ? reactionModeState : null"
               :target-message-id="activeThreadTargetMessageId"
-              :link-preview-lookup="lookupActiveChannelLinkPreview"
-              :link-preview-scope="activeChannelRoomJid"
+              :link-preview-lookup="lookupActiveConversationLinkPreview"
+              :link-preview-scope="threadPanelIsDm ? activeDmPeer?.peerJid ?? null : activeChannelRoomJid"
               @close="closeThreadPanel"
               @pop-to="popThreadTo"
               @push-thread="pushThread"

--- a/chat/src/components/chat/DmPanel.vue
+++ b/chat/src/components/chat/DmPanel.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { useStore } from "@nanostores/vue";
-import { ArrowRight, MessageCircle, Phone, PhoneCall, PhoneIncoming, PhoneOff, PhoneOutgoing, Plus, Video } from "lucide-vue-next";
+import { ArrowRight, MessageCircle, MessagesSquare, Phone, PhoneCall, PhoneIncoming, PhoneOff, PhoneOutgoing, Plus, Video } from "lucide-vue-next";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import { formatTimelineStamp } from "@/channels/timeline";
+import type { MessageThreadEntry } from "@/channels/threads";
 import { $callState } from "@/lib/calls/call-store";
 import {
   canEndRecoveredDmCallActivity,
@@ -24,15 +25,18 @@ import type { DmConversation } from "@/lib/xmpp-client";
 const props = withDefaults(defineProps<{
   conversations: DmConversation[];
   activePeerJid: string | null;
+  threadEntries?: MessageThreadEntry[];
   selfFullJid?: string | null;
   hideCurrentCall?: boolean;
 }>(), {
+  threadEntries: () => [],
   hideCurrentCall: false,
 });
 
 const emit = defineEmits<{
   answerDm: [peerJid: string, remoteFullJid: string, sid: string, media: CallMedia];
   selectDm: [peerJid: string];
+  selectThread: [threadId: string];
   reconnectDm: [peerJid: string, media: CallMedia];
   endDm: [peerJid: string, sid?: string];
   newDm: [];
@@ -78,6 +82,7 @@ const visibleConversations = computed<DmConversation[]>(() => {
     .filter((conversation) => !activeCallPeers.has(normalizedPeerJid(conversation.peerJid)))
     .sort(compareDmConversations);
 });
+const visibleThreadEntries = computed(() => props.threadEntries.filter((entry) => entry.count > 0));
 
 function normalizedPeerJid(peerJid: string): string {
   return barePeerJid(peerJid).toLowerCase();
@@ -429,6 +434,20 @@ function conversationRowLabel(conversation: DmConversation): string {
   }
   return parts.join(", ");
 }
+
+function threadEntryTitle(entry: MessageThreadEntry): string {
+  const body = entry.root?.body?.trim();
+  return body || entry.threadId;
+}
+
+function threadEntryLabel(entry: MessageThreadEntry): string {
+  const parts = [
+    `Open thread ${threadEntryTitle(entry)}`,
+    `${entry.count} ${entry.count === 1 ? "reply" : "replies"}`,
+  ];
+  if (entry.lastTs) parts.push(formatTimelineStamp(entry.lastTs));
+  return parts.filter(Boolean).join(", ");
+}
 </script>
 
 <template>
@@ -470,6 +489,39 @@ function conversationRowLabel(conversation: DmConversation): string {
       </div>
 
       <div v-else class="chat-list-stack">
+        <section
+          v-if="visibleThreadEntries.length > 0"
+          class="grid gap-1"
+          aria-label="Direct message threads"
+        >
+          <div class="type-section-label flex items-center gap-1.5 px-2 pt-2 pb-1 text-sidebar-muted">
+            <MessagesSquare class="h-3 w-3 text-primary/70" aria-hidden="true" />
+            <span class="flex-1 truncate">Threads</span>
+            <span
+              class="type-count-badge inline-flex min-w-[18px] h-[18px] px-1 items-center justify-center rounded-full bg-primary/15 text-primary ring-1 ring-primary/25"
+              aria-hidden="true"
+            >
+              {{ visibleThreadEntries.length }}
+            </span>
+          </div>
+          <button
+            v-for="entry in visibleThreadEntries"
+            :key="entry.threadId"
+            class="chat-list-row w-full min-h-12 flex items-center gap-3 px-3 py-2 text-left group text-sidebar-muted hover:bg-sidebar-accent/50 hover:text-sidebar-foreground"
+            type="button"
+            :aria-label="threadEntryLabel(entry)"
+            @click="emit('selectThread', entry.threadId)"
+          >
+            <MessagesSquare class="h-4 w-4 shrink-0 text-primary/70" aria-hidden="true" />
+            <span class="min-w-0 flex-1">
+              <span class="type-control block truncate text-sidebar-foreground">{{ threadEntryTitle(entry) }}</span>
+              <span class="type-caption block truncate text-sidebar-muted">
+                {{ entry.count }} {{ entry.count === 1 ? 'reply' : 'replies' }}<template v-if="entry.lastTs"> · {{ formatTimelineStamp(entry.lastTs) }}</template>
+              </span>
+            </span>
+          </button>
+        </section>
+
         <section
           v-if="activeCallRows.length > 0"
           class="grid gap-1"

--- a/chat/src/dms/chat-send.ts
+++ b/chat/src/dms/chat-send.ts
@@ -36,6 +36,15 @@ type UseChatSendDeps = {
   ) => void;
 };
 
+function threadRefFromMessage(
+  message: TimelineMessage | null | undefined,
+): { id: string; parent?: string } | undefined {
+  if (!message?.threadId) return undefined;
+  return message.parentThreadId
+    ? { id: message.threadId, parent: message.parentThreadId }
+    : { id: message.threadId };
+}
+
 export function useChatSend(deps: UseChatSendDeps) {
   const {
     session,
@@ -66,6 +75,7 @@ export function useChatSend(deps: UseChatSendDeps) {
     files?: Array<File | Blob>,
     replyTo?: { id: string; author: string; body?: string },
     linkPreview?: ComposerLinkPreviewSendPayload,
+    threadOverride?: { threadId: string; parentThreadId?: string },
   ) {
     const bodyText = explicitBody ?? draft.value;
     const fromComposer = markup !== undefined;
@@ -108,7 +118,7 @@ export function useChatSend(deps: UseChatSendDeps) {
             ...(replyTo.body ? { body: replyTo.body } : {}),
           }
         : undefined;
-      const threadId = parent ? (parent.threadId ?? parent.id) : undefined;
+      const threadId = threadOverride?.threadId ?? (parent ? (parent.threadId ?? parent.id) : undefined);
       const freshLinkPreview = composerLinkPreviewPayloadIsFresh(linkPreview) ? linkPreview : undefined;
       const linkPreviews = freshLinkPreview ? [freshLinkPreview.preview] : [];
       const result = await client.sendDirectMessage(peerJid, bodyText, {
@@ -119,6 +129,7 @@ export function useChatSend(deps: UseChatSendDeps) {
         ...(freshLinkPreview ? { linkPreviewExpiresAt: freshLinkPreview.expiresAt } : {}),
         ...(wireReplyTo ? { replyTo: wireReplyTo } : {}),
         ...(threadId ? { threadId } : {}),
+        ...(threadOverride?.parentThreadId ? { parentThreadId: threadOverride.parentThreadId } : {}),
       });
       const msgId = result?.id ?? null;
       const isStillActive = xmppClient.value === client && activePeerJid.value === peerJid;
@@ -146,7 +157,10 @@ export function useChatSend(deps: UseChatSendDeps) {
               ...(replyTo.body ? { preview: replyTo.body } : {}),
             };
           }
-          if (threadId) optimistic.threadId = threadId;
+          if (threadId) {
+            optimistic.threadId = threadId;
+            if (threadOverride?.parentThreadId) optimistic.parentThreadId = threadOverride.parentThreadId;
+          }
           if (attachments && attachments.length > 0) {
             optimistic.sharedFiles = attachments.map((a) => ({
               url: a.url,
@@ -203,6 +217,7 @@ export function useChatSend(deps: UseChatSendDeps) {
           linkPreviewToken: freshLinkPreview.token,
           linkPreviewExpiresAt: freshLinkPreview.expiresAt,
         } : undefined,
+        threadRefFromMessage(message),
       );
     } catch (e) {
       actionError.value = normalizeError(e);

--- a/chat/src/dms/chat-send.ts
+++ b/chat/src/dms/chat-send.ts
@@ -13,6 +13,7 @@ import {
 } from "@/lib/chat-ui";
 import { findMessageById } from "@/lib/message-ids";
 import { applyDeliveryEventById } from "@/lib/timeline-state";
+import { dmThreadRefFromMessage, dmThreadRefFromOverride, type DmThreadRef } from "@/dms/threading";
 
 // Derived from the wasm client's return shape; see useMucSend for rationale.
 type ChatSendResult = Awaited<ReturnType<BrowserXmppClient["sendDirectMessage"]>>;
@@ -35,15 +36,6 @@ type UseChatSendDeps = {
     isStillActive: boolean,
   ) => void;
 };
-
-function threadRefFromMessage(
-  message: TimelineMessage | null | undefined,
-): { id: string; parent?: string } | undefined {
-  if (!message?.threadId) return undefined;
-  return message.parentThreadId
-    ? { id: message.threadId, parent: message.parentThreadId }
-    : { id: message.threadId };
-}
 
 export function useChatSend(deps: UseChatSendDeps) {
   const {
@@ -118,7 +110,9 @@ export function useChatSend(deps: UseChatSendDeps) {
             ...(replyTo.body ? { body: replyTo.body } : {}),
           }
         : undefined;
-      const threadId = threadOverride?.threadId ?? (parent ? (parent.threadId ?? parent.id) : undefined);
+      const overrideThread = dmThreadRefFromOverride(threadOverride);
+      const fallbackThreadId = parent ? (parent.threadId?.trim() || parent.id.trim()) : undefined;
+      const thread: DmThreadRef | undefined = overrideThread ?? (fallbackThreadId ? { id: fallbackThreadId } : undefined);
       const freshLinkPreview = composerLinkPreviewPayloadIsFresh(linkPreview) ? linkPreview : undefined;
       const linkPreviews = freshLinkPreview ? [freshLinkPreview.preview] : [];
       const result = await client.sendDirectMessage(peerJid, bodyText, {
@@ -128,8 +122,8 @@ export function useChatSend(deps: UseChatSendDeps) {
         ...(freshLinkPreview ? { linkPreviewToken: freshLinkPreview.token } : {}),
         ...(freshLinkPreview ? { linkPreviewExpiresAt: freshLinkPreview.expiresAt } : {}),
         ...(wireReplyTo ? { replyTo: wireReplyTo } : {}),
-        ...(threadId ? { threadId } : {}),
-        ...(threadOverride?.parentThreadId ? { parentThreadId: threadOverride.parentThreadId } : {}),
+        ...(thread ? { threadId: thread.id } : {}),
+        ...(thread?.parent ? { parentThreadId: thread.parent } : {}),
       });
       const msgId = result?.id ?? null;
       const isStillActive = xmppClient.value === client && activePeerJid.value === peerJid;
@@ -157,9 +151,9 @@ export function useChatSend(deps: UseChatSendDeps) {
               ...(replyTo.body ? { preview: replyTo.body } : {}),
             };
           }
-          if (threadId) {
-            optimistic.threadId = threadId;
-            if (threadOverride?.parentThreadId) optimistic.parentThreadId = threadOverride.parentThreadId;
+          if (thread) {
+            optimistic.threadId = thread.id;
+            if (thread.parent) optimistic.parentThreadId = thread.parent;
           }
           if (attachments && attachments.length > 0) {
             optimistic.sharedFiles = attachments.map((a) => ({
@@ -217,7 +211,7 @@ export function useChatSend(deps: UseChatSendDeps) {
           linkPreviewToken: freshLinkPreview.token,
           linkPreviewExpiresAt: freshLinkPreview.expiresAt,
         } : undefined,
-        threadRefFromMessage(message),
+        dmThreadRefFromMessage(message),
       );
     } catch (e) {
       actionError.value = normalizeError(e);

--- a/chat/src/dms/chat-states.ts
+++ b/chat/src/dms/chat-states.ts
@@ -63,23 +63,19 @@ export function useDmChatStates(deps: UseDmChatStatesDeps) {
     onScopeDispose(() => clearTypingState());
   }
 
-  // DMs have no thread surface — the optional `thread` arg keeps a uniform
-  // signature with the channel-side notifyComposing so the shell controller
-  // can call `activeTarget.value.notifyComposing(thread)` against either
-  // target without branching on sidebar mode.
-  function notifyComposing(_thread?: { id: string; parent?: string }) {
+  function notifyComposing(thread?: { id: string; parent?: string }) {
     const client = xmppClient.value;
     const peerJid = activePeerJid.value;
     if (!client || !peerJid) return;
     if (lastChatState !== "composing") {
       lastChatState = "composing";
-      void client.sendDmChatState(peerJid, "composing").catch(() => undefined);
+      void client.sendDmChatState(peerJid, "composing", thread).catch(() => undefined);
     }
     if (composingTimeout) clearTimeout(composingTimeout);
     composingTimeout = setTimeout(() => {
       if (xmppClient.value !== client || activePeerJid.value !== peerJid) return;
       lastChatState = "paused";
-      void client.sendDmChatState(peerJid, "paused").catch(() => undefined);
+      void client.sendDmChatState(peerJid, "paused", thread).catch(() => undefined);
     }, COMPOSING_PAUSE_MS);
   }
 

--- a/chat/src/dms/message-actions.ts
+++ b/chat/src/dms/message-actions.ts
@@ -4,6 +4,7 @@ import type { BrowserXmppClient } from "@/lib/xmpp-client";
 import type { ExtensionAnnotationAction, TimelineMessage } from "@/lib/chat-ui";
 import type { ExtensionCommandResult } from "@/lib/xmpp/extension-commands";
 import { findMessageById } from "@/lib/message-ids";
+import { dmThreadRefFromMessage } from "@/dms/threading";
 
 // Outbound message-action handlers for the DM side: reactions (XEP-0444),
 // retractions (XEP-0424), and extension-annotation actions. Mirrors the
@@ -22,15 +23,6 @@ type UseDmMessageActionsDeps = {
   normalizeError: (e: unknown) => string;
   applyReaction: (messageId: string, nick: string, emojis: string[]) => void;
 };
-
-function threadRefFromMessage(
-  message: TimelineMessage | null | undefined,
-): { id: string; parent?: string } | undefined {
-  if (!message?.threadId) return undefined;
-  return message.parentThreadId
-    ? { id: message.threadId, parent: message.parentThreadId }
-    : { id: message.threadId };
-}
 
 export function useDmMessageActions(deps: UseDmMessageActionsDeps) {
   const {
@@ -68,7 +60,7 @@ export function useDmMessageActions(deps: UseDmMessageActionsDeps) {
     applyReaction(targetId, myNick, nextEmojis);
 
     try {
-      await xmppClient.value.sendDmReaction(activePeerJid.value, targetId, nextEmojis, threadRefFromMessage(msg));
+      await xmppClient.value.sendDmReaction(activePeerJid.value, targetId, nextEmojis, dmThreadRefFromMessage(msg));
     } catch (e) {
       applyReaction(targetId, myNick, previousEmojis);
       actionError.value = normalizeError(e);
@@ -89,7 +81,7 @@ export function useDmMessageActions(deps: UseDmMessageActionsDeps) {
     const targetId = target?.replyableId ?? target?.id ?? messageId;
     clearActionError();
     try {
-      await xmppClient.value.sendDmRetraction(activePeerJid.value, targetId, threadRefFromMessage(target));
+      await xmppClient.value.sendDmRetraction(activePeerJid.value, targetId, dmThreadRefFromMessage(target));
     } catch (e) {
       actionError.value = normalizeError(e);
     }

--- a/chat/src/dms/message-actions.ts
+++ b/chat/src/dms/message-actions.ts
@@ -23,6 +23,15 @@ type UseDmMessageActionsDeps = {
   applyReaction: (messageId: string, nick: string, emojis: string[]) => void;
 };
 
+function threadRefFromMessage(
+  message: TimelineMessage | null | undefined,
+): { id: string; parent?: string } | undefined {
+  if (!message?.threadId) return undefined;
+  return message.parentThreadId
+    ? { id: message.threadId, parent: message.parentThreadId }
+    : { id: message.threadId };
+}
+
 export function useDmMessageActions(deps: UseDmMessageActionsDeps) {
   const {
     session,
@@ -59,7 +68,7 @@ export function useDmMessageActions(deps: UseDmMessageActionsDeps) {
     applyReaction(targetId, myNick, nextEmojis);
 
     try {
-      await xmppClient.value.sendDmReaction(activePeerJid.value, targetId, nextEmojis);
+      await xmppClient.value.sendDmReaction(activePeerJid.value, targetId, nextEmojis, threadRefFromMessage(msg));
     } catch (e) {
       applyReaction(targetId, myNick, previousEmojis);
       actionError.value = normalizeError(e);
@@ -80,7 +89,7 @@ export function useDmMessageActions(deps: UseDmMessageActionsDeps) {
     const targetId = target?.replyableId ?? target?.id ?? messageId;
     clearActionError();
     try {
-      await xmppClient.value.sendDmRetraction(activePeerJid.value, targetId);
+      await xmppClient.value.sendDmRetraction(activePeerJid.value, targetId, threadRefFromMessage(target));
     } catch (e) {
       actionError.value = normalizeError(e);
     }

--- a/chat/src/dms/read-markers.ts
+++ b/chat/src/dms/read-markers.ts
@@ -17,6 +17,15 @@ type UseDmReadMarkersDeps = {
   messages: Ref<TimelineMessage[]>;
 };
 
+function threadRefFromMessage(
+  message: TimelineMessage | null | undefined,
+): { id: string; parent?: string } | undefined {
+  if (!message?.threadId) return undefined;
+  return message.parentThreadId
+    ? { id: message.threadId, parent: message.parentThreadId }
+    : { id: message.threadId };
+}
+
 export function useDmReadMarkers(deps: UseDmReadMarkersDeps) {
   const { xmppClient, activePeerJid, messages } = deps;
 
@@ -34,7 +43,7 @@ export function useDmReadMarkers(deps: UseDmReadMarkersDeps) {
     const peerJid = activePeerJid.value;
     if (sendDisplayedMarkers.value && target?.displayedMarkerRequested) {
       void client
-        .sendDmDisplayed(peerJid, targetId)
+        .sendDmDisplayed(peerJid, targetId, threadRefFromMessage(target))
         .catch(() => undefined);
     }
     // XEP-0490 §3 publish for the DM. The chat id is the peer bare

--- a/chat/src/dms/read-markers.ts
+++ b/chat/src/dms/read-markers.ts
@@ -6,6 +6,7 @@ import { findMessageById } from "@/lib/message-ids";
 import { dmKey, setLastSeen } from "@/lib/last-seen-store";
 import { latestRemoteMessageIdFor } from "@/lib/timeline-state";
 import { useReadReceiptPreference } from "@/preferences/read-receipts";
+import { dmThreadRefFromMessage } from "@/dms/threading";
 
 // XEP-0333 chat-marker outbound state for the DM side. Mirrors
 // useChannelReadMarkers; uses `dmKey(barePeerJid(peerJid))` as the
@@ -16,15 +17,6 @@ type UseDmReadMarkersDeps = {
   activePeerJid: Ref<string | null>;
   messages: Ref<TimelineMessage[]>;
 };
-
-function threadRefFromMessage(
-  message: TimelineMessage | null | undefined,
-): { id: string; parent?: string } | undefined {
-  if (!message?.threadId) return undefined;
-  return message.parentThreadId
-    ? { id: message.threadId, parent: message.parentThreadId }
-    : { id: message.threadId };
-}
 
 export function useDmReadMarkers(deps: UseDmReadMarkersDeps) {
   const { xmppClient, activePeerJid, messages } = deps;
@@ -43,7 +35,7 @@ export function useDmReadMarkers(deps: UseDmReadMarkersDeps) {
     const peerJid = activePeerJid.value;
     if (sendDisplayedMarkers.value && target?.displayedMarkerRequested) {
       void client
-        .sendDmDisplayed(peerJid, targetId, threadRefFromMessage(target))
+        .sendDmDisplayed(peerJid, targetId, dmThreadRefFromMessage(target))
         .catch(() => undefined);
     }
     // XEP-0490 §3 publish for the DM. The chat id is the peer bare

--- a/chat/src/dms/threading.ts
+++ b/chat/src/dms/threading.ts
@@ -1,0 +1,30 @@
+import type { TimelineMessage } from "@/lib/chat-ui";
+
+export type DmThreadRef = {
+  id: string;
+  parent?: string;
+};
+
+function nonBlank(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function dmThreadRefFromMessage(
+  message: TimelineMessage | null | undefined,
+): DmThreadRef | undefined {
+  const id = nonBlank(message?.threadId);
+  if (!id) return undefined;
+  const parent = nonBlank(message?.parentThreadId);
+  return parent ? { id, parent } : { id };
+}
+
+export function dmThreadRefFromOverride(
+  threadOverride: { threadId: string; parentThreadId?: string } | undefined,
+): DmThreadRef | undefined {
+  const id = nonBlank(threadOverride?.threadId);
+  if (!id) return undefined;
+  const parent = nonBlank(threadOverride?.parentThreadId);
+  return parent ? { id, parent } : { id };
+}
+

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -1898,11 +1898,17 @@ export class BrowserXmppClient {
     if (thread?.parent) opts.parentThreadId = thread.parent;
     return await this.compatSendCorrection(xmpp, roomJid, "groupchat", body, replacesId, opts);
   }
-  async sendDmChatState(peerJid: string, state: ChatStateType): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await this.compatSendChatState(xmpp, barePeerJid(peerJid), "chat", state); }
-  async sendDmDisplayed(peerJid: string, messageId: string): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await this.compatSendDisplayed(xmpp, barePeerJid(peerJid), "chat", messageId); }
-  async sendDmRetraction(peerJid: string, messageId: string): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await this.compatSendRetraction(xmpp, barePeerJid(peerJid), "chat", messageId); }
-  async sendDmCorrection(peerJid: string, body: string, replacesId: string, markup?: SendDirectMessageOptions["markup"], references?: SendDirectMessageOptions["references"], preview?: Pick<SendDirectMessageOptions, "linkPreviewToken" | "linkPreviewExpiresAt">): Promise<string | null> { const xmpp = await this.requireConnectedXmpp(); return await this.compatSendCorrection(xmpp, barePeerJid(peerJid), "chat", body, replacesId, { markup, references, ...preview }); }
-  async sendDmReaction(peerJid: string, messageId: string, emojis: string[]): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await this.compatSendReaction(xmpp, barePeerJid(peerJid), "chat", messageId, emojis); }
+  async sendDmChatState(peerJid: string, state: ChatStateType, thread?: { id: string; parent?: string }): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await this.compatSendChatState(xmpp, barePeerJid(peerJid), "chat", state, thread); }
+  async sendDmDisplayed(peerJid: string, messageId: string, thread?: { id: string; parent?: string }): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await this.compatSendDisplayed(xmpp, barePeerJid(peerJid), "chat", messageId, thread); }
+  async sendDmRetraction(peerJid: string, messageId: string, thread?: { id: string; parent?: string }): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await this.compatSendRetraction(xmpp, barePeerJid(peerJid), "chat", messageId, thread); }
+  async sendDmCorrection(peerJid: string, body: string, replacesId: string, markup?: SendDirectMessageOptions["markup"], references?: SendDirectMessageOptions["references"], preview?: Pick<SendDirectMessageOptions, "linkPreviewToken" | "linkPreviewExpiresAt">, thread?: { id: string; parent?: string }): Promise<string | null> {
+    const xmpp = await this.requireConnectedXmpp();
+    const opts: SendDirectMessageOptions = { markup, references, ...preview };
+    if (thread?.id) opts.threadId = thread.id;
+    if (thread?.parent) opts.parentThreadId = thread.parent;
+    return await this.compatSendCorrection(xmpp, barePeerJid(peerJid), "chat", body, replacesId, opts);
+  }
+  async sendDmReaction(peerJid: string, messageId: string, emojis: string[], thread?: { id: string; parent?: string }): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await this.compatSendReaction(xmpp, barePeerJid(peerJid), "chat", messageId, emojis, thread); }
 
   /**
    * XEP-0490 §3 multi-device "read up to here" publish. `chatId` is

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -1614,6 +1614,7 @@ export function useChatAppController(giphyApiKey: string) {
         const domain = session.value ? jidDomain(session.value.jid) : "";
         if (!domain) return;
         await handleOpenDm(`${username}@${domain}`);
+        if (requestId !== routeRequestId) return;
       }
       activeThreadTargetMessageId.value = null;
       activeThreadStack.value = match.search.thread;

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -228,8 +228,7 @@ export function useChatAppController(giphyApiKey: string) {
   );
 
   // Thread panel state - stack = breadcrumb trail into nested sub-threads.
-  // Empty stack = panel closed. Only meaningful for channel messages since DMs
-  // don't use XEP-0201 threads yet.
+  // Empty stack = panel closed. Channels and DMs both use XEP-0201 threads.
   const activeThreadStack = ref<string[]>([]);
   const activeThreadTargetMessageId = ref<string | null>(null);
   const threads = useMessageThreads(activeMessages);
@@ -249,8 +248,9 @@ export function useChatAppController(giphyApiKey: string) {
   }
 
   function isRightPanelAvailable(panel: ActiveRightPanel): boolean {
-    if (ui.sidebarMode.value !== "channels" || ui.activePage.value !== "chat") return false;
+    if (ui.activePage.value !== "chat") return false;
     if (panel === "thread") return activeThreadStack.value.length > 0;
+    if (ui.sidebarMode.value !== "channels") return false;
     if (panel === "pinned") return ui.showPinnedPanel.value && !!waddles.currentChannel.value && !!activeChannelRoomJid.value;
     return !!activeExtensionRouteKey.value && !!waddles.currentChannel.value;
   }
@@ -287,7 +287,6 @@ export function useChatAppController(giphyApiKey: string) {
   );
 
   const activeThreadReactionMessages = computed<TimelineMessage[]>(() => {
-    if (ui.sidebarMode.value !== "channels") return [];
     const threadId = activeThreadStack.value[activeThreadStack.value.length - 1];
     if (!threadId) return [];
     const entry = threads.resolveEntry(threadId);
@@ -937,6 +936,10 @@ export function useChatAppController(giphyApiKey: string) {
     threadOverride: { threadId: string; parentThreadId?: string },
     linkPreview?: ComposerLinkPreviewSendPayload,
   ) {
+    if (ui.sidebarMode.value === "dms") {
+      await dmMessaging.sendMessage(body, markup, references, files, replyTo, linkPreview, threadOverride);
+      return;
+    }
     await messaging.sendMessage(body, markup, references, files, replyTo, threadOverride, linkPreview);
   }
 
@@ -959,11 +962,11 @@ export function useChatAppController(giphyApiKey: string) {
       activeThreadStack.value.length > 0 &&
       activeThreadStack.value[activeThreadStack.value.length - 1] === threadId
     ) {
-      if (targetMessageId) void messaging.backfillThread(threadId);
+      if (targetMessageId && ui.sidebarMode.value === "channels") void messaging.backfillThread(threadId);
       return;
     }
     activeThreadStack.value = [threadId];
-    void messaging.backfillThread(threadId);
+    if (ui.sidebarMode.value === "channels") void messaging.backfillThread(threadId);
   }
 
   function roomJidForChannelId(channelId: string): string | null {
@@ -996,7 +999,7 @@ export function useChatAppController(giphyApiKey: string) {
       return;
     }
     activeThreadStack.value = [...activeThreadStack.value, threadId];
-    void messaging.backfillThread(threadId);
+    if (ui.sidebarMode.value === "channels") void messaging.backfillThread(threadId);
   }
 
   function popThreadTo(index: number) {
@@ -1135,6 +1138,7 @@ export function useChatAppController(giphyApiKey: string) {
   }
 
   function loadOlderThreadMessages(threadId: string) {
+    if (ui.sidebarMode.value === "dms") return;
     void messaging.loadOlderThreadMessages(threadId);
   }
 
@@ -1250,7 +1254,7 @@ export function useChatAppController(giphyApiKey: string) {
         navigate({
           id: "dm",
           params: { username: activeDmPeer.value.peerUsername },
-          search: { thread: [] },
+          search: { thread: activeThreadStack.value },
         });
       } else {
         navigate({ id: "dmList" });
@@ -1611,6 +1615,9 @@ export function useChatAppController(giphyApiKey: string) {
         if (!domain) return;
         await handleOpenDm(`${username}@${domain}`);
       }
+      activeThreadTargetMessageId.value = null;
+      activeThreadStack.value = match.search.thread;
+      activeRightPanel.value = match.search.thread.length > 0 ? "thread" : null;
       return;
     }
 

--- a/chat/tests/chat-send.test.ts
+++ b/chat/tests/chat-send.test.ts
@@ -223,6 +223,29 @@ describe("useChatSend.editMessage", () => {
     expect(call[2]).toBe("original-server-id");
   });
 
+  test("DM corrections echo the target message's XEP-0201 thread", async () => {
+    const sendDmCorrection = mock(async () => undefined);
+    const client = makeClient({ sendDmCorrection } as Partial<BrowserXmppClient>);
+    const h = harness({ client });
+    h.messages.value = [
+      {
+        id: "dm-msg-1",
+        correctionTargetId: "original-server-id",
+        threadId: "dm-child-thread",
+        parentThreadId: "dm-root-thread",
+        body: "old text",
+        nick: "alice",
+        timestamp: 0,
+        isSelf: true,
+      } as TimelineMessage,
+    ];
+
+    await h.send.editMessage("dm-msg-1", "new text");
+
+    const call = (sendDmCorrection as unknown as ReturnType<typeof mock>).mock.calls[0]!;
+    expect(call[6]).toEqual({ id: "dm-child-thread", parent: "dm-root-thread" });
+  });
+
   test("passes a fresh composer preview token on corrections", async () => {
     const sendDmCorrection = mock(async () => undefined);
     const client = makeClient({ sendDmCorrection } as Partial<BrowserXmppClient>);

--- a/chat/tests/chat-send.test.ts
+++ b/chat/tests/chat-send.test.ts
@@ -140,6 +140,28 @@ describe("useChatSend.sendMessage — happy path", () => {
     expect(call[2].linkPreviewExpiresAt).toBeUndefined();
     expect(h.messages.value[0]?.linkPreviews).toBeUndefined();
   });
+
+  test("ignores parentThreadId when a thread override has no usable threadId", async () => {
+    const sendDirectMessage = mock(async () => ({ id: "dm-thread", state: "sending" }));
+    const client = makeClient({ sendDirectMessage } as Partial<BrowserXmppClient>);
+    const h = harness({ client, draft: "nested reply" });
+
+    await h.send.sendMessage(
+      undefined,
+      [],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { threadId: "   ", parentThreadId: "dm-root-thread" },
+    );
+
+    const call = (sendDirectMessage as unknown as ReturnType<typeof mock>).mock.calls[0]!;
+    expect(call[2].threadId).toBeUndefined();
+    expect(call[2].parentThreadId).toBeUndefined();
+    expect(h.messages.value[0]?.threadId).toBeUndefined();
+    expect(h.messages.value[0]?.parentThreadId).toBeUndefined();
+  });
 });
 
 describe("useChatSend.sendMessage — guards", () => {

--- a/chat/tests/chat-states.test.ts
+++ b/chat/tests/chat-states.test.ts
@@ -132,6 +132,17 @@ describe("useDmChatStates", () => {
     expect(sendDmChatState.mock.calls[0]![1]).toBe("composing");
   });
 
+  test("notifyComposing echoes XEP-0201 thread metadata for threaded DMs", () => {
+    const sendDmChatState = mock(async () => undefined);
+    const states = withScope(() => useDmChatStates({
+      xmppClient: ref<BrowserXmppClient | null>(makeDmClient(sendDmChatState)),
+      activePeerJid: ref("bob@example.com"),
+    }));
+    states.notifyComposing({ id: "dm-child-thread", parent: "dm-root-thread" });
+    expect(sendDmChatState).toHaveBeenCalledTimes(1);
+    expect(sendDmChatState.mock.calls[0]![2]).toEqual({ id: "dm-child-thread", parent: "dm-root-thread" });
+  });
+
   test("addTypingUser + clearTypingState surfaces and clears typingUsers", () => {
     const states = withScope(() => useDmChatStates({
       xmppClient: ref<BrowserXmppClient | null>(makeDmClient()),

--- a/chat/tests/dm-message-actions.test.ts
+++ b/chat/tests/dm-message-actions.test.ts
@@ -99,6 +99,24 @@ describe("toggleReaction target-id precedence", () => {
     expect(sendDmReaction).toHaveBeenCalledTimes(1);
     expect(sendDmReaction.mock.calls[0]![1]).toBe("server-stable-id");
   });
+
+  test("echoes XEP-0201 thread metadata for threaded DM reactions", async () => {
+    const h = harness();
+    h.messages.value = [
+      {
+        id: "client-id",
+        replyableId: "server-stable-id",
+        threadId: "dm-child-thread",
+        parentThreadId: "dm-root-thread",
+        reactions: {},
+        body: "", nick: "", timestamp: 0,
+      } as TimelineMessage,
+    ];
+    await h.actions.toggleReaction("client-id", "👀");
+    const sendDmReaction = h.xmppClient.value!.sendDmReaction as unknown as ReturnType<typeof mock>;
+    expect(sendDmReaction).toHaveBeenCalledTimes(1);
+    expect(sendDmReaction.mock.calls[0]![3]).toEqual({ id: "dm-child-thread", parent: "dm-root-thread" });
+  });
 });
 
 describe("retractMessage (XEP-0424)", () => {
@@ -118,6 +136,23 @@ describe("retractMessage (XEP-0424)", () => {
     const sendDmRetraction = h.xmppClient.value!.sendDmRetraction as unknown as ReturnType<typeof mock>;
     expect(sendDmRetraction).toHaveBeenCalledTimes(1);
     expect(sendDmRetraction.mock.calls[0]![1]).toBe("wire-origin-id");
+  });
+
+  test("echoes XEP-0201 thread metadata for threaded DM retractions", async () => {
+    const h = harness();
+    h.messages.value = [
+      {
+        id: "mam-archive-id",
+        replyableId: "wire-origin-id",
+        threadId: "dm-child-thread",
+        parentThreadId: "dm-root-thread",
+        body: "", nick: "", timestamp: 0,
+      } as TimelineMessage,
+    ];
+    await h.actions.retractMessage("mam-archive-id");
+    const sendDmRetraction = h.xmppClient.value!.sendDmRetraction as unknown as ReturnType<typeof mock>;
+    expect(sendDmRetraction).toHaveBeenCalledTimes(1);
+    expect(sendDmRetraction.mock.calls[0]![2]).toEqual({ id: "dm-child-thread", parent: "dm-root-thread" });
   });
 
   test("falls back to message id when replyableId is absent (DMs don't require room stanza-id)", async () => {

--- a/chat/tests/dm-threading-ui.test.ts
+++ b/chat/tests/dm-threading-ui.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+describe("DM threading UI contract", () => {
+  test("exposes DM thread list and thread panel affordances", () => {
+    const readyShell = readFileSync(new URL("../src/components/chat/ChatReadyShell.vue", import.meta.url), "utf8");
+    const dmPanel = readFileSync(new URL("../src/components/chat/DmPanel.vue", import.meta.url), "utf8");
+    const controller = readFileSync(new URL("../src/shell/chat-app-controller.ts", import.meta.url), "utf8");
+
+    expect(readyShell).toContain(":thread-entries=\"activeDmThreadEntries\"");
+    expect(readyShell).toContain("@select-thread=\"openThread\"");
+    expect(readyShell).toContain("threadPanelConversationActive");
+    expect(readyShell).toContain("threadPanelIsDm");
+    expect(controller).toContain('if (panel === "thread") return activeThreadStack.value.length > 0');
+    expect(controller).not.toContain('if (ui.sidebarMode.value !== "channels" || ui.activePage.value !== "chat") return false;');
+    expect(dmPanel).toContain("threadEntries?: MessageThreadEntry[]");
+    expect(dmPanel).toContain("selectThread: [threadId: string]");
+  });
+});

--- a/chat/tests/dm-threading-ui.test.ts
+++ b/chat/tests/dm-threading-ui.test.ts
@@ -1,19 +1,197 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { createSSRApp, h } from "vue";
+import { parse, compileScript } from "vue/compiler-sfc";
+import { renderToString } from "vue/server-renderer";
+import ts from "typescript";
+import type { MessageThreadEntry } from "../src/channels/threads";
+import type { TimelineMessage } from "../src/lib/chat-ui";
+import type { DmConversation } from "../src/lib/xmpp-client";
 
 describe("DM threading UI contract", () => {
-  test("exposes DM thread list and thread panel affordances", () => {
-    const readyShell = readFileSync(new URL("../src/components/chat/ChatReadyShell.vue", import.meta.url), "utf8");
-    const dmPanel = readFileSync(new URL("../src/components/chat/DmPanel.vue", import.meta.url), "utf8");
-    const controller = readFileSync(new URL("../src/shell/chat-app-controller.ts", import.meta.url), "utf8");
+  test("renders DM thread entries and selects them from the panel model", async () => {
+    const thread = threadEntry("dm-thread-1", "Launch follow-up", 2);
+    const html = await renderVueComponent("../src/components/chat/DmPanel.vue", {
+      conversations: [conversation()],
+      activePeerJid: "alice@example.com",
+      threadEntries: [thread, threadEntry("empty-thread", "Empty", 0)],
+    });
 
-    expect(readyShell).toContain(":thread-entries=\"activeDmThreadEntries\"");
-    expect(readyShell).toContain("@select-thread=\"openThread\"");
-    expect(readyShell).toContain("threadPanelConversationActive");
-    expect(readyShell).toContain("threadPanelIsDm");
-    expect(controller).toContain('if (panel === "thread") return activeThreadStack.value.length > 0');
-    expect(controller).not.toContain('if (ui.sidebarMode.value !== "channels" || ui.activePage.value !== "chat") return false;');
-    expect(dmPanel).toContain("threadEntries?: MessageThreadEntry[]");
-    expect(dmPanel).toContain("selectThread: [threadId: string]");
+    expect(html).toContain("Direct message threads");
+    expect(html).toContain("Launch follow-up");
+    expect(html).toContain("2 replies");
+    expect(html).not.toContain("Open thread Empty");
+
+    const emitted: unknown[][] = [];
+    const bindings = await setupVueComponent("../src/components/chat/DmPanel.vue", {
+      conversations: [conversation()],
+      activePeerJid: "alice@example.com",
+      threadEntries: [thread],
+    }, (...args) => {
+      emitted.push(args);
+    });
+
+    setupBindingFunction(bindings, "emit")("selectThread", thread.threadId);
+    expect(emitted).toEqual([["selectThread", "dm-thread-1"]]);
+  });
+
+  test("restores DM route threads only after the async route request is still current", () => {
+    const controller = readFileSync(new URL("../src/shell/chat-app-controller.ts", import.meta.url), "utf8");
+    const dmRouteStart = controller.indexOf('if (match.id === "dm") {');
+    const openDmIndex = controller.indexOf("await handleOpenDm(`${username}@${domain}`);", dmRouteStart);
+    const staleGuardIndex = controller.indexOf("if (requestId !== routeRequestId) return;", openDmIndex);
+    const restoreIndex = controller.indexOf("activeThreadStack.value = match.search.thread;", staleGuardIndex);
+
+    expect(dmRouteStart).toBeGreaterThan(-1);
+    expect(openDmIndex).toBeGreaterThan(dmRouteStart);
+    expect(staleGuardIndex).toBeGreaterThan(openDmIndex);
+    expect(restoreIndex).toBeGreaterThan(staleGuardIndex);
   });
 });
+
+function conversation(): DmConversation {
+  return {
+    peerJid: "alice@example.com",
+    peerUsername: "Alice",
+    lastMessage: "See the thread",
+    lastMessageAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function threadEntry(threadId: string, body: string, count: number): MessageThreadEntry {
+  const root: TimelineMessage = {
+    id: threadId,
+    body,
+    nick: "alice",
+    timestamp: 1,
+    createdAt: "2026-01-01T00:00:00.000Z",
+  } as TimelineMessage;
+  const directChildren = Array.from({ length: count }, (_, index) => ({
+    id: `${threadId}-reply-${index}`,
+    body: `reply ${index}`,
+    nick: "bob",
+    timestamp: index + 2,
+    createdAt: `2026-01-01T00:0${index + 1}:00.000Z`,
+    threadId,
+  })) as TimelineMessage[];
+  return {
+    threadId,
+    root,
+    directChildren,
+    allDescendants: directChildren,
+    count,
+    lastTs: directChildren.at(-1)?.createdAt ?? root.createdAt,
+  };
+}
+
+async function renderVueComponent(path: string, props: Record<string, unknown>) {
+  const component = await loadVueComponent(path);
+  return renderToString(createSSRApp({ render: () => h(component, props) }));
+}
+
+async function setupVueComponent(
+  path: string,
+  props: Record<string, unknown>,
+  emit: (...args: unknown[]) => void = () => undefined,
+): Promise<Record<string, unknown>> {
+  const component = await loadVueComponent(path, { inlineTemplate: false }) as {
+    setup?: (
+      props: Record<string, unknown>,
+      context: {
+        emit: (...args: unknown[]) => void;
+        expose: () => void;
+        attrs: Record<string, unknown>;
+        slots: Record<string, unknown>;
+      },
+    ) => Record<string, unknown>;
+  };
+  if (!component.setup) throw new Error(`${path} has no setup function`);
+  return component.setup(props, {
+    emit,
+    expose: () => undefined,
+    attrs: {},
+    slots: {},
+  });
+}
+
+function setupBindingFunction(
+  bindings: Record<string, unknown>,
+  key: string,
+): (...args: unknown[]) => unknown {
+  const binding = bindings[key];
+  if (typeof binding !== "function") {
+    throw new Error(`Expected setup binding ${key} to be a function`);
+  }
+  return binding as (...args: unknown[]) => unknown;
+}
+
+async function loadVueComponent(path: string, options: { inlineTemplate?: boolean } = {}) {
+  const filename = new URL(path, import.meta.url);
+  const source = readFileSync(filename, "utf8");
+  const { descriptor } = parse(source, { filename: filename.pathname });
+  const script = compileScript(descriptor, {
+    id: filename.pathname,
+    inlineTemplate: options.inlineTemplate ?? true,
+  });
+
+  const tempDir = mkdtempSync(join(tmpdir(), "waddle-vue-component-"));
+  try {
+    const compiled = [
+      rewriteImports(script.content.replace("export default", "const __sfc__ ="), filename),
+      "export default __sfc__;",
+    ].join("\n");
+
+    const js = ts.transpileModule(compiled, {
+      compilerOptions: {
+        module: ts.ModuleKind.ESNext,
+        target: ts.ScriptTarget.ES2022,
+        verbatimModuleSyntax: false,
+      },
+    }).outputText;
+    const modulePath = join(tempDir, "Component.mjs");
+    writeFileSync(modulePath, js);
+    const component = await import(pathToFileURL(modulePath).href);
+    return component.default;
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function rewriteImports(code: string, importer: URL): string {
+  return code.replace(/from\s+["']([^"']+)["']/g, (_match, specifier: string) =>
+    `from ${JSON.stringify(resolveModuleSpecifier(specifier, importer))}`);
+}
+
+function resolveModuleSpecifier(specifier: string, importer: URL): string {
+  if (specifier.startsWith("@/")) {
+    return moduleUrlForPath(resolveSourcePath(new URL(`../src/${specifier.slice(2)}`, import.meta.url).pathname));
+  }
+  if (specifier.startsWith(".")) {
+    return moduleUrlForPath(resolveSourcePath(new URL(specifier, importer).pathname));
+  }
+  return import.meta.resolve(specifier);
+}
+
+function resolveSourcePath(basePath: string): string {
+  const candidates = [
+    basePath,
+    `${basePath}.ts`,
+    `${basePath}.tsx`,
+    `${basePath}.js`,
+    `${basePath}.mjs`,
+    `${basePath}.vue`,
+    `${basePath}.json`,
+    `${basePath}/index.ts`,
+  ];
+  const resolved = candidates.find((candidate) => existsSync(candidate));
+  if (!resolved) throw new Error(`Unable to resolve test SFC import: ${basePath}`);
+  return resolved;
+}
+
+function moduleUrlForPath(resolvedPath: string): string {
+  if (!resolvedPath.endsWith(".vue")) return pathToFileURL(resolvedPath).href;
+  return new URL("./helpers/vue-sfc-stub.ts", import.meta.url).href;
+}

--- a/chat/tests/edit-targeting.test.ts
+++ b/chat/tests/edit-targeting.test.ts
@@ -306,14 +306,11 @@ describe("edit targeting", () => {
 
     await messaging.editMessage("server-stanza-id", "hello");
 
-    expect(sendDmCorrection).toHaveBeenCalledWith(
-      "bob@example.com",
-      "hello",
-      "original-message-id",
-      undefined,
-      undefined,
-      undefined,
-    );
+    expect(sendDmCorrection).toHaveBeenCalledTimes(1);
+    const call = sendDmCorrection.mock.calls[0]!;
+    expect(call[0]).toBe("bob@example.com");
+    expect(call[1]).toBe("hello");
+    expect(call[2]).toBe("original-message-id");
   });
 
   test("DM corrections from a different bare JID do not rewrite the target", () => {

--- a/chat/tests/read-markers.test.ts
+++ b/chat/tests/read-markers.test.ts
@@ -212,6 +212,29 @@ describe("useDmReadMarkers", () => {
     expect(sendDmDisplayed.mock.calls[0]![1]).toBe("dm1");
   });
 
+  test("markDisplayed echoes XEP-0201 thread metadata for threaded DMs", () => {
+    const sendDmDisplayed = mock(async () => undefined);
+    const messages = ref<TimelineMessage[]>([
+      {
+        id: "dm1",
+        body: "",
+        nick: "",
+        timestamp: 0,
+        threadId: "dm-child-thread",
+        parentThreadId: "dm-root-thread",
+        displayedMarkerRequested: true,
+      } as TimelineMessage,
+    ]);
+    const r = useDmReadMarkers({
+      xmppClient: ref<BrowserXmppClient | null>(makeDmClient(sendDmDisplayed)),
+      activePeerJid: ref("bob@example.com"),
+      messages,
+    });
+    r.markDisplayed("dm1");
+    expect(sendDmDisplayed).toHaveBeenCalledTimes(1);
+    expect(sendDmDisplayed.mock.calls[0]![2]).toEqual({ id: "dm-child-thread", parent: "dm-root-thread" });
+  });
+
   test("markDisplayed does not send opportunistic 1:1 XEP-0333 markers", () => {
     const sendDmDisplayed = mock(async () => undefined);
     const publishMdsDisplayed = mock(async () => undefined);

--- a/chat/tests/reply-addressing.test.ts
+++ b/chat/tests/reply-addressing.test.ts
@@ -300,6 +300,65 @@ describe("reply addressing", () => {
     expect(messaging.messages.value.at(-1)?.replyTo).toBeUndefined();
     expect(messaging.messages.value.at(-1)?.threadId).toBeUndefined();
   });
+
+  test("DM thread sends serialize the active XEP-0201 thread id", async () => {
+    const sendDirectMessage = mock(async () => ({ id: "reply-1", state: "sending" as const }));
+    const sendDmChatState = mock(async () => undefined);
+    const actionError = ref("");
+    const messaging = useDirectMessages(
+      ref(session()),
+      ref({ sendDirectMessage, sendDmChatState } as never),
+      ref("bob@example.com"),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    await messaging.sendMessage("thread reply", [], [], undefined, undefined, undefined, {
+      threadId: "dm-root-1",
+    });
+
+    expect(sendDirectMessage).toHaveBeenCalledWith(
+      "bob@example.com",
+      "thread reply",
+      expect.objectContaining({ threadId: "dm-root-1" }),
+    );
+    expect(messaging.messages.value.at(-1)?.threadId).toBe("dm-root-1");
+  });
+
+  test("DM nested thread sends serialize the XEP-0201 parent thread id", async () => {
+    const sendDirectMessage = mock(async () => ({ id: "nested-reply-1", state: "sending" as const }));
+    const sendDmChatState = mock(async () => undefined);
+    const actionError = ref("");
+    const messaging = useDirectMessages(
+      ref(session()),
+      ref({ sendDirectMessage, sendDmChatState } as never),
+      ref("bob@example.com"),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    await messaging.sendMessage("nested thread reply", [], [], undefined, undefined, undefined, {
+      threadId: "dm-child-thread",
+      parentThreadId: "dm-root-thread",
+    });
+
+    expect(sendDirectMessage).toHaveBeenCalledWith(
+      "bob@example.com",
+      "nested thread reply",
+      expect.objectContaining({
+        threadId: "dm-child-thread",
+        parentThreadId: "dm-root-thread",
+      }),
+    );
+    expect(messaging.messages.value.at(-1)?.threadId).toBe("dm-child-thread");
+    expect(messaging.messages.value.at(-1)?.parentThreadId).toBe("dm-root-thread");
+  });
 });
 
 describe("room stanza-id targeting", () => {

--- a/chat/tests/sm-delivery.test.ts
+++ b/chat/tests/sm-delivery.test.ts
@@ -591,7 +591,10 @@ describe("XEP-0198 delivery status (DM)", () => {
     await nextTick();
     await dm.toggleReaction(messageId, "👍");
 
-    expect(sendDmReaction).toHaveBeenCalledWith("bob@example.com", originId, ["👍"]);
+    expect(sendDmReaction).toHaveBeenCalledTimes(1);
+    expect(sendDmReaction.mock.calls[0]?.[0]).toBe("bob@example.com");
+    expect(sendDmReaction.mock.calls[0]?.[1]).toBe(originId);
+    expect(sendDmReaction.mock.calls[0]?.[2]).toEqual(["👍"]);
     const original = dm.messages.value.find((m) => m.body === "react to origin-id");
     expect(original?.reactions).toEqual({ "👍": ["alice"] });
   });

--- a/chat/tests/use-threads.test.ts
+++ b/chat/tests/use-threads.test.ts
@@ -145,4 +145,34 @@ describe("useMessageThreads", () => {
     expect(entry!.count).toBe(1);
     expect(rootOf(messages.value[1])?.id).toBe("msg-1");
   });
+
+  test("DM timeline messages produce thread entries from XEP-0201 ids", () => {
+    const messages = ref<TimelineMessage[]>([
+      makeMessage({
+        id: "dm-root-1",
+        author: "Bob",
+        authorJid: "bob@example.com/phone",
+        createdAt: "2026-01-01T00:00:00Z",
+        body: "want to split this out?",
+      }),
+      makeMessage({
+        id: "dm-reply-1",
+        author: "alice",
+        authorJid: "alice@example.com/desktop",
+        threadId: "dm-root-1",
+        replyTo: { id: "dm-root-1", author: "Bob", preview: "want to split this out?" },
+        createdAt: "2026-01-01T00:01:00Z",
+        body: "yes",
+        isSelf: true,
+      }),
+    ]);
+
+    const { index, resolveEntry } = useMessageThreads(messages);
+    const entry = index.value.get("dm-root-1");
+
+    expect(entry).toBeTruthy();
+    expect(resolveEntry("dm-root-1")?.root?.authorJid).toBe("bob@example.com/phone");
+    expect(entry!.directChildren.map((message) => message.id)).toEqual(["dm-reply-1"]);
+    expect(entry!.count).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary

Implements #917 by ungating the existing XEP-0201 thread system for direct messages without adding a new wire shape.

## What changed

- DMs now feed the existing `useMessageThreads` index into the DM sidebar and right-side `ThreadPanel`.
- DM routes preserve and restore `?thread=...`, so direct-message thread panels deep-link like channel thread panels.
- DM route thread restoration is guarded against stale async route completions after `handleOpenDm(...)`.
- DM thread composer sends use `sendDirectMessage` with `threadId` and nested `parentThreadId` when present.
- DM thread-local corrections, reactions, retractions, displayed markers, and chat-state notifications now echo XEP-0201 thread refs through typed `BrowserXmppClient` methods.
- DM thread metadata normalization is shared across outbound DM sends, corrections, markers, reactions, and retractions so whitespace-only thread overrides cannot emit orphan `parentThreadId` payloads.
- DM thread composer link preview lookup now scopes to the active DM peer instead of the active channel room.
- Replaced the brittle DM threading UI source-literal contract test with component render/setup coverage for thread list rendering and selection.
- Added regression coverage for DM thread sends, nested thread parent refs, invalid whitespace thread overrides, DM thread action scoping, DM displayed/chat-state scoping, DM timeline thread entries, and the DM thread UI contract.

## Plan / acceptance coverage

- [x] A DM message can be replied to in a thread; the thread panel opens for DMs.
- [x] DMs expose a thread list in the DM sidebar using the existing thread index.
- [x] DM thread actions preserve XEP-0201 thread metadata.
- [x] Invalid/blank DM thread overrides do not emit orphan XEP-0201 parent metadata.
- [x] Stale async DM route completions cannot overwrite the active thread panel state.
- [x] Tests cover controller/shell exposure and DM timeline messages producing thread entries.
- [x] `knip` clean in `chat/` via `bun run lint`.
- [x] No channel threading regressions found in full chat test/build runs.
- [ ] HITL design review of DM thread affordances remains required before final product sign-off.

## Reviewer findings addressed

- Fixed nested DM sub-thread sends dropping `parentThreadId` on the wire.
- Fixed DM thread-local actions being emitted without XEP-0201 thread context.
- Fixed DM thread composer link preview lookup using the channel-only lookup path.
- Fixed review-commented orphan `parentThreadId` emission when `threadOverride.threadId` is blank or whitespace.
- Consolidated duplicated DM thread-reference helpers into one shared normalizer.
- Fixed stale async DM route completions restoring `activeThreadStack` / `activeRightPanel` after a newer route request.
- Replaced source-file string-literal DM threading UI assertions with component render/setup behavior coverage.

## Verification

- `cd chat && bun test tests/chat-send.test.ts tests/read-markers.test.ts tests/dm-message-actions.test.ts tests/reply-addressing.test.ts` — 50 pass, 0 fail
- `cd chat && bun test tests/dm-threading-ui.test.ts tests/chat-send.test.ts` — 19 pass, 0 fail
- `cd chat && bun run lint`
- `cd chat && bun test` — 1887 pass, 0 fail
- `cd chat && bun run build` — Astro check/build passed with the existing async-function hint in `src/lib/xmpp/discovery.ts` and existing chunk-size warning
- Adversarial protocol reviewer: no actionable issues
- Adversarial TypeScript/test reviewer: no actionable issues
- Adversarial latest-comment reviewer: no actionable issues

## Notes

- No new dependencies.
- No custom `urn:waddle:*` thread namespace added; this reuses XEP-0201 metadata already carried by DM messages.
- `docs/prd/004-call-chat.md` is present as an unrelated untracked local file and was not included in this PR.

Related: #917