### PR TITLE
fix(server): use users.id UUID (not raw JID) as SpiceDB subject for group-DM membership

### DIFF
--- a/server/crates/waddle-server/src/admin/channels.rs
+++ b/server/crates/waddle-server/src/admin/channels.rs
@@ -52,7 +52,6 @@ use xmpp_parsers::message::{Message, MessageType};
 use xmpp_parsers::minidom::Element;
 
 use crate::admin::is_community_owner;
-use crate::auth::local_account_exists;
 use crate::channel_space_links::{ChannelSpaceLink, ChannelSpaceLinkError};
 use crate::db::actor::{DbExecute, DbQuery};
 use crate::db::{row_value, ValueExt};
@@ -2080,34 +2079,44 @@ async fn list_durable_group_dm_members(
     state: &AppState,
     group_dm_id: &str,
 ) -> Result<Vec<BareJid>, AdminErr> {
+    // Durable group-DM membership stores the member's `users.id` (the SpiceDB
+    // subject id), so rehydrate the addressable JID by joining `users` and
+    // pairing the localpart with the deployment's user-bearing domain.
     let rows = state
         .db_pool
         .global_actor()
         .ask(DbQuery {
             sql: r#"
-                SELECT DISTINCT subject_id
-                FROM permission_tuples
-                WHERE object_type = 'channel'
-                  AND object_id = ?
-                  AND relation = 'member'
-                  AND subject_type = 'user'
-                  AND subject_relation IS NULL
-                ORDER BY subject_id ASC
+                SELECT DISTINCT u.xmpp_localpart
+                FROM permission_tuples pt
+                JOIN users u ON u.id = pt.subject_id
+                WHERE pt.object_type = 'channel'
+                  AND pt.object_id = ?
+                  AND pt.relation = 'member'
+                  AND pt.subject_type = 'user'
+                  AND pt.subject_relation IS NULL
+                ORDER BY u.xmpp_localpart ASC
             "#
             .to_string(),
             params: vec![group_dm_id.into()],
         })
         .await
         .map_err(|error| internal_err(format!("group-DM member lookup failed: {error}")))?;
+    let domain = state.domain.as_str();
     rows.into_iter()
         .map(|row| {
-            row_value(&row, 0)
+            let localpart = row_value(&row, 0)
                 .and_then(ValueExt::as_string)
-                .map_err(|error| internal_err(format!("invalid group-DM member row: {error}")))
-                .and_then(|jid| {
-                    jid.parse::<BareJid>().map_err(|error| {
-                        internal_err(format!("invalid durable group-DM member JID: {error}"))
-                    })
+                .map_err(|error| internal_err(format!("invalid group-DM member row: {error}")))?;
+            crate::auth::localpart_to_jid(&localpart, domain)
+                .map_err(|error| {
+                    internal_err(format!(
+                        "invalid durable group-DM member localpart: {error}"
+                    ))
+                })?
+                .parse::<BareJid>()
+                .map_err(|error| {
+                    internal_err(format!("invalid durable group-DM member JID: {error}"))
                 })
         })
         .collect()
@@ -2397,15 +2406,38 @@ async fn rollback_group_dm_create(
         .await;
 }
 
+/// Resolve a group-DM member's bare JID to its canonical `users.id` (the SpiceDB
+/// subject id). Group-DM membership lives in the permission model, so a member
+/// must be a provisioned local account; native-only or unknown JIDs are rejected
+/// with `item-not-found`.
+async fn resolve_group_dm_member_user_id(
+    state: &AppState,
+    member_jid: &BareJid,
+) -> Result<String, XmppError> {
+    let Some(localpart) = member_jid.node().map(|node| node.to_string()) else {
+        return Err(XmppError::bad_request(Some(
+            "group-DM member JID must have a localpart".to_string(),
+        )));
+    };
+    crate::auth::resolve_user_id(state.db_pool.global_actor(), &localpart)
+        .await
+        .map_err(|error| XmppError::internal(format!("group-DM member lookup failed: {error}")))?
+        .ok_or_else(|| {
+            XmppError::item_not_found(Some(format!(
+                "group-DM member is not a provisioned account: {member_jid}"
+            )))
+        })
+}
+
 pub(crate) async fn persist_group_dm_member_tuple(
     state: &AppState,
     group_dm_id: &str,
     member_jid: &BareJid,
 ) -> Result<(), XmppError> {
-    persist_group_dm_member_actor_tuple(state, group_dm_id, member_jid).await?;
-    if let Err(error) = persist_durable_group_dm_member_tuple(state, group_dm_id, member_jid).await
-    {
-        let _ = delete_group_dm_member_actor_tuple(state, group_dm_id, member_jid).await;
+    let user_id = resolve_group_dm_member_user_id(state, member_jid).await?;
+    persist_group_dm_member_actor_tuple(state, group_dm_id, &user_id).await?;
+    if let Err(error) = persist_durable_group_dm_member_tuple(state, group_dm_id, &user_id).await {
+        let _ = delete_group_dm_member_actor_tuple(state, group_dm_id, &user_id).await;
         return Err(error);
     }
     Ok(())
@@ -2414,12 +2446,12 @@ pub(crate) async fn persist_group_dm_member_tuple(
 async fn persist_group_dm_member_actor_tuple(
     state: &AppState,
     group_dm_id: &str,
-    member_jid: &BareJid,
+    user_id: &str,
 ) -> Result<(), XmppError> {
     let tuple = Tuple::new(
         Object::new(ObjectType::Channel, group_dm_id),
         Relation::new("member"),
-        Subject::user(member_jid.to_string()),
+        Subject::user(user_id),
     );
     match state.permission_actor.ask(WriteTuple { tuple }).await {
         Ok(()) => {}
@@ -2436,7 +2468,7 @@ async fn persist_group_dm_member_actor_tuple(
 async fn persist_durable_group_dm_member_tuple(
     state: &AppState,
     group_dm_id: &str,
-    member_jid: &BareJid,
+    user_id: &str,
 ) -> Result<(), XmppError> {
     state
         .db_pool
@@ -2458,11 +2490,11 @@ async fn persist_durable_group_dm_member_tuple(
             "#
             .to_string(),
             params: vec![
-                format!("group-dm-member:{group_dm_id}:{member_jid}").into(),
+                format!("group-dm-member:{group_dm_id}:{user_id}").into(),
                 group_dm_id.into(),
-                member_jid.to_string().into(),
+                user_id.into(),
                 group_dm_id.into(),
-                member_jid.to_string().into(),
+                user_id.into(),
             ],
         })
         .await
@@ -2477,11 +2509,12 @@ async fn delete_group_dm_member_tuple(
     group_dm_id: &str,
     member_jid: &BareJid,
 ) -> Result<(), XmppError> {
-    delete_group_dm_member_actor_tuple(state, group_dm_id, member_jid).await?;
-    match delete_durable_group_dm_member_tuple(state, group_dm_id, member_jid).await {
+    let user_id = resolve_group_dm_member_user_id(state, member_jid).await?;
+    delete_group_dm_member_actor_tuple(state, group_dm_id, &user_id).await?;
+    match delete_durable_group_dm_member_tuple(state, group_dm_id, &user_id).await {
         Ok(()) => Ok(()),
         Err(error) => {
-            let _ = persist_group_dm_member_actor_tuple(state, group_dm_id, member_jid).await;
+            let _ = persist_group_dm_member_actor_tuple(state, group_dm_id, &user_id).await;
             Err(error)
         }
     }
@@ -2490,12 +2523,12 @@ async fn delete_group_dm_member_tuple(
 async fn delete_group_dm_member_actor_tuple(
     state: &AppState,
     group_dm_id: &str,
-    member_jid: &BareJid,
+    user_id: &str,
 ) -> Result<(), XmppError> {
     let tuple = Tuple::new(
         Object::new(ObjectType::Channel, group_dm_id),
         Relation::new("member"),
-        Subject::user(member_jid.to_string()),
+        Subject::user(user_id),
     );
     match state.permission_actor.ask(DeleteTuple { tuple }).await {
         Ok(()) => {}
@@ -2512,7 +2545,7 @@ async fn delete_group_dm_member_actor_tuple(
 async fn delete_durable_group_dm_member_tuple(
     state: &AppState,
     group_dm_id: &str,
-    member_jid: &BareJid,
+    user_id: &str,
 ) -> Result<(), XmppError> {
     state
         .db_pool
@@ -2528,7 +2561,7 @@ async fn delete_durable_group_dm_member_tuple(
                   AND subject_relation IS NULL
             "#
             .to_string(),
-            params: vec![group_dm_id.into(), member_jid.to_string().into()],
+            params: vec![group_dm_id.into(), user_id.into()],
         })
         .await
         .map(|_| ())
@@ -2556,24 +2589,14 @@ pub(crate) async fn validate_group_dm_invitee(
             inviter_jid.domain()
         ))));
     }
-    let Some(localpart) = invitee_jid.node().map(|node| node.to_string()) else {
-        return Err(XmppError::bad_request(Some(
-            "invitee must be a user JID with a localpart".to_string(),
-        )));
-    };
-    let exists = local_account_exists(
-        state.db_pool.global_actor(),
-        &localpart,
-        invitee_jid.domain().as_str(),
-    )
-    .await
-    .map_err(|error| XmppError::internal(format!("user lookup failed: {error}")))?;
-    if !exists {
-        return Err(XmppError::item_not_found(Some(format!(
-            "group-DM invitee does not exist: {invitee_jid}"
-        ))));
-    }
-    Ok(())
+    // A group-DM invitee must resolve to a `users.id` (the SpiceDB subject), the
+    // same requirement persistence enforces. Rejecting unprovisioned/native-only
+    // JIDs here with item-not-found keeps the mediated-invite precheck
+    // consistent with what the persist path can actually do, so the invite never
+    // records archive-boundary state for an invitee it cannot add.
+    resolve_group_dm_member_user_id(state, invitee_jid)
+        .await
+        .map(|_| ())
 }
 
 async fn validate_group_dm_members(
@@ -2588,21 +2611,12 @@ async fn validate_group_dm_members(
                 creator_jid.domain()
             )));
         }
-        let Some(localpart) = member_jid.node().map(|node| node.to_string()) else {
-            return Err(bad_request("member_jids must be user JIDs with localparts"));
-        };
-        let exists = local_account_exists(
-            state.db_pool.global_actor(),
-            &localpart,
-            member_jid.domain().as_str(),
-        )
-        .await
-        .map_err(|error| internal_err(format!("user lookup failed: {error}")))?;
-        if !exists {
-            return Err(Box::new(CommandResult::Error(XmppError::item_not_found(
-                Some(format!("group-DM member does not exist: {member_jid}")),
-            ))));
-        }
+        // Each member must resolve to a `users.id` (the SpiceDB subject);
+        // unprovisioned or native-only JIDs are rejected with item-not-found,
+        // matching what persistence requires.
+        resolve_group_dm_member_user_id(state, member_jid)
+            .await
+            .map_err(|error| Box::new(CommandResult::Error(error)))?;
     }
     Ok(())
 }

--- a/server/crates/waddle-server/src/auth/directory.rs
+++ b/server/crates/waddle-server/src/auth/directory.rs
@@ -21,6 +21,7 @@
 use kameo::actor::ActorRef;
 
 use crate::db::actor::{DbActor, DbQueryOne};
+use crate::db::{row_value, ValueExt};
 
 use super::AuthError;
 
@@ -54,4 +55,34 @@ pub async fn local_account_exists(
         .map_err(|error| AuthError::DatabaseError(error.to_string()))?;
 
     Ok(row.is_some())
+}
+
+/// Resolve a local user's `users.id` — the canonical SpiceDB subject id used
+/// throughout Waddle's permission model — from their `xmpp_localpart`.
+///
+/// Returns `None` when the localpart has no OIDC `users` row. SpiceDB object ids
+/// forbid `@`/`.`, so a JID can never be a valid subject; this UUID is the
+/// stable handle. Native-only accounts (no `users` row) are not representable as
+/// permission subjects and resolve to `None`.
+pub async fn resolve_user_id(
+    actor: &ActorRef<DbActor>,
+    localpart: &str,
+) -> Result<Option<String>, AuthError> {
+    let row = actor
+        .ask(DbQueryOne {
+            sql: "SELECT id FROM users WHERE xmpp_localpart = ? LIMIT 1".to_string(),
+            params: vec![localpart.into()],
+        })
+        .await
+        .map_err(|error| AuthError::DatabaseError(error.to_string()))?;
+
+    match row {
+        Some(row) => {
+            let id = row_value(&row, 0)
+                .and_then(ValueExt::as_string)
+                .map_err(|error| AuthError::DatabaseError(format!("decode user id: {error}")))?;
+            Ok(Some(id))
+        }
+        None => Ok(None),
+    }
 }

--- a/server/crates/waddle-server/src/auth/mod.rs
+++ b/server/crates/waddle-server/src/auth/mod.rs
@@ -17,7 +17,7 @@ pub mod session;
 
 use thiserror::Error;
 
-pub use directory::local_account_exists;
+pub use directory::{local_account_exists, resolve_user_id};
 pub use identity::IdentityClaims;
 pub use jid::{localpart_to_jid, username_to_localpart};
 pub use native::{NativeUserStore, RegisterRequest};

--- a/server/crates/waddle-server/src/server/fixed_account.rs
+++ b/server/crates/waddle-server/src/server/fixed_account.rs
@@ -1,4 +1,5 @@
 use crate::auth::{NativeUserStore, RegisterRequest};
+use crate::db::actor::{DbExecute, DbQueryOne};
 use crate::db::DatabasePool;
 use crate::server::XmppConfig;
 use anyhow::Result;
@@ -126,10 +127,62 @@ pub(crate) async fn seed_fixed_test_account(
         .await
         .map_err(|err| anyhow::anyhow!("Failed creating fixed test account: {err}"))?;
 
+    // Provision a matching OIDC `users` identity so the account has a
+    // `users.id` — the canonical permission subject. Real deployments only have
+    // OIDC users; native-only test accounts cannot be group-DM members or carry
+    // any SpiceDB affiliation, so the fixed-account harness mirrors a real
+    // identity here.
+    ensure_oidc_identity_row(db_pool, config).await?;
+
     info!(
         username = %config.username,
         domain = %config.domain,
         "Provisioned fixed native test account"
     );
+    Ok(())
+}
+
+/// Upsert an OIDC `users` row for a fixed test account (idempotent across
+/// server restarts on a persistent DB). `display_name` is left NULL so the
+/// admin Users panel's `users`∪`native_users` walk still dedupes by localpart.
+async fn ensure_oidc_identity_row(
+    db_pool: &Arc<DatabasePool>,
+    config: &FixedTestAccountConfig,
+) -> Result<()> {
+    // Normalize the localpart the same way the OIDC path and the JID node
+    // resolution do, so SCRAM-session and group-DM membership lookups (which key
+    // on the nodeprep-normalized localpart) resolve to this row.
+    let xmpp_localpart = crate::auth::username_to_localpart(&config.username);
+    let actor = db_pool.global_actor();
+    let existing = actor
+        .ask(DbQueryOne {
+            sql: "SELECT 1 FROM users WHERE xmpp_localpart = ? LIMIT 1".to_string(),
+            params: vec![xmpp_localpart.as_str().into()],
+        })
+        .await
+        .map_err(|err| anyhow::anyhow!("Failed checking fixed OIDC identity: {err}"))?;
+    if existing.is_some() {
+        return Ok(());
+    }
+
+    let now = chrono::Utc::now().to_rfc3339();
+    actor
+        .ask(DbExecute {
+            sql: r#"
+                INSERT INTO users
+                    (id, username, xmpp_localpart, display_name, avatar_url, primary_email, created_at, updated_at)
+                VALUES (?, ?, ?, NULL, NULL, NULL, ?, ?)
+            "#
+            .to_string(),
+            params: vec![
+                uuid::Uuid::new_v4().to_string().into(),
+                config.username.as_str().into(),
+                xmpp_localpart.as_str().into(),
+                now.clone().into(),
+                now.into(),
+            ],
+        })
+        .await
+        .map_err(|err| anyhow::anyhow!("Failed creating fixed OIDC identity: {err}"))?;
     Ok(())
 }

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -191,6 +191,10 @@ pub async fn start_with_config(
         room_registry: room_registry.clone(),
         spaces_jid: xmpp_config.spaces_jid.clone(),
         muc_domain: xmpp_config.muc_domain.clone(),
+        domain: xmpp_config
+            .domain
+            .parse()
+            .map_err(|e| anyhow::anyhow!("invalid xmpp domain '{}': {e}", xmpp_config.domain))?,
         occupant_id_secret: server_config.occupant_id_secret.clone(),
         permission_actor: permission_actor.clone(),
         server_owner_jids,

--- a/server/crates/waddle-server/src/server/routes/uploads/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/uploads/tests.rs
@@ -52,6 +52,7 @@ async fn create_test_upload_state() -> (Arc<UploadState>, std::path::PathBuf) {
         room_registry,
         spaces_jid: "spaces.example.com".parse().expect("spaces JID parses"),
         muc_domain,
+        domain: "example.com".parse().expect("user domain parses"),
         occupant_id_secret,
         permission_actor,
         server_owner_jids: Arc::from(Vec::<jid::BareJid>::new()),

--- a/server/crates/waddle-server/src/server/routes/websocket/frame.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame.rs
@@ -132,7 +132,8 @@ pub(super) async fn handle_xmpp_frame(
             let scram = phase
                 .take_scram_pending()
                 .expect("SASL response must have pending SCRAM state");
-            handle_sasl_scram_response(&data, domain, scram, authenticated_session, phase)
+            handle_sasl_scram_response(&data, domain, scram, authenticated_session, phase, state)
+                .await
         }
 
         InboundFrame::Stanza(stanza) => {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/archive_inbox_upload.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/archive_inbox_upload.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use super::group_dm_membership::requester_has_group_dm_membership_tuple;
+
 pub(super) async fn handle_archive_inbox_upload_iq(
     iq: &xmpp_parsers::iq::Iq,
     id: &str,
@@ -369,23 +371,11 @@ async fn group_dm_archive_visibility(
         return GroupDmArchiveVisibility::NotGroupDm;
     }
 
-    let allowed = state
-        .deps
-        .app_state
-        .permission_actor
-        .ask(CheckPermission {
-            subject: Subject::user(sender_bare.to_string()),
-            permission: Permission::Member,
-            object: Object::new(ObjectType::Channel, &channel_id),
-        })
-        .await
-        .map(|response| response.allowed);
-    match allowed {
-        Ok(true) => {}
-        Ok(false) => return GroupDmArchiveVisibility::Denied,
-        Err(error) => {
+    match requester_has_group_dm_membership_tuple(state, sender_bare, &channel_id).await {
+        Some(true) => {}
+        Some(false) => return GroupDmArchiveVisibility::Denied,
+        None => {
             warn!(
-                error = %error,
                 room = %room_jid,
                 requester = %sender_bare,
                 "Failed to authorize group-DM MAM query"

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/commands.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/commands.rs
@@ -1,4 +1,7 @@
 use super::extension_forms::CommandBoundary;
+use super::group_dm_membership::{
+    requester_has_durable_group_dm_membership, requester_has_group_dm_membership_tuple,
+};
 use super::*;
 
 pub(super) struct CommandTargets<'a> {
@@ -168,48 +171,11 @@ async fn room_command_available(
     if channel.channel_type != waddle_xmpp::admin::CHANNEL_TYPE_GROUP_DM {
         return false;
     }
-    if state
-        .deps
-        .app_state
-        .permission_actor
-        .ask(CheckPermission {
-            subject: Subject::user(requester_bare.to_string()),
-            permission: Permission::Member,
-            object: Object::new(ObjectType::Channel, &channel_id),
-        })
+    if requester_has_group_dm_membership_tuple(state, &requester_bare, &channel_id)
         .await
-        .ok()
-        .is_some_and(|response| response.allowed)
+        .unwrap_or(false)
     {
         return true;
     }
     requester_has_durable_group_dm_membership(state, &requester_bare, &channel_id).await
-}
-
-async fn requester_has_durable_group_dm_membership(
-    state: &WebSocketState,
-    requester_bare: &BareJid,
-    channel_id: &str,
-) -> bool {
-    state
-        .deps
-        .app_state
-        .db_pool
-        .global_actor()
-        .ask(DbQueryOne {
-            sql: r#"
-                SELECT 1 FROM permission_tuples
-                WHERE object_type = 'channel'
-                  AND object_id = ?
-                  AND relation = 'member'
-                  AND subject_type = 'user'
-                  AND subject_id = ?
-                  AND subject_relation IS NULL
-                LIMIT 1
-            "#
-            .to_string(),
-            params: vec![channel_id.into(), requester_bare.to_string().into()],
-        })
-        .await
-        .is_ok_and(|row| row.is_some())
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/disco_info/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/disco_info/muc.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+use super::super::group_dm_membership::{
+    requester_has_durable_group_dm_membership, requester_has_group_dm_membership_tuple,
+};
+
 /// XEP-0030 routing classification for a disco#info target as seen by the
 /// MUC dispatcher.
 ///
@@ -111,43 +115,28 @@ async fn classify_room_command_target(
             let Some(channel_id) = waddle_xmpp::parse_managed_room_jid(room_jid) else {
                 return RoomCommandTarget::Missing;
             };
-            if requester_has_group_dm_membership_tuple(state, &requester_bare, &channel_id)
-                .await
-                .is_some_and(|allowed| allowed)
-                || requester_has_durable_group_dm_membership(state, &requester_bare, &channel_id)
-                    .await
+            match requester_has_group_dm_membership_tuple(state, &requester_bare, &channel_id).await
             {
-                RoomCommandTarget::GroupDm
-            } else {
-                match state
-                    .deps
-                    .app_state
-                    .permission_actor
-                    .ask(CheckPermission {
-                        subject: Subject::user(requester_bare.to_string()),
-                        permission: Permission::Member,
-                        object: Object::new(ObjectType::Channel, channel_id),
-                    })
+                Some(true) => RoomCommandTarget::GroupDm,
+                Some(false) => {
+                    if requester_has_durable_group_dm_membership(
+                        state,
+                        &requester_bare,
+                        &channel_id,
+                    )
                     .await
-                {
-                    Err(kameo::error::SendError::HandlerError(error)) => {
-                        warn!(
-                            room = %room_jid,
-                            error = ?error,
-                            "Failed to check persisted group-DM membership for command disco#info"
-                        );
-                        RoomCommandTarget::Failed
+                    {
+                        RoomCommandTarget::GroupDm
+                    } else {
+                        RoomCommandTarget::NotMember
                     }
-                    Ok(response) if response.allowed => RoomCommandTarget::GroupDm,
-                    Ok(_) => RoomCommandTarget::NotMember,
-                    Err(error) => {
-                        warn!(
-                            room = %room_jid,
-                            error = ?error,
-                            "Failed to ask permission actor for command disco#info"
-                        );
-                        RoomCommandTarget::Failed
-                    }
+                }
+                None => {
+                    warn!(
+                        room = %room_jid,
+                        "Indeterminate group-DM membership check for command disco#info"
+                    );
+                    RoomCommandTarget::Failed
                 }
             }
         }
@@ -162,53 +151,6 @@ async fn classify_room_command_target(
             RoomCommandTarget::Failed
         }
     }
-}
-
-async fn requester_has_group_dm_membership_tuple(
-    state: &WebSocketState,
-    requester_bare: &BareJid,
-    channel_id: &str,
-) -> Option<bool> {
-    state
-        .deps
-        .app_state
-        .permission_actor
-        .ask(CheckPermission {
-            subject: Subject::user(requester_bare.to_string()),
-            permission: Permission::Member,
-            object: Object::new(ObjectType::Channel, channel_id),
-        })
-        .await
-        .ok()
-        .map(|response| response.allowed)
-}
-
-async fn requester_has_durable_group_dm_membership(
-    state: &WebSocketState,
-    requester_bare: &BareJid,
-    channel_id: &str,
-) -> bool {
-    state
-        .deps
-        .app_state
-        .db_pool
-        .global_actor()
-        .ask(DbQueryOne {
-            sql: r#"
-                SELECT 1 FROM permission_tuples
-                WHERE object_type = 'channel'
-                  AND object_id = ?
-                  AND relation = 'member'
-                  AND subject_type = 'user'
-                  AND subject_id = ?
-                  AND subject_relation IS NULL
-                LIMIT 1
-            "#
-            .to_string(),
-            params: vec![channel_id.into(), requester_bare.to_string().into()],
-        })
-        .await
-        .is_ok_and(|row| row.is_some())
 }
 
 pub(super) async fn handle_muc_disco_info<'a>(

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/disco_items.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/disco_items.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+use super::group_dm_membership::{
+    requester_has_durable_group_dm_membership, requester_has_group_dm_membership_tuple,
+};
+
 enum RoomCommandTarget {
     GroupDm,
     NotGroupDm,
@@ -60,40 +64,26 @@ async fn classify_room_command_target(
             let Some(channel_id) = waddle_xmpp::parse_managed_room_jid(room_jid) else {
                 return RoomCommandTarget::Missing;
             };
-            if requester_has_group_dm_membership_tuple(state, &requester_bare, &channel_id)
-                .await
-                .is_some_and(|allowed| allowed)
-                || requester_has_durable_group_dm_membership(state, &requester_bare, &channel_id)
+            match requester_has_group_dm_membership_tuple(state, &requester_bare, &channel_id).await
+            {
+                Some(true) => RoomCommandTarget::GroupDm,
+                Some(false) => {
+                    if requester_has_durable_group_dm_membership(
+                        state,
+                        &requester_bare,
+                        &channel_id,
+                    )
                     .await
-            {
-                return RoomCommandTarget::GroupDm;
-            }
-            match state
-                .deps
-                .app_state
-                .permission_actor
-                .ask(CheckPermission {
-                    subject: Subject::user(requester_bare.to_string()),
-                    permission: Permission::Member,
-                    object: Object::new(ObjectType::Channel, channel_id),
-                })
-                .await
-            {
-                Err(kameo::error::SendError::HandlerError(error)) => {
-                    warn!(
-                        room = %room_jid,
-                        error = ?error,
-                        "Failed to check persisted group-DM membership for disco#items"
-                    );
-                    RoomCommandTarget::Failed
+                    {
+                        RoomCommandTarget::GroupDm
+                    } else {
+                        RoomCommandTarget::NotMember
+                    }
                 }
-                Ok(response) if response.allowed => RoomCommandTarget::GroupDm,
-                Ok(_) => RoomCommandTarget::NotMember,
-                Err(error) => {
+                None => {
                     warn!(
                         room = %room_jid,
-                        error = ?error,
-                        "Failed to ask permission actor for disco#items"
+                        "Indeterminate group-DM membership check for disco#items"
                     );
                     RoomCommandTarget::Failed
                 }
@@ -110,53 +100,6 @@ async fn classify_room_command_target(
             RoomCommandTarget::Failed
         }
     }
-}
-
-async fn requester_has_group_dm_membership_tuple(
-    state: &WebSocketState,
-    requester_bare: &BareJid,
-    channel_id: &str,
-) -> Option<bool> {
-    state
-        .deps
-        .app_state
-        .permission_actor
-        .ask(CheckPermission {
-            subject: Subject::user(requester_bare.to_string()),
-            permission: Permission::Member,
-            object: Object::new(ObjectType::Channel, channel_id),
-        })
-        .await
-        .ok()
-        .map(|response| response.allowed)
-}
-
-async fn requester_has_durable_group_dm_membership(
-    state: &WebSocketState,
-    requester_bare: &BareJid,
-    channel_id: &str,
-) -> bool {
-    state
-        .deps
-        .app_state
-        .db_pool
-        .global_actor()
-        .ask(DbQueryOne {
-            sql: r#"
-                SELECT 1 FROM permission_tuples
-                WHERE object_type = 'channel'
-                  AND object_id = ?
-                  AND relation = 'member'
-                  AND subject_type = 'user'
-                  AND subject_id = ?
-                  AND subject_relation IS NULL
-                LIMIT 1
-            "#
-            .to_string(),
-            params: vec![channel_id.into(), requester_bare.to_string().into()],
-        })
-        .await
-        .is_ok_and(|row| row.is_some())
 }
 
 pub(super) async fn handle_disco_items_iq(

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/group_dm_membership.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/group_dm_membership.rs
@@ -1,0 +1,88 @@
+//! Shared group-DM membership checks.
+//!
+//! Group-DM membership is an XEP-0045 `member` affiliation recorded in the
+//! Zanzibar permission model (SpiceDB), with a durable mirror in the
+//! `permission_tuples` table. Both key on the member's `users.id` — the
+//! canonical SpiceDB subject id. SpiceDB object ids forbid `@`/`.`, so a raw JID
+//! can never be a valid subject; a requester JID is resolved to its `users.id`
+//! before either lookup.
+
+use super::*;
+
+/// Resolve the requester's `users.id`. `Ok(None)` means the requester is not a
+/// provisioned account (so cannot be a member); `Err` means the lookup failed
+/// and membership is indeterminate.
+async fn requester_user_id(
+    state: &WebSocketState,
+    requester_bare: &BareJid,
+) -> Result<Option<String>, crate::auth::AuthError> {
+    let Some(localpart) = requester_bare.node().map(|node| node.to_string()) else {
+        return Ok(None);
+    };
+    crate::auth::resolve_user_id(state.deps.app_state.db_pool.global_actor(), &localpart).await
+}
+
+/// SpiceDB membership check. `None` is indeterminate (lookup/permission error);
+/// `Some(false)` includes "requester is not a provisioned account".
+pub(crate) async fn requester_has_group_dm_membership_tuple(
+    state: &WebSocketState,
+    requester_bare: &BareJid,
+    channel_id: &str,
+) -> Option<bool> {
+    let user_id = match requester_user_id(state, requester_bare).await {
+        Ok(Some(user_id)) => user_id,
+        Ok(None) => return Some(false),
+        Err(_) => return None,
+    };
+    state
+        .deps
+        .app_state
+        .permission_actor
+        .ask(CheckPermission {
+            subject: Subject::user(user_id),
+            permission: Permission::Member,
+            object: Object::new(ObjectType::Channel, channel_id),
+        })
+        .await
+        .map_err(|error| {
+            warn!(
+                error = %error,
+                channel_id,
+                "group-DM membership CheckPermission failed"
+            );
+        })
+        .ok()
+        .map(|response| response.allowed)
+}
+
+/// Durable `permission_tuples` membership fallback.
+pub(crate) async fn requester_has_durable_group_dm_membership(
+    state: &WebSocketState,
+    requester_bare: &BareJid,
+    channel_id: &str,
+) -> bool {
+    let Ok(Some(user_id)) = requester_user_id(state, requester_bare).await else {
+        return false;
+    };
+    state
+        .deps
+        .app_state
+        .db_pool
+        .global_actor()
+        .ask(DbQueryOne {
+            sql: r#"
+                SELECT 1 FROM permission_tuples
+                WHERE object_type = 'channel'
+                  AND object_id = ?
+                  AND relation = 'member'
+                  AND subject_type = 'user'
+                  AND subject_id = ?
+                  AND subject_relation IS NULL
+                LIMIT 1
+            "#
+            .to_string(),
+            params: vec![channel_id.into(), user_id.into()],
+        })
+        .await
+        .is_ok_and(|row| row.is_some())
+}

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
@@ -83,6 +83,7 @@ mod disco_info;
 mod disco_items;
 pub(crate) mod errors;
 mod extension_forms;
+mod group_dm_membership;
 mod jingle_muji_gate;
 mod last_activity;
 mod link_preview_lookup;

--- a/server/crates/waddle-server/src/server/routes/websocket/sasl.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/sasl.rs
@@ -171,12 +171,13 @@ pub(super) async fn handle_sasl_scram_client_first(
 ///
 /// Verifies the client proof against stored keys and returns `<success>` or
 /// `<failure>`.
-pub(super) fn handle_sasl_scram_response(
+pub(super) async fn handle_sasl_scram_response(
     b64_data: &str,
     domain: &str,
     mut scram: ScramPendingState,
     authenticated_session: &mut Option<Session>,
     phase: &mut ConnectionPhase,
+    state: &WebSocketState,
 ) -> Vec<String> {
     let decoded = match BASE64_STANDARD.decode(b64_data.trim()) {
         Ok(data) => data,
@@ -229,7 +230,33 @@ pub(super) fn handle_sasl_scram_response(
         "SASL SCRAM-SHA-256 authentication successful",
     );
 
-    let session = Session::new(&bare_jid.to_string(), scram.username(), scram.username());
+    // Use the account's canonical `users.id` as the session subject so native
+    // (SCRAM) logins key into the permission model identically to OIDC logins.
+    // Resolve against the bare-JID node (nodeprep-normalized) — the same key the
+    // membership write path uses (`member_jid.node()`) — so the session id and
+    // the persisted member id are provably equal for the same account. Fall back
+    // to the bare JID only for native-only accounts with no `users` row (which
+    // cannot hold any SpiceDB affiliation anyway).
+    let localpart = bare_jid
+        .node()
+        .map(|node| node.to_string())
+        .unwrap_or_else(|| scram.username().to_string());
+    let user_id =
+        match crate::auth::resolve_user_id(state.deps.app_state.db_pool.global_actor(), &localpart)
+            .await
+        {
+            Ok(Some(id)) => id,
+            // Native-only account with no `users` row: no permission identity.
+            Ok(None) => bare_jid.to_string(),
+            // A lookup failure must not silently vend a JID for an account that
+            // may well have a `users` row — that would hand an OIDC user the
+            // wrong session subject on a transient DB hiccup. Fail the auth.
+            Err(error) => {
+                warn!(error = %error, jid = %bare_jid, "SCRAM: failed to resolve users.id");
+                return vec![sasl_failure_xml("temporary-auth-failure")];
+            }
+        };
+    let session = Session::new(&user_id, scram.username(), &localpart);
 
     *authenticated_session = Some(session);
     *phase = ConnectionPhase::authenticated(&full_jid);

--- a/server/crates/waddle-server/src/server/state.rs
+++ b/server/crates/waddle-server/src/server/state.rs
@@ -53,6 +53,12 @@ pub struct AppState {
     /// `channels:create` constructs new managed room JIDs against this
     /// domain.
     pub muc_domain: DomainPart,
+    /// The deployment's user-bearing XMPP domain (e.g. `waddle.social`), the
+    /// domain local accounts are addressed under. Resolved from
+    /// [`crate::server::XmppConfig`] (`WADDLE_XMPP_DOMAIN`). Used to rebuild a
+    /// member's bare JID from their stored `users.id`/localpart when rehydrating
+    /// durable group-DM membership.
+    pub domain: DomainPart,
     /// Shared secret for XEP-0421 occupant-id generation.
     pub occupant_id_secret: OccupantIdSecret,
     /// Shared permission actor handle.
@@ -107,6 +113,8 @@ impl AppState {
             room_registry,
             spaces_jid,
             muc_domain,
+            domain: DomainPart::from_str("localhost")
+                .expect("test user domain 'localhost' parses as DomainPart"),
             occupant_id_secret,
             permission_actor,
             server_owner_jids: Arc::from(Vec::<BareJid>::new()),
@@ -127,6 +135,7 @@ impl AppState {
             room_registry,
             spaces_jid,
             muc_domain,
+            domain,
             occupant_id_secret,
             permission_actor,
             server_owner_jids,
@@ -141,6 +150,7 @@ impl AppState {
             room_registry,
             spaces_jid,
             muc_domain,
+            domain,
             occupant_id_secret,
             permission_actor,
             server_owner_jids,
@@ -161,6 +171,7 @@ pub struct AppStateDeps {
     pub room_registry: ActorRef<RoomRegistryActor>,
     pub spaces_jid: BareJid,
     pub muc_domain: DomainPart,
+    pub domain: DomainPart,
     pub occupant_id_secret: OccupantIdSecret,
     pub permission_actor: ActorRef<PermissionActor>,
     pub server_owner_jids: Arc<[BareJid]>,

--- a/server/crates/waddle-server/tests/group_dm_ws.rs
+++ b/server/crates/waddle-server/tests/group_dm_ws.rs
@@ -835,6 +835,44 @@ async fn group_dm_create_accepts_oidc_registered_member() {
         "expected managed MUC room, got: {room_jid}"
     );
 
+    // Persisted permission subjects must be the members' `users.id` (SpiceDB
+    // object ids forbid `@`/`.`), never a raw JID — otherwise real SpiceDB
+    // rejects the tuple. Verify the durable mirror stores UUIDs, not JIDs.
+    let pool = open_push_publish_job_pool(&database_url).await;
+    let channel_id = room_jid
+        .split_once('@')
+        .map(|(node, _)| node.to_string())
+        .expect("room JID has a localpart");
+    let jid_shaped: i64 = sqlx::query(
+        "SELECT COUNT(*) AS count FROM permission_tuples \
+         WHERE object_type = 'channel' AND object_id = ? AND subject_type = 'user' \
+         AND subject_id LIKE '%@%'",
+    )
+    .bind(&channel_id)
+    .fetch_one(&pool)
+    .await
+    .expect("count jid-shaped subjects")
+    .get("count");
+    assert_eq!(
+        jid_shaped, 0,
+        "group-DM member subjects must be users.id UUIDs, not JIDs"
+    );
+    let member_rows: i64 = sqlx::query(
+        "SELECT COUNT(*) AS count FROM permission_tuples \
+         WHERE object_type = 'channel' AND object_id = ? AND relation = 'member' \
+         AND subject_type = 'user'",
+    )
+    .bind(&channel_id)
+    .fetch_one(&pool)
+    .await
+    .expect("count member tuples")
+    .get("count");
+    assert!(
+        member_rows >= 2,
+        "expected persisted member tuples for alice and carol, got {member_rows}"
+    );
+    pool.close().await;
+
     let _ = alice.close().await;
 }
 


### PR DESCRIPTION
## Problem

Creating a group DM in production fails after the member-existence check passes (#982):

```
<error type='wait'><internal-server-error/>
<text>Failed to persist group-DM member: ... SubjectFilter.OptionalSubjectId:
value does not match regex pattern "^(([a-zA-Z0-9/_|\-=+]{1,})|\*)?$"</text>
```

## Root cause

Group-DM membership wrote the member's **raw JID** as the SpiceDB subject id (`Subject::user(member_jid.to_string())`). SpiceDB object ids forbid `@` and `.`, so real SpiceDB rejected the tuple. The rest of Waddle keys SpiceDB subjects on the `users.id` UUID (`bootstrap_membership`, `set_room_affiliation`, `resolve_managed_channel_affiliation` via `session.user_id`). Group DM diverged. **Pre-existing** (group-DM feature #977–#981), not from #982.

**Why CI missed it:** the permission layer has two backends — real `SpiceDb` (prod, enforces the id regex) and `Local` (an in-process `permission_tuples` store used by tests, no validation) — and tests use domain `localhost` (no dot). So group DM never ran against a regex-enforcing backend.

## Fix — key group-DM membership on `users.id` everywhere

- **`auth::resolve_user_id`** — JID localpart → `users.id`.
- **Write** (`channels.rs`): group-DM member persist/delete resolve to `users.id`; both SpiceDB and the durable `permission_tuples` mirror store the UUID. `list_durable_group_dm_members` rebuilds member JIDs via a `users` JOIN + the new **`AppState.domain`** (the user-bearing domain, distinct from `muc_domain`).
- **Read** (`iq/group_dm_membership.rs`): consolidates **three** duplicated membership-check helper pairs (disco_items, commands, muc-disco) into one shared module that resolves the requester JID → `users.id`; inbox/MAM visibility (`archive_inbox_upload.rs`) uses it too. Also removed two leftover inline JID-subject `CheckPermission` fallbacks in `classify_room_command_target`.
- **Native SCRAM login** (`sasl.rs`): sets `session.user_id` to the `users.id` (resolved against the nodeprep-normalized JID node), so the in-process test backend exercises the same identity model production OIDC logins already use.
- **Test harness** (`fixed_account.rs`): provisions a normalized `users` row alongside each native test account so test identities have a `users.id`.

## XMPP / XEP conformance

Internal data-model fix, no new wire semantics: same XEP-0050 command / XEP-0004 form; non-provisioned members get RFC 6120 `item-not-found`. No XML by string; typed payloads (`BareJid`/`AuthError`/`Subject`), `&str` only at the DB boundary.

## Scope / implication

Group-DM membership now requires a real `users.id` (an OIDC-provisioned account) — already true for every production user, and consistent with MUC affiliations (`set_room_affiliation` is OIDC-only too).

## Adversarial review

Three reviewers (correctness, scope/completeness, plus the earlier conformance pass). Findings addressed:
- **Fixed:** native SCRAM session resolved `users.id` against the raw `n=` username while the write used the nodeprep-lowercased node — divergent for non-lowercase usernames. Now both resolve against the JID node, and the harness stores a normalized localpart.
- **Fixed:** two stale inline JID-subject `CheckPermission` fallbacks in `classify_room_command_target` (disco_items, muc) routed through the shared UUID helper.
- **Deferred (separate, confirmed out of scope):** native **server**-membership provisioning (`bootstrap_membership.rs`, `register_native_user`) still uses JID subjects → filed as **#986**.

## Verification

- [x] `cargo test -p waddle-server` — full suite green (1322 lib + 1678 integration across 55 binaries, 0 failures)
- [x] group-DM subjects asserted to be UUIDs, not JIDs (regression check in `group_dm_ws`)
- [x] `cargo clippy -p waddle-server --all-targets -- -D warnings` clean; `cargo fmt` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)