### PR TITLE
feat(chat): support group dm calls via muji

### DIFF
--- a/chat/src/components/calls/CallActivityDock.vue
+++ b/chat/src/components/calls/CallActivityDock.vue
@@ -21,7 +21,7 @@ import {
 } from "@/lib/calls/call-activity-dock";
 import { readRoomHasActiveCall } from "@/lib/calls/use-active-muc-call";
 import type { CallMedia } from "@/lib/calls/types";
-import type { ChannelSummary } from "@/lib/chat-types";
+import type { ChannelSummary, GroupDmSummary } from "@/lib/chat-types";
 import type { DmConversation } from "@/lib/xmpp-client";
 import { barePeerJid } from "@/lib/xmpp/jid";
 
@@ -29,6 +29,7 @@ defineOptions({ inheritAttrs: false });
 
 const props = withDefaults(defineProps<{
   channels: ChannelSummary[];
+  groupDms?: GroupDmSummary[];
   conversations: DmConversation[];
   activeChannelId: string | null;
   activeChannelRoomJid?: string | null;
@@ -44,13 +45,16 @@ const props = withDefaults(defineProps<{
 }>(), {
   showDmCalls: true,
   hideCurrentCall: false,
+  groupDms: () => [],
 });
 
 const emit = defineEmits<{
   answerDm: [peerJid: string, remoteFullJid: string, sid: string, media: CallMedia];
   selectChannel: [channelId: string | null, roomJid: string];
+  selectGroupDm: [roomJid: string];
   leaveChannelCall: [roomJid: string];
   joinChannelCall: [channelId: string | null, roomJid: string, media: CallMedia];
+  joinGroupDmCall: [roomJid: string, media: CallMedia];
   selectDm: [peerJid: string];
   reconnectDm: [peerJid: string, media: CallMedia];
   endDm: [peerJid: string, sid?: string];
@@ -69,6 +73,7 @@ const entries = computed(() =>
   sortCallActivityDockEntries(
     buildCallActivityDockEntries({
       channels: props.channels,
+      groupDms: props.groupDms,
       conversations: props.conversations,
       activeChannelId: props.activeChannelId,
       activeChannelRoomJid: props.activeChannelRoomJid ?? null,
@@ -252,8 +257,14 @@ function selectEntry(entry: CallActivityDockEntry): void {
     case "channel-join":
       emit("joinChannelCall", selection.channelId, selection.roomJid, selection.media);
       return;
+    case "group-dm-join":
+      emit("joinGroupDmCall", selection.roomJid, selection.media);
+      return;
     case "channel":
       emit("selectChannel", selection.channelId, selection.roomJid);
+      return;
+    case "group-dm":
+      emit("selectGroupDm", selection.roomJid);
       return;
     case "dm-reconnect":
       emit("reconnectDm", selection.peerJid, selection.media);

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -460,6 +460,29 @@ function joinChannelCallFromActivity(channelId: string | null, roomJid: string, 
   });
 }
 
+function joinGroupDmCallFromActivity(roomJid: string, media: CallMedia): void {
+  ui.activeCommunitySurface.value = null;
+  void (async () => {
+    await selectGroupDm(roomJid);
+    await startMucCallAction({
+      roomJid,
+      media,
+      isBusy: isGroupCallBusy,
+      setStarting: (next) => {
+        activityGroupCallStarting.value = next;
+      },
+      getSender: getMucCallSender,
+      getSelfNick: () => connectionStore.session?.username ?? undefined,
+      getSelfFullJid,
+      getExpectedMixerJid,
+      ensureJoined: async () => {
+        await getClientJoiner()?.(roomJid);
+      },
+      tryResumeFirst: true,
+    });
+  })();
+}
+
 function leaveRetainedChannelCall(roomJid: string): void {
   void leaveRetainedMucCallAction({
     roomJid,
@@ -550,6 +573,7 @@ onUnmounted(() => {
     <CallActivityDock
       class="call-activity-dock--mobile"
       :channels="waddles.sortedChannels.value"
+      :group-dms="groupDmConversations"
       :conversations="dmConversations.conversations.value"
       :active-channel-id="waddles.activeChannelId.value"
       :active-channel-room-jid="activeChannelRoomJid"
@@ -562,7 +586,9 @@ onUnmounted(() => {
       :self-full-jid="selfFullJid"
       hide-current-call
       @select-channel="onSelectChannelFromSidebar"
+      @select-group-dm="selectGroupDm"
       @join-channel-call="joinChannelCallFromActivity"
+      @join-group-dm-call="joinGroupDmCallFromActivity"
       @leave-channel-call="leaveRetainedChannelCall"
       @answer-dm="answerDmFromActivity"
       @select-dm="selectDm"
@@ -670,6 +696,7 @@ onUnmounted(() => {
         />
         <CallActivityDock
           :channels="waddles.sortedChannels.value"
+          :group-dms="groupDmConversations"
           :conversations="dmConversations.conversations.value"
           :active-channel-id="waddles.activeChannelId.value"
           :active-channel-room-jid="activeChannelRoomJid"
@@ -683,7 +710,9 @@ onUnmounted(() => {
           :show-dm-calls="ui.sidebarMode.value !== 'dms'"
           hide-current-call
           @select-channel="onSelectChannelFromSidebar"
+          @select-group-dm="selectGroupDm"
           @join-channel-call="joinChannelCallFromActivity"
+          @join-group-dm-call="joinGroupDmCallFromActivity"
           @leave-channel-call="leaveRetainedChannelCall"
           @answer-dm="answerDmFromActivity"
           @select-dm="selectDm"
@@ -698,7 +727,9 @@ onUnmounted(() => {
         v-bind="homeDashboardProps"
         @select-channel="(id: string, roomJid?: string) => selectChannel(id, roomJid ? { roomJid } : undefined)"
         @select-channel-room="selectChannelByRoomJid"
+        @select-group-dm="selectGroupDm"
         @join-channel-call="joinChannelCallFromActivity"
+        @join-group-dm-call="joinGroupDmCallFromActivity"
         @leave-channel-call="leaveRetainedChannelCall"
         @answer-dm="answerDmFromActivity"
         @select-contact="handleOpenDm"

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -241,6 +241,7 @@ const homeDashboardProps = computed(() => buildHomeDashboardProps({
   mentionedRoomJids: messaging.mentionedChannelCounts.value,
   activeChannelJids: messaging.activeChannels.value,
   dmConversations: dmConversations.conversations.value,
+  groupDms: groupDmConversations?.value ?? [],
   callParticipantCounts: callParticipantCounts.value,
   callParticipants: retainedMucCallParticipantsStore.value,
   callMediaByRoom: retainedMucCallMediaStore.value,
@@ -463,7 +464,8 @@ function joinChannelCallFromActivity(channelId: string | null, roomJid: string, 
 function joinGroupDmCallFromActivity(roomJid: string, media: CallMedia): void {
   ui.activeCommunitySurface.value = null;
   void (async () => {
-    await selectGroupDm(roomJid);
+    const selected = await selectGroupDm(roomJid);
+    if (selected === false) return;
     await startMucCallAction({
       roomJid,
       media,

--- a/chat/src/components/chat/DmPanel.vue
+++ b/chat/src/components/chat/DmPanel.vue
@@ -7,6 +7,12 @@ import { formatTimelineStamp } from "@/channels/timeline";
 import type { MessageThreadEntry } from "@/channels/threads";
 import { $callState } from "@/lib/calls/call-store";
 import {
+  $mucCallMedia,
+  $mucCallParticipants,
+  mucCallMediaForRoom,
+  normalizeMucCallRoomJid,
+} from "@/lib/calls/muc-call-presence";
+import {
   canEndRecoveredDmCallActivity,
   dmCallActivityAction,
   dmCallActivitySortPriority,
@@ -50,6 +56,8 @@ const emit = defineEmits<{
 }>();
 
 const dmCallActivities = useStore($dmCallActivities);
+const mucCallParticipants = useStore($mucCallParticipants);
+const mucCallMedia = useStore($mucCallMedia);
 const callState = useStore($callState);
 const activePeer = computed(() => normalizedPeerJid(props.activePeerJid ?? ""));
 const currentActiveDmPeer = computed(() => {
@@ -424,6 +432,33 @@ function isActiveConversation(peerJid: string): boolean {
   return !!peer && activePeer.value === peer;
 }
 
+function groupCallParticipantCount(roomJid: string): number {
+  const normalized = normalizeMucCallRoomJid(roomJid);
+  return normalized ? mucCallParticipants.value[normalized]?.length ?? 0 : 0;
+}
+
+function groupCallMediaLabel(roomJid: string): string {
+  return mucCallMediaForRoom(roomJid, mucCallMedia.value).video ? "Video call" : "Voice call";
+}
+
+function hasGroupCallActivity(roomJid: string): boolean {
+  return groupCallParticipantCount(roomJid) > 0;
+}
+
+function groupCallActivityLabel(roomJid: string): string {
+  const count = groupCallParticipantCount(roomJid);
+  if (count <= 0) return "";
+  const noun = count === 1 ? "person" : "people";
+  return `${groupCallMediaLabel(roomJid)} live, ${count} ${noun}`;
+}
+
+function groupDmRowLabel(group: GroupDmSummary): string {
+  const parts = [`Open group message ${group.name}`];
+  const call = groupCallActivityLabel(group.roomJid);
+  if (call) parts.push(call);
+  return parts.join(", ");
+}
+
 function conversationRowLabel(conversation: DmConversation): string {
   const parts = [
     conversation.peerUsername,
@@ -635,7 +670,7 @@ function threadEntryLabel(entry: MessageThreadEntry): string {
               : 'text-sidebar-muted hover:bg-sidebar-accent/50 hover:text-sidebar-foreground'"
             type="button"
             :aria-current="normalizedPeerJid(activeGroupDmRoomJid ?? '') === normalizedPeerJid(group.roomJid) ? 'page' : undefined"
-            :aria-label="`Open group message ${group.name}`"
+            :aria-label="groupDmRowLabel(group)"
             @click="emit('selectGroupDm', group.roomJid)"
           >
             <span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-sidebar-accent text-sidebar-foreground">
@@ -643,9 +678,21 @@ function threadEntryLabel(entry: MessageThreadEntry): string {
             </span>
             <span class="min-w-0 flex-1">
               <span class="type-control block truncate text-sidebar-foreground">{{ group.name }}</span>
-              <span class="type-caption block truncate text-sidebar-muted">Group message</span>
+              <span class="type-caption block truncate text-sidebar-muted">
+                <template v-if="hasGroupCallActivity(group.roomJid)">{{ groupCallActivityLabel(group.roomJid) }}</template>
+                <template v-else>Group message</template>
+              </span>
             </span>
             <span class="flex shrink-0 items-center gap-1">
+              <span
+                v-if="hasGroupCallActivity(group.roomJid)"
+                class="type-meta inline-flex h-[18px] shrink-0 items-center gap-1 rounded-full border border-success/25 bg-success/10 px-1.5 text-success-foreground"
+                :title="groupCallMediaLabel(group.roomJid)"
+                :aria-label="groupCallMediaLabel(group.roomJid)"
+              >
+                <PhoneCall class="h-3 w-3" />
+                <span>{{ groupCallMediaLabel(group.roomJid) }}</span>
+              </span>
               <span
                 v-if="(group.mentionCount ?? 0) > 0"
                 class="chat-list-row--mention-badge type-count-badge inline-flex min-w-[18px] h-[18px] px-1 items-center justify-center rounded-full bg-destructive text-destructive-foreground"

--- a/chat/src/components/chat/HomeDashboard.vue
+++ b/chat/src/components/chat/HomeDashboard.vue
@@ -66,6 +66,8 @@ const emit = defineEmits<{
   selectChannel: [id: string, roomJid?: string];
   selectChannelRoom: [roomJid: string];
   joinChannelCall: [channelId: string | null, roomJid: string, media: CallMedia];
+  selectGroupDm: [roomJid: string];
+  joinGroupDmCall: [roomJid: string, media: CallMedia];
   leaveChannelCall: [roomJid: string];
   answerDm: [peerJid: string, remoteFullJid: string, sid: string, media: CallMedia];
   selectContact: [jid: string];
@@ -220,12 +222,18 @@ function selectCallEntry(entry: CallActivityDockEntry) {
     case "channel-join":
       emit("joinChannelCall", selection.channelId, selection.roomJid, selection.media);
       return;
+    case "group-dm-join":
+      emit("joinGroupDmCall", selection.roomJid, selection.media);
+      return;
     case "channel":
       if (selection.channelId) {
         emit("selectChannel", selection.channelId, selection.roomJid);
         return;
       }
       if (selection.roomJid) emit("selectChannelRoom", selection.roomJid);
+      return;
+    case "group-dm":
+      emit("selectGroupDm", selection.roomJid);
       return;
     case "dm-reconnect":
       emit("reconnectDm", selection.peerJid, selection.media);

--- a/chat/src/components/chat/HomeDashboard.vue
+++ b/chat/src/components/chat/HomeDashboard.vue
@@ -160,6 +160,7 @@ const discoveredCallEntries = computed<CallActivityDockEntry[]>(() =>
   sortCallActivityDockEntries(
     buildCallActivityDockEntries({
       channels: props.channels,
+      groupDms: props.groupDms ?? [],
       conversations: props.dmConversations ?? [],
       activeChannelId: null,
       activeChannelRoomJid: null,

--- a/chat/src/home/dashboard-props.ts
+++ b/chat/src/home/dashboard-props.ts
@@ -1,4 +1,4 @@
-import type { ChannelSummary, SpaceSummary } from "@/lib/chat-types";
+import type { ChannelSummary, GroupDmSummary, SpaceSummary } from "@/lib/chat-types";
 import type { RosterContact } from "@/lib/xmpp/types";
 import type { DmConversation } from "@/lib/xmpp-client";
 import type { ChannelUnreadMap } from "@/home/activity";
@@ -13,6 +13,7 @@ export interface HomeDashboardProps {
   channelUnreadMap?: ChannelUnreadMap;
   activeChannelJids?: Set<string>;
   dmConversations?: DmConversation[];
+  groupDms?: GroupDmSummary[];
   callParticipantCounts?: Record<string, number>;
   callParticipants?: Record<string, string[]>;
   callMediaByRoom?: Record<string, CallMedia>;
@@ -39,6 +40,7 @@ export function buildHomeDashboardProps(sources: HomeDashboardSources): HomeDash
     ),
     activeChannelJids: sources.activeChannelJids,
     dmConversations: sources.dmConversations,
+    groupDms: sources.groupDms,
     callParticipantCounts: sources.callParticipantCounts,
     callParticipants: sources.callParticipants,
     callMediaByRoom: sources.callMediaByRoom,

--- a/chat/src/lib/calls/call-activity-dock.ts
+++ b/chat/src/lib/calls/call-activity-dock.ts
@@ -1,4 +1,4 @@
-import type { ChannelSummary } from "@/lib/chat-types";
+import type { ChannelSummary, GroupDmSummary } from "@/lib/chat-types";
 import type { DmConversation } from "@/lib/xmpp/types";
 import { barePeerJid } from "@/lib/xmpp/jid";
 import type { CallMedia, CallState } from "./types";
@@ -29,6 +29,7 @@ export type CallActivityDockEntry =
       media: CallMedia;
       isKnownChannel: boolean;
       isActive: boolean;
+      isGroupDm?: boolean;
     }
   | {
       kind: "dm";
@@ -52,6 +53,8 @@ type CallActivityDockAction = "answer" | "open" | "join" | "return" | "reconnect
 type CallActivityDockSelection =
   | { kind: "channel"; channelId: string | null; roomJid: string }
   | { kind: "channel-join"; channelId: string | null; roomJid: string; media: CallMedia }
+  | { kind: "group-dm"; roomJid: string }
+  | { kind: "group-dm-join"; roomJid: string; media: CallMedia }
   | { kind: "dm-answer"; peerJid: string; remoteFullJid: string; sid: string; media: DmCallActivity["media"] }
   | { kind: "dm-open"; peerJid: string }
   | { kind: "dm-reconnect"; peerJid: string; media: DmCallActivity["media"] };
@@ -134,11 +137,24 @@ export function callActivityDockSelection(
 ): CallActivityDockSelection {
   if (entry.kind === "channel") {
     if (callActivityDockAction(entry, callState, selfFullJid) === "join") {
+      if (entry.isGroupDm === true) {
+        return {
+          kind: "group-dm-join",
+          roomJid: entry.roomJid,
+          media: entry.media,
+        };
+      }
       return {
         kind: "channel-join",
         channelId: entry.channelId,
         roomJid: entry.roomJid,
         media: entry.media,
+      };
+    }
+    if (entry.isGroupDm === true) {
+      return {
+        kind: "group-dm",
+        roomJid: entry.roomJid,
       };
     }
     return {
@@ -234,6 +250,7 @@ function entryTitleForSort(entry: CallActivityDockEntry): string {
 
 export function buildCallActivityDockEntries(options: {
   channels: ReadonlyArray<Pick<ChannelSummary, "id" | "name" | "jid">>;
+  groupDms?: ReadonlyArray<Pick<GroupDmSummary, "id" | "name" | "roomJid">>;
   conversations: ReadonlyArray<Pick<DmConversation, "peerJid" | "peerUsername">>;
   activeChannelId: string | null;
   activeChannelRoomJid?: string | null;
@@ -248,35 +265,56 @@ export function buildCallActivityDockEntries(options: {
 }): CallActivityDockEntry[] {
   const activeChannelRoomJid = normalizeMucCallRoomJid(options.activeChannelRoomJid ?? "");
   const participantLabelsByRoom = normalizedParticipantLabels(options.callParticipants ?? {});
-  const channelEntries = options.channels.flatMap((channel): CallActivityDockEntry[] => {
-    const participantCount = callParticipantCountForChannel(
-      channel,
-      options.callParticipantCounts,
-      options.activeChannelJids,
-      options.managedMucDomain,
-    );
-    if (participantCount <= 0) return [];
-    const roomJid = callRoomJidForChannel(
-      channel,
-      options.callParticipantCounts,
-      options.activeChannelJids,
-      options.managedMucDomain,
-    );
-    return [{
-      kind: "channel",
-      key: `channel:${channel.id}`,
-      channelId: channel.id,
-      roomJid,
-      title: channel.name,
-      participantCount,
-      participantLabels: participantLabelsByRoom.get(roomJid) ?? [],
-      media: mucCallMediaForRoom(roomJid, options.callMediaByRoom),
-      isKnownChannel: true,
-      isActive: options.sidebarMode === "channels" && (
-        options.activeChannelId === channel.id || activeChannelRoomJid === roomJid
+  const channelEntries = mucConversationEntries({
+    conversations: options.channels.map((channel) => ({
+      keyPrefix: "channel",
+      id: channel.id,
+      name: channel.name,
+      roomJid: callRoomJidForChannel(
+        channel,
+        options.callParticipantCounts,
+        options.activeChannelJids,
+        options.managedMucDomain,
       ),
-    }];
+      participantCount: callParticipantCountForChannel(
+        channel,
+        options.callParticipantCounts,
+        options.activeChannelJids,
+        options.managedMucDomain,
+      ),
+      activeSidebarMode: "channels" as const,
+    })),
+    activeChannelId: options.activeChannelId,
+    activeChannelRoomJid,
+    currentSidebarMode: options.sidebarMode,
+    participantLabelsByRoom,
+    callMediaByRoom: options.callMediaByRoom,
   });
+
+  const groupDmEntries = mucConversationEntries({
+    conversations: (options.groupDms ?? []).map((groupDm) => {
+      const roomJid = normalizeMucCallRoomJid(groupDm.roomJid);
+      return {
+        keyPrefix: "group-dm",
+        id: groupDm.id,
+        name: groupDm.name,
+        roomJid,
+        participantCount: roomJid ? options.callParticipantCounts[roomJid] ?? 0 : 0,
+        activeSidebarMode: "dms" as const,
+        isGroupDm: true,
+      };
+    }),
+    activeChannelId: options.activeChannelId,
+    activeChannelRoomJid,
+    currentSidebarMode: options.sidebarMode,
+    participantLabelsByRoom,
+    callMediaByRoom: options.callMediaByRoom,
+  });
+  const knownGroupDmRoomJids = new Set(
+    (options.groupDms ?? [])
+      .map((groupDm) => normalizeMucCallRoomJid(groupDm.roomJid))
+      .filter(Boolean),
+  );
 
   const fallbackChannelEntries = refreshedMucCallRooms({
     channels: options.channels,
@@ -285,6 +323,7 @@ export function buildCallActivityDockEntries(options: {
     callParticipantCounts: options.callParticipantCounts,
     callMediaByRoom: options.callMediaByRoom,
   })
+    .filter((room) => !knownGroupDmRoomJids.has(room.roomJid))
     .map((room): CallActivityDockEntry => ({
       kind: "channel",
       key: `channel:${room.roomJid}`,
@@ -296,6 +335,7 @@ export function buildCallActivityDockEntries(options: {
       media: room.media,
       isKnownChannel: false,
       isActive: options.sidebarMode === "channels" && activeChannelRoomJid === room.roomJid,
+      ...(isGroupDmFallbackRoomJid(room.roomJid) ? { isGroupDm: true } : {}),
     }));
 
   const conversationNames = new Map(
@@ -334,7 +374,44 @@ export function buildCallActivityDockEntries(options: {
       return left.title.localeCompare(right.title);
     });
 
-  return [...channelEntries, ...fallbackChannelEntries, ...dmEntries];
+  return [...channelEntries, ...groupDmEntries, ...fallbackChannelEntries, ...dmEntries];
+}
+
+function mucConversationEntries(options: {
+  conversations: ReadonlyArray<{
+    keyPrefix: string;
+    id: string;
+    name: string;
+    roomJid: string;
+    participantCount: number;
+    activeSidebarMode: SidebarMode;
+    isGroupDm?: boolean;
+  }>;
+  activeChannelId: string | null;
+  activeChannelRoomJid: string;
+  currentSidebarMode: SidebarMode;
+  participantLabelsByRoom: Map<string, string[]>;
+  callMediaByRoom?: Record<string, CallMedia>;
+}): CallActivityDockEntry[] {
+  return options.conversations.flatMap((conversation): CallActivityDockEntry[] => {
+    if (conversation.participantCount <= 0 || !conversation.roomJid) return [];
+    return [{
+      kind: "channel",
+      key: `${conversation.keyPrefix}:${conversation.id}`,
+      channelId: conversation.id,
+      roomJid: conversation.roomJid,
+      title: conversation.name,
+      participantCount: conversation.participantCount,
+      participantLabels: options.participantLabelsByRoom.get(conversation.roomJid) ?? [],
+      media: mucCallMediaForRoom(conversation.roomJid, options.callMediaByRoom),
+      isKnownChannel: true,
+      isActive: options.currentSidebarMode === conversation.activeSidebarMode && (
+        options.activeChannelId === conversation.id ||
+        options.activeChannelRoomJid === conversation.roomJid
+      ),
+      ...(conversation.isGroupDm === true ? { isGroupDm: true } : {}),
+    }];
+  });
 }
 
 function normalizedParticipantLabels(
@@ -353,4 +430,9 @@ function normalizedParticipantLabels(
     ]);
   }
   return labels;
+}
+
+function isGroupDmFallbackRoomJid(roomJid: string): boolean {
+  const localpart = normalizeMucCallRoomJid(roomJid).split("@")[0] ?? "";
+  return localpart.startsWith("group-dm-");
 }

--- a/chat/src/lib/calls/call-activity-dock.ts
+++ b/chat/src/lib/calls/call-activity-dock.ts
@@ -434,5 +434,8 @@ function normalizedParticipantLabels(
 
 function isGroupDmFallbackRoomJid(roomJid: string): boolean {
   const localpart = normalizeMucCallRoomJid(roomJid).split("@")[0] ?? "";
+  // Server-created group-DM rooms currently use `group-dm-...` localparts.
+  // This fallback keeps pre-hydration calls on the DM route until bookmarks
+  // hydrate and the explicit group-DM summary can take over.
   return localpart.startsWith("group-dm-");
 }

--- a/chat/src/lib/calls/muc-call-presence.ts
+++ b/chat/src/lib/calls/muc-call-presence.ts
@@ -81,7 +81,7 @@ function mucCallParticipantsForRoom(roomJid: string): string[] {
 }
 
 export function mucCallParticipantCounts(
-  participants: Record<string, string[]>,
+  participants: Record<string, readonly string[]>,
 ): Record<string, number> {
   const counts: Record<string, number> = {};
   for (const [roomJid, nicks] of Object.entries(participants)) {

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -2329,11 +2329,12 @@ export function useChatAppController(giphyApiKey: string) {
     if (!channelId) {
       ui.actionError.value = "Group message is not available yet.";
       navigate({ id: "dmList" }, { replace: true });
-      return;
+      return false;
     }
     dmConversations.closeDm();
     await selectChannel(channelId, { roomJid: normalizedRoomJid, surface: "dms" });
     if (options.updateUrl !== false) updateUrl();
+    return true;
   }
 
   async function selectExtensionRoute(channelId: string, route: DiscoveredExtensionRoute) {

--- a/chat/tests/call-activity-dock.test.ts
+++ b/chat/tests/call-activity-dock.test.ts
@@ -141,6 +141,62 @@ describe("call activity dock model", () => {
     ]);
   });
 
+  test("surfaces group-DM room calls while the DM sidebar is active", () => {
+    const entries = buildCallActivityDockEntries({
+      channels: [],
+      groupDms: [
+        { id: "gdm-launch", name: "Launch crew", roomJid: "group-dm-launch@muc.example.com" },
+      ],
+      conversations: [],
+      activeChannelId: "gdm-launch",
+      activeChannelRoomJid: "group-dm-launch@muc.example.com",
+      activePeerJid: null,
+      sidebarMode: "dms",
+      activeChannelJids: new Set(["group-dm-launch@muc.example.com"]),
+      managedMucDomain: "muc.example.com",
+      callParticipantCounts: {
+        "group-dm-launch@muc.example.com": 2,
+      },
+      callParticipants: {
+        "group-dm-launch@muc.example.com": ["alice", "bob"],
+      },
+      callMediaByRoom: {
+        "group-dm-launch@muc.example.com": { audio: true, video: true },
+      },
+      dmCallActivities: {},
+    });
+
+    expect(entries).toEqual([
+      {
+        kind: "channel",
+        key: "group-dm:gdm-launch",
+        channelId: "gdm-launch",
+        roomJid: "group-dm-launch@muc.example.com",
+        title: "Launch crew",
+        participantCount: 2,
+        participantLabels: ["alice", "bob"],
+        media: { audio: true, video: true },
+        isKnownChannel: true,
+        isActive: true,
+        isGroupDm: true,
+      },
+    ]);
+    expect(callActivityDockSelection(entries[0], { phase: "idle" }, "alice@example.com/web")).toEqual({
+      kind: "group-dm-join",
+      roomJid: "group-dm-launch@muc.example.com",
+      media: { audio: true, video: true },
+    });
+    expect(callActivityDockSelection(entries[0], {
+      phase: "outgoing",
+      to: "bob@example.com",
+      sid: "dm-call",
+      media: { audio: true, video: false },
+    }, "alice@example.com/web")).toEqual({
+      kind: "group-dm",
+      roomJid: "group-dm-launch@muc.example.com",
+    });
+  });
+
   test("falls back to peer localpart and orders DM calls by recency", () => {
     const entries = buildCallActivityDockEntries({
       channels: [],
@@ -670,6 +726,59 @@ describe("CallActivityDock rendering", () => {
     ]);
   });
 
+  test("activates group-DM call rows through DM-specific join and open events", async () => {
+    const props = {
+      channels: [],
+      groupDms: [
+        { id: "gdm-launch", name: "Launch crew", roomJid: "group-dm-launch@muc.example.com" },
+      ],
+      conversations: [],
+      activeChannelId: null,
+      activePeerJid: null,
+      sidebarMode: "dms",
+      activeChannelJids: new Set(["group-dm-launch@muc.example.com"]),
+      managedMucDomain: "muc.example.com",
+      callParticipants: {
+        "group-dm-launch@muc.example.com": ["alice", "bob"],
+      },
+      callMediaByRoom: {
+        "group-dm-launch@muc.example.com": { audio: true, video: true },
+      },
+      selfFullJid: "alice@example.com/web",
+    };
+
+    const emitted: unknown[][] = [];
+    let bindings = await setupVueComponent("../src/components/calls/CallActivityDock.vue", props, (...args) => {
+      emitted.push(args);
+    });
+    setupBindingFunction(bindings, "selectEntry")(
+      setupBindingRefValue<unknown[]>(bindings, "visibleEntries")[0],
+    );
+
+    expect(emitted).toEqual([
+      ["joinGroupDmCall", "group-dm-launch@muc.example.com", { audio: true, video: true }],
+    ]);
+
+    clearCallState();
+    $callState.set({
+      phase: "outgoing",
+      to: "bob@example.com",
+      sid: "dm-call",
+      media: { audio: true, video: false },
+    });
+    emitted.length = 0;
+    bindings = await setupVueComponent("../src/components/calls/CallActivityDock.vue", props, (...args) => {
+      emitted.push(args);
+    });
+    setupBindingFunction(bindings, "selectEntry")(
+      setupBindingRefValue<unknown[]>(bindings, "visibleEntries")[0],
+    );
+
+    expect(emitted).toEqual([
+      ["selectGroupDm", "group-dm-launch@muc.example.com"],
+    ]);
+  });
+
   test("renders active group calls before channel metadata hydrates", async () => {
     $mucCallParticipants.set({
       "general@conference.example.com": ["alice", "bob"],
@@ -693,6 +802,94 @@ describe("CallActivityDock rendering", () => {
     expect(html).toContain("Join");
     expect(html).toContain("aria-label=\"Join general, Group call · syncing · 2 people, alice, bob in call\"");
     expect(html).not.toContain("disabled");
+  });
+
+  test("routes pre-hydration group-DM fallback calls through DM-specific events", async () => {
+    const props = {
+      channels: [],
+      groupDms: [],
+      conversations: [],
+      activeChannelId: null,
+      activePeerJid: null,
+      sidebarMode: "dms",
+      activeChannelJids: new Set<string>(),
+      managedMucDomain: "muc.example.com",
+      callParticipants: {
+        "group-dm-launch@muc.example.com": ["alice", "bob"],
+      },
+      callMediaByRoom: {
+        "group-dm-launch@muc.example.com": { audio: true, video: true },
+      },
+      selfFullJid: "alice@example.com/web",
+    };
+
+    const entries = buildCallActivityDockEntries({
+      ...props,
+      callParticipantCounts: {
+        "group-dm-launch@muc.example.com": 2,
+      },
+      dmCallActivities: {},
+    });
+    expect(callActivityDockSelection(entries[0], { phase: "idle" }, "alice@example.com/web")).toEqual({
+      kind: "group-dm-join",
+      roomJid: "group-dm-launch@muc.example.com",
+      media: { audio: true, video: true },
+    });
+
+    const emitted: unknown[][] = [];
+    const bindings = await setupVueComponent("../src/components/calls/CallActivityDock.vue", props, (...args) => {
+      emitted.push(args);
+    });
+    setupBindingFunction(bindings, "selectEntry")(
+      setupBindingRefValue<unknown[]>(bindings, "visibleEntries")[0],
+    );
+
+    expect(emitted).toEqual([
+      ["joinGroupDmCall", "group-dm-launch@muc.example.com", { audio: true, video: true }],
+    ]);
+  });
+
+  test("keeps unmatched channel fallback calls on channel events while DMs are open", async () => {
+    const props = {
+      channels: [],
+      groupDms: [],
+      conversations: [],
+      activeChannelId: null,
+      activePeerJid: null,
+      sidebarMode: "dms",
+      activeChannelJids: new Set<string>(),
+      managedMucDomain: "muc.example.com",
+      callParticipants: {
+        "general@muc.example.com": ["alice", "bob"],
+      },
+      selfFullJid: "alice@example.com/web",
+    };
+
+    const entries = buildCallActivityDockEntries({
+      ...props,
+      callParticipantCounts: {
+        "general@muc.example.com": 2,
+      },
+      dmCallActivities: {},
+    });
+    expect(callActivityDockSelection(entries[0], { phase: "idle" }, "alice@example.com/web")).toEqual({
+      kind: "channel-join",
+      channelId: null,
+      roomJid: "general@muc.example.com",
+      media: { audio: true, video: false },
+    });
+
+    const emitted: unknown[][] = [];
+    const bindings = await setupVueComponent("../src/components/calls/CallActivityDock.vue", props, (...args) => {
+      emitted.push(args);
+    });
+    setupBindingFunction(bindings, "selectEntry")(
+      setupBindingRefValue<unknown[]>(bindings, "visibleEntries")[0],
+    );
+
+    expect(emitted).toEqual([
+      ["joinChannelCall", null, "general@muc.example.com", { audio: true, video: false }],
+    ]);
   });
 
   test("keeps group calls visible when the desktop DM dock suppresses DM rows", async () => {
@@ -1201,7 +1398,9 @@ describe("CallActivityDock rendering", () => {
     expect(readyShell).toContain(":call-participants=\"retainedMucCallParticipantsStore\"");
     expect(readyShell).toContain(":call-media-by-room=\"retainedMucCallMediaStore\"");
     expect(readyShell).toContain("@select-channel=\"onSelectChannelFromSidebar\"");
+    expect(readyShell).toContain("@select-group-dm=\"selectGroupDm\"");
     expect(readyShell).toContain("@join-channel-call=\"joinChannelCallFromActivity\"");
+    expect(readyShell).toContain("@join-group-dm-call=\"joinGroupDmCallFromActivity\"");
     expect(readyShell.match(/@leave-channel-call="leaveRetainedChannelCall"/g)?.length ?? 0).toBeGreaterThanOrEqual(3);
     expect(readyShell).toContain("@answer-dm=\"answerDmFromActivity\"");
     expect(readyShell).toContain("@select-dm=\"selectDm\"");
@@ -1818,6 +2017,26 @@ describe("CallActivityDock rendering", () => {
     expect(html).toContain("Live video call");
     expect(html).toContain("Reconnect bob call, Live now, Live video call");
     expect(html).toContain("Live");
+  });
+
+  test("renders active group-DM call indicators in the direct-message panel", async () => {
+    $mucCallParticipants.set({
+      "group-dm-launch@muc.example.com": ["alice", "bob"],
+    });
+    $mucCallMedia.setKey("group-dm-launch@muc.example.com", { audio: true, video: true });
+
+    const html = await renderVueComponent("../src/components/chat/DmPanel.vue", {
+      conversations: [],
+      groupDms: [
+        { id: "gdm-launch", name: "Launch crew", roomJid: "group-dm-launch@muc.example.com" },
+      ],
+      activePeerJid: null,
+      activeGroupDmRoomJid: null,
+    });
+
+    expect(html).toContain("Launch crew");
+    expect(html).toContain("Video call");
+    expect(html).toContain('aria-label="Open group message Launch crew, Video call live, 2 people"');
   });
 
   test("orders direct-call panel rows by action urgency before recency", async () => {
@@ -2989,7 +3208,19 @@ describe("CallActivityDock rendering", () => {
       callParticipantCounts: { "standup@conference.example.com": 2 },
       dmCallActivities: {},
     })[0];
-    if (!validDmEntry || !staleDmEntry || !fallbackRoomEntry) {
+    const groupDmFallbackRoomEntry = buildCallActivityDockEntries({
+      channels: [],
+      conversations: [],
+      activeChannelId: null,
+      activePeerJid: null,
+      sidebarMode: "channels",
+      activeChannelJids: new Set(["group-dm-launch@conference.example.com"]),
+      managedMucDomain: "conference.example.com",
+      callParticipantCounts: { "group-dm-launch@conference.example.com": 2 },
+      callMediaByRoom: { "group-dm-launch@conference.example.com": { audio: true, video: true } },
+      dmCallActivities: {},
+    })[0];
+    if (!validDmEntry || !staleDmEntry || !fallbackRoomEntry || !groupDmFallbackRoomEntry) {
       throw new Error("expected call entries for dashboard routing test");
     }
     const bindings = await suppressVueLifecycleSetupWarnings(() =>
@@ -3001,7 +3232,10 @@ describe("CallActivityDock rendering", () => {
         channelUnreadMap: {},
         activeChannelJids: new Set(["standup@conference.example.com"]),
         managedMucDomain: "conference.example.com",
-        callParticipantCounts: { "standup@conference.example.com": 2 },
+        callParticipantCounts: {
+          "standup@conference.example.com": 2,
+          "group-dm-launch@conference.example.com": 2,
+        },
         dmConversations: [],
         selfFullJid: "alice@example.com/web",
       }, (...args) => {
@@ -3012,11 +3246,13 @@ describe("CallActivityDock rendering", () => {
     setupBindingFunction(bindings, "selectCallEntry")(validDmEntry);
     setupBindingFunction(bindings, "selectCallEntry")(staleDmEntry);
     setupBindingFunction(bindings, "selectCallEntry")(fallbackRoomEntry);
+    setupBindingFunction(bindings, "selectCallEntry")(groupDmFallbackRoomEntry);
 
     expect(emitted).toEqual([
       ["reconnectDm", "bob@example.com", { audio: true, video: true }],
       ["selectContact", "carol@example.com"],
       ["joinChannelCall", null, "standup@conference.example.com", { audio: true, video: false }],
+      ["joinGroupDmCall", "group-dm-launch@conference.example.com", { audio: true, video: true }],
     ]);
   });
 

--- a/chat/tests/call-activity-dock.test.ts
+++ b/chat/tests/call-activity-dock.test.ts
@@ -3256,6 +3256,29 @@ describe("CallActivityDock rendering", () => {
     ]);
   });
 
+  test("home dashboard uses hydrated group-DM names for active group-DM calls", async () => {
+    const html = await renderVueComponent("../src/components/chat/HomeDashboard.vue", {
+      spaces: [],
+      channels: [],
+      contacts: [],
+      isLoading: false,
+      channelUnreadMap: {},
+      groupDms: [
+        { id: "gdm-launch", name: "Launch crew", roomJid: "group-dm-launch@conference.example.com" },
+      ],
+      activeChannelJids: new Set(["group-dm-launch@conference.example.com"]),
+      managedMucDomain: "conference.example.com",
+      callParticipantCounts: { "group-dm-launch@conference.example.com": 2 },
+      callParticipants: { "group-dm-launch@conference.example.com": ["alice", "bob"] },
+      callMediaByRoom: { "group-dm-launch@conference.example.com": { audio: true, video: true } },
+      dmConversations: [],
+      selfFullJid: "alice@example.com/web",
+    });
+
+    expect(html).toContain("Launch crew");
+    expect(html).not.toContain("group-dm-launch,");
+  });
+
   test("home dashboard leaves retained local group calls without rejoining media", async () => {
     connectionStore.session = {
       username: "alice",
@@ -3407,6 +3430,69 @@ describe("CallActivityDock rendering", () => {
     expect(selected).toEqual([
       ["general", { roomJid: "general@conference.example.com" }],
     ]);
+  });
+
+  test("shell does not start pre-hydration group-DM calls when selection cannot resolve", async () => {
+    const selected: unknown[][] = [];
+    let ensureJoinedCalls = 0;
+    const ui = {
+      activeCommunitySurface: { value: "feed" },
+    };
+    const bindings = await suppressVueLifecycleSetupWarnings(() =>
+      setupVueComponent("../src/components/chat/ChatReadyShell.vue", {
+        controller: {
+          ui,
+          connectionStore: {
+            client: {
+              fullJid: "alice@example.com/web",
+              ensureJoined: async () => {
+                ensureJoinedCalls += 1;
+              },
+              xmpp: {
+                send_muji_session_initiate: async () => {
+                  throw new Error("group-DM call should not start before selection resolves");
+                },
+              },
+            },
+            session: { username: "alice", jid: "alice@example.com" },
+          },
+          waddles: { mucServiceJid: { value: "conference.example.com" } },
+          selfDomain: { value: "example.com" },
+          rosterContacts: {
+            contacts: { value: [] },
+            isLoadingContacts: { value: false },
+          },
+          messaging: {
+            mentionedChannelCounts: { value: {} },
+            activeChannels: { value: new Set<string>() },
+          },
+          dmConversations: { conversations: { value: [] } },
+          computedChannelUnreadMap: { value: {} },
+          activeRightPanel: { value: null },
+          activeThreadStack: { value: [] },
+          communityEvents: { rsvp: () => undefined },
+          closePinnedPanel: () => undefined,
+          activateRightPanel: () => undefined,
+          selectDm: () => undefined,
+          selectChannel: () => undefined,
+          selectChannelByRoomJid: () => undefined,
+          selectGroupDm: async (...args: unknown[]) => {
+            selected.push(args);
+            return false;
+          },
+        },
+      }),
+    );
+
+    setupBindingFunction(bindings, "joinGroupDmCallFromActivity")(
+      "group-dm-launch@conference.example.com",
+      { audio: true, video: true },
+    );
+    await Promise.resolve();
+
+    expect(ui.activeCommunitySurface.value).toBe(null);
+    expect(selected).toEqual([["group-dm-launch@conference.example.com"]]);
+    expect(ensureJoinedCalls).toBe(0);
   });
 
   test("shell answer selects the DM and proceeds with the hydrated full JID", async () => {

--- a/server/crates/waddle-server/tests/calls_e2e_ws.rs
+++ b/server/crates/waddle-server/tests/calls_e2e_ws.rs
@@ -376,6 +376,23 @@ async fn muji_join_room(client: &mut WsXmppClient, room: &str, nick: &str) {
         .expect("join responses including subject ack");
 }
 
+async fn try_join_room(client: &mut WsXmppClient, room: &str, nick: &str) -> String {
+    client
+        .send(&format!(
+            r#"<presence xmlns="jabber:client" to="{room}/{nick}"><x xmlns="{NS_MUC}"/></presence>"#
+        ))
+        .await
+        .expect("send join");
+    client
+        .recv_matching(|frame| {
+            frame.contains("<presence")
+                && (frame.contains(&format!("from='{room}/{nick}'"))
+                    || frame.contains(&format!("from=\"{room}/{nick}\"")))
+        })
+        .await
+        .expect("join response")
+}
+
 fn parse_presence(frame: &str) -> Element {
     frame
         .parse::<Element>()
@@ -483,6 +500,10 @@ fn extract_field(frame: &str, var: &str) -> Option<String> {
 
 fn is_result(frame: &str) -> bool {
     frame.contains(r#"type='result'"#) || frame.contains(r#"type="result""#)
+}
+
+fn is_error(frame: &str) -> bool {
+    frame.contains(r#"type='error'"#) || frame.contains(r#"type="error""#)
 }
 
 async fn send_command(client: &mut WsXmppClient, node: &str, id: &str, form: Element) -> String {
@@ -1147,6 +1168,11 @@ async fn group_dm_muji_call_lifecycle_uses_existing_muc_gate() {
         "group-DM member must receive the call-thread anchor: {bob_frames:?}"
     );
 
+    let carol_join = try_join_room(&mut carol, &room, "carol").await;
+    assert!(
+        is_error(&carol_join) && carol_join.contains("registration-required"),
+        "non-member must not be able to enter members-only group-DM room: {carol_join}"
+    );
     send_muji_session_initiate_expect_forbidden(&mut carol, &room, "carol-forbidden").await;
     send_muji_session_initiate(&mut admin_web, &room, "admin-group-dm-allowed").await;
     send_muji_session_initiate(&mut bob, &room, "bob-group-dm-allowed").await;

--- a/server/crates/waddle-server/tests/calls_e2e_ws.rs
+++ b/server/crates/waddle-server/tests/calls_e2e_ws.rs
@@ -20,16 +20,21 @@ use xmpp_parsers::minidom::Element;
 
 const NS_MUC: &str = "http://jabber.org/protocol/muc";
 const NS_MUC_USER: &str = "http://jabber.org/protocol/muc#user";
+const NS_COMMANDS: &str = "http://jabber.org/protocol/commands";
+const NS_DATA: &str = "jabber:x:data";
 const NS_MUJI: &str = "urn:xmpp:jingle:muji:0";
 const NS_CALL_THREAD: &str = "urn:waddle:call-thread:0";
 const NS_FASTEN: &str = "urn:xmpp:fasten:0";
 const NS_SID: &str = "urn:xmpp:sid:0";
+const NODE_GROUP_DM_CREATE: &str = "urn:waddle:group-dm:create:0";
 
 const DOMAIN: &str = "localhost";
 const ALICE: &str = "alice";
 const BOB: &str = "bob";
+const CAROL: &str = "carol";
 const ALICE_PW: &str = "alice-pw-12345";
 const BOB_PW: &str = "bob-pw-12345";
+const CAROL_PW: &str = "carol-pw-12345";
 const LIVEKIT_WEBHOOK_SECRET: &str = "test-webhook-secret-with-at-least-32-bytes";
 
 // The harness rejects api-secrets shorter than 32 bytes; this one is
@@ -433,6 +438,131 @@ fn element_to_xml(element: Element) -> String {
     let mut bytes = Vec::new();
     element.write_to(&mut bytes).expect("serialize XML");
     String::from_utf8(bytes).expect("XML serialization is UTF-8")
+}
+
+fn frame_has_iq_id(frame: &str, id: &str) -> bool {
+    frame.contains(&format!(r#"id='{id}'"#)) || frame.contains(&format!(r#"id="{id}""#))
+}
+
+fn text_field(var: &str, value: &str) -> Element {
+    Element::builder("field", NS_DATA)
+        .attr(minidom::rxml::xml_ncname!("var").to_owned(), var)
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "text-single")
+        .append(Element::builder("value", NS_DATA).append(value).build())
+        .build()
+}
+
+fn hidden_field(var: &str, value: &str) -> Element {
+    Element::builder("field", NS_DATA)
+        .attr(minidom::rxml::xml_ncname!("var").to_owned(), var)
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "hidden")
+        .append(Element::builder("value", NS_DATA).append(value).build())
+        .build()
+}
+
+fn list_multi_field(var: &str, values: &[&str]) -> Element {
+    let mut field = Element::builder("field", NS_DATA)
+        .attr(minidom::rxml::xml_ncname!("var").to_owned(), var)
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "list-multi");
+    for value in values {
+        field = field.append(Element::builder("value", NS_DATA).append(*value).build());
+    }
+    field.build()
+}
+
+fn extract_field(frame: &str, var: &str) -> Option<String> {
+    let marker_dq = format!(r#"var="{var}""#);
+    let marker_sq = format!(r#"var='{var}'"#);
+    let idx = frame.find(&marker_dq).or_else(|| frame.find(&marker_sq))?;
+    let after = &frame[idx..];
+    let open = after.find("<value>")?;
+    let inner = &after[open + "<value>".len()..];
+    let close = inner.find("</value>")?;
+    Some(inner[..close].to_string())
+}
+
+fn is_result(frame: &str) -> bool {
+    frame.contains(r#"type='result'"#) || frame.contains(r#"type="result""#)
+}
+
+async fn send_command(client: &mut WsXmppClient, node: &str, id: &str, form: Element) -> String {
+    let command = Element::builder("command", NS_COMMANDS)
+        .attr(minidom::rxml::xml_ncname!("node").to_owned(), node)
+        .attr(minidom::rxml::xml_ncname!("action").to_owned(), "execute")
+        .append(form)
+        .build();
+    let iq = Element::builder("iq", "jabber:client")
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "set")
+        .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
+        .attr(minidom::rxml::xml_ncname!("to").to_owned(), DOMAIN)
+        .append(command)
+        .build();
+    client.send(&element_to_xml(iq)).await.expect("send iq");
+    client
+        .recv_matching(|frame| frame.contains("<iq") && frame_has_iq_id(frame, id))
+        .await
+        .expect("iq response")
+}
+
+async fn create_group_dm(
+    client: &mut WsXmppClient,
+    id: &str,
+    name: &str,
+    members: &[&str],
+) -> String {
+    let resp = send_command(
+        client,
+        NODE_GROUP_DM_CREATE,
+        id,
+        Element::builder("x", NS_DATA)
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "submit")
+            .append(hidden_field("FORM_TYPE", NODE_GROUP_DM_CREATE))
+            .append(text_field("name", name))
+            .append(list_multi_field("member_jids", members))
+            .build(),
+    )
+    .await;
+    assert!(
+        is_result(&resp),
+        "expected group-DM create result, got: {resp}"
+    );
+    extract_field(&resp, "room_jid").expect("room_jid in create response")
+}
+
+async fn recv_muji_leave_reflection(client: &mut WsXmppClient, room: &str, nick: &str) -> Element {
+    let from_attr_single = format!("from='{room}/{nick}'");
+    let from_attr_double = format!("from=\"{room}/{nick}\"");
+    let frame = client
+        .recv_matching(|frame| {
+            frame.contains("<presence")
+                && (frame.contains(&from_attr_single) || frame.contains(&from_attr_double))
+                && !frame.contains("<muji")
+        })
+        .await
+        .unwrap_or_else(|err| panic!("{nick} leave reflection must arrive: {err}"));
+    let presence = parse_presence(&frame);
+    assert!(
+        muji_child(&presence).is_none(),
+        "XEP-0272 §Leaving wire shape: muji child must be stripped: {frame}"
+    );
+    presence
+}
+
+async fn assert_no_call_thread_ended(client: &mut WsXmppClient, context: &str) {
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(750);
+    while let Some(remaining) = deadline.checked_duration_since(tokio::time::Instant::now()) {
+        let frame = client.recv_timeout(remaining).await;
+        match frame {
+            Ok(frame) => {
+                assert!(
+                    !(frame.contains("<call-thread-ended") && frame.contains("<apply-to")),
+                    "{context}: call-thread-ended arrived too early: {frame}"
+                );
+            }
+            Err(err) if err.contains("Timeout waiting for message") => break,
+            Err(err) => panic!("{context}: failed while checking for premature call end: {err}"),
+        }
+    }
 }
 
 fn livekit_webhook_auth(body: &[u8]) -> String {
@@ -929,6 +1059,123 @@ async fn muji_session_initiate_from_non_occupant_is_forbidden() {
         .recv_matching(|frame| frame.contains("<call-thread-ended") && frame.contains("<apply-to"))
         .await
         .expect("observer receives ended fastening when the only accepted participant leaves");
+}
+
+#[tokio::test]
+async fn group_dm_muji_call_lifecycle_uses_existing_muc_gate() {
+    let server = TestServer::start_with_extra_envs(
+        &[(BOB, BOB_PW), (CAROL, CAROL_PW)],
+        &livekit_test_envs(),
+    );
+    let admin_pass = server.fixed_account_password().to_string();
+    let mut admin_web = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "admin",
+        &admin_pass,
+        "group-dm-call-web",
+    )
+    .await
+    .expect("admin connects");
+    let mut bob =
+        WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, BOB, BOB_PW, "group-dm-call-bob")
+            .await
+            .expect("bob connects");
+    let mut carol = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        CAROL,
+        CAROL_PW,
+        "group-dm-call-carol",
+    )
+    .await
+    .expect("carol connects");
+
+    let room = create_group_dm(
+        &mut admin_web,
+        "group-dm-call-create",
+        "Launch crew",
+        &["admin@localhost", "bob@localhost"],
+    )
+    .await;
+    muji_join_room(&mut admin_web, &room, "admin").await;
+    muji_join_room(&mut bob, &room, "bob").await;
+
+    let active = Element::builder("presence", "jabber:client")
+        .attr(
+            minidom::rxml::xml_ncname!("to").to_owned(),
+            format!("{room}/admin"),
+        )
+        .append(Element::builder("x", NS_MUC).build())
+        .append(
+            Element::builder("muji", NS_MUJI)
+                .append(
+                    Element::builder("content", NS_MUJI)
+                        .attr(
+                            minidom::rxml::xml_ncname!("creator").to_owned(),
+                            "initiator",
+                        )
+                        .attr(minidom::rxml::xml_ncname!("name").to_owned(), "audio")
+                        .append(
+                            Element::builder("description", "urn:xmpp:jingle:apps:rtp:1")
+                                .attr(minidom::rxml::xml_ncname!("media").to_owned(), "audio")
+                                .build(),
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .build();
+    admin_web
+        .send(&element_to_xml(active))
+        .await
+        .expect("admin sends active group-DM Muji");
+
+    let bob_frames = recv_until_muji_and_anchor(&mut bob).await;
+    assert!(
+        bob_frames.iter().any(|frame| {
+            frame.contains("<presence")
+                && (frame.contains("<muji ") || frame.contains("<muji>"))
+                && frame.contains(&format!("{room}/admin"))
+        }),
+        "group-DM member must see active-call Muji presence: {bob_frames:?}"
+    );
+    assert!(
+        bob_frames
+            .iter()
+            .any(|frame| frame.contains("<call-thread") && frame.contains(NS_CALL_THREAD)),
+        "group-DM member must receive the call-thread anchor: {bob_frames:?}"
+    );
+
+    send_muji_session_initiate_expect_forbidden(&mut carol, &room, "carol-forbidden").await;
+    send_muji_session_initiate(&mut admin_web, &room, "admin-group-dm-allowed").await;
+    send_muji_session_initiate(&mut bob, &room, "bob-group-dm-allowed").await;
+
+    let admin_full_jid = admin_web.full_jid.clone().expect("admin full jid");
+    post_participant_left_webhook(&server, &room, &admin_full_jid).await;
+    recv_muji_leave_reflection(&mut bob, &room, "admin").await;
+    assert_no_call_thread_ended(
+        &mut bob,
+        "first group-DM participant left while bob remained active",
+    )
+    .await;
+
+    send_muji_session_initiate(&mut admin_web, &room, "admin-group-dm-rejoin").await;
+
+    let bob_full_jid = bob.full_jid.clone().expect("bob full jid");
+    post_participant_left_webhook(&server, &room, &bob_full_jid).await;
+    recv_muji_leave_reflection(&mut admin_web, &room, "bob").await;
+    assert_no_call_thread_ended(
+        &mut admin_web,
+        "bob left while rejoined admin remained active",
+    )
+    .await;
+
+    post_participant_left_webhook(&server, &room, &admin_full_jid).await;
+    admin_web
+        .recv_matching(|frame| frame.contains("<call-thread-ended") && frame.contains("<apply-to"))
+        .await
+        .expect("group-DM call ends cleanly when the last participant leaves");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Route group-DM calls through the existing MUC/Muji/LiveKit call flow while preserving the DM conversation surface.
- Surface active group-DM call indicators in the DM panel, call activity dock, and home dashboard, including hydrated group-DM names and pre-hydration fallback rooms with group-DM room identity.
- Add WebSocket e2e coverage for group-DM Muji membership gating, non-member MUC join rejection, non-member token rejection, rejoin mid-call, XEP-0272 leave reflections, no premature ended fastening, and last-participant cleanup.

## Plan
1. Add failing chat model/component coverage for hydrated and pre-hydration group-DM call rows.
2. Add failing server WebSocket coverage for group-DM Muji call lifecycle and non-member rejection.
3. Implement group-DM call activity routing through DM-specific handlers while keeping standard channel fallback rows on channel handlers.
4. Surface retained Muji group-DM call state in the direct-message panel and dashboard.
5. Address PR review feedback: guard unresolved group-DM selection before starting calls, pass hydrated group-DMs to HomeDashboard, document fallback room identity, and assert non-member MUC join rejection.
6. Run focused and broad verification, then monitor CI.

## Verification
- bun test ./tests/call-activity-dock.test.ts
- bun test
- bun run lint
- cargo test -p waddle-server --test calls_e2e_ws
- cargo clippy -p waddle-server --tests -- -D warnings
- git diff --check

## Review Feedback Addressed
- Codex: unresolved pre-hydration group-DM selection now stops before starting Muji.
- Copilot: Carol now explicitly fails to join the members-only group-DM MUC before token rejection is asserted.
- Greptile: fallback room naming convention is documented, and HomeDashboard receives hydrated group-DM summaries for friendly call names.

## Notes
- bunx vue-tsc --noEmit remains blocked by existing unrelated project-wide Vue type errors; this change removed the touched-area readonly error found during the initial run.

Closes #960