### PR TITLE
feat(chat): call media-path telemetry — negotiated codec + ICE candidate path

### DIFF
--- a/chat/src/components/calls/CallSettingsDialog.vue
+++ b/chat/src/components/calls/CallSettingsDialog.vue
@@ -728,6 +728,8 @@ function close(): void {
               <span>{{ row.bitrate }}</span>
               <span>loss {{ row.loss }}</span>
               <span>{{ row.rtt }}</span>
+              <span>{{ row.codec }}</span>
+              <span>{{ row.icePath }}</span>
             </div>
           </li>
         </ul>

--- a/chat/src/lib/calls/call-media-path-telemetry.ts
+++ b/chat/src/lib/calls/call-media-path-telemetry.ts
@@ -1,0 +1,93 @@
+import type { CallStatDirection, IceCandidateType, IceTransport } from "./call-stats";
+
+/**
+ * Fleet-measurement telemetry for the media path one call track actually got:
+ * the negotiated video codec and the succeeded ICE candidate-pair, tagged with
+ * direction (publish vs subscribe) and source (camera vs screen). It is the
+ * baseline the codec / Opus / ICE levers in #995 verify against, and it is what
+ * surfaces the silent "stuck on TCP relay" rate.
+ *
+ * Pure and Faro-free: the call engine samples `summarizeVideoStats` and feeds
+ * snapshots in; `telemetry.ts` owns the actual `pushEvent`. Observability only —
+ * no XMPP/Jingle wire effect.
+ */
+
+/** What a call track is carrying its media as. */
+type CallMediaPathSource = "camera" | "screen";
+
+/**
+ * One observed media path for a single track. `codec` and the two ICE fields
+ * are null until the report names them; the sampler skips fully-empty
+ * snapshots so a not-yet-negotiated track never beacons.
+ */
+export type CallMediaPathSnapshot = {
+  direction: CallStatDirection;
+  source: CallMediaPathSource;
+  codec: string | null;
+  iceCandidateType: IceCandidateType | null;
+  iceTransport: IceTransport | null;
+};
+
+/**
+ * Map a snapshot to the flat, string-valued attribute record beaconed to
+ * Grafana Faro (#996). Low-cardinality and PII-free: direction, source, the
+ * codec name, and the ICE candidate type + transport — never a participant
+ * identity or JID. A null field becomes `"unknown"` so a partially-negotiated
+ * path is still countable rather than silently dropped.
+ */
+export function callMediaPathEventAttributes(
+  snapshot: CallMediaPathSnapshot,
+): Record<string, string> {
+  return {
+    direction: snapshot.direction,
+    source: snapshot.source,
+    codec: snapshot.codec ?? "unknown",
+    ice_candidate_type: snapshot.iceCandidateType ?? "unknown",
+    ice_transport: snapshot.iceTransport ?? "unknown",
+  };
+}
+
+/** Stateful, per-call de-duplicating beacon over observed media paths. */
+export type CallMediaPathBeacon = {
+  /** Report `snapshot` unless an equal one already beaconed this call. */
+  observe(snapshot: CallMediaPathSnapshot): void;
+  /** Forget the paths seen this call so the next call re-arms from scratch. */
+  reset(): void;
+};
+
+/** Value-equality of two snapshots — any field differing is a new path. */
+function sameCallMediaPath(a: CallMediaPathSnapshot, b: CallMediaPathSnapshot): boolean {
+  return (
+    a.direction === b.direction &&
+    a.source === b.source &&
+    a.codec === b.codec &&
+    a.iceCandidateType === b.iceCandidateType &&
+    a.iceTransport === b.iceTransport
+  );
+}
+
+/**
+ * Wrap a `report` sink so each *distinct* media path beacons at most once per
+ * call: a recompute that yields the same path collapses to nothing, while a
+ * codec switch (VP9 → VP8 backup) or an ICE re-route (relay → host) emits a
+ * fresh event. `reset()` is called when a call ends so the next call starts
+ * from an empty seen-set.
+ *
+ * The seen-set is bounded (a few directions × sources × codecs × paths), so a
+ * linear scan with value-equality is both simplest and correct.
+ */
+export function createCallMediaPathBeacon(
+  report: (snapshot: CallMediaPathSnapshot) => void,
+): CallMediaPathBeacon {
+  let seen: CallMediaPathSnapshot[] = [];
+  return {
+    observe(snapshot) {
+      if (seen.some((prior) => sameCallMediaPath(prior, snapshot))) return;
+      seen.push(snapshot);
+      report(snapshot);
+    },
+    reset() {
+      seen = [];
+    },
+  };
+}

--- a/chat/src/lib/calls/call-stats.ts
+++ b/chat/src/lib/calls/call-stats.ts
@@ -14,6 +14,20 @@
 
 export type CallStatDirection = "send" | "recv";
 
+/**
+ * ICE candidate type of the succeeded pair's local candidate. `host` is a
+ * direct path, `srflx` a STUN-discovered reflexive one, `prflx` a
+ * peer-reflexive one, and `relay` a TURN-relayed path (the costly fallback).
+ */
+export type IceCandidateType = "host" | "srflx" | "prflx" | "relay";
+
+/**
+ * Transport of the succeeded path. For a relay candidate this is the
+ * client↔TURN leg (`relayProtocol`), so a TURN/TCP or TURN/TLS fallback —
+ * the silent "stuck on TCP relay" case — reads as `tcp`.
+ */
+export type IceTransport = "udp" | "tcp";
+
 /** Byte/timestamp pair carried between polls to derive a bitrate. */
 export type CallStatSample = { bytes: number; timestampMs: number };
 
@@ -24,6 +38,24 @@ export type VideoStatsSummary = {
   bitrateKbps: number | null;
   packetLossPct: number | null;
   rttMs: number | null;
+  /**
+   * Actually-negotiated video codec for the track (e.g. "VP9", "VP8",
+   * "H264"), derived from the live report's `codec` entry — null until a
+   * codec is reported. This is the real wire codec, not the configured
+   * preference: the lever PRD (#995) verifies the VP9-vs-VP8 mix against it.
+   */
+  codec: string | null;
+  /**
+   * Local-candidate type of the succeeded ICE pair (host/srflx/prflx/relay),
+   * or null until a pair is selected. Exposes how often calls fall back to a
+   * TURN relay.
+   */
+  iceCandidateType: IceCandidateType | null;
+  /**
+   * Transport of the succeeded ICE path (udp/tcp), or null. For relay it is
+   * the TURN-leg protocol, so a TCP/TLS relay reads as `tcp`.
+   */
+  iceTransport: IceTransport | null;
 };
 
 /** A single diagnostics row: one video track of one participant. */
@@ -41,6 +73,10 @@ export type VideoStatsDisplay = {
   bitrate: string;
   loss: string;
   rtt: string;
+  /** Negotiated codec, e.g. "VP9", or an em dash. */
+  codec: string;
+  /** ICE path as "type · transport" (e.g. "relay · tcp"), or an em dash. */
+  icePath: string;
 };
 
 /**
@@ -50,6 +86,7 @@ export type VideoStatsDisplay = {
  * the partial typings — values that are absent simply stay null.
  */
 type RtpLike = {
+  id?: string;
   type?: string;
   kind?: string;
   mediaType?: string;
@@ -65,7 +102,78 @@ type RtpLike = {
   currentRoundTripTime?: number;
   nominated?: boolean;
   timestamp?: number;
+  /** RTP entries point at their `codec` entry by id. */
+  codecId?: string;
+  /** `codec` entries carry the negotiated MIME, e.g. "video/VP9". */
+  mimeType?: string;
+  /** `candidate-pair` fields used to find and qualify the active path. */
+  selected?: boolean;
+  state?: string;
+  localCandidateId?: string;
+  /** `local-candidate` fields describing the path. */
+  candidateType?: string;
+  protocol?: string;
+  relayProtocol?: string;
 };
+
+/** Strip the "video/" prefix off a codec MIME, e.g. "video/VP9" → "VP9". */
+function codecName(mimeType: string | undefined): string | null {
+  if (!mimeType) return null;
+  const slash = mimeType.indexOf("/");
+  const name = slash >= 0 ? mimeType.slice(slash + 1) : mimeType;
+  return name.length > 0 ? name : null;
+}
+
+/**
+ * Pick the active candidate pair: the nominated/selected/succeeded one if
+ * present, else any pair carrying an RTT (a path that at least probed), else
+ * the first. A failed pair can still report fields, so it must never shadow
+ * the path media is actually flowing over.
+ */
+function selectCandidatePair(pairs: RtpLike[]): RtpLike | undefined {
+  return (
+    pairs.find((pair) => pair.nominated) ??
+    pairs.find((pair) => pair.selected) ??
+    pairs.find((pair) => pair.state === "succeeded") ??
+    pairs.find((pair) => pair.currentRoundTripTime !== undefined) ??
+    pairs[0]
+  );
+}
+
+/** Narrow a raw `candidateType` to the types we report, else null. */
+function normalizeIceCandidateType(value: string | undefined): IceCandidateType | null {
+  return value === "host" || value === "srflx" || value === "prflx" || value === "relay"
+    ? value
+    : null;
+}
+
+/**
+ * Narrow a raw candidate/relay protocol to udp/tcp. `tls` is TCP-based, so
+ * it folds into `tcp`: operationally it is the same non-UDP relay leg.
+ */
+function normalizeIceTransport(value: string | undefined): IceTransport | null {
+  const normalized = value?.toLowerCase();
+  if (normalized === "udp") return "udp";
+  if (normalized === "tcp" || normalized === "tls") return "tcp";
+  return null;
+}
+
+/**
+ * Resolve the succeeded pair's local candidate to a (type, transport) pair.
+ * Relay transport comes from `relayProtocol` (the client↔TURN leg), which is
+ * what reveals a TCP/TLS relay; other types use the candidate's `protocol`.
+ */
+function iceCandidatePath(
+  candidatePair: RtpLike | undefined,
+  byId: Map<string, RtpLike>,
+): { iceCandidateType: IceCandidateType | null; iceTransport: IceTransport | null } {
+  const localId = candidatePair?.localCandidateId;
+  const local = localId !== undefined ? byId.get(localId) : undefined;
+  const iceCandidateType = normalizeIceCandidateType(local?.candidateType);
+  const rawTransport =
+    iceCandidateType === "relay" ? local?.relayProtocol ?? local?.protocol : local?.protocol;
+  return { iceCandidateType, iceTransport: normalizeIceTransport(rawTransport) };
+}
 
 function isVideo(stat: RtpLike): boolean {
   return stat.kind === "video" || stat.mediaType === "video";
@@ -101,20 +209,24 @@ export function summarizeVideoStats(
   const mainType = direction === "send" ? "outbound-rtp" : "inbound-rtp";
   const mains: RtpLike[] = [];
   const remoteInbounds: RtpLike[] = [];
-  let candidatePair: RtpLike | undefined;
+  const candidatePairs: RtpLike[] = [];
+  // Index every entry by its own `id` so RTP→codec and pair→candidate
+  // references resolve without depending on how the report Map is keyed.
+  const byId = new Map<string, RtpLike>();
 
   report.forEach((raw: unknown) => {
     const stat = raw as RtpLike;
+    if (stat.id !== undefined) byId.set(stat.id, stat);
     if (stat.type === mainType && isVideo(stat)) {
       mains.push(stat);
     } else if (stat.type === "remote-inbound-rtp" && isVideo(stat)) {
       remoteInbounds.push(stat);
-    } else if (stat.type === "candidate-pair" && stat.currentRoundTripTime !== undefined) {
-      // Prefer the nominated/selected pair; a failed pair can also carry
-      // an RTT, so don't let it shadow the active path.
-      if (!candidatePair || stat.nominated) candidatePair = stat;
+    } else if (stat.type === "candidate-pair") {
+      candidatePairs.push(stat);
     }
   });
+  const candidatePair = selectCandidatePair(candidatePairs);
+  const { iceCandidateType, iceTransport } = iceCandidatePath(candidatePair, byId);
 
   // Resolution + fps from the top (largest-area) active layer.
   let top: RtpLike | undefined;
@@ -127,6 +239,11 @@ export function summarizeVideoStats(
   const resolution =
     top?.frameWidth && top?.frameHeight ? `${top.frameWidth}×${top.frameHeight}` : null;
   const fps = top?.framesPerSecond !== undefined ? Math.round(top.framesPerSecond) : null;
+
+  // All simulcast layers share one codec, so the first RTP entry that
+  // names a `codecId` resolves it; prefer the top layer's reference.
+  const codecRef = top?.codecId ?? mains.find((main) => main.codecId !== undefined)?.codecId;
+  const codec = codecRef !== undefined ? codecName(byId.get(codecRef)?.mimeType) : null;
 
   // Bytes summed across all layers; timestamp is the newest layer's.
   const bytesField = direction === "send" ? "bytesSent" : "bytesReceived";
@@ -168,7 +285,10 @@ export function summarizeVideoStats(
   if (rttSec === undefined) rttSec = candidatePair?.currentRoundTripTime;
   const rttMs = rttSec !== undefined ? Math.round(rttSec * 1000) : null;
 
-  return { summary: { resolution, fps, bitrateKbps, packetLossPct, rttMs }, sample };
+  return {
+    summary: { resolution, fps, bitrateKbps, packetLossPct, rttMs, codec, iceCandidateType, iceTransport },
+    sample,
+  };
 }
 
 /** Inbound loss: summed lost / (lost + received) across decoded entries. */
@@ -224,5 +344,16 @@ export function describeVideoStats(summary: VideoStatsSummary): VideoStatsDispla
     bitrate: formatBitrate(summary.bitrateKbps),
     loss: summary.packetLossPct !== null ? `${summary.packetLossPct}%` : "—",
     rtt: summary.rttMs !== null ? `${summary.rttMs} ms` : "—",
+    codec: summary.codec ?? "—",
+    icePath: formatIcePath(summary.iceCandidateType, summary.iceTransport),
   };
+}
+
+/** "type · transport" (e.g. "relay · tcp"); type alone if transport is unknown. */
+function formatIcePath(
+  candidateType: IceCandidateType | null,
+  transport: IceTransport | null,
+): string {
+  if (candidateType === null) return "—";
+  return transport !== null ? `${candidateType} · ${transport}` : candidateType;
 }

--- a/chat/src/lib/calls/call-stats.ts
+++ b/chat/src/lib/calls/call-stats.ts
@@ -106,6 +106,8 @@ type RtpLike = {
   codecId?: string;
   /** `codec` entries carry the negotiated MIME, e.g. "video/VP9". */
   mimeType?: string;
+  /** `transport` entries name the in-use pair — the spec-correct selector. */
+  selectedCandidatePairId?: string;
   /** `candidate-pair` fields used to find and qualify the active path. */
   selected?: boolean;
   state?: string;
@@ -125,17 +127,24 @@ function codecName(mimeType: string | undefined): string | null {
 }
 
 /**
- * Pick the active candidate pair: the nominated/selected/succeeded one if
- * present, else any pair carrying an RTT (a path that at least probed), else
- * the first. A failed pair can still report fields, so it must never shadow
- * the path media is actually flowing over.
+ * Pick the active candidate pair. The spec-correct selector is the transport's
+ * `selectedCandidatePairId`; without it we fall back to Firefox's `selected`
+ * flag, then a nominated *and* succeeded pair, then any succeeded pair, then a
+ * pair carrying an RTT, then a bare-nominated one, then the first. `nominated`
+ * alone is unreliable — several pairs can be nominated and a failed pair can
+ * stay nominated — so it must never shadow the path media is flowing over.
  */
-function selectCandidatePair(pairs: RtpLike[]): RtpLike | undefined {
+function selectCandidatePair(pairs: RtpLike[], selectedId: string | undefined): RtpLike | undefined {
+  if (selectedId !== undefined) {
+    const selected = pairs.find((pair) => pair.id === selectedId);
+    if (selected) return selected;
+  }
   return (
-    pairs.find((pair) => pair.nominated) ??
     pairs.find((pair) => pair.selected) ??
+    pairs.find((pair) => pair.nominated && pair.state === "succeeded") ??
     pairs.find((pair) => pair.state === "succeeded") ??
     pairs.find((pair) => pair.currentRoundTripTime !== undefined) ??
+    pairs.find((pair) => pair.nominated) ??
     pairs[0]
   );
 }
@@ -170,8 +179,10 @@ function iceCandidatePath(
   const localId = candidatePair?.localCandidateId;
   const local = localId !== undefined ? byId.get(localId) : undefined;
   const iceCandidateType = normalizeIceCandidateType(local?.candidateType);
-  const rawTransport =
-    iceCandidateType === "relay" ? local?.relayProtocol ?? local?.protocol : local?.protocol;
+  // For relay, only `relayProtocol` (the client↔TURN leg) is meaningful — the
+  // candidate's own `protocol` is the server↔peer leg (≈always udp) and would
+  // mask a TURN/TCP fallback. Absent relayProtocol → null, never a false udp.
+  const rawTransport = iceCandidateType === "relay" ? local?.relayProtocol : local?.protocol;
   return { iceCandidateType, iceTransport: normalizeIceTransport(rawTransport) };
 }
 
@@ -210,6 +221,7 @@ export function summarizeVideoStats(
   const mains: RtpLike[] = [];
   const remoteInbounds: RtpLike[] = [];
   const candidatePairs: RtpLike[] = [];
+  let selectedPairId: string | undefined;
   // Index every entry by its own `id` so RTP→codec and pair→candidate
   // references resolve without depending on how the report Map is keyed.
   const byId = new Map<string, RtpLike>();
@@ -223,9 +235,11 @@ export function summarizeVideoStats(
       remoteInbounds.push(stat);
     } else if (stat.type === "candidate-pair") {
       candidatePairs.push(stat);
+    } else if (stat.type === "transport" && stat.selectedCandidatePairId !== undefined) {
+      selectedPairId = stat.selectedCandidatePairId;
     }
   });
-  const candidatePair = selectCandidatePair(candidatePairs);
+  const candidatePair = selectCandidatePair(candidatePairs, selectedPairId);
   const { iceCandidateType, iceTransport } = iceCandidatePath(candidatePair, byId);
 
   // Resolution + fps from the top (largest-area) active layer.
@@ -241,9 +255,11 @@ export function summarizeVideoStats(
   const fps = top?.framesPerSecond !== undefined ? Math.round(top.framesPerSecond) : null;
 
   // All simulcast layers share one codec, so the first RTP entry that
-  // names a `codecId` resolves it; prefer the top layer's reference.
+  // names a `codecId` resolves it; prefer the top layer's reference. Pin to a
+  // genuine `codec` entry so a stray/duplicate id can't surface a wrong MIME.
   const codecRef = top?.codecId ?? mains.find((main) => main.codecId !== undefined)?.codecId;
-  const codec = codecRef !== undefined ? codecName(byId.get(codecRef)?.mimeType) : null;
+  const codecEntry = codecRef !== undefined ? byId.get(codecRef) : undefined;
+  const codec = codecEntry?.type === "codec" ? codecName(codecEntry.mimeType) : null;
 
   // Bytes summed across all layers; timestamp is the newest layer's.
   const bytesField = direction === "send" ? "bytesSent" : "bytesReceived";
@@ -282,7 +298,13 @@ export function summarizeVideoStats(
       }
     }
   }
-  if (rttSec === undefined) rttSec = candidatePair?.currentRoundTripTime;
+  // Prefer the active pair's RTT; fall back to any pair that reported one so a
+  // momentarily RTT-less selected pair doesn't blank an otherwise-known RTT.
+  if (rttSec === undefined) {
+    rttSec =
+      candidatePair?.currentRoundTripTime ??
+      candidatePairs.find((pair) => pair.currentRoundTripTime !== undefined)?.currentRoundTripTime;
+  }
   const rttMs = rttSec !== undefined ? Math.round(rttSec * 1000) : null;
 
   return {

--- a/chat/src/lib/calls/call-stats.ts
+++ b/chat/src/lib/calls/call-stats.ts
@@ -298,12 +298,15 @@ export function summarizeVideoStats(
       }
     }
   }
-  // Prefer the active pair's RTT; fall back to any pair that reported one so a
-  // momentarily RTT-less selected pair doesn't blank an otherwise-known RTT.
+  // Prefer the active pair's RTT; fall back to any non-failed pair that
+  // reported one so a momentarily RTT-less selected pair doesn't blank an
+  // otherwise-known RTT — but never surface a failed pair's stale round-trip.
   if (rttSec === undefined) {
     rttSec =
       candidatePair?.currentRoundTripTime ??
-      candidatePairs.find((pair) => pair.currentRoundTripTime !== undefined)?.currentRoundTripTime;
+      candidatePairs.find(
+        (pair) => pair.state !== "failed" && pair.currentRoundTripTime !== undefined,
+      )?.currentRoundTripTime;
   }
   const rttMs = rttSec !== undefined ? Math.round(rttSec * 1000) : null;
 

--- a/chat/src/lib/calls/use-call-engine.ts
+++ b/chat/src/lib/calls/use-call-engine.ts
@@ -72,6 +72,12 @@ const MEDIA_PATH_SAMPLE_INTERVAL_MS = 5_000;
 let mediaPathTimer: ReturnType<typeof setInterval> | null = null;
 // Guards against overlapping ticks if a `getStats()` pass outlives the interval.
 let mediaPathSampling = false;
+// Bumped on every start/stop. A tick captures the generation at launch and
+// re-checks it after its awaits before observing, so an in-flight pass that
+// outlives a disconnect (or a switch to another call) can never re-populate the
+// just-reset beacon — which would otherwise suppress the next call's first
+// event when both calls share a codec/ICE path.
+let mediaPathGeneration = 0;
 
 /**
  * Read one video track's live stats and reduce them to a media-path snapshot,
@@ -101,8 +107,9 @@ async function sampleTrackMediaPath(
 }
 
 /** Sample every published/subscribed video track once and beacon the distinct
- * media paths. Skips re-entrant ticks so a slow pass cannot stack. */
-async function sampleMediaPaths(): Promise<void> {
+ * media paths. Skips re-entrant ticks so a slow pass cannot stack, and discards
+ * its results if the call ended (or restarted) while `getStats()` was awaited. */
+async function sampleMediaPaths(generation: number): Promise<void> {
   if (mediaPathSampling) return;
   mediaPathSampling = true;
   try {
@@ -114,6 +121,9 @@ async function sampleMediaPaths(): Promise<void> {
         .filter((track) => track.kind === "video")
         .map((track) => sampleTrackMediaPath(track, "recv")),
     ]);
+    // Bail if polling was stopped/restarted while we awaited: this pass belongs
+    // to a torn-down call and must not observe into the (reset) beacon.
+    if (generation !== mediaPathGeneration) return;
     for (const snapshot of snapshots) {
       if (snapshot) callMediaPathBeacon.observe(snapshot);
     }
@@ -124,10 +134,16 @@ async function sampleMediaPaths(): Promise<void> {
 
 function startMediaPathPolling(): void {
   stopMediaPathPolling();
-  mediaPathTimer = setInterval(() => void sampleMediaPaths(), MEDIA_PATH_SAMPLE_INTERVAL_MS);
+  const generation = mediaPathGeneration;
+  // Sample immediately so a short call (or the early-settling host/udp path)
+  // still beacons, then poll for any mid-call re-route.
+  void sampleMediaPaths(generation);
+  mediaPathTimer = setInterval(() => void sampleMediaPaths(generation), MEDIA_PATH_SAMPLE_INTERVAL_MS);
 }
 
 function stopMediaPathPolling(): void {
+  // Invalidate any in-flight tick so its post-await observe no-ops.
+  mediaPathGeneration += 1;
   if (mediaPathTimer) {
     clearInterval(mediaPathTimer);
     mediaPathTimer = null;

--- a/chat/src/lib/calls/use-call-engine.ts
+++ b/chat/src/lib/calls/use-call-engine.ts
@@ -68,7 +68,7 @@ const callMediaPathBeacon = createCallMediaPathBeacon(reportCallMediaPath);
 /** Cadence of the observational media-path poll. Codec/ICE settle within the
  * first seconds and then rarely change, and the beacon de-dupes, so a slow 5 s
  * poll captures the path and any mid-call re-route at negligible cost. */
-const MEDIA_PATH_SAMPLE_INTERVAL_MS = 5000;
+const MEDIA_PATH_SAMPLE_INTERVAL_MS = 5_000;
 let mediaPathTimer: ReturnType<typeof setInterval> | null = null;
 // Guards against overlapping ticks if a `getStats()` pass outlives the interval.
 let mediaPathSampling = false;

--- a/chat/src/lib/calls/use-call-engine.ts
+++ b/chat/src/lib/calls/use-call-engine.ts
@@ -18,7 +18,12 @@ import {
   setAiNoiseFilterError,
 } from "./ai-noise-filter-error-state";
 import { createCallAudioProcessingBeacon } from "./call-audio-processing-telemetry";
-import { reportCallAudioProcessing } from "../telemetry";
+import {
+  createCallMediaPathBeacon,
+  type CallMediaPathSnapshot,
+} from "./call-media-path-telemetry";
+import { summarizeVideoStats, type CallStatDirection } from "./call-stats";
+import { reportCallAudioProcessing, reportCallMediaPath } from "../telemetry";
 import {
   resetCallConnectionQuality,
   setCallConnectionPhase,
@@ -49,6 +54,85 @@ const localTracks: Ref<LocalMediaTrack[]> = ref([]);
  * re-arms from scratch.
  */
 const micAudioProcessingBeacon = createCallAudioProcessingBeacon(reportCallAudioProcessing);
+
+/**
+ * Fleet-measurement beacon for the media path each call track actually got
+ * (#996): negotiated video codec + the succeeded ICE candidate-pair. Fed by a
+ * lightweight read-only `getRTCStatsReport` poll that runs for the whole call
+ * (independent of the diagnostics dialog), so the fleet baseline — and the
+ * silent "stuck on TCP relay" rate — is captured on every call. De-dupes to at
+ * most one event per distinct path per call; reset on disconnect.
+ */
+const callMediaPathBeacon = createCallMediaPathBeacon(reportCallMediaPath);
+
+/** Cadence of the observational media-path poll. Codec/ICE settle within the
+ * first seconds and then rarely change, and the beacon de-dupes, so a slow 5 s
+ * poll captures the path and any mid-call re-route at negligible cost. */
+const MEDIA_PATH_SAMPLE_INTERVAL_MS = 5000;
+let mediaPathTimer: ReturnType<typeof setInterval> | null = null;
+// Guards against overlapping ticks if a `getStats()` pass outlives the interval.
+let mediaPathSampling = false;
+
+/**
+ * Read one video track's live stats and reduce them to a media-path snapshot,
+ * or `null` when nothing has been negotiated yet (so a not-yet-connected track
+ * never beacons) or the report is unavailable. `getRTCStatsReport()` rejects
+ * mid-teardown, so a failure drops that single track rather than the tick.
+ */
+async function sampleTrackMediaPath(
+  track: LocalMediaTrack | RemoteMediaTrack,
+  direction: CallStatDirection,
+): Promise<CallMediaPathSnapshot | null> {
+  try {
+    const report = await track.track.getRTCStatsReport();
+    if (!report) return null;
+    const { summary } = summarizeVideoStats(report, direction);
+    if (summary.codec === null && summary.iceCandidateType === null) return null;
+    return {
+      direction,
+      source: track.source === "screen_share" ? "screen" : "camera",
+      codec: summary.codec,
+      iceCandidateType: summary.iceCandidateType,
+      iceTransport: summary.iceTransport,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Sample every published/subscribed video track once and beacon the distinct
+ * media paths. Skips re-entrant ticks so a slow pass cannot stack. */
+async function sampleMediaPaths(): Promise<void> {
+  if (mediaPathSampling) return;
+  mediaPathSampling = true;
+  try {
+    const snapshots = await Promise.all([
+      ...localTracks.value
+        .filter((track) => track.kind === "video")
+        .map((track) => sampleTrackMediaPath(track, "send")),
+      ...remoteTracks.value
+        .filter((track) => track.kind === "video")
+        .map((track) => sampleTrackMediaPath(track, "recv")),
+    ]);
+    for (const snapshot of snapshots) {
+      if (snapshot) callMediaPathBeacon.observe(snapshot);
+    }
+  } finally {
+    mediaPathSampling = false;
+  }
+}
+
+function startMediaPathPolling(): void {
+  stopMediaPathPolling();
+  mediaPathTimer = setInterval(() => void sampleMediaPaths(), MEDIA_PATH_SAMPLE_INTERVAL_MS);
+}
+
+function stopMediaPathPolling(): void {
+  if (mediaPathTimer) {
+    clearInterval(mediaPathTimer);
+    mediaPathTimer = null;
+  }
+}
 
 export function useCallEngine(): {
   engine: CallEngine;
@@ -84,6 +168,12 @@ export function useCallEngine(): {
       const roomJid = activeMucRoomJid();
       if (!roomJid) return;
       setLiveCallParticipants(roomJid, [localIdentity, ...remoteIdentities]);
+    });
+    singletonEngine.on("connected", () => {
+      // Start the observational media-path poll for the whole call (every
+      // call, not just when the diagnostics dialog is open). Separate from the
+      // MUC-projection handler above, which early-returns for 1:1 DM calls.
+      startMediaPathPolling();
     });
     singletonEngine.on("mediaDevicesError", ({ source, error }) => {
       // A best-effort mic/cam capture failed (no device / denied
@@ -156,6 +246,9 @@ export function useCallEngine(): {
       // Re-arm the fleet-measurement beacon so the next call emits its
       // first verified state even if it matches the last call's.
       micAudioProcessingBeacon.reset();
+      // Stop the media-path poll and re-arm its beacon for the next call.
+      stopMediaPathPolling();
+      callMediaPathBeacon.reset();
       // Drop the connection-quality chip so a stale `poor`/`reconnecting`
       // from the call that just ended can't bleed into the next call.
       resetCallConnectionQuality();

--- a/chat/src/lib/telemetry.ts
+++ b/chat/src/lib/telemetry.ts
@@ -44,6 +44,10 @@ import {
   callAudioProcessingEventAttributes,
   type VerifiedCallAudioProcessing,
 } from "./calls/call-audio-processing-telemetry";
+import {
+  callMediaPathEventAttributes,
+  type CallMediaPathSnapshot,
+} from "./calls/call-media-path-telemetry";
 
 type MessageKind = "room" | "dm";
 
@@ -921,6 +925,20 @@ export function reportSessionLifecycle(payload: {
  */
 export function reportCallAudioProcessing(state: VerifiedCallAudioProcessing): void {
   faro?.api.pushEvent("chat.call.audio_processing", callAudioProcessingEventAttributes(state));
+}
+
+/**
+ * Beacon the media path a call track actually got (#996): the negotiated video
+ * codec and the succeeded ICE candidate-pair (type + transport). This is the
+ * baseline the #995 codec/Opus/ICE levers verify against and what surfaces the
+ * silent "stuck on TCP relay" rate. The payload is the PII-free attribute set
+ * from {@link callMediaPathEventAttributes}; coarse browser/platform context
+ * rides along in Faro's event meta. Pure observability — no XMPP/Jingle wire
+ * effect. De-dup (at most once per call per distinct path) is the caller's job
+ * via `createCallMediaPathBeacon`.
+ */
+export function reportCallMediaPath(snapshot: CallMediaPathSnapshot): void {
+  faro?.api.pushEvent("chat.call.media_path", callMediaPathEventAttributes(snapshot));
 }
 
 export function reportStatusChange(payload: {

--- a/chat/tests/call-media-path-telemetry.test.ts
+++ b/chat/tests/call-media-path-telemetry.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+import {
+  callMediaPathEventAttributes,
+  createCallMediaPathBeacon,
+  type CallMediaPathSnapshot,
+} from "../src/lib/calls/call-media-path-telemetry";
+
+const RELAY_TCP: CallMediaPathSnapshot = {
+  direction: "send",
+  source: "screen",
+  codec: "VP9",
+  iceCandidateType: "relay",
+  iceTransport: "tcp",
+};
+
+describe("callMediaPathEventAttributes", () => {
+  test("maps a snapshot to flat, low-cardinality attributes", () => {
+    expect(callMediaPathEventAttributes(RELAY_TCP)).toEqual({
+      direction: "send",
+      source: "screen",
+      codec: "VP9",
+      ice_candidate_type: "relay",
+      ice_transport: "tcp",
+    });
+  });
+
+  test("renders unknown fields as 'unknown' rather than dropping them", () => {
+    expect(
+      callMediaPathEventAttributes({
+        direction: "recv",
+        source: "camera",
+        codec: null,
+        iceCandidateType: null,
+        iceTransport: null,
+      }),
+    ).toEqual({
+      direction: "recv",
+      source: "camera",
+      codec: "unknown",
+      ice_candidate_type: "unknown",
+      ice_transport: "unknown",
+    });
+  });
+
+  test("never emits participant identifiers or JIDs", () => {
+    const attrs = callMediaPathEventAttributes(RELAY_TCP);
+    const allowed = new Set([
+      "direction",
+      "source",
+      "codec",
+      "ice_candidate_type",
+      "ice_transport",
+    ]);
+    for (const key of Object.keys(attrs)) {
+      expect(allowed.has(key)).toBe(true);
+    }
+    const serialized = JSON.stringify(attrs).toLowerCase();
+    expect(serialized).not.toContain("@");
+    expect(serialized).not.toContain("identity");
+    expect(serialized).not.toContain("jid");
+  });
+});
+
+describe("createCallMediaPathBeacon", () => {
+  const snap = (over: Partial<CallMediaPathSnapshot> = {}): CallMediaPathSnapshot => ({
+    ...RELAY_TCP,
+    ...over,
+  });
+
+  test("reports a snapshot once, not again for an equal recompute", () => {
+    const reported: CallMediaPathSnapshot[] = [];
+    const beacon = createCallMediaPathBeacon((s) => reported.push(s));
+
+    beacon.observe(snap());
+    beacon.observe(snap());
+
+    expect(reported).toHaveLength(1);
+  });
+
+  test("re-beacons when the negotiated codec changes", () => {
+    const reported: CallMediaPathSnapshot[] = [];
+    const beacon = createCallMediaPathBeacon((s) => reported.push(s));
+
+    beacon.observe(snap({ codec: "VP9" }));
+    beacon.observe(snap({ codec: "VP8" }));
+
+    expect(reported).toHaveLength(2);
+    expect(reported[1]?.codec).toBe("VP8");
+  });
+
+  test("re-beacons when the ICE path changes (relay → host)", () => {
+    const reported: CallMediaPathSnapshot[] = [];
+    const beacon = createCallMediaPathBeacon((s) => reported.push(s));
+
+    beacon.observe(snap({ iceCandidateType: "relay", iceTransport: "tcp" }));
+    beacon.observe(snap({ iceCandidateType: "host", iceTransport: "udp" }));
+
+    expect(reported).toHaveLength(2);
+  });
+
+  test("treats send and recv of an otherwise-equal path as distinct", () => {
+    const reported: CallMediaPathSnapshot[] = [];
+    const beacon = createCallMediaPathBeacon((s) => reported.push(s));
+
+    beacon.observe(snap({ direction: "send" }));
+    beacon.observe(snap({ direction: "recv" }));
+
+    expect(reported).toHaveLength(2);
+  });
+
+  test("does not re-beacon a snapshot already seen earlier in the same call", () => {
+    const reported: CallMediaPathSnapshot[] = [];
+    const beacon = createCallMediaPathBeacon((s) => reported.push(s));
+
+    beacon.observe(snap({ codec: "VP9" }));
+    beacon.observe(snap({ codec: "VP8" }));
+    beacon.observe(snap({ codec: "VP9" }));
+
+    expect(reported).toHaveLength(2);
+  });
+
+  test("reset re-arms the beacon for the next call", () => {
+    const reported: CallMediaPathSnapshot[] = [];
+    const beacon = createCallMediaPathBeacon((s) => reported.push(s));
+
+    beacon.observe(snap());
+    beacon.reset();
+    beacon.observe(snap());
+
+    expect(reported).toHaveLength(2);
+  });
+});

--- a/chat/tests/call-stats.test.ts
+++ b/chat/tests/call-stats.test.ts
@@ -368,6 +368,34 @@ describe("summarizeVideoStats — ICE candidate path", () => {
     expect(summary.rttMs).toBe(20);
   });
 
+  test("falls through to the quality chain when selectedCandidatePairId names a missing pair", () => {
+    const pair = {
+      type: "candidate-pair",
+      id: "cp-real",
+      state: "succeeded",
+      currentRoundTripTime: 0.03,
+      localCandidateId: "lc-host",
+    };
+    const transport = { type: "transport", id: "T1", selectedCandidatePairId: "cp-gone" };
+    const host = { type: "local-candidate", id: "lc-host", candidateType: "host", protocol: "udp" };
+    const { summary } = summarizeVideoStats(report([inbound, pair, transport, host]), "recv");
+    expect(summary.iceCandidateType).toBe("host");
+    expect(summary.rttMs).toBe(30);
+  });
+
+  test("borrows a sibling pair's RTT when the selected pair reports none this tick", () => {
+    const selectedPair = { type: "candidate-pair", id: "cp-sel", localCandidateId: "lc-host" };
+    const sibling = { type: "candidate-pair", id: "cp-other", currentRoundTripTime: 0.04 };
+    const transport = { type: "transport", id: "T1", selectedCandidatePairId: "cp-sel" };
+    const host = { type: "local-candidate", id: "lc-host", candidateType: "host", protocol: "udp" };
+    const { summary } = summarizeVideoStats(
+      report([inbound, selectedPair, sibling, transport, host]),
+      "recv",
+    );
+    expect(summary.iceCandidateType).toBe("host"); // path from the selected pair
+    expect(summary.rttMs).toBe(40); // RTT borrowed from the sibling
+  });
+
   test("a relay candidate with no relayProtocol reports a null transport, not a misleading udp", () => {
     // A relay candidate's own `protocol` is the server↔peer leg (≈always udp);
     // borrowing it would hide a real TURN/TCP leg. Absent relayProtocol → null.

--- a/chat/tests/call-stats.test.ts
+++ b/chat/tests/call-stats.test.ts
@@ -396,6 +396,26 @@ describe("summarizeVideoStats — ICE candidate path", () => {
     expect(summary.rttMs).toBe(40); // RTT borrowed from the sibling
   });
 
+  test("does not borrow RTT from a failed pair when a non-failed pair reports one", () => {
+    // A failed pair can still carry an RTT; the borrow must skip it rather than
+    // surface a misleading round-trip from a path media never settled on.
+    const selectedPair = {
+      type: "candidate-pair",
+      id: "cp-sel",
+      state: "succeeded",
+      localCandidateId: "lc-host",
+    };
+    const failed = { type: "candidate-pair", id: "cp-failed", state: "failed", currentRoundTripTime: 0.5 };
+    const healthy = { type: "candidate-pair", id: "cp-ok", currentRoundTripTime: 0.03 };
+    const transport = { type: "transport", id: "T1", selectedCandidatePairId: "cp-sel" };
+    const host = { type: "local-candidate", id: "lc-host", candidateType: "host", protocol: "udp" };
+    const { summary } = summarizeVideoStats(
+      report([inbound, failed, selectedPair, healthy, transport, host]),
+      "recv",
+    );
+    expect(summary.rttMs).toBe(30); // from the healthy pair, not the failed 500ms one
+  });
+
   test("a relay candidate with no relayProtocol reports a null transport, not a misleading udp", () => {
     // A relay candidate's own `protocol` is the server↔peer leg (≈always udp);
     // borrowing it would hide a real TURN/TCP leg. Absent relayProtocol → null.

--- a/chat/tests/call-stats.test.ts
+++ b/chat/tests/call-stats.test.ts
@@ -79,6 +79,38 @@ describe("summarizeVideoStats — outbound (send) video", () => {
   });
 });
 
+describe("summarizeVideoStats — negotiated codec", () => {
+  test("reads the codec name from the track's codec entry, dropping the media prefix", () => {
+    const out = {
+      type: "outbound-rtp",
+      kind: "video",
+      frameWidth: 1920,
+      frameHeight: 1080,
+      framesPerSecond: 30,
+      bytesSent: 1_000_000,
+      packetsSent: 1000,
+      timestamp: 10_000,
+      codecId: "RTCCodec_1_outbound_98",
+    };
+    const codec = { type: "codec", id: "RTCCodec_1_outbound_98", mimeType: "video/VP9" };
+    const { summary } = summarizeVideoStats(report([out, codec]), "send");
+    expect(summary.codec).toBe("VP9");
+  });
+
+  test("codec is null when no codec entry is referenced", () => {
+    const out = {
+      type: "outbound-rtp",
+      kind: "video",
+      frameWidth: 1280,
+      frameHeight: 720,
+      bytesSent: 1,
+      timestamp: 1,
+    };
+    const { summary } = summarizeVideoStats(report([out]), "send");
+    expect(summary.codec).toBeNull();
+  });
+});
+
 describe("summarizeVideoStats — inbound (recv) video", () => {
   test("computes packet loss from received vs lost and rtt from the candidate pair", () => {
     const inbound = {
@@ -107,6 +139,9 @@ describe("summarizeVideoStats — inbound (recv) video", () => {
       bitrateKbps: null,
       packetLossPct: null,
       rttMs: null,
+      codec: null,
+      iceCandidateType: null,
+      iceTransport: null,
     });
     expect(describeVideoStats(summary)).toEqual({
       resolution: "—",
@@ -114,7 +149,151 @@ describe("summarizeVideoStats — inbound (recv) video", () => {
       bitrate: "—",
       loss: "—",
       rtt: "—",
+      codec: "—",
+      icePath: "—",
     });
+  });
+});
+
+describe("describeVideoStats — codec and ICE path", () => {
+  const base = {
+    resolution: "1280×720",
+    fps: 30,
+    bitrateKbps: 800,
+    packetLossPct: 0,
+    rttMs: 12,
+  };
+
+  test("shows the codec name and a 'type · transport' ICE path", () => {
+    const display = describeVideoStats({
+      ...base,
+      codec: "VP9",
+      iceCandidateType: "relay",
+      iceTransport: "tcp",
+    });
+    expect(display.codec).toBe("VP9");
+    expect(display.icePath).toBe("relay · tcp");
+  });
+
+  test("renders an em dash for a missing codec and falls back to type alone when transport is unknown", () => {
+    const display = describeVideoStats({
+      ...base,
+      codec: null,
+      iceCandidateType: "host",
+      iceTransport: null,
+    });
+    expect(display.codec).toBe("—");
+    expect(display.icePath).toBe("host");
+  });
+});
+
+describe("summarizeVideoStats — ICE candidate path", () => {
+  const inbound = {
+    type: "inbound-rtp",
+    kind: "video",
+    frameWidth: 1280,
+    frameHeight: 720,
+    bytesReceived: 1,
+    timestamp: 1,
+  };
+
+  test("a relay candidate over a TCP TURN leg reports relay + tcp (from relayProtocol)", () => {
+    // The candidate's own `protocol` is udp (relayed media always leaves the
+    // TURN server over UDP); the slow leg that "stuck on TCP relay" means is
+    // the client↔TURN protocol, carried by `relayProtocol`.
+    const pair = {
+      type: "candidate-pair",
+      nominated: true,
+      currentRoundTripTime: 0.03,
+      localCandidateId: "lc-relay",
+    };
+    const local = {
+      type: "local-candidate",
+      id: "lc-relay",
+      candidateType: "relay",
+      protocol: "udp",
+      relayProtocol: "tcp",
+    };
+    const { summary } = summarizeVideoStats(report([inbound, pair, local]), "recv");
+    expect(summary.iceCandidateType).toBe("relay");
+    expect(summary.iceTransport).toBe("tcp");
+  });
+
+  test("a direct host candidate reports host + udp (from the candidate protocol)", () => {
+    const pair = {
+      type: "candidate-pair",
+      nominated: true,
+      currentRoundTripTime: 0.01,
+      localCandidateId: "lc-host",
+    };
+    const local = { type: "local-candidate", id: "lc-host", candidateType: "host", protocol: "udp" };
+    const { summary } = summarizeVideoStats(report([inbound, pair, local]), "recv");
+    expect(summary.iceCandidateType).toBe("host");
+    expect(summary.iceTransport).toBe("udp");
+  });
+
+  test("a server-reflexive candidate reports srflx", () => {
+    const pair = {
+      type: "candidate-pair",
+      nominated: true,
+      currentRoundTripTime: 0.02,
+      localCandidateId: "lc-srflx",
+    };
+    const local = { type: "local-candidate", id: "lc-srflx", candidateType: "srflx", protocol: "udp" };
+    const { summary } = summarizeVideoStats(report([inbound, pair, local]), "recv");
+    expect(summary.iceCandidateType).toBe("srflx");
+    expect(summary.iceTransport).toBe("udp");
+  });
+
+  test("reads the path from the nominated pair, ignoring an also-present failed pair", () => {
+    const failed = {
+      type: "candidate-pair",
+      state: "failed",
+      localCandidateId: "lc-host",
+    };
+    const nominated = {
+      type: "candidate-pair",
+      nominated: true,
+      currentRoundTripTime: 0.05,
+      localCandidateId: "lc-relay",
+    };
+    const host = { type: "local-candidate", id: "lc-host", candidateType: "host", protocol: "udp" };
+    const relay = {
+      type: "local-candidate",
+      id: "lc-relay",
+      candidateType: "relay",
+      protocol: "udp",
+      relayProtocol: "udp",
+    };
+    const { summary } = summarizeVideoStats(report([inbound, failed, nominated, host, relay]), "recv");
+    expect(summary.iceCandidateType).toBe("relay");
+    expect(summary.iceTransport).toBe("udp");
+    expect(summary.rttMs).toBe(50); // RTT still comes from the nominated pair
+  });
+
+  test("a TLS TURN leg counts as tcp transport (non-UDP relay)", () => {
+    const pair = {
+      type: "candidate-pair",
+      nominated: true,
+      currentRoundTripTime: 0.04,
+      localCandidateId: "lc-tls",
+    };
+    const local = {
+      type: "local-candidate",
+      id: "lc-tls",
+      candidateType: "relay",
+      protocol: "udp",
+      relayProtocol: "tls",
+    };
+    const { summary } = summarizeVideoStats(report([inbound, pair, local]), "recv");
+    expect(summary.iceCandidateType).toBe("relay");
+    expect(summary.iceTransport).toBe("tcp");
+  });
+
+  test("ICE fields are null when no candidate pair is reported", () => {
+    const { summary } = summarizeVideoStats(report([inbound]), "recv");
+    expect(summary.iceCandidateType).toBeNull();
+    expect(summary.iceTransport).toBeNull();
   });
 });
 

--- a/chat/tests/call-stats.test.ts
+++ b/chat/tests/call-stats.test.ts
@@ -97,6 +97,19 @@ describe("summarizeVideoStats — negotiated codec", () => {
     expect(summary.codec).toBe("VP9");
   });
 
+  test("ignores a codecId that resolves to a non-codec entry", () => {
+    const out = {
+      type: "outbound-rtp",
+      kind: "video",
+      bytesSent: 1,
+      timestamp: 1,
+      codecId: "not-a-codec",
+    };
+    const stray = { type: "track", id: "not-a-codec", mimeType: "video/HACK" };
+    const { summary } = summarizeVideoStats(report([out, stray]), "send");
+    expect(summary.codec).toBeNull();
+  });
+
   test("codec is null when no codec entry is referenced", () => {
     const out = {
       type: "outbound-rtp",
@@ -288,6 +301,87 @@ describe("summarizeVideoStats — ICE candidate path", () => {
     const { summary } = summarizeVideoStats(report([inbound, pair, local]), "recv");
     expect(summary.iceCandidateType).toBe("relay");
     expect(summary.iceTransport).toBe("tcp");
+  });
+
+  test("prefers the transport's selectedCandidatePairId over a bare nominated flag", () => {
+    // The spec allows several pairs to be `nominated`; only the one named by
+    // RTCTransportStats.selectedCandidatePairId is the path media flows over.
+    const relayPair = {
+      type: "candidate-pair",
+      id: "cp-relay",
+      nominated: true,
+      state: "succeeded",
+      currentRoundTripTime: 0.09,
+      localCandidateId: "lc-relay",
+    };
+    const hostPair = {
+      type: "candidate-pair",
+      id: "cp-host",
+      nominated: true,
+      state: "succeeded",
+      currentRoundTripTime: 0.01,
+      localCandidateId: "lc-host",
+    };
+    const transport = { type: "transport", id: "T1", selectedCandidatePairId: "cp-host" };
+    const host = { type: "local-candidate", id: "lc-host", candidateType: "host", protocol: "udp" };
+    const relay = {
+      type: "local-candidate",
+      id: "lc-relay",
+      candidateType: "relay",
+      protocol: "udp",
+      relayProtocol: "tcp",
+    };
+    // Relay first, so a naive `find(nominated)` would wrongly pick it.
+    const { summary } = summarizeVideoStats(
+      report([inbound, relayPair, hostPair, transport, host, relay]),
+      "recv",
+    );
+    expect(summary.iceCandidateType).toBe("host");
+    expect(summary.iceTransport).toBe("udp");
+    expect(summary.rttMs).toBe(10); // RTT from the actually-selected pair
+  });
+
+  test("falls back to Firefox's `selected` flag when no transport entry is present", () => {
+    const other = {
+      type: "candidate-pair",
+      id: "cp-1",
+      currentRoundTripTime: 0.2,
+      localCandidateId: "lc-host",
+    };
+    const active = {
+      type: "candidate-pair",
+      id: "cp-2",
+      selected: true,
+      currentRoundTripTime: 0.02,
+      localCandidateId: "lc-relay",
+    };
+    const host = { type: "local-candidate", id: "lc-host", candidateType: "host", protocol: "udp" };
+    const relay = {
+      type: "local-candidate",
+      id: "lc-relay",
+      candidateType: "relay",
+      protocol: "udp",
+      relayProtocol: "udp",
+    };
+    const { summary } = summarizeVideoStats(report([inbound, other, active, host, relay]), "recv");
+    expect(summary.iceCandidateType).toBe("relay");
+    expect(summary.rttMs).toBe(20);
+  });
+
+  test("a relay candidate with no relayProtocol reports a null transport, not a misleading udp", () => {
+    // A relay candidate's own `protocol` is the server↔peer leg (≈always udp);
+    // borrowing it would hide a real TURN/TCP leg. Absent relayProtocol → null.
+    const pair = {
+      type: "candidate-pair",
+      nominated: true,
+      state: "succeeded",
+      currentRoundTripTime: 0.03,
+      localCandidateId: "lc-relay",
+    };
+    const local = { type: "local-candidate", id: "lc-relay", candidateType: "relay", protocol: "udp" };
+    const { summary } = summarizeVideoStats(report([inbound, pair, local]), "recv");
+    expect(summary.iceCandidateType).toBe("relay");
+    expect(summary.iceTransport).toBeNull();
   });
 
   test("ICE fields are null when no candidate pair is reported", () => {


### PR DESCRIPTION
## Summary

Telemetry-first slice of #995 (LiveKit call media quality). Makes every
Waddle call report **which media path it actually got** so the later
codec / Opus / ICE levers have a measurable baseline and the silent
"stuck on TCP relay" rate becomes visible. Purely observational — no
change to media behavior and no XMPP wire surface (the XEP-0215 ICE
work is a separate later slice, so no XEP conformance impact here).

Closes #996.

## What this adds

While a call is connected, a lightweight read-only `getRTCStatsReport`
poll samples the live `RTCStatsReport` and extracts:

- the **actually-negotiated video codec** for each published/subscribed
  track (e.g. VP9 vs the VP8 backup), via the track's `codecId` →
  `codec` entry `mimeType`, pinned to a genuine `codec` entry;
- the **succeeded ICE candidate-pair's** candidate type
  (host / srflx / prflx / relay) and transport (udp / tcp). The active
  pair is chosen the spec-correct way — `RTCTransportStats.selectedCandidatePairId`
  — falling back to Firefox's `selected`, then nominated-and-succeeded,
  etc. For a relay candidate the transport is read from `relayProtocol`
  (the client↔TURN leg, with TLS folded into tcp), which is what
  actually exposes a TCP-relay fallback.

These are surfaced in the existing call-stats diagnostics table and
emitted on a Faro beacon (`chat.call.media_path`), de-duplicated so an
unchanged recompute does not re-emit — mirroring the audio-processing
beacon (injected-callback pattern, no Faro SDK in tests). The poll runs
for the whole call (started on `connected`, stopped + reset on
`disconnected`), independent of the diagnostics dialog, so the fleet
baseline is captured on every call.

## Files

- `call-stats.ts` — extend the pure `summarizeVideoStats` to extract
  codec + ICE candidate type/transport; add fields to
  `VideoStatsSummary` and display strings to `describeVideoStats`.
  Entries are indexed by their `id` for codec/candidate lookups.
- `call-media-path-telemetry.ts` (new) — `CallMediaPathSnapshot`,
  PII-free `callMediaPathEventAttributes`, and
  `createCallMediaPathBeacon(report)` with value-equality de-dup +
  `reset()`.
- `telemetry.ts` — `reportCallMediaPath` → `chat.call.media_path`.
- `use-call-engine.ts` — fleet-wide wiring: 5s media-path poll, beacon
  lifecycle on connect/disconnect.
- `CallSettingsDialog.vue` — show codec + ICE path in the stats table.

## Testing

- Stats summarizer: synthetic `RTCStatsReport` (codec + candidate-pair +
  local-candidate + transport entries) asserts the new fields alongside
  the existing bitrate/resolution/framerate/loss/RTT assertions,
  including simulcast aggregation, failed-pair shadowing, the
  `selectedCandidatePairId` precedence, the Firefox `selected` fallback,
  TLS→tcp, relay-without-relayProtocol, and codec-entry pinning.
- Faro beacon: the attribute mapping and per-call de-dup/reset are
  covered with an injected callback — no Faro SDK touched.
- `bun test` green (2211 pass), `knip` clean, `astro check` 0 errors.

Reviewed by adversarial-persona agents (RTCStats correctness,
telemetry/privacy/lifecycle, standards/tests); their findings — most
significantly a spec-unsound `nominated`-first pair selection that would
corrupt the TCP-relay metric — are fixed and covered by tests.

## Acceptance criteria

- [x] Call-stats summary includes negotiated video codec per track.
- [x] Call-stats summary includes succeeded ICE candidate-pair type +
      transport.
- [x] Faro beacon emits these fields, de-duplicated.
- [x] Summarizer unit-tested with a synthetic report.
- [x] Beacon emission unit-tested (incl. de-dup), no Faro SDK.
- [x] No behavior change to media itself.
- [x] `bun test` passes and `knip` is clean in chat/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
