### PR TITLE
fix(chat): clone the mic track for the noise-filter source so it stops sending silence

### DIFF
--- a/chat/src/lib/calls/ai-noise-filter/processor.ts
+++ b/chat/src/lib/calls/ai-noise-filter/processor.ts
@@ -1,4 +1,10 @@
-import type { AudioProcessorOptions, Track, TrackProcessor } from "livekit-client";
+import {
+  TrackEvent,
+  type AudioProcessorOptions,
+  type LocalTrack,
+  type Track,
+  type TrackProcessor,
+} from "livekit-client";
 
 /**
  * A LiveKit audio `TrackProcessor` we attach to the local mic via
@@ -8,12 +14,51 @@ import type { AudioProcessorOptions, Track, TrackProcessor } from "livekit-clien
 export type AudioNoiseProcessor = TrackProcessor<Track.Kind.Audio, AudioProcessorOptions>;
 
 /**
+ * One built denoise graph: `source → worklet → MediaStreamDestination`, plus the
+ * private capture-track clone that feeds it and the mute listener bound to the
+ * owning track. Held as a unit so a graph can be torn down independently of the
+ * one currently published (see `restart`).
+ */
+type DenoiseGraph = {
+  clone: MediaStreamTrack;
+  source: MediaStreamAudioSourceNode;
+  worklet: AudioWorkletNode;
+  destination: MediaStreamAudioDestinationNode;
+  processedTrack?: MediaStreamTrack;
+  muteSource?: LocalTrack;
+  mirror?: () => void;
+};
+
+/**
  * Shared Web Audio plumbing for a model that exposes its denoiser as a single
  * `AudioWorkletNode`: build `source → worklet → MediaStreamDestination` on the
  * room's shared `AudioContext` and publish the destination track as
  * `processedTrack`. LiveKit calls `restart` on a track swap (device change /
- * constraint restart) and `destroy` on stop, so the graph is torn down and
- * rebuilt cleanly. Subclasses supply only how to make (and dispose) the node.
+ * constraint restart) and `destroy` on stop. Subclasses supply only how to make
+ * (and dispose) the node.
+ *
+ * The source is built from a CLONE of `opts.track`, never the track itself.
+ * When a model attaches, the engine restarts mic capture to drop the now
+ * redundant browser noise suppression, and LiveKit's restart STOPS the
+ * underlying capture track (its `readyState` flips to "ended"). A
+ * `MediaStreamAudioSourceNode` reading a stopped track emits silence — which
+ * is exactly the "filter on → no audio sent" bug. A clone has an independent
+ * lifecycle tied only to the device, so our graph keeps pulling audio across
+ * LiveKit recycling its own track; we stop the clone ourselves on teardown.
+ * A device switch hands us a fresh `opts.track` via `restart`, so the new
+ * device's track is the one cloned here.
+ *
+ * `restart` builds the new graph BEFORE tearing down the old one: if the build
+ * fails (e.g. a transient worklet/wasm load), the existing graph keeps running
+ * — its clone is independent of the capture track LiveKit just recycled — so we
+ * never strand the published track on a dead graph (silence) nor leave a live
+ * processor with no output (a lying "filter on" the reconciler can't recover).
+ *
+ * Because the clone's `enabled` is independent of LiveKit's capture track, it
+ * would NOT follow a mute: with `stopMicTrackOnMute: false`, muting only sets
+ * `enabled = false` on LiveKit's track, leaving the clone live and the user
+ * audible while "muted". So we mirror the owning `LocalTrack`'s mute state onto
+ * the clone (`opts.localTrack` emits `Muted`/`Unmuted`).
  *
  * This is the thin Web-Audio boundary — verified manually, not in unit tests
  * (there is no `AudioContext`/`AudioWorklet` in the test runtime).
@@ -22,9 +67,7 @@ export abstract class WorkletNoiseProcessor implements AudioNoiseProcessor {
   abstract readonly name: string;
   processedTrack?: MediaStreamTrack;
 
-  private sourceNode?: MediaStreamAudioSourceNode;
-  private workletNode?: AudioWorkletNode;
-  private destinationNode?: MediaStreamAudioDestinationNode;
+  private graph?: DenoiseGraph;
 
   /** Load the worklet module and construct the model's node. */
   protected abstract createWorkletNode(context: AudioContext): Promise<AudioWorkletNode>;
