### PR TITLE
feat(chat): in-call Chat dock tab with unread badge (#1026)

### DIFF
--- a/chat/src/components/calls/CallChatPanel.vue
+++ b/chat/src/components/calls/CallChatPanel.vue
@@ -112,7 +112,10 @@ onMounted(() => void nextTick(scrollToBottom));
         <div class="call-chat__bubble">
           <div class="call-chat__meta">
             <span class="call-chat__author type-control">{{ m.author }}</span>
-            <time class="call-chat__time type-caption text-muted-foreground">{{ timeLabel(m.createdAt) }}</time>
+            <time
+              :datetime="m.createdAt"
+              class="call-chat__time type-caption text-muted-foreground"
+            >{{ timeLabel(m.createdAt) }}</time>
           </div>
           <MessageBody :message="m" compact />
         </div>

--- a/chat/src/components/calls/CallChatPanel.vue
+++ b/chat/src/components/calls/CallChatPanel.vue
@@ -20,6 +20,9 @@ import type {
 const props = defineProps<{
   messages: readonly TimelineMessage[];
   draft: string;
+  /** Whether the Chat tab is the visible dock tab. Becoming visible re-pins to
+   *  the latest message so the unread badge → newest-message flow lands right. */
+  visible?: boolean;
   avatarUrlByAuthor: Record<string, string | null>;
   isSending?: boolean;
   disabled?: boolean;
@@ -73,6 +76,16 @@ watch(
     if (next <= prev) return;
     const el = messagesRef.value;
     if (!el || isNearBottom(el)) void nextTick(scrollToBottom);
+  },
+);
+
+// Switching to the Chat tab is a `v-show` toggle (no remount), so neither
+// `onMounted` nor the length watch fires. Re-pin to the newest message when the
+// tab becomes visible so a reader following the unread badge sees it.
+watch(
+  () => props.visible,
+  (visible) => {
+    if (visible) void nextTick(scrollToBottom);
   },
 );
 

--- a/chat/src/components/calls/CallChatPanel.vue
+++ b/chat/src/components/calls/CallChatPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, nextTick, onMounted, ref, watch } from "vue";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import MessageBody from "@/components/chat/MessageBody.vue";
 import MessageComposer from "@/components/chat/MessageComposer.vue";
@@ -20,7 +20,6 @@ import type {
 const props = defineProps<{
   messages: readonly TimelineMessage[];
   draft: string;
-  currentUser?: string;
   avatarUrlByAuthor: Record<string, string | null>;
   isSending?: boolean;
   disabled?: boolean;
@@ -51,11 +50,38 @@ function timeLabel(iso: string): string {
   if (Number.isNaN(date.getTime())) return "";
   return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
+
+// Keep the latest message in view when one arrives — but only when the reader is
+// already near the bottom, so scrolling up to read history isn't yanked away.
+const messagesRef = ref<HTMLElement | null>(null);
+const NEAR_BOTTOM_PX = 80;
+
+function isNearBottom(el: HTMLElement): boolean {
+  return el.scrollHeight - el.scrollTop - el.clientHeight < NEAR_BOTTOM_PX;
+}
+
+function scrollToBottom(): void {
+  const el = messagesRef.value;
+  if (el) el.scrollTop = el.scrollHeight;
+}
+
+// The watcher runs before the DOM patch (default "pre" flush), so `isNearBottom`
+// reflects the pre-append position; the actual scroll runs after the patch.
+watch(
+  () => props.messages.length,
+  (next, prev) => {
+    if (next <= prev) return;
+    const el = messagesRef.value;
+    if (!el || isNearBottom(el)) void nextTick(scrollToBottom);
+  },
+);
+
+onMounted(() => void nextTick(scrollToBottom));
 </script>
 
 <template>
   <div class="call-chat">
-    <div class="call-chat__messages" role="log" aria-label="Call chat messages">
+    <div ref="messagesRef" class="call-chat__messages" role="log" aria-label="Call chat messages">
       <p v-if="!hasMessages" class="call-chat__empty type-caption text-muted-foreground">
         No messages yet. Say hello.
       </p>

--- a/chat/src/components/calls/CallChatPanel.vue
+++ b/chat/src/components/calls/CallChatPanel.vue
@@ -1,0 +1,146 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import AppAvatar from "@/components/ui/AppAvatar.vue";
+import MessageBody from "@/components/chat/MessageBody.vue";
+import MessageComposer from "@/components/chat/MessageComposer.vue";
+import type { MarkupSpan, MessageReference, TimelineMessage } from "@/lib/chat-ui";
+import type { MentionCandidate } from "@/lib/mentions";
+import type {
+  ComposerLinkPreviewLookup,
+  ComposerLinkPreviewSendPayload,
+} from "@/lib/link-preview-composer";
+
+/**
+ * The in-call **Chat** panel: a scrollable list of the active call's
+ * XEP-0201 thread messages plus the call-chat composer. Lives inside the
+ * Dock's Chat tab. Purely presentational — the parent (ContentArea) owns
+ * the thread, message data, and the send path; this panel renders them and
+ * forwards composer intents.
+ */
+const props = defineProps<{
+  messages: readonly TimelineMessage[];
+  draft: string;
+  currentUser?: string;
+  avatarUrlByAuthor: Record<string, string | null>;
+  isSending?: boolean;
+  disabled?: boolean;
+  giphyApiKey?: string;
+  mentionCandidates?: MentionCandidate[];
+  slowModeCooldown?: number;
+  uploadProgress?: { uploading: boolean; progress: number; filename: string };
+  inMuc?: boolean;
+  linkPreviewLookup?: ComposerLinkPreviewLookup | null;
+  linkPreviewScope?: string | null;
+}>();
+
+const emit = defineEmits<{
+  "update:draft": [value: string];
+  send: [
+    body: string,
+    markup: MarkupSpan[],
+    references: MessageReference[],
+    files: Array<File | Blob> | undefined,
+    linkPreview?: ComposerLinkPreviewSendPayload,
+  ];
+}>();
+
+const hasMessages = computed(() => props.messages.length > 0);
+
+function timeLabel(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+</script>
+
+<template>
+  <div class="call-chat">
+    <div class="call-chat__messages" role="log" aria-label="Call chat messages">
+      <p v-if="!hasMessages" class="call-chat__empty type-caption text-muted-foreground">
+        No messages yet. Say hello.
+      </p>
+      <div
+        v-for="m in messages"
+        :key="m.id"
+        class="call-chat__row"
+        :data-message-id="m.id"
+      >
+        <AppAvatar
+          :name="m.author"
+          :src="avatarUrlByAuthor[m.author] ?? null"
+          size="xs"
+        />
+        <div class="call-chat__bubble">
+          <div class="call-chat__meta">
+            <span class="call-chat__author type-control">{{ m.author }}</span>
+            <time class="call-chat__time type-caption text-muted-foreground">{{ timeLabel(m.createdAt) }}</time>
+          </div>
+          <MessageBody :message="m" compact />
+        </div>
+      </div>
+    </div>
+    <MessageComposer
+      :draft="draft"
+      channel-name="call chat"
+      composer-label="Call chat composer"
+      :is-forum-channel="false"
+      :is-sending="!!isSending"
+      :disabled="!!disabled"
+      :giphy-api-key="giphyApiKey ?? ''"
+      :mention-candidates="mentionCandidates ?? []"
+      :slow-mode-cooldown="slowModeCooldown ?? 0"
+      :upload-progress="uploadProgress ?? { uploading: false, progress: 0, filename: '' }"
+      :in-muc="!!inMuc"
+      :link-preview-lookup="linkPreviewLookup ?? null"
+      :link-preview-scope="linkPreviewScope ?? null"
+      :show-extensions="false"
+      @update:draft="emit('update:draft', $event)"
+      @send="(body, markup, references, files, linkPreview) => emit('send', body, markup, references, files, linkPreview)"
+    />
+  </div>
+</template>
+
+<style scoped>
+.call-chat {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.call-chat__messages {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.75rem;
+}
+
+.call-chat__empty {
+  margin: auto;
+  text-align: center;
+}
+
+.call-chat__row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.call-chat__bubble {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.call-chat__meta {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.call-chat__author {
+  font-weight: 600;
+}
+</style>

--- a/chat/src/components/calls/CallControls.vue
+++ b/chat/src/components/calls/CallControls.vue
@@ -2,6 +2,7 @@
 import {
   LayoutGrid,
   Maximize2,
+  MessageSquare,
   Mic,
   MicOff,
   Minimize2,
@@ -37,6 +38,11 @@ const props = defineProps<{
   participantsOpen: boolean;
   /** Attendee count shown as a badge on the participants button. */
   participantCount: number;
+  /** True while the dock is open on the Chat tab — drives the chat
+   *  button's pressed/expanded state. The parent owns the dock store. */
+  chatOpen: boolean;
+  /** Unread call-chat messages shown as a badge on the chat button. */
+  chatUnread: number;
   /** The chosen stage layout — drives the view switcher's pressed state. */
   viewMode: CallViewMode;
 }>();
@@ -47,6 +53,7 @@ const emit = defineEmits<{
   toggleScreenShare: [];
   toggleExpanded: [];
   toggleParticipants: [];
+  toggleChat: [];
   openSettings: [];
   setViewMode: [mode: CallViewMode];
   hangup: [];
@@ -181,6 +188,23 @@ function onViewKeydown(event: KeyboardEvent): void {
     </button>
     <button
       type="button"
+      class="call-controls__chat chat-icon-button chat-icon-button--md hover:bg-muted"
+      :class="{ 'bg-muted text-foreground': chatOpen }"
+      :title="chatOpen ? 'Close chat' : 'Open chat'"
+      :aria-label="chatOpen ? 'Close chat' : 'Open chat'"
+      :aria-pressed="chatOpen"
+      :aria-expanded="chatOpen"
+      @click="emit('toggleChat')"
+    >
+      <MessageSquare class="w-4 h-4" />
+      <span
+        v-if="chatUnread > 0"
+        class="call-controls__unread"
+        :aria-label="`${chatUnread} unread messages`"
+      >{{ chatUnread }}</span>
+    </button>
+    <button
+      type="button"
       class="chat-icon-button chat-icon-button--md hover:bg-muted"
       title="Call settings"
       @click="emit('openSettings')"
@@ -241,6 +265,28 @@ function onViewKeydown(event: KeyboardEvent): void {
   padding: 0 0.3125rem;
   border-radius: 9999px;
   background: color-mix(in oklab, var(--foreground) 14%, transparent);
+  font-size: 0.6875rem;
+  font-variant-numeric: tabular-nums;
+}
+
+/* The chat toggle widens into a pill when an unread badge rides on it,
+ * mirroring the participants toggle. */
+.call-controls__chat {
+  width: auto;
+  gap: 0.375rem;
+  padding-inline: 0.5rem;
+}
+
+.call-controls__unread {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.125rem;
+  height: 1.125rem;
+  padding: 0 0.3125rem;
+  border-radius: 9999px;
+  background: var(--primary);
+  color: var(--primary-foreground);
   font-size: 0.6875rem;
   font-variant-numeric: tabular-nums;
 }

--- a/chat/src/components/calls/CallControls.vue
+++ b/chat/src/components/calls/CallControls.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from "vue";
 import {
   LayoutGrid,
   Maximize2,
@@ -58,6 +59,16 @@ const emit = defineEmits<{
   setViewMode: [mode: CallViewMode];
   hangup: [];
 }>();
+
+// The button's own `aria-label` overrides the accessible-name calculation, so a
+// nested badge (even with its own label) is never announced. Fold the unread
+// count into the label and mark the visual badge `aria-hidden`.
+const chatButtonLabel = computed(() => {
+  const base = props.chatOpen ? "Close chat" : "Open chat";
+  if (props.chatUnread <= 0) return base;
+  const plural = props.chatUnread === 1 ? "" : "s";
+  return `${base}, ${props.chatUnread} unread message${plural}`;
+});
 
 /**
  * Arrow-key navigation for the two-option Gallery/Speaker radiogroup, per the
@@ -191,7 +202,7 @@ function onViewKeydown(event: KeyboardEvent): void {
       class="call-controls__chat chat-icon-button chat-icon-button--md hover:bg-muted"
       :class="{ 'bg-muted text-foreground': chatOpen }"
       :title="chatOpen ? 'Close chat' : 'Open chat'"
-      :aria-label="chatOpen ? 'Close chat' : 'Open chat'"
+      :aria-label="chatButtonLabel"
       :aria-pressed="chatOpen"
       :aria-expanded="chatOpen"
       @click="emit('toggleChat')"
@@ -200,7 +211,7 @@ function onViewKeydown(event: KeyboardEvent): void {
       <span
         v-if="chatUnread > 0"
         class="call-controls__unread"
-        :aria-label="`${chatUnread} unread message${chatUnread === 1 ? '' : 's'}`"
+        aria-hidden="true"
       >{{ chatUnread }}</span>
     </button>
     <button

--- a/chat/src/components/calls/CallControls.vue
+++ b/chat/src/components/calls/CallControls.vue
@@ -200,7 +200,7 @@ function onViewKeydown(event: KeyboardEvent): void {
       <span
         v-if="chatUnread > 0"
         class="call-controls__unread"
-        :aria-label="`${chatUnread} unread messages`"
+        :aria-label="`${chatUnread} unread message${chatUnread === 1 ? '' : 's'}`"
       >{{ chatUnread }}</span>
     </button>
     <button

--- a/chat/src/components/calls/CallDock.vue
+++ b/chat/src/components/calls/CallDock.vue
@@ -83,7 +83,7 @@ function onTabKeydown(event: KeyboardEvent): void {
           <span
             v-if="chatUnread > 0"
             class="call-dock__unread"
-            :aria-label="`${chatUnread} unread messages`"
+            :aria-label="`${chatUnread} unread message${chatUnread === 1 ? '' : 's'}`"
           >{{ chatUnread }}</span>
         </button>
       </div>

--- a/chat/src/components/calls/CallDock.vue
+++ b/chat/src/components/calls/CallDock.vue
@@ -2,31 +2,56 @@
 import { computed } from "vue";
 import { X } from "lucide-vue-next";
 import CallParticipantsPanel from "./CallParticipantsPanel.vue";
+import type { CallDockTab } from "@/lib/calls/call-dock-state";
 import type { CallRosterRow } from "@/lib/calls/call-roster";
 import type { CallVolumeMixerRow } from "@/lib/calls/call-volume-mixer";
 
 /**
  * The in-call **Dock**: a right-side panel that reflows the Expanded
- * stage. A single-choice tab strip (currently just **Participants**)
- * heads it so future tabs (e.g. call chat) can slot in without changing
- * the shell. Stateless — the parent surface owns the roster controller
- * and the open/close store; the dock only forwards intents.
+ * stage (and overlays it in Immersive). A single-choice tab strip heads
+ * it — **Participants** (roster + volume) and **Chat** (call-thread
+ * messages + composer). Stateless: the parent surface owns the dock
+ * open/active-tab stores and the roster controller; the dock only
+ * forwards intents and renders the Chat panel from the `chat` slot.
  */
 const props = defineProps<{
   rows: readonly CallRosterRow[];
+  activeTab: CallDockTab;
+  chatUnread: number;
 }>();
 
 const emit = defineEmits<{
   setVolume: [row: CallVolumeMixerRow, level: number];
   resetAll: [];
   close: [];
+  setTab: [tab: CallDockTab];
 }>();
 
 const participantCount = computed(() => props.rows.length);
+
+/**
+ * Arrow-key navigation across the two tabs, per the WAI-ARIA tabs pattern with
+ * roving tabindex: an arrow moves selection to the other tab (every arrow flips
+ * with two tabs) and focus follows it.
+ */
+function onTabKeydown(event: KeyboardEvent): void {
+  const isArrow =
+    event.key === "ArrowRight" ||
+    event.key === "ArrowDown" ||
+    event.key === "ArrowLeft" ||
+    event.key === "ArrowUp";
+  if (!isArrow) return;
+  event.preventDefault();
+  const next: CallDockTab = props.activeTab === "participants" ? "chat" : "participants";
+  emit("setTab", next);
+  const current = event.currentTarget as HTMLElement;
+  const other = current.nextElementSibling ?? current.previousElementSibling;
+  if (other instanceof HTMLElement) other.focus();
+}
 </script>
 
 <template>
-  <aside class="call-dock" role="region" aria-label="Participants dock">
+  <aside class="call-dock" role="region" aria-label="Call dock">
     <header class="call-dock__header">
       <div class="call-dock__tabs" role="tablist" aria-label="Dock">
         <button
@@ -34,17 +59,38 @@ const participantCount = computed(() => props.rows.length);
           type="button"
           role="tab"
           class="call-dock__tab"
-          aria-selected="true"
+          :aria-selected="activeTab === 'participants'"
           aria-controls="call-dock-participants"
+          :tabindex="activeTab === 'participants' ? 0 : -1"
+          @click="emit('setTab', 'participants')"
+          @keydown="onTabKeydown"
         >
           Participants
           <span class="call-dock__count">{{ participantCount }}</span>
+        </button>
+        <button
+          id="call-dock-tab-chat"
+          type="button"
+          role="tab"
+          class="call-dock__tab"
+          :aria-selected="activeTab === 'chat'"
+          aria-controls="call-dock-chat"
+          :tabindex="activeTab === 'chat' ? 0 : -1"
+          @click="emit('setTab', 'chat')"
+          @keydown="onTabKeydown"
+        >
+          Chat
+          <span
+            v-if="chatUnread > 0"
+            class="call-dock__unread"
+            :aria-label="`${chatUnread} unread messages`"
+          >{{ chatUnread }}</span>
         </button>
       </div>
       <button
         type="button"
         class="call-dock__close chat-icon-button chat-icon-button--md hover:bg-muted"
-        aria-label="Close participants"
+        aria-label="Close dock"
         @click="emit('close')"
       >
         <X class="w-4 h-4" />
@@ -52,6 +98,7 @@ const participantCount = computed(() => props.rows.length);
     </header>
     <div
       id="call-dock-participants"
+      v-show="activeTab === 'participants'"
       class="call-dock__body"
       role="tabpanel"
       aria-labelledby="call-dock-tab-participants"
@@ -61,6 +108,15 @@ const participantCount = computed(() => props.rows.length);
         @set-volume="(row, level) => emit('setVolume', row, level)"
         @reset-all="emit('resetAll')"
       />
+    </div>
+    <div
+      id="call-dock-chat"
+      v-show="activeTab === 'chat'"
+      class="call-dock__body"
+      role="tabpanel"
+      aria-labelledby="call-dock-tab-chat"
+    >
+      <slot name="chat" />
     </div>
   </aside>
 </template>
@@ -120,6 +176,22 @@ const participantCount = computed(() => props.rows.length);
   background: color-mix(in oklab, var(--foreground) 12%, transparent);
   color: var(--muted-foreground);
   font-size: 0.75rem;
+}
+
+/* The Chat tab's unread badge — a small accent pill so a new message is
+ * noticeable even when the dock is parked on the Participants tab. */
+.call-dock__unread {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.25rem;
+  height: 1.25rem;
+  padding: 0 0.375rem;
+  border-radius: 9999px;
+  background: var(--primary);
+  color: var(--primary-foreground);
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
 }
 
 .call-dock__close {

--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -27,13 +27,17 @@ import { normalizeMucCallRoomJid } from "@/lib/calls/muc-call-presence";
 import { useCallRoster } from "@/lib/calls/use-call-roster";
 import {
   $callDockOpen,
+  $callDockTab,
   closeCallDock,
-  toggleCallDock,
+  setCallDockTab,
+  toggleCallChat,
+  toggleCallParticipants,
 } from "@/lib/calls/call-dock-state";
+import { $callChatUnread } from "@/lib/calls/call-chat-unread";
 import { barePeerJid } from "@/lib/xmpp/jid";
 import { expectedRemoteIdentitiesForCallState } from "@/lib/calls/call-tiles";
 import type { MentionCandidate } from "@/lib/mentions";
-import type { MarkupSpan, MessageReference } from "@/lib/chat-ui";
+import type { MarkupSpan, MessageReference, TimelineMessage } from "@/lib/chat-ui";
 import type { ComposerLinkPreviewLookup, ComposerLinkPreviewSendPayload } from "@/lib/link-preview-composer";
 import CallTileGrid from "./CallTileGrid.vue";
 import CallControls from "./CallControls.vue";
@@ -41,7 +45,7 @@ import CallSettingsDialog from "./CallSettingsDialog.vue";
 import CallMediaNotice from "./CallMediaNotice.vue";
 import CallSelfShareNotice from "./CallSelfShareNotice.vue";
 import CallDock from "./CallDock.vue";
-import MessageComposer from "@/components/chat/MessageComposer.vue";
+import CallChatPanel from "./CallChatPanel.vue";
 
 /**
  * "Expanded" call surface — fills the chat content pane while the
@@ -71,6 +75,10 @@ const props = defineProps<{
   uploadProgress?: { uploading: boolean; progress: number; filename: string };
   linkPreviewLookup?: ComposerLinkPreviewLookup | null;
   linkPreviewScope?: string | null;
+  /** The active call's XEP-0201 thread messages, rendered in the Chat tab. */
+  callChatMessages?: readonly TimelineMessage[];
+  avatarUrlByAuthor?: Record<string, string | null>;
+  currentUser?: string;
   sendCallChatMessage?: (
     body: string,
     markup: MarkupSpan[],
@@ -109,7 +117,14 @@ const { activeRoomJid, selfInCall } = useActiveMucCall();
 
 const settingsOpen = ref(false);
 const dockOpen = useStore($callDockOpen);
+const dockTab = useStore($callDockTab);
+const chatUnread = useStore($callChatUnread);
 const callChatDraft = ref("");
+
+// The dock is shared with the Participants tab; split these out so the control
+// bar buttons reflect which tab (if any) the open dock is parked on.
+const chatOpen = computed(() => dockOpen.value && dockTab.value === "chat");
+const participantsOpen = computed(() => dockOpen.value && dockTab.value === "participants");
 
 const normalizedRoomJid = computed(() =>
   normalizeMucCallRoomJid(props.roomJid ?? ""),
@@ -172,15 +187,6 @@ const callThreadOverride = computed(() => {
   const threadId = props.callThreadId?.trim();
   return threadId ? { threadId } : null;
 });
-
-// The dedicated call chat is available for both group (MUC) and 1:1 (DM)
-// calls. A resolved `callThreadOverride` already implies an active call with
-// a usable thread (MUC: room timeline; DM: the call sid), so the thread id
-// is the only gate beyond an active call.
-const canShowCallChatComposer = computed(() =>
-  state.value.phase === "active" &&
-  !!callThreadOverride.value,
-);
 
 const isMucCall = computed(
   () => state.value.phase === "active" && state.value.kind === "muc",
@@ -251,8 +257,8 @@ function onKeydown(event: KeyboardEvent): void {
     settingsOpen.value = false;
     return;
   }
-  // The Participants dock is non-modal but still a layer the user opened
-  // on top of the stage; Escape closes it before it collapses the call.
+  // The dock is non-modal but still a layer the user opened on top of the
+  // stage; Escape closes it before it collapses the call.
   if (dockOpen.value) {
     event.preventDefault();
     closeCallDock();
@@ -316,37 +322,33 @@ onBeforeUnmount(() => {
       <CallDock
         v-if="dockOpen"
         :rows="rosterRows"
+        :active-tab="dockTab"
+        :chat-unread="chatUnread"
+        @set-tab="setCallDockTab"
         @set-volume="setParticipantVolume"
         @reset-all="resetParticipantVolumes"
         @close="closeCallDock"
-      />
+      >
+        <template #chat>
+          <CallChatPanel
+            v-model:draft="callChatDraft"
+            :messages="callChatMessages ?? []"
+            :current-user="currentUser"
+            :avatar-url-by-author="avatarUrlByAuthor ?? {}"
+            :is-sending="!!isSending"
+            :disabled="!!disabled || !callThreadOverride"
+            :giphy-api-key="giphyApiKey ?? ''"
+            :mention-candidates="mentionCandidates ?? []"
+            :slow-mode-cooldown="slowModeCooldown ?? 0"
+            :upload-progress="uploadProgress ?? { uploading: false, progress: 0, filename: '' }"
+            :in-muc="isMucCall"
+            :link-preview-lookup="linkPreviewLookup ?? null"
+            :link-preview-scope="linkPreviewScope ?? null"
+            @send="onSendCallChat"
+          />
+        </template>
+      </CallDock>
     </main>
-    <section
-      v-if="canShowCallChatComposer"
-      class="call-expanded__chat"
-      aria-label="Call chat"
-    >
-      <div class="call-expanded__chat-label type-section-label text-muted-foreground">
-        Call chat
-      </div>
-      <MessageComposer
-        v-model:draft="callChatDraft"
-        channel-name="call chat"
-        composer-label="Call chat composer"
-        :is-forum-channel="false"
-        :is-sending="!!isSending"
-        :disabled="!!disabled || !callThreadOverride"
-        :giphy-api-key="giphyApiKey ?? ''"
-        :mention-candidates="mentionCandidates ?? []"
-        :slow-mode-cooldown="slowModeCooldown ?? 0"
-        :upload-progress="uploadProgress ?? { uploading: false, progress: 0, filename: '' }"
-        :in-muc="isMucCall"
-        :link-preview-lookup="linkPreviewLookup ?? null"
-        :link-preview-scope="linkPreviewScope ?? null"
-        :show-extensions="false"
-        @send="onSendCallChat"
-      />
-    </section>
     <footer class="call-expanded__footer">
       <CallControls
         :mic-enabled="micEnabled"
@@ -354,14 +356,17 @@ onBeforeUnmount(() => {
         :screen-share-enabled="screenShareEnabled"
         :screen-share-supported="screenShareSupported"
         :is-expanded="true"
-        :participants-open="dockOpen"
+        :participants-open="participantsOpen"
         :participant-count="participantCount"
+        :chat-open="chatOpen"
+        :chat-unread="chatUnread"
         :view-mode="viewMode"
         @toggle-mic="toggleMic"
         @toggle-cam="toggleCam"
         @toggle-screen-share="toggleScreenShare"
         @toggle-expanded="collapseToSplit"
-        @toggle-participants="toggleCallDock"
+        @toggle-participants="toggleCallParticipants"
+        @toggle-chat="toggleCallChat"
         @open-settings="settingsOpen = true"
         @set-view-mode="setCallViewMode"
         @hangup="onHangup"
@@ -422,15 +427,6 @@ onBeforeUnmount(() => {
   justify-content: center;
   border-top: 1px solid var(--border);
   padding: 0.75rem 1rem;
-}
-
-.call-expanded__chat {
-  border-top: 1px solid var(--border);
-  background: color-mix(in oklab, var(--background) 88%, transparent);
-}
-
-.call-expanded__chat-label {
-  padding: 0.625rem 1rem 0;
 }
 
 /* On narrow viewports the dock becomes a full-width bottom panel (see

--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -332,6 +332,7 @@ onBeforeUnmount(() => {
           <CallChatPanel
             v-model:draft="callChatDraft"
             :messages="callChatMessages ?? []"
+            :visible="chatOpen"
             :avatar-url-by-author="avatarUrlByAuthor ?? {}"
             :is-sending="!!isSending"
             :disabled="!!disabled || !callThreadOverride"

--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -78,7 +78,6 @@ const props = defineProps<{
   /** The active call's XEP-0201 thread messages, rendered in the Chat tab. */
   callChatMessages?: readonly TimelineMessage[];
   avatarUrlByAuthor?: Record<string, string | null>;
-  currentUser?: string;
   sendCallChatMessage?: (
     body: string,
     markup: MarkupSpan[],
@@ -333,7 +332,6 @@ onBeforeUnmount(() => {
           <CallChatPanel
             v-model:draft="callChatDraft"
             :messages="callChatMessages ?? []"
-            :current-user="currentUser"
             :avatar-url-by-author="avatarUrlByAuthor ?? {}"
             :is-sending="!!isSending"
             :disabled="!!disabled || !callThreadOverride"

--- a/chat/src/components/calls/CallSplitContainer.vue
+++ b/chat/src/components/calls/CallSplitContainer.vue
@@ -26,7 +26,8 @@ import { useSplitResize } from "@/lib/calls/use-split-resize";
 import { localScreenSharePresentation } from "@/lib/calls/call-self-share";
 import { normalizeMucCallRoomJid } from "@/lib/calls/muc-call-presence";
 import { useCallRoster } from "@/lib/calls/use-call-roster";
-import { openCallDock } from "@/lib/calls/call-dock-state";
+import { openCallDock, setCallDockTab } from "@/lib/calls/call-dock-state";
+import { $callChatUnread } from "@/lib/calls/call-chat-unread";
 import { barePeerJid } from "@/lib/xmpp/jid";
 import { expectedRemoteIdentitiesForCallState } from "@/lib/calls/call-tiles";
 import CallTileGrid from "./CallTileGrid.vue";
@@ -77,12 +78,21 @@ const normalizedRoomJid = computed(() =>
 );
 
 // The split surface has no room for the dock itself; it only needs the
-// attendee count for the Participants button, which bumps to Expanded
-// (where the dock reflows the stage) on click.
+// attendee count for the Participants button and the unread count for the
+// Chat button, both of which bump to Expanded (where the dock reflows the
+// stage) on click.
 const { rows: rosterRows } = useCallRoster(normalizedRoomJid);
 const participantCount = computed(() => rosterRows.value.length);
+const chatUnread = useStore($callChatUnread);
 
 function enterExpandedWithDock(): void {
+  setCallDockTab("participants");
+  openCallDock();
+  $callUiMode.set("expanded");
+}
+
+function enterExpandedWithChat(): void {
+  setCallDockTab("chat");
   openCallDock();
   $callUiMode.set("expanded");
 }
@@ -237,12 +247,15 @@ async function onHangup(): Promise<void> {
           :is-expanded="false"
           :participants-open="false"
           :participant-count="participantCount"
+          :chat-open="false"
+          :chat-unread="chatUnread"
           :view-mode="viewMode"
           @toggle-mic="toggleMic"
           @toggle-cam="toggleCam"
           @toggle-screen-share="toggleScreenShare"
           @toggle-expanded="enterExpanded"
           @toggle-participants="enterExpandedWithDock"
+          @toggle-chat="enterExpandedWithChat"
           @open-settings="settingsOpen = true"
           @set-view-mode="setCallViewMode"
           @hangup="onHangup"

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -1585,7 +1585,6 @@ function dayDividerLabel(createdAt: string): string {
       :call-thread-id="activeCallThreadId"
       :call-chat-messages="callChatMessages"
       :avatar-url-by-author="avatarUrlByAuthor"
-      :current-user="currentUser"
       :is-sending="isSending"
       :disabled="!canShowComposer"
       :giphy-api-key="giphyApiKey"

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -12,6 +12,12 @@ import { getReplyJumpNotice } from "@/lib/reply-ux";
 import { findThreadToAutoOpen } from "@/lib/thread-auto-open";
 import { activeCallChatThreadId } from "@/lib/calls/call-chat-composer";
 import { $callState } from "@/lib/calls/call-store";
+import { $callDockOpen, $callDockTab } from "@/lib/calls/call-dock-state";
+import {
+  inboundCallChatThreadIds,
+  isCallChatTabFocused,
+  syncCallChatUnread,
+} from "@/lib/calls/call-chat-unread";
 import {
   getPinnedScrollTop,
   getNewMessagesDividerPlacement,
@@ -452,6 +458,27 @@ const callAnchorConversationJid = computed(
 );
 const activeCallThreadId = computed(() =>
   activeCallChatThreadId(callState.value, props.messages, callRoomJid.value),
+);
+
+// Messages on the active call's XEP-0201 thread, rendered in the Dock's Chat tab
+// (all of them, including the local user's own, so they see what they sent).
+const callChatMessages = computed(() =>
+  activeCallThreadId.value
+    ? props.messages.filter((message) => message.threadId === activeCallThreadId.value)
+    : [],
+);
+
+// Drive the Chat tab's unread badge: inbound (non-self) call-thread messages
+// accumulate while the Chat tab isn't the focused dock tab and clear once it is.
+const callDockOpen = useStore($callDockOpen);
+const callDockTab = useStore($callDockTab);
+watch(
+  [
+    () => inboundCallChatThreadIds(props.messages, activeCallThreadId.value),
+    () => isCallChatTabFocused(callDockOpen.value, callDockTab.value),
+  ],
+  ([inboundIds, focused]) => syncCallChatUnread(inboundIds, focused),
+  { immediate: true },
 );
 
 watch(
@@ -1556,6 +1583,9 @@ function dayDividerLabel(createdAt: string): string {
       :dm-peer-jid="dmPeer?.peerJid"
       :dm-peer-name="dmPeer?.peerUsername"
       :call-thread-id="activeCallThreadId"
+      :call-chat-messages="callChatMessages"
+      :avatar-url-by-author="avatarUrlByAuthor"
+      :current-user="currentUser"
       :is-sending="isSending"
       :disabled="!canShowComposer"
       :giphy-api-key="giphyApiKey"

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -461,10 +461,14 @@ const activeCallThreadId = computed(() =>
 );
 
 // Messages on the active call's XEP-0201 thread, rendered in the Dock's Chat tab
-// (all of them, including the local user's own, so they see what they sent).
+// (all of them, including the local user's own, so they see what they sent — but
+// not the bodyless call-anchor card, which shares the thread id).
 const callChatMessages = computed(() =>
   activeCallThreadId.value
-    ? props.messages.filter((message) => message.threadId === activeCallThreadId.value)
+    ? props.messages.filter(
+        (message) =>
+          message.threadId === activeCallThreadId.value && !message.callThread,
+      )
     : [],
 );
 
@@ -472,12 +476,18 @@ const callChatMessages = computed(() =>
 // accumulate while the Chat tab isn't the focused dock tab and clear once it is.
 const callDockOpen = useStore($callDockOpen);
 const callDockTab = useStore($callDockTab);
+const callChatInboundIds = computed(() =>
+  inboundCallChatThreadIds(props.messages, activeCallThreadId.value),
+);
+// Key the watch on a stable string so it fires only when the call-thread inbound
+// ids (or focus) actually change — not on every unrelated conversation message,
+// reaction, or edit during a busy call.
 watch(
   [
-    () => inboundCallChatThreadIds(props.messages, activeCallThreadId.value),
+    () => callChatInboundIds.value.join("\n"),
     () => isCallChatTabFocused(callDockOpen.value, callDockTab.value),
   ],
-  ([inboundIds, focused]) => syncCallChatUnread(inboundIds, focused),
+  ([, focused]) => syncCallChatUnread(callChatInboundIds.value, focused),
   { immediate: true },
 );
 

--- a/chat/src/lib/calls/call-chat-unread.ts
+++ b/chat/src/lib/calls/call-chat-unread.ts
@@ -35,7 +35,24 @@ type CallChatThreadMessage = {
   id: string;
   threadId?: string | null;
   isSelf?: boolean;
+  /** Present on the call-anchor system card (not a chat message). */
+  callThread?: unknown;
 };
+
+/**
+ * Whether a thread message is an actual call-chat message: on the active call
+ * thread, not the local user's own, and not the bodyless call-anchor card
+ * (which shares the thread id — DM anchors use `threadId === sid`, MUC anchors
+ * are the thread root).
+ */
+function isInboundCallChatMessage(
+  message: CallChatThreadMessage,
+  threadId: string,
+): boolean {
+  return (
+    message.threadId === threadId && !message.isSelf && !message.callThread
+  );
+}
 
 /**
  * Ordered ids of inbound (not-self) messages on the active call-chat thread.
@@ -48,9 +65,7 @@ export function inboundCallChatThreadIds(
   if (!threadId) return [];
   const ids: string[] = [];
   for (const message of messages) {
-    if (message.threadId !== threadId) continue;
-    if (message.isSelf) continue;
-    ids.push(message.id);
+    if (isInboundCallChatMessage(message, threadId)) ids.push(message.id);
   }
   return ids;
 }
@@ -67,6 +82,10 @@ export function nextCallChatUnread(input: CallChatUnreadInput): CallChatUnreadRe
     // Reading the tab marks everything currently loaded as seen.
     return { unread: 0, lastSeenId: inboundIds.at(-1) ?? lastSeenId };
   }
+  // If the watermark id is no longer in the loaded slice (-1), everything loaded
+  // counts as unread. Safe for in-call chat: the thread is short-lived and never
+  // paged/trimmed today. Revisit with a position/time sentinel if the Immersive
+  // rework (#1028) starts paging this thread.
   const seenIndex = lastSeenId ? inboundIds.lastIndexOf(lastSeenId) : -1;
   const unread = inboundIds.length - (seenIndex + 1);
   return { unread, lastSeenId };
@@ -92,7 +111,8 @@ export function syncCallChatUnread(
 ): void {
   const result = nextCallChatUnread({ inboundIds, lastSeenId, focused });
   lastSeenId = result.lastSeenId;
-  $callChatUnread.set(result.unread);
+  // Skip a no-op write so subscribers aren't notified when the count is unchanged.
+  if ($callChatUnread.get() !== result.unread) $callChatUnread.set(result.unread);
 }
 
 /** Clear the badge and the watermark — used at the start/end of a call. */

--- a/chat/src/lib/calls/call-chat-unread.ts
+++ b/chat/src/lib/calls/call-chat-unread.ts
@@ -1,0 +1,98 @@
+import { atom } from "nanostores";
+import { $callState } from "./call-store";
+
+/**
+ * Inputs to the in-call Chat unread reducer: the ordered ids of inbound
+ * (non-self) call-thread messages currently loaded, the last-seen watermark,
+ * and whether the Chat tab is the focused dock tab right now.
+ */
+export type CallChatUnreadInput = {
+  inboundIds: readonly string[];
+  lastSeenId: string | null;
+  focused: boolean;
+};
+
+export type CallChatUnreadResult = {
+  unread: number;
+  lastSeenId: string | null;
+};
+
+/**
+ * The slice of a timeline message the unread selector needs. Kept structural
+ * so callers can pass live `TimelineMessage`s or test fixtures alike.
+ */
+export type CallChatThreadMessage = {
+  id: string;
+  threadId?: string | null;
+  isSelf?: boolean;
+};
+
+/**
+ * Ordered ids of inbound (not-self) messages on the active call-chat thread.
+ * Empty when no call thread is active.
+ */
+export function inboundCallChatThreadIds(
+  messages: readonly CallChatThreadMessage[],
+  threadId: string | null,
+): string[] {
+  if (!threadId) return [];
+  const ids: string[] = [];
+  for (const message of messages) {
+    if (message.threadId !== threadId) continue;
+    if (message.isSelf) continue;
+    ids.push(message.id);
+  }
+  return ids;
+}
+
+/**
+ * Pure reducer for the Chat tab's unread badge.
+ *
+ * While the Chat tab is unfocused, every inbound call-thread message that
+ * arrived after the watermark counts as unread and the watermark holds still.
+ */
+export function nextCallChatUnread(input: CallChatUnreadInput): CallChatUnreadResult {
+  const { inboundIds, lastSeenId, focused } = input;
+  if (focused) {
+    // Reading the tab marks everything currently loaded as seen.
+    return { unread: 0, lastSeenId: inboundIds.at(-1) ?? lastSeenId };
+  }
+  const seenIndex = lastSeenId ? inboundIds.lastIndexOf(lastSeenId) : -1;
+  const unread = inboundIds.length - (seenIndex + 1);
+  return { unread, lastSeenId };
+}
+
+/**
+ * The Chat tab's live unread count. A plain module-scoped atom, not persisted:
+ * it tracks one call's session and starts fresh on the next.
+ */
+export const $callChatUnread = atom<number>(0);
+
+// The read watermark behind the badge. Module-scoped (not a component ref) so
+// it survives the split⟷expanded surface remounts within one call.
+let lastSeenId: string | null = null;
+
+/**
+ * Fold the current inbound call-thread ids and Chat-tab focus into the badge.
+ * Called whenever the loaded messages or the focus state change.
+ */
+export function syncCallChatUnread(
+  inboundIds: readonly string[],
+  focused: boolean,
+): void {
+  const result = nextCallChatUnread({ inboundIds, lastSeenId, focused });
+  lastSeenId = result.lastSeenId;
+  $callChatUnread.set(result.unread);
+}
+
+/** Clear the badge and the watermark — used at the start/end of a call. */
+export function resetCallChatUnread(): void {
+  lastSeenId = null;
+  $callChatUnread.set(0);
+}
+
+// Reset whenever the call leaves the active phase so a stale unread count can't
+// carry into the next call. Subscribed once at module load.
+$callState.subscribe((state) => {
+  if (state.phase !== "active") resetCallChatUnread();
+});

--- a/chat/src/lib/calls/call-chat-unread.ts
+++ b/chat/src/lib/calls/call-chat-unread.ts
@@ -16,13 +16,13 @@ export function isCallChatTabFocused(dockOpen: boolean, tab: CallDockTab): boole
  * (non-self) call-thread messages currently loaded, the last-seen watermark,
  * and whether the Chat tab is the focused dock tab right now.
  */
-export type CallChatUnreadInput = {
+type CallChatUnreadInput = {
   inboundIds: readonly string[];
   lastSeenId: string | null;
   focused: boolean;
 };
 
-export type CallChatUnreadResult = {
+type CallChatUnreadResult = {
   unread: number;
   lastSeenId: string | null;
 };
@@ -31,7 +31,7 @@ export type CallChatUnreadResult = {
  * The slice of a timeline message the unread selector needs. Kept structural
  * so callers can pass live `TimelineMessage`s or test fixtures alike.
  */
-export type CallChatThreadMessage = {
+type CallChatThreadMessage = {
   id: string;
   threadId?: string | null;
   isSelf?: boolean;

--- a/chat/src/lib/calls/call-chat-unread.ts
+++ b/chat/src/lib/calls/call-chat-unread.ts
@@ -1,5 +1,15 @@
 import { atom } from "nanostores";
 import { $callState } from "./call-store";
+import type { CallDockTab } from "./call-dock-state";
+
+/**
+ * The Chat tab is "focused" — and therefore reads incoming messages live —
+ * only when the dock is open on the Chat tab. While the dock is closed or
+ * parked on Participants, inbound messages accumulate as unread.
+ */
+export function isCallChatTabFocused(dockOpen: boolean, tab: CallDockTab): boolean {
+  return dockOpen && tab === "chat";
+}
 
 /**
  * Inputs to the in-call Chat unread reducer: the ordered ids of inbound

--- a/chat/src/lib/calls/call-dock-state.ts
+++ b/chat/src/lib/calls/call-dock-state.ts
@@ -13,6 +13,16 @@ import { $callState } from "./call-store";
  */
 export const $callDockOpen = atom<boolean>(false);
 
+/** Which tab the dock currently shows. */
+export type CallDockTab = "participants" | "chat";
+
+/**
+ * The selected dock tab. Like {@link $callDockOpen} it is module-scoped and
+ * survives the split⟷expanded remount within a call, and resets to
+ * `participants` once the call ends.
+ */
+export const $callDockTab = atom<CallDockTab>("participants");
+
 export function openCallDock(): void {
   $callDockOpen.set(true);
 }
@@ -25,8 +35,38 @@ export function toggleCallDock(): void {
   $callDockOpen.set(!$callDockOpen.get());
 }
 
-// Close the dock whenever the call leaves the active phase, so a stale
-// "open" can't carry into the next call. Subscribed once at module load.
+export function setCallDockTab(tab: CallDockTab): void {
+  $callDockTab.set(tab);
+}
+
+/**
+ * Toggle the dock for a given tab from a control-bar button: if the dock is
+ * already open on that tab, close it; otherwise select the tab and open it.
+ * A click on the *other* tab's button just switches tabs without closing.
+ */
+function toggleCallDockTab(tab: CallDockTab): void {
+  if ($callDockOpen.get() && $callDockTab.get() === tab) {
+    closeCallDock();
+    return;
+  }
+  $callDockTab.set(tab);
+  openCallDock();
+}
+
+export function toggleCallParticipants(): void {
+  toggleCallDockTab("participants");
+}
+
+export function toggleCallChat(): void {
+  toggleCallDockTab("chat");
+}
+
+// Close the dock and reset the tab whenever the call leaves the active phase,
+// so a stale "open" or tab can't carry into the next call. Subscribed once at
+// module load.
 $callState.subscribe((state) => {
-  if (state.phase !== "active") closeCallDock();
+  if (state.phase !== "active") {
+    closeCallDock();
+    $callDockTab.set("participants");
+  }
 });

--- a/chat/src/lib/calls/call-dock-state.ts
+++ b/chat/src/lib/calls/call-dock-state.ts
@@ -31,10 +31,6 @@ export function closeCallDock(): void {
   $callDockOpen.set(false);
 }
 
-export function toggleCallDock(): void {
-  $callDockOpen.set(!$callDockOpen.get());
-}
-
 export function setCallDockTab(tab: CallDockTab): void {
   $callDockTab.set(tab);
 }

--- a/chat/tests/call-chat-composer.test.ts
+++ b/chat/tests/call-chat-composer.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { $callState } from "../src/lib/calls/call-store";
 import { $callUiMode } from "../src/lib/calls/ui-mode";
+import {
+  closeCallDock,
+  openCallDock,
+  setCallDockTab,
+} from "../src/lib/calls/call-dock-state";
 import { $mucCallParticipants } from "../src/lib/calls/muc-call-presence";
 import { connectionStore } from "../src/lib/connection-store";
 import { activeCallChatThreadId, resolveActiveMucCallThreadId } from "../src/lib/calls/call-chat-composer";
@@ -13,6 +18,8 @@ describe("call-chat composer", () => {
   afterEach(() => {
     $callState.set({ phase: "idle" });
     $callUiMode.set("split");
+    closeCallDock();
+    setCallDockTab("participants");
     $mucCallParticipants.set({});
     connectionStore.session = null;
   });
@@ -119,8 +126,11 @@ describe("call-chat composer", () => {
     ).toBeNull();
   });
 
-  test("expanded channel calls render a labelled call-chat composer when a call thread is available", async () => {
+  test("expanded channel calls render a labelled call-chat composer in the dock Chat tab", async () => {
     seedExpandedMucCall();
+    // Chat now lives in the dock's Chat tab, so open the dock there to render it.
+    setCallDockTab("chat");
+    openCallDock();
 
     const html = await renderVueComponent(
       "../src/components/calls/CallExpandedSurface.vue",
@@ -133,17 +143,22 @@ describe("call-chat composer", () => {
         mentionCandidates: [],
         slowModeCooldown: 0,
         uploadProgress: { uploading: false, progress: 0, filename: "" },
+        callChatMessages: [],
+        avatarUrlByAuthor: {},
       },
       import.meta.url,
     );
 
-    expect(html).toContain("Call chat");
     expect(html).toContain('aria-label="Call chat composer"');
     expect(html).not.toContain('aria-label="Extensions"');
+    // With a usable thread the composer is enabled (not greyed out).
+    expect(html).not.toContain("pointer-events-none");
   });
 
   test("expanded DM calls render the call-chat composer from the call sid", async () => {
     seedExpandedDmCall();
+    setCallDockTab("chat");
+    openCallDock();
 
     const html = await renderVueComponent(
       "../src/components/calls/CallExpandedSurface.vue",
@@ -152,16 +167,19 @@ describe("call-chat composer", () => {
         dmPeerName: "Bob",
         callThreadId: "dm-sid-1",
         uploadProgress: { uploading: false, progress: 0, filename: "" },
+        callChatMessages: [],
+        avatarUrlByAuthor: {},
       },
       import.meta.url,
     );
 
-    expect(html).toContain("Call chat");
     expect(html).toContain('aria-label="Call chat composer"');
   });
 
-  test("expanded channel calls hide the call-chat composer without a usable thread id", async () => {
+  test("expanded channel calls disable the call-chat composer without a usable thread id", async () => {
     seedExpandedMucCall();
+    setCallDockTab("chat");
+    openCallDock();
 
     const html = await renderVueComponent(
       "../src/components/calls/CallExpandedSurface.vue",
@@ -169,11 +187,15 @@ describe("call-chat composer", () => {
         roomJid: ROOM,
         callThreadId: "   ",
         uploadProgress: { uploading: false, progress: 0, filename: "" },
+        callChatMessages: [],
+        avatarUrlByAuthor: {},
       },
       import.meta.url,
     );
 
-    expect(html).not.toContain("Call chat composer");
+    // The composer stays in the tab but is disabled until a thread resolves.
+    expect(html).toContain('aria-label="Call chat composer"');
+    expect(html).toContain("pointer-events-none");
   });
 });
 

--- a/chat/tests/call-chat-panel.test.ts
+++ b/chat/tests/call-chat-panel.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { renderVueComponent } from "./helpers/render-vue-sfc";
+import type { TimelineMessage } from "../src/lib/chat-ui";
+
+function message(id: string, body: string, author = "alice"): TimelineMessage {
+  return { id, author, body, createdAt: "2026-06-18T12:00:00Z", isSelf: false };
+}
+
+function panelSource(): string {
+  return readFileSync(
+    new URL("../src/components/calls/CallChatPanel.vue", import.meta.url),
+    "utf8",
+  );
+}
+
+describe("CallChatPanel", () => {
+  test("renders the call-thread messages and the call-chat composer", async () => {
+    const html = await renderVueComponent(
+      "../src/components/calls/CallChatPanel.vue",
+      {
+        messages: [message("m1", "hello call"), message("m2", "second")],
+        draft: "",
+        currentUser: "me",
+        avatarUrlByAuthor: {},
+      },
+      import.meta.url,
+    );
+
+    expect(html).toContain("hello call");
+    expect(html).toContain("second");
+    expect(html).toContain("alice");
+    // The moved composer is present.
+    expect(html).toContain("Call chat composer");
+  });
+
+  test("shows an empty state when the call thread has no messages yet", async () => {
+    const html = await renderVueComponent(
+      "../src/components/calls/CallChatPanel.vue",
+      { messages: [], draft: "", currentUser: "me", avatarUrlByAuthor: {} },
+      import.meta.url,
+    );
+
+    expect(html).toContain("No messages yet");
+  });
+
+  test("renders message bodies via MessageBody and forwards the composer send", () => {
+    const source = panelSource();
+    expect(source).toContain("MessageBody");
+    expect(source).toContain("MessageComposer");
+    expect(source).toContain("emit('send'");
+    // The in-call composer keeps extensions hidden, matching the old footer.
+    expect(source).toContain(":show-extensions=\"false\"");
+  });
+});

--- a/chat/tests/call-chat-panel.test.ts
+++ b/chat/tests/call-chat-panel.test.ts
@@ -21,7 +21,6 @@ describe("CallChatPanel", () => {
       {
         messages: [message("m1", "hello call"), message("m2", "second")],
         draft: "",
-        currentUser: "me",
         avatarUrlByAuthor: {},
       },
       import.meta.url,
@@ -37,7 +36,7 @@ describe("CallChatPanel", () => {
   test("shows an empty state when the call thread has no messages yet", async () => {
     const html = await renderVueComponent(
       "../src/components/calls/CallChatPanel.vue",
-      { messages: [], draft: "", currentUser: "me", avatarUrlByAuthor: {} },
+      { messages: [], draft: "", avatarUrlByAuthor: {} },
       import.meta.url,
     );
 

--- a/chat/tests/call-chat-panel.test.ts
+++ b/chat/tests/call-chat-panel.test.ts
@@ -29,6 +29,8 @@ describe("CallChatPanel", () => {
     expect(html).toContain("hello call");
     expect(html).toContain("second");
     expect(html).toContain("alice");
+    // Each timestamp carries a machine-readable datetime for assistive tech.
+    expect(html).toContain('datetime="2026-06-18T12:00:00Z"');
     // The moved composer is present.
     expect(html).toContain("Call chat composer");
   });

--- a/chat/tests/call-chat-unread.test.ts
+++ b/chat/tests/call-chat-unread.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  $callChatUnread,
+  inboundCallChatThreadIds,
+  nextCallChatUnread,
+  resetCallChatUnread,
+  syncCallChatUnread,
+} from "../src/lib/calls/call-chat-unread";
+import { $callState, clearCallState } from "../src/lib/calls/call-store";
+
+afterEach(() => {
+  resetCallChatUnread();
+  clearCallState();
+});
+
+describe("nextCallChatUnread", () => {
+  test("counts inbound messages arriving while not focused as unread", () => {
+    const result = nextCallChatUnread({
+      inboundIds: ["m1", "m2", "m3"],
+      lastSeenId: "m1",
+      focused: false,
+    });
+
+    // m2 and m3 arrived after the last-seen watermark.
+    expect(result.unread).toBe(2);
+    // The watermark does not advance while the Chat tab is unfocused.
+    expect(result.lastSeenId).toBe("m1");
+  });
+
+  test("clears the count and advances the watermark while focused", () => {
+    const result = nextCallChatUnread({
+      inboundIds: ["m1", "m2", "m3"],
+      lastSeenId: "m1",
+      focused: true,
+    });
+
+    expect(result.unread).toBe(0);
+    // Reading the tab marks everything currently loaded as seen.
+    expect(result.lastSeenId).toBe("m3");
+  });
+
+  test("treats every inbound message as unread when there is no watermark yet", () => {
+    const result = nextCallChatUnread({
+      inboundIds: ["m1", "m2"],
+      lastSeenId: null,
+      focused: false,
+    });
+
+    expect(result.unread).toBe(2);
+    expect(result.lastSeenId).toBe(null);
+  });
+});
+
+describe("inboundCallChatThreadIds", () => {
+  test("keeps inbound messages on the call thread in order, dropping self and other threads", () => {
+    const messages = [
+      { id: "a", threadId: "call-1", isSelf: false },
+      { id: "b", threadId: "other", isSelf: false },
+      { id: "c", threadId: "call-1", isSelf: true },
+      { id: "d", threadId: "call-1", isSelf: false },
+    ];
+
+    expect(inboundCallChatThreadIds(messages, "call-1")).toEqual(["a", "d"]);
+  });
+
+  test("returns nothing when there is no active call thread", () => {
+    const messages = [{ id: "a", threadId: "call-1", isSelf: false }];
+    expect(inboundCallChatThreadIds(messages, null)).toEqual([]);
+  });
+});
+
+describe("$callChatUnread store", () => {
+  test("accumulates while unfocused and clears once the Chat tab is focused", () => {
+    expect($callChatUnread.get()).toBe(0);
+
+    syncCallChatUnread(["m1", "m2"], false);
+    expect($callChatUnread.get()).toBe(2);
+
+    syncCallChatUnread(["m1", "m2", "m3"], false);
+    expect($callChatUnread.get()).toBe(3);
+
+    // Focusing the tab clears the badge and marks the loaded messages seen.
+    syncCallChatUnread(["m1", "m2", "m3"], true);
+    expect($callChatUnread.get()).toBe(0);
+
+    // A later message arriving while unfocused only counts the new one.
+    syncCallChatUnread(["m1", "m2", "m3", "m4"], false);
+    expect($callChatUnread.get()).toBe(1);
+  });
+
+  test("resets to zero when the call leaves the active phase", () => {
+    $callState.set({
+      phase: "active",
+      peer: "room@muc.waddle.test",
+      sid: "c1",
+      media: { audio: true, video: false },
+      join: { url: "wss://livekit.test", room: "room@muc.waddle.test", identity: "me", token: "jwt" },
+      kind: "muc",
+      selfNick: "me",
+      selfFullJid: "me@waddle.test/browser",
+    });
+    syncCallChatUnread(["m1", "m2"], false);
+    expect($callChatUnread.get()).toBe(2);
+
+    clearCallState();
+    expect($callChatUnread.get()).toBe(0);
+  });
+});

--- a/chat/tests/call-chat-unread.test.ts
+++ b/chat/tests/call-chat-unread.test.ts
@@ -68,6 +68,16 @@ describe("inboundCallChatThreadIds", () => {
     const messages = [{ id: "a", threadId: "call-1", isSelf: false }];
     expect(inboundCallChatThreadIds(messages, null)).toEqual([]);
   });
+
+  test("excludes the call-anchor system row that shares the thread id", () => {
+    // The call anchor (DM: threadId === sid; MUC: the thread root) carries the
+    // same threadId but is a bodyless system card, not a chat message.
+    const messages = [
+      { id: "anchor", threadId: "call-1", isSelf: false, callThread: { kind: "muc" } },
+      { id: "a", threadId: "call-1", isSelf: false },
+    ];
+    expect(inboundCallChatThreadIds(messages, "call-1")).toEqual(["a"]);
+  });
 });
 
 describe("isCallChatTabFocused", () => {

--- a/chat/tests/call-chat-unread.test.ts
+++ b/chat/tests/call-chat-unread.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import {
   $callChatUnread,
   inboundCallChatThreadIds,
+  isCallChatTabFocused,
   nextCallChatUnread,
   resetCallChatUnread,
   syncCallChatUnread,
@@ -66,6 +67,14 @@ describe("inboundCallChatThreadIds", () => {
   test("returns nothing when there is no active call thread", () => {
     const messages = [{ id: "a", threadId: "call-1", isSelf: false }];
     expect(inboundCallChatThreadIds(messages, null)).toEqual([]);
+  });
+});
+
+describe("isCallChatTabFocused", () => {
+  test("is focused only when the dock is open on the Chat tab", () => {
+    expect(isCallChatTabFocused(true, "chat")).toBe(true);
+    expect(isCallChatTabFocused(true, "participants")).toBe(false);
+    expect(isCallChatTabFocused(false, "chat")).toBe(false);
   });
 });
 

--- a/chat/tests/call-controls.test.ts
+++ b/chat/tests/call-controls.test.ts
@@ -707,16 +707,19 @@ describe("call control bar chat toggle", () => {
   });
 
   test("shows an unread badge on the chat button only when there are unread messages", async () => {
+    // The unread count is folded into the button's own aria-label (a nested
+    // badge label would be ignored once the button has an aria-label), and the
+    // visual pill is aria-hidden.
     const withUnread = await renderCallControls({ chatUnread: 5 });
-    expect(withUnread).toContain('aria-label="5 unread messages"');
+    expect(withUnread).toContain('aria-label="Open chat, 5 unread messages"');
     expect(withUnread).toContain(">5<");
 
     const oneUnread = await renderCallControls({ chatUnread: 1 });
-    expect(oneUnread).toContain('aria-label="1 unread message"');
+    expect(oneUnread).toContain('aria-label="Open chat, 1 unread message"');
     expect(oneUnread).not.toContain("1 unread messages");
 
     const noUnread = await renderCallControls({ chatUnread: 0 });
-    expect(noUnread).not.toContain("unread messages");
+    expect(noUnread).not.toContain("unread message");
   });
 
   test("wires the chat toggle emit", () => {

--- a/chat/tests/call-controls.test.ts
+++ b/chat/tests/call-controls.test.ts
@@ -711,6 +711,10 @@ describe("call control bar chat toggle", () => {
     expect(withUnread).toContain('aria-label="5 unread messages"');
     expect(withUnread).toContain(">5<");
 
+    const oneUnread = await renderCallControls({ chatUnread: 1 });
+    expect(oneUnread).toContain('aria-label="1 unread message"');
+    expect(oneUnread).not.toContain("1 unread messages");
+
     const noUnread = await renderCallControls({ chatUnread: 0 });
     expect(noUnread).not.toContain("unread messages");
   });

--- a/chat/tests/call-controls.test.ts
+++ b/chat/tests/call-controls.test.ts
@@ -692,6 +692,40 @@ describe("call control bar participants toggle", () => {
   });
 });
 
+describe("call control bar chat toggle", () => {
+  test("renders an accessible chat button reflecting the closed dock state", async () => {
+    const html = await renderCallControls({ chatOpen: false });
+
+    expect(html).toContain('aria-label="Open chat"');
+  });
+
+  test("reflects the open Chat tab state on the chat button", async () => {
+    const html = await renderCallControls({ chatOpen: true });
+
+    expect(html).toContain('aria-label="Close chat"');
+    expect(html).toMatch(/aria-label="Close chat"[^>]*aria-pressed="true"/);
+  });
+
+  test("shows an unread badge on the chat button only when there are unread messages", async () => {
+    const withUnread = await renderCallControls({ chatUnread: 5 });
+    expect(withUnread).toContain('aria-label="5 unread messages"');
+    expect(withUnread).toContain(">5<");
+
+    const noUnread = await renderCallControls({ chatUnread: 0 });
+    expect(noUnread).not.toContain("unread messages");
+  });
+
+  test("wires the chat toggle emit", () => {
+    const source = readFileSync(
+      new URL("../src/components/calls/CallControls.vue", import.meta.url),
+      "utf8",
+    );
+    expect(source).toContain("toggleChat");
+    expect(source).toContain("chatOpen");
+    expect(source).toContain("chatUnread");
+  });
+});
+
 async function renderCallControls(overrides: Record<string, unknown>): Promise<string> {
   const component = await loadVueComponent("../src/components/calls/CallControls.vue");
   const props = {
@@ -702,6 +736,8 @@ async function renderCallControls(overrides: Record<string, unknown>): Promise<s
     isExpanded: false,
     participantsOpen: false,
     participantCount: 0,
+    chatOpen: false,
+    chatUnread: 0,
     viewMode: "gallery",
     ...overrides,
   };

--- a/chat/tests/call-dock-state.test.ts
+++ b/chat/tests/call-dock-state.test.ts
@@ -1,15 +1,20 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
   $callDockOpen,
+  $callDockTab,
   closeCallDock,
   openCallDock,
+  setCallDockTab,
+  toggleCallChat,
   toggleCallDock,
+  toggleCallParticipants,
 } from "../src/lib/calls/call-dock-state";
 import { $callState, clearCallState } from "../src/lib/calls/call-store";
 
 afterEach(() => {
   clearCallState();
   closeCallDock();
+  setCallDockTab("participants");
 });
 
 describe("call dock state", () => {
@@ -45,5 +50,46 @@ describe("call dock state", () => {
 
     clearCallState();
     expect($callDockOpen.get()).toBe(false);
+  });
+});
+
+describe("call dock tab", () => {
+  test("defaults to the participants tab", () => {
+    expect($callDockTab.get()).toBe("participants");
+  });
+
+  test("toggleCallChat opens the dock on Chat, switches to it, then closes on repeat", () => {
+    // Closed → opens straight to the Chat tab.
+    toggleCallChat();
+    expect($callDockOpen.get()).toBe(true);
+    expect($callDockTab.get()).toBe("chat");
+
+    // Already open on Chat → closes the dock.
+    toggleCallChat();
+    expect($callDockOpen.get()).toBe(false);
+
+    // Open on Participants → switches to Chat without closing.
+    toggleCallParticipants();
+    expect($callDockTab.get()).toBe("participants");
+    toggleCallChat();
+    expect($callDockOpen.get()).toBe(true);
+    expect($callDockTab.get()).toBe("chat");
+  });
+
+  test("toggleCallParticipants mirrors the behaviour for the Participants tab", () => {
+    toggleCallParticipants();
+    expect($callDockOpen.get()).toBe(true);
+    expect($callDockTab.get()).toBe("participants");
+
+    toggleCallParticipants();
+    expect($callDockOpen.get()).toBe(false);
+  });
+
+  test("resets to the participants tab when the call ends", () => {
+    setCallDockTab("chat");
+    expect($callDockTab.get()).toBe("chat");
+
+    clearCallState();
+    expect($callDockTab.get()).toBe("participants");
   });
 });

--- a/chat/tests/call-dock-state.test.ts
+++ b/chat/tests/call-dock-state.test.ts
@@ -6,7 +6,6 @@ import {
   openCallDock,
   setCallDockTab,
   toggleCallChat,
-  toggleCallDock,
   toggleCallParticipants,
 } from "../src/lib/calls/call-dock-state";
 import { $callState, clearCallState } from "../src/lib/calls/call-store";
@@ -18,16 +17,10 @@ afterEach(() => {
 });
 
 describe("call dock state", () => {
-  test("defaults to closed; open/close/toggle mutate it", () => {
+  test("defaults to closed; open/close mutate it", () => {
     expect($callDockOpen.get()).toBe(false);
 
     openCallDock();
-    expect($callDockOpen.get()).toBe(true);
-
-    toggleCallDock();
-    expect($callDockOpen.get()).toBe(false);
-
-    toggleCallDock();
     expect($callDockOpen.get()).toBe(true);
 
     closeCallDock();

--- a/chat/tests/call-dock-wiring.test.ts
+++ b/chat/tests/call-dock-wiring.test.ts
@@ -110,9 +110,11 @@ describe("call surfaces use the Participants dock", () => {
     expect(source).toContain(":active-tab");
     expect(source).toContain(":chat-unread");
     expect(source).toContain("@set-tab");
-    // The Chat panel is projected into the dock's chat slot.
+    // The Chat panel is projected into the dock's chat slot, and told when it's
+    // the visible tab so it can re-pin to the newest message.
     expect(source).toContain("<CallChatPanel");
     expect(source).toContain("#chat");
+    expect(source).toContain(":visible=\"chatOpen\"");
   });
 
   test("Expanded wires the control-bar Chat toggle and drops the footer composer", () => {

--- a/chat/tests/call-dock-wiring.test.ts
+++ b/chat/tests/call-dock-wiring.test.ts
@@ -56,7 +56,6 @@ describe("ContentArea feeds the in-call Chat tab", () => {
     expect(source).toContain("callChatMessages");
     expect(source).toContain(":call-chat-messages=\"callChatMessages\"");
     expect(source).toContain(":avatar-url-by-author=\"avatarUrlByAuthor\"");
-    expect(source).toContain(":current-user=\"currentUser\"");
   });
 
   test("drives the unread sync from inbound call-thread messages and Chat-tab focus", () => {

--- a/chat/tests/call-dock-wiring.test.ts
+++ b/chat/tests/call-dock-wiring.test.ts
@@ -21,6 +21,8 @@ describe("CallControls participants toggle", () => {
         isExpanded: true,
         participantsOpen: false,
         participantCount: 3,
+        chatOpen: false,
+        chatUnread: 0,
         viewMode: "gallery",
       },
       import.meta.url,
@@ -58,14 +60,44 @@ describe("call surfaces use the Participants dock", () => {
     expect(source).toContain("@toggle-participants");
   });
 
+  test("Split's Chat button bumps to Expanded with the Chat tab open and shows unread", () => {
+    const source = surfaceSource("CallSplitContainer.vue");
+    expect(source).toContain('setCallDockTab("chat")');
+    expect(source).toContain("@toggle-chat");
+    // The unread badge rides along even in Split so it's visible before expanding.
+    expect(source).toContain("$callChatUnread");
+    expect(source).toContain(":chat-unread");
+  });
+
   test("Expanded toggles the dock, renders it gated on open, and reflows the stage", () => {
     const source = surfaceSource("CallExpandedSurface.vue");
     expect(source).toContain("$callDockOpen");
-    expect(source).toContain("@toggle-participants=\"toggleCallDock\"");
+    expect(source).toContain("@toggle-participants=\"toggleCallParticipants\"");
     // The dock renders only when open, as a sibling of the grid inside
     // __main (a flex row), so the stage reflows beside it.
     expect(source).toContain("<CallDock");
     expect(source).toContain("v-if=\"dockOpen\"");
+  });
+
+  test("Expanded drives the dock's active tab + chat unread and projects the Chat panel", () => {
+    const source = surfaceSource("CallExpandedSurface.vue");
+    // The dock's selected tab and the chat unread badge are driven from stores.
+    expect(source).toContain("$callDockTab");
+    expect(source).toContain("$callChatUnread");
+    expect(source).toContain(":active-tab");
+    expect(source).toContain(":chat-unread");
+    expect(source).toContain("@set-tab");
+    // The Chat panel is projected into the dock's chat slot.
+    expect(source).toContain("<CallChatPanel");
+    expect(source).toContain("#chat");
+  });
+
+  test("Expanded wires the control-bar Chat toggle and drops the footer composer", () => {
+    const source = surfaceSource("CallExpandedSurface.vue");
+    expect(source).toContain("@toggle-chat=\"toggleCallChat\"");
+    expect(source).toContain(":chat-open");
+    // The standalone footer chat section is gone — chat now lives in the dock.
+    expect(source).not.toContain("call-expanded__chat");
   });
 
   test("Expanded Escape closes the open dock before collapsing the call", () => {

--- a/chat/tests/call-dock-wiring.test.ts
+++ b/chat/tests/call-dock-wiring.test.ts
@@ -43,6 +43,30 @@ describe("CallControls participants toggle", () => {
   });
 });
 
+describe("ContentArea feeds the in-call Chat tab", () => {
+  function contentAreaSource(): string {
+    return readFileSync(
+      new URL("../src/components/chat/ContentArea.vue", import.meta.url),
+      "utf8",
+    );
+  }
+
+  test("passes the call-thread message slice + author maps into the Expanded surface", () => {
+    const source = contentAreaSource();
+    expect(source).toContain("callChatMessages");
+    expect(source).toContain(":call-chat-messages=\"callChatMessages\"");
+    expect(source).toContain(":avatar-url-by-author=\"avatarUrlByAuthor\"");
+    expect(source).toContain(":current-user=\"currentUser\"");
+  });
+
+  test("drives the unread sync from inbound call-thread messages and Chat-tab focus", () => {
+    const source = contentAreaSource();
+    expect(source).toContain("inboundCallChatThreadIds");
+    expect(source).toContain("isCallChatTabFocused");
+    expect(source).toContain("syncCallChatUnread");
+  });
+});
+
 describe("call surfaces use the Participants dock", () => {
   test("both surfaces drive the roster + dock and drop the volume mixer dialog", () => {
     for (const name of ["CallSplitContainer.vue", "CallExpandedSurface.vue"]) {

--- a/chat/tests/call-dock.test.ts
+++ b/chat/tests/call-dock.test.ts
@@ -67,6 +67,15 @@ describe("CallDock", () => {
     expect(withUnread).toContain('aria-label="5 unread messages"');
     expect(withUnread).toContain(">5<");
 
+    const oneUnread = await renderVueComponent(
+      "../src/components/calls/CallDock.vue",
+      { rows: rosterFixture(), activeTab: "participants", chatUnread: 1 },
+      import.meta.url,
+    );
+    // Singular grammar for a single unread message.
+    expect(oneUnread).toContain('aria-label="1 unread message"');
+    expect(oneUnread).not.toContain("1 unread messages");
+
     const noUnread = await renderVueComponent(
       "../src/components/calls/CallDock.vue",
       { rows: rosterFixture(), activeTab: "participants", chatUnread: 0 },

--- a/chat/tests/call-dock.test.ts
+++ b/chat/tests/call-dock.test.ts
@@ -15,36 +15,73 @@ function rosterFixture() {
   });
 }
 
+function dockSource(): string {
+  return readFileSync(
+    new URL("../src/components/calls/CallDock.vue", import.meta.url),
+    "utf8",
+  );
+}
+
 describe("CallDock", () => {
-  test("renders a Participants tab, the embedded roster, and an accessible close control", async () => {
+  test("renders Participants and Chat tabs with the active one selected and the roster embedded", async () => {
     const html = await renderVueComponent(
       "../src/components/calls/CallDock.vue",
-      { rows: rosterFixture() },
+      { rows: rosterFixture(), activeTab: "participants", chatUnread: 0 },
       import.meta.url,
     );
 
     expect(html).toContain('role="tablist"');
-    expect(html).toContain('role="tab"');
-    expect(html).toContain('aria-selected="true"');
-    // The tab and its panel are associated both ways for screen readers.
+    // Both tabs and both panels exist and are associated for screen readers.
     expect(html).toContain('id="call-dock-tab-participants"');
-    expect(html).toContain('role="tabpanel"');
+    expect(html).toContain('id="call-dock-tab-chat"');
     expect(html).toContain('aria-labelledby="call-dock-tab-participants"');
+    expect(html).toContain('aria-labelledby="call-dock-tab-chat"');
     expect(html).toContain("Participants");
+    expect(html).toContain("Chat");
+    // The Participants tab is the selected one; Chat is not.
+    expect(html).toMatch(/id="call-dock-tab-participants"[^>]*aria-selected="true"/);
+    expect(html).toMatch(/id="call-dock-tab-chat"[^>]*aria-selected="false"/);
     // The roster panel is embedded for real (not stubbed).
     expect(html).toContain("You");
     expect(html).toContain("alice");
-    expect(html).toContain('aria-label="Close participants"');
+    expect(html).toContain('aria-label="Close dock"');
   });
 
-  test("forwards the panel's volume events and exposes a close emit", () => {
-    const source = readFileSync(
-      new URL("../src/components/calls/CallDock.vue", import.meta.url),
-      "utf8",
+  test("selects the Chat tab when it is the active tab", async () => {
+    const html = await renderVueComponent(
+      "../src/components/calls/CallDock.vue",
+      { rows: rosterFixture(), activeTab: "chat", chatUnread: 0 },
+      import.meta.url,
     );
+
+    expect(html).toMatch(/id="call-dock-tab-chat"[^>]*aria-selected="true"/);
+    expect(html).toMatch(/id="call-dock-tab-participants"[^>]*aria-selected="false"/);
+  });
+
+  test("shows an unread badge on the Chat tab only when there are unread messages", async () => {
+    const withUnread = await renderVueComponent(
+      "../src/components/calls/CallDock.vue",
+      { rows: rosterFixture(), activeTab: "participants", chatUnread: 5 },
+      import.meta.url,
+    );
+    expect(withUnread).toContain('aria-label="5 unread messages"');
+    expect(withUnread).toContain(">5<");
+
+    const noUnread = await renderVueComponent(
+      "../src/components/calls/CallDock.vue",
+      { rows: rosterFixture(), activeTab: "participants", chatUnread: 0 },
+      import.meta.url,
+    );
+    expect(noUnread).not.toContain("unread messages");
+  });
+
+  test("forwards roster events, emits tab selection + close, and projects chat via a slot", () => {
+    const source = dockSource();
     expect(source).toContain("CallParticipantsPanel");
     expect(source).toContain("@set-volume");
     expect(source).toContain("@reset-all");
     expect(source).toContain("emit('close')");
+    expect(source).toContain("emit('setTab'");
+    expect(source).toContain('name="chat"');
   });
 });


### PR DESCRIPTION
Closes #1026. Part of the Zoom-parity epic #1017.

## What

Moves the in-call chat out of the Expanded footer composer into a **Chat** tab inside the shared in-call **Dock**, alongside the existing **Participants** tab (#1019). Adds an **unread badge** on the Chat tab (and the control-bar Chat button) and a **control-bar Chat toggle** that opens the dock straight to the Chat tab. The Chat tab shows the call's XEP-0201 thread messages plus the composer, so you can read and reply without leaving the call view.

Because the Dock is the shared component both surfaces mount, the Chat tab is built into `CallDock` and will work in the **Immersive** surface as soon as that lands (#1028). Verified here on **Expanded** (the only surface that renders the dock today).

## Acceptance criteria

- [x] In-call chat is available as a Chat tab in the dock, replacing the Expanded footer composer.
- [x] The Chat tab shows an unread badge when new messages arrive while it is not focused.
- [x] The control-bar Chat button toggles the dock to the Chat tab.
- [x] Works in both Expanded and Immersive surfaces (Chat tab built into the shared Dock; the Immersive surface itself is #1028).

## Design

- **`call-chat-unread.ts`** (new) — pure `nextCallChatUnread` reducer + `inboundCallChatThreadIds` selector + `isCallChatTabFocused` rule, behind a thin `$callChatUnread` store. Inbound (non-self) call-thread messages accumulate while the Chat tab isn't the focused dock tab; opening the tab advances the watermark and clears the badge. Resets on call end.
- **`call-dock-state.ts`** — adds `$callDockTab` (`participants` | `chat`) and `toggleCallParticipants()` / `toggleCallChat()` helpers (open straight to a tab, switch without closing, close on repeat). Removes the now-dead `toggleCallDock`. Tab resets to Participants on call end.
- **`CallDock.vue`** — two-tab tablist driven by an `activeTab` prop with a `setTab` emit, roving-tabindex arrow-key nav, an unread badge on the Chat tab, and a `#chat` slot so the dock stays stateless.
- **`CallChatPanel.vue`** (new) — presentational call-thread message list (avatar + author + time + `MessageBody`) + the moved composer, with an empty state and near-bottom autoscroll (re-pins to the newest message when the tab becomes visible).
- **`CallControls.vue`** — adds a Chat toggle (pressed state + unread badge, `toggleChat` emit); `participantsOpen`/`chatOpen` now reflect which tab the open dock is on.
- **`CallExpandedSurface.vue`** — drops the footer chat section, projects `CallChatPanel` into the dock's `#chat` slot, drives the dock's active tab + unread from stores, and wires the Chat toggle + Escape.
- **`CallSplitContainer.vue`** — the Chat button bumps Split to Expanded with the Chat tab open and shows the unread badge.
- **`ContentArea.vue`** — feeds the call-thread message slice + author maps into the surface and drives the unread sync.

## Tests

TDD throughout (red → green per slice). New/updated suites: `call-chat-unread`, `call-dock-state`, `call-dock`, `call-controls`, `call-chat-panel`, `call-dock-wiring`, `call-chat-composer`. `bun test` green (one pre-existing, unrelated `startup-loading` failure that needs a prior `bun run build`); `bunx knip` clean; `astro check` clean for the changed files. Reviewed by three adversarial passes; all findings fixed.

## Follow-up for #1028 (Immersive)

The call-thread message slice and unread sync currently live in `ContentArea` keyed to the viewed conversation. This is coherent today because a call surface only renders while viewing the call's own conversation. An Immersive surface floating over a *different* conversation will need call-chat message sourcing hoisted out of per-conversation `ContentArea` into a call-scoped store — tracked for #1028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)