### PR TITLE
feat(chat): live call anchor state + global thread-list call cards (MUC)

### DIFF
--- a/chat/src/components/calls/CallAnchorCard.vue
+++ b/chat/src/components/calls/CallAnchorCard.vue
@@ -68,7 +68,6 @@ function openThread() {
         type="button"
         class="inline-flex h-8 flex-shrink-0 items-center gap-1.5 rounded-md bg-primary px-3 type-control text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         :class="{ 'cursor-not-allowed opacity-60': state.actionDisabled }"
-        :aria-label="state.ariaLabel"
         :disabled="state.actionDisabled"
         @click.stop="joinCall"
       >

--- a/chat/src/components/calls/CallAnchorCard.vue
+++ b/chat/src/components/calls/CallAnchorCard.vue
@@ -23,9 +23,10 @@ const participantSummary = computed(() => {
 const messageCountLabel = computed(() =>
   `${props.state.messageCount} ${props.state.messageCount === 1 ? "message" : "messages"} in call chat`
 );
+const showAction = computed(() => props.state.actionLabel !== null);
 
 function joinCall() {
-  if (!isLive.value) return;
+  if (!isLive.value || props.state.actionDisabled) return;
   emit("join");
 }
 
@@ -63,10 +64,12 @@ function openThread() {
         <p class="type-caption truncate text-muted-foreground">{{ participantSummary }}</p>
       </div>
       <button
-        v-if="isLive"
+        v-if="showAction"
         type="button"
         class="inline-flex h-8 flex-shrink-0 items-center gap-1.5 rounded-md bg-primary px-3 type-control text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        :class="{ 'cursor-not-allowed opacity-60': state.actionDisabled }"
         :aria-label="state.ariaLabel"
+        :disabled="state.actionDisabled"
         @click.stop="joinCall"
       >
         <component :is="MediaIcon" class="h-3.5 w-3.5" aria-hidden="true" />

--- a/chat/src/components/calls/CallAnchorCard.vue
+++ b/chat/src/components/calls/CallAnchorCard.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { MessageSquare, Phone, Video } from "lucide-vue-next";
+import type { CallAnchorCardState } from "@/lib/call-thread-anchor";
+
+const props = defineProps<{
+  state: CallAnchorCardState;
+}>();
+
+const emit = defineEmits<{
+  join: [];
+  openThread: [threadId: string];
+}>();
+
+const isLive = computed(() => props.state.status === "live");
+const MediaIcon = computed(() => props.state.media.video ? Video : Phone);
+const participantSummary = computed(() => {
+  if (props.state.participantLabels.length === 0) return "No one connected";
+  const visible = props.state.participantLabels.slice(0, 3).join(", ");
+  const extra = props.state.participantLabels.length - 3;
+  return extra > 0 ? `${visible} +${extra}` : visible;
+});
+const messageCountLabel = computed(() =>
+  `${props.state.messageCount} ${props.state.messageCount === 1 ? "message" : "messages"} in call chat`
+);
+
+function joinCall() {
+  if (!isLive.value) return;
+  emit("join");
+}
+
+function openThread() {
+  if (!props.state.threadId) return;
+  emit("openThread", props.state.threadId);
+}
+</script>
+
+<template>
+  <section
+    class="call-anchor-card rounded-lg border border-border bg-card px-3 py-2.5 shadow-sm"
+    :class="{
+      'call-anchor-card--live border-primary/35 bg-primary/5': isLive,
+      'call-anchor-card--ended opacity-70': !isLive,
+    }"
+    :aria-label="state.ariaLabel"
+  >
+    <div class="flex min-w-0 items-center gap-3">
+      <div class="relative flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border border-border bg-background text-muted-foreground">
+        <span
+          v-if="isLive"
+          class="call-anchor-card__pulse absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full bg-success motion-safe:animate-pulse"
+          aria-hidden="true"
+        />
+        <component :is="MediaIcon" class="h-4 w-4" aria-hidden="true" />
+      </div>
+      <div class="min-w-0 flex-1">
+        <div class="flex min-w-0 items-center gap-2">
+          <p class="type-field-sm truncate text-foreground">{{ state.title }}</p>
+          <span class="type-meta type-numeric text-muted-foreground">
+            {{ state.participantCount }}
+          </span>
+        </div>
+        <p class="type-caption truncate text-muted-foreground">{{ participantSummary }}</p>
+      </div>
+      <button
+        v-if="isLive"
+        type="button"
+        class="inline-flex h-8 flex-shrink-0 items-center gap-1.5 rounded-md bg-primary px-3 type-control text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        :aria-label="state.ariaLabel"
+        @click.stop="joinCall"
+      >
+        <component :is="MediaIcon" class="h-3.5 w-3.5" aria-hidden="true" />
+        <span>{{ state.actionLabel }}</span>
+      </button>
+    </div>
+    <button
+      v-if="state.threadId"
+      type="button"
+      class="mt-2 inline-flex max-w-full items-center gap-1.5 type-caption text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      @click.stop="openThread"
+    >
+      <MessageSquare class="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
+      <span class="truncate">{{ messageCountLabel }} ›</span>
+    </button>
+  </section>
+</template>

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -724,6 +724,7 @@ onUnmounted(() => {
         v-else-if="ui.activePage.value === 'threads'"
         :channels="waddles.sortedChannels.value"
         :on-select-thread="onSelectThread"
+        :on-join-channel-call="joinChannelCallFromActivity"
         @open-nav="ui.showMobileNav.value = true"
       />
       <UnreadView

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -941,6 +941,8 @@ onUnmounted(() => {
               :has-older-replies="threadPanelIsDm ? false : (messaging.threadHasOlder.value[activeThreadStack[activeThreadStack.length - 2] ?? ''] ?? false)"
               :upload-progress="{ uploading: false, progress: 0, filename: '' }"
               :channel-name="threadPanelIsDm ? (activeDmPeer?.peerUsername ?? '') : (waddles.currentChannel.value?.name ?? '')"
+              :channel-id="threadPanelIsDm ? null : (waddles.currentChannel.value?.id ?? null)"
+              :room-jid="threadPanelIsDm ? null : activeChannelRoomJid"
               :hide-composer="true"
               :reaction-mode="null"
               :link-preview-lookup="lookupActiveConversationLinkPreview"
@@ -954,6 +956,7 @@ onUnmounted(() => {
               :invoke-extension-action="invokeActiveExtensionAction"
               @displayed="markActiveDisplayed"
               @load-older="loadOlderThreadMessages"
+              @join-channel-call="joinChannelCallFromActivity"
             />
           </div>
 
@@ -983,6 +986,8 @@ onUnmounted(() => {
               :has-older-replies="threadPanelIsDm ? false : (messaging.threadHasOlder.value[activeThreadStack[activeThreadStack.length - 1] ?? ''] ?? false)"
               :upload-progress="activeUploadProgress"
               :channel-name="threadPanelIsDm ? (activeDmPeer?.peerUsername ?? '') : (waddles.currentChannel.value?.name ?? '')"
+              :channel-id="threadPanelIsDm ? null : (waddles.currentChannel.value?.id ?? null)"
+              :room-jid="threadPanelIsDm ? null : activeChannelRoomJid"
               :reaction-mode="reactionModeTarget === 'thread' ? reactionModeState : null"
               :target-message-id="activeThreadTargetMessageId"
               :link-preview-lookup="lookupActiveConversationLinkPreview"
@@ -999,6 +1004,7 @@ onUnmounted(() => {
               @select-gif="sendGif"
               @typing="notifyActiveComposing"
               @load-older="loadOlderThreadMessages"
+              @join-channel-call="joinChannelCallFromActivity"
             />
           </div>
 

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -1375,6 +1375,8 @@ function dayDividerLabel(createdAt: string): string {
             :can-pin-messages="currentUserCanPin"
             :link-preview-lookup="linkPreviewLookup"
             :link-preview-scope="linkPreviewScope"
+            :call-room-jid="callRoomJid"
+            :call-channel-id="channel?.id ?? null"
             @edit="(id, body, m, r, lp) => emit('editMessage', id, body, m, r, lp)"
             @retract="(id) => emit('retractMessage', id)"
             @react="(id, emoji) => emit('reactMessage', id, emoji)"
@@ -1382,6 +1384,7 @@ function dayDividerLabel(createdAt: string): string {
             @scroll-to-message="scrollToMessage"
             @avatar-click="onAvatarClick"
             @open-thread="(tid: string) => emit('openThread', tid)"
+            @join-channel-call="(channelId, roomJid, media) => emit('joinChannelCall', channelId, roomJid, media)"
             @pin="(id: string) => emit('pinMessage', id)"
             @unpin="(id: string) => emit('unpinMessage', id)"
           />

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -23,6 +23,7 @@ import {
 } from "lucide-vue-next";
 import type { JSONContent } from "@tiptap/core";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
+import CallAnchorCard from "@/components/calls/CallAnchorCard.vue";
 import ChatEditor from "@/components/chat/ChatEditor.vue";
 import MessageBody from "@/components/chat/MessageBody.vue";
 import EditorBubbleToolbar from "@/components/chat/EditorBubbleToolbar.vue";
@@ -52,7 +53,8 @@ import {
   clearDesktopToolbarOwner,
 } from "@/stores/message-toolbar";
 import { QUICK_REACTION_EMOJIS } from "@/lib/reaction-mode";
-import { callThreadAnchorLabel, callThreadAnchorThreadId } from "@/lib/call-thread-anchor";
+import { callThreadAnchorLabel, callThreadAnchorThreadId, useCallAnchorCardState } from "@/lib/call-thread-anchor";
+import type { CallMedia } from "@/lib/calls/types";
 
 // Two separate badge layers:
 //
@@ -169,6 +171,8 @@ const props = defineProps<{
   canPinMessages?: boolean;
   linkPreviewLookup?: ComposerLinkPreviewLookup | null;
   linkPreviewScope?: string | null;
+  callRoomJid?: string | null;
+  callChannelId?: string | null;
 }>();
 
 const emit = defineEmits<{
@@ -179,6 +183,7 @@ const emit = defineEmits<{
   scrollToMessage: [messageId: string];
   avatarClick: [author: string];
   openThread: [threadId: string];
+  joinChannelCall: [channelId: string | null, roomJid: string, media: CallMedia];
   pin: [messageId: string];
   unpin: [messageId: string];
 }>();
@@ -366,10 +371,21 @@ function formatThreadRecency(iso: string | undefined): string {
 const threadChipRecency = computed(() => formatThreadRecency(props.threadLastReplyAt));
 const callThreadLabel = computed(() => callThreadAnchorLabel(props.message));
 const callThreadId = computed(() => callThreadAnchorThreadId(props.message));
+const callAnchorCardState = useCallAnchorCardState(
+  () => props.message,
+  () => props.callRoomJid,
+  () => props.threadReplyCount ?? 0,
+);
 
 function openCallThreadAnchor() {
   if (!callThreadId.value) return;
   emit("openThread", callThreadId.value);
+}
+
+function joinCallThreadAnchor() {
+  const state = callAnchorCardState.value;
+  if (!state || !props.callRoomJid || state.status !== "live") return;
+  emit("joinChannelCall", props.callChannelId ?? null, props.callRoomJid, state.media);
 }
 
 function togglePinFromMenu() {
@@ -911,7 +927,14 @@ onBeforeUnmount(() => {
       <PhoneCall class="w-4 h-4" aria-hidden="true" />
     </div>
     <div class="chat-message-body-stack">
+      <CallAnchorCard
+        v-if="callAnchorCardState"
+        :state="callAnchorCardState"
+        @join="joinCallThreadAnchor"
+        @open-thread="openCallThreadAnchor"
+      />
       <button
+        v-else
         type="button"
         class="type-field-sm inline-flex items-center gap-1.5 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         :disabled="!callThreadId"

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -173,6 +173,7 @@ const props = defineProps<{
   linkPreviewScope?: string | null;
   callRoomJid?: string | null;
   callChannelId?: string | null;
+  hideCallAnchorCard?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -919,7 +920,7 @@ onBeforeUnmount(() => {
   </template>
 
   <div
-    v-else-if="message.callThread"
+    v-else-if="message.callThread && !hideCallAnchorCard"
     :data-message-id="message.id"
     :data-message-created-at="message.createdAt"
     class="chat-message-grid relative animate-message-in"

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -333,8 +333,9 @@ function onReplyChipClick() {
   emit("scrollToMessage", replyTo.id);
 }
 
+const threadReplyCountValue = computed(() => props.threadReplyCount ?? 0);
 const showThreadChip = computed(
-  () => !props.hideThreadChip && (props.threadReplyCount ?? 0) > 0,
+  () => !props.hideThreadChip && threadReplyCountValue.value > 0,
 );
 
 function openThreadFromChip() {
@@ -374,7 +375,7 @@ const callThreadId = computed(() => callThreadAnchorThreadId(props.message));
 const callAnchorCardState = useCallAnchorCardState(
   () => props.message,
   () => props.callRoomJid,
-  () => props.threadReplyCount ?? 0,
+  () => threadReplyCountValue.value,
 );
 
 function openCallThreadAnchor() {
@@ -1221,7 +1222,7 @@ onBeforeUnmount(() => {
       v-if="showThreadChip"
       type="button"
       class="chat-thread-chip type-caption flex w-full items-center rounded-md py-0.5 text-primary/85 transition-colors hover:text-primary"
-      :title="`Open thread (${threadReplyCount} ${threadReplyCount === 1 ? 'reply' : 'replies'})`"
+      :title="`Open thread (${threadReplyCountValue} ${threadReplyCountValue === 1 ? 'reply' : 'replies'})`"
       @click="openThreadFromChip"
     >
       <span
@@ -1246,7 +1247,7 @@ onBeforeUnmount(() => {
           class="chat-thread-chip__overflow"
         >+{{ threadParticipantOverflow }}</span>
       </span>
-      <span class="chat-thread-chip__count min-w-0 truncate">{{ threadReplyCount }} {{ threadReplyCount === 1 ? "reply" : "replies" }}</span>
+      <span class="chat-thread-chip__count min-w-0 truncate">{{ threadReplyCountValue }} {{ threadReplyCountValue === 1 ? "reply" : "replies" }}</span>
       <span v-if="threadChipRecency" class="chat-thread-chip__recency">{{ threadChipRecency }}</span>
     </button>
 
@@ -1338,8 +1339,8 @@ onBeforeUnmount(() => {
       <button
         type="button"
         class="chat-hover-action-toolbar-btn h-8 w-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted"
-        :title="threadReplyCount > 0 ? 'Open thread' : 'Reply in thread'"
-        :aria-label="threadReplyCount > 0 ? 'Open thread' : 'Reply in thread'"
+        :title="threadReplyCountValue > 0 ? 'Open thread' : 'Reply in thread'"
+        :aria-label="threadReplyCountValue > 0 ? 'Open thread' : 'Reply in thread'"
         @click="startReplyInThreadFromMenu"
       >
         <MessageSquare class="w-4 h-4" aria-hidden="true" />
@@ -1455,7 +1456,7 @@ onBeforeUnmount(() => {
             @click="startReplyInThreadFromMenu"
           >
             <MessageSquare class="w-5 h-5 text-muted-foreground" aria-hidden="true" />
-            <span>{{ (threadReplyCount ?? 0) > 0 ? "Open thread" : "Reply in thread" }}</span>
+            <span>{{ threadReplyCountValue > 0 ? "Open thread" : "Reply in thread" }}</span>
           </button>
           <button
             v-if="canPinMessages && message.id"

--- a/chat/src/components/chat/ThreadPanel.vue
+++ b/chat/src/components/chat/ThreadPanel.vue
@@ -3,6 +3,7 @@ import { computed, nextTick, onBeforeUnmount, ref, watch, type ComponentPublicIn
 import { ArrowDown, ArrowUp, X, CornerDownRight, ChevronRight, ChevronLeft } from "lucide-vue-next";
 import { useJumpToLiveEdge } from "@/ui/use-jump-to-live-edge";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
+import CallAnchorCard from "@/components/calls/CallAnchorCard.vue";
 import MessageCard from "@/components/chat/MessageCard.vue";
 import MessageComposer from "@/components/chat/MessageComposer.vue";
 import VirtualTimeline from "@/components/chat/VirtualTimeline.vue";
@@ -20,6 +21,8 @@ import {
 import { createPinnedEdgeScroller } from "@/lib/pinned-edge-scroll";
 import { useChatWindowVisibility } from "@/shell/window-visibility";
 import { formatTimelineDayDivider, isSameTimelineDay } from "@/channels/timeline";
+import { useCallAnchorCardState } from "@/lib/call-thread-anchor";
+import type { CallMedia } from "@/lib/calls/types";
 
 const props = defineProps<{
   threadStack: string[];
@@ -46,6 +49,8 @@ const props = defineProps<{
   hasOlderReplies?: boolean;
   uploadProgress: { uploading: boolean; progress: number; filename: string };
   channelName: string;
+  channelId?: string | null;
+  roomJid?: string | null;
   reactionMode?: { selectedMessageId: string | null } | null;
   targetMessageId?: string | null;
   /**
@@ -84,6 +89,7 @@ const emit = defineEmits<{
   // and peers can show "typing in thread X" instead of channel-wide.
   typing: [threadOverride?: { threadId: string; parentThreadId?: string }];
   loadOlder: [threadId: string];
+  joinChannelCall: [channelId: string | null, roomJid: string, media: CallMedia];
 }>();
 
 const { mode: scrollDirectionMode } = useScrollDirectionPreference();
@@ -411,6 +417,11 @@ const breadcrumbLabels = computed(() =>
 // "Thread > author" breadcrumb with: who started it, how many replies,
 // who's been participating, and when activity last happened.
 const threadReplyCount = computed(() => activeEntry.value?.count ?? 0);
+const threadCallAnchorState = useCallAnchorCardState(
+  () => activeEntry.value?.root ?? ({ body: "", author: "", threadId: null } as Pick<TimelineMessage, "body" | "author" | "callThread" | "threadId">),
+  () => props.roomJid,
+  () => threadReplyCount.value,
+);
 
 const threadRootAuthor = computed(() => activeEntry.value?.root?.author ?? null);
 
@@ -574,6 +585,12 @@ function onOpenThreadFromCard(threadId: string) {
   emit("pushThread", threadId);
 }
 
+function joinThreadCallAnchor() {
+  const state = threadCallAnchorState.value;
+  if (!state || !props.roomJid || state.status !== "live") return;
+  emit("joinChannelCall", props.channelId ?? null, props.roomJid, state.media);
+}
+
 function replyChildHasNestedThread(message: TimelineMessage): boolean {
   const entry = props.threadIndex.get(message.id);
   return !!entry && entry.count > 0;
@@ -634,6 +651,14 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
             <X class="w-4 h-4" />
           </button>
         </div>
+      </div>
+      <div v-if="threadCallAnchorState" class="chat-thread-header__row">
+        <CallAnchorCard
+          :state="threadCallAnchorState"
+          class="w-full"
+          @join="joinThreadCallAnchor"
+          @open-thread="onOpenThreadFromCard"
+        />
       </div>
       <div class="chat-thread-header__row chat-thread-header__row--meta">
         <div class="chat-thread-header__meta type-caption">
@@ -764,11 +789,14 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
             :invoke-extension-action="props.invokeExtensionAction"
             :link-preview-lookup="props.linkPreviewLookup"
             :link-preview-scope="props.linkPreviewScope"
+            :call-room-jid="props.roomJid ?? null"
+            :call-channel-id="props.channelId ?? null"
             @edit="(id, body, m, r, lp) => emit('editMessage', id, body, m, r, lp)"
             @retract="(id) => emit('retractMessage', id)"
             @react="(id, emoji) => emit('reactMessage', id, emoji)"
             @reply="beginReplyInThread"
             @open-thread="onOpenThreadFromCard"
+            @join-channel-call="(channelId, roomJid, media) => emit('joinChannelCall', channelId, roomJid, media)"
           />
           <div
             v-if="orderedChildren.length > 0"
@@ -808,11 +836,14 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
               :invoke-extension-action="props.invokeExtensionAction"
               :link-preview-lookup="props.linkPreviewLookup"
               :link-preview-scope="props.linkPreviewScope"
+              :call-room-jid="props.roomJid ?? null"
+              :call-channel-id="props.channelId ?? null"
               @edit="(id, body, m, r, lp) => emit('editMessage', id, body, m, r, lp)"
               @retract="(id) => emit('retractMessage', id)"
               @react="(id, emoji) => emit('reactMessage', id, emoji)"
               @reply="beginReplyInThread"
               @open-thread="onOpenThreadFromCard"
+              @join-channel-call="(channelId, roomJid, media) => emit('joinChannelCall', channelId, roomJid, media)"
             />
           <div v-if="replyChildHasNestedThread(message)" class="chat-thread-actions">
             <button

--- a/chat/src/components/chat/ThreadPanel.vue
+++ b/chat/src/components/chat/ThreadPanel.vue
@@ -791,6 +791,7 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
             :link-preview-scope="props.linkPreviewScope"
             :call-room-jid="props.roomJid ?? null"
             :call-channel-id="props.channelId ?? null"
+            :hide-call-anchor-card="!!threadCallAnchorState"
             @edit="(id, body, m, r, lp) => emit('editMessage', id, body, m, r, lp)"
             @retract="(id) => emit('retractMessage', id)"
             @react="(id, emoji) => emit('reactMessage', id, emoji)"

--- a/chat/src/components/chat/ThreadPanel.vue
+++ b/chat/src/components/chat/ThreadPanel.vue
@@ -418,7 +418,7 @@ const breadcrumbLabels = computed(() =>
 // who's been participating, and when activity last happened.
 const threadReplyCount = computed(() => activeEntry.value?.count ?? 0);
 const threadCallAnchorState = useCallAnchorCardState(
-  () => activeEntry.value?.root ?? ({ body: "", author: "", threadId: null } as Pick<TimelineMessage, "body" | "author" | "callThread" | "threadId">),
+  () => activeEntry.value?.root ?? { body: "", author: "" },
   () => props.roomJid,
   () => threadReplyCount.value,
 );

--- a/chat/src/components/chat/ThreadsListPanel.vue
+++ b/chat/src/components/chat/ThreadsListPanel.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted } from "vue";
 import type { BrowserXmppClient } from "@/lib/xmpp-client";
 import type { ChannelSummary } from "@/lib/chat-types";
+import type { CallMedia } from "@/lib/calls/types";
 import type { WasmThreadEntry } from "@/lib/xmpp/wasm-types";
 import {
   type ThreadsActiveWindow,
@@ -37,6 +38,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   openThread: [entry: WasmThreadEntry];
+  joinCall: [entry: WasmThreadEntry, media: CallMedia];
 }>();
 
 const browserUrlState = typeof window === "undefined" ? undefined : {
@@ -190,6 +192,7 @@ onMounted(() => {
           :marking-read="markingReadKey === threadKey(entry)"
           @open="emit('openThread', $event)"
           @mark-read="markThreadRead"
+          @join-call="(joined, media) => emit('joinCall', joined, media)"
         />
       </section>
 

--- a/chat/src/components/chat/ThreadsListRow.vue
+++ b/chat/src/components/chat/ThreadsListRow.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import type { WasmThreadEntry } from "@/lib/xmpp/wasm-types";
+import type { CallMedia } from "@/lib/calls/types";
 import { threadDisplayTitle } from "@/lib/threads-view-filters";
+import { useCallAnchorCardState, wasmThreadEntryToAnchorMessage } from "@/lib/call-thread-anchor";
+import CallAnchorCard from "@/components/calls/CallAnchorCard.vue";
 
 const props = defineProps<{
   entry: WasmThreadEntry;
@@ -11,7 +14,20 @@ const props = defineProps<{
 const emit = defineEmits<{
   open: [entry: WasmThreadEntry];
   markRead: [entry: WasmThreadEntry];
+  joinCall: [entry: WasmThreadEntry, media: CallMedia];
 }>();
+
+// A MUC call-thread row shares the one live-state composable and the one
+// Join path with the in-channel anchor card and the call banner, so the
+// global Threads view reflects the same live/ended call state. Rows that
+// don't anchor a MUC call (DM anchors, plain threads) keep the title row.
+const anchorMessage = computed(() => wasmThreadEntryToAnchorMessage(props.entry));
+const callState = useCallAnchorCardState(
+  () => anchorMessage.value ?? { body: "", author: "", threadId: null, callThread: undefined },
+  () => props.entry.channel,
+  () => props.entry.reply_count,
+);
+const isCallThread = computed(() => callState.value !== null);
 
 const recencyLabel = computed(() => {
   const ts = Date.parse(props.entry.last_activity);
@@ -33,7 +49,15 @@ const title = computed(() => threadDisplayTitle(props.entry));
 
 <template>
   <div class="chat-thread-row glass-panel flex w-full items-stretch gap-2 rounded-md px-3 py-2 hover:bg-sidebar-accent/35">
+    <CallAnchorCard
+      v-if="isCallThread && callState"
+      class="min-w-0 flex-1"
+      :state="callState"
+      @join="callState && emit('joinCall', entry, callState.media)"
+      @open-thread="emit('open', entry)"
+    />
     <button
+      v-else
       type="button"
       class="min-w-0 flex-1 text-left"
       @click="emit('open', entry)"

--- a/chat/src/components/chat/ThreadsListRow.vue
+++ b/chat/src/components/chat/ThreadsListRow.vue
@@ -49,13 +49,17 @@ const title = computed(() => threadDisplayTitle(props.entry));
 
 <template>
   <div class="chat-thread-row glass-panel flex w-full items-stretch gap-2 rounded-md px-3 py-2 hover:bg-sidebar-accent/35">
-    <CallAnchorCard
+    <div
       v-if="isCallThread && callState"
-      class="min-w-0 flex-1"
-      :state="callState"
-      @join="callState && emit('joinCall', entry, callState.media)"
-      @open-thread="emit('open', entry)"
-    />
+      class="call-thread-row__open min-w-0 flex-1"
+      @click="emit('open', entry)"
+    >
+      <CallAnchorCard
+        :state="callState"
+        @join="callState && emit('joinCall', entry, callState.media)"
+        @open-thread="emit('open', entry)"
+      />
+    </div>
     <button
       v-else
       type="button"

--- a/chat/src/components/chat/ThreadsView.vue
+++ b/chat/src/components/chat/ThreadsView.vue
@@ -3,6 +3,7 @@ import { computed } from "vue";
 import { Menu, MessagesSquare } from "lucide-vue-next";
 import { connectionStore } from "@/lib/connection-store";
 import type { ChannelSummary } from "@/lib/chat-types";
+import type { CallMedia } from "@/lib/calls/types";
 import type { WasmThreadEntry } from "@/lib/xmpp/wasm-types";
 import { resolveChannelIdForRoomJid } from "@/lib/threads-channel-resolve";
 import ThreadsListPanel from "@/components/chat/ThreadsListPanel.vue";
@@ -10,6 +11,7 @@ import ThreadsListPanel from "@/components/chat/ThreadsListPanel.vue";
 const props = defineProps<{
   channels: readonly ChannelSummary[];
   onSelectThread: (channelId: string, threadId: string) => void | Promise<void>;
+  onJoinChannelCall: (channelId: string | null, roomJid: string, media: CallMedia) => void;
 }>();
 
 const xmppClient = computed(() => connectionStore.client);
@@ -29,6 +31,14 @@ async function openThread(entry: WasmThreadEntry) {
   if (!channelId) return;
   await props.onSelectThread(channelId, entry.thread_id);
 }
+
+// Join routes through the same shared handler the call banner and the
+// in-channel anchor card use (`joinChannelCallFromActivity` in the shell),
+// resolving the row's channel via the same lookup as `openThread`.
+function joinCall(entry: WasmThreadEntry, media: CallMedia) {
+  const channelId = resolveChannelIdForRoomJid(entry.channel, props.channels);
+  props.onJoinChannelCall(channelId, entry.channel, media);
+}
 </script>
 
 <template>
@@ -47,6 +57,11 @@ async function openThread(entry: WasmThreadEntry) {
       </span>
       <h1 class="type-pane-title text-foreground leading-tight">Threads</h1>
     </header>
-    <ThreadsListPanel :xmpp-client="xmppClient" :channels="channels" @open-thread="openThread" />
+    <ThreadsListPanel
+      :xmpp-client="xmppClient"
+      :channels="channels"
+      @open-thread="openThread"
+      @join-call="joinCall"
+    />
   </div>
 </template>

--- a/chat/src/lib/call-thread-anchor.ts
+++ b/chat/src/lib/call-thread-anchor.ts
@@ -77,9 +77,10 @@ function buildCallAnchorCardState(options: {
   participantLabels: string[];
   messageCount: number;
 }): CallAnchorCardState | null {
-  if (!options.message.callThread) return null;
+  const callThread = options.message.callThread;
+  if (!callThread) return null;
   const { message, media, participantCount, participantLabels, messageCount } = options;
-  const live = !message.callThread.ended && options.hasActiveCall;
+  const live = !callThread.ended && options.hasActiveCall;
   const mediaLabel = media.video ? "video call" : "call";
   const peopleLabel = `${participantCount} ${participantCount === 1 ? "person" : "people"}`;
   const participants = participantLabels.length > 0 ? `: ${participantLabels.join(", ")}` : "";

--- a/chat/src/lib/call-thread-anchor.ts
+++ b/chat/src/lib/call-thread-anchor.ts
@@ -1,4 +1,21 @@
+import { computed, type ComputedRef } from "vue";
+import { useStore } from "@nanostores/vue";
 import type { TimelineMessage } from "@/lib/chat-ui";
+import { $mucCallParticipants, normalizeMucCallRoomJid } from "@/lib/calls/muc-call-presence";
+import { readRoomHasActiveCall, useRoomHasActiveCall } from "@/lib/calls/use-active-muc-call";
+import type { CallMedia } from "@/lib/calls/types";
+
+export interface CallAnchorCardState {
+  status: "live" | "ended";
+  media: CallMedia;
+  participantCount: number;
+  participantLabels: string[];
+  messageCount: number;
+  threadId: string | null;
+  title: string;
+  actionLabel: "Join" | null;
+  ariaLabel: string;
+}
 
 export function callThreadAnchorLabel(message: Pick<TimelineMessage, "body" | "author" | "callThread">): string {
   if (message.callThread?.ended && message.callThread.duration) {
@@ -9,6 +26,75 @@ export function callThreadAnchorLabel(message: Pick<TimelineMessage, "body" | "a
 
 export function callThreadAnchorThreadId(message: Pick<TimelineMessage, "threadId" | "callThread">): string | null {
   return message.callThread && message.threadId ? message.threadId : null;
+}
+
+export function readCallAnchorCardState(
+  message: Pick<TimelineMessage, "body" | "author" | "callThread" | "threadId">,
+  roomJid: string,
+  messageCount = 0,
+): CallAnchorCardState | null {
+  if (!message.callThread) return null;
+  const room = normalizeMucCallRoomJid(roomJid);
+  const roomState = readRoomHasActiveCall(room);
+  const participantLabels = room ? [...($mucCallParticipants.get()[room] ?? [])] : [];
+  return buildCallAnchorCardState({
+    message,
+    hasActiveCall: roomState.hasActiveCall,
+    media: roomState.media,
+    participantCount: roomState.participantCount,
+    participantLabels,
+    messageCount,
+  });
+}
+
+export function useCallAnchorCardState(
+  message: () => Pick<TimelineMessage, "body" | "author" | "callThread" | "threadId">,
+  roomJid: () => string | null | undefined,
+  messageCount: () => number = () => 0,
+): ComputedRef<CallAnchorCardState | null> {
+  const participants = useStore($mucCallParticipants);
+  const roomCall = useRoomHasActiveCall(() => roomJid() ?? "");
+  return computed(() => {
+    const current = message();
+    const room = normalizeMucCallRoomJid(roomJid() ?? "");
+    const participantLabels = room ? [...(participants.value[room] ?? [])] : [];
+    return buildCallAnchorCardState({
+      message: current,
+      hasActiveCall: roomCall.hasActiveCall.value,
+      media: roomCall.media.value,
+      participantCount: roomCall.participantCount.value,
+      participantLabels,
+      messageCount: messageCount(),
+    });
+  });
+}
+
+function buildCallAnchorCardState(options: {
+  message: Pick<TimelineMessage, "body" | "author" | "callThread" | "threadId">;
+  hasActiveCall: boolean;
+  media: CallMedia;
+  participantCount: number;
+  participantLabels: string[];
+  messageCount: number;
+}): CallAnchorCardState | null {
+  if (!options.message.callThread) return null;
+  const { message, media, participantCount, participantLabels, messageCount } = options;
+  const live = !message.callThread.ended && options.hasActiveCall;
+  const mediaLabel = media.video ? "video call" : "call";
+  const peopleLabel = `${participantCount} ${participantCount === 1 ? "person" : "people"}`;
+  const participants = participantLabels.length > 0 ? `: ${participantLabels.join(", ")}` : "";
+
+  return {
+    status: live ? "live" : "ended",
+    media,
+    participantCount,
+    participantLabels,
+    messageCount,
+    threadId: callThreadAnchorThreadId(message),
+    title: live ? `Live ${mediaLabel}` : "Call ended",
+    actionLabel: live ? "Join" : null,
+    ariaLabel: live ? `Join live ${mediaLabel}, ${peopleLabel}${participants}` : callThreadAnchorLabel(message),
+  };
 }
 
 function formatCallThreadDuration(value: string): string {

--- a/chat/src/lib/call-thread-anchor.ts
+++ b/chat/src/lib/call-thread-anchor.ts
@@ -120,8 +120,15 @@ function buildCallAnchorCardState(options: {
 }): CallAnchorCardState | null {
   const callThread = options.message.callThread;
   if (!callThread) return null;
-  const { message, media, participantCount, participantLabels, messageCount } = options;
+  const { message, participantCount, participantLabels, messageCount } = options;
   const live = !callThread.ended && options.hasActiveCall;
+  // Live calls prefer the live detector (current media can differ from the
+  // anchor's initial media). Ended calls must use the wire-authoritative anchor
+  // media: the live detector is cleared when the call ends and falls back to an
+  // audio-only default, which would mislabel an ended video call as audio.
+  const media: CallMedia = live
+    ? options.media
+    : { audio: callThread.media.includes("audio"), video: callThread.media.includes("video") };
   const localGroupCallInThisRoom = isLocalGroupCallInRoom(options.callState, options.roomJid);
   const busy = live && isBusy(options.callState) && !localGroupCallInThisRoom;
   const retainedLocalResource = live && options.localResourceInCall && !localGroupCallInThisRoom;

--- a/chat/src/lib/call-thread-anchor.ts
+++ b/chat/src/lib/call-thread-anchor.ts
@@ -6,6 +6,7 @@ import { isBusy } from "@/lib/calls/call-activity-dock";
 import { $mucCallParticipants, normalizeMucCallRoomJid } from "@/lib/calls/muc-call-presence";
 import { readRoomHasActiveCall, useRoomHasActiveCall } from "@/lib/calls/use-active-muc-call";
 import type { CallMedia } from "@/lib/calls/types";
+import type { WasmThreadEntry } from "@/lib/xmpp/wasm-types";
 
 export interface CallAnchorCardState {
   status: "live" | "ended";
@@ -29,6 +30,32 @@ export function callThreadAnchorLabel(message: Pick<TimelineMessage, "body" | "a
 
 export function callThreadAnchorThreadId(message: Pick<TimelineMessage, "threadId" | "callThread">): string | null {
   return message.callThread && message.threadId ? message.threadId : null;
+}
+
+/**
+ * Adapts a global Threads-query entry into the message shape the call-anchor
+ * card state builder consumes, so a thread-list row can feed
+ * `readCallAnchorCardState`/`useCallAnchorCardState` without a timeline message.
+ *
+ * Returns `null` for entries that don't anchor a MUC call (DM call anchors and
+ * plain threads), matching the channel feed which only renders MUC anchors.
+ */
+export function wasmThreadEntryToAnchorMessage(
+  entry: WasmThreadEntry,
+): Pick<TimelineMessage, "body" | "author" | "callThread" | "threadId"> | null {
+  if (!entry.callThread || entry.callThread.kind !== "muc") return null;
+  return {
+    body: "",
+    author: "",
+    threadId: entry.thread_id,
+    callThread: {
+      kind: "muc",
+      media: entry.callThread.media,
+      ...(entry.callThreadEnded
+        ? { ended: entry.callThreadEnded.ended, duration: entry.callThreadEnded.duration }
+        : {}),
+    },
+  };
 }
 
 export function readCallAnchorCardState(

--- a/chat/src/lib/call-thread-anchor.ts
+++ b/chat/src/lib/call-thread-anchor.ts
@@ -137,7 +137,11 @@ function buildCallAnchorCardState(options: {
     participantLabels,
     messageCount,
     threadId: callThreadAnchorThreadId(message),
-    title: live ? `Live ${mediaLabel}` : "Call ended",
+    title: live
+      ? `Live ${mediaLabel}`
+      : callThread.ended && callThread.duration
+        ? `Call ended · ${formatCallThreadDuration(callThread.duration)}`
+        : "Call ended",
     actionLabel: joinAvailable ? (retainedLocalResource ? "Rejoin" : "Join") : busy ? "In another call" : null,
     actionDisabled: busy,
     ariaLabel: live

--- a/chat/src/lib/call-thread-anchor.ts
+++ b/chat/src/lib/call-thread-anchor.ts
@@ -1,6 +1,8 @@
 import { computed, type ComputedRef } from "vue";
 import { useStore } from "@nanostores/vue";
 import type { TimelineMessage } from "@/lib/chat-ui";
+import { $callState } from "@/lib/calls/call-store";
+import { isBusy } from "@/lib/calls/call-activity-dock";
 import { $mucCallParticipants, normalizeMucCallRoomJid } from "@/lib/calls/muc-call-presence";
 import { readRoomHasActiveCall, useRoomHasActiveCall } from "@/lib/calls/use-active-muc-call";
 import type { CallMedia } from "@/lib/calls/types";
@@ -13,7 +15,8 @@ export interface CallAnchorCardState {
   messageCount: number;
   threadId: string | null;
   title: string;
-  actionLabel: "Join" | null;
+  actionLabel: "Join" | "Rejoin" | "In another call" | null;
+  actionDisabled: boolean;
   ariaLabel: string;
 }
 
@@ -36,10 +39,14 @@ export function readCallAnchorCardState(
   if (!message.callThread) return null;
   const room = normalizeMucCallRoomJid(roomJid);
   const roomState = readRoomHasActiveCall(room);
+  const callState = $callState.get();
   const participantLabels = room ? [...($mucCallParticipants.get()[room] ?? [])] : [];
   return buildCallAnchorCardState({
     message,
+    roomJid: room,
     hasActiveCall: roomState.hasActiveCall,
+    localResourceInCall: roomState.localResourceInCall,
+    callState,
     media: roomState.media,
     participantCount: roomState.participantCount,
     participantLabels,
@@ -53,6 +60,7 @@ export function useCallAnchorCardState(
   messageCount: () => number = () => 0,
 ): ComputedRef<CallAnchorCardState | null> {
   const participants = useStore($mucCallParticipants);
+  const callState = useStore($callState);
   const roomCall = useRoomHasActiveCall(() => roomJid() ?? "");
   return computed(() => {
     const current = message();
@@ -60,7 +68,10 @@ export function useCallAnchorCardState(
     const participantLabels = room ? [...(participants.value[room] ?? [])] : [];
     return buildCallAnchorCardState({
       message: current,
+      roomJid: room,
       hasActiveCall: roomCall.hasActiveCall.value,
+      localResourceInCall: roomCall.localResourceInCall.value,
+      callState: callState.value,
       media: roomCall.media.value,
       participantCount: roomCall.participantCount.value,
       participantLabels,
@@ -71,7 +82,10 @@ export function useCallAnchorCardState(
 
 function buildCallAnchorCardState(options: {
   message: Pick<TimelineMessage, "body" | "author" | "callThread" | "threadId">;
+  roomJid: string;
   hasActiveCall: boolean;
+  localResourceInCall: boolean;
+  callState: ReturnType<typeof $callState.get>;
   media: CallMedia;
   participantCount: number;
   participantLabels: string[];
@@ -81,6 +95,10 @@ function buildCallAnchorCardState(options: {
   if (!callThread) return null;
   const { message, media, participantCount, participantLabels, messageCount } = options;
   const live = !callThread.ended && options.hasActiveCall;
+  const localGroupCallInThisRoom = isLocalGroupCallInRoom(options.callState, options.roomJid);
+  const busy = live && isBusy(options.callState) && !localGroupCallInThisRoom;
+  const retainedLocalResource = live && options.localResourceInCall && !localGroupCallInThisRoom;
+  const joinAvailable = live && !busy && !localGroupCallInThisRoom;
   const mediaLabel = media.video ? "video call" : "call";
   const peopleLabel = `${participantCount} ${participantCount === 1 ? "person" : "people"}`;
   const participants = participantLabels.length > 0 ? `: ${participantLabels.join(", ")}` : "";
@@ -93,9 +111,26 @@ function buildCallAnchorCardState(options: {
     messageCount,
     threadId: callThreadAnchorThreadId(message),
     title: live ? `Live ${mediaLabel}` : "Call ended",
-    actionLabel: live ? "Join" : null,
-    ariaLabel: live ? `Join live ${mediaLabel}, ${peopleLabel}${participants}` : callThreadAnchorLabel(message),
+    actionLabel: joinAvailable ? (retainedLocalResource ? "Rejoin" : "Join") : busy ? "In another call" : null,
+    actionDisabled: busy,
+    ariaLabel: live
+      ? busy
+        ? `Live ${mediaLabel}, ${peopleLabel}${participants}; already in another call`
+        : retainedLocalResource
+          ? `Rejoin live ${mediaLabel}, ${peopleLabel}${participants}`
+          : `Join live ${mediaLabel}, ${peopleLabel}${participants}`
+      : callThreadAnchorLabel(message),
   };
+}
+
+function isLocalGroupCallInRoom(
+  state: ReturnType<typeof $callState.get>,
+  roomJid: string,
+): boolean {
+  if (!roomJid) return false;
+  if (state.phase !== "active" && state.phase !== "muc-pending") return false;
+  if (state.kind !== "muc") return false;
+  return normalizeMucCallRoomJid(state.peer) === roomJid;
 }
 
 function formatCallThreadDuration(value: string): string {

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -43,10 +43,16 @@ export interface TimelineSharedFile {
 
 export interface CallThreadAnchor {
   kind: "muc";
-  sid: string;
+  /**
+   * Set on anchors derived from timeline messages (the inbound
+   * `urn:waddle:call-thread:0` marker). Absent on anchors derived from a
+   * global Threads-query entry, which only carries kind/media/ended/duration —
+   * `readCallAnchorCardState` and the card never read these.
+   */
+  sid?: string;
   media: readonly ("audio" | "video")[];
-  initiator: string;
-  started: string;
+  initiator?: string;
+  started?: string;
   ended?: string;
   duration?: string;
 }

--- a/chat/src/lib/xmpp/wasm-types.ts
+++ b/chat/src/lib/xmpp/wasm-types.ts
@@ -369,13 +369,13 @@ export interface WasmVCard4 {
 }
 
 /** Call-thread anchor summary on a thread entry. */
-export interface WasmThreadCallAnchor {
+interface WasmThreadCallAnchor {
   kind: "muc" | "dm";
   media: Array<"audio" | "video">;
 }
 
 /** Ended-call summary on a thread entry. */
-export interface WasmThreadCallEnded {
+interface WasmThreadCallEnded {
   /** RFC 3339 timestamp. */
   ended: string;
   /** ISO-8601 duration, e.g. "PT5M". */

--- a/chat/src/lib/xmpp/wasm-types.ts
+++ b/chat/src/lib/xmpp/wasm-types.ts
@@ -368,6 +368,20 @@ export interface WasmVCard4 {
   photo_uri?: string;
 }
 
+/** Call-thread anchor summary on a thread entry. */
+export interface WasmThreadCallAnchor {
+  kind: "muc" | "dm";
+  media: Array<"audio" | "video">;
+}
+
+/** Ended-call summary on a thread entry. */
+export interface WasmThreadCallEnded {
+  /** RFC 3339 timestamp. */
+  ended: string;
+  /** ISO-8601 duration, e.g. "PT5M". */
+  duration: string;
+}
+
 /** One entry in a urn:waddle:threads:0 response. */
 export interface WasmThreadEntry {
   channel: string;
@@ -381,6 +395,10 @@ export interface WasmThreadEntry {
   root_author?: string;
   preview?: string;
   thread_title?: string;
+  /** Present when this thread anchors a call. */
+  callThread?: WasmThreadCallAnchor;
+  /** Present when the anchored call has ended. */
+  callThreadEnded?: WasmThreadCallEnded;
 }
 
 /** Paged response to a urn:waddle:threads:0 query. */

--- a/chat/tests/call-anchor-card.test.ts
+++ b/chat/tests/call-anchor-card.test.ts
@@ -18,6 +18,7 @@ const liveState: CallAnchorCardState = {
   threadId: "call-thread-uuid",
   title: "Live video call",
   actionLabel: "Join",
+  actionDisabled: false,
   ariaLabel: "Join live video call, 2 people: alice, bob",
 };
 
@@ -45,6 +46,7 @@ describe("CallAnchorCard", () => {
         participantLabels: [],
         title: "Call ended",
         actionLabel: null,
+        actionDisabled: false,
         ariaLabel: "Call ended · 5m",
       } satisfies CallAnchorCardState,
     });

--- a/chat/tests/call-anchor-card.test.ts
+++ b/chat/tests/call-anchor-card.test.ts
@@ -30,6 +30,23 @@ describe("CallAnchorCard", () => {
     expect(html).toContain('aria-label="Join live video call, 2 people: alice, bob"');
   });
 
+  test("the action button's accessible name is the visible action label, not the full description", async () => {
+    const html = await renderVueComponent("../src/components/calls/CallAnchorCard.vue", {
+      state: liveState,
+    }, import.meta.url);
+
+    // The descriptive aria-label belongs only to the <section>; the action
+    // button must not repeat it (screen readers would announce it twice).
+    const ariaLabelCount = html.split('aria-label="Join live video call, 2 people: alice, bob"').length - 1;
+    expect(ariaLabelCount).toBe(1);
+    // The button carries no aria-label, so its accessible name is the visible
+    // "Join" text inside its <span>.
+    const button = html.match(/<button[^>]*bg-primary[^>]*>([\s\S]*?)<\/button>/);
+    expect(button).not.toBeNull();
+    expect(button?.[0]).not.toContain("aria-label");
+    expect(button?.[1]).toContain("<span>Join</span>");
+  });
+
   test("renders ended call anchors muted without a join action", async () => {
     const html = await renderVueComponent("../src/components/calls/CallAnchorCard.vue", {
       state: {

--- a/chat/tests/call-anchor-card.test.ts
+++ b/chat/tests/call-anchor-card.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { createSSRApp, h } from "vue";
+import { parse, compileScript } from "vue/compiler-sfc";
+import { renderToString } from "vue/server-renderer";
+import ts from "typescript";
+import type { CallAnchorCardState } from "../src/lib/call-thread-anchor";
+
+const liveState: CallAnchorCardState = {
+  status: "live",
+  media: { audio: true, video: true },
+  participantCount: 2,
+  participantLabels: ["alice", "bob"],
+  messageCount: 7,
+  threadId: "call-thread-uuid",
+  title: "Live video call",
+  actionLabel: "Join",
+  ariaLabel: "Join live video call, 2 people: alice, bob",
+};
+
+describe("CallAnchorCard", () => {
+  test("renders the live call anchor with media, participants, join, and call-chat count", async () => {
+    const html = await renderVueComponent("../src/components/calls/CallAnchorCard.vue", {
+      state: liveState,
+    });
+
+    expect(html).toContain("Live video call");
+    expect(html).toContain("call-anchor-card__pulse");
+    expect(html).toContain("alice");
+    expect(html).toContain("bob");
+    expect(html).toContain("Join");
+    expect(html).toContain("7 messages in call chat");
+    expect(html).toContain('aria-label="Join live video call, 2 people: alice, bob"');
+  });
+
+  test("renders ended call anchors muted without a join action", async () => {
+    const html = await renderVueComponent("../src/components/calls/CallAnchorCard.vue", {
+      state: {
+        ...liveState,
+        status: "ended",
+        participantCount: 0,
+        participantLabels: [],
+        title: "Call ended",
+        actionLabel: null,
+        ariaLabel: "Call ended · 5m",
+      } satisfies CallAnchorCardState,
+    });
+
+    expect(html).toContain("Call ended");
+    expect(html).toContain("call-anchor-card--ended");
+    expect(html).not.toContain(">Join<");
+    expect(html).toContain('aria-label="Call ended · 5m"');
+  });
+});
+
+async function renderVueComponent(path: string, props: Record<string, unknown>) {
+  const component = await loadVueComponent(path);
+  return renderToString(createSSRApp({ render: () => h(component, props) }));
+}
+
+async function loadVueComponent(path: string) {
+  const filename = new URL(path, import.meta.url);
+  const source = readFileSync(filename, "utf8");
+  const { descriptor } = parse(source, { filename: filename.pathname });
+  const script = compileScript(descriptor, {
+    id: filename.pathname,
+    inlineTemplate: true,
+  });
+
+  const tempDir = mkdtempSync(join(tmpdir(), "waddle-vue-component-"));
+  try {
+    const compiled = [
+      rewriteImports(script.content.replace("export default", "const __sfc__ ="), filename),
+      "export default __sfc__;",
+    ].join("\n");
+
+    const js = ts.transpileModule(compiled, {
+      compilerOptions: {
+        module: ts.ModuleKind.ESNext,
+        target: ts.ScriptTarget.ES2022,
+        verbatimModuleSyntax: false,
+      },
+    }).outputText;
+    const modulePath = join(tempDir, "Component.mjs");
+    writeFileSync(modulePath, js);
+    const component = await import(pathToFileURL(modulePath).href);
+    return component.default;
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function rewriteImports(code: string, importer: URL): string {
+  return code.replace(/from\s+["']([^"']+)["']/g, (_match, specifier: string) =>
+    `from ${JSON.stringify(resolveModuleSpecifier(specifier, importer))}`);
+}
+
+function resolveModuleSpecifier(specifier: string, importer: URL): string {
+  if (specifier.startsWith("@/")) {
+    return moduleUrlForPath(resolveSourcePath(new URL(`../src/${specifier.slice(2)}`, import.meta.url).pathname));
+  }
+  if (specifier.startsWith(".")) {
+    return moduleUrlForPath(resolveSourcePath(new URL(specifier, importer).pathname));
+  }
+  return import.meta.resolve(specifier);
+}
+
+function resolveSourcePath(basePath: string): string {
+  const candidates = [
+    basePath,
+    `${basePath}.ts`,
+    `${basePath}.js`,
+    `${basePath}.vue`,
+    `${basePath}/index.ts`,
+  ];
+  const resolved = candidates.find((candidate) => existsSync(candidate));
+  if (!resolved) throw new Error(`Unable to resolve test SFC import: ${basePath}`);
+  return resolved;
+}
+
+function moduleUrlForPath(resolvedPath: string): string {
+  if (!resolvedPath.endsWith(".vue")) return pathToFileURL(resolvedPath).href;
+  return new URL("./helpers/vue-sfc-stub.ts", import.meta.url).href;
+}

--- a/chat/tests/call-anchor-card.test.ts
+++ b/chat/tests/call-anchor-card.test.ts
@@ -1,12 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { pathToFileURL } from "node:url";
-import { createSSRApp, h } from "vue";
-import { parse, compileScript } from "vue/compiler-sfc";
-import { renderToString } from "vue/server-renderer";
-import ts from "typescript";
+import { renderVueComponent } from "./helpers/render-vue-sfc";
 import type { CallAnchorCardState } from "../src/lib/call-thread-anchor";
 
 const liveState: CallAnchorCardState = {
@@ -26,7 +19,7 @@ describe("CallAnchorCard", () => {
   test("renders the live call anchor with media, participants, join, and call-chat count", async () => {
     const html = await renderVueComponent("../src/components/calls/CallAnchorCard.vue", {
       state: liveState,
-    });
+    }, import.meta.url);
 
     expect(html).toContain("Live video call");
     expect(html).toContain("call-anchor-card__pulse");
@@ -49,7 +42,7 @@ describe("CallAnchorCard", () => {
         actionDisabled: false,
         ariaLabel: "Call ended · 5m",
       } satisfies CallAnchorCardState,
-    });
+    }, import.meta.url);
 
     expect(html).toContain("Call ended");
     expect(html).toContain("call-anchor-card--ended");
@@ -57,73 +50,3 @@ describe("CallAnchorCard", () => {
     expect(html).toContain('aria-label="Call ended · 5m"');
   });
 });
-
-async function renderVueComponent(path: string, props: Record<string, unknown>) {
-  const component = await loadVueComponent(path);
-  return renderToString(createSSRApp({ render: () => h(component, props) }));
-}
-
-async function loadVueComponent(path: string) {
-  const filename = new URL(path, import.meta.url);
-  const source = readFileSync(filename, "utf8");
-  const { descriptor } = parse(source, { filename: filename.pathname });
-  const script = compileScript(descriptor, {
-    id: filename.pathname,
-    inlineTemplate: true,
-  });
-
-  const tempDir = mkdtempSync(join(tmpdir(), "waddle-vue-component-"));
-  try {
-    const compiled = [
-      rewriteImports(script.content.replace("export default", "const __sfc__ ="), filename),
-      "export default __sfc__;",
-    ].join("\n");
-
-    const js = ts.transpileModule(compiled, {
-      compilerOptions: {
-        module: ts.ModuleKind.ESNext,
-        target: ts.ScriptTarget.ES2022,
-        verbatimModuleSyntax: false,
-      },
-    }).outputText;
-    const modulePath = join(tempDir, "Component.mjs");
-    writeFileSync(modulePath, js);
-    const component = await import(pathToFileURL(modulePath).href);
-    return component.default;
-  } finally {
-    rmSync(tempDir, { recursive: true, force: true });
-  }
-}
-
-function rewriteImports(code: string, importer: URL): string {
-  return code.replace(/from\s+["']([^"']+)["']/g, (_match, specifier: string) =>
-    `from ${JSON.stringify(resolveModuleSpecifier(specifier, importer))}`);
-}
-
-function resolveModuleSpecifier(specifier: string, importer: URL): string {
-  if (specifier.startsWith("@/")) {
-    return moduleUrlForPath(resolveSourcePath(new URL(`../src/${specifier.slice(2)}`, import.meta.url).pathname));
-  }
-  if (specifier.startsWith(".")) {
-    return moduleUrlForPath(resolveSourcePath(new URL(specifier, importer).pathname));
-  }
-  return import.meta.resolve(specifier);
-}
-
-function resolveSourcePath(basePath: string): string {
-  const candidates = [
-    basePath,
-    `${basePath}.ts`,
-    `${basePath}.js`,
-    `${basePath}.vue`,
-    `${basePath}/index.ts`,
-  ];
-  const resolved = candidates.find((candidate) => existsSync(candidate));
-  if (!resolved) throw new Error(`Unable to resolve test SFC import: ${basePath}`);
-  return resolved;
-}
-
-function moduleUrlForPath(resolvedPath: string): string {
-  if (!resolvedPath.endsWith(".vue")) return pathToFileURL(resolvedPath).href;
-  return new URL("./helpers/vue-sfc-stub.ts", import.meta.url).href;
-}

--- a/chat/tests/call-thread-anchor.test.ts
+++ b/chat/tests/call-thread-anchor.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { isFeedTimelineMessage, mapLiveRoomMessageToTimeline } from "../src/channels/timeline";
-import { callThreadAnchorLabel, callThreadAnchorThreadId, readCallAnchorCardState } from "../src/lib/call-thread-anchor";
+import {
+  callThreadAnchorLabel,
+  callThreadAnchorThreadId,
+  readCallAnchorCardState,
+  wasmThreadEntryToAnchorMessage,
+} from "../src/lib/call-thread-anchor";
+import type { WasmThreadEntry } from "../src/lib/xmpp/wasm-types";
 import { $callState } from "../src/lib/calls/call-store";
 import { $mucCallMedia, $mucCallParticipants, clearMucCallParticipants } from "../src/lib/calls/muc-call-presence";
 import type { WaddleSession } from "../src/lib/server-auth";
@@ -279,5 +285,91 @@ describe("call-thread anchor timeline mapping", () => {
     });
 
     expect(live).toBeNull();
+  });
+});
+
+const baseEntry: WasmThreadEntry = {
+  channel: "general@conference.example.com",
+  thread_id: "call-thread-uuid",
+  last_stanza_id: "s1",
+  last_activity: "2026-06-07T14:30:00Z",
+  unread: 0,
+  reply_count: 7,
+  has_unread: false,
+};
+
+describe("wasmThreadEntryToAnchorMessage", () => {
+  afterEach(() => {
+    $callState.set({ phase: "idle" });
+    clearMucCallParticipants();
+    $mucCallMedia.set({});
+  });
+
+  test("adapts a live MUC call-thread entry into an anchor-shaped message", () => {
+    const msg = wasmThreadEntryToAnchorMessage({
+      ...baseEntry,
+      callThread: { kind: "muc", media: ["audio", "video"] },
+    });
+    expect(msg).not.toBeNull();
+    expect(msg?.threadId).toBe("call-thread-uuid");
+    expect(msg?.callThread?.media).toEqual(["audio", "video"]);
+    expect(msg?.callThread?.ended).toBeUndefined();
+  });
+
+  test("adapts an ended MUC call-thread entry with duration", () => {
+    const msg = wasmThreadEntryToAnchorMessage({
+      ...baseEntry,
+      callThread: { kind: "muc", media: ["audio"] },
+      callThreadEnded: { ended: "2026-06-07T14:35:00Z", duration: "PT5M" },
+    });
+    expect(msg?.callThread).toMatchObject({
+      kind: "muc",
+      media: ["audio"],
+      ended: "2026-06-07T14:35:00Z",
+      duration: "PT5M",
+    });
+  });
+
+  test("returns null for non-call and non-muc entries", () => {
+    expect(wasmThreadEntryToAnchorMessage(baseEntry)).toBeNull();
+    expect(
+      wasmThreadEntryToAnchorMessage({ ...baseEntry, callThread: { kind: "dm", media: ["audio"] } }),
+    ).toBeNull();
+  });
+
+  test("drives the shared composable to a live card when the room call is active", () => {
+    const msg = wasmThreadEntryToAnchorMessage({
+      ...baseEntry,
+      callThread: { kind: "muc", media: ["audio", "video"] },
+    });
+    expect(msg).not.toBeNull();
+    $mucCallParticipants.set({ "general@conference.example.com": ["alice", "bob"] });
+    $mucCallMedia.setKey("general@conference.example.com", { audio: true, video: true });
+
+    expect(readCallAnchorCardState(msg!, "general@conference.example.com")).toMatchObject({
+      status: "live",
+      media: { audio: true, video: true },
+      participantCount: 2,
+      participantLabels: ["alice", "bob"],
+      threadId: "call-thread-uuid",
+      title: "Live video call",
+      actionLabel: "Join",
+    });
+  });
+
+  test("drives the shared composable to an ended card for an ended entry", () => {
+    const msg = wasmThreadEntryToAnchorMessage({
+      ...baseEntry,
+      callThread: { kind: "muc", media: ["audio"] },
+      callThreadEnded: { ended: "2026-06-07T14:35:00Z", duration: "PT5M" },
+    });
+    expect(msg).not.toBeNull();
+
+    expect(readCallAnchorCardState(msg!, "general@conference.example.com")).toMatchObject({
+      status: "ended",
+      title: "Call ended",
+      actionLabel: null,
+      ariaLabel: "Call ended · 5m",
+    });
   });
 });

--- a/chat/tests/call-thread-anchor.test.ts
+++ b/chat/tests/call-thread-anchor.test.ts
@@ -163,6 +163,28 @@ describe("call-thread anchor timeline mapping", () => {
     expect(callThreadAnchorThreadId(timelineMessage)).toBe("call-thread-uuid");
   });
 
+  test("derives ended card media from the anchor, not the cleared live detector", () => {
+    const timelineMessage = mapLiveRoomMessageToTimeline(session, callAnchor({
+      roomJid: "general@conference.example.com",
+      callThread: {
+        kind: "muc",
+        sid: "session-uuid",
+        media: ["audio", "video"],
+        initiator: "alice@example",
+        started: "2026-06-07T14:30:00Z",
+        ended: "2026-06-07T14:35:00Z",
+        duration: "PT5M",
+      },
+    }));
+
+    // No active call seeded: the live detector falls back to audio-only default.
+    expect(readCallAnchorCardState(timelineMessage, "general@conference.example.com")).toMatchObject({
+      status: "ended",
+      media: { audio: true, video: true },
+      title: "Call ended · 5m",
+    });
+  });
+
   test("shows the formatted duration in the ended anchor card title", () => {
     const timelineMessage = mapLiveRoomMessageToTimeline(session, callAnchor({
       roomJid: "general@conference.example.com",

--- a/chat/tests/call-thread-anchor.test.ts
+++ b/chat/tests/call-thread-anchor.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { isFeedTimelineMessage, mapLiveRoomMessageToTimeline } from "../src/channels/timeline";
 import { callThreadAnchorLabel, callThreadAnchorThreadId, readCallAnchorCardState } from "../src/lib/call-thread-anchor";
+import { $callState } from "../src/lib/calls/call-store";
 import { $mucCallMedia, $mucCallParticipants, clearMucCallParticipants } from "../src/lib/calls/muc-call-presence";
 import type { WaddleSession } from "../src/lib/server-auth";
 import { roomMessageFromArchived } from "../src/lib/xmpp/wasm-message-codecs";
@@ -40,6 +41,12 @@ function callAnchor(overrides: Partial<LiveRoomMessage> = {}): LiveRoomMessage {
 }
 
 describe("call-thread anchor timeline mapping", () => {
+  afterEach(() => {
+    $callState.set({ phase: "idle" });
+    clearMucCallParticipants();
+    $mucCallMedia.set({});
+  });
+
   test("maps inbound channel call-thread marker onto the unified timeline message", () => {
     const timelineMessage = mapLiveRoomMessageToTimeline(session, callAnchor());
 
@@ -87,6 +94,7 @@ describe("call-thread anchor timeline mapping", () => {
       threadId: "call-thread-uuid",
       title: "Live video call",
       actionLabel: "Join",
+      actionDisabled: false,
       ariaLabel: "Join live video call, 2 people: alice, bob",
     });
 
@@ -98,6 +106,37 @@ describe("call-thread anchor timeline mapping", () => {
       participantLabels: [],
       title: "Call ended",
       actionLabel: null,
+      actionDisabled: false,
+    });
+  });
+
+  test("uses the banner's busy semantics for live anchor join actions", () => {
+    const timelineMessage = mapLiveRoomMessageToTimeline(session, callAnchor({
+      roomJid: "general@conference.example.com",
+    }));
+    $mucCallParticipants.set({
+      "general@conference.example.com": ["alice", "bob"],
+    });
+    $callState.set({
+      phase: "active",
+      kind: "muc",
+      peer: "other@conference.example.com",
+      sid: "other-call",
+      media: { audio: true, video: false },
+      join: {
+        url: "wss://livekit.test",
+        room: "other",
+        identity: "alice@example.com/web",
+        token: "tok",
+      },
+      selfNick: "alice",
+    });
+
+    expect(readCallAnchorCardState(timelineMessage, "general@conference.example.com")).toMatchObject({
+      status: "live",
+      actionLabel: "In another call",
+      actionDisabled: true,
+      ariaLabel: "Live call, 2 people: alice, bob; already in another call",
     });
   });
 

--- a/chat/tests/call-thread-anchor.test.ts
+++ b/chat/tests/call-thread-anchor.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { isFeedTimelineMessage, mapLiveRoomMessageToTimeline } from "../src/channels/timeline";
-import { callThreadAnchorLabel, callThreadAnchorThreadId } from "../src/lib/call-thread-anchor";
+import { callThreadAnchorLabel, callThreadAnchorThreadId, readCallAnchorCardState } from "../src/lib/call-thread-anchor";
+import { $mucCallMedia, $mucCallParticipants, clearMucCallParticipants } from "../src/lib/calls/muc-call-presence";
 import type { WaddleSession } from "../src/lib/server-auth";
 import { roomMessageFromArchived } from "../src/lib/xmpp/wasm-message-codecs";
 import type { LiveRoomMessage } from "../src/lib/xmpp-client";
@@ -66,6 +67,38 @@ describe("call-thread anchor timeline mapping", () => {
 
     expect(callThreadAnchorLabel(timelineMessage)).toBe("Alice started a call");
     expect(callThreadAnchorThreadId(timelineMessage)).toBe("call-thread-uuid");
+  });
+
+  test("derives rich anchor card state from room live detectors with stale-live override", () => {
+    const timelineMessage = mapLiveRoomMessageToTimeline(session, callAnchor({
+      roomJid: "general@conference.example.com",
+    }));
+    $mucCallParticipants.set({
+      "general@conference.example.com": ["alice", "bob"],
+    });
+    $mucCallMedia.setKey("general@conference.example.com", { audio: true, video: true });
+
+    expect(readCallAnchorCardState(timelineMessage, "general@conference.example.com")).toEqual({
+      status: "live",
+      media: { audio: true, video: true },
+      participantCount: 2,
+      participantLabels: ["alice", "bob"],
+      messageCount: 0,
+      threadId: "call-thread-uuid",
+      title: "Live video call",
+      actionLabel: "Join",
+      ariaLabel: "Join live video call, 2 people: alice, bob",
+    });
+
+    clearMucCallParticipants();
+
+    expect(readCallAnchorCardState(timelineMessage, "general@conference.example.com")).toMatchObject({
+      status: "ended",
+      participantCount: 0,
+      participantLabels: [],
+      title: "Call ended",
+      actionLabel: null,
+    });
   });
 
   test("renders ended call-thread anchors as muted duration summaries", () => {

--- a/chat/tests/call-thread-anchor.test.ts
+++ b/chat/tests/call-thread-anchor.test.ts
@@ -163,6 +163,26 @@ describe("call-thread anchor timeline mapping", () => {
     expect(callThreadAnchorThreadId(timelineMessage)).toBe("call-thread-uuid");
   });
 
+  test("shows the formatted duration in the ended anchor card title", () => {
+    const timelineMessage = mapLiveRoomMessageToTimeline(session, callAnchor({
+      roomJid: "general@conference.example.com",
+      callThread: {
+        kind: "muc",
+        sid: "session-uuid",
+        media: ["audio"],
+        initiator: "alice@example",
+        started: "2026-06-07T14:30:00Z",
+        ended: "2026-06-07T14:35:00Z",
+        duration: "PT5M",
+      },
+    }));
+
+    expect(readCallAnchorCardState(timelineMessage, "general@conference.example.com")).toMatchObject({
+      status: "ended",
+      title: "Call ended · 5m",
+    });
+  });
+
   test("room archive codec maps the WASM call-thread marker onto LiveRoomMessage", () => {
     const live = roomMessageFromArchived({
       mam_id: "mam-anchor-1",
@@ -367,7 +387,7 @@ describe("wasmThreadEntryToAnchorMessage", () => {
 
     expect(readCallAnchorCardState(msg!, "general@conference.example.com")).toMatchObject({
       status: "ended",
-      title: "Call ended",
+      title: "Call ended · 5m",
       actionLabel: null,
       ariaLabel: "Call ended · 5m",
     });

--- a/chat/tests/helpers/render-vue-sfc.ts
+++ b/chat/tests/helpers/render-vue-sfc.ts
@@ -1,0 +1,140 @@
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { createSSRApp, h } from "vue";
+import { parse, compileScript } from "vue/compiler-sfc";
+import { renderToString } from "vue/server-renderer";
+import ts from "typescript";
+
+/**
+ * SSR render harness for `.vue` single-file components in `bun test`.
+ *
+ * Compiles a target SFC — and any `.vue` components it imports,
+ * recursively — to ESM via `vue/compiler-sfc` + the TypeScript
+ * transpiler, then renders it with `renderToString`. `@/` and relative
+ * specifiers resolve against `chat/src`; bare specifiers resolve via the
+ * Node resolver.
+ *
+ * Nested `.vue` imports are compiled into sibling ESM modules rather than
+ * stubbed, so child components (e.g. a row's embedded card) render for
+ * real and their markup appears in the returned HTML.
+ *
+ * Nanostores composables work under this harness because `@nanostores/vue`
+ * reads `store.get()` synchronously when `window` is undefined (the
+ * default in `bun test`), so a render reflects whatever the stores were
+ * seeded with — no mount lifecycle required.
+ */
+export async function renderVueComponent(
+  path: string,
+  props: Record<string, unknown> = {},
+  importMetaUrl: string,
+): Promise<string> {
+  const outDir = mkdtempSync(join(tmpdir(), "waddle-vue-sfc-"));
+  const moduleUrl = await compileSfcModule(new URL(path, importMetaUrl), outDir, new Map());
+  const component = (await import(moduleUrl)).default;
+  return renderToString(createSSRApp({ render: () => h(component, props) }));
+}
+
+/**
+ * Compiles `filename` (a `.vue` SFC) into an ESM module written under
+ * `outDir`, returning its `file://` URL. `cache` dedupes shared child
+ * SFCs across the dependency graph so each is compiled once.
+ */
+async function compileSfcModule(
+  filename: URL,
+  outDir: string,
+  cache: Map<string, string>,
+): Promise<string> {
+  const cached = cache.get(filename.pathname);
+  if (cached) return cached;
+
+  const source = readFileSync(filename, "utf8");
+  const { descriptor } = parse(source, { filename: filename.pathname });
+  const script = compileScript(descriptor, {
+    id: filename.pathname,
+    inlineTemplate: true,
+  });
+
+  const transpiled = ts.transpileModule(
+    [
+      script.content.replace("export default", "const __sfc__ ="),
+      "export default __sfc__;",
+    ].join("\n"),
+    {
+      compilerOptions: {
+        module: ts.ModuleKind.ESNext,
+        target: ts.ScriptTarget.ES2022,
+        verbatimModuleSyntax: false,
+      },
+    },
+  ).outputText;
+
+  const rewritten = await rewriteImports(transpiled, filename, outDir, cache);
+  const modulePath = join(outDir, `sfc-${cache.size}.mjs`);
+  const moduleUrl = pathToFileURL(modulePath).href;
+  // Reserve the cache slot before writing so recursive imports see it.
+  cache.set(filename.pathname, moduleUrl);
+  writeFileSync(modulePath, rewritten);
+  return moduleUrl;
+}
+
+async function rewriteImports(
+  code: string,
+  importer: URL,
+  outDir: string,
+  cache: Map<string, string>,
+): Promise<string> {
+  const specifiers = [...code.matchAll(/from\s+["']([^"']+)["']/g)].map((m) => m[1]);
+  let result = code;
+  for (const specifier of specifiers) {
+    const resolved = await resolveModuleSpecifier(specifier, importer, outDir, cache);
+    result = result.replaceAll(`from "${specifier}"`, `from "${resolved}"`);
+    result = result.replaceAll(`from '${specifier}'`, `from "${resolved}"`);
+  }
+  return result;
+}
+
+async function resolveModuleSpecifier(
+  specifier: string,
+  importer: URL,
+  outDir: string,
+  cache: Map<string, string>,
+): Promise<string> {
+  if (specifier.startsWith("@/")) {
+    const path = resolveSourcePath(new URL(`../../src/${specifier.slice(2)}`, import.meta.url).pathname);
+    return moduleUrlForPath(path, outDir, cache);
+  }
+  if (specifier.startsWith(".")) {
+    const path = resolveSourcePath(new URL(specifier, importer).pathname);
+    return moduleUrlForPath(path, outDir, cache);
+  }
+  return import.meta.resolve(specifier);
+}
+
+async function moduleUrlForPath(
+  resolvedPath: string,
+  outDir: string,
+  cache: Map<string, string>,
+): Promise<string> {
+  if (resolvedPath.endsWith(".vue")) {
+    return compileSfcModule(pathToFileURL(resolvedPath), outDir, cache);
+  }
+  return pathToFileURL(resolvedPath).href;
+}
+
+function resolveSourcePath(basePath: string): string {
+  const candidates = [
+    basePath,
+    `${basePath}.ts`,
+    `${basePath}.tsx`,
+    `${basePath}.js`,
+    `${basePath}.mjs`,
+    `${basePath}.vue`,
+    `${basePath}.json`,
+    `${basePath}/index.ts`,
+  ];
+  const resolved = candidates.find((candidate) => existsSync(candidate));
+  if (!resolved) throw new Error(`Unable to resolve test SFC import: ${basePath}`);
+  return resolved;
+}

--- a/chat/tests/threads-list-row.test.ts
+++ b/chat/tests/threads-list-row.test.ts
@@ -39,6 +39,25 @@ describe("ThreadsListRow call-thread anchors", () => {
     expect(html).toContain("7 messages in call chat");
   });
 
+  test("wraps the call anchor card in a row-body container that opens the thread", async () => {
+    $mucCallParticipants.set({ "general@conference.example.com": ["alice", "bob"] });
+    $mucCallMedia.setKey("general@conference.example.com", { audio: true, video: true });
+
+    const html = await renderRow({
+      ...baseEntry,
+      callThread: { kind: "muc", media: ["audio", "video"] },
+    });
+
+    // The whole call-row body is a clickable wrapper (open the thread), with
+    // the card nested inside it — not a bare, mostly-inert card.
+    const opener = html.match(/<div class="call-thread-row__open[^"]*">([\s\S]*?)<\/section>/);
+    expect(opener).not.toBeNull();
+    expect(opener?.[1]).toContain("call-anchor-card");
+    // The wrapper is a <div>, never a <button>, because the card already
+    // contains the Join / call-chat buttons (nested buttons are invalid HTML).
+    expect(html).not.toContain("<button class=\"call-thread-row__open");
+  });
+
   test("renders the ended call anchor card without a join action", async () => {
     const html = await renderRow({
       ...baseEntry,

--- a/chat/tests/threads-list-row.test.ts
+++ b/chat/tests/threads-list-row.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { renderVueComponent } from "./helpers/render-vue-sfc";
+import type { WasmThreadEntry } from "../src/lib/xmpp/wasm-types";
+import { $callState } from "../src/lib/calls/call-store";
+import { $mucCallMedia, $mucCallParticipants, clearMucCallParticipants } from "../src/lib/calls/muc-call-presence";
+
+const baseEntry: WasmThreadEntry = {
+  channel: "general@conference.example.com",
+  thread_id: "t1",
+  last_stanza_id: "s",
+  last_activity: "2026-06-07T14:30:00Z",
+  unread: 0,
+  reply_count: 7,
+  has_unread: false,
+};
+
+function renderRow(entry: WasmThreadEntry) {
+  return renderVueComponent("../src/components/chat/ThreadsListRow.vue", { entry }, import.meta.url);
+}
+
+describe("ThreadsListRow call-thread anchors", () => {
+  afterEach(() => {
+    $callState.set({ phase: "idle" });
+    clearMucCallParticipants();
+    $mucCallMedia.set({});
+  });
+
+  test("renders the live call anchor card for a live MUC call-thread row", async () => {
+    $mucCallParticipants.set({ "general@conference.example.com": ["alice", "bob"] });
+    $mucCallMedia.setKey("general@conference.example.com", { audio: true, video: true });
+
+    const html = await renderRow({
+      ...baseEntry,
+      callThread: { kind: "muc", media: ["audio", "video"] },
+    });
+
+    expect(html).toContain("call-anchor-card__pulse");
+    expect(html).toContain("Join");
+    expect(html).toContain("7 messages in call chat");
+  });
+
+  test("renders the ended call anchor card without a join action", async () => {
+    const html = await renderRow({
+      ...baseEntry,
+      callThread: { kind: "muc", media: ["audio"] },
+      callThreadEnded: { ended: "2026-06-07T14:35:00Z", duration: "PT5M" },
+    });
+
+    expect(html).toContain("call-anchor-card--ended");
+    expect(html).toContain("Call ended · 5m");
+    expect(html).not.toContain(">Join<");
+  });
+
+  test("renders the plain title row for a non-call thread", async () => {
+    const html = await renderRow({
+      ...baseEntry,
+      thread_title: "Roadmap planning",
+    });
+
+    expect(html).not.toContain("call-anchor-card");
+    expect(html).toContain("Roadmap planning");
+  });
+});

--- a/chat/tests/threads-view.test.ts
+++ b/chat/tests/threads-view.test.ts
@@ -14,6 +14,8 @@
 
 import { describe, expect, mock, test } from "bun:test";
 import type { WasmThreadEntry } from "../src/lib/xmpp/wasm-types";
+import type { CallMedia } from "../src/lib/calls/types";
+import type { ChannelSummary } from "../src/lib/chat-types";
 import { resolveChannelIdForRoomJid } from "../src/lib/threads-channel-resolve";
 import { resolveThreadEntryTarget } from "../src/lib/threads-view-target";
 
@@ -172,5 +174,105 @@ describe("ThreadsView click handler", () => {
     };
     await handleOpenThread(entry(), [], h);
     expect(resolved).toBe(true);
+  });
+});
+
+/**
+ * Mirrors `ThreadsView.vue`'s `joinCall(entry, media)` exactly: resolve
+ * the row's room JID to a channel-id and hand off to the controller's
+ * `onJoinChannelCall(channelId, roomJid, media)` — the shared Join path
+ * the call banner and the in-channel anchor card also drive.
+ */
+function handleJoinCall(
+  e: WasmThreadEntry,
+  media: CallMedia,
+  channels: readonly ChannelSummary[],
+  onJoinChannelCall: (channelId: string | null, roomJid: string, media: CallMedia) => void,
+): void {
+  const channelId = resolveChannelIdForRoomJid(e.channel, channels);
+  onJoinChannelCall(channelId, e.channel, media);
+}
+
+function channel(overrides: Partial<ChannelSummary> = {}): ChannelSummary {
+  return {
+    id: "general",
+    name: "general",
+    jid: "general@muc.waddle.example",
+    ...overrides,
+  };
+}
+
+describe("ThreadsView join-call handler", () => {
+  function handlers() {
+    return {
+      onSelectThread: mock(async (_channelId: string, _threadId: string) => {}),
+      onOpenDmThread: mock(async (_peerJid: string, _threadId: string) => {}),
+    };
+  }
+
+  test("resolves the channel-id and hands off the room JID + media to onJoinChannelCall", () => {
+    const onJoinChannelCall = mock(
+      (_channelId: string | null, _roomJid: string, _media: CallMedia) => {},
+    );
+    const media: CallMedia = { audio: true, video: true };
+    handleJoinCall(
+      entry({ channel: "general@muc.waddle.example" }),
+      media,
+      [channel()],
+      onJoinChannelCall,
+    );
+    // Resolved channel-id, the original room JID (unchanged), and the
+    // exact media object — same reference, not a copy.
+    expect(onJoinChannelCall).toHaveBeenCalledTimes(1);
+    expect(onJoinChannelCall.mock.calls[0]).toEqual([
+      "general",
+      "general@muc.waddle.example",
+      media,
+    ]);
+    expect(onJoinChannelCall.mock.calls[0]?.[2]).toBe(media);
+  });
+
+  test("passes the resolver's local-part fallback through when the channel is unknown", () => {
+    // `resolveChannelIdForRoomJid` falls back to the JID's local-part
+    // for an unknown managed-room JID (not null) — that value must reach
+    // onJoinChannelCall verbatim so the Join still targets the right room.
+    const onJoinChannelCall = mock(
+      (_channelId: string | null, _roomJid: string, _media: CallMedia) => {},
+    );
+    const media: CallMedia = { audio: false, video: true };
+    handleJoinCall(
+      entry({ channel: "orphan@muc.waddle.example" }),
+      media,
+      [],
+      onJoinChannelCall,
+    );
+    expect(onJoinChannelCall.mock.calls).toEqual([
+      ["orphan", "orphan@muc.waddle.example", media],
+    ]);
+  });
+
+  // No DM-row-no-join test at this layer: it would be vacuous. The Join
+  // path is unreachable for DM threads upstream of `ThreadsView` — only
+  // `ThreadsListRow.vue` decides whether to emit `join-call`, and it
+  // renders the `CallAnchorCard` (the sole emitter) behind
+  // `v-if="isCallThread && callState"`. DM anchors and plain threads keep
+  // the plain title row, which has no Join affordance, so no `join-call`
+  // event is ever dispatched for them. At the ThreadsView level the
+  // meaningful guarantee is the one above (and that `open-thread`, the
+  // DM routing path, never reaches `onJoinChannelCall`), asserted next.
+  test("an open-thread dispatch never reaches onJoinChannelCall", async () => {
+    const onJoinChannelCall = mock(
+      (_channelId: string | null, _roomJid: string, _media: CallMedia) => {},
+    );
+    const h = handlers();
+    await handleOpenThread(
+      entry({ channel: "bob@waddle.example", thread_id: "t-dm" }),
+      [{ id: "general", jid: "general@muc.waddle.example" }],
+      h,
+    );
+    // Opening a (DM) thread routes through onSelectThreadEntry, never the
+    // Join path — the two handlers are wired to distinct panel events.
+    expect(h.onOpenDmThread).toHaveBeenCalledTimes(1);
+    expect(onJoinChannelCall).not.toHaveBeenCalled();
   });
 });

--- a/docs/superpowers/plans/2026-06-08-thread-list-row-call-anchor.md
+++ b/docs/superpowers/plans/2026-06-08-thread-list-row-call-anchor.md
@@ -1,0 +1,675 @@
+# Thread-list-row call anchor (issue #919, AC #4) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a MUC call-thread anchor's row in the global Threads view render the live/ended `CallAnchorCard` (sharing the one live-state composable + Join path), by surfacing the anchor's call-thread metadata through the `urn:waddle:threads:0` query.
+
+**Architecture:** Capture the anchor's typed `kind`+`media` onto the inbox row at the existing groupchat thread-projection point; correlate the XEP-0422 ended fastening back to the thread via a `thread_id` added to the in-memory `ActiveCallThread`, then persist `ended`+`duration` with one cross-user `UPDATE`. Surface all four fields through `ThreadEntry` → `WaddleThreadEntry` → `WasmThreadEntry`, and feed them into the existing `useCallAnchorCardState` composable via a pure adapter consumed by `ThreadsListRow.vue`.
+
+**Tech Stack:** Rust (`waddle-xmpp`, `waddle-server`, `waddle-xmpp-client-wasm`), SQLite/Postgres via the project DB layer, TypeScript/Vue 3 (`chat/`), Bun test, `bun run lint` (knip), `cargo test`, `cargo clippy -D warnings`.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-thread-list-row-call-anchor-design.md`
+
+**Branch:** `issue-919-live-call-anchor` (PR #926). Commit after every task. Run `cargo fmt` before every Rust commit (server/CLAUDE.md). Never `unwrap`; never add clippy `allow`.
+
+---
+
+## Conventions for the implementer
+
+- Reuse the existing typed call-thread values — do NOT introduce `String` blobs for protocol data:
+  - `CallThreadKind` (`Dm`/`Muc`), `CallThreadMedia { audio: bool, video: bool }`,
+    `CallThreadDuration` — all in `server/crates/waddle-xmpp/src/xep/xep_waddle_call_thread.rs`
+    (re-exported via `xep::exports`). The anchor parser `parse_call_thread_anchor_child(&Message)` and
+    the ended parser `parse_call_thread_ended_child(&Message)` already exist there.
+- Storage serializes typed values to `String`/`i64` only at the SQL boundary (in `inbox/codec.rs`).
+- Each task is TDD: failing test → run (fail) → implement → run (pass) → `cargo fmt` (Rust) → commit.
+
+---
+
+## Task 1: `InboxEntry` carries typed call-thread metadata
+
+**Files:**
+- Modify: `server/crates/waddle-xmpp/src/inbox/mod.rs:88-164` (struct + `new` + builders)
+- Test: `server/crates/waddle-xmpp/src/inbox/tests.rs`
+
+- [ ] **Step 1: Write the failing test** (append to `inbox/tests.rs`)
+
+```rust
+#[test]
+fn inbox_entry_carries_call_thread_anchor_and_ended_metadata() {
+    use crate::xep::exports::{CallThreadDuration, CallThreadKind, CallThreadMedia};
+    let entry = InboxEntry::new(
+        "general@conference.example.com".parse().unwrap(),
+        ConversationKind::MucRoom,
+        "stanza-1",
+        1_700_000_000,
+    )
+    .with_thread("call-thread-uuid")
+    .with_call_thread(CallThreadKind::Muc, CallThreadMedia { audio: true, video: true })
+    .with_call_ended(
+        chrono::DateTime::parse_from_rfc3339("2026-06-07T14:35:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc),
+        CallThreadDuration::parse("PT5M").unwrap(),
+    );
+
+    assert_eq!(entry.call_thread_kind, Some(CallThreadKind::Muc));
+    assert_eq!(entry.call_thread_media, Some(CallThreadMedia { audio: true, video: true }));
+    assert_eq!(entry.call_duration, Some(CallThreadDuration::parse("PT5M").unwrap()));
+    assert!(entry.call_ended_at.is_some());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && cargo test -p waddle-xmpp inbox_entry_carries_call_thread -- --nocapture`
+Expected: FAIL — `no method named with_call_thread` / unknown fields.
+
+- [ ] **Step 3: Implement** — add fields to `InboxEntry` (after `author`):
+
+```rust
+    /// Call-thread anchor kind, when this thread's root is a call anchor.
+    pub call_thread_kind: Option<CallThreadKind>,
+    /// Call-thread anchor media, when this thread's root is a call anchor.
+    pub call_thread_media: Option<CallThreadMedia>,
+    /// When the call ended (XEP-0422 ended fastening), if it has ended.
+    pub call_ended_at: Option<DateTime<Utc>>,
+    /// Call duration from the ended fastening.
+    pub call_duration: Option<CallThreadDuration>,
+```
+
+Add imports at top of `mod.rs`:
+```rust
+use crate::xep::exports::{CallThreadDuration, CallThreadKind, CallThreadMedia};
+use chrono::{DateTime, Utc};
+```
+
+Initialize all four to `None` in `InboxEntry::new`. Add builders:
+```rust
+    pub fn with_call_thread(mut self, kind: CallThreadKind, media: CallThreadMedia) -> Self {
+        self.call_thread_kind = Some(kind);
+        self.call_thread_media = Some(media);
+        self
+    }
+
+    pub fn with_call_ended(mut self, ended: DateTime<Utc>, duration: CallThreadDuration) -> Self {
+        self.call_ended_at = Some(ended);
+        self.call_duration = Some(duration);
+        self
+    }
+```
+
+If `CallThreadKind`/`CallThreadMedia`/`CallThreadDuration` do not derive `Serialize`/`Deserialize` (needed because `InboxEntry` derives them), add `#[derive(Serialize, Deserialize)]` to those types in `xep_waddle_call_thread.rs` (they already derive `Debug, Clone, PartialEq, Eq`). Verify they round-trip via serde; `CallThreadMedia` is a plain struct, `CallThreadKind` an enum, `CallThreadDuration` likely wraps a `String` — derive serde on each.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && cargo test -p waddle-xmpp inbox_entry_carries_call_thread`
+Expected: PASS.
+
+- [ ] **Step 5: cargo fmt + commit**
+
+```bash
+cd server && cargo fmt
+git add server/crates/waddle-xmpp/src/inbox/mod.rs server/crates/waddle-xmpp/src/inbox/tests.rs server/crates/waddle-xmpp/src/xep/xep_waddle_call_thread.rs
+git commit -m "feat(server): carry typed call-thread metadata on InboxEntry"
+```
+
+---
+
+## Task 2: Inbox storage — schema columns, codec, upsert, select, mark-ended
+
+**Files:**
+- Modify: `server/crates/waddle-server/src/inbox/schema.rs` (add 4 columns + idempotent ALTER migrations)
+- Modify: `server/crates/waddle-server/src/inbox/codec.rs` (`SELECT_COLS`, row decode, value encode)
+- Modify: `server/crates/waddle-server/src/inbox.rs` (UPSERT bindings + `mark_call_thread_ended`)
+- Modify: `server/crates/waddle-server/src/inbox/mod.rs` or the `InboxStorage` trait def (add `mark_call_thread_ended`)
+- Test: `server/crates/waddle-server/src/inbox/tests.rs`
+
+### 2a — schema columns
+
+- [ ] **Step 1:** In `schema.rs`, add to BOTH the migration `CREATE TABLE inbox_entries_new` and the `CREATE TABLE IF NOT EXISTS inbox_entries` (before `PRIMARY KEY`):
+
+```sql
+                call_thread_kind TEXT,
+                call_thread_media TEXT,
+                call_ended_at {i64_type},
+                call_duration TEXT,
+```
+
+(In the migration `inbox_entries_new` block there is no `{i64_type}` interpolation — use `INTEGER` there to match its literal `last_updated INTEGER`.)
+
+- [ ] **Step 2:** Add an idempotent migration helper mirroring `migrate_recovery_channel_broadcast_column`, named `migrate_inbox_call_thread_columns`, that for SQLite probes `PRAGMA table_info(inbox_entries)` per column and `ALTER TABLE inbox_entries ADD COLUMN <c> <type>` when missing, and for Postgres runs `ALTER TABLE inbox_entries ADD COLUMN IF NOT EXISTS <c> <type>`. Columns/types: `call_thread_kind TEXT`, `call_thread_media TEXT`, `call_ended_at BIGINT` (use `i64_type` on Postgres path), `call_duration TEXT`. Call it from `initialize` after the `CREATE INDEX` for threads. Factor the SQLite column probe out of `recovery_column_present_sqlite` into a reusable `column_present_sqlite(storage, table, column)`.
+
+### 2b — codec + upsert + select
+
+- [ ] **Step 3: Write the failing storage test** (`inbox/tests.rs`)
+
+```rust
+#[tokio::test]
+async fn upsert_persists_call_thread_metadata_and_mark_ended_updates_all_users() {
+    use waddle_xmpp::xep::exports::{CallThreadDuration, CallThreadKind, CallThreadMedia};
+    let storage = new_test_storage().await; // follow the existing test-setup helper in this file
+    let room: BareJid = "general@conference.example.com".parse().unwrap();
+    let alice: BareJid = "alice@example.com".parse().unwrap();
+    let bob: BareJid = "bob@example.com".parse().unwrap();
+
+    let anchor = |owner: &BareJid| {
+        InboxEntry::new(room.clone(), ConversationKind::MucRoom, "anchor-stanza", 1_700_000_000)
+            .with_thread("call-thread-uuid")
+            .with_call_thread(CallThreadKind::Muc, CallThreadMedia { audio: true, video: false });
+        // owner param documents intent; upsert is keyed by user below
+    };
+    let _ = anchor;
+
+    storage.upsert(&alice, anchor_entry(&room), true).await.unwrap();
+    storage.upsert(&bob, anchor_entry(&room), true).await.unwrap();
+
+    let alice_threads = storage.list_all_threads(&alice).await.unwrap();
+    let entry = alice_threads.iter().find(|e| e.thread_id.as_deref() == Some("call-thread-uuid")).unwrap();
+    assert_eq!(entry.call_thread_kind, Some(CallThreadKind::Muc));
+    assert_eq!(entry.call_thread_media, Some(CallThreadMedia { audio: true, video: false }));
+    assert!(entry.call_ended_at.is_none());
+
+    let ended = chrono::Utc::now();
+    storage
+        .mark_call_thread_ended(&room, "call-thread-uuid", ended, &CallThreadDuration::parse("PT5M").unwrap())
+        .await
+        .unwrap();
+
+    for who in [&alice, &bob] {
+        let threads = storage.list_all_threads(who).await.unwrap();
+        let e = threads.iter().find(|e| e.thread_id.as_deref() == Some("call-thread-uuid")).unwrap();
+        assert!(e.call_ended_at.is_some(), "ended marked for {who}");
+        assert_eq!(e.call_duration, Some(CallThreadDuration::parse("PT5M").unwrap()));
+        // anchor kind/media survived the ended UPDATE
+        assert_eq!(e.call_thread_kind, Some(CallThreadKind::Muc));
+    }
+}
+
+fn anchor_entry(room: &BareJid) -> InboxEntry {
+    use waddle_xmpp::xep::exports::{CallThreadKind, CallThreadMedia};
+    InboxEntry::new(room.clone(), ConversationKind::MucRoom, "anchor-stanza", 1_700_000_000)
+        .with_thread("call-thread-uuid")
+        .with_call_thread(CallThreadKind::Muc, CallThreadMedia { audio: true, video: false })
+}
+```
+
+(Adapt `new_test_storage()` to whatever helper this test file already uses to construct a `DatabaseInboxStorage`.)
+
+- [ ] **Step 4: Run — expect FAIL** (`mark_call_thread_ended` missing; fields not decoded).
+
+Run: `cd server && cargo test -p waddle-server upsert_persists_call_thread_metadata -- --nocapture`
+
+- [ ] **Step 5: Implement codec** — in `codec.rs`:
+  - Extend `SELECT_COLS` to append `, call_thread_kind, call_thread_media, call_ended_at, call_duration`.
+  - In the row→`InboxEntry` decode, read the four columns and map:
+    - `call_thread_kind`: `Option<String>` → `CallThreadKind` (`"muc"`→`Muc`, `"dm"`→`Dm`); reuse the existing kind string<->enum helper if one exists, else add `call_thread_kind_from_str`/`to_str`.
+    - `call_thread_media`: `Option<String>` space-joined tokens (`"audio"`, `"video"`) → `CallThreadMedia` (mirror `media_from_str`/`media_to_string` used by the anchor codec).
+    - `call_ended_at`: `Option<i64>` epoch secs → `DateTime<Utc>` via `Utc.timestamp_opt`.
+    - `call_duration`: `Option<String>` → `CallThreadDuration::parse(...).ok()`.
+  - Add an encode helper `call_thread_columns(entry) -> (Option<String>, Option<String>, Option<i64>, Option<String>)` for the upsert bindings.
+
+- [ ] **Step 6: Implement upsert** — in `inbox.rs` UPSERT (lines ~254-316):
+  - Add the four columns to the INSERT column list and `VALUES` placeholders, binding via `call_thread_columns(&entry)`.
+  - In `ON CONFLICT ... DO UPDATE SET`, use `COALESCE(excluded.call_thread_kind, inbox_entries.call_thread_kind)` and likewise for `call_thread_media` (so a later reply that lacks anchor metadata does NOT wipe it). Do the same `COALESCE` for `call_ended_at` and `call_duration`.
+
+- [ ] **Step 7: Implement `mark_call_thread_ended`** — add to the `InboxStorage` trait and the `DatabaseInboxStorage` impl:
+
+```rust
+async fn mark_call_thread_ended(
+    &self,
+    room: &BareJid,
+    thread_id: &str,
+    ended: DateTime<Utc>,
+    duration: &CallThreadDuration,
+) -> Result<(), InboxStorageError>;
+```
+
+Impl runs (bind types per the project DB helpers):
+```sql
+UPDATE inbox_entries
+   SET call_ended_at = ?, call_duration = ?
+ WHERE partner_jid = ? AND thread_id = ?
+```
+with `ended.timestamp()`, `duration.as_str()` (or its serialized form), `room.to_string()`, `thread_id`.
+Add a no-op default or `unimplemented!`-free stub for any other `InboxStorage` impls (e.g. an in-memory test store) — search for `impl InboxStorage for`.
+
+- [ ] **Step 8: Run — expect PASS.** Then `cargo fmt`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd server && cargo fmt
+git add server/crates/waddle-server/src/inbox.rs server/crates/waddle-server/src/inbox/
+git commit -m "feat(server): persist call-thread metadata + mark-ended in inbox storage"
+```
+
+---
+
+## Task 3: Capture anchor kind+media at groupchat thread projection
+
+**Files:**
+- Modify: `server/crates/waddle-xmpp/src/protocol/room/inbox.rs:148-171` (`thread_projection`, `GroupchatThreadProjection`)
+- Modify: the `OutboundEvent::ProjectGroupchatInbox` definition (add call-thread fields to the `thread` projection — it is already a struct field, so extend `GroupchatThreadProjection`)
+- Modify: `server/crates/waddle-server/src/server/routes/interpret.rs` (where `ProjectGroupchatInbox` builds the `InboxEntry`) — call `.with_call_thread(kind, media)` when present
+- Test: `server/crates/waddle-xmpp/src/protocol/room/` test module (find the existing inbox-handler tests; else add `#[cfg(test)]` here)
+
+- [ ] **Step 1: Write the failing test** — feed a call-thread anchor message through `thread_projection` and assert the projection carries `call_thread_kind = Muc` and the media; feed a plain thread reply and assert `None`.
+
+```rust
+#[test]
+fn thread_projection_captures_call_thread_anchor_metadata() {
+    use crate::xep::exports::{CallThreadAnchor, CallThreadKind, CallThreadMedia, build_call_thread_anchor};
+    // Build a groupchat message that is a thread root (id == thread id) carrying the anchor marker.
+    let mut msg = /* construct Message with <thread> id="t1", message.id = "t1" */;
+    msg.payloads.push(build_call_thread_anchor(&CallThreadAnchor {
+        kind: CallThreadKind::Muc,
+        sid: /* SessionId */,
+        media: CallThreadMedia { audio: true, video: true },
+        initiator: "alice@example.com".parse().unwrap(),
+        started: chrono::Utc::now(),
+    }));
+    let projection = thread_projection(&msg).expect("projection");
+    assert_eq!(projection.call_thread_kind, Some(CallThreadKind::Muc));
+    assert_eq!(projection.call_thread_media, Some(CallThreadMedia { audio: true, video: true }));
+}
+```
+
+(Model the `Message` construction on the existing tests in this module / `xep_waddle_call_thread.rs`.)
+
+- [ ] **Step 2: Run — expect FAIL** (unknown fields).
+
+Run: `cd server && cargo test -p waddle-xmpp thread_projection_captures_call_thread`
+
+- [ ] **Step 3: Implement**
+  - Add to `GroupchatThreadProjection`: `pub call_thread_kind: Option<CallThreadKind>`, `pub call_thread_media: Option<CallThreadMedia>`.
+  - In `thread_projection`, after computing title/author, parse the anchor:
+    ```rust
+    let call_anchor = parse_call_thread_anchor_child(message);
+    ```
+    (import `parse_call_thread_anchor_child` from the call-thread xep module) and set
+    `call_thread_kind: call_anchor.as_ref().map(|a| a.kind)`, `call_thread_media: call_anchor.as_ref().map(|a| a.media.clone())`.
+  - Initialize the new fields wherever `GroupchatThreadProjection { .. }` is constructed (search for it).
+  - In `interpret.rs`, where the `InboxEntry` is built from `thread`, add:
+    ```rust
+    if let (Some(kind), Some(media)) = (thread.call_thread_kind, thread.call_thread_media.clone()) {
+        entry = entry.with_call_thread(kind, media);
+    }
+    ```
+
+- [ ] **Step 4: Run — expect PASS.** `cargo fmt`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd server && cargo fmt
+git add server/crates/waddle-xmpp/src/protocol/room/inbox.rs server/crates/waddle-server/src/server/routes/interpret.rs
+git commit -m "feat(server): project call-thread anchor metadata into the inbox"
+```
+
+---
+
+## Task 4: Correlate the ended fastening to the thread + persist ended/duration
+
+**Files:**
+- Modify: `server/crates/waddle-server/src/server/routes/websocket/state.rs` (`ActiveCallThread` += `thread_id`)
+- Modify: `server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs` (capture thread_id into `ActiveCallThread`; the anchor message builds the `<thread>` so the id is in scope at `build_call_thread_anchor_message` / its caller)
+- Modify: `server/crates/waddle-server/src/server/routes/muc_muji_clear.rs` (`maybe_broadcast_call_thread_ended`: after removing the `ActiveCallThread`, call `inbox.mark_call_thread_ended(room, &active.thread_id, ended, &duration)`)
+- Test: `server/crates/waddle-server/tests/calls_e2e_ws.rs` (extend the existing `livekit_last_participant_left_fastens_ended_summary_to_call_thread_anchor` or add a sibling that also asserts the inbox/threads-query reflects ended)
+
+- [ ] **Step 1: Write/extend the failing integration test** — after the ended fastening is broadcast, issue a `urn:waddle:threads:0` query (mirror `waddle_threads_query_ws.rs` helpers) and assert the call-thread row comes back with `call_thread_ended` populated (the WASM field added in Task 6) — OR, to keep this task server-internal, assert via a direct `inbox.list_all_threads` lookup that `call_ended_at`/`call_duration` are set. Prefer the storage-level assertion here; the WASM/threads-query end-to-end is covered in Task 5/6.
+
+- [ ] **Step 2: Run — expect FAIL** (thread_id missing on `ActiveCallThread`; ended not persisted).
+
+- [ ] **Step 3: Implement**
+  - `ActiveCallThread { anchor_origin_id, started, thread_id }`.
+  - At anchor creation in `muc_update.rs`, the `thread_id` UUID is generated in `build_call_thread_anchor_message`. Return it (or extract from the built message's `<thread>`) so the caller stores it in the `call_threads` insert (lines ~332-342). Update the insert to include `thread_id`.
+  - In `maybe_broadcast_call_thread_ended` (`muc_muji_clear.rs`), after `let Some((_, active)) = ...call_threads.remove(room_jid)`, compute `ended`/`duration` (already done), then:
+    ```rust
+    if let Err(error) = state.deps.inbox.mark_call_thread_ended(room_jid, &active.thread_id, ended, &duration).await {
+        // log via the existing Log/tracing path used in this file
+        tracing::warn!(%room_jid, %error, "failed to mark call-thread ended in inbox");
+    }
+    ```
+    (Use whatever inbox handle `state.deps` exposes — search `deps.inbox` / how `interpret.rs` reaches inbox storage; reuse that path. Do not `unwrap`.)
+
+- [ ] **Step 4: Run — expect PASS.** `cargo fmt`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd server && cargo fmt
+git add server/crates/waddle-server/src/server/routes/websocket/state.rs server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs server/crates/waddle-server/src/server/routes/muc_muji_clear.rs server/crates/waddle-server/tests/calls_e2e_ws.rs
+git commit -m "feat(server): persist call-thread ended summary onto the thread inbox rows"
+```
+
+---
+
+## Task 5: Threads query carries the call-thread fields
+
+**Files:**
+- Modify: `server/crates/waddle-server/src/threads/query.rs` (`ThreadEntry`)
+- Modify: `server/crates/waddle-server/src/threads/storage.rs:247-264` (`build_thread_entry`)
+- Test: `server/crates/waddle-server/tests/waddle_threads_query_ws.rs`
+
+- [ ] **Step 1: Write the failing test** — seed an inbox call-thread anchor (+ optionally mark ended), run the threads-query WS flow, assert the returned entry exposes the call-thread anchor kind/media and (when ended) ended/duration. Mirror the existing helpers in this file.
+
+- [ ] **Step 2: Run — expect FAIL.**
+
+Run: `cd server && cargo test -p waddle-server --test waddle_threads_query_ws -- --nocapture`
+
+- [ ] **Step 3: Implement** — add to `ThreadEntry`:
+```rust
+    pub call_thread_kind: Option<CallThreadKind>,
+    pub call_thread_media: Option<CallThreadMedia>,
+    pub call_ended_at: Option<DateTime<Utc>>,
+    pub call_duration: Option<CallThreadDuration>,
+```
+and in `build_thread_entry` copy them from the `InboxEntry` row (`row.call_thread_kind.clone()`, etc.).
+
+- [ ] **Step 4: Run — expect PASS.** `cargo fmt`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd server && cargo fmt
+git add server/crates/waddle-server/src/threads/
+git commit -m "feat(server): expose call-thread fields on threads-query entries"
+```
+
+---
+
+## Task 6: WASM bridge — `WaddleThreadEntry` call-thread fields + d.ts
+
+**Files:**
+- Modify: `server/crates/waddle-xmpp-client-wasm/src/types.rs:870-886` (`WaddleThreadEntry`)
+- Modify: `server/crates/waddle-xmpp-client-wasm/src/client_account.rs` (ThreadEntry→WaddleThreadEntry conversion)
+- Modify (generated): `server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts` (regenerate or hand-edit to match)
+- Test: `server/crates/waddle-xmpp-client-wasm/` test module (add a serde-shape test if the crate has one; else assert in `client_account` conversion test)
+
+- [ ] **Step 1: Write the failing test** — construct a `ThreadEntry` with `call_thread_kind=Muc`, media audio+video, ended+duration; convert to `WaddleThreadEntry`; serialize to JSON; assert `callThread.kind == "muc"`, `callThread.media == ["audio","video"]`, `callThreadEnded.ended` + `callThreadEnded.duration == "PT5M"`. For a non-call entry assert both are absent (`skip_serializing_if`).
+
+- [ ] **Step 2: Run — expect FAIL.**
+
+- [ ] **Step 3: Implement** — add to `WaddleThreadEntry`:
+```rust
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub call_thread: Option<WaddleThreadCallAnchor>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub call_thread_ended: Option<WaddleThreadCallEnded>,
+```
+with new serde structs (camelCase via the crate's existing rename convention — match `WaddleCallThreadAnchor` style):
+```rust
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WaddleThreadCallAnchor { pub kind: String, pub media: Vec<String> }
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WaddleThreadCallEnded { pub ended: String, pub duration: String }
+```
+In `client_account.rs` conversion, map `kind` via `match { Muc => "muc", Dm => "dm" }`, media via the existing media→`Vec<String>` helper (`["audio"]`/`["audio","video"]`), `ended` to RFC 3339, `duration` to its string form.
+
+- [ ] **Step 4: Regenerate the d.ts** — run the project's wasm build/typegen (check `server/` scripts / `justfile` / `Makefile`; e.g. `wasm-pack`/`wasm-bindgen` step). If typegen is manual, add to the `WaddleThreadEntry` interface in the `.d.ts`:
+```ts
+  callThread?: { kind: string; media: string[] };
+  callThreadEnded?: { ended: string; duration: string };
+```
+
+- [ ] **Step 5: Run — expect PASS.** `cargo fmt`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd server && cargo fmt
+git add server/crates/waddle-xmpp-client-wasm/ server/wasm-pkg/waddle-xmpp-client-wasm/
+git commit -m "feat(server): surface call-thread fields on the WASM thread entry"
+```
+
+---
+
+## Task 7: TS contract + `wasmThreadEntryToAnchorMessage` adapter
+
+**Files:**
+- Modify: `chat/src/lib/xmpp/wasm-types.ts:372-384` (`WasmThreadEntry`)
+- Modify: `chat/src/lib/call-thread-anchor.ts` (add adapter)
+- Test: `chat/tests/call-thread-anchor.test.ts`
+
+- [ ] **Step 1: Write the failing test** (append to `call-thread-anchor.test.ts`)
+
+```ts
+import { wasmThreadEntryToAnchorMessage } from "../src/lib/call-thread-anchor";
+import type { WasmThreadEntry } from "../src/lib/xmpp/wasm-types";
+
+const baseEntry: WasmThreadEntry = {
+  channel: "general@conference.example.com",
+  thread_id: "call-thread-uuid",
+  last_stanza_id: "s1",
+  last_activity: "2026-06-07T14:30:00Z",
+  unread: 0,
+  reply_count: 7,
+  has_unread: false,
+};
+
+test("adapts a live MUC call-thread entry into an anchor-shaped message", () => {
+  const msg = wasmThreadEntryToAnchorMessage({
+    ...baseEntry,
+    callThread: { kind: "muc", media: ["audio", "video"] },
+  });
+  expect(msg).toEqual({
+    body: "",
+    author: "",
+    threadId: "call-thread-uuid",
+    callThread: { kind: "muc", media: ["audio", "video"] },
+  });
+});
+
+test("adapts an ended MUC call-thread entry with duration", () => {
+  const msg = wasmThreadEntryToAnchorMessage({
+    ...baseEntry,
+    callThread: { kind: "muc", media: ["audio"] },
+    callThreadEnded: { ended: "2026-06-07T14:35:00Z", duration: "PT5M" },
+  });
+  expect(msg?.callThread).toEqual({
+    kind: "muc",
+    media: ["audio"],
+    ended: "2026-06-07T14:35:00Z",
+    duration: "PT5M",
+  });
+});
+
+test("returns null for non-call and non-muc entries", () => {
+  expect(wasmThreadEntryToAnchorMessage(baseEntry)).toBeNull();
+  expect(
+    wasmThreadEntryToAnchorMessage({ ...baseEntry, callThread: { kind: "dm", media: ["audio"] } }),
+  ).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL.**
+
+Run: `cd chat && bun test tests/call-thread-anchor.test.ts`
+
+- [ ] **Step 3: Implement** — in `wasm-types.ts`, add to `WasmThreadEntry`:
+```ts
+  callThread?: { kind: "muc" | "dm"; media: ("audio" | "video")[] };
+  callThreadEnded?: { ended: string; duration: string };
+```
+In `call-thread-anchor.ts`, add:
+```ts
+import type { WasmThreadEntry } from "@/lib/xmpp/wasm-types";
+
+export function wasmThreadEntryToAnchorMessage(
+  entry: WasmThreadEntry,
+): Pick<TimelineMessage, "body" | "author" | "callThread" | "threadId"> | null {
+  if (!entry.callThread || entry.callThread.kind !== "muc") return null;
+  return {
+    body: "",
+    author: "",
+    threadId: entry.thread_id,
+    callThread: {
+      kind: "muc",
+      media: entry.callThread.media,
+      ...(entry.callThreadEnded
+        ? { ended: entry.callThreadEnded.ended, duration: entry.callThreadEnded.duration }
+        : {}),
+    },
+  };
+}
+```
+(Confirm `CallThreadAnchor` in `chat-ui.ts` requires `sid`/`initiator`/`started`. If those are non-optional, relax them to optional — they are unused by `readCallAnchorCardState`, which only reads `ended`/`duration`/`media` — or build a minimal object cast through the same `Pick`. Prefer making `sid`/`initiator`/`started` optional on `CallThreadAnchor` since timeline messages always set them but thread-entry-derived anchors do not.)
+
+- [ ] **Step 4: Run — expect PASS.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add chat/src/lib/xmpp/wasm-types.ts chat/src/lib/call-thread-anchor.ts chat/tests/call-thread-anchor.test.ts
+git commit -m "feat(chat): adapt WASM thread entries into call-anchor card state"
+```
+
+---
+
+## Task 8: Visible ended duration in the card title
+
+**Files:**
+- Modify: `chat/src/lib/call-thread-anchor.ts` (`buildCallAnchorCardState` ended title)
+- Test: `chat/tests/call-thread-anchor.test.ts` (extend the existing stale-live test)
+
+- [ ] **Step 1: Write the failing assertion** — in the stale-live `toMatchObject({ status: "ended", ... })` test, after clearing participants set `callThread.ended`+`duration` on the timeline message and assert `title: "Call ended · 5m"`. Add a fresh test:
+
+```ts
+test("ended card title includes the formatted duration", () => {
+  const timelineMessage = mapLiveRoomMessageToTimeline(session, callAnchor({
+    roomJid: "general@conference.example.com",
+    callThread: { kind: "muc", sid: "s", media: ["audio"], initiator: "alice@example.com", started: "2026-06-07T14:30:00Z", ended: "2026-06-07T14:35:00Z", duration: "PT5M" },
+  }));
+  expect(readCallAnchorCardState(timelineMessage, "general@conference.example.com")).toMatchObject({
+    status: "ended",
+    title: "Call ended · 5m",
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL** (title is `"Call ended"`).
+
+- [ ] **Step 3: Implement** — in `buildCallAnchorCardState`, replace the ended title:
+```ts
+    title: live
+      ? `Live ${mediaLabel}`
+      : callThread.ended && callThread.duration
+        ? `Call ended · ${formatCallThreadDuration(callThread.duration)}`
+        : "Call ended",
+```
+(Export/keep `formatCallThreadDuration` accessible within the module — it already exists.)
+
+- [ ] **Step 4: Run — expect PASS** (also re-run the full `call-thread-anchor.test.ts` and `call-anchor-card.test.ts` to confirm no regression to existing title assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add chat/src/lib/call-thread-anchor.ts chat/tests/call-thread-anchor.test.ts
+git commit -m "feat(chat): show call duration in ended anchor card title"
+```
+
+---
+
+## Task 9: `ThreadsListRow.vue` renders the call card + shared Join
+
+**Files:**
+- Modify: `chat/src/components/chat/ThreadsListRow.vue` (render `CallAnchorCard` when entry is a MUC call thread)
+- Modify: `chat/src/components/chat/ThreadsListPanel.vue` (forward a `joinCall` event)
+- Modify: `chat/src/components/chat/ThreadsView.vue` (route `joinCall` to the shared channel-join path used by the banner)
+- Modify: `chat/src/components/chat/ChatReadyShell.vue` (wire `ThreadsView`'s join to the same handler the banner uses; reuse existing `joinChannelCall` wiring)
+- Test: `chat/tests/threads-list-row.test.ts` (new — SSR harness copied from `call-anchor-card.test.ts`)
+
+- [ ] **Step 1: Write the failing SSR test** (`tests/threads-list-row.test.ts`) — reuse the `renderVueComponent`/`loadVueComponent` helper pattern from `call-anchor-card.test.ts` (extract it to `tests/helpers/render-vue-sfc.ts` and import from both, to stay DRY). Cases:
+  - live MUC entry (`callThread` set, room has an active call via the seeded `$mucCallParticipants` store) → html contains `call-anchor-card__pulse` and `Join` and `7 messages in call chat`.
+  - ended MUC entry (`callThreadEnded` set, no active call) → contains `call-anchor-card--ended`, `Call ended`, and NOT `>Join<`.
+  - non-call entry → contains the plain `{{ title }}` row, NOT `call-anchor-card`.
+
+  Since the row uses the reactive `useCallAnchorCardState`, drive the nanostores (`$mucCallParticipants.set({...})`, `$mucCallMedia.setKey(...)`) before render, and reset in `afterEach` (mirror `call-thread-anchor.test.ts`).
+
+- [ ] **Step 2: Run — expect FAIL.**
+
+Run: `cd chat && bun test tests/threads-list-row.test.ts`
+
+- [ ] **Step 3: Implement `ThreadsListRow.vue`**
+```vue
+<script setup lang="ts">
+import { computed } from "vue";
+import CallAnchorCard from "@/components/calls/CallAnchorCard.vue";
+import { useCallAnchorCardState, wasmThreadEntryToAnchorMessage } from "@/lib/call-thread-anchor";
+import type { WasmThreadEntry } from "@/lib/xmpp/wasm-types";
+// ...existing imports/props/emits...
+const emit = defineEmits<{
+  open: [entry: WasmThreadEntry];
+  markRead: [entry: WasmThreadEntry];
+  joinCall: [entry: WasmThreadEntry];
+}>();
+
+const anchorMessage = computed(() => wasmThreadEntryToAnchorMessage(props.entry));
+const isCallThread = computed(() => anchorMessage.value !== null);
+const callState = useCallAnchorCardState(
+  () => anchorMessage.value ?? { body: "", author: "", threadId: null, callThread: undefined },
+  () => props.entry.channel,
+  () => props.entry.reply_count,
+);
+</script>
+
+<template>
+  <div class="chat-thread-row ...">
+    <CallAnchorCard
+      v-if="isCallThread && callState"
+      :state="callState"
+      @join="emit('joinCall', entry)"
+      @open-thread="emit('open', entry)"
+    />
+    <template v-else>
+      <!-- existing button/title/replies/unread markup unchanged -->
+    </template>
+    <!-- existing mark-read button unchanged -->
+  </div>
+</template>
+```
+(Keep the existing prop `entry: WasmThreadEntry` and `markingRead`. Guard `callState` for null.)
+
+- [ ] **Step 4: Implement the join routing** — `ThreadsListPanel.vue` re-emits `joinCall`; `ThreadsView.vue` resolves `entry.channel` → channelId (it already has `resolveChannelIdForRoomJid`) and calls the same prop the banner's Join uses. In `ChatReadyShell.vue`, pass `ThreadsView` a `:on-join-call` that invokes the existing `joinChannelCall` handler (the one `ConversationCallBanner` uses) — do NOT introduce a second join path. Search `joinChannelCall` / the banner's `@join` wiring and reuse it.
+
+- [ ] **Step 5: Run — expect PASS.** Run the whole call + threads suite:
+
+Run: `cd chat && bun test tests/threads-list-row.test.ts tests/call-anchor-card.test.ts tests/call-thread-anchor.test.ts tests/threads-view.test.ts`
+Expected: all PASS.
+
+- [ ] **Step 6: knip + commit**
+
+```bash
+cd chat && bunx knip
+git add chat/src/components/chat/ThreadsListRow.vue chat/src/components/chat/ThreadsListPanel.vue chat/src/components/chat/ThreadsView.vue chat/src/components/chat/ChatReadyShell.vue chat/tests/threads-list-row.test.ts chat/tests/helpers/render-vue-sfc.ts
+git commit -m "feat(chat): render live/ended call card on global thread-list rows"
+```
+
+---
+
+## Task 10: Full verification + PR finalize
+
+- [ ] **Step 1:** `cd chat && bun test` → all pass.
+- [ ] **Step 2:** `cd chat && bun run lint` (knip) → clean.
+- [ ] **Step 3:** `cd chat && bunx astro check` → no NEW errors (the pre-existing `cloudflare:workers` diagnostic is allowed).
+- [ ] **Step 4:** `cd server && cargo fmt --check`
+- [ ] **Step 5:** `cd server && cargo test -p waddle-xmpp -p waddle-server -p waddle-xmpp-client-wasm` (at least the call-thread, inbox, threads-query, calls_e2e_ws suites) → all pass.
+- [ ] **Step 6:** `cd server && cargo clippy -p waddle-xmpp -p waddle-server -p waddle-xmpp-client-wasm -- -D warnings` → clean.
+- [ ] **Step 7:** Adversarial review (per CLAUDE.md): dispatch reviewer sub-agents (protocol-conformance, Rust/storage correctness, TS/Vue) over the diff; fix real findings; repeat until clean.
+- [ ] **Step 8:** Update PR #926 title/description to describe the complete work (frontend + server), mark ready for review (remove draft), keep the spec link; verify rendered body with `gh pr view`.
+- [ ] **Step 9:** Push; monitor CI (`waddle-chat-pullRequest`, nix gates, CodeQL) until all green; fix failures.
+
+---
+
+## Self-review notes (spec coverage)
+
+- AC #4 global thread-list row live/ended + shared Join → Tasks 1–9 (9 wires the row + shared join).
+- "No new wire data" → Tasks 3/4 reuse existing markers; only the `urn:waddle:threads:0` response shape grows (Tasks 5/6/7).
+- Typed payloads → Tasks 1/3/5/6 keep `CallThreadKind`/`CallThreadMedia`/`CallThreadDuration` typed; strings only in codec (Task 2) and WASM boundary (Task 6).
+- Ended duration visible → Task 8.
+- XEP custom test-suite rule → Rust tests in Tasks 1–6; TS tests in 7–9.
+- knip clean / clippy -D warnings → Task 10.
+- Type-name consistency: `with_call_thread`, `with_call_ended`, `mark_call_thread_ended`, `call_thread_kind`/`call_thread_media`/`call_ended_at`/`call_duration`, `WaddleThreadCallAnchor`/`WaddleThreadCallEnded`, `callThread`/`callThreadEnded` (TS), `wasmThreadEntryToAnchorMessage` — used consistently across tasks.

--- a/docs/superpowers/specs/2026-06-08-thread-list-row-call-anchor-design.md
+++ b/docs/superpowers/specs/2026-06-08-thread-list-row-call-anchor-design.md
@@ -1,0 +1,173 @@
+# Thread-list-row call anchor (issue #919, AC #4) — design
+
+Date: 2026-06-08
+Branch / PR: `issue-919-live-call-anchor` / #926
+Closes the remaining acceptance item of **#919** ("Call Chat 3/7: live state + rich
+anchor card + banner dedup (MUC)"): the **thread-list row** must reflect the same
+live/ended call state as the banner and thread-panel header, and share one Join
+action.
+
+## Background
+
+PR #926 already added the shared live-state composable (`readCallAnchorCardState` /
+`useCallAnchorCardState`), the `CallAnchorCard`, and wired the channel timeline
+anchor (`MessageCard.vue`) and the thread-panel header (`ThreadPanel.vue`). It
+deliberately deferred the **global Threads view row** (`ThreadsListRow.vue`)
+because that row is fed by the server `urn:waddle:threads:0` query
+(`WasmThreadEntry`), which carries no call-thread metadata, and the live MUC
+detector is keyed only by room JID (it cannot tell a row "you are *the* call
+thread").
+
+## Goal
+
+A `ThreadsListRow` that represents a MUC call-thread anchor renders the
+`CallAnchorCard`:
+- **Live** (room currently has an active call): pulse, media icon, participant
+  count, Join, "N messages in call chat".
+- **Ended**: muted "Call ended · <duration>", no Join — including for channels the
+  client has not loaded into memory.
+
+All three surfaces (banner, thread-list row, thread-panel header) read the one
+shared composable and invoke the one shared `joinChannelCall` path — no divergence.
+
+## Constraints (from CLAUDE.md)
+
+- **No new XMPP wire data.** The `urn:waddle:call-thread:0` anchor marker and the
+  XEP-0422 `<call-thread-ended>` fastening already exist on the wire (slices
+  #916/#918). We only surface what is already there through the *internal*
+  `urn:waddle:threads:0` query response shape (a `urn:waddle:*` namespace, free to
+  extend; no official XEP conflict).
+- **Typed payloads.** New `InboxEntry` / `ThreadEntry` fields are typed
+  (`CallThreadKind`, `CallThreadMedia`, `CallThreadDuration`), not strings.
+  Serialization to `String` happens only at the SQL/WASM boundary.
+- **XEP custom test-suite rule.** Threads-query + call-thread behavior changes ship
+  with Rust tests in the same PR.
+- `clippy -D warnings` (server), `knip` clean (chat), no channel-threading
+  regressions.
+- Breaking changes by default; no production data — schema columns added directly,
+  no back-compat shims.
+
+## Architecture / data flow
+
+```
+MUC call anchor message (urn:waddle:call-thread:0 + <thread> + origin-id)
+  └─ MucInboxHandler.thread_projection  ──capture kind+media──┐
+                                                              ▼
+                                          GroupchatThreadProjection (+ call_thread)
+                                                              ▼
+                                ProjectGroupchatInbox event ─► interpret.rs
+                                                              ▼
+                          InboxEntry (+ call_thread_kind, call_thread_media)  ──► inbox_entries
+call ends (last participant) → maybe_broadcast_call_thread_ended
+  └─ ActiveCallThread (now carries thread_id) ──► inbox.mark_call_thread_ended(room, thread_id, ended, duration)
+                                                              ▼
+                          inbox_entries.call_ended_at / call_duration  (UPDATE across all users for that thread)
+                                                              ▼
+list_all_threads → build_thread_entry → ThreadEntry (+ call_thread*) → WaddleThreadEntry → WasmThreadEntry
+                                                              ▼
+ThreadsListRow.vue: wasmThreadEntryToAnchorMessage(entry) → useCallAnchorCardState(msg, channel, count) → CallAnchorCard
+                                                              │ live state from useRoomHasActiveCall(entry.channel)
+                                                              └ Join → shared joinChannelCall path
+```
+
+## Server changes (Rust)
+
+1. **`InboxEntry`** (`waddle-xmpp/src/inbox/mod.rs`) — add typed optional fields and
+   builder methods:
+   - `call_thread_kind: Option<CallThreadKind>`
+   - `call_thread_media: Option<CallThreadMedia>`
+   - `call_ended_at: Option<DateTime<Utc>>` (or unix secs at the storage boundary)
+   - `call_duration: Option<CallThreadDuration>`
+
+2. **Anchor capture** (`waddle-xmpp/src/protocol/room/inbox.rs`) — extend
+   `GroupchatThreadProjection` with `call_thread_kind` + `call_thread_media`, parsed
+   from the anchor child of the message in `thread_projection`. Thread root markers
+   only (the anchor is the thread root). Propagate through `ProjectGroupchatInbox`
+   into the `InboxEntry` built in `interpret.rs`.
+
+3. **Ended correlation** (`websocket/state.rs`, `handlers/presence/muc_update.rs`,
+   `routes/muc_muji_clear.rs`):
+   - Add `thread_id: String` to `ActiveCallThread`; capture it from the anchor's
+     `<thread>` when inserting into `protocol.call_threads`.
+   - In `maybe_broadcast_call_thread_ended`, after removing the `ActiveCallThread`
+     (now with `thread_id`), call a new
+     `InboxStorage::mark_call_thread_ended(partner=room, thread_id, ended, duration)`
+     that issues a single
+     `UPDATE inbox_entries SET call_ended_at=?, call_duration=? WHERE partner_jid=? AND thread_id=?`
+     — updating every user's row for that thread without enumerating recipients
+     (the inbox table is shared, keyed by `(user_jid, partner_jid, thread_id)`).
+
+4. **Storage** (`waddle-server/src/inbox/schema.rs`, `inbox.rs`, `inbox/codec.rs`):
+   - Add nullable columns: `call_thread_kind TEXT`, `call_thread_media TEXT`,
+     `call_ended_at BIGINT`, `call_duration TEXT` (ISO-8601 duration string).
+   - Extend `SELECT_COLS`, the UPSERT (carry kind+media via `COALESCE` so a later
+     reply does not wipe the anchor's metadata), row decode, and add the
+     `mark_call_thread_ended` UPDATE.
+
+5. **Threads query** (`waddle-server/src/threads/query.rs`, `storage.rs`) —
+   `ThreadEntry` gains the four call-thread fields; `build_thread_entry` copies them
+   from `InboxEntry`.
+
+6. **WASM bridge** (`waddle-xmpp-client-wasm/src/types.rs`, `client_account.rs`) —
+   `WaddleThreadEntry` gains `call_thread: Option<{ kind, media }>` and
+   `call_thread_ended: Option<{ ended, duration }>` (camelCase via serde),
+   `skip_serializing_if = None`.
+
+## Contract / frontend (TypeScript)
+
+7. **`WasmThreadEntry`** (`chat/src/lib/xmpp/wasm-types.ts`) — add optional
+   `callThread?: { kind: "muc"; media: ("audio"|"video")[] }` and
+   `callThreadEnded?: { ended: string; duration: string }`.
+
+8. **Adapter** (`chat/src/lib/call-thread-anchor.ts`) — add a pure
+   `wasmThreadEntryToAnchorMessage(entry): Pick<TimelineMessage,"body"|"author"|"callThread"|"threadId"> | null`
+   returning `null` when `entry.callThread` is absent or `kind !== "muc"`, else a
+   message-shaped object with `callThread: { kind, media, ended?, duration? }` and
+   `threadId: entry.thread_id`. This feeds the *existing*
+   `useCallAnchorCardState(message, roomJid, messageCount)` unchanged.
+
+9. **`ThreadsListRow.vue`** — when the adapter yields a call anchor:
+   - render `CallAnchorCard` with `useCallAnchorCardState(() => msg, () => entry.channel, () => entry.reply_count)`;
+   - `@join` → emit a shared join intent the panel routes to `joinChannelCall`
+     (same path as the banner); `@open-thread` → existing open behavior.
+   - otherwise render the current row markup unchanged.
+
+   (Scope: the global Threads view row is the deferred AC surface. The channel
+   sidebar list / `TopicsPanel` rows are a low-value follow-up — the thread-panel
+   header and timeline anchor already cover the active-conversation surface — and
+   are out of scope here.)
+
+10. **Visible ended duration** (`buildCallAnchorCardState` in
+    `call-thread-anchor.ts`) — the ended `title` is currently the literal
+    `"Call ended"`; the duration only reaches `ariaLabel`. Change the ended title to
+    `Call ended · <formatted duration>` when `callThread.ended && duration`, so the
+    AC's visible "Call ended · <duration>" holds across all three surfaces (timeline
+    anchor, thread-panel header, global row). Reuse the existing
+    `formatCallThreadDuration`. No behavior change when duration is absent.
+
+## Testing
+
+- **Rust**
+  - inbox storage: upsert persists kind+media; `mark_call_thread_ended` sets
+    ended+duration for all users' rows of a thread; reply upsert does not clear
+    kind+media (`waddle-server/src/inbox/tests.rs`).
+  - threads query: `ThreadEntry` carries the call-thread fields end-to-end
+    (`tests/waddle_threads_query_ws.rs`).
+  - call-thread anchor projection: anchor message yields a projection with
+    kind+media; non-anchor reply does not (inbox handler test / call-thread suite).
+- **TypeScript**
+  - `wasmThreadEntryToAnchorMessage`: maps a MUC call entry; returns `null` for
+    non-call / non-muc / missing metadata.
+  - `ThreadsListRow.vue` SSR render: live entry → pulse + Join + "N messages";
+    ended entry (`callThreadEnded` set, no active call) → muted "Call ended · 5m",
+    no Join; non-call entry → unchanged title/replies row. (mirrors
+    `call-anchor-card.test.ts` SSR harness)
+  - `knip` clean.
+
+## Out of scope
+
+- DM 1:1 call threads (different slice; anchors here are `kind: "muc"` only).
+- `TopicsPanel` / channel-sidebar thread-list rows (follow-up; not the deferred AC
+  surface).
+- Server-restart durability of in-flight call anchors (pre-existing limitation of
+  the in-memory `call_threads` map; unchanged here).

--- a/server/crates/waddle-server/src/inbox.rs
+++ b/server/crates/waddle-server/src/inbox.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use crate::db::{DatabaseConfig, DatabaseDriver, IntoParams};
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use jid::BareJid;
 use tracing::{info, instrument};
 use waddle_xmpp::inbox::storage::{
@@ -12,6 +13,7 @@ use waddle_xmpp::inbox::storage::{
     InboxStorageError,
 };
 use waddle_xmpp::inbox::{ConversationKind, InboxEntry};
+use waddle_xmpp::xep::CallThreadDuration;
 use waddle_xmpp_core::xep0359::StanzaId;
 
 use crate::db::Database;
@@ -20,7 +22,7 @@ mod codec;
 mod open;
 mod schema;
 
-use codec::{decode_row, encode_kind, SELECT_COLS};
+use codec::{decode_row, encode_call_thread_columns, encode_kind, SELECT_COLS};
 pub use open::build_inbox_storage;
 
 const GROUPCHAT_NOTIFICATION_RECOVERY_SELECT_COLS: &str = "recipient_bare_jid, room_jid, thread_id, stanza_id_by, stanza_id, sender_jid, is_live_occupant, room_members_only, sender_can_broadcast_channel_mention, created_at_ms";
@@ -81,6 +83,76 @@ impl DatabaseInboxStorage {
             .map_err(|error| InboxStorageError::Other(error.to_string()))?;
         Ok(())
     }
+}
+
+/// Shared INSERT … ON CONFLICT for the inbox upsert. The two trailing
+/// `?` placeholders carry the unread/reply increment flags; the
+/// `call_*` columns COALESCE `excluded` over the stored value so a later
+/// non-anchor reply upsert (which carries no call metadata) does not
+/// wipe the anchor's kind/media or the ended summary.
+fn upsert_sql() -> String {
+    format!(
+        r#"
+        INSERT INTO inbox_entries (
+            user_jid, partner_jid, thread_id, kind, last_stanza_id, last_updated,
+            unread, preview, thread_title, reply_count, author,
+            call_thread_kind, call_thread_media, call_ended_at, call_duration
+        ) VALUES (?, ?, ?, ?, ?, ?, CASE WHEN ? != 0 THEN 1 ELSE 0 END, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(user_jid, partner_jid, thread_id) DO UPDATE SET
+            kind = excluded.kind,
+            last_stanza_id = excluded.last_stanza_id,
+            last_updated = excluded.last_updated,
+            preview = excluded.preview,
+            unread = CASE
+                WHEN ? != 0 THEN inbox_entries.unread + 1
+                ELSE inbox_entries.unread
+            END,
+            thread_title = COALESCE(excluded.thread_title, inbox_entries.thread_title),
+            reply_count = CASE
+                WHEN ? != 0 THEN inbox_entries.reply_count + 1
+                ELSE inbox_entries.reply_count
+            END,
+            author = COALESCE(excluded.author, inbox_entries.author),
+            call_thread_kind = COALESCE(excluded.call_thread_kind, inbox_entries.call_thread_kind),
+            call_thread_media = COALESCE(excluded.call_thread_media, inbox_entries.call_thread_media),
+            call_ended_at = COALESCE(excluded.call_ended_at, inbox_entries.call_ended_at),
+            call_duration = COALESCE(excluded.call_duration, inbox_entries.call_duration)
+        RETURNING {SELECT_COLS}
+        "#
+    )
+}
+
+/// Binds the inbox upsert parameters in `upsert_sql` placeholder order.
+/// The four `call_*` Values come from the codec encode helper so typed
+/// metadata serializes to TEXT/INTEGER only here at the SQL boundary.
+fn upsert_params(
+    user: &BareJid,
+    entry: &InboxEntry,
+    increment: i64,
+    is_thread: i64,
+) -> Vec<crate::db::Value> {
+    let thread_id = entry.thread_id.as_deref().unwrap_or("");
+    let [call_thread_kind, call_thread_media, call_ended_at, call_duration] =
+        encode_call_thread_columns(entry);
+    vec![
+        crate::db::Value::from(user.to_string()),
+        crate::db::Value::from(entry.partner.to_string()),
+        crate::db::Value::from(thread_id.to_string()),
+        crate::db::Value::from(encode_kind(entry.kind)),
+        crate::db::Value::from(entry.last_stanza_id.clone()),
+        crate::db::Value::from(entry.last_updated),
+        crate::db::Value::from(increment),
+        crate::db::Value::from(entry.preview.clone()),
+        crate::db::Value::from(entry.thread_title.clone()),
+        crate::db::Value::from(entry.reply_count as i64),
+        crate::db::Value::from(entry.author.clone()),
+        call_thread_kind,
+        call_thread_media,
+        call_ended_at,
+        call_duration,
+        crate::db::Value::from(increment),
+        crate::db::Value::from(is_thread),
+    ]
 }
 
 fn insert_groupchat_notification_recovery_sql() -> &'static str {
@@ -261,49 +333,9 @@ impl InboxStorage for DatabaseInboxStorage {
         let increment = i64::from(u8::from(increment_unread));
         let thread_id = entry.thread_id.as_deref().unwrap_or("");
         let is_thread = i64::from(u8::from(!thread_id.is_empty()));
-        let sql = format!(
-            r#"
-            INSERT INTO inbox_entries (
-                user_jid, partner_jid, thread_id, kind, last_stanza_id, last_updated,
-                unread, preview, thread_title, reply_count, author
-            ) VALUES (?, ?, ?, ?, ?, ?, CASE WHEN ? != 0 THEN 1 ELSE 0 END, ?, ?, ?, ?)
-            ON CONFLICT(user_jid, partner_jid, thread_id) DO UPDATE SET
-                kind = excluded.kind,
-                last_stanza_id = excluded.last_stanza_id,
-                last_updated = excluded.last_updated,
-                preview = excluded.preview,
-                unread = CASE
-                    WHEN ? != 0 THEN inbox_entries.unread + 1
-                    ELSE inbox_entries.unread
-                END,
-                thread_title = COALESCE(excluded.thread_title, inbox_entries.thread_title),
-                reply_count = CASE
-                    WHEN ? != 0 THEN inbox_entries.reply_count + 1
-                    ELSE inbox_entries.reply_count
-                END,
-                author = COALESCE(excluded.author, inbox_entries.author)
-            RETURNING {SELECT_COLS}
-            "#
-        );
+        let sql = upsert_sql();
         let mut rows = self
-            .query(
-                &sql,
-                crate::db_params![
-                    user.to_string(),
-                    entry.partner.to_string(),
-                    thread_id.to_string(),
-                    encode_kind(entry.kind),
-                    entry.last_stanza_id,
-                    entry.last_updated,
-                    increment,
-                    entry.preview,
-                    entry.thread_title,
-                    entry.reply_count as i64,
-                    entry.author,
-                    increment,
-                    is_thread,
-                ],
-            )
+            .query(&sql, upsert_params(user, &entry, increment, is_thread))
             .await?;
 
         let row = rows
@@ -326,54 +358,14 @@ impl InboxStorage for DatabaseInboxStorage {
         let increment = i64::from(u8::from(increment_unread));
         let thread_id = entry.thread_id.as_deref().unwrap_or("");
         let is_thread = i64::from(u8::from(!thread_id.is_empty()));
-        let sql = format!(
-            r#"
-            INSERT INTO inbox_entries (
-                user_jid, partner_jid, thread_id, kind, last_stanza_id, last_updated,
-                unread, preview, thread_title, reply_count, author
-            ) VALUES (?, ?, ?, ?, ?, ?, CASE WHEN ? != 0 THEN 1 ELSE 0 END, ?, ?, ?, ?)
-            ON CONFLICT(user_jid, partner_jid, thread_id) DO UPDATE SET
-                kind = excluded.kind,
-                last_stanza_id = excluded.last_stanza_id,
-                last_updated = excluded.last_updated,
-                preview = excluded.preview,
-                unread = CASE
-                    WHEN ? != 0 THEN inbox_entries.unread + 1
-                    ELSE inbox_entries.unread
-                END,
-                thread_title = COALESCE(excluded.thread_title, inbox_entries.thread_title),
-                reply_count = CASE
-                    WHEN ? != 0 THEN inbox_entries.reply_count + 1
-                    ELSE inbox_entries.reply_count
-                END,
-                author = COALESCE(excluded.author, inbox_entries.author)
-            RETURNING {SELECT_COLS}
-            "#
-        );
+        let sql = upsert_sql();
         let mut tx = self
             .db
             .begin()
             .await
             .map_err(|error| InboxStorageError::Other(error.to_string()))?;
         let mut rows = tx
-            .query(
-                &sql,
-                crate::db_params![
-                    user.to_string(),
-                    entry.partner.to_string(),
-                    thread_id.to_string(),
-                    encode_kind(entry.kind),
-                    entry.last_stanza_id,
-                    entry.last_updated,
-                    increment,
-                    entry.preview,
-                    entry.thread_title,
-                    entry.reply_count as i64,
-                    entry.author,
-                    increment,
-                    is_thread,
-                ],
-            )
+            .query(&sql, upsert_params(user, &entry, increment, is_thread))
             .await
             .map_err(|error| InboxStorageError::Other(error.to_string()))?;
         let row = rows
@@ -530,6 +522,28 @@ impl InboxStorage for DatabaseInboxStorage {
             .get(0)
             .map_err(|error| InboxStorageError::Other(error.to_string()))?;
         Ok(total.max(0) as u64)
+    }
+
+    #[instrument(skip(self), fields(room = %room, thread_id))]
+    async fn mark_call_thread_ended(
+        &self,
+        room: &BareJid,
+        thread_id: &str,
+        ended: DateTime<Utc>,
+        duration: &CallThreadDuration,
+    ) -> Result<(), InboxStorageError> {
+        self.execute(
+            "UPDATE inbox_entries SET call_ended_at = ?, call_duration = ? \
+             WHERE partner_jid = ? AND thread_id = ?",
+            crate::db_params![
+                ended.timestamp(),
+                duration.as_str().to_owned(),
+                room.to_string(),
+                thread_id.to_string(),
+            ],
+        )
+        .await?;
+        Ok(())
     }
 }
 

--- a/server/crates/waddle-server/src/inbox.rs
+++ b/server/crates/waddle-server/src/inbox.rs
@@ -532,16 +532,18 @@ impl InboxStorage for DatabaseInboxStorage {
         ended: DateTime<Utc>,
         duration: &CallThreadDuration,
     ) -> Result<(), InboxStorageError> {
-        // Only stamp the ended summary onto genuine call-thread rows
-        // (those carrying a `call_thread_kind`). A reply-only inbox row —
-        // a durable user who received a thread reply but not the
-        // anchor-root projection — has `call_thread_kind` NULL; stamping
-        // it would produce an ended summary without kind/media, which
-        // serializes as `<call-ended>` WITHOUT `<call>` and is silently
-        // dropped by the frontend.
+        // Only stamp the ended summary onto genuine call-thread rows.
+        // The wire emits `<call>` only when BOTH kind and media are
+        // present, so an ended summary on a row missing either would
+        // serialize as `<call-ended>` WITHOUT `<call>` and be silently
+        // dropped by the frontend. Guard on both columns to match the
+        // wire condition exactly. A reply-only inbox row — a durable
+        // user who received a thread reply but not the anchor-root
+        // projection — has both NULL and is skipped.
         self.execute(
             "UPDATE inbox_entries SET call_ended_at = ?, call_duration = ? \
-             WHERE partner_jid = ? AND thread_id = ? AND call_thread_kind IS NOT NULL",
+             WHERE partner_jid = ? AND thread_id = ? \
+             AND call_thread_kind IS NOT NULL AND call_thread_media IS NOT NULL",
             crate::db_params![
                 ended.timestamp(),
                 duration.as_str().to_owned(),

--- a/server/crates/waddle-server/src/inbox.rs
+++ b/server/crates/waddle-server/src/inbox.rs
@@ -532,9 +532,16 @@ impl InboxStorage for DatabaseInboxStorage {
         ended: DateTime<Utc>,
         duration: &CallThreadDuration,
     ) -> Result<(), InboxStorageError> {
+        // Only stamp the ended summary onto genuine call-thread rows
+        // (those carrying a `call_thread_kind`). A reply-only inbox row —
+        // a durable user who received a thread reply but not the
+        // anchor-root projection — has `call_thread_kind` NULL; stamping
+        // it would produce an ended summary without kind/media, which
+        // serializes as `<call-ended>` WITHOUT `<call>` and is silently
+        // dropped by the frontend.
         self.execute(
             "UPDATE inbox_entries SET call_ended_at = ?, call_duration = ? \
-             WHERE partner_jid = ? AND thread_id = ?",
+             WHERE partner_jid = ? AND thread_id = ? AND call_thread_kind IS NOT NULL",
             crate::db_params![
                 ended.timestamp(),
                 duration.as_str().to_owned(),

--- a/server/crates/waddle-server/src/inbox/codec.rs
+++ b/server/crates/waddle-server/src/inbox/codec.rs
@@ -49,6 +49,25 @@ pub(super) fn decode_row(row: &crate::db::Row) -> Result<InboxEntry, InboxStorag
         .get(13)
         .map_err(|error| InboxStorageError::Other(error.to_string()))?;
 
+    // Call-thread metadata is a display projection: a single corrupt row
+    // must not brick the whole threads listing. A present-but-invalid
+    // value degrades that field to `None` (the row decodes as a non-call
+    // thread) rather than erroring out of `decode_row` → `list_all_threads`.
+    let decoded_kind = call_thread_kind_raw
+        .as_deref()
+        .and_then(decode_call_thread_kind);
+    let decoded_media = call_thread_media_raw
+        .as_deref()
+        .and_then(decode_call_thread_media);
+    // Kind+media-together invariant on read: if either ends up `None`,
+    // treat BOTH as `None` so a row never has kind-without-media or
+    // media-without-kind after decode (matching the wire `<call>`
+    // condition, which requires both).
+    let (call_thread_kind, call_thread_media) = match (decoded_kind, decoded_media) {
+        (Some(kind), Some(media)) => (Some(kind), Some(media)),
+        _ => (None, None),
+    };
+
     Ok(InboxEntry {
         partner,
         kind: decode_kind(&kind_raw)?,
@@ -64,15 +83,11 @@ pub(super) fn decode_row(row: &crate::db::Row) -> Result<InboxEntry, InboxStorag
         thread_title,
         reply_count: reply_count.max(0) as u32,
         author,
-        call_thread_kind: call_thread_kind_raw
-            .as_deref()
-            .map(decode_call_thread_kind)
-            .transpose()?,
-        call_thread_media: call_thread_media_raw
-            .as_deref()
-            .map(decode_call_thread_media)
-            .transpose()?,
-        call_ended_at: call_ended_at_raw.map(decode_call_ended_at).transpose()?,
+        call_thread_kind,
+        call_thread_media,
+        // Out-of-range epoch seconds degrade to `None` rather than failing
+        // the whole row decode (display-projection resilience).
+        call_ended_at: call_ended_at_raw.and_then(decode_call_ended_at),
         call_duration: call_duration_raw
             .as_deref()
             .and_then(|raw| CallThreadDuration::parse(raw).ok()),
@@ -83,14 +98,33 @@ pub(super) fn decode_row(row: &crate::db::Row) -> Result<InboxEntry, InboxStorag
 /// order: `call_thread_kind, call_thread_media, call_ended_at,
 /// call_duration`. Typed values serialize to `String`/`i64` only here at
 /// the SQL boundary; `None` becomes a typed NULL.
+///
+/// Kind+media-together invariant on write: a genuine call row carries
+/// both a kind and a non-empty media token set. `CallThreadMedia`
+/// serializes the impossible `(audio:false, video:false)` state to `""`;
+/// writing that empty string would later trip the decoder. So if the
+/// media tokens are empty we treat the row as "not a call thread" and
+/// write NULL for BOTH `call_thread_kind` AND `call_thread_media`. The
+/// encoded pair is therefore always either `(Some kind, non-empty media)`
+/// or `(NULL, NULL)`.
 pub(super) fn encode_call_thread_columns(entry: &InboxEntry) -> [crate::db::Value; 4] {
+    let media_tokens = entry
+        .call_thread_media
+        .map(|media| media.as_tokens())
+        .filter(|tokens| !tokens.is_empty());
+    let kind_token = media_tokens
+        .as_ref()
+        .and(entry.call_thread_kind)
+        .map(|kind| kind.as_token().to_owned());
+    // Either both kind and (non-empty) media survive, or both drop to
+    // NULL — a row never carries kind-without-media or media-without-kind.
+    let (kind_token, media_tokens) = match (kind_token, media_tokens) {
+        (Some(kind), Some(media)) => (Some(kind), Some(media)),
+        _ => (None, None),
+    };
     [
-        crate::db::Value::from(
-            entry
-                .call_thread_kind
-                .map(|kind| kind.as_token().to_owned()),
-        ),
-        crate::db::Value::from(entry.call_thread_media.map(|media| media.as_tokens())),
+        crate::db::Value::from(kind_token),
+        crate::db::Value::from(media_tokens),
         crate::db::Value::from(entry.call_ended_at.map(|ended| ended.timestamp())),
         crate::db::Value::from(
             entry
@@ -101,17 +135,25 @@ pub(super) fn encode_call_thread_columns(entry: &InboxEntry) -> [crate::db::Valu
     ]
 }
 
-fn decode_call_thread_kind(raw: &str) -> Result<CallThreadKind, InboxStorageError> {
+/// Decodes a stored call-thread kind token. Resilient: an
+/// unrecognized value degrades to `None` (the row is treated as a
+/// non-call thread) instead of failing the whole row decode. NULL
+/// (absent) is handled by the caller before this is reached.
+fn decode_call_thread_kind(raw: &str) -> Option<CallThreadKind> {
     match raw {
-        "dm" => Ok(CallThreadKind::Dm),
-        "muc" => Ok(CallThreadKind::Muc),
-        other => Err(InboxStorageError::Other(format!(
-            "unknown call-thread kind '{other}'"
-        ))),
+        "dm" => Some(CallThreadKind::Dm),
+        "muc" => Some(CallThreadKind::Muc),
+        _ => None,
     }
 }
 
-fn decode_call_thread_media(raw: &str) -> Result<CallThreadMedia, InboxStorageError> {
+/// Decodes a stored call-thread media token set. Resilient: an
+/// unrecognized token, or an empty/token-less value (the impossible
+/// `audio:false, video:false` state that `media_attr` panics on),
+/// degrades the field to `None` instead of failing the whole row
+/// decode. NULL (absent) is handled by the caller before this is
+/// reached.
+fn decode_call_thread_media(raw: &str) -> Option<CallThreadMedia> {
     let mut audio = false;
     let mut video = false;
     let mut saw_token = false;
@@ -120,29 +162,23 @@ fn decode_call_thread_media(raw: &str) -> Result<CallThreadMedia, InboxStorageEr
         match token {
             "audio" => audio = true,
             "video" => video = true,
-            other => {
-                return Err(InboxStorageError::Other(format!(
-                    "unknown call-thread media token '{other}'"
-                )))
-            }
+            // Unknown token → not a media value we can project; degrade.
+            _ => return None,
         }
     }
     // A non-NULL media value that yields no recognized tokens is the
-    // impossible `audio:false, video:false` state (the XEP `media_attr`
-    // panics on it). Reject it so decode is a true inverse of encode;
-    // NULL (absent) decodes to `None` upstream before this is called.
+    // impossible `audio:false, video:false` state. Degrade to `None`.
     if !saw_token {
-        return Err(InboxStorageError::Other(
-            "empty call-thread media value has no audio/video token".to_owned(),
-        ));
+        return None;
     }
-    Ok(CallThreadMedia { audio, video })
+    Some(CallThreadMedia { audio, video })
 }
 
-fn decode_call_ended_at(secs: i64) -> Result<DateTime<Utc>, InboxStorageError> {
-    Utc.timestamp_opt(secs, 0).single().ok_or_else(|| {
-        InboxStorageError::Other(format!("invalid call_ended_at epoch seconds: {secs}"))
-    })
+/// Decodes stored `call_ended_at` epoch seconds. Resilient:
+/// out-of-range seconds degrade to `None` rather than failing the whole
+/// row decode.
+fn decode_call_ended_at(secs: i64) -> Option<DateTime<Utc>> {
+    Utc.timestamp_opt(secs, 0).single()
 }
 
 pub(super) fn encode_kind(kind: ConversationKind) -> &'static str {
@@ -193,16 +229,30 @@ mod codec_tests {
     }
 
     #[test]
-    fn decode_call_thread_media_rejects_present_but_token_less_value() {
-        // A present-but-empty media string would otherwise decode to the
-        // impossible `audio:false, video:false` (which `media_attr` panics
-        // on). Decode must reject it instead. NULL stays `None` upstream.
-        assert!(decode_call_thread_media("").is_err());
-        assert!(decode_call_thread_media("   ").is_err());
+    fn decode_call_thread_media_degrades_present_but_token_less_value() {
+        // A present-but-empty media string is the impossible
+        // `audio:false, video:false` state. Decode is a display
+        // projection: it degrades to `None` (graceful) rather than
+        // erroring and bricking the whole threads listing. NULL stays
+        // `None` upstream before this is reached.
+        assert_eq!(decode_call_thread_media(""), None);
+        assert_eq!(decode_call_thread_media("   "), None);
     }
 
     #[test]
-    fn decode_call_thread_media_rejects_unknown_token() {
-        assert!(decode_call_thread_media("audio screenshare").is_err());
+    fn decode_call_thread_media_degrades_unknown_token() {
+        // An unknown media token degrades the field to `None` instead of
+        // erroring (resilience over fail-fast for this projection).
+        assert_eq!(decode_call_thread_media("audio screenshare"), None);
+    }
+
+    #[test]
+    fn decode_call_thread_kind_degrades_unknown_value() {
+        // A garbage kind yields `None`, not an error; the row still
+        // decodes (as a non-call thread).
+        assert_eq!(decode_call_thread_kind("muc"), Some(CallThreadKind::Muc));
+        assert_eq!(decode_call_thread_kind("dm"), Some(CallThreadKind::Dm));
+        assert_eq!(decode_call_thread_kind("garbage"), None);
+        assert_eq!(decode_call_thread_kind(""), None);
     }
 }

--- a/server/crates/waddle-server/src/inbox/codec.rs
+++ b/server/crates/waddle-server/src/inbox/codec.rs
@@ -129,7 +129,9 @@ fn encode_call_thread_media(media: CallThreadMedia) -> String {
 fn decode_call_thread_media(raw: &str) -> Result<CallThreadMedia, InboxStorageError> {
     let mut audio = false;
     let mut video = false;
+    let mut saw_token = false;
     for token in raw.split_ascii_whitespace() {
+        saw_token = true;
         match token {
             "audio" => audio = true,
             "video" => video = true,
@@ -139,6 +141,15 @@ fn decode_call_thread_media(raw: &str) -> Result<CallThreadMedia, InboxStorageEr
                 )))
             }
         }
+    }
+    // A non-NULL media value that yields no recognized tokens is the
+    // impossible `audio:false, video:false` state (the XEP `media_attr`
+    // panics on it). Reject it so decode is a true inverse of encode;
+    // NULL (absent) decodes to `None` upstream before this is called.
+    if !saw_token {
+        return Err(InboxStorageError::Other(
+            "empty call-thread media value has no audio/video token".to_owned(),
+        ));
     }
     Ok(CallThreadMedia { audio, video })
 }
@@ -167,3 +178,46 @@ fn decode_kind(raw: &str) -> Result<ConversationKind, InboxStorageError> {
 }
 
 pub(super) const SELECT_COLS: &str = "partner_jid, thread_id, kind, last_stanza_id, last_updated, unread, preview, thread_title, reply_count, author, call_thread_kind, call_thread_media, call_ended_at, call_duration";
+
+#[cfg(test)]
+mod codec_tests {
+    use super::*;
+
+    #[test]
+    fn decode_call_thread_media_parses_both_tokens() {
+        let media = decode_call_thread_media("audio video").expect("both tokens decode");
+        assert_eq!(
+            media,
+            CallThreadMedia {
+                audio: true,
+                video: true,
+            }
+        );
+    }
+
+    #[test]
+    fn decode_call_thread_media_parses_audio_only() {
+        let media = decode_call_thread_media("audio").expect("audio-only decodes");
+        assert_eq!(
+            media,
+            CallThreadMedia {
+                audio: true,
+                video: false,
+            }
+        );
+    }
+
+    #[test]
+    fn decode_call_thread_media_rejects_present_but_token_less_value() {
+        // A present-but-empty media string would otherwise decode to the
+        // impossible `audio:false, video:false` (which `media_attr` panics
+        // on). Decode must reject it instead. NULL stays `None` upstream.
+        assert!(decode_call_thread_media("").is_err());
+        assert!(decode_call_thread_media("   ").is_err());
+    }
+
+    #[test]
+    fn decode_call_thread_media_rejects_unknown_token() {
+        assert!(decode_call_thread_media("audio screenshare").is_err());
+    }
+}

--- a/server/crates/waddle-server/src/inbox/codec.rs
+++ b/server/crates/waddle-server/src/inbox/codec.rs
@@ -85,8 +85,12 @@ pub(super) fn decode_row(row: &crate::db::Row) -> Result<InboxEntry, InboxStorag
 /// the SQL boundary; `None` becomes a typed NULL.
 pub(super) fn encode_call_thread_columns(entry: &InboxEntry) -> [crate::db::Value; 4] {
     [
-        crate::db::Value::from(entry.call_thread_kind.map(encode_call_thread_kind)),
-        crate::db::Value::from(entry.call_thread_media.map(encode_call_thread_media)),
+        crate::db::Value::from(
+            entry
+                .call_thread_kind
+                .map(|kind| kind.as_token().to_owned()),
+        ),
+        crate::db::Value::from(entry.call_thread_media.map(|media| media.as_tokens())),
         crate::db::Value::from(entry.call_ended_at.map(|ended| ended.timestamp())),
         crate::db::Value::from(
             entry
@@ -97,14 +101,6 @@ pub(super) fn encode_call_thread_columns(entry: &InboxEntry) -> [crate::db::Valu
     ]
 }
 
-fn encode_call_thread_kind(kind: CallThreadKind) -> String {
-    match kind {
-        CallThreadKind::Dm => "dm",
-        CallThreadKind::Muc => "muc",
-    }
-    .to_owned()
-}
-
 fn decode_call_thread_kind(raw: &str) -> Result<CallThreadKind, InboxStorageError> {
     match raw {
         "dm" => Ok(CallThreadKind::Dm),
@@ -113,17 +109,6 @@ fn decode_call_thread_kind(raw: &str) -> Result<CallThreadKind, InboxStorageErro
             "unknown call-thread kind '{other}'"
         ))),
     }
-}
-
-fn encode_call_thread_media(media: CallThreadMedia) -> String {
-    let mut tokens = Vec::with_capacity(2);
-    if media.audio {
-        tokens.push("audio");
-    }
-    if media.video {
-        tokens.push("video");
-    }
-    tokens.join(" ")
 }
 
 fn decode_call_thread_media(raw: &str) -> Result<CallThreadMedia, InboxStorageError> {

--- a/server/crates/waddle-server/src/inbox/codec.rs
+++ b/server/crates/waddle-server/src/inbox/codec.rs
@@ -1,4 +1,6 @@
 use super::*;
+use chrono::{DateTime, TimeZone, Utc};
+use waddle_xmpp::xep::{CallThreadDuration, CallThreadKind, CallThreadMedia};
 
 pub(super) fn decode_row(row: &crate::db::Row) -> Result<InboxEntry, InboxStorageError> {
     let partner_raw: String = row
@@ -34,6 +36,18 @@ pub(super) fn decode_row(row: &crate::db::Row) -> Result<InboxEntry, InboxStorag
     let author: Option<String> = row
         .get(9)
         .map_err(|error| InboxStorageError::Other(error.to_string()))?;
+    let call_thread_kind_raw: Option<String> = row
+        .get(10)
+        .map_err(|error| InboxStorageError::Other(error.to_string()))?;
+    let call_thread_media_raw: Option<String> = row
+        .get(11)
+        .map_err(|error| InboxStorageError::Other(error.to_string()))?;
+    let call_ended_at_raw: Option<i64> = row
+        .get(12)
+        .map_err(|error| InboxStorageError::Other(error.to_string()))?;
+    let call_duration_raw: Option<String> = row
+        .get(13)
+        .map_err(|error| InboxStorageError::Other(error.to_string()))?;
 
     Ok(InboxEntry {
         partner,
@@ -50,6 +64,88 @@ pub(super) fn decode_row(row: &crate::db::Row) -> Result<InboxEntry, InboxStorag
         thread_title,
         reply_count: reply_count.max(0) as u32,
         author,
+        call_thread_kind: call_thread_kind_raw
+            .as_deref()
+            .map(decode_call_thread_kind)
+            .transpose()?,
+        call_thread_media: call_thread_media_raw
+            .as_deref()
+            .map(decode_call_thread_media)
+            .transpose()?,
+        call_ended_at: call_ended_at_raw.map(decode_call_ended_at).transpose()?,
+        call_duration: call_duration_raw
+            .as_deref()
+            .and_then(|raw| CallThreadDuration::parse(raw).ok()),
+    })
+}
+
+/// Encodes the four call-thread columns from an entry, in `SELECT_COLS`
+/// order: `call_thread_kind, call_thread_media, call_ended_at,
+/// call_duration`. Typed values serialize to `String`/`i64` only here at
+/// the SQL boundary; `None` becomes a typed NULL.
+pub(super) fn encode_call_thread_columns(entry: &InboxEntry) -> [crate::db::Value; 4] {
+    [
+        crate::db::Value::from(entry.call_thread_kind.map(encode_call_thread_kind)),
+        crate::db::Value::from(entry.call_thread_media.map(encode_call_thread_media)),
+        crate::db::Value::from(entry.call_ended_at.map(|ended| ended.timestamp())),
+        crate::db::Value::from(
+            entry
+                .call_duration
+                .as_ref()
+                .map(|duration| duration.as_str().to_owned()),
+        ),
+    ]
+}
+
+fn encode_call_thread_kind(kind: CallThreadKind) -> String {
+    match kind {
+        CallThreadKind::Dm => "dm",
+        CallThreadKind::Muc => "muc",
+    }
+    .to_owned()
+}
+
+fn decode_call_thread_kind(raw: &str) -> Result<CallThreadKind, InboxStorageError> {
+    match raw {
+        "dm" => Ok(CallThreadKind::Dm),
+        "muc" => Ok(CallThreadKind::Muc),
+        other => Err(InboxStorageError::Other(format!(
+            "unknown call-thread kind '{other}'"
+        ))),
+    }
+}
+
+fn encode_call_thread_media(media: CallThreadMedia) -> String {
+    let mut tokens = Vec::with_capacity(2);
+    if media.audio {
+        tokens.push("audio");
+    }
+    if media.video {
+        tokens.push("video");
+    }
+    tokens.join(" ")
+}
+
+fn decode_call_thread_media(raw: &str) -> Result<CallThreadMedia, InboxStorageError> {
+    let mut audio = false;
+    let mut video = false;
+    for token in raw.split_ascii_whitespace() {
+        match token {
+            "audio" => audio = true,
+            "video" => video = true,
+            other => {
+                return Err(InboxStorageError::Other(format!(
+                    "unknown call-thread media token '{other}'"
+                )))
+            }
+        }
+    }
+    Ok(CallThreadMedia { audio, video })
+}
+
+fn decode_call_ended_at(secs: i64) -> Result<DateTime<Utc>, InboxStorageError> {
+    Utc.timestamp_opt(secs, 0).single().ok_or_else(|| {
+        InboxStorageError::Other(format!("invalid call_ended_at epoch seconds: {secs}"))
     })
 }
 
@@ -70,4 +166,4 @@ fn decode_kind(raw: &str) -> Result<ConversationKind, InboxStorageError> {
     }
 }
 
-pub(super) const SELECT_COLS: &str = "partner_jid, thread_id, kind, last_stanza_id, last_updated, unread, preview, thread_title, reply_count, author";
+pub(super) const SELECT_COLS: &str = "partner_jid, thread_id, kind, last_stanza_id, last_updated, unread, preview, thread_title, reply_count, author, call_thread_kind, call_thread_media, call_ended_at, call_duration";

--- a/server/crates/waddle-server/src/inbox/schema.rs
+++ b/server/crates/waddle-server/src/inbox/schema.rs
@@ -22,6 +22,10 @@ pub(super) async fn initialize(storage: &DatabaseInboxStorage) -> Result<(), Inb
                 thread_title TEXT,
                 reply_count INTEGER NOT NULL DEFAULT 0,
                 author TEXT,
+                call_thread_kind TEXT,
+                call_thread_media TEXT,
+                call_ended_at INTEGER,
+                call_duration TEXT,
                 PRIMARY KEY (user_jid, partner_jid, thread_id)
             );
             INSERT INTO inbox_entries_new (user_jid, partner_jid, thread_id, kind, last_stanza_id, last_updated, unread, preview)
@@ -50,6 +54,10 @@ pub(super) async fn initialize(storage: &DatabaseInboxStorage) -> Result<(), Inb
                 thread_title TEXT,
                 reply_count INTEGER NOT NULL DEFAULT 0,
                 author TEXT,
+                call_thread_kind TEXT,
+                call_thread_media TEXT,
+                call_ended_at {i64_type},
+                call_duration TEXT,
                 PRIMARY KEY (user_jid, partner_jid, thread_id)
             );
             "#,
@@ -73,6 +81,12 @@ pub(super) async fn initialize(storage: &DatabaseInboxStorage) -> Result<(), Inb
         (),
     )
     .await?;
+    // Existing databases that pre-date the call-thread columns (issue
+    // #919) get them added in place; fresh databases already have them
+    // from the CREATE TABLE above. Without this targeted ALTER, the
+    // runtime SELECT against the new columns errors with "no such
+    // column" / "column does not exist" on every list query.
+    migrate_inbox_call_thread_columns(storage).await?;
     // Fresh databases get the full schema via CREATE TABLE IF NOT
     // EXISTS. Existing databases that pre-date the
     // `sender_can_broadcast_channel_mention` column are migrated
@@ -187,10 +201,71 @@ async fn recovery_column_present_sqlite(
     storage: &DatabaseInboxStorage,
     column: &str,
 ) -> Result<bool, InboxStorageError> {
+    column_present_sqlite(storage, "groupchat_notification_recovery", column).await
+}
+
+/// Adds the four call-thread columns (issue #919) to existing
+/// `inbox_entries` tables that pre-date them. Idempotent on both SQLite
+/// and Postgres — re-runs at every startup are no-ops once the columns
+/// exist. All four are nullable: a row that pre-dates a call thread has
+/// no anchor metadata, and a row whose call has not ended has no ended
+/// summary.
+async fn migrate_inbox_call_thread_columns(
+    storage: &DatabaseInboxStorage,
+) -> Result<(), InboxStorageError> {
+    let i64_type = crate::db::i64_sql_type(storage.db.driver());
+    // (column, SQL type) for the four call-thread columns.
+    let columns: [(&str, &str); 4] = [
+        ("call_thread_kind", "TEXT"),
+        ("call_thread_media", "TEXT"),
+        ("call_ended_at", i64_type),
+        ("call_duration", "TEXT"),
+    ];
+    match storage.db.driver() {
+        DatabaseDriver::Sqlite => {
+            for (column, sql_type) in columns {
+                if !column_present_sqlite(storage, "inbox_entries", column).await? {
+                    info!(column, "Adding column to inbox_entries (SQLite)");
+                    storage
+                        .execute(
+                            &format!("ALTER TABLE inbox_entries ADD COLUMN {column} {sql_type}"),
+                            (),
+                        )
+                        .await?;
+                }
+            }
+        }
+        DatabaseDriver::Postgres => {
+            // `ADD COLUMN IF NOT EXISTS` makes this idempotent at the
+            // SQL layer; no PRAGMA-equivalent probe needed.
+            for (column, sql_type) in columns {
+                storage
+                    .execute(
+                        &format!(
+                            "ALTER TABLE inbox_entries ADD COLUMN IF NOT EXISTS {column} {sql_type}"
+                        ),
+                        (),
+                    )
+                    .await?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// SQLite-only: returns `true` if `column` exists on `table`. Probes
+/// `PRAGMA table_info(<table>)`. When the table itself does not yet
+/// exist, returns `true` so callers treat the missing-column ALTER as
+/// moot (the CREATE TABLE IF NOT EXISTS path owns that case).
+async fn column_present_sqlite(
+    storage: &DatabaseInboxStorage,
+    table: &str,
+    column: &str,
+) -> Result<bool, InboxStorageError> {
     let mut rows = storage
         .query(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name='groupchat_notification_recovery'",
-            (),
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+            crate::db_params![table],
         )
         .await
         .map_err(|error| InboxStorageError::Other(error.to_string()))?;
@@ -200,13 +275,13 @@ async fn recovery_column_present_sqlite(
         .map_err(|error| InboxStorageError::Other(error.to_string()))?
         .is_some();
     if !table_exists {
-        // The CREATE TABLE IF NOT EXISTS above ran first; if the
-        // table still doesn't exist, this run is unusual but the
+        // The CREATE TABLE IF NOT EXISTS path ran first; if the table
+        // still doesn't exist, this run is unusual but the
         // missing-column path is moot.
         return Ok(true);
     }
     let mut cols = storage
-        .query("PRAGMA table_info(groupchat_notification_recovery)", ())
+        .query(&format!("PRAGMA table_info({table})"), ())
         .await
         .map_err(|error| InboxStorageError::Other(error.to_string()))?;
     while let Some(row) = cols

--- a/server/crates/waddle-server/src/inbox/schema.rs
+++ b/server/crates/waddle-server/src/inbox/schema.rs
@@ -280,6 +280,13 @@ async fn column_present_sqlite(
         // missing-column path is moot.
         return Ok(true);
     }
+    // SAFETY: `table` is interpolated directly into the PRAGMA string.
+    // SQLite's `PRAGMA table_info(...)` cannot take a bound parameter for
+    // the table name, so interpolation is unavoidable here. `table` MUST
+    // therefore be a compile-time string literal — all current callers
+    // pass `&'static str` constants ("inbox_entries",
+    // "groupchat_notification_recovery"). NEVER pass user input or any
+    // runtime-derived value to this helper.
     let mut cols = storage
         .query(&format!("PRAGMA table_info({table})"), ())
         .await

--- a/server/crates/waddle-server/src/inbox/tests.rs
+++ b/server/crates/waddle-server/src/inbox/tests.rs
@@ -144,6 +144,95 @@ async fn upsert_persists_call_thread_metadata_and_mark_ended_updates_all_users()
 }
 
 #[tokio::test]
+async fn mark_ended_skips_reply_only_rows_without_call_thread_kind() {
+    use waddle_xmpp::xep::{CallThreadDuration, CallThreadKind, CallThreadMedia};
+    let storage = DatabaseInboxStorage::open(Some("sqlite::memory:"))
+        .await
+        .expect("storage");
+    let room: BareJid = "general@conference.example.com".parse().expect("room jid");
+    let alice: BareJid = "alice@example.com".parse().expect("alice jid");
+    let bob: BareJid = "bob@example.com".parse().expect("bob jid");
+
+    // Alice received the anchor-root projection: a genuine call-thread
+    // row with kind + media.
+    let anchor = InboxEntry::new(
+        room.clone(),
+        ConversationKind::MucRoom,
+        "anchor-stanza",
+        1_700_000_000,
+    )
+    .with_thread("call-thread-uuid")
+    .with_call_thread(
+        CallThreadKind::Muc,
+        CallThreadMedia {
+            audio: true,
+            video: false,
+        },
+    );
+    storage.upsert(&alice, anchor, true).await.expect("alice");
+
+    // Bob is a durable user who only received a thread reply, not the
+    // anchor projection — a reply-only row on the SAME (room, thread_id)
+    // with call_thread_kind / call_thread_media NULL.
+    let reply_only = InboxEntry::new(
+        room.clone(),
+        ConversationKind::MucRoom,
+        "reply-stanza",
+        1_700_000_100,
+    )
+    .with_thread("call-thread-uuid");
+    assert!(reply_only.call_thread_kind.is_none());
+    assert!(reply_only.call_thread_media.is_none());
+    storage.upsert(&bob, reply_only, true).await.expect("bob");
+
+    let ended = chrono::DateTime::parse_from_rfc3339("2026-06-07T14:35:00Z")
+        .expect("ended")
+        .with_timezone(&chrono::Utc);
+    storage
+        .mark_call_thread_ended(
+            &room,
+            "call-thread-uuid",
+            ended,
+            &CallThreadDuration::parse("PT5M").expect("duration"),
+        )
+        .await
+        .expect("mark ended");
+
+    // Alice's genuine call-thread row gets the ended summary stamped.
+    let alice_row = storage
+        .list_all_threads(&alice)
+        .await
+        .expect("list_all_threads")
+        .into_iter()
+        .find(|e| e.thread_id.as_deref() == Some("call-thread-uuid"))
+        .expect("alice anchor thread");
+    assert_eq!(alice_row.call_ended_at, Some(ended));
+    assert_eq!(
+        alice_row.call_duration,
+        Some(CallThreadDuration::parse("PT5M").expect("duration"))
+    );
+
+    // Bob's reply-only row is NOT stamped — stamping it would produce an
+    // ended summary without kind/media that the frontend silently drops.
+    let bob_row = storage
+        .list_all_threads(&bob)
+        .await
+        .expect("list_all_threads")
+        .into_iter()
+        .find(|e| e.thread_id.as_deref() == Some("call-thread-uuid"))
+        .expect("bob reply-only thread");
+    assert!(
+        bob_row.call_ended_at.is_none(),
+        "reply-only row (call_thread_kind NULL) must not be stamped with the ended summary"
+    );
+    assert!(
+        bob_row.call_duration.is_none(),
+        "reply-only row must not gain a call_duration"
+    );
+    assert!(bob_row.call_thread_kind.is_none());
+}
+
+#[tokio::test]
 async fn upsert_reply_preserves_anchor_call_thread_metadata() {
     use waddle_xmpp::xep::{CallThreadKind, CallThreadMedia};
     let storage = DatabaseInboxStorage::open(Some("sqlite::memory:"))

--- a/server/crates/waddle-server/src/inbox/tests.rs
+++ b/server/crates/waddle-server/src/inbox/tests.rs
@@ -144,6 +144,71 @@ async fn upsert_persists_call_thread_metadata_and_mark_ended_updates_all_users()
 }
 
 #[tokio::test]
+async fn upsert_reply_preserves_anchor_call_thread_metadata() {
+    use waddle_xmpp::xep::{CallThreadKind, CallThreadMedia};
+    let storage = DatabaseInboxStorage::open(Some("sqlite::memory:"))
+        .await
+        .expect("storage");
+    let room: BareJid = "general@conference.example.com".parse().expect("room jid");
+    let alice: BareJid = "alice@example.com".parse().expect("alice jid");
+
+    // Anchor the call thread with kind + media.
+    let anchor = InboxEntry::new(
+        room.clone(),
+        ConversationKind::MucRoom,
+        "anchor-stanza",
+        1_700_000_000,
+    )
+    .with_thread("call-thread-uuid")
+    .with_call_thread(
+        CallThreadKind::Muc,
+        CallThreadMedia {
+            audio: true,
+            video: false,
+        },
+    );
+    storage.upsert(&alice, anchor, true).await.expect("anchor");
+
+    // A later PLAIN reply to the same thread carries no call metadata
+    // (its call_* columns are NULL); the COALESCE upsert must not wipe
+    // the anchor's kind/media.
+    let plain_reply = InboxEntry::new(
+        room.clone(),
+        ConversationKind::MucRoom,
+        "reply-stanza",
+        1_700_000_100,
+    )
+    .with_thread("call-thread-uuid");
+    assert!(plain_reply.call_thread_kind.is_none());
+    assert!(plain_reply.call_thread_media.is_none());
+    storage
+        .upsert(&alice, plain_reply, true)
+        .await
+        .expect("plain reply");
+
+    let entry = storage
+        .list_all_threads(&alice)
+        .await
+        .expect("list_all_threads")
+        .into_iter()
+        .find(|e| e.thread_id.as_deref() == Some("call-thread-uuid"))
+        .expect("anchor thread");
+    assert_eq!(
+        entry.call_thread_kind,
+        Some(CallThreadKind::Muc),
+        "anchor kind survived a plain reply upsert"
+    );
+    assert_eq!(
+        entry.call_thread_media,
+        Some(CallThreadMedia {
+            audio: true,
+            video: false,
+        }),
+        "anchor media survived a plain reply upsert"
+    );
+}
+
+#[tokio::test]
 async fn sqlx_inbox_storage_mark_read_returns_none_for_missing_row() {
     let storage = DatabaseInboxStorage::open(Some("sqlite::memory:"))
         .await

--- a/server/crates/waddle-server/src/inbox/tests.rs
+++ b/server/crates/waddle-server/src/inbox/tests.rs
@@ -64,6 +64,86 @@ async fn sqlx_inbox_storage_round_trips_entries() {
 }
 
 #[tokio::test]
+async fn upsert_persists_call_thread_metadata_and_mark_ended_updates_all_users() {
+    use waddle_xmpp::xep::{CallThreadDuration, CallThreadKind, CallThreadMedia};
+    let storage = DatabaseInboxStorage::open(Some("sqlite::memory:"))
+        .await
+        .expect("storage");
+    let room: BareJid = "general@conference.example.com".parse().expect("room jid");
+    let alice: BareJid = "alice@example.com".parse().expect("alice jid");
+    let bob: BareJid = "bob@example.com".parse().expect("bob jid");
+    let anchor = || {
+        InboxEntry::new(
+            room.clone(),
+            ConversationKind::MucRoom,
+            "anchor-stanza",
+            1_700_000_000,
+        )
+        .with_thread("call-thread-uuid")
+        .with_call_thread(
+            CallThreadKind::Muc,
+            CallThreadMedia {
+                audio: true,
+                video: false,
+            },
+        )
+    };
+
+    storage.upsert(&alice, anchor(), true).await.expect("alice");
+    storage.upsert(&bob, anchor(), true).await.expect("bob");
+
+    let entry = storage
+        .list_all_threads(&alice)
+        .await
+        .expect("list_all_threads")
+        .into_iter()
+        .find(|e| e.thread_id.as_deref() == Some("call-thread-uuid"))
+        .expect("anchor thread");
+    assert_eq!(entry.call_thread_kind, Some(CallThreadKind::Muc));
+    assert_eq!(
+        entry.call_thread_media,
+        Some(CallThreadMedia {
+            audio: true,
+            video: false,
+        })
+    );
+    assert!(entry.call_ended_at.is_none());
+
+    let ended = chrono::DateTime::parse_from_rfc3339("2026-06-07T14:35:00Z")
+        .expect("ended")
+        .with_timezone(&chrono::Utc);
+    storage
+        .mark_call_thread_ended(
+            &room,
+            "call-thread-uuid",
+            ended,
+            &CallThreadDuration::parse("PT5M").expect("duration"),
+        )
+        .await
+        .expect("mark ended");
+
+    for who in [&alice, &bob] {
+        let e = storage
+            .list_all_threads(who)
+            .await
+            .expect("list_all_threads")
+            .into_iter()
+            .find(|e| e.thread_id.as_deref() == Some("call-thread-uuid"))
+            .expect("anchor thread");
+        assert_eq!(e.call_ended_at, Some(ended), "ended marked for {who}");
+        assert_eq!(
+            e.call_duration,
+            Some(CallThreadDuration::parse("PT5M").expect("duration"))
+        );
+        assert_eq!(
+            e.call_thread_kind,
+            Some(CallThreadKind::Muc),
+            "anchor kind survived ended UPDATE for {who}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn sqlx_inbox_storage_mark_read_returns_none_for_missing_row() {
     let storage = DatabaseInboxStorage::open(Some("sqlite::memory:"))
         .await
@@ -474,5 +554,110 @@ async fn migration_adds_sender_can_broadcast_channel_mention_to_legacy_recovery_
     );
 
     // Cleanup
+    std::fs::remove_file(&path).ok();
+}
+
+/// Issue #919 migration regression: an existing `inbox_entries` table
+/// created BEFORE the four `call_*` columns landed must be migrated
+/// forward. Without the targeted ALTERs, every `list*` SELECT errors
+/// with "no such column". Simulates the pre-#919 shape, re-opens to
+/// trigger the migration, then asserts a call-anchor upsert round-trips
+/// through the migrated columns.
+#[tokio::test(flavor = "multi_thread")]
+async fn migration_adds_call_thread_columns_to_legacy_inbox_table() {
+    use waddle_xmpp::xep::{CallThreadKind, CallThreadMedia};
+    let artifacts = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target/test-artifacts");
+    std::fs::create_dir_all(&artifacts).expect("artifacts dir");
+    let path = artifacts.join(format!("inbox-call-migration-{}.db", uuid::Uuid::new_v4()));
+    let url = format!("sqlite://{}", path.display());
+
+    // Build a DB whose inbox table predates the call-thread columns:
+    // open fresh, drop, recreate without the four `call_*` columns.
+    {
+        let storage = DatabaseInboxStorage::open(Some(&url))
+            .await
+            .expect("open fresh storage");
+        storage
+            .execute("DROP TABLE inbox_entries", ())
+            .await
+            .expect("drop fresh inbox table");
+        storage
+            .execute(
+                r#"
+                CREATE TABLE inbox_entries (
+                    user_jid TEXT NOT NULL,
+                    partner_jid TEXT NOT NULL,
+                    thread_id TEXT NOT NULL DEFAULT '',
+                    kind TEXT NOT NULL,
+                    last_stanza_id TEXT NOT NULL,
+                    last_updated INTEGER NOT NULL,
+                    unread INTEGER NOT NULL DEFAULT 0,
+                    preview TEXT,
+                    thread_title TEXT,
+                    reply_count INTEGER NOT NULL DEFAULT 0,
+                    author TEXT,
+                    PRIMARY KEY (user_jid, partner_jid, thread_id)
+                )
+                "#,
+                (),
+            )
+            .await
+            .expect("create legacy inbox table");
+    }
+
+    // Re-open. The init path detects the missing columns and runs the
+    // ALTERs; a call-anchor upsert then round-trips through them (it
+    // would fail with "no such column" if the migration didn't run).
+    let storage = DatabaseInboxStorage::open(Some(&url))
+        .await
+        .expect("re-open storage triggers migration");
+
+    for column in [
+        "call_thread_kind",
+        "call_thread_media",
+        "call_ended_at",
+        "call_duration",
+    ] {
+        let mut cols = storage
+            .query("PRAGMA table_info(inbox_entries)", ())
+            .await
+            .expect("PRAGMA table_info");
+        let mut present = false;
+        while let Some(row) = cols.next().await.expect("advance pragma row") {
+            let name: String = row.get(1).expect("col name");
+            if name == column {
+                present = true;
+                break;
+            }
+        }
+        assert!(
+            present,
+            "migration must add `{column}` to legacy inbox_entries"
+        );
+    }
+
+    let user = jid("me@example.com");
+    let room = jid("room@muc.example.com");
+    storage
+        .upsert(
+            &user,
+            InboxEntry::new(room.clone(), ConversationKind::MucRoom, "anchor", 100)
+                .with_thread("t1")
+                .with_call_thread(CallThreadKind::Muc, CallThreadMedia::audio_video()),
+            true,
+        )
+        .await
+        .expect("upsert after migration must succeed");
+    let threads = storage
+        .list_threads(&user, &room)
+        .await
+        .expect("list_threads after migration must succeed");
+    assert_eq!(threads.len(), 1);
+    assert_eq!(threads[0].call_thread_kind, Some(CallThreadKind::Muc));
+    assert_eq!(
+        threads[0].call_thread_media,
+        Some(CallThreadMedia::audio_video())
+    );
+
     std::fs::remove_file(&path).ok();
 }

--- a/server/crates/waddle-server/src/inbox/tests.rs
+++ b/server/crates/waddle-server/src/inbox/tests.rs
@@ -233,6 +233,66 @@ async fn mark_ended_skips_reply_only_rows_without_call_thread_kind() {
 }
 
 #[tokio::test]
+async fn mark_ended_skips_rows_with_kind_but_null_media() {
+    // Defense-in-depth for the wire `<call>` condition: it emits only
+    // when BOTH kind and media are present. After Fix 1+2 the encoder
+    // never persists a kind-without-media row, but a row could exist from
+    // a legacy/corrupt write. Insert one directly via raw SQL (bypassing
+    // the encoder's normalization) and assert mark-ended does NOT stamp
+    // it — stamping would serialize `<call-ended>` without `<call>`.
+    use waddle_xmpp::xep::CallThreadDuration;
+    let storage = DatabaseInboxStorage::open(Some("sqlite::memory:"))
+        .await
+        .expect("storage");
+    let room: BareJid = "general@conference.example.com".parse().expect("room jid");
+    let user: BareJid = "carol@example.com".parse().expect("carol jid");
+
+    // Raw insert: call_thread_kind = 'muc' but call_thread_media NULL.
+    storage
+        .execute(
+            "INSERT INTO inbox_entries (user_jid, partner_jid, thread_id, kind, last_stanza_id, \
+             last_updated, unread, reply_count, call_thread_kind, call_thread_media) \
+             VALUES (?, ?, ?, 'muc', 'anchor-stanza', 1700000000, 0, 0, 'muc', NULL)",
+            crate::db_params![
+                user.to_string(),
+                room.to_string(),
+                "call-thread-uuid".to_string(),
+            ],
+        )
+        .await
+        .expect("raw insert kind-without-media row");
+
+    let ended = chrono::DateTime::parse_from_rfc3339("2026-06-07T14:35:00Z")
+        .expect("ended")
+        .with_timezone(&chrono::Utc);
+    storage
+        .mark_call_thread_ended(
+            &room,
+            "call-thread-uuid",
+            ended,
+            &CallThreadDuration::parse("PT5M").expect("duration"),
+        )
+        .await
+        .expect("mark ended");
+
+    let row = storage
+        .list_all_threads(&user)
+        .await
+        .expect("list_all_threads")
+        .into_iter()
+        .find(|e| e.thread_id.as_deref() == Some("call-thread-uuid"))
+        .expect("kind-without-media thread");
+    assert!(
+        row.call_ended_at.is_none(),
+        "row with kind set but media NULL must not be stamped with the ended summary"
+    );
+    assert!(
+        row.call_duration.is_none(),
+        "row with kind set but media NULL must not gain a call_duration"
+    );
+}
+
+#[tokio::test]
 async fn upsert_reply_preserves_anchor_call_thread_metadata() {
     use waddle_xmpp::xep::{CallThreadKind, CallThreadMedia};
     let storage = DatabaseInboxStorage::open(Some("sqlite::memory:"))

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
@@ -339,7 +339,7 @@ pub(super) async fn project_groupchat_inbox(
     let Some(thread) = thread else {
         return outcome;
     };
-    let thread_entry = groupchat_thread_entry(
+    let mut thread_entry = groupchat_thread_entry(
         room.clone(),
         message,
         dispatch_timestamp,
@@ -347,6 +347,13 @@ pub(super) async fn project_groupchat_inbox(
         thread.title.as_deref(),
         thread.author_nick.as_deref(),
     );
+    // Persist the call-thread anchor metadata (Task 2 storage supports
+    // it). The MUC call anchor's `kind`/`media` ride along on the
+    // thread-root projection; replies carry neither, so a later reply's
+    // projection leaves the stored anchor metadata untouched.
+    if let (Some(kind), Some(media)) = (thread.call_thread_kind, thread.call_thread_media) {
+        thread_entry = thread_entry.with_call_thread(kind, media);
+    }
     match inbox_storage
         .upsert_with_groupchat_notification_recovery(
             owner,

--- a/server/crates/waddle-server/src/server/routes/muc_muji_clear.rs
+++ b/server/crates/waddle-server/src/server/routes/muc_muji_clear.rs
@@ -152,12 +152,34 @@ pub(crate) async fn maybe_broadcast_call_thread_ended(state: &WebSocketState, ro
     let message = build_call_thread_ended_message(
         room_jid,
         &active.anchor_origin_id,
-        &CallThreadEnded { ended, duration },
+        &CallThreadEnded {
+            ended,
+            duration: duration.clone(),
+        },
     );
     let deps = build_interpret_deps(state, None);
     let _ =
         super::interpret::broadcast_room_system_message(&deps, room_jid.clone(), Box::new(message))
             .await;
+
+    // Stamp the ended summary onto every subscriber's inbox/threads
+    // projection of this thread. The fastening above is the wire record;
+    // this persists the same `ended` + `duration` onto the durable rows
+    // keyed by the anchor's `urn:waddle:threads:0` thread id so the
+    // threads view can surface the ended summary without replaying MAM.
+    if let Err(error) = state
+        .deps
+        .protocol
+        .inbox_storage
+        .mark_call_thread_ended(room_jid, &active.thread_id, ended, &duration)
+        .await
+    {
+        warn!(
+            room = %room_jid,
+            %error,
+            "failed to persist call-thread ended summary to inbox"
+        );
+    }
 }
 
 fn build_call_thread_ended_message(

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
@@ -235,7 +235,15 @@ pub(super) async fn try_handle_muc_presence_update(
         outcome.sender_muji.as_ref(),
         &outcome.session_mujis,
     );
-    let call_thread_anchor = if outcome.active_call_started {
+    // Gate the entire call-thread lifecycle on a configured SFU. The
+    // `active_call_started` flag comes from client-driven Muji presence,
+    // not the SFU; without this gate a no-SFU deployment would build,
+    // broadcast, and persist a call-thread anchor whose end path
+    // (`maybe_broadcast_call_thread_ended` / the `call_threads` registry)
+    // is itself SFU-gated — leaving a permanent call-thread row and a
+    // false Join affordance that can never be ended. Per #918,
+    // call-thread tracking is disabled when no SFU bridge is configured.
+    let call_thread_anchor = if outcome.active_call_started && state.deps.protocol.sfu.is_some() {
         build_call_thread_anchor_message(
             room_jid,
             &sender_jid.to_bare(),
@@ -333,17 +341,17 @@ pub(super) async fn try_handle_muc_presence_update(
             Box::new(anchor),
         )
         .await;
-        if state.deps.protocol.sfu.is_some() {
-            if let Some((anchor_origin_id, started)) = anchor_origin_id.zip(started) {
-                state.deps.protocol.call_threads.insert(
-                    room_jid.clone(),
-                    ActiveCallThread {
-                        anchor_origin_id,
-                        started,
-                        thread_id: thread_id.as_str().to_owned(),
-                    },
-                );
-            }
+        // The anchor only exists when an SFU is configured (gated at the
+        // build site above), so no inner SFU check is needed here.
+        if let Some((anchor_origin_id, started)) = anchor_origin_id.zip(started) {
+            state.deps.protocol.call_threads.insert(
+                room_jid.clone(),
+                ActiveCallThread {
+                    anchor_origin_id,
+                    started,
+                    thread_id: thread_id.as_str().to_owned(),
+                },
+            );
         }
     }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
@@ -236,12 +236,12 @@ pub(super) async fn try_handle_muc_presence_update(
         &outcome.session_mujis,
     );
     let call_thread_anchor = if outcome.active_call_started {
-        Some(build_call_thread_anchor_message(
+        build_call_thread_anchor_message(
             room_jid,
             &sender_jid.to_bare(),
             outcome.active_muji.as_ref(),
             &outcome.update.sender_nick,
-        ))
+        )
     } else {
         None
     };
@@ -307,7 +307,11 @@ pub(super) async fn try_handle_muc_presence_update(
             .await;
     }
 
-    if let Some(anchor) = call_thread_anchor {
+    if let Some(CallThreadAnchorMessage {
+        message: anchor,
+        thread_id,
+    }) = call_thread_anchor
+    {
         let started = anchor
             .payloads
             .iter()
@@ -336,6 +340,7 @@ pub(super) async fn try_handle_muc_presence_update(
                     ActiveCallThread {
                         anchor_origin_id,
                         started,
+                        thread_id: thread_id.as_str().to_owned(),
                     },
                 );
             }
@@ -347,13 +352,28 @@ pub(super) async fn try_handle_muc_presence_update(
     Some(responses)
 }
 
+/// A freshly-built call-thread anchor system message together with the
+/// `urn:waddle:threads:0` thread id it was assigned. The thread id is
+/// surfaced so the caller can register it in
+/// [`ActiveCallThread`](crate::server::routes::websocket::ActiveCallThread),
+/// correlating the later `<call-thread-ended/>` fastening back to the
+/// inbox/threads rows for this exact thread.
+struct CallThreadAnchorMessage {
+    message: Message,
+    thread_id: ThreadId,
+}
+
+/// Build the call-thread anchor system message. Returns `None` only in
+/// the impossible case that a freshly generated UUID is empty — handled
+/// without panicking so the no-`expect` hard rule holds; the caller then
+/// simply skips anchoring this call.
 fn build_call_thread_anchor_message(
     room_jid: &BareJid,
     initiator: &BareJid,
     active_muji: Option<&Muji>,
     initiator_nick: &str,
-) -> Message {
-    let thread_id = uuid::Uuid::new_v4().to_string();
+) -> Option<CallThreadAnchorMessage> {
+    let thread_id = ThreadId::new(uuid::Uuid::new_v4().to_string())?;
     let sid = SessionId(uuid::Uuid::new_v4().to_string());
     let media = media_from_muji(active_muji);
     let body = format!("{initiator_nick} started a call");
@@ -361,7 +381,7 @@ fn build_call_thread_anchor_message(
     message.from = Some(jid::Jid::from(room_jid.clone()));
     message.type_ = MessageType::Groupchat;
     message.bodies.insert(Lang(String::new()), body);
-    let thread = ThreadInfo::root(ThreadId::new(thread_id).expect("uuid thread id is non-empty"));
+    let thread = ThreadInfo::root(thread_id.clone());
     message
         .payloads
         .push(build_thread_element(&thread, CLIENT_STANZA_NS));
@@ -378,7 +398,7 @@ fn build_call_thread_anchor_message(
             started: chrono::Utc::now(),
         }));
     message.payloads.push(build_hint_element(Hint::Store));
-    message
+    Some(CallThreadAnchorMessage { message, thread_id })
 }
 
 fn media_from_muji(active_muji: Option<&Muji>) -> CallThreadMedia {

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -4,6 +4,12 @@ use super::*;
 pub struct ActiveCallThread {
     pub anchor_origin_id: String,
     pub started: chrono::DateTime<chrono::Utc>,
+    /// The anchor message's `urn:waddle:threads:0` thread id (the
+    /// `<thread/>` value). Correlates the ended fastening back to the
+    /// inbox/threads rows so [`InboxStorage::mark_call_thread_ended`]
+    /// can stamp the ended timestamp + duration onto every
+    /// subscriber's projection of `(room, thread_id)`.
+    pub thread_id: String,
 }
 
 #[derive(Debug, Clone)]

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -1343,11 +1343,41 @@ async fn empty_muji_presence_ends_the_active_call_thread() {
         &Some(owner_session.clone()),
     )
     .await;
+    // Anchor the call thread in the inbox under the same thread id the
+    // active-call registration carries, so the ended summary can be
+    // correlated back to this exact thread's row.
+    let thread_id = "call-thread-uuid";
+    state
+        .deps
+        .protocol
+        .inbox_storage
+        .upsert(
+            &alice.to_bare(),
+            waddle_xmpp::inbox::InboxEntry::new(
+                room_jid.clone(),
+                waddle_xmpp::inbox::ConversationKind::MucRoom,
+                "anchor-stanza",
+                1_700_000_000,
+            )
+            .with_thread(thread_id)
+            .with_call_thread(
+                waddle_xmpp::xep::CallThreadKind::Muc,
+                waddle_xmpp::xep::CallThreadMedia {
+                    audio: true,
+                    video: false,
+                },
+            ),
+            true,
+        )
+        .await
+        .expect("seed call-thread anchor inbox row");
+
     state.deps.protocol.call_threads.insert(
         room_jid.clone(),
         crate::server::routes::websocket::ActiveCallThread {
             anchor_origin_id: "anchor-origin-id".to_owned(),
             started: chrono::Utc::now() - chrono::Duration::minutes(5),
+            thread_id: thread_id.to_owned(),
         },
     );
 
@@ -1366,6 +1396,37 @@ async fn empty_muji_presence_ends_the_active_call_thread() {
     assert!(
         !state.deps.protocol.call_threads.contains_key(&room_jid),
         "XMPP-native Muji clear must consume the active call thread when the SFU participant set is empty"
+    );
+
+    // The ended summary must be persisted onto the thread's inbox row so
+    // the durable threads projection reflects the call ending without a
+    // MAM replay.
+    let anchor_row = state
+        .deps
+        .protocol
+        .inbox_storage
+        .list_threads(&alice.to_bare(), &room_jid)
+        .await
+        .expect("list room threads")
+        .into_iter()
+        .find(|entry| entry.thread_id.as_deref() == Some(thread_id))
+        .expect("anchor thread row persists");
+    assert!(
+        anchor_row.call_ended_at.is_some(),
+        "ending the active call must stamp call_ended_at onto the thread inbox row"
+    );
+    assert!(
+        anchor_row
+            .call_duration
+            .as_ref()
+            .is_some_and(|duration| duration.as_str().starts_with("PT")),
+        "ending the active call must stamp an ISO-8601 call_duration onto the thread inbox row: {:?}",
+        anchor_row.call_duration
+    );
+    assert_eq!(
+        anchor_row.call_thread_kind,
+        Some(waddle_xmpp::xep::CallThreadKind::Muc),
+        "the anchor kind must survive the ended UPDATE"
     );
 }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -1430,6 +1430,89 @@ async fn empty_muji_presence_ends_the_active_call_thread() {
     );
 }
 
+// Per #918: the whole call-thread lifecycle is gated on a configured SFU
+// (`muc_update.rs`: anchor built only when `active_call_started &&
+// sfu.is_some()`). Without an SFU the `active_call_started` flag from
+// client-driven Muji presence must NOT register a call-thread anchor,
+// because the end path that would consume it is itself SFU-gated. These
+// two tests pin both sides of that gate.
+#[tokio::test]
+async fn active_muji_presence_without_sfu_does_not_register_call_thread_anchor() {
+    // `create_test_websocket_state` builds state with `sfu: None`, so the
+    // call-thread gate is closed.
+    let state = create_test_websocket_state().await;
+    let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let room_jid: BareJid = "no-sfu-anchor@muc.example.com".parse().expect("room jid");
+    let alice: FullJid = "alice@example.com/web".parse().expect("alice jid");
+
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &alice,
+        "alice",
+        None,
+        &Some(owner_session.clone()),
+    )
+    .await;
+    let alice_phase = waddle_xmpp::protocol::ConnectionPhase::ready(alice.clone(), false);
+
+    let mut active = muc_presence_to(&room_jid, "alice");
+    active.payloads.push(active_muji().to_element());
+    let _ = handlers::presence::handle_presence(
+        active,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &alice_phase,
+        &Some(owner_session),
+    )
+    .await;
+
+    assert!(
+        !state.deps.protocol.call_threads.contains_key(&room_jid),
+        "an active <muji/> must not register a call-thread anchor when no SFU is configured"
+    );
+}
+
+#[tokio::test]
+async fn active_muji_presence_with_sfu_registers_call_thread_anchor() {
+    let recorder = std::sync::Arc::new(RecordingSfu::default());
+    let state = state_with_recording_sfu(std::sync::Arc::clone(&recorder)).await;
+    let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let room_jid: BareJid = "with-sfu-anchor@muc.example.com".parse().expect("room jid");
+    let alice: FullJid = "alice@example.com/web".parse().expect("alice jid");
+
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &alice,
+        "alice",
+        None,
+        &Some(owner_session.clone()),
+    )
+    .await;
+    let alice_phase = waddle_xmpp::protocol::ConnectionPhase::ready(alice.clone(), false);
+
+    let mut active = muc_presence_to(&room_jid, "alice");
+    active.payloads.push(active_muji().to_element());
+    let _ = handlers::presence::handle_presence(
+        active,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &alice_phase,
+        &Some(owner_session),
+    )
+    .await;
+
+    assert!(
+        state.deps.protocol.call_threads.contains_key(&room_jid),
+        "an active <muji/> must register a call-thread anchor when an SFU is configured"
+    );
+}
+
 #[tokio::test]
 async fn resumed_muc_join_presence_replays_existing_muji_state() {
     let state = create_test_websocket_state().await;

--- a/server/crates/waddle-server/src/threads/query.rs
+++ b/server/crates/waddle-server/src/threads/query.rs
@@ -1,6 +1,8 @@
 //! Typed request and response values for the threads query.
 
+use chrono::{DateTime, Utc};
 use jid::BareJid;
+use waddle_xmpp::xep::{CallThreadDuration, CallThreadKind, CallThreadMedia};
 
 /// `urn:waddle:threads:0` namespace.
 pub const NS_THREADS: &str = "urn:waddle:threads:0";
@@ -106,6 +108,17 @@ pub struct ThreadEntry {
     pub root_author: Option<ThreadRootAuthor>,
     pub preview: Option<String>,
     pub thread_title: Option<String>,
+    /// Kind of call anchored to this thread (DM or MUC). `None` for
+    /// non-call threads.
+    pub call_thread_kind: Option<CallThreadKind>,
+    /// Media negotiated for the anchored call (audio and/or video). `None`
+    /// for non-call threads.
+    pub call_thread_media: Option<CallThreadMedia>,
+    /// When the anchored call ended. `Some` only once the call has ended.
+    pub call_ended_at: Option<DateTime<Utc>>,
+    /// Duration of the ended call (ISO 8601 `PT…`). `Some` only once the
+    /// call has ended.
+    pub call_duration: Option<CallThreadDuration>,
 }
 
 impl ThreadEntry {

--- a/server/crates/waddle-server/src/threads/storage.rs
+++ b/server/crates/waddle-server/src/threads/storage.rs
@@ -260,6 +260,10 @@ fn build_thread_entry(row: &InboxEntry) -> Option<ThreadEntry> {
         root_author,
         preview: row.preview.clone(),
         thread_title: row.thread_title.clone(),
+        call_thread_kind: row.call_thread_kind,
+        call_thread_media: row.call_thread_media,
+        call_ended_at: row.call_ended_at,
+        call_duration: row.call_duration.clone(),
     })
 }
 
@@ -352,7 +356,9 @@ impl ThreadsStorage for InboxBackedThreadsStorage {
 mod tests {
     use super::*;
     use crate::inbox::DatabaseInboxStorage;
+    use chrono::{DateTime, Utc};
     use waddle_xmpp::inbox::{ConversationKind, InboxEntry};
+    use waddle_xmpp::xep::{CallThreadDuration, CallThreadKind, CallThreadMedia};
 
     fn jid(value: &str) -> BareJid {
         value.parse().expect("valid JID")
@@ -1060,6 +1066,42 @@ mod tests {
                 .map(|entry| entry.thread_id.as_str())
                 .collect::<Vec<_>>(),
             vec!["few"]
+        );
+    }
+
+    #[tokio::test]
+    async fn page_carries_call_thread_metadata() {
+        let (inbox, threads) = make_storage_pair().await;
+        let user = jid("me@example.com");
+        let room = jid("room@muc.example");
+        let ended = "2026-06-07T14:35:00Z"
+            .parse::<DateTime<Utc>>()
+            .expect("ended timestamp");
+
+        inbox
+            .upsert(
+                &user,
+                InboxEntry::new(room, ConversationKind::MucRoom, "s-call", 100)
+                    .with_thread("call-thread")
+                    .with_call_thread(CallThreadKind::Muc, CallThreadMedia::audio_video())
+                    .with_call_ended(ended, CallThreadDuration::parse("PT5M").expect("duration")),
+                true,
+            )
+            .await
+            .expect("upsert call thread");
+
+        let page = threads.page(&user, &threads_query(50)).await.expect("page");
+        assert_eq!(page.entries.len(), 1);
+        let entry = &page.entries[0];
+        assert_eq!(entry.call_thread_kind, Some(CallThreadKind::Muc));
+        assert_eq!(
+            entry.call_thread_media,
+            Some(CallThreadMedia::audio_video())
+        );
+        assert_eq!(entry.call_ended_at, Some(ended));
+        assert_eq!(
+            entry.call_duration.as_ref().map(CallThreadDuration::as_str),
+            Some("PT5M")
         );
     }
 

--- a/server/crates/waddle-server/src/threads/wire.rs
+++ b/server/crates/waddle-server/src/threads/wire.rs
@@ -2,6 +2,7 @@
 //! so no XML is ever concatenated as strings (CLAUDE.md hard rule).
 
 use minidom::Element;
+use waddle_xmpp::xep::{CallThreadKind, CallThreadMedia};
 use xmpp_parsers::iq::Iq;
 
 use super::query::{
@@ -155,13 +156,59 @@ fn build_thread_entry(entry: &ThreadEntry) -> Element {
         title_el.append_text_node(title);
         t.append_child(title_el);
     }
+    if let (Some(kind), Some(media)) = (entry.call_thread_kind, entry.call_thread_media) {
+        let call_el = Element::builder("call", NS_THREADS)
+            .attr(
+                minidom::rxml::xml_ncname!("kind").to_owned(),
+                call_kind_token(kind),
+            )
+            .attr(
+                minidom::rxml::xml_ncname!("media").to_owned(),
+                call_media_tokens(media),
+            )
+            .build();
+        t.append_child(call_el);
+    }
+    if let (Some(ended_at), Some(ref duration)) = (entry.call_ended_at, &entry.call_duration) {
+        let call_ended_el = Element::builder("call-ended", NS_THREADS)
+            .attr(
+                minidom::rxml::xml_ncname!("ended").to_owned(),
+                ended_at.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+            )
+            .attr(
+                minidom::rxml::xml_ncname!("duration").to_owned(),
+                duration.as_str(),
+            )
+            .build();
+        t.append_child(call_ended_el);
+    }
     t
+}
+
+/// `kind` attribute token for the `<call>` child.
+fn call_kind_token(kind: CallThreadKind) -> &'static str {
+    match kind {
+        CallThreadKind::Dm => "dm",
+        CallThreadKind::Muc => "muc",
+    }
+}
+
+/// Space-joined `media` tokens, `audio` before `video`, matching the
+/// call-thread anchor marker convention.
+fn call_media_tokens(media: CallThreadMedia) -> &'static str {
+    match (media.audio, media.video) {
+        (true, true) => "audio video",
+        (true, false) => "audio",
+        (false, true) => "video",
+        (false, false) => "",
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::threads::query::ThreadRootAuthor;
+    use waddle_xmpp::xep::{CallThreadDuration, CallThreadKind, CallThreadMedia};
     use xmpp_parsers::iq::Iq;
 
     fn make_get_iq(payload: Element) -> Iq {
@@ -311,6 +358,10 @@ mod tests {
             root_author: ThreadRootAuthor::parse("juliet"),
             preview: Some("Anyone reviewed the doc?".into()),
             thread_title: Some("Q3 planning".into()),
+            call_thread_kind: None,
+            call_thread_media: None,
+            call_ended_at: None,
+            call_duration: None,
         };
         let page = ThreadsPage {
             entries: vec![entry.clone()],
@@ -349,6 +400,10 @@ mod tests {
             root_author: None,
             preview: None,
             thread_title: None,
+            call_thread_kind: None,
+            call_thread_media: None,
+            call_ended_at: None,
+            call_duration: None,
         };
         let page = ThreadsPage {
             entries: vec![entry],
@@ -363,5 +418,102 @@ mod tests {
             .find(|c| c.name() == "thread")
             .expect("has thread");
         assert_eq!(thread_el.attr("has-unread"), Some("false"));
+    }
+
+    fn call_thread_entry() -> ThreadEntry {
+        ThreadEntry {
+            channel: "room@conference.example".parse().expect("valid bare JID"),
+            thread_id: "call-1".into(),
+            last_stanza_id: "S-9".into(),
+            last_activity_secs: 1_700_000_000,
+            unread: 0,
+            reply_count: 0,
+            root_author: None,
+            preview: None,
+            thread_title: None,
+            call_thread_kind: Some(CallThreadKind::Muc),
+            call_thread_media: Some(CallThreadMedia::audio_video()),
+            call_ended_at: None,
+            call_duration: None,
+        }
+    }
+
+    fn thread_child(entry: ThreadEntry) -> Element {
+        let page = ThreadsPage {
+            entries: vec![entry],
+            total: 1,
+            unread_threads: 0,
+            first_cursor: None,
+            last_cursor: None,
+        };
+        let elem = build_threads_response(&page);
+        elem.children()
+            .find(|c| c.name() == "thread")
+            .cloned()
+            .expect("has thread")
+    }
+
+    #[test]
+    fn build_emits_call_child_for_call_thread() {
+        let thread_el = thread_child(call_thread_entry());
+
+        let call = thread_el
+            .get_child("call", NS_THREADS)
+            .expect("has call child");
+        assert_eq!(call.attr("kind"), Some("muc"));
+        assert_eq!(call.attr("media"), Some("audio video"));
+        assert!(
+            thread_el.get_child("call-ended", NS_THREADS).is_none(),
+            "ongoing call must not emit <call-ended>"
+        );
+    }
+
+    #[test]
+    fn build_emits_call_ended_child_when_ended() {
+        let mut entry = call_thread_entry();
+        entry.call_thread_media = Some(CallThreadMedia::audio_only());
+        entry.call_ended_at = Some(
+            "2026-06-07T14:35:00Z"
+                .parse::<chrono::DateTime<chrono::Utc>>()
+                .expect("ended timestamp"),
+        );
+        entry.call_duration = Some(CallThreadDuration::parse("PT5M").expect("duration"));
+
+        let thread_el = thread_child(entry);
+
+        let call = thread_el
+            .get_child("call", NS_THREADS)
+            .expect("has call child");
+        assert_eq!(call.attr("kind"), Some("muc"));
+        assert_eq!(call.attr("media"), Some("audio"));
+
+        let ended = thread_el
+            .get_child("call-ended", NS_THREADS)
+            .expect("has call-ended child");
+        assert_eq!(ended.attr("ended"), Some("2026-06-07T14:35:00Z"));
+        assert_eq!(ended.attr("duration"), Some("PT5M"));
+    }
+
+    #[test]
+    fn build_omits_call_children_for_non_call_thread() {
+        let entry = ThreadEntry {
+            channel: "room@conference.example".parse().expect("valid bare JID"),
+            thread_id: "plain".into(),
+            last_stanza_id: "S-1".into(),
+            last_activity_secs: 1_700_000_000,
+            unread: 0,
+            reply_count: 0,
+            root_author: None,
+            preview: None,
+            thread_title: None,
+            call_thread_kind: None,
+            call_thread_media: None,
+            call_ended_at: None,
+            call_duration: None,
+        };
+        let thread_el = thread_child(entry);
+
+        assert!(thread_el.get_child("call", NS_THREADS).is_none());
+        assert!(thread_el.get_child("call-ended", NS_THREADS).is_none());
     }
 }

--- a/server/crates/waddle-server/src/threads/wire.rs
+++ b/server/crates/waddle-server/src/threads/wire.rs
@@ -2,7 +2,6 @@
 //! so no XML is ever concatenated as strings (CLAUDE.md hard rule).
 
 use minidom::Element;
-use waddle_xmpp::xep::{CallThreadKind, CallThreadMedia};
 use xmpp_parsers::iq::Iq;
 
 use super::query::{
@@ -160,11 +159,11 @@ fn build_thread_entry(entry: &ThreadEntry) -> Element {
         let call_el = Element::builder("call", NS_THREADS)
             .attr(
                 minidom::rxml::xml_ncname!("kind").to_owned(),
-                call_kind_token(kind),
+                kind.as_token(),
             )
             .attr(
                 minidom::rxml::xml_ncname!("media").to_owned(),
-                call_media_tokens(media),
+                media.as_tokens(),
             )
             .build();
         t.append_child(call_el);
@@ -183,25 +182,6 @@ fn build_thread_entry(entry: &ThreadEntry) -> Element {
         t.append_child(call_ended_el);
     }
     t
-}
-
-/// `kind` attribute token for the `<call>` child.
-fn call_kind_token(kind: CallThreadKind) -> &'static str {
-    match kind {
-        CallThreadKind::Dm => "dm",
-        CallThreadKind::Muc => "muc",
-    }
-}
-
-/// Space-joined `media` tokens, `audio` before `video`, matching the
-/// call-thread anchor marker convention.
-fn call_media_tokens(media: CallThreadMedia) -> &'static str {
-    match (media.audio, media.video) {
-        (true, true) => "audio video",
-        (true, false) => "audio",
-        (false, true) => "video",
-        (false, false) => "",
-    }
 }
 
 #[cfg(test)]

--- a/server/crates/waddle-xmpp-client-wasm/src/client_account.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_account.rs
@@ -529,6 +529,14 @@ impl WaddleClient {
                         root_author: e.root_author,
                         preview: e.preview,
                         thread_title: e.thread_title,
+                        call_thread: e.call_thread.map(|c| WaddleThreadCallAnchor {
+                            kind: c.kind.as_token().to_owned(),
+                            media: c.media.token_list(),
+                        }),
+                        call_thread_ended: e.call_thread_ended.map(|c| WaddleThreadCallEnded {
+                            ended: c.ended,
+                            duration: c.duration,
+                        }),
                     })
                     .collect(),
                 next_cursor: page.next_cursor,

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -883,6 +883,30 @@ pub struct WaddleThreadEntry {
     pub preview: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thread_title: Option<String>,
+    /// Call-thread anchor summary, present when this thread anchors a call.
+    #[serde(rename = "callThread", skip_serializing_if = "Option::is_none")]
+    pub call_thread: Option<WaddleThreadCallAnchor>,
+    /// Ended-call summary, present when the anchored call has ended.
+    #[serde(rename = "callThreadEnded", skip_serializing_if = "Option::is_none")]
+    pub call_thread_ended: Option<WaddleThreadCallEnded>,
+}
+
+/// Call-thread anchor summary on a `urn:waddle:threads:0` entry.
+#[derive(Debug, Clone, Serialize)]
+pub struct WaddleThreadCallAnchor {
+    /// `"muc"` or `"dm"`.
+    pub kind: String,
+    /// Ordered media tokens, e.g. `["audio", "video"]`.
+    pub media: Vec<String>,
+}
+
+/// Ended-call summary on a `urn:waddle:threads:0` entry.
+#[derive(Debug, Clone, Serialize)]
+pub struct WaddleThreadCallEnded {
+    /// RFC 3339 timestamp when the call ended.
+    pub ended: String,
+    /// ISO-8601 duration, e.g. `"PT5M"`.
+    pub duration: String,
 }
 
 /// Paged response to a urn:waddle:threads:0 query, shaped for JS.
@@ -1262,5 +1286,63 @@ mod tests {
             parsed.into_credentials().is_err(),
             "web platform must require all three Web Push fields"
         );
+    }
+
+    /// Pin the JSON shape the chat client consumes for `WasmThreadEntry`
+    /// (see `chat/src/lib/xmpp/wasm-types.ts`): a call-thread entry carries
+    /// the camelCase `callThread` and, once ended, `callThreadEnded` keys.
+    #[test]
+    fn thread_entry_serializes_call_thread_fields() {
+        let entry = super::WaddleThreadEntry {
+            channel: "room@x".into(),
+            thread_id: "call-1".into(),
+            last_stanza_id: "S1".into(),
+            last_activity: "2026-06-07T14:30:00Z".into(),
+            unread: 0,
+            reply_count: 4,
+            has_unread: false,
+            root_author: None,
+            preview: None,
+            thread_title: None,
+            call_thread: Some(super::WaddleThreadCallAnchor {
+                kind: "muc".into(),
+                media: vec!["audio".into(), "video".into()],
+            }),
+            call_thread_ended: Some(super::WaddleThreadCallEnded {
+                ended: "2026-06-07T14:35:00Z".into(),
+                duration: "PT5M".into(),
+            }),
+        };
+        let value = serde_json::to_value(&entry).expect("serializes");
+        assert_eq!(
+            value["callThread"],
+            serde_json::json!({ "kind": "muc", "media": ["audio", "video"] })
+        );
+        assert_eq!(
+            value["callThreadEnded"],
+            serde_json::json!({ "ended": "2026-06-07T14:35:00Z", "duration": "PT5M" })
+        );
+    }
+
+    #[test]
+    fn thread_entry_omits_call_thread_fields_when_absent() {
+        let entry = super::WaddleThreadEntry {
+            channel: "room@x".into(),
+            thread_id: "plain-1".into(),
+            last_stanza_id: "S2".into(),
+            last_activity: "2026-06-07T13:00:00Z".into(),
+            unread: 0,
+            reply_count: 1,
+            has_unread: false,
+            root_author: None,
+            preview: None,
+            thread_title: None,
+            call_thread: None,
+            call_thread_ended: None,
+        };
+        let value = serde_json::to_value(&entry).expect("serializes");
+        let map = value.as_object().expect("object");
+        assert!(!map.contains_key("callThread"));
+        assert!(!map.contains_key("callThreadEnded"));
     }
 }

--- a/server/crates/waddle-xmpp-client/src/xep/call_thread.rs
+++ b/server/crates/waddle-xmpp-client/src/xep/call_thread.rs
@@ -16,6 +16,25 @@ pub enum CallThreadKind {
     Muc,
 }
 
+impl CallThreadKind {
+    /// Canonical wire/storage token for the kind: `"dm"` or `"muc"`.
+    pub fn as_token(self) -> &'static str {
+        match self {
+            CallThreadKind::Dm => "dm",
+            CallThreadKind::Muc => "muc",
+        }
+    }
+
+    /// Parse a wire token (`"dm"`/`"muc"`) into a typed kind.
+    pub fn parse_token(token: &str) -> Result<Self, CallThreadParseError> {
+        match token {
+            "dm" => Ok(CallThreadKind::Dm),
+            "muc" => Ok(CallThreadKind::Muc),
+            _ => Err(CallThreadParseError::InvalidKind),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CallThreadMedia {
     pub audio: bool,
@@ -35,6 +54,23 @@ impl CallThreadMedia {
             audio: true,
             video: true,
         }
+    }
+
+    /// Parse a space-separated media token list (e.g. `"audio video"`).
+    pub fn parse_tokens(value: &str) -> Result<Self, CallThreadParseError> {
+        parse_media(value)
+    }
+
+    /// Ordered media tokens (`audio` before `video`) for the wasm boundary.
+    pub fn token_list(self) -> Vec<String> {
+        let mut tokens = Vec::with_capacity(2);
+        if self.audio {
+            tokens.push("audio".to_owned());
+        }
+        if self.video {
+            tokens.push("video".to_owned());
+        }
+        tokens
     }
 }
 
@@ -117,11 +153,7 @@ pub fn parse_call_thread_anchor(
         return Err(CallThreadParseError::NotCallThread);
     }
 
-    let kind = match required_attr(element, "kind")? {
-        "dm" => CallThreadKind::Dm,
-        "muc" => CallThreadKind::Muc,
-        _ => return Err(CallThreadParseError::InvalidKind),
-    };
+    let kind = CallThreadKind::parse_token(required_attr(element, "kind")?)?;
 
     let sid = SessionId(required_attr(element, "sid")?.to_string());
     let media = parse_media(required_attr(element, "media")?)?;

--- a/server/crates/waddle-xmpp-client/src/xep/threads.rs
+++ b/server/crates/waddle-xmpp-client/src/xep/threads.rs
@@ -4,6 +4,7 @@
 //! `waddle-server/src/threads/wire.rs`. The chat client uses the IQ
 //! builder/parser to drive the global Threads view.
 
+use crate::xep::call_thread::{CallThreadKind, CallThreadMedia};
 use chrono::{DateTime, SecondsFormat, Utc};
 use jid::BareJid;
 use minidom::Element;
@@ -13,6 +14,28 @@ pub const NS_THREADS: &str = "urn:waddle:threads:0";
 
 const NS_CLIENT: &str = "jabber:client";
 const NS_RSM: &str = "http://jabber.org/protocol/rsm";
+
+/// Call-thread anchor summary carried by a `<thread>` entry.
+///
+/// Present only when the thread is a call-thread anchor (the server
+/// emits a `<call kind=… media=…/>` child).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ThreadCallSummary {
+    pub kind: CallThreadKind,
+    pub media: CallThreadMedia,
+}
+
+/// Ended-call summary carried by a `<thread>` entry.
+///
+/// Present only when the anchored call has ended (the server emits a
+/// `<call-ended ended=… duration=…/>` child). Both fields are kept as
+/// wire strings (RFC 3339 timestamp / ISO-8601 duration) so they cross
+/// the wasm boundary unchanged.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ThreadCallEndedSummary {
+    pub ended: String,
+    pub duration: String,
+}
 
 /// One entry in a `<threads>` response.
 ///
@@ -31,6 +54,10 @@ pub struct ThreadEntry {
     pub root_author: Option<String>,
     pub preview: Option<String>,
     pub thread_title: Option<String>,
+    /// Call-thread anchor summary, present when this thread anchors a call.
+    pub call_thread: Option<ThreadCallSummary>,
+    /// Ended-call summary, present when the anchored call has ended.
+    pub call_thread_ended: Option<ThreadCallEndedSummary>,
 }
 
 /// Full response payload.
@@ -185,6 +212,8 @@ pub fn parse_threads_response(iq: &Element) -> Option<ThreadsPage> {
                 .get_child("thread-title", NS_THREADS)
                 .map(|e| e.text())
                 .filter(|s| !s.is_empty()),
+            call_thread: parse_call_summary(t),
+            call_thread_ended: parse_call_ended_summary(t),
         })
         .collect();
 
@@ -200,6 +229,27 @@ pub fn parse_threads_response(iq: &Element) -> Option<ThreadsPage> {
         entries,
         next_cursor,
     })
+}
+
+/// Parse the optional `<call kind=… media=…/>` child of a `<thread>`.
+///
+/// Returns `None` when the child is absent or carries an unknown/garbage
+/// `kind`/`media` — a malformed call marker is treated as "not a call
+/// thread" rather than failing the whole page.
+fn parse_call_summary(thread: &Element) -> Option<ThreadCallSummary> {
+    let call = thread.get_child("call", NS_THREADS)?;
+    let kind = CallThreadKind::parse_token(call.attr("kind")?).ok()?;
+    let media = CallThreadMedia::parse_tokens(call.attr("media")?).ok()?;
+    Some(ThreadCallSummary { kind, media })
+}
+
+/// Parse the optional `<call-ended ended=… duration=…/>` child of a
+/// `<thread>`. Returns `None` when the child or either attribute is absent.
+fn parse_call_ended_summary(thread: &Element) -> Option<ThreadCallEndedSummary> {
+    let ended_el = thread.get_child("call-ended", NS_THREADS)?;
+    let ended = ended_el.attr("ended")?.to_owned();
+    let duration = ended_el.attr("duration")?.to_owned();
+    Some(ThreadCallEndedSummary { ended, duration })
 }
 
 #[cfg(test)]
@@ -300,5 +350,76 @@ mod tests {
         let xml = "<iq xmlns='jabber:client' type='result' id='r'/>";
         let iq: Element = xml.parse().expect("valid XML");
         assert!(parse_threads_response(&iq).is_none());
+    }
+
+    #[test]
+    fn parse_extracts_call_thread_children() {
+        let xml = "<iq xmlns='jabber:client' type='result' id='r'>\
+                     <threads xmlns='urn:waddle:threads:0' total='2' unread-threads='0'>\
+                       <thread channel='room@x' thread-id='call-1' \
+                               last-stanza-id='S1' last-activity='2026-06-07T14:30:00Z' \
+                               unread='0' reply-count='4' has-unread='false'>\
+                         <call kind='muc' media='audio video'/>\
+                         <call-ended ended='2026-06-07T14:35:00Z' duration='PT5M'/>\
+                       </thread>\
+                       <thread channel='room@x' thread-id='plain-1' \
+                               last-stanza-id='S2' last-activity='2026-06-07T13:00:00Z' \
+                               unread='0' reply-count='1' has-unread='false'/>\
+                     </threads>\
+                   </iq>";
+        let iq: Element = xml.parse().expect("valid XML");
+        let page = parse_threads_response(&iq).expect("parses");
+        assert_eq!(page.entries.len(), 2);
+
+        let call = &page.entries[0];
+        let summary = call.call_thread.expect("call-thread summary present");
+        assert_eq!(summary.kind, CallThreadKind::Muc);
+        assert_eq!(summary.media, CallThreadMedia::audio_video());
+        let ended = call
+            .call_thread_ended
+            .as_ref()
+            .expect("call-ended summary present");
+        assert_eq!(ended.ended, "2026-06-07T14:35:00Z");
+        assert_eq!(ended.duration, "PT5M");
+
+        let plain = &page.entries[1];
+        assert!(plain.call_thread.is_none());
+        assert!(plain.call_thread_ended.is_none());
+    }
+
+    #[test]
+    fn parse_ongoing_call_thread_has_no_ended_summary() {
+        let xml = "<iq xmlns='jabber:client' type='result' id='r'>\
+                     <threads xmlns='urn:waddle:threads:0' total='1' unread-threads='0'>\
+                       <thread channel='room@x' thread-id='call-2' \
+                               last-stanza-id='S1' last-activity='2026-06-07T14:30:00Z' \
+                               unread='0' reply-count='0' has-unread='false'>\
+                         <call kind='dm' media='audio'/>\
+                       </thread>\
+                     </threads>\
+                   </iq>";
+        let iq: Element = xml.parse().expect("valid XML");
+        let page = parse_threads_response(&iq).expect("parses");
+        let entry = &page.entries[0];
+        let summary = entry.call_thread.expect("call-thread summary present");
+        assert_eq!(summary.kind, CallThreadKind::Dm);
+        assert_eq!(summary.media, CallThreadMedia::audio_only());
+        assert!(entry.call_thread_ended.is_none());
+    }
+
+    #[test]
+    fn parse_ignores_call_marker_with_garbage_kind() {
+        let xml = "<iq xmlns='jabber:client' type='result' id='r'>\
+                     <threads xmlns='urn:waddle:threads:0' total='1' unread-threads='0'>\
+                       <thread channel='room@x' thread-id='call-3' \
+                               last-stanza-id='S1' last-activity='2026-06-07T14:30:00Z' \
+                               unread='0' reply-count='0' has-unread='false'>\
+                         <call kind='bogus' media='audio'/>\
+                       </thread>\
+                     </threads>\
+                   </iq>";
+        let iq: Element = xml.parse().expect("valid XML");
+        let page = parse_threads_response(&iq).expect("parses");
+        assert!(page.entries[0].call_thread.is_none());
     }
 }

--- a/server/crates/waddle-xmpp/src/inbox/mod.rs
+++ b/server/crates/waddle-xmpp/src/inbox/mod.rs
@@ -321,6 +321,28 @@ impl InboxView {
         v
     }
 
+    /// Mark the call anchored to `(room, thread_id)` as ended on this view.
+    /// Returns `true` when a matching thread entry was updated. The
+    /// call-end summary is room-wide; callers fan this across every user's
+    /// view of the thread.
+    pub fn mark_call_thread_ended(
+        &mut self,
+        room: &BareJid,
+        thread_id: &str,
+        ended: DateTime<Utc>,
+        duration: CallThreadDuration,
+    ) -> bool {
+        let key = InboxKey::thread(room.clone(), thread_id);
+        match self.entries.get_mut(&key) {
+            Some(entry) => {
+                entry.call_ended_at = Some(ended);
+                entry.call_duration = Some(duration);
+                true
+            }
+            None => false,
+        }
+    }
+
     /// Total unread across channel-level conversations (excludes thread entries).
     pub fn total_unread(&self) -> u64 {
         self.entries

--- a/server/crates/waddle-xmpp/src/inbox/mod.rs
+++ b/server/crates/waddle-xmpp/src/inbox/mod.rs
@@ -18,9 +18,12 @@ pub mod storage;
 
 use std::collections::HashMap;
 
+use chrono::{DateTime, Utc};
 use jid::BareJid;
 use minidom::Element;
 use serde::{Deserialize, Serialize};
+
+use crate::xep::{CallThreadDuration, CallThreadKind, CallThreadMedia};
 
 /// Composite key identifying one inbox conversation.
 ///
@@ -109,6 +112,17 @@ pub struct InboxEntry {
     pub reply_count: u32,
     /// Nick of the thread starter.
     pub author: Option<String>,
+    /// Kind of call anchored to this thread (DM or MUC), when the thread is a
+    /// call thread. `None` for non-call threads.
+    pub call_thread_kind: Option<CallThreadKind>,
+    /// Media negotiated for the anchored call (audio and/or video). `None`
+    /// for non-call threads.
+    pub call_thread_media: Option<CallThreadMedia>,
+    /// When the anchored call ended. `Some` only once the call has ended.
+    pub call_ended_at: Option<DateTime<Utc>>,
+    /// Duration of the ended call (ISO 8601 `PT…`). `Some` only once the call
+    /// has ended.
+    pub call_duration: Option<CallThreadDuration>,
 }
 
 impl InboxEntry {
@@ -129,6 +143,10 @@ impl InboxEntry {
             thread_title: None,
             reply_count: 0,
             author: None,
+            call_thread_kind: None,
+            call_thread_media: None,
+            call_ended_at: None,
+            call_duration: None,
         }
     }
 
@@ -159,6 +177,18 @@ impl InboxEntry {
 
     pub fn with_author(mut self, author: impl Into<String>) -> Self {
         self.author = Some(author.into());
+        self
+    }
+
+    pub fn with_call_thread(mut self, kind: CallThreadKind, media: CallThreadMedia) -> Self {
+        self.call_thread_kind = Some(kind);
+        self.call_thread_media = Some(media);
+        self
+    }
+
+    pub fn with_call_ended(mut self, ended: DateTime<Utc>, duration: CallThreadDuration) -> Self {
+        self.call_ended_at = Some(ended);
+        self.call_duration = Some(duration);
         self
     }
 }

--- a/server/crates/waddle-xmpp/src/inbox/mod.rs
+++ b/server/crates/waddle-xmpp/src/inbox/mod.rs
@@ -333,12 +333,16 @@ impl InboxView {
         duration: CallThreadDuration,
     ) -> bool {
         let key = InboxKey::thread(room.clone(), thread_id);
-        // Only stamp the ended summary onto genuine call-thread rows
-        // (those carrying a `call_thread_kind`). A reply-only entry has
-        // `call_thread_kind` NULL; stamping it would produce an ended
-        // summary without kind/media that the frontend silently drops.
+        // Only stamp the ended summary onto genuine call-thread rows. The
+        // wire emits `<call>` only when BOTH kind and media are present,
+        // so an ended summary on a row missing either would serialize as
+        // `<call-ended>` WITHOUT `<call>` and be silently dropped by the
+        // frontend. Guard on both fields to match the wire condition. A
+        // reply-only entry has both `None` and is skipped.
         match self.entries.get_mut(&key) {
-            Some(entry) if entry.call_thread_kind.is_some() => {
+            Some(entry)
+                if entry.call_thread_kind.is_some() && entry.call_thread_media.is_some() =>
+            {
                 entry.call_ended_at = Some(ended);
                 entry.call_duration = Some(duration);
                 true

--- a/server/crates/waddle-xmpp/src/inbox/mod.rs
+++ b/server/crates/waddle-xmpp/src/inbox/mod.rs
@@ -333,13 +333,17 @@ impl InboxView {
         duration: CallThreadDuration,
     ) -> bool {
         let key = InboxKey::thread(room.clone(), thread_id);
+        // Only stamp the ended summary onto genuine call-thread rows
+        // (those carrying a `call_thread_kind`). A reply-only entry has
+        // `call_thread_kind` NULL; stamping it would produce an ended
+        // summary without kind/media that the frontend silently drops.
         match self.entries.get_mut(&key) {
-            Some(entry) => {
+            Some(entry) if entry.call_thread_kind.is_some() => {
                 entry.call_ended_at = Some(ended);
                 entry.call_duration = Some(duration);
                 true
             }
-            None => false,
+            _ => false,
         }
     }
 

--- a/server/crates/waddle-xmpp/src/inbox/storage.rs
+++ b/server/crates/waddle-xmpp/src/inbox/storage.rs
@@ -8,10 +8,12 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use jid::{BareJid, Jid};
 use waddle_xmpp_core::xep0359::StanzaId;
 
 use super::{InboxEntry, InboxKey, InboxView};
+use crate::xep::CallThreadDuration;
 
 /// Durable key for one groupchat notification recovery item.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -160,6 +162,19 @@ pub trait InboxStorage: Send + Sync {
 
     /// Return the total unread count for the user (channel-level only).
     async fn total_unread(&self, user: &BareJid) -> Result<u64, InboxStorageError>;
+
+    /// Mark the call anchored to `(room, thread_id)` as ended across every
+    /// user's projection of that thread. The call-end summary
+    /// (`urn:waddle:call-thread:0` `<call-thread-ended/>`) is room-wide, so
+    /// the ended timestamp and duration must land on all subscribers' rows,
+    /// not just one user's.
+    async fn mark_call_thread_ended(
+        &self,
+        room: &BareJid,
+        thread_id: &str,
+        ended: DateTime<Utc>,
+        duration: &CallThreadDuration,
+    ) -> Result<(), InboxStorageError>;
 }
 
 /// In-memory implementation used for tests and as the storage fake for
@@ -377,6 +392,23 @@ impl InboxStorage for InMemoryInboxStorage {
             .lock()
             .map_err(|e| InboxStorageError::Other(e.to_string()))?;
         Ok(guard.get(user).map(|v| v.total_unread()).unwrap_or(0))
+    }
+
+    async fn mark_call_thread_ended(
+        &self,
+        room: &BareJid,
+        thread_id: &str,
+        ended: DateTime<Utc>,
+        duration: &CallThreadDuration,
+    ) -> Result<(), InboxStorageError> {
+        let mut guard = self
+            .per_user
+            .lock()
+            .map_err(|e| InboxStorageError::Other(e.to_string()))?;
+        for view in guard.values_mut() {
+            view.mark_call_thread_ended(room, thread_id, ended, duration.clone());
+        }
+        Ok(())
     }
 }
 

--- a/server/crates/waddle-xmpp/src/inbox/tests.rs
+++ b/server/crates/waddle-xmpp/src/inbox/tests.rs
@@ -212,3 +212,42 @@ fn test_inbox_key_equality() {
     assert!(k3.is_thread());
     assert!(!k1.is_thread());
 }
+
+#[test]
+fn inbox_entry_carries_call_thread_anchor_and_ended_metadata() {
+    use crate::xep::{CallThreadDuration, CallThreadKind, CallThreadMedia};
+    let entry = InboxEntry::new(
+        jid("general@conference.example.com"),
+        ConversationKind::MucRoom,
+        "stanza-1",
+        1_700_000_000,
+    )
+    .with_thread("call-thread-uuid")
+    .with_call_thread(
+        CallThreadKind::Muc,
+        CallThreadMedia {
+            audio: true,
+            video: true,
+        },
+    )
+    .with_call_ended(
+        chrono::DateTime::parse_from_rfc3339("2026-06-07T14:35:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc),
+        CallThreadDuration::parse("PT5M").unwrap(),
+    );
+
+    assert_eq!(entry.call_thread_kind, Some(CallThreadKind::Muc));
+    assert_eq!(
+        entry.call_thread_media,
+        Some(CallThreadMedia {
+            audio: true,
+            video: true
+        })
+    );
+    assert_eq!(
+        entry.call_duration,
+        Some(CallThreadDuration::parse("PT5M").unwrap())
+    );
+    assert!(entry.call_ended_at.is_some());
+}

--- a/server/crates/waddle-xmpp/src/protocol/event.rs
+++ b/server/crates/waddle-xmpp/src/protocol/event.rs
@@ -16,6 +16,7 @@
 //! machine.
 
 use super::frame::InboundFrame;
+use crate::xep::{CallThreadKind, CallThreadMedia};
 use crate::Stanza;
 use jid::{BareJid, FullJid};
 use waddle_xmpp_core::xep0359::{OriginId, StanzaId};
@@ -198,6 +199,13 @@ pub struct GroupchatThreadProjection {
     pub title: Option<String>,
     /// Thread author nickname (the resource component of `from`).
     pub author_nick: Option<String>,
+    /// Call-thread anchor kind — `Some(...)` only when this projection
+    /// is a thread root carrying a `urn:waddle:call-thread:0` anchor
+    /// marker (a DM or MUC call session). Replies never carry it.
+    pub call_thread_kind: Option<CallThreadKind>,
+    /// Call-thread media flags from the anchor marker — present iff
+    /// `call_thread_kind` is present.
+    pub call_thread_media: Option<CallThreadMedia>,
 }
 
 /// Read-only context supplied to every stanza handler

--- a/server/crates/waddle-xmpp/src/protocol/room/inbox.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/inbox.rs
@@ -22,6 +22,7 @@ use super::context::{RoomContext, SyntheticSenderAuthority};
 use super::traits::{RoomHandler, RoomHandlerOutcome};
 use crate::inbox::runtime::{preview_text, should_project_message};
 use crate::types::Role;
+use crate::xep::parse_call_thread_anchor_child;
 use crate::xep::xep_waddle_forums::{extract_forum_action, ForumAction};
 use jid::BareJid;
 use std::collections::HashSet;
@@ -163,10 +164,17 @@ fn thread_projection(message: &Message) -> Option<GroupchatThreadProjection> {
             .as_ref()
             .and_then(|jid| jid.resource().map(|r| r.to_string()))
     });
+    // Capture the `urn:waddle:call-thread:0` anchor metadata when this
+    // message carries the marker. The parser already requires the anchor
+    // namespace, so a plain reply (no marker) yields `None` for both
+    // fields and never overwrites the root's persisted call metadata.
+    let call_anchor = parse_call_thread_anchor_child(message);
     Some(GroupchatThreadProjection {
         thread_id: info.id.as_str().to_owned(),
         title,
         author_nick,
+        call_thread_kind: call_anchor.as_ref().map(|anchor| anchor.kind),
+        call_thread_media: call_anchor.as_ref().map(|anchor| anchor.media),
     })
 }
 
@@ -721,6 +729,54 @@ mod tests {
         assert_eq!(thread.thread_id, "root-stanza");
         assert_eq!(thread.title.as_deref(), Some("Root prompt"));
         assert_eq!(thread.author_nick.as_deref(), Some("alice"));
+    }
+
+    #[test]
+    fn thread_projection_captures_call_thread_anchor_metadata() {
+        use crate::xep::{
+            build_call_thread_anchor, CallThreadAnchor, CallThreadKind, CallThreadMedia,
+        };
+        use chrono::{DateTime, Utc};
+        use xmpp_parsers::jingle::SessionId;
+
+        let room = bare("team@conf.example.com");
+        let alice = full("team@conf.example.com/alice");
+
+        // Thread-root groupchat message carrying the call-thread anchor.
+        let mut root = groupchat(&room, &alice, "starting a call");
+        root.id = Some(xmpp_parsers::message::Id("call-root".to_string()));
+        set_thread_id(&mut root, "call-root");
+        let anchor = CallThreadAnchor {
+            kind: CallThreadKind::Muc,
+            sid: SessionId("session-abc".to_owned()),
+            media: CallThreadMedia {
+                audio: true,
+                video: true,
+            },
+            initiator: "alice@example.com".parse().expect("initiator"),
+            started: "2026-06-07T14:30:00Z"
+                .parse::<DateTime<Utc>>()
+                .expect("started"),
+        };
+        root.payloads.push(build_call_thread_anchor(&anchor));
+
+        let projection = thread_projection(&root).expect("anchor is a thread root → Some");
+        assert_eq!(projection.call_thread_kind, Some(CallThreadKind::Muc));
+        assert_eq!(
+            projection.call_thread_media,
+            Some(CallThreadMedia {
+                audio: true,
+                video: true,
+            })
+        );
+
+        // A plain thread reply (no anchor marker) carries no call-thread metadata.
+        let mut reply = groupchat(&room, &alice, "follow-up");
+        reply.id = Some(xmpp_parsers::message::Id("reply-stanza".to_string()));
+        set_thread_id(&mut reply, "call-root");
+        let reply_projection = thread_projection(&reply).expect("reply still resolves a thread id");
+        assert_eq!(reply_projection.call_thread_kind, None);
+        assert_eq!(reply_projection.call_thread_media, None);
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/xep/xep0430.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0430.rs
@@ -382,6 +382,12 @@ pub fn parse_inbox_entry_with_metadata(
         thread_title,
         reply_count,
         author,
+        // Call-thread anchor/ended metadata is not yet projected onto the
+        // wire; later tasks populate these from the stanza.
+        call_thread_kind: None,
+        call_thread_media: None,
+        call_ended_at: None,
+        call_duration: None,
     })
 }
 

--- a/server/crates/waddle-xmpp/src/xep/xep0430.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0430.rs
@@ -382,8 +382,11 @@ pub fn parse_inbox_entry_with_metadata(
         thread_title,
         reply_count,
         author,
-        // Call-thread anchor/ended metadata is not yet projected onto the
-        // wire; later tasks populate these from the stanza.
+        // XEP-0430 inbox-entry parsing does not carry the call-thread
+        // fields, so they default to `None` here. The call-thread
+        // metadata is projected separately, from the MUC
+        // `urn:waddle:call-thread:0` anchor marker, via the
+        // `urn:waddle:threads:0` threads path.
         call_thread_kind: None,
         call_thread_media: None,
         call_ended_at: None,

--- a/server/crates/waddle-xmpp/src/xep/xep_waddle_call_thread.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep_waddle_call_thread.rs
@@ -19,6 +19,16 @@ pub enum CallThreadKind {
     Muc,
 }
 
+impl CallThreadKind {
+    /// Canonical wire/storage token for the kind: `"dm"` or `"muc"`.
+    pub fn as_token(&self) -> &'static str {
+        match self {
+            CallThreadKind::Dm => "dm",
+            CallThreadKind::Muc => "muc",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CallThreadMedia {
     pub audio: bool,
@@ -38,6 +48,20 @@ impl CallThreadMedia {
             audio: true,
             video: true,
         }
+    }
+
+    /// Canonical space-joined media tokens, `audio` before `video`:
+    /// `(true,true)=>"audio video"`, `(true,false)=>"audio"`,
+    /// `(false,true)=>"video"`, `(false,false)=>""`.
+    pub fn as_tokens(&self) -> String {
+        let mut tokens = Vec::with_capacity(2);
+        if self.audio {
+            tokens.push("audio");
+        }
+        if self.video {
+            tokens.push("video");
+        }
+        tokens.join(" ")
     }
 }
 
@@ -86,10 +110,7 @@ pub enum CallThreadParseError {
 }
 
 pub fn build_call_thread_anchor(anchor: &CallThreadAnchor) -> Element {
-    let kind = match anchor.kind {
-        CallThreadKind::Dm => "dm",
-        CallThreadKind::Muc => "muc",
-    };
+    let kind = anchor.kind.as_token();
     let media = media_attr(anchor.media);
 
     Element::builder("call-thread", NS_WADDLE_CALL_THREAD)
@@ -197,13 +218,14 @@ fn call_thread_ended_payload(payload: &Element) -> Option<&Element> {
 }
 
 fn media_attr(media: CallThreadMedia) -> &'static str {
-    match (media.audio, media.video) {
-        (true, true) => "audio video",
-        (true, false) => "audio",
-        (false, true) => "video",
-        (false, false) => {
-            panic!("call-thread marker requires audio or video media")
-        }
+    // Derive tokens via the canonical `as_tokens`, but preserve this
+    // builder's existing contract: a `&'static str` and a panic on the
+    // impossible empty-media state.
+    match media.as_tokens().as_str() {
+        "audio video" => "audio video",
+        "audio" => "audio",
+        "video" => "video",
+        _ => panic!("call-thread marker requires audio or video media"),
     }
 }
 
@@ -287,6 +309,48 @@ mod tests {
 
         let parsed = parse_call_thread_anchor(&element).expect("marker parses");
         assert_eq!(parsed, original);
+    }
+
+    #[test]
+    fn kind_as_token_maps_both_variants() {
+        assert_eq!(CallThreadKind::Dm.as_token(), "dm");
+        assert_eq!(CallThreadKind::Muc.as_token(), "muc");
+    }
+
+    #[test]
+    fn media_as_tokens_maps_all_combos() {
+        assert_eq!(
+            CallThreadMedia {
+                audio: true,
+                video: true,
+            }
+            .as_tokens(),
+            "audio video"
+        );
+        assert_eq!(
+            CallThreadMedia {
+                audio: true,
+                video: false,
+            }
+            .as_tokens(),
+            "audio"
+        );
+        assert_eq!(
+            CallThreadMedia {
+                audio: false,
+                video: true,
+            }
+            .as_tokens(),
+            "video"
+        );
+        assert_eq!(
+            CallThreadMedia {
+                audio: false,
+                video: false,
+            }
+            .as_tokens(),
+            ""
+        );
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/xep/xep_waddle_call_thread.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep_waddle_call_thread.rs
@@ -6,19 +6,20 @@
 use chrono::{DateTime, Utc};
 use jid::BareJid;
 use minidom::Element;
+use serde::{Deserialize, Serialize};
 use xmpp_parsers::jingle::SessionId;
 use xmpp_parsers::message::Message;
 
 pub const NS_WADDLE_CALL_THREAD: &str = "urn:waddle:call-thread:0";
 pub const NS_FASTEN: &str = "urn:xmpp:fasten:0";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CallThreadKind {
     Dm,
     Muc,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CallThreadMedia {
     pub audio: bool,
     pub video: bool,
@@ -49,7 +50,7 @@ pub struct CallThreadAnchor {
     pub started: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CallThreadDuration(String);
 
 impl CallThreadDuration {

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=5977aa9a09a1";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=5977aa9a09a1";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=5977aa9a09a1";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=49774c35adc0";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=49774c35adc0";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=49774c35adc0";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=5977aa9a09a1";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=49774c35adc0";


### PR DESCRIPTION
Implements #919 — "Call Chat 3/7: live state + rich anchor card + banner dedup (MUC)" — in full, including the previously-deferred global Threads-view row (AC #4).

## What this delivers

A single shared live-state composable drives every MUC call surface, and the rich `CallAnchorCard` now renders on **all three** surfaces named in the issue — the pinned banner, the **thread-list row**, and the thread-panel header — all reading one source of truth and invoking one shared Join action.

### Frontend (original scope of this PR)
- Shared `useCallAnchorCardState` / `readCallAnchorCardState` derive live/ended + participants/media/join-availability from the existing MUC detectors (`useRoomHasActiveCall`, `$mucCallParticipants`) — **no new wire data**. Includes the stale-live override (presence gone ⇒ not-live even without an ended record).
- `CallAnchorCard` renders the live state (pulse, media icon, participant count, Join/Rejoin/In-another-call, "N messages in call chat") and the ended state (muted "Call ended · <duration>", no Join), with accessibility labels.
- Wired into the channel timeline anchor (`MessageCard`) and the thread-panel header (`ThreadPanel`); the pinned `ConversationCallBanner` shares the same detector + `joinChannelCall` path.

### Closing AC #4: the global Threads-view row (server + client)
The global Threads view (`urn:waddle:threads:0`) is backed by the server inbox, which carried no call-thread metadata — so its rows could not identify call threads. This PR threads that metadata end-to-end, reusing markers already on the wire (no new XMPP wire data):

- **Server** — capture the anchor's typed `kind`+`media` at the existing groupchat thread-projection point onto the inbox row; add `thread_id` to the in-memory `ActiveCallThread` so the XEP-0422 ended fastening correlates back to the thread and persists `ended`+`duration` via one room-wide `UPDATE`; surface all four fields through `ThreadEntry` and the `urn:waddle:threads:0` wire (`<call>` / `<call-ended>` child elements in the custom namespace). New nullable inbox columns with an idempotent migration. Typed payloads throughout (`CallThreadKind`/`CallThreadMedia`/`CallThreadDuration`); XML via builders only.
- **Client/WASM/TS** — `waddle-xmpp-client` parses the new child elements; `waddle-xmpp-client-wasm` surfaces `callThread`/`callThreadEnded` on `WaddleThreadEntry`; a pure `wasmThreadEntryToAnchorMessage` adapter feeds the existing composable.
- **Frontend** — `ThreadsListRow` renders `CallAnchorCard` for MUC call threads (live state from the room detector, ended from the persisted fastening), routing Join through the one shared `joinChannelCallFromActivity` path.
- Also: the ended card title now shows the duration visibly across all surfaces; and the ended card icon uses the wire-authoritative anchor media (the live detector is cleared on call end, which previously mislabeled an ended video call as audio).

## Acceptance criteria (all met)
- [x] Shared live-state composable derives live/ended + participant count from existing MUC detectors; unit test drives the stores and asserts output.
- [x] Stale-live override verified: presence gone ⇒ not-live even with no ended record.
- [x] `CallAnchorCard` renders the live card (pulse, media icon, avatars, Join, "N messages") and the ended card (muted, no Join); SSR render test covers both + accessibility labels.
- [x] `ConversationCallBanner`, thread-list row, and thread-panel header reflect the same live state and share one Join action (no divergence).
- [x] `knip` clean (chat/).

## Approach / docs
Design: `docs/superpowers/specs/2026-06-08-thread-list-row-call-anchor-design.md`
Plan: `docs/superpowers/plans/2026-06-08-thread-list-row-call-anchor.md`

## Constraints honored
- No new XMPP wire data — reuses the existing `urn:waddle:call-thread:0` anchor marker and the XEP-0422 `<call-thread-ended>` fastening; only the internal `urn:waddle:threads:0` response shape grows (additive, optional children, custom namespace — no official-namespace change).
- Typed payloads end-to-end; XML built via `minidom` builders; clippy `-D warnings`; no `unwrap`/`#[allow]` in non-test code.

## Verification
- `chat`: `bun test` → 1905 pass / 0 fail; `bun run lint` (knip) clean; `astro check` 0 errors / 0 warnings (1 pre-existing unrelated hint).
- `server`: `cargo fmt --check` clean; `cargo clippy -p waddle-xmpp -p waddle-server -p waddle-xmpp-client -p waddle-xmpp-client-wasm -- -D warnings` clean; lib tests for all four crates pass; the existing `livekit_last_participant_left_fastens_ended_summary_to_call_thread_anchor` e2e and a new `empty_muji_presence_ends_the_active_call_thread` storage assertion pass.
- Four adversarial review passes (protocol/XEP conformance, Rust storage correctness, TS/Vue, end-to-end integration coherence): one finding (ended-card media icon) found and fixed; no remaining actionable issues; all nine data-flow seams verified consistent.

Closes #919.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Post-review hardening (second adversarial round)

A second adversarial review (concurrency/failure-modes, data-integrity/SQL, frontend, spec-completeness) found two real server issues, both fixed with tests:
- **SFU-gating consistency** — the call-thread anchor was *built/broadcast* on Muji presence alone while registration + ending were SFU-gated, so a no-SFU deployment could persist an anchor that never ends (and a false Join affordance). The anchor build is now SFU-gated too, making the whole lifecycle consistent with #918's "tracking disabled without SFU". Covered by new tests asserting `call_threads` is populated with an SFU and not without.
- **Ended-UPDATE scoped to call rows** — `mark_call_thread_ended` now includes `AND call_thread_kind IS NOT NULL` (and the in-memory store mirrors it) so a reply-only inbox row can never be stamped into a `<call-ended>`-without-`<call>` partial. Regression test added.
- Added `ThreadsView` join-routing test coverage.

Accepted (documented) limitations, unchanged: server-restart loses the in-memory `call_threads` map (pre-existing); a late-joiner whose inbox row didn't exist at call-end gets no persisted duration but degrades gracefully to a non-call/"Call ended" row via the stale-live override (no stale-live card). The `ConversationCallBanner` shares the same detector + Join terminal as the composable but derives liveness in parallel (disclosed; behavior matches).
