### PR TITLE
feat(server): support group dm leave

### DIFF
--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -378,7 +378,7 @@ describe("client send readiness", () => {
     enqueueQueuedMessage("alice@example.com", {
       kind: "room",
       id: "room-replay-1",
-      createdAt: "2026-06-05T10:00:00Z",
+      createdAt: new Date().toISOString(),
       roomJid,
       body: "queued room",
     });

--- a/server/crates/waddle-server/src/admin/channels.rs
+++ b/server/crates/waddle-server/src/admin/channels.rs
@@ -21,7 +21,7 @@
 //! `room_registry` (`waddle_xmpp::muc::room_registry_actor::*`), and
 //! `muc_domain` (used to construct fresh room JIDs on `create`).
 
-use std::sync::Arc;
+use std::{collections::BTreeSet, sync::Arc};
 
 use jid::{BareJid, FullJid};
 use waddle_xmpp::commands::{CommandContext, CommandResult};
@@ -29,8 +29,8 @@ use waddle_xmpp::muc::room_registry_actor::{CreateRoom, DestroyRoom, GetRoom, Li
 use waddle_xmpp::muc::{
     affiliation::FederatedAffiliationConfig,
     room_actor::{
-        ApplyAdminItems, ChangeAffiliation, GetConfig, LeaveByRealJid, ListAffiliations,
-        ListOccupants, OccupantCount, UpdateConfig,
+        ApplyAdminItems, ChangeAffiliation, GetAffiliation, GetConfig, LeaveByRealJid,
+        ListAffiliations, ListOccupants, OccupantCount, UpdateConfig,
     },
     AdminItem, PinPermission, RoomConfig,
 };
@@ -1720,7 +1720,23 @@ async fn run_group_dm_leave(
             ))))
         })?;
 
