### PR TITLE
fix(chat): restore desktop sub-thread creation

### DIFF
--- a/chat/src/channels/threads.ts
+++ b/chat/src/channels/threads.ts
@@ -19,6 +19,8 @@ export interface MessageThreadEntry {
   count: number;
   /** ISO timestamp of the most recent descendant (or root when empty). */
   lastTs: string;
+  /** XEP-0201 parent thread id when this entry is a child thread. */
+  parentThreadId?: string;
 }
 
 export type MessageThreadIndex = ReadonlyMap<string, MessageThreadEntry>;
@@ -83,6 +85,7 @@ function buildIndex(messages: readonly TimelineMessage[]): MessageThreadIndex {
     const root = byId.get(threadId) ?? standardRoot;
     const directChildren = root ? group.filter((m) => m.id !== root.id) : group.slice();
     const lastTs = group[group.length - 1]?.createdAt ?? root?.createdAt ?? "";
+    const parentThreadId = parentLinks.get(threadId);
     entries.set(threadId, {
       threadId,
       root,
@@ -90,6 +93,7 @@ function buildIndex(messages: readonly TimelineMessage[]): MessageThreadIndex {
       allDescendants: directChildren.slice(),
       count: directChildren.length,
       lastTs,
+      ...(parentThreadId ? { parentThreadId } : {}),
     });
   }
 

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -156,6 +156,7 @@ const {
   sendCallChatMessage,
   sendGif,
   openThread,
+  pushThreadFromStack,
   pushThread,
   popThreadTo,
   closeThreadPanel,
@@ -1020,7 +1021,7 @@ onUnmounted(() => {
               :link-preview-scope="threadPanelIsDm ? activeDmPeer?.peerJid ?? null : activeChannelRoomJid"
               @close="closeThreadPanel"
               @pop-to="popThreadTo"
-              @push-thread="pushThread"
+              @push-thread="(threadId) => pushThreadFromStack(activeThreadStack.slice(0, -1), threadId)"
               @edit-message="editActiveMessage"
               @retract-message="retractActiveMessage"
               @react-message="reactActiveMessage"

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -54,6 +54,7 @@ import {
 } from "@/stores/message-toolbar";
 import { QUICK_REACTION_EMOJIS } from "@/lib/reaction-mode";
 import { callThreadAnchorLabel, callThreadAnchorThreadId, useCallAnchorCardState } from "@/lib/call-thread-anchor";
+import { resolveThreadActionTarget } from "@/lib/thread-action-target";
 import type { CallMedia } from "@/lib/calls/types";
 
 // Two separate badge layers:
@@ -171,6 +172,12 @@ const props = defineProps<{
   canPinMessages?: boolean;
   linkPreviewLookup?: ComposerLinkPreviewLookup | null;
   linkPreviewScope?: string | null;
+  /**
+   * Overrides the toolbar/action-sheet/swipe thread target. ThreadPanel uses
+   * this on reply rows so "Reply in thread" enters the reply's child thread
+   * instead of reopening the parent thread carried by message.threadId.
+   */
+  threadActionThreadId?: string;
   callRoomJid?: string | null;
   callChannelId?: string | null;
   hideCallAnchorCard?: boolean;
@@ -371,6 +378,7 @@ function formatThreadRecency(iso: string | undefined): string {
 }
 
 const threadChipRecency = computed(() => formatThreadRecency(props.threadLastReplyAt));
+const threadActionTargetId = computed(() => resolveThreadActionTarget(props.message, props.threadActionThreadId));
 const callThreadLabel = computed(() => callThreadAnchorLabel(props.message));
 const callThreadId = computed(() => callThreadAnchorThreadId(props.message));
 const callAnchorCardState = useCallAnchorCardState(
@@ -406,11 +414,10 @@ function togglePinFromMenu() {
 }
 
 function startReplyInThreadFromMenu() {
-  // Open the thread first so the follow-up reply lands in the panel's
-  // composer. Panel ownership of the reply target means we just need to be
-  // sure the panel is in focus; the user can then tap "Reply" in-thread.
-  const threadId = props.message.threadId ?? props.message.id;
-  emit("openThread", threadId);
+  // Open the target thread first so the panel composer sends with the
+  // matching threadOverride. ThreadPanel can target a reply's own id here,
+  // which starts an empty child thread whose parent is the current thread.
+  emit("openThread", threadActionTargetId.value);
   closeSheet();
 }
 
@@ -733,11 +740,9 @@ const longPress = useLongPress({
 const swipe = useHorizontalSwipe({
   onSwipeLeft: () => {
     // Right-to-left drag opens (or enters) the thread for this message.
-    // For root messages this jumps to their existing thread; for replies
-    // it walks into the thread of the parent (matches the toolbar's
-    // "open thread" affordance).
-    const threadId = props.message.threadId ?? props.message.id;
-    emit("openThread", threadId);
+    // ThreadPanel can override the target so swiping a reply enters that
+    // reply's child thread instead of reopening its parent thread.
+    emit("openThread", threadActionTargetId.value);
   },
   onSwipeRight: () => {
     // Left-to-right drag fills the composer reply chip targeting this

--- a/chat/src/components/chat/ThreadPanel.vue
+++ b/chat/src/components/chat/ThreadPanel.vue
@@ -22,6 +22,7 @@ import { createPinnedEdgeScroller } from "@/lib/pinned-edge-scroll";
 import { useChatWindowVisibility } from "@/shell/window-visibility";
 import { formatTimelineDayDivider, isSameTimelineDay } from "@/channels/timeline";
 import { useCallAnchorCardState } from "@/lib/call-thread-anchor";
+import { buildReplyChildThreadTargets, resolveReplyChildThreadTarget } from "@/lib/thread-child-target";
 import type { CallMedia } from "@/lib/calls/types";
 
 const props = defineProps<{
@@ -120,6 +121,9 @@ const newestThreadMessageId = computed(() =>
   activeEntry.value?.directChildren.at(-1)?.id
     ?? activeEntry.value?.root?.id
     ?? null,
+);
+const replyChildThreadTargets = computed(() =>
+  buildReplyChildThreadTargets(props.threadIndex, activeThreadId.value),
 );
 
 // Burst window matches the main feed (ContentArea.vue): same author + < 5 min
@@ -591,9 +595,20 @@ function joinThreadCallAnchor() {
   emit("joinChannelCall", props.channelId ?? null, props.roomJid, state.media);
 }
 
+function replyChildThreadTarget(message: TimelineMessage) {
+  return resolveReplyChildThreadTarget(replyChildThreadTargets.value, message);
+}
+
+function replyChildThreadCount(message: TimelineMessage): number {
+  return replyChildThreadTarget(message).count;
+}
+
+function replyChildThreadId(message: TimelineMessage): string {
+  return replyChildThreadTarget(message).threadId;
+}
+
 function replyChildHasNestedThread(message: TimelineMessage): boolean {
-  const entry = props.threadIndex.get(message.id);
-  return !!entry && entry.count > 0;
+  return replyChildThreadCount(message) > 0;
 }
 </script>
 
@@ -789,6 +804,7 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
             :invoke-extension-action="props.invokeExtensionAction"
             :link-preview-lookup="props.linkPreviewLookup"
             :link-preview-scope="props.linkPreviewScope"
+            :thread-action-thread-id="activeThreadId ?? message.id"
             :call-room-jid="props.roomJid ?? null"
             :call-channel-id="props.channelId ?? null"
             :hide-call-anchor-card="!!threadCallAnchorState"
@@ -819,6 +835,9 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
             <div class="chat-day-divider__rule" />
           </div>
           <div class="relative group/thread-child">
+            <!-- In ThreadPanel, the card's thread action targets an existing
+                 XEP-0201 child thread when present, falling back to this row's
+                 message id to start an empty child thread. -->
             <MessageCard
               :message="message"
               :current-user="currentUser"
@@ -829,7 +848,7 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
               :presence="presenceFor(message.author)"
               :last-seen="roomLastSeen[message.author]"
               :author-jid="authorJidByNick?.[message.author]"
-              :thread-reply-count="threadIndex.get(message.id)?.count ?? 0"
+              :thread-reply-count="replyChildThreadCount(message)"
               :grouped="isGroupedFollowUp(message.id)"
               hide-thread-chip
               hide-reply-chip
@@ -837,6 +856,7 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
               :invoke-extension-action="props.invokeExtensionAction"
               :link-preview-lookup="props.linkPreviewLookup"
               :link-preview-scope="props.linkPreviewScope"
+              :thread-action-thread-id="replyChildThreadId(message)"
               :call-room-jid="props.roomJid ?? null"
               :call-channel-id="props.channelId ?? null"
               @edit="(id, body, m, r, lp) => emit('editMessage', id, body, m, r, lp)"
@@ -850,10 +870,10 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
             <button
               type="button"
               class="type-caption inline-flex items-center gap-1 text-primary/80 hover:text-primary transition-colors"
-              @click="onOpenThreadFromCard(message.id)"
+              @click="onOpenThreadFromCard(replyChildThreadId(message))"
             >
               <CornerDownRight class="w-3 h-3" />
-              <span>{{ threadIndex.get(message.id)?.count ?? 0 }} in sub-thread</span>
+              <span>{{ replyChildThreadCount(message) }} in sub-thread</span>
             </button>
           </div>
           </div>

--- a/chat/src/lib/thread-action-target.ts
+++ b/chat/src/lib/thread-action-target.ts
@@ -1,0 +1,11 @@
+export interface ThreadActionMessage {
+  id: string;
+  threadId?: string | null;
+}
+
+export function resolveThreadActionTarget(
+  message: ThreadActionMessage,
+  overrideThreadId?: string | null,
+): string {
+  return overrideThreadId ?? message.threadId ?? message.id;
+}

--- a/chat/src/lib/thread-child-target.ts
+++ b/chat/src/lib/thread-child-target.ts
@@ -1,0 +1,54 @@
+import type { MessageThreadIndex } from "@/channels/threads";
+import type { TimelineMessage } from "@/lib/chat-ui";
+
+export interface ReplyChildThreadTarget {
+  threadId: string;
+  count: number;
+}
+
+function threadTargetAliases(message: TimelineMessage): string[] {
+  const aliases = new Set<string>();
+  for (const id of [message.id, message.replyableId, ...(message.wireIds ?? [])]) {
+    const trimmed = id?.trim();
+    if (trimmed) aliases.add(trimmed);
+  }
+  return [...aliases];
+}
+
+export function buildReplyChildThreadTargets(
+  threadIndex: MessageThreadIndex,
+  parentThreadId: string | null | undefined,
+): ReadonlyMap<string, ReplyChildThreadTarget> {
+  const targets = new Map<string, ReplyChildThreadTarget>();
+  if (!parentThreadId) return targets;
+
+  for (const entry of threadIndex.values()) {
+    if (entry.threadId === parentThreadId || entry.parentThreadId !== parentThreadId) continue;
+
+    const root = entry.root;
+    if (root?.threadId === parentThreadId) {
+      targets.set(root.id, { threadId: entry.threadId, count: entry.count });
+      continue;
+    }
+
+    const anchorId = root?.replyTo?.id ?? entry.directChildren.find((message) => message.replyTo?.id)?.replyTo?.id;
+    if (!anchorId) continue;
+    targets.set(anchorId, {
+      threadId: entry.threadId,
+      count: entry.count + (root ? 1 : 0),
+    });
+  }
+
+  return targets;
+}
+
+export function resolveReplyChildThreadTarget(
+  targets: ReadonlyMap<string, ReplyChildThreadTarget>,
+  message: TimelineMessage,
+): ReplyChildThreadTarget {
+  for (const id of threadTargetAliases(message)) {
+    const target = targets.get(id);
+    if (target) return target;
+  }
+  return { threadId: message.id, count: 0 };
+}

--- a/chat/src/lib/thread-stack.ts
+++ b/chat/src/lib/thread-stack.ts
@@ -1,0 +1,7 @@
+export function sameThreadStack(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((threadId, index) => threadId === right[index]);
+}
+
+export function nextThreadStack(baseStack: readonly string[], threadId: string): string[] {
+  return baseStack[baseStack.length - 1] === threadId ? [...baseStack] : [...baseStack, threadId];
+}

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -44,6 +44,7 @@ import { dmMessageFromArchived, roomMessageFromArchived } from "@/lib/xmpp/wasm-
 import { mapLiveRoomMessageToTimeline } from "@/channels/timeline";
 import { fromLiveDmMessage } from "@/dms/message-timeline-state";
 import { orderTimelineForScrollDirection, type ScrollDirectionMode } from "@/lib/scroll-direction";
+import { nextThreadStack, sameThreadStack } from "@/lib/thread-stack";
 import { useScrollDirectionPreference } from "@/preferences/scroll-direction";
 import type { MemberSummary } from "@/lib/chat-types";
 import type { ExtensionAnnotationAction, MarkupSpan, MessageReference, TimelineMessage } from "@/lib/chat-ui";
@@ -1219,18 +1220,20 @@ export function useChatAppController(giphyApiKey: string) {
     openThread(threadId);
   }
 
-  function pushThread(threadId: string) {
+  function pushThreadFromStack(baseStack: readonly string[], threadId: string) {
     if (!threadId) return;
     activeRightPanel.value = "thread";
     activeThreadTargetMessageId.value = null;
-    if (
-      activeThreadStack.value.length > 0 &&
-      activeThreadStack.value[activeThreadStack.value.length - 1] === threadId
-    ) {
+    const nextStack = nextThreadStack(baseStack, threadId);
+    if (sameThreadStack(activeThreadStack.value, nextStack)) {
       return;
     }
-    activeThreadStack.value = [...activeThreadStack.value, threadId];
+    activeThreadStack.value = nextStack;
     backfillActiveThread(threadId);
+  }
+
+  function pushThread(threadId: string) {
+    pushThreadFromStack(activeThreadStack.value, threadId);
   }
 
   function popThreadTo(index: number) {
@@ -2677,6 +2680,7 @@ export function useChatAppController(giphyApiKey: string) {
       sendCallChatMessage,
       sendGif,
       openThread,
+      pushThreadFromStack,
       pushThread,
       popThreadTo,
       closeThreadPanel,

--- a/chat/tests/thread-panel-subthread-action.test.ts
+++ b/chat/tests/thread-panel-subthread-action.test.ts
@@ -1,0 +1,306 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, test } from "bun:test";
+import { buildReplyChildThreadTargets, resolveReplyChildThreadTarget } from "../src/lib/thread-child-target";
+import { resolveThreadActionTarget } from "../src/lib/thread-action-target";
+import { nextThreadStack, sameThreadStack } from "../src/lib/thread-stack";
+import type { MessageThreadEntry, MessageThreadIndex } from "../src/channels/threads";
+import type { TimelineMessage } from "../src/lib/chat-ui";
+
+const messageCardSource = readFileSync(
+  new URL("../src/components/chat/MessageCard.vue", import.meta.url),
+  "utf8",
+);
+const threadPanelSource = readFileSync(
+  new URL("../src/components/chat/ThreadPanel.vue", import.meta.url),
+  "utf8",
+);
+const chatReadyShellSource = readFileSync(
+  new URL("../src/components/chat/ChatReadyShell.vue", import.meta.url),
+  "utf8",
+);
+const chatControllerSource = readFileSync(
+  new URL("../src/shell/chat-app-controller.ts", import.meta.url),
+  "utf8",
+);
+
+function message(partial: Partial<TimelineMessage> & { id: string; createdAt?: string }): TimelineMessage {
+  return {
+    author: "alice",
+    body: "",
+    createdAt: "2026-01-01T00:00:00Z",
+    isSelf: false,
+    ...partial,
+  };
+}
+
+function sourceBlock(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex);
+  expect(startIndex).toBeGreaterThanOrEqual(0);
+  expect(endIndex).toBeGreaterThan(startIndex);
+  return source.slice(startIndex, endIndex);
+}
+
+function sourceBlockAfter(source: string, after: string, start: string, end: string): string {
+  const afterIndex = source.indexOf(after);
+  expect(afterIndex).toBeGreaterThanOrEqual(0);
+  const startIndex = source.indexOf(start, afterIndex + after.length);
+  const endIndex = source.indexOf(end, startIndex);
+  expect(startIndex).toBeGreaterThan(afterIndex);
+  expect(endIndex).toBeGreaterThan(startIndex);
+  return source.slice(startIndex, endIndex);
+}
+
+describe("ThreadPanel desktop sub-thread action", () => {
+  test("thread action target prefers the explicit ThreadPanel override at runtime", () => {
+    expect(resolveThreadActionTarget({ id: "message-1" })).toBe("message-1");
+    expect(resolveThreadActionTarget({ id: "message-1", threadId: "thread-1" })).toBe("thread-1");
+    expect(resolveThreadActionTarget({ id: "message-1", threadId: "thread-1" }, "child-1")).toBe(
+      "child-1",
+    );
+  });
+
+  test("stack-relative thread push derives sibling and child stacks at runtime", () => {
+    const baseStack = ["root"];
+    const childStack = nextThreadStack(baseStack, "child-a");
+    expect(childStack).toEqual(["root", "child-a"]);
+    expect(childStack).not.toBe(baseStack);
+    expect(baseStack).toEqual(["root"]);
+
+    const duplicateStack = nextThreadStack(baseStack, "root");
+    expect(duplicateStack).toEqual(["root"]);
+    expect(duplicateStack).not.toBe(baseStack);
+    expect(baseStack).toEqual(["root"]);
+
+    expect(nextThreadStack(["root", "child-a"], "child-b")).toEqual([
+      "root",
+      "child-a",
+      "child-b",
+    ]);
+    expect(sameThreadStack(["root", "child-a"], ["root", "child-a"])).toBe(true);
+    expect(sameThreadStack(["root", "child-a"], ["root", "child-b"])).toBe(false);
+  });
+
+  test("reply child thread targets preserve existing arbitrary XEP-0201 child ids", () => {
+    const parentReply = message({
+      id: "reply-1",
+      threadId: "root-thread",
+      createdAt: "2026-01-01T00:01:00Z",
+    });
+    const arbitraryChildRoot = message({
+      id: "child-root-message",
+      threadId: "child-thread-id",
+      parentThreadId: "root-thread",
+      replyTo: { id: "reply-1", author: "alice" },
+      createdAt: "2026-01-01T00:02:00Z",
+    });
+    const arbitraryChildReply = message({
+      id: "child-reply-message",
+      threadId: "child-thread-id",
+      parentThreadId: "root-thread",
+      replyTo: { id: "child-root-message", author: "alice" },
+      createdAt: "2026-01-01T00:03:00Z",
+    });
+    const threadIndex: MessageThreadIndex = new Map<string, MessageThreadEntry>([
+      [
+        "child-thread-id",
+        {
+          threadId: "child-thread-id",
+          parentThreadId: "root-thread",
+          root: arbitraryChildRoot,
+          directChildren: [arbitraryChildReply],
+          allDescendants: [arbitraryChildReply],
+          count: 1,
+          lastTs: arbitraryChildReply.createdAt,
+        },
+      ],
+    ]);
+
+    const targets = buildReplyChildThreadTargets(threadIndex, "root-thread");
+    expect(resolveReplyChildThreadTarget(targets, parentReply)).toEqual({
+      threadId: "child-thread-id",
+      count: 2,
+    });
+    expect(resolveReplyChildThreadTarget(targets, message({ id: "new-reply" }))).toEqual({
+      threadId: "new-reply",
+      count: 0,
+    });
+  });
+
+  test("reply child thread targets match MUC stanza-id aliases", () => {
+    const parentReply = message({
+      id: "local-row-id",
+      replyableId: "room-stanza-id",
+      wireIds: ["origin-id", "room-stanza-id"],
+      threadId: "root-thread",
+      createdAt: "2026-01-01T00:01:00Z",
+    });
+    const arbitraryChildRoot = message({
+      id: "child-root-message",
+      threadId: "child-thread-id",
+      parentThreadId: "root-thread",
+      replyTo: { id: "room-stanza-id", author: "alice" },
+      createdAt: "2026-01-01T00:02:00Z",
+    });
+    const threadIndex: MessageThreadIndex = new Map<string, MessageThreadEntry>([
+      [
+        "child-thread-id",
+        {
+          threadId: "child-thread-id",
+          parentThreadId: "root-thread",
+          root: arbitraryChildRoot,
+          directChildren: [],
+          allDescendants: [],
+          count: 0,
+          lastTs: arbitraryChildRoot.createdAt,
+        },
+      ],
+    ]);
+
+    const targets = buildReplyChildThreadTargets(threadIndex, "root-thread");
+    expect(resolveReplyChildThreadTarget(targets, parentReply)).toEqual({
+      threadId: "child-thread-id",
+      count: 1,
+    });
+  });
+
+  test("reply child thread targets keep implicit message-id child threads", () => {
+    const parentReply = message({
+      id: "reply-1",
+      threadId: "root-thread",
+      createdAt: "2026-01-01T00:01:00Z",
+    });
+    const nestedReply = message({
+      id: "nested-reply",
+      threadId: "reply-1",
+      parentThreadId: "root-thread",
+      createdAt: "2026-01-01T00:02:00Z",
+    });
+    const threadIndex: MessageThreadIndex = new Map<string, MessageThreadEntry>([
+      [
+        "reply-1",
+        {
+          threadId: "reply-1",
+          parentThreadId: "root-thread",
+          root: parentReply,
+          directChildren: [nestedReply],
+          allDescendants: [nestedReply],
+          count: 1,
+          lastTs: nestedReply.createdAt,
+        },
+      ],
+    ]);
+
+    const targets = buildReplyChildThreadTargets(threadIndex, "root-thread");
+    expect(resolveReplyChildThreadTarget(targets, parentReply)).toEqual({
+      threadId: "reply-1",
+      count: 1,
+    });
+  });
+
+  test("MessageCard thread action uses the explicit ThreadPanel target", () => {
+    expect(messageCardSource).toContain("threadActionThreadId?: string;");
+    expect(messageCardSource).toContain(
+      "resolveThreadActionTarget(props.message, props.threadActionThreadId)",
+    );
+
+    const menuAction = sourceBlock(
+      messageCardSource,
+      "function startReplyInThreadFromMenu()",
+      "const isMentioned = computed",
+    );
+    expect(menuAction).toContain('emit("openThread", threadActionTargetId.value)');
+    expect(menuAction).not.toContain("props.message.threadId ?? props.message.id");
+
+    const toolbarThreadButton = sourceBlockAfter(
+      messageCardSource,
+      '@click="startReplyFromMenu"',
+      '<button\n        type="button"',
+      '<button\n        v-if="canPinMessages',
+    );
+    expect(toolbarThreadButton).toContain('@click="startReplyInThreadFromMenu"');
+
+    const actionSheetThreadButton = sourceBlockAfter(
+      messageCardSource,
+      '@click="sheetView = \'emoji\'"',
+      '<button\n            type="button"',
+      '<button\n            v-if="canPinMessages',
+    );
+    expect(actionSheetThreadButton).toContain('@click="startReplyInThreadFromMenu"');
+
+    const swipeAction = sourceBlock(
+      messageCardSource,
+      "const swipe = useHorizontalSwipe({",
+      "function onSwipePointerdown",
+    );
+    expect(swipeAction).toContain('emit("openThread", threadActionTargetId.value)');
+    expect(swipeAction).not.toContain("props.message.threadId ?? props.message.id");
+  });
+
+  test("ThreadPanel targets a reply row's own child thread", () => {
+    const rootCard = sourceBlock(
+      threadPanelSource,
+      'v-if="message.id === activeEntry.root?.id"',
+      "<template v-else>",
+    );
+    expect(rootCard).toContain(':thread-action-thread-id="activeThreadId ?? message.id"');
+    expect(rootCard).not.toContain(':thread-action-thread-id="message.id"');
+
+    const replyCard = sourceBlockAfter(
+      threadPanelSource,
+      'v-if="message.id === activeEntry.root?.id"',
+      '<div class="relative group/thread-child">',
+      '<div v-if="replyChildHasNestedThread(message)"',
+    );
+    expect(replyCard).toContain(':thread-action-thread-id="replyChildThreadId(message)"');
+    expect(replyCard).toContain(":thread-reply-count=\"replyChildThreadCount(message)\"");
+
+    const childThreadAction = sourceBlock(
+      threadPanelSource,
+      '<div v-if="replyChildHasNestedThread(message)" class="chat-thread-actions">',
+      "</button>",
+    );
+    expect(childThreadAction).toContain('@click="onOpenThreadFromCard(replyChildThreadId(message))"');
+    expect(childThreadAction).not.toContain('onOpenThreadFromCard(message.id)');
+  });
+
+  test("parent context pane pushes relative to its displayed stack", () => {
+    const parentPane = sourceBlock(
+      chatReadyShellSource,
+      "<!-- Parent thread pane: desktop-only context when depth >= 2.",
+      "<!-- Active thread pane: shown when any thread is open.",
+    );
+    expect(parentPane).toContain(":thread-stack=\"activeThreadStack.slice(0, -1)\"");
+    expect(parentPane).toContain(
+      '@push-thread="(threadId) => pushThreadFromStack(activeThreadStack.slice(0, -1), threadId)"',
+    );
+
+    const activePane = sourceBlock(
+      chatReadyShellSource,
+      "<!-- Active thread pane: shown when any thread is open.",
+      "</template>",
+    );
+    expect(activePane).toContain('@push-thread="pushThread"');
+  });
+
+  test("controller stack-relative push preserves thread backfill", () => {
+    expect(chatControllerSource).toContain(
+      "function pushThreadFromStack(baseStack: readonly string[], threadId: string)",
+    );
+    const relativePush = sourceBlock(
+      chatControllerSource,
+      "function pushThreadFromStack(baseStack: readonly string[], threadId: string)",
+      "function pushThread(threadId: string)",
+    );
+    expect(relativePush).toContain("activeThreadStack.value = nextStack;");
+    expect(relativePush).toContain("nextThreadStack(baseStack, threadId)");
+    expect(relativePush).toContain("backfillActiveThread(threadId);");
+
+    const defaultPush = sourceBlock(
+      chatControllerSource,
+      "function pushThread(threadId: string)",
+      "function popThreadTo(index: number)",
+    );
+    expect(defaultPush).toContain("pushThreadFromStack(activeThreadStack.value, threadId);");
+  });
+});

--- a/chat/tests/use-threads.test.ts
+++ b/chat/tests/use-threads.test.ts
@@ -87,6 +87,39 @@ describe("useMessageThreads", () => {
     expect(rootEntry!.lastTs).toBe("2026-01-01T00:03:00Z");
   });
 
+  test("records parent thread ids for arbitrary XEP-0201 child threads", () => {
+    const messages = ref<TimelineMessage[]>([
+      makeMessage({ id: "root", createdAt: "2026-01-01T00:00:00Z", body: "root" }),
+      makeMessage({ id: "c1", threadId: "root", createdAt: "2026-01-01T00:01:00Z", body: "reply" }),
+      makeMessage({
+        id: "sub1",
+        threadId: "child-thread-id",
+        parentThreadId: "root",
+        replyTo: { id: "c1", author: "alice" },
+        createdAt: "2026-01-01T00:02:00Z",
+        body: "nested",
+      }),
+      makeMessage({
+        id: "sub2",
+        threadId: "child-thread-id",
+        parentThreadId: "root",
+        replyTo: { id: "sub1", author: "alice" },
+        createdAt: "2026-01-01T00:03:00Z",
+        body: "nested 2",
+      }),
+    ]);
+    const { index } = useMessageThreads(messages);
+    const rootEntry = index.value.get("root");
+    const subEntry = index.value.get("child-thread-id");
+    expect(subEntry).toBeTruthy();
+    expect(subEntry!.parentThreadId).toBe("root");
+    expect(subEntry!.root?.id).toBe("sub1");
+    expect(subEntry!.directChildren.map((m) => m.id)).toEqual(["sub2"]);
+    expect(rootEntry).toBeTruthy();
+    expect(rootEntry!.count).toBe(3);
+    expect(rootEntry!.allDescendants.map((m) => m.id)).toEqual(["c1", "sub1", "sub2"]);
+  });
+
   test("getEntry returns undefined for unknown ids", () => {
     const messages = ref<TimelineMessage[]>([]);
     const { getEntry } = useMessageThreads(messages);
@@ -95,20 +128,23 @@ describe("useMessageThreads", () => {
   });
 
   test("resolveEntry synthesises an empty entry for a freshly-started sub-thread", () => {
-    // User clicks "Start sub-thread" on a reply (`c1`) before typing. The
-    // sub-thread has zero messages, so there's no index entry — but the
+    // User enters a reply's child thread from the thread action before typing.
+    // The sub-thread has zero messages, so there's no index entry — but the
     // panel still needs to render the root + composer instead of "Loading…".
     const messages = ref<TimelineMessage[]>([
-      makeMessage({ id: "root", threadId: "root", createdAt: "2026-01-01T00:00:00Z", body: "root msg" }),
+      makeMessage({ id: "root", createdAt: "2026-01-01T00:00:00Z", body: "root msg" }),
       makeMessage({ id: "c1", threadId: "root", createdAt: "2026-01-01T00:01:00Z", body: "reply" }),
     ]);
-    const { getEntry, resolveEntry } = useMessageThreads(messages);
+    const { index, getEntry, resolveEntry } = useMessageThreads(messages);
     expect(getEntry("c1")).toBeUndefined();
     const entry = resolveEntry("c1");
     expect(entry).toBeTruthy();
     expect(entry!.root?.id).toBe("c1");
     expect(entry!.directChildren).toEqual([]);
+    expect(entry!.allDescendants).toEqual([]);
     expect(entry!.count).toBe(0);
+    expect(entry!.lastTs).toBe("2026-01-01T00:01:00Z");
+    expect(index.value.get("root")!.directChildren.map((m) => m.id)).toEqual(["c1"]);
   });
 
   test("resolveEntry returns undefined when the id doesn't match any loaded message", () => {


### PR DESCRIPTION
## Summary

Restores desktop sub-thread creation from reply rows inside an open thread, including existing XEP-0201 child threads whose ThreadID is not the reply message id.

## Completed plan

- Reviewed XEP-0201 child-thread semantics in `./xeps`: child threads use their own ThreadID and carry the parent ThreadID in the `parent` attribute.
- Added an explicit `MessageCard` thread-action target so desktop toolbar, action-sheet, and swipe actions can be retargeted by `ThreadPanel`.
- Kept active thread roots targeted at `activeThreadId` so arbitrary XEP-0201 ThreadIDs are not replaced by root stanza/message ids.
- Added child-thread target resolution for reply rows that reopens an existing child ThreadID when present, including MUC `replyableId` / `wireIds` aliases, and falls back to the row message id only for an empty child thread.
- Added `pushThreadFromStack` for the desktop parent context pane so sibling sub-thread actions push relative to the displayed parent stack instead of nesting under the active child.
- Added focused runtime/source-contract coverage for target resolution, stack immutability, visible toolbar/action-sheet hooks, swipe behavior, parent-pane stack behavior, arbitrary child ThreadIDs, MUC stanza-id aliases, and empty child-thread entry synthesis.
- Ran adversarial review rounds and fixed every real finding: brittle source anchor, missing runtime coverage, arbitrary child ThreadID routing, visible sub-thread button routing, MUC stanza-id alias routing, toolbar/action-sheet hook coverage, and stack immutability coverage.

## XEP review

This is UI/controller routing only. It does not add a namespace or alter XMPP wire serialization. Existing send, GIF, and typing paths still route typed `{ threadId, parentThreadId }` values through the established ThreadPanel plumbing.

## Validation

- `bun test tests/thread-panel-subthread-action.test.ts tests/use-threads.test.ts`
- `bun test`
- `bun run lint`
- `bun run build`

Notes: Bun prints an existing shell init parse warning before commands start. `bun run build` required local port access for the Astro/Cloudflare build probe; with that allowed, `astro check` reported 0 errors.

## Browser QA

Earlier in-app Browser validation was attempted, but the Browser runtime reported that the `iab` browser was unavailable. The local dev server smoke from the original pass returned HTTP 200.
