### PR TITLE
fix(server): recognize OIDC accounts in group-DM and XEP-0012 existence checks

### DIFF
--- a/server/crates/waddle-server/src/admin/channels.rs
+++ b/server/crates/waddle-server/src/admin/channels.rs
@@ -52,7 +52,7 @@ use xmpp_parsers::message::{Message, MessageType};
 use xmpp_parsers::minidom::Element;
 
 use crate::admin::is_community_owner;
-use crate::auth::NativeUserStore;
+use crate::auth::local_account_exists;
 use crate::channel_space_links::{ChannelSpaceLink, ChannelSpaceLinkError};
 use crate::db::actor::{DbExecute, DbQuery};
 use crate::db::{row_value, ValueExt};
@@ -2561,11 +2561,13 @@ pub(crate) async fn validate_group_dm_invitee(
             "invitee must be a user JID with a localpart".to_string(),
         )));
     };
-    let native_users = NativeUserStore::new(state.db_pool.global_actor().clone());
-    let exists = native_users
-        .user_exists(&localpart, invitee_jid.domain().as_str())
-        .await
-        .map_err(|error| XmppError::internal(format!("native user lookup failed: {error}")))?;
+    let exists = local_account_exists(
+        state.db_pool.global_actor(),
+        &localpart,
+        invitee_jid.domain().as_str(),
+    )
+    .await
+    .map_err(|error| XmppError::internal(format!("user lookup failed: {error}")))?;
     if !exists {
         return Err(XmppError::item_not_found(Some(format!(
             "group-DM invitee does not exist: {invitee_jid}"
@@ -2579,7 +2581,6 @@ async fn validate_group_dm_members(
     creator_jid: &BareJid,
     member_jids: &[BareJid],
 ) -> Result<(), AdminErr> {
-    let native_users = NativeUserStore::new(state.db_pool.global_actor().clone());
     for member_jid in member_jids {
         if member_jid.domain() != creator_jid.domain() {
             return Err(bad_request(format!(
@@ -2590,10 +2591,13 @@ async fn validate_group_dm_members(
         let Some(localpart) = member_jid.node().map(|node| node.to_string()) else {
             return Err(bad_request("member_jids must be user JIDs with localparts"));
         };
-        let exists = native_users
-            .user_exists(&localpart, member_jid.domain().as_str())
-            .await
-            .map_err(|error| internal_err(format!("native user lookup failed: {error}")))?;
+        let exists = local_account_exists(
+            state.db_pool.global_actor(),
+            &localpart,
+            member_jid.domain().as_str(),
+        )
+        .await
+        .map_err(|error| internal_err(format!("user lookup failed: {error}")))?;
         if !exists {
             return Err(Box::new(CommandResult::Error(XmppError::item_not_found(
                 Some(format!("group-DM member does not exist: {member_jid}")),

--- a/server/crates/waddle-server/src/auth/directory.rs
+++ b/server/crates/waddle-server/src/auth/directory.rs
@@ -1,0 +1,57 @@
+//! Unified local-account existence across Waddle's two registration paths.
+//!
+//! Waddle stores local identities in two tables that are populated by
+//! independent provisioning flows:
+//!
+//! - `users` — accounts created through OIDC/web login, keyed by
+//!   `xmpp_localpart`. These carry no password material and no `domain`
+//!   column; an OIDC account is always local to the server's own domain.
+//! - `native_users` — XEP-0077 / SCRAM accounts, keyed by
+//!   `(username, domain)`.
+//!
+//! A JID belongs to a real local account when it is present in *either*
+//! table. Callers that must recognise every registered identity — regardless
+//! of how it was provisioned — use [`local_account_exists`] rather than
+//! [`crate::auth::NativeUserStore::user_exists`], which only sees native
+//! accounts and therefore reports every OIDC user as non-existent.
+//!
+//! The admin Users panel already unions both tables for the same reason (see
+//! `admin/users_list.rs`); this is the single-row existence counterpart.
+
+use kameo::actor::ActorRef;
+
+use crate::db::actor::{DbActor, DbQueryOne};
+
+use super::AuthError;
+
+#[cfg(test)]
+mod tests;
+
+/// Returns `true` when `localpart@domain` resolves to a registered local
+/// account through either the OIDC `users` table or the native `native_users`
+/// table.
+///
+/// `users` rows carry no `domain` column — OIDC accounts are always local to
+/// the server's own domain — so they are matched on `xmpp_localpart` alone.
+/// Native accounts are matched on `(username, domain)`. Callers are expected
+/// to have already constrained `domain` to the local server domain (group-DM
+/// validation, for example, rejects non-local members before reaching here).
+pub async fn local_account_exists(
+    actor: &ActorRef<DbActor>,
+    localpart: &str,
+    domain: &str,
+) -> Result<bool, AuthError> {
+    let row = actor
+        .ask(DbQueryOne {
+            sql: "SELECT 1 FROM users WHERE xmpp_localpart = ? \
+                  UNION ALL \
+                  SELECT 1 FROM native_users WHERE username = ? AND domain = ? \
+                  LIMIT 1"
+                .to_string(),
+            params: vec![localpart.into(), localpart.into(), domain.into()],
+        })
+        .await
+        .map_err(|error| AuthError::DatabaseError(error.to_string()))?;
+
+    Ok(row.is_some())
+}

--- a/server/crates/waddle-server/src/auth/directory/tests.rs
+++ b/server/crates/waddle-server/src/auth/directory/tests.rs
@@ -1,0 +1,116 @@
+use super::local_account_exists;
+use crate::auth::{NativeUserStore, RegisterRequest};
+use crate::db::actor::{DbActor, DbExecute};
+use crate::db::{Database, MigrationRunner};
+use kameo::actor::{ActorRef, Spawn};
+use std::sync::Arc;
+
+async fn test_actor() -> ActorRef<DbActor> {
+    let db = Database::in_memory("test-local-directory")
+        .await
+        .expect("create test database");
+    let db = Arc::new(db);
+    MigrationRunner::global()
+        .run(&db)
+        .await
+        .expect("run migrations");
+    DbActor::spawn(DbActor::new((*db).clone()))
+}
+
+/// Insert an OIDC-provisioned identity directly into the `users` table, the
+/// way the OIDC login flow does (see `auth/identity.rs::create_user`).
+async fn seed_oidc_user(actor: &ActorRef<DbActor>, localpart: &str) {
+    actor
+        .ask(DbExecute {
+            sql: "INSERT INTO users \
+                  (id, username, xmpp_localpart, display_name, avatar_url, primary_email, created_at, updated_at) \
+                  VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+                .to_string(),
+            params: vec![
+                format!("id-{localpart}").into(),
+                localpart.into(),
+                localpart.into(),
+                "Test User".into(),
+                crate::db::Value::NullText,
+                crate::db::Value::NullText,
+                "2026-01-01T00:00:00Z".into(),
+                "2026-01-01T00:00:00Z".into(),
+            ],
+        })
+        .await
+        .expect("seed oidc user");
+}
+
+/// An OIDC user lives only in `users`, never in `native_users`. The unified
+/// directory check must still recognise it — this is the exact regression
+/// behind "group-DM member does not exist" for web-registered accounts.
+#[tokio::test]
+async fn finds_oidc_only_user() {
+    let actor = test_actor().await;
+    seed_oidc_user(&actor, "icepuma").await;
+
+    // The native-only check is blind to OIDC accounts...
+    let native_only = NativeUserStore::new(actor.clone())
+        .user_exists("icepuma", "localhost")
+        .await
+        .expect("native lookup");
+    assert!(!native_only, "OIDC user must be absent from native_users");
+
+    // ...but the unified directory check sees it.
+    let exists = local_account_exists(&actor, "icepuma", "localhost")
+        .await
+        .expect("directory lookup");
+    assert!(exists, "OIDC user must be recognised as a local account");
+}
+
+#[tokio::test]
+async fn finds_native_user() {
+    let actor = test_actor().await;
+    NativeUserStore::new(actor.clone())
+        .register(RegisterRequest {
+            username: "rawkode".to_string(),
+            domain: "localhost".to_string(),
+            password: "rawkode-pass-1234".to_string(),
+            email: None,
+        })
+        .await
+        .expect("register native user");
+
+    let exists = local_account_exists(&actor, "rawkode", "localhost")
+        .await
+        .expect("directory lookup");
+    assert!(exists, "native user must be recognised as a local account");
+}
+
+#[tokio::test]
+async fn false_for_unknown_account() {
+    let actor = test_actor().await;
+    let exists = local_account_exists(&actor, "nobody", "localhost")
+        .await
+        .expect("directory lookup");
+    assert!(!exists, "unknown localpart must not resolve to an account");
+}
+
+/// Native accounts are keyed by `(username, domain)`; a matching localpart on
+/// a different domain must not be treated as the same account.
+#[tokio::test]
+async fn native_match_is_domain_scoped() {
+    let actor = test_actor().await;
+    NativeUserStore::new(actor.clone())
+        .register(RegisterRequest {
+            username: "frank".to_string(),
+            domain: "example.com".to_string(),
+            password: "frank-pass-1234".to_string(),
+            email: None,
+        })
+        .await
+        .expect("register native user");
+
+    let other_domain = local_account_exists(&actor, "frank", "other.test")
+        .await
+        .expect("directory lookup");
+    assert!(
+        !other_domain,
+        "native account must not match across domains"
+    );
+}

--- a/server/crates/waddle-server/src/auth/mod.rs
+++ b/server/crates/waddle-server/src/auth/mod.rs
@@ -6,6 +6,7 @@
 //! - Local session management with UUID principals
 //! - Optional native XMPP auth (XEP-0077/SCRAM)
 
+pub mod directory;
 pub mod identity;
 pub mod jid;
 pub mod native;
@@ -16,6 +17,7 @@ pub mod session;
 
 use thiserror::Error;
 
+pub use directory::local_account_exists;
 pub use identity::IdentityClaims;
 pub use jid::{localpart_to_jid, username_to_localpart};
 pub use native::{NativeUserStore, RegisterRequest};

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/last_activity.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/last_activity.rs
@@ -124,9 +124,13 @@ pub(super) async fn handle_last_activity_iq(
                 service_unavailable_iq_error("Service unavailable at this address."),
             )];
         };
-        let native_user_store =
-            NativeUserStore::new(state.deps.app_state.db_pool.global_actor().clone());
-        match native_user_store.user_exists(node.as_str(), domain).await {
+        match local_account_exists(
+            state.deps.app_state.db_pool.global_actor(),
+            node.as_str(),
+            domain,
+        )
+        .await
+        {
             Ok(false) => {
                 return vec![build_iq_error_xml_typed(
                     iq.id(),

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
@@ -191,7 +191,7 @@ use super::presence::{
     get_managed_channel_for_room, send_current_presence_from_user_to_jid,
     send_unavailable_presence_from_user_to_jid,
 };
-use crate::auth::{NativeUserStore, Session};
+use crate::auth::{local_account_exists, Session};
 use crate::db::actor::{DbExecute, DbQuery, DbQueryOne, GetDatabase};
 use crate::db::blocking::DatabaseBlockingStorage;
 use crate::db::roster::{

--- a/server/crates/waddle-server/tests/group_dm_ws.rs
+++ b/server/crates/waddle-server/tests/group_dm_ws.rs
@@ -741,6 +741,103 @@ async fn group_dm_create_provisions_hidden_members_only_room_with_disco_feature(
     let _ = alice.close().await;
 }
 
+/// Insert an OIDC-provisioned identity straight into `users`, mirroring
+/// `auth/identity.rs::create_user`. The ws harness only provisions native
+/// (`WADDLE_TEST_EXTRA_FIXED_ACCOUNTS`) accounts, so this is the only way to
+/// exercise the OIDC member path end to end.
+async fn seed_oidc_user(database_url: &str, localpart: &str) {
+    use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+
+    let options = SqliteConnectOptions::from_str(database_url)
+        .expect("parse sqlite url")
+        .busy_timeout(Duration::from_secs(5));
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(options)
+        .await
+        .expect("open sqlite db for oidc seed");
+    sqlx::query(
+        "INSERT INTO users \
+         (id, username, xmpp_localpart, display_name, avatar_url, primary_email, created_at, updated_at) \
+         VALUES (?, ?, ?, ?, NULL, NULL, ?, ?)",
+    )
+    .bind(format!("id-{localpart}"))
+    .bind(localpart)
+    .bind(localpart)
+    .bind("OIDC Member")
+    .bind("2026-01-01T00:00:00Z")
+    .bind("2026-01-01T00:00:00Z")
+    .execute(&pool)
+    .await
+    .expect("seed oidc user row");
+    pool.close().await;
+}
+
+/// Regression: group-DM creation must accept members provisioned through the
+/// OIDC/web login flow (rows in `users`), not only XEP-0077/SCRAM accounts
+/// (`native_users`). Before the unified directory lookup, the member existence
+/// check consulted `native_users` only, so every web-registered user was
+/// rejected with `item-not-found` ("group-DM member does not exist").
+#[tokio::test]
+async fn group_dm_create_accepts_oidc_registered_member() {
+    let _serial = TEST_SERIAL.lock().await;
+    let db_dir = tempfile::tempdir().expect("temp db dir");
+    let db_path = db_dir.path().join("group-dm-oidc.sqlite3");
+    let database_url = format!("sqlite://{}?mode=rwc", db_path.display());
+    let server =
+        TestServer::start_persistent_with_extra_accounts(&database_url, &[("alice", "alice-pass")]);
+
+    // Connecting alice guarantees the server is up and migrations have run
+    // before we write the OIDC row directly into `users`.
+    let mut alice = user_client(&server, "alice", "alice-pass", "group-dm-oidc-1").await;
+    seed_oidc_user(&database_url, "carol").await;
+
+    // A member present in neither `users` nor `native_users` is still rejected.
+    let missing = send_command(
+        &mut alice,
+        NODE_GROUP_DM_CREATE,
+        "group-dm-oidc-missing",
+        submit_form(
+            NODE_GROUP_DM_CREATE,
+            vec![
+                text_field("name", "Alice & Ghost"),
+                list_multi_field("member_jids", &["alice@localhost", "ghost@localhost"]),
+            ],
+        ),
+    )
+    .await;
+    assert!(
+        is_error(&missing) && missing.contains("item-not-found"),
+        "unknown member must still be rejected: {missing}"
+    );
+
+    // The OIDC-registered member is accepted.
+    let resp = send_command(
+        &mut alice,
+        NODE_GROUP_DM_CREATE,
+        "group-dm-oidc-create",
+        submit_form(
+            NODE_GROUP_DM_CREATE,
+            vec![
+                text_field("name", "Alice & Carol"),
+                list_multi_field("member_jids", &["alice@localhost", "carol@localhost"]),
+            ],
+        ),
+    )
+    .await;
+    assert!(
+        is_result(&resp),
+        "OIDC-registered member must be accepted into a group DM: {resp}"
+    );
+    let room_jid = extract_field(&resp, "room_jid").expect("room_jid in response");
+    assert!(
+        room_jid.ends_with("@muc.localhost"),
+        "expected managed MUC room, got: {room_jid}"
+    );
+
+    let _ = alice.close().await;
+}
+
 #[tokio::test]
 async fn group_dm_member_invites_new_member_with_history_access_extension() {
     let _serial = TEST_SERIAL.lock().await;

--- a/server/crates/waddle-server/tests/xep0012_0202_ws.rs
+++ b/server/crates/waddle-server/tests/xep0012_0202_ws.rs
@@ -2,6 +2,9 @@
 
 mod ws_common;
 
+use std::str::FromStr;
+use std::time::Duration;
+
 use ws_common::{
     disco_info_query, entity_time_query, extract_element_text, last_activity_query, TestServer,
     WsXmppClient,
@@ -142,6 +145,87 @@ async fn websocket_entity_time_rejects_non_server_target() {
     assert!(
         response.contains("service-unavailable"),
         "expected service-unavailable for non-server entity time target, got: {response}"
+    );
+
+    let _ = client.close().await;
+}
+
+/// Insert an OIDC-provisioned identity straight into `users`, mirroring
+/// `auth/identity.rs::create_user`. The ws harness only provisions native
+/// accounts, so this is the only way to exercise the OIDC user path.
+async fn seed_oidc_user(database_url: &str, localpart: &str) {
+    use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+
+    let options = SqliteConnectOptions::from_str(database_url)
+        .expect("parse sqlite url")
+        .busy_timeout(Duration::from_secs(5));
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(options)
+        .await
+        .expect("open sqlite db for oidc seed");
+    sqlx::query(
+        "INSERT INTO users \
+         (id, username, xmpp_localpart, display_name, avatar_url, primary_email, created_at, updated_at) \
+         VALUES (?, ?, ?, ?, NULL, NULL, ?, ?)",
+    )
+    .bind(format!("id-{localpart}"))
+    .bind(localpart)
+    .bind(localpart)
+    .bind("OIDC Member")
+    .bind("2026-01-01T00:00:00Z")
+    .bind("2026-01-01T00:00:00Z")
+    .execute(&pool)
+    .await
+    .expect("seed oidc user row");
+    pool.close().await;
+}
+
+/// Regression: a `jabber:iq:last` query for an offline **OIDC-registered** user
+/// must return `forbidden` (a known account whose presence is private), not
+/// `service-unavailable` (which means "no such entity"). The existence gate
+/// previously consulted `native_users` only, so OIDC users were reported as
+/// nonexistent. See issue #983.
+#[tokio::test]
+async fn websocket_last_activity_for_offline_oidc_user_is_forbidden() {
+    let db_dir = tempfile::tempdir().expect("temp db dir");
+    let db_path = db_dir.path().join("xep0012-oidc.sqlite3");
+    let database_url = format!("sqlite://{}?mode=rwc", db_path.display());
+    let server = TestServer::start_persistent_with_extra_accounts(&database_url, &[]);
+    let password = server.fixed_account_password().to_string();
+    let mut client = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        USERNAME,
+        &password,
+        &format!("activity-oidc-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("websocket connection");
+
+    // `carol` exists only via OIDC (a row in `users`), is offline, and has no
+    // recorded activity — so the query falls through to the existence gate.
+    seed_oidc_user(&database_url, "carol").await;
+
+    let response = last_activity_query(&mut client, "carol@localhost", "ws-last-oidc")
+        .await
+        .expect("last activity response");
+    assert!(
+        response.contains("forbidden"),
+        "offline OIDC user must be forbidden (known account), got: {response}"
+    );
+    assert!(
+        !response.contains("service-unavailable"),
+        "OIDC user must not be reported as nonexistent: {response}"
+    );
+
+    // Control: a truly unknown local user is still service-unavailable.
+    let ghost = last_activity_query(&mut client, "ghost@localhost", "ws-last-ghost")
+        .await
+        .expect("ghost response");
+    assert!(
+        ghost.contains("service-unavailable"),
+        "unknown local user must be service-unavailable: {ghost}"
     );
 
     let _ = client.close().await;

--- a/server/docs/adrs/0013-group-dm-protocol.md
+++ b/server/docs/adrs/0013-group-dm-protocol.md
@@ -37,6 +37,16 @@ discovery, exposes the classification feature, and publishes XEP-0402
 `urn:xmpp:bookmarks:1` conference bookmarks with `autojoin='true'` for each
 initial member.
 
+Member eligibility is a Waddle policy layer, not an XEP-0045 requirement (MUC
+itself permits granting `member` affiliation to any JID). A group-DM member must
+be a real **local account on the creator's domain**. Locality is enforced first
+(`bad-request` for a foreign or bare-domain JID), then existence. A JID "exists"
+when it resolves to a registered local account through **either** registration
+path: the OIDC `users` table or the XEP-0077/SCRAM `native_users` table. Both are
+first-class XMPP accounts, so the existence check unions them; an unresolved
+member is rejected with `item-not-found`. (Federated/remote members are out of
+scope while members are constrained to the local domain.)
+
 Group-DM membership expansion uses XEP-0045 mediated invites. The server grants
 the invitee member affiliation, publishes their XEP-0402 autojoin bookmark, and
 delivers a trusted mediated invite from the room JID. Waddle-specific invite


### PR DESCRIPTION
## Problem

Creating a group DM fails for normal users with:

```xml
<iq type='error'><error type='cancel'>
  <item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
  <text>group-DM member does not exist: icepuma@waddle.social</text>
</error></iq>
```

even though the member is a real, logged-in user.

## Root cause

Waddle stores local identities in **two** tables, populated by independent flows:

- `users` — OIDC/web-login accounts, keyed by `xmpp_localpart` (no password material).
- `native_users` — XEP-0077 / SCRAM accounts, keyed by `(username, domain)`.

Existence checks that consult only `native_users` (via `NativeUserStore::user_exists`) report every OIDC-registered user as non-existent. The group-DM member/invitee validators had this bug; an audit found the **same pattern** in the XEP-0012 last-activity gate.

Confirmed against production: `icepuma` and `rawkode` are both present in `users` and absent from `native_users`.

### Why CI didn't catch it

The ws integration harness provisions every test account as a **native** user (`WADDLE_TEST_EXTRA_FIXED_ACCOUNTS` → `fixed_account.rs`), so no existing test exercised an OIDC-only user. The gap was invisible.

## Fix

- New focused module `auth/directory.rs` with `local_account_exists(actor, localpart, domain)` that unions both registration paths — the single-row counterpart to the existing `admin/users_list.rs` UNION.
- **Group DM** (`admin/channels.rs`): both member/invitee validators now use it.
- **XEP-0012 last-activity** (`last_activity.rs`): the existence gate now uses it, so an offline OIDC user gets the privacy-correct `forbidden` instead of `service-unavailable` ("no such entity"). Closes #983.
- ADR-0013 updated to document member eligibility (any **local** account, OIDC or native; remote members out of scope).

## XMPP / XEP conformance

Internal data-model fix with **no wire change**:

- Same XEP-0050 command, XEP-0004 form, RFC 6120 `item-not-found`; XEP-0012 now returns the correct `forbidden` vs `service-unavailable` distinction.
- The existence check is a Waddle **policy** layer (members must be real local accounts), not an XEP-0045 requirement — MUC itself permits granting `member` to any JID. The fix makes that policy recognize all valid local XMPP accounts instead of only SCRAM ones, so it is *more* native, not less.
- No XML built by string; typed payloads preserved (`BareJid` in, `bool`/`AuthError` out, callers map to typed `XmppError`/`AdminErr`); `&str` only at the DB I/O boundary.

## Tests

- `auth/directory/tests.rs` — unit coverage; `finds_oidc_only_user` asserts the native-only check returns `false` for the exact OIDC user (the bug) while the unified check returns `true` (the fix).
- `group_dm_ws.rs::group_dm_create_accepts_oidc_registered_member` — e2e regression (seeds an OIDC `users` row; unknown member still `item-not-found`). Independently confirmed to FAIL on `main`.
- `xep0012_0202_ws.rs::websocket_last_activity_for_offline_oidc_user_is_forbidden` — e2e regression asserting `forbidden` for an offline OIDC user, with an unknown-user `service-unavailable` control.

## Adversarial review

Three reviewers (XEP/native, correctness/security, test-quality): 2 clean; correctness confirmed `?`→`$n` mapping, single-domain scoping, no privilege widening. One **pre-existing** finding tracked separately below.

### Follow-up filed (not in this PR)

- #984 — `username_to_localpart` skips XMPP nodeprep/NFKC, so non-ASCII OIDC localparts (e.g. `Straße`→stored `straße`) diverge from the nodeprepped addressable JID (`strasse`). Broad blast radius (routing/rosters/vCards) + needs row migration. Correct for all nodeprep-stable localparts (ASCII + most accented-Latin, including the reported users).

## Verification

- [x] `cargo test -p waddle-server --lib auth::directory` — 4 passed
- [x] `cargo test -p waddle-server --test group_dm_ws` — 18 passed
- [x] `cargo test -p waddle-server --test xep0012_0202_ws` — 6 passed
- [x] `cargo clippy -p waddle-server --all-targets -- -D warnings` — clean
- [x] `cargo fmt` — clean
- [ ] CI green (re-running after XEP-0012 commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)