### PR TITLE
feat(chat): XEP-0215 ICE injection into LiveKit rtcConfig (#999)

### DIFF
--- a/chat/src/components/calls/CallOverlay.vue
+++ b/chat/src/components/calls/CallOverlay.vue
@@ -72,7 +72,12 @@ watch(
     resetCallControls(active.media.audio, active.media.video);
     try {
       const iceServers = await resolveIceServers();
-      await engine.connect(active.join, { ...active.media, iceServers });
+      // The ICE fetch can block for up to 10s. Re-confirm this is still the
+      // same active call before connecting — a hang-up + redial during the
+      // fetch would otherwise open a LiveKit session against a stale join/sid.
+      const current = state.value;
+      if (current.phase !== "active" || current.sid !== sid) return;
+      await engine.connect(current.join, { ...current.media, iceServers });
       // Capture is best-effort inside connect(): a missing device or a
       // denied mic/cam permission no longer throws — the user joins as a
       // receive-only participant and the engine emits `mediaDevicesError`

--- a/chat/src/components/calls/CallOverlay.vue
+++ b/chat/src/components/calls/CallOverlay.vue
@@ -8,6 +8,7 @@ import {
 } from "@/lib/calls/call-store";
 import type { CallWireSender } from "@/lib/calls/outbound";
 import { useCallEngine } from "@/lib/calls/use-call-engine";
+import { iceServersFromExternalServices } from "@/lib/calls/ice-servers";
 import { connectionStore } from "@/lib/connection-store";
 import {
   $callConnecting,
@@ -42,6 +43,16 @@ function getSender(): CallWireSender | null {
   return (client?.xmpp as CallWireSender | undefined) ?? null;
 }
 
+// XEP-0215: ask our own server for its advertised TURN/STUN before connecting
+// so LiveKit negotiates ICE over the XMPP-native, client-controlled path.
+// Resolves to `[]` on any failure (the wrapper never throws) — the engine then
+// connects with LiveKit's default servers instead of an empty list.
+async function resolveIceServers(): Promise<RTCIceServer[]> {
+  const client = connectionStore.client;
+  if (!client) return [];
+  return iceServersFromExternalServices(await client.fetchExternalServices());
+}
+
 // Connect to LiveKit when a fresh `active` phase appears with a new
 // sid; disconnect on the way out. We key the watcher on the sid as a
 // PRIMITIVE — building an object literal inside the source would
@@ -60,7 +71,8 @@ watch(
     // notice left over from the previous call.
     resetCallControls(active.media.audio, active.media.video);
     try {
-      await engine.connect(active.join, active.media);
+      const iceServers = await resolveIceServers();
+      await engine.connect(active.join, { ...active.media, iceServers });
       // Capture is best-effort inside connect(): a missing device or a
       // denied mic/cam permission no longer throws — the user joins as a
       // receive-only participant and the engine emits `mediaDevicesError`

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -277,6 +277,15 @@ export class CallEngine {
    * one. This bridges that await window.
    */
   private connecting = false;
+  /**
+   * Bumped by every `connect()` and by `disconnect()`. A `connect()` whose
+   * generation no longer matches once `room.connect` resolves was cancelled
+   * mid-flight (a `disconnect()` or newer `connect()` superseded it); it tears
+   * its own `Room` down instead of publishing an orphan. Without this, a
+   * `disconnect()` racing the connect await sees `this.room === null`, returns,
+   * and the in-flight `Room` later connects with nothing left to tear it down.
+   */
+  private connectGeneration = 0;
   private participantAudioVolumes: ParticipantAudioVolumeStore = {};
   private subscribedAudioTracks = new Map<string, Set<VolumeAdjustableTrack>>();
   private listeners: { [K in keyof CallEngineEvents]: Set<CallEngineEvents[K]> } = {
@@ -388,6 +397,7 @@ export class CallEngine {
     // Reserve the engine synchronously now that we're committed to building a
     // Room; cleared on the connect-failure path and once `this.room` is set.
     this.connecting = true;
+    const generation = ++this.connectGeneration;
     const prefs = $devicePrefs.get();
     // Seed the AI-filter desired model from prefs so it re-applies on this
     // call's mic publish; start each call with a clean failure guard and
@@ -426,8 +436,18 @@ export class CallEngine {
       // a clean path. `this.room` was never set so the caller stays
       // on the well-defined "not connected" path.
       room.removeAllListeners();
-      this.connecting = false;
+      // Only release the reservation if it's still ours — a disconnect() or
+      // newer connect() during the await owns `connecting` now.
+      if (this.connectGeneration === generation) this.connecting = false;
       throw err;
+    }
+    // A disconnect() (or a newer connect()) during the await bumped the
+    // generation: this connect was cancelled. Tear our own Room down rather
+    // than publishing it as an orphan that nothing will ever disconnect.
+    if (this.connectGeneration !== generation) {
+      room.removeAllListeners();
+      await room.disconnect().catch(() => undefined);
+      return;
     }
     this.room = room;
     this.connecting = false;
@@ -703,6 +723,11 @@ export class CallEngine {
   }
 
   async disconnect(): Promise<void> {
+    // Cancel any in-flight connect(): bump the generation so a connect still
+    // awaiting `room.connect` tears its own Room down instead of publishing it,
+    // and release the reservation so the engine can never wedge "connecting".
+    this.connectGeneration++;
+    this.connecting = false;
     const room = this.room;
     this.room = null;
     if (!room) return;

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -269,6 +269,14 @@ export type CallEngineEvents = {
  */
 export class CallEngine {
   private room: Room | null = null;
+  /**
+   * True from the start of `connect()` until `this.room` is assigned. The
+   * `this.room` guard alone is set only AFTER `await room.connect`, so two
+   * overlapping `connect()` calls (e.g. a hang-up-and-redial during the
+   * pre-connect ICE fetch) would both pass it and each build a `Room`, leaking
+   * one. This bridges that await window.
+   */
+  private connecting = false;
   private participantAudioVolumes: ParticipantAudioVolumeStore = {};
   private subscribedAudioTracks = new Map<string, Set<VolumeAdjustableTrack>>();
   private listeners: { [K in keyof CallEngineEvents]: Set<CallEngineEvents[K]> } = {
@@ -367,7 +375,7 @@ export class CallEngine {
     join: LiveKitJoin,
     opts: { audio: boolean; video: boolean; iceServers?: RTCIceServer[] },
   ): Promise<void> {
-    if (this.room) throw new Error("CallEngine already connected");
+    if (this.room || this.connecting) throw new Error("CallEngine already connected");
     // Defensive pre-flight: confirm the JWT actually carries a usable
     // `video` grant (roomJoin + a room) before the SDK opens its
     // WebSocket. A mismatched / misconfigured token otherwise fails
@@ -377,6 +385,9 @@ export class CallEngine {
     if (!grant.ok) {
       throw new Error(`Invalid LiveKit join token: ${grant.reason}`);
     }
+    // Reserve the engine synchronously now that we're committed to building a
+    // Room; cleared on the connect-failure path and once `this.room` is set.
+    this.connecting = true;
     const prefs = $devicePrefs.get();
     // Seed the AI-filter desired model from prefs so it re-applies on this
     // call's mic publish; start each call with a clean failure guard and
@@ -415,9 +426,11 @@ export class CallEngine {
       // a clean path. `this.room` was never set so the caller stays
       // on the well-defined "not connected" path.
       room.removeAllListeners();
+      this.connecting = false;
       throw err;
     }
     this.room = room;
+    this.connecting = false;
     // Emit the initial participant snapshot so subscribers can seed
     // their projection without missing peers that connected before
     // our listeners attached.

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -14,6 +14,8 @@ import {
   type RemoteTrackPublication,
   type TrackPublication,
   type AudioCaptureOptions,
+  type RoomConnectOptions,
+  type RoomOptions,
   type TrackPublishOptions,
   type VideoCaptureOptions,
 } from "livekit-client";
@@ -314,13 +316,21 @@ export class CallEngine {
    * incapable devices without real WebRTC.
    */
   private readonly codecSupport: VideoCodecSupport;
+  /**
+   * Builds the LiveKit `Room`; injectable so tests can assert the connect
+   * options (notably the XEP-0215 `rtcConfig.iceServers`) without a real
+   * `RTCPeerConnection`, which `new Room()` reaches for at construction.
+   */
+  private readonly makeRoom: (options: RoomOptions) => Room;
 
   constructor(opts?: {
     makeAiNoiseProcessor?: (model: NoiseModelId) => Promise<AudioNoiseProcessor>;
     videoCodecSupport?: VideoCodecSupport;
+    makeRoom?: (options: RoomOptions) => Room;
   }) {
     this.makeAiNoiseProcessor = opts?.makeAiNoiseProcessor ?? makeNoiseProcessor;
     this.codecSupport = opts?.videoCodecSupport ?? videoCodecSupport(currentVideoCodecSupportEnv());
+    this.makeRoom = opts?.makeRoom ?? ((options) => new Room(options));
   }
 
   /** LiveKit identity of the local participant, populated once
@@ -353,7 +363,10 @@ export class CallEngine {
     return this.room?.canPlaybackAudio ?? true;
   }
 
-  async connect(join: LiveKitJoin, opts: { audio: boolean; video: boolean }): Promise<void> {
+  async connect(
+    join: LiveKitJoin,
+    opts: { audio: boolean; video: boolean; iceServers?: RTCIceServer[] },
+  ): Promise<void> {
     if (this.room) throw new Error("CallEngine already connected");
     // Defensive pre-flight: confirm the JWT actually carries a usable
     // `video` grant (roomJoin + a room) before the SDK opens its
@@ -371,7 +384,7 @@ export class CallEngine {
     this.desiredAiNoiseModel = prefs.aiNoiseModel;
     this.aiNoiseFailedModels.clear();
     this.appliedModelActiveForCapture = false;
-    const room = new Room(callRoomOptionsForPrefs(prefs));
+    const room = this.makeRoom(callRoomOptionsForPrefs(prefs));
     room.on(RoomEvent.TrackSubscribed, this.handleTrackSubscribed);
     room.on(RoomEvent.TrackUnsubscribed, this.handleTrackUnsubscribed);
     room.on(RoomEvent.LocalTrackPublished, this.handleLocalTrackPublished);
@@ -385,8 +398,16 @@ export class CallEngine {
     room.on(RoomEvent.TrackUnmuted, this.handleTrackMuteChanged);
     room.on(RoomEvent.ConnectionQualityChanged, this.handleConnectionQualityChanged);
     room.on(RoomEvent.ConnectionStateChanged, this.handleConnectionStateChanged);
+    // XEP-0215 ICE injection: when the server advertised external services,
+    // make them the authoritative ICE list via `rtcConfig`. An empty/absent
+    // list means "no advertisement" — pass no `rtcConfig` so LiveKit keeps its
+    // own signalling-provided servers rather than connecting with none.
+    const connectOptions: RoomConnectOptions | undefined =
+      opts.iceServers && opts.iceServers.length > 0
+        ? { rtcConfig: { iceServers: opts.iceServers } }
+        : undefined;
     try {
-      await room.connect(join.url, join.token);
+      await room.connect(join.url, join.token, connectOptions);
     } catch (err) {
       // Connect itself failed; the listeners we bound above would
       // otherwise dangle on a `Room` that nothing references but the

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -394,10 +394,6 @@ export class CallEngine {
     if (!grant.ok) {
       throw new Error(`Invalid LiveKit join token: ${grant.reason}`);
     }
-    // Reserve the engine synchronously now that we're committed to building a
-    // Room; cleared on the connect-failure path and once `this.room` is set.
-    this.connecting = true;
-    const generation = ++this.connectGeneration;
     const prefs = $devicePrefs.get();
     // Seed the AI-filter desired model from prefs so it re-applies on this
     // call's mic publish; start each call with a clean failure guard and
@@ -427,6 +423,12 @@ export class CallEngine {
       opts.iceServers && opts.iceServers.length > 0
         ? { rtcConfig: { iceServers: opts.iceServers } }
         : undefined;
+    // Reserve the engine now — AFTER the synchronous setup above, which can
+    // throw (`makeRoom`/`callRoomOptionsForPrefs` reach for WebRTC globals).
+    // There is no `await` between here and the guard at the top, so this still
+    // closes the concurrent-connect window without risking a stuck flag.
+    this.connecting = true;
+    const generation = ++this.connectGeneration;
     try {
       await room.connect(join.url, join.token, connectOptions);
     } catch (err) {

--- a/chat/src/lib/calls/ice-servers.ts
+++ b/chat/src/lib/calls/ice-servers.ts
@@ -1,0 +1,81 @@
+import type { ExternalService } from "./types";
+
+const SERVICE_TYPES = new Set<ExternalService["serviceType"]>(["stun", "turn", "turns"]);
+const TRANSPORTS = new Set<NonNullable<ExternalService["transport"]>>(["udp", "tcp"]);
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * Validate the untyped value returned across the WASM boundary by
+ * `fetch_external_services` into typed [`ExternalService`] entries, dropping
+ * anything malformed. Defends against bundle drift (a Rust-side shape change
+ * shipping ahead of the chat) the same way `fetchVapidPublicKey` hard-checks
+ * its boundary — an entry the chat can't model is skipped, never trusted.
+ */
+export function coerceExternalServices(raw: unknown): ExternalService[] {
+  if (!Array.isArray(raw)) return [];
+  const services: ExternalService[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const candidate = entry as Record<string, unknown>;
+    const serviceType = candidate.serviceType;
+    if (typeof serviceType !== "string" || !SERVICE_TYPES.has(serviceType as ExternalService["serviceType"])) {
+      continue;
+    }
+    if (typeof candidate.host !== "string" || typeof candidate.port !== "number") continue;
+    const transport =
+      typeof candidate.transport === "string" && TRANSPORTS.has(candidate.transport as never)
+        ? (candidate.transport as ExternalService["transport"])
+        : undefined;
+    services.push({
+      serviceType: serviceType as ExternalService["serviceType"],
+      host: candidate.host,
+      port: candidate.port,
+      transport,
+      username: optionalString(candidate.username),
+      password: optionalString(candidate.password),
+      expires: optionalString(candidate.expires),
+      restricted: candidate.restricted === true,
+    });
+  }
+  return services;
+}
+
+/**
+ * Map XEP-0215 external services (from the WASM client's
+ * `fetch_external_services`) to the `RTCIceServer[]` LiveKit accepts in its
+ * connection `rtcConfig.iceServers`.
+ *
+ * Per-type URI scheme (RFC 7064/7065):
+ *   - `stun`  → `stun:host:port`            (no credentials)
+ *   - `turn`  → `turn:host:port[?transport]` (username + credential)
+ *   - `turns` → `turns:host:port[?transport]` (TLS-protected TURN)
+ *
+ * A TURN/TURNS entry without both `username` and `password` is dropped: a relay
+ * the client cannot authenticate to is unusable and would only add ICE
+ * gathering latency. STUN entries never carry credentials.
+ */
+export function iceServersFromExternalServices(
+  services: ReadonlyArray<ExternalService>,
+): RTCIceServer[] {
+  const iceServers: RTCIceServer[] = [];
+  for (const service of services) {
+    if (service.serviceType === "stun") {
+      // STUN URIs take no `?transport` parameter (RFC 7064) and never carry
+      // credentials.
+      iceServers.push({ urls: `stun:${service.host}:${service.port}` });
+      continue;
+    }
+    // turn / turns require credentials to be usable as a relay.
+    if (service.username === undefined || service.password === undefined) {
+      continue;
+    }
+    // The `?transport` parameter is turn-specific (RFC 7065).
+    const transportQuery = service.transport ? `?transport=${service.transport}` : "";
+    const urls = `${service.serviceType}:${service.host}:${service.port}${transportQuery}`;
+    iceServers.push({ urls, username: service.username, credential: service.password });
+  }
+  return iceServers;
+}

--- a/chat/src/lib/calls/ice-servers.ts
+++ b/chat/src/lib/calls/ice-servers.ts
@@ -24,7 +24,9 @@ export function coerceExternalServices(raw: unknown): ExternalService[] {
     if (typeof serviceType !== "string" || !SERVICE_TYPES.has(serviceType as ExternalService["serviceType"])) {
       continue;
     }
-    if (typeof candidate.host !== "string" || typeof candidate.port !== "number") continue;
+    if (typeof candidate.host !== "string") continue;
+    // `port` is optional (XEP-0215); accept a number, ignore anything else.
+    const port = typeof candidate.port === "number" ? candidate.port : undefined;
     const transport =
       typeof candidate.transport === "string" && TRANSPORTS.has(candidate.transport as never)
         ? (candidate.transport as ExternalService["transport"])
@@ -32,7 +34,7 @@ export function coerceExternalServices(raw: unknown): ExternalService[] {
     services.push({
       serviceType: serviceType as ExternalService["serviceType"],
       host: candidate.host,
-      port: candidate.port,
+      port,
       transport,
       username: optionalString(candidate.username),
       password: optionalString(candidate.password),
@@ -62,10 +64,11 @@ export function iceServersFromExternalServices(
 ): RTCIceServer[] {
   const iceServers: RTCIceServer[] = [];
   for (const service of services) {
+    const hostPort = formatHostPort(service.host, service.port);
     if (service.serviceType === "stun") {
       // STUN URIs take no `?transport` parameter (RFC 7064) and never carry
       // credentials.
-      iceServers.push({ urls: `stun:${service.host}:${service.port}` });
+      iceServers.push({ urls: `stun:${hostPort}` });
       continue;
     }
     // turn / turns require credentials to be usable as a relay.
@@ -74,8 +77,18 @@ export function iceServersFromExternalServices(
     }
     // The `?transport` parameter is turn-specific (RFC 7065).
     const transportQuery = service.transport ? `?transport=${service.transport}` : "";
-    const urls = `${service.serviceType}:${service.host}:${service.port}${transportQuery}`;
+    const urls = `${service.serviceType}:${hostPort}${transportQuery}`;
     iceServers.push({ urls, username: service.username, credential: service.password });
   }
   return iceServers;
+}
+
+/**
+ * Build the `host[:port]` portion of an ICE URI. IPv6 literals (which contain
+ * `:`) MUST be bracketed (RFC 3986 / RFC 7064) so the port colon is
+ * unambiguous; a missing port is omitted so the scheme default applies.
+ */
+function formatHostPort(host: string, port?: number): string {
+  const bracketed = host.includes(":") ? `[${host}]` : host;
+  return port === undefined ? bracketed : `${bracketed}:${port}`;
 }

--- a/chat/src/lib/calls/types.ts
+++ b/chat/src/lib/calls/types.ts
@@ -16,6 +16,27 @@ export type LiveKitJoin = {
   token: string;
 };
 
+/**
+ * One XEP-0215 external service (TURN/STUN) advertised by the server,
+ * surfaced by the WASM client's `fetch_external_services`. Mirrors
+ * `WaddleExternalService` in
+ * `server/crates/waddle-xmpp-client-wasm/src/types.rs`. The chat maps an array
+ * of these to `RTCIceServer[]` for LiveKit's connection `rtcConfig`.
+ *
+ * `serviceType: "turns"` is TLS-protected TURN (XEP-0215 §3.6.5); credentials
+ * are present only on `turn`/`turns` entries.
+ */
+export type ExternalService = {
+  serviceType: "stun" | "turn" | "turns";
+  host: string;
+  port: number;
+  transport?: "udp" | "tcp";
+  username?: string;
+  password?: string;
+  expires?: string;
+  restricted: boolean;
+};
+
 type CallEventEnvelope = {
   from: string;
   to?: string | null;

--- a/chat/src/lib/calls/types.ts
+++ b/chat/src/lib/calls/types.ts
@@ -29,7 +29,8 @@ export type LiveKitJoin = {
 export type ExternalService = {
   serviceType: "stun" | "turn" | "turns";
   host: string;
-  port: number;
+  /** RECOMMENDED but optional in XEP-0215; omitted ⇒ ICE URI uses the scheme default. */
+  port?: number;
   transport?: "udp" | "tcp";
   username?: string;
   password?: string;

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -26,7 +26,8 @@ import {
 import { clearAllLiveCallParticipants } from "@/lib/calls/muc-call-live-participants";
 import { useCallEngine } from "@/lib/calls/use-call-engine";
 import type { CallWireSender } from "@/lib/calls/outbound";
-import type { CallEvent } from "@/lib/calls/types";
+import type { CallEvent, ExternalService } from "@/lib/calls/types";
+import { coerceExternalServices } from "@/lib/calls/ice-servers";
 import { barePeerJid, fullJidIdentityKey, jidDomain, roomBareJidFor } from "./jid";
 import type {
   ChatStateEvent,
@@ -2245,6 +2246,68 @@ export class BrowserXmppClient {
       }
       console.warn("[xmpp] fetch_vapid_public_key IQ rejected:", error);
       return null;
+    } finally {
+      if (timeoutHandle !== null) clearTimeout(timeoutHandle);
+    }
+  }
+
+  /**
+   * Fetch the XEP-0215 (`urn:xmpp:extdisco:2`) external services — TURN/STUN —
+   * the user's own server advertises, so a call can inject them into LiveKit's
+   * connection `rtcConfig.iceServers` (an XMPP-native, client-controlled ICE
+   * path).
+   *
+   * Returns `[]` on EVERY failure mode — never throws — because the caller's
+   * fallback is identical in all of them: connect without an `rtcConfig` and
+   * let LiveKit use its own signalling-provided ICE servers. Each path emits a
+   * precise `console.warn` for diagnostics:
+   *   - session not ready (mid-reconnect / mid-teardown race)
+   *   - the wasm `fetch_external_services` method is missing (older bundle)
+   *   - the IQ times out after 10s
+   *   - the IQ is rejected (transport / stanza error)
+   *   - the JS-boundary value is not an array (regression on the Rust side)
+   *
+   * Empty is also the correct success value when the server advertises no
+   * services — the caller must not connect with an empty ICE list (that would
+   * REPLACE LiveKit's servers with nothing), so `[]` deliberately collapses
+   * "none advertised" and "fetch failed" into the same fall-back action.
+   */
+  async fetchExternalServices(): Promise<ExternalService[]> {
+    // Bounded timeout (10s): the wasm-side `send_iq_command` is an unbounded
+    // oneshot, and this fetch sits on the call-connect critical path — a
+    // stalled server handler must not hang the join.
+    const TIMEOUT_MS = 10_000;
+    let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+    let timedOut = false;
+    const timeoutSentinel = Symbol("extdisco-fetch-timeout");
+    const timeoutPromise = new Promise<typeof timeoutSentinel>((resolve) => {
+      timeoutHandle = setTimeout(() => {
+        timedOut = true;
+        resolve(timeoutSentinel);
+      }, TIMEOUT_MS);
+    });
+    try {
+      const xmpp = await this.requireConnectedXmpp();
+      if (!xmpp.fetch_external_services) {
+        console.warn(
+          "[xmpp] fetch_external_services is unavailable (older wasm bundle?); " +
+          "calls will use LiveKit's default ICE servers",
+        );
+        return [];
+      }
+      const result = await Promise.race([xmpp.fetch_external_services(), timeoutPromise]);
+      if (result === timeoutSentinel) {
+        console.warn(
+          `[xmpp] fetch_external_services timed out after ${TIMEOUT_MS}ms; ` +
+          "connecting with LiveKit's default ICE servers.",
+        );
+        return [];
+      }
+      return coerceExternalServices(result);
+    } catch (error) {
+      if (timedOut) return [];
+      console.warn("[xmpp] fetch_external_services IQ rejected:", error);
+      return [];
     } finally {
       if (timeoutHandle !== null) clearTimeout(timeoutHandle);
     }

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -2308,6 +2308,17 @@ export class BrowserXmppClient {
         );
         return [];
       }
+      if (!Array.isArray(result)) {
+        // Bundle drift: the wasm method's signature is `Promise<any>`, so a
+        // Rust-side shape regression would otherwise fall through silently.
+        // Surface it (mirrors `fetchVapidPublicKey`'s shape hard-check).
+        console.warn(
+          "[xmpp] fetch_external_services returned a non-array value; " +
+          "connecting with LiveKit's default ICE servers:",
+          result,
+        );
+        return [];
+      }
       return coerceExternalServices(result);
     } catch (error) {
       if (timedOut) return [];

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -2295,7 +2295,12 @@ export class BrowserXmppClient {
         );
         return [];
       }
-      const result = await Promise.race([xmpp.fetch_external_services(), timeoutPromise]);
+      const fetchPromise = xmpp.fetch_external_services();
+      // If the timeout wins the race, the IQ promise settles unobserved later.
+      // Attach a no-op catch so a late rejection never surfaces as an
+      // unhandledrejection (the race below still handles a rejection that wins).
+      fetchPromise.catch(() => {});
+      const result = await Promise.race([fetchPromise, timeoutPromise]);
       if (result === timeoutSentinel) {
         console.warn(
           `[xmpp] fetch_external_services timed out after ${TIMEOUT_MS}ms; ` +

--- a/chat/tests/call-ice-config.test.ts
+++ b/chat/tests/call-ice-config.test.ts
@@ -90,4 +90,43 @@ describe("CallEngine.connect — XEP-0215 ICE injection", () => {
 
     expect(room.connectCalls[0].opts).toBeUndefined();
   });
+
+  test("rejects a second concurrent connect before the first resolves, building only one Room", async () => {
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let roomsBuilt = 0;
+    const makeRoom = () => {
+      roomsBuilt += 1;
+      const room = {
+        on() {
+          return room;
+        },
+        removeAllListeners() {},
+        async connect() {
+          await gate; // hold the connect open to overlap a second call
+        },
+        localParticipant: {
+          identity: "alice@waddle.test/desktop",
+          async setMicrophoneEnabled() {},
+          async setCameraEnabled() {},
+        },
+        remoteParticipants: new Map(),
+      };
+      return room as unknown as Room;
+    };
+    const engine = new CallEngine({
+      makeRoom,
+      videoCodecSupport: videoCodecSupport({ encode: ["video/vp8"], decode: ["video/vp8"] }),
+    });
+
+    const first = engine.connect(join(), { audio: false, video: false });
+    await expect(engine.connect(join(), { audio: false, video: false })).rejects.toThrow(
+      "already connected",
+    );
+    release();
+    await first;
+    expect(roomsBuilt).toBe(1);
+  });
 });

--- a/chat/tests/call-ice-config.test.ts
+++ b/chat/tests/call-ice-config.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import type { Room, RoomConnectOptions, RoomOptions } from "livekit-client";
+import { CallEngine } from "../src/lib/calls/engine";
+import { videoCodecSupport } from "../src/lib/calls/video-codec/support";
+import type { LiveKitJoin } from "../src/lib/calls/types";
+
+// Minimal base64url JWT carrying a valid LiveKit video grant so the engine's
+// `validateLiveKitGrant` pre-flight passes before `room.connect`.
+function base64url(value: object): string {
+  return btoa(JSON.stringify(value))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function joinToken(): string {
+  const header = base64url({ alg: "HS256", typ: "JWT" });
+  const payload = base64url({ video: { roomJoin: true, room: "alice@waddle.test::c1" } });
+  return `${header}.${payload}.sig`;
+}
+
+function join(): LiveKitJoin {
+  return {
+    url: "wss://livekit.waddle.test",
+    room: "alice@waddle.test::c1",
+    identity: "alice@waddle.test/desktop",
+    token: joinToken(),
+  };
+}
+
+/**
+ * Records every `room.connect(...)` call so the test can assert what the engine
+ * forwards. Provides only the surface `CallEngine.connect` touches.
+ */
+function stubRoom() {
+  const connectCalls: Array<{ url: string; token: string; opts?: RoomConnectOptions }> = [];
+  const room = {
+    connectCalls,
+    on() {
+      return room;
+    },
+    removeAllListeners() {},
+    async connect(url: string, token: string, opts?: RoomConnectOptions) {
+      connectCalls.push({ url, token, opts });
+    },
+    localParticipant: {
+      identity: "alice@waddle.test/desktop",
+      async setMicrophoneEnabled() {},
+      async setCameraEnabled() {},
+    },
+    remoteParticipants: new Map(),
+  };
+  return room;
+}
+
+function engineWith(room: ReturnType<typeof stubRoom>) {
+  return new CallEngine({
+    makeRoom: (_options: RoomOptions) => room as unknown as Room,
+    videoCodecSupport: videoCodecSupport({ encode: ["video/vp8"], decode: ["video/vp8"] }),
+  });
+}
+
+const iceServers: RTCIceServer[] = [
+  { urls: "turns:turn.waddle.social:443?transport=tcp", username: "u", credential: "p" },
+  { urls: "stun:turn.waddle.social:3478" },
+];
+
+describe("CallEngine.connect — XEP-0215 ICE injection", () => {
+  test("passes the mapped iceServers via rtcConfig at connect", async () => {
+    const room = stubRoom();
+    await engineWith(room).connect(join(), { audio: false, video: false, iceServers });
+
+    expect(room.connectCalls).toHaveLength(1);
+    const { url, token, opts } = room.connectCalls[0];
+    expect(url).toBe("wss://livekit.waddle.test");
+    expect(token).toBe(joinToken());
+    expect(opts?.rtcConfig?.iceServers).toEqual(iceServers);
+  });
+
+  test("omits rtcConfig when no iceServers are supplied (LiveKit defaults)", async () => {
+    const room = stubRoom();
+    await engineWith(room).connect(join(), { audio: false, video: false });
+
+    expect(room.connectCalls[0].opts).toBeUndefined();
+  });
+
+  test("omits rtcConfig when the iceServers list is empty (fall back, never replace with nothing)", async () => {
+    const room = stubRoom();
+    await engineWith(room).connect(join(), { audio: false, video: false, iceServers: [] });
+
+    expect(room.connectCalls[0].opts).toBeUndefined();
+  });
+});

--- a/chat/tests/call-ice-config.test.ts
+++ b/chat/tests/call-ice-config.test.ts
@@ -129,4 +129,49 @@ describe("CallEngine.connect — XEP-0215 ICE injection", () => {
     await first;
     expect(roomsBuilt).toBe(1);
   });
+
+  test("a disconnect during connect cancels it (no wedge, no orphaned Room)", async () => {
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let built = 0;
+    let roomsDisconnected = 0;
+    const makeRoom = () => {
+      built += 1;
+      const room = {
+        on() {
+          return room;
+        },
+        removeAllListeners() {},
+        async connect() {
+          await gate;
+        },
+        async disconnect() {
+          roomsDisconnected += 1;
+        },
+        localParticipant: {
+          identity: "alice@waddle.test/desktop",
+          async setMicrophoneEnabled() {},
+          async setCameraEnabled() {},
+        },
+        remoteParticipants: new Map(),
+      };
+      return room as unknown as Room;
+    };
+    const engine = new CallEngine({
+      makeRoom,
+      videoCodecSupport: videoCodecSupport({ encode: ["video/vp8"], decode: ["video/vp8"] }),
+    });
+
+    const first = engine.connect(join(), { audio: false, video: false });
+    await engine.disconnect(); // cancel mid-connect, before the Room is published
+    release();
+    await first; // resolves but must abandon (tear down) its Room, not publish it
+    expect(roomsDisconnected).toBe(1);
+
+    // The engine is not wedged: a fresh connect proceeds (gate already resolved).
+    await engine.connect(join(), { audio: false, video: false });
+    expect(built).toBe(2);
+  });
 });

--- a/chat/tests/ice-servers.test.ts
+++ b/chat/tests/ice-servers.test.ts
@@ -80,6 +80,20 @@ describe("iceServersFromExternalServices", () => {
   test("returns an empty array for empty input", () => {
     expect(iceServersFromExternalServices([])).toEqual([]);
   });
+
+  test("brackets IPv6 literal hosts in the URI", () => {
+    const [turnsServer] = iceServersFromExternalServices([turns({ host: "2001:db8::1" })]);
+    expect(turnsServer.urls).toBe("turns:[2001:db8::1]:443?transport=tcp");
+    const [stunServer] = iceServersFromExternalServices([stun({ host: "2001:db8::1" })]);
+    expect(stunServer.urls).toBe("stun:[2001:db8::1]:3478");
+  });
+
+  test("omits the port from the URI when the service has none", () => {
+    const [stunServer] = iceServersFromExternalServices([stun({ port: undefined })]);
+    expect(stunServer.urls).toBe("stun:turn.waddle.social");
+    const [turnsServer] = iceServersFromExternalServices([turns({ port: undefined })]);
+    expect(turnsServer.urls).toBe("turns:turn.waddle.social?transport=tcp");
+  });
 });
 
 describe("coerceExternalServices", () => {
@@ -108,11 +122,10 @@ describe("coerceExternalServices", () => {
     expect(services[1]).toMatchObject({ serviceType: "stun", port: 3478 });
   });
 
-  test("drops entries with an unknown type or missing/ill-typed host/port", () => {
+  test("drops entries with an unknown type or missing host", () => {
     const services = coerceExternalServices([
       { serviceType: "ftp", host: "ftp.waddle.social", port: 21, restricted: false },
       { serviceType: "stun", port: 3478, restricted: false },
-      { serviceType: "stun", host: "turn.waddle.social", port: "3478", restricted: false },
       { serviceType: "stun", host: "turn.waddle.social", port: 3478, restricted: false },
     ]);
     expect(services).toHaveLength(1);
@@ -124,5 +137,15 @@ describe("coerceExternalServices", () => {
       { serviceType: "stun", host: "turn.waddle.social", port: 3478, transport: "sctp", restricted: false },
     ]);
     expect(service.transport).toBeUndefined();
+  });
+
+  test("keeps an entry with an omitted or ill-typed port (port becomes undefined)", () => {
+    const services = coerceExternalServices([
+      { serviceType: "stun", host: "a.waddle.social", restricted: false },
+      { serviceType: "stun", host: "b.waddle.social", port: "3478", restricted: false },
+    ]);
+    expect(services).toHaveLength(2);
+    expect(services[0].port).toBeUndefined();
+    expect(services[1].port).toBeUndefined();
   });
 });

--- a/chat/tests/ice-servers.test.ts
+++ b/chat/tests/ice-servers.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+import {
+  coerceExternalServices,
+  iceServersFromExternalServices,
+} from "../src/lib/calls/ice-servers";
+import type { ExternalService } from "../src/lib/calls/types";
+
+function stun(over: Partial<ExternalService> = {}): ExternalService {
+  return {
+    serviceType: "stun",
+    host: "turn.waddle.social",
+    port: 3478,
+    transport: "udp",
+    restricted: false,
+    ...over,
+  };
+}
+
+function turns(over: Partial<ExternalService> = {}): ExternalService {
+  return {
+    serviceType: "turns",
+    host: "turn.waddle.social",
+    port: 443,
+    transport: "tcp",
+    username: "1700000000:alice@waddle.social/desktop",
+    password: "base64hmac==",
+    expires: "2026-06-17T12:00:00Z",
+    restricted: true,
+    ...over,
+  };
+}
+
+describe("iceServersFromExternalServices", () => {
+  test("maps a STUN entry to a stun: URL with no credentials", () => {
+    const [server, ...rest] = iceServersFromExternalServices([stun()]);
+    expect(rest).toHaveLength(0);
+    expect(server.urls).toBe("stun:turn.waddle.social:3478");
+    expect(server.username).toBeUndefined();
+    expect(server.credential).toBeUndefined();
+  });
+
+  test("maps a TLS-TURN entry to a turns: URL with credentials and transport", () => {
+    const [server] = iceServersFromExternalServices([turns()]);
+    expect(server.urls).toBe("turns:turn.waddle.social:443?transport=tcp");
+    expect(server.username).toBe("1700000000:alice@waddle.social/desktop");
+    expect(server.credential).toBe("base64hmac==");
+  });
+
+  test("maps a plain TURN entry with udp transport", () => {
+    const [server] = iceServersFromExternalServices([
+      turns({ serviceType: "turn", port: 3478, transport: "udp" }),
+    ]);
+    expect(server.urls).toBe("turn:turn.waddle.social:3478?transport=udp");
+    expect(server.credential).toBe("base64hmac==");
+  });
+
+  test("omits the transport query when transport is absent", () => {
+    const [server] = iceServersFromExternalServices([
+      turns({ serviceType: "turn", transport: undefined }),
+    ]);
+    expect(server.urls).toBe("turn:turn.waddle.social:443");
+  });
+
+  test("skips a TURN entry missing credentials (unusable as a relay)", () => {
+    const servers = iceServersFromExternalServices([
+      turns({ username: undefined }),
+      turns({ password: undefined }),
+    ]);
+    expect(servers).toHaveLength(0);
+  });
+
+  test("preserves order across a mixed server list", () => {
+    const servers = iceServersFromExternalServices([turns(), stun()]);
+    expect(servers.map((s) => s.urls)).toEqual([
+      "turns:turn.waddle.social:443?transport=tcp",
+      "stun:turn.waddle.social:3478",
+    ]);
+  });
+
+  test("returns an empty array for empty input", () => {
+    expect(iceServersFromExternalServices([])).toEqual([]);
+  });
+});
+
+describe("coerceExternalServices", () => {
+  test("returns an empty array for non-array input (older bundle / shape drift)", () => {
+    expect(coerceExternalServices(null)).toEqual([]);
+    expect(coerceExternalServices(undefined)).toEqual([]);
+    expect(coerceExternalServices({ serviceType: "stun" })).toEqual([]);
+  });
+
+  test("keeps well-formed entries and preserves credentials + restricted", () => {
+    const services = coerceExternalServices([
+      {
+        serviceType: "turns",
+        host: "turn.waddle.social",
+        port: 443,
+        transport: "tcp",
+        username: "u",
+        password: "p",
+        expires: "2026-06-17T12:00:00Z",
+        restricted: true,
+      },
+      { serviceType: "stun", host: "turn.waddle.social", port: 3478, transport: "udp", restricted: false },
+    ]);
+    expect(services).toHaveLength(2);
+    expect(services[0]).toMatchObject({ serviceType: "turns", username: "u", password: "p", restricted: true });
+    expect(services[1]).toMatchObject({ serviceType: "stun", port: 3478 });
+  });
+
+  test("drops entries with an unknown type or missing/ill-typed host/port", () => {
+    const services = coerceExternalServices([
+      { serviceType: "ftp", host: "ftp.waddle.social", port: 21, restricted: false },
+      { serviceType: "stun", port: 3478, restricted: false },
+      { serviceType: "stun", host: "turn.waddle.social", port: "3478", restricted: false },
+      { serviceType: "stun", host: "turn.waddle.social", port: 3478, restricted: false },
+    ]);
+    expect(services).toHaveLength(1);
+    expect(services[0].host).toBe("turn.waddle.social");
+  });
+
+  test("drops an ill-typed transport but keeps the entry", () => {
+    const [service] = coerceExternalServices([
+      { serviceType: "stun", host: "turn.waddle.social", port: 3478, transport: "sctp", restricted: false },
+    ]);
+    expect(service.transport).toBeUndefined();
+  });
+});

--- a/server/crates/waddle-xmpp-client-wasm/src/client_calls.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_calls.rs
@@ -309,13 +309,7 @@ impl WaddleClient {
         let inner = self.inner.clone();
         future_to_promise(async move {
             let initiator = stored_full_jid(&inner)?;
-            let initiator_bare = initiator.to_bare().to_string();
-            let server_domain = initiator_bare
-                .split('@')
-                .next_back()
-                .map(str::to_owned)
-                .ok_or_else(|| js_error("authenticated JID has no domain"))?;
-            let mixer = calls_mixer_jid(&server_domain);
+            let mixer = calls_mixer_jid(initiator.domain().as_str());
 
             let sid = sid(sid_str);
             let jingle = build_muji_session_initiate(&sid, &initiator, &room_jid, video);
@@ -349,12 +343,7 @@ impl WaddleClient {
     pub fn fetch_external_services(&self) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
-            let initiator_bare = stored_full_jid(&inner)?.to_bare().to_string();
-            let server_domain = initiator_bare
-                .split('@')
-                .next_back()
-                .map(str::to_owned)
-                .ok_or_else(|| js_error("authenticated JID has no domain"))?;
+            let server_domain = stored_full_jid(&inner)?.domain().to_string();
             let request_id = uuid::Uuid::new_v4().to_string();
             let iq = waddle_xmpp_client::xep::xep0215::build_extdisco_services_iq(
                 &server_domain,
@@ -400,14 +389,7 @@ impl WaddleClient {
     pub fn send_muji_session_terminate(&self, room_jid: String, sid_str: String) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
-            let full_jid = stored_full_jid(&inner)?;
-            let bare_jid = full_jid.to_bare().to_string();
-            let server_domain = bare_jid
-                .split('@')
-                .next_back()
-                .map(str::to_owned)
-                .ok_or_else(|| js_error("authenticated JID has no domain"))?;
-            let mixer = calls_mixer_jid(&server_domain);
+            let mixer = calls_mixer_jid(stored_full_jid(&inner)?.domain().as_str());
 
             let jingle = build_muji_session_terminate(&room_jid, &sid(sid_str));
             let stanza = Element::builder("iq", NS_JABBER_CLIENT)

--- a/server/crates/waddle-xmpp-client-wasm/src/client_calls.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_calls.rs
@@ -341,6 +341,46 @@ impl WaddleClient {
         })
     }
 
+    /// XEP-0215 §3.2: fetch the external services (TURN/STUN) the user's own
+    /// server advertises, resolving to a typed array the chat maps to
+    /// `RTCIceServer[]` for LiveKit's `rtcConfig` at connect time. The query is
+    /// addressed to the authenticated user's server domain; an empty
+    /// `<services/>` requests every advertised service type.
+    pub fn fetch_external_services(&self) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let initiator_bare = stored_full_jid(&inner)?.to_bare().to_string();
+            let server_domain = initiator_bare
+                .split('@')
+                .next_back()
+                .map(str::to_owned)
+                .ok_or_else(|| js_error("authenticated JID has no domain"))?;
+            let request_id = uuid::Uuid::new_v4().to_string();
+            let iq = waddle_xmpp_client::xep::xep0215::build_extdisco_services_iq(
+                &server_domain,
+                &request_id,
+            );
+            let result = send_iq_command(inner, iq).await?;
+            // Defense-in-depth (RFC 6120 §8.1.2.1): if the reply stamps a
+            // `from`, it MUST be our own server. An absent `from` is acceptable
+            // for a reply from one's own bare server — the IQ id correlation in
+            // `send_iq_command` already pins the response.
+            if let Some(from) = result.attr("from") {
+                if !from.eq_ignore_ascii_case(&server_domain) {
+                    return Err(js_error(format!(
+                        "extdisco services reply `from` {from:?} does not match queried server {server_domain:?}"
+                    )));
+                }
+            }
+            let services: Vec<WaddleExternalService> =
+                waddle_xmpp_client::xep::xep0215::parse_external_services(&result)
+                    .into_iter()
+                    .map(WaddleExternalService::from)
+                    .collect();
+            to_js_value(&services)
+        })
+    }
+
     /// Send a XEP-0272 Muji-bearing Jingle `session-terminate` IQ
     /// to the SFU mixer (`calls.<server-domain>`). Server
     /// unregisters the participant + revokes every jti it minted

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -358,7 +358,8 @@ pub struct WaddleExternalService {
     #[serde(rename = "serviceType")]
     pub service_type: &'static str,
     pub host: String,
-    pub port: u16,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub port: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transport: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -379,7 +380,9 @@ impl From<waddle_xmpp_client::xep::xep0215::ExternalService> for WaddleExternalS
             transport: service.transport.map(|t| t.as_str()),
             username: service.username,
             password: service.password,
-            expires: service.expires,
+            // Serialize the typed expiry back to an RFC 3339 string for JSON
+            // transit (the JS-facing boundary).
+            expires: service.expires.map(|expires| expires.to_rfc3339()),
             restricted: service.restricted,
         }
     }
@@ -1197,11 +1200,13 @@ mod tests {
         let surfaced = WaddleExternalService::from(ExternalService {
             service_type: ExternalServiceType::Turns,
             host: "turn.waddle.social".into(),
-            port: 443,
+            port: Some(443),
             transport: Some(ExternalServiceTransport::Tcp),
             username: Some("u".into()),
             password: Some("p".into()),
-            expires: Some("2026-06-17T12:00:00Z".into()),
+            expires: Some(
+                chrono::DateTime::parse_from_rfc3339("2026-06-17T12:00:00Z").expect("rfc3339"),
+            ),
             restricted: true,
         });
         let json = serde_json::to_value(&surfaced).expect("serialize");
@@ -1211,7 +1216,7 @@ mod tests {
         assert_eq!(json["transport"], "tcp");
         assert_eq!(json["username"], "u");
         assert_eq!(json["password"], "p");
-        assert_eq!(json["expires"], "2026-06-17T12:00:00Z");
+        assert_eq!(json["expires"], "2026-06-17T12:00:00+00:00");
         assert_eq!(json["restricted"], true);
     }
 
@@ -1222,7 +1227,7 @@ mod tests {
         let surfaced = WaddleExternalService::from(ExternalService {
             service_type: ExternalServiceType::Stun,
             host: "turn.waddle.social".into(),
-            port: 3478,
+            port: None,
             transport: Some(ExternalServiceTransport::Udp),
             username: None,
             password: None,
@@ -1232,6 +1237,8 @@ mod tests {
         let json = serde_json::to_value(&surfaced).expect("serialize");
         assert_eq!(json["serviceType"], "stun");
         let obj = json.as_object().expect("object");
+        // Absent optional fields (incl. an omitted port) are dropped, not null.
+        assert!(!obj.contains_key("port"));
         assert!(!obj.contains_key("username"));
         assert!(!obj.contains_key("password"));
         assert!(!obj.contains_key("expires"));

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -349,6 +349,42 @@ pub struct WaddleLiveKitJoin {
     pub token: String,
 }
 
+/// JS-facing XEP-0215 external service (one `<service/>` entry). The chat maps
+/// an array of these to `RTCIceServer[]` for LiveKit's `rtcConfig`. Wire-form
+/// `serviceType`/`transport` strings come straight from the typed core value's
+/// `as_str`, so the discriminator has a single source of truth.
+#[derive(Debug, Serialize)]
+pub struct WaddleExternalService {
+    #[serde(rename = "serviceType")]
+    pub service_type: &'static str,
+    pub host: String,
+    pub port: u16,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transport: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub password: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires: Option<String>,
+    pub restricted: bool,
+}
+
+impl From<waddle_xmpp_client::xep::xep0215::ExternalService> for WaddleExternalService {
+    fn from(service: waddle_xmpp_client::xep::xep0215::ExternalService) -> Self {
+        Self {
+            service_type: service.service_type.as_str(),
+            host: service.host,
+            port: service.port,
+            transport: service.transport.map(|t| t.as_str()),
+            username: service.username,
+            password: service.password,
+            expires: service.expires,
+            restricted: service.restricted,
+        }
+    }
+}
+
 /// JS-facing call event. The `kind` discriminator drives a switch
 /// on the chat side: `propose|ringing|proceed|reject|retract|finish|
 /// session-initiate|session-accept|session-terminate`.
@@ -1147,8 +1183,60 @@ pub struct SetDmNotificationModeOptions {
 
 #[cfg(test)]
 mod tests {
-    use super::RegisterPushDeviceOptions;
+    use super::{RegisterPushDeviceOptions, WaddleExternalService};
     use waddle_xmpp_client::push::{PushDeviceCredentials, PushEnvironment, PushPlatform};
+    use waddle_xmpp_client::xep::xep0215::{
+        ExternalService, ExternalServiceTransport, ExternalServiceType,
+    };
+
+    /// A TLS-TURN entry converts to the JS surface with the `turns`
+    /// discriminator, credentials, and `restricted` preserved. Pins the
+    /// camelCase `serviceType` key the chat-side mapping reads.
+    #[test]
+    fn turns_service_serializes_with_camelcase_and_credentials() {
+        let surfaced = WaddleExternalService::from(ExternalService {
+            service_type: ExternalServiceType::Turns,
+            host: "turn.waddle.social".into(),
+            port: 443,
+            transport: Some(ExternalServiceTransport::Tcp),
+            username: Some("u".into()),
+            password: Some("p".into()),
+            expires: Some("2026-06-17T12:00:00Z".into()),
+            restricted: true,
+        });
+        let json = serde_json::to_value(&surfaced).expect("serialize");
+        assert_eq!(json["serviceType"], "turns");
+        assert_eq!(json["host"], "turn.waddle.social");
+        assert_eq!(json["port"], 443);
+        assert_eq!(json["transport"], "tcp");
+        assert_eq!(json["username"], "u");
+        assert_eq!(json["password"], "p");
+        assert_eq!(json["expires"], "2026-06-17T12:00:00Z");
+        assert_eq!(json["restricted"], true);
+    }
+
+    /// A STUN entry has no credentials; the optional fields are omitted from
+    /// the JS object entirely (not emitted as `null`).
+    #[test]
+    fn stun_service_omits_absent_credential_fields() {
+        let surfaced = WaddleExternalService::from(ExternalService {
+            service_type: ExternalServiceType::Stun,
+            host: "turn.waddle.social".into(),
+            port: 3478,
+            transport: Some(ExternalServiceTransport::Udp),
+            username: None,
+            password: None,
+            expires: None,
+            restricted: false,
+        });
+        let json = serde_json::to_value(&surfaced).expect("serialize");
+        assert_eq!(json["serviceType"], "stun");
+        let obj = json.as_object().expect("object");
+        assert!(!obj.contains_key("username"));
+        assert!(!obj.contains_key("password"));
+        assert!(!obj.contains_key("expires"));
+        assert_eq!(json["restricted"], false);
+    }
 
     /// Pin the camelCase wire contract for the `register_push_device`
     /// WASM bridge. The chat-side wrapper at

--- a/server/crates/waddle-xmpp-client/src/xep/mod.rs
+++ b/server/crates/waddle-xmpp-client/src/xep/mod.rs
@@ -12,6 +12,7 @@ pub mod reply;
 pub mod thread;
 pub mod threads;
 pub mod xep0050;
+pub mod xep0215;
 pub mod xep0292;
 pub mod xep0357;
 pub mod xep0402;

--- a/server/crates/waddle-xmpp-client/src/xep/xep0215.rs
+++ b/server/crates/waddle-xmpp-client/src/xep/xep0215.rs
@@ -11,6 +11,7 @@
 //! `type='turns'` (XEP-0215 §3.6.5), and `xmpp_parsers`' `Type` enum has no
 //! `Turns` variant, so the typed parser would reject Waddle's own response.
 
+use chrono::{DateTime, FixedOffset};
 use minidom::Element;
 
 /// External Service Discovery namespace.
@@ -84,15 +85,19 @@ impl ExternalServiceTransport {
 pub struct ExternalService {
     pub service_type: ExternalServiceType,
     pub host: String,
-    pub port: u16,
+    /// `port` is RECOMMENDED but optional in XEP-0215; `None` when the server
+    /// omits it (the ICE URI then carries no explicit port and the client uses
+    /// the scheme default).
+    pub port: Option<u16>,
     pub transport: Option<ExternalServiceTransport>,
     pub username: Option<String>,
     pub password: Option<String>,
-    /// XEP-0082 dateTime string (UTC) marking when the credentials expire.
-    /// Kept verbatim from the wire — it crosses the WASM boundary unchanged for
-    /// the client's refresh logic.
-    pub expires: Option<String>,
-    /// `restricted='1'` — credentials are required (XEP-0215 §3.6.5).
+    /// When the credentials expire (XEP-0215 §3.6.5 `expires`, an XEP-0082
+    /// dateTime). Parsed to a typed value so the client's refresh logic never
+    /// re-parses a stringly-typed timestamp.
+    pub expires: Option<DateTime<FixedOffset>>,
+    /// Whether credentials are required (XEP-0215 §3.6.5 `restricted`, an
+    /// `xs:boolean` — `"1"` or `"true"`).
     pub restricted: bool,
 }
 
@@ -130,10 +135,19 @@ pub fn parse_external_services(iq: &Element) -> Vec<ExternalService> {
 fn parse_service_element(service: &Element) -> Option<ExternalService> {
     let service_type = ExternalServiceType::from_wire(service.attr("type")?)?;
     let host = service.attr("host")?.to_string();
-    let port = service.attr("port")?.parse::<u16>().ok()?;
+    // `port` is optional (XEP-0215): keep a port-less service, but drop one
+    // whose `port` is present yet not a valid u16.
+    let port = match service.attr("port") {
+        Some(raw) => Some(raw.parse::<u16>().ok()?),
+        None => None,
+    };
     let transport = service
         .attr("transport")
         .and_then(ExternalServiceTransport::from_wire);
+    // A malformed `expires` is informational only — drop it, not the service.
+    let expires = service
+        .attr("expires")
+        .and_then(|raw| DateTime::parse_from_rfc3339(raw).ok());
     Some(ExternalService {
         service_type,
         host,
@@ -141,8 +155,9 @@ fn parse_service_element(service: &Element) -> Option<ExternalService> {
         transport,
         username: service.attr("username").map(str::to_string),
         password: service.attr("password").map(str::to_string),
-        expires: service.attr("expires").map(str::to_string),
-        restricted: service.attr("restricted") == Some("1"),
+        expires,
+        // `xs:boolean` lexical space: "1" or "true" mean restricted.
+        restricted: matches!(service.attr("restricted"), Some("1") | Some("true")),
     })
 }
 
@@ -165,7 +180,7 @@ mod tests {
         let stun = &services[0];
         assert_eq!(stun.service_type, ExternalServiceType::Stun);
         assert_eq!(stun.host, "turn.waddle.social");
-        assert_eq!(stun.port, 3478);
+        assert_eq!(stun.port, Some(3478));
         assert_eq!(stun.transport, Some(ExternalServiceTransport::Udp));
         assert!(stun.username.is_none());
         assert!(stun.password.is_none());
@@ -194,13 +209,16 @@ mod tests {
         let turns = &services[0];
         assert_eq!(turns.service_type, ExternalServiceType::Turns);
         assert_eq!(turns.transport, Some(ExternalServiceTransport::Tcp));
-        assert_eq!(turns.port, 443);
+        assert_eq!(turns.port, Some(443));
         assert_eq!(
             turns.username.as_deref(),
             Some("1700000000:alice@waddle.social/desktop")
         );
         assert_eq!(turns.password.as_deref(), Some("base64hmac=="));
-        assert_eq!(turns.expires.as_deref(), Some("2026-06-17T12:00:00Z"));
+        assert_eq!(
+            turns.expires.expect("expires parsed").to_rfc3339(),
+            "2026-06-17T12:00:00+00:00"
+        );
         assert!(turns.restricted);
     }
 
@@ -238,16 +256,45 @@ mod tests {
     }
 
     #[test]
-    fn skips_entry_missing_host_or_port() {
+    fn skips_entry_missing_host_or_with_invalid_port() {
         let xml = "<iq xmlns='jabber:client' type='result' id='e1'>\
                      <services xmlns='urn:xmpp:extdisco:2'>\
                        <service type='stun' port='3478'/>\
-                       <service type='stun' host='turn.waddle.social'/>\
                        <service type='stun' host='turn.waddle.social' port='not-a-port'/>\
                      </services>\
                    </iq>";
         let iq: Element = xml.parse().expect("valid xml");
         assert!(parse_external_services(&iq).is_empty());
+    }
+
+    /// XEP-0215 marks `port` RECOMMENDED, not required: a service that omits it
+    /// is kept with `port: None` (the ICE URI then uses the scheme default).
+    #[test]
+    fn keeps_service_with_omitted_port() {
+        let xml = "<iq xmlns='jabber:client' type='result' id='e1'>\
+                     <services xmlns='urn:xmpp:extdisco:2'>\
+                       <service type='stun' host='turn.waddle.social'/>\
+                     </services>\
+                   </iq>";
+        let iq: Element = xml.parse().expect("valid xml");
+        let services = parse_external_services(&iq);
+        assert_eq!(services.len(), 1);
+        assert_eq!(services[0].port, None);
+    }
+
+    /// `xs:boolean` also permits the lexical form `"true"`, not just `"1"`.
+    #[test]
+    fn restricted_accepts_xs_boolean_true() {
+        let xml = "<iq xmlns='jabber:client' type='result' id='e1'>\
+                     <services xmlns='urn:xmpp:extdisco:2'>\
+                       <service type='turns' host='turn.waddle.social' port='443' \
+                                username='u' password='p' restricted='true'/>\
+                     </services>\
+                   </iq>";
+        let iq: Element = xml.parse().expect("valid xml");
+        let services = parse_external_services(&iq);
+        assert_eq!(services.len(), 1);
+        assert!(services[0].restricted);
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client/src/xep/xep0215.rs
+++ b/server/crates/waddle-xmpp-client/src/xep/xep0215.rs
@@ -1,0 +1,281 @@
+//! XEP-0215: External Service Discovery (client side).
+//!
+//! The Waddle server advertises its LiveKit-fronted TURN/STUN service over the
+//! `urn:xmpp:extdisco:2` namespace. This module is the client counterpart: it
+//! builds the `<services/>` IQ-get the client sends to its own server and parses
+//! the `<service/>` entries in the result into typed [`ExternalService`] values
+//! that the call engine maps to `RTCIceServer`s.
+//!
+//! Parsing is done by hand over [`minidom::Element`] rather than through
+//! `xmpp_parsers::extdisco`: the server emits the TLS-protected TURN entry as
+//! `type='turns'` (XEP-0215 §3.6.5), and `xmpp_parsers`' `Type` enum has no
+//! `Turns` variant, so the typed parser would reject Waddle's own response.
+
+use minidom::Element;
+
+/// External Service Discovery namespace.
+pub const NS_EXT_DISCO: &str = "urn:xmpp:extdisco:2";
+
+/// Service type advertised in a `<service type='…'/>` entry. The XEP-0215
+/// §3.6.5 `turns` value (TLS-protected TURN) is a distinct variant — it is the
+/// shape Waddle advertises and is absent from `xmpp_parsers`' typed surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExternalServiceType {
+    /// `stun` — STUN server (RFC 5389).
+    Stun,
+    /// `turn` — plain TURN relay (RFC 5766).
+    Turn,
+    /// `turns` — TLS-protected TURN relay (XEP-0215 §3.6.5).
+    Turns,
+}
+
+impl ExternalServiceType {
+    /// Map the wire `type` attribute to a typed value. Unknown types (e.g.
+    /// `ftp`) yield `None` so the caller can skip entries it cannot use as ICE
+    /// servers.
+    fn from_wire(value: &str) -> Option<Self> {
+        match value {
+            "stun" => Some(Self::Stun),
+            "turn" => Some(Self::Turn),
+            "turns" => Some(Self::Turns),
+            _ => None,
+        }
+    }
+}
+
+/// Transport of a `<service transport='…'/>` entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExternalServiceTransport {
+    Udp,
+    Tcp,
+}
+
+impl ExternalServiceTransport {
+    fn from_wire(value: &str) -> Option<Self> {
+        match value {
+            "udp" => Some(Self::Udp),
+            "tcp" => Some(Self::Tcp),
+            _ => None,
+        }
+    }
+}
+
+/// A single external service advertised by the server, parsed from one
+/// `<service/>` element. Credentials are present only on TURN/TURNS entries.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExternalService {
+    pub service_type: ExternalServiceType,
+    pub host: String,
+    pub port: u16,
+    pub transport: Option<ExternalServiceTransport>,
+    pub username: Option<String>,
+    pub password: Option<String>,
+    /// XEP-0082 dateTime string (UTC) marking when the credentials expire.
+    /// Kept verbatim from the wire — it crosses the WASM boundary unchanged for
+    /// the client's refresh logic.
+    pub expires: Option<String>,
+    /// `restricted='1'` — credentials are required (XEP-0215 §3.6.5).
+    pub restricted: bool,
+}
+
+/// `jabber:client` namespace for the IQ envelope.
+const NS_CLIENT: &str = "jabber:client";
+
+/// Build the `<iq type='get'><services xmlns='urn:xmpp:extdisco:2'/></iq>` a
+/// client sends to its own server to learn the advertised external services
+/// (XEP-0215 §3.2). An empty `<services/>` requests every service type.
+pub fn build_extdisco_services_iq(to: &str, request_id: &str) -> Element {
+    Element::builder("iq", NS_CLIENT)
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "get")
+        .attr(minidom::rxml::xml_ncname!("to").to_owned(), to)
+        .attr(minidom::rxml::xml_ncname!("id").to_owned(), request_id)
+        .append(Element::builder("services", NS_EXT_DISCO).build())
+        .build()
+}
+
+/// Parse the `<service/>` entries from a `services` IQ-result payload into typed
+/// values. Entries whose `type` is unknown or which lack the mandatory
+/// `host`/`port` attributes are skipped.
+pub fn parse_external_services(iq: &Element) -> Vec<ExternalService> {
+    let Some(services) = iq.get_child("services", NS_EXT_DISCO) else {
+        return Vec::new();
+    };
+    services
+        .children()
+        .filter(|child| child.name() == "service" && child.ns() == NS_EXT_DISCO)
+        .filter_map(parse_service_element)
+        .collect()
+}
+
+/// Parse one `<service/>` element. Returns `None` when the entry is unusable as
+/// an ICE server: unknown `type`, or missing/invalid `host`/`port`.
+fn parse_service_element(service: &Element) -> Option<ExternalService> {
+    let service_type = ExternalServiceType::from_wire(service.attr("type")?)?;
+    let host = service.attr("host")?.to_string();
+    let port = service.attr("port")?.parse::<u16>().ok()?;
+    let transport = service
+        .attr("transport")
+        .and_then(ExternalServiceTransport::from_wire);
+    Some(ExternalService {
+        service_type,
+        host,
+        port,
+        transport,
+        username: service.attr("username").map(str::to_string),
+        password: service.attr("password").map(str::to_string),
+        expires: service.attr("expires").map(str::to_string),
+        restricted: service.attr("restricted") == Some("1"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_single_stun_service() {
+        let xml = "<iq xmlns='jabber:client' type='result' from='waddle.test' id='e1'>\
+                     <services xmlns='urn:xmpp:extdisco:2'>\
+                       <service action='add' type='stun' transport='udp' \
+                                host='turn.waddle.social' port='3478'/>\
+                     </services>\
+                   </iq>";
+        let iq: Element = xml.parse().expect("valid xml");
+        let services = parse_external_services(&iq);
+
+        assert_eq!(services.len(), 1);
+        let stun = &services[0];
+        assert_eq!(stun.service_type, ExternalServiceType::Stun);
+        assert_eq!(stun.host, "turn.waddle.social");
+        assert_eq!(stun.port, 3478);
+        assert_eq!(stun.transport, Some(ExternalServiceTransport::Udp));
+        assert!(stun.username.is_none());
+        assert!(stun.password.is_none());
+        assert!(!stun.restricted);
+    }
+
+    /// The conformance-critical case and the reason this module parses by hand:
+    /// the server advertises TLS-protected TURN as `type='turns'`, which the
+    /// `xmpp_parsers` typed surface cannot represent. This mirrors the exact
+    /// wire shape `waddle-xmpp` emits (see its `build_turn_service`).
+    #[test]
+    fn parses_tls_turn_service_with_credentials() {
+        let xml = "<iq xmlns='jabber:client' type='result' from='waddle.test' id='e1'>\
+                     <services xmlns='urn:xmpp:extdisco:2'>\
+                       <service action='add' type='turns' transport='tcp' \
+                                host='turn.waddle.social' port='443' \
+                                username='1700000000:alice@waddle.social/desktop' \
+                                password='base64hmac==' \
+                                expires='2026-06-17T12:00:00Z' restricted='1'/>\
+                     </services>\
+                   </iq>";
+        let iq: Element = xml.parse().expect("valid xml");
+        let services = parse_external_services(&iq);
+
+        assert_eq!(services.len(), 1);
+        let turns = &services[0];
+        assert_eq!(turns.service_type, ExternalServiceType::Turns);
+        assert_eq!(turns.transport, Some(ExternalServiceTransport::Tcp));
+        assert_eq!(turns.port, 443);
+        assert_eq!(
+            turns.username.as_deref(),
+            Some("1700000000:alice@waddle.social/desktop")
+        );
+        assert_eq!(turns.password.as_deref(), Some("base64hmac=="));
+        assert_eq!(turns.expires.as_deref(), Some("2026-06-17T12:00:00Z"));
+        assert!(turns.restricted);
+    }
+
+    #[test]
+    fn parses_full_server_response_turns_and_stun() {
+        let xml = "<iq xmlns='jabber:client' type='result' from='waddle.test' id='e1'>\
+                     <services xmlns='urn:xmpp:extdisco:2'>\
+                       <service action='add' type='turns' transport='tcp' \
+                                host='turn.waddle.social' port='443' \
+                                username='u' password='p' restricted='1'/>\
+                       <service action='add' type='stun' transport='udp' \
+                                host='turn.waddle.social' port='3478'/>\
+                     </services>\
+                   </iq>";
+        let iq: Element = xml.parse().expect("valid xml");
+        let services = parse_external_services(&iq);
+
+        assert_eq!(services.len(), 2);
+        assert_eq!(services[0].service_type, ExternalServiceType::Turns);
+        assert_eq!(services[1].service_type, ExternalServiceType::Stun);
+    }
+
+    #[test]
+    fn skips_unknown_service_type() {
+        let xml = "<iq xmlns='jabber:client' type='result' id='e1'>\
+                     <services xmlns='urn:xmpp:extdisco:2'>\
+                       <service type='ftp' host='ftp.waddle.social' port='21'/>\
+                       <service type='stun' host='turn.waddle.social' port='3478'/>\
+                     </services>\
+                   </iq>";
+        let iq: Element = xml.parse().expect("valid xml");
+        let services = parse_external_services(&iq);
+        assert_eq!(services.len(), 1);
+        assert_eq!(services[0].service_type, ExternalServiceType::Stun);
+    }
+
+    #[test]
+    fn skips_entry_missing_host_or_port() {
+        let xml = "<iq xmlns='jabber:client' type='result' id='e1'>\
+                     <services xmlns='urn:xmpp:extdisco:2'>\
+                       <service type='stun' port='3478'/>\
+                       <service type='stun' host='turn.waddle.social'/>\
+                       <service type='stun' host='turn.waddle.social' port='not-a-port'/>\
+                     </services>\
+                   </iq>";
+        let iq: Element = xml.parse().expect("valid xml");
+        assert!(parse_external_services(&iq).is_empty());
+    }
+
+    #[test]
+    fn missing_services_payload_yields_empty() {
+        let xml = "<iq xmlns='jabber:client' type='result' id='e1'/>";
+        let iq: Element = xml.parse().expect("valid xml");
+        assert!(parse_external_services(&iq).is_empty());
+    }
+
+    #[test]
+    fn builds_services_get_iq() {
+        let iq = build_extdisco_services_iq("waddle.test", "req-1");
+        assert_eq!(iq.name(), "iq");
+        assert_eq!(iq.attr("type"), Some("get"));
+        assert_eq!(iq.attr("to"), Some("waddle.test"));
+        assert_eq!(iq.attr("id"), Some("req-1"));
+
+        let services = iq
+            .get_child("services", NS_EXT_DISCO)
+            .expect("services payload present");
+        // XEP-0215 §3.6.1: an empty <services/> requests every service type.
+        assert!(services.attr("type").is_none());
+        assert_eq!(services.children().count(), 0);
+    }
+
+    /// Round-trip: the query we build, answered with the server's wire shape,
+    /// parses back to the advertised services.
+    #[test]
+    fn query_round_trips_against_server_response() {
+        let query = build_extdisco_services_iq("waddle.test", "req-1");
+        assert_eq!(
+            query.get_child("services", NS_EXT_DISCO).map(Element::name),
+            Some("services")
+        );
+
+        let response = "<iq xmlns='jabber:client' type='result' from='waddle.test' id='req-1'>\
+                          <services xmlns='urn:xmpp:extdisco:2'>\
+                            <service action='add' type='turns' transport='tcp' \
+                                     host='turn.waddle.social' port='443' \
+                                     username='u' password='p' restricted='1'/>\
+                            <service action='add' type='stun' transport='udp' \
+                                     host='turn.waddle.social' port='3478'/>\
+                          </services>\
+                        </iq>";
+        let response: Element = response.parse().expect("valid xml");
+        let services = parse_external_services(&response);
+        assert_eq!(services.len(), 2);
+    }
+}

--- a/server/crates/waddle-xmpp-client/src/xep/xep0215.rs
+++ b/server/crates/waddle-xmpp-client/src/xep/xep0215.rs
@@ -41,6 +41,16 @@ impl ExternalServiceType {
             _ => None,
         }
     }
+
+    /// Wire-form `type` value. Single source of truth for the discriminator
+    /// that crosses the WASM boundary and drives the chat-side ICE mapping.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Stun => "stun",
+            Self::Turn => "turn",
+            Self::Turns => "turns",
+        }
+    }
 }
 
 /// Transport of a `<service transport='…'/>` entry.
@@ -56,6 +66,14 @@ impl ExternalServiceTransport {
             "udp" => Some(Self::Udp),
             "tcp" => Some(Self::Tcp),
             _ => None,
+        }
+    }
+
+    /// Wire-form `transport` value.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Udp => "udp",
+            Self::Tcp => "tcp",
         }
     }
 }
@@ -237,6 +255,21 @@ mod tests {
         let xml = "<iq xmlns='jabber:client' type='result' id='e1'/>";
         let iq: Element = xml.parse().expect("valid xml");
         assert!(parse_external_services(&iq).is_empty());
+    }
+
+    #[test]
+    fn service_type_wire_strings_round_trip() {
+        for t in [
+            ExternalServiceType::Stun,
+            ExternalServiceType::Turn,
+            ExternalServiceType::Turns,
+        ] {
+            assert_eq!(ExternalServiceType::from_wire(t.as_str()), Some(t));
+        }
+        assert_eq!(ExternalServiceType::Turns.as_str(), "turns");
+        for t in [ExternalServiceTransport::Udp, ExternalServiceTransport::Tcp] {
+            assert_eq!(ExternalServiceTransport::from_wire(t.as_str()), Some(t));
+        }
     }
 
     #[test]

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -107,6 +107,14 @@ export class WaddleClient {
     fetch_dm_history_page(peer_jid: string, max: number, page_param: any): Promise<any>;
     fetch_extension_route_items(route: any, room_jid: string): Promise<any>;
     /**
+     * XEP-0215 §3.2: fetch the external services (TURN/STUN) the user's own
+     * server advertises, resolving to a typed array the chat maps to
+     * `RTCIceServer[]` for LiveKit's `rtcConfig` at connect time. The query is
+     * addressed to the authenticated user's server domain; an empty
+     * `<services/>` requests every advertised service type.
+     */
+    fetch_external_services(): Promise<any>;
+    /**
      * Fetch the user's inbox via XEP-0430 (`urn:xmpp:inbox:1`).
      *
      * Wire-shape: IQ-get with `<inbox/>`, server streams

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=afbcf6b752ca";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=afbcf6b752ca";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=afbcf6b752ca";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=19dc297fce33";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=19dc297fce33";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=19dc297fce33";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=afbcf6b752ca";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=19dc297fce33";


### PR DESCRIPTION
## Closes #999

Makes the previously cosmetic XEP-0215 (`urn:xmpp:extdisco:2`) advertisement **behavior-complete**: the Rust XMPP client fetches the server-advertised TURN/STUN servers, surfaces them as a typed value across the WASM boundary, and the web client injects them into LiveKit's connection `rtcConfig` so calls negotiate ICE over an XMPP-native, client-controlled path.

Parent: #995 · Blocked by: #996 (closed).

## Design decisions (grounded in `xeps/xep-0215.xml`)

- **Discovery trigger — client-initiated `<services/>` IQ-get at connect time** (XEP-0215 §3.2: "a requesting entity … sends an IQ-get containing an empty `<services/>` element … typically to its own server"). Mirrors the existing `fetch_vapid_public_key` request pattern and yields fresh time-limited TURN credentials per call.
- **ICE semantics — replace.** The XEP-0215 servers become the authoritative `rtcConfig.iceServers` list. Augmenting would depend on LiveKit's proprietary out-of-band ICE provisioning, which the constitution discourages. The advertised host is the same LiveKit-fronted coturn LiveKit would use anyway, and the server hands out both `stun` (srflx) and `turns` (relay), so the list is complete. **Fallback safety:** when the server advertises nothing or the fetch fails, the client connects with *no* `rtcConfig` (LiveKit defaults) rather than an empty ICE list.
- **Scope — web (WASM) only.** Matches the issue's acceptance criteria. Swift FFI parity and credential refresh via XEP-0215 push / `<credentials/>` are tracked as fast-follow.

### Conformance note
The server emits the TLS-protected TURN entry as `type='turns'`, which `xmpp_parsers::extdisco` cannot represent (no `Turns` variant). The client parses `<service/>` entries by hand via `minidom`, matching the server's own rationale, and is covered by a dedicated XEP-0215 Rust test suite.

## What was built

**Rust core — `server/crates/waddle-xmpp-client/src/xep/xep0215.rs`**
- Typed `ExternalService { service_type: {Stun|Turn|Turns}, host, port, transport, username, password, expires, restricted }`; `as_str`/`from_wire` are the single source of truth for the wire discriminators.
- `build_extdisco_services_iq` (the `<services/>` IQ-get) and `parse_external_services` (manual minidom; handles `turns`).
- Dedicated XEP-0215 test suite: STUN, TLS-TURN-with-creds, mixed server response, unknown-type/invalid-entry skipping, query build, server round-trip, wire round-trip.

**WASM — `server/crates/waddle-xmpp-client-wasm`**
- `WaddleExternalService` serde surface (mirrors `WaddleLiveKitJoin`) + `WaddleClient::fetch_external_services` — queries the user's own server, parses, converts to the typed JS array, with a defense-in-depth `from`-check on the reply.

**Chat — `chat/`**
- `ExternalService` boundary type; `coerceExternalServices` validates the untyped WASM value against bundle drift.
- `iceServersFromExternalServices`: pure, unit-tested `stun:` / `turn:?transport=` / `turns:?transport=tcp` mapping (STUN takes no transport query; a TURN entry without credentials is dropped).
- `BrowserXmppClient.fetchExternalServices`: resilient wrapper, `[]`-on-any-error so connect falls back to LiveKit's own ICE servers (never an empty list).
- `CallEngine.connect` takes `iceServers` and passes `rtcConfig` only when the list is non-empty; a `makeRoom` seam makes this unit-testable via stub-Room injection.
- `CallOverlay` resolves + injects iceServers before connect (MUC + DM share this one connect site).
- Regenerated WASM bindings (`.d.ts`/`.js`) for `fetch_external_services`.

**Connect-lifecycle hardening (from adversarial review)**
- The pre-connect ICE fetch (up to 10s) widened a teardown/redial race. `CallEngine` now guards concurrent `connect()` with a generation counter: `disconnect()` cancels an in-flight connect, and a connect superseded during its `await room.connect` tears its own Room down instead of publishing an orphan — never wedging the singleton engine. `CallOverlay` re-validates phase+sid after the fetch. The wrapper swallows a late IQ rejection that loses the timeout race.

## Verification

- `cargo test` (incl. the new XEP-0215 suite), `cargo clippy -- -D warnings`, `cargo fmt --check`: clean.
- `bun test` (2277 pass, incl. new `ice-servers` + `call-ice-config` suites), `knip`, `astro check` (0 errors): clean.
- Three rounds of adversarial-persona review converged with no remaining real issues; the connect-race findings are fixed and regression-tested.
- ICE telemetry (#996) reflects the advertised servers in the candidate set at the unit level (mapping + connect-injection tests). Runtime relay-path confirmation needs live verification on a deployment.

## Out of scope (fast-follow)
- Swift FFI (`waddle-xmpp-client-ffi`) parity.
- Credential refresh via XEP-0215 push (`<iq type='set'>` + `action`) and the `<credentials/>` sub-request for `restricted='1'` services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
