### PR TITLE
ci(server): bump cuenv to 0.51.2 to fix the broken server image build

### DIFF
--- a/.github/workflows/waddle-chat-default.yml
+++ b/.github/workflows/waddle-chat-default.yml
@@ -80,7 +80,7 @@ jobs:
           aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
           *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
         esac
-        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.0/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
+        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.2/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: cuenv:contributor:bun.workspace.setup

--- a/.github/workflows/waddle-chat-publishwasm.yml
+++ b/.github/workflows/waddle-chat-publishwasm.yml
@@ -54,7 +54,7 @@ jobs:
           aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
           *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
         esac
-        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.0/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
+        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.2/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: cuenv:contributor:bun.workspace.setup

--- a/.github/workflows/waddle-chat-pullrequest.yml
+++ b/.github/workflows/waddle-chat-pullrequest.yml
@@ -78,7 +78,7 @@ jobs:
           aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
           *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
         esac
-        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.0/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
+        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.2/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: cuenv:contributor:bun.workspace.setup

--- a/.github/workflows/waddle-cloud-default.yml
+++ b/.github/workflows/waddle-cloud-default.yml
@@ -51,7 +51,7 @@ jobs:
           aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
           *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
         esac
-        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.0/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
+        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.2/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: 'Run pipeline: default'

--- a/.github/workflows/waddle-colony-default.yml
+++ b/.github/workflows/waddle-colony-default.yml
@@ -67,7 +67,7 @@ jobs:
           aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
           *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
         esac
-        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.0/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
+        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.2/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: cuenv:contributor:bun.workspace.setup

--- a/.github/workflows/waddle-colony-pullrequest.yml
+++ b/.github/workflows/waddle-colony-pullrequest.yml
@@ -62,7 +62,7 @@ jobs:
           aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
           *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
         esac
-        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.0/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
+        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.2/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: cuenv:contributor:bun.workspace.setup

--- a/.github/workflows/waddle-server-default.yml
+++ b/.github/workflows/waddle-server-default.yml
@@ -82,9 +82,15 @@ jobs:
           aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
           *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
         esac
-        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.0/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
+        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.2/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Upload cuenv
+      uses: actions/upload-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: result/bin/cuenv
+        if-no-files-found: error
   buildExtensionModules:
     name: buildExtensionModules
     runs-on: namespace-profile-linux-x86
@@ -108,17 +114,15 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Download cuenv
+      uses: actions/download-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: .cuenv-bootstrap
+    - name: Add cuenv to PATH
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.0/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        chmod +x .cuenv-bootstrap/cuenv
+        echo "$PWD/.cuenv-bootstrap" >> "$GITHUB_PATH"
     - name: buildExtensionModules
       run: cuenv task buildExtensionModules --skip-dependencies
       working-directory: server
@@ -158,17 +162,15 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Download cuenv
+      uses: actions/download-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: .cuenv-bootstrap
+    - name: Add cuenv to PATH
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.0/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        chmod +x .cuenv-bootstrap/cuenv
+        echo "$PWD/.cuenv-bootstrap" >> "$GITHUB_PATH"
     - name: checkCiDrift
       run: cuenv task checkCiDrift --skip-dependencies
       working-directory: server
@@ -197,17 +199,15 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Download cuenv
+      uses: actions/download-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: .cuenv-bootstrap
+    - name: Add cuenv to PATH
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.0/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        chmod +x .cuenv-bootstrap/cuenv
+        echo "$PWD/.cuenv-bootstrap" >> "$GITHUB_PATH"
     - name: checkRootSyncDrift
       run: cuenv task checkRootSyncDrift --skip-dependencies
       working-directory: server
@@ -236,17 +236,15 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Download cuenv
+      uses: actions/download-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: .cuenv-bootstrap
+    - name: Add cuenv to PATH
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.0/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        chmod +x .cuenv-bootstrap/cuenv
+        echo "$PWD/.cuenv-bootstrap" >> "$GITHUB_PATH"
     - name: checkXmppClientFfiBindings
       run: cuenv task checkXmppClientFfiBindings --skip-dependencies
       working-directory: server
