### PR TITLE
feat(server): provision group dm rooms

### DIFF
--- a/server/crates/waddle-server/src/admin/channels.rs
+++ b/server/crates/waddle-server/src/admin/channels.rs
@@ -27,6 +27,7 @@ use jid::{BareJid, FullJid};
 use waddle_xmpp::commands::{CommandContext, CommandResult};
 use waddle_xmpp::muc::room_registry_actor::{CreateRoom, DestroyRoom, GetRoom, ListRooms};
 use waddle_xmpp::muc::{
+    affiliation::FederatedAffiliationConfig,
     room_actor::{
         ApplyAdminItems, ChangeAffiliation, GetConfig, ListAffiliations, ListOccupants,
         OccupantCount, UpdateConfig,
@@ -63,6 +64,7 @@ pub const NODE_OCCUPANTS: &str = waddle_xmpp::admin::NS_ADMIN_CHANNELS_OCCUPANTS
 pub const NODE_AFFILIATIONS: &str = waddle_xmpp::admin::NS_ADMIN_CHANNELS_AFFILIATIONS;
 pub const NODE_SET_AFFILIATION: &str = waddle_xmpp::admin::NS_ADMIN_CHANNELS_SET_AFFILIATION;
 pub const NODE_KICK: &str = waddle_xmpp::admin::NS_ADMIN_CHANNELS_KICK;
+pub const NODE_GROUP_DM_CREATE: &str = waddle_xmpp::admin::NS_GROUP_DM_CREATE;
 
 pub const DEFAULT_PAGE_SIZE: u32 = 50;
 pub const MAX_PAGE_SIZE: u32 = 200;
@@ -272,6 +274,21 @@ pub struct ChannelsKickResult {
     pub occupant_jid: BareJid,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GroupDmCreateArgs {
+    pub name: String,
+    pub member_jids: Vec<BareJid>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GroupDmRef {
+    pub room_jid: BareJid,
+    pub name: String,
+    pub is_public: bool,
+    pub members_only: bool,
+    pub persistent: bool,
+}
+
 // ---------------------------------------------------------------------------
 // Registration
 // ---------------------------------------------------------------------------
@@ -359,6 +376,15 @@ pub async fn register(
             })
             .await;
     }
+    {
+        let state = Arc::clone(&app_state);
+        registry
+            .register(NODE_GROUP_DM_CREATE, "Create group DM", move |ctx| {
+                let state = Arc::clone(&state);
+                async move { handle_group_dm_create(ctx, state).await }
+            })
+            .await;
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -415,6 +441,20 @@ async fn handle_create(ctx: CommandContext, state: Arc<AppState>) -> CommandResu
     match run_create(&state, &args).await {
         Ok(channel) => CommandResult::Completed {
             form: Some(build_channel_form(&channel)),
+            notes: vec![],
+        },
+        Err(result) => *result,
+    }
+}
+
+async fn handle_group_dm_create(ctx: CommandContext, state: Arc<AppState>) -> CommandResult {
+    let args = match parse_group_dm_create_args(ctx.command.form.as_ref()) {
+        Ok(args) => args,
+        Err(error) => return *bad_request(error),
+    };
+    match run_group_dm_create(&state, &ctx.from.to_bare(), &args).await {
+        Ok(group_dm) => CommandResult::Completed {
+            form: Some(build_group_dm_form(&group_dm)),
             notes: vec![],
         },
         Err(result) => *result,
@@ -666,6 +706,33 @@ pub fn parse_create_args(form: Option<&DataForm>) -> Result<ChannelsCreateArgs, 
         is_public,
         members_only,
     })
+}
+
+pub fn parse_group_dm_create_args(form: Option<&DataForm>) -> Result<GroupDmCreateArgs, String> {
+    let form = form.ok_or_else(|| "group-dm:create requires an args form".to_string())?;
+    let name = parse_required_text(form, "name")?;
+    validate_name(&name)?;
+    let member_values = form
+        .get_values("member_jids")
+        .ok_or_else(|| "member_jids is required".to_string())?;
+    let mut member_jids = Vec::with_capacity(member_values.len());
+    for value in member_values
+        .iter()
+        .filter(|value| !value.trim().is_empty())
+    {
+        member_jids.push(
+            value
+                .trim()
+                .parse::<BareJid>()
+                .map_err(|e| format!("member_jids contains invalid JID '{value}': {e}"))?,
+        );
+    }
+    member_jids.sort();
+    member_jids.dedup();
+    if member_jids.len() < 2 {
+        return Err("group-dm:create requires at least two member_jids".to_string());
+    }
+    Ok(GroupDmCreateArgs { name, member_jids })
 }
 
 pub fn parse_update_args(form: Option<&DataForm>) -> Result<ChannelsUpdateArgs, String> {
@@ -1433,6 +1500,63 @@ async fn run_create(state: &AppState, args: &ChannelsCreateArgs) -> Result<Chann
         topic: args.topic.clone(),
         is_public: args.is_public,
         members_only,
+    })
+}
+
+async fn run_group_dm_create(
+    state: &AppState,
+    creator_jid: &BareJid,
+    args: &GroupDmCreateArgs,
+) -> Result<GroupDmRef, AdminErr> {
+    let localpart = format!("group-dm-{}", mint_channel_localpart(&args.name));
+    let muc_domain = state.muc_domain.to_string();
+    let room_jid: BareJid = format!("{localpart}@{muc_domain}")
+        .parse()
+        .map_err(|e| internal_err(format!("constructed group-DM JID is invalid: {e}")))?;
+    let config = RoomConfig {
+        name: args.name.clone(),
+        description: None,
+        persistent: true,
+        members_only: true,
+        public_room: false,
+        moderated: false,
+        enable_logging: true,
+        group_dm: true,
+        federated_affiliation_config: FederatedAffiliationConfig::open_none(),
+        ..RoomConfig::default()
+    };
+
+    let actor = state
+        .room_registry
+        .ask(CreateRoom {
+            room_jid: room_jid.clone(),
+            waddle_id: "group-dm".to_string(),
+            channel_id: localpart,
+            config,
+        })
+        .await
+        .map_err(send_err("room_registry ask CreateRoom"))?;
+
+    let mut members = args.member_jids.clone();
+    members.push(creator_jid.clone());
+    members.sort();
+    members.dedup();
+    for member_jid in members {
+        actor
+            .ask(ChangeAffiliation {
+                jid: member_jid,
+                affiliation: Affiliation::Member,
+            })
+            .await
+            .map_err(send_err("room actor ChangeAffiliation"))?;
+    }
+
+    Ok(GroupDmRef {
+        room_jid,
+        name: args.name.clone(),
+        is_public: false,
+        members_only: true,
+        persistent: true,
     })
 }
 
