### PR TITLE
feat(server): add stargate quotes extension

### DIFF
--- a/.github/workflows/waddle-server-default.yml
+++ b/.github/workflows/waddle-server-default.yml
@@ -114,6 +114,7 @@ jobs:
           server/target/wasm32-wasip2/release/ai_chatbot.wasm
           server/target/wasm32-wasip2/release/decision_polls.wasm
           server/target/wasm32-wasip2/release/github.wasm
+          server/target/wasm32-wasip2/release/stargate_quotes.wasm
         if-no-files-found: ignore
         include-hidden-files: true
   checkCiDrift:

--- a/flake.nix
+++ b/flake.nix
@@ -313,7 +313,7 @@
             baseArgs
             // {
               CARGO_BUILD_TARGET = "wasm32-wasip2";
-              cargoExtraArgs = "--locked --package ai-chatbot --package decision-polls --package github --package link-board";
+              cargoExtraArgs = "--locked --package ai-chatbot --package decision-polls --package github --package link-board --package stargate-quotes";
               cargoCheckExtraArgs = "";
               cargoBuildExtraArgs = "";
               cargoTestExtraArgs = "";
@@ -359,7 +359,7 @@
               pname = "waddle-server-extension-modules";
               CARGO_BUILD_TARGET = "wasm32-wasip2";
               cargoArtifacts = extensionWasmArtifacts;
-              cargoExtraArgs = "--locked --package ai-chatbot --package decision-polls --package github --package link-board";
+              cargoExtraArgs = "--locked --package ai-chatbot --package decision-polls --package github --package link-board --package stargate-quotes";
             }
           );
           waddle-server-xmpp-unit-tests = craneLib.cargoTest (

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -5470,6 +5470,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "stargate-quotes"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "extensions/decision-polls",
     "extensions/github",
     "extensions/link-board",
+    "extensions/stargate-quotes",
 ]
 
 [workspace.package]

--- a/server/crates/waddle-extensions/examples/profile_all_extensions.rs
+++ b/server/crates/waddle-extensions/examples/profile_all_extensions.rs
@@ -117,6 +117,19 @@ const EXTENSIONS: &[ExtSpec] = &[
         allowed_http_origins: &[],
         config: empty_config,
     },
+    ExtSpec {
+        name: "stargate-quotes",
+        namespace: "urn:waddle:stargate-quotes:1",
+        wasm_filename: "stargate_quotes.wasm",
+        grants: &[
+            ExtensionCapability::Commands,
+            ExtensionCapability::HostMessageSend,
+            ExtensionCapability::MessageEnrich,
+        ],
+        provider_room_grants: &[],
+        allowed_http_origins: &[],
+        config: empty_config,
+    },
 ];
 
 fn wasm_root() -> PathBuf {

--- a/server/crates/waddle-extensions/src/runtime.rs
+++ b/server/crates/waddle-extensions/src/runtime.rs
@@ -6,6 +6,7 @@ wasmtime::component::bindgen!({
     with: {
         "wasi:io": wasmtime_wasi::p2::bindings::io,
         "wasi:clocks": wasmtime_wasi::p2::bindings::clocks,
+        "wasi:random": wasmtime_wasi::p2::bindings::random,
     },
 });
 

--- a/server/deployment.cue
+++ b/server/deployment.cue
@@ -8,6 +8,7 @@ package cuenv
 #AiChatbotDigest: #Digest @tag(aiChatbotDigest)
 #DecisionPollsDigest: #Digest @tag(decisionPollsDigest)
 #GithubDigest: #Digest @tag(githubDigest)
+#StargateQuotesDigest: #Digest @tag(stargateQuotesDigest)
 #ServerImageDigest: #Digest @tag(serverImageDigest)
 
 #GitHubActionsRoom: "github-actions@muc.waddle.social"
@@ -77,6 +78,18 @@ package cuenv
 			"host.message.send",
 			"commands",
 			"pubsub.publish",
+		]
+	},
+	{
+		name:      "stargate-quotes"
+		registry:  "ghcr.io/waddle-social/waddle/extensions/stargate-quotes"
+		digest:    #StargateQuotesDigest
+		namespace: "urn:waddle:stargate-quotes:1"
+		config: {}
+		capabilityGrants: [
+			"commands",
+			"host.message.send",
+			"message.enrich",
 		]
 	},
 ]