-    let mut resources = connections.get_resources_for_user(&caller_bare);
+    let pre_leave_affiliation = actor
+        .ask(GetAffiliation {
+            jid: caller_bare.clone(),
+        })
+        .await
+        .map_err(send_err("room actor GetAffiliation"))?;
+    let left = pre_leave_affiliation >= Affiliation::Member;
+    if !left {
+        return Ok(GroupDmLeaveResult {
+            room_jid: args.room_jid.clone(),
+            left,
+        });
+    }
+
+    let live_resources = connections.get_resources_for_user(&caller_bare);
+    let live_resource_set = live_resources.iter().cloned().collect::<BTreeSet<_>>();
+    let mut resources = live_resources;
     match sm_sessions.detached_resources_for_user(&caller_bare).await {
         Ok(detached_resources) => resources.extend(detached_resources),
         Err(error) => {
@@ -1761,13 +1777,19 @@ async fn run_group_dm_leave(
             .await
             .map_err(send_err("room actor LeaveByRealJid"))?
         {
-            broadcast_group_dm_leave(state, connections, &resource, &outcome);
+            broadcast_group_dm_leave(
+                state,
+                connections,
+                &resource,
+                live_resource_set.contains(&resource),
+                &outcome,
+            );
         }
     }
 
     Ok(GroupDmLeaveResult {
         room_jid: args.room_jid.clone(),
-        left: true,
+        left,
     })
 }
 
@@ -1775,11 +1797,9 @@ fn broadcast_group_dm_leave(
     state: &AppState,
     connections: &ConnectionRegistry,
     leaving_real_jid: &FullJid,
+    notify_self: bool,
     outcome: &waddle_xmpp::muc::room_actor::LeaveOutcome,
 ) {
-    if !outcome.removed_last_session {
-        return;
-    }
     let from_jid = outcome
         .leaving_room_jid
         .to_bare()
@@ -1791,6 +1811,19 @@ fn broadcast_group_dm_leave(
         real_jid: Some(leaving_real_jid),
         secret: &state.occupant_id_secret,
     };
+    if notify_self {
+        let presence = waddle_xmpp::muc::build_leave_presence(
+            &from_jid,
+            leaving_real_jid,
+            outcome.affiliation,
+            true,
+            &identity,
+        );
+        let _ = connections.try_send_to(leaving_real_jid, Stanza::Presence(presence));
+    }
+    if !outcome.removed_last_session {
+        return;
+    }
     for occupant_jid in &outcome.remaining_occupants {
         let presence = waddle_xmpp::muc::build_leave_presence(
             &from_jid,
@@ -1827,7 +1860,7 @@ pub(crate) async fn publish_group_dm_bookmark(
         .map_err(|error| internal_err(format!("failed to publish group-DM bookmark: {error}")))
 }
 
-async fn retract_group_dm_bookmark(
+pub(crate) async fn retract_group_dm_bookmark(
     state: &AppState,
     member_jid: &BareJid,
     room_jid: &BareJid,

--- a/server/crates/waddle-server/src/admin/channels.rs
+++ b/server/crates/waddle-server/src/admin/channels.rs
@@ -29,14 +29,16 @@ use waddle_xmpp::muc::room_registry_actor::{CreateRoom, DestroyRoom, GetRoom, Li
 use waddle_xmpp::muc::{
     affiliation::FederatedAffiliationConfig,
     room_actor::{
-        ApplyAdminItems, ChangeAffiliation, GetConfig, ListAffiliations, ListOccupants,
-        OccupantCount, UpdateConfig,
+        ApplyAdminItems, ChangeAffiliation, GetConfig, LeaveByRealJid, ListAffiliations,
+        ListOccupants, OccupantCount, UpdateConfig,
     },
     AdminItem, PinPermission, RoomConfig,
 };
 use waddle_xmpp::pubsub::PubSubItem;
 use waddle_xmpp::registry::ConnectionRegistry;
+use waddle_xmpp::stream_management::InMemorySmSessionRegistry;
 use waddle_xmpp::xep::xep0004::{DataForm, Field, FieldType, FormType};
+use waddle_xmpp::xep::xep0421::OccupantIdentity;
 use waddle_xmpp::XmppError;
 use waddle_xmpp::{Affiliation, ChannelInfo, Role, Stanza};
 
@@ -66,6 +68,7 @@ pub const NODE_AFFILIATIONS: &str = waddle_xmpp::admin::NS_ADMIN_CHANNELS_AFFILI
 pub const NODE_SET_AFFILIATION: &str = waddle_xmpp::admin::NS_ADMIN_CHANNELS_SET_AFFILIATION;
 pub const NODE_KICK: &str = waddle_xmpp::admin::NS_ADMIN_CHANNELS_KICK;
 pub const NODE_GROUP_DM_CREATE: &str = waddle_xmpp::admin::NS_GROUP_DM_CREATE;
+pub const NODE_GROUP_DM_LEAVE: &str = waddle_xmpp::admin::NS_GROUP_DM_LEAVE;
 
 pub const DEFAULT_PAGE_SIZE: u32 = 50;
 pub const MAX_PAGE_SIZE: u32 = 200;
@@ -282,12 +285,23 @@ pub struct GroupDmCreateArgs {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GroupDmLeaveArgs {
+    pub room_jid: BareJid,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GroupDmRef {
     pub room_jid: BareJid,
     pub name: String,
     pub is_public: bool,
     pub members_only: bool,
     pub persistent: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GroupDmLeaveResult {
+    pub room_jid: BareJid,
+    pub left: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -298,6 +312,7 @@ pub async fn register(
     registry: &waddle_xmpp::commands::CommandRegistry,
     app_state: Arc<AppState>,
     connection_registry: Arc<ConnectionRegistry>,
+    sm_session_registry: Arc<InMemorySmSessionRegistry>,
 ) {
     {
         let state = Arc::clone(&app_state);
@@ -386,6 +401,19 @@ pub async fn register(
             })
             .await;
     }
+    {
+        let state = Arc::clone(&app_state);
+        let connections = Arc::clone(&connection_registry);
+        let sm_sessions = Arc::clone(&sm_session_registry);
+        registry
+            .register(NODE_GROUP_DM_LEAVE, "Leave group DM", move |ctx| {
+                let state = Arc::clone(&state);
+                let connections = Arc::clone(&connections);
+                let sm_sessions = Arc::clone(&sm_sessions);
+                async move { handle_group_dm_leave(ctx, state, connections, sm_sessions).await }
+            })
+            .await;
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -459,6 +487,37 @@ async fn handle_group_dm_create(ctx: CommandContext, state: Arc<AppState>) -> Co
             notes: vec![],
         },
         Err(result) => *result,
+    }
+}
+
+async fn handle_group_dm_leave(
+    ctx: CommandContext,
+    state: Arc<AppState>,
+    connections: Arc<ConnectionRegistry>,
+    sm_sessions: Arc<InMemorySmSessionRegistry>,
+) -> CommandResult {
+    let caller_bare = ctx.from.to_bare();
+    let caller_full = match ctx.from.clone().try_into_full() {
+        Ok(full) => full,
+        Err(_) => match caller_bare.with_resource_str("group-dm-leave") {
+            Ok(full) => full,
+            Err(error) => {
+                return *internal_err(format!(
+                    "group-DM leave caller JID '{caller_bare}' is not a valid full JID base: {error}"
+                ));
+            }
+        },
+    };
+    let args = match parse_group_dm_leave_args(ctx.command.form.as_ref()) {
+        Ok(args) => args,
+        Err(e) => return CommandResult::Error(XmppError::bad_request(Some(e))),
+    };
+    match run_group_dm_leave(&state, &connections, &sm_sessions, &caller_full, &args).await {
+        Ok(result) => CommandResult::Completed {
+            form: Some(build_group_dm_leave_form(&result)),
+            notes: vec![],
+        },
+        Err(err) => *err,
     }
 }
 
@@ -734,6 +793,12 @@ pub fn parse_group_dm_create_args(form: Option<&DataForm>) -> Result<GroupDmCrea
         return Err("group-dm:create requires at least two member_jids".to_string());
     }
     Ok(GroupDmCreateArgs { name, member_jids })
+}
+
+pub fn parse_group_dm_leave_args(form: Option<&DataForm>) -> Result<GroupDmLeaveArgs, String> {
+    let form = form.ok_or_else(|| "group-dm:leave requires an args form".to_string())?;
+    let room_jid = parse_required_bare_jid(form, "room_jid")?;
+    Ok(GroupDmLeaveArgs { room_jid })
 }
 
 pub fn parse_update_args(form: Option<&DataForm>) -> Result<ChannelsUpdateArgs, String> {
@@ -1590,13 +1655,19 @@ async fn run_group_dm_create(
         persisted_members.push(member_jid.clone());
         if let Err(error) = actor
             .ask(ChangeAffiliation {
-                jid: member_jid,
+                jid: member_jid.clone(),
                 affiliation: Affiliation::Member,
             })
             .await
         {
             rollback_group_dm_create(state, &localpart, &room_jid, &persisted_members).await;
             return Err(send_err("room actor ChangeAffiliation")(error));
+        }
+        if let Err(error) =
+            publish_group_dm_bookmark(state, &member_jid, &room_jid, &args.name).await
+        {
+            rollback_group_dm_create(state, &localpart, &room_jid, &persisted_members).await;
+            return Err(error);
         }
     }
 
@@ -1609,6 +1680,170 @@ async fn run_group_dm_create(
     })
 }
 
+async fn run_group_dm_leave(
+    state: &AppState,
+    connections: &ConnectionRegistry,
+    sm_sessions: &InMemorySmSessionRegistry,
+    caller_full_jid: &FullJid,
+    args: &GroupDmLeaveArgs,
+) -> Result<GroupDmLeaveResult, AdminErr> {
+    let channel_id = waddle_xmpp::parse_managed_room_jid(&args.room_jid).ok_or_else(|| {
+        Box::new(CommandResult::Error(XmppError::bad_request(Some(
+            "room_jid must be a managed group-DM room JID".to_string(),
+        ))))
+    })?;
+    let record = get_xmpp_channel(state.db_pool.global_actor().clone(), &channel_id)
+        .await
+        .map_err(|error| internal_err(format!("failed to load group-DM channel: {error}")))?
+        .ok_or_else(|| {
+            Box::new(CommandResult::Error(XmppError::item_not_found(Some(
+                format!("no group DM '{}'", args.room_jid),
+            ))))
+        })?;
+    if record.channel_type != waddle_xmpp::admin::CHANNEL_TYPE_GROUP_DM {
+        return Err(Box::new(CommandResult::Error(XmppError::bad_request(
+            Some("room_jid is not a group DM".to_string()),
+        ))));
+    }
+
+    let caller_bare = caller_full_jid.to_bare();
+    let actor = state
+        .room_registry
+        .ask(GetRoom {
+            room_jid: args.room_jid.clone(),
+        })
+        .await
+        .map_err(send_err("room_registry ask GetRoom"))?
+        .ok_or_else(|| {
+            Box::new(CommandResult::Error(XmppError::item_not_found(Some(
+                format!("no group DM '{}'", args.room_jid),
+            ))))
+        })?;
+
+    let mut resources = connections.get_resources_for_user(&caller_bare);
+    match sm_sessions.detached_resources_for_user(&caller_bare).await {
+        Ok(detached_resources) => resources.extend(detached_resources),
+        Err(error) => {
+            return Err(internal_err(format!(
+                "failed to list detached group-DM leave resources: {error}"
+            )));
+        }
+    }
+    if !resources.iter().any(|resource| resource == caller_full_jid) {
+        resources.push(caller_full_jid.clone());
+    }
+    resources.sort();
+    resources.dedup();
+
+    delete_group_dm_member_tuple(state, &channel_id, &caller_bare)
+        .await
+        .map_err(|error| Box::new(CommandResult::Error(error)))?;
+    if let Err(error) = retract_group_dm_bookmark(state, &caller_bare, &args.room_jid).await {
+        let _ = persist_group_dm_member_tuple(state, &channel_id, &caller_bare).await;
+        return Err(error);
+    }
+    if let Err(error) = actor
+        .ask(ChangeAffiliation {
+            jid: caller_bare.clone(),
+            affiliation: Affiliation::None,
+        })
+        .await
+    {
+        let _ = persist_group_dm_member_tuple(state, &channel_id, &caller_bare).await;
+        let _ = publish_group_dm_bookmark(state, &caller_bare, &args.room_jid, &record.name).await;
+        return Err(send_err("room actor ChangeAffiliation")(error));
+    }
+    for resource in resources {
+        if let Some(outcome) = actor
+            .ask(LeaveByRealJid {
+                sender_jid: resource.clone(),
+            })
+            .await
+            .map_err(send_err("room actor LeaveByRealJid"))?
+        {
+            broadcast_group_dm_leave(state, connections, &resource, &outcome);
+        }
+    }
+
+    Ok(GroupDmLeaveResult {
+        room_jid: args.room_jid.clone(),
+        left: true,
+    })
+}
+
+fn broadcast_group_dm_leave(
+    state: &AppState,
+    connections: &ConnectionRegistry,
+    leaving_real_jid: &FullJid,
+    outcome: &waddle_xmpp::muc::room_actor::LeaveOutcome,
+) {
+    if !outcome.removed_last_session {
+        return;
+    }
+    let from_jid = outcome
+        .leaving_room_jid
+        .to_bare()
+        .with_resource_str(&outcome.nick)
+        .unwrap_or_else(|_| outcome.leaving_room_jid.clone());
+    let sender_bare = leaving_real_jid.to_bare();
+    let identity = OccupantIdentity {
+        bare_jid: &sender_bare,
+        real_jid: Some(leaving_real_jid),
+        secret: &state.occupant_id_secret,
+    };
+    for occupant_jid in &outcome.remaining_occupants {
+        let presence = waddle_xmpp::muc::build_leave_presence(
+            &from_jid,
+            occupant_jid,
+            outcome.affiliation,
+            false,
+            &identity,
+        );
+        let _ = connections.try_send_to(occupant_jid, Stanza::Presence(presence));
+    }
+}
+
+pub(crate) async fn publish_group_dm_bookmark(
+    state: &AppState,
+    member_jid: &BareJid,
+    room_jid: &BareJid,
+    name: &str,
+) -> Result<(), AdminErr> {
+    let bookmark = waddle_xmpp::xep::xep0402::Bookmark::new(room_jid.clone())
+        .with_name(name)
+        .with_autojoin(true);
+    let item = waddle_xmpp::xep::xep0402::build_bookmark_item(&bookmark);
+    state
+        .pubsub_storage
+        .publish_item(
+            member_jid,
+            waddle_xmpp::xep::xep0402::PEP_NODE,
+            &item,
+            Some(member_jid),
+            true,
+        )
+        .await
+        .map(|_| ())
+        .map_err(|error| internal_err(format!("failed to publish group-DM bookmark: {error}")))
+}
+
+async fn retract_group_dm_bookmark(
+    state: &AppState,
+    member_jid: &BareJid,
+    room_jid: &BareJid,
+) -> Result<(), AdminErr> {
+    state
+        .pubsub_storage
+        .retract_item(
+            member_jid,
+            waddle_xmpp::xep::xep0402::PEP_NODE,
+            &room_jid.to_string(),
+        )
+        .await
+        .map(|_| ())
+        .map_err(|error| internal_err(format!("failed to retract group-DM bookmark: {error}")))
+}
+
 async fn rollback_group_dm_create(
     state: &AppState,
     group_dm_id: &str,
@@ -1616,6 +1851,7 @@ async fn rollback_group_dm_create(
     persisted_members: &[BareJid],
 ) {
     for persisted_member in persisted_members {
+        let _ = retract_group_dm_bookmark(state, persisted_member, room_jid).await;
         let _ = delete_group_dm_member_tuple(state, group_dm_id, persisted_member).await;
     }
     let _ = delete_xmpp_channel(state.db_pool.global_actor().clone(), group_dm_id).await;
@@ -2527,6 +2763,15 @@ pub fn build_group_dm_form(group_dm: &GroupDmRef) -> DataForm {
             "persistent",
             bool_str(group_dm.persistent),
         ))
+}
+
+pub fn build_group_dm_leave_form(result: &GroupDmLeaveResult) -> DataForm {
+    DataForm::new(FormType::Result)
+        .add_field(Field::form_type(NODE_GROUP_DM_LEAVE))
+        .add_field(
+            Field::new("room_jid", FieldType::JidSingle).with_value(result.room_jid.to_string()),
+        )
+        .add_field(Field::text_single("left", bool_str(result.left)))
 }
 
 pub fn build_occupants_form(result: &ChannelsOccupantsResult) -> DataForm {

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -417,6 +417,7 @@ async fn create_websocket_state(
         }
     }
     let stanza_dispatcher = Arc::new(stanza_dispatcher);
+    let sm_session_registry = create_sm_session_registry(xmpp_config).await;
 
     let extension_pubsub_owner: jid::BareJid = service_domains.extensions.parse()?;
     register_extension_commands(
@@ -447,6 +448,7 @@ async fn create_websocket_state(
         &websocket_command_registry,
         Arc::clone(&state),
         Arc::clone(&connection_registry),
+        Arc::clone(&sm_session_registry),
     )
     .await;
     if let Err(error) = bootstrap_fresh_xmpp_topology(
@@ -542,7 +544,6 @@ async fn create_websocket_state(
         })?,
     );
 
-    let sm_session_registry = create_sm_session_registry(xmpp_config).await;
     let resumable_sessions: Arc<dashmap::DashMap<String, crate::auth::Session>> =
         Arc::new(dashmap::DashMap::new());
     let blocking_storage: Arc<dyn waddle_xmpp::xep::xep0191::BlockingStorage> = Arc::new(

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -191,6 +191,7 @@ pub async fn start_with_config(
         room_registry: room_registry.clone(),
         spaces_jid: xmpp_config.spaces_jid.clone(),
         muc_domain: xmpp_config.muc_domain.clone(),
+        occupant_id_secret: server_config.occupant_id_secret.clone(),
         permission_actor: permission_actor.clone(),
         server_owner_jids,
     }));

--- a/server/crates/waddle-server/src/server/routes/uploads/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/uploads/tests.rs
@@ -38,7 +38,7 @@ async fn create_test_upload_state() -> (Arc<UploadState>, std::path::PathBuf) {
             .expect("test occupant-id secret meets length floor");
     let room_registry = RoomRegistryActor::spawn(RoomRegistryActor::new(
         muc_domain.to_string(),
-        occupant_id_secret,
+        occupant_id_secret.clone(),
     ));
     let app_state = Arc::new(AppState::new_with_deps(AppStateDeps {
         db_pool: Arc::clone(&db_pool),
@@ -52,6 +52,7 @@ async fn create_test_upload_state() -> (Arc<UploadState>, std::path::PathBuf) {
         room_registry,
         spaces_jid: "spaces.example.com".parse().expect("spaces JID parses"),
         muc_domain,
+        occupant_id_secret,
         permission_actor,
         server_owner_jids: Arc::from(Vec::<jid::BareJid>::new()),
     }));

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, collections::BTreeMap};
 
 use tracing::warn;
 use waddle_xmpp::{
-    muc::room_actor::{ChangeAffiliation, GetAdminContext},
+    muc::room_actor::{ChangeAffiliation, GetAdminContext, GetConfig},
     muc::room_registry_actor::GetRoom,
     parser::stanza_to_string,
     pending_delivery::{InsertOutcome, PendingPayload, PendingRow, PendingRowId},
@@ -341,6 +341,27 @@ async fn handle_group_dm_mediated_invite(
             "Internal server error.",
         )]);
     }
+    let room_name = match room_actor.ask(GetConfig).await {
+        Ok(config) => config.name,
+        Err(_) => room_jid.to_string(),
+    };
+    if crate::admin::channels::publish_group_dm_bookmark(
+        &state.deps.app_state,
+        &invitee,
+        &room_jid,
+        &room_name,
+    )
+    .await
+    .is_err()
+    {
+        rollback_group_dm_invite_grant(state, room_actor, &channel_id, &room_jid, &invitee).await;
+        return Some(vec![error_reply(
+            incoming,
+            bound_jid,
+            GroupDmInviteError::InternalServerError,
+            "Internal server error.",
+        )]);
+    }
 
     let mut invite = incoming.clone();
     invite.from = Some(jid::Jid::from(room_jid.clone()));
@@ -438,6 +459,16 @@ async fn rollback_group_dm_invite_grant(
         })
         .await;
     let _ = delete_group_dm_archive_boundary(state, room_jid, invitee).await;
+    let _ = state
+        .deps
+        .app_state
+        .pubsub_storage
+        .retract_item(
+            invitee,
+            waddle_xmpp::xep::xep0402::PEP_NODE,
+            &room_jid.to_string(),
+        )
+        .await;
     crate::admin::channels::rollback_group_dm_member_tuple(
         &state.deps.app_state,
         channel_id,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -459,16 +459,9 @@ async fn rollback_group_dm_invite_grant(
         })
         .await;
     let _ = delete_group_dm_archive_boundary(state, room_jid, invitee).await;
-    let _ = state
-        .deps
-        .app_state
-        .pubsub_storage
-        .retract_item(
-            invitee,
-            waddle_xmpp::xep::xep0402::PEP_NODE,
-            &room_jid.to_string(),
-        )
-        .await;
+    let _ =
+        crate::admin::channels::retract_group_dm_bookmark(&state.deps.app_state, invitee, room_jid)
+            .await;
     crate::admin::channels::rollback_group_dm_member_tuple(
         &state.deps.app_state,
         channel_id,

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
@@ -2709,6 +2709,7 @@ async fn admin_channels_delete_retracts_duplicate_space_bookmarks() {
         &state.deps.protocol.command_registry,
         std::sync::Arc::clone(&state.deps.app_state),
         std::sync::Arc::clone(&state.deps.protocol.connection_registry),
+        std::sync::Arc::clone(&state.deps.protocol.sm_session_registry),
     )
     .await;
 
@@ -2836,6 +2837,7 @@ async fn admin_channels_update_retracts_duplicate_space_bookmarks() {
         &state.deps.protocol.command_registry,
         std::sync::Arc::clone(&state.deps.app_state),
         std::sync::Arc::clone(&state.deps.protocol.connection_registry),
+        std::sync::Arc::clone(&state.deps.protocol.sm_session_registry),
     )
     .await;
 
@@ -2983,6 +2985,7 @@ async fn admin_channels_create_space_bookmark_grants_space_members_channel_view(
         &state.deps.protocol.command_registry,
         std::sync::Arc::clone(&state.deps.app_state),
         std::sync::Arc::clone(&state.deps.protocol.connection_registry),
+        std::sync::Arc::clone(&state.deps.protocol.sm_session_registry),
     )
     .await;
 

--- a/server/crates/waddle-server/src/server/state.rs
+++ b/server/crates/waddle-server/src/server/state.rs
@@ -9,6 +9,7 @@ use tracing::warn;
 use waddle_xmpp::inbox::storage::InboxStorage;
 use waddle_xmpp::muc::room_registry_actor::RoomRegistryActor;
 use waddle_xmpp::pubsub::PubSubStorage;
+use waddle_xmpp::xep::xep0421::OccupantIdSecret;
 
 /// Server application state
 pub struct AppState {
@@ -52,6 +53,8 @@ pub struct AppState {
     /// `channels:create` constructs new managed room JIDs against this
     /// domain.
     pub muc_domain: DomainPart,
+    /// Shared secret for XEP-0421 occupant-id generation.
+    pub occupant_id_secret: OccupantIdSecret,
     /// Shared permission actor handle.
     pub permission_actor: ActorRef<PermissionActor>,
     /// Bare JIDs of server owners (resolved from
@@ -85,7 +88,7 @@ impl AppState {
                 .expect("test occupant-id secret meets length floor");
         let room_registry = RoomRegistryActor::spawn(RoomRegistryActor::new(
             muc_domain.to_string(),
-            occupant_id_secret,
+            occupant_id_secret.clone(),
         ));
         let spaces_jid: BareJid = "spaces.localhost"
             .parse()
@@ -104,6 +107,7 @@ impl AppState {
             room_registry,
             spaces_jid,
             muc_domain,
+            occupant_id_secret,
             permission_actor,
             server_owner_jids: Arc::from(Vec::<BareJid>::new()),
         })
@@ -123,6 +127,7 @@ impl AppState {
             room_registry,
             spaces_jid,
             muc_domain,
+            occupant_id_secret,
             permission_actor,
             server_owner_jids,
         } = deps;
@@ -136,6 +141,7 @@ impl AppState {
             room_registry,
             spaces_jid,
             muc_domain,
+            occupant_id_secret,
             permission_actor,
             server_owner_jids,
         }
@@ -155,6 +161,7 @@ pub struct AppStateDeps {
     pub room_registry: ActorRef<RoomRegistryActor>,
     pub spaces_jid: BareJid,
     pub muc_domain: DomainPart,
+    pub occupant_id_secret: OccupantIdSecret,
     pub permission_actor: ActorRef<PermissionActor>,
     pub server_owner_jids: Arc<[BareJid]>,
 }

--- a/server/crates/waddle-server/tests/group_dm_ws.rs
+++ b/server/crates/waddle-server/tests/group_dm_ws.rs
@@ -12,8 +12,11 @@ const DOMAIN: &str = "localhost";
 const NS_COMMANDS: &str = "http://jabber.org/protocol/commands";
 const NS_DATA: &str = "jabber:x:data";
 const NODE_GROUP_DM_CREATE: &str = "urn:waddle:group-dm:create:0";
+const NODE_GROUP_DM_LEAVE: &str = "urn:waddle:group-dm:leave:0";
 const FEATURE_GROUP_DM: &str = "urn:waddle:group-dm:0";
 const NS_MUC_USER: &str = "http://jabber.org/protocol/muc#user";
+const NS_PUBSUB: &str = "http://jabber.org/protocol/pubsub";
+const PEP_NODE_BOOKMARKS: &str = "urn:xmpp:bookmarks:1";
 
 static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
 
@@ -25,6 +28,18 @@ fn element_to_xml(element: Element) -> String {
     let mut buf = Vec::new();
     element.write_to(&mut buf).expect("serialize XML");
     String::from_utf8(buf).expect("xmpp_parsers serializes UTF-8")
+}
+
+fn attr_value(frame: &str, attr: &str) -> Option<String> {
+    let double = format!("{attr}=\"");
+    if let Some(start) = frame.find(&double).map(|start| start + double.len()) {
+        let end = frame[start..].find('"')?;
+        return Some(frame[start..start + end].to_string());
+    }
+    let single = format!("{attr}='");
+    let start = frame.find(&single).map(|start| start + single.len())?;
+    let end = frame[start..].find('\'')?;
+    Some(frame[start..start + end].to_string())
 }
 
 async fn user_client(
@@ -74,6 +89,18 @@ async fn disco_info(client: &mut WsXmppClient, to: &str, id: &str) -> String {
         .expect("disco info response")
 }
 
+async fn enable_resumption(client: &mut WsXmppClient) -> String {
+    client
+        .send(r#"<enable xmlns="urn:xmpp:sm:3" resume="true"/>"#)
+        .await
+        .expect("enable stream management");
+    let enabled = client
+        .recv_matching(|frame| frame.contains("<enabled"))
+        .await
+        .expect("stream management enabled");
+    attr_value(&enabled, "id").unwrap_or_else(|| panic!("enabled missing id: {enabled}"))
+}
+
 async fn create_group_dm(
     client: &mut WsXmppClient,
     id: &str,
@@ -113,6 +140,19 @@ async fn join_room(client: &mut WsXmppClient, room_jid: &str, nick: &str) {
         .expect("self join presence");
 }
 
+async fn try_join_room(client: &mut WsXmppClient, room_jid: &str, nick: &str) -> String {
+    let join = format!("<presence xmlns='jabber:client' to='{room_jid}/{nick}'/>");
+    client.send(&join).await.expect("send room join");
+    client
+        .recv_matching(|frame| {
+            frame.contains("<presence")
+                && (frame.contains(&format!("from='{room_jid}/{nick}'"))
+                    || frame.contains(&format!("from=\"{room_jid}/{nick}\"")))
+        })
+        .await
+        .expect("join response")
+}
+
 async fn send_groupchat(client: &mut WsXmppClient, room_jid: &str, id: &str, body: &str) {
     let message = format!(
         "<message xmlns='jabber:client' type='groupchat' to='{room_jid}' id='{id}'>\
@@ -124,6 +164,43 @@ async fn send_groupchat(client: &mut WsXmppClient, room_jid: &str, id: &str, bod
         .recv_matching(|frame| frame.contains(id) && frame.contains(body))
         .await
         .expect("groupchat echo");
+}
+
+async fn get_bookmarks(client: &mut WsXmppClient, id: &str) -> String {
+    let iq = Element::builder("iq", "jabber:client")
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "get")
+        .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
+        .append(
+            Element::builder("pubsub", NS_PUBSUB)
+                .append(
+                    Element::builder("items", NS_PUBSUB)
+                        .attr(
+                            minidom::rxml::xml_ncname!("node").to_owned(),
+                            PEP_NODE_BOOKMARKS,
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .build();
+    client
+        .send(&element_to_xml(iq))
+        .await
+        .expect("send bookmarks query");
+    client
+        .recv_matching(|frame| frame.contains("<iq") && frame_has_iq_id(frame, id))
+        .await
+        .expect("bookmarks response")
+}
+
+async fn leave_group_dm(client: &mut WsXmppClient, id: &str, room_jid: &str) -> String {
+    send_command(
+        client,
+        NODE_GROUP_DM_LEAVE,
+        id,
+        submit_form(NODE_GROUP_DM_LEAVE, vec![text_field("room_jid", room_jid)]),
+    )
+    .await
 }
 
 async fn query_room_mam(client: &mut WsXmppClient, room_jid: &str, id: &str) -> Vec<String> {
@@ -675,6 +752,207 @@ async fn group_dm_invite_to_offline_member_is_queued_for_next_presence() {
     assert!(
         delivered.contains(FEATURE_GROUP_DM) && delivered.contains("mode='full'"),
         "queued invite must preserve history-access extension: {delivered}"
+    );
+}
+
+#[tokio::test]
+async fn group_dm_member_can_leave_and_be_readded_later() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start_with_extra_accounts(&[
+        ("alice", "alice-pass"),
+        ("bob", "bob-pass"),
+        ("charlie", "charlie-pass"),
+    ]);
+    let mut alice = user_client(&server, "alice", "alice-pass", "group-dm-leave-alice").await;
+    let mut bob = user_client(&server, "bob", "bob-pass", "group-dm-leave-bob").await;
+    let mut bob_phone = user_client(&server, "bob", "bob-pass", "group-dm-leave-bob-phone").await;
+    let mut bob_detached =
+        user_client(&server, "bob", "bob-pass", "group-dm-leave-bob-detached").await;
+    let mut charlie =
+        user_client(&server, "charlie", "charlie-pass", "group-dm-leave-charlie").await;
+
+    let room_jid = create_group_dm(
+        &mut alice,
+        "group-dm-leave-create",
+        "Alice, Bob, Charlie",
+        &["alice@localhost", "bob@localhost", "charlie@localhost"],
+    )
+    .await;
+    join_room(&mut alice, &room_jid, "alice").await;
+    join_room(&mut bob, &room_jid, "bob").await;
+    join_room(&mut bob_phone, &room_jid, "bob").await;
+    join_room(&mut bob_detached, &room_jid, "bob-detached").await;
+    let bob_detached_stream_id = enable_resumption(&mut bob_detached).await;
+    drop(bob_detached);
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    join_room(&mut charlie, &room_jid, "charlie").await;
+
+    let bob_bookmarks = get_bookmarks(&mut bob, "bob-bookmarks-before-leave").await;
+    assert!(
+        bob_bookmarks.contains(&room_jid),
+        "created group DM must be bookmarked for Bob before leave: {bob_bookmarks}"
+    );
+
+    bob.send(&format!(
+        "<presence xmlns='jabber:client' type='unavailable' to='{room_jid}/bob'/>"
+    ))
+    .await
+    .expect("send unavailable presence");
+    bob.recv_matching(|frame| frame.contains("type='unavailable'"))
+        .await
+        .expect("unavailable echo");
+    assert_no_frame_matching_for(
+        &mut alice,
+        Duration::from_millis(300),
+        |frame| {
+            frame.contains("<presence")
+                && frame.contains("type='unavailable'")
+                && frame.contains(&format!("{room_jid}/bob"))
+        },
+        "single-resource unavailable must not announce a leave while Bob has another joined resource",
+    )
+    .await;
+    assert_no_frame_matching_for(
+        &mut charlie,
+        Duration::from_millis(300),
+        |frame| {
+            frame.contains("<presence")
+                && frame.contains("type='unavailable'")
+                && frame.contains(&format!("{room_jid}/bob"))
+        },
+        "single-resource unavailable must not announce a leave to any remaining member while Bob has another joined resource",
+    )
+    .await;
+    let still_member_join = try_join_room(&mut bob, &room_jid, "bob").await;
+    assert!(
+        !is_error(&still_member_join),
+        "offline/unavailable presence must not remove group-DM membership: {still_member_join}"
+    );
+
+    let leave = leave_group_dm(&mut bob, "group-dm-leave-bob-command", &room_jid).await;
+    assert!(is_result(&leave), "leave command must succeed: {leave}");
+
+    let membership_change = alice
+        .recv_matching(|frame| {
+            frame.contains("<presence")
+                && frame.contains("type='unavailable'")
+                && frame.contains(&format!("{room_jid}/bob"))
+        })
+        .await
+        .expect("remaining member sees leave presence");
+    assert!(
+        membership_change.contains("affiliation='none'"),
+        "remaining members must see Bob's membership removal: {membership_change}"
+    );
+    let charlie_membership_change = charlie
+        .recv_matching(|frame| {
+            frame.contains("<presence")
+                && frame.contains("type='unavailable'")
+                && frame.contains(&format!("{room_jid}/bob"))
+        })
+        .await
+        .expect("second remaining member sees leave presence");
+    assert!(
+        charlie_membership_change.contains("affiliation='none'"),
+        "every remaining member must see Bob's membership removal: {charlie_membership_change}"
+    );
+
+    let bob_bookmarks = get_bookmarks(&mut bob, "bob-bookmarks-after-leave").await;
+    assert!(
+        !bob_bookmarks.contains(&room_jid),
+        "leave must retract Bob's XEP-0402 bookmark: {bob_bookmarks}"
+    );
+    let bob_phone_bookmarks =
+        get_bookmarks(&mut bob_phone, "bob-phone-bookmarks-after-leave").await;
+    assert!(
+        !bob_phone_bookmarks.contains(&room_jid),
+        "bookmark retraction must be visible to Bob's other device: {bob_phone_bookmarks}"
+    );
+
+    send_groupchat(
+        &mut alice,
+        &room_jid,
+        "after-bob-leaves",
+        "remaining members continue",
+    )
+    .await;
+    let charlie_echo = charlie
+        .recv_matching(|frame| frame.contains("after-bob-leaves"))
+        .await
+        .expect("remaining member receives post-leave message");
+    assert!(
+        charlie_echo.contains("remaining members continue"),
+        "remaining members must keep chatting after leave: {charlie_echo}"
+    );
+    let mut resumed_detached = WsXmppClient::connect(&server.ws_url())
+        .await
+        .expect("connect detached resume candidate");
+    resumed_detached
+        .authenticate(DOMAIN, "bob", "bob-pass")
+        .await
+        .expect("authenticate detached resume candidate");
+    resumed_detached
+        .send(&format!(
+            r#"<resume xmlns="urn:xmpp:sm:3" previd="{bob_detached_stream_id}" h="0"/>"#
+        ))
+        .await
+        .expect("resume detached Bob resource");
+    resumed_detached
+        .recv_matching(|frame| frame.contains("<resumed"))
+        .await
+        .expect("detached Bob resource resumes");
+    assert_no_frame_matching_for(
+        &mut resumed_detached,
+        Duration::from_millis(500),
+        |frame| frame.contains("after-bob-leaves"),
+        "leave must evict detached resumable resources so post-leave messages are not replayed",
+    )
+    .await;
+
+    let denied_join = try_join_room(&mut bob, &room_jid, "bob").await;
+    assert!(
+        is_error(&denied_join) && denied_join.contains("registration-required"),
+        "former member must not be able to enter members-only room: {denied_join}"
+    );
+    let denied_phone_join = try_join_room(&mut bob_phone, &room_jid, "bob").await;
+    assert!(
+        is_error(&denied_phone_join) && denied_phone_join.contains("registration-required"),
+        "leave must remove every connected resource for the former member: {denied_phone_join}"
+    );
+    let denied_mam = query_room_mam(&mut bob, &room_jid, "bob-mam-after-leave").await;
+    assert!(
+        denied_mam
+            .iter()
+            .any(|frame| is_error(frame) && frame.contains("forbidden")),
+        "former member must not read new room history after leave: {denied_mam:?}"
+    );
+
+    let invite = format!(
+        "<message xmlns='jabber:client' type='normal' to='{room_jid}' id='readd-bob-after-leave'>\
+            <x xmlns='{NS_MUC_USER}'>\
+                <invite to='bob@localhost'/>\
+            </x>\
+         </message>"
+    );
+    alice.send(&invite).await.expect("send Bob re-add invite");
+    bob.recv_matching(|frame| frame.contains("readd-bob-after-leave"))
+        .await
+        .expect("Bob receives re-add invite");
+    let bob_bookmarks = get_bookmarks(&mut bob, "bob-bookmarks-after-readd").await;
+    assert!(
+        bob_bookmarks.contains(&room_jid),
+        "normal re-add must restore Bob's XEP-0402 bookmark: {bob_bookmarks}"
+    );
+    let bob_phone_bookmarks =
+        get_bookmarks(&mut bob_phone, "bob-phone-bookmarks-after-readd").await;
+    assert!(
+        bob_phone_bookmarks.contains(&room_jid),
+        "re-add bookmark restore must be visible to Bob's other device: {bob_phone_bookmarks}"
+    );
+    let readded_join = try_join_room(&mut bob, &room_jid, "bob").await;
+    assert!(
+        !is_error(&readded_join) && readded_join.contains("affiliation='member'"),
+        "former member must be able to rejoin after normal add flow: {readded_join}"
     );
 }
 

--- a/server/crates/waddle-server/tests/group_dm_ws.rs
+++ b/server/crates/waddle-server/tests/group_dm_ws.rs
@@ -762,6 +762,7 @@ async fn group_dm_member_can_leave_and_be_readded_later() {
         ("alice", "alice-pass"),
         ("bob", "bob-pass"),
         ("charlie", "charlie-pass"),
+        ("dave", "dave-pass"),
     ]);
     let mut alice = user_client(&server, "alice", "alice-pass", "group-dm-leave-alice").await;
     let mut bob = user_client(&server, "bob", "bob-pass", "group-dm-leave-bob").await;
@@ -770,6 +771,7 @@ async fn group_dm_member_can_leave_and_be_readded_later() {
         user_client(&server, "bob", "bob-pass", "group-dm-leave-bob-detached").await;
     let mut charlie =
         user_client(&server, "charlie", "charlie-pass", "group-dm-leave-charlie").await;
+    let mut dave = user_client(&server, "dave", "dave-pass", "group-dm-leave-dave").await;
 
     let room_jid = create_group_dm(
         &mut alice,
@@ -791,6 +793,14 @@ async fn group_dm_member_can_leave_and_be_readded_later() {
     assert!(
         bob_bookmarks.contains(&room_jid),
         "created group DM must be bookmarked for Bob before leave: {bob_bookmarks}"
+    );
+    let non_member_leave =
+        leave_group_dm(&mut dave, "group-dm-leave-dave-command", &room_jid).await;
+    assert!(
+        is_result(&non_member_leave)
+            && (non_member_leave.contains("<value>false</value>")
+                || non_member_leave.contains("<value>0</value>")),
+        "non-member leave must be a no-op result with left=false: {non_member_leave}"
     );
 
     bob.send(&format!(
@@ -831,6 +841,36 @@ async fn group_dm_member_can_leave_and_be_readded_later() {
 
     let leave = leave_group_dm(&mut bob, "group-dm-leave-bob-command", &room_jid).await;
     assert!(is_result(&leave), "leave command must succeed: {leave}");
+
+    let bob_self_leave = bob
+        .recv_matching(|frame| {
+            frame.contains("<presence")
+                && attr_value(frame, "type").as_deref() == Some("unavailable")
+                && attr_value(frame, "from").as_deref() == Some(&format!("{room_jid}/bob"))
+                && attr_value(frame, "to").as_deref() == Some("bob@localhost/group-dm-leave-bob")
+        })
+        .await
+        .expect("leaving command resource receives self leave presence");
+    assert!(
+        bob_self_leave.contains("status code='110'")
+            || bob_self_leave.contains("status code=\"110\""),
+        "leaving command resource must get XEP-0045 self-presence: {bob_self_leave}"
+    );
+    let bob_phone_self_leave = bob_phone
+        .recv_matching(|frame| {
+            frame.contains("<presence")
+                && attr_value(frame, "type").as_deref() == Some("unavailable")
+                && attr_value(frame, "from").as_deref() == Some(&format!("{room_jid}/bob"))
+                && attr_value(frame, "to").as_deref()
+                    == Some("bob@localhost/group-dm-leave-bob-phone")
+        })
+        .await
+        .expect("leaving sibling resource receives self leave presence");
+    assert!(
+        bob_phone_self_leave.contains("status code='110'")
+            || bob_phone_self_leave.contains("status code=\"110\""),
+        "leaving sibling resource must get XEP-0045 self-presence: {bob_phone_self_leave}"
+    );
 
     let membership_change = alice
         .recv_matching(|frame| {

--- a/server/crates/waddle-server/tests/xmpp_e2e_cue.rs
+++ b/server/crates/waddle-server/tests/xmpp_e2e_cue.rs
@@ -253,6 +253,10 @@ const ADVERTISED_FEATURE_EXEMPTIONS: &[FeatureCoverageExemption] = &[
         reason: "Private Waddle ad-hoc command namespace, not official XEP coverage.",
     },
     FeatureCoverageExemption {
+        feature: "urn:waddle:group-dm:leave:0",
+        reason: "Private Waddle ad-hoc command namespace, covered by group_dm_ws.",
+    },
+    FeatureCoverageExemption {
         feature: "urn:waddle:mam-thread:0",
         reason: "Private Waddle MAM extension namespace, not official XEP coverage.",
     },

--- a/server/crates/waddle-xmpp/src/admin.rs
+++ b/server/crates/waddle-xmpp/src/admin.rs
@@ -81,6 +81,11 @@ pub const NS_ADMIN_CHANNELS_KICK: &str = "urn:waddle:admin:channels:kick:0";
 /// members-only, persistent XEP-0045 room.
 pub const NS_GROUP_DM_CREATE: &str = "urn:waddle:group-dm:create:0";
 
+/// `group-dm:leave` — explicit service-mediated removal of the caller from
+/// a private group DM. Presence-unavailable is only an occupancy signal and
+/// MUST NOT remove durable membership.
+pub const NS_GROUP_DM_LEAVE: &str = "urn:waddle:group-dm:leave:0";
+
 /// Disco feature advertised by group-DM rooms so clients can classify them
 /// into the DM surface instead of the channel surface.
 pub const NS_GROUP_DM_FEATURE: &str = "urn:waddle:group-dm:0";

--- a/server/crates/waddle-xmpp/src/disco/info.rs
+++ b/server/crates/waddle-xmpp/src/disco/info.rs
@@ -50,6 +50,7 @@ pub fn server_features() -> Vec<Feature> {
     ));
     features.push(Feature::new(crate::admin::NS_ADMIN_CHANNELS_KICK));
     features.push(Feature::new(crate::admin::NS_GROUP_DM_CREATE));
+    features.push(Feature::new(crate::admin::NS_GROUP_DM_LEAVE));
     features
 }
 


### PR DESCRIPTION
## Plan

Implements #956.

1. Add an XMPP-native `urn:waddle:group-dm:leave:0` ad-hoc command for explicit group-DM leave.
2. Remove durable membership by deleting the group-DM member tuple, retracting the leaver's XEP-0402 bookmark, and changing MUC affiliation to `none`.
3. Evict every live and detached XEP-0198 resource for the leaving bare JID so resumed streams cannot replay post-leave room traffic.
4. Notify every live evicted resource with XEP-0045 self-unavailable presence, while remaining occupants receive the final membership-removal leave presence once.
5. Keep ordinary unavailable presence as occupancy-only, so disconnect/offline does not remove membership.
6. Publish XEP-0402 bookmarks on group-DM creation and mediated re-add, with shared helper cleanup for rollback paths.
7. Cover leave, no-op non-member leave, denial, detached-resource eviction, bookmark removal/restoration, and re-add in WebSocket e2e tests.

## Notes

- Leave is implemented via XEP-0050 plus existing XEP-0045/XEP-0402 surfaces. No HTTP or out-of-band membership API was added.
- Group-DM leave presence uses the canonical MUC leave builder, including the existing XEP-0421 occupant-id shape.
- The `left` result now reflects whether the caller was a member before the command, so non-members get `left=false` instead of a false-positive success flag.
- The `chat/tests/client-send-readiness.test.ts` fixture now uses the current time so the queued-message TTL test does not age out under the current 2026-06-12 test date.
- Root `bun run lint` is not available in this repo; `chat/` lint/knip was run instead per the project hard rule.

## Verification

- `cargo fmt --check`
- `cargo clippy -p waddle-server -- -D warnings`
- `cargo test -p waddle-server`
- `cargo test -p waddle-xmpp`
- `cargo test -p waddle-server --test group_dm_ws group_dm_member_can_leave_and_be_readded_later -- --nocapture`
- `bun test`
- `(cd chat && bun run lint)`
- `git diff --check`
- Adversarial review agents checked the comment-fix diff; one test brittleness finding was fixed, then the focused regression test and clippy were rerun.

## Remaining risks

- Leave uses compensating writes rather than a single cross-store transaction because membership, PEP bookmarks, and room actor state live behind separate actors/stores.
- The invite rollback bookmark helper reuse was statically reviewed but not separately runtime-exercised beyond existing invite coverage.