@@ -275,17 +273,15 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Download cuenv
+      uses: actions/download-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: .cuenv-bootstrap
+    - name: Add cuenv to PATH
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.0/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        chmod +x .cuenv-bootstrap/cuenv
+        echo "$PWD/.cuenv-bootstrap" >> "$GITHUB_PATH"
     - name: clippy
       run: cuenv task clippy --skip-dependencies
       working-directory: server
@@ -314,17 +310,15 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Download cuenv
+      uses: actions/download-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: .cuenv-bootstrap
+    - name: Add cuenv to PATH
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.0/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        chmod +x .cuenv-bootstrap/cuenv
+        echo "$PWD/.cuenv-bootstrap" >> "$GITHUB_PATH"
     - name: fmt
       run: cuenv task fmt --skip-dependencies
       working-directory: server
@@ -358,17 +352,15 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Download cuenv
+      uses: actions/download-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: .cuenv-bootstrap
+    - name: Add cuenv to PATH
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.0/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        chmod +x .cuenv-bootstrap/cuenv
+        echo "$PWD/.cuenv-bootstrap" >> "$GITHUB_PATH"
     - name: publishContainerImage
       run: cuenv task publishContainerImage --skip-dependencies
       working-directory: server
@@ -409,17 +401,15 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Download cuenv
+      uses: actions/download-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: .cuenv-bootstrap
+    - name: Add cuenv to PATH
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.0/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        chmod +x .cuenv-bootstrap/cuenv
+        echo "$PWD/.cuenv-bootstrap" >> "$GITHUB_PATH"
     - name: renderDeployment
       run: cuenv task renderDeployment --skip-dependencies
       working-directory: server
@@ -448,17 +438,15 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Download cuenv
+      uses: actions/download-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: .cuenv-bootstrap
+    - name: Add cuenv to PATH
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.0/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        chmod +x .cuenv-bootstrap/cuenv
+        echo "$PWD/.cuenv-bootstrap" >> "$GITHUB_PATH"
     - name: test
       run: cuenv task test --skip-dependencies
       working-directory: server

--- a/.github/workflows/waddle-server-publish-tags-to-flakehub.yml
+++ b/.github/workflows/waddle-server-publish-tags-to-flakehub.yml
@@ -57,7 +57,7 @@ jobs:
           aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
           *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
         esac
-        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.0/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
+        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.2/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: 'Run pipeline: Publish tags to FlakeHub'

--- a/.github/workflows/waddle-server-pullrequest.yml
+++ b/.github/workflows/waddle-server-pullrequest.yml
@@ -79,9 +79,15 @@ jobs:
           aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
           *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
         esac
-        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.0/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
+        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.2/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Upload cuenv
+      uses: actions/upload-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: result/bin/cuenv
+        if-no-files-found: error
   checkCiDrift:
     name: checkCiDrift
     runs-on: namespace-profile-linux-x86
@@ -102,17 +108,15 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Download cuenv
+      uses: actions/download-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: .cuenv-bootstrap
+    - name: Add cuenv to PATH
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.0/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        chmod +x .cuenv-bootstrap/cuenv
+        echo "$PWD/.cuenv-bootstrap" >> "$GITHUB_PATH"
     - name: checkCiDrift
       run: cuenv task checkCiDrift --skip-dependencies
       working-directory: server
@@ -141,17 +145,15 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Download cuenv
+      uses: actions/download-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: .cuenv-bootstrap
+    - name: Add cuenv to PATH
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.0/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        chmod +x .cuenv-bootstrap/cuenv
+        echo "$PWD/.cuenv-bootstrap" >> "$GITHUB_PATH"
     - name: checkRootSyncDrift
       run: cuenv task checkRootSyncDrift --skip-dependencies
       working-directory: server
@@ -180,17 +182,15 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Download cuenv
+      uses: actions/download-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: .cuenv-bootstrap
+    - name: Add cuenv to PATH
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.0/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        chmod +x .cuenv-bootstrap/cuenv
+        echo "$PWD/.cuenv-bootstrap" >> "$GITHUB_PATH"
     - name: checkXmppClientFfiBindings
       run: cuenv task checkXmppClientFfiBindings --skip-dependencies
       working-directory: server
@@ -202,8 +202,6 @@ jobs:
   nixBuildCi:
     name: nixBuildCi
     runs-on: namespace-profile-linux-x86
