### PR TITLE
fix(server): stop 1:1 DM calls erroring with feature-not-implemented

### DIFF
--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
@@ -350,10 +350,15 @@ pub async fn handle_iq_with_conn_state(
         response_to,
     };
 
-    let sans_io_response =
-        handle_sans_io_iq(handler_ctx, state, authenticated_session, phase, conn_state).await;
-    if !sans_io_response.is_empty() {
-        return sans_io_response;
+    // `Some(_)` means a registered dispatcher handler owned this IQ;
+    // it is terminal even when the frame list is empty (e.g. a Jingle
+    // 1:1 stanza forwarded to the peer with no synchronous reply for
+    // the sender). Only `None` — no handler claimed the namespace —
+    // continues to the remaining branches below.
+    if let Some(frames) =
+        handle_sans_io_iq(handler_ctx, state, authenticated_session, phase, conn_state).await
+    {
+        return frames;
     }
 
     let misc_response = handle_misc_iq(handler_ctx, state, phase, conn_state).await;

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/sans_io.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/sans_io.rs
@@ -14,13 +14,29 @@ fn events_contain_iq_error(events: &[waddle_xmpp::protocol::OutboundEvent]) -> b
     })
 }
 
+/// Dispatch an IQ whose payload namespace has a registered handler in
+/// the protocol dispatcher.
+///
+/// Returns `Some(frames)` when a registered handler owned the IQ —
+/// even when `frames` is empty. An empty `Some` is a legitimate,
+/// terminal outcome: a handler may forward the stanza to a peer
+/// (`OutboundEvent::RouteToConnection`) and produce no synchronous
+/// frame for the sender (e.g. XEP-0166 Jingle 1:1 `session-initiate`,
+/// which the peer's client answers). The caller MUST treat `Some(_)`
+/// as final and NOT fall through to the unhandled-IQ branch, otherwise
+/// a successfully-forwarded call IQ is wrongly answered with
+/// `feature-not-implemented`.
+///
+/// Returns `None` only when no registered handler claims the
+/// namespace, so the caller can continue to the remaining (disco,
+/// misc, MUC, pubsub) branches.
 pub(super) async fn handle_sans_io_iq(
     ctx: IqHandlerContext<'_>,
     state: &WebSocketState,
     authenticated_session: &Option<Session>,
     phase: &ConnectionPhase,
     conn_state: &mut IqConnState<'_>,
-) -> Vec<String> {
+) -> Option<Vec<String>> {
     let iq = ctx.iq;
     let id = ctx.id;
     let payload_ns = ctx.payload_ns;
@@ -46,53 +62,53 @@ pub(super) async fn handle_sans_io_iq(
     };
     if state.deps.protocol.dispatcher.has_iq_handler(payload_ns) {
         if payload_ns == waddle_xmpp::xep::NS_VERSION && !is_version_query(iq) {
-            return vec![build_iq_error_xml_typed(
+            return Some(vec![build_iq_error_xml_typed(
                 id,
                 response_from,
                 response_to,
                 bad_request_iq_error("Malformed IQ payload."),
-            )];
+            )]);
         }
         if payload_ns == waddle_xmpp::xep::NS_VERSION
             && iq
                 .to()
                 .is_some_and(|target| target.to_bare().as_str() != domain)
         {
-            return vec![build_iq_error_xml_typed(
+            return Some(vec![build_iq_error_xml_typed(
                 id,
                 response_from,
                 response_to,
                 service_unavailable_iq_error("Service unavailable at this address."),
-            )];
+            )]);
         }
         if payload_ns == waddle_xmpp::xep::NS_TIME {
             if !is_time_query(iq) {
-                return vec![build_iq_error_xml_typed(
+                return Some(vec![build_iq_error_xml_typed(
                     id,
                     response_from,
                     response_to,
                     bad_request_iq_error("Malformed IQ payload."),
-                )];
+                )]);
             }
             if iq
                 .to()
                 .is_some_and(|target| target.to_bare().as_str() != domain)
             {
-                return vec![build_iq_error_xml_typed(
+                return Some(vec![build_iq_error_xml_typed(
                     id,
                     response_from,
                     response_to,
                     service_unavailable_iq_error("Service unavailable at this address."),
-                )];
+                )]);
             }
         }
         let Some(full_jid) = phase.bound_jid() else {
-            return vec![build_iq_error_xml_typed(
+            return Some(vec![build_iq_error_xml_typed(
                 id,
                 response_from,
                 response_to,
                 not_authorized_iq_error("Authentication required."),
-            )];
+            )]);
         };
         if let Some(enabled) = carbons_toggle {
             *conn_state.carbons_enabled = enabled;
@@ -114,12 +130,12 @@ pub(super) async fn handle_sans_io_iq(
             match super::jingle_muji_gate::verify_muji_jingle_request(state, full_jid, iq).await {
                 super::jingle_muji_gate::GateOutcome::Allow => {}
                 super::jingle_muji_gate::GateOutcome::Deny(stanza_error) => {
-                    return vec![build_iq_error_xml_typed(
+                    return Some(vec![build_iq_error_xml_typed(
                         id,
                         response_from,
                         response_to,
                         *stanza_error,
-                    )];
+                    )]);
                 }
             }
         }
@@ -155,7 +171,11 @@ pub(super) async fn handle_sans_io_iq(
                  WebSocket adapter cannot honour CloseTransport yet"
             );
         }
-        return outcome.frames;
+        // A registered handler owned this IQ. Empty frames are valid
+        // and terminal (e.g. a Jingle 1:1 stanza forwarded to the peer
+        // with no synchronous reply for the sender) — return `Some` so
+        // the caller does NOT fall through to the unhandled-IQ error.
+        return Some(outcome.frames);
     }
-    Vec::new()
+    None
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests.rs
@@ -50,7 +50,44 @@ mod stream_features;
 mod stream_management;
 
 pub(crate) async fn create_test_websocket_state() -> Arc<WebSocketState> {
-    create_test_websocket_state_with_extension_manager(empty_extension_manager().await).await
+    create_test_websocket_state_with_extension_manager(empty_extension_manager().await, None).await
+}
+
+/// A self-contained [`waddle_sfu::LiveKitSfu`] for tests. Mints real
+/// JWTs locally (no network), so the XEP-0166 Jingle handler can
+/// rewrite the Waddle LiveKit transport exactly as it does in
+/// production. Mirrors the fixture used by the `waddle-xmpp` Jingle
+/// unit tests.
+fn fixture_call_sfu() -> Arc<dyn waddle_sfu::SfuService> {
+    let cfg = waddle_sfu::SfuConfig {
+        api_key: waddle_sfu::ApiKey::new("APItestkey"),
+        api_secret: waddle_sfu::ApiSecret::from_text("super-secret-secret-32-bytes-min")
+            .expect("test api secret meets min length"),
+        webhook_secret: waddle_sfu::ApiSecret::from_text("super-secret-secret-32-bytes-min")
+            .expect("test webhook secret meets min length"),
+        ws_url: waddle_sfu::WebsocketUrl::new("wss://livekit.test/".parse().expect("ws url"))
+            .expect("ws url valid"),
+        turn_host: waddle_sfu::TurnHost::new("turn.test"),
+        turn_tls_port: 443,
+        turn_udp_port: 3478,
+        turn_shared_secret: waddle_sfu::TurnSharedSecret::from_text("turn-secret"),
+        token_ttl: chrono::Duration::seconds(3600),
+        turn_ttl: chrono::Duration::seconds(3600),
+    };
+    Arc::new(waddle_sfu::LiveKitSfu::new(cfg).expect("LiveKitSfu init in test"))
+}
+
+/// Build a test [`WebSocketState`] whose dispatcher has the XEP-0166
+/// Jingle + XEP-0215 extdisco handlers registered — i.e. the
+/// production wiring when `LIVEKIT_*` env is configured (see
+/// `http.rs::register_call_handlers`). Required to exercise 1:1 DM
+/// calling through the real IQ-handler path.
+pub(crate) async fn create_test_websocket_state_with_calls() -> Arc<WebSocketState> {
+    create_test_websocket_state_with_extension_manager(
+        empty_extension_manager().await,
+        Some(fixture_call_sfu()),
+    )
+    .await
 }
 
 async fn empty_extension_manager() -> Arc<ExtensionManager> {
@@ -70,6 +107,7 @@ async fn empty_extension_manager() -> Arc<ExtensionManager> {
 
 async fn create_test_websocket_state_with_extension_manager(
     extension_manager: Arc<ExtensionManager>,
+    call_sfu: Option<Arc<dyn waddle_sfu::SfuService>>,
 ) -> Arc<WebSocketState> {
     let config = DatabaseConfig::default();
     let pool_config = PoolConfig;
@@ -102,6 +140,18 @@ async fn create_test_websocket_state_with_extension_manager(
     let mut dispatcher = StanzaDispatcher::new();
     waddle_xmpp::protocol::handlers::register_default_handlers(&mut dispatcher);
     waddle_xmpp::protocol::handlers::register_default_message_handlers(&mut dispatcher);
+    if let Some(sfu) = call_sfu.as_ref() {
+        // Mirror `http.rs`: when an SFU is configured the XEP-0166
+        // Jingle + XEP-0215 extdisco handlers are registered on the
+        // dispatcher. Without this, `has_iq_handler(NS_JINGLE)` is
+        // false and a call IQ never reaches the forward path.
+        waddle_xmpp::protocol::handlers::register_call_handlers(
+            &mut dispatcher,
+            Arc::clone(sfu),
+            443,
+            3478,
+        );
+    }
     let pubsub_storage = Arc::new(
         crate::pubsub::DatabasePubSubStorage::open(Some("sqlite::memory:"))
             .await
@@ -224,7 +274,7 @@ async fn create_test_websocket_state_with_extension_manager(
                     dm_pin_store: Arc::new(crate::server::routes::websocket::DmPinStore::default()),
                     dm_call_thread_projections: Arc::new(dashmap::DashSet::new()),
                     pending_dm_call_offers: Arc::new(dashmap::DashMap::new()),
-                    sfu: None,
+                    sfu: call_sfu,
                 },
                 occupant_id_secret: OccupantIdSecret::new(
                     b"test-occupant-id-secret-32-bytes-long".to_vec(),

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
@@ -4468,8 +4468,8 @@ async fn dm_call_session_initiate_forwards_to_peer_not_feature_not_implemented()
         .connection_registry
         .register(bob.clone(), bob_tx);
 
-    // Realistic XEP-0353/0166 1:1 session-initiate: audio content with
-    // an Opus RTP description and the Waddle LiveKit transport request
+    // Realistic XEP-0166 1:1 session-initiate carrying an XEP-0167
+    // Opus RTP description and the Waddle LiveKit transport request
     // placeholder the server rewrites with an issued token.
     let frame = r#"<iq xmlns='jabber:client' id='dm-call-1' type='set' to='bob@example.com/phone'>
         <jingle xmlns='urn:xmpp:jingle:1' action='session-initiate' sid='dmcall1' initiator='alice@example.com/web'>

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
@@ -4431,3 +4431,82 @@ async fn handle_iq_pubsub_items_empty_node_returns_result() {
     let iq = xmpp_parsers::iq::Iq::try_from(element).expect("parseable IQ");
     assert_eq!(iq.id(), "items-1");
 }
+
+// ---------------------------------------------------------------
+// 1:1 DM calling (XEP-0166 Jingle) regression
+// ---------------------------------------------------------------
+//
+// Bug: starting a call in a DM failed with "server returned a stanza
+// error: Cancel: feature-not-implemented". A 1:1 `session-initiate`
+// IQ is addressed to the peer's full JID; the Jingle handler mints a
+// LiveKit transport and forwards the stanza to the peer
+// (`RouteToConnection`), emitting NO synchronous frame back to the
+// initiator — the peer's client returns the IQ result. The WebSocket
+// IQ handler used to treat the empty sans-I/O result as "no handler
+// ran" and fall through to a generic `feature-not-implemented`.
+//
+// This test drives a real `session-initiate` through `handle_iq` with
+// the call handlers registered (production wiring when LiveKit is
+// configured) and asserts the initiator gets no error while the peer
+// receives the forwarded stanza.
+#[tokio::test]
+async fn dm_call_session_initiate_forwards_to_peer_not_feature_not_implemented() {
+    let state = create_test_websocket_state_with_calls().await;
+    let alice: FullJid = "alice@example.com/web".parse().expect("alice jid");
+    let bob: FullJid = "bob@example.com/phone".parse().expect("bob jid");
+
+    let (alice_tx, _alice_rx) = tokio::sync::mpsc::channel(8);
+    let (bob_tx, mut bob_rx) = tokio::sync::mpsc::channel::<OutboundStanza>(8);
+    state
+        .deps
+        .protocol
+        .connection_registry
+        .register(alice.clone(), alice_tx);
+    state
+        .deps
+        .protocol
+        .connection_registry
+        .register(bob.clone(), bob_tx);
+
+    // Realistic XEP-0353/0166 1:1 session-initiate: audio content with
+    // an Opus RTP description and the Waddle LiveKit transport request
+    // placeholder the server rewrites with an issued token.
+    let frame = r#"<iq xmlns='jabber:client' id='dm-call-1' type='set' to='bob@example.com/phone'>
+        <jingle xmlns='urn:xmpp:jingle:1' action='session-initiate' sid='dmcall1' initiator='alice@example.com/web'>
+            <content creator='initiator' name='audio'>
+                <description xmlns='urn:xmpp:jingle:apps:rtp:1' media='audio'>
+                    <payload-type id='111' name='opus' clockrate='48000' channels='2'/>
+                    <rtcp-mux/>
+                </description>
+                <transport xmlns='urn:waddle:transports:livekit:0'/>
+            </content>
+        </jingle>
+    </iq>"#;
+
+    let responses = handle_iq(
+        frame,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &None,
+        &ready_phase(&alice),
+    )
+    .await;
+
+    let joined = responses.join("\n");
+    assert!(
+        !joined.contains("feature-not-implemented"),
+        "1:1 Jingle session-initiate must not fall through to \
+         feature-not-implemented; initiator got: {joined}"
+    );
+
+    // The session-initiate must be forwarded to the peer's connection.
+    let forwarded = bob_rx
+        .try_recv()
+        .expect("peer connection must receive the forwarded session-initiate");
+    let xml = stanza_to_xml(&forwarded.stanza);
+    assert!(
+        xml.contains("urn:xmpp:jingle:1") && xml.contains("session-initiate"),
+        "peer must receive the forwarded Jingle session-initiate; got: {xml}"
+    );
+}


### PR DESCRIPTION
## Problem

Starting a call inside a 1:1 DM fails on the initiator with:

> server returned a stanza error: Cancel: feature-not-implemented (Some("Requested feature not implemented."))

## Root cause

A 1:1 call sends an XEP-0166 Jingle `session-initiate` IQ addressed to the **peer's full JID**. The server's `JingleHandler` mints a LiveKit transport and **forwards** the stanza to the peer via `OutboundEvent::RouteToConnection`, emitting **no synchronous frame** back to the initiator — per XEP-0166 the peer's client returns the IQ-result.

In the WebSocket adapter, Jingle is in the `payload_mediates_peer_routing` set, so the IQ is dispatched through `handle_sans_io_iq` (it skips the terminal `route_full_jid_iq` forwarder used by other namespaces). `handle_sans_io_iq` returned `Vec<String>` (the frames), and `interpret()` of a lone `RouteToConnection` routes to the peer as a side-effect and yields **empty** frames. The caller in `iq/mod.rs` treated an empty result as *"no handler ran"* and fell through every later branch to the generic `feature-not-implemented` fallback.

The non-mediated path (`route_full_jid_iq`) does the exact same forward-and-return-empty, but it's reached via `return route_full_jid_iq(...)` (terminal), so empty is fine there. Jingle lacked that "handled — empty is valid" signal.

Only **1:1 (P2P-forwarded)** Jingle actions were affected (`session-initiate`, `session-accept`, `session-terminate`, `transport-info`, …). **MUC/Muji** group calls were unaffected because the SFU-focus path replies with a `SendStanza` (non-empty frames).

## Fix

`handle_sans_io_iq` now returns `Option<Vec<String>>`:

- `Some(frames)` — a registered dispatcher handler owned the IQ. **Terminal even when `frames` is empty** (forwarded to a peer with no synchronous reply).
- `None` — no registered handler claims the namespace; the caller continues to the disco/misc/MUC/pubsub branches.

`iq/mod.rs` returns `Some(_)` directly instead of testing `!is_empty()`.

## Tests

New websocket-layer regression test `dm_call_session_initiate_forwards_to_peer_not_feature_not_implemented` drives a **real** 1:1 `session-initiate` (Opus RTP description + Waddle LiveKit transport request) through `handle_iq` with the call handlers registered (production wiring when LiveKit is configured), asserting:

1. the initiator receives **no** `feature-not-implemented`, and
2. the peer's connection receives the forwarded `session-initiate`.

Confirmed RED before the fix (reproduced the exact error/text), GREEN after. Added a `create_test_websocket_state_with_calls()` fixture so the test dispatcher registers Jingle/extdisco handlers like `http.rs::register_call_handlers`.

## Verification

- `cargo test -p waddle-server --lib server::routes::websocket` — 471 passed
- `cargo fmt -p waddle-server -- --check` — clean
- `cargo clippy -p waddle-server --lib --all-targets -- -D warnings` — clean

## XEP conformance

No wire-shape change. Behavior now conforms to XEP-0166: the server relays `session-initiate` to the responder and lets the responder's client acknowledge, instead of the server spuriously answering `feature-not-implemented`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)