### PR TITLE
fix(chat): keep focus in composer after sending

### DIFF
--- a/chat/src/components/chat/MessageComposer.vue
+++ b/chat/src/components/chat/MessageComposer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch, onBeforeUnmount } from "vue";
+import { ref, computed, watch, onBeforeUnmount, nextTick } from "vue";
 import { Send, Paperclip, FileText, Music4, Puzzle, X, Loader2, Megaphone, Radio, CornerDownLeft } from "lucide-vue-next";
 import type { JSONContent } from "@tiptap/core";
 import GifPicker from "@/components/chat/GifPicker.vue";
@@ -489,11 +489,24 @@ async function onSend(doc: JSONContent) {
     );
   } finally {
     isPreparingSend.value = false;
+    refocusAfterSend();
   }
 }
 
 function focus() {
   editorRef.value?.focus();
+}
+
+/**
+ * Return the caret to the composer after a send so the user can keep typing
+ * without re-clicking the input. Both send paths pull focus out of the
+ * editor: clicking the send button moves focus onto the button, and the
+ * brief `isPreparingSend` disable toggles the editor's `contenteditable`
+ * off, which blurs it. Wait a tick so the editor is editable again before
+ * focusing.
+ */
+function refocusAfterSend() {
+  void nextTick(() => editorRef.value?.focus());
 }
 
 function focusExtensions() {
@@ -575,6 +588,7 @@ function onGifSelected(url: string) {
   if (isPreparingSend.value) return;
   showGifPicker.value = false;
   emit("selectGif", url);
+  refocusAfterSend();
 }
 
 function onEditorPaste(e: ClipboardEvent) {


### PR DESCRIPTION
## Problem

After sending a message, the caret left the message composer input. The user
had to click back into the composer before they could type the next message —
a jarring break in the chat flow that every mainstream chat app avoids.

## Root cause

Two distinct send paths pull DOM focus out of the editor:

1. **Send button click** — clicking the `<button>` moves browser focus onto
   the button, away from the ProseMirror editor.
2. **Enter-key send** — `onSend` flips `isPreparingSend` true while it prepares
   the payload. That disables `ChatEditor` (`:disabled="… || isPreparingSend"`),
   which calls `setEditable(false)` and toggles `contenteditable` off, blurring
   ProseMirror. Re-enabling it afterwards does **not** restore focus.

The post-send `clearContent()` then leaves an unfocused, empty composer.

## Fix

Restore focus to the editor on the next tick (once it is editable again) after:

- a committed text send (`onSend` `finally`), and
- a GIF send (`onGifSelected`).

A single `refocusAfterSend()` helper wraps `nextTick(() => editorRef.value?.focus())`.
`nextTick` ensures the `isPreparingSend → false` change has propagated and the
editor is editable before we focus. Placing the call in the `finally` means it
runs only once a send is actually committed (after all the autocomplete /
empty / forum-title guards), and on both success and failure — on failure the
draft is preserved, so keeping focus is exactly right for a retry.

## Scope / coverage

Every composer surface renders this one `MessageComposer`, so the fix covers
all of them with no per-surface wiring:

- channels & DMs — `ContentArea.vue`
- threads — `ThreadPanel.vue`
- call chat — `CallExpandedSurface.vue`

## XEP / conformance

Pure client-side focus management. No XMPP wire behavior, namespaces, or
stanza shapes are touched, so no XEP surface is involved.

## Verification

- `bunx knip` — clean (lint hard rule).
- `astro check` — no new type errors (the single pre-existing
  `cloudflare:workers` virtual-module error in `AppLayout.astro` is unrelated).
- `bun test` — 2040/2040 relevant tests pass. The one failure
  (`startup-loading.test.ts`) requires an `astro build` `dist/` output that
  only exists in CI; unrelated to this change.

A component-level focus regression test was not added: the chat test harness
renders SFCs via SSR `renderToString` only (no mount lifecycle / `document.activeElement`),
and no DOM-mount harness (`happy-dom` / `@vue/test-utils`) is configured, so
focus behavior is not assertable without new infra disproportionate to this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)