### PR TITLE
refactor(server): use bare JIDs as user principal, drop UUID mapping

### DIFF
--- a/chat/src/lib/server-auth.ts
+++ b/chat/src/lib/server-auth.ts
@@ -2,7 +2,6 @@ import { reportError } from "@/lib/telemetry";
 
 export interface WaddleSession {
   session_id: string;
-  user_id: string;
   username: string;
   avatar_url: string | null;
   xmpp_localpart: string;

--- a/server/crates/waddle-server/src/auth/directory/tests.rs
+++ b/server/crates/waddle-server/src/auth/directory/tests.rs
@@ -23,11 +23,11 @@ async fn seed_oidc_user(actor: &ActorRef<DbActor>, localpart: &str) {
     actor
         .ask(DbExecute {
             sql: "INSERT INTO users \
-                  (id, username, xmpp_localpart, display_name, avatar_url, primary_email, created_at, updated_at) \
+                  (jid, username, xmpp_localpart, display_name, avatar_url, primary_email, created_at, updated_at) \
                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
                 .to_string(),
             params: vec![
-                format!("id-{localpart}").into(),
+                format!("{localpart}@localhost").into(),
                 localpart.into(),
                 localpart.into(),
                 "Test User".into(),

--- a/server/crates/waddle-server/src/auth/identity.rs
+++ b/server/crates/waddle-server/src/auth/identity.rs
@@ -1,4 +1,4 @@
-use crate::auth::{username_to_localpart, AuthError, AuthProviderConfig};
+use crate::auth::{localpart_to_jid, username_to_localpart, AuthError, AuthProviderConfig};
 use kameo::actor::ActorRef;
 
 use crate::db::actor::{DbActor, DbExecute, DbQueryOne};
@@ -23,7 +23,8 @@ pub struct IdentityClaims {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UserRecord {
-    pub id: String,
+    /// Bare JID principal (e.g. `alice@example.com`). Immutable once created.
+    pub jid: String,
     pub username: String,
     pub xmpp_localpart: String,
     pub display_name: Option<String>,
@@ -51,6 +52,7 @@ impl IdentityService {
         &self,
         provider: &AuthProviderConfig,
         claims: &IdentityClaims,
+        domain: &str,
     ) -> Result<LinkedIdentity, AuthError> {
         let subject = claims.subject.trim();
         if subject.is_empty() {
@@ -62,9 +64,9 @@ impl IdentityService {
         let issuer = Self::identity_issuer(provider, claims)?;
 
         if let Some(existing) = self.find_by_issuer_subject(&issuer, subject).await? {
-            let user = self
-                .reconcile_existing_user(provider, claims, &issuer, &existing)
-                .await?;
+            // The bare JID is immutable: reconciliation only refreshes
+            // mutable profile fields, never the localpart/JID/username.
+            let user = self.reconcile_existing_user(claims, &existing).await?;
             self.update_identity_last_login(provider, claims, &issuer, subject)
                 .await?;
             return Ok(LinkedIdentity {
@@ -74,8 +76,8 @@ impl IdentityService {
             });
         }
 
-        let user = self.create_user(provider, claims, &issuer).await?;
-        self.insert_identity(provider, claims, &issuer, &user.id)
+        let user = self.create_user(provider, claims, &issuer, domain).await?;
+        self.insert_identity(provider, claims, &issuer, &user.jid)
             .await?;
 
         Ok(LinkedIdentity {
@@ -112,9 +114,9 @@ impl IdentityService {
         subject: &str,
     ) -> Result<Option<UserRecord>, AuthError> {
         let query = r#"
-            SELECT u.id, u.username, u.xmpp_localpart, u.display_name, u.avatar_url, u.primary_email
+            SELECT u.jid, u.username, u.xmpp_localpart, u.display_name, u.avatar_url, u.primary_email
             FROM auth_identities ai
-            JOIN users u ON u.id = ai.user_id
+            JOIN users u ON u.jid = ai.user_jid
             WHERE ai.issuer = ? AND ai.subject = ?
             LIMIT 1
         "#;
@@ -130,10 +132,10 @@ impl IdentityService {
 
         match row {
             Some(row) => Ok(Some(UserRecord {
-                id: row_value(&row, 0)
+                jid: row_value(&row, 0)
                     .and_then(ValueExt::as_string)
                     .map_err(|e| {
-                        AuthError::DatabaseError(format!("Failed to get user id: {}", e))
+                        AuthError::DatabaseError(format!("Failed to get user jid: {}", e))
                     })?,
                 username: row_value(&row, 1)
                     .and_then(ValueExt::as_string)
@@ -212,6 +214,7 @@ impl IdentityService {
         provider: &AuthProviderConfig,
         claims: &IdentityClaims,
         issuer: &str,
+        domain: &str,
     ) -> Result<UserRecord, AuthError> {
         let base = Self::derive_base_username(provider, claims, issuer);
 
@@ -222,12 +225,13 @@ impl IdentityService {
                 format!("{}{}", base, i)
             };
             let xmpp_localpart = username_to_localpart(&username);
-            let user_id = Uuid::new_v4().to_string();
+            // The bare JID is the immutable principal and primary key.
+            let jid = localpart_to_jid(&xmpp_localpart, domain)?;
             let now = Utc::now().to_rfc3339();
 
             let insert = r#"
                 INSERT INTO users (
-                    id, username, xmpp_localpart, display_name, avatar_url, primary_email, created_at, updated_at
+                    jid, username, xmpp_localpart, display_name, avatar_url, primary_email, created_at, updated_at
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             "#;
 
@@ -236,7 +240,7 @@ impl IdentityService {
                 .ask(DbExecute {
                     sql: insert.to_string(),
                     params: vec![
-                        user_id.clone().into(),
+                        jid.clone().into(),
                         username.clone().into(),
                         xmpp_localpart.clone().into(),
                         claims.name.clone().into(),
@@ -251,7 +255,7 @@ impl IdentityService {
             match result {
                 Ok(_) => {
                     return Ok(UserRecord {
-                        id: user_id,
+                        jid,
                         username,
                         xmpp_localpart,
                         display_name: claims.name.clone(),
@@ -277,72 +281,52 @@ impl IdentityService {
         ))
     }
 
+    /// Refresh the mutable profile fields of an existing user from the
+    /// latest identity claims.
+    ///
+    /// The bare JID is the immutable principal (primary key referenced by
+    /// sessions, identities, messages, and permission tuples), so the
+    /// localpart/JID/username are never rewritten here — only
+    /// `display_name`, `avatar_url`, and `primary_email`.
     async fn reconcile_existing_user(
         &self,
-        provider: &AuthProviderConfig,
         claims: &IdentityClaims,
-        issuer: &str,
         existing: &UserRecord,
     ) -> Result<UserRecord, AuthError> {
-        let base = Self::derive_base_username(provider, claims, issuer);
+        let now = Utc::now().to_rfc3339();
 
-        for i in 0..200 {
-            let username = if i == 0 {
-                base.clone()
-            } else {
-                format!("{}{}", base, i)
-            };
-            let xmpp_localpart = username_to_localpart(&username);
-            let now = Utc::now().to_rfc3339();
+        self.actor
+            .ask(DbExecute {
+                sql: r#"
+                    UPDATE users
+                    SET display_name = ?, avatar_url = ?, primary_email = ?, updated_at = ?
+                    WHERE jid = ?
+                "#
+                .to_string(),
+                params: vec![
+                    claims.name.clone().into(),
+                    claims.avatar_url.clone().into(),
+                    claims.email.clone().into(),
+                    now.into(),
+                    existing.jid.clone().into(),
+                ],
+            })
+            .await
+            .map_err(|err| {
+                AuthError::DatabaseError(format!(
+                    "Failed to update user from identity claims: {}",
+                    err
+                ))
+            })?;
 
-            let result = self
-                .actor
-                .ask(DbExecute {
-                    sql: r#"
-                        UPDATE users
-                        SET username = ?, xmpp_localpart = ?, display_name = ?, avatar_url = ?, primary_email = ?, updated_at = ?
-                        WHERE id = ?
-                    "#
-                    .to_string(),
-                    params: vec![
-                        username.clone().into(),
-                        xmpp_localpart.clone().into(),
-                        claims.name.clone().into(),
-                        claims.avatar_url.clone().into(),
-                        claims.email.clone().into(),
-                        now.clone().into(),
-                        existing.id.clone().into(),
-                    ],
-                })
-                .await;
-
-            match result {
-                Ok(_) => {
-                    return Ok(UserRecord {
-                        id: existing.id.clone(),
-                        username,
-                        xmpp_localpart,
-                        display_name: claims.name.clone(),
-                        avatar_url: claims.avatar_url.clone(),
-                        primary_email: claims.email.clone(),
-                    });
-                }
-                Err(err) => {
-                    let msg = err.to_string();
-                    if msg.contains("UNIQUE") || msg.contains("constraint") {
-                        continue;
-                    }
-                    return Err(AuthError::DatabaseError(format!(
-                        "Failed to update user from identity claims: {}",
-                        err
-                    )));
-                }
-            }
-        }
-
-        Err(AuthError::DatabaseError(
-            "Failed to allocate unique username".to_string(),
-        ))
+        Ok(UserRecord {
+            jid: existing.jid.clone(),
+            username: existing.username.clone(),
+            xmpp_localpart: existing.xmpp_localpart.clone(),
+            display_name: claims.name.clone(),
+            avatar_url: claims.avatar_url.clone(),
+            primary_email: claims.email.clone(),
+        })
     }
 
     async fn insert_identity(
@@ -350,7 +334,7 @@ impl IdentityService {
         provider: &AuthProviderConfig,
         claims: &IdentityClaims,
         issuer: &str,
-        user_id: &str,
+        user_jid: &str,
     ) -> Result<(), AuthError> {
         let now = Utc::now().to_rfc3339();
         let identity_id = Uuid::new_v4().to_string();
@@ -361,14 +345,14 @@ impl IdentityService {
             .ask(DbExecute {
                 sql: r#"
                     INSERT INTO auth_identities (
-                        id, user_id, provider_id, issuer, subject, email, email_verified,
+                        id, user_jid, provider_id, issuer, subject, email, email_verified,
                         raw_claims_json, created_at, last_login_at
                     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 "#
                 .to_string(),
                 params: vec![
                     identity_id.into(),
-                    user_id.into(),
+                    user_jid.into(),
                     provider.id.clone().into(),
                     issuer.into(),
                     claims.subject.clone().into(),

--- a/server/crates/waddle-server/src/auth/identity/tests.rs
+++ b/server/crates/waddle-server/src/auth/identity/tests.rs
@@ -127,7 +127,7 @@ fn issuer_is_normalized_for_identity_mapping() {
 }
 
 #[tokio::test]
-async fn existing_identity_updates_username_and_claims_on_login() {
+async fn existing_identity_keeps_immutable_jid_and_updates_profile_on_login() {
     let db = create_test_db().await;
     let actor = crate::db::actor::DbActor::spawn(crate::db::actor::DbActor::new((*db).clone()));
     let service = IdentityService::new(actor);
@@ -139,11 +139,11 @@ async fn existing_identity_updates_username_and_claims_on_login() {
 
         conn.execute(
             r#"
-            INSERT INTO users (id, username, xmpp_localpart, display_name, avatar_url, primary_email, created_at, updated_at)
+            INSERT INTO users (jid, username, xmpp_localpart, display_name, avatar_url, primary_email, created_at, updated_at)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             "#,
             crate::db_params![
-                "user-1",
+                "example.person@waddle.test",
                 "example.person",
                 "example.person",
                 "Example Person",
@@ -159,13 +159,13 @@ async fn existing_identity_updates_username_and_claims_on_login() {
         conn.execute(
             r#"
             INSERT INTO auth_identities (
-                id, user_id, provider_id, issuer, subject, email, email_verified,
+                id, user_jid, provider_id, issuer, subject, email, email_verified,
                 raw_claims_json, created_at, last_login_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             "#,
             crate::db_params![
                 "identity-1",
-                "user-1",
+                "example.person@waddle.test",
                 "provider",
                 "https://issuer.example",
                 "sub-1234",
@@ -180,6 +180,9 @@ async fn existing_identity_updates_username_and_claims_on_login() {
         .expect("insert identity");
     }
 
+    // The IDP now reports a different preferred username, display name, and
+    // email. The bare JID is immutable, so the localpart/username/JID must
+    // NOT change; only the mutable profile fields are refreshed.
     let mut claims = claims();
     claims.preferred_username = Some("rawkode".to_string());
     claims.name = Some("Rawkode".to_string());
@@ -190,26 +193,29 @@ async fn existing_identity_updates_username_and_claims_on_login() {
     });
 
     let linked = service
-        .resolve_or_create_user(&provider, &claims)
+        .resolve_or_create_user(&provider, &claims, "waddle.test")
         .await
         .expect("resolve identity");
-    assert_eq!(linked.user.username, "rawkode");
-    assert_eq!(linked.user.xmpp_localpart, "rawkode");
+    assert_eq!(linked.user.jid, "example.person@waddle.test");
+    assert_eq!(linked.user.username, "example.person");
+    assert_eq!(linked.user.xmpp_localpart, "example.person");
 
     let conn = db.guard().await.expect("db guard");
     let mut rows = conn
         .query(
-            "SELECT username, xmpp_localpart, primary_email FROM users WHERE id = ?",
-            crate::db_params!["user-1"],
+            "SELECT username, xmpp_localpart, display_name, primary_email FROM users WHERE jid = ?",
+            crate::db_params!["example.person@waddle.test"],
         )
         .await
         .expect("query user");
     let row = rows.next().await.expect("read row").expect("row exists");
     let username: String = row.get(0).expect("username");
     let xmpp_localpart: String = row.get(1).expect("xmpp_localpart");
-    let primary_email: Option<String> = row.get(2).expect("primary_email");
-    assert_eq!(username, "rawkode");
-    assert_eq!(xmpp_localpart, "rawkode");
+    let display_name: Option<String> = row.get(2).expect("display_name");
+    let primary_email: Option<String> = row.get(3).expect("primary_email");
+    assert_eq!(username, "example.person");
+    assert_eq!(xmpp_localpart, "example.person");
+    assert_eq!(display_name.as_deref(), Some("Rawkode"));
     assert_eq!(primary_email.as_deref(), Some("rawkode@waddle.social"));
 
     let mut rows = conn
@@ -227,7 +233,7 @@ async fn existing_identity_updates_username_and_claims_on_login() {
 }
 
 #[tokio::test]
-async fn existing_identity_uses_suffix_when_username_conflicts() {
+async fn existing_identity_keeps_username_even_when_claim_conflicts() {
     let db = create_test_db().await;
     let actor = crate::db::actor::DbActor::spawn(crate::db::actor::DbActor::new((*db).clone()));
     let service = IdentityService::new(actor);
@@ -239,11 +245,11 @@ async fn existing_identity_uses_suffix_when_username_conflicts() {
 
         conn.execute(
             r#"
-            INSERT INTO users (id, username, xmpp_localpart, created_at, updated_at)
+            INSERT INTO users (jid, username, xmpp_localpart, created_at, updated_at)
             VALUES (?, ?, ?, ?, ?)
             "#,
             crate::db_params![
-                "user-conflict",
+                "rawkode@waddle.test",
                 "rawkode",
                 "rawkode",
                 now.as_str(),
@@ -255,11 +261,11 @@ async fn existing_identity_uses_suffix_when_username_conflicts() {
 
         conn.execute(
             r#"
-            INSERT INTO users (id, username, xmpp_localpart, created_at, updated_at)
+            INSERT INTO users (jid, username, xmpp_localpart, created_at, updated_at)
             VALUES (?, ?, ?, ?, ?)
             "#,
             crate::db_params![
-                "user-1",
+                "example.person@waddle.test",
                 "example.person",
                 "example.person",
                 now.as_str(),
@@ -272,12 +278,12 @@ async fn existing_identity_uses_suffix_when_username_conflicts() {
         conn.execute(
             r#"
             INSERT INTO auth_identities (
-                id, user_id, provider_id, issuer, subject, raw_claims_json, created_at, last_login_at
+                id, user_jid, provider_id, issuer, subject, raw_claims_json, created_at, last_login_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             "#,
             crate::db_params![
                 "identity-1",
-                "user-1",
+                "example.person@waddle.test",
                 "provider",
                 "https://issuer.example",
                 "sub-1234",
@@ -290,6 +296,9 @@ async fn existing_identity_uses_suffix_when_username_conflicts() {
         .expect("insert identity");
     }
 
+    // Even though the IDP now reports `rawkode` (which collides with another
+    // user), the existing identity's immutable JID/username are preserved —
+    // there is no username reallocation on login anymore.
     let mut claims = claims();
     claims.preferred_username = Some("rawkode".to_string());
     claims.raw_claims = json!({
@@ -298,9 +307,10 @@ async fn existing_identity_uses_suffix_when_username_conflicts() {
     });
 
     let linked = service
-        .resolve_or_create_user(&provider, &claims)
+        .resolve_or_create_user(&provider, &claims, "waddle.test")
         .await
         .expect("resolve identity");
-    assert_eq!(linked.user.username, "rawkode1");
-    assert_eq!(linked.user.xmpp_localpart, "rawkode1");
+    assert_eq!(linked.user.jid, "example.person@waddle.test");
+    assert_eq!(linked.user.username, "example.person");
+    assert_eq!(linked.user.xmpp_localpart, "example.person");
 }

--- a/server/crates/waddle-server/src/auth/session.rs
+++ b/server/crates/waddle-server/src/auth/session.rs
@@ -21,8 +21,8 @@ type HmacSha256 = Hmac<Sha256>;
 pub struct Session {
     /// Opaque session token and database id.
     pub id: String,
-    /// Internal UUID principal.
-    pub user_id: String,
+    /// Bare JID principal (e.g. `alice@example.com`). Immutable.
+    pub user_jid: String,
     /// Immutable username.
     pub username: String,
     /// Immutable xmpp localpart.
@@ -34,10 +34,10 @@ pub struct Session {
 }
 
 impl Session {
-    pub fn new(user_id: &str, username: &str, xmpp_localpart: &str) -> Self {
+    pub fn new(user_jid: &str, username: &str, xmpp_localpart: &str) -> Self {
         Self {
             id: Uuid::new_v4().to_string(),
-            user_id: user_id.to_string(),
+            user_jid: user_jid.to_string(),
             username: username.to_string(),
             xmpp_localpart: xmpp_localpart.to_string(),
             // 30-day session by default.
@@ -99,7 +99,7 @@ impl SessionManager {
         self.actor
             .ask(CreateAuthSession {
                 session_id: session.id.clone(),
-                user_id: session.user_id.clone(),
+                user_jid: session.user_jid.clone(),
                 username: session.username.clone(),
                 xmpp_localpart: session.xmpp_localpart.clone(),
                 token_hash,
@@ -110,7 +110,7 @@ impl SessionManager {
             .await
             .map_err(Self::ask_err)?;
 
-        debug!(session_id = %session.id, user_id = %session.user_id, "Session created");
+        debug!(session_id = %session.id, user_jid = %session.user_jid, "Session created");
         Ok(())
     }
 
@@ -133,9 +133,9 @@ impl SessionManager {
         let id = row_value(row, 0)
             .and_then(ValueExt::as_string)
             .map_err(|e| AuthError::DatabaseError(format!("Failed to get session id: {}", e)))?;
-        let user_id = row_value(row, 1)
+        let user_jid = row_value(row, 1)
             .and_then(ValueExt::as_string)
-            .map_err(|e| AuthError::DatabaseError(format!("Failed to get user id: {}", e)))?;
+            .map_err(|e| AuthError::DatabaseError(format!("Failed to get user jid: {}", e)))?;
         let token_hash = row_value(row, 2)
             .and_then(ValueExt::as_string)
             .map_err(|e| AuthError::DatabaseError(format!("Failed to get token hash: {}", e)))?;
@@ -175,7 +175,7 @@ impl SessionManager {
 
         Ok(Session {
             id,
-            user_id,
+            user_jid,
             username,
             xmpp_localpart,
             expires_at,
@@ -187,10 +187,10 @@ impl SessionManager {
     #[instrument(skip(self))]
     pub async fn get_session(&self, session_id: &str) -> Result<Option<Session>, AuthError> {
         let sql = r#"
-            SELECT s.id, s.user_id, s.token_hash, s.expires_at, s.created_at, s.last_used_at,
+            SELECT s.id, s.user_jid, s.token_hash, s.expires_at, s.created_at, s.last_used_at,
                    u.username, u.xmpp_localpart
             FROM sessions s
-            JOIN users u ON u.id = s.user_id
+            JOIN users u ON u.jid = s.user_jid
             WHERE s.id = ?
             LIMIT 1
         "#
@@ -275,10 +275,10 @@ mod tests {
         let actor = DbActor::spawn(DbActor::new(db.clone()));
         let manager = SessionManager::new(actor, Some(b"test-session-key"));
 
-        let first = Session::new("user-1", "alice", "alice");
+        let first = Session::new("alice@example.com", "alice", "alice");
         manager.create_session(&first).await.expect("first session");
 
-        let second = Session::new("user-1", "alice", "alice");
+        let second = Session::new("alice@example.com", "alice", "alice");
         manager
             .create_session(&second)
             .await
@@ -290,7 +290,7 @@ mod tests {
             .expect("load session")
             .expect("session exists");
 
-        assert_eq!(loaded.user_id, "user-1");
+        assert_eq!(loaded.user_jid, "alice@example.com");
         assert_eq!(loaded.username, "alice");
         assert_eq!(loaded.xmpp_localpart, "alice");
     }

--- a/server/crates/waddle-server/src/db/actor.rs
+++ b/server/crates/waddle-server/src/db/actor.rs
@@ -63,7 +63,7 @@ impl kameo::message::Message<DbExecute> for DbActor {
 
 pub struct CreateAuthSession {
     pub session_id: String,
-    pub user_id: String,
+    pub user_jid: String,
     pub username: String,
     pub xmpp_localpart: String,
     pub token_hash: String,
@@ -88,12 +88,12 @@ impl kameo::message::Message<CreateAuthSession> for DbActor {
 
                 query(
                     r#"
-                    INSERT INTO users (id, username, xmpp_localpart, created_at, updated_at)
+                    INSERT INTO users (jid, username, xmpp_localpart, created_at, updated_at)
                     VALUES (?, ?, ?, ?, ?)
                     ON CONFLICT DO NOTHING
                     "#,
                 )
-                .bind(&msg.user_id)
+                .bind(&msg.user_jid)
                 .bind(&msg.username)
                 .bind(&msg.xmpp_localpart)
                 .bind(msg.created_at.clone())
@@ -103,12 +103,12 @@ impl kameo::message::Message<CreateAuthSession> for DbActor {
 
                 query(
                     r#"
-                    INSERT INTO sessions (id, user_id, token_hash, expires_at, created_at, last_used_at)
+                    INSERT INTO sessions (id, user_jid, token_hash, expires_at, created_at, last_used_at)
                     VALUES (?, ?, ?, ?, ?, ?)
                     "#,
                 )
                 .bind(&msg.session_id)
-                .bind(&msg.user_id)
+                .bind(&msg.user_jid)
                 .bind(&msg.token_hash)
                 .bind(&msg.expires_at)
                 .bind(&msg.created_at)
@@ -123,12 +123,12 @@ impl kameo::message::Message<CreateAuthSession> for DbActor {
 
                 query(
                     r#"
-                    INSERT INTO users (id, username, xmpp_localpart, created_at, updated_at)
+                    INSERT INTO users (jid, username, xmpp_localpart, created_at, updated_at)
                     VALUES ($1, $2, $3, $4, $5)
                     ON CONFLICT DO NOTHING
                     "#,
                 )
-                .bind(&msg.user_id)
+                .bind(&msg.user_jid)
                 .bind(&msg.username)
                 .bind(&msg.xmpp_localpart)
                 .bind(msg.created_at.clone())
@@ -138,12 +138,12 @@ impl kameo::message::Message<CreateAuthSession> for DbActor {
 
                 query(
                     r#"
-                    INSERT INTO sessions (id, user_id, token_hash, expires_at, created_at, last_used_at)
+                    INSERT INTO sessions (id, user_jid, token_hash, expires_at, created_at, last_used_at)
                     VALUES ($1, $2, $3, $4, $5, $6)
                     "#,
                 )
                 .bind(&msg.session_id)
-                .bind(&msg.user_id)
+                .bind(&msg.user_jid)
                 .bind(&msg.token_hash)
                 .bind(&msg.expires_at)
                 .bind(&msg.created_at)

--- a/server/crates/waddle-server/src/db/migrations/global.rs
+++ b/server/crates/waddle-server/src/db/migrations/global.rs
@@ -19,7 +19,7 @@ DROP TABLE IF EXISTS private_xml_storage;
 DROP TABLE IF EXISTS provider_webhook_deliveries;
 
 CREATE TABLE users (
-    id TEXT PRIMARY KEY,
+    jid TEXT PRIMARY KEY,
     username TEXT NOT NULL UNIQUE,
     xmpp_localpart TEXT NOT NULL UNIQUE,
     display_name TEXT,
@@ -31,7 +31,7 @@ CREATE TABLE users (
 
 CREATE TABLE auth_identities (
     id TEXT PRIMARY KEY,
-    user_id TEXT NOT NULL,
+    user_jid TEXT NOT NULL,
     provider_id TEXT NOT NULL,
     issuer TEXT NOT NULL,
     subject TEXT NOT NULL,
@@ -41,22 +41,22 @@ CREATE TABLE auth_identities (
     created_at TEXT NOT NULL,
     last_login_at TEXT NOT NULL,
     UNIQUE(issuer, subject),
-    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    FOREIGN KEY (user_jid) REFERENCES users(jid) ON DELETE CASCADE
 );
 
-CREATE INDEX idx_auth_identities_user_id ON auth_identities(user_id);
+CREATE INDEX idx_auth_identities_user_jid ON auth_identities(user_jid);
 
 CREATE TABLE sessions (
     id TEXT PRIMARY KEY,
-    user_id TEXT NOT NULL,
+    user_jid TEXT NOT NULL,
     token_hash TEXT NOT NULL UNIQUE,
     expires_at TEXT,
     created_at TEXT NOT NULL,
     last_used_at TEXT NOT NULL,
-    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    FOREIGN KEY (user_jid) REFERENCES users(jid) ON DELETE CASCADE
 );
 
-CREATE INDEX idx_sessions_user_id ON sessions(user_id);
+CREATE INDEX idx_sessions_user_jid ON sessions(user_jid);
 CREATE INDEX idx_sessions_expires_at ON sessions(expires_at);
 
 CREATE TABLE permission_tuples (
@@ -189,7 +189,7 @@ DROP TABLE IF EXISTS private_xml_storage CASCADE;
 DROP TABLE IF EXISTS provider_webhook_deliveries CASCADE;
 
 CREATE TABLE users (
-    id TEXT PRIMARY KEY,
+    jid TEXT PRIMARY KEY,
     username TEXT NOT NULL UNIQUE,
     xmpp_localpart TEXT NOT NULL UNIQUE,
     display_name TEXT,
@@ -201,7 +201,7 @@ CREATE TABLE users (
 
 CREATE TABLE auth_identities (
     id TEXT PRIMARY KEY,
-    user_id TEXT NOT NULL,
+    user_jid TEXT NOT NULL,
     provider_id TEXT NOT NULL,
     issuer TEXT NOT NULL,
     subject TEXT NOT NULL,
@@ -211,22 +211,22 @@ CREATE TABLE auth_identities (
     created_at TEXT NOT NULL,
     last_login_at TEXT NOT NULL,
     UNIQUE(issuer, subject),
-    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    FOREIGN KEY (user_jid) REFERENCES users(jid) ON DELETE CASCADE
 );
 
-CREATE INDEX idx_auth_identities_user_id ON auth_identities(user_id);
+CREATE INDEX idx_auth_identities_user_jid ON auth_identities(user_jid);
 
 CREATE TABLE sessions (
     id TEXT PRIMARY KEY,
-    user_id TEXT NOT NULL,
+    user_jid TEXT NOT NULL,
     token_hash TEXT NOT NULL UNIQUE,
     expires_at TEXT,
     created_at TEXT NOT NULL,
     last_used_at TEXT NOT NULL,
-    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    FOREIGN KEY (user_jid) REFERENCES users(jid) ON DELETE CASCADE
 );
 
-CREATE INDEX idx_sessions_user_id ON sessions(user_id);
+CREATE INDEX idx_sessions_user_jid ON sessions(user_jid);
 CREATE INDEX idx_sessions_expires_at ON sessions(expires_at);
 
 CREATE TABLE permission_tuples (

--- a/server/crates/waddle-server/src/db/migrations/tests.rs
+++ b/server/crates/waddle-server/src/db/migrations/tests.rs
@@ -101,7 +101,7 @@ async fn test_waddle_v1002_adds_pin_permission_to_existing_v1001_schema() {
     .await
     .unwrap();
     conn.execute(
-        "INSERT INTO _migrations (version, description) VALUES (1001, 'Hard-cut per-waddle schema with user_id principals')",
+        "INSERT INTO _migrations (version, description) VALUES (1001, 'Hard-cut per-waddle schema with bare-JID principals')",
         (),
     )
     .await

--- a/server/crates/waddle-server/src/db/migrations/waddle.rs
+++ b/server/crates/waddle-server/src/db/migrations/waddle.rs
@@ -1,6 +1,6 @@
 use super::Migration;
 
-/// Hard-cut per-waddle schema with UUID user principals.
+/// Hard-cut per-waddle schema with bare-JID user principals.
 pub const V0001_SCHEMA: &str = r#"
 PRAGMA foreign_keys = OFF;
 
@@ -25,7 +25,7 @@ CREATE INDEX idx_channels_position ON channels(position);
 CREATE TABLE messages (
     id TEXT PRIMARY KEY,
     channel_id TEXT NOT NULL,
-    author_user_id TEXT NOT NULL,
+    author_jid TEXT NOT NULL,
     content TEXT,
     reply_to_id TEXT,
     thread_id TEXT,
@@ -37,7 +37,7 @@ CREATE TABLE messages (
 );
 
 CREATE INDEX idx_messages_channel_id ON messages(channel_id);
-CREATE INDEX idx_messages_author_user_id ON messages(author_user_id);
+CREATE INDEX idx_messages_author_jid ON messages(author_jid);
 CREATE INDEX idx_messages_created_at ON messages(created_at);
 CREATE INDEX idx_messages_reply_to_id ON messages(reply_to_id);
 CREATE INDEX idx_messages_thread ON messages(thread_id, created_at);
@@ -47,10 +47,10 @@ CREATE INDEX idx_messages_expires ON messages(expires_at) WHERE expires_at IS NO
 CREATE TABLE reactions (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     message_id TEXT NOT NULL,
-    user_id TEXT NOT NULL,
+    user_jid TEXT NOT NULL,
     emoji TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
-    UNIQUE(message_id, user_id, emoji),
+    UNIQUE(message_id, user_jid, emoji),
     FOREIGN KEY (message_id) REFERENCES messages(id) ON DELETE CASCADE
 );
 
@@ -72,7 +72,7 @@ CREATE INDEX idx_attachments_message_id ON attachments(message_id);
 PRAGMA foreign_keys = ON;
 "#;
 
-/// Hard-cut per-waddle schema with UUID user principals — Postgres dialect.
+/// Hard-cut per-waddle schema with bare-JID user principals — Postgres dialect.
 pub const V0001_SCHEMA_POSTGRES: &str = r#"
 DROP TABLE IF EXISTS attachments CASCADE;
 DROP TABLE IF EXISTS reactions CASCADE;
@@ -95,7 +95,7 @@ CREATE INDEX idx_channels_position ON channels(position);
 CREATE TABLE messages (
     id TEXT PRIMARY KEY,
     channel_id TEXT NOT NULL,
-    author_user_id TEXT NOT NULL,
+    author_jid TEXT NOT NULL,
     content TEXT,
     reply_to_id TEXT,
     thread_id TEXT,
@@ -107,7 +107,7 @@ CREATE TABLE messages (
 );
 
 CREATE INDEX idx_messages_channel_id ON messages(channel_id);
-CREATE INDEX idx_messages_author_user_id ON messages(author_user_id);
+CREATE INDEX idx_messages_author_jid ON messages(author_jid);
 CREATE INDEX idx_messages_created_at ON messages(created_at);
 CREATE INDEX idx_messages_reply_to_id ON messages(reply_to_id);
 CREATE INDEX idx_messages_thread ON messages(thread_id, created_at);
@@ -117,10 +117,10 @@ CREATE INDEX idx_messages_expires ON messages(expires_at) WHERE expires_at IS NO
 CREATE TABLE reactions (
     id BIGSERIAL PRIMARY KEY,
     message_id TEXT NOT NULL,
-    user_id TEXT NOT NULL,
+    user_jid TEXT NOT NULL,
     emoji TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP::TEXT,
-    UNIQUE(message_id, user_id, emoji),
+    UNIQUE(message_id, user_jid, emoji),
     FOREIGN KEY (message_id) REFERENCES messages(id) ON DELETE CASCADE
 );
 
@@ -224,7 +224,7 @@ pub fn all() -> Vec<Migration> {
     vec![
         Migration {
             version: 1001,
-            description: "Hard-cut per-waddle schema with user_id principals".to_string(),
+            description: "Hard-cut per-waddle schema with bare-JID principals".to_string(),
             sql_sqlite: V0001_SCHEMA,
             sql_postgres: V0001_SCHEMA_POSTGRES,
         },

--- a/server/crates/waddle-server/src/messages/mod.rs
+++ b/server/crates/waddle-server/src/messages/mod.rs
@@ -106,13 +106,13 @@ mod tests {
         // Create a message
         let create = MessageCreate::new(
             "channel-123".to_string(),
-            "user-alice".to_string(),
+            "alice@example.com".to_string(),
             "Hello, world!".to_string(),
         );
 
         let message = repo.create(create).await.unwrap();
         assert_eq!(message.content, Some("Hello, world!".to_string()));
-        assert_eq!(message.author_user_id, "user-alice");
+        assert_eq!(message.author_jid, "alice@example.com");
         assert_eq!(message.channel_id, "channel-123");
 
         // Get the message by ID
@@ -144,7 +144,7 @@ mod tests {
         for i in 0..10 {
             let create = MessageCreate::new(
                 "channel-test".to_string(),
-                "user-alice".to_string(),
+                "alice@example.com".to_string(),
                 format!("Message {}", i),
             );
             repo.create(create).await.unwrap();

--- a/server/crates/waddle-server/src/messages/repository.rs
+++ b/server/crates/waddle-server/src/messages/repository.rs
@@ -42,7 +42,7 @@ impl MessageRepository {
             .ask(DbExecute {
                 sql: r#"
                     INSERT INTO messages (
-                        id, channel_id, author_user_id, content, reply_to_id, thread_id,
+                        id, channel_id, author_jid, content, reply_to_id, thread_id,
                         flags, edited_at, created_at, expires_at
                     ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)
                 "#
@@ -50,7 +50,7 @@ impl MessageRepository {
                 params: vec![
                     id.clone().into(),
                     create.channel_id.clone().into(),
-                    create.author_user_id.clone().into(),
+                    create.author_jid.clone().into(),
                     content.clone().into(),
                     create.reply_to_id.clone().into(),
                     create.thread_id.clone().into(),
@@ -67,7 +67,7 @@ impl MessageRepository {
         Ok(Message {
             id,
             channel_id: create.channel_id,
-            author_user_id: create.author_user_id,
+            author_jid: create.author_jid,
             content: Some(content),
             reply_to_id: create.reply_to_id,
             thread_id: create.thread_id,
@@ -81,7 +81,7 @@ impl MessageRepository {
     #[instrument(skip(self))]
     pub async fn get_by_id(&self, id: &str) -> Result<Option<Message>, MessageError> {
         let query = r#"
-            SELECT id, channel_id, author_user_id, content, reply_to_id, thread_id,
+            SELECT id, channel_id, author_jid, content, reply_to_id, thread_id,
                    flags, edited_at, created_at, expires_at
             FROM messages
             WHERE id = ?
@@ -142,7 +142,7 @@ impl MessageRepository {
 
                 (
                     r#"
-                    SELECT id, channel_id, author_user_id, content, reply_to_id, thread_id,
+                    SELECT id, channel_id, author_jid, content, reply_to_id, thread_id,
                            flags, edited_at, created_at, expires_at
                     FROM messages
                     WHERE channel_id = ? AND created_at < ?
@@ -158,7 +158,7 @@ impl MessageRepository {
             }
             None => (
                 r#"
-                SELECT id, channel_id, author_user_id, content, reply_to_id, thread_id,
+                SELECT id, channel_id, author_jid, content, reply_to_id, thread_id,
                        flags, edited_at, created_at, expires_at
                 FROM messages
                 WHERE channel_id = ?
@@ -273,11 +273,9 @@ impl MessageRepository {
             .and_then(ValueExt::as_string)
             .map_err(|e| MessageError::DatabaseError(format!("Failed to get channel_id: {}", e)))?;
 
-        let author_user_id = row_value(row, 2)
+        let author_jid = row_value(row, 2)
             .and_then(ValueExt::as_string)
-            .map_err(|e| {
-                MessageError::DatabaseError(format!("Failed to get author_user_id: {}", e))
-            })?;
+            .map_err(|e| MessageError::DatabaseError(format!("Failed to get author_jid: {}", e)))?;
 
         let content = row_value(row, 3)
             .and_then(ValueExt::as_optional_string)
@@ -334,7 +332,7 @@ impl MessageRepository {
         Ok(Message {
             id,
             channel_id,
-            author_user_id,
+            author_jid,
             content,
             reply_to_id,
             thread_id,

--- a/server/crates/waddle-server/src/messages/types.rs
+++ b/server/crates/waddle-server/src/messages/types.rs
@@ -103,7 +103,7 @@ impl From<i64> for MessageFlags {
 pub struct Message {
     pub id: String,
     pub channel_id: String,
-    pub author_user_id: String,
+    pub author_jid: String,
     pub content: Option<String>,
     pub reply_to_id: Option<String>,
     pub thread_id: Option<String>,
@@ -154,7 +154,7 @@ impl Message {
 #[derive(Debug, Clone)]
 pub struct MessageCreate {
     pub channel_id: String,
-    pub author_user_id: String,
+    pub author_jid: String,
     pub content: String,
     pub reply_to_id: Option<String>,
     pub thread_id: Option<String>,
@@ -163,10 +163,10 @@ pub struct MessageCreate {
 }
 
 impl MessageCreate {
-    pub fn new(channel_id: String, author_user_id: String, content: String) -> Self {
+    pub fn new(channel_id: String, author_jid: String, content: String) -> Self {
         Self {
             channel_id,
-            author_user_id,
+            author_jid,
             content,
             reply_to_id: None,
             thread_id: None,
@@ -353,7 +353,7 @@ mod tests {
         let message = Message {
             id: "msg-123".to_string(),
             channel_id: "channel-456".to_string(),
-            author_user_id: "user-alice".to_string(),
+            author_jid: "alice@example.com".to_string(),
             content: Some("Hello".to_string()),
             reply_to_id: Some("msg-parent".to_string()),
             thread_id: Some("thread-root".to_string()),

--- a/server/crates/waddle-server/src/permissions/spicedb.rs
+++ b/server/crates/waddle-server/src/permissions/spicedb.rs
@@ -149,7 +149,10 @@ impl SpiceDbPermissionBackend {
             let item = item.map_err(map_spicedb_error)?;
             match item.permission {
                 PermissionResult::Allowed => {
-                    resources.push(Object::new(object_type, item.resource_id));
+                    resources.push(Object::new(
+                        object_type,
+                        decode_spicedb_id(&item.resource_id),
+                    ));
                 }
                 PermissionResult::Denied => {}
                 PermissionResult::Conditional { missing_fields } => {
@@ -182,7 +185,7 @@ impl SpiceDbPermissionBackend {
                 PermissionResult::Allowed => {
                     subjects.push(Subject {
                         subject_type,
-                        id: item.subject_id,
+                        id: decode_spicedb_id(&item.subject_id),
                         relation: None,
                     });
                 }
@@ -230,14 +233,34 @@ fn map_spicedb_error(error: prescience::Error) -> PermissionError {
     }
 }
 
+/// SpiceDB object IDs disallow `@`. Bare JIDs are the user principal, so at
+/// the SpiceDB wire boundary every id has `@` encoded as `|` on the way out
+/// and decoded back on the way in. `|` does not occur in the ids Waddle
+/// produces, so the transform round-trips losslessly.
+fn encode_spicedb_id(id: &str) -> String {
+    id.replace('@', "|")
+}
+
+/// Inverse of [`encode_spicedb_id`]: restore `@` from `|` for ids read back
+/// from SpiceDB.
+fn decode_spicedb_id(id: &str) -> String {
+    id.replace('|', "@")
+}
+
 fn object_reference(object: &Object) -> Result<ObjectReference, PermissionError> {
-    ObjectReference::new(object.object_type.to_string(), object.id.clone())
-        .map_err(|e| PermissionError::InvalidObject(e.to_string()))
+    ObjectReference::new(
+        object.object_type.to_string(),
+        encode_spicedb_id(&object.id),
+    )
+    .map_err(|e| PermissionError::InvalidObject(e.to_string()))
 }
 
 fn subject_reference(subject: &Subject) -> Result<SubjectReference, PermissionError> {
-    let object = ObjectReference::new(subject.subject_type.to_string(), subject.id.clone())
-        .map_err(|e| PermissionError::InvalidSubject(e.to_string()))?;
+    let object = ObjectReference::new(
+        subject.subject_type.to_string(),
+        encode_spicedb_id(&subject.id),
+    )
+    .map_err(|e| PermissionError::InvalidSubject(e.to_string()))?;
     SubjectReference::new(object, subject.relation.clone())
         .map_err(|e| PermissionError::InvalidSubject(e.to_string()))
 }
@@ -247,7 +270,7 @@ fn subject_from_reference(reference: &SubjectReference) -> Result<Subject, Permi
         .map_err(|e| PermissionError::InvalidSubject(e.to_string()))?;
     Ok(Subject {
         subject_type,
-        id: reference.object().object_id().to_string(),
+        id: decode_spicedb_id(reference.object().object_id()),
         relation: reference.optional_relation().map(ToString::to_string),
     })
 }
@@ -263,29 +286,57 @@ fn relationship_from_tuple(tuple: &Tuple) -> Result<Relationship, PermissionErro
 fn exact_relationship_filter(tuple: &Tuple) -> RelationshipFilter {
     let subject_filter = subject_filter(&tuple.subject);
     RelationshipFilter::new(tuple.object.object_type.to_string())
-        .resource_id(tuple.object.id.clone())
+        .resource_id(encode_spicedb_id(&tuple.object.id))
         .relation(tuple.relation.name.clone())
         .subject_filter(subject_filter)
 }
 
 fn filter_for_object_and_subject(object: &Object, subject: &Subject) -> RelationshipFilter {
     RelationshipFilter::new(object.object_type.to_string())
-        .resource_id(object.id.clone())
+        .resource_id(encode_spicedb_id(&object.id))
         .subject_filter(subject_filter(subject))
 }
 
 fn filter_for_object_and_relation(object: &Object, relation: &str) -> RelationshipFilter {
     RelationshipFilter::new(object.object_type.to_string())
-        .resource_id(object.id.clone())
+        .resource_id(encode_spicedb_id(&object.id))
         .relation(relation.to_string())
 }
 
 fn subject_filter(subject: &Subject) -> SubjectFilter {
-    let filter =
-        SubjectFilter::new(subject.subject_type.to_string()).subject_id(subject.id.clone());
+    let filter = SubjectFilter::new(subject.subject_type.to_string())
+        .subject_id(encode_spicedb_id(&subject.id));
     if let Some(relation) = &subject.relation {
         filter.relation(relation.clone())
     } else {
         filter
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{decode_spicedb_id, encode_spicedb_id};
+
+    #[test]
+    fn bare_jid_round_trips_through_pipe_encoding() {
+        let jid = "alice@example.com";
+        let encoded = encode_spicedb_id(jid);
+        assert_eq!(encoded, "alice|example.com");
+        assert_eq!(decode_spicedb_id(&encoded), jid);
+    }
+
+    #[test]
+    fn ids_without_at_are_unchanged() {
+        // Channel/space ids that carry no `@` survive the boundary intact.
+        assert_eq!(encode_spicedb_id("penguin-club"), "penguin-club");
+        assert_eq!(decode_spicedb_id("penguin-club"), "penguin-club");
+    }
+
+    #[test]
+    fn muc_room_jid_round_trips() {
+        let room = "general@conference.example.com";
+        let encoded = encode_spicedb_id(room);
+        assert_eq!(encoded, "general|conference.example.com");
+        assert_eq!(decode_spicedb_id(&encoded), room);
     }
 }

--- a/server/crates/waddle-server/src/server/bootstrap_membership.rs
+++ b/server/crates/waddle-server/src/server/bootstrap_membership.rs
@@ -86,17 +86,17 @@ fn normalize_localpart(value: &str) -> Option<String> {
 pub async fn provision_user_membership(
     permission_actor: &ActorRef<PermissionActor>,
     config: &BootstrapMembershipConfig,
-    user_id: &str,
+    user_jid: &str,
     xmpp_localpart: &str,
 ) -> Result<(), String> {
-    let subject = Subject::user(user_id);
+    let subject = Subject::user(user_jid);
     if config.is_owner(xmpp_localpart) {
         let object = Object::new(ObjectType::Server, config.server_id.as_str());
         let tuple = Tuple::new(object, Relation::new("owner"), subject);
         write_tuple_if_absent(permission_actor, tuple).await?;
 
         debug!(
-            user_id = %user_id,
+            user_jid = %user_jid,
             xmpp_localpart = %xmpp_localpart,
             relation = "owner",
             "Provisioned deployment owner membership"
@@ -109,7 +109,7 @@ pub async fn provision_user_membership(
     write_tuple_if_absent(permission_actor, tuple).await?;
 
     debug!(
-        user_id = %user_id,
+        user_jid = %user_jid,
         xmpp_localpart = %xmpp_localpart,
         relation = "member",
         "Provisioned bootstrap membership"
@@ -120,14 +120,14 @@ pub async fn provision_user_membership(
 pub async fn reconcile_user_membership(
     permission_actor: &ActorRef<PermissionActor>,
     config: &BootstrapMembershipConfig,
-    user_id: &str,
+    user_jid: &str,
     xmpp_localpart: &str,
 ) -> Result<(), String> {
     if config.is_owner(xmpp_localpart) {
-        return provision_user_membership(permission_actor, config, user_id, xmpp_localpart).await;
+        return provision_user_membership(permission_actor, config, user_jid, xmpp_localpart).await;
     }
 
-    let subject = Subject::user(user_id);
+    let subject = Subject::user(user_jid);
     let object = Object::new(ObjectType::Server, config.server_id.as_str());
     for permission in [Permission::Owner, Permission::Admin, Permission::Member] {
         let response = permission_actor
@@ -143,7 +143,7 @@ pub async fn reconcile_user_membership(
         }
     }
 
-    provision_user_membership(permission_actor, config, user_id, xmpp_localpart).await
+    provision_user_membership(permission_actor, config, user_jid, xmpp_localpart).await
 }
 
 async fn write_tuple_if_absent(
@@ -173,20 +173,20 @@ pub async fn reconcile_existing_accounts(
 ) -> Result<(), String> {
     let users = db_actor
         .ask(DbQuery {
-            sql: "SELECT id, xmpp_localpart FROM users".to_string(),
+            sql: "SELECT jid, xmpp_localpart FROM users".to_string(),
             params: vec![],
         })
         .await
         .map_err(|err| format!("failed listing users for membership bootstrap: {err}"))?;
 
     for row in users {
-        let user_id = row_value(&row, 0)
+        let user_jid = row_value(&row, 0)
             .and_then(ValueExt::as_string)
-            .map_err(|err| format!("failed decoding user id: {err}"))?;
+            .map_err(|err| format!("failed decoding user jid: {err}"))?;
         let localpart = row_value(&row, 1)
             .and_then(ValueExt::as_string)
             .map_err(|err| format!("failed decoding user localpart: {err}"))?;
-        reconcile_user_membership(permission_actor, config, &user_id, &localpart).await?;
+        reconcile_user_membership(permission_actor, config, &user_jid, &localpart).await?;
     }
 
     let native_users = db_actor
@@ -204,8 +204,8 @@ pub async fn reconcile_existing_accounts(
         let domain = row_value(&row, 1)
             .and_then(ValueExt::as_string)
             .map_err(|err| format!("failed decoding native domain: {err}"))?;
-        let user_id = format!("{username}@{domain}");
-        reconcile_user_membership(permission_actor, config, &user_id, &username).await?;
+        let user_jid = format!("{username}@{domain}");
+        reconcile_user_membership(permission_actor, config, &user_jid, &username).await?;
     }
 
     info!("Reconciled bootstrap memberships for existing accounts");

--- a/server/crates/waddle-server/src/server/extension_host_adapter.rs
+++ b/server/crates/waddle-server/src/server/extension_host_adapter.rs
@@ -376,7 +376,7 @@ impl ExtensionHostAdapter {
         let Some(session) = invocation.session.as_ref() else {
             return Err(ExtensionHostAdapterError::NotAuthorized);
         };
-        let subject = Subject::user(&session.user_id);
+        let subject = Subject::user(&session.user_jid);
         if self
             .permission_allowed(
                 subject,
@@ -441,7 +441,7 @@ impl ExtensionHostAdapter {
         let Some(session) = invocation.session.as_ref() else {
             return Err(ExtensionHostAdapterError::NotAuthorized);
         };
-        let subject = Subject::user(&session.user_id);
+        let subject = Subject::user(&session.user_jid);
         if self
             .permission_allowed(subject.clone(), object, permission)
             .await?

--- a/server/crates/waddle-server/src/server/extension_host_adapter/host_tools.rs
+++ b/server/crates/waddle-server/src/server/extension_host_adapter/host_tools.rs
@@ -345,14 +345,14 @@ impl ExtensionHostAdapter {
             .db_pool
             .global_actor()
             .ask(DbQueryOne {
-                sql: "SELECT id, username, xmpp_localpart FROM users WHERE xmpp_localpart = ? LIMIT 1"
+                sql: "SELECT jid, username, xmpp_localpart FROM users WHERE xmpp_localpart = ? LIMIT 1"
                     .to_string(),
                 params: vec![localpart.as_str().into()],
             })
             .await
             .map_err(|error| host_tool_error(ExtensionHostAdapterError::Storage(format!("{error:?}"))))?
             .ok_or_else(|| host_tool_error(ExtensionHostAdapterError::NotAuthorized))?;
-        let user_id = row_value(&row, 0)
+        let user_jid = row_value(&row, 0)
             .and_then(ValueExt::as_string)
             .map_err(|error| {
                 host_tool_error(ExtensionHostAdapterError::Storage(error.to_string()))
@@ -374,7 +374,7 @@ impl ExtensionHostAdapter {
                 host_tool_error(ExtensionHostAdapterError::Protocol(error.to_string()))
             })?;
         Ok(ExtensionInvocation {
-            session: Some(Session::new(&user_id, &username, &xmpp_localpart)),
+            session: Some(Session::new(&user_jid, &username, &xmpp_localpart)),
             actor_jid,
             plugin_id,
             source_room,

--- a/server/crates/waddle-server/src/server/routes/auth.rs
+++ b/server/crates/waddle-server/src/server/routes/auth.rs
@@ -198,7 +198,6 @@ pub struct LogoutRequest {
 #[derive(Debug, Serialize)]
 pub struct SessionResponse {
     pub session_id: String,
-    pub user_id: String,
     pub username: String,
     pub avatar_url: Option<String>,
     pub xmpp_localpart: String,
@@ -257,7 +256,7 @@ pub(super) fn auth_error_to_response(err: AuthError) -> (StatusCode, Json<ErrorR
 
 async fn load_avatar_url(
     actor: &kameo::actor::ActorRef<crate::db::actor::DbActor>,
-    user_id: &str,
+    user_jid: &str,
 ) -> Result<Option<String>, AuthError> {
     let row = actor
         .ask(DbQueryOne {
@@ -265,14 +264,14 @@ async fn load_avatar_url(
                          (
                              SELECT ai.raw_claims_json
                              FROM auth_identities ai
-                             WHERE ai.user_id = u.id
+                             WHERE ai.user_jid = u.jid
                              ORDER BY ai.last_login_at DESC
                              LIMIT 1
                          )
                   FROM users u
-                  WHERE u.id = ? LIMIT 1"
+                  WHERE u.jid = ? LIMIT 1"
                 .to_string(),
-            params: vec![user_id.into()],
+            params: vec![user_jid.into()],
         })
         .await
         .map_err(|e| AuthError::DatabaseError(format!("Failed to query avatar_url: {}", e)))?;
@@ -305,12 +304,12 @@ async fn load_avatar_url(
             if let Some(ref avatar_url) = avatar_url {
                 actor
                     .ask(DbExecute {
-                        sql: "UPDATE users SET avatar_url = ?, updated_at = ? WHERE id = ?"
+                        sql: "UPDATE users SET avatar_url = ?, updated_at = ? WHERE jid = ?"
                             .to_string(),
                         params: vec![
                             avatar_url.clone().into(),
                             Utc::now().to_rfc3339().into(),
-                            user_id.into(),
+                            user_jid.into(),
                         ],
                     })
                     .await
@@ -413,16 +412,19 @@ pub async fn session_handler(
             let expires_at = session.expires_at.map(|v| v.to_rfc3339());
             let jid = localpart_to_jid(&session.xmpp_localpart, &state.xmpp_domain)
                 .unwrap_or_else(|_| format!("{}@{}", session.xmpp_localpart, state.xmpp_domain));
-            let avatar_url =
-                match load_avatar_url(&state.session_manager.actor_ref(), &session.user_id).await {
-                    Ok(avatar_url) => avatar_url,
-                    Err(err) => return auth_error_to_response(err).into_response(),
-                };
+            let avatar_url = match load_avatar_url(
+                &state.session_manager.actor_ref(),
+                &session.user_jid,
+            )
+            .await
+            {
+                Ok(avatar_url) => avatar_url,
+                Err(err) => return auth_error_to_response(err).into_response(),
+            };
             (
                 StatusCode::OK,
                 Json(SessionResponse {
                     session_id: session.id,
-                    user_id: session.user_id,
                     username: session.username,
                     avatar_url,
                     xmpp_localpart: session.xmpp_localpart,

--- a/server/crates/waddle-server/src/server/routes/auth/callback.rs
+++ b/server/crates/waddle-server/src/server/routes/auth/callback.rs
@@ -141,7 +141,7 @@ pub(super) async fn callback_handler(
 
     let linked = match state
         .identity_service
-        .resolve_or_create_user(provider, &identity_claims)
+        .resolve_or_create_user(provider, &identity_claims, &state.xmpp_domain)
         .await
     {
         Ok(v) => v,
@@ -214,7 +214,7 @@ pub(super) async fn callback_handler(
     if let Err(err) = reconcile_user_membership(
         &state.permission_actor,
         &state.bootstrap_membership,
-        &linked.user.id,
+        &linked.user.jid,
         &linked.user.xmpp_localpart,
     )
     .await
@@ -226,7 +226,7 @@ pub(super) async fn callback_handler(
     }
 
     let session = Session::new(
-        &linked.user.id,
+        &linked.user.jid,
         &linked.user.username,
         &linked.user.xmpp_localpart,
     );

--- a/server/crates/waddle-server/src/server/routes/auth/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/auth/tests.rs
@@ -31,7 +31,7 @@ async fn create_test_auth_state(
 async fn session_response_includes_jid_websocket_url_and_link_preview_media_origin() {
     let server_config = ServerConfig::test_homeserver();
     let (auth_state, actor) = create_test_auth_state(&server_config).await;
-    let session = Session::new("user-1", "alice", "alice");
+    let session = Session::new("alice@example.com", "alice", "alice");
     auth_state
         .session_manager
         .create_session(&session)
@@ -39,10 +39,10 @@ async fn session_response_includes_jid_websocket_url_and_link_preview_media_orig
         .unwrap();
     actor
         .ask(DbExecute {
-            sql: "UPDATE users SET avatar_url = ? WHERE id = ?".to_string(),
+            sql: "UPDATE users SET avatar_url = ? WHERE jid = ?".to_string(),
             params: vec![
                 "https://avatars.example.com/alice.png".into(),
-                session.user_id.clone().into(),
+                session.user_jid.clone().into(),
             ],
         })
         .await
@@ -85,7 +85,7 @@ async fn session_response_includes_jid_websocket_url_and_link_preview_media_orig
 async fn session_response_falls_back_to_raw_claim_profile_avatar() {
     let server_config = ServerConfig::test_homeserver();
     let (auth_state, actor) = create_test_auth_state(&server_config).await;
-    let session = Session::new("user-1", "alice", "alice");
+    let session = Session::new("alice@example.com", "alice", "alice");
     auth_state
         .session_manager
         .create_session(&session)
@@ -93,12 +93,12 @@ async fn session_response_falls_back_to_raw_claim_profile_avatar() {
         .unwrap();
     actor
         .ask(DbExecute {
-            sql: "INSERT INTO auth_identities (id, user_id, provider_id, issuer, subject, email, email_verified, raw_claims_json, created_at, last_login_at)
+            sql: "INSERT INTO auth_identities (id, user_jid, provider_id, issuer, subject, email, email_verified, raw_claims_json, created_at, last_login_at)
              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
                 .to_string(),
             params: vec![
                 "identity-1".into(),
-                session.user_id.clone().into(),
+                session.user_jid.clone().into(),
                 "colony".into(),
                 "https://colony.waddle.social".into(),
                 "subject-1".into(),

--- a/server/crates/waddle-server/src/server/routes/device.rs
+++ b/server/crates/waddle-server/src/server/routes/device.rs
@@ -56,7 +56,6 @@ pub struct DevicePollPendingResponse {
 pub struct DevicePollCompleteResponse {
     pub status: String,
     pub session_id: String,
-    pub user_id: String,
     pub username: String,
     pub provider_id: String,
     pub jid: String,
@@ -254,7 +253,6 @@ pub async fn device_poll_handler(
                         Json(DevicePollCompleteResponse {
                             status: "complete".to_string(),
                             session_id,
-                            user_id: session.user_id,
                             username: session.username,
                             provider_id: auth.provider_id,
                             jid,

--- a/server/crates/waddle-server/src/server/routes/interpret/room_helpers.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_helpers.rs
@@ -113,7 +113,7 @@ pub(super) async fn session_is_server_owner(
         .permission_actor
         .ask(CheckPermission {
             object: Object::new(ObjectType::Server, DEPLOYMENT_SERVER_ID),
-            subject: Subject::user(&session.user_id),
+            subject: Subject::user(&session.user_jid),
             permission: Permission::Owner,
         })
         .await

--- a/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
@@ -254,7 +254,7 @@ pub(super) async fn cleanup_connection_shutdown(
         let user_id = conn
             .authenticated_session
             .as_ref()
-            .map(|session| session.user_id.to_string())
+            .map(|session| session.user_jid.to_string())
             .unwrap_or_else(|| jid.to_bare().to_string());
         if let Some(detached) = conn.sm_state.to_detached_session(
             waddle_xmpp::stream_management::DetachedSessionSnapshot {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/commands.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/commands.rs
@@ -79,7 +79,7 @@ pub(super) async fn handle_command_iq(
         from: sender_jid,
         authenticated_user_id: authenticated_session
             .as_ref()
-            .map(|session| session.user_id.clone()),
+            .map(|session| session.user_jid.clone()),
         iq: request_iq.clone(),
         command,
     };

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_config.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_config.rs
@@ -142,7 +142,7 @@ pub(super) async fn apply_muc_owner_config(
                 Tuple::new(
                     Object::new(ObjectType::Channel, &channel_id),
                     Relation::new("owner"),
-                    Subject::user(&session.user_id),
+                    Subject::user(&session.user_jid),
                 ),
             )
             .await

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/permissions.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/permissions.rs
@@ -90,7 +90,7 @@ pub(super) async fn permission_allowed(
         .app_state
         .permission_actor
         .ask(CheckPermission {
-            subject: Subject::user(&session.user_id),
+            subject: Subject::user(&session.user_jid),
             permission,
             object,
         })
@@ -306,7 +306,7 @@ pub(super) async fn write_space_owner_tuple(
         Tuple::new(
             Object::new(ObjectType::Space, node),
             Relation::new("owner"),
-            Subject::user(&session.user_id),
+            Subject::user(&session.user_jid),
         ),
     )
     .await

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/session_misc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/session_misc.rs
@@ -77,7 +77,7 @@ pub(super) async fn handle_isr_token_request_iq(
         .deps
         .protocol
         .isr_token_store
-        .create_token(session.user_id.to_string(), sender_jid.to_bare());
+        .create_token(session.user_jid.to_string(), sender_jid.to_bare());
     vec![iq_to_xml(build_isr_token_result(iq, &token))]
 }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc/access.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc/access.rs
@@ -6,7 +6,7 @@ pub(super) async fn resolve_managed_channel_affiliation(
     channel_id: &str,
 ) -> Result<Option<Affiliation>, ()> {
     let object = Object::new(ObjectType::Channel, channel_id);
-    let subject = Subject::user(&session.user_id);
+    let subject = Subject::user(&session.user_jid);
     if check_channel_permission(
         state,
         object.clone(),
@@ -86,7 +86,7 @@ pub(super) async fn server_permission_allowed(
         .app_state
         .permission_actor
         .ask(CheckPermission {
-            subject: Subject::user(&session.user_id),
+            subject: Subject::user(&session.user_jid),
             permission,
             object: Object::new(ObjectType::Server, DEPLOYMENT_SERVER_ID),
         })

--- a/server/crates/waddle-server/src/server/routes/websocket/sasl.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/sasl.rs
@@ -62,7 +62,7 @@ pub(super) async fn handle_sasl_oauthbearer(
 
             info!(
                 jid = %bare_jid_str,
-                user_id = %session.user_id,
+                user_jid = %session.user_jid,
                 "SASL OAUTHBEARER authentication successful",
             );
 

--- a/server/crates/waddle-server/src/server/routes/websocket/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests.rs
@@ -262,7 +262,7 @@ async fn create_test_server_owner_session(state: &WebSocketState, username: &str
             tuple: Tuple::new(
                 Object::new(ObjectType::Server, DEPLOYMENT_SERVER_ID),
                 Relation::new("owner"),
-                Subject::user(&session.user_id),
+                Subject::user(&session.user_jid),
             ),
         })
         .await

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/frame_parsing.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/frame_parsing.rs
@@ -248,8 +248,8 @@ async fn websocket_oauthbearer_authenticates_session_token() {
     assert_eq!(
         conn.authenticated_session
             .as_ref()
-            .map(|s| s.user_id.as_str()),
-        Some(session.user_id.as_str())
+            .map(|s| s.user_jid.as_str()),
+        Some(session.user_jid.as_str())
     );
     let expected_bare =
         localpart_to_jid(&session.xmpp_localpart, &state.deps.auth_state.xmpp_domain)
@@ -283,7 +283,7 @@ async fn websocket_rejects_reauthentication_after_successful_sasl() {
     let first_user_id = conn
         .authenticated_session
         .as_ref()
-        .map(|saved| saved.user_id.clone());
+        .map(|saved| saved.user_jid.clone());
 
     let second = handle_xmpp_frame(&frame, "example.com", state.as_ref(), &mut conn).await;
 
@@ -294,7 +294,7 @@ async fn websocket_rejects_reauthentication_after_successful_sasl() {
     assert_eq!(
         conn.authenticated_session
             .as_ref()
-            .map(|saved| saved.user_id.clone()),
+            .map(|saved| saved.user_jid.clone()),
         first_user_id
     );
     assert!(matches!(conn.phase, ConnectionPhase::Authenticated { .. }));

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
@@ -3012,7 +3012,7 @@ async fn admin_channels_create_space_bookmark_grants_space_members_channel_view(
         .expect("owner affiliation");
 
     let viewer = create_test_session(state.as_ref(), "viewer").await;
-    grant_space_member_for_test(state.as_ref(), "alpha", &viewer.user_id).await;
+    grant_space_member_for_test(state.as_ref(), "alpha", &viewer.user_jid).await;
 
     let session = create_test_server_owner_session(state.as_ref(), "owner").await;
     let bound_jid: FullJid = "owner@example.com/web".parse().expect("bound jid");
@@ -3042,7 +3042,7 @@ async fn admin_channels_create_space_bookmark_grants_space_members_channel_view(
     let channel_id = waddle_xmpp::parse_managed_room_jid(&channel_jid).expect("managed channel");
 
     assert!(
-        channel_view_allowed_for_test(state.as_ref(), &channel_id, &viewer.user_id).await,
+        channel_view_allowed_for_test(state.as_ref(), &channel_id, &viewer.user_jid).await,
         "admin-created XEP-0503 bookmark should write the channel parent tuple"
     );
 }
@@ -3129,7 +3129,7 @@ async fn admin_spaces_delete_clears_channel_parent_tuple() {
         .expect("publish bookmark");
 
     let viewer = create_test_session(state.as_ref(), "viewer").await;
-    grant_space_member_for_test(state.as_ref(), "alpha", &viewer.user_id).await;
+    grant_space_member_for_test(state.as_ref(), "alpha", &viewer.user_jid).await;
     state
         .deps
         .app_state
@@ -3144,7 +3144,7 @@ async fn admin_spaces_delete_clears_channel_parent_tuple() {
         .await
         .expect("channel parent tuple");
     assert!(
-        channel_view_allowed_for_test(state.as_ref(), "delete-parent", &viewer.user_id).await,
+        channel_view_allowed_for_test(state.as_ref(), "delete-parent", &viewer.user_jid).await,
         "test setup should grant channel view through the space parent tuple"
     );
 
@@ -3172,7 +3172,7 @@ async fn admin_spaces_delete_clears_channel_parent_tuple() {
         "expected completed space delete command response: {response}"
     );
     assert!(
-        !channel_view_allowed_for_test(state.as_ref(), "delete-parent", &viewer.user_id).await,
+        !channel_view_allowed_for_test(state.as_ref(), "delete-parent", &viewer.user_jid).await,
         "spaces:delete should remove the channel parent tuple"
     );
 }
@@ -3305,7 +3305,7 @@ async fn spaces_publish_accepts_non_jid_node_and_syncs_parent_tuple() {
         .expect("space node");
 
     let viewer = create_test_session(state.as_ref(), "viewer").await;
-    grant_space_member_for_test(state.as_ref(), "music/A", &viewer.user_id).await;
+    grant_space_member_for_test(state.as_ref(), "music/A", &viewer.user_jid).await;
 
     let session = create_test_server_owner_session(state.as_ref(), "owner").await;
     let bound_jid: FullJid = "owner@example.com/web".parse().expect("bound jid");
@@ -3346,7 +3346,7 @@ async fn spaces_publish_accepts_non_jid_node_and_syncs_parent_tuple() {
         "non-JID Space nodes should not be forced into the BareJid link projection"
     );
     assert!(
-        channel_view_allowed_for_test(state.as_ref(), "hierarchical", &viewer.user_id).await,
+        channel_view_allowed_for_test(state.as_ref(), "hierarchical", &viewer.user_jid).await,
         "publish should still write the channel parent tuple for non-JID Space nodes"
     );
 
@@ -3372,7 +3372,7 @@ async fn spaces_publish_accepts_non_jid_node_and_syncs_parent_tuple() {
         "spaces retract should accept non-JID node ids: {retract_response}"
     );
     assert!(
-        !channel_view_allowed_for_test(state.as_ref(), "hierarchical", &viewer.user_id).await,
+        !channel_view_allowed_for_test(state.as_ref(), "hierarchical", &viewer.user_jid).await,
         "retract should clear the channel parent tuple for non-JID Space nodes"
     );
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/misc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/misc.rs
@@ -43,7 +43,7 @@ async fn extension_route_channel_permission_allows_bootstrap_chat_member() {
             tuple: Tuple::new(
                 Object::new(ObjectType::Server, DEPLOYMENT_SERVER_ID),
                 Relation::new("member"),
-                Subject::user(&session.user_id),
+                Subject::user(&session.user_jid),
             ),
         })
         .await
@@ -58,7 +58,7 @@ async fn extension_route_channel_permission_allows_bootstrap_chat_member() {
             tuple: Tuple::new(
                 Object::new(ObjectType::Server, DEPLOYMENT_SERVER_ID),
                 Relation::new("owner"),
-                Subject::user(&owner_session.user_id),
+                Subject::user(&owner_session.user_jid),
             ),
         })
         .await
@@ -127,7 +127,7 @@ async fn extension_route_channel_permission_allows_bootstrap_chat_member() {
             tuple: Tuple::new(
                 Object::new(ObjectType::Channel, "announcements"),
                 Relation::new("writer"),
-                Subject::user(&session.user_id),
+                Subject::user(&session.user_jid),
             ),
         })
         .await

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/registration.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/registration.rs
@@ -147,7 +147,7 @@ async fn register_bound_connection_after_frame_completes_pending_resume_claim() 
         .sm_session_registry
         .store_session(DetachedSession {
             stream_id: stream_id.clone(),
-            user_id: session.user_id.clone(),
+            user_id: session.user_jid.clone(),
             jid: jid.clone(),
             inbound_count: 4,
             outbound_count: 10,
@@ -294,7 +294,7 @@ async fn replay_gap_during_resume_finalization_clears_blocklist_interest_for_fre
         .sm_session_registry
         .store_session(DetachedSession {
             stream_id: stream_id.clone(),
-            user_id: session.user_id.clone(),
+            user_id: session.user_jid.clone(),
             jid: jid.clone(),
             inbound_count: 4,
             outbound_count: 0,

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
@@ -463,8 +463,8 @@ async fn sm_resume_matching_authenticated_identity_preserves_current_session_wit
     assert_eq!(
         conn.authenticated_session
             .as_ref()
-            .map(|saved| saved.user_id.as_str()),
-        Some(session.user_id.as_str())
+            .map(|saved| saved.user_jid.as_str()),
+        Some(session.user_jid.as_str())
     );
 }
 
@@ -492,7 +492,7 @@ async fn sm_resume_matching_authenticated_identity_prefers_detached_sidecar_sess
 
     let stream_id = "stream-auth-match-with-sidecar";
     let detached_jid: FullJid = format!("bob@{domain}/web").parse().expect("jid");
-    let resumed_session = Session::new(&fresh_session.user_id, "bob", "bob");
+    let resumed_session = Session::new(&fresh_session.user_jid, "bob", "bob");
     state
         .deps
         .protocol

--- a/server/crates/waddle-server/src/server/routes/xmpp_oauth.rs
+++ b/server/crates/waddle-server/src/server/routes/xmpp_oauth.rs
@@ -266,7 +266,7 @@ pub async fn xmpp_token_handler(
     };
 
     debug!(
-        user_id = %session.user_id,
+        user_jid = %session.user_jid,
         username = %session.username,
         "Issued XMPP OAuth bearer token"
     );

--- a/server/crates/waddle-server/src/server/xmpp_auth_state.rs
+++ b/server/crates/waddle-server/src/server/xmpp_auth_state.rs
@@ -28,7 +28,7 @@ pub(crate) async fn validate_session(
     }
 
     Ok(XmppSession {
-        user_id: session.user_id,
+        user_id: session.user_jid,
         jid: jid.to_bare(),
         created_at: session.created_at,
         expires_at: session_expires_at(session.expires_at),
@@ -54,10 +54,10 @@ pub(crate) async fn validate_session_token(
         XmppError::auth_failed(format!("Invalid JID: {:?}", e))
     })?;
 
-    debug!(jid = %bare_jid, user_id = %session.user_id, "OAUTHBEARER session validated");
+    debug!(jid = %bare_jid, user_jid = %session.user_jid, "OAUTHBEARER session validated");
 
     Ok(XmppSession {
-        user_id: session.user_id,
+        user_id: session.user_jid,
         jid: bare_jid,
         created_at: session.created_at,
         expires_at: session_expires_at(session.expires_at),

--- a/server/crates/waddle-server/src/server/xmpp_permission_state.rs
+++ b/server/crates/waddle-server/src/server/xmpp_permission_state.rs
@@ -2,9 +2,6 @@ use kameo::actor::ActorRef;
 use tracing::{debug, warn};
 use waddle_xmpp::{Affiliation, XmppError};
 
-use crate::auth::localpart_to_jid;
-use crate::db::actor::{DbActor, DbQueryOne, RowValues};
-use crate::db::{row_value, ValueExt};
 use crate::permissions::{
     CheckPermission, DeleteTuple, ListRelations, ListSubjects, Object, ObjectType, Permission,
     PermissionActor, Relation, Subject, SubjectType, Tuple, WriteTuple,
@@ -142,64 +139,36 @@ pub(crate) async fn list_subjects(
     Ok(subject_strings)
 }
 
-pub(crate) async fn resolve_subject_jid(
-    global_db_actor: &ActorRef<DbActor>,
-    domain: &str,
-    subject: &str,
-) -> Result<Option<jid::BareJid>, XmppError> {
+/// Resolve a permission subject string to a bare JID.
+///
+/// The user principal is the bare JID itself, so a `user:` subject id is
+/// already a bare JID — no database lookup is required. Userset subjects and
+/// non-user subjects do not map to a JID.
+pub(crate) fn resolve_subject_jid(subject: &str) -> Result<Option<jid::BareJid>, XmppError> {
     let subject = parse_subject(subject)?;
     if subject.subject_type != SubjectType::User || subject.relation.is_some() {
         return Ok(None);
     }
 
-    let row = global_db_actor
-        .ask(DbQueryOne {
-            sql: "SELECT xmpp_localpart FROM users WHERE id = ? LIMIT 1".to_string(),
-            params: vec![subject.id.as_str().into()],
-        })
-        .await
-        .map_err(|e| XmppError::internal(format!("Failed to resolve user JID: {}", e)))?;
-
-    let Some(row) = row else {
-        return Ok(None);
-    };
-    let localpart = db_string(&row, 0, "xmpp_localpart")
-        .map_err(|e| XmppError::internal(format!("Failed to decode user JID: {}", e)))?;
-    let jid = localpart_to_jid(&localpart, domain)
-        .map_err(|e| XmppError::internal(format!("Failed to build user JID: {}", e)))?
-        .parse()
+    let jid = subject
+        .id
+        .parse::<jid::BareJid>()
         .map_err(|e| XmppError::internal(format!("Failed to parse user JID: {}", e)))?;
     Ok(Some(jid))
 }
 
 pub(crate) async fn set_room_affiliation(
-    global_db_actor: &ActorRef<DbActor>,
     permission_actor: &ActorRef<PermissionActor>,
     channel_id: &str,
     jid: &jid::BareJid,
     affiliation: Affiliation,
 ) -> Result<(), XmppError> {
-    let Some(localpart) = jid.node() else {
+    if jid.node().is_none() {
         return Err(XmppError::bad_request(Some("JID has no localpart".into())));
-    };
-    let row = global_db_actor
-        .ask(DbQueryOne {
-            sql: "SELECT id FROM users WHERE xmpp_localpart = ? LIMIT 1".to_string(),
-            params: vec![localpart.as_str().into()],
-        })
-        .await
-        .map_err(|e| XmppError::internal(format!("Failed to resolve user: {}", e)))?;
-    let Some(row) = row else {
-        return Err(XmppError::item_not_found(Some(format!(
-            "User {} not found",
-            jid
-        ))));
-    };
-    let user_id = db_string(&row, 0, "id")
-        .map_err(|e| XmppError::internal(format!("Failed to decode user id: {}", e)))?;
+    }
 
     let object = Object::new(ObjectType::Channel, channel_id);
-    let subject = Subject::user(&user_id);
+    let subject = Subject::user(jid.to_string());
     for relation in ["owner", "admin", "member", "outcast"] {
         let tuple = Tuple::new(object.clone(), Relation::new(relation), subject.clone());
         permission_actor
@@ -229,10 +198,4 @@ pub(crate) async fn set_room_affiliation(
     }
 
     Ok(())
-}
-
-fn db_string(row: &RowValues, index: usize, name: &str) -> Result<String, String> {
-    row_value(row, index)
-        .and_then(ValueExt::as_string)
-        .map_err(|e| format!("Failed to get {name}: {e}"))
 }

--- a/server/crates/waddle-server/src/server/xmpp_state.rs
+++ b/server/crates/waddle-server/src/server/xmpp_state.rs
@@ -96,12 +96,7 @@ impl waddle_xmpp::AppState for XmppAppState {
     }
 
     async fn resolve_subject_jid(&self, subject: &str) -> Result<Option<jid::BareJid>, XmppError> {
-        super::xmpp_permission_state::resolve_subject_jid(
-            &self.global_db_actor,
-            &self.domain,
-            subject,
-        )
-        .await
+        super::xmpp_permission_state::resolve_subject_jid(subject)
     }
 
     async fn search_users(
@@ -120,7 +115,6 @@ impl waddle_xmpp::AppState for XmppAppState {
         affiliation: waddle_xmpp::Affiliation,
     ) -> Result<(), XmppError> {
         super::xmpp_permission_state::set_room_affiliation(
-            &self.global_db_actor,
             &self.permission_actor,
             channel_id,
             jid,

--- a/server/crates/waddle-server/tests/group_dm_ws.rs
+++ b/server/crates/waddle-server/tests/group_dm_ws.rs
@@ -758,10 +758,10 @@ async fn seed_oidc_user(database_url: &str, localpart: &str) {
         .expect("open sqlite db for oidc seed");
     sqlx::query(
         "INSERT INTO users \
-         (id, username, xmpp_localpart, display_name, avatar_url, primary_email, created_at, updated_at) \
+         (jid, username, xmpp_localpart, display_name, avatar_url, primary_email, created_at, updated_at) \
          VALUES (?, ?, ?, ?, NULL, NULL, ?, ?)",
     )
-    .bind(format!("id-{localpart}"))
+    .bind(format!("{localpart}@localhost"))
     .bind(localpart)
     .bind(localpart)
     .bind("OIDC Member")

--- a/server/crates/waddle-server/tests/xep0012_0202_ws.rs
+++ b/server/crates/waddle-server/tests/xep0012_0202_ws.rs
@@ -166,10 +166,10 @@ async fn seed_oidc_user(database_url: &str, localpart: &str) {
         .expect("open sqlite db for oidc seed");
     sqlx::query(
         "INSERT INTO users \
-         (id, username, xmpp_localpart, display_name, avatar_url, primary_email, created_at, updated_at) \
+         (jid, username, xmpp_localpart, display_name, avatar_url, primary_email, created_at, updated_at) \
          VALUES (?, ?, ?, ?, NULL, NULL, ?, ?)",
     )
-    .bind(format!("id-{localpart}"))
+    .bind(format!("{localpart}@localhost"))
     .bind(localpart)
     .bind(localpart)
     .bind("OIDC Member")

--- a/server/crates/waddle-xmpp/src/app_state.rs
+++ b/server/crates/waddle-xmpp/src/app_state.rs
@@ -463,7 +463,8 @@ pub trait AppState: Send + Sync + 'static {
 /// User session information.
 #[derive(Debug, Clone)]
 pub struct Session {
-    /// Internal user ID
+    /// Bare JID principal as a string (e.g. `alice@example.com`); mirrors
+    /// [`Self::jid`] in string form for storage/lookup paths.
     pub user_id: String,
     /// XMPP JID (bare)
     pub jid: jid::BareJid,


### PR DESCRIPTION
Replace the internal UUID user principal (`users.id`) with the user's bare
JID everywhere, removing the JID<->UUID mapping. The bare JID is now the
immutable primary key referenced by sessions, auth identities, messages, and
permission tuples.

- DB: `users.jid` PK (was `id` UUID); `auth_identities.user_jid` /
  `sessions.user_jid` FKs; `messages.author_jid`; `reactions.user_jid`.
- Identity: build the bare JID from localpart+domain at creation; logins
  reconcile only mutable profile fields (display name, avatar, email) — the
  JID/localpart/username are immutable.
- Permissions: every `Subject::user(..)` is a bare JID; drop the obsolete
  localpart<->id lookups in `resolve_subject_jid` / `set_room_affiliation`.
- SpiceDB: encode `@`->`|` for every object/subject id at the client
  boundary (SpiceDB object ids disallow `@`) and decode on read; the local
  fallback store keeps raw bare JIDs.
- Drop the now-redundant `user_id` field from the session/device HTTP
  responses (and the chat `WaddleSession` type); `jid` carries the principal.

https://claude.ai/code/session_01Nqn3AHQZiYAz4gWx5KPfqC