### PR TITLE
feat(chat): VP9+SVC camera capped at 720p (#1001)

### DIFF
--- a/chat/src/lib/calls/call-media-path-telemetry.ts
+++ b/chat/src/lib/calls/call-media-path-telemetry.ts
@@ -3,6 +3,7 @@ import type {
   CallStatDirection,
   IceCandidateType,
   IceTransport,
+  VideoResolutionBand,
 } from "./call-stats";
 
 /**
@@ -28,7 +29,12 @@ type CallMediaPathSource = "camera" | "screen" | "microphone";
  * `audioBitrateBand` is the active-speaker bitrate bucket — non-null only for
  * `microphone` snapshots, so the raised ~64k Opus default is provable fleet-wide
  * while a continuously-varying send bitrate stays low-cardinality and the beacon
- * de-dupes. Always null for video (its quality lever is codec/ICE).
+ * de-dupes. Always null for video.
+ *
+ * `videoResolutionBand` is the symmetric video signal — the negotiated top-layer
+ * resolution bucket, non-null only for `camera`/`screen` snapshots. A fleet-wide
+ * shift from `1080p` to `720p` is what proves the #1001 camera cap took effect
+ * and reduced camera egress/decode. Always null for audio.
  */
 export type CallMediaPathSnapshot = {
   direction: CallStatDirection;
@@ -37,6 +43,7 @@ export type CallMediaPathSnapshot = {
   iceCandidateType: IceCandidateType | null;
   iceTransport: IceTransport | null;
   audioBitrateBand: AudioBitrateBand | null;
+  videoResolutionBand: VideoResolutionBand | null;
 };
 
 /**
@@ -59,6 +66,12 @@ export function callMediaPathEventAttributes(
     // so video events keep their exact shape and never carry a meaningless
     // audio attribute.
     ...(snapshot.audioBitrateBand ? { audio_bitrate_band: snapshot.audioBitrateBand } : {}),
+    // Video-only: the symmetric resolution bucket, emitted only for a camera /
+    // screen path that has a measured band, so audio events never carry a
+    // meaningless video attribute.
+    ...(snapshot.videoResolutionBand
+      ? { video_resolution_band: snapshot.videoResolutionBand }
+      : {}),
   };
 }
 
@@ -78,7 +91,8 @@ function sameCallMediaPath(a: CallMediaPathSnapshot, b: CallMediaPathSnapshot): 
     a.codec === b.codec &&
     a.iceCandidateType === b.iceCandidateType &&
     a.iceTransport === b.iceTransport &&
-    a.audioBitrateBand === b.audioBitrateBand
+    a.audioBitrateBand === b.audioBitrateBand &&
+    a.videoResolutionBand === b.videoResolutionBand
   );
 }
 

--- a/chat/src/lib/calls/call-stats.ts
+++ b/chat/src/lib/calls/call-stats.ts
@@ -164,6 +164,30 @@ export function audioBitrateBand(bitrateKbps: number | null): AudioBitrateBand |
   return "high";
 }
 
+/**
+ * Video counterpart of {@link audioBitrateBand}: a coarse, low-cardinality band
+ * over the negotiated top-layer resolution. It is the fleet-wide signal for the
+ * resolution levers in #995 — a shift from `1080p` to `720p` is what proves the
+ * #1001 camera cap took effect and reduced camera egress/decode. Banding the
+ * height (not beaconing the raw "W×H") keeps the de-duping media-path beacon to
+ * a handful of events per call rather than one per SVC-layer flip. `null` (an
+ * unreported first poll) has no band yet.
+ */
+export type VideoResolutionBand = "180p" | "360p" | "540p" | "720p" | "1080p" | "1440p";
+
+export function videoResolutionBand(resolution: string | null): VideoResolutionBand | null {
+  if (resolution === null) return null;
+  // `summarizeVideoStats` formats resolution as "W×H" (U+00D7); band on height.
+  const height = Number.parseInt(resolution.split("×")[1] ?? "", 10);
+  if (!Number.isFinite(height) || height <= 0) return null;
+  if (height <= 180) return "180p";
+  if (height <= 360) return "360p";
+  if (height <= 540) return "540p";
+  if (height <= 720) return "720p";
+  if (height <= 1080) return "1080p";
+  return "1440p";
+}
+
 /** Strip the "video/" prefix off a codec MIME, e.g. "video/VP9" → "VP9". */
 function codecName(mimeType: string | undefined): string | null {
   if (!mimeType) return null;

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -4,7 +4,6 @@ import {
   Room,
   RoomEvent,
   Track,
-  VideoPresets,
   type LocalParticipant,
   type LocalTrack,
   type LocalTrackPublication,
@@ -19,7 +18,7 @@ import {
   type TrackPublishOptions,
   type VideoCaptureOptions,
 } from "livekit-client";
-import { videoPublishPlan } from "./video-codec/video-publish";
+import { videoPublishPlan, type CameraPublishPlan } from "./video-codec/video-publish";
 import { audioPublishOptions } from "./audio-publish";
 import {
   currentVideoCodecSupportEnv,
@@ -56,15 +55,6 @@ type ProcessorCapableTrack = {
   stopProcessor(): Promise<void>;
 };
 
-/**
- * Camera capture ceiling. AdaptiveStream (`adaptiveStream: true`) and
- * simulcast still scale each subscriber DOWN to the layer matching its
- * rendered tile, so this only governs the maximum a large/expanded tile
- * can pull — it is not the bandwidth every viewer pays. h1080 lifts the
- * per-publisher upstream ceiling to ~3 Mbps (vs. 720p's 1.7 Mbps).
- */
-const CAMERA_CAPTURE_RESOLUTION = VideoPresets.h1080.resolution;
-
 export function audioCaptureDefaultsForPrefs(prefs: {
   mic: string | null;
   audioProcessing: AudioProcessingPrefs;
@@ -89,15 +79,16 @@ export function callRoomOptionsForPrefs(prefs: {
     // model actually attaches (see syncEffectiveCaptureConstraints) — so a
     // model that fails to load never leaves capture with NS force-disabled.
     audioCaptureDefaults: audioCaptureDefaultsForPrefs(prefs),
+    // Only the device selection lives here; the camera's 720p capture cap is set
+    // per-publish by `videoPublishPlan` (so the builder owns the cap and LiveKit
+    // merges it over this without overwriting `deviceId`). Screen-share
+    // encoding/codec is likewise per-publish (capability-dependent), and the
+    // mic's Opus voice-clarity profile is set per-publish by `audioPublishOptions`
+    // (scoped to the mic so it never bleeds onto screen-share *system* audio,
+    // which may be stereo). Hence no global `publishDefaults` here.
     videoCaptureDefaults: {
       deviceId: prefs.cam ?? undefined,
-      resolution: CAMERA_CAPTURE_RESOLUTION,
     },
-    // Screen-share encoding/codec is set per-publish by `videoPublishPlan`
-    // (it is capability-dependent), and the mic's Opus voice-clarity profile is
-    // set per-publish by `audioPublishOptions` (so it stays scoped to the
-    // microphone and never bleeds onto screen-share *system* audio, which may be
-    // stereo). Hence no global `publishDefaults` here.
   };
 }
 
@@ -474,7 +465,7 @@ export class CallEngine {
       (source, error) => this.emit("mediaDevicesError", { source, error }),
       {
         audio: audioPublishOptions(),
-        camera: videoPublishPlan({ source: "camera", capability: this.codecSupport }).publish,
+        camera: videoPublishPlan({ source: "camera", capability: this.codecSupport }),
       },
     );
     // Re-apply the speaker preference now that the room has remote
@@ -497,8 +488,11 @@ export class CallEngine {
 
   async setCameraEnabled(enabled: boolean): Promise<void> {
     if (!this.room) return;
-    const { publish } = videoPublishPlan({ source: "camera", capability: this.codecSupport });
-    await this.room.localParticipant.setCameraEnabled(enabled, undefined, publish);
+    // Forward the VP9+L3T3 / 720p camera plan — including the per-publish capture
+    // cap — so a camera (re)enabled mid-call publishes at the same default as the
+    // initial join, not LiveKit's 1080p/VP8 default.
+    const { capture, publish } = videoPublishPlan({ source: "camera", capability: this.codecSupport });
+    await this.room.localParticipant.setCameraEnabled(enabled, capture, publish);
   }
 
   async setScreenShareEnabled(
@@ -1141,7 +1135,7 @@ export async function enableRequestedCapture(
   participant: CapturableParticipant,
   opts: { audio: boolean; video: boolean },
   onError: (source: "audio" | "video", error: unknown) => void,
-  publish: { audio: TrackPublishOptions; camera: TrackPublishOptions },
+  publish: { audio: TrackPublishOptions; camera: CameraPublishPlan },
 ): Promise<void> {
   if (opts.audio) {
     try {
@@ -1152,7 +1146,9 @@ export async function enableRequestedCapture(
   }
   if (opts.video) {
     try {
-      await participant.setCameraEnabled(true, undefined, publish.camera);
+      // The camera carries both its capture cap and codec/SVC publish options;
+      // forward both so the initial join publishes the 720p VP9 plan.
+      await participant.setCameraEnabled(true, publish.camera.capture, publish.camera.publish);
     } catch (error) {
       onError("video", error);
     }

--- a/chat/src/lib/calls/use-call-engine.ts
+++ b/chat/src/lib/calls/use-call-engine.ts
@@ -26,6 +26,7 @@ import {
   audioBitrateBand,
   summarizeAudioStats,
   summarizeVideoStats,
+  videoResolutionBand,
   type CallStatDirection,
   type CallStatSample,
 } from "./call-stats";
@@ -113,6 +114,9 @@ async function sampleTrackMediaPath(
       iceCandidateType: summary.iceCandidateType,
       iceTransport: summary.iceTransport,
       audioBitrateBand: null, // video paths carry no audio band
+      // The negotiated top-layer resolution bucket: a fleet shift from 1080p to
+      // 720p is the camera-cap egress signal (#1001).
+      videoResolutionBand: videoResolutionBand(summary.resolution),
     };
   } catch {
     return null;
@@ -167,6 +171,7 @@ async function sampleAudioTrackMediaPath(
             iceCandidateType: summary.iceCandidateType,
             iceTransport: summary.iceTransport,
             audioBitrateBand: band,
+            videoResolutionBand: null, // audio paths carry no resolution band
           };
     return { snapshot, key, sample };
   } catch {

--- a/chat/src/lib/calls/video-codec/video-publish.ts
+++ b/chat/src/lib/calls/video-codec/video-publish.ts
@@ -158,6 +158,12 @@ const CAMERA_RESOLUTION: VideoResolution = { width: 1280, height: 720, frameRate
  * multi-codec simulcast (so a VP8-only iOS subscriber can't drag capable
  * viewers down to VP8); VP8-only fallback; nothing forced when neither is
  * available.
+ *
+ * Unlike `screenShareCodec`, the backup here carries its own `encoding`: the
+ * top-level `videoEncoding` bounds only the primary codec's layers, not the
+ * simulcast backup track, so the VP8 backup needs the 720p cap set explicitly
+ * or it would re-derive an uncapped (1080p-band) ceiling. The screen share
+ * doesn't need this because its cap rides the `screenShareEncoding` field.
  */
 function cameraCodec(capability: VideoCodecSupport): TrackPublishOptions {
   if (capability.vp9.available) {

--- a/chat/src/lib/calls/video-codec/video-publish.ts
+++ b/chat/src/lib/calls/video-codec/video-publish.ts
@@ -10,6 +10,7 @@ import type {
   ScalabilityMode,
   ScreenShareCaptureOptions,
   TrackPublishOptions,
+  VideoCaptureOptions,
   VideoEncoding,
   VideoResolution,
 } from "livekit-client";
@@ -49,12 +50,25 @@ const SCREEN_SHARE_ENCODING: VideoEncoding = {
  */
 const SCREEN_SHARE_RESOLUTION: VideoResolution = { width: 2560, height: 1440, frameRate: 30 };
 
-type VideoPublishPlan = {
-  /** Capture-side options (resolution cap, contentHint). `null` when the
-   *  source uses the room's capture defaults (camera). */
+/**
+ * Camera plan: the 720p capture cap plus the codec/SVC/encoding publish
+ * options, both forwarded verbatim to `setCameraEnabled(enabled, capture,
+ * publish)`. `capture` is always present — the builder owns the cap so the
+ * engine stays thin — and carries only `resolution`, so the room's
+ * `videoCaptureDefaults.deviceId` survives LiveKit's merge.
+ */
+export type CameraPublishPlan = {
+  capture: VideoCaptureOptions;
+  publish: TrackPublishOptions;
+};
+
+/**
+ * Screen-share plan: capture-side options (resolution cap, contentHint),
+ * `null` only when the browser can't be constrained (Safari 17), forwarded to
+ * `setScreenShareEnabled`.
+ */
+type ScreenPublishPlan = {
   capture: ScreenShareCaptureOptions | null;
-  /** Publish-side options forwarded to `setScreenShareEnabled` /
-   *  `setCameraEnabled`. */
   publish: TrackPublishOptions;
 };
 
@@ -89,7 +103,7 @@ function screenShareCodec(capability: VideoCodecSupport): TrackPublishOptions {
 function screenSharePlan(
   capability: VideoCodecSupport,
   screen: ScreenCaptureEnv,
-): VideoPublishPlan {
+): ScreenPublishPlan {
   // `contentHint: "detail"` favours sharpness over motion smoothness — the
   // right call for text/code. It is honoured on the VP8 path; for VP9 SVC
   // LiveKit force-sets the track's hint to "motion" (a Chrome screenshare-SVC
@@ -110,23 +124,85 @@ function screenSharePlan(
 }
 
 /**
- * Camera publish plan. This slice only builds the codec rails; the camera
- * VP9 treatment is a later slice, so today it preserves the existing
- * behavior — a talking head keeps motion smooth and sheds resolution
- * (`maintain-framerate`) — and lets the room's `videoCaptureDefaults` govern
- * capture (`capture: null`).
+ * SVC mode for the VP9 camera: `L3T3` — three spatial layers (the 720/360/180
+ * ladder) and three temporal layers. Unlike the screen share (which Chrome
+ * collapses to temporal-only `L1T3`), camera content encodes spatial layers
+ * fine, so subscribers adapt down the full ladder: a small tile pulls 180p, a
+ * spotlight the 720p top layer, and the SFU drops layers per subscriber.
  */
-function cameraPlan(): VideoPublishPlan {
-  return { capture: null, publish: { degradationPreference: "maintain-framerate" } };
+const CAMERA_SVC_MODE: ScalabilityMode = "L3T3";
+
+/**
+ * Top-layer ceiling for the camera: the 720p band (~1.7 Mbps, 30 fps), the
+ * VP8 `h720` preset bitrate. Deliberately below the old 1080p `h720`→`h1080`
+ * ~3 Mbps ceiling — camera tiles render small in a screen-share-focal call, so
+ * the spare encode/egress/decode budget goes to the focal screen and audio.
+ * Governs both the VP9 primary and the VP8 backup so neither exceeds 720p.
+ */
+const CAMERA_ENCODING: VideoEncoding = {
+  maxBitrate: 1_700_000,
+  maxFramerate: 30,
+};
+
+/**
+ * Capture cap for the camera: 720p (1280×720), the top SVC spatial layer.
+ * Replaces the old 1080p ceiling. Carried as a per-publish `VideoCaptureOptions`
+ * so the builder — not the engine — owns the cap; LiveKit merges it over the
+ * room's `videoCaptureDefaults` without overwriting the camera `deviceId`.
+ */
+const CAMERA_RESOLUTION: VideoResolution = { width: 1280, height: 720, frameRate: 30 };
+
+/**
+ * Per-codec publish options for the camera, gated on the probe exactly like the
+ * screen share: VP9 + SVC with an explicit VP8 backup published alongside via
+ * multi-codec simulcast (so a VP8-only iOS subscriber can't drag capable
+ * viewers down to VP8); VP8-only fallback; nothing forced when neither is
+ * available.
+ */
+function cameraCodec(capability: VideoCodecSupport): TrackPublishOptions {
+  if (capability.vp9.available) {
+    return {
+      videoCodec: "vp9",
+      scalabilityMode: CAMERA_SVC_MODE,
+      ...(capability.vp8.available
+        ? {
+            backupCodec: { codec: "vp8", encoding: { ...CAMERA_ENCODING } },
+            backupCodecPolicy: BackupCodecPolicy.SIMULCAST,
+          }
+        : {}),
+    };
+  }
+  if (capability.vp8.available) return { videoCodec: "vp8" };
+  return {};
+}
+
+function cameraPlan(capability: VideoCodecSupport): CameraPublishPlan {
+  return {
+    capture: { resolution: { ...CAMERA_RESOLUTION } },
+    publish: {
+      ...cameraCodec(capability),
+      videoEncoding: { ...CAMERA_ENCODING },
+      degradationPreference: "maintain-framerate",
+    },
+  };
 }
 
 export function videoPublishPlan(args: {
-  source: VideoPublishSource;
+  source: "camera";
+  capability: VideoCodecSupport;
+}): CameraPublishPlan;
+export function videoPublishPlan(args: {
+  source: "screen";
   capability: VideoCodecSupport;
   /** Screen-capture environment; defaults to "can constrain" (the common,
-   *  non-Safari-17 case). Ignored for the camera source. */
+   *  non-Safari-17 case). */
   screenCapture?: ScreenCaptureEnv;
-}): VideoPublishPlan {
-  if (args.source !== "screen") return cameraPlan();
+}): ScreenPublishPlan;
+export function videoPublishPlan(args: {
+  source: VideoPublishSource;
+  capability: VideoCodecSupport;
+  screenCapture?: ScreenCaptureEnv;
+}): CameraPublishPlan | ScreenPublishPlan {
+  if (args.source !== "screen") return cameraPlan(args.capability);
   return screenSharePlan(args.capability, args.screenCapture ?? { canConstrainResolution: true });
 }

--- a/chat/src/lib/calls/video-codec/video-publish.ts
+++ b/chat/src/lib/calls/video-codec/video-publish.ts
@@ -93,7 +93,10 @@ function screenShareCodec(capability: VideoCodecSupport): TrackPublishOptions {
       scalabilityMode: SCREEN_SHARE_SVC_MODE,
       ...(capability.vp8.available
         ? { backupCodec: { codec: "vp8" }, backupCodecPolicy: BackupCodecPolicy.SIMULCAST }
-        : {}),
+        // `false`, not omitted: an omitted `backupCodec` inherits LiveKit's
+        // `publishDefaults.backupCodec = true`, which re-enables a VP8 backup
+        // the probe said this device can't do. `false` honors the gating.
+        : { backupCodec: false }),
     };
   }
   if (capability.vp8.available) return { videoCodec: "vp8" };
@@ -175,7 +178,10 @@ function cameraCodec(capability: VideoCodecSupport): TrackPublishOptions {
             backupCodec: { codec: "vp8", encoding: { ...CAMERA_ENCODING } },
             backupCodecPolicy: BackupCodecPolicy.SIMULCAST,
           }
-        : {}),
+        // `false`, not omitted: an omitted `backupCodec` inherits LiveKit's
+        // `publishDefaults.backupCodec = true`, which re-enables a VP8 backup
+        // the probe said this device can't do. `false` honors the gating.
+        : { backupCodec: false }),
     };
   }
   if (capability.vp8.available) return { videoCodec: "vp8" };

--- a/chat/tests/call-engine.test.ts
+++ b/chat/tests/call-engine.test.ts
@@ -42,6 +42,28 @@ function captureStub(opts: { micThrows?: Error; camThrows?: Error } = {}) {
   };
 }
 
+/**
+ * Records every `setCameraEnabled(enabled, capture, publish)` the engine
+ * forwards, so a test can assert the camera VP9/720p plan reaches the SDK.
+ */
+function cameraStub() {
+  const calls: Array<{
+    enabled: boolean;
+    capture?: { resolution?: { width?: number; height?: number } };
+    publish?: { videoCodec?: string; scalabilityMode?: string };
+  }> = [];
+  return {
+    calls,
+    async setCameraEnabled(
+      enabled: boolean,
+      capture?: { resolution?: { width?: number; height?: number } },
+      publish?: { videoCodec?: string; scalabilityMode?: string },
+    ) {
+      calls.push({ enabled, capture, publish });
+    },
+  };
+}
+
 function screenShareStub(opts: { audioThrows?: Error } = {}) {
   const calls: Array<{ enabled: boolean; audio: boolean }> = [];
   return {
@@ -354,6 +376,37 @@ describe("call-engine module", () => {
     };
     expect(remote.source).toBe("screen_share");
     expect(local.source).toBe("screen_share_audio");
+  });
+
+  test("setCameraEnabled forwards the VP9 720p camera plan (capture + publish) to LiveKit", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const capable = videoCodecSupport({
+      encode: ["video/vp8", "video/vp9"],
+      decode: ["video/vp8", "video/vp9"],
+    });
+    const engine = new CallEngine({ videoCodecSupport: capable });
+    const participant = cameraStub();
+    (engine as unknown as { room: unknown }).room = { localParticipant: participant };
+    await engine.setCameraEnabled(true);
+    expect(participant.calls).toHaveLength(1);
+    const [call] = participant.calls;
+    expect(call.enabled).toBe(true);
+    expect(call.capture?.resolution?.height).toBe(720);
+    expect(call.publish?.videoCodec).toBe("vp9");
+    expect(call.publish?.scalabilityMode).toBe("L3T3");
+  });
+
+  test("setCameraEnabled forwards the VP8 720p fallback on a VP9-incapable device", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const incapable = videoCodecSupport({ encode: ["video/vp8"], decode: ["video/vp8"] });
+    const engine = new CallEngine({ videoCodecSupport: incapable });
+    const participant = cameraStub();
+    (engine as unknown as { room: unknown }).room = { localParticipant: participant };
+    await engine.setCameraEnabled(true);
+    const [call] = participant.calls;
+    expect(call.capture?.resolution?.height).toBe(720);
+    expect(call.publish?.videoCodec).toBe("vp8");
+    expect(call.publish?.scalabilityMode).toBeUndefined();
   });
 
   test("setScreenShareEnabled delegates video-only requests to LiveKit", async () => {
@@ -687,9 +740,12 @@ describe("call-engine module", () => {
 describe("enableRequestedCapture — best-effort, never ejects", () => {
   // Publish options are irrelevant to the best-effort guarantees here; any
   // typed bundle satisfies the (now required) parameter.
-  const cameraOpts = { degradationPreference: "maintain-framerate" as const };
+  const cameraPlan = {
+    capture: { resolution: { width: 1280, height: 720, frameRate: 30 } },
+    publish: { degradationPreference: "maintain-framerate" as const },
+  };
   const audioOpts = { audioPreset: { maxBitrate: 64_000 }, red: true, dtx: true, forceStereo: false };
-  const publish = { audio: audioOpts, camera: cameraOpts };
+  const publish = { audio: audioOpts, camera: cameraPlan };
 
   test("enables both tracks when capture succeeds", async () => {
     const stub = captureStub();
@@ -1109,7 +1165,10 @@ describe("call-engine — camera capture ceiling + per-source degradation", () =
     };
   }
 
-  test("setCameraEnabled publishes the camera with maintain-framerate degradation and no codec override", async () => {
+  test("setCameraEnabled caps capture at 720p with maintain-framerate; no codec forced when the probe reports none", async () => {
+    // `new CallEngine()` in bun's node env has no RTCRtpSender, so the probe
+    // reports no codecs — the camera is still capped at 720p and sheds
+    // resolution under pressure, but no codec is forced (LiveKit picks).
     const { CallEngine } = await import("../src/lib/calls/engine");
     const engine = new CallEngine();
     const stub = videoRoomStub();
@@ -1118,28 +1177,36 @@ describe("call-engine — camera capture ceiling + per-source degradation", () =
     expect(stub.camera).toEqual([
       {
         enabled: true,
-        options: undefined,
-        publishOptions: { degradationPreference: "maintain-framerate" },
+        options: { resolution: { width: 1280, height: 720, frameRate: 30 } },
+        publishOptions: {
+          videoEncoding: { maxBitrate: 1_700_000, maxFramerate: 30 },
+          degradationPreference: "maintain-framerate",
+        },
       },
     ]);
   });
 
-  test("enableRequestedCapture forwards the camera publish options it is given", async () => {
-    const camera: Array<{ enabled: boolean; publishOptions: unknown }> = [];
+  test("enableRequestedCapture forwards both the camera capture cap and publish options it is given", async () => {
+    const camera: Array<{ enabled: boolean; options: unknown; publishOptions: unknown }> = [];
     const stub = {
       async setMicrophoneEnabled() {},
-      async setCameraEnabled(enabled: boolean, _options?: unknown, publishOptions?: unknown) {
-        camera.push({ enabled, publishOptions });
+      async setCameraEnabled(enabled: boolean, options?: unknown, publishOptions?: unknown) {
+        camera.push({ enabled, options, publishOptions });
       },
     };
-    const cameraPublishOptions = { degradationPreference: "maintain-framerate" as const };
+    const cameraPlan = {
+      capture: { resolution: { width: 1280, height: 720, frameRate: 30 } },
+      publish: { videoCodec: "vp9" as const, degradationPreference: "maintain-framerate" as const },
+    };
     await enableRequestedCapture(
       stub,
       { audio: false, video: true },
       () => {},
-      { audio: {}, camera: cameraPublishOptions },
+      { audio: {}, camera: cameraPlan },
     );
-    expect(camera).toEqual([{ enabled: true, publishOptions: cameraPublishOptions }]);
+    expect(camera).toEqual([
+      { enabled: true, options: cameraPlan.capture, publishOptions: cameraPlan.publish },
+    ]);
   });
 });
 
@@ -1189,7 +1256,7 @@ describe("call-engine — Opus voice-clarity audio publish profile (#998)", () =
       stub,
       { audio: true, video: false },
       () => {},
-      { audio: audioPublishOpts, camera: {} },
+      { audio: audioPublishOpts, camera: { capture: { resolution: { width: 1280, height: 720 } }, publish: {} } },
     );
     expect(mic).toEqual([{ enabled: true, publishOptions: audioPublishOpts }]);
   });

--- a/chat/tests/call-engine.test.ts
+++ b/chat/tests/call-engine.test.ts
@@ -42,28 +42,6 @@ function captureStub(opts: { micThrows?: Error; camThrows?: Error } = {}) {
   };
 }
 
-/**
- * Records every `setCameraEnabled(enabled, capture, publish)` the engine
- * forwards, so a test can assert the camera VP9/720p plan reaches the SDK.
- */
-function cameraStub() {
-  const calls: Array<{
-    enabled: boolean;
-    capture?: { resolution?: { width?: number; height?: number } };
-    publish?: { videoCodec?: string; scalabilityMode?: string };
-  }> = [];
-  return {
-    calls,
-    async setCameraEnabled(
-      enabled: boolean,
-      capture?: { resolution?: { width?: number; height?: number } },
-      publish?: { videoCodec?: string; scalabilityMode?: string },
-    ) {
-      calls.push({ enabled, capture, publish });
-    },
-  };
-}
-
 function screenShareStub(opts: { audioThrows?: Error } = {}) {
   const calls: Array<{ enabled: boolean; audio: boolean }> = [];
   return {
@@ -376,37 +354,6 @@ describe("call-engine module", () => {
     };
     expect(remote.source).toBe("screen_share");
     expect(local.source).toBe("screen_share_audio");
-  });
-
-  test("setCameraEnabled forwards the VP9 720p camera plan (capture + publish) to LiveKit", async () => {
-    const { CallEngine } = await import("../src/lib/calls/engine");
-    const capable = videoCodecSupport({
-      encode: ["video/vp8", "video/vp9"],
-      decode: ["video/vp8", "video/vp9"],
-    });
-    const engine = new CallEngine({ videoCodecSupport: capable });
-    const participant = cameraStub();
-    (engine as unknown as { room: unknown }).room = { localParticipant: participant };
-    await engine.setCameraEnabled(true);
-    expect(participant.calls).toHaveLength(1);
-    const [call] = participant.calls;
-    expect(call.enabled).toBe(true);
-    expect(call.capture?.resolution?.height).toBe(720);
-    expect(call.publish?.videoCodec).toBe("vp9");
-    expect(call.publish?.scalabilityMode).toBe("L3T3");
-  });
-
-  test("setCameraEnabled forwards the VP8 720p fallback on a VP9-incapable device", async () => {
-    const { CallEngine } = await import("../src/lib/calls/engine");
-    const incapable = videoCodecSupport({ encode: ["video/vp8"], decode: ["video/vp8"] });
-    const engine = new CallEngine({ videoCodecSupport: incapable });
-    const participant = cameraStub();
-    (engine as unknown as { room: unknown }).room = { localParticipant: participant };
-    await engine.setCameraEnabled(true);
-    const [call] = participant.calls;
-    expect(call.capture?.resolution?.height).toBe(720);
-    expect(call.publish?.videoCodec).toBe("vp8");
-    expect(call.publish?.scalabilityMode).toBeUndefined();
   });
 
   test("setScreenShareEnabled delegates video-only requests to LiveKit", async () => {
@@ -1184,6 +1131,35 @@ describe("call-engine — camera capture ceiling + per-source degradation", () =
         },
       },
     ]);
+  });
+
+  test("setCameraEnabled forwards the VP9 + L3T3 720p plan to the SDK on a capable device", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const capable = videoCodecSupport({
+      encode: ["video/vp8", "video/vp9"],
+      decode: ["video/vp8", "video/vp9"],
+    });
+    const engine = new CallEngine({ videoCodecSupport: capable });
+    const stub = videoRoomStub();
+    (engine as unknown as { room: unknown }).room = stub.room;
+    await engine.setCameraEnabled(true);
+    expect(stub.camera).toHaveLength(1);
+    const [call] = stub.camera;
+    expect(call?.options).toEqual({ resolution: { width: 1280, height: 720, frameRate: 30 } });
+    expect(call?.publishOptions).toMatchObject({ videoCodec: "vp9", scalabilityMode: "L3T3" });
+  });
+
+  test("setCameraEnabled forwards the VP8 720p fallback on a VP9-incapable device (iOS)", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const incapable = videoCodecSupport({ encode: ["video/vp8"], decode: ["video/vp8"] });
+    const engine = new CallEngine({ videoCodecSupport: incapable });
+    const stub = videoRoomStub();
+    (engine as unknown as { room: unknown }).room = stub.room;
+    await engine.setCameraEnabled(true);
+    const [call] = stub.camera;
+    expect(call?.options).toEqual({ resolution: { width: 1280, height: 720, frameRate: 30 } });
+    expect(call?.publishOptions).toMatchObject({ videoCodec: "vp8" });
+    expect(call?.publishOptions).not.toHaveProperty("scalabilityMode");
   });
 
   test("enableRequestedCapture forwards both the camera capture cap and publish options it is given", async () => {

--- a/chat/tests/call-media-path-telemetry.test.ts
+++ b/chat/tests/call-media-path-telemetry.test.ts
@@ -12,6 +12,7 @@ const RELAY_TCP: CallMediaPathSnapshot = {
   iceCandidateType: "relay",
   iceTransport: "tcp",
   audioBitrateBand: null,
+  videoResolutionBand: "1440p",
 };
 
 describe("callMediaPathEventAttributes", () => {
@@ -22,6 +23,7 @@ describe("callMediaPathEventAttributes", () => {
       codec: "VP9",
       ice_candidate_type: "relay",
       ice_transport: "tcp",
+      video_resolution_band: "1440p",
     });
   });
 
@@ -34,6 +36,7 @@ describe("callMediaPathEventAttributes", () => {
         iceCandidateType: null,
         iceTransport: null,
         audioBitrateBand: null,
+        videoResolutionBand: null,
       }),
     ).toEqual({
       direction: "recv",
@@ -42,6 +45,20 @@ describe("callMediaPathEventAttributes", () => {
       ice_candidate_type: "unknown",
       ice_transport: "unknown",
     });
+  });
+
+  test("a camera path carries its resolution band — the 720p-vs-1080p egress signal", () => {
+    expect(
+      callMediaPathEventAttributes({
+        direction: "send",
+        source: "camera",
+        codec: "VP9",
+        iceCandidateType: "host",
+        iceTransport: "udp",
+        audioBitrateBand: null,
+        videoResolutionBand: "720p",
+      }),
+    ).toMatchObject({ source: "camera", codec: "VP9", video_resolution_band: "720p" });
   });
 
   test("an audio path carries the bitrate band (active-speaker signal), codec and source", () => {
@@ -53,6 +70,7 @@ describe("callMediaPathEventAttributes", () => {
         iceCandidateType: "host",
         iceTransport: "udp",
         audioBitrateBand: "high",
+        videoResolutionBand: null,
       }),
     ).toEqual({
       direction: "send",
@@ -68,6 +86,20 @@ describe("callMediaPathEventAttributes", () => {
     expect(callMediaPathEventAttributes(RELAY_TCP)).not.toHaveProperty("audio_bitrate_band");
   });
 
+  test("an audio path omits the video_resolution_band attribute entirely", () => {
+    expect(
+      callMediaPathEventAttributes({
+        direction: "send",
+        source: "microphone",
+        codec: "opus",
+        iceCandidateType: "host",
+        iceTransport: "udp",
+        audioBitrateBand: "high",
+        videoResolutionBand: null,
+      }),
+    ).not.toHaveProperty("video_resolution_band");
+  });
+
   test("never emits participant identifiers or JIDs", () => {
     const attrs = callMediaPathEventAttributes(RELAY_TCP);
     const allowed = new Set([
@@ -77,6 +109,7 @@ describe("callMediaPathEventAttributes", () => {
       "ice_candidate_type",
       "ice_transport",
       "audio_bitrate_band",
+      "video_resolution_band",
     ]);
     for (const key of Object.keys(attrs)) {
       expect(allowed.has(key)).toBe(true);
@@ -125,6 +158,7 @@ describe("createCallMediaPathBeacon", () => {
       iceCandidateType: "host",
       iceTransport: "udp",
       audioBitrateBand: band,
+      videoResolutionBand: null,
     });
 
     beacon.observe(audio("silent"));
@@ -132,6 +166,17 @@ describe("createCallMediaPathBeacon", () => {
     beacon.observe(audio("silent")); // back to a band already seen → no re-beacon
 
     expect(reported.map((s) => s.audioBitrateBand)).toEqual(["silent", "high"]);
+  });
+
+  test("re-beacons when the camera resolution band changes (1080p → 720p cap)", () => {
+    const reported: CallMediaPathSnapshot[] = [];
+    const beacon = createCallMediaPathBeacon((s) => reported.push(s));
+
+    beacon.observe(snap({ source: "camera", videoResolutionBand: "1080p" }));
+    beacon.observe(snap({ source: "camera", videoResolutionBand: "720p" }));
+
+    expect(reported).toHaveLength(2);
+    expect(reported.map((s) => s.videoResolutionBand)).toEqual(["1080p", "720p"]);
   });
 
   test("re-beacons when the ICE path changes (relay → host)", () => {

--- a/chat/tests/call-stats.test.ts
+++ b/chat/tests/call-stats.test.ts
@@ -5,6 +5,7 @@ import {
   formatBitrate,
   summarizeAudioStats,
   summarizeVideoStats,
+  videoResolutionBand,
   type CallStatSample,
 } from "../src/lib/calls/call-stats";
 
@@ -472,6 +473,28 @@ describe("audioBitrateBand — coarse band over the measured on-the-wire audio r
 
   test("an unmeasured bitrate (null, first poll) has no band yet", () => {
     expect(audioBitrateBand(null)).toBeNull();
+  });
+});
+
+describe("videoResolutionBand — coarse band over the negotiated top-layer resolution", () => {
+  test("the camera's new 720p cap and the old 1080p baseline land in distinct bands", () => {
+    // The egress signal for the #1001 camera lever: a fleet-wide shift from
+    // "1080p" to "720p" is what proves the cap took effect and reduced egress.
+    expect(videoResolutionBand("1280×720")).toBe("720p");
+    expect(videoResolutionBand("1920×1080")).toBe("1080p");
+  });
+
+  test("the lower SVC layers a small tile pulls read as their own bands", () => {
+    expect(videoResolutionBand("320×180")).toBe("180p");
+    expect(videoResolutionBand("640×360")).toBe("360p");
+  });
+
+  test("a higher-than-1080p share (screen QHD) reads '1440p'", () => {
+    expect(videoResolutionBand("2560×1440")).toBe("1440p");
+  });
+
+  test("an unreported resolution (null, first poll) has no band yet", () => {
+    expect(videoResolutionBand(null)).toBeNull();
   });
 });
 

--- a/chat/tests/call-stats.test.ts
+++ b/chat/tests/call-stats.test.ts
@@ -496,6 +496,24 @@ describe("videoResolutionBand — coarse band over the negotiated top-layer reso
   test("an unreported resolution (null, first poll) has no band yet", () => {
     expect(videoResolutionBand(null)).toBeNull();
   });
+
+  test("bands a real summarizeVideoStats resolution — guards the W×H separator coupling", () => {
+    // End-to-end: the band classifier splits on the exact separator
+    // summarizeVideoStats emits. If either side ever diverges (e.g. ASCII 'x'
+    // vs U+00D7), every band would silently go null — this catches that.
+    const camera720 = {
+      type: "outbound-rtp",
+      kind: "video",
+      frameWidth: 1280,
+      frameHeight: 720,
+      framesPerSecond: 30,
+      bytesSent: 500_000,
+      packetsSent: 500,
+      timestamp: 10_000,
+    };
+    const { summary } = summarizeVideoStats(report([camera720]), "send");
+    expect(videoResolutionBand(summary.resolution)).toBe("720p");
+  });
 });
 
 describe("summarizeAudioStats — outbound (send) audio", () => {

--- a/chat/tests/call-video-publish.test.ts
+++ b/chat/tests/call-video-publish.test.ts
@@ -117,16 +117,101 @@ describe("videoPublishPlan — pure: returns fresh objects callers can't alias",
   });
 });
 
-describe("videoPublishPlan — camera preserves current behavior (rails only this slice)", () => {
-  test("a talking head sheds resolution before framerate and gets no codec override", () => {
+describe("videoPublishPlan — camera on a VP9-capable device", () => {
+  test("publishes VP9", () => {
     const plan = videoPublishPlan({ source: "camera", capability: capable });
-    expect(plan.publish.degradationPreference).toBe("maintain-framerate");
-    expect(plan.publish.videoCodec).toBeUndefined();
-    expect(plan.publish.scalabilityMode).toBeUndefined();
+    expect(plan.publish.videoCodec).toBe("vp9");
   });
 
-  test("camera capture is governed by the room defaults, not this plan", () => {
+  test("enables L3T3 spatial+temporal SVC and an explicit VP8 backup codec", () => {
+    // Unlike the screen share (forced to temporal-only L1T3), the camera can
+    // encode spatial layers, so L3 gives the 720/360/180 ladder subscribers
+    // adapt down — small tiles pull the 180p layer, a spotlight the 720p one.
     const plan = videoPublishPlan({ source: "camera", capability: capable });
-    expect(plan.capture).toBeNull();
+    expect(plan.publish.scalabilityMode).toBe("L3T3");
+    expect(plan.publish.backupCodec).toMatchObject({ codec: "vp8" });
+  });
+
+  test("keeps capable viewers on VP9 in a mixed room via multi-codec simulcast", () => {
+    const plan = videoPublishPlan({ source: "camera", capability: capable });
+    expect(plan.publish.backupCodecPolicy).toBe(BackupCodecPolicy.SIMULCAST);
+  });
+
+  test("caps the top layer at the 720p band (~1.7 Mbps), below the old 1080p ~3 Mbps", () => {
+    const plan = videoPublishPlan({ source: "camera", capability: capable });
+    expect(plan.publish.videoEncoding?.maxBitrate).toBe(1_700_000);
+    const fps = plan.publish.videoEncoding?.maxFramerate ?? 0;
+    expect(fps).toBeGreaterThanOrEqual(24);
+    expect(fps).toBeLessThanOrEqual(30);
+  });
+
+  test("caps the VP8 backup at the same 720p band so the fallback never exceeds it", () => {
+    const plan = videoPublishPlan({ source: "camera", capability: capable });
+    const backup = plan.publish.backupCodec;
+    expect(backup).not.toBe(false);
+    if (backup && backup !== true) {
+      expect(backup.encoding?.maxBitrate).toBe(1_700_000);
+    }
+  });
+
+  test("caps capture at 720p — no longer the old 1080p ceiling", () => {
+    const plan = videoPublishPlan({ source: "camera", capability: capable });
+    expect(plan.capture?.resolution?.width).toBe(1280);
+    expect(plan.capture?.resolution?.height).toBe(720);
+  });
+
+  test("a talking head sheds resolution before framerate (maintain-framerate)", () => {
+    const plan = videoPublishPlan({ source: "camera", capability: capable });
+    expect(plan.publish.degradationPreference).toBe("maintain-framerate");
+  });
+
+  test("camera capture carries only resolution so the room's deviceId survives the merge", () => {
+    const plan = videoPublishPlan({ source: "camera", capability: capable });
+    expect(Object.keys(plan.capture)).toEqual(["resolution"]);
+  });
+});
+
+describe("videoPublishPlan — camera on a VP9-incapable device (iOS)", () => {
+  test("falls back to VP8 with no SVC and no backup codec", () => {
+    const plan = videoPublishPlan({ source: "camera", capability: incapable });
+    expect(plan.publish.videoCodec).toBe("vp8");
+    expect(plan.publish.scalabilityMode).toBeUndefined();
+    expect(plan.publish.backupCodec).toBeUndefined();
+  });
+
+  test("keeps the fallback first-class: same 720p capture cap, encoding and degradation", () => {
+    const fallback = videoPublishPlan({ source: "camera", capability: incapable });
+    const best = videoPublishPlan({ source: "camera", capability: capable });
+    expect(fallback.capture).toEqual(best.capture);
+    expect(fallback.publish.videoEncoding).toEqual(best.publish.videoEncoding);
+    expect(fallback.publish.degradationPreference).toBe("maintain-framerate");
+  });
+});
+
+describe("videoPublishPlan — camera codec gating matches the probe", () => {
+  test("neither codec available → videoCodec unset for LiveKit to pick, still 720p", () => {
+    const plan = videoPublishPlan({ source: "camera", capability: noCodecs });
+    expect(plan.publish.videoCodec).toBeUndefined();
+    expect(plan.publish.backupCodec).toBeUndefined();
+    expect(plan.publish.backupCodecPolicy).toBeUndefined();
+    expect(plan.capture.resolution?.height).toBe(720);
+  });
+
+  test("VP9 without an available VP8 baseline publishes VP9 with no backup", () => {
+    const plan = videoPublishPlan({ source: "camera", capability: vp9OnlyEncode });
+    expect(plan.publish.videoCodec).toBe("vp9");
+    expect(plan.publish.scalabilityMode).toBe("L3T3");
+    expect(plan.publish.backupCodec).toBeUndefined();
+    expect(plan.publish.backupCodecPolicy).toBeUndefined();
+  });
+});
+
+describe("videoPublishPlan — camera is pure: callers can't alias shared objects", () => {
+  test("two camera plans don't share mutable option objects", () => {
+    const a = videoPublishPlan({ source: "camera", capability: capable });
+    const b = videoPublishPlan({ source: "camera", capability: capable });
+    expect(a.publish).not.toBe(b.publish);
+    expect(a.capture).not.toBe(b.capture);
+    expect(a.publish.videoEncoding).not.toBe(b.publish.videoEncoding);
   });
 });

--- a/chat/tests/call-video-publish.test.ts
+++ b/chat/tests/call-video-publish.test.ts
@@ -165,9 +165,12 @@ describe("videoPublishPlan — camera on a VP9-capable device", () => {
     expect(plan.publish.degradationPreference).toBe("maintain-framerate");
   });
 
-  test("camera capture carries only resolution so the room's deviceId survives the merge", () => {
+  test("camera capture sets resolution but no deviceId, so the room default survives LiveKit's merge", () => {
     const plan = videoPublishPlan({ source: "camera", capability: capable });
-    expect(Object.keys(plan.capture)).toEqual(["resolution"]);
+    expect(plan.capture).toEqual({ resolution: { width: 1280, height: 720, frameRate: 30 } });
+    // No deviceId: LiveKit's merge-without-overwriting fills the room's chosen
+    // camera in; if the builder set one here it would clobber that choice.
+    expect("deviceId" in plan.capture).toBe(false);
   });
 });
 

--- a/chat/tests/call-video-publish.test.ts
+++ b/chat/tests/call-video-publish.test.ts
@@ -78,10 +78,14 @@ describe("videoPublishPlan — codec gating matches the probe (no codec the devi
     expect(plan.publish.backupCodecPolicy).toBeUndefined();
   });
 
-  test("VP9 without an available VP8 baseline publishes VP9 with no backup", () => {
+  test("VP9 without an available VP8 baseline explicitly disables the backup (false, not omitted)", () => {
+    // `backupCodec` must be `false`, not just omitted: LiveKit merges per-publish
+    // options over `publishDefaults`, whose `backupCodec` default is `true`, so
+    // an omitted value silently re-enables a VP8 backup — forcing the exact codec
+    // the probe reported unavailable. `false` is what actually honors the gating.
     const plan = videoPublishPlan({ source: "screen", capability: vp9OnlyEncode });
     expect(plan.publish.videoCodec).toBe("vp9");
-    expect(plan.publish.backupCodec).toBeUndefined();
+    expect(plan.publish.backupCodec).toBe(false);
     expect(plan.publish.backupCodecPolicy).toBeUndefined();
   });
 });
@@ -200,11 +204,14 @@ describe("videoPublishPlan — camera codec gating matches the probe", () => {
     expect(plan.capture.resolution?.height).toBe(720);
   });
 
-  test("VP9 without an available VP8 baseline publishes VP9 with no backup", () => {
+  test("VP9 without an available VP8 baseline explicitly disables the backup (false, not omitted)", () => {
+    // See the screen-share twin: an omitted `backupCodec` inherits LiveKit's
+    // `publishDefaults.backupCodec = true` and re-enables a VP8 backup the probe
+    // said the device can't do. `false` is the value that honors the gating.
     const plan = videoPublishPlan({ source: "camera", capability: vp9OnlyEncode });
     expect(plan.publish.videoCodec).toBe("vp9");
     expect(plan.publish.scalabilityMode).toBe("L3T3");
-    expect(plan.publish.backupCodec).toBeUndefined();
+    expect(plan.publish.backupCodec).toBe(false);
     expect(plan.publish.backupCodecPolicy).toBeUndefined();
   });
 });


### PR DESCRIPTION
## What & why

Closes #1001 (parent: #995). Publishes the **camera** track as **VP9 with L3T3 SVC (720/360/180), capped at a 720p top layer**, `maintain-framerate`, with a **VP8 backup capped at 720p** — deliberately lower than the old 1080p ceiling.

In this topology (5–15 people, screen-share focal) camera tiles render small, so capping the camera reclaims publisher encode, SFU egress, and subscriber decode budget for the focal screen-share and audio, with no perceptible loss. Reuses the capability probe + publish-option rails from the screen-share slice (#1009).

## Approach (mirrors the screen-share slice, for the camera source)

**Builder** — `chat/src/lib/calls/video-codec/video-publish.ts`. Extend the pure `cameraPlan(capability)` so that, gated on the codec probe, it emits:
- VP9 + `L3T3` SVC when VP9-capable; first-class VP8-only fallback (iOS); nothing forced when neither codec is available (LiveKit picks).
- `videoEncoding` capped at the 720p band (~1.7 Mbps / 30 fps, the `h720` preset; down from the 1080p ~3 Mbps).
- `backupCodec: { codec: "vp8", encoding: <720p band> }` + `BackupCodecPolicy.SIMULCAST`, so a VP8-only subscriber can't drag capable viewers down to VP8. The backup carries its **own** encoding because the top-level `videoEncoding` bounds only the primary codec's layers — documented inline.
- `degradationPreference: "maintain-framerate"` (talking head keeps motion, sheds resolution).
- `capture: { resolution: 1280×720 }` — the cap lives in the builder; the engine stays thin. Per-source overloads type `capture` precisely (`VideoCaptureOptions` for camera, `ScreenShareCaptureOptions` for screen).

**Engine** — `chat/src/lib/calls/engine.ts`. Forward the camera `capture` to the SDK in `setCameraEnabled` and at the initial join (`enableRequestedCapture` now carries the full `CameraPublishPlan`); drop the room `videoCaptureDefaults.resolution: h1080` override (and the now-unused `VideoPresets` import). The per-publish 720p capture wins via LiveKit's `mergeObjectWithoutOverwriting`, so the camera `deviceId` is preserved.

**Telemetry** — `chat/src/lib/calls/{call-stats,call-media-path-telemetry,use-call-engine}.ts`. The `call-media-path` beacon already tagged `source: camera` + the negotiated `codec`, but dropped resolution — so "720p" / "reduced egress vs 1080p" were unverifiable. Add a low-cardinality `video_resolution_band` (180p…1440p) to the snapshot + beacon, mirroring the #998 `audio_bitrate_band` pattern: a fleet shift from `1080p`→`720p` is now the proof the cap took effect and reduced camera egress/decode.

## Acceptance criteria

- [x] Builders, given source = camera + capability, return VP9 + L3T3 SVC capped at 720p, maintain-framerate, and a 720p-capped VP8 backup. *(`call-video-publish.test.ts`)*
- [x] Camera capture/publish no longer targets 1080p. *(room override removed; capture cap is 1280×720)*
- [x] The engine forwards the camera options to the SDK; verified via stub-Room injection. *(`call-engine.test.ts`, capable / iOS / probe-reports-none branches)*
- [x] Call-media telemetry shows the camera negotiated as 720p VP9 on capable devices and reduced egress vs 1080p — now beaconed as `codec` + `video_resolution_band`.
- [x] A spotlighted/promoted camera tile still renders acceptably at 720p — `adaptiveStream` + the L3 720/360/180 ladder let a spotlight pull the 720p top layer while small tiles pull 180p.
- [x] Builders covered by unit tests asserting the returned option objects.
- [x] `bun test` (2302) passes and `knip` is clean in `chat/`.

## Notes

- XEP conformance: N/A for this slice — LiveKit media-plane (WebRTC) codec config plus a Faro observability beacon (within the CLAUDE.md beacon exception), no XMPP/Jingle wire shape. Call signalling / XEP-0215 ICE injection shipped separately (#1011).

## Review

Three adversarial persona reviews (WebRTC/LiveKit correctness — SDK-cited; spec conformance; code/test quality) plus a final pass. All findings addressed: the telemetry resolution gap (criterion 4), a shape-coupled test, an undocumented backup-encoding divergence, duplicated engine tests, and an end-to-end separator-coupling guard. Final pass found no remaining actionable issues.

**Codex P2 (post-open), fixed in f3bbf702:** in the VP9-available-but-VP8-unavailable branch the publish options omitted `backupCodec`, so LiveKit inherited its `publishDefaults.backupCodec = true` default and would publish a VP8 backup — forcing a codec the probe said the device can't do. Now set `backupCodec: false` explicitly in that branch (camera **and** the sibling screen-share); tests assert `=== false`.

## Verification

- `bun test` → 2302 pass / 0 fail. `bunx tsc --noEmit` → clean. `bunx knip` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
