### PR TITLE
docs(server): align group dm adr with implementation

### DIFF
--- a/chat/src/components/chat/ChatAppModals.vue
+++ b/chat/src/components/chat/ChatAppModals.vue
@@ -2,6 +2,7 @@
 import CreateChannelDialog from "@/components/modals/CreateChannelDialog.vue";
 import WaddleSettingsDialog from "@/components/modals/WaddleSettingsDialog.vue";
 import EditChannelDialog from "@/components/modals/EditChannelDialog.vue";
+import NewGroupDmDialog from "@/components/modals/NewGroupDmDialog.vue";
 import NewDmDialog from "@/components/modals/NewDmDialog.vue";
 import MemberManagement from "@/components/modals/MemberManagement.vue";
 import ConfirmDialog from "@/components/ui/ConfirmDialog.vue";
@@ -20,6 +21,7 @@ const {
   inferredMemberJids,
   displayedMemberState,
   handleNewDm,
+  handleCreateGroupDm,
   handleCreateChannel,
   handleUpdateChannel,
   handleDeleteChannel,
@@ -38,6 +40,13 @@ const {
     <NewDmDialog
       v-model:open="ui.showNewDm.value"
       @submit="handleNewDm"
+    />
+    <NewGroupDmDialog
+      v-model:open="ui.showNewGroupDm.value"
+      :contacts="controller.rosterContacts.contacts.value"
+      :is-submitting="waddles.isSubmitting.value"
+      :self-jid="controller.connectionStore.session?.jid ?? null"
+      @submit="handleCreateGroupDm"
     />
     <CreateChannelDialog
       v-model:open="ui.showCreateChannel.value"

--- a/chat/src/components/chat/ChatMobileDrawers.vue
+++ b/chat/src/components/chat/ChatMobileDrawers.vue
@@ -240,7 +240,7 @@ function openExtensionRoute(route: DiscoveredExtensionRoute) {
           :conversations="dmConversations.conversations.value"
           :group-dms="groupDmConversations"
           :active-peer-jid="dmConversations.activePeerJid.value"
-          :active-group-dm-room-jid="ui.sidebarMode.value === 'dms' ? activeChannelRoomJid : null"
+          :active-group-dm-room-jid="ui.sidebarMode.value === 'dms' && !dmConversations.activePeerJid.value ? activeChannelRoomJid : null"
           :self-full-jid="visibleSelfFullJid"
           hide-current-call
           class="!w-full !border-r-0 !flex-1"

--- a/chat/src/components/chat/ChatMobileDrawers.vue
+++ b/chat/src/components/chat/ChatMobileDrawers.vue
@@ -53,6 +53,8 @@ const {
   displayedMemberState,
   memberCountLabel,
   computedChannelUnreadMap,
+  groupDmConversations,
+  activeChannelRoomJid,
   channelExtensionRoutes,
   activeExtensionRouteKey,
   activeRightPanel,
@@ -68,6 +70,7 @@ const {
   handleToggleMessageSounds,
   selectChannel,
   selectChannelByRoomJid,
+  selectGroupDm,
   onSelectThread,
   selectDm,
   selectExtensionRoute,
@@ -235,15 +238,19 @@ function openExtensionRoute(route: DiscoveredExtensionRoute) {
         <DmPanel
           v-else
           :conversations="dmConversations.conversations.value"
+          :group-dms="groupDmConversations"
           :active-peer-jid="dmConversations.activePeerJid.value"
+          :active-group-dm-room-jid="ui.sidebarMode.value === 'dms' ? activeChannelRoomJid : null"
           :self-full-jid="visibleSelfFullJid"
           hide-current-call
           class="!w-full !border-r-0 !flex-1"
           @answer-dm="answerDmFromMobile"
           @select-dm="selectDm"
+          @select-group-dm="selectGroupDm"
           @reconnect-dm="reconnectDmFromMobile"
           @end-dm="endDmFromMobile"
           @new-dm="ui.showNewDm.value = true"
+          @new-group-dm="ui.showNewGroupDm.value = true"
         />
         <ProfilePanel
           v-if="connectionStore.session"

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -114,6 +114,7 @@ const {
   displayedMemberState,
   activeDmPeer,
   computedChannelUnreadMap,
+  groupDmConversations,
   notifications,
   appUpdate,
   version,
@@ -139,6 +140,7 @@ const {
   handleLogout,
   selectChannel,
   selectChannelByRoomJid,
+  selectGroupDm,
   onSelectThread,
   onSelectThreadEntry,
   selectExtensionRoute,
@@ -263,7 +265,7 @@ const activeDmThreadEntries = computed<MessageThreadEntry[]>(() => {
   if (ui.sidebarMode.value !== "dms" || !activeDmPeer.value) return [];
   return [...threads.index.value.values()].sort((left, right) => right.lastTs.localeCompare(left.lastTs));
 });
-const threadPanelIsDm = computed(() => ui.sidebarMode.value === "dms");
+const threadPanelIsDm = computed(() => ui.sidebarMode.value === "dms" && !!activeDmPeer.value);
 const threadPanelConversationActive = computed(() =>
   (ui.sidebarMode.value === "channels" || ui.sidebarMode.value === "dms") &&
   activeRightPanel.value === "thread" &&
@@ -312,7 +314,7 @@ function onSelectChannelFromSidebar(id: string | null, roomJid?: string) {
 
 async function lookupActiveConversationLinkPreview(body: string) {
   const client = xmppClient.value;
-  const scope = ui.sidebarMode.value === "dms"
+  const scope = threadPanelIsDm.value
     ? activeDmPeer.value?.peerJid
     : activeChannelRoomJid.value;
   if (!client || !scope) return null;
@@ -642,16 +644,20 @@ onUnmounted(() => {
         <DmPanel
           v-else
           :conversations="dmConversations.conversations.value"
+          :group-dms="groupDmConversations"
           :active-peer-jid="dmConversations.activePeerJid.value"
+          :active-group-dm-room-jid="ui.sidebarMode.value === 'dms' ? activeChannelRoomJid : null"
           :thread-entries="activeDmThreadEntries"
           :self-full-jid="selfFullJid"
           hide-current-call
           @answer-dm="answerDmFromActivity"
           @select-dm="selectDm"
+          @select-group-dm="selectGroupDm"
           @select-thread="openThread"
           @reconnect-dm="reconnectDmFromDock"
           @end-dm="endRecoveredDmFromActivity"
           @new-dm="ui.showNewDm.value = true"
+          @new-group-dm="ui.showNewGroupDm.value = true"
         />
         <CurrentCallPanel
           :channels="waddles.sortedChannels.value"
@@ -803,8 +809,8 @@ onUnmounted(() => {
               v-model:forum-title="activeForumTitle"
               :pinned-panel-open="activeRightPanel === 'pinned' && ui.showPinnedPanel.value"
               :waddle="waddles.currentSpace.value"
-              :channel="ui.sidebarMode.value === 'dms' ? null : waddles.currentChannel.value"
-              :room-jid="ui.sidebarMode.value === 'dms' ? null : activeChannelRoomJid"
+              :channel="threadPanelIsDm ? null : waddles.currentChannel.value"
+              :room-jid="threadPanelIsDm ? null : activeChannelRoomJid"
               :dm-peer="activeDmPeer"
               :sidebar-mode="ui.sidebarMode.value"
               :messages="activeMessages"
@@ -1045,8 +1051,8 @@ onUnmounted(() => {
             class="chat-active-thread-pane"
           >
             <PinnedPanel
-              :room-jid="ui.sidebarMode.value === 'dms' ? activeDmPeer?.peerJid ?? '' : activeChannelRoomJid ?? ''"
-              :channel-name="ui.sidebarMode.value === 'dms' ? activeDmPeer?.peerUsername ?? 'Direct message' : waddles.currentChannel.value?.name ?? ''"
+              :room-jid="threadPanelIsDm ? activeDmPeer?.peerJid ?? '' : activeChannelRoomJid ?? ''"
+              :channel-name="threadPanelIsDm ? activeDmPeer?.peerUsername ?? 'Direct message' : waddles.currentChannel.value?.name ?? ''"
               :timeline-messages="activeMessages"
               @close="closePinnedPanel"
               @jump-to-message="(stanzaId: string) => jumpToPinnedMessage(stanzaId)"

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -646,7 +646,7 @@ onUnmounted(() => {
           :conversations="dmConversations.conversations.value"
           :group-dms="groupDmConversations"
           :active-peer-jid="dmConversations.activePeerJid.value"
-          :active-group-dm-room-jid="ui.sidebarMode.value === 'dms' ? activeChannelRoomJid : null"
+          :active-group-dm-room-jid="ui.sidebarMode.value === 'dms' && !dmConversations.activePeerJid.value ? activeChannelRoomJid : null"
           :thread-entries="activeDmThreadEntries"
           :self-full-jid="selfFullJid"
           hide-current-call

--- a/chat/src/components/chat/DmPanel.vue
+++ b/chat/src/components/chat/DmPanel.vue
@@ -643,7 +643,7 @@ function threadEntryLabel(entry: MessageThreadEntry): string {
             </span>
             <span class="min-w-0 flex-1">
               <span class="type-control block truncate text-sidebar-foreground">{{ group.name }}</span>
-              <span class="type-caption block truncate text-sidebar-muted">{{ group.roomJid }}</span>
+              <span class="type-caption block truncate text-sidebar-muted">Group message</span>
             </span>
             <span class="flex shrink-0 items-center gap-1">
               <span

--- a/chat/src/components/chat/DmPanel.vue
+++ b/chat/src/components/chat/DmPanel.vue
@@ -20,15 +20,20 @@ import {
 import type { DmCallActivity } from "@/lib/calls/dm-call-activity";
 import type { CallMedia } from "@/lib/calls/types";
 import { barePeerJid } from "@/lib/xmpp/jid";
+import type { GroupDmSummary } from "@/lib/chat-types";
 import type { DmConversation } from "@/lib/xmpp-client";
 
 const props = withDefaults(defineProps<{
   conversations: DmConversation[];
+  groupDms?: GroupDmSummary[];
   activePeerJid: string | null;
+  activeGroupDmRoomJid?: string | null;
   threadEntries?: MessageThreadEntry[];
   selfFullJid?: string | null;
   hideCurrentCall?: boolean;
 }>(), {
+  groupDms: () => [],
+  activeGroupDmRoomJid: null,
   threadEntries: () => [],
   hideCurrentCall: false,
 });
@@ -36,10 +41,12 @@ const props = withDefaults(defineProps<{
 const emit = defineEmits<{
   answerDm: [peerJid: string, remoteFullJid: string, sid: string, media: CallMedia];
   selectDm: [peerJid: string];
+  selectGroupDm: [roomJid: string];
   selectThread: [threadId: string];
   reconnectDm: [peerJid: string, media: CallMedia];
   endDm: [peerJid: string, sid?: string];
   newDm: [];
+  newGroupDm: [];
 }>();
 
 const dmCallActivities = useStore($dmCallActivities);
@@ -82,6 +89,9 @@ const visibleConversations = computed<DmConversation[]>(() => {
     .filter((conversation) => !activeCallPeers.has(normalizedPeerJid(conversation.peerJid)))
     .sort(compareDmConversations);
 });
+const visibleGroupDms = computed(() =>
+  [...props.groupDms].sort((a, b) => (a.position ?? 0) - (b.position ?? 0) || a.name.localeCompare(b.name)),
+);
 const visibleThreadEntries = computed(() => props.threadEntries.filter((entry) => entry.count > 0));
 
 function normalizedPeerJid(peerJid: string): string {
@@ -457,15 +467,26 @@ function threadEntryLabel(entry: MessageThreadEntry): string {
         <MessageCircle class="w-4 h-4 text-primary/70" />
         <h2 class="type-pane-title text-sidebar-foreground">Direct messages</h2>
       </div>
-      <button
-        class="chat-icon-button text-sidebar-muted hover:bg-sidebar-accent hover:text-sidebar-foreground"
-        title="New message"
-        aria-label="New direct message"
-        type="button"
-        @click="emit('newDm')"
-      >
-        <Plus class="w-4 h-4" />
-      </button>
+      <div class="flex items-center gap-1">
+        <button
+          class="chat-icon-button text-sidebar-muted hover:bg-sidebar-accent hover:text-sidebar-foreground"
+          title="New group message"
+          aria-label="New group message"
+          type="button"
+          @click="emit('newGroupDm')"
+        >
+          <MessagesSquare class="w-4 h-4" />
+        </button>
+        <button
+          class="chat-icon-button text-sidebar-muted hover:bg-sidebar-accent hover:text-sidebar-foreground"
+          title="New message"
+          aria-label="New direct message"
+          type="button"
+          @click="emit('newDm')"
+        >
+          <Plus class="w-4 h-4" />
+        </button>
+      </div>
     </div>
 
     <div class="chat-pane-scroll chat-sidebar-scroll">
@@ -475,7 +496,7 @@ function threadEntryLabel(entry: MessageThreadEntry): string {
       <!-- Empty state — halo + MessageCircle glyph + caption + hint
            matches the iter-37 / 47 / 48 authored-empty-state pattern
            used elsewhere in the app. -->
-      <div v-if="visibleConversations.length === 0 && activeCallRows.length === 0" class="flex flex-col items-center justify-center gap-2 py-10 text-center">
+      <div v-if="visibleGroupDms.length === 0 && visibleConversations.length === 0 && activeCallRows.length === 0" class="flex flex-col items-center justify-center gap-2 py-10 text-center">
         <div class="chat-empty-state__halo">
           <span class="chat-empty-state__halo-glow chat-empty-state__halo-glow--primary" aria-hidden="true" />
           <span class="chat-empty-state__halo-ring chat-empty-state__halo-ring--primary">
@@ -594,6 +615,49 @@ function threadEntryLabel(entry: MessageThreadEntry): string {
               <PhoneOff class="h-3.5 w-3.5" aria-hidden="true" />
             </button>
           </div>
+        </section>
+
+        <section
+          v-if="visibleGroupDms.length > 0"
+          class="grid gap-1"
+          aria-label="Group direct messages"
+        >
+          <div class="type-section-label flex items-center gap-1.5 px-2 pt-2 pb-1 text-sidebar-muted">
+            <MessagesSquare class="h-3 w-3 text-primary/70" aria-hidden="true" />
+            <span class="flex-1 truncate">Groups</span>
+          </div>
+          <button
+            v-for="group in visibleGroupDms"
+            :key="group.roomJid"
+            class="chat-list-row w-full min-h-14 flex items-center gap-3 px-3 py-2 text-left group"
+            :class="normalizedPeerJid(activeGroupDmRoomJid ?? '') === normalizedPeerJid(group.roomJid)
+              ? 'chat-list-row--active bg-sidebar-accent text-sidebar-foreground'
+              : 'text-sidebar-muted hover:bg-sidebar-accent/50 hover:text-sidebar-foreground'"
+            type="button"
+            :aria-current="normalizedPeerJid(activeGroupDmRoomJid ?? '') === normalizedPeerJid(group.roomJid) ? 'page' : undefined"
+            :aria-label="`Open group message ${group.name}`"
+            @click="emit('selectGroupDm', group.roomJid)"
+          >
+            <span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-sidebar-accent text-sidebar-foreground">
+              <MessagesSquare class="h-4 w-4" aria-hidden="true" />
+            </span>
+            <span class="min-w-0 flex-1">
+              <span class="type-control block truncate text-sidebar-foreground">{{ group.name }}</span>
+              <span class="type-caption block truncate text-sidebar-muted">{{ group.roomJid }}</span>
+            </span>
+            <span class="flex shrink-0 items-center gap-1">
+              <span
+                v-if="(group.mentionCount ?? 0) > 0"
+                class="chat-list-row--mention-badge type-count-badge inline-flex min-w-[18px] h-[18px] px-1 items-center justify-center rounded-full bg-destructive text-destructive-foreground"
+                aria-hidden="true"
+              >@{{ group.mentionCount }}</span>
+              <span
+                v-if="(group.unreadCount ?? 0) > 0"
+                class="chat-list-row--unread-badge type-count-badge inline-flex min-w-[18px] h-[18px] px-1 items-center justify-center rounded-full bg-primary text-primary-foreground"
+                aria-hidden="true"
+              >{{ group.unreadCount }}</span>
+            </span>
+          </button>
         </section>
 
         <button

--- a/chat/src/components/modals/NewGroupDmDialog.vue
+++ b/chat/src/components/modals/NewGroupDmDialog.vue
@@ -1,0 +1,126 @@
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import { Check, X } from "lucide-vue-next";
+import AppDialog from "@/components/ui/AppDialog.vue";
+import type { RosterContact } from "@/lib/xmpp/types";
+
+const open = defineModel<boolean>("open", { required: true });
+
+const props = defineProps<{
+  contacts: RosterContact[];
+  isSubmitting?: boolean;
+  selfJid?: string | null;
+}>();
+
+const emit = defineEmits<{
+  submit: [payload: { name: string; memberJids: string[] }];
+}>();
+
+const selected = ref<Set<string>>(new Set());
+
+const selectableContacts = computed(() => {
+  const self = (props.selfJid ?? "").split("/")[0]?.toLowerCase() ?? "";
+  return props.contacts
+    .filter((contact) => contact.jid.toLowerCase() !== self)
+    .sort((a, b) => contactLabel(a).localeCompare(contactLabel(b), undefined, { sensitivity: "base" }));
+});
+
+const selectedContacts = computed(() =>
+  selectableContacts.value.filter((contact) => selected.value.has(contact.jid)),
+);
+
+const defaultName = computed(() => selectedContacts.value.map(contactLabel).join(", "));
+const name = ref("");
+const canSubmit = computed(() => selected.value.size >= 2 && !props.isSubmitting);
+
+watch(open, (next) => {
+  if (!next) {
+    selected.value = new Set();
+    name.value = "";
+  }
+});
+
+function contactLabel(contact: RosterContact): string {
+  return contact.name?.trim() || contact.username?.trim() || contact.jid.split("@")[0] || contact.jid;
+}
+
+function toggleContact(jid: string) {
+  const next = new Set(selected.value);
+  if (next.has(jid)) next.delete(jid);
+  else next.add(jid);
+  selected.value = next;
+}
+
+function handleSubmit() {
+  if (!canSubmit.value) return;
+  emit("submit", {
+    name: name.value.trim() || defaultName.value,
+    memberJids: [...selected.value],
+  });
+}
+</script>
+
+<template>
+  <AppDialog v-model:open="open">
+    <div class="chat-dialog-header">
+      <h2 class="type-dialog-title">New group message</h2>
+      <button
+        class="chat-icon-button hover:bg-muted"
+        type="button"
+        aria-label="Close new group message dialog"
+        @click="open = false"
+      >
+        <X class="w-4 h-4 text-muted-foreground" />
+      </button>
+    </div>
+
+    <div class="chat-field-stack chat-dialog-body">
+      <label for="new-group-dm-name" class="type-section-label text-muted-foreground">
+        Name
+      </label>
+      <input
+        id="new-group-dm-name"
+        v-model="name"
+        class="chat-field-control type-field"
+        :placeholder="defaultName || 'Alice, Bob'"
+      />
+
+      <div class="grid max-h-72 gap-1 overflow-auto pr-1">
+        <button
+          v-for="contact in selectableContacts"
+          :key="contact.jid"
+          class="chat-list-row flex min-h-11 items-center gap-3 rounded-md px-3 py-2 text-left hover:bg-muted"
+          type="button"
+          :aria-pressed="selected.has(contact.jid)"
+          @click="toggleContact(contact.jid)"
+        >
+          <span class="flex h-5 w-5 shrink-0 items-center justify-center rounded border border-border">
+            <Check v-if="selected.has(contact.jid)" class="h-3.5 w-3.5 text-primary" />
+          </span>
+          <span class="min-w-0 flex-1">
+            <span class="type-control block truncate text-foreground">{{ contactLabel(contact) }}</span>
+            <span class="type-caption block truncate text-muted-foreground">{{ contact.jid }}</span>
+          </span>
+        </button>
+      </div>
+    </div>
+
+    <div class="chat-dialog-footer">
+      <button
+        class="chat-action-button chat-action-button--secondary type-control"
+        type="button"
+        @click="open = false"
+      >
+        Cancel
+      </button>
+      <button
+        class="chat-action-button chat-action-button--primary type-control disabled:opacity-40"
+        type="button"
+        :disabled="!canSubmit"
+        @click="handleSubmit"
+      >
+        Create group
+      </button>
+    </div>
+  </AppDialog>
+</template>

--- a/chat/src/lib/chat-types.ts
+++ b/chat/src/lib/chat-types.ts
@@ -18,6 +18,7 @@ export interface ChannelSummary {
   channel_type?: string;
   position?: number;
   features?: string[];
+  isGroupDm?: boolean;
   is_default?: boolean;
   created_at?: string;
   updated_at?: string | null;
@@ -25,6 +26,18 @@ export interface ChannelSummary {
    * `urn:waddle:roomconfig:pinpermission` field. Default
    * `admins-only`. */
   pinPermission?: PinPermission;
+}
+
+export interface GroupDmSummary {
+  id: string;
+  roomJid: string;
+  name: string;
+  position?: number;
+  features?: string[];
+  autojoin?: boolean;
+  pinPermission?: PinPermission;
+  unreadCount?: number;
+  mentionCount?: number;
 }
 
 /** #415: wire values for the `urn:waddle:roomconfig:pinpermission`

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -58,6 +58,7 @@ import { prepareEncryptedAttachmentUpload } from "./encrypted-attachments";
 
 import { discoverChannels, discoverTopology } from "./discovery";
 import { discoverUploadService, uploadFile, type UploadProgress } from "./file-upload";
+import { createGroupDm, type CreateGroupDmResult } from "./group-dm";
 import { ReconnectCatchup } from "./reconnect-catchup";
 import { classifyMamError, isMamCursorNotFound } from "./mam";
 import { parseRegisterDeviceResult, type RegisterDeviceResult } from "./push-register-result";
@@ -2993,6 +2994,14 @@ export class BrowserXmppClient {
   async listRosterContacts(): Promise<RosterContact[]> { const xmpp = await this.requireConnectedXmpp(); const roster = await xmpp.list_roster_contacts?.() as WasmRosterContact[]; return (roster ?? []).map((item) => { const jid = barePeerJid(item.jid); return { jid, name: item.name, username: item.name?.trim() || jid.split("@")[0] || jid, subscription: (item.subscription ?? "none") as RosterContact["subscription"], groups: item.groups ?? [] }; }); }
   async getServerVersion(): Promise<WasmServerVersion | null> { const xmpp = await this.requireConnectedXmpp(); return await xmpp.get_server_version?.() as WasmServerVersion | null; }
   async discoverSpaceChannels(): Promise<any[]> { const xmpp = await this.requireConnectedXmpp(); return discoverChannels(xmpp as WasmClient, this.session.jid); }
+  async createGroupDm(name: string, memberJids: string[]): Promise<CreateGroupDmResult> {
+    const xmpp = await this.requireConnectedXmpp();
+    return createGroupDm(xmpp as WasmClient, {
+      userJid: this.session.jid,
+      name,
+      memberJids,
+    });
+  }
   async discoverTopology(): Promise<DiscoveredTopology> {
     const xmpp = await this.requireConnectedXmpp();
     const topology = await discoverTopology(xmpp as WasmClient, this.session.jid);

--- a/chat/src/lib/xmpp/discovery.ts
+++ b/chat/src/lib/xmpp/discovery.ts
@@ -474,10 +474,11 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
     for (const bookmark of userBookmarks) {
       if (!bookmark.jid) continue;
       const roomJid = barePeerJid(bookmark.jid);
+      const existing = bookmarkedRooms.get(roomJid);
       bookmarkedRooms.set(roomJid, {
-        ...bookmarkedRooms.get(roomJid),
+        ...existing,
         autojoin: bookmark.autojoin ?? false,
-        name: bookmark.name,
+        name: bookmark.name ?? existing?.name,
       });
     }
   } catch {}

--- a/chat/src/lib/xmpp/discovery.ts
+++ b/chat/src/lib/xmpp/discovery.ts
@@ -10,6 +10,7 @@ const NS_SPACES_0 = "urn:xmpp:spaces:0";
 const NS_PUBSUB = "http://jabber.org/protocol/pubsub";
 const NS_PUBSUB_METADATA = "http://jabber.org/protocol/pubsub#meta-data";
 const NS_BOOKMARKS_1 = "urn:xmpp:bookmarks:1";
+const NS_WADDLE_GROUP_DM = "urn:waddle:group-dm:0";
 const NS_MUC_ROOMINFO = "http://jabber.org/protocol/muc#roominfo";
 const DISCO_INFO_NS = "http://jabber.org/protocol/disco#info";
 const DISCO_ITEMS_NS = "http://jabber.org/protocol/disco#items";
@@ -169,6 +170,10 @@ function parseDiscoveryRole(value: string | null): DiscoveryRole {
 function channelTypeFromInfo(info: DiscoInfoData): DiscoveredChannel["channelType"] {
   const forumField = parseBooleanValue(info.fields.get(FIELD_FORUM_MODE) ?? null);
   return normalizeChannelType(info.features.includes(NS_FORUMS_0) || forumField ? "forum" : "text");
+}
+
+export function isGroupDmDiscoInfo(info: DiscoInfoData | null | undefined): boolean {
+  return hasDiscoFeature(info, NS_WADDLE_GROUP_DM);
 }
 
 function hasDiscoFeature(info: DiscoInfoData | null | undefined, feature: string): boolean {
@@ -382,6 +387,7 @@ export function applyDiscoInfoToChannel(room: DiscoveredChannel, info: DiscoInfo
   return {
     ...room,
     channelType: channelTypeFromInfo(info),
+    ...(isGroupDmDiscoInfo(info) ? { isGroupDm: true } : {}),
     ...(parentSpaceId ? { spaceId: parentSpaceId, standalone: false } : {}),
     ...(info.features.length ? { features: info.features } : {}),
     ...(pinPermission ? { pinPermission } : {}),
@@ -425,7 +431,7 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
   const domain = jidDomain(jid);
   const services = await discoverComponentServices(xmpp, domain, jid);
   let rooms: DiscoveredChannel[] = [];
-  const bookmarkedRooms = new Map<string, { spaceId: string; autojoin: boolean; name?: string }>();
+  const bookmarkedRooms = new Map<string, { spaceId?: string; autojoin: boolean; name?: string }>();
   const spaces: DiscoveredSpace[] = [];
   let serverRole: DiscoveryRole = null;
 
@@ -463,6 +469,19 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
     }
   } catch {}
 
+  try {
+    const userBookmarks = await sendPubsubItems(xmpp, barePeerJid(jid), NS_BOOKMARKS_1);
+    for (const bookmark of userBookmarks) {
+      if (!bookmark.jid) continue;
+      const roomJid = barePeerJid(bookmark.jid);
+      bookmarkedRooms.set(roomJid, {
+        ...bookmarkedRooms.get(roomJid),
+        autojoin: bookmark.autojoin ?? false,
+        name: bookmark.name,
+      });
+    }
+  } catch {}
+
   // Narrow try/catch JUST around `sendDiscoItems`: a wedged muc service
   // (which now times out via `withIqTimeout` instead of hanging forever)
   // degrades the sidebar to "no rooms" rather than failing the whole
@@ -482,7 +501,8 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
     // console for diagnostics.
     void err;
   }
-  const roomItems = [...mucRooms];
+  const roomItems: Array<{ jid?: string; name?: string; bookmarkOnly?: boolean }> =
+    mucRooms.map((room) => ({ ...room, bookmarkOnly: false }));
   const discoveredRoomJids = new Set(
     roomItems
       .map((room) => room.jid ? barePeerJid(room.jid) : null)
@@ -490,7 +510,7 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
   );
   for (const [roomJid, bookmark] of bookmarkedRooms.entries()) {
     if (!discoveredRoomJids.has(roomJid)) {
-      roomItems.push({ jid: roomJid, name: bookmark.name });
+      roomItems.push({ jid: roomJid, name: bookmark.name, bookmarkOnly: true });
     }
   }
   const hydratedSettled = await Promise.allSettled(
@@ -498,11 +518,17 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
       hydrateRoomInfo(xmpp, channelFromRoom({ jid: room.jid ?? "", name: room.name }, position)),
     ),
   );
-  const hydrated = hydratedSettled.map((entry, index) =>
-    entry.status === "fulfilled"
-      ? entry.value
-      : channelFromRoom({ jid: roomItems[index]!.jid ?? "", name: roomItems[index]!.name }, index),
-  );
+  const hydrated = hydratedSettled.flatMap((entry, index) => {
+    const source = roomItems[index]!;
+    if (entry.status === "fulfilled") {
+      if (source.bookmarkOnly && !entry.value.features?.includes(NS_MUC)) {
+        return [];
+      }
+      return [entry.value];
+    }
+    if (source.bookmarkOnly) return [];
+    return [channelFromRoom({ jid: source.jid ?? "", name: source.name }, index)];
+  });
   const validSpaceIds = new Set(spaces.map((space) => space.id));
   rooms = hydrated.map((room, position) => {
     const bookmark = room.jid ? bookmarkedRooms.get(barePeerJid(room.jid)) : undefined;
@@ -511,11 +537,13 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
     return {
       ...roomWithoutSpace,
       position,
-      ...(bookmark
+      ...(bookmark?.spaceId
         ? { spaceId: bookmark.spaceId, standalone: false, autojoin: bookmark.autojoin }
         : parentSpaceId
           ? { spaceId: parentSpaceId, standalone: false, autojoin: true }
-        : { autojoin: true }),
+        : bookmark
+          ? { autojoin: bookmark.autojoin }
+          : { autojoin: true }),
     };
   });
 

--- a/chat/src/lib/xmpp/discovery.ts
+++ b/chat/src/lib/xmpp/discovery.ts
@@ -521,7 +521,7 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
   const hydrated = hydratedSettled.flatMap((entry, index) => {
     const source = roomItems[index]!;
     if (entry.status === "fulfilled") {
-      if (source.bookmarkOnly && !entry.value.features?.includes(NS_MUC)) {
+      if (source.bookmarkOnly && !entry.value.features?.some((feature) => feature === NS_MUC)) {
         return [];
       }
       return [entry.value];

--- a/chat/src/lib/xmpp/group-dm.ts
+++ b/chat/src/lib/xmpp/group-dm.ts
@@ -1,0 +1,56 @@
+import { jidDomain } from "./jid";
+import type { XmppSendIq } from "./extension-commands/types";
+import { escapeXml, parseCommandIqResponse } from "./extension-commands/xml";
+
+export const GROUP_DM_CREATE_NODE = "urn:waddle:group-dm:create:0";
+const NS_COMMANDS = "http://jabber.org/protocol/commands";
+const NS_DATA = "jabber:x:data";
+
+export interface CreateGroupDmInput {
+  userJid: string;
+  name: string;
+  memberJids: string[];
+}
+
+export interface CreateGroupDmResult {
+  roomJid: string;
+}
+
+function fieldXml(name: string, values: string[], type?: string): string {
+  const typeAttr = type ? ` type="${escapeXml(type)}"` : "";
+  return `<field var="${escapeXml(name)}"${typeAttr}>${values.map((value) => `<value>${escapeXml(value)}</value>`).join("")}</field>`;
+}
+
+export function buildCreateGroupDmCommandXml(input: CreateGroupDmInput): string {
+  const fields = [
+    fieldXml("FORM_TYPE", [GROUP_DM_CREATE_NODE], "hidden"),
+    fieldXml("name", [input.name]),
+    fieldXml("member_jids", input.memberJids, "jid-multi"),
+  ].join("");
+  return `<iq type="set" id="${crypto.randomUUID()}" to="${escapeXml(jidDomain(input.userJid))}"><command xmlns="${NS_COMMANDS}" node="${GROUP_DM_CREATE_NODE}" action="execute"><x xmlns="${NS_DATA}" type="submit">${fields}</x></command></iq>`;
+}
+
+export function parseCreateGroupDmResult(xml: string): CreateGroupDmResult {
+  const result = parseCommandIqResponse(xml);
+  const form = result.form as { fields?: Array<{ name?: string; var?: string; value?: string; values?: string[] }> } | undefined;
+  const roomJid = form?.fields
+    ?.find((field) => (field.name || field.var) === "room_jid")
+    ?.values?.[0]
+    ?? form?.fields?.find((field) => (field.name || field.var) === "room_jid")?.value
+    ?? "";
+  if (!roomJid) {
+    throw new Error("Group-DM create response did not include room_jid.");
+  }
+  return { roomJid };
+}
+
+export async function createGroupDm(
+  xmpp: XmppSendIq,
+  input: CreateGroupDmInput,
+): Promise<CreateGroupDmResult> {
+  if (!xmpp.send_raw_iq) {
+    throw new Error("XMPP raw IQ transport is unavailable.");
+  }
+  const response = await xmpp.send_raw_iq(buildCreateGroupDmCommandXml(input));
+  return parseCreateGroupDmResult(response);
+}

--- a/chat/src/lib/xmpp/group-dm.ts
+++ b/chat/src/lib/xmpp/group-dm.ts
@@ -33,11 +33,8 @@ export function buildCreateGroupDmCommandXml(input: CreateGroupDmInput): string 
 export function parseCreateGroupDmResult(xml: string): CreateGroupDmResult {
   const result = parseCommandIqResponse(xml);
   const form = result.form as { fields?: Array<{ name?: string; var?: string; value?: string; values?: string[] }> } | undefined;
-  const roomJid = form?.fields
-    ?.find((field) => (field.name || field.var) === "room_jid")
-    ?.values?.[0]
-    ?? form?.fields?.find((field) => (field.name || field.var) === "room_jid")?.value
-    ?? "";
+  const roomJidField = form?.fields?.find((field) => (field.name || field.var) === "room_jid");
+  const roomJid = roomJidField?.values?.[0] ?? roomJidField?.value ?? "";
   if (!roomJid) {
     throw new Error("Group-DM create response did not include room_jid.");
   }

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -416,6 +416,7 @@ export interface DiscoveredChannel {
   spaceId?: string;
   standalone?: boolean;
   features?: string[];
+  isGroupDm?: boolean;
   /**
    * XEP-0402 bookmark `autojoin` value. Bookmarked rooms with the
    * attribute omitted are `false` per spec; rooms discovered outside

--- a/chat/src/pages/dm/room/[roomJid].astro
+++ b/chat/src/pages/dm/room/[roomJid].astro
@@ -1,0 +1,8 @@
+---
+import AppLayout from "@/layouts/AppLayout.astro";
+import RoutePageShell from "@/components/pages/RoutePageShell.vue";
+---
+
+<AppLayout>
+  <RoutePageShell client:only="vue" routeId="groupDmRoom" />
+</AppLayout>

--- a/chat/src/router/match.ts
+++ b/chat/src/router/match.ts
@@ -5,6 +5,7 @@ import { dmListRoute } from "./routes/dm-list";
 import { dmRoute } from "./routes/dm";
 import { eventsRoute } from "./routes/events";
 import { feedRoute } from "./routes/feed";
+import { groupDmRoomRoute } from "./routes/group-dm-room";
 import { homeRoute } from "./routes/home";
 import { settingsRoute } from "./routes/settings";
 import { storiesRoute } from "./routes/stories";
@@ -14,12 +15,14 @@ import type { RouteMatch } from "./registry";
 
 // Order matters: longer-prefix routes must be tried before their
 // shorter prefixes. `channelExtension` (`/r/:c/x/:p/:r`) must beat
-// `channel` (`/r/:c`); `dm` (`/dm/:user`) must beat `dmList` (`/dm`).
+// `channel` (`/r/:c`); `groupDmRoom` (`/dm/room/:roomJid`) and
+// `dm` (`/dm/:user`) must beat `dmList` (`/dm`).
 // `home` (`/` only) sits last and `matchLocation` falls back to it
 // for anything that didn't match a real route.
 const ORDER = [
   channelExtensionRoute,
   channelRoute,
+  groupDmRoomRoute,
   dmRoute,
   dmListRoute,
   feedRoute,

--- a/chat/src/router/navigate.ts
+++ b/chat/src/router/navigate.ts
@@ -5,6 +5,7 @@ import { dmListRoute } from "./routes/dm-list";
 import { dmRoute } from "./routes/dm";
 import { eventsRoute } from "./routes/events";
 import { feedRoute } from "./routes/feed";
+import { groupDmRoomRoute } from "./routes/group-dm-room";
 import { homeRoute } from "./routes/home";
 import { settingsRoute } from "./routes/settings";
 import { storiesRoute } from "./routes/stories";
@@ -23,6 +24,8 @@ export function buildHref(match: RouteMatch): string {
       return channelExtensionRoute.href({ params: match.params, search: match.search });
     case "dm":
       return dmRoute.href({ params: match.params, search: match.search });
+    case "groupDmRoom":
+      return groupDmRoomRoute.href({ params: match.params, search: match.search });
     case "dmList":
       return dmListRoute.href();
     case "feed":

--- a/chat/src/router/registry.ts
+++ b/chat/src/router/registry.ts
@@ -5,6 +5,7 @@ import type { DmListMatch } from "./routes/dm-list";
 import type { DmMatch } from "./routes/dm";
 import type { EventsMatch } from "./routes/events";
 import type { FeedMatch } from "./routes/feed";
+import type { GroupDmRoomMatch } from "./routes/group-dm-room";
 import type { HomeMatch } from "./routes/home";
 import type { SettingsMatch } from "./routes/settings";
 import type { StoriesMatch } from "./routes/stories";
@@ -16,6 +17,7 @@ export type RouteMatch =
   | ChannelMatch
   | ChannelExtensionMatch
   | DmMatch
+  | GroupDmRoomMatch
   | DmListMatch
   | FeedMatch
   | StoriesMatch

--- a/chat/src/router/routes/group-dm-room.ts
+++ b/chat/src/router/routes/group-dm-room.ts
@@ -1,0 +1,41 @@
+import { threadAndPinnedSearch } from "../codecs";
+
+export interface GroupDmRoomMatch {
+  readonly id: "groupDmRoom";
+  readonly params: { roomJid: string };
+  readonly search: { thread: string[]; pinned: boolean };
+}
+
+interface GroupDmRoomMatchInput {
+  params: { roomJid: string };
+  search?: { thread?: string[]; pinned?: boolean };
+}
+
+export const groupDmRoomRoute = {
+  id: "groupDmRoom" as const,
+  match(input: GroupDmRoomMatchInput): GroupDmRoomMatch {
+    return {
+      id: "groupDmRoom",
+      params: { roomJid: input.params.roomJid },
+      search: { thread: input.search?.thread ?? [], pinned: input.search?.pinned ?? false },
+    };
+  },
+  href(input: GroupDmRoomMatchInput): string {
+    const search = threadAndPinnedSearch.encode({
+      thread: input.search?.thread ?? [],
+      pinned: input.search?.pinned ?? false,
+    });
+    return `/dm/room/${encodeURIComponent(input.params.roomJid)}${search}`;
+  },
+  tryParse(pathname: string, searchString: string): GroupDmRoomMatch | null {
+    const segments = pathname.split("/").filter(Boolean);
+    if (segments.length !== 3) return null;
+    if (segments[0] !== "dm" || segments[1] !== "room") return null;
+    if (!segments[2]) return null;
+    return {
+      id: "groupDmRoom",
+      params: { roomJid: decodeURIComponent(segments[2]) },
+      search: threadAndPinnedSearch.decode(searchString),
+    };
+  },
+};

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -299,11 +299,14 @@ export function useChatAppController(giphyApiKey: string) {
   ) => {
     contentAreaRef.value = instance;
   };
+  function isActiveDirectDmSurface(): boolean {
+    return ui.sidebarMode.value === "dms" && !!dmConversations.activePeerJid.value;
+  }
 
   watchEffect(() => {
     const timeline = contentAreaRef.value?.messagesContainer ?? null;
     const edgeScroller = contentAreaRef.value?.scrollToPinnedEdge ?? null;
-    if (ui.sidebarMode.value === "dms") {
+    if (isActiveDirectDmSurface()) {
       dmMessaging.timelineEl.value = timeline;
       dmMessaging.timelineEdgeScroller.value = edgeScroller;
       messaging.timelineEl.value = null;
@@ -317,10 +320,10 @@ export function useChatAppController(giphyApiKey: string) {
   });
 
   const activeMessages = computed(() =>
-    ui.sidebarMode.value === "dms" ? dmMessaging.messages.value : messaging.messages.value,
+    isActiveDirectDmSurface() ? dmMessaging.messages.value : messaging.messages.value,
   );
   const activeFirstUnseenId = computed(() =>
-    ui.sidebarMode.value === "dms" ? dmMessaging.firstUnseenId.value : messaging.firstUnseenId.value,
+    isActiveDirectDmSurface() ? dmMessaging.firstUnseenId.value : messaging.firstUnseenId.value,
   );
   const extensionRoutes = ref<DiscoveredExtensionRoute[]>([]);
   const selectedChannelRoomJids = ref<Record<string, string>>({});
@@ -593,27 +596,27 @@ export function useChatAppController(giphyApiKey: string) {
     if (!shouldYield) consumeKeystrokEvent(event);
   }
   const activeDraft = computed({
-    get: () => (ui.sidebarMode.value === "dms" ? dmMessaging.draft.value : messaging.draft.value),
+    get: () => (isActiveDirectDmSurface() ? dmMessaging.draft.value : messaging.draft.value),
     set: (value: string) => {
-      if (ui.sidebarMode.value === "dms") dmMessaging.draft.value = value;
+      if (isActiveDirectDmSurface()) dmMessaging.draft.value = value;
       else messaging.draft.value = value;
     },
   });
   const activeForumTitle = computed({
-    get: () => (ui.sidebarMode.value === "dms" ? "" : messaging.forumPostTitle.value),
+    get: () => (isActiveDirectDmSurface() ? "" : messaging.forumPostTitle.value),
     set: (value: string) => {
-      if (ui.sidebarMode.value !== "dms") {
+      if (!isActiveDirectDmSurface()) {
         messaging.forumPostTitle.value = value;
       }
     },
   });
   const activeTypingUsers = computed(() =>
-    ui.sidebarMode.value === "dms" ? dmMessaging.typingUsers.value : messaging.typingUsers.value,
+    isActiveDirectDmSurface() ? dmMessaging.typingUsers.value : messaging.typingUsers.value,
   );
   const isApplyingRoute = ref(false);
   let routeRequestId = 0;
   const activeIsLoadingMessages = computed(() =>
-    ui.sidebarMode.value === "dms" ? dmMessaging.isLoadingMessages.value : messaging.isLoadingMessages.value,
+    isActiveDirectDmSurface() ? dmMessaging.isLoadingMessages.value : messaging.isLoadingMessages.value,
   );
   const isResolvingActiveConversation = computed(() =>
     ui.activePage.value === "chat"
@@ -625,19 +628,19 @@ export function useChatAppController(giphyApiKey: string) {
     activeIsLoadingMessages.value || isResolvingActiveConversation.value,
   );
   const activeIsLoadingOlderMessages = computed(() =>
-    ui.sidebarMode.value === "dms" ? dmMessaging.isLoadingOlderMessages.value : messaging.isLoadingOlderMessages.value,
+    isActiveDirectDmSurface() ? dmMessaging.isLoadingOlderMessages.value : messaging.isLoadingOlderMessages.value,
   );
   const activeHasOlderMessages = computed(() =>
-    ui.sidebarMode.value === "dms" ? dmMessaging.hasOlderMessages.value : messaging.hasOlderMessages.value,
+    isActiveDirectDmSurface() ? dmMessaging.hasOlderMessages.value : messaging.hasOlderMessages.value,
   );
   const activeIsSending = computed(() =>
-    ui.sidebarMode.value === "dms" ? dmMessaging.isSending.value : messaging.isSending.value,
+    isActiveDirectDmSurface() ? dmMessaging.isSending.value : messaging.isSending.value,
   );
   const activeSearchResults = computed(() =>
-    ui.sidebarMode.value === "dms" ? dmMessaging.searchResults.value : messaging.searchResults.value,
+    isActiveDirectDmSurface() ? dmMessaging.searchResults.value : messaging.searchResults.value,
   );
   const activeIsSearching = computed(() =>
-    ui.sidebarMode.value === "dms" ? dmMessaging.isSearching.value : messaging.isSearching.value,
+    isActiveDirectDmSurface() ? dmMessaging.isSearching.value : messaging.isSearching.value,
   );
 
   const members = useWaddleMembers(
@@ -718,7 +721,7 @@ export function useChatAppController(giphyApiKey: string) {
   });
 
   const activeTarget = computed(() =>
-    ui.sidebarMode.value === "dms" ? dmMessaging : messaging,
+    isActiveDirectDmSurface() ? dmMessaging : messaging,
   );
   const { computedChannelUnreadMap, totalTabUnreadCount } = useChatReadActivity({
     appReady: computed(() => connectionStore.appState === "ready"),
@@ -735,6 +738,16 @@ export function useChatAppController(giphyApiKey: string) {
     activeTarget,
     roomJidForChannelId: resolveRoomJidForChannelId,
   });
+  const groupDmConversations = computed(() =>
+    waddles.groupDms.value.map((group) => {
+      const activity = computedChannelUnreadMap.value[group.id];
+      return {
+        ...group,
+        unreadCount: activity?.unread ?? 0,
+        mentionCount: activity?.mentions ?? 0,
+      };
+    }),
+  );
 
   const notifications = usePushNotifications();
   const messageSound = createBrowserMessageTonePlayer();
@@ -895,7 +908,7 @@ export function useChatAppController(giphyApiKey: string) {
         stanzaId: entry.stanzaId,
         stanzaIdBy: barePeerJid(entry.stanzaIdBy),
       };
-      const accepted = ui.sidebarMode.value === "dms"
+      const accepted = isActiveDirectDmSurface()
         ? dmMessaging.applyMdsDisplayed(chatId, displayed)
         : messaging.applyMdsDisplayed(chatId, displayed);
       const key = mdsChatKey(chatId);
@@ -1017,12 +1030,12 @@ export function useChatAppController(giphyApiKey: string) {
   }
 
   const activeUploadProgress = computed(() =>
-    ui.sidebarMode.value === "dms" ? dmMessaging.uploadProgress.value : messaging.uploadProgress.value,
+    isActiveDirectDmSurface() ? dmMessaging.uploadProgress.value : messaging.uploadProgress.value,
   );
   const activeActionError = computed(() => ui.actionError.value);
   const activeErrorActionLabel = computed(() => {
     const peer = activeDmPeer.value;
-    return ui.sidebarMode.value === "dms" &&
+    return isActiveDirectDmSurface() &&
       peer &&
       dmMessaging.loadErrorPeerJid.value === peer.peerJid &&
       activeActionError.value === dmMessaging.loadErrorMessage.value
@@ -1072,7 +1085,7 @@ export function useChatAppController(giphyApiKey: string) {
     forumTitle?: string,
     linkPreview?: ComposerLinkPreviewSendPayload,
   ) {
-    if (ui.sidebarMode.value === "dms") {
+    if (isActiveDirectDmSurface()) {
       await dmMessaging.sendMessage(body, markup, references, files, replyTo, linkPreview);
       return;
     }
@@ -1099,7 +1112,7 @@ export function useChatAppController(giphyApiKey: string) {
     threadOverride: { threadId: string; parentThreadId?: string },
     linkPreview?: ComposerLinkPreviewSendPayload,
   ) {
-    if (ui.sidebarMode.value === "dms") {
+    if (isActiveDirectDmSurface()) {
       await dmMessaging.sendMessage(body, markup, references, files, replyTo, linkPreview, threadOverride);
       return;
     }
@@ -1154,9 +1167,11 @@ export function useChatAppController(giphyApiKey: string) {
   // or a deep link shows only the replies that happen to be in the loaded
   // conversation window.
   function backfillActiveThread(threadId: string) {
-    if (ui.sidebarMode.value === "dms") {
+    if (isActiveDirectDmSurface()) {
       void dmMessaging.backfillThread(threadId);
     } else if (ui.sidebarMode.value === "channels") {
+      void messaging.backfillThread(threadId);
+    } else if (waddles.currentChannel.value?.isGroupDm) {
       void messaging.backfillThread(threadId);
     }
   }
@@ -1245,7 +1260,7 @@ export function useChatAppController(giphyApiKey: string) {
   }
 
   function editActiveMessage(messageId: string, newBody: string, markup?: MarkupSpan[], references?: MessageReference[], linkPreview?: ComposerLinkPreviewSendPayload) {
-    if (ui.sidebarMode.value === "dms") {
+    if (isActiveDirectDmSurface()) {
       void dmMessaging.editMessage(messageId, newBody, markup, references, linkPreview);
       return;
     }
@@ -1269,7 +1284,7 @@ export function useChatAppController(giphyApiKey: string) {
     if (!client) return;
     const stanzaId = resolvePinTargetStanzaId(messageId);
     if (!stanzaId) return;
-    if (ui.sidebarMode.value === "dms") {
+    if (isActiveDirectDmSurface()) {
       const peer = dmConversations.activePeerJid.value;
       if (!peer || !("pinDirectMessage" in client)) return;
       void client.pinDirectMessage(peer, stanzaId).catch((error: unknown) => {
@@ -1289,7 +1304,7 @@ export function useChatAppController(giphyApiKey: string) {
     if (!client) return;
     const stanzaId = resolvePinTargetStanzaId(messageId);
     if (!stanzaId) return;
-    if (ui.sidebarMode.value === "dms") {
+    if (isActiveDirectDmSurface()) {
       const peer = dmConversations.activePeerJid.value;
       if (!peer || !("unpinDirectMessage" in client)) return;
       void client.unpinDirectMessage(peer, stanzaId).catch((error: unknown) => {
@@ -1358,7 +1373,7 @@ export function useChatAppController(giphyApiKey: string) {
 
   function retryActiveLoad() {
     const peer = activeDmPeer.value;
-    if (ui.sidebarMode.value !== "dms" || !peer) return;
+    if (!isActiveDirectDmSurface() || !peer) return;
     void dmMessaging.loadMessages(peer.peerJid);
   }
 
@@ -1367,7 +1382,7 @@ export function useChatAppController(giphyApiKey: string) {
   }
 
   function loadOlderThreadMessages(threadId: string) {
-    if (ui.sidebarMode.value === "dms") {
+    if (isActiveDirectDmSurface()) {
       void dmMessaging.loadOlderThreadMessages(threadId);
       return;
     }
@@ -1486,6 +1501,12 @@ export function useChatAppController(giphyApiKey: string) {
         navigate({
           id: "dm",
           params: { username: activeDmPeer.value.peerUsername },
+          search: { thread: activeThreadStack.value, pinned: ui.showPinnedPanel.value },
+        });
+      } else if (channel?.isGroupDm && channel.jid) {
+        navigate({
+          id: "groupDmRoom",
+          params: { roomJid: channel.jid },
           search: { thread: activeThreadStack.value, pinned: ui.showPinnedPanel.value },
         });
       } else {
@@ -1823,6 +1844,7 @@ export function useChatAppController(giphyApiKey: string) {
       case "channel":
       case "channelExtension":
       case "dm":
+      case "groupDmRoom":
       case "dmList":
       case "feed":
       case "stories":
@@ -1854,10 +1876,10 @@ export function useChatAppController(giphyApiKey: string) {
       ui.feedDefaultComposerMode.value = "post";
     }
     ui.sidebarMode.value =
-      match.id === "dm" || match.id === "dmList" ? "dms" : "channels";
+      match.id === "dm" || match.id === "groupDmRoom" || match.id === "dmList" ? "dms" : "channels";
     // #414/#951: channel and DM conversation routes carry the pinned-panel flag.
     ui.showPinnedPanel.value =
-      match.id === "channel" || match.id === "channelExtension" || match.id === "dm"
+      match.id === "channel" || match.id === "channelExtension" || match.id === "dm" || match.id === "groupDmRoom"
         ? match.search.pinned
         : false;
   }
@@ -1942,6 +1964,25 @@ export function useChatAppController(giphyApiKey: string) {
       return;
     }
 
+    if (match.id === "groupDmRoom") {
+      activeExtensionRouteKey.value = null;
+      dmConversations.closeDm();
+      await selectGroupDm(match.params.roomJid);
+      if (requestId !== routeRequestId) return;
+      activeThreadTargetMessageId.value = null;
+      activeThreadStack.value = match.search.thread;
+      ui.showPinnedPanel.value = match.search.pinned;
+      activeRightPanel.value = match.search.pinned
+        ? "pinned"
+        : match.search.thread.length > 0
+          ? "thread"
+          : null;
+      for (const threadId of new Set(match.search.thread)) {
+        void messaging.backfillThread(threadId);
+      }
+      return;
+    }
+
 
     if (match.id === "channelExtension") {
       ui.sidebarMode.value = "channels";
@@ -1983,6 +2024,15 @@ export function useChatAppController(giphyApiKey: string) {
       messaging.clearMessages();
       return;
     }
+    if (ch.isGroupDm && ch.jid) {
+      navigate({
+        id: "groupDmRoom",
+        params: { roomJid: ch.jid },
+        search: match.search,
+      }, { replace: true });
+      await selectGroupDm(ch.jid);
+      return;
+    }
     waddles.activeChannelId.value = ch.id;
     void waddles.reloadChannelMembers(ch.id);
     messaging.clearMessages();
@@ -2015,12 +2065,16 @@ export function useChatAppController(giphyApiKey: string) {
   let pendingChannelRouteMatch: RouteMatch | null = null;
 
   function routeNeedsDiscoveredChannel(match: RouteMatch): boolean {
-    return match.id === "channel" || match.id === "channelExtension";
+    return match.id === "channel" || match.id === "channelExtension" || match.id === "groupDmRoom";
   }
 
   function channelRouteTargetMissing(match: RouteMatch): boolean {
+    if (match.id === "groupDmRoom") {
+      const roomJid = barePeerJid(match.params.roomJid);
+      return !waddles.groupDms.value.some((group) => barePeerJid(group.roomJid) === roomJid);
+    }
     if (match.id !== "channel" && match.id !== "channelExtension") return false;
-    return resolveChannelBySlug(match.params.channelId, waddles.channels.value) === null;
+    return resolveChannelBySlug(match.params.channelId, waddles.channels.value) == null;
   }
 
   async function applyPendingChannelRouteAfterStructure() {
@@ -2190,12 +2244,12 @@ export function useChatAppController(giphyApiKey: string) {
     await connectionStore.logout();
   }
 
-  async function selectChannel(channelId: string, options: { roomJid?: string } = {}) {
+  async function selectChannel(channelId: string, options: { roomJid?: string; surface?: "channels" | "dms" } = {}) {
     clearPendingChannelRoomJidSelection();
     ui.activePage.value = "chat";
-    ui.sidebarMode.value = "channels";
+    ui.sidebarMode.value = options.surface ?? "channels";
     activeExtensionRouteKey.value = null;
-    dmConversations.closeDm();
+    if (ui.sidebarMode.value !== "dms") dmConversations.closeDm();
     memberJidByNick.value = {};
     const selectedRoomJid = options.roomJid ? barePeerJid(options.roomJid) : null;
     if (selectedRoomJid) {
@@ -2248,6 +2302,25 @@ export function useChatAppController(giphyApiKey: string) {
     await selectChannel(channelId, { roomJid: normalizedRoomJid });
   }
 
+  async function selectGroupDm(roomJid: string) {
+    const normalizedRoomJid = barePeerJid(roomJid);
+    const group = waddles.groupDms.value.find((candidate) => barePeerJid(candidate.roomJid) === normalizedRoomJid);
+    const channelId = group?.id ?? knownChannelIdForRoomJid(
+      normalizedRoomJid,
+      waddles.groupDms.value.map((groupDm) => ({
+        id: groupDm.id,
+        name: groupDm.name,
+        jid: groupDm.roomJid,
+        isGroupDm: true,
+      })),
+      managedMucDomain.value,
+    );
+    if (!channelId) return;
+    dmConversations.closeDm();
+    await selectChannel(channelId, { roomJid: normalizedRoomJid, surface: "dms" });
+    updateUrl();
+  }
+
   async function selectExtensionRoute(channelId: string, route: DiscoveredExtensionRoute) {
     clearPendingChannelRoomJidSelection();
     ui.activePage.value = "chat";
@@ -2288,6 +2361,30 @@ export function useChatAppController(giphyApiKey: string) {
   async function handleNewDm(username: string) {
     if (!selfDomain.value) return;
     await handleOpenDm(`${username}@${selfDomain.value}`);
+  }
+
+  async function handleCreateGroupDm(payload: { name: string; memberJids: string[] }) {
+    const client = xmppClient.value;
+    if (!client) {
+      ui.actionError.value = "XMPP session is not ready.";
+      return;
+    }
+    if (payload.memberJids.length < 2) {
+      ui.actionError.value = "Choose at least two contacts.";
+      return;
+    }
+    waddles.isSubmitting.value = true;
+    ui.clearActionError();
+    try {
+      const created = await client.createGroupDm(payload.name, payload.memberJids);
+      await waddles.loadStructure(null, { noChannelSelect: true });
+      ui.showNewGroupDm.value = false;
+      await selectGroupDm(created.roomJid);
+    } catch (error) {
+      ui.actionError.value = ui.normalizeError(error);
+    } finally {
+      waddles.isSubmitting.value = false;
+    }
   }
 
   async function handleCreateChannel() {
@@ -2472,6 +2569,7 @@ export function useChatAppController(giphyApiKey: string) {
       memberCountLabel,
       activeDmPeer,
       computedChannelUnreadMap,
+      groupDmConversations,
       totalTabUnreadCount,
       notifications,
       appUpdate,
@@ -2500,12 +2598,14 @@ export function useChatAppController(giphyApiKey: string) {
       handleLogout,
       selectChannel,
       selectChannelByRoomJid,
+      selectGroupDm,
       onSelectThread,
       onSelectThreadEntry,
       selectExtensionRoute,
       handleOpenDm,
       selectDm,
       handleNewDm,
+      handleCreateGroupDm,
       openCreateChannelDialog,
       handleCreateChannel,
       handleUpdateChannel,

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -1555,12 +1555,12 @@ export function useChatAppController(giphyApiKey: string) {
   // any pinned stanza-ids not already in the loaded timeline or cache.
   watch(() => ui.showPinnedPanel.value, async (open) => {
     if (!open) return;
-    if (ui.sidebarMode.value === "dms") return;
+    if (isActiveDirectDmSurface()) return;
     const client = xmppClient.value;
-    const spaceId = waddles.activeSpaceId.value;
+    const spaceId = waddles.currentChannel.value?.spaceId ?? "";
     const channelId = waddles.activeChannelId.value;
     const roomJid = messaging.currentRoomJid.value;
-    if (!client || !spaceId || !channelId || !roomJid) return;
+    if (!client || !channelId || !roomJid) return;
     if (!("fetchRoomMessagesByStanzaIds" in client)) return;
     const convertForTimeline = (a: Parameters<typeof roomMessageFromArchived>[0]) => {
       const live = roomMessageFromArchived(a, {
@@ -1587,7 +1587,7 @@ export function useChatAppController(giphyApiKey: string) {
     }
   });
   watch(() => ui.showPinnedPanel.value, async (open) => {
-    if (!open || ui.sidebarMode.value !== "dms") return;
+    if (!open || !isActiveDirectDmSurface()) return;
     const client = xmppClient.value;
     const peerJid = dmConversations.activePeerJid.value;
     const currentSession = session.value;
@@ -1614,7 +1614,7 @@ export function useChatAppController(giphyApiKey: string) {
     }
   });
   watch(pinnedRooms, (rooms) => {
-    if (!ui.showPinnedPanel.value || ui.sidebarMode.value !== "dms") return;
+    if (!ui.showPinnedPanel.value || !isActiveDirectDmSurface()) return;
     const client = xmppClient.value;
     const peerJid = dmConversations.activePeerJid.value;
     const currentSession = session.value;
@@ -1651,7 +1651,7 @@ export function useChatAppController(giphyApiKey: string) {
       const epoch = pinnedRoomsEpoch();
       void client.fetchDirectPins(peerJid)
         .then((entries) => {
-          if (ui.sidebarMode.value !== "dms" || dmConversations.activePeerJid.value !== peerJid) return;
+          if (!isActiveDirectDmSurface() || dmConversations.activePeerJid.value !== peerJid) return;
           hydratePinnedRoom(peerJid, entries, epoch);
         })
         .catch((error: unknown) => {
@@ -1967,7 +1967,7 @@ export function useChatAppController(giphyApiKey: string) {
     if (match.id === "groupDmRoom") {
       activeExtensionRouteKey.value = null;
       dmConversations.closeDm();
-      await selectGroupDm(match.params.roomJid);
+      await selectGroupDm(match.params.roomJid, { updateUrl: false });
       if (requestId !== routeRequestId) return;
       activeThreadTargetMessageId.value = null;
       activeThreadStack.value = match.search.thread;
@@ -2030,7 +2030,18 @@ export function useChatAppController(giphyApiKey: string) {
         params: { roomJid: ch.jid },
         search: match.search,
       }, { replace: true });
-      await selectGroupDm(ch.jid);
+      await selectGroupDm(ch.jid, { updateUrl: false });
+      ui.showPinnedPanel.value = match.search.pinned;
+      activeThreadTargetMessageId.value = null;
+      activeThreadStack.value = match.search.thread;
+      activeRightPanel.value = match.search.pinned
+        ? "pinned"
+        : match.search.thread.length > 0
+          ? "thread"
+          : null;
+      for (const threadId of match.search.thread) {
+        void messaging.backfillThread(threadId);
+      }
       return;
     }
     waddles.activeChannelId.value = ch.id;
@@ -2302,7 +2313,7 @@ export function useChatAppController(giphyApiKey: string) {
     await selectChannel(channelId, { roomJid: normalizedRoomJid });
   }
 
-  async function selectGroupDm(roomJid: string) {
+  async function selectGroupDm(roomJid: string, options: { updateUrl?: boolean } = {}) {
     const normalizedRoomJid = barePeerJid(roomJid);
     const group = waddles.groupDms.value.find((candidate) => barePeerJid(candidate.roomJid) === normalizedRoomJid);
     const channelId = group?.id ?? knownChannelIdForRoomJid(
@@ -2315,10 +2326,14 @@ export function useChatAppController(giphyApiKey: string) {
       })),
       managedMucDomain.value,
     );
-    if (!channelId) return;
+    if (!channelId) {
+      ui.actionError.value = "Group message is not available yet.";
+      navigate({ id: "dmList" }, { replace: true });
+      return;
+    }
     dmConversations.closeDm();
     await selectChannel(channelId, { roomJid: normalizedRoomJid, surface: "dms" });
-    updateUrl();
+    if (options.updateUrl !== false) updateUrl();
   }
 
   async function selectExtensionRoute(channelId: string, route: DiscoveredExtensionRoute) {

--- a/chat/src/shell/read-activity.ts
+++ b/chat/src/shell/read-activity.ts
@@ -45,9 +45,7 @@ export function useChatReadActivity(options: {
   const { isWindowFocused } = useChatWindowVisibility();
   const readReceiptsKind = computed<"channel" | "dm" | null>(() => {
     if (options.activePage.value !== "chat") return null;
-    if (options.sidebarMode.value === "dms") {
-      return options.dmConversations.activePeerJid.value ? "dm" : null;
-    }
+    if (options.sidebarMode.value === "dms" && options.dmConversations.activePeerJid.value) return "dm";
     return options.activeChannelId.value ? "channel" : null;
   });
   const readReceiptsActiveRoomJid = computed<string | null>(() => {

--- a/chat/src/shell/state.ts
+++ b/chat/src/shell/state.ts
@@ -31,6 +31,7 @@ export function useChatShellState() {
   const confirmDeleteWaddle = ref(false);
   const confirmDeleteChannel = ref(false);
   const showNewDm = ref(false);
+  const showNewGroupDm = ref(false);
   const confirmRemoveMember = ref<string | null>(null);
   const actionError = ref("");
 
@@ -60,6 +61,7 @@ export function useChatShellState() {
     showPinnedPanel,
     confirmDeleteWaddle,
     showNewDm,
+    showNewGroupDm,
     confirmDeleteChannel,
     confirmRemoveMember,
     actionError,

--- a/chat/src/waddles/directory.ts
+++ b/chat/src/waddles/directory.ts
@@ -1,5 +1,5 @@
 import { ref, computed, watch, type Ref } from "vue";
-import type { SpaceSummary, ChannelSummary, MemberSummary } from "@/lib/chat-types";
+import type { SpaceSummary, ChannelSummary, GroupDmSummary, MemberSummary } from "@/lib/chat-types";
 import type { WaddleSession } from "@/lib/server-auth";
 import type { BrowserXmppClient } from "@/lib/xmpp-client";
 import type { CommunityFormData, CreateFormData, ChannelEditFormData, CreateChannelResult } from "@/lib/chat-ui";
@@ -35,6 +35,7 @@ export function useWaddleDirectory(
 ) {
   const waddles = ref<SpaceSummary[]>([]);
   const channels = ref<ChannelSummary[]>([]);
+  const groupDms = ref<GroupDmSummary[]>([]);
   const members = ref<MemberSummary[]>([]);
   const memberLoadState = ref<MemberLoadState>("idle");
   const serverRole = ref<SpaceSummary["role"]>(null);
@@ -97,6 +98,7 @@ export function useWaddleDirectory(
 
   const sortedChannels = computed(() =>
     [...channels.value]
+      .filter((channel) => !channel.isGroupDm)
       .sort(
       (a, b) =>
         (a.position ?? 0) - (b.position ?? 0) ||
@@ -198,7 +200,7 @@ export function useWaddleDirectory(
       }) satisfies SpaceSummary);
       waddles.value = discoveredSpaces;
 
-      const channelList: ChannelSummary[] = topology.rooms.map((c) => ({
+      const allRooms: ChannelSummary[] = topology.rooms.map((c) => ({
         id: c.id,
         name: c.name,
         jid: c.jid,
@@ -206,13 +208,26 @@ export function useWaddleDirectory(
         channel_type: c.channelType,
         position: c.position,
         features: c.features,
+        isGroupDm: c.isGroupDm,
         // #422: hydrated from the room's disco-info extended form so
         // non-owners get correct Pin action visibility without owner
         // affiliation.
         ...(c.pinPermission ? { pinPermission: c.pinPermission } : {}),
       }));
 
-      channels.value = channelList;
+      const channelList = allRooms.filter((channel) => !channel.isGroupDm);
+      groupDms.value = allRooms
+        .filter((channel): channel is ChannelSummary & { jid: string } => !!channel.isGroupDm && !!channel.jid)
+        .map((channel) => ({
+          id: channel.id,
+          roomJid: channel.jid,
+          name: channel.name,
+          position: channel.position,
+          features: channel.features,
+          pinPermission: channel.pinPermission,
+          autojoin: topology.rooms.find((room) => room.jid === channel.jid)?.autojoin,
+        }));
+      channels.value = allRooms;
 
       if (opts?.noChannelSelect) {
         activeChannelId.value = null;
@@ -539,6 +554,7 @@ export function useWaddleDirectory(
     memberRequestId++;
     waddles.value = [];
     channels.value = [];
+    groupDms.value = [];
     members.value = [];
     memberLoadState.value = "idle";
     memberSnapshotsByChannelId.clear();
@@ -552,6 +568,7 @@ export function useWaddleDirectory(
   return {
     waddles,
     channels,
+    groupDms,
     members,
     memberLoadState,
     serverRole,

--- a/chat/tests/discovery-bookmark-autojoin.test.ts
+++ b/chat/tests/discovery-bookmark-autojoin.test.ts
@@ -74,9 +74,10 @@ describe("discoverTopology XEP-0402 bookmark autojoin", () => {
     await withFakeDomParser(async () => {
       const topology = await discoverTopology(
         topologyClient({
-          bookmarks: [
+          spaceBookmarks: [
             { id: "bookmarked@muc.example.test", name: "Bookmarked", autojoin: true },
           ],
+          userBookmarks: [],
           rooms: [],
         }),
         "alice@example.test",
@@ -87,6 +88,43 @@ describe("discoverTopology XEP-0402 bookmark autojoin", () => {
       expect(room?.spaceId).toBe("space-engineering");
       expect(room?.standalone).toBe(false);
       expect(room?.autojoin).toBe(true);
+    });
+  });
+
+  test("preserves autojoin=false for disco-confirmed bookmark-only rooms", async () => {
+    await withFakeDomParser(async () => {
+      const topology = await discoverTopology(
+        topologyClient({
+          bookmarks: [],
+          userBookmarks: [
+            { id: "quiet@muc.example.test", name: "Quiet", autojoin: false },
+          ],
+          rooms: [],
+        }),
+        "alice@example.test",
+      );
+
+      const room = topology.rooms.find((candidate) => candidate.jid === "quiet@muc.example.test");
+      expect(room?.name).toBe("Quiet");
+      expect(room?.spaceId).toBeUndefined();
+      expect(room?.autojoin).toBe(false);
+    });
+  });
+
+  test("drops bookmark-only rooms that do not disco as MUC rooms", async () => {
+    await withFakeDomParser(async () => {
+      const topology = await discoverTopology(
+        topologyClient({
+          bookmarks: [],
+          userBookmarks: [
+            { id: "not-a-room@example.test", name: "Not a room", autojoin: true },
+          ],
+          rooms: [],
+        }),
+        "alice@example.test",
+      );
+
+      expect(topology.rooms.some((candidate) => candidate.jid === "not-a-room@example.test")).toBe(false);
     });
   });
 
@@ -115,9 +153,13 @@ type Bookmark = {
 };
 
 function topologyClient(options: {
-  bookmarks: Bookmark[];
+  bookmarks?: Bookmark[];
+  spaceBookmarks?: Bookmark[];
+  userBookmarks?: Bookmark[];
   rooms: Array<{ jid: string; name?: string }>;
 }) {
+  const spaceBookmarks = options.spaceBookmarks ?? options.bookmarks ?? [];
+  const userBookmarks = options.userBookmarks ?? options.bookmarks ?? [];
   return {
     async send_raw_iq(xml: string): Promise<string> {
       if (xml.includes('xmlns="http://jabber.org/protocol/disco#items"')) {
@@ -140,6 +182,12 @@ function topologyClient(options: {
         if (xml.includes('to="muc.example.test"')) {
           return discoInfoXml({
             identities: [{ category: "conference", type: "text", name: "Chatrooms" }],
+            features: ["http://jabber.org/protocol/muc"],
+          });
+        }
+        if (xml.includes('@muc.example.test"')) {
+          return discoInfoXml({
+            identities: [{ category: "conference", type: "text" }],
             features: ["http://jabber.org/protocol/muc"],
           });
         }
@@ -166,7 +214,7 @@ function topologyClient(options: {
       }
 
       if (xml.includes('xmlns="http://jabber.org/protocol/pubsub"')) {
-        return pubsubItemsXml(options.bookmarks);
+        return pubsubItemsXml(xml.includes('to="spaces.example.test"') ? spaceBookmarks : userBookmarks);
       }
 
       throw new Error(`Unexpected IQ: ${xml}`);

--- a/chat/tests/discovery-bookmark-autojoin.test.ts
+++ b/chat/tests/discovery-bookmark-autojoin.test.ts
@@ -111,6 +111,27 @@ describe("discoverTopology XEP-0402 bookmark autojoin", () => {
     });
   });
 
+  test("user bookmarks without names do not erase space bookmark names", async () => {
+    await withFakeDomParser(async () => {
+      const topology = await discoverTopology(
+        topologyClient({
+          spaceBookmarks: [
+            { id: "named@muc.example.test", name: "Named from space", autojoin: true },
+          ],
+          userBookmarks: [
+            { id: "named@muc.example.test", autojoin: false },
+          ],
+          rooms: [],
+        }),
+        "alice@example.test",
+      );
+
+      const room = topology.rooms.find((candidate) => candidate.jid === "named@muc.example.test");
+      expect(room?.name).toBe("Named from space");
+      expect(room?.autojoin).toBe(false);
+    });
+  });
+
   test("drops bookmark-only rooms that do not disco as MUC rooms", async () => {
     await withFakeDomParser(async () => {
       const topology = await discoverTopology(

--- a/chat/tests/group-dm-discovery.test.ts
+++ b/chat/tests/group-dm-discovery.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { applyDiscoInfoToChannel, isGroupDmDiscoInfo } from "../src/lib/xmpp/discovery";
+
+describe("group-DM discovery classification", () => {
+  test("classifies rooms by urn:waddle:group-dm:0 disco feature", () => {
+    const info = {
+      features: ["http://jabber.org/protocol/muc", "urn:waddle:group-dm:0"],
+      identities: [],
+      fields: new Map<string, string>(),
+      forms: [],
+    };
+
+    expect(isGroupDmDiscoInfo(info)).toBe(true);
+    expect(applyDiscoInfoToChannel({
+      id: "group-dm-rock",
+      name: "Rock",
+      jid: "group-dm-rock@muc.example.com",
+      channelType: "text",
+      position: 0,
+    }, info).isGroupDm).toBe(true);
+  });
+});

--- a/chat/tests/group-dm-room-route.test.ts
+++ b/chat/tests/group-dm-room-route.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { groupDmRoomRoute } from "../src/router/routes/group-dm-room";
+
+describe("groupDmRoomRoute", () => {
+  test("builds an encoded route with the room bare JID as identity", () => {
+    expect(groupDmRoomRoute.href({
+      params: { roomJid: "group-dm-rock@muc.localhost" },
+      search: { thread: ["root"], pinned: true },
+    })).toBe("/dm/room/group-dm-rock%40muc.localhost?thread=root&pinned=1");
+  });
+
+  test("parses the encoded room bare JID", () => {
+    expect(groupDmRoomRoute.tryParse("/dm/room/group-dm-rock%40muc.localhost", "?pinned=1"))
+      .toEqual({
+        id: "groupDmRoom",
+        params: { roomJid: "group-dm-rock@muc.localhost" },
+        search: { thread: [], pinned: true },
+      });
+  });
+});

--- a/chat/tests/group-dm-xmpp.test.ts
+++ b/chat/tests/group-dm-xmpp.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildCreateGroupDmCommandXml,
+  GROUP_DM_CREATE_NODE,
+  parseCreateGroupDmResult,
+} from "../src/lib/xmpp/group-dm";
+
+describe("group-DM XEP-0050 helper", () => {
+  test("builds a submit form with jid-multi members", () => {
+    const xml = buildCreateGroupDmCommandXml({
+      userJid: "alice@example.com/browser",
+      name: "Alice, Bob, Carol",
+      memberJids: ["bob@example.com", "carol@example.com"],
+    });
+
+    expect(xml).toContain(`node="${GROUP_DM_CREATE_NODE}"`);
+    expect(xml).toContain(`action="execute"`);
+    expect(xml).toContain(`to="example.com"`);
+    expect(xml).toContain(`<field var="FORM_TYPE" type="hidden"><value>${GROUP_DM_CREATE_NODE}</value></field>`);
+    expect(xml).toContain(`<field var="member_jids" type="jid-multi"><value>bob@example.com</value><value>carol@example.com</value></field>`);
+  });
+
+  test("parses the room_jid result field", () => {
+    const result = parseCreateGroupDmResult(`
+      <iq type="result">
+        <command xmlns="http://jabber.org/protocol/commands" status="completed">
+          <x xmlns="jabber:x:data" type="result">
+            <field var="room_jid"><value>group-dm-rock@muc.example.com</value></field>
+          </x>
+        </command>
+      </iq>
+    `);
+
+    expect(result).toEqual({ roomJid: "group-dm-rock@muc.example.com" });
+  });
+});

--- a/chat/tests/read-activity.test.ts
+++ b/chat/tests/read-activity.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, mock, test } from "bun:test";
 import { effectScope, ref } from "vue";
 import { useChatReadActivity } from "../src/shell/read-activity";
 
-function makeReadActivityHarness(options: { unread: number; latestId: string | null }) {
+function makeReadActivityHarness(options: {
+  unread: number;
+  latestId: string | null;
+  sidebarMode?: "channels" | "dms";
+  activePeerJid?: string | null;
+}) {
   const roomJid = "general@conference.example.com";
   const unread = ref(options.unread);
   const latestRemoteMessageId = ref<string | null>(options.latestId);
@@ -17,7 +22,7 @@ function makeReadActivityHarness(options: { unread: number; latestId: string | n
       session: ref({} as never),
       xmppClient: ref({} as never),
       activePage: ref("chat"),
-      sidebarMode: ref("channels"),
+      sidebarMode: ref(options.sidebarMode ?? "channels"),
       activeChannelId: ref("general"),
       channels: ref([{ id: "general", name: "General", jid: roomJid }]),
       channelUnread: {
@@ -30,7 +35,7 @@ function makeReadActivityHarness(options: { unread: number; latestId: string | n
       dmConversations: {
         totalUnreadCount: ref(0),
         conversations: ref([]),
-        activePeerJid: ref(null),
+        activePeerJid: ref(options.activePeerJid ?? null),
         hydrateFromInbox: mock(async () => true),
         markRead: mock(() => undefined),
       } as never,
@@ -82,6 +87,20 @@ describe("useChatReadActivity", () => {
       expect(h.markDisplayed).toHaveBeenCalledWith("remote-1");
       expect(h.markRead).not.toHaveBeenCalled();
       expect(h.clearChannelActivity).toHaveBeenCalledTimes(1);
+      expect(h.clearChannelActivity).toHaveBeenCalledWith(h.roomJid);
+    } finally {
+      h.stop();
+    }
+  });
+
+  test("treats a DM-sidebar group DM as the active channel/MUC read target", async () => {
+    const h = makeReadActivityHarness({ unread: 1, latestId: "remote-1", sidebarMode: "dms" });
+
+    try {
+      await Promise.resolve();
+
+      expect(h.markDisplayed).toHaveBeenCalledWith("remote-1");
+      expect(h.markRead).toHaveBeenCalledWith(h.roomJid);
       expect(h.clearChannelActivity).toHaveBeenCalledWith(h.roomJid);
     } finally {
       h.stop();

--- a/server/docs/adrs/0013-group-dm-protocol.md
+++ b/server/docs/adrs/0013-group-dm-protocol.md
@@ -31,11 +31,17 @@ Provisioned rooms advertise the Waddle classification feature
 `urn:waddle:group-dm:0` in room `disco#info`. Clients classify rooms with that
 feature into the DM sidebar, not the channel/sidebar Space hierarchy.
 
-The first walking-skeleton slice creates the room, writes the creator and
-initial participants as member affiliations, keeps the room hidden from public
-MUC discovery, and exposes the classification feature. Mediated invites and
-XEP-0402 autojoin bookmarks remain part of the same protocol shape and should be
-implemented as follow-up slices on the same command.
+The create command provisions the room, writes the creator and initial
+participants as member affiliations, keeps the room hidden from public MUC
+discovery, exposes the classification feature, and publishes XEP-0402
+`urn:xmpp:bookmarks:1` conference bookmarks with `autojoin='true'` for each
+initial member.
+
+Group-DM membership expansion uses XEP-0045 mediated invites. The server grants
+the invitee member affiliation, publishes their XEP-0402 autojoin bookmark, and
+delivers a trusted mediated invite from the room JID. Waddle-specific invite
+history policy is carried as an extension in the Waddle group-DM namespace
+rather than by changing XEP-0045 semantics.
 
 ## Consequences
 
@@ -52,8 +58,9 @@ implemented as follow-up slices on the same command.
 
 - Group-DM creation now has its own Waddle namespace because no XEP defines this
   exact provisioning command.
-- The first slice does not complete cross-device appearance until XEP-0402
-  bookmark publication is added.
+- Group-DM create and membership expansion must keep the affiliation change,
+  bookmark publication, and mediated invite delivery consistent. Rollback paths
+  are required when any provisioning step fails.
 
 ## Related
 


### PR DESCRIPTION
## Summary

Updates ADR-0013 so the accepted group-DM protocol record matches the implemented issue #950 behavior:

- XEP-0050 create provisions member affiliations and XEP-0402 autojoin bookmarks.
- XEP-0045 mediated invites are the membership-expansion path.
- Waddle-specific history policy remains an extension instead of changing XEP-0045 semantics.
- Consequences now call out consistency and rollback requirements across affiliation, bookmark, and invite steps.

## Verification

- Documentation diff reviewed.
- No code tests run; documentation-only change.

Closes #950