### PR TITLE
fix(chat): add DM incoming call alerting

### DIFF
--- a/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_client.swift
+++ b/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_client.swift
@@ -3428,6 +3428,10 @@ public enum WaddleCallEventKind: Equatable, Hashable {
     case propose(media: WaddleCallMedia
     )
     /**
+     * XEP-0353 §3.2 `<ringing/>` — responder device is ringing.
+     */
+    case ringing
+    /**
      * XEP-0353 §5.1.2 `<proceed/>` — peer is accepting the call.
      */
     case proceed
@@ -3493,24 +3497,26 @@ public struct FfiConverterTypeWaddleCallEventKind: FfiConverterRustBuffer {
         case 1: return .propose(media: try FfiConverterTypeWaddleCallMedia.read(from: &buf)
         )
 
-        case 2: return .proceed
+        case 2: return .ringing
 
-        case 3: return .reject(reason: try FfiConverterOptionTypeWaddleJingleReason.read(from: &buf), tieBreak: try FfiConverterBool.read(from: &buf)
+        case 3: return .proceed
+
+        case 4: return .reject(reason: try FfiConverterOptionTypeWaddleJingleReason.read(from: &buf), tieBreak: try FfiConverterBool.read(from: &buf)
         )
 
-        case 4: return .retract(reason: try FfiConverterOptionTypeWaddleJingleReason.read(from: &buf), tieBreak: try FfiConverterBool.read(from: &buf)
+        case 5: return .retract(reason: try FfiConverterOptionTypeWaddleJingleReason.read(from: &buf), tieBreak: try FfiConverterBool.read(from: &buf)
         )
 
-        case 5: return .finish(reason: try FfiConverterOptionTypeWaddleJingleReason.read(from: &buf), migratedTo: try FfiConverterOptionString.read(from: &buf)
+        case 6: return .finish(reason: try FfiConverterOptionTypeWaddleJingleReason.read(from: &buf), migratedTo: try FfiConverterOptionString.read(from: &buf)
         )
 
-        case 6: return .sessionInitiate(join: try FfiConverterTypeWaddleLiveKitJoin.read(from: &buf), media: try FfiConverterTypeWaddleCallMedia.read(from: &buf)
+        case 7: return .sessionInitiate(join: try FfiConverterTypeWaddleLiveKitJoin.read(from: &buf), media: try FfiConverterTypeWaddleCallMedia.read(from: &buf)
         )
 
-        case 7: return .sessionAccept(join: try FfiConverterTypeWaddleLiveKitJoin.read(from: &buf), media: try FfiConverterTypeWaddleCallMedia.read(from: &buf)
+        case 8: return .sessionAccept(join: try FfiConverterTypeWaddleLiveKitJoin.read(from: &buf), media: try FfiConverterTypeWaddleCallMedia.read(from: &buf)
         )
 
-        case 8: return .sessionTerminate(reason: try FfiConverterOptionTypeWaddleJingleReason.read(from: &buf)
+        case 9: return .sessionTerminate(reason: try FfiConverterOptionTypeWaddleJingleReason.read(from: &buf)
         )
 
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -3526,42 +3532,46 @@ public struct FfiConverterTypeWaddleCallEventKind: FfiConverterRustBuffer {
             FfiConverterTypeWaddleCallMedia.write(media, into: &buf)
 
 
-        case .proceed:
+        case .ringing:
             writeInt(&buf, Int32(2))
 
 
-        case let .reject(reason,tieBreak):
+        case .proceed:
             writeInt(&buf, Int32(3))
-            FfiConverterOptionTypeWaddleJingleReason.write(reason, into: &buf)
-            FfiConverterBool.write(tieBreak, into: &buf)
 
 
-        case let .retract(reason,tieBreak):
+        case let .reject(reason,tieBreak):
             writeInt(&buf, Int32(4))
             FfiConverterOptionTypeWaddleJingleReason.write(reason, into: &buf)
             FfiConverterBool.write(tieBreak, into: &buf)
 
 
-        case let .finish(reason,migratedTo):
+        case let .retract(reason,tieBreak):
             writeInt(&buf, Int32(5))
+            FfiConverterOptionTypeWaddleJingleReason.write(reason, into: &buf)
+            FfiConverterBool.write(tieBreak, into: &buf)
+
+
+        case let .finish(reason,migratedTo):
+            writeInt(&buf, Int32(6))
             FfiConverterOptionTypeWaddleJingleReason.write(reason, into: &buf)
             FfiConverterOptionString.write(migratedTo, into: &buf)
 
 
         case let .sessionInitiate(join,media):
-            writeInt(&buf, Int32(6))
-            FfiConverterTypeWaddleLiveKitJoin.write(join, into: &buf)
-            FfiConverterTypeWaddleCallMedia.write(media, into: &buf)
-
-
-        case let .sessionAccept(join,media):
             writeInt(&buf, Int32(7))
             FfiConverterTypeWaddleLiveKitJoin.write(join, into: &buf)
             FfiConverterTypeWaddleCallMedia.write(media, into: &buf)
 
 
-        case let .sessionTerminate(reason):
+        case let .sessionAccept(join,media):
             writeInt(&buf, Int32(8))
+            FfiConverterTypeWaddleLiveKitJoin.write(join, into: &buf)
+            FfiConverterTypeWaddleCallMedia.write(media, into: &buf)
+
+
+        case let .sessionTerminate(reason):
+            writeInt(&buf, Int32(9))
             FfiConverterOptionTypeWaddleJingleReason.write(reason, into: &buf)
 
         }

--- a/apps/apple/Waddle/RustClient/RustXmppClient.swift
+++ b/apps/apple/Waddle/RustClient/RustXmppClient.swift
@@ -500,6 +500,8 @@ private func makeCallEvent(_ event: WaddleCallEvent) -> XMPPCallEvent {
         switch event.kind {
         case let .propose(media):
             return .propose(media: makeCallMedia(media))
+        case .ringing:
+            return .ringing
         case .proceed:
             return .proceed
         case let .reject(reason, tieBreak):

--- a/apps/apple/Waddle/XMPP/XMPPTypes.swift
+++ b/apps/apple/Waddle/XMPP/XMPPTypes.swift
@@ -316,6 +316,7 @@ enum XMPPJingleReason: Sendable, Equatable {
 /// importing UniFFI types into its own surface.
 enum XMPPCallEventKind: Sendable, Equatable {
     case propose(media: XMPPCallMedia)
+    case ringing
     case proceed
     case reject(reason: XMPPJingleReason?, tieBreak: Bool)
     case retract(reason: XMPPJingleReason?, tieBreak: Bool)

--- a/chat/src/components/calls/OutgoingCallToast.vue
+++ b/chat/src/components/calls/OutgoingCallToast.vue
@@ -23,6 +23,11 @@ const mediaLabel = computed(() => {
   return state.value.media.video ? "Video call" : "Audio call";
 });
 
+const outgoingStatusLabel = computed(() => {
+  if (state.value.phase !== "outgoing") return "";
+  return state.value.ringing ? "ringing…" : "calling…";
+});
+
 const endedCopy = computed(() => {
   if (state.value.phase !== "ended") return null;
   // The reducer stamps `reason` from the wire: `reject` /
@@ -96,7 +101,7 @@ function dismissEnded(): void {
       </span>
       <div class="min-w-0 flex-1">
         <div class="type-chat-title truncate">{{ peerLabel }}</div>
-        <div class="type-caption text-muted-foreground">{{ mediaLabel }} · calling…</div>
+        <div class="type-caption text-muted-foreground">{{ mediaLabel }} · {{ outgoingStatusLabel }}</div>
       </div>
     </div>
     <div

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -24,6 +24,7 @@ import {
 import { normalizeMucServiceDomain } from "@/lib/calls/muc-call-indicators";
 import {
   $callState,
+  configureIncomingCallAlerts,
   type RawIqSender,
 } from "@/lib/calls/call-store";
 import type { CallWireSender } from "@/lib/calls/outbound";
@@ -58,6 +59,11 @@ import type { FeedPostInput, StoryPostInput } from "@/lib/xmpp-client";
 import type { ActivityPublication, MoodPublication, TunePublication } from "@/lib/xmpp/pep-types";
 import type { VCard4Profile } from "@/lib/xmpp/vcard4-types";
 import { installMessageToolbarLifecycleSuppression } from "@/stores/message-toolbar";
+import {
+  createBrowserIncomingCallNotifier,
+  createBrowserLoopingTonePlayer,
+  createIncomingCallAlertController,
+} from "@/shell/audio-alerts";
 
 const props = defineProps<{
   controller: ChatAppController;
@@ -480,6 +486,16 @@ let disconnectMessageToolbarLifecycle: (() => void) | null = null;
 
 onMounted(() => {
   disconnectMessageToolbarLifecycle = installMessageToolbarLifecycleSuppression();
+  configureIncomingCallAlerts(createIncomingCallAlertController({
+    player: createBrowserLoopingTonePlayer(),
+    notifier: createBrowserIncomingCallNotifier(),
+    focusTarget: {
+      focusConversation(peerJid) {
+        selectDm(peerJid);
+      },
+    },
+    isTabFocused: () => document.visibilityState === "visible" && document.hasFocus(),
+  }));
 });
 
 watch(selfFullJid, (fullJid) => {
@@ -487,6 +503,7 @@ watch(selfFullJid, (fullJid) => {
 }, { immediate: true });
 
 onUnmounted(() => {
+  configureIncomingCallAlerts(null);
   disconnectMessageToolbarLifecycle?.();
   disconnectMessageToolbarLifecycle = null;
 });

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -375,7 +375,9 @@ function emitRingingOnIncomingPropose(
   if (!sender || event.kind !== "propose") return;
   if (next.phase !== "incoming" || next.sid !== event.sid) return;
   if (before.phase === "incoming" && before.sid === event.sid) return;
-  void outboundCalls.ringing(sender, event.from, event.sid).catch((err) => reportCallError(err));
+  void outboundCalls
+    .ringing(sender, barePeerJid(event.from) || event.from, event.sid)
+    .catch((err) => reportCallError(err));
 }
 
 /**

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -20,6 +20,7 @@ import { clearLiveCallParticipants } from "./muc-call-live-participants";
 import { mediaErrorMessage } from "./call-media-issues";
 import { dmCallStartedAnchorFromTransition, publishDmCallStartedAnchor } from "./dm-call-anchor";
 import { barePeerJid } from "../xmpp/jid";
+import type { IncomingCallAlertController } from "@/shell/audio-alerts";
 
 /**
  * XEP-0272 §Joining MUST: a client emitting a preparing presence
@@ -171,6 +172,15 @@ export const $callState = atom<CallState>({ phase: "idle" });
  */
 export const $lastCallError = atom<string | null>(null);
 
+let incomingCallAlerts: IncomingCallAlertController | null = null;
+
+export function configureIncomingCallAlerts(
+  controller: IncomingCallAlertController | null,
+): void {
+  incomingCallAlerts?.stopAll();
+  incomingCallAlerts = controller;
+}
+
 /**
  * Pure reducer over the current call state. Exposed for unit
  * testing; the production caller is the `on_call` registration in
@@ -196,6 +206,15 @@ export function reduceCallState(current: CallState, event: CallEvent): CallState
           sid: event.sid,
           media: event.media,
         };
+      }
+      return current;
+    case "ringing":
+      if (
+        current.phase === "outgoing" &&
+        current.sid === event.sid &&
+        barePeerJid(event.from).toLowerCase() === barePeerJid(current.to).toLowerCase()
+      ) {
+        return { ...current, ringing: true };
       }
       return current;
     case "proceed":
@@ -296,7 +315,10 @@ export function reduceCallState(current: CallState, event: CallEvent): CallState
  *    in the reducer, because
  *    `setTimeout`/`clearTimeout` are global-state side-effects.
  */
-export function applyCallEvent(event: CallEvent): void {
+export function applyCallEvent(
+  event: CallEvent,
+  options: { sender?: CallWireSender | null } = {},
+): void {
   // Route inbound Muji session-accept stanzas to the pending
   // `beginMucCall` Promise BEFORE the 1:1 reducer sees them. A
   // Muji accept carries a per-attempt sid and arrives from the SFU
@@ -323,10 +345,37 @@ export function applyCallEvent(event: CallEvent): void {
     cancelOutgoingTimeout();
   }
   $callState.set(next);
+  applyIncomingCallAlerts(before, next);
+  emitRingingOnIncomingPropose(before, next, event, options.sender ?? null);
   // Surface the DM "started a call" card live (the server only enriches the
   // archived `<proceed/>` row, which never reaches the live timeline).
   const dmCallAnchor = dmCallStartedAnchorFromTransition(before, next, new Date().toISOString());
   if (dmCallAnchor) publishDmCallStartedAnchor(dmCallAnchor);
+}
+
+function applyIncomingCallAlerts(before: CallState, next: CallState): void {
+  if (before.phase === "incoming" && (next.phase !== "incoming" || next.sid !== before.sid)) {
+    incomingCallAlerts?.stop(before.sid);
+  }
+  if (next.phase === "incoming" && (before.phase !== "incoming" || before.sid !== next.sid)) {
+    incomingCallAlerts?.start({
+      peerJid: barePeerJid(next.from) || next.from,
+      sid: next.sid,
+      media: next.media,
+    });
+  }
+}
+
+function emitRingingOnIncomingPropose(
+  before: CallState,
+  next: CallState,
+  event: CallEvent,
+  sender: CallWireSender | null,
+): void {
+  if (!sender || event.kind !== "propose") return;
+  if (next.phase !== "incoming" || next.sid !== event.sid) return;
+  if (before.phase === "incoming" && before.sid === event.sid) return;
+  void outboundCalls.ringing(sender, event.from, event.sid).catch((err) => reportCallError(err));
 }
 
 /**
@@ -339,6 +388,11 @@ export function clearCallState(): void {
     new Error("Muji session-accept wait cancelled while clearing call state"),
   );
   const current = $callState.get();
+  if (current.phase === "incoming") {
+    incomingCallAlerts?.stop(current.sid);
+  } else {
+    incomingCallAlerts?.stopAll();
+  }
   if (current.phase === "muc-pending") {
     cancelMucCallPreparationWaiters(
       current.peer,
@@ -366,6 +420,11 @@ export function acceptIncomingTieBreakPropose(
   $callState.set({
     phase: "incoming",
     from: event.from,
+    sid: event.sid,
+    media: event.media,
+  });
+  incomingCallAlerts?.start({
+    peerJid: barePeerJid(event.from) || event.from,
     sid: event.sid,
     media: event.media,
   });
@@ -635,6 +694,7 @@ export async function tearDownActiveCall(
           try {
             await outboundCalls.reject(sender, s.from, s.sid);
           } finally {
+            incomingCallAlerts?.stop(s.sid);
             clearDmCallActivity(s.from, s.sid);
           }
           break;

--- a/chat/src/lib/calls/dm-call-activity.ts
+++ b/chat/src/lib/calls/dm-call-activity.ts
@@ -532,6 +532,8 @@ export function applyDmCallEvent(envelope: DmCallEventEnvelope): void {
   const direction = directionForEnvelope(envelope);
   const remoteFullJid = remoteFullJidForEnvelope(envelope, peerJid);
   switch (envelope.event.kind) {
+    case "ringing":
+      return;
     case "propose":
       setActivity(peerJid, envelope.event.sid, eventSelfFullJid(envelope), {
         peerJid,

--- a/chat/src/lib/calls/outbound.ts
+++ b/chat/src/lib/calls/outbound.ts
@@ -9,6 +9,7 @@ import type { CallMedia } from "./types";
 export type CallWireSender = {
   send_call_propose?: (peer_bare_jid: string, sid: string, audio: boolean, video: boolean) => Promise<unknown>;
   send_call_proceed?: (peer_full_jid: string, sid: string) => Promise<unknown>;
+  send_call_ringing?: (peer_full_jid: string, sid: string) => Promise<unknown>;
   send_call_reject?: (peer_full_jid: string, sid: string) => Promise<unknown>;
   send_call_reject_tie_break?: (peer_full_jid: string, sid: string) => Promise<unknown>;
   send_call_retract?: (peer_bare_jid: string, sid: string) => Promise<unknown>;
@@ -73,6 +74,11 @@ export const outboundCalls = {
   async proceed(client: CallWireSender, peerFullJid: string, sid: string): Promise<void> {
     if (!client.send_call_proceed) throw new WasmCallApiUnavailable("send_call_proceed");
     await client.send_call_proceed(peerFullJid, sid);
+  },
+
+  async ringing(client: CallWireSender, peerFullJid: string, sid: string): Promise<void> {
+    if (!client.send_call_ringing) throw new WasmCallApiUnavailable("send_call_ringing");
+    await client.send_call_ringing(peerFullJid, sid);
   },
 
   async reject(client: CallWireSender, peerFullJid: string, sid: string): Promise<void> {

--- a/chat/src/lib/calls/outbound.ts
+++ b/chat/src/lib/calls/outbound.ts
@@ -9,7 +9,7 @@ import type { CallMedia } from "./types";
 export type CallWireSender = {
   send_call_propose?: (peer_bare_jid: string, sid: string, audio: boolean, video: boolean) => Promise<unknown>;
   send_call_proceed?: (peer_full_jid: string, sid: string) => Promise<unknown>;
-  send_call_ringing?: (peer_full_jid: string, sid: string) => Promise<unknown>;
+  send_call_ringing?: (peer_bare_jid: string, sid: string) => Promise<unknown>;
   send_call_reject?: (peer_full_jid: string, sid: string) => Promise<unknown>;
   send_call_reject_tie_break?: (peer_full_jid: string, sid: string) => Promise<unknown>;
   send_call_retract?: (peer_bare_jid: string, sid: string) => Promise<unknown>;
@@ -76,9 +76,9 @@ export const outboundCalls = {
     await client.send_call_proceed(peerFullJid, sid);
   },
 
-  async ringing(client: CallWireSender, peerFullJid: string, sid: string): Promise<void> {
+  async ringing(client: CallWireSender, peerBareJid: string, sid: string): Promise<void> {
     if (!client.send_call_ringing) throw new WasmCallApiUnavailable("send_call_ringing");
-    await client.send_call_ringing(peerFullJid, sid);
+    await client.send_call_ringing(peerBareJid, sid);
   },
 
   async reject(client: CallWireSender, peerFullJid: string, sid: string): Promise<void> {

--- a/chat/src/lib/calls/types.ts
+++ b/chat/src/lib/calls/types.ts
@@ -26,6 +26,7 @@ export type CallEvent =
   // `from` is the sender's full JID for every inbound event. The
   // only bare-addressed send path is outbound `<propose/>`.
   | (CallEventEnvelope & { kind: "propose"; media: CallMedia })
+  | (CallEventEnvelope & { kind: "ringing" })
   | (CallEventEnvelope & { kind: "proceed" })
   | (CallEventEnvelope & { kind: "reject"; reason?: string | null; tieBreak?: boolean })
   | (CallEventEnvelope & { kind: "retract"; reason?: string | null; tieBreak?: boolean })
@@ -51,7 +52,7 @@ export type CallEvent =
 export type CallState =
   | { phase: "idle" }
   | { phase: "incoming"; from: string; sid: string; media: CallMedia; accepting?: boolean }
-  | { phase: "outgoing"; to: string; sid: string; media: CallMedia; initiator?: string }
+  | { phase: "outgoing"; to: string; sid: string; media: CallMedia; initiator?: string; ringing?: boolean }
   | {
       phase: "muc-pending";
       peer: string;

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -3718,6 +3718,7 @@ export class BrowserXmppClient {
               : undefined;
       if (
         event.kind === "propose" ||
+        event.kind === "ringing" ||
         event.kind === "proceed" ||
         event.kind === "reject" ||
         event.kind === "retract" ||
@@ -3755,7 +3756,7 @@ export class BrowserXmppClient {
           (event.kind === "finish" && prev.phase === "active" && prev.kind === "dm")
         );
       if (!isSelfOriginated || selfOriginatedEventShouldTouchCurrentCall) {
-        applyCallEvent(event);
+        applyCallEvent(event, { sender: xmpp as unknown as CallWireSender });
       }
       if (!isSelfOriginated) {
         void handleCallEventSideEffect(event, prev, xmpp as unknown as CallWireSender, this.fullJid);

--- a/chat/src/shell/audio-alerts.ts
+++ b/chat/src/shell/audio-alerts.ts
@@ -1,0 +1,134 @@
+import type { CallMedia } from "@/lib/calls/types";
+
+export interface AudioAlertPlayer {
+  startLoop(key: string): void | Promise<void>;
+  stop(key: string): void | Promise<void>;
+}
+
+interface IncomingCallNotificationHandle {
+  close(): void;
+}
+
+export interface IncomingCallNotifier {
+  showIncomingCall(options: {
+    peerJid: string;
+    sid: string;
+    media: CallMedia;
+    onClick: () => void;
+  }): IncomingCallNotificationHandle | null;
+}
+
+export interface IncomingCallFocusTarget {
+  focusConversation(peerJid: string, sid: string): void;
+}
+
+export interface IncomingCallAlertController {
+  start(options: { peerJid: string; sid: string; media: CallMedia }): void;
+  stop(sid: string): void;
+  stopAll(): void;
+}
+
+export function createIncomingCallAlertController(options: {
+  player: AudioAlertPlayer;
+  notifier?: IncomingCallNotifier;
+  focusTarget?: IncomingCallFocusTarget;
+  isTabFocused?: () => boolean;
+}): IncomingCallAlertController {
+  const active = new Map<string, IncomingCallNotificationHandle | null>();
+
+  return {
+    start({ peerJid, sid, media }) {
+      if (active.has(sid)) return;
+      active.set(sid, null);
+      void options.player.startLoop(sid);
+      if (options.isTabFocused?.() !== false) return;
+      const handle = options.notifier?.showIncomingCall({
+        peerJid,
+        sid,
+        media,
+        onClick: () => options.focusTarget?.focusConversation(peerJid, sid),
+      }) ?? null;
+      active.set(sid, handle);
+    },
+    stop(sid) {
+      if (!active.has(sid)) return;
+      active.get(sid)?.close();
+      active.delete(sid);
+      void options.player.stop(sid);
+    },
+    stopAll() {
+      for (const sid of [...active.keys()]) {
+        this.stop(sid);
+      }
+    },
+  };
+}
+
+export function createBrowserIncomingCallNotifier(): IncomingCallNotifier {
+  return {
+    showIncomingCall({ peerJid, media, onClick }) {
+      if (typeof window === "undefined" || !("Notification" in window)) return null;
+      if (Notification.permission !== "granted") return null;
+      const label = media.video ? "video" : "audio";
+      const notification = new Notification(`Incoming ${label} call`, {
+        body: "Open Waddle to answer",
+        tag: `call:${peerJid}`,
+        icon: "/android-chrome-192x192.png",
+      });
+      notification.onclick = () => {
+        window.focus();
+        onClick();
+        notification.close();
+      };
+      return notification;
+    },
+  };
+}
+
+export function createBrowserLoopingTonePlayer(): AudioAlertPlayer {
+  const active = new Map<string, {
+    context: AudioContext;
+    oscillator: OscillatorNode;
+    gain: GainNode;
+    interval: ReturnType<typeof setInterval>;
+  }>();
+
+  return {
+    async startLoop(key) {
+      if (active.has(key)) return;
+      if (typeof window === "undefined" || typeof AudioContext === "undefined") return;
+      const context = new AudioContext();
+      const oscillator = context.createOscillator();
+      const gain = context.createGain();
+      oscillator.type = "sine";
+      oscillator.frequency.value = 880;
+      gain.gain.value = 0;
+      oscillator.connect(gain);
+      gain.connect(context.destination);
+      oscillator.start();
+      const pulse = () => {
+        const now = context.currentTime;
+        gain.gain.cancelScheduledValues(now);
+        gain.gain.setValueAtTime(0, now);
+        gain.gain.linearRampToValueAtTime(0.08, now + 0.03);
+        gain.gain.linearRampToValueAtTime(0, now + 0.35);
+      };
+      pulse();
+      active.set(key, {
+        context,
+        oscillator,
+        gain,
+        interval: setInterval(pulse, 1400),
+      });
+      await context.resume().catch(() => undefined);
+    },
+    stop(key) {
+      const current = active.get(key);
+      if (!current) return;
+      active.delete(key);
+      clearInterval(current.interval);
+      current.oscillator.stop();
+      void current.context.close().catch(() => undefined);
+    },
+  };
+}

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -261,7 +261,7 @@ describe("incoming DM call alerting", () => {
     await flushCallSideEffects();
 
     expect(player.startLoop).toHaveBeenCalledWith("c1");
-    expect(sender.send_call_ringing).toHaveBeenCalledWith("bob@waddle.test/phone", "c1");
+    expect(sender.send_call_ringing).toHaveBeenCalledWith("bob@waddle.test", "c1");
 
     await tearDownActiveCall(sender, "gone");
     expect(player.stop).toHaveBeenCalledWith("c1");

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -4,6 +4,7 @@ import {
   $lastCallError,
   beginOutgoingCall,
   clearCallState,
+  configureIncomingCallAlerts,
   type RawIqSender,
   scheduleOutgoingTimeout,
   setSessionAcceptTimeoutMsForTests,
@@ -25,6 +26,7 @@ import {
 } from "../src/lib/calls/muc-call-session-cache";
 import type { CallWireSender } from "../src/lib/calls/outbound";
 import type { CallEvent, CallMedia, LiveKitJoin } from "../src/lib/calls/types";
+import { createIncomingCallAlertController } from "../src/shell/audio-alerts";
 import { BrowserXmppClient } from "../src/lib/xmpp-client";
 import type { WaddleSession } from "../src/lib/server-auth";
 
@@ -187,6 +189,7 @@ function mockSender(): CallWireSender {
   return {
     send_call_propose: mock(async () => undefined),
     send_call_proceed: mock(async () => undefined),
+    send_call_ringing: mock(async () => undefined),
     send_call_reject: mock(async () => undefined),
     send_call_retract: mock(async () => undefined),
     send_call_finish: mock(async () => undefined),
@@ -226,6 +229,7 @@ afterAll(() => {
 
 afterEach(() => {
   clearCallState();
+  configureIncomingCallAlerts(null);
   $lastCallError.set(null);
   // The Muji mocks above fire `applyMucCallPresence` to simulate
   // MUC echoes; clearing the participants store between tests
@@ -233,6 +237,236 @@ afterEach(() => {
   // `muc-call-presence.test.ts`) that expect an empty store.
   clearMucCallParticipants();
   clearAllMucCallSessionCacheForTests();
+});
+
+describe("incoming DM call alerting", () => {
+  test("incoming propose starts ringtone, sends ringing, and local decline stops it", async () => {
+    const sender = mockSender();
+    const player = {
+      startLoop: mock(() => undefined),
+      stop: mock(() => undefined),
+    };
+    configureIncomingCallAlerts(createIncomingCallAlertController({
+      player,
+      isTabFocused: () => true,
+    }));
+
+    const { emitCall } = wireClientEvents(sender);
+    emitCall({
+      kind: "propose",
+      from: "bob@waddle.test/phone",
+      sid: "c1",
+      media: audioVideo,
+    });
+    await flushCallSideEffects();
+
+    expect(player.startLoop).toHaveBeenCalledWith("c1");
+    expect(sender.send_call_ringing).toHaveBeenCalledWith("bob@waddle.test/phone", "c1");
+
+    await tearDownActiveCall(sender, "gone");
+    expect(player.stop).toHaveBeenCalledWith("c1");
+  });
+
+  test("answering locally stops the ringtone when session-initiate arrives", () => {
+    const player = {
+      startLoop: mock(() => undefined),
+      stop: mock(() => undefined),
+    };
+    configureIncomingCallAlerts(createIncomingCallAlertController({
+      player,
+      isTabFocused: () => true,
+    }));
+
+    const { emitCall } = wireClientEvents(mockSender());
+    emitCall({
+      kind: "propose",
+      from: "bob@waddle.test/phone",
+      sid: "c1",
+      media: audioVideo,
+    });
+    emitCall({
+      kind: "session-initiate",
+      from: "bob@waddle.test/phone",
+      sid: "c1",
+      media: audioVideo,
+      join,
+    });
+
+    expect(player.stop).toHaveBeenCalledWith("c1");
+    expect($callState.get()).toMatchObject({ phase: "active", sid: "c1", kind: "dm" });
+  });
+
+  test("declining on a sibling resource stops local ringing from carbon events", async () => {
+    const player = {
+      startLoop: mock(() => undefined),
+      stop: mock(() => undefined),
+    };
+    configureIncomingCallAlerts(createIncomingCallAlertController({
+      player,
+      isTabFocused: () => true,
+    }));
+    const { emitCall } = wireClientEvents(mockSender());
+    emitCall({
+      kind: "propose",
+      from: "bob@waddle.test/phone",
+      sid: "c1",
+      media: audioVideo,
+    });
+    emitCall({
+      kind: "reject",
+      from: "alice@waddle.test/tablet",
+      to: "bob@waddle.test/phone",
+      sid: "c1",
+    });
+
+    expect(player.stop).toHaveBeenCalledWith("c1");
+  });
+
+  test("answering on a sibling resource stops local ringing from carbon events", () => {
+    const player = {
+      startLoop: mock(() => undefined),
+      stop: mock(() => undefined),
+    };
+    configureIncomingCallAlerts(createIncomingCallAlertController({
+      player,
+      isTabFocused: () => true,
+    }));
+    const { emitCall } = wireClientEvents(mockSender());
+    emitCall({
+      kind: "propose",
+      from: "bob@waddle.test/phone",
+      sid: "c1",
+      media: audioVideo,
+    });
+    emitCall({
+      kind: "proceed",
+      from: "alice@waddle.test/tablet",
+      to: "bob@waddle.test/phone",
+      sid: "c1",
+    });
+
+    expect(player.stop).toHaveBeenCalledWith("c1");
+  });
+
+  test("caller retract stops ringing and dismisses the incoming call slot", () => {
+    const player = {
+      startLoop: mock(() => undefined),
+      stop: mock(() => undefined),
+    };
+    configureIncomingCallAlerts(createIncomingCallAlertController({
+      player,
+      isTabFocused: () => true,
+    }));
+    const { emitCall } = wireClientEvents(mockSender());
+    emitCall({
+      kind: "propose",
+      from: "bob@waddle.test/phone",
+      sid: "c1",
+      media: audioVideo,
+    });
+    emitCall({
+      kind: "retract",
+      from: "bob@waddle.test/phone",
+      sid: "c1",
+    });
+
+    expect(player.stop).toHaveBeenCalledWith("c1");
+    expect($callState.get()).toEqual({ phase: "ended", sid: "c1", reason: "retract" });
+  });
+
+  test("unfocused tab shows incoming-call notification whose click focuses the DM", () => {
+    const focused: string[] = [];
+    let click: (() => void) | null = null;
+    const notifier = {
+      showIncomingCall: mock((options: { peerJid: string; onClick: () => void }) => {
+        click = options.onClick;
+        return { close: mock(() => undefined) };
+      }),
+    };
+    configureIncomingCallAlerts(createIncomingCallAlertController({
+      player: { startLoop: mock(() => undefined), stop: mock(() => undefined) },
+      notifier,
+      focusTarget: {
+        focusConversation(peerJid) {
+          focused.push(peerJid);
+        },
+      },
+      isTabFocused: () => false,
+    }));
+    const { emitCall } = wireClientEvents(mockSender());
+    emitCall({
+      kind: "propose",
+      from: "bob@waddle.test/phone",
+      sid: "c1",
+      media: audioVideo,
+    });
+
+    expect(notifier.showIncomingCall).toHaveBeenCalledTimes(1);
+    click?.();
+    expect(focused).toEqual(["bob@waddle.test"]);
+  });
+
+  test("ringing event marks the caller's outgoing call as ringing", () => {
+    const { emitCall } = wireClientEvents(mockSender());
+    beginOutgoingCall("bob@waddle.test", "c1", audioVideo, "alice@waddle.test/web");
+    emitCall({
+      kind: "ringing",
+      from: "bob@waddle.test/phone",
+      sid: "c1",
+    });
+
+    expect($callState.get()).toMatchObject({ phase: "outgoing", sid: "c1", ringing: true });
+  });
+
+  test("ringing event from another bare JID does not mark outgoing call as ringing", () => {
+    const { emitCall } = wireClientEvents(mockSender());
+    beginOutgoingCall("bob@waddle.test", "c1", audioVideo, "alice@waddle.test/web");
+    emitCall({
+      kind: "ringing",
+      from: "mallory@waddle.test/phone",
+      sid: "c1",
+    });
+
+    expect($callState.get()).toEqual({
+      phase: "outgoing",
+      to: "bob@waddle.test",
+      sid: "c1",
+      media: audioVideo,
+      initiator: "alice@waddle.test/web",
+    });
+  });
+
+  test("propose during an active call is rejected without audible ringing", async () => {
+    const sender = mockSender();
+    const player = {
+      startLoop: mock(() => undefined),
+      stop: mock(() => undefined),
+    };
+    configureIncomingCallAlerts(createIncomingCallAlertController({
+      player,
+      isTabFocused: () => true,
+    }));
+    $callState.set({
+      phase: "active",
+      peer: "carol@waddle.test/laptop",
+      sid: "active-1",
+      media: audioVideo,
+      join,
+      kind: "dm",
+      initiator: "alice@waddle.test/web",
+    });
+    const { emitCall } = wireClientEvents(sender);
+    emitCall({
+      kind: "propose",
+      from: "bob@waddle.test/phone",
+      sid: "c2",
+      media: audioVideo,
+    });
+    await flushCallSideEffects();
+
+    expect(player.startLoop).not.toHaveBeenCalled();
+    expect(sender.send_call_reject).toHaveBeenCalledWith("bob@waddle.test/phone", "c2");
+  });
 });
 
 describe("tearDownActiveCall", () => {

--- a/chat/tests/outgoing-call-toast.test.ts
+++ b/chat/tests/outgoing-call-toast.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { renderVueComponent } from "./helpers/render-vue-sfc";
+import { $callState, clearCallState } from "../src/lib/calls/call-store";
+
+describe("OutgoingCallToast", () => {
+  afterEach(() => {
+    clearCallState();
+  });
+
+  test("renders calling before the peer reports a ringing device", async () => {
+    $callState.set({
+      phase: "outgoing",
+      to: "bob@waddle.test",
+      sid: "c1",
+      media: { audio: true, video: false },
+      initiator: "alice@waddle.test/web",
+    });
+
+    const html = await render();
+    expect(html).toContain("Audio call");
+    expect(html).toContain("calling");
+    expect(html).not.toContain("ringing");
+  });
+
+  test("renders ringing after XEP-0353 ringing arrives", async () => {
+    $callState.set({
+      phase: "outgoing",
+      to: "bob@waddle.test",
+      sid: "c1",
+      media: { audio: true, video: true },
+      initiator: "alice@waddle.test/web",
+      ringing: true,
+    });
+
+    const html = await render();
+    expect(html).toContain("Video call");
+    expect(html).toContain("ringing");
+    expect(html).not.toContain("calling");
+  });
+});
+
+function render(): Promise<string> {
+  return renderVueComponent("../src/components/calls/OutgoingCallToast.vue", {}, import.meta.url);
+}

--- a/server/crates/waddle-xmpp-client-ffi/src/convert.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/convert.rs
@@ -258,6 +258,7 @@ pub(super) fn call_event_to_ffi(event: InboundCallEvent) -> WaddleCallEvent {
         CallEventKind::Propose { media } => WaddleCallEventKind::Propose {
             media: call_media_to_ffi(media),
         },
+        CallEventKind::Ringing => WaddleCallEventKind::Ringing,
         CallEventKind::Proceed => WaddleCallEventKind::Proceed,
         CallEventKind::Reject { reason, tie_break } => WaddleCallEventKind::Reject {
             reason: reason.map(jingle_reason_to_ffi),
@@ -661,6 +662,13 @@ mod tests {
             }
             other => panic!("expected Retract, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn jmi_ringing_round_trips_through_call_event_to_ffi() {
+        let ringing = call_event_to_ffi(parse_jmi(messaging::build_ringing(&sid("c1"))));
+        assert_eq!(ringing.sid, "c1");
+        assert!(matches!(ringing.kind, WaddleCallEventKind::Ringing));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client-ffi/src/types.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/types.rs
@@ -344,6 +344,8 @@ pub struct WaddleLiveKitJoin {
 pub enum WaddleCallEventKind {
     /// XEP-0353 §5.1.1 `<propose/>` — the ringing UI start signal.
     Propose { media: WaddleCallMedia },
+    /// XEP-0353 §3.2 `<ringing/>` — responder device is ringing.
+    Ringing,
     /// XEP-0353 §5.1.2 `<proceed/>` — peer is accepting the call.
     Proceed,
     /// XEP-0353 §5.1.3 `<reject/>` — peer declined the call.

--- a/server/crates/waddle-xmpp-client-wasm/src/client_calls.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_calls.rs
@@ -2,7 +2,7 @@ use super::*;
 use waddle_xmpp_client::messaging::{
     build_finish, build_finish_migrated, build_muji_session_initiate, build_muji_session_terminate,
     build_proceed, build_propose, build_reject, build_reject_with_options, build_retract,
-    build_retract_with_options, build_session_accept, build_session_initiate,
+    build_retract_with_options, build_ringing, build_session_accept, build_session_initiate,
     build_session_terminate, jingle_reason_from_wire_name, wrap_jmi_message, CallMedia,
     JingleReason, SessionId,
 };
@@ -116,6 +116,15 @@ impl WaddleClient {
         let inner = self.inner.clone();
         future_to_promise(async move {
             let stanza = message_with_jmi_to_full(&peer_full_jid, build_proceed(&sid(sid_str)))?;
+            send_stanza_command(inner, stanza).await?;
+            Ok(JsValue::UNDEFINED)
+        })
+    }
+
+    pub fn send_call_ringing(&self, peer_full_jid: String, sid_str: String) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let stanza = message_with_jmi_to_full(&peer_full_jid, build_ringing(&sid(sid_str)))?;
             send_stanza_command(inner, stanza).await?;
             Ok(JsValue::UNDEFINED)
         })

--- a/server/crates/waddle-xmpp-client-wasm/src/client_calls.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_calls.rs
@@ -121,10 +121,13 @@ impl WaddleClient {
         })
     }
 
-    pub fn send_call_ringing(&self, peer_full_jid: String, sid_str: String) -> Promise {
+    /// Send a JMI `<ringing/>` to the caller's bare JID (XEP-0353
+    /// §3.2). The bare JID lets the initiator's server fan out the
+    /// responder's device-ring state to every caller resource.
+    pub fn send_call_ringing(&self, peer_bare_jid: String, sid_str: String) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
-            let stanza = message_with_jmi_to_full(&peer_full_jid, build_ringing(&sid(sid_str)))?;
+            let stanza = message_with_jmi_to_bare(&peer_bare_jid, build_ringing(&sid(sid_str)))?;
             send_stanza_command(inner, stanza).await?;
             Ok(JsValue::UNDEFINED)
         })
@@ -490,6 +493,25 @@ mod tests {
             .expect("full JID accepted");
         assert_eq!(stanza.attr("to"), Some("bob@waddle.test/phone"));
         assert!(FullJid::from_str("bob@waddle.test").is_err());
+    }
+
+    #[test]
+    fn jmi_ringing_targets_bare_jid_and_rejects_full_jid() {
+        use waddle_xmpp_client::messaging::{build_ringing, SessionId};
+
+        let stanza = super::message_with_jmi_to_bare(
+            "bob@waddle.test",
+            build_ringing(&SessionId("c1".into())),
+        )
+        .expect("bare JID accepted for ringing");
+        assert_eq!(stanza.attr("to"), Some("bob@waddle.test"));
+        assert!(
+            stanza
+                .children()
+                .any(|child| child.name() == "ringing" && child.ns() == NS_JINGLE_MESSAGE),
+            "JMI ringing child preserved"
+        );
+        assert!("bob@waddle.test/phone".parse::<jid::BareJid>().is_err());
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
@@ -615,6 +615,17 @@ pub(crate) fn call_event_to_js(event: InboundCallEvent) -> WaddleCallEvent {
             tie_break: None,
             migrated_to: None,
         },
+        CallEventKind::Ringing => WaddleCallEvent {
+            from,
+            to,
+            sid,
+            kind: "ringing",
+            media: None,
+            join: None,
+            reason: None,
+            tie_break: None,
+            migrated_to: None,
+        },
         CallEventKind::Reject { reason, tie_break } => WaddleCallEvent {
             from,
             to,

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -350,7 +350,7 @@ pub struct WaddleLiveKitJoin {
 }
 
 /// JS-facing call event. The `kind` discriminator drives a switch
-/// on the chat side: `propose|proceed|reject|retract|finish|
+/// on the chat side: `propose|ringing|proceed|reject|retract|finish|
 /// session-initiate|session-accept|session-terminate`.
 ///
 /// For `propose`, `session-initiate`, and `session-accept`, the

--- a/server/crates/waddle-xmpp-client/src/messaging.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging.rs
@@ -24,7 +24,7 @@ pub use call::{
     build_finish, build_finish_migrated, build_finish_with_options, build_finish_with_reason,
     build_muji_jingle_content, build_muji_session_initiate, build_muji_session_terminate,
     build_proceed, build_propose, build_reject, build_reject_with_options, build_retract,
-    build_retract_with_options, build_session_accept, build_session_initiate,
+    build_retract_with_options, build_ringing, build_session_accept, build_session_initiate,
     build_session_terminate, jingle_reason_from_wire_name, jingle_reason_wire_name,
     parse_call_event, parse_jingle_iq, parse_jmi_message, wrap_jmi_message, CallEventKind,
     CallMedia, InboundCallEvent, LiveKitJoin,

--- a/server/crates/waddle-xmpp-client/src/messaging/call.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/call.rs
@@ -3,8 +3,8 @@
 //! Detects two shapes the client receives during a call:
 //!
 //! 1. **XEP-0353 Jingle Message Initiation** envelopes carried on
-//!    `<message>` stanzas — `<propose>`, `<proceed>`, `<reject>`,
-//!    `<retract>`, `<finish>`. These drive the ringing UI before
+//!    `<message>` stanzas — `<propose>`, `<ringing>`, `<proceed>`,
+//!    `<reject>`, `<retract>`, `<finish>`. These drive the ringing UI before
 //!    media starts.
 //! 2. **XEP-0166 Jingle session control** carried on `<iq type='set'>`
 //!    stanzas — `session-initiate`, `session-accept`,
@@ -74,6 +74,7 @@ pub enum CallEventKind {
     Propose {
         media: CallMedia,
     },
+    Ringing,
     Proceed,
     Reject {
         reason: Option<JingleReason>,
@@ -152,6 +153,7 @@ pub fn parse_jmi_message(stanza: &Element) -> Option<InboundCallEvent> {
             "propose" => CallEventKind::Propose {
                 media: media_from_descriptions(child),
             },
+            "ringing" => CallEventKind::Ringing,
             "proceed" => CallEventKind::Proceed,
             "reject" => CallEventKind::Reject {
                 reason: extract_jmi_reason(child),
@@ -402,6 +404,12 @@ pub fn build_propose(sid: &SessionId, media: CallMedia) -> Element {
 
 pub fn build_proceed(sid: &SessionId) -> Element {
     Element::builder("proceed", NS_JINGLE_MESSAGE)
+        .attr(minidom::rxml::xml_ncname!("id").to_owned(), sid.0.as_str())
+        .build()
+}
+
+pub fn build_ringing(sid: &SessionId) -> Element {
+    Element::builder("ringing", NS_JINGLE_MESSAGE)
         .attr(minidom::rxml::xml_ncname!("id").to_owned(), sid.0.as_str())
         .build()
 }

--- a/server/crates/waddle-xmpp-client/src/messaging/call/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/call/tests.rs
@@ -32,6 +32,22 @@ fn parses_proceed() {
 }
 
 #[test]
+fn parses_ringing() {
+    let xml = "<message xmlns='jabber:client' from='bob@waddle.test/phone' to='alice@waddle.test/desktop'>
+            <ringing xmlns='urn:xmpp:jingle-message:0' id='c1'/>
+        </message>";
+    let elem: Element = xml.parse().unwrap();
+    let ev = parse_call_event(&elem).expect("ringing parses");
+    assert_eq!(ev.from.to_string(), "bob@waddle.test/phone");
+    assert_eq!(
+        ev.to.map(|jid| jid.to_string()).as_deref(),
+        Some("alice@waddle.test/desktop")
+    );
+    assert_eq!(ev.sid.0, "c1");
+    assert!(matches!(ev.kind, CallEventKind::Ringing));
+}
+
+#[test]
 fn parses_finish() {
     let xml = "<message xmlns='jabber:client' from='alice@waddle.test/desktop'>
             <finish xmlns='urn:xmpp:jingle-message:0' id='c1'/>
@@ -341,6 +357,16 @@ fn build_jmi_helpers_roundtrip_through_parser() {
         .build();
     let ev = parse_call_event(&stanza).expect("proceed parses");
     assert!(matches!(ev.kind, CallEventKind::Proceed));
+
+    let stanza = Element::builder("message", "jabber:client")
+        .attr(
+            minidom::rxml::xml_ncname!("from").to_owned(),
+            "bob@waddle.test/desktop",
+        )
+        .append(build_ringing(&sid("c1")))
+        .build();
+    let ev = parse_call_event(&stanza).expect("ringing parses");
+    assert!(matches!(ev.kind, CallEventKind::Ringing));
 
     let stanza = Element::builder("message", "jabber:client")
         .attr(

--- a/server/crates/waddle-xmpp/src/xep/xep0353.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0353.rs
@@ -8,7 +8,7 @@
 //!
 //! `<proceed/>`, `<reject/>`, and `<retract/>` continue to ride the
 //! typed [`xmpp_parsers::jingle_message::JingleMI`] enum since they
-//! carry no children. `<propose/>` and `<finish/>` instead build the
+//! carry no children. `<propose/>`, `<ringing/>`, and `<finish/>` instead build the
 //! element directly via [`minidom`]:
 //!
 //! - `JingleMI::Propose` accepts only a single `<description/>` child;
@@ -111,6 +111,12 @@ pub fn build_proceed(sid: SessionId) -> JingleMI {
     JingleMI::Proceed(sid)
 }
 
+pub fn build_ringing(sid: SessionId) -> minidom::Element {
+    minidom::Element::builder("ringing", NS_JINGLE_MESSAGE)
+        .attr(minidom::rxml::xml_ncname!("id").to_owned(), sid.0)
+        .build()
+}
+
 pub fn build_reject(sid: SessionId) -> JingleMI {
     JingleMI::Reject(sid)
 }
@@ -204,6 +210,15 @@ mod tests {
         assert_eq!(elem.attr("id"), Some("c1"));
         let reparsed = JingleMI::try_from(elem).unwrap();
         assert!(matches!(reparsed, JingleMI::Proceed(_)));
+    }
+
+    #[test]
+    fn ringing_has_expected_shape() {
+        let elem = build_ringing(SessionId("c1".into()));
+        assert_eq!(elem.name(), "ringing");
+        assert_eq!(elem.ns(), NS_JINGLE_MESSAGE);
+        assert_eq!(elem.attr("id"), Some("c1"));
+        assert!(elem.children().next().is_none());
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/tests/xep0353_jingle_message.rs
+++ b/server/crates/waddle-xmpp/tests/xep0353_jingle_message.rs
@@ -27,8 +27,8 @@
 
 use minidom::Element;
 use waddle_xmpp::xep::xep0353::{
-    build_finish, build_proceed, build_propose, build_reject, build_retract, CallOffer, JingleMI,
-    NS_JINGLE_MESSAGE,
+    build_finish, build_proceed, build_propose, build_reject, build_retract, build_ringing,
+    CallOffer, JingleMI, NS_JINGLE_MESSAGE,
 };
 use xmpp_parsers::jingle::{Reason as JingleReason, SessionId};
 use xmpp_parsers::message::{Message, MessageType};
@@ -121,6 +121,15 @@ fn xep_0353_proceed_round_trips_through_typed_jingle_mi() {
 
     let reparsed = JingleMI::try_from(elem).expect("proceed reparses");
     assert!(matches!(reparsed, JingleMI::Proceed(_)));
+}
+
+#[test]
+fn xep_0353_ringing_reports_device_ring_state() {
+    let elem = build_ringing(SessionId("c1".into()));
+    assert_eq!(elem.name(), "ringing");
+    assert_eq!(elem.ns(), NS_JINGLE_MESSAGE);
+    assert_eq!(elem.attr("id"), Some("c1"));
+    assert!(elem.children().next().is_none());
 }
 
 #[test]
@@ -259,6 +268,11 @@ fn xep_0353_propose_envelope_is_chat_with_store_hint() {
 #[test]
 fn xep_0353_proceed_envelope_is_chat_with_store_hint() {
     assert_jmi_envelope_conformant("proceed", || build_proceed(SessionId("c1".into())).into());
+}
+
+#[test]
+fn xep_0353_ringing_envelope_is_chat_with_store_hint() {
+    assert_jmi_envelope_conformant("ringing", || build_ringing(SessionId("c1".into())));
 }
 
 #[test]

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -273,7 +273,12 @@ export class WaddleClient {
      */
     send_call_retract(peer_bare_jid: string, sid_str: string): Promise<any>;
     send_call_retract_tie_break(peer_full_jid: string, sid_str: string): Promise<any>;
-    send_call_ringing(peer_full_jid: string, sid_str: string): Promise<any>;
+    /**
+     * Send a JMI `<ringing/>` to the caller's bare JID (XEP-0353
+     * §3.2). The bare JID lets the initiator's server fan out the
+     * responder's device-ring state to every caller resource.
+     */
+    send_call_ringing(peer_bare_jid: string, sid_str: string): Promise<any>;
     /**
      * Send a Jingle `session-accept` IQ in response to a received
      * session-initiate. `responder` is validated as a full JID at

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -273,6 +273,7 @@ export class WaddleClient {
      */
     send_call_retract(peer_bare_jid: string, sid_str: string): Promise<any>;
     send_call_retract_tie_break(peer_full_jid: string, sid_str: string): Promise<any>;
+    send_call_ringing(peer_full_jid: string, sid_str: string): Promise<any>;
     /**
      * Send a Jingle `session-accept` IQ in response to a received
      * session-initiate. `responder` is validated as a full JID at

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=72784cf63a3b";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=72784cf63a3b";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=72784cf63a3b";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=5e8bf2254b89";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=5e8bf2254b89";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=5e8bf2254b89";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=72784cf63a3b";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=5e8bf2254b89";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=2f59805d5876";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=2f59805d5876";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=2f59805d5876";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=72784cf63a3b";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=72784cf63a3b";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=72784cf63a3b";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=2f59805d5876";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=72784cf63a3b";


### PR DESCRIPTION
Closes #947.

## Plan

- Extend XEP-0353 call handling with a typed `ringing` event and sender helper.
- Add an app-shell incoming-call alert controller with injectable audio, notification, and focus adapters.
- Wire incoming DM call proposals to start/stop alerts, send `<ringing/>`, and keep sibling-device answer/decline/retract behavior quiet and consistent.
- Surface caller-side ringing state in the outgoing call toast.
- Cover the behavior in chat tests plus dedicated XEP-0353 Rust, WASM, and Apple FFI surfaces.

## Changes

- Added `chat/src/shell/audio-alerts.ts` for injectable looping ringtone, desktop notification, and focus behavior.
- Wired `ChatReadyShell` to configure browser alert adapters for the call store.
- Updated call state reduction so incoming proposes start alerts and emit XEP-0353 `<ringing/>`, while local decline, sibling proceed/reject, caller retract, and active-call auto-reject stop or avoid audible ringing.
- Addressed review feedback by sending `<ringing/>` to the caller's bare JID so all caller resources can observe ring state.
- Added caller UI state for `ringing...` in `OutgoingCallToast`.
- Added XEP-0353 ringing parsing/building in `waddle-xmpp-client`, WASM bindings for `send_call_ringing`, and server-side XEP-0353 ringing envelope coverage.
- Mirrored the new `ringing` call event through the Apple UniFFI and Swift call-event surfaces.
- Updated generated WASM and Apple UniFFI bindings.

## Simplifications

- Kept browser audio and Notification APIs out of the reducer through injected adapters.
- Reused existing call state and XMPP outbound wiring instead of adding a separate call-alert state machine.
- Used generic notification text so OS-level notifications do not expose peer JIDs.
- Rejected spoofed ringing updates unless the event comes from the active outgoing call peer.
- Kept Apple handling to a typed event mirror because the Apple call UI is not part of this PR.

## Verification

- `bun test`
- `bun run lint`
- `bun run build`
- `cargo test -p waddle-xmpp-client messaging::call`
- `cargo test -p waddle-xmpp-client-wasm`
- `cargo test -p waddle-xmpp-client-wasm client_calls`
- `cargo test -p waddle-xmpp-client-ffi`
- `cargo test -p waddle-xmpp --test xep0353_jingle_message`
- `cargo clippy -p waddle-xmpp -p waddle-xmpp-client -p waddle-xmpp-client-wasm -- -D warnings`
- `cargo clippy -p waddle-xmpp-client-ffi -p waddle-xmpp-client -- -D warnings`
- `cargo fmt --all -- --check`
- `bash server/scripts/check-xmpp-client-ffi-bindings.sh`
- `bash scripts/build-xcframework.sh --debug`
- `CLANG_MODULE_CACHE_PATH=/private/tmp/waddle-clang-module-cache SWIFT_MODULE_CACHE_PATH=/private/tmp/waddle-swift-module-cache xcodebuild -project apps/apple/Waddle.xcodeproj -scheme Waddle-macOS -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -derivedDataPath /private/tmp/waddle-xcode-derived build`
- `git diff --check`

## CI

All PR checks are green on the latest commit, including `waddle-chat-pullRequest`, `apple-xmpp-client`, `checkXmppClientFfiBindings`, `nixFmt`, `nixClippy`, `nixTest`, and the XMPP server/unit/XEP integration suites.

## Review Notes

- Addressed PR review by changing `<ringing/>` addressing from proposer full JID to initiator bare JID.
- Addressed adversarial test review by adding sibling proceed, local answer, and dedicated XEP-0353 ringing tests.
- Addressed security review by keeping notification contents generic and validating ringing senders against the active outgoing peer.
- Addressed code review by adding visible caller-side ringing state and a component test.

## Remaining Risks

- Browser autoplay and desktop notification behavior can vary by browser and OS; the implementation is adapter-based and covered with injected fakes, but exact platform UX still needs manual browser smoke testing.
