### PR TITLE
fix(server): harden dm pin review findings

### DIFF
--- a/chat/src/services/pinned-message-bodies.ts
+++ b/chat/src/services/pinned-message-bodies.ts
@@ -33,10 +33,11 @@ import type { WasmArchivedMessage } from "@/lib/xmpp/wasm-types";
  * the room-scoped XEP-0359 id (the canonical UUID pins reference). Returns the
  * matched requested id so that the cache key equals what the caller asked for.
  *
- * Contract: the server's stanza-id filter guarantees only messages whose
- * XEP-0359 room-scoped stanza-id is in the requested set are returned. Both
- * archive paths expose that id either through the `stanza_ids` array (branch 1)
- * or the singular `stanza_id`/`stanza_id_by` fields (branch 2).
+ * Contract: the server's stanza-id filter guarantees only messages matching
+ * one of the requested pin target IDs are returned. Room archives usually
+ * expose that ID through XEP-0359 `stanza_ids`; personal DM archives may expose
+ * the pair-stable wire ID through either `stanza_ids` or the singular
+ * `stanza_id` field.
  */
 function matchRequestedStanzaId(
   archived: WasmArchivedMessage,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -173,7 +173,10 @@ async fn handle_dm_pin_message(
     };
     let target = intent.target().to_string();
     let Some(peer) = incoming.to.as_ref().map(|to| to.to_bare()) else {
-        return Some(Vec::new());
+        let mut stamped = incoming.clone();
+        stamped.from = Some(jid::Jid::from(bound_jid.clone()));
+        let reply = bad_request_reply(&stamped, "DM pin marker requires a local peer JID.");
+        return stanza_to_string(reply).ok().map(|frame| vec![frame]);
     };
     if peer.domain() != bound_jid.domain() {
         let mut stamped = incoming.clone();
@@ -317,11 +320,11 @@ fn canonical_dm_pin_stanza_id(
     archive_jid: &jid::BareJid,
 ) -> StanzaId {
     let by = jid::Jid::from(archive_jid.clone());
-    if let Some(origin_id) = archived.origin_id.as_ref() {
-        return StanzaId::new(origin_id.id.clone(), by);
-    }
     if let Some(stanza_id) = archived.stanza_id.as_ref() {
         return StanzaId::new(stanza_id.id.clone(), by);
+    }
+    if let Some(origin_id) = archived.origin_id.as_ref() {
+        return StanzaId::new(origin_id.id.clone(), by);
     }
     StanzaId::new(archived.id.clone(), by)
 }

--- a/server/crates/waddle-server/tests/dm_pinned_messages_ws.rs
+++ b/server/crates/waddle-server/tests/dm_pinned_messages_ws.rs
@@ -671,6 +671,81 @@ async fn dm_pin_to_remote_domain_returns_forbidden() {
 }
 
 #[tokio::test]
+async fn dm_pin_without_to_returns_bad_request() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server = TestServer::start_with_extra_accounts(&[("alice", "alice-pass")]);
+    let mut alice = user_client(&server, "alice", "alice-pass", "dm-pin-no-to-alice").await;
+
+    alice
+        .send(&format!(
+            r#"<message xmlns="jabber:client" type="chat" id="dm-pin-no-to">
+                <pinned xmlns="{NS_WADDLE_PIN}" target="missing-peer-target"/>
+            </message>"#
+        ))
+        .await
+        .expect("send no-to DM pin request");
+
+    let error = alice
+        .recv_matching(|frame| frame.contains("dm-pin-no-to") && frame.contains("<bad-request"))
+        .await
+        .expect("no-to DM pin is rejected");
+    assert!(
+        error.contains("DM pin marker requires a local peer JID"),
+        "no-to pin should explain the malformed request: {error}"
+    );
+}
+
+#[tokio::test]
+async fn dm_pin_prefers_wire_message_id_over_origin_id() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server =
+        TestServer::start_with_extra_accounts(&[("alice", "alice-pass"), ("bob", "bob-pass")]);
+    let mut alice = user_client(&server, "alice", "alice-pass", "dm-pin-origin-alice").await;
+    let mut bob = user_client(&server, "bob", "bob-pass", "dm-pin-origin-bob").await;
+
+    alice
+        .send(
+            r#"<message xmlns="jabber:client" type="chat" to="bob@localhost" id="dm-origin-target">
+                <origin-id xmlns="urn:xmpp:sid:0" id="dm-origin-different"/>
+                <body>origin id differs from wire id</body>
+            </message>"#,
+        )
+        .await
+        .expect("send target DM with origin-id");
+    let delivered = bob
+        .recv_matching(|frame| frame.contains("origin id differs from wire id"))
+        .await
+        .expect("Bob receives target DM");
+    let target_stanza_id = extract_attr_after(&delivered, "stanza-id", "id")
+        .unwrap_or_else(|| panic!("DM delivery must carry XEP-0359 stanza-id: {delivered}"));
+
+    alice
+        .send(&format!(
+            r#"<message xmlns="jabber:client" type="chat" to="bob@localhost" id="dm-origin-pin">
+                <pinned xmlns="{NS_WADDLE_PIN}" target="{target_stanza_id}"/>
+            </message>"#
+        ))
+        .await
+        .expect("send DM pin request");
+
+    let pin_event = bob
+        .recv_matching(|frame| frame.contains("<pin-event") && frame.contains("action='pinned'"))
+        .await
+        .expect("Bob receives live DM pin event");
+    let canonical_target = extract_pin_event_target(&pin_event);
+    assert_eq!(
+        canonical_target, "dm-origin-target",
+        "DM pins must use the projected wire id, not a divergent origin-id: {pin_event}"
+    );
+
+    let bob_pins = fetch_dm_pins(&mut bob, "alice@localhost", "bob-origin-pins").await;
+    assert!(
+        bob_pins.contains("dm-origin-target") && !bob_pins.contains("dm-origin-different"),
+        "pin list should expose the hydratable wire id: {bob_pins}"
+    );
+}
+
+#[tokio::test]
 async fn dm_pin_event_respects_recipient_blocklist() {
     let _guard = TEST_SERIAL.lock().await;
     let server =


### PR DESCRIPTION
# Summary

Follow-up PR for review findings discovered after PR #975 was merged.

## Findings fixed

- DM pin/unpin markers without a `to` JID now return a `<bad-request/>` stanza error instead of being silently ignored.
- DM pin canonical target selection now prefers the projected wire message id over a divergent `<origin-id/>`, keeping pin hydration aligned with the MAM stanza-id filter.
- The pinned-message body hydration comment now documents both room archive stanza IDs and personal DM archive wire IDs.

## Plan

1. Add regression coverage for malformed DM pin markers with no peer JID.
2. Add regression coverage for DMs whose origin-id differs from the wire id.
3. Keep the client-side documentation comment aligned with the server archive contract.

## Verification

- `cargo test -p waddle-server --test dm_pinned_messages_ws -- --nocapture`
- `cargo test -p waddle-xmpp stanza_id_filter`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`

## Notes

- Chat tests were not rerun because the chat change is comment-only.