### PR TITLE
feat(chat): add call audio processing controls

### DIFF
--- a/chat/src/components/calls/CallSettingsDialog.vue
+++ b/chat/src/components/calls/CallSettingsDialog.vue
@@ -8,8 +8,12 @@ import {
   enumerateCallDevices,
   isSpeakerOutputSelectionSupported,
   type EnumeratedDevices,
+  type AudioProcessingPrefs,
 } from "@/lib/calls/device-prefs";
-import { applyCallDeviceSelection } from "@/lib/calls/call-device-selection";
+import {
+  applyAudioProcessingSelection,
+  applyCallDeviceSelection,
+} from "@/lib/calls/call-device-selection";
 import { $micAudioProcessing } from "@/lib/calls/mic-audio-processing-state";
 import { audioProcessingRows } from "@/lib/calls/mic-audio-processing";
 import { useCallEngine } from "@/lib/calls/use-call-engine";
@@ -50,6 +54,10 @@ const speakerSupported = ref(isSpeakerOutputSelectionSupported());
 const micProcessing = useStore($micAudioProcessing);
 const processingRows = computed(() =>
   micProcessing.value.kind === "active" ? audioProcessingRows(micProcessing.value) : [],
+);
+const audioProcessingPending = ref(false);
+const audioProcessingDisabled = computed(
+  () => micProcessing.value.kind !== "active" || audioProcessingPending.value,
 );
 
 /**
@@ -239,6 +247,27 @@ async function selectSpeaker(id: string | null): Promise<void> {
   }
 }
 
+async function setAudioProcessing(
+  key: keyof AudioProcessingPrefs,
+  enabled: boolean,
+  event: Event,
+): Promise<void> {
+  const input = event.target instanceof HTMLInputElement ? event.target : null;
+  const previous = prefs.value.audioProcessing[key];
+  audioProcessingPending.value = true;
+  try {
+    await applyAudioProcessingSelection(
+      { ...prefs.value.audioProcessing, [key]: enabled },
+      engine,
+    );
+  } catch (err) {
+    if (input) input.checked = previous;
+    reportCallError(err);
+  } finally {
+    audioProcessingPending.value = false;
+  }
+}
+
 /**
  * `devicechange` listener wired up only while the dialog is open.
  * Previously this was mounted for the entire call lifetime, which
@@ -359,9 +388,52 @@ function close(): void {
         <!-- Read-only verification of the audio processing the browser
              actually applied to the live mic (not what we requested). -->
         <div class="call-processing">
+          <fieldset
+            class="call-processing-controls"
+            :aria-describedby="micProcessing.kind === 'no-mic' ? 'call-processing-no-mic' : undefined"
+            :disabled="audioProcessingDisabled"
+          >
+            <legend class="type-caption call-processing__title">
+              Requested audio processing
+            </legend>
+            <label class="call-processing-toggle">
+              <span class="call-processing-toggle__copy">
+                <span class="type-caption call-processing-toggle__label">Noise cancellation</span>
+              </span>
+              <input
+                class="call-processing-toggle__input"
+                type="checkbox"
+                :checked="prefs.audioProcessing.noiseSuppression"
+                @change="setAudioProcessing('noiseSuppression', ($event.target as HTMLInputElement).checked, $event)"
+              />
+            </label>
+            <label class="call-processing-toggle">
+              <span class="call-processing-toggle__copy">
+                <span class="type-caption call-processing-toggle__label">Echo cancellation</span>
+              </span>
+              <input
+                class="call-processing-toggle__input"
+                type="checkbox"
+                :checked="prefs.audioProcessing.echoCancellation"
+                @change="setAudioProcessing('echoCancellation', ($event.target as HTMLInputElement).checked, $event)"
+              />
+            </label>
+            <label class="call-processing-toggle">
+              <span class="call-processing-toggle__copy">
+                <span class="type-caption call-processing-toggle__label">Auto gain control</span>
+              </span>
+              <input
+                class="call-processing-toggle__input"
+                type="checkbox"
+                :checked="prefs.audioProcessing.autoGainControl"
+                @change="setAudioProcessing('autoGainControl', ($event.target as HTMLInputElement).checked, $event)"
+              />
+            </label>
+          </fieldset>
           <h4 class="type-caption call-processing__title">Audio processing</h4>
           <p
             v-if="micProcessing.kind === 'no-mic'"
+            id="call-processing-no-mic"
             class="type-caption text-muted-foreground"
           >
             No microphone active — enable your mic to verify audio
@@ -561,6 +633,39 @@ function close(): void {
 
 .call-processing__title {
   color: var(--muted-foreground);
+}
+
+.call-processing-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.call-processing-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  min-height: 2rem;
+}
+
+.call-processing-toggle__copy {
+  min-width: 0;
+}
+
+.call-processing-toggle__label {
+  color: var(--foreground);
+}
+
+.call-processing-toggle__input {
+  width: 2.25rem;
+  height: 1.25rem;
+  flex: 0 0 auto;
+  accent-color: var(--primary);
+}
+
+.call-processing-toggle__input:disabled {
+  opacity: 0.55;
 }
 
 .call-processing__list {

--- a/chat/src/lib/calls/call-device-selection.ts
+++ b/chat/src/lib/calls/call-device-selection.ts
@@ -1,5 +1,7 @@
 import {
+  type AudioProcessingPrefs,
   setCamDevice,
+  setAudioProcessingPrefs,
   setMicDevice,
   setSpeakerDevice,
 } from "./device-prefs";
@@ -10,6 +12,10 @@ export type CallDeviceSelectionEngine = {
   setMicDevice(deviceId: string): Promise<void>;
   setCameraDevice(deviceId: string): Promise<void>;
   setSpeakerDevice(deviceId: string): Promise<void>;
+};
+
+export type CallAudioProcessingSelectionEngine = {
+  setAudioProcessing(prefs: AudioProcessingPrefs): Promise<void>;
 };
 
 export async function applyCallDeviceSelection(
@@ -30,4 +36,12 @@ export async function applyCallDeviceSelection(
   }
   await engine.setSpeakerDevice(activeDeviceId);
   setSpeakerDevice(deviceId);
+}
+
+export async function applyAudioProcessingSelection(
+  prefs: AudioProcessingPrefs,
+  engine: CallAudioProcessingSelectionEngine,
+): Promise<void> {
+  await engine.setAudioProcessing(prefs);
+  setAudioProcessingPrefs(prefs);
 }

--- a/chat/src/lib/calls/device-prefs.ts
+++ b/chat/src/lib/calls/device-prefs.ts
@@ -15,30 +15,91 @@ type DevicePrefs = {
   mic: string | null;
   cam: string | null;
   speaker: string | null;
+  audioProcessing: AudioProcessingPrefs;
 };
 
 const STORAGE_KEY = "waddle:call-device-prefs";
 
-function readInitialPrefs(): DevicePrefs {
-  if (typeof window === "undefined") {
-    return { mic: null, cam: null, speaker: null };
+export type AudioProcessingPrefs = {
+  noiseSuppression: boolean;
+  echoCancellation: boolean;
+  autoGainControl: boolean;
+};
+
+export type AudioProcessingConstraints = AudioProcessingPrefs;
+
+export function defaultAudioProcessingPrefs(): AudioProcessingPrefs {
+  return {
+    noiseSuppression: true,
+    echoCancellation: true,
+    autoGainControl: true,
+  };
+}
+
+export function normalizeAudioProcessingPrefs(value: unknown): AudioProcessingPrefs {
+  if (typeof value !== "object" || value === null) return defaultAudioProcessingPrefs();
+  const obj = value as Record<string, unknown>;
+  if (
+    typeof obj.noiseSuppression !== "boolean" ||
+    typeof obj.echoCancellation !== "boolean" ||
+    typeof obj.autoGainControl !== "boolean"
+  ) {
+    return defaultAudioProcessingPrefs();
   }
+  return {
+    noiseSuppression: obj.noiseSuppression,
+    echoCancellation: obj.echoCancellation,
+    autoGainControl: obj.autoGainControl,
+  };
+}
+
+export function audioProcessingConstraints(
+  prefs: AudioProcessingPrefs,
+): AudioProcessingConstraints {
+  return {
+    noiseSuppression: prefs.noiseSuppression,
+    echoCancellation: prefs.echoCancellation,
+    autoGainControl: prefs.autoGainControl,
+  };
+}
+
+function defaultDevicePrefs(): DevicePrefs {
+  return {
+    mic: null,
+    cam: null,
+    speaker: null,
+    audioProcessing: defaultAudioProcessingPrefs(),
+  };
+}
+
+export function parseDevicePrefsStorage(raw: string | null): DevicePrefs {
   try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (!raw) return { mic: null, cam: null, speaker: null };
+    if (!raw) return defaultDevicePrefs();
     const parsed: unknown = JSON.parse(raw);
     if (typeof parsed !== "object" || parsed === null) {
-      return { mic: null, cam: null, speaker: null };
+      return defaultDevicePrefs();
     }
     const obj = parsed as Record<string, unknown>;
     return {
       mic: typeof obj.mic === "string" ? obj.mic : null,
       cam: typeof obj.cam === "string" ? obj.cam : null,
       speaker: typeof obj.speaker === "string" ? obj.speaker : null,
+      audioProcessing: normalizeAudioProcessingPrefs(obj.audioProcessing),
     };
   } catch {
-    return { mic: null, cam: null, speaker: null };
+    return defaultDevicePrefs();
   }
+}
+
+export function serializeDevicePrefsStorage(prefs: DevicePrefs): string {
+  return JSON.stringify(prefs);
+}
+
+function readInitialPrefs(): DevicePrefs {
+  if (typeof window === "undefined") {
+    return defaultDevicePrefs();
+  }
+  return parseDevicePrefsStorage(window.localStorage.getItem(STORAGE_KEY));
 }
 
 export const $devicePrefs = atom<DevicePrefs>(readInitialPrefs());
@@ -46,7 +107,7 @@ export const $devicePrefs = atom<DevicePrefs>(readInitialPrefs());
 $devicePrefs.subscribe((prefs) => {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+    window.localStorage.setItem(STORAGE_KEY, serializeDevicePrefsStorage(prefs));
   } catch {
     // Persistence is best-effort.
   }
@@ -62,6 +123,10 @@ export function setCamDevice(id: string | null): void {
 
 export function setSpeakerDevice(id: string | null): void {
   $devicePrefs.set({ ...$devicePrefs.get(), speaker: id });
+}
+
+export function setAudioProcessingPrefs(audioProcessing: AudioProcessingPrefs): void {
+  $devicePrefs.set({ ...$devicePrefs.get(), audioProcessing });
 }
 
 type SpeakerOutputSelectionEnvironment = {

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -19,7 +19,12 @@ import {
 } from "livekit-client";
 import type { LiveKitJoin } from "./types";
 import type { CallConnectionPhase, CallConnectionQuality } from "./connection-quality";
-import { $devicePrefs } from "./device-prefs";
+import {
+  $devicePrefs,
+  audioProcessingConstraints,
+  type AudioProcessingConstraints,
+  type AudioProcessingPrefs,
+} from "./device-prefs";
 import { validateLiveKitGrant } from "./dm-call-activity";
 import { activeMicAudioProcessing, type MicAudioProcessing } from "./mic-audio-processing";
 
@@ -52,6 +57,36 @@ const CAMERA_PUBLISH_OPTIONS: TrackPublishOptions = {
 const SCREEN_SHARE_PUBLISH_OPTIONS: TrackPublishOptions = {
   degradationPreference: "maintain-resolution",
 };
+
+export function audioCaptureDefaultsForPrefs(prefs: {
+  mic: string | null;
+  audioProcessing: AudioProcessingPrefs;
+}): AudioProcessingConstraints & { deviceId?: string } {
+  return {
+    ...audioProcessingConstraints(prefs.audioProcessing),
+    deviceId: prefs.mic ?? undefined,
+  };
+}
+
+export function callRoomOptionsForPrefs(prefs: {
+  mic: string | null;
+  cam: string | null;
+  audioProcessing: AudioProcessingPrefs;
+}) {
+  return {
+    adaptiveStream: true,
+    dynacast: true,
+    webAudioMix: true,
+    audioCaptureDefaults: audioCaptureDefaultsForPrefs(prefs),
+    videoCaptureDefaults: {
+      deviceId: prefs.cam ?? undefined,
+      resolution: CAMERA_CAPTURE_RESOLUTION,
+    },
+    publishDefaults: {
+      screenShareEncoding: SCREEN_SHARE_ENCODING,
+    },
+  };
+}
 
 /**
  * Identifies a remote media track surfaced to the UI. The `kind`
@@ -258,24 +293,7 @@ export class CallEngine {
       throw new Error(`Invalid LiveKit join token: ${grant.reason}`);
     }
     const prefs = $devicePrefs.get();
-    const room = new Room({
-      adaptiveStream: true,
-      dynacast: true,
-      webAudioMix: true,
-      audioCaptureDefaults: {
-        autoGainControl: true,
-        echoCancellation: true,
-        noiseSuppression: true,
-        deviceId: prefs.mic ?? undefined,
-      },
-      videoCaptureDefaults: {
-        deviceId: prefs.cam ?? undefined,
-        resolution: CAMERA_CAPTURE_RESOLUTION,
-      },
-      publishDefaults: {
-        screenShareEncoding: SCREEN_SHARE_ENCODING,
-      },
-    });
+    const room = new Room(callRoomOptionsForPrefs(prefs));
     room.on(RoomEvent.TrackSubscribed, this.handleTrackSubscribed);
     room.on(RoomEvent.TrackUnsubscribed, this.handleTrackUnsubscribed);
     room.on(RoomEvent.LocalTrackPublished, this.handleLocalTrackPublished);
@@ -374,6 +392,30 @@ export class CallEngine {
   async setMicDevice(deviceId: string): Promise<void> {
     if (!this.room) return;
     await this.room.switchActiveDevice("audioinput", deviceId);
+  }
+
+  /**
+   * Restart the live microphone capture with updated browser-native
+   * audio-processing constraints. LiveKit swaps the capture track inside
+   * the existing publication, so the call stays joined and no Jingle
+   * signaling is needed.
+   */
+  async setAudioProcessing(prefs: AudioProcessingPrefs): Promise<void> {
+    const publication = this.room?.localParticipant.getTrackPublication(Track.Source.Microphone);
+    if (!publication || publication.isMuted) return;
+    const track = publication.track;
+    if (!track) return;
+    const restartTrack = track?.restartTrack;
+    if (typeof restartTrack !== "function") return;
+    const settings = track.mediaStreamTrack?.getSettings();
+    await restartTrack.call(
+      track,
+      audioCaptureDefaultsForPrefs({
+        mic: settings?.deviceId ?? $devicePrefs.get().mic,
+        audioProcessing: prefs,
+      }),
+    );
+    this.emitMicAudioProcessing();
   }
 
   /**

--- a/chat/tests/call-device-prefs.test.ts
+++ b/chat/tests/call-device-prefs.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { isSpeakerOutputSelectionSupported } from "../src/lib/calls/device-prefs";
+import {
+  audioProcessingConstraints,
+  defaultAudioProcessingPrefs,
+  isSpeakerOutputSelectionSupported,
+  normalizeAudioProcessingPrefs,
+  parseDevicePrefsStorage,
+  serializeDevicePrefsStorage,
+} from "../src/lib/calls/device-prefs";
 
 describe("call speaker output support", () => {
   test("is disabled during SSR or when media elements cannot switch sinks", () => {
@@ -41,5 +48,79 @@ describe("call speaker output support", () => {
         },
       }),
     ).toBe(true);
+  });
+});
+
+describe("call audio processing preferences", () => {
+  test("default to requesting browser audio processing", () => {
+    expect(defaultAudioProcessingPrefs()).toEqual({
+      noiseSuppression: true,
+      echoCancellation: true,
+      autoGainControl: true,
+    });
+    expect(audioProcessingConstraints(defaultAudioProcessingPrefs())).toEqual({
+      noiseSuppression: true,
+      echoCancellation: true,
+      autoGainControl: true,
+    });
+  });
+
+  test("fall back to defaults for malformed stored values", () => {
+    expect(normalizeAudioProcessingPrefs(null)).toEqual(defaultAudioProcessingPrefs());
+    expect(normalizeAudioProcessingPrefs({ noiseSuppression: false })).toEqual(
+      defaultAudioProcessingPrefs(),
+    );
+    expect(
+      normalizeAudioProcessingPrefs({
+        noiseSuppression: false,
+        echoCancellation: false,
+        autoGainControl: false,
+      }),
+    ).toEqual({
+      noiseSuppression: false,
+      echoCancellation: false,
+      autoGainControl: false,
+    });
+  });
+
+  test("round-trips audio processing through the persisted device prefs shape", () => {
+    const stored = serializeDevicePrefsStorage({
+      mic: "headset-mic",
+      cam: "desk-cam",
+      speaker: "usb-speaker",
+      audioProcessing: {
+        noiseSuppression: false,
+        echoCancellation: false,
+        autoGainControl: false,
+      },
+    });
+
+    expect(parseDevicePrefsStorage(stored)).toEqual({
+      mic: "headset-mic",
+      cam: "desk-cam",
+      speaker: "usb-speaker",
+      audioProcessing: {
+        noiseSuppression: false,
+        echoCancellation: false,
+        autoGainControl: false,
+      },
+    });
+  });
+
+  test("legacy stored device prefs default audio processing on", () => {
+    expect(
+      parseDevicePrefsStorage(
+        JSON.stringify({
+          mic: "headset-mic",
+          cam: "desk-cam",
+          speaker: "usb-speaker",
+        }),
+      ),
+    ).toEqual({
+      mic: "headset-mic",
+      cam: "desk-cam",
+      speaker: "usb-speaker",
+      audioProcessing: defaultAudioProcessingPrefs(),
+    });
   });
 });

--- a/chat/tests/call-device-selection.test.ts
+++ b/chat/tests/call-device-selection.test.ts
@@ -1,9 +1,21 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { $devicePrefs } from "../src/lib/calls/device-prefs";
-import { applyCallDeviceSelection } from "../src/lib/calls/call-device-selection";
+import {
+  $devicePrefs,
+  defaultAudioProcessingPrefs,
+  type AudioProcessingPrefs,
+} from "../src/lib/calls/device-prefs";
+import {
+  applyAudioProcessingSelection,
+  applyCallDeviceSelection,
+} from "../src/lib/calls/call-device-selection";
 
 afterEach(() => {
-  $devicePrefs.set({ mic: null, cam: null, speaker: null });
+  $devicePrefs.set({
+    mic: null,
+    cam: null,
+    speaker: null,
+    audioProcessing: defaultAudioProcessingPrefs(),
+  });
 });
 
 describe("call device selection", () => {
@@ -22,6 +34,7 @@ describe("call device selection", () => {
       mic: "headset-mic",
       cam: "desk-cam",
       speaker: "usb-speaker",
+      audioProcessing: defaultAudioProcessingPrefs(),
     });
     expect(engine.setMicDevice).toHaveBeenCalledWith("headset-mic");
     expect(engine.setCameraDevice).toHaveBeenCalledWith("desk-cam");
@@ -39,7 +52,12 @@ describe("call device selection", () => {
     await applyCallDeviceSelection("cam", null, engine);
     await applyCallDeviceSelection("speaker", null, engine);
 
-    expect($devicePrefs.get()).toEqual({ mic: null, cam: null, speaker: null });
+    expect($devicePrefs.get()).toEqual({
+      mic: null,
+      cam: null,
+      speaker: null,
+      audioProcessing: defaultAudioProcessingPrefs(),
+    });
     expect(engine.setMicDevice).toHaveBeenCalledWith("default");
     expect(engine.setCameraDevice).toHaveBeenCalledWith("default");
     expect(engine.setSpeakerDevice).toHaveBeenCalledWith("default");
@@ -53,11 +71,58 @@ describe("call device selection", () => {
       setCameraDevice: mock(async (_id: string) => undefined),
       setSpeakerDevice: mock(async (_id: string) => undefined),
     };
-    $devicePrefs.set({ mic: "old-mic", cam: null, speaker: null });
+    $devicePrefs.set({
+      mic: "old-mic",
+      cam: null,
+      speaker: null,
+      audioProcessing: defaultAudioProcessingPrefs(),
+    });
 
     await expect(applyCallDeviceSelection("mic", null, engine)).rejects.toThrow("device unavailable");
 
     expect(engine.setMicDevice).toHaveBeenCalledWith("default");
-    expect($devicePrefs.get()).toEqual({ mic: "old-mic", cam: null, speaker: null });
+    expect($devicePrefs.get()).toEqual({
+      mic: "old-mic",
+      cam: null,
+      speaker: null,
+      audioProcessing: defaultAudioProcessingPrefs(),
+    });
+  });
+
+  test("persists and applies audio processing selections to the active call", async () => {
+    const audioProcessing: AudioProcessingPrefs = {
+      noiseSuppression: false,
+      echoCancellation: false,
+      autoGainControl: false,
+    };
+    const engine = {
+      setAudioProcessing: mock(async (_prefs: AudioProcessingPrefs) => undefined),
+    };
+
+    await applyAudioProcessingSelection(audioProcessing, engine);
+
+    expect($devicePrefs.get().audioProcessing).toEqual(audioProcessing);
+    expect(engine.setAudioProcessing).toHaveBeenCalledWith(audioProcessing);
+  });
+
+  test("does not persist audio processing when the active call rejects restart", async () => {
+    const engine = {
+      setAudioProcessing: mock(async (_prefs: AudioProcessingPrefs) => {
+        throw new Error("restart failed");
+      }),
+    };
+
+    await expect(
+      applyAudioProcessingSelection(
+        {
+          noiseSuppression: false,
+          echoCancellation: false,
+          autoGainControl: false,
+        },
+        engine,
+      ),
+    ).rejects.toThrow("restart failed");
+
+    expect($devicePrefs.get().audioProcessing).toEqual(defaultAudioProcessingPrefs());
   });
 });

--- a/chat/tests/call-engine.test.ts
+++ b/chat/tests/call-engine.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import {
+  audioCaptureDefaultsForPrefs,
+  callRoomOptionsForPrefs,
   enableRequestedCapture,
   mapLiveKitConnectionQuality,
   mapLiveKitConnectionState,
@@ -12,6 +14,7 @@ import {
 } from "../src/lib/calls/engine";
 import { ConnectionQuality, ConnectionState, Track } from "livekit-client";
 import type { MicAudioProcessing } from "../src/lib/calls/mic-audio-processing";
+import type { AudioProcessingPrefs } from "../src/lib/calls/device-prefs";
 
 function deviceError(name: string): Error {
   const err = new Error(`${name} message`);
@@ -59,6 +62,44 @@ function screenShareStub(opts: { audioThrows?: Error } = {}) {
 // is exercised by manual smoke tests in the browser per the call PR
 // plan, and by the planned `calls_e2e` integration test on the server.
 describe("call-engine module", () => {
+  test("maps persisted audio processing preferences into connect-time capture defaults", () => {
+    const audioProcessing: AudioProcessingPrefs = {
+      noiseSuppression: false,
+      echoCancellation: false,
+      autoGainControl: false,
+    };
+
+    expect(audioCaptureDefaultsForPrefs({ mic: "headset-mic", audioProcessing })).toEqual({
+      deviceId: "headset-mic",
+      noiseSuppression: false,
+      echoCancellation: false,
+      autoGainControl: false,
+    });
+    expect(audioCaptureDefaultsForPrefs({ mic: null, audioProcessing })).toEqual({
+      deviceId: undefined,
+      noiseSuppression: false,
+      echoCancellation: false,
+      autoGainControl: false,
+    });
+    expect(
+      callRoomOptionsForPrefs({
+        mic: "headset-mic",
+        cam: "desk-cam",
+        audioProcessing,
+      }),
+    ).toMatchObject({
+      audioCaptureDefaults: {
+        deviceId: "headset-mic",
+        noiseSuppression: false,
+        echoCancellation: false,
+        autoGainControl: false,
+      },
+      videoCaptureDefaults: {
+        deviceId: "desk-cam",
+      },
+    });
+  });
+
   test("resolves participant audio volume by identity and source with default full volume", () => {
     const store: ParticipantAudioVolumeStore = {
       "bob@waddle.test/desktop:microphone": 0.3,
@@ -656,16 +697,20 @@ describe("enableRequestedCapture — best-effort, never ejects", () => {
  */
 function micRoomStub(
   settings: MediaTrackSettings | null,
-  opts: { readyState?: MediaStreamTrackState; isMuted?: boolean } = {},
+  opts: {
+    readyState?: MediaStreamTrackState;
+    isMuted?: boolean;
+    restartTrack?: (constraints: unknown) => Promise<void>;
+  } = {},
 ) {
-  const { readyState = "live", isMuted = false } = opts;
+  const { readyState = "live", isMuted = false, restartTrack } = opts;
   const publication =
     settings === null
       ? undefined
       : {
           isMuted,
           source: Track.Source.Microphone,
-          track: { mediaStreamTrack: { readyState, getSettings: () => settings } },
+          track: { mediaStreamTrack: { readyState, getSettings: () => settings }, restartTrack },
         };
   return {
     localParticipant: {
@@ -897,6 +942,87 @@ describe("call-engine — verifies applied mic audio processing", () => {
         autoGainControl: "unknown",
       },
     ]);
+  });
+
+  test("a mid-call audio processing change restarts the active mic track in place", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    const restarts: unknown[] = [];
+    const events: MicAudioProcessing[] = [];
+    engine.on("micAudioProcessingChanged", (state) => events.push(state));
+    (engine as unknown as { room: unknown }).room = micRoomStub(
+      {
+        deviceId: "headset-mic",
+        noiseSuppression: false,
+        echoCancellation: false,
+        autoGainControl: false,
+      } as MediaTrackSettings,
+      {
+        restartTrack: async (constraints: unknown) => {
+          restarts.push(constraints);
+        },
+      },
+    );
+
+    await engine.setAudioProcessing({
+      noiseSuppression: false,
+      echoCancellation: false,
+      autoGainControl: false,
+    });
+
+    expect(restarts).toEqual([
+      {
+        noiseSuppression: false,
+        echoCancellation: false,
+        autoGainControl: false,
+        deviceId: "headset-mic",
+      },
+    ]);
+    expect(events.at(-1)).toEqual({
+      kind: "active",
+      noiseSuppression: "off",
+      echoCancellation: "off",
+      autoGainControl: "off",
+    });
+  });
+
+  test("an audio processing change with no room or no active mic is a safe no-op", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    await engine.setAudioProcessing({
+      noiseSuppression: false,
+      echoCancellation: false,
+      autoGainControl: false,
+    });
+    (engine as unknown as { room: unknown }).room = micRoomStub(null);
+    await engine.setAudioProcessing({
+      noiseSuppression: true,
+      echoCancellation: true,
+      autoGainControl: true,
+    });
+  });
+
+  test("an audio processing change with a muted mic is a safe no-op", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    const restarts: unknown[] = [];
+    (engine as unknown as { room: unknown }).room = micRoomStub(
+      { noiseSuppression: true } as MediaTrackSettings,
+      {
+        isMuted: true,
+        restartTrack: async (constraints: unknown) => {
+          restarts.push(constraints);
+        },
+      },
+    );
+
+    await engine.setAudioProcessing({
+      noiseSuppression: false,
+      echoCancellation: false,
+      autoGainControl: false,
+    });
+
+    expect(restarts).toEqual([]);
   });
 
   test("a device change with no connected room emits no-mic, not a crash", async () => {

--- a/chat/tests/call-settings-dialog.test.ts
+++ b/chat/tests/call-settings-dialog.test.ts
@@ -25,6 +25,24 @@ describe("CallSettingsDialog speaker support", () => {
 
 });
 
+describe("CallSettingsDialog audio processing controls", () => {
+  test("renders requested noise cancellation controls near the applied-state readout", async () => {
+    const html = await renderVueComponent("../src/components/calls/CallSettingsDialog.vue", {
+      open: true,
+      "onUpdate:open": () => undefined,
+    });
+
+    expect(html).toContain("Noise cancellation");
+    expect(html).toContain("Echo cancellation");
+    expect(html).toContain("Auto gain control");
+    expect(html).toContain("<fieldset");
+    expect(html).toContain("disabled");
+    expect(html).toContain("aria-describedby=\"call-processing-no-mic\"");
+    expect(html).toContain("Requested audio processing");
+    expect(html).toContain("Audio processing");
+  });
+});
+
 async function renderVueComponent(path: string, props: Record<string, unknown>): Promise<string> {
   const component = await loadVueComponent(path);
   return renderToString(createSSRApp({ render: () => h(component, props) }));


### PR DESCRIPTION
Implements #912.

## Completed work

- Added persisted call audio-processing preferences beside mic/cam/speaker device prefs, defaulting all three constraints on.
- Added pure mapping for persisted prefs into LiveKit/browser audio capture options.
- Applied persisted processing prefs when constructing a fresh LiveKit room.
- Added mid-call microphone processing changes via `LocalAudioTrack.restartTrack(...)`, preserving the selected/current mic device and avoiding a Jingle round-trip.
- Refreshed the #911 applied-state indicator immediately after a successful processing restart.
- Added Microphone-section controls for noise cancellation, echo cancellation, and auto gain control near the applied-state readout.
- Kept listener/no-active-mic states sensible by disabling the controls when there is no active microphone, and while a restart is pending.
- Added semantic fieldset/legend labeling for the requested controls and no-mic helper text association.

## Tests

- `bun test`
- `bunx astro check`
- `bun run lint`

## Notes

- This is local browser capture configuration only. It does not change XMPP/Jingle wire behavior or server APIs.
- `bunx astro check` reports one existing hint in `src/lib/xmpp/discovery.ts`; it exits cleanly with zero errors.