@@ -33,37 +76,99 @@ export abstract class WorkletNoiseProcessor implements AudioNoiseProcessor {
   protected disposeWorkletNode(_node: AudioWorkletNode): void {}
 
   async init(opts: AudioProcessorOptions): Promise<void> {
-    const context = opts.audioContext;
-    const source = context.createMediaStreamSource(new MediaStream([opts.track]));
-    const node = await this.createWorkletNode(context);
-    const destination = context.createMediaStreamDestination();
-    source.connect(node);
-    node.connect(destination);
-    this.sourceNode = source;
-    this.workletNode = node;
-    this.destinationNode = destination;
-    this.processedTrack = destination.stream.getAudioTracks()[0];
+    const graph = await this.buildGraph(opts);
+    this.graph = graph;
+    this.processedTrack = graph.processedTrack;
   }
 
   async restart(opts: AudioProcessorOptions): Promise<void> {
-    await this.destroy();
-    await this.init(opts);
+    let next: DenoiseGraph;
+    try {
+      next = await this.buildGraph(opts);
+    } catch {
+      // Building the replacement failed. Keep the existing graph published
+      // rather than tearing it down for nothing: its clone is independent of
+      // the capture track LiveKit just recycled, so it keeps producing audio,
+      // and leaving `processedTrack` unchanged means LiveKit keeps publishing
+      // the working filtered track instead of falling to silence.
+      return;
+    }
+    const previous = this.graph;
+    this.graph = next;
+    this.processedTrack = next.processedTrack;
+    if (previous) this.teardownGraph(previous);
   }
 
   async destroy(): Promise<void> {
-    this.sourceNode?.disconnect();
-    if (this.workletNode) {
-      this.workletNode.disconnect();
-      this.disposeWorkletNode(this.workletNode);
+    if (this.graph) this.teardownGraph(this.graph);
+    this.graph = undefined;
+    this.processedTrack = undefined;
+  }
+
+  /** Build (but do not install) a fresh denoise graph from `opts`. */
+  private async buildGraph(opts: AudioProcessorOptions): Promise<DenoiseGraph> {
+    const context = opts.audioContext;
+    // Clone so our source outlives LiveKit stopping its own capture track on a
+    // restart (see class doc) — this is what stops the filter publishing silence.
+    const clone = opts.track.clone();
+    try {
+      const source = context.createMediaStreamSource(new MediaStream([clone]));
+      const worklet = await this.createWorkletNode(context);
+      const destination = context.createMediaStreamDestination();
+      source.connect(worklet);
+      worklet.connect(destination);
+      const graph: DenoiseGraph = {
+        clone,
+        source,
+        worklet,
+        destination,
+        processedTrack: destination.stream.getAudioTracks()[0],
+      };
+      this.mirrorMute(opts.localTrack, graph);
+      return graph;
+    } catch (err) {
+      // Failed partway (e.g. the worklet module / wasm failed to load). Stop the
+      // clone so it doesn't hold the input device open, then propagate.
+      clone.stop();
+      throw err;
     }
-    this.destinationNode?.disconnect();
+  }
+
+  /** Disconnect, dispose, and release every resource owned by `graph`. */
+  private teardownGraph(graph: DenoiseGraph): void {
+    if (graph.muteSource && graph.mirror) {
+      graph.muteSource.off(TrackEvent.Muted, graph.mirror);
+      graph.muteSource.off(TrackEvent.Unmuted, graph.mirror);
+    }
+    graph.source.disconnect();
+    graph.worklet.disconnect();
+    this.disposeWorkletNode(graph.worklet);
+    graph.destination.disconnect();
     // A `MediaStreamAudioDestinationNode`'s output track does NOT end when the
     // graph is torn down — only an explicit stop() transitions it to "ended".
     // Without this, rapid device switches leak "live" ghost tracks until GC.
-    this.processedTrack?.stop();
-    this.sourceNode = undefined;
-    this.workletNode = undefined;
-    this.destinationNode = undefined;
-    this.processedTrack = undefined;
+    graph.processedTrack?.stop();
+    // Release our private clone so it stops holding the input device open.
+    graph.clone.stop();
+  }
+
+  /**
+   * Keep the graph's clone `enabled` in lockstep with the owning track's mute
+   * state, so muting the mic actually silences the published processed track.
+   * No-op if LiveKit didn't supply the owning track (it always does in practice).
+   */
+  private mirrorMute(localTrack: LocalTrack | undefined, graph: DenoiseGraph): void {
+    if (!localTrack) return;
+    const mirror = (): void => {
+      // Disabling the clone makes the source feed digital silence into the
+      // worklet, so the published processed track goes silent — that is what
+      // makes muting actually mute while a filter is attached.
+      graph.clone.enabled = !localTrack.isMuted;
+    };
+    mirror();
+    localTrack.on(TrackEvent.Muted, mirror);
+    localTrack.on(TrackEvent.Unmuted, mirror);
+    graph.muteSource = localTrack;
+    graph.mirror = mirror;
   }
 }

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -689,6 +689,16 @@ export class CallEngine {
     room.off(RoomEvent.TrackUnmuted, this.handleTrackMuteChanged);
     room.off(RoomEvent.ConnectionQualityChanged, this.handleConnectionQualityChanged);
     room.off(RoomEvent.ConnectionStateChanged, this.handleConnectionStateChanged);
+    // Tear the mic noise processor down explicitly first: its destroy() stops a
+    // private clone of the capture track that holds the input device open. A
+    // normal room.disconnect() stops local tracks (which destroys the processor)
+    // for us, but doing it here means an erroring/partial disconnect can't leave
+    // the device — and its indicator — live until GC.
+    const micTrack = room.localParticipant?.getTrackPublication?.(Track.Source.Microphone)
+      ?.track as unknown as ProcessorCapableTrack | undefined;
+    if (micTrack && typeof micTrack.getProcessor === "function" && micTrack.getProcessor()) {
+      await micTrack.stopProcessor().catch(() => undefined);
+    }
     await room.disconnect();
   }
 

--- a/chat/tests/call-engine.test.ts
+++ b/chat/tests/call-engine.test.ts
@@ -260,6 +260,50 @@ describe("call-engine module", () => {
     expect(disconnects).toBe(1);
   });
 
+  test("disconnect() stops an attached mic noise processor so its capture clone is released", async () => {
+    // The noise processor holds a private clone of the capture track that keeps
+    // the input device live; it is freed only in the processor's destroy(). We
+    // stop it explicitly on disconnect so an erroring/partial room.disconnect()
+    // can't leave the mic (and its indicator) on until GC.
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    let stopped = 0;
+    const micTrack = {
+      getProcessor: () => ({ name: "waddle-ai-noise-filter:rnnoise" }),
+      stopProcessor: async () => {
+        stopped += 1;
+      },
+    };
+    const stub = {
+      off: () => stub,
+      disconnect: async () => undefined,
+      localParticipant: { getTrackPublication: () => ({ track: micTrack }) },
+    };
+    (engine as unknown as { room: typeof stub }).room = stub;
+    await engine.disconnect();
+    expect(stopped).toBe(1);
+  });
+
+  test("disconnect() does not call stopProcessor when no model is attached", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    let stopped = 0;
+    const micTrack = {
+      getProcessor: () => undefined,
+      stopProcessor: async () => {
+        stopped += 1;
+      },
+    };
+    const stub = {
+      off: () => stub,
+      disconnect: async () => undefined,
+      localParticipant: { getTrackPublication: () => ({ track: micTrack }) },
+    };
+    (engine as unknown as { room: typeof stub }).room = stub;
+    await engine.disconnect();
+    expect(stopped).toBe(0);
+  });
+
   test("disconnect() is a no-op when no room was connected", async () => {
     const { CallEngine } = await import("../src/lib/calls/engine");
     const engine = new CallEngine();


### PR DESCRIPTION
## Symptom

Enabling **any** AI noise filter (RNNoise *or* DTLN, #914 / #989) on the call mic published a **silent** track — other participants heard nothing. Local playback (hearing others) was unaffected.

## Root cause

`WorkletNoiseProcessor` built its `MediaStreamAudioSourceNode` directly on `opts.track` — the `LocalAudioTrack`'s own capture `MediaStreamTrack`. The moment a model attaches, the engine restarts mic capture (`syncEffectiveCaptureConstraints` → `restartMicCapture`, to drop the now-redundant browser `noiseSuppression`), and LiveKit's restart **stops the underlying capture track** (`LocalTrack` `_mediaStreamTrack.stop()`). A source node reading a stopped track (`readyState: "ended"`) emits silence, so the published `processedTrack` carried no audio.

### How it was confirmed (instrumented in-browser)

On a **running** `AudioContext`:

| | value |
|---|---|
| `srcRMS` (our source) | `0.00000` |
| `cloneRMS` (clone of same track, control) | `0.06–0.07` (speech) |
| input track `readyState` | `live` at init → **`ended`** 800 ms later |

A clone with an independent lifecycle kept delivering audio while our source died → the track was being stopped out from under us. **Sample rate was a red herring** (the clone produced audio fine at a 44.1 kHz context with a 48 kHz mic), so the earlier 48 kHz approach was dropped.

## Fix

Build the source from `opts.track.clone()`. A clone's lifecycle is tied only to the device, not to LiveKit's capture track, so the graph keeps pulling audio across LiveKit recycling its own track. A device switch hands us a fresh `opts.track` via `restart`. The clone is stopped on teardown (and on a partial build failure) so it never holds the input device open.

### Correctness details (driven by adversarial review)

- **Mute.** A clone's `enabled` is independent of LiveKit's capture track, and with `stopMicTrackOnMute: false` muting only sets `enabled = false` on LiveKit's track — which would leave you **audible while muted**. We mirror the owning `LocalTrack`'s mute state (`opts.localTrack` `Muted`/`Unmuted`) onto the clone so muting still silences the published track.
- **Resilient restart.** `restart` builds the new graph *before* tearing down the old one. If the build fails (e.g. a transient worklet/wasm load), the existing graph keeps running and stays published — avoiding both stranding the sender on a stopped track (silence) and leaving a live processor with no output (a "filter on" lie the reconciler can't recover from).
- **Deterministic teardown.** `CallEngine.disconnect()` stops the mic processor explicitly, so the capture-track clone is released even if `room.disconnect()` errors/partially runs, instead of leaving the mic device (and its indicator) live until GC.

One Web-Audio-boundary file (`processor.ts`) plus a small `engine.ts` disconnect guard.

## Testing

- `bun test` — 2157 pass, 0 fail (incl. 2 new `disconnect()` teardown tests)
- `bun run lint` (knip) — exit 0
- `astro check` — 0 errors, 0 warnings
- Manual, in-browser: **audio confirmed working** with the filter on (reporter). Recommend a final re-verify of **mute-while-filtered** and a **mid-call mic device switch** on the latest commit (mute handling + resilient restart were added after the first sign-off).
- Three adversarial-review rounds; converged with no remaining actionable findings.

## Notes / follow-up

- Branch name (`fix/rnnoise-48khz-context`) is historical — the root cause was the source track lifecycle, not sample rate. History squashed to the single real fix.
- RNNoise assumes 48 kHz and doesn't resample, so on a non-48 kHz output device it runs at reduced *quality* (audible, not silent). Tracked as a separate follow-up; not a blocker for the silence fix.