### PR TITLE
fix(server): let members post to the XEP-0472 social feed

### DIFF
--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
@@ -1729,28 +1729,33 @@ async fn handle_story_attachment_retract(
     }
 }
 
-/// Whether `session` may publish to the XEP-0472 social feed node.
+/// The authenticated publisher permitted to post to the XEP-0472
+/// social feed node, or `None` if the request is not authorized.
 ///
 /// The feed is member-postable: any authenticated member may post
 /// (the node's `publish_model` is Open). This honors the node's
 /// configured pubsub publish-model via `can_publish` rather than the
 /// owner-only Spaces structural gate, while still requiring an
 /// authenticated session and rejecting outcasts (XEP-0472
-/// §"Replying to a Post"; XEP-0060 §7.1.3).
-async fn community_feed_publish_allowed(
+/// §"Replying to a Post"; XEP-0060 §7.1.3). The returned JID is the
+/// server-side session principal — the value the service stamps as the
+/// item publisher (XEP-0060 §7.1.2.1: the publisher MUST be generated
+/// by the service, never taken from the client's item, to prevent
+/// spoofing).
+async fn community_feed_publisher(
     state: &WebSocketState,
     session: Option<&Session>,
     community_jid: &BareJid,
     node: &str,
-) -> Result<bool, String> {
+) -> Result<Option<BareJid>, String> {
     let Some(session) = session else {
-        return Ok(false);
+        return Ok(None);
     };
     let entity = session
         .user_jid
         .parse::<BareJid>()
         .map_err(|error| format!("invalid session JID for feed publish: {error}"))?;
-    crate::pubsub_authz::can_publish(
+    let allowed = crate::pubsub_authz::can_publish(
         &state.deps.protocol.pubsub_storage,
         community_jid,
         node,
@@ -1758,16 +1763,18 @@ async fn community_feed_publish_allowed(
         false,
     )
     .await
-    .map_err(|error| format!("can_publish failed for feed node: {error}"))
+    .map_err(|error| format!("can_publish failed for feed node: {error}"))?;
+    Ok(allowed.then_some(entity))
 }
 
 /// Publish a non-bookmark item to a community pubsub node. Used by
 /// `handle_community_publish` (feed + stories + calendar events on
 /// `community.<domain>`). The XEP-0472 social feed is member-postable
 /// (gated by the node's pubsub publish-model via
-/// `community_feed_publish_allowed`); stories and calendar events keep
-/// the owner-only Spaces gate. Either way the standard pubsub fan-out
-/// runs so subscribers see new posts in real time.
+/// `community_feed_publisher`) and the item is stamped with the
+/// server-derived publisher; stories and calendar events keep the
+/// owner-only Spaces gate. Either way the standard pubsub fan-out runs
+/// so subscribers see new posts in real time.
 async fn handle_community_non_bookmark_publish(
     iq: &xmpp_parsers::iq::Iq,
     state: &WebSocketState,
@@ -1779,19 +1786,28 @@ async fn handle_community_non_bookmark_publish(
     let Ok(community_jid) = community_domain.parse::<BareJid>() else {
         return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::InvalidJid))];
     };
-    let authorized = if node == waddle_xmpp_core::xep0472::PUBSUB_NODE_FEED {
-        community_feed_publish_allowed(state, session, &community_jid, node).await
-    } else {
-        spaces_node_mutation_allowed(state, session, node).await
-    };
-    match authorized {
-        Ok(true) => {}
-        Ok(false) => return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))],
-        Err(error) => {
-            warn!(node, error = %error, "Failed to authorize community publish");
-            return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))];
+    // The feed is member-postable and the service stamps the authenticated
+    // publisher on each item; stories/events stay owner-only and carry no
+    // publisher attribution (publisher == node owner).
+    let publisher = if node == waddle_xmpp_core::xep0472::PUBSUB_NODE_FEED {
+        match community_feed_publisher(state, session, &community_jid, node).await {
+            Ok(Some(entity)) => Some(entity),
+            Ok(None) => return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))],
+            Err(error) => {
+                warn!(node, error = %error, "Failed to authorize community feed publish");
+                return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))];
+            }
         }
-    }
+    } else {
+        match spaces_node_mutation_allowed(state, session, node).await {
+            Ok(true) => None,
+            Ok(false) => return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))],
+            Err(error) => {
+                warn!(node, error = %error, "Failed to authorize community publish");
+                return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))];
+            }
+        }
+    };
     match state
         .deps
         .protocol
