### PR TITLE
feat(chat): react to stories from the Community feed

### DIFF
--- a/chat/src/components/community/FeedPane.vue
+++ b/chat/src/components/community/FeedPane.vue
@@ -134,6 +134,7 @@ const activeFilter = ref<FeedSurfaceFilter>(props.initialFilter);
 watch(activeFilter, (filter) => {
   if (filter === "pep" || filter === "posts") {
     activeStoryId.value = null;
+    closeStoryReactionPicker();
   }
 });
 
@@ -145,6 +146,10 @@ watch(() => props.stories, (stories) => {
   const id = activeStoryId.value;
   if (id && !stories.some((story) => story.id === id)) {
     activeStoryId.value = null;
+  }
+  const pickerStoryId = reactionPickerStoryId.value;
+  if (pickerStoryId && !stories.some((story) => story.id === pickerStoryId)) {
+    closeStoryReactionPicker();
   }
 });
 
@@ -304,8 +309,11 @@ function openStoryReactionPicker(storyId: string, event: MouseEvent) {
 }
 
 function closeStoryReactionPicker() {
+  const anchor = reactionPickerAnchor.value;
   reactionPickerStoryId.value = null;
   reactionPickerAnchor.value = null;
+  // Return focus to the trigger so keyboard users don't get dropped to <body>.
+  anchor?.focus();
 }
 
 function selectStoryReaction(emoji: string) {
@@ -512,8 +520,8 @@ function selectStoryReaction(emoji: string) {
               type="button"
               class="inline-flex h-8 items-center gap-1 rounded-md border px-2 text-sm"
               :class="chip.mine ? 'border-primary bg-primary/10 text-primary' : 'border-input text-foreground hover:bg-muted/60'"
-              :aria-label="`React to story with ${chip.emoji}`"
-              :aria-pressed="chip.mine ? 'true' : 'false'"
+              :aria-label="`React with ${chip.emoji}, ${chip.count} so far`"
+              :aria-pressed="chip.mine"
               @click="reactToStory(item.story.id, chip.emoji)"
             >
               <span aria-hidden="true">{{ chip.emoji }}</span>

--- a/chat/src/components/community/FeedPane.vue
+++ b/chat/src/components/community/FeedPane.vue
@@ -134,7 +134,7 @@ const activeFilter = ref<FeedSurfaceFilter>(props.initialFilter);
 watch(activeFilter, (filter) => {
   if (filter === "pep" || filter === "posts") {
     activeStoryId.value = null;
-    closeStoryReactionPicker();
+    closeStoryReactionPicker({ restoreFocus: false });
   }
 });
 
@@ -149,7 +149,7 @@ watch(() => props.stories, (stories) => {
   }
   const pickerStoryId = reactionPickerStoryId.value;
   if (pickerStoryId && !stories.some((story) => story.id === pickerStoryId)) {
-    closeStoryReactionPicker();
+    closeStoryReactionPicker({ restoreFocus: false });
   }
 });
 
@@ -308,12 +308,15 @@ function openStoryReactionPicker(storyId: string, event: MouseEvent) {
   reactionPickerStoryId.value = storyId;
 }
 
-function closeStoryReactionPicker() {
+function closeStoryReactionPicker({ restoreFocus = true } = {}) {
   const anchor = reactionPickerAnchor.value;
   reactionPickerStoryId.value = null;
   reactionPickerAnchor.value = null;
   // Return focus to the trigger so keyboard users don't get dropped to <body>.
-  anchor?.focus();
+  // Skip for programmatic dismissals (filter change / story removal): the
+  // anchor is about to leave the DOM, so focusing it would steal focus from
+  // wherever the user currently is and then drop it to <body> on re-render.
+  if (restoreFocus) anchor?.focus();
 }
 
 function selectStoryReaction(emoji: string) {

--- a/chat/src/components/community/FeedPane.vue
+++ b/chat/src/components/community/FeedPane.vue
@@ -12,10 +12,12 @@ import {
   Music,
   RefreshCw,
   Smile,
+  SmilePlus,
   User,
 } from "lucide-vue-next";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import Skeleton from "@/components/ui/Skeleton.vue";
+import EmojiPicker from "@/components/chat/EmojiPicker.vue";
 import FeedUpdateComposer from "@/components/community/FeedUpdateComposer.vue";
 import StoryReaderDialog from "@/components/community/StoryReaderDialog.vue";
 import type { FeedSurfaceComposerMode, FeedSurfaceFilter } from "@/shell/state";
@@ -114,8 +116,8 @@ interface FeedPaneProps {
 }
 
 const props = withDefaults(defineProps<FeedPaneProps>(), {
-  isStoryRead: () => () => false,
-  reactionSummary: () => () => ({ counts: {}, reactors: {}, mine: [] }),
+  isStoryRead: (_id: string) => false,
+  reactionSummary: (_id: string) => ({ counts: {}, reactors: {}, mine: [] }),
   initialFilter: "all",
   initialComposerMode: "post",
 });
@@ -226,14 +228,23 @@ const activeStory = computed<Story | null>(() => {
   return index === null ? null : props.stories[index] ?? null;
 });
 
-const activeReactionSummary = computed(() => activeStory.value ? props.reactionSummary(activeStory.value.id) : null);
-const activeReactionEntries = computed(() => {
-  const summary = activeReactionSummary.value;
-  if (!summary) return [];
+interface StoryReactionChip {
+  emoji: string;
+  count: number;
+  mine: boolean;
+  reactors: readonly string[];
+}
+
+/** Sorted, display-ready reaction chips for a story, highest count first. */
+function reactionChipsFor(storyId: string): StoryReactionChip[] {
+  const summary = props.reactionSummary(storyId);
   return Object.entries(summary.counts)
-    .map(([emoji, count]) => ({ emoji, count, reactors: summary.reactors[emoji] ?? [] }))
+    .map(([emoji, count]) => ({ emoji, count, mine: summary.mine.includes(emoji), reactors: summary.reactors[emoji] ?? [] }))
     .sort((a, b) => b.count - a.count || a.emoji.localeCompare(b.emoji));
-});
+}
+
+const activeReactionSummary = computed(() => activeStory.value ? props.reactionSummary(activeStory.value.id) : null);
+const activeReactionEntries = computed(() => activeStory.value ? reactionChipsFor(activeStory.value.id) : []);
 
 const loadingAny = computed(() => props.isLoading || props.isStoriesLoading);
 const emptyCopy = computed(() => {
@@ -270,10 +281,38 @@ function nextStory() {
   selectStory(index + 1);
 }
 
+function reactToStory(storyId: string, emoji: string) {
+  if (!storyId) return;
+  emit("react", storyId, emoji);
+}
+
 function toggleReaction(emoji: string) {
-  const story = activeStory.value;
-  if (!story) return;
-  emit("react", story.id, emoji);
+  if (!activeStory.value) return;
+  reactToStory(activeStory.value.id, emoji);
+}
+
+const reactionPickerStoryId = ref<string | null>(null);
+const reactionPickerAnchor = ref<HTMLElement | null>(null);
+
+function openStoryReactionPicker(storyId: string, event: MouseEvent) {
+  if (reactionPickerStoryId.value === storyId) {
+    closeStoryReactionPicker();
+    return;
+  }
+  reactionPickerAnchor.value = event.currentTarget as HTMLElement;
+  reactionPickerStoryId.value = storyId;
+}
+
+function closeStoryReactionPicker() {
+  reactionPickerStoryId.value = null;
+  reactionPickerAnchor.value = null;
+}
+
+function selectStoryReaction(emoji: string) {
+  const storyId = reactionPickerStoryId.value;
+  if (!storyId) return;
+  reactToStory(storyId, emoji);
+  closeStoryReactionPicker();
 }
 </script>
 
@@ -411,8 +450,8 @@ function toggleReaction(emoji: string) {
               {{ item.entry.link }}
             </a>
           </div>
+          <template v-else>
           <button
-            v-else
             type="button"
             class="grid w-full gap-3 p-4 text-left sm:grid-cols-[minmax(0,1fr)_8rem] sm:items-start"
             @click="selectStory(item.storyIndex)"
@@ -466,6 +505,32 @@ function toggleReaction(emoji: string) {
               />
             </span>
           </button>
+          <footer class="flex flex-wrap items-center gap-1.5 border-t border-border px-4 py-2.5">
+            <button
+              v-for="chip in reactionChipsFor(item.story.id)"
+              :key="chip.emoji"
+              type="button"
+              class="inline-flex h-8 items-center gap-1 rounded-md border px-2 text-sm"
+              :class="chip.mine ? 'border-primary bg-primary/10 text-primary' : 'border-input text-foreground hover:bg-muted/60'"
+              :aria-label="`React to story with ${chip.emoji}`"
+              :aria-pressed="chip.mine ? 'true' : 'false'"
+              @click="reactToStory(item.story.id, chip.emoji)"
+            >
+              <span aria-hidden="true">{{ chip.emoji }}</span>
+              <span class="type-numeric text-muted-foreground">{{ chip.count }}</span>
+            </button>
+            <button
+              type="button"
+              class="ml-auto inline-flex h-8 w-8 items-center justify-center rounded-md border border-input text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+              :aria-expanded="reactionPickerStoryId === item.story.id"
+              aria-haspopup="dialog"
+              aria-label="React to story"
+              @click="openStoryReactionPicker(item.story.id, $event)"
+            >
+              <SmilePlus class="h-4 w-4" aria-hidden="true" />
+            </button>
+          </footer>
+          </template>
         </article>
 
         <template v-if="loadingAny && feedItems.length === 0">
@@ -513,5 +578,12 @@ function toggleReaction(emoji: string) {
     @previous="prevStory"
     @next="nextStory"
     @react="toggleReaction"
+  />
+
+  <EmojiPicker
+    :open="reactionPickerStoryId !== null"
+    :anchor-el="reactionPickerAnchor"
+    @select="selectStoryReaction"
+    @close="closeStoryReactionPicker"
   />
 </template>

--- a/chat/tests/feed-story-reactions.test.ts
+++ b/chat/tests/feed-story-reactions.test.ts
@@ -114,6 +114,20 @@ describe("Community feed story reactions", () => {
     expect(emitted).toContainEqual(["react", "story-2", "🔥"]);
   });
 
+  test("returns focus to the trigger button when the picker closes", async () => {
+    const bindings = await setupVueComponent(
+      FEED_PANE,
+      feedPaneProps({ stories: [{ id: "story-1", author: "a@x" }] }),
+    );
+
+    let focusCount = 0;
+    const trigger = { focus() { focusCount += 1; } };
+    setupBindingFunction(bindings, "openStoryReactionPicker")("story-1", { currentTarget: trigger });
+    setupBindingFunction(bindings, "selectStoryReaction")("👍");
+
+    expect(focusCount).toBe(1);
+  });
+
   test("does not render a react button on non-story feed entries", async () => {
     const html = await renderVueComponent(FEED_PANE, feedPaneProps({
       entries: [{ id: "post-1", author: "bob@example.com", body: "a community post", publishedMs: 1000 }],

--- a/chat/tests/feed-story-reactions.test.ts
+++ b/chat/tests/feed-story-reactions.test.ts
@@ -59,13 +59,13 @@ describe("Community feed story reactions", () => {
           : { counts: {}, reactors: {}, mine: [] },
     }));
 
-    const thumbChip = html.match(/<button[^>]*React to story with 👍[\s\S]*?<\/button>/)?.[0] ?? "";
+    const thumbChip = html.match(/<button[^>]*React with 👍[\s\S]*?<\/button>/)?.[0] ?? "";
     expect(thumbChip).toContain('aria-pressed="true"');
-    expect(thumbChip).toContain("2");
+    expect(thumbChip).toMatch(/type-numeric[^>]*>\s*2\s*</);
 
-    const heartChip = html.match(/<button[^>]*React to story with ❤️[\s\S]*?<\/button>/)?.[0] ?? "";
+    const heartChip = html.match(/<button[^>]*React with ❤️[\s\S]*?<\/button>/)?.[0] ?? "";
     expect(heartChip).toContain('aria-pressed="false"');
-    expect(heartChip).toContain("1");
+    expect(heartChip).toMatch(/type-numeric[^>]*>\s*1\s*</);
   });
 
   test("shows the react affordance on the viewer's own story (self-react parity)", async () => {
@@ -79,7 +79,7 @@ describe("Community feed story reactions", () => {
     }));
 
     expect(html).toContain('aria-label="React to story"');
-    const ownChip = html.match(/<button[^>]*React to story with 🎉[\s\S]*?<\/button>/)?.[0] ?? "";
+    const ownChip = html.match(/<button[^>]*React with 🎉[\s\S]*?<\/button>/)?.[0] ?? "";
     expect(ownChip).toContain('aria-pressed="true"');
   });
 
@@ -96,6 +96,22 @@ describe("Community feed story reactions", () => {
     setupBindingFunction(bindings, "selectStory")(0);
 
     expect(emitted).toContainEqual(["storySelected", "story-1"]);
+  });
+
+  test("selecting an emoji from the picker reacts to the story it was opened for", async () => {
+    const emitted: unknown[][] = [];
+    const bindings = await setupVueComponent(
+      FEED_PANE,
+      feedPaneProps({ stories: [{ id: "story-1", author: "a@x" }, { id: "story-2", author: "b@x" }] }),
+      (...args) => {
+        emitted.push(args);
+      },
+    );
+
+    setupBindingFunction(bindings, "openStoryReactionPicker")("story-2", { currentTarget: { focus() {} } });
+    setupBindingFunction(bindings, "selectStoryReaction")("🔥");
+
+    expect(emitted).toContainEqual(["react", "story-2", "🔥"]);
   });
 
   test("does not render a react button on non-story feed entries", async () => {

--- a/chat/tests/feed-story-reactions.test.ts
+++ b/chat/tests/feed-story-reactions.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "no
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
-import { createSSRApp, h } from "vue";
+import { createSSRApp, h, nextTick, reactive } from "vue";
 import { parse, compileScript } from "vue/compiler-sfc";
 import { renderToString } from "vue/server-renderer";
 import ts from "typescript";
@@ -126,6 +126,37 @@ describe("Community feed story reactions", () => {
     setupBindingFunction(bindings, "selectStoryReaction")("👍");
 
     expect(focusCount).toBe(1);
+  });
+
+  test("dismisses an open reaction picker when the filter switches to a story-less view", async () => {
+    const bindings = await setupVueComponent(
+      FEED_PANE,
+      feedPaneProps({ stories: [{ id: "story-1", author: "a@x" }] }),
+    );
+    const reactionPickerStoryId = bindings.reactionPickerStoryId as { value: string | null };
+    const activeFilter = bindings.activeFilter as { value: string };
+
+    setupBindingFunction(bindings, "openStoryReactionPicker")("story-1", { currentTarget: { focus() {} } });
+    expect(reactionPickerStoryId.value).toBe("story-1");
+
+    activeFilter.value = "posts";
+    await nextTick();
+
+    expect(reactionPickerStoryId.value).toBeNull();
+  });
+
+  test("dismisses an open reaction picker when its story leaves the feed", async () => {
+    const props = reactive(feedPaneProps({ stories: [{ id: "story-1", author: "a@x" }] }));
+    const bindings = await setupVueComponent(FEED_PANE, props);
+    const reactionPickerStoryId = bindings.reactionPickerStoryId as { value: string | null };
+
+    setupBindingFunction(bindings, "openStoryReactionPicker")("story-1", { currentTarget: { focus() {} } });
+    expect(reactionPickerStoryId.value).toBe("story-1");
+
+    props.stories = [];
+    await nextTick();
+
+    expect(reactionPickerStoryId.value).toBeNull();
   });
 
   test("does not render a react button on non-story feed entries", async () => {

--- a/chat/tests/feed-story-reactions.test.ts
+++ b/chat/tests/feed-story-reactions.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { createSSRApp, h } from "vue";
+import { parse, compileScript } from "vue/compiler-sfc";
+import { renderToString } from "vue/server-renderer";
+import ts from "typescript";
+
+const FEED_PANE = "../src/components/community/FeedPane.vue";
+
+function feedPaneProps(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    entries: [],
+    stories: [],
+    isLoading: false,
+    isStoriesLoading: false,
+    isPosting: false,
+    isStoryPosting: false,
+    error: null,
+    storiesError: null,
+    canPost: true,
+    selfJid: "me@example.com",
+    ...overrides,
+  };
+}
+
+describe("Community feed story reactions", () => {
+  test("reactToStory emits react with the targeted story id and emoji", async () => {
+    const emitted: unknown[][] = [];
+    const bindings = await setupVueComponent(FEED_PANE, feedPaneProps(), (...args) => {
+      emitted.push(args);
+    });
+
+    setupBindingFunction(bindings, "reactToStory")("story-1", "👍");
+
+    expect(emitted).toEqual([["react", "story-1", "👍"]]);
+  });
+
+  test("renders a react button on each story card in the feed", async () => {
+    const html = await renderVueComponent(FEED_PANE, feedPaneProps({
+      stories: [{ id: "story-1", author: "alice@example.com", body: "hello" }],
+    }));
+
+    expect(html).toContain('aria-label="React to story"');
+  });
+
+  test("renders clickable reaction count chips, highlighting the user's own reactions", async () => {
+    const html = await renderVueComponent(FEED_PANE, feedPaneProps({
+      stories: [{ id: "story-1", author: "alice@example.com", body: "hi" }],
+      reactionSummary: (id: string) =>
+        id === "story-1"
+          ? {
+              counts: { "👍": 2, "❤️": 1 },
+              reactors: { "👍": ["a@x", "me@example.com"], "❤️": ["b@x"] },
+              mine: ["👍"],
+            }
+          : { counts: {}, reactors: {}, mine: [] },
+    }));
+
+    const thumbChip = html.match(/<button[^>]*React to story with 👍[\s\S]*?<\/button>/)?.[0] ?? "";
+    expect(thumbChip).toContain('aria-pressed="true"');
+    expect(thumbChip).toContain("2");
+
+    const heartChip = html.match(/<button[^>]*React to story with ❤️[\s\S]*?<\/button>/)?.[0] ?? "";
+    expect(heartChip).toContain('aria-pressed="false"');
+    expect(heartChip).toContain("1");
+  });
+
+  test("shows the react affordance on the viewer's own story (self-react parity)", async () => {
+    const html = await renderVueComponent(FEED_PANE, feedPaneProps({
+      selfJid: "me@example.com",
+      stories: [{ id: "mine-1", author: "me@example.com", body: "my story" }],
+      reactionSummary: (id: string) =>
+        id === "mine-1"
+          ? { counts: { "🎉": 1 }, reactors: { "🎉": ["me@example.com"] }, mine: ["🎉"] }
+          : { counts: {}, reactors: {}, mine: [] },
+    }));
+
+    expect(html).toContain('aria-label="React to story"');
+    const ownChip = html.match(/<button[^>]*React to story with 🎉[\s\S]*?<\/button>/)?.[0] ?? "";
+    expect(ownChip).toContain('aria-pressed="true"');
+  });
+
+  test("opening a story from the feed still emits storySelected after de-nesting the card", async () => {
+    const emitted: unknown[][] = [];
+    const bindings = await setupVueComponent(
+      FEED_PANE,
+      feedPaneProps({ stories: [{ id: "story-1", author: "alice@example.com" }] }),
+      (...args) => {
+        emitted.push(args);
+      },
+    );
+
+    setupBindingFunction(bindings, "selectStory")(0);
+
+    expect(emitted).toContainEqual(["storySelected", "story-1"]);
+  });
+
+  test("does not render a react button on non-story feed entries", async () => {
+    const html = await renderVueComponent(FEED_PANE, feedPaneProps({
+      entries: [{ id: "post-1", author: "bob@example.com", body: "a community post", publishedMs: 1000 }],
+      stories: [],
+    }));
+
+    expect(html).toContain("a community post");
+    expect(html).not.toContain('aria-label="React to story"');
+  });
+});
+
+async function renderVueComponent(path: string, props: Record<string, unknown>) {
+  const component = await loadVueComponent(path);
+  return renderToString(createSSRApp({ render: () => h(component, props) }));
+}
+
+async function setupVueComponent(
+  path: string,
+  props: Record<string, unknown>,
+  emit: (...args: unknown[]) => void = () => undefined,
+): Promise<Record<string, unknown>> {
+  const component = await loadVueComponent(path, { inlineTemplate: false }) as {
+    setup?: (
+      props: Record<string, unknown>,
+      context: {
+        emit: (...args: unknown[]) => void;
+        expose: () => void;
+        attrs: Record<string, unknown>;
+        slots: Record<string, unknown>;
+      },
+    ) => Record<string, unknown>;
+  };
+  if (!component.setup) throw new Error(`${path} has no setup function`);
+  return component.setup(props, {
+    emit,
+    expose: () => undefined,
+    attrs: {},
+    slots: {},
+  });
+}
+
+function setupBindingFunction(
+  bindings: Record<string, unknown>,
+  key: string,
+): (...args: unknown[]) => unknown {
+  const binding = bindings[key];
+  if (typeof binding !== "function") {
+    throw new Error(`Expected setup binding ${key} to be a function`);
+  }
+  return binding as (...args: unknown[]) => unknown;
+}
+
+async function loadVueComponent(path: string, options: { inlineTemplate?: boolean } = {}) {
+  const filename = new URL(path, import.meta.url);
+  const source = readFileSync(filename, "utf8");
+  const { descriptor } = parse(source, { filename: filename.pathname });
+  const script = compileScript(descriptor, {
+    id: filename.pathname,
+    inlineTemplate: options.inlineTemplate ?? true,
+  });
+
+  const tempDir = mkdtempSync(join(tmpdir(), "waddle-vue-component-"));
+  try {
+    const compiled = [
+      rewriteImports(script.content.replace("export default", "const __sfc__ ="), filename),
+      "export default __sfc__;",
+    ].join("\n");
+
+    const js = ts.transpileModule(compiled, {
+      compilerOptions: {
+        module: ts.ModuleKind.ESNext,
+        target: ts.ScriptTarget.ES2022,
+        verbatimModuleSyntax: false,
+      },
+    }).outputText;
+    const modulePath = join(tempDir, "Component.mjs");
+    writeFileSync(modulePath, js);
+    const component = await import(pathToFileURL(modulePath).href);
+    return component.default;
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function rewriteImports(code: string, importer: URL): string {
+  return code.replace(/from\s+["']([^"']+)["']/g, (_match, specifier: string) =>
+    `from ${JSON.stringify(resolveModuleSpecifier(specifier, importer))}`);
+}
+
+function resolveModuleSpecifier(specifier: string, importer: URL): string {
+  if (specifier.startsWith("@/")) {
+    return moduleUrlForPath(resolveSourcePath(new URL(`../src/${specifier.slice(2)}`, import.meta.url).pathname));
+  }
+  if (specifier.startsWith(".")) {
+    return moduleUrlForPath(resolveSourcePath(new URL(specifier, importer).pathname));
+  }
+  return import.meta.resolve(specifier);
+}
+
+function resolveSourcePath(basePath: string): string {
+  const candidates = [
+    basePath,
+    `${basePath}.ts`,
+    `${basePath}.tsx`,
+    `${basePath}.js`,
+    `${basePath}.mjs`,
+    `${basePath}.vue`,
+    `${basePath}.json`,
+    `${basePath}/index.ts`,
+  ];
+  const resolved = candidates.find((candidate) => existsSync(candidate));
+  if (!resolved) throw new Error(`Unable to resolve test SFC import: ${basePath}`);
+  return resolved;
+}
+
+function moduleUrlForPath(resolvedPath: string): string {
+  if (!resolvedPath.endsWith(".vue")) return pathToFileURL(resolvedPath).href;
+  return new URL("./helpers/vue-sfc-stub.ts", import.meta.url).href;
+}


### PR DESCRIPTION
## Summary

Today you can only react to a story after opening it in `StoryReaderDialog`. This PR lets members react to a story **directly from the Community feed** (`FeedPane`), without opening the reader.

The reaction wire path is unchanged — this is a new UI entry point to the existing `react(id, emoji)` → `toggleReaction` → `publishStoryReactions`/`retractStoryReactions` (XEP-0060 pubsub + `urn:xmpp:pubsub-attachments:1`) flow. No protocol/wire-shape change, so no new server XEP behavior or XEP test obligation.

## Design decisions (resolved with the requester)

| Branch | Decision |
|---|---|
| **Trigger** | A single react button (`SmilePlus`) per story card that opens a picker |
| **Picker** | Reuse existing `EmojiPicker.vue` (full picker), `popover` variant on all viewports |
| **Existing reactions** | Count chips on the card, **clickable** to toggle your own reaction (MessageCard parity: `aria-pressed`, "mine" highlight, count in the accessible name) |
| **Read state** | Reacting from the feed does **not** mark the story read — independent ("reacted but New" is allowed) |
| **Layout** | Reactions row pinned to a card **footer**; the avatar/name/body/media region above remains the tap target that opens the reader |
| **Self-react** | React affordance appears on your own stories too — parity with the reader dialog |
| **Scope** | Reaction affordance is story-only; posts/PEP feed entries are unaffected |

## What changed (`chat/src/components/community/FeedPane.vue`)

- De-nested the story card: it was a single `<button>`; it's now a content button (opens the reader) plus a sibling `<footer>`, so reaction controls aren't nested inside a button.
- Footer renders clickable count chips (`reactionChipsFor(id)`, highlighting `mine`) + a `SmilePlus` react button that opens one shared `EmojiPicker` (popover) anchored to the clicked card.
- Added `reactToStory(storyId, emoji)` emitting the existing `react(id, emoji)`; `toggleReaction` (reader path) now delegates to it. No upstream plumbing needed — `ChatReadyShell` already binds `@react` → `stories.toggleReaction` and passes `reactionSummary`.
- a11y: focus returns to the trigger when the picker closes; the open picker is dismissed when its anchored story leaves the feed or the filter hides all stories.
- Fixed a latent `withDefaults` bug: `isStoryRead`/`reactionSummary` fallbacks were double-wrapped (`() => () => …`). Because these are `Function`-typed props, Vue uses the default as-is, so the fallback returned a function instead of a value/summary. Production always passes real providers, but the inline chips exercise the fallback. Corrected to single-arrow defaults.

## Testing

`chat/tests/feed-story-reactions.test.ts` (Bun SSR component harness), 8 tests covering: `reactToStory` emit; react button per story card; clickable count chips with count-scoped assertions and `aria-pressed`/"mine" highlight; self-react parity; reader-open preserved after de-nesting; no react button on non-story entries; the picker → `selectStoryReaction` → `react(id, emoji)` path; and focus return to the trigger on close.

- `bun test`: full suite green (2174 pass).
- `bunx knip`: clean (exit 0); `EmojiPicker`/`SmilePlus` imports are used.
- `bunx astro check`: 0 errors.

Reviewed by adversarial-persona passes (a11y/UX, Vue reactivity, repo hard-rules); all surfaced majors fixed (focus return, dismiss-on-disappear, chip aria-label/aria-pressed, tautological test assertions, untested picker path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
