### PR TITLE
fix(chat): keep active call audio alive across navigation

### DIFF
--- a/chat/src/components/AppShell.vue
+++ b/chat/src/components/AppShell.vue
@@ -2,6 +2,7 @@
 import { onBeforeUnmount } from "vue";
 import LandingState from "@/components/chat/LandingState.vue";
 import LoginScreen from "@/components/chat/LoginScreen.vue";
+import CallAudioSink from "@/components/calls/CallAudioSink.vue";
 import { useChatAppController } from "@/shell/chat-app-controller";
 import { appController } from "@/stores/app-controller";
 
@@ -55,5 +56,8 @@ onBeforeUnmount(() => {
     module-level store to access shared connection / channel / unread
     state without prop drilling across separate Astro islands.
   -->
-  <slot v-else />
+  <template v-else>
+    <CallAudioSink />
+    <slot />
+  </template>
 </template>

--- a/chat/src/components/calls/CallAudioSink.vue
+++ b/chat/src/components/calls/CallAudioSink.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount } from "vue";
+import { computed, onBeforeUnmount, watch } from "vue";
 import {
   CallAudioSinkAttachments,
   callAudioSinkTrackKey,
@@ -11,13 +11,29 @@ import { useCallEngine } from "@/lib/calls/use-call-engine";
 const { remoteTracks } = useCallEngine();
 const audioTracks = computed(() => callAudioSinkTracks(remoteTracks.value));
 const attachments = new CallAudioSinkAttachments();
+const audioRefs = new Map<string, { track: CallAudioSinkTrack; ref: (el: Element | null) => void }>();
 
-function refAudio(track: CallAudioSinkTrack, el: Element | null): void {
-  attachments.sync(track, el instanceof HTMLAudioElement ? el : null);
+function audioRef(track: CallAudioSinkTrack): (el: Element | null) => void {
+  const key = callAudioSinkTrackKey(track);
+  const existing = audioRefs.get(key);
+  if (existing?.track === track) return existing.ref;
+  const ref = (el: Element | null) => {
+    attachments.sync(track, el instanceof HTMLAudioElement ? el : null);
+  };
+  audioRefs.set(key, { track, ref });
+  return ref;
 }
+
+watch(audioTracks, (tracks) => {
+  const liveKeys = new Set(tracks.map(callAudioSinkTrackKey));
+  for (const key of audioRefs.keys()) {
+    if (!liveKeys.has(key)) audioRefs.delete(key);
+  }
+});
 
 onBeforeUnmount(() => {
   attachments.detachAll();
+  audioRefs.clear();
 });
 </script>
 
@@ -26,7 +42,7 @@ onBeforeUnmount(() => {
     <audio
       v-for="track in audioTracks"
       :key="callAudioSinkTrackKey(track)"
-      :ref="(el) => refAudio(track, el)"
+      :ref="audioRef(track)"
       autoplay
     />
   </div>

--- a/chat/src/components/calls/CallAudioSink.vue
+++ b/chat/src/components/calls/CallAudioSink.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount } from "vue";
+import {
+  CallAudioSinkAttachments,
+  callAudioSinkTrackKey,
+  callAudioSinkTracks,
+  type CallAudioSinkTrack,
+} from "@/lib/calls/call-audio-sink";
+import { useCallEngine } from "@/lib/calls/use-call-engine";
+
+const { remoteTracks } = useCallEngine();
+const audioTracks = computed(() => callAudioSinkTracks(remoteTracks.value));
+const attachments = new CallAudioSinkAttachments();
+
+function refAudio(track: CallAudioSinkTrack, el: Element | null): void {
+  attachments.sync(track, el instanceof HTMLAudioElement ? el : null);
+}
+
+onBeforeUnmount(() => {
+  attachments.detachAll();
+});
+</script>
+
+<template>
+  <div class="call-audio-sink" aria-hidden="true">
+    <audio
+      v-for="track in audioTracks"
+      :key="callAudioSinkTrackKey(track)"
+      :ref="(el) => refAudio(track, el)"
+      autoplay
+    />
+  </div>
+</template>
+
+<style scoped>
+.call-audio-sink {
+  display: none;
+}
+</style>

--- a/chat/src/components/calls/CallTile.vue
+++ b/chat/src/components/calls/CallTile.vue
@@ -24,10 +24,7 @@ import type { TileAttachable } from "@/lib/calls/tile-attach";
 const props = withDefaults(defineProps<{
   /** Human label rendered in the nameplate and derived into initials. */
   label: string;
-  /** Stable identity-derived key namespace for `TileAttachments.sync`.
-   *  The tile builds `${attachKey}:video` / `${attachKey}:audio` so
-   *  one attachments map can host video and audio for the same
-   *  participant without collision. */
+  /** Stable identity-derived key namespace for `TileAttachments.sync`. */
   attachKey: string;
   /** Whether this tile represents the local participant. */
   isSelf: boolean;
@@ -42,10 +39,8 @@ const props = withDefaults(defineProps<{
   /** Optional video track to render. When `null`, the placeholder
    *  layer shows through unchanged. */
   videoTrack: TileAttachable | null;
-  /** Optional remote audio track. Self-tiles never play audio (echo). */
-  audioTrack: TileAttachable | null;
   /** Parent's attach reconciler — see `tile-attach.ts`. The tile
-   *  invokes this from its `<video>` / `<audio>` ref callbacks. */
+   *  invokes this from its `<video>` ref callback. */
   attach: (key: string, el: HTMLMediaElement | null, track: TileAttachable | null) => void;
   interactive?: boolean;
 }>(), {
@@ -75,14 +70,6 @@ function refVideo(el: Element | null): void {
     `${props.attachKey}:video`,
     el instanceof HTMLVideoElement ? el : null,
     props.videoTrack,
-  );
-}
-
-function refAudio(el: Element | null): void {
-  props.attach(
-    `${props.attachKey}:audio`,
-    el instanceof HTMLAudioElement ? el : null,
-    props.audioTrack,
   );
 }
 
@@ -129,12 +116,6 @@ const emit = defineEmits<{
       autoplay
       playsinline
       :muted="isSelf"
-    />
-
-    <audio
-      v-if="audioTrack && !isSelf"
-      :ref="refAudio"
-      autoplay
     />
 
     <!-- Persistent nameplate — same look whether a video is playing

--- a/chat/src/components/calls/CallTileGrid.vue
+++ b/chat/src/components/calls/CallTileGrid.vue
@@ -173,7 +173,6 @@ const gridStyle = computed(() => ({
           :shows-presenting-glyph="focusedTile.showsPresentingGlyph"
           :mic-enabled="focusedTile.micEnabledHint"
           :video-track="focusedTile.videoTrack"
-          :audio-track="focusedTile.audioTrack"
           :attach="attach"
           class="call-tile--focused"
           @activate="toggleFocus(focusedTile)"
@@ -190,7 +189,6 @@ const gridStyle = computed(() => ({
           :shows-presenting-glyph="tile.showsPresentingGlyph"
           :mic-enabled="tile.micEnabledHint"
           :video-track="tile.videoTrack"
-          :audio-track="tile.audioTrack"
           :attach="attach"
           class="call-tile--thumb"
           @activate="toggleFocus(tile)"
@@ -218,7 +216,6 @@ const gridStyle = computed(() => ({
         :shows-presenting-glyph="tile.showsPresentingGlyph"
         :mic-enabled="tile.micEnabledHint"
         :video-track="tile.videoTrack"
-        :audio-track="tile.audioTrack"
         :attach="attach"
         @activate="toggleFocus(tile)"
       />

--- a/chat/src/lib/calls/call-audio-sink.ts
+++ b/chat/src/lib/calls/call-audio-sink.ts
@@ -23,10 +23,6 @@ export class CallAudioSinkAttachments {
     this.attachments.sync(callAudioSinkTrackKey(track), el, track.track);
   }
 
-  detach(track: CallAudioSinkTrack): void {
-    this.attachments.sync(callAudioSinkTrackKey(track), null, null);
-  }
-
   detachAll(): void {
     this.attachments.detachAll();
   }

--- a/chat/src/lib/calls/call-audio-sink.ts
+++ b/chat/src/lib/calls/call-audio-sink.ts
@@ -1,0 +1,42 @@
+import type { RemoteMediaTrack } from "./engine";
+import { TileAttachments } from "./tile-attach";
+
+export type CallAudioSinkTrack = RemoteMediaTrack & {
+  kind: "audio";
+  source: "microphone" | "screen_share_audio";
+};
+
+export function callAudioSinkTracks(
+  remoteTracks: readonly RemoteMediaTrack[],
+): CallAudioSinkTrack[] {
+  return remoteTracks.filter(isCallAudioSinkTrack);
+}
+
+export function callAudioSinkTrackKey(track: CallAudioSinkTrack): string {
+  return `call-audio:${track.participantIdentity}:${track.publicationSid}`;
+}
+
+export class CallAudioSinkAttachments {
+  private readonly attachments = new TileAttachments();
+
+  sync(track: CallAudioSinkTrack, el: HTMLMediaElement | null): void {
+    this.attachments.sync(callAudioSinkTrackKey(track), el, track.track);
+  }
+
+  detach(track: CallAudioSinkTrack): void {
+    this.attachments.sync(callAudioSinkTrackKey(track), null, null);
+  }
+
+  detachAll(): void {
+    this.attachments.detachAll();
+  }
+
+  size(): number {
+    return this.attachments.size();
+  }
+}
+
+function isCallAudioSinkTrack(track: RemoteMediaTrack): track is CallAudioSinkTrack {
+  return track.kind === "audio" &&
+    (track.source === "microphone" || track.source === "screen_share_audio");
+}

--- a/chat/src/lib/calls/call-tiles.ts
+++ b/chat/src/lib/calls/call-tiles.ts
@@ -14,7 +14,6 @@ export type CallTileModel = {
   showsPresentingGlyph: boolean;
   micEnabledHint: boolean;
   videoTrack: TileAttachable | null;
-  audioTrack: TileAttachable | null;
 };
 
 export type BuildCallTilesInput = {
@@ -63,7 +62,6 @@ function newTile(
     showsPresentingGlyph: source === "screen_share",
     micEnabledHint: isSelf ? micEnabled : true,
     videoTrack: null,
-    audioTrack: null,
   };
 }
 
@@ -80,7 +78,6 @@ export function buildCallTiles(input: BuildCallTilesInput): CallTileModel[] {
       existing.videoTrack = local.track;
       if (source === "screen_share") existing.screenTrackKey = local.publicationSid;
     }
-    if (local.kind === "audio") existing.audioTrack = local.track;
     byKey.set(key, existing);
   }
 
@@ -92,7 +89,6 @@ export function buildCallTiles(input: BuildCallTilesInput): CallTileModel[] {
       existing.videoTrack = remote.track;
       if (source === "screen_share") existing.screenTrackKey = remote.publicationSid;
     }
-    if (remote.kind === "audio") existing.audioTrack = remote.track;
     byKey.set(key, existing);
   }
 

--- a/chat/tests/call-audio-sink.test.ts
+++ b/chat/tests/call-audio-sink.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CallAudioSinkAttachments,
+  callAudioSinkTrackKey,
+  callAudioSinkTracks,
+  type CallAudioSinkTrack,
+} from "../src/lib/calls/call-audio-sink";
+import type { RemoteMediaTrack } from "../src/lib/calls/engine";
+
+type FakeAttachableTrack = {
+  attached: HTMLMediaElement[];
+  attach: (el: HTMLMediaElement) => void;
+  detach: (el: HTMLMediaElement) => HTMLMediaElement;
+};
+
+class FakeHTMLAudioElement {
+  srcObject: unknown = null;
+}
+
+const globalRef = globalThis as unknown as {
+  HTMLAudioElement: typeof FakeHTMLAudioElement;
+  HTMLMediaElement: typeof FakeHTMLAudioElement;
+};
+if (typeof globalRef.HTMLAudioElement === "undefined") {
+  globalRef.HTMLAudioElement = FakeHTMLAudioElement;
+}
+if (typeof globalRef.HTMLMediaElement === "undefined") {
+  globalRef.HTMLMediaElement = FakeHTMLAudioElement;
+}
+
+function fakeAttachableTrack(): FakeAttachableTrack {
+  const attached: HTMLMediaElement[] = [];
+  return {
+    attached,
+    attach(el) {
+      attached.push(el);
+    },
+    detach(el) {
+      const index = attached.indexOf(el);
+      if (index >= 0) attached.splice(index, 1);
+      return el;
+    },
+  };
+}
+
+function fakeAudioEl(): HTMLMediaElement {
+  return new FakeHTMLAudioElement() as unknown as HTMLMediaElement;
+}
+
+function remoteTrack(
+  publicationSid: string,
+  kind: "audio" | "video",
+  source: RemoteMediaTrack["source"],
+  track: unknown = fakeAttachableTrack(),
+): RemoteMediaTrack {
+  return {
+    participantIdentity: "alice@example.com/web",
+    publicationSid,
+    kind,
+    source,
+    track: track as never,
+  };
+}
+
+describe("CallAudioSink", () => {
+  test("owns microphone and screen-share audio tracks", () => {
+    const tracks = callAudioSinkTracks([
+      remoteTrack("camera", "video", "camera"),
+      remoteTrack("mic", "audio", "microphone"),
+      remoteTrack("screen", "video", "screen_share"),
+      remoteTrack("screen-audio", "audio", "screen_share_audio"),
+    ]);
+
+    expect(tracks.map((track) => track.publicationSid)).toEqual(["mic", "screen-audio"]);
+  });
+
+  test("keys audio elements by participant and publication", () => {
+    const track = remoteTrack("mic", "audio", "microphone") as CallAudioSinkTrack;
+
+    expect(callAudioSinkTrackKey(track)).toBe("call-audio:alice@example.com/web:mic");
+  });
+
+  test("keeps sink-owned audio attached while call surfaces unmount and remount", () => {
+    const sink = new CallAudioSinkAttachments();
+    const track = fakeAttachableTrack();
+    const audio = remoteTrack("mic", "audio", "microphone", track) as CallAudioSinkTrack;
+    const el = fakeAudioEl();
+
+    sink.sync(audio, el);
+    // Simulates navigating away from the conversation call surface:
+    // no sink ref update happens, so playback remains owned here.
+    expect(track.attached).toEqual([el]);
+    expect(sink.size()).toBe(1);
+
+    // Simulates returning to the conversation and remounting tiles:
+    // the sink sees the same audio element/track pair and must not
+    // attach a duplicate playback element.
+    sink.sync(audio, el);
+    expect(track.attached).toEqual([el]);
+    expect(sink.size()).toBe(1);
+  });
+
+  test("detaches playback when call-end removes audio tracks", () => {
+    const sink = new CallAudioSinkAttachments();
+    const track = fakeAttachableTrack();
+    const audio = remoteTrack("mic", "audio", "microphone", track) as CallAudioSinkTrack;
+    const el = fakeAudioEl();
+    el.srcObject = { stream: true };
+
+    sink.sync(audio, el);
+    sink.detach(audio);
+
+    expect(track.attached).toEqual([]);
+    expect(el.srcObject).toBeNull();
+    expect(sink.size()).toBe(0);
+  });
+
+  test("detaches every audio element when the persistent sink unmounts", () => {
+    const sink = new CallAudioSinkAttachments();
+    const micTrack = fakeAttachableTrack();
+    const shareTrack = fakeAttachableTrack();
+    const mic = remoteTrack("mic", "audio", "microphone", micTrack) as CallAudioSinkTrack;
+    const share = remoteTrack("screen-audio", "audio", "screen_share_audio", shareTrack) as CallAudioSinkTrack;
+    const micEl = fakeAudioEl();
+    const shareEl = fakeAudioEl();
+
+    sink.sync(mic, micEl);
+    sink.sync(share, shareEl);
+    sink.detachAll();
+
+    expect(micTrack.attached).toEqual([]);
+    expect(shareTrack.attached).toEqual([]);
+    expect(sink.size()).toBe(0);
+  });
+});

--- a/chat/tests/call-audio-sink.test.ts
+++ b/chat/tests/call-audio-sink.test.ts
@@ -108,7 +108,7 @@ describe("CallAudioSink", () => {
     el.srcObject = { stream: true };
 
     sink.sync(audio, el);
-    sink.detach(audio);
+    sink.sync(audio, null);
 
     expect(track.attached).toEqual([]);
     expect(el.srcObject).toBeNull();

--- a/chat/tests/call-grid-layout.test.ts
+++ b/chat/tests/call-grid-layout.test.ts
@@ -136,7 +136,7 @@ describe("buildCallTiles", () => {
     expect(tiles.filter((tile) => tile.identity === "bob@waddle.test/laptop")).toHaveLength(2);
   });
 
-  test("groups microphone audio with camera and screen-share audio with screen", () => {
+  test("keeps microphone and screen-share audio out of tile models", () => {
     const tiles = buildCallTiles({
       remoteTracks: [
         remoteVideo("cam-pub", "camera"),
@@ -153,8 +153,8 @@ describe("buildCallTiles", () => {
       "remote:bob@waddle.test/laptop:camera",
       "remote:bob@waddle.test/laptop:screen_share",
     ]);
-    expect(tiles[0]?.audioTrack).not.toBeNull();
-    expect(tiles[1]?.audioTrack).not.toBeNull();
+    expect("audioTrack" in (tiles[0] ?? {})).toBe(false);
+    expect("audioTrack" in (tiles[1] ?? {})).toBe(false);
   });
 
   test("mirrors local camera previews but not local screen-share previews", () => {

--- a/chat/tests/call-tile-projection.test.ts
+++ b/chat/tests/call-tile-projection.test.ts
@@ -13,7 +13,6 @@ const fakeTrack = {} as never;
 
 describe("call tile projection", () => {
   test("projects a remote camera and screen share as distinct tiles", () => {
-    const screenAudioTrack = {} as never;
     const tiles = buildCallTiles({
       remoteTracks: [
         {
@@ -35,7 +34,7 @@ describe("call tile projection", () => {
           publicationSid: "screen-audio",
           kind: "audio",
           source: "screen_share_audio",
-          track: screenAudioTrack,
+          track: fakeTrack,
         },
       ],
       localTracks: [],
@@ -76,8 +75,8 @@ describe("call tile projection", () => {
         showsPresentingGlyph: true,
       },
     ]);
-    expect(tiles.find((tile) => tile.key === "remote:alice@example.com/web:screen_share")?.audioTrack)
-      .toBe(screenAudioTrack);
+    const screenTile = tiles.find((tile) => tile.key === "remote:alice@example.com/web:screen_share");
+    expect(screenTile && "audioTrack" in screenTile).toBe(false);
   });
 
   test("projects local camera and screen share with separate mirror decisions", () => {
@@ -139,7 +138,6 @@ describe("call tile projection", () => {
       showsPresentingGlyph: true,
       micEnabled: true,
       videoTrack: null,
-      audioTrack: null,
       attach: () => undefined,
     });
 
@@ -157,7 +155,6 @@ describe("call tile projection", () => {
       showsPresentingGlyph: true,
       micEnabled: true,
       videoTrack: null,
-      audioTrack: null,
       attach: () => undefined,
       interactive: false,
     });
@@ -171,6 +168,12 @@ describe("call tile projection", () => {
   test("forwards the presenting glyph flag in every grid branch", () => {
     const source = readFileSync(new URL("../src/components/calls/CallTileGrid.vue", import.meta.url), "utf8");
     expect(source.match(/:shows-presenting-glyph=/g)?.length).toBe(3);
+  });
+
+  test("call tiles do not render audio elements", () => {
+    const source = readFileSync(new URL("../src/components/calls/CallTile.vue", import.meta.url), "utf8");
+    expect(source).not.toContain("<audio");
+    expect(source).not.toContain("audioTrack");
   });
 });
 


### PR DESCRIPTION
## Summary

Implements #937.

- Added a persistent, headless `CallAudioSink` under `AppShell`, the navigation-surviving chat shell.
- Moved subscribed remote audio playback ownership to that sink for both participant microphones and screen-share audio.
- Removed tile-local audio playback: call tiles now render video/nameplate only, so returning to a call surface cannot create duplicate audio elements.
- Kept per-participant volume on the existing engine-level per-track `setVolume` path, independent of playback element ownership.
- Added behavioral sink lifecycle tests for stable single attachment across call-surface unmount/remount, call-end detach, and full sink unmount detach.

## Review feedback addressed

- Cached `CallAudioSink` function refs per audio track key so unchanged audio elements are not detached and reattached on unrelated renders.
- Removed the unused `CallAudioSinkAttachments.detach()` helper and kept call-end cleanup on the same `sync(track, null)` path Vue uses when audio refs unmount.

## XEP review

- Reviewed local XEP-0166, XEP-0167, and XEP-0272 context. This change does not alter XMPP/Jingle/MUJI stanzas or namespaces; it only changes browser playback ownership for already-negotiated LiveKit media tracks.

## Verification

- `bun test` in `chat/` — 1957 pass, 0 fail.
- `bun run lint` in `chat/` — clean, including knip; no orphaned exports/files from tile audio removal.
- `bun run build` in `chat/` — clean build; Astro check reports 0 errors and one existing hint in `src/lib/xmpp/discovery.ts` about an async conversion opportunity.

## Not tested

- Manual browser call across real LiveKit participants.