### PR TITLE
fix(chat): show admin spaces

### DIFF
--- a/chat/src/components/admin/ChannelCreateDialog.vue
+++ b/chat/src/components/admin/ChannelCreateDialog.vue
@@ -9,33 +9,35 @@ const open = defineModel<boolean>("open", { required: true });
 
 const props = defineProps<{
   isSubmitting?: boolean;
-  spaces?: { space_jid: string; name: string }[];
+  spaces?: { space_jid: string; space_node: string; name: string }[];
 }>();
 
 const emit = defineEmits<{
-  submit: [payload: { name: string; topic?: string | null; spaceJid?: string | null; isPublic?: boolean | null }];
+  submit: [payload: { name: string; topic?: string | null; spaceJid?: string | null; spaceNode?: string | null; isPublic?: boolean | null }];
 }>();
 
 const name = ref("");
 const topic = ref("");
-const spaceJid = ref("");
+const spaceNode = ref("");
 const isPublic = ref(true);
 
 watch(open, (isOpen) => {
   if (isOpen) {
     name.value = "";
     topic.value = "";
-    spaceJid.value = "";
+    spaceNode.value = "";
     isPublic.value = true;
   }
 });
 
 function onSubmit() {
   if (!name.value.trim() || props.isSubmitting) return;
+  const selectedSpace = props.spaces?.find((space) => space.space_node === spaceNode.value);
   emit("submit", {
     name: name.value.trim(),
     topic: topic.value.trim() || null,
-    spaceJid: spaceJid.value || null,
+    spaceJid: selectedSpace?.space_jid ?? null,
+    spaceNode: selectedSpace?.space_node ?? null,
     isPublic: isPublic.value,
   });
 }
