### PR TITLE
fix(chat): show dedicated call chat on call start (DM + group)

### DIFF
--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -165,10 +165,17 @@ const callThreadOverride = computed(() => {
   return threadId ? { threadId } : null;
 });
 
+// The dedicated call chat is available for both group (MUC) and 1:1 (DM)
+// calls. A resolved `callThreadOverride` already implies an active call with
+// a usable thread (MUC: room timeline; DM: the call sid), so the thread id
+// is the only gate beyond an active call.
 const canShowCallChatComposer = computed(() =>
   state.value.phase === "active" &&
-  state.value.kind === "muc" &&
   !!callThreadOverride.value,
+);
+
+const isMucCall = computed(
+  () => state.value.phase === "active" && state.value.kind === "muc",
 );
 
 const localIdentity = computed(() => engine.localIdentity);
@@ -305,7 +312,7 @@ onBeforeUnmount(() => {
         :mention-candidates="mentionCandidates ?? []"
         :slow-mode-cooldown="slowModeCooldown ?? 0"
         :upload-progress="uploadProgress ?? { uploading: false, progress: 0, filename: '' }"
-        :in-muc="true"
+        :in-muc="isMucCall"
         :link-preview-lookup="linkPreviewLookup ?? null"
         :link-preview-scope="linkPreviewScope ?? null"
         :show-extensions="false"

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -10,7 +10,7 @@ import { findMessageElementById } from "@/lib/message-targeting";
 import { findMessageById } from "@/lib/message-ids";
 import { getReplyJumpNotice } from "@/lib/reply-ux";
 import { findThreadToAutoOpen } from "@/lib/thread-auto-open";
-import { resolveActiveCallThreadId } from "@/lib/calls/call-chat-composer";
+import { activeCallChatThreadId } from "@/lib/calls/call-chat-composer";
 import { $callState } from "@/lib/calls/call-store";
 import {
   getPinnedScrollTop,
@@ -439,25 +439,9 @@ async function dispatchSlashCommand(
 }
 const inMucContext = computed(() => !!props.roomJid);
 const callRoomJid = computed(() => props.roomJid ?? props.channel?.jid ?? null);
-const activeCallThreadId = computed(() => {
-  const state = callState.value;
-  if (state.phase !== "active") return null;
-  if (state.kind === "muc") {
-    return resolveActiveCallThreadId(props.messages, {
-      kind: "muc",
-      roomJid: callRoomJid.value,
-      sid: state.sid,
-    });
-  }
-  if (state.kind === "dm") {
-    return resolveActiveCallThreadId(props.messages, {
-      kind: "dm",
-      peerJid: props.dmPeer?.peerJid,
-      sid: state.sid,
-    });
-  }
-  return null;
-});
+const activeCallThreadId = computed(() =>
+  activeCallChatThreadId(callState.value, props.messages, callRoomJid.value),
+);
 
 watch(
   () => props.xmppClient,

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -439,6 +439,13 @@ async function dispatchSlashCommand(
 }
 const inMucContext = computed(() => !!props.roomJid);
 const callRoomJid = computed(() => props.roomJid ?? props.channel?.jid ?? null);
+// The call-anchor card keys its live/ended state on the conversation: the room
+// JID for channels, the peer JID for DMs. `callRoomJid` is null for DMs, so a
+// DM anchor would otherwise never match its `$dmCallActivities` entry and would
+// render "Call ended" while the call is live.
+const callAnchorConversationJid = computed(
+  () => callRoomJid.value ?? props.dmPeer?.peerJid ?? null,
+);
 const activeCallThreadId = computed(() =>
   activeCallChatThreadId(callState.value, props.messages, callRoomJid.value),
 );
@@ -1399,7 +1406,7 @@ function dayDividerLabel(createdAt: string): string {
             :can-pin-messages="currentUserCanPin"
             :link-preview-lookup="linkPreviewLookup"
             :link-preview-scope="linkPreviewScope"
-            :call-room-jid="callRoomJid"
+            :call-room-jid="callAnchorConversationJid"
             :call-channel-id="channel?.id ?? null"
             @edit="(id, body, m, r, lp) => emit('editMessage', id, body, m, r, lp)"
             @retract="(id) => emit('retractMessage', id)"

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -386,6 +386,11 @@ function openCallThreadAnchor() {
 
 function joinCallThreadAnchor() {
   const state = callAnchorCardState.value;
+  // MUC-only: `joinChannelCall` joins a group call by room JID. DM anchors
+  // never offer Join (their card has no action), but guard anyway so a DM
+  // anchor — whose `callRoomJid` is the peer JID — can't fire a malformed
+  // group-call join.
+  if (props.message.callThread?.kind !== "muc") return;
   if (!state || !props.callRoomJid || state.status !== "live") return;
   emit("joinChannelCall", props.callChannelId ?? null, props.callRoomJid, state.media);
 }

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -199,19 +199,23 @@ export function useDirectMessages(
   // synthesized card is the live path; the later MAM-replayed archive row
   // dedups against it by call sid (see `dm-call-anchor.ts`). `.listen` fires
   // only on new publishes, so a stale anchor is never replayed on mount.
-  const stopDmCallAnchorListener = $dmCallStartedAnchor.listen((anchor) => {
-    if (!anchor) return;
-    const card = resolveDmCallAnchorInjection(
-      anchor,
-      activePeerJid.value,
-      session.value?.jid ?? null,
-    );
-    if (card) liveMerge.mergeLiveMessage(card);
-  });
+  //
   // `useDirectMessages` runs inside component setup in the app (an effect
-  // scope is present); guard so unit instantiation outside a scope neither
-  // warns nor leaks a disposer.
-  if (getCurrentScope()) onScopeDispose(stopDmCallAnchorListener);
+  // scope is present). Subscribe only within a scope so the listener is always
+  // paired with its disposer — never subscribed-and-leaked when the composable
+  // is unit-instantiated outside a scope.
+  if (getCurrentScope()) {
+    const stopDmCallAnchorListener = $dmCallStartedAnchor.listen((anchor) => {
+      if (!anchor) return;
+      const card = resolveDmCallAnchorInjection(
+        anchor,
+        activePeerJid.value,
+        session.value?.jid ?? null,
+      );
+      if (card) liveMerge.mergeLiveMessage(card);
+    });
+    onScopeDispose(stopDmCallAnchorListener);
+  }
 
   const actions = useDmMessageActions({
     session,

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -33,7 +33,7 @@ import { useDmChatStates } from "@/dms/chat-states";
 import { useDmReadMarkers } from "@/dms/read-markers";
 import { useDmMessageSearch } from "@/dms/message-search";
 import { useChatWindowVisibility } from "@/shell/window-visibility";
-import { $dmCallStartedAnchor, buildDmCallStartedAnchor } from "@/lib/calls/dm-call-anchor";
+import { $dmCallStartedAnchor, resolveDmCallAnchorInjection } from "@/lib/calls/dm-call-anchor";
 
 export function useDirectMessages(
   session: Ref<WaddleSession | null>,
@@ -201,11 +201,12 @@ export function useDirectMessages(
   // only on new publishes, so a stale anchor is never replayed on mount.
   const stopDmCallAnchorListener = $dmCallStartedAnchor.listen((anchor) => {
     if (!anchor) return;
-    const currentSession = session.value;
-    const peerJid = activePeerJid.value;
-    if (!currentSession || !peerJid) return;
-    if (barePeerJid(anchor.peerBareJid) !== barePeerJid(peerJid)) return;
-    liveMerge.mergeLiveMessage(buildDmCallStartedAnchor(anchor, currentSession.jid));
+    const card = resolveDmCallAnchorInjection(
+      anchor,
+      activePeerJid.value,
+      session.value?.jid ?? null,
+    );
+    if (card) liveMerge.mergeLiveMessage(card);
   });
   // `useDirectMessages` runs inside component setup in the app (an effect
   // scope is present); guard so unit instantiation outside a scope neither

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -1,4 +1,4 @@
-import { nextTick, ref, watch, type Ref } from "vue";
+import { getCurrentScope, nextTick, onScopeDispose, ref, watch, type Ref } from "vue";
 import type { TimelineMessage } from "@/lib/chat-ui";
 import type {
   BrowserXmppClient,
@@ -33,6 +33,7 @@ import { useDmChatStates } from "@/dms/chat-states";
 import { useDmReadMarkers } from "@/dms/read-markers";
 import { useDmMessageSearch } from "@/dms/message-search";
 import { useChatWindowVisibility } from "@/shell/window-visibility";
+import { $dmCallStartedAnchor, buildDmCallStartedAnchor } from "@/lib/calls/dm-call-anchor";
 
 export function useDirectMessages(
   session: Ref<WaddleSession | null>,
@@ -192,6 +193,24 @@ export function useDirectMessages(
     isFeedVisible,
   });
   const { applyDisplayed, applyReaction } = liveMerge;
+
+  // Surface a "started a call" anchor card the moment a 1:1 call becomes
+  // active. The server only enriches the archived `<proceed/>` row, so this
+  // synthesized card is the live path; the later MAM-replayed archive row
+  // dedups against it by call sid (see `dm-call-anchor.ts`). `.listen` fires
+  // only on new publishes, so a stale anchor is never replayed on mount.
+  const stopDmCallAnchorListener = $dmCallStartedAnchor.listen((anchor) => {
+    if (!anchor) return;
+    const currentSession = session.value;
+    const peerJid = activePeerJid.value;
+    if (!currentSession || !peerJid) return;
+    if (barePeerJid(anchor.peerBareJid) !== barePeerJid(peerJid)) return;
+    liveMerge.mergeLiveMessage(buildDmCallStartedAnchor(anchor, currentSession.jid));
+  });
+  // `useDirectMessages` runs inside component setup in the app (an effect
+  // scope is present); guard so unit instantiation outside a scope neither
+  // warns nor leaks a disposer.
+  if (getCurrentScope()) onScopeDispose(stopDmCallAnchorListener);
 
   const actions = useDmMessageActions({
     session,

--- a/chat/src/lib/call-thread-anchor.ts
+++ b/chat/src/lib/call-thread-anchor.ts
@@ -66,6 +66,7 @@ export function readCallAnchorCardState(
   messageCount = 0,
 ): CallAnchorCardState | null {
   if (!message.callThread) return null;
+  const callState = $callState.get();
   if (message.callThread.kind === "dm") {
     const activity = readMatchingDmCallActivity(message, roomJid);
     return buildCallAnchorCardState({
@@ -73,16 +74,16 @@ export function readCallAnchorCardState(
       roomJid: "",
       hasActiveCall: !!activity,
       localResourceInCall: false,
-      callState: $callState.get(),
+      callState,
       media: activity?.media ?? { audio: false, video: false },
       participantCount: activity ? 2 : 0,
       participantLabels: activity ? [barePeerJid(roomJid)] : [],
       messageCount,
+      localCallActive: localCallActiveForAnchor(callState, message.callThread, roomJid),
     });
   }
   const room = normalizeMucCallRoomJid(roomJid);
   const roomState = readRoomHasActiveCall(room);
-  const callState = $callState.get();
   const participantLabels = room ? [...($mucCallParticipants.get()[room] ?? [])] : [];
   return buildCallAnchorCardState({
     message,
@@ -94,6 +95,7 @@ export function readCallAnchorCardState(
     participantCount: roomState.participantCount,
     participantLabels,
     messageCount,
+    localCallActive: localCallActiveForAnchor(callState, message.callThread, room),
   });
 }
 
@@ -108,8 +110,10 @@ export function useCallAnchorCardState(
   const roomCall = useRoomHasActiveCall(() => roomJid() ?? "");
   return computed(() => {
     const current = message();
-    if (current.callThread?.kind === "dm") {
-      const activity = readMatchingDmCallActivity(current, roomJid() ?? "", dmActivities.value);
+    if (!current.callThread) return null;
+    if (current.callThread.kind === "dm") {
+      const peerJid = roomJid() ?? "";
+      const activity = readMatchingDmCallActivity(current, peerJid, dmActivities.value);
       return buildCallAnchorCardState({
         message: current,
         roomJid: "",
@@ -118,8 +122,9 @@ export function useCallAnchorCardState(
         callState: callState.value,
         media: activity?.media ?? { audio: false, video: false },
         participantCount: activity ? 2 : 0,
-        participantLabels: activity ? [barePeerJid(roomJid() ?? "")] : [],
+        participantLabels: activity ? [barePeerJid(peerJid)] : [],
         messageCount: messageCount(),
+        localCallActive: localCallActiveForAnchor(callState.value, current.callThread, peerJid),
       });
     }
     const room = normalizeMucCallRoomJid(roomJid() ?? "");
@@ -134,6 +139,7 @@ export function useCallAnchorCardState(
       participantCount: roomCall.participantCount.value,
       participantLabels,
       messageCount: messageCount(),
+      localCallActive: localCallActiveForAnchor(callState.value, current.callThread, room),
     });
   });
 }
@@ -163,6 +169,12 @@ function buildCallAnchorCardState(options: {
   participantCount: number;
   participantLabels: string[];
   messageCount: number;
+  /**
+   * True when the local user's active call IS this anchor's call (the MUC room
+   * call you joined, or the DM call you are in). Such a card must not read as
+   * "busy / In another call" or offer Join — you are already in it.
+   */
+  localCallActive: boolean;
 }): CallAnchorCardState | null {
   const callThread = options.message.callThread;
   if (!callThread) return null;
@@ -175,10 +187,10 @@ function buildCallAnchorCardState(options: {
   const media: CallMedia = live
     ? options.media
     : { audio: callThread.media.includes("audio"), video: callThread.media.includes("video") };
-  const localGroupCallInThisRoom = isLocalGroupCallInRoom(options.callState, options.roomJid);
-  const busy = live && isBusy(options.callState) && !localGroupCallInThisRoom;
-  const retainedLocalResource = live && options.localResourceInCall && !localGroupCallInThisRoom;
-  const joinAvailable = live && !busy && !localGroupCallInThisRoom;
+  const localCallActive = options.localCallActive;
+  const busy = live && isBusy(options.callState) && !localCallActive;
+  const retainedLocalResource = live && options.localResourceInCall && !localCallActive;
+  const joinAvailable = live && !busy && !localCallActive;
   const mediaLabel = media.video ? "video call" : "call";
   const peopleLabel = `${participantCount} ${participantCount === 1 ? "person" : "people"}`;
   const participants = participantLabels.length > 0 ? `: ${participantLabels.join(", ")}` : "";
@@ -215,6 +227,27 @@ function isLocalGroupCallInRoom(
   if (state.phase !== "active" && state.phase !== "muc-pending") return false;
   if (state.kind !== "muc") return false;
   return normalizeMucCallRoomJid(state.peer) === roomJid;
+}
+
+/**
+ * Whether the local user's active call is exactly this anchor's call. For MUC
+ * that is "the group call in this room"; for DM it is the active 1:1 call with
+ * the same peer and session id. `conversationJid` is the room JID for MUC and
+ * the peer JID for DM (the same value the card-state matcher keys on).
+ */
+function localCallActiveForAnchor(
+  state: ReturnType<typeof $callState.get>,
+  callThread: NonNullable<TimelineMessage["callThread"]>,
+  conversationJid: string,
+): boolean {
+  if (callThread.kind === "muc") {
+    return isLocalGroupCallInRoom(state, normalizeMucCallRoomJid(conversationJid));
+  }
+  if (state.phase !== "active" || state.kind !== "dm") return false;
+  return (
+    barePeerJid(state.peer).toLowerCase() === barePeerJid(conversationJid).toLowerCase()
+    && state.sid === callThread.sid
+  );
 }
 
 function formatCallThreadDuration(value: string): string {

--- a/chat/src/lib/call-thread-anchor.ts
+++ b/chat/src/lib/call-thread-anchor.ts
@@ -79,7 +79,6 @@ export function readCallAnchorCardState(
       participantCount: activity ? 2 : 0,
       participantLabels: activity ? [barePeerJid(roomJid)] : [],
       messageCount,
-      localCallActive: localCallActiveForAnchor(callState, message.callThread, roomJid),
     });
   }
   const room = normalizeMucCallRoomJid(roomJid);
@@ -95,7 +94,6 @@ export function readCallAnchorCardState(
     participantCount: roomState.participantCount,
     participantLabels,
     messageCount,
-    localCallActive: localCallActiveForAnchor(callState, message.callThread, room),
   });
 }
 
@@ -124,7 +122,6 @@ export function useCallAnchorCardState(
         participantCount: activity ? 2 : 0,
         participantLabels: activity ? [barePeerJid(peerJid)] : [],
         messageCount: messageCount(),
-        localCallActive: localCallActiveForAnchor(callState.value, current.callThread, peerJid),
       });
     }
     const room = normalizeMucCallRoomJid(roomJid() ?? "");
@@ -139,7 +136,6 @@ export function useCallAnchorCardState(
       participantCount: roomCall.participantCount.value,
       participantLabels,
       messageCount: messageCount(),
-      localCallActive: localCallActiveForAnchor(callState.value, current.callThread, room),
     });
   });
 }
@@ -169,12 +165,6 @@ function buildCallAnchorCardState(options: {
   participantCount: number;
   participantLabels: string[];
   messageCount: number;
-  /**
-   * True when the local user's active call IS this anchor's call (the MUC room
-   * call you joined, or the DM call you are in). Such a card must not read as
-   * "busy / In another call" or offer Join — you are already in it.
-   */
-  localCallActive: boolean;
 }): CallAnchorCardState | null {
   const callThread = options.message.callThread;
   if (!callThread) return null;
@@ -187,10 +177,16 @@ function buildCallAnchorCardState(options: {
   const media: CallMedia = live
     ? options.media
     : { audio: callThread.media.includes("audio"), video: callThread.media.includes("video") };
-  const localCallActive = options.localCallActive;
-  const busy = live && isBusy(options.callState) && !localCallActive;
-  const retainedLocalResource = live && options.localResourceInCall && !localCallActive;
-  const joinAvailable = live && !busy && !localCallActive;
+  // Action affordances are MUC-only: a group call has a room you can Join /
+  // Rejoin and "In another call" busy semantics. A DM call is 1:1 — its
+  // timeline card is a pure live/ended marker (answer/reconnect/return live in
+  // the call dock and banner, never on the card). A DM "Join" would also be
+  // malformed: the card's room JID is the peer JID, not a MUC room.
+  const mucActions = callThread.kind === "muc";
+  const localGroupCallInThisRoom = isLocalGroupCallInRoom(options.callState, options.roomJid);
+  const busy = mucActions && live && isBusy(options.callState) && !localGroupCallInThisRoom;
+  const retainedLocalResource = mucActions && live && options.localResourceInCall && !localGroupCallInThisRoom;
+  const joinAvailable = mucActions && live && !busy && !localGroupCallInThisRoom;
   const mediaLabel = media.video ? "video call" : "call";
   const peopleLabel = `${participantCount} ${participantCount === 1 ? "person" : "people"}`;
   const participants = participantLabels.length > 0 ? `: ${participantLabels.join(", ")}` : "";
@@ -227,27 +223,6 @@ function isLocalGroupCallInRoom(
   if (state.phase !== "active" && state.phase !== "muc-pending") return false;
   if (state.kind !== "muc") return false;
   return normalizeMucCallRoomJid(state.peer) === roomJid;
-}
-
-/**
- * Whether the local user's active call is exactly this anchor's call. For MUC
- * that is "the group call in this room"; for DM it is the active 1:1 call with
- * the same peer and session id. `conversationJid` is the room JID for MUC and
- * the peer JID for DM (the same value the card-state matcher keys on).
- */
-function localCallActiveForAnchor(
-  state: ReturnType<typeof $callState.get>,
-  callThread: NonNullable<TimelineMessage["callThread"]>,
-  conversationJid: string,
-): boolean {
-  if (callThread.kind === "muc") {
-    return isLocalGroupCallInRoom(state, normalizeMucCallRoomJid(conversationJid));
-  }
-  if (state.phase !== "active" || state.kind !== "dm") return false;
-  return (
-    barePeerJid(state.peer).toLowerCase() === barePeerJid(conversationJid).toLowerCase()
-    && state.sid === callThread.sid
-  );
 }
 
 function formatCallThreadDuration(value: string): string {

--- a/chat/src/lib/call-thread-anchor.ts
+++ b/chat/src/lib/call-thread-anchor.ts
@@ -205,12 +205,18 @@ function buildCallAnchorCardState(options: {
         : "Call ended",
     actionLabel: joinAvailable ? (retainedLocalResource ? "Rejoin" : "Join") : busy ? "In another call" : null,
     actionDisabled: busy,
+    // Keep the aria label in step with the rendered action: only announce
+    // "Join"/"Rejoin" when that affordance actually exists (a joinable MUC
+    // call). DM cards and a MUC call you are already in have no action, so
+    // they announce a plain live marker.
     ariaLabel: live
       ? busy
         ? `Live ${mediaLabel}, ${peopleLabel}${participants}; already in another call`
-        : retainedLocalResource
-          ? `Rejoin live ${mediaLabel}, ${peopleLabel}${participants}`
-          : `Join live ${mediaLabel}, ${peopleLabel}${participants}`
+        : joinAvailable
+          ? retainedLocalResource
+            ? `Rejoin live ${mediaLabel}, ${peopleLabel}${participants}`
+            : `Join live ${mediaLabel}, ${peopleLabel}${participants}`
+          : `Live ${mediaLabel}, ${peopleLabel}${participants}`
       : callThreadAnchorLabel(message),
   };
 }

--- a/chat/src/lib/calls/call-chat-composer.ts
+++ b/chat/src/lib/calls/call-chat-composer.ts
@@ -7,52 +7,68 @@ type CallThreadCandidate = {
 };
 
 /**
- * Resolve the active call's XEP-0201 thread from the current conversation's
- * loaded timeline. The message list is intentionally conversation-scoped by
- * `ContentArea`; timeline messages do not carry a room JID themselves.
+ * The slice of `$callState` the in-call composer needs to locate its
+ * call-chat thread. Kept structural so callers can pass the live store
+ * value (or a test fixture) without importing the full discriminated union.
+ */
+type ActiveCallChat = {
+  phase: string;
+  kind?: "dm" | "muc";
+  sid?: string | null;
+};
+
+/**
+ * Resolve the active MUC call's XEP-0201 thread from the current
+ * conversation's loaded timeline.
+ *
+ * A MUC anchor's `urn:waddle:call-thread:0` marker carries a throwaway
+ * server-side session id that never equals the client's per-attempt call
+ * sid, so we cannot match on sid. There is at most one active call per room,
+ * so the thread is simply the most recent **non-ended** `muc` anchor in the
+ * room-scoped timeline (`ContentArea` scopes `messages` to one conversation;
+ * timeline messages do not carry a room JID themselves, so `roomJid` only
+ * guards that a room is in context).
  */
 export function resolveActiveMucCallThreadId(
   messages: readonly CallThreadCandidate[],
   roomJid: string | null | undefined,
-  sid: string | null | undefined,
 ): string | null {
   const room = normalizeMucCallRoomJid(roomJid ?? "");
-  const activeSid = sid?.trim();
-  if (!room || !activeSid) return null;
+  if (!room) return null;
 
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index];
     if (!message?.threadId || !message.callThread) continue;
     if (message.callThread.kind !== "muc") continue;
-    if (message.callThread.sid !== activeSid) continue;
+    if (message.callThread.ended) continue;
     return message.threadId;
   }
 
   return null;
 }
 
-export function resolveActiveCallThreadId(
+/**
+ * Resolve the call-chat thread id for the in-call composer of the currently
+ * active call.
+ *
+ * - DM: the thread id equals the JMI session id by server invariant
+ *   (`thread_id == key.sid.0`), which is exactly the client's active call
+ *   sid — so it resolves live without waiting for a timeline anchor.
+ * - MUC: resolved from the room timeline (see
+ *   {@link resolveActiveMucCallThreadId}).
+ */
+export function activeCallChatThreadId(
+  call: ActiveCallChat,
   messages: readonly CallThreadCandidate[],
-  active: {
-    kind: "dm" | "muc";
-    sid: string | null | undefined;
-    roomJid?: string | null;
-    peerJid?: string | null;
-  },
+  roomJid: string | null | undefined,
 ): string | null {
-  if (active.kind === "muc") {
-    return resolveActiveMucCallThreadId(messages, active.roomJid, active.sid);
+  if (call.phase !== "active") return null;
+  if (call.kind === "dm") {
+    const sid = call.sid?.trim();
+    return sid ? sid : null;
   }
-  const activeSid = active.sid?.trim();
-  if (!activeSid) return null;
-
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const message = messages[index];
-    if (!message?.threadId || !message.callThread) continue;
-    if (message.callThread.kind !== "dm") continue;
-    if (message.callThread.sid !== activeSid) continue;
-    return message.threadId;
+  if (call.kind === "muc") {
+    return resolveActiveMucCallThreadId(messages, roomJid);
   }
-
   return null;
 }

--- a/chat/src/lib/calls/call-chat-composer.ts
+++ b/chat/src/lib/calls/call-chat-composer.ts
@@ -28,6 +28,13 @@ type ActiveCallChat = {
  * room-scoped timeline (`ContentArea` scopes `messages` to one conversation;
  * timeline messages do not carry a room JID themselves, so `roomJid` only
  * guards that a room is in context).
+ *
+ * Assumption: the most recent non-ended `muc` anchor is the active call. The
+ * server emits exactly one anchor per call start and an XEP-0422 ended
+ * fastening on call end, so this holds in steady state. A prior call whose
+ * ended fastening was missed live (and not yet reconciled from MAM) could
+ * momentarily mis-bind until the new call's anchor arrives; this is a strict
+ * improvement over the previous sid match, which never resolved at all.
  */
 export function resolveActiveMucCallThreadId(
   messages: readonly CallThreadCandidate[],

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -18,6 +18,7 @@ import {
 } from "./muc-call-session-cache";
 import { clearLiveCallParticipants } from "./muc-call-live-participants";
 import { mediaErrorMessage } from "./call-media-issues";
+import { publishDmCallStartedAnchor } from "./dm-call-anchor";
 import { barePeerJid } from "../xmpp/jid";
 
 /**
@@ -322,6 +323,27 @@ export function applyCallEvent(event: CallEvent): void {
     cancelOutgoingTimeout();
   }
   $callState.set(next);
+  maybePublishDmCallStartedAnchor(before, next);
+}
+
+/**
+ * On the transition INTO an active 1:1 call, publish a "started a call" anchor
+ * so the DM messaging composable can surface it live (the server only enriches
+ * the archived `<proceed/>` row, which never reaches the live timeline). Skips
+ * media renegotiations that keep the same active call, and skips when the
+ * initiator is unknown (the card falls back to MAM replay).
+ */
+function maybePublishDmCallStartedAnchor(before: CallState, next: CallState): void {
+  if (next.phase !== "active" || next.kind !== "dm") return;
+  if (before.phase === "active" && before.kind === "dm" && before.sid === next.sid) return;
+  if (!next.initiator) return;
+  publishDmCallStartedAnchor({
+    peerBareJid: barePeerJid(next.peer),
+    sid: next.sid,
+    media: next.media,
+    initiator: next.initiator,
+    started: new Date().toISOString(),
+  });
 }
 
 /**

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -18,7 +18,7 @@ import {
 } from "./muc-call-session-cache";
 import { clearLiveCallParticipants } from "./muc-call-live-participants";
 import { mediaErrorMessage } from "./call-media-issues";
-import { publishDmCallStartedAnchor } from "./dm-call-anchor";
+import { dmCallStartedAnchorFromTransition, publishDmCallStartedAnchor } from "./dm-call-anchor";
 import { barePeerJid } from "../xmpp/jid";
 
 /**
@@ -323,27 +323,10 @@ export function applyCallEvent(event: CallEvent): void {
     cancelOutgoingTimeout();
   }
   $callState.set(next);
-  maybePublishDmCallStartedAnchor(before, next);
-}
-
-/**
- * On the transition INTO an active 1:1 call, publish a "started a call" anchor
- * so the DM messaging composable can surface it live (the server only enriches
- * the archived `<proceed/>` row, which never reaches the live timeline). Skips
- * media renegotiations that keep the same active call, and skips when the
- * initiator is unknown (the card falls back to MAM replay).
- */
-function maybePublishDmCallStartedAnchor(before: CallState, next: CallState): void {
-  if (next.phase !== "active" || next.kind !== "dm") return;
-  if (before.phase === "active" && before.kind === "dm" && before.sid === next.sid) return;
-  if (!next.initiator) return;
-  publishDmCallStartedAnchor({
-    peerBareJid: barePeerJid(next.peer),
-    sid: next.sid,
-    media: next.media,
-    initiator: next.initiator,
-    started: new Date().toISOString(),
-  });
+  // Surface the DM "started a call" card live (the server only enriches the
+  // archived `<proceed/>` row, which never reaches the live timeline).
+  const dmCallAnchor = dmCallStartedAnchorFromTransition(before, next, new Date().toISOString());
+  if (dmCallAnchor) publishDmCallStartedAnchor(dmCallAnchor);
 }
 
 /**

--- a/chat/src/lib/calls/dm-call-anchor.ts
+++ b/chat/src/lib/calls/dm-call-anchor.ts
@@ -109,7 +109,14 @@ export function resolveDmCallAnchorInjection(
   selfJid: string | null,
 ): TimelineMessage | null {
   if (!selfJid || !activePeerJid) return null;
-  if (barePeerJid(anchor.peerBareJid) !== barePeerJid(activePeerJid)) return null;
+  // JID node/domain are case-insensitive (RFC 7622), so normalize before
+  // matching the anchor's peer against the open conversation.
+  if (
+    barePeerJid(anchor.peerBareJid).toLowerCase()
+    !== barePeerJid(activePeerJid).toLowerCase()
+  ) {
+    return null;
+  }
   return buildDmCallStartedAnchor(anchor, selfJid);
 }
 

--- a/chat/src/lib/calls/dm-call-anchor.ts
+++ b/chat/src/lib/calls/dm-call-anchor.ts
@@ -1,7 +1,7 @@
 import { atom } from "nanostores";
 import type { CallThreadAnchor, TimelineMessage } from "@/lib/chat-ui";
 import { barePeerJid } from "../xmpp/jid";
-import type { CallMedia } from "./types";
+import type { CallMedia, CallState } from "./types";
 
 /**
  * A 1:1 (DM) call that has just become active and should surface a "started a
@@ -72,6 +72,45 @@ export function buildDmCallStartedAnchor(
     threadId: anchor.sid,
     callThread,
   };
+}
+
+/**
+ * Producer guard: derive the anchor to publish from a call-state transition,
+ * or `null` when none should be published. Publishes only on the transition
+ * INTO an active 1:1 call — not media renegotiations that keep the same active
+ * call, and not when the initiator is unknown (the card falls back to MAM
+ * replay). Pure so the guard logic is unit-testable without the global store.
+ */
+export function dmCallStartedAnchorFromTransition(
+  before: CallState,
+  next: CallState,
+  startedIso: string,
+): DmCallStartedAnchor | null {
+  if (next.phase !== "active" || next.kind !== "dm") return null;
+  if (before.phase === "active" && before.kind === "dm" && before.sid === next.sid) return null;
+  if (!next.initiator) return null;
+  return {
+    peerBareJid: barePeerJid(next.peer),
+    sid: next.sid,
+    media: next.media,
+    initiator: next.initiator,
+    started: startedIso,
+  };
+}
+
+/**
+ * Consumer guard: build the timeline card for `anchor` only when it belongs to
+ * the open conversation, isolating it from other DMs (a call with Bob must not
+ * inject a card into Carol's open timeline). Returns `null` otherwise.
+ */
+export function resolveDmCallAnchorInjection(
+  anchor: DmCallStartedAnchor,
+  activePeerJid: string | null,
+  selfJid: string | null,
+): TimelineMessage | null {
+  if (!selfJid || !activePeerJid) return null;
+  if (barePeerJid(anchor.peerBareJid) !== barePeerJid(activePeerJid)) return null;
+  return buildDmCallStartedAnchor(anchor, selfJid);
 }
 
 /**

--- a/chat/src/lib/calls/dm-call-anchor.ts
+++ b/chat/src/lib/calls/dm-call-anchor.ts
@@ -1,0 +1,87 @@
+import { atom } from "nanostores";
+import type { CallThreadAnchor, TimelineMessage } from "@/lib/chat-ui";
+import { barePeerJid } from "../xmpp/jid";
+import type { CallMedia } from "./types";
+
+/**
+ * A 1:1 (DM) call that has just become active and should surface a "started a
+ * call" anchor card in the peer conversation's live timeline — the DM analogue
+ * of the server-broadcast MUC anchor.
+ *
+ * Unlike MUC (where the server broadcasts a live groupchat anchor), the DM
+ * anchor is only enriched onto the archived XEP-0353 `<proceed/>` row, so it
+ * never reaches the live timeline. This carries the data needed to synthesize
+ * an equivalent in-memory card that the later MAM-replayed archive row dedups
+ * against by call sid.
+ */
+export type DmCallStartedAnchor = {
+  peerBareJid: string;
+  sid: string;
+  media: CallMedia;
+  /** Bare or full JID of the call initiator (the server invariant author). */
+  initiator: string;
+  /** ISO-8601 start time. */
+  started: string;
+};
+
+/**
+ * Deterministic timeline id for a DM call-thread anchor, shared by the
+ * synthesized live card and the MAM-replayed archive row (via a wire-id alias)
+ * so the two collapse to a single card instead of duplicating.
+ */
+export function dmCallAnchorId(sid: string): string {
+  return `dmcall:${sid}`;
+}
+
+function callThreadMedia(media: CallMedia): ("audio" | "video")[] {
+  const kinds: ("audio" | "video")[] = [];
+  if (media.audio) kinds.push("audio");
+  if (media.video) kinds.push("video");
+  // A call always has at least audio; default so the card never renders empty.
+  if (kinds.length === 0) kinds.push("audio");
+  return kinds;
+}
+
+/**
+ * Build the in-memory "started a call" anchor card for a live DM call. The
+ * card roots its own call thread (`threadId == sid`, matching the server's
+ * `thread_id == key.sid.0` invariant) and uses the lowest-authority
+ * `fallback` timestamp so the MAM archive stamp wins on merge.
+ */
+export function buildDmCallStartedAnchor(
+  anchor: DmCallStartedAnchor,
+  selfJid: string,
+): TimelineMessage {
+  const initiatorBare = barePeerJid(anchor.initiator).toLowerCase();
+  const isSelf = !!initiatorBare && initiatorBare === barePeerJid(selfJid).toLowerCase();
+  const callThread: CallThreadAnchor = {
+    kind: "dm",
+    sid: anchor.sid,
+    media: callThreadMedia(anchor.media),
+    initiator: anchor.initiator,
+    started: anchor.started,
+  };
+  return {
+    id: dmCallAnchorId(anchor.sid),
+    author: initiatorBare.split("@")[0] ?? "unknown",
+    authorJid: anchor.initiator,
+    body: "",
+    createdAt: anchor.started,
+    createdAtSource: "fallback",
+    isSelf,
+    threadId: anchor.sid,
+    callThread,
+  };
+}
+
+/**
+ * Bridge from the call layer (`applyCallEvent`) to the DM messaging
+ * composable, which appends the synthesized anchor to the open conversation.
+ * A plain atom (last-writer signal) keeps the call store decoupled from the
+ * timeline/session — the composable derives `isSelf` from its own session.
+ */
+export const $dmCallStartedAnchor = atom<DmCallStartedAnchor | null>(null);
+
+export function publishDmCallStartedAnchor(anchor: DmCallStartedAnchor): void {
+  $dmCallStartedAnchor.set(anchor);
+}

--- a/chat/src/lib/xmpp/wasm-message-codecs.ts
+++ b/chat/src/lib/xmpp/wasm-message-codecs.ts
@@ -18,6 +18,7 @@ import {
   type SendGroupMessageOptions,
 } from "./send-types";
 import type { TimestampSource } from "@/lib/timeline-timestamps";
+import { dmCallAnchorId } from "../calls/dm-call-anchor";
 import type { LiveDmMessage, LiveRoomMessage, OccupantPresence, PresenceUpdateEvent, SharedFileInfo } from "./types";
 import type {
   WasmArchivedMessage,
@@ -636,6 +637,15 @@ export function dmMessageFromArchived(
   const callThreadEnded = message.call_thread_ended;
   const dmWireIds = [message.id, message.origin_id]
     .filter((value): value is string => !!value && value !== dmPrimaryId);
+  // Alias a DM call-thread anchor by its sid so a same-session MAM backfill
+  // collapses onto the synthesized live anchor (see `dm-call-anchor.ts`)
+  // instead of duplicating the "started a call" card.
+  if (callThread?.sid) {
+    const anchorAlias = dmCallAnchorId(callThread.sid);
+    if (anchorAlias !== dmPrimaryId && !dmWireIds.includes(anchorAlias)) {
+      dmWireIds.push(anchorAlias);
+    }
+  }
   // See `roomMessageFromArchived` for the rationale: `<thread/>` alone is
   // metadata, not content. DMs don't currently surface threads in the UI
   // anyway, but the codec stays symmetric with the room path so a stray

--- a/chat/tests/call-chat-composer.test.ts
+++ b/chat/tests/call-chat-composer.test.ts
@@ -3,7 +3,7 @@ import { $callState } from "../src/lib/calls/call-store";
 import { $callUiMode } from "../src/lib/calls/ui-mode";
 import { $mucCallParticipants } from "../src/lib/calls/muc-call-presence";
 import { connectionStore } from "../src/lib/connection-store";
-import { resolveActiveCallThreadId, resolveActiveMucCallThreadId } from "../src/lib/calls/call-chat-composer";
+import { activeCallChatThreadId, resolveActiveMucCallThreadId } from "../src/lib/calls/call-chat-composer";
 import type { TimelineMessage } from "../src/lib/chat-ui";
 import { renderVueComponent } from "./helpers/render-vue-sfc";
 
@@ -17,74 +17,87 @@ describe("call-chat composer", () => {
     connectionStore.session = null;
   });
 
-  test("resolves the active MUC call thread from the current conversation timeline", () => {
+  test("resolves the active MUC call thread by room, skipping ended calls", () => {
+    // The MUC anchor's marker sid is a throwaway server-side uuid that never
+    // matches the client's per-attempt call sid, so resolution is by room:
+    // the most recent non-ended `muc` anchor in the room's timeline.
     const messages: TimelineMessage[] = [
       message({ id: "ordinary", body: "hello" }),
       message({
-        id: "call-anchor",
-        threadId: "call-thread-123",
-        callThread: {
-          kind: "muc",
-          sid: "sid-active",
-          media: ["audio"],
-          initiator: "alice@waddle.test/web",
-          started: "2026-06-09T12:00:00Z",
-        },
-      }),
-      message({
-        id: "other-call-anchor",
-        threadId: "call-thread-older",
+        id: "ended-call-anchor",
+        threadId: "call-thread-old",
         callThread: {
           kind: "muc",
           sid: "sid-old",
           media: ["audio"],
           initiator: "alice@waddle.test/web",
           started: "2026-06-09T11:00:00Z",
+          ended: "2026-06-09T11:30:00Z",
         },
       }),
-    ];
-
-    expect(resolveActiveMucCallThreadId(messages, `${ROOM}/alice`, "sid-active")).toBe("call-thread-123");
-  });
-
-  test("does not resolve when the active room or sid is unusable", () => {
-    const messages = [
       message({
-        id: "call-anchor",
-        threadId: "call-thread-123",
-        callThread: { kind: "muc", sid: "sid-active", media: ["audio"] },
-      }),
-    ];
-
-    expect(resolveActiveMucCallThreadId(messages, "", "sid-active")).toBeNull();
-    expect(resolveActiveMucCallThreadId(messages, ROOM, " ")).toBeNull();
-  });
-
-  test("resolves the active DM call thread from the current conversation timeline", () => {
-    const messages: TimelineMessage[] = [
-      message({ id: "ordinary", body: "hello" }),
-      message({
-        id: "dm-call-anchor",
-        threadId: "dm-call-thread-123",
+        id: "active-call-anchor",
+        threadId: "call-thread-active",
         callThread: {
-          kind: "dm",
-          sid: "dm-active",
+          kind: "muc",
+          sid: "sid-fresh",
           media: ["audio"],
-          initiator: "alice@waddle.test",
+          initiator: "alice@waddle.test/web",
           started: "2026-06-09T12:00:00Z",
         },
       }),
     ];
 
-    expect(resolveActiveCallThreadId(messages, {
-      kind: "dm",
-      peerJid: "bob@waddle.test",
-      sid: "dm-active",
-    })).toBe("dm-call-thread-123");
-    expect(resolveActiveCallThreadId(messages, {
-      kind: "dm",
-      sid: "dm-active",
-    })).toBe("dm-call-thread-123");
+    expect(resolveActiveMucCallThreadId(messages, `${ROOM}/alice`)).toBe("call-thread-active");
+  });
+
+  test("does not resolve a MUC call thread without a room or an active anchor", () => {
+    const active: TimelineMessage[] = [
+      message({
+        id: "active-call-anchor",
+        threadId: "call-thread-active",
+        callThread: { kind: "muc", sid: "sid-fresh", media: ["audio"] },
+      }),
+    ];
+    const endedOnly: TimelineMessage[] = [
+      message({
+        id: "ended-call-anchor",
+        threadId: "call-thread-old",
+        callThread: { kind: "muc", sid: "sid-old", media: ["audio"], ended: "2026-06-09T11:30:00Z" },
+      }),
+    ];
+
+    expect(resolveActiveMucCallThreadId(active, "")).toBeNull();
+    expect(resolveActiveMucCallThreadId(endedOnly, ROOM)).toBeNull();
+  });
+
+  test("derives the active DM call-chat thread id from the call sid", () => {
+    // Server invariant: a DM call-thread id equals the JMI session id, which
+    // is exactly the client's active call sid — so the in-call composer can
+    // resolve the thread live without waiting for a timeline anchor.
+    expect(
+      activeCallChatThreadId({ phase: "active", kind: "dm", sid: "dm-sid-1" }, [], null),
+    ).toBe("dm-sid-1");
+    expect(
+      activeCallChatThreadId({ phase: "active", kind: "dm", sid: "  " }, [], null),
+    ).toBeNull();
+  });
+
+  test("derives the active MUC call-chat thread id from the room timeline", () => {
+    const messages: TimelineMessage[] = [
+      message({
+        id: "active-call-anchor",
+        threadId: "call-thread-active",
+        callThread: { kind: "muc", sid: "sid-fresh", media: ["audio"] },
+      }),
+    ];
+
+    expect(
+      activeCallChatThreadId({ phase: "active", kind: "muc", sid: "sid-fresh" }, messages, ROOM),
+    ).toBe("call-thread-active");
+    expect(
+      activeCallChatThreadId({ phase: "idle" }, messages, ROOM),
+    ).toBeNull();
   });
 
   test("expanded channel calls render a labelled call-chat composer when a call thread is available", async () => {
@@ -108,6 +121,24 @@ describe("call-chat composer", () => {
     expect(html).toContain("Call chat");
     expect(html).toContain('aria-label="Call chat composer"');
     expect(html).not.toContain('aria-label="Extensions"');
+  });
+
+  test("expanded DM calls render the call-chat composer from the call sid", async () => {
+    seedExpandedDmCall();
+
+    const html = await renderVueComponent(
+      "../src/components/calls/CallExpandedSurface.vue",
+      {
+        dmPeerJid: "bob@waddle.test",
+        dmPeerName: "Bob",
+        callThreadId: "dm-sid-1",
+        uploadProgress: { uploading: false, progress: 0, filename: "" },
+      },
+      import.meta.url,
+    );
+
+    expect(html).toContain("Call chat");
+    expect(html).toContain('aria-label="Call chat composer"');
   });
 
   test("expanded channel calls hide the call-chat composer without a usable thread id", async () => {
@@ -148,6 +179,28 @@ function seedExpandedMucCall(): void {
     },
     selfNick: "alice",
     selfFullJid: "alice@waddle.test/browser",
+  });
+}
+
+function seedExpandedDmCall(): void {
+  connectionStore.session = {
+    username: "alice",
+    jid: "alice@waddle.test/browser",
+  } as typeof connectionStore.session;
+  $callUiMode.set("expanded");
+  $callState.set({
+    phase: "active",
+    kind: "dm",
+    peer: "bob@waddle.test/desktop",
+    sid: "dm-sid-1",
+    media: { audio: true, video: false },
+    join: {
+      url: "wss://livekit.waddle.test",
+      room: "dm-sid-1",
+      identity: "alice",
+      token: "token",
+    },
+    initiator: "alice@waddle.test/browser",
   });
 }
 

--- a/chat/tests/call-chat-composer.test.ts
+++ b/chat/tests/call-chat-composer.test.ts
@@ -51,6 +51,25 @@ describe("call-chat composer", () => {
     expect(resolveActiveMucCallThreadId(messages, `${ROOM}/alice`)).toBe("call-thread-active");
   });
 
+  test("skips a more recent ended muc anchor to find the still-active one", () => {
+    // The ended anchor is the most recent row, so the reverse scan must skip
+    // it (not just stop at the newest) to return the still-active call.
+    const messages: TimelineMessage[] = [
+      message({
+        id: "active-call-anchor",
+        threadId: "call-thread-active",
+        callThread: { kind: "muc", sid: "sid-fresh", media: ["audio"] },
+      }),
+      message({
+        id: "ended-call-anchor",
+        threadId: "call-thread-old",
+        callThread: { kind: "muc", sid: "sid-old", media: ["audio"], ended: "2026-06-09T13:00:00Z" },
+      }),
+    ];
+
+    expect(resolveActiveMucCallThreadId(messages, `${ROOM}/alice`)).toBe("call-thread-active");
+  });
+
   test("does not resolve a MUC call thread without a room or an active anchor", () => {
     const active: TimelineMessage[] = [
       message({

--- a/chat/tests/call-thread-anchor.test.ts
+++ b/chat/tests/call-thread-anchor.test.ts
@@ -9,6 +9,7 @@ import {
 import type { WasmThreadEntry } from "../src/lib/xmpp/wasm-types";
 import { $callState } from "../src/lib/calls/call-store";
 import { $dmCallActivities, clearDmCallActivities } from "../src/lib/calls/dm-call-activity";
+import { dmCallAnchorId } from "../src/lib/calls/dm-call-anchor";
 import { $mucCallMedia, $mucCallParticipants, clearMucCallParticipants } from "../src/lib/calls/muc-call-presence";
 import type { WaddleSession } from "../src/lib/server-auth";
 import { dmMessageFromArchived, roomMessageFromArchived } from "../src/lib/xmpp/wasm-message-codecs";
@@ -314,6 +315,37 @@ describe("call-thread anchor timeline mapping", () => {
 
     const timeline = fromLiveDmMessage(session, live!);
     expect(timeline.callThread).toEqual(live?.callThread);
+  });
+
+  test("DM archive codec aliases the call-thread anchor by sid for live dedup", () => {
+    const live = dmMessageFromArchived({
+      mam_id: "mam-dm-anchor-1",
+      id: "dm-anchor-1",
+      from: "bob@example.com/phone",
+      to: "alice@example.com/web",
+      message_type: "chat",
+      timestamp: "2026-06-07T14:30:00Z",
+      reaction_emojis: [],
+      is_muc: false,
+      thread: "dm-session-uuid",
+      markup_spans: [],
+      mention_uris: [],
+      references: [],
+      is_sticker: false,
+      shared_files: [],
+      link_previews: [],
+      call_thread: {
+        kind: "dm",
+        sid: "dm-session-uuid",
+        media: ["audio"],
+        initiator: "bob@example.com",
+        started: "2026-06-07T14:30:00Z",
+      },
+    }, "alice@example.com");
+
+    // The deterministic alias lets a same-session MAM backfill collapse onto
+    // the synthesized live anchor (same call sid) instead of duplicating it.
+    expect(live?.wireIds).toContain(dmCallAnchorId("dm-session-uuid"));
   });
 
   test("DM archive codec maps ended metadata and suppresses stale live activity", () => {

--- a/chat/tests/call-thread-anchor.test.ts
+++ b/chat/tests/call-thread-anchor.test.ts
@@ -241,6 +241,80 @@ describe("call-thread anchor timeline mapping", () => {
     });
   });
 
+  test("a DM anchor for the call you are in reads live with no busy/join action", () => {
+    // Production path: when the synthesized card appears you are in the call,
+    // so $callState is the active DM call for this peer+sid. The card must read
+    // "Live", not "In another call" (you are not in ANOTHER call) and not offer
+    // Join (you are already in it).
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com",
+        sid: "dm-live",
+        media: { audio: true, video: false },
+        state: "accepted",
+        direction: "outgoing",
+        updatedAt: "2026-06-07T14:31:00Z",
+      },
+    });
+    $callState.set({
+      phase: "active",
+      kind: "dm",
+      peer: "bob@example.com/desktop",
+      sid: "dm-live",
+      media: { audio: true, video: false },
+      join: { url: "wss://livekit.example", room: "dm-live", identity: "alice", token: "t" },
+      initiator: "alice@example.com/web",
+    });
+    const message = {
+      body: "",
+      author: "alice",
+      threadId: "dm-live",
+      callThread: {
+        kind: "dm" as const,
+        sid: "dm-live",
+        media: ["audio"] as ("audio" | "video")[],
+        initiator: "alice@example.com/web",
+        started: "2026-06-07T14:30:00Z",
+      },
+    };
+
+    expect(readCallAnchorCardState(message, "bob@example.com")).toMatchObject({
+      status: "live",
+      actionLabel: null,
+    });
+  });
+
+  test("a live DM anchor mislabels as ended without the wired peer JID", () => {
+    // Regression context for the ContentArea wiring fix: the card-state matcher
+    // keys on the conversation (peer) JID. With an empty JID it can't find the
+    // activity, so a live call wrongly renders ended — which is why ContentArea
+    // passes the DM peer JID as the card's `call-room-jid`.
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com",
+        sid: "dm-live",
+        media: { audio: true, video: false },
+        state: "accepted",
+        direction: "outgoing",
+        updatedAt: "2026-06-07T14:31:00Z",
+      },
+    });
+    const message = {
+      body: "",
+      author: "alice",
+      threadId: "dm-live",
+      callThread: {
+        kind: "dm" as const,
+        sid: "dm-live",
+        media: ["audio"] as ("audio" | "video")[],
+        initiator: "alice@example.com/web",
+        started: "2026-06-07T14:30:00Z",
+      },
+    };
+
+    expect(readCallAnchorCardState(message, "")).toMatchObject({ status: "ended" });
+  });
+
   test("room archive codec maps the WASM call-thread marker onto LiveRoomMessage", () => {
     const live = roomMessageFromArchived({
       mam_id: "mam-anchor-1",

--- a/chat/tests/call-thread-anchor.test.ts
+++ b/chat/tests/call-thread-anchor.test.ts
@@ -237,12 +237,15 @@ describe("call-thread anchor timeline mapping", () => {
       },
     };
 
-    expect(readCallAnchorCardState(message, "bob@example.com")).toMatchObject({
+    const card = readCallAnchorCardState(message, "bob@example.com");
+    expect(card).toMatchObject({
       status: "live",
       media: { audio: true, video: true },
       participantCount: 2,
       actionLabel: null,
     });
+    // The aria label must not promise a Join affordance the card doesn't show.
+    expect(card?.ariaLabel).not.toContain("Join");
   });
 
   test("a DM anchor for the call you are in reads live with no busy/join action", () => {

--- a/chat/tests/call-thread-anchor.test.ts
+++ b/chat/tests/call-thread-anchor.test.ts
@@ -209,7 +209,11 @@ describe("call-thread anchor timeline mapping", () => {
     });
   });
 
-  test("derives live DM anchor card state from peer and sid activity", () => {
+  test("derives live DM anchor card state from peer and sid activity, with no Join action", () => {
+    // A DM anchor is a 1:1 marker: even live (and even when the local call
+    // state is idle, e.g. a resumable call after reload) it must NOT offer the
+    // MUC "Join" affordance — that would fire a malformed group-call join
+    // against the peer JID. Answer/reconnect live in the call dock/banner.
     $dmCallActivities.set({
       "bob@example.com": {
         peerJid: "bob@example.com",
@@ -237,7 +241,7 @@ describe("call-thread anchor timeline mapping", () => {
       status: "live",
       media: { audio: true, video: true },
       participantCount: 2,
-      actionLabel: "Join",
+      actionLabel: null,
     });
   });
 

--- a/chat/tests/dm-call-anchor.test.ts
+++ b/chat/tests/dm-call-anchor.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import { buildDmCallStartedAnchor, dmCallAnchorId } from "../src/lib/calls/dm-call-anchor";
+import { isFeedTimelineMessage } from "../src/channels/timeline";
+import { buildDmTimelineFromMamResults } from "../src/dms/message-timeline-state";
+import type { LiveDmMessage } from "../src/lib/xmpp-client";
+import type { WaddleSession } from "../src/lib/server-auth";
+
+const base = {
+  peerBareJid: "bob@waddle.test",
+  sid: "sid-123",
+  media: { audio: true, video: false },
+  initiator: "alice@waddle.test/web",
+  started: "2026-06-09T12:00:00Z",
+};
+
+describe("dm call-started anchor", () => {
+  test("builds a feed-visible dm call anchor keyed by the call sid", () => {
+    const anchor = buildDmCallStartedAnchor(base, "alice@waddle.test/desktop");
+
+    expect(anchor.id).toBe(dmCallAnchorId("sid-123"));
+    expect(anchor.threadId).toBe("sid-123");
+    expect(anchor.callThread).toEqual({
+      kind: "dm",
+      sid: "sid-123",
+      media: ["audio"],
+      initiator: "alice@waddle.test/web",
+      started: "2026-06-09T12:00:00Z",
+    });
+    expect(anchor.createdAtSource).toBe("fallback");
+    // The initiator is the local user (same bare JID, different resource).
+    expect(anchor.isSelf).toBe(true);
+    // A call anchor is always feed-visible despite carrying a thread id.
+    expect(isFeedTimelineMessage(anchor)).toBe(true);
+  });
+
+  test("marks the anchor as remote when the peer is the initiator", () => {
+    const anchor = buildDmCallStartedAnchor(
+      { ...base, initiator: "bob@waddle.test/phone" },
+      "alice@waddle.test/desktop",
+    );
+
+    expect(anchor.isSelf).toBe(false);
+  });
+
+  test("includes video when the call carries it", () => {
+    const anchor = buildDmCallStartedAnchor(
+      { ...base, media: { audio: true, video: true } },
+      "alice@waddle.test/desktop",
+    );
+
+    expect(anchor.callThread?.media).toEqual(["audio", "video"]);
+  });
+
+  test("a MAM-replayed anchor dedups onto the synthesized live card by sid", () => {
+    const session = { jid: "alice@waddle.test/web", username: "alice" } as WaddleSession;
+    const synth = buildDmCallStartedAnchor(base, session.jid);
+
+    // The archived `<proceed/>` row carries a distinct primary id but is
+    // aliased by the call sid, so a same-session backfill must merge — not
+    // append a second "started a call" card.
+    const mamAnchor: LiveDmMessage = {
+      id: "proceed-stanza-id",
+      peerJid: "bob@waddle.test",
+      fromJid: "bob@waddle.test/phone",
+      nick: "bob",
+      body: "",
+      createdAt: "2026-06-09T12:00:05Z",
+      createdAtSource: "archive",
+      type: "message",
+      threadId: base.sid,
+      wireIds: [dmCallAnchorId(base.sid)],
+      callThread: {
+        kind: "dm",
+        sid: base.sid,
+        media: ["audio"],
+        initiator: base.initiator,
+        started: base.started,
+      },
+    };
+
+    const timeline = buildDmTimelineFromMamResults({
+      session,
+      mamResults: [mamAnchor],
+      existing: [synth],
+    });
+
+    expect(timeline.filter((m) => m.callThread)).toHaveLength(1);
+  });
+});

--- a/chat/tests/dm-call-anchor.test.ts
+++ b/chat/tests/dm-call-anchor.test.ts
@@ -176,6 +176,15 @@ describe("dm call-started anchor consumer guard", () => {
     ).toBeNull();
   });
 
+  test("matches the open conversation case-insensitively (JIDs are case-insensitive)", () => {
+    const card = resolveDmCallAnchorInjection(
+      { ...anchor, peerBareJid: "Bob@Waddle.Test" },
+      "bob@waddle.test",
+      "alice@waddle.test/web",
+    );
+    expect(card?.callThread?.sid).toBe("sid-1");
+  });
+
   test("returns null without a session or an open conversation", () => {
     expect(resolveDmCallAnchorInjection(anchor, null, "alice@waddle.test/web")).toBeNull();
     expect(resolveDmCallAnchorInjection(anchor, "bob@waddle.test", null)).toBeNull();

--- a/chat/tests/dm-call-anchor.test.ts
+++ b/chat/tests/dm-call-anchor.test.ts
@@ -1,9 +1,26 @@
 import { describe, expect, test } from "bun:test";
-import { buildDmCallStartedAnchor, dmCallAnchorId } from "../src/lib/calls/dm-call-anchor";
+import {
+  buildDmCallStartedAnchor,
+  dmCallAnchorId,
+  dmCallStartedAnchorFromTransition,
+  resolveDmCallAnchorInjection,
+} from "../src/lib/calls/dm-call-anchor";
 import { isFeedTimelineMessage } from "../src/channels/timeline";
 import { buildDmTimelineFromMamResults } from "../src/dms/message-timeline-state";
+import type { CallState } from "../src/lib/calls/types";
 import type { LiveDmMessage } from "../src/lib/xmpp-client";
 import type { WaddleSession } from "../src/lib/server-auth";
+
+const join = { url: "wss://livekit.waddle.test", room: "r", identity: "alice", token: "t" };
+const activeDmState = (sid: string, initiator?: string): CallState => ({
+  phase: "active",
+  kind: "dm",
+  peer: "bob@waddle.test/desktop",
+  sid,
+  media: { audio: true, video: false },
+  join,
+  ...(initiator ? { initiator } : {}),
+});
 
 const base = {
   peerBareJid: "bob@waddle.test",
@@ -85,5 +102,82 @@ describe("dm call-started anchor", () => {
     });
 
     expect(timeline.filter((m) => m.callThread)).toHaveLength(1);
+  });
+});
+
+describe("dm call-started anchor producer guard", () => {
+  test("publishes on the transition into an active 1:1 call", () => {
+    const anchor = dmCallStartedAnchorFromTransition(
+      { phase: "idle" },
+      activeDmState("sid-1", "alice@waddle.test/web"),
+      "2026-06-09T12:00:00Z",
+    );
+
+    expect(anchor).toEqual({
+      peerBareJid: "bob@waddle.test",
+      sid: "sid-1",
+      media: { audio: true, video: false },
+      initiator: "alice@waddle.test/web",
+      started: "2026-06-09T12:00:00Z",
+    });
+  });
+
+  test("does not re-publish on a media renegotiation of the same active call", () => {
+    expect(
+      dmCallStartedAnchorFromTransition(
+        activeDmState("sid-1", "alice@waddle.test/web"),
+        activeDmState("sid-1", "alice@waddle.test/web"),
+        "2026-06-09T12:00:01Z",
+      ),
+    ).toBeNull();
+  });
+
+  test("does not publish when the initiator is unknown", () => {
+    expect(
+      dmCallStartedAnchorFromTransition({ phase: "idle" }, activeDmState("sid-1"), "t"),
+    ).toBeNull();
+  });
+
+  test("does not publish for group calls or non-active transitions", () => {
+    const activeMuc: CallState = {
+      phase: "active",
+      kind: "muc",
+      peer: "room@muc.waddle.test",
+      sid: "sid-1",
+      media: { audio: true, video: false },
+      join,
+      selfNick: "alice",
+    };
+    expect(dmCallStartedAnchorFromTransition({ phase: "idle" }, activeMuc, "t")).toBeNull();
+    expect(
+      dmCallStartedAnchorFromTransition({ phase: "idle" }, { phase: "idle" }, "t"),
+    ).toBeNull();
+  });
+});
+
+describe("dm call-started anchor consumer guard", () => {
+  const anchor = {
+    peerBareJid: "bob@waddle.test",
+    sid: "sid-1",
+    media: { audio: true, video: false },
+    initiator: "alice@waddle.test/web",
+    started: "2026-06-09T12:00:00Z",
+  };
+
+  test("builds the card when the anchor belongs to the open conversation", () => {
+    const card = resolveDmCallAnchorInjection(anchor, "bob@waddle.test", "alice@waddle.test/web");
+    expect(card?.id).toBe(dmCallAnchorId("sid-1"));
+    expect(card?.callThread?.sid).toBe("sid-1");
+  });
+
+  test("isolates other DMs: a call with bob never injects into carol's open timeline", () => {
+    expect(
+      resolveDmCallAnchorInjection(anchor, "carol@waddle.test", "alice@waddle.test/web"),
+    ).toBeNull();
+  });
+
+  test("returns null without a session or an open conversation", () => {
+    expect(resolveDmCallAnchorInjection(anchor, null, "alice@waddle.test/web")).toBeNull();
+    expect(resolveDmCallAnchorInjection(anchor, "bob@waddle.test", null)).toBeNull();
   });
 });

--- a/chat/tests/dm-live-merge.test.ts
+++ b/chat/tests/dm-live-merge.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import { ref } from "vue";
 import { useDmLiveMerge } from "../src/dms/live-merge";
+import { buildDmCallStartedAnchor, dmCallAnchorId } from "../src/lib/calls/dm-call-anchor";
 import type { LiveDmMessage } from "../src/lib/xmpp-client";
 import type { WaddleSession } from "../src/lib/server-auth";
 import type { TimelineMessage } from "../src/lib/chat-ui";
@@ -330,5 +331,48 @@ describe("mergeLiveMessage self-echo reconciliation", () => {
     expect(h.messages.value).toHaveLength(1);
     expect(h.messages.value[0]?.deliveryStatus).toBe("delivered");
     expect(h.messages.value[0]?.linkPreviews).toBeUndefined();
+  });
+});
+
+describe("dm call-anchor dedup via the live-merge path", () => {
+  test("a MAM call anchor collapses onto the synthesized live card by sid alias", () => {
+    const h = harness();
+    // The live synthesized "started a call" card is already in the timeline.
+    const synth = buildDmCallStartedAnchor(
+      {
+        peerBareJid: "bob@example.com",
+        sid: "sid-x",
+        media: { audio: true, video: false },
+        initiator: "alice@example.com/desktop",
+        started: "2026-06-09T12:00:00Z",
+      },
+      session.jid,
+    );
+    h.messages.value = [synth];
+
+    // The archived `<proceed/>` row for the same call arrives via the live
+    // merge with a distinct primary id but the `dmcall:<sid>` wire alias.
+    const mamCard: TimelineMessage = {
+      id: "proceed-stanza-id",
+      wireIds: [dmCallAnchorId("sid-x")],
+      author: "bob",
+      authorJid: "bob@example.com/phone",
+      body: "",
+      createdAt: "2026-06-09T12:00:05Z",
+      createdAtSource: "archive",
+      isSelf: false,
+      threadId: "sid-x",
+      callThread: {
+        kind: "dm",
+        sid: "sid-x",
+        media: ["audio"],
+        initiator: "alice@example.com/desktop",
+        started: "2026-06-09T12:00:00Z",
+      },
+    };
+
+    h.liveMerge.mergeLiveMessage(mamCard);
+
+    expect(h.messages.value.filter((m) => m.callThread)).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

Starting a call did not surface the dedicated call chat. The call-chat
plumbing from #926/#928/#930 was only half-wired: it worked on MAM replay but
not live, and the in-call composer gate never accepted the real call shapes.
Three root-cause defects, each of which alone blocked the dedicated call chat
on call start:

- **Defect 1 — the DM anchor was never delivered live.** #930 enriched the
  archived XEP-0353 `<proceed/>` row only (inside `archive_direct`), so a DM
  call's "started a call" card appeared only after a reload/MAM catch-up. MUC,
  by contrast, broadcasts a live groupchat anchor.
- **Defect 2 — the in-call composer gate was hardcoded to MUC.**
  `CallExpandedSurface` gated `canShowCallChatComposer` on `kind === "muc"`, so
  a DM call could never render the composer even though the expanded surface
  mounts for DM.
- **Defect 3 — the MUC composer thread id never resolved.** The client's MUC
  `$callState.sid` is a client-generated `attemptId`, but the server anchor
  marker carries a throwaway server-side `SessionId`. The resolver required
  `callThread.sid === activeSid` — two independent UUIDs that never match, so
  the MUC card showed but the composer never did.

## What changed

All fixes are client-side; the server's #930 archive/inbox/ended logic is the
unchanged wire/interop source of truth.

1. **MUC composer resolves by room** (`call-chat-composer.ts`). The
   unsatisfiable sid match is replaced by "most recent non-ended `muc` anchor
   in the room timeline" (there is one active call per room). Fixes Defect 3.
2. **DM composer thread id derived from the call sid** (`call-chat-composer.ts`,
   `ContentArea.vue`). The server invariant `thread_id == key.sid.0 == sid`
   means the active call sid *is* the call-chat thread id, so the composer
   resolves live with no timeline dependency. (Defect 1, composer half.)
3. **Composer gate accepts DM** (`CallExpandedSurface.vue`). Gate on an active
   call + a resolved thread id for both kinds; bind the composer's `in-muc` to
   the call kind. Fixes Defect 2.
4. **DM "started a call" card synthesized live** (`dm-call-anchor.ts`, hook in
   `call-store.ts` `applyCallEvent`, consumed in `dms/messages.ts`). When a DM
   call goes active, a card is synthesized into the open conversation's live
   timeline. It roots its own call thread (`threadId == sid`) and uses a
   deterministic `dmcall:<sid>` id; the MAM-replayed archive row carries the
   same id as a wire alias (`wasm-message-codecs.ts`), so a same-session MAM
   backfill collapses onto the live card instead of duplicating it. On full
   reload only the MAM anchor remains. Fixes Defect 1 (card), live, without
   touching the server. The deterministic id is local-only and never serialized
   to the wire.

XEP posture: real call-chat replies still go out as normal XMPP DMs carrying
the XEP-0201 `<thread/>` = sid; the synthesized card is an in-memory UI
optimization that dedups against the MAM archive (the wire truth). The
`urn:waddle:call-thread:0` marker remains the only Waddle-specific extension.

## Verification

- `bun test` (chat) for the affected suites — call-chat-composer,
  call-thread-anchor, dm-call-anchor, dm-live-merge, plus a 196-test call/DM
  regression sweep: all green.
- `bun run lint` (knip via cuenv) clean; no new `vue-tsc` errors in touched
  files.
- Adversarial multi-persona review (correctness, architecture/XEP, test
  quality) plus a mutation-testing verification pass: every new test is
  load-bearing (the targeted mutation fails it), the producer/consumer guards
  are extracted into pure tested functions (`dmCallStartedAnchorFromTransition`,
  `resolveDmCallAnchorInjection`), and cross-DM isolation is covered.
- CI green: `waddle-chat-pullRequest`, CodeQL, Rust/Go analyze.

## Notes / known limits

- The "most recent non-ended `muc` anchor == active call" assumption can
  momentarily mis-bind the MUC composer if a prior call's XEP-0422 ended
  fastening was missed live and not yet reconciled from MAM. Documented in
  `resolveActiveMucCallThreadId`; it is a strict improvement over the prior sid
  match, which never resolved at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
