### PR TITLE
feat(chat): add message notification sounds

### DIFF
--- a/chat/src/components/chat/ChatMobileDrawers.vue
+++ b/chat/src/components/chat/ChatMobileDrawers.vue
@@ -65,6 +65,7 @@ const {
   handleLogout,
   handleRequestNotifications,
   handleToggleNotifications,
+  handleToggleMessageSounds,
   selectChannel,
   selectChannelByRoomJid,
   onSelectThread,
@@ -249,6 +250,7 @@ function openExtensionRoute(route: DiscoveredExtensionRoute) {
           :session="connectionStore.session"
           :notification-permission="notifications.permissionState.value"
           :notifications-enabled="notifications.notificationsEnabled.value"
+          :message-sounds-enabled="notifications.messageSoundsEnabled.value"
           :total-unread-count="channelUnread.totalUnreadCount.value"
           :total-mention-count="channelUnread.totalMentionCount.value"
           :web-commit-sha="version.webCommitSha.value"
@@ -257,6 +259,7 @@ function openExtensionRoute(route: DiscoveredExtensionRoute) {
           @logout="handleLogout"
           @request-notifications="handleRequestNotifications"
           @toggle-notifications="handleToggleNotifications"
+          @toggle-message-sounds="handleToggleMessageSounds"
         />
       </div>
     </AppDrawer>

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -128,6 +128,7 @@ const {
   refreshAppUpdate,
   handleRequestNotifications,
   handleToggleNotifications,
+  handleToggleMessageSounds,
   openUserSettings,
   openHome,
   openDmList,
@@ -582,6 +583,7 @@ onUnmounted(() => {
           :session="connectionStore.session"
           :notification-permission="notifications.permissionState.value"
           :notifications-enabled="notifications.notificationsEnabled.value"
+          :message-sounds-enabled="notifications.messageSoundsEnabled.value"
           :total-unread-count="channelUnread.totalUnreadCount.value"
           :total-mention-count="channelUnread.totalMentionCount.value"
           :web-commit-sha="version.webCommitSha.value"
@@ -593,6 +595,7 @@ onUnmounted(() => {
           @logout="handleLogout"
           @request-notifications="handleRequestNotifications"
           @toggle-notifications="handleToggleNotifications"
+          @toggle-message-sounds="handleToggleMessageSounds"
         />
       </div>
 
@@ -762,9 +765,11 @@ onUnmounted(() => {
         v-else-if="ui.activePage.value === 'settings' && connectionStore.session"
         :session="connectionStore.session"
         :xmpp-client="xmppClient"
+        :message-sounds-enabled="notifications.messageSoundsEnabled.value"
         :web-commit-sha="version.webCommitSha.value"
         :server-version="version.serverVersion.value"
         @close="closeUserSettings"
+        @toggle-message-sounds="handleToggleMessageSounds"
       />
       <template v-else>
         <!--

--- a/chat/src/components/chat/ProfilePanel.vue
+++ b/chat/src/components/chat/ProfilePanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
-import { Bell, BellOff, ChevronUp, LogOut, Settings } from "lucide-vue-next";
+import { Bell, BellOff, ChevronUp, LogOut, Settings, Volume2, VolumeX } from "lucide-vue-next";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import ThemeSwitcher from "@/components/chat/ThemeSwitcher.vue";
 import VersionFooter from "@/components/chat/VersionFooter.vue";
@@ -11,6 +11,7 @@ const props = defineProps<{
   session: WaddleSession;
   notificationPermission?: NotificationPermission;
   notificationsEnabled?: boolean;
+  messageSoundsEnabled?: boolean;
   totalUnreadCount?: number;
   totalMentionCount?: number;
   compact?: boolean;
@@ -23,6 +24,7 @@ const emit = defineEmits<{
   "open-settings": [];
   "request-notifications": [];
   "toggle-notifications": [];
+  "toggle-message-sounds": [];
 }>();
 
 const bellTitle = computed(() => {
@@ -51,6 +53,10 @@ function handleBellClick() {
   } else {
     emit("request-notifications");
   }
+}
+
+function handleToggleMessageSounds() {
+  emit("toggle-message-sounds");
 }
 
 function toggleDetails() {
@@ -181,6 +187,16 @@ onUnmounted(() => {
           <span>Settings</span>
         </button>
         <button
+          class="type-menu-item flex h-9 w-full items-center gap-2 rounded-lg px-2.5 text-left text-foreground transition-colors duration-200 hover:bg-muted"
+          type="button"
+          :aria-pressed="messageSoundsEnabled !== false"
+          @click="handleToggleMessageSounds"
+        >
+          <Volume2 v-if="messageSoundsEnabled !== false" class="h-3.5 w-3.5 text-primary/70" />
+          <VolumeX v-else class="h-3.5 w-3.5 text-muted-foreground" />
+          <span>{{ messageSoundsEnabled !== false ? "Message sounds on" : "Message sounds off" }}</span>
+        </button>
+        <button
           class="type-menu-item flex h-9 w-full items-center gap-2 rounded-lg px-2.5 text-left text-muted-foreground transition-colors duration-200 hover:bg-muted hover:text-destructive"
           type="button"
           @click="handleLogout"
@@ -255,6 +271,17 @@ onUnmounted(() => {
         >
           <Settings class="h-3.5 w-3.5 text-primary/70" />
           <span>Settings</span>
+        </button>
+        <button
+          role="menuitemcheckbox"
+          class="type-menu-item flex h-9 w-full items-center gap-2 rounded-lg px-2.5 text-left text-foreground transition-colors duration-200 hover:bg-muted"
+          type="button"
+          :aria-checked="messageSoundsEnabled !== false"
+          @click="handleToggleMessageSounds"
+        >
+          <Volume2 v-if="messageSoundsEnabled !== false" class="h-3.5 w-3.5 text-primary/70" />
+          <VolumeX v-else class="h-3.5 w-3.5 text-muted-foreground" />
+          <span>{{ messageSoundsEnabled !== false ? "Message sounds on" : "Message sounds off" }}</span>
         </button>
         <button
           role="menuitem"

--- a/chat/src/components/chat/UserSettingsPage.vue
+++ b/chat/src/components/chat/UserSettingsPage.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, reactive, ref } from "vue";
-import { ChevronLeft, MessageCircle, ScanText, UserRound } from "lucide-vue-next";
+import { ChevronLeft, MessageCircle, ScanText, UserRound, Volume2, VolumeX } from "lucide-vue-next";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import ReadReceiptSwitcher from "@/components/chat/ReadReceiptSwitcher.vue";
 import ScrollDirectionSwitcher from "@/components/chat/ScrollDirectionSwitcher.vue";
@@ -30,12 +30,14 @@ import {
 const props = defineProps<{
   session: WaddleSession;
   xmppClient?: BrowserXmppClient | null;
+  messageSoundsEnabled?: boolean;
   webCommitSha?: string;
   serverVersion?: XmppServerVersion | null;
 }>();
 
 const emit = defineEmits<{
   close: [];
+  "toggle-message-sounds": [];
 }>();
 
 type FeedbackTone = "muted" | "success" | "error";
@@ -373,6 +375,33 @@ async function clearTuneStatus() {
       </section>
 
       <VCardEditor :xmpp-client="xmppClient" :self-jid="session.jid" />
+
+      <section class="chat-section-card glass-panel">
+        <div class="flex items-center justify-between gap-3">
+          <div class="flex min-w-0 items-center gap-3">
+            <div class="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10 text-primary">
+              <Volume2 v-if="messageSoundsEnabled !== false" class="h-4 w-4" />
+              <VolumeX v-else class="h-4 w-4" />
+            </div>
+            <div class="chat-settings-copy min-w-0">
+              <h2 id="message-sounds-title" class="type-pane-title">Message sounds</h2>
+              <p id="message-sounds-description" class="type-caption text-muted-foreground">
+                {{ messageSoundsEnabled !== false ? "In-app message sounds are enabled on this device." : "In-app message sounds are disabled on this device." }}
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            :class="secondaryButtonClass"
+            :aria-pressed="messageSoundsEnabled !== false"
+            :aria-label="messageSoundsEnabled !== false ? 'Disable message sounds' : 'Enable message sounds'"
+            aria-describedby="message-sounds-description"
+            @click="emit('toggle-message-sounds')"
+          >
+            {{ messageSoundsEnabled !== false ? "Disable message sounds" : "Enable message sounds" }}
+          </button>
+        </div>
+      </section>
 
       <section class="chat-section-card glass-panel">
         <div class="flex items-start gap-3 pb-4">

--- a/chat/src/components/chat/WaddlesSidebar.vue
+++ b/chat/src/components/chat/WaddlesSidebar.vue
@@ -13,6 +13,7 @@ defineProps<{
   session: WaddleSession | null;
   notificationPermission?: NotificationPermission;
   notificationsEnabled?: boolean;
+  messageSoundsEnabled?: boolean;
   totalUnreadCount?: number;
   totalMentionCount?: number;
   activeChannelCallCount?: number;
@@ -33,6 +34,7 @@ const emit = defineEmits<{
   logout: [];
   "request-notifications": [];
   "toggle-notifications": [];
+  "toggle-message-sounds": [];
 }>();
 
 function activeCallLabel(count: number | undefined, noun = "call"): string {
@@ -158,6 +160,7 @@ function directMessagesLabel(hasUnread?: boolean, activeCallCount?: number): str
       :session="session"
       :notification-permission="notificationPermission"
       :notifications-enabled="notificationsEnabled"
+      :message-sounds-enabled="messageSoundsEnabled"
       :total-unread-count="totalUnreadCount"
       :total-mention-count="totalMentionCount"
       :web-commit-sha="webCommitSha"
@@ -167,6 +170,7 @@ function directMessagesLabel(hasUnread?: boolean, activeCallCount?: number): str
       @logout="emit('logout')"
       @request-notifications="emit('request-notifications')"
       @toggle-notifications="emit('toggle-notifications')"
+      @toggle-message-sounds="emit('toggle-message-sounds')"
     />
   </div>
 </template>

--- a/chat/src/shell/audio-alerts.ts
+++ b/chat/src/shell/audio-alerts.ts
@@ -5,6 +5,10 @@ export interface AudioAlertPlayer {
   stop(key: string): void | Promise<void>;
 }
 
+export interface MessageAudioAlertPlayer {
+  play(key: string): void | Promise<void>;
+}
+
 interface IncomingCallNotificationHandle {
   close(): void;
 }
@@ -129,6 +133,37 @@ export function createBrowserLoopingTonePlayer(): AudioAlertPlayer {
       clearInterval(current.interval);
       current.oscillator.stop();
       void current.context.close().catch(() => undefined);
+    },
+  };
+}
+
+export function createBrowserMessageTonePlayer(): MessageAudioAlertPlayer {
+  const active = new Set<string>();
+
+  return {
+    async play(key) {
+      if (active.has(key)) return;
+      if (typeof window === "undefined" || typeof AudioContext === "undefined") return;
+      active.add(key);
+      const context = new AudioContext();
+      const oscillator = context.createOscillator();
+      const gain = context.createGain();
+      oscillator.type = "sine";
+      oscillator.frequency.value = 1046.5;
+      gain.gain.value = 0;
+      oscillator.connect(gain);
+      gain.connect(context.destination);
+      oscillator.start();
+      const now = context.currentTime;
+      gain.gain.setValueAtTime(0, now);
+      gain.gain.linearRampToValueAtTime(0.06, now + 0.02);
+      gain.gain.linearRampToValueAtTime(0, now + 0.18);
+      oscillator.stop(now + 0.22);
+      oscillator.onended = () => {
+        active.delete(key);
+        void context.close().catch(() => undefined);
+      };
+      await context.resume().catch(() => undefined);
     },
   };
 }

--- a/chat/src/shell/audio-alerts.ts
+++ b/chat/src/shell/audio-alerts.ts
@@ -144,26 +144,37 @@ export function createBrowserMessageTonePlayer(): MessageAudioAlertPlayer {
     async play(key) {
       if (active.has(key)) return;
       if (typeof window === "undefined" || typeof AudioContext === "undefined") return;
+
       active.add(key);
-      const context = new AudioContext();
-      const oscillator = context.createOscillator();
-      const gain = context.createGain();
-      oscillator.type = "sine";
-      oscillator.frequency.value = 1046.5;
-      gain.gain.value = 0;
-      oscillator.connect(gain);
-      gain.connect(context.destination);
-      oscillator.start();
-      const now = context.currentTime;
-      gain.gain.setValueAtTime(0, now);
-      gain.gain.linearRampToValueAtTime(0.06, now + 0.02);
-      gain.gain.linearRampToValueAtTime(0, now + 0.18);
-      oscillator.stop(now + 0.22);
-      oscillator.onended = () => {
+      let context: AudioContext | undefined;
+      let cleanedUp = false;
+      const cleanup = () => {
+        if (cleanedUp) return;
+        cleanedUp = true;
         active.delete(key);
-        void context.close().catch(() => undefined);
+        void context?.close().catch(() => undefined);
       };
-      await context.resume().catch(() => undefined);
+
+      try {
+        context = new AudioContext();
+        const oscillator = context.createOscillator();
+        const gain = context.createGain();
+        oscillator.type = "sine";
+        oscillator.frequency.value = 1046.5;
+        gain.gain.value = 0;
+        oscillator.connect(gain);
+        gain.connect(context.destination);
+        oscillator.onended = cleanup;
+        await context.resume();
+        const now = context.currentTime;
+        gain.gain.setValueAtTime(0, now);
+        gain.gain.linearRampToValueAtTime(0.06, now + 0.02);
+        gain.gain.linearRampToValueAtTime(0, now + 0.18);
+        oscillator.start(now);
+        oscillator.stop(now + 0.22);
+      } catch {
+        cleanup();
+      }
     },
   };
 }

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -9,6 +9,8 @@ import { useMessageThreads } from "@/channels/threads";
 import { useChatShellState } from "@/shell/state";
 import { useServiceWorkerUpdate } from "@/shell/service-worker-update";
 import { shouldShowChannelForegroundNotification, usePushNotifications } from "@/shell/notifications";
+import { createBrowserMessageTonePlayer } from "@/shell/audio-alerts";
+import { useChatWindowVisibility } from "@/shell/window-visibility";
 import { useChannelInbox } from "@/channels/inbox";
 import { useSocialFeed } from "@/services/social-feed";
 import { useStories } from "@/services/stories";
@@ -22,7 +24,7 @@ import { useDeploymentVersionInfo } from "@/shell/version";
 import { useXmppRosterContacts } from "@/contacts/roster";
 import { matchLocation, navigate, type RouteMatch } from "@/router";
 import { resolveChannelBySlug } from "@/shell/route-helpers";
-import { barePeerJid, jidDomain, parseManagedRoomBareJid, type RoomActivityEvent } from "@/lib/xmpp-client";
+import { barePeerJid, jidDomain, parseManagedRoomBareJid, type LiveDmMessage, type RoomActivityEvent } from "@/lib/xmpp-client";
 import { createNotifySettingsStore, type NotifySettingsStore } from "@/lib/notify-settings";
 import { mdsChatKey, queueMdsDisplayed, setMdsDisplayed } from "@/lib/last-seen-store";
 import {
@@ -74,9 +76,39 @@ interface ChannelActivityNotificationDeps {
       onNavigate?: (roomJid: string) => void;
     }) => void;
   };
+  messageSound?: {
+    play: (key: string) => void | Promise<void>;
+  };
+  messageSoundsEnabled?: () => boolean;
+  canShowForegroundNotification?: () => boolean;
+  isDoNotDisturb?: () => boolean;
+  isTabFocused?: () => boolean;
   sessionJid: string | null | undefined;
   resolveChannelNameFromJid: (roomJid: string) => string | null;
   onNavigate: (roomJid: string) => void;
+}
+
+interface DmActivityNotificationDeps {
+  notifySettings: Pick<NotifySettingsStore, "getMode">;
+  notifications: {
+    showDmNotification: (opts: {
+      senderUsername: string;
+      peerJid: string;
+      body: string;
+      stanzaId?: string;
+      onNavigate?: (peerJid: string) => void;
+    }) => void;
+  };
+  messageSound?: {
+    play: (key: string) => void | Promise<void>;
+  };
+  messageSoundsEnabled?: () => boolean;
+  canShowForegroundNotification?: () => boolean;
+  isDoNotDisturb?: () => boolean;
+  isTabFocused?: () => boolean;
+  sessionJid: string | null | undefined;
+  activePeerJid: string | null | undefined;
+  onNavigate: (peerJid: string) => void;
 }
 
 export function showForegroundNotificationForChannelActivity(
@@ -92,6 +124,12 @@ export function showForegroundNotificationForChannelActivity(
   const mode = deps.notifySettings.getMode(event.roomJid, "private-group");
 
   if (!shouldShowChannelForegroundNotification({ mode, isMention })) return;
+  if (deps.isDoNotDisturb?.() === true) return;
+  if (deps.canShowForegroundNotification?.() === false) return;
+
+  if (deps.isTabFocused?.() === false && deps.messageSoundsEnabled?.() !== false) {
+    void deps.messageSound?.play(messageSoundKey(event.roomJid, event.stanzaId));
+  }
 
   if (isMention) {
     deps.notifications.showMentionNotification({
@@ -125,9 +163,46 @@ export function showForegroundNotificationsForChannelActivities(
   }
 }
 
+export function showForegroundNotificationForDmActivity(
+  message: LiveDmMessage,
+  deps: DmActivityNotificationDeps,
+): void {
+  const isSelf = barePeerJid(message.fromJid) === barePeerJid(deps.sessionJid ?? "");
+  const isViewingThisDm = deps.activePeerJid === message.peerJid;
+  if (isSelf || isViewingThisDm) return;
+
+  const mode = deps.notifySettings.getMode(message.peerJid, "direct-chat");
+  const isMention = message.mentions?.some((mention) =>
+    mentionMatchesBareJid(mention, deps.sessionJid)
+  ) ?? false;
+  if (!shouldShowChannelForegroundNotification({ mode, isMention })) return;
+  if (deps.isDoNotDisturb?.() === true) return;
+  if (deps.canShowForegroundNotification?.() === false) return;
+  if (deps.isTabFocused?.() !== false) return;
+
+  if (deps.messageSoundsEnabled?.() !== false) {
+    void deps.messageSound?.play(messageSoundKey(message.peerJid, message.stanzaId ?? message.id));
+  }
+
+  deps.notifications.showDmNotification({
+    senderUsername: message.nick,
+    peerJid: message.peerJid,
+    body: message.body,
+    stanzaId: message.stanzaId,
+    onNavigate: deps.onNavigate,
+  });
+}
+
+let nextUnstampedSoundId = 0;
+
+function messageSoundKey(conversationJid: string, stanzaId: string | undefined): string {
+  return `message:${conversationJid}:${stanzaId ?? `unstamped-${++nextUnstampedSoundId}`}`;
+}
+
 export function useChatAppController(giphyApiKey: string) {
   const ui = useChatShellState();
   const { mode: scrollDirectionMode } = useScrollDirectionPreference();
+  const { isWindowFocused } = useChatWindowVisibility();
 
   // Seed page-level UI state from the current URL so the first render
   // lands on the right page. Without this, every cold load flashes the
@@ -651,6 +726,8 @@ export function useChatAppController(giphyApiKey: string) {
   });
 
   const notifications = usePushNotifications();
+  const messageSound = createBrowserMessageTonePlayer();
+  const selfPresenceShow = ref<"available" | "away" | "xa" | "dnd" | "offline">("available");
   const appUpdate = useServiceWorkerUpdate();
   const version = useDeploymentVersionInfo(xmppClient);
   // RFC 363 PR 6: include DM peers in the iterate-and-pull avatar
@@ -756,6 +833,11 @@ export function useChatAppController(giphyApiKey: string) {
     showForegroundNotificationsForChannelActivities(events, {
       notifySettings,
       notifications,
+      messageSound,
+      messageSoundsEnabled: () => notifications.messageSoundsEnabled.value,
+      canShowForegroundNotification: () => notifications.canShowForegroundNotifications.value,
+      isDoNotDisturb: () => selfPresenceShow.value === "dnd",
+      isTabFocused: () => isWindowFocused.value,
       sessionJid: connectionStore.session?.jid,
       resolveChannelNameFromJid,
       onNavigate: (roomJid) => {
@@ -773,20 +855,20 @@ export function useChatAppController(giphyApiKey: string) {
     client.setDirectMessageHandler((msg) => {
       dmMessaging.onIncomingMessage(msg);
       dmConversations.receiveIncomingDm(msg);
-      const isSelf = barePeerJid(msg.fromJid) === barePeerJid(session.value?.jid ?? "");
-      const isViewingThisDm = ui.sidebarMode.value === "dms"
-        && dmConversations.activePeerJid.value === msg.peerJid;
-      if (!isSelf && !isViewingThisDm) {
-        notifications.showDmNotification({
-          senderUsername: msg.nick,
-          peerJid: msg.peerJid,
-          body: msg.body,
-          stanzaId: msg.stanzaId,
-          onNavigate: (peerJid) => {
-            void handleOpenDm(peerJid);
-          },
-        });
-      }
+      showForegroundNotificationForDmActivity(msg, {
+        notifySettings,
+        notifications,
+        messageSound,
+        messageSoundsEnabled: () => notifications.messageSoundsEnabled.value,
+        canShowForegroundNotification: () => notifications.canShowForegroundNotifications.value,
+        isDoNotDisturb: () => selfPresenceShow.value === "dnd",
+        isTabFocused: () => isWindowFocused.value,
+        sessionJid: session.value?.jid,
+        activePeerJid: ui.sidebarMode.value === "dms" ? dmConversations.activePeerJid.value : null,
+        onNavigate: (peerJid) => {
+          void handleOpenDm(peerJid);
+        },
+      });
     });
     client.setDmChatStateHandler(dmMessaging.onChatState);
     client.setDmDisplayedHandler(dmMessaging.onDisplayed);
@@ -810,6 +892,9 @@ export function useChatAppController(giphyApiKey: string) {
       else queueMdsDisplayed(key, displayed);
     });
     client.setPresenceUpdateHandler((event) => {
+      if (barePeerJid(event.bareJid) === barePeerJid(session.value?.jid ?? "")) {
+        selfPresenceShow.value = event.show;
+      }
       dmConversations.updatePresence(event);
       rosterContacts.updatePresence(event.bareJid, event.show);
     });
@@ -910,6 +995,10 @@ export function useChatAppController(giphyApiKey: string) {
     } else if (xmppClient.value && connectionStore.session) {
       await notifications.disablePushSubscription(xmppClient.value, connectionStore.session.jid);
     }
+  }
+
+  function handleToggleMessageSounds() {
+    notifications.messageSoundsEnabled.value = !notifications.messageSoundsEnabled.value;
   }
 
   async function refreshAppUpdate() {
@@ -2288,6 +2377,7 @@ export function useChatAppController(giphyApiKey: string) {
       refreshAppUpdate,
       handleRequestNotifications,
       handleToggleNotifications,
+      handleToggleMessageSounds,
       openUserSettings,
       openHome,
       openDmList,

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -178,9 +178,8 @@ export function showForegroundNotificationForDmActivity(
   if (!shouldShowChannelForegroundNotification({ mode, isMention })) return;
   if (deps.isDoNotDisturb?.() === true) return;
   if (deps.canShowForegroundNotification?.() === false) return;
-  if (deps.isTabFocused?.() !== false) return;
 
-  if (deps.messageSoundsEnabled?.() !== false) {
+  if (deps.isTabFocused?.() === false && deps.messageSoundsEnabled?.() !== false) {
     void deps.messageSound?.play(messageSoundKey(message.peerJid, message.stanzaId ?? message.id));
   }
 
@@ -193,10 +192,15 @@ export function showForegroundNotificationForDmActivity(
   });
 }
 
-let nextUnstampedSoundId = 0;
-
 function messageSoundKey(conversationJid: string, stanzaId: string | undefined): string {
-  return `message:${conversationJid}:${stanzaId ?? `unstamped-${++nextUnstampedSoundId}`}`;
+  return `message:${conversationJid}:${stanzaId ?? createUnstampedMessageSoundId()}`;
+}
+
+function createUnstampedMessageSoundId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return `unstamped-${crypto.randomUUID()}`;
+  }
+  return `unstamped-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
 
 export function useChatAppController(giphyApiKey: string) {

--- a/chat/src/shell/notifications.ts
+++ b/chat/src/shell/notifications.ts
@@ -139,13 +139,21 @@ export function usePushNotifications() {
 
   watch(notificationsEnabled, (v) => {
     if (typeof window !== "undefined") {
-      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(v));
+      try {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(v));
+      } catch (error) {
+        console.warn("Unable to persist notification preference", error);
+      }
     }
   });
 
   watch(messageSoundsEnabled, (v) => {
     if (typeof window !== "undefined") {
-      window.localStorage.setItem(MESSAGE_SOUNDS_STORAGE_KEY, JSON.stringify(v));
+      try {
+        window.localStorage.setItem(MESSAGE_SOUNDS_STORAGE_KEY, JSON.stringify(v));
+      } catch (error) {
+        console.warn("Unable to persist message sound preference", error);
+      }
     }
   });
 

--- a/chat/src/shell/notifications.ts
+++ b/chat/src/shell/notifications.ts
@@ -1,4 +1,4 @@
-import { ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 import type { BrowserXmppClient, NotifyMode } from "@/lib/xmpp-client";
 import { getOrRegisterServiceWorker, registerServiceWorker as registerChatServiceWorker } from "@/lib/service-worker-registration";
 import { createPushFlowLock } from "./push-flow-lock";
@@ -14,6 +14,7 @@ import { clearCachedVapidKey, loadVapidPublicKey } from "./vapid-cache";
 import { withVapidRotationLock } from "./vapid-rotation-lock";
 
 const STORAGE_KEY = "waddle.chat.notifications-enabled";
+const MESSAGE_SOUNDS_STORAGE_KEY = "waddle.chat.message-sounds-enabled";
 /// Prefix for the per-(account, service) persisted VAPID kid. The
 /// full key is built by `pushKidStorageKey(accountJid, serviceJid)`.
 /// Multi-account sessions MUST NOT share one global kid — without
@@ -109,6 +110,10 @@ export function usePushNotifications() {
     hasNotificationApi() ? Notification.permission : "denied",
   );
   const notificationsEnabled = ref(loadEnabled());
+  const messageSoundsEnabled = ref(loadMessageSoundsEnabled());
+  const canShowForegroundNotifications = computed(() =>
+    permissionState.value === "granted" && notificationsEnabled.value,
+  );
   /// Surfaced to the UI as a non-intrusive banner the first time a
   /// silent kid rotation re-binds the browser PushSubscription to a new
   /// VAPID key. The UI clears the flag once the banner is dismissed; we
@@ -135,6 +140,12 @@ export function usePushNotifications() {
   watch(notificationsEnabled, (v) => {
     if (typeof window !== "undefined") {
       window.localStorage.setItem(STORAGE_KEY, JSON.stringify(v));
+    }
+  });
+
+  watch(messageSoundsEnabled, (v) => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(MESSAGE_SOUNDS_STORAGE_KEY, JSON.stringify(v));
     }
   });
 
@@ -595,6 +606,8 @@ export function usePushNotifications() {
   return {
     permissionState,
     notificationsEnabled,
+    messageSoundsEnabled,
+    canShowForegroundNotifications,
     rotationBannerVisible,
     dismissRotationBanner,
     requestPermission,
@@ -629,6 +642,16 @@ function loadEnabled(): boolean {
     return raw ? JSON.parse(raw) === true : false;
   } catch {
     return false;
+  }
+}
+
+function loadMessageSoundsEnabled(): boolean {
+  if (typeof window === "undefined") return true;
+  try {
+    const raw = window.localStorage.getItem(MESSAGE_SOUNDS_STORAGE_KEY);
+    return raw ? JSON.parse(raw) === true : true;
+  } catch {
+    return true;
   }
 }
 

--- a/chat/tests/foreground-notifications.test.ts
+++ b/chat/tests/foreground-notifications.test.ts
@@ -369,12 +369,18 @@ describe("DM foreground notification dispatch", () => {
     expect(harness.messageSound.play).toHaveBeenCalledWith("message:bob@example.com:dm-stanza-1");
   });
 
-  test("focused inactive DM suppresses notifications and message sounds", () => {
+  test("focused inactive DM shows notification without message sound", () => {
     const harness = createDmActivityDispatchHarness("always", { focused: true });
 
     showForegroundNotificationForDmActivity(dmMessage(), harness.deps);
 
-    expect(harness.notifications.showDmNotification).not.toHaveBeenCalled();
+    expect(harness.notifications.showDmNotification).toHaveBeenCalledWith({
+      senderUsername: "bob",
+      peerJid: "bob@example.com",
+      body: "hello",
+      stanzaId: "dm-stanza-1",
+      onNavigate: expect.any(Function),
+    });
     expect(harness.messageSound.play).not.toHaveBeenCalled();
   });
 

--- a/chat/tests/foreground-notifications.test.ts
+++ b/chat/tests/foreground-notifications.test.ts
@@ -1,10 +1,15 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { shouldShowChannelForegroundNotification, usePushNotifications } from "../src/shell/notifications";
 import {
+  shouldShowChannelForegroundNotification,
+  usePushNotifications,
+} from "../src/shell/notifications";
+import { createIncomingCallAlertController } from "../src/shell/audio-alerts";
+import {
+  showForegroundNotificationForDmActivity,
   showForegroundNotificationForChannelActivity,
   showForegroundNotificationsForChannelActivities,
 } from "../src/shell/chat-app-controller";
-import type { NotifyMode } from "../src/lib/xmpp-client";
+import type { LiveDmMessage, NotifyMode } from "../src/lib/xmpp-client";
 
 const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
 const originalNotification = Object.getOwnPropertyDescriptor(globalThis, "Notification");
@@ -74,6 +79,62 @@ test("channel foreground notification titles include sender and conversation and
   });
 });
 
+test("message sound toggle persists and silences only message sound playback", async () => {
+  const localStorage = memoryStorage();
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: { localStorage },
+  });
+  const first = usePushNotifications();
+  expect(first.messageSoundsEnabled.value).toBe(true);
+
+  first.messageSoundsEnabled.value = false;
+  await Promise.resolve();
+  expect(localStorage.getItem("waddle.chat.message-sounds-enabled")).toBe("false");
+
+  const reloaded = usePushNotifications();
+  expect(reloaded.messageSoundsEnabled.value).toBe(false);
+
+  const harness = createChannelActivityDispatchHarness("always", {
+    focused: false,
+    messageSoundsEnabled: reloaded.messageSoundsEnabled.value,
+  });
+  showForegroundNotificationForChannelActivity({
+    roomJid: "general@conference.example.com",
+    nick: "bob",
+    body: "plain update",
+    stanzaId: "stanza-muted-globally",
+  }, harness.deps);
+
+  expect(harness.notifications.showChannelMessageNotification).toHaveBeenCalled();
+  expect(harness.messageSound.play).not.toHaveBeenCalled();
+});
+
+test("disabled message sounds do not affect incoming-call ringing", async () => {
+  const localStorage = memoryStorage();
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: { localStorage },
+  });
+  const pushNotifications = usePushNotifications();
+  pushNotifications.messageSoundsEnabled.value = false;
+  await Promise.resolve();
+
+  const player = {
+    startLoop: mock((_key: string) => {}),
+    stop: mock((_key: string) => {}),
+  };
+  const controller = createIncomingCallAlertController({ player });
+
+  controller.start({
+    peerJid: "bob@example.com",
+    sid: "call-1",
+    media: { audio: true, video: false },
+  });
+
+  expect(player.startLoop).toHaveBeenCalledWith("call-1");
+});
+
 describe("channel activity foreground notification dispatch", () => {
   test("always-mode plain activity uses the channel-message foreground renderer", () => {
     const harness = createChannelActivityDispatchHarness("always");
@@ -94,6 +155,29 @@ describe("channel activity foreground notification dispatch", () => {
       onNavigate: harness.onNavigate,
     });
     expect(harness.notifications.showMentionNotification).not.toHaveBeenCalled();
+  });
+
+  test("always-mode plain activity plays the message sound only while unfocused", () => {
+    const unfocused = createChannelActivityDispatchHarness("always", { focused: false });
+
+    showForegroundNotificationForChannelActivity({
+      roomJid: "general@conference.example.com",
+      nick: "bob",
+      body: "plain update",
+      stanzaId: "stanza-plain",
+    }, unfocused.deps);
+
+    expect(unfocused.messageSound.play).toHaveBeenCalledWith("message:general@conference.example.com:stanza-plain");
+
+    const focused = createChannelActivityDispatchHarness("always", { focused: true });
+    showForegroundNotificationForChannelActivity({
+      roomJid: "general@conference.example.com",
+      nick: "bob",
+      body: "plain update",
+      stanzaId: "stanza-focused",
+    }, focused.deps);
+
+    expect(focused.messageSound.play).not.toHaveBeenCalled();
   });
 
   test("on-mention suppresses plain activity and routes mentions through the mention renderer", () => {
@@ -124,6 +208,82 @@ describe("channel activity foreground notification dispatch", () => {
       onNavigate: mention.onNavigate,
     });
     expect(mention.notifications.showChannelMessageNotification).not.toHaveBeenCalled();
+  });
+
+  test("message sounds follow the channel foreground notification eligibility matrix", () => {
+    const plainMentionOnly = createChannelActivityDispatchHarness("on-mention", { focused: false });
+    showForegroundNotificationForChannelActivity({
+      roomJid: "general@conference.example.com",
+      nick: "bob",
+      body: "plain update",
+      stanzaId: "stanza-plain",
+    }, plainMentionOnly.deps);
+    expect(plainMentionOnly.messageSound.play).not.toHaveBeenCalled();
+
+    const mentioned = createChannelActivityDispatchHarness("on-mention", { focused: false });
+    showForegroundNotificationForChannelActivity({
+      roomJid: "general@conference.example.com",
+      nick: "bob",
+      body: "alice please review",
+      mentions: ["xmpp:alice@example.com"],
+      stanzaId: "stanza-mention",
+    }, mentioned.deps);
+    expect(mentioned.messageSound.play).toHaveBeenCalledWith("message:general@conference.example.com:stanza-mention");
+
+    const never = createChannelActivityDispatchHarness("never", { focused: false });
+    showForegroundNotificationForChannelActivity({
+      roomJid: "general@conference.example.com",
+      nick: "bob",
+      body: "@everyone update",
+      broadcastMention: "everyone",
+      stanzaId: "stanza-never",
+    }, never.deps);
+    expect(never.messageSound.play).not.toHaveBeenCalled();
+  });
+
+  test("message sounds stop when foreground notifications or DND suppress the channel notification", () => {
+    const notificationsOff = createChannelActivityDispatchHarness("always", {
+      focused: false,
+      canShowForegroundNotification: false,
+    });
+    showForegroundNotificationForChannelActivity({
+      roomJid: "general@conference.example.com",
+      nick: "bob",
+      body: "plain update",
+      stanzaId: "stanza-notifications-off",
+    }, notificationsOff.deps);
+    expect(notificationsOff.notifications.showChannelMessageNotification).not.toHaveBeenCalled();
+    expect(notificationsOff.messageSound.play).not.toHaveBeenCalled();
+
+    const dnd = createChannelActivityDispatchHarness("always", {
+      focused: false,
+      doNotDisturb: true,
+    });
+    showForegroundNotificationForChannelActivity({
+      roomJid: "general@conference.example.com",
+      nick: "bob",
+      body: "plain update",
+      stanzaId: "stanza-dnd",
+    }, dnd.deps);
+    expect(dnd.notifications.showChannelMessageNotification).not.toHaveBeenCalled();
+    expect(dnd.messageSound.play).not.toHaveBeenCalled();
+  });
+
+  test("unstamped duplicate channel messages each get their own message sound key", () => {
+    const harness = createChannelActivityDispatchHarness("always", { focused: false });
+    const event = {
+      roomJid: "general@conference.example.com",
+      nick: "bob",
+      body: "ok",
+    };
+
+    showForegroundNotificationForChannelActivity(event, harness.deps);
+    showForegroundNotificationForChannelActivity(event, harness.deps);
+
+    expect(harness.messageSound.play).toHaveBeenCalledTimes(2);
+    expect(harness.messageSound.play.mock.calls[0]?.[0]).not.toBe(
+      harness.messageSound.play.mock.calls[1]?.[0],
+    );
   });
 
   test("never suppresses both plain and mention activity", () => {
@@ -193,6 +353,74 @@ describe("channel activity foreground notification dispatch", () => {
   });
 });
 
+describe("DM foreground notification dispatch", () => {
+  test("unfocused always-mode DM plays a message sound", () => {
+    const harness = createDmActivityDispatchHarness("always", { focused: false });
+
+    showForegroundNotificationForDmActivity(dmMessage(), harness.deps);
+
+    expect(harness.notifications.showDmNotification).toHaveBeenCalledWith({
+      senderUsername: "bob",
+      peerJid: "bob@example.com",
+      body: "hello",
+      stanzaId: "dm-stanza-1",
+      onNavigate: harness.onNavigate,
+    });
+    expect(harness.messageSound.play).toHaveBeenCalledWith("message:bob@example.com:dm-stanza-1");
+  });
+
+  test("focused inactive DM suppresses notifications and message sounds", () => {
+    const harness = createDmActivityDispatchHarness("always", { focused: true });
+
+    showForegroundNotificationForDmActivity(dmMessage(), harness.deps);
+
+    expect(harness.notifications.showDmNotification).not.toHaveBeenCalled();
+    expect(harness.messageSound.play).not.toHaveBeenCalled();
+  });
+
+  test("never-mode DM suppresses notifications and message sounds", () => {
+    const harness = createDmActivityDispatchHarness("never", { focused: false });
+
+    showForegroundNotificationForDmActivity(dmMessage(), harness.deps);
+
+    expect(harness.notifications.showDmNotification).not.toHaveBeenCalled();
+    expect(harness.messageSound.play).not.toHaveBeenCalled();
+  });
+
+  test("self-sent and currently open DMs suppress notifications and message sounds", () => {
+    const self = createDmActivityDispatchHarness("always", { focused: false });
+    showForegroundNotificationForDmActivity(dmMessage({ fromJid: "alice@example.com/web" }), self.deps);
+    expect(self.notifications.showDmNotification).not.toHaveBeenCalled();
+    expect(self.messageSound.play).not.toHaveBeenCalled();
+
+    const open = createDmActivityDispatchHarness("always", {
+      focused: false,
+      activePeerJid: "bob@example.com",
+    });
+    showForegroundNotificationForDmActivity(dmMessage(), open.deps);
+    expect(open.notifications.showDmNotification).not.toHaveBeenCalled();
+    expect(open.messageSound.play).not.toHaveBeenCalled();
+  });
+
+  test("foreground notification disablement and DND suppress DM message sounds", () => {
+    const notificationsOff = createDmActivityDispatchHarness("always", {
+      focused: false,
+      canShowForegroundNotification: false,
+    });
+    showForegroundNotificationForDmActivity(dmMessage(), notificationsOff.deps);
+    expect(notificationsOff.notifications.showDmNotification).not.toHaveBeenCalled();
+    expect(notificationsOff.messageSound.play).not.toHaveBeenCalled();
+
+    const dnd = createDmActivityDispatchHarness("always", {
+      focused: false,
+      doNotDisturb: true,
+    });
+    showForegroundNotificationForDmActivity(dmMessage(), dnd.deps);
+    expect(dnd.notifications.showDmNotification).not.toHaveBeenCalled();
+    expect(dnd.messageSound.play).not.toHaveBeenCalled();
+  });
+});
+
 function installNotificationHarness(): Array<{ title: string; options?: NotificationOptions }> {
   const notifications: Array<{ title: string; options?: NotificationOptions }> = [];
   const localStorage = memoryStorage();
@@ -245,23 +473,93 @@ function restoreGlobal(name: "window" | "Notification" | "navigator", descriptor
   }
 }
 
-function createChannelActivityDispatchHarness(mode: NotifyMode) {
+function createChannelActivityDispatchHarness(
+  mode: NotifyMode,
+  options: {
+    focused?: boolean;
+    messageSoundsEnabled?: boolean;
+    canShowForegroundNotification?: boolean;
+    doNotDisturb?: boolean;
+  } = {},
+) {
   const onNavigate = mock((_roomJid: string) => {});
   const notifications = {
     showMentionNotification: mock((_opts: unknown) => {}),
     showChannelMessageNotification: mock((_opts: unknown) => {}),
   };
+  const messageSound = {
+    play: mock((_key: string) => {}),
+  };
   return {
     onNavigate,
     notifications,
+    messageSound,
     deps: {
       notifySettings: {
         getMode: mock(() => mode),
       },
       notifications,
+      messageSound,
+      messageSoundsEnabled: () => options.messageSoundsEnabled ?? true,
+      canShowForegroundNotification: () => options.canShowForegroundNotification ?? true,
+      isDoNotDisturb: () => options.doNotDisturb ?? false,
+      isTabFocused: () => options.focused ?? false,
       sessionJid: "alice@example.com/web",
       resolveChannelNameFromJid: mock((_roomJid: string) => "General"),
       onNavigate,
     },
+  };
+}
+
+function createDmActivityDispatchHarness(
+  mode: NotifyMode,
+  options: {
+    focused?: boolean;
+    messageSoundsEnabled?: boolean;
+    canShowForegroundNotification?: boolean;
+    doNotDisturb?: boolean;
+    activePeerJid?: string | null;
+  } = {},
+) {
+  const onNavigate = mock((_peerJid: string) => {});
+  const notifications = {
+    showDmNotification: mock((_opts: unknown) => {}),
+  };
+  const messageSound = {
+    play: mock((_key: string) => {}),
+  };
+  return {
+    onNavigate,
+    notifications,
+    messageSound,
+    deps: {
+      notifySettings: {
+        getMode: mock(() => mode),
+      },
+      notifications,
+      messageSound,
+      messageSoundsEnabled: () => options.messageSoundsEnabled ?? true,
+      canShowForegroundNotification: () => options.canShowForegroundNotification ?? true,
+      isDoNotDisturb: () => options.doNotDisturb ?? false,
+      isTabFocused: () => options.focused ?? false,
+      sessionJid: "alice@example.com/web",
+      activePeerJid: options.activePeerJid ?? null,
+      onNavigate,
+    },
+  };
+}
+
+function dmMessage(overrides: Partial<LiveDmMessage> = {}): LiveDmMessage {
+  return {
+    id: "dm-1",
+    peerJid: "bob@example.com",
+    fromJid: "bob@example.com/phone",
+    nick: "bob",
+    body: "hello",
+    createdAt: "2026-06-12T10:00:00.000Z",
+    createdAtSource: "server",
+    type: "message",
+    stanzaId: "dm-stanza-1",
+    ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

Implements #954 message notification sounds for chat foreground notifications.

## Completed work

- Added a one-shot browser message tone player separate from incoming-call ringing.
- Routed channel and DM message sounds through the same foreground notification eligibility gate: XEP-0492 mode, global browser notification enablement, tab focus, DND, self/open-DM suppression, and per-message notification dispatch.
- Kept foreground DM popup notifications visible while the app is focused but the DM is not open; focus gates only the sound, matching channel behavior.
- Added a persisted device-local global message-sound toggle in Settings and account menus.
- Kept incoming-call ringing on the existing looping call player so message-sound opt-out does not affect calls.
- Hardened repeated unstamped channel messages so identical short bodies do not collapse into one sound key, without a module-level mutable counter.
- Made message-tone playback and preference persistence best-effort when WebAudio or localStorage are unavailable.

## TDD / tests

- Expanded foreground notification tests around channel and DM sound eligibility using injected fake players.
- Covered always / mentions-only / never modes, DND, global notification disablement, focus state, self/current DM suppression, focused inactive DM notification behavior, persisted toggle reload behavior, and call ringing independence.

## Review follow-up

- Resolved Codex, Copilot, and Greptile review threads about focused DM notifications, audio active-key cleanup, localStorage write failures, and module-level unstamped sound state.

## Verification

- bun test tests/foreground-notifications.test.ts
- bun test
- bunx astro check
- bun run lint
- git diff --check

## Notes

No new dependencies. No knip ignores added.

Closes #954