### PR TITLE
feat(chat): VP9+SVC screen-share for capable devices (VP8 backup)

### DIFF
--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -22,6 +22,7 @@ import {
   videoCodecSupport,
   type VideoCodecSupport,
 } from "./video-codec/support";
+import { currentScreenCaptureEnv } from "./video-codec/screen-capture-env";
 import type { LiveKitJoin } from "./types";
 import type { CallConnectionPhase, CallConnectionQuality } from "./connection-quality";
 import {
@@ -440,6 +441,7 @@ export class CallEngine {
     const { capture, publish } = videoPublishPlan({
       source: "screen",
       capability: this.codecSupport,
+      screenCapture: currentScreenCaptureEnv(),
     });
     const captureOptions = { ...capture, audio: opts.audio };
     try {

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -3,7 +3,6 @@ import {
   ConnectionState,
   Room,
   RoomEvent,
-  ScreenSharePresets,
   Track,
   VideoPresets,
   type LocalParticipant,
@@ -17,6 +16,12 @@ import {
   type TrackPublishOptions,
   type VideoCaptureOptions,
 } from "livekit-client";
+import { videoPublishPlan } from "./video-codec/video-publish";
+import {
+  currentVideoCodecSupportEnv,
+  videoCodecSupport,
+  type VideoCodecSupport,
+} from "./video-codec/support";
 import type { LiveKitJoin } from "./types";
 import type { CallConnectionPhase, CallConnectionQuality } from "./connection-quality";
 import {
@@ -55,27 +60,6 @@ type ProcessorCapableTrack = {
  */
 const CAMERA_CAPTURE_RESOLUTION = VideoPresets.h1080.resolution;
 
-/**
- * Screen-share encoding. 1080p@15fps keeps shared code/text crisp at a
- * modest 2.5 Mbps; 15fps is plenty for slides, docs, and scrolling.
- */
-const SCREEN_SHARE_ENCODING = ScreenSharePresets.h1080fps15.encoding;
-
-/**
- * Per-source degradation under CPU / bandwidth pressure. A camera is a
- * talking head: keep motion smooth and shed resolution
- * (`maintain-framerate`). A screen share is usually text: keep it
- * readable and shed frames (`maintain-resolution`). Passed per-publish
- * because the two sources want opposite tradeoffs and `publishDefaults`
- * is a single global value.
- */
-const CAMERA_PUBLISH_OPTIONS: TrackPublishOptions = {
-  degradationPreference: "maintain-framerate",
-};
-const SCREEN_SHARE_PUBLISH_OPTIONS: TrackPublishOptions = {
-  degradationPreference: "maintain-resolution",
-};
-
 export function audioCaptureDefaultsForPrefs(prefs: {
   mic: string | null;
   audioProcessing: AudioProcessingPrefs;
@@ -104,9 +88,8 @@ export function callRoomOptionsForPrefs(prefs: {
       deviceId: prefs.cam ?? undefined,
       resolution: CAMERA_CAPTURE_RESOLUTION,
     },
-    publishDefaults: {
-      screenShareEncoding: SCREEN_SHARE_ENCODING,
-    },
+    // Screen-share encoding/codec is set per-publish by `videoPublishPlan`
+    // (it is capability-dependent), so no global `publishDefaults` here.
   };
 }
 
@@ -319,11 +302,19 @@ export class CallEngine {
   private appliedModelActiveForCapture = false;
   /** Builds a processor for a model; injectable so tests avoid real wasm. */
   private readonly makeAiNoiseProcessor: (model: NoiseModelId) => Promise<AudioNoiseProcessor>;
+  /**
+   * Which video codecs this device can publish, probed once at construction.
+   * Injectable so tests assert the forwarded options for capable vs.
+   * incapable devices without real WebRTC.
+   */
+  private readonly codecSupport: VideoCodecSupport;
 
   constructor(opts?: {
     makeAiNoiseProcessor?: (model: NoiseModelId) => Promise<AudioNoiseProcessor>;
+    videoCodecSupport?: VideoCodecSupport;
   }) {
     this.makeAiNoiseProcessor = opts?.makeAiNoiseProcessor ?? makeNoiseProcessor;
+    this.codecSupport = opts?.videoCodecSupport ?? videoCodecSupport(currentVideoCodecSupportEnv());
   }
 
   /** LiveKit identity of the local participant, populated once
@@ -419,6 +410,7 @@ export class CallEngine {
       room.localParticipant,
       { audio: opts.audio, video: opts.video },
       (source, error) => this.emit("mediaDevicesError", { source, error }),
+      videoPublishPlan({ source: "camera", capability: this.codecSupport }).publish,
     );
     // Re-apply the speaker preference now that the room has remote
     // audio elements to retarget; the engine ignores it on connect
@@ -436,11 +428,8 @@ export class CallEngine {
 
   async setCameraEnabled(enabled: boolean): Promise<void> {
     if (!this.room) return;
-    await this.room.localParticipant.setCameraEnabled(
-      enabled,
-      undefined,
-      CAMERA_PUBLISH_OPTIONS,
-    );
+    const { publish } = videoPublishPlan({ source: "camera", capability: this.codecSupport });
+    await this.room.localParticipant.setCameraEnabled(enabled, undefined, publish);
   }
 
   async setScreenShareEnabled(
@@ -448,18 +437,19 @@ export class CallEngine {
     opts: { audio: boolean },
   ): Promise<void> {
     if (!this.room) return;
+    const { capture, publish } = videoPublishPlan({
+      source: "screen",
+      capability: this.codecSupport,
+    });
+    const captureOptions = { ...capture, audio: opts.audio };
     try {
-      await this.room.localParticipant.setScreenShareEnabled(
-        enabled,
-        { audio: opts.audio },
-        SCREEN_SHARE_PUBLISH_OPTIONS,
-      );
+      await this.room.localParticipant.setScreenShareEnabled(enabled, captureOptions, publish);
     } catch (error) {
       if (!enabled || !opts.audio || !isUnsupportedScreenAudioError(error)) throw error;
       await this.room.localParticipant.setScreenShareEnabled(
         true,
-        { audio: false },
-        SCREEN_SHARE_PUBLISH_OPTIONS,
+        { ...captureOptions, audio: false },
+        publish,
       );
     }
   }
@@ -1072,6 +1062,7 @@ export async function enableRequestedCapture(
   participant: CapturableParticipant,
   opts: { audio: boolean; video: boolean },
   onError: (source: "audio" | "video", error: unknown) => void,
+  cameraPublishOptions: TrackPublishOptions,
 ): Promise<void> {
   if (opts.audio) {
     try {
@@ -1082,7 +1073,7 @@ export async function enableRequestedCapture(
   }
   if (opts.video) {
     try {
-      await participant.setCameraEnabled(true, undefined, CAMERA_PUBLISH_OPTIONS);
+      await participant.setCameraEnabled(true, undefined, cameraPublishOptions);
     } catch (error) {
       onError("video", error);
     }

--- a/chat/src/lib/calls/video-codec/screen-capture-env.ts
+++ b/chat/src/lib/calls/video-codec/screen-capture-env.ts
@@ -1,0 +1,34 @@
+/**
+ * Whether the browser can be given an explicit screen-capture resolution.
+ *
+ * macOS Safari 17.x has a WebKit bug (https://bugs.webkit.org/show_bug.cgi?id=263015):
+ * passing ANY resolution to `getDisplayMedia` collapses the capture to a low
+ * resolution. livekit-client works around it by only injecting a default
+ * resolution when the browser is NOT Safari-17-based — but it leaves an
+ * explicitly-passed resolution untouched, so we must not pass one there
+ * either, or we re-introduce the degraded capture. Elsewhere the bitrate
+ * ceiling still bounds the encode, so leaving capture uncapped on Safari 17 is
+ * safe.
+ *
+ * Pure over an injected user-agent so it is unit-tested without globals.
+ */
+
+export type ScreenCaptureEnv = {
+  /** False on macOS Safari 17.x (see above); true everywhere else. */
+  canConstrainResolution: boolean;
+};
+
+/** Pure: does this user-agent have the Safari-17 capture-resolution bug? */
+export function hasSafari17CaptureBug(userAgent: string): boolean {
+  // Apple Safari only — exclude every Chromium/Gecko engine that also carries
+  // "Safari" (or runs on Apple hardware) in its UA.
+  const isAppleSafari = /^((?!chrome|chromium|android|crios|fxios|edg).)*safari/i.test(userAgent);
+  return isAppleSafari && /version\/17\./i.test(userAgent);
+}
+
+/** Read the real environment. Thin; the decision logic lives in the pure probe. */
+export function currentScreenCaptureEnv(
+  userAgent: string = typeof navigator === "undefined" ? "" : navigator.userAgent,
+): ScreenCaptureEnv {
+  return { canConstrainResolution: !hasSafari17CaptureBug(userAgent) };
+}

--- a/chat/src/lib/calls/video-codec/support.ts
+++ b/chat/src/lib/calls/video-codec/support.ts
@@ -14,9 +14,11 @@
 type ProbedVideoCodec = "vp9" | "vp8";
 
 export type VideoCodecSupportEnv = {
-  /** Lowercased mimeTypes from `RTCRtpSender.getCapabilities('video')`. */
+  /** mimeTypes from `RTCRtpSender.getCapabilities('video')`, any casing
+   *  (matched case-insensitively; the edge reader passes them through raw). */
   encode: readonly string[];
-  /** Lowercased mimeTypes from `RTCRtpReceiver.getCapabilities('video')`. */
+  /** mimeTypes from `RTCRtpReceiver.getCapabilities('video')`, any casing
+   *  (matched case-insensitively; the edge reader passes them through raw). */
   decode: readonly string[];
 };
 

--- a/chat/src/lib/calls/video-codec/support.ts
+++ b/chat/src/lib/calls/video-codec/support.ts
@@ -25,10 +25,20 @@ type VideoCodecAvailability = { available: true } | { available: false; reason: 
 
 export type VideoCodecSupport = Record<ProbedVideoCodec, VideoCodecAvailability>;
 
-function availability(codec: ProbedVideoCodec, env: VideoCodecSupportEnv): VideoCodecAvailability {
+function advertises(mimeTypes: readonly string[], codec: ProbedVideoCodec): boolean {
   const mime = `video/${codec}`;
-  const canEncode = env.encode.includes(mime);
-  return canEncode ? { available: true } : { available: false, reason: `This browser can't encode ${codec.toUpperCase()}.` };
+  return mimeTypes.some((m) => m.toLowerCase() === mime);
+}
+
+function availability(codec: ProbedVideoCodec, env: VideoCodecSupportEnv): VideoCodecAvailability {
+  const name = codec.toUpperCase();
+  if (!advertises(env.encode, codec)) {
+    return { available: false, reason: `This browser can't encode ${name}.` };
+  }
+  if (!advertises(env.decode, codec)) {
+    return { available: false, reason: `This browser can't decode ${name}.` };
+  }
+  return { available: true };
 }
 
 /** Per-codec availability for the current environment. */
@@ -36,5 +46,32 @@ export function videoCodecSupport(env: VideoCodecSupportEnv): VideoCodecSupport 
   return {
     vp9: availability("vp9", env),
     vp8: availability("vp8", env),
+  };
+}
+
+/**
+ * The `static getCapabilities('video')` surface of `RTCRtpSender` /
+ * `RTCRtpReceiver`. Narrowed to what the probe reads and made injectable so
+ * the edge reader is testable without real WebRTC globals.
+ */
+export type RtpCapabilitiesSource = {
+  getCapabilities?: (kind: "video") => { codecs?: { mimeType?: string }[] } | null;
+};
+
+function capabilityMimeTypes(source: RtpCapabilitiesSource | undefined): string[] {
+  const codecs = source?.getCapabilities?.("video")?.codecs ?? [];
+  return codecs.map((c) => c.mimeType ?? "").filter((m) => m.length > 0);
+}
+
+/** Read the real environment. Thin; the decision logic lives in the pure probe. */
+export function currentVideoCodecSupportEnv(
+  env: { sender?: RtpCapabilitiesSource; receiver?: RtpCapabilitiesSource } = {
+    sender: typeof RTCRtpSender === "undefined" ? undefined : RTCRtpSender,
+    receiver: typeof RTCRtpReceiver === "undefined" ? undefined : RTCRtpReceiver,
+  },
+): VideoCodecSupportEnv {
+  return {
+    encode: capabilityMimeTypes(env.sender),
+    decode: capabilityMimeTypes(env.receiver),
   };
 }

--- a/chat/src/lib/calls/video-codec/support.ts
+++ b/chat/src/lib/calls/video-codec/support.ts
@@ -11,8 +11,7 @@
  * therefore reports VP9 unavailable and falls back to the VP8 backup.
  */
 
-export const PROBED_VIDEO_CODECS = ["vp9", "vp8"] as const;
-export type ProbedVideoCodec = (typeof PROBED_VIDEO_CODECS)[number];
+type ProbedVideoCodec = "vp9" | "vp8";
 
 export type VideoCodecSupportEnv = {
   /** Lowercased mimeTypes from `RTCRtpSender.getCapabilities('video')`. */
@@ -54,7 +53,7 @@ export function videoCodecSupport(env: VideoCodecSupportEnv): VideoCodecSupport 
  * `RTCRtpReceiver`. Narrowed to what the probe reads and made injectable so
  * the edge reader is testable without real WebRTC globals.
  */
-export type RtpCapabilitiesSource = {
+type RtpCapabilitiesSource = {
   getCapabilities?: (kind: "video") => { codecs?: { mimeType?: string }[] } | null;
 };
 

--- a/chat/src/lib/calls/video-codec/support.ts
+++ b/chat/src/lib/calls/video-codec/support.ts
@@ -1,0 +1,40 @@
+/**
+ * Capability probe: which video codecs this device can actually publish.
+ *
+ * Mirrors the AI-noise-filter support probe: pure over an injected env so it
+ * is unit-tested without touching globals, with a thin reader that reads the
+ * real `RTCRtpSender` / `RTCRtpReceiver` capabilities at the edge.
+ *
+ * A codec is "available" only when the device can BOTH encode it (to publish)
+ * and decode it (to subscribe to peers using it) — the bidirectional reading
+ * of the WebRTC sender/receiver capabilities. iOS, which has no VP9 encoder,
+ * therefore reports VP9 unavailable and falls back to the VP8 backup.
+ */
+
+export const PROBED_VIDEO_CODECS = ["vp9", "vp8"] as const;
+export type ProbedVideoCodec = (typeof PROBED_VIDEO_CODECS)[number];
+
+export type VideoCodecSupportEnv = {
+  /** Lowercased mimeTypes from `RTCRtpSender.getCapabilities('video')`. */
+  encode: readonly string[];
+  /** Lowercased mimeTypes from `RTCRtpReceiver.getCapabilities('video')`. */
+  decode: readonly string[];
+};
+
+type VideoCodecAvailability = { available: true } | { available: false; reason: string };
+
+export type VideoCodecSupport = Record<ProbedVideoCodec, VideoCodecAvailability>;
+
+function availability(codec: ProbedVideoCodec, env: VideoCodecSupportEnv): VideoCodecAvailability {
+  const mime = `video/${codec}`;
+  const canEncode = env.encode.includes(mime);
+  return canEncode ? { available: true } : { available: false, reason: `This browser can't encode ${codec.toUpperCase()}.` };
+}
+
+/** Per-codec availability for the current environment. */
+export function videoCodecSupport(env: VideoCodecSupportEnv): VideoCodecSupport {
+  return {
+    vp9: availability("vp9", env),
+    vp8: availability("vp8", env),
+  };
+}

--- a/chat/src/lib/calls/video-codec/video-publish.ts
+++ b/chat/src/lib/calls/video-codec/video-publish.ts
@@ -1,0 +1,95 @@
+/**
+ * Pure publish-option builder for video tracks. Given the track source and the
+ * device's codec capability, it returns the typed LiveKit capture + publish
+ * option objects the engine forwards verbatim — the engine stays a thin
+ * applier. Source-aware so the camera slice reuses the same rails.
+ */
+
+import type {
+  ScalabilityMode,
+  ScreenShareCaptureOptions,
+  TrackPublishOptions,
+  VideoEncoding,
+} from "livekit-client";
+import type { VideoCodecSupport } from "./support";
+
+export type VideoPublishSource = "camera" | "screen";
+
+/**
+ * SVC mode for the VP9 screen-share. `L3T3_KEY` is LiveKit's SVC default and
+ * the right fit for screen content: three spatial layers let small-tile
+ * subscribers pull a lower resolution, and the key-picture prediction makes
+ * the upper layers decode from key frames — so they survive lower-layer loss,
+ * which matters for crisp text.
+ */
+const SCREEN_SHARE_SVC_MODE: ScalabilityMode = "L3T3_KEY";
+
+/**
+ * Raised focal-stream ceiling for the shared screen. ~5 Mbps on the top SVC
+ * layer keeps dense code/text crisp (vs. the old 1080p15 preset's 2.5 Mbps);
+ * 30 fps covers smooth scrolling without paying for motion the content
+ * rarely has.
+ */
+const SCREEN_SHARE_ENCODING: VideoEncoding = {
+  maxBitrate: 5_000_000,
+  maxFramerate: 30,
+};
+
+/**
+ * Capture ceiling for the shared screen: ~1440p. A `max` constraint caps a
+ * larger display without upscaling a smaller source (not force-downscaled).
+ * `contentHint: "detail"` tells the encoder to favour sharpness over motion
+ * smoothness — the right call for text and code.
+ */
+const SCREEN_SHARE_CAPTURE: ScreenShareCaptureOptions = {
+  resolution: { width: 2560, height: 1440, frameRate: 30 },
+  contentHint: "detail",
+};
+
+export type VideoPublishPlan = {
+  /** Capture-side options (resolution cap, contentHint). `null` when the
+   *  source uses the room's capture defaults (camera). */
+  capture: ScreenShareCaptureOptions | null;
+  /** Publish-side options forwarded to `setScreenShareEnabled` /
+   *  `setCameraEnabled`. */
+  publish: TrackPublishOptions;
+};
+
+function screenSharePlan(capability: VideoCodecSupport): VideoPublishPlan {
+  // Capable devices get VP9 + SVC + an explicit VP8 backup; incapable devices
+  // fall back to VP8 — but at the SAME raised bitrate and resolution, so the
+  // fallback is first-class, not merely working.
+  const codec: TrackPublishOptions = capability.vp9.available
+    ? {
+        videoCodec: "vp9",
+        scalabilityMode: SCREEN_SHARE_SVC_MODE,
+        backupCodec: { codec: "vp8" },
+      }
+    : { videoCodec: "vp8" };
+  return {
+    capture: SCREEN_SHARE_CAPTURE,
+    publish: {
+      ...codec,
+      screenShareEncoding: SCREEN_SHARE_ENCODING,
+      degradationPreference: "maintain-resolution",
+    },
+  };
+}
+
+/**
+ * Camera publish plan. This slice only builds the codec rails; the camera
+ * VP9 treatment is a later slice, so today it preserves the existing
+ * behavior — a talking head keeps motion smooth and sheds resolution
+ * (`maintain-framerate`) — and lets the room's `videoCaptureDefaults` govern
+ * capture (`capture: null`).
+ */
+function cameraPlan(): VideoPublishPlan {
+  return { capture: null, publish: { degradationPreference: "maintain-framerate" } };
+}
+
+export function videoPublishPlan(args: {
+  source: VideoPublishSource;
+  capability: VideoCodecSupport;
+}): VideoPublishPlan {
+  return args.source === "screen" ? screenSharePlan(args.capability) : cameraPlan();
+}

--- a/chat/src/lib/calls/video-codec/video-publish.ts
+++ b/chat/src/lib/calls/video-codec/video-publish.ts
@@ -11,8 +11,10 @@ import type {
   ScreenShareCaptureOptions,
   TrackPublishOptions,
   VideoEncoding,
+  VideoResolution,
 } from "livekit-client";
 import type { VideoCodecSupport } from "./support";
+import type { ScreenCaptureEnv } from "./screen-capture-env";
 
 type VideoPublishSource = "camera" | "screen";
 
@@ -43,18 +45,9 @@ const SCREEN_SHARE_ENCODING: VideoEncoding = {
  * Capture ceiling for the shared screen: ~1440p (2560×1440, the 16:9 QHD
  * frame). LiveKit maps `resolution` to an `ideal`/`max` capture constraint,
  * so it caps a larger display without upscaling a smaller source (not
- * force-downscaled). `contentHint: "detail"` favours sharpness over motion
- * smoothness — the right call for text and code. Note this hint only takes
- * effect on the VP8 fallback path: for the VP9 SVC path LiveKit force-sets
- * the track's contentHint to `"motion"` (a Chrome screenshare-SVC
- * workaround), so VP9 screen-share rides the camera-style encode path. We
- * still request `"detail"` because it is honoured for the VP8 fallback and
- * harmless for VP9.
+ * force-downscaled).
  */
-const SCREEN_SHARE_CAPTURE: ScreenShareCaptureOptions = {
-  resolution: { width: 2560, height: 1440, frameRate: 30 },
-  contentHint: "detail",
-};
+const SCREEN_SHARE_RESOLUTION: VideoResolution = { width: 2560, height: 1440, frameRate: 30 };
 
 type VideoPublishPlan = {
   /** Capture-side options (resolution cap, contentHint). `null` when the
@@ -65,29 +58,52 @@ type VideoPublishPlan = {
   publish: TrackPublishOptions;
 };
 
-function screenSharePlan(capability: VideoCodecSupport): VideoPublishPlan {
-  // Capable devices get VP9 + SVC + an explicit VP8 backup; incapable devices
-  // fall back to VP8 — but at the SAME raised bitrate and resolution, so the
-  // fallback is first-class, not merely working.
-  const codec: TrackPublishOptions = capability.vp9.available
-    ? {
-        videoCodec: "vp9",
-        scalabilityMode: SCREEN_SHARE_SVC_MODE,
-        // Send VP9 and the VP8 backup at the same time (multi-codec simulcast)
-        // rather than the default regression policy. Under regression a single
-        // VP8-only (iOS) subscriber forces the whole room down to VP8; with
-        // simulcast, capable subscribers keep VP9 — "everybody good, capable
-        // devices better" — at the cost of a second encode on the (already
-        // capability-gated) publisher.
-        backupCodec: { codec: "vp8" },
-        backupCodecPolicy: BackupCodecPolicy.SIMULCAST,
-      }
-    : { videoCodec: "vp8" };
+/**
+ * Per-codec publish options for the screen share, gated on what the device can
+ * actually do (never force a codec the probe reports unavailable):
+ *  - VP9-capable → VP9 + SVC, plus an explicit VP8 backup published *alongside*
+ *    via multi-codec simulcast (`SIMULCAST`) rather than the default regression
+ *    policy. Under regression a single VP8-only (iOS) subscriber forces the
+ *    whole room down to VP8; with simulcast capable subscribers keep VP9 —
+ *    "everybody good, capable devices better" — at the cost of a second encode
+ *    on the (already capability-gated) publisher. The explicit `backupCodec` is
+ *    load-bearing: simulcast only emits the second codec when it is set.
+ *  - VP8-only → VP8 at the same raised ceiling (first-class fallback).
+ *  - neither reported available (e.g. no `getCapabilities`) → leave `videoCodec`
+ *    unset so LiveKit picks its own working default rather than us forcing one.
+ */
+function screenShareCodec(capability: VideoCodecSupport): TrackPublishOptions {
+  if (capability.vp9.available) {
+    return {
+      videoCodec: "vp9",
+      scalabilityMode: SCREEN_SHARE_SVC_MODE,
+      ...(capability.vp8.available
+        ? { backupCodec: { codec: "vp8" }, backupCodecPolicy: BackupCodecPolicy.SIMULCAST }
+        : {}),
+    };
+  }
+  if (capability.vp8.available) return { videoCodec: "vp8" };
+  return {};
+}
+
+function screenSharePlan(
+  capability: VideoCodecSupport,
+  screen: ScreenCaptureEnv,
+): VideoPublishPlan {
+  // `contentHint: "detail"` favours sharpness over motion smoothness — the
+  // right call for text/code. It is honoured on the VP8 path; for VP9 SVC
+  // LiveKit force-sets the track's hint to "motion" (a Chrome screenshare-SVC
+  // workaround), so it is harmless there. The resolution cap is omitted when
+  // the browser can't be constrained (Safari 17, see ScreenCaptureEnv).
+  const capture: ScreenShareCaptureOptions = {
+    contentHint: "detail",
+    ...(screen.canConstrainResolution ? { resolution: { ...SCREEN_SHARE_RESOLUTION } } : {}),
+  };
   return {
-    capture: SCREEN_SHARE_CAPTURE,
+    capture,
     publish: {
-      ...codec,
-      screenShareEncoding: SCREEN_SHARE_ENCODING,
+      ...screenShareCodec(capability),
+      screenShareEncoding: { ...SCREEN_SHARE_ENCODING },
       degradationPreference: "maintain-resolution",
     },
   };
@@ -107,6 +123,10 @@ function cameraPlan(): VideoPublishPlan {
 export function videoPublishPlan(args: {
   source: VideoPublishSource;
   capability: VideoCodecSupport;
+  /** Screen-capture environment; defaults to "can constrain" (the common,
+   *  non-Safari-17 case). Ignored for the camera source. */
+  screenCapture?: ScreenCaptureEnv;
 }): VideoPublishPlan {
-  return args.source === "screen" ? screenSharePlan(args.capability) : cameraPlan();
+  if (args.source !== "screen") return cameraPlan();
+  return screenSharePlan(args.capability, args.screenCapture ?? { canConstrainResolution: true });
 }

--- a/chat/src/lib/calls/video-codec/video-publish.ts
+++ b/chat/src/lib/calls/video-codec/video-publish.ts
@@ -5,6 +5,7 @@
  * applier. Source-aware so the camera slice reuses the same rails.
  */
 
+import { BackupCodecPolicy } from "livekit-client";
 import type {
   ScalabilityMode,
   ScreenShareCaptureOptions,
@@ -16,13 +17,16 @@ import type { VideoCodecSupport } from "./support";
 type VideoPublishSource = "camera" | "screen";
 
 /**
- * SVC mode for the VP9 screen-share. `L3T3_KEY` is LiveKit's SVC default and
- * the right fit for screen content: three spatial layers let small-tile
- * subscribers pull a lower resolution, and the key-picture prediction makes
- * the upper layers decode from key frames — so they survive lower-layer loss,
- * which matters for crisp text.
+ * SVC mode for the VP9 screen-share: `L1T3` — one spatial layer, three
+ * temporal layers (temporal-only scalability). We state it explicitly to
+ * document the negotiated shape, but note LiveKit *enforces* `L1T3` for any
+ * VP9 SVC screen-share track regardless of what we request: Chrome can't
+ * encode multiple spatial layers for screen content (it collapses the
+ * publish resolution), so spatial SVC (`L3T3*`) is off the table here.
+ * Temporal SVC still buys per-subscriber framerate adaptation and VP9's
+ * efficiency over VP8.
  */
-const SCREEN_SHARE_SVC_MODE: ScalabilityMode = "L3T3_KEY";
+const SCREEN_SHARE_SVC_MODE: ScalabilityMode = "L1T3";
 
 /**
  * Raised focal-stream ceiling for the shared screen. ~5 Mbps on the top SVC
@@ -36,10 +40,16 @@ const SCREEN_SHARE_ENCODING: VideoEncoding = {
 };
 
 /**
- * Capture ceiling for the shared screen: ~1440p. A `max` constraint caps a
- * larger display without upscaling a smaller source (not force-downscaled).
- * `contentHint: "detail"` tells the encoder to favour sharpness over motion
- * smoothness — the right call for text and code.
+ * Capture ceiling for the shared screen: ~1440p (2560×1440, the 16:9 QHD
+ * frame). LiveKit maps `resolution` to an `ideal`/`max` capture constraint,
+ * so it caps a larger display without upscaling a smaller source (not
+ * force-downscaled). `contentHint: "detail"` favours sharpness over motion
+ * smoothness — the right call for text and code. Note this hint only takes
+ * effect on the VP8 fallback path: for the VP9 SVC path LiveKit force-sets
+ * the track's contentHint to `"motion"` (a Chrome screenshare-SVC
+ * workaround), so VP9 screen-share rides the camera-style encode path. We
+ * still request `"detail"` because it is honoured for the VP8 fallback and
+ * harmless for VP9.
  */
 const SCREEN_SHARE_CAPTURE: ScreenShareCaptureOptions = {
   resolution: { width: 2560, height: 1440, frameRate: 30 },
@@ -63,7 +73,14 @@ function screenSharePlan(capability: VideoCodecSupport): VideoPublishPlan {
     ? {
         videoCodec: "vp9",
         scalabilityMode: SCREEN_SHARE_SVC_MODE,
+        // Send VP9 and the VP8 backup at the same time (multi-codec simulcast)
+        // rather than the default regression policy. Under regression a single
+        // VP8-only (iOS) subscriber forces the whole room down to VP8; with
+        // simulcast, capable subscribers keep VP9 — "everybody good, capable
+        // devices better" — at the cost of a second encode on the (already
+        // capability-gated) publisher.
         backupCodec: { codec: "vp8" },
+        backupCodecPolicy: BackupCodecPolicy.SIMULCAST,
       }
     : { videoCodec: "vp8" };
   return {

--- a/chat/src/lib/calls/video-codec/video-publish.ts
+++ b/chat/src/lib/calls/video-codec/video-publish.ts
@@ -13,7 +13,7 @@ import type {
 } from "livekit-client";
 import type { VideoCodecSupport } from "./support";
 
-export type VideoPublishSource = "camera" | "screen";
+type VideoPublishSource = "camera" | "screen";
 
 /**
  * SVC mode for the VP9 screen-share. `L3T3_KEY` is LiveKit's SVC default and
@@ -46,7 +46,7 @@ const SCREEN_SHARE_CAPTURE: ScreenShareCaptureOptions = {
   contentHint: "detail",
 };
 
-export type VideoPublishPlan = {
+type VideoPublishPlan = {
   /** Capture-side options (resolution cap, contentHint). `null` when the
    *  source uses the room's capture defaults (camera). */
   capture: ScreenShareCaptureOptions | null;

--- a/chat/tests/call-engine.test.ts
+++ b/chat/tests/call-engine.test.ts
@@ -13,6 +13,7 @@ import {
   type RemoteMediaTrack,
 } from "../src/lib/calls/engine";
 import { ConnectionQuality, ConnectionState, Track } from "livekit-client";
+import { videoCodecSupport } from "../src/lib/calls/video-codec/support";
 import type { MicAudioProcessing } from "../src/lib/calls/mic-audio-processing";
 import type { AudioProcessingPrefs } from "../src/lib/calls/device-prefs";
 
@@ -684,10 +685,14 @@ describe("call-engine module", () => {
 });
 
 describe("enableRequestedCapture — best-effort, never ejects", () => {
+  // Camera publish options are irrelevant to the best-effort guarantees here;
+  // any typed value satisfies the (now required) parameter.
+  const cameraOpts = { degradationPreference: "maintain-framerate" as const };
+
   test("enables both tracks when capture succeeds", async () => {
     const stub = captureStub();
     const errors: string[] = [];
-    await enableRequestedCapture(stub, { audio: true, video: true }, (s) => errors.push(s));
+    await enableRequestedCapture(stub, { audio: true, video: true }, (s) => errors.push(s), cameraOpts);
     expect(stub.calls).toEqual(["mic:true", "cam:true"]);
     expect(errors).toEqual([]);
   });
@@ -699,7 +704,7 @@ describe("enableRequestedCapture — best-effort, never ejects", () => {
     const seen: Array<{ source: string; name: string }> = [];
     await enableRequestedCapture(stub, { audio: true, video: true }, (source, error) => {
       seen.push({ source, name: (error as Error).name });
-    });
+    }, cameraOpts);
     expect(stub.calls).toEqual(["mic:true", "cam:true"]); // camera still attempted
     expect(seen).toEqual([{ source: "audio", name: "NotAllowedError" }]);
   });
@@ -707,7 +712,7 @@ describe("enableRequestedCapture — best-effort, never ejects", () => {
   test("a missing camera reports only video and leaves the mic untouched", async () => {
     const stub = captureStub({ camThrows: deviceError("NotFoundError") });
     const seen: string[] = [];
-    await enableRequestedCapture(stub, { audio: true, video: true }, (source) => seen.push(source));
+    await enableRequestedCapture(stub, { audio: true, video: true }, (source) => seen.push(source), cameraOpts);
     expect(seen).toEqual(["video"]);
   });
 
@@ -719,7 +724,7 @@ describe("enableRequestedCapture — best-effort, never ejects", () => {
     });
     const seen: string[] = [];
     await expect(
-      enableRequestedCapture(stub, { audio: true, video: true }, (source) => seen.push(source)),
+      enableRequestedCapture(stub, { audio: true, video: true }, (source) => seen.push(source), cameraOpts),
     ).resolves.toBeUndefined();
     expect(seen).toEqual(["audio", "video"]);
   });
@@ -727,7 +732,7 @@ describe("enableRequestedCapture — best-effort, never ejects", () => {
   test("audio-only call never touches the camera", async () => {
     const stub = captureStub({ camThrows: deviceError("NotFoundError") });
     const seen: string[] = [];
-    await enableRequestedCapture(stub, { audio: true, video: false }, (source) => seen.push(source));
+    await enableRequestedCapture(stub, { audio: true, video: false }, (source) => seen.push(source), cameraOpts);
     expect(stub.calls).toEqual(["mic:true"]);
     expect(seen).toEqual([]);
   });
@@ -1087,27 +1092,22 @@ describe("call-engine — verifies applied mic audio processing", () => {
   });
 });
 
-describe("call-engine — 1080p capture ceiling + per-source degradation", () => {
+describe("call-engine — camera capture ceiling + per-source degradation", () => {
   function videoRoomStub() {
     const camera: Array<{ enabled: boolean; options: unknown; publishOptions: unknown }> = [];
-    const screen: Array<{ enabled: boolean; options: unknown; publishOptions: unknown }> = [];
     return {
       camera,
-      screen,
       room: {
         localParticipant: {
           async setCameraEnabled(enabled: boolean, options?: unknown, publishOptions?: unknown) {
             camera.push({ enabled, options, publishOptions });
-          },
-          async setScreenShareEnabled(enabled: boolean, options?: unknown, publishOptions?: unknown) {
-            screen.push({ enabled, options, publishOptions });
           },
         },
       },
     };
   }
 
-  test("setCameraEnabled publishes the camera with maintain-framerate degradation", async () => {
+  test("setCameraEnabled publishes the camera with maintain-framerate degradation and no codec override", async () => {
     const { CallEngine } = await import("../src/lib/calls/engine");
     const engine = new CallEngine();
     const stub = videoRoomStub();
@@ -1122,22 +1122,7 @@ describe("call-engine — 1080p capture ceiling + per-source degradation", () =>
     ]);
   });
 
-  test("setScreenShareEnabled publishes the share with maintain-resolution degradation", async () => {
-    const { CallEngine } = await import("../src/lib/calls/engine");
-    const engine = new CallEngine();
-    const stub = videoRoomStub();
-    (engine as unknown as { room: unknown }).room = stub.room;
-    await engine.setScreenShareEnabled(true, { audio: false });
-    expect(stub.screen).toEqual([
-      {
-        enabled: true,
-        options: { audio: false },
-        publishOptions: { degradationPreference: "maintain-resolution" },
-      },
-    ]);
-  });
-
-  test("enableRequestedCapture publishes the camera with maintain-framerate degradation", async () => {
+  test("enableRequestedCapture forwards the camera publish options it is given", async () => {
     const camera: Array<{ enabled: boolean; publishOptions: unknown }> = [];
     const stub = {
       async setMicrophoneEnabled() {},
@@ -1145,10 +1130,69 @@ describe("call-engine — 1080p capture ceiling + per-source degradation", () =>
         camera.push({ enabled, publishOptions });
       },
     };
-    await enableRequestedCapture(stub, { audio: false, video: true }, () => {});
-    expect(camera).toEqual([
-      { enabled: true, publishOptions: { degradationPreference: "maintain-framerate" } },
-    ]);
+    const cameraPublishOptions = { degradationPreference: "maintain-framerate" as const };
+    await enableRequestedCapture(stub, { audio: false, video: true }, () => {}, cameraPublishOptions);
+    expect(camera).toEqual([{ enabled: true, publishOptions: cameraPublishOptions }]);
+  });
+});
+
+describe("call-engine — forwards the codec publish plan to the SDK", () => {
+  function videoRoomStub() {
+    const screen: Array<{ enabled: boolean; options: unknown; publishOptions: unknown }> = [];
+    return {
+      screen,
+      room: {
+        localParticipant: {
+          async setScreenShareEnabled(enabled: boolean, options?: unknown, publishOptions?: unknown) {
+            screen.push({ enabled, options, publishOptions });
+          },
+        },
+      },
+    };
+  }
+  const support = (encode: string[], decode: string[]) => videoCodecSupport({ encode, decode });
+  const capable = support(["video/vp8", "video/vp9"], ["video/vp8", "video/vp9"]);
+  const incapable = support(["video/vp8"], ["video/vp8"]);
+
+  test("a VP9-capable device forwards VP9 + SVC + VP8 backup and a 1440p/detail capture", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine({ videoCodecSupport: capable });
+    const stub = videoRoomStub();
+    (engine as unknown as { room: unknown }).room = stub.room;
+
+    await engine.setScreenShareEnabled(true, { audio: false });
+
+    expect(stub.screen).toHaveLength(1);
+    expect(stub.screen[0]?.publishOptions).toMatchObject({
+      videoCodec: "vp9",
+      scalabilityMode: "L3T3_KEY",
+      backupCodec: { codec: "vp8" },
+      screenShareEncoding: { maxBitrate: 5_000_000 },
+      degradationPreference: "maintain-resolution",
+    });
+    expect(stub.screen[0]?.options).toMatchObject({
+      audio: false,
+      contentHint: "detail",
+      resolution: { height: 1440 },
+    });
+  });
+
+  test("an incapable device forwards VP8 with no SVC/backup at the same raised ceiling", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine({ videoCodecSupport: incapable });
+    const stub = videoRoomStub();
+    (engine as unknown as { room: unknown }).room = stub.room;
+
+    await engine.setScreenShareEnabled(true, { audio: false });
+
+    const publishOptions = stub.screen[0]?.publishOptions as Record<string, unknown>;
+    expect(publishOptions).toMatchObject({
+      videoCodec: "vp8",
+      screenShareEncoding: { maxBitrate: 5_000_000 },
+      degradationPreference: "maintain-resolution",
+    });
+    expect(publishOptions.scalabilityMode).toBeUndefined();
+    expect(publishOptions.backupCodec).toBeUndefined();
   });
 });
 

--- a/chat/tests/call-engine.test.ts
+++ b/chat/tests/call-engine.test.ts
@@ -1137,14 +1137,19 @@ describe("call-engine — camera capture ceiling + per-source degradation", () =
 });
 
 describe("call-engine — forwards the codec publish plan to the SDK", () => {
-  function videoRoomStub() {
-    const screen: Array<{ enabled: boolean; options: unknown; publishOptions: unknown }> = [];
+  function videoRoomStub(opts: { audioThrows?: Error } = {}) {
+    const screen: Array<{ enabled: boolean; options: { audio?: boolean }; publishOptions: unknown }> = [];
     return {
       screen,
       room: {
         localParticipant: {
-          async setScreenShareEnabled(enabled: boolean, options?: unknown, publishOptions?: unknown) {
-            screen.push({ enabled, options, publishOptions });
+          async setScreenShareEnabled(
+            enabled: boolean,
+            options?: { audio?: boolean },
+            publishOptions?: unknown,
+          ) {
+            screen.push({ enabled, options: options ?? {}, publishOptions });
+            if (enabled && options?.audio && opts.audioThrows) throw opts.audioThrows;
           },
         },
       },
@@ -1165,7 +1170,7 @@ describe("call-engine — forwards the codec publish plan to the SDK", () => {
     expect(stub.screen).toHaveLength(1);
     expect(stub.screen[0]?.publishOptions).toMatchObject({
       videoCodec: "vp9",
-      scalabilityMode: "L3T3_KEY",
+      scalabilityMode: "L1T3",
       backupCodec: { codec: "vp8" },
       screenShareEncoding: { maxBitrate: 5_000_000 },
       degradationPreference: "maintain-resolution",
@@ -1193,6 +1198,28 @@ describe("call-engine — forwards the codec publish plan to the SDK", () => {
     });
     expect(publishOptions.scalabilityMode).toBeUndefined();
     expect(publishOptions.backupCodec).toBeUndefined();
+  });
+
+  test("the screen-audio-unsupported fallback retry still forwards the full codec plan", async () => {
+    // Regression guard: when screen-share audio is unsupported the engine
+    // retries video-only. That retry MUST carry the same VP9 publish plan and
+    // 1440p/detail capture — otherwise the fallback would silently run at
+    // LiveKit's defaults (VP8, 1080p, no SVC).
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine({ videoCodecSupport: capable });
+    const stub = videoRoomStub({ audioThrows: deviceError("NotSupportedError") });
+    (engine as unknown as { room: unknown }).room = stub.room;
+
+    await engine.setScreenShareEnabled(true, { audio: true });
+
+    expect(stub.screen).toHaveLength(2);
+    expect(stub.screen[1]?.options).toMatchObject({ audio: false, contentHint: "detail" });
+    expect(stub.screen[1]?.publishOptions).toMatchObject({
+      videoCodec: "vp9",
+      scalabilityMode: "L1T3",
+      screenShareEncoding: { maxBitrate: 5_000_000 },
+      degradationPreference: "maintain-resolution",
+    });
   });
 });
 

--- a/chat/tests/call-screen-capture-env.test.ts
+++ b/chat/tests/call-screen-capture-env.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import {
+  currentScreenCaptureEnv,
+  hasSafari17CaptureBug,
+} from "../src/lib/calls/video-codec/screen-capture-env";
+
+// Representative user-agent strings.
+const MACOS_SAFARI_17 =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15";
+const MACOS_SAFARI_18 =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.1 Safari/605.1.15";
+const MACOS_CHROME =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
+const CHROME_IOS =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/124.0 Mobile/15E148 Safari/604.1";
+
+describe("hasSafari17CaptureBug — the WebKit getDisplayMedia resolution bug", () => {
+  test("macOS Safari 17.x is affected", () => {
+    expect(hasSafari17CaptureBug(MACOS_SAFARI_17)).toBe(true);
+  });
+
+  test("macOS Safari 18 is not affected (bug is 17.x-specific)", () => {
+    expect(hasSafari17CaptureBug(MACOS_SAFARI_18)).toBe(false);
+  });
+
+  test("Chromium-based browsers are never affected, even on Apple hardware", () => {
+    expect(hasSafari17CaptureBug(MACOS_CHROME)).toBe(false);
+    expect(hasSafari17CaptureBug(CHROME_IOS)).toBe(false);
+  });
+});
+
+describe("currentScreenCaptureEnv — read the real environment", () => {
+  test("a Safari-17 user-agent cannot be given an explicit capture resolution", () => {
+    expect(currentScreenCaptureEnv(MACOS_SAFARI_17).canConstrainResolution).toBe(false);
+  });
+
+  test("everywhere else, an explicit resolution is safe", () => {
+    expect(currentScreenCaptureEnv(MACOS_CHROME).canConstrainResolution).toBe(true);
+  });
+});

--- a/chat/tests/call-video-codec-support.test.ts
+++ b/chat/tests/call-video-codec-support.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import {
+  videoCodecSupport,
+  type VideoCodecSupportEnv,
+} from "../src/lib/calls/video-codec/support";
+
+const env = (over: Partial<VideoCodecSupportEnv> = {}): VideoCodecSupportEnv => ({
+  encode: ["video/vp8", "video/vp9"],
+  decode: ["video/vp8", "video/vp9"],
+  ...over,
+});
+
+describe("videoCodecSupport — which codecs this device can publish", () => {
+  test("VP9 is available when the device can both encode and decode it", () => {
+    const support = videoCodecSupport(env());
+    expect(support.vp9.available).toBe(true);
+  });
+});

--- a/chat/tests/call-video-codec-support.test.ts
+++ b/chat/tests/call-video-codec-support.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import {
+  currentVideoCodecSupportEnv,
   videoCodecSupport,
   type VideoCodecSupportEnv,
 } from "../src/lib/calls/video-codec/support";
+
+const capabilitiesOf = (mimeTypes: string[]) => ({
+  getCapabilities: () => ({ codecs: mimeTypes.map((mimeType) => ({ mimeType })) }),
+});
 
 const env = (over: Partial<VideoCodecSupportEnv> = {}): VideoCodecSupportEnv => ({
   encode: ["video/vp8", "video/vp9"],
@@ -14,5 +19,40 @@ describe("videoCodecSupport — which codecs this device can publish", () => {
   test("VP9 is available when the device can both encode and decode it", () => {
     const support = videoCodecSupport(env());
     expect(support.vp9.available).toBe(true);
+  });
+
+  test("VP9 is unavailable, with a reason, when the device can't encode it (iOS)", () => {
+    const support = videoCodecSupport(env({ encode: ["video/vp8"] }));
+    expect(support.vp9.available).toBe(false);
+    if (!support.vp9.available) expect(support.vp9.reason).toMatch(/encode.*vp9/i);
+  });
+
+  test("VP9 is unavailable when the device can encode but not decode it (no peer playback)", () => {
+    const support = videoCodecSupport(env({ decode: ["video/vp8"] }));
+    expect(support.vp9.available).toBe(false);
+    if (!support.vp9.available) expect(support.vp9.reason).toMatch(/decode.*vp9/i);
+  });
+
+  test("codec mimeType matching is case-insensitive (browsers report 'video/VP9')", () => {
+    const support = videoCodecSupport(env({ encode: ["video/VP8", "video/VP9"], decode: ["video/VP8", "video/VP9"] }));
+    expect(support.vp9.available).toBe(true);
+    expect(support.vp8.available).toBe(true);
+  });
+});
+
+describe("currentVideoCodecSupportEnv — read real sender/receiver capabilities", () => {
+  test("maps injected sender/receiver capabilities into encode/decode mimeTypes", () => {
+    const env = currentVideoCodecSupportEnv({
+      sender: capabilitiesOf(["video/VP8", "video/VP9"]),
+      receiver: capabilitiesOf(["video/VP8"]),
+    });
+    expect(env.encode).toEqual(["video/VP8", "video/VP9"]);
+    expect(env.decode).toEqual(["video/VP8"]);
+  });
+
+  test("a platform without getCapabilities reports no codecs (everything unavailable)", () => {
+    const env = currentVideoCodecSupportEnv({ sender: {}, receiver: {} });
+    expect(videoCodecSupport(env).vp9.available).toBe(false);
+    expect(videoCodecSupport(env).vp8.available).toBe(false);
   });
 });

--- a/chat/tests/call-video-codec-support.test.ts
+++ b/chat/tests/call-video-codec-support.test.ts
@@ -33,6 +33,12 @@ describe("videoCodecSupport — which codecs this device can publish", () => {
     if (!support.vp9.available) expect(support.vp9.reason).toMatch(/decode.*vp9/i);
   });
 
+  test("the baseline VP8 also reports unavailable-with-reason on a device that lacks it", () => {
+    const support = videoCodecSupport(env({ encode: [], decode: [] }));
+    expect(support.vp8.available).toBe(false);
+    if (!support.vp8.available) expect(support.vp8.reason).toMatch(/encode.*vp8/i);
+  });
+
   test("codec mimeType matching is case-insensitive (browsers report 'video/VP9')", () => {
     const support = videoCodecSupport(env({ encode: ["video/VP8", "video/VP9"], decode: ["video/VP8", "video/VP9"] }));
     expect(support.vp9.available).toBe(true);

--- a/chat/tests/call-video-publish.test.ts
+++ b/chat/tests/call-video-publish.test.ts
@@ -8,6 +8,8 @@ const capable = videoCodecSupport({
   decode: ["video/vp8", "video/vp9"],
 });
 const incapable = videoCodecSupport({ encode: ["video/vp8"], decode: ["video/vp8"] });
+const noCodecs = videoCodecSupport({ encode: [], decode: [] });
+const vp9OnlyEncode = videoCodecSupport({ encode: ["video/vp9"], decode: ["video/vp9"] });
 
 describe("videoPublishPlan — screen-share on a VP9-capable device", () => {
   test("publishes VP9", () => {
@@ -63,6 +65,55 @@ describe("videoPublishPlan — screen-share on a VP9-incapable device (iOS)", ()
     expect(fallback.publish.screenShareEncoding).toEqual(best.publish.screenShareEncoding);
     expect(fallback.publish.degradationPreference).toBe("maintain-resolution");
     expect(fallback.capture).toEqual(best.capture);
+  });
+});
+
+describe("videoPublishPlan — codec gating matches the probe (no codec the device can't do)", () => {
+  test("when neither VP9 nor VP8 is reported available, leave videoCodec unset for LiveKit to pick", () => {
+    // e.g. a platform without getCapabilities: forcing a specific codec could
+    // override LiveKit's own (working) default with one the browser can't do.
+    const plan = videoPublishPlan({ source: "screen", capability: noCodecs });
+    expect(plan.publish.videoCodec).toBeUndefined();
+    expect(plan.publish.backupCodec).toBeUndefined();
+    expect(plan.publish.backupCodecPolicy).toBeUndefined();
+  });
+
+  test("VP9 without an available VP8 baseline publishes VP9 with no backup", () => {
+    const plan = videoPublishPlan({ source: "screen", capability: vp9OnlyEncode });
+    expect(plan.publish.videoCodec).toBe("vp9");
+    expect(plan.publish.backupCodec).toBeUndefined();
+    expect(plan.publish.backupCodecPolicy).toBeUndefined();
+  });
+});
+
+describe("videoPublishPlan — Safari-17 capture-resolution bug", () => {
+  test("omits the explicit resolution when the browser can't be constrained, keeping contentHint", () => {
+    const plan = videoPublishPlan({
+      source: "screen",
+      capability: capable,
+      screenCapture: { canConstrainResolution: false },
+    });
+    expect(plan.capture?.resolution).toBeUndefined();
+    expect(plan.capture?.contentHint).toBe("detail");
+  });
+
+  test("applies the 1440p cap when the browser can be constrained", () => {
+    const plan = videoPublishPlan({
+      source: "screen",
+      capability: capable,
+      screenCapture: { canConstrainResolution: true },
+    });
+    expect(plan.capture?.resolution?.height).toBe(1440);
+  });
+});
+
+describe("videoPublishPlan — pure: returns fresh objects callers can't alias", () => {
+  test("two screen plans don't share mutable option objects", () => {
+    const a = videoPublishPlan({ source: "screen", capability: capable });
+    const b = videoPublishPlan({ source: "screen", capability: capable });
+    expect(a.publish).not.toBe(b.publish);
+    expect(a.capture).not.toBe(b.capture);
+    expect(a.publish.screenShareEncoding).not.toBe(b.publish.screenShareEncoding);
   });
 });
 

--- a/chat/tests/call-video-publish.test.ts
+++ b/chat/tests/call-video-publish.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { BackupCodecPolicy } from "livekit-client";
 import { videoCodecSupport } from "../src/lib/calls/video-codec/support";
 import { videoPublishPlan } from "../src/lib/calls/video-codec/video-publish";
 
@@ -18,6 +19,14 @@ describe("videoPublishPlan — screen-share on a VP9-capable device", () => {
     const plan = videoPublishPlan({ source: "screen", capability: capable });
     expect(plan.publish.scalabilityMode).toMatch(/^L\d+T\d+/);
     expect(plan.publish.backupCodec).toEqual({ codec: "vp8" });
+  });
+
+  test("keeps capable viewers on VP9 in a mixed room via multi-codec simulcast", () => {
+    // 'everybody good, capable devices better': the presenter sends VP9 AND
+    // the VP8 backup at once, so a VP8-only (iOS) viewer can't drag capable
+    // viewers down to VP8 the way the default regression policy would.
+    const plan = videoPublishPlan({ source: "screen", capability: capable });
+    expect(plan.publish.backupCodecPolicy).toBe(BackupCodecPolicy.SIMULCAST);
   });
 
   test("raises the focal-stream bitrate ceiling (~5 Mbps top layer) at a 24-30 fps target", () => {

--- a/chat/tests/call-video-publish.test.ts
+++ b/chat/tests/call-video-publish.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { videoCodecSupport } from "../src/lib/calls/video-codec/support";
+import { videoPublishPlan } from "../src/lib/calls/video-codec/video-publish";
+
+const capable = videoCodecSupport({
+  encode: ["video/vp8", "video/vp9"],
+  decode: ["video/vp8", "video/vp9"],
+});
+const incapable = videoCodecSupport({ encode: ["video/vp8"], decode: ["video/vp8"] });
+
+describe("videoPublishPlan — screen-share on a VP9-capable device", () => {
+  test("publishes VP9", () => {
+    const plan = videoPublishPlan({ source: "screen", capability: capable });
+    expect(plan.publish.videoCodec).toBe("vp9");
+  });
+
+  test("enables SVC and an explicit VP8 backup codec", () => {
+    const plan = videoPublishPlan({ source: "screen", capability: capable });
+    expect(plan.publish.scalabilityMode).toMatch(/^L\d+T\d+/);
+    expect(plan.publish.backupCodec).toEqual({ codec: "vp8" });
+  });
+
+  test("raises the focal-stream bitrate ceiling (~5 Mbps top layer) at a 24-30 fps target", () => {
+    const plan = videoPublishPlan({ source: "screen", capability: capable });
+    expect(plan.publish.screenShareEncoding?.maxBitrate).toBe(5_000_000);
+    const fps = plan.publish.screenShareEncoding?.maxFramerate ?? 0;
+    expect(fps).toBeGreaterThanOrEqual(24);
+    expect(fps).toBeLessThanOrEqual(30);
+  });
+
+  test("sheds frames before resolution under pressure (text stays readable)", () => {
+    const plan = videoPublishPlan({ source: "screen", capability: capable });
+    expect(plan.publish.degradationPreference).toBe("maintain-resolution");
+  });
+
+  test("captures at source resolution capped at ~1440p with contentHint detail", () => {
+    const plan = videoPublishPlan({ source: "screen", capability: capable });
+    expect(plan.capture?.contentHint).toBe("detail");
+    expect(plan.capture?.resolution?.height).toBe(1440);
+  });
+});
+
+describe("videoPublishPlan — screen-share on a VP9-incapable device (iOS)", () => {
+  test("falls back to VP8 with no SVC and no backup codec", () => {
+    const plan = videoPublishPlan({ source: "screen", capability: incapable });
+    expect(plan.publish.videoCodec).toBe("vp8");
+    expect(plan.publish.scalabilityMode).toBeUndefined();
+    expect(plan.publish.backupCodec).toBeUndefined();
+  });
+
+  test("keeps the fallback first-class: same raised bitrate, framerate and capture cap", () => {
+    const fallback = videoPublishPlan({ source: "screen", capability: incapable });
+    const best = videoPublishPlan({ source: "screen", capability: capable });
+    expect(fallback.publish.screenShareEncoding).toEqual(best.publish.screenShareEncoding);
+    expect(fallback.publish.degradationPreference).toBe("maintain-resolution");
+    expect(fallback.capture).toEqual(best.capture);
+  });
+});
+
+describe("videoPublishPlan — camera preserves current behavior (rails only this slice)", () => {
+  test("a talking head sheds resolution before framerate and gets no codec override", () => {
+    const plan = videoPublishPlan({ source: "camera", capability: capable });
+    expect(plan.publish.degradationPreference).toBe("maintain-framerate");
+    expect(plan.publish.videoCodec).toBeUndefined();
+    expect(plan.publish.scalabilityMode).toBeUndefined();
+  });
+
+  test("camera capture is governed by the room defaults, not this plan", () => {
+    const plan = videoPublishPlan({ source: "camera", capability: capable });
+    expect(plan.capture).toBeNull();
+  });
+});


### PR DESCRIPTION
## What & why

Implements #997 (parent #995): ship **VP9 + SVC on the screen-share track**
for devices that can encode/decode it, with an automatic **VP8 backup** so
incapable devices (notably iOS) still get a first-class stream. Parity
principle: *"everybody good, capable devices better."*

This slice builds the **codec rails** the camera slice reuses: a pure
capability probe + a source-aware publish-option builder, with the call engine
as a thin applier of the typed option objects.

Blocked by #996 (media-path telemetry) — merged in PR #1008 — so the negotiated
codec is already observable for acceptance verification.

## What shipped

1. **`videoCodecSupport(env)` probe** (`chat/src/lib/calls/video-codec/support.ts`)
   — pure, over an injected `RTCRtpSender`/`RTCRtpReceiver` capabilities env,
   mirroring the AI-noise-filter `noiseModelSupport` probe. A codec is available
   only when the device can **both encode and decode** it (case-insensitive
   mimeType match); the reason names the missing side. iOS (no VP9 encoder) →
   VP9 unavailable. Thin, injectable `currentVideoCodecSupportEnv()` reads the
   real globals at the edge.
2. **`videoPublishPlan({ source, capability })` builder**
   (`chat/src/lib/calls/video-codec/video-publish.ts`) — pure, source-aware so
   the camera slice reuses the rails:
   - **screen + capable** → VP9, `scalabilityMode: L1T3`, explicit VP8
     `backupCodec`, `backupCodecPolicy: SIMULCAST`, raised screen-share encoding
     (5 Mbps ceiling, 30 fps), 1440p capture cap, `contentHint: "detail"`,
     `degradationPreference: "maintain-resolution"`.
   - **screen + incapable** → VP8 at the same raised ceiling/resolution
     (first-class fallback).
   - **camera** → preserves current behavior (`maintain-framerate`, no codec
     override; capture governed by room defaults).
3. **Engine wiring** (`chat/src/lib/calls/engine.ts`) — `CallEngine` probes
   codec support once at construction (injectable for tests) and forwards the
   builder's capture + publish options into `setScreenShareEnabled` /
   `setCameraEnabled` / `enableRequestedCapture`. Removed the ad-hoc
   publish-option consts and the now-dead `screenShareEncoding` room default.

## LiveKit SDK reality (validated against livekit-client 2.19.1 source)

Adversarial review against the SDK source surfaced behaviors the options must
account for; the code and comments now reflect them truthfully:

- For a **VP9 SVC screen-share** track the SDK **forces `scalabilityMode = L1T3`**
  (Chrome can't encode multiple spatial layers for screen content). VP9
  screen-share is therefore temporal-only SVC — still VP9-efficient and
  framerate-adaptive. We set `L1T3` explicitly so the option object matches the
  wire.
- The SDK **forces `contentHint = "motion"`** on the VP9 path (a documented
  Chrome screenshare-SVC workaround). We still request `"detail"`: it is
  honoured on the VP8 fallback path and harmless on VP9.
- `backupCodecPolicy` defaulted to *regression*, which drops the **whole room**
  to VP8 the moment one VP8-only (iOS) viewer joins. We set **`SIMULCAST`** so
  the publisher sends VP9 and VP8 simultaneously and capable viewers keep VP9 —
  the explicit `backupCodec` is load-bearing for this. Costs the (already
  capability-gated) publisher a second encode.
- The capability probe is intentionally caps-based per the issue; the SDK's own
  `supportsVP9()` (Firefox/old-Safari guards) remains the publish backstop, and
  the #996 beacon reports the **actually-negotiated** wire codec — so telemetry
  is always truthful even if the probe's model is optimistic.

## Acceptance criteria

- [x] Pure `videoCodecSupport(env)` reports per-codec availability with reason, unit-tested without globals.
- [x] Builder returns VP9+SVC+VP8-backup (capable) / VP8-raised (incapable) for source = screen.
- [x] Screen-share captured at ~1440p, `contentHint: detail` (VP8 path), maintain-resolution, raised bitrate ceiling.
- [x] Engine forwards options to the SDK — verified with a stub `Room` (no real WebRTC), incl. the screen-audio-unsupported fallback retry.
- [x] On a capable device telemetry shows VP9 for screen-share; iOS shows VP8 — field-verified via the #996 media-path beacon (reads the negotiated wire codec).
- [x] Builders + probe covered by unit tests asserting the returned option objects.
- [x] `bun test` passes and `knip` is clean in `chat/`.

## Testing

- New unit tests: probe (`call-video-codec-support.test.ts`), builder
  (`call-video-publish.test.ts`), engine forwarding incl. capable/incapable +
  fallback retry (`call-engine.test.ts`).
- `bun test` — 2233 pass / 0 fail. `knip` — clean. `astro check` — 0 errors.
- Built test-first (red→green per behavior); reviewed by adversarial spec /
  LiveKit-correctness / code-quality personas over two rounds until no
  real, actionable issues remained.

## XEP conformance

No XMPP wire shape, namespace, or stanza is touched. Media runs on the
established LiveKit plane (per #995); this is client-side LiveKit SDK codec
configuration only — the "XMPP Native" media exception applies, nothing to
conform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
