### PR TITLE
fix(chat): preserve extension command channel context

### DIFF
--- a/chat/src/channels/extension-launcher.ts
+++ b/chat/src/channels/extension-launcher.ts
@@ -30,7 +30,7 @@ export function useExtensionLauncher(input: {
   const state = ref<ExtensionLauncherState>("idle");
   const detail = ref("");
   const commandStates = ref<Record<string, { state: ExtensionCommandUiState; detail?: string }>>({});
-  const commandForms = ref<Record<string, { sessionId: string; fields: ExtensionCommandFormField[]; actions?: ExtensionCommandAction[] }>>({});
+  const commandForms = ref<Record<string, { sessionId: string; fields: ExtensionCommandFormField[]; actions?: ExtensionCommandAction[]; roomJid?: string }>>({});
   const commandActions = ref<Record<string, ExtensionAnnotationAction[]>>({});
   const availableCommands = computed(() =>
     input.roomJid.value
@@ -52,7 +52,7 @@ export function useExtensionLauncher(input: {
     commandActions.value = nextActions;
   }
 
-  function storeResultSurfaces(key: string, result: ExtensionCommandResult) {
+  function storeResultSurfaces(key: string, result: ExtensionCommandResult, options: { roomJid?: string } = {}) {
     let foundActions = false;
     if (result.form) {
       const actions = parseExtensionCommandLaunches(result.form);
@@ -75,6 +75,7 @@ export function useExtensionLauncher(input: {
           [key]: {
             sessionId: result.sessionId,
             fields,
+            ...(options.roomJid ? { roomJid: options.roomJid } : {}),
             ...(result.actions?.allowed.length ? { actions: result.actions.allowed } : {}),
           },
         };
@@ -88,6 +89,20 @@ export function useExtensionLauncher(input: {
 
   let discoveryPromise: Promise<void> | null = null;
   let discoveryAttempted = false;
+  let discoveryGeneration = 0;
+  let commandGeneration = 0;
+
+  function commandContext() {
+    return {
+      generation: commandGeneration,
+      roomJid: input.roomJid.value ?? undefined,
+    };
+  }
+
+  function isCurrentCommandContext(context: { generation: number }) {
+    return context.generation === commandGeneration;
+  }
+
   async function ensureDiscovered() {
     if (commands.value.length > 0 || discoveryAttempted) return;
     if (discoveryPromise) {
@@ -98,17 +113,21 @@ export function useExtensionLauncher(input: {
     if (!client) return;
     state.value = "loading";
     detail.value = "";
+    const generation = discoveryGeneration;
     discoveryPromise = (async () => {
       try {
-        commands.value = await client.discoverExtensionCommands();
-        discoveryAttempted = true;
+        const discovered = await client.discoverExtensionCommands();
+        if (generation !== discoveryGeneration) return;
+        commands.value = discovered;
+        discoveryAttempted = commands.value.length > 0;
         state.value = "idle";
         if (commands.value.length === 0) detail.value = "No extension commands discovered.";
       } catch (error) {
+        if (generation !== discoveryGeneration) return;
         state.value = "error";
         detail.value = error instanceof Error ? error.message : "Could not discover extension commands.";
       } finally {
-        discoveryPromise = null;
+        if (generation === discoveryGeneration) discoveryPromise = null;
       }
     })();
     await discoveryPromise;
@@ -131,13 +150,16 @@ export function useExtensionLauncher(input: {
     const client = input.xmppClient.value;
     if (!client) return;
     const key = command.node;
+    const context = commandContext();
     clearCommandSurfaces(key);
     commandStates.value = { ...commandStates.value, [key]: { state: "loading" } };
     try {
-      const result = await client.invokeExtensionCommand(command);
-      storeResultSurfaces(key, result);
+      const result = await client.invokeExtensionCommand(command, context.roomJid);
+      if (!isCurrentCommandContext(context)) return;
+      storeResultSurfaces(key, result, { roomJid: context.roomJid });
       commandStates.value = { ...commandStates.value, [key]: extensionCommandOutcome(result) };
     } catch (error) {
+      if (!isCurrentCommandContext(context)) return;
       commandStates.value = {
         ...commandStates.value,
         [key]: { state: "error", detail: error instanceof Error ? error.message : "Extension command failed." },
@@ -161,37 +183,50 @@ export function useExtensionLauncher(input: {
     };
   }
 
-  function reset() {
+  function reset(options: { clearCommands?: boolean } = {}) {
+    commandGeneration += 1;
     open.value = false;
-    commands.value = [];
     state.value = "idle";
     detail.value = "";
     commandStates.value = {};
     commandForms.value = {};
     commandActions.value = {};
-    discoveryAttempted = false;
+    if (options.clearCommands) {
+      discoveryGeneration += 1;
+      discoveryPromise = null;
+      commands.value = [];
+      discoveryAttempted = false;
+    }
   }
 
   async function submitForm(
     command: DiscoveredExtensionCommand,
     action: ExtensionCommandAction = "complete",
-    options: { skipPublicPrompt?: boolean } = {},
+    options: { skipPublicPrompt?: boolean; roomJid?: string; generation?: number } = {},
   ): Promise<boolean> {
     const client = input.xmppClient.value;
     if (!client) return false;
     const key = command.node;
     const form = commandForms.value[key];
     if (!form) return false;
+    const context = {
+      generation: options.generation ?? commandGeneration,
+      roomJid: options.roomJid ?? form.roomJid,
+    };
     commandStates.value = { ...commandStates.value, [key]: { state: "loading" } };
     try {
       if (!options.skipPublicPrompt) {
-        await sendPublicPromptIfRequested(command, form.fields, action);
+        if (!isCurrentCommandContext(context)) return false;
+        await sendPublicPromptIfRequested(command, form.fields, action, context.roomJid);
       }
-      const result = await client.submitExtensionCommandForm(command, form.sessionId, form.fields, action, input.roomJid.value ?? undefined);
-      storeResultSurfaces(key, result);
+      if (!isCurrentCommandContext(context)) return false;
+      const result = await client.submitExtensionCommandForm(command, form.sessionId, form.fields, action, context.roomJid);
+      if (!isCurrentCommandContext(context)) return false;
+      storeResultSurfaces(key, result, { roomJid: context.roomJid });
       commandStates.value = { ...commandStates.value, [key]: extensionCommandOutcome(result) };
       return true;
     } catch (error) {
+      if (!isCurrentCommandContext(context)) return false;
       commandStates.value = {
         ...commandStates.value,
         [key]: { state: "error", detail: error instanceof Error ? error.message : "Extension form submission failed." },
@@ -212,6 +247,7 @@ export function useExtensionLauncher(input: {
     const command = invocation.command;
     const key = command.node;
     const wantsPalette = invocation.kind === "open-palette";
+    const context = commandContext();
 
     clearCommandSurfaces(key);
     commandStates.value = { ...commandStates.value, [key]: { state: "loading" } };
@@ -221,8 +257,9 @@ export function useExtensionLauncher(input: {
     }
 
     try {
-      const result = await client.invokeExtensionCommand(command);
-      storeResultSurfaces(key, result);
+      const result = await client.invokeExtensionCommand(command, context.roomJid);
+      if (!isCurrentCommandContext(context)) return false;
+      storeResultSurfaces(key, result, { roomJid: context.roomJid });
       const form = commandForms.value[key];
 
       if (invocation.kind === "open-palette") {
@@ -242,8 +279,8 @@ export function useExtensionLauncher(input: {
       const allowed = form?.actions ?? [];
       if (form && allowed.includes("complete")) {
         updateField(key, invocation.fieldName, [invocation.value]);
-        forceChannelOutputForSlashAi(command);
-        return await submitForm(command, "complete");
+        forceChannelOutputForSlashAi(command, context.roomJid);
+        return await submitForm(command, "complete", { roomJid: context.roomJid, generation: context.generation });
       }
 
       commandStates.value = { ...commandStates.value, [key]: extensionCommandOutcome(result) };
@@ -254,6 +291,7 @@ export function useExtensionLauncher(input: {
       }
       return true;
     } catch (error) {
+      if (!isCurrentCommandContext(context)) return false;
       commandStates.value = {
         ...commandStates.value,
         [key]: { state: "error", detail: error instanceof Error ? error.message : "Extension command failed." },
@@ -266,11 +304,12 @@ export function useExtensionLauncher(input: {
     command: DiscoveredExtensionCommand,
     fields: ExtensionCommandFormField[],
     action: ExtensionCommandAction,
+    roomJid?: string,
   ) {
     if (command.node !== AI_CHATBOT_COMMAND_NODE) return;
     if (action === "cancel" || action === "prev") return;
     if (formFieldValue(fields, "output") !== "channel") return;
-    if (!input.roomJid.value) return;
+    if (!roomJid) return;
     const prompt = formFieldValue(fields, "prompt")?.trim();
     if (!prompt) return;
     const sendPublicChannelMessage = input.sendPublicChannelMessage?.value;
@@ -280,8 +319,8 @@ export function useExtensionLauncher(input: {
     await sendPublicChannelMessage(prompt);
   }
 
-  function forceChannelOutputForSlashAi(command: DiscoveredExtensionCommand) {
-    if (!input.roomJid.value || command.node !== AI_CHATBOT_COMMAND_NODE) return;
+  function forceChannelOutputForSlashAi(command: DiscoveredExtensionCommand, roomJid?: string) {
+    if (!roomJid || command.node !== AI_CHATBOT_COMMAND_NODE) return;
     const form = commandForms.value[command.node];
     const output = form?.fields.find((field) => field.name === "output");
     if (!output) return;
@@ -302,12 +341,15 @@ export function useExtensionLauncher(input: {
     const invokeExtensionAction = input.invokeExtensionAction.value;
     if (!invokeExtensionAction) return;
     const key = command.node;
+    const context = commandContext();
     commandStates.value = { ...commandStates.value, [key]: { state: "loading" } };
     try {
       const result = await invokeExtensionAction(action);
-      storeResultSurfaces(key, result);
+      if (!isCurrentCommandContext(context)) return;
+      storeResultSurfaces(key, result, { roomJid: context.roomJid });
       commandStates.value = { ...commandStates.value, [key]: extensionCommandOutcome(result) };
     } catch (error) {
+      if (!isCurrentCommandContext(context)) return;
       commandStates.value = {
         ...commandStates.value,
         [key]: { state: "error", detail: error instanceof Error ? error.message : "Extension action failed." },

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -456,7 +456,8 @@ const activeCallThreadId = computed(() =>
 
 watch(
   () => props.xmppClient,
-  (client) => {
+  (client, previousClient) => {
+    if (client !== previousClient) resetExtensionLauncherState({ clearCommands: true });
     if (client) void extensionLauncher.ensureDiscovered();
   },
   { immediate: true },
@@ -756,6 +757,7 @@ watch(conversationScope, () => {
   clearReplyJumpNotice();
   clearReconnectedNotice();
   resetExtensionLauncherState();
+  if (props.xmppClient) void extensionLauncher.ensureDiscovered();
   forumTitle.value = "";
 });
 

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -2115,7 +2115,7 @@ export class BrowserXmppClient {
   async discoverExtensionCommands(): Promise<DiscoveredExtensionCommand[]> { const xmpp = await this.requireConnectedXmpp(); return discoverExtensionCommands(xmpp as WasmClient, this.session.jid); }
   async discoverExtensionRoutes(): Promise<DiscoveredExtensionRoute[]> { const xmpp = await this.requireConnectedXmpp(); return discoverExtensionRoutes(xmpp as WasmClient, this.session.jid); }
   async fetchExtensionRouteItems(route: DiscoveredExtensionRoute, roomJid: string): Promise<ExtensionRouteItem[]> { const xmpp = await this.requireConnectedXmpp(); return fetchExtensionRouteItems(xmpp as WasmClient, route, roomJid); }
-  async invokeExtensionCommand(command: DiscoveredExtensionCommand): Promise<ExtensionCommandResult> { const xmpp = await this.requireConnectedXmpp(); return invokeExtensionCommand(xmpp as WasmClient, this.session.jid, command); }
+  async invokeExtensionCommand(command: DiscoveredExtensionCommand, roomJid?: string): Promise<ExtensionCommandResult> { const xmpp = await this.requireConnectedXmpp(); return invokeExtensionCommand(xmpp as WasmClient, this.session.jid, command, roomJid); }
   async submitExtensionCommandForm(command: DiscoveredExtensionCommand, sessionId: string, fields: ExtensionCommandFormField[], action?: ExtensionCommandAction, roomJid?: string): Promise<ExtensionCommandResult> { const xmpp = await this.requireConnectedXmpp(); return submitExtensionCommandForm(xmpp as WasmClient, command, sessionId, fields, action, roomJid); }
 
   async enablePushNotifications(opts: { serviceJid: string; node: string }): Promise<boolean> {

--- a/chat/src/lib/xmpp/extension-commands/invoke.ts
+++ b/chat/src/lib/xmpp/extension-commands/invoke.ts
@@ -30,10 +30,12 @@ export async function invokeExtensionCommand(
   xmpp: XmppSendIq,
   userJid: string,
   command: DiscoveredExtensionCommand,
+  roomJid?: string,
 ): Promise<ExtensionCommandResult> {
   const sendRawIq = requireRawIq(xmpp);
   const serviceJid = command.serviceJid || await discoverExtensionCommandService(xmpp, userJid);
-  const responseXml = await sendRawIq(buildCommandIqXml(serviceJid, command.node, "execute"));
+  const fields: DataFormField[] = roomJid ? [{ name: "waddle#room_jid", value: roomJid }] : [];
+  const responseXml = await sendRawIq(buildCommandIqXml(serviceJid, command.node, "execute", fields));
   return parseCommandIqResponse(responseXml);
 }
 

--- a/chat/tests/extension-command.test.ts
+++ b/chat/tests/extension-command.test.ts
@@ -284,6 +284,29 @@ describe("extension command invocation", () => {
     expect(sent).not.toContain('jabber:x:data');
   });
 
+  test("adds active room context to initial XEP-0050 execute requests", async () => {
+    let sent = "";
+    const xmpp = {
+      async send_raw_iq(xml: string) {
+        sent = xml;
+        return `<iq type="result"><command xmlns="http://jabber.org/protocol/commands" status="completed" /></iq>`;
+      },
+    };
+
+    await invokeExtensionCommand(
+      xmpp as any,
+      "alice@example.com/web",
+      { serviceJid: "extensions.example.com", node: "urn:waddle:extension:1:stargate-quotes", name: "/stargate" },
+      "pub@muc.example.com",
+    );
+
+    expect(sent).toContain('type="set"');
+    expect(sent).toContain('node="urn:waddle:extension:1:stargate-quotes"');
+    expect(sent).toContain('action="execute"');
+    expect(sent).toContain('<x xmlns="jabber:x:data" type="submit">');
+    expect(sent).toContain('<field var="waddle#room_jid"><value>pub@muc.example.com</value></field>');
+  });
+
   test("returns discovered commands from the extension service", async () => {
     const xmpp = {
       async send_raw_iq(xml: string) {

--- a/chat/tests/extension-launcher-slash.test.ts
+++ b/chat/tests/extension-launcher-slash.test.ts
@@ -35,11 +35,24 @@ const genericCommand: DiscoveredExtensionCommand = {
   inlineField: "prompt",
 };
 
+const stargateCommand: DiscoveredExtensionCommand = {
+  serviceJid: "extensions.example.com",
+  node: "urn:waddle:extension:1:stargate-quotes",
+  name: "/stargate",
+  scope: "channel",
+  composerPrefix: "stargate",
+};
+
 interface SubmitCall {
   command: DiscoveredExtensionCommand;
   sessionId: string;
   fields: ExtensionCommandFormField[];
   action?: ExtensionCommandAction;
+  roomJid?: string;
+}
+
+interface InvokeCall {
+  command: DiscoveredExtensionCommand;
   roomJid?: string;
 }
 
@@ -81,17 +94,18 @@ function executingResult(fields: ExtensionCommandFormField[], allowed: Extension
 function fakeClient(executeResults: ExtensionCommandResult[], options: {
   events?: string[] | undefined;
   submitError?: Error | undefined;
+  discoveredCommands?: DiscoveredExtensionCommand[] | undefined;
 } = {}): {
   client: Ref<unknown>;
   submitCalls: SubmitCall[];
-  invokeCalls: DiscoveredExtensionCommand[];
+  invokeCalls: InvokeCall[];
 } {
   const submitCalls: SubmitCall[] = [];
-  const invokeCalls: DiscoveredExtensionCommand[] = [];
+  const invokeCalls: InvokeCall[] = [];
   const queue = [...executeResults];
   const fake = {
-    async invokeExtensionCommand(command: DiscoveredExtensionCommand): Promise<ExtensionCommandResult> {
-      invokeCalls.push(command);
+    async invokeExtensionCommand(command: DiscoveredExtensionCommand, roomJid?: string): Promise<ExtensionCommandResult> {
+      invokeCalls.push({ command, roomJid });
       return queue.shift() ?? { status: "completed", notes: [] };
     },
     async submitExtensionCommandForm(
@@ -107,7 +121,7 @@ function fakeClient(executeResults: ExtensionCommandResult[], options: {
       return { status: "completed", notes: [] };
     },
     async discoverExtensionCommands(): Promise<DiscoveredExtensionCommand[]> {
-      return [];
+      return options.discoveredCommands ?? [];
     },
   };
   return { client: ref(fake), submitCalls, invokeCalls };
@@ -120,21 +134,24 @@ function createLauncher(
     sendPublicChannelMessage?: (body: string) => Promise<void>;
     events?: string[] | undefined;
     submitError?: Error | undefined;
+    discoveredCommands?: DiscoveredExtensionCommand[] | undefined;
   } = {},
 ) {
+  const roomJid = ref(options.roomJid ?? null);
   const fake = fakeClient(executeResults, {
     events: options.events,
     submitError: options.submitError,
+    discoveredCommands: options.discoveredCommands,
   });
   const launcher = useExtensionLauncher({
     xmppClient: fake.client as never,
-    roomJid: ref(options.roomJid ?? null),
+    roomJid,
     invokeExtensionAction: ref(undefined),
     sendPublicChannelMessage: ref(options.sendPublicChannelMessage),
     focusPalette: () => {},
     focusComposerExtensions: () => {},
   });
-  return { ...fake, launcher };
+  return { ...fake, launcher, roomJid };
 }
 
 describe("dispatchSlashInvocation: inline-submit", () => {
@@ -152,7 +169,7 @@ describe("dispatchSlashInvocation: inline-submit", () => {
     const ok = await launcher.dispatchSlashInvocation(invocation);
 
     expect(ok).toBe(true);
-    expect(invokeCalls).toEqual([aiCommand]);
+    expect(invokeCalls).toEqual([{ command: aiCommand, roomJid: undefined }]);
     expect(submitCalls).toHaveLength(1);
     expect(submitCalls[0].action).toBe("complete");
     expect(submitCalls[0].fields.find((f) => f.name === "prompt")?.values).toEqual([
@@ -162,7 +179,7 @@ describe("dispatchSlashInvocation: inline-submit", () => {
   });
 
   test("passes the active room into XEP-0050 inline command submissions", async () => {
-    const { launcher, submitCalls } = createLauncher([
+    const { launcher, submitCalls, invokeCalls } = createLauncher([
       executingResult([field("prompt", { required: true })], ["complete", "cancel"]),
     ], { roomJid: "pub@muc.example.com" });
 
@@ -173,6 +190,7 @@ describe("dispatchSlashInvocation: inline-submit", () => {
       value: "tell the room",
     });
 
+    expect(invokeCalls[0]).toEqual({ command: aiCommand, roomJid: "pub@muc.example.com" });
     expect(submitCalls).toHaveLength(1);
     expect(submitCalls[0].roomJid).toBe("pub@muc.example.com");
   });
@@ -368,6 +386,22 @@ describe("dispatchSlashInvocation: inline-submit", () => {
 });
 
 describe("dispatchSlashInvocation: open-palette", () => {
+  test("passes the active room into initial execute for single-stage channel commands", async () => {
+    const { launcher, invokeCalls, submitCalls } = createLauncher([
+      { status: "completed", notes: [] },
+    ], { roomJid: "pub@muc.example.com" });
+
+    const ok = await launcher.dispatchSlashInvocation({
+      kind: "open-palette",
+      command: stargateCommand,
+    });
+
+    expect(ok).toBe(true);
+    expect(invokeCalls).toEqual([{ command: stargateCommand, roomJid: "pub@muc.example.com" }]);
+    expect(submitCalls).toEqual([]);
+    expect(launcher.commandStates.value[stargateCommand.node]?.state).toBe("success");
+  });
+
   test("opens the palette and prefills the first required visible field", async () => {
     const { launcher, submitCalls } = createLauncher([
       executingResult([
@@ -419,7 +453,168 @@ describe("dispatchSlashInvocation: open-palette", () => {
   });
 });
 
+describe("invokeCommand", () => {
+  test("passes the active room into direct palette command execution", async () => {
+    const { launcher, invokeCalls } = createLauncher([
+      { status: "completed", notes: [] },
+    ], { roomJid: "pub@muc.example.com" });
+
+    await launcher.invokeCommand(stargateCommand);
+
+    expect(invokeCalls).toEqual([{ command: stargateCommand, roomJid: "pub@muc.example.com" }]);
+    expect(launcher.commandStates.value[stargateCommand.node]?.state).toBe("success");
+  });
+
+  test("ignores pending command execution results after a conversation reset", async () => {
+    let resolveInvoke: ((result: ExtensionCommandResult) => void) | null = null;
+    const invokeCalls: InvokeCall[] = [];
+    const fake = {
+      async invokeExtensionCommand(command: DiscoveredExtensionCommand, roomJid?: string): Promise<ExtensionCommandResult> {
+        invokeCalls.push({ command, roomJid });
+        return new Promise((resolve) => {
+          resolveInvoke = resolve;
+        });
+      },
+      async submitExtensionCommandForm(): Promise<ExtensionCommandResult> {
+        return { status: "completed", notes: [] };
+      },
+      async discoverExtensionCommands(): Promise<DiscoveredExtensionCommand[]> {
+        return [];
+      },
+    };
+    const launcher = useExtensionLauncher({
+      xmppClient: ref(fake) as never,
+      roomJid: ref("room-a@muc.example.com"),
+      invokeExtensionAction: ref(undefined),
+      focusPalette: () => {},
+      focusComposerExtensions: () => {},
+    });
+
+    const pending = launcher.dispatchSlashInvocation({
+      kind: "open-palette",
+      command: pollCommand,
+    });
+    launcher.reset();
+    resolveInvoke?.(executingResult([field("question", { required: true })]));
+
+    expect(await pending).toBe(false);
+    expect(invokeCalls).toEqual([{ command: pollCommand, roomJid: "room-a@muc.example.com" }]);
+    expect(launcher.commandForms.value).toEqual({});
+    expect(launcher.commandStates.value).toEqual({});
+  });
+});
+
+describe("extension command discovery lifecycle", () => {
+  test("keeps discovered commands across conversation UI resets", async () => {
+    const { launcher } = createLauncher([], {
+      roomJid: "pub@muc.example.com",
+      discoveredCommands: [stargateCommand],
+    });
+
+    await launcher.ensureDiscovered();
+    expect(launcher.commands.value).toEqual([stargateCommand]);
+    expect(launcher.availableCommands.value).toEqual([stargateCommand]);
+
+    launcher.reset();
+
+    expect(launcher.commands.value).toEqual([stargateCommand]);
+    expect(launcher.availableCommands.value).toEqual([stargateCommand]);
+    expect(launcher.open.value).toBe(false);
+    expect(launcher.commandStates.value).toEqual({});
+  });
+
+  test("clears discovered commands when explicitly resetting the session", async () => {
+    const { launcher } = createLauncher([], {
+      discoveredCommands: [stargateCommand],
+    });
+
+    await launcher.ensureDiscovered();
+    launcher.reset({ clearCommands: true });
+
+    expect(launcher.commands.value).toEqual([]);
+  });
+
+  test("retries discovery after an empty result", async () => {
+    const discovered = [
+      [],
+      [stargateCommand],
+    ];
+    const fake = {
+      async discoverExtensionCommands(): Promise<DiscoveredExtensionCommand[]> {
+        return discovered.shift() ?? [];
+      },
+      async invokeExtensionCommand(): Promise<ExtensionCommandResult> {
+        return { status: "completed", notes: [] };
+      },
+      async submitExtensionCommandForm(): Promise<ExtensionCommandResult> {
+        return { status: "completed", notes: [] };
+      },
+    };
+    const launcher = useExtensionLauncher({
+      xmppClient: ref(fake) as never,
+      roomJid: ref("pub@muc.example.com"),
+      invokeExtensionAction: ref(undefined),
+      focusPalette: () => {},
+      focusComposerExtensions: () => {},
+    });
+
+    await launcher.ensureDiscovered();
+    expect(launcher.commands.value).toEqual([]);
+
+    await launcher.ensureDiscovered();
+    expect(launcher.commands.value).toEqual([stargateCommand]);
+    expect(launcher.availableCommands.value).toEqual([stargateCommand]);
+  });
+
+  test("ignores stale discovery results after a session reset", async () => {
+    let resolveDiscovery: ((commands: DiscoveredExtensionCommand[]) => void) | null = null;
+    const fake = {
+      async discoverExtensionCommands(): Promise<DiscoveredExtensionCommand[]> {
+        return new Promise((resolve) => {
+          resolveDiscovery = resolve;
+        });
+      },
+      async invokeExtensionCommand(): Promise<ExtensionCommandResult> {
+        return { status: "completed", notes: [] };
+      },
+      async submitExtensionCommandForm(): Promise<ExtensionCommandResult> {
+        return { status: "completed", notes: [] };
+      },
+    };
+    const launcher = useExtensionLauncher({
+      xmppClient: ref(fake) as never,
+      roomJid: ref("pub@muc.example.com"),
+      invokeExtensionAction: ref(undefined),
+      focusPalette: () => {},
+      focusComposerExtensions: () => {},
+    });
+
+    const pendingDiscovery = launcher.ensureDiscovered();
+    launcher.reset({ clearCommands: true });
+    resolveDiscovery?.([stargateCommand]);
+    await pendingDiscovery;
+
+    expect(launcher.commands.value).toEqual([]);
+    expect(launcher.availableCommands.value).toEqual([]);
+  });
+});
+
 describe("submitForm: public channel output", () => {
+  test("uses the room captured when the command form was opened", async () => {
+    const { launcher, submitCalls, roomJid } = createLauncher([
+      executingResult([field("prompt", { required: true })], ["complete", "cancel"]),
+    ], { roomJid: "room-a@muc.example.com" });
+    await launcher.invokeCommand(aiCommand);
+    roomJid.value = "room-b@muc.example.com";
+    launcher.updateField(aiCommand.node, "prompt", ["stay in room a"]);
+
+    const ok = await launcher.submitForm(aiCommand, "complete", { skipPublicPrompt: true });
+
+    expect(ok).toBe(true);
+    expect(submitCalls).toHaveLength(1);
+    expect(submitCalls[0].roomJid).toBe("room-a@muc.example.com");
+  });
+
   test("posts the user's prompt to the room before submitting the command", async () => {
     const events: string[] = [];
     const { launcher, submitCalls } = createLauncher([


### PR DESCRIPTION
## Summary
- Preserve discovered extension commands across channel/DM conversation UI resets so slash command candidates remain available after joining a chat.
- Send `waddle#room_jid` on the initial XEP-0050 execute request so single-stage channel commands like `/stargate` have active room context.
- Snapshot command room/generation state so delayed command discovery or execution results cannot bleed into a later conversation.

## Plan
- [x] Review relevant XEP-0050/XEP-0030 command discovery behavior in `xeps/`.
- [x] Trace chat command discovery state from channel join through composer command options.
- [x] Trace server-side extension command invocation context and room propagation.
- [x] Patch initial execute and command lifecycle boundaries.
- [x] Add regression coverage for `/stargate`-style single-stage commands, discovery resets, empty discovery retry, stale discovery, and stale command execution.
- [x] Run focused checks, full chat build, full chat tests, lint, and adversarial review.

## Verification
- `bun test tests/extension-launcher-slash.test.ts tests/extension-command.test.ts tests/slash-match.test.ts`
- `bun run build`
- `bun test`
- `bun run lint`

## Review
- XMPP/protocol adversarial review: no actionable issues.
- Chat UI lifecycle adversarial review found stale pending command execution after reset; fixed with command generation/room snapshots.
- Follow-up chat UI lifecycle review: no actionable issues.