### PR TITLE
fix(server): make v2/v3 Postgres migrations idempotent with IF NOT EXISTS

### DIFF
--- a/server/crates/waddle-server/src/db/migrations/global.rs
+++ b/server/crates/waddle-server/src/db/migrations/global.rs
@@ -358,7 +358,7 @@ CREATE TABLE user_avatar_source (
 "#;
 
 pub const V0002_USER_AVATAR_SOURCE_POSTGRES: &str = r#"
-CREATE TABLE user_avatar_source (
+CREATE TABLE IF NOT EXISTS user_avatar_source (
     xmpp_localpart TEXT PRIMARY KEY,
     source TEXT NOT NULL CHECK (source IN ('oidc', 'user')),
     updated_at TEXT NOT NULL DEFAULT to_char(NOW() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
@@ -384,7 +384,7 @@ CREATE TABLE user_avatar_fetch_state (
 "#;
 
 pub const V0003_USER_AVATAR_FETCH_STATE_POSTGRES: &str = r#"
-CREATE TABLE user_avatar_fetch_state (
+CREATE TABLE IF NOT EXISTS user_avatar_fetch_state (
     xmpp_localpart TEXT PRIMARY KEY,
     last_attempt_at TEXT NOT NULL,
     last_error TEXT,


### PR DESCRIPTION
## Problem

After PR #991 merged and deployed, the new pod still crashes. The sequence:

1. PR #990 changed v1001 description → incompatible-history reset fired
2. v1 ran successfully: recreated `users` table with `jid` PK
3. v2 crashed: `user_avatar_source` already exists → `_migrations` recorded v1 but not v2+
4. PR #991 fixed the reset path (v1 now drops the missing tables)
5. BUT on the next deploy, `_migrations` already has v1 with the new description, so the incompatible-history reset does NOT fire again — the runner goes straight to applying v2, which still fails

## Root Cause

The `_migrations` table records v1 as applied (new description). The runner skips v1 and tries v2 directly. `user_avatar_source` still exists from before the failed run. `CREATE TABLE user_avatar_source` → fails again.

## Fix

Use `CREATE TABLE IF NOT EXISTS` for the Postgres v2 (`user_avatar_source`) and v3 (`user_avatar_fetch_state`) migrations so re-application after a partial run is a clean no-op.

## Effect

On next deploy:
1. Runner sees v1 already applied → skips
2. v2: `CREATE TABLE IF NOT EXISTS user_avatar_source` → no-op, succeeds, recorded
3. v3: `CREATE TABLE IF NOT EXISTS user_avatar_fetch_state` → no-op or creates, succeeds, recorded
4. v4-v7: apply normally
5. New pod starts, old pod terminates, auth queries use `u.jid` ✓