### PR TITLE
feat(chat): hide self-view toggle (#1021)

### DIFF
--- a/chat/src/components/calls/CallControls.vue
+++ b/chat/src/components/calls/CallControls.vue
@@ -10,6 +10,7 @@ import {
   MonitorUp,
   MoreHorizontal,
   PhoneOff,
+  ScanFace,
   Settings,
   SquareUser,
   Users,
@@ -49,6 +50,8 @@ const props = defineProps<{
   chatUnread: number;
   /** The chosen stage layout — drives the view switcher's pressed state. */
   viewMode: CallViewMode;
+  /** True while the local self-view tile is hidden from this client's stage. */
+  selfViewHidden: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -60,6 +63,7 @@ const emit = defineEmits<{
   toggleChat: [];
   openSettings: [];
   setViewMode: [mode: CallViewMode];
+  toggleSelfView: [];
   hangup: [];
 }>();
 
@@ -174,6 +178,13 @@ function selectSettings(): void {
   emit("openSettings");
   // Focus moves into the dialog that opens — don't yank it back to the trigger.
   closeMore(false);
+}
+
+function selectSelfView(): void {
+  emit("toggleSelfView");
+  // Toggling self-view leaves no new surface to receive focus, so return it to
+  // the trigger as the menu closes.
+  closeMore(true);
 }
 
 function onDocumentPointerDown(event: PointerEvent): void {
@@ -337,6 +348,15 @@ onBeforeUnmount(() => {
         aria-label="More options"
         @keydown="onMoreMenuKeydown"
       >
+        <button
+          type="button"
+          role="menuitem"
+          class="call-controls__more-item"
+          @click="selectSelfView"
+        >
+          <ScanFace class="w-4 h-4" />
+          <span>{{ selfViewHidden ? "Show self-view" : "Hide self-view" }}</span>
+        </button>
         <button
           type="button"
           role="menuitem"

--- a/chat/src/components/calls/CallControls.vue
+++ b/chat/src/components/calls/CallControls.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, ref, watch } from "vue";
 import {
+  Check,
   LayoutGrid,
   Maximize2,
   MessageSquare,
@@ -114,7 +115,11 @@ const moreMenuEl = ref<HTMLElement | null>(null);
 function menuItems(): HTMLElement[] {
   const root = moreMenuEl.value;
   if (!root) return [];
-  return Array.from(root.querySelectorAll<HTMLElement>('[role="menuitem"]'));
+  // Includes the checkbox item (Self-view) alongside the plain action items so
+  // every entry stays in the arrow-key roving-focus order.
+  return Array.from(
+    root.querySelectorAll<HTMLElement>('[role="menuitem"],[role="menuitemcheckbox"]'),
+  );
 }
 
 async function openMore(focusFirst: boolean): Promise<void> {
@@ -350,12 +355,14 @@ onBeforeUnmount(() => {
       >
         <button
           type="button"
-          role="menuitem"
+          role="menuitemcheckbox"
+          :aria-checked="!selfViewHidden"
           class="call-controls__more-item"
           @click="selectSelfView"
         >
           <ScanFace class="w-4 h-4" />
-          <span>{{ selfViewHidden ? "Show self-view" : "Hide self-view" }}</span>
+          <span>Self-view</span>
+          <Check v-if="!selfViewHidden" class="ml-auto w-4 h-4 text-primary" />
         </button>
         <button
           type="button"

--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -6,7 +6,12 @@ import {
   $lastCallError,
 } from "@/lib/calls/call-store";
 import { $callUiMode } from "@/lib/calls/ui-mode";
-import { $callViewMode, setCallViewMode } from "@/lib/calls/call-view-state";
+import {
+  $callSelfViewHidden,
+  $callViewMode,
+  setCallViewMode,
+  toggleCallSelfViewHidden,
+} from "@/lib/calls/call-view-state";
 import {
   $callConnecting,
   $callMicEnabled,
@@ -106,6 +111,7 @@ const emit = defineEmits<{
 const state = useStore($callState);
 const uiMode = useStore($callUiMode);
 const viewMode = useStore($callViewMode);
+const selfViewHidden = useStore($callSelfViewHidden);
 const lastError = useStore($lastCallError);
 const connecting = useStore($callConnecting);
 const micEnabled = useStore($callMicEnabled);
@@ -370,6 +376,7 @@ onBeforeUnmount(() => {
         :chat-open="chatOpen"
         :chat-unread="chatUnread"
         :view-mode="viewMode"
+        :self-view-hidden="selfViewHidden"
         @toggle-mic="toggleMic"
         @toggle-cam="toggleCam"
         @toggle-screen-share="toggleScreenShare"
@@ -378,6 +385,7 @@ onBeforeUnmount(() => {
         @toggle-chat="toggleCallChat"
         @open-settings="settingsOpen = true"
         @set-view-mode="setCallViewMode"
+        @toggle-self-view="toggleCallSelfViewHidden"
         @hangup="onHangup"
       />
     </footer>

--- a/chat/src/components/calls/CallSplitContainer.vue
+++ b/chat/src/components/calls/CallSplitContainer.vue
@@ -6,7 +6,12 @@ import {
   $lastCallError,
 } from "@/lib/calls/call-store";
 import { $callUiMode } from "@/lib/calls/ui-mode";
-import { $callViewMode, setCallViewMode } from "@/lib/calls/call-view-state";
+import {
+  $callSelfViewHidden,
+  $callViewMode,
+  setCallViewMode,
+  toggleCallSelfViewHidden,
+} from "@/lib/calls/call-view-state";
 import {
   $callConnecting,
   $callMicEnabled,
@@ -61,6 +66,7 @@ const props = defineProps<{
 const state = useStore($callState);
 const uiMode = useStore($callUiMode);
 const viewMode = useStore($callViewMode);
+const selfViewHidden = useStore($callSelfViewHidden);
 const lastError = useStore($lastCallError);
 const connecting = useStore($callConnecting);
 const micEnabled = useStore($callMicEnabled);
@@ -247,6 +253,7 @@ async function onHangup(): Promise<void> {
           :chat-open="false"
           :chat-unread="chatUnread"
           :view-mode="viewMode"
+          :self-view-hidden="selfViewHidden"
           @toggle-mic="toggleMic"
           @toggle-cam="toggleCam"
           @toggle-screen-share="toggleScreenShare"
@@ -255,6 +262,7 @@ async function onHangup(): Promise<void> {
           @toggle-chat="enterExpandedWithChat"
           @open-settings="settingsOpen = true"
           @set-view-mode="setCallViewMode"
+          @toggle-self-view="toggleCallSelfViewHidden"
           @hangup="onHangup"
         />
       </footer>

--- a/chat/src/components/calls/CallTileGrid.vue
+++ b/chat/src/components/calls/CallTileGrid.vue
@@ -8,7 +8,12 @@ import { partitionStageTiles } from "@/lib/calls/stage-overflow";
 import type { CallTileModel } from "@/lib/calls/call-tiles";
 import { projectCallTiles, reconcileCallTileProjectionState } from "@/lib/calls/call-tile-projection";
 import { highlightedTileKeys } from "@/lib/calls/active-speakers";
-import { $callPinnedTileKey, $callViewMode, toggleCallPin } from "@/lib/calls/call-view-state";
+import {
+  $callPinnedTileKey,
+  $callSelfViewHidden,
+  $callViewMode,
+  toggleCallPin,
+} from "@/lib/calls/call-view-state";
 import CallTile from "./CallTile.vue";
 
 /**
@@ -69,6 +74,7 @@ const seenRemoteScreenTrackKeys = ref<ReadonlySet<string>>(new Set());
 // split⟷expanded surface switch that remounts this grid.
 const viewMode = useStore($callViewMode);
 const pinnedTileKey = useStore($callPinnedTileKey);
+const selfViewHidden = useStore($callSelfViewHidden);
 
 const projection = computed(() => {
   return projectCallTiles({
@@ -81,6 +87,7 @@ const projection = computed(() => {
     pinnedTileKey: pinnedTileKey.value,
     viewMode: viewMode.value,
     promotedSpeakerIdentity: props.promotedSpeakerIdentity ?? null,
+    hideSelfView: selfViewHidden.value,
   });
 });
 

--- a/chat/src/lib/calls/call-tile-projection.ts
+++ b/chat/src/lib/calls/call-tile-projection.ts
@@ -59,7 +59,12 @@ export function retainPinnedTileKey(
 
 export function projectCallTiles(input: ProjectCallTilesInput): CallTileProjection {
   const built = buildCallTiles(input);
-  const tiles = input.hideSelfView ? built.filter((tile) => !tile.isSelf) : built;
+  // Hide self-view drops only the local *camera* tile. The local screen-share
+  // tile is also `isSelf` but must stay on stage — the user is still presenting
+  // it, and other participants keep seeing it.
+  const tiles = input.hideSelfView
+    ? built.filter((tile) => !(tile.isSelf && tile.source === "camera"))
+    : built;
   const remoteScreens = tiles.filter((tile) =>
     tile.source === "screen_share" && !tile.isSelf && tile.screenTrackKey !== null
   );

--- a/chat/src/lib/calls/call-tile-projection.ts
+++ b/chat/src/lib/calls/call-tile-projection.ts
@@ -8,6 +8,13 @@ export type ProjectCallTilesInput = BuildCallTilesInput & {
   viewMode?: CallViewMode;
   /** Identity the Speaker layout should auto-promote to the large tile. */
   promotedSpeakerIdentity?: string | null;
+  /**
+   * Drop the local participant's own self-view tile from the stage. Purely a
+   * local rendering choice — the camera keeps publishing to other participants.
+   * Removing the self tile before spotlight selection also means the local
+   * participant is never auto-promoted to the large Speaker tile while hidden.
+   */
+  hideSelfView?: boolean;
 };
 
 export type CallTileProjection = {
@@ -51,7 +58,8 @@ export function retainPinnedTileKey(
 }
 
 export function projectCallTiles(input: ProjectCallTilesInput): CallTileProjection {
-  const tiles = buildCallTiles(input);
+  const built = buildCallTiles(input);
+  const tiles = input.hideSelfView ? built.filter((tile) => !tile.isSelf) : built;
   const remoteScreens = tiles.filter((tile) =>
     tile.source === "screen_share" && !tile.isSelf && tile.screenTrackKey !== null
   );

--- a/chat/src/lib/calls/call-view-state.ts
+++ b/chat/src/lib/calls/call-view-state.ts
@@ -21,6 +21,14 @@ export const $callViewMode = atom<CallViewMode>("gallery");
 /** The locally pinned tile key, or `null` when nothing is pinned. */
 export const $callPinnedTileKey = atom<string | null>(null);
 
+/**
+ * Whether the local participant has hidden their own self-view tile from the
+ * stage. Local-only and view-only: the outgoing camera keeps publishing — this
+ * just removes the self tile from this client's grid (see `projectCallTiles`),
+ * which also keeps the local participant off the large Speaker tile.
+ */
+export const $callSelfViewHidden = atom<boolean>(false);
+
 export function setCallViewMode(mode: CallViewMode): void {
   $callViewMode.set(mode);
 }
@@ -30,8 +38,17 @@ export function toggleCallPin(tileKey: string): void {
   $callPinnedTileKey.set($callPinnedTileKey.get() === tileKey ? null : tileKey);
 }
 
-/** Reset stage presentation to its per-call defaults: Gallery, nothing pinned. */
+/** Hide the self-view tile, or reveal it if it is already hidden. */
+export function toggleCallSelfViewHidden(): void {
+  $callSelfViewHidden.set(!$callSelfViewHidden.get());
+}
+
+/**
+ * Reset stage presentation to its per-call defaults: Gallery, nothing pinned,
+ * self-view visible.
+ */
 export function resetCallViewState(): void {
   $callViewMode.set("gallery");
   $callPinnedTileKey.set(null);
+  $callSelfViewHidden.set(false);
 }

--- a/chat/tests/call-controls.test.ts
+++ b/chat/tests/call-controls.test.ts
@@ -770,19 +770,30 @@ describe("call control bar restructure (#1020)", () => {
 });
 
 describe("call control bar hide self-view (#1021)", () => {
-  test("offers a Hide self-view action under More while the self-view is visible", async () => {
+  test("offers a checkable Self-view item under More, checked while the self-view is visible", async () => {
     const html = await renderCallControls({ selfViewHidden: false });
-    // A plain menuitem whose label is the action (Zoom/Meet convention),
-    // sitting in the same More menu as Call settings.
-    expect((html.match(/role="menuitem"/g) ?? []).length).toBeGreaterThanOrEqual(2);
-    expect(html).toContain("Hide self-view");
-    expect(html).not.toContain("Show self-view");
+    // A menuitemcheckbox with a stable label and aria-checked carrying state,
+    // matching the codebase's other in-menu binary toggles — so a screen reader
+    // announces the current state, not just the next action.
+    expect(html).toContain('role="menuitemcheckbox"');
+    expect(html).toContain("Self-view");
+    expect(html).toMatch(/role="menuitemcheckbox"[^>]*aria-checked="true"/);
   });
 
-  test("flips the action to Show self-view once the self-view is hidden", async () => {
+  test("unchecks the Self-view item once the self-view is hidden", async () => {
     const html = await renderCallControls({ selfViewHidden: true });
-    expect(html).toContain("Show self-view");
-    expect(html).not.toContain("Hide self-view");
+    expect(html).toContain("Self-view");
+    expect(html).toMatch(/role="menuitemcheckbox"[^>]*aria-checked="false"/);
+  });
+
+  test("keeps the checkable Self-view item in the roving-focus set with the other menu items", () => {
+    const source = readFileSync(
+      new URL("../src/components/calls/CallControls.vue", import.meta.url),
+      "utf8",
+    );
+    // The menu's keyboard navigation must collect both plain items and the
+    // checkbox item, or the toggle drops out of arrow-key focus order.
+    expect(source).toContain('[role="menuitemcheckbox"]');
   });
 
   test("wires the self-view item to the toggleSelfView emit", () => {

--- a/chat/tests/call-controls.test.ts
+++ b/chat/tests/call-controls.test.ts
@@ -769,6 +769,32 @@ describe("call control bar restructure (#1020)", () => {
   });
 });
 
+describe("call control bar hide self-view (#1021)", () => {
+  test("offers a Hide self-view action under More while the self-view is visible", async () => {
+    const html = await renderCallControls({ selfViewHidden: false });
+    // A plain menuitem whose label is the action (Zoom/Meet convention),
+    // sitting in the same More menu as Call settings.
+    expect((html.match(/role="menuitem"/g) ?? []).length).toBeGreaterThanOrEqual(2);
+    expect(html).toContain("Hide self-view");
+    expect(html).not.toContain("Show self-view");
+  });
+
+  test("flips the action to Show self-view once the self-view is hidden", async () => {
+    const html = await renderCallControls({ selfViewHidden: true });
+    expect(html).toContain("Show self-view");
+    expect(html).not.toContain("Hide self-view");
+  });
+
+  test("wires the self-view item to the toggleSelfView emit", () => {
+    const source = readFileSync(
+      new URL("../src/components/calls/CallControls.vue", import.meta.url),
+      "utf8",
+    );
+    expect(source).toContain("toggleSelfView");
+    expect(source).toContain("selfViewHidden");
+  });
+});
+
 async function renderCallControls(overrides: Record<string, unknown>): Promise<string> {
   const component = await loadVueComponent("../src/components/calls/CallControls.vue");
   const props = {
@@ -782,6 +808,7 @@ async function renderCallControls(overrides: Record<string, unknown>): Promise<s
     chatOpen: false,
     chatUnread: 0,
     viewMode: "gallery",
+    selfViewHidden: false,
     ...overrides,
   };
   return renderToString(createSSRApp({ render: () => h(component, props) }));

--- a/chat/tests/call-dock-wiring.test.ts
+++ b/chat/tests/call-dock-wiring.test.ts
@@ -24,6 +24,7 @@ describe("CallControls participants toggle", () => {
         chatOpen: false,
         chatUnread: 0,
         viewMode: "gallery",
+        selfViewHidden: false,
       },
       import.meta.url,
     );

--- a/chat/tests/call-tile-grid-overflow.test.ts
+++ b/chat/tests/call-tile-grid-overflow.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { renderVueComponent } from "./helpers/render-vue-sfc";
 import type { RemoteMediaTrack } from "../src/lib/calls/engine";
+import { $callSelfViewHidden, resetCallViewState } from "../src/lib/calls/call-view-state";
 
 function gridSource(): string {
   return readFileSync(
@@ -64,6 +65,59 @@ describe("CallTileGrid overflow tile", () => {
     );
     expect(html).not.toContain("call-tile-grid__overflow");
   });
+});
+
+describe("CallTileGrid hide self-view (#1021)", () => {
+  afterEach(() => {
+    resetCallViewState();
+  });
+
+  test("keeps the local self-view tile on stage by default", async () => {
+    const html = await renderVueComponent(
+      "../src/components/calls/CallTileGrid.vue",
+      {
+        remoteTracks: [remoteCamera("bob@waddle.test/web")],
+        localTracks: [],
+        localIdentity: "me@waddle.test/web",
+        micEnabled: true,
+      },
+      import.meta.url,
+    );
+    // The degenerate SSR 1×1 grid shows the first tile, which is the self tile.
+    expect(html).toContain("You");
+  });
+
+  test("drops the local self-view tile from the stage when self-view is hidden", async () => {
+    $callSelfViewHidden.set(true);
+    const html = await renderVueComponent(
+      "../src/components/calls/CallTileGrid.vue",
+      {
+        remoteTracks: [remoteCamera("bob@waddle.test/web")],
+        localTracks: [],
+        localIdentity: "me@waddle.test/web",
+        micEnabled: true,
+      },
+      import.meta.url,
+    );
+    expect(html).not.toContain("You");
+    expect(html).toContain("bob");
+  });
+});
+
+describe("surfaces wire the hide self-view control (#1021)", () => {
+  function read(rel: string): string {
+    return readFileSync(new URL(rel, import.meta.url), "utf8");
+  }
+
+  for (const surface of ["CallSplitContainer", "CallExpandedSurface"] as const) {
+    test(`${surface} binds the self-view state and toggle to CallControls`, () => {
+      const source = read(`../src/components/calls/${surface}.vue`);
+      expect(source).toContain("$callSelfViewHidden");
+      expect(source).toContain("toggleCallSelfViewHidden");
+      expect(source).toContain(":self-view-hidden=");
+      expect(source).toContain('@toggle-self-view="toggleCallSelfViewHidden"');
+    });
+  }
 });
 
 describe("surfaces wire the overflow tile to the Participants panel", () => {

--- a/chat/tests/call-tile-spotlight.test.ts
+++ b/chat/tests/call-tile-spotlight.test.ts
@@ -360,6 +360,25 @@ describe("call tile spotlight projection", () => {
     ]);
   });
 
+  test("hides the camera self-view but keeps the local screen-share tile when self-view is hidden", () => {
+    const projection = projectCallTiles({
+      remoteTracks: [],
+      localTracks: [localVideo("alice@example.com/web", "screen-pub", "screen_share")],
+      localIdentity: "alice@example.com/web",
+      micEnabled: true,
+      seenRemoteScreenTrackKeys: new Set(),
+      pinnedTileKey: null,
+      hideSelfView: true,
+    });
+
+    // Only the camera self-view tile is removed; the local screen-share tile is
+    // also `isSelf` but must stay on stage — hiding self-view never affects the
+    // screen the user is still presenting.
+    expect(projection.tiles.map((tile) => tile.key)).toEqual([
+      "self:alice@example.com/web:screen_share",
+    ]);
+  });
+
   test("never auto-promotes the hidden self-view to the large Speaker tile when alone", () => {
     const projection = projectCallTiles({
       remoteTracks: [],

--- a/chat/tests/call-tile-spotlight.test.ts
+++ b/chat/tests/call-tile-spotlight.test.ts
@@ -344,6 +344,56 @@ describe("call tile spotlight projection", () => {
     expect(projection.spotlightKey).toBe("remote:bob@example.com/web:screen_share");
   });
 
+  test("hides the local self-view camera tile from the stage when hideSelfView is set", () => {
+    const projection = projectCallTiles({
+      remoteTracks: [remoteVideo("bob@example.com/web", "bob-camera", "camera")],
+      localTracks: [],
+      localIdentity: "alice@example.com/web",
+      micEnabled: true,
+      seenRemoteScreenTrackKeys: new Set(),
+      pinnedTileKey: null,
+      hideSelfView: true,
+    });
+
+    expect(projection.tiles.map((tile) => tile.key)).toEqual([
+      "remote:bob@example.com/web:camera",
+    ]);
+  });
+
+  test("never auto-promotes the hidden self-view to the large Speaker tile when alone", () => {
+    const projection = projectCallTiles({
+      remoteTracks: [],
+      localTracks: [],
+      localIdentity: "alice@example.com/web",
+      micEnabled: true,
+      seenRemoteScreenTrackKeys: new Set(),
+      pinnedTileKey: null,
+      viewMode: "speaker",
+      promotedSpeakerIdentity: null,
+      hideSelfView: true,
+    });
+
+    expect(projection.spotlightKey).toBeNull();
+    expect(projection.tiles).toEqual([]);
+  });
+
+  test("promotes the remote camera in Speaker view while the self-view is hidden", () => {
+    const projection = projectCallTiles({
+      remoteTracks: [remoteVideo("bob@example.com/web", "bob-camera", "camera")],
+      localTracks: [],
+      localIdentity: "alice@example.com/web",
+      micEnabled: true,
+      seenRemoteScreenTrackKeys: new Set(),
+      pinnedTileKey: null,
+      viewMode: "speaker",
+      promotedSpeakerIdentity: null,
+      hideSelfView: true,
+    });
+
+    expect(projection.spotlightKey).toBe("remote:bob@example.com/web:camera");
+    expect(projection.tiles.some((tile) => tile.isSelf)).toBe(false);
+  });
+
   test("retains manual focus while its target tile is still present", () => {
     const projection = projectCallTiles({
       remoteTracks: [

--- a/chat/tests/call-view-state.test.ts
+++ b/chat/tests/call-view-state.test.ts
@@ -1,14 +1,18 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
   $callPinnedTileKey,
+  $callSelfViewHidden,
   $callViewMode,
   resetCallViewState,
   setCallViewMode,
   toggleCallPin,
+  toggleCallSelfViewHidden,
 } from "../src/lib/calls/call-view-state";
+import { $callCamEnabled } from "../src/lib/calls/call-controls";
 
 afterEach(() => {
   resetCallViewState();
+  $callCamEnabled.set(true);
 });
 
 describe("call view state", () => {
@@ -44,5 +48,33 @@ describe("call view state", () => {
 
     expect($callViewMode.get()).toBe("gallery");
     expect($callPinnedTileKey.get()).toBeNull();
+  });
+
+  test("self-view starts visible and toggleCallSelfViewHidden flips it both ways", () => {
+    expect($callSelfViewHidden.get()).toBe(false);
+
+    toggleCallSelfViewHidden();
+    expect($callSelfViewHidden.get()).toBe(true);
+
+    toggleCallSelfViewHidden();
+    expect($callSelfViewHidden.get()).toBe(false);
+  });
+
+  test("resetCallViewState restores the self-view", () => {
+    toggleCallSelfViewHidden();
+
+    resetCallViewState();
+
+    expect($callSelfViewHidden.get()).toBe(false);
+  });
+
+  test("hiding the self-view leaves the outgoing camera publishing untouched", () => {
+    expect($callCamEnabled.get()).toBe(true);
+
+    toggleCallSelfViewHidden();
+
+    // Hide self-view is a local rendering choice only; it must never mute the
+    // camera the way the cam toggle would.
+    expect($callCamEnabled.get()).toBe(true);
   });
 });


### PR DESCRIPTION
## What & why

Closes #1021 (part of the call Zoom-parity epic #1017).

Adds a **Hide self-view** control that removes your own camera tile from the
stage **without** stopping your outgoing video to other participants, and
guarantees you are never auto-promoted to the large Speaker tile while hidden.

## Design

Hide self-view is a **local view-state** concern, exactly like the existing
local pin (`$callPinnedTileKey`) and Gallery/Speaker mode (`$callViewMode`):

- It changes only this client's **stage projection**; it never calls the
  engine, so the camera keeps publishing (AC #2 holds by construction — a unit
  test asserts toggling leaves `$callCamEnabled` untouched).
- It is purely client-local rendering with **no XMPP wire shape** — analogous
  to the local pin, which is documented as local-only and never put on the
  wire. No XEP governs this behavior, so there is nothing to conform to and no
  Rust/server change is involved.

### Changes

1. `call-view-state.ts` — new `$callSelfViewHidden` atom (default `false`),
   `toggleCallSelfViewHidden()`, reset in `resetCallViewState()` so it never
   leaks across calls.
2. `call-tile-projection.ts` — new `hideSelfView?: boolean` on
   `ProjectCallTilesInput`. When set, the local **camera** self-view tile is
   filtered out **before** spotlight selection, so it is dropped from the grid
   **and** can never be auto-promoted to the large Speaker tile (AC #1 + #3).
   The local screen-share tile (also `isSelf`) is deliberately kept — the user
   is still presenting it.
3. `CallTileGrid.vue` — reads `$callSelfViewHidden`, passes `hideSelfView` to
   `projectCallTiles` (re-projects reactively on toggle).
4. `CallControls.vue` — a checkable **Self-view** item in the More ▸ overflow
   menu (`role="menuitemcheckbox"` + `aria-checked`, stable label + trailing
   check), matching the codebase's existing in-menu toggles
   (`ProfilePanel`, `NotifyModeButton`). Roving-focus selector broadened so the
   checkbox item stays in arrow-key order.
5. `CallSplitContainer.vue` + `CallExpandedSurface.vue` — wire the prop/event.

The local screen-share **notice** ("You're sharing your screen") is driven
separately from the projection and is intentionally **not** affected by
hide self-view.

## Acceptance criteria

- [x] A control toggles your self-tile off the stage.
- [x] Hiding self-view does not stop your outgoing camera/video.
- [x] You are never auto-promoted to the large Speaker tile while self-view is hidden.
- [x] Projection with hidden self-view is unit-tested via `bun test`.

## Testing

- TDD red→green per behavior across `call-tile-spotlight`, `call-tile-projection`,
  `call-view-state`, `call-tile-grid-overflow` (behavioral render + container
  wiring), and `call-controls` (menu item + a11y state).
- Affected suite green (`bun test`, 100+ tests across the touched files); `knip`
  clean (exit 0). The only full-suite failure is the pre-existing spurious
  `startup-loading` test (needs a completed `bun run build`, which is blocked
  locally by an unrelated `cloudflare:workers` astro-check type error — not
  touched by this PR).
- Reviewed with three adversarial personas (correctness, a11y/UX, standards) —
  the a11y pass drove the switch from a plain flipping-label item to the
  `menuitemcheckbox` pattern above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)