### PR TITLE
feat(chat): '+N more' overflow tile replacing the 25-tile clip

### DIFF
--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -29,6 +29,7 @@ import {
   $callDockOpen,
   $callDockTab,
   closeCallDock,
+  openCallParticipants,
   setCallDockTab,
   toggleCallChat,
   toggleCallParticipants,
@@ -324,6 +325,7 @@ onBeforeUnmount(() => {
           :mic-enabled="micEnabled"
           :active-speaker-identities="activeSpeakerIdentities"
           :promoted-speaker-identity="promotedSpeakerIdentity"
+          @open-participants="openCallParticipants"
         />
       </div>
       <CallDock

--- a/chat/src/components/calls/CallSplitContainer.vue
+++ b/chat/src/components/calls/CallSplitContainer.vue
@@ -232,6 +232,7 @@ async function onHangup(): Promise<void> {
           :mic-enabled="micEnabled"
           :active-speaker-identities="activeSpeakerIdentities"
           :promoted-speaker-identity="promotedSpeakerIdentity"
+          @open-participants="enterExpandedWithDock"
         />
       </div>
       <footer class="call-split__footer">

--- a/chat/src/components/calls/CallTileGrid.vue
+++ b/chat/src/components/calls/CallTileGrid.vue
@@ -327,27 +327,32 @@ const gridStyle = computed(() => ({
   gap: var(--space-2xs);
   min-width: 0;
   min-height: 0;
-  border: none;
+  border: 1px solid var(--border);
   border-radius: var(--radius-md);
-  background: var(--color-surface-raised, rgba(255, 255, 255, 0.06));
-  color: var(--color-text, inherit);
+  background: var(--muted);
+  color: var(--foreground);
   cursor: pointer;
   font: inherit;
 }
 
 .call-tile-grid__overflow:hover,
 .call-tile-grid__overflow:focus-visible {
-  background: var(--color-surface-raised-hover, rgba(255, 255, 255, 0.12));
+  background: color-mix(in oklab, var(--muted) 70%, var(--foreground) 12%);
+}
+
+.call-tile-grid__overflow:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
 }
 
 .call-tile-grid__overflow-count {
-  font-size: var(--font-size-xl, 1.5rem);
+  font-size: var(--text-display);
   font-weight: 600;
   line-height: 1;
 }
 
 .call-tile-grid__overflow-label {
-  font-size: var(--font-size-sm, 0.875rem);
+  font-size: var(--text-body);
   opacity: 0.8;
 }
 

--- a/chat/src/components/calls/CallTileGrid.vue
+++ b/chat/src/components/calls/CallTileGrid.vue
@@ -4,6 +4,7 @@ import { useStore } from "@nanostores/vue";
 import type { LocalMediaTrack, RemoteMediaTrack } from "@/lib/calls/engine";
 import { TileAttachments, type TileAttachable } from "@/lib/calls/tile-attach";
 import { selectGridLayout } from "@/lib/calls/grid-layout";
+import { partitionStageTiles } from "@/lib/calls/stage-overflow";
 import type { CallTileModel } from "@/lib/calls/call-tiles";
 import { projectCallTiles, reconcileCallTileProjectionState } from "@/lib/calls/call-tile-projection";
 import { highlightedTileKeys } from "@/lib/calls/active-speakers";
@@ -55,6 +56,12 @@ const props = defineProps<{
   activeSpeakerIdentities?: ReadonlySet<string>;
   /** Participant the Speaker layout auto-promotes to the large tile. */
   promotedSpeakerIdentity?: string | null;
+}>();
+
+const emit = defineEmits<{
+  /** The "+N more" Overflow tile was activated; the surface opens the
+   *  Participants panel (Split bumps to Expanded first). */
+  openParticipants: [];
 }>();
 
 const seenRemoteScreenTrackKeys = ref<ReadonlySet<string>>(new Set());
@@ -173,13 +180,21 @@ const speakingTileKeys = computed<ReadonlySet<string>>(() =>
   highlightedTileKeys(tiles.value, props.activeSpeakerIdentities ?? EMPTY_ACTIVE_SPEAKERS),
 );
 
-const visibleTiles = computed<Tile[]>(() => {
-  // When the participant count exceeds the layout's capacity (e.g.
-  // 30 participants in a 5×5), we clip to the first `maxTiles`. The
-  // "+N more" affordance lives in a future pagination pass — for
-  // now we show as many as the layout supports.
-  return tiles.value.slice(0, layout.value.maxTiles);
-});
+// When the tile count exceeds the layout's capacity, the last cell becomes a
+// "+N more" Overflow tile instead of silently dropping people. `+N` counts the
+// participants who have no tile on the Stage; audio for them stays subscribed
+// via the separate CallAudioSink, and their unrendered video auto-pauses under
+// `adaptiveStream`/`dynacast`. The grid stays structured so true Gallery
+// pagination can replace the single overflow cell later.
+const stagePartition = computed(() =>
+  partitionStageTiles(tiles.value, layout.value.maxTiles),
+);
+const visibleTiles = computed<Tile[]>(() => stagePartition.value.tiles);
+const overflow = computed(() => stagePartition.value.overflow);
+
+function activateOverflow(): void {
+  emit("openParticipants");
+}
 
 const gridStyle = computed(() => ({
   gridTemplateColumns: `repeat(${layout.value.cols}, minmax(0, 1fr))`,
@@ -248,6 +263,16 @@ const gridStyle = computed(() => ({
         :attach="attach"
         @activate="toggleFocus(tile)"
       />
+      <button
+        v-if="overflow"
+        type="button"
+        class="call-tile-grid__overflow"
+        :aria-label="`Show ${overflow.hiddenCount} more ${overflow.hiddenCount === 1 ? 'participant' : 'participants'}`"
+        @click="activateOverflow"
+      >
+        <span class="call-tile-grid__overflow-count">+{{ overflow.hiddenCount }}</span>
+        <span class="call-tile-grid__overflow-label">more</span>
+      </button>
     </div>
   </div>
 </template>
@@ -289,6 +314,41 @@ const gridStyle = computed(() => ({
   flex-shrink: 0;
   padding: 0 var(--space-xs) var(--space-xs);
   max-height: 6.5rem;
+}
+
+/* The "+N more" Overflow tile fills its grid cell like any tile, but
+ * is an activatable button (opens the Participants panel) rather than a
+ * video surface. */
+.call-tile-grid__overflow {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2xs);
+  min-width: 0;
+  min-height: 0;
+  border: none;
+  border-radius: var(--radius-md);
+  background: var(--color-surface-raised, rgba(255, 255, 255, 0.06));
+  color: var(--color-text, inherit);
+  cursor: pointer;
+  font: inherit;
+}
+
+.call-tile-grid__overflow:hover,
+.call-tile-grid__overflow:focus-visible {
+  background: var(--color-surface-raised-hover, rgba(255, 255, 255, 0.12));
+}
+
+.call-tile-grid__overflow-count {
+  font-size: var(--font-size-xl, 1.5rem);
+  font-weight: 600;
+  line-height: 1;
+}
+
+.call-tile-grid__overflow-label {
+  font-size: var(--font-size-sm, 0.875rem);
+  opacity: 0.8;
 }
 
 /* The `.call-tile--focused` and `.call-tile--thumb` variants are

--- a/chat/src/components/calls/CallTileGrid.vue
+++ b/chat/src/components/calls/CallTileGrid.vue
@@ -337,7 +337,9 @@ const gridStyle = computed(() => ({
 
 .call-tile-grid__overflow:hover,
 .call-tile-grid__overflow:focus-visible {
-  background: color-mix(in oklab, var(--muted) 70%, var(--foreground) 12%);
+  /* Single percentage so the components sum to 100% — otherwise color-mix
+   * scales the result's alpha down and the hover renders translucent. */
+  background: color-mix(in oklab, var(--muted), var(--foreground) 12%);
 }
 
 .call-tile-grid__overflow:focus-visible {

--- a/chat/src/lib/calls/call-dock-state.ts
+++ b/chat/src/lib/calls/call-dock-state.ts
@@ -53,6 +53,16 @@ export function toggleCallParticipants(): void {
   toggleCallDockTab("participants");
 }
 
+/**
+ * Open the dock on the Participants tab — unlike {@link toggleCallParticipants}
+ * this never closes an already-open dock. Used by the Stage "+N more" Overflow
+ * tile, whose intent is always to reveal the roster.
+ */
+export function openCallParticipants(): void {
+  setCallDockTab("participants");
+  openCallDock();
+}
+
 export function toggleCallChat(): void {
   toggleCallDockTab("chat");
 }

--- a/chat/src/lib/calls/stage-overflow.ts
+++ b/chat/src/lib/calls/stage-overflow.ts
@@ -1,6 +1,6 @@
 import type { CallTileModel } from "./call-tiles";
 
-export type StageOverflow = {
+type StageOverflow = {
   /** Distinct participants who have no tile on the Stage. */
   hiddenCount: number;
 };

--- a/chat/src/lib/calls/stage-overflow.ts
+++ b/chat/src/lib/calls/stage-overflow.ts
@@ -1,0 +1,50 @@
+import type { CallTileModel } from "./call-tiles";
+
+export type StageOverflow = {
+  /** Distinct participants who have no tile on the Stage. */
+  hiddenCount: number;
+};
+
+export type StagePartition = {
+  /** Tiles to render in the equal grid, in order. */
+  tiles: CallTileModel[];
+  /** The "+N more" Overflow affordance, or `null` when every tile fits. */
+  overflow: StageOverflow | null;
+};
+
+/**
+ * Partition the full Stage tile list into the tiles shown in the grid plus an
+ * optional "+N more" Overflow tile.
+ */
+export function partitionStageTiles(
+  tiles: readonly CallTileModel[],
+  capacity: number,
+): StagePartition {
+  const cap = Math.max(1, Math.floor(capacity));
+  if (tiles.length <= cap) return { tiles: [...tiles], overflow: null };
+
+  if (cap <= 1) {
+    // A 1-cell Stage has no room for the overflow tile; keep the single tile
+    // rather than render an all-button, no-video Stage. Everyone else stays
+    // reachable via the roster/participant count.
+    return { tiles: tiles.slice(0, 1), overflow: null };
+  }
+
+  // The overflow tile takes the last cell, so the grid shows `cap - 1` real
+  // tiles. The count is of *people* with no tile on the Stage, so a participant
+  // whose camera is shown but whose extra (e.g. screen-share) tile spilled over
+  // is not double-counted.
+  const visible = tiles.slice(0, cap - 1);
+  const visibleIdentities = new Set(visible.map((tile) => tile.identity));
+  const hiddenIdentities = new Set<string>();
+  for (const tile of tiles.slice(cap - 1)) {
+    if (!visibleIdentities.has(tile.identity)) hiddenIdentities.add(tile.identity);
+  }
+  if (hiddenIdentities.size === 0) {
+    // Everyone past the cut is already on the Stage (only their extra tiles
+    // spilled over). Fill the last cell with a real tile rather than show a
+    // meaningless "+0 more".
+    return { tiles: tiles.slice(0, cap), overflow: null };
+  }
+  return { tiles: visible, overflow: { hiddenCount: hiddenIdentities.size } };
+}

--- a/chat/tests/call-dock-state.test.ts
+++ b/chat/tests/call-dock-state.test.ts
@@ -4,6 +4,7 @@ import {
   $callDockTab,
   closeCallDock,
   openCallDock,
+  openCallParticipants,
   setCallDockTab,
   toggleCallChat,
   toggleCallParticipants,
@@ -76,6 +77,25 @@ describe("call dock tab", () => {
 
     toggleCallParticipants();
     expect($callDockOpen.get()).toBe(false);
+  });
+
+  test("openCallParticipants opens the Participants tab and never closes (unlike toggle)", () => {
+    // From closed: opens straight to Participants.
+    openCallParticipants();
+    expect($callDockOpen.get()).toBe(true);
+    expect($callDockTab.get()).toBe("participants");
+
+    // Already open on Participants: stays open — the overflow tile must open,
+    // not toggle the dock shut.
+    openCallParticipants();
+    expect($callDockOpen.get()).toBe(true);
+    expect($callDockTab.get()).toBe("participants");
+
+    // Open on Chat: switches to Participants and keeps the dock open.
+    setCallDockTab("chat");
+    openCallParticipants();
+    expect($callDockOpen.get()).toBe(true);
+    expect($callDockTab.get()).toBe("participants");
   });
 
   test("resets to the participants tab when the call ends", () => {

--- a/chat/tests/call-tile-grid-overflow.test.ts
+++ b/chat/tests/call-tile-grid-overflow.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { renderVueComponent } from "./helpers/render-vue-sfc";
+import type { RemoteMediaTrack } from "../src/lib/calls/engine";
+
+function gridSource(): string {
+  return readFileSync(
+    new URL("../src/components/calls/CallTileGrid.vue", import.meta.url),
+    "utf8",
+  );
+}
+
+function remoteCamera(identity: string): RemoteMediaTrack {
+  return {
+    participantIdentity: identity,
+    publicationSid: `${identity}-cam`,
+    kind: "video",
+    source: "camera",
+    track: {} as RemoteMediaTrack["track"],
+  };
+}
+
+describe("CallTileGrid overflow tile", () => {
+  test("derives the visible tiles from partitionStageTiles, not a raw clip", () => {
+    const source = gridSource();
+    expect(source).toContain("partitionStageTiles");
+    // The old silent clip must be gone.
+    expect(source).not.toContain("tiles.value.slice(0, layout.value.maxTiles)");
+  });
+
+  test("renders a '+N more' overflow cell bound to the hidden count", () => {
+    const source = gridSource();
+    expect(source).toContain("call-tile-grid__overflow");
+    // The cell is an activatable button labelled for assistive tech.
+    expect(source).toContain("aria-label");
+    expect(source).toMatch(/hiddenCount/);
+    expect(source).toContain("more");
+  });
+
+  test("emits open-participants when the overflow cell is activated", () => {
+    const source = gridSource();
+    expect(source).toContain("openParticipants");
+    expect(source).toContain('emit("openParticipants")');
+  });
+
+  test("a degenerate 1-cell Stage renders one tile and no overflow cell", async () => {
+    // SSR has no ResizeObserver, so the container measures 0×0 and the layout
+    // collapses to 1×1. With several participants the grid must show the single
+    // tile and never an overflow cell (matching the partition's degenerate
+    // rule) — nobody is silently promoted into a phantom overflow.
+    const html = await renderVueComponent(
+      "../src/components/calls/CallTileGrid.vue",
+      {
+        remoteTracks: [
+          remoteCamera("a@waddle.test/web"),
+          remoteCamera("b@waddle.test/web"),
+          remoteCamera("c@waddle.test/web"),
+        ],
+        localTracks: [],
+        localIdentity: "me@waddle.test/web",
+        micEnabled: true,
+      },
+      import.meta.url,
+    );
+    expect(html).not.toContain("call-tile-grid__overflow");
+  });
+});
+
+describe("surfaces wire the overflow tile to the Participants panel", () => {
+  function read(rel: string): string {
+    return readFileSync(new URL(rel, import.meta.url), "utf8");
+  }
+
+  test("Expanded surface opens the dock in place on overflow", () => {
+    const source = read("../src/components/calls/CallExpandedSurface.vue");
+    expect(source).toContain("openCallParticipants");
+    expect(source).toContain('@open-participants="openCallParticipants"');
+  });
+
+  test("Split surface bumps to Expanded with the Participants dock on overflow", () => {
+    const source = read("../src/components/calls/CallSplitContainer.vue");
+    // The Split surface has no room for the dock, so the overflow tile reuses
+    // the same bump-to-Expanded path as its Participants button.
+    expect(source).toContain('@open-participants="enterExpandedWithDock"');
+  });
+});

--- a/chat/tests/stage-overflow.test.ts
+++ b/chat/tests/stage-overflow.test.ts
@@ -108,6 +108,16 @@ describe("partitionStageTiles", () => {
 });
 
 describe("audio is independent of the Stage overflow", () => {
+  function remoteCamera(identity: string): RemoteMediaTrack {
+    return {
+      participantIdentity: identity,
+      publicationSid: `${identity}-cam`,
+      kind: "video",
+      source: "camera",
+      track: {} as RemoteMediaTrack["track"],
+    };
+  }
+
   function remoteMic(identity: string): RemoteMediaTrack {
     return {
       participantIdentity: identity,
@@ -118,27 +128,37 @@ describe("audio is independent of the Stage overflow", () => {
     };
   }
 
-  test("every off-stage participant still has an audio sink", () => {
-    // 30 people, each with a camera tile and a mic. The Stage shows 24 + the
-    // overflow tile, so 6 people are off-stage — but audio is attached by the
-    // separate CallAudioSink (keyed off the remote tracks, not the tile grid),
-    // so all 30 mics still get a sink. Off-stage audio is never lost.
+  function sinkIdentitySet(tracks: readonly RemoteMediaTrack[]): Set<string> {
+    return new Set(callAudioSinkTracks(tracks).map((track) => track.participantIdentity));
+  }
+
+  test("the audio sink set is invariant to Stage capacity, so off-stage people stay audible", () => {
+    // 30 people, each publishing a camera and a mic. The audio sink is derived
+    // from the raw remote tracks (CallAudioSink), never from the tile grid, so
+    // tightening the Stage capacity changes who is on-stage but NOT who is
+    // audible. We prove independence by shrinking capacity and showing the sink
+    // set is unchanged and still covers everyone the Stage hides.
     const identities = Array.from({ length: 30 }, (_, i) => `p${i}@waddle.test/web`);
     const tiles = identities.map(cameraTile);
-    const mics = identities.map(remoteMic);
+    const remoteTracks = identities.flatMap((id) => [remoteCamera(id), remoteMic(id)]);
 
-    const partition = partitionStageTiles(tiles, 25);
-    expect(partition.overflow).toEqual({ hiddenCount: 6 });
+    const roomy = partitionStageTiles(tiles, 25); // 24 on stage, 6 hidden
+    const cramped = partitionStageTiles(tiles, 3); // 2 on stage, 28 hidden
+    expect(roomy.overflow).toEqual({ hiddenCount: 6 });
+    expect(cramped.overflow).toEqual({ hiddenCount: 28 });
 
-    const onStage = new Set(partition.tiles.map((tile) => tile.identity));
-    const offStage = identities.filter((identity) => !onStage.has(identity));
-    expect(offStage).toHaveLength(6);
+    // CallAudioSink filters mic/screen-audio off the full track list itself —
+    // feeding it the same tracks yields the same 30 mics regardless of layout.
+    const sinks = sinkIdentitySet(remoteTracks);
+    expect(sinks).toEqual(new Set(identities));
 
-    const sinks = callAudioSinkTracks(mics);
-    const sinkIdentities = new Set(sinks.map((track) => track.participantIdentity));
-    expect(sinks).toHaveLength(30);
-    for (const identity of offStage) {
-      expect(sinkIdentities.has(identity)).toBe(true);
+    for (const partition of [roomy, cramped]) {
+      const onStage = new Set(partition.tiles.map((tile) => tile.identity));
+      const offStage = identities.filter((identity) => !onStage.has(identity));
+      expect(offStage.length).toBeGreaterThan(0);
+      for (const identity of offStage) {
+        expect(sinks.has(identity)).toBe(true);
+      }
     }
   });
 });

--- a/chat/tests/stage-overflow.test.ts
+++ b/chat/tests/stage-overflow.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import type { CallTileModel } from "../src/lib/calls/call-tiles";
+import { partitionStageTiles } from "../src/lib/calls/stage-overflow";
+
+/**
+ * Build a camera tile for `identity`. Only the fields the overflow
+ * partition reads (`key`, `identity`) carry meaning; the rest mirror a
+ * plain remote camera tile so the fixture is a real `CallTileModel`.
+ */
+function cameraTile(identity: string): CallTileModel {
+  return {
+    key: `remote:${identity}:camera`,
+    identity,
+    label: identity,
+    source: "camera",
+    screenTrackKey: null,
+    isSelf: false,
+    mirrorVideo: false,
+    showsPresentingGlyph: false,
+    micEnabledHint: true,
+    videoTrack: null,
+  };
+}
+
+function cameraTiles(count: number): CallTileModel[] {
+  return Array.from({ length: count }, (_, i) => cameraTile(`p${i}@waddle.test/web`));
+}
+
+/** A screen-share tile for `identity` (a second tile for the same person). */
+function screenTile(identity: string): CallTileModel {
+  return {
+    ...cameraTile(identity),
+    key: `remote:${identity}:screen_share`,
+    source: "screen_share",
+    screenTrackKey: `${identity}-screen`,
+    showsPresentingGlyph: true,
+  };
+}
+
+describe("partitionStageTiles", () => {
+  test("shows every tile and no overflow when the count is under capacity", () => {
+    const tiles = cameraTiles(6);
+    const partition = partitionStageTiles(tiles, 25);
+    expect(partition.tiles).toEqual(tiles);
+    expect(partition.overflow).toBeNull();
+  });
+
+  test("reserves the last cell for overflow when the count exceeds capacity", () => {
+    // 30 distinct people, capacity 25: show 24 real tiles + the overflow
+    // cell, which counts the 6 people who have no tile on the Stage.
+    const tiles = cameraTiles(30);
+    const partition = partitionStageTiles(tiles, 25);
+    expect(partition.tiles).toEqual(tiles.slice(0, 24));
+    expect(partition.overflow).toEqual({ hiddenCount: 6 });
+  });
+
+  test("does not count a person whose camera is on stage but screen-share spilled over", () => {
+    const a = cameraTile("a@waddle.test/web");
+    const b = cameraTile("b@waddle.test/web");
+    const c = cameraTile("c@waddle.test/web");
+    const aScreen = screenTile("a@waddle.test/web");
+    // capacity 3: show 2 real tiles (a, b); the hidden tail is [c, a-screen].
+    // Only `c` is fully off-stage — `a` is still visible via their camera.
+    const partition = partitionStageTiles([a, b, c, aScreen], 3);
+    expect(partition.tiles).toEqual([a, b]);
+    expect(partition.overflow).toEqual({ hiddenCount: 1 });
+  });
+
+  test("fills the last cell instead of a '+0 more' tile when no people are hidden", () => {
+    const a = cameraTile("a@waddle.test/web");
+    const b = cameraTile("b@waddle.test/web");
+    const aScreen = screenTile("a@waddle.test/web");
+    const bScreen = screenTile("b@waddle.test/web");
+    // capacity 3, 4 tiles, but the 2 spilled tiles are just screen-shares of
+    // the 2 people already shown — nobody is actually hidden, so there is no
+    // overflow and the last cell shows a real tile rather than "+0 more".
+    const partition = partitionStageTiles([a, b, aScreen, bScreen], 3);
+    expect(partition.tiles).toEqual([a, b, aScreen]);
+    expect(partition.overflow).toBeNull();
+  });
+
+  test("keeps the single tile and shows no overflow in a degenerate 1-cell Stage", () => {
+    // A 1×1 fallback (call dragged tiny) has no room for the affordance, so we
+    // keep the one tile rather than render an all-button, no-video Stage.
+    // Everyone else stays reachable via the roster/participant count.
+    const tiles = cameraTiles(8);
+    const partition = partitionStageTiles(tiles, 1);
+    expect(partition.tiles).toEqual([tiles[0]]);
+    expect(partition.overflow).toBeNull();
+  });
+
+  test("shows everyone with no overflow when the count exactly equals capacity", () => {
+    const tiles = cameraTiles(25);
+    const partition = partitionStageTiles(tiles, 25);
+    expect(partition.tiles).toEqual(tiles);
+    expect(partition.overflow).toBeNull();
+  });
+
+  test("normalizes a fractional capacity down to whole cells", () => {
+    // A 2.9-cell Stage is a 2-cell Stage: 1 real tile + overflow for the rest.
+    const tiles = cameraTiles(5);
+    const partition = partitionStageTiles(tiles, 2.9);
+    expect(partition.tiles).toEqual(tiles.slice(0, 1));
+    expect(partition.overflow).toEqual({ hiddenCount: 4 });
+  });
+});

--- a/chat/tests/stage-overflow.test.ts
+++ b/chat/tests/stage-overflow.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import type { CallTileModel } from "../src/lib/calls/call-tiles";
 import { partitionStageTiles } from "../src/lib/calls/stage-overflow";
+import { callAudioSinkTracks } from "../src/lib/calls/call-audio-sink";
+import type { RemoteMediaTrack } from "../src/lib/calls/engine";
 
 /**
  * Build a camera tile for `identity`. Only the fields the overflow
@@ -102,5 +104,41 @@ describe("partitionStageTiles", () => {
     const partition = partitionStageTiles(tiles, 2.9);
     expect(partition.tiles).toEqual(tiles.slice(0, 1));
     expect(partition.overflow).toEqual({ hiddenCount: 4 });
+  });
+});
+
+describe("audio is independent of the Stage overflow", () => {
+  function remoteMic(identity: string): RemoteMediaTrack {
+    return {
+      participantIdentity: identity,
+      publicationSid: `${identity}-mic`,
+      kind: "audio",
+      source: "microphone",
+      track: {} as RemoteMediaTrack["track"],
+    };
+  }
+
+  test("every off-stage participant still has an audio sink", () => {
+    // 30 people, each with a camera tile and a mic. The Stage shows 24 + the
+    // overflow tile, so 6 people are off-stage — but audio is attached by the
+    // separate CallAudioSink (keyed off the remote tracks, not the tile grid),
+    // so all 30 mics still get a sink. Off-stage audio is never lost.
+    const identities = Array.from({ length: 30 }, (_, i) => `p${i}@waddle.test/web`);
+    const tiles = identities.map(cameraTile);
+    const mics = identities.map(remoteMic);
+
+    const partition = partitionStageTiles(tiles, 25);
+    expect(partition.overflow).toEqual({ hiddenCount: 6 });
+
+    const onStage = new Set(partition.tiles.map((tile) => tile.identity));
+    const offStage = identities.filter((identity) => !onStage.has(identity));
+    expect(offStage).toHaveLength(6);
+
+    const sinks = callAudioSinkTracks(mics);
+    const sinkIdentities = new Set(sinks.map((track) => track.participantIdentity));
+    expect(sinks).toHaveLength(30);
+    for (const identity of offStage) {
+      expect(sinkIdentities.has(identity)).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
Closes #1027. Part of the Zoom-parity epic #1017.

## Problem

The in-call participant **Stage** silently dropped people beyond the grid's
capacity: `CallTileGrid.vue` did `tiles.slice(0, layout.maxTiles)`, so the
26th+ participant in a 5×5 just disappeared with no affordance to reach them.

## Solution

Replace the hard clip with a single **"+N more" Overflow tile** that takes the
last grid cell and opens the **Participants panel**. When tiles exceed Stage
capacity the grid shows `capacity − 1` real tiles plus the overflow cell;
otherwise everyone shows unchanged. The grid stays structured so true Gallery
pagination can replace the single overflow cell later (out of scope here).

### Decisions
- **N counts people, not tiles** — `N` = distinct participants who have *no*
  tile on the Stage. A person whose camera is shown but whose screen-share
  spilled over isn't counted, and a "+0 more" tile is never rendered (the cell
  is filled with a real tile instead).
- **Degenerate 1-cell Stage keeps its video** — the overflow tile only appears
  when capacity ≥ 2. At a 1×1 fallback (call dragged tiny) the single tile is
  kept; everyone stays reachable via the always-visible roster/participant
  count.
- **Audio is untouched** — audio is attached by the separate global
  `CallAudioSink` (driven by `callAudioSinkTracks(remoteTracks)`), independent
  of the video grid. Off-stage participants stay audible by construction;
  `adaptiveStream`/`dynacast` (already enabled) pause only their unrendered
  video.
- **Grid emits intent, surfaces decide** — the overflow tile emits
  `open-participants`; Expanded opens the dock in place via a new
  `openCallParticipants` (open, never toggle), Split bumps to Expanded with the
  dock (reusing its Participants-button path).

## What changed
- `lib/calls/stage-overflow.ts` — pure `partitionStageTiles(tiles, capacity)`
  → `{ tiles, overflow: { hiddenCount } | null }`.
- `lib/calls/call-dock-state.ts` — `openCallParticipants()` (open, not toggle).
- `components/calls/CallTileGrid.vue` — renders the "+N more" button cell and
  emits `open-participants`; the silent clip is gone.
- `CallExpandedSurface.vue` / `CallSplitContainer.vue` — wire the emit.

## Tests (`bun test`)
- `tests/stage-overflow.test.ts` — overflow/capacity logic: under/at/over
  capacity, screen-share dedup, "+0" suppression, degenerate 1-cell,
  fractional-capacity; plus an audio-independence proof (sink set is invariant
  to Stage capacity and still covers hidden people).
- `tests/call-dock-state.test.ts` — `openCallParticipants` opens, never closes.
- `tests/call-tile-grid-overflow.test.ts` — grid derives tiles from the
  partition, renders the "+N more" cell, emits `open-participants`; both
  surfaces wire it.

Full chat suite: 2428 pass (the lone `startup-loading` failure is a known
pre-existing spurious failure that needs `bun run build` first). `knip` clean;
`astro check` introduces no new errors. Reviewed by three adversarial personas
(spec/AC, correctness/edge-cases, standards/a11y/tests) — no blocker/major
issues; their test-quality note (audio guard) was addressed.

## Acceptance criteria
- [x] "+N more" tile shows the hidden count instead of dropping people.
- [x] Selecting the overflow tile opens the Participants panel.
- [x] Audio remains audible for off-stage participants.
- [x] Overflow/capacity logic unit-tested via `bun test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)