### PR TITLE
feat(chat): Opus voice-clarity default — ~64k mono mic, RED/DTX on (#998)

### DIFF
--- a/chat/src/lib/calls/audio-publish.ts
+++ b/chat/src/lib/calls/audio-publish.ts
@@ -1,0 +1,33 @@
+/**
+ * Pure publish-option builder for the local microphone track. Mirrors
+ * `video-publish.ts`: it returns the typed LiveKit `TrackPublishOptions` the
+ * engine forwards verbatim to `setMicrophoneEnabled`, keeping the engine a thin
+ * applier. The default voice-clarity profile raises Opus to ~64 kbps mono.
+ */
+
+import type { TrackPublishOptions } from "livekit-client";
+
+/**
+ * ~64 kbps Opus, musicHighQuality-class voice clarity. We state it as an
+ * explicit `AudioPreset` rather than reaching for a named `AudioPresets`
+ * constant: `AudioPresets.musicStereo` is also 64k but forces stereo, and
+ * `AudioPresets.musicHighQuality` is 96k — neither is "64k mono". A bare
+ * `{ maxBitrate }` keeps the channel count governed by `forceStereo` below.
+ */
+const OPUS_VOICE_CLARITY_BITRATE = 64_000;
+
+export function audioPublishOptions(): TrackPublishOptions {
+  return {
+    audioPreset: { maxBitrate: OPUS_VOICE_CLARITY_BITRATE },
+    // RED (redundant audio) for packet-loss resilience and DTX (discontinuous
+    // transmission) so silent participants cost ~nothing. Both default on for
+    // mono tracks in LiveKit, but we set them explicitly so the contract is
+    // locked and testable rather than relying on the SDK's implicit default.
+    red: true,
+    dtx: true,
+    // Mono. The 64k target is mono, and DTX/RED above only auto-apply to mono
+    // tracks; pinning this off stops a stereo capture device from doubling the
+    // channel count (and the bitrate) behind our back.
+    forceStereo: false,
+  };
+}

--- a/chat/src/lib/calls/call-media-path-telemetry.ts
+++ b/chat/src/lib/calls/call-media-path-telemetry.ts
@@ -1,4 +1,9 @@
-import type { CallStatDirection, IceCandidateType, IceTransport } from "./call-stats";
+import type {
+  AudioBitrateBand,
+  CallStatDirection,
+  IceCandidateType,
+  IceTransport,
+} from "./call-stats";
 
 /**
  * Fleet-measurement telemetry for the media path one call track actually got:
@@ -13,12 +18,17 @@ import type { CallStatDirection, IceCandidateType, IceTransport } from "./call-s
  */
 
 /** What a call track is carrying its media as. */
-type CallMediaPathSource = "camera" | "screen";
+type CallMediaPathSource = "camera" | "screen" | "microphone";
 
 /**
  * One observed media path for a single track. `codec` and the two ICE fields
  * are null until the report names them; the sampler skips fully-empty
  * snapshots so a not-yet-negotiated track never beacons.
+ *
+ * `audioBitrateBand` is the active-speaker bitrate bucket — non-null only for
+ * `microphone` snapshots, so the raised ~64k Opus default is provable fleet-wide
+ * while a continuously-varying send bitrate stays low-cardinality and the beacon
+ * de-dupes. Always null for video (its quality lever is codec/ICE).
  */
 export type CallMediaPathSnapshot = {
   direction: CallStatDirection;
@@ -26,6 +36,7 @@ export type CallMediaPathSnapshot = {
   codec: string | null;
   iceCandidateType: IceCandidateType | null;
   iceTransport: IceTransport | null;
+  audioBitrateBand: AudioBitrateBand | null;
 };
 
 /**
@@ -44,6 +55,10 @@ export function callMediaPathEventAttributes(
     codec: snapshot.codec ?? "unknown",
     ice_candidate_type: snapshot.iceCandidateType ?? "unknown",
     ice_transport: snapshot.iceTransport ?? "unknown",
+    // Audio-only: emitted only for a microphone path that has a measured band,
+    // so video events keep their exact shape and never carry a meaningless
+    // audio attribute.
+    ...(snapshot.audioBitrateBand ? { audio_bitrate_band: snapshot.audioBitrateBand } : {}),
   };
 }
 
@@ -62,7 +77,8 @@ function sameCallMediaPath(a: CallMediaPathSnapshot, b: CallMediaPathSnapshot): 
     a.source === b.source &&
     a.codec === b.codec &&
     a.iceCandidateType === b.iceCandidateType &&
-    a.iceTransport === b.iceTransport
+    a.iceTransport === b.iceTransport &&
+    a.audioBitrateBand === b.audioBitrateBand
   );
 }
 

--- a/chat/src/lib/calls/call-stats.ts
+++ b/chat/src/lib/calls/call-stats.ts
@@ -58,6 +58,19 @@ export type VideoStatsSummary = {
   iceTransport: IceTransport | null;
 };
 
+/**
+ * Audio counterpart of {@link VideoStatsSummary}: the negotiated audio codec
+ * (e.g. "opus"), the derived send/recv bitrate, and the succeeded ICE path.
+ * Resolution/fps/loss are video-only concepts and intentionally absent — the
+ * audio lever's signal is bitrate (banded via {@link audioBitrateBand}).
+ */
+type AudioStatsSummary = {
+  codec: string | null;
+  bitrateKbps: number | null;
+  iceCandidateType: IceCandidateType | null;
+  iceTransport: IceTransport | null;
+};
+
 /** A single diagnostics row: one video track of one participant. */
 export type CallStatRow = VideoStatsSummary & {
   key: string;
@@ -117,6 +130,30 @@ type RtpLike = {
   protocol?: string;
   relayProtocol?: string;
 };
+
+/**
+ * Coarse band over a measured audio send/recv bitrate (kbps). Three buckets,
+ * low-cardinality so the de-duping media-path beacon emits at most a handful of
+ * audio events per call rather than one per fluctuating sample:
+ *  - `silent`   — DTX idle / comfort-noise floor; an idle participant costs
+ *                 ~nothing, so the raised default never burdens listeners.
+ *  - `standard` — the old `AudioPresets.music` (~48k) class and below.
+ *  - `high`     — the raised ~64k musicHighQuality-class voice-clarity default.
+ * `null` (an unmeasured first poll) has no band yet.
+ */
+export type AudioBitrateBand = "silent" | "standard" | "high";
+
+/** ≤ this reads as `silent`: DTX comfort-noise / keepalive, not real speech. */
+const AUDIO_SILENCE_CEILING_KBPS = 12;
+/** > this reads as `high`: midpoint between the old 48k and the raised 64k. */
+const AUDIO_RAISED_FLOOR_KBPS = 56;
+
+export function audioBitrateBand(bitrateKbps: number | null): AudioBitrateBand | null {
+  if (bitrateKbps === null) return null;
+  if (bitrateKbps <= AUDIO_SILENCE_CEILING_KBPS) return "silent";
+  if (bitrateKbps <= AUDIO_RAISED_FLOOR_KBPS) return "standard";
+  return "high";
+}
 
 /** Strip the "video/" prefix off a codec MIME, e.g. "video/VP9" → "VP9". */
 function codecName(mimeType: string | undefined): string | null {
@@ -190,6 +227,88 @@ function isVideo(stat: RtpLike): boolean {
   return stat.kind === "video" || stat.mediaType === "video";
 }
 
+function isAudio(stat: RtpLike): boolean {
+  return stat.kind === "audio" || stat.mediaType === "audio";
+}
+
+/**
+ * Derive a kbps rate from the byte/timestamp delta between two samples, or null
+ * when there is no prior sample (first poll) or the clock did not advance. A
+ * negative delta (counter reset) clamps to 0.
+ */
+function bitrateFromSamples(
+  sample: CallStatSample | null,
+  prev: CallStatSample | undefined,
+): number | null {
+  if (!sample || !prev || sample.timestampMs <= prev.timestampMs) return null;
+  const deltaBits = (sample.bytes - prev.bytes) * 8;
+  const deltaSec = (sample.timestampMs - prev.timestampMs) / 1000;
+  const kbps = deltaBits / deltaSec / 1000;
+  return kbps > 0 ? Math.round(kbps) : 0;
+}
+
+/**
+ * Sum a stream's byte counter and take the newest timestamp across entries
+ * (audio is a single RTP stream, but summing is harmless and symmetric with the
+ * video simulcast aggregation). Null when no entry reported its bytes.
+ */
+function sampleFromRtp(mains: RtpLike[], bytesField: "bytesSent" | "bytesReceived"): CallStatSample | null {
+  let bytes: number | undefined;
+  let timestampMs: number | undefined;
+  for (const main of mains) {
+    const layerBytes = main[bytesField];
+    if (layerBytes !== undefined) bytes = (bytes ?? 0) + layerBytes;
+    if (main.timestamp !== undefined && (timestampMs === undefined || main.timestamp > timestampMs)) {
+      timestampMs = main.timestamp;
+    }
+  }
+  return bytes !== undefined && timestampMs !== undefined ? { bytes, timestampMs } : null;
+}
+
+/**
+ * Reduce one audio track's `RTCStatsReport` to an {@link AudioStatsSummary} plus
+ * the fresh `CallStatSample` to retain. Mirrors {@link summarizeVideoStats} but
+ * reads the audio RTP stream: the negotiated codec, the bitrate (diffed against
+ * `prev`, null on the first poll), and the succeeded ICE candidate path. Used by
+ * the media-path beacon to band the active-speaker bitrate and confirm the
+ * raised ~64k Opus default fleet-wide.
+ */
+export function summarizeAudioStats(
+  report: RTCStatsReport,
+  direction: CallStatDirection,
+  prev?: CallStatSample,
+): { summary: AudioStatsSummary; sample: CallStatSample | null } {
+  const mainType = direction === "send" ? "outbound-rtp" : "inbound-rtp";
+  const mains: RtpLike[] = [];
+  const candidatePairs: RtpLike[] = [];
+  let selectedPairId: string | undefined;
+  const byId = new Map<string, RtpLike>();
+
+  report.forEach((raw: unknown) => {
+    const stat = raw as RtpLike;
+    if (stat.id !== undefined) byId.set(stat.id, stat);
+    if (stat.type === mainType && isAudio(stat)) {
+      mains.push(stat);
+    } else if (stat.type === "candidate-pair") {
+      candidatePairs.push(stat);
+    } else if (stat.type === "transport" && stat.selectedCandidatePairId !== undefined) {
+      selectedPairId = stat.selectedCandidatePairId;
+    }
+  });
+
+  const candidatePair = selectCandidatePair(candidatePairs, selectedPairId);
+  const { iceCandidateType, iceTransport } = iceCandidatePath(candidatePair, byId);
+
+  const codecRef = mains.find((main) => main.codecId !== undefined)?.codecId;
+  const codecEntry = codecRef !== undefined ? byId.get(codecRef) : undefined;
+  const codec = codecEntry?.type === "codec" ? codecName(codecEntry.mimeType) : null;
+
+  const sample = sampleFromRtp(mains, direction === "send" ? "bytesSent" : "bytesReceived");
+  const bitrateKbps = bitrateFromSamples(sample, prev);
+
+  return { summary: { codec, bitrateKbps, iceCandidateType, iceTransport }, sample };
+}
+
 function clampPercent(value: number): number {
   if (!Number.isFinite(value) || value < 0) return 0;
   if (value > 100) return 100;
@@ -261,27 +380,9 @@ export function summarizeVideoStats(
   const codecEntry = codecRef !== undefined ? byId.get(codecRef) : undefined;
   const codec = codecEntry?.type === "codec" ? codecName(codecEntry.mimeType) : null;
 
-  // Bytes summed across all layers; timestamp is the newest layer's.
-  const bytesField = direction === "send" ? "bytesSent" : "bytesReceived";
-  let bytes: number | undefined;
-  let timestampMs: number | undefined;
-  for (const main of mains) {
-    const layerBytes = main[bytesField];
-    if (layerBytes !== undefined) bytes = (bytes ?? 0) + layerBytes;
-    if (main.timestamp !== undefined && (timestampMs === undefined || main.timestamp > timestampMs)) {
-      timestampMs = main.timestamp;
-    }
-  }
-  const sample: CallStatSample | null =
-    bytes !== undefined && timestampMs !== undefined ? { bytes, timestampMs } : null;
-
-  let bitrateKbps: number | null = null;
-  if (sample && prev && sample.timestampMs > prev.timestampMs) {
-    const deltaBits = (sample.bytes - prev.bytes) * 8;
-    const deltaSec = (sample.timestampMs - prev.timestampMs) / 1000;
-    const kbps = deltaBits / deltaSec / 1000;
-    bitrateKbps = kbps > 0 ? Math.round(kbps) : 0;
-  }
+  // Bytes summed across all simulcast layers; timestamp is the newest layer's.
+  const sample = sampleFromRtp(mains, direction === "send" ? "bytesSent" : "bytesReceived");
+  const bitrateKbps = bitrateFromSamples(sample, prev);
 
   const packetLossPct =
     direction === "recv"

--- a/chat/src/lib/calls/call-stats.ts
+++ b/chat/src/lib/calls/call-stats.ts
@@ -241,19 +241,22 @@ function isAudio(stat: RtpLike): boolean {
 }
 
 /**
- * Derive a kbps rate from the byte/timestamp delta between two samples, or null
- * when there is no prior sample (first poll) or the clock did not advance. A
- * negative delta (counter reset) clamps to 0.
+ * Derive a kbps rate from the byte/timestamp delta between two samples. Null
+ * (unmeasured) when there is no prior sample (first poll), the clock did not
+ * advance, or the byte counter went *backwards* — a counter reset (track
+ * replaced / ICE restart) is no measurement this tick, not a genuinely idle
+ * one, so it must not collapse to 0 (which an audio band would read as DTX
+ * silence). A genuine idle tick (bytes unchanged, clock advanced) is a real 0.
  */
 function bitrateFromSamples(
   sample: CallStatSample | null,
   prev: CallStatSample | undefined,
 ): number | null {
   if (!sample || !prev || sample.timestampMs <= prev.timestampMs) return null;
+  if (sample.bytes < prev.bytes) return null;
   const deltaBits = (sample.bytes - prev.bytes) * 8;
   const deltaSec = (sample.timestampMs - prev.timestampMs) / 1000;
-  const kbps = deltaBits / deltaSec / 1000;
-  return kbps > 0 ? Math.round(kbps) : 0;
+  return Math.round(deltaBits / deltaSec / 1000);
 }
 
 /**

--- a/chat/src/lib/calls/call-stats.ts
+++ b/chat/src/lib/calls/call-stats.ts
@@ -132,20 +132,29 @@ type RtpLike = {
 };
 
 /**
- * Coarse band over a measured audio send/recv bitrate (kbps). Three buckets,
- * low-cardinality so the de-duping media-path beacon emits at most a handful of
- * audio events per call rather than one per fluctuating sample:
+ * Coarse band over the *measured on-the-wire* audio send/recv rate (kbps).
+ * Important: this is the wire rate, which sits ABOVE the Opus encoder target —
+ * it includes RED redundancy and RTP/SRTP overhead — and Opus is VBR, so quiet
+ * speech measures lower than loud speech on the same encoder cap. So the bands
+ * describe observed activity, not the configured preset:
  *  - `silent`   — DTX idle / comfort-noise floor; an idle participant costs
  *                 ~nothing, so the raised default never burdens listeners.
- *  - `standard` — the old `AudioPresets.music` (~48k) class and below.
- *  - `high`     — the raised ~64k musicHighQuality-class voice-clarity default.
- * `null` (an unmeasured first poll) has no band yet.
+ *  - `standard` — light / quiet / intermittent speech, or a lower-rate path.
+ *  - `high`     — sustained active speech. On the raised ~64k default an active
+ *                 speaker's wire rate clearly clears the floor, so a fleet-wide
+ *                 shift toward `high` is the signal that the raise took effect.
+ * Three buckets keep it low-cardinality so the de-duping media-path beacon emits
+ * at most a handful of audio events per call rather than one per fluctuating
+ * sample. `null` (an unmeasured first poll) has no band yet. Thresholds are
+ * coarse operational buckets meant to be validated/tuned against Faro
+ * (telemetry-first), NOT exact encoder-target cutoffs.
  */
 export type AudioBitrateBand = "silent" | "standard" | "high";
 
 /** ≤ this reads as `silent`: DTX comfort-noise / keepalive, not real speech. */
 const AUDIO_SILENCE_CEILING_KBPS = 12;
-/** > this reads as `high`: midpoint between the old 48k and the raised 64k. */
+/** > this reads as `high`: a sustained active speaker on the raised 64k default
+ *  clears this wire-rate floor (encoder target + RED + overhead). */
 const AUDIO_RAISED_FLOOR_KBPS = 56;
 
 export function audioBitrateBand(bitrateKbps: number | null): AudioBitrateBand | null {
@@ -248,9 +257,10 @@ function bitrateFromSamples(
 }
 
 /**
- * Sum a stream's byte counter and take the newest timestamp across entries
- * (audio is a single RTP stream, but summing is harmless and symmetric with the
- * video simulcast aggregation). Null when no entry reported its bytes.
+ * Sum a stream's byte counter across all of its RTP entries (one per simulcast
+ * layer for video; a single entry for audio) and take the newest timestamp.
+ * Null when no entry reported its bytes. Shared by the video and audio
+ * summarizers.
  */
 function sampleFromRtp(mains: RtpLike[], bytesField: "bytesSent" | "bytesReceived"): CallStatSample | null {
   let bytes: number | undefined;

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -17,6 +17,7 @@ import {
   type VideoCaptureOptions,
 } from "livekit-client";
 import { videoPublishPlan } from "./video-codec/video-publish";
+import { audioPublishOptions } from "./audio-publish";
 import {
   currentVideoCodecSupportEnv,
   videoCodecSupport,
@@ -89,8 +90,13 @@ export function callRoomOptionsForPrefs(prefs: {
       deviceId: prefs.cam ?? undefined,
       resolution: CAMERA_CAPTURE_RESOLUTION,
     },
-    // Screen-share encoding/codec is set per-publish by `videoPublishPlan`
-    // (it is capability-dependent), so no global `publishDefaults` here.
+    // The Opus voice-clarity profile (~64k mono, RED + DTX) is uniform — not
+    // device-capability dependent — so it lives here as a room-wide publish
+    // default rather than being threaded per-publish. It applies to every mic
+    // publish (initial join, mid-call unmute) automatically; its audio-only
+    // fields are ignored for video tracks. Screen-share/camera encoding+codec
+    // stay per-publish (`videoPublishPlan`) because those ARE capability-gated.
+    publishDefaults: audioPublishOptions(),
   };
 }
 
@@ -424,6 +430,9 @@ export class CallEngine {
 
   async setMicEnabled(enabled: boolean): Promise<void> {
     if (!this.room) return;
+    // The Opus voice-clarity profile is the room's `publishDefaults` (set in
+    // `callRoomOptionsForPrefs`), so a mid-call enable re-publishes at ~64k mono
+    // automatically — no per-publish options needed here.
     await this.room.localParticipant.setMicrophoneEnabled(enabled);
   }
 
@@ -1068,6 +1077,8 @@ export async function enableRequestedCapture(
 ): Promise<void> {
   if (opts.audio) {
     try {
+      // The mic's Opus voice-clarity profile comes from the room's
+      // `publishDefaults`, so no per-publish options are needed here.
       await participant.setMicrophoneEnabled(true);
     } catch (error) {
       onError("audio", error);

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -13,6 +13,7 @@ import {
   type RemoteTrack,
   type RemoteTrackPublication,
   type TrackPublication,
+  type AudioCaptureOptions,
   type TrackPublishOptions,
   type VideoCaptureOptions,
 } from "livekit-client";
@@ -90,13 +91,11 @@ export function callRoomOptionsForPrefs(prefs: {
       deviceId: prefs.cam ?? undefined,
       resolution: CAMERA_CAPTURE_RESOLUTION,
     },
-    // The Opus voice-clarity profile (~64k mono, RED + DTX) is uniform — not
-    // device-capability dependent — so it lives here as a room-wide publish
-    // default rather than being threaded per-publish. It applies to every mic
-    // publish (initial join, mid-call unmute) automatically; its audio-only
-    // fields are ignored for video tracks. Screen-share/camera encoding+codec
-    // stay per-publish (`videoPublishPlan`) because those ARE capability-gated.
-    publishDefaults: audioPublishOptions(),
+    // Screen-share encoding/codec is set per-publish by `videoPublishPlan`
+    // (it is capability-dependent), and the mic's Opus voice-clarity profile is
+    // set per-publish by `audioPublishOptions` (so it stays scoped to the
+    // microphone and never bleeds onto screen-share *system* audio, which may be
+    // stereo). Hence no global `publishDefaults` here.
   };
 }
 
@@ -417,7 +416,10 @@ export class CallEngine {
       room.localParticipant,
       { audio: opts.audio, video: opts.video },
       (source, error) => this.emit("mediaDevicesError", { source, error }),
-      videoPublishPlan({ source: "camera", capability: this.codecSupport }).publish,
+      {
+        audio: audioPublishOptions(),
+        camera: videoPublishPlan({ source: "camera", capability: this.codecSupport }).publish,
+      },
     );
     // Re-apply the speaker preference now that the room has remote
     // audio elements to retarget; the engine ignores it on connect
@@ -430,10 +432,11 @@ export class CallEngine {
 
   async setMicEnabled(enabled: boolean): Promise<void> {
     if (!this.room) return;
-    // The Opus voice-clarity profile is the room's `publishDefaults` (set in
-    // `callRoomOptionsForPrefs`), so a mid-call enable re-publishes at ~64k mono
-    // automatically — no per-publish options needed here.
-    await this.room.localParticipant.setMicrophoneEnabled(enabled);
+    // Forward the Opus voice-clarity profile (~64k mono, RED + DTX) so a mic
+    // (re)enabled mid-call publishes at the same default as the initial join,
+    // not LiveKit's lower `AudioPresets.music`. Scoped to the mic on purpose —
+    // screen-share system audio keeps the SDK defaults. Inert on disable (mute).
+    await this.room.localParticipant.setMicrophoneEnabled(enabled, undefined, audioPublishOptions());
   }
 
   async setCameraEnabled(enabled: boolean): Promise<void> {
@@ -1051,7 +1054,11 @@ function isUnsupportedScreenAudioError(error: unknown): boolean {
  * `Room` (which reaches for browser-only globals at construction).
  */
 type CapturableParticipant = {
-  setMicrophoneEnabled(enabled: boolean): Promise<unknown>;
+  setMicrophoneEnabled(
+    enabled: boolean,
+    options?: AudioCaptureOptions,
+    publishOptions?: TrackPublishOptions,
+  ): Promise<unknown>;
   setCameraEnabled(
     enabled: boolean,
     options?: VideoCaptureOptions,
@@ -1073,20 +1080,18 @@ export async function enableRequestedCapture(
   participant: CapturableParticipant,
   opts: { audio: boolean; video: boolean },
   onError: (source: "audio" | "video", error: unknown) => void,
-  cameraPublishOptions: TrackPublishOptions,
+  publish: { audio: TrackPublishOptions; camera: TrackPublishOptions },
 ): Promise<void> {
   if (opts.audio) {
     try {
-      // The mic's Opus voice-clarity profile comes from the room's
-      // `publishDefaults`, so no per-publish options are needed here.
-      await participant.setMicrophoneEnabled(true);
+      await participant.setMicrophoneEnabled(true, undefined, publish.audio);
     } catch (error) {
       onError("audio", error);
     }
   }
   if (opts.video) {
     try {
-      await participant.setCameraEnabled(true, undefined, cameraPublishOptions);
+      await participant.setCameraEnabled(true, undefined, publish.camera);
     } catch (error) {
       onError("video", error);
     }

--- a/chat/src/lib/calls/use-call-engine.ts
+++ b/chat/src/lib/calls/use-call-engine.ts
@@ -134,6 +134,11 @@ type AudioMediaPathResult = {
  * measured (the first poll has no prior sample) — codec/ICE then ride along with
  * the band on the next tick. `getRTCStatsReport()` rejects mid-teardown, so a
  * failure drops this track rather than the whole pass.
+ *
+ * Direction matters when reading the band downstream: a `send` band is OUR
+ * publish (direct evidence the raised default took effect); a `recv` band is a
+ * remote peer's publish (whatever client they run), disambiguated by the
+ * snapshot's `direction`.
  */
 async function sampleAudioTrackMediaPath(
   track: LocalMediaTrack | RemoteMediaTrack,

--- a/chat/src/lib/calls/use-call-engine.ts
+++ b/chat/src/lib/calls/use-call-engine.ts
@@ -146,11 +146,12 @@ async function sampleAudioTrackMediaPath(
 ): Promise<AudioMediaPathResult | null> {
   // `send` is the local mic, `recv` is a remote participant's mic; the
   // publicationSid is unique per track, scoped by direction so a stale key from
-  // a prior call never collides.
+  // a prior call never collides. Same `local:`/`remote:` scheme as the
+  // diagnostics-dialog poller, so the two are easy to correlate.
   const key =
     direction === "send"
       ? `local:${track.source}:${track.publicationSid}`
-      : `recv:${track.participantIdentity}:${track.source}:${track.publicationSid}`;
+      : `remote:${track.participantIdentity}:${track.source}:${track.publicationSid}`;
   try {
     const report = await track.track.getRTCStatsReport();
     if (!report) return null;

--- a/chat/src/lib/calls/use-call-engine.ts
+++ b/chat/src/lib/calls/use-call-engine.ts
@@ -22,7 +22,13 @@ import {
   createCallMediaPathBeacon,
   type CallMediaPathSnapshot,
 } from "./call-media-path-telemetry";
-import { summarizeVideoStats, type CallStatDirection } from "./call-stats";
+import {
+  audioBitrateBand,
+  summarizeAudioStats,
+  summarizeVideoStats,
+  type CallStatDirection,
+  type CallStatSample,
+} from "./call-stats";
 import { reportCallAudioProcessing, reportCallMediaPath } from "../telemetry";
 import {
   resetCallConnectionQuality,
@@ -78,6 +84,12 @@ let mediaPathSampling = false;
 // just-reset beacon — which would otherwise suppress the next call's first
 // event when both calls share a codec/ICE path.
 let mediaPathGeneration = 0;
+// Previous byte/timestamp sample per audio track, so the media-path poll can
+// derive the send/recv bitrate (a rate needs two samples) and band it. Keyed by
+// the same track key used in the diagnostics dialog; cleared between calls in
+// `stopMediaPathPolling`. Committed only after the generation re-check so a
+// stale in-flight pass can't seed the next call's bitrate.
+const audioMediaPathSamples = new Map<string, CallStatSample>();
 
 /**
  * Read one video track's live stats and reduce them to a media-path snapshot,
@@ -100,7 +112,57 @@ async function sampleTrackMediaPath(
       codec: summary.codec,
       iceCandidateType: summary.iceCandidateType,
       iceTransport: summary.iceTransport,
+      audioBitrateBand: null, // video paths carry no audio band
     };
+  } catch {
+    return null;
+  }
+}
+
+/** One audio track's media-path sample, carrying the fresh byte/timestamp
+ *  sample to retain so the next poll can derive a bitrate. */
+type AudioMediaPathResult = {
+  snapshot: CallMediaPathSnapshot | null;
+  key: string;
+  sample: CallStatSample | null;
+};
+
+/**
+ * Read one mic track's live stats and reduce them to an audio media-path
+ * snapshot (negotiated codec, ICE path, and the active-speaker bitrate band),
+ * plus the fresh sample to retain. The snapshot is `null` until a bitrate can be
+ * measured (the first poll has no prior sample) — codec/ICE then ride along with
+ * the band on the next tick. `getRTCStatsReport()` rejects mid-teardown, so a
+ * failure drops this track rather than the whole pass.
+ */
+async function sampleAudioTrackMediaPath(
+  track: LocalMediaTrack | RemoteMediaTrack,
+  direction: CallStatDirection,
+): Promise<AudioMediaPathResult | null> {
+  // `send` is the local mic, `recv` is a remote participant's mic; the
+  // publicationSid is unique per track, scoped by direction so a stale key from
+  // a prior call never collides.
+  const key =
+    direction === "send"
+      ? `local:${track.source}:${track.publicationSid}`
+      : `recv:${track.participantIdentity}:${track.source}:${track.publicationSid}`;
+  try {
+    const report = await track.track.getRTCStatsReport();
+    if (!report) return null;
+    const { summary, sample } = summarizeAudioStats(report, direction, audioMediaPathSamples.get(key));
+    const band = audioBitrateBand(summary.bitrateKbps);
+    const snapshot: CallMediaPathSnapshot | null =
+      band === null
+        ? null
+        : {
+            direction,
+            source: "microphone",
+            codec: summary.codec,
+            iceCandidateType: summary.iceCandidateType,
+            iceTransport: summary.iceTransport,
+            audioBitrateBand: band,
+          };
+    return { snapshot, key, sample };
   } catch {
     return null;
   }
@@ -113,19 +175,37 @@ async function sampleMediaPaths(generation: number): Promise<void> {
   if (mediaPathSampling) return;
   mediaPathSampling = true;
   try {
-    const snapshots = await Promise.all([
-      ...localTracks.value
-        .filter((track) => track.kind === "video")
-        .map((track) => sampleTrackMediaPath(track, "send")),
-      ...remoteTracks.value
-        .filter((track) => track.kind === "video")
-        .map((track) => sampleTrackMediaPath(track, "recv")),
+    const [videoSnapshots, audioResults] = await Promise.all([
+      Promise.all([
+        ...localTracks.value
+          .filter((track) => track.kind === "video")
+          .map((track) => sampleTrackMediaPath(track, "send")),
+        ...remoteTracks.value
+          .filter((track) => track.kind === "video")
+          .map((track) => sampleTrackMediaPath(track, "recv")),
+      ]),
+      // Only the microphone carries the voice-clarity lever; screen-share audio
+      // is system/tab audio, not speech, so it is excluded.
+      Promise.all([
+        ...localTracks.value
+          .filter((track) => track.source === "microphone")
+          .map((track) => sampleAudioTrackMediaPath(track, "send")),
+        ...remoteTracks.value
+          .filter((track) => track.source === "microphone")
+          .map((track) => sampleAudioTrackMediaPath(track, "recv")),
+      ]),
     ]);
     // Bail if polling was stopped/restarted while we awaited: this pass belongs
-    // to a torn-down call and must not observe into the (reset) beacon.
+    // to a torn-down call and must not observe into the (reset) beacon or seed
+    // the next call's bitrate samples.
     if (generation !== mediaPathGeneration) return;
-    for (const snapshot of snapshots) {
+    for (const snapshot of videoSnapshots) {
       if (snapshot) callMediaPathBeacon.observe(snapshot);
+    }
+    for (const result of audioResults) {
+      if (!result) continue;
+      if (result.sample) audioMediaPathSamples.set(result.key, result.sample);
+      if (result.snapshot) callMediaPathBeacon.observe(result.snapshot);
     }
   } finally {
     mediaPathSampling = false;
@@ -148,6 +228,9 @@ function stopMediaPathPolling(): void {
     clearInterval(mediaPathTimer);
     mediaPathTimer = null;
   }
+  // Drop the per-track bitrate samples so the next call's first delta is not
+  // diffed against a previous call's byte counter.
+  audioMediaPathSamples.clear();
 }
 
 export function useCallEngine(): {

--- a/chat/tests/call-audio-publish.test.ts
+++ b/chat/tests/call-audio-publish.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { audioPublishOptions } from "../src/lib/calls/audio-publish";
+
+describe("audioPublishOptions — default Opus voice-clarity profile", () => {
+  test("requests ~64k mono Opus (musicHighQuality-class)", () => {
+    const publish = audioPublishOptions();
+    expect(publish.audioPreset?.maxBitrate).toBe(64_000);
+  });
+
+  test("keeps RED (redundant audio) and DTX (discontinuous transmission) enabled", () => {
+    const publish = audioPublishOptions();
+    expect(publish.red).toBe(true);
+    expect(publish.dtx).toBe(true);
+  });
+
+  test("publishes mono — never lets a stereo capture inflate the bitrate or disable DTX/RED", () => {
+    // DTX/RED only auto-apply to mono in LiveKit, and the target is 64k MONO,
+    // not 64k stereo; pin forceStereo off so a stereo capture device can't
+    // silently double the channel count.
+    const publish = audioPublishOptions();
+    expect(publish.forceStereo).toBe(false);
+  });
+
+  test("pure: returns fresh objects callers can't alias into a shared singleton", () => {
+    const a = audioPublishOptions();
+    const b = audioPublishOptions();
+    expect(a).not.toBe(b);
+    expect(a.audioPreset).not.toBe(b.audioPreset);
+  });
+});

--- a/chat/tests/call-engine.test.ts
+++ b/chat/tests/call-engine.test.ts
@@ -101,6 +101,24 @@ describe("call-engine module", () => {
     });
   });
 
+  test("sets the Opus voice-clarity profile (~64k mono, RED + DTX) as the room publish default", () => {
+    // The voice-clarity lever is uniform (not capability-gated), so it rides on
+    // the room's `publishDefaults` and applies to every mic publish. Asserted on
+    // the returned options — the engine is a thin applier.
+    const audioProcessing: AudioProcessingPrefs = {
+      noiseSuppression: true,
+      echoCancellation: true,
+      autoGainControl: true,
+    };
+    const options = callRoomOptionsForPrefs({ mic: null, cam: null, audioProcessing });
+    expect(options.publishDefaults).toMatchObject({
+      audioPreset: { maxBitrate: 64_000 },
+      red: true,
+      dtx: true,
+      forceStereo: false,
+    });
+  });
+
   test("resolves participant audio volume by identity and source with default full volume", () => {
     const store: ParticipantAudioVolumeStore = {
       "bob@waddle.test/desktop:microphone": 0.3,

--- a/chat/tests/call-engine.test.ts
+++ b/chat/tests/call-engine.test.ts
@@ -101,24 +101,6 @@ describe("call-engine module", () => {
     });
   });
 
-  test("sets the Opus voice-clarity profile (~64k mono, RED + DTX) as the room publish default", () => {
-    // The voice-clarity lever is uniform (not capability-gated), so it rides on
-    // the room's `publishDefaults` and applies to every mic publish. Asserted on
-    // the returned options — the engine is a thin applier.
-    const audioProcessing: AudioProcessingPrefs = {
-      noiseSuppression: true,
-      echoCancellation: true,
-      autoGainControl: true,
-    };
-    const options = callRoomOptionsForPrefs({ mic: null, cam: null, audioProcessing });
-    expect(options.publishDefaults).toMatchObject({
-      audioPreset: { maxBitrate: 64_000 },
-      red: true,
-      dtx: true,
-      forceStereo: false,
-    });
-  });
-
   test("resolves participant audio volume by identity and source with default full volume", () => {
     const store: ParticipantAudioVolumeStore = {
       "bob@waddle.test/desktop:microphone": 0.3,
@@ -703,14 +685,16 @@ describe("call-engine module", () => {
 });
 
 describe("enableRequestedCapture — best-effort, never ejects", () => {
-  // Camera publish options are irrelevant to the best-effort guarantees here;
-  // any typed value satisfies the (now required) parameter.
+  // Publish options are irrelevant to the best-effort guarantees here; any
+  // typed bundle satisfies the (now required) parameter.
   const cameraOpts = { degradationPreference: "maintain-framerate" as const };
+  const audioOpts = { audioPreset: { maxBitrate: 64_000 }, red: true, dtx: true, forceStereo: false };
+  const publish = { audio: audioOpts, camera: cameraOpts };
 
   test("enables both tracks when capture succeeds", async () => {
     const stub = captureStub();
     const errors: string[] = [];
-    await enableRequestedCapture(stub, { audio: true, video: true }, (s) => errors.push(s), cameraOpts);
+    await enableRequestedCapture(stub, { audio: true, video: true }, (s) => errors.push(s), publish);
     expect(stub.calls).toEqual(["mic:true", "cam:true"]);
     expect(errors).toEqual([]);
   });
@@ -722,7 +706,7 @@ describe("enableRequestedCapture — best-effort, never ejects", () => {
     const seen: Array<{ source: string; name: string }> = [];
     await enableRequestedCapture(stub, { audio: true, video: true }, (source, error) => {
       seen.push({ source, name: (error as Error).name });
-    }, cameraOpts);
+    }, publish);
     expect(stub.calls).toEqual(["mic:true", "cam:true"]); // camera still attempted
     expect(seen).toEqual([{ source: "audio", name: "NotAllowedError" }]);
   });
@@ -730,7 +714,7 @@ describe("enableRequestedCapture — best-effort, never ejects", () => {
   test("a missing camera reports only video and leaves the mic untouched", async () => {
     const stub = captureStub({ camThrows: deviceError("NotFoundError") });
     const seen: string[] = [];
-    await enableRequestedCapture(stub, { audio: true, video: true }, (source) => seen.push(source), cameraOpts);
+    await enableRequestedCapture(stub, { audio: true, video: true }, (source) => seen.push(source), publish);
     expect(seen).toEqual(["video"]);
   });
 
@@ -742,7 +726,7 @@ describe("enableRequestedCapture — best-effort, never ejects", () => {
     });
     const seen: string[] = [];
     await expect(
-      enableRequestedCapture(stub, { audio: true, video: true }, (source) => seen.push(source), cameraOpts),
+      enableRequestedCapture(stub, { audio: true, video: true }, (source) => seen.push(source), publish),
     ).resolves.toBeUndefined();
     expect(seen).toEqual(["audio", "video"]);
   });
@@ -750,7 +734,7 @@ describe("enableRequestedCapture — best-effort, never ejects", () => {
   test("audio-only call never touches the camera", async () => {
     const stub = captureStub({ camThrows: deviceError("NotFoundError") });
     const seen: string[] = [];
-    await enableRequestedCapture(stub, { audio: true, video: false }, (source) => seen.push(source), cameraOpts);
+    await enableRequestedCapture(stub, { audio: true, video: false }, (source) => seen.push(source), publish);
     expect(stub.calls).toEqual(["mic:true"]);
     expect(seen).toEqual([]);
   });
@@ -1149,8 +1133,65 @@ describe("call-engine — camera capture ceiling + per-source degradation", () =
       },
     };
     const cameraPublishOptions = { degradationPreference: "maintain-framerate" as const };
-    await enableRequestedCapture(stub, { audio: false, video: true }, () => {}, cameraPublishOptions);
+    await enableRequestedCapture(
+      stub,
+      { audio: false, video: true },
+      () => {},
+      { audio: {}, camera: cameraPublishOptions },
+    );
     expect(camera).toEqual([{ enabled: true, publishOptions: cameraPublishOptions }]);
+  });
+});
+
+describe("call-engine — Opus voice-clarity audio publish profile (#998)", () => {
+  function micRoomStub() {
+    const mic: Array<{ enabled: boolean; options: unknown; publishOptions: unknown }> = [];
+    return {
+      mic,
+      room: {
+        localParticipant: {
+          async setMicrophoneEnabled(enabled: boolean, options?: unknown, publishOptions?: unknown) {
+            mic.push({ enabled, options, publishOptions });
+          },
+        },
+      },
+    };
+  }
+
+  test("setMicEnabled publishes the mic with ~64k mono Opus, RED + DTX on", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    const stub = micRoomStub();
+    (engine as unknown as { room: unknown }).room = stub.room;
+
+    await engine.setMicEnabled(true);
+
+    expect(stub.mic).toHaveLength(1);
+    expect(stub.mic[0]?.enabled).toBe(true);
+    expect(stub.mic[0]?.publishOptions).toMatchObject({
+      audioPreset: { maxBitrate: 64_000 },
+      red: true,
+      dtx: true,
+      forceStereo: false,
+    });
+  });
+
+  test("enableRequestedCapture forwards the audio publish options to the mic", async () => {
+    const mic: Array<{ enabled: boolean; publishOptions: unknown }> = [];
+    const stub = {
+      async setMicrophoneEnabled(enabled: boolean, _options?: unknown, publishOptions?: unknown) {
+        mic.push({ enabled, publishOptions });
+      },
+      async setCameraEnabled() {},
+    };
+    const audioPublishOpts = { audioPreset: { maxBitrate: 64_000 }, red: true, dtx: true, forceStereo: false };
+    await enableRequestedCapture(
+      stub,
+      { audio: true, video: false },
+      () => {},
+      { audio: audioPublishOpts, camera: {} },
+    );
+    expect(mic).toEqual([{ enabled: true, publishOptions: audioPublishOpts }]);
   });
 });
 

--- a/chat/tests/call-media-path-telemetry.test.ts
+++ b/chat/tests/call-media-path-telemetry.test.ts
@@ -11,6 +11,7 @@ const RELAY_TCP: CallMediaPathSnapshot = {
   codec: "VP9",
   iceCandidateType: "relay",
   iceTransport: "tcp",
+  audioBitrateBand: null,
 };
 
 describe("callMediaPathEventAttributes", () => {
@@ -32,6 +33,7 @@ describe("callMediaPathEventAttributes", () => {
         codec: null,
         iceCandidateType: null,
         iceTransport: null,
+        audioBitrateBand: null,
       }),
     ).toEqual({
       direction: "recv",
@@ -42,6 +44,30 @@ describe("callMediaPathEventAttributes", () => {
     });
   });
 
+  test("an audio path carries the bitrate band (active-speaker signal), codec and source", () => {
+    expect(
+      callMediaPathEventAttributes({
+        direction: "send",
+        source: "microphone",
+        codec: "opus",
+        iceCandidateType: "host",
+        iceTransport: "udp",
+        audioBitrateBand: "high",
+      }),
+    ).toEqual({
+      direction: "send",
+      source: "microphone",
+      codec: "opus",
+      ice_candidate_type: "host",
+      ice_transport: "udp",
+      audio_bitrate_band: "high",
+    });
+  });
+
+  test("a video path omits the audio_bitrate_band attribute entirely", () => {
+    expect(callMediaPathEventAttributes(RELAY_TCP)).not.toHaveProperty("audio_bitrate_band");
+  });
+
   test("never emits participant identifiers or JIDs", () => {
     const attrs = callMediaPathEventAttributes(RELAY_TCP);
     const allowed = new Set([
@@ -50,6 +76,7 @@ describe("callMediaPathEventAttributes", () => {
       "codec",
       "ice_candidate_type",
       "ice_transport",
+      "audio_bitrate_band",
     ]);
     for (const key of Object.keys(attrs)) {
       expect(allowed.has(key)).toBe(true);
@@ -86,6 +113,25 @@ describe("createCallMediaPathBeacon", () => {
 
     expect(reported).toHaveLength(2);
     expect(reported[1]?.codec).toBe("VP8");
+  });
+
+  test("re-beacons when the audio bitrate band changes (silent → high speaker)", () => {
+    const reported: CallMediaPathSnapshot[] = [];
+    const beacon = createCallMediaPathBeacon((s) => reported.push(s));
+    const audio = (band: "silent" | "standard" | "high"): CallMediaPathSnapshot => ({
+      direction: "send",
+      source: "microphone",
+      codec: "opus",
+      iceCandidateType: "host",
+      iceTransport: "udp",
+      audioBitrateBand: band,
+    });
+
+    beacon.observe(audio("silent"));
+    beacon.observe(audio("high"));
+    beacon.observe(audio("silent")); // back to a band already seen → no re-beacon
+
+    expect(reported.map((s) => s.audioBitrateBand)).toEqual(["silent", "high"]);
   });
 
   test("re-beacons when the ICE path changes (relay → host)", () => {

--- a/chat/tests/call-stats.test.ts
+++ b/chat/tests/call-stats.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
+  audioBitrateBand,
   describeVideoStats,
   formatBitrate,
+  summarizeAudioStats,
   summarizeVideoStats,
   type CallStatSample,
 } from "../src/lib/calls/call-stats";
@@ -446,5 +448,103 @@ describe("formatBitrate", () => {
     expect(formatBitrate(450)).toBe("450 kbps");
     expect(formatBitrate(1000)).toBe("1.0 Mbps");
     expect(formatBitrate(2800)).toBe("2.8 Mbps");
+  });
+});
+
+describe("audioBitrateBand — coarse band over a measured audio bitrate", () => {
+  test("DTX-silent (≈0 kbps) reads 'silent' — idle participants cost ~nothing", () => {
+    expect(audioBitrateBand(0)).toBe("silent");
+    expect(audioBitrateBand(8)).toBe("silent");
+  });
+
+  test("old ~48k music-class default reads 'standard'", () => {
+    expect(audioBitrateBand(32)).toBe("standard");
+    expect(audioBitrateBand(48)).toBe("standard");
+  });
+
+  test("the raised ~64k musicHighQuality-class default reads 'high'", () => {
+    expect(audioBitrateBand(64)).toBe("high");
+    expect(audioBitrateBand(72)).toBe("high");
+  });
+
+  test("an unmeasured bitrate (null, first poll) has no band yet", () => {
+    expect(audioBitrateBand(null)).toBeNull();
+  });
+});
+
+describe("summarizeAudioStats — outbound (send) audio", () => {
+  const outbound = {
+    type: "outbound-rtp",
+    kind: "audio",
+    bytesSent: 100_000,
+    timestamp: 10_000,
+    codecId: "RTCCodec_opus",
+  };
+  const opus = { type: "codec", id: "RTCCodec_opus", mimeType: "audio/opus" };
+
+  test("reads the negotiated codec; bitrate is null on the first sample", () => {
+    const { summary, sample } = summarizeAudioStats(report([outbound, opus]), "send");
+    expect(summary.codec).toBe("opus");
+    expect(summary.bitrateKbps).toBeNull(); // needs two samples
+    expect(sample).toEqual({ bytes: 100_000, timestampMs: 10_000 });
+  });
+
+  test("derives the send bitrate from the byte/timestamp delta against the previous sample", () => {
+    const prev: CallStatSample = { bytes: 100_000, timestampMs: 10_000 };
+    // +8,000 bytes = 64,000 bits over 1.0s = 64 kbps (the raised target).
+    const next = { ...outbound, bytesSent: 108_000, timestamp: 11_000 };
+    const { summary } = summarizeAudioStats(report([next, opus]), "send", prev);
+    expect(summary.bitrateKbps).toBe(64);
+    expect(audioBitrateBand(summary.bitrateKbps)).toBe("high");
+  });
+
+  test("only looks at audio RTP — a co-reported video stream never bleeds in", () => {
+    const prev: CallStatSample = { bytes: 100_000, timestampMs: 10_000 };
+    const video = {
+      type: "outbound-rtp",
+      kind: "video",
+      bytesSent: 5_000_000,
+      timestamp: 11_000,
+    };
+    const next = { ...outbound, bytesSent: 108_000, timestamp: 11_000 };
+    const { summary } = summarizeAudioStats(report([next, video, opus]), "send", prev);
+    expect(summary.bitrateKbps).toBe(64); // not inflated by the 5 Mbps video
+  });
+});
+
+describe("summarizeAudioStats — inbound (recv) audio and ICE path", () => {
+  test("derives the recv bitrate and reads the succeeded ICE candidate path", () => {
+    const prev: CallStatSample = { bytes: 50_000, timestampMs: 5_000 };
+    const inbound = {
+      type: "inbound-rtp",
+      kind: "audio",
+      bytesReceived: 56_000, // +6,000 bytes = 48 kbps over 1.0s
+      timestamp: 6_000,
+      codecId: "c-opus",
+    };
+    const codec = { type: "codec", id: "c-opus", mimeType: "audio/opus" };
+    const transport = { type: "transport", selectedCandidatePairId: "pair-1" };
+    const pair = { type: "candidate-pair", id: "pair-1", state: "succeeded", localCandidateId: "lc-1" };
+    const local = { type: "local-candidate", id: "lc-1", candidateType: "host", protocol: "udp" };
+    const { summary } = summarizeAudioStats(
+      report([inbound, codec, transport, pair, local]),
+      "recv",
+      prev,
+    );
+    expect(summary.bitrateKbps).toBe(48);
+    expect(audioBitrateBand(summary.bitrateKbps)).toBe("standard");
+    expect(summary.codec).toBe("opus");
+    expect(summary.iceCandidateType).toBe("host");
+    expect(summary.iceTransport).toBe("udp");
+  });
+
+  test("a track not yet flowing yields all-null fields", () => {
+    const { summary } = summarizeAudioStats(report([]), "recv");
+    expect(summary).toEqual({
+      codec: null,
+      bitrateKbps: null,
+      iceCandidateType: null,
+      iceTransport: null,
+    });
   });
 });

--- a/chat/tests/call-stats.test.ts
+++ b/chat/tests/call-stats.test.ts
@@ -514,6 +514,24 @@ describe("summarizeAudioStats — outbound (send) audio", () => {
     const { summary } = summarizeAudioStats(report([next, video, opus]), "send", prev);
     expect(summary.bitrateKbps).toBe(64); // not inflated by the 5 Mbps video
   });
+
+  test("a genuine idle tick (bytes unchanged, clock advanced) reads 0 → 'silent'", () => {
+    const prev: CallStatSample = { bytes: 100_000, timestampMs: 10_000 };
+    const next = { ...outbound, bytesSent: 100_000, timestamp: 11_000 };
+    const { summary } = summarizeAudioStats(report([next, opus]), "send", prev);
+    expect(summary.bitrateKbps).toBe(0);
+    expect(audioBitrateBand(summary.bitrateKbps)).toBe("silent");
+  });
+
+  test("a byte-counter reset (negative delta) is unmeasured (null), not a false 'silent'", () => {
+    // A WebRTC counter reset (track replaced / ICE restart) must not beacon as
+    // DTX silence — it is no measurement this tick, matching the first-poll null.
+    const prev: CallStatSample = { bytes: 500_000, timestampMs: 10_000 };
+    const next = { ...outbound, bytesSent: 1_000, timestamp: 11_000 };
+    const { summary } = summarizeAudioStats(report([next, opus]), "send", prev);
+    expect(summary.bitrateKbps).toBeNull();
+    expect(audioBitrateBand(summary.bitrateKbps)).toBeNull();
+  });
 });
 
 describe("summarizeAudioStats — inbound (recv) audio and ICE path", () => {

--- a/chat/tests/call-stats.test.ts
+++ b/chat/tests/call-stats.test.ts
@@ -451,19 +451,22 @@ describe("formatBitrate", () => {
   });
 });
 
-describe("audioBitrateBand — coarse band over a measured audio bitrate", () => {
-  test("DTX-silent (≈0 kbps) reads 'silent' — idle participants cost ~nothing", () => {
+describe("audioBitrateBand — coarse band over the measured on-the-wire audio rate", () => {
+  test("a near-silent wire rate (DTX idle / comfort noise) reads 'silent'", () => {
     expect(audioBitrateBand(0)).toBe("silent");
-    expect(audioBitrateBand(8)).toBe("silent");
+    expect(audioBitrateBand(12)).toBe("silent"); // boundary
   });
 
-  test("old ~48k music-class default reads 'standard'", () => {
-    expect(audioBitrateBand(32)).toBe("standard");
+  test("a light / quiet / intermittent wire rate reads 'standard'", () => {
+    expect(audioBitrateBand(13)).toBe("standard"); // just past silence
     expect(audioBitrateBand(48)).toBe("standard");
+    expect(audioBitrateBand(56)).toBe("standard"); // boundary
   });
 
-  test("the raised ~64k musicHighQuality-class default reads 'high'", () => {
-    expect(audioBitrateBand(64)).toBe("high");
+  test("a sustained active-speaker wire rate reads 'high' (the raised default's signal)", () => {
+    // Wire rate, not encoder target: a 64k Opus stream + RED + RTP overhead
+    // measures above the encoder cap, so a real active speaker clears the floor.
+    expect(audioBitrateBand(57)).toBe("high"); // just past the floor
     expect(audioBitrateBand(72)).toBe("high");
   });
 
@@ -491,7 +494,8 @@ describe("summarizeAudioStats — outbound (send) audio", () => {
 
   test("derives the send bitrate from the byte/timestamp delta against the previous sample", () => {
     const prev: CallStatSample = { bytes: 100_000, timestampMs: 10_000 };
-    // +8,000 bytes = 64,000 bits over 1.0s = 64 kbps (the raised target).
+    // +8,000 bytes = 64,000 bits over 1.0s = 64 kbps on the wire → a sustained
+    // active speaker on the raised default, so the band reads 'high'.
     const next = { ...outbound, bytesSent: 108_000, timestamp: 11_000 };
     const { summary } = summarizeAudioStats(report([next, opus]), "send", prev);
     expect(summary.bitrateKbps).toBe(64);


### PR DESCRIPTION
Closes #998. Part of the #995 media-quality PRD (Opus voice-clarity lever).

## What & why

Make voice clearer by default on every call by raising the default Opus **microphone** publish to ~64 kbps **mono** (musicHighQuality-class) — up from the LiveKit default (`AudioPresets.music`, 48k). RED (loss resilience) and DTX (idle participants cost ~nothing) stay enabled and the track stays mono (`forceStereo: false`, so DTX/RED keep applying and a stereo capture can't double the bitrate). Browser echo-cancellation/auto-gain stay on; the WASM AI noise filter stays opt-in. No UI change. Independent of the video-codec slices.

## How

1. **Pure `audioPublishOptions()`** (`chat/src/lib/calls/audio-publish.ts`, mirrors `video-publish.ts`): returns typed `TrackPublishOptions` — `audioPreset: { maxBitrate: 64_000 }`, `dtx: true`, `red: true`, `forceStereo: false`. Pure, returns fresh objects. Unit-tested.
2. **Engine wiring (thin applier), scoped to the mic**: `setMicEnabled` and `enableRequestedCapture` forward the profile to `setMicrophoneEnabled(enabled, undefined, audioPublishOptions())`, covering both the initial join and mid-call unmute. Deliberately **not** a room-wide `publishDefaults` — that would also force screen-share *system* audio to mono/64k (a stereo→mono regression for shared media). The lever is voice = the mic. Engine tests assert the forwarded options via stub participants.
3. **Telemetry — Faro media beacon + audio bitrate band** (acceptance #4): pure `summarizeAudioStats` + `audioBitrateBand` classifier in `call-stats.ts` (shared bitrate/sample helpers de-dup the video summarizer); `CallMediaPathSnapshot` gains a `microphone` source + `audioBitrateBand`; the media-path poll samples the mic track (threading prev byte/timestamp samples for a rate). The band is the measured **on-the-wire** rate (Opus target + RED redundancy + RTP overhead; Opus is VBR), bucketed coarsely — `silent` (DTX idle) / `standard` (light speech) / `high` (sustained active speech). A fleet-wide shift toward `high` is the signal the raise took effect. De-duped and PII-free; `audio_bitrate_band` is emitted only for microphone paths.

## Acceptance criteria

- [x] Default audio publish options request ~64k mono Opus (musicHighQuality-class).
- [x] RED and DTX remain enabled; browser EC/AGC remain on; AI noise filter remains opt-in.
- [x] The audio publish-option decision is a pure function covered by unit tests asserting the returned options.
- [x] Call-media telemetry reflects the raised audio bitrate for active speakers (Faro `audio_bitrate_band`).
- [x] `bun test` passes and `knip` is clean in `chat/`.

## Verification

`bun test` (2261 pass), `knip` clean, `astro check` clean. Reviewed by three adversarial personas (spec, correctness/LiveKit, conventions); their findings — room-`publishDefaults` over-applying to screen-share audio, and bitrate-band framing implying encoder-target == wire-rate — are fixed in this branch, and a second pass confirmed no remaining issues.

## XEP conformance

No XMPP wire impact: audio codec/bitrate is a LiveKit publish-option concern (media plane), not a Jingle/stanza change — no new namespace, no stanza shape change. Telemetry is a Faro operational beacon (allowed exception), carrying a low-cardinality bitrate band only (no JID/identity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)