### PR TITLE
feat(chat): add in-call call-chat composer

### DIFF
--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -25,6 +25,9 @@ import { localScreenSharePresentation } from "@/lib/calls/call-self-share";
 import { normalizeMucCallRoomJid } from "@/lib/calls/muc-call-presence";
 import { useCallVolumeMixer } from "@/lib/calls/use-call-volume-mixer";
 import { barePeerJid } from "@/lib/xmpp/jid";
+import type { MentionCandidate } from "@/lib/mentions";
+import type { MarkupSpan, MessageReference } from "@/lib/chat-ui";
+import type { ComposerLinkPreviewLookup, ComposerLinkPreviewSendPayload } from "@/lib/link-preview-composer";
 import CallTileGrid from "./CallTileGrid.vue";
 import CallControls from "./CallControls.vue";
 import CallSettingsDialog from "./CallSettingsDialog.vue";
@@ -32,6 +35,7 @@ import CallMediaNotice from "./CallMediaNotice.vue";
 import CallSelfShareNotice from "./CallSelfShareNotice.vue";
 import CallVolumeMixerDialog from "./CallVolumeMixerDialog.vue";
 import CallAudioPlaybackPrompt from "./CallAudioPlaybackPrompt.vue";
+import MessageComposer from "@/components/chat/MessageComposer.vue";
 
 /**
  * "Expanded" call surface — fills the chat content pane while the
@@ -52,6 +56,27 @@ const props = defineProps<{
   roomJid?: string;
   dmPeerJid?: string;
   dmPeerName?: string;
+  callThreadId?: string | null;
+  isSending?: boolean;
+  disabled?: boolean;
+  giphyApiKey?: string;
+  mentionCandidates?: MentionCandidate[];
+  slowModeCooldown?: number;
+  uploadProgress?: { uploading: boolean; progress: number; filename: string };
+  linkPreviewLookup?: ComposerLinkPreviewLookup | null;
+  linkPreviewScope?: string | null;
+}>();
+
+const emit = defineEmits<{
+  sendCallChat: [
+    body: string,
+    markup: MarkupSpan[],
+    references: MessageReference[],
+    files: Array<File | Blob> | undefined,
+    replyTo: undefined,
+    threadOverride: { threadId: string },
+    linkPreview?: ComposerLinkPreviewSendPayload,
+  ];
 }>();
 
 const state = useStore($callState);
@@ -67,6 +92,7 @@ const { activeRoomJid, selfInCall } = useActiveMucCall();
 
 const settingsOpen = ref(false);
 const volumeOpen = ref(false);
+const callChatDraft = ref("");
 
 const normalizedRoomJid = computed(() =>
   normalizeMucCallRoomJid(props.roomJid ?? ""),
@@ -125,6 +151,17 @@ const subline = computed(() => {
   return state.value.media.video ? "Video call" : "Audio call";
 });
 
+const canShowCallChatComposer = computed(() =>
+  state.value.phase === "active" &&
+  state.value.kind === "muc" &&
+  !!props.callThreadId,
+);
+
+const callThreadOverride = computed(() => {
+  const threadId = props.callThreadId?.trim();
+  return threadId ? { threadId } : null;
+});
+
 const localIdentity = computed(() => engine.localIdentity);
 const selfSharePresentation = computed(() =>
   localScreenSharePresentation({
@@ -152,6 +189,19 @@ async function onHangup(): Promise<void> {
   // "active"); flip the mode back so the next call defaults to split
   // instead of inheriting "expanded".
   $callUiMode.set("split");
+}
+
+function onSendCallChat(
+  body: string,
+  markup: MarkupSpan[],
+  references: MessageReference[],
+  files?: Array<File | Blob>,
+  linkPreview?: ComposerLinkPreviewSendPayload,
+): void {
+  const override = callThreadOverride.value;
+  if (!override) return;
+  emit("sendCallChat", body, markup, references, files, undefined, override, linkPreview);
+  callChatDraft.value = "";
 }
 
 function onKeydown(event: KeyboardEvent): void {
@@ -223,6 +273,32 @@ onBeforeUnmount(() => {
         />
       </div>
     </main>
+    <section
+      v-if="canShowCallChatComposer"
+      class="call-expanded__chat"
+      aria-label="Call chat"
+    >
+      <div class="call-expanded__chat-label type-section-label text-muted-foreground">
+        Call chat
+      </div>
+      <MessageComposer
+        v-model:draft="callChatDraft"
+        channel-name="call chat"
+        composer-label="Call chat composer"
+        :is-forum-channel="false"
+        :is-sending="!!isSending"
+        :disabled="!!disabled || !callThreadOverride"
+        :giphy-api-key="giphyApiKey ?? ''"
+        :mention-candidates="mentionCandidates ?? []"
+        :slow-mode-cooldown="slowModeCooldown ?? 0"
+        :upload-progress="uploadProgress ?? { uploading: false, progress: 0, filename: '' }"
+        :in-muc="true"
+        :link-preview-lookup="linkPreviewLookup ?? null"
+        :link-preview-scope="linkPreviewScope ?? null"
+        :show-extensions="false"
+        @send="onSendCallChat"
+      />
+    </section>
     <footer class="call-expanded__footer">
       <CallControls
         :mic-enabled="micEnabled"
@@ -301,5 +377,14 @@ onBeforeUnmount(() => {
   justify-content: center;
   border-top: 1px solid var(--border);
   padding: 0.75rem 1rem;
+}
+
+.call-expanded__chat {
+  border-top: 1px solid var(--border);
+  background: color-mix(in oklab, var(--background) 88%, transparent);
+}
+
+.call-expanded__chat-label {
+  padding: 0.625rem 1rem 0;
 }
 </style>

--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -65,6 +65,15 @@ const props = defineProps<{
   uploadProgress?: { uploading: boolean; progress: number; filename: string };
   linkPreviewLookup?: ComposerLinkPreviewLookup | null;
   linkPreviewScope?: string | null;
+  sendCallChatMessage?: (
+    body: string,
+    markup: MarkupSpan[],
+    references: MessageReference[],
+    files: Array<File | Blob> | undefined,
+    replyTo: undefined,
+    threadOverride: { threadId: string },
+    linkPreview?: ComposerLinkPreviewSendPayload,
+  ) => Promise<void> | void;
 }>();
 
 const emit = defineEmits<{
@@ -151,16 +160,16 @@ const subline = computed(() => {
   return state.value.media.video ? "Video call" : "Audio call";
 });
 
-const canShowCallChatComposer = computed(() =>
-  state.value.phase === "active" &&
-  state.value.kind === "muc" &&
-  !!props.callThreadId,
-);
-
 const callThreadOverride = computed(() => {
   const threadId = props.callThreadId?.trim();
   return threadId ? { threadId } : null;
 });
+
+const canShowCallChatComposer = computed(() =>
+  state.value.phase === "active" &&
+  state.value.kind === "muc" &&
+  !!callThreadOverride.value,
+);
 
 const localIdentity = computed(() => engine.localIdentity);
 const selfSharePresentation = computed(() =>
@@ -191,16 +200,20 @@ async function onHangup(): Promise<void> {
   $callUiMode.set("split");
 }
 
-function onSendCallChat(
+async function onSendCallChat(
   body: string,
   markup: MarkupSpan[],
   references: MessageReference[],
   files?: Array<File | Blob>,
   linkPreview?: ComposerLinkPreviewSendPayload,
-): void {
+): Promise<void> {
   const override = callThreadOverride.value;
   if (!override) return;
-  emit("sendCallChat", body, markup, references, files, undefined, override, linkPreview);
+  if (props.sendCallChatMessage) {
+    await props.sendCallChatMessage(body, markup, references, files, undefined, override, linkPreview);
+  } else {
+    emit("sendCallChat", body, markup, references, files, undefined, override, linkPreview);
+  }
   callChatDraft.value = "";
 }
 

--- a/chat/src/components/chat/ChatEditor.vue
+++ b/chat/src/components/chat/ChatEditor.vue
@@ -102,6 +102,8 @@ defineExpose({
 <template>
   <div
     class="chat-editor type-chat-editor flex min-w-0 items-center transition-all duration-300 cursor-text"
+    role="textbox"
+    :aria-label="editorLabel"
     :class="[
       embedded ? 'min-h-9 flex-1 px-2 py-1' : compact ? 'min-h-9 py-1' : 'min-h-10 flex-1 py-1.5',
       embedded ? '' : 'rounded-lg bg-muted px-4 has-[:focus]:ring-2 has-[:focus]:ring-primary/20 has-[:focus]:shadow-[0_0_16px_var(--glow)]',

--- a/chat/src/components/chat/ChatEditor.vue
+++ b/chat/src/components/chat/ChatEditor.vue
@@ -11,6 +11,7 @@ const props = withDefaults(
     compact?: boolean;
     embedded?: boolean;
     initialContent?: JSONContent;
+    editorLabel?: string;
   }>(),
   {
     placeholder: "Type a message…",
@@ -56,6 +57,7 @@ const editor = useEditor({
       return false;
     },
     attributes: {
+      ...(props.editorLabel ? { "aria-label": props.editorLabel } : {}),
       class: "outline-none",
     },
   },

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -820,6 +820,7 @@ onUnmounted(() => {
               :ensure-message-loaded="ensureActiveMessageLoaded"
               :send-public-channel-message="sendPublicChannelMessage"
               @send="sendActiveMessage"
+              @send-call-chat="sendThreadMessage"
               @typing="notifyActiveComposing"
               @edit-message="editActiveMessage"
               @retract-message="retractActiveMessage"

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -141,6 +141,7 @@ const {
   sendActiveMessage,
   sendPublicChannelMessage,
   sendThreadMessage,
+  sendCallChatMessage,
   sendGif,
   openThread,
   pushThread,
@@ -819,6 +820,7 @@ onUnmounted(() => {
               :reaction-mode="reactionModeTarget === 'main' ? reactionModeState : null"
               :ensure-message-loaded="ensureActiveMessageLoaded"
               :send-public-channel-message="sendPublicChannelMessage"
+              :send-call-chat-message="sendCallChatMessage"
               @send="sendActiveMessage"
               @send-call-chat="sendThreadMessage"
               @typing="notifyActiveComposing"

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -10,6 +10,8 @@ import { findMessageElementById } from "@/lib/message-targeting";
 import { findMessageById } from "@/lib/message-ids";
 import { getReplyJumpNotice } from "@/lib/reply-ux";
 import { findThreadToAutoOpen } from "@/lib/thread-auto-open";
+import { resolveActiveMucCallThreadId } from "@/lib/calls/call-chat-composer";
+import { $callState } from "@/lib/calls/call-store";
 import {
   getPinnedScrollTop,
   getNewMessagesDividerPlacement,
@@ -119,6 +121,15 @@ const emit = defineEmits<{
     forumTitle?: string,
     linkPreview?: ComposerLinkPreviewSendPayload,
   ];
+  sendCallChat: [
+    body: string,
+    markup: MarkupSpan[],
+    references: MessageReference[],
+    files: Array<File | Blob> | undefined,
+    replyTo: { id: string; author: string; body?: string } | undefined,
+    threadOverride: { threadId: string; parentThreadId?: string },
+    linkPreview?: ComposerLinkPreviewSendPayload,
+  ];
   typing: [];
   editMessage: [messageId: string, newBody: string, markup?: MarkupSpan[], references?: MessageReference[], linkPreview?: ComposerLinkPreviewSendPayload];
   retractMessage: [messageId: string];
@@ -178,6 +189,7 @@ const newMessagesDividerPlacement = computed(() =>
   getNewMessagesDividerPlacement(scrollDirection.value),
 );
 const olderSentinelPosition = computed(() => scrollDirection.value === "social" ? "end" : "start");
+const callState = useStore($callState);
 
 const replyingTo = ref<{ id: string; author: string; body?: string; preview?: string } | null>(null);
 const autoOpenedThreadIds = new Set<string>();
@@ -418,6 +430,11 @@ async function dispatchSlashCommand(
 }
 const inMucContext = computed(() => !!props.roomJid);
 const callRoomJid = computed(() => props.roomJid ?? props.channel?.jid ?? null);
+const activeCallThreadId = computed(() => {
+  const state = callState.value;
+  if (state.phase !== "active" || state.kind !== "muc") return null;
+  return resolveActiveMucCallThreadId(props.messages, callRoomJid.value, state.sid);
+});
 
 watch(
   () => props.xmppClient,
@@ -1518,6 +1535,16 @@ function dayDividerLabel(createdAt: string): string {
       :room-jid="callRoomJid ?? undefined"
       :dm-peer-jid="dmPeer?.peerJid"
       :dm-peer-name="dmPeer?.peerUsername"
+      :call-thread-id="activeCallThreadId"
+      :is-sending="isSending"
+      :disabled="!canShowComposer"
+      :giphy-api-key="giphyApiKey"
+      :mention-candidates="mentionCandidates"
+      :slow-mode-cooldown="slowModeCooldown"
+      :upload-progress="uploadProgress"
+      :link-preview-lookup="linkPreviewLookup"
+      :link-preview-scope="linkPreviewScope"
+      @send-call-chat="(...args) => emit('sendCallChat', ...args)"
     />
   </div>
 </template>

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -109,6 +109,15 @@ const props = defineProps<{
   ensureMessageLoaded?: (messageId: string) => Promise<boolean>;
   invokeExtensionAction?: (action: ExtensionAnnotationAction) => Promise<ExtensionCommandResult>;
   sendPublicChannelMessage?: (body: string) => Promise<void>;
+  sendCallChatMessage?: (
+    body: string,
+    markup: MarkupSpan[],
+    references: MessageReference[],
+    files: Array<File | Blob> | undefined,
+    replyTo: { id: string; author: string; body?: string } | undefined,
+    threadOverride: { threadId: string; parentThreadId?: string },
+    linkPreview?: ComposerLinkPreviewSendPayload,
+  ) => Promise<void>;
 }>();
 
 const emit = defineEmits<{
@@ -1544,6 +1553,7 @@ function dayDividerLabel(createdAt: string): string {
       :upload-progress="uploadProgress"
       :link-preview-lookup="linkPreviewLookup"
       :link-preview-scope="linkPreviewScope"
+      :send-call-chat-message="sendCallChatMessage"
       @send-call-chat="(...args) => emit('sendCallChat', ...args)"
     />
   </div>

--- a/chat/src/components/chat/MessageComposer.vue
+++ b/chat/src/components/chat/MessageComposer.vue
@@ -59,6 +59,8 @@ const props = defineProps<{
   dispatchSlashCommand?: (invocation: SlashInvocation) => Promise<boolean>;
   linkPreviewLookup?: ComposerLinkPreviewLookup | null;
   linkPreviewScope?: string | null;
+  composerLabel?: string;
+  showExtensions?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -194,6 +196,7 @@ const emojiResults = computed(() => searchEmoji(emojiQuery.value));
 const showForumTitleInput = computed(() => props.isForumChannel && !props.replyingTo);
 
 const slashContext = computed(() => ({ inMuc: !!props.inMuc }));
+const showExtensions = computed(() => props.showExtensions !== false);
 const slashCandidates = computed(() =>
   filterSlashCandidates(slashPrefix.value, props.slashCommands ?? [], slashContext.value),
 );
@@ -923,6 +926,7 @@ watch(isPreparingSend, (preparing) => {
         embedded
         :placeholder="editorPlaceholder"
         :disabled="disabled || slowModeCooldown > 0 || isPreparingSend"
+        :editor-label="composerLabel ?? `${channelName} composer`"
         @send="onSend"
         @update="onEditorUpdate"
         @selection-update="checkAutocompleteFromEditor"
@@ -934,6 +938,7 @@ watch(isPreparingSend, (preparing) => {
            "fire an action"; the left edge is consistently "add to the
            message draft". -->
       <button
+        v-if="showExtensions"
         :ref="setExtensionButtonRef"
         type="button"
         class="chat-composer-input-action h-9 w-9 shrink-0 flex items-center justify-center transition-all duration-200 text-muted-foreground hover:bg-background/70 hover:text-primary active:scale-[0.94] disabled:opacity-40 disabled:active:scale-100 [@media(pointer:coarse)]:h-11 [@media(pointer:coarse)]:w-11"

--- a/chat/src/lib/calls/call-chat-composer.ts
+++ b/chat/src/lib/calls/call-chat-composer.ts
@@ -1,0 +1,29 @@
+import type { CallThreadAnchor } from "@/lib/chat-ui";
+import { normalizeMucCallRoomJid } from "./muc-call-presence";
+
+type CallThreadCandidate = {
+  threadId?: string;
+  roomJid?: string;
+  callThread?: CallThreadAnchor;
+};
+
+export function resolveActiveMucCallThreadId(
+  messages: readonly CallThreadCandidate[],
+  roomJid: string | null | undefined,
+  sid: string | null | undefined,
+): string | null {
+  const room = normalizeMucCallRoomJid(roomJid ?? "");
+  const activeSid = sid?.trim();
+  if (!room || !activeSid) return null;
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (!message?.threadId || !message.callThread) continue;
+    if (message.callThread.kind !== "muc") continue;
+    if (message.callThread.sid !== activeSid) continue;
+    if (message.roomJid && normalizeMucCallRoomJid(message.roomJid) !== room) continue;
+    return message.threadId;
+  }
+
+  return null;
+}

--- a/chat/src/lib/calls/call-chat-composer.ts
+++ b/chat/src/lib/calls/call-chat-composer.ts
@@ -3,10 +3,14 @@ import { normalizeMucCallRoomJid } from "./muc-call-presence";
 
 type CallThreadCandidate = {
   threadId?: string;
-  roomJid?: string;
   callThread?: CallThreadAnchor;
 };
 
+/**
+ * Resolve the active call's XEP-0201 thread from the current conversation's
+ * loaded timeline. The message list is intentionally conversation-scoped by
+ * `ContentArea`; timeline messages do not carry a room JID themselves.
+ */
 export function resolveActiveMucCallThreadId(
   messages: readonly CallThreadCandidate[],
   roomJid: string | null | undefined,
@@ -21,7 +25,6 @@ export function resolveActiveMucCallThreadId(
     if (!message?.threadId || !message.callThread) continue;
     if (message.callThread.kind !== "muc") continue;
     if (message.callThread.sid !== activeSid) continue;
-    if (message.roomJid && normalizeMucCallRoomJid(message.roomJid) !== room) continue;
     return message.threadId;
   }
 

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -944,6 +944,22 @@ export function useChatAppController(giphyApiKey: string) {
     await messaging.sendMessage(body, markup, references, files, replyTo, threadOverride, linkPreview);
   }
 
+  async function sendCallChatMessage(
+    body: string,
+    markup: MarkupSpan[],
+    references: MessageReference[],
+    files: Array<File | Blob> | undefined,
+    replyTo: { id: string; author: string; body?: string } | undefined,
+    threadOverride: { threadId: string; parentThreadId?: string },
+    linkPreview?: ComposerLinkPreviewSendPayload,
+  ) {
+    ui.clearActionError();
+    await sendThreadMessage(body, markup, references, files, replyTo, threadOverride, linkPreview);
+    if (ui.actionError.value) {
+      throw new Error(ui.actionError.value);
+    }
+  }
+
   function sendGif(
     url: string,
     threadOverride?: { threadId: string; parentThreadId?: string },
@@ -2241,6 +2257,7 @@ export function useChatAppController(giphyApiKey: string) {
       sendActiveMessage,
       sendPublicChannelMessage,
       sendThreadMessage,
+      sendCallChatMessage,
       sendGif,
       openThread,
       pushThread,

--- a/chat/tests/call-chat-composer.test.ts
+++ b/chat/tests/call-chat-composer.test.ts
@@ -1,20 +1,32 @@
-import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { afterEach, describe, expect, test } from "bun:test";
+import { $callState } from "../src/lib/calls/call-store";
+import { $callUiMode } from "../src/lib/calls/ui-mode";
+import { $mucCallParticipants } from "../src/lib/calls/muc-call-presence";
+import { connectionStore } from "../src/lib/connection-store";
 import { resolveActiveMucCallThreadId } from "../src/lib/calls/call-chat-composer";
 import type { TimelineMessage } from "../src/lib/chat-ui";
+import { renderVueComponent } from "./helpers/render-vue-sfc";
+
+const ROOM = "lobby@muc.waddle.test";
 
 describe("call-chat composer", () => {
-  test("resolves the active MUC call thread from the call anchor", () => {
+  afterEach(() => {
+    $callState.set({ phase: "idle" });
+    $callUiMode.set("split");
+    $mucCallParticipants.set({});
+    connectionStore.session = null;
+  });
+
+  test("resolves the active MUC call thread from the current conversation timeline", () => {
     const messages: TimelineMessage[] = [
       message({ id: "ordinary", body: "hello" }),
       message({
         id: "call-anchor",
         threadId: "call-thread-123",
-        roomJid: "lobby@muc.waddle.test",
         callThread: {
           kind: "muc",
           sid: "sid-active",
-          media: "audio",
+          media: ["audio"],
           initiator: "alice@waddle.test/web",
           started: "2026-06-09T12:00:00Z",
         },
@@ -22,66 +34,95 @@ describe("call-chat composer", () => {
       message({
         id: "other-call-anchor",
         threadId: "call-thread-older",
-        roomJid: "lobby@muc.waddle.test",
         callThread: {
           kind: "muc",
           sid: "sid-old",
-          media: "audio",
+          media: ["audio"],
           initiator: "alice@waddle.test/web",
           started: "2026-06-09T11:00:00Z",
         },
       }),
     ];
 
-    expect(resolveActiveMucCallThreadId(messages, "lobby@muc.waddle.test/alice", "sid-active")).toBe("call-thread-123");
+    expect(resolveActiveMucCallThreadId(messages, `${ROOM}/alice`, "sid-active")).toBe("call-thread-123");
   });
 
-  test("expanded channel calls render a labelled composer bound to the call thread", () => {
-    const source = readFileSync(
-      new URL("../src/components/calls/CallExpandedSurface.vue", import.meta.url),
-      "utf8",
-    );
+  test("does not resolve when the active room or sid is unusable", () => {
+    const messages = [
+      message({
+        id: "call-anchor",
+        threadId: "call-thread-123",
+        callThread: { kind: "muc", sid: "sid-active", media: ["audio"] },
+      }),
+    ];
 
-    expect(source).toContain("Call chat");
-    expect(source).toContain("MessageComposer");
-    expect(source).toContain("callThreadOverride");
-    expect(source).toContain(":show-extensions=\"false\"");
-    expect(source).toContain("emit(\"sendCallChat\"");
+    expect(resolveActiveMucCallThreadId(messages, "", "sid-active")).toBeNull();
+    expect(resolveActiveMucCallThreadId(messages, ROOM, " ")).toBeNull();
   });
 
-  test("composer labels the editable control and can hide unsupported extension actions", () => {
-    const composer = readFileSync(
-      new URL("../src/components/chat/MessageComposer.vue", import.meta.url),
-      "utf8",
-    );
-    const editor = readFileSync(
-      new URL("../src/components/chat/ChatEditor.vue", import.meta.url),
-      "utf8",
+  test("expanded channel calls render a labelled call-chat composer when a call thread is available", async () => {
+    seedExpandedMucCall();
+
+    const html = await renderVueComponent(
+      "../src/components/calls/CallExpandedSurface.vue",
+      {
+        roomJid: ROOM,
+        callThreadId: "call-thread-123",
+        isSending: false,
+        disabled: false,
+        giphyApiKey: "",
+        mentionCandidates: [],
+        slowModeCooldown: 0,
+        uploadProgress: { uploading: false, progress: 0, filename: "" },
+      },
+      import.meta.url,
     );
 
-    expect(composer).toContain("showExtensions");
-    expect(composer).toContain("v-if=\"showExtensions\"");
-    expect(composer).toContain(":editor-label=\"composerLabel ?? `${channelName} composer`\"");
-    expect(editor).toContain("editorLabel");
-    expect(editor).toContain("\"aria-label\": props.editorLabel");
+    expect(html).toContain("Call chat");
+    expect(html).toContain('aria-label="Call chat composer"');
+    expect(html).not.toContain('aria-label="Extensions"');
   });
 
-  test("call-chat sends use the thread handler while the main composer keeps the channel handler", () => {
-    const contentArea = readFileSync(
-      new URL("../src/components/chat/ContentArea.vue", import.meta.url),
-      "utf8",
-    );
-    const readyShell = readFileSync(
-      new URL("../src/components/chat/ChatReadyShell.vue", import.meta.url),
-      "utf8",
+  test("expanded channel calls hide the call-chat composer without a usable thread id", async () => {
+    seedExpandedMucCall();
+
+    const html = await renderVueComponent(
+      "../src/components/calls/CallExpandedSurface.vue",
+      {
+        roomJid: ROOM,
+        callThreadId: "   ",
+        uploadProgress: { uploading: false, progress: 0, filename: "" },
+      },
+      import.meta.url,
     );
 
-    expect(contentArea).toContain("@send=\"onSend\"");
-    expect(contentArea).toContain("@send-call-chat=\"(...args) => emit('sendCallChat', ...args)\"");
-    expect(readyShell).toContain("@send=\"sendActiveMessage\"");
-    expect(readyShell).toContain("@send-call-chat=\"sendThreadMessage\"");
+    expect(html).not.toContain("Call chat composer");
   });
 });
+
+function seedExpandedMucCall(): void {
+  connectionStore.session = {
+    username: "alice",
+    jid: "alice@waddle.test/browser",
+  } as typeof connectionStore.session;
+  $mucCallParticipants.set({ [ROOM]: ["alice"] });
+  $callUiMode.set("expanded");
+  $callState.set({
+    phase: "active",
+    kind: "muc",
+    peer: ROOM,
+    sid: "sid-active",
+    media: { audio: true, video: false },
+    join: {
+      url: "wss://livekit.waddle.test",
+      room: ROOM,
+      identity: "alice",
+      token: "token",
+    },
+    selfNick: "alice",
+    selfFullJid: "alice@waddle.test/browser",
+  });
+}
 
 function message(overrides: Partial<TimelineMessage>): TimelineMessage {
   return {
@@ -89,7 +130,7 @@ function message(overrides: Partial<TimelineMessage>): TimelineMessage {
     body: "",
     author: "alice",
     createdAt: "2026-06-09T12:00:00Z",
-    timestamp: Date.parse("2026-06-09T12:00:00Z"),
+    createdAtSource: "archive",
     isSelf: false,
     ...overrides,
   };

--- a/chat/tests/call-chat-composer.test.ts
+++ b/chat/tests/call-chat-composer.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolveActiveMucCallThreadId } from "../src/lib/calls/call-chat-composer";
+import type { TimelineMessage } from "../src/lib/chat-ui";
+
+describe("call-chat composer", () => {
+  test("resolves the active MUC call thread from the call anchor", () => {
+    const messages: TimelineMessage[] = [
+      message({ id: "ordinary", body: "hello" }),
+      message({
+        id: "call-anchor",
+        threadId: "call-thread-123",
+        roomJid: "lobby@muc.waddle.test",
+        callThread: {
+          kind: "muc",
+          sid: "sid-active",
+          media: "audio",
+          initiator: "alice@waddle.test/web",
+          started: "2026-06-09T12:00:00Z",
+        },
+      }),
+      message({
+        id: "other-call-anchor",
+        threadId: "call-thread-older",
+        roomJid: "lobby@muc.waddle.test",
+        callThread: {
+          kind: "muc",
+          sid: "sid-old",
+          media: "audio",
+          initiator: "alice@waddle.test/web",
+          started: "2026-06-09T11:00:00Z",
+        },
+      }),
+    ];
+
+    expect(resolveActiveMucCallThreadId(messages, "lobby@muc.waddle.test/alice", "sid-active")).toBe("call-thread-123");
+  });
+
+  test("expanded channel calls render a labelled composer bound to the call thread", () => {
+    const source = readFileSync(
+      new URL("../src/components/calls/CallExpandedSurface.vue", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).toContain("Call chat");
+    expect(source).toContain("MessageComposer");
+    expect(source).toContain("callThreadOverride");
+    expect(source).toContain(":show-extensions=\"false\"");
+    expect(source).toContain("emit(\"sendCallChat\"");
+  });
+
+  test("composer labels the editable control and can hide unsupported extension actions", () => {
+    const composer = readFileSync(
+      new URL("../src/components/chat/MessageComposer.vue", import.meta.url),
+      "utf8",
+    );
+    const editor = readFileSync(
+      new URL("../src/components/chat/ChatEditor.vue", import.meta.url),
+      "utf8",
+    );
+
+    expect(composer).toContain("showExtensions");
+    expect(composer).toContain("v-if=\"showExtensions\"");
+    expect(composer).toContain(":editor-label=\"composerLabel ?? `${channelName} composer`\"");
+    expect(editor).toContain("editorLabel");
+    expect(editor).toContain("\"aria-label\": props.editorLabel");
+  });
+
+  test("call-chat sends use the thread handler while the main composer keeps the channel handler", () => {
+    const contentArea = readFileSync(
+      new URL("../src/components/chat/ContentArea.vue", import.meta.url),
+      "utf8",
+    );
+    const readyShell = readFileSync(
+      new URL("../src/components/chat/ChatReadyShell.vue", import.meta.url),
+      "utf8",
+    );
+
+    expect(contentArea).toContain("@send=\"onSend\"");
+    expect(contentArea).toContain("@send-call-chat=\"(...args) => emit('sendCallChat', ...args)\"");
+    expect(readyShell).toContain("@send=\"sendActiveMessage\"");
+    expect(readyShell).toContain("@send-call-chat=\"sendThreadMessage\"");
+  });
+});
+
+function message(overrides: Partial<TimelineMessage>): TimelineMessage {
+  return {
+    id: "message",
+    body: "",
+    author: "alice",
+    createdAt: "2026-06-09T12:00:00Z",
+    timestamp: Date.parse("2026-06-09T12:00:00Z"),
+    isSelf: false,
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary

- Adds a dedicated call-chat composer inside the expanded MUC call surface.
- Resolves the active call-thread id from the loaded call-thread anchor and active MUC call sid.
- Routes call-chat sends through the existing thread-aware MUC send path while leaving the main conversation composer wired to the channel send handler.
- Reuses the normal MessageComposer so attachments, mentions, rich text, GIFs, link previews, replies, edits, and reactions stay on the normal message feature path.
- Labels the call-chat editable control for assistive tech and hides unsupported extension actions in the nested composer.

## XEP review

- XEP-0201 threading remains the send target mechanism: call-chat sends pass the call thread id as message thread metadata.
- XEP-0461 replies remain normal message behavior through the existing MessageComposer/useMucSend path.
- No Waddle-specific namespace is added for composer routing; the feature reuses the call-thread anchor produced by the earlier Call Chat work.

## Verification

- `bun test tests/call-chat-composer.test.ts tests/muc-send.test.ts tests/call-thread-anchor.test.ts`
- `bun run lint`
- Local Astro dev server smoke check returned `200 text/html`.
- Adversarial behavior review: no actionable issues.
- Adversarial UI/accessibility review: found dead extension button + editor label issue; both fixed and covered.

## Known gaps

- `bun test` has one unrelated artifact-dependent failure: `tests/startup-loading.test.ts` expects `dist/server/chunks/` to exist before the test run.
- `bunx vue-tsc --noEmit` still fails on existing baseline Vue/Tiptap diagnostics unrelated to this change.

Closes #920