### PR TITLE
fix(server): drop user_avatar tables in v1 hard-cut reset

### DIFF
--- a/server/crates/waddle-server/src/db/migrations/global.rs
+++ b/server/crates/waddle-server/src/db/migrations/global.rs
@@ -17,6 +17,8 @@ DROP TABLE IF EXISTS roster_versions;
 DROP TABLE IF EXISTS blocking_list;
 DROP TABLE IF EXISTS private_xml_storage;
 DROP TABLE IF EXISTS provider_webhook_deliveries;
+DROP TABLE IF EXISTS user_avatar_fetch_state;
+DROP TABLE IF EXISTS user_avatar_source;
 
 CREATE TABLE users (
     jid TEXT PRIMARY KEY,
@@ -187,6 +189,8 @@ DROP TABLE IF EXISTS roster_versions CASCADE;
 DROP TABLE IF EXISTS blocking_list CASCADE;
 DROP TABLE IF EXISTS private_xml_storage CASCADE;
 DROP TABLE IF EXISTS provider_webhook_deliveries CASCADE;
+DROP TABLE IF EXISTS user_avatar_fetch_state CASCADE;
+DROP TABLE IF EXISTS user_avatar_source CASCADE;
 
 CREATE TABLE users (
     jid TEXT PRIMARY KEY,


### PR DESCRIPTION
## Problem

Production pod `waddle-server-7dcb7f4b48-zg44k` is in CrashLoopBackOff (76 restarts) with:

```
Error: Failed to run migrations: Migration failed: Migration v2 failed:
Internal database error: error returned from database: relation "user_avatar_source" already exists
```

## Root Cause

PR #990 changed the `waddle` v1001 migration description from `"…with user_id principals"` to `"…with bare-JID principals"`. The migration runner's incompatible-history detector compares stored descriptions against the current binary:

1. New pod starts, sees v1001 description mismatch → drops `_migrations`
2. Replays all migrations from scratch starting at v1
3. v1 does `DROP TABLE IF EXISTS` on most tables — but **not** `user_avatar_source` or `user_avatar_fetch_state` (added later in v2/v3)
4. v2 runs `CREATE TABLE user_avatar_source` → table already exists → crash

The old pod (`waddle-server-5dc8ff7d7d-b2h6d`, 24h) continues serving during the crash loop.

## Fix

Add `DROP TABLE IF EXISTS user_avatar_source` and `DROP TABLE IF EXISTS user_avatar_fetch_state` to the v1 hard-cut reset in both the SQLite and Postgres variants. This makes the hard-cut replay fully idempotent regardless of which later-migration tables already exist in the database.

## Prevention

Any future migration that adds a new table must also add a corresponding `DROP TABLE IF EXISTS` to the v1 hard-cut list.