-    needs:
-    - build-cuenv
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -230,8 +228,6 @@ jobs:
   nixBuildExtensionModules:
     name: nixBuildExtensionModules
     runs-on: namespace-profile-linux-x86
-    needs:
-    - build-cuenv
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -258,8 +254,6 @@ jobs:
   nixClippy:
     name: nixClippy
     runs-on: namespace-profile-linux-x86
-    needs:
-    - build-cuenv
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -286,8 +280,6 @@ jobs:
   nixFmt:
     name: nixFmt
     runs-on: namespace-profile-linux-x86
-    needs:
-    - build-cuenv
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -314,8 +306,6 @@ jobs:
   nixTest:
     name: nixTest
     runs-on: namespace-profile-linux-x86
-    needs:
-    - build-cuenv
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -359,17 +349,15 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Download cuenv
+      uses: actions/download-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: .cuenv-bootstrap
+    - name: Add cuenv to PATH
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.0/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        chmod +x .cuenv-bootstrap/cuenv
+        echo "$PWD/.cuenv-bootstrap" >> "$GITHUB_PATH"
     - name: renderDeployment
       run: cuenv task renderDeployment --skip-dependencies
       working-directory: server

--- a/.github/workflows/waddle-server-xmppcompliance.yml
+++ b/.github/workflows/waddle-server-xmppcompliance.yml
@@ -58,41 +58,9 @@ permissions:
   packages: read
   id-token: write
 jobs:
-  build-cuenv:
-    name: build.cuenv
-    runs-on: namespace-profile-linux-x86
-    timeout-minutes: 30
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 2
-    - name: Cache /nix on Namespace volume
-      uses: namespacelabs/nscloud-cache-action@v1
-      with:
-        cache: nix
-    - name: Hand /nix to the runner user
-      run: sudo chown -R runner /nix
-    - name: Install Nix
-      uses: cachix/install-nix-action@v31
-      with:
-        extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
-      run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.0/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   nixXmppServerTests:
     name: nixXmppServerTests
     runs-on: namespace-profile-linux-x86
-    needs:
-    - build-cuenv
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -119,8 +87,6 @@ jobs:
   nixXmppUnitTests:
     name: nixXmppUnitTests
     runs-on: namespace-profile-linux-x86
-    needs:
-    - build-cuenv
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -147,8 +113,6 @@ jobs:
   nixXmppXepIntegration:
     name: nixXmppXepIntegration
     runs-on: namespace-profile-linux-x86
-    needs:
-    - build-cuenv
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/waddle-website-default.yml
+++ b/.github/workflows/waddle-website-default.yml
@@ -71,7 +71,7 @@ jobs:
           aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
           *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
         esac
-        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.0/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
+        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.2/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: cuenv:contributor:bun.workspace.setup

--- a/.github/workflows/waddle-website-pullrequest.yml
+++ b/.github/workflows/waddle-website-pullrequest.yml
@@ -61,7 +61,7 @@ jobs:
           aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
           *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
         esac
-        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.0/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
+        curl -fsSL -o /usr/local/bin/cuenv "https://github.com/cuenv/cuenv/releases/download/0.51.2/${cuenv_asset}" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: cuenv:contributor:bun.workspace.setup

--- a/cue.mod/module.cue
+++ b/cue.mod/module.cue
@@ -4,11 +4,11 @@ language: {
 }
 deps: {
 	"github.com/cuenv/cuenv@v0": {
-		v: "v0.41.3"
+		v: "v0.51.2"
 	}
 }
 custom: {
 	"github.com/cuenv/cuenv": {
-		version: "0.51.0"
+		version: "0.51.2"
 	}
 }


### PR DESCRIPTION
Fixes the `waddle-server-default` image build that has failed since 2026-06-05 on a cuenv cache permission error (`Permission denied … cuenv@v0.41.3`), which is why no server image including the call-thread anchor work (#923+) was ever built/deployed.

Bumps both cuenv pins in `cue.mod/module.cue` to 0.51.2 and regenerates the server CI workflows (`cuenv sync ci`). The 0.51.2 generator builds cuenv from the nix flake and shares it as an artifact, so clippy/test no longer extract the stale `v0.41.3` module that hit the permission error.

**The server CI checks on this PR are the validation.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)