@@ -79,9 +81,9 @@ function onSubmit() {
       </label>
       <label v-if="spaces && spaces.length > 0" class="flex flex-col gap-1">
         <span class="type-section-label text-muted-foreground">Space (optional)</span>
-        <select v-model="spaceJid" class="chat-field-control type-field">
+        <select v-model="spaceNode" class="chat-field-control type-field">
           <option value="">No space</option>
-          <option v-for="s in spaces" :key="s.space_jid" :value="s.space_jid">{{ s.name }}</option>
+          <option v-for="s in spaces" :key="s.space_node" :value="s.space_node">{{ s.name }}</option>
         </select>
       </label>
       <div class="flex flex-col gap-1.5 rounded-lg border border-border bg-muted/30 px-3 py-2.5">

--- a/chat/src/components/admin/ChannelsPanel.vue
+++ b/chat/src/components/admin/ChannelsPanel.vue
@@ -18,6 +18,8 @@ const props = defineProps<{
 
 const SEARCH_DEBOUNCE_MS = 200;
 const PAGE_SIZE = 50;
+const SPACE_OPTIONS_PAGE_SIZE = 200;
+type SpaceOption = Pick<WasmAdminSpaceListEntry, "space_jid" | "space_node" | "name">;
 
 const entries = ref<WasmAdminChannelListEntry[]>([]);
 const cursor = ref<string | null>(null);
@@ -26,8 +28,11 @@ const isLoadingMore = ref(false);
 const errorMessage = ref("");
 const prefix = ref("");
 const debouncedPrefix = ref("");
-const spaceFilter = ref<string | null>(null);
-const spaces = ref<WasmAdminSpaceListEntry[]>([]);
+const spaceFilter = ref<SpaceOption | null>(null);
+const spaces = ref<SpaceOption[]>([]);
+const activePrefix = ref("");
+const activeSpaceJid = ref<string | null>(null);
+const activeSpaceNode = ref<string | null>(null);
 const showCreate = ref(false);
 const isSubmitting = ref(false);
 const selected = ref<WasmAdminChannelListEntry | null>(null);
@@ -37,25 +42,56 @@ let requestId = 0;
 async function loadSpaces() {
   if (!props.xmppClient) return;
   try {
-    const page = await props.xmppClient.adminSpacesList({ pageSize: 200 });
-    spaces.value = page.entries;
+    const loaded: SpaceOption[] = [];
+    const seenCursors = new Set<string>();
+    let afterCursor: string | null = null;
+    do {
+      const page = await props.xmppClient.adminSpacesList({
+        pageSize: SPACE_OPTIONS_PAGE_SIZE,
+        afterCursor,
+      });
+      loaded.push(
+        ...page.entries.map((space) => ({
+          space_jid: space.space_jid,
+          space_node: space.space_node,
+          name: space.name,
+        })),
+      );
+      const nextCursor = page.next_cursor ?? null;
+      if (nextCursor && seenCursors.has(nextCursor)) break;
+      if (nextCursor) seenCursors.add(nextCursor);
+      afterCursor = nextCursor;
+    } while (afterCursor);
+    spaces.value = loaded;
+    if (
+      spaceFilter.value &&
+      !loaded.some((space) => space.space_node === spaceFilter.value?.space_node)
+    ) {
+      spaceFilter.value = null;
+    }
   } catch {
     /* ignored — the filter row gracefully degrades to "All" */
   }
 }
 
-async function fetchFirstPage(currentPrefix: string, currentSpace: string | null): Promise<void> {
+async function fetchFirstPage(currentPrefix: string, currentSpace: SpaceOption | null): Promise<void> {
   if (!props.xmppClient) return;
   const localRequestId = ++requestId;
   isLoading.value = true;
+  isLoadingMore.value = false;
+  cursor.value = null;
   errorMessage.value = "";
   try {
     const page: WasmAdminChannelsListResult = await props.xmppClient.adminChannelsList({
-      spaceJid: currentSpace ?? null,
+      spaceJid: currentSpace?.space_jid ?? null,
+      spaceNode: currentSpace?.space_node ?? null,
       prefix: currentPrefix || null,
       pageSize: PAGE_SIZE,
     });
     if (requestId !== localRequestId) return;
+    activePrefix.value = currentPrefix;
+    activeSpaceJid.value = currentSpace?.space_jid ?? null;
+    activeSpaceNode.value = currentSpace?.space_node ?? null;
     entries.value = page.entries;
     cursor.value = page.next_cursor ?? null;
   } catch (err: unknown) {
@@ -67,25 +103,41 @@ async function fetchFirstPage(currentPrefix: string, currentSpace: string | null
 }
 
 async function loadMore(): Promise<void> {
-  if (!props.xmppClient || !cursor.value || isLoadingMore.value) return;
+  if (!props.xmppClient || !cursor.value || isLoading.value || isLoadingMore.value) return;
+  const localRequestId = requestId;
+  const afterCursor = cursor.value;
+  const currentPrefix = activePrefix.value;
+  const currentSpaceJid = activeSpaceJid.value;
+  const currentSpaceNode = activeSpaceNode.value;
   isLoadingMore.value = true;
   try {
     const page = await props.xmppClient.adminChannelsList({
-      spaceJid: spaceFilter.value ?? null,
-      prefix: prefix.value || null,
+      spaceJid: currentSpaceJid,
+      spaceNode: currentSpaceNode,
+      prefix: currentPrefix || null,
       pageSize: PAGE_SIZE,
-      afterCursor: cursor.value,
+      afterCursor,
     });
+    if (
+      requestId !== localRequestId ||
+      cursor.value !== afterCursor ||
+      activePrefix.value !== currentPrefix ||
+      activeSpaceJid.value !== currentSpaceJid ||
+      activeSpaceNode.value !== currentSpaceNode
+    ) {
+      return;
+    }
     entries.value = entries.value.concat(page.entries);
     cursor.value = page.next_cursor ?? null;
   } catch (err: unknown) {
+    if (requestId !== localRequestId) return;
     errorMessage.value = err instanceof Error ? err.message : "Failed to load more channels.";
   } finally {
     isLoadingMore.value = false;
   }
 }
 
-async function onCreate(payload: { name: string; topic?: string | null; spaceJid?: string | null; isPublic?: boolean | null }) {
+async function onCreate(payload: { name: string; topic?: string | null; spaceJid?: string | null; spaceNode?: string | null; isPublic?: boolean | null }) {
   if (!props.xmppClient) return;
   isSubmitting.value = true;
   try {
@@ -137,7 +189,13 @@ const hasMore = computed(() => cursor.value !== null);
 const showEmptyState = computed(
   () => !isLoading.value && entries.value.length === 0 && !errorMessage.value,
 );
-const dialogSpaces = computed(() => spaces.value.map((s) => ({ space_jid: s.space_jid, name: s.name })));
+const dialogSpaces = computed(() =>
+  spaces.value.map((space) => ({
+    space_jid: space.space_jid,
+    space_node: space.space_node,
+    name: space.name,
+  })),
+);
 </script>
 
 <template>
@@ -174,11 +232,11 @@ const dialogSpaces = computed(() => spaces.value.map((s) => ({ space_jid: s.spac
         </button>
         <button
           v-for="s in spaces"
-          :key="s.space_jid"
+          :key="s.space_node"
           type="button"
           class="rounded-full border px-2.5 py-0.5 type-caption transition-colors"
-          :class="spaceFilter === s.space_jid ? 'border-primary/40 bg-primary/10 text-primary' : 'border-border bg-card hover:bg-muted'"
-          @click="spaceFilter = s.space_jid"
+          :class="spaceFilter?.space_node === s.space_node ? 'border-primary/40 bg-primary/10 text-primary' : 'border-border bg-card hover:bg-muted'"
+          @click="spaceFilter = s"
         >
           {{ s.name }}
         </button>
@@ -243,7 +301,7 @@ const dialogSpaces = computed(() => spaces.value.map((s) => ({ space_jid: s.spac
       <button
         type="button"
         class="chat-action-button chat-action-button--secondary type-control"
-        :disabled="isLoadingMore"
+        :disabled="isLoadingMore || isLoading"
         @click="loadMore"
       >
         {{ isLoadingMore ? "Loading…" : "Load more" }}

--- a/chat/src/components/admin/SpaceDetailDrawer.vue
+++ b/chat/src/components/admin/SpaceDetailDrawer.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 // Admin V2 — slide-from-right drawer for editing a single space.
 // Three sections: editor, members, danger (delete).
-import { onMounted, ref, watch } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import AppDrawer from "@/components/ui/AppDrawer.vue";
 import ConfirmDialog from "@/components/ui/ConfirmDialog.vue";
 import type { BrowserXmppClient } from "@/lib/xmpp";
@@ -24,6 +24,7 @@ const emit = defineEmits<{
 
 type Role = "owner" | "admin" | "member" | "none";
 const ROLES: Role[] = ["owner", "admin", "member", "none"];
+const MEMBERS_PAGE_SIZE = 200;
 
 const openLocal = ref(props.open);
 watch(() => props.open, (v) => { openLocal.value = v; });
@@ -37,8 +38,11 @@ const editError = ref("");
 
 const members = ref<WasmAdminSpaceMemberEntry[]>([]);
 const membersLoading = ref(false);
+const membersLoadingMore = ref(false);
+const memberCursor = ref<string | null>(null);
 const membersError = ref("");
 const memberMutating = ref<string | null>(null);
+let membersRequestId = 0;
 
 const showDelete = ref(false);
 const deleting = ref(false);
@@ -53,15 +57,51 @@ watch(() => props.space, (s) => {
 
 async function loadMembers() {
   if (!props.xmppClient) return;
+  const requestId = ++membersRequestId;
   membersLoading.value = true;
+  membersLoadingMore.value = false;
   membersError.value = "";
+  memberCursor.value = null;
   try {
-    const page = await props.xmppClient.adminSpacesMembers({ spaceJid: props.space.space_jid, pageSize: 200 });
+    const page = await props.xmppClient.adminSpacesMembers({
+      spaceJid: props.space.space_jid,
+      spaceNode: props.space.space_node,
+      pageSize: MEMBERS_PAGE_SIZE,
+    });
+    if (requestId !== membersRequestId) return;
     members.value = page.entries;
+    memberCursor.value = page.next_cursor ?? null;
   } catch (err: unknown) {
+    if (requestId !== membersRequestId) return;
     membersError.value = err instanceof Error ? err.message : "Failed to load members.";
   } finally {
-    membersLoading.value = false;
+    if (requestId === membersRequestId) {
+      membersLoading.value = false;
+    }
+  }
+}
+
+async function loadMoreMembers() {
+  if (!props.xmppClient || !memberCursor.value || membersLoadingMore.value) return;
+  const requestId = membersRequestId;
+  const afterCursor = memberCursor.value;
+  membersLoadingMore.value = true;
+  membersError.value = "";
+  try {
+    const page = await props.xmppClient.adminSpacesMembers({
+      spaceJid: props.space.space_jid,
+      spaceNode: props.space.space_node,
+      pageSize: MEMBERS_PAGE_SIZE,
+      afterCursor,
+    });
+    if (requestId !== membersRequestId || memberCursor.value !== afterCursor) return;
+    members.value = members.value.concat(page.entries);
+    memberCursor.value = page.next_cursor ?? null;
+  } catch (err: unknown) {
+    if (requestId !== membersRequestId) return;
+    membersError.value = err instanceof Error ? err.message : "Failed to load more members.";
+  } finally {
+    membersLoadingMore.value = false;
   }
 }
 
@@ -73,6 +113,7 @@ async function saveEdits() {
   try {
     await props.xmppClient.adminSpacesUpdate({
       spaceJid: props.space.space_jid,
+      spaceNode: props.space.space_node,
       name: editName.value.trim(),
       description: editDescription.value.trim() || null,
       iconUrl: editIconUrl.value.trim() || null,
@@ -86,11 +127,12 @@ async function saveEdits() {
 }
 
 async function changeMemberRole(member: WasmAdminSpaceMemberEntry, newRole: Role) {
-  if (!props.xmppClient) return;
+  if (!props.xmppClient || membersLoading.value || membersLoadingMore.value) return;
   memberMutating.value = member.jid;
   try {
     await props.xmppClient.adminSpacesSetRole({
       spaceJid: props.space.space_jid,
+      spaceNode: props.space.space_node,
       memberJid: member.jid,
       role: newRole,
     });
@@ -108,7 +150,10 @@ async function confirmDelete() {
   deleting.value = true;
   deleteError.value = "";
   try {
-    await props.xmppClient.adminSpacesDelete({ spaceJid: props.space.space_jid });
+    await props.xmppClient.adminSpacesDelete({
+      spaceJid: props.space.space_jid,
+      spaceNode: props.space.space_node,
+    });
     showDelete.value = false;
     emit("deleted");
   } catch (err: unknown) {
@@ -119,6 +164,8 @@ async function confirmDelete() {
 }
 
 onMounted(() => { void loadMembers(); });
+
+const hasMoreMembers = computed(() => memberCursor.value !== null);
 </script>
 
 <template>
@@ -160,20 +207,31 @@ onMounted(() => { void loadMembers(); });
         <h3 class="type-section-label text-muted-foreground">Members</h3>
         <div v-if="membersError" class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 type-caption text-destructive" role="alert">{{ membersError }}</div>
         <div v-if="membersLoading" class="type-caption text-muted-foreground">Loading…</div>
-        <ul v-else-if="members.length > 0" class="flex flex-col gap-1.5" role="list">
-          <li v-for="m in members" :key="m.jid" class="flex items-center gap-2 rounded-md border border-border bg-card px-2.5 py-2">
-            <span class="flex-1 truncate font-mono type-caption">{{ m.jid }}</span>
-            <select
-              :value="m.role"
-              :disabled="memberMutating === m.jid"
-              class="chat-field-control type-caption"
-              :aria-label="`Role for ${m.jid}`"
-              @change="changeMemberRole(m, ($event.target as HTMLSelectElement).value as Role)"
-            >
-              <option v-for="r in ROLES" :key="r" :value="r">{{ r }}</option>
-            </select>
-          </li>
-        </ul>
+        <div v-else-if="members.length > 0" class="flex flex-col gap-2">
+          <ul class="flex flex-col gap-1.5" role="list">
+            <li v-for="m in members" :key="m.jid" class="flex items-center gap-2 rounded-md border border-border bg-card px-2.5 py-2">
+              <span class="flex-1 truncate font-mono type-caption">{{ m.jid }}</span>
+              <select
+                :value="m.role"
+                :disabled="memberMutating === m.jid || membersLoadingMore || membersLoading"
+                class="chat-field-control type-caption"
+                :aria-label="`Role for ${m.jid}`"
+                @change="changeMemberRole(m, ($event.target as HTMLSelectElement).value as Role)"
+              >
+                <option v-for="r in ROLES" :key="r" :value="r">{{ r }}</option>
+              </select>
+            </li>
+          </ul>
+          <button
+            v-if="hasMoreMembers"
+            type="button"
+            class="chat-action-button type-action self-start disabled:opacity-30"
+            :disabled="membersLoadingMore || memberMutating !== null || membersLoading"
+            @click="loadMoreMembers"
+          >
+            {{ membersLoadingMore ? "Loading…" : "Load more members" }}
+          </button>
+        </div>
         <p v-else class="type-caption text-muted-foreground">No members yet.</p>
       </section>
 

--- a/chat/src/components/admin/SpacesPanel.vue
+++ b/chat/src/components/admin/SpacesPanel.vue
@@ -26,6 +26,7 @@ const isLoadingMore = ref(false);
 const errorMessage = ref("");
 const prefix = ref("");
 const debouncedPrefix = ref("");
+const activePrefix = ref("");
 const showCreate = ref(false);
 const isSubmitting = ref(false);
 const selected = ref<WasmAdminSpaceListEntry | null>(null);
@@ -36,6 +37,8 @@ async function fetchFirstPage(currentPrefix: string): Promise<void> {
   if (!props.xmppClient) return;
   const localRequestId = ++requestId;
   isLoading.value = true;
+  isLoadingMore.value = false;
+  cursor.value = null;
   errorMessage.value = "";
   try {
     const page: WasmAdminSpacesListResult = await props.xmppClient.adminSpacesList({
@@ -43,6 +46,7 @@ async function fetchFirstPage(currentPrefix: string): Promise<void> {
       pageSize: PAGE_SIZE,
     });
     if (requestId !== localRequestId) return;
+    activePrefix.value = currentPrefix;
     entries.value = page.entries;
     cursor.value = page.next_cursor ?? null;
   } catch (err: unknown) {
@@ -54,17 +58,28 @@ async function fetchFirstPage(currentPrefix: string): Promise<void> {
 }
 
 async function loadMore(): Promise<void> {
-  if (!props.xmppClient || !cursor.value || isLoadingMore.value) return;
+  if (!props.xmppClient || !cursor.value || isLoading.value || isLoadingMore.value) return;
+  const localRequestId = requestId;
+  const afterCursor = cursor.value;
+  const currentPrefix = activePrefix.value;
   isLoadingMore.value = true;
   try {
     const page = await props.xmppClient.adminSpacesList({
-      prefix: prefix.value || null,
+      prefix: currentPrefix || null,
       pageSize: PAGE_SIZE,
-      afterCursor: cursor.value,
+      afterCursor,
     });
+    if (
+      requestId !== localRequestId ||
+      cursor.value !== afterCursor ||
+      activePrefix.value !== currentPrefix
+    ) {
+      return;
+    }
     entries.value = entries.value.concat(page.entries);
     cursor.value = page.next_cursor ?? null;
   } catch (err: unknown) {
+    if (requestId !== localRequestId) return;
     errorMessage.value = err instanceof Error ? err.message : "Failed to load more spaces.";
   } finally {
     isLoadingMore.value = false;
@@ -167,7 +182,7 @@ const showEmptyState = computed(
     </div>
 
     <ul v-else-if="entries.length > 0" class="flex flex-col gap-2" role="list">
-      <li v-for="entry in entries" :key="entry.space_jid">
+      <li v-for="entry in entries" :key="entry.space_node">
         <button
           type="button"
           class="w-full flex items-center justify-between gap-3 rounded-lg border border-border bg-card px-3 py-2.5 text-left hover:bg-muted transition-colors"
@@ -196,7 +211,7 @@ const showEmptyState = computed(
       <button
         type="button"
         class="chat-action-button chat-action-button--secondary type-control"
-        :disabled="isLoadingMore"
+        :disabled="isLoadingMore || isLoading"
         @click="loadMore"
       >
         {{ isLoadingMore ? "Loading…" : "Load more" }}

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -3082,56 +3082,65 @@ export class BrowserXmppClient {
       icon_url: opts.iconUrl ?? null,
     });
   }
-  async adminSpacesUpdate(opts: { spaceJid: string; name?: string | null; description?: string | null; iconUrl?: string | null }): Promise<WasmAdminSpaceRef> {
+  async adminSpacesUpdate(opts: { spaceJid: string; spaceNode?: string | null; name?: string | null; description?: string | null; iconUrl?: string | null }): Promise<WasmAdminSpaceRef> {
     const xmpp = await this.requireConnectedXmpp();
     if (!xmpp.admin_spaces_update) throw new Error("admin_spaces_update binding missing");
     return await xmpp.admin_spaces_update({
       space_jid: opts.spaceJid,
+      space_node: opts.spaceNode ?? null,
       name: opts.name ?? null,
       description: opts.description ?? null,
       icon_url: opts.iconUrl ?? null,
     });
   }
-  async adminSpacesDelete(opts: { spaceJid: string }): Promise<boolean> {
+  async adminSpacesDelete(opts: { spaceJid: string; spaceNode?: string | null }): Promise<boolean> {
     const xmpp = await this.requireConnectedXmpp();
     if (!xmpp.admin_spaces_delete) throw new Error("admin_spaces_delete binding missing");
-    return await xmpp.admin_spaces_delete({ space_jid: opts.spaceJid, confirm: "yes" });
+    return await xmpp.admin_spaces_delete({
+      space_jid: opts.spaceJid,
+      space_node: opts.spaceNode ?? null,
+      confirm: "yes",
+    });
   }
-  async adminSpacesMembers(opts: { spaceJid: string; pageSize?: number | null; afterCursor?: string | null }): Promise<WasmAdminSpacesMembersResult> {
+  async adminSpacesMembers(opts: { spaceJid: string; spaceNode?: string | null; pageSize?: number | null; afterCursor?: string | null }): Promise<WasmAdminSpacesMembersResult> {
     const xmpp = await this.requireConnectedXmpp();
     if (!xmpp.admin_spaces_members) throw new Error("admin_spaces_members binding missing");
     return await xmpp.admin_spaces_members({
       space_jid: opts.spaceJid,
+      space_node: opts.spaceNode ?? null,
       page_size: opts.pageSize ?? null,
       after_cursor: opts.afterCursor ?? null,
     });
   }
-  async adminSpacesSetRole(opts: { spaceJid: string; memberJid: string; role: "owner" | "admin" | "member" | "none" }): Promise<WasmAdminSpacesSetRoleResult> {
+  async adminSpacesSetRole(opts: { spaceJid: string; spaceNode?: string | null; memberJid: string; role: "owner" | "admin" | "member" | "none" }): Promise<WasmAdminSpacesSetRoleResult> {
     const xmpp = await this.requireConnectedXmpp();
     if (!xmpp.admin_spaces_set_role) throw new Error("admin_spaces_set_role binding missing");
     return await xmpp.admin_spaces_set_role({
       space_jid: opts.spaceJid,
+      space_node: opts.spaceNode ?? null,
       member_jid: opts.memberJid,
       role: opts.role,
     });
   }
-  async adminChannelsList(opts: { spaceJid?: string | null; prefix?: string | null; pageSize?: number | null; afterCursor?: string | null } = {}): Promise<WasmAdminChannelsListResult> {
+  async adminChannelsList(opts: { spaceJid?: string | null; spaceNode?: string | null; prefix?: string | null; pageSize?: number | null; afterCursor?: string | null } = {}): Promise<WasmAdminChannelsListResult> {
     const xmpp = await this.requireConnectedXmpp();
     if (!xmpp.admin_channels_list) throw new Error("admin_channels_list binding missing");
     return await xmpp.admin_channels_list({
       space_jid: opts.spaceJid ?? null,
+      space_node: opts.spaceNode ?? null,
       prefix: opts.prefix ?? null,
       page_size: opts.pageSize ?? null,
       after_cursor: opts.afterCursor ?? null,
     });
   }
-  async adminChannelsCreate(opts: { name: string; topic?: string | null; spaceJid?: string | null; isPublic?: boolean | null }): Promise<WasmAdminChannelRef> {
+  async adminChannelsCreate(opts: { name: string; topic?: string | null; spaceJid?: string | null; spaceNode?: string | null; isPublic?: boolean | null }): Promise<WasmAdminChannelRef> {
     const xmpp = await this.requireConnectedXmpp();
     if (!xmpp.admin_channels_create) throw new Error("admin_channels_create binding missing");
     return await xmpp.admin_channels_create({
       name: opts.name,
       topic: opts.topic ?? null,
       space_jid: opts.spaceJid ?? null,
+      space_node: opts.spaceNode ?? null,
       is_public: opts.isPublic ?? null,
     });
   }

--- a/chat/src/lib/xmpp/wasm-types.ts
+++ b/chat/src/lib/xmpp/wasm-types.ts
@@ -491,6 +491,7 @@ export type WasmSendMessageOutcome =
 
 export interface WasmAdminSpaceListEntry {
   space_jid: string;
+  space_node: string;
   name: string;
   description?: string | null;
   icon_url?: string | null;
@@ -505,6 +506,7 @@ export interface WasmAdminSpacesListResult {
 
 export interface WasmAdminSpaceRef {
   space_jid: string;
+  space_node: string;
   name: string;
   description?: string | null;
   icon_url?: string | null;

--- a/server/crates/waddle-server/src/admin/channels.rs
+++ b/server/crates/waddle-server/src/admin/channels.rs
@@ -65,6 +65,7 @@ use crate::server::xmpp_state::{
     XmppChannelUpsert,
 };
 use crate::server::AppState;
+use crate::space_identity::{canonical_space_projection, SpaceNode, SpaceProjectionError};
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -163,6 +164,7 @@ fn role_as_wire(role: waddle_xmpp::Role) -> &'static str {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ChannelsListArgs {
     pub space_jid: Option<BareJid>,
+    pub space_node: Option<SpaceNode>,
     pub prefix: Option<String>,
     pub page_size: u32,
     pub after_cursor: Option<String>,
@@ -191,6 +193,7 @@ pub struct ChannelsListResult {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChannelsCreateArgs {
     pub space_jid: Option<BareJid>,
+    pub space_node: Option<SpaceNode>,
     pub name: String,
     pub topic: Option<String>,
     /// XEP-0045 `muc#roomconfig_publicroom`; default `true`.
@@ -782,6 +785,7 @@ pub fn parse_list_args(form: Option<&DataForm>) -> Result<ChannelsListArgs, Stri
     let Some(form) = form else {
         return Ok(ChannelsListArgs {
             space_jid: None,
+            space_node: None,
             prefix: None,
             page_size: DEFAULT_PAGE_SIZE,
             after_cursor: None,
@@ -790,6 +794,7 @@ pub fn parse_list_args(form: Option<&DataForm>) -> Result<ChannelsListArgs, Stri
     if !matches!(form.form_type, FormType::Submit) {
         return Ok(ChannelsListArgs {
             space_jid: None,
+            space_node: None,
             prefix: None,
             page_size: DEFAULT_PAGE_SIZE,
             after_cursor: None,
@@ -806,10 +811,12 @@ pub fn parse_list_args(form: Option<&DataForm>) -> Result<ChannelsListArgs, Stri
         .get_value("prefix")
         .map(|s| s.trim().to_lowercase())
         .filter(|s| !s.is_empty());
+    let space_node = parse_optional_text(form, "space_node").map(SpaceNode::from);
     let page_size = parse_page_size(form)?;
     let after_cursor = parse_optional_text(form, "after_cursor");
     Ok(ChannelsListArgs {
         space_jid,
+        space_node,
         prefix,
         page_size,
         after_cursor,
@@ -828,11 +835,13 @@ pub fn parse_create_args(form: Option<&DataForm>) -> Result<ChannelsCreateArgs, 
         ),
         _ => None,
     };
+    let space_node = parse_optional_text(form, "space_node").map(SpaceNode::from);
     // XEP-0045 public-room discovery visibility defaults true.
     let is_public = parse_optional_bool(form, "is_public")?.unwrap_or(true);
     let members_only = parse_optional_bool(form, "members_only")?;
     Ok(ChannelsCreateArgs {
         space_jid,
+        space_node,
         name,
         topic,
         is_public,
@@ -1000,14 +1009,24 @@ async fn run_list(
         .map_err(send_err("room_registry ask ListRooms"))?;
     rooms.sort();
 
-    // Narrow by `space_jid` against the channel↔space link projection.
+    // Narrow by the exact Spaces PubSub node against the channel↔space link projection.
     // A channel belongs to at most one space; rooms with no link row
     // are not in any space, so they are filtered out when a
-    // `space_jid` filter is supplied.
+    // space filter is supplied.
     if let Some(space_jid) = args.space_jid.as_ref() {
+        let (space_node, _) =
+            canonical_space_jid(&state.spaces_jid, space_jid, args.space_node.as_ref())?;
         let in_space = state
             .channel_space_link_store
-            .list_channels_in_space(space_jid)
+            .list_channels_in_space_node(&space_node)
+            .await
+            .map_err(map_link_err)?;
+        let permitted: std::collections::HashSet<BareJid> = in_space.into_iter().collect();
+        rooms.retain(|jid| permitted.contains(jid));
+    } else if let Some(space_node) = args.space_node.as_ref() {
+        let in_space = state
+            .channel_space_link_store
+            .list_channels_in_space_node(space_node)
             .await
             .map_err(map_link_err)?;
         let permitted: std::collections::HashSet<BareJid> = in_space.into_iter().collect();
@@ -1125,20 +1144,31 @@ fn mint_channel_localpart(name: &str) -> String {
     format!("{base}-{short_tail}")
 }
 
-fn space_node_name(space_jid: &BareJid) -> Option<String> {
-    space_jid.node().map(|n| n.to_string())
+fn canonical_space_jid(
+    spaces_jid: &BareJid,
+    space_jid: &BareJid,
+    space_node: Option<&SpaceNode>,
+) -> Result<(SpaceNode, BareJid), AdminErr> {
+    canonical_space_projection(spaces_jid, space_jid, space_node).map_err(|error| match error {
+        SpaceProjectionError::WrongDomain => {
+            bad_request(format!("space_jid must target {}", spaces_jid.domain()))
+        }
+        SpaceProjectionError::MissingLocalpart => bad_request("space_jid must have a localpart"),
+        SpaceProjectionError::InvalidNode(node) => {
+            internal_err(format!("invalid space node '{node}'"))
+        }
+        SpaceProjectionError::MismatchedProjection => {
+            bad_request("space_jid must match the space_node projection")
+        }
+    })
 }
 
-async fn existing_space_node(state: &AppState, space_jid: &BareJid) -> Result<String, AdminErr> {
-    if space_jid.domain() != state.spaces_jid.domain() {
-        return Err(bad_request(format!(
-            "space_jid must target {}",
-            state.spaces_jid.domain()
-        )));
-    }
-    let Some(node) = space_node_name(space_jid) else {
-        return Err(bad_request("space_jid must have a localpart"));
-    };
+async fn existing_space_node(
+    state: &AppState,
+    space_jid: &BareJid,
+    space_node: Option<&SpaceNode>,
+) -> Result<(SpaceNode, BareJid), AdminErr> {
+    let (node, canonical_jid) = canonical_space_jid(&state.spaces_jid, space_jid, space_node)?;
     let exists = state
         .pubsub_storage
         .get_node(&state.spaces_jid, &node)
@@ -1149,7 +1179,7 @@ async fn existing_space_node(state: &AppState, space_jid: &BareJid) -> Result<St
             Some(format!("no space '{}'", space_jid)),
         ))));
     }
-    Ok(node)
+    Ok((node, canonical_jid))
 }
 
 async fn publish_channel_space_bookmark(
@@ -1550,8 +1580,13 @@ async fn run_create(state: &AppState, args: &ChannelsCreateArgs) -> Result<Chann
     let channel_jid: BareJid = format!("{localpart}@{muc_domain}")
         .parse()
         .map_err(|e| internal_err(format!("constructed channel JID is invalid: {e}")))?;
-    let space_node = match args.space_jid.as_ref() {
-        Some(space_jid) => Some(existing_space_node(state, space_jid).await?),
+    let space_ref = match args.space_jid.as_ref() {
+        Some(space_jid) => {
+            Some(existing_space_node(state, space_jid, args.space_node.as_ref()).await?)
+        }
+        None if args.space_node.is_some() => {
+            return Err(bad_request("space_node requires space_jid"));
+        }
         None => None,
     };
 
@@ -1596,7 +1631,7 @@ async fn run_create(state: &AppState, args: &ChannelsCreateArgs) -> Result<Chann
     // `spaces:delete` cascade behavior; the room itself lives in the
     // MUC registry independent of any space. The matching XEP-0503
     // bookmark is the public discovery source for native clients.
-    if let (Some(space_jid), Some(node)) = (args.space_jid.as_ref(), space_node.as_deref()) {
+    if let Some((node, space_jid)) = space_ref.as_ref() {
         let parent_tuple_created = match publish_channel_space_bookmark(
             state,
             node,
@@ -1623,6 +1658,7 @@ async fn run_create(state: &AppState, args: &ChannelsCreateArgs) -> Result<Chann
             .set(&ChannelSpaceLink {
                 channel_jid: channel_jid.clone(),
                 space_jid: space_jid.clone(),
+                space_node: node.clone(),
                 created_at: now_unix_seconds(),
             })
             .await
@@ -2650,9 +2686,7 @@ async fn run_update(state: &AppState, args: &ChannelsUpdateArgs) -> Result<Chann
         .await
         .map_err(map_link_err)?
     {
-        let Some(node) = space_node_name(&link.space_jid) else {
-            return Err(bad_request("stored space_jid must have a localpart"));
-        };
+        let node = link.space_node.clone();
         let Some(channel_id) = waddle_xmpp::parse_managed_room_jid(&args.channel_jid) else {
             return Err(internal_err(format!(
                 "linked channel JID is not managed: {}",
@@ -2735,9 +2769,8 @@ async fn run_delete(state: &AppState, args: &ChannelsDeleteArgs) -> Result<(), A
         .get(&args.channel_jid)
         .await
         .map_err(map_link_err)?;
-    let linked_node = link
-        .as_ref()
-        .and_then(|link| space_node_name(&link.space_jid));
+    let linked_node = link.as_ref().map(|link| link.space_node.clone());
+    let linked_node_text = linked_node.as_ref().map(ToString::to_string);
     let item_id = args.channel_jid.to_string();
     let channel_id = waddle_xmpp::parse_managed_room_jid(&args.channel_jid);
     let catalog_snapshot = match channel_id.as_deref() {
@@ -2756,7 +2789,7 @@ async fn run_delete(state: &AppState, args: &ChannelsDeleteArgs) -> Result<(), A
         .into_iter()
         .collect();
     if let Some(node) = linked_node.as_ref() {
-        bookmark_nodes.insert(node.clone());
+        bookmark_nodes.insert(node.to_string());
     }
 
     let mut bookmark_snapshots: std::collections::BTreeMap<String, Option<PubSubItem>> =
@@ -2772,7 +2805,7 @@ async fn run_delete(state: &AppState, args: &ChannelsDeleteArgs) -> Result<(), A
 
     for node in bookmark_nodes
         .iter()
-        .filter(|node| Some(node.as_str()) != linked_node.as_deref())
+        .filter(|node| Some(node.as_str()) != linked_node_text.as_deref())
     {
         let snapshot = bookmark_snapshots.get(node).cloned().unwrap_or(None);
         let fallback_item = if snapshot.is_none() {
@@ -2839,7 +2872,8 @@ async fn run_delete(state: &AppState, args: &ChannelsDeleteArgs) -> Result<(), A
     }
 
     if let Some(node) = linked_node.as_ref() {
-        let snapshot = bookmark_snapshots.get(node).cloned().unwrap_or(None);
+        let node = node.to_string();
+        let snapshot = bookmark_snapshots.get(&node).cloned().unwrap_or(None);
         let fallback_item = if snapshot.is_none() {
             if let Some(channel_id) = channel_id.as_deref() {
                 match rollback_channel_bookmark_item(state, &args.channel_jid, channel_id).await {
@@ -2876,11 +2910,11 @@ async fn run_delete(state: &AppState, args: &ChannelsDeleteArgs) -> Result<(), A
         } else {
             None
         };
-        match retract_channel_bookmark_and_parent(state, node, &item_id, channel_id.as_deref())
+        match retract_channel_bookmark_and_parent(state, &node, &item_id, channel_id.as_deref())
             .await
         {
             Ok(parent_tuple_deleted) => removed_bookmarks.push(RemovedChannelBookmark {
-                node: node.clone(),
+                node,
                 item: snapshot,
                 fallback_item,
                 parent_tuple_deleted,

--- a/server/crates/waddle-server/src/admin/spaces.rs
+++ b/server/crates/waddle-server/src/admin/spaces.rs
@@ -22,13 +22,14 @@
 //!
 //! The wire vocabulary for space membership (`owner`/`admin`/`member`) maps
 //! onto XEP-0060 PubSub affiliations on the space's PubSub node (the space
-//! JID is owned by [`crate::server::AppState::spaces_jid`] and the node name
-//! is the space's localpart). `owner` ↔ [`waddle_xmpp_core::pubsub::Affiliation::Owner`],
-//! `admin` ↔ [`waddle_xmpp_core::pubsub::Affiliation::Publisher`] (the
-//! highest read+write tier short of Owner), `member` ↔
+//! JID is owned by [`crate::server::AppState::spaces_jid`] and the node name is
+//! projected through the space JID's XEP-0106-escaped localpart). `owner` ↔
+//! [`waddle_xmpp_core::pubsub::Affiliation::Owner`], `admin` ↔
+//! [`waddle_xmpp_core::pubsub::Affiliation::Publisher`] (the highest read+write
+//! tier short of Owner), `member` ↔
 //! [`waddle_xmpp_core::pubsub::Affiliation::Member`], `none` removes the row.
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use jid::BareJid;
 use waddle_xmpp::commands::{CommandContext, CommandResult};
@@ -45,6 +46,9 @@ use crate::permissions::{
     WriteTuple,
 };
 use crate::server::AppState;
+use crate::space_identity::{
+    canonical_space_projection, space_jid_for_node, SpaceNode, SpaceProjectionError,
+};
 use crate::spaces_metadata::{SpaceMetadata, SpacesMetadataError};
 
 // ---------------------------------------------------------------------------
@@ -152,6 +156,7 @@ pub struct SpacesListArgs {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SpaceListEntry {
     pub space_jid: BareJid,
+    pub space_node: SpaceNode,
     pub name: String,
     pub description: Option<String>,
     pub icon_url: Option<String>,
@@ -175,6 +180,7 @@ pub struct SpacesCreateArgs {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SpaceRef {
     pub space_jid: BareJid,
+    pub space_node: SpaceNode,
     pub name: String,
     pub description: Option<String>,
     pub icon_url: Option<String>,
@@ -183,6 +189,7 @@ pub struct SpaceRef {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SpacesUpdateArgs {
     pub space_jid: BareJid,
+    pub space_node: Option<SpaceNode>,
     pub name: Option<String>,
     pub description: Option<String>,
     pub icon_url: Option<String>,
@@ -191,12 +198,14 @@ pub struct SpacesUpdateArgs {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SpacesDeleteArgs {
     pub space_jid: BareJid,
+    pub space_node: Option<SpaceNode>,
     pub confirm: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SpacesMembersArgs {
     pub space_jid: BareJid,
+    pub space_node: Option<SpaceNode>,
     pub page_size: u32,
     pub after_cursor: Option<String>,
 }
@@ -216,6 +225,7 @@ pub struct SpacesMembersResult {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SpacesSetRoleArgs {
     pub space_jid: BareJid,
+    pub space_node: Option<SpaceNode>,
     pub member_jid: BareJid,
     pub role: SpaceRole,
 }
@@ -347,7 +357,7 @@ async fn handle_create(ctx: CommandContext, state: Arc<AppState>) -> CommandResu
     };
     match run_create(&state, &args).await {
         Ok(space) => CommandResult::Completed {
-            form: Some(build_space_form(&space)),
+            form: Some(build_space_form(NODE_CREATE, &space)),
             notes: vec![],
         },
         Err(result) => *result,
@@ -364,7 +374,7 @@ async fn handle_update(ctx: CommandContext, state: Arc<AppState>) -> CommandResu
     };
     match run_update(&state, &args).await {
         Ok(space) => CommandResult::Completed {
-            form: Some(build_space_form(&space)),
+            form: Some(build_space_form(NODE_UPDATE, &space)),
             notes: vec![],
         },
         Err(result) => *result,
@@ -498,6 +508,7 @@ pub fn parse_create_args(form: Option<&DataForm>) -> Result<SpacesCreateArgs, St
 pub fn parse_update_args(form: Option<&DataForm>) -> Result<SpacesUpdateArgs, String> {
     let form = form.ok_or_else(|| "spaces:update requires an args form".to_string())?;
     let space_jid = parse_required_bare_jid(form, "space_jid")?;
+    let space_node = parse_optional_text(form, "space_node").map(SpaceNode::from);
     let name = parse_optional_text(form, "name");
     if let Some(ref name) = name {
         validate_name(name)?;
@@ -506,6 +517,7 @@ pub fn parse_update_args(form: Option<&DataForm>) -> Result<SpacesUpdateArgs, St
     let icon_url = parse_optional_text(form, "icon_url");
     Ok(SpacesUpdateArgs {
         space_jid,
+        space_node,
         name,
         description,
         icon_url,
@@ -515,20 +527,27 @@ pub fn parse_update_args(form: Option<&DataForm>) -> Result<SpacesUpdateArgs, St
 pub fn parse_delete_args(form: Option<&DataForm>) -> Result<SpacesDeleteArgs, String> {
     let form = form.ok_or_else(|| "spaces:delete requires an args form".to_string())?;
     let space_jid = parse_required_bare_jid(form, "space_jid")?;
+    let space_node = parse_optional_text(form, "space_node").map(SpaceNode::from);
     let confirm = parse_required_text(form, "confirm")?;
     if confirm != "yes" {
         return Err("spaces:delete requires confirm='yes'".to_string());
     }
-    Ok(SpacesDeleteArgs { space_jid, confirm })
+    Ok(SpacesDeleteArgs {
+        space_jid,
+        space_node,
+        confirm,
+    })
 }
 
 pub fn parse_members_args(form: Option<&DataForm>) -> Result<SpacesMembersArgs, String> {
     let form = form.ok_or_else(|| "spaces:members requires an args form".to_string())?;
     let space_jid = parse_required_bare_jid(form, "space_jid")?;
+    let space_node = parse_optional_text(form, "space_node").map(SpaceNode::from);
     let page_size = parse_page_size(form)?;
     let after_cursor = parse_optional_text(form, "after_cursor");
     Ok(SpacesMembersArgs {
         space_jid,
+        space_node,
         page_size,
         after_cursor,
     })
@@ -537,11 +556,13 @@ pub fn parse_members_args(form: Option<&DataForm>) -> Result<SpacesMembersArgs, 
 pub fn parse_set_role_args(form: Option<&DataForm>) -> Result<SpacesSetRoleArgs, String> {
     let form = form.ok_or_else(|| "spaces:set-role requires an args form".to_string())?;
     let space_jid = parse_required_bare_jid(form, "space_jid")?;
+    let space_node = parse_optional_text(form, "space_node").map(SpaceNode::from);
     let member_jid = parse_required_bare_jid(form, "member_jid")?;
     let role_raw = parse_required_text(form, "role")?;
     let role = SpaceRole::parse(&role_raw)?;
     Ok(SpacesSetRoleArgs {
         space_jid,
+        space_node,
         member_jid,
         role,
     })
@@ -568,44 +589,95 @@ fn now_unix_seconds() -> i64 {
     chrono::Utc::now().timestamp()
 }
 
-fn space_node_name(space_jid: &BareJid) -> Option<String> {
-    space_jid.node().map(|n| n.to_string())
+fn canonical_space_jid(
+    spaces_jid: &BareJid,
+    space_jid: &BareJid,
+    space_node: Option<&SpaceNode>,
+) -> Result<(SpaceNode, BareJid), AdminErr> {
+    canonical_space_projection(spaces_jid, space_jid, space_node).map_err(|error| match error {
+        SpaceProjectionError::WrongDomain => {
+            bad_request("space_jid must belong to the spaces service")
+        }
+        SpaceProjectionError::MissingLocalpart => bad_request("space_jid must have a localpart"),
+        SpaceProjectionError::InvalidNode(node) => {
+            internal_err(format!("invalid space node '{node}'"))
+        }
+        SpaceProjectionError::MismatchedProjection => {
+            bad_request("space_jid must match the space_node projection")
+        }
+    })
+}
+
+fn default_space_name(node: &SpaceNode) -> String {
+    if node.as_str() == "general" {
+        "General".to_string()
+    } else {
+        node.to_string()
+    }
 }
 
 async fn run_list(state: &AppState, args: &SpacesListArgs) -> Result<SpacesListResult, AdminErr> {
-    let mut metadata_rows = state
+    let metadata_by_node: HashMap<SpaceNode, SpaceMetadata> = state
         .spaces_metadata_store
         .list_all()
         .await
-        .map_err(map_metadata_err)?;
+        .map_err(map_metadata_err)?
+        .into_iter()
+        .map(|row| (row.space_node.clone(), row))
+        .collect();
 
-    if let Some(prefix) = args.prefix.as_deref() {
-        metadata_rows.retain(|row| row.name.to_lowercase().starts_with(prefix));
-    }
+    let nodes = state
+        .pubsub_storage
+        .list_nodes(&state.spaces_jid)
+        .await
+        .map_err(|e| internal_err(format!("pubsub list_nodes failed: {e}")))?;
 
+    let mut rows: Vec<SpaceListEntry> = nodes
+        .into_iter()
+        .filter_map(|node| {
+            let node = SpaceNode::from(node);
+            let space_jid = space_jid_for_node(&state.spaces_jid, &node)?;
+            let metadata = metadata_by_node.get(&node);
+            let name = metadata
+                .map(|row| row.name.clone())
+                .unwrap_or_else(|| default_space_name(&node));
+            if args
+                .prefix
+                .as_deref()
+                .is_some_and(|prefix| !name.to_lowercase().starts_with(prefix))
+            {
+                return None;
+            }
+            Some(SpaceListEntry {
+                space_jid,
+                space_node: node,
+                name,
+                description: metadata.and_then(|row| row.description.clone()),
+                icon_url: metadata.and_then(|row| row.icon_url.clone()),
+                channel_count: 0,
+                member_count: 0,
+            })
+        })
+        .collect();
+
+    rows.sort_by(|a, b| a.space_node.cmp(&b.space_node));
     if let Some(cursor) = args.after_cursor.as_deref() {
-        metadata_rows.retain(|row| row.space_jid.to_string().as_str() > cursor);
+        rows.retain(|row| row.space_node.as_str() > cursor);
     }
-    metadata_rows.sort_by(|a, b| a.space_jid.cmp(&b.space_jid));
 
     let limit = args.page_size as usize;
-    let total = metadata_rows.len();
+    let total = rows.len();
     let mut entries = Vec::with_capacity(limit.min(total));
 
-    for row in metadata_rows.iter().take(limit) {
-        let (channel_count, member_count) = counts_for_space(state, &row.space_jid).await?;
-        entries.push(SpaceListEntry {
-            space_jid: row.space_jid.clone(),
-            name: row.name.clone(),
-            description: row.description.clone(),
-            icon_url: row.icon_url.clone(),
-            channel_count,
-            member_count,
-        });
+    for mut row in rows.into_iter().take(limit) {
+        let (channel_count, member_count) = counts_for_space(state, &row.space_node).await?;
+        row.channel_count = channel_count;
+        row.member_count = member_count;
+        entries.push(row);
     }
 
     let next_cursor = if total > limit {
-        entries.last().map(|entry| entry.space_jid.to_string())
+        entries.last().map(|entry| entry.space_node.to_string())
     } else {
         None
     };
@@ -615,18 +687,15 @@ async fn run_list(state: &AppState, args: &SpacesListArgs) -> Result<SpacesListR
     })
 }
 
-async fn counts_for_space(state: &AppState, space_jid: &BareJid) -> Result<(u32, u32), AdminErr> {
-    let Some(node) = space_node_name(space_jid) else {
-        return Ok((0, 0));
-    };
+async fn counts_for_space(state: &AppState, node: &SpaceNode) -> Result<(u32, u32), AdminErr> {
     let items = state
         .pubsub_storage
-        .get_items(&state.spaces_jid, &node, None, &[])
+        .get_items(&state.spaces_jid, node, None, &[])
         .await
         .map_err(|e| internal_err(format!("pubsub get_items failed: {e}")))?;
     let affiliations = state
         .pubsub_storage
-        .list_node_affiliations(&state.spaces_jid, &node)
+        .list_node_affiliations(&state.spaces_jid, node)
         .await
         .map_err(|e| internal_err(format!("pubsub list_node_affiliations failed: {e}")))?;
     let channel_count = u32::try_from(items.len()).unwrap_or(u32::MAX);
@@ -883,8 +952,10 @@ async fn run_create(state: &AppState, args: &SpacesCreateArgs) -> Result<SpaceRe
     )
     .await;
 
+    let space_node = SpaceNode::from(localpart.clone());
     let metadata = SpaceMetadata {
         space_jid: space_jid.clone(),
+        space_node: space_node.clone(),
         name: args.name.clone(),
         description: args.description.clone(),
         icon_url: args.icon_url.clone(),
@@ -901,6 +972,7 @@ async fn run_create(state: &AppState, args: &SpacesCreateArgs) -> Result<SpaceRe
 
     Ok(SpaceRef {
         space_jid,
+        space_node,
         name: args.name.clone(),
         description: args.description.clone(),
         icon_url: args.icon_url.clone(),
@@ -926,27 +998,49 @@ fn mint_space_localpart(name: &str) -> String {
 }
 
 async fn run_update(state: &AppState, args: &SpacesUpdateArgs) -> Result<SpaceRef, AdminErr> {
-    let existing = state
-        .spaces_metadata_store
-        .get(&args.space_jid)
+    let (node_name, space_jid) =
+        canonical_space_jid(&state.spaces_jid, &args.space_jid, args.space_node.as_ref())?;
+    let space_node = state
+        .pubsub_storage
+        .get_node(&state.spaces_jid, &node_name)
         .await
-        .map_err(map_metadata_err)?
+        .map_err(|e| internal_err(format!("pubsub get_node failed: {e}")))?
         .ok_or_else(|| {
             Box::new(CommandResult::Error(XmppError::item_not_found(Some(
                 format!("no space '{}'", args.space_jid),
             ))))
         })?;
+    let existing = state
+        .spaces_metadata_store
+        .get_by_node(&node_name)
+        .await
+        .map_err(map_metadata_err)?;
 
-    let updated_name = args.name.clone().unwrap_or_else(|| existing.name.clone());
-    let updated_description = args.description.clone().or(existing.description.clone());
-    let updated_icon_url = args.icon_url.clone().or(existing.icon_url.clone());
+    let fallback_name = default_space_name(&node_name);
+    let updated_name = args
+        .name
+        .clone()
+        .or_else(|| existing.as_ref().map(|row| row.name.clone()))
+        .unwrap_or(fallback_name);
+    let updated_description = args
+        .description
+        .clone()
+        .or_else(|| existing.as_ref().and_then(|row| row.description.clone()));
+    let updated_icon_url = args
+        .icon_url
+        .clone()
+        .or_else(|| existing.as_ref().and_then(|row| row.icon_url.clone()));
 
     let metadata = SpaceMetadata {
-        space_jid: existing.space_jid.clone(),
+        space_jid: space_jid.clone(),
+        space_node: node_name.clone(),
         name: updated_name.clone(),
         description: updated_description.clone(),
         icon_url: updated_icon_url.clone(),
-        created_at: existing.created_at,
+        created_at: existing
+            .as_ref()
+            .map(|row| row.created_at)
+            .unwrap_or_else(|| space_node.created_at.timestamp()),
         updated_at: now_unix_seconds(),
     };
     state
@@ -956,7 +1050,8 @@ async fn run_update(state: &AppState, args: &SpacesUpdateArgs) -> Result<SpaceRe
         .map_err(map_metadata_err)?;
 
     Ok(SpaceRef {
-        space_jid: existing.space_jid,
+        space_jid,
+        space_node: node_name,
         name: updated_name,
         description: updated_description,
         icon_url: updated_icon_url,
@@ -973,16 +1068,15 @@ async fn run_delete(state: &AppState, args: &SpacesDeleteArgs) -> Result<(), Adm
     //   2. Legacy/bookmark items stored on the space's pubsub node
     //      (each item's `id` is a managed-room JID).
     // Both are unioned so the cascade is total.
-    let Some(node_name) = space_node_name(&args.space_jid) else {
-        return Err(bad_request("space_jid must have a localpart"));
-    };
+    let (node_name, space_jid) =
+        canonical_space_jid(&state.spaces_jid, &args.space_jid, args.space_node.as_ref())?;
 
     // Collect channels-to-destroy from both sources.
     let mut targets: std::collections::BTreeSet<BareJid> = std::collections::BTreeSet::new();
 
     let linked = state
         .channel_space_link_store
-        .list_channels_in_space(&args.space_jid)
+        .list_channels_in_space_node(&node_name)
         .await
         .map_err(|e| internal_err(format!("channel-space link storage: {e}")))?;
     for jid in linked {
@@ -1079,7 +1173,7 @@ async fn run_delete(state: &AppState, args: &SpacesDeleteArgs) -> Result<(), Adm
 
         if existing_link
             .as_ref()
-            .is_some_and(|link| link.space_jid != args.space_jid)
+            .is_some_and(|link| link.space_node != node_name)
         {
             cleanups.push(cleanup);
             continue;
@@ -1092,7 +1186,8 @@ async fn run_delete(state: &AppState, args: &SpacesDeleteArgs) -> Result<(), Adm
                 cleanup.removed_link = existing_link.or_else(|| {
                     Some(ChannelSpaceLink {
                         channel_jid: room_jid.clone(),
-                        space_jid: args.space_jid.clone(),
+                        space_jid: space_jid.clone(),
+                        space_node: node_name.clone(),
                         created_at: now_unix_seconds(),
                     })
                 });
@@ -1200,7 +1295,7 @@ async fn run_delete(state: &AppState, args: &SpacesDeleteArgs) -> Result<(), Adm
 
     let _existed = state
         .spaces_metadata_store
-        .delete(&args.space_jid)
+        .delete_by_node(&node_name)
         .await
         .map_err(map_metadata_err)?;
 
@@ -1211,9 +1306,8 @@ async fn run_members(
     state: &AppState,
     args: &SpacesMembersArgs,
 ) -> Result<SpacesMembersResult, AdminErr> {
-    let Some(node) = space_node_name(&args.space_jid) else {
-        return Err(bad_request("space_jid must have a localpart"));
-    };
+    let (node, _) =
+        canonical_space_jid(&state.spaces_jid, &args.space_jid, args.space_node.as_ref())?;
 
     let mut affiliations = state
         .pubsub_storage
@@ -1254,16 +1348,13 @@ async fn run_set_role(
     state: &AppState,
     args: &SpacesSetRoleArgs,
 ) -> Result<SpacesSetRoleResult, AdminErr> {
-    let Some(node) = space_node_name(&args.space_jid) else {
-        return Err(bad_request("space_jid must have a localpart"));
-    };
-    // Refuse silently for unknown spaces: if there's no metadata row,
-    // there's no space to grant a role on.
+    let (node, _) =
+        canonical_space_jid(&state.spaces_jid, &args.space_jid, args.space_node.as_ref())?;
     let exists = state
-        .spaces_metadata_store
-        .get(&args.space_jid)
+        .pubsub_storage
+        .get_node(&state.spaces_jid, &node)
         .await
-        .map_err(map_metadata_err)?
+        .map_err(|e| internal_err(format!("pubsub get_node failed: {e}")))?
         .is_some();
     if !exists {
         return Err(Box::new(CommandResult::Error(XmppError::item_not_found(
@@ -1291,6 +1382,7 @@ pub fn build_list_form(result: &SpacesListResult) -> DataForm {
     let mut form = DataForm::new(FormType::Result)
         .add_field(Field::form_type(NODE_LIST))
         .add_reported(Field::new("space_jid", FieldType::JidSingle).with_label("Space JID"))
+        .add_reported(Field::new("space_node", FieldType::TextSingle).with_label("Space Node"))
         .add_reported(Field::new("name", FieldType::TextSingle).with_label("Name"))
         .add_reported(Field::new("description", FieldType::TextSingle).with_label("Description"))
         .add_reported(Field::new("icon_url", FieldType::TextSingle).with_label("Icon URL"))
@@ -1299,6 +1391,8 @@ pub fn build_list_form(result: &SpacesListResult) -> DataForm {
     for entry in &result.entries {
         let row = vec![
             Field::new("space_jid", FieldType::JidSingle).with_value(entry.space_jid.to_string()),
+            Field::new("space_node", FieldType::TextSingle)
+                .with_value(entry.space_node.to_string()),
             Field::new("name", FieldType::TextSingle).with_value(entry.name.clone()),
             Field::new("description", FieldType::TextSingle)
                 .with_value(entry.description.clone().unwrap_or_default()),
@@ -1317,12 +1411,16 @@ pub fn build_list_form(result: &SpacesListResult) -> DataForm {
     form
 }
 
-pub fn build_space_form(space: &SpaceRef) -> DataForm {
+pub fn build_space_form(form_type: &str, space: &SpaceRef) -> DataForm {
     let mut form = DataForm::new(FormType::Result)
-        .add_field(Field::form_type(NODE_CREATE))
+        .add_field(Field::form_type(form_type))
         .add_field(
             Field::new("space_jid", FieldType::JidSingle).with_value(space.space_jid.to_string()),
         )
+        .add_field(Field::text_single(
+            "space_node",
+            space.space_node.to_string(),
+        ))
         .add_field(Field::text_single("name", space.name.clone()));
     if let Some(description) = space.description.as_ref() {
         form = form.add_field(Field::text_single("description", description));
@@ -1485,19 +1583,46 @@ mod tests {
         let result = SpacesListResult {
             entries: vec![SpaceListEntry {
                 space_jid: "eng@spaces.localhost".parse().expect("jid"),
+                space_node: SpaceNode::from("eng"),
                 name: "Engineering".to_string(),
                 description: Some("Hack".to_string()),
                 icon_url: None,
                 channel_count: 3,
                 member_count: 5,
             }],
-            next_cursor: Some("eng@spaces.localhost".to_string()),
+            next_cursor: Some("eng".to_string()),
         };
         let form = build_list_form(&result);
         assert!(matches!(form.form_type, FormType::Result));
-        assert_eq!(form.reported.len(), 6);
+        assert_eq!(form.reported.len(), 7);
         assert_eq!(form.items.len(), 1);
-        assert_eq!(form.get_value("next_cursor"), Some("eng@spaces.localhost"));
+        assert_eq!(form.get_value("next_cursor"), Some("eng"));
+    }
+
+    #[test]
+    fn space_jid_projection_round_trips_xep0106_escaped_node_ids() {
+        let spaces_jid: BareJid = "spaces.localhost".parse().expect("spaces jid");
+        let node = SpaceNode::from("music/a");
+        let projected = space_jid_for_node(&spaces_jid, &node).expect("projected jid");
+        assert_eq!(projected.to_string(), "music\\2fa@spaces.localhost");
+        assert_eq!(
+            crate::space_identity::space_node_name(&projected).as_deref(),
+            Some("music/a")
+        );
+    }
+
+    #[test]
+    fn build_space_form_uses_supplied_command_form_type() {
+        let space = SpaceRef {
+            space_jid: "eng@spaces.localhost".parse().expect("jid"),
+            space_node: SpaceNode::from("eng"),
+            name: "Engineering".to_string(),
+            description: None,
+            icon_url: None,
+        };
+        let form = build_space_form(NODE_UPDATE, &space);
+        assert!(matches!(form.form_type, FormType::Result));
+        assert_eq!(form.get_value("FORM_TYPE"), Some(NODE_UPDATE));
     }
 
     #[test]

--- a/server/crates/waddle-server/src/channel_space_links/mod.rs
+++ b/server/crates/waddle-server/src/channel_space_links/mod.rs
@@ -28,6 +28,7 @@ use thiserror::Error;
 use tracing::{info, instrument};
 
 use crate::db::{Database, DatabaseConfig, DatabaseDriver, IntoParams};
+use crate::space_identity::SpaceNode;
 
 mod schema;
 pub mod storage;
@@ -41,6 +42,7 @@ pub use storage::InMemoryChannelSpaceLinkStore;
 pub struct ChannelSpaceLink {
     pub channel_jid: BareJid,
     pub space_jid: BareJid,
+    pub space_node: SpaceNode,
     /// Unix seconds.
     pub created_at: i64,
 }
@@ -87,6 +89,12 @@ pub trait ChannelSpaceLinkStore: Send + Sync {
     async fn list_channels_in_space(
         &self,
         space_jid: &BareJid,
+    ) -> Result<Vec<BareJid>, ChannelSpaceLinkError>;
+
+    /// Return every `channel_jid` linked to the exact XEP-0060 Spaces node id.
+    async fn list_channels_in_space_node(
+        &self,
+        space_node: &SpaceNode,
     ) -> Result<Vec<BareJid>, ChannelSpaceLinkError>;
 
     /// Return every link row, ordered by ascending `created_at` then
@@ -228,17 +236,21 @@ fn decode_row(row: &crate::db::Row) -> Result<ChannelSpaceLink, ChannelSpaceLink
                 raw: space_jid_raw.clone(),
                 source: error,
             })?;
-    let created_at: i64 = row
+    let space_node: String = row
         .get(2)
+        .map_err(|error| ChannelSpaceLinkError::Storage(error.to_string()))?;
+    let created_at: i64 = row
+        .get(3)
         .map_err(|error| ChannelSpaceLinkError::Storage(error.to_string()))?;
     Ok(ChannelSpaceLink {
         channel_jid,
         space_jid,
+        space_node: SpaceNode::from(space_node),
         created_at,
     })
 }
 
-const SELECT_COLS: &str = "channel_jid, space_jid, created_at";
+const SELECT_COLS: &str = "channel_jid, space_jid, space_node, created_at";
 
 #[async_trait]
 impl ChannelSpaceLinkStore for DatabaseChannelSpaceLinkStore {
@@ -248,16 +260,18 @@ impl ChannelSpaceLinkStore for DatabaseChannelSpaceLinkStore {
         // ordering is stable.
         let sql = r#"
             INSERT INTO channel_space_links (
-                channel_jid, space_jid, created_at
-            ) VALUES (?, ?, ?)
+                channel_jid, space_jid, space_node, created_at
+            ) VALUES (?, ?, ?, ?)
             ON CONFLICT(channel_jid) DO UPDATE SET
-                space_jid = excluded.space_jid
+                space_jid = excluded.space_jid,
+                space_node = excluded.space_node
         "#;
         self.execute(
             sql,
             crate::db_params![
                 link.channel_jid.to_string(),
                 link.space_jid.to_string(),
+                link.space_node.as_str(),
                 link.created_at,
             ],
         )
@@ -307,6 +321,30 @@ impl ChannelSpaceLinkStore for DatabaseChannelSpaceLinkStore {
         );
         let mut rows = self
             .query(&sql, crate::db_params![space_jid.to_string()])
+            .await?;
+        let mut out = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|error| ChannelSpaceLinkError::Storage(error.to_string()))?
+        {
+            out.push(decode_row(&row)?.channel_jid);
+        }
+        Ok(out)
+    }
+
+    #[instrument(skip(self), fields(space_node = %space_node))]
+    async fn list_channels_in_space_node(
+        &self,
+        space_node: &SpaceNode,
+    ) -> Result<Vec<BareJid>, ChannelSpaceLinkError> {
+        let sql = format!(
+            "SELECT {SELECT_COLS} FROM channel_space_links \
+             WHERE space_node = ? \
+             ORDER BY created_at ASC, channel_jid ASC"
+        );
+        let mut rows = self
+            .query(&sql, crate::db_params![space_node.as_str()])
             .await?;
         let mut out = Vec::new();
         while let Some(row) = rows

--- a/server/crates/waddle-server/src/channel_space_links/schema.rs
+++ b/server/crates/waddle-server/src/channel_space_links/schema.rs
@@ -2,6 +2,7 @@
 //! mirroring the `spaces_metadata` schema migration shape.
 
 use super::{ChannelSpaceLinkError, DatabaseChannelSpaceLinkStore};
+use crate::space_identity::projected_space_node_from_jid_text;
 
 pub(super) async fn initialize(
     store: &DatabaseChannelSpaceLinkStore,
@@ -12,11 +13,14 @@ pub(super) async fn initialize(
         CREATE TABLE IF NOT EXISTS channel_space_links (
             channel_jid TEXT PRIMARY KEY,
             space_jid TEXT NOT NULL,
+            space_node TEXT NOT NULL,
             created_at {i64_type} NOT NULL
         )
         "#
     );
     store.execute(&sql, ()).await?;
+    add_column_if_missing(store, "space_node TEXT NOT NULL DEFAULT ''").await?;
+    backfill_space_node_from_jid(store).await?;
 
     crate::db::widen_postgres_i64_column_to_bigint(&store.db, "channel_space_links", "created_at")
         .await
@@ -31,10 +35,75 @@ pub(super) async fn initialize(
         .await?;
     store
         .execute(
+            "CREATE INDEX IF NOT EXISTS idx_channel_space_links_space_node \
+             ON channel_space_links (space_node, created_at ASC, channel_jid ASC)",
+            (),
+        )
+        .await?;
+    store
+        .execute(
             "CREATE INDEX IF NOT EXISTS idx_channel_space_links_created_at \
              ON channel_space_links (created_at ASC, channel_jid ASC)",
             (),
         )
         .await?;
     Ok(())
+}
+
+async fn backfill_space_node_from_jid(
+    store: &DatabaseChannelSpaceLinkStore,
+) -> Result<(), ChannelSpaceLinkError> {
+    let mut rows = store
+        .query(
+            "SELECT channel_jid, space_jid FROM channel_space_links WHERE space_node = ''",
+            (),
+        )
+        .await?;
+    let mut updates = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|error| ChannelSpaceLinkError::Storage(error.to_string()))?
+    {
+        let channel_jid: String = row
+            .get(0)
+            .map_err(|error| ChannelSpaceLinkError::Storage(error.to_string()))?;
+        let space_jid: String = row
+            .get(1)
+            .map_err(|error| ChannelSpaceLinkError::Storage(error.to_string()))?;
+        updates.push((channel_jid, projected_space_node_from_jid_text(&space_jid)));
+    }
+    drop(rows);
+
+    for (channel_jid, space_node) in updates {
+        let space_node = space_node.into_string();
+        store
+            .execute(
+                "UPDATE channel_space_links SET space_node = ? WHERE channel_jid = ?",
+                crate::db_params![space_node, channel_jid],
+            )
+            .await?;
+    }
+    Ok(())
+}
+
+async fn add_column_if_missing(
+    store: &DatabaseChannelSpaceLinkStore,
+    definition: &'static str,
+) -> Result<(), ChannelSpaceLinkError> {
+    match store
+        .execute(
+            &format!("ALTER TABLE channel_space_links ADD COLUMN {definition}"),
+            (),
+        )
+        .await
+    {
+        Ok(_) => Ok(()),
+        Err(ChannelSpaceLinkError::Storage(error))
+            if error.contains("duplicate column") || error.contains("already exists") =>
+        {
+            Ok(())
+        }
+        Err(error) => Err(error),
+    }
 }

--- a/server/crates/waddle-server/src/channel_space_links/storage.rs
+++ b/server/crates/waddle-server/src/channel_space_links/storage.rs
@@ -8,6 +8,7 @@ use async_trait::async_trait;
 use jid::BareJid;
 
 use super::{ChannelSpaceLink, ChannelSpaceLinkError, ChannelSpaceLinkStore};
+use crate::space_identity::SpaceNode;
 
 #[derive(Debug, Default)]
 pub struct InMemoryChannelSpaceLinkStore {
@@ -77,6 +78,27 @@ impl ChannelSpaceLinkStore for InMemoryChannelSpaceLinkStore {
         let mut rows: Vec<ChannelSpaceLink> = guard
             .values()
             .filter(|row| &row.space_jid == space_jid)
+            .cloned()
+            .collect();
+        rows.sort_by(|a, b| {
+            a.created_at
+                .cmp(&b.created_at)
+                .then_with(|| a.channel_jid.cmp(&b.channel_jid))
+        });
+        Ok(rows.into_iter().map(|row| row.channel_jid).collect())
+    }
+
+    async fn list_channels_in_space_node(
+        &self,
+        space_node: &SpaceNode,
+    ) -> Result<Vec<BareJid>, ChannelSpaceLinkError> {
+        let guard = self
+            .rows
+            .lock()
+            .map_err(|error| ChannelSpaceLinkError::Storage(error.to_string()))?;
+        let mut rows: Vec<ChannelSpaceLink> = guard
+            .values()
+            .filter(|row| &row.space_node == space_node)
             .cloned()
             .collect();
         rows.sort_by(|a, b| {

--- a/server/crates/waddle-server/src/channel_space_links/tests.rs
+++ b/server/crates/waddle-server/src/channel_space_links/tests.rs
@@ -2,6 +2,8 @@
 
 use jid::BareJid;
 
+use crate::space_identity::SpaceNode;
+
 use super::{ChannelSpaceLink, ChannelSpaceLinkStore, DatabaseChannelSpaceLinkStore};
 
 fn channel_jid(local: &str) -> BareJid {
@@ -17,9 +19,11 @@ fn space_jid(local: &str) -> BareJid {
 }
 
 fn link(channel: BareJid, space: BareJid, created_at: i64) -> ChannelSpaceLink {
+    let space_node = SpaceNode::from(space.node().expect("space node").to_string());
     ChannelSpaceLink {
         channel_jid: channel,
         space_jid: space,
+        space_node,
         created_at,
     }
 }
@@ -55,6 +59,7 @@ async fn set_preserves_created_at_when_relinking_channel() {
 
     let relinked = ChannelSpaceLink {
         space_jid: space_jid("design"),
+        space_node: SpaceNode::from("design"),
         created_at: 1_700_000_500,
         ..initial.clone()
     };
@@ -66,6 +71,7 @@ async fn set_preserves_created_at_when_relinking_channel() {
         .expect("get")
         .expect("row present after relink");
     assert_eq!(fetched.space_jid, space_jid("design"));
+    assert_eq!(fetched.space_node, "design");
     assert_eq!(
         fetched.created_at, 1_700_000_000,
         "created_at preserved across relink"
@@ -122,20 +128,33 @@ async fn list_channels_in_space_filters_by_space_and_orders_by_created_at() {
         .expect("list eng");
     assert_eq!(
         in_eng,
-        vec![alpha.channel_jid, beta.channel_jid, gamma.channel_jid]
+        vec![
+            alpha.channel_jid.clone(),
+            beta.channel_jid.clone(),
+            gamma.channel_jid.clone()
+        ]
     );
 
     let in_design = store
         .list_channels_in_space(&space_jid("design"))
         .await
         .expect("list design");
-    assert_eq!(in_design, vec![unrelated.channel_jid]);
+    assert_eq!(in_design, vec![unrelated.channel_jid.clone()]);
 
     let in_empty = store
         .list_channels_in_space(&space_jid("ghost"))
         .await
         .expect("list ghost");
     assert!(in_empty.is_empty());
+
+    let in_eng_node = store
+        .list_channels_in_space_node(&SpaceNode::from("eng"))
+        .await
+        .expect("list eng node");
+    assert_eq!(
+        in_eng_node,
+        vec![alpha.channel_jid, beta.channel_jid, gamma.channel_jid]
+    );
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/src/lib.rs
+++ b/server/crates/waddle-server/src/lib.rs
@@ -24,6 +24,7 @@ pub mod room_policy;
 pub mod server;
 pub mod sm_persistence;
 pub mod sm_promotion;
+pub mod space_identity;
 pub mod spaces_metadata;
 pub mod spaces_pubsub_seed;
 pub mod storage;

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/disco_info/spaces.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/disco_info/spaces.rs
@@ -58,22 +58,20 @@ pub(super) async fn handle_spaces_disco_info<'a>(
                 internal_server_error_iq_error("Internal server error."),
             ));
         };
-        if let Ok(space_jid) = format!("{}@{}", node, spaces_jid.domain()).parse::<BareJid>() {
-            if let Ok(Some(metadata)) = state
-                .deps
-                .app_state
-                .spaces_metadata_store
-                .get(&space_jid)
-                .await
+        if let Ok(Some(metadata)) = state
+            .deps
+            .app_state
+            .spaces_metadata_store
+            .get_by_node(&crate::space_identity::SpaceNode::from(node))
+            .await
+        {
+            space.name = metadata.name;
+            space.description = metadata.description;
+            space.icon_url = metadata.icon_url;
+            if let Some(created_at) =
+                chrono::DateTime::<chrono::Utc>::from_timestamp(metadata.created_at, 0)
             {
-                space.name = metadata.name;
-                space.description = metadata.description;
-                space.icon_url = metadata.icon_url;
-                if let Some(created_at) =
-                    chrono::DateTime::<chrono::Utc>::from_timestamp(metadata.created_at, 0)
-                {
-                    space.created_at = created_at.to_rfc3339();
-                }
+                space.created_at = created_at.to_rfc3339();
             }
         }
         let requester_affiliation =

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_admin.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_admin.rs
@@ -3,6 +3,7 @@ use super::permissions::{
 };
 use super::pubsub_helpers::{is_pep_self_or_to, spaces_service_bare_jid};
 use super::*;
+use crate::space_identity::{space_jid_for_node, SpaceNode};
 
 fn is_pubsub_attachment_or_summary_node(node: &str) -> bool {
     node.starts_with(&format!(
@@ -40,6 +41,10 @@ pub(super) async fn handle_pubsub_admin_request(
                     let Ok(spaces_jid) = spaces_service_bare_jid(spaces_domain) else {
                         return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::InvalidJid))];
                     };
+                    let space_node = SpaceNode::from(node.as_str());
+                    if space_jid_for_node(&spaces_jid, &space_node).is_none() {
+                        return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::BadRequest))];
+                    }
                     match state
                         .deps
                         .protocol

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
@@ -4,6 +4,7 @@ use super::permissions::{
 };
 use super::*;
 use crate::server::routes::websocket::handlers::pubsub_fanout;
+use crate::space_identity::{space_jid_for_node, SpaceNode};
 
 /// PEP self-or-to check (XEP-0163 §3).
 ///
@@ -78,10 +79,6 @@ pub(super) fn spaces_service_bare_jid(spaces_domain: &str) -> Result<BareJid, St
     spaces_domain
         .parse::<BareJid>()
         .map_err(|error| format!("invalid spaces service JID: {error}"))
-}
-
-fn space_jid_for_node(spaces_jid: &BareJid, node: &str) -> Option<BareJid> {
-    format!("{}@{}", node, spaces_jid.domain()).parse().ok()
 }
 
 pub(super) fn space_details_from_node(
@@ -275,19 +272,12 @@ async fn backfill_missing_space_bookmarks(
     node: &str,
     item_ids: &[String],
 ) {
-    let Some(space_jid) = space_jid_for_node(spaces_jid, node) else {
-        warn!(
-            node,
-            spaces = %spaces_jid,
-            "Skipping channel-space link bookmark backfill for non-JID Space node"
-        );
-        return;
-    };
+    let space_node = SpaceNode::from(node);
     let links = match state
         .deps
         .app_state
         .channel_space_link_store
-        .list_channels_in_space(&space_jid)
+        .list_channels_in_space_node(&space_node)
         .await
     {
         Ok(links) => links,
@@ -720,7 +710,8 @@ pub(super) async fn handle_spaces_publish(
         .await
     {
         Ok(result) => {
-            let projected_space_jid = space_jid_for_node(&spaces_jid, node);
+            let space_node = SpaceNode::from(node);
+            let projected_space_jid = space_jid_for_node(&spaces_jid, &space_node);
             if let Some(space_jid) = projected_space_jid.as_ref() {
                 if let Err(error) = state
                     .deps
@@ -729,6 +720,7 @@ pub(super) async fn handle_spaces_publish(
                     .set(&crate::channel_space_links::ChannelSpaceLink {
                         channel_jid: bookmark.jid.clone(),
                         space_jid: space_jid.clone(),
+                        space_node: space_node.clone(),
                         created_at: chrono::Utc::now().timestamp(),
                     })
                     .await
@@ -2034,7 +2026,6 @@ pub(super) async fn handle_spaces_retract(
     let Ok(spaces_jid) = spaces_service_bare_jid(spaces_domain) else {
         return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::InvalidJid))];
     };
-    let target_space_jid = space_jid_for_node(&spaces_jid, node);
     let item_filter = [item_id.to_string()];
     match state
         .deps
@@ -2062,7 +2053,7 @@ pub(super) async fn handle_spaces_retract(
         .get(&room_jid)
         .await
     {
-        Ok(Some(link)) if target_space_jid.as_ref() == Some(&link.space_jid) => Some(link),
+        Ok(Some(link)) if link.space_node == node => Some(link),
         Ok(_) => None,
         Err(error) => {
             warn!(item_id, node, error = %error, "Failed to read channel-space link before Spaces retract");

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
@@ -2301,6 +2301,7 @@ async fn handle_iq_pubsub_items_spaces_node_backfills_linked_channel_bookmarks()
         .set(&crate::channel_space_links::ChannelSpaceLink {
             channel_jid: channel_jid.clone(),
             space_jid: "team@spaces.example.com".parse().expect("space jid"),
+            space_node: crate::space_identity::SpaceNode::from("team"),
             created_at: 0,
         })
         .await
@@ -2408,6 +2409,7 @@ async fn handle_iq_pubsub_items_spaces_node_requires_authorization_before_backfi
             space_jid: "private-team@spaces.example.com"
                 .parse()
                 .expect("space jid"),
+            space_node: crate::space_identity::SpaceNode::from("private-team"),
             created_at: 0,
         })
         .await
@@ -2770,6 +2772,7 @@ async fn admin_channels_delete_retracts_duplicate_space_bookmarks() {
             space_jid: format!("alpha@{}", state.deps.app_state.spaces_jid.domain())
                 .parse()
                 .expect("space jid"),
+            space_node: crate::space_identity::SpaceNode::from("alpha"),
             created_at: 0,
         })
         .await
@@ -2893,6 +2896,7 @@ async fn admin_channels_update_retracts_duplicate_space_bookmarks() {
             space_jid: format!("alpha@{}", state.deps.app_state.spaces_jid.domain())
                 .parse()
                 .expect("space jid"),
+            space_node: crate::space_identity::SpaceNode::from("alpha"),
             created_at: 0,
         })
         .await
@@ -3107,6 +3111,7 @@ async fn admin_spaces_delete_clears_channel_parent_tuple() {
             space_jid: format!("alpha@{}", spaces_jid.domain())
                 .parse()
                 .expect("space jid"),
+            space_node: crate::space_identity::SpaceNode::from("alpha"),
             created_at: 0,
         })
         .await
@@ -3277,7 +3282,7 @@ async fn spaces_publish_and_retract_sync_channel_space_link_projection() {
 }
 
 #[tokio::test]
-async fn spaces_publish_accepts_non_jid_node_and_syncs_parent_tuple() {
+async fn spaces_publish_accepts_escaped_space_node_and_syncs_link_projection() {
     let state = create_test_websocket_state().await;
     let conn = state
         .deps
@@ -3334,17 +3339,15 @@ async fn spaces_publish_accepts_non_jid_node_and_syncs_parent_tuple() {
         publish_response.contains("type='result'") || publish_response.contains("type=\"result\""),
         "spaces publish should accept non-JID node ids: {publish_response}"
     );
-    assert!(
-        state
-            .deps
-            .app_state
-            .channel_space_link_store
-            .get(&room_jid)
-            .await
-            .expect("channel-space link")
-            .is_none(),
-        "non-JID Space nodes should not be forced into the BareJid link projection"
-    );
+    let link = state
+        .deps
+        .app_state
+        .channel_space_link_store
+        .get(&room_jid)
+        .await
+        .expect("channel-space link")
+        .expect("escaped Space node should sync durable channel-space link");
+    assert_eq!(link.space_node, "music/A");
     assert!(
         channel_view_allowed_for_test(state.as_ref(), "hierarchical", &viewer.user_jid).await,
         "publish should still write the channel parent tuple for non-JID Space nodes"
@@ -3374,6 +3377,17 @@ async fn spaces_publish_accepts_non_jid_node_and_syncs_parent_tuple() {
     assert!(
         !channel_view_allowed_for_test(state.as_ref(), "hierarchical", &viewer.user_jid).await,
         "retract should clear the channel parent tuple for non-JID Space nodes"
+    );
+    assert!(
+        state
+            .deps
+            .app_state
+            .channel_space_link_store
+            .get(&room_jid)
+            .await
+            .expect("channel-space link after retract")
+            .is_none(),
+        "retract should clear the matching exact-node channel-space link"
     );
 }
 

--- a/server/crates/waddle-server/src/space_identity.rs
+++ b/server/crates/waddle-server/src/space_identity.rs
@@ -1,0 +1,222 @@
+//! Typed Spaces PubSub node identity and XEP-0106 JID projection helpers.
+
+use std::fmt;
+use std::ops::Deref;
+
+use jid::BareJid;
+use waddle_xmpp::xep::xep0106::unescape_node;
+
+/// Exact XEP-0060 node id under the Spaces PubSub service.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SpaceNode(String);
+
+impl SpaceNode {
+    pub fn new(node: impl Into<String>) -> Self {
+        Self(node.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl From<String> for SpaceNode {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<&str> for SpaceNode {
+    fn from(value: &str) -> Self {
+        Self::new(value)
+    }
+}
+
+impl AsRef<str> for SpaceNode {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Deref for SpaceNode {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for SpaceNode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl PartialEq<&str> for SpaceNode {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
+    }
+}
+
+impl PartialEq<SpaceNode> for &str {
+    fn eq(&self, other: &SpaceNode) -> bool {
+        *self == other.as_str()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SpaceProjectionError {
+    WrongDomain,
+    MissingLocalpart,
+    InvalidNode(SpaceNode),
+    MismatchedProjection,
+}
+
+pub fn space_node_name(space_jid: &BareJid) -> Option<SpaceNode> {
+    space_jid
+        .node()
+        .map(|node| SpaceNode::from(unescape_node(node.as_ref())))
+}
+
+pub fn projected_space_node_from_jid_text(space_jid_raw: &str) -> SpaceNode {
+    space_jid_raw
+        .parse::<BareJid>()
+        .ok()
+        .and_then(|space_jid| space_node_name(&space_jid))
+        .filter(|space_node| !space_node.as_str().is_empty())
+        .unwrap_or_else(|| SpaceNode::from(space_jid_raw))
+}
+
+pub fn space_jid_for_node(spaces_jid: &BareJid, node: &SpaceNode) -> Option<BareJid> {
+    if !is_projectable_space_node(node) {
+        return None;
+    }
+    format!(
+        "{}@{}",
+        escape_space_node_projection(node.as_str()),
+        spaces_jid.domain()
+    )
+    .parse()
+    .ok()
+}
+
+pub fn is_projectable_space_node(node: &SpaceNode) -> bool {
+    let node = node.as_str();
+    !node.starts_with(' ') && !node.ends_with(' ')
+}
+
+fn escape_space_node_projection(input: &str) -> String {
+    let mut result = String::with_capacity(input.len());
+    for (byte_idx, ch) in input.char_indices() {
+        match ch {
+            ' ' => result.push_str("\\20"),
+            '"' => result.push_str("\\22"),
+            '&' => result.push_str("\\26"),
+            '\'' => result.push_str("\\27"),
+            '/' => result.push_str("\\2f"),
+            ':' => result.push_str("\\3a"),
+            '<' => result.push_str("\\3c"),
+            '>' => result.push_str("\\3e"),
+            '@' => result.push_str("\\40"),
+            '\\' if starts_xep0106_escape_sequence(&input[byte_idx + 1..]) => {
+                result.push_str("\\5c");
+            }
+            '\\' => result.push('\\'),
+            _ => result.push(ch),
+        }
+    }
+    result
+}
+
+fn starts_xep0106_escape_sequence(input: &str) -> bool {
+    let next_two: String = input.chars().take(2).collect();
+    matches!(
+        next_two.as_str(),
+        "20" | "22" | "26" | "27" | "2f" | "3a" | "3c" | "3e" | "40" | "5c"
+    )
+}
+
+pub fn canonical_space_projection(
+    spaces_jid: &BareJid,
+    space_jid: &BareJid,
+    space_node: Option<&SpaceNode>,
+) -> Result<(SpaceNode, BareJid), SpaceProjectionError> {
+    if space_jid.domain() != spaces_jid.domain() {
+        return Err(SpaceProjectionError::WrongDomain);
+    }
+    let node = match space_node {
+        Some(node) => node.clone(),
+        None => space_node_name(space_jid).ok_or(SpaceProjectionError::MissingLocalpart)?,
+    };
+    let Some(canonical) = space_jid_for_node(spaces_jid, &node) else {
+        return Err(SpaceProjectionError::InvalidNode(node));
+    };
+    if &canonical != space_jid {
+        return Err(SpaceProjectionError::MismatchedProjection);
+    }
+    Ok((node, canonical))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn space_jid_projection_distinguishes_escape_looking_space_nodes() {
+        let spaces_jid: BareJid = "spaces.localhost".parse().expect("spaces jid");
+        let slash_node = SpaceNode::from("music/a");
+        let literal_escape_node = SpaceNode::from("music\\2fa");
+
+        let slash_projection =
+            space_jid_for_node(&spaces_jid, &slash_node).expect("slash projection");
+        let literal_projection =
+            space_jid_for_node(&spaces_jid, &literal_escape_node).expect("literal projection");
+
+        assert_eq!(slash_projection.to_string(), "music\\2fa@spaces.localhost");
+        assert_eq!(
+            literal_projection.to_string(),
+            "music\\5c2fa@spaces.localhost"
+        );
+        assert_ne!(slash_projection, literal_projection);
+        assert_eq!(space_node_name(&slash_projection), Some(slash_node));
+        assert_eq!(
+            space_node_name(&literal_projection),
+            Some(literal_escape_node)
+        );
+    }
+
+    #[test]
+    fn space_jid_projection_preserves_non_escape_backslash_sequences() {
+        let spaces_jid: BareJid = "spaces.localhost".parse().expect("spaces jid");
+        let node = SpaceNode::from("foo\\bar");
+
+        let projection = space_jid_for_node(&spaces_jid, &node).expect("projection");
+
+        assert_eq!(projection.to_string(), "foo\\bar@spaces.localhost");
+        assert_eq!(space_node_name(&projection), Some(node));
+    }
+
+    #[test]
+    fn space_jid_projection_rejects_boundary_space_nodes() {
+        let spaces_jid: BareJid = "spaces.localhost".parse().expect("spaces jid");
+
+        for node in [" ops", "ops ", " "] {
+            assert_eq!(
+                space_jid_for_node(&spaces_jid, &SpaceNode::from(node)),
+                None,
+                "{node:?} must not project to a jid-single value"
+            );
+        }
+
+        assert_eq!(
+            space_jid_for_node(&spaces_jid, &SpaceNode::from("ops team"))
+                .expect("interior space projection")
+                .to_string(),
+            "ops\\20team@spaces.localhost"
+        );
+    }
+}

--- a/server/crates/waddle-server/src/spaces_metadata/mod.rs
+++ b/server/crates/waddle-server/src/spaces_metadata/mod.rs
@@ -25,6 +25,7 @@ use thiserror::Error;
 use tracing::{info, instrument};
 
 use crate::db::{Database, DatabaseConfig, DatabaseDriver, IntoParams};
+use crate::space_identity::SpaceNode;
 
 mod schema;
 pub mod storage;
@@ -37,6 +38,7 @@ pub use storage::InMemorySpacesMetadataStore;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SpaceMetadata {
     pub space_jid: BareJid,
+    pub space_node: SpaceNode,
     pub name: String,
     pub description: Option<String>,
     pub icon_url: Option<String>,
@@ -68,6 +70,12 @@ pub trait SpacesMetadataStore: Send + Sync {
     /// Fetch the metadata row for `space_jid` (`Ok(None)` when absent).
     async fn get(&self, space_jid: &BareJid) -> Result<Option<SpaceMetadata>, SpacesMetadataError>;
 
+    /// Fetch the metadata row for the exact XEP-0060 Spaces node id.
+    async fn get_by_node(
+        &self,
+        space_node: &SpaceNode,
+    ) -> Result<Option<SpaceMetadata>, SpacesMetadataError>;
+
     /// Insert or replace the metadata row keyed by `metadata.space_jid`.
     ///
     /// On conflict the row is overwritten; the caller is responsible for
@@ -79,6 +87,9 @@ pub trait SpacesMetadataStore: Send + Sync {
     ///
     /// Returns `true` when a row was removed, `false` when no row matched.
     async fn delete(&self, space_jid: &BareJid) -> Result<bool, SpacesMetadataError>;
+
+    /// Delete the metadata row for the exact XEP-0060 Spaces node id.
+    async fn delete_by_node(&self, space_node: &SpaceNode) -> Result<bool, SpacesMetadataError>;
 
     /// Return every metadata row, ordered by ascending `created_at` so
     /// callers see rows in insertion order. Pagination is intentionally
@@ -211,23 +222,27 @@ fn decode_row(row: &crate::db::Row) -> Result<SpaceMetadata, SpacesMetadataError
                 raw: space_jid_raw.clone(),
                 source: error,
             })?;
-    let name: String = row
+    let space_node: String = row
         .get(1)
         .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
-    let description: Option<String> = row
+    let name: String = row
         .get(2)
         .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
-    let icon_url: Option<String> = row
+    let description: Option<String> = row
         .get(3)
         .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
-    let created_at: i64 = row
+    let icon_url: Option<String> = row
         .get(4)
         .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
-    let updated_at: i64 = row
+    let created_at: i64 = row
         .get(5)
+        .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+    let updated_at: i64 = row
+        .get(6)
         .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
     Ok(SpaceMetadata {
         space_jid,
+        space_node: SpaceNode::from(space_node),
         name,
         description,
         icon_url,
@@ -236,7 +251,8 @@ fn decode_row(row: &crate::db::Row) -> Result<SpaceMetadata, SpacesMetadataError
     })
 }
 
-const SELECT_COLS: &str = "space_jid, name, description, icon_url, created_at, updated_at";
+const SELECT_COLS: &str =
+    "space_jid, space_node, name, description, icon_url, created_at, updated_at";
 
 #[async_trait]
 impl SpacesMetadataStore for DatabaseSpacesMetadataStore {
@@ -256,13 +272,33 @@ impl SpacesMetadataStore for DatabaseSpacesMetadataStore {
         Ok(Some(decode_row(&row)?))
     }
 
+    #[instrument(skip(self), fields(space_node = %space_node))]
+    async fn get_by_node(
+        &self,
+        space_node: &SpaceNode,
+    ) -> Result<Option<SpaceMetadata>, SpacesMetadataError> {
+        let sql = format!("SELECT {SELECT_COLS} FROM spaces_metadata WHERE space_node = ?");
+        let mut rows = self
+            .query(&sql, crate::db_params![space_node.as_str()])
+            .await?;
+        let Some(row) = rows
+            .next()
+            .await
+            .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(decode_row(&row)?))
+    }
+
     #[instrument(skip(self, metadata), fields(space = %metadata.space_jid))]
     async fn upsert(&self, metadata: &SpaceMetadata) -> Result<(), SpacesMetadataError> {
         let sql = r#"
             INSERT INTO spaces_metadata (
-                space_jid, name, description, icon_url, created_at, updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?)
-            ON CONFLICT(space_jid) DO UPDATE SET
+                space_jid, space_node, name, description, icon_url, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(space_node) DO UPDATE SET
+                space_jid = excluded.space_jid,
                 name = excluded.name,
                 description = excluded.description,
                 icon_url = excluded.icon_url,
@@ -272,6 +308,7 @@ impl SpacesMetadataStore for DatabaseSpacesMetadataStore {
             sql,
             crate::db_params![
                 metadata.space_jid.to_string(),
+                metadata.space_node.as_str(),
                 metadata.name.clone(),
                 metadata.description.clone(),
                 metadata.icon_url.clone(),
@@ -294,10 +331,21 @@ impl SpacesMetadataStore for DatabaseSpacesMetadataStore {
         Ok(affected > 0)
     }
 
+    #[instrument(skip(self), fields(space_node = %space_node))]
+    async fn delete_by_node(&self, space_node: &SpaceNode) -> Result<bool, SpacesMetadataError> {
+        let affected = self
+            .execute(
+                "DELETE FROM spaces_metadata WHERE space_node = ?",
+                crate::db_params![space_node.as_str()],
+            )
+            .await?;
+        Ok(affected > 0)
+    }
+
     #[instrument(skip(self))]
     async fn list_all(&self) -> Result<Vec<SpaceMetadata>, SpacesMetadataError> {
         let sql = format!(
-            "SELECT {SELECT_COLS} FROM spaces_metadata ORDER BY created_at ASC, space_jid ASC"
+            "SELECT {SELECT_COLS} FROM spaces_metadata ORDER BY created_at ASC, space_node ASC"
         );
         let mut rows = self.query(&sql, ()).await?;
         let mut out = Vec::new();

--- a/server/crates/waddle-server/src/spaces_metadata/schema.rs
+++ b/server/crates/waddle-server/src/spaces_metadata/schema.rs
@@ -2,24 +2,17 @@
 //! mirroring the inbox schema migration shape.
 
 use super::{DatabaseSpacesMetadataStore, SpacesMetadataError};
+use crate::space_identity::projected_space_node_from_jid_text;
 
 pub(super) async fn initialize(
     store: &DatabaseSpacesMetadataStore,
 ) -> Result<(), SpacesMetadataError> {
     let i64_type = crate::db::i64_sql_type(store.db.driver());
-    let sql = format!(
-        r#"
-        CREATE TABLE IF NOT EXISTS spaces_metadata (
-            space_jid TEXT PRIMARY KEY,
-            name TEXT NOT NULL,
-            description TEXT,
-            icon_url TEXT,
-            created_at {i64_type} NOT NULL,
-            updated_at {i64_type} NOT NULL
-        )
-        "#
-    );
+    let sql = create_table_sql("spaces_metadata", i64_type);
     store.execute(&sql, ()).await?;
+    add_column_if_missing(store, "space_node TEXT NOT NULL DEFAULT ''").await?;
+    backfill_space_node_from_jid(store).await?;
+    rebuild_legacy_space_jid_primary_key(store, i64_type).await?;
 
     crate::db::widen_postgres_i64_column_to_bigint(&store.db, "spaces_metadata", "created_at")
         .await
@@ -30,10 +23,230 @@ pub(super) async fn initialize(
 
     store
         .execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_spaces_metadata_space_node \
+             ON spaces_metadata (space_node)",
+            (),
+        )
+        .await?;
+    store
+        .execute(
             "CREATE INDEX IF NOT EXISTS idx_spaces_metadata_created_at \
-             ON spaces_metadata (created_at ASC, space_jid ASC)",
+             ON spaces_metadata (created_at ASC, space_node ASC)",
+            (),
+        )
+        .await?;
+    store
+        .execute(
+            "CREATE INDEX IF NOT EXISTS idx_spaces_metadata_space_jid \
+             ON spaces_metadata (space_jid)",
             (),
         )
         .await?;
     Ok(())
+}
+
+fn create_table_sql(table_name: &str, i64_type: &str) -> String {
+    format!(
+        r#"
+        CREATE TABLE IF NOT EXISTS spaces_metadata (
+            space_node TEXT PRIMARY KEY,
+            space_jid TEXT NOT NULL,
+            name TEXT NOT NULL,
+            description TEXT,
+            icon_url TEXT,
+            created_at {i64_type} NOT NULL,
+            updated_at {i64_type} NOT NULL
+        )
+        "#
+    )
+    .replace("spaces_metadata", table_name)
+}
+
+async fn backfill_space_node_from_jid(
+    store: &DatabaseSpacesMetadataStore,
+) -> Result<(), SpacesMetadataError> {
+    let mut rows = store
+        .query(
+            "SELECT space_jid FROM spaces_metadata WHERE space_node = ''",
+            (),
+        )
+        .await?;
+    let mut updates = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?
+    {
+        let space_jid_raw: String = row
+            .get(0)
+            .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+        let space_node = projected_space_node_from_jid_text(&space_jid_raw);
+        updates.push((space_jid_raw, space_node));
+    }
+    drop(rows);
+
+    for (space_jid, space_node) in updates {
+        let space_node = space_node.into_string();
+        store
+            .execute(
+                "UPDATE spaces_metadata SET space_node = ? WHERE space_jid = ?",
+                crate::db_params![space_node, space_jid],
+            )
+            .await?;
+    }
+    Ok(())
+}
+
+async fn rebuild_legacy_space_jid_primary_key(
+    store: &DatabaseSpacesMetadataStore,
+    i64_type: &str,
+) -> Result<(), SpacesMetadataError> {
+    if primary_key_column(store).await?.as_deref() != Some("space_jid") {
+        return Ok(());
+    }
+
+    let mut tx = store
+        .db
+        .begin_immediate()
+        .await
+        .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+    tx.execute("DROP TABLE IF EXISTS spaces_metadata_new", ())
+        .await
+        .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+    tx.execute("DROP TABLE IF EXISTS spaces_metadata_old", ())
+        .await
+        .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+    tx.execute(&create_table_sql("spaces_metadata_new", i64_type), ())
+        .await
+        .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+    let copy_sql = match store.db.driver() {
+        crate::db::DatabaseDriver::Sqlite => {
+            r#"
+            INSERT OR IGNORE INTO spaces_metadata_new (
+                space_node, space_jid, name, description, icon_url, created_at, updated_at
+            )
+            SELECT space_node, space_jid, name, description, icon_url, created_at, updated_at
+            FROM spaces_metadata
+            WHERE space_node <> ''
+            "#
+        }
+        crate::db::DatabaseDriver::Postgres => {
+            r#"
+            INSERT INTO spaces_metadata_new (
+                space_node, space_jid, name, description, icon_url, created_at, updated_at
+            )
+            SELECT space_node, space_jid, name, description, icon_url, created_at, updated_at
+            FROM spaces_metadata
+            WHERE space_node <> ''
+            ON CONFLICT (space_node) DO NOTHING
+            "#
+        }
+    };
+    tx.execute(copy_sql, ())
+        .await
+        .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+    tx.execute(
+        "ALTER TABLE spaces_metadata RENAME TO spaces_metadata_old",
+        (),
+    )
+    .await
+    .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+    tx.execute(
+        "ALTER TABLE spaces_metadata_new RENAME TO spaces_metadata",
+        (),
+    )
+    .await
+    .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+    tx.execute("DROP TABLE spaces_metadata_old", ())
+        .await
+        .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+    tx.commit()
+        .await
+        .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+    Ok(())
+}
+
+async fn primary_key_column(
+    store: &DatabaseSpacesMetadataStore,
+) -> Result<Option<String>, SpacesMetadataError> {
+    match store.db.driver() {
+        crate::db::DatabaseDriver::Sqlite => sqlite_primary_key_column(store).await,
+        crate::db::DatabaseDriver::Postgres => postgres_primary_key_column(store).await,
+    }
+}
+
+async fn sqlite_primary_key_column(
+    store: &DatabaseSpacesMetadataStore,
+) -> Result<Option<String>, SpacesMetadataError> {
+    let mut rows = store
+        .query("PRAGMA table_info(spaces_metadata)", ())
+        .await?;
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?
+    {
+        let column_name: String = row
+            .get(1)
+            .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+        let pk: i64 = row
+            .get(5)
+            .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+        if pk > 0 {
+            return Ok(Some(column_name));
+        }
+    }
+    Ok(None)
+}
+
+async fn postgres_primary_key_column(
+    store: &DatabaseSpacesMetadataStore,
+) -> Result<Option<String>, SpacesMetadataError> {
+    let mut rows = store
+        .query(
+            r#"
+            SELECT a.attname
+            FROM pg_index i
+            JOIN pg_attribute a
+              ON a.attrelid = i.indrelid
+             AND a.attnum = ANY(i.indkey)
+            WHERE i.indrelid = 'spaces_metadata'::regclass
+              AND i.indisprimary
+            LIMIT 1
+            "#,
+            (),
+        )
+        .await?;
+    let Some(row) = rows
+        .next()
+        .await
+        .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?
+    else {
+        return Ok(None);
+    };
+    let column_name: String = row
+        .get(0)
+        .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+    Ok(Some(column_name))
+}
+
+async fn add_column_if_missing(
+    store: &DatabaseSpacesMetadataStore,
+    definition: &'static str,
+) -> Result<(), SpacesMetadataError> {
+    match store
+        .execute(
+            &format!("ALTER TABLE spaces_metadata ADD COLUMN {definition}"),
+            (),
+        )
+        .await
+    {
+        Ok(_) => Ok(()),
+        Err(SpacesMetadataError::Storage(error))
+            if error.contains("duplicate column") || error.contains("already exists") =>
+        {
+            Ok(())
+        }
+        Err(error) => Err(error),
+    }
 }

--- a/server/crates/waddle-server/src/spaces_metadata/storage.rs
+++ b/server/crates/waddle-server/src/spaces_metadata/storage.rs
@@ -8,10 +8,11 @@ use async_trait::async_trait;
 use jid::BareJid;
 
 use super::{SpaceMetadata, SpacesMetadataError, SpacesMetadataStore};
+use crate::space_identity::SpaceNode;
 
 #[derive(Debug, Default)]
 pub struct InMemorySpacesMetadataStore {
-    rows: Mutex<HashMap<BareJid, SpaceMetadata>>,
+    rows: Mutex<HashMap<String, SpaceMetadata>>,
 }
 
 impl InMemorySpacesMetadataStore {
@@ -27,7 +28,21 @@ impl SpacesMetadataStore for InMemorySpacesMetadataStore {
             .rows
             .lock()
             .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
-        Ok(guard.get(space_jid).cloned())
+        Ok(guard
+            .values()
+            .find(|row| &row.space_jid == space_jid)
+            .cloned())
+    }
+
+    async fn get_by_node(
+        &self,
+        space_node: &SpaceNode,
+    ) -> Result<Option<SpaceMetadata>, SpacesMetadataError> {
+        let guard = self
+            .rows
+            .lock()
+            .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+        Ok(guard.get(space_node.as_str()).cloned())
     }
 
     async fn upsert(&self, metadata: &SpaceMetadata) -> Result<(), SpacesMetadataError> {
@@ -38,11 +53,11 @@ impl SpacesMetadataStore for InMemorySpacesMetadataStore {
         // Preserve created_at on an existing row so callers can supply
         // it freely on `upsert`; the trait contract says created_at is
         // assigned at first insert.
-        match guard.get(&metadata.space_jid) {
+        match guard.get(metadata.space_node.as_str()) {
             Some(existing) => {
                 let preserved_created_at = existing.created_at;
                 guard.insert(
-                    metadata.space_jid.clone(),
+                    metadata.space_node.to_string(),
                     SpaceMetadata {
                         created_at: preserved_created_at,
                         ..metadata.clone()
@@ -50,7 +65,7 @@ impl SpacesMetadataStore for InMemorySpacesMetadataStore {
                 );
             }
             None => {
-                guard.insert(metadata.space_jid.clone(), metadata.clone());
+                guard.insert(metadata.space_node.to_string(), metadata.clone());
             }
         }
         Ok(())
@@ -61,7 +76,18 @@ impl SpacesMetadataStore for InMemorySpacesMetadataStore {
             .rows
             .lock()
             .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
-        Ok(guard.remove(space_jid).is_some())
+        let key = guard
+            .iter()
+            .find_map(|(key, row)| (&row.space_jid == space_jid).then(|| key.clone()));
+        Ok(key.and_then(|key| guard.remove(&key)).is_some())
+    }
+
+    async fn delete_by_node(&self, space_node: &SpaceNode) -> Result<bool, SpacesMetadataError> {
+        let mut guard = self
+            .rows
+            .lock()
+            .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+        Ok(guard.remove(space_node.as_str()).is_some())
     }
 
     async fn list_all(&self) -> Result<Vec<SpaceMetadata>, SpacesMetadataError> {
@@ -73,7 +99,7 @@ impl SpacesMetadataStore for InMemorySpacesMetadataStore {
         rows.sort_by(|a, b| {
             a.created_at
                 .cmp(&b.created_at)
-                .then_with(|| a.space_jid.cmp(&b.space_jid))
+                .then_with(|| a.space_node.cmp(&b.space_node))
         });
         Ok(rows)
     }

--- a/server/crates/waddle-server/src/spaces_metadata/tests.rs
+++ b/server/crates/waddle-server/src/spaces_metadata/tests.rs
@@ -2,6 +2,8 @@
 
 use jid::BareJid;
 
+use crate::space_identity::SpaceNode;
+
 use super::{DatabaseSpacesMetadataStore, SpaceMetadata, SpacesMetadataStore};
 
 fn space_jid(local: &str) -> BareJid {
@@ -18,8 +20,10 @@ fn metadata(
     created_at: i64,
     updated_at: i64,
 ) -> SpaceMetadata {
+    let space_node = SpaceNode::from(space_jid.node().expect("space node").to_string());
     SpaceMetadata {
         space_jid,
+        space_node,
         name: name.to_string(),
         description: description.map(str::to_string),
         icon_url: icon_url.map(str::to_string),
@@ -54,6 +58,13 @@ async fn upsert_then_get_round_trips_full_row() {
         .expect("get")
         .expect("row present after upsert");
     assert_eq!(fetched, row);
+
+    let fetched_by_node = store
+        .get_by_node(&row.space_node)
+        .await
+        .expect("get_by_node")
+        .expect("row present after upsert");
+    assert_eq!(fetched_by_node, row);
 }
 
 #[tokio::test]
@@ -112,6 +123,34 @@ async fn delete_returns_true_when_row_present() {
     assert!(removed, "delete returns true when a row was removed");
     let after = store.get(&row.space_jid).await.expect("get");
     assert!(after.is_none(), "row absent after delete");
+}
+
+#[tokio::test]
+async fn delete_by_node_returns_true_when_row_present() {
+    let store = fresh_store().await;
+    let row = metadata(
+        space_jid("ops"),
+        "Ops",
+        None,
+        None,
+        1_700_000_000,
+        1_700_000_000,
+    );
+    store.upsert(&row).await.expect("upsert");
+
+    let removed = store
+        .delete_by_node(&row.space_node)
+        .await
+        .expect("delete_by_node");
+    assert!(
+        removed,
+        "delete_by_node returns true when a row was removed"
+    );
+    let after = store
+        .get_by_node(&row.space_node)
+        .await
+        .expect("get_by_node");
+    assert!(after.is_none(), "row absent after delete_by_node");
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/tests/admin_channel_space_link_ws.rs
+++ b/server/crates/waddle-server/tests/admin_channel_space_link_ws.rs
@@ -18,12 +18,15 @@
 mod ws_common;
 
 use tokio::sync::Mutex;
+use waddle_xmpp::xep::xep0106::escape_node;
 use ws_common::{TestServer, WsXmppClient};
 
 const DOMAIN: &str = "localhost";
 const ADMIN: &str = "admin";
 const NS_COMMANDS: &str = "http://jabber.org/protocol/commands";
 const NS_DATA: &str = "jabber:x:data";
+const NS_PUBSUB: &str = "http://jabber.org/protocol/pubsub";
+const SPACES_JID: &str = "spaces.localhost";
 
 const NODE_SPACES_CREATE: &str = "urn:waddle:admin:spaces:create:0";
 const NODE_SPACES_DELETE: &str = "urn:waddle:admin:spaces:delete:0";
@@ -127,6 +130,33 @@ async fn create_channel_in_space(
     extract_field(&resp, "channel_jid").expect("channel_jid in channels:create response")
 }
 
+async fn create_channel_in_space_node(
+    admin: &mut WsXmppClient,
+    name: &str,
+    space_jid: &str,
+    space_node: &str,
+    id: &str,
+) -> String {
+    let extra = format!(
+        "{}{}{}",
+        text_field("name", name),
+        text_field("space_jid", space_jid),
+        text_field("space_node", space_node)
+    );
+    let resp = send_command(
+        admin,
+        NODE_CHANNELS_CREATE,
+        id,
+        &submit_form(NODE_CHANNELS_CREATE, &extra),
+    )
+    .await;
+    assert!(
+        is_result(&resp),
+        "expected channels:create result, got: {resp}"
+    );
+    extract_field(&resp, "channel_jid").expect("channel_jid in channels:create response")
+}
+
 async fn update_channel_name(admin: &mut WsXmppClient, channel_jid: &str, name: &str, id: &str) {
     let extra = format!(
         "{}{}",
@@ -163,6 +193,52 @@ async fn list_channels(admin: &mut WsXmppClient, space_jid: Option<&str>, id: &s
         "expected channels:list result, got: {resp}"
     );
     resp
+}
+
+async fn list_channels_in_space_node(
+    admin: &mut WsXmppClient,
+    space_jid: &str,
+    space_node: &str,
+    id: &str,
+) -> String {
+    let extra = format!(
+        "{}{}",
+        text_field("space_jid", space_jid),
+        text_field("space_node", space_node)
+    );
+    let resp = send_command(
+        admin,
+        NODE_CHANNELS_LIST,
+        id,
+        &submit_form(NODE_CHANNELS_LIST, &extra),
+    )
+    .await;
+    assert!(
+        is_result(&resp),
+        "expected channels:list result, got: {resp}"
+    );
+    resp
+}
+
+async fn create_pubsub_space_node(admin: &mut WsXmppClient, node: &str, id: &str) {
+    admin
+        .send(&format!(
+            r#"<iq type="set" id="{id}" to="{SPACES_JID}"><pubsub xmlns="{NS_PUBSUB}"><create node="{node}"/></pubsub></iq>"#
+        ))
+        .await
+        .expect("send pubsub create");
+    let resp = admin
+        .recv_matching(|frame| {
+            frame.contains("<iq")
+                && (frame.contains(&format!(r#"id='{id}'"#))
+                    || frame.contains(&format!(r#"id="{id}""#)))
+        })
+        .await
+        .expect("pubsub create response");
+    assert!(
+        is_result(&resp),
+        "expected pubsub create result, got: {resp}"
+    );
 }
 
 async fn space_pubsub_items(admin: &mut WsXmppClient, space_jid: &str, id: &str) -> String {
@@ -353,6 +429,42 @@ async fn channels_list_space_jid_filter_narrows_results_and_survives_lifecycle()
     assert!(
         !final_unfiltered.contains(&channel_b),
         "cascade-deleted channel B '{channel_b}' should be absent from unfiltered list, got: {final_unfiltered}"
+    );
+
+    let _ = admin.close().await;
+}
+
+#[tokio::test]
+async fn channels_create_and_list_accept_exact_space_node_for_escaped_projection() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut admin = admin_client(&server, "admin-csl-node-1").await;
+
+    let space_node = "music/A";
+    create_pubsub_space_node(&mut admin, space_node, "csl-node-create-space").await;
+    let space_jid = format!("{}@{SPACES_JID}", escape_node(space_node));
+
+    let channel = create_channel_in_space_node(
+        &mut admin,
+        "music-room",
+        &space_jid,
+        space_node,
+        "csl-node-create-channel",
+    )
+    .await;
+
+    let filtered =
+        list_channels_in_space_node(&mut admin, &space_jid, space_node, "csl-node-list-channels")
+            .await;
+    assert!(
+        filtered.contains(&channel),
+        "exact space_node filter should include channel '{channel}', got: {filtered}"
+    );
+
+    let items = client_send_pubsub_items(&mut admin, space_node, "csl-node-pubsub-items").await;
+    assert!(
+        items.contains(&channel),
+        "space PubSub node '{space_node}' should include channel bookmark '{channel}', got: {items}"
     );
 
     let _ = admin.close().await;

--- a/server/crates/waddle-server/tests/admin_spaces_ws.rs
+++ b/server/crates/waddle-server/tests/admin_spaces_ws.rs
@@ -5,7 +5,7 @@
 //!
 //! - owner-only ACL on every command,
 //! - `spaces:create` mints a space + backing pubsub node,
-//! - `spaces:list` paginates the metadata projection,
+//! - `spaces:list` enumerates the Spaces PubSub nodes with metadata overlay,
 //! - `spaces:update` patches name/description/icon_url,
 //! - `spaces:delete` requires `confirm='yes'`,
 //! - `spaces:members` lists pubsub-affiliation membership,
@@ -19,11 +19,14 @@ mod ws_common;
 
 use tokio::sync::Mutex;
 use ws_common::{TestServer, WsXmppClient};
+use xmpp_parsers::minidom::Element;
 
 const DOMAIN: &str = "localhost";
 const ADMIN: &str = "admin";
 const NS_COMMANDS: &str = "http://jabber.org/protocol/commands";
 const NS_DATA: &str = "jabber:x:data";
+const NS_PUBSUB: &str = "http://jabber.org/protocol/pubsub";
+const SPACES_JID: &str = "spaces.localhost";
 
 const NODE_SPACES_LIST: &str = "urn:waddle:admin:spaces:list:0";
 const NODE_SPACES_CREATE: &str = "urn:waddle:admin:spaces:create:0";
@@ -60,13 +63,22 @@ async fn send_command(client: &mut WsXmppClient, node: &str, id: &str, form_xml:
         .await
         .expect("send iq");
     client
-        .recv_matching(|frame| {
-            frame.contains("<iq")
-                && (frame.contains(&format!(r#"id='{id}'"#))
-                    || frame.contains(&format!(r#"id='{id}'"#)))
-        })
+        .recv_matching(|frame| iq_attr_equals(frame, "id", id))
         .await
         .expect("iq response")
+}
+
+async fn send_iq_set_to(client: &mut WsXmppClient, id: &str, to: &str, body: &str) -> String {
+    client
+        .send(&format!(
+            r#"<iq type="set" id="{id}" to="{to}">{body}</iq>"#
+        ))
+        .await
+        .expect("send iq set");
+    client
+        .recv_matching(|frame| iq_attr_equals(frame, "id", id))
+        .await
+        .expect("iq set response")
 }
 
 fn submit_form(node: &str, extra: &str) -> String {
@@ -79,25 +91,45 @@ fn text_field(var: &str, value: &str) -> String {
     format!(r#"<field var="{var}" type="text-single"><value>{value}</value></field>"#)
 }
 
+fn parse_iq(frame: &str) -> Option<Element> {
+    frame
+        .parse::<Element>()
+        .ok()
+        .filter(|element| element.name() == "iq")
+}
+
+fn iq_attr_equals(frame: &str, attr: &str, value: &str) -> bool {
+    parse_iq(frame)
+        .as_ref()
+        .and_then(|iq| iq.attr(attr))
+        .is_some_and(|actual| actual == value)
+}
+
 fn is_result(frame: &str) -> bool {
-    frame.contains(r#"type='result'"#) || frame.contains(r#"type='result'"#)
+    iq_attr_equals(frame, "type", "result")
 }
 
 fn is_error(frame: &str) -> bool {
-    frame.contains(r#"type='error'"#) || frame.contains(r#"type='error'"#)
+    iq_attr_equals(frame, "type", "error")
 }
 
 /// Pull the value of `var=...` text-single field from the result form
 /// — used to grab the space JID minted by `spaces:create`.
 fn extract_field(frame: &str, var: &str) -> Option<String> {
-    let marker_dq = format!(r#"var='{var}'"#);
-    let marker_sq = format!(r#"var='{var}'"#);
-    let idx = frame.find(&marker_dq).or_else(|| frame.find(&marker_sq))?;
-    let after = &frame[idx..];
-    let open = after.find("<value>")?;
-    let inner = &after[open + "<value>".len()..];
-    let close = inner.find("</value>")?;
-    Some(inner[..close].to_string())
+    let iq = parse_iq(frame)?;
+    find_field_value(&iq, var)
+}
+
+fn find_field_value(element: &Element, var: &str) -> Option<String> {
+    if element.name() == "field" && element.attr("var") == Some(var) {
+        return element
+            .children()
+            .find(|child| child.name() == "value")
+            .map(|value| value.text());
+    }
+    element
+        .children()
+        .find_map(|child| find_field_value(child, var))
 }
 
 // ---------------------------------------------------------------------------
@@ -105,7 +137,7 @@ fn extract_field(frame: &str, var: &str) -> Option<String> {
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn spaces_list_returns_empty_for_fresh_server() {
+async fn spaces_list_includes_bootstrapped_general_space() {
     let _serial = TEST_SERIAL.lock().await;
     let server = TestServer::start();
     let mut admin = admin_client(&server, "admin-spaces-list-1").await;
@@ -119,9 +151,146 @@ async fn spaces_list_returns_empty_for_fresh_server() {
     .await;
     assert!(is_result(&resp), "expected result, got: {resp}");
     assert!(
-        !resp.contains("<item>"),
-        "fresh server should have no spaces, got: {resp}"
+        resp.contains("general@spaces.localhost"),
+        "fresh server should list the bootstrapped General space JID, got: {resp}"
     );
+    assert!(
+        resp.contains("General"),
+        "fresh server should list the bootstrapped General space name, got: {resp}"
+    );
+    assert!(
+        resp.contains("<item>"),
+        "fresh server should return at least one space item, got: {resp}"
+    );
+    let _ = admin.close().await;
+}
+
+#[tokio::test]
+async fn spaces_list_projects_non_jid_pubsub_node_ids_as_escaped_space_jids() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut admin = admin_client(&server, "admin-spaces-list-escaped").await;
+
+    let create = send_iq_set_to(
+        &mut admin,
+        "spaces-escaped-create",
+        SPACES_JID,
+        &format!(r#"<pubsub xmlns="{NS_PUBSUB}"><create node="music/A"/></pubsub>"#),
+    )
+    .await;
+    assert!(
+        is_result(&create),
+        "expected native PubSub create result, got: {create}"
+    );
+
+    let list_resp = send_command(
+        &mut admin,
+        NODE_SPACES_LIST,
+        "spaces-escaped-list",
+        &submit_form(NODE_SPACES_LIST, ""),
+    )
+    .await;
+    assert!(
+        list_resp.contains("music\\2fa@spaces.localhost") && list_resp.contains("music/A"),
+        "spaces:list should include escaped JID projection for non-JID node ids, got: {list_resp}"
+    );
+
+    let update_extra = format!(
+        "{}{}{}",
+        text_field("space_jid", "music\\2fa@spaces.localhost"),
+        text_field("space_node", "music/A"),
+        text_field("name", "Music")
+    );
+    let update_resp = send_command(
+        &mut admin,
+        NODE_SPACES_UPDATE,
+        "spaces-escaped-update",
+        &submit_form(NODE_SPACES_UPDATE, &update_extra),
+    )
+    .await;
+    assert!(
+        is_result(&update_resp) && update_resp.contains(NODE_SPACES_UPDATE),
+        "escaped space_jid update should succeed with update FORM_TYPE, got: {update_resp}"
+    );
+
+    let readback = send_command(
+        &mut admin,
+        NODE_SPACES_LIST,
+        "spaces-escaped-readback",
+        &submit_form(NODE_SPACES_LIST, ""),
+    )
+    .await;
+    assert!(
+        readback.contains("music\\2fa@spaces.localhost")
+            && readback.contains("music/A")
+            && readback.contains("Music"),
+        "metadata overlay should use escaped JID projection, got: {readback}"
+    );
+    let _ = admin.close().await;
+}
+
+#[tokio::test]
+async fn spaces_list_distinguishes_literal_escape_sequences_from_escaped_slashes() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut admin = admin_client(&server, "admin-spaces-list-escape-collision").await;
+
+    for (id, node) in [
+        ("spaces-collision-slash-create", "music/a"),
+        ("spaces-collision-literal-create", "music\\2fa"),
+    ] {
+        let create = send_iq_set_to(
+            &mut admin,
+            id,
+            SPACES_JID,
+            &format!(r#"<pubsub xmlns="{NS_PUBSUB}"><create node="{node}"/></pubsub>"#),
+        )
+        .await;
+        assert!(
+            is_result(&create),
+            "expected native PubSub create result for {node}, got: {create}"
+        );
+    }
+
+    let list_resp = send_command(
+        &mut admin,
+        NODE_SPACES_LIST,
+        "spaces-collision-list",
+        &submit_form(NODE_SPACES_LIST, ""),
+    )
+    .await;
+    assert!(
+        list_resp.contains("music\\2fa@spaces.localhost")
+            && list_resp.contains("music\\5c2fa@spaces.localhost")
+            && list_resp.contains("music/a")
+            && list_resp.contains("music\\2fa"),
+        "spaces:list should keep escape-looking node ids distinct, got: {list_resp}"
+    );
+    let _ = admin.close().await;
+}
+
+#[tokio::test]
+async fn spaces_native_create_rejects_nodes_with_boundary_spaces() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut admin = admin_client(&server, "admin-spaces-create-boundary-spaces").await;
+
+    for (id, node) in [
+        ("spaces-boundary-leading-space", " ops"),
+        ("spaces-boundary-trailing-space", "ops "),
+    ] {
+        let create = send_iq_set_to(
+            &mut admin,
+            id,
+            SPACES_JID,
+            &format!(r#"<pubsub xmlns="{NS_PUBSUB}"><create node="{node}"/></pubsub>"#),
+        )
+        .await;
+        assert!(
+            is_error(&create) && create.contains("bad-request"),
+            "expected bad-request for unprojectable Spaces node {node:?}, got: {create}"
+        );
+    }
     let _ = admin.close().await;
 }
 
@@ -289,6 +458,45 @@ async fn spaces_update_changes_name() {
 }
 
 #[tokio::test]
+async fn spaces_update_bootstrapped_general_space_creates_metadata_overlay() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut admin = admin_client(&server, "admin-spaces-update-general").await;
+
+    let update_extra = format!(
+        "{}{}{}",
+        text_field("space_jid", "general@spaces.localhost"),
+        text_field("name", "Community"),
+        text_field("description", "Default community space"),
+    );
+    let resp = send_command(
+        &mut admin,
+        NODE_SPACES_UPDATE,
+        "spaces-upd-general",
+        &submit_form(NODE_SPACES_UPDATE, &update_extra),
+    )
+    .await;
+    assert!(is_result(&resp), "expected update result, got: {resp}");
+    assert!(
+        resp.contains("Community"),
+        "updated General space should reflect metadata overlay, got: {resp}"
+    );
+
+    let list_resp = send_command(
+        &mut admin,
+        NODE_SPACES_LIST,
+        "spaces-upd-general-list",
+        &submit_form(NODE_SPACES_LIST, ""),
+    )
+    .await;
+    assert!(
+        list_resp.contains("general@spaces.localhost") && list_resp.contains("Community"),
+        "spaces:list should show updated bootstrapped General metadata, got: {list_resp}"
+    );
+    let _ = admin.close().await;
+}
+
+#[tokio::test]
 async fn spaces_update_rejects_unknown_space() {
     let _serial = TEST_SERIAL.lock().await;
     let server = TestServer::start();
@@ -312,6 +520,110 @@ async fn spaces_update_rejects_unknown_space() {
     assert!(
         resp.contains("item-not-found") || resp.contains("not-found"),
         "expected item-not-found, got: {resp}"
+    );
+    let _ = admin.close().await;
+}
+
+#[tokio::test]
+async fn spaces_commands_reject_space_jids_outside_spaces_service() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut admin = admin_client(&server, "admin-spaces-wrong-domain").await;
+
+    let update_extra = format!(
+        "{}{}",
+        text_field("space_jid", "general@wrong.localhost"),
+        text_field("name", "Wrong Domain")
+    );
+    let update_resp = send_command(
+        &mut admin,
+        NODE_SPACES_UPDATE,
+        "spaces-wrong-domain-update",
+        &submit_form(NODE_SPACES_UPDATE, &update_extra),
+    )
+    .await;
+    assert!(
+        is_error(&update_resp) && update_resp.contains("bad-request"),
+        "expected bad-request for wrong-domain update, got: {update_resp}"
+    );
+
+    let delete_extra = format!(
+        "{}{}",
+        text_field("space_jid", "general@wrong.localhost"),
+        text_field("confirm", "yes"),
+    );
+    let delete_resp = send_command(
+        &mut admin,
+        NODE_SPACES_DELETE,
+        "spaces-wrong-domain-delete",
+        &submit_form(NODE_SPACES_DELETE, &delete_extra),
+    )
+    .await;
+    assert!(
+        is_error(&delete_resp) && delete_resp.contains("bad-request"),
+        "expected bad-request for wrong-domain delete, got: {delete_resp}"
+    );
+
+    let members_resp = send_command(
+        &mut admin,
+        NODE_SPACES_MEMBERS,
+        "spaces-wrong-domain-members",
+        &submit_form(
+            NODE_SPACES_MEMBERS,
+            &text_field("space_jid", "general@wrong.localhost"),
+        ),
+    )
+    .await;
+    assert!(
+        is_error(&members_resp) && members_resp.contains("bad-request"),
+        "expected bad-request for wrong-domain members, got: {members_resp}"
+    );
+
+    let role_extra = format!(
+        "{}{}{}",
+        text_field("space_jid", "general@wrong.localhost"),
+        text_field("member_jid", "wrong-domain@localhost"),
+        text_field("role", "admin"),
+    );
+    let role_resp = send_command(
+        &mut admin,
+        NODE_SPACES_SET_ROLE,
+        "spaces-wrong-domain-role",
+        &submit_form(NODE_SPACES_SET_ROLE, &role_extra),
+    )
+    .await;
+    assert!(
+        is_error(&role_resp) && role_resp.contains("bad-request"),
+        "expected bad-request for wrong-domain set-role, got: {role_resp}"
+    );
+
+    let list_resp = send_command(
+        &mut admin,
+        NODE_SPACES_LIST,
+        "spaces-wrong-domain-list",
+        &submit_form(NODE_SPACES_LIST, ""),
+    )
+    .await;
+    assert!(
+        list_resp.contains("general@spaces.localhost")
+            && list_resp.contains("General")
+            && !list_resp.contains("Wrong Domain"),
+        "wrong-domain update/delete should not mutate General, got: {list_resp}"
+    );
+
+    let correct_members = send_command(
+        &mut admin,
+        NODE_SPACES_MEMBERS,
+        "spaces-wrong-domain-correct-members",
+        &submit_form(
+            NODE_SPACES_MEMBERS,
+            &text_field("space_jid", "general@spaces.localhost"),
+        ),
+    )
+    .await;
+    assert!(
+        !correct_members.contains("wrong-domain@localhost"),
+        "wrong-domain set-role should not mutate General members, got: {correct_members}"
     );
     let _ = admin.close().await;
 }
@@ -536,6 +848,47 @@ async fn spaces_set_role_round_trips_through_members() {
     assert!(
         list_resp.contains(">admin<"),
         "members list missing 'admin' role marker, got: {list_resp}"
+    );
+    let _ = admin.close().await;
+}
+
+#[tokio::test]
+async fn spaces_set_role_works_for_bootstrapped_general_space() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut admin = admin_client(&server, "admin-spaces-role-general").await;
+
+    let set_extra = format!(
+        "{}{}{}",
+        text_field("space_jid", "general@spaces.localhost"),
+        text_field("member_jid", "bystander@localhost"),
+        text_field("role", "admin"),
+    );
+    let resp = send_command(
+        &mut admin,
+        NODE_SPACES_SET_ROLE,
+        "spaces-role-general-set",
+        &submit_form(NODE_SPACES_SET_ROLE, &set_extra),
+    )
+    .await;
+    assert!(
+        is_result(&resp),
+        "expected set-role on General to succeed, got: {resp}"
+    );
+
+    let list_resp = send_command(
+        &mut admin,
+        NODE_SPACES_MEMBERS,
+        "spaces-role-general-list",
+        &submit_form(
+            NODE_SPACES_MEMBERS,
+            &text_field("space_jid", "general@spaces.localhost"),
+        ),
+    )
+    .await;
+    assert!(
+        list_resp.contains("bystander@localhost") && list_resp.contains(">admin<"),
+        "General members list should include promoted user, got: {list_resp}"
     );
     let _ = admin.close().await;
 }

--- a/server/crates/waddle-xmpp-client-wasm/src/client_admin_v2.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_admin_v2.rs
@@ -62,6 +62,7 @@ pub struct WaddleAdminSpacesListArgs {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct WaddleAdminSpaceListEntry {
     pub space_jid: String,
+    pub space_node: String,
     pub name: String,
     pub description: Option<String>,
     pub icon_url: Option<String>,
@@ -85,6 +86,7 @@ pub struct WaddleAdminSpacesCreateArgs {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct WaddleAdminSpaceRef {
     pub space_jid: String,
+    pub space_node: String,
     pub name: String,
     pub description: Option<String>,
     pub icon_url: Option<String>,
@@ -93,6 +95,7 @@ pub struct WaddleAdminSpaceRef {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct WaddleAdminSpacesUpdateArgs {
     pub space_jid: String,
+    pub space_node: Option<String>,
     pub name: Option<String>,
     pub description: Option<String>,
     pub icon_url: Option<String>,
@@ -101,6 +104,7 @@ pub struct WaddleAdminSpacesUpdateArgs {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct WaddleAdminSpacesDeleteArgs {
     pub space_jid: String,
+    pub space_node: Option<String>,
     /// MUST be the literal string "yes"; mirrors the server-side guard.
     pub confirm: String,
 }
@@ -108,6 +112,7 @@ pub struct WaddleAdminSpacesDeleteArgs {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct WaddleAdminSpacesMembersArgs {
     pub space_jid: String,
+    pub space_node: Option<String>,
     pub page_size: Option<u32>,
     pub after_cursor: Option<String>,
 }
@@ -128,6 +133,7 @@ pub struct WaddleAdminSpacesMembersResult {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct WaddleAdminSpacesSetRoleArgs {
     pub space_jid: String,
+    pub space_node: Option<String>,
     pub member_jid: String,
     /// `owner` | `admin` | `member` | `none`.
     pub role: String,
@@ -144,6 +150,7 @@ pub struct WaddleAdminSpacesSetRoleResult {
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct WaddleAdminChannelsListArgs {
     pub space_jid: Option<String>,
+    pub space_node: Option<String>,
     pub prefix: Option<String>,
     pub page_size: Option<u32>,
     pub after_cursor: Option<String>,
@@ -174,6 +181,7 @@ pub struct WaddleAdminChannelsCreateArgs {
     pub name: String,
     pub topic: Option<String>,
     pub space_jid: Option<String>,
+    pub space_node: Option<String>,
     /// Defaults to `true` per the V2 spec; the client wrapper passes
     /// this through verbatim. The server enforces the same default
     /// when the field is absent.
@@ -563,6 +571,9 @@ fn build_spaces_create_iq(server_domain: &str, args: &WaddleAdminSpacesCreateArg
 fn build_spaces_update_iq(server_domain: &str, args: &WaddleAdminSpacesUpdateArgs) -> Element {
     let mut form = submit_form_with_type(NS_ADMIN_SPACES_UPDATE)
         .append(jid_field("space_jid", &args.space_jid));
+    if let Some(space_node) = args.space_node.as_deref() {
+        form = form.append(text_single_field("space_node", space_node));
+    }
     if let Some(name) = args.name.as_deref() {
         form = form.append(text_single_field("name", name));
     }
@@ -576,15 +587,21 @@ fn build_spaces_update_iq(server_domain: &str, args: &WaddleAdminSpacesUpdateArg
 }
 
 fn build_spaces_delete_iq(server_domain: &str, args: &WaddleAdminSpacesDeleteArgs) -> Element {
-    let form = submit_form_with_type(NS_ADMIN_SPACES_DELETE)
-        .append(jid_field("space_jid", &args.space_jid))
-        .append(text_single_field("confirm", &args.confirm));
+    let mut form = submit_form_with_type(NS_ADMIN_SPACES_DELETE)
+        .append(jid_field("space_jid", &args.space_jid));
+    if let Some(space_node) = args.space_node.as_deref() {
+        form = form.append(text_single_field("space_node", space_node));
+    }
+    form = form.append(text_single_field("confirm", &args.confirm));
     wrap_command_iq(server_domain, NS_ADMIN_SPACES_DELETE, form.build())
 }
 
 fn build_spaces_members_iq(server_domain: &str, args: &WaddleAdminSpacesMembersArgs) -> Element {
     let mut form = submit_form_with_type(NS_ADMIN_SPACES_MEMBERS)
         .append(jid_field("space_jid", &args.space_jid));
+    if let Some(space_node) = args.space_node.as_deref() {
+        form = form.append(text_single_field("space_node", space_node));
+    }
     if let Some(page_size) = args.page_size {
         form = form.append(text_single_field("page_size", &page_size.to_string()));
     }
@@ -595,8 +612,12 @@ fn build_spaces_members_iq(server_domain: &str, args: &WaddleAdminSpacesMembersA
 }
 
 fn build_spaces_set_role_iq(server_domain: &str, args: &WaddleAdminSpacesSetRoleArgs) -> Element {
-    let form = submit_form_with_type(NS_ADMIN_SPACES_SET_ROLE)
-        .append(jid_field("space_jid", &args.space_jid))
+    let mut form = submit_form_with_type(NS_ADMIN_SPACES_SET_ROLE)
+        .append(jid_field("space_jid", &args.space_jid));
+    if let Some(space_node) = args.space_node.as_deref() {
+        form = form.append(text_single_field("space_node", space_node));
+    }
+    form = form
         .append(jid_field("member_jid", &args.member_jid))
         .append(text_single_field("role", &args.role));
     wrap_command_iq(server_domain, NS_ADMIN_SPACES_SET_ROLE, form.build())
@@ -606,6 +627,9 @@ fn build_channels_list_iq(server_domain: &str, args: &WaddleAdminChannelsListArg
     let mut form = submit_form_with_type(NS_ADMIN_CHANNELS_LIST);
     if let Some(space_jid) = args.space_jid.as_deref() {
         form = form.append(jid_field("space_jid", space_jid));
+    }
+    if let Some(space_node) = args.space_node.as_deref() {
+        form = form.append(text_single_field("space_node", space_node));
     }
     if let Some(prefix) = args.prefix.as_deref() {
         form = form.append(text_single_field("prefix", prefix));
@@ -627,6 +651,9 @@ fn build_channels_create_iq(server_domain: &str, args: &WaddleAdminChannelsCreat
     }
     if let Some(space_jid) = args.space_jid.as_deref() {
         form = form.append(jid_field("space_jid", space_jid));
+    }
+    if let Some(space_node) = args.space_node.as_deref() {
+        form = form.append(text_single_field("space_node", space_node));
     }
     if let Some(is_public) = args.is_public {
         form = form.append(boolean_field("is_public", is_public));
@@ -791,6 +818,7 @@ fn parse_spaces_list_result(iq: &Element) -> AdminParseResult<WaddleAdminSpacesL
     for item in form.children().filter(|c| c.name() == "item") {
         entries.push(WaddleAdminSpaceListEntry {
             space_jid: field_text_required(item, "space_jid")?,
+            space_node: field_text_required(item, "space_node")?,
             name: field_text_required(item, "name")?,
             description: field_text(item, "description").filter(|s| !s.is_empty()),
             icon_url: field_text(item, "icon_url").filter(|s| !s.is_empty()),
@@ -808,6 +836,7 @@ fn parse_space_ref_result(iq: &Element) -> AdminParseResult<WaddleAdminSpaceRef>
     let form = command_form(iq)?;
     Ok(WaddleAdminSpaceRef {
         space_jid: top_level_field_text_required(form, "space_jid")?,
+        space_node: top_level_field_text_required(form, "space_node")?,
         name: top_level_field_text_required(form, "name")?,
         description: top_level_field_text_opt(form, "description"),
         icon_url: top_level_field_text_opt(form, "icon_url"),

--- a/server/crates/waddle-xmpp-client-wasm/src/client_admin_v2_tests.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_admin_v2_tests.rs
@@ -19,6 +19,7 @@ fn parse_spaces_list_handles_empty_form() {
 fn parse_spaces_list_extracts_counts_and_cursor() {
     let item = r#"<item>
             <field var="space_jid"><value>eng@spaces.localhost</value></field>
+            <field var="space_node"><value>eng</value></field>
             <field var="name"><value>Engineering</value></field>
             <field var="description"><value>Hack stuff</value></field>
             <field var="icon_url"><value></value></field>
@@ -31,6 +32,7 @@ fn parse_spaces_list_extracts_counts_and_cursor() {
     assert_eq!(result.entries.len(), 1);
     let entry = &result.entries[0];
     assert_eq!(entry.space_jid, "eng@spaces.localhost");
+    assert_eq!(entry.space_node, "eng");
     assert_eq!(entry.name, "Engineering");
     assert_eq!(entry.description.as_deref(), Some("Hack stuff"));
     assert!(entry.icon_url.is_none());
@@ -42,11 +44,13 @@ fn parse_spaces_list_extracts_counts_and_cursor() {
 #[test]
 fn parse_space_ref_round_trip() {
     let inner = r#"<field var="space_jid"><value>eng@spaces.localhost</value></field>
+            <field var="space_node"><value>eng</value></field>
             <field var="name"><value>Engineering</value></field>
             <field var="description"><value>Hack stuff</value></field>"#;
     let iq = wrap_response(NS_ADMIN_SPACES_CREATE, inner);
     let space = parse_space_ref_result(&iq).expect("ok");
     assert_eq!(space.space_jid, "eng@spaces.localhost");
+    assert_eq!(space.space_node, "eng");
     assert_eq!(space.name, "Engineering");
     assert_eq!(space.description.as_deref(), Some("Hack stuff"));
     assert!(space.icon_url.is_none());
@@ -188,6 +192,7 @@ fn build_channels_create_iq_includes_all_optional_fields() {
         name: "general".to_string(),
         topic: Some("All things".to_string()),
         space_jid: Some("eng@spaces.localhost".to_string()),
+        space_node: Some("eng".to_string()),
         is_public: Some(true),
         members_only: Some(true),
     };
@@ -204,6 +209,7 @@ fn build_channels_create_iq_includes_all_optional_fields() {
     assert!(var_names.contains(&"name"));
     assert!(var_names.contains(&"topic"));
     assert!(var_names.contains(&"space_jid"));
+    assert!(var_names.contains(&"space_node"));
     assert!(var_names.contains(&"is_public"));
     assert!(var_names.contains(&"members_only"));
 }
@@ -212,6 +218,7 @@ fn build_channels_create_iq_includes_all_optional_fields() {
 fn build_spaces_delete_iq_carries_confirm() {
     let args = WaddleAdminSpacesDeleteArgs {
         space_jid: "eng@spaces.localhost".to_string(),
+        space_node: Some("eng".to_string()),
         confirm: "yes".to_string(),
     };
     let iq = build_spaces_delete_iq("localhost", &args);
@@ -225,4 +232,10 @@ fn build_spaces_delete_iq_carries_confirm() {
         .find_map(|f| f.get_child("value", NS_XDATA).map(|v| v.text()))
         .expect("confirm field");
     assert_eq!(confirm_value, "yes");
+    let node_value = form
+        .children()
+        .filter(|c| c.name() == "field" && c.attr("var") == Some("space_node"))
+        .find_map(|f| f.get_child("value", NS_XDATA).map(|v| v.text()))
+        .expect("space_node field");
+    assert_eq!(node_value, "eng");
 }


### PR DESCRIPTION
## Summary
- Fix `/admin/spaces` by listing Spaces from the authoritative Spaces PubSub service instead of only metadata overlay rows.
- Carry exact `space_node` through admin Spaces and Channels commands, WASM bindings, and the admin UI so XEP-0060 node IDs are not lost through JID projection.
- Store metadata and channel-space links by exact typed `SpaceNode`, including legacy row backfills and a transactional rebuild for old `spaces_metadata` tables keyed by `space_jid`.
- Keep native XEP-0503 publish/retract/disco paths in sync with the same exact-node projection.
- Address PR review comments by sharing collision-safe XEP-0106 projection helpers, rejecting unprojectable Spaces node IDs, parsing root IQ attributes in admin WS tests, and consuming pagination for admin space/channel/member lists without stale load races.

## Plan
- Trace `/admin/spaces` from Vue -> `BrowserXmppClient` -> WASM XEP-0050 -> server admin handler.
- Ground space listing in XEP-0060 PubSub nodes and overlay metadata where present.
- Preserve exact PubSub node identity across admin update/delete/members/set-role and channel create/list/update/delete.
- Replace raw storage-trait `space_node` string boundaries with a typed `SpaceNode` helper and shared projection logic.
- Add regression coverage for the bootstrapped General space, escaped/non-JID-like node names, and exact-node filtering.
- Verify server, WASM, and chat behavior locally.

## XEP review
- XEP-0050: admin operations remain ad-hoc commands over `http://jabber.org/protocol/commands` with XEP-0004 data forms.
- XEP-0060: Spaces inventory, counts, affiliations, publish, retract, and owner behavior remain PubSub-node based.
- XEP-0106: `space_jid` is treated as a projection; exact `SpaceNode` identity is carried for identity-sensitive operations.
- XEP-0503: Spaces discovery and bookmarks continue to use the Spaces PubSub service and bookmark items; no out-of-band admin API was added.

## Verification
- `cargo check -p waddle-server --tests`
- `cargo test -p waddle-server --lib spaces_metadata`
- `cargo test -p waddle-server --lib channel_space_links`
- `cargo test -p waddle-server --lib admin::spaces`
- `cargo test -p waddle-server --lib spaces_publish_accepts_escaped_space_node_and_syncs_link_projection`
- `cargo test -p waddle-server space_identity`
- `cargo test -p waddle-server --test admin_spaces_ws --test admin_channel_space_link_ws --test admin_channels_ws`
- `cargo test -p waddle-server --test xep0503_spaces_ws --test xep0060_spaces_owner_ws`
- `cargo test -p waddle-xmpp-client-wasm client_admin_v2`
- `cargo clippy -p waddle-server -p waddle-xmpp-client-wasm --all-targets -- -D warnings`
- `cd chat && bun test`
- `cd chat && bun run lint`
- `cd chat && bun run build`
- `git diff --check`

## Review notes
- Copilot XML matcher thread addressed in `admin_spaces_ws.rs`; tests now parse the root IQ element before matching `id`/`type`.
- Greptile typed-payload concern addressed with `SpaceNode` and shared XEP-0106 projection helpers, including storage backfills, collision coverage for literal escape-looking node IDs, and rejection of leading/trailing-space Spaces nodes that cannot be emitted as conforming `jid-single` values.
- Greptile pagination concern addressed by draining all spaces for channel filter/create options and adding guarded load-more pagination in spaces, channels, and the space detail drawer.
- Per-space count fan-out remains a performance follow-up, not a correctness blocker for this fix.
- `bun run build` still reports an existing Astro hint in `src/lib/xmpp/discovery.ts` and Vite chunk-size warnings; no build errors.
