### PR TITLE
feat(chat): Gallery/Speaker view switcher with active-speaker + Pin (#1025)

### DIFF
--- a/chat/src/components/calls/CallControls.vue
+++ b/chat/src/components/calls/CallControls.vue
@@ -24,7 +24,7 @@ import CallConnectionIndicator from "./CallConnectionIndicator.vue";
  * The old multi-mode chrome (dock-toggle, minimize, PIP) is gone —
  * the only mode switch left is split ↔ expanded.
  */
-defineProps<{
+const props = defineProps<{
   micEnabled: boolean;
   camEnabled: boolean;
   screenShareEnabled: boolean;
@@ -51,19 +51,24 @@ const emit = defineEmits<{
 }>();
 
 /**
- * Arrow-key navigation for the Gallery/Speaker radiogroup: Right/Down select
- * Speaker, Left/Up select Gallery, and focus follows selection (roving
- * tabindex) per the WAI-ARIA radio-group pattern.
+ * Arrow-key navigation for the two-option Gallery/Speaker radiogroup, per the
+ * WAI-ARIA radio-group pattern: an arrow moves selection to the other option
+ * (wrapping at both ends) and focus follows the selection (roving tabindex).
+ * With two options every arrow flips the mode, so no redundant emit fires.
  */
 function onViewKeydown(event: KeyboardEvent): void {
-  const goNext = event.key === "ArrowRight" || event.key === "ArrowDown";
-  const goPrev = event.key === "ArrowLeft" || event.key === "ArrowUp";
-  if (!goNext && !goPrev) return;
+  const isArrow =
+    event.key === "ArrowRight" ||
+    event.key === "ArrowDown" ||
+    event.key === "ArrowLeft" ||
+    event.key === "ArrowUp";
+  if (!isArrow) return;
   event.preventDefault();
-  emit("setViewMode", goNext ? "speaker" : "gallery");
+  const next: CallViewMode = props.viewMode === "gallery" ? "speaker" : "gallery";
+  emit("setViewMode", next);
   const current = event.currentTarget as HTMLElement;
-  const sibling = goNext ? current.nextElementSibling : current.previousElementSibling;
-  if (sibling instanceof HTMLElement) sibling.focus();
+  const other = current.nextElementSibling ?? current.previousElementSibling;
+  if (other instanceof HTMLElement) other.focus();
 }
 </script>
 

--- a/chat/src/components/calls/CallControls.vue
+++ b/chat/src/components/calls/CallControls.vue
@@ -49,6 +49,22 @@ const emit = defineEmits<{
   setViewMode: [mode: CallViewMode];
   hangup: [];
 }>();
+
+/**
+ * Arrow-key navigation for the Gallery/Speaker radiogroup: Right/Down select
+ * Speaker, Left/Up select Gallery, and focus follows selection (roving
+ * tabindex) per the WAI-ARIA radio-group pattern.
+ */
+function onViewKeydown(event: KeyboardEvent): void {
+  const goNext = event.key === "ArrowRight" || event.key === "ArrowDown";
+  const goPrev = event.key === "ArrowLeft" || event.key === "ArrowUp";
+  if (!goNext && !goPrev) return;
+  event.preventDefault();
+  emit("setViewMode", goNext ? "speaker" : "gallery");
+  const current = event.currentTarget as HTMLElement;
+  const sibling = goNext ? current.nextElementSibling : current.previousElementSibling;
+  if (sibling instanceof HTMLElement) sibling.focus();
+}
 </script>
 
 <template>
@@ -89,27 +105,34 @@ const emit = defineEmits<{
     </button>
 
     <!-- Gallery ⟷ Speaker view switcher. Sticky for the call; a pin or an
-         incoming screen share still overrides the chosen layout's large tile. -->
-    <div class="call-controls__view-switch" role="group" aria-label="Stage view">
+         incoming screen share still overrides the chosen layout's large tile.
+         A radiogroup (single-choice) rather than two independent toggles. -->
+    <div class="call-controls__view-switch" role="radiogroup" aria-label="Stage view">
       <button
         type="button"
+        role="radio"
         class="chat-icon-button chat-icon-button--md hover:bg-muted"
         :class="{ 'bg-muted text-foreground': viewMode === 'gallery' }"
         title="Gallery view"
         aria-label="Gallery view"
-        :aria-pressed="viewMode === 'gallery'"
+        :aria-checked="viewMode === 'gallery'"
+        :tabindex="viewMode === 'gallery' ? 0 : -1"
         @click="emit('setViewMode', 'gallery')"
+        @keydown="onViewKeydown"
       >
         <LayoutGrid class="w-4 h-4" />
       </button>
       <button
         type="button"
+        role="radio"
         class="chat-icon-button chat-icon-button--md hover:bg-muted"
         :class="{ 'bg-muted text-foreground': viewMode === 'speaker' }"
         title="Speaker view"
         aria-label="Speaker view"
-        :aria-pressed="viewMode === 'speaker'"
+        :aria-checked="viewMode === 'speaker'"
+        :tabindex="viewMode === 'speaker' ? 0 : -1"
         @click="emit('setViewMode', 'speaker')"
+        @keydown="onViewKeydown"
       >
         <SquareUser class="w-4 h-4" />
       </button>

--- a/chat/src/components/calls/CallControls.vue
+++ b/chat/src/components/calls/CallControls.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import {
+  LayoutGrid,
   Maximize2,
   Mic,
   MicOff,
@@ -7,10 +8,12 @@ import {
   MonitorUp,
   PhoneOff,
   Settings,
+  SquareUser,
   Video,
   VideoOff,
   Volume2,
 } from "lucide-vue-next";
+import type { CallViewMode } from "@/lib/calls/view-mode";
 import CallConnectionIndicator from "./CallConnectionIndicator.vue";
 
 /**
@@ -32,6 +35,8 @@ defineProps<{
   /** True while the volume mixer dialog is open — drives the speaker
    *  button's pressed/expanded state. The parent owns the dialog. */
   volumeOpen: boolean;
+  /** The chosen stage layout — drives the view switcher's pressed state. */
+  viewMode: CallViewMode;
 }>();
 
 const emit = defineEmits<{
@@ -41,6 +46,7 @@ const emit = defineEmits<{
   toggleExpanded: [];
   toggleVolume: [];
   openSettings: [];
+  setViewMode: [mode: CallViewMode];
   hangup: [];
 }>();
 </script>
@@ -81,6 +87,33 @@ const emit = defineEmits<{
       <MonitorUp class="w-4 h-4" />
       <span class="type-control sr-only sm:not-sr-only">{{ screenShareEnabled ? "Stop" : "Share" }}</span>
     </button>
+
+    <!-- Gallery ⟷ Speaker view switcher. Sticky for the call; a pin or an
+         incoming screen share still overrides the chosen layout's large tile. -->
+    <div class="call-controls__view-switch" role="group" aria-label="Stage view">
+      <button
+        type="button"
+        class="chat-icon-button chat-icon-button--md hover:bg-muted"
+        :class="{ 'bg-muted text-foreground': viewMode === 'gallery' }"
+        title="Gallery view"
+        aria-label="Gallery view"
+        :aria-pressed="viewMode === 'gallery'"
+        @click="emit('setViewMode', 'gallery')"
+      >
+        <LayoutGrid class="w-4 h-4" />
+      </button>
+      <button
+        type="button"
+        class="chat-icon-button chat-icon-button--md hover:bg-muted"
+        :class="{ 'bg-muted text-foreground': viewMode === 'speaker' }"
+        title="Speaker view"
+        aria-label="Speaker view"
+        :aria-pressed="viewMode === 'speaker'"
+        @click="emit('setViewMode', 'speaker')"
+      >
+        <SquareUser class="w-4 h-4" />
+      </button>
+    </div>
 
     <!-- Ambient self-connection quality. Self-contained/store-connected,
          so it adds no props to this otherwise stateless bar. Shows quiet
@@ -149,5 +182,11 @@ const emit = defineEmits<{
   height: 1.5rem;
   background: var(--border);
   margin-inline: var(--space-xs);
+}
+
+.call-controls__view-switch {
+  display: flex;
+  align-items: center;
+  gap: 2px;
 }
 </style>

--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -6,6 +6,7 @@ import {
   $lastCallError,
 } from "@/lib/calls/call-store";
 import { $callUiMode } from "@/lib/calls/ui-mode";
+import { $callViewMode, setCallViewMode } from "@/lib/calls/call-view-state";
 import {
   $callConnecting,
   $callMicEnabled,
@@ -90,13 +91,15 @@ const emit = defineEmits<{
 
 const state = useStore($callState);
 const uiMode = useStore($callUiMode);
+const viewMode = useStore($callViewMode);
 const lastError = useStore($lastCallError);
 const connecting = useStore($callConnecting);
 const micEnabled = useStore($callMicEnabled);
 const camEnabled = useStore($callCamEnabled);
 const screenShareEnabled = useStore($callScreenShareEnabled);
 const screenShareSupported = useStore($callScreenShareSupported);
-const { remoteTracks, localTracks, engine, activeSpeakerIdentities } = useCallEngine();
+const { remoteTracks, localTracks, engine, activeSpeakerIdentities, promotedSpeakerIdentity } =
+  useCallEngine();
 const { activeRoomJid, selfInCall } = useActiveMucCall();
 
 const settingsOpen = ref(false);
@@ -294,6 +297,7 @@ onBeforeUnmount(() => {
           :expected-remote-identities="expectedRemoteIdentities"
           :mic-enabled="micEnabled"
           :active-speaker-identities="activeSpeakerIdentities"
+          :promoted-speaker-identity="promotedSpeakerIdentity"
         />
       </div>
     </main>
@@ -331,12 +335,14 @@ onBeforeUnmount(() => {
         :screen-share-supported="screenShareSupported"
         :is-expanded="true"
         :volume-open="volumeOpen"
+        :view-mode="viewMode"
         @toggle-mic="toggleMic"
         @toggle-cam="toggleCam"
         @toggle-screen-share="toggleScreenShare"
         @toggle-expanded="collapseToSplit"
         @toggle-volume="volumeOpen = !volumeOpen"
         @open-settings="settingsOpen = true"
+        @set-view-mode="setCallViewMode"
         @hangup="onHangup"
       />
     </footer>

--- a/chat/src/components/calls/CallOverlay.vue
+++ b/chat/src/components/calls/CallOverlay.vue
@@ -17,6 +17,7 @@ import {
   seedCallControlsFromEngine,
 } from "@/lib/calls/call-controls";
 import { $callUiMode } from "@/lib/calls/ui-mode";
+import { resetCallViewState } from "@/lib/calls/call-view-state";
 
 /**
  * Engine lifecycle host for the call subsystem.
@@ -70,6 +71,9 @@ watch(
     // Optimistic baseline shown while connecting; also clears any media
     // notice left over from the previous call.
     resetCallControls(active.media.audio, active.media.video);
+    // Stage presentation starts each call in Gallery with nothing pinned —
+    // a previous call's Speaker view or pin must not leak across.
+    resetCallViewState();
     try {
       const iceServers = await resolveIceServers();
       // The ICE fetch can block for up to 10s. Re-confirm this is still the

--- a/chat/src/components/calls/CallSplitContainer.vue
+++ b/chat/src/components/calls/CallSplitContainer.vue
@@ -6,6 +6,7 @@ import {
   $lastCallError,
 } from "@/lib/calls/call-store";
 import { $callUiMode } from "@/lib/calls/ui-mode";
+import { $callViewMode, setCallViewMode } from "@/lib/calls/call-view-state";
 import {
   $callConnecting,
   $callMicEnabled,
@@ -57,13 +58,15 @@ const props = defineProps<{
 
 const state = useStore($callState);
 const uiMode = useStore($callUiMode);
+const viewMode = useStore($callViewMode);
 const lastError = useStore($lastCallError);
 const connecting = useStore($callConnecting);
 const micEnabled = useStore($callMicEnabled);
 const camEnabled = useStore($callCamEnabled);
 const screenShareEnabled = useStore($callScreenShareEnabled);
 const screenShareSupported = useStore($callScreenShareSupported);
-const { remoteTracks, localTracks, engine, activeSpeakerIdentities } = useCallEngine();
+const { remoteTracks, localTracks, engine, activeSpeakerIdentities, promotedSpeakerIdentity } =
+  useCallEngine();
 const { activeRoomJid, selfInCall } = useActiveMucCall();
 
 const settingsOpen = ref(false);
@@ -218,6 +221,7 @@ async function onHangup(): Promise<void> {
           :expected-remote-identities="expectedRemoteIdentities"
           :mic-enabled="micEnabled"
           :active-speaker-identities="activeSpeakerIdentities"
+          :promoted-speaker-identity="promotedSpeakerIdentity"
         />
       </div>
       <footer class="call-split__footer">
@@ -228,12 +232,14 @@ async function onHangup(): Promise<void> {
           :screen-share-supported="screenShareSupported"
           :is-expanded="false"
           :volume-open="volumeOpen"
+          :view-mode="viewMode"
           @toggle-mic="toggleMic"
           @toggle-cam="toggleCam"
           @toggle-screen-share="toggleScreenShare"
           @toggle-expanded="enterExpanded"
           @toggle-volume="volumeOpen = !volumeOpen"
           @open-settings="settingsOpen = true"
+          @set-view-mode="setCallViewMode"
           @hangup="onHangup"
         />
       </footer>

--- a/chat/src/components/calls/CallTileGrid.vue
+++ b/chat/src/components/calls/CallTileGrid.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, ref, watch } from "vue";
+import { useStore } from "@nanostores/vue";
 import type { LocalMediaTrack, RemoteMediaTrack } from "@/lib/calls/engine";
 import { TileAttachments, type TileAttachable } from "@/lib/calls/tile-attach";
 import { selectGridLayout } from "@/lib/calls/grid-layout";
 import type { CallTileModel } from "@/lib/calls/call-tiles";
 import { projectCallTiles, reconcileCallTileProjectionState } from "@/lib/calls/call-tile-projection";
 import { highlightedTileKeys } from "@/lib/calls/active-speakers";
+import { $callPinnedTileKey, $callViewMode, toggleCallPin } from "@/lib/calls/call-view-state";
 import CallTile from "./CallTile.vue";
 
 /**
@@ -51,10 +53,15 @@ const props = defineProps<{
   micEnabled: boolean;
   /** Identities LiveKit currently reports (held) as actively speaking. */
   activeSpeakerIdentities?: ReadonlySet<string>;
+  /** Participant the Speaker layout auto-promotes to the large tile. */
+  promotedSpeakerIdentity?: string | null;
 }>();
 
 const seenRemoteScreenTrackKeys = ref<ReadonlySet<string>>(new Set());
-const manualFocusKey = ref<string | null>(null);
+// View mode + pin are call-scoped atoms (not local refs) so they survive the
+// split⟷expanded surface switch that remounts this grid.
+const viewMode = useStore($callViewMode);
+const manualFocusKey = useStore($callPinnedTileKey);
 
 const projection = computed(() => {
   return projectCallTiles({
@@ -65,6 +72,8 @@ const projection = computed(() => {
     micEnabled: props.micEnabled,
     seenRemoteScreenTrackKeys: seenRemoteScreenTrackKeys.value,
     manualFocusKey: manualFocusKey.value,
+    viewMode: viewMode.value,
+    promotedSpeakerIdentity: props.promotedSpeakerIdentity ?? null,
   });
 });
 
@@ -78,8 +87,11 @@ watch(projection, (next) => {
   if (seenRemoteScreenTrackKeys.value !== reconciled.seenRemoteScreenTrackKeys) {
     seenRemoteScreenTrackKeys.value = reconciled.seenRemoteScreenTrackKeys;
   }
+  // A pinned participant who has left is cleared so the pin can't reapply if
+  // they rejoin; written back through the atom (the store is the source of
+  // truth, not a local ref).
   if (manualFocusKey.value !== reconciled.manualFocusKey) {
-    manualFocusKey.value = reconciled.manualFocusKey;
+    $callPinnedTileKey.set(reconciled.manualFocusKey);
   }
 }, { immediate: true });
 
@@ -95,7 +107,7 @@ const otherTiles = computed<Tile[]>(() => {
 });
 
 function toggleFocus(tile: Tile): void {
-  manualFocusKey.value = manualFocusKey.value === tile.key ? null : tile.key;
+  toggleCallPin(tile.key);
 }
 
 // One `TileAttachments` per grid instance — reconciles (element,

--- a/chat/src/components/calls/CallTileGrid.vue
+++ b/chat/src/components/calls/CallTileGrid.vue
@@ -61,7 +61,7 @@ const seenRemoteScreenTrackKeys = ref<ReadonlySet<string>>(new Set());
 // View mode + pin are call-scoped atoms (not local refs) so they survive the
 // split⟷expanded surface switch that remounts this grid.
 const viewMode = useStore($callViewMode);
-const manualFocusKey = useStore($callPinnedTileKey);
+const pinnedTileKey = useStore($callPinnedTileKey);
 
 const projection = computed(() => {
   return projectCallTiles({
@@ -71,7 +71,7 @@ const projection = computed(() => {
     expectedRemoteIdentities: props.expectedRemoteIdentities,
     micEnabled: props.micEnabled,
     seenRemoteScreenTrackKeys: seenRemoteScreenTrackKeys.value,
-    manualFocusKey: manualFocusKey.value,
+    pinnedTileKey: pinnedTileKey.value,
     viewMode: viewMode.value,
     promotedSpeakerIdentity: props.promotedSpeakerIdentity ?? null,
   });
@@ -80,7 +80,7 @@ const projection = computed(() => {
 watch(projection, (next) => {
   const reconciled = reconcileCallTileProjectionState({
     tiles: next.tiles,
-    manualFocusKey: manualFocusKey.value,
+    pinnedTileKey: pinnedTileKey.value,
     currentSeenRemoteScreenTrackKeys: seenRemoteScreenTrackKeys.value,
     nextSeenRemoteScreenTrackKeys: next.seenRemoteScreenTrackKeys,
   });
@@ -90,8 +90,8 @@ watch(projection, (next) => {
   // A pinned participant who has left is cleared so the pin can't reapply if
   // they rejoin; written back through the atom (the store is the source of
   // truth, not a local ref).
-  if (manualFocusKey.value !== reconciled.manualFocusKey) {
-    $callPinnedTileKey.set(reconciled.manualFocusKey);
+  if (pinnedTileKey.value !== reconciled.pinnedTileKey) {
+    $callPinnedTileKey.set(reconciled.pinnedTileKey);
   }
 }, { immediate: true });
 

--- a/chat/src/lib/calls/active-speakers.ts
+++ b/chat/src/lib/calls/active-speakers.ts
@@ -78,6 +78,26 @@ export function advanceActiveSpeakers(input: AdvanceActiveSpeakersInput): Active
   };
 }
 
+/**
+ * Drop a participant from the active-speaker hold entirely — both the live
+ * speaking set and any in-flight release countdown. Used when a participant
+ * leaves the call so their brief highlight (and any Speaker-view promotion
+ * derived from it) cannot survive their departure and re-apply the instant they
+ * rejoin with a fresh tile. Returns the same state when the identity is absent,
+ * so a departure that touches no speaker state causes no needless churn.
+ */
+export function evictActiveSpeaker(
+  state: ActiveSpeakerState,
+  identity: string,
+): ActiveSpeakerState {
+  if (!state.speaking.has(identity) && !state.releasing.has(identity)) return state;
+  const speaking = new Set(state.speaking);
+  speaking.delete(identity);
+  const releasing = new Map(state.releasing);
+  releasing.delete(identity);
+  return { speaking, releasing };
+}
+
 export function highlightedTileKeys(
   tiles: readonly CallTileModel[],
   activeIdentities: ReadonlySet<string>,

--- a/chat/src/lib/calls/call-tile-projection.ts
+++ b/chat/src/lib/calls/call-tile-projection.ts
@@ -1,8 +1,13 @@
 import { buildCallTiles, type BuildCallTilesInput, type CallTileModel } from "./call-tiles";
+import type { CallViewMode } from "./view-mode";
 
 export type ProjectCallTilesInput = BuildCallTilesInput & {
   seenRemoteScreenTrackKeys: ReadonlySet<string>;
   manualFocusKey: string | null;
+  /** Stage layout the user has chosen for this call. Defaults to `gallery`. */
+  viewMode?: CallViewMode;
+  /** Identity the Speaker layout should auto-promote to the large tile. */
+  promotedSpeakerIdentity?: string | null;
 };
 
 export type CallTileProjection = {
@@ -62,9 +67,13 @@ export function projectCallTiles(input: ProjectCallTilesInput): CallTileProjecti
   const manualTile = input.manualFocusKey
     ? tiles.find((tile) => tile.key === input.manualFocusKey) ?? null
     : null;
-  const spotlightKey = manualTile?.key
-    ?? newlyAppearedScreen?.key
+  // Precedence: a screen share always claims the large tile, then a local
+  // pin, then (in Speaker view) the auto-promoted active speaker; Gallery
+  // with nothing sharing or pinned falls through to the equal grid.
+  const spotlightKey = newlyAppearedScreen?.key
     ?? newestSeenRemoteScreen(remoteScreens, nextSeenRemoteScreenTrackKeys)?.key
+    ?? manualTile?.key
+    ?? speakerPromotionKey(tiles, input.viewMode ?? "gallery", input.promotedSpeakerIdentity ?? null)
     ?? null;
 
   return {
@@ -72,6 +81,26 @@ export function projectCallTiles(input: ProjectCallTilesInput): CallTileProjecti
     spotlightKey,
     seenRemoteScreenTrackKeys: nextSeenRemoteScreenTrackKeys,
   };
+}
+
+/**
+ * The large tile in Speaker view: the promoted speaker's camera tile, or — when
+ * nobody has spoken yet or the promoted participant has left — a stable
+ * fallback (a remote camera tile if any, else the first camera tile) so the
+ * Speaker layout always has a large tile. Returns `null` in Gallery view.
+ */
+function speakerPromotionKey(
+  tiles: readonly CallTileModel[],
+  viewMode: CallViewMode,
+  promotedSpeakerIdentity: string | null,
+): string | null {
+  if (viewMode !== "speaker") return null;
+  const cameraTiles = tiles.filter((tile) => tile.source === "camera");
+  const promoted = promotedSpeakerIdentity
+    ? cameraTiles.find((tile) => tile.identity === promotedSpeakerIdentity) ?? null
+    : null;
+  const fallback = cameraTiles.find((tile) => !tile.isSelf) ?? cameraTiles[0] ?? null;
+  return (promoted ?? fallback)?.key ?? null;
 }
 
 function newestSeenRemoteScreen(

--- a/chat/src/lib/calls/call-tile-projection.ts
+++ b/chat/src/lib/calls/call-tile-projection.ts
@@ -3,7 +3,7 @@ import type { CallViewMode } from "./view-mode";
 
 export type ProjectCallTilesInput = BuildCallTilesInput & {
   seenRemoteScreenTrackKeys: ReadonlySet<string>;
-  manualFocusKey: string | null;
+  pinnedTileKey: string | null;
   /** Stage layout the user has chosen for this call. Defaults to `gallery`. */
   viewMode?: CallViewMode;
   /** Identity the Speaker layout should auto-promote to the large tile. */
@@ -18,13 +18,13 @@ export type CallTileProjection = {
 
 export type ReconcileCallTileProjectionStateInput = {
   tiles: readonly CallTileModel[];
-  manualFocusKey: string | null;
+  pinnedTileKey: string | null;
   currentSeenRemoteScreenTrackKeys: ReadonlySet<string>;
   nextSeenRemoteScreenTrackKeys: ReadonlySet<string>;
 };
 
 export type ReconciledCallTileProjectionState = {
-  manualFocusKey: string | null;
+  pinnedTileKey: string | null;
   seenRemoteScreenTrackKeys: ReadonlySet<string>;
 };
 
@@ -32,7 +32,7 @@ export function reconcileCallTileProjectionState(
   input: ReconcileCallTileProjectionStateInput,
 ): ReconciledCallTileProjectionState {
   return {
-    manualFocusKey: retainManualFocusKey(input.tiles, input.manualFocusKey),
+    pinnedTileKey: retainPinnedTileKey(input.tiles, input.pinnedTileKey),
     seenRemoteScreenTrackKeys: sameSet(
       input.currentSeenRemoteScreenTrackKeys,
       input.nextSeenRemoteScreenTrackKeys,
@@ -42,12 +42,12 @@ export function reconcileCallTileProjectionState(
   };
 }
 
-export function retainManualFocusKey(
+export function retainPinnedTileKey(
   tiles: readonly CallTileModel[],
-  manualFocusKey: string | null,
+  pinnedTileKey: string | null,
 ): string | null {
-  if (manualFocusKey === null) return null;
-  return tiles.some((tile) => tile.key === manualFocusKey) ? manualFocusKey : null;
+  if (pinnedTileKey === null) return null;
+  return tiles.some((tile) => tile.key === pinnedTileKey) ? pinnedTileKey : null;
 }
 
 export function projectCallTiles(input: ProjectCallTilesInput): CallTileProjection {
@@ -64,15 +64,17 @@ export function projectCallTiles(input: ProjectCallTilesInput): CallTileProjecti
     if (tile.screenTrackKey !== null) nextSeenRemoteScreenTrackKeys.add(tile.screenTrackKey);
   }
 
-  const manualTile = input.manualFocusKey
-    ? tiles.find((tile) => tile.key === input.manualFocusKey) ?? null
+  const pinnedTile = input.pinnedTileKey
+    ? tiles.find((tile) => tile.key === input.pinnedTileKey) ?? null
     : null;
-  // Precedence: a screen share always claims the large tile, then a local
-  // pin, then (in Speaker view) the auto-promoted active speaker; Gallery
-  // with nothing sharing or pinned falls through to the equal grid.
+  // Precedence: an incoming (remote) screen share always claims the large
+  // tile, then a local pin, then (in Speaker view) the auto-promoted active
+  // speaker; Gallery with nothing sharing or pinned falls through to the equal
+  // grid. A local screen share is shown as a self-share notice, not a stage
+  // tile, so it never competes here.
   const spotlightKey = newlyAppearedScreen?.key
     ?? newestSeenRemoteScreen(remoteScreens, nextSeenRemoteScreenTrackKeys)?.key
-    ?? manualTile?.key
+    ?? pinnedTile?.key
     ?? speakerPromotionKey(tiles, input.viewMode ?? "gallery", input.promotedSpeakerIdentity ?? null)
     ?? null;
 

--- a/chat/src/lib/calls/call-view-state.ts
+++ b/chat/src/lib/calls/call-view-state.ts
@@ -1,0 +1,37 @@
+import { atom } from "nanostores";
+import type { CallViewMode } from "./view-mode";
+
+/**
+ * Per-call stage presentation: the chosen Gallery/Speaker view mode and the
+ * locally pinned tile. Both are module-scoped atoms (not component refs) so the
+ * choice survives the split⟷expanded surface switch — which remounts the tile
+ * grid — and persists for the duration of the call.
+ *
+ * Both reset to their defaults at the start of every fresh call via
+ * [`resetCallViewState`] so a previous call's Speaker view or pin never leaks
+ * in. Distinct from `$callUiMode` (the localStorage-backed split/expanded
+ * surface preference), which deliberately outlives individual calls.
+ *
+ * The pin is local-only — it affects only this client's view and is never put
+ * on the wire (the signalling-propagated host "Spotlight" is separate, future
+ * work; see ADR-0016).
+ */
+export const $callViewMode = atom<CallViewMode>("gallery");
+
+/** The locally pinned tile key, or `null` when nothing is pinned. */
+export const $callPinnedTileKey = atom<string | null>(null);
+
+export function setCallViewMode(mode: CallViewMode): void {
+  $callViewMode.set(mode);
+}
+
+/** Pin a tile, or unpin it if it is already the pinned one. */
+export function toggleCallPin(tileKey: string): void {
+  $callPinnedTileKey.set($callPinnedTileKey.get() === tileKey ? null : tileKey);
+}
+
+/** Reset stage presentation to its per-call defaults: Gallery, nothing pinned. */
+export function resetCallViewState(): void {
+  $callViewMode.set("gallery");
+  $callPinnedTileKey.set(null);
+}

--- a/chat/src/lib/calls/use-call-engine.ts
+++ b/chat/src/lib/calls/use-call-engine.ts
@@ -4,6 +4,7 @@ import { CallEngine, type LocalMediaTrack, type RemoteMediaTrack } from "./engin
 import {
   advanceActiveSpeakers,
   emptyActiveSpeakerState,
+  evictActiveSpeaker,
   type ActiveSpeakerState,
 } from "./active-speakers";
 import {
@@ -122,6 +123,22 @@ function pumpActiveSpeakers(): void {
   if (step.nextDeadline !== null) {
     activeSpeakerSweep = setTimeout(pumpActiveSpeakers, Math.max(0, step.nextDeadline - now));
   }
+}
+
+/**
+ * Purge a departed participant from all active-speaker state — the brief hold
+ * AND the sticky Speaker-view promotion — then re-derive. Without this, the ~1s
+ * release hold (or the sticky promotion, which holds the last speaker through
+ * silence) would survive their departure and re-highlight or re-promote them
+ * the instant they rejoin with a fresh tile.
+ */
+function forgetDepartedSpeaker(identity: string): void {
+  if (speakerPromotion.promotedIdentity === identity) {
+    speakerPromotion = emptySpeakerPromotion();
+  }
+  activeSpeakerState = evictActiveSpeaker(activeSpeakerState, identity);
+  lastSpeakingIdentities = lastSpeakingIdentities.filter((id) => id !== identity);
+  pumpActiveSpeakers();
 }
 
 /** Drop all active-speaker state so the next call starts from a clean slate. */
@@ -426,6 +443,9 @@ export function useCallEngine(): {
       addLiveCallParticipant(roomJid, identity);
     });
     singletonEngine.on("participantDisconnected", (identity) => {
+      // Clear any active-speaker highlight + Speaker-view promotion the leaver
+      // held, so neither survives their departure to re-apply on a fast rejoin.
+      forgetDepartedSpeaker(identity);
       const roomJid = activeMucRoomJid();
       if (!roomJid) return;
       removeLiveCallParticipant(roomJid, identity);

--- a/chat/src/lib/calls/use-call-engine.ts
+++ b/chat/src/lib/calls/use-call-engine.ts
@@ -7,6 +7,11 @@ import {
   type ActiveSpeakerState,
 } from "./active-speakers";
 import {
+  advanceSpeakerPromotion,
+  emptySpeakerPromotion,
+  type SpeakerPromotionState,
+} from "./view-mode";
+import {
   addLiveCallParticipant,
   clearLiveCallParticipants,
   markRoomLeavingCall,
@@ -78,6 +83,17 @@ let lastSpeakingIdentities: readonly string[] = [];
 let activeSpeakerSweep: ReturnType<typeof setTimeout> | null = null;
 
 /**
+ * The participant the Speaker layout auto-promotes to the large tile, derived
+ * from the held active-speaker set through the sticky `advanceSpeakerPromotion`
+ * machine: it holds the current speaker through silence and only hands the
+ * large tile to a different participant once they become active. Consumed only
+ * in Speaker view; a pin or a screen share outranks it (see `projectCallTiles`).
+ */
+const promotedSpeakerIdentity: Ref<string | null> = ref(null);
+/** Sticky promotion state for the derivation; reset between calls. */
+let speakerPromotion: SpeakerPromotionState = emptySpeakerPromotion();
+
+/**
  * Re-derive the highlighted set against `lastSpeakingIdentities` at the current
  * wall-clock time, publish it, and (re)arm a single sweep for the next release
  * deadline. Idempotent: safe to call from a LiveKit event or from the sweep.
@@ -98,6 +114,11 @@ function pumpActiveSpeakers(): void {
   });
   activeSpeakerState = step.state;
   activeSpeakerIdentities.value = step.activeIdentities;
+  speakerPromotion = advanceSpeakerPromotion({
+    state: speakerPromotion,
+    activeIdentities: step.activeIdentities,
+  });
+  promotedSpeakerIdentity.value = speakerPromotion.promotedIdentity;
   if (step.nextDeadline !== null) {
     activeSpeakerSweep = setTimeout(pumpActiveSpeakers, Math.max(0, step.nextDeadline - now));
   }
@@ -112,6 +133,8 @@ function resetActiveSpeakers(): void {
   activeSpeakerState = emptyActiveSpeakerState();
   lastSpeakingIdentities = [];
   activeSpeakerIdentities.value = new Set();
+  speakerPromotion = emptySpeakerPromotion();
+  promotedSpeakerIdentity.value = null;
 }
 
 /**
@@ -309,6 +332,7 @@ export function useCallEngine(): {
   remoteTracks: Ref<RemoteMediaTrack[]>;
   localTracks: Ref<LocalMediaTrack[]>;
   activeSpeakerIdentities: Ref<ReadonlySet<string>>;
+  promotedSpeakerIdentity: Ref<string | null>;
 } {
   if (!singletonEngine) {
     singletonEngine = new CallEngine();
@@ -447,7 +471,13 @@ export function useCallEngine(): {
       clearLiveCallParticipants(slot.roomJid);
     });
   }
-  return { engine: singletonEngine, remoteTracks, localTracks, activeSpeakerIdentities };
+  return {
+    engine: singletonEngine,
+    remoteTracks,
+    localTracks,
+    activeSpeakerIdentities,
+    promotedSpeakerIdentity,
+  };
 }
 
 /**

--- a/chat/src/lib/calls/view-mode.ts
+++ b/chat/src/lib/calls/view-mode.ts
@@ -1,0 +1,44 @@
+/**
+ * View mode for the in-call stage: an equal-weight Gallery grid, or a
+ * Speaker layout with one large tile following the active speaker.
+ */
+export type CallViewMode = "gallery" | "speaker";
+
+/**
+ * The sticky promotion the Speaker layout uses to pick its large tile:
+ * the identity currently promoted to the large tile, or `null` before
+ * anyone has spoken.
+ */
+export type SpeakerPromotionState = {
+  readonly promotedIdentity: string | null;
+};
+
+export function emptySpeakerPromotion(): SpeakerPromotionState {
+  return { promotedIdentity: null };
+}
+
+export type AdvanceSpeakerPromotionInput = {
+  state: SpeakerPromotionState;
+  /** Identities currently (held) reported as actively speaking. */
+  activeIdentities: ReadonlySet<string>;
+};
+
+export function advanceSpeakerPromotion(
+  input: AdvanceSpeakerPromotionInput,
+): SpeakerPromotionState {
+  const current = input.state.promotedIdentity;
+  // Stay on the current speaker while they are still active — a co-speaker
+  // joining in must not snatch the large tile from whoever already has it —
+  // and through a silence, so the large tile holds the last speaker rather
+  // than going blank until someone else talks.
+  if (current !== null && (input.activeIdentities.size === 0 || input.activeIdentities.has(current))) {
+    return input.state;
+  }
+  const next = firstOf(input.activeIdentities);
+  return { promotedIdentity: next };
+}
+
+function firstOf(identities: ReadonlySet<string>): string | null {
+  for (const identity of identities) return identity;
+  return null;
+}

--- a/chat/src/lib/calls/view-mode.ts
+++ b/chat/src/lib/calls/view-mode.ts
@@ -34,6 +34,10 @@ export function advanceSpeakerPromotion(
   if (current !== null && (input.activeIdentities.size === 0 || input.activeIdentities.has(current))) {
     return input.state;
   }
+  // Hand the large tile to the first active identity. The set preserves the
+  // order of LiveKit's active-speaker signal, which is sorted loudest-first,
+  // so on a hand-off with several simultaneous speakers the loudest wins — a
+  // deterministic, sensible tie-break without tracking per-speaker timestamps.
   const next = firstOf(input.activeIdentities);
   return { promotedIdentity: next };
 }

--- a/chat/tests/active-speakers.test.ts
+++ b/chat/tests/active-speakers.test.ts
@@ -3,6 +3,7 @@ import {
   ACTIVE_SPEAKER_HOLD_MS,
   advanceActiveSpeakers,
   emptyActiveSpeakerState,
+  evictActiveSpeaker,
   highlightedTileKeys,
 } from "../src/lib/calls/active-speakers";
 import { buildCallTiles } from "../src/lib/calls/call-tiles";
@@ -243,5 +244,60 @@ describe("highlightedTileKeys", () => {
     const highlighted = highlightedTileKeys(tiles, new Set(["bob@example.com/phone"]));
 
     expect([...highlighted]).toEqual([]);
+  });
+});
+
+describe("evictActiveSpeaker", () => {
+  test("removes a currently-speaking identity from the derived active set", () => {
+    const spoke = advanceActiveSpeakers({
+      state: emptyActiveSpeakerState(),
+      speakingIdentities: ["bob@example.com/web", "carol@example.com/web"],
+      now: 0,
+    });
+
+    const evicted = evictActiveSpeaker(spoke.state, "bob@example.com/web");
+    const next = advanceActiveSpeakers({
+      state: evicted,
+      speakingIdentities: ["carol@example.com/web"],
+      now: 10,
+    });
+
+    expect([...next.activeIdentities]).toEqual(["carol@example.com/web"]);
+  });
+
+  test("removes an identity still inside its release hold so it cannot be re-highlighted", () => {
+    // Bob speaks, then falls silent — he is now held in the release countdown.
+    const spoke = advanceActiveSpeakers({
+      state: emptyActiveSpeakerState(),
+      speakingIdentities: ["bob@example.com/web"],
+      now: 0,
+    });
+    const releasing = advanceActiveSpeakers({
+      state: spoke.state,
+      speakingIdentities: [],
+      now: 100,
+    });
+    expect(releasing.activeIdentities.has("bob@example.com/web")).toBe(true);
+
+    // Bob leaves mid-hold; evicting him drops the lingering release entry.
+    const evicted = evictActiveSpeaker(releasing.state, "bob@example.com/web");
+    const next = advanceActiveSpeakers({
+      state: evicted,
+      speakingIdentities: [],
+      now: 200,
+    });
+
+    expect(next.activeIdentities.has("bob@example.com/web")).toBe(false);
+    expect(next.nextDeadline).toBeNull();
+  });
+
+  test("returns the same state object when the identity is absent", () => {
+    const spoke = advanceActiveSpeakers({
+      state: emptyActiveSpeakerState(),
+      speakingIdentities: ["bob@example.com/web"],
+      now: 0,
+    });
+
+    expect(evictActiveSpeaker(spoke.state, "carol@example.com/web")).toBe(spoke.state);
   });
 });

--- a/chat/tests/call-tile-spotlight.test.ts
+++ b/chat/tests/call-tile-spotlight.test.ts
@@ -61,7 +61,7 @@ describe("call tile spotlight projection", () => {
     expect(projection.spotlightKey).toBe("remote:bob@example.com/web:screen_share");
   });
 
-  test("lets manual tile focus override a remote screen spotlight", () => {
+  test("lets a remote screen share outrank a pin for the large tile", () => {
     const projection = projectCallTiles({
       remoteTracks: [
         remoteVideo("bob@example.com/web", "camera-pub", "camera"),
@@ -72,6 +72,42 @@ describe("call tile spotlight projection", () => {
       micEnabled: true,
       seenRemoteScreenTrackKeys: new Set(["screen-pub"]),
       manualFocusKey: "remote:bob@example.com/web:camera",
+    });
+
+    // Screen share always claims the large tile, even over an explicit pin —
+    // the pin is retained and re-asserts once the share stops.
+    expect(projection.spotlightKey).toBe("remote:bob@example.com/web:screen_share");
+  });
+
+  test("honours a pin for the large tile when nothing is being shared", () => {
+    const projection = projectCallTiles({
+      remoteTracks: [
+        remoteVideo("bob@example.com/web", "bob-camera", "camera"),
+        remoteVideo("carol@example.com/web", "carol-camera", "camera"),
+      ],
+      localTracks: [],
+      localIdentity: "alice@example.com/web",
+      micEnabled: true,
+      seenRemoteScreenTrackKeys: new Set(),
+      manualFocusKey: "remote:carol@example.com/web:camera",
+    });
+
+    expect(projection.spotlightKey).toBe("remote:carol@example.com/web:camera");
+  });
+
+  test("lets a pin override active-speaker promotion in Speaker view", () => {
+    const projection = projectCallTiles({
+      remoteTracks: [
+        remoteVideo("bob@example.com/web", "bob-camera", "camera"),
+        remoteVideo("carol@example.com/web", "carol-camera", "camera"),
+      ],
+      localTracks: [],
+      localIdentity: "alice@example.com/web",
+      micEnabled: true,
+      seenRemoteScreenTrackKeys: new Set(),
+      manualFocusKey: "remote:bob@example.com/web:camera",
+      viewMode: "speaker",
+      promotedSpeakerIdentity: "carol@example.com/web",
     });
 
     expect(projection.spotlightKey).toBe("remote:bob@example.com/web:camera");
@@ -189,7 +225,9 @@ describe("call tile spotlight projection", () => {
       seenRemoteScreenTrackKeys: new Set(["carol-screen-pub"]),
       manualFocusKey: "remote:bob@example.com/web:camera",
     });
-    expect(focused.spotlightKey).toBe("remote:bob@example.com/web:camera");
+    // Carol's screen outranks Bob's pin for the large tile, but the pin is
+    // still retained internally — until Bob leaves and reconcile clears it.
+    expect(focused.spotlightKey).toBe("remote:carol@example.com/web:screen_share");
 
     const afterBobLeaves = projectCallTiles({
       remoteTracks: [
@@ -225,6 +263,87 @@ describe("call tile spotlight projection", () => {
     expect(afterBobRejoins.spotlightKey).toBe("remote:carol@example.com/web:screen_share");
   });
 
+  test("promotes the active speaker's camera tile in Speaker view", () => {
+    const projection = projectCallTiles({
+      remoteTracks: [
+        remoteVideo("bob@example.com/web", "bob-camera", "camera"),
+        remoteVideo("carol@example.com/web", "carol-camera", "camera"),
+      ],
+      localTracks: [],
+      localIdentity: "alice@example.com/web",
+      micEnabled: true,
+      seenRemoteScreenTrackKeys: new Set(),
+      manualFocusKey: null,
+      viewMode: "speaker",
+      promotedSpeakerIdentity: "carol@example.com/web",
+    });
+
+    expect(projection.spotlightKey).toBe("remote:carol@example.com/web:camera");
+  });
+
+  test("keeps the equal grid in Gallery view even with an active speaker", () => {
+    const projection = projectCallTiles({
+      remoteTracks: [remoteVideo("bob@example.com/web", "bob-camera", "camera")],
+      localTracks: [],
+      localIdentity: "alice@example.com/web",
+      micEnabled: true,
+      seenRemoteScreenTrackKeys: new Set(),
+      manualFocusKey: null,
+      viewMode: "gallery",
+      promotedSpeakerIdentity: "bob@example.com/web",
+    });
+
+    expect(projection.spotlightKey).toBeNull();
+  });
+
+  test("falls back to a remote camera in Speaker view before anyone has spoken", () => {
+    const projection = projectCallTiles({
+      remoteTracks: [remoteVideo("bob@example.com/web", "bob-camera", "camera")],
+      localTracks: [],
+      localIdentity: "alice@example.com/web",
+      micEnabled: true,
+      seenRemoteScreenTrackKeys: new Set(),
+      manualFocusKey: null,
+      viewMode: "speaker",
+      promotedSpeakerIdentity: null,
+    });
+
+    expect(projection.spotlightKey).toBe("remote:bob@example.com/web:camera");
+  });
+
+  test("falls back to the self tile in Speaker view when alone in the call", () => {
+    const projection = projectCallTiles({
+      remoteTracks: [],
+      localTracks: [],
+      localIdentity: "alice@example.com/web",
+      micEnabled: true,
+      seenRemoteScreenTrackKeys: new Set(),
+      manualFocusKey: null,
+      viewMode: "speaker",
+      promotedSpeakerIdentity: null,
+    });
+
+    expect(projection.spotlightKey).toBe("self:alice@example.com/web:camera");
+  });
+
+  test("lets a screen share outrank active-speaker promotion in Speaker view", () => {
+    const projection = projectCallTiles({
+      remoteTracks: [
+        remoteVideo("bob@example.com/web", "bob-screen", "screen_share"),
+        remoteVideo("carol@example.com/web", "carol-camera", "camera"),
+      ],
+      localTracks: [],
+      localIdentity: "alice@example.com/web",
+      micEnabled: true,
+      seenRemoteScreenTrackKeys: new Set(),
+      manualFocusKey: null,
+      viewMode: "speaker",
+      promotedSpeakerIdentity: "carol@example.com/web",
+    });
+
+    expect(projection.spotlightKey).toBe("remote:bob@example.com/web:screen_share");
+  });
+
   test("retains manual focus while its target tile is still present", () => {
     const projection = projectCallTiles({
       remoteTracks: [
@@ -238,7 +357,9 @@ describe("call tile spotlight projection", () => {
       manualFocusKey: "remote:bob@example.com/web:camera",
     });
 
-    expect(projection.spotlightKey).toBe("remote:bob@example.com/web:camera");
+    // Carol's screen holds the large tile, yet the pin on Bob's still-present
+    // camera tile is retained (it re-asserts once Carol stops sharing).
+    expect(projection.spotlightKey).toBe("remote:carol@example.com/web:screen_share");
     expect(retainManualFocusKey(projection.tiles, "remote:bob@example.com/web:camera"))
       .toBe("remote:bob@example.com/web:camera");
   });

--- a/chat/tests/call-tile-spotlight.test.ts
+++ b/chat/tests/call-tile-spotlight.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   projectCallTiles,
   reconcileCallTileProjectionState,
-  retainManualFocusKey,
+  retainPinnedTileKey,
 } from "../src/lib/calls/call-tile-projection";
 import type { LocalMediaTrack, RemoteMediaTrack } from "../src/lib/calls/engine";
 
@@ -19,7 +19,7 @@ describe("call tile spotlight projection", () => {
       localIdentity: "alice@example.com/web",
       micEnabled: true,
       seenRemoteScreenTrackKeys: new Set(),
-      manualFocusKey: null,
+      pinnedTileKey: null,
     });
 
     expect(projection.spotlightKey).toBe("remote:bob@example.com/web:screen_share");
@@ -37,7 +37,7 @@ describe("call tile spotlight projection", () => {
       localIdentity: "alice@example.com/web",
       micEnabled: true,
       seenRemoteScreenTrackKeys,
-      manualFocusKey: null,
+      pinnedTileKey: null,
     });
 
     expect(projection.spotlightKey).toBe("remote:bob@example.com/web:screen_share");
@@ -55,7 +55,7 @@ describe("call tile spotlight projection", () => {
       localIdentity: "alice@example.com/web",
       micEnabled: true,
       seenRemoteScreenTrackKeys: new Set(["carol-screen-pub", "bob-screen-pub"]),
-      manualFocusKey: null,
+      pinnedTileKey: null,
     });
 
     expect(projection.spotlightKey).toBe("remote:bob@example.com/web:screen_share");
@@ -71,7 +71,7 @@ describe("call tile spotlight projection", () => {
       localIdentity: "alice@example.com/web",
       micEnabled: true,
       seenRemoteScreenTrackKeys: new Set(["screen-pub"]),
-      manualFocusKey: "remote:bob@example.com/web:camera",
+      pinnedTileKey: "remote:bob@example.com/web:camera",
     });
 
     // Screen share always claims the large tile, even over an explicit pin —
@@ -89,7 +89,7 @@ describe("call tile spotlight projection", () => {
       localIdentity: "alice@example.com/web",
       micEnabled: true,
       seenRemoteScreenTrackKeys: new Set(),
-      manualFocusKey: "remote:carol@example.com/web:camera",
+      pinnedTileKey: "remote:carol@example.com/web:camera",
     });
 
     expect(projection.spotlightKey).toBe("remote:carol@example.com/web:camera");
@@ -105,7 +105,7 @@ describe("call tile spotlight projection", () => {
       localIdentity: "alice@example.com/web",
       micEnabled: true,
       seenRemoteScreenTrackKeys: new Set(),
-      manualFocusKey: "remote:bob@example.com/web:camera",
+      pinnedTileKey: "remote:bob@example.com/web:camera",
       viewMode: "speaker",
       promotedSpeakerIdentity: "carol@example.com/web",
     });
@@ -122,7 +122,7 @@ describe("call tile spotlight projection", () => {
       localIdentity: "alice@example.com/web",
       micEnabled: true,
       seenRemoteScreenTrackKeys: new Set(["bob-screen-pub", "screen-pub"]),
-      manualFocusKey: "remote:bob@example.com/web:screen_share",
+      pinnedTileKey: "remote:bob@example.com/web:screen_share",
     });
 
     expect(projection.spotlightKey).toBe("remote:carol@example.com/web:screen_share");
@@ -135,7 +135,7 @@ describe("call tile spotlight projection", () => {
       localIdentity: "alice@example.com/web",
       micEnabled: true,
       seenRemoteScreenTrackKeys: new Set(["screen-pub"]),
-      manualFocusKey: "remote:bob@example.com/web:screen_share",
+      pinnedTileKey: "remote:bob@example.com/web:screen_share",
     });
 
     expect(projection.spotlightKey).toBeNull();
@@ -149,7 +149,7 @@ describe("call tile spotlight projection", () => {
       expectedRemoteIdentities: ["bob@example.com/phone"],
       micEnabled: true,
       seenRemoteScreenTrackKeys: new Set(),
-      manualFocusKey: null,
+      pinnedTileKey: null,
     });
 
     expect(sharing.spotlightKey).toBe("remote:bob@example.com/web:screen_share");
@@ -165,7 +165,7 @@ describe("call tile spotlight projection", () => {
       expectedRemoteIdentities: ["bob@example.com/phone"],
       micEnabled: true,
       seenRemoteScreenTrackKeys: sharing.seenRemoteScreenTrackKeys,
-      manualFocusKey: sharing.spotlightKey,
+      pinnedTileKey: sharing.spotlightKey,
     });
 
     expect(afterStop.spotlightKey).toBeNull();
@@ -182,7 +182,7 @@ describe("call tile spotlight projection", () => {
       localIdentity: "alice@example.com/web",
       micEnabled: true,
       seenRemoteScreenTrackKeys: new Set(),
-      manualFocusKey: null,
+      pinnedTileKey: null,
     });
 
     expect(projection.spotlightKey).toBeNull();
@@ -202,7 +202,7 @@ describe("call tile spotlight projection", () => {
         "bob-screen-pub-1",
         "carol-screen-pub",
       ]),
-      manualFocusKey: null,
+      pinnedTileKey: null,
     });
 
     expect(projection.spotlightKey).toBe("remote:bob@example.com/web:screen_share");
@@ -223,7 +223,7 @@ describe("call tile spotlight projection", () => {
       localIdentity: "alice@example.com/web",
       micEnabled: true,
       seenRemoteScreenTrackKeys: new Set(["carol-screen-pub"]),
-      manualFocusKey: "remote:bob@example.com/web:camera",
+      pinnedTileKey: "remote:bob@example.com/web:camera",
     });
     // Carol's screen outranks Bob's pin for the large tile, but the pin is
     // still retained internally — until Bob leaves and reconcile clears it.
@@ -237,17 +237,17 @@ describe("call tile spotlight projection", () => {
       localIdentity: "alice@example.com/web",
       micEnabled: true,
       seenRemoteScreenTrackKeys: new Set(["carol-screen-pub"]),
-      manualFocusKey: "remote:bob@example.com/web:camera",
+      pinnedTileKey: "remote:bob@example.com/web:camera",
     });
     const reconciled = reconcileCallTileProjectionState({
       tiles: afterBobLeaves.tiles,
-      manualFocusKey: "remote:bob@example.com/web:camera",
+      pinnedTileKey: "remote:bob@example.com/web:camera",
       currentSeenRemoteScreenTrackKeys: new Set(["carol-screen-pub"]),
       nextSeenRemoteScreenTrackKeys: afterBobLeaves.seenRemoteScreenTrackKeys,
     });
 
     expect(afterBobLeaves.spotlightKey).toBe("remote:carol@example.com/web:screen_share");
-    expect(reconciled.manualFocusKey).toBeNull();
+    expect(reconciled.pinnedTileKey).toBeNull();
 
     const afterBobRejoins = projectCallTiles({
       remoteTracks: [
@@ -258,7 +258,7 @@ describe("call tile spotlight projection", () => {
       localIdentity: "alice@example.com/web",
       micEnabled: true,
       seenRemoteScreenTrackKeys: reconciled.seenRemoteScreenTrackKeys,
-      manualFocusKey: reconciled.manualFocusKey,
+      pinnedTileKey: reconciled.pinnedTileKey,
     });
     expect(afterBobRejoins.spotlightKey).toBe("remote:carol@example.com/web:screen_share");
   });
@@ -273,7 +273,7 @@ describe("call tile spotlight projection", () => {
       localIdentity: "alice@example.com/web",
       micEnabled: true,
       seenRemoteScreenTrackKeys: new Set(),
-      manualFocusKey: null,
+      pinnedTileKey: null,
       viewMode: "speaker",
       promotedSpeakerIdentity: "carol@example.com/web",
     });
@@ -288,7 +288,7 @@ describe("call tile spotlight projection", () => {
       localIdentity: "alice@example.com/web",
       micEnabled: true,
       seenRemoteScreenTrackKeys: new Set(),
-      manualFocusKey: null,
+      pinnedTileKey: null,
       viewMode: "gallery",
       promotedSpeakerIdentity: "bob@example.com/web",
     });
@@ -303,7 +303,7 @@ describe("call tile spotlight projection", () => {
       localIdentity: "alice@example.com/web",
       micEnabled: true,
       seenRemoteScreenTrackKeys: new Set(),
-      manualFocusKey: null,
+      pinnedTileKey: null,
       viewMode: "speaker",
       promotedSpeakerIdentity: null,
     });
@@ -318,7 +318,7 @@ describe("call tile spotlight projection", () => {
       localIdentity: "alice@example.com/web",
       micEnabled: true,
       seenRemoteScreenTrackKeys: new Set(),
-      manualFocusKey: null,
+      pinnedTileKey: null,
       viewMode: "speaker",
       promotedSpeakerIdentity: null,
     });
@@ -336,7 +336,7 @@ describe("call tile spotlight projection", () => {
       localIdentity: "alice@example.com/web",
       micEnabled: true,
       seenRemoteScreenTrackKeys: new Set(),
-      manualFocusKey: null,
+      pinnedTileKey: null,
       viewMode: "speaker",
       promotedSpeakerIdentity: "carol@example.com/web",
     });
@@ -354,13 +354,13 @@ describe("call tile spotlight projection", () => {
       localIdentity: "alice@example.com/web",
       micEnabled: true,
       seenRemoteScreenTrackKeys: new Set(["carol-screen-pub"]),
-      manualFocusKey: "remote:bob@example.com/web:camera",
+      pinnedTileKey: "remote:bob@example.com/web:camera",
     });
 
     // Carol's screen holds the large tile, yet the pin on Bob's still-present
     // camera tile is retained (it re-asserts once Carol stops sharing).
     expect(projection.spotlightKey).toBe("remote:carol@example.com/web:screen_share");
-    expect(retainManualFocusKey(projection.tiles, "remote:bob@example.com/web:camera"))
+    expect(retainPinnedTileKey(projection.tiles, "remote:bob@example.com/web:camera"))
       .toBe("remote:bob@example.com/web:camera");
   });
 });

--- a/chat/tests/call-view-state.test.ts
+++ b/chat/tests/call-view-state.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  $callPinnedTileKey,
+  $callViewMode,
+  resetCallViewState,
+  setCallViewMode,
+  toggleCallPin,
+} from "../src/lib/calls/call-view-state";
+
+afterEach(() => {
+  resetCallViewState();
+});
+
+describe("call view state", () => {
+  test("defaults to Gallery with nothing pinned", () => {
+    expect($callViewMode.get()).toBe("gallery");
+    expect($callPinnedTileKey.get()).toBeNull();
+  });
+
+  test("setCallViewMode switches the stage layout", () => {
+    setCallViewMode("speaker");
+    expect($callViewMode.get()).toBe("speaker");
+  });
+
+  test("toggleCallPin pins a tile and unpins the same tile", () => {
+    toggleCallPin("remote:bob@example.com/web:camera");
+    expect($callPinnedTileKey.get()).toBe("remote:bob@example.com/web:camera");
+
+    toggleCallPin("remote:bob@example.com/web:camera");
+    expect($callPinnedTileKey.get()).toBeNull();
+  });
+
+  test("toggleCallPin moves the pin to a different tile", () => {
+    toggleCallPin("remote:bob@example.com/web:camera");
+    toggleCallPin("remote:carol@example.com/web:camera");
+    expect($callPinnedTileKey.get()).toBe("remote:carol@example.com/web:camera");
+  });
+
+  test("resetCallViewState returns to Gallery with nothing pinned", () => {
+    setCallViewMode("speaker");
+    toggleCallPin("remote:bob@example.com/web:camera");
+
+    resetCallViewState();
+
+    expect($callViewMode.get()).toBe("gallery");
+    expect($callPinnedTileKey.get()).toBeNull();
+  });
+});

--- a/chat/tests/view-mode.test.ts
+++ b/chat/tests/view-mode.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import {
+  advanceSpeakerPromotion,
+  emptySpeakerPromotion,
+} from "../src/lib/calls/view-mode";
+
+describe("speaker promotion", () => {
+  test("promotes the sole active speaker from an empty start", () => {
+    const next = advanceSpeakerPromotion({
+      state: emptySpeakerPromotion(),
+      activeIdentities: new Set(["bob@example.com/web"]),
+    });
+
+    expect(next.promotedIdentity).toBe("bob@example.com/web");
+  });
+
+  test("keeps the current promotion while it is still active and others join in", () => {
+    const next = advanceSpeakerPromotion({
+      state: { promotedIdentity: "bob@example.com/web" },
+      activeIdentities: new Set(["carol@example.com/web", "bob@example.com/web"]),
+    });
+
+    expect(next.promotedIdentity).toBe("bob@example.com/web");
+  });
+
+  test("holds the last speaker through a silence so the large tile never goes blank", () => {
+    const next = advanceSpeakerPromotion({
+      state: { promotedIdentity: "bob@example.com/web" },
+      activeIdentities: new Set(),
+    });
+
+    expect(next.promotedIdentity).toBe("bob@example.com/web");
+  });
+
+  test("promotes the new speaker once the previous one is no longer active", () => {
+    const next = advanceSpeakerPromotion({
+      state: { promotedIdentity: "bob@example.com/web" },
+      activeIdentities: new Set(["carol@example.com/web"]),
+    });
+
+    expect(next.promotedIdentity).toBe("carol@example.com/web");
+  });
+
+  test("stays empty before anyone has spoken", () => {
+    const next = advanceSpeakerPromotion({
+      state: emptySpeakerPromotion(),
+      activeIdentities: new Set(),
+    });
+
+    expect(next.promotedIdentity).toBeNull();
+  });
+});


### PR DESCRIPTION
## Issue

Closes #1025 (parent epic #1017): **Gallery/Speaker view switcher with active-speaker auto-promotion + Pin.**

## What this does

Adds an explicit, sticky-per-call **Gallery** ⟷ **Speaker** view switcher to the call control bar. In Speaker view the large tile auto-promotes to the active speaker (held, anti-flicker, sticky through silence). A local **Pin** forces the large tile and overrides active-speaker promotion until unpinned. An incoming **screen share always claims the large tile**.

Pin and view mode are local-only presentation (per `chat/CONTEXT.md` glossary; the signalling-propagated host "Spotlight" is separate future work, see ADR-0016) — **no XMPP wire/XEP changes**.

## Decisions (confirmed up front)

- **Large-tile precedence: `screen share > pin > active-speaker promotion > equal grid`.** Screen share always wins (this intentionally flips the previous `pin > screen` order; the pin is retained and re-asserts once the share stops). Affected spotlight tests were updated.
- **Auto-promotion candidates: anyone, including yourself** (LiveKit's held active-speaker set includes the local participant).
- **View mode is per-call**: default Gallery, reset on each fresh call, surviving the split⟷expanded surface switch (nanostores atom, not local component state).

## Approach — mirrors the #1018 three-layer pattern (engine → pure module → composable → UI)

1. **Pure `src/lib/calls/view-mode.ts`** — `CallViewMode` type + the sticky `advanceSpeakerPromotion` machine: keep the current promoted speaker while still active or while nobody is active; promote a different participant only once they become the active speaker.
2. **Extended pure `src/lib/calls/call-tile-projection.ts`** — `projectCallTiles` gains optional `viewMode` + `promotedSpeakerIdentity` and resolves the precedence above; Speaker view always falls back to a real large tile (remote camera, else self).
3. **Sticky state `src/lib/calls/call-view-state.ts`** — `$callViewMode` + `$callPinnedTileKey` atoms with `setCallViewMode` / `toggleCallPin` / `resetCallViewState`; reset wired into the fresh-call path in `CallOverlay.vue`.
4. **Composable `use-call-engine.ts`** — derives `promotedSpeakerIdentity` from the held active-speaker set; resets on disconnect; and on `participantDisconnected` purges the leaver from both the active-speaker hold (`evictActiveSpeaker`) and the promotion, so neither survives a fast rejoin.
5. **UI** — a WAI-ARIA radiogroup view switcher in `CallControls.vue` (roving tabindex + arrow keys); `viewMode` + `promotedSpeakerIdentity` threaded through both call surfaces; `CallTileGrid` reads the atoms, feeds `projectCallTiles`, and click-to-pin toggles `$callPinnedTileKey`.

## Acceptance criteria

- [x] View switcher toggles Gallery and Speaker; the choice persists for the duration of the call.
- [x] In Speaker view the large tile auto-promotes to the active speaker, held to avoid flicker.
- [x] Pinning a participant forces them into the large tile and overrides active-speaker promotion until unpinned.
- [x] An incoming screen share still takes the large tile.
- [x] View-mode and pin logic live in a pure module unit-tested via `bun test`.

## Review hardening (adversarial passes)

- Fixed a stale-promotion bug: a participant who left while silent could re-grab the large tile on rejoin — now purged from the active-speaker hold + promotion on departure (pure `evictActiveSpeaker`, unit-tested).
- View switcher modeled as a single-choice radiogroup (was two independent `aria-pressed` toggles).

## Testing

- `bun test` — `view-mode.test.ts`, extended `call-tile-spotlight.test.ts`, `call-view-state.test.ts`, `active-speakers.test.ts` (eviction). Full suite: 2337 pass / 0 fail.
- `bunx astro check` — 0 errors. `bunx knip` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
