### PR TITLE
feat(chat): call stage-header (title/duration/connection) + More overflow (#1020)

### DIFF
--- a/chat/src/components/calls/CallControls.vue
+++ b/chat/src/components/calls/CallControls.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, nextTick, onBeforeUnmount, ref, watch } from "vue";
 import {
   LayoutGrid,
   Maximize2,
@@ -8,6 +8,7 @@ import {
   MicOff,
   Minimize2,
   MonitorUp,
+  MoreHorizontal,
   PhoneOff,
   Settings,
   SquareUser,
@@ -16,15 +17,17 @@ import {
   VideoOff,
 } from "lucide-vue-next";
 import type { CallViewMode } from "@/lib/calls/view-mode";
-import CallConnectionIndicator from "./CallConnectionIndicator.vue";
 
 /**
  * Shared control bar for the in-call surfaces (split + expanded).
- * Stateless: every callback is invoked on the parent, which owns the
- * shared `call-controls` store (mic/cam atoms + toggle functions).
+ * Holds every call action; the only local state is the open/closed flag
+ * of the More ▸ overflow menu — call state stays in the parent's
+ * `call-controls` store (mic/cam atoms + toggle functions).
  *
- * The old multi-mode chrome (dock-toggle, minimize, PIP) is gone —
- * the only mode switch left is split ↔ expanded.
+ * Status read-outs (connection quality, the live timer) live in the
+ * stage-header now, not here, so this bar is actions-only. Less-used
+ * actions (Settings, and future devices/diagnostics entries) live under
+ * the More ▸ overflow to keep the bar uncluttered.
  */
 const props = defineProps<{
   micEnabled: boolean;
@@ -90,6 +93,109 @@ function onViewKeydown(event: KeyboardEvent): void {
   const other = current.nextElementSibling ?? current.previousElementSibling;
   if (other instanceof HTMLElement) other.focus();
 }
+
+/**
+ * More ▸ overflow menu (WAI-ARIA menu-button pattern). The trigger
+ * carries `aria-haspopup="menu"` + `aria-expanded`; the menu is a
+ * `role="menu"` of `menuitem` buttons. Opening focuses the first item;
+ * Escape, an outside click, or selecting an item closes it. Selecting an
+ * item routes focus to whatever it opens (e.g. the settings dialog),
+ * while Escape returns focus to the trigger.
+ */
+const moreOpen = ref(false);
+const moreWrapEl = ref<HTMLElement | null>(null);
+const moreTriggerEl = ref<HTMLButtonElement | null>(null);
+const moreMenuEl = ref<HTMLElement | null>(null);
+
+function menuItems(): HTMLElement[] {
+  const root = moreMenuEl.value;
+  if (!root) return [];
+  return Array.from(root.querySelectorAll<HTMLElement>('[role="menuitem"]'));
+}
+
+async function openMore(focusFirst: boolean): Promise<void> {
+  moreOpen.value = true;
+  if (!focusFirst) return;
+  await nextTick();
+  menuItems()[0]?.focus();
+}
+
+function closeMore(returnFocus: boolean): void {
+  if (!moreOpen.value) return;
+  moreOpen.value = false;
+  if (returnFocus) moreTriggerEl.value?.focus();
+}
+
+function onMoreTriggerKeydown(event: KeyboardEvent): void {
+  if (event.key === "ArrowDown" || event.key === "Enter" || event.key === " ") {
+    event.preventDefault();
+    void openMore(true);
+  } else if (event.key === "ArrowUp") {
+    event.preventDefault();
+    void openMore(true).then(() => menuItems().at(-1)?.focus());
+  } else if (event.key === "Escape") {
+    closeMore(true);
+  }
+}
+
+function onMoreMenuKeydown(event: KeyboardEvent): void {
+  const items = menuItems();
+  if (items.length === 0) return;
+  const index = items.indexOf(document.activeElement as HTMLElement);
+  switch (event.key) {
+    case "Escape":
+      event.preventDefault();
+      closeMore(true);
+      break;
+    case "Tab":
+      // Leaving the menu by Tab dismisses it without stealing focus.
+      closeMore(false);
+      break;
+    case "ArrowDown":
+      event.preventDefault();
+      items[(index + 1) % items.length]?.focus();
+      break;
+    case "ArrowUp":
+      event.preventDefault();
+      items[(index - 1 + items.length) % items.length]?.focus();
+      break;
+    case "Home":
+      event.preventDefault();
+      items[0]?.focus();
+      break;
+    case "End":
+      event.preventDefault();
+      items.at(-1)?.focus();
+      break;
+  }
+}
+
+function selectSettings(): void {
+  emit("openSettings");
+  // Focus moves into the dialog that opens — don't yank it back to the trigger.
+  closeMore(false);
+}
+
+function onDocumentPointerDown(event: PointerEvent): void {
+  const target = event.target as Node | null;
+  if (target && moreWrapEl.value?.contains(target)) return;
+  closeMore(false);
+}
+
+watch(moreOpen, (open) => {
+  if (typeof document === "undefined") return;
+  if (open) {
+    document.addEventListener("pointerdown", onDocumentPointerDown, true);
+  } else {
+    document.removeEventListener("pointerdown", onDocumentPointerDown, true);
+  }
+});
+
+onBeforeUnmount(() => {
+  if (typeof document !== "undefined") {
+    document.removeEventListener("pointerdown", onDocumentPointerDown, true);
+  }
+});
 </script>
 
 <template>
@@ -163,11 +269,6 @@ function onViewKeydown(event: KeyboardEvent): void {
       </button>
     </div>
 
-    <!-- Ambient self-connection quality. Self-contained/store-connected,
-         so it adds no props to this otherwise stateless bar. Shows quiet
-         measuring bars until the first quality sample arrives. -->
-    <CallConnectionIndicator />
-
     <span class="call-controls__divider" aria-hidden="true" />
 
     <button
@@ -214,14 +315,39 @@ function onViewKeydown(event: KeyboardEvent): void {
         aria-hidden="true"
       >{{ chatUnread }}</span>
     </button>
-    <button
-      type="button"
-      class="chat-icon-button chat-icon-button--md hover:bg-muted"
-      title="Call settings"
-      @click="emit('openSettings')"
-    >
-      <Settings class="w-4 h-4" />
-    </button>
+    <div ref="moreWrapEl" class="call-controls__more">
+      <button
+        ref="moreTriggerEl"
+        type="button"
+        class="chat-icon-button chat-icon-button--md hover:bg-muted"
+        :class="{ 'bg-muted text-foreground': moreOpen }"
+        aria-label="More options"
+        aria-haspopup="menu"
+        :aria-expanded="moreOpen"
+        @click="moreOpen ? closeMore(false) : openMore(true)"
+        @keydown="onMoreTriggerKeydown"
+      >
+        <MoreHorizontal class="w-4 h-4" />
+      </button>
+      <div
+        v-show="moreOpen"
+        ref="moreMenuEl"
+        class="call-controls__more-menu"
+        role="menu"
+        aria-label="More options"
+        @keydown="onMoreMenuKeydown"
+      >
+        <button
+          type="button"
+          role="menuitem"
+          class="call-controls__more-item"
+          @click="selectSettings"
+        >
+          <Settings class="w-4 h-4" />
+          <span>Call settings</span>
+        </button>
+      </div>
+    </div>
 
     <span class="call-controls__divider" aria-hidden="true" />
 
@@ -257,6 +383,42 @@ function onViewKeydown(event: KeyboardEvent): void {
   display: flex;
   align-items: center;
   gap: 2px;
+}
+
+/* More ▸ overflow. The menu floats above the bar (the bar sits at the
+ * bottom of both surfaces), anchored to the trigger. */
+.call-controls__more {
+  position: relative;
+  display: inline-flex;
+}
+
+.call-controls__more-menu {
+  position: absolute;
+  bottom: calc(100% + 0.375rem);
+  right: 0;
+  z-index: 10;
+  min-width: 12rem;
+  padding: var(--space-2xs);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--popover, var(--background));
+  box-shadow: var(--shadow-lg, 0 10px 30px rgb(0 0 0 / 0.18));
+}
+
+.call-controls__more-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.5rem 0.625rem;
+  border-radius: var(--radius-sm);
+  text-align: start;
+  color: var(--foreground);
+}
+
+.call-controls__more-item:hover,
+.call-controls__more-item:focus-visible {
+  background: var(--muted);
 }
 
 /* The participants toggle carries a live attendee count, so it widens

--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -40,6 +40,7 @@ import type { MentionCandidate } from "@/lib/mentions";
 import type { MarkupSpan, MessageReference, TimelineMessage } from "@/lib/chat-ui";
 import type { ComposerLinkPreviewLookup, ComposerLinkPreviewSendPayload } from "@/lib/link-preview-composer";
 import CallTileGrid from "./CallTileGrid.vue";
+import CallStageHeader from "./CallStageHeader.vue";
 import CallControls from "./CallControls.vue";
 import CallSettingsDialog from "./CallSettingsDialog.vue";
 import CallMediaNotice from "./CallMediaNotice.vue";
@@ -288,12 +289,7 @@ onBeforeUnmount(() => {
     role="region"
     aria-label="Active call (expanded)"
   >
-    <header class="call-expanded__header">
-      <div class="min-w-0 flex-1">
-        <div class="type-chat-title truncate">{{ peerLabel }}</div>
-        <div class="type-caption text-muted-foreground truncate">{{ subline }}</div>
-      </div>
-    </header>
+    <CallStageHeader :title="peerLabel" :subline="subline" />
     <div
       v-if="lastError"
       class="call-expanded__error"
@@ -386,15 +382,6 @@ onBeforeUnmount(() => {
   display: flex;
   flex-direction: column;
   background: var(--background);
-}
-
-.call-expanded__header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: var(--space-sm);
-  border-bottom: 1px solid var(--border);
-  padding: 0.75rem 1rem;
 }
 
 .call-expanded__error {

--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -246,6 +246,18 @@ async function onSendCallChat(
 function onKeydown(event: KeyboardEvent): void {
   if (!isOpen.value) return;
   if (event.key !== "Escape") return;
+  // The control bar's More overflow owns Escape while open. This listener runs
+  // in the CAPTURE phase, so without this guard it would collapse the call
+  // before the menu's own bubble-phase Escape handler could simply close the
+  // menu. Defer to it: an open menu-button advertises `aria-expanded="true"`.
+  if (
+    typeof document !== "undefined" &&
+    document.querySelector(
+      '.call-controls [aria-haspopup="menu"][aria-expanded="true"]',
+    )
+  ) {
+    return;
+  }
   // The settings modal owns Escape while open: dismiss it rather than
   // collapsing the whole expanded call out from under it. This listener
   // runs in the CAPTURE phase so it sees the still-open flag before

--- a/chat/src/components/calls/CallSplitContainer.vue
+++ b/chat/src/components/calls/CallSplitContainer.vue
@@ -31,6 +31,7 @@ import { $callChatUnread } from "@/lib/calls/call-chat-unread";
 import { barePeerJid } from "@/lib/xmpp/jid";
 import { expectedRemoteIdentitiesForCallState } from "@/lib/calls/call-tiles";
 import CallTileGrid from "./CallTileGrid.vue";
+import CallStageHeader from "./CallStageHeader.vue";
 import CallControls from "./CallControls.vue";
 import CallSettingsDialog from "./CallSettingsDialog.vue";
 import CallMediaNotice from "./CallMediaNotice.vue";
@@ -208,12 +209,7 @@ async function onHangup(): Promise<void> {
       role="region"
       aria-label="Active call"
     >
-      <header class="call-split__header">
-        <div class="call-split__title">
-          <span class="call-split__live-dot" aria-hidden="true" />
-          <span class="type-control">Live · {{ callLabel }} · {{ subline }}</span>
-        </div>
-      </header>
+      <CallStageHeader :title="callLabel" :subline="subline" compact />
       <div
         v-if="lastError"
         class="call-split__error"
@@ -290,42 +286,6 @@ async function onHangup(): Promise<void> {
 
 .call-split--dragging {
   transition: none;
-}
-
-.call-split__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-sm);
-  padding: 0.5rem 0.75rem;
-  border-bottom: 1px solid var(--border);
-}
-
-.call-split__title {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  color: var(--muted-foreground);
-}
-
-.call-split__live-dot {
-  width: 0.5rem;
-  height: 0.5rem;
-  border-radius: 9999px;
-  background: oklch(0.7 0.18 145);
-  box-shadow: 0 0 0 4px color-mix(in oklab, oklch(0.7 0.18 145) 25%, transparent);
-  animation: call-split-live-pulse 1.6s ease-in-out infinite;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .call-split__live-dot {
-    animation: none;
-  }
-}
-
-@keyframes call-split-live-pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.55; }
 }
 
 .call-split__error {

--- a/chat/src/components/calls/CallStageHeader.vue
+++ b/chat/src/components/calls/CallStageHeader.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Circle } from "lucide-vue-next";
 import { useCallElapsed } from "@/lib/calls/use-call-elapsed";
 import CallConnectionIndicator from "./CallConnectionIndicator.vue";
 
@@ -37,17 +36,27 @@ const { running, label } = useCallElapsed();
     class="call-stage-header"
     :class="{ 'call-stage-header--compact': props.compact }"
   >
-    <span class="call-stage-header__live-dot" aria-hidden="true" />
+    <!-- The live dot only goes green + pulses once the room is connected; before
+         that it stays muted and static so it doesn't imply the call is already
+         live. Always present so the connect transition doesn't reflow. -->
+    <span
+      class="call-stage-header__live-dot"
+      :class="{ 'call-stage-header__live-dot--live': running }"
+      aria-hidden="true"
+    />
     <div class="call-stage-header__meta">
       <div class="call-stage-header__title type-control truncate">{{ props.title }}</div>
       <div v-if="props.subline" class="call-stage-header__subline type-caption truncate">
         {{ props.subline }}
       </div>
     </div>
+    <!-- The timer role applies only to an actual duration; while connecting this
+         is plain status text, so the role and label are dropped until it runs.
+         The per-second tick is non-announcing so it never floods a screen reader. -->
     <span
       class="call-stage-header__timer type-control"
-      role="timer"
-      aria-label="Call duration"
+      :role="running ? 'timer' : undefined"
+      :aria-label="running ? 'Call duration' : undefined"
       aria-live="off"
       aria-atomic="true"
     >{{ running ? label : "Connecting…" }}</span>
@@ -57,7 +66,7 @@ const { running, label } = useCallElapsed();
          is announced. Empty (no dot, no label) until then. -->
     <span class="call-stage-header__recording" role="status" aria-live="polite">
       <template v-if="props.recording">
-        <Circle class="call-stage-header__recording-dot" aria-hidden="true" />
+        <span class="call-stage-header__recording-dot" aria-hidden="true" />
         <span class="type-control">Recording</span>
       </template>
     </span>
@@ -82,13 +91,19 @@ const { running, label } = useCallElapsed();
   width: 0.5rem;
   height: 0.5rem;
   border-radius: 9999px;
+  /* Muted + static while connecting — not yet "live". */
+  background: var(--muted-foreground);
+}
+
+/* Connected: green + pulsing. */
+.call-stage-header__live-dot--live {
   background: oklch(0.7 0.18 145);
   box-shadow: 0 0 0 4px color-mix(in oklab, oklch(0.7 0.18 145) 25%, transparent);
   animation: call-stage-live-pulse 1.6s ease-in-out infinite;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .call-stage-header__live-dot {
+  .call-stage-header__live-dot--live {
     animation: none;
   }
 }
@@ -125,9 +140,12 @@ const { running, label } = useCallElapsed();
   color: var(--destructive);
 }
 
+/* A CSS-native filled circle — unambiguously solid, no SVG paint inheritance. */
 .call-stage-header__recording-dot {
+  flex: none;
   width: 0.625rem;
   height: 0.625rem;
-  fill: currentColor;
+  border-radius: 9999px;
+  background: currentColor;
 }
 </style>

--- a/chat/src/components/calls/CallStageHeader.vue
+++ b/chat/src/components/calls/CallStageHeader.vue
@@ -48,15 +48,18 @@ const { running, label } = useCallElapsed();
       class="call-stage-header__timer type-control"
       role="timer"
       aria-label="Call duration"
+      aria-live="off"
+      aria-atomic="true"
     >{{ running ? label : "Connecting…" }}</span>
     <CallConnectionIndicator />
-    <span
-      v-if="props.recording"
-      class="call-stage-header__recording"
-      role="status"
-    >
-      <Circle class="call-stage-header__recording-dot" aria-hidden="true" />
-      <span class="type-control">Recording</span>
+    <!-- Inert capture-state slot: a present-but-empty polite live region so
+         that, once capture lands and flips `recording` on, the inserted label
+         is announced. Empty (no dot, no label) until then. -->
+    <span class="call-stage-header__recording" role="status" aria-live="polite">
+      <template v-if="props.recording">
+        <Circle class="call-stage-header__recording-dot" aria-hidden="true" />
+        <span class="type-control">Recording</span>
+      </template>
     </span>
   </header>
 </template>

--- a/chat/src/components/calls/CallStageHeader.vue
+++ b/chat/src/components/calls/CallStageHeader.vue
@@ -1,0 +1,130 @@
+<script setup lang="ts">
+import { Circle } from "lucide-vue-next";
+import { useCallElapsed } from "@/lib/calls/use-call-elapsed";
+import CallConnectionIndicator from "./CallConnectionIndicator.vue";
+
+/**
+ * Status-only stage-header for the in-call surfaces (split + expanded).
+ *
+ * Shows the call title, a live elapsed-time timer, a contextual subline,
+ * the self-connection-quality indicator (relocated here from the control
+ * bar), and an inert recording-indicator slot. Carries NO actions — every
+ * control lives in `CallControls`. The timer's start instant is owned by
+ * the `$callActiveSince` store (via `useCallElapsed`), so it keeps
+ * counting across the split↔expanded remount instead of resetting.
+ */
+const props = withDefaults(
+  defineProps<{
+    /** The call title — the peer's name (1:1) or the room name (group). */
+    title: string;
+    /** Contextual status under the title ("Waiting for others…", "Video
+     *  call", …). Empty hides the subline row. */
+    subline?: string;
+    /** Recording-indicator slot. Wired but driven `false` until recording
+     *  lands in a later slice — the dot only renders when this is `true`. */
+    recording?: boolean;
+    /** Tightens padding for the inline split surface. */
+    compact?: boolean;
+  }>(),
+  { subline: "", recording: false, compact: false },
+);
+
+const { running, label } = useCallElapsed();
+</script>
+
+<template>
+  <header
+    class="call-stage-header"
+    :class="{ 'call-stage-header--compact': props.compact }"
+  >
+    <span class="call-stage-header__live-dot" aria-hidden="true" />
+    <div class="call-stage-header__meta">
+      <div class="call-stage-header__title type-control truncate">{{ props.title }}</div>
+      <div v-if="props.subline" class="call-stage-header__subline type-caption truncate">
+        {{ props.subline }}
+      </div>
+    </div>
+    <span
+      class="call-stage-header__timer type-control"
+      role="timer"
+      aria-label="Call duration"
+    >{{ running ? label : "Connecting…" }}</span>
+    <CallConnectionIndicator />
+    <span
+      v-if="props.recording"
+      class="call-stage-header__recording"
+      role="status"
+    >
+      <Circle class="call-stage-header__recording-dot" aria-hidden="true" />
+      <span class="type-control">Recording</span>
+    </span>
+  </header>
+</template>
+
+<style scoped>
+.call-stage-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: 0.625rem 1rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.call-stage-header--compact {
+  padding: 0.5rem 0.75rem;
+}
+
+.call-stage-header__live-dot {
+  flex: none;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 9999px;
+  background: oklch(0.7 0.18 145);
+  box-shadow: 0 0 0 4px color-mix(in oklab, oklch(0.7 0.18 145) 25%, transparent);
+  animation: call-stage-live-pulse 1.6s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .call-stage-header__live-dot {
+    animation: none;
+  }
+}
+
+@keyframes call-stage-live-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}
+
+.call-stage-header__meta {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.call-stage-header__title {
+  color: var(--foreground);
+}
+
+.call-stage-header__subline {
+  color: var(--muted-foreground);
+}
+
+.call-stage-header__timer {
+  flex: none;
+  color: var(--muted-foreground);
+  font-variant-numeric: tabular-nums;
+}
+
+.call-stage-header__recording {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  flex: none;
+  color: var(--destructive);
+}
+
+.call-stage-header__recording-dot {
+  width: 0.625rem;
+  height: 0.625rem;
+  fill: currentColor;
+}
+</style>

--- a/chat/src/lib/calls/call-duration.ts
+++ b/chat/src/lib/calls/call-duration.ts
@@ -1,0 +1,51 @@
+import { atom } from "nanostores";
+
+/**
+ * Wall-clock instant (ms epoch) at which the active call's LiveKit room
+ * connected, or `null` while no call is connected. The engine stamps it
+ * on `connected` and clears it on `disconnect`, mirroring the
+ * connection-quality lifecycle. The stage-header reads it to drive a
+ * live elapsed-time timer that survives split↔expanded remounts (the
+ * timestamp lives in the store, not in component state).
+ */
+export const $callActiveSince = atom<number | null>(null);
+
+/** Stamp the call clock at `now` (the connect instant). */
+export function setCallActiveSince(now: number): void {
+  $callActiveSince.set(now);
+}
+
+/** Clear the call clock when the call disconnects. */
+export function resetCallActiveSince(): void {
+  $callActiveSince.set(null);
+}
+
+/**
+ * Elapsed milliseconds since the call clock started. `0` while the clock
+ * is unset (still connecting) and clamped to `0` if `now` precedes the
+ * start, so the timer never runs backwards on clock skew.
+ */
+export function callElapsedMs(since: number | null, now: number): number {
+  if (since === null) return 0;
+  return Math.max(0, now - since);
+}
+
+/**
+ * Format an elapsed call duration (in milliseconds) as a compact timer
+ * label: `M:SS` under an hour, `H:MM:SS` once it crosses one hour.
+ * Seconds (and, in the long form, minutes) are zero-padded; the leading
+ * unit is not. Pure and clock-free so the call stage-header's live timer
+ * can be unit-tested without faking time.
+ */
+export function formatCallDuration(ms: number): string {
+  const totalSeconds = Math.floor(Math.max(0, ms) / 1000);
+  const seconds = totalSeconds % 60;
+  const minutes = Math.floor(totalSeconds / 60) % 60;
+  const hours = Math.floor(totalSeconds / 3600);
+  const ss = String(seconds).padStart(2, "0");
+  if (hours > 0) {
+    const mm = String(minutes).padStart(2, "0");
+    return `${hours}:${mm}:${ss}`;
+  }
+  return `${minutes}:${ss}`;
+}

--- a/chat/src/lib/calls/call-duration.ts
+++ b/chat/src/lib/calls/call-duration.ts
@@ -3,7 +3,7 @@ import { atom } from "nanostores";
 /**
  * Wall-clock instant (ms epoch) at which the active call's LiveKit room
  * connected, or `null` while no call is connected. The engine stamps it
- * on `connected` and clears it on `disconnect`, mirroring the
+ * on the `connected` event and clears it on `disconnected`, mirroring the
  * connection-quality lifecycle. The stage-header reads it to drive a
  * live elapsed-time timer that survives split↔expanded remounts (the
  * timestamp lives in the store, not in component state).

--- a/chat/src/lib/calls/use-call-elapsed.ts
+++ b/chat/src/lib/calls/use-call-elapsed.ts
@@ -1,0 +1,44 @@
+import { computed, onUnmounted, ref, type ComputedRef } from "vue";
+import { useStore } from "@nanostores/vue";
+import {
+  $callActiveSince,
+  callElapsedMs,
+  formatCallDuration,
+} from "./call-duration";
+
+/**
+ * Live elapsed-time clock for the call stage-header.
+ *
+ * Reads the store-owned `$callActiveSince` stamp (set by the engine on
+ * `connected`, cleared on `disconnect`) and re-renders a `M:SS` /
+ * `H:MM:SS` label once per second. Keeping the start instant in the
+ * store — not in component state — means the timer survives the
+ * split↔expanded remount of the surface that hosts the header.
+ *
+ * `running` is `false` until the call connects, so the header can show
+ * "Connecting…" rather than a stuck `0:00`. The per-second tick only
+ * arms in a browser; under SSR (`window` undefined) the label is
+ * computed once from the current clock, which keeps the harness
+ * deterministic and leak-free.
+ */
+export function useCallElapsed(): {
+  running: ComputedRef<boolean>;
+  label: ComputedRef<string>;
+} {
+  const since = useStore($callActiveSince);
+  const now = ref(Date.now());
+
+  if (typeof window !== "undefined") {
+    const timer = setInterval(() => {
+      now.value = Date.now();
+    }, 1000);
+    onUnmounted(() => clearInterval(timer));
+  }
+
+  const running = computed(() => since.value !== null);
+  const label = computed(() =>
+    formatCallDuration(callElapsedMs(since.value, now.value)),
+  );
+
+  return { running, label };
+}

--- a/chat/src/lib/calls/use-call-elapsed.ts
+++ b/chat/src/lib/calls/use-call-elapsed.ts
@@ -10,7 +10,7 @@ import {
  * Live elapsed-time clock for the call stage-header.
  *
  * Reads the store-owned `$callActiveSince` stamp (set by the engine on
- * `connected`, cleared on `disconnect`) and re-renders a `M:SS` /
+ * the `connected` event, cleared on `disconnected`) and re-renders a `M:SS` /
  * `H:MM:SS` label once per second. Keeping the start instant in the
  * store — not in component state — means the timer survives the
  * split↔expanded remount of the surface that hosts the header.

--- a/chat/src/lib/calls/use-call-engine.ts
+++ b/chat/src/lib/calls/use-call-engine.ts
@@ -47,6 +47,7 @@ import {
   setCallConnectionPhase,
   setCallConnectionQuality,
 } from "./connection-quality";
+import { resetCallActiveSince, setCallActiveSince } from "./call-duration";
 
 /**
  * Process-wide singleton: only one call engine should ever exist
@@ -387,6 +388,13 @@ export function useCallEngine(): {
       // MUC-projection handler above, which early-returns for 1:1 DM calls.
       startMediaPathPolling();
     });
+    singletonEngine.on("connected", () => {
+      // Stamp the call clock so the stage-header's elapsed timer starts at the
+      // moment the LiveKit room actually connects (not at the optimistic
+      // `active` transition). Reset on `disconnected`, mirroring the
+      // connection-quality lifecycle.
+      setCallActiveSince(Date.now());
+    });
     singletonEngine.on("mediaDevicesError", ({ source, error }) => {
       // A best-effort mic/cam capture failed (no device / denied
       // permission). The call stays connected as receive-only; record
@@ -476,6 +484,9 @@ export function useCallEngine(): {
       // Drop the connection-quality chip so a stale `poor`/`reconnecting`
       // from the call that just ended can't bleed into the next call.
       resetCallConnectionQuality();
+      // Stop the elapsed-timer clock so the next call's header starts from
+      // "Connecting…" instead of inheriting this call's start instant.
+      resetCallActiveSince();
       // The active call's room — if any — is no longer in our LK
       // view. Drop the LK snapshot so the room's UI reverts to the
       // Muji-derived (server-bridged) view, which the LK webhook

--- a/chat/tests/call-controls.test.ts
+++ b/chat/tests/call-controls.test.ts
@@ -733,6 +733,42 @@ describe("call control bar chat toggle", () => {
   });
 });
 
+describe("call control bar restructure (#1020)", () => {
+  test("no longer embeds the connection-quality indicator (now in the stage-header)", () => {
+    // The indicator moved to CallStageHeader (asserted there via the recursive
+    // SFC harness). This bar must not import or render it any more.
+    const source = readFileSync(
+      new URL("../src/components/calls/CallControls.vue", import.meta.url),
+      "utf8",
+    );
+    expect(source).not.toContain("CallConnectionIndicator");
+  });
+
+  test("exposes a More overflow trigger that opens a menu", async () => {
+    const html = await renderCallControls({});
+    expect(html).toContain('aria-haspopup="menu"');
+    expect(html).toContain('aria-label="More options"');
+    // Collapsed at rest.
+    expect(html).toMatch(/aria-haspopup="menu"[^>]*aria-expanded="false"/);
+  });
+
+  test("holds the Settings action as a menu item under More, not as a top-level button", async () => {
+    const html = await renderCallControls({});
+    // Settings is a menu item now…
+    expect(html).toContain('role="menuitem"');
+    expect(html).toContain("Call settings");
+  });
+
+  test("wires the More menu's Settings item to the openSettings emit", () => {
+    const source = readFileSync(
+      new URL("../src/components/calls/CallControls.vue", import.meta.url),
+      "utf8",
+    );
+    expect(source).toContain("openSettings");
+    expect(source).toContain('role="menu"');
+  });
+});
+
 async function renderCallControls(overrides: Record<string, unknown>): Promise<string> {
   const component = await loadVueComponent("../src/components/calls/CallControls.vue");
   const props = {

--- a/chat/tests/call-duration.test.ts
+++ b/chat/tests/call-duration.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  $callActiveSince,
+  callElapsedMs,
+  formatCallDuration,
+  resetCallActiveSince,
+  setCallActiveSince,
+} from "../src/lib/calls/call-duration";
+
+afterEach(() => {
+  resetCallActiveSince();
+});
+
+describe("formatCallDuration — elapsed call timer label", () => {
+  test("formats sub-minute durations as M:SS with a leading zero on seconds", () => {
+    expect(formatCallDuration(5_000)).toBe("0:05");
+  });
+
+  test("rolls into minutes past 60 seconds", () => {
+    expect(formatCallDuration(65_000)).toBe("1:05");
+  });
+
+  test("switches to H:MM:SS once it crosses an hour", () => {
+    // 1h 01m 01s
+    expect(formatCallDuration(3_661_000)).toBe("1:01:01");
+  });
+
+  test("a fresh (zero) duration reads 0:00, not blank", () => {
+    expect(formatCallDuration(0)).toBe("0:00");
+  });
+
+  test("clamps a negative elapsed (clock skew) to 0:00 rather than going backwards", () => {
+    expect(formatCallDuration(-5_000)).toBe("0:00");
+  });
+
+  test("floors sub-second remainders so the timer never shows a partial second", () => {
+    expect(formatCallDuration(900)).toBe("0:00");
+    expect(formatCallDuration(1_900)).toBe("0:01");
+  });
+});
+
+describe("$callActiveSince — when the live call clock started", () => {
+  test("starts unset so a header before connect shows no running timer", () => {
+    expect($callActiveSince.get()).toBeNull();
+  });
+
+  test("setCallActiveSince stamps the connect instant; reset clears it", () => {
+    setCallActiveSince(1_000);
+    expect($callActiveSince.get()).toBe(1_000);
+    resetCallActiveSince();
+    expect($callActiveSince.get()).toBeNull();
+  });
+});
+
+describe("callElapsedMs — elapsed since the call clock started", () => {
+  test("is zero while the clock is unset (still connecting)", () => {
+    expect(callElapsedMs(null, 10_000)).toBe(0);
+  });
+
+  test("is the difference between now and the stamped start", () => {
+    expect(callElapsedMs(1_000, 6_500)).toBe(5_500);
+  });
+
+  test("clamps to zero if now precedes the start (clock skew)", () => {
+    expect(callElapsedMs(6_500, 1_000)).toBe(0);
+  });
+});

--- a/chat/tests/call-elapsed-engine.test.ts
+++ b/chat/tests/call-elapsed-engine.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { useCallEngine } from "../src/lib/calls/use-call-engine";
+import {
+  $callActiveSince,
+  resetCallActiveSince,
+} from "../src/lib/calls/call-duration";
+
+/**
+ * The stage-header's elapsed timer is driven by `$callActiveSince`, which
+ * the engine lifecycle owns: stamped when the LiveKit room connects,
+ * cleared when it disconnects. These tests exercise the wiring through the
+ * engine's own event emitter so a future refactor of the handler can't
+ * silently drop the timer.
+ */
+
+// `useCallEngine()` registers the singleton handlers on first call.
+const engine = useCallEngine().engine;
+const emit = (
+  engine as unknown as { emit: (event: string, ...args: unknown[]) => void }
+).emit.bind(engine);
+
+afterEach(() => {
+  // Balance any media-path poll the synthetic `connected` started, then
+  // clear the clock for the next test.
+  emit("disconnected", "local");
+  resetCallActiveSince();
+});
+
+describe("call elapsed clock — engine lifecycle wiring", () => {
+  test("stamps $callActiveSince when the room connects", () => {
+    expect($callActiveSince.get()).toBeNull();
+    emit("connected", { localIdentity: "me@waddle.test/web", remoteIdentities: [] });
+    expect($callActiveSince.get()).not.toBeNull();
+  });
+
+  test("clears $callActiveSince when the room disconnects", () => {
+    emit("connected", { localIdentity: "me@waddle.test/web", remoteIdentities: [] });
+    expect($callActiveSince.get()).not.toBeNull();
+    emit("disconnected", "local");
+    expect($callActiveSince.get()).toBeNull();
+  });
+});

--- a/chat/tests/call-stage-header-surface.test.ts
+++ b/chat/tests/call-stage-header-surface.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { renderVueComponent } from "./helpers/render-vue-sfc";
+import { $callState, clearCallState } from "../src/lib/calls/call-store";
+import { $callUiMode } from "../src/lib/calls/ui-mode";
+import { resetCallActiveSince } from "../src/lib/calls/call-duration";
+import type { LiveKitJoin } from "../src/lib/calls/types";
+
+const join: LiveKitJoin = {
+  url: "wss://livekit.test",
+  room: "bob@waddle.test::c1",
+  identity: "me@waddle.test/web",
+  token: "jwt",
+};
+
+afterEach(() => {
+  clearCallState();
+  $callUiMode.set("split");
+  resetCallActiveSince();
+});
+
+function setActiveDmCall(): void {
+  $callState.set({
+    phase: "active",
+    peer: "bob@waddle.test/web",
+    sid: "c1",
+    media: { audio: true, video: false },
+    join,
+    kind: "dm",
+  });
+  $callUiMode.set("split");
+}
+
+describe("CallSplitContainer stage-header integration", () => {
+  test("mounts the stage-header with the call title and the relocated connection indicator", async () => {
+    setActiveDmCall();
+    const html = await renderVueComponent(
+      "../src/components/calls/CallSplitContainer.vue",
+      { dmPeerJid: "bob@waddle.test", dmPeerName: "Bob" },
+      import.meta.url,
+    );
+    // Title in the new status-only header.
+    expect(html).toContain("Bob");
+    // Connection indicator now lives in the header (rendered on the surface).
+    expect(html).toContain("call-connection");
+    // The timer reads "Connecting…" until the engine stamps the call clock.
+    expect(html).toContain("Connecting…");
+  });
+});

--- a/chat/tests/call-stage-header.test.ts
+++ b/chat/tests/call-stage-header.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { renderVueComponent } from "./helpers/render-vue-sfc";
+import {
+  resetCallActiveSince,
+  setCallActiveSince,
+} from "../src/lib/calls/call-duration";
+
+afterEach(() => {
+  resetCallActiveSince();
+});
+
+async function renderHeader(props: Record<string, unknown>): Promise<string> {
+  return renderVueComponent(
+    "../src/components/calls/CallStageHeader.vue",
+    props,
+    import.meta.url,
+  );
+}
+
+describe("CallStageHeader", () => {
+  test("shows the call title", async () => {
+    const html = await renderHeader({ title: "Alice Cooper", subline: "Audio call" });
+    expect(html).toContain("Alice Cooper");
+  });
+
+  test("shows the contextual subline next to the title", async () => {
+    const html = await renderHeader({
+      title: "Design sync",
+      subline: "2 others in call",
+    });
+    expect(html).toContain("2 others in call");
+  });
+
+  test("shows 'Connecting…' instead of a timer before the call clock starts", async () => {
+    // $callActiveSince left null (reset in afterEach) → not yet connected.
+    const html = await renderHeader({ title: "Alice", subline: "Audio call" });
+    expect(html).toContain("Connecting…");
+    expect(html).not.toContain("0:00");
+  });
+
+  test("shows the live elapsed timer once the call clock has started", async () => {
+    const fixed = 1_700_000_000_000;
+    const original = Date.now;
+    Date.now = () => fixed;
+    try {
+      setCallActiveSince(fixed - 65_000); // 1m 05s ago
+      const html = await renderHeader({ title: "Alice", subline: "Audio call" });
+      expect(html).toContain("1:05");
+      expect(html).not.toContain("Connecting…");
+    } finally {
+      Date.now = original;
+    }
+  });
+
+  test("hosts the connection-quality indicator (relocated from the control bar)", async () => {
+    const html = await renderHeader({ title: "Alice", subline: "Audio call" });
+    expect(html).toContain("call-connection");
+  });
+
+  test("keeps the recording indicator inert by default", async () => {
+    const html = await renderHeader({ title: "Alice", subline: "Audio call" });
+    expect(html).not.toContain("Recording");
+  });
+
+  test("renders the recording indicator when wired on (future recording slice)", async () => {
+    const html = await renderHeader({
+      title: "Alice",
+      subline: "Audio call",
+      recording: true,
+    });
+    expect(html).toContain("Recording");
+  });
+});

--- a/chat/tests/call-stage-header.test.ts
+++ b/chat/tests/call-stage-header.test.ts
@@ -52,6 +52,25 @@ describe("CallStageHeader", () => {
     }
   });
 
+  test("drops role=timer (and goes live) only once the call clock is running", async () => {
+    // Connecting: no real duration yet, so no timer role and the dot is muted.
+    const connecting = await renderHeader({ title: "Alice", subline: "Audio call" });
+    expect(connecting).not.toContain('role="timer"');
+    expect(connecting).not.toContain("call-stage-header__live-dot--live");
+
+    const fixed = 1_700_000_000_000;
+    const original = Date.now;
+    Date.now = () => fixed;
+    try {
+      setCallActiveSince(fixed - 5_000);
+      const running = await renderHeader({ title: "Alice", subline: "Audio call" });
+      expect(running).toContain('role="timer"');
+      expect(running).toContain("call-stage-header__live-dot--live");
+    } finally {
+      Date.now = original;
+    }
+  });
+
   test("hosts the connection-quality indicator (relocated from the control bar)", async () => {
     const html = await renderHeader({ title: "Alice", subline: "Audio call" });
     expect(html).toContain("call-connection");

--- a/chat/tests/call-stage-header.test.ts
+++ b/chat/tests/call-stage-header.test.ts
@@ -59,7 +59,11 @@ describe("CallStageHeader", () => {
 
   test("keeps the recording indicator inert by default", async () => {
     const html = await renderHeader({ title: "Alice", subline: "Audio call" });
-    expect(html).not.toContain("Recording");
+    // The live-region slot exists (reserved for the future recording slice)…
+    expect(html).toContain('class="call-stage-header__recording"');
+    // …but shows no dot and no label until recording is wired on.
+    expect(html).not.toContain("call-stage-header__recording-dot");
+    expect(html).not.toContain(">Recording<");
   });
 
   test("renders the recording indicator when wired on (future recording slice)", async () => {
@@ -68,6 +72,7 @@ describe("CallStageHeader", () => {
       subline: "Audio call",
       recording: true,
     });
-    expect(html).toContain("Recording");
+    expect(html).toContain("call-stage-header__recording-dot");
+    expect(html).toContain(">Recording<");
   });
 });


### PR DESCRIPTION
## Summary

Implements #1020 (Call Zoom-parity epic #1017): a status-only **stage-header**
for the in-call surfaces and a control-bar restructure that moves less-used
actions under a **More ▸** overflow. Built test-first (red→green per behavior).

## What changed

- **`CallStageHeader.vue`** (new) — status-only header mounted above the stage
  on both the split and expanded surfaces. Shows:
  - the call title,
  - a live elapsed-time timer (counts up once the LiveKit room connects; reads
    "Connecting…" until then),
  - the contextual subline ("Waiting for others…", "N others in call", "Video
    call"),
  - the connection-quality indicator, **relocated here** from the control bar,
  - an inert **recording-indicator slot** — reserved as a present-but-empty
    polite live region (driven `false` until recording lands in a later slice).
- **`call-duration.ts`** (new) — pure `formatCallDuration(ms)` (`M:SS` /
  `H:MM:SS`, clamped/floored) plus the `$callActiveSince` atom and
  `callElapsedMs` helper.
- **`use-call-elapsed.ts`** (new) — composable that ticks once per second and
  formats the elapsed time; browser-only interval with `onUnmounted` cleanup,
  SSR-safe. The start instant lives in the store, so the timer survives the
  split↔expanded remount instead of resetting.
- **`CallControls.vue`** — connection indicator removed (now in the header); the
  Settings action folds into an accessible **More ▸** overflow menu (WAI-ARIA
  menu-button: `aria-haspopup`/`aria-expanded`, `role=menu`/`menuitem`, arrow /
  Home / End / Escape / Tab, outside-click + unmount cleanup). The single
  "Call settings" item opens the existing dialog, which already houses the
  device pickers and the diagnostics/stats section.
- **`use-call-engine.ts`** — `setCallActiveSince(Date.now())` on the engine
  `connected` event, `resetCallActiveSince()` on `disconnected`, mirroring the
  connection-quality lifecycle. `connected` fires once per call (a LiveKit
  reconnect uses the separate `connectionPhaseChanged` signal), so the timer is
  not reset mid-call.
- Old per-surface header markup + styles removed from `CallSplitContainer.vue`
  and `CallExpandedSurface.vue` (no orphaned CSS/imports).

## Acceptance criteria

- [x] Stage-header shows call title, a live elapsed-time timer, and connection quality.
- [x] Connection indicator removed from the control bar (now in the header).
- [x] Recording-indicator slot exists in the header, inert until recording lands.
- [x] Settings moves under a More ▸ overflow; the bar stays uncluttered.
- [x] Timer and header state unit-tested via `bun test`.

## Tests

- `call-duration.test.ts` — formatter edge cases (zero, minute/hour rollover,
  negative clamp, sub-second floor), `$callActiveSince` lifecycle, `callElapsedMs`.
- `call-stage-header.test.ts` — title, subline, Connecting↔timer states,
  relocated connection indicator, inert↔wired recording slot.
- `call-stage-header-surface.test.ts` — the header mounts on a live surface and
  the indicator renders there.
- `call-elapsed-engine.test.ts` — engine `connected`/`disconnected` stamp/clear
  the call clock through the real emitter.
- `call-controls.test.ts` — connection indicator gone from the bar; More ▸
  trigger + `role=menu`/`menuitem` Settings item.

`bun test` (affected files) green; `knip` clean; `astro check` reports no new
errors from these files.

## Decisions (confirmed with reviewer)

- More ▸ exposes a single "Settings" item — the dialog already contains devices
  + diagnostics; the menu is list-based so future items slot in.
- The header keeps the contextual subline next to the timer.

## XEP conformance

Status-only UI change with **no XMPP wire shapes or namespaces** introduced. The
recording slot is inert (no Jingle/recording semantics yet), so there is no XEP
conformance surface in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
