### PR TITLE
fix(chat): keep DM call peer tile visible before media

### DIFF
--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -187,6 +187,11 @@ const selfSharePresentation = computed(() =>
 const stageLocalTracks = computed(() =>
   selfSharePresentation.value?.stageLocalTracks ?? localTracks.value,
 );
+const expectedRemoteIdentities = computed(() => {
+  if (state.value.phase !== "active" || state.value.kind !== "dm") return [];
+  const peer = state.value.peer.trim();
+  return peer ? [peer] : [];
+});
 
 const {
   rows: volumeRows,
@@ -287,6 +292,7 @@ onBeforeUnmount(() => {
           :remote-tracks="remoteTracks"
           :local-tracks="stageLocalTracks"
           :local-identity="localIdentity"
+          :expected-remote-identities="expectedRemoteIdentities"
           :mic-enabled="micEnabled"
         />
       </div>

--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -25,6 +25,7 @@ import { localScreenSharePresentation } from "@/lib/calls/call-self-share";
 import { normalizeMucCallRoomJid } from "@/lib/calls/muc-call-presence";
 import { useCallVolumeMixer } from "@/lib/calls/use-call-volume-mixer";
 import { barePeerJid } from "@/lib/xmpp/jid";
+import { expectedRemoteIdentitiesForCallState } from "@/lib/calls/call-tiles";
 import type { MentionCandidate } from "@/lib/mentions";
 import type { MarkupSpan, MessageReference } from "@/lib/chat-ui";
 import type { ComposerLinkPreviewLookup, ComposerLinkPreviewSendPayload } from "@/lib/link-preview-composer";
@@ -187,11 +188,9 @@ const selfSharePresentation = computed(() =>
 const stageLocalTracks = computed(() =>
   selfSharePresentation.value?.stageLocalTracks ?? localTracks.value,
 );
-const expectedRemoteIdentities = computed(() => {
-  if (state.value.phase !== "active" || state.value.kind !== "dm") return [];
-  const peer = state.value.peer.trim();
-  return peer ? [peer] : [];
-});
+const expectedRemoteIdentities = computed(() =>
+  expectedRemoteIdentitiesForCallState(state.value),
+);
 
 const {
   rows: volumeRows,

--- a/chat/src/components/calls/CallSplitContainer.vue
+++ b/chat/src/components/calls/CallSplitContainer.vue
@@ -167,6 +167,11 @@ const selfSharePresentation = computed(() =>
 const stageLocalTracks = computed(() =>
   selfSharePresentation.value?.stageLocalTracks ?? localTracks.value,
 );
+const expectedRemoteIdentities = computed(() => {
+  if (state.value.phase !== "active" || state.value.kind !== "dm") return [];
+  const peer = state.value.peer.trim();
+  return peer ? [peer] : [];
+});
 
 onMounted(() => {
   refreshScreenShareSupported();
@@ -211,6 +216,7 @@ async function onHangup(): Promise<void> {
           :remote-tracks="remoteTracks"
           :local-tracks="stageLocalTracks"
           :local-identity="localIdentity"
+          :expected-remote-identities="expectedRemoteIdentities"
           :mic-enabled="micEnabled"
         />
       </div>

--- a/chat/src/components/calls/CallSplitContainer.vue
+++ b/chat/src/components/calls/CallSplitContainer.vue
@@ -26,6 +26,7 @@ import { localScreenSharePresentation } from "@/lib/calls/call-self-share";
 import { normalizeMucCallRoomJid } from "@/lib/calls/muc-call-presence";
 import { useCallVolumeMixer } from "@/lib/calls/use-call-volume-mixer";
 import { barePeerJid } from "@/lib/xmpp/jid";
+import { expectedRemoteIdentitiesForCallState } from "@/lib/calls/call-tiles";
 import CallTileGrid from "./CallTileGrid.vue";
 import CallControls from "./CallControls.vue";
 import CallSettingsDialog from "./CallSettingsDialog.vue";
@@ -167,11 +168,9 @@ const selfSharePresentation = computed(() =>
 const stageLocalTracks = computed(() =>
   selfSharePresentation.value?.stageLocalTracks ?? localTracks.value,
 );
-const expectedRemoteIdentities = computed(() => {
-  if (state.value.phase !== "active" || state.value.kind !== "dm") return [];
-  const peer = state.value.peer.trim();
-  return peer ? [peer] : [];
-});
+const expectedRemoteIdentities = computed(() =>
+  expectedRemoteIdentitiesForCallState(state.value),
+);
 
 onMounted(() => {
   refreshScreenShareSupported();

--- a/chat/src/components/calls/CallTileGrid.vue
+++ b/chat/src/components/calls/CallTileGrid.vue
@@ -36,8 +36,8 @@ import CallTile from "./CallTile.vue";
 type Tile = CallTileModel;
 
 const props = defineProps<{
-  remoteTracks: RemoteMediaTrack[];
-  localTracks: LocalMediaTrack[];
+  remoteTracks: readonly RemoteMediaTrack[];
+  localTracks: readonly LocalMediaTrack[];
   /** LiveKit identity for the local participant (may be null pre-connect). */
   localIdentity: string | null;
   /** Remote participants known from call state before LiveKit has subscribed to their tracks. */

--- a/chat/src/components/calls/CallTileGrid.vue
+++ b/chat/src/components/calls/CallTileGrid.vue
@@ -40,6 +40,8 @@ const props = defineProps<{
   localTracks: LocalMediaTrack[];
   /** LiveKit identity for the local participant (may be null pre-connect). */
   localIdentity: string | null;
+  /** Remote participants known from call state before LiveKit has subscribed to their tracks. */
+  expectedRemoteIdentities?: readonly string[];
   /** Whether the local mic is currently un-muted. */
   micEnabled: boolean;
 }>();
@@ -52,6 +54,7 @@ const projection = computed(() => {
     remoteTracks: props.remoteTracks,
     localTracks: props.localTracks,
     localIdentity: props.localIdentity,
+    expectedRemoteIdentities: props.expectedRemoteIdentities,
     micEnabled: props.micEnabled,
     seenRemoteScreenTrackKeys: seenRemoteScreenTrackKeys.value,
     manualFocusKey: manualFocusKey.value,

--- a/chat/src/lib/calls/call-tiles.ts
+++ b/chat/src/lib/calls/call-tiles.ts
@@ -1,5 +1,6 @@
 import type { CallTrackSource, LocalMediaTrack, RemoteMediaTrack } from "./engine";
 import type { TileAttachable } from "./tile-attach";
+import type { CallState } from "./types";
 import { barePeerJid } from "../xmpp/jid";
 
 type TileSource = "camera" | "screen_share";
@@ -18,8 +19,8 @@ export type CallTileModel = {
 };
 
 export type BuildCallTilesInput = {
-  remoteTracks: RemoteMediaTrack[];
-  localTracks: LocalMediaTrack[];
+  remoteTracks: readonly RemoteMediaTrack[];
+  localTracks: readonly LocalMediaTrack[];
   localIdentity: string | null;
   expectedRemoteIdentities?: readonly string[];
   micEnabled: boolean;
@@ -46,10 +47,14 @@ function callTileKey(side: "self" | "remote", identity: string, source: TileSour
   return `${side}:${identity}:${source}`;
 }
 
-function sameBareIdentity(left: string, right: string): boolean {
-  const leftBare = barePeerJid(left).toLowerCase();
-  const rightBare = barePeerJid(right).toLowerCase();
-  return !!leftBare && leftBare === rightBare;
+function bareIdentityKey(identity: string): string {
+  return barePeerJid(identity.trim()).toLowerCase();
+}
+
+export function expectedRemoteIdentitiesForCallState(state: CallState): string[] {
+  if (state.phase !== "active" || state.kind !== "dm") return [];
+  const peer = state.peer.trim();
+  return bareIdentityKey(peer) ? [peer] : [];
 }
 
 function newTile(
@@ -75,6 +80,7 @@ function newTile(
 
 export function buildCallTiles(input: BuildCallTilesInput): CallTileModel[] {
   const byKey = new Map<string, CallTileModel>();
+  const remoteCameraBareIdentities = new Set<string>();
   const selfId = input.localTracks[0]?.participantIdentity ?? input.localIdentity ?? "you";
   byKey.set(callTileKey("self", selfId, "camera"), newTile("self", selfId, "camera", input.micEnabled));
 
@@ -90,9 +96,15 @@ export function buildCallTiles(input: BuildCallTilesInput): CallTileModel[] {
   }
 
   for (const remote of input.remoteTracks) {
+    const participantIdentity = remote.participantIdentity.trim();
+    if (!participantIdentity) continue;
     const source = tileSourceForTrack(remote.source);
-    const key = callTileKey("remote", remote.participantIdentity, source);
-    const existing = byKey.get(key) ?? newTile("remote", remote.participantIdentity, source, input.micEnabled);
+    const key = callTileKey("remote", participantIdentity, source);
+    const existing = byKey.get(key) ?? newTile("remote", participantIdentity, source, input.micEnabled);
+    if (source === "camera") {
+      const remoteBareIdentity = bareIdentityKey(participantIdentity);
+      if (remoteBareIdentity) remoteCameraBareIdentities.add(remoteBareIdentity);
+    }
     if (remote.kind === "video") {
       existing.videoTrack = remote.track;
       if (source === "screen_share") existing.screenTrackKey = remote.publicationSid;
@@ -101,17 +113,13 @@ export function buildCallTiles(input: BuildCallTilesInput): CallTileModel[] {
   }
 
   for (const identity of input.expectedRemoteIdentities ?? []) {
-    if (!identity.trim()) continue;
-    const hasRemoteCameraTile = Array.from(byKey.values()).some((tile) =>
-      !tile.isSelf &&
-      tile.source === "camera" &&
-      sameBareIdentity(tile.identity, identity)
+    const trimmedIdentity = identity.trim();
+    const bareIdentity = bareIdentityKey(trimmedIdentity);
+    if (!bareIdentity || remoteCameraBareIdentities.has(bareIdentity)) continue;
+    byKey.set(
+      callTileKey("remote", trimmedIdentity, "camera"),
+      newTile("remote", trimmedIdentity, "camera", input.micEnabled),
     );
-    if (hasRemoteCameraTile) continue;
-    const key = callTileKey("remote", identity, "camera");
-    if (!byKey.has(key)) {
-      byKey.set(key, newTile("remote", identity, "camera", input.micEnabled));
-    }
   }
 
   return Array.from(byKey.values());

--- a/chat/src/lib/calls/call-tiles.ts
+++ b/chat/src/lib/calls/call-tiles.ts
@@ -1,5 +1,6 @@
 import type { CallTrackSource, LocalMediaTrack, RemoteMediaTrack } from "./engine";
 import type { TileAttachable } from "./tile-attach";
+import { barePeerJid } from "../xmpp/jid";
 
 type TileSource = "camera" | "screen_share";
 
@@ -20,6 +21,7 @@ export type BuildCallTilesInput = {
   remoteTracks: RemoteMediaTrack[];
   localTracks: LocalMediaTrack[];
   localIdentity: string | null;
+  expectedRemoteIdentities?: readonly string[];
   micEnabled: boolean;
 };
 
@@ -42,6 +44,12 @@ function labelFor(identity: string, isSelf: boolean, source: TileSource): string
 
 function callTileKey(side: "self" | "remote", identity: string, source: TileSource): string {
   return `${side}:${identity}:${source}`;
+}
+
+function sameBareIdentity(left: string, right: string): boolean {
+  const leftBare = barePeerJid(left).toLowerCase();
+  const rightBare = barePeerJid(right).toLowerCase();
+  return !!leftBare && leftBare === rightBare;
 }
 
 function newTile(
@@ -90,6 +98,20 @@ export function buildCallTiles(input: BuildCallTilesInput): CallTileModel[] {
       if (source === "screen_share") existing.screenTrackKey = remote.publicationSid;
     }
     byKey.set(key, existing);
+  }
+
+  for (const identity of input.expectedRemoteIdentities ?? []) {
+    if (!identity.trim()) continue;
+    const hasRemoteCameraTile = Array.from(byKey.values()).some((tile) =>
+      !tile.isSelf &&
+      tile.source === "camera" &&
+      sameBareIdentity(tile.identity, identity)
+    );
+    if (hasRemoteCameraTile) continue;
+    const key = callTileKey("remote", identity, "camera");
+    if (!byKey.has(key)) {
+      byKey.set(key, newTile("remote", identity, "camera", input.micEnabled));
+    }
   }
 
   return Array.from(byKey.values());

--- a/chat/tests/call-tile-projection.test.ts
+++ b/chat/tests/call-tile-projection.test.ts
@@ -7,7 +7,10 @@ import { createSSRApp, h } from "vue";
 import { renderToString } from "vue/server-renderer";
 import { parse, compileScript } from "vue/compiler-sfc";
 import ts from "typescript";
-import { buildCallTiles } from "../src/lib/calls/call-tiles";
+import {
+  buildCallTiles,
+  expectedRemoteIdentitiesForCallState,
+} from "../src/lib/calls/call-tiles";
 
 const fakeTrack = {} as never;
 
@@ -131,6 +134,77 @@ describe("call tile projection", () => {
       "remote:BOB@example.com/desktop:camera",
     ]);
     expect(tiles.find((tile) => !tile.isSelf)?.videoTrack).toBe(fakeTrack);
+  });
+
+  test("trims expected DM peer identities before placeholder keys and merge checks", () => {
+    const placeholderTiles = buildCallTiles({
+      remoteTracks: [],
+      localTracks: [],
+      localIdentity: "alice@example.com/web",
+      expectedRemoteIdentities: [" bob@example.com/phone "],
+      micEnabled: true,
+    });
+    expect(placeholderTiles.map((tile) => tile.key)).toEqual([
+      "self:alice@example.com/web:camera",
+      "remote:bob@example.com/phone:camera",
+    ]);
+
+    const mergedTiles = buildCallTiles({
+      remoteTracks: [
+        {
+          participantIdentity: " BOB@example.com/desktop ",
+          publicationSid: "camera",
+          kind: "video",
+          source: "camera",
+          track: fakeTrack,
+        },
+      ],
+      localTracks: [],
+      localIdentity: "alice@example.com/web",
+      expectedRemoteIdentities: [" bob@example.com/phone "],
+      micEnabled: true,
+    });
+    expect(mergedTiles.map((tile) => tile.key)).toEqual([
+      "self:alice@example.com/web:camera",
+      "remote:BOB@example.com/desktop:camera",
+    ]);
+  });
+
+  test("derives expected remote identities only for active DM calls", () => {
+    expect(expectedRemoteIdentitiesForCallState({
+      phase: "active",
+      kind: "dm",
+      peer: " bob@example.com/phone ",
+      sid: "dm-call",
+      media: { audio: true, video: false },
+      join: {
+        url: "wss://livekit.example.test",
+        room: "dm-call",
+        identity: "alice@example.com/web",
+        token: "token",
+      },
+    })).toEqual(["bob@example.com/phone"]);
+
+    expect(expectedRemoteIdentitiesForCallState({
+      phase: "active",
+      kind: "muc",
+      peer: "general@conference.example.com",
+      sid: "muc-call",
+      media: { audio: true, video: false },
+      join: {
+        url: "wss://livekit.example.test",
+        room: "general",
+        identity: "alice@example.com/web",
+        token: "token",
+      },
+    })).toEqual([]);
+
+    expect(expectedRemoteIdentitiesForCallState({
+      phase: "incoming",
+      from: "bob@example.com/phone",
+      sid: "dm-call",
+      media: { audio: true, video: false },
+    })).toEqual([]);
   });
 
   test("projects local camera and screen share with separate mirror decisions", () => {

--- a/chat/tests/call-tile-projection.test.ts
+++ b/chat/tests/call-tile-projection.test.ts
@@ -79,6 +79,60 @@ describe("call tile projection", () => {
     expect(screenTile && "audioTrack" in screenTile).toBe(false);
   });
 
+  test("projects expected DM peer as a placeholder tile before media tracks arrive", () => {
+    const tiles = buildCallTiles({
+      remoteTracks: [],
+      localTracks: [],
+      localIdentity: "alice@example.com/web",
+      expectedRemoteIdentities: ["bob@example.com/phone"],
+      micEnabled: true,
+    });
+
+    expect(tiles.map((tile) => ({
+      key: tile.key,
+      label: tile.label,
+      isSelf: tile.isSelf,
+      videoTrack: tile.videoTrack,
+    }))).toEqual([
+      {
+        key: "self:alice@example.com/web:camera",
+        label: "You",
+        isSelf: true,
+        videoTrack: null,
+      },
+      {
+        key: "remote:bob@example.com/phone:camera",
+        label: "bob",
+        isSelf: false,
+        videoTrack: null,
+      },
+    ]);
+  });
+
+  test("merges an expected DM peer placeholder into the real remote camera tile by bare JID", () => {
+    const tiles = buildCallTiles({
+      remoteTracks: [
+        {
+          participantIdentity: "BOB@example.com/desktop",
+          publicationSid: "camera",
+          kind: "video",
+          source: "camera",
+          track: fakeTrack,
+        },
+      ],
+      localTracks: [],
+      localIdentity: "alice@example.com/web",
+      expectedRemoteIdentities: ["bob@example.com/phone"],
+      micEnabled: true,
+    });
+
+    expect(tiles.map((tile) => tile.key)).toEqual([
+      "self:alice@example.com/web:camera",
+      "remote:BOB@example.com/desktop:camera",
+    ]);
+    expect(tiles.find((tile) => !tile.isSelf)?.videoTrack).toBe(fakeTrack);
+  });
+
   test("projects local camera and screen share with separate mirror decisions", () => {
     const tiles = buildCallTiles({
       remoteTracks: [],


### PR DESCRIPTION
## Summary

Implements the rendering slice for #946 by making active 1:1 DM calls keep the shared call surface in a true two-party shape even before the peer has published a video track.

- Reuses the existing split and expanded call surfaces, `CallTileGrid`, and call controls for DM calls.
- Seeds the shared tile projection with the active DM peer so voice-first calls render both the local self-view tile and peer tile immediately.
- Merges the seeded peer placeholder into the real remote camera tile by normalized bare JID once LiveKit media arrives, avoiding duplicate peer tiles when full resources, casing, or surrounding whitespace differ.
- Centralizes the active-DM expected-peer rule in one shared helper used by split and expanded call surfaces.
- Adds projection regression tests for the pre-media placeholder, placeholder-to-real-tile merge, whitespace normalization, and expected-peer helper behavior.

## Plan / Checks

- [x] Review issue #946 and existing call surface components.
- [x] Add failing behavior coverage for the missing two-party DM tile state.
- [x] Implement via shared call tile projection and existing split/expanded surfaces.
- [x] Run adversarial review; fixed duplicate-tile and weak-test findings.
- [x] Address PR review comments: whitespace normalization, no repeated `Array.from`, remove unreachable guard, deduplicate surface logic.
- [x] `bun test` in `chat/`
- [x] `bun run lint` in `chat/`

## Notes

No XMPP protocol or LiveKit signaling changes. This stays on the client rendering/state projection side of the existing DM call flow.

Tested: `cd chat && bun test` (1966 pass)
Tested: `cd chat && bun run lint`
Tested: `cd chat && bun test tests/call-tile-projection.test.ts tests/call-activity-dock.test.ts`
Not-tested: `cd chat && bunx vue-tsc --noEmit` remains blocked by existing repo-wide chat type errors outside this change.
Not-tested: manual browser media session with two real clients.
