### PR TITLE
feat(chat): post stargate quotes directly

### DIFF
--- a/chat/src/channels/extension-launcher.ts
+++ b/chat/src/channels/extension-launcher.ts
@@ -273,6 +273,21 @@ export function useExtensionLauncher(input: {
         return true;
       }
 
+      if (invocation.kind === "direct-execute") {
+        const outcome = extensionCommandOutcome(result);
+        commandStates.value = { ...commandStates.value, [key]: outcome };
+        if (form) {
+          open.value = true;
+          void nextTick(input.focusPalette);
+        } else if (outcome.state !== "success" || outcome.detail) {
+          open.value = true;
+          void nextTick(input.focusPalette);
+        } else {
+          open.value = false;
+        }
+        return true;
+      }
+
       // inline-submit only stays inline if the server returned a single-stage
       // form whose advertised XEP-0050 actions include `complete`. Otherwise
       // fall back to the palette so the user can drive the multi-stage flow.
@@ -296,6 +311,10 @@ export function useExtensionLauncher(input: {
         ...commandStates.value,
         [key]: { state: "error", detail: error instanceof Error ? error.message : "Extension command failed." },
       };
+      if (invocation.kind === "direct-execute") {
+        open.value = true;
+        void nextTick(input.focusPalette);
+      }
       return false;
     }
   }

--- a/chat/src/lib/slash-dispatch.ts
+++ b/chat/src/lib/slash-dispatch.ts
@@ -11,6 +11,10 @@ export type SlashInvocation =
       kind: "open-palette";
       command: DiscoveredExtensionCommand;
       prefillFirstRequired?: string;
+    }
+  | {
+      kind: "direct-execute";
+      command: DiscoveredExtensionCommand;
     };
 
 export function buildSlashInvocation(
@@ -20,6 +24,9 @@ export function buildSlashInvocation(
   const value = trailing.trim();
   if (command.inlineField && value.length > 0) {
     return { kind: "inline-submit", command, fieldName: command.inlineField, value };
+  }
+  if (command.composerExecute && value.length === 0) {
+    return { kind: "direct-execute", command };
   }
   if (!command.inlineField && value.length > 0) {
     return { kind: "open-palette", command, prefillFirstRequired: value };

--- a/chat/src/lib/slash-dispatch.ts
+++ b/chat/src/lib/slash-dispatch.ts
@@ -28,6 +28,7 @@ export function buildSlashInvocation(
   if (command.composerExecute && value.length === 0) {
     return { kind: "direct-execute", command };
   }
+  // Preserve unexpected trailing text by opening the palette with a prefill.
   if (!command.inlineField && value.length > 0) {
     return { kind: "open-palette", command, prefillFirstRequired: value };
   }

--- a/chat/src/lib/xmpp/extension-commands/disco.ts
+++ b/chat/src/lib/xmpp/extension-commands/disco.ts
@@ -55,12 +55,14 @@ export async function discoverExtensionCommands(
     let scope: ExtensionCommandScope = "global";
     let composerPrefix: string | undefined;
     let inlineField: string | undefined;
+    let composerExecute = false;
     try {
       const info = await rawDiscoInfoFull(xmpp, itemServiceJid, node);
       const metadata = parseExtensionCommandMetadata(info.extensions);
       if (metadata.scope) scope = metadata.scope;
       composerPrefix = metadata.composerPrefix;
       inlineField = metadata.inlineField;
+      composerExecute = metadata.composerExecute === true;
     } catch {
       // If disco#info is unavailable, fall back to global scope.
     }
@@ -71,6 +73,7 @@ export async function discoverExtensionCommands(
       scope,
       ...(composerPrefix !== undefined ? { composerPrefix } : {}),
       ...(inlineField !== undefined ? { inlineField } : {}),
+      ...(composerExecute ? { composerExecute } : {}),
     });
   }
   return commands;
@@ -80,6 +83,7 @@ interface ExtensionCommandMetadata {
   scope: ExtensionCommandScope | null;
   composerPrefix?: string;
   inlineField?: string;
+  composerExecute?: boolean;
 }
 
 function parseExtensionCommandMetadata(extensions: unknown[] | undefined): ExtensionCommandMetadata {
@@ -96,6 +100,8 @@ function parseExtensionCommandMetadata(extensions: unknown[] | undefined): Exten
     if (composerPrefix) result.composerPrefix = composerPrefix;
     const inlineField = formFieldValue(fields, "waddle#inline_field");
     if (inlineField) result.inlineField = inlineField;
+    const composerExecute = formFieldValue(fields, "waddle#composer_execute");
+    if (composerExecute?.toLowerCase() === "true") result.composerExecute = true;
   }
   return result;
 }

--- a/chat/src/lib/xmpp/extension-commands/types.ts
+++ b/chat/src/lib/xmpp/extension-commands/types.ts
@@ -65,6 +65,7 @@ export interface DiscoveredExtensionCommand {
   scope: ExtensionCommandScope;
   composerPrefix?: string;
   inlineField?: string;
+  composerExecute?: boolean;
 }
 
 type ExtensionRouteScope = "channel";

--- a/chat/tests/extension-command.test.ts
+++ b/chat/tests/extension-command.test.ts
@@ -83,7 +83,7 @@ describe("extension command invocation", () => {
     ]);
   });
 
