### PR TITLE
feat(server): add group DM mediated member invites

### DIFF
--- a/server/crates/waddle-server/src/admin/channels.rs
+++ b/server/crates/waddle-server/src/admin/channels.rs
@@ -1627,7 +1627,7 @@ async fn rollback_group_dm_create(
         .await;
 }
 
-async fn persist_group_dm_member_tuple(
+pub(crate) async fn persist_group_dm_member_tuple(
     state: &AppState,
     group_dm_id: &str,
     member_jid: &BareJid,
@@ -1661,6 +1661,43 @@ async fn delete_group_dm_member_tuple(
             "Failed to roll back group-DM member: {error}"
         ))),
     }
+}
+
+pub(crate) async fn rollback_group_dm_member_tuple(
+    state: &AppState,
+    group_dm_id: &str,
+    member_jid: &BareJid,
+) {
+    let _ = delete_group_dm_member_tuple(state, group_dm_id, member_jid).await;
+}
+
+pub(crate) async fn validate_group_dm_invitee(
+    state: &AppState,
+    inviter_jid: &BareJid,
+    invitee_jid: &BareJid,
+) -> Result<(), XmppError> {
+    if invitee_jid.domain() != inviter_jid.domain() {
+        return Err(XmppError::bad_request(Some(format!(
+            "invitee must be local to {}",
+            inviter_jid.domain()
+        ))));
+    }
+    let Some(localpart) = invitee_jid.node().map(|node| node.to_string()) else {
+        return Err(XmppError::bad_request(Some(
+            "invitee must be a user JID with a localpart".to_string(),
+        )));
+    };
+    let native_users = NativeUserStore::new(state.db_pool.global_actor().clone());
+    let exists = native_users
+        .user_exists(&localpart, invitee_jid.domain().as_str())
+        .await
+        .map_err(|error| XmppError::internal(format!("native user lookup failed: {error}")))?;
+    if !exists {
+        return Err(XmppError::item_not_found(Some(format!(
+            "group-DM invitee does not exist: {invitee_jid}"
+        ))));
+    }
+    Ok(())
 }
 
 async fn validate_group_dm_members(

--- a/server/crates/waddle-server/src/db/migrations/tests.rs
+++ b/server/crates/waddle-server/src/db/migrations/tests.rs
@@ -16,7 +16,7 @@ async fn test_migration_runner_global() {
 
     // Check version (global + shared waddle schema)
     let version = runner.current_version(&db).await.unwrap();
-    assert_eq!(version, Some(1005));
+    assert_eq!(version, Some(1006));
 }
 
 #[tokio::test]
@@ -48,6 +48,7 @@ async fn test_migration_runner_waddle() {
     assert!(tables.contains(&"messages".to_string()));
     assert!(tables.contains(&"reactions".to_string()));
     assert!(tables.contains(&"attachments".to_string()));
+    assert!(tables.contains(&"group_dm_archive_boundaries".to_string()));
 
     let mut rows = conn
         .query(
@@ -135,7 +136,7 @@ async fn test_waddle_v1002_adds_pin_permission_to_existing_v1001_schema() {
 
     let runner = MigrationRunner::waddle();
     let applied = runner.run(&db).await.unwrap();
-    assert_eq!(applied, vec![1002, 1003, 1004, 1005]);
+    assert_eq!(applied, vec![1002, 1003, 1004, 1005, 1006]);
 
     let conn = db.guard().await.unwrap();
     let mut rows = conn
@@ -154,7 +155,7 @@ async fn test_waddle_v1002_adds_pin_permission_to_existing_v1001_schema() {
     assert_eq!(public_room, 1);
 
     let version = runner.current_version(&db).await.unwrap();
-    assert_eq!(version, Some(1005));
+    assert_eq!(version, Some(1006));
 }
 
 #[tokio::test]
@@ -231,14 +232,17 @@ async fn test_global_v0004_adds_policy_digest_to_existing_v0003_schema() {
     drop(conn);
 
     // `MigrationRunner::global()` composes global + waddle migrations,
-    // so the runner also reports applying 1001 through 1005 (the waddle
+    // so the runner also reports applying 1001 through 1006 (the waddle
     // schema tables) on top of V0004. The test's invariant is V0004
     // specifically, asserted via the `pragma_table_info` probe below;
     // the version list is included in the assertion so a future PR
     // that reorders or renumbers can't silently shift it.
     let runner = MigrationRunner::global();
     let applied = runner.run(&db).await.unwrap();
-    assert_eq!(applied, vec![4, 5, 6, 7, 1001, 1002, 1003, 1004, 1005]);
+    assert_eq!(
+        applied,
+        vec![4, 5, 6, 7, 1001, 1002, 1003, 1004, 1005, 1006]
+    );
 
     // Column exists.
     let conn = db.guard().await.unwrap();
@@ -300,7 +304,7 @@ async fn test_global_v0004_adds_policy_digest_to_existing_v0003_schema() {
     let version = runner.current_version(&db).await.unwrap();
     assert_eq!(
         version,
-        Some(1005),
+        Some(1006),
         "current version reflects the highest applied across global+waddle"
     );
 }
@@ -351,14 +355,14 @@ async fn test_incompatible_history_forces_hard_cut_reapply() {
     let applied = runner.run(&db).await.unwrap();
     assert_eq!(
         applied,
-        vec![1, 2, 3, 4, 5, 6, 7, 1001, 1002, 1003, 1004, 1005]
+        vec![1, 2, 3, 4, 5, 6, 7, 1001, 1002, 1003, 1004, 1005, 1006]
     );
 
     let applied_again = runner.run(&db).await.unwrap();
     assert!(applied_again.is_empty());
 
     let version = runner.current_version(&db).await.unwrap();
-    assert_eq!(version, Some(1005));
+    assert_eq!(version, Some(1006));
 }
 
 #[tokio::test]
@@ -405,7 +409,7 @@ async fn test_incompatible_history_recreates_existing_owned_tables() {
     let applied = runner.run(&db).await.unwrap();
     assert_eq!(
         applied,
-        vec![1, 2, 3, 4, 5, 6, 7, 1001, 1002, 1003, 1004, 1005]
+        vec![1, 2, 3, 4, 5, 6, 7, 1001, 1002, 1003, 1004, 1005, 1006]
     );
 
     let conn = db.guard().await.unwrap();
@@ -624,7 +628,7 @@ async fn postgres_v0006_widens_existing_upload_slot_size_bytes() {
         .run(&db)
         .await
         .expect("run global migration");
-    assert_eq!(applied, vec![6, 7, 1001, 1002, 1003, 1004, 1005]);
+    assert_eq!(applied, vec![6, 7, 1001, 1002, 1003, 1004, 1005, 1006]);
     assert_postgres_column_type(&db, "upload_slots", "size_bytes", "bigint").await;
 
     let oversized_int4 = i64::from(i32::MAX) + 1;
@@ -689,7 +693,7 @@ async fn sqlite_v0007_tracks_link_preview_media_refs() {
     drop(conn);
 
     let applied = MigrationRunner::global().run(&db).await.unwrap();
-    assert_eq!(applied, vec![7, 1001, 1002, 1003, 1004, 1005]);
+    assert_eq!(applied, vec![7, 1001, 1002, 1003, 1004, 1005, 1006]);
 
     let conn = db.guard().await.unwrap();
     let mut rows = conn
@@ -810,7 +814,7 @@ async fn postgres_v0007_tracks_link_preview_media_refs() {
         .run(&db)
         .await
         .expect("run global migration");
-    assert_eq!(applied, vec![7, 1001, 1002, 1003, 1004, 1005]);
+    assert_eq!(applied, vec![7, 1001, 1002, 1003, 1004, 1005, 1006]);
 
     let conn = db.guard().await.expect("postgres guard");
     let mut rows = conn
@@ -980,7 +984,7 @@ async fn postgres_v1003_widens_existing_attachment_size_bytes() {
         .run(&db)
         .await
         .expect("run waddle migration");
-    assert_eq!(applied, vec![1003, 1004, 1005]);
+    assert_eq!(applied, vec![1003, 1004, 1005, 1006]);
     assert_postgres_column_type(&db, "attachments", "size_bytes", "bigint").await;
 
     let oversized_int4 = i64::from(i32::MAX) + 1;

--- a/server/crates/waddle-server/src/db/migrations/waddle.rs
+++ b/server/crates/waddle-server/src/db/migrations/waddle.rs
@@ -193,6 +193,29 @@ ALTER TABLE channels
 ADD COLUMN IF NOT EXISTS public_room INTEGER NOT NULL DEFAULT 1;
 "#;
 
+/// Per-member MAM visibility boundary for group-DM mediated invites.
+/// A `NULL` boundary means full history access; a timestamp boundary means
+/// the member may only read archived room messages created at or after it.
+pub const V1006_ADD_GROUP_DM_ARCHIVE_BOUNDARIES: &str = r#"
+CREATE TABLE IF NOT EXISTS group_dm_archive_boundaries (
+    room_jid TEXT NOT NULL,
+    member_jid TEXT NOT NULL,
+    visible_after TEXT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (room_jid, member_jid)
+);
+"#;
+
+pub const V1006_ADD_GROUP_DM_ARCHIVE_BOUNDARIES_POSTGRES: &str = r#"
+CREATE TABLE IF NOT EXISTS group_dm_archive_boundaries (
+    room_jid TEXT NOT NULL,
+    member_jid TEXT NOT NULL,
+    visible_after TEXT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (room_jid, member_jid)
+);
+"#;
+
 /// Get all waddle schema migrations in order.
 ///
 /// Versions are intentionally offset from global migrations so a single
@@ -228,6 +251,12 @@ pub fn all() -> Vec<Migration> {
             description: "Persist channel public-room discovery visibility".to_string(),
             sql_sqlite: V1005_ADD_CHANNEL_PUBLIC_ROOM,
             sql_postgres: V1005_ADD_CHANNEL_PUBLIC_ROOM_POSTGRES,
+        },
+        Migration {
+            version: 1006,
+            description: "Persist group-DM archive visibility boundaries".to_string(),
+            sql_sqlite: V1006_ADD_GROUP_DM_ARCHIVE_BOUNDARIES,
+            sql_postgres: V1006_ADD_GROUP_DM_ARCHIVE_BOUNDARIES_POSTGRES,
         },
     ]
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/archive_inbox_upload.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/archive_inbox_upload.rs
@@ -395,16 +395,6 @@ async fn group_dm_archive_visibility(
     }
 
     let actor = state.deps.app_state.db_pool.global_actor().clone();
-    if actor
-        .ask(crate::db::actor::DbExecute {
-            sql: "CREATE TABLE IF NOT EXISTS group_dm_archive_boundaries (room_jid TEXT NOT NULL, member_jid TEXT NOT NULL, visible_after TEXT NULL, updated_at TEXT NOT NULL, PRIMARY KEY (room_jid, member_jid))".to_string(),
-            params: vec![],
-        })
-        .await
-        .is_err()
-    {
-        return GroupDmArchiveVisibility::Error;
-    }
     let row = match actor
         .ask(crate::db::actor::DbQueryOne {
             sql: "SELECT visible_after FROM group_dm_archive_boundaries WHERE room_jid = ? AND member_jid = ?".to_string(),

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/archive_inbox_upload.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/archive_inbox_upload.rs
@@ -52,7 +52,7 @@ pub(super) async fn handle_archive_inbox_upload_iq(
             return vec![iq_to_xml(build_query_form_iq(request_iq))];
         }
 
-        let (query_id, query) = match parse_mam_query(request_iq) {
+        let (query_id, mut query) = match parse_mam_query(request_iq) {
             Ok(parsed) => parsed,
             Err(err) => {
                 warn!(error = %err, target = %target_bare, "Invalid MAM query");
@@ -72,6 +72,32 @@ pub(super) async fn handle_archive_inbox_upload_iq(
                 )];
             }
         };
+
+        let visibility =
+            group_dm_archive_visibility(state, &target_bare, sender_bare.as_ref()).await;
+        let visibility_boundary = match visibility {
+            GroupDmArchiveVisibility::NotGroupDm | GroupDmArchiveVisibility::Full => None,
+            GroupDmArchiveVisibility::Restricted(boundary) => Some(boundary),
+            GroupDmArchiveVisibility::Denied => {
+                return vec![build_iq_error_xml_typed(
+                    id,
+                    None,
+                    None,
+                    forbidden_iq_error("Operation not permitted."),
+                )];
+            }
+            GroupDmArchiveVisibility::Error => {
+                return vec![build_iq_error_xml_typed(
+                    id,
+                    None,
+                    None,
+                    internal_server_error_iq_error("Internal server error."),
+                )];
+            }
+        };
+        if let Some(boundary) = visibility_boundary {
+            query.start = Some(query.start.map_or(boundary, |start| start.max(boundary)));
+        }
 
         let mut result = match state
             .deps
@@ -308,6 +334,103 @@ pub(super) async fn handle_archive_inbox_upload_iq(
         }
     }
     Vec::new()
+}
+
+enum GroupDmArchiveVisibility {
+    NotGroupDm,
+    Full,
+    Restricted(chrono::DateTime<chrono::Utc>),
+    Denied,
+    Error,
+}
+
+async fn group_dm_archive_visibility(
+    state: &WebSocketState,
+    room_jid: &BareJid,
+    sender_bare: Option<&BareJid>,
+) -> GroupDmArchiveVisibility {
+    let Some(sender_bare) = sender_bare else {
+        return GroupDmArchiveVisibility::Denied;
+    };
+    let Some(channel_id) = waddle_xmpp::parse_managed_room_jid(room_jid) else {
+        return GroupDmArchiveVisibility::NotGroupDm;
+    };
+    let channel = get_xmpp_channel(
+        state.deps.app_state.db_pool.global_actor().clone(),
+        &channel_id,
+    )
+    .await
+    .ok()
+    .flatten();
+    let Some(channel) = channel else {
+        return GroupDmArchiveVisibility::NotGroupDm;
+    };
+    if channel.channel_type != waddle_xmpp::admin::CHANNEL_TYPE_GROUP_DM {
+        return GroupDmArchiveVisibility::NotGroupDm;
+    }
+
+    let allowed = state
+        .deps
+        .app_state
+        .permission_actor
+        .ask(CheckPermission {
+            subject: Subject::user(sender_bare.to_string()),
+            permission: Permission::Member,
+            object: Object::new(ObjectType::Channel, &channel_id),
+        })
+        .await
+        .map(|response| response.allowed);
+    match allowed {
+        Ok(true) => {}
+        Ok(false) => return GroupDmArchiveVisibility::Denied,
+        Err(error) => {
+            warn!(
+                error = %error,
+                room = %room_jid,
+                requester = %sender_bare,
+                "Failed to authorize group-DM MAM query"
+            );
+            return GroupDmArchiveVisibility::Error;
+        }
+    }
+
+    let actor = state.deps.app_state.db_pool.global_actor().clone();
+    if actor
+        .ask(crate::db::actor::DbExecute {
+            sql: "CREATE TABLE IF NOT EXISTS group_dm_archive_boundaries (room_jid TEXT NOT NULL, member_jid TEXT NOT NULL, visible_after TEXT NULL, updated_at TEXT NOT NULL, PRIMARY KEY (room_jid, member_jid))".to_string(),
+            params: vec![],
+        })
+        .await
+        .is_err()
+    {
+        return GroupDmArchiveVisibility::Error;
+    }
+    let row = match actor
+        .ask(crate::db::actor::DbQueryOne {
+            sql: "SELECT visible_after FROM group_dm_archive_boundaries WHERE room_jid = ? AND member_jid = ?".to_string(),
+            params: vec![room_jid.to_string().into(), sender_bare.to_string().into()],
+        })
+        .await
+    {
+        Ok(Some(row)) => row,
+        Ok(None) => return GroupDmArchiveVisibility::Full,
+        Err(error) => {
+            warn!(
+                error = %error,
+                room = %room_jid,
+                requester = %sender_bare,
+                "Failed to load group-DM archive boundary"
+            );
+            return GroupDmArchiveVisibility::Error;
+        }
+    };
+    match row.first() {
+        Some(crate::db::Value::Text(value)) => chrono::DateTime::parse_from_rfc3339(value)
+            .map(|dt| GroupDmArchiveVisibility::Restricted(dt.with_timezone(&chrono::Utc)))
+            .unwrap_or(GroupDmArchiveVisibility::Error),
+        Some(value) if value.is_null() => GroupDmArchiveVisibility::Full,
+        _ => GroupDmArchiveVisibility::Error,
+    }
 }
 
 /// Handle the XEP-0430 `<inbox xmlns='urn:xmpp:inbox:1'/>` IQ-get

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -5,7 +5,8 @@ use waddle_xmpp::{
     muc::room_actor::{ChangeAffiliation, GetAdminContext},
     muc::room_registry_actor::GetRoom,
     parser::stanza_to_string,
-    protocol::handlers::errors::bad_request_reply,
+    pending_delivery::{InsertOutcome, PendingPayload, PendingRow, PendingRowId},
+    protocol::handlers::errors::{bad_request_reply, message_error_reply},
     protocol::{frame::InboundFrame, InboundEvent, XmppStateMachine},
     xep::{
         add_reference, build_file_sharing_element, build_link_metadata_element,
@@ -20,6 +21,7 @@ use waddle_xmpp::{
 use waddle_xmpp_core::first_eligible_https_url_text;
 #[cfg(test)]
 use waddle_xmpp_core::PreviewImageMediaType;
+use xmpp_parsers::stanza_error::{DefinedCondition, ErrorType, StanzaError};
 
 use super::super::{
     interpret_loop::build_interpret_deps, replay::drive_interpret_loop, WebSocketState,
@@ -179,6 +181,7 @@ async fn handle_group_dm_mediated_invite(
         return Some(vec![error_reply(
             incoming,
             bound_jid,
+            GroupDmInviteError::ItemNotFound,
             "Requested room not found.",
         )]);
     };
@@ -191,6 +194,7 @@ async fn handle_group_dm_mediated_invite(
         return Some(vec![error_reply(
             incoming,
             bound_jid,
+            GroupDmInviteError::InternalServerError,
             "Internal server error.",
         )]);
     };
@@ -198,6 +202,7 @@ async fn handle_group_dm_mediated_invite(
         return Some(vec![error_reply(
             incoming,
             bound_jid,
+            GroupDmInviteError::Forbidden,
             "Only group-DM members may invite people.",
         )]);
     }
@@ -226,6 +231,7 @@ async fn handle_group_dm_mediated_invite(
         return Some(vec![error_reply(
             incoming,
             bound_jid,
+            GroupDmInviteError::NotAuthorized,
             "Authentication required.",
         )]);
     };
@@ -240,6 +246,7 @@ async fn handle_group_dm_mediated_invite(
         return Some(vec![error_reply(
             incoming,
             bound_jid,
+            GroupDmInviteError::ItemNotFound,
             "Requested invitee not found.",
         )]);
     }
@@ -254,6 +261,7 @@ async fn handle_group_dm_mediated_invite(
         return Some(vec![error_reply(
             incoming,
             bound_jid,
+            GroupDmInviteError::InternalServerError,
             "Internal server error.",
         )]);
     }
@@ -279,6 +287,7 @@ async fn handle_group_dm_mediated_invite(
         return Some(vec![error_reply(
             incoming,
             bound_jid,
+            GroupDmInviteError::InternalServerError,
             "Internal server error.",
         )]);
     }
@@ -300,6 +309,7 @@ async fn handle_group_dm_mediated_invite(
         return Some(vec![error_reply(
             incoming,
             bound_jid,
+            GroupDmInviteError::InternalServerError,
             "Internal server error.",
         )]);
     }
@@ -317,16 +327,94 @@ async fn handle_group_dm_mediated_invite(
         .protocol
         .connection_registry
         .get_resources_for_user(&invitee);
-    for resource in resources {
-        let _ = state
-            .deps
-            .protocol
-            .connection_registry
-            .send_to(&resource, Stanza::Message(invite.clone()))
-            .await;
+    if resources.is_empty() {
+        if let Err(error) = queue_offline_group_dm_invite(state, &invitee, &invite).await {
+            warn!(
+                invitee = %invitee,
+                error = %error,
+                "Failed to queue offline group-DM invite; rolling back member grant"
+            );
+            rollback_group_dm_invite_grant(state, room_actor, &channel_id, &room_jid, &invitee)
+                .await;
+            let error_kind = match error {
+                OfflineGroupDmInviteError::QuotaExceeded => GroupDmInviteError::ServiceUnavailable,
+                OfflineGroupDmInviteError::Storage(_) => GroupDmInviteError::InternalServerError,
+            };
+            return Some(vec![error_reply(
+                incoming,
+                bound_jid,
+                error_kind,
+                "Internal server error.",
+            )]);
+        }
+    } else {
+        for resource in resources {
+            let _ = state
+                .deps
+                .protocol
+                .connection_registry
+                .send_to(&resource, Stanza::Message(invite.clone()))
+                .await;
+        }
     }
 
     Some(vec![])
+}
+
+#[derive(Debug, thiserror::Error)]
+enum OfflineGroupDmInviteError {
+    #[error("pending_delivery quota exceeded")]
+    QuotaExceeded,
+    #[error("{0}")]
+    Storage(String),
+}
+
+async fn queue_offline_group_dm_invite(
+    state: &WebSocketState,
+    invitee: &jid::BareJid,
+    invite: &xmpp_parsers::message::Message,
+) -> Result<(), OfflineGroupDmInviteError> {
+    let row = PendingRow {
+        id: PendingRowId::fresh(),
+        recipient: invitee.clone(),
+        original_receipt_at: chrono::Utc::now(),
+        payload: PendingPayload::Transient(Box::new(invite.clone())),
+        flushed_in_session: None,
+        outbound_sequence: None,
+    };
+    match state
+        .deps
+        .protocol
+        .pending_delivery_storage
+        .insert(row)
+        .await
+    {
+        Ok(InsertOutcome::Inserted) => Ok(()),
+        Ok(InsertOutcome::QuotaExceeded) => Err(OfflineGroupDmInviteError::QuotaExceeded),
+        Err(error) => Err(OfflineGroupDmInviteError::Storage(error.to_string())),
+    }
+}
+
+async fn rollback_group_dm_invite_grant(
+    state: &WebSocketState,
+    room_actor: kameo::actor::ActorRef<waddle_xmpp::muc::room_actor::RoomActor>,
+    channel_id: &str,
+    room_jid: &jid::BareJid,
+    invitee: &jid::BareJid,
+) {
+    let _ = room_actor
+        .ask(ChangeAffiliation {
+            jid: invitee.clone(),
+            affiliation: waddle_xmpp::Affiliation::None,
+        })
+        .await;
+    let _ = delete_group_dm_archive_boundary(state, room_jid, invitee).await;
+    crate::admin::channels::rollback_group_dm_member_tuple(
+        &state.deps.app_state,
+        channel_id,
+        invitee,
+    )
+    .await;
 }
 
 async fn record_group_dm_archive_boundary(
@@ -336,13 +424,6 @@ async fn record_group_dm_archive_boundary(
     visible_after: Option<&str>,
 ) -> Result<(), String> {
     let actor = state.deps.app_state.db_pool.global_actor().clone();
-    actor
-        .ask(crate::db::actor::DbExecute {
-            sql: "CREATE TABLE IF NOT EXISTS group_dm_archive_boundaries (room_jid TEXT NOT NULL, member_jid TEXT NOT NULL, visible_after TEXT NULL, updated_at TEXT NOT NULL, PRIMARY KEY (room_jid, member_jid))".to_string(),
-            params: vec![],
-        })
-        .await
-        .map_err(|error| error.to_string())?;
     actor
         .ask(crate::db::actor::DbExecute {
             sql: "INSERT INTO group_dm_archive_boundaries (room_jid, member_jid, visible_after, updated_at) VALUES (?, ?, ?, ?) ON CONFLICT(room_jid, member_jid) DO UPDATE SET visible_after = excluded.visible_after, updated_at = excluded.updated_at".to_string(),
@@ -417,14 +498,37 @@ fn build_server_mediated_invite_payload(
         .build()
 }
 
+#[derive(Clone, Copy)]
+enum GroupDmInviteError {
+    NotAuthorized,
+    Forbidden,
+    ItemNotFound,
+    InternalServerError,
+    ServiceUnavailable,
+}
+
+impl GroupDmInviteError {
+    fn stanza_error(self, text: &str) -> StanzaError {
+        let (error_type, condition) = match self {
+            Self::NotAuthorized => (ErrorType::Auth, DefinedCondition::NotAuthorized),
+            Self::Forbidden => (ErrorType::Auth, DefinedCondition::Forbidden),
+            Self::ItemNotFound => (ErrorType::Cancel, DefinedCondition::ItemNotFound),
+            Self::InternalServerError => (ErrorType::Wait, DefinedCondition::InternalServerError),
+            Self::ServiceUnavailable => (ErrorType::Cancel, DefinedCondition::ServiceUnavailable),
+        };
+        StanzaError::new(error_type, condition, "en", text)
+    }
+}
+
 fn error_reply(
     incoming: &xmpp_parsers::message::Message,
     bound_jid: &jid::FullJid,
+    kind: GroupDmInviteError,
     text: &str,
 ) -> String {
     let mut stamped = incoming.clone();
     stamped.from = Some(jid::Jid::from(bound_jid.clone()));
-    stanza_to_string(bad_request_reply(&stamped, text)).unwrap_or_default()
+    stanza_to_string(message_error_reply(&stamped, kind.stanza_error(text))).unwrap_or_default()
 }
 
 fn strip_client_authored_delay(message: &mut xmpp_parsers::message::Message) {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -2,6 +2,8 @@ use std::borrow::Cow;
 
 use tracing::warn;
 use waddle_xmpp::{
+    muc::room_actor::{ChangeAffiliation, GetAdminContext},
+    muc::room_registry_actor::GetRoom,
     parser::stanza_to_string,
     protocol::handlers::errors::bad_request_reply,
     protocol::{frame::InboundFrame, InboundEvent, XmppStateMachine},
@@ -87,6 +89,12 @@ pub async fn handle_message(
         &state.deps.link_preview,
     );
 
+    if let Some(frames) =
+        handle_group_dm_mediated_invite(&incoming, state, &bound_jid, authenticated_session).await
+    {
+        return frames;
+    }
+
     if incoming.type_ != xmpp_parsers::message::MessageType::Error
         && message_has_inbox_payload(&incoming)
     {
@@ -129,6 +137,294 @@ pub async fn handle_message(
     let deps = build_interpret_deps(state, authenticated_session);
     let (frames, _close) = drive_interpret_loop(events, sm, &deps).await;
     frames
+}
+
+async fn handle_group_dm_mediated_invite(
+    incoming: &xmpp_parsers::message::Message,
+    state: &WebSocketState,
+    bound_jid: &jid::FullJid,
+    authenticated_session: Option<&Session>,
+) -> Option<Vec<String>> {
+    if incoming.type_ != xmpp_parsers::message::MessageType::Normal {
+        return None;
+    }
+    let room_jid = incoming.to.as_ref()?.to_bare();
+    if room_jid.domain().as_str() != state.deps.service_domains.muc {
+        return None;
+    }
+
+    let (invitee, inbound_invite) = mediated_invitee(incoming)?;
+    let channel_id = waddle_xmpp::parse_managed_room_jid(&room_jid)?;
+    let channel = crate::server::xmpp_state::get_xmpp_channel(
+        state.deps.app_state.db_pool.global_actor().clone(),
+        &channel_id,
+    )
+    .await
+    .ok()
+    .flatten()?;
+    if channel.channel_type != waddle_xmpp::admin::CHANNEL_TYPE_GROUP_DM {
+        return None;
+    }
+    let Some(room_actor) = state
+        .deps
+        .protocol
+        .room_registry
+        .ask(GetRoom {
+            room_jid: room_jid.clone(),
+        })
+        .await
+        .ok()
+        .flatten()
+    else {
+        return Some(vec![error_reply(
+            incoming,
+            bound_jid,
+            "Requested room not found.",
+        )]);
+    };
+    let Ok(context) = room_actor
+        .ask(GetAdminContext {
+            sender_jid: bound_jid.clone(),
+        })
+        .await
+    else {
+        return Some(vec![error_reply(
+            incoming,
+            bound_jid,
+            "Internal server error.",
+        )]);
+    };
+    if context.affiliation < waddle_xmpp::Affiliation::Member {
+        return Some(vec![error_reply(
+            incoming,
+            bound_jid,
+            "Only group-DM members may invite people.",
+        )]);
+    }
+    let invitee_blocklist = match state
+        .deps
+        .protocol
+        .blocking_storage
+        .list_blocked_jid_entries(&invitee)
+        .await
+    {
+        Ok(entries) => waddle_xmpp::protocol::Blocklist::new(entries),
+        Err(error) => {
+            warn!(
+                invitee = %invitee,
+                error = %error,
+                "Suppressing group-DM invite because blocklist lookup failed"
+            );
+            return Some(vec![]);
+        }
+    };
+    if invitee_blocklist.contains_jid(&jid::Jid::from(bound_jid.clone())) {
+        return Some(vec![]);
+    }
+
+    let Some(_session) = authenticated_session else {
+        return Some(vec![error_reply(
+            incoming,
+            bound_jid,
+            "Authentication required.",
+        )]);
+    };
+    if crate::admin::channels::validate_group_dm_invitee(
+        &state.deps.app_state,
+        &bound_jid.to_bare(),
+        &invitee,
+    )
+    .await
+    .is_err()
+    {
+        return Some(vec![error_reply(
+            incoming,
+            bound_jid,
+            "Requested invitee not found.",
+        )]);
+    }
+    if crate::admin::channels::persist_group_dm_member_tuple(
+        &state.deps.app_state,
+        &channel_id,
+        &invitee,
+    )
+    .await
+    .is_err()
+    {
+        return Some(vec![error_reply(
+            incoming,
+            bound_jid,
+            "Internal server error.",
+        )]);
+    }
+    let access =
+        waddle_xmpp::xep::xep_waddle_group_dm::history_access_from_mediated_invite(&inbound_invite)
+            .unwrap_or(waddle_xmpp::xep::xep_waddle_group_dm::GroupDmHistoryAccess::FromJoin);
+    let visible_after = match access {
+        waddle_xmpp::xep::xep_waddle_group_dm::GroupDmHistoryAccess::Full => None,
+        waddle_xmpp::xep::xep_waddle_group_dm::GroupDmHistoryAccess::FromJoin => {
+            Some(chrono::Utc::now().to_rfc3339())
+        }
+    };
+    if record_group_dm_archive_boundary(state, &room_jid, &invitee, visible_after.as_deref())
+        .await
+        .is_err()
+    {
+        crate::admin::channels::rollback_group_dm_member_tuple(
+            &state.deps.app_state,
+            &channel_id,
+            &invitee,
+        )
+        .await;
+        return Some(vec![error_reply(
+            incoming,
+            bound_jid,
+            "Internal server error.",
+        )]);
+    }
+    if room_actor
+        .ask(ChangeAffiliation {
+            jid: invitee.clone(),
+            affiliation: waddle_xmpp::Affiliation::Member,
+        })
+        .await
+        .is_err()
+    {
+        let _ = delete_group_dm_archive_boundary(state, &room_jid, &invitee).await;
+        crate::admin::channels::rollback_group_dm_member_tuple(
+            &state.deps.app_state,
+            &channel_id,
+            &invitee,
+        )
+        .await;
+        return Some(vec![error_reply(
+            incoming,
+            bound_jid,
+            "Internal server error.",
+        )]);
+    }
+
+    let mut invite = incoming.clone();
+    invite.from = Some(jid::Jid::from(room_jid.clone()));
+    invite.to = Some(jid::Jid::from(invitee.clone()));
+    invite.payloads = vec![build_server_mediated_invite_payload(
+        &bound_jid.to_bare(),
+        &invitee,
+        &inbound_invite,
+    )];
+    let resources = state
+        .deps
+        .protocol
+        .connection_registry
+        .get_resources_for_user(&invitee);
+    for resource in resources {
+        let _ = state
+            .deps
+            .protocol
+            .connection_registry
+            .send_to(&resource, Stanza::Message(invite.clone()))
+            .await;
+    }
+
+    Some(vec![])
+}
+
+async fn record_group_dm_archive_boundary(
+    state: &WebSocketState,
+    room_jid: &jid::BareJid,
+    member_jid: &jid::BareJid,
+    visible_after: Option<&str>,
+) -> Result<(), String> {
+    let actor = state.deps.app_state.db_pool.global_actor().clone();
+    actor
+        .ask(crate::db::actor::DbExecute {
+            sql: "CREATE TABLE IF NOT EXISTS group_dm_archive_boundaries (room_jid TEXT NOT NULL, member_jid TEXT NOT NULL, visible_after TEXT NULL, updated_at TEXT NOT NULL, PRIMARY KEY (room_jid, member_jid))".to_string(),
+            params: vec![],
+        })
+        .await
+        .map_err(|error| error.to_string())?;
+    actor
+        .ask(crate::db::actor::DbExecute {
+            sql: "INSERT INTO group_dm_archive_boundaries (room_jid, member_jid, visible_after, updated_at) VALUES (?, ?, ?, ?) ON CONFLICT(room_jid, member_jid) DO UPDATE SET visible_after = excluded.visible_after, updated_at = excluded.updated_at".to_string(),
+            params: vec![
+                room_jid.to_string().into(),
+                member_jid.to_string().into(),
+                visible_after.map(str::to_string).into(),
+                chrono::Utc::now().to_rfc3339().into(),
+            ],
+        })
+        .await
+        .map_err(|error| error.to_string())?;
+    Ok(())
+}
+
+async fn delete_group_dm_archive_boundary(
+    state: &WebSocketState,
+    room_jid: &jid::BareJid,
+    member_jid: &jid::BareJid,
+) -> Result<(), String> {
+    let actor = state.deps.app_state.db_pool.global_actor().clone();
+    actor
+        .ask(crate::db::actor::DbExecute {
+            sql: "DELETE FROM group_dm_archive_boundaries WHERE room_jid = ? AND member_jid = ?"
+                .to_string(),
+            params: vec![room_jid.to_string().into(), member_jid.to_string().into()],
+        })
+        .await
+        .map_err(|error| error.to_string())?;
+    Ok(())
+}
+
+fn mediated_invitee(
+    message: &xmpp_parsers::message::Message,
+) -> Option<(jid::BareJid, minidom::Element)> {
+    let x = message
+        .payloads
+        .iter()
+        .find(|payload| payload.is("x", waddle_xmpp::muc::presence::NS_MUC_USER))?;
+    let invite = x.get_child("invite", waddle_xmpp::muc::presence::NS_MUC_USER)?;
+    let to = invite.attr("to")?.parse::<jid::BareJid>().ok()?;
+    Some((to, invite.clone()))
+}
+
+fn build_server_mediated_invite_payload(
+    inviter: &jid::BareJid,
+    invitee: &jid::BareJid,
+    inbound_invite: &minidom::Element,
+) -> minidom::Element {
+    let mut invite = minidom::Element::builder("invite", waddle_xmpp::muc::presence::NS_MUC_USER)
+        .attr(
+            minidom::rxml::xml_ncname!("from").to_owned(),
+            inviter.to_string(),
+        )
+        .attr(
+            minidom::rxml::xml_ncname!("to").to_owned(),
+            invitee.to_string(),
+        );
+    if let Some(reason) =
+        inbound_invite.get_child("reason", waddle_xmpp::muc::presence::NS_MUC_USER)
+    {
+        invite = invite.append(reason.clone());
+    }
+    if let Some(history_access) = inbound_invite.get_child(
+        "history-access",
+        waddle_xmpp::xep::xep_waddle_group_dm::NS_GROUP_DM,
+    ) {
+        invite = invite.append(history_access.clone());
+    }
+    minidom::Element::builder("x", waddle_xmpp::muc::presence::NS_MUC_USER)
+        .append(invite.build())
+        .build()
+}
+
+fn error_reply(
+    incoming: &xmpp_parsers::message::Message,
+    bound_jid: &jid::FullJid,
+    text: &str,
+) -> String {
+    let mut stamped = incoming.clone();
+    stamped.from = Some(jid::Jid::from(bound_jid.clone()));
+    stanza_to_string(bad_request_reply(&stamped, text)).unwrap_or_default()
 }
 
 fn strip_client_authored_delay(message: &mut xmpp_parsers::message::Message) {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, collections::BTreeMap};
 
 use tracing::warn;
 use waddle_xmpp::{
@@ -28,6 +28,7 @@ use super::super::{
 };
 use crate::auth::Session;
 use crate::config::LinkPreviewConfig;
+use crate::db::ValueExt;
 use crate::server::routes::websocket::handlers::iq::link_preview_player_embed::is_sealed_player_embed_allowed;
 use crate::server::routes::websocket::link_preview_telemetry::{
     record_link_preview_event, LinkPreviewTelemetryEvent,
@@ -235,39 +236,56 @@ async fn handle_group_dm_mediated_invite(
             "Authentication required.",
         )]);
     };
-    if crate::admin::channels::validate_group_dm_invitee(
+    if let Err(error) = crate::admin::channels::validate_group_dm_invitee(
         &state.deps.app_state,
         &bound_jid.to_bare(),
         &invitee,
     )
     .await
-    .is_err()
     {
-        return Some(vec![error_reply(
-            incoming,
-            bound_jid,
-            GroupDmInviteError::ItemNotFound,
-            "Requested invitee not found.",
-        )]);
+        return Some(vec![xmpp_error_reply(incoming, bound_jid, error)]);
     }
-    if crate::admin::channels::persist_group_dm_member_tuple(
-        &state.deps.app_state,
-        &channel_id,
-        &invitee,
-    )
-    .await
-    .is_err()
-    {
+    let Ok(invitee_context) = room_actor
+        .ask(GetAdminContext {
+            sender_jid: invitee
+                .clone()
+                .with_resource_str("group-dm-invite-check")
+                .expect("static resource is valid"),
+        })
+        .await
+    else {
         return Some(vec![error_reply(
             incoming,
             bound_jid,
             GroupDmInviteError::InternalServerError,
             "Internal server error.",
         )]);
+    };
+    if invitee_context.affiliation >= waddle_xmpp::Affiliation::Member {
+        return Some(vec![error_reply(
+            incoming,
+            bound_jid,
+            GroupDmInviteError::Conflict,
+            "Invitee is already a group-DM member.",
+        )]);
     }
-    let access =
+
+    let requested_access =
         waddle_xmpp::xep::xep_waddle_group_dm::history_access_from_mediated_invite(&inbound_invite)
             .unwrap_or(waddle_xmpp::xep::xep_waddle_group_dm::GroupDmHistoryAccess::FromJoin);
+    let inviter_has_full_history =
+        group_dm_archive_boundary(state, &room_jid, &bound_jid.to_bare())
+            .await
+            .map(|boundary| boundary.is_none())
+            .unwrap_or(false);
+    let access = match requested_access {
+        waddle_xmpp::xep::xep_waddle_group_dm::GroupDmHistoryAccess::Full
+            if inviter_has_full_history =>
+        {
+            waddle_xmpp::xep::xep_waddle_group_dm::GroupDmHistoryAccess::Full
+        }
+        _ => waddle_xmpp::xep::xep_waddle_group_dm::GroupDmHistoryAccess::FromJoin,
+    };
     let visible_after = match access {
         waddle_xmpp::xep::xep_waddle_group_dm::GroupDmHistoryAccess::Full => None,
         waddle_xmpp::xep::xep_waddle_group_dm::GroupDmHistoryAccess::FromJoin => {
@@ -278,12 +296,22 @@ async fn handle_group_dm_mediated_invite(
         .await
         .is_err()
     {
-        crate::admin::channels::rollback_group_dm_member_tuple(
-            &state.deps.app_state,
-            &channel_id,
-            &invitee,
-        )
-        .await;
+        return Some(vec![error_reply(
+            incoming,
+            bound_jid,
+            GroupDmInviteError::InternalServerError,
+            "Internal server error.",
+        )]);
+    }
+    if crate::admin::channels::persist_group_dm_member_tuple(
+        &state.deps.app_state,
+        &channel_id,
+        &invitee,
+    )
+    .await
+    .is_err()
+    {
+        let _ = delete_group_dm_archive_boundary(state, &room_jid, &invitee).await;
         return Some(vec![error_reply(
             incoming,
             bound_jid,
@@ -321,6 +349,7 @@ async fn handle_group_dm_mediated_invite(
         &bound_jid.to_bare(),
         &invitee,
         &inbound_invite,
+        access,
     )];
     let resources = state
         .deps
@@ -439,6 +468,35 @@ async fn record_group_dm_archive_boundary(
     Ok(())
 }
 
+async fn group_dm_archive_boundary(
+    state: &WebSocketState,
+    room_jid: &jid::BareJid,
+    member_jid: &jid::BareJid,
+) -> Result<Option<chrono::DateTime<chrono::Utc>>, String> {
+    let actor = state.deps.app_state.db_pool.global_actor().clone();
+    let row = actor
+        .ask(crate::db::actor::DbQueryOne {
+            sql: "SELECT visible_after FROM group_dm_archive_boundaries WHERE room_jid = ? AND member_jid = ?"
+                .to_string(),
+            params: vec![room_jid.to_string().into(), member_jid.to_string().into()],
+        })
+        .await
+        .map_err(|error| error.to_string())?;
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    let visible_after = crate::db::row_value(&row, 0)
+        .map_err(|error| error.to_string())?
+        .as_optional_string()
+        .map_err(|error| error.to_string())?;
+    match visible_after {
+        Some(value) => chrono::DateTime::parse_from_rfc3339(&value)
+            .map(|dt| Some(dt.with_timezone(&chrono::Utc)))
+            .map_err(|error| error.to_string()),
+        None => Ok(None),
+    }
+}
+
 async fn delete_group_dm_archive_boundary(
     state: &WebSocketState,
     room_jid: &jid::BareJid,
@@ -472,6 +530,7 @@ fn build_server_mediated_invite_payload(
     inviter: &jid::BareJid,
     invitee: &jid::BareJid,
     inbound_invite: &minidom::Element,
+    access: waddle_xmpp::xep::xep_waddle_group_dm::GroupDmHistoryAccess,
 ) -> minidom::Element {
     let mut invite = minidom::Element::builder("invite", waddle_xmpp::muc::presence::NS_MUC_USER)
         .attr(
@@ -487,12 +546,9 @@ fn build_server_mediated_invite_payload(
     {
         invite = invite.append(reason.clone());
     }
-    if let Some(history_access) = inbound_invite.get_child(
-        "history-access",
-        waddle_xmpp::xep::xep_waddle_group_dm::NS_GROUP_DM,
-    ) {
-        invite = invite.append(history_access.clone());
-    }
+    invite = invite.append(waddle_xmpp::xep::xep_waddle_group_dm::build_history_access(
+        access,
+    ));
     minidom::Element::builder("x", waddle_xmpp::muc::presence::NS_MUC_USER)
         .append(invite.build())
         .build()
@@ -502,6 +558,7 @@ fn build_server_mediated_invite_payload(
 enum GroupDmInviteError {
     NotAuthorized,
     Forbidden,
+    Conflict,
     ItemNotFound,
     InternalServerError,
     ServiceUnavailable,
@@ -512,6 +569,7 @@ impl GroupDmInviteError {
         let (error_type, condition) = match self {
             Self::NotAuthorized => (ErrorType::Auth, DefinedCondition::NotAuthorized),
             Self::Forbidden => (ErrorType::Auth, DefinedCondition::Forbidden),
+            Self::Conflict => (ErrorType::Cancel, DefinedCondition::Conflict),
             Self::ItemNotFound => (ErrorType::Cancel, DefinedCondition::ItemNotFound),
             Self::InternalServerError => (ErrorType::Wait, DefinedCondition::InternalServerError),
             Self::ServiceUnavailable => (ErrorType::Cancel, DefinedCondition::ServiceUnavailable),
@@ -529,6 +587,51 @@ fn error_reply(
     let mut stamped = incoming.clone();
     stamped.from = Some(jid::Jid::from(bound_jid.clone()));
     stanza_to_string(message_error_reply(&stamped, kind.stanza_error(text))).unwrap_or_default()
+}
+
+fn xmpp_error_reply(
+    incoming: &xmpp_parsers::message::Message,
+    bound_jid: &jid::FullJid,
+    error: waddle_xmpp::XmppError,
+) -> String {
+    let stanza_error = match error {
+        waddle_xmpp::XmppError::Stanza {
+            condition,
+            error_type,
+            text,
+        } => stanza_error_from_waddle_parts(error_type, condition, text),
+        other => {
+            warn!(
+                error = %other,
+                "group-DM invite validation failed with non-stanza error"
+            );
+            stanza_error_from_waddle_parts(
+                waddle_xmpp::StanzaErrorType::Wait,
+                waddle_xmpp::StanzaErrorCondition::InternalServerError,
+                Some("Internal server error.".to_string()),
+            )
+        }
+    };
+    let mut stamped = incoming.clone();
+    stamped.from = Some(jid::Jid::from(bound_jid.clone()));
+    stanza_to_string(message_error_reply(&stamped, stanza_error)).unwrap_or_default()
+}
+
+fn stanza_error_from_waddle_parts(
+    error_type: waddle_xmpp::StanzaErrorType,
+    condition: waddle_xmpp::StanzaErrorCondition,
+    text: Option<String>,
+) -> StanzaError {
+    match text {
+        Some(text) => StanzaError::new(error_type.to_xmpp(), condition.to_xmpp(), "en", text),
+        None => StanzaError {
+            type_: error_type.to_xmpp(),
+            by: None,
+            defined_condition: condition.to_xmpp(),
+            texts: BTreeMap::new(),
+            other: None,
+        },
+    }
 }
 
 fn strip_client_authored_delay(message: &mut xmpp_parsers::message::Message) {

--- a/server/crates/waddle-server/tests/group_dm_ws.rs
+++ b/server/crates/waddle-server/tests/group_dm_ws.rs
@@ -105,7 +105,9 @@ async fn join_room(client: &mut WsXmppClient, room_jid: &str, nick: &str) {
     client.send(&join).await.expect("send room join");
     client
         .recv_matching(|frame| {
-            frame.contains("<presence") && frame.contains(&format!("from='{room_jid}/{nick}'"))
+            frame.contains("<presence")
+                && (frame.contains(&format!("from='{room_jid}/{nick}'"))
+                    || frame.contains(&format!("from=\"{room_jid}/{nick}\"")))
         })
         .await
         .expect("self join presence");
@@ -392,6 +394,39 @@ async fn group_dm_member_invites_new_member_with_history_access_extension() {
             .any(|frame| frame.contains("pre-add visible to full")),
         "share-all add should expose pre-add room history via server MAM: {mam:?}"
     );
+
+    let reinvite = format!(
+        "<message xmlns='jabber:client' type='normal' to='{room_jid}' id='readd-charlie'>\
+            <x xmlns='{NS_MUC_USER}'>\
+                <invite to='charlie@localhost'/>\
+            </x>\
+         </message>"
+    );
+    bob.send(&reinvite)
+        .await
+        .expect("send duplicate mediated invite");
+    let duplicate_rejection = bob
+        .recv_matching(|frame| frame.contains("readd-charlie") && frame.contains("conflict"))
+        .await
+        .expect("duplicate invite rejection");
+    assert!(
+        is_error(&duplicate_rejection),
+        "duplicate invite must be rejected: {duplicate_rejection}"
+    );
+    assert_no_frame_matching_for(
+        &mut charlie,
+        Duration::from_millis(300),
+        |frame| frame.contains("readd-charlie"),
+        "duplicate invite must not be delivered to an existing member",
+    )
+    .await;
+
+    let mam = query_room_mam(&mut charlie, &room_jid, "mam-full-after-readd").await;
+    assert!(
+        mam.iter()
+            .any(|frame| frame.contains("pre-add visible to full")),
+        "duplicate invite must not overwrite an existing full-history boundary: {mam:?}"
+    );
 }
 
 #[tokio::test]
@@ -428,6 +463,48 @@ async fn group_dm_default_add_hides_pre_add_history_from_mam() {
     )
     .await;
 
+    let foreign_invite = format!(
+        "<message xmlns='jabber:client' type='normal' to='{room_jid}' id='foreign-add-charlie'>\
+            <x xmlns='{NS_MUC_USER}'>\
+                <invite to='charlie@example.org'/>\
+            </x>\
+         </message>"
+    );
+    bob.send(&foreign_invite)
+        .await
+        .expect("send invalid-domain mediated invite");
+    let foreign_rejection = bob
+        .recv_matching(|frame| {
+            frame.contains("foreign-add-charlie") && frame.contains("bad-request")
+        })
+        .await
+        .expect("invalid-domain invite rejection");
+    assert!(
+        is_error(&foreign_rejection) && !foreign_rejection.contains("item-not-found"),
+        "invitee validation must preserve typed stanza error: {foreign_rejection}"
+    );
+
+    let missing_invite = format!(
+        "<message xmlns='jabber:client' type='normal' to='{room_jid}' id='missing-add-mallory'>\
+            <x xmlns='{NS_MUC_USER}'>\
+                <invite to='mallory@localhost'/>\
+            </x>\
+         </message>"
+    );
+    bob.send(&missing_invite)
+        .await
+        .expect("send missing invitee mediated invite");
+    let missing_rejection = bob
+        .recv_matching(|frame| {
+            frame.contains("missing-add-mallory") && frame.contains("item-not-found")
+        })
+        .await
+        .expect("missing invitee rejection");
+    assert!(
+        is_error(&missing_rejection) && !missing_rejection.contains("bad-request"),
+        "missing local invitee must preserve item-not-found stanza error: {missing_rejection}"
+    );
+
     let invite = format!(
         "<message xmlns='jabber:client' type='normal' to='{room_jid}' id='default-add-charlie'>\
             <x xmlns='{NS_MUC_USER}'>\
@@ -438,16 +515,109 @@ async fn group_dm_default_add_hides_pre_add_history_from_mam() {
     bob.send(&invite)
         .await
         .expect("send default mediated invite");
-    charlie
+    let delivered = charlie
         .recv_matching(|frame| frame.contains("default-add-charlie"))
         .await
         .expect("charlie receives default invite");
+    assert!(
+        delivered.contains("mode='from-join'") || delivered.contains("mode=\"from-join\""),
+        "default invite must stamp the effective restricted access mode: {delivered}"
+    );
+    assert!(
+        !delivered.contains("mode='full'") && !delivered.contains("mode=\"full\""),
+        "default invite must not grant full-history payload: {delivered}"
+    );
 
     let mam = query_room_mam(&mut charlie, &room_jid, "mam-default-after-add").await;
     assert!(
         !mam.iter()
             .any(|frame| frame.contains("pre-add hidden by default")),
         "default add must hide pre-add room history server-side: {mam:?}"
+    );
+}
+
+#[tokio::test]
+async fn group_dm_restricted_member_cannot_grant_full_history() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start_with_extra_accounts(&[
+        ("alice", "alice-pass"),
+        ("bob", "bob-pass"),
+        ("charlie", "charlie-pass"),
+        ("dave", "dave-pass"),
+    ]);
+    let mut alice = user_client(&server, "alice", "alice-pass", "group-dm-escalate-alice").await;
+    let mut bob = user_client(&server, "bob", "bob-pass", "group-dm-escalate-bob").await;
+    let mut charlie = user_client(
+        &server,
+        "charlie",
+        "charlie-pass",
+        "group-dm-escalate-charlie",
+    )
+    .await;
+    let mut dave = user_client(&server, "dave", "dave-pass", "group-dm-escalate-dave").await;
+
+    let room_jid = create_group_dm(
+        &mut alice,
+        "group-dm-escalate-create",
+        "Alice, Bob",
+        &["alice@localhost", "bob@localhost"],
+    )
+    .await;
+    join_room(&mut alice, &room_jid, "alice").await;
+    send_groupchat(
+        &mut alice,
+        &room_jid,
+        "before-charlie-add",
+        "hidden from restricted chain",
+    )
+    .await;
+
+    let add_charlie = format!(
+        "<message xmlns='jabber:client' type='normal' to='{room_jid}' id='default-add-charlie-for-escalation'>\
+            <x xmlns='{NS_MUC_USER}'>\
+                <invite to='charlie@localhost'/>\
+            </x>\
+         </message>"
+    );
+    bob.send(&add_charlie)
+        .await
+        .expect("send default mediated invite");
+    charlie
+        .recv_matching(|frame| frame.contains("default-add-charlie-for-escalation"))
+        .await
+        .expect("charlie receives default invite");
+
+    let add_dave = format!(
+        "<message xmlns='jabber:client' type='normal' to='{room_jid}' id='restricted-full-add-dave'>\
+            <x xmlns='{NS_MUC_USER}'>\
+                <invite to='dave@localhost'>\
+                    <history-access xmlns='{FEATURE_GROUP_DM}' mode='full'/>\
+                </invite>\
+            </x>\
+         </message>"
+    );
+    charlie
+        .send(&add_dave)
+        .await
+        .expect("restricted member sends full invite");
+    let delivered = dave
+        .recv_matching(|frame| frame.contains("restricted-full-add-dave"))
+        .await
+        .expect("dave receives mediated invite");
+    assert!(
+        delivered.contains("mode='from-join'") || delivered.contains("mode=\"from-join\""),
+        "server must stamp the effective restricted access mode: {delivered}"
+    );
+    assert!(
+        !delivered.contains("mode='full'") && !delivered.contains("mode=\"full\""),
+        "restricted inviter must not grant full-history payload: {delivered}"
+    );
+
+    let mam = query_room_mam(&mut dave, &room_jid, "mam-restricted-chain").await;
+    assert!(
+        !mam.iter()
+            .any(|frame| frame.contains("hidden from restricted chain")),
+        "restricted inviter must not escalate MAM history access: {mam:?}"
     );
 }
 

--- a/server/crates/waddle-server/tests/group_dm_ws.rs
+++ b/server/crates/waddle-server/tests/group_dm_ws.rs
@@ -141,6 +141,31 @@ async fn query_room_mam(client: &mut WsXmppClient, room_jid: &str, id: &str) -> 
         .expect("MAM responses")
 }
 
+async fn assert_no_frame_matching_for<F>(
+    client: &mut WsXmppClient,
+    duration: Duration,
+    predicate: F,
+    description: &str,
+) where
+    F: Fn(&str) -> bool,
+{
+    let deadline = tokio::time::Instant::now() + duration;
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            return;
+        }
+        match client.recv_timeout(remaining).await {
+            Ok(frame) if predicate(&frame) => {
+                panic!("{description}: matched unexpected frame: {frame}");
+            }
+            Ok(_) => continue,
+            Err(error) if error == "Timeout waiting for message" => return,
+            Err(error) => panic!("{description}: receive failed: {error}"),
+        }
+    }
+}
+
 fn submit_form(node: &str, fields: Vec<Element>) -> Element {
     let mut form = Element::builder("x", NS_DATA)
         .attr(minidom::rxml::xml_ncname!("type").to_owned(), "submit")
@@ -427,6 +452,63 @@ async fn group_dm_default_add_hides_pre_add_history_from_mam() {
 }
 
 #[tokio::test]
+async fn group_dm_invite_to_offline_member_is_queued_for_next_presence() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start_with_extra_accounts(&[
+        ("alice", "alice-pass"),
+        ("bob", "bob-pass"),
+        ("charlie", "charlie-pass"),
+    ]);
+    let mut alice = user_client(&server, "alice", "alice-pass", "group-dm-offline-alice").await;
+    let mut bob = user_client(&server, "bob", "bob-pass", "group-dm-offline-bob").await;
+
+    let room_jid = create_group_dm(
+        &mut alice,
+        "group-dm-offline-create",
+        "Alice, Bob",
+        &["alice@localhost", "bob@localhost"],
+    )
+    .await;
+
+    let invite = format!(
+        "<message xmlns='jabber:client' type='normal' to='{room_jid}' id='offline-add-charlie'>\
+            <x xmlns='{NS_MUC_USER}'>\
+                <invite to='charlie@localhost'>\
+                    <history-access xmlns='{FEATURE_GROUP_DM}' mode='full'/>\
+                </invite>\
+            </x>\
+         </message>"
+    );
+    bob.send(&invite)
+        .await
+        .expect("send offline mediated invite");
+
+    let mut charlie = user_client(
+        &server,
+        "charlie",
+        "charlie-pass",
+        "group-dm-offline-charlie",
+    )
+    .await;
+    charlie
+        .send("<presence xmlns='jabber:client'/>")
+        .await
+        .expect("send initial presence");
+    let delivered = charlie
+        .recv_matching(|frame| frame.contains("offline-add-charlie") && frame.contains(&room_jid))
+        .await
+        .expect("queued mediated invite flushes when invitee comes online");
+    assert!(
+        delivered.contains("from='bob@localhost'") || delivered.contains("from=\"bob@localhost\""),
+        "queued invite must preserve trusted inviter stamp: {delivered}"
+    );
+    assert!(
+        delivered.contains(FEATURE_GROUP_DM) && delivered.contains("mode='full'"),
+        "queued invite must preserve history-access extension: {delivered}"
+    );
+}
+
+#[tokio::test]
 async fn group_dm_mam_rejects_non_member() {
     let _serial = TEST_SERIAL.lock().await;
     let server = TestServer::start_with_extra_accounts(&[
@@ -516,9 +598,11 @@ async fn group_dm_invite_from_blocked_member_is_suppressed() {
         .await
         .expect("send blocked mediated invite");
 
-    let maybe_invite = charlie.recv_timeout(Duration::from_millis(300)).await;
-    assert!(
-        !matches!(maybe_invite, Ok(ref frame) if frame.contains("blocked-add-charlie")),
-        "blocked inviter's mediated invite must not reach invitee: {maybe_invite:?}"
-    );
+    assert_no_frame_matching_for(
+        &mut charlie,
+        Duration::from_millis(300),
+        |frame| frame.contains("blocked-add-charlie"),
+        "blocked inviter's mediated invite must not reach invitee",
+    )
+    .await;
 }

--- a/server/crates/waddle-server/tests/group_dm_ws.rs
+++ b/server/crates/waddle-server/tests/group_dm_ws.rs
@@ -2,6 +2,8 @@
 
 mod ws_common;
 
+use std::time::Duration;
+
 use tokio::sync::Mutex;
 use ws_common::{TestServer, WsXmppClient};
 use xmpp_parsers::minidom::Element;
@@ -11,6 +13,7 @@ const NS_COMMANDS: &str = "http://jabber.org/protocol/commands";
 const NS_DATA: &str = "jabber:x:data";
 const NODE_GROUP_DM_CREATE: &str = "urn:waddle:group-dm:create:0";
 const FEATURE_GROUP_DM: &str = "urn:waddle:group-dm:0";
+const NS_MUC_USER: &str = "http://jabber.org/protocol/muc#user";
 
 static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
 
@@ -69,6 +72,73 @@ async fn disco_info(client: &mut WsXmppClient, to: &str, id: &str) -> String {
         .recv_matching(|frame| frame.contains("<iq") && frame_has_iq_id(frame, id))
         .await
         .expect("disco info response")
+}
+
+async fn create_group_dm(
+    client: &mut WsXmppClient,
+    id: &str,
+    name: &str,
+    members: &[&str],
+) -> String {
+    let resp = send_command(
+        client,
+        NODE_GROUP_DM_CREATE,
+        id,
+        submit_form(
+            NODE_GROUP_DM_CREATE,
+            vec![
+                text_field("name", name),
+                list_multi_field("member_jids", members),
+            ],
+        ),
+    )
+    .await;
+    assert!(
+        is_result(&resp),
+        "expected group-DM create result, got: {resp}"
+    );
+    extract_field(&resp, "room_jid").expect("room_jid in create response")
+}
+
+async fn join_room(client: &mut WsXmppClient, room_jid: &str, nick: &str) {
+    let join = format!("<presence xmlns='jabber:client' to='{room_jid}/{nick}'/>");
+    client.send(&join).await.expect("send room join");
+    client
+        .recv_matching(|frame| {
+            frame.contains("<presence") && frame.contains(&format!("from='{room_jid}/{nick}'"))
+        })
+        .await
+        .expect("self join presence");
+}
+
+async fn send_groupchat(client: &mut WsXmppClient, room_jid: &str, id: &str, body: &str) {
+    let message = format!(
+        "<message xmlns='jabber:client' type='groupchat' to='{room_jid}' id='{id}'>\
+            <body>{body}</body>\
+         </message>"
+    );
+    client.send(&message).await.expect("send groupchat");
+    client
+        .recv_matching(|frame| frame.contains(id) && frame.contains(body))
+        .await
+        .expect("groupchat echo");
+}
+
+async fn query_room_mam(client: &mut WsXmppClient, room_jid: &str, id: &str) -> Vec<String> {
+    let query = format!(
+        "<iq xmlns='jabber:client' type='set' to='{room_jid}' id='{id}'>\
+            <query xmlns='urn:xmpp:mam:2' queryid='{id}-q'>\
+                <x xmlns='jabber:x:data' type='submit'>\
+                    <field var='FORM_TYPE' type='hidden'><value>urn:xmpp:mam:2</value></field>\
+                </x>\
+            </query>\
+         </iq>"
+    );
+    client.send(&query).await.expect("send MAM query");
+    client
+        .recv_until(|frame| frame_has_iq_id(frame, id))
+        .await
+        .expect("MAM responses")
 }
 
 fn submit_form(node: &str, fields: Vec<Element>) -> Element {
@@ -214,4 +284,241 @@ async fn group_dm_create_provisions_hidden_members_only_room_with_disco_feature(
         "restarted group DM room must stay members-only: {disco}"
     );
     let _ = alice.close().await;
+}
+
+#[tokio::test]
+async fn group_dm_member_invites_new_member_with_history_access_extension() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start_with_extra_accounts(&[
+        ("alice", "alice-pass"),
+        ("bob", "bob-pass"),
+        ("charlie", "charlie-pass"),
+    ]);
+    let mut alice = user_client(&server, "alice", "alice-pass", "group-dm-add-alice").await;
+    let mut bob = user_client(&server, "bob", "bob-pass", "group-dm-add-bob").await;
+    let mut charlie = user_client(&server, "charlie", "charlie-pass", "group-dm-add-charlie").await;
+
+    let room_jid = create_group_dm(
+        &mut alice,
+        "group-dm-add-create",
+        "Alice, Bob",
+        &["alice@localhost", "bob@localhost"],
+    )
+    .await;
+    join_room(&mut alice, &room_jid, "alice").await;
+    send_groupchat(
+        &mut alice,
+        &room_jid,
+        "before-full-add",
+        "pre-add visible to full",
+    )
+    .await;
+
+    let invite = format!(
+        "<message xmlns='jabber:client' type='normal' to='{room_jid}' id='add-charlie'>\
+            <x xmlns='{NS_MUC_USER}'>\
+                <invite from='mallory@localhost' to='charlie@localhost'>\
+                    <history-access xmlns='{FEATURE_GROUP_DM}' mode='full'/>\
+                </invite>\
+            </x>\
+         </message>"
+    );
+    bob.send(&invite).await.expect("send mediated invite");
+
+    let delivered = charlie
+        .recv_matching(|frame| {
+            frame.contains("add-charlie")
+                && frame.contains(&room_jid)
+                && frame.contains("charlie@localhost")
+        })
+        .await
+        .expect("charlie receives mediated invite");
+    assert!(
+        delivered.contains(FEATURE_GROUP_DM) && delivered.contains("mode='full'"),
+        "invite must carry Waddle group-DM history-access extension: {delivered}"
+    );
+    assert!(
+        delivered.contains("from='bob@localhost'") || delivered.contains("from=\"bob@localhost\""),
+        "server must stamp the actual inviter on mediated invite: {delivered}"
+    );
+    assert!(
+        !delivered.contains("mallory@localhost"),
+        "server must not reflect client-spoofed muc#user invite fields: {delivered}"
+    );
+
+    let join = format!("<presence xmlns='jabber:client' to='{room_jid}/charlie'/>");
+    charlie.send(&join).await.expect("charlie joins added room");
+    let joined = charlie
+        .recv_matching(|frame| {
+            frame.contains("<presence")
+                && frame.contains(&format!("from='{room_jid}/charlie'"))
+                && frame.contains("affiliation='member'")
+        })
+        .await
+        .expect("charlie member join presence");
+    assert!(
+        !is_error(&joined),
+        "new invitee should be auto-added and allowed to join members-only room: {joined}"
+    );
+
+    let mam = query_room_mam(&mut charlie, &room_jid, "mam-full-after-add").await;
+    assert!(
+        mam.iter()
+            .any(|frame| frame.contains("pre-add visible to full")),
+        "share-all add should expose pre-add room history via server MAM: {mam:?}"
+    );
+}
+
+#[tokio::test]
+async fn group_dm_default_add_hides_pre_add_history_from_mam() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start_with_extra_accounts(&[
+        ("alice", "alice-pass"),
+        ("bob", "bob-pass"),
+        ("charlie", "charlie-pass"),
+    ]);
+    let mut alice = user_client(&server, "alice", "alice-pass", "group-dm-history-alice").await;
+    let mut bob = user_client(&server, "bob", "bob-pass", "group-dm-history-bob").await;
+    let mut charlie = user_client(
+        &server,
+        "charlie",
+        "charlie-pass",
+        "group-dm-history-charlie",
+    )
+    .await;
+
+    let room_jid = create_group_dm(
+        &mut alice,
+        "group-dm-history-create",
+        "Alice, Bob",
+        &["alice@localhost", "bob@localhost"],
+    )
+    .await;
+    join_room(&mut alice, &room_jid, "alice").await;
+    send_groupchat(
+        &mut alice,
+        &room_jid,
+        "before-default-add",
+        "pre-add hidden by default",
+    )
+    .await;
+
+    let invite = format!(
+        "<message xmlns='jabber:client' type='normal' to='{room_jid}' id='default-add-charlie'>\
+            <x xmlns='{NS_MUC_USER}'>\
+                <invite to='charlie@localhost'/>\
+            </x>\
+         </message>"
+    );
+    bob.send(&invite)
+        .await
+        .expect("send default mediated invite");
+    charlie
+        .recv_matching(|frame| frame.contains("default-add-charlie"))
+        .await
+        .expect("charlie receives default invite");
+
+    let mam = query_room_mam(&mut charlie, &room_jid, "mam-default-after-add").await;
+    assert!(
+        !mam.iter()
+            .any(|frame| frame.contains("pre-add hidden by default")),
+        "default add must hide pre-add room history server-side: {mam:?}"
+    );
+}
+
+#[tokio::test]
+async fn group_dm_mam_rejects_non_member() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start_with_extra_accounts(&[
+        ("alice", "alice-pass"),
+        ("bob", "bob-pass"),
+        ("charlie", "charlie-pass"),
+    ]);
+    let mut alice = user_client(&server, "alice", "alice-pass", "group-dm-deny-alice").await;
+    let mut charlie =
+        user_client(&server, "charlie", "charlie-pass", "group-dm-deny-charlie").await;
+
+    let room_jid = create_group_dm(
+        &mut alice,
+        "group-dm-deny-create",
+        "Alice, Bob",
+        &["alice@localhost", "bob@localhost"],
+    )
+    .await;
+
+    let query = format!(
+        "<iq xmlns='jabber:client' type='set' to='{room_jid}' id='mam-deny-non-member'>\
+            <query xmlns='urn:xmpp:mam:2' queryid='mam-deny-non-member-q'>\
+                <x xmlns='jabber:x:data' type='submit'>\
+                    <field var='FORM_TYPE' type='hidden'><value>urn:xmpp:mam:2</value></field>\
+                </x>\
+            </query>\
+         </iq>"
+    );
+    charlie.send(&query).await.expect("send denied MAM query");
+    let denied = charlie
+        .recv_matching(|frame| frame_has_iq_id(frame, "mam-deny-non-member"))
+        .await
+        .expect("MAM denial");
+    assert!(
+        is_error(&denied) && denied.contains("forbidden"),
+        "non-member MAM query must be forbidden: {denied}"
+    );
+}
+
+#[tokio::test]
+async fn group_dm_invite_from_blocked_member_is_suppressed() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start_with_extra_accounts(&[
+        ("alice", "alice-pass"),
+        ("bob", "bob-pass"),
+        ("charlie", "charlie-pass"),
+    ]);
+    let mut alice = user_client(&server, "alice", "alice-pass", "group-dm-block-alice").await;
+    let mut bob = user_client(&server, "bob", "bob-pass", "group-dm-block-bob").await;
+    let mut charlie =
+        user_client(&server, "charlie", "charlie-pass", "group-dm-block-charlie").await;
+
+    let room_jid = create_group_dm(
+        &mut alice,
+        "group-dm-block-create",
+        "Alice, Bob",
+        &["alice@localhost", "bob@localhost"],
+    )
+    .await;
+
+    charlie
+        .send(
+            "<iq xmlns='jabber:client' type='set' id='charlie-blocks-bob'>\
+                <block xmlns='urn:xmpp:blocking'>\
+                    <item jid='bob@localhost'/>\
+                </block>\
+             </iq>",
+        )
+        .await
+        .expect("charlie blocks bob");
+    let block_result = charlie
+        .recv_matching(|frame| frame_has_iq_id(frame, "charlie-blocks-bob"))
+        .await
+        .expect("block result");
+    assert!(is_result(&block_result), "block failed: {block_result}");
+
+    let invite = format!(
+        "<message xmlns='jabber:client' type='normal' to='{room_jid}' id='blocked-add-charlie'>\
+            <x xmlns='{NS_MUC_USER}'>\
+                <invite to='charlie@localhost'>\
+                    <history-access xmlns='{FEATURE_GROUP_DM}' mode='full'/>\
+                </invite>\
+            </x>\
+         </message>"
+    );
+    bob.send(&invite)
+        .await
+        .expect("send blocked mediated invite");
+
+    let maybe_invite = charlie.recv_timeout(Duration::from_millis(300)).await;
+    assert!(
+        !matches!(maybe_invite, Ok(ref frame) if frame.contains("blocked-add-charlie")),
+        "blocked inviter's mediated invite must not reach invitee: {maybe_invite:?}"
+    );
 }

--- a/server/crates/waddle-xmpp/src/xep/mod.rs
+++ b/server/crates/waddle-xmpp/src/xep/mod.rs
@@ -203,6 +203,7 @@ pub mod xep_waddle_call_thread;
 pub mod xep_waddle_dm_bookmarks;
 pub mod xep_waddle_dnd;
 pub mod xep_waddle_forums;
+pub mod xep_waddle_group_dm;
 pub mod xep_waddle_link_preview;
 pub mod xep_waddle_livekit_transport;
 pub mod xep_waddle_pin;

--- a/server/crates/waddle-xmpp/src/xep/xep_waddle_group_dm.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep_waddle_group_dm.rs
@@ -1,0 +1,61 @@
+//! Waddle group-DM protocol extensions.
+//!
+//! Group DMs are XEP-0045 rooms classified by `urn:waddle:group-dm:0`.
+//! This module owns the Waddle-specific child that rides inside a
+//! XEP-0045 mediated `<invite/>` to describe how much history a newly
+//! added member may see.
+
+use minidom::Element;
+
+/// Group-DM room disco feature and invite-extension namespace.
+pub const NS_GROUP_DM: &str = "urn:waddle:group-dm:0";
+
+/// History visibility requested by the inviter for a newly added member.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GroupDmHistoryAccess {
+    /// New member may only query archive rows from their add/join boundary.
+    FromJoin,
+    /// New member may query the full group-DM archive.
+    Full,
+}
+
+impl GroupDmHistoryAccess {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::FromJoin => "from-join",
+            Self::Full => "full",
+        }
+    }
+}
+
+/// Build `<history-access xmlns='urn:waddle:group-dm:0' mode='…'/>`.
+pub fn build_history_access(access: GroupDmHistoryAccess) -> Element {
+    Element::builder("history-access", NS_GROUP_DM)
+        .attr(
+            minidom::rxml::xml_ncname!("mode").to_owned(),
+            access.as_str(),
+        )
+        .build()
+}
+
+/// Parse a Waddle group-DM history-access child.
+///
+/// Missing or unknown modes are treated as `from-join`, the privacy-preserving
+/// default required by the group-DM add-members flow.
+pub fn parse_history_access(element: &Element) -> Option<GroupDmHistoryAccess> {
+    if !element.is("history-access", NS_GROUP_DM) {
+        return None;
+    }
+
+    Some(match element.attr("mode") {
+        Some("full") => GroupDmHistoryAccess::Full,
+        _ => GroupDmHistoryAccess::FromJoin,
+    })
+}
+
+/// Return the first history-access child under a XEP-0045 mediated invite.
+pub fn history_access_from_mediated_invite(invite: &Element) -> Option<GroupDmHistoryAccess> {
+    invite
+        .children()
+        .find_map(|child| parse_history_access(child))
+}

--- a/server/crates/waddle-xmpp/src/xep/xep_waddle_group_dm.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep_waddle_group_dm.rs
@@ -55,7 +55,5 @@ pub fn parse_history_access(element: &Element) -> Option<GroupDmHistoryAccess> {
 
 /// Return the first history-access child under a XEP-0045 mediated invite.
 pub fn history_access_from_mediated_invite(invite: &Element) -> Option<GroupDmHistoryAccess> {
-    invite
-        .children()
-        .find_map(|child| parse_history_access(child))
+    invite.children().find_map(parse_history_access)
 }

--- a/server/crates/waddle-xmpp/tests/xep_waddle_group_dm.rs
+++ b/server/crates/waddle-xmpp/tests/xep_waddle_group_dm.rs
@@ -1,0 +1,37 @@
+use minidom::Element;
+use waddle_xmpp::xep::xep_waddle_group_dm::{
+    build_history_access, history_access_from_mediated_invite, GroupDmHistoryAccess, NS_GROUP_DM,
+};
+
+#[test]
+fn group_dm_history_access_extension_round_trips_inside_mediated_invite() {
+    let invite = Element::builder("invite", "http://jabber.org/protocol/muc#user")
+        .append(build_history_access(GroupDmHistoryAccess::Full))
+        .build();
+
+    assert_eq!(
+        history_access_from_mediated_invite(&invite),
+        Some(GroupDmHistoryAccess::Full)
+    );
+
+    let child = invite
+        .get_child("history-access", NS_GROUP_DM)
+        .expect("history-access child");
+    assert_eq!(child.attr("mode"), Some("full"));
+}
+
+#[test]
+fn group_dm_history_access_defaults_to_from_join_when_mode_is_absent() {
+    let invite: Element = format!(
+        "<invite xmlns='http://jabber.org/protocol/muc#user'>\
+            <history-access xmlns='{NS_GROUP_DM}'/>\
+         </invite>"
+    )
+    .parse()
+    .expect("valid invite");
+
+    assert_eq!(
+        history_access_from_mediated_invite(&invite),
+        Some(GroupDmHistoryAccess::FromJoin)
+    );
+}


### PR DESCRIPTION
## Plan

- Add typed Waddle group-DM history-access XML under `urn:waddle:group-dm:0`.
- Handle XEP-0045 mediated invites sent to managed group-DM rooms.
- Enforce inviter membership, invitee existence, and XEP-0191 blocking before granting access.
- Persist group-DM member authorization and per-member MAM visibility boundaries.
- Keep mediated-invite grants privacy-safe under duplicate invites, offline delivery, and restricted-history inviters.
- Cover default history, share-all history, non-member MAM rejection, blocked inviter suppression, duplicate invite rejection, restricted-inviter downgrade, typed validation errors, offline delivery, and migration behavior.

## What Changed

- Added the `history-access` extension parser/builder for mediated invites.
- Added server-side group-DM mediated invite handling:
  - only members can invite,
  - invitees must be local existing users,
  - blocked inviters are suppressed,
  - outbound mediated invites are server-stamped and do not reflect spoofed `invite@from`,
  - archive boundary is written before membership is granted,
  - duplicate invites for existing members are rejected with `conflict`,
  - restricted-history members cannot grant `mode='full'`,
  - validator stanza errors are preserved without leaking backend diagnostics,
  - permission tuple, archive boundary, and room affiliation are kept consistent with rollback on failure.
- Added group-DM archive boundary storage via migration `1006`.
- Enforced group-DM MAM visibility server-side:
  - initial/legacy members get full history,
  - explicit `mode='full'` invitees get full history only when the inviter has full history,
  - default and downgraded invitees only see messages from their add boundary,
  - non-members receive `forbidden`.
- Expanded WebSocket e2e coverage for issue #955 and review feedback.

## Verification

- `cargo test -p waddle-xmpp --test xep_waddle_group_dm`
- `cargo test -p waddle-server --test group_dm_ws -- --test-threads=1 --nocapture`
- `cargo test -p waddle-server db::migrations::tests -- --nocapture`
- `cargo clippy -p waddle-xmpp -p waddle-server --tests -- -D warnings`

## Notes

- No new dependencies.
- Bun checks were not run because this PR only changes Rust server/XMPP code.
- Review hardening intentionally rejects duplicate member invites rather than mutating existing archive boundaries.

Closes #955