@@ -1811,7 +1827,7 @@ async fn handle_community_non_bookmark_publish(
         .deps
         .protocol
         .pubsub_storage
-        .publish_item(&community_jid, node, &item, None, false)
+        .publish_item(&community_jid, node, &item, publisher.as_ref(), false)
         .await
     {
         Ok(result) => {
@@ -1833,7 +1849,7 @@ async fn handle_community_non_bookmark_publish(
                     node,
                     published_item: &item,
                     item_id: &result.item_id,
-                    publisher: None,
+                    publisher: publisher.as_ref(),
                     publisher_full: None,
                     is_pep: false,
                 },

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
@@ -932,9 +932,10 @@ pub(super) async fn handle_spaces_publish(
 /// `urn:xmpp:pubsub-social-feed:0` or XEP-0501 stories at
 /// `urn:xmpp:stories:0`. Both live on `community.<domain>` (distinct
 /// from the spaces service so the spaces enumeration only returns
-/// real spaces). Same publish gate as spaces (server owners or
-/// space owners) and the standard pubsub fan-out so subscribers see
-/// new posts in real time.
+/// real spaces). The social feed is member-postable (gated by its
+/// pubsub publish-model); stories and calendar events keep the
+/// owner-only spaces gate. The standard pubsub fan-out runs either
+/// way so subscribers see new posts in real time.
 pub(super) async fn handle_community_publish(
     iq: &xmpp_parsers::iq::Iq,
     state: &WebSocketState,
@@ -1728,11 +1729,45 @@ async fn handle_story_attachment_retract(
     }
 }
 
-/// Publish a non-bookmark item to a spaces-or-community pubsub node.
-/// Used by `handle_community_publish` (feed + stories on
-/// `community.<domain>`). Same auth gate as space-node mutations
-/// (server owners or space owners) and the standard pubsub fan-out
-/// so subscribers see new posts in real time.
+/// Whether `session` may publish to the XEP-0472 social feed node.
+///
+/// The feed is member-postable: any authenticated member may post
+/// (the node's `publish_model` is Open). This honors the node's
+/// configured pubsub publish-model via `can_publish` rather than the
+/// owner-only Spaces structural gate, while still requiring an
+/// authenticated session and rejecting outcasts (XEP-0472
+/// §"Replying to a Post"; XEP-0060 §7.1.3).
+async fn community_feed_publish_allowed(
+    state: &WebSocketState,
+    session: Option<&Session>,
+    community_jid: &BareJid,
+    node: &str,
+) -> Result<bool, String> {
+    let Some(session) = session else {
+        return Ok(false);
+    };
+    let entity = session
+        .user_jid
+        .parse::<BareJid>()
+        .map_err(|error| format!("invalid session JID for feed publish: {error}"))?;
+    crate::pubsub_authz::can_publish(
+        &state.deps.protocol.pubsub_storage,
+        community_jid,
+        node,
+        &entity,
+        false,
+    )
+    .await
+    .map_err(|error| format!("can_publish failed for feed node: {error}"))
+}
+
+/// Publish a non-bookmark item to a community pubsub node. Used by
+/// `handle_community_publish` (feed + stories + calendar events on
+/// `community.<domain>`). The XEP-0472 social feed is member-postable
+/// (gated by the node's pubsub publish-model via
+/// `community_feed_publish_allowed`); stories and calendar events keep
+/// the owner-only Spaces gate. Either way the standard pubsub fan-out
+/// runs so subscribers see new posts in real time.
 async fn handle_community_non_bookmark_publish(
     iq: &xmpp_parsers::iq::Iq,
     state: &WebSocketState,
@@ -1741,7 +1776,15 @@ async fn handle_community_non_bookmark_publish(
     item: PubSubItem,
     session: Option<&Session>,
 ) -> Vec<String> {
-    match spaces_node_mutation_allowed(state, session, node).await {
+    let Ok(community_jid) = community_domain.parse::<BareJid>() else {
+        return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::InvalidJid))];
+    };
+    let authorized = if node == waddle_xmpp_core::xep0472::PUBSUB_NODE_FEED {
+        community_feed_publish_allowed(state, session, &community_jid, node).await
+    } else {
+        spaces_node_mutation_allowed(state, session, node).await
+    };
+    match authorized {
         Ok(true) => {}
         Ok(false) => return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))],
         Err(error) => {
@@ -1749,9 +1792,6 @@ async fn handle_community_non_bookmark_publish(
             return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))];
         }
     }
-    let Ok(community_jid) = community_domain.parse::<BareJid>() else {
-        return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::InvalidJid))];
-    };
     match state
         .deps
         .protocol

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
@@ -1767,6 +1767,40 @@ async fn community_feed_publisher(
     Ok(allowed.then_some(entity))
 }
 
