### PR TITLE
fix(chat): record dm call outcomes

### DIFF
--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -33,7 +33,12 @@ import { useDmChatStates } from "@/dms/chat-states";
 import { useDmReadMarkers } from "@/dms/read-markers";
 import { useDmMessageSearch } from "@/dms/message-search";
 import { useChatWindowVisibility } from "@/shell/window-visibility";
-import { $dmCallStartedAnchor, resolveDmCallAnchorInjection } from "@/lib/calls/dm-call-anchor";
+import {
+  $dmCallOutcomeAnchor,
+  $dmCallStartedAnchor,
+  resolveDmCallAnchorInjection,
+  resolveDmCallOutcomeInjection,
+} from "@/lib/calls/dm-call-anchor";
 
 export function useDirectMessages(
   session: Ref<WaddleSession | null>,
@@ -214,7 +219,17 @@ export function useDirectMessages(
       );
       if (card) liveMerge.mergeLiveMessage(card);
     });
+    const stopDmCallOutcomeListener = $dmCallOutcomeAnchor.listen((anchor) => {
+      if (!anchor) return;
+      const card = resolveDmCallOutcomeInjection(
+        anchor,
+        activePeerJid.value,
+        session.value?.jid ?? null,
+      );
+      if (card) liveMerge.mergeLiveMessage(card);
+    });
     onScopeDispose(stopDmCallAnchorListener);
