### PR TITLE
fix(chat): complete dm call screenshare controls

### DIFF
--- a/chat/src/components/calls/CallSettingsDialog.vue
+++ b/chat/src/components/calls/CallSettingsDialog.vue
@@ -7,11 +7,9 @@ import {
   $devicePrefs,
   enumerateCallDevices,
   isSpeakerOutputSelectionSupported,
-  setCamDevice,
-  setMicDevice,
-  setSpeakerDevice,
   type EnumeratedDevices,
 } from "@/lib/calls/device-prefs";
+import { applyCallDeviceSelection } from "@/lib/calls/call-device-selection";
 import { $micAudioProcessing } from "@/lib/calls/mic-audio-processing-state";
 import { audioProcessingRows } from "@/lib/calls/mic-audio-processing";
 import { useCallEngine } from "@/lib/calls/use-call-engine";
@@ -218,35 +216,26 @@ function stopStatsPolling(): void {
 onScopeDispose(stopStatsPolling);
 
 async function selectMic(id: string | null): Promise<void> {
-  setMicDevice(id);
-  if (id) {
-    try {
-      await engine.setMicDevice(id);
-    } catch (err) {
-      reportCallError(err);
-    }
+  try {
+    await applyCallDeviceSelection("mic", id, engine);
+  } catch (err) {
+    reportCallError(err);
   }
 }
 
 async function selectCam(id: string | null): Promise<void> {
-  setCamDevice(id);
-  if (id) {
-    try {
-      await engine.setCameraDevice(id);
-    } catch (err) {
-      reportCallError(err);
-    }
+  try {
+    await applyCallDeviceSelection("cam", id, engine);
+  } catch (err) {
+    reportCallError(err);
   }
 }
 
 async function selectSpeaker(id: string | null): Promise<void> {
-  setSpeakerDevice(id);
-  if (id) {
-    try {
-      await engine.setSpeakerDevice(id);
-    } catch (err) {
-      reportCallError(err);
-    }
+  try {
+    await applyCallDeviceSelection("speaker", id, engine);
+  } catch (err) {
+    reportCallError(err);
   }
 }
 

--- a/chat/src/lib/calls/call-device-selection.ts
+++ b/chat/src/lib/calls/call-device-selection.ts
@@ -1,0 +1,33 @@
+import {
+  setCamDevice,
+  setMicDevice,
+  setSpeakerDevice,
+} from "./device-prefs";
+
+export type CallDeviceKind = "mic" | "cam" | "speaker";
+
+export type CallDeviceSelectionEngine = {
+  setMicDevice(deviceId: string): Promise<void>;
+  setCameraDevice(deviceId: string): Promise<void>;
+  setSpeakerDevice(deviceId: string): Promise<void>;
+};
+
+export async function applyCallDeviceSelection(
+  kind: CallDeviceKind,
+  deviceId: string | null,
+  engine: CallDeviceSelectionEngine,
+): Promise<void> {
+  const activeDeviceId = deviceId ?? "default";
+  if (kind === "mic") {
+    setMicDevice(deviceId);
+    await engine.setMicDevice(activeDeviceId);
+    return;
+  }
+  if (kind === "cam") {
+    setCamDevice(deviceId);
+    await engine.setCameraDevice(activeDeviceId);
+    return;
+  }
+  setSpeakerDevice(deviceId);
+  await engine.setSpeakerDevice(activeDeviceId);
+}

--- a/chat/src/lib/calls/call-device-selection.ts
+++ b/chat/src/lib/calls/call-device-selection.ts
@@ -19,15 +19,15 @@ export async function applyCallDeviceSelection(
 ): Promise<void> {
   const activeDeviceId = deviceId ?? "default";
   if (kind === "mic") {
-    setMicDevice(deviceId);
     await engine.setMicDevice(activeDeviceId);
+    setMicDevice(deviceId);
     return;
   }
   if (kind === "cam") {
-    setCamDevice(deviceId);
     await engine.setCameraDevice(activeDeviceId);
+    setCamDevice(deviceId);
     return;
   }
-  setSpeakerDevice(deviceId);
   await engine.setSpeakerDevice(activeDeviceId);
+  setSpeakerDevice(deviceId);
 }

--- a/chat/src/lib/calls/call-tiles.ts
+++ b/chat/src/lib/calls/call-tiles.ts
@@ -80,7 +80,7 @@ function newTile(
 
 export function buildCallTiles(input: BuildCallTilesInput): CallTileModel[] {
   const byKey = new Map<string, CallTileModel>();
-  const remoteCameraBareIdentities = new Set<string>();
+  const activeRemoteBareIdentities = new Set<string>();
   const selfId = input.localTracks[0]?.participantIdentity ?? input.localIdentity ?? "you";
   byKey.set(callTileKey("self", selfId, "camera"), newTile("self", selfId, "camera", input.micEnabled));
 
@@ -98,13 +98,11 @@ export function buildCallTiles(input: BuildCallTilesInput): CallTileModel[] {
   for (const remote of input.remoteTracks) {
     const participantIdentity = remote.participantIdentity.trim();
     if (!participantIdentity) continue;
+    const remoteBareIdentity = bareIdentityKey(participantIdentity);
+    if (remoteBareIdentity) activeRemoteBareIdentities.add(remoteBareIdentity);
     const source = tileSourceForTrack(remote.source);
     const key = callTileKey("remote", participantIdentity, source);
     const existing = byKey.get(key) ?? newTile("remote", participantIdentity, source, input.micEnabled);
-    if (source === "camera") {
-      const remoteBareIdentity = bareIdentityKey(participantIdentity);
-      if (remoteBareIdentity) remoteCameraBareIdentities.add(remoteBareIdentity);
-    }
     if (remote.kind === "video") {
       existing.videoTrack = remote.track;
       if (source === "screen_share") existing.screenTrackKey = remote.publicationSid;
@@ -115,7 +113,7 @@ export function buildCallTiles(input: BuildCallTilesInput): CallTileModel[] {
   for (const identity of input.expectedRemoteIdentities ?? []) {
     const trimmedIdentity = identity.trim();
     const bareIdentity = bareIdentityKey(trimmedIdentity);
-    if (!bareIdentity || remoteCameraBareIdentities.has(bareIdentity)) continue;
+    if (!bareIdentity || activeRemoteBareIdentities.has(bareIdentity)) continue;
     byKey.set(
       callTileKey("remote", trimmedIdentity, "camera"),
       newTile("remote", trimmedIdentity, "camera", input.micEnabled),

--- a/chat/tests/call-device-selection.test.ts
+++ b/chat/tests/call-device-selection.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { $devicePrefs } from "../src/lib/calls/device-prefs";
+import { applyCallDeviceSelection } from "../src/lib/calls/call-device-selection";
+
+afterEach(() => {
+  $devicePrefs.set({ mic: null, cam: null, speaker: null });
+});
+
+describe("call device selection", () => {
+  test("persists and applies mic, camera, and speaker selections to the active call", async () => {
+    const engine = {
+      setMicDevice: mock(async (_id: string) => undefined),
+      setCameraDevice: mock(async (_id: string) => undefined),
+      setSpeakerDevice: mock(async (_id: string) => undefined),
+    };
+
+    await applyCallDeviceSelection("mic", "headset-mic", engine);
+    await applyCallDeviceSelection("cam", "desk-cam", engine);
+    await applyCallDeviceSelection("speaker", "usb-speaker", engine);
+
+    expect($devicePrefs.get()).toEqual({
+      mic: "headset-mic",
+      cam: "desk-cam",
+      speaker: "usb-speaker",
+    });
+    expect(engine.setMicDevice).toHaveBeenCalledWith("headset-mic");
+    expect(engine.setCameraDevice).toHaveBeenCalledWith("desk-cam");
+    expect(engine.setSpeakerDevice).toHaveBeenCalledWith("usb-speaker");
+  });
+
+  test("applies the system default device without leaving the active call", async () => {
+    const engine = {
+      setMicDevice: mock(async (_id: string) => undefined),
+      setCameraDevice: mock(async (_id: string) => undefined),
+      setSpeakerDevice: mock(async (_id: string) => undefined),
+    };
+
+    await applyCallDeviceSelection("mic", null, engine);
+    await applyCallDeviceSelection("cam", null, engine);
+    await applyCallDeviceSelection("speaker", null, engine);
+
+    expect($devicePrefs.get()).toEqual({ mic: null, cam: null, speaker: null });
+    expect(engine.setMicDevice).toHaveBeenCalledWith("default");
+    expect(engine.setCameraDevice).toHaveBeenCalledWith("default");
+    expect(engine.setSpeakerDevice).toHaveBeenCalledWith("default");
+  });
+});

--- a/chat/tests/call-device-selection.test.ts
+++ b/chat/tests/call-device-selection.test.ts
@@ -44,4 +44,20 @@ describe("call device selection", () => {
     expect(engine.setCameraDevice).toHaveBeenCalledWith("default");
     expect(engine.setSpeakerDevice).toHaveBeenCalledWith("default");
   });
+
+  test("does not persist a preference when the active call rejects the device switch", async () => {
+    const engine = {
+      setMicDevice: mock(async (_id: string) => {
+        throw new Error("device unavailable");
+      }),
+      setCameraDevice: mock(async (_id: string) => undefined),
+      setSpeakerDevice: mock(async (_id: string) => undefined),
+    };
+    $devicePrefs.set({ mic: "old-mic", cam: null, speaker: null });
+
+    await expect(applyCallDeviceSelection("mic", null, engine)).rejects.toThrow("device unavailable");
+
+    expect(engine.setMicDevice).toHaveBeenCalledWith("default");
+    expect($devicePrefs.get()).toEqual({ mic: "old-mic", cam: null, speaker: null });
+  });
 });

--- a/chat/tests/call-self-share.test.ts
+++ b/chat/tests/call-self-share.test.ts
@@ -1,8 +1,31 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import { renderVueComponent } from "./helpers/render-vue-sfc";
+import { $callState, clearCallState } from "../src/lib/calls/call-store";
+import {
+  $callScreenShareEnabled,
+  resetCallControls,
+} from "../src/lib/calls/call-controls";
+import { $callUiMode } from "../src/lib/calls/ui-mode";
 import { localScreenSharePresentation } from "../src/lib/calls/call-self-share";
 import type { LocalMediaTrack } from "../src/lib/calls/engine";
+import { useCallEngine } from "../src/lib/calls/use-call-engine";
+import type { LiveKitJoin } from "../src/lib/calls/types";
 
 const fakeTrack = {} as LocalMediaTrack["track"];
+const join: LiveKitJoin = {
+  url: "wss://livekit.test",
+  room: "dm-call",
+  identity: "alice@waddle.test/web",
+  token: "jwt",
+};
+
+afterEach(() => {
+  clearCallState();
+  resetCallControls(true, true);
+  $callScreenShareEnabled.set(false);
+  $callUiMode.set("split");
+  useCallEngine().localTracks.value = [];
+});
 
 function localVideo(
   publicationSid: string,
@@ -70,5 +93,30 @@ describe("local screen-share presentation", () => {
       },
       stageLocalTracks: [camera],
     });
+  });
+
+  test("DM split surface renders the self-share notice while the local screen is published", async () => {
+    const camera = localVideo("camera-pub", "camera");
+    const screen = localVideo("screen-pub", "screen_share");
+    $callState.set({
+      phase: "active",
+      peer: "bob@waddle.test/desktop",
+      sid: "dm-call",
+      media: { audio: true, video: true },
+      join,
+      kind: "dm",
+    });
+    $callUiMode.set("split");
+    $callScreenShareEnabled.set(true);
+    useCallEngine().localTracks.value = [camera, screen];
+
+    const html = await renderVueComponent(
+      "../src/components/calls/CallSplitContainer.vue",
+      { dmPeerJid: "bob@waddle.test", dmPeerName: "Bob" },
+      import.meta.url,
+    );
+
+    expect(html).toContain("You&#39;re sharing your screen");
+    expect(html).toContain("Your screen");
   });
 });

--- a/chat/tests/call-self-share.test.ts
+++ b/chat/tests/call-self-share.test.ts
@@ -24,7 +24,10 @@ afterEach(() => {
   resetCallControls(true, true);
   $callScreenShareEnabled.set(false);
   $callUiMode.set("split");
-  useCallEngine().localTracks.value = [];
+  const { engine, localTracks, remoteTracks } = useCallEngine();
+  localTracks.value = [];
+  remoteTracks.value = [];
+  (engine as unknown as { room: unknown }).room = null;
 });
 
 function localVideo(

--- a/chat/tests/call-settings-dialog.test.ts
+++ b/chat/tests/call-settings-dialog.test.ts
@@ -23,20 +23,6 @@ describe("CallSettingsDialog speaker support", () => {
     expect(html).not.toContain("System default");
   });
 
-  test("wires system-default picker rows through the active-call device selection helper", () => {
-    const source = readFileSync(
-      new URL("../src/components/calls/CallSettingsDialog.vue", import.meta.url),
-      "utf8",
-    );
-
-    expect(source).toContain('import { applyCallDeviceSelection } from "@/lib/calls/call-device-selection"');
-    expect(source).toContain('await applyCallDeviceSelection("mic", id, engine)');
-    expect(source).toContain('await applyCallDeviceSelection("cam", id, engine)');
-    expect(source).toContain('await applyCallDeviceSelection("speaker", id, engine)');
-    expect(source).toContain('@click="selectMic(null)"');
-    expect(source).toContain('@click="selectCam(null)"');
-    expect(source).toContain('@click="selectSpeaker(null)"');
-  });
 });
 
 async function renderVueComponent(path: string, props: Record<string, unknown>): Promise<string> {

--- a/chat/tests/call-settings-dialog.test.ts
+++ b/chat/tests/call-settings-dialog.test.ts
@@ -22,6 +22,21 @@ describe("CallSettingsDialog speaker support", () => {
     expect(html).not.toContain('aria-label="Speaker"');
     expect(html).not.toContain("System default");
   });
+
+  test("wires system-default picker rows through the active-call device selection helper", () => {
+    const source = readFileSync(
+      new URL("../src/components/calls/CallSettingsDialog.vue", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).toContain('import { applyCallDeviceSelection } from "@/lib/calls/call-device-selection"');
+    expect(source).toContain('await applyCallDeviceSelection("mic", id, engine)');
+    expect(source).toContain('await applyCallDeviceSelection("cam", id, engine)');
+    expect(source).toContain('await applyCallDeviceSelection("speaker", id, engine)');
+    expect(source).toContain('@click="selectMic(null)"');
+    expect(source).toContain('@click="selectCam(null)"');
+    expect(source).toContain('@click="selectSpeaker(null)"');
+  });
 });
 
 async function renderVueComponent(path: string, props: Record<string, unknown>): Promise<string> {

--- a/chat/tests/call-tile-spotlight.test.ts
+++ b/chat/tests/call-tile-spotlight.test.ts
@@ -105,6 +105,40 @@ describe("call tile spotlight projection", () => {
     expect(projection.spotlightKey).toBeNull();
   });
 
+  test("uses one remote tile for a DM peer that is publishing only a screen", () => {
+    const sharing = projectCallTiles({
+      remoteTracks: [remoteVideo("bob@example.com/web", "screen-pub", "screen_share")],
+      localTracks: [],
+      localIdentity: "alice@example.com/web",
+      expectedRemoteIdentities: ["bob@example.com/phone"],
+      micEnabled: true,
+      seenRemoteScreenTrackKeys: new Set(),
+      manualFocusKey: null,
+    });
+
+    expect(sharing.spotlightKey).toBe("remote:bob@example.com/web:screen_share");
+    expect(sharing.tiles.map((tile) => tile.key)).toEqual([
+      "self:alice@example.com/web:camera",
+      "remote:bob@example.com/web:screen_share",
+    ]);
+
+    const afterStop = projectCallTiles({
+      remoteTracks: [],
+      localTracks: [],
+      localIdentity: "alice@example.com/web",
+      expectedRemoteIdentities: ["bob@example.com/phone"],
+      micEnabled: true,
+      seenRemoteScreenTrackKeys: sharing.seenRemoteScreenTrackKeys,
+      manualFocusKey: sharing.spotlightKey,
+    });
+
+    expect(afterStop.spotlightKey).toBeNull();
+    expect(afterStop.tiles.map((tile) => tile.key)).toEqual([
+      "self:alice@example.com/web:camera",
+      "remote:bob@example.com/phone:camera",
+    ]);
+  });
+
   test("does not auto-promote the local participant's own screen share", () => {
     const projection = projectCallTiles({
       remoteTracks: [],


### PR DESCRIPTION
## Summary

- Fix DM two-party screen-share projection so a remote peer publishing only a screen is not duplicated as both a screen tile and camera placeholder.
- Keep the remote screen spotlighted while active, then restore the normal two-tile DM layout when sharing stops.
- Route mic, camera, and speaker picker selections through a shared active-call helper, including `System default`, so changes apply to the current LiveKit room without reconnecting.
- Persist device preferences only after the active LiveKit device switch succeeds, avoiding stale saved prefs on switch failure.
- Add rendered DM split-surface coverage for the local self-share notice and broaden singleton cleanup for that test.

## XEP review

Reviewed local XEP context for Jingle RTP/ICE call signaling. This change stays inside already-negotiated in-call LiveKit media UI/control state and does not add new XMPP stanzas, custom namespaces, or wire semantics.

## Verification

- `bun test ./tests/call-device-selection.test.ts ./tests/call-self-share.test.ts ./tests/call-settings-dialog.test.ts`
- `bun test`
- `bun run lint`

## Review feedback

- Resolved Copilot and Greptile comments about device preference write ordering by applying the engine switch before persisting prefs and adding rejection coverage.
- Resolved singleton cleanup feedback by clearing local tracks, remote tracks, and injected engine room state in the self-share surface test cleanup.
- Removed the brittle raw-source CallSettingsDialog wiring assertion.

Closes #952