### PR TITLE
feat(chat): show ended summaries for MUC call threads

### DIFF
--- a/chat/src/channels/live-merge.ts
+++ b/chat/src/channels/live-merge.ts
@@ -176,6 +176,31 @@ export function useChannelLiveMerge(deps: UseChannelLiveMergeDeps) {
     messages.value = next;
   }
 
+  function applyCallThreadEnded(ended: NonNullable<LiveRoomMessage["callThreadEnded"]>) {
+    const index = messages.value.findIndex((message) =>
+      !!message.callThread
+      && (
+        message.replyableId === ended.anchorId
+        || message.stanzaId === ended.anchorId
+        || message.id === ended.anchorId
+        || message.wireIds?.includes(ended.anchorId)
+      )
+    );
+    if (index < 0) return;
+    const current = messages.value[index]!;
+    if (!current.callThread) return;
+    const next = messages.value.slice();
+    next[index] = {
+      ...current,
+      callThread: {
+        ...current.callThread,
+        ended: ended.ended,
+        duration: ended.duration,
+      },
+    };
+    messages.value = next;
+  }
+
   /**
    * Merges a regular incoming message (no retract, no correction). If the
    * message reconciles a still-pending self-echo we promote the existing
@@ -263,6 +288,10 @@ export function useChannelLiveMerge(deps: UseChannelLiveMergeDeps) {
    * inspect the kind without re-classifying.
    */
   function handleRoomMessage(msg: LiveRoomMessage) {
+    if (msg.callThreadEnded) {
+      applyCallThreadEnded(msg.callThreadEnded);
+      return { kind: "ignore" as const };
+    }
     const classified = classifyRoomMessage(msg);
     switch (classified.kind) {
       case "retraction":
@@ -298,6 +327,7 @@ export function useChannelLiveMerge(deps: UseChannelLiveMergeDeps) {
     applyReaction,
     applyRetraction,
     applyCorrection,
+    applyCallThreadEnded,
     mergeLiveMessage,
     handleRoomMessage,
   };

--- a/chat/src/channels/message-timeline-state.ts
+++ b/chat/src/channels/message-timeline-state.ts
@@ -297,6 +297,7 @@ export function buildChannelTimelineFromMamResults(params: {
     extensionAnnotations?: LiveRoomMessage["extensionAnnotations"];
     extensionBodyFallback?: boolean;
   }[] = [];
+  const callThreadEndedUpdates: NonNullable<LiveRoomMessage["callThreadEnded"]>[] = [];
 
   for (const msg of mamResults) {
     if (msg._reactionTarget && msg._reactionEmojis) {
@@ -324,6 +325,8 @@ export function buildChannelTimelineFromMamResults(params: {
         extensionAnnotations: msg.extensionAnnotations,
         extensionBodyFallback: msg.extensionBodyFallback,
       });
+    } else if (msg.callThreadEnded) {
+      callThreadEndedUpdates.push(msg.callThreadEnded);
     } else if (
       msg.body
       || msg.isRetracted
@@ -375,6 +378,24 @@ export function buildChannelTimelineFromMamResults(params: {
     }
     byId.add(tm);
     timeline.push(tm);
+  }
+
+  for (const update of callThreadEndedUpdates) {
+    const target = timeline.find((message) =>
+      !!message.callThread
+      && (
+        message.replyableId === update.anchorId
+        || message.stanzaId === update.anchorId
+        || message.id === update.anchorId
+        || message.wireIds?.includes(update.anchorId)
+      )
+    );
+    if (!target?.callThread) continue;
+    target.callThread = {
+      ...target.callThread,
+      ended: update.ended,
+      duration: update.duration,
+    };
   }
 
   for (const update of correctionUpdates) {

--- a/chat/src/lib/call-thread-anchor.ts
+++ b/chat/src/lib/call-thread-anchor.ts
@@ -1,9 +1,23 @@
 import type { TimelineMessage } from "@/lib/chat-ui";
 
-export function callThreadAnchorLabel(message: Pick<TimelineMessage, "body" | "author">): string {
+export function callThreadAnchorLabel(message: Pick<TimelineMessage, "body" | "author" | "callThread">): string {
+  if (message.callThread?.ended && message.callThread.duration) {
+    return `Call ended · ${formatCallThreadDuration(message.callThread.duration)}`;
+  }
   return message.body || `${message.author} started a call`;
 }
 
 export function callThreadAnchorThreadId(message: Pick<TimelineMessage, "threadId" | "callThread">): string | null {
   return message.callThread && message.threadId ? message.threadId : null;
+}
+
+function formatCallThreadDuration(value: string): string {
+  const match = /^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/.exec(value);
+  if (!match) return value;
+  const hours = Number(match[1] ?? 0);
+  const minutes = Number(match[2] ?? 0);
+  const seconds = Number(match[3] ?? 0);
+  if (hours > 0) return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  if (minutes > 0) return `${minutes}m`;
+  return `${seconds}s`;
 }

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -47,6 +47,8 @@ export interface CallThreadAnchor {
   media: readonly ("audio" | "video")[];
   initiator: string;
   started: string;
+  ended?: string;
+  duration?: string;
 }
 
 export interface LinkPreview {

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -185,7 +185,7 @@ export interface LiveRoomMessage {
   parentThreadId?: string;
   /** Waddle call-thread anchor marker (`urn:waddle:call-thread:0`). */
   callThread?: CallThreadAnchor;
-  /** Waddle call-thread ended fastening targeting an anchor stanza-id. */
+  /** Waddle call-thread ended fastening target from XEP-0422 apply-to@id. */
   callThreadEnded?: {
     anchorId: string;
     ended: string;

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -185,6 +185,12 @@ export interface LiveRoomMessage {
   parentThreadId?: string;
   /** Waddle call-thread anchor marker (`urn:waddle:call-thread:0`). */
   callThread?: CallThreadAnchor;
+  /** Waddle call-thread ended fastening targeting an anchor stanza-id. */
+  callThreadEnded?: {
+    anchorId: string;
+    ended: string;
+    duration: string;
+  };
   /** Waddle thread metadata */
   forumPostKind?: "topic" | "reply";
   forumTitle?: string;

--- a/chat/src/lib/xmpp/wasm-message-codecs.ts
+++ b/chat/src/lib/xmpp/wasm-message-codecs.ts
@@ -467,6 +467,25 @@ export function roomMessageFromArchived(
       pinEventAction: message.pin_event.action,
     };
   }
+  if (message.call_thread_ended) {
+    return {
+      id: roomPrimaryId,
+      archiveId: message.mam_id,
+      fromJid,
+      roomJid,
+      nick,
+      body: "",
+      createdAt,
+      createdAtSource,
+      type: "message",
+      callThreadEnded: {
+        anchorId: message.call_thread_ended.anchor_id,
+        ended: message.call_thread_ended.ended,
+        duration: message.call_thread_ended.duration,
+      },
+      ...(stampedByRoom ? { stanzaId: stampedByRoom, stanzaIdBy: roomJid } : {}),
+    };
+  }
   const sharedFiles = message.shared_files ?? [];
   const linkPreviews = message.link_previews ?? [];
   const mentionUris = message.mention_uris ?? [];

--- a/chat/src/lib/xmpp/wasm-types.ts
+++ b/chat/src/lib/xmpp/wasm-types.ts
@@ -56,6 +56,12 @@ export interface WasmCallThreadAnchor {
   started: string;
 }
 
+interface WasmCallThreadEnded {
+  anchor_id: string;
+  ended: string;
+  duration: string;
+}
+
 export interface WasmExtensionEnvelope {
   version: number;
   enrichments: WasmExtensionEnrichment[];
@@ -146,6 +152,7 @@ export interface WasmMessage {
   forum_thread_title?: string;
   is_sticker: boolean;
   call_thread?: WasmCallThreadAnchor;
+  call_thread_ended?: WasmCallThreadEnded;
   shared_files: WasmSharedFile[];
   link_previews: WasmLinkPreview[];
   call_event?: CallEvent;

--- a/chat/tests/call-thread-anchor.test.ts
+++ b/chat/tests/call-thread-anchor.test.ts
@@ -68,6 +68,23 @@ describe("call-thread anchor timeline mapping", () => {
     expect(callThreadAnchorThreadId(timelineMessage)).toBe("call-thread-uuid");
   });
 
+  test("renders ended call-thread anchors as muted duration summaries", () => {
+    const timelineMessage = mapLiveRoomMessageToTimeline(session, callAnchor({
+      callThread: {
+        kind: "muc",
+        sid: "session-uuid",
+        media: ["audio"],
+        initiator: "alice@example",
+        started: "2026-06-07T14:30:00Z",
+        ended: "2026-06-07T14:35:00Z",
+        duration: "PT5M",
+      },
+    }));
+
+    expect(callThreadAnchorLabel(timelineMessage)).toBe("Call ended · 5m");
+    expect(callThreadAnchorThreadId(timelineMessage)).toBe("call-thread-uuid");
+  });
+
   test("room archive codec maps the WASM call-thread marker onto LiveRoomMessage", () => {
     const live = roomMessageFromArchived({
       mam_id: "mam-anchor-1",
@@ -102,6 +119,37 @@ describe("call-thread anchor timeline mapping", () => {
       media: ["audio", "video"],
       initiator: "alice@example",
       started: "2026-06-07T14:30:00Z",
+    });
+  });
+
+  test("room archive codec maps call-thread-ended fastening onto a control event", () => {
+    const live = roomMessageFromArchived({
+      mam_id: "mam-ended-1",
+      id: "ended-1",
+      from: "general@muc.example.com",
+      to: "alice@example.com/web",
+      message_type: "groupchat",
+      timestamp: "2026-06-07T14:35:00Z",
+      reaction_emojis: [],
+      is_muc: true,
+      markup_spans: [],
+      mention_uris: [],
+      references: [],
+      is_sticker: false,
+      shared_files: [],
+      link_previews: [],
+      call_thread_ended: {
+        anchor_id: "anchor-stanza-id",
+        ended: "2026-06-07T14:35:00Z",
+        duration: "PT5M",
+      },
+    });
+
+    expect(live?.body).toBe("");
+    expect(live?.callThreadEnded).toEqual({
+      anchorId: "anchor-stanza-id",
+      ended: "2026-06-07T14:35:00Z",
+      duration: "PT5M",
     });
   });
 

--- a/chat/tests/channel-live-merge.test.ts
+++ b/chat/tests/channel-live-merge.test.ts
@@ -182,6 +182,52 @@ describe("handleRoomMessage typed dispatch", () => {
     expect(h.messages.value.length).toBe(before + 1);
   });
 
+  test("call-thread-ended fastening updates the existing anchor instead of appending", () => {
+    const h = harness();
+    h.messages.value = [
+      {
+        id: "anchor-local",
+        replyableId: "anchor-stanza-id",
+        body: "alice started a call",
+        author: "alice",
+        authorJid: "room@muc.example.com/alice",
+        createdAt: "2026-06-07T14:30:00Z",
+        createdAtSource: "archive",
+        isSelf: false,
+        threadId: "call-thread-uuid",
+        callThread: {
+          kind: "muc",
+          sid: "session-uuid",
+          media: ["audio"],
+          initiator: "alice@example.com",
+          started: "2026-06-07T14:30:00Z",
+        },
+      } as TimelineMessage,
+    ];
+
+    const out = h.liveMerge.handleRoomMessage(makeLive({
+      id: "ended-event",
+      body: "",
+      callThreadEnded: {
+        anchorId: "anchor-stanza-id",
+        ended: "2026-06-07T14:35:00Z",
+        duration: "PT5M",
+      },
+    }));
+
+    expect(out.kind).toBe("ignore");
+    expect(h.messages.value).toHaveLength(1);
+    expect(h.messages.value[0]?.callThread).toEqual({
+      kind: "muc",
+      sid: "session-uuid",
+      media: ["audio"],
+      initiator: "alice@example.com",
+      started: "2026-06-07T14:30:00Z",
+      ended: "2026-06-07T14:35:00Z",
+      duration: "PT5M",
+    });
+  });
+
   test("ignore: non-message stanza doesn't touch the timeline", () => {
     const h = harness();
     const before = h.messages.value.length;

--- a/chat/tests/tombstone-replay.test.ts
+++ b/chat/tests/tombstone-replay.test.ts
@@ -27,6 +27,57 @@ const extensionAnnotation: ExtensionAnnotation = {
 };
 
 describe("XEP-0424 tombstone replay", () => {
+  test("folds archived call-thread-ended fastenings into their call anchors", () => {
+    const anchor: LiveRoomMessage = {
+      id: "anchor-message",
+      wireIds: ["anchor-origin-id"],
+      replyableId: "anchor-origin-id",
+      stanzaId: "anchor-room-stanza-id",
+      roomJid: "room@muc.example.com",
+      nick: "alice",
+      body: "Alice started a call",
+      createdAt: "2026-05-08T13:00:00Z",
+      type: "message",
+      callThread: {
+        kind: "muc",
+        sid: "call-thread-uuid",
+        media: ["audio"],
+        initiator: "room@muc.example.com/alice",
+        started: "2026-05-08T13:00:00Z",
+      },
+    };
+    const ended: LiveRoomMessage = {
+      id: "ended-message",
+      roomJid: "room@muc.example.com",
+      nick: "room",
+      body: "",
+      createdAt: "2026-05-08T13:05:00Z",
+      type: "message",
+      callThreadEnded: {
+        anchorId: "anchor-origin-id",
+        ended: "2026-05-08T13:05:00Z",
+        duration: "PT5M",
+      },
+    };
+
+    const timeline = buildChannelTimelineFromMamResults({
+      session,
+      channelIsForum: false,
+      mamResults: [anchor, ended],
+    });
+
+    expect(timeline).toHaveLength(1);
+    expect(timeline[0]?.callThread).toEqual({
+      kind: "muc",
+      sid: "call-thread-uuid",
+      media: ["audio"],
+      initiator: "room@muc.example.com/alice",
+      started: "2026-05-08T13:00:00Z",
+      ended: "2026-05-08T13:05:00Z",
+      duration: "PT5M",
+    });
+  });
+
   test("updates an already-loaded channel message from a MAM tombstone", () => {
     const existing: TimelineMessage = {
       id: "original-message",

--- a/cuenv.lock
+++ b/cuenv.lock
@@ -1,11 +1,5 @@
 version = 4
 
-[runtimes.chat]
-type = "nix"
-flake = ".."
-digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
-lockfile = "chat/../flake.lock"
-
 [runtimes.colony]
 type = "nix"
 flake = ".."
@@ -17,18 +11,6 @@ type = "nix"
 flake = "../.."
 digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
 lockfile = "infrastructure/waddle.cloud/../../flake.lock"
-
-[runtimes.server]
-type = "nix"
-flake = ".."
-digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
-lockfile = "server/../flake.lock"
-
-[runtimes.website]
-type = "nix"
-flake = ".."
-digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
-lockfile = "website/../flake.lock"
 
 [vcs.xeps]
 url = "https://github.com/xsf/xeps.git"

--- a/cuenv.lock
+++ b/cuenv.lock
@@ -1,5 +1,11 @@
 version = 4
 
+[runtimes.chat]
+type = "nix"
+flake = ".."
+digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
+lockfile = "chat/../flake.lock"
+
 [runtimes.colony]
 type = "nix"
 flake = ".."
@@ -11,6 +17,18 @@ type = "nix"
 flake = "../.."
 digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
 lockfile = "infrastructure/waddle.cloud/../../flake.lock"
+
+[runtimes.server]
+type = "nix"
+flake = ".."
+digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
+lockfile = "server/../flake.lock"
+
+[runtimes.website]
+type = "nix"
+flake = ".."
+digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
+lockfile = "website/../flake.lock"
 
 [vcs.xeps]
 url = "https://github.com/xsf/xeps.git"

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -591,6 +591,7 @@ async fn create_websocket_state(
                 avatar_source_locks: Arc::new(crate::profile::AvatarLockMap::new()),
                 profile_publish_tracker: tokio_util::task::TaskTracker::new(),
                 pep_feed_bridge: Arc::new(crate::pep_feed_bridge::PepFeedBridge::new()),
+                call_threads: Arc::new(dashmap::DashMap::new()),
                 sfu: sfu_service,
             },
             occupant_id_secret: server_config.occupant_id_secret.clone(),

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -195,7 +195,7 @@ pub(crate) async fn broadcast_room_system_message(
     deps: &Deps<'_>,
     room: BareJid,
     message: Box<Message>,
-) {
+) -> Option<String> {
     room_system_message::broadcast_room_system_message_event(
         deps.connection_registry,
         deps,
@@ -203,7 +203,7 @@ pub(crate) async fn broadcast_room_system_message(
         message,
         0,
     )
-    .await;
+    .await
 }
 
 /// Execute the side effects described by `events`.

--- a/server/crates/waddle-server/src/server/routes/interpret/room_system_message.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_system_message.rs
@@ -22,13 +22,13 @@ pub(super) async fn broadcast_room_system_message_event(
     room: BareJid,
     mut message: Box<Message>,
     recursion_depth: u8,
-) {
+) -> Option<String> {
     let Some(room_registry) = deps.room_registry else {
         debug!(
             room = %room,
             "BroadcastRoomSystemMessage: no room_registry in Deps; skipping"
         );
-        return;
+        return None;
     };
     let room_actor = match room_registry
         .ask(GetRoom {
@@ -42,7 +42,7 @@ pub(super) async fn broadcast_room_system_message_event(
                 room = %room,
                 "BroadcastRoomSystemMessage: room not registered; dropping"
             );
-            return;
+            return None;
         }
         Err(error) => {
             warn!(
@@ -50,7 +50,7 @@ pub(super) async fn broadcast_room_system_message_event(
                 error = ?error,
                 "BroadcastRoomSystemMessage: room registry lookup failed; dropping"
             );
-            return;
+            return None;
         }
     };
 
@@ -67,7 +67,7 @@ pub(super) async fn broadcast_room_system_message_event(
                 ?error,
                 "BroadcastRoomSystemMessage: failed to build synthetic sender; dropping"
             );
-            return;
+            return None;
         }
     };
     let snapshot = match room_actor
@@ -83,7 +83,7 @@ pub(super) async fn broadcast_room_system_message_event(
                 error = ?error,
                 "BroadcastRoomSystemMessage: GetRoomSnapshot failed; dropping"
             );
-            return;
+            return None;
         }
     };
 
@@ -130,4 +130,5 @@ pub(super) async fn broadcast_room_system_message_event(
         )
         .await;
     }
+    Some(stanza_id)
 }

--- a/server/crates/waddle-server/src/server/routes/muc_muji_clear.rs
+++ b/server/crates/waddle-server/src/server/routes/muc_muji_clear.rs
@@ -131,7 +131,7 @@ pub(crate) fn broadcast_muji_clear(
     }
 }
 
-async fn maybe_broadcast_call_thread_ended(state: &WebSocketState, room_jid: &BareJid) {
+pub(crate) async fn maybe_broadcast_call_thread_ended(state: &WebSocketState, room_jid: &BareJid) {
     let Some(sfu) = state.deps.protocol.sfu.as_ref() else {
         return;
     };

--- a/server/crates/waddle-server/src/server/routes/muc_muji_clear.rs
+++ b/server/crates/waddle-server/src/server/routes/muc_muji_clear.rs
@@ -7,14 +7,23 @@
 //! occupants. Centralising the logic keeps the wire shape identical.
 
 use jid::{BareJid, FullJid};
+use minidom::Element;
 use tracing::{debug, warn};
 use waddle_xmpp::muc::build_occupant_presence;
 use waddle_xmpp::muc::room_actor::{ClearMujiPresence, MujiPresenceUpdateOutcome};
 use waddle_xmpp::xep::xep0272::Muji;
 use waddle_xmpp::xep::xep0421::OccupantIdentity;
+use waddle_xmpp::xep::{
+    build_call_thread_ended, build_hint_element, CallThreadDuration, CallThreadEnded, Hint,
+    NS_FASTEN,
+};
 use waddle_xmpp_core::Stanza;
+use xmpp_parsers::message::{Message, MessageType};
 
-use super::websocket::{get_room_actor, note_participant_left_from_webhook, WebSocketState};
+use super::websocket::{
+    get_room_actor, interpret_loop::build_interpret_deps, note_participant_left_from_webhook,
+    WebSocketState,
+};
 
 /// Clear `full_jid`'s Muji advertisement in `room_jid` and broadcast
 /// the leave marker to remaining occupants. Idempotent: a participant
@@ -65,6 +74,7 @@ pub(crate) async fn clear_muji_presence_for_departure(
 
     broadcast_muji_clear(state, room_jid, full_jid, &outcome);
     note_participant_left_from_webhook(state, room_jid, full_jid);
+    maybe_broadcast_call_thread_ended(state, room_jid).await;
 }
 
 /// Broadcast a server-originated Muji-presence clear to every remaining
@@ -118,5 +128,68 @@ pub(crate) fn broadcast_muji_clear(
                 .connection_registry
                 .try_send_to(recipient, Stanza::Presence(presence));
         }
+    }
+}
+
+async fn maybe_broadcast_call_thread_ended(state: &WebSocketState, room_jid: &BareJid) {
+    let Some(sfu) = state.deps.protocol.sfu.as_ref() else {
+        return;
+    };
+    let Ok(call_id) = waddle_sfu::CallId::new(room_jid.to_string()) else {
+        return;
+    };
+    if !sfu.participants_for_call(&call_id).is_empty() {
+        return;
+    }
+    let Some((_, active)) = state.deps.protocol.call_threads.remove(room_jid) else {
+        return;
+    };
+
+    let ended = chrono::Utc::now();
+    let duration = ended.signed_duration_since(active.started);
+    let duration = CallThreadDuration::parse(&format_call_thread_duration(duration))
+        .expect("formatted call-thread duration is valid");
+    let message = build_call_thread_ended_message(
+        room_jid,
+        &active.anchor_origin_id,
+        &CallThreadEnded { ended, duration },
+    );
+    let deps = build_interpret_deps(state, None);
+    let _ =
+        super::interpret::broadcast_room_system_message(&deps, room_jid.clone(), Box::new(message))
+            .await;
+}
+
+fn build_call_thread_ended_message(
+    room_jid: &BareJid,
+    anchor_origin_id: &str,
+    ended: &CallThreadEnded,
+) -> Message {
+    let apply_to = Element::builder("apply-to", NS_FASTEN)
+        .attr(
+            minidom::rxml::xml_ncname!("id").to_owned(),
+            anchor_origin_id,
+        )
+        .append(build_call_thread_ended(ended))
+        .build();
+    let mut message = Message::new(Some(jid::Jid::from(room_jid.clone())));
+    message.from = Some(jid::Jid::from(room_jid.clone()));
+    message.type_ = MessageType::Groupchat;
+    message.payloads.push(apply_to);
+    message.payloads.push(build_hint_element(Hint::Store));
+    message
+}
+
+fn format_call_thread_duration(duration: chrono::Duration) -> String {
+    let seconds = duration.num_seconds().max(0);
+    let hours = seconds / 3600;
+    let minutes = (seconds % 3600) / 60;
+    let seconds = seconds % 60;
+    if hours > 0 {
+        format!("PT{hours}H{minutes}M{seconds}S")
+    } else if minutes > 0 {
+        format!("PT{minutes}M{seconds}S")
+    } else {
+        format!("PT{seconds}S")
     }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
@@ -198,8 +198,6 @@ pub(super) async fn try_handle_muc_presence_update(
         super::super::super::muc_call_sfu::unregister_participant_from_room(
             state, room_jid, sender_jid,
         );
-        crate::server::routes::muc_muji_clear::maybe_broadcast_call_thread_ended(state, room_jid)
-            .await;
     }
 
     // XEP-0045 §7.7: a user may change their *own* in-room presence
@@ -302,6 +300,11 @@ pub(super) async fn try_handle_muc_presence_update(
                     .try_send_to(recipient, stanza);
             }
         }
+    }
+
+    if clears_muji_presence {
+        crate::server::routes::muc_muji_clear::maybe_broadcast_call_thread_ended(state, room_jid)
+            .await;
     }
 
     if let Some(anchor) = call_thread_anchor {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
@@ -44,17 +44,20 @@ use waddle_xmpp::xep::xep0272::{find_muji, Muji, NS_MUJI};
 use waddle_xmpp::xep::xep0421::OccupantIdentity;
 use waddle_xmpp::xep::{
     build_call_thread_anchor, build_hint_element, CallThreadAnchor, CallThreadKind,
-    CallThreadMedia, Hint,
+    CallThreadMedia, Hint, NS_WADDLE_CALL_THREAD,
 };
 use waddle_xmpp::Stanza;
 use waddle_xmpp_core::mam::ThreadId;
 use waddle_xmpp_core::xep0201::{build_thread_element, ThreadInfo, CLIENT_STANZA_NS};
+use waddle_xmpp_core::xep0359::{build_origin_id_element, NS_SID};
 use xmpp_parsers::jingle::SessionId;
 use xmpp_parsers::message::{Lang, Message, MessageType};
 use xmpp_parsers::presence::Presence;
 
 use super::super::super::{get_room_actor, stanza_to_xml};
-use crate::server::routes::websocket::{interpret_loop::build_interpret_deps, WebSocketState};
+use crate::server::routes::websocket::{
+    interpret_loop::build_interpret_deps, ActiveCallThread, WebSocketState,
+};
 
 /// Pull out the typed [`Muji`] element from an inbound presence's
 /// payloads if it carries one. Returns `None` when the namespace
@@ -300,13 +303,36 @@ pub(super) async fn try_handle_muc_presence_update(
     }
 
     if let Some(anchor) = call_thread_anchor {
+        let started = anchor
+            .payloads
+            .iter()
+            .find(|payload| {
+                payload.name() == "call-thread" && payload.ns() == NS_WADDLE_CALL_THREAD
+            })
+            .and_then(|payload| waddle_xmpp::xep::parse_call_thread_anchor(payload).ok())
+            .map(|marker| marker.started);
+        let anchor_origin_id = anchor
+            .payloads
+            .iter()
+            .find(|payload| payload.name() == "origin-id" && payload.ns() == NS_SID)
+            .and_then(|payload| payload.attr("id"))
+            .map(str::to_owned);
         let deps = build_interpret_deps(state, None);
-        crate::server::routes::interpret::broadcast_room_system_message(
+        let _ = crate::server::routes::interpret::broadcast_room_system_message(
             &deps,
             room_jid.clone(),
             Box::new(anchor),
         )
         .await;
+        if let Some((anchor_origin_id, started)) = anchor_origin_id.zip(started) {
+            state.deps.protocol.call_threads.insert(
+                room_jid.clone(),
+                ActiveCallThread {
+                    anchor_origin_id,
+                    started,
+                },
+            );
+        }
     }
 
     // Silence unused-import warning when feature flags trim the path.
@@ -332,6 +358,9 @@ fn build_call_thread_anchor_message(
     message
         .payloads
         .push(build_thread_element(&thread, CLIENT_STANZA_NS));
+    message
+        .payloads
+        .push(build_origin_id_element(&uuid::Uuid::new_v4().to_string()));
     message
         .payloads
         .push(build_call_thread_anchor(&CallThreadAnchor {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
@@ -198,6 +198,8 @@ pub(super) async fn try_handle_muc_presence_update(
         super::super::super::muc_call_sfu::unregister_participant_from_room(
             state, room_jid, sender_jid,
         );
+        crate::server::routes::muc_muji_clear::maybe_broadcast_call_thread_ended(state, room_jid)
+            .await;
     }
 
     // XEP-0045 §7.7: a user may change their *own* in-room presence
@@ -324,14 +326,16 @@ pub(super) async fn try_handle_muc_presence_update(
             Box::new(anchor),
         )
         .await;
-        if let Some((anchor_origin_id, started)) = anchor_origin_id.zip(started) {
-            state.deps.protocol.call_threads.insert(
-                room_jid.clone(),
-                ActiveCallThread {
-                    anchor_origin_id,
-                    started,
-                },
-            );
+        if state.deps.protocol.sfu.is_some() {
+            if let Some((anchor_origin_id, started)) = anchor_origin_id.zip(started) {
+                state.deps.protocol.call_threads.insert(
+                    room_jid.clone(),
+                    ActiveCallThread {
+                        anchor_origin_id,
+                        started,
+                    },
+                );
+            }
         }
     }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -71,7 +71,7 @@ mod cleanup;
 mod connection;
 mod frame;
 mod frame_backstop;
-mod interpret_loop;
+pub(crate) mod interpret_loop;
 pub(crate) mod link_preview_refs;
 pub(crate) mod link_preview_telemetry;
 mod muc_call_sfu;
@@ -91,7 +91,9 @@ pub mod handlers;
 
 pub use cleanup::cleanup_muc_presence_for_jid;
 pub use connection::router;
-pub use state::{ProtocolServices, WebSocketDeps, WebSocketState, XmppServiceDomains};
+pub use state::{
+    ActiveCallThread, ProtocolServices, WebSocketDeps, WebSocketState, XmppServiceDomains,
+};
 
 pub(crate) use cleanup::{
     destroy_room_actor, get_or_create_room_actor, get_room_actor, is_muc_room_jid,

--- a/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
@@ -226,6 +226,7 @@ mod tests {
                     avatar_source_locks: Arc::clone(&deps.protocol.avatar_source_locks),
                     profile_publish_tracker: deps.protocol.profile_publish_tracker.clone(),
                     pep_feed_bridge: Arc::clone(&deps.protocol.pep_feed_bridge),
+                    call_threads: Arc::clone(&deps.protocol.call_threads),
                     sfu: Some(sfu),
                 },
                 occupant_id_secret: deps.occupant_id_secret.clone(),

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -1,6 +1,12 @@
 use super::*;
 
 #[derive(Debug, Clone)]
+pub struct ActiveCallThread {
+    pub anchor_origin_id: String,
+    pub started: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Clone)]
 pub struct XmppServiceDomains {
     pub muc: String,
     pub spaces: String,
@@ -167,6 +173,11 @@ pub struct ProtocolServices {
     /// Feed pane surfaces user activity automatically. Holds per-
     /// (user, kind) throttle state.
     pub pep_feed_bridge: Arc<crate::pep_feed_bridge::PepFeedBridge>,
+    /// Active MUC call-thread anchors keyed by room bare JID. The room
+    /// anchor message records a XEP-0359 origin-id so the SFU webhook path
+    /// can later fasten a historical `<call-thread-ended/>` record to that
+    /// exact anchor with XEP-0422 `<apply-to/>`.
+    pub call_threads: Arc<dashmap::DashMap<BareJid, ActiveCallThread>>,
     /// LiveKit SFU bridge — `Some` iff `LIVEKIT_*` env vars are set
     /// and `register_call_handlers` was invoked at startup. The
     /// WebSocket cleanup paths call

--- a/server/crates/waddle-server/src/server/routes/websocket/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests.rs
@@ -219,6 +219,7 @@ async fn create_test_websocket_state_with_extension_manager(
                     avatar_source_locks: Arc::new(crate::profile::AvatarLockMap::new()),
                     profile_publish_tracker: tokio_util::task::TaskTracker::new(),
                     pep_feed_bridge: Arc::new(crate::pep_feed_bridge::PepFeedBridge::new()),
+                    call_threads: Arc::new(dashmap::DashMap::new()),
                     sfu: None,
                 },
                 occupant_id_secret: OccupantIdSecret::new(

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -1311,6 +1311,65 @@ async fn empty_muji_presence_unregisters_the_sfu_participant() {
 }
 
 #[tokio::test]
+async fn empty_muji_presence_ends_the_active_call_thread() {
+    let recorder = std::sync::Arc::new(RecordingSfu::default());
+    let state = state_with_recording_sfu(std::sync::Arc::clone(&recorder)).await;
+    let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let room_jid: BareJid = "presence-clear-ended@muc.example.com"
+        .parse()
+        .expect("room jid");
+    let alice: FullJid = "alice@example.com/web".parse().expect("alice jid");
+
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &alice,
+        "alice",
+        None,
+        &Some(owner_session.clone()),
+    )
+    .await;
+    let alice_phase = waddle_xmpp::protocol::ConnectionPhase::ready(alice.clone(), false);
+
+    let mut active = muc_presence_to(&room_jid, "alice");
+    active.payloads.push(active_muji().to_element());
+    let _ = handlers::presence::handle_presence(
+        active,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &alice_phase,
+        &Some(owner_session.clone()),
+    )
+    .await;
+    state.deps.protocol.call_threads.insert(
+        room_jid.clone(),
+        crate::server::routes::websocket::ActiveCallThread {
+            anchor_origin_id: "anchor-origin-id".to_owned(),
+            started: chrono::Utc::now() - chrono::Duration::minutes(5),
+        },
+    );
+
+    let mut empty = muc_presence_to(&room_jid, "alice");
+    empty.payloads.push(empty_muji().to_element());
+    let _ = handlers::presence::handle_presence(
+        empty,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &alice_phase,
+        &Some(owner_session),
+    )
+    .await;
+
+    assert!(
+        !state.deps.protocol.call_threads.contains_key(&room_jid),
+        "XMPP-native Muji clear must consume the active call thread when the SFU participant set is empty"
+    );
+}
+
+#[tokio::test]
 async fn resumed_muc_join_presence_replays_existing_muji_state() {
     let state = create_test_websocket_state().await;
     let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;

--- a/server/crates/waddle-server/tests/calls_e2e_ws.rs
+++ b/server/crates/waddle-server/tests/calls_e2e_ws.rs
@@ -11,6 +11,10 @@
 
 mod ws_common;
 
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine};
+use jsonwebtoken::{encode, EncodingKey, Header};
+use serde_json::json;
+use sha2::{Digest, Sha256};
 use ws_common::{disco_info_query, TestServer, WsXmppClient};
 use xmpp_parsers::minidom::Element;
 
@@ -18,12 +22,15 @@ const NS_MUC: &str = "http://jabber.org/protocol/muc";
 const NS_MUC_USER: &str = "http://jabber.org/protocol/muc#user";
 const NS_MUJI: &str = "urn:xmpp:jingle:muji:0";
 const NS_CALL_THREAD: &str = "urn:waddle:call-thread:0";
+const NS_FASTEN: &str = "urn:xmpp:fasten:0";
+const NS_SID: &str = "urn:xmpp:sid:0";
 
 const DOMAIN: &str = "localhost";
 const ALICE: &str = "alice";
 const BOB: &str = "bob";
 const ALICE_PW: &str = "alice-pw-12345";
 const BOB_PW: &str = "bob-pw-12345";
+const LIVEKIT_WEBHOOK_SECRET: &str = "test-webhook-secret-with-at-least-32-bytes";
 
 // The harness rejects api-secrets shorter than 32 bytes; this one is
 // exactly 32 ASCII characters. The other LIVEKIT_* values are
@@ -42,6 +49,7 @@ fn livekit_test_envs() -> Vec<(&'static str, &'static str)> {
             "LIVEKIT_TURN_SHARED_SECRET",
             "turn-shared-secret-value-also-long-enough",
         ),
+        ("LIVEKIT_WEBHOOK_SECRET", LIVEKIT_WEBHOOK_SECRET),
     ]
 }
 
@@ -393,6 +401,109 @@ fn call_thread_child(message: &Element) -> Option<&Element> {
         .find(|c| c.name() == "call-thread" && c.ns() == NS_CALL_THREAD)
 }
 
+fn apply_to_child(message: &Element) -> Option<&Element> {
+    message
+        .children()
+        .find(|c| c.name() == "apply-to" && c.ns() == NS_FASTEN)
+}
+
+fn call_thread_ended_child(apply_to: &Element) -> Option<&Element> {
+    apply_to
+        .children()
+        .find(|c| c.name() == "call-thread-ended" && c.ns() == NS_CALL_THREAD)
+}
+
+fn room_stanza_id(message: &Element, room: &str) -> Option<String> {
+    message
+        .children()
+        .find(|c| c.name() == "stanza-id" && c.ns() == NS_SID && c.attr("by") == Some(room))
+        .and_then(|c| c.attr("id"))
+        .map(ToOwned::to_owned)
+}
+
+fn origin_id(message: &Element) -> Option<String> {
+    message
+        .children()
+        .find(|c| c.name() == "origin-id" && c.ns() == NS_SID)
+        .and_then(|c| c.attr("id"))
+        .map(ToOwned::to_owned)
+}
+
+fn livekit_webhook_auth(body: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(body);
+    let digest = hasher.finalize();
+    let claims = json!({
+        "sha256": BASE64_STANDARD.encode(digest),
+        "exp": (chrono::Utc::now() + chrono::Duration::seconds(60)).timestamp(),
+        "iat": chrono::Utc::now().timestamp(),
+    });
+    let token = encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(LIVEKIT_WEBHOOK_SECRET.as_bytes()),
+    )
+    .expect("sign LiveKit webhook");
+    format!("Bearer {token}")
+}
+
+async fn post_participant_left_webhook(server: &TestServer, room: &str, identity: &str) {
+    let body = serde_json::to_vec(&json!({
+        "id": format!("EV_{}", uuid::Uuid::new_v4()),
+        "event": "participant_left",
+        "room": { "name": room },
+        "participant": { "identity": identity },
+    }))
+    .expect("webhook body");
+    let response = reqwest::Client::new()
+        .post(format!("{}/api/v1/livekit/webhook", server.http_base_url()))
+        .header("Authorization", livekit_webhook_auth(&body))
+        .body(body)
+        .send()
+        .await
+        .expect("post LiveKit webhook");
+    assert!(
+        response.status().is_success(),
+        "LiveKit webhook failed: {}",
+        response.status()
+    );
+}
+
+async fn send_muji_session_initiate(client: &mut WsXmppClient, room: &str, sid: &str) {
+    let full_jid = client.full_jid.clone().expect("client bound");
+    client
+        .send(&format!(
+            r#"<iq xmlns="jabber:client" type="set" id="muji-join-{sid}" to="calls.{DOMAIN}">
+                 <jingle xmlns="urn:xmpp:jingle:1" action="session-initiate"
+                         initiator="{full_jid}" sid="{sid}">
+                   <muji xmlns="{NS_MUJI}" room="{room}"/>
+                   <content creator="initiator" name="audio">
+                     <description xmlns="urn:xmpp:jingle:apps:rtp:1" media="audio">
+                       <payload-type id="111" name="opus" clockrate="48000" channels="2"/>
+                     </description>
+                     <transport xmlns="urn:waddle:transports:livekit:0"/>
+                   </content>
+                 </jingle>
+               </iq>"#
+        ))
+        .await
+        .expect("send Muji session-initiate");
+    client
+        .recv_matching(|frame| {
+            (frame.contains("type='result'") && frame.contains(&format!("id='muji-join-{sid}'")))
+                || (frame.contains("type=\"result\"")
+                    && frame.contains(&format!("id=\"muji-join-{sid}\"")))
+        })
+        .await
+        .expect("Muji session-initiate ack");
+    client
+        .recv_matching(|frame| {
+            frame.contains("session-accept") && frame.contains(&format!("sid='{sid}'"))
+        })
+        .await
+        .expect("Muji session-accept");
+}
+
 async fn recv_until_muji_and_anchor(client: &mut WsXmppClient) -> Vec<String> {
     let mut frames = Vec::new();
     tokio::time::timeout(std::time::Duration::from_secs(10), async {
@@ -678,5 +789,129 @@ async fn muji_presence_reflects_to_senders_sibling_resource() {
     assert!(
         muc_user_has_status_110(&leave_element),
         "XEP-0045 §7.1: sibling session still gets <status code='110'/> on a self-driven update: {mobile_leave}"
+    );
+}
+
+#[tokio::test]
+async fn livekit_last_participant_left_fastens_ended_summary_to_call_thread_anchor() {
+    let server = TestServer::start_with_extra_envs(&[], &livekit_test_envs());
+    let admin_pass = server.fixed_account_password().to_string();
+    let mut web =
+        WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, "admin", &admin_pass, "end-web")
+            .await
+            .expect("admin/web connects");
+    let mut mobile = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "admin",
+        &admin_pass,
+        "end-mobile",
+    )
+    .await
+    .expect("admin/mobile connects");
+
+    let room = format!("ended-call-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    let nick = "admin";
+    muji_join_room(&mut web, &room, nick).await;
+    muji_join_room(&mut mobile, &room, nick).await;
+
+    let active = format!(
+        r#"<presence to="{room}/{nick}">
+             <x xmlns="{NS_MUC}"/>
+             <muji xmlns="{NS_MUJI}">
+               <content creator="initiator" name="audio">
+                 <description xmlns="urn:xmpp:jingle:apps:rtp:1" media="audio"/>
+               </content>
+             </muji>
+           </presence>"#
+    );
+    web.send(&active).await.expect("web sends active muji");
+
+    let active_frames = recv_until_muji_and_anchor(&mut mobile).await;
+    let anchor = active_frames
+        .iter()
+        .find(|frame| frame.contains("<call-thread") && frame.contains(NS_CALL_THREAD))
+        .expect("mobile receives call-thread anchor");
+    let anchor_element: Element = anchor
+        .parse()
+        .unwrap_or_else(|err| panic!("anchor must parse as XML: {err}; frame={anchor}"));
+    let anchor_stanza_id = room_stanza_id(&anchor_element, &room)
+        .unwrap_or_else(|| panic!("anchor must carry room-assigned XEP-0359 stanza-id: {anchor}"));
+    assert!(!anchor_stanza_id.is_empty());
+    let anchor_origin_id = origin_id(&anchor_element)
+        .unwrap_or_else(|| panic!("anchor must carry origin-id: {anchor}"));
+
+    mobile
+        .send(&active)
+        .await
+        .expect("mobile also sends active muji");
+    web.recv_matching(|frame| {
+        frame.contains("<presence") && (frame.contains("<muji ") || frame.contains("<muji>"))
+    })
+    .await
+    .expect("web receives mobile active muji reflection");
+    send_muji_session_initiate(&mut web, &room, "web-ended").await;
+    send_muji_session_initiate(&mut mobile, &room, "mobile-ended").await;
+
+    let web_full_jid = web.full_jid.clone().expect("web has full jid");
+    post_participant_left_webhook(&server, &room, &web_full_jid).await;
+    let no_early_ended = tokio::time::timeout(std::time::Duration::from_millis(750), async {
+        mobile
+            .recv_matching(|frame| {
+                frame.contains("<call-thread-ended") && frame.contains("<apply-to")
+            })
+            .await
+    })
+    .await;
+    assert!(
+        no_early_ended.is_err(),
+        "first participant leaving must not emit call-thread-ended while another SFU participant remains"
+    );
+
+    let mobile_full_jid = mobile.full_jid.clone().expect("mobile has full jid");
+    post_participant_left_webhook(&server, &room, &mobile_full_jid).await;
+
+    let ended_frame = web
+        .recv_matching(|frame| frame.contains("<call-thread-ended") && frame.contains("<apply-to"))
+        .await
+        .expect("remaining room occupant receives call-thread-ended fastening");
+    let ended_message: Element = ended_frame
+        .parse()
+        .unwrap_or_else(|err| panic!("ended frame must parse as XML: {err}; frame={ended_frame}"));
+    assert_eq!(ended_message.name(), "message");
+    assert_eq!(ended_message.attr("type"), Some("groupchat"));
+    assert_eq!(ended_message.attr("from"), Some(room.as_str()));
+    let apply_to = apply_to_child(&ended_message)
+        .unwrap_or_else(|| panic!("ended message must carry apply-to: {ended_frame}"));
+    assert_eq!(apply_to.attr("id"), Some(anchor_origin_id.as_str()));
+    let ended = call_thread_ended_child(apply_to)
+        .unwrap_or_else(|| panic!("apply-to must carry call-thread-ended: {ended_frame}"));
+    assert!(
+        ended.attr("ended").is_some(),
+        "ended marker must carry RFC3339 ended timestamp: {ended_frame}"
+    );
+    assert!(ended
+        .attr("duration")
+        .is_some_and(|value| value.starts_with("PT")));
+    assert!(
+        ended_message.get_child("store", "urn:xmpp:hints").is_some(),
+        "ended fastening must carry XEP-0334 <store/> hint: {ended_frame}"
+    );
+
+    let mam_frames = query_room_mam(&mut mobile, &room, "call-thread-ended-mam-1").await;
+    let archived_ended: Vec<&String> = mam_frames
+        .iter()
+        .filter(|frame| frame.contains("<forwarded") && frame.contains("<call-thread-ended"))
+        .collect();
+    assert_eq!(
+        archived_ended.len(),
+        1,
+        "MAM must archive exactly one ended fastening: {mam_frames:?}"
+    );
+    assert!(
+        archived_ended[0].contains(&format!("id='{anchor_origin_id}'"))
+            || archived_ended[0].contains(&format!("id=\"{anchor_origin_id}\"")),
+        "archived ended fastening must target the anchor origin id: {}",
+        archived_ended[0]
     );
 }

--- a/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
@@ -80,7 +80,7 @@ pub(crate) fn call_thread_ended_to_js(
     WaddleCallThreadEnded {
         anchor_id: ended.anchor_id,
         ended: ended.ended.to_rfc3339(),
-        duration: ended.duration,
+        duration: ended.duration.as_str().to_owned(),
     }
 }
 

--- a/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
@@ -74,6 +74,16 @@ pub(crate) fn call_thread_to_js(
     }
 }
 
+pub(crate) fn call_thread_ended_to_js(
+    ended: waddle_xmpp_client::xep::call_thread::CallThreadEnded,
+) -> WaddleCallThreadEnded {
+    WaddleCallThreadEnded {
+        anchor_id: ended.anchor_id,
+        ended: ended.ended.to_rfc3339(),
+        duration: ended.duration,
+    }
+}
+
 pub(crate) fn extension_envelope_to_js(
     envelope: messaging::ExtensionEnvelopeData,
 ) -> WaddleExtensionEnvelope {
@@ -227,6 +237,7 @@ pub(crate) fn inbound_to_js(message: InboundMessage) -> WaddleMessage {
         forum_thread_title,
         is_sticker: message.is_sticker,
         call_thread: message.call_thread.map(call_thread_to_js),
+        call_thread_ended: message.call_thread_ended.map(call_thread_ended_to_js),
         shared_files: message
             .shared_files
             .into_iter()
@@ -352,6 +363,7 @@ pub(crate) fn inbox_push_to_js(
         forum_thread_title: None,
         is_sticker: false,
         call_thread: None,
+        call_thread_ended: None,
         shared_files: Vec::new(),
         link_previews: Vec::new(),
         pin_event: None,
@@ -477,6 +489,9 @@ pub(crate) fn archived_to_js(archived: ArchivedMessage) -> Option<WaddleArchived
         call_thread: parsed
             .and_then(|message| message.call_thread.clone())
             .map(call_thread_to_js),
+        call_thread_ended: parsed
+            .and_then(|message| message.call_thread_ended.clone())
+            .map(call_thread_ended_to_js),
         shared_files: parsed
             .map(|message| {
                 message
@@ -1091,6 +1106,38 @@ mod inbound_to_js_tests {
         assert_eq!(anchor.media, vec!["audio".to_owned(), "video".to_owned()]);
         assert_eq!(anchor.initiator, "alice@waddle.test");
         assert_eq!(anchor.started, "2026-06-07T14:30:00+00:00");
+    }
+
+    #[test]
+    fn archived_to_js_preserves_call_thread_ended_for_room_reload() {
+        let archived = parse_mam_archived(
+            "<message xmlns='jabber:client'>\
+               <result xmlns='urn:xmpp:mam:2' id='mam-ended' queryid='q1'>\
+                 <forwarded xmlns='urn:xmpp:forward:0'>\
+                   <delay xmlns='urn:xmpp:delay' stamp='2026-06-07T14:35:00Z'/>\
+                   <message xmlns='jabber:client' type='groupchat' id='ended-1' \
+                            from='general@muc.waddle.test' to='alice@waddle.test/web'>\
+                     <apply-to xmlns='urn:xmpp:fasten:0' id='anchor-stanza-id'>\
+                       <call-thread-ended xmlns='urn:waddle:call-thread:0' \
+                                          ended='2026-06-07T14:35:00Z' \
+                                          duration='PT5M'/>\
+                     </apply-to>\
+                     <store xmlns='urn:xmpp:hints'/>\
+                   </message>\
+                 </forwarded>\
+               </result>\
+             </message>",
+        );
+
+        let js = archived_to_js(archived).expect("call-thread-ended MAM row should convert");
+        let ended = js
+            .call_thread_ended
+            .expect("call-thread-ended should survive archive conversion");
+
+        assert_eq!(js.mam_id, "mam-ended");
+        assert_eq!(ended.anchor_id, "anchor-stanza-id");
+        assert_eq!(ended.ended, "2026-06-07T14:35:00+00:00");
+        assert_eq!(ended.duration, "PT5M");
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -24,6 +24,13 @@ pub struct WaddleCallThreadAnchor {
 }
 
 #[derive(Debug, Serialize)]
+pub struct WaddleCallThreadEnded {
+    pub anchor_id: String,
+    pub ended: String,
+    pub duration: String,
+}
+
+#[derive(Debug, Serialize)]
 pub struct WaddleMessage {
     pub id: Option<String>,
     pub from: Option<String>,
@@ -66,6 +73,8 @@ pub struct WaddleMessage {
     /// urn:waddle:call-thread:0 room call-thread anchor.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub call_thread: Option<WaddleCallThreadAnchor>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub call_thread_ended: Option<WaddleCallThreadEnded>,
     pub shared_files: Vec<WaddleSharedFile>,
     pub link_previews: Vec<WaddleLinkPreview>,
     /// urn:waddle:pin:0 pin/unpin event surfaced from a system message
@@ -302,6 +311,8 @@ pub struct WaddleArchivedMessage {
     /// urn:waddle:call-thread:0 room call-thread anchor.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub call_thread: Option<WaddleCallThreadAnchor>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub call_thread_ended: Option<WaddleCallThreadEnded>,
     pub shared_files: Vec<WaddleSharedFile>,
     pub link_previews: Vec<WaddleLinkPreview>,
     pub extension_envelope: Option<WaddleExtensionEnvelope>,

--- a/server/crates/waddle-xmpp-client/src/messaging/parsing/mod.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/parsing/mod.rs
@@ -129,6 +129,7 @@ fn parse_message(el: &Element) -> Option<InboundMessage> {
     });
     let pubsub_events = crate::pubsub_event::parse_pubsub_events(el);
     let call_thread = xep_call_thread::parse_call_thread_anchor_child(el);
+    let call_thread_ended = xep_call_thread::parse_call_thread_ended_child(el);
 
     let reply_marker = xep_reply::parse_reply(el);
     let reply_to_id = reply_marker.as_ref().map(|m| m.id.clone());
@@ -354,6 +355,7 @@ fn parse_message(el: &Element) -> Option<InboundMessage> {
         thread_id,
         parent_thread_id,
         call_thread,
+        call_thread_ended,
         is_sticker,
         pin_event,
         extension_envelope,

--- a/server/crates/waddle-xmpp-client/src/messaging/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/tests.rs
@@ -367,7 +367,7 @@ fn parse_message_with_call_thread_ended_fastening() {
 
     assert_eq!(ended.anchor_id, "anchor-stanza-id");
     assert_eq!(ended.ended.to_rfc3339(), "2026-06-07T14:35:00+00:00");
-    assert_eq!(ended.duration, "PT5M");
+    assert_eq!(ended.duration.as_str(), "PT5M");
 }
 
 #[test]

--- a/server/crates/waddle-xmpp-client/src/messaging/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/tests.rs
@@ -353,6 +353,24 @@ fn parse_message_with_call_thread_anchor() {
 }
 
 #[test]
+fn parse_message_with_call_thread_ended_fastening() {
+    let e = el("<message xmlns='jabber:client' from='room@muc.example' type='groupchat'>\
+         <apply-to xmlns='urn:xmpp:fasten:0' id='anchor-stanza-id'>\
+           <call-thread-ended xmlns='urn:waddle:call-thread:0' ended='2026-06-07T14:35:00Z' duration='PT5M'/>\
+         </apply-to>\
+         <store xmlns='urn:xmpp:hints'/>\
+         </message>");
+    let MessagingEvent::Message(msg) = parse(&e).unwrap() else {
+        panic!("expected Message");
+    };
+    let ended = msg.call_thread_ended.expect("call-thread-ended marker");
+
+    assert_eq!(ended.anchor_id, "anchor-stanza-id");
+    assert_eq!(ended.ended.to_rfc3339(), "2026-06-07T14:35:00+00:00");
+    assert_eq!(ended.duration, "PT5M");
+}
+
+#[test]
 fn parse_message_with_retract() {
     let e = el("<message xmlns='jabber:client' type='groupchat'>\
          <retract xmlns='urn:xmpp:message-retract:1' id='old-msg-id'/>\

--- a/server/crates/waddle-xmpp-client/src/messaging/types.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/types.rs
@@ -169,6 +169,8 @@ pub struct InboundMessage {
     /// urn:waddle:call-thread:0 call anchor authored by the room.
     /// `None` when the message carries no `<call-thread/>` payload.
     pub call_thread: Option<crate::xep::call_thread::CallThreadAnchor>,
+    /// urn:waddle:call-thread:0 ended fastening targeting a call-thread anchor.
+    pub call_thread_ended: Option<crate::xep::call_thread::CallThreadEnded>,
     pub is_sticker: bool,
     /// urn:waddle:pin:0 pin/unpin system event surfaced by the room.
     /// `None` when the message carries no `<pin-event/>` payload.

--- a/server/crates/waddle-xmpp-client/src/xep/call_thread.rs
+++ b/server/crates/waddle-xmpp-client/src/xep/call_thread.rs
@@ -48,6 +48,13 @@ pub struct CallThreadAnchor {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CallThreadEnded {
+    pub anchor_id: String,
+    pub ended: DateTime<Utc>,
+    pub duration: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CallThreadParseError {
     NotCallThread,
     MissingAttribute(&'static str),
@@ -55,6 +62,8 @@ pub enum CallThreadParseError {
     InvalidMedia,
     InvalidInitiator,
     InvalidStarted,
+    InvalidEnded,
+    InvalidDuration,
 }
 
 pub fn build_call_thread_anchor(anchor: &CallThreadAnchor) -> Element {
@@ -121,6 +130,36 @@ pub fn parse_call_thread_anchor_child(message: &Element) -> Option<CallThreadAnc
         .and_then(|child| parse_call_thread_anchor(child).ok())
 }
 
+pub fn parse_call_thread_ended_child(message: &Element) -> Option<CallThreadEnded> {
+    let apply_to = message.get_child("apply-to", "urn:xmpp:fasten:0")?;
+    let anchor_id = required_attr(apply_to, "id").ok()?.to_string();
+    let ended = apply_to
+        .get_child("call-thread-ended", NS_WADDLE_CALL_THREAD)
+        .and_then(|child| parse_call_thread_ended(child, anchor_id).ok())?;
+    Some(ended)
+}
+
+fn parse_call_thread_ended(
+    element: &Element,
+    anchor_id: String,
+) -> Result<CallThreadEnded, CallThreadParseError> {
+    if element.name() != "call-thread-ended" || element.ns() != NS_WADDLE_CALL_THREAD {
+        return Err(CallThreadParseError::NotCallThread);
+    }
+    let ended = DateTime::parse_from_rfc3339(required_attr(element, "ended")?)
+        .map_err(|_| CallThreadParseError::InvalidEnded)?
+        .with_timezone(&Utc);
+    let duration = required_attr(element, "duration")?;
+    if !is_valid_call_thread_duration(duration) {
+        return Err(CallThreadParseError::InvalidDuration);
+    }
+    Ok(CallThreadEnded {
+        anchor_id,
+        ended,
+        duration: duration.to_string(),
+    })
+}
+
 fn media_attr(media: CallThreadMedia) -> Result<&'static str, CallThreadParseError> {
     match (media.audio, media.video) {
         (true, true) => Ok("audio video"),
@@ -153,6 +192,29 @@ fn parse_media(value: &str) -> Result<CallThreadMedia, CallThreadParseError> {
         return Err(CallThreadParseError::InvalidMedia);
     }
     Ok(CallThreadMedia { audio, video })
+}
+
+fn is_valid_call_thread_duration(value: &str) -> bool {
+    if !value.starts_with("PT") || value.len() <= 2 {
+        return false;
+    }
+    let mut chars = value[2..].chars().peekable();
+    let mut saw_component = false;
+    while chars.peek().is_some() {
+        let mut saw_digit = false;
+        while chars.peek().is_some_and(|c| c.is_ascii_digit()) {
+            saw_digit = true;
+            chars.next();
+        }
+        if !saw_digit {
+            return false;
+        }
+        match chars.next() {
+            Some('H' | 'M' | 'S') => saw_component = true,
+            _ => return false,
+        }
+    }
+    saw_component
 }
 
 #[cfg(test)]

--- a/server/crates/waddle-xmpp-client/src/xep/call_thread.rs
+++ b/server/crates/waddle-xmpp-client/src/xep/call_thread.rs
@@ -51,7 +51,24 @@ pub struct CallThreadAnchor {
 pub struct CallThreadEnded {
     pub anchor_id: String,
     pub ended: DateTime<Utc>,
-    pub duration: String,
+    pub duration: CallThreadDuration,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CallThreadDuration(String);
+
+impl CallThreadDuration {
+    pub fn parse(value: &str) -> Result<Self, CallThreadParseError> {
+        if is_valid_call_thread_duration(value) {
+            Ok(Self(value.to_owned()))
+        } else {
+            Err(CallThreadParseError::InvalidDuration)
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -149,14 +166,11 @@ fn parse_call_thread_ended(
     let ended = DateTime::parse_from_rfc3339(required_attr(element, "ended")?)
         .map_err(|_| CallThreadParseError::InvalidEnded)?
         .with_timezone(&Utc);
-    let duration = required_attr(element, "duration")?;
-    if !is_valid_call_thread_duration(duration) {
-        return Err(CallThreadParseError::InvalidDuration);
-    }
+    let duration = CallThreadDuration::parse(required_attr(element, "duration")?)?;
     Ok(CallThreadEnded {
         anchor_id,
         ended,
-        duration: duration.to_string(),
+        duration,
     })
 }
 

--- a/server/crates/waddle-xmpp/src/xep/exports.rs
+++ b/server/crates/waddle-xmpp/src/xep/exports.rs
@@ -355,8 +355,10 @@ pub use super::xep_waddle_pin::{
 };
 
 pub use super::xep_waddle_call_thread::{
-    build_call_thread_anchor, parse_call_thread_anchor, parse_call_thread_anchor_child,
-    CallThreadAnchor, CallThreadKind, CallThreadMedia, CallThreadParseError, NS_WADDLE_CALL_THREAD,
+    build_call_thread_anchor, build_call_thread_ended, parse_call_thread_anchor,
+    parse_call_thread_anchor_child, parse_call_thread_ended, parse_call_thread_ended_child,
+    CallThreadAnchor, CallThreadDuration, CallThreadEnded, CallThreadKind, CallThreadMedia,
+    CallThreadParseError, NS_FASTEN, NS_WADDLE_CALL_THREAD,
 };
 
 pub use waddle_xmpp_core::xep0472::{

--- a/server/crates/waddle-xmpp/src/xep/xep_waddle_call_thread.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep_waddle_call_thread.rs
@@ -187,9 +187,6 @@ pub fn parse_call_thread_ended_child(message: &Message) -> Option<CallThreadEnde
 }
 
 fn call_thread_ended_payload(payload: &Element) -> Option<&Element> {
-    if payload.name() == "call-thread-ended" && payload.ns() == NS_WADDLE_CALL_THREAD {
-        return Some(payload);
-    }
     if payload.name() != "apply-to" || payload.ns() != NS_FASTEN {
         return None;
     }

--- a/server/crates/waddle-xmpp/src/xep/xep_waddle_call_thread.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep_waddle_call_thread.rs
@@ -10,6 +10,7 @@ use xmpp_parsers::jingle::SessionId;
 use xmpp_parsers::message::Message;
 
 pub const NS_WADDLE_CALL_THREAD: &str = "urn:waddle:call-thread:0";
+pub const NS_FASTEN: &str = "urn:xmpp:fasten:0";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CallThreadKind {
@@ -49,6 +50,29 @@ pub struct CallThreadAnchor {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CallThreadDuration(String);
+
+impl CallThreadDuration {
+    pub fn parse(value: &str) -> Result<Self, CallThreadParseError> {
+        if is_valid_call_thread_duration(value) {
+            Ok(Self(value.to_owned()))
+        } else {
+            Err(CallThreadParseError::InvalidDuration)
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CallThreadEnded {
+    pub ended: DateTime<Utc>,
+    pub duration: CallThreadDuration,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CallThreadParseError {
     NotCallThread,
     MissingAttribute(&'static str),
@@ -56,6 +80,8 @@ pub enum CallThreadParseError {
     InvalidMedia,
     InvalidInitiator,
     InvalidStarted,
+    InvalidEnded,
+    InvalidDuration,
 }
 
 pub fn build_call_thread_anchor(anchor: &CallThreadAnchor) -> Element {
@@ -116,12 +142,60 @@ pub fn parse_call_thread_anchor(
     })
 }
 
+pub fn build_call_thread_ended(ended: &CallThreadEnded) -> Element {
+    Element::builder("call-thread-ended", NS_WADDLE_CALL_THREAD)
+        .attr(
+            minidom::rxml::xml_ncname!("ended").to_owned(),
+            ended
+                .ended
+                .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        )
+        .attr(
+            minidom::rxml::xml_ncname!("duration").to_owned(),
+            ended.duration.as_str(),
+        )
+        .build()
+}
+
+pub fn parse_call_thread_ended(element: &Element) -> Result<CallThreadEnded, CallThreadParseError> {
+    if element.name() != "call-thread-ended" || element.ns() != NS_WADDLE_CALL_THREAD {
+        return Err(CallThreadParseError::NotCallThread);
+    }
+
+    let ended = DateTime::parse_from_rfc3339(required_attr(element, "ended")?)
+        .map_err(|_| CallThreadParseError::InvalidEnded)?
+        .with_timezone(&Utc);
+    let duration = CallThreadDuration::parse(required_attr(element, "duration")?)?;
+
+    Ok(CallThreadEnded { ended, duration })
+}
+
 pub fn parse_call_thread_anchor_child(message: &Message) -> Option<CallThreadAnchor> {
     message
         .payloads
         .iter()
         .find(|payload| payload.name() == "call-thread" && payload.ns() == NS_WADDLE_CALL_THREAD)
         .and_then(|payload| parse_call_thread_anchor(payload).ok())
+}
+
+pub fn parse_call_thread_ended_child(message: &Message) -> Option<CallThreadEnded> {
+    message
+        .payloads
+        .iter()
+        .find_map(call_thread_ended_payload)
+        .and_then(|payload| parse_call_thread_ended(payload).ok())
+}
+
+fn call_thread_ended_payload(payload: &Element) -> Option<&Element> {
+    if payload.name() == "call-thread-ended" && payload.ns() == NS_WADDLE_CALL_THREAD {
+        return Some(payload);
+    }
+    if payload.name() != "apply-to" || payload.ns() != NS_FASTEN {
+        return None;
+    }
+    payload
+        .children()
+        .find(|child| child.name() == "call-thread-ended" && child.ns() == NS_WADDLE_CALL_THREAD)
 }
 
 fn media_attr(media: CallThreadMedia) -> &'static str {
@@ -158,6 +232,30 @@ fn parse_media(value: &str) -> Result<CallThreadMedia, CallThreadParseError> {
         return Err(CallThreadParseError::InvalidMedia);
     }
     Ok(CallThreadMedia { audio, video })
+}
+
+fn is_valid_call_thread_duration(value: &str) -> bool {
+    if !value.starts_with("PT") || value.len() <= 2 {
+        return false;
+    }
+
+    let mut chars = value[2..].chars().peekable();
+    let mut saw_component = false;
+    while chars.peek().is_some() {
+        let mut saw_digit = false;
+        while chars.peek().is_some_and(|c| c.is_ascii_digit()) {
+            saw_digit = true;
+            chars.next();
+        }
+        if !saw_digit {
+            return false;
+        }
+        match chars.next() {
+            Some('H' | 'M' | 'S') => saw_component = true,
+            _ => return false,
+        }
+    }
+    saw_component
 }
 
 #[cfg(test)]

--- a/server/crates/waddle-xmpp/tests/xep_waddle_call_thread.rs
+++ b/server/crates/waddle-xmpp/tests/xep_waddle_call_thread.rs
@@ -6,10 +6,13 @@
 use chrono::{DateTime, Utc};
 use minidom::Element;
 use waddle_xmpp::xep::{
-    build_call_thread_anchor, parse_call_thread_anchor, CallThreadAnchor, CallThreadKind,
-    CallThreadMedia, CallThreadParseError, NS_WADDLE_CALL_THREAD,
+    build_call_thread_anchor, build_call_thread_ended, parse_call_thread_anchor,
+    parse_call_thread_ended, parse_call_thread_ended_child, CallThreadAnchor, CallThreadDuration,
+    CallThreadEnded, CallThreadKind, CallThreadMedia, CallThreadParseError, NS_FASTEN,
+    NS_WADDLE_CALL_THREAD,
 };
 use xmpp_parsers::jingle::SessionId;
+use xmpp_parsers::message::Message;
 
 fn anchor(media: CallThreadMedia) -> CallThreadAnchor {
     CallThreadAnchor {
@@ -58,6 +61,48 @@ fn call_thread_marker_round_trips_video_only_media() {
         parse_call_thread_anchor(&element).expect("marker parses"),
         original
     );
+}
+
+#[test]
+fn call_thread_ended_round_trips_duration_summary() {
+    let original = CallThreadEnded {
+        ended: "2026-06-07T14:35:00Z"
+            .parse::<DateTime<Utc>>()
+            .expect("ended"),
+        duration: CallThreadDuration::parse("PT5M").expect("duration"),
+    };
+
+    let element = build_call_thread_ended(&original);
+
+    assert_eq!(element.name(), "call-thread-ended");
+    assert_eq!(element.ns(), NS_WADDLE_CALL_THREAD);
+    assert_eq!(element.attr("ended"), Some("2026-06-07T14:35:00Z"));
+    assert_eq!(element.attr("duration"), Some("PT5M"));
+    assert_eq!(
+        parse_call_thread_ended(&element).expect("ended marker parses"),
+        original
+    );
+}
+
+#[test]
+fn call_thread_ended_child_parses_xep0422_fastening_shape() {
+    let expected = CallThreadEnded {
+        ended: "2026-06-07T14:35:00Z"
+            .parse::<DateTime<Utc>>()
+            .expect("ended"),
+        duration: CallThreadDuration::parse("PT5M").expect("duration"),
+    };
+    let apply_to = Element::builder("apply-to", NS_FASTEN)
+        .attr(
+            minidom::rxml::xml_ncname!("id").to_owned(),
+            "anchor-origin-id",
+        )
+        .append(build_call_thread_ended(&expected))
+        .build();
+    let mut message = Message::new(None);
+    message.payloads.push(apply_to);
+
+    assert_eq!(parse_call_thread_ended_child(&message), Some(expected));
 }
 
 #[test]

--- a/server/crates/waddle-xmpp/tests/xep_waddle_call_thread.rs
+++ b/server/crates/waddle-xmpp/tests/xep_waddle_call_thread.rs
@@ -106,6 +106,20 @@ fn call_thread_ended_child_parses_xep0422_fastening_shape() {
 }
 
 #[test]
+fn call_thread_ended_child_rejects_bare_payload_without_fastening() {
+    let ended = CallThreadEnded {
+        ended: "2026-06-07T14:35:00Z"
+            .parse::<DateTime<Utc>>()
+            .expect("ended"),
+        duration: CallThreadDuration::parse("PT5M").expect("duration"),
+    };
+    let mut message = Message::new(None);
+    message.payloads.push(build_call_thread_ended(&ended));
+
+    assert_eq!(parse_call_thread_ended_child(&message), None);
+}
+
+#[test]
 #[should_panic(expected = "call-thread marker requires audio or video media")]
 fn call_thread_marker_builder_rejects_empty_media() {
     let _ = build_call_thread_anchor(&anchor(CallThreadMedia {

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=9ccb9b272957";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=9ccb9b272957";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=9ccb9b272957";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=5977aa9a09a1";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=5977aa9a09a1";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=5977aa9a09a1";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=9ccb9b272957";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=5977aa9a09a1";


### PR DESCRIPTION
## Summary

Implements #918.

- Adds typed `call-thread-ended` support to the Rust XMPP codec, Rust client parser, WASM bridge, and chat message codecs.
- Emits a MUC call-ended record when the SFU participant set becomes empty from LiveKit webhook cleanup, Muji IQ cleanup, or XMPP-native Muji presence clear.
- Fastens the ended record to the call-thread anchor with XEP-0422 `<apply-to/>` targeting the anchor XEP-0359 `<origin-id/>`, includes `<store/>`, and archives through room MAM.
- Folds live and archived ended fastenings back into the existing timeline anchor so the call row renders `Call ended · <duration>` instead of a joinable active-call row.
- Keeps call-thread tracking disabled when no SFU bridge is configured, and restores the root `cuenv.lock` runtime entries that CI regenerates.

## Plan

1. Add typed server/client codecs for `<call-thread-ended ended=... duration=.../>`.
2. Track active MUC call anchors and their origin-id/start time only while SFU-backed call teardown can consume that state.
3. On participant departure, clear Muji state and emit the ended fastening only after the SFU participant set is empty.
4. Map the new control payload through WASM and chat timeline merge/replay paths.
5. Add regression coverage for codec round-trips, last-participant behavior, XMPP-native presence clear, MAM archive replay, and UI label rendering.
6. Address PR review feedback by rejecting bare ended payloads, using a validated Rust client duration newtype, and clarifying `apply-to@id` docs.

## Verification

- `cargo test -p waddle-xmpp --test xep_waddle_call_thread`
- `cargo test -p waddle-server --test calls_e2e_ws livekit_last_participant_left_fastens_ended_summary_to_call_thread_anchor -- --nocapture`
- `cargo test -p waddle-server empty_muji_presence`
- `cargo test -p waddle-xmpp-client call_thread`
- `cargo test -p waddle-xmpp-client-wasm call_thread -- --nocapture`
- `bun test tests/tombstone-replay.test.ts tests/call-thread-anchor.test.ts tests/channel-live-merge.test.ts`
- `bun run lint`
- `cargo clippy -p waddle-server -p waddle-xmpp -p waddle-xmpp-client -p waddle-xmpp-client-wasm -- -D warnings`
- `git diff --check`

## Notes

- The ended fastening targets the anchor `origin-id`, not the room `stanza-id`, to keep the official `urn:xmpp:fasten:0` shape conformant.
- `knip` required no ignores or dependency changes.
- Full workspace tests were not run locally.