--- a/server/env.cue
+++ b/server/env.cue
@@ -310,13 +310,14 @@ schema.#Project & {
 			args: ["-c", #"""
 					set -euo pipefail
 					rustup target add wasm32-wasip2 >/dev/null 2>&1 || true
-					for module in link-board ai-chatbot decision-polls github; do
+					for module in link-board ai-chatbot decision-polls github stargate-quotes; do
 					  cargo build --release --locked --target wasm32-wasip2 --target-dir target --manifest-path "extensions/${module}/Cargo.toml"
 					done
 					test -s target/wasm32-wasip2/release/link_board.wasm
 					test -s target/wasm32-wasip2/release/ai_chatbot.wasm
 					test -s target/wasm32-wasip2/release/decision_polls.wasm
 					test -s target/wasm32-wasip2/release/github.wasm
+					test -s target/wasm32-wasip2/release/stargate_quotes.wasm
 				"""#]
 			inputs: _rustInputs
 			outputs: [
@@ -324,6 +325,7 @@ schema.#Project & {
 				"server/target/wasm32-wasip2/release/ai_chatbot.wasm",
 				"server/target/wasm32-wasip2/release/decision_polls.wasm",
 				"server/target/wasm32-wasip2/release/github.wasm",
+				"server/target/wasm32-wasip2/release/stargate_quotes.wasm",
 			]
 			dependsOn: [tasks.fmt, tasks.clippy, tasks.test]
 		}
@@ -453,7 +455,8 @@ schema.#Project & {
 					  -t linkBoardDigest="${sample_digest}" \
 					  -t aiChatbotDigest="${sample_digest}" \
 					  -t decisionPollsDigest="${sample_digest}" \
-					  -t githubDigest="${sample_digest}" > "${modules_yaml}"
+					  -t githubDigest="${sample_digest}" \
+					  -t stargateQuotesDigest="${sample_digest}" > "${modules_yaml}"
 					cp "${gitops_values}" "${published_values}"
 					MODULES_YAML="${modules_yaml}" SAMPLE_DIGEST="${sample_digest}" SAMPLE_GIT_SHA="${sample_git_sha}" yq -i '
 					  .image.digest = strenv(SAMPLE_DIGEST) |
@@ -466,7 +469,8 @@ schema.#Project & {
 					  -t linkBoardDigest="${sample_digest}" \
 					  -t aiChatbotDigest="${sample_digest}" \
 					  -t decisionPollsDigest="${sample_digest}" \
-					  -t githubDigest="${sample_digest}"
+					  -t githubDigest="${sample_digest}" \
+					  -t stargateQuotesDigest="${sample_digest}"
 					helm lint charts/waddle-server -f "${published_values}"
 					helm template waddle-server charts/waddle-server \
 					  --namespace waddle \
@@ -603,12 +607,14 @@ schema.#Project & {
 					  "ai-chatbot:ai_chatbot:urn:waddle:ai-chatbot:1"
 					  "decision-polls:decision_polls:urn:waddle:decision-polls:1"
 					  "github:github:urn:waddle:web-integration:1"
+					  "stargate-quotes:stargate_quotes:urn:waddle:stargate-quotes:1"
 					)
 
 					link_board_digest=""
 					ai_chatbot_digest=""
 					decision_polls_digest=""
 					github_digest=""
+					stargate_quotes_digest=""
 					modules_yaml="../target/digests/extensions-modules.yaml"
 					for extension_spec in "${EXTENSIONS[@]}"; do
 					  IFS=: read -r extension_name crate_name _namespace_scheme _namespace_rest <<< "${extension_spec}"
@@ -641,6 +647,7 @@ schema.#Project & {
 					    ai-chatbot) ai_chatbot_digest="${extension_digest}" ;;
 					    decision-polls) decision_polls_digest="${extension_digest}" ;;
 					    github) github_digest="${extension_digest}" ;;
+					    stargate-quotes) stargate_quotes_digest="${extension_digest}" ;;
 					    *) echo "unknown extension ${extension_name}" >&2; exit 1 ;;
 					  esac
 					done
@@ -648,7 +655,8 @@ schema.#Project & {
 					  -t linkBoardDigest="${link_board_digest:?missing link-board digest}" \
 					  -t aiChatbotDigest="${ai_chatbot_digest:?missing ai-chatbot digest}" \
 					  -t decisionPollsDigest="${decision_polls_digest:?missing decision-polls digest}" \
-					  -t githubDigest="${github_digest:?missing github digest}" > "${modules_yaml}"
+					  -t githubDigest="${github_digest:?missing github digest}" \
+					  -t stargateQuotesDigest="${stargate_quotes_digest:?missing stargate-quotes digest}" > "${modules_yaml}"
 
 					FULL_SHA="${FULL_SHA}" yq -i ".spec.values.image.tag = \"sha-${SHORT_SHA}\" | .spec.values.image.digest = \"${digest}\" | .spec.values.containerExtraEnv = ((.spec.values.containerExtraEnv // []) | map(select(.name != \"WADDLE_GIT_SHA\"))) + [{\"name\": \"WADDLE_GIT_SHA\", \"value\": strenv(FULL_SHA)}] | .spec.values.extensions.enabled = true" ../infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml
 					yq -e ".spec.values.image.tag == \"sha-${SHORT_SHA}\"" ../infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml > /dev/null
@@ -672,7 +680,8 @@ schema.#Project & {
 					  -t linkBoardDigest="${link_board_digest}" \
 					  -t aiChatbotDigest="${ai_chatbot_digest}" \
 					  -t decisionPollsDigest="${decision_polls_digest}" \
-					  -t githubDigest="${github_digest}"
+					  -t githubDigest="${github_digest}" \
+					  -t stargateQuotesDigest="${stargate_quotes_digest}"
 					helm template waddle-server charts/waddle-server \
 					  --namespace waddle \
 					  -f "${gitops_values}" > "${gitops_render}"

--- a/server/extensions/ai-chatbot/src/lib.rs
+++ b/server/extensions/ai-chatbot/src/lib.rs
@@ -6,6 +6,7 @@ mod bindings {
             "wasi:logging/logging@0.1.0-draft": generate,
             "wasi:clocks/monotonic-clock@0.2.0": generate,
             "wasi:io/poll@0.2.0": generate,
+            "wasi:random/random@0.2.0": generate,
         },
     });
 }

--- a/server/extensions/decision-polls/src/lib.rs
+++ b/server/extensions/decision-polls/src/lib.rs
@@ -6,6 +6,7 @@ mod bindings {
             "wasi:logging/logging@0.1.0-draft": generate,
             "wasi:clocks/monotonic-clock@0.2.0": generate,
             "wasi:io/poll@0.2.0": generate,
+            "wasi:random/random@0.2.0": generate,
         },
     });
 }

--- a/server/extensions/github/src/lib.rs
+++ b/server/extensions/github/src/lib.rs
@@ -6,6 +6,7 @@ mod bindings {
             "wasi:logging/logging@0.1.0-draft": generate,
             "wasi:clocks/monotonic-clock@0.2.0": generate,
             "wasi:io/poll@0.2.0": generate,
+            "wasi:random/random@0.2.0": generate,
         },
     });
 }

--- a/server/extensions/link-board/src/lib.rs
+++ b/server/extensions/link-board/src/lib.rs
@@ -6,6 +6,7 @@ mod bindings {
             "wasi:logging/logging@0.1.0-draft": generate,
             "wasi:clocks/monotonic-clock@0.2.0": generate,
             "wasi:io/poll@0.2.0": generate,
+            "wasi:random/random@0.2.0": generate,
         },
     });
 }

--- a/server/extensions/stargate-quotes/Cargo.toml
+++ b/server/extensions/stargate-quotes/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "stargate-quotes"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+wit-bindgen = "0.57.1"

--- a/server/extensions/stargate-quotes/src/command.rs
+++ b/server/extensions/stargate-quotes/src/command.rs
@@ -1,0 +1,140 @@
+#[cfg(not(test))]
+use crate::bindings::waddle::extension::host_tools;
+use crate::bindings::waddle::extension::types;
+use crate::constants::{COMMAND_NODE, COMMAND_RESULT_ID, COMMAND_RESULT_TEXT};
+use crate::quotes::{quote_body, quote_catalog, select_quote_with_rng};
+use crate::ui::{display, payload_namespace, plugin_id, timestamp};
+
+#[cfg(test)]
+use std::sync::OnceLock;
+
+pub(crate) fn handle_command(
+    command: types::CommandInvocation,
+) -> Result<Vec<types::ExtensionEffect>, types::ExtensionError> {
+    handle_command_with_rng(command, random_u64)
+}
+
+pub(crate) fn handle_command_with_rng(
+    command: types::CommandInvocation,
+    mut next_u64: impl FnMut() -> u64,
+) -> Result<Vec<types::ExtensionEffect>, types::ExtensionError> {
+    if command.command_node.value != COMMAND_NODE {
+        return Ok(vec![]);
+    }
+    if matches!(command.action, Some(types::CommandAction::Cancel)) {
+        return Ok(vec![]);
+    }
+    let Some(room) = command.room else {
+        return Ok(vec![types::ExtensionEffect::HostWarning(display(
+            "Stargate quotes require an active channel.",
+        ))]);
+    };
+    let quotes = quote_catalog()?;
+    let quote = select_quote_with_rng(&quotes, &mut next_u64)?;
+    send_room_message(&room, display(&quote_body(quote)))?;
+    Ok(vec![posted_result_effect()])
+}
+
+#[cfg(not(test))]
+fn random_u64() -> u64 {
+    crate::bindings::wasi::random::random::get_random_u64()
+}
+
+#[cfg(test)]
+fn random_u64() -> u64 {
+    0
+}
+
+fn posted_result_effect() -> types::ExtensionEffect {
+    types::ExtensionEffect::EnrichMessage(types::ExtensionEnvelope {
+        version: 1,
+        enrichments: vec![types::MessageEnrichment {
+            id: types::EnrichmentId {
+                value: COMMAND_RESULT_ID.to_string(),
+            },
+            plugin: plugin_id(),
+            capability: types::ExtensionCapability::MessageEnrich,
+            payload_namespace: payload_namespace(),
+            created_at: timestamp(),
+            source: None,
+            ui: vec![types::UiView {
+                id: types::UiViewId {
+                    value: COMMAND_RESULT_ID.to_string(),
+                },
+                title: Some(display("Stargate Quotes")),
+                blocks: vec![types::UiBlock::Text(types::TextBlock {
+                    text: display(COMMAND_RESULT_TEXT),
+                    style: types::TextStyle::Body,
+                })],
+            }],
+            payloads: vec![],
+            launches: vec![],
+        }],
+    })
+}
+
+fn room_message_request(
+    room: &types::RoomJid,
+    body: types::DisplayText,
+) -> types::SendMessageRequest {
+    types::SendMessageRequest {
+        target: types::MessageTarget::Muc(room.clone()),
+        body,
+        thread_id: None,
+        reply_to: None,
+        extensions: None,
+    }
+}
+
+#[cfg(not(test))]
+fn send_room_message(
+    room: &types::RoomJid,
+    body: types::DisplayText,
+) -> Result<(), types::ExtensionError> {
+    host_tools::send_message(&room_message_request(room, body))
+        .map(|_| ())
+        .map_err(extension_error_from_host_tool)
+}
+
+#[cfg(test)]
+fn send_room_message(
+    room: &types::RoomJid,
+    body: types::DisplayText,
+) -> Result<(), types::ExtensionError> {
+    sent_room_messages()
+        .lock()
+        .expect("sent room messages lock")
+        .push(room_message_request(room, body));
+    Ok(())
+}
+
+#[cfg(test)]
+fn sent_room_messages() -> &'static std::sync::Mutex<Vec<types::SendMessageRequest>> {
+    static SENT_ROOM_MESSAGES: OnceLock<std::sync::Mutex<Vec<types::SendMessageRequest>>> =
+        OnceLock::new();
+    SENT_ROOM_MESSAGES.get_or_init(|| std::sync::Mutex::new(Vec::new()))
+}
+
+#[cfg(test)]
+pub(crate) fn take_sent_room_messages() -> Vec<types::SendMessageRequest> {
+    std::mem::take(
+        &mut *sent_room_messages()
+            .lock()
+            .expect("sent room messages lock"),
+    )
+}
+
+#[cfg(not(test))]
+fn extension_error_from_host_tool(error: types::HostToolError) -> types::ExtensionError {
+    let code = match error.code {
+        types::HostToolErrorCode::Denied => types::ExtensionErrorCode::Denied,
+        types::HostToolErrorCode::InvalidRequest
+        | types::HostToolErrorCode::NotFound
+        | types::HostToolErrorCode::Unsupported => types::ExtensionErrorCode::InvalidRequest,
+        types::HostToolErrorCode::TemporaryFailure => types::ExtensionErrorCode::TemporaryFailure,
+    };
+    types::ExtensionError {
+        code,
+        message: error.message,
+    }
+}

--- a/server/extensions/stargate-quotes/src/constants.rs
+++ b/server/extensions/stargate-quotes/src/constants.rs
@@ -1,0 +1,8 @@
+pub(crate) const PLUGIN_ID: &str = "stargate-quotes";
+pub(crate) const PLUGIN_NAME: &str = "Stargate Quotes";
+pub(crate) const PLUGIN_NS: &str = "urn:waddle:stargate-quotes:1";
+pub(crate) const VERSION: &str = "0.1.0";
+pub(crate) const COMMAND_NAME: &str = "/stargate";
+pub(crate) const COMMAND_NODE: &str = "urn:waddle:extension:1:stargate-quotes";
+pub(crate) const COMMAND_RESULT_ID: &str = "stargate-quote-posted";
+pub(crate) const COMMAND_RESULT_TEXT: &str = "Stargate quote posted to channel.";

--- a/server/extensions/stargate-quotes/src/constants.rs
+++ b/server/extensions/stargate-quotes/src/constants.rs
@@ -1,7 +1,7 @@
 pub(crate) const PLUGIN_ID: &str = "stargate-quotes";
 pub(crate) const PLUGIN_NAME: &str = "Stargate Quotes";
 pub(crate) const PLUGIN_NS: &str = "urn:waddle:stargate-quotes:1";
-pub(crate) const VERSION: &str = "0.1.0";
+pub(crate) const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub(crate) const COMMAND_NAME: &str = "/stargate";
 pub(crate) const COMMAND_NODE: &str = "urn:waddle:extension:1:stargate-quotes";
 pub(crate) const COMMAND_RESULT_ID: &str = "stargate-quote-posted";

--- a/server/extensions/stargate-quotes/src/lib.rs
+++ b/server/extensions/stargate-quotes/src/lib.rs
@@ -1,0 +1,59 @@
+mod bindings {
+    wit_bindgen::generate!({
+        path: "../../wit",
+        world: "waddle-extension",
+        with: {
+            "wasi:logging/logging@0.1.0-draft": generate,
+            "wasi:clocks/monotonic-clock@0.2.0": generate,
+            "wasi:io/poll@0.2.0": generate,
+            "wasi:random/random@0.2.0": generate,
+        },
+    });
+}
+
+mod command;
+mod constants;
+mod manifest;
+mod quotes;
+mod ui;
+
+use bindings::exports;
+use bindings::waddle::extension::types;
+use command::handle_command;
+
+struct StargateQuotes;
+
+bindings::export!(StargateQuotes with_types_in bindings);
+
+impl exports::waddle::extension::lifecycle::Guest for StargateQuotes {
+    fn init(_config: String) -> Result<types::ExtensionManifest, String> {
+        quotes::quote_catalog().map_err(|error| error.message.value)?;
+        Ok(manifest::manifest())
+    }
+}
+
+impl exports::waddle::extension::framework::Guest for StargateQuotes {
+    fn handle_event(
+        event: types::ExtensionEvent,
+    ) -> Result<types::ExtensionResponse, types::ExtensionError> {
+        let effects = match event {
+            types::ExtensionEvent::Command(command) => handle_command(command)?,
+            types::ExtensionEvent::MessageHook(_)
+            | types::ExtensionEvent::Launch(_)
+            | types::ExtensionEvent::ProviderWebhook(_) => vec![],
+        };
+        Ok(types::ExtensionResponse { effects })
+    }
+}
+
+#[cfg(test)]
+pub(crate) use command::{handle_command_with_rng, take_sent_room_messages};
+#[cfg(test)]
+pub(crate) use constants::{COMMAND_NAME, COMMAND_NODE, COMMAND_RESULT_TEXT, PLUGIN_NS};
+#[cfg(test)]
+pub(crate) use manifest::manifest;
+#[cfg(test)]
+pub(crate) use quotes::{parse_quotes_json, quote_body, quote_catalog, select_quote_with_rng};
+
+#[cfg(test)]
+mod tests;

--- a/server/extensions/stargate-quotes/src/manifest.rs
+++ b/server/extensions/stargate-quotes/src/manifest.rs
@@ -1,0 +1,38 @@
+use crate::bindings::waddle::extension::types;
+use crate::constants::{COMMAND_NAME, COMMAND_NODE, PLUGIN_NAME, VERSION};
+use crate::ui::{display, plugin_id};
+
+pub(crate) fn manifest() -> types::ExtensionManifest {
+    types::ExtensionManifest {
+        id: plugin_id(),
+        name: display(PLUGIN_NAME),
+        version: types::PluginVersion {
+            value: VERSION.to_string(),
+        },
+        payloads: vec![],
+        capabilities: vec![
+            types::ExtensionCapability::Commands,
+            types::ExtensionCapability::HostMessageSend,
+            types::ExtensionCapability::MessageEnrich,
+        ],
+        commands: vec![types::CommandDescriptor {
+            node: types::CommandNode {
+                value: COMMAND_NODE.to_string(),
+            },
+            name: display(COMMAND_NAME),
+            scope: types::CommandScope::Channel,
+            composer_prefix: Some("stargate".to_string()),
+            inline_field: None,
+        }],
+        routes: vec![],
+        pubsub_nodes: vec![],
+        profile: Some(types::ExtensionProfile {
+            display_name: display(PLUGIN_NAME),
+            description: Some(display("Random Stargate quotes")),
+            accent: Some("blue".to_string()),
+            avatar: None,
+            bot_hat_label: Some(display("Bot")),
+        }),
+        artifact: None,
+    }
+}

--- a/server/extensions/stargate-quotes/src/quotes.json
+++ b/server/extensions/stargate-quotes/src/quotes.json
@@ -1,0 +1,380 @@
+[
+  {
+    "id": "sg1-serpents-lair-oneill-001",
+    "series": "Stargate SG-1",
+    "episode": "The Serpent's Lair",
+    "role": "Col. O'Neill",
+    "text": "Nothing comes to mind, let's do it.",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_SG-1"
+  },
+  {
+    "id": "sg1-serpents-lair-tealc-001",
+    "series": "Stargate SG-1",
+    "episode": "The Serpent's Lair",
+    "role": "Teal'c",
+    "text": "Not to my knowledge.",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_SG-1"
+  },
+  {
+    "id": "sg1-redemption-oneill-001",
+    "series": "Stargate SG-1",
+    "episode": "Redemption",
+    "role": "Col. O'Neill",
+    "text": "Over my rotting corpse, Sir.",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_SG-1"
+  },
+  {
+    "id": "sg1-redemption-oneill-002",
+    "series": "Stargate SG-1",
+    "episode": "Redemption",
+    "role": "Col. O'Neill",
+    "text": "I'm sorry, did I say that out loud?",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_SG-1"
+  },
+  {
+    "id": "sg1-flesh-and-blood-carter-001",
+    "series": "Stargate SG-1",
+    "episode": "Flesh and Blood",
+    "role": "Lt. Colonel Carter",
+    "text": "Oh, boy.",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_SG-1"
+  },
+  {
+    "id": "atlantis-doppelganger-sheppard-001",
+    "series": "Stargate Atlantis",
+    "episode": "Doppelganger",
+    "role": "Sheppard",
+    "text": "Did I have a goatee?",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_Atlantis"
+  },
+  {
+    "id": "atlantis-doppelganger-sheppard-002",
+    "series": "Stargate Atlantis",
+    "episode": "Doppelganger",
+    "role": "Sheppard",
+    "text": "I hate clowns.",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_Atlantis"
+  },
+  {
+    "id": "atlantis-doppelganger-rodney-001",
+    "series": "Stargate Atlantis",
+    "episode": "Doppelganger",
+    "role": "Rodney",
+    "text": "Then I was eaten by a whale.",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_Atlantis"
+  },
+  {
+    "id": "atlantis-mckay-001",
+    "series": "Stargate Atlantis",
+    "episode": "The Siege",
+    "role": "Dr. Rodney McKay",
+    "text": "Who told you that?",
+    "source_name": "MovieMistakes",
+    "source_url": "https://www.moviemistakes.com/tv4411/quotes"
+  },
+  {
+    "id": "atlantis-mckay-002",
+    "series": "Stargate Atlantis",
+    "episode": "The Hive",
+    "role": "Dr. Rodney McKay",
+    "text": "So... just to confirm, we're all still... definitely not dead.",
+    "source_name": "MovieMistakes",
+    "source_url": "https://www.moviemistakes.com/tv4411/quotes"
+  },
+  {
+    "id": "atlantis-beckett-001",
+    "series": "Stargate Atlantis",
+    "episode": "The Siege",
+    "role": "Carson Beckett",
+    "text": "We're in another galaxy. How much more out can you get?",
+    "source_name": "MovieMistakes",
+    "source_url": "https://www.moviemistakes.com/tv4411/quotes"
+  },
+  {
+    "id": "universe-life-eli-001",
+    "series": "Stargate Universe",
+    "episode": "Life",
+    "role": "Eli",
+    "text": "All I've got is \"You are here.\"",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+  },
+  {
+    "id": "universe-justice-rush-001",
+    "series": "Stargate Universe",
+    "episode": "Justice",
+    "role": "Rush",
+    "text": "We'll never be done.",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+  },
+  {
+    "id": "universe-blockade-rush-001",
+    "series": "Stargate Universe",
+    "episode": "Blockade",
+    "role": "Rush",
+    "text": "Then we have a very big problem.",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+  },
+  {
+    "id": "universe-blockade-eli-001",
+    "series": "Stargate Universe",
+    "episode": "Blockade",
+    "role": "Eli",
+    "text": "No. No,no. We're totally screwed.",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+  },
+  {
+    "id": "universe-blockade-eli-002",
+    "series": "Stargate Universe",
+    "episode": "Blockade",
+    "role": "Eli",
+    "text": "Holy crap, we dialed Pittsburgh.",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+  },
+  {
+    "id": "universe-blockade-greer-001",
+    "series": "Stargate Universe",
+    "episode": "Blockade",
+    "role": "Greer",
+    "text": "Have you ever been to Pittsburgh?",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+  },
+  {
+    "id": "universe-blockade-rush-002",
+    "series": "Stargate Universe",
+    "episode": "Blockade",
+    "role": "Rush",
+    "text": "Oh, bloody hell! We're all doomed!",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+  },
+  {
+    "id": "sg1-children-of-the-gods-oneill-001",
+    "series": "Stargate SG-1",
+    "episode": "Children of the Gods",
+    "role": "Col. O'Neill",
+    "text": "Well, they could be blowing their noses right now.",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_SG-1"
+  },
+  {
+    "id": "sg1-serpents-lair-oneill-002",
+    "series": "Stargate SG-1",
+    "episode": "The Serpent's Lair",
+    "role": "Col. O'Neill",
+    "text": "Well, that's a bad plan.",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_SG-1"
+  },
+  {
+    "id": "sg1-thors-chariot-tealc-001",
+    "series": "Stargate SG-1",
+    "episode": "Thor's Chariot",
+    "role": "Teal'c",
+    "text": "Things will not calm down, Daniel Jackson. They will, in fact, calm up.",
+    "source_name": "Planet Claire Quotes",
+    "source_url": "https://planetclaire.tv/quotes/stargate-sg1/tealc/season-two-tealc/"
+  },
+  {
+    "id": "sg1-message-in-a-bottle-tealc-001",
+    "series": "Stargate SG-1",
+    "episode": "Message in a Bottle",
+    "role": "Teal'c",
+    "text": "Undomesticated equines could not remove me.",
+    "source_name": "Planet Claire Quotes",
+    "source_url": "https://planetclaire.tv/quotes/stargate-sg1/season-two-tealc/"
+  },
+  {
+    "id": "sg1-small-victories-oneill-001",
+    "series": "Stargate SG-1",
+    "episode": "Small Victories",
+    "role": "Col. O'Neill",
+    "text": "Again. This should not get old, General.",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_SG-1"
+  },
+  {
+    "id": "sg1-enemies-oneill-001",
+    "series": "Stargate SG-1",
+    "episode": "Enemies",
+    "role": "Col. O'Neill",
+    "text": "Shoot first, send flowers later. It works.",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_SG-1"
+  },
+  {
+    "id": "sg1-fallen-oneill-001",
+    "series": "Stargate SG-1",
+    "episode": "Fallen",
+    "role": "Col. O'Neill",
+    "text": "No, but he plays one on TV.",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_SG-1"
+  },
+  {
+    "id": "sg1-camelot-jackson-001",
+    "series": "Stargate SG-1",
+    "episode": "Camelot",
+    "role": "Dr. Jackson",
+    "text": "Boy, my timing's off today...",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_SG-1"
+  },
+  {
+    "id": "atlantis-doppelganger-sheppard-003",
+    "series": "Stargate Atlantis",
+    "episode": "Doppelganger",
+    "role": "Sheppard",
+    "text": "You know? This really isn't as strange as you made me believe.",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_Atlantis"
+  },
+  {
+    "id": "atlantis-this-mortal-coil-sheppard-001",
+    "series": "Stargate Atlantis",
+    "episode": "This Mortal Coil",
+    "role": "Sheppard",
+    "text": "Never underestimate the size of that man's ego.",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_Atlantis"
+  },
+  {
+    "id": "atlantis-this-mortal-coil-ronon-001",
+    "series": "Stargate Atlantis",
+    "episode": "This Mortal Coil",
+    "role": "Ronon",
+    "text": "A lot stronger than a shark.",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_Atlantis"
+  },
+  {
+    "id": "atlantis-harmony-sheppard-001",
+    "series": "Stargate Atlantis",
+    "episode": "Harmony",
+    "role": "Sheppard",
+    "text": "More searching, less complaining.",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_Atlantis"
+  },
+  {
+    "id": "atlantis-harmony-sheppard-002",
+    "series": "Stargate Atlantis",
+    "episode": "Harmony",
+    "role": "Sheppard",
+    "text": "Real good.",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_Atlantis"
+  },
+  {
+    "id": "atlantis-outcast-ronon-001",
+    "series": "Stargate Atlantis",
+    "episode": "Outcast",
+    "role": "Ronon",
+    "text": "Your planet's weird.",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_Atlantis"
+  },
+  {
+    "id": "atlantis-the-hive-mckay-001",
+    "series": "Stargate Atlantis",
+    "episode": "The Hive",
+    "role": "Dr. McKay",
+    "text": "Lock and load!",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_Atlantis"
+  },
+  {
+    "id": "atlantis-tracker-mckay-001",
+    "series": "Stargate Atlantis",
+    "episode": "Tracker",
+    "role": "McKay",
+    "text": "That is clearly a moustache!",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_Atlantis"
+  },
+  {
+    "id": "universe-air-eli-001",
+    "series": "Stargate Universe",
+    "episode": "Air, Part 1",
+    "role": "Eli Wallace",
+    "text": "It can't be worse than here, can it?",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+  },
+  {
+    "id": "universe-air-rush-001",
+    "series": "Stargate Universe",
+    "episode": "Air, Part 1",
+    "role": "Nicholas Rush",
+    "text": "Several billion light years from home.",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+  },
+  {
+    "id": "universe-air-rush-002",
+    "series": "Stargate Universe",
+    "episode": "Air, Part 1",
+    "role": "Nicholas Rush",
+    "text": "We have a way out.",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+  },
+  {
+    "id": "universe-pathogen-greer-001",
+    "series": "Stargate Universe",
+    "episode": "Pathogen",
+    "role": "Greer",
+    "text": "You were saying?",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+  },
+  {
+    "id": "universe-pathogen-eli-001",
+    "series": "Stargate Universe",
+    "episode": "Pathogen",
+    "role": "Eli Wallace",
+    "text": "The other side of the universe, Mom.",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+  },
+  {
+    "id": "universe-the-greater-good-greer-001",
+    "series": "Stargate Universe",
+    "episode": "The Greater Good",
+    "role": "Greer",
+    "text": "And got its ass kicked.",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+  },
+  {
+    "id": "universe-the-greater-good-rush-001",
+    "series": "Stargate Universe",
+    "episode": "The Greater Good",
+    "role": "Rush",
+    "text": "A message, perhaps, or a sign of intelligence from the beginning of time.",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+  },
+  {
+    "id": "universe-malice-eli-001",
+    "series": "Stargate Universe",
+    "episode": "Malice",
+    "role": "Eli",
+    "text": "Were you expecting \"Stairway to Heaven?\"",
+    "source_name": "Wikiquote",
+    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+  }
+]

--- a/server/extensions/stargate-quotes/src/quotes.json
+++ b/server/extensions/stargate-quotes/src/quotes.json
@@ -1,380 +1,212 @@
 [
   {
-    "id": "sg1-serpents-lair-oneill-001",
-    "series": "Stargate SG-1",
-    "episode": "The Serpent's Lair",
     "role": "Col. O'Neill",
-    "text": "Nothing comes to mind, let's do it.",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_SG-1"
+    "quote": "Nothing comes to mind, let's do it.",
+    "series": "Stargate SG-1"
   },
   {
-    "id": "sg1-serpents-lair-tealc-001",
-    "series": "Stargate SG-1",
-    "episode": "The Serpent's Lair",
     "role": "Teal'c",
-    "text": "Not to my knowledge.",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_SG-1"
+    "quote": "Not to my knowledge.",
+    "series": "Stargate SG-1"
   },
   {
-    "id": "sg1-redemption-oneill-001",
-    "series": "Stargate SG-1",
-    "episode": "Redemption",
     "role": "Col. O'Neill",
-    "text": "Over my rotting corpse, Sir.",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_SG-1"
+    "quote": "Over my rotting corpse, Sir.",
+    "series": "Stargate SG-1"
   },
   {
-    "id": "sg1-redemption-oneill-002",
-    "series": "Stargate SG-1",
-    "episode": "Redemption",
     "role": "Col. O'Neill",
-    "text": "I'm sorry, did I say that out loud?",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_SG-1"
+    "quote": "I'm sorry, did I say that out loud?",
+    "series": "Stargate SG-1"
   },
   {
-    "id": "sg1-flesh-and-blood-carter-001",
-    "series": "Stargate SG-1",
-    "episode": "Flesh and Blood",
     "role": "Lt. Colonel Carter",
-    "text": "Oh, boy.",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_SG-1"
+    "quote": "Oh, boy.",
+    "series": "Stargate SG-1"
   },
   {
-    "id": "atlantis-doppelganger-sheppard-001",
-    "series": "Stargate Atlantis",
-    "episode": "Doppelganger",
     "role": "Sheppard",
-    "text": "Did I have a goatee?",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_Atlantis"
+    "quote": "Did I have a goatee?",
+    "series": "Stargate Atlantis"
   },
   {
-    "id": "atlantis-doppelganger-sheppard-002",
-    "series": "Stargate Atlantis",
-    "episode": "Doppelganger",
     "role": "Sheppard",
-    "text": "I hate clowns.",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_Atlantis"
+    "quote": "I hate clowns.",
+    "series": "Stargate Atlantis"
   },
   {
-    "id": "atlantis-doppelganger-rodney-001",
-    "series": "Stargate Atlantis",
-    "episode": "Doppelganger",
     "role": "Rodney",
-    "text": "Then I was eaten by a whale.",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_Atlantis"
+    "quote": "Then I was eaten by a whale.",
+    "series": "Stargate Atlantis"
   },
   {
-    "id": "atlantis-mckay-001",
-    "series": "Stargate Atlantis",
-    "episode": "The Siege",
     "role": "Dr. Rodney McKay",
-    "text": "Who told you that?",
-    "source_name": "MovieMistakes",
-    "source_url": "https://www.moviemistakes.com/tv4411/quotes"
+    "quote": "Who told you that?",
+    "series": "Stargate Atlantis"
   },
   {
-    "id": "atlantis-mckay-002",
-    "series": "Stargate Atlantis",
-    "episode": "The Hive",
     "role": "Dr. Rodney McKay",
-    "text": "So... just to confirm, we're all still... definitely not dead.",
-    "source_name": "MovieMistakes",
-    "source_url": "https://www.moviemistakes.com/tv4411/quotes"
+    "quote": "So... just to confirm, we're all still... definitely not dead.",
+    "series": "Stargate Atlantis"
   },
   {
-    "id": "atlantis-beckett-001",
-    "series": "Stargate Atlantis",
-    "episode": "The Siege",
     "role": "Carson Beckett",
-    "text": "We're in another galaxy. How much more out can you get?",
-    "source_name": "MovieMistakes",
-    "source_url": "https://www.moviemistakes.com/tv4411/quotes"
+    "quote": "We're in another galaxy. How much more out can you get?",
+    "series": "Stargate Atlantis"
   },
   {
-    "id": "universe-life-eli-001",
-    "series": "Stargate Universe",
-    "episode": "Life",
     "role": "Eli",
-    "text": "All I've got is \"You are here.\"",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+    "quote": "All I've got is \"You are here.\"",
+    "series": "Stargate Universe"
   },
   {
-    "id": "universe-justice-rush-001",
-    "series": "Stargate Universe",
-    "episode": "Justice",
     "role": "Rush",
-    "text": "We'll never be done.",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+    "quote": "We'll never be done.",
+    "series": "Stargate Universe"
   },
   {
-    "id": "universe-blockade-rush-001",
-    "series": "Stargate Universe",
-    "episode": "Blockade",
     "role": "Rush",
-    "text": "Then we have a very big problem.",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+    "quote": "Then we have a very big problem.",
+    "series": "Stargate Universe"
   },
   {
-    "id": "universe-blockade-eli-001",
-    "series": "Stargate Universe",
-    "episode": "Blockade",
     "role": "Eli",
-    "text": "No. No,no. We're totally screwed.",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+    "quote": "No. No,no. We're totally screwed.",
+    "series": "Stargate Universe"
   },
   {
-    "id": "universe-blockade-eli-002",
-    "series": "Stargate Universe",
-    "episode": "Blockade",
     "role": "Eli",
-    "text": "Holy crap, we dialed Pittsburgh.",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+    "quote": "Holy crap, we dialed Pittsburgh.",
+    "series": "Stargate Universe"
   },
   {
-    "id": "universe-blockade-greer-001",
-    "series": "Stargate Universe",
-    "episode": "Blockade",
     "role": "Greer",
-    "text": "Have you ever been to Pittsburgh?",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+    "quote": "Have you ever been to Pittsburgh?",
+    "series": "Stargate Universe"
   },
   {
-    "id": "universe-blockade-rush-002",
-    "series": "Stargate Universe",
-    "episode": "Blockade",
     "role": "Rush",
-    "text": "Oh, bloody hell! We're all doomed!",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+    "quote": "Oh, bloody hell! We're all doomed!",
+    "series": "Stargate Universe"
   },
   {
-    "id": "sg1-children-of-the-gods-oneill-001",
-    "series": "Stargate SG-1",
-    "episode": "Children of the Gods",
     "role": "Col. O'Neill",
-    "text": "Well, they could be blowing their noses right now.",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_SG-1"
+    "quote": "Well, they could be blowing their noses right now.",
+    "series": "Stargate SG-1"
   },
   {
-    "id": "sg1-serpents-lair-oneill-002",
-    "series": "Stargate SG-1",
-    "episode": "The Serpent's Lair",
     "role": "Col. O'Neill",
-    "text": "Well, that's a bad plan.",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_SG-1"
+    "quote": "Well, that's a bad plan.",
+    "series": "Stargate SG-1"
   },
   {
-    "id": "sg1-thors-chariot-tealc-001",
-    "series": "Stargate SG-1",
-    "episode": "Thor's Chariot",
     "role": "Teal'c",
-    "text": "Things will not calm down, Daniel Jackson. They will, in fact, calm up.",
-    "source_name": "Planet Claire Quotes",
-    "source_url": "https://planetclaire.tv/quotes/stargate-sg1/tealc/season-two-tealc/"
+    "quote": "Things will not calm down, Daniel Jackson. They will, in fact, calm up.",
+    "series": "Stargate SG-1"
   },
   {
-    "id": "sg1-message-in-a-bottle-tealc-001",
-    "series": "Stargate SG-1",
-    "episode": "Message in a Bottle",
     "role": "Teal'c",
-    "text": "Undomesticated equines could not remove me.",
-    "source_name": "Planet Claire Quotes",
-    "source_url": "https://planetclaire.tv/quotes/stargate-sg1/season-two-tealc/"
+    "quote": "Undomesticated equines could not remove me.",
+    "series": "Stargate SG-1"
   },
   {
-    "id": "sg1-small-victories-oneill-001",
-    "series": "Stargate SG-1",
-    "episode": "Small Victories",
     "role": "Col. O'Neill",
-    "text": "Again. This should not get old, General.",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_SG-1"
+    "quote": "Again. This should not get old, General.",
+    "series": "Stargate SG-1"
   },
   {
-    "id": "sg1-enemies-oneill-001",
-    "series": "Stargate SG-1",
-    "episode": "Enemies",
     "role": "Col. O'Neill",
-    "text": "Shoot first, send flowers later. It works.",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_SG-1"
+    "quote": "Shoot first, send flowers later. It works.",
+    "series": "Stargate SG-1"
   },
   {
-    "id": "sg1-fallen-oneill-001",
-    "series": "Stargate SG-1",
-    "episode": "Fallen",
     "role": "Col. O'Neill",
-    "text": "No, but he plays one on TV.",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_SG-1"
+    "quote": "No, but he plays one on TV.",
+    "series": "Stargate SG-1"
   },
   {
-    "id": "sg1-camelot-jackson-001",
-    "series": "Stargate SG-1",
-    "episode": "Camelot",
     "role": "Dr. Jackson",
-    "text": "Boy, my timing's off today...",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_SG-1"
+    "quote": "Boy, my timing's off today...",
+    "series": "Stargate SG-1"
   },
   {
-    "id": "atlantis-doppelganger-sheppard-003",
-    "series": "Stargate Atlantis",
-    "episode": "Doppelganger",
     "role": "Sheppard",
-    "text": "You know? This really isn't as strange as you made me believe.",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_Atlantis"
+    "quote": "You know? This really isn't as strange as you made me believe.",
+    "series": "Stargate Atlantis"
   },
   {
-    "id": "atlantis-this-mortal-coil-sheppard-001",
-    "series": "Stargate Atlantis",
-    "episode": "This Mortal Coil",
     "role": "Sheppard",
-    "text": "Never underestimate the size of that man's ego.",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_Atlantis"
+    "quote": "Never underestimate the size of that man's ego.",
+    "series": "Stargate Atlantis"
   },
   {
-    "id": "atlantis-this-mortal-coil-ronon-001",
-    "series": "Stargate Atlantis",
-    "episode": "This Mortal Coil",
     "role": "Ronon",
-    "text": "A lot stronger than a shark.",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_Atlantis"
+    "quote": "A lot stronger than a shark.",
+    "series": "Stargate Atlantis"
   },
   {
-    "id": "atlantis-harmony-sheppard-001",
-    "series": "Stargate Atlantis",
-    "episode": "Harmony",
     "role": "Sheppard",
-    "text": "More searching, less complaining.",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_Atlantis"
+    "quote": "More searching, less complaining.",
+    "series": "Stargate Atlantis"
   },
   {
-    "id": "atlantis-harmony-sheppard-002",
-    "series": "Stargate Atlantis",
-    "episode": "Harmony",
     "role": "Sheppard",
-    "text": "Real good.",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_Atlantis"
+    "quote": "Real good.",
+    "series": "Stargate Atlantis"
   },
   {
-    "id": "atlantis-outcast-ronon-001",
-    "series": "Stargate Atlantis",
-    "episode": "Outcast",
     "role": "Ronon",
-    "text": "Your planet's weird.",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_Atlantis"
+    "quote": "Your planet's weird.",
+    "series": "Stargate Atlantis"
   },
   {
-    "id": "atlantis-the-hive-mckay-001",
-    "series": "Stargate Atlantis",
-    "episode": "The Hive",
     "role": "Dr. McKay",
-    "text": "Lock and load!",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_Atlantis"
+    "quote": "Lock and load!",
+    "series": "Stargate Atlantis"
   },
   {
-    "id": "atlantis-tracker-mckay-001",
-    "series": "Stargate Atlantis",
-    "episode": "Tracker",
     "role": "McKay",
-    "text": "That is clearly a moustache!",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_Atlantis"
+    "quote": "That is clearly a moustache!",
+    "series": "Stargate Atlantis"
   },
   {
-    "id": "universe-air-eli-001",
-    "series": "Stargate Universe",
-    "episode": "Air, Part 1",
     "role": "Eli Wallace",
-    "text": "It can't be worse than here, can it?",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+    "quote": "It can't be worse than here, can it?",
+    "series": "Stargate Universe"
   },
   {
-    "id": "universe-air-rush-001",
-    "series": "Stargate Universe",
-    "episode": "Air, Part 1",
     "role": "Nicholas Rush",
-    "text": "Several billion light years from home.",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+    "quote": "Several billion light years from home.",
+    "series": "Stargate Universe"
   },
   {
-    "id": "universe-air-rush-002",
-    "series": "Stargate Universe",
-    "episode": "Air, Part 1",
     "role": "Nicholas Rush",
-    "text": "We have a way out.",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+    "quote": "We have a way out.",
+    "series": "Stargate Universe"
   },
   {
-    "id": "universe-pathogen-greer-001",
-    "series": "Stargate Universe",
-    "episode": "Pathogen",
     "role": "Greer",
-    "text": "You were saying?",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+    "quote": "You were saying?",
+    "series": "Stargate Universe"
   },
   {
-    "id": "universe-pathogen-eli-001",
-    "series": "Stargate Universe",
-    "episode": "Pathogen",
     "role": "Eli Wallace",
-    "text": "The other side of the universe, Mom.",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+    "quote": "The other side of the universe, Mom.",
+    "series": "Stargate Universe"
   },
   {
-    "id": "universe-the-greater-good-greer-001",
-    "series": "Stargate Universe",
-    "episode": "The Greater Good",
     "role": "Greer",
-    "text": "And got its ass kicked.",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+    "quote": "And got its ass kicked.",
+    "series": "Stargate Universe"
   },
   {
-    "id": "universe-the-greater-good-rush-001",
-    "series": "Stargate Universe",
-    "episode": "The Greater Good",
     "role": "Rush",
-    "text": "A message, perhaps, or a sign of intelligence from the beginning of time.",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+    "quote": "A message, perhaps, or a sign of intelligence from the beginning of time.",
+    "series": "Stargate Universe"
   },
   {
-    "id": "universe-malice-eli-001",
-    "series": "Stargate Universe",
-    "episode": "Malice",
     "role": "Eli",
-    "text": "Were you expecting \"Stairway to Heaven?\"",
-    "source_name": "Wikiquote",
-    "source_url": "https://en.wikiquote.org/wiki/Stargate_Universe"
+    "quote": "Were you expecting \"Stairway to Heaven?\"",
+    "series": "Stargate Universe"
   }
 ]

--- a/server/extensions/stargate-quotes/src/quotes.rs
+++ b/server/extensions/stargate-quotes/src/quotes.rs
@@ -7,13 +7,9 @@ const QUOTES_JSON: &str = include_str!("quotes.json");
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub(crate) struct Quote {
-    pub(crate) id: String,
     pub(crate) series: String,
-    pub(crate) episode: String,
     pub(crate) role: String,
-    pub(crate) text: String,
-    pub(crate) source_name: String,
-    pub(crate) source_url: String,
+    pub(crate) quote: String,
 }
 
 pub(crate) fn quote_catalog() -> Result<Vec<Quote>, types::ExtensionError> {
@@ -50,7 +46,7 @@ pub(crate) fn select_quote_with_rng(
 }
 
 pub(crate) fn quote_body(quote: &Quote) -> String {
-    format!("{}\n\n{}, {}", quote.text, quote.role, quote.series)
+    format!("{}\n\n{}, {}", quote.quote, quote.role, quote.series)
 }
 
 fn extension_error(code: types::ExtensionErrorCode, message: &str) -> types::ExtensionError {

--- a/server/extensions/stargate-quotes/src/quotes.rs
+++ b/server/extensions/stargate-quotes/src/quotes.rs
@@ -1,0 +1,61 @@
+use serde::Deserialize;
+
+use crate::bindings::waddle::extension::types;
+use crate::ui::display;
+
+const QUOTES_JSON: &str = include_str!("quotes.json");
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub(crate) struct Quote {
+    pub(crate) id: String,
+    pub(crate) series: String,
+    pub(crate) episode: String,
+    pub(crate) role: String,
+    pub(crate) text: String,
+    pub(crate) source_name: String,
+    pub(crate) source_url: String,
+}
+
+pub(crate) fn quote_catalog() -> Result<Vec<Quote>, types::ExtensionError> {
+    parse_quotes_json(QUOTES_JSON).map_err(|error| {
+        extension_error(
+            types::ExtensionErrorCode::TemporaryFailure,
+            &format!("stargate quote catalog is invalid: {error}"),
+        )
+    })
+}
+
+pub(crate) fn parse_quotes_json(input: &str) -> Result<Vec<Quote>, serde_json::Error> {
+    serde_json::from_str(input)
+}
+
+pub(crate) fn select_quote_with_rng(
+    quotes: &[Quote],
+    mut next_u64: impl FnMut() -> u64,
+) -> Result<&Quote, types::ExtensionError> {
+    if quotes.is_empty() {
+        return Err(extension_error(
+            types::ExtensionErrorCode::TemporaryFailure,
+            "stargate quote catalog is empty",
+        ));
+    }
+    let len = quotes.len() as u64;
+    let threshold = len.wrapping_neg() % len;
+    loop {
+        let candidate = next_u64();
+        if candidate >= threshold {
+            return Ok(&quotes[(candidate % len) as usize]);
+        }
+    }
+}
+
+pub(crate) fn quote_body(quote: &Quote) -> String {
+    format!("{}\n\n{}, {}", quote.text, quote.role, quote.series)
+}
+
+fn extension_error(code: types::ExtensionErrorCode, message: &str) -> types::ExtensionError {
+    types::ExtensionError {
+        code,
+        message: display(message),
+    }
+}

--- a/server/extensions/stargate-quotes/src/tests.rs
+++ b/server/extensions/stargate-quotes/src/tests.rs
@@ -1,0 +1,152 @@
+use super::{
+    handle_command_with_rng, manifest, parse_quotes_json, quote_body, quote_catalog,
+    select_quote_with_rng, take_sent_room_messages, types, COMMAND_NAME, COMMAND_NODE,
+    COMMAND_RESULT_TEXT, PLUGIN_NS,
+};
+
+#[test]
+fn manifest_registers_channel_stargate_command() {
+    let manifest = manifest();
+
+    assert_eq!(manifest.id.value, "stargate-quotes");
+    assert_eq!(manifest.commands.len(), 1);
+    assert_eq!(manifest.commands[0].node.value, COMMAND_NODE);
+    assert_eq!(manifest.commands[0].name.value, COMMAND_NAME);
+    assert_eq!(
+        manifest.commands[0].composer_prefix.as_deref(),
+        Some("stargate")
+    );
+    assert!(matches!(
+        manifest.commands[0].scope,
+        types::CommandScope::Channel
+    ));
+    assert_eq!(
+        manifest.capabilities,
+        vec![
+            types::ExtensionCapability::Commands,
+            types::ExtensionCapability::HostMessageSend,
+            types::ExtensionCapability::MessageEnrich,
+        ]
+    );
+}
+
+#[test]
+fn quote_catalog_is_typed_and_covers_all_series() {
+    let quotes = quote_catalog().expect("quote catalog parses");
+
+    assert!(quotes.iter().any(|quote| quote.series == "Stargate SG-1"));
+    assert!(quotes
+        .iter()
+        .any(|quote| quote.series == "Stargate Atlantis"));
+    assert!(quotes
+        .iter()
+        .any(|quote| quote.series == "Stargate Universe"));
+    assert!(quotes.len() >= 36);
+    assert!(quotes.iter().all(|quote| {
+        !quote.id.is_empty()
+            && !quote.episode.is_empty()
+            && !quote.role.is_empty()
+            && !quote.text.is_empty()
+            && !quote.source_name.is_empty()
+            && quote.source_url.starts_with("https://")
+    }));
+}
+
+#[test]
+fn quote_catalog_rejects_invalid_json() {
+    assert!(parse_quotes_json(r#"{"not":"a list"}"#).is_err());
+}
+
+#[test]
+fn quote_body_renders_without_source_metadata() {
+    let quotes = quote_catalog().expect("quote catalog parses");
+    let body = quote_body(&quotes[0]);
+
+    assert_eq!(
+        body,
+        format!(
+            "{}\n\n{}, {}",
+            quotes[0].text, quotes[0].role, quotes[0].series
+        )
+    );
+    assert!(!body.starts_with('"'));
+    assert!(!body.contains("\n\n- "));
+    assert!(!body.contains(quotes[0].source_name.as_str()));
+    assert!(!body.contains(quotes[0].source_url.as_str()));
+}
+
+#[test]
+fn random_selection_rejects_low_values_that_would_bias_modulo() {
+    let quotes = quote_catalog().expect("quote catalog parses");
+    let mut values = [0, quotes.len() as u64].into_iter();
+    let quote = select_quote_with_rng(&quotes, || values.next().expect("next random value"))
+        .expect("quote selected");
+
+    assert_eq!(quote, &quotes[0]);
+}
+
+#[test]
+fn room_command_posts_plain_quote_and_returns_completion() {
+    let _ = take_sent_room_messages();
+    let command = command_invocation(Some("sgc@muc.example.com"));
+    let quotes = quote_catalog().expect("quote catalog parses");
+    let expected = select_quote_with_rng(&quotes, || 42).expect("expected quote");
+
+    let effects = handle_command_with_rng(command, || 42).expect("command succeeds");
+
+    assert_eq!(effects.len(), 1);
+    let types::ExtensionEffect::EnrichMessage(envelope) = &effects[0] else {
+        panic!("expected command completion enrichment");
+    };
+    assert_eq!(envelope.enrichments[0].payload_namespace.value, PLUGIN_NS);
+    let types::UiBlock::Text(text) = &envelope.enrichments[0].ui[0].blocks[0] else {
+        panic!("expected text block");
+    };
+    assert_eq!(text.text.value, COMMAND_RESULT_TEXT);
+
+    let sent = take_sent_room_messages();
+    assert_eq!(sent.len(), 1);
+    assert_eq!(sent[0].body.value, quote_body(expected));
+    assert!(sent[0].extensions.is_none());
+    assert!(matches!(
+        &sent[0].target,
+        types::MessageTarget::Muc(room) if room.value == "sgc@muc.example.com"
+    ));
+}
+
+#[test]
+fn command_without_room_warns_and_sends_nothing() {
+    let _ = take_sent_room_messages();
+    let effects = handle_command_with_rng(command_invocation(None), || 42).expect("command runs");
+
+    assert_eq!(effects.len(), 1);
+    let types::ExtensionEffect::HostWarning(message) = &effects[0] else {
+        panic!("expected warning");
+    };
+    assert_eq!(
+        message.value,
+        "Stargate quotes require an active channel.".to_string()
+    );
+    assert!(take_sent_room_messages().is_empty());
+}
+
+fn command_invocation(room: Option<&str>) -> types::CommandInvocation {
+    types::CommandInvocation {
+        waddle_id: types::WaddleId {
+            value: "test-waddle".to_string(),
+        },
+        room: room.map(|value| types::RoomJid {
+            value: value.to_string(),
+        }),
+        requester: types::FullJid {
+            value: "sam@example.com/alpha".to_string(),
+        },
+        command_node: types::CommandNode {
+            value: COMMAND_NODE.to_string(),
+        },
+        session_id: None,
+        action: Some(types::CommandAction::Execute),
+        form: None,
+        fields: vec![],
+    }
+}

--- a/server/extensions/stargate-quotes/src/tests.rs
+++ b/server/extensions/stargate-quotes/src/tests.rs
@@ -3,6 +3,7 @@ use super::{
     select_quote_with_rng, take_sent_room_messages, types, COMMAND_NAME, COMMAND_NODE,
     COMMAND_RESULT_TEXT, PLUGIN_NS,
 };
+use serde_json::Value;
 
 #[test]
 fn manifest_registers_channel_stargate_command() {
@@ -42,14 +43,9 @@ fn quote_catalog_is_typed_and_covers_all_series() {
         .iter()
         .any(|quote| quote.series == "Stargate Universe"));
     assert!(quotes.len() >= 36);
-    assert!(quotes.iter().all(|quote| {
-        !quote.id.is_empty()
-            && !quote.episode.is_empty()
-            && !quote.role.is_empty()
-            && !quote.text.is_empty()
-            && !quote.source_name.is_empty()
-            && quote.source_url.starts_with("https://")
-    }));
+    assert!(quotes.iter().all(|quote| !quote.role.is_empty()
+        && !quote.quote.is_empty()
+        && !quote.series.is_empty()));
 }
 
 #[test]
@@ -58,7 +54,21 @@ fn quote_catalog_rejects_invalid_json() {
 }
 
 #[test]
-fn quote_body_renders_without_source_metadata() {
+fn quote_catalog_json_only_contains_rendered_fields() {
+    let values: Value = serde_json::from_str(include_str!("quotes.json")).expect("json parses");
+    let quotes = values.as_array().expect("quote catalog is a list");
+
+    assert!(quotes.iter().all(|quote| {
+        let fields = quote.as_object().expect("quote is object");
+        fields.len() == 3
+            && fields.contains_key("role")
+            && fields.contains_key("quote")
+            && fields.contains_key("series")
+    }));
+}
+
+#[test]
+fn quote_body_renders_plain_quote_with_role_and_series() {
     let quotes = quote_catalog().expect("quote catalog parses");
     let body = quote_body(&quotes[0]);
 
@@ -66,13 +76,11 @@ fn quote_body_renders_without_source_metadata() {
         body,
         format!(
             "{}\n\n{}, {}",
-            quotes[0].text, quotes[0].role, quotes[0].series
+            quotes[0].quote, quotes[0].role, quotes[0].series
         )
     );
     assert!(!body.starts_with('"'));
     assert!(!body.contains("\n\n- "));
-    assert!(!body.contains(quotes[0].source_name.as_str()));
-    assert!(!body.contains(quotes[0].source_url.as_str()));
 }
 
 #[test]

--- a/server/extensions/stargate-quotes/src/ui.rs
+++ b/server/extensions/stargate-quotes/src/ui.rs
@@ -1,0 +1,38 @@
+#[cfg(not(test))]
+use crate::bindings::waddle::extension::runtime;
+use crate::bindings::waddle::extension::types;
+use crate::constants::{PLUGIN_ID, PLUGIN_NS};
+
+pub(crate) fn plugin_id() -> types::PluginId {
+    types::PluginId {
+        value: PLUGIN_ID.to_string(),
+    }
+}
+
+pub(crate) fn payload_namespace() -> types::PayloadNamespace {
+    types::PayloadNamespace {
+        value: PLUGIN_NS.to_string(),
+    }
+}
+
+pub(crate) fn display(value: &str) -> types::DisplayText {
+    types::DisplayText {
+        value: value.to_string(),
+    }
+}
+
+pub(crate) fn timestamp() -> types::Timestamp {
+    types::Timestamp {
+        value: current_timestamp_value(),
+    }
+}
+
+#[cfg(not(test))]
+fn current_timestamp_value() -> String {
+    runtime::current_timestamp()
+}
+
+#[cfg(test)]
+fn current_timestamp_value() -> String {
+    "1970-01-01T00:00:00Z".to_string()
+}

--- a/server/wit/waddle-extension.wit
+++ b/server/wit/waddle-extension.wit
@@ -803,6 +803,7 @@ interface runtime {
 world waddle-extension {
     import wasi:logging/logging@0.1.0-draft;
     import wasi:clocks/monotonic-clock@0.2.0;
+    import wasi:random/random@0.2.0;
     import host-tools;
     import runtime;
 


### PR DESCRIPTION
## Summary
- Adds a new `stargate-quotes` WASM extension with a channel-scoped `/stargate` command.
- Embeds a typed JSON quote catalog with short Stargate SG-1, Atlantis, and Universe quotes.
- Keeps the catalog schema intentionally minimal: `role`, `quote`, and `series` only.
- Posts a simple plain room message only: quote text followed by `role, series`.
- Wires the extension into the WIT/runtime WASI random import, direct CUE build, Nix extension build check, release publish values, deployment config, and workflow artifact upload.
- Addresses PR review feedback by deriving the extension manifest version from Cargo package metadata.

## Plan
- [x] Review XEP-0050 command usage against local `xeps/` before changing command behavior.
- [x] Add the new WASM extension crate and tests.
- [x] Use WASI randomness for unbiased quote selection.
- [x] Keep user-facing output simple and source-free.
- [x] Reduce the persisted quote JSON to `role`, `quote`, and `series`.
- [x] Add build, deployment, and CI artifact wiring.
- [x] Address actionable PR review feedback.
- [x] Run local verification and monitor CI after push.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p stargate-quotes`
- `cargo test -p waddle-extensions`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy -p stargate-quotes --all-targets -- -D warnings`
- `cuenv sync ci --check -A`
- `git diff --check`
- `cuenv task buildExtensionModules --skip-dependencies`
- `cargo build --release --locked --target wasm32-wasip2 --target-dir target --manifest-path extensions/stargate-quotes/Cargo.toml`
- `cargo test --workspace --all-targets --all-features`

## Notes
- `cuenv task nixBuildExtensionModules --skip-dependencies` was attempted locally after wiring `stargate-quotes` into `flake.nix`, but this host is `aarch64-darwin` and the task targets `checks.x86_64-linux.waddle-server-extension-modules` without a local Linux builder. CI exercises that exact x86_64-linux Nix path.
- I did not add a 300+ item verbatim web-sourced quote corpus; that would be a bulk copyrighted dialogue dataset. The current implementation keeps a smaller curated catalog and the exact minimal schema requested.