### PR TITLE
docs(calls): record session-scoped call audio decisions (glossary + ADR-010)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,41 @@
+# Waddle — Domain Glossary
+
+Terms with a precise meaning in this codebase. Keep entries
+implementation-free: what a thing *is*, not how it's built.
+
+## Calls
+
+### Active Call
+The single call the local user has currently joined. A user is in at
+most one Active Call at a time. Being in an Active Call is independent
+of which conversation they are viewing.
+
+### Originating Conversation
+The conversation a call belongs to: the channel (MUC room) where the
+call was started, or the DM pair for a 1:1 call. A call has exactly one
+Originating Conversation for its lifetime.
+
+### Session-bound audio (rule)
+An Active Call's audio follows the user across the entire app. The user
+hears the call regardless of which conversation, dashboard, or surface
+they are viewing, until they explicitly leave the call. Losing audio is
+never a side effect of navigation.
+
+### Membership-scoped visibility (rule)
+A call is visible and joinable only to members of its Originating
+Conversation. For a channel call, joining requires being a *current
+occupant* of the channel (present in the room at the moment of
+joining); for a DM call, only the two participants may join.
+Non-members must not be able to see that the call exists or obtain the
+means to join it. This must hold at the protocol level, not merely in
+what the UI shows.
+
+If a participant's membership ends involuntarily (kick or ban), their
+call participation ends with it. Transient connection loss is not a
+membership change and must never end call participation.
+
+### Call Surface
+A visible UI region rendering an ongoing call (participant tiles,
+controls). Call Surfaces are bound to the Originating Conversation's
+view and may come and go with navigation — unlike audio, which is
+session-bound.

--- a/docs/adr/010-session-scoped-call-audio.md
+++ b/docs/adr/010-session-scoped-call-audio.md
@@ -1,0 +1,80 @@
+# ADR-010: Session-Scoped Call Audio via a Single Persistent Sink
+
+## Status
+
+Accepted
+
+## Date
+
+2026-06-11
+
+## Context
+
+Joining a channel call and then navigating to any other view silenced
+the call: the user stayed connected (the LiveKit room lives in a
+process-wide singleton engine, and the mic kept publishing) but could
+no longer hear anyone.
+
+Root cause: the only `<audio>` elements playing remote call audio
+lived inside `CallTile.vue`, mounted by the per-conversation call
+surfaces (`CallSplitContainer` / `CallExpandedSurface`). Those
+surfaces render only when the *viewed* conversation is the call's
+Originating Conversation (`ownsMucCall` gating), and the whole page
+island unmounts on navigation (Astro view transitions persist only
+`XmppProvider` / `AppShell`). On unmount, the `:ref` callbacks detach
+the tracks and clear `srcObject` — by design, to keep LiveKit's
+`attachedElements` clean. Audio playback was therefore route-scoped
+while the call connection was session-scoped.
+
+History note: `CallOverlay.vue` once owned the entire call UI and was
+already persistent. The refactor that split presentation into
+per-channel surfaces moved audio playback with it and introduced this
+bug — evidence that the invariant is easy to break silently when it is
+not recorded.
+
+### Options considered
+
+- **(A) Tile-owned audio (status quo).** Audio elements live in
+  participant tiles. Rejected: ties hearing a call to viewing it;
+  violates the Session-bound audio rule (CONTEXT.md).
+- **(B) Dual sinks with handoff.** Tiles keep audio while a surface is
+  mounted; a global sink takes over on unmount. Rejected: every
+  navigation needs detach-here/attach-there choreography; any bug in
+  it yields silence (this bug again) or double-attach echo — the exact
+  failure class `tile-attach.ts` exists to prevent.
+- **(C) Single persistent sink.** One headless component in the
+  persistent layer owns all remote audio playback for the Active
+  Call's lifetime; tiles render video only. **Chosen.**
+
+## Decision
+
+Adopt **(C)**. Call audio playback is **session-scoped**: a headless
+`CallAudioSink` mounted in the persistent layer (`XmppProvider`, which
+carries `transition:persist`, next to `CallOverlay`) owns hidden
+`<audio>` elements for **all** subscribed remote audio tracks
+(screen-share audio included), reusing the `TileAttachments`
+reconciler. `CallTile` renders video and nameplate only.
+
+**Invariant: anything required to keep Session-bound audio true must
+live in the persistent layer, never in a route-scoped surface.** This
+covers both the audio sink and the means to unblock it — the
+autoplay-blocked recovery prompt (`CallAudioPlaybackPrompt`, which
+drives `room.startAudio()`) is likewise mounted once in the persistent
+layer and removed from the call surfaces.
+
+Per-participant volume is unaffected: the mixer applies
+`track.setVolume()`, which is element-agnostic.
+
+## Consequences
+
+- Users keep hearing an Active Call across every view; losing audio is
+  never a side effect of navigation (Session-bound audio rule,
+  CONTEXT.md).
+- Future contributors must not "simplify" audio back into participant
+  tiles, even though upstream LiveKit examples attach audio there —
+  that reintroduces this bug. This ADR is the guard.
+- Call surfaces become pure decoration: they may mount and unmount
+  freely without touching audio machinery.
+- Companion protocol rule (not this ADR's subject): call joinability is
+  occupancy-gated server-side at LiveKit token mint, and involuntary
+  MUC removal evicts the participant from the SFU call (#935).


### PR DESCRIPTION
## What this PR is

The decision record for the call-audio-on-navigation bug. Docs only — no code changes. The implementation is broken into tracer-bullet issues (below); each slice references the rules and ADR landed here.

- `CONTEXT.md` (new) — domain glossary for calls: **Active Call**, **Originating Conversation**, **Call Surface**, and two rules: **Session-bound audio** (an Active Call's audio follows the user across the app; losing audio is never a side effect of navigation) and **Membership-scoped visibility** (occupancy-gated join, enforced at protocol level; involuntary removal ends call participation, connection loss never does).
- `docs/adr/010-session-scoped-call-audio.md` — call audio playback is session-scoped, owned by a single persistent sink; tiles render video only. Records the rejected alternatives (tile-owned audio, dual-sink handoff) and the invariant that audio machinery — sink and unblock prompt — lives only in the persistent layer.

## Root cause (summary)

The only `<audio>` elements playing call audio lived in participant tiles inside the per-conversation call surfaces, which render only when the viewed room owns the call and which fully unmount on navigation. Unmount actively detaches the tracks. The call connection (singleton engine) and mic survive navigation — audio playback did not.

A second, protocol-level gap was found while scoping the fix: the Muji join path mints LiveKit tokens without checking room occupancy.

## Implementation slices

| Issue | Slice |
|---|---|
| #937 | Session-bound call audio via persistent `CallAudioSink`; tiles go video-only |
| #939 | Audio-blocked recovery banner reachable from every view (blocked by #937) |
| #938 | Occupancy-gate the Muji LiveKit join token mint |
| #940 | Audit the 1:1 DM token path for third-party minting (blocked by #938) |
| #935 | Evict SFU call participants on involuntary MUC removal (blocked by #938) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
