### PR TITLE
fix(chat): make audio recovery app-level

### DIFF
--- a/chat/src/components/AppShell.vue
+++ b/chat/src/components/AppShell.vue
@@ -2,6 +2,7 @@
 import { onBeforeUnmount } from "vue";
 import LandingState from "@/components/chat/LandingState.vue";
 import LoginScreen from "@/components/chat/LoginScreen.vue";
+import CallAudioPlaybackPrompt from "@/components/calls/CallAudioPlaybackPrompt.vue";
 import CallAudioSink from "@/components/calls/CallAudioSink.vue";
 import { useChatAppController } from "@/shell/chat-app-controller";
 import { appController } from "@/stores/app-controller";
@@ -57,6 +58,7 @@ onBeforeUnmount(() => {
     state without prop drilling across separate Astro islands.
   -->
   <template v-else>
+    <CallAudioPlaybackPrompt />
     <CallAudioSink />
     <slot />
   </template>

--- a/chat/src/components/AppShell.vue
+++ b/chat/src/components/AppShell.vue
@@ -2,7 +2,6 @@
 import { onBeforeUnmount } from "vue";
 import LandingState from "@/components/chat/LandingState.vue";
 import LoginScreen from "@/components/chat/LoginScreen.vue";
-import CallAudioPlaybackPrompt from "@/components/calls/CallAudioPlaybackPrompt.vue";
 import CallAudioSink from "@/components/calls/CallAudioSink.vue";
 import { useChatAppController } from "@/shell/chat-app-controller";
 import { appController } from "@/stores/app-controller";
@@ -58,7 +57,6 @@ onBeforeUnmount(() => {
     state without prop drilling across separate Astro islands.
   -->
   <template v-else>
-    <CallAudioPlaybackPrompt />
     <CallAudioSink />
     <slot />
   </template>

--- a/chat/src/components/calls/CallAudioPlaybackPrompt.vue
+++ b/chat/src/components/calls/CallAudioPlaybackPrompt.vue
@@ -1,34 +1,24 @@
 <script setup lang="ts">
-import { ref } from "vue";
 import { useStore } from "@nanostores/vue";
-import {
-  $callAudioPlaybackBlocked,
-  resumeCallAudioPlayback,
-} from "@/lib/calls/call-audio-playback";
+import { $callAudioPlaybackBlocked } from "@/lib/calls/call-audio-playback";
+import { useCallAudioPlaybackPromptController } from "@/lib/calls/call-audio-playback-prompt-controller";
+import { $callState } from "@/lib/calls/call-store";
 import { useCallEngine } from "@/lib/calls/use-call-engine";
 
 const blocked = useStore($callAudioPlaybackBlocked);
+const callState = useStore($callState);
 const { engine } = useCallEngine();
-const resumeFailed = ref(false);
-const resuming = ref(false);
-
-async function enableAudio(): Promise<void> {
-  if (resuming.value) return;
-  resumeFailed.value = false;
-  resuming.value = true;
-  try {
-    await resumeCallAudioPlayback(engine, () => {
-      resumeFailed.value = true;
-    });
-  } finally {
-    resuming.value = false;
-  }
-}
+const {
+  enableAudio,
+  resumeFailed,
+  resuming,
+  visible,
+} = useCallAudioPlaybackPromptController(blocked, callState, engine);
 </script>
 
 <template>
   <div
-    v-if="blocked"
+    v-if="visible"
     class="call-audio-playback-prompt"
     role="alert"
   >

--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -34,7 +34,6 @@ import CallSettingsDialog from "./CallSettingsDialog.vue";
 import CallMediaNotice from "./CallMediaNotice.vue";
 import CallSelfShareNotice from "./CallSelfShareNotice.vue";
 import CallVolumeMixerDialog from "./CallVolumeMixerDialog.vue";
-import CallAudioPlaybackPrompt from "./CallAudioPlaybackPrompt.vue";
 import MessageComposer from "@/components/chat/MessageComposer.vue";
 
 /**
@@ -278,7 +277,6 @@ onBeforeUnmount(() => {
       {{ lastError }}
     </div>
     <CallMediaNotice />
-    <CallAudioPlaybackPrompt />
     <CallSelfShareNotice
       v-if="selfSharePresentation"
       :presentation="selfSharePresentation"

--- a/chat/src/components/calls/CallSplitContainer.vue
+++ b/chat/src/components/calls/CallSplitContainer.vue
@@ -32,7 +32,6 @@ import CallSettingsDialog from "./CallSettingsDialog.vue";
 import CallMediaNotice from "./CallMediaNotice.vue";
 import CallSelfShareNotice from "./CallSelfShareNotice.vue";
 import CallVolumeMixerDialog from "./CallVolumeMixerDialog.vue";
-import CallAudioPlaybackPrompt from "./CallAudioPlaybackPrompt.vue";
 import SplitDragHandle from "./SplitDragHandle.vue";
 
 /**
@@ -202,7 +201,6 @@ async function onHangup(): Promise<void> {
         {{ lastError }}
       </div>
       <CallMediaNotice />
-      <CallAudioPlaybackPrompt />
       <CallSelfShareNotice
         v-if="selfSharePresentation"
         :presentation="selfSharePresentation"

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -46,6 +46,7 @@ import UserSettingsPage from "@/components/chat/UserSettingsPage.vue";
 import WaddlesSidebar from "@/components/chat/WaddlesSidebar.vue";
 import AdminView from "@/components/admin/AdminView.vue";
 import CallActivityDock from "@/components/calls/CallActivityDock.vue";
+import CallAudioPlaybackPrompt from "@/components/calls/CallAudioPlaybackPrompt.vue";
 import CurrentCallPanel from "@/components/calls/CurrentCallPanel.vue";
 import { navigate, useRouteMatch, type AdminMatch, type AdminPanel } from "@/router";
 import { buildHomeDashboardProps } from "@/home/dashboard-props";
@@ -500,6 +501,7 @@ onUnmounted(() => {
     @back="onAdminBack"
   />
   <div v-else class="chat-app-shell">
+    <CallAudioPlaybackPrompt />
     <ChatMobileDrawers
       :controller="controller"
       :active-channel-call-count="activeChannelCallCount"

--- a/chat/src/lib/calls/call-audio-playback-prompt-controller.ts
+++ b/chat/src/lib/calls/call-audio-playback-prompt-controller.ts
@@ -1,0 +1,63 @@
+import { computed, ref, watch, type Ref } from "vue";
+import {
+  resumeCallAudioPlayback,
+  type CallAudioResumeTarget,
+} from "./call-audio-playback";
+import { CallAudioResumeAttemptGuard } from "./call-audio-resume-attempt";
+import type { CallState } from "./types";
+
+export function useCallAudioPlaybackPromptController(
+  blocked: Ref<boolean>,
+  callState: Ref<CallState>,
+  engine: CallAudioResumeTarget,
+) {
+  const resumeFailed = ref(false);
+  const resuming = ref(false);
+  const resumeAttempts = new CallAudioResumeAttemptGuard();
+  const visible = computed(() => blocked.value && callState.value.phase === "active");
+  const activeCallSid = computed(() =>
+    callState.value.phase === "active" ? callState.value.sid : null,
+  );
+
+  function resetResumeState(): void {
+    resumeAttempts.reset();
+    resumeFailed.value = false;
+    resuming.value = false;
+  }
+
+  watch(
+    visible,
+    (isVisible) => {
+      if (!isVisible) resetResumeState();
+    },
+    { flush: "sync" },
+  );
+
+  watch(activeCallSid, resetResumeState, { flush: "sync" });
+
+  async function enableAudio(): Promise<void> {
+    if (resuming.value) return;
+    const attempt = resumeAttempts.begin(activeCallSid.value);
+    resumeFailed.value = false;
+    resuming.value = true;
+    try {
+      await resumeCallAudioPlayback(engine, () => {
+        if (!attempt.matches(activeCallSid.value)) return;
+        resumeFailed.value = true;
+      });
+    } finally {
+      if (attempt.matches(activeCallSid.value)) {
+        resuming.value = false;
+      }
+    }
+  }
+
+  return {
+    activeCallSid,
+    enableAudio,
+    resetResumeState,
+    resumeFailed,
+    resuming,
+    visible,
+  };
+}

--- a/chat/src/lib/calls/call-audio-playback-prompt-controller.ts
+++ b/chat/src/lib/calls/call-audio-playback-prompt-controller.ts
@@ -55,7 +55,6 @@ export function useCallAudioPlaybackPromptController(
   return {
     activeCallSid,
     enableAudio,
-    resetResumeState,
     resumeFailed,
     resuming,
     visible,

--- a/chat/src/lib/calls/call-audio-resume-attempt.ts
+++ b/chat/src/lib/calls/call-audio-resume-attempt.ts
@@ -1,0 +1,19 @@
+export type CallAudioResumeAttempt = {
+  matches(activeCallSid: string | null): boolean;
+};
+
+export class CallAudioResumeAttemptGuard {
+  private currentAttemptId = 0;
+
+  begin(callSid: string | null): CallAudioResumeAttempt {
+    const attemptId = ++this.currentAttemptId;
+    return {
+      matches: (activeCallSid) =>
+        attemptId === this.currentAttemptId && callSid === activeCallSid,
+    };
+  }
+
+  reset(): void {
+    this.currentAttemptId += 1;
+  }
+}

--- a/chat/tests/call-controls.test.ts
+++ b/chat/tests/call-controls.test.ts
@@ -4,9 +4,9 @@ import { tmpdir } from "node:os";
 import { join as joinPath } from "node:path";
 import { pathToFileURL } from "node:url";
 import { createRequire } from "node:module";
-import { createSSRApp, h } from "vue";
+import { createSSRApp, h, ref } from "vue";
 import { renderToString } from "vue/server-renderer";
-import { parse, compileScript } from "vue/compiler-sfc";
+import { parse, compileScript, compileTemplate } from "vue/compiler-sfc";
 import ts from "typescript";
 import { $callState, clearCallState } from "../src/lib/calls/call-store";
 import {
@@ -31,6 +31,8 @@ import {
   $callAudioPlaybackBlocked,
   resumeCallAudioPlayback,
 } from "../src/lib/calls/call-audio-playback";
+import { CallAudioResumeAttemptGuard } from "../src/lib/calls/call-audio-resume-attempt";
+import { useCallAudioPlaybackPromptController } from "../src/lib/calls/call-audio-playback-prompt-controller";
 import { useCallEngine } from "../src/lib/calls/use-call-engine";
 import {
   $dmCallActivities,
@@ -43,6 +45,8 @@ import {
 import { connectionStore } from "../src/lib/connection-store";
 import type { LiveKitJoin } from "../src/lib/calls/types";
 import { Track } from "livekit-client";
+import { renderVueComponent as renderSfcComponent } from "./helpers/render-vue-sfc";
+import { $callUiMode } from "../src/lib/calls/ui-mode";
 
 const require = createRequire(import.meta.url);
 
@@ -86,10 +90,12 @@ afterEach(() => {
   clearDmCallActivities();
   $mucCallLiveParticipants.set({});
   connectionStore.client = null;
+  connectionStore.appState = "loading";
   clearAllMediaIssues();
   $callAudioPlaybackBlocked.set(false);
   $callScreenShareEnabled.set(false);
   $callScreenShareSupported.set(false);
+  $callUiMode.set("split");
   // The engine is a process-wide singleton; drop any injected room
   // stub so it doesn't leak into the next test.
   (useCallEngine().engine as unknown as { room: unknown }).room = null;
@@ -470,12 +476,91 @@ describe("device-less call controls", () => {
     const component = await loadVueComponent("../src/components/calls/CallAudioPlaybackPrompt.vue");
 
     $callAudioPlaybackBlocked.set(false);
+    setActiveMucCall();
     expect(await renderVueComponent(component)).not.toContain("Tap to enable audio");
 
     $callAudioPlaybackBlocked.set(true);
     const html = await renderVueComponent(component);
     expect(html).toContain("Audio is paused by your browser.");
     expect(html).toContain("Tap to enable audio");
+  });
+
+  test("call audio playback prompt stays hidden outside an active call", async () => {
+    const component = await loadVueComponent("../src/components/calls/CallAudioPlaybackPrompt.vue");
+
+    $callAudioPlaybackBlocked.set(true);
+    expect(await renderVueComponent(component)).not.toContain("Tap to enable audio");
+  });
+
+  test("app-level blocked audio recovery renders while viewing another conversation", async () => {
+    const component = await loadVueComponent("../src/components/calls/CallAudioPlaybackPrompt.vue");
+
+    setActiveMucCall();
+    $callAudioPlaybackBlocked.set(true);
+
+    const html = await renderToString(createSSRApp({
+      render: () =>
+        h("main", [
+          h(component as never),
+          h("section", { "aria-label": "Direct message with Bob" }, "Different conversation"),
+        ]),
+    }));
+
+    expect(html).toContain("Audio is paused by your browser.");
+    expect(html).toContain("Tap to enable audio");
+    expect(html).toContain("Different conversation");
+  });
+
+  test("call audio playback prompt keeps retry affordance after failed browser resume", async () => {
+    const component = await loadVueComponent("../src/components/calls/CallAudioPlaybackPrompt.vue", {
+      inlineTemplate: false,
+    }) as {
+      setup: (
+        props: Record<string, never>,
+        context: { expose: () => void },
+      ) => {
+        enableAudio: () => Promise<void>;
+        visible: { value: boolean };
+        resumeFailed: { value: boolean };
+        resuming: { value: boolean };
+      };
+    };
+    let shouldFail = true;
+    (useCallEngine().engine as unknown as { startAudio: () => Promise<void> }).startAudio = async () => {
+      if (shouldFail) throw new Error("blocked");
+    };
+    const bindings = component.setup({}, { expose: () => undefined });
+
+    await bindings.enableAudio();
+
+    expect(bindings.resumeFailed.value).toBe(true);
+    expect(bindings.resuming.value).toBe(false);
+    const failedRenderBindings = {
+      ...bindings,
+      visible: true,
+      resumeFailed: bindings.resumeFailed.value,
+      resuming: bindings.resuming.value,
+    };
+    expect(await renderVueComponentWithBindings(component, failedRenderBindings)).toContain(
+      "Try again from this button.",
+    );
+    expect(await renderVueComponentWithBindings(component, failedRenderBindings)).toContain(
+      "Tap to enable audio",
+    );
+
+    shouldFail = false;
+    await bindings.enableAudio();
+
+    expect(bindings.resumeFailed.value).toBe(false);
+    const recoveredRenderBindings = {
+      ...bindings,
+      visible: true,
+      resumeFailed: bindings.resumeFailed.value,
+      resuming: bindings.resuming.value,
+    };
+    expect(await renderVueComponentWithBindings(component, recoveredRenderBindings)).not.toContain(
+      "Try again from this button.",
+    );
   });
 
   test("call audio resume helper reports failed browser resume without throwing", async () => {
@@ -493,23 +578,106 @@ describe("device-less call controls", () => {
     expect(failures).toEqual(["failed"]);
   });
 
-  test("call surfaces mount the tap-to-enable audio affordance", () => {
-    const promptSource = readFileSync(
-      new URL("../src/components/calls/CallAudioPlaybackPrompt.vue", import.meta.url),
-      "utf8",
-    );
-    const splitSource = readFileSync(
-      new URL("../src/components/calls/CallSplitContainer.vue", import.meta.url),
-      "utf8",
-    );
-    const expandedSource = readFileSync(
-      new URL("../src/components/calls/CallExpandedSurface.vue", import.meta.url),
-      "utf8",
-    );
+  test("call audio resume attempts ignore settlements after the active call changes", () => {
+    const guard = new CallAudioResumeAttemptGuard();
+    const callA = guard.begin("call-a");
 
-    expect(promptSource).toContain(":disabled=\"resuming\"");
-    expect(splitSource).toContain("<CallAudioPlaybackPrompt />");
-    expect(expandedSource).toContain("<CallAudioPlaybackPrompt />");
+    expect(callA.matches("call-a")).toBe(true);
+    expect(callA.matches("call-b")).toBe(false);
+
+    const callB = guard.begin("call-b");
+
+    expect(callA.matches("call-a")).toBe(false);
+    expect(callA.matches("call-b")).toBe(false);
+    expect(callB.matches("call-b")).toBe(true);
+  });
+
+  test("call audio playback prompt ignores delayed resume failure after call changes", async () => {
+    let rejectResume: ((error: Error) => void) | null = null;
+    const blocked = ref(true);
+    const callState = ref({
+      phase: "active",
+      peer: "bob@waddle.test/web",
+      sid: "call-a",
+      media: { audio: true, video: false },
+      join,
+      kind: "dm",
+    } as const);
+    const controller = useCallAudioPlaybackPromptController(blocked, callState, {
+      startAudio: () =>
+        new Promise((_resolve, reject) => {
+          rejectResume = reject;
+        }),
+    });
+
+    const pending = controller.enableAudio();
+
+    expect(controller.resuming.value).toBe(true);
+
+    callState.value = {
+      phase: "active",
+      peer: "carol@waddle.test/web",
+      sid: "call-b",
+      media: { audio: true, video: false },
+      join,
+      kind: "dm",
+    };
+
+    expect(controller.resuming.value).toBe(false);
+
+    rejectResume?.(new Error("blocked"));
+    await pending;
+
+    expect(controller.activeCallSid.value).toBe("call-b");
+    expect(controller.resumeFailed.value).toBe(false);
+    expect(controller.resuming.value).toBe(false);
+  });
+
+  test("app shell and mounted call surface render exactly one audio recovery banner", async () => {
+    $callState.set({
+      phase: "active",
+      peer: "bob@waddle.test/web",
+      sid: "dm-call",
+      media: { audio: true, video: false },
+      join,
+      kind: "dm",
+    });
+    $callUiMode.set("split");
+    $callAudioPlaybackBlocked.set(true);
+    connectionStore.appState = "ready";
+
+    const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        location: { pathname: "/dm/alice", search: "" },
+        history: {
+          pushState: () => undefined,
+          replaceState: () => undefined,
+        },
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+      },
+    });
+    let appLevelHtml: string;
+    try {
+      appLevelHtml = await renderSfcComponent(
+        "../src/components/AppShell.vue",
+        { giphyApiKey: "" },
+        import.meta.url,
+      );
+    } finally {
+      if (originalWindow) Object.defineProperty(globalThis, "window", originalWindow);
+      else Reflect.deleteProperty(globalThis, "window");
+    }
+    const surfaceHtml = await renderSfcComponent(
+      "../src/components/calls/CallSplitContainer.vue",
+      { dmPeerJid: "bob@waddle.test" },
+      import.meta.url,
+    );
+    const combinedHtml = `${appLevelHtml}${surfaceHtml}`;
+
+    expect(combinedHtml.match(/Tap to enable audio/g)?.length ?? 0).toBe(1);
   });
 });
 
@@ -546,25 +714,66 @@ async function renderCallControls(overrides: Record<string, unknown>): Promise<s
   return renderToString(createSSRApp({ render: () => h(component, props) }));
 }
 
+function setActiveMucCall(): void {
+  $callState.set({
+    phase: "active",
+    peer: "general@conference.example.com",
+    sid: "c1",
+    media: { audio: true, video: false },
+    join,
+    kind: "muc",
+    selfNick: "alice",
+  });
+}
+
 async function renderVueComponent(component: unknown): Promise<string> {
   return renderToString(createSSRApp({ render: () => h(component as never) }));
 }
 
-async function loadVueComponent(path: string) {
+async function renderVueComponentWithBindings(
+  component: { render: unknown },
+  bindings: Record<string, unknown>,
+): Promise<string> {
+  return renderToString(createSSRApp({
+    render: () =>
+      (component.render as (
+        ctx: Record<string, unknown>,
+        cache: unknown[],
+        props: Record<string, unknown>,
+        setup: Record<string, unknown>,
+        data: Record<string, unknown>,
+        options: Record<string, unknown>,
+      ) => unknown)(bindings, [], {}, bindings, {}, {}),
+  }));
+}
+
+async function loadVueComponent(
+  path: string,
+  options: { inlineTemplate?: boolean } = { inlineTemplate: true },
+) {
   const filename = new URL(path, import.meta.url);
   const source = readFileSync(filename, "utf8");
   const { descriptor } = parse(source, { filename: filename.pathname });
   const script = compileScript(descriptor, {
     id: filename.pathname,
-    inlineTemplate: true,
+    inlineTemplate: options.inlineTemplate ?? true,
   });
 
   const tempDir = mkdtempSync(joinPath(tmpdir(), "waddle-call-audio-playback-"));
   try {
-    const compiled = [
+    const parts = [
       rewriteImports(script.content.replace("export default", "const __sfc__ ="), filename),
-      "export default __sfc__;",
-    ].join("\n");
+    ];
+    if (!(options.inlineTemplate ?? true) && descriptor.template) {
+      const template = compileTemplate({
+        id: filename.pathname,
+        filename: filename.pathname,
+        source: descriptor.template.content,
+      }).code.replace("export function render", "function render");
+      parts.push(rewriteImports(template, filename), "__sfc__.render = render;");
+    }
+    parts.push("export default __sfc__;");
+    const compiled = parts.join("\n");
     const js = ts.transpileModule(compiled, {
       compilerOptions: {
         module: ts.ModuleKind.ESNext,

--- a/chat/tests/call-controls.test.ts
+++ b/chat/tests/call-controls.test.ts
@@ -633,7 +633,7 @@ describe("device-less call controls", () => {
     expect(controller.resuming.value).toBe(false);
   });
 
-  test("app shell and mounted call surface render exactly one audio recovery banner", async () => {
+  test("ready shell owns one in-viewport audio recovery banner", async () => {
     $callState.set({
       phase: "active",
       peer: "bob@waddle.test/web",
@@ -644,40 +644,31 @@ describe("device-less call controls", () => {
     });
     $callUiMode.set("split");
     $callAudioPlaybackBlocked.set(true);
-    connectionStore.appState = "ready";
-
-    const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
-    Object.defineProperty(globalThis, "window", {
-      configurable: true,
-      value: {
-        location: { pathname: "/dm/alice", search: "" },
-        history: {
-          pushState: () => undefined,
-          replaceState: () => undefined,
-        },
-        addEventListener: () => undefined,
-        removeEventListener: () => undefined,
-      },
-    });
-    let appLevelHtml: string;
-    try {
-      appLevelHtml = await renderSfcComponent(
-        "../src/components/AppShell.vue",
-        { giphyApiKey: "" },
-        import.meta.url,
-      );
-    } finally {
-      if (originalWindow) Object.defineProperty(globalThis, "window", originalWindow);
-      else Reflect.deleteProperty(globalThis, "window");
-    }
+    const appShellSource = readFileSync(
+      new URL("../src/components/AppShell.vue", import.meta.url),
+      "utf8",
+    );
+    const readyShellSource = readFileSync(
+      new URL("../src/components/chat/ChatReadyShell.vue", import.meta.url),
+      "utf8",
+    );
+    const promptHtml = await renderVueComponent(
+      await loadVueComponent("../src/components/calls/CallAudioPlaybackPrompt.vue"),
+    );
     const surfaceHtml = await renderSfcComponent(
       "../src/components/calls/CallSplitContainer.vue",
       { dmPeerJid: "bob@waddle.test" },
       import.meta.url,
     );
-    const combinedHtml = `${appLevelHtml}${surfaceHtml}`;
+    const shellStart = readyShellSource.indexOf('<div v-else class="chat-app-shell">');
+    const promptMount = readyShellSource.indexOf("<CallAudioPlaybackPrompt />");
+    const desktopShell = readyShellSource.indexOf('<div class="chat-desktop-shell">');
 
-    expect(combinedHtml.match(/Tap to enable audio/g)?.length ?? 0).toBe(1);
+    expect(appShellSource).not.toContain("<CallAudioPlaybackPrompt />");
+    expect(shellStart).toBeGreaterThanOrEqual(0);
+    expect(promptMount).toBeGreaterThan(shellStart);
+    expect(promptMount).toBeLessThan(desktopShell);
+    expect(`${promptHtml}${surfaceHtml}`.match(/Tap to enable audio/g)?.length ?? 0).toBe(1);
   });
 });
 


### PR DESCRIPTION
Fixes #939

## Summary

- Mounts the blocked call-audio recovery banner inside the persistent ready-shell layout (`ChatReadyShell`'s `chat-app-shell`) so it is reachable from any signed-in route while a call is active without adding height outside the 100dvh app shell.
- Removes the inline `CallAudioPlaybackPrompt` mounts from split and expanded call surfaces, leaving exactly one production banner owner.
- Gates the banner on `playback blocked && active call`, so it never renders for idle, ringing, ended, or non-call states.
- Adds a prompt controller plus resume-attempt guard so retry UI resets on hide/SID changes and delayed failures from an old call cannot leak into a later call.

## Tests and coverage

- Adds runtime tests for hidden-outside-active-call behavior, recovery visibility while viewing another conversation, and exactly one banner when the ready shell and a call surface are both represented.
- Adds a placement regression that keeps the banner inside `chat-app-shell`, before the desktop flex layout, instead of as a sibling before the full-height routed shell.
- Adds rendered retry-affordance coverage for failed resume followed by successful retry.
- Adds guard/controller regressions for stale resume attempts settling after the active call changes.

## XEP review

This change is browser playback UI only. It does not alter XMPP wire behavior, stanza shapes, XEP namespaces, call signaling, or advertised XEP support.

## Verification

- `cd chat && bun test` - 1962 pass, 0 fail
- `cd chat && bun run lint` - passed; wasm artifacts found, knip clean
- `cd chat && bun run build` - passed; Astro check/build complete with existing non-blocking hint in `src/lib/xmpp/discovery.ts` and existing Vite chunk-size warning
- Adversarial review: final code-review pass found 0 actionable issues after fixing stale-state and delayed-settlement findings

## Review follow-up

- Addressed Codex review thread `PRRT_kwDOPCg5ys6IwLA5` by moving the banner from `AppShell` into the ready shell's viewport-owned flex column.

## Notes

- `bunx vue-tsc --noEmit -p tsconfig.json` was reported by a reviewer to hit existing unrelated chat type errors; the required `bun run build` Astro check path passed for this diff.
