### PR TITLE
feat(chat): spawn group dm from direct message

### DIFF
--- a/chat/src/components/chat/ChatAppModals.vue
+++ b/chat/src/components/chat/ChatAppModals.vue
@@ -46,6 +46,9 @@ const {
       :contacts="controller.rosterContacts.contacts.value"
       :is-submitting="waddles.isSubmitting.value"
       :self-jid="controller.connectionStore.session?.jid ?? null"
+      :excluded-jids="ui.groupDmSeedPeerJid.value ? [ui.groupDmSeedPeerJid.value] : []"
+      :minimum-selected-contacts="ui.groupDmSeedPeerJid.value ? 1 : 2"
+      :title="ui.groupDmSeedPeerJid.value ? 'Add people' : 'New group message'"
       @submit="handleCreateGroupDm"
     />
     <CreateChannelDialog

--- a/chat/src/components/chat/ChatMobileDrawers.vue
+++ b/chat/src/components/chat/ChatMobileDrawers.vue
@@ -73,6 +73,8 @@ const {
   selectGroupDm,
   onSelectThread,
   selectDm,
+  handleNewGroupDm,
+  handleAddPeopleToDm,
   selectExtensionRoute,
   openCreateChannelDialog,
   openChannelEdit,
@@ -250,7 +252,8 @@ function openExtensionRoute(route: DiscoveredExtensionRoute) {
           @reconnect-dm="reconnectDmFromMobile"
           @end-dm="endDmFromMobile"
           @new-dm="ui.showNewDm.value = true"
-          @new-group-dm="ui.showNewGroupDm.value = true"
+          @new-group-dm="handleNewGroupDm"
+          @add-people-to-dm="handleAddPeopleToDm"
         />
         <ProfilePanel
           v-if="connectionStore.session"

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -146,6 +146,8 @@ const {
   selectExtensionRoute,
   handleOpenDm,
   selectDm,
+  handleNewGroupDm,
+  handleAddPeopleToDm,
   openCreateChannelDialog,
   openChannelEdit,
   sendActiveMessage,
@@ -657,7 +659,8 @@ onUnmounted(() => {
           @reconnect-dm="reconnectDmFromDock"
           @end-dm="endRecoveredDmFromActivity"
           @new-dm="ui.showNewDm.value = true"
-          @new-group-dm="ui.showNewGroupDm.value = true"
+          @new-group-dm="handleNewGroupDm"
+          @add-people-to-dm="handleAddPeopleToDm"
         />
         <CurrentCallPanel
           :channels="waddles.sortedChannels.value"

--- a/chat/src/components/chat/DmPanel.vue
+++ b/chat/src/components/chat/DmPanel.vue
@@ -679,7 +679,7 @@ function threadEntryLabel(entry: MessageThreadEntry): string {
             type="button"
             :aria-current="isActiveConversation(conversation.peerJid) ? 'page' : undefined"
             :aria-label="conversationRowLabel(conversation)"
-            @click="emit('selectDm', conversation.peerJid)"
+            @click.stop="emit('selectDm', conversation.peerJid)"
           >
             <div class="relative">
               <AppAvatar :name="conversation.peerUsername" :src="conversation.peerAvatarUrl ?? null" size="sm" />

--- a/chat/src/components/chat/DmPanel.vue
+++ b/chat/src/components/chat/DmPanel.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { useStore } from "@nanostores/vue";
-import { ArrowRight, MessageCircle, MessagesSquare, Phone, PhoneCall, PhoneIncoming, PhoneOff, PhoneOutgoing, Plus, Video } from "lucide-vue-next";
+import { ArrowRight, MessageCircle, MessagesSquare, Phone, PhoneCall, PhoneIncoming, PhoneOff, PhoneOutgoing, Plus, UserPlus, Video } from "lucide-vue-next";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import { formatTimelineStamp } from "@/channels/timeline";
 import type { MessageThreadEntry } from "@/channels/threads";
@@ -47,6 +47,7 @@ const emit = defineEmits<{
   endDm: [peerJid: string, sid?: string];
   newDm: [];
   newGroupDm: [];
+  addPeopleToDm: [peerJid: string];
 }>();
 
 const dmCallActivities = useStore($dmCallActivities);
@@ -445,6 +446,10 @@ function conversationRowLabel(conversation: DmConversation): string {
   return parts.join(", ");
 }
 
+function addPeopleLabel(conversation: DmConversation): string {
+  return `Add people to ${conversation.peerUsername || normalizedPeerJid(conversation.peerJid)}`;
+}
+
 function threadEntryTitle(entry: MessageThreadEntry): string {
   const body = entry.root?.body?.trim();
   return body || entry.threadId;
@@ -660,52 +665,66 @@ function threadEntryLabel(entry: MessageThreadEntry): string {
           </button>
         </section>
 
-        <button
+        <div
           v-for="conversation in visibleConversations"
           :key="conversation.peerJid"
           class="chat-list-row w-full min-h-14 flex items-center gap-3 px-3 py-2 text-left group"
           :class="isActiveConversation(conversation.peerJid)
             ? 'chat-list-row--active bg-sidebar-accent text-sidebar-foreground'
             : 'text-sidebar-muted hover:bg-sidebar-accent/50 hover:text-sidebar-foreground'"
-          :aria-current="isActiveConversation(conversation.peerJid) ? 'page' : undefined"
-          :aria-label="conversationRowLabel(conversation)"
-          type="button"
           @click="emit('selectDm', conversation.peerJid)"
         >
-          <div class="relative">
-            <AppAvatar :name="conversation.peerUsername" :src="conversation.peerAvatarUrl ?? null" size="sm" />
-            <span class="absolute -right-0.5 -bottom-0.5 w-2 h-2 rounded-full border border-background" :class="dotClass(conversation.presenceShow)" />
-          </div>
-          <div class="min-w-0 flex-1">
-            <div class="flex items-center justify-between gap-2">
-              <span class="type-control truncate">{{ conversation.peerUsername }}</span>
-              <span v-if="conversation.lastMessageAt" class="type-meta type-numeric text-sidebar-muted">
-                {{ formatTimelineStamp(conversation.lastMessageAt) }}
-              </span>
+          <button
+            class="flex min-w-0 flex-1 items-center gap-3 text-left"
+            type="button"
+            :aria-current="isActiveConversation(conversation.peerJid) ? 'page' : undefined"
+            :aria-label="conversationRowLabel(conversation)"
+            @click="emit('selectDm', conversation.peerJid)"
+          >
+            <div class="relative">
+              <AppAvatar :name="conversation.peerUsername" :src="conversation.peerAvatarUrl ?? null" size="sm" />
+              <span class="absolute -right-0.5 -bottom-0.5 w-2 h-2 rounded-full border border-background" :class="dotClass(conversation.presenceShow)" />
             </div>
-            <div class="flex items-center gap-1.5">
-              <span class="type-caption text-sidebar-muted min-w-0 flex-1 truncate">{{ preview(conversation.lastMessageBody) }}</span>
-              <span
-                v-if="hasCallActivity(conversation.peerJid)"
-                class="type-meta inline-flex h-[18px] shrink-0 items-center gap-1 rounded-full border px-1.5"
-                :class="isHiddenCurrentCallPeer(conversation.peerJid)
-                  ? 'border-border bg-muted/60 text-sidebar-muted'
-                  : 'border-success/25 bg-success/10 text-success-foreground'"
-                :title="callActivityLabel(conversation.peerJid)"
-                :aria-label="callActivityLabel(conversation.peerJid)"
-              >
-                <PhoneCall class="h-3 w-3" />
-                <span>{{ isHiddenCurrentCallPeer(conversation.peerJid) ? 'Current call' : callActivityLabel(conversation.peerJid) }}</span>
-              </span>
-              <span
-                v-if="conversation.unreadCount > 0"
-                class="chat-badge-glow--primary type-count-badge inline-flex min-w-[18px] h-[18px] shrink-0 items-center justify-center rounded-full bg-primary px-1 text-primary-foreground"
-              >
-                {{ conversation.unreadCount }}
-              </span>
+            <div class="min-w-0 flex-1">
+              <div class="flex items-center justify-between gap-2">
+                <span class="type-control truncate">{{ conversation.peerUsername }}</span>
+                <span v-if="conversation.lastMessageAt" class="type-meta type-numeric text-sidebar-muted">
+                  {{ formatTimelineStamp(conversation.lastMessageAt) }}
+                </span>
+              </div>
+              <div class="flex items-center gap-1.5">
+                <span class="type-caption text-sidebar-muted min-w-0 flex-1 truncate">{{ preview(conversation.lastMessageBody) }}</span>
+                <span
+                  v-if="hasCallActivity(conversation.peerJid)"
+                  class="type-meta inline-flex h-[18px] shrink-0 items-center gap-1 rounded-full border px-1.5"
+                  :class="isHiddenCurrentCallPeer(conversation.peerJid)
+                    ? 'border-border bg-muted/60 text-sidebar-muted'
+                    : 'border-success/25 bg-success/10 text-success-foreground'"
+                  :title="callActivityLabel(conversation.peerJid)"
+                  :aria-label="callActivityLabel(conversation.peerJid)"
+                >
+                  <PhoneCall class="h-3 w-3" />
+                  <span>{{ isHiddenCurrentCallPeer(conversation.peerJid) ? 'Current call' : callActivityLabel(conversation.peerJid) }}</span>
+                </span>
+                <span
+                  v-if="conversation.unreadCount > 0"
+                  class="chat-badge-glow--primary type-count-badge inline-flex min-w-[18px] h-[18px] shrink-0 items-center justify-center rounded-full bg-primary px-1 text-primary-foreground"
+                >
+                  {{ conversation.unreadCount }}
+                </span>
+              </div>
             </div>
-          </div>
-        </button>
+          </button>
+          <button
+            class="chat-icon-button shrink-0 text-sidebar-muted hover:bg-sidebar-accent hover:text-sidebar-foreground"
+            type="button"
+            :title="addPeopleLabel(conversation)"
+            :aria-label="addPeopleLabel(conversation)"
+            @click.stop="emit('addPeopleToDm', conversation.peerJid)"
+          >
+            <UserPlus class="h-3.5 w-3.5" aria-hidden="true" />
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/chat/src/components/modals/NewGroupDmDialog.vue
+++ b/chat/src/components/modals/NewGroupDmDialog.vue
@@ -61,7 +61,7 @@ function toggleContact(jid: string) {
 function handleSubmit() {
   if (!canSubmit.value) return;
   emit("submit", {
-    name: name.value.trim() || defaultName.value,
+    name: name.value.trim(),
     memberJids: [...selected.value],
   });
 }
@@ -126,7 +126,7 @@ function handleSubmit() {
         :disabled="!canSubmit"
         @click="handleSubmit"
       >
-        {{ props.title === "Add people" ? "Add people" : "Create group" }}
+        {{ (props.minimumSelectedContacts ?? 2) < 2 ? "Add people" : "Create group" }}
       </button>
     </div>
   </AppDialog>

--- a/chat/src/components/modals/NewGroupDmDialog.vue
+++ b/chat/src/components/modals/NewGroupDmDialog.vue
@@ -10,6 +10,9 @@ const props = defineProps<{
   contacts: RosterContact[];
   isSubmitting?: boolean;
   selfJid?: string | null;
+  excludedJids?: readonly string[];
+  minimumSelectedContacts?: number;
+  title?: string;
 }>();
 
 const emit = defineEmits<{
@@ -20,8 +23,12 @@ const selected = ref<Set<string>>(new Set());
 
 const selectableContacts = computed(() => {
   const self = (props.selfJid ?? "").split("/")[0]?.toLowerCase() ?? "";
+  const excluded = new Set((props.excludedJids ?? []).map((jid) => jid.split("/")[0]?.toLowerCase() ?? ""));
   return props.contacts
-    .filter((contact) => contact.jid.toLowerCase() !== self)
+    .filter((contact) => {
+      const bare = contact.jid.split("/")[0]?.toLowerCase() ?? "";
+      return bare !== self && !excluded.has(bare);
+    })
     .sort((a, b) => contactLabel(a).localeCompare(contactLabel(b), undefined, { sensitivity: "base" }));
 });
 
@@ -31,7 +38,7 @@ const selectedContacts = computed(() =>
 
 const defaultName = computed(() => selectedContacts.value.map(contactLabel).join(", "));
 const name = ref("");
-const canSubmit = computed(() => selected.value.size >= 2 && !props.isSubmitting);
+const canSubmit = computed(() => selected.value.size >= (props.minimumSelectedContacts ?? 2) && !props.isSubmitting);
 
 watch(open, (next) => {
   if (!next) {
@@ -61,13 +68,13 @@ function handleSubmit() {
 </script>
 
 <template>
-  <AppDialog v-model:open="open">
+  <AppDialog v-model:open="open" labelled-by="new-group-dm-title">
     <div class="chat-dialog-header">
-      <h2 class="type-dialog-title">New group message</h2>
+      <h2 id="new-group-dm-title" class="type-dialog-title">{{ props.title ?? "New group message" }}</h2>
       <button
         class="chat-icon-button hover:bg-muted"
         type="button"
-        aria-label="Close new group message dialog"
+        :aria-label="`Close ${props.title ?? 'new group message'} dialog`"
         @click="open = false"
       >
         <X class="w-4 h-4 text-muted-foreground" />
@@ -119,7 +126,7 @@ function handleSubmit() {
         :disabled="!canSubmit"
         @click="handleSubmit"
       >
-        Create group
+        {{ props.title === "Add people" ? "Add people" : "Create group" }}
       </button>
     </div>
   </AppDialog>

--- a/chat/src/components/ui/AppDialog.vue
+++ b/chat/src/components/ui/AppDialog.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 const open = defineModel<boolean>("open", { required: true });
 
+defineProps<{
+  labelledBy?: string;
+}>();
+
 function onBackdropClick() {
   open.value = false;
 }
@@ -24,6 +28,7 @@ function onKeydown(e: KeyboardEvent) {
           class="relative flex max-h-[min(44rem,calc(100dvh-2rem))] w-full max-w-lg flex-col overflow-hidden glass-panel rounded-lg border border-border shadow-2xl animate-slide-up"
           role="dialog"
           aria-modal="true"
+          :aria-labelledby="labelledBy"
           @click.stop
         >
           <slot />

--- a/chat/src/dms/group-dm-spawn.ts
+++ b/chat/src/dms/group-dm-spawn.ts
@@ -1,0 +1,42 @@
+import { barePeerJid } from "@/lib/xmpp/jid";
+
+interface GroupDmSpawnInput {
+  peerJid: string;
+  selfJid?: string | null;
+  name?: string;
+  selectedMemberJids: readonly string[];
+  selectedMemberLabels?: readonly string[];
+}
+
+export interface GroupDmSpawnPayload {
+  name: string;
+  memberJids: string[];
+}
+
+export function groupDmSpawnPayloadFromDm(input: GroupDmSpawnInput): GroupDmSpawnPayload {
+  const self = normalizedBareJid(input.selfJid ?? "");
+  const memberJids = uniqueBareJids([input.peerJid, ...input.selectedMemberJids])
+    .filter((jid) => jid && jid !== self);
+  return {
+    name: input.name?.trim() || groupDmSpawnName(input.peerJid, input.selectedMemberLabels ?? []),
+    memberJids,
+  };
+}
+
+function uniqueBareJids(jids: readonly string[]): string[] {
+  return [...new Set(jids.map(normalizedBareJid).filter(Boolean))];
+}
+
+function normalizedBareJid(jid: string): string {
+  return barePeerJid(jid).toLowerCase();
+}
+
+function groupDmSpawnName(peerJid: string, selectedMemberLabels: readonly string[]): string {
+  const labels = [labelFromJid(peerJid), ...selectedMemberLabels.map((label) => label.trim()).filter(Boolean)];
+  return [...new Set(labels)].join(", ");
+}
+
+function labelFromJid(jid: string): string {
+  const localpart = normalizedBareJid(jid).split("@")[0] ?? "";
+  return localpart ? `${localpart.charAt(0).toUpperCase()}${localpart.slice(1)}` : jid;
+}

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -2408,7 +2408,10 @@ export function useChatAppController(giphyApiKey: string) {
           selectedMemberJids: payload.memberJids,
           selectedMemberLabels: payload.memberJids.map(groupDmMemberLabel),
         })
-      : payload;
+      : {
+          name: payload.name.trim() || payload.memberJids.map(groupDmMemberLabel).join(", "),
+          memberJids: payload.memberJids,
+        };
     if (createPayload.memberJids.length < 2) {
       ui.actionError.value = seedPeerJid ? "Choose at least one more contact." : "Choose at least two contacts.";
       return;

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -4,6 +4,7 @@ import { useStore } from "@nanostores/vue";
 import { useWaddleDirectory, type MemberLoadState } from "@/waddles/directory";
 import { useWaddleMembers } from "@/waddles/members";
 import { useDirectMessageConversations } from "@/dms/conversations";
+import { groupDmSpawnPayloadFromDm } from "@/dms/group-dm-spawn";
 import { useDirectMessages } from "@/dms/messages";
 import { useChannelMessages } from "@/channels/messages";
 import { useMessageThreads } from "@/channels/threads";
@@ -209,6 +210,10 @@ export function useChatAppController(giphyApiKey: string) {
   const ui = useChatShellState();
   const { mode: scrollDirectionMode } = useScrollDirectionPreference();
   const { isWindowFocused } = useChatWindowVisibility();
+
+  watch(() => ui.showNewGroupDm.value, (open) => {
+    if (!open) ui.groupDmSeedPeerJid.value = null;
+  });
 
   // Seed page-level UI state from the current URL so the first render
   // lands on the right page. Without this, every cold load flashes the
@@ -2378,28 +2383,55 @@ export function useChatAppController(giphyApiKey: string) {
     await handleOpenDm(`${username}@${selfDomain.value}`);
   }
 
+  function handleAddPeopleToDm(peerJid: string) {
+    ui.groupDmSeedPeerJid.value = barePeerJid(peerJid);
+    ui.showNewGroupDm.value = true;
+  }
+
+  function handleNewGroupDm() {
+    ui.groupDmSeedPeerJid.value = null;
+    ui.showNewGroupDm.value = true;
+  }
+
   async function handleCreateGroupDm(payload: { name: string; memberJids: string[] }) {
     const client = xmppClient.value;
     if (!client) {
       ui.actionError.value = "XMPP session is not ready.";
       return;
     }
-    if (payload.memberJids.length < 2) {
-      ui.actionError.value = "Choose at least two contacts.";
+    const seedPeerJid = ui.groupDmSeedPeerJid.value;
+    const createPayload = seedPeerJid
+      ? groupDmSpawnPayloadFromDm({
+          peerJid: seedPeerJid,
+          selfJid: connectionStore.session?.jid ?? null,
+          name: payload.name,
+          selectedMemberJids: payload.memberJids,
+          selectedMemberLabels: payload.memberJids.map(groupDmMemberLabel),
+        })
+      : payload;
+    if (createPayload.memberJids.length < 2) {
+      ui.actionError.value = seedPeerJid ? "Choose at least one more contact." : "Choose at least two contacts.";
       return;
     }
     waddles.isSubmitting.value = true;
     ui.clearActionError();
     try {
-      const created = await client.createGroupDm(payload.name, payload.memberJids);
+      const created = await client.createGroupDm(createPayload.name, createPayload.memberJids);
       await waddles.loadStructure(null, { noChannelSelect: true });
       ui.showNewGroupDm.value = false;
+      ui.groupDmSeedPeerJid.value = null;
       await selectGroupDm(created.roomJid);
     } catch (error) {
       ui.actionError.value = ui.normalizeError(error);
     } finally {
       waddles.isSubmitting.value = false;
     }
+  }
+
+  function groupDmMemberLabel(jid: string): string {
+    const normalized = barePeerJid(jid);
+    const contact = rosterContacts.contacts.value.find((candidate) => barePeerJid(candidate.jid) === normalized);
+    return contact?.name?.trim() || contact?.username?.trim() || normalized.split("@")[0] || normalized;
   }
 
   async function handleCreateChannel() {
@@ -2620,6 +2652,8 @@ export function useChatAppController(giphyApiKey: string) {
       handleOpenDm,
       selectDm,
       handleNewDm,
+      handleNewGroupDm,
+      handleAddPeopleToDm,
       handleCreateGroupDm,
       openCreateChannelDialog,
       handleCreateChannel,

--- a/chat/src/shell/state.ts
+++ b/chat/src/shell/state.ts
@@ -32,6 +32,7 @@ export function useChatShellState() {
   const confirmDeleteChannel = ref(false);
   const showNewDm = ref(false);
   const showNewGroupDm = ref(false);
+  const groupDmSeedPeerJid = ref<string | null>(null);
   const confirmRemoveMember = ref<string | null>(null);
   const actionError = ref("");
 
@@ -62,6 +63,7 @@ export function useChatShellState() {
     confirmDeleteWaddle,
     showNewDm,
     showNewGroupDm,
+    groupDmSeedPeerJid,
     confirmDeleteChannel,
     confirmRemoveMember,
     actionError,

--- a/chat/tests/dm-threading-ui.test.ts
+++ b/chat/tests/dm-threading-ui.test.ts
@@ -52,7 +52,7 @@ describe("DM threading UI contract", () => {
     const readyShell = readFileSync(new URL("../src/components/chat/ChatReadyShell.vue", import.meta.url), "utf8");
     const mobileDrawers = readFileSync(new URL("../src/components/chat/ChatMobileDrawers.vue", import.meta.url), "utf8");
 
-    expect(dmPanel).toContain('@click="emit(\'selectDm\', conversation.peerJid)"');
+    expect(dmPanel).toContain('@click.stop="emit(\'selectDm\', conversation.peerJid)"');
     expect(dmPanel).toContain('@click.stop="emit(\'addPeopleToDm\', conversation.peerJid)"');
     expect(readyShell).toContain('@add-people-to-dm="handleAddPeopleToDm"');
     expect(mobileDrawers).toContain('@add-people-to-dm="handleAddPeopleToDm"');
@@ -65,6 +65,7 @@ describe("DM threading UI contract", () => {
     const peerIndex = controller.indexOf("peerJid: seedPeerJid", payloadIndex);
     const nameIndex = controller.indexOf("name: payload.name", payloadIndex);
     const membersIndex = controller.indexOf("selectedMemberJids: payload.memberJids", payloadIndex);
+    const genericNameIndex = controller.indexOf('name: payload.name.trim() || payload.memberJids.map(groupDmMemberLabel).join(", ")', payloadIndex);
     const errorIndex = controller.indexOf('"Choose at least one more contact."', payloadIndex);
     const createIndex = controller.indexOf("client.createGroupDm(createPayload.name, createPayload.memberJids)", payloadIndex);
     const selectIndex = controller.indexOf("await selectGroupDm(created.roomJid);", createIndex);
@@ -74,6 +75,7 @@ describe("DM threading UI contract", () => {
     expect(peerIndex).toBeGreaterThan(payloadIndex);
     expect(nameIndex).toBeGreaterThan(payloadIndex);
     expect(membersIndex).toBeGreaterThan(payloadIndex);
+    expect(genericNameIndex).toBeGreaterThan(payloadIndex);
     expect(errorIndex).toBeGreaterThan(payloadIndex);
     expect(createIndex).toBeGreaterThan(payloadIndex);
     expect(selectIndex).toBeGreaterThan(createIndex);
@@ -89,6 +91,8 @@ describe("DM threading UI contract", () => {
     expect(dialog).toContain("!excluded.has(bare)");
     expect(dialog).toContain('labelled-by="new-group-dm-title"');
     expect(dialog).toContain('id="new-group-dm-title"');
+    expect(dialog).toContain('name: name.value.trim()');
+    expect(dialog).toContain('(props.minimumSelectedContacts ?? 2) < 2 ? "Add people" : "Create group"');
   });
 
   test("restores DM route threads only after the async route request is still current", () => {

--- a/chat/tests/dm-threading-ui.test.ts
+++ b/chat/tests/dm-threading-ui.test.ts
@@ -38,6 +38,59 @@ describe("DM threading UI contract", () => {
     expect(emitted).toEqual([["selectThread", "dm-thread-1"]]);
   });
 
+  test("offers Add people from a 1:1 direct message", async () => {
+    const html = await renderVueComponent("../src/components/chat/DmPanel.vue", {
+      conversations: [conversation()],
+      activePeerJid: "alice@example.com",
+    });
+
+    expect(html).toContain("Add people to Alice");
+  });
+
+  test("wires Add people clicks through desktop and mobile shells", () => {
+    const dmPanel = readFileSync(new URL("../src/components/chat/DmPanel.vue", import.meta.url), "utf8");
+    const readyShell = readFileSync(new URL("../src/components/chat/ChatReadyShell.vue", import.meta.url), "utf8");
+    const mobileDrawers = readFileSync(new URL("../src/components/chat/ChatMobileDrawers.vue", import.meta.url), "utf8");
+
+    expect(dmPanel).toContain('@click="emit(\'selectDm\', conversation.peerJid)"');
+    expect(dmPanel).toContain('@click.stop="emit(\'addPeopleToDm\', conversation.peerJid)"');
+    expect(readyShell).toContain('@add-people-to-dm="handleAddPeopleToDm"');
+    expect(mobileDrawers).toContain('@add-people-to-dm="handleAddPeopleToDm"');
+  });
+
+  test("seeded group-DM submits include the original direct-message peer", () => {
+    const controller = readFileSync(new URL("../src/shell/chat-app-controller.ts", import.meta.url), "utf8");
+    const seedIndex = controller.indexOf("const seedPeerJid = ui.groupDmSeedPeerJid.value;");
+    const payloadIndex = controller.indexOf("groupDmSpawnPayloadFromDm({", seedIndex);
+    const peerIndex = controller.indexOf("peerJid: seedPeerJid", payloadIndex);
+    const nameIndex = controller.indexOf("name: payload.name", payloadIndex);
+    const membersIndex = controller.indexOf("selectedMemberJids: payload.memberJids", payloadIndex);
+    const errorIndex = controller.indexOf('"Choose at least one more contact."', payloadIndex);
+    const createIndex = controller.indexOf("client.createGroupDm(createPayload.name, createPayload.memberJids)", payloadIndex);
+    const selectIndex = controller.indexOf("await selectGroupDm(created.roomJid);", createIndex);
+
+    expect(seedIndex).toBeGreaterThan(-1);
+    expect(payloadIndex).toBeGreaterThan(seedIndex);
+    expect(peerIndex).toBeGreaterThan(payloadIndex);
+    expect(nameIndex).toBeGreaterThan(payloadIndex);
+    expect(membersIndex).toBeGreaterThan(payloadIndex);
+    expect(errorIndex).toBeGreaterThan(payloadIndex);
+    expect(createIndex).toBeGreaterThan(payloadIndex);
+    expect(selectIndex).toBeGreaterThan(createIndex);
+  });
+
+  test("seeded Add people dialog requires one picked contact while generic group creation requires two", () => {
+    const modals = readFileSync(new URL("../src/components/chat/ChatAppModals.vue", import.meta.url), "utf8");
+    const dialog = readFileSync(new URL("../src/components/modals/NewGroupDmDialog.vue", import.meta.url), "utf8");
+
+    expect(modals).toContain(':minimum-selected-contacts="ui.groupDmSeedPeerJid.value ? 1 : 2"');
+    expect(modals).toContain(':excluded-jids="ui.groupDmSeedPeerJid.value ? [ui.groupDmSeedPeerJid.value] : []"');
+    expect(dialog).toContain("selected.value.size >= (props.minimumSelectedContacts ?? 2)");
+    expect(dialog).toContain("!excluded.has(bare)");
+    expect(dialog).toContain('labelled-by="new-group-dm-title"');
+    expect(dialog).toContain('id="new-group-dm-title"');
+  });
+
   test("restores DM route threads only after the async route request is still current", () => {
     const controller = readFileSync(new URL("../src/shell/chat-app-controller.ts", import.meta.url), "utf8");
     const dmRouteStart = controller.indexOf('if (match.id === "dm") {');

--- a/chat/tests/group-dm-spawn.test.ts
+++ b/chat/tests/group-dm-spawn.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { groupDmSpawnPayloadFromDm } from "@/dms/group-dm-spawn";
+
+describe("group DM spawn from a direct message", () => {
+  test("builds a fresh group-DM create payload from the DM peer plus picked people", () => {
+    const payload = groupDmSpawnPayloadFromDm({
+      peerJid: "bob@example.com/laptop",
+      selfJid: "alice@example.com/browser",
+      selectedMemberJids: [
+        "carol@example.com",
+        "bob@example.com/phone",
+        "alice@example.com/tablet",
+        "dave@example.com",
+        "carol@example.com/mobile",
+      ],
+      selectedMemberLabels: ["Carol", "Dave"],
+    });
+
+    expect(payload).toEqual({
+      name: "Bob, Carol, Dave",
+      memberJids: ["bob@example.com", "carol@example.com", "dave@example.com"],
+    });
+  });
+
+  test("uses an explicit room name when the initiator provides one", () => {
+    const payload = groupDmSpawnPayloadFromDm({
+      peerJid: "bob@example.com",
+      name: "Project launch",
+      selectedMemberJids: ["carol@example.com"],
+    });
+
+    expect(payload.name).toBe("Project launch");
+    expect(payload.memberJids).toEqual(["bob@example.com", "carol@example.com"]);
+  });
+});


### PR DESCRIPTION
## Summary

- Added an Add people affordance on 1:1 DM rows that seeds group-DM creation from the active direct-message peer.
- Reused the existing XMPP-native group-DM provisioning command with a derived member set: original DM peer plus newly selected contacts, excluding self and duplicates.
- Kept the original 1:1 conversation untouched by opening a fresh group-DM room after structure reload rather than migrating any personal archive/history.
- Updated the group-DM dialog for seeded mode: one new contact minimum, seeded peer excluded from the picker, and accessible dialog labelling.
- Added focused TDD coverage for payload derivation, event forwarding, seeded dialog state, and controller submit/routing contracts.

## Plan

- Add client flow coverage for using Add people from a 1:1 DM to provision a fresh group DM.
- Reuse existing group DM provisioning command semantics with a member set derived from both 1:1 participants plus selected invitees.
- Verify the original 1:1 conversation remains listed and unchanged, and the spawned room starts with a fresh archive.
- Extend WebSocket/server coverage only where the 1:1-derived member set needs explicit proof beyond existing provision tests.

## Verification

- `bun test`
- `bun run lint`
- `bunx astro check` (0 errors, 0 warnings, 1 existing hint in `src/lib/xmpp/discovery.ts`)
- Adversarial review passes: test coverage, UX/accessibility, and behavior/spec reviewers; actionable findings were addressed.

## XEP Notes

- Reviewed XEP-0045 MUC room creation/invite guidance and XEP-0249 continuation semantics.
- This implementation intentionally does not use one-to-one continuation/history migration: issue #959 requires a fresh group-DM archive and the original 1:1 to remain private.

Closes #959