-  test("reads composer-prefix and inline-field from XEP-0128 disco metadata", async () => {
+  test("reads composer metadata from XEP-0128 disco metadata", async () => {
     const xmpp = {
       async send_raw_iq(xml: string) {
         if (xml.includes('to="example.com"') && xml.includes("disco#items")) {
@@ -93,13 +93,16 @@ describe("extension command invocation", () => {
           return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#info"><feature var="urn:waddle:extension:1" /><feature var="http://jabber.org/protocol/commands" /></query></iq>`;
         }
         if (xml.includes('node="http://jabber.org/protocol/commands"')) {
-          return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#items"><item jid="extensions.example.com" node="urn:waddle:extension:1:ai-chatbot" name="Ask AI Chatbot" /><item jid="extensions.example.com" node="urn:waddle:extension:1:decision-polls" name="Create Decision Poll" /></query></iq>`;
+          return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#items"><item jid="extensions.example.com" node="urn:waddle:extension:1:ai-chatbot" name="Ask AI Chatbot" /><item jid="extensions.example.com" node="urn:waddle:extension:1:decision-polls" name="Create Decision Poll" /><item jid="extensions.example.com" node="urn:waddle:extension:1:stargate-quotes" name="/stargate" /></query></iq>`;
         }
         if (xml.includes('node="urn:waddle:extension:1:ai-chatbot"')) {
           return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#info"><x xmlns="jabber:x:data" type="result"><field var="FORM_TYPE"><value>urn:waddle:extension:1:command</value></field><field var="waddle#command_scope"><value>global</value></field><field var="waddle#composer_prefix"><value>ai</value></field><field var="waddle#inline_field"><value>prompt</value></field></x></query></iq>`;
         }
-        expect(xml).toContain('node="urn:waddle:extension:1:decision-polls"');
-        return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#info"><x xmlns="jabber:x:data" type="result"><field var="FORM_TYPE"><value>urn:waddle:extension:1:command</value></field><field var="waddle#command_scope"><value>channel</value></field><field var="waddle#composer_prefix"><value>poll</value></field></x></query></iq>`;
+        if (xml.includes('node="urn:waddle:extension:1:decision-polls"')) {
+          return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#info"><x xmlns="jabber:x:data" type="result"><field var="FORM_TYPE"><value>urn:waddle:extension:1:command</value></field><field var="waddle#command_scope"><value>channel</value></field><field var="waddle#composer_prefix"><value>poll</value></field></x></query></iq>`;
+        }
+        expect(xml).toContain('node="urn:waddle:extension:1:stargate-quotes"');
+        return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#info"><x xmlns="jabber:x:data" type="result"><field var="FORM_TYPE"><value>urn:waddle:extension:1:command</value></field><field var="waddle#command_scope"><value>channel</value></field><field var="waddle#composer_prefix"><value>stargate</value></field><field var="waddle#composer_execute"><value>true</value></field></x></query></iq>`;
       },
     };
 
@@ -119,6 +122,14 @@ describe("extension command invocation", () => {
         name: "Create Decision Poll",
         scope: "channel",
         composerPrefix: "poll",
+      },
+      {
+        serviceJid: "extensions.example.com",
+        node: "urn:waddle:extension:1:stargate-quotes",
+        name: "/stargate",
+        scope: "channel",
+        composerPrefix: "stargate",
+        composerExecute: true,
       },
     ]);
   });

--- a/chat/tests/extension-launcher-slash.test.ts
+++ b/chat/tests/extension-launcher-slash.test.ts
@@ -41,6 +41,7 @@ const stargateCommand: DiscoveredExtensionCommand = {
   name: "/stargate",
   scope: "channel",
   composerPrefix: "stargate",
+  composerExecute: true,
 };
 
 interface SubmitCall {
@@ -93,6 +94,7 @@ function executingResult(fields: ExtensionCommandFormField[], allowed: Extension
 
 function fakeClient(executeResults: ExtensionCommandResult[], options: {
   events?: string[] | undefined;
+  invokeError?: Error | undefined;
   submitError?: Error | undefined;
   discoveredCommands?: DiscoveredExtensionCommand[] | undefined;
 } = {}): {
@@ -106,6 +108,7 @@ function fakeClient(executeResults: ExtensionCommandResult[], options: {
   const fake = {
     async invokeExtensionCommand(command: DiscoveredExtensionCommand, roomJid?: string): Promise<ExtensionCommandResult> {
       invokeCalls.push({ command, roomJid });
+      if (options.invokeError) throw options.invokeError;
       return queue.shift() ?? { status: "completed", notes: [] };
     },
     async submitExtensionCommandForm(
@@ -133,6 +136,7 @@ function createLauncher(
     roomJid?: string | null;
     sendPublicChannelMessage?: (body: string) => Promise<void>;
     events?: string[] | undefined;
+    invokeError?: Error | undefined;
     submitError?: Error | undefined;
     discoveredCommands?: DiscoveredExtensionCommand[] | undefined;
   } = {},
@@ -140,6 +144,7 @@ function createLauncher(
   const roomJid = ref(options.roomJid ?? null);
   const fake = fakeClient(executeResults, {
     events: options.events,
+    invokeError: options.invokeError,
     submitError: options.submitError,
     discoveredCommands: options.discoveredCommands,
   });
@@ -382,6 +387,96 @@ describe("dispatchSlashInvocation: inline-submit", () => {
     expect(submitCalls).toHaveLength(1);
     expect(launcher.commandStates.value[aiCommand.node]?.state).toBe("error");
     expect(launcher.commandStates.value[aiCommand.node]?.detail).toBe("submit failed");
+  });
+});
+
+describe("dispatchSlashInvocation: direct-execute", () => {
+  test("invokes completed channel commands without opening the palette", async () => {
+    const { launcher, invokeCalls, submitCalls } = createLauncher([
+      { status: "completed", notes: [] },
+    ], { roomJid: "pub@muc.example.com" });
+
+    const ok = await launcher.dispatchSlashInvocation({
+      kind: "direct-execute",
+      command: stargateCommand,
+    });
+
+    expect(ok).toBe(true);
+    expect(invokeCalls).toEqual([{ command: stargateCommand, roomJid: "pub@muc.example.com" }]);
+    expect(submitCalls).toEqual([]);
+    expect(launcher.open.value).toBe(false);
+    expect(launcher.commandStates.value[stargateCommand.node]?.state).toBe("success");
+  });
+
+  test("closes an already-open palette after a clean no-form result", async () => {
+    const { launcher } = createLauncher([
+      { status: "completed", notes: [] },
+    ], { roomJid: "pub@muc.example.com" });
+    launcher.open.value = true;
+
+    const ok = await launcher.dispatchSlashInvocation({
+      kind: "direct-execute",
+      command: stargateCommand,
+    });
+
+    expect(ok).toBe(true);
+    expect(launcher.open.value).toBe(false);
+  });
+
+  test("opens the palette for a no-form warning result", async () => {
+    const { launcher } = createLauncher([
+      {
+        status: "completed",
+        notes: [{ type: "warning", value: "Stargate quotes require an active channel." }],
+      },
+    ]);
+
+    const ok = await launcher.dispatchSlashInvocation({
+      kind: "direct-execute",
+      command: stargateCommand,
+    });
+
+    expect(ok).toBe(true);
+    expect(launcher.open.value).toBe(true);
+    expect(launcher.commandStates.value[stargateCommand.node]).toEqual({
+      state: "warning",
+      detail: "Stargate quotes require an active channel.",
+    });
+  });
+
+  test("falls back to the palette when direct execution returns a form", async () => {
+    const { launcher } = createLauncher([
+      executingResult([field("question", { required: true })]),
+    ], { roomJid: "pub@muc.example.com" });
+
+    const ok = await launcher.dispatchSlashInvocation({
+      kind: "direct-execute",
+      command: stargateCommand,
+    });
+
+    expect(ok).toBe(true);
+    expect(launcher.open.value).toBe(true);
+    expect(launcher.commandForms.value[stargateCommand.node]?.fields[0]?.name).toBe("question");
+  });
+
+  test("opens the palette when direct execution fails", async () => {
+    const { launcher, invokeCalls } = createLauncher([], {
+      roomJid: "pub@muc.example.com",
+      invokeError: new Error("command failed"),
+    });
+
+    const ok = await launcher.dispatchSlashInvocation({
+      kind: "direct-execute",
+      command: stargateCommand,
+    });
+
+    expect(ok).toBe(false);
+    expect(invokeCalls).toEqual([{ command: stargateCommand, roomJid: "pub@muc.example.com" }]);
+    expect(launcher.open.value).toBe(true);
+    expect(launcher.commandStates.value[stargateCommand.node]).toEqual({
+      state: "error",
+      detail: "command failed",
+    });
   });
 });
 

--- a/chat/tests/slash-dispatch.test.ts
+++ b/chat/tests/slash-dispatch.test.ts
@@ -19,6 +19,15 @@ const poll: DiscoveredExtensionCommand = {
   composerPrefix: "poll",
 };
 
+const stargate: DiscoveredExtensionCommand = {
+  serviceJid: "extensions.example.com",
+  node: "urn:waddle:extension:1:stargate-quotes",
+  name: "/stargate",
+  scope: "channel",
+  composerPrefix: "stargate",
+  composerExecute: true,
+};
+
 describe("buildSlashInvocation", () => {
   test("inline-submit when inlineField is declared and trailing has text", () => {
     expect(buildSlashInvocation(ai, "tell me a joke")).toEqual({
@@ -48,6 +57,21 @@ describe("buildSlashInvocation", () => {
     expect(buildSlashInvocation(poll, "")).toEqual({
       kind: "open-palette",
       command: poll,
+    });
+  });
+
+  test("direct-execute for composer execute commands without trailing text", () => {
+    expect(buildSlashInvocation(stargate, "")).toEqual({
+      kind: "direct-execute",
+      command: stargate,
+    });
+  });
+
+  test("open-palette with prefill for composer execute commands with trailing text", () => {
+    expect(buildSlashInvocation(stargate, "indeed")).toEqual({
+      kind: "open-palette",
+      command: stargate,
+      prefillFirstRequired: "indeed",
     });
   });
 

--- a/server/crates/waddle-extensions/src/host_tools.rs
+++ b/server/crates/waddle-extensions/src/host_tools.rs
@@ -200,12 +200,25 @@ pub enum MessageTarget {
     Direct(BareJid),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MessageMarkupKind {
+    Blockquote,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MessageMarkupSpan {
+    pub kind: MessageMarkupKind,
+    pub start: u32,
+    pub end: u32,
+}
+
 #[derive(Debug, Clone)]
 pub struct SendMessageRequest {
     pub target: MessageTarget,
     pub body: DisplayText,
     pub thread_id: Option<ThreadId>,
     pub reply_to: Option<ReplyTarget>,
+    pub markup: Vec<MessageMarkupSpan>,
     pub extensions: Option<ExtensionEnvelope>,
 }
 

--- a/server/crates/waddle-extensions/src/lib.rs
+++ b/server/crates/waddle-extensions/src/lib.rs
@@ -12,10 +12,10 @@ pub use host_tools::{
     GetPresenceRequest, GetPresenceResponse, GetRosterRequest, GetRosterResponse, HostToolError,
     HostToolErrorCode, InvocationContext, ListChannelsRequest, ListChannelsResponse,
     ListRoomMembersRequest, ListRoomMembersResponse, ListSpacesRequest, ListSpacesResponse,
-    MamQuery, MamQueryResponse, MamTarget, MessageTarget, MucAffiliation, MucRole,
-    PresenceAvailability, PresenceShow, PresenceState, PubSubGetItemsRequest,
-    PubSubGetItemsResponse, PubSubStoredItem, RoomMember, RosterAsk, RosterEntry,
-    RosterSubscription, SendMessageRequest, SendMessageResponse, SpaceSummary,
+    MamQuery, MamQueryResponse, MamTarget, MessageMarkupKind, MessageMarkupSpan, MessageTarget,
+    MucAffiliation, MucRole, PresenceAvailability, PresenceShow, PresenceState,
+    PubSubGetItemsRequest, PubSubGetItemsResponse, PubSubStoredItem, RoomMember, RosterAsk,
+    RosterEntry, RosterSubscription, SendMessageRequest, SendMessageResponse, SpaceSummary,
 };
 pub use manager::{ExtensionManager, MessageExtensionOutcome};
 pub use types::{

--- a/server/crates/waddle-extensions/src/runtime/host_tool_conversions.rs
+++ b/server/crates/waddle-extensions/src/runtime/host_tool_conversions.rs
@@ -389,13 +389,10 @@ fn validate_message_markup(
     }
     for (index, left) in spans.iter().enumerate() {
         for right in &spans[index + 1..] {
-            let crosses_left =
-                left.start < right.start && right.start < left.end && left.end < right.end;
-            let crosses_right =
-                right.start < left.start && left.start < right.end && right.end < left.end;
-            if crosses_left || crosses_right {
+            let overlaps = left.start < right.end && right.start < left.end;
+            if overlaps {
                 return Err(HostToolError::invalid_request(
-                    DisplayText::new("message markup block ranges must not partially overlap")
+                    DisplayText::new("message markup block ranges must not overlap")
                         .expect("static message is non-empty"),
                 ));
             }

--- a/server/crates/waddle-extensions/src/runtime/host_tool_conversions.rs
+++ b/server/crates/waddle-extensions/src/runtime/host_tool_conversions.rs
@@ -317,6 +317,12 @@ impl TryFrom<wit_types::SendMessageRequest> for host_domain::SendMessageRequest 
                 DisplayText::new(error.to_string()).expect("type error message is non-empty"),
             )
         })?;
+        let markup = value
+            .markup
+            .into_iter()
+            .map(TryInto::try_into)
+            .collect::<Result<Vec<_>, _>>()?;
+        validate_message_markup(&body, &markup)?;
         Ok(Self {
             target: value.target.try_into()?,
             body,
@@ -333,6 +339,7 @@ impl TryFrom<wit_types::SendMessageRequest> for host_domain::SendMessageRequest 
                     )
                 },
             )?,
+            markup,
             extensions: value
                 .extensions
                 .map(TryInto::try_into)
@@ -345,6 +352,56 @@ impl TryFrom<wit_types::SendMessageRequest> for host_domain::SendMessageRequest 
                 })?,
         })
     }
+}
+
+impl TryFrom<wit_types::MessageMarkupSpan> for host_domain::MessageMarkupSpan {
+    type Error = HostToolError;
+
+    fn try_from(value: wit_types::MessageMarkupSpan) -> Result<Self, Self::Error> {
+        Ok(Self {
+            kind: value.kind.into(),
+            start: value.start,
+            end: value.end,
+        })
+    }
+}
+
+impl From<wit_types::MessageMarkupKind> for host_domain::MessageMarkupKind {
+    fn from(value: wit_types::MessageMarkupKind) -> Self {
+        match value {
+            wit_types::MessageMarkupKind::Blockquote => Self::Blockquote,
+        }
+    }
+}
+
+fn validate_message_markup(
+    body: &DisplayText,
+    spans: &[host_domain::MessageMarkupSpan],
+) -> Result<(), HostToolError> {
+    let body_len = body.as_str().chars().count() as u32;
+    for span in spans {
+        if span.start >= span.end || span.end > body_len {
+            return Err(HostToolError::invalid_request(
+                DisplayText::new("message markup span range is outside the body")
+                    .expect("static message is non-empty"),
+            ));
+        }
+    }
+    for (index, left) in spans.iter().enumerate() {
+        for right in &spans[index + 1..] {
+            let crosses_left =
+                left.start < right.start && right.start < left.end && left.end < right.end;
+            let crosses_right =
+                right.start < left.start && left.start < right.end && right.end < left.end;
+            if crosses_left || crosses_right {
+                return Err(HostToolError::invalid_request(
+                    DisplayText::new("message markup block ranges must not partially overlap")
+                        .expect("static message is non-empty"),
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 impl TryFrom<wit_types::MessageTarget> for host_domain::MessageTarget {

--- a/server/crates/waddle-extensions/src/runtime/tests.rs
+++ b/server/crates/waddle-extensions/src/runtime/tests.rs
@@ -105,11 +105,18 @@ impl ExtensionHostTools for MockHostTools {
         assert_eq!(request.body.as_str(), "hello from extension");
         assert_eq!(
             request.markup,
-            vec![host_domain::MessageMarkupSpan {
-                kind: host_domain::MessageMarkupKind::Blockquote,
-                start: 0,
-                end: 5,
-            }]
+            vec![
+                host_domain::MessageMarkupSpan {
+                    kind: host_domain::MessageMarkupKind::Blockquote,
+                    start: 0,
+                    end: 5,
+                },
+                host_domain::MessageMarkupSpan {
+                    kind: host_domain::MessageMarkupKind::Blockquote,
+                    start: 5,
+                    end: 10,
+                },
+            ]
         );
         Ok(host_domain::SendMessageResponse {
             stanza_id: StanzaId::new("extension-stanza").expect("stanza id"),
@@ -179,11 +186,18 @@ async fn granted_send_message_import_delegates_to_trait() {
             },
             thread_id: None,
             reply_to: None,
-            markup: vec![wit_types::MessageMarkupSpan {
-                kind: wit_types::MessageMarkupKind::Blockquote,
-                start: 0,
-                end: 5,
-            }],
+            markup: vec![
+                wit_types::MessageMarkupSpan {
+                    kind: wit_types::MessageMarkupKind::Blockquote,
+                    start: 0,
+                    end: 5,
+                },
+                wit_types::MessageMarkupSpan {
+                    kind: wit_types::MessageMarkupKind::Blockquote,
+                    start: 5,
+                    end: 10,
+                },
+            ],
             extensions: None,
         },
     )
@@ -269,6 +283,50 @@ async fn crossing_send_message_markup_ranges_fail_before_delegating() {
     .expect("host import does not trap");
 
     let error = result.expect_err("crossing markup ranges are rejected");
+    assert!(matches!(
+        error.code,
+        wit_types::HostToolErrorCode::InvalidRequest
+    ));
+    assert_eq!(tools.send_message_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn contained_send_message_markup_ranges_fail_before_delegating() {
+    let tools = Arc::new(MockHostTools::default());
+    let mut grants = HashSet::new();
+    grants.insert(ExtensionCapability::HostMessageSend);
+    let mut state = host_state(Arc::clone(&tools), grants);
+
+    let result = HostToolsHost::send_message(
+        &mut state,
+        wit_types::SendMessageRequest {
+            target: wit_types::MessageTarget::Muc(wit_types::RoomJid {
+                value: "room@muc.example.com".to_string(),
+            }),
+            body: wit_types::DisplayText {
+                value: "0123456789abcdef".to_string(),
+            },
+            thread_id: None,
+            reply_to: None,
+            markup: vec![
+                wit_types::MessageMarkupSpan {
+                    kind: wit_types::MessageMarkupKind::Blockquote,
+                    start: 0,
+                    end: 10,
+                },
+                wit_types::MessageMarkupSpan {
+                    kind: wit_types::MessageMarkupKind::Blockquote,
+                    start: 2,
+                    end: 8,
+                },
+            ],
+            extensions: None,
+        },
+    )
+    .await
+    .expect("host import does not trap");
+
+    let error = result.expect_err("contained markup ranges are rejected");
     assert!(matches!(
         error.code,
         wit_types::HostToolErrorCode::InvalidRequest

--- a/server/crates/waddle-extensions/src/runtime/tests.rs
+++ b/server/crates/waddle-extensions/src/runtime/tests.rs
@@ -103,6 +103,14 @@ impl ExtensionHostTools for MockHostTools {
             "alice@example.com"
         );
         assert_eq!(request.body.as_str(), "hello from extension");
+        assert_eq!(
+            request.markup,
+            vec![host_domain::MessageMarkupSpan {
+                kind: host_domain::MessageMarkupKind::Blockquote,
+                start: 0,
+                end: 5,
+            }]
+        );
         Ok(host_domain::SendMessageResponse {
             stanza_id: StanzaId::new("extension-stanza").expect("stanza id"),
         })
@@ -171,6 +179,11 @@ async fn granted_send_message_import_delegates_to_trait() {
             },
             thread_id: None,
             reply_to: None,
+            markup: vec![wit_types::MessageMarkupSpan {
+                kind: wit_types::MessageMarkupKind::Blockquote,
+                start: 0,
+                end: 5,
+            }],
             extensions: None,
         },
     )
@@ -180,6 +193,87 @@ async fn granted_send_message_import_delegates_to_trait() {
 
     assert_eq!(tools.send_message_calls.load(Ordering::SeqCst), 1);
     assert_eq!(response.stanza_id.value, "extension-stanza");
+}
+
+#[tokio::test]
+async fn invalid_send_message_markup_range_fails_before_delegating() {
+    let tools = Arc::new(MockHostTools::default());
+    let mut grants = HashSet::new();
+    grants.insert(ExtensionCapability::HostMessageSend);
+    let mut state = host_state(Arc::clone(&tools), grants);
+
+    let result = HostToolsHost::send_message(
+        &mut state,
+        wit_types::SendMessageRequest {
+            target: wit_types::MessageTarget::Muc(wit_types::RoomJid {
+                value: "room@muc.example.com".to_string(),
+            }),
+            body: wit_types::DisplayText {
+                value: "hi".to_string(),
+            },
+            thread_id: None,
+            reply_to: None,
+            markup: vec![wit_types::MessageMarkupSpan {
+                kind: wit_types::MessageMarkupKind::Blockquote,
+                start: 0,
+                end: 3,
+            }],
+            extensions: None,
+        },
+    )
+    .await
+    .expect("host import does not trap");
+
+    let error = result.expect_err("invalid markup range is rejected");
+    assert!(matches!(
+        error.code,
+        wit_types::HostToolErrorCode::InvalidRequest
+    ));
+    assert_eq!(tools.send_message_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn crossing_send_message_markup_ranges_fail_before_delegating() {
+    let tools = Arc::new(MockHostTools::default());
+    let mut grants = HashSet::new();
+    grants.insert(ExtensionCapability::HostMessageSend);
+    let mut state = host_state(Arc::clone(&tools), grants);
+
+    let result = HostToolsHost::send_message(
+        &mut state,
+        wit_types::SendMessageRequest {
+            target: wit_types::MessageTarget::Muc(wit_types::RoomJid {
+                value: "room@muc.example.com".to_string(),
+            }),
+            body: wit_types::DisplayText {
+                value: "0123456789abcdef".to_string(),
+            },
+            thread_id: None,
+            reply_to: None,
+            markup: vec![
+                wit_types::MessageMarkupSpan {
+                    kind: wit_types::MessageMarkupKind::Blockquote,
+                    start: 0,
+                    end: 10,
+                },
+                wit_types::MessageMarkupSpan {
+                    kind: wit_types::MessageMarkupKind::Blockquote,
+                    start: 5,
+                    end: 15,
+                },
+            ],
+            extensions: None,
+        },
+    )
+    .await
+    .expect("host import does not trap");
+
+    let error = result.expect_err("crossing markup ranges are rejected");
+    assert!(matches!(
+        error.code,
+        wit_types::HostToolErrorCode::InvalidRequest
+    ));
+    assert_eq!(tools.send_message_calls.load(Ordering::SeqCst), 0);
 }
 
 #[tokio::test]

--- a/server/crates/waddle-extensions/src/runtime/wit_to_domain.rs
+++ b/server/crates/waddle-extensions/src/runtime/wit_to_domain.rs
@@ -75,6 +75,7 @@ impl TryFrom<wit_types::CommandDescriptor> for CommandDescriptor {
             scope: value.scope.into(),
             composer_prefix: value.composer_prefix,
             inline_field: value.inline_field,
+            composer_execute: value.composer_execute,
         })
     }
 }
@@ -280,6 +281,7 @@ mod tests {
         node: &str,
         composer_prefix: Option<&str>,
         inline_field: Option<&str>,
+        composer_execute: bool,
     ) -> wit_types::CommandDescriptor {
         wit_types::CommandDescriptor {
             node: wit_types::CommandNode {
@@ -291,30 +293,34 @@ mod tests {
             scope: wit_types::CommandScope::Global,
             composer_prefix: composer_prefix.map(str::to_string),
             inline_field: inline_field.map(str::to_string),
+            composer_execute,
         }
     }
 
     #[test]
-    fn command_descriptor_round_trip_carries_composer_prefix_and_inline_field() {
+    fn command_descriptor_round_trip_carries_composer_metadata() {
         let descriptor: CommandDescriptor = wit_descriptor(
             "urn:waddle:extension:1:ai-chatbot",
             Some("ai"),
             Some("prompt"),
+            true,
         )
         .try_into()
         .expect("convert");
         assert_eq!(descriptor.composer_prefix.as_deref(), Some("ai"));
         assert_eq!(descriptor.inline_field.as_deref(), Some("prompt"));
+        assert!(descriptor.composer_execute);
     }
 
     #[test]
     fn command_descriptor_round_trip_preserves_none_when_absent() {
         let descriptor: CommandDescriptor =
-            wit_descriptor("urn:waddle:extension:1:invoke", None, None)
+            wit_descriptor("urn:waddle:extension:1:invoke", None, None, false)
                 .try_into()
                 .expect("convert");
         assert!(descriptor.composer_prefix.is_none());
         assert!(descriptor.inline_field.is_none());
+        assert!(!descriptor.composer_execute);
     }
 
     #[test]

--- a/server/crates/waddle-extensions/src/types/manifest.rs
+++ b/server/crates/waddle-extensions/src/types/manifest.rs
@@ -133,6 +133,12 @@ pub struct CommandDescriptor {
     pub composer_prefix: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub inline_field: Option<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub composer_execute: bool,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]

--- a/server/crates/waddle-extensions/tests/framework_vocabulary.rs
+++ b/server/crates/waddle-extensions/tests/framework_vocabulary.rs
@@ -81,6 +81,7 @@ fn sample_manifest() -> ExtensionManifest {
             scope: CommandScope::Global,
             composer_prefix: None,
             inline_field: None,
+            composer_execute: false,
         }],
         routes: Vec::new(),
         pubsub_nodes: vec![id!(

--- a/server/crates/waddle-server/src/server/extension_host_adapter.rs
+++ b/server/crates/waddle-server/src/server/extension_host_adapter.rs
@@ -48,6 +48,14 @@ pub struct ExtensionHostAdapter {
     state: Arc<WebSocketState>,
 }
 
+struct DirectDispatchMessage {
+    stanza_id: waddle_extensions::StanzaId,
+    body: String,
+    thread_id: Option<ThreadId>,
+    reply_to: Option<ReplyTarget>,
+    markup: Vec<waddle_extensions::MessageMarkupSpan>,
+}
+
 impl ExtensionHostAdapter {
     pub fn new(state: Arc<WebSocketState>) -> Self {
         Self { state }
@@ -105,6 +113,7 @@ impl ExtensionHostAdapter {
                     stanza_id: Some(request.stanza_id),
                     thread_id: request.thread_id,
                     reply_to: request.reply_to,
+                    markup: request.markup,
                     extensions,
                 };
                 let session = invocation.session.as_ref();
@@ -133,10 +142,13 @@ impl ExtensionHostAdapter {
                 self.dispatch_direct(
                     invocation,
                     target,
-                    request.stanza_id.clone(),
-                    request.body,
-                    request.thread_id,
-                    request.reply_to,
+                    DirectDispatchMessage {
+                        stanza_id: request.stanza_id.clone(),
+                        body: request.body,
+                        thread_id: request.thread_id,
+                        reply_to: request.reply_to,
+                        markup: request.markup,
+                    },
                 )
                 .await?;
                 Ok(request.stanza_id)
@@ -148,21 +160,20 @@ impl ExtensionHostAdapter {
         &self,
         invocation: &ExtensionInvocation,
         target: Jid,
-        stanza_id: waddle_extensions::StanzaId,
-        body: String,
-        thread_id: Option<ThreadId>,
-        reply_to: Option<ReplyTarget>,
+        request: DirectDispatchMessage,
     ) -> Result<(), ExtensionHostAdapterError> {
         let mut message = Message::new(Some(target));
-        message.id = Some(xmpp_parsers::message::Id(stanza_id.as_str().to_string()));
+        message.id = Some(xmpp_parsers::message::Id(
+            request.stanza_id.as_str().to_string(),
+        ));
         message.type_ = XmppMessageType::Chat;
         message
             .bodies
-            .insert(xmpp_parsers::message::Lang(String::new()), body);
-        if let Some(thread_id) = thread_id.as_ref() {
+            .insert(xmpp_parsers::message::Lang(String::new()), request.body);
+        if let Some(thread_id) = request.thread_id.as_ref() {
             waddle_xmpp::xep0201::set_thread_id(&mut message, thread_id.as_str());
         }
-        if let Some(reply_to) = reply_to.as_ref() {
+        if let Some(reply_to) = request.reply_to.as_ref() {
             let mut reply = waddle_xmpp::xep::ReplyReference::new(reply_to.id.as_str());
             if let Some(to) = reply_to
                 .to
@@ -172,6 +183,9 @@ impl ExtensionHostAdapter {
                 reply = reply.with_to(to);
             }
             waddle_xmpp::xep::set_reply_payload(&mut message, &reply);
+        }
+        if let Some(markup) = interpret::build_extension_message_markup(&request.markup) {
+            message.payloads.push(markup);
         }
 
         let mut sm = XmppStateMachine::new(

--- a/server/crates/waddle-server/src/server/extension_host_adapter/host_tools.rs
+++ b/server/crates/waddle-server/src/server/extension_host_adapter/host_tools.rs
@@ -209,6 +209,7 @@ impl ext_host::ExtensionHostTools for ExtensionHostAdapter {
                     body: request.body.into_string(),
                     thread_id: request.thread_id,
                     reply_to: request.reply_to,
+                    markup: request.markup,
                     extensions: request.extensions,
                 },
             )

--- a/server/crates/waddle-server/src/server/extension_host_adapter/types.rs
+++ b/server/crates/waddle-server/src/server/extension_host_adapter/types.rs
@@ -104,6 +104,7 @@ pub struct HostSendMessage {
     pub body: String,
     pub thread_id: Option<ThreadId>,
     pub reply_to: Option<ReplyTarget>,
+    pub markup: Vec<waddle_extensions::MessageMarkupSpan>,
     pub extensions: Option<waddle_extensions::ExtensionEnvelope>,
 }
 

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -76,7 +76,8 @@ use std::sync::Arc;
 use tracing::{debug, error, info, warn};
 use waddle_extensions::{
     message_has_framework_envelope, DisplayText, ExtensionEffect, ExtensionEnvelope,
-    ExtensionManager, ReplyTarget, RoomJid, StanzaId, ThreadId, WaddleId,
+    ExtensionManager, MessageMarkupKind, MessageMarkupSpan, ReplyTarget, RoomJid, StanzaId,
+    ThreadId, WaddleId,
 };
 use waddle_xmpp::carbons::{build_received_carbon, build_sent_carbon};
 use waddle_xmpp::inbox::runtime::{direct_message_entry, groupchat_entry, groupchat_thread_entry};
@@ -155,7 +156,9 @@ use archive_groupchat_event::archive_groupchat_event;
 use archive_lookup::{
     build_carbon_envelope, lookup_archived_message, waddle_id_for_room_jid, ToElementString,
 };
-pub(crate) use bot::{dispatch_extension_bot_groupchat_response, ExtensionRoomMessage};
+pub(crate) use bot::{
+    build_extension_message_markup, dispatch_extension_bot_groupchat_response, ExtensionRoomMessage,
+};
 use carbons::send_carbons;
 use direct_archive::archive_direct;
 use direct_inbox::project_direct_inbox;

--- a/server/crates/waddle-server/src/server/routes/interpret/bot.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/bot.rs
@@ -59,6 +59,9 @@ pub(super) async fn dispatch_bot_groupchat_response(
         }
         set_reply_payload(&mut working, &reply);
     }
+    if let Some(markup) = build_extension_message_markup(&response.markup) {
+        working.payloads.push(markup);
+    }
     if let Some(extensions) = response.extensions.as_ref() {
         working.payloads.push(extensions.to_minidom());
         working
@@ -143,12 +146,27 @@ pub(crate) struct ExtensionRoomMessage {
     pub stanza_id: Option<StanzaId>,
     pub thread_id: Option<ThreadId>,
     pub reply_to: Option<ReplyTarget>,
+    pub markup: Vec<MessageMarkupSpan>,
     pub extensions: Option<ExtensionEnvelope>,
 }
 
 pub(crate) struct ExtensionRoomDispatchResult {
     pub outcome: InterpretOutcome,
     pub stanza_id: StanzaId,
+}
+
+pub(crate) fn build_extension_message_markup(spans: &[MessageMarkupSpan]) -> Option<Element> {
+    let xep_spans = spans
+        .iter()
+        .map(|span| waddle_xmpp::xep::Xep0394MarkupSpan {
+            kind: match span.kind {
+                MessageMarkupKind::Blockquote => waddle_xmpp::xep::Xep0394MarkupKind::Blockquote,
+            },
+            start: span.start,
+            end: span.end,
+        })
+        .collect::<Vec<_>>();
+    waddle_xmpp::xep::build_message_markup_element(&xep_spans)
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/server/crates/waddle-server/src/server/routes/interpret/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/tests.rs
@@ -1594,7 +1594,10 @@ async fn dispatch_to_room_drops_when_no_web_socket_state_in_deps() {
 
 #[tokio::test]
 async fn extension_room_message_dispatches_threaded_muc_message() {
-    use waddle_extensions::{DisplayText, FullJidValue, ReplyTarget, RoomJid, StanzaId, ThreadId};
+    use waddle_extensions::{
+        DisplayText, FullJidValue, MessageMarkupKind, MessageMarkupSpan, ReplyTarget, RoomJid,
+        StanzaId, ThreadId,
+    };
 
     let registry = ConnectionRegistry::new();
     let room_jid: jid::BareJid = "chat@muc.example.com".parse().expect("room jid");
@@ -1637,6 +1640,11 @@ async fn extension_room_message_dispatches_threaded_muc_message() {
             id: StanzaId::new("root-msg").expect("reply id"),
             to: Some(FullJidValue::new(alice.to_string()).expect("reply to")),
         }),
+        markup: vec![MessageMarkupSpan {
+            kind: MessageMarkupKind::Blockquote,
+            start: 0,
+            end: 10,
+        }],
         extensions: None,
     };
 
@@ -1688,6 +1696,16 @@ async fn extension_room_message_dispatches_threaded_muc_message() {
         message.bodies.get("").map(|body| body.as_str()),
         Some("bot answer")
     );
+    let markup = message
+        .payloads
+        .iter()
+        .find(|payload| payload.is("markup", waddle_xmpp::xep::NS_MESSAGE_MARKUP))
+        .expect("markup payload");
+    let quote = markup
+        .get_child("bquote", waddle_xmpp::xep::NS_MESSAGE_MARKUP)
+        .expect("blockquote markup");
+    assert_eq!(quote.attr("start"), Some("0"));
+    assert_eq!(quote.attr("end"), Some("10"));
     let reply = parse_reply_from_message(message).expect("reply payload");
     assert_eq!(reply.id, "root-msg");
     assert_eq!(reply.to, None);

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/extension_forms.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/extension_forms.rs
@@ -152,6 +152,9 @@ pub(super) fn extension_command_metadata_form(
     if let Some(field_name) = descriptor.inline_field.as_deref() {
         form = form.add_field(Field::text_single("waddle#inline_field", field_name));
     }
+    if descriptor.composer_execute {
+        form = form.add_field(Field::text_single("waddle#composer_execute", "true"));
+    }
     form = add_profile_fields(form, profile);
     form.into_element()
 }
@@ -200,6 +203,7 @@ mod tests {
         scope: waddle_extensions::CommandScope,
         composer_prefix: Option<&str>,
         inline_field: Option<&str>,
+        composer_execute: bool,
     ) -> waddle_extensions::CommandDescriptor {
         waddle_extensions::CommandDescriptor {
             node: waddle_extensions::CommandNode::new(node).expect("command node"),
@@ -207,6 +211,7 @@ mod tests {
             scope,
             composer_prefix: composer_prefix.map(str::to_string),
             inline_field: inline_field.map(str::to_string),
+            composer_execute,
         }
     }
 
@@ -273,11 +278,13 @@ mod tests {
                 waddle_extensions::CommandScope::Channel,
                 None,
                 None,
+                false,
             ),
             None,
         );
         assert!(!has_field(&form, "waddle#composer_prefix"));
         assert!(!has_field(&form, "waddle#inline_field"));
+        assert!(!has_field(&form, "waddle#composer_execute"));
         assert_eq!(
             field_value(&form, "waddle#command_scope").as_deref(),
             Some("channel"),
@@ -293,6 +300,7 @@ mod tests {
                 waddle_extensions::CommandScope::Global,
                 Some("ai"),
                 Some("prompt"),
+                false,
             ),
             None,
         );
@@ -315,6 +323,7 @@ mod tests {
                 waddle_extensions::CommandScope::Channel,
                 Some("poll"),
                 None,
+                false,
             ),
             None,
         );
@@ -323,6 +332,26 @@ mod tests {
             Some("poll"),
         );
         assert!(!has_field(&form, "waddle#inline_field"));
+    }
+
+    #[test]
+    fn command_metadata_form_serializes_composer_execute_when_enabled() {
+        let form = extension_command_metadata_form(
+            &plugin("stargate-quotes"),
+            &descriptor(
+                "urn:waddle:extension:1:stargate-quotes",
+                waddle_extensions::CommandScope::Channel,
+                Some("stargate"),
+                None,
+                true,
+            ),
+            None,
+        );
+
+        assert_eq!(
+            field_value(&form, "waddle#composer_execute").as_deref(),
+            Some("true"),
+        );
     }
 
     #[test]
@@ -335,6 +364,7 @@ mod tests {
                 waddle_extensions::CommandScope::Channel,
                 Some("github"),
                 None,
+                false,
             ),
             Some(&extension_profile),
         );

--- a/server/crates/waddle-xmpp/src/xep/exports.rs
+++ b/server/crates/waddle-xmpp/src/xep/exports.rs
@@ -178,6 +178,11 @@ pub use super::xep0393::{
     spans_to_plain, strip_unstyled, Block, Span, StyledBody, StylingCarrier, NS_STYLING,
 };
 
+pub use super::xep0394::{
+    build_message_markup_element, MarkupKind as Xep0394MarkupKind, MarkupSpan as Xep0394MarkupSpan,
+    NS_MARKUP as NS_MESSAGE_MARKUP,
+};
+
 pub use waddle_xmpp_core::xep0359::{
     add_origin_id, add_stanza_id as add_stanza_id_xep0359, build_origin_id_element,
     build_stanza_id_element, extract_origin_id as extract_origin_id_xep0359, extract_origin_id_str,

--- a/server/crates/waddle-xmpp/src/xep/mod.rs
+++ b/server/crates/waddle-xmpp/src/xep/mod.rs
@@ -47,6 +47,8 @@
 //!   from input strings via SHA-1 hue mapping with CVD correction.
 //! - **XEP-0393**: Message Styling - Inline text formatting parser for
 //!   bold, italic, strikethrough, code, code blocks, and block quotes.
+//! - **XEP-0394**: Message Markup - Semantic message formatting metadata,
+//!   including block quotes via `<bquote/>`.
 //! - **XEP-0359**: Unique and Stable Stanza IDs - Server-assigned `<stanza-id/>`
 //!   and client-assigned `<origin-id/>` for stable message referencing.
 //! - **XEP-0334**: Message Processing Hints
@@ -169,6 +171,7 @@ pub mod xep0363;
 pub mod xep0372;
 pub mod xep0377;
 pub mod xep0393;
+pub mod xep0394;
 pub mod xep0401;
 pub mod xep0402;
 pub mod xep0410;

--- a/server/crates/waddle-xmpp/src/xep/xep0394.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0394.rs
@@ -1,0 +1,71 @@
+//! XEP-0394: Message Markup
+//!
+//! Builds markup metadata payloads that keep the message body as the single
+//! textual source of truth while carrying semantic formatting separately.
+
+use minidom::Element;
+
+/// Namespace for XEP-0394 Message Markup.
+pub const NS_MARKUP: &str = "urn:xmpp:markup:0";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MarkupKind {
+    Blockquote,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MarkupSpan {
+    pub kind: MarkupKind,
+    pub start: u32,
+    pub end: u32,
+}
+
+pub fn build_message_markup_element(spans: &[MarkupSpan]) -> Option<Element> {
+    if spans.is_empty() {
+        return None;
+    }
+    let mut markup = Element::builder("markup", NS_MARKUP).build();
+    for span in spans {
+        let child = match span.kind {
+            MarkupKind::Blockquote => Element::builder("bquote", NS_MARKUP)
+                .attr(
+                    minidom::rxml::xml_ncname!("start").to_owned(),
+                    span.start.to_string(),
+                )
+                .attr(
+                    minidom::rxml::xml_ncname!("end").to_owned(),
+                    span.end.to_string(),
+                )
+                .build(),
+        };
+        markup.append_child(child);
+    }
+    Some(markup)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_blockquote_markup_element() {
+        let element = build_message_markup_element(&[MarkupSpan {
+            kind: MarkupKind::Blockquote,
+            start: 0,
+            end: 8,
+        }])
+        .expect("markup element");
+
+        assert!(element.is("markup", NS_MARKUP));
+        let quote = element
+            .get_child("bquote", NS_MARKUP)
+            .expect("blockquote child");
+        assert_eq!(quote.attr("start"), Some("0"));
+        assert_eq!(quote.attr("end"), Some("8"));
+    }
+
+    #[test]
+    fn omits_empty_markup() {
+        assert!(build_message_markup_element(&[]).is_none());
+    }
+}

--- a/server/extensions/ai-chatbot/src/command.rs
+++ b/server/extensions/ai-chatbot/src/command.rs
@@ -196,6 +196,7 @@ fn room_message_request(
         body,
         thread_id: target.thread_id.clone(),
         reply_to: target.reply_to.clone(),
+        markup: vec![],
         extensions: None,
     }
 }

--- a/server/extensions/ai-chatbot/src/manifest.rs
+++ b/server/extensions/ai-chatbot/src/manifest.rs
@@ -70,5 +70,6 @@ fn command_descriptor(
         scope,
         composer_prefix: composer_prefix.map(str::to_string),
         inline_field: inline_field.map(str::to_string),
+        composer_execute: false,
     }
 }

--- a/server/extensions/decision-polls/src/helpers.rs
+++ b/server/extensions/decision-polls/src/helpers.rs
@@ -162,6 +162,7 @@ pub(super) fn command_descriptor(
         scope,
         composer_prefix: composer_prefix.map(str::to_string),
         inline_field: inline_field.map(str::to_string),
+        composer_execute: false,
     }
 }
 

--- a/server/extensions/decision-polls/src/poll.rs
+++ b/server/extensions/decision-polls/src/poll.rs
@@ -63,6 +63,7 @@ pub(super) fn send_poll_message(poll: &Poll) -> Result<(), types::ExtensionError
         body: display(&format!("Poll: {}", poll.question)),
         thread_id: None,
         reply_to: None,
+        markup: vec![],
         extensions: Some(types::ExtensionEnvelope {
             version: 1,
             enrichments: vec![poll_enrichment(poll)],

--- a/server/extensions/github/src/lib.rs
+++ b/server/extensions/github/src/lib.rs
@@ -112,6 +112,7 @@ fn command_descriptor(node: &str, name: &str) -> types::CommandDescriptor {
         scope: types::CommandScope::Global,
         composer_prefix: None,
         inline_field: None,
+        composer_execute: false,
     }
 }
 
@@ -887,6 +888,7 @@ fn send_room_message(
         body,
         thread_id: None,
         reply_to: None,
+        markup: vec![],
         extensions,
     };
     send_message_request(&request)

--- a/server/extensions/link-board/src/helpers.rs
+++ b/server/extensions/link-board/src/helpers.rs
@@ -39,6 +39,7 @@ pub(super) fn command_descriptor(
         scope,
         composer_prefix: composer_prefix.map(str::to_string),
         inline_field: inline_field.map(str::to_string),
+        composer_execute: false,
     }
 }
 

--- a/server/extensions/stargate-quotes/src/command.rs
+++ b/server/extensions/stargate-quotes/src/command.rs
@@ -2,7 +2,7 @@
 use crate::bindings::waddle::extension::host_tools;
 use crate::bindings::waddle::extension::types;
 use crate::constants::{COMMAND_NODE, COMMAND_RESULT_ID, COMMAND_RESULT_TEXT};
-use crate::quotes::{quote_body, quote_catalog, select_quote_with_rng};
+use crate::quotes::{quote_body, quote_catalog, quote_markup, select_quote_with_rng};
 use crate::ui::{display, payload_namespace, plugin_id, timestamp};
 
 #[cfg(test)]
@@ -31,7 +31,7 @@ pub(crate) fn handle_command_with_rng(
     };
     let quotes = quote_catalog()?;
     let quote = select_quote_with_rng(&quotes, &mut next_u64)?;
-    send_room_message(&room, display(&quote_body(quote)))?;
+    send_room_message(&room, display(&quote_body(quote)), quote_markup(quote))?;
     Ok(vec![posted_result_effect()])
 }
 
@@ -76,12 +76,14 @@ fn posted_result_effect() -> types::ExtensionEffect {
 fn room_message_request(
     room: &types::RoomJid,
     body: types::DisplayText,
+    markup: Vec<types::MessageMarkupSpan>,
 ) -> types::SendMessageRequest {
     types::SendMessageRequest {
         target: types::MessageTarget::Muc(room.clone()),
         body,
         thread_id: None,
         reply_to: None,
+        markup,
         extensions: None,
     }
 }
@@ -90,8 +92,9 @@ fn room_message_request(
 fn send_room_message(
     room: &types::RoomJid,
     body: types::DisplayText,
+    markup: Vec<types::MessageMarkupSpan>,
 ) -> Result<(), types::ExtensionError> {
-    host_tools::send_message(&room_message_request(room, body))
+    host_tools::send_message(&room_message_request(room, body, markup))
         .map(|_| ())
         .map_err(extension_error_from_host_tool)
 }
@@ -100,11 +103,12 @@ fn send_room_message(
 fn send_room_message(
     room: &types::RoomJid,
     body: types::DisplayText,
+    markup: Vec<types::MessageMarkupSpan>,
 ) -> Result<(), types::ExtensionError> {
     sent_room_messages()
         .lock()
         .expect("sent room messages lock")
-        .push(room_message_request(room, body));
+        .push(room_message_request(room, body, markup));
     Ok(())
 }
 

--- a/server/extensions/stargate-quotes/src/lib.rs
+++ b/server/extensions/stargate-quotes/src/lib.rs
@@ -53,7 +53,9 @@ pub(crate) use constants::{COMMAND_NAME, COMMAND_NODE, COMMAND_RESULT_TEXT, PLUG
 #[cfg(test)]
 pub(crate) use manifest::manifest;
 #[cfg(test)]
-pub(crate) use quotes::{parse_quotes_json, quote_body, quote_catalog, select_quote_with_rng};
+pub(crate) use quotes::{
+    parse_quotes_json, quote_body, quote_catalog, quote_markup, select_quote_with_rng,
+};
 
 #[cfg(test)]
 mod tests;

--- a/server/extensions/stargate-quotes/src/manifest.rs
+++ b/server/extensions/stargate-quotes/src/manifest.rs
@@ -23,6 +23,7 @@ pub(crate) fn manifest() -> types::ExtensionManifest {
             scope: types::CommandScope::Channel,
             composer_prefix: Some("stargate".to_string()),
             inline_field: None,
+            composer_execute: true,
         }],
         routes: vec![],
         pubsub_nodes: vec![],

--- a/server/extensions/stargate-quotes/src/quotes.rs
+++ b/server/extensions/stargate-quotes/src/quotes.rs
@@ -52,7 +52,7 @@ pub(crate) fn quote_body(quote: &Quote) -> String {
 pub(crate) fn quote_markup(quote: &Quote) -> Vec<types::MessageMarkupSpan> {
     vec![types::MessageMarkupSpan {
         kind: types::MessageMarkupKind::Blockquote,
-        start: 0,
+        start: 2,
         end: (2 + quote.quote.chars().count()) as u32,
     }]
 }

--- a/server/extensions/stargate-quotes/src/quotes.rs
+++ b/server/extensions/stargate-quotes/src/quotes.rs
@@ -46,7 +46,15 @@ pub(crate) fn select_quote_with_rng(
 }
 
 pub(crate) fn quote_body(quote: &Quote) -> String {
-    format!("{}\n\n{}, {}", quote.quote, quote.role, quote.series)
+    format!("> {}\n\n{}, {}", quote.quote, quote.role, quote.series)
+}
+
+pub(crate) fn quote_markup(quote: &Quote) -> Vec<types::MessageMarkupSpan> {
+    vec![types::MessageMarkupSpan {
+        kind: types::MessageMarkupKind::Blockquote,
+        start: 0,
+        end: (2 + quote.quote.chars().count()) as u32,
+    }]
 }
 
 fn extension_error(code: types::ExtensionErrorCode, message: &str) -> types::ExtensionError {

--- a/server/extensions/stargate-quotes/src/tests.rs
+++ b/server/extensions/stargate-quotes/src/tests.rs
@@ -1,5 +1,5 @@
 use super::{
-    handle_command_with_rng, manifest, parse_quotes_json, quote_body, quote_catalog,
+    handle_command_with_rng, manifest, parse_quotes_json, quote_body, quote_catalog, quote_markup,
     select_quote_with_rng, take_sent_room_messages, types, COMMAND_NAME, COMMAND_NODE,
     COMMAND_RESULT_TEXT, PLUGIN_NS,
 };
@@ -17,6 +17,7 @@ fn manifest_registers_channel_stargate_command() {
         manifest.commands[0].composer_prefix.as_deref(),
         Some("stargate")
     );
+    assert!(manifest.commands[0].composer_execute);
     assert!(matches!(
         manifest.commands[0].scope,
         types::CommandScope::Channel
@@ -68,19 +69,33 @@ fn quote_catalog_json_only_contains_rendered_fields() {
 }
 
 #[test]
-fn quote_body_renders_plain_quote_with_role_and_series() {
+fn quote_body_renders_markdown_fallback_quote_with_role_and_series() {
     let quotes = quote_catalog().expect("quote catalog parses");
     let body = quote_body(&quotes[0]);
 
     assert_eq!(
         body,
         format!(
-            "{}\n\n{}, {}",
+            "> {}\n\n{}, {}",
             quotes[0].quote, quotes[0].role, quotes[0].series
         )
     );
-    assert!(!body.starts_with('"'));
     assert!(!body.contains("\n\n- "));
+}
+
+#[test]
+fn quote_markup_marks_only_the_quote_block() {
+    let quotes = quote_catalog().expect("quote catalog parses");
+    let spans = quote_markup(&quotes[0]);
+
+    assert_eq!(spans.len(), 1);
+    assert!(matches!(
+        spans[0].kind,
+        types::MessageMarkupKind::Blockquote
+    ));
+    assert_eq!(spans[0].start, 0);
+    assert_eq!(spans[0].end, (2 + quotes[0].quote.chars().count()) as u32);
+    assert!(spans[0].end < quote_body(&quotes[0]).chars().count() as u32);
 }
 
 #[test]
@@ -94,7 +109,7 @@ fn random_selection_rejects_low_values_that_would_bias_modulo() {
 }
 
 #[test]
-fn room_command_posts_plain_quote_and_returns_completion() {
+fn room_command_posts_blockquoted_quote_and_returns_completion() {
     let _ = take_sent_room_messages();
     let command = command_invocation(Some("sgc@muc.example.com"));
     let quotes = quote_catalog().expect("quote catalog parses");
@@ -115,6 +130,14 @@ fn room_command_posts_plain_quote_and_returns_completion() {
     let sent = take_sent_room_messages();
     assert_eq!(sent.len(), 1);
     assert_eq!(sent[0].body.value, quote_body(expected));
+    let expected_markup = quote_markup(expected);
+    assert_eq!(sent[0].markup.len(), expected_markup.len());
+    assert!(matches!(
+        sent[0].markup[0].kind,
+        types::MessageMarkupKind::Blockquote
+    ));
+    assert_eq!(sent[0].markup[0].start, expected_markup[0].start);
+    assert_eq!(sent[0].markup[0].end, expected_markup[0].end);
     assert!(sent[0].extensions.is_none());
     assert!(matches!(
         &sent[0].target,

--- a/server/extensions/stargate-quotes/src/tests.rs
+++ b/server/extensions/stargate-quotes/src/tests.rs
@@ -93,8 +93,12 @@ fn quote_markup_marks_only_the_quote_block() {
         spans[0].kind,
         types::MessageMarkupKind::Blockquote
     ));
-    assert_eq!(spans[0].start, 0);
+    assert_eq!(spans[0].start, 2);
     assert_eq!(spans[0].end, (2 + quotes[0].quote.chars().count()) as u32);
+    assert_eq!(
+        spans[0].end - spans[0].start,
+        quotes[0].quote.chars().count() as u32
+    );
     assert!(spans[0].end < quote_body(&quotes[0]).chars().count() as u32);
 }
 

--- a/server/wit/waddle-extension.wit
+++ b/server/wit/waddle-extension.wit
@@ -156,6 +156,16 @@ interface types {
         end: u32,
     }
 
+    enum message-markup-kind {
+        blockquote,
+    }
+
+    record message-markup-span {
+        kind: message-markup-kind,
+        start: u32,
+        end: u32,
+    }
+
     record artifact-reference {
         uri: artifact-uri,
         sha256: sha256-digest,
@@ -244,6 +254,10 @@ interface types {
         /// XEP-0004 form has a single user-fillable field. (XEP-0128 form var
         /// `waddle#inline_field`.)
         inline-field: option<string>,
+        /// True when the chat composer may execute `/<prefix>` immediately
+        /// instead of opening the extension palette first. (XEP-0128 form var
+        /// `waddle#composer_execute`.)
+        composer-execute: bool,
     }
 
     record extension-route-descriptor {
@@ -708,6 +722,7 @@ interface types {
         body: display-text,
         thread-id: option<thread-id>,
         reply-to: option<reply-target>,
+        markup: list<message-markup-span>,
         extensions: option<extension-envelope>,
     }
 


### PR DESCRIPTION
## Summary

- Adds extension-host message markup spans and serializes blockquote payloads with XEP-0394 `urn:xmpp:markup:0`.
- Marks `/stargate` as a composer-execute command so typing `/stargate` posts directly to the active channel instead of opening the launcher on success.
- Formats Stargate quote messages as a markdown-style blockquote followed by `role, series`, with no source field.
- Keeps the launcher visible for returned forms, warnings, and command failures so errors are not hidden.

## Review Follow-up

- Rejects contained XEP-0394 block markup spans while preserving adjacent block ranges.
- Scopes Stargate XEP-0394 blockquote markup to the quote text after the `> ` markdown fallback prefix.
- Documents the intentional palette fallback for `composerExecute` commands with trailing text.

## Plan

- Review the slash-command and extension-dispatch flow against XEP command/message markup requirements.
- Extend the WIT/host API with typed message markup spans.
- Add XEP-0394 blockquote serialization in the XMPP layer and wire it through server dispatch.
- Advertise composer-execute metadata and use it in chat slash dispatch.
- Update Stargate quote output and tests.
- Run focused Rust/chat tests, full chat tests, lint, and adversarial review.

## Validation

- `cargo fmt --all`
- `cargo test -p stargate-quotes`
- `cargo test -p waddle-extensions send_message`
- `cargo test -p waddle-extensions command_descriptor_round_trip`
- `cargo test -p waddle-xmpp xep0394`
- `cargo test -p waddle-server command_metadata_form_serializes_composer_execute_when_enabled`
- `cargo test -p waddle-server extension_room_message_dispatches_threaded_muc_message`
- `cargo check --workspace` in `server/`
- `cargo clippy --workspace -- -D warnings` in `server/`
- extension WASM release builds for all server extensions
- `bun test tests/extension-launcher-slash.test.ts tests/slash-dispatch.test.ts tests/extension-command.test.ts` in `chat/`
- `bun test` in `chat/`
- `bun run lint` in `chat/`
- `git diff --check`

## Review Fix Validation

- `cargo test -p waddle-extensions send_message`
- `cargo test -p stargate-quotes quote`
- `cargo clippy -p waddle-extensions -p stargate-quotes -- -D warnings`
- `bun test tests/slash-dispatch.test.ts`
- `bun run lint` in `chat/`
- `git diff --check`

## Review

- Server/XMPP adversarial review: fixed the adjacent-range positive test gap; no remaining actionable issue.
- Chat launcher adversarial review: no actionable issues after direct-execute error visibility fix.