### PR TITLE
fix(infra): allow STUN egress so LiveKit SFU can boot

### DIFF
--- a/infrastructure/waddle.cloud/gitops/livekit-sfu/networkpolicy.yaml
+++ b/infrastructure/waddle.cloud/gitops/livekit-sfu/networkpolicy.yaml
@@ -108,6 +108,21 @@ spec:
               protocol: UDP
             - port: "30881"
               protocol: TCP
+    # LiveKit external-IP auto-detection (`rtc.use_external_ip: true`)
+    # performs a STUN binding to public STUN servers at startup — BEFORE it
+    # logs anything or binds :7880. Without this allow a fresh pod blocks on
+    # external-IP resolution, is liveness-killed at ~30s, and CrashLoops with
+    # empty logs (a running pod survives only until its next restart). STUN
+    # is UDP/3478 (e.g. Twilio) and UDP/19302 (Google), to arbitrary public
+    # servers, hence `world`.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "3478"
+              protocol: UDP
+            - port: "19302"
+              protocol: UDP
     # Signaling responses back to the gateway proxy / host data path.
     - toEntities:
         - ingress


### PR DESCRIPTION
## Production outage fix

The LiveKit SFU is currently CrashLooping in production (single-replica → full SFU outage). Root cause confirmed by an off-prod Docker repro.

## Root cause

LiveKit runs with `rtc.use_external_ip: true`, which performs a **STUN binding to public STUN servers (UDP 3478 / 19302) at startup** — *before* it logs anything or binds `:7880` — to discover its external IP.

The `livekit-sfu` CiliumNetworkPolicy egress is default-deny and re-opens only:
- kube-dns (53)
- world 443/TCP (webhook delivery)
- world media UDP 30000-40000 / 30882 + TCP 30881

It **never allowed STUN**, so a fresh SFU pod blocks on external-IP resolution, is liveness-killed at ~30s (before the `could not resolve external IP: context deadline exceeded` fatal line even prints), and CrashLoops with **empty logs**.

The running pod survived for ~3 weeks only because it had resolved its external IP before the policy took effect — any restart (node drain, eviction, helm rollout) was a latent outage. It surfaced when an unrelated HelmRelease rollout rolled the single-replica pod.

## Repro (off-prod)

`livekit-server` with `use_external_ip: true` + an unreachable STUN server reproduces prod exactly: zero logs, never binds `:7880`, dies at ~30s with `could not resolve external IP: context deadline exceeded`. With STUN reachable it boots normally.

## Fix

Add a `world` egress allow for **UDP 3478 + 19302** so external-IP auto-detection works on a fresh pod.

## Deploy / recovery

After merge, Flux's `infra-livekit-sfu` Kustomization applies the rule; recover the crashlooping pod (delete it / force a Kustomization reconcile). Independent of PR #1012 (the TURN-UDP work) — that PR's relay/probe is fine; unsticking its release merely triggered the restart that exposed this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)