### PR TITLE
feat(chat): flag call threads in Threads view

### DIFF
--- a/chat/src/components/chat/ThreadsListRow.vue
+++ b/chat/src/components/chat/ThreadsListRow.vue
@@ -89,7 +89,7 @@ const DmCallFlagIcon = computed(() => {
             >
               <component :is="DmCallFlagIcon" class="h-3 w-3" aria-hidden="true" />
             </span>
-            <div class="type-card-title truncate">{{ title }}</div>
+            <div class="type-card-title min-w-0 flex-1 truncate">{{ title }}</div>
           </div>
           <div class="type-caption text-muted-foreground truncate">
             {{ channelLabel }} · {{ recencyLabel }}

--- a/chat/src/components/chat/ThreadsListRow.vue
+++ b/chat/src/components/chat/ThreadsListRow.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
+import { Phone, Video } from "lucide-vue-next";
 import type { WasmThreadEntry } from "@/lib/xmpp/wasm-types";
 import type { CallMedia } from "@/lib/calls/types";
 import { threadDisplayTitle } from "@/lib/threads-view-filters";
@@ -23,7 +24,7 @@ const emit = defineEmits<{
 // don't anchor a MUC call (DM anchors, plain threads) keep the title row.
 const anchorMessage = computed(() => wasmThreadEntryToAnchorMessage(props.entry));
 const callState = useCallAnchorCardState(
-  () => anchorMessage.value ?? { body: "", author: "", threadId: null, callThread: undefined },
+  () => anchorMessage.value ?? { body: "", author: "", threadId: undefined, callThread: undefined },
   () => props.entry.channel,
   () => props.entry.reply_count,
 );
@@ -45,6 +46,16 @@ const channelLabel = computed(() => {
 });
 
 const title = computed(() => threadDisplayTitle(props.entry));
+const isDmCallThread = computed(() => props.entry.callThread?.kind === "dm");
+const dmCallFlagLabel = computed(() => {
+  if (!isDmCallThread.value) return "";
+  const hasVideo = props.entry.callThread?.media.includes("video") ?? false;
+  return hasVideo ? "Video call thread" : "Call thread";
+});
+const DmCallFlagIcon = computed(() => {
+  const hasVideo = props.entry.callThread?.media.includes("video") ?? false;
+  return hasVideo ? Video : Phone;
+});
 </script>
 
 <template>
@@ -68,7 +79,18 @@ const title = computed(() => threadDisplayTitle(props.entry));
     >
       <div class="flex items-center justify-between gap-2">
         <div class="min-w-0 flex-1">
-          <div class="type-card-title truncate">{{ title }}</div>
+          <div class="flex min-w-0 items-center gap-1.5">
+            <span
+              v-if="isDmCallThread"
+              class="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-primary/30 bg-primary/10 text-primary"
+              role="img"
+              :aria-label="dmCallFlagLabel"
+              :title="dmCallFlagLabel"
+            >
+              <component :is="DmCallFlagIcon" class="h-3 w-3" aria-hidden="true" />
+            </span>
+            <div class="type-card-title truncate">{{ title }}</div>
+          </div>
           <div class="type-caption text-muted-foreground truncate">
             {{ channelLabel }} · {{ recencyLabel }}
             <span v-if="entry.reply_count > 0"> · {{ entry.reply_count }} replies</span>

--- a/chat/tests/threads-list-row.test.ts
+++ b/chat/tests/threads-list-row.test.ts
@@ -79,4 +79,23 @@ describe("ThreadsListRow call-thread anchors", () => {
     expect(html).not.toContain("call-anchor-card");
     expect(html).toContain("Roadmap planning");
   });
+
+  test("renders a call flag for a DM call-thread row without the MUC join card", async () => {
+    const html = await renderRow({
+      ...baseEntry,
+      channel: "bob@example.com",
+      thread_id: "dm-call-thread",
+      thread_title: "Bob",
+      unread: 3,
+      has_unread: true,
+      callThread: { kind: "dm", media: ["audio"] },
+    });
+
+    expect(html).not.toContain("call-anchor-card");
+    expect(html).not.toContain(">Join<");
+    expect(html).toContain("Call thread");
+    expect(html).toContain('role="img"');
+    expect(html).toContain('aria-label="Call thread"');
+    expect(html).toContain('aria-label="3 unread"');
+  });
 });

--- a/server/crates/waddle-server/src/threads/storage.rs
+++ b/server/crates/waddle-server/src/threads/storage.rs
@@ -1070,10 +1070,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn page_carries_call_thread_metadata() {
+    async fn page_carries_call_thread_metadata_for_channel_and_dm_threads() {
         let (inbox, threads) = make_storage_pair().await;
         let user = jid("me@example.com");
         let room = jid("room@muc.example");
+        let peer = jid("bob@example.com");
         let ended = "2026-06-07T14:35:00Z"
             .parse::<DateTime<Utc>>()
             .expect("ended timestamp");
@@ -1090,17 +1091,51 @@ mod tests {
             .await
             .expect("upsert call thread");
 
+        inbox
+            .upsert(
+                &user,
+                InboxEntry::new(peer, ConversationKind::Direct, "s-dm-call", 200)
+                    .with_thread("dm-call-thread")
+                    .with_call_thread(CallThreadKind::Dm, CallThreadMedia::audio_only()),
+                true,
+            )
+            .await
+            .expect("upsert DM call thread");
+
         let page = threads.page(&user, &threads_query(50)).await.expect("page");
-        assert_eq!(page.entries.len(), 1);
-        let entry = &page.entries[0];
-        assert_eq!(entry.call_thread_kind, Some(CallThreadKind::Muc));
+        assert_eq!(page.entries.len(), 2);
+
+        let dm_entry = page
+            .entries
+            .iter()
+            .find(|entry| entry.thread_id == "dm-call-thread")
+            .expect("DM call thread surfaces in global Threads view");
+        assert_eq!(dm_entry.channel, jid("bob@example.com"));
+        assert_eq!(dm_entry.unread, 1);
+        assert_eq!(dm_entry.call_thread_kind, Some(CallThreadKind::Dm));
         assert_eq!(
-            entry.call_thread_media,
+            dm_entry.call_thread_media,
+            Some(CallThreadMedia::audio_only())
+        );
+
+        let channel_entry = page
+            .entries
+            .iter()
+            .find(|entry| entry.thread_id == "call-thread")
+            .expect("channel call thread surfaces in global Threads view");
+        assert_eq!(channel_entry.channel, jid("room@muc.example"));
+        assert_eq!(channel_entry.unread, 1);
+        assert_eq!(channel_entry.call_thread_kind, Some(CallThreadKind::Muc));
+        assert_eq!(
+            channel_entry.call_thread_media,
             Some(CallThreadMedia::audio_video())
         );
-        assert_eq!(entry.call_ended_at, Some(ended));
+        assert_eq!(channel_entry.call_ended_at, Some(ended));
         assert_eq!(
-            entry.call_duration.as_ref().map(CallThreadDuration::as_str),
+            channel_entry
+                .call_duration
+                .as_ref()
+                .map(CallThreadDuration::as_str),
             Some("PT5M")
         );
     }
@@ -1139,10 +1174,39 @@ mod tests {
             )
             .await
             .expect("upsert thread");
+        inbox
+            .upsert(
+                &user,
+                InboxEntry::new(
+                    jid("bob@example.com"),
+                    ConversationKind::Direct,
+                    "s-dm",
+                    120,
+                )
+                .with_thread("dm-call-thread")
+                .with_call_thread(CallThreadKind::Dm, CallThreadMedia::audio_only()),
+                true,
+            )
+            .await
+            .expect("upsert DM call thread without parent row");
 
         let page = threads.page(&user, &threads_query(50)).await.expect("page");
-        assert_eq!(page.entries.len(), 1);
-        assert_eq!(page.total, 1);
-        assert_eq!(page.entries[0].thread_id, "t1");
+        assert_eq!(page.entries.len(), 2);
+        assert_eq!(page.total, 2);
+        assert_eq!(
+            page.entries
+                .iter()
+                .map(|entry| entry.thread_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["dm-call-thread", "t1"]
+        );
+        let dm_entry = page
+            .entries
+            .iter()
+            .find(|entry| entry.thread_id == "dm-call-thread")
+            .expect("DM call thread surfaces from in-memory storage");
+        assert_eq!(dm_entry.channel, jid("bob@example.com"));
+        assert_eq!(dm_entry.unread, 1);
+        assert_eq!(dm_entry.call_thread_kind, Some(CallThreadKind::Dm));
     }
 }

--- a/server/crates/waddle-xmpp/src/inbox/mod.rs
+++ b/server/crates/waddle-xmpp/src/inbox/mod.rs
@@ -321,6 +321,18 @@ impl InboxView {
         v
     }
 
+    /// Returns all thread-level entries across partners, sorted newest-first.
+    pub fn all_threads(&self) -> Vec<InboxEntry> {
+        let mut v: Vec<_> = self
+            .entries
+            .values()
+            .filter(|e| e.thread_id.is_some())
+            .cloned()
+            .collect();
+        v.sort_by_key(|b| std::cmp::Reverse(b.last_updated));
+        v
+    }
+
     /// Mark the call anchored to `(room, thread_id)` as ended on this view.
     /// Returns `true` when a matching thread entry was updated. The
     /// call-end summary is room-wide; callers fan this across every user's

--- a/server/crates/waddle-xmpp/src/inbox/storage.rs
+++ b/server/crates/waddle-xmpp/src/inbox/storage.rs
@@ -219,6 +219,17 @@ impl InboxStorage for InMemoryInboxStorage {
             .unwrap_or_default())
     }
 
+    async fn list_all_threads(&self, user: &BareJid) -> Result<Vec<InboxEntry>, InboxStorageError> {
+        let guard = self
+            .per_user
+            .lock()
+            .map_err(|e| InboxStorageError::Other(e.to_string()))?;
+        Ok(guard
+            .get(user)
+            .map(InboxView::all_threads)
+            .unwrap_or_default())
+    }
+
     async fn upsert(
         &self,
         user: &BareJid,

--- a/server/crates/waddle-xmpp/src/inbox/storage.rs
+++ b/server/crates/waddle-xmpp/src/inbox/storage.rs
@@ -66,9 +66,11 @@ pub trait InboxStorage: Send + Sync {
     /// newest first. Used by the global `urn:waddle:threads:0` view.
     ///
     /// Default implementation walks `list` over the user's channel
-    /// conversations and aggregates `list_threads` per room — backends
-    /// SHOULD override with a single-query implementation when one is
-    /// available (the SQL backend does).
+    /// conversations and aggregates `list_threads` per room. This is only a
+    /// compatibility fallback: it cannot discover DM thread rows, including DM
+    /// call threads, unless a parent channel-level row already exists. Backends
+    /// SHOULD override with a direct all-threads implementation when one is
+    /// available.
     async fn list_all_threads(&self, user: &BareJid) -> Result<Vec<InboxEntry>, InboxStorageError> {
         let channels = self.list(user).await?;
         let mut all = Vec::new();


### PR DESCRIPTION
## Summary

- Adds a compact accessible call flag to DM call-thread rows in the global Threads list while keeping MUC call threads on the existing rich call-card row with Join.
- Keeps DM call-thread rows on the plain open-thread path so they remain discoverable without exposing MUC-specific call actions.
- Makes the in-memory inbox backend list all thread rows directly, matching SQL storage so DM thread rows without a parent conversation row surface through the inbox-backed Threads projection.

## Plan / completed work

- Verified existing XEP/internal `urn:waddle:threads:0` design and avoided new wire semantics.
- Added row-level regression coverage for DM call-thread flags, unread badge preservation, and no MUC Join card.
- Expanded threads projection tests for channel and DM call rows with unread counts.
- Fixed the in-memory inbox projection gap found during adversarial review.

## Changed files

- `chat/src/components/chat/ThreadsListRow.vue`
- `chat/tests/threads-list-row.test.ts`
- `server/crates/waddle-server/src/threads/storage.rs`
- `server/crates/waddle-xmpp/src/inbox/mod.rs`
- `server/crates/waddle-xmpp/src/inbox/storage.rs`

## Simplifications made

- Reused the existing MUC call-card path for MUC rows instead of creating a second call-card model.
- Used a small plain-row DM flag rather than introducing DM-specific call actions that do not exist in the Threads row controller.
- Reused `InboxView` snapshots for the in-memory backend instead of adding a second projection data structure.

## Verification

- `bun test tests/call-thread-anchor.test.ts tests/threads-list-row.test.ts tests/threads-view.test.ts`
- `bun run lint`
- `cargo fmt --check`
- `cargo test -p waddle-server page_carries_call_thread_metadata_for_channel_and_dm_threads`
- `cargo test -p waddle-server page_works_against_in_memory_storage`
- `cargo test -p waddle-xmpp-client call_thread`
- `cargo clippy --all-targets -- -D warnings`
- Two adversarial review passes: frontend/accessibility and backend/projection; second pass found no actionable issues.

## Remaining risks / local gaps

- `bun test` full suite passes 1922/1923 locally but `tests/startup-loading.test.ts` fails because `chat/dist/server/chunks/` is absent.
- `bun run build` is locally blocked by the existing `src/layouts/AppLayout.astro` `cloudflare:workers` type-resolution error, so the startup-loading build-output test could not be completed locally.

Related: #921