### PR TITLE
fix(chat): make group foreground notifications follow mode

### DIFF
--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -89,6 +89,7 @@ export function useChannelMessages(
   const activeChannels = ref<Set<string>>(new Set());
   const mentionedChannelCounts = ref<Record<string, number>>({});
   const lastMentionActivity = ref<RoomActivityEvent | null>(null);
+  const pendingNotificationActivities = ref<RoomActivityEvent[]>([]);
   const roomAvatarHashes = ref<Record<string, string>>({});
   const roomJidOverrides = ref<Record<string, string>>({});
 
@@ -192,6 +193,7 @@ export function useChannelMessages(
             roomJid: msg.roomJid,
             nick: msg.nick,
             body: msg.body,
+            ...(msg.stanzaId ? { stanzaId: msg.stanzaId } : {}),
             ...(msg.mentions ? { mentions: msg.mentions } : {}),
             ...(msg.broadcastMention ? { broadcastMention: msg.broadcastMention } : {}),
           });
@@ -211,24 +213,24 @@ export function useChannelMessages(
         // applyCorrection / mergeLiveMessage based on the stanza shape.
         const classified = liveMerge.handleRoomMessage(msg);
 
-        // Mention-driven notification routing stays in the orchestrator —
+        // Foreground notification routing stays in the orchestrator —
         // it depends on cross-room session state and the tab-visibility
         // signal, both of which are out of scope for live-merge.
         if (classified.kind !== "live") return;
-        const isTabHidden = typeof document !== "undefined"
-          && (!document.hasFocus() || document.visibilityState === "hidden");
-        if (msg.nick !== session.value?.username && isTabHidden) {
+        if (msg.nick !== session.value?.username && isTabHidden()) {
           const isMentioned =
             !!msg.broadcastMention ||
             msg.mentions?.some(isSessionMention);
+          const activity: RoomActivityEvent = {
+            roomJid: msg.roomJid,
+            nick: msg.nick,
+            body: msg.body,
+          };
+          if (msg.stanzaId) activity.stanzaId = msg.stanzaId;
+          if (msg.mentions) activity.mentions = msg.mentions;
+          if (msg.broadcastMention) activity.broadcastMention = msg.broadcastMention;
+          enqueueNotificationActivity(activity);
           if (isMentioned) {
-            const activity: RoomActivityEvent = {
-              roomJid: msg.roomJid,
-              nick: msg.nick,
-              body: msg.body,
-            };
-            if (msg.mentions) activity.mentions = msg.mentions;
-            if (msg.broadcastMention) activity.broadcastMention = msg.broadcastMention;
             recordMentionActivity(activity);
             lastMentionActivity.value = activity;
           }
@@ -588,6 +590,7 @@ export function useChannelMessages(
     activeChannels.value = new Set();
     mentionedChannelCounts.value = {};
     lastMentionActivity.value = null;
+    pendingNotificationActivities.value = [];
   }
 
   function isOwnMentionActivity(event: RoomActivityEvent): boolean {
@@ -611,10 +614,22 @@ export function useChannelMessages(
   function recordRoomActivity(event: RoomActivityEvent) {
     const roomJid = barePeerJid(event.roomJid);
     activeChannels.value = new Set([...activeChannels.value, roomJid]);
+    if (event.nick !== session.value?.username && isTabHidden()) {
+      enqueueNotificationActivity(event);
+    }
     if (isOwnMentionActivity(event)) {
       recordMentionActivity(event);
       lastMentionActivity.value = event;
     }
+  }
+
+  function isTabHidden(): boolean {
+    return typeof document !== "undefined"
+      && (!document.hasFocus() || document.visibilityState === "hidden");
+  }
+
+  function enqueueNotificationActivity(event: RoomActivityEvent) {
+    pendingNotificationActivities.value = [...pendingNotificationActivities.value, event];
   }
 
   watch(scrollDirection, () => {
@@ -707,6 +722,7 @@ export function useChannelMessages(
     isPinnedAtEdge: pinnedEdgeScroller.isPinnedAtEdge,
     latestRemoteMessageId,
     lastMentionActivity,
+    pendingNotificationActivities,
     onMessageQueueStatus,
     onMessageAck,
     onMessageDeliveryFailure,

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -8,7 +8,7 @@ import { useChannelMessages } from "@/channels/messages";
 import { useMessageThreads } from "@/channels/threads";
 import { useChatShellState } from "@/shell/state";
 import { useServiceWorkerUpdate } from "@/shell/service-worker-update";
-import { usePushNotifications } from "@/shell/notifications";
+import { shouldShowChannelForegroundNotification, usePushNotifications } from "@/shell/notifications";
 import { useChannelInbox } from "@/channels/inbox";
 import { useSocialFeed } from "@/services/social-feed";
 import { useStories } from "@/services/stories";
@@ -22,8 +22,8 @@ import { useDeploymentVersionInfo } from "@/shell/version";
 import { useXmppRosterContacts } from "@/contacts/roster";
 import { matchLocation, navigate, type RouteMatch } from "@/router";
 import { resolveChannelBySlug } from "@/shell/route-helpers";
-import { barePeerJid, jidDomain, parseManagedRoomBareJid } from "@/lib/xmpp-client";
-import { createNotifySettingsStore } from "@/lib/notify-settings";
+import { barePeerJid, jidDomain, parseManagedRoomBareJid, type RoomActivityEvent } from "@/lib/xmpp-client";
+import { createNotifySettingsStore, type NotifySettingsStore } from "@/lib/notify-settings";
 import { mdsChatKey, queueMdsDisplayed, setMdsDisplayed } from "@/lib/last-seen-store";
 import {
   isTrustedManagedRoomJid,
@@ -52,6 +52,78 @@ import {
   selectInitialReactionMessage,
   type ReactionModeScope,
 } from "@/lib/reaction-mode";
+
+interface ChannelActivityNotificationDeps {
+  notifySettings: Pick<NotifySettingsStore, "getMode">;
+  notifications: {
+    showMentionNotification: (opts: {
+      senderNick: string;
+      channelName: string;
+      body: string;
+      roomJid: string;
+      isBroadcast: boolean;
+      stanzaId?: string;
+      onNavigate?: (roomJid: string) => void;
+    }) => void;
+    showChannelMessageNotification: (opts: {
+      senderNick: string;
+      channelName: string;
+      body: string;
+      roomJid: string;
+      stanzaId?: string;
+      onNavigate?: (roomJid: string) => void;
+    }) => void;
+  };
+  sessionJid: string | null | undefined;
+  resolveChannelNameFromJid: (roomJid: string) => string | null;
+  onNavigate: (roomJid: string) => void;
+}
+
+export function showForegroundNotificationForChannelActivity(
+  event: RoomActivityEvent,
+  deps: ChannelActivityNotificationDeps,
+): void {
+  const channelName = deps.resolveChannelNameFromJid(event.roomJid) ?? "unknown";
+  const isBroadcast = !!event.broadcastMention;
+  const isPersonalMention = event.mentions?.some((mention) =>
+    mentionMatchesBareJid(mention, deps.sessionJid)
+  ) ?? false;
+  const isMention = isBroadcast || isPersonalMention;
+  const mode = deps.notifySettings.getMode(event.roomJid, "private-group");
+
+  if (!shouldShowChannelForegroundNotification({ mode, isMention })) return;
+
+  if (isMention) {
+    deps.notifications.showMentionNotification({
+      senderNick: event.nick,
+      channelName,
+      body: event.body,
+      roomJid: event.roomJid,
+      isBroadcast,
+      stanzaId: event.stanzaId,
+      onNavigate: deps.onNavigate,
+    });
+    return;
+  }
+
+  deps.notifications.showChannelMessageNotification({
+    senderNick: event.nick,
+    channelName,
+    body: event.body,
+    roomJid: event.roomJid,
+    stanzaId: event.stanzaId,
+    onNavigate: deps.onNavigate,
+  });
+}
+
+export function showForegroundNotificationsForChannelActivities(
+  events: RoomActivityEvent[],
+  deps: ChannelActivityNotificationDeps,
+): void {
+  for (const event of events) {
+    showForegroundNotificationForChannelActivity(event, deps);
+  }
+}
 
 export function useChatAppController(giphyApiKey: string) {
   const ui = useChatShellState();
@@ -678,32 +750,22 @@ export function useChatAppController(giphyApiKey: string) {
     return waddles.channels.value.find((c) => c.id === managedRoom.channelId)?.name ?? null;
   }
 
-  watch(() => messaging.lastMentionActivity.value, (event) => {
-    if (!event) return;
+  watch(() => messaging.pendingNotificationActivities.value, (events) => {
+    if (events.length === 0) return;
 
-    const channelName = resolveChannelNameFromJid(event.roomJid) ?? "unknown";
-    const isBroadcast = !!event.broadcastMention;
-    const isPersonalMention = event.mentions?.some((mention) =>
-      mentionMatchesBareJid(mention, connectionStore.session?.jid)
-    );
+    showForegroundNotificationsForChannelActivities(events, {
+      notifySettings,
+      notifications,
+      sessionJid: connectionStore.session?.jid,
+      resolveChannelNameFromJid,
+      onNavigate: (roomJid) => {
+        const managedRoom = parseManagedRoomBareJid(roomJid);
+        if (!managedRoom) return;
+        void selectChannel(managedRoom.channelId);
+      },
+    });
 
-    if (isBroadcast || isPersonalMention) {
-      notifications.showMentionNotification({
-        senderNick: event.nick,
-        channelName,
-        body: event.body,
-        roomJid: event.roomJid,
-        isBroadcast,
-        stanzaId: event.stanzaId,
-        onNavigate: (roomJid) => {
-          const managedRoom = parseManagedRoomBareJid(roomJid);
-          if (!managedRoom) return;
-          void selectChannel(managedRoom.channelId);
-        },
-      });
-    }
-
-    messaging.lastMentionActivity.value = null;
+    messaging.pendingNotificationActivities.value = [];
   });
 
   watch(xmppClient, (client) => {

--- a/chat/src/shell/notifications.ts
+++ b/chat/src/shell/notifications.ts
@@ -1,5 +1,5 @@
 import { ref, watch } from "vue";
-import type { BrowserXmppClient } from "@/lib/xmpp-client";
+import type { BrowserXmppClient, NotifyMode } from "@/lib/xmpp-client";
 import { getOrRegisterServiceWorker, registerServiceWorker as registerChatServiceWorker } from "@/lib/service-worker-registration";
 import { createPushFlowLock } from "./push-flow-lock";
 import {
@@ -34,8 +34,9 @@ const APP_ID_WEB = "web";
 /// pinned here so the server's environment-filter logic is exercised.
 const PUSH_ENVIRONMENT = "prod";
 
-const hasNotificationApi =
-  typeof window !== "undefined" && "Notification" in window;
+function hasNotificationApi(): boolean {
+  return typeof window !== "undefined" && "Notification" in window;
+}
 
 interface MentionNotificationOptions {
   senderNick: string;
@@ -51,6 +52,15 @@ interface MentionNotificationOptions {
   onNavigate?: (roomJid: string) => void;
 }
 
+interface ChannelMessageNotificationOptions {
+  senderNick: string;
+  channelName: string;
+  body: string;
+  roomJid: string;
+  stanzaId?: string;
+  onNavigate?: (roomJid: string) => void;
+}
+
 interface DmNotificationOptions {
   senderUsername: string;
   peerJid: string;
@@ -58,6 +68,20 @@ interface DmNotificationOptions {
   /** XEP-0359 stanza id; see `MentionNotificationOptions.stanzaId`. */
   stanzaId?: string;
   onNavigate?: (peerJid: string) => void;
+}
+
+export function shouldShowChannelForegroundNotification(opts: {
+  mode: NotifyMode;
+  isMention: boolean;
+}): boolean {
+  switch (opts.mode) {
+    case "always":
+      return true;
+    case "on-mention":
+      return opts.isMention;
+    case "never":
+      return false;
+  }
 }
 
 /// Foreground→SW signal: tell the active service worker we just
@@ -82,7 +106,7 @@ function postItemShownToServiceWorker(itemId: string | undefined): void {
 
 export function usePushNotifications() {
   const permissionState = ref<NotificationPermission>(
-    hasNotificationApi ? Notification.permission : "denied",
+    hasNotificationApi() ? Notification.permission : "denied",
   );
   const notificationsEnabled = ref(loadEnabled());
   /// Surfaced to the UI as a non-intrusive banner the first time a
@@ -115,7 +139,7 @@ export function usePushNotifications() {
   });
 
   async function requestPermission(): Promise<NotificationPermission> {
-    if (!hasNotificationApi) return "denied";
+    if (!hasNotificationApi()) return "denied";
     const result = await Notification.requestPermission();
     permissionState.value = result;
     if (result === "granted") {
@@ -125,7 +149,7 @@ export function usePushNotifications() {
   }
 
   function showMentionNotification(opts: MentionNotificationOptions) {
-    if (!hasNotificationApi) return;
+    if (!hasNotificationApi()) return;
     if (permissionState.value !== "granted" || !notificationsEnabled.value) return;
 
     const title = opts.isBroadcast
@@ -154,8 +178,29 @@ export function usePushNotifications() {
     setTimeout(() => notification.close(), 5000);
   }
 
+  function showChannelMessageNotification(opts: ChannelMessageNotificationOptions) {
+    if (!hasNotificationApi()) return;
+    if (permissionState.value !== "granted" || !notificationsEnabled.value) return;
+
+    const body = opts.body.length > 100 ? `${opts.body.slice(0, 100)}…` : opts.body;
+    const notification = new Notification(`@${opts.senderNick} in #${opts.channelName}`, {
+      body,
+      tag: opts.roomJid,
+      icon: NOTIFICATION_ICON_URL,
+    });
+
+    notification.onclick = () => {
+      window.focus();
+      opts.onNavigate?.(opts.roomJid);
+      notification.close();
+    };
+
+    postItemShownToServiceWorker(opts.stanzaId);
+    setTimeout(() => notification.close(), 5000);
+  }
+
   function showDmNotification(opts: DmNotificationOptions) {
-    if (!hasNotificationApi) return;
+    if (!hasNotificationApi()) return;
     if (permissionState.value !== "granted" || !notificationsEnabled.value) return;
     const body = opts.body.length > 100 ? `${opts.body.slice(0, 100)}…` : opts.body;
     const notification = new Notification(`Message from @${opts.senderUsername}`, {
@@ -549,6 +594,7 @@ export function usePushNotifications() {
     dismissRotationBanner,
     requestPermission,
     showMentionNotification,
+    showChannelMessageNotification,
     showDmNotification,
     registerServiceWorker,
     subscribeToPush,

--- a/chat/src/shell/notifications.ts
+++ b/chat/src/shell/notifications.ts
@@ -160,6 +160,9 @@ export function usePushNotifications() {
 
     const notification = new Notification(title, {
       body,
+      // Per-room tag intentionally lets the browser replace an older
+      // visible banner for the same channel while every stanza id still
+      // posts to the service worker for Web Push dedup below.
       tag: opts.roomJid,
       icon: NOTIFICATION_ICON_URL,
     });
@@ -185,6 +188,8 @@ export function usePushNotifications() {
     const body = opts.body.length > 100 ? `${opts.body.slice(0, 100)}…` : opts.body;
     const notification = new Notification(`@${opts.senderNick} in #${opts.channelName}`, {
       body,
+      // Match mention notifications: one visible banner per room, with
+      // per-message Web Push dedup still handled by stanza id below.
       tag: opts.roomJid,
       icon: NOTIFICATION_ICON_URL,
     });

--- a/chat/tests/channel-activity.test.ts
+++ b/chat/tests/channel-activity.test.ts
@@ -141,6 +141,62 @@ describe("channel activity", () => {
         "general@conference.example.com": 1,
       });
       expect(messaging.lastMentionActivity.value?.body).toBe("right alice");
+      const notificationActivity = messaging.pendingNotificationActivities.value.at(-1);
+      expect(notificationActivity?.roomJid).toBe("general@conference.example.com");
+      expect(notificationActivity?.nick).toBe("bob");
+      expect(notificationActivity?.body).toBe("right alice");
+      expect(notificationActivity?.mentions).toEqual(["xmpp:alice@example.com"]);
+    } finally {
+      scope.stop();
+      cleanupDocument?.();
+    }
+  });
+
+  test("records current-room hidden plain messages as foreground notification candidates", async () => {
+    let onMessage: ((message: LiveRoomMessage) => void) | null = null;
+    const actionError = ref("");
+    const scope = effectScope();
+    let cleanupDocument: (() => void) | null = null;
+
+    try {
+      cleanupDocument = installHiddenDocument();
+      const messaging = scope.run(() =>
+        useChannelMessages(
+          ref(session()),
+          ref(null),
+          ref({
+            ...handlerStubs(),
+            setMessageHandler(handler: (message: LiveRoomMessage) => void) {
+              onMessage = handler;
+            },
+          } as never),
+          ref("team"),
+          ref("general"),
+          ref({ id: "general", name: "General", jid: "general@conference.example.com" }),
+          String,
+          actionError,
+          () => {
+            actionError.value = "";
+          },
+        )
+      );
+      if (!messaging) throw new Error("channel messages composable did not initialize");
+      await nextTick();
+
+      onMessage?.(roomMessage({
+        id: "plain-hidden",
+        body: "plain update",
+        stanzaId: "stanza-plain-hidden",
+      }));
+
+      expect(messaging.pendingNotificationActivities.value.at(-1)).toMatchObject({
+        roomJid: "general@conference.example.com",
+        nick: "bob",
+        body: "plain update",
+        stanzaId: "stanza-plain-hidden",
+      });
+      expect(messaging.mentionedChannelCounts.value).toEqual({});
+      expect(messaging.lastMentionActivity.value).toBeNull();
     } finally {
       scope.stop();
       cleanupDocument?.();
@@ -151,6 +207,7 @@ describe("channel activity", () => {
     let onMessage: ((message: LiveRoomMessage) => void) | null = null;
     const actionError = ref("");
     const scope = effectScope();
+    let cleanupDocument: (() => void) | null = null;
     const messaging = scope.run(() =>
       useChannelMessages(
         ref(session()),
@@ -173,6 +230,7 @@ describe("channel activity", () => {
     );
 
     try {
+      cleanupDocument = installHiddenDocument();
       if (!messaging) throw new Error("channel messages composable did not initialize");
       await nextTick();
 
@@ -188,8 +246,66 @@ describe("channel activity", () => {
         "general@conference.example.com": 1,
       });
       expect(messaging.lastMentionActivity.value?.body).toBe("right alice from previous room");
+      const notificationActivity = messaging.pendingNotificationActivities.value.at(-1);
+      expect(notificationActivity?.roomJid).toBe("general@conference.example.com");
+      expect(notificationActivity?.nick).toBe("bob");
+      expect(notificationActivity?.body).toBe("right alice from previous room");
+      expect(notificationActivity?.mentions).toEqual(["xmpp:alice@example.com"]);
     } finally {
       scope.stop();
+      cleanupDocument?.();
+    }
+  });
+
+  test("records previous-room hidden plain messages as foreground notification candidates", async () => {
+    let onMessage: ((message: LiveRoomMessage) => void) | null = null;
+    const actionError = ref("");
+    const scope = effectScope();
+    let cleanupDocument: (() => void) | null = null;
+    const messaging = scope.run(() =>
+      useChannelMessages(
+        ref(session()),
+        ref(null),
+        ref({
+          ...handlerStubs(),
+          setMessageHandler(handler: (message: LiveRoomMessage) => void) {
+            onMessage = handler;
+          },
+        } as never),
+        ref("team"),
+        ref(null),
+        ref(null),
+        String,
+        actionError,
+        () => {
+          actionError.value = "";
+        },
+      )
+    );
+
+    try {
+      cleanupDocument = installHiddenDocument();
+      if (!messaging) throw new Error("channel messages composable did not initialize");
+      await nextTick();
+
+      onMessage?.(roomMessage({
+        id: "home-activity-plain",
+        body: "plain update from previous room",
+        stanzaId: "stanza-previous-plain",
+      }));
+
+      expect(messaging.messages.value).toEqual([]);
+      expect(messaging.activeChannels.value.has("general@conference.example.com")).toBe(true);
+      expect(messaging.mentionedChannelCounts.value).toEqual({});
+      expect(messaging.pendingNotificationActivities.value.at(-1)).toMatchObject({
+        roomJid: "general@conference.example.com",
+        nick: "bob",
+        body: "plain update from previous room",
+        stanzaId: "stanza-previous-plain",
+      });
+    } finally {
+      scope.stop();
+      cleanupDocument?.();
     }
   });
 
@@ -409,6 +525,58 @@ describe("channel activity", () => {
       expect(messaging.messages.value[0]?.isRetracted).toBe(true);
     } finally {
       scope.stop();
+    }
+  });
+
+  test("queues every hidden plain message in a burst for foreground notification", async () => {
+    let onMessage: ((message: LiveRoomMessage) => void) | null = null;
+    const actionError = ref("");
+    const scope = effectScope();
+    let cleanupDocument: (() => void) | null = null;
+
+    try {
+      cleanupDocument = installHiddenDocument();
+      const messaging = scope.run(() =>
+        useChannelMessages(
+          ref(session()),
+          ref(null),
+          ref({
+            ...handlerStubs(),
+            setMessageHandler(handler: (message: LiveRoomMessage) => void) {
+              onMessage = handler;
+            },
+          } as never),
+          ref("team"),
+          ref("general"),
+          ref({ id: "general", name: "General", jid: "general@conference.example.com" }),
+          String,
+          actionError,
+          () => {
+            actionError.value = "";
+          },
+        )
+      );
+      if (!messaging) throw new Error("channel messages composable did not initialize");
+      await nextTick();
+
+      onMessage?.(roomMessage({
+        id: "burst-1",
+        body: "first",
+        stanzaId: "stanza-burst-1",
+      }));
+      onMessage?.(roomMessage({
+        id: "burst-2",
+        body: "second",
+        stanzaId: "stanza-burst-2",
+      }));
+
+      expect(messaging.pendingNotificationActivities.value.map((event) => event.stanzaId)).toEqual([
+        "stanza-burst-1",
+        "stanza-burst-2",
+      ]);
+    } finally {
+      scope.stop();
+      cleanupDocument?.();
     }
   });
 

--- a/chat/tests/foreground-notifications.test.ts
+++ b/chat/tests/foreground-notifications.test.ts
@@ -1,0 +1,267 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { shouldShowChannelForegroundNotification, usePushNotifications } from "../src/shell/notifications";
+import {
+  showForegroundNotificationForChannelActivity,
+  showForegroundNotificationsForChannelActivities,
+} from "../src/shell/chat-app-controller";
+import type { NotifyMode } from "../src/lib/xmpp-client";
+
+const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+const originalNotification = Object.getOwnPropertyDescriptor(globalThis, "Notification");
+const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+
+afterEach(() => {
+  restoreGlobal("window", originalWindow);
+  restoreGlobal("Notification", originalNotification);
+  restoreGlobal("navigator", originalNavigator);
+});
+
+describe("channel foreground notification matrix", () => {
+  const cases: Array<{
+    mode: NotifyMode;
+    isMention: boolean;
+    expected: boolean;
+  }> = [
+    { mode: "always", isMention: false, expected: true },
+    { mode: "always", isMention: true, expected: true },
+    { mode: "on-mention", isMention: false, expected: false },
+    { mode: "on-mention", isMention: true, expected: true },
+    { mode: "never", isMention: false, expected: false },
+    { mode: "never", isMention: true, expected: false },
+  ];
+
+  for (const { mode, isMention, expected } of cases) {
+    test(`${mode} ${isMention ? "shows" : "handles"} ${isMention ? "mention" : "plain"} messages`, () => {
+      expect(shouldShowChannelForegroundNotification({ mode, isMention })).toBe(expected);
+    });
+  }
+});
+
+test("channel foreground notification titles include sender and conversation and signal SW dedup", () => {
+  const notifications = installNotificationHarness();
+  const postMessage = mock((_message: unknown) => {});
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {
+      serviceWorker: {
+        controller: { postMessage },
+      },
+    },
+  });
+
+  const pushNotifications = usePushNotifications();
+  pushNotifications.showChannelMessageNotification({
+    senderNick: "bob",
+    channelName: "General",
+    body: "plain update",
+    roomJid: "general@conference.example.com",
+    stanzaId: "stanza-plain-1",
+  });
+
+  expect(notifications).toEqual([
+    {
+      title: "@bob in #General",
+      options: {
+        body: "plain update",
+        tag: "general@conference.example.com",
+        icon: "/android-chrome-192x192.png",
+      },
+    },
+  ]);
+  expect(postMessage).toHaveBeenCalledWith({
+    type: "waddle:item-shown",
+    itemId: "stanza-plain-1",
+  });
+});
+
+describe("channel activity foreground notification dispatch", () => {
+  test("always-mode plain activity uses the channel-message foreground renderer", () => {
+    const harness = createChannelActivityDispatchHarness("always");
+
+    showForegroundNotificationForChannelActivity({
+      roomJid: "general@conference.example.com",
+      nick: "bob",
+      body: "plain update",
+      stanzaId: "stanza-plain",
+    }, harness.deps);
+
+    expect(harness.notifications.showChannelMessageNotification).toHaveBeenCalledWith({
+      senderNick: "bob",
+      channelName: "General",
+      body: "plain update",
+      roomJid: "general@conference.example.com",
+      stanzaId: "stanza-plain",
+      onNavigate: harness.onNavigate,
+    });
+    expect(harness.notifications.showMentionNotification).not.toHaveBeenCalled();
+  });
+
+  test("on-mention suppresses plain activity and routes mentions through the mention renderer", () => {
+    const plain = createChannelActivityDispatchHarness("on-mention");
+    showForegroundNotificationForChannelActivity({
+      roomJid: "general@conference.example.com",
+      nick: "bob",
+      body: "plain update",
+    }, plain.deps);
+    expect(plain.notifications.showChannelMessageNotification).not.toHaveBeenCalled();
+    expect(plain.notifications.showMentionNotification).not.toHaveBeenCalled();
+
+    const mention = createChannelActivityDispatchHarness("on-mention");
+    showForegroundNotificationForChannelActivity({
+      roomJid: "general@conference.example.com",
+      nick: "bob",
+      body: "alice please review",
+      mentions: ["xmpp:alice@example.com"],
+      stanzaId: "stanza-mention",
+    }, mention.deps);
+    expect(mention.notifications.showMentionNotification).toHaveBeenCalledWith({
+      senderNick: "bob",
+      channelName: "General",
+      body: "alice please review",
+      roomJid: "general@conference.example.com",
+      isBroadcast: false,
+      stanzaId: "stanza-mention",
+      onNavigate: mention.onNavigate,
+    });
+    expect(mention.notifications.showChannelMessageNotification).not.toHaveBeenCalled();
+  });
+
+  test("never suppresses both plain and mention activity", () => {
+    const harness = createChannelActivityDispatchHarness("never");
+
+    showForegroundNotificationForChannelActivity({
+      roomJid: "general@conference.example.com",
+      nick: "bob",
+      body: "plain update",
+    }, harness.deps);
+    showForegroundNotificationForChannelActivity({
+      roomJid: "general@conference.example.com",
+      nick: "bob",
+      body: "@everyone update",
+      broadcastMention: "everyone",
+    }, harness.deps);
+
+    expect(harness.notifications.showChannelMessageNotification).not.toHaveBeenCalled();
+    expect(harness.notifications.showMentionNotification).not.toHaveBeenCalled();
+  });
+
+  test("allowed broadcast mentions route through the mention renderer as broadcast", () => {
+    const harness = createChannelActivityDispatchHarness("on-mention");
+
+    showForegroundNotificationForChannelActivity({
+      roomJid: "general@conference.example.com",
+      nick: "bob",
+      body: "@everyone deploy starting",
+      broadcastMention: "everyone",
+      stanzaId: "stanza-broadcast",
+    }, harness.deps);
+
+    expect(harness.notifications.showMentionNotification).toHaveBeenCalledWith({
+      senderNick: "bob",
+      channelName: "General",
+      body: "@everyone deploy starting",
+      roomJid: "general@conference.example.com",
+      isBroadcast: true,
+      stanzaId: "stanza-broadcast",
+      onNavigate: harness.onNavigate,
+    });
+    expect(harness.notifications.showChannelMessageNotification).not.toHaveBeenCalled();
+  });
+
+  test("queued activity drain renders every foreground-eligible event", () => {
+    const harness = createChannelActivityDispatchHarness("always");
+
+    showForegroundNotificationsForChannelActivities([
+      {
+        roomJid: "general@conference.example.com",
+        nick: "bob",
+        body: "first",
+        stanzaId: "stanza-first",
+      },
+      {
+        roomJid: "general@conference.example.com",
+        nick: "carol",
+        body: "second",
+        stanzaId: "stanza-second",
+      },
+    ], harness.deps);
+
+    expect(harness.notifications.showChannelMessageNotification).toHaveBeenCalledTimes(2);
+    expect(harness.notifications.showChannelMessageNotification.mock.calls.map(([opts]) => (
+      (opts as { stanzaId?: string }).stanzaId
+    ))).toEqual(["stanza-first", "stanza-second"]);
+  });
+});
+
+function installNotificationHarness(): Array<{ title: string; options?: NotificationOptions }> {
+  const notifications: Array<{ title: string; options?: NotificationOptions }> = [];
+  const localStorage = memoryStorage();
+  localStorage.setItem("waddle.chat.notifications-enabled", "true");
+
+  class FakeNotification {
+    static permission: NotificationPermission = "granted";
+    static requestPermission = mock(async () => "granted" as NotificationPermission);
+    onclick: (() => void) | null = null;
+
+    constructor(title: string, options?: NotificationOptions) {
+      notifications.push({ title, options });
+    }
+
+    close() {}
+  }
+
+  Object.defineProperty(globalThis, "Notification", {
+    configurable: true,
+    value: FakeNotification,
+  });
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      Notification: FakeNotification,
+      localStorage,
+      focus: mock(() => {}),
+    },
+  });
+  return notifications;
+}
+
+function memoryStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    get length() { return store.size; },
+    clear: () => store.clear(),
+    getItem: (key) => store.get(key) ?? null,
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key) => { store.delete(key); },
+    setItem: (key, value) => { store.set(key, String(value)); },
+  };
+}
+
+function restoreGlobal(name: "window" | "Notification" | "navigator", descriptor: PropertyDescriptor | undefined) {
+  if (descriptor) {
+    Object.defineProperty(globalThis, name, descriptor);
+  } else {
+    delete (globalThis as Record<string, unknown>)[name];
+  }
+}
+
+function createChannelActivityDispatchHarness(mode: NotifyMode) {
+  const onNavigate = mock((_roomJid: string) => {});
+  const notifications = {
+    showMentionNotification: mock((_opts: unknown) => {}),
+    showChannelMessageNotification: mock((_opts: unknown) => {}),
+  };
+  return {
+    onNavigate,
+    notifications,
+    deps: {
+      notifySettings: {
+        getMode: mock(() => mode),
+      },
+      notifications,
+      sessionJid: "alice@example.com/web",
+      resolveChannelNameFromJid: mock((_roomJid: string) => "General"),
+      onNavigate,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Queue hidden-tab channel message activity so every foreground-eligible group message is evaluated and burst deliveries do not collapse into one Vue ref update.
- Apply the effective XEP-0492 notification mode before foreground display: `always` shows plain and mention messages, `on-mention` shows only mention-class messages, and `never` suppresses both.
- Preserve existing mention-class rendering and foreground-to-service-worker `waddle:item-shown` stanza-id dedup for both mention and plain channel notifications.
- Document the intentional per-room browser Notification `tag` behavior: visible same-room banners may collapse at the OS level while every stanza id is still posted for Web Push dedup.
- Add client coverage for the notification-class to foreground-display matrix, active/inactive channel activity queueing, burst queueing, broadcast mentions, renderer choice, and Web Push dedup signaling.

## Issue

Closes #949

## XEP Review

- Reviewed local `xeps/xep-0492.xml`: effective modes remain `always`, `on-mention`, and `never`; public group default text is unchanged. This PR only changes client foreground display behavior based on the already-resolved effective mode.

## Review Comments

- Addressed Greptile P2 comment on per-room Notification tag collapse by documenting the intentional browser replacement behavior near both channel foreground notification tag fields.

## Verification

- `bun test` — 2042 pass, 0 fail
- `bun test chat/tests/foreground-notifications.test.ts` — 12 pass, 0 fail after review-comment fix
- `bunx astro check` in `chat/` — 0 errors, 0 warnings, 1 existing hint in `src/lib/xmpp/discovery.ts`
- `bun run lint` in `chat/` — pass
- Adversarial code-review subagent — no issues found after queue fix
- Adversarial test-review subagent — no issues found after expanded matrix/queue coverage
- GitHub CI — all checks passing after latest push

## Notes

- Root `bun run lint` is not defined in this repo, so verification used `chat/` lint where this change lives and where Knip is enforced.