### PR TITLE
fix(chat): serve admin root route

### DIFF
--- a/chat/src/pages/admin/index.astro
+++ b/chat/src/pages/admin/index.astro
@@ -1,0 +1,8 @@
+---
+import AppLayout from "@/layouts/AppLayout.astro";
+import RoutePageShell from "@/components/pages/RoutePageShell.vue";
+---
+
+<AppLayout>
+  <RoutePageShell client:only="vue" routeId="admin" />
+</AppLayout>

--- a/chat/tests/admin-entrypoint.test.ts
+++ b/chat/tests/admin-entrypoint.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+
+describe("admin Astro entrypoints", () => {
+  test("serves both /admin and /admin/:panel through the admin route shell", () => {
+    const rootPage = new URL("../src/pages/admin/index.astro", import.meta.url);
+    const panelPage = new URL("../src/pages/admin/[panel].astro", import.meta.url);
+
+    expect(existsSync(rootPage)).toBe(true);
+    expect(existsSync(panelPage)).toBe(true);
+
+    for (const page of [rootPage, panelPage]) {
+      const source = readFileSync(page, "utf8");
+      expect(source).toContain('from "@/layouts/AppLayout.astro"');
+      expect(source).toContain('from "@/components/pages/RoutePageShell.vue"');
+      expect(source).toContain('routeId="admin"');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add the missing Astro file-backed route for `/admin` so direct browser requests no longer 404.
- Keep `/admin/:panel` behavior unchanged by mounting the same `RoutePageShell` admin route shell.
- Add a regression test that verifies both admin Astro entrypoints exist and mount the admin route shell.

## Plan
- [x] Confirm the client router already recognizes `/admin` and defaults it to the users panel.
- [x] Add `chat/src/pages/admin/index.astro` to serve the existing admin shell for direct `/admin` requests.
- [x] Add narrow regression coverage for `/admin` and `/admin/:panel` Astro entrypoints.
- [x] Verify route behavior with tests, lint, Astro build, and local direct HTTP checks.
- [x] Run adversarial review passes and address actionable feedback.

## XEP review
- Reviewed local `xeps/` context for the admin surface boundary.
- This change is HTTP/Astro route serving only.
- No XMPP stanzas, namespaces, XEP-0050 command nodes, MUC affiliations, PubSub behavior, or admin command wire shapes changed.

## Verification
- `bun test tests/admin-entrypoint.test.ts tests/router.test.ts`
- `bun test`
- `bun run lint`
- `/Users/rawkode/.bun/bin/bun run build`
- Local dev server direct checks: `GET /admin` and `GET /admin/users` both returned `200 OK`.

## Review
- Adversarial route/deploy reviewer: no actionable issues after final pass.
- Adversarial test/maintenance reviewer: initial brittle-test finding was fixed; no actionable issues after final pass.

## Notes
- The in-app Browser runtime was unavailable in this session (`Browser is not available: iab`), so rendered Browser QA could not be completed.
- A non-escalated build hit the known Cloudflare/Vite inspector bind sandbox issue; the same build passed when rerun with escalation.
