### PR TITLE
feat: add DM pinned messages

### DIFF
--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -271,7 +271,11 @@ export function useChannelMessages(
           // Waddle MAM stanza-id filter: fetch the full message body so
           // PinnedPanel can render the message without a panel re-open.
           // Skip if the client does not support the stanza-id MAM filter.
-          if (xmppClient.value && "fetchRoomMessagesByStanzaIds" in xmppClient.value) {
+          if (
+            activeTimelineRoomJid.value === roomJid &&
+            xmppClient.value &&
+            "fetchRoomMessagesByStanzaIds" in xmppClient.value
+          ) {
             const currentClient = xmppClient.value;
             const spaceId = activeSpaceId.value ?? "";
             const channelId = activeChannelId.value ?? "";
@@ -286,7 +290,8 @@ export function useChannelMessages(
                 : null;
             };
             void hydrateSinglePinnedBody({
-              client: currentClient,
+              fetchByStanzaIds: (stanzaIds) =>
+                currentClient.fetchRoomMessagesByStanzaIds(spaceId, channelId, stanzaIds),
               spaceId,
               channelId,
               roomJid,

--- a/chat/src/components/chat/ChatHeader.vue
+++ b/chat/src/components/chat/ChatHeader.vue
@@ -264,7 +264,7 @@ const memberButtonCopy = computed(() => {
           <Search class="w-3.5 h-3.5" />
         </button>
         <button
-          v-if="channel"
+          v-if="channel || dmPeer"
           class="chat-icon-button chat-icon-button--md transition-all duration-200"
           :class="showPinnedPanel
             ? 'bg-muted text-primary ring-1 ring-primary/40 shadow-[0_0_10px_var(--glow)]'

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -916,11 +916,10 @@ onUnmounted(() => {
           </template>
 
           <button
-            v-if="ui.sidebarMode.value === 'channels'
+            v-if="(ui.sidebarMode.value === 'channels' || ui.sidebarMode.value === 'dms')
               && activeRightPanel !== 'pinned'
               && ui.showPinnedPanel.value
-              && waddles.currentChannel.value
-              && activeChannelRoomJid"
+              && (activeChannelRoomJid || activeDmPeer?.peerJid)"
             type="button"
             class="chat-accordion-bar bg-muted/20 hover:bg-muted/50"
             title="Pinned messages"
@@ -1039,16 +1038,15 @@ onUnmounted(() => {
           </div>
 
           <div
-            v-if="ui.sidebarMode.value === 'channels'
+            v-if="(ui.sidebarMode.value === 'channels' || ui.sidebarMode.value === 'dms')
               && activeRightPanel === 'pinned'
               && ui.showPinnedPanel.value
-              && waddles.currentChannel.value
-              && activeChannelRoomJid"
+              && (activeChannelRoomJid || activeDmPeer?.peerJid)"
             class="chat-active-thread-pane"
           >
             <PinnedPanel
-              :room-jid="activeChannelRoomJid"
-              :channel-name="waddles.currentChannel.value?.name ?? ''"
+              :room-jid="ui.sidebarMode.value === 'dms' ? activeDmPeer?.peerJid ?? '' : activeChannelRoomJid ?? ''"
+              :channel-name="ui.sidebarMode.value === 'dms' ? activeDmPeer?.peerUsername ?? 'Direct message' : waddles.currentChannel.value?.name ?? ''"
               :timeline-messages="activeMessages"
               @close="closePinnedPanel"
               @jump-to-message="(stanzaId: string) => jumpToPinnedMessage(stanzaId)"

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -505,6 +505,7 @@ function isPinnedMessage(msg: TimelineMessage): boolean {
 // server emits status-code-104 on owner-config set (separate
 // follow-up).
 const currentUserCanPin = computed(() => {
+  if (props.sidebarMode === "dms") return true;
   const me = props.currentUser;
   if (!me) return false;
   if (props.roomPresence[me] === undefined) return false;

--- a/chat/src/components/chat/PinnedPanel.vue
+++ b/chat/src/components/chat/PinnedPanel.vue
@@ -53,11 +53,10 @@ const timelineIndex = computed(() => {
 });
 
 function liveMessageFor(stanzaId: string): TimelineMessage | null {
-  return (
-    timelineIndex.value.get(stanzaId) ??
-    pinnedBodies.value.get(props.roomJid)?.get(stanzaId) ??
-    null
-  );
+  const live = timelineIndex.value.get(stanzaId);
+  if (live) return live as TimelineMessage;
+  const cached = pinnedBodies.value.get(props.roomJid)?.get(stanzaId);
+  return cached ? (cached as TimelineMessage) : null;
 }
 
 interface ResolvedEntry {
@@ -116,7 +115,7 @@ function relativeTime(iso: string): string {
     >
       <Pin class="w-6 h-6" aria-hidden="true" />
       <p>No pinned messages yet.</p>
-      <p class="text-xs">Admins can pin a message from the message menu.</p>
+      <p class="text-xs">Pin a message from the message menu.</p>
     </div>
     <ol v-else class="flex-1 overflow-y-auto divide-y divide-border" role="list">
       <li

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -670,6 +670,16 @@ type XmppClientInstance = Partial<WasmClient> & CompatEmitter & {
     deviceId: string,
   ) => Promise<{ id: string; node: string; status: "active" | "disabled" }>;
   fetch_user_bookmarks?: () => Promise<UserBookmarkItem[] | null>;
+  pin_direct_message?: (peerJid: string, targetStanzaId: string) => Promise<void>;
+  unpin_direct_message?: (peerJid: string, targetStanzaId: string) => Promise<void>;
+  fetch_room_messages_by_stanza_ids?: (
+    targetJid: string,
+    stanzaIds: string[],
+  ) => Promise<import("./wasm-types").WasmMamPage | null>;
+  fetch_direct_messages_by_stanza_ids?: (
+    peerJid: string,
+    stanzaIds: string[],
+  ) => Promise<import("./wasm-types").WasmMamPage | null>;
   set_room_notification_mode?: (options: {
     roomJid: string;
     mode: NotifyMode;
@@ -1870,6 +1880,18 @@ export class BrowserXmppClient {
     if (typeof xmpp.unpin_message !== "function") throw new Error("unpin_message not available in wasm client");
     await xmpp.unpin_message(roomJid, targetStanzaId);
   }
+  async pinDirectMessage(peerJid: string, targetStanzaId: string) {
+    const xmpp = await this.requireConnectedXmpp();
+    const normalizedPeerJid = barePeerJid(peerJid);
+    if (typeof xmpp.pin_direct_message !== "function") throw new Error("pin_direct_message not available in wasm client");
+    await xmpp.pin_direct_message(normalizedPeerJid, targetStanzaId);
+  }
+  async unpinDirectMessage(peerJid: string, targetStanzaId: string) {
+    const xmpp = await this.requireConnectedXmpp();
+    const normalizedPeerJid = barePeerJid(peerJid);
+    if (typeof xmpp.unpin_direct_message !== "function") throw new Error("unpin_direct_message not available in wasm client");
+    await xmpp.unpin_direct_message(normalizedPeerJid, targetStanzaId);
+  }
   /** #414: fetch the room's current pin list. Server requires the
    * caller to be a current room occupant. Returns entries in
    * pin-time-desc order. */
@@ -1877,6 +1899,13 @@ export class BrowserXmppClient {
     const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId);
     if (typeof xmpp.fetch_room_pins !== "function") throw new Error("fetch_room_pins not available in wasm client");
     const result = await xmpp.fetch_room_pins(roomJid);
+    return Array.isArray(result) ? (result as import("./wasm-types").WasmPinEntry[]) : [];
+  }
+  async fetchDirectPins(peerJid: string): Promise<import("./wasm-types").WasmPinEntry[]> {
+    const xmpp = await this.requireConnectedXmpp();
+    const normalizedPeerJid = barePeerJid(peerJid);
+    if (typeof xmpp.fetch_room_pins !== "function") throw new Error("fetch_room_pins not available in wasm client");
+    const result = await xmpp.fetch_room_pins(normalizedPeerJid);
     return Array.isArray(result) ? (result as import("./wasm-types").WasmPinEntry[]) : [];
   }
   /** XEP-0359: fetch a batch of MAM messages by their stanza-ids. */
@@ -1889,6 +1918,17 @@ export class BrowserXmppClient {
     const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId);
     if (typeof xmpp.fetch_room_messages_by_stanza_ids !== "function") throw new Error("fetch_room_messages_by_stanza_ids not available in wasm client");
     const page = (await xmpp.fetch_room_messages_by_stanza_ids(roomJid, stanzaIds)) as import("./wasm-types").WasmMamPage | null;
+    return Array.isArray(page?.messages) ? page.messages : [];
+  }
+  async fetchDirectMessagesByStanzaIds(
+    peerJid: string,
+    stanzaIds: string[],
+  ): Promise<import("./wasm-types").WasmArchivedMessage[]> {
+    if (stanzaIds.length === 0) return [];
+    const xmpp = await this.requireConnectedXmpp();
+    const normalizedPeerJid = barePeerJid(peerJid);
+    if (typeof xmpp.fetch_direct_messages_by_stanza_ids !== "function") throw new Error("fetch_direct_messages_by_stanza_ids not available in wasm client");
+    const page = await xmpp.fetch_direct_messages_by_stanza_ids(normalizedPeerJid, stanzaIds);
     return Array.isArray(page?.messages) ? page.messages : [];
   }
   async sendRetraction(spaceId: string, channelId: string, retractsId: string, thread?: { id: string; parent?: string }) { const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId); await this.compatSendRetraction(xmpp, roomJid, "groupchat", retractsId, thread); }
@@ -3449,9 +3489,12 @@ export class BrowserXmppClient {
     }
     if (message.displayed_marker_id) { if (message.is_muc) { const roomJid = barePeerJid(message.from ?? message.to ?? ""); const nick = (message.from ?? "").split("/")[1] ?? "unknown"; this.displayedHandler?.({ roomJid, nick, messageId: message.displayed_marker_id }); } else this.dmDisplayedHandler?.({ peerJid: barePeerJid(message.from ?? message.to ?? ""), messageId: message.displayed_marker_id }); return; }
     if (message.reaction_target_id) { if (message.is_muc) { const roomJid = barePeerJid(message.from ?? message.to ?? ""); const nick = (message.from ?? "").split("/")[1] ?? "unknown"; this.reactionHandler?.({ roomJid, nick, messageId: message.reaction_target_id, emojis: message.reaction_emojis }); } else { const fromBare = barePeerJid(message.from ?? ""); const toBare = barePeerJid(message.to ?? ""); const selfBare = barePeerJid(this.session.jid); const peerJid = fromBare === selfBare ? toBare : fromBare; const reactorJid = fromBare || selfBare; if (peerJid && reactorJid) this.dmReactionHandler?.({ peerJid, reactorJid, messageId: message.reaction_target_id, emojis: message.reaction_emojis }); } return; }
-    if (message.pin_event && message.is_muc) {
-      const roomJid = barePeerJid(message.from ?? message.to ?? "");
-      this.pinEventHandler?.({ roomJid, event: message.pin_event });
+    if (message.pin_event) {
+      const roomJid = message.is_muc
+        ? barePeerJid(message.from ?? message.to ?? "")
+        : this.directPeerFromMessage(message);
+      if (roomJid) this.pinEventHandler?.({ roomJid, event: message.pin_event });
+      if (!message.is_muc) return;
       // Fall through: also render the system message in the timeline so
       // the user sees "alice pinned a message" inline (#414). The
       // pin store update has already happened above.
@@ -3476,6 +3519,13 @@ export class BrowserXmppClient {
       this.catchup.recordDmSeen(converted.peerJid, converted.createdAt, undefined, rawMessageSeenIds(message));
       this.directMessageHandler?.(converted);
     }
+  }
+
+  private directPeerFromMessage(message: InboundWasmMessage): string {
+    const selfBare = barePeerJid(this.session.jid);
+    const fromBare = barePeerJid(message.from ?? "");
+    const toBare = barePeerJid(message.to ?? "");
+    return fromBare === selfBare ? toBare : fromBare;
   }
   private async runReconnectCatchup(
     xmpp: XmppClientInstance,

--- a/chat/src/router/codecs.ts
+++ b/chat/src/router/codecs.ts
@@ -34,17 +34,6 @@ function encodeThreadStack(stack: readonly string[]): string | null {
   return `thread=${stack.map((id) => encodeURIComponent(id)).join(",")}`;
 }
 
-export const threadSearch: SearchCodec<{ thread: string[] }> = {
-  encode: ({ thread }) => {
-    const encoded = encodeThreadStack(thread);
-    return encoded ? `?${encoded}` : "";
-  },
-  decode: (searchString) => {
-    if (!searchString) return { thread: [] };
-    return { thread: decodeThreadStack(stripLeadingQuestion(searchString)) };
-  },
-};
-
 export const threadAndPinnedSearch: SearchCodec<{ thread: string[]; pinned: boolean }> = {
   encode: ({ thread, pinned }) => {
     const parts: string[] = [];

--- a/chat/src/router/routes/dm.ts
+++ b/chat/src/router/routes/dm.ts
@@ -1,14 +1,14 @@
-import { threadSearch } from "../codecs";
+import { threadAndPinnedSearch } from "../codecs";
 
 export interface DmMatch {
   readonly id: "dm";
   readonly params: { username: string };
-  readonly search: { thread: string[] };
+  readonly search: { thread: string[]; pinned: boolean };
 }
 
 interface DmMatchInput {
   params: { username: string };
-  search?: { thread?: string[] };
+  search?: { thread?: string[]; pinned?: boolean };
 }
 
 export const dmRoute = {
@@ -17,11 +17,14 @@ export const dmRoute = {
     return {
       id: "dm",
       params: { username: input.params.username },
-      search: { thread: input.search?.thread ?? [] },
+      search: { thread: input.search?.thread ?? [], pinned: input.search?.pinned ?? false },
     };
   },
   href(input: DmMatchInput): string {
-    const search = threadSearch.encode({ thread: input.search?.thread ?? [] });
+    const search = threadAndPinnedSearch.encode({
+      thread: input.search?.thread ?? [],
+      pinned: input.search?.pinned ?? false,
+    });
     return `/dm/${encodeURIComponent(input.params.username)}${search}`;
   },
   tryParse(pathname: string, searchString: string): DmMatch | null {
@@ -32,7 +35,7 @@ export const dmRoute = {
     return {
       id: "dm",
       params: { username: decodeURIComponent(segments[1]) },
-      search: threadSearch.decode(searchString),
+      search: threadAndPinnedSearch.decode(searchString),
     };
   },
 };

--- a/chat/src/services/pinned-message-bodies.ts
+++ b/chat/src/services/pinned-message-bodies.ts
@@ -40,18 +40,18 @@ import type { WasmArchivedMessage } from "@/lib/xmpp/wasm-types";
  */
 function matchRequestedStanzaId(
   archived: WasmArchivedMessage,
-  roomJid: string,
   requested: Set<string>,
 ): string | null {
-  // Branch 1: the canonical room-scoped XEP-0359 stanza-id, where the
-  // wasm `stanza_ids` array contains a `by === roomJid` entry. This is
-  // the production path for well-formed XEP-0313 §5.1.2 archives.
-  const roomStamped = archived.stanza_ids?.find((s) => s.by === roomJid)?.id;
-  if (roomStamped && requested.has(roomStamped)) return roomStamped;
+  // The server-side MAM stanza-id filter has already constrained the
+  // returned page to the requested IDs. Match by value so both room
+  // (`by=room`) and 1:1 personal archives (`by=user`) hydrate through
+  // the same cache path.
+  const stamped = archived.stanza_ids?.find((s) => requested.has(s.id))?.id;
+  if (stamped) return stamped;
 
   // Branch 2: the singular `stanza_id` field (some archive paths
   // surface the canonical id this way instead of the array).
-  if (archived.stanza_id && archived.stanza_id_by === roomJid && requested.has(archived.stanza_id)) {
+  if (archived.stanza_id && requested.has(archived.stanza_id)) {
     return archived.stanza_id;
   }
 
@@ -75,16 +75,10 @@ function timelinePresenceSet(messages: ReadonlyArray<TimelineMessage>): Set<stri
   return set;
 }
 
-interface MamFetcher {
-  fetchRoomMessagesByStanzaIds: (
-    spaceId: string,
-    channelId: string,
-    stanzaIds: string[],
-  ) => Promise<WasmArchivedMessage[]>;
-}
+type StanzaIdFetcher = (stanzaIds: string[]) => Promise<WasmArchivedMessage[]>;
 
 interface HydrateOpenArgs {
-  client: MamFetcher;
+  fetchByStanzaIds: StanzaIdFetcher;
   spaceId: string;
   channelId: string;
   roomJid: string;
@@ -106,14 +100,10 @@ export async function hydratePinnedBodiesOnPanelOpen(args: HydrateOpenArgs): Pro
   if (missing.length === 0) return;
 
   const epoch = pinnedMessageBodiesEpoch();
-  const archived = await args.client.fetchRoomMessagesByStanzaIds(
-    args.spaceId,
-    args.channelId,
-    missing,
-  );
+  const archived = await args.fetchByStanzaIds(missing);
   const requestedSet = new Set(missing);
   const cached = archived.flatMap((m) => {
-    const stanzaId = matchRequestedStanzaId(m, args.roomJid, requestedSet);
+    const stanzaId = matchRequestedStanzaId(m, requestedSet);
     if (!stanzaId) return [];
     const message = args.convert(m);
     return message ? [{ stanzaId, message }] : [];
@@ -122,7 +112,7 @@ export async function hydratePinnedBodiesOnPanelOpen(args: HydrateOpenArgs): Pro
 }
 
 interface HydrateSingleArgs {
-  client: MamFetcher;
+  fetchByStanzaIds: StanzaIdFetcher;
   spaceId: string;
   channelId: string;
   roomJid: string;
@@ -140,14 +130,10 @@ export async function hydrateSinglePinnedBody(args: HydrateSingleArgs): Promise<
   if (room?.has(args.stanzaId)) return;
 
   const epoch = pinnedMessageBodiesEpoch();
-  const archived = await args.client.fetchRoomMessagesByStanzaIds(
-    args.spaceId,
-    args.channelId,
-    [args.stanzaId],
-  );
+  const archived = await args.fetchByStanzaIds([args.stanzaId]);
   const requestedSet = new Set([args.stanzaId]);
   const cached = archived.flatMap((m) => {
-    const stanzaId = matchRequestedStanzaId(m, args.roomJid, requestedSet);
+    const stanzaId = matchRequestedStanzaId(m, requestedSet);
     if (!stanzaId) return [];
     const message = args.convert(m);
     return message ? [{ stanzaId, message }] : [];

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -1,5 +1,6 @@
 import { type ComponentPublicInstance, computed, onMounted, onUnmounted, ref, watch, watchEffect } from "vue";
 import { createKeystrok, type Keystrok } from "keystrok";
+import { useStore } from "@nanostores/vue";
 import { useWaddleDirectory, type MemberLoadState } from "@/waddles/directory";
 import { useWaddleMembers } from "@/waddles/members";
 import { useDirectMessageConversations } from "@/dms/conversations";
@@ -35,11 +36,12 @@ import {
 import { normalizeMucServiceDomain } from "@/lib/calls/muc-call-indicators";
 import { resolveThreadEntryTarget } from "@/lib/threads-view-target";
 import { connectionStore } from "@/lib/connection-store";
-import { resetPinnedRooms } from "@/stores/pinned-messages";
-import { hydratePinnedBodiesOnPanelOpen } from "@/services/pinned-message-bodies";
+import { $pinnedRooms, hydratePinnedRoom, pinnedRoomsEpoch, resetPinnedRooms } from "@/stores/pinned-messages";
+import { hydratePinnedBodiesOnPanelOpen, hydrateSinglePinnedBody } from "@/services/pinned-message-bodies";
 import { trustedLinkPreviewMediaOrigin } from "@/lib/xmpp/link-preview";
-import { roomMessageFromArchived } from "@/lib/xmpp/wasm-message-codecs";
+import { dmMessageFromArchived, roomMessageFromArchived } from "@/lib/xmpp/wasm-message-codecs";
 import { mapLiveRoomMessageToTimeline } from "@/channels/timeline";
+import { fromLiveDmMessage } from "@/dms/message-timeline-state";
 import { orderTimelineForScrollDirection, type ScrollDirectionMode } from "@/lib/scroll-direction";
 import { useScrollDirectionPreference } from "@/preferences/scroll-direction";
 import type { MemberSummary } from "@/lib/chat-types";
@@ -284,6 +286,7 @@ export function useChatAppController(giphyApiKey: string) {
     ui.actionError,
     ui.clearActionError,
   );
+  const pinnedRooms = useStore($pinnedRooms);
 
   type ContentAreaHandle = ComponentPublicInstance & {
     messagesContainer: HTMLDivElement | null;
@@ -402,8 +405,12 @@ export function useChatAppController(giphyApiKey: string) {
   function isRightPanelAvailable(panel: ActiveRightPanel): boolean {
     if (ui.activePage.value !== "chat") return false;
     if (panel === "thread") return activeThreadStack.value.length > 0;
+    if (panel === "pinned") {
+      if (!ui.showPinnedPanel.value) return false;
+      if (ui.sidebarMode.value === "dms") return !!dmConversations.activePeerJid.value;
+      return ui.sidebarMode.value === "channels" && !!waddles.currentChannel.value && !!activeChannelRoomJid.value;
+    }
     if (ui.sidebarMode.value !== "channels") return false;
-    if (panel === "pinned") return ui.showPinnedPanel.value && !!waddles.currentChannel.value && !!activeChannelRoomJid.value;
     return !!activeExtensionRouteKey.value && !!waddles.currentChannel.value;
   }
 
@@ -1259,10 +1266,19 @@ export function useChatAppController(giphyApiKey: string) {
    * this — but the server is authoritative. */
   function pinActiveMessage(messageId: string) {
     const client = xmppClient.value;
-    const channel = waddles.currentChannel.value;
-    if (!client || !channel) return;
+    if (!client) return;
     const stanzaId = resolvePinTargetStanzaId(messageId);
     if (!stanzaId) return;
+    if (ui.sidebarMode.value === "dms") {
+      const peer = dmConversations.activePeerJid.value;
+      if (!peer || !("pinDirectMessage" in client)) return;
+      void client.pinDirectMessage(peer, stanzaId).catch((error: unknown) => {
+        console.warn("pinDirectMessage failed", error);
+      });
+      return;
+    }
+    const channel = waddles.currentChannel.value;
+    if (!channel) return;
     void client.pinMessage(channel.spaceId ?? "", channel.id, stanzaId).catch((error: unknown) => {
       console.warn("pinMessage failed", error);
     });
@@ -1270,10 +1286,19 @@ export function useChatAppController(giphyApiKey: string) {
 
   function unpinActiveMessage(messageId: string) {
     const client = xmppClient.value;
-    const channel = waddles.currentChannel.value;
-    if (!client || !channel) return;
+    if (!client) return;
     const stanzaId = resolvePinTargetStanzaId(messageId);
     if (!stanzaId) return;
+    if (ui.sidebarMode.value === "dms") {
+      const peer = dmConversations.activePeerJid.value;
+      if (!peer || !("unpinDirectMessage" in client)) return;
+      void client.unpinDirectMessage(peer, stanzaId).catch((error: unknown) => {
+        console.warn("unpinDirectMessage failed", error);
+      });
+      return;
+    }
+    const channel = waddles.currentChannel.value;
+    if (!channel) return;
     void client.unpinMessage(channel.spaceId ?? "", channel.id, stanzaId).catch((error: unknown) => {
       console.warn("unpinMessage failed", error);
     });
@@ -1298,7 +1323,7 @@ export function useChatAppController(giphyApiKey: string) {
    * `message.stanza_id` upstream. Returns null when no archive id is
    * known yet (e.g., a queued send hasn't been reflected). */
   function resolvePinTargetStanzaId(messageId: string): string | null {
-    const message = messaging.messages.value.find((m) => m.id === messageId);
+    const message = activeTarget.value.messages.value.find((m) => m.id === messageId);
     if (!message) return null;
     const m = message as TimelineMessage & {
       reactionTargetId?: string;
@@ -1461,7 +1486,7 @@ export function useChatAppController(giphyApiKey: string) {
         navigate({
           id: "dm",
           params: { username: activeDmPeer.value.peerUsername },
-          search: { thread: activeThreadStack.value },
+          search: { thread: activeThreadStack.value, pinned: ui.showPinnedPanel.value },
         });
       } else {
         navigate({ id: "dmList" });
@@ -1509,6 +1534,7 @@ export function useChatAppController(giphyApiKey: string) {
   // any pinned stanza-ids not already in the loaded timeline or cache.
   watch(() => ui.showPinnedPanel.value, async (open) => {
     if (!open) return;
+    if (ui.sidebarMode.value === "dms") return;
     const client = xmppClient.value;
     const spaceId = waddles.activeSpaceId.value;
     const channelId = waddles.activeChannelId.value;
@@ -1527,7 +1553,8 @@ export function useChatAppController(giphyApiKey: string) {
     };
     try {
       await hydratePinnedBodiesOnPanelOpen({
-        client,
+        fetchByStanzaIds: (stanzaIds) =>
+          client.fetchRoomMessagesByStanzaIds(spaceId, channelId, stanzaIds),
         spaceId,
         channelId,
         roomJid,
@@ -1538,6 +1565,81 @@ export function useChatAppController(giphyApiKey: string) {
       console.warn("hydratePinnedBodiesOnPanelOpen failed", error);
     }
   });
+  watch(() => ui.showPinnedPanel.value, async (open) => {
+    if (!open || ui.sidebarMode.value !== "dms") return;
+    const client = xmppClient.value;
+    const peerJid = dmConversations.activePeerJid.value;
+    const currentSession = session.value;
+    if (!client || !peerJid || !currentSession) return;
+    if (!("fetchDirectMessagesByStanzaIds" in client)) return;
+    const convertForTimeline = (archived: Parameters<typeof dmMessageFromArchived>[0]) => {
+      const live = dmMessageFromArchived(archived, barePeerJid(currentSession.jid), {
+        trustedMediaOrigin: trustedLinkPreviewMediaOrigin(currentSession),
+      });
+      return live ? fromLiveDmMessage(currentSession, live) : null;
+    };
+    try {
+      await hydratePinnedBodiesOnPanelOpen({
+        fetchByStanzaIds: (stanzaIds) =>
+          client.fetchDirectMessagesByStanzaIds(peerJid, stanzaIds),
+        spaceId: "",
+        channelId: "",
+        roomJid: peerJid,
+        timelineMessages: dmMessaging.messages.value,
+        convert: convertForTimeline,
+      });
+    } catch (error) {
+      console.warn("hydratePinnedBodiesOnPanelOpen failed", error);
+    }
+  });
+  watch(pinnedRooms, (rooms) => {
+    if (!ui.showPinnedPanel.value || ui.sidebarMode.value !== "dms") return;
+    const client = xmppClient.value;
+    const peerJid = dmConversations.activePeerJid.value;
+    const currentSession = session.value;
+    if (!client || !peerJid || !currentSession) return;
+    if (!("fetchDirectMessagesByStanzaIds" in client)) return;
+    const state = rooms.get(peerJid);
+    const entry = state?.entries[0];
+    if (!entry) return;
+    const convertForTimeline = (archived: Parameters<typeof dmMessageFromArchived>[0]) => {
+      const live = dmMessageFromArchived(archived, barePeerJid(currentSession.jid), {
+        trustedMediaOrigin: trustedLinkPreviewMediaOrigin(currentSession),
+      });
+      return live ? fromLiveDmMessage(currentSession, live) : null;
+    };
+    void hydrateSinglePinnedBody({
+      fetchByStanzaIds: (stanzaIds) =>
+        client.fetchDirectMessagesByStanzaIds(peerJid, stanzaIds),
+      spaceId: "",
+      channelId: "",
+      roomJid: peerJid,
+      stanzaId: entry.target_stanza_id,
+      timelineMessages: dmMessaging.messages.value,
+      convert: convertForTimeline,
+    }).catch((error) => console.warn("hydrateSinglePinnedBody failed", error));
+  });
+  watch(
+    [xmppClient, () => ui.sidebarMode.value, () => dmConversations.activePeerJid.value],
+    ([client, mode, peerJid]) => {
+      if (mode !== "dms" || !peerJid) return;
+      if (!client || !("fetchDirectPins" in client)) {
+        hydratePinnedRoom(peerJid, []);
+        return;
+      }
+      const epoch = pinnedRoomsEpoch();
+      void client.fetchDirectPins(peerJid)
+        .then((entries) => {
+          if (ui.sidebarMode.value !== "dms" || dmConversations.activePeerJid.value !== peerJid) return;
+          hydratePinnedRoom(peerJid, entries, epoch);
+        })
+        .catch((error: unknown) => {
+          console.warn("fetchDirectPins failed", error);
+          hydratePinnedRoom(peerJid, [], epoch);
+        });
+    },
+    { immediate: true },
+  );
   watch(activeExtensionRouteKey, () => {
     normalizeActiveRightPanel();
   }, { deep: true });
@@ -1753,10 +1855,9 @@ export function useChatAppController(giphyApiKey: string) {
     }
     ui.sidebarMode.value =
       match.id === "dm" || match.id === "dmList" ? "dms" : "channels";
-    // #414: only channel-context routes carry the pinned-panel flag;
-    // DM/home/settings/threads/admin/community always clear it.
+    // #414/#951: channel and DM conversation routes carry the pinned-panel flag.
     ui.showPinnedPanel.value =
-      match.id === "channel" || match.id === "channelExtension"
+      match.id === "channel" || match.id === "channelExtension" || match.id === "dm"
         ? match.search.pinned
         : false;
   }
@@ -1825,7 +1926,14 @@ export function useChatAppController(giphyApiKey: string) {
       }
       activeThreadTargetMessageId.value = null;
       activeThreadStack.value = match.search.thread;
-      activeRightPanel.value = match.search.thread.length > 0 ? "thread" : null;
+      ui.showPinnedPanel.value = match.search.pinned;
+      if (match.search.pinned) {
+        activeRightPanel.value = "pinned";
+      } else if (match.search.thread.length > 0) {
+        activeRightPanel.value = "thread";
+      } else {
+        activeRightPanel.value = null;
+      }
       // Dedup: a nested stack can legitimately repeat a thread id (e.g.
       // `[A,B,A]`), but each thread only needs one backfill.
       for (const threadId of new Set(match.search.thread)) {

--- a/chat/tests/pin-standalone-channel.test.ts
+++ b/chat/tests/pin-standalone-channel.test.ts
@@ -47,4 +47,13 @@ describe("pin/unpin handlers for standalone channels", () => {
     expect(pinRegion).not.toContain("currentSpace");
     expect(unpinRegion).not.toContain("currentSpace");
   });
+
+  test("pin target lookup uses the active timeline for DMs and channels", () => {
+    expect(controllerSource).toContain(
+      "activeTarget.value.messages.value.find((m) => m.id === messageId)",
+    );
+    expect(controllerSource).not.toContain(
+      "messaging.messages.value.find((m) => m.id === messageId)",
+    );
+  });
 });

--- a/chat/tests/pinned-message-bodies-service.test.ts
+++ b/chat/tests/pinned-message-bodies-service.test.ts
@@ -63,15 +63,11 @@ describe("hydratePinnedBodiesOnPanelOpen", () => {
   });
 
   it("fetches every stanza-id not already in the timeline", async () => {
-    const client = {
-      fetchRoomMessagesByStanzaIds: mock(async (_s: string, _c: string, ids: string[]) =>
-        ids.map((id) => archived(id)),
-      ),
-    };
+    const fetchByStanzaIds = mock(async (ids: string[]) => ids.map((id) => archived(id)));
     hydratePinnedRoom("room@conf.example", [pinEntry("sid-A"), pinEntry("sid-B")]);
 
     await hydratePinnedBodiesOnPanelOpen({
-      client,
+      fetchByStanzaIds,
       spaceId: "space1",
       channelId: "channel1",
       roomJid: "room@conf.example",
@@ -79,25 +75,17 @@ describe("hydratePinnedBodiesOnPanelOpen", () => {
       convert: fakeConvert,
     });
 
-    expect(client.fetchRoomMessagesByStanzaIds).toHaveBeenCalledWith(
-      "space1",
-      "channel1",
-      ["sid-A", "sid-B"],
-    );
+    expect(fetchByStanzaIds).toHaveBeenCalledWith(["sid-A", "sid-B"]);
     const room = $pinnedMessageBodies.get().get("room@conf.example");
     expect(room?.size).toBe(2);
   });
 
   it("skips fetching ids that already resolve from the timeline", async () => {
-    const client = {
-      fetchRoomMessagesByStanzaIds: mock(async (_s: string, _c: string, ids: string[]) =>
-        ids.map((id) => archived(id)),
-      ),
-    };
+    const fetchByStanzaIds = mock(async (ids: string[]) => ids.map((id) => archived(id)));
     hydratePinnedRoom("room@conf.example", [pinEntry("sid-A"), pinEntry("sid-B")]);
 
     await hydratePinnedBodiesOnPanelOpen({
-      client,
+      fetchByStanzaIds,
       spaceId: "space1",
       channelId: "channel1",
       roomJid: "room@conf.example",
@@ -107,18 +95,14 @@ describe("hydratePinnedBodiesOnPanelOpen", () => {
       convert: fakeConvert,
     });
 
-    expect(client.fetchRoomMessagesByStanzaIds).toHaveBeenCalledWith(
-      "space1",
-      "channel1",
-      ["sid-B"],
-    );
+    expect(fetchByStanzaIds).toHaveBeenCalledWith(["sid-B"]);
   });
 
   it("is a no-op when every id is already in the timeline", async () => {
-    const client = { fetchRoomMessagesByStanzaIds: mock(async () => []) };
+    const fetchByStanzaIds = mock(async () => []);
     hydratePinnedRoom("room@x", [pinEntry("sid-A")]);
     await hydratePinnedBodiesOnPanelOpen({
-      client,
+      fetchByStanzaIds,
       spaceId: "s",
       channelId: "c",
       roomJid: "room@x",
@@ -127,17 +111,15 @@ describe("hydratePinnedBodiesOnPanelOpen", () => {
       ],
       convert: fakeConvert,
     });
-    expect(client.fetchRoomMessagesByStanzaIds).not.toHaveBeenCalled();
+    expect(fetchByStanzaIds).not.toHaveBeenCalled();
   });
 
   it("is a no-op when the room has no pinned entries", async () => {
-    const client = {
-      fetchRoomMessagesByStanzaIds: mock(async () => []),
-    };
+    const fetchByStanzaIds = mock(async () => []);
     hydratePinnedRoom("room@x", []);
 
     await hydratePinnedBodiesOnPanelOpen({
-      client,
+      fetchByStanzaIds,
       spaceId: "space1",
       channelId: "channel1",
       roomJid: "room@x",
@@ -145,15 +127,11 @@ describe("hydratePinnedBodiesOnPanelOpen", () => {
       convert: fakeConvert,
     });
 
-    expect(client.fetchRoomMessagesByStanzaIds).not.toHaveBeenCalled();
+    expect(fetchByStanzaIds).not.toHaveBeenCalled();
   });
 
   it("skips fetching ids that are already in the body cache", async () => {
-    const client = {
-      fetchRoomMessagesByStanzaIds: mock(async (_s: string, _c: string, ids: string[]) =>
-        ids.map((id) => archived(id)),
-      ),
-    };
+    const fetchByStanzaIds = mock(async (ids: string[]) => ids.map((id) => archived(id)));
     hydratePinnedRoom("room@conf.example", [pinEntry("sid-A"), pinEntry("sid-B")]);
     // Pre-populate the cache with sid-A so only sid-B should be fetched.
     cachePinnedMessageBody(
@@ -164,7 +142,7 @@ describe("hydratePinnedBodiesOnPanelOpen", () => {
     );
 
     await hydratePinnedBodiesOnPanelOpen({
-      client,
+      fetchByStanzaIds,
       spaceId: "space1",
       channelId: "channel1",
       roomJid: "room@conf.example",
@@ -172,11 +150,7 @@ describe("hydratePinnedBodiesOnPanelOpen", () => {
       convert: fakeConvert,
     });
 
-    expect(client.fetchRoomMessagesByStanzaIds).toHaveBeenCalledWith(
-      "space1",
-      "channel1",
-      ["sid-B"],
-    );
+    expect(fetchByStanzaIds).toHaveBeenCalledWith(["sid-B"]);
   });
 });
 
@@ -187,13 +161,9 @@ describe("hydrateSinglePinnedBody", () => {
   });
 
   it("fetches the single id when not in the timeline", async () => {
-    const client = {
-      fetchRoomMessagesByStanzaIds: mock(async (_s: string, _c: string, _ids: string[]) =>
-        [archived("sid-new", "live body", "room@x")],
-      ),
-    };
+    const fetchByStanzaIds = mock(async () => [archived("sid-new", "live body", "room@x")]);
     await hydrateSinglePinnedBody({
-      client,
+      fetchByStanzaIds,
       spaceId: "space1",
       channelId: "channel1",
       roomJid: "room@x",
@@ -201,18 +171,14 @@ describe("hydrateSinglePinnedBody", () => {
       timelineMessages: [],
       convert: fakeConvert,
     });
-    expect(client.fetchRoomMessagesByStanzaIds).toHaveBeenCalledWith(
-      "space1",
-      "channel1",
-      ["sid-new"],
-    );
+    expect(fetchByStanzaIds).toHaveBeenCalledWith(["sid-new"]);
     expect($pinnedMessageBodies.get().get("room@x")?.get("sid-new")).toBeTruthy();
   });
 
   it("short-circuits when id is in the timeline", async () => {
-    const client = { fetchRoomMessagesByStanzaIds: mock(async () => []) };
+    const fetchByStanzaIds = mock(async () => []);
     await hydrateSinglePinnedBody({
-      client,
+      fetchByStanzaIds,
       spaceId: "s",
       channelId: "c",
       roomJid: "room@x",
@@ -222,11 +188,11 @@ describe("hydrateSinglePinnedBody", () => {
       ],
       convert: fakeConvert,
     });
-    expect(client.fetchRoomMessagesByStanzaIds).not.toHaveBeenCalled();
+    expect(fetchByStanzaIds).not.toHaveBeenCalled();
   });
 
   it("short-circuits when id is already cached", async () => {
-    const client = { fetchRoomMessagesByStanzaIds: mock(async () => []) };
+    const fetchByStanzaIds = mock(async () => []);
     cachePinnedMessageBody(
       "room@x",
       "sid-cached",
@@ -234,7 +200,7 @@ describe("hydrateSinglePinnedBody", () => {
       pinnedMessageBodiesEpoch(),
     );
     await hydrateSinglePinnedBody({
-      client,
+      fetchByStanzaIds,
       spaceId: "s",
       channelId: "c",
       roomJid: "room@x",
@@ -242,7 +208,7 @@ describe("hydrateSinglePinnedBody", () => {
       timelineMessages: [],
       convert: fakeConvert,
     });
-    expect(client.fetchRoomMessagesByStanzaIds).not.toHaveBeenCalled();
+    expect(fetchByStanzaIds).not.toHaveBeenCalled();
   });
 });
 
@@ -278,13 +244,11 @@ describe("matchRequestedStanzaId — branch 2: singular stanza_id field", () => 
       // deliberately no stanza_ids array — branch 1 must not match
     } as unknown as WasmArchivedMessage;
 
-    const client = {
-      fetchRoomMessagesByStanzaIds: mock(async () => [archivedFixture]),
-    };
+    const fetchByStanzaIds = mock(async () => [archivedFixture]);
     hydratePinnedRoom("room@x", [pinEntry("uuid-X")]);
 
     await hydratePinnedBodiesOnPanelOpen({
-      client,
+      fetchByStanzaIds,
       spaceId: "s",
       channelId: "c",
       roomJid: "room@x",
@@ -296,15 +260,13 @@ describe("matchRequestedStanzaId — branch 2: singular stanza_id field", () => 
   });
 });
 
-describe("matchRequestedStanzaId — wrong-JID fall-through (no match)", () => {
+describe("matchRequestedStanzaId — personal archive stanza-id", () => {
   beforeEach(() => {
     resetPinnedRooms();
     resetPinnedMessageBodies();
   });
 
-  it("does not match when stanza_ids only has entries with by !== roomJid", async () => {
-    // The stanza_ids array contains only a foreign-by entry; branch 1 must
-    // not match. Branch 2 has no stanza_id_by. Result: no cache entry.
+  it("matches a requested stanza-id even when by is a personal archive JID", async () => {
     const archivedFixture = {
       id: "uuid-canonical",
       mam_id: "mam-id",
@@ -320,16 +282,14 @@ describe("matchRequestedStanzaId — wrong-JID fall-through (no match)", () => {
       markup_spans: [],
       is_sticker: false,
       shared_files: [],
-      stanza_ids: [{ by: "foreign.example", id: "uuid-canonical" }],
+      stanza_ids: [{ by: "alice@example.com", id: "uuid-canonical" }],
     } as unknown as WasmArchivedMessage;
 
-    const client = {
-      fetchRoomMessagesByStanzaIds: mock(async () => [archivedFixture]),
-    };
+    const fetchByStanzaIds = mock(async () => [archivedFixture]);
     hydratePinnedRoom("room@x", [pinEntry("uuid-canonical")]);
 
     await hydratePinnedBodiesOnPanelOpen({
-      client,
+      fetchByStanzaIds,
       spaceId: "s",
       channelId: "c",
       roomJid: "room@x",
@@ -337,9 +297,8 @@ describe("matchRequestedStanzaId — wrong-JID fall-through (no match)", () => {
       convert: fakeConvert,
     });
 
-    // Neither branch matched → nothing cached.
     const room = $pinnedMessageBodies.get().get("room@x");
-    expect(room?.size ?? 0).toBe(0);
+    expect(room?.get("uuid-canonical")?.body).toBe("foreign body");
   });
 });
 
@@ -354,13 +313,11 @@ describe("hydratePinnedBodiesOnPanelOpen — alias + requested-id fixes", () => 
   });
 
   it("skips fetching when the requested id is in timeline under reactionTargetId alias", async () => {
-    const client = {
-      fetchRoomMessagesByStanzaIds: mock(async () => []),
-    };
+    const fetchByStanzaIds = mock(async () => []);
     hydratePinnedRoom("room@x", [pinEntry("uuid-canonical")]);
 
     await hydratePinnedBodiesOnPanelOpen({
-      client,
+      fetchByStanzaIds,
       spaceId: "s",
       channelId: "c",
       roomJid: "room@x",
@@ -377,7 +334,7 @@ describe("hydratePinnedBodiesOnPanelOpen — alias + requested-id fixes", () => 
       convert: fakeConvert,
     });
 
-    expect(client.fetchRoomMessagesByStanzaIds).not.toHaveBeenCalled();
+    expect(fetchByStanzaIds).not.toHaveBeenCalled();
   });
 
   it("caches body under requested stanza-id even when result's id is the wire message-id", async () => {
@@ -404,9 +361,7 @@ describe("hydratePinnedBodiesOnPanelOpen — alias + requested-id fixes", () => 
       stanza_ids: [{ by: "room@x", id: "uuid-canonical" }],
     } as unknown as WasmArchivedMessage;
 
-    const client = {
-      fetchRoomMessagesByStanzaIds: mock(async () => [archivedFixture]),
-    };
+    const fetchByStanzaIds = mock(async () => [archivedFixture]);
     hydratePinnedRoom("room@x", [pinEntry("uuid-canonical")]);
 
     // Convert maps the archived to a TimelineMessage whose `id` is the
@@ -421,7 +376,7 @@ describe("hydratePinnedBodiesOnPanelOpen — alias + requested-id fixes", () => 
     } as TimelineMessage);
 
     await hydratePinnedBodiesOnPanelOpen({
-      client,
+      fetchByStanzaIds,
       spaceId: "s",
       channelId: "c",
       roomJid: "room@x",

--- a/chat/tests/router.test.ts
+++ b/chat/tests/router.test.ts
@@ -58,7 +58,16 @@ describe("matchLocation", () => {
     expect(m).toEqual({
       id: "dm",
       params: { username: "first.last_user+test" },
-      search: { thread: [] },
+      search: { thread: [], pinned: false },
+    });
+  });
+
+  test("parses dm with thread stack and pinned flag", () => {
+    const m = matchLocation("/dm/first.last_user%2Btest", "?thread=root&pinned=1");
+    expect(m).toEqual({
+      id: "dm",
+      params: { username: "first.last_user+test" },
+      search: { thread: ["root"], pinned: true },
     });
   });
 
@@ -248,7 +257,16 @@ describe("buildHref ↔ matchLocation round trips", () => {
     const m: RouteMatch = {
       id: "dm",
       params: { username: "first.last_user+test" },
-      search: { thread: ["root"] },
+      search: { thread: ["root"], pinned: false },
+    };
+    expect(roundtrip(m)).toEqual(m);
+  });
+
+  test("dm with pinned flag round-trips", () => {
+    const m: RouteMatch = {
+      id: "dm",
+      params: { username: "first.last_user+test" },
+      search: { thread: ["root"], pinned: true },
     };
     expect(roundtrip(m)).toEqual(m);
   });

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -594,6 +594,7 @@ async fn create_websocket_state(
                 pep_feed_bridge: Arc::new(crate::pep_feed_bridge::PepFeedBridge::new()),
                 call_threads: Arc::new(dashmap::DashMap::new()),
                 dm_call_threads: Arc::new(dashmap::DashMap::new()),
+                dm_pin_store: Arc::new(crate::server::routes::websocket::DmPinStore::default()),
                 dm_call_thread_projections: Arc::new(dashmap::DashSet::new()),
                 pending_dm_call_offers: Arc::new(dashmap::DashMap::new()),
                 sfu: sfu_service,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
@@ -400,7 +400,7 @@ pub async fn handle_iq_with_conn_state(
         .await;
     }
 
-    if is_pin_query_iq(&iq, muc_domain) {
+    if is_pin_query_iq(&iq, muc_domain, domain) {
         return handle_pin_query_iq(&iq, state, phase.bound_jid(), response_from, response_to)
             .await;
     }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pin_query.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pin_query.rs
@@ -22,15 +22,18 @@ use xmpp_parsers::iq::Iq;
 use xmpp_parsers::minidom::Element;
 
 /// Detects `<iq type='get'><query xmlns='urn:waddle:pin:0'/></iq>`
-/// targeting a MUC room JID.
-pub(super) fn is_pin_query_iq(iq: &Iq, muc_domain: &str) -> bool {
+/// targeting either a MUC room JID or a local bare 1:1 peer JID.
+pub(super) fn is_pin_query_iq(iq: &Iq, muc_domain: &str, xmpp_domain: &str) -> bool {
     let Iq::Get { payload, .. } = iq else {
         return false;
     };
     if payload.name() != "query" || payload.ns() != NS_WADDLE_PIN_V0 {
         return false;
     }
-    iq.to().is_some_and(|to| to.domain().as_str() == muc_domain)
+    iq.to().is_some_and(|to| {
+        to.resource().is_none()
+            && (to.domain().as_str() == muc_domain || to.domain().as_str() == xmpp_domain)
+    })
 }
 
 pub(super) async fn handle_pin_query_iq(
@@ -61,8 +64,18 @@ pub(super) async fn handle_pin_query_iq(
             iq.id(),
             response_from,
             response_to,
-            bad_request_iq_error("Pin query 'to' must be a bare room JID."),
+            bad_request_iq_error("Pin query 'to' must be a bare room or peer JID."),
         )];
+    }
+    if target.domain().as_str() != state.deps.service_domains.muc {
+        return handle_dm_pin_query_iq(
+            iq,
+            state,
+            sender,
+            target.to_bare(),
+            response_from,
+            response_to,
+        );
     }
     let room_jid = target.to_bare();
 
@@ -157,47 +170,40 @@ pub(super) async fn handle_pin_query_iq(
         }
     };
 
+    build_pin_query_result(iq, entries, response_from, response_to)
+}
+
+fn handle_dm_pin_query_iq(
+    iq: &Iq,
+    state: &WebSocketState,
+    sender: &FullJid,
+    peer: jid::BareJid,
+    response_from: Option<&str>,
+    response_to: Option<&str>,
+) -> Vec<String> {
+    if peer.domain() != sender.domain() {
+        return vec![build_iq_error_xml_typed(
+            iq.id(),
+            response_from,
+            response_to,
+            forbidden_iq_error("DM pin list is visible only to local conversation participants."),
+        )];
+    }
+    let key = crate::server::routes::websocket::DmPairKey::new(sender.to_bare(), peer);
+    let entries = state.deps.protocol.dm_pin_store.list(&key);
+    build_pin_query_result(iq, entries, response_from, response_to)
+}
+
+fn build_pin_query_result(
+    iq: &Iq,
+    entries: Vec<waddle_xmpp::muc::PinnedEntry>,
+    response_from: Option<&str>,
+    response_to: Option<&str>,
+) -> Vec<String> {
     let mut query = Element::builder("query", NS_WADDLE_PIN_V0).build();
     for entry in entries {
-        let mut pin_elem = Element::builder("pin", NS_WADDLE_PIN_V0)
-            .attr(
-                minidom::rxml::xml_ncname!("id").to_owned(),
-                entry.target_stanza_id.id.as_str(),
-            )
-            .attr(
-                minidom::rxml::xml_ncname!("by").to_owned(),
-                entry.pinner_jid.to_string().as_str(),
-            )
-            .attr(
-                minidom::rxml::xml_ncname!("at").to_owned(),
-                entry.pinned_at.to_rfc3339().as_str(),
-            )
-            .build();
-        let mut preview = Element::builder("preview", NS_WADDLE_PIN_V0).build();
-        let mut author = Element::builder("author", NS_WADDLE_PIN_V0)
-            .attr(
-                minidom::rxml::xml_ncname!("jid").to_owned(),
-                entry.preview.author_jid.to_string().as_str(),
-            )
-            .build();
-        if let Some(ref nick) = entry.preview.author_nick {
-            author.set_attr(
-                minidom::rxml::Namespace::NONE,
-                minidom::rxml::xml_ncname!("nick").to_owned(),
-                nick,
-            );
-        }
-        preview.append_child(author);
-        let mut text = Element::builder("text", NS_WADDLE_PIN_V0).build();
-        text.append_text_node(&entry.preview.text);
-        preview.append_child(text);
-        let mut ts = Element::builder("ts", NS_WADDLE_PIN_V0).build();
-        ts.append_text_node(entry.preview.message_timestamp.to_rfc3339());
-        preview.append_child(ts);
-        pin_elem.append_child(preview);
-        query.append_child(pin_elem);
+        append_pin_entry(&mut query, entry);
     }
-
     let response = Iq::Result {
         from: response_from.and_then(|s| jid::Jid::from_str(s).ok()),
         to: response_to.and_then(|s| jid::Jid::from_str(s).ok()),
@@ -205,6 +211,46 @@ pub(super) async fn handle_pin_query_iq(
         payload: Some(query),
     };
     vec![iq_to_xml(response)]
+}
+
+fn append_pin_entry(query: &mut Element, entry: waddle_xmpp::muc::PinnedEntry) {
+    let mut pin_elem = Element::builder("pin", NS_WADDLE_PIN_V0)
+        .attr(
+            minidom::rxml::xml_ncname!("id").to_owned(),
+            entry.target_stanza_id.id.as_str(),
+        )
+        .attr(
+            minidom::rxml::xml_ncname!("by").to_owned(),
+            entry.pinner_jid.to_string().as_str(),
+        )
+        .attr(
+            minidom::rxml::xml_ncname!("at").to_owned(),
+            entry.pinned_at.to_rfc3339().as_str(),
+        )
+        .build();
+    let mut preview = Element::builder("preview", NS_WADDLE_PIN_V0).build();
+    let mut author = Element::builder("author", NS_WADDLE_PIN_V0)
+        .attr(
+            minidom::rxml::xml_ncname!("jid").to_owned(),
+            entry.preview.author_jid.to_string().as_str(),
+        )
+        .build();
+    if let Some(ref nick) = entry.preview.author_nick {
+        author.set_attr(
+            minidom::rxml::Namespace::NONE,
+            minidom::rxml::xml_ncname!("nick").to_owned(),
+            nick,
+        );
+    }
+    preview.append_child(author);
+    let mut text = Element::builder("text", NS_WADDLE_PIN_V0).build();
+    text.append_text_node(&entry.preview.text);
+    preview.append_child(text);
+    let mut ts = Element::builder("ts", NS_WADDLE_PIN_V0).build();
+    ts.append_text_node(entry.preview.message_timestamp.to_rfc3339());
+    preview.append_child(ts);
+    pin_elem.append_child(preview);
+    query.append_child(pin_elem);
 }
 
 #[cfg(test)]
@@ -224,21 +270,21 @@ mod tests {
     fn is_pin_query_iq_accepts_well_formed_get() {
         let payload = Element::builder("query", NS_WADDLE_PIN_V0).build();
         let iq = iq_get_with_payload(payload, Some("room@conf.example"));
-        assert!(is_pin_query_iq(&iq, "conf.example"));
+        assert!(is_pin_query_iq(&iq, "conf.example", "example.com"));
     }
 
     #[test]
     fn is_pin_query_iq_rejects_wrong_namespace() {
         let payload = Element::builder("query", "wrong:ns").build();
         let iq = iq_get_with_payload(payload, Some("room@conf.example"));
-        assert!(!is_pin_query_iq(&iq, "conf.example"));
+        assert!(!is_pin_query_iq(&iq, "conf.example", "example.com"));
     }
 
     #[test]
     fn is_pin_query_iq_rejects_wrong_element_name() {
         let payload = Element::builder("items", NS_WADDLE_PIN_V0).build();
         let iq = iq_get_with_payload(payload, Some("room@conf.example"));
-        assert!(!is_pin_query_iq(&iq, "conf.example"));
+        assert!(!is_pin_query_iq(&iq, "conf.example", "example.com"));
     }
 
     #[test]
@@ -250,20 +296,27 @@ mod tests {
             id: "test-iq".into(),
             payload,
         };
-        assert!(!is_pin_query_iq(&iq, "conf.example"));
+        assert!(!is_pin_query_iq(&iq, "conf.example", "example.com"));
     }
 
     #[test]
     fn is_pin_query_iq_rejects_missing_to() {
         let payload = Element::builder("query", NS_WADDLE_PIN_V0).build();
         let iq = iq_get_with_payload(payload, None);
-        assert!(!is_pin_query_iq(&iq, "conf.example"));
+        assert!(!is_pin_query_iq(&iq, "conf.example", "example.com"));
     }
 
     #[test]
     fn is_pin_query_iq_rejects_wrong_domain() {
         let payload = Element::builder("query", NS_WADDLE_PIN_V0).build();
         let iq = iq_get_with_payload(payload, Some("room@other.example"));
-        assert!(!is_pin_query_iq(&iq, "conf.example"));
+        assert!(!is_pin_query_iq(&iq, "conf.example", "example.com"));
+    }
+
+    #[test]
+    fn is_pin_query_iq_accepts_local_bare_dm_peer() {
+        let payload = Element::builder("query", NS_WADDLE_PIN_V0).build();
+        let iq = iq_get_with_payload(payload, Some("alice@example.com"));
+        assert!(is_pin_query_iq(&iq, "conf.example", "example.com"));
     }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, collections::BTreeMap};
 
-use tracing::warn;
+use tracing::{debug, warn};
 use waddle_xmpp::{
     muc::room_actor::{ChangeAffiliation, GetAdminContext, GetConfig},
     muc::room_registry_actor::GetRoom,
@@ -34,6 +34,7 @@ use crate::server::routes::websocket::link_preview_telemetry::{
     record_link_preview_event, LinkPreviewTelemetryEvent,
 };
 use waddle_xmpp::protocol::ConnectionPhase;
+use waddle_xmpp_core::xep0359::StanzaId;
 
 /// Thin transport adapter that drives the sans-I/O dispatcher
 /// (#229 PR16 + PR18). Every `<message/>` stanza arriving on the
@@ -97,6 +98,10 @@ pub async fn handle_message(
     {
         return frames;
     }
+    if let Some(frames) = handle_dm_pin_message(&incoming, state, &bound_jid).await {
+        return frames;
+    }
+    handle_dm_pin_retraction_cascade(&incoming, state, &bound_jid).await;
 
     if incoming.type_ != xmpp_parsers::message::MessageType::Error
         && message_has_inbox_payload(&incoming)
@@ -140,6 +145,438 @@ pub async fn handle_message(
     let deps = build_interpret_deps(state, authenticated_session);
     let (frames, _close) = drive_interpret_loop(events, sm, &deps).await;
     frames
+}
+
+async fn handle_dm_pin_message(
+    incoming: &xmpp_parsers::message::Message,
+    state: &WebSocketState,
+    bound_jid: &jid::FullJid,
+) -> Option<Vec<String>> {
+    if incoming.type_ != xmpp_parsers::message::MessageType::Chat {
+        return None;
+    }
+    let intent = match waddle_xmpp::xep::extract_pin_intent_from_message(incoming) {
+        Some(intent) => intent,
+        None => {
+            if incoming
+                .payloads
+                .iter()
+                .any(|payload| payload.ns() == waddle_xmpp::xep::NS_WADDLE_PIN_V0)
+            {
+                let mut stamped = incoming.clone();
+                stamped.from = Some(jid::Jid::from(bound_jid.clone()));
+                let reply = bad_request_reply(&stamped, "Malformed DM pin marker.");
+                return stanza_to_string(reply).ok().map(|frame| vec![frame]);
+            }
+            return None;
+        }
+    };
+    let target = intent.target().to_string();
+    let Some(peer) = incoming.to.as_ref().map(|to| to.to_bare()) else {
+        return Some(Vec::new());
+    };
+    if peer.domain() != bound_jid.domain() {
+        let mut stamped = incoming.clone();
+        stamped.from = Some(jid::Jid::from(bound_jid.clone()));
+        let reply = message_error_reply(
+            &stamped,
+            xmpp_parsers::stanza_error::StanzaError::new(
+                xmpp_parsers::stanza_error::ErrorType::Auth,
+                xmpp_parsers::stanza_error::DefinedCondition::Forbidden,
+                "en",
+                "DM pins are only supported for local peers.",
+            ),
+        );
+        return stanza_to_string(reply).ok().map(|frame| vec![frame]);
+    }
+
+    let sender = bound_jid.to_bare();
+    let key = crate::server::routes::websocket::DmPairKey::new(sender.clone(), peer.clone());
+    if matches!(intent, waddle_xmpp::xep::PinIntent::Unpin { .. }) {
+        let Some(target) =
+            lookup_dm_pin_target(state, [&peer, &sender], &sender, &peer, &target).await
+        else {
+            return Some(Vec::new());
+        };
+        if !state
+            .deps
+            .protocol
+            .dm_pin_store
+            .unpin(&key, &target.canonical_stanza_id)
+        {
+            return Some(Vec::new());
+        }
+        let event = build_dm_pin_event_message(
+            &sender,
+            &peer,
+            DmPinAction::Unpinned,
+            &target.canonical_stanza_id,
+            &sender,
+            None,
+        );
+        fanout_dm_pin_event(state, &sender, &[sender.clone(), peer], event).await;
+        return Some(Vec::new());
+    }
+    let target = match lookup_dm_pin_target(state, [&peer, &sender], &sender, &peer, &target).await
+    {
+        Some(found) => found,
+        None => {
+            let mut stamped = incoming.clone();
+            stamped.from = Some(jid::Jid::from(bound_jid.clone()));
+            let reply = message_error_reply(
+                &stamped,
+                xmpp_parsers::stanza_error::StanzaError::new(
+                    xmpp_parsers::stanza_error::ErrorType::Cancel,
+                    xmpp_parsers::stanza_error::DefinedCondition::ItemNotFound,
+                    "en",
+                    "Pinned DM target was not found.",
+                ),
+            );
+            return stanza_to_string(reply).ok().map(|frame| vec![frame]);
+        }
+    };
+    let body = target.archived.body.as_deref().unwrap_or("");
+    let preview = waddle_xmpp::muc::PinPreview::new(
+        target.archived.from.to_bare(),
+        None,
+        body,
+        target.archived.timestamp,
+    );
+    let target_stanza_id = target.canonical_stanza_id.clone();
+    let entry = waddle_xmpp::muc::PinnedEntry {
+        target_stanza_id: target_stanza_id.clone(),
+        pinner_jid: sender.clone(),
+        pinned_at: chrono::Utc::now(),
+        preview,
+    };
+    state
+        .deps
+        .protocol
+        .dm_pin_store
+        .apply_pin(key, entry.clone());
+
+    let event = build_dm_pin_event_message(
+        &sender,
+        &peer,
+        DmPinAction::Pinned,
+        &entry.target_stanza_id,
+        &entry.pinner_jid,
+        Some(&entry.preview),
+    );
+    fanout_dm_pin_event(state, &sender, &[sender.clone(), peer], event).await;
+    Some(Vec::new())
+}
+
+async fn lookup_dm_pin_target<'a>(
+    state: &WebSocketState,
+    archives: impl IntoIterator<Item = &'a jid::BareJid>,
+    sender: &jid::BareJid,
+    peer: &jid::BareJid,
+    target: &str,
+) -> Option<DmPinTarget> {
+    for archive in archives {
+        match state
+            .deps
+            .protocol
+            .mam_storage
+            .get_message_by_archive_or_stanza_id(archive, target)
+            .await
+        {
+            Ok(Some(archived))
+                if archived_belongs_to_dm_pair(&archived, sender, peer)
+                    && !is_tombstoned_archive_row(&archived) =>
+            {
+                let canonical_stanza_id = canonical_dm_pin_stanza_id(&archived, archive);
+                return Some(DmPinTarget {
+                    canonical_stanza_id,
+                    archived,
+                });
+            }
+            Ok(Some(_)) => {}
+            Ok(None) => {}
+            Err(error) => {
+                warn!(
+                    archive = %archive,
+                    target,
+                    %error,
+                    "DM pin target lookup failed"
+                );
+            }
+        }
+    }
+    None
+}
+
+struct DmPinTarget {
+    canonical_stanza_id: StanzaId,
+    archived: waddle_xmpp::mam::ArchivedMessage,
+}
+
+fn canonical_dm_pin_stanza_id(
+    archived: &waddle_xmpp::mam::ArchivedMessage,
+    archive_jid: &jid::BareJid,
+) -> StanzaId {
+    let by = jid::Jid::from(archive_jid.clone());
+    if let Some(origin_id) = archived.origin_id.as_ref() {
+        return StanzaId::new(origin_id.id.clone(), by);
+    }
+    if let Some(stanza_id) = archived.stanza_id.as_ref() {
+        return StanzaId::new(stanza_id.id.clone(), by);
+    }
+    StanzaId::new(archived.id.clone(), by)
+}
+
+fn is_tombstoned_archive_row(archived: &waddle_xmpp::mam::ArchivedMessage) -> bool {
+    matches!(
+        archived
+            .rich
+            .as_ref()
+            .and_then(|rich| rich.payload.as_ref()),
+        Some(waddle_xmpp::mam::ArchivedRichPayload::Tombstone(_))
+    )
+}
+
+fn archived_belongs_to_dm_pair(
+    archived: &waddle_xmpp::mam::ArchivedMessage,
+    sender: &jid::BareJid,
+    peer: &jid::BareJid,
+) -> bool {
+    let from = archived.from.to_bare();
+    let to = archived.to.to_bare();
+    (from == *sender && to == *peer) || (from == *peer && to == *sender)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DmPinAction {
+    Pinned,
+    Unpinned,
+}
+
+impl DmPinAction {
+    fn as_attr(self) -> &'static str {
+        match self {
+            Self::Pinned => "pinned",
+            Self::Unpinned => "unpinned",
+        }
+    }
+
+    fn body_verb(self) -> &'static str {
+        match self {
+            Self::Pinned => "pinned",
+            Self::Unpinned => "unpinned",
+        }
+    }
+}
+
+fn build_dm_pin_event_message(
+    sender: &jid::BareJid,
+    peer: &jid::BareJid,
+    action: DmPinAction,
+    target: &StanzaId,
+    by: &jid::BareJid,
+    preview: Option<&waddle_xmpp::muc::PinPreview>,
+) -> xmpp_parsers::message::Message {
+    let mut event = xmpp_parsers::message::Message::new(Some(jid::Jid::from(peer.clone())));
+    event.from = Some(jid::Jid::from(sender.clone()));
+    event.type_ = xmpp_parsers::message::MessageType::Chat;
+    event.bodies.insert(
+        xmpp_parsers::message::Lang::new(),
+        format!("{by} {} a message", action.body_verb()),
+    );
+    let mut pin_event = minidom::Element::builder("pin-event", waddle_xmpp::xep::NS_WADDLE_PIN_V0)
+        .attr(
+            minidom::rxml::xml_ncname!("action").to_owned(),
+            action.as_attr(),
+        )
+        .attr(
+            minidom::rxml::xml_ncname!("target").to_owned(),
+            target.id.as_str(),
+        )
+        .attr(
+            minidom::rxml::xml_ncname!("by").to_owned(),
+            by.to_string().as_str(),
+        )
+        .build();
+    if let Some(preview) = preview {
+        let mut preview_elem =
+            minidom::Element::builder("preview", waddle_xmpp::xep::NS_WADDLE_PIN_V0).build();
+        let author = minidom::Element::builder("author", waddle_xmpp::xep::NS_WADDLE_PIN_V0)
+            .attr(
+                minidom::rxml::xml_ncname!("jid").to_owned(),
+                preview.author_jid.to_string().as_str(),
+            )
+            .build();
+        preview_elem.append_child(author);
+        let mut text =
+            minidom::Element::builder("text", waddle_xmpp::xep::NS_WADDLE_PIN_V0).build();
+        text.append_text_node(&preview.text);
+        preview_elem.append_child(text);
+        let mut ts = minidom::Element::builder("ts", waddle_xmpp::xep::NS_WADDLE_PIN_V0).build();
+        ts.append_text_node(preview.message_timestamp.to_rfc3339());
+        preview_elem.append_child(ts);
+        pin_event.append_child(preview_elem);
+    }
+    event.payloads.push(pin_event);
+    event
+}
+
+async fn fanout_dm_pin_event(
+    state: &WebSocketState,
+    sender: &jid::BareJid,
+    recipients: &[jid::BareJid],
+    event: xmpp_parsers::message::Message,
+) {
+    for resource in state
+        .deps
+        .protocol
+        .connection_registry
+        .list_connections()
+        .into_iter()
+        .filter(|resource| {
+            recipients
+                .iter()
+                .any(|recipient| resource.to_bare() == *recipient)
+        })
+    {
+        let recipient = resource.to_bare();
+        if dm_pin_delivery_blocked(state, sender, &recipient).await {
+            debug!(
+                from = %sender,
+                to = %recipient,
+                "Suppressing DM pin event because XEP-0191 blocks delivery"
+            );
+            continue;
+        }
+        let _ = state
+            .deps
+            .protocol
+            .connection_registry
+            .try_send_to(&resource, Stanza::Message(event.clone()));
+    }
+}
+
+async fn dm_pin_delivery_blocked(
+    state: &WebSocketState,
+    sender: &jid::BareJid,
+    recipient: &jid::BareJid,
+) -> bool {
+    if sender == recipient {
+        return false;
+    }
+    let sender_jid = jid::Jid::from(sender.clone());
+    let recipient_jid = jid::Jid::from(recipient.clone());
+    match state
+        .deps
+        .protocol
+        .blocking_storage
+        .list_blocked_jid_entries(recipient)
+        .await
+    {
+        Ok(entries) => {
+            if waddle_xmpp::protocol::Blocklist::new(entries).contains_jid(&sender_jid) {
+                return true;
+            }
+        }
+        Err(error) => {
+            warn!(
+                from = %sender,
+                to = %recipient,
+                %error,
+                "Failed to check recipient blocklist for DM pin event; failing closed"
+            );
+            return true;
+        }
+    }
+    match state
+        .deps
+        .protocol
+        .blocking_storage
+        .list_blocked_jid_entries(sender)
+        .await
+    {
+        Ok(entries) => waddle_xmpp::protocol::Blocklist::new(entries).contains_jid(&recipient_jid),
+        Err(error) => {
+            warn!(
+                from = %sender,
+                to = %recipient,
+                %error,
+                "Failed to check sender blocklist for DM pin event; failing closed"
+            );
+            true
+        }
+    }
+}
+
+async fn handle_dm_pin_retraction_cascade(
+    incoming: &xmpp_parsers::message::Message,
+    state: &WebSocketState,
+    bound_jid: &jid::FullJid,
+) {
+    if incoming.type_ != xmpp_parsers::message::MessageType::Chat {
+        return;
+    }
+    let Some(waddle_xmpp::xep::RetractionKind::Request(retraction)) =
+        waddle_xmpp::xep::extract_retraction_from_message(incoming)
+    else {
+        return;
+    };
+    let Some(peer) = incoming.to.as_ref().map(|to| to.to_bare()) else {
+        return;
+    };
+    if peer.domain() != bound_jid.domain() {
+        return;
+    }
+    let sender = bound_jid.to_bare();
+    let key = crate::server::routes::websocket::DmPairKey::new(sender.clone(), peer.clone());
+    let Some(target) = lookup_dm_pin_target(
+        state,
+        [&peer, &sender],
+        &sender,
+        &peer,
+        retraction.retracts_id.as_str(),
+    )
+    .await
+    else {
+        return;
+    };
+    if target.archived.from.to_bare() != sender {
+        return;
+    }
+    if !state
+        .deps
+        .protocol
+        .dm_pin_store
+        .contains(&key, &target.canonical_stanza_id)
+    {
+        return;
+    }
+    if !state
+        .deps
+        .protocol
+        .dm_pin_store
+        .unpin(&key, &target.canonical_stanza_id)
+    {
+        return;
+    }
+    let event = build_dm_pin_event_message(
+        &sender,
+        &peer,
+        DmPinAction::Unpinned,
+        &target.canonical_stanza_id,
+        &sender,
+        None,
+    );
+    let mut event = event;
+    if let Some(pin_event) = event.payloads.iter_mut().find(|payload| {
+        payload.name() == "pin-event" && payload.ns() == waddle_xmpp::xep::NS_WADDLE_PIN_V0
+    }) {
+        pin_event.set_attr(
+            minidom::rxml::Namespace::NONE,
+            minidom::rxml::xml_ncname!("reason").to_owned(),
+            "retracted",
+        );
+    }
+    fanout_dm_pin_event(state, &sender, &[sender.clone(), peer], event).await;
 }
 
 async fn handle_group_dm_mediated_invite(

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -92,8 +92,8 @@ pub mod handlers;
 pub use cleanup::cleanup_muc_presence_for_jid;
 pub use connection::router;
 pub use state::{
-    ActiveCallThread, DmCallThreadKey, PendingDmCallOffer, ProtocolServices, WebSocketDeps,
-    WebSocketState, XmppServiceDomains,
+    ActiveCallThread, DmCallThreadKey, DmPairKey, DmPinStore, PendingDmCallOffer, ProtocolServices,
+    WebSocketDeps, WebSocketState, XmppServiceDomains,
 };
 
 pub(crate) use cleanup::{

--- a/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
@@ -228,6 +228,7 @@ mod tests {
                     pep_feed_bridge: Arc::clone(&deps.protocol.pep_feed_bridge),
                     call_threads: Arc::clone(&deps.protocol.call_threads),
                     dm_call_threads: Arc::clone(&deps.protocol.dm_call_threads),
+                    dm_pin_store: Arc::clone(&deps.protocol.dm_pin_store),
                     dm_call_thread_projections: Arc::clone(
                         &deps.protocol.dm_call_thread_projections,
                     ),

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -43,6 +43,82 @@ pub struct PendingDmCallOffer {
     pub started: chrono::DateTime<chrono::Utc>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DmPairKey {
+    pub low_peer: BareJid,
+    pub high_peer: BareJid,
+}
+
+impl DmPairKey {
+    pub fn new(a: BareJid, b: BareJid) -> Self {
+        let (low_peer, high_peer) = if a.as_str() <= b.as_str() {
+            (a, b)
+        } else {
+            (b, a)
+        };
+        Self {
+            low_peer,
+            high_peer,
+        }
+    }
+
+    pub fn contains(&self, jid: &BareJid) -> bool {
+        self.low_peer == *jid || self.high_peer == *jid
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct DmPinStore {
+    entries: dashmap::DashMap<DmPairKey, Vec<waddle_xmpp::muc::PinnedEntry>>,
+}
+
+impl DmPinStore {
+    pub fn apply_pin(&self, key: DmPairKey, entry: waddle_xmpp::muc::PinnedEntry) {
+        let target_stanza_id = entry.target_stanza_id.clone();
+        let mut entries = self.entries.entry(key).or_default();
+        entries.retain(|existing| existing.target_stanza_id.id != target_stanza_id.id);
+        entries.insert(0, entry);
+        if entries.len() > waddle_xmpp::muc::pin::MAX_PINNED_ENTRIES {
+            entries.pop();
+        }
+    }
+
+    pub fn list(&self, key: &DmPairKey) -> Vec<waddle_xmpp::muc::PinnedEntry> {
+        self.entries
+            .get(key)
+            .map(|entries| entries.clone())
+            .unwrap_or_default()
+    }
+
+    pub fn unpin(
+        &self,
+        key: &DmPairKey,
+        target_stanza_id: &waddle_xmpp_core::xep0359::StanzaId,
+    ) -> bool {
+        let Some(mut entries) = self.entries.get_mut(key) else {
+            return false;
+        };
+        let before = entries.len();
+        entries.retain(|entry| entry.target_stanza_id.id != target_stanza_id.id);
+        entries.len() != before
+    }
+
+    pub fn contains(
+        &self,
+        key: &DmPairKey,
+        target_stanza_id: &waddle_xmpp_core::xep0359::StanzaId,
+    ) -> bool {
+        self.entries
+            .get(key)
+            .map(|entries| {
+                entries
+                    .iter()
+                    .any(|entry| entry.target_stanza_id.id == target_stanza_id.id)
+            })
+            .unwrap_or(false)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct XmppServiceDomains {
     pub muc: String,
@@ -219,6 +295,10 @@ pub struct ProtocolServices {
     /// JMI/Jingle sid. `proceed` creates the anchor; `finish` later
     /// consumes the entry to stamp the ended summary.
     pub dm_call_threads: Arc<dashmap::DashMap<DmCallThreadKey, ActiveCallThread>>,
+    /// Shared pair-scoped 1:1 pinned-message projection. The pair key
+    /// deliberately ignores direction so both participants fetch the
+    /// same list using their peer's bare JID.
+    pub dm_pin_store: Arc<DmPinStore>,
     /// Per-owner projection guard for 1:1 call-thread anchors. `ArchiveDirect`
     /// runs once per user archive row; this lets each owner receive its own
     /// MAM id exactly once while duplicate/replayed proceeds remain inert.

--- a/server/crates/waddle-server/src/server/routes/websocket/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests.rs
@@ -221,6 +221,7 @@ async fn create_test_websocket_state_with_extension_manager(
                     pep_feed_bridge: Arc::new(crate::pep_feed_bridge::PepFeedBridge::new()),
                     call_threads: Arc::new(dashmap::DashMap::new()),
                     dm_call_threads: Arc::new(dashmap::DashMap::new()),
+                    dm_pin_store: Arc::new(crate::server::routes::websocket::DmPinStore::default()),
                     dm_call_thread_projections: Arc::new(dashmap::DashSet::new()),
                     pending_dm_call_offers: Arc::new(dashmap::DashMap::new()),
                     sfu: None,

--- a/server/crates/waddle-server/tests/dm_pinned_messages_ws.rs
+++ b/server/crates/waddle-server/tests/dm_pinned_messages_ws.rs
@@ -1,0 +1,723 @@
+//! Waddle 1:1 DM pinned-message integration tests over WebSocket.
+
+mod ws_common;
+
+use std::time::Duration;
+use tokio::sync::Mutex;
+use ws_common::{extract_attr_after, TestServer, WsXmppClient};
+
+const DOMAIN: &str = "localhost";
+const NS_WADDLE_PIN: &str = "urn:waddle:pin:0";
+
+static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+async fn user_client(
+    server: &TestServer,
+    username: &str,
+    password: &str,
+    resource: &str,
+) -> WsXmppClient {
+    WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, username, password, resource)
+        .await
+        .expect("connect and auth")
+}
+
+fn frame_has_iq_id(frame: &str, id: &str) -> bool {
+    frame.contains(&format!(r#"id='{id}'"#)) || frame.contains(&format!(r#"id="{id}""#))
+}
+
+fn extract_pin_event_target(frame: &str) -> String {
+    extract_attr_after(frame, "pin-event", "target")
+        .unwrap_or_else(|| panic!("pin event must carry a target attribute: {frame}"))
+}
+
+async fn fetch_dm_pins(client: &mut WsXmppClient, peer: &str, id: &str) -> String {
+    client
+        .send(&format!(
+            r#"<iq xmlns="jabber:client" type="get" to="{peer}" id="{id}">
+                <query xmlns="{NS_WADDLE_PIN}"/>
+            </iq>"#
+        ))
+        .await
+        .expect("send DM pin query");
+    client
+        .recv_matching(|frame| frame.contains("<iq") && frame_has_iq_id(frame, id))
+        .await
+        .expect("pin query response")
+}
+
+fn pin_entry_count(frame: &str) -> usize {
+    frame.matches("<pin ").count()
+}
+
+async fn block_peer(client: &mut WsXmppClient, peer: &str, id: &str) {
+    client
+        .send(&format!(
+            r#"<iq xmlns="jabber:client" type="set" id="{id}">
+                <block xmlns="urn:xmpp:blocking">
+                    <item jid="{peer}"/>
+                </block>
+            </iq>"#
+        ))
+        .await
+        .expect("send blocking IQ");
+    let response = client
+        .recv_matching(|frame| frame.contains("<iq") && frame_has_iq_id(frame, id))
+        .await
+        .expect("blocking IQ response");
+    assert!(
+        response.contains("type='result'") || response.contains(r#"type="result""#),
+        "blocking IQ should succeed: {response}"
+    );
+}
+
+#[tokio::test]
+async fn dm_pin_updates_peer_live_and_survives_reload() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server =
+        TestServer::start_with_extra_accounts(&[("alice", "alice-pass"), ("bob", "bob-pass")]);
+    let mut alice = user_client(&server, "alice", "alice-pass", "dm-pin-alice").await;
+    let mut bob = user_client(&server, "bob", "bob-pass", "dm-pin-bob").await;
+
+    alice
+        .send(
+            r#"<message xmlns="jabber:client" type="chat" to="bob@localhost" id="dm-pin-target">
+                <body>pin this direct message</body>
+            </message>"#,
+        )
+        .await
+        .expect("send target DM");
+    let delivered = bob
+        .recv_matching(|frame| frame.contains("pin this direct message"))
+        .await
+        .expect("Bob receives target DM");
+    let target_stanza_id = extract_attr_after(&delivered, "stanza-id", "id")
+        .unwrap_or_else(|| panic!("DM delivery must carry XEP-0359 stanza-id: {delivered}"));
+
+    alice
+        .send(&format!(
+            r#"<message xmlns="jabber:client" type="chat" to="bob@localhost" id="dm-pin-request">
+                <pinned xmlns="{NS_WADDLE_PIN}" target="{target_stanza_id}"/>
+            </message>"#
+        ))
+        .await
+        .expect("send DM pin request");
+
+    let live_pin = bob
+        .recv_matching(|frame| {
+            frame.contains("<pin-event")
+                && frame.contains("action='pinned'")
+                && frame.contains("target=")
+        })
+        .await
+        .expect("Bob receives live DM pin event");
+    let canonical_pin_target = extract_pin_event_target(&live_pin);
+    assert!(
+        live_pin.contains("by='alice@localhost'") && live_pin.contains("pin this direct message"),
+        "live DM pin event must identify the pinner and carry a preview: {live_pin}"
+    );
+
+    let alice_pins = fetch_dm_pins(&mut alice, "bob@localhost", "alice-dm-pins").await;
+    assert!(
+        alice_pins.contains("<query")
+            && alice_pins.contains(&canonical_pin_target)
+            && alice_pins.contains("pin this direct message"),
+        "Alice's server-fetched DM pin list must include the pin: {alice_pins}"
+    );
+    let bob_pins = fetch_dm_pins(&mut bob, "alice@localhost", "bob-dm-pins").await;
+    assert!(
+        bob_pins.contains("<query")
+            && bob_pins.contains(&canonical_pin_target)
+            && bob_pins.contains("pin this direct message"),
+        "Bob's server-fetched DM pin list must include the same pair pin: {bob_pins}"
+    );
+
+    let _ = bob.close().await;
+    let mut bob_reloaded = user_client(&server, "bob", "bob-pass", "dm-pin-bob-reloaded").await;
+    let bob_reloaded_pins =
+        fetch_dm_pins(&mut bob_reloaded, "alice@localhost", "bob-dm-pins-reload").await;
+    assert!(
+        bob_reloaded_pins.contains(&canonical_pin_target)
+            && bob_reloaded_pins.contains("pin this direct message"),
+        "Bob must fetch the same DM pin list after reconnect: {bob_reloaded_pins}"
+    );
+}
+
+#[tokio::test]
+async fn dm_pin_deduplicates_archive_local_target_ids() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server =
+        TestServer::start_with_extra_accounts(&[("alice", "alice-pass"), ("bob", "bob-pass")]);
+    let mut alice = user_client(&server, "alice", "alice-pass", "dm-pin-dual-alice").await;
+    let mut bob = user_client(&server, "bob", "bob-pass", "dm-pin-dual-bob").await;
+
+    alice
+        .send(
+            r#"<message xmlns="jabber:client" type="chat" to="bob@localhost" id="dm-dual-target">
+                <body>one logical DM, two archive ids</body>
+            </message>"#,
+        )
+        .await
+        .expect("send target DM");
+    let delivered = bob
+        .recv_matching(|frame| frame.contains("one logical DM, two archive ids"))
+        .await
+        .expect("Bob receives target DM");
+    let bob_archive_id = extract_attr_after(&delivered, "stanza-id", "id")
+        .unwrap_or_else(|| panic!("DM delivery must carry XEP-0359 stanza-id: {delivered}"));
+
+    alice
+        .send(&format!(
+            r#"<message xmlns="jabber:client" type="chat" to="bob@localhost" id="dm-dual-pin-a">
+                <pinned xmlns="{NS_WADDLE_PIN}" target="{bob_archive_id}"/>
+            </message>"#
+        ))
+        .await
+        .expect("Alice pins with Bob archive id");
+    let alice_pin_event = bob
+        .recv_matching(|frame| frame.contains("<pin-event") && frame.contains("action='pinned'"))
+        .await
+        .expect("Bob receives Alice pin");
+    let canonical_target = extract_pin_event_target(&alice_pin_event);
+
+    bob.send(&format!(
+        r#"<message xmlns="jabber:client" type="chat" to="alice@localhost" id="dm-dual-pin-b">
+            <pinned xmlns="{NS_WADDLE_PIN}" target="dm-dual-target"/>
+        </message>"#
+    ))
+    .await
+    .expect("Bob pins with Alice wire id");
+    let bob_pin_event = alice
+        .recv_matching(|frame| {
+            frame.contains("<pin-event")
+                && frame.contains("action='pinned'")
+                && frame.contains(&canonical_target)
+        })
+        .await
+        .expect("Alice receives Bob pin");
+    assert!(
+        bob_pin_event.contains("one logical DM, two archive ids"),
+        "replacement pin event should keep the preview: {bob_pin_event}"
+    );
+
+    let alice_pins = fetch_dm_pins(&mut alice, "bob@localhost", "alice-dual-pins").await;
+    assert_eq!(
+        pin_entry_count(&alice_pins),
+        1,
+        "both archive-local target ids must converge to one pair pin: {alice_pins}"
+    );
+    assert!(
+        alice_pins.contains(&canonical_target),
+        "pin list should use the canonical pair-stable target: {alice_pins}"
+    );
+}
+
+#[tokio::test]
+async fn dm_unpin_resolves_archive_local_target_ids() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server =
+        TestServer::start_with_extra_accounts(&[("alice", "alice-pass"), ("bob", "bob-pass")]);
+    let mut alice = user_client(&server, "alice", "alice-pass", "dm-unpin-dual-alice").await;
+    let mut bob = user_client(&server, "bob", "bob-pass", "dm-unpin-dual-bob").await;
+
+    alice
+        .send(
+            r#"<message xmlns="jabber:client" type="chat" to="bob@localhost" id="dm-unpin-dual-target">
+                <body>unpin through the other archive id</body>
+            </message>"#,
+        )
+        .await
+        .expect("send target DM");
+    let delivered = bob
+        .recv_matching(|frame| frame.contains("unpin through the other archive id"))
+        .await
+        .expect("Bob receives target DM");
+    let bob_archive_id = extract_attr_after(&delivered, "stanza-id", "id")
+        .unwrap_or_else(|| panic!("DM delivery must carry XEP-0359 stanza-id: {delivered}"));
+
+    alice
+        .send(&format!(
+            r#"<message xmlns="jabber:client" type="chat" to="bob@localhost" id="dm-unpin-dual-pin">
+                <pinned xmlns="{NS_WADDLE_PIN}" target="{bob_archive_id}"/>
+            </message>"#
+        ))
+        .await
+        .expect("Alice pins with Bob archive id");
+    let pin_event = bob
+        .recv_matching(|frame| frame.contains("<pin-event") && frame.contains("action='pinned'"))
+        .await
+        .expect("Bob receives Alice pin");
+    let canonical_target = extract_pin_event_target(&pin_event);
+
+    bob.send(&format!(
+        r#"<message xmlns="jabber:client" type="chat" to="alice@localhost" id="dm-unpin-dual-request">
+            <unpinned xmlns="{NS_WADDLE_PIN}" target="dm-unpin-dual-target"/>
+        </message>"#
+    ))
+    .await
+    .expect("Bob unpins with Alice wire id");
+    alice
+        .recv_matching(|frame| {
+            frame.contains("<pin-event")
+                && frame.contains("action='unpinned'")
+                && frame.contains(&canonical_target)
+        })
+        .await
+        .expect("Alice receives canonical unpin event");
+
+    let alice_pins = fetch_dm_pins(&mut alice, "bob@localhost", "alice-dual-unpin-pins").await;
+    assert!(
+        !alice_pins.contains(&canonical_target),
+        "alternate-id unpin must remove the canonical stored pin: {alice_pins}"
+    );
+}
+
+#[tokio::test]
+async fn dm_unpin_converges_both_participants() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server =
+        TestServer::start_with_extra_accounts(&[("alice", "alice-pass"), ("bob", "bob-pass")]);
+    let mut alice = user_client(&server, "alice", "alice-pass", "dm-unpin-alice").await;
+    let mut bob = user_client(&server, "bob", "bob-pass", "dm-unpin-bob").await;
+
+    alice
+        .send(
+            r#"<message xmlns="jabber:client" type="chat" to="bob@localhost" id="dm-unpin-target">
+                <body>pin then unpin this direct message</body>
+            </message>"#,
+        )
+        .await
+        .expect("send target DM");
+    let delivered = bob
+        .recv_matching(|frame| frame.contains("pin then unpin this direct message"))
+        .await
+        .expect("Bob receives target DM");
+    let target_stanza_id = extract_attr_after(&delivered, "stanza-id", "id")
+        .unwrap_or_else(|| panic!("DM delivery must carry XEP-0359 stanza-id: {delivered}"));
+
+    alice
+        .send(&format!(
+            r#"<message xmlns="jabber:client" type="chat" to="bob@localhost" id="dm-unpin-pin">
+                <pinned xmlns="{NS_WADDLE_PIN}" target="{target_stanza_id}"/>
+            </message>"#
+        ))
+        .await
+        .expect("send DM pin request");
+    let pin_event = bob
+        .recv_matching(|frame| frame.contains("<pin-event") && frame.contains("action='pinned'"))
+        .await
+        .expect("Bob receives live DM pin event");
+    let canonical_target = extract_pin_event_target(&pin_event);
+
+    bob.send(&format!(
+        r#"<message xmlns="jabber:client" type="chat" to="alice@localhost" id="dm-unpin-request">
+            <unpinned xmlns="{NS_WADDLE_PIN}" target="{target_stanza_id}"/>
+        </message>"#
+    ))
+    .await
+    .expect("send DM unpin request");
+
+    let alice_unpin = alice
+        .recv_matching(|frame| {
+            frame.contains("<pin-event")
+                && frame.contains("action='unpinned'")
+                && frame.contains(&canonical_target)
+                && frame.contains("by='bob@localhost'")
+        })
+        .await
+        .expect("Alice receives live DM unpin event");
+    assert!(
+        !alice_unpin.contains("<preview"),
+        "unpin event must not carry a stale preview: {alice_unpin}"
+    );
+
+    let alice_pins = fetch_dm_pins(&mut alice, "bob@localhost", "alice-dm-pins-after-unpin").await;
+    assert!(
+        !alice_pins.contains(&canonical_target),
+        "Alice's DM pin list must remove the unpinned entry: {alice_pins}"
+    );
+    let bob_pins = fetch_dm_pins(&mut bob, "alice@localhost", "bob-dm-pins-after-unpin").await;
+    assert!(
+        !bob_pins.contains(&canonical_target),
+        "Bob's DM pin list must remove the unpinned entry: {bob_pins}"
+    );
+}
+
+#[tokio::test]
+async fn dm_retraction_removes_pinned_message() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server =
+        TestServer::start_with_extra_accounts(&[("alice", "alice-pass"), ("bob", "bob-pass")]);
+    let mut alice = user_client(&server, "alice", "alice-pass", "dm-pin-retract-alice").await;
+    let mut bob = user_client(&server, "bob", "bob-pass", "dm-pin-retract-bob").await;
+
+    alice
+        .send(
+            r#"<message xmlns="jabber:client" type="chat" to="bob@localhost" id="dm-retract-pin-target">
+                <body>pin then retract this direct message</body>
+            </message>"#,
+        )
+        .await
+        .expect("send target DM");
+    let delivered = bob
+        .recv_matching(|frame| frame.contains("pin then retract this direct message"))
+        .await
+        .expect("Bob receives target DM");
+    let target_stanza_id = extract_attr_after(&delivered, "stanza-id", "id")
+        .unwrap_or_else(|| panic!("DM delivery must carry XEP-0359 stanza-id: {delivered}"));
+
+    alice
+        .send(&format!(
+            r#"<message xmlns="jabber:client" type="chat" to="bob@localhost" id="dm-retract-pin-request">
+                <pinned xmlns="{NS_WADDLE_PIN}" target="{target_stanza_id}"/>
+            </message>"#
+        ))
+        .await
+        .expect("send DM pin request");
+    let pin_event = bob
+        .recv_matching(|frame| frame.contains("<pin-event") && frame.contains("action='pinned'"))
+        .await
+        .expect("Bob receives live DM pin event");
+    let canonical_target = extract_pin_event_target(&pin_event);
+
+    alice
+        .send(&format!(
+            r#"<message xmlns="jabber:client" type="chat" to="bob@localhost" id="dm-pin-retraction">
+                <retract xmlns="urn:xmpp:message-retract:1" id="{target_stanza_id}"/>
+                <body>/me retracted a previous message</body>
+            </message>"#
+        ))
+        .await
+        .expect("send DM retraction");
+    let bob_unpin = bob
+        .recv_matching(|frame| {
+            frame.contains("<pin-event")
+                && frame.contains("action='unpinned'")
+                && frame.contains("reason='retracted'")
+                && frame.contains(&canonical_target)
+        })
+        .await
+        .expect("Bob receives pin removal caused by retraction");
+    assert!(
+        bob_unpin.contains("by='alice@localhost'"),
+        "retraction-caused unpin should be attributed to the retractor: {bob_unpin}"
+    );
+
+    let bob_pins = fetch_dm_pins(&mut bob, "alice@localhost", "bob-dm-pins-after-retract").await;
+    assert!(
+        !bob_pins.contains(&canonical_target),
+        "retracted DM must not remain pinned: {bob_pins}"
+    );
+}
+
+#[tokio::test]
+async fn dm_pin_after_retraction_is_rejected() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server =
+        TestServer::start_with_extra_accounts(&[("alice", "alice-pass"), ("bob", "bob-pass")]);
+    let mut alice = user_client(&server, "alice", "alice-pass", "dm-pin-tombstone-alice").await;
+    let mut bob = user_client(&server, "bob", "bob-pass", "dm-pin-tombstone-bob").await;
+
+    alice
+        .send(
+            r#"<message xmlns="jabber:client" type="chat" to="bob@localhost" id="dm-tombstone-target">
+                <body>this direct message will be tombstoned</body>
+            </message>"#,
+        )
+        .await
+        .expect("send target DM");
+    let delivered = bob
+        .recv_matching(|frame| frame.contains("this direct message will be tombstoned"))
+        .await
+        .expect("Bob receives target DM");
+    let _target_stanza_id = extract_attr_after(&delivered, "stanza-id", "id")
+        .unwrap_or_else(|| panic!("DM delivery must carry XEP-0359 stanza-id: {delivered}"));
+
+    alice
+        .send(
+            r#"<message xmlns="jabber:client" type="chat" to="bob@localhost" id="dm-tombstone-retract">
+                <retract xmlns="urn:xmpp:message-retract:1" id="dm-tombstone-target"/>
+                <body>/me retracted a previous message</body>
+            </message>"#,
+        )
+        .await
+        .expect("send DM retraction");
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    alice
+        .send(&format!(
+            r#"<message xmlns="jabber:client" type="chat" to="bob@localhost" id="dm-tombstone-pin">
+                <pinned xmlns="{NS_WADDLE_PIN}" target="dm-tombstone-target"/>
+            </message>"#
+        ))
+        .await
+        .expect("send stale DM pin request");
+    let error = alice
+        .recv_matching(|frame| {
+            frame.contains("dm-tombstone-pin") && frame.contains("<item-not-found")
+        })
+        .await
+        .expect("pinning a tombstoned DM is rejected");
+    assert!(
+        error.contains("Pinned DM target was not found"),
+        "tombstone rejection should not expose the original preview: {error}"
+    );
+    let bob_pins = fetch_dm_pins(&mut bob, "alice@localhost", "bob-tombstone-pins").await;
+    assert!(
+        !bob_pins.contains("this direct message will be tombstoned"),
+        "tombstoned DM must not be stored as a pin: {bob_pins}"
+    );
+}
+
+#[tokio::test]
+async fn dm_pin_lists_are_scoped_per_pair() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server = TestServer::start_with_extra_accounts(&[
+        ("alice", "alice-pass"),
+        ("bob", "bob-pass"),
+        ("charlie", "charlie-pass"),
+    ]);
+    let mut alice = user_client(&server, "alice", "alice-pass", "dm-scope-alice").await;
+    let mut bob = user_client(&server, "bob", "bob-pass", "dm-scope-bob").await;
+    let mut charlie = user_client(&server, "charlie", "charlie-pass", "dm-scope-charlie").await;
+
+    alice
+        .send(
+            r#"<message xmlns="jabber:client" type="chat" to="bob@localhost" id="dm-scope-target">
+                <body>Alice and Bob only</body>
+            </message>"#,
+        )
+        .await
+        .expect("send target DM");
+    let delivered = bob
+        .recv_matching(|frame| frame.contains("Alice and Bob only"))
+        .await
+        .expect("Bob receives target DM");
+    let target_stanza_id = extract_attr_after(&delivered, "stanza-id", "id")
+        .unwrap_or_else(|| panic!("DM delivery must carry XEP-0359 stanza-id: {delivered}"));
+
+    alice
+        .send(&format!(
+            r#"<message xmlns="jabber:client" type="chat" to="bob@localhost" id="dm-scope-pin">
+                <pinned xmlns="{NS_WADDLE_PIN}" target="{target_stanza_id}"/>
+            </message>"#
+        ))
+        .await
+        .expect("send DM pin request");
+    let pin_event = bob
+        .recv_matching(|frame| frame.contains("<pin-event") && frame.contains("action='pinned'"))
+        .await
+        .expect("Bob receives live DM pin event");
+    let canonical_target = extract_pin_event_target(&pin_event);
+
+    let bob_pins = fetch_dm_pins(&mut bob, "alice@localhost", "bob-alice-pins").await;
+    assert!(
+        bob_pins.contains(&canonical_target),
+        "Bob/Alice pair should contain the pin: {bob_pins}"
+    );
+    let charlie_bob_pins = fetch_dm_pins(&mut charlie, "bob@localhost", "charlie-bob-pins").await;
+    assert!(
+        !charlie_bob_pins.contains(&canonical_target)
+            && !charlie_bob_pins.contains("Alice and Bob only"),
+        "Charlie/Bob pair must not leak Alice/Bob pins: {charlie_bob_pins}"
+    );
+}
+
+#[tokio::test]
+async fn dm_pin_target_must_belong_to_the_pair() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server = TestServer::start_with_extra_accounts(&[
+        ("alice", "alice-pass"),
+        ("bob", "bob-pass"),
+        ("charlie", "charlie-pass"),
+    ]);
+    let mut alice = user_client(&server, "alice", "alice-pass", "dm-cross-alice").await;
+    let mut bob = user_client(&server, "bob", "bob-pass", "dm-cross-bob").await;
+    let mut charlie = user_client(&server, "charlie", "charlie-pass", "dm-cross-charlie").await;
+
+    alice
+        .send(
+            r#"<message xmlns="jabber:client" type="chat" to="charlie@localhost" id="dm-cross-target">
+                <body>Alice and Charlie only</body>
+            </message>"#,
+        )
+        .await
+        .expect("send cross-pair target DM");
+    let delivered = charlie
+        .recv_matching(|frame| frame.contains("Alice and Charlie only"))
+        .await
+        .expect("Charlie receives target DM");
+    let target_stanza_id = extract_attr_after(&delivered, "stanza-id", "id")
+        .unwrap_or_else(|| panic!("DM delivery must carry XEP-0359 stanza-id: {delivered}"));
+
+    alice
+        .send(&format!(
+            r#"<message xmlns="jabber:client" type="chat" to="bob@localhost" id="dm-cross-pin">
+                <pinned xmlns="{NS_WADDLE_PIN}" target="{target_stanza_id}"/>
+            </message>"#
+        ))
+        .await
+        .expect("send cross-pair DM pin request");
+
+    let error = alice
+        .recv_matching(|frame| frame.contains("dm-cross-pin") && frame.contains("<item-not-found"))
+        .await
+        .expect("cross-pair DM pin is rejected");
+    assert!(
+        error.contains("Pinned DM target was not found"),
+        "cross-pair pin rejection should not leak the target preview: {error}"
+    );
+    let bob_unexpected_pin = bob
+        .recv_timeout(Duration::from_millis(250))
+        .await
+        .unwrap_or_default();
+    assert!(
+        !bob_unexpected_pin.contains("<pin-event"),
+        "Bob must not receive a pin event for Alice/Charlie content: {bob_unexpected_pin}"
+    );
+    let bob_pins = fetch_dm_pins(&mut bob, "alice@localhost", "bob-cross-pins").await;
+    assert!(
+        !bob_pins.contains(&target_stanza_id) && !bob_pins.contains("Alice and Charlie only"),
+        "Alice/Bob pair must not store Alice/Charlie pins: {bob_pins}"
+    );
+}
+
+#[tokio::test]
+async fn dm_retraction_from_non_author_does_not_clear_pin() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server =
+        TestServer::start_with_extra_accounts(&[("alice", "alice-pass"), ("bob", "bob-pass")]);
+    let mut alice = user_client(&server, "alice", "alice-pass", "dm-invalid-retract-alice").await;
+    let mut bob = user_client(&server, "bob", "bob-pass", "dm-invalid-retract-bob").await;
+
+    alice
+        .send(
+            r#"<message xmlns="jabber:client" type="chat" to="bob@localhost" id="dm-invalid-retract-target">
+                <body>Alice authored this pinned direct message</body>
+            </message>"#,
+        )
+        .await
+        .expect("send target DM");
+    let delivered = bob
+        .recv_matching(|frame| frame.contains("Alice authored this pinned direct message"))
+        .await
+        .expect("Bob receives target DM");
+    let target_stanza_id = extract_attr_after(&delivered, "stanza-id", "id")
+        .unwrap_or_else(|| panic!("DM delivery must carry XEP-0359 stanza-id: {delivered}"));
+
+    alice
+        .send(&format!(
+            r#"<message xmlns="jabber:client" type="chat" to="bob@localhost" id="dm-invalid-retract-pin">
+                <pinned xmlns="{NS_WADDLE_PIN}" target="{target_stanza_id}"/>
+            </message>"#
+        ))
+        .await
+        .expect("send DM pin request");
+    let pin_event = bob
+        .recv_matching(|frame| frame.contains("<pin-event") && frame.contains("action='pinned'"))
+        .await
+        .expect("Bob receives live DM pin event");
+    let canonical_target = extract_pin_event_target(&pin_event);
+
+    bob.send(&format!(
+        r#"<message xmlns="jabber:client" type="chat" to="alice@localhost" id="dm-invalid-retract">
+            <retract xmlns="urn:xmpp:message-retract:1" id="{target_stanza_id}"/>
+            <body>/me retracted a previous message</body>
+        </message>"#
+    ))
+    .await
+    .expect("send invalid DM retraction");
+
+    let alice_unexpected_unpin = alice
+        .recv_timeout(Duration::from_millis(250))
+        .await
+        .unwrap_or_default();
+    assert!(
+        !alice_unexpected_unpin.contains("<pin-event")
+            || !alice_unexpected_unpin.contains("action='unpinned'"),
+        "invalid retraction must not fan out a pin removal: {alice_unexpected_unpin}"
+    );
+    let bob_pins = fetch_dm_pins(&mut bob, "alice@localhost", "bob-invalid-retract-pins").await;
+    assert!(
+        bob_pins.contains(&canonical_target)
+            && bob_pins.contains("Alice authored this pinned direct message"),
+        "pin must remain after rejected non-author retraction: {bob_pins}"
+    );
+}
+
+#[tokio::test]
+async fn dm_pin_to_remote_domain_returns_forbidden() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server = TestServer::start_with_extra_accounts(&[("alice", "alice-pass")]);
+    let mut alice = user_client(&server, "alice", "alice-pass", "dm-pin-remote-alice").await;
+
+    alice
+        .send(&format!(
+            r#"<message xmlns="jabber:client" type="chat" to="mallory@example.test" id="dm-pin-remote">
+                <pinned xmlns="{NS_WADDLE_PIN}" target="remote-target"/>
+            </message>"#
+        ))
+        .await
+        .expect("send remote-domain DM pin request");
+
+    let error = alice
+        .recv_matching(|frame| frame.contains("dm-pin-remote") && frame.contains("<forbidden"))
+        .await
+        .expect("remote-domain DM pin is rejected");
+    assert!(
+        error.contains("type='error'") || error.contains(r#"type="error""#),
+        "remote-domain pin must return a stanza error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn dm_pin_event_respects_recipient_blocklist() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server =
+        TestServer::start_with_extra_accounts(&[("alice", "alice-pass"), ("bob", "bob-pass")]);
+    let mut alice = user_client(&server, "alice", "alice-pass", "dm-pin-block-alice").await;
+    let mut bob = user_client(&server, "bob", "bob-pass", "dm-pin-block-bob").await;
+
+    alice
+        .send(
+            r#"<message xmlns="jabber:client" type="chat" to="bob@localhost" id="dm-block-target">
+                <body>blocked recipient should not see pin event</body>
+            </message>"#,
+        )
+        .await
+        .expect("send target DM");
+    let delivered = bob
+        .recv_matching(|frame| frame.contains("blocked recipient should not see pin event"))
+        .await
+        .expect("Bob receives target DM before blocking Alice");
+    let target_stanza_id = extract_attr_after(&delivered, "stanza-id", "id")
+        .unwrap_or_else(|| panic!("DM delivery must carry XEP-0359 stanza-id: {delivered}"));
+
+    block_peer(&mut bob, "alice@localhost", "dm-pin-block-bob-blocks-alice").await;
+
+    alice
+        .send(&format!(
+            r#"<message xmlns="jabber:client" type="chat" to="bob@localhost" id="dm-block-pin">
+                <pinned xmlns="{NS_WADDLE_PIN}" target="{target_stanza_id}"/>
+            </message>"#
+        ))
+        .await
+        .expect("send DM pin request after block");
+
+    alice
+        .recv_matching(|frame| {
+            frame.contains("<pin-event")
+                && frame.contains("action='pinned'")
+                && frame.contains("blocked recipient should not see pin event")
+        })
+        .await
+        .expect("sender still receives local pin event");
+    let bob_unexpected_pin = bob
+        .recv_timeout(Duration::from_millis(250))
+        .await
+        .unwrap_or_default();
+    assert!(
+        !bob_unexpected_pin.contains("<pin-event"),
+        "blocked recipient must not receive live DM pin events: {bob_unexpected_pin}"
+    );
+}

--- a/server/crates/waddle-xmpp-client-wasm/src/client_history.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_history.rs
@@ -274,6 +274,41 @@ impl WaddleClient {
             to_js_value(&mam_page_to_js(page))
         })
     }
+
+    /// Waddle-specific MAM stanza-id filter for 1:1 history. Targets the
+    /// account's personal archive and constrains the query with `with=peer`.
+    pub fn fetch_direct_messages_by_stanza_ids(
+        &self,
+        peer_jid: String,
+        stanza_ids: Vec<String>,
+    ) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            if stanza_ids.is_empty() {
+                return to_js_value(&mam_page_to_js(waddle_xmpp_client::MamPage {
+                    messages: vec![],
+                    rsm: waddle_xmpp_client::RsmPageInfo::default(),
+                    query_id: String::new(),
+                    is_complete: true,
+                }));
+            }
+            let account_jid = {
+                let stored = inner.borrow().config.clone();
+                bare_jid(&stored.jid)
+            };
+            let refs: Vec<&str> = stanza_ids.iter().map(String::as_str).collect();
+            let query_id = uuid::Uuid::new_v4().to_string();
+            let iq_id = uuid::Uuid::new_v4().to_string();
+            let iq = MamIqBuilder::new(&iq_id, &query_id, stanza_ids.len() as u32)
+                .before("")
+                .to_jid(&account_jid)
+                .with_jid(&peer_jid)
+                .stanza_ids(&refs)
+                .build();
+            let page = send_mam_query_command(inner, iq, query_id).await?;
+            to_js_value(&mam_page_to_js(page))
+        })
+    }
 }
 
 fn apply_page_param<'a>(

--- a/server/crates/waddle-xmpp-client-wasm/src/client_messaging.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_messaging.rs
@@ -214,12 +214,34 @@ impl WaddleClient {
         })
     }
 
+    /// Publish a 1:1 DM pin request.
+    pub fn pin_direct_message(&self, peer_jid: String, target_stanza_id: String) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let stanza =
+                waddle_xmpp_client::build_pinned_chat_message(&peer_jid, &target_stanza_id);
+            send_stanza_command(inner, stanza).await?;
+            Ok(JsValue::UNDEFINED)
+        })
+    }
+
     /// Publish an unpin request (#414). Same authorization rules as
     /// [`Self::pin_message`].
     pub fn unpin_message(&self, room_jid: String, target_stanza_id: String) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
             let stanza = build_unpinned_message(&room_jid, &target_stanza_id);
+            send_stanza_command(inner, stanza).await?;
+            Ok(JsValue::UNDEFINED)
+        })
+    }
+
+    /// Publish a 1:1 DM unpin request.
+    pub fn unpin_direct_message(&self, peer_jid: String, target_stanza_id: String) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let stanza =
+                waddle_xmpp_client::build_unpinned_chat_message(&peer_jid, &target_stanza_id);
             send_stanza_command(inner, stanza).await?;
             Ok(JsValue::UNDEFINED)
         })

--- a/server/crates/waddle-xmpp-client/src/lib.rs
+++ b/server/crates/waddle-xmpp-client/src/lib.rs
@@ -72,13 +72,13 @@ pub use mam::{
 pub use messaging::MessagingExt;
 pub use messaging::{
     build_chat_state_message, build_correction_message, build_displayed_message,
-    build_moderation_message, build_outbound_message, build_reaction_message,
-    build_retraction_message, parse_chat_state_payload, parse_correction_payload,
-    parse_displayed_marker_payload, parse_moderation_payload, parse_reaction_payload,
-    parse_retraction_payload, ChatStatePayload, CorrectionPayload, DisplayedMarkerPayload,
-    InboundMessage, InboundPresence, MessagingEvent, ModerationPayload, ReactionPayload,
-    RetractionPayload, NS_CHAT_MARKERS, NS_CHAT_STATES, NS_MESSAGE_CORRECT, NS_MESSAGE_MODERATE,
-    NS_MESSAGE_RETRACT, NS_REACTIONS,
+    build_moderation_message, build_outbound_message, build_pinned_chat_message,
+    build_reaction_message, build_retraction_message, build_unpinned_chat_message,
+    parse_chat_state_payload, parse_correction_payload, parse_displayed_marker_payload,
+    parse_moderation_payload, parse_reaction_payload, parse_retraction_payload, ChatStatePayload,
+    CorrectionPayload, DisplayedMarkerPayload, InboundMessage, InboundPresence, MessagingEvent,
+    ModerationPayload, ReactionPayload, RetractionPayload, NS_CHAT_MARKERS, NS_CHAT_STATES,
+    NS_MESSAGE_CORRECT, NS_MESSAGE_MODERATE, NS_MESSAGE_RETRACT, NS_REACTIONS,
 };
 pub use messaging::{MarkupSpan, MarkupSpanType};
 #[cfg(all(feature = "native", not(target_arch = "wasm32")))]

--- a/server/crates/waddle-xmpp-client/src/messaging.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging.rs
@@ -18,7 +18,8 @@ mod types;
 pub use builders::{
     build_chat_state_message, build_correction_message, build_displayed_message,
     build_file_sharing_element, build_moderation_message, build_outbound_message,
-    build_pinned_message, build_reaction_message, build_retraction_message, build_unpinned_message,
+    build_pinned_chat_message, build_pinned_message, build_reaction_message,
+    build_retraction_message, build_unpinned_chat_message, build_unpinned_message,
 };
 pub use call::{
     build_finish, build_finish_migrated, build_finish_with_options, build_finish_with_reason,

--- a/server/crates/waddle-xmpp-client/src/messaging/builders.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/builders.rs
@@ -107,39 +107,59 @@ pub fn build_reaction_message(
 /// `to` is the room bare JID; `target_stanza_id` is the XEP-0359
 /// stanza-id (`by=room`) of the message being pinned.
 pub fn build_pinned_message(to: &str, target_stanza_id: &str) -> Element {
-    let stanza_id = Uuid::new_v4().to_string();
-    Element::builder("message", NS_CLIENT)
-        .attr(minidom::rxml::xml_ncname!("to").to_owned(), to)
-        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "groupchat")
-        .attr(
-            minidom::rxml::xml_ncname!("id").to_owned(),
-            stanza_id.as_str(),
-        )
-        .append(build_origin_id(&stanza_id))
-        .append(
-            Element::builder("pinned", NS_WADDLE_PIN_V0)
-                .attr(
-                    minidom::rxml::xml_ncname!("target").to_owned(),
-                    target_stanza_id,
-                )
-                .build(),
-        )
-        .build()
+    build_pin_message(to, PinMessageType::Groupchat, "pinned", target_stanza_id)
+}
+
+/// Build a 1:1 `<message type='chat'><pinned target='…'/></message>` request.
+pub fn build_pinned_chat_message(to: &str, target_stanza_id: &str) -> Element {
+    build_pin_message(to, PinMessageType::Chat, "pinned", target_stanza_id)
 }
 
 /// Build a `<message><unpinned target='…'/></message>` request for #414.
 pub fn build_unpinned_message(to: &str, target_stanza_id: &str) -> Element {
+    build_pin_message(to, PinMessageType::Groupchat, "unpinned", target_stanza_id)
+}
+
+/// Build a 1:1 `<message type='chat'><unpinned target='…'/></message>` request.
+pub fn build_unpinned_chat_message(to: &str, target_stanza_id: &str) -> Element {
+    build_pin_message(to, PinMessageType::Chat, "unpinned", target_stanza_id)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PinMessageType {
+    Chat,
+    Groupchat,
+}
+
+impl PinMessageType {
+    fn as_attr(self) -> &'static str {
+        match self {
+            Self::Chat => "chat",
+            Self::Groupchat => "groupchat",
+        }
+    }
+}
+
+fn build_pin_message(
+    to: &str,
+    message_type: PinMessageType,
+    element_name: &'static str,
+    target_stanza_id: &str,
+) -> Element {
     let stanza_id = Uuid::new_v4().to_string();
     Element::builder("message", NS_CLIENT)
         .attr(minidom::rxml::xml_ncname!("to").to_owned(), to)
-        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "groupchat")
+        .attr(
+            minidom::rxml::xml_ncname!("type").to_owned(),
+            message_type.as_attr(),
+        )
         .attr(
             minidom::rxml::xml_ncname!("id").to_owned(),
             stanza_id.as_str(),
         )
         .append(build_origin_id(&stanza_id))
         .append(
-            Element::builder("unpinned", NS_WADDLE_PIN_V0)
+            Element::builder(element_name, NS_WADDLE_PIN_V0)
                 .attr(
                     minidom::rxml::xml_ncname!("target").to_owned(),
                     target_stanza_id,

--- a/server/crates/waddle-xmpp/src/mam/storage/in_memory.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/in_memory.rs
@@ -162,14 +162,17 @@ impl MamStorage for InMemoryMamStorage {
             });
         }
         if !query.stanza_ids.is_empty() {
-            // `MamQuery.stanza_ids` carries canonical XEP-0359 room-stamped
-            // UUIDs, stored in the `id` field (the archive primary key). The
-            // `stanza_id` field holds the wire `<message id>` attribute —
-            // a different value. Filtering by `id` matches what the chat
-            // client supplies (via `roomAssignedStanzaId`). See
-            // `groupchat_archive.rs:10,94-97`.
+            // Room pins pass archive-primary IDs. DM pins pass the pair-stable
+            // logical message ID, stored as the wire `<message id>` on each
+            // participant's personal archive row. Match both so the same MAM
+            // filter hydrates pinned bodies for rooms and DMs.
             let allowed: HashSet<&str> = query.stanza_ids.iter().map(|id| id.as_str()).collect();
-            messages.retain(|m| allowed.contains(m.id.as_str()));
+            messages.retain(|m| {
+                allowed.contains(m.id.as_str())
+                    || m.stanza_id
+                        .as_ref()
+                        .is_some_and(|stanza_id| allowed.contains(stanza_id.id.as_str()))
+            });
         }
         if let Some(cursor) = filter_before_cursor.as_ref() {
             messages.retain(|message| archive_order_before(message, cursor));

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/query.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/query.rs
@@ -105,18 +105,21 @@ macro_rules! push_common_mam_filters {
             ids.push_unseparated(")");
         }
         if !$query.stanza_ids.is_empty() {
-            // `MamQuery.stanza_ids` carries canonical XEP-0359 room-stamped
-            // UUIDs, stored in the `id` column (the SQL primary key). The
-            // `stanza_id` column holds the wire `<message id>` attribute —
-            // a different value. Filtering by `id` matches what the chat
-            // client supplies (via `roomAssignedStanzaId`). See
-            // `groupchat_archive.rs:10,94-97`.
-            $builder.push(" AND id IN (");
+            // Room pins pass archive-primary IDs. DM pins pass the pair-stable
+            // logical message ID, stored as the wire `<message id>` on each
+            // participant's personal archive row. Match both so the same MAM
+            // filter hydrates pinned bodies for rooms and DMs.
+            $builder.push(" AND (id IN (");
             let mut ids = $builder.separated(", ");
             for id in &$query.stanza_ids {
                 ids.push_bind(id.as_str());
             }
-            ids.push_unseparated(")");
+            ids.push_unseparated(") OR stanza_id IN (");
+            let mut stanza_ids = $builder.separated(", ");
+            for id in &$query.stanza_ids {
+                stanza_ids.push_bind(id.as_str());
+            }
+            stanza_ids.push_unseparated("))");
         }
         if let Some(thread_id) = $query.thread_id.as_ref() {
             $builder

--- a/server/crates/waddle-xmpp/src/xep/xep_waddle_mam_stanza_id_tests.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep_waddle_mam_stanza_id_tests.rs
@@ -105,11 +105,10 @@ fn stanza_id_filter_caps_match_pin_protocol() {
 /// single value MUST return only messages whose server-assigned stanza-id
 /// matches that value.
 ///
-/// `MamQuery.stanza_ids` filters by the canonical XEP-0359 room-stamped id,
-/// stored in the `id` column (the SQL primary key), not the `stanza_id`
-/// column which holds the wire `<message id>` attribute. The chat client
-/// supplies the canonical id via `roomAssignedStanzaId`. See
-/// `groupchat_archive.rs:10,94-97`.
+/// `MamQuery.stanza_ids` filters by either the archive-primary id or the
+/// stored wire `<message id>`. Room pins supply archive ids; DM pins supply
+/// pair-stable wire ids so either participant can hydrate the same logical
+/// pin through their personal archive.
 ///
 /// Integration level: storage API (`InMemoryMamStorage::query_messages`).
 /// The filter is exercised through the same `MamQuery.stanza_ids` path that
@@ -156,6 +155,45 @@ async fn stanza_id_filter_returns_only_matching_message() {
         "returned message has the canonical archive id"
     );
     assert!(result.complete, "single-result page is complete");
+}
+
+#[tokio::test]
+async fn stanza_id_filter_matches_wire_message_id_for_dm_pin_hydration() {
+    let store = InMemoryMamStorage::new();
+    let archive = bare("alice@example.com");
+
+    store
+        .store_message(
+            &archive,
+            &archived_with_stanza_id(&archive, "alice-archive-1", "shared-wire-id"),
+        )
+        .await
+        .expect("store matching DM archive row");
+    store
+        .store_message(
+            &archive,
+            &archived_with_stanza_id(&archive, "alice-archive-2", "other-wire-id"),
+        )
+        .await
+        .expect("store non-matching DM archive row");
+
+    let result = store
+        .query_messages(
+            &archive,
+            &MamQuery {
+                stanza_ids: vec![filter_id("shared-wire-id")],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("query must succeed");
+
+    assert_eq!(result.messages.len(), 1, "exactly one message returned");
+    assert_eq!(
+        result.messages[0].id.as_str(),
+        "alice-archive-1",
+        "wire-id filter returns the matching archive row"
+    );
 }
 
 // ── test 4 ───────────────────────────────────────────────────────────────────

--- a/server/crates/waddle-xmpp/src/xep/xep_waddle_pin.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep_waddle_pin.rs
@@ -13,6 +13,9 @@
 //! </message>
 //! ```
 //!
+//! The same markers are also valid on 1:1 `<message type='chat'>`
+//! stanzas for Waddle DM pair pinning.
+//!
 //! Or for unpin:
 //!
 //! ```xml
@@ -196,6 +199,21 @@ mod tests {
             intent,
             Some(PinIntent::Pin {
                 target: "stanza-1".into()
+            })
+        );
+    }
+
+    #[test]
+    fn extract_pin_intent_accepts_direct_chat_marker() {
+        let mut msg = Message::new(Some(Jid::from(
+            BareJid::from_str("bob@example.com").expect("valid jid"),
+        )));
+        msg.type_ = MessageType::Chat;
+        msg.payloads.push(build_pinned_element(&stanza_id("dm-1")));
+        assert_eq!(
+            extract_pin_intent_from_message(&msg),
+            Some(PinIntent::Pin {
+                target: "dm-1".into()
             })
         );
     }

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -69,6 +69,11 @@ export class WaddleClient {
      */
     feed_publish(spaces_jid: string, entry: any): Promise<any>;
     /**
+     * Waddle-specific MAM stanza-id filter for 1:1 history. Targets the
+     * account's personal archive and constrains the query with `with=peer`.
+     */
+    fetch_direct_messages_by_stanza_ids(peer_jid: string, stanza_ids: string[]): Promise<any>;
+    /**
      * Fetch the user's Waddle DM-bookmark items (issue #720) from PEP,
      * surfaced as a typed array carrying the XEP-0492 fallback
      * notification mode + rich-payload opt-in (#719) per direct-chat
@@ -210,6 +215,10 @@ export class WaddleClient {
     list_roster_contacts(): Promise<any>;
     mark_inbox_read(partner_jid: string, thread_id?: string | null): Promise<any>;
     constructor(config: WaddleConfig);
+    /**
+     * Publish a 1:1 DM pin request.
+     */
+    pin_direct_message(peer_jid: string, target_stanza_id: string): Promise<any>;
     /**
      * Publish a pin request (#414). `room_jid` is the bare MUC JID;
      * `target_stanza_id` is the XEP-0359 `by=room` stanza-id of the
@@ -484,6 +493,10 @@ export class WaddleClient {
     subscribe_mds_displayed(): Promise<any>;
     subscribe_to_presence(peer_jid: string): Promise<any>;
     supports_mds_publish_options(): Promise<any>;
+    /**
+     * Publish a 1:1 DM unpin request.
+     */
+    unpin_direct_message(peer_jid: string, target_stanza_id: string): Promise<any>;
     /**
      * Publish an unpin request (#414). Same authorization rules as
      * [`Self::pin_message`].

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=d5140df1ec1c";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=d5140df1ec1c";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=d5140df1ec1c";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=afbcf6b752ca";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=afbcf6b752ca";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=afbcf6b752ca";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=d5140df1ec1c";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=afbcf6b752ca";


### PR DESCRIPTION
## Summary

Implements #951: DM pinned messages for 1:1 conversations.

- Adds XMPP-native DM pin/unpin handling on `<message type="chat">` using `urn:waddle:pin:0`.
- Adds pair-scoped DM pin storage, live fanout to both participants' resources, and DM pin IQ queries.
- Normalizes DM pin targets to a pair-stable logical message id so both participant archives converge on one logical pin.
- Rejects tombstoned/retracted DM targets, removes pins on valid author retraction, and ignores non-author retraction attempts.
- Returns stanza errors for unsupported remote-domain DM pin markers.
- Filters live DM pin events through XEP-0191 blocking checks before delivery.
- Exposes DM pin/unpin and direct stanza-id MAM fetches through the Rust/WASM client.
- Enables DM pinned panels in chat, including live updates, historical body hydration through personal-archive MAM (`with=peer`), and `pinned=1` DM route state.

Closes #951.

## Plan / implementation notes

1. Extend the Waddle pin marker to direct chat stanzas without introducing non-XMPP APIs.
2. Add server-side pair-scoped DM pin CRUD and live convergence.
3. Add client/WASM methods for direct pin/unpin and direct pinned-body hydration.
4. Wire the chat UI so DMs can show and hydrate pinned messages like channels.
5. Cover the DM-specific edge cases: pair scoping, alternate archive-local ids, tombstones, valid/invalid retractions, cross-domain errors, blocking, and route state.

## XEP review

- Reviewed `./xeps`; no suitable official XEP defines 1:1 pinned messages.
- The implementation keeps official XEP namespaces conformant and uses `urn:waddle:pin:0` only for Waddle-specific pin semantics.
- MAM hydration remains XEP-0313 shaped; DM hydration targets the personal archive and constrains with `with=peer`.

## Review fixes

Addressed unresolved PR review feedback:

- Store/unpin/contains now use typed `StanzaId` boundaries and remove all matching logical target entries.
- DM pin identity now uses a pair-stable logical message id instead of archive-local ids.
- Remote-domain DM pin markers return `<forbidden/>` instead of being silently swallowed.
- Live DM pin events honor XEP-0191 blocklists in both directions.
- Pin message builders use a typed internal message-type enum instead of raw message-type strings.
- MAM stanza-id filtering resolves both archive ids and stored wire ids so pair-stable DM pin ids hydrate bodies correctly.

## Verification

- `cargo test -p waddle-server --test dm_pinned_messages_ws -- --nocapture`
- `cargo test -p waddle-xmpp stanza_id_filter`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- Prior full implementation verification remains: `cargo test -p waddle-server`, `REBUILD_WASM=1 bun run wasm:build`, `bun run lint`, `bun test`, and touched-path `bunx vue-tsc --noEmit` filtering.

## Review

Initial adversarial review findings were fixed before marking ready; this update addresses the follow-up PR review threads around canonical identity, typed boundaries, cross-domain errors, and blocking-aware fanout.