+/// Refuse to let `entity` overwrite a social-feed item already published
+/// by a different member. The feed is one shared, open-publish node with
+/// client-chosen item ids, so without this a member could reuse another
+/// member's item id and clobber their post. Returns the stanza error to
+/// send, or `None` when the publish may proceed (a new id, or the
+/// existing item belongs to `entity`).
+async fn feed_item_ownership_error(
+    state: &WebSocketState,
+    community_jid: &BareJid,
+    node: &str,
+    item: &PubSubItem,
+    entity: &BareJid,
+) -> Option<PubSubError> {
+    let item_id = item.id.as_deref()?;
+    match state
+        .deps
+        .protocol
+        .pubsub_storage
+        .get_items(community_jid, node, None, &[item_id.to_owned()])
+        .await
+    {
+        Ok(existing) => match existing.first() {
+            Some(existing_item) if existing_item.publisher.as_ref() != Some(entity) => {
+                Some(PubSubError::Forbidden)
+            }
+            _ => None,
+        },
+        Err(error) => {
+            warn!(node, item_id, error = %error, "Failed to check feed item ownership");
+            Some(PubSubError::InternalServerError)
+        }
+    }
+}
+
 /// Publish a non-bookmark item to a community pubsub node. Used by
 /// `handle_community_publish` (feed + stories + calendar events on
 /// `community.<domain>`). The XEP-0472 social feed is member-postable
@@ -1780,34 +1814,16 @@ async fn handle_community_non_bookmark_publish(
     state: &WebSocketState,
     community_domain: &str,
     node: &str,
-    item: PubSubItem,
+    mut item: PubSubItem,
     session: Option<&Session>,
 ) -> Vec<String> {
     let Ok(community_jid) = community_domain.parse::<BareJid>() else {
         return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::InvalidJid))];
     };
-    // The feed is member-postable and the service stamps the authenticated
-    // publisher on each item; stories/events stay owner-only and carry no
-    // publisher attribution (publisher == node owner).
-    let publisher = if node == waddle_xmpp_core::xep0472::PUBSUB_NODE_FEED {
-        match community_feed_publisher(state, session, &community_jid, node).await {
-            Ok(Some(entity)) => Some(entity),
-            Ok(None) => return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))],
-            Err(error) => {
-                warn!(node, error = %error, "Failed to authorize community feed publish");
-                return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))];
-            }
-        }
-    } else {
-        match spaces_node_mutation_allowed(state, session, node).await {
-            Ok(true) => None,
-            Ok(false) => return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))],
-            Err(error) => {
-                warn!(node, error = %error, "Failed to authorize community publish");
-                return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))];
-            }
-        }
-    };
+    // Resolve the node before authorizing or mutating it. Community nodes
+    // are bootstrapped at startup; checking existence first keeps the
+    // error semantics correct (NodeNotFound, not a misleading Forbidden)
+    // for the deleted-node edge case.
     match state
         .deps
         .protocol
@@ -1820,6 +1836,57 @@ async fn handle_community_non_bookmark_publish(
         Err(error) => {
             warn!(node, error = %error, "Failed to resolve community node for publish");
             return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::NodeNotFound))];
+        }
+    }
+    // The feed is member-postable and the service stamps the authenticated
+    // publisher on each item; stories/events stay owner-only and carry no
+    // publisher attribution (publisher == node owner). A storage/permission
+    // backend failure is an internal error, not an authorization denial.
+    let publisher = if node == waddle_xmpp_core::xep0472::PUBSUB_NODE_FEED {
+        match community_feed_publisher(state, session, &community_jid, node).await {
+            Ok(Some(entity)) => Some(entity),
+            Ok(None) => return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))],
+            Err(error) => {
+                warn!(node, error = %error, "Failed to authorize community feed publish");
+                return vec![iq_to_xml(build_pubsub_error(
+                    iq,
+                    PubSubError::InternalServerError,
+                ))];
+            }
+        }
+    } else {
+        match spaces_node_mutation_allowed(state, session, node).await {
+            Ok(true) => None,
+            Ok(false) => return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))],
+            Err(error) => {
+                warn!(node, error = %error, "Failed to authorize community publish");
+                return vec![iq_to_xml(build_pubsub_error(
+                    iq,
+                    PubSubError::InternalServerError,
+                ))];
+            }
+        }
+    };
+
+    // The social feed is a single shared, open-publish node, so the
+    // service binds each item to its author: refuse to overwrite an item
+    // published by a different member (no clobbering posts via id reuse)
+    // and stamp the authenticated JID into the payload `<author>` so a
+    // member cannot impersonate another through the displayed author.
+    // `publisher` is `Some` only for the feed; stories/events skip this.
+    if let Some(entity) = publisher.as_ref() {
+        if let Some(error) =
+            feed_item_ownership_error(state, &community_jid, node, &item, entity).await
+        {
+            return vec![iq_to_xml(build_pubsub_error(iq, error))];
+        }
+        if let Some(payload) = item.payload.as_ref() {
+            if waddle_xmpp_core::xep0472::is_feed_entry(payload) {
+                item.payload = Some(waddle_xmpp_core::xep0472::stamp_feed_entry_author(
+                    payload,
+                    &entity.to_string(),
+                ));
+            }
         }
     }
 