+    onScopeDispose(stopDmCallOutcomeListener);
   }
 
   const actions = useDmMessageActions({

--- a/chat/src/lib/call-thread-anchor.ts
+++ b/chat/src/lib/call-thread-anchor.ts
@@ -24,6 +24,16 @@ export interface CallAnchorCardState {
 }
 
 export function callThreadAnchorLabel(message: Pick<TimelineMessage, "body" | "author" | "callThread">): string {
+  switch (message.callThread?.outcome) {
+    case "declined":
+      return "Call declined";
+    case "missed":
+      return "Missed call";
+    case "no-answer":
+      return "No answer";
+    case "ended":
+      return "Call ended";
+  }
   if (message.callThread?.ended && message.callThread.duration) {
     return `Call ended · ${formatCallThreadDuration(message.callThread.duration)}`;
   }
@@ -200,9 +210,11 @@ function buildCallAnchorCardState(options: {
     threadId: callThreadAnchorThreadId(message),
     title: live
       ? `Live ${mediaLabel}`
-      : callThread.ended && callThread.duration
-        ? `Call ended · ${formatCallThreadDuration(callThread.duration)}`
-        : "Call ended",
+      : callThread.outcome
+        ? callThreadAnchorLabel(message)
+        : callThread.ended && callThread.duration
+          ? `Call ended · ${formatCallThreadDuration(callThread.duration)}`
+          : "Call ended",
     actionLabel: joinAvailable ? (retainedLocalResource ? "Rejoin" : "Join") : busy ? "In another call" : null,
     actionDisabled: busy,
     // Keep the aria label in step with the rendered action: only announce

--- a/chat/src/lib/call-thread-anchor.ts
+++ b/chat/src/lib/call-thread-anchor.ts
@@ -32,6 +32,9 @@ export function callThreadAnchorLabel(message: Pick<TimelineMessage, "body" | "a
     case "no-answer":
       return "No answer";
     case "ended":
+      if (message.callThread.duration) {
+        return `Call ended · ${formatCallThreadDuration(message.callThread.duration)}`;
+      }
       return "Call ended";
   }
   if (message.callThread?.ended && message.callThread.duration) {

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -18,7 +18,11 @@ import {
 } from "./muc-call-session-cache";
 import { clearLiveCallParticipants } from "./muc-call-live-participants";
 import { mediaErrorMessage } from "./call-media-issues";
-import { dmCallStartedAnchorFromTransition, publishDmCallStartedAnchor } from "./dm-call-anchor";
+import {
+  dmCallStartedAnchorFromTransition,
+  publishDmCallOutcomeAnchor,
+  publishDmCallStartedAnchor,
+} from "./dm-call-anchor";
 import { barePeerJid } from "../xmpp/jid";
 import type { IncomingCallAlertController } from "@/shell/audio-alerts";
 
@@ -479,6 +483,17 @@ let outgoingTimer: ReturnType<typeof setTimeout> | null = null;
 let sessionAcceptTimer: ReturnType<typeof setTimeout> | null = null;
 let sessionAcceptTimeoutMs = SESSION_ACCEPT_TIMEOUT_MS;
 
+function publishNoAnswerOutcome(peerJid: string, sid: string, media: CallMedia, initiator?: string): void {
+  publishDmCallOutcomeAnchor({
+    peerBareJid: barePeerJid(peerJid),
+    sid,
+    media,
+    outcome: "no-answer",
+    ...(initiator ? { initiator } : {}),
+    ended: new Date().toISOString(),
+  });
+}
+
 /**
  * Schedule the auto-retract for the most recent `beginOutgoingCall`.
  * The timer fires `outboundCalls.retract` if the slot is still in
@@ -504,6 +519,7 @@ export function scheduleOutgoingTimeout(
     void outboundCalls
       .retract(sender, s.to, s.sid)
       .catch((err) => reportCallError(err));
+    publishNoAnswerOutcome(s.to, sid, s.media, s.initiator);
     clearDmCallActivity(s.to, sid);
     $callState.set({
       phase: "ended",
@@ -535,6 +551,7 @@ export function scheduleSessionAcceptTimeout(
     void outboundCalls
       .sessionTerminate(sender, peerFullJid, sid, "timeout")
       .catch((err) => reportCallError(err));
+    publishNoAnswerOutcome(peerFullJid, sid, s.media, s.initiator);
     clearDmCallActivity(peerFullJid, sid);
     $callState.set({
       phase: "ended",

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -671,10 +671,9 @@ export async function tearDownActiveCall(
                 await outboundCalls.finish(sender, s.peer, s.sid);
               } catch (err) {
                 reportCallError(err);
-              } finally {
-                clearDmCallActivity(s.peer, s.sid);
               }
             }
+            clearDmCallActivity(s.peer, s.sid);
           } else {
             // MUC group call: clear our Muji presence AND leave via
             // the IQ surface. Presence-first ordering (XEP-0272

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -646,21 +646,34 @@ export async function tearDownActiveCall(
       switch (s.phase) {
         case "active":
           if (s.kind === "dm") {
+            let terminateAllowsFinish = false;
             try {
-              await outboundCalls.sessionTerminate(sender, s.peer, s.sid, reason);
-              // XEP-0353 §3.5: both parties SHOULD send `<finish/>` after
-              // the call ends so MAM archives both sides consistently
-              // (the JMI message stack uses the finish marker to bookend
-              // the call record). Best-effort: a wasm bundle that
-              // doesn't expose `send_call_finish` shouldn't keep the
-              // terminate from clearing the local slot.
+              const outcome = await outboundCalls.sessionTerminateWithOutcome(
+                sender,
+                s.peer,
+                s.sid,
+                reason,
+              );
+              terminateAllowsFinish = outcome === "ok" || outcome === "orphaned";
+              if (outcome === "error") {
+                reportCallError(new Error("call session terminate failed"));
+              }
+            } catch (err) {
+              reportCallError(err);
+            }
+            if (terminateAllowsFinish) {
               try {
+                // XEP-0353 §3.5: both parties SHOULD send `<finish/>`
+                // after the call ends so MAM archives both sides
+                // consistently. A classified orphaned Jingle terminate
+                // means the server has already lost the call registry, so
+                // only the message-level bookend can still route.
                 await outboundCalls.finish(sender, s.peer, s.sid);
               } catch (err) {
                 reportCallError(err);
+              } finally {
+                clearDmCallActivity(s.peer, s.sid);
               }
-            } finally {
-              clearDmCallActivity(s.peer, s.sid);
             }
           } else {
             // MUC group call: clear our Muji presence AND leave via

--- a/chat/src/lib/calls/dm-call-actions.ts
+++ b/chat/src/lib/calls/dm-call-actions.ts
@@ -162,23 +162,33 @@ export async function endRecoveredDmCallAction(options: {
   const remoteFullJid = activity.remoteFullJid;
   if (!remoteFullJid) return false;
 
+  let sentEndMarker = false;
+  let terminateAllowsFinish = false;
   try {
-    await outboundCalls.sessionTerminate(
+    const outcome = await outboundCalls.sessionTerminateWithOutcome(
       sender,
       remoteFullJid,
       activity.sid,
       "success",
     );
+    terminateAllowsFinish = outcome === "ok" || outcome === "orphaned";
+    if (outcome === "error") {
+      reportCallError(new Error("call session terminate failed"));
+    }
   } catch (err) {
     reportCallError(err);
-    return false;
   }
 
-  try {
-    await outboundCalls.finish(sender, remoteFullJid, activity.sid);
-  } catch (err) {
-    reportCallError(err);
+  if (terminateAllowsFinish) {
+    try {
+      await outboundCalls.finish(sender, remoteFullJid, activity.sid);
+      sentEndMarker = true;
+    } catch (err) {
+      reportCallError(err);
+    }
   }
+
+  if (!sentEndMarker) return false;
 
   clearDmCallActivity(peer, activity.sid);
   return true;

--- a/chat/src/lib/calls/dm-call-activity.ts
+++ b/chat/src/lib/calls/dm-call-activity.ts
@@ -7,6 +7,7 @@ import {
   readDmCallJoin,
   rememberDmCallJoin,
 } from "./dm-call-join-cache";
+import { publishDmCallOutcomeAnchor, type DmCallOutcome } from "./dm-call-anchor";
 import type { CallEvent, CallMedia, LiveKitJoin } from "./types";
 
 export const DM_CALL_ACTIVITY_ACTIVE_WINDOW_MS = 24 * 60 * 60 * 1000;
@@ -64,6 +65,7 @@ interface DmCallEventEnvelope {
   timestamp?: string | null;
   now?: Date;
   directionHint?: DmCallActivity["direction"];
+  publishOutcome?: boolean;
 }
 
 function normalizedBare(jid?: string | null): string {
@@ -301,6 +303,58 @@ function isTerminalEvent(event: CallEvent): boolean {
     event.kind === "retract" ||
     event.kind === "finish" ||
     event.kind === "session-terminate";
+}
+
+function outcomeForTerminalEvent(
+  event: CallEvent,
+  previous: DmCallActivity | undefined,
+  direction: DmCallActivity["direction"],
+): DmCallOutcome {
+  if (event.kind === "reject") return "declined";
+  if (event.kind === "finish" || event.kind === "session-terminate") return "ended";
+  const callDirection = previous?.direction ?? direction;
+  return callDirection === "outgoing" ? "no-answer" : "missed";
+}
+
+function publishTerminalOutcome(params: {
+  peerJid: string;
+  sid: string;
+  timestamp: string;
+  event: CallEvent;
+  previous?: DmCallActivity;
+  direction: DmCallActivity["direction"];
+  selfJid?: string | null;
+}): void {
+  const media = eventMedia(params.event, params.previous);
+  const initiator = terminalOutcomeInitiator(params);
+  publishDmCallOutcomeAnchor({
+    peerBareJid: params.peerJid,
+    sid: params.sid,
+    media: media.media,
+    outcome: outcomeForTerminalEvent(params.event, params.previous, params.direction),
+    ...(initiator ? { initiator } : {}),
+    ended: params.timestamp,
+  });
+}
+
+function terminalOutcomeInitiator(params: {
+  peerJid: string;
+  event: CallEvent;
+  previous?: DmCallActivity;
+  direction: DmCallActivity["direction"];
+  selfJid?: string | null;
+}): string | undefined {
+  if (params.previous?.direction === "outgoing") return params.selfJid ?? undefined;
+  if (params.previous?.direction === "incoming") return params.previous.remoteFullJid ?? params.event.from;
+  const selfBare = normalizedBare(params.selfJid);
+  const fromBare = normalizedBare(params.event.from);
+  if (params.event.kind === "reject") {
+    return fromBare === selfBare ? params.peerJid : params.selfJid ?? undefined;
+  }
+  if (params.event.kind === "retract") return params.event.from;
+  if (params.direction === "outgoing") return params.selfJid ?? undefined;
+  if (params.direction === "incoming") return params.event.from;
+  return undefined;
 }
 
 function isOlderThanTerminal(peerJid: string, sid: string, timestamp: string): boolean {
@@ -602,6 +656,17 @@ export function applyDmCallEvent(envelope: DmCallEventEnvelope): void {
     case "retract":
     case "finish":
     case "session-terminate":
+      if (envelope.publishOutcome !== false) {
+        publishTerminalOutcome({
+          peerJid,
+          sid: envelope.event.sid,
+          timestamp,
+          event: envelope.event,
+          previous: previousForSid,
+          direction,
+          selfJid: envelope.selfFullJid ?? envelope.selfBareJid,
+        });
+      }
       recordTerminal(peerJid, envelope.event.sid, timestamp, now);
       forgetDmCallJoin({ selfBareJid: envelope.selfBareJid, peerJid, sid: envelope.event.sid });
       removeActivity(peerJid, envelope.event.sid);

--- a/chat/src/lib/calls/dm-call-activity.ts
+++ b/chat/src/lib/calls/dm-call-activity.ts
@@ -7,7 +7,11 @@ import {
   readDmCallJoin,
   rememberDmCallJoin,
 } from "./dm-call-join-cache";
-import { publishDmCallOutcomeAnchor, type DmCallOutcome } from "./dm-call-anchor";
+import {
+  publishDmCallOutcomeAnchor,
+  type DmCallOutcome,
+  type DmCallOutcomeAnchor,
+} from "./dm-call-anchor";
 import type { CallEvent, CallMedia, LiveKitJoin } from "./types";
 
 export const DM_CALL_ACTIVITY_ACTIVE_WINDOW_MS = 24 * 60 * 60 * 1000;
@@ -311,12 +315,13 @@ function outcomeForTerminalEvent(
   direction: DmCallActivity["direction"],
 ): DmCallOutcome {
   if (event.kind === "reject") return "declined";
+  if (event.kind === "session-terminate" && event.reason === "timeout") return "no-answer";
   if (event.kind === "finish" || event.kind === "session-terminate") return "ended";
   const callDirection = previous?.direction ?? direction;
   return callDirection === "outgoing" ? "no-answer" : "missed";
 }
 
-function publishTerminalOutcome(params: {
+function terminalOutcomeAnchor(params: {
   peerJid: string;
   sid: string;
   timestamp: string;
@@ -324,17 +329,17 @@ function publishTerminalOutcome(params: {
   previous?: DmCallActivity;
   direction: DmCallActivity["direction"];
   selfJid?: string | null;
-}): void {
+}): DmCallOutcomeAnchor {
   const media = eventMedia(params.event, params.previous);
   const initiator = terminalOutcomeInitiator(params);
-  publishDmCallOutcomeAnchor({
+  return {
     peerBareJid: params.peerJid,
     sid: params.sid,
     media: media.media,
     outcome: outcomeForTerminalEvent(params.event, params.previous, params.direction),
     ...(initiator ? { initiator } : {}),
     ended: params.timestamp,
-  });
+  };
 }
 
 function terminalOutcomeInitiator(params: {
@@ -570,24 +575,24 @@ export function clearDmCallActivity(peerJid: string, sid?: string): void {
   $dmCallActivities.set(next);
 }
 
-export function applyDmCallEvent(envelope: DmCallEventEnvelope): void {
+export function applyDmCallEvent(envelope: DmCallEventEnvelope): DmCallOutcomeAnchor | null {
   const peerJid = peerForEnvelope(envelope);
-  if (!peerJid) return;
+  if (!peerJid) return null;
   const timestamp = timestampFromEnvelope(envelope);
   const now = envelope.now ?? new Date();
   if (isStale(timestamp, now)) {
     removeActivity(peerJid, envelope.event.sid);
-    return;
+    return null;
   }
   const previousForSidEntry = findActivityForSid(peerJid, envelope.event.sid);
   const previousForSid = previousForSidEntry?.[1];
-  if (isOlderThanCurrent(timestamp, previousForSid)) return;
-  if (!isTerminalEvent(envelope.event) && isOlderThanTerminal(peerJid, envelope.event.sid, timestamp)) return;
+  if (isOlderThanCurrent(timestamp, previousForSid)) return null;
+  if (!isTerminalEvent(envelope.event) && isOlderThanTerminal(peerJid, envelope.event.sid, timestamp)) return null;
   const direction = directionForEnvelope(envelope);
   const remoteFullJid = remoteFullJidForEnvelope(envelope, peerJid);
   switch (envelope.event.kind) {
     case "ringing":
-      return;
+      return null;
     case "propose":
       setActivity(peerJid, envelope.event.sid, eventSelfFullJid(envelope), {
         peerJid,
@@ -599,7 +604,7 @@ export function applyDmCallEvent(envelope: DmCallEventEnvelope): void {
         updatedAt: timestamp,
       });
       scheduleActivityPrune(now);
-      return;
+      return null;
     case "proceed":
     case "session-initiate":
     case "session-accept":
@@ -651,26 +656,28 @@ export function applyDmCallEvent(envelope: DmCallEventEnvelope): void {
         updatedAt: timestamp,
       });
       scheduleActivityPrune(now);
-      return;
+      return null;
     case "reject":
     case "retract":
     case "finish":
     case "session-terminate":
+      if (isOlderThanTerminal(peerJid, envelope.event.sid, timestamp)) return null;
+      const outcomeAnchor = terminalOutcomeAnchor({
+        peerJid,
+        sid: envelope.event.sid,
+        timestamp,
+        event: envelope.event,
+        previous: previousForSid,
+        direction,
+        selfJid: envelope.selfFullJid ?? envelope.selfBareJid,
+      });
       if (envelope.publishOutcome !== false) {
-        publishTerminalOutcome({
-          peerJid,
-          sid: envelope.event.sid,
-          timestamp,
-          event: envelope.event,
-          previous: previousForSid,
-          direction,
-          selfJid: envelope.selfFullJid ?? envelope.selfBareJid,
-        });
+        publishDmCallOutcomeAnchor(outcomeAnchor);
       }
       recordTerminal(peerJid, envelope.event.sid, timestamp, now);
       forgetDmCallJoin({ selfBareJid: envelope.selfBareJid, peerJid, sid: envelope.event.sid });
       removeActivity(peerJid, envelope.event.sid);
-      return;
+      return outcomeAnchor;
   }
 }
 

--- a/chat/src/lib/calls/dm-call-activity.ts
+++ b/chat/src/lib/calls/dm-call-activity.ts
@@ -371,6 +371,10 @@ function isOlderThanTerminal(peerJid: string, sid: string, timestamp: string): b
   return nextMs <= terminalMs;
 }
 
+function hasRecordedTerminal(peerJid: string, sid: string): boolean {
+  return dmCallTerminalTimestamps.has(terminalKey(peerJid, sid));
+}
+
 function pruneTerminalTimestamps(now: Date): void {
   for (const [key, timestamp] of dmCallTerminalTimestamps) {
     if (isStale(timestamp, now)) {
@@ -661,7 +665,7 @@ export function applyDmCallEvent(envelope: DmCallEventEnvelope): DmCallOutcomeAn
     case "retract":
     case "finish":
     case "session-terminate":
-      if (isOlderThanTerminal(peerJid, envelope.event.sid, timestamp)) return null;
+      if (hasRecordedTerminal(peerJid, envelope.event.sid)) return null;
       const outcomeAnchor = terminalOutcomeAnchor({
         peerJid,
         sid: envelope.event.sid,

--- a/chat/src/lib/calls/dm-call-anchor.ts
+++ b/chat/src/lib/calls/dm-call-anchor.ts
@@ -24,6 +24,19 @@ export type DmCallStartedAnchor = {
   started: string;
 };
 
+export type DmCallOutcome = "declined" | "missed" | "no-answer" | "ended";
+
+export type DmCallOutcomeAnchor = {
+  peerBareJid: string;
+  sid: string;
+  media: CallMedia;
+  outcome: DmCallOutcome;
+  /** Bare or full JID of the call initiator when known. */
+  initiator?: string;
+  /** ISO-8601 terminal timestamp. */
+  ended: string;
+};
+
 /**
  * Deterministic timeline id for a DM call-thread anchor, shared by the
  * synthesized live card and the MAM-replayed archive row (via a wire-id alias)
@@ -31,6 +44,10 @@ export type DmCallStartedAnchor = {
  */
 export function dmCallAnchorId(sid: string): string {
   return `dmcall:${sid}`;
+}
+
+export function dmCallOutcomeAnchorId(sid: string, outcome: DmCallOutcome): string {
+  return `dmcall:${sid}:${outcome}`;
 }
 
 function callThreadMedia(media: CallMedia): ("audio" | "video")[] {
@@ -71,6 +88,33 @@ export function buildDmCallStartedAnchor(
     isSelf,
     threadId: anchor.sid,
     callThread,
+  };
+}
+
+export function buildDmCallOutcomeAnchor(
+  anchor: DmCallOutcomeAnchor,
+  selfJid: string,
+): TimelineMessage {
+  const initiator = anchor.initiator ? barePeerJid(anchor.initiator).toLowerCase() : "";
+  const selfBare = barePeerJid(selfJid).toLowerCase();
+  const isSelfInitiated = !!initiator && initiator === selfBare;
+  return {
+    id: dmCallOutcomeAnchorId(anchor.sid, anchor.outcome),
+    author: isSelfInitiated ? (selfBare.split("@")[0] ?? "you") : (anchor.peerBareJid.split("@")[0] ?? "unknown"),
+    authorJid: isSelfInitiated ? selfJid : anchor.peerBareJid,
+    body: "",
+    createdAt: anchor.ended,
+    createdAtSource: "fallback",
+    isSelf: isSelfInitiated,
+    threadId: anchor.sid,
+    callThread: {
+      kind: "dm",
+      sid: anchor.sid,
+      media: callThreadMedia(anchor.media),
+      ...(anchor.initiator ? { initiator: anchor.initiator } : {}),
+      ended: anchor.ended,
+      outcome: anchor.outcome,
+    },
   };
 }
 
@@ -120,6 +164,21 @@ export function resolveDmCallAnchorInjection(
   return buildDmCallStartedAnchor(anchor, selfJid);
 }
 
+export function resolveDmCallOutcomeInjection(
+  anchor: DmCallOutcomeAnchor,
+  activePeerJid: string | null,
+  selfJid: string | null,
+): TimelineMessage | null {
+  if (!selfJid || !activePeerJid) return null;
+  if (
+    barePeerJid(anchor.peerBareJid).toLowerCase()
+    !== barePeerJid(activePeerJid).toLowerCase()
+  ) {
+    return null;
+  }
+  return buildDmCallOutcomeAnchor(anchor, selfJid);
+}
+
 /**
  * Bridge from the call layer (`applyCallEvent`) to the DM messaging
  * composable, which appends the synthesized anchor to the open conversation.
@@ -127,7 +186,12 @@ export function resolveDmCallAnchorInjection(
  * timeline/session — the composable derives `isSelf` from its own session.
  */
 export const $dmCallStartedAnchor = atom<DmCallStartedAnchor | null>(null);
+export const $dmCallOutcomeAnchor = atom<DmCallOutcomeAnchor | null>(null);
 
 export function publishDmCallStartedAnchor(anchor: DmCallStartedAnchor): void {
   $dmCallStartedAnchor.set(anchor);
+}
+
+export function publishDmCallOutcomeAnchor(anchor: DmCallOutcomeAnchor): void {
+  $dmCallOutcomeAnchor.set(anchor);
 }

--- a/chat/src/lib/calls/dm-call-anchor.ts
+++ b/chat/src/lib/calls/dm-call-anchor.ts
@@ -95,8 +95,12 @@ export function buildDmCallOutcomeAnchor(
   anchor: DmCallOutcomeAnchor,
   selfJid: string,
 ): TimelineMessage {
-  const initiator = anchor.initiator ? barePeerJid(anchor.initiator).toLowerCase() : "";
   const selfBare = barePeerJid(selfJid).toLowerCase();
+  const initiator = anchor.initiator
+    ? barePeerJid(anchor.initiator).toLowerCase()
+    : anchor.outcome === "no-answer"
+      ? selfBare
+      : "";
   const isSelfInitiated = !!initiator && initiator === selfBare;
   return {
     id: dmCallOutcomeAnchorId(anchor.sid, anchor.outcome),

--- a/chat/src/lib/calls/outbound.ts
+++ b/chat/src/lib/calls/outbound.ts
@@ -35,7 +35,14 @@ export type CallWireSender = {
     sid: string,
     reason: string | null,
   ) => Promise<unknown>;
+  send_call_session_terminate_with_outcome?: (
+    peer_full_jid: string,
+    sid: string,
+    reason: string | null,
+  ) => Promise<unknown>;
 };
+
+export type CallSessionTerminateOutcome = "ok" | "orphaned" | "error";
 
 /**
  * Generate a fresh Jingle session id. The server namespaces this
@@ -159,4 +166,25 @@ export const outboundCalls = {
       throw new WasmCallApiUnavailable("send_call_session_terminate");
     await client.send_call_session_terminate(peerFullJid, sid, reason);
   },
+
+  async sessionTerminateWithOutcome(
+    client: CallWireSender,
+    peerFullJid: string,
+    sid: string,
+    reason: string | null,
+  ): Promise<CallSessionTerminateOutcome> {
+    if (!client.send_call_session_terminate_with_outcome) {
+      await this.sessionTerminate(client, peerFullJid, sid, reason);
+      return "ok";
+    }
+    const result = await client.send_call_session_terminate_with_outcome(peerFullJid, sid, reason);
+    if (isCallSessionTerminateOutcome(result)) return result.kind;
+    return "error";
+  },
 };
+
+function isCallSessionTerminateOutcome(value: unknown): value is { kind: CallSessionTerminateOutcome } {
+  if (!value || typeof value !== "object") return false;
+  const kind = (value as { kind?: unknown }).kind;
+  return kind === "ok" || kind === "orphaned" || kind === "error";
+}

--- a/chat/src/lib/calls/outbound.ts
+++ b/chat/src/lib/calls/outbound.ts
@@ -174,7 +174,7 @@ export const outboundCalls = {
     reason: string | null,
   ): Promise<CallSessionTerminateOutcome> {
     if (!client.send_call_session_terminate_with_outcome) {
-      await this.sessionTerminate(client, peerFullJid, sid, reason);
+      await outboundCalls.sessionTerminate(client, peerFullJid, sid, reason);
       return "ok";
     }
     const result = await client.send_call_session_terminate_with_outcome(peerFullJid, sid, reason);

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -55,6 +55,7 @@ export interface CallThreadAnchor {
   started?: string;
   ended?: string;
   duration?: string;
+  outcome?: "declined" | "missed" | "no-answer" | "ended";
 }
 
 export interface LinkPreview {

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -2784,7 +2784,7 @@ export class BrowserXmppClient {
   private applyDmCallEventsFromMamPage(
     page: WasmMamPage | null | undefined,
     selfBare = barePeerJid(this.session.jid),
-    options: { since?: string; seenIds?: ReadonlyArray<string> } = {},
+    options: { since?: string; seenIds?: ReadonlyArray<string>; publishOutcome?: boolean } = {},
   ): void {
     for (const message of page?.messages ?? []) {
       if (!message.call_event) continue;
@@ -2795,6 +2795,7 @@ export class BrowserXmppClient {
         selfFullJid: this.fullJid,
         to: message.to,
         timestamp: message.timestamp,
+        publishOutcome: options.publishOutcome,
       });
     }
   }
@@ -2873,7 +2874,7 @@ export class BrowserXmppClient {
     if (!this.isCurrentConnectedXmpp(xmpp, sessionJid)) return;
     const selfBare = barePeerJid(sessionJid);
     for (const page of [...pages].reverse()) {
-      this.applyDmCallEventsFromMamPage(page, selfBare);
+      this.applyDmCallEventsFromMamPage(page, selfBare, { publishOutcome: false });
     }
   }
   async hydrateRecentDmCallActivities(
@@ -2891,7 +2892,7 @@ export class BrowserXmppClient {
     if (!this.isCurrentConnectedXmpp(xmpp, sessionJid)) return;
     const selfBare = barePeerJid(sessionJid);
     for (const page of [...pages].reverse()) {
-      this.applyDmCallEventsFromMamPage(page, selfBare);
+      this.applyDmCallEventsFromMamPage(page, selfBare, { publishOutcome: false });
     }
   }
   async searchDmMessages(peerJid: string, query: string, max = 20): Promise<MessageSearchResult[]> {

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -17,6 +17,7 @@ import {
   applyDmCallEvent,
   clearDmCallActivities,
 } from "@/lib/calls/dm-call-activity";
+import { buildDmCallOutcomeAnchor, type DmCallOutcomeAnchor } from "@/lib/calls/dm-call-anchor";
 import { handleCallEventSideEffect } from "@/lib/calls/call-effects";
 import {
   applyMucCallPresence,
@@ -257,6 +258,11 @@ type InboundWasmMessage = WasmMessage & {
   inboxPush?: InboxEntry;
   inbox_push?: WasmInboxConversation;
   _fromCarbon?: boolean;
+};
+
+type ArchivedDmCallOutcome = {
+  anchor: DmCallOutcomeAnchor;
+  terminalMessage: WasmArchivedMessage;
 };
 
 function shouldSkipCatchupMessage(
@@ -2771,25 +2777,53 @@ export class BrowserXmppClient {
   private roomMamPageToMessages(page: WasmMamPage): MamHistoryPage<LiveRoomMessage> {
     return { messages: page.messages.map((message) => roomMessageFromArchived(message, { trustedMediaOrigin: this.trustedLinkPreviewMediaOrigin() })).filter((message): message is LiveRoomMessage => !!message), ...(page.first_id ? { firstArchiveId: page.first_id } : {}), ...(page.last_id ? { lastArchiveId: page.last_id } : {}), complete: page.is_complete };
   }
-  private dmMamPageToMessages(
-    page: WasmMamPage,
-    options: { applyCallEvents?: boolean } = {},
-  ): MamHistoryPage<LiveDmMessage> {
+  private dmMamPageToMessages(page: WasmMamPage): MamHistoryPage<LiveDmMessage> {
     const selfBare = barePeerJid(this.session.jid);
-    if (options.applyCallEvents !== false) {
-      this.applyDmCallEventsFromMamPage(page, selfBare);
-    }
-    return { messages: page.messages.map((message) => dmMessageFromArchived(message, selfBare, { trustedMediaOrigin: this.trustedLinkPreviewMediaOrigin() })).filter((message): message is LiveDmMessage => !!message), ...(page.first_id ? { firstArchiveId: page.first_id } : {}), ...(page.last_id ? { lastArchiveId: page.last_id } : {}), complete: page.is_complete };
+    const outcomeAnchors = this.applyDmCallEventsFromMamPage(page, selfBare, { publishOutcome: false });
+    const messages = page.messages
+      .map((message) => dmMessageFromArchived(message, selfBare, { trustedMediaOrigin: this.trustedLinkPreviewMediaOrigin() }))
+      .filter((message): message is LiveDmMessage => !!message);
+    const outcomeMessages = outcomeAnchors.map((outcome) =>
+      this.dmCallOutcomeAnchorToLiveMessage(outcome),
+    );
+    return {
+      messages: [...messages, ...outcomeMessages],
+      ...(page.first_id ? { firstArchiveId: page.first_id } : {}),
+      ...(page.last_id ? { lastArchiveId: page.last_id } : {}),
+      complete: page.is_complete,
+    };
   }
+
+  private dmCallOutcomeAnchorToLiveMessage(outcome: ArchivedDmCallOutcome): LiveDmMessage {
+    const { anchor, terminalMessage } = outcome;
+    const card = buildDmCallOutcomeAnchor(anchor, this.session.jid);
+    const wireIds = rawMessageSeenIds(terminalMessage);
+    return {
+      id: card.id,
+      ...(terminalMessage.mam_id ? { archiveId: terminalMessage.mam_id } : {}),
+      peerJid: anchor.peerBareJid,
+      fromJid: card.authorJid ?? anchor.peerBareJid,
+      nick: card.author,
+      body: card.body,
+      createdAt: card.createdAt,
+      createdAtSource: "archive",
+      type: "message",
+      ...(wireIds.length > 0 ? { wireIds } : {}),
+      ...(card.threadId ? { threadId: card.threadId } : {}),
+      ...(card.callThread ? { callThread: card.callThread } : {}),
+    };
+  }
+
   private applyDmCallEventsFromMamPage(
     page: WasmMamPage | null | undefined,
     selfBare = barePeerJid(this.session.jid),
     options: { since?: string; seenIds?: ReadonlyArray<string>; publishOutcome?: boolean } = {},
-  ): void {
+  ): ArchivedDmCallOutcome[] {
+    const outcomeAnchors: ArchivedDmCallOutcome[] = [];
     for (const message of page?.messages ?? []) {
       if (!message.call_event) continue;
       if (shouldSkipRawCatchupMessage(message, options.since, options.seenIds)) continue;
-      applyDmCallEvent({
+      const outcomeAnchor = applyDmCallEvent({
         event: message.call_event,
         selfBareJid: selfBare,
         selfFullJid: this.fullJid,
@@ -2797,7 +2831,9 @@ export class BrowserXmppClient {
         timestamp: message.timestamp,
         publishOutcome: options.publishOutcome,
       });
+      if (outcomeAnchor) outcomeAnchors.push({ anchor: outcomeAnchor, terminalMessage: message });
     }
+    return outcomeAnchors;
   }
   private recordRoomMamWatermarks(messages: ReadonlyArray<LiveRoomMessage>) {
     for (const message of messages) {
@@ -2844,7 +2880,7 @@ export class BrowserXmppClient {
   async queryPersonalMamPage(peerJid: string, max = 100, pageParam: MamPageParam = { type: "latest" }): Promise<MamHistoryPage<LiveDmMessage>> {
     const xmpp = await this.requireConnectedXmpp(); const page = await xmpp.fetch_dm_history_page?.(barePeerJid(peerJid), max, pageParam) as WasmMamPage;
     if (!page) return { messages: [], complete: true };
-    const result = this.dmMamPageToMessages(page, { applyCallEvents: pageParam.type !== "before" });
+    const result = this.dmMamPageToMessages(page);
     this.recordDmMamWatermarks(result.messages);
     return result;
   }
@@ -2852,7 +2888,7 @@ export class BrowserXmppClient {
     if (!threadId) return { messages: [], complete: true };
     const xmpp = await this.requireConnectedXmpp(); const page = await xmpp.fetch_dm_history_by_thread?.(barePeerJid(peerJid), threadId, max, pageParam.type === "before" ? pageParam.before : null) as WasmMamPage;
     if (!page) return { messages: [], complete: true };
-    const result = this.dmMamPageToMessages(page, { applyCallEvents: false });
+    const result = this.dmMamPageToMessages(page);
     this.recordDmMamWatermarks(result.messages);
     return result;
   }
@@ -2899,7 +2935,7 @@ export class BrowserXmppClient {
     if (!query.trim()) return [];
     const xmpp = await this.requireConnectedXmpp();
     const page = await xmpp.search_dm_history?.(barePeerJid(peerJid), query, max) as WasmMamPage;
-    const parsed = page ? this.dmMamPageToMessages(page, { applyCallEvents: false }).messages : [];
+    const parsed = page ? this.dmMamPageToMessages(page).messages : [];
     return parsed.filter((message) => !!message.body).map((message, index) => ({ id: message.id, ...(page?.messages[index]?.mam_id ? { archiveId: page.messages[index].mam_id } : {}), nick: message.nick, body: message.body, createdAt: message.createdAt, ...(message.threadId ? { threadId: message.threadId } : {}), ...(message.parentThreadId ? { parentThreadId: message.parentThreadId } : {}), peerJid: message.peerJid }));
   }
   async subscribeToPeerPresence(peerJid: string): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await xmpp.subscribe_to_presence?.(barePeerJid(peerJid)); }

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -2777,9 +2777,14 @@ export class BrowserXmppClient {
   private roomMamPageToMessages(page: WasmMamPage): MamHistoryPage<LiveRoomMessage> {
     return { messages: page.messages.map((message) => roomMessageFromArchived(message, { trustedMediaOrigin: this.trustedLinkPreviewMediaOrigin() })).filter((message): message is LiveRoomMessage => !!message), ...(page.first_id ? { firstArchiveId: page.first_id } : {}), ...(page.last_id ? { lastArchiveId: page.last_id } : {}), complete: page.is_complete };
   }
-  private dmMamPageToMessages(page: WasmMamPage): MamHistoryPage<LiveDmMessage> {
+  private dmMamPageToMessages(
+    page: WasmMamPage,
+    options: { applyCallEvents?: boolean } = {},
+  ): MamHistoryPage<LiveDmMessage> {
     const selfBare = barePeerJid(this.session.jid);
-    const outcomeAnchors = this.applyDmCallEventsFromMamPage(page, selfBare, { publishOutcome: false });
+    const outcomeAnchors = options.applyCallEvents === false
+      ? []
+      : this.applyDmCallEventsFromMamPage(page, selfBare, { publishOutcome: false });
     const messages = page.messages
       .map((message) => dmMessageFromArchived(message, selfBare, { trustedMediaOrigin: this.trustedLinkPreviewMediaOrigin() }))
       .filter((message): message is LiveDmMessage => !!message);
@@ -2888,7 +2893,7 @@ export class BrowserXmppClient {
     if (!threadId) return { messages: [], complete: true };
     const xmpp = await this.requireConnectedXmpp(); const page = await xmpp.fetch_dm_history_by_thread?.(barePeerJid(peerJid), threadId, max, pageParam.type === "before" ? pageParam.before : null) as WasmMamPage;
     if (!page) return { messages: [], complete: true };
-    const result = this.dmMamPageToMessages(page);
+    const result = this.dmMamPageToMessages(page, { applyCallEvents: false });
     this.recordDmMamWatermarks(result.messages);
     return result;
   }
@@ -2935,8 +2940,14 @@ export class BrowserXmppClient {
     if (!query.trim()) return [];
     const xmpp = await this.requireConnectedXmpp();
     const page = await xmpp.search_dm_history?.(barePeerJid(peerJid), query, max) as WasmMamPage;
-    const parsed = page ? this.dmMamPageToMessages(page).messages : [];
-    return parsed.filter((message) => !!message.body).map((message, index) => ({ id: message.id, ...(page?.messages[index]?.mam_id ? { archiveId: page.messages[index].mam_id } : {}), nick: message.nick, body: message.body, createdAt: message.createdAt, ...(message.threadId ? { threadId: message.threadId } : {}), ...(message.parentThreadId ? { parentThreadId: message.parentThreadId } : {}), peerJid: message.peerJid }));
+    const selfBare = barePeerJid(this.session.jid);
+    const parsed = page?.messages
+      .map((archived) => ({
+        archived,
+        message: dmMessageFromArchived(archived, selfBare, { trustedMediaOrigin: this.trustedLinkPreviewMediaOrigin() }),
+      }))
+      .filter((entry): entry is { archived: WasmArchivedMessage; message: LiveDmMessage } => !!entry.message) ?? [];
+    return parsed.filter(({ message }) => !!message.body).map(({ archived, message }) => ({ id: message.id, ...(archived.mam_id ? { archiveId: archived.mam_id } : {}), nick: message.nick, body: message.body, createdAt: message.createdAt, ...(message.threadId ? { threadId: message.threadId } : {}), ...(message.parentThreadId ? { parentThreadId: message.parentThreadId } : {}), peerJid: message.peerJid }));
   }
   async subscribeToPeerPresence(peerJid: string): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await xmpp.subscribe_to_presence?.(barePeerJid(peerJid)); }
   async listRosterContacts(): Promise<RosterContact[]> { const xmpp = await this.requireConnectedXmpp(); const roster = await xmpp.list_roster_contacts?.() as WasmRosterContact[]; return (roster ?? []).map((item) => { const jid = barePeerJid(item.jid); return { jid, name: item.name, username: item.name?.trim() || jid.split("@")[0] || jid, subscription: (item.subscription ?? "none") as RosterContact["subscription"], groups: item.groups ?? [] }; }); }

--- a/chat/tests/call-activity-dock.test.ts
+++ b/chat/tests/call-activity-dock.test.ts
@@ -3378,6 +3378,78 @@ describe("CallActivityDock rendering", () => {
     expect($dmCallActivities.get()["bob@example.com"]).toBeUndefined();
   });
 
+  test("shell end action leaves recovered DM visible when teardown fails", async () => {
+    $dmCallActivities.set({
+      "bob@example.com": {
+        peerJid: "bob@example.com",
+        remoteFullJid: "bob@example.com/phone",
+        sid: "dm-recovered-retry",
+        media: { audio: true, video: true },
+        join: liveKitJoinFor(),
+        state: "accepted",
+        direction: "incoming",
+        updatedAt: new Date().toISOString(),
+      },
+    });
+    const selected: unknown[][] = [];
+    const sendCallSessionTerminateWithOutcome = mock(async () => ({ kind: "error" }));
+    const sendCallFinish = mock(async () => undefined);
+    const bindings = await suppressVueLifecycleSetupWarnings(() =>
+      setupVueComponent("../src/components/chat/ChatReadyShell.vue", {
+        controller: {
+          ui: { activeCommunitySurface: { value: null } },
+          connectionStore: {
+            client: {
+              fullJid: "alice@example.com/web",
+              xmpp: {
+                send_call_session_terminate_with_outcome: sendCallSessionTerminateWithOutcome,
+                send_call_finish: sendCallFinish,
+              },
+            },
+            session: null,
+          },
+          waddles: { mucServiceJid: { value: "" } },
+          selfDomain: { value: "" },
+          rosterContacts: {
+            contacts: { value: [] },
+            isLoadingContacts: { value: false },
+          },
+          messaging: {
+            mentionedChannelCounts: { value: {} },
+            activeChannels: { value: new Set<string>() },
+          },
+          dmConversations: { conversations: { value: [] } },
+          computedChannelUnreadMap: { value: {} },
+          activeRightPanel: { value: null },
+          activeThreadStack: { value: [] },
+          communityEvents: { rsvp: () => undefined },
+          closePinnedPanel: () => undefined,
+          activateRightPanel: () => undefined,
+          selectDm: (...args: unknown[]) => {
+            selected.push(args);
+          },
+          selectChannel: () => undefined,
+          selectChannelByRoomJid: () => undefined,
+        },
+      }),
+    );
+
+    setupBindingFunction(bindings, "endRecoveredDmFromActivity")("bob@example.com");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(selected).toEqual([["bob@example.com"]]);
+    expect(sendCallSessionTerminateWithOutcome).toHaveBeenCalledWith(
+      "bob@example.com/phone",
+      "dm-recovered-retry",
+      "success",
+    );
+    expect(sendCallFinish).not.toHaveBeenCalled();
+    expect($dmCallActivities.get()["bob@example.com"]).toMatchObject({
+      sid: "dm-recovered-retry",
+      state: "accepted",
+    });
+  });
+
   test("shell reconnect leaves stale accepted activity open-only instead of sending a new propose", async () => {
     $dmCallActivities.set({
       "bob@example.com": {

--- a/chat/tests/call-outbound.test.ts
+++ b/chat/tests/call-outbound.test.ts
@@ -170,6 +170,23 @@ describe("outboundCalls", () => {
     ]);
   });
 
+  test("sessionTerminateWithOutcome legacy fallback is safe when destructured", async () => {
+    const { client, calls } = recorder();
+    const { sessionTerminateWithOutcome } = outboundCalls;
+    await expect(sessionTerminateWithOutcome(
+      client,
+      "bob@waddle.test/desktop",
+      "c1",
+      "success",
+    )).resolves.toBe("ok");
+    expect(calls).toEqual([
+      {
+        method: "send_call_session_terminate",
+        args: ["bob@waddle.test/desktop", "c1", "success"],
+      },
+    ]);
+  });
+
   test("sessionTerminateWithOutcome treats malformed typed outcome as error", async () => {
     const client: CallWireSender = {
       send_call_session_terminate_with_outcome: async () => ({ kind: "forbidden" }),

--- a/chat/tests/call-outbound.test.ts
+++ b/chat/tests/call-outbound.test.ts
@@ -137,6 +137,51 @@ describe("outboundCalls", () => {
     ]);
   });
 
+  test("sessionTerminateWithOutcome uses typed wasm outcome when available", async () => {
+    const calls: unknown[][] = [];
+    const client: CallWireSender = {
+      send_call_session_terminate_with_outcome: async (...args) => {
+        calls.push(args);
+        return { kind: "orphaned" };
+      },
+    };
+    await expect(outboundCalls.sessionTerminateWithOutcome(
+      client,
+      "bob@waddle.test/desktop",
+      "c1",
+      "success",
+    )).resolves.toBe("orphaned");
+    expect(calls).toEqual([["bob@waddle.test/desktop", "c1", "success"]]);
+  });
+
+  test("sessionTerminateWithOutcome falls back to legacy success only", async () => {
+    const { client, calls } = recorder();
+    await expect(outboundCalls.sessionTerminateWithOutcome(
+      client,
+      "bob@waddle.test/desktop",
+      "c1",
+      "success",
+    )).resolves.toBe("ok");
+    expect(calls).toEqual([
+      {
+        method: "send_call_session_terminate",
+        args: ["bob@waddle.test/desktop", "c1", "success"],
+      },
+    ]);
+  });
+
+  test("sessionTerminateWithOutcome treats malformed typed outcome as error", async () => {
+    const client: CallWireSender = {
+      send_call_session_terminate_with_outcome: async () => ({ kind: "forbidden" }),
+    };
+    await expect(outboundCalls.sessionTerminateWithOutcome(
+      client,
+      "bob@waddle.test/desktop",
+      "c1",
+      "success",
+    )).resolves.toBe("error");
+  });
+
   test("throws WasmCallApiUnavailable when the wasm method is missing", async () => {
     const empty: CallWireSender = {};
     await expect(outboundCalls.propose(empty, "x@test", "c1", audioVideo)).rejects.toThrow(

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -334,6 +334,28 @@ describe("DM call outcome feed anchors", () => {
     });
   });
 
+  test("timeout session-terminate records no-answer rather than ended", () => {
+    applyDmCallEvent({
+      selfBareJid: "alice@waddle.test",
+      selfFullJid: "alice@waddle.test/web",
+      timestamp: "2026-06-09T12:00:00Z",
+      now: new Date("2026-06-09T12:01:00Z"),
+      event: {
+        kind: "session-terminate",
+        from: "alice@waddle.test/web",
+        to: "bob@waddle.test/phone",
+        sid: "c-timeout-terminate",
+        reason: "timeout",
+      },
+    });
+
+    expect($dmCallOutcomeAnchor.get()).toMatchObject({
+      peerBareJid: "bob@waddle.test",
+      sid: "c-timeout-terminate",
+      outcome: "no-answer",
+    });
+  });
+
   test("archived MAM call events derive a missed entry after reconnect", () => {
     applyDmCallEvent({
       selfBareJid: "alice@waddle.test",
@@ -367,6 +389,52 @@ describe("DM call outcome feed anchors", () => {
       outcome: "missed",
       ended: "2026-06-09T12:00:45Z",
     });
+  });
+
+  test("duplicate terminal replay does not republish with fallback media", () => {
+    applyDmCallEvent({
+      selfBareJid: "alice@waddle.test",
+      selfFullJid: "alice@waddle.test/web",
+      timestamp: "2026-06-09T12:00:00Z",
+      now: new Date("2026-06-09T12:01:00Z"),
+      event: {
+        kind: "propose",
+        from: "bob@waddle.test/phone",
+        to: "alice@waddle.test/web",
+        sid: "c-duplicate",
+        media: audioVideo,
+      },
+    });
+    applyDmCallEvent({
+      selfBareJid: "alice@waddle.test",
+      selfFullJid: "alice@waddle.test/web",
+      timestamp: "2026-06-09T12:00:45Z",
+      now: new Date("2026-06-09T12:01:00Z"),
+      event: {
+        kind: "retract",
+        from: "bob@waddle.test/phone",
+        to: "alice@waddle.test/web",
+        sid: "c-duplicate",
+      },
+    });
+    const firstOutcome = $dmCallOutcomeAnchor.get();
+
+    const duplicateOutcome = applyDmCallEvent({
+      selfBareJid: "alice@waddle.test",
+      selfFullJid: "alice@waddle.test/web",
+      timestamp: "2026-06-09T12:00:45Z",
+      now: new Date("2026-06-09T12:01:00Z"),
+      event: {
+        kind: "retract",
+        from: "bob@waddle.test/phone",
+        to: "alice@waddle.test/web",
+        sid: "c-duplicate",
+      },
+    });
+
+    expect(duplicateOutcome).toBeNull();
+    expect($dmCallOutcomeAnchor.get()).toEqual(firstOutcome);
+    expect($dmCallOutcomeAnchor.get()?.media).toEqual(audioVideo);
   });
 
   test("background MAM call hydration can update activity without publishing feed outcomes", () => {

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -16,6 +16,8 @@ import {
   applyMucCallPresence,
   clearMucCallParticipants,
 } from "../src/lib/calls/muc-call-presence";
+import { applyDmCallEvent, clearDmCallActivities, readDmCallActivity } from "../src/lib/calls/dm-call-activity";
+import { $dmCallOutcomeAnchor } from "../src/lib/calls/dm-call-anchor";
 import { leaveRetainedMucCallAction, startMucCallAction } from "../src/lib/calls/muc-call-actions";
 import {
   $mucCallTerminatePendingSessions,
@@ -229,6 +231,8 @@ afterAll(() => {
 
 afterEach(() => {
   clearCallState();
+  clearDmCallActivities();
+  $dmCallOutcomeAnchor.set(null);
   configureIncomingCallAlerts(null);
   $lastCallError.set(null);
   // The Muji mocks above fire `applyMucCallPresence` to simulate
@@ -237,6 +241,180 @@ afterEach(() => {
   // `muc-call-presence.test.ts`) that expect an empty store.
   clearMucCallParticipants();
   clearAllMucCallSessionCacheForTests();
+});
+
+describe("DM call outcome feed anchors", () => {
+  test("live reject records a declined entry for the peer feed", () => {
+    const events = wireClientEvents();
+
+    events.emitCall({
+      kind: "propose",
+      from: "bob@waddle.test/phone",
+      to: "alice@waddle.test/web",
+      sid: "c-decline",
+      media: audioVideo,
+    });
+    events.emitCall({
+      kind: "reject",
+      from: "alice@waddle.test/web",
+      to: "bob@waddle.test/phone",
+      sid: "c-decline",
+    });
+
+    expect($dmCallOutcomeAnchor.get()).toMatchObject({
+      peerBareJid: "bob@waddle.test",
+      sid: "c-decline",
+      outcome: "declined",
+    });
+  });
+
+  test("caller retract records missed for the recipient feed", () => {
+    const events = wireClientEvents();
+
+    events.emitCall({
+      kind: "propose",
+      from: "bob@waddle.test/phone",
+      to: "alice@waddle.test/web",
+      sid: "c-missed",
+      media: audioVideo,
+    });
+    events.emitCall({
+      kind: "retract",
+      from: "bob@waddle.test/phone",
+      to: "alice@waddle.test/web",
+      sid: "c-missed",
+    });
+
+    expect($dmCallOutcomeAnchor.get()).toMatchObject({
+      peerBareJid: "bob@waddle.test",
+      sid: "c-missed",
+      outcome: "missed",
+    });
+  });
+
+  test("outgoing unanswered timeout records no-answer for the caller feed", async () => {
+    const sender = mockSender();
+
+    beginOutgoingCall("bob@waddle.test", "c-no-answer", audioVideo, "alice@waddle.test/web");
+    scheduleOutgoingTimeout(sender, "c-no-answer", 10);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect($dmCallOutcomeAnchor.get()).toMatchObject({
+      peerBareJid: "bob@waddle.test",
+      sid: "c-no-answer",
+      outcome: "no-answer",
+    });
+  });
+
+  test("completed call terminate records an ended entry for the feed", () => {
+    const events = wireClientEvents();
+
+    beginOutgoingCall("bob@waddle.test", "c-ended", audioVideo, "alice@waddle.test/web");
+    events.emitCall({
+      kind: "session-accept",
+      from: "bob@waddle.test/phone",
+      to: "alice@waddle.test/web",
+      sid: "c-ended",
+      media: audioVideo,
+      join,
+    });
+    events.emitCall({
+      kind: "session-terminate",
+      from: "bob@waddle.test/phone",
+      to: "alice@waddle.test/web",
+      sid: "c-ended",
+      reason: "success",
+    });
+
+    expect($dmCallOutcomeAnchor.get()).toMatchObject({
+      peerBareJid: "bob@waddle.test",
+      sid: "c-ended",
+      outcome: "ended",
+    });
+  });
+
+  test("archived MAM call events derive a missed entry after reconnect", () => {
+    applyDmCallEvent({
+      selfBareJid: "alice@waddle.test",
+      selfFullJid: "alice@waddle.test/web",
+      timestamp: "2026-06-09T12:00:00Z",
+      now: new Date("2026-06-09T12:01:00Z"),
+      event: {
+        kind: "propose",
+        from: "bob@waddle.test/phone",
+        to: "alice@waddle.test/web",
+        sid: "c-offline",
+        media: audioVideo,
+      },
+    });
+    applyDmCallEvent({
+      selfBareJid: "alice@waddle.test",
+      selfFullJid: "alice@waddle.test/web",
+      timestamp: "2026-06-09T12:00:45Z",
+      now: new Date("2026-06-09T12:01:00Z"),
+      event: {
+        kind: "retract",
+        from: "bob@waddle.test/phone",
+        to: "alice@waddle.test/web",
+        sid: "c-offline",
+      },
+    });
+
+    expect($dmCallOutcomeAnchor.get()).toMatchObject({
+      peerBareJid: "bob@waddle.test",
+      sid: "c-offline",
+      outcome: "missed",
+      ended: "2026-06-09T12:00:45Z",
+    });
+  });
+
+  test("background MAM call hydration can update activity without publishing feed outcomes", () => {
+    applyDmCallEvent({
+      selfBareJid: "alice@waddle.test",
+      selfFullJid: "alice@waddle.test/web",
+      timestamp: "2026-06-09T12:00:00Z",
+      now: new Date("2026-06-09T12:01:00Z"),
+      publishOutcome: false,
+      event: {
+        kind: "session-accept",
+        from: "bob@waddle.test/phone",
+        to: "alice@waddle.test/web",
+        sid: "c-silent-hydrate",
+        media: audioVideo,
+        join,
+      },
+    });
+
+    expect($dmCallOutcomeAnchor.get()).toBeNull();
+    expect(readDmCallActivity("bob@waddle.test", new Date("2026-06-09T12:01:00Z"))).toMatchObject({
+      peerJid: "bob@waddle.test",
+      sid: "c-silent-hydrate",
+      state: "accepted",
+    });
+  });
+
+  test("lone archived self-reject attributes the declined call to the peer initiator", () => {
+    applyDmCallEvent({
+      selfBareJid: "alice@waddle.test",
+      selfFullJid: "alice@waddle.test/web",
+      timestamp: "2026-06-09T12:00:45Z",
+      now: new Date("2026-06-09T12:01:00Z"),
+      event: {
+        kind: "reject",
+        from: "alice@waddle.test/web",
+        to: "bob@waddle.test/phone",
+        sid: "c-lone-reject",
+      },
+    });
+
+    expect($dmCallOutcomeAnchor.get()).toMatchObject({
+      peerBareJid: "bob@waddle.test",
+      sid: "c-lone-reject",
+      outcome: "declined",
+      initiator: "bob@waddle.test",
+    });
+  });
 });
 
 describe("incoming DM call alerting", () => {
@@ -1027,6 +1205,11 @@ describe("1:1 call event wiring", () => {
         "c-no-accept",
         "timeout",
       );
+      expect($dmCallOutcomeAnchor.get()).toMatchObject({
+        peerBareJid: "bob@waddle.test",
+        sid: "c-no-accept",
+        outcome: "no-answer",
+      });
       expect($callState.get()).toEqual({
         phase: "ended",
         sid: "c-no-accept",

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -719,6 +719,86 @@ describe("tearDownActiveCall", () => {
     expect($callState.get()).toEqual({ phase: "idle" });
   });
 
+  test("active DM call: orphaned terminate still dispatches XEP-0353 finish", async () => {
+    const sender: CallWireSender = {
+      send_call_session_terminate_with_outcome: mock(async () => ({ kind: "orphaned" })),
+      send_call_finish: mock(async () => undefined),
+    };
+    $callState.set({
+      phase: "active",
+      peer: "bob@waddle.test/desktop",
+      sid: "c1",
+      media: audioVideo,
+      join,
+      kind: "dm",
+      initiator: "alice@waddle.test/web",
+    });
+    await tearDownActiveCall(sender, "success");
+    expect(sender.send_call_session_terminate_with_outcome).toHaveBeenCalledWith(
+      "bob@waddle.test/desktop",
+      "c1",
+      "success",
+    );
+    expect(sender.send_call_finish).toHaveBeenCalledWith(
+      "bob@waddle.test/desktop",
+      "c1",
+    );
+    expect($callState.get()).toEqual({ phase: "idle" });
+    expect($lastCallError.get()).toBeNull();
+  });
+
+  test("active DM call: unclassified terminate failure does not send finish", async () => {
+    const sender: CallWireSender = {
+      send_call_session_terminate: mock(async () => {
+        throw new Error("terminate failed");
+      }),
+      send_call_finish: mock(async () => undefined),
+    };
+    $callState.set({
+      phase: "active",
+      peer: "bob@waddle.test/desktop",
+      sid: "c1",
+      media: audioVideo,
+      join,
+      kind: "dm",
+      initiator: "alice@waddle.test/web",
+    });
+    await tearDownActiveCall(sender, "success");
+    expect(sender.send_call_session_terminate).toHaveBeenCalledWith(
+      "bob@waddle.test/desktop",
+      "c1",
+      "success",
+    );
+    expect(sender.send_call_finish).not.toHaveBeenCalled();
+    expect($callState.get()).toEqual({ phase: "idle" });
+    expect($lastCallError.get()).toBe("terminate failed");
+  });
+
+  test("active DM call: typed terminate error does not send finish", async () => {
+    const sender: CallWireSender = {
+      send_call_session_terminate_with_outcome: mock(async () => ({ kind: "error" })),
+      send_call_finish: mock(async () => undefined),
+    };
+    $callState.set({
+      phase: "active",
+      peer: "bob@waddle.test/desktop",
+      sid: "c1",
+      media: audioVideo,
+      join,
+      kind: "dm",
+      initiator: "alice@waddle.test/web",
+    });
+    await tearDownActiveCall(sender, "success");
+    expect(sender.send_call_session_terminate_with_outcome).toHaveBeenCalledWith(
+      "bob@waddle.test/desktop",
+      "c1",
+      "success",
+    );
+    expect(sender.send_call_finish).not.toHaveBeenCalled();
+    expect($callState.get()).toEqual({ phase: "idle" });
+    expect($lastCallError.get()).toBe("call session terminate failed");
+  });
+
   test("active call: success reason for graceful logout", async () => {
     const sender = mockSender();
     $callState.set({

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -356,6 +356,40 @@ describe("DM call outcome feed anchors", () => {
     });
   });
 
+  test("later finish after timeout terminate does not create a second outcome", () => {
+    const timeoutOutcome = applyDmCallEvent({
+      selfBareJid: "alice@waddle.test",
+      selfFullJid: "alice@waddle.test/web",
+      timestamp: "2026-06-09T12:00:45Z",
+      now: new Date("2026-06-09T12:01:00Z"),
+      event: {
+        kind: "session-terminate",
+        from: "alice@waddle.test/web",
+        to: "bob@waddle.test/phone",
+        sid: "c-timeout-finish",
+        reason: "timeout",
+      },
+    });
+    const firstPublished = $dmCallOutcomeAnchor.get();
+
+    const finishOutcome = applyDmCallEvent({
+      selfBareJid: "alice@waddle.test",
+      selfFullJid: "alice@waddle.test/web",
+      timestamp: "2026-06-09T12:00:46Z",
+      now: new Date("2026-06-09T12:01:00Z"),
+      event: {
+        kind: "finish",
+        from: "bob@waddle.test/phone",
+        to: "alice@waddle.test/web",
+        sid: "c-timeout-finish",
+      },
+    });
+
+    expect(timeoutOutcome?.outcome).toBe("no-answer");
+    expect(finishOutcome).toBeNull();
+    expect($dmCallOutcomeAnchor.get()).toEqual(firstPublished);
+  });
+
   test("archived MAM call events derive a missed entry after reconnect", () => {
     applyDmCallEvent({
       selfBareJid: "alice@waddle.test",
@@ -822,6 +856,32 @@ describe("tearDownActiveCall", () => {
       }),
       send_call_finish: mock(async () => undefined),
     };
+    applyDmCallEvent({
+      selfBareJid: "alice@waddle.test",
+      selfFullJid: "alice@waddle.test/web",
+      timestamp: new Date(Date.now() - 1_000).toISOString(),
+      event: {
+        kind: "propose",
+        from: "bob@waddle.test/desktop",
+        to: "alice@waddle.test/web",
+        sid: "c1",
+        media: audioVideo,
+      },
+    });
+    applyDmCallEvent({
+      selfBareJid: "alice@waddle.test",
+      selfFullJid: "alice@waddle.test/web",
+      timestamp: new Date().toISOString(),
+      event: {
+        kind: "session-accept",
+        from: "bob@waddle.test/desktop",
+        to: "alice@waddle.test/web",
+        sid: "c1",
+        media: audioVideo,
+        join,
+      },
+    });
+    expect(readDmCallActivity("bob@waddle.test")).toMatchObject({ sid: "c1" });
     $callState.set({
       phase: "active",
       peer: "bob@waddle.test/desktop",
@@ -840,6 +900,7 @@ describe("tearDownActiveCall", () => {
     expect(sender.send_call_finish).not.toHaveBeenCalled();
     expect($callState.get()).toEqual({ phase: "idle" });
     expect($lastCallError.get()).toBe("terminate failed");
+    expect(readDmCallActivity("bob@waddle.test")).toBeNull();
   });
 
   test("active DM call: typed terminate error does not send finish", async () => {
@@ -865,6 +926,54 @@ describe("tearDownActiveCall", () => {
     expect(sender.send_call_finish).not.toHaveBeenCalled();
     expect($callState.get()).toEqual({ phase: "idle" });
     expect($lastCallError.get()).toBe("call session terminate failed");
+  });
+
+  test("active DM call: typed terminate error still clears dock activity", async () => {
+    const sender: CallWireSender = {
+      send_call_session_terminate_with_outcome: mock(async () => ({ kind: "error" })),
+      send_call_finish: mock(async () => undefined),
+    };
+    applyDmCallEvent({
+      selfBareJid: "alice@waddle.test",
+      selfFullJid: "alice@waddle.test/web",
+      timestamp: new Date(Date.now() - 1_000).toISOString(),
+      event: {
+        kind: "propose",
+        from: "bob@waddle.test/desktop",
+        to: "alice@waddle.test/web",
+        sid: "c1",
+        media: audioVideo,
+      },
+    });
+    applyDmCallEvent({
+      selfBareJid: "alice@waddle.test",
+      selfFullJid: "alice@waddle.test/web",
+      timestamp: new Date().toISOString(),
+      event: {
+        kind: "session-accept",
+        from: "bob@waddle.test/desktop",
+        to: "alice@waddle.test/web",
+        sid: "c1",
+        media: audioVideo,
+        join,
+      },
+    });
+    expect(readDmCallActivity("bob@waddle.test")).toMatchObject({ sid: "c1" });
+    $callState.set({
+      phase: "active",
+      peer: "bob@waddle.test/desktop",
+      sid: "c1",
+      media: audioVideo,
+      join,
+      kind: "dm",
+      initiator: "alice@waddle.test/web",
+    });
+
+    await tearDownActiveCall(sender, "success");
+
+    expect(sender.send_call_finish).not.toHaveBeenCalled();
+    expect($callState.get()).toEqual({ phase: "idle" });
+    expect(readDmCallActivity("bob@waddle.test")).toBeNull();
   });
 
   test("active call: success reason for graceful logout", async () => {

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -7,6 +7,7 @@ import { useChannelMessages } from "../src/channels/messages";
 import { BrowserXmppClient, roomBareJidFor, type InboxEntry, type LiveDmMessage, type RoomActivityEvent } from "../src/lib/xmpp-client";
 import { enqueueQueuedMessage, listQueuedDmMessages, listQueuedRoomMessages } from "../src/lib/outbound-queue-store";
 import { clearDmCallActivities, readDmCallActivity } from "../src/lib/calls/dm-call-activity";
+import { $dmCallOutcomeAnchor } from "../src/lib/calls/dm-call-anchor";
 import type { ResumePersistence } from "../src/lib/xmpp/resume-persistence";
 import { handlerStubs } from "./helpers/xmpp-client-mock";
 
@@ -106,10 +107,12 @@ beforeEach(() => {
   } as Window & { localStorage: typeof storage };
   localStorage.clear();
   clearDmCallActivities();
+  $dmCallOutcomeAnchor.set(null);
 });
 
 afterEach(() => {
   clearDmCallActivities();
+  $dmCallOutcomeAnchor.set(null);
   localStorage.clear();
   if (originalLocalStorage === undefined) {
     Reflect.deleteProperty(globalThis, "localStorage");
@@ -1878,6 +1881,149 @@ describe("client keepalive lifecycle", () => {
     expect((client as unknown as { catchup: { onSessionStarted: () => unknown[] } }).catchup.onSessionStarted()).toEqual([
       { kind: "dm", key: "bob@example.com", after: "mam-loaded-1", since: "2024-01-01T00:00:01.000Z", seenIds: ["dm-loaded-1"] },
     ]);
+  });
+
+  test("queryPersonalMamPage returns archived DM call outcome cards", async () => {
+    const client = new BrowserXmppClient(session());
+    (client as unknown as { connect: () => Promise<void> }).connect = async () => undefined;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { catchup: { onSessionStarted: () => unknown[] } }).catchup.onSessionStarted();
+    const proposedAt = new Date(Date.now() - 60_000).toISOString();
+    const retractedAt = new Date(Date.now() - 30_000).toISOString();
+    const fetchDmHistoryPage = mock(async () => ({
+      messages: [
+        {
+          mam_id: "mam-propose-video",
+          id: "stanza-propose-video",
+          from: "bob@example.com/phone",
+          to: "alice@example.com/desktop",
+          message_type: "chat",
+          timestamp: proposedAt,
+          reaction_emojis: [],
+          shared_files: [],
+          call_event: {
+            kind: "propose",
+            from: "bob@example.com/phone",
+            to: "alice@example.com/desktop",
+            sid: "call-archive-video",
+            media: { audio: true, video: true },
+          },
+        },
+        {
+          mam_id: "mam-retract-video",
+          id: "stanza-retract-video",
+          from: "bob@example.com/phone",
+          to: "alice@example.com/desktop",
+          message_type: "chat",
+          timestamp: retractedAt,
+          reaction_emojis: [],
+          shared_files: [],
+          call_event: {
+            kind: "retract",
+            from: "bob@example.com/phone",
+            to: "alice@example.com/desktop",
+            sid: "call-archive-video",
+          },
+        },
+      ],
+      last_id: "mam-retract-video",
+      is_complete: true,
+    }));
+    (client as unknown as { xmpp: Agent }).xmpp = Object.assign(new EventEmitter(), {
+      fetch_dm_history_page: fetchDmHistoryPage,
+    }) as unknown as Agent;
+
+    const page = await client.queryPersonalMamPage("bob@example.com", 100, { type: "latest" });
+
+    expect(page.messages).toHaveLength(1);
+    expect(page.messages[0]).toMatchObject({
+      id: "dmcall:call-archive-video:missed",
+      archiveId: "mam-retract-video",
+      wireIds: ["stanza-retract-video"],
+      peerJid: "bob@example.com",
+      threadId: "call-archive-video",
+      callThread: {
+        kind: "dm",
+        sid: "call-archive-video",
+        media: ["audio", "video"],
+        outcome: "missed",
+      },
+    });
+    expect($dmCallOutcomeAnchor.get()).toBeNull();
+    expect((client as unknown as { catchup: { onSessionStarted: () => unknown[] } }).catchup.onSessionStarted()).toEqual([
+      {
+        kind: "dm",
+        key: "bob@example.com",
+        after: "mam-retract-video",
+        since: retractedAt,
+        seenIds: ["dmcall:call-archive-video:missed", "stanza-retract-video"],
+      },
+    ]);
+  });
+
+  test("queryPersonalMamPage returns archived DM call outcome cards on older pages", async () => {
+    const client = new BrowserXmppClient(session());
+    (client as unknown as { connect: () => Promise<void> }).connect = async () => undefined;
+    (client as unknown as { connected: boolean }).connected = true;
+    const proposedAt = new Date(Date.now() - 60_000).toISOString();
+    const retractedAt = new Date(Date.now() - 30_000).toISOString();
+    const fetchDmHistoryPage = mock(async () => ({
+      messages: [
+        {
+          mam_id: "mam-before-propose-video",
+          id: "stanza-before-propose-video",
+          from: "bob@example.com/phone",
+          to: "alice@example.com/desktop",
+          message_type: "chat",
+          timestamp: proposedAt,
+          reaction_emojis: [],
+          shared_files: [],
+          call_event: {
+            kind: "propose",
+            from: "bob@example.com/phone",
+            to: "alice@example.com/desktop",
+            sid: "call-before-video",
+            media: { audio: true, video: true },
+          },
+        },
+        {
+          mam_id: "mam-before-retract-video",
+          id: "stanza-before-retract-video",
+          from: "bob@example.com/phone",
+          to: "alice@example.com/desktop",
+          message_type: "chat",
+          timestamp: retractedAt,
+          reaction_emojis: [],
+          shared_files: [],
+          call_event: {
+            kind: "retract",
+            from: "bob@example.com/phone",
+            to: "alice@example.com/desktop",
+            sid: "call-before-video",
+          },
+        },
+      ],
+      first_id: "mam-before-propose-video",
+      last_id: "mam-before-retract-video",
+      is_complete: false,
+    }));
+    (client as unknown as { xmpp: Agent }).xmpp = Object.assign(new EventEmitter(), {
+      fetch_dm_history_page: fetchDmHistoryPage,
+    }) as unknown as Agent;
+
+    const page = await client.queryPersonalMamPage("bob@example.com", 100, { type: "before", before: "mam-newer" });
+
+    expect(page.messages).toHaveLength(1);
+    expect(page.messages[0]).toMatchObject({
+      id: "dmcall:call-before-video:missed",
+      archiveId: "mam-before-retract-video",
+      wireIds: ["stanza-before-retract-video"],
+      callThread: {
+        sid: "call-before-video",
+        media: ["audio", "video"],
+        outcome: "missed",
+      },
+    });
   });
 
   test("queryMamThreadPage seeds room reconnect catch-up from XEP-0313 archive ids", async () => {

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -6,7 +6,7 @@ import { useDirectMessages } from "../src/dms/messages";
 import { useChannelMessages } from "../src/channels/messages";
 import { BrowserXmppClient, roomBareJidFor, type InboxEntry, type LiveDmMessage, type RoomActivityEvent } from "../src/lib/xmpp-client";
 import { enqueueQueuedMessage, listQueuedDmMessages, listQueuedRoomMessages } from "../src/lib/outbound-queue-store";
-import { clearDmCallActivities, readDmCallActivity } from "../src/lib/calls/dm-call-activity";
+import { applyDmCallEvent, clearDmCallActivities, readDmCallActivity } from "../src/lib/calls/dm-call-activity";
 import { $dmCallOutcomeAnchor } from "../src/lib/calls/dm-call-anchor";
 import type { ResumePersistence } from "../src/lib/xmpp/resume-persistence";
 import { handlerStubs } from "./helpers/xmpp-client-mock";
@@ -2026,6 +2026,74 @@ describe("client keepalive lifecycle", () => {
     });
   });
 
+  test("searchDmMessages ignores call events without mutating call activity", async () => {
+    const client = new BrowserXmppClient(session());
+    (client as unknown as { connected: boolean }).connected = true;
+    applyDmCallEvent({
+      selfBareJid: "alice@example.com",
+      selfFullJid: "alice@example.com/desktop",
+      timestamp: new Date().toISOString(),
+      event: {
+        kind: "propose",
+        from: "bob@example.com/phone",
+        to: "alice@example.com/desktop",
+        sid: "call-existing-search",
+        media: { audio: true, video: false },
+      },
+    });
+    $dmCallOutcomeAnchor.set({
+      peerBareJid: "bob@example.com",
+      sid: "call-existing-outcome",
+      media: { audio: true, video: false },
+      outcome: "missed",
+      initiator: "bob@example.com/phone",
+      ended: "2024-01-01T00:00:00.000Z",
+    });
+    const existingActivity = readDmCallActivity("bob@example.com");
+    const existingOutcome = $dmCallOutcomeAnchor.get();
+    const searchDmHistory = mock(async () => ({
+      messages: [
+        dmWasmMessage({
+          mam_id: "mam-search-propose",
+          id: "search-propose",
+          body: undefined,
+          call_event: {
+            kind: "propose",
+            from: "bob@example.com/phone",
+            to: "alice@example.com/desktop",
+            sid: "call-search",
+            media: { audio: true, video: true },
+          },
+        }),
+        dmWasmMessage({
+          mam_id: "mam-search-body",
+          id: "search-body",
+          body: "matched text",
+          timestamp: "2024-01-01T00:00:02.000Z",
+        }),
+      ],
+      is_complete: true,
+    }));
+    (client as unknown as { xmpp: Agent }).xmpp = Object.assign(new EventEmitter(), {
+      search_dm_history: searchDmHistory,
+    }) as unknown as Agent;
+
+    const results = await client.searchDmMessages("bob@example.com", "matched", 20);
+
+    expect(results).toEqual([
+      {
+        id: "search-body",
+        archiveId: "mam-search-body",
+        nick: "bob",
+        body: "matched text",
+        createdAt: "2024-01-01T00:00:02.000Z",
+        peerJid: "bob@example.com",
+      },
+    ]);
+    expect(readDmCallActivity("bob@example.com")).toEqual(existingActivity);
+    expect($dmCallOutcomeAnchor.get()).toEqual(existingOutcome);
+  });
+
   test("queryMamThreadPage seeds room reconnect catch-up from XEP-0313 archive ids", async () => {
     const client = new BrowserXmppClient(session());
     const roomJid = roomBareJidFor(session(), "c1");
@@ -2055,6 +2123,62 @@ describe("client keepalive lifecycle", () => {
     expect((client as unknown as { catchup: { onSessionStarted: () => unknown[] } }).catchup.onSessionStarted()).toEqual([
       { kind: "room", key: roomJid, after: "mam-thread-1", since: "2024-01-01T00:00:01.000Z", seenIds: ["room-thread-1"] },
     ]);
+  });
+
+  test("queryPersonalMamThreadPage ignores call events without mutating call activity", async () => {
+    const client = new BrowserXmppClient(session());
+    (client as unknown as { connected: boolean }).connected = true;
+    applyDmCallEvent({
+      selfBareJid: "alice@example.com",
+      selfFullJid: "alice@example.com/desktop",
+      timestamp: new Date().toISOString(),
+      event: {
+        kind: "propose",
+        from: "bob@example.com/phone",
+        to: "alice@example.com/desktop",
+        sid: "call-existing-thread",
+        media: { audio: true, video: false },
+      },
+    });
+    $dmCallOutcomeAnchor.set({
+      peerBareJid: "bob@example.com",
+      sid: "call-existing-thread-outcome",
+      media: { audio: true, video: false },
+      outcome: "missed",
+      initiator: "bob@example.com/phone",
+      ended: "2024-01-01T00:00:00.000Z",
+    });
+    const existingActivity = readDmCallActivity("bob@example.com");
+    const existingOutcome = $dmCallOutcomeAnchor.get();
+    const fetchDmHistoryByThread = mock(async () => ({
+      messages: [
+        dmWasmMessage({
+          mam_id: "mam-thread-call",
+          id: "thread-call",
+          body: undefined,
+          thread: "call-thread",
+          call_event: {
+            kind: "propose",
+            from: "bob@example.com/phone",
+            to: "alice@example.com/desktop",
+            sid: "call-thread",
+            media: { audio: true, video: true },
+          },
+        }),
+      ],
+      last_id: "mam-thread-call",
+      is_complete: true,
+    }));
+    (client as unknown as { xmpp: Agent }).xmpp = Object.assign(new EventEmitter(), {
+      fetch_dm_history_by_thread: fetchDmHistoryByThread,
+    }) as unknown as Agent;
+
+    const page = await client.queryPersonalMamThreadPage("bob@example.com", "call-thread", 100, { type: "latest" });
+
+    expect(page.messages).toEqual([]);
+    expect(fetchDmHistoryByThread).toHaveBeenCalledWith("bob@example.com", "call-thread", 100, null);
+    expect(readDmCallActivity("bob@example.com")).toEqual(existingActivity);
+    expect($dmCallOutcomeAnchor.get()).toEqual(existingOutcome);
   });
 
   test("queryMamByThread seeds room reconnect catch-up from XEP-0313 archive ids", async () => {

--- a/chat/tests/dm-call-actions.test.ts
+++ b/chat/tests/dm-call-actions.test.ts
@@ -495,6 +495,51 @@ describe("startDmCallAction", () => {
     });
   });
 
+  test("ends recovered DM activity when terminate is orphaned but finish sends", async () => {
+    const now = new Date();
+    const tokenExp = new Date(now.getTime() + 60 * 60 * 1000);
+    const sender: CallWireSender = {
+      send_call_session_terminate_with_outcome: mock(async () => ({ kind: "orphaned" })),
+      send_call_finish: mock(async () => undefined),
+    };
+    applyDmCallEvent({
+      event: {
+        kind: "session-accept",
+        from: "bob@waddle.test/phone",
+        to: "alice@waddle.test/web",
+        sid: "finish-recovered-live",
+        media: { audio: true, video: false },
+        join: {
+          url: "wss://livekit.waddle.test",
+          room: "dm-call-retry",
+          identity: "alice@waddle.test/web",
+          token: jwtWithExp(tokenExp.getTime() / 1000),
+        },
+      },
+      selfBareJid: "alice@waddle.test",
+      timestamp: now.toISOString(),
+      now,
+    });
+
+    await expect(endRecoveredDmCallAction({
+      peerBareJid: "bob@waddle.test",
+      getSender: () => sender,
+      getSelfFullJid: () => "alice@waddle.test/web",
+      now,
+    })).resolves.toBe(true);
+
+    expect(sender.send_call_session_terminate_with_outcome).toHaveBeenCalledWith(
+      "bob@waddle.test/phone",
+      "finish-recovered-live",
+      "success",
+    );
+    expect(sender.send_call_finish).toHaveBeenCalledWith(
+      "bob@waddle.test/phone",
+      "finish-recovered-live",
+    );
+    expect(readDmCallActivity("bob@waddle.test", now)).toBeNull();
+  });
+
   test("keeps recovered DM activity retryable when no end marker sends", async () => {
     const now = new Date();
     const tokenExp = new Date(now.getTime() + 60 * 60 * 1000);
@@ -535,6 +580,51 @@ describe("startDmCallAction", () => {
     expect(sender.send_call_finish).not.toHaveBeenCalled();
     expect(readDmCallActivity("bob@waddle.test", now)).toMatchObject({
       sid: "retry-live",
+      state: "accepted",
+    });
+  });
+
+  test("keeps recovered DM activity retryable when typed terminate outcome is error", async () => {
+    const now = new Date();
+    const tokenExp = new Date(now.getTime() + 60 * 60 * 1000);
+    const sender: CallWireSender = {
+      send_call_session_terminate_with_outcome: mock(async () => ({ kind: "error" })),
+      send_call_finish: mock(async () => undefined),
+    };
+    applyDmCallEvent({
+      event: {
+        kind: "session-accept",
+        from: "bob@waddle.test/phone",
+        to: "alice@waddle.test/web",
+        sid: "typed-error-live",
+        media: { audio: true, video: false },
+        join: {
+          url: "wss://livekit.waddle.test",
+          room: "dm-call-typed-error",
+          identity: "alice@waddle.test/web",
+          token: jwtWithExp(tokenExp.getTime() / 1000),
+        },
+      },
+      selfBareJid: "alice@waddle.test",
+      timestamp: now.toISOString(),
+      now,
+    });
+
+    await expect(endRecoveredDmCallAction({
+      peerBareJid: "bob@waddle.test",
+      getSender: () => sender,
+      getSelfFullJid: () => "alice@waddle.test/web",
+      now,
+    })).resolves.toBe(false);
+
+    expect(sender.send_call_session_terminate_with_outcome).toHaveBeenCalledWith(
+      "bob@waddle.test/phone",
+      "typed-error-live",
+      "success",
+    );
+    expect(sender.send_call_finish).not.toHaveBeenCalled();
+    expect(readDmCallActivity("bob@waddle.test", now)).toMatchObject({
+      sid: "typed-error-live",
       state: "accepted",
     });
   });

--- a/chat/tests/dm-call-anchor.test.ts
+++ b/chat/tests/dm-call-anchor.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { effectScope, ref } from "vue";
 import {
+  $dmCallOutcomeAnchor,
   buildDmCallOutcomeAnchor,
   buildDmCallStartedAnchor,
   dmCallAnchorId,
@@ -36,6 +37,10 @@ const base = {
   initiator: "alice@waddle.test/web",
   started: "2026-06-09T12:00:00Z",
 };
+
+afterEach(() => {
+  $dmCallOutcomeAnchor.set(null);
+});
 
 describe("dm call-started anchor", () => {
   test("builds a feed-visible dm call anchor keyed by the call sid", () => {
@@ -242,6 +247,30 @@ describe("dm call outcome anchor", () => {
       isSelf: false,
     });
     expect(callThreadAnchorLabel(card)).toBe("Missed call");
+  });
+
+  test("renders no-answer outcome cards as self-authored even without an initiator", () => {
+    const { initiator: _initiator, ...outcomeWithoutInitiator } = outcome;
+    const card = buildDmCallOutcomeAnchor(
+      { ...outcomeWithoutInitiator, outcome: "no-answer" },
+      "alice@waddle.test/desktop",
+    );
+
+    expect(card).toMatchObject({
+      author: "alice",
+      authorJid: "alice@waddle.test/desktop",
+      isSelf: true,
+    });
+  });
+
+  test("keeps ended duration in outcome labels", () => {
+    const card = buildDmCallOutcomeAnchor(
+      { ...outcome, outcome: "ended" },
+      "alice@waddle.test/desktop",
+    );
+    card.callThread = { ...card.callThread!, duration: "PT5M" };
+
+    expect(callThreadAnchorLabel(card)).toBe("Call ended · 5m");
   });
 
   test("labels missed, no-answer, and ended outcome cards", () => {

--- a/chat/tests/dm-call-anchor.test.ts
+++ b/chat/tests/dm-call-anchor.test.ts
@@ -1,12 +1,19 @@
 import { describe, expect, test } from "bun:test";
+import { effectScope, ref } from "vue";
 import {
+  buildDmCallOutcomeAnchor,
   buildDmCallStartedAnchor,
   dmCallAnchorId,
+  dmCallOutcomeAnchorId,
   dmCallStartedAnchorFromTransition,
+  publishDmCallOutcomeAnchor,
   resolveDmCallAnchorInjection,
+  resolveDmCallOutcomeInjection,
 } from "../src/lib/calls/dm-call-anchor";
+import { callThreadAnchorLabel, readCallAnchorCardState } from "../src/lib/call-thread-anchor";
 import { isFeedTimelineMessage } from "../src/channels/timeline";
 import { buildDmTimelineFromMamResults } from "../src/dms/message-timeline-state";
+import { useDirectMessages } from "../src/dms/messages";
 import type { CallState } from "../src/lib/calls/types";
 import type { LiveDmMessage } from "../src/lib/xmpp-client";
 import type { WaddleSession } from "../src/lib/server-auth";
@@ -188,5 +195,99 @@ describe("dm call-started anchor consumer guard", () => {
   test("returns null without a session or an open conversation", () => {
     expect(resolveDmCallAnchorInjection(anchor, null, "alice@waddle.test/web")).toBeNull();
     expect(resolveDmCallAnchorInjection(anchor, "bob@waddle.test", null)).toBeNull();
+  });
+});
+
+describe("dm call outcome anchor", () => {
+  const outcome = {
+    peerBareJid: "bob@waddle.test",
+    sid: "sid-1",
+    media: { audio: true, video: true },
+    initiator: "alice@waddle.test/web",
+    ended: "2026-06-09T12:05:00Z",
+    outcome: "declined" as const,
+  };
+
+  test("builds a feed-visible declined entry keyed by sid and outcome", () => {
+    const card = buildDmCallOutcomeAnchor(outcome, "alice@waddle.test/desktop");
+
+    expect(card.id).toBe(dmCallOutcomeAnchorId("sid-1", "declined"));
+    expect(card.threadId).toBe("sid-1");
+    expect(card.callThread).toMatchObject({
+      kind: "dm",
+      sid: "sid-1",
+      media: ["audio", "video"],
+      ended: "2026-06-09T12:05:00Z",
+      outcome: "declined",
+    });
+    expect(card).toMatchObject({
+      author: "alice",
+      authorJid: "alice@waddle.test/desktop",
+      isSelf: true,
+    });
+    expect(callThreadAnchorLabel(card)).toBe("Call declined");
+    expect(readCallAnchorCardState(card, "bob@waddle.test")?.title).toBe("Call declined");
+    expect(isFeedTimelineMessage(card)).toBe(true);
+  });
+
+  test("renders peer-initiated outcome cards as remote-authored", () => {
+    const card = buildDmCallOutcomeAnchor(
+      { ...outcome, initiator: "bob@waddle.test/phone", outcome: "missed" },
+      "alice@waddle.test/desktop",
+    );
+
+    expect(card).toMatchObject({
+      author: "bob",
+      authorJid: "bob@waddle.test",
+      isSelf: false,
+    });
+    expect(callThreadAnchorLabel(card)).toBe("Missed call");
+  });
+
+  test("labels missed, no-answer, and ended outcome cards", () => {
+    expect(callThreadAnchorLabel(buildDmCallOutcomeAnchor({ ...outcome, outcome: "missed" }, "alice@waddle.test/web"))).toBe("Missed call");
+    expect(callThreadAnchorLabel(buildDmCallOutcomeAnchor({ ...outcome, outcome: "no-answer" }, "alice@waddle.test/web"))).toBe("No answer");
+    expect(callThreadAnchorLabel(buildDmCallOutcomeAnchor({ ...outcome, outcome: "ended" }, "alice@waddle.test/web"))).toBe("Call ended");
+  });
+
+  test("injects only into the matching open conversation", () => {
+    expect(
+      resolveDmCallOutcomeInjection(outcome, "bob@waddle.test", "alice@waddle.test/web")?.id,
+    ).toBe(dmCallOutcomeAnchorId("sid-1", "declined"));
+    expect(
+      resolveDmCallOutcomeInjection(outcome, "carol@waddle.test", "alice@waddle.test/web"),
+    ).toBeNull();
+  });
+
+  test("publishes into the open DM timeline and ignores other peers", () => {
+    const scope = effectScope();
+    const sessionRef = ref({ jid: "alice@waddle.test/web", username: "alice" } as WaddleSession);
+    const activePeerJid = ref("bob@waddle.test");
+    const actionError = ref("");
+    const messaging = scope.run(() =>
+      useDirectMessages(
+        sessionRef,
+        ref(null),
+        activePeerJid,
+        String,
+        actionError,
+        () => {
+          actionError.value = "";
+        },
+      )
+    );
+    if (!messaging) throw new Error("scope did not create DM messaging");
+
+    publishDmCallOutcomeAnchor(outcome);
+    expect(messaging.messages.value).toHaveLength(1);
+    expect(messaging.messages.value[0]?.callThread).toMatchObject({
+      sid: "sid-1",
+      outcome: "declined",
+    });
+
+    publishDmCallOutcomeAnchor({ ...outcome, peerBareJid: "carol@waddle.test", sid: "sid-2" });
+    expect(messaging.messages.value).toHaveLength(1);
+
+    scope.stop();
   });
 });

--- a/server/crates/waddle-xmpp-client-wasm/src/client_calls.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_calls.rs
@@ -408,6 +408,42 @@ impl WaddleClient {
             Ok(JsValue::UNDEFINED)
         })
     }
+
+    pub fn send_call_session_terminate_with_outcome(
+        &self,
+        peer_full_jid: String,
+        sid_str: String,
+        reason: Option<String>,
+    ) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let typed_reason = match reason {
+                Some(name) => Some(
+                    jingle_reason_from_wire_name(&name)
+                        .ok_or_else(|| js_error(format!("unknown jingle reason: {name}")))?,
+                ),
+                None => None,
+            };
+            let _ = parse_full_jid(&peer_full_jid)?;
+            let stanza = iq_set(
+                &peer_full_jid,
+                build_session_terminate(&sid(sid_str), typed_reason),
+            );
+            let outcome = match send_iq_command_stanza_aware(inner, stanza).await? {
+                Ok(_) => WaddleCallSessionTerminateOutcome::Ok,
+                Err(err) if is_orphaned_dm_call_terminate(&err) => {
+                    WaddleCallSessionTerminateOutcome::Orphaned
+                }
+                Err(_) => WaddleCallSessionTerminateOutcome::Error,
+            };
+            to_js_value(&outcome)
+        })
+    }
+}
+
+fn is_orphaned_dm_call_terminate(err: &waddle_xmpp_client::StanzaError) -> bool {
+    err.condition == "forbidden"
+        && err.text.as_deref() == Some("Jingle terminator is not a participant in this call")
 }
 
 #[cfg(test)]
@@ -426,6 +462,30 @@ mod tests {
     fn calls_mixer_jid_appends_localpart_to_domain() {
         assert_eq!(calls_mixer_jid("waddle.test"), "calls.waddle.test");
         assert_eq!(calls_mixer_jid("example.com"), "calls.example.com");
+    }
+
+    #[test]
+    fn classifies_only_orphaned_dm_terminate_stanza_error() {
+        let orphaned = waddle_xmpp_client::StanzaError {
+            error_type: waddle_xmpp_client::StanzaErrorType::Auth,
+            condition: "forbidden".to_string(),
+            text: Some("Jingle terminator is not a participant in this call".to_string()),
+        };
+        assert!(is_orphaned_dm_call_terminate(&orphaned));
+
+        let generic_forbidden = waddle_xmpp_client::StanzaError {
+            error_type: waddle_xmpp_client::StanzaErrorType::Auth,
+            condition: "forbidden".to_string(),
+            text: Some("Jingle responder was not invited to this call party".to_string()),
+        };
+        assert!(!is_orphaned_dm_call_terminate(&generic_forbidden));
+
+        let transportish = waddle_xmpp_client::StanzaError {
+            error_type: waddle_xmpp_client::StanzaErrorType::Cancel,
+            condition: "remote-server-timeout".to_string(),
+            text: None,
+        };
+        assert!(!is_orphaned_dm_call_terminate(&transportish));
     }
 
     /// `parse_full_jid` itself returns `Result<FullJid, JsValue>`,

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -990,6 +990,22 @@ pub enum WaddleSendMessageOutcome {
     Error,
 }
 
+/// JS-facing outcome for DM Jingle `session-terminate`.
+///
+/// `Orphaned` is deliberately narrow: it means the server rejected the
+/// terminate because its in-memory Jingle participant registry no
+/// longer contains the sender/peer pair, so the chat layer may still
+/// send the XEP-0353 `<finish/>` message-level bookend. Other stanza
+/// errors remain generic `Error` and must not be treated as a completed
+/// Jingle termination.
+#[derive(Debug, Serialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum WaddleCallSessionTerminateOutcome {
+    Ok,
+    Orphaned,
+    Error,
+}
+
 /// JS-facing tagged outcome of `WaddleClient::set_room_notification_mode`.
 ///
 /// Returned by always-resolving the Promise (never rejecting on

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -294,6 +294,7 @@ export class WaddleClient {
      */
     send_call_session_initiate(peer_full_jid: string, initiator_full_jid: string, sid_str: string, audio: boolean, video: boolean): Promise<any>;
     send_call_session_terminate(peer_full_jid: string, sid_str: string, reason?: string | null): Promise<any>;
+    send_call_session_terminate_with_outcome(peer_full_jid: string, sid_str: string, reason?: string | null): Promise<any>;
     send_chat_message(peer_jid: string, body: string, options: any): Promise<any>;
     send_chat_state(to: string, msg_type: string, state: string, thread_id?: string | null, thread_parent?: string | null): Promise<any>;
     send_correction(to: string, msg_type: string, body: string, replaces_id: string, options: any): Promise<any>;

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=5e8bf2254b89";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=5e8bf2254b89";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=5e8bf2254b89";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=d5140df1ec1c";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=d5140df1ec1c";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=d5140df1ec1c";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=5e8bf2254b89";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=d5140df1ec1c";


### PR DESCRIPTION
Implements #948.

## Completed
- Records terminal 1:1 DM call outcomes as feed-visible call-anchor entries:
  - declined from `<reject/>`
  - missed from peer `<retract/>`
  - no-answer from local outgoing ring timeout, timeout `<session-terminate/>`, and post-proceed session-accept timeout
  - ended from completed-call `<finish/>` / non-timeout `<session-terminate/>`
- Reuses the existing typed JMI/Jingle `CallEvent` reducer path so live callbacks and MAM replay derive the same outcomes.
- Keeps background and initial MAM hydration silent: archive outcome cards are returned in the loaded timeline instead of being transiently published through the live atom.
- Preserves terminal MAM archive IDs and raw wire IDs on synthesized DM call outcome cards so reconnect catch-up can advance by XEP-0313 cursor and skip already-seen terminal rows.
- Synthesizes DM call outcome cards for both latest and older paged MAM history.
- Prevents duplicate/out-of-order terminal replays from republishing fallback-media outcome cards after a terminal event is already recorded.
- Treats the first recorded terminal event for a DM call SID as exclusive, preventing later `<finish/>` bookends from adding a second conflicting outcome card after timeout/no-answer.
- Adds DM timeline outcome labels and author attribution for self-initiated vs peer-initiated outcome records, including no-answer cards with missing initiators.
- Keeps ended outcome labels from losing duration formatting.
- Wires outcome anchors into the existing open-DM call-anchor bridge.
- Fixes stuck recovered DM teardown after server-side Jingle state is lost:
  - Adds a typed WASM `send_call_session_terminate_with_outcome` result.
  - Classifies only the exact orphaned DM terminate stanza error (`forbidden` + `Jingle terminator is not a participant in this call`) as safe to follow with XEP-0353 `<finish/>`.
  - Keeps arbitrary terminate failures retryable and does not send `<finish/>` for them.
  - Preserves the recovered DM activity row when teardown fails so the user can retry.
- Addresses follow-up review comments:
  - Active DM teardown now clears the dock activity even when terminate returns `error` or throws, while recovered-call teardown remains retryable.
  - `sessionTerminateWithOutcome` no longer depends on object-literal `this` binding for the legacy fallback.
  - DM search decodes archived messages directly and does not run the call-event reducer.
  - DM thread-history pages keep call-event reducer side effects disabled.
  - Later terminal bookends after an already-recorded terminal event no longer create duplicate outcome cards.

## Test plan
- `cd chat && bun test`
- `cd chat && bun run lint`
- `cd chat && bunx astro check`
- `cd chat && bun run build`
- `cd server && cargo test -p waddle-xmpp-client-wasm classifies_only_orphaned_dm_terminate_stanza_error`

## Review notes
- Addressed GitHub review comments for timeout terminate classification, archive-only outcome visibility, duplicate terminal replay handling, outcome test isolation, ended duration labels, and no-answer attribution when the initiator is absent.
- Addressed follow-up review comments for active-call activity cleanup on terminate failure, side-effect-free DM search/thread MAM reads, the fragile `this` fallback in outbound calls, and duplicate conflicting outcomes from later terminal bookends.
- Ran adversarial code-review and test-review subagents after the fixes. The code reviewer found no remaining behavioral issues; the test reviewer requested stronger coverage, which is now included.
- `bun run lint` invokes the existing wasm/knip flow; this run reused existing WASM artifacts.
- `astro check` still reports the existing non-blocking hint in `src/lib/xmpp/discovery.ts` about converting `withIqTimeout` to async.