@@ -2213,6 +2337,27 @@ pub fn build_channel_form(channel: &ChannelRef) -> DataForm {
         form = form.add_field(Field::text_single("topic", topic));
     }
     form
+}
+
+pub fn build_group_dm_form(group_dm: &GroupDmRef) -> DataForm {
+    DataForm::new(FormType::Result)
+        .add_field(Field::form_type(NODE_GROUP_DM_CREATE))
+        .add_field(
+            Field::new("room_jid", FieldType::JidSingle).with_value(group_dm.room_jid.to_string()),
+        )
+        .add_field(Field::text_single("name", group_dm.name.clone()))
+        .add_field(Field::text_single(
+            "is_public",
+            bool_str(group_dm.is_public),
+        ))
+        .add_field(Field::text_single(
+            "members_only",
+            bool_str(group_dm.members_only),
+        ))
+        .add_field(Field::text_single(
+            "persistent",
+            bool_str(group_dm.persistent),
+        ))
 }
 
 pub fn build_occupants_form(result: &ChannelsOccupantsResult) -> DataForm {

--- a/server/crates/waddle-server/src/admin/channels.rs
+++ b/server/crates/waddle-server/src/admin/channels.rs
@@ -41,6 +41,7 @@ use waddle_xmpp::XmppError;
 use waddle_xmpp::{Affiliation, ChannelInfo, Role, Stanza};
 
 use crate::admin::is_community_owner;
+use crate::auth::NativeUserStore;
 use crate::channel_space_links::{ChannelSpaceLink, ChannelSpaceLinkError};
 use crate::permissions::{
     DeleteTuple, Object, ObjectType, PermissionError, Relation, Subject, SubjectType, Tuple,
@@ -1508,6 +1509,7 @@ async fn run_group_dm_create(
     creator_jid: &BareJid,
     args: &GroupDmCreateArgs,
 ) -> Result<GroupDmRef, AdminErr> {
+    validate_group_dm_members(state, creator_jid, &args.member_jids).await?;
     let localpart = format!("group-dm-{}", mint_channel_localpart(&args.name));
     let muc_domain = state.muc_domain.to_string();
     let room_jid: BareJid = format!("{localpart}@{muc_domain}")
@@ -1558,6 +1560,35 @@ async fn run_group_dm_create(
         members_only: true,
         persistent: true,
     })
+}
+
+async fn validate_group_dm_members(
+    state: &AppState,
+    creator_jid: &BareJid,
+    member_jids: &[BareJid],
+) -> Result<(), AdminErr> {
+    let native_users = NativeUserStore::new(state.db_pool.global_actor().clone());
+    for member_jid in member_jids {
+        if member_jid.domain() != creator_jid.domain() {
+            return Err(bad_request(format!(
+                "member_jids must be local to {}",
+                creator_jid.domain()
+            )));
+        }
+        let Some(localpart) = member_jid.node().map(|node| node.to_string()) else {
+            return Err(bad_request("member_jids must be user JIDs with localparts"));
+        };
+        let exists = native_users
+            .user_exists(&localpart, member_jid.domain().as_str())
+            .await
+            .map_err(|error| internal_err(format!("native user lookup failed: {error}")))?;
+        if !exists {
+            return Err(Box::new(CommandResult::Error(XmppError::item_not_found(
+                Some(format!("group-DM member does not exist: {member_jid}")),
+            ))));
+        }
+    }
+    Ok(())
 }
 
 async fn run_update(state: &AppState, args: &ChannelsUpdateArgs) -> Result<ChannelRef, AdminErr> {

--- a/server/crates/waddle-server/src/admin/channels.rs
+++ b/server/crates/waddle-server/src/admin/channels.rs
@@ -70,6 +70,7 @@ pub const NODE_GROUP_DM_CREATE: &str = waddle_xmpp::admin::NS_GROUP_DM_CREATE;
 pub const DEFAULT_PAGE_SIZE: u32 = 50;
 pub const MAX_PAGE_SIZE: u32 = 200;
 const MAX_NAME_LEN: usize = 80;
+const GROUP_DM_CHANNEL_TYPE: &str = "group-dm";
 
 // ---------------------------------------------------------------------------
 // Affiliation wire vocabulary
@@ -884,6 +885,9 @@ async fn run_list(
             .ask(GetConfig)
             .await
             .map_err(send_err("room actor GetConfig"))?;
+        if config.group_dm {
+            continue;
+        }
         if let Some(prefix) = args.prefix.as_deref() {
             if !config.name.to_lowercase().starts_with(prefix) {
                 continue;
@@ -1228,6 +1232,9 @@ async fn retract_duplicate_channel_bookmarks(
 }
 
 fn channel_type_from_config(config: &RoomConfig) -> &'static str {
+    if config.group_dm {
+        return GROUP_DM_CHANNEL_TYPE;
+    }
     if config.forum {
         "forum"
     } else {
@@ -1268,6 +1275,27 @@ async fn upsert_channel_catalog(
     upsert_xmpp_channel(db_actor, &record)
         .await
         .map_err(|error| internal_err(format!("channel catalog upsert failed: {error}")))
+}
+
+async fn upsert_group_dm_catalog(
+    state: &AppState,
+    group_dm_id: &str,
+    config: &RoomConfig,
+) -> Result<(), AdminErr> {
+    let record = XmppChannelUpsert {
+        id: group_dm_id.to_string(),
+        name: config.name.clone(),
+        description: config.description.clone(),
+        channel_type: GROUP_DM_CHANNEL_TYPE.to_string(),
+        position: 0,
+        is_default: false,
+        pin_permission: config.pin_permission,
+        members_only: config.members_only,
+        public_room: config.public_room,
+    };
+    upsert_xmpp_channel(state.db_pool.global_actor().clone(), &record)
+        .await
+        .map_err(|error| internal_err(format!("group-DM catalog upsert failed: {error}")))
 }
 
 async fn restore_channel_catalog_record(state: &AppState, record: &XmppChannelRecord) {
@@ -1533,17 +1561,42 @@ async fn run_group_dm_create(
         .ask(CreateRoom {
             room_jid: room_jid.clone(),
             waddle_id: "group-dm".to_string(),
-            channel_id: localpart,
-            config,
+            channel_id: localpart.clone(),
+            config: config.clone(),
         })
         .await
         .map_err(send_err("room_registry ask CreateRoom"))?;
+
+    if let Err(error) = upsert_group_dm_catalog(state, &localpart, &config).await {
+        let _ = state
+            .room_registry
+            .ask(DestroyRoom {
+                room_jid: room_jid.clone(),
+            })
+            .await;
+        return Err(error);
+    }
 
     let mut members = args.member_jids.clone();
     members.push(creator_jid.clone());
     members.sort();
     members.dedup();
+    let mut persisted_members: Vec<BareJid> = Vec::with_capacity(members.len());
     for member_jid in members {
+        if let Err(error) = persist_group_dm_member_tuple(state, &localpart, &member_jid).await {
+            for persisted_member in &persisted_members {
+                let _ = delete_group_dm_member_tuple(state, &localpart, persisted_member).await;
+            }
+            let _ = delete_xmpp_channel(state.db_pool.global_actor().clone(), &localpart).await;
+            let _ = state
+                .room_registry
+                .ask(DestroyRoom {
+                    room_jid: room_jid.clone(),
+                })
+                .await;
+            return Err(Box::new(CommandResult::Error(error)));
+        }
+        persisted_members.push(member_jid.clone());
         actor
             .ask(ChangeAffiliation {
                 jid: member_jid,
@@ -1560,6 +1613,42 @@ async fn run_group_dm_create(
         members_only: true,
         persistent: true,
     })
+}
+
+async fn persist_group_dm_member_tuple(
+    state: &AppState,
+    group_dm_id: &str,
+    member_jid: &BareJid,
+) -> Result<(), XmppError> {
+    let tuple = Tuple::new(
+        Object::new(ObjectType::Channel, group_dm_id),
+        Relation::new("member"),
+        Subject::user(member_jid.to_string()),
+    );
+    state
+        .permission_actor
+        .ask(WriteTuple { tuple })
+        .await
+        .map_err(|error| XmppError::internal(format!("Failed to persist group-DM member: {error}")))
+}
+
+async fn delete_group_dm_member_tuple(
+    state: &AppState,
+    group_dm_id: &str,
+    member_jid: &BareJid,
+) -> Result<(), XmppError> {
+    let tuple = Tuple::new(
+        Object::new(ObjectType::Channel, group_dm_id),
+        Relation::new("member"),
+        Subject::user(member_jid.to_string()),
+    );
+    match state.permission_actor.ask(DeleteTuple { tuple }).await {
+        Ok(()) => Ok(()),
+        Err(kameo::error::SendError::HandlerError(PermissionError::TupleNotFound)) => Ok(()),
+        Err(error) => Err(XmppError::internal(format!(
+            "Failed to roll back group-DM member: {error}"
+        ))),
+    }
 }
 
 async fn validate_group_dm_members(

--- a/server/crates/waddle-server/src/admin/channels.rs
+++ b/server/crates/waddle-server/src/admin/channels.rs
@@ -32,7 +32,7 @@ use waddle_xmpp::muc::{
         ApplyAdminItems, ChangeAffiliation, GetConfig, ListAffiliations, ListOccupants,
         OccupantCount, UpdateConfig,
     },
-    AdminItem, RoomConfig,
+    AdminItem, PinPermission, RoomConfig,
 };
 use waddle_xmpp::pubsub::PubSubItem;
 use waddle_xmpp::registry::ConnectionRegistry;
@@ -70,7 +70,6 @@ pub const NODE_GROUP_DM_CREATE: &str = waddle_xmpp::admin::NS_GROUP_DM_CREATE;
 pub const DEFAULT_PAGE_SIZE: u32 = 50;
 pub const MAX_PAGE_SIZE: u32 = 200;
 const MAX_NAME_LEN: usize = 80;
-const GROUP_DM_CHANNEL_TYPE: &str = "group-dm";
 
 // ---------------------------------------------------------------------------
 // Affiliation wire vocabulary
@@ -1233,7 +1232,7 @@ async fn retract_duplicate_channel_bookmarks(
 
 fn channel_type_from_config(config: &RoomConfig) -> &'static str {
     if config.group_dm {
-        return GROUP_DM_CHANNEL_TYPE;
+        return waddle_xmpp::admin::CHANNEL_TYPE_GROUP_DM;
     }
     if config.forum {
         "forum"
@@ -1286,7 +1285,7 @@ async fn upsert_group_dm_catalog(
         id: group_dm_id.to_string(),
         name: config.name.clone(),
         description: config.description.clone(),
-        channel_type: GROUP_DM_CHANNEL_TYPE.to_string(),
+        channel_type: waddle_xmpp::admin::CHANNEL_TYPE_GROUP_DM.to_string(),
         position: 0,
         is_default: false,
         pin_permission: config.pin_permission,
@@ -1552,6 +1551,7 @@ async fn run_group_dm_create(
         moderated: false,
         enable_logging: true,
         group_dm: true,
+        pin_permission: PinPermission::Anyone,
         federated_affiliation_config: FederatedAffiliationConfig::open_none(),
         ..RoomConfig::default()
     };
@@ -1560,7 +1560,7 @@ async fn run_group_dm_create(
         .room_registry
         .ask(CreateRoom {
             room_jid: room_jid.clone(),
-            waddle_id: "group-dm".to_string(),
+            waddle_id: waddle_xmpp::admin::CHANNEL_TYPE_GROUP_DM.to_string(),
             channel_id: localpart.clone(),
             config: config.clone(),
         })
@@ -1584,26 +1584,20 @@ async fn run_group_dm_create(
     let mut persisted_members: Vec<BareJid> = Vec::with_capacity(members.len());
     for member_jid in members {
         if let Err(error) = persist_group_dm_member_tuple(state, &localpart, &member_jid).await {
-            for persisted_member in &persisted_members {
-                let _ = delete_group_dm_member_tuple(state, &localpart, persisted_member).await;
-            }
-            let _ = delete_xmpp_channel(state.db_pool.global_actor().clone(), &localpart).await;
-            let _ = state
-                .room_registry
-                .ask(DestroyRoom {
-                    room_jid: room_jid.clone(),
-                })
-                .await;
+            rollback_group_dm_create(state, &localpart, &room_jid, &persisted_members).await;
             return Err(Box::new(CommandResult::Error(error)));
         }
         persisted_members.push(member_jid.clone());
-        actor
+        if let Err(error) = actor
             .ask(ChangeAffiliation {
                 jid: member_jid,
                 affiliation: Affiliation::Member,
             })
             .await
-            .map_err(send_err("room actor ChangeAffiliation"))?;
+        {
+            rollback_group_dm_create(state, &localpart, &room_jid, &persisted_members).await;
+            return Err(send_err("room actor ChangeAffiliation")(error));
+        }
     }
 
     Ok(GroupDmRef {
@@ -1613,6 +1607,24 @@ async fn run_group_dm_create(
         members_only: true,
         persistent: true,
     })
+}
+
+async fn rollback_group_dm_create(
+    state: &AppState,
+    group_dm_id: &str,
+    room_jid: &BareJid,
+    persisted_members: &[BareJid],
+) {
+    for persisted_member in persisted_members {
+        let _ = delete_group_dm_member_tuple(state, group_dm_id, persisted_member).await;
+    }
+    let _ = delete_xmpp_channel(state.db_pool.global_actor().clone(), group_dm_id).await;
+    let _ = state
+        .room_registry
+        .ask(DestroyRoom {
+            room_jid: room_jid.clone(),
+        })
+        .await;
 }
 
 async fn persist_group_dm_member_tuple(

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/disco_info/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/disco_info/muc.rs
@@ -137,6 +137,9 @@ pub(super) async fn handle_muc_disco_info<'a>(
             channel.channel_type == "announcement",
             channel.channel_type == "forum",
         );
+        if channel.channel_type == "group-dm" {
+            features.push(Feature::new(waddle_xmpp::admin::NS_GROUP_DM_FEATURE));
+        }
         features.extend(extension_features_for_disco(state));
         let mut extensions =
             room_space_metadata_extensions(state, &room_jid, channel.description.as_deref()).await;

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/disco_info/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/disco_info/muc.rs
@@ -137,7 +137,7 @@ pub(super) async fn handle_muc_disco_info<'a>(
             channel.channel_type == "announcement",
             channel.channel_type == "forum",
         );
-        if channel.channel_type == "group-dm" {
+        if channel.channel_type == waddle_xmpp::admin::CHANNEL_TYPE_GROUP_DM {
             features.push(Feature::new(waddle_xmpp::admin::NS_GROUP_DM_FEATURE));
         }
         features.extend(extension_features_for_disco(state));

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/disco_info/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/disco_info/muc.rs
@@ -102,6 +102,9 @@ pub(super) async fn handle_muc_disco_info<'a>(
             snapshot.config.moderated || channel_type == "announcement",
             snapshot.config.forum || channel_type == "forum",
         );
+        if snapshot.config.group_dm {
+            features.push(Feature::new(waddle_xmpp::admin::NS_GROUP_DM_FEATURE));
+        }
         features.extend(extension_features_for_disco(state));
         let mut extensions = room_space_metadata_extensions(state, &room_jid, description).await;
         let has_space_metadata = !extensions.is_empty();

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
@@ -111,6 +111,7 @@ pub(super) fn space_details_from_node(
 fn channels_to_disco_items(channels: Vec<XmppChannelRecord>, muc_domain: &str) -> Vec<DiscoItem> {
     channels
         .into_iter()
+        .filter(|channel| channel.channel_type != "group-dm")
         .filter(|channel| channel.public_room)
         .filter_map(|channel| {
             waddle_xmpp::managed_room_jid(&channel.id, muc_domain)

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
@@ -111,7 +111,7 @@ pub(super) fn space_details_from_node(
 fn channels_to_disco_items(channels: Vec<XmppChannelRecord>, muc_domain: &str) -> Vec<DiscoItem> {
     channels
         .into_iter()
-        .filter(|channel| channel.channel_type != "group-dm")
+        .filter(|channel| channel.channel_type != waddle_xmpp::admin::CHANNEL_TYPE_GROUP_DM)
         .filter(|channel| channel.public_room)
         .filter_map(|channel| {
             waddle_xmpp::managed_room_jid(&channel.id, muc_domain)

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/search.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/search.rs
@@ -40,7 +40,7 @@ pub(super) async fn handle_channel_search_iq(
         };
     let mut results = Vec::new();
     for channel in channels {
-        if channel.channel_type == "group-dm" {
+        if channel.channel_type == waddle_xmpp::admin::CHANNEL_TYPE_GROUP_DM {
             continue;
         }
         let Some(room_jid) = waddle_xmpp::managed_room_jid(&channel.id, muc_domain).ok() else {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/search.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/search.rs
@@ -40,6 +40,9 @@ pub(super) async fn handle_channel_search_iq(
         };
     let mut results = Vec::new();
     for channel in channels {
+        if channel.channel_type == "group-dm" {
+            continue;
+        }
         let Some(room_jid) = waddle_xmpp::managed_room_jid(&channel.id, muc_domain).ok() else {
             continue;
         };

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -40,6 +40,9 @@ pub async fn handle_muc_join(
             )];
         }
     };
+    let managed_room_is_group_dm = managed_channel
+        .as_ref()
+        .is_some_and(|channel| channel.channel_type == waddle_xmpp::admin::CHANNEL_TYPE_GROUP_DM);
     let managed_affiliation = if let Some(channel) = managed_channel.as_ref() {
         let Some(session) = authenticated_session else {
             return vec![build_muc_presence_error_xml(
@@ -138,7 +141,7 @@ pub async fn handle_muc_join(
                     public_room: channel.public_room,
                     moderated: channel.channel_type == "announcement",
                     forum: channel.channel_type == "forum",
-                    group_dm: channel.channel_type == "group-dm",
+                    group_dm: channel.channel_type == waddle_xmpp::admin::CHANNEL_TYPE_GROUP_DM,
                     // #422: load persisted pin policy so the actor's
                     // snapshot matches the channel's last-saved value
                     // even after eviction.
@@ -175,10 +178,7 @@ pub async fn handle_muc_join(
         Affiliation::Owner
     } else if let Some(affiliation) = managed_affiliation {
         affiliation
-    } else if room_jid
-        .node()
-        .is_some_and(|node| node.as_str().starts_with("group-dm-"))
-    {
+    } else if managed_room_is_group_dm {
         Affiliation::None
     } else {
         Affiliation::Member

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -174,6 +174,11 @@ pub async fn handle_muc_join(
         Affiliation::Owner
     } else if let Some(affiliation) = managed_affiliation {
         affiliation
+    } else if room_jid
+        .node()
+        .is_some_and(|node| node.as_str().starts_with("group-dm-"))
+    {
+        Affiliation::None
     } else {
         Affiliation::Member
     };

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -138,6 +138,7 @@ pub async fn handle_muc_join(
                     public_room: channel.public_room,
                     moderated: channel.channel_type == "announcement",
                     forum: channel.channel_type == "forum",
+                    group_dm: channel.channel_type == "group-dm",
                     // #422: load persisted pin policy so the actor's
                     // snapshot matches the channel's last-saved value
                     // even after eviction.

--- a/server/crates/waddle-server/src/server/topology.rs
+++ b/server/crates/waddle-server/src/server/topology.rs
@@ -207,8 +207,10 @@ async fn seed_initial_xmpp_topology(
         room_registry
             .ask(GetOrCreateRoom {
                 room_jid: room_jid.clone(),
-                waddle_id: if channel_record.channel_type == "group-dm" {
-                    "group-dm".to_string()
+                waddle_id: if channel_record.channel_type
+                    == waddle_xmpp::admin::CHANNEL_TYPE_GROUP_DM
+                {
+                    waddle_xmpp::admin::CHANNEL_TYPE_GROUP_DM.to_string()
                 } else {
                     "space".to_string()
                 },
@@ -220,7 +222,8 @@ async fn seed_initial_xmpp_topology(
                     public_room: channel_record.public_room,
                     moderated: channel_record.channel_type == "announcement",
                     forum: channel_record.channel_type == "forum",
-                    group_dm: channel_record.channel_type == "group-dm",
+                    group_dm: channel_record.channel_type
+                        == waddle_xmpp::admin::CHANNEL_TYPE_GROUP_DM,
                     pin_permission: channel_record.pin_permission,
                     ..Default::default()
                 },

--- a/server/crates/waddle-server/src/server/topology.rs
+++ b/server/crates/waddle-server/src/server/topology.rs
@@ -207,7 +207,11 @@ async fn seed_initial_xmpp_topology(
         room_registry
             .ask(GetOrCreateRoom {
                 room_jid: room_jid.clone(),
-                waddle_id: "space".to_string(),
+                waddle_id: if channel_record.channel_type == "group-dm" {
+                    "group-dm".to_string()
+                } else {
+                    "space".to_string()
+                },
                 channel_id: channel_record.id.clone(),
                 config: RoomConfig {
                     name: channel_record.name.clone(),
@@ -216,6 +220,7 @@ async fn seed_initial_xmpp_topology(
                     public_room: channel_record.public_room,
                     moderated: channel_record.channel_type == "announcement",
                     forum: channel_record.channel_type == "forum",
+                    group_dm: channel_record.channel_type == "group-dm",
                     pin_permission: channel_record.pin_permission,
                     ..Default::default()
                 },

--- a/server/crates/waddle-server/tests/group_dm_ws.rs
+++ b/server/crates/waddle-server/tests/group_dm_ws.rs
@@ -97,8 +97,13 @@ fn is_error(frame: &str) -> bool {
 #[tokio::test]
 async fn group_dm_create_provisions_hidden_members_only_room_with_disco_feature() {
     let _serial = TEST_SERIAL.lock().await;
-    let server =
-        TestServer::start_with_extra_accounts(&[("alice", "alice-pass"), ("bob", "bob-pass")]);
+    let db_dir = tempfile::tempdir().expect("temp db dir");
+    let db_path = db_dir.path().join("group-dm.sqlite3");
+    let database_url = format!("sqlite://{}?mode=rwc", db_path.display());
+    let server = TestServer::start_persistent_with_extra_accounts(
+        &database_url,
+        &[("alice", "alice-pass"), ("bob", "bob-pass")],
+    );
     let mut alice = user_client(&server, "alice", "alice-pass", "group-dm-create-1").await;
 
     let missing_member_resp = send_command(
@@ -163,5 +168,22 @@ async fn group_dm_create_provisions_hidden_members_only_room_with_disco_feature(
         "group DM room must stay hidden from public room discovery: {disco}"
     );
 
+    let _ = alice.close().await;
+    drop(server);
+
+    let server = TestServer::start_persistent_with_extra_accounts(
+        &database_url,
+        &[("alice", "alice-pass"), ("bob", "bob-pass")],
+    );
+    let mut alice = user_client(&server, "alice", "alice-pass", "group-dm-restart-2").await;
+    let disco = disco_info(&mut alice, &room_jid, "group-dm-disco-after-restart").await;
+    assert!(
+        disco.contains(FEATURE_GROUP_DM),
+        "restarted server lost group DM disco feature: {disco}"
+    );
+    assert!(
+        disco.contains("muc_membersonly"),
+        "restarted group DM room must stay members-only: {disco}"
+    );
     let _ = alice.close().await;
 }

--- a/server/crates/waddle-server/tests/group_dm_ws.rs
+++ b/server/crates/waddle-server/tests/group_dm_ws.rs
@@ -4,6 +4,7 @@ mod ws_common;
 
 use tokio::sync::Mutex;
 use ws_common::{TestServer, WsXmppClient};
+use xmpp_parsers::minidom::Element;
 
 const DOMAIN: &str = "localhost";
 const NS_COMMANDS: &str = "http://jabber.org/protocol/commands";
@@ -17,6 +18,12 @@ fn frame_has_iq_id(frame: &str, id: &str) -> bool {
     frame.contains(&format!(r#"id='{id}'"#)) || frame.contains(&format!(r#"id="{id}""#))
 }
 
+fn element_to_xml(element: Element) -> String {
+    let mut buf = Vec::new();
+    element.write_to(&mut buf).expect("serialize XML");
+    String::from_utf8(buf).expect("xmpp_parsers serializes UTF-8")
+}
+
 async fn user_client(
     server: &TestServer,
     username: &str,
@@ -28,16 +35,19 @@ async fn user_client(
         .expect("user connect")
 }
 
-async fn send_command(client: &mut WsXmppClient, node: &str, id: &str, form_xml: &str) -> String {
-    let body = format!(
-        r#"<command xmlns="{NS_COMMANDS}" node="{node}" action="execute">{form_xml}</command>"#
-    );
-    client
-        .send(&format!(
-            r#"<iq type="set" id="{id}" to="{DOMAIN}">{body}</iq>"#
-        ))
-        .await
-        .expect("send iq");
+async fn send_command(client: &mut WsXmppClient, node: &str, id: &str, form: Element) -> String {
+    let command = Element::builder("command", NS_COMMANDS)
+        .attr(minidom::rxml::xml_ncname!("node").to_owned(), node)
+        .attr(minidom::rxml::xml_ncname!("action").to_owned(), "execute")
+        .append(form)
+        .build();
+    let iq = Element::builder("iq", "jabber:client")
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "set")
+        .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
+        .attr(minidom::rxml::xml_ncname!("to").to_owned(), DOMAIN)
+        .append(command)
+        .build();
+    client.send(&element_to_xml(iq)).await.expect("send iq");
     client
         .recv_matching(|frame| frame.contains("<iq") && frame_has_iq_id(frame, id))
         .await
@@ -45,10 +55,14 @@ async fn send_command(client: &mut WsXmppClient, node: &str, id: &str, form_xml:
 }
 
 async fn disco_info(client: &mut WsXmppClient, to: &str, id: &str) -> String {
+    let iq = Element::builder("iq", "jabber:client")
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "get")
+        .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
+        .attr(minidom::rxml::xml_ncname!("to").to_owned(), to)
+        .append(Element::builder("query", "http://jabber.org/protocol/disco#info").build())
+        .build();
     client
-        .send(&format!(
-            r#"<iq type="get" id="{id}" to="{to}"><query xmlns="http://jabber.org/protocol/disco#info"/></iq>"#
-        ))
+        .send(&element_to_xml(iq))
         .await
         .expect("send disco info");
     client
@@ -57,22 +71,38 @@ async fn disco_info(client: &mut WsXmppClient, to: &str, id: &str) -> String {
         .expect("disco info response")
 }
 
-fn submit_form(node: &str, extra: &str) -> String {
-    format!(
-        r#"<x xmlns="{NS_DATA}" type="submit"><field var="FORM_TYPE" type="hidden"><value>{node}</value></field>{extra}</x>"#
-    )
+fn submit_form(node: &str, fields: Vec<Element>) -> Element {
+    let mut form = Element::builder("x", NS_DATA)
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "submit")
+        .append(
+            Element::builder("field", NS_DATA)
+                .attr(minidom::rxml::xml_ncname!("var").to_owned(), "FORM_TYPE")
+                .attr(minidom::rxml::xml_ncname!("type").to_owned(), "hidden")
+                .append(Element::builder("value", NS_DATA).append(node).build())
+                .build(),
+        );
+    for field in fields {
+        form = form.append(field);
+    }
+    form.build()
 }
 
-fn text_field(var: &str, value: &str) -> String {
-    format!(r#"<field var="{var}" type="text-single"><value>{value}</value></field>"#)
+fn text_field(var: &str, value: &str) -> Element {
+    Element::builder("field", NS_DATA)
+        .attr(minidom::rxml::xml_ncname!("var").to_owned(), var)
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "text-single")
+        .append(Element::builder("value", NS_DATA).append(value).build())
+        .build()
 }
 
-fn list_multi_field(var: &str, values: &[&str]) -> String {
-    let values_xml = values
-        .iter()
-        .map(|value| format!("<value>{value}</value>"))
-        .collect::<String>();
-    format!(r#"<field var="{var}" type="list-multi">{values_xml}</field>"#)
+fn list_multi_field(var: &str, values: &[&str]) -> Element {
+    let mut field = Element::builder("field", NS_DATA)
+        .attr(minidom::rxml::xml_ncname!("var").to_owned(), var)
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "list-multi");
+    for value in values {
+        field = field.append(Element::builder("value", NS_DATA).append(*value).build());
+    }
+    field.build()
 }
 
 fn extract_field(frame: &str, var: &str) -> Option<String> {
@@ -110,13 +140,12 @@ async fn group_dm_create_provisions_hidden_members_only_room_with_disco_feature(
         &mut alice,
         NODE_GROUP_DM_CREATE,
         "group-dm-create-missing-member",
-        &submit_form(
+        submit_form(
             NODE_GROUP_DM_CREATE,
-            &format!(
-                "{}{}",
+            vec![
                 text_field("name", "Alice, Mallory"),
-                list_multi_field("member_jids", &["alice@localhost", "mallory@localhost"])
-            ),
+                list_multi_field("member_jids", &["alice@localhost", "mallory@localhost"]),
+            ],
         ),
     )
     .await;
@@ -133,13 +162,12 @@ async fn group_dm_create_provisions_hidden_members_only_room_with_disco_feature(
         &mut alice,
         NODE_GROUP_DM_CREATE,
         "group-dm-create",
-        &submit_form(
+        submit_form(
             NODE_GROUP_DM_CREATE,
-            &format!(
-                "{}{}",
-                text_field("name", "Alice, Bob"),
-                list_multi_field("member_jids", &["alice@localhost", "bob@localhost"])
-            ),
+            vec![
+                text_field("name", "Rock & Roll"),
+                list_multi_field("member_jids", &["alice@localhost", "bob@localhost"]),
+            ],
         ),
     )
     .await;

--- a/server/crates/waddle-server/tests/group_dm_ws.rs
+++ b/server/crates/waddle-server/tests/group_dm_ws.rs
@@ -1,0 +1,140 @@
+//! Integration suite for Waddle group-DM provisioning over XEP-0050.
+
+mod ws_common;
+
+use tokio::sync::Mutex;
+use ws_common::{TestServer, WsXmppClient};
+
+const DOMAIN: &str = "localhost";
+const NS_COMMANDS: &str = "http://jabber.org/protocol/commands";
+const NS_DATA: &str = "jabber:x:data";
+const NODE_GROUP_DM_CREATE: &str = "urn:waddle:group-dm:create:0";
+const FEATURE_GROUP_DM: &str = "urn:waddle:group-dm:0";
+
+static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+fn frame_has_iq_id(frame: &str, id: &str) -> bool {
+    frame.contains(&format!(r#"id='{id}'"#)) || frame.contains(&format!(r#"id="{id}""#))
+}
+
+async fn user_client(
+    server: &TestServer,
+    username: &str,
+    password: &str,
+    resource: &str,
+) -> WsXmppClient {
+    WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, username, password, resource)
+        .await
+        .expect("user connect")
+}
+
+async fn send_command(client: &mut WsXmppClient, node: &str, id: &str, form_xml: &str) -> String {
+    let body = format!(
+        r#"<command xmlns="{NS_COMMANDS}" node="{node}" action="execute">{form_xml}</command>"#
+    );
+    client
+        .send(&format!(
+            r#"<iq type="set" id="{id}" to="{DOMAIN}">{body}</iq>"#
+        ))
+        .await
+        .expect("send iq");
+    client
+        .recv_matching(|frame| frame.contains("<iq") && frame_has_iq_id(frame, id))
+        .await
+        .expect("iq response")
+}
+
+async fn disco_info(client: &mut WsXmppClient, to: &str, id: &str) -> String {
+    client
+        .send(&format!(
+            r#"<iq type="get" id="{id}" to="{to}"><query xmlns="http://jabber.org/protocol/disco#info"/></iq>"#
+        ))
+        .await
+        .expect("send disco info");
+    client
+        .recv_matching(|frame| frame.contains("<iq") && frame_has_iq_id(frame, id))
+        .await
+        .expect("disco info response")
+}
+
+fn submit_form(node: &str, extra: &str) -> String {
+    format!(
+        r#"<x xmlns="{NS_DATA}" type="submit"><field var="FORM_TYPE" type="hidden"><value>{node}</value></field>{extra}</x>"#
+    )
+}
+
+fn text_field(var: &str, value: &str) -> String {
+    format!(r#"<field var="{var}" type="text-single"><value>{value}</value></field>"#)
+}
+
+fn list_multi_field(var: &str, values: &[&str]) -> String {
+    let values_xml = values
+        .iter()
+        .map(|value| format!("<value>{value}</value>"))
+        .collect::<String>();
+    format!(r#"<field var="{var}" type="list-multi">{values_xml}</field>"#)
+}
+
+fn extract_field(frame: &str, var: &str) -> Option<String> {
+    let marker_dq = format!(r#"var="{var}""#);
+    let marker_sq = format!(r#"var='{var}'"#);
+    let idx = frame.find(&marker_dq).or_else(|| frame.find(&marker_sq))?;
+    let after = &frame[idx..];
+    let open = after.find("<value>")?;
+    let inner = &after[open + "<value>".len()..];
+    let close = inner.find("</value>")?;
+    Some(inner[..close].to_string())
+}
+
+fn is_result(frame: &str) -> bool {
+    frame.contains(r#"type='result'"#) || frame.contains(r#"type="result""#)
+}
+
+#[tokio::test]
+async fn group_dm_create_provisions_hidden_members_only_room_with_disco_feature() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server =
+        TestServer::start_with_extra_accounts(&[("alice", "alice-pass"), ("bob", "bob-pass")]);
+    let mut alice = user_client(&server, "alice", "alice-pass", "group-dm-create-1").await;
+
+    let resp = send_command(
+        &mut alice,
+        NODE_GROUP_DM_CREATE,
+        "group-dm-create",
+        &submit_form(
+            NODE_GROUP_DM_CREATE,
+            &format!(
+                "{}{}",
+                text_field("name", "Alice, Bob"),
+                list_multi_field("member_jids", &["alice@localhost", "bob@localhost"])
+            ),
+        ),
+    )
+    .await;
+
+    assert!(is_result(&resp), "expected result, got: {resp}");
+    let room_jid = extract_field(&resp, "room_jid").expect("room_jid in response");
+    assert!(
+        room_jid.ends_with("@muc.localhost"),
+        "expected managed MUC room, got: {room_jid}"
+    );
+    assert_eq!(extract_field(&resp, "is_public").as_deref(), Some("0"));
+    assert_eq!(extract_field(&resp, "members_only").as_deref(), Some("1"));
+    assert_eq!(extract_field(&resp, "persistent").as_deref(), Some("1"));
+
+    let disco = disco_info(&mut alice, &room_jid, "group-dm-disco").await;
+    assert!(
+        disco.contains(FEATURE_GROUP_DM),
+        "group DM room disco#info missing {FEATURE_GROUP_DM}: {disco}"
+    );
+    assert!(
+        disco.contains("muc_membersonly"),
+        "group DM room must be members-only: {disco}"
+    );
+    assert!(
+        !disco.contains("muc_public"),
+        "group DM room must stay hidden from public room discovery: {disco}"
+    );
+
+    let _ = alice.close().await;
+}

--- a/server/crates/waddle-server/tests/group_dm_ws.rs
+++ b/server/crates/waddle-server/tests/group_dm_ws.rs
@@ -90,12 +90,39 @@ fn is_result(frame: &str) -> bool {
     frame.contains(r#"type='result'"#) || frame.contains(r#"type="result""#)
 }
 
+fn is_error(frame: &str) -> bool {
+    frame.contains(r#"type='error'"#) || frame.contains(r#"type="error""#)
+}
+
 #[tokio::test]
 async fn group_dm_create_provisions_hidden_members_only_room_with_disco_feature() {
     let _serial = TEST_SERIAL.lock().await;
     let server =
         TestServer::start_with_extra_accounts(&[("alice", "alice-pass"), ("bob", "bob-pass")]);
     let mut alice = user_client(&server, "alice", "alice-pass", "group-dm-create-1").await;
+
+    let missing_member_resp = send_command(
+        &mut alice,
+        NODE_GROUP_DM_CREATE,
+        "group-dm-create-missing-member",
+        &submit_form(
+            NODE_GROUP_DM_CREATE,
+            &format!(
+                "{}{}",
+                text_field("name", "Alice, Mallory"),
+                list_multi_field("member_jids", &["alice@localhost", "mallory@localhost"])
+            ),
+        ),
+    )
+    .await;
+    assert!(
+        is_error(&missing_member_resp),
+        "expected nonexistent member rejection, got: {missing_member_resp}"
+    );
+    assert!(
+        missing_member_resp.contains("item-not-found"),
+        "nonexistent member should use item-not-found: {missing_member_resp}"
+    );
 
     let resp = send_command(
         &mut alice,

--- a/server/crates/waddle-server/tests/xmpp_e2e_cue.rs
+++ b/server/crates/waddle-server/tests/xmpp_e2e_cue.rs
@@ -249,6 +249,10 @@ const ADVERTISED_FEATURE_EXEMPTIONS: &[FeatureCoverageExemption] = &[
         reason: "Private Waddle ad-hoc command namespace, not official XEP coverage.",
     },
     FeatureCoverageExemption {
+        feature: "urn:waddle:group-dm:create:0",
+        reason: "Private Waddle ad-hoc command namespace, not official XEP coverage.",
+    },
+    FeatureCoverageExemption {
         feature: "urn:waddle:mam-thread:0",
         reason: "Private Waddle MAM extension namespace, not official XEP coverage.",
     },

--- a/server/crates/waddle-xmpp/src/admin.rs
+++ b/server/crates/waddle-xmpp/src/admin.rs
@@ -84,3 +84,6 @@ pub const NS_GROUP_DM_CREATE: &str = "urn:waddle:group-dm:create:0";
 /// Disco feature advertised by group-DM rooms so clients can classify them
 /// into the DM surface instead of the channel surface.
 pub const NS_GROUP_DM_FEATURE: &str = "urn:waddle:group-dm:0";
+
+/// Persisted channel type for private group-DM MUC rooms.
+pub const CHANNEL_TYPE_GROUP_DM: &str = "group-dm";

--- a/server/crates/waddle-xmpp/src/admin.rs
+++ b/server/crates/waddle-xmpp/src/admin.rs
@@ -76,3 +76,11 @@ pub const NS_ADMIN_CHANNELS_AFFILIATIONS: &str = "urn:waddle:admin:channels:affi
 pub const NS_ADMIN_CHANNELS_SET_AFFILIATION: &str = "urn:waddle:admin:channels:set-affiliation:0";
 /// `channels:kick` — XEP-0045 §9.1 role-change to `none`.
 pub const NS_ADMIN_CHANNELS_KICK: &str = "urn:waddle:admin:channels:kick:0";
+
+/// `group-dm:create` — provision a private group DM as a hidden,
+/// members-only, persistent XEP-0045 room.
+pub const NS_GROUP_DM_CREATE: &str = "urn:waddle:group-dm:create:0";
+
+/// Disco feature advertised by group-DM rooms so clients can classify them
+/// into the DM surface instead of the channel surface.
+pub const NS_GROUP_DM_FEATURE: &str = "urn:waddle:group-dm:0";

--- a/server/crates/waddle-xmpp/src/disco/info.rs
+++ b/server/crates/waddle-xmpp/src/disco/info.rs
@@ -49,6 +49,7 @@ pub fn server_features() -> Vec<Feature> {
         crate::admin::NS_ADMIN_CHANNELS_SET_AFFILIATION,
     ));
     features.push(Feature::new(crate::admin::NS_ADMIN_CHANNELS_KICK));
+    features.push(Feature::new(crate::admin::NS_GROUP_DM_CREATE));
     features
 }
 

--- a/server/crates/waddle-xmpp/src/muc/room.rs
+++ b/server/crates/waddle-xmpp/src/muc/room.rs
@@ -44,6 +44,9 @@ pub struct RoomConfig {
     /// Whether the room uses Waddle thread-oriented metadata.
     #[serde(default)]
     pub forum: bool,
+    /// Whether this MUC room is a Waddle group DM rather than a channel.
+    #[serde(default)]
+    pub group_dm: bool,
     /// #415: who may pin/unpin messages in this room. Default is
     /// `admins-only`; when set to `anyone`, any current occupant may
     /// pin. Set via the `urn:waddle:roomconfig:pinpermission` field on
@@ -71,6 +74,7 @@ impl Default for RoomConfig {
             max_occupants: 0,
             enable_logging: true,
             forum: false,
+            group_dm: false,
             pin_permission: PinPermission::default(),
             federation_policy: FederatedPermissionPolicy::default(),
             federated_affiliation_config: FederatedAffiliationConfig::open_member(),

--- a/server/docs/adrs/0013-group-dm-protocol.md
+++ b/server/docs/adrs/0013-group-dm-protocol.md
@@ -1,0 +1,61 @@
+# ADR-0013: Group DM Protocol Shape
+
+## Status
+
+Accepted
+
+## Context
+
+Issue #950 starts Workstream B from PRD #945: group DMs should behave like direct
+messages in product placement while reusing the existing XEP-0045 room machinery
+for multi-party conversation features.
+
+The protocol needs to preserve Waddle's XMPP-native rule. Group-DM creation,
+classification, membership, and follow-up sync must stay on XMPP surfaces rather
+than side-band HTTP APIs.
+
+ADR-0009 establishes relationship-based authorization as the general permission
+model. Group DMs deliberately use a flatter room-level model: the service owns
+the room and humans are plain members, so no human participant can kick, ban, or
+moderate another participant.
+
+## Decision
+
+Group DMs are hidden, persistent, members-only, non-anonymous XEP-0045 rooms on
+the MUC service, outside any Space.
+
+Creation is exposed as a XEP-0050 ad-hoc command:
+`urn:waddle:group-dm:create:0`.
+
+Provisioned rooms advertise the Waddle classification feature
+`urn:waddle:group-dm:0` in room `disco#info`. Clients classify rooms with that
+feature into the DM sidebar, not the channel/sidebar Space hierarchy.
+
+The first walking-skeleton slice creates the room, writes the creator and
+initial participants as member affiliations, keeps the room hidden from public
+MUC discovery, and exposes the classification feature. Mediated invites and
+XEP-0402 autojoin bookmarks remain part of the same protocol shape and should be
+implemented as follow-up slices on the same command.
+
+## Consequences
+
+### Positive
+
+- Existing MUC message features can be reused for replies, reactions, threads,
+  uploads, read markers, unread counts, and pins.
+- Client classification has a stable disco feature instead of relying on JID
+  naming conventions.
+- The flat human-member model avoids accidental human moderation authority in
+  private group conversations.
+
+### Negative
+
+- Group-DM creation now has its own Waddle namespace because no XEP defines this
+  exact provisioning command.
+- The first slice does not complete cross-device appearance until XEP-0402
+  bookmark publication is added.
+
+## Related
+
+- [ADR-0009: Zanzibar-Inspired Authorization](0009-zanzibar-permissions.md)
+- [Issue #950: Group DMs walking skeleton](https://github.com/waddle-social/waddle/issues/950)


### PR DESCRIPTION
## Summary

Implements the first server walking-skeleton slice for issue #950: a user can
provision a group DM through XEP-0050, and the resulting MUC room advertises a
stable group-DM disco feature for client classification.

## Plan / status

- [x] Add `urn:waddle:group-dm:create:0` XEP-0050 command registration.
- [x] Create hidden, persistent, members-only MUC rooms with creator and initial participants as member affiliations.
- [x] Reject nonexistent or remote requested members before provisioning.
- [x] Persist group-DM room metadata and member tuples so room disco survives restart/cold rehydration.
- [x] Filter internal group-DM catalog rows out of ordinary channel disco/search/list surfaces.
- [x] Add typed `RoomConfig.group_dm` and advertise `urn:waddle:group-dm:0` from room disco#info.
- [x] Use exported group-DM channel-type vocabulary instead of local raw discriminator strings.
- [x] Default group-DM pin permissions to member-usable `Anyone`.
- [x] Roll back catalog/member state if post-persistence room actor affiliation updates fail.
- [x] Add WebSocket integration coverage for provision -> disco classification -> restart disco classification.
- [x] Build group-DM test XML through `minidom` builders, including an XML-metacharacter room name.
- [x] Add ADR-0013 for the protocol shape and carrier decisions.
- [ ] Follow up with mediated invites, XEP-0402 autojoin bookmarks, second-device appearance, and client sidebar classification.

## XEP review

Reviewed the local XEP corpus for the touched protocol surfaces:

- XEP-0045 for hidden, persistent, members-only MUC room shape and room disco flags.
- XEP-0050 for ad-hoc command provisioning.
- XEP-0402 for the bookmark/autojoin follow-up called out in ADR-0013.

## Verification

- `cargo test -p waddle-server --test group_dm_ws -- --nocapture`
- `cargo test -p waddle-server --test xmpp_e2e_cue advertised_features_have_explicit_xep_coverage -- --nocapture`
- `cargo clippy -p waddle-server --tests -- -D warnings`

## Review fixes

- Security review: fixed arbitrary/nonexistent member injection by requiring local existing native accounts.
- Correctness review: fixed non-durable group-DM rooms by persisting room metadata and member permission tuples, with restart coverage.
- Code review: replaced hand-built XML test requests with builders, centralized group-DM type vocabulary, removed JID-prefix classification, made pins usable by member-only group DMs, and rolled back persisted state on room-actor affiliation failures.

## Remaining risks

- Full issue #950 is not complete: mediated invites, bookmark publication, second-device sync, and client UI classification remain.
- Full workspace test suite was not run.