--- a/server/crates/waddle-server/src/server/topology.rs
+++ b/server/crates/waddle-server/src/server/topology.rs
@@ -132,8 +132,10 @@ async fn seed_initial_xmpp_topology(
 
     // XEP-0472 Social Feed — community-wide pubsub feed for
     // announcements and microblog-style posts. Access model is
-    // `spaces_public()`: anyone can subscribe and read, only entities
-    // with Publisher or Owner affiliation may publish.
+    // `community_feed()`: anyone can subscribe and read, and any
+    // authenticated member may publish (`publish_model: Open`), per
+    // XEP-0472 §"Replying to a Post". Stories and calendar nodes below
+    // deliberately keep `spaces_public()` (owner-only publish).
     pubsub_storage
         .get_or_create_node(&community_jid, waddle_xmpp_core::xep0472::PUBSUB_NODE_FEED)
         .await
@@ -142,7 +144,7 @@ async fn seed_initial_xmpp_topology(
         .update_node_config(
             &community_jid,
             waddle_xmpp_core::xep0472::PUBSUB_NODE_FEED,
-            &NodeConfig::spaces_public(),
+            &NodeConfig::community_feed(),
         )
         .await
         .map_err(|error| anyhow::anyhow!("failed to configure social feed node: {error}"))?;

--- a/server/crates/waddle-server/tests/xep0472_social_feed_ws.rs
+++ b/server/crates/waddle-server/tests/xep0472_social_feed_ws.rs
@@ -153,13 +153,16 @@ async fn member_can_publish_to_social_feed() {
     let _guard = TEST_SERIAL.lock().await;
     let (_server, mut client) = setup_member().await;
 
+    // Spoof a `publisher` attribute pointing at admin — the server MUST
+    // ignore it and stamp the authenticated session JID instead
+    // (XEP-0060 §7.1.2.1).
     let post_id = format!("post-{}", uuid::Uuid::new_v4());
     client
         .send(&format!(
             r#"<iq type="set" id="member-feed-publish" to="{COMMUNITY_JID}">
               <pubsub xmlns="http://jabber.org/protocol/pubsub">
                 <publish node="{FEED_NODE}">
-                  <item id="{post_id}">
+                  <item id="{post_id}" publisher="admin@{DOMAIN}">
                     <entry xmlns="{NS_SOCIAL_FEED}">
                       <title>Hello from a member</title>
                       <body>Members can post to the feed now.</body>
@@ -182,7 +185,8 @@ async fn member_can_publish_to_social_feed() {
         "a non-owner member must be allowed to publish to the social feed: {publish_result}"
     );
 
-    // The member's post round-trips through an items query.
+    // The member's post round-trips through an items query, stamped with
+    // the server-derived publisher (not the spoofed admin JID).
     client
         .send(&format!(
             r#"<iq type="get" id="member-feed-items" to="{COMMUNITY_JID}">
@@ -200,6 +204,14 @@ async fn member_can_publish_to_social_feed() {
     assert!(
         items_response.contains(&post_id),
         "member's published post must round-trip through items: {items_response}"
+    );
+    assert!(
+        items_response.contains(&format!("publisher='{MEMBER_USERNAME}@{DOMAIN}'")),
+        "feed item must be stamped with the server-derived publisher: {items_response}"
+    );
+    assert!(
+        !items_response.contains(&format!("publisher='admin@{DOMAIN}'")),
+        "spoofed publisher attribute must be overridden by the server: {items_response}"
     );
 
     let _ = client.close().await;

--- a/server/crates/waddle-server/tests/xep0472_social_feed_ws.rs
+++ b/server/crates/waddle-server/tests/xep0472_social_feed_ws.rs
@@ -12,6 +12,8 @@ use ws_common::{TestServer, WsXmppClient};
 
 const DOMAIN: &str = "localhost";
 const USERNAME: &str = "admin";
+const MEMBER_USERNAME: &str = "member";
+const MEMBER_PASSWORD: &str = "xep0472-member-password";
 const COMMUNITY_JID: &str = "community.localhost";
 const FEED_NODE: &str = "urn:xmpp:pubsub-social-feed:0";
 const NS_SOCIAL_FEED: &str = "urn:xmpp:pubsub-social-feed:0";
@@ -26,6 +28,25 @@ async fn setup() -> (TestServer, WsXmppClient) {
         WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, USERNAME, &password, &resource)
             .await
             .expect("connect and auth");
+    (server, client)
+}
+
+/// Start a server with a regular (non-owner) member account seeded and
+/// connect as that member. Only `admin` is a server owner
+/// (`WADDLE_SERVER_OWNER_LOCALPARTS`), so `member` exercises the
+/// member-write path on the social feed.
+async fn setup_member() -> (TestServer, WsXmppClient) {
+    let server = TestServer::start_with_extra_accounts(&[(MEMBER_USERNAME, MEMBER_PASSWORD)]);
+    let resource = format!("xep0472-member-{}", uuid::Uuid::new_v4());
+    let client = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        MEMBER_USERNAME,
+        MEMBER_PASSWORD,
+        &resource,
+    )
+    .await
+    .expect("connect and auth as member");
     (server, client)
 }
 
@@ -119,6 +140,66 @@ async fn social_feed_publish_and_items_round_trip() {
     assert!(
         items_response.contains("The community feed is live!"),
         "items query lost body: {items_response}"
+    );
+
+    let _ = client.close().await;
+}
+
+#[tokio::test]
+async fn member_can_publish_to_social_feed() {
+    // XEP-0472 §"Replying to a Post": "Anyone can publish a post" to a
+    // shared feed node. A non-owner community member must be able to
+    // post to the global social feed (the read path is already open).
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup_member().await;
+
+    let post_id = format!("post-{}", uuid::Uuid::new_v4());
+    client
+        .send(&format!(
+            r#"<iq type="set" id="member-feed-publish" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <publish node="{FEED_NODE}">
+                  <item id="{post_id}">
+                    <entry xmlns="{NS_SOCIAL_FEED}">
+                      <title>Hello from a member</title>
+                      <body>Members can post to the feed now.</body>
+                      <author>{MEMBER_USERNAME}@{DOMAIN}</author>
+                      <published>2026-06-17T12:00:00Z</published>
+                    </entry>
+                  </item>
+                </publish>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send publish");
+    let publish_result = client
+        .recv_matching(|frame| frame.contains("member-feed-publish"))
+        .await
+        .expect("publish result");
+    assert!(
+        publish_result.contains("type='result'"),
+        "a non-owner member must be allowed to publish to the social feed: {publish_result}"
+    );
+
+    // The member's post round-trips through an items query.
+    client
+        .send(&format!(
+            r#"<iq type="get" id="member-feed-items" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <items node="{FEED_NODE}"/>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send items query");
+    let items_response = client
+        .recv_matching(|frame| frame.contains("member-feed-items") && frame.contains("<entry"))
+        .await
+        .expect("items response");
+    assert!(
+        items_response.contains(&post_id),
+        "member's published post must round-trip through items: {items_response}"
     );
 
     let _ = client.close().await;

--- a/server/crates/waddle-server/tests/xep0472_social_feed_ws.rs
+++ b/server/crates/waddle-server/tests/xep0472_social_feed_ws.rs
@@ -14,6 +14,8 @@ const DOMAIN: &str = "localhost";
 const USERNAME: &str = "admin";
 const MEMBER_USERNAME: &str = "member";
 const MEMBER_PASSWORD: &str = "xep0472-member-password";
+const MEMBER2_USERNAME: &str = "member2";
+const MEMBER2_PASSWORD: &str = "xep0472-member2-password";
 const COMMUNITY_JID: &str = "community.localhost";
 const FEED_NODE: &str = "urn:xmpp:pubsub-social-feed:0";
 const NS_SOCIAL_FEED: &str = "urn:xmpp:pubsub-social-feed:0";
@@ -153,9 +155,10 @@ async fn member_can_publish_to_social_feed() {
     let _guard = TEST_SERIAL.lock().await;
     let (_server, mut client) = setup_member().await;
 
-    // Spoof a `publisher` attribute pointing at admin — the server MUST
-    // ignore it and stamp the authenticated session JID instead
-    // (XEP-0060 §7.1.2.1).
+    // Spoof BOTH the item `publisher` attribute and the payload
+    // `<author>` to point at admin — the server MUST ignore both and
+    // stamp the authenticated session JID instead (XEP-0060 §7.1.2.1 for
+    // the publisher; author stamping prevents displayed-author spoofing).
     let post_id = format!("post-{}", uuid::Uuid::new_v4());
     client
         .send(&format!(
@@ -166,7 +169,7 @@ async fn member_can_publish_to_social_feed() {
                     <entry xmlns="{NS_SOCIAL_FEED}">
                       <title>Hello from a member</title>
                       <body>Members can post to the feed now.</body>
-                      <author>{MEMBER_USERNAME}@{DOMAIN}</author>
+                      <author>admin@{DOMAIN}</author>
                       <published>2026-06-17T12:00:00Z</published>
                     </entry>
                   </item>
@@ -186,7 +189,7 @@ async fn member_can_publish_to_social_feed() {
     );
 
     // The member's post round-trips through an items query, stamped with
-    // the server-derived publisher (not the spoofed admin JID).
+    // the server-derived publisher and author (not the spoofed admin JID).
     client
         .send(&format!(
             r#"<iq type="get" id="member-feed-items" to="{COMMUNITY_JID}">
@@ -210,9 +213,116 @@ async fn member_can_publish_to_social_feed() {
         "feed item must be stamped with the server-derived publisher: {items_response}"
     );
     assert!(
-        !items_response.contains(&format!("publisher='admin@{DOMAIN}'")),
-        "spoofed publisher attribute must be overridden by the server: {items_response}"
+        items_response.contains(&format!(">{MEMBER_USERNAME}@{DOMAIN}<")),
+        "feed entry author must be stamped with the authenticated JID: {items_response}"
+    );
+    assert!(
+        !items_response.contains(&format!("admin@{DOMAIN}")),
+        "spoofed publisher AND author must be overridden by the server: {items_response}"
     );
 
     let _ = client.close().await;
+}
+
+#[tokio::test]
+async fn member_cannot_clobber_another_members_feed_post() {
+    // The feed is one shared, open-publish node with client-chosen item
+    // ids. A member must not be able to overwrite another member's post by
+    // reusing its id.
+    let _guard = TEST_SERIAL.lock().await;
+    let server = TestServer::start_with_extra_accounts(&[
+        (MEMBER_USERNAME, MEMBER_PASSWORD),
+        (MEMBER2_USERNAME, MEMBER2_PASSWORD),
+    ]);
+    let mut alice = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        MEMBER_USERNAME,
+        MEMBER_PASSWORD,
+        &format!("a-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("connect member A");
+    let mut bob = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        MEMBER2_USERNAME,
+        MEMBER2_PASSWORD,
+        &format!("b-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("connect member B");
+
+    let post_id = format!("post-{}", uuid::Uuid::new_v4());
+    alice
+        .send(&format!(
+            r#"<iq type="set" id="a-publish" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <publish node="{FEED_NODE}">
+                  <item id="{post_id}">
+                    <entry xmlns="{NS_SOCIAL_FEED}"><body>Original by A</body></entry>
+                  </item>
+                </publish>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("A publish");
+    let a_result = alice
+        .recv_matching(|frame| frame.contains("a-publish"))
+        .await
+        .expect("A result");
+    assert!(
+        a_result.contains("type='result'"),
+        "member A publish must succeed: {a_result}"
+    );
+
+    bob.send(&format!(
+        r#"<iq type="set" id="b-clobber" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <publish node="{FEED_NODE}">
+                  <item id="{post_id}">
+                    <entry xmlns="{NS_SOCIAL_FEED}"><body>Hijacked by B</body></entry>
+                  </item>
+                </publish>
+              </pubsub>
+            </iq>"#
+    ))
+    .await
+    .expect("B publish");
+    let b_result = bob
+        .recv_matching(|frame| frame.contains("b-clobber"))
+        .await
+        .expect("B result");
+    assert!(
+        b_result.contains("type='error'") && b_result.contains("forbidden"),
+        "member B must not overwrite member A's post: {b_result}"
+    );
+
+    // A's content is intact; B's clobber never landed.
+    alice
+        .send(&format!(
+            r#"<iq type="get" id="verify-items" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <items node="{FEED_NODE}"/>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("items query");
+    let items = alice
+        .recv_matching(|frame| frame.contains("verify-items") && frame.contains("<entry"))
+        .await
+        .expect("items response");
+    assert!(
+        items.contains("Original by A"),
+        "member A's content must be intact: {items}"
+    );
+    assert!(
+        !items.contains("Hijacked by B"),
+        "member B's clobber must not have landed: {items}"
+    );
+
+    let _ = alice.close().await;
+    let _ = bob.close().await;
 }

--- a/server/crates/waddle-server/tests/xep0501_stories_ws.rs
+++ b/server/crates/waddle-server/tests/xep0501_stories_ws.rs
@@ -12,6 +12,8 @@ use ws_common::{TestServer, WsXmppClient};
 
 const DOMAIN: &str = "localhost";
 const USERNAME: &str = "admin";
+const MEMBER_USERNAME: &str = "member";
+const MEMBER_PASSWORD: &str = "xep0501-member-password";
 const COMMUNITY_JID: &str = "community.localhost";
 const STORIES_NODE: &str = "urn:xmpp:stories:0";
 const NS_STORIES: &str = "urn:xmpp:stories:0";
@@ -119,6 +121,54 @@ async fn stories_publish_and_items_round_trip() {
     assert!(
         items_response.contains(expires),
         "items query lost expires attr: {items_response}"
+    );
+
+    let _ = client.close().await;
+}
+
+#[tokio::test]
+async fn member_cannot_publish_to_stories() {
+    // Stories remain owner-only. Opening the social feed to member
+    // writes must NOT open stories: a non-owner member publishing a
+    // story must still be rejected with a `forbidden` auth error.
+    let _guard = TEST_SERIAL.lock().await;
+    let server = TestServer::start_with_extra_accounts(&[(MEMBER_USERNAME, MEMBER_PASSWORD)]);
+    let resource = format!("xep0501-member-{}", uuid::Uuid::new_v4());
+    let mut client = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        MEMBER_USERNAME,
+        MEMBER_PASSWORD,
+        &resource,
+    )
+    .await
+    .expect("connect and auth as member");
+
+    let story_id = format!("story-{}", uuid::Uuid::new_v4());
+    client
+        .send(&format!(
+            r#"<iq type="set" id="member-story-publish" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <publish node="{STORIES_NODE}">
+                  <item id="{story_id}">
+                    <story xmlns="{NS_STORIES}" expires="2030-01-01T12:00:00Z">
+                      <body>Should be rejected</body>
+                      <author>{MEMBER_USERNAME}@{DOMAIN}</author>
+                    </story>
+                  </item>
+                </publish>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send publish");
+    let publish_result = client
+        .recv_matching(|frame| frame.contains("member-story-publish"))
+        .await
+        .expect("publish result");
+    assert!(
+        publish_result.contains("type='error'") && publish_result.contains("forbidden"),
+        "stories must stay owner-only — a member publish must be forbidden: {publish_result}"
     );
 
     let _ = client.close().await;

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0472_social_feed.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0472_social_feed.cue
@@ -37,8 +37,8 @@ scenario: #Scenario & {
 		},
 		// 2. Publish a feed entry to the bootstrapped community feed
 		//    node. The server bootstraps this node at startup with
-		//    spaces_public() access; server-owner affiliation seed
-		//    grants admin Publisher access.
+		//    community_feed() config (open read + open publish), so any
+		//    authenticated member may post; admin publishes here.
 		#SendIq & {
 			actor: adminPhone
 			type:  "set"

--- a/server/crates/waddle-xmpp-core/src/pubsub/node.rs
+++ b/server/crates/waddle-xmpp-core/src/pubsub/node.rs
@@ -204,6 +204,30 @@ impl NodeConfig {
         }
     }
 
+    /// Configuration for the XEP-0472 community social-feed node.
+    ///
+    /// Open on both axes: anyone may subscribe/read (`access_model:
+    /// Open`) AND any authenticated entity may publish (`publish_model:
+    /// Open`, XEP-0060 §7.1.4). This makes the global feed
+    /// member-postable, matching XEP-0472 §"Replying to a Post"
+    /// ("Anyone can publish a post" to a shared feed node). The publish
+    /// handler still requires an authenticated session and rejects
+    /// outcasts via `can_publish`. Distinct from `spaces_public()`
+    /// (Publisher publish-model) which the owner-only stories and
+    /// calendar nodes keep.
+    pub fn community_feed() -> Self {
+        Self {
+            access_model: AccessModel::Open,
+            publish_model: PublishModel::Open,
+            max_items: u32::MAX,
+            persist_items: true,
+            deliver_payloads: true,
+            notify_retract: true,
+            notify_delete: true,
+            send_last_published_item: SendLastPublishedItem::OnSub,
+        }
+    }
+
     /// XEP-0503 configuration for a private Space node.
     pub fn spaces_private() -> Self {
         Self {
@@ -455,6 +479,21 @@ mod tests {
             Ok(PublishModel::Publishers)
         );
         assert_eq!(PublishModel::Open.to_string(), "open");
+    }
+
+    #[test]
+    fn community_feed_is_open_read_and_open_publish() {
+        let config = NodeConfig::community_feed();
+        assert_eq!(config.access_model, AccessModel::Open);
+        assert_eq!(config.publish_model, PublishModel::Open);
+        assert!(config.persist_items);
+        assert!(config.deliver_payloads);
+        // Differs from spaces_public() only on publish-model: the feed
+        // is member-postable, spaces nodes are Publisher-gated.
+        assert_eq!(
+            NodeConfig::spaces_public().publish_model,
+            PublishModel::Publishers
+        );
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-core/src/xep0472.rs
+++ b/server/crates/waddle-xmpp-core/src/xep0472.rs
@@ -171,6 +171,25 @@ pub fn build_feed_entry_element(entry: &FeedEntry) -> Element {
     elem
 }
 
+/// Return a copy of a feed `<entry/>` whose `<author>` is `author`,
+/// replacing any author the client supplied. On the open, member-postable
+/// feed the service stamps the authenticated publisher here so a member
+/// cannot impersonate another user through the displayed payload author.
+/// All other children are preserved.
+pub fn stamp_feed_entry_author(elem: &Element, author: &str) -> Element {
+    let mut stamped = Element::builder("entry", NS_SOCIAL_FEED).build();
+    for child in elem.children() {
+        if child.name() == "author" && child.ns() == NS_SOCIAL_FEED {
+            continue;
+        }
+        stamped.append_child(child.clone());
+    }
+    let mut author_el = Element::builder("author", NS_SOCIAL_FEED).build();
+    author_el.append_text_node(author);
+    stamped.append_child(author_el);
+    stamped
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -259,5 +278,43 @@ mod tests {
     #[test]
     fn test_pubsub_node() {
         assert_eq!(PUBSUB_NODE_FEED, "urn:xmpp:pubsub-social-feed:0");
+    }
+
+    #[test]
+    fn test_stamp_feed_entry_author_overrides_and_preserves() {
+        // A client-supplied (spoofed) author is replaced; title/body/link
+        // and the entry shape survive.
+        let entry = FeedEntry::new("p-9", "Body text")
+            .with_title("Title")
+            .with_author("admin@example.com")
+            .with_published(test_time())
+            .with_link("https://example.com/p/9");
+        let elem = build_feed_entry_element(&entry);
+
+        let stamped = stamp_feed_entry_author(&elem, "member@example.com");
+        assert!(is_feed_entry(&stamped));
+
+        let parsed = parse_feed_entry("p-9", &stamped).expect("parseable");
+        assert_eq!(parsed.author.as_deref(), Some("member@example.com"));
+        assert_eq!(parsed.body, "Body text");
+        assert_eq!(parsed.title.as_deref(), Some("Title"));
+        assert_eq!(parsed.published, Some(test_time()));
+        assert_eq!(parsed.link.as_deref(), Some("https://example.com/p/9"));
+
+        // Exactly one author element after stamping.
+        let authors = stamped
+            .children()
+            .filter(|c| c.name() == "author" && c.ns() == NS_SOCIAL_FEED)
+            .count();
+        assert_eq!(authors, 1);
+    }
+
+    #[test]
+    fn test_stamp_feed_entry_author_adds_when_absent() {
+        let elem = build_feed_entry_element(&FeedEntry::new("p-10", "No author here"));
+        let stamped = stamp_feed_entry_author(&elem, "member@example.com");
+        let parsed = parse_feed_entry("p-10", &stamped).expect("parseable");
+        assert_eq!(parsed.author.as_deref(), Some("member@example.com"));
+        assert_eq!(parsed.body, "No author here");
     }
 }


### PR DESCRIPTION
## Problem

A regular member posting to the community social feed gets:

> Couldn't load the feed: server returned a stanza error: Auth: forbidden (Some(""))

The label "Couldn't load the feed" is misleading — the failing operation is the **post**, not a load. The client (`useSocialFeed`) reuses one `error` ref for both `refresh()` and `post()`, so a failed publish surfaces under the static "Couldn't load the feed" banner.

## Root cause

The XEP-0472 feed publish lands in `handle_community_non_bookmark_publish` (`pubsub_helpers.rs`), which gated on `spaces_node_mutation_allowed` — the **Spaces structural-ownership** permission (server owner or space owner). A regular member is neither, so the server returns `<error type='auth'><forbidden/></error>`, which the client renders as `Auth: forbidden (Some(""))`. Member-write was explicitly deferred in #645. The read path (`handle_community_items`) has no auth gate, so members could already read — only writes were blocked.

XEP-0472 §"Replying to a Post" states *"Anyone can publish a post"* to a shared feed node, so a member-postable feed is the intended pattern.

## Fix

Open the feed to members, the XEP-0472 way, and attribute/protect posts safely:

- **`NodeConfig::community_feed()`** — open read + open publish (XEP-0060 §7.1.4). Bootstrap the feed node with it in `topology.rs`. Stories and calendar events keep `spaces_public()` (owner-only).
- **Member-postable publish gate** — route the feed publish through `pubsub_authz::can_publish` (authenticated session required; outcasts rejected; honors the node publish-model) instead of the owner-only Spaces gate.
- **Server-stamped publisher** — stamp the authenticated JID as the item `publisher` (XEP-0060 §7.1.2.1, anti-spoofing) on the stored item + fan-out.
- **Server-stamped `<author>`** — the client renders the payload `<author>`, so the service also overwrites it with the authenticated JID (`xep0472::stamp_feed_entry_author`); the web composer already sends the user's own JID, so this is transparent for legitimate posts.
- **Cross-author clobber protection** — reject (`<forbidden/>`) a publish reusing an item id owned by a different member, so posts can't be overwritten by id reuse.
- **Error semantics** — operational failures in the authz check return `<internal-server-error/>` (not `<forbidden/>`); a missing node returns `<item-not-found/>` (node existence is checked before authorization).

## XEP conformance

- XEP-0060 §7.1.4 open publish-model; §7.1.2.1 service-generated publisher; §7.1.3 `<forbidden type='auth'>` on denial.
- XEP-0472 §"Replying to a Post" (multi-author shared feed).

## Tests (XEP custom test-suite rule)

- `xep0472_social_feed_ws::member_can_publish_to_social_feed` — member publish succeeds, round-trips, and **both** a spoofed `publisher` attribute and a spoofed `<author>` are overridden with the authenticated JID.
- `xep0472_social_feed_ws::member_cannot_clobber_another_members_feed_post` — a member can't overwrite another member's post by id reuse; the original content stays intact.
- `xep0501_stories_ws::member_cannot_publish_to_stories` — stories stay owner-only (`forbidden`).
- `xep0472::stamp_feed_entry_author` unit tests; `node.rs::community_feed_is_open_read_and_open_publish`.
- Full regression (admin publish, calendar, story reactions/reads, PEP→feed bridge, cue e2e) passes; `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Review

Reviewed by adversarial sub-agents (security / XEP / correctness) and automated reviewers (Copilot, Codex, Greptile). All raised findings are addressed in this PR: member publish, publisher + author stamping (anti-spoof), cross-author clobber protection, and the `internal-server-error` / `item-not-found` error semantics. Remaining non-blocking hardening is tracked in **#1037**: member self-retract, feed rate-limiting, disco#info publish-model disclosure, base-profile config SHOULDs, and the `:0`→`:1`/Atom payload migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)