### PR TITLE
fix(chat): resolve channel in-call chat thread off the wire

### DIFF
--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -11,6 +11,7 @@ import { findMessageById } from "@/lib/message-ids";
 import { getReplyJumpNotice } from "@/lib/reply-ux";
 import { findThreadToAutoOpen } from "@/lib/thread-auto-open";
 import { activeCallChatThreadId } from "@/lib/calls/call-chat-composer";
+import { $mucCallThreadId } from "@/lib/calls/muc-call-thread";
 import { $callState } from "@/lib/calls/call-store";
 import {
   getPinnedScrollTop,
@@ -446,8 +447,14 @@ const callRoomJid = computed(() => props.roomJid ?? props.channel?.jid ?? null);
 const callAnchorConversationJid = computed(
   () => callRoomJid.value ?? props.dmPeer?.peerJid ?? null,
 );
+const mucCallThreadIds = useStore($mucCallThreadId);
 const activeCallThreadId = computed(() =>
-  activeCallChatThreadId(callState.value, props.messages, callRoomJid.value),
+  activeCallChatThreadId(
+    callState.value,
+    props.messages,
+    callRoomJid.value,
+    mucCallThreadIds.value,
+  ),
 );
 
 watch(

--- a/chat/src/lib/calls/call-chat-composer.ts
+++ b/chat/src/lib/calls/call-chat-composer.ts
@@ -1,5 +1,6 @@
 import type { CallThreadAnchor } from "@/lib/chat-ui";
 import { normalizeMucCallRoomJid } from "./muc-call-presence";
+import { readMucCallThread } from "./muc-call-thread";
 
 type CallThreadCandidate = {
   threadId?: string;
@@ -15,6 +16,8 @@ type ActiveCallChat = {
   phase: string;
   kind?: "dm" | "muc";
   sid?: string | null;
+  /** For MUC calls, the room bare JID (`$callState.peer`). */
+  peer?: string | null;
 };
 
 /**
@@ -68,6 +71,7 @@ export function activeCallChatThreadId(
   call: ActiveCallChat,
   messages: readonly CallThreadCandidate[],
   roomJid: string | null | undefined,
+  mucThreadIds: Record<string, string> = {},
 ): string | null {
   if (call.phase !== "active") return null;
   if (call.kind === "dm") {
@@ -75,7 +79,11 @@ export function activeCallChatThreadId(
     return sid ? sid : null;
   }
   if (call.kind === "muc") {
-    return resolveActiveMucCallThreadId(messages, roomJid);
+    // Prefer the wire-captured store (keyed by the call's room), which does not
+    // depend on the anchor being in the loaded timeline; fall back to the
+    // room-scoped timeline scan.
+    const stored = call.peer ? readMucCallThread(call.peer, mucThreadIds) : null;
+    return stored ?? resolveActiveMucCallThreadId(messages, roomJid);
   }
   return null;
 }

--- a/chat/src/lib/calls/muc-call-thread.ts
+++ b/chat/src/lib/calls/muc-call-thread.ts
@@ -1,0 +1,40 @@
+import { map } from "nanostores";
+import { normalizeMucCallRoomJid } from "./muc-call-presence";
+
+/**
+ * Normalized room JID → the active MUC call's XEP-0201 thread id, captured from
+ * the broadcast `urn:waddle:call-thread:0` anchor the moment it is received.
+ *
+ * The in-call composer reads from here so it can resolve the call-chat thread
+ * without the anchor message being present in the currently-loaded channel
+ * timeline (the anchor can be routed to notifications when it arrives before
+ * the room is "current", and the timeline window may not contain it).
+ */
+export const $mucCallThreadId = map<Record<string, string>>({});
+
+export function rememberMucCallThread(roomJid: string, threadId: string): void {
+  const room = normalizeMucCallRoomJid(roomJid);
+  const id = threadId.trim();
+  if (!room || !id) return;
+  if ($mucCallThreadId.get()[room] === id) return;
+  $mucCallThreadId.setKey(room, id);
+}
+
+export function forgetMucCallThread(roomJid: string): void {
+  const room = normalizeMucCallRoomJid(roomJid);
+  if (!room) return;
+  const current = $mucCallThreadId.get();
+  if (!(room in current)) return;
+  const next = { ...current };
+  delete next[room];
+  $mucCallThreadId.set(next);
+}
+
+export function readMucCallThread(
+  roomJid: string,
+  snapshot: Record<string, string> = $mucCallThreadId.get(),
+): string | null {
+  const room = normalizeMucCallRoomJid(roomJid);
+  if (!room) return null;
+  return snapshot[room] ?? null;
+}

--- a/chat/src/lib/calls/muc-call-thread.ts
+++ b/chat/src/lib/calls/muc-call-thread.ts
@@ -38,3 +38,10 @@ export function readMucCallThread(
   if (!room) return null;
   return snapshot[room] ?? null;
 }
+
+/** Drop all captured call-thread ids — on logout/disconnect, alongside the
+ *  other per-room call stores, so a stale entry can't outlive the session. */
+export function clearMucCallThreads(): void {
+  if (Object.keys($mucCallThreadId.get()).length === 0) return;
+  $mucCallThreadId.set({});
+}

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -12,7 +12,7 @@ import {
   type PersistedQueuedDmMessage,
 } from "../outbound-queue-store";
 import { $callState, applyCallEvent, clearCallState, tearDownActiveCall } from "@/lib/calls/call-store";
-import { forgetMucCallThread, rememberMucCallThread } from "@/lib/calls/muc-call-thread";
+import { clearMucCallThreads, forgetMucCallThread, rememberMucCallThread } from "@/lib/calls/muc-call-thread";
 import {
   DM_CALL_ACTIVITY_ACTIVE_WINDOW_MS,
   applyDmCallEvent,
@@ -1284,6 +1284,7 @@ export class BrowserXmppClient {
     clearDmCallJoinCacheForAccount(this.session.jid);
     clearDmCallActivities();
     clearMucCallParticipants();
+    clearMucCallThreads();
     clearAllLiveCallParticipants();
     // Best-effort hangup: if we're in a call when the user logs out
     // we want the peer to see session-terminate before the stream
@@ -3276,6 +3277,7 @@ export class BrowserXmppClient {
     // connected).
     clearCallState();
     clearMucCallParticipants();
+    clearMucCallThreads();
     clearAllLiveCallParticipants();
     void useCallEngine().engine.disconnect();
     this.rejectRoomJoinWaiters(new Error("XMPP disconnected while joining a room"));

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -12,6 +12,7 @@ import {
   type PersistedQueuedDmMessage,
 } from "../outbound-queue-store";
 import { $callState, applyCallEvent, clearCallState, tearDownActiveCall } from "@/lib/calls/call-store";
+import { forgetMucCallThread, rememberMucCallThread } from "@/lib/calls/muc-call-thread";
 import {
   DM_CALL_ACTIVITY_ACTIVE_WINDOW_MS,
   applyDmCallEvent,
@@ -3420,6 +3421,17 @@ export class BrowserXmppClient {
       const converted = roomMessageFromArchived({ ...message, mam_id: message.id ?? crypto.randomUUID() } as WasmArchivedMessage, "live", { trustedMediaOrigin: this.trustedLinkPreviewMediaOrigin() });
       if (!converted) return;
       this.catchup.recordRoomSeen(converted.roomJid, converted.createdAt, undefined, rawMessageSeenIds(message));
+      // Capture the MUC call-thread id off the wire, BEFORE the
+      // timeline-vs-activity routing below — the in-call composer resolves the
+      // call-chat thread from this store so it works even when the anchor is
+      // routed to notifications (room not yet "current") or has scrolled out
+      // of the loaded timeline window.
+      if (converted.callThread?.kind === "muc" && converted.threadId) {
+        rememberMucCallThread(converted.roomJid, converted.threadId);
+      }
+      if (converted.callThreadEnded) {
+        forgetMucCallThread(converted.roomJid);
+      }
       if (converted.roomJid !== this.currentRoom && isRoomActivityMessage(converted)) { this.activityHandler?.(roomActivityEventFromMessage(converted)); return; }
       this.messageHandler?.(converted); return;
     }
@@ -3643,6 +3655,14 @@ export class BrowserXmppClient {
       const converted = roomMessageFromArchived(message, { trustedMediaOrigin: this.trustedLinkPreviewMediaOrigin() });
       if (!converted || shouldSkipCatchupMessage(converted, since, seenIds)) continue;
       this.catchup.recordRoomSeen(converted.roomJid, converted.createdAt, converted.archiveId, messageSeenIds(converted));
+      // Keep the MUC call-thread store fresh on MAM catch-up too (e.g. reload
+      // mid-call), independent of timeline routing — see the live path.
+      if (converted.callThread?.kind === "muc" && converted.threadId) {
+        rememberMucCallThread(converted.roomJid, converted.threadId);
+      }
+      if (converted.callThreadEnded) {
+        forgetMucCallThread(converted.roomJid);
+      }
       if (converted.roomJid !== this.currentRoom && isRoomActivityMessage(converted)) {
         this.activityHandler?.(roomActivityEventFromMessage(converted));
       } else {

--- a/chat/tests/call-chat-composer.test.ts
+++ b/chat/tests/call-chat-composer.test.ts
@@ -119,6 +119,38 @@ describe("call-chat composer", () => {
     ).toBeNull();
   });
 
+  test("prefers the MUC call-thread store (keyed by the call's room) over the timeline", () => {
+    // The store is captured off the wire and does not depend on the anchor
+    // being in the loaded timeline, so it wins.
+    expect(
+      activeCallChatThreadId(
+        { phase: "active", kind: "muc", peer: ROOM, sid: "sid-fresh" },
+        [],
+        ROOM,
+        { [ROOM]: "stored-thread" },
+      ),
+    ).toBe("stored-thread");
+  });
+
+  test("falls back to the room timeline when the call-thread store is empty", () => {
+    const messages: TimelineMessage[] = [
+      message({
+        id: "active-call-anchor",
+        threadId: "call-thread-active",
+        callThread: { kind: "muc", sid: "sid-fresh", media: ["audio"] },
+      }),
+    ];
+
+    expect(
+      activeCallChatThreadId(
+        { phase: "active", kind: "muc", peer: ROOM, sid: "sid-fresh" },
+        messages,
+        ROOM,
+        {},
+      ),
+    ).toBe("call-thread-active");
+  });
+
   test("expanded channel calls render a labelled call-chat composer when a call thread is available", async () => {
     seedExpandedMucCall();
 

--- a/chat/tests/muc-call-thread.test.ts
+++ b/chat/tests/muc-call-thread.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  $mucCallThreadId,
+  forgetMucCallThread,
+  readMucCallThread,
+  rememberMucCallThread,
+} from "../src/lib/calls/muc-call-thread";
+
+describe("muc call-thread store", () => {
+  afterEach(() => $mucCallThreadId.set({}));
+
+  test("remembers a call thread id keyed by the normalized room jid", () => {
+    rememberMucCallThread("Lobby@MUC.example.com/alice", "thread-1");
+    expect(readMucCallThread("lobby@muc.example.com")).toBe("thread-1");
+  });
+
+  test("forgets the thread id (e.g. on the call-thread-ended fastening)", () => {
+    rememberMucCallThread("lobby@muc.example.com", "thread-1");
+    forgetMucCallThread("lobby@muc.example.com");
+    expect(readMucCallThread("lobby@muc.example.com")).toBeNull();
+  });
+
+  test("ignores an empty room or thread id", () => {
+    rememberMucCallThread("", "thread-1");
+    rememberMucCallThread("lobby@muc.example.com", "   ");
+    expect(readMucCallThread("lobby@muc.example.com")).toBeNull();
+  });
+
+  test("reads from a passed-in snapshot for reactive consumers", () => {
+    const snapshot = { "lobby@muc.example.com": "thread-9" };
+    expect(readMucCallThread("Lobby@MUC.example.com", snapshot)).toBe("thread-9");
+  });
+});

--- a/chat/tests/muc-call-thread.test.ts
+++ b/chat/tests/muc-call-thread.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
   $mucCallThreadId,
+  clearMucCallThreads,
   forgetMucCallThread,
   readMucCallThread,
   rememberMucCallThread,
@@ -29,5 +30,12 @@ describe("muc call-thread store", () => {
   test("reads from a passed-in snapshot for reactive consumers", () => {
     const snapshot = { "lobby@muc.example.com": "thread-9" };
     expect(readMucCallThread("Lobby@MUC.example.com", snapshot)).toBe("thread-9");
+  });
+
+  test("clears all entries on logout/disconnect", () => {
+    rememberMucCallThread("lobby@muc.example.com", "thread-1");
+    rememberMucCallThread("other@muc.example.com", "thread-2");
+    clearMucCallThreads();
+    expect($mucCallThreadId.get()).toEqual({});
   });
 });

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -1515,6 +1515,83 @@ async fn active_muji_presence_with_sfu_registers_call_thread_anchor() {
     );
 }
 
+// Diagnostic: registering the anchor (above) is not enough — the in-call
+// composer only resolves when the anchor MESSAGE actually reaches occupants'
+// timelines. This asserts the caller who starts the call receives the live
+// call-thread anchor broadcast on their own connection.
+#[tokio::test]
+async fn active_muji_presence_broadcasts_call_thread_anchor_to_caller() {
+    let recorder = std::sync::Arc::new(RecordingSfu::default());
+    let state = state_with_recording_sfu(std::sync::Arc::clone(&recorder)).await;
+    let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let room_jid: BareJid = "anchor-broadcast@muc.example.com".parse().expect("room jid");
+    let alice: FullJid = "alice@example.com/web".parse().expect("alice jid");
+
+    let (alice_tx, mut alice_rx) = mpsc::channel::<OutboundStanza>(32);
+    state
+        .deps
+        .protocol
+        .connection_registry
+        .register(alice.clone(), alice_tx);
+
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &alice,
+        "alice",
+        None,
+        &Some(owner_session.clone()),
+    )
+    .await;
+    while alice_rx.try_recv().is_ok() {}
+
+    let alice_phase = waddle_xmpp::protocol::ConnectionPhase::ready(alice.clone(), false);
+    let mut active = muc_presence_to(&room_jid, "alice");
+    active.payloads.push(active_muji().to_element());
+    let _ = handlers::presence::handle_presence(
+        active,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &alice_phase,
+        &Some(owner_session),
+    )
+    .await;
+
+    let mut anchor_seen = false;
+    while let Ok(out) = alice_rx.try_recv() {
+        let xml = stanza_to_xml(&out.stanza);
+        let Ok(element) = Element::from_str(&xml) else {
+            continue;
+        };
+        if element.name() != "message" {
+            continue;
+        }
+        if element
+            .get_child("call-thread", waddle_xmpp::xep::NS_WADDLE_CALL_THREAD)
+            .is_some()
+        {
+            anchor_seen = true;
+            assert_eq!(
+                element.attr("type"),
+                Some("groupchat"),
+                "anchor is a groupchat message"
+            );
+            assert_eq!(
+                element.attr("from"),
+                Some(room_jid.to_string().as_str()),
+                "anchor is from the room bare JID"
+            );
+        }
+    }
+
+    assert!(
+        anchor_seen,
+        "the caller must receive the live call-thread anchor broadcast on call start"
+    );
+}
+
 #[tokio::test]
 async fn resumed_muc_join_presence_replays_existing_muji_state() {
     let state = create_test_websocket_state().await;

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -1524,7 +1524,9 @@ async fn active_muji_presence_broadcasts_call_thread_anchor_to_caller() {
     let recorder = std::sync::Arc::new(RecordingSfu::default());
     let state = state_with_recording_sfu(std::sync::Arc::clone(&recorder)).await;
     let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
-    let room_jid: BareJid = "anchor-broadcast@muc.example.com".parse().expect("room jid");
+    let room_jid: BareJid = "anchor-broadcast@muc.example.com"
+        .parse()
+        .expect("room jid");
     let alice: FullJid = "alice@example.com/web".parse().expect("alice jid");
 
     let (alice_tx, mut alice_rx) = mpsc::channel::<OutboundStanza>(32);


### PR DESCRIPTION
## Problem

The in-call call-chat composer never appears for group (channel/MUC) calls —
no chat box in either the split or expanded call view. PR #931 fixed the
expanded-mode resolution logic, but the composer still can't resolve its
thread id because the resolution depends on the MUC call-thread **anchor
message** landing in the currently-loaded channel timeline, and it doesn't.

## Root cause

The MUC composer can only learn the call's server-generated XEP-0201 thread id
from the broadcast anchor message. That coupling is fragile:

- The server broadcasts the anchor correctly and routes it to every occupant —
  **proven** by a new test (`active_muji_presence_broadcasts_call_thread_anchor_to_caller`).
- On the client, `dispatchLiveBodyMessage` only appends a room message to the
  timeline when `converted.roomJid === this.currentRoom`; otherwise it routes
  the message to the notification/activity handler and it never reaches
  `props.messages`. During call setup the anchor can arrive before the room is
  "current", so the anchor is consumed as a notification and the composer's
  `resolveActiveMucCallThreadId(props.messages, …)` scan finds nothing.
- `resolveActiveMucCallThreadId` also returns null when `callRoomJid`
  (`props.roomJid ?? props.channel?.jid`) is momentarily empty, even if the
  anchor is loaded.

Net: no thread id → `canShowCallChatComposer` is false → no chat box, even in
the expanded view. (This is the MUC analogue of the DM live-anchor bug; for DM
the thread id equals the call sid so the client can derive it, but the MUC
thread id is server-generated and must be received.)

## Plan

1. **Capture the MUC call-thread id off the wire, decoupled from the timeline.**
   Add a `$mucCallThreadId` store (room JID → thread id). In
   `dispatchLiveBodyMessage`, when a live room message carries a `muc`
   call-thread anchor, remember `{roomJid → threadId}` **before** the
   timeline-vs-notification routing branch, so it's captured regardless of how
   the message is routed. Forget it on the call-thread-ended fastening.
2. **Resolve the composer thread id from the store, keyed by the active call's
   room** (`$callState.peer`, always set for an active MUC call), falling back
   to the timeline scan. This removes the dependency on the anchor being in the
   loaded window and on `callRoomJid`.
3. TDD: unit-test the store capture/forget and the resolver; keep the server
   broadcast-delivery test as the wire-contract regression guard.
4. (Follow-up consideration) surface the call chat in the split view too, so it
   works without expanding — tracked separately if in scope.
5. Adversarial review; knip/clippy/tests green; CI green.

## Verification

- `cargo test -p waddle-server active_muji_presence_broadcasts_call_thread_anchor_to_caller`
- `bun test` for the touched chat suites; `bun run lint` (knip)
- Manual: start a channel call, confirm the in-call chat box appears and sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
