### PR TITLE
feat(chat): open DM threads from the global Threads view + backfill their replies

### DIFF
--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -70,6 +70,7 @@ const {
   ui,
   waddles,
   messaging,
+  dmMessaging,
   dmConversations,
   channelUnread,
   rosterContacts,
@@ -938,8 +939,8 @@ onUnmounted(() => {
               :mention-candidates="mentionCandidates"
               :slow-mode-cooldown="threadPanelIsDm ? 0 : messaging.slowModeCooldown.value"
               :is-sending="false"
-              :is-loading-older-replies="threadPanelIsDm ? false : messaging.loadingOlderThreadIds.value.has(activeThreadStack[activeThreadStack.length - 2] ?? '')"
-              :has-older-replies="threadPanelIsDm ? false : (messaging.threadHasOlder.value[activeThreadStack[activeThreadStack.length - 2] ?? ''] ?? false)"
+              :is-loading-older-replies="(threadPanelIsDm ? dmMessaging.loadingOlderThreadIds.value : messaging.loadingOlderThreadIds.value).has(activeThreadStack[activeThreadStack.length - 2] ?? '')"
+              :has-older-replies="(threadPanelIsDm ? dmMessaging.threadHasOlder.value : messaging.threadHasOlder.value)[activeThreadStack[activeThreadStack.length - 2] ?? ''] ?? false"
               :upload-progress="{ uploading: false, progress: 0, filename: '' }"
               :channel-name="threadPanelIsDm ? (activeDmPeer?.peerUsername ?? '') : (waddles.currentChannel.value?.name ?? '')"
               :hide-composer="true"
@@ -980,8 +981,8 @@ onUnmounted(() => {
               :mention-candidates="mentionCandidates"
               :slow-mode-cooldown="threadPanelIsDm ? 0 : messaging.slowModeCooldown.value"
               :is-sending="activeIsSending"
-              :is-loading-older-replies="threadPanelIsDm ? false : messaging.loadingOlderThreadIds.value.has(activeThreadStack[activeThreadStack.length - 1] ?? '')"
-              :has-older-replies="threadPanelIsDm ? false : (messaging.threadHasOlder.value[activeThreadStack[activeThreadStack.length - 1] ?? ''] ?? false)"
+              :is-loading-older-replies="(threadPanelIsDm ? dmMessaging.loadingOlderThreadIds.value : messaging.loadingOlderThreadIds.value).has(activeThreadStack[activeThreadStack.length - 1] ?? '')"
+              :has-older-replies="(threadPanelIsDm ? dmMessaging.threadHasOlder.value : messaging.threadHasOlder.value)[activeThreadStack[activeThreadStack.length - 1] ?? ''] ?? false"
               :upload-progress="activeUploadProgress"
               :channel-name="threadPanelIsDm ? (activeDmPeer?.peerUsername ?? '') : (waddles.currentChannel.value?.name ?? '')"
               :reaction-mode="reactionModeTarget === 'thread' ? reactionModeState : null"

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -131,6 +131,7 @@ const {
   selectChannel,
   selectChannelByRoomJid,
   onSelectThread,
+  onSelectThreadEntry,
   selectExtensionRoute,
   handleOpenDm,
   selectDm,
@@ -723,7 +724,7 @@ onUnmounted(() => {
       <ThreadsView
         v-else-if="ui.activePage.value === 'threads'"
         :channels="waddles.sortedChannels.value"
-        :on-select-thread="onSelectThread"
+        :on-select-thread-entry="onSelectThreadEntry"
         @open-nav="ui.showMobileNav.value = true"
       />
       <UnreadView

--- a/chat/src/components/chat/ThreadsView.vue
+++ b/chat/src/components/chat/ThreadsView.vue
@@ -4,12 +4,11 @@ import { Menu, MessagesSquare } from "lucide-vue-next";
 import { connectionStore } from "@/lib/connection-store";
 import type { ChannelSummary } from "@/lib/chat-types";
 import type { WasmThreadEntry } from "@/lib/xmpp/wasm-types";
-import { resolveChannelIdForRoomJid } from "@/lib/threads-channel-resolve";
 import ThreadsListPanel from "@/components/chat/ThreadsListPanel.vue";
 
 const props = defineProps<{
   channels: readonly ChannelSummary[];
-  onSelectThread: (channelId: string, threadId: string) => void | Promise<void>;
+  onSelectThreadEntry: (channelJid: string, threadId: string) => void | Promise<void>;
 }>();
 
 const xmppClient = computed(() => connectionStore.client);
@@ -18,16 +17,13 @@ const emit = defineEmits<{
   openNav: [];
 }>();
 
-// Clicking a row hands off to the controller's `onSelectThread`, which
-// (a) selects the channel that hosts the thread — switching the URL
-// from `/threads` to `/r/<channel>?thread=<rootId>` via the existing
-// watchers — and (b) opens the ThreadPanel reader. The user lands
-// directly inside the thread; a hard refresh of the resulting URL
-// restores the same view.
+// Clicking a row hands off the entry's bare JID to the controller's
+// `onSelectThreadEntry`, which (a) routes to the hosting surface — a
+// channel selection for MUC rooms, or a DM open for partner JIDs — and
+// (b) opens the ThreadPanel reader. The user lands directly inside the
+// thread; a hard refresh of the resulting URL restores the same view.
 async function openThread(entry: WasmThreadEntry) {
-  const channelId = resolveChannelIdForRoomJid(entry.channel, props.channels);
-  if (!channelId) return;
-  await props.onSelectThread(channelId, entry.thread_id);
+  await props.onSelectThreadEntry(entry.channel, entry.thread_id);
 }
 </script>
 

--- a/chat/src/dms/mam-paging.ts
+++ b/chat/src/dms/mam-paging.ts
@@ -17,10 +17,12 @@ import {
 import { getMdsDisplayedCandidates, mdsChatKey, setMdsDisplayed } from "@/lib/last-seen-store";
 import {
   advanceCursorWithBeforePage,
+  advanceThreadCursor,
   classifyMamError,
   cursorFromLatestPage,
   isMamCursorNotFound,
   stripQueuedSelfMessages,
+  threadCursorFromLatestPage,
 } from "@/lib/xmpp/mam";
 
 const PAGE_SIZE = 100;
@@ -71,10 +73,13 @@ export function useDmMamPaging(deps: UseDmMamPagingDeps) {
   const isLoadingMessages = ref(false);
   const isLoadingOlderMessages = ref(false);
   const hasOlderMessages = ref(true);
+  const loadingOlderThreadIds = ref<Set<string>>(new Set());
+  const threadHasOlder = ref<Record<string, boolean>>({});
 
   let messageRequestId = 0;
   let oldestArchiveId: string | null = null;
   let initialLatestPagePinned = false;
+  const oldestThreadArchiveIds = new Map<string, string>();
 
   function buildTimelineFromMamResults(
     mamResults: LiveDmMessage[],
@@ -279,6 +284,95 @@ export function useDmMamPaging(deps: UseDmMamPagingDeps) {
     return !!findMessageById(messages.value, messageId);
   }
 
+  // Backfill a DM thread via XEP-0313 MAM filtered by thread id against the
+  // account archive (`with=peer` + thread field). Mirrors the channel
+  // `backfillThread`: the thread root carries no `<thread>` (threads start on
+  // the first reply), so MAM-by-thread never returns it — the panel resolves
+  // the root from the loaded DM window separately.
+  async function backfillThread(threadId: string): Promise<void> {
+    const client = xmppClient.value;
+    const peerJid = activePeerJid.value;
+    if (!client || !peerJid || !threadId || !session.value) return;
+    if (!("queryPersonalMamThreadPage" in client) && !("queryPersonalMamByThread" in client)) return;
+    const requestId = messageRequestId;
+    const isCurrentRequest = () =>
+      requestId === messageRequestId &&
+      xmppClient.value === client &&
+      activePeerJid.value === peerJid;
+    let page: { messages: LiveDmMessage[]; firstArchiveId?: string; complete?: boolean } | null = null;
+    let results: LiveDmMessage[] = [];
+    try {
+      page = "queryPersonalMamThreadPage" in client
+        ? await client.queryPersonalMamThreadPage(peerJid, threadId, PAGE_SIZE, { type: "latest" })
+        : null;
+      results = page ? page.messages : await client.queryPersonalMamByThread(peerJid, threadId, PAGE_SIZE);
+    } catch (e) {
+      if (isCurrentRequest()) {
+        threadHasOlder.value = { ...threadHasOlder.value, [threadId]: false };
+        actionError.value = dmLoadErrorMessage(peerJid);
+        console.warn("Could not backfill DM thread", e);
+      }
+      return;
+    }
+    if (!isCurrentRequest()) return;
+    const cursor = threadCursorFromLatestPage({
+      page,
+      pageSize: PAGE_SIZE,
+      fallbackMessages: page ? undefined : results,
+    });
+    if (cursor.oldestId !== undefined) oldestThreadArchiveIds.set(threadId, cursor.oldestId);
+    threadHasOlder.value = { ...threadHasOlder.value, [threadId]: cursor.hasOlder };
+    const next = buildTimelineFromMamResults(results, messages.value);
+    if (
+      next.length === messages.value.length &&
+      next.every((message, index) => message === messages.value[index])
+    ) {
+      return;
+    }
+    messages.value = next;
+  }
+
+  async function loadOlderThreadMessages(threadId: string): Promise<void> {
+    const client = xmppClient.value;
+    const peerJid = activePeerJid.value;
+    const before = oldestThreadArchiveIds.get(threadId);
+    if (!client || !peerJid || !threadId || !before || loadingOlderThreadIds.value.has(threadId)) return;
+    if (!("queryPersonalMamThreadPage" in client)) return;
+    const requestId = messageRequestId;
+    const isCurrentRequest = () =>
+      requestId === messageRequestId &&
+      xmppClient.value === client &&
+      activePeerJid.value === peerJid;
+    loadingOlderThreadIds.value = new Set([...loadingOlderThreadIds.value, threadId]);
+    try {
+      const page = await client.queryPersonalMamThreadPage(peerJid, threadId, PAGE_SIZE, { type: "before", before });
+      if (!isCurrentRequest()) return;
+      const advanced = advanceThreadCursor({ prior: { oldestId: before }, page });
+      if (advanced.oldestId !== undefined) oldestThreadArchiveIds.set(threadId, advanced.oldestId);
+      threadHasOlder.value = { ...threadHasOlder.value, [threadId]: advanced.hasOlder };
+      messages.value = buildTimelineFromMamResults(page.messages, messages.value);
+    } catch (e) {
+      const classified = classifyMamError(e);
+      if (isMamCursorNotFound(classified)) {
+        // §4.3.4 — drop the stale thread cursor; the next backfill restarts
+        // from the latest page. Guarded so a stale completion after a peer
+        // switch can't corrupt the new conversation's thread state.
+        if (isCurrentRequest()) {
+          oldestThreadArchiveIds.delete(threadId);
+          threadHasOlder.value = { ...threadHasOlder.value, [threadId]: false };
+        }
+      } else if (isCurrentRequest()) {
+        actionError.value = dmLoadErrorMessage(peerJid);
+      }
+    } finally {
+      if (isCurrentRequest()) {
+        const next = new Set(loadingOlderThreadIds.value);
+        next.delete(threadId);
+        loadingOlderThreadIds.value = next;
+      }
+    }
+  }
+
   function reset() {
     messageRequestId++;
     initialLatestPagePinned = false;
@@ -286,6 +380,9 @@ export function useDmMamPaging(deps: UseDmMamPagingDeps) {
     hasOlderMessages.value = true;
     isLoadingOlderMessages.value = false;
     isLoadingMessages.value = false;
+    loadingOlderThreadIds.value = new Set();
+    threadHasOlder.value = {};
+    oldestThreadArchiveIds.clear();
   }
 
   function currentRequestId(): number {
@@ -300,9 +397,13 @@ export function useDmMamPaging(deps: UseDmMamPagingDeps) {
     isLoadingMessages,
     isLoadingOlderMessages,
     hasOlderMessages,
+    loadingOlderThreadIds,
+    threadHasOlder,
     loadMessages,
     loadOlderMessages,
     ensureMessageLoaded,
+    backfillThread,
+    loadOlderThreadMessages,
     reset,
     currentRequestId,
     markInitialLatestPagePinned,

--- a/chat/src/dms/mam-paging.ts
+++ b/chat/src/dms/mam-paging.ts
@@ -286,9 +286,11 @@ export function useDmMamPaging(deps: UseDmMamPagingDeps) {
 
   // Backfill a DM thread via XEP-0313 MAM filtered by thread id against the
   // account archive (`with=peer` + thread field). Mirrors the channel
-  // `backfillThread`: the thread root carries no `<thread>` (threads start on
-  // the first reply), so MAM-by-thread never returns it — the panel resolves
-  // the root from the loaded DM window separately.
+  // `backfillThread`. The server thread filter (`matches_thread_filter`)
+  // matches both the replies (which carry `<thread>`) and the root by message
+  // id, so this populates a thread whose messages fall outside the loaded DM
+  // window; the panel still resolves the root from the loaded window when it
+  // is present there.
   async function backfillThread(threadId: string): Promise<void> {
     const client = xmppClient.value;
     const peerJid = activePeerJid.value;

--- a/chat/src/dms/mam-paging.ts
+++ b/chat/src/dms/mam-paging.ts
@@ -295,19 +295,15 @@ export function useDmMamPaging(deps: UseDmMamPagingDeps) {
     const client = xmppClient.value;
     const peerJid = activePeerJid.value;
     if (!client || !peerJid || !threadId || !session.value) return;
-    if (!("queryPersonalMamThreadPage" in client) && !("queryPersonalMamByThread" in client)) return;
+    if (!("queryPersonalMamThreadPage" in client)) return;
     const requestId = messageRequestId;
     const isCurrentRequest = () =>
       requestId === messageRequestId &&
       xmppClient.value === client &&
       activePeerJid.value === peerJid;
-    let page: { messages: LiveDmMessage[]; firstArchiveId?: string; complete?: boolean } | null = null;
-    let results: LiveDmMessage[] = [];
+    let page: Awaited<ReturnType<typeof client.queryPersonalMamThreadPage>>;
     try {
-      page = "queryPersonalMamThreadPage" in client
-        ? await client.queryPersonalMamThreadPage(peerJid, threadId, PAGE_SIZE, { type: "latest" })
-        : null;
-      results = page ? page.messages : await client.queryPersonalMamByThread(peerJid, threadId, PAGE_SIZE);
+      page = await client.queryPersonalMamThreadPage(peerJid, threadId, PAGE_SIZE, { type: "latest" });
     } catch (e) {
       if (isCurrentRequest()) {
         threadHasOlder.value = { ...threadHasOlder.value, [threadId]: false };
@@ -317,14 +313,13 @@ export function useDmMamPaging(deps: UseDmMamPagingDeps) {
       return;
     }
     if (!isCurrentRequest()) return;
-    const cursor = threadCursorFromLatestPage({
-      page,
-      pageSize: PAGE_SIZE,
-      fallbackMessages: page ? undefined : results,
-    });
+    // `page` is always present here, so `hasOlder` is only set when the page
+    // carries a `firstArchiveId` cursor — the UI never advertises paging that
+    // `loadOlderThreadMessages` cannot perform.
+    const cursor = threadCursorFromLatestPage({ page, pageSize: PAGE_SIZE });
     if (cursor.oldestId !== undefined) oldestThreadArchiveIds.set(threadId, cursor.oldestId);
     threadHasOlder.value = { ...threadHasOlder.value, [threadId]: cursor.hasOlder };
-    const next = buildTimelineFromMamResults(results, messages.value);
+    const next = buildTimelineFromMamResults(page.messages, messages.value);
     if (
       next.length === messages.value.length &&
       next.every((message, index) => message === messages.value[index])

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -233,8 +233,12 @@ export function useDirectMessages(
     isLoadingMessages,
     isLoadingOlderMessages,
     hasOlderMessages,
+    loadingOlderThreadIds,
+    threadHasOlder,
     loadOlderMessages,
     ensureMessageLoaded,
+    backfillThread,
+    loadOlderThreadMessages,
   } = paging;
 
   // DM-load entry point. The MAM-paging composable owns paging state; the
@@ -376,6 +380,10 @@ export function useDirectMessages(
     isLoadingMessages,
     isLoadingOlderMessages,
     hasOlderMessages,
+    loadingOlderThreadIds,
+    threadHasOlder,
+    backfillThread,
+    loadOlderThreadMessages,
     isSending,
     typingUsers,
     timelineEl,

--- a/chat/src/lib/threads-view-target.ts
+++ b/chat/src/lib/threads-view-target.ts
@@ -1,0 +1,54 @@
+// Classify a global Threads-view row (`urn:waddle:threads:0`) by the bare
+// JID it carries so the shell can route a click to the right surface.
+//
+// The threads list mixes channel (MUC room) threads with DM
+// (partner-keyed) threads. Channel rows carry a managed room JID on the
+// MUC service domain; DM rows carry the partner's bare JID on a user
+// domain. The only durable discriminator is the domain — see
+// `isTrustedManagedRoomJid` — with an explicit channel-JID match taking
+// precedence so a known channel on a foreign conference domain still
+// resolves as a channel.
+
+import type { ChannelSummary } from "@/lib/chat-types";
+import { isTrustedManagedRoomJid } from "@/lib/channel-room";
+import { resolveChannelIdForRoomJid } from "@/lib/threads-channel-resolve";
+import { barePeerJid } from "@/lib/xmpp/jid";
+
+export type ThreadEntryTarget =
+  | { kind: "channel"; channelId: string }
+  | { kind: "dm"; peerJid: string };
+
+interface ResolveThreadEntryTargetOptions {
+  channels: readonly Pick<ChannelSummary, "id" | "jid">[];
+  managedMucDomain: string;
+}
+
+/**
+ * Returns the routing target for a Threads-view entry JID, or `null` when
+ * the JID is unusable (empty / no local-part).
+ *
+ * Resolution order:
+ *  1. Explicit channel match by exact room JID.
+ *  2. Managed MUC room (domain matches `managedMucDomain`) → channel,
+ *     resolving the channel-id slug via the existing room-JID resolver.
+ *  3. Otherwise a DM partner JID → open the direct-message conversation.
+ */
+export function resolveThreadEntryTarget(
+  channelJid: string,
+  { channels, managedMucDomain }: ResolveThreadEntryTargetOptions,
+): ThreadEntryTarget | null {
+  const bare = barePeerJid(channelJid);
+  if (!bare || !bare.includes("@") || bare.startsWith("@")) return null;
+
+  const explicit = channels.find(
+    (channel) => channel.jid && barePeerJid(channel.jid) === bare,
+  );
+  if (explicit) return { kind: "channel", channelId: explicit.id };
+
+  if (isTrustedManagedRoomJid(bare, managedMucDomain)) {
+    const channelId = resolveChannelIdForRoomJid(bare, channels);
+    return channelId ? { kind: "channel", channelId } : null;
+  }
+
+  return { kind: "dm", peerJid: bare };
+}

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -2847,6 +2847,15 @@ export class BrowserXmppClient {
     this.recordDmMamWatermarks(result.messages);
     return result;
   }
+  async queryPersonalMamByThread(peerJid: string, threadId: string, max = 100): Promise<LiveDmMessage[]> { const page = await this.queryPersonalMamThreadPage(peerJid, threadId, max, { type: "latest" }); return page.messages; }
+  async queryPersonalMamThreadPage(peerJid: string, threadId: string, max = 100, pageParam: MamThreadPageParam = { type: "latest" }): Promise<MamHistoryPage<LiveDmMessage>> {
+    if (!threadId) return { messages: [], complete: true };
+    const xmpp = await this.requireConnectedXmpp(); const page = await xmpp.fetch_dm_history_by_thread?.(barePeerJid(peerJid), threadId, max, pageParam.type === "before" ? pageParam.before : null) as WasmMamPage;
+    if (!page) return { messages: [], complete: true };
+    const result = this.dmMamPageToMessages(page, { applyCallEvents: false });
+    this.recordDmMamWatermarks(result.messages);
+    return result;
+  }
   async hydrateRecentDmCallActivity(
     peerJid: string,
     options: DmCallActivityHydrationOptions = {},

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -2847,7 +2847,6 @@ export class BrowserXmppClient {
     this.recordDmMamWatermarks(result.messages);
     return result;
   }
-  async queryPersonalMamByThread(peerJid: string, threadId: string, max = 100): Promise<LiveDmMessage[]> { const page = await this.queryPersonalMamThreadPage(peerJid, threadId, max, { type: "latest" }); return page.messages; }
   async queryPersonalMamThreadPage(peerJid: string, threadId: string, max = 100, pageParam: MamThreadPageParam = { type: "latest" }): Promise<MamHistoryPage<LiveDmMessage>> {
     if (!threadId) return { messages: [], complete: true };
     const xmpp = await this.requireConnectedXmpp(); const page = await xmpp.fetch_dm_history_by_thread?.(barePeerJid(peerJid), threadId, max, pageParam.type === "before" ? pageParam.before : null) as WasmMamPage;

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -1655,7 +1655,9 @@ export function useChatAppController(giphyApiKey: string) {
       activeThreadTargetMessageId.value = null;
       activeThreadStack.value = match.search.thread;
       activeRightPanel.value = match.search.thread.length > 0 ? "thread" : null;
-      for (const threadId of match.search.thread) {
+      // Dedup: a nested stack can legitimately repeat a thread id (e.g.
+      // `[A,B,A]`), but each thread only needs one backfill.
+      for (const threadId of new Set(match.search.thread)) {
         void dmMessaging.backfillThread(threadId);
       }
       return;

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -31,6 +31,7 @@ import {
   roomJidForChannelId as resolveRoomJidForChannelId,
 } from "@/lib/channel-room";
 import { normalizeMucServiceDomain } from "@/lib/calls/muc-call-indicators";
+import { resolveThreadEntryTarget } from "@/lib/threads-view-target";
 import { connectionStore } from "@/lib/connection-store";
 import { resetPinnedRooms } from "@/stores/pinned-messages";
 import { hydratePinnedBodiesOnPanelOpen } from "@/services/pinned-message-bodies";
@@ -985,6 +986,25 @@ export function useChatAppController(giphyApiKey: string) {
     if (roomJid) {
       channelUnread.markThreadRead(roomJid, threadId);
     }
+    openThread(threadId);
+  }
+
+  // Global Threads view (`urn:waddle:threads:0`) rows carry a bare JID,
+  // which may be a channel (MUC) room or a DM partner. Route each to its
+  // own surface — channel selection vs DM open — then open the thread
+  // panel. Without this, DM rows fell through `selectChannel(<localpart>)`
+  // and tried to open a nonexistent channel (#917).
+  async function onSelectThreadEntry(channelJid: string, threadId: string) {
+    const target = resolveThreadEntryTarget(channelJid, {
+      channels: waddles.channels.value,
+      managedMucDomain: managedMucDomain.value,
+    });
+    if (!target) return;
+    if (target.kind === "channel") {
+      await onSelectThread(target.channelId, threadId);
+      return;
+    }
+    await handleOpenDm(target.peerJid);
     openThread(threadId);
   }
 
@@ -2180,6 +2200,7 @@ export function useChatAppController(giphyApiKey: string) {
       selectChannel,
       selectChannelByRoomJid,
       onSelectThread,
+      onSelectThreadEntry,
       selectExtensionRoute,
       handleOpenDm,
       selectDm,

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -963,11 +963,24 @@ export function useChatAppController(giphyApiKey: string) {
       activeThreadStack.value.length > 0 &&
       activeThreadStack.value[activeThreadStack.value.length - 1] === threadId
     ) {
-      if (targetMessageId && ui.sidebarMode.value === "channels") void messaging.backfillThread(threadId);
+      if (targetMessageId) backfillActiveThread(threadId);
       return;
     }
     activeThreadStack.value = [threadId];
-    if (ui.sidebarMode.value === "channels") void messaging.backfillThread(threadId);
+    backfillActiveThread(threadId);
+  }
+
+  // Backfill a thread's replies from the archive for the active surface. DMs
+  // query the personal archive (`with=peer` + thread); channels query the
+  // room archive. Without this a thread opened from the global Threads view
+  // or a deep link shows only the replies that happen to be in the loaded
+  // conversation window.
+  function backfillActiveThread(threadId: string) {
+    if (ui.sidebarMode.value === "dms") {
+      void dmMessaging.backfillThread(threadId);
+    } else if (ui.sidebarMode.value === "channels") {
+      void messaging.backfillThread(threadId);
+    }
   }
 
   function roomJidForChannelId(channelId: string): string | null {
@@ -1019,7 +1032,7 @@ export function useChatAppController(giphyApiKey: string) {
       return;
     }
     activeThreadStack.value = [...activeThreadStack.value, threadId];
-    if (ui.sidebarMode.value === "channels") void messaging.backfillThread(threadId);
+    backfillActiveThread(threadId);
   }
 
   function popThreadTo(index: number) {
@@ -1158,7 +1171,10 @@ export function useChatAppController(giphyApiKey: string) {
   }
 
   function loadOlderThreadMessages(threadId: string) {
-    if (ui.sidebarMode.value === "dms") return;
+    if (ui.sidebarMode.value === "dms") {
+      void dmMessaging.loadOlderThreadMessages(threadId);
+      return;
+    }
     void messaging.loadOlderThreadMessages(threadId);
   }
 
@@ -1639,6 +1655,9 @@ export function useChatAppController(giphyApiKey: string) {
       activeThreadTargetMessageId.value = null;
       activeThreadStack.value = match.search.thread;
       activeRightPanel.value = match.search.thread.length > 0 ? "thread" : null;
+      for (const threadId of match.search.thread) {
+        void dmMessaging.backfillThread(threadId);
+      }
       return;
     }
 

--- a/chat/tests/dm-thread-backfill.test.ts
+++ b/chat/tests/dm-thread-backfill.test.ts
@@ -1,0 +1,133 @@
+// DM thread backfill: opening a DM thread (from the global Threads view, the
+// DM sidebar thread list, or a deep link) must fetch the thread's replies
+// from the personal archive via XEP-0313 MAM filtered by `with=peer` + the
+// Waddle thread field — so threads whose replies fall outside the latest DM
+// window still populate, with parity to channel thread backfill.
+
+import { describe, expect, mock, test } from "bun:test";
+import { ref } from "vue";
+import { useDmMamPaging } from "../src/dms/mam-paging";
+import type { BrowserXmppClient, LiveDmMessage } from "../src/lib/xmpp-client";
+import type { WaddleSession } from "../src/lib/server-auth";
+import type { TimelineMessage } from "../src/lib/chat-ui";
+
+const session: WaddleSession = {
+  username: "alice",
+  jid: "alice@example.com/desktop",
+  session_id: "tok",
+  xmpp_websocket_url: "wss://example.com/ws",
+};
+
+const PEER = "bob@example.com";
+
+function reply(id: string, threadId: string, body: string): LiveDmMessage {
+  return {
+    id,
+    type: "message",
+    peerJid: PEER,
+    fromJid: "bob@example.com/phone",
+    nick: "bob",
+    body,
+    timestamp: Date.now(),
+    isSelf: false,
+    threadId,
+  } as unknown as LiveDmMessage;
+}
+
+function harness(xmppClient: BrowserXmppClient) {
+  const messages = ref<TimelineMessage[]>([]);
+  const actionError = ref("");
+  const paging = useDmMamPaging({
+    session: ref(session),
+    xmppClient: ref(xmppClient),
+    activePeerJid: ref(PEER),
+    messages,
+    firstUnseenId: ref<string | null>(null),
+    loadErrorPeerJid: ref<string | null>(null),
+    loadErrorMessage: ref(""),
+    timelineEl: ref(null),
+    scrollDirection: ref("bottom"),
+    pinnedEdgeScroller: { disconnect: () => {} },
+    actionError,
+    clearActionError: () => {},
+    pendingEchoClientIds: new Set<string>(),
+    appendQueuedMessages: (timeline) => timeline,
+    scrollToPinnedEdgeAndPin: async () => true,
+    isFeedVisible: (m) => !m.threadId || m.id === m.threadId,
+    persistLastSeen: () => {},
+    dmLoadErrorMessage: () => "load error",
+  });
+  return { paging, messages, actionError };
+}
+
+describe("useDmMamPaging — DM thread backfill", () => {
+  test("backfillThread fetches replies for a peer+thread and merges them", async () => {
+    const queryPersonalMamThreadPage = mock(
+      async (_peer: string, _thread: string, _max: number, _param: { type: string }) => ({
+        messages: [reply("r1", "root-1", "first reply")],
+        firstArchiveId: "arch-r1",
+        complete: false,
+      }),
+    );
+    const xmppClient = { queryPersonalMamThreadPage } as unknown as BrowserXmppClient;
+    const { paging, messages } = harness(xmppClient);
+
+    await paging.backfillThread("root-1");
+
+    expect(queryPersonalMamThreadPage).toHaveBeenCalledTimes(1);
+    expect(queryPersonalMamThreadPage.mock.calls[0]?.slice(0, 4)).toEqual([
+      PEER,
+      "root-1",
+      100,
+      { type: "latest" },
+    ]);
+    expect(messages.value.some((m) => m.id === "r1")).toBe(true);
+    // Page was not complete and carried a first archive id → older replies.
+    expect(paging.threadHasOlder.value["root-1"]).toBe(true);
+  });
+
+  test("backfillThread marks no-older when the latest page is complete", async () => {
+    const xmppClient = {
+      queryPersonalMamThreadPage: mock(async () => ({
+        messages: [reply("r1", "root-1", "only reply")],
+        firstArchiveId: "arch-r1",
+        complete: true,
+      })),
+    } as unknown as BrowserXmppClient;
+    const { paging } = harness(xmppClient);
+
+    await paging.backfillThread("root-1");
+
+    expect(paging.threadHasOlder.value["root-1"]).toBe(false);
+  });
+
+  test("loadOlderThreadMessages pages older replies with a before-cursor", async () => {
+    const queryPersonalMamThreadPage = mock(
+      async (_peer: string, _thread: string, _max: number, param: { type: string; before?: string }) => {
+        if (param.type === "before") {
+          expect(param.before).toBe("arch-r1");
+          return { messages: [reply("r0", "root-1", "older reply")], firstArchiveId: "arch-r0", complete: true };
+        }
+        return { messages: [reply("r1", "root-1", "first reply")], firstArchiveId: "arch-r1", complete: false };
+      },
+    );
+    const xmppClient = { queryPersonalMamThreadPage } as unknown as BrowserXmppClient;
+    const { paging, messages } = harness(xmppClient);
+
+    await paging.backfillThread("root-1");
+    await paging.loadOlderThreadMessages("root-1");
+
+    expect(messages.value.some((m) => m.id === "r0")).toBe(true);
+    expect(messages.value.some((m) => m.id === "r1")).toBe(true);
+    expect(paging.threadHasOlder.value["root-1"]).toBe(false);
+    expect(paging.loadingOlderThreadIds.value.has("root-1")).toBe(false);
+  });
+
+  test("backfillThread no-ops when the client lacks the thread query", async () => {
+    const xmppClient = {} as unknown as BrowserXmppClient;
+    const { paging, messages } = harness(xmppClient);
+    await paging.backfillThread("root-1");
+    expect(messages.value).toHaveLength(0);
+    expect(paging.threadHasOlder.value["root-1"]).toBeUndefined();
+  });
+});

--- a/chat/tests/threads-view-target.test.ts
+++ b/chat/tests/threads-view-target.test.ts
@@ -1,0 +1,88 @@
+// The global Threads view (`urn:waddle:threads:0`) lists both channel
+// (MUC room) threads and DM (partner-keyed) threads. Each row carries a
+// bare JID in `entry.channel`. `resolveThreadEntryTarget` classifies that
+// JID so the shell can route a click to the right surface: a channel
+// selection for MUC rooms, or a DM open for partner JIDs. Misclassifying
+// a DM as a channel was the #917 bug — it routed DM threads into
+// `selectChannel(<partner-localpart>)`, a nonexistent channel.
+
+import { describe, expect, test } from "bun:test";
+import { resolveThreadEntryTarget } from "../src/lib/threads-view-target";
+
+const MUC_DOMAIN = "muc.waddle.example";
+
+describe("resolveThreadEntryTarget", () => {
+  test("classifies a listed channel by its exact room JID", () => {
+    const channels = [{ id: "general", jid: "general@muc.waddle.example" }];
+    expect(
+      resolveThreadEntryTarget("general@muc.waddle.example", {
+        channels,
+        managedMucDomain: MUC_DOMAIN,
+      }),
+    ).toEqual({ kind: "channel", channelId: "general" });
+  });
+
+  test("classifies a managed MUC room not yet in the channel list as a channel", () => {
+    expect(
+      resolveThreadEntryTarget("orphan@muc.waddle.example", {
+        channels: [],
+        managedMucDomain: MUC_DOMAIN,
+      }),
+    ).toEqual({ kind: "channel", channelId: "orphan" });
+  });
+
+  test("classifies a partner JID on a non-MUC domain as a DM", () => {
+    expect(
+      resolveThreadEntryTarget("bob@waddle.example", {
+        channels: [{ id: "general", jid: "general@muc.waddle.example" }],
+        managedMucDomain: MUC_DOMAIN,
+      }),
+    ).toEqual({ kind: "dm", peerJid: "bob@waddle.example" });
+  });
+
+  test("bare-normalizes a resource-qualified DM JID", () => {
+    expect(
+      resolveThreadEntryTarget("bob@waddle.example/phone", {
+        channels: [],
+        managedMucDomain: MUC_DOMAIN,
+      }),
+    ).toEqual({ kind: "dm", peerJid: "bob@waddle.example" });
+  });
+
+  test("routes a DM peer to a DM even when its node matches a channel id", () => {
+    // A DM with `general@waddle.example` shares the node `general` with the
+    // `general` channel — but it lives on the user domain, not the MUC
+    // domain, so it must open as a DM, never as the channel.
+    const channels = [{ id: "general", jid: "general@muc.waddle.example" }];
+    expect(
+      resolveThreadEntryTarget("general@waddle.example", {
+        channels,
+        managedMucDomain: MUC_DOMAIN,
+      }),
+    ).toEqual({ kind: "dm", peerJid: "general@waddle.example" });
+  });
+
+  test("prefers an explicit channel match over the MUC-domain heuristic", () => {
+    // A foreign-domain room that is nonetheless a known channel by exact
+    // JID must still classify as that channel.
+    const channels = [{ id: "pretty-name", jid: "room@conference.other.example" }];
+    expect(
+      resolveThreadEntryTarget("room@conference.other.example", {
+        channels,
+        managedMucDomain: MUC_DOMAIN,
+      }),
+    ).toEqual({ kind: "channel", channelId: "pretty-name" });
+  });
+
+  test("returns null for an unusable JID", () => {
+    expect(
+      resolveThreadEntryTarget("", { channels: [], managedMucDomain: MUC_DOMAIN }),
+    ).toBeNull();
+    expect(
+      resolveThreadEntryTarget("@muc.waddle.example", {
+        channels: [],
+        managedMucDomain: MUC_DOMAIN,
+      }),
+    ).toBeNull();
+  });
+});

--- a/chat/tests/threads-view.test.ts
+++ b/chat/tests/threads-view.test.ts
@@ -1,18 +1,23 @@
 // Tests for the click-thru behaviour of the global Threads view.
 //
 // `ThreadsView.vue` is a thin wrapper: it fetches threads (delegated
-// to `ThreadsListPanel`) and, on click, hands the entry off to the
-// controller's `onSelectThread(channelId, threadId)`. The controller
-// then selects the channel and opens the ThreadPanel reader, and the
-// existing URL watchers push `/r/<channel>?thread=<rootId>`.
+// to `ThreadsListPanel`) and, on click, hands the entry's bare JID off
+// to the controller's `onSelectThreadEntry(channelJid, threadId)`. The
+// controller routes the JID to its hosting surface — a channel
+// selection for MUC rooms, or a DM open for partner JIDs — and opens
+// the ThreadPanel reader.
 //
 // The component itself is too small to be worth mounting under
 // `@vue/test-utils`; we exercise the two pieces of behaviour that
-// matter: the JID→channel-id resolver and the controller-call shape.
+// matter: the room-JID resolver and the channel/DM routing shape that
+// the controller's `onSelectThreadEntry` implements.
 
 import { describe, expect, mock, test } from "bun:test";
 import type { WasmThreadEntry } from "../src/lib/xmpp/wasm-types";
 import { resolveChannelIdForRoomJid } from "../src/lib/threads-channel-resolve";
+import { resolveThreadEntryTarget } from "../src/lib/threads-view-target";
+
+const MUC_DOMAIN = "muc.waddle.example";
 
 function entry(overrides: Partial<WasmThreadEntry> = {}): WasmThreadEntry {
   return {
@@ -27,19 +32,32 @@ function entry(overrides: Partial<WasmThreadEntry> = {}): WasmThreadEntry {
   };
 }
 
+interface ThreadEntryHandlers {
+  onSelectThread: (channelId: string, threadId: string) => void | Promise<void>;
+  onOpenDmThread: (peerJid: string, threadId: string) => void | Promise<void>;
+}
+
 /**
- * Mirrors the click handler inside `ThreadsView.vue`: resolve the
- * entry's room JID to a channel-id slug, then call `onSelectThread`.
- * If the JID is unusable, the handler is a no-op.
+ * Mirrors the controller's `onSelectThreadEntry`, which is what
+ * `ThreadsView.vue` now delegates to: classify the entry's bare JID and
+ * route a channel selection vs a DM open. If the JID is unusable, the
+ * handler is a no-op.
  */
 async function handleOpenThread(
   e: WasmThreadEntry,
   channels: { id: string; jid?: string }[],
-  onSelectThread: (channelId: string, threadId: string) => void | Promise<void>,
+  handlers: ThreadEntryHandlers,
 ): Promise<void> {
-  const channelId = resolveChannelIdForRoomJid(e.channel, channels);
-  if (!channelId) return;
-  await onSelectThread(channelId, e.thread_id);
+  const target = resolveThreadEntryTarget(e.channel, {
+    channels,
+    managedMucDomain: MUC_DOMAIN,
+  });
+  if (!target) return;
+  if (target.kind === "channel") {
+    await handlers.onSelectThread(target.channelId, e.thread_id);
+    return;
+  }
+  await handlers.onOpenDmThread(target.peerJid, e.thread_id);
 }
 
 describe("resolveChannelIdForRoomJid", () => {
@@ -88,45 +106,71 @@ describe("resolveChannelIdForRoomJid", () => {
 });
 
 describe("ThreadsView click handler", () => {
-  test("calls onSelectThread with the resolved channel-id and the thread id", async () => {
-    const onSelectThread = mock(async (_channelId: string, _threadId: string) => {});
+  function handlers() {
+    return {
+      onSelectThread: mock(async (_channelId: string, _threadId: string) => {}),
+      onOpenDmThread: mock(async (_peerJid: string, _threadId: string) => {}),
+    };
+  }
+
+  test("routes a channel thread to onSelectThread with the resolved channel-id", async () => {
+    const h = handlers();
     const channels = [{ id: "general", jid: "general@muc.waddle.example" }];
     await handleOpenThread(
       entry({ channel: "general@muc.waddle.example", thread_id: "root-abc" }),
       channels,
-      onSelectThread,
+      h,
     );
-    expect(onSelectThread).toHaveBeenCalledTimes(1);
-    expect(onSelectThread.mock.calls[0]).toEqual(["general", "root-abc"]);
+    expect(h.onSelectThread.mock.calls).toEqual([["general", "root-abc"]]);
+    expect(h.onOpenDmThread).not.toHaveBeenCalled();
   });
 
   test("falls back to the JID local-part when the channel is unknown", async () => {
     // Threads view can outlive the structure load: a thread can be
     // listed before its channel summary has been wired into
-    // `waddles.channels`. The handler must still route correctly.
-    const onSelectThread = mock(async (_channelId: string, _threadId: string) => {});
+    // `waddles.channels`. A managed-room JID must still route to the
+    // channel surface via its local-part.
+    const h = handlers();
     await handleOpenThread(
       entry({ channel: "history@muc.waddle.example", thread_id: "t-9" }),
       [],
-      onSelectThread,
+      h,
     );
-    expect(onSelectThread).toHaveBeenCalledTimes(1);
-    expect(onSelectThread.mock.calls[0]).toEqual(["history", "t-9"]);
+    expect(h.onSelectThread.mock.calls).toEqual([["history", "t-9"]]);
+    expect(h.onOpenDmThread).not.toHaveBeenCalled();
+  });
+
+  test("routes a DM thread to the DM open, not a channel selection (#917)", async () => {
+    // The regression this PR fixes: a partner-keyed DM thread must open
+    // the direct-message conversation, never `selectChannel(<localpart>)`.
+    const h = handlers();
+    const channels = [{ id: "general", jid: "general@muc.waddle.example" }];
+    await handleOpenThread(
+      entry({ channel: "bob@waddle.example", thread_id: "t-dm" }),
+      channels,
+      h,
+    );
+    expect(h.onOpenDmThread.mock.calls).toEqual([["bob@waddle.example", "t-dm"]]);
+    expect(h.onSelectThread).not.toHaveBeenCalled();
   });
 
   test("is a no-op for entries with an unusable channel JID", async () => {
-    const onSelectThread = mock(async (_channelId: string, _threadId: string) => {});
-    await handleOpenThread(entry({ channel: "" }), [], onSelectThread);
-    expect(onSelectThread).not.toHaveBeenCalled();
+    const h = handlers();
+    await handleOpenThread(entry({ channel: "" }), [], h);
+    expect(h.onSelectThread).not.toHaveBeenCalled();
+    expect(h.onOpenDmThread).not.toHaveBeenCalled();
   });
 
-  test("awaits onSelectThread so async controller work completes before returning", async () => {
+  test("awaits the routed handler so async controller work completes before returning", async () => {
     let resolved = false;
-    const onSelectThread = mock(async () => {
-      await new Promise<void>((r) => setTimeout(r, 1));
-      resolved = true;
-    });
-    await handleOpenThread(entry(), [], onSelectThread);
+    const h = {
+      onSelectThread: mock(async () => {
+        await new Promise<void>((r) => setTimeout(r, 1));
+        resolved = true;
+      }),
+      onOpenDmThread: mock(async () => {}),
+    };
+    await handleOpenThread(entry(), [], h);
     expect(resolved).toBe(true);
   });
 });

--- a/server/crates/waddle-xmpp-client-wasm/src/client_history.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_history.rs
@@ -25,6 +25,39 @@ impl WaddleClient {
         })
     }
 
+    /// Fetch a DM thread's archived replies from the account archive,
+    /// filtered by `with=peer` and the Waddle MAM thread field. Mirrors
+    /// `fetch_room_history_by_thread`, but targets the personal archive
+    /// (`to=account` + `with=peer`) instead of a room. `before_id` pages
+    /// older replies via RSM (XEP-0059).
+    pub fn fetch_dm_history_by_thread(
+        &self,
+        peer_jid: String,
+        thread_id: String,
+        max: u32,
+        before_id: Option<String>,
+    ) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let query_id = uuid::Uuid::new_v4().to_string();
+            let iq_id = uuid::Uuid::new_v4().to_string();
+            let account_jid = {
+                let stored = inner.borrow().config.clone();
+                bare_jid(&stored.jid)
+            };
+            let mut builder = MamIqBuilder::new(&iq_id, &query_id, max)
+                .to_jid(&account_jid)
+                .with_jid(&peer_jid)
+                .thread_id(&thread_id);
+            if let Some(before) = before_id.as_deref() {
+                builder = builder.before(before);
+            }
+            let iq = builder.build();
+            let page = send_mam_query_command(inner, iq, query_id).await?;
+            to_js_value(&mam_page_to_js(page))
+        })
+    }
+
     pub fn search_room_history(&self, room_jid: String, query: String, max: u32) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
@@ -413,6 +446,72 @@ mod client_history_tests {
         assert_eq!(iq.attr("to"), Some("alice@example.com"));
         let with_value = mam_form_value(&iq, "with");
         assert_eq!(with_value.as_deref(), Some("bob@example.com"));
+    }
+
+    fn build_dm_history_by_thread_iq(
+        iq_id: &str,
+        query_id: &str,
+        max: u32,
+        account_jid: &str,
+        peer_jid: &str,
+        thread_id: &str,
+        before_id: Option<&str>,
+    ) -> Element {
+        let mut builder = MamIqBuilder::new(iq_id, query_id, max)
+            .to_jid(account_jid)
+            .with_jid(peer_jid)
+            .thread_id(thread_id);
+        if let Some(before) = before_id {
+            builder = builder.before(before);
+        }
+        builder.build()
+    }
+
+    #[test]
+    fn dm_history_by_thread_targets_account_filters_peer_and_thread() {
+        let iq = build_dm_history_by_thread_iq(
+            "iq-1",
+            "query-1",
+            10,
+            "alice@example.com",
+            "bob@example.com",
+            "thread-42",
+            None,
+        );
+
+        assert_eq!(iq.attr("to"), Some("alice@example.com"));
+        assert_eq!(
+            mam_form_value(&iq, "with").as_deref(),
+            Some("bob@example.com")
+        );
+        assert_eq!(
+            mam_form_value(&iq, "{urn:waddle:mam-thread:0}thread").as_deref(),
+            Some("thread-42")
+        );
+    }
+
+    #[test]
+    fn dm_history_by_thread_pages_older_with_rsm_before() {
+        let iq = build_dm_history_by_thread_iq(
+            "iq-1",
+            "query-1",
+            10,
+            "alice@example.com",
+            "bob@example.com",
+            "thread-42",
+            Some("cursor-7"),
+        );
+
+        let before = iq
+            .get_child("query", TEST_MAM_NS)
+            .and_then(|query| query.get_child("set", TEST_RSM_NS))
+            .and_then(|set| set.get_child("before", TEST_RSM_NS))
+            .map(|element| element.text());
+        assert_eq!(before.as_deref(), Some("cursor-7"));
+        assert_eq!(
+            mam_form_value(&iq, "{urn:waddle:mam-thread:0}thread").as_deref(),
+            Some("thread-42")
+        );
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client-wasm/src/client_history.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_history.rs
@@ -13,13 +13,16 @@ impl WaddleClient {
         future_to_promise(async move {
             let query_id = uuid::Uuid::new_v4().to_string();
             let iq_id = uuid::Uuid::new_v4().to_string();
-            let mut builder = MamIqBuilder::new(&iq_id, &query_id, max)
+            // An empty `<before/>` requests the most-recent page (XEP-0059
+            // §2.5 / XEP-0313 §3.4): the server treats any present `<before>`
+            // — including empty — as backward pagination. Omitting it would
+            // page forward and return the *oldest* page instead, so default
+            // the latest fetch to an empty cursor like the non-thread bindings.
+            let iq = MamIqBuilder::new(&iq_id, &query_id, max)
                 .to_jid(&room_jid)
-                .thread_id(&thread_id);
-            if let Some(before) = before_id.as_deref() {
-                builder = builder.before(before);
-            }
-            let iq = builder.build();
+                .thread_id(&thread_id)
+                .before(before_id.as_deref().unwrap_or(""))
+                .build();
             let page = send_mam_query_command(inner, iq, query_id).await?;
             to_js_value(&mam_page_to_js(page))
         })
@@ -28,8 +31,9 @@ impl WaddleClient {
     /// Fetch a DM thread's archived replies from the account archive,
     /// filtered by `with=peer` and the Waddle MAM thread field. Mirrors
     /// `fetch_room_history_by_thread`, but targets the personal archive
-    /// (`to=account` + `with=peer`) instead of a room. `before_id` pages
-    /// older replies via RSM (XEP-0059).
+    /// (`to=account` + `with=peer`) instead of a room. A `None` / empty
+    /// `before_id` requests the most-recent page; a cursor pages older
+    /// replies via RSM (XEP-0059).
     pub fn fetch_dm_history_by_thread(
         &self,
         peer_jid: String,
@@ -45,14 +49,15 @@ impl WaddleClient {
                 let stored = inner.borrow().config.clone();
                 bare_jid(&stored.jid)
             };
-            let mut builder = MamIqBuilder::new(&iq_id, &query_id, max)
+            // Empty `<before/>` = most-recent page (see
+            // `fetch_room_history_by_thread`); omitting it would return the
+            // oldest page and strand the newest replies of a long thread.
+            let iq = MamIqBuilder::new(&iq_id, &query_id, max)
                 .to_jid(&account_jid)
                 .with_jid(&peer_jid)
-                .thread_id(&thread_id);
-            if let Some(before) = before_id.as_deref() {
-                builder = builder.before(before);
-            }
-            let iq = builder.build();
+                .thread_id(&thread_id)
+                .before(before_id.as_deref().unwrap_or(""))
+                .build();
             let page = send_mam_query_command(inner, iq, query_id).await?;
             to_js_value(&mam_page_to_js(page))
         })
@@ -457,14 +462,21 @@ mod client_history_tests {
         thread_id: &str,
         before_id: Option<&str>,
     ) -> Element {
-        let mut builder = MamIqBuilder::new(iq_id, query_id, max)
+        // Mirrors `fetch_dm_history_by_thread`: always emit `<before>` (empty
+        // for the latest page), so the server pages backward (newest-first).
+        MamIqBuilder::new(iq_id, query_id, max)
             .to_jid(account_jid)
             .with_jid(peer_jid)
-            .thread_id(thread_id);
-        if let Some(before) = before_id {
-            builder = builder.before(before);
-        }
-        builder.build()
+            .thread_id(thread_id)
+            .before(before_id.unwrap_or(""))
+            .build()
+    }
+
+    fn rsm_before(iq: &Element) -> Option<String> {
+        iq.get_child("query", TEST_MAM_NS)
+            .and_then(|query| query.get_child("set", TEST_RSM_NS))
+            .and_then(|set| set.get_child("before", TEST_RSM_NS))
+            .map(|element| element.text())
     }
 
     #[test]
@@ -491,6 +503,23 @@ mod client_history_tests {
     }
 
     #[test]
+    fn dm_history_by_thread_latest_requests_newest_page_via_empty_before() {
+        // No cursor → an empty `<before/>` must be present so the server pages
+        // backward and returns the newest replies (not the oldest page).
+        let iq = build_dm_history_by_thread_iq(
+            "iq-1",
+            "query-1",
+            10,
+            "alice@example.com",
+            "bob@example.com",
+            "thread-42",
+            None,
+        );
+
+        assert_eq!(rsm_before(&iq).as_deref(), Some(""));
+    }
+
+    #[test]
     fn dm_history_by_thread_pages_older_with_rsm_before() {
         let iq = build_dm_history_by_thread_iq(
             "iq-1",
@@ -502,12 +531,7 @@ mod client_history_tests {
             Some("cursor-7"),
         );
 
-        let before = iq
-            .get_child("query", TEST_MAM_NS)
-            .and_then(|query| query.get_child("set", TEST_RSM_NS))
-            .and_then(|set| set.get_child("before", TEST_RSM_NS))
-            .map(|element| element.text());
-        assert_eq!(before.as_deref(), Some("cursor-7"));
+        assert_eq!(rsm_before(&iq).as_deref(), Some("cursor-7"));
         assert_eq!(
             mam_form_value(&iq, "{urn:waddle:mam-thread:0}thread").as_deref(),
             Some("thread-42")

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -90,6 +90,14 @@ export class WaddleClient {
      */
     fetch_dm_bookmarks(): Promise<any>;
     fetch_dm_history(peer_jid: string, max: number, before_id?: string | null): Promise<any>;
+    /**
+     * Fetch a DM thread's archived replies from the account archive,
+     * filtered by `with=peer` and the Waddle MAM thread field. Mirrors
+     * `fetch_room_history_by_thread`, but targets the personal archive
+     * (`to=account` + `with=peer`) instead of a room. `before_id` pages
+     * older replies via RSM (XEP-0059).
+     */
+    fetch_dm_history_by_thread(peer_jid: string, thread_id: string, max: number, before_id?: string | null): Promise<any>;
     fetch_dm_history_page(peer_jid: string, max: number, page_param: any): Promise<any>;
     fetch_extension_route_items(route: any, room_jid: string): Promise<any>;
     /**

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -94,8 +94,9 @@ export class WaddleClient {
      * Fetch a DM thread's archived replies from the account archive,
      * filtered by `with=peer` and the Waddle MAM thread field. Mirrors
      * `fetch_room_history_by_thread`, but targets the personal archive
-     * (`to=account` + `with=peer`) instead of a room. `before_id` pages
-     * older replies via RSM (XEP-0059).
+     * (`to=account` + `with=peer`) instead of a room. A `None` / empty
+     * `before_id` requests the most-recent page; a cursor pages older
+     * replies via RSM (XEP-0059).
      */
     fetch_dm_history_by_thread(peer_jid: string, thread_id: string, max: number, before_id?: string | null): Promise<any>;
     fetch_dm_history_page(peer_jid: string, max: number, page_param: any): Promise<any>;

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=66db352f05e3";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=66db352f05e3";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=66db352f05e3";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=bbbf13efe418";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=bbbf13efe418";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=bbbf13efe418";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=66db352f05e3";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=bbbf13efe418";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=5977aa9a09a1";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=5977aa9a09a1";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=5977aa9a09a1";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=66db352f05e3";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=66db352f05e3";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=66db352f05e3";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=5977aa9a09a1";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=66db352f05e3";


### PR DESCRIPTION
Part of **Call Chat / general DM threading** (#917). Two related gaps in DM
threading, fixed together.

## Problem

1. **DM threads couldn't be opened from the global Threads view.** The view
   (`urn:waddle:threads:0`) lists channel *and* DM threads, but
   `ThreadsView.vue` resolved every row's bare JID to a channel and called
   `onSelectThread → selectChannel`. A DM row's partner JID
   (`bob@waddle.example`) has no channel match, so it fell back to the
   local-part (`"bob"`), switched out of DMs mode, and tried to open a
   nonexistent channel — the DM thread never opened.
2. **DM thread panels weren't backfilled.** Even via the DM sidebar thread
   list, a DM thread populated only from the conversation's latest-window MAM
   page, so a thread whose replies fell outside that window opened empty —
   DMs had no thread-scoped backfill or older-replies paging, unlike channels.

## Fix

### 1. Route DM threads to the DM surface
- New pure helper `chat/src/lib/threads-view-target.ts` —
  `resolveThreadEntryTarget(channelJid, { channels, managedMucDomain })`
  classifies a row JID as `{ kind: "channel", channelId }` or
  `{ kind: "dm", peerJid }` (explicit channel-JID match → MUC-domain
  heuristic → DM peer).
- New controller `onSelectThreadEntry` routes channel rows through the
  existing `onSelectThread`, DM rows through `handleOpenDm` + `openThread`.
- `ThreadsView.vue` delegates the raw JID to the controller; channel routing
  is byte-for-byte unchanged.

### 2. Backfill DM thread replies from the personal archive
- **WASM**: `fetch_dm_history_by_thread` mirrors `fetch_room_history_by_thread`
  but targets the account archive (`to=account` + `with=peer` + the
  `{urn:waddle:mam-thread:0}thread` field). The server already applies the
  thread filter to the account archive (composed with `with` in the MAM SQL
  builder, `mam/storage/sqlx_store/query.rs`), so **no server change** is
  needed. The thread filter matches both replies and the root (by message id).
- **client**: `queryPersonalMamByThread` / `queryPersonalMamThreadPage`.
- **DM MAM paging**: `backfillThread`, `loadOlderThreadMessages`,
  `threadHasOlder`, `loadingOlderThreadIds` — mirroring the channel paging.
- **controller**: `openThread`/`pushThread` backfill the active thread for DMs
  too (shared `backfillActiveThread`); `loadOlderThreadMessages` routes to the
  DM pager; the DM route restore backfills deep-linked threads.
- **shell**: DM thread panels read has-older / loading-older from the DM pager
  instead of being hardwired off.

No new wire shape — pure reuse of XEP-0201 / `urn:xmpp:mam:2` machinery on the
DM surface.

## Tests
- `threads-view-target.test.ts` — JID classification incl. the node-collision
  DM-vs-channel case and explicit-match precedence.
- `threads-view.test.ts` — dispatch now mirrors `onSelectThreadEntry`, with a
  regression guard that a DM row opens the DM (never `onSelectThread`).
- `dm-thread-backfill.test.ts` — backfill merge, no-older, before-cursor
  older-paging, no-capability no-op.
- Rust `client_history` tests — DM-by-thread IQ shape (account + peer + thread
  filter) and RSM before-paging.

## Verification
- `bun test` (chat): **1903 pass**, 0 fail.
- `bun run lint` (knip): clean.
- `astro check`: 0 errors (after `wrangler types`; the `cloudflare:workers`
  diagnostic is pre-existing and unrelated). `astro build`: succeeds.
- `cargo test -p waddle-xmpp-client-wasm`: pass; `cargo clippy … -D warnings`:
  clean.
- Two adversarial review passes (correctness + wiring): no blockers; confirmed
  staleness guards, ternary precedence, route-restore ordering, and DM thread
  *root* visibility are all at parity with the channel path.

## Scope / relation to #917
This closes the "DM threads appear in the global Threads view / inbox" AC and
brings DM thread backfill to parity with channels. The **HITL design-review
gate** on DM thread affordances remains a separate human sign-off and is out of
scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review fixes (post-open)

- **Newest-page thread backfill (chatgpt-codex):** the `*_by_thread` MAM
  bindings now emit an empty `<before/>` for the "latest" fetch, so the server
  pages backward and returns the *newest* replies. Previously they omitted
  `<before>`, paging forward to the oldest page and stranding the newest
  replies of a long (>100-reply) thread. Applied to **both** the DM and the
  room (channel) thread bindings for consistency with the non-thread history
  bindings — this also fixes the same latent issue for channel thread backfill.
- **Dead-code cleanup (greptile):** removed the unreachable
  `queryPersonalMamByThread` shim and the `backfillThread` fallback branch;
  the guard now matches `loadOlderThreadMessages`.
- **No phantom "load older" (Copilot):** with the fallback gone, `backfillThread`
  always has a page, so `threadHasOlder` is set only when a real cursor exists.
