### PR TITLE
feat(chat): add immersive call surface

### DIFF
--- a/chat/src/components/calls/CallControls.vue
+++ b/chat/src/components/calls/CallControls.vue
@@ -39,6 +39,10 @@ const props = defineProps<{
   /** True when the parent surface is the expanded variant — flips
    *  the toggle button between "expand" and "collapse". */
   isExpanded: boolean;
+  /** True when the parent surface is the cinematic viewport takeover. */
+  isImmersive?: boolean;
+  /** True while the immersive surface owns browser-native fullscreen. */
+  isNativeFullscreen?: boolean;
   /** True while the Participants dock is open — drives the participants
    *  button's pressed/expanded state. The parent owns the dock store. */
   participantsOpen: boolean;
@@ -60,6 +64,7 @@ const emit = defineEmits<{
   toggleCam: [];
   toggleScreenShare: [];
   toggleExpanded: [];
+  toggleNativeFullscreen: [];
   toggleParticipants: [];
   toggleChat: [];
   openSettings: [];
@@ -290,12 +295,22 @@ onBeforeUnmount(() => {
     <button
       type="button"
       class="chat-icon-button chat-icon-button--md hover:bg-muted"
-      :title="isExpanded ? 'Collapse call' : 'Expand call'"
+      :title="isImmersive ? 'Return call to expanded view' : isExpanded ? 'Make call immersive' : 'Expand call'"
       :aria-pressed="isExpanded"
-      :aria-label="isExpanded ? 'Collapse call to split view' : 'Expand call to fill the chat pane'"
+      :aria-label="isImmersive ? 'Return call to expanded view' : isExpanded ? 'Make call immersive' : 'Expand call to fill the chat pane'"
       @click="emit('toggleExpanded')"
     >
-      <component :is="isExpanded ? Minimize2 : Maximize2" class="w-4 h-4" />
+      <component :is="isImmersive ? Minimize2 : Maximize2" class="w-4 h-4" />
+    </button>
+    <button
+      v-if="isImmersive"
+      type="button"
+      class="chat-icon-button chat-icon-button--md hover:bg-muted"
+      :title="isNativeFullscreen ? 'Exit browser fullscreen' : 'Enter browser fullscreen'"
+      :aria-label="isNativeFullscreen ? 'Exit browser fullscreen' : 'Enter browser fullscreen'"
+      @click="emit('toggleNativeFullscreen')"
+    >
+      <Maximize2 class="w-4 h-4" />
     </button>
     <button
       type="button"

--- a/chat/src/components/calls/CallControls.vue
+++ b/chat/src/components/calls/CallControls.vue
@@ -320,7 +320,7 @@ onBeforeUnmount(() => {
       :aria-label="isNativeFullscreen ? 'Exit browser fullscreen' : 'Enter browser fullscreen'"
       @click="emit('toggleNativeFullscreen')"
     >
-      <Maximize2 class="w-4 h-4" />
+      <component :is="isNativeFullscreen ? Minimize2 : Maximize2" class="w-4 h-4" />
     </button>
     <button
       type="button"

--- a/chat/src/components/calls/CallControls.vue
+++ b/chat/src/components/calls/CallControls.vue
@@ -64,6 +64,7 @@ const emit = defineEmits<{
   toggleCam: [];
   toggleScreenShare: [];
   toggleExpanded: [];
+  toggleImmersive: [];
   toggleNativeFullscreen: [];
   toggleParticipants: [];
   toggleChat: [];
@@ -295,12 +296,21 @@ onBeforeUnmount(() => {
     <button
       type="button"
       class="chat-icon-button chat-icon-button--md hover:bg-muted"
-      :title="isImmersive ? 'Return call to expanded view' : isExpanded ? 'Make call immersive' : 'Expand call'"
-      :aria-pressed="isExpanded"
-      :aria-label="isImmersive ? 'Return call to expanded view' : isExpanded ? 'Make call immersive' : 'Expand call to fill the chat pane'"
+      :title="isImmersive ? 'Return call to expanded view' : isExpanded ? 'Collapse call' : 'Expand call'"
+      :aria-label="isImmersive ? 'Return call to expanded view' : isExpanded ? 'Collapse call to split view' : 'Expand call to fill the chat pane'"
       @click="emit('toggleExpanded')"
     >
-      <component :is="isImmersive ? Minimize2 : Maximize2" class="w-4 h-4" />
+      <component :is="isExpanded ? Minimize2 : Maximize2" class="w-4 h-4" />
+    </button>
+    <button
+      v-if="isExpanded && !isImmersive"
+      type="button"
+      class="chat-icon-button chat-icon-button--md hover:bg-muted"
+      title="Make call immersive"
+      aria-label="Make call immersive"
+      @click="emit('toggleImmersive')"
+    >
+      <Maximize2 class="w-4 h-4" />
     </button>
     <button
       v-if="isImmersive"

--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -297,8 +297,9 @@ async function toggleNativeFullscreen(): Promise<void> {
 
 function onFullscreenChange(): void {
   if (typeof document === "undefined") return;
+  const wasNativeFullscreenActive = nativeFullscreenActive.value;
   nativeFullscreenActive.value = document.fullscreenElement === surfaceRef.value;
-  if (!nativeFullscreenActive.value) {
+  if (wasNativeFullscreenActive && !nativeFullscreenActive.value) {
     $callUiMode.set(callUiModeAfterFullscreenExit(uiMode.value));
   }
 }

--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -9,7 +9,6 @@ import {
   $callUiMode,
   callUiModeAfterFullscreenExit,
   callUiModeAfterSurfaceEscape,
-  nextCallUiMode,
   shouldExitNativeFullscreenForModeChange,
 } from "@/lib/calls/ui-mode";
 import {
@@ -233,12 +232,8 @@ const {
 
 const participantCount = computed(() => rosterRows.value.length);
 
-function collapseToSplit(): void {
-  $callUiMode.set("split");
-}
-
-async function toggleUiMode(): Promise<void> {
-  const nextMode = nextCallUiMode(uiMode.value);
+async function toggleExpandedSurface(): Promise<void> {
+  const nextMode = callUiModeAfterSurfaceEscape(uiMode.value);
   if (
     shouldExitNativeFullscreenForModeChange(
       uiMode.value,
@@ -253,6 +248,10 @@ async function toggleUiMode(): Promise<void> {
   $callUiMode.set(nextMode);
 }
 
+function enterImmersive(): void {
+  $callUiMode.set("immersive");
+}
+
 function clearChromeIdleTimer(): void {
   if (typeof window === "undefined") return;
   if (chromeIdleTimer === null) return;
@@ -260,21 +259,39 @@ function clearChromeIdleTimer(): void {
   chromeIdleTimer = null;
 }
 
+function chromeHasFocus(): boolean {
+  if (typeof document === "undefined") return false;
+  const active = document.activeElement;
+  return active instanceof Element && !!active.closest(".call-expanded__chrome");
+}
+
+function scheduleImmersiveChromeHide(): void {
+  if (typeof window === "undefined" || !isImmersive.value) return;
+  chromeIdleTimer = window.setTimeout(() => {
+    chromeIdleTimer = null;
+    if (!isImmersive.value) return;
+    if (chromeHasFocus()) {
+      scheduleImmersiveChromeHide();
+      return;
+    }
+    chromeVisible.value = false;
+  }, 2_000);
+}
+
 function revealImmersiveChrome(): void {
   chromeVisible.value = true;
   if (typeof window === "undefined" || !isImmersive.value) return;
   clearChromeIdleTimer();
-  chromeIdleTimer = window.setTimeout(() => {
-    if (isImmersive.value) chromeVisible.value = false;
-  }, 2_000);
+  scheduleImmersiveChromeHide();
 }
 
 async function toggleNativeFullscreen(): Promise<void> {
   if (typeof document === "undefined") return;
-  if (document.fullscreenElement) {
+  if (document.fullscreenElement === surfaceRef.value) {
     await document.exitFullscreen();
     return;
   }
+  if (document.fullscreenElement) return;
   await surfaceRef.value?.requestFullscreen?.();
 }
 
@@ -390,6 +407,8 @@ onBeforeUnmount(() => {
     }"
     role="region"
     :aria-label="isImmersive ? 'Active call (immersive)' : 'Active call (expanded)'"
+    @focusin="revealImmersiveChrome"
+    @keydown="revealImmersiveChrome"
     @pointermove="revealImmersiveChrome"
   >
     <CallStageHeader
@@ -474,7 +493,8 @@ onBeforeUnmount(() => {
         @toggle-mic="toggleMic"
         @toggle-cam="toggleCam"
         @toggle-screen-share="toggleScreenShare"
-        @toggle-expanded="toggleUiMode"
+        @toggle-expanded="toggleExpandedSurface"
+        @toggle-immersive="enterImmersive"
         @toggle-native-fullscreen="toggleNativeFullscreen"
         @toggle-participants="toggleCallParticipants"
         @toggle-chat="toggleCallChat"
@@ -507,13 +527,35 @@ onBeforeUnmount(() => {
   background: #050507;
 }
 
+.call-expanded--immersive .call-expanded__main {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+
+.call-expanded--immersive .call-expanded__header,
+.call-expanded--immersive .call-expanded__footer {
+  position: absolute;
+  inset-inline: 0;
+  z-index: 3;
+}
+
+.call-expanded--immersive .call-expanded__header {
+  inset-block-start: 0;
+}
+
+.call-expanded--immersive .call-expanded__footer {
+  inset-block-end: 0;
+}
+
 .call-expanded__chrome {
-  transition: opacity 180ms ease, transform 180ms ease;
+  transition: opacity 180ms ease, transform 180ms ease, visibility 180ms ease;
 }
 
 .call-expanded--chrome-hidden .call-expanded__chrome {
   opacity: 0;
   pointer-events: none;
+  visibility: hidden;
 }
 
 .call-expanded--chrome-hidden .call-expanded__header {
@@ -575,10 +617,6 @@ onBeforeUnmount(() => {
 @media (max-width: 760px) {
   .call-expanded__main {
     flex-direction: column;
-  }
-
-  .call-expanded--immersive .call-expanded__main {
-    flex-direction: row;
   }
 
   .call-expanded--immersive .call-expanded__dock-overlay {

--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -1,11 +1,17 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { useStore } from "@nanostores/vue";
 import {
   $callState,
   $lastCallError,
 } from "@/lib/calls/call-store";
-import { $callUiMode } from "@/lib/calls/ui-mode";
+import {
+  $callUiMode,
+  callUiModeAfterFullscreenExit,
+  callUiModeAfterSurfaceEscape,
+  nextCallUiMode,
+  shouldExitNativeFullscreenForModeChange,
+} from "@/lib/calls/ui-mode";
 import {
   $callSelfViewHidden,
   $callViewMode,
@@ -108,6 +114,7 @@ const emit = defineEmits<{
   ];
 }>();
 
+const surfaceRef = ref<HTMLElement | null>(null);
 const state = useStore($callState);
 const uiMode = useStore($callUiMode);
 const viewMode = useStore($callViewMode);
@@ -123,6 +130,9 @@ const { remoteTracks, localTracks, engine, activeSpeakerIdentities, promotedSpea
 const { activeRoomJid, selfInCall } = useActiveMucCall();
 
 const settingsOpen = ref(false);
+const chromeVisible = ref(true);
+const nativeFullscreenActive = ref(false);
+let chromeIdleTimer: number | null = null;
 const dockOpen = useStore($callDockOpen);
 const dockTab = useStore($callDockTab);
 const chatUnread = useStore($callChatUnread);
@@ -159,11 +169,13 @@ const ownsDmCall = computed(() => {
 const isOpen = computed(() => {
   return (
     state.value.phase === "active" &&
-    uiMode.value === "expanded" &&
+    (uiMode.value === "expanded" || uiMode.value === "immersive") &&
     ((state.value.kind === "muc" && ownsMucCall.value && selfInCall.value) ||
       (state.value.kind === "dm" && ownsDmCall.value))
   );
 });
+
+const isImmersive = computed(() => uiMode.value === "immersive");
 
 const remoteParticipantCount = computed(() => {
   const ids = new Set<string>();
@@ -225,6 +237,55 @@ function collapseToSplit(): void {
   $callUiMode.set("split");
 }
 
+async function toggleUiMode(): Promise<void> {
+  const nextMode = nextCallUiMode(uiMode.value);
+  if (
+    shouldExitNativeFullscreenForModeChange(
+      uiMode.value,
+      nextMode,
+      nativeFullscreenActive.value,
+    ) &&
+    typeof document !== "undefined" &&
+    document.fullscreenElement === surfaceRef.value
+  ) {
+    await document.exitFullscreen();
+  }
+  $callUiMode.set(nextMode);
+}
+
+function clearChromeIdleTimer(): void {
+  if (typeof window === "undefined") return;
+  if (chromeIdleTimer === null) return;
+  window.clearTimeout(chromeIdleTimer);
+  chromeIdleTimer = null;
+}
+
+function revealImmersiveChrome(): void {
+  chromeVisible.value = true;
+  if (typeof window === "undefined" || !isImmersive.value) return;
+  clearChromeIdleTimer();
+  chromeIdleTimer = window.setTimeout(() => {
+    if (isImmersive.value) chromeVisible.value = false;
+  }, 2_000);
+}
+
+async function toggleNativeFullscreen(): Promise<void> {
+  if (typeof document === "undefined") return;
+  if (document.fullscreenElement) {
+    await document.exitFullscreen();
+    return;
+  }
+  await surfaceRef.value?.requestFullscreen?.();
+}
+
+function onFullscreenChange(): void {
+  if (typeof document === "undefined") return;
+  nativeFullscreenActive.value = document.fullscreenElement === surfaceRef.value;
+  if (!nativeFullscreenActive.value) {
+    $callUiMode.set(callUiModeAfterFullscreenExit(uiMode.value));
+  }
+}
+
 async function onHangup(): Promise<void> {
   await hangupActiveCall();
   // After hangup the surface unmounts on its own (phase flips out of
@@ -284,19 +345,36 @@ function onKeydown(event: KeyboardEvent): void {
     return;
   }
   event.preventDefault();
-  collapseToSplit();
+  $callUiMode.set(callUiModeAfterSurfaceEscape(uiMode.value));
 }
+
+watch(isImmersive, (immersive) => {
+  if (immersive) {
+    revealImmersiveChrome();
+  } else {
+    clearChromeIdleTimer();
+    chromeVisible.value = true;
+  }
+});
 
 onMounted(() => {
   refreshScreenShareSupported();
+  revealImmersiveChrome();
   if (typeof window !== "undefined") {
     window.addEventListener("keydown", onKeydown, true);
+  }
+  if (typeof document !== "undefined") {
+    document.addEventListener("fullscreenchange", onFullscreenChange);
   }
 });
 
 onBeforeUnmount(() => {
+  clearChromeIdleTimer();
   if (typeof window !== "undefined") {
     window.removeEventListener("keydown", onKeydown, true);
+  }
+  if (typeof document !== "undefined") {
+    document.removeEventListener("fullscreenchange", onFullscreenChange);
   }
 });
 </script>
@@ -304,11 +382,21 @@ onBeforeUnmount(() => {
 <template>
   <div
     v-if="isOpen"
+    ref="surfaceRef"
     class="call-expanded"
+    :class="{
+      'call-expanded--immersive': isImmersive,
+      'call-expanded--chrome-hidden': isImmersive && !chromeVisible,
+    }"
     role="region"
-    aria-label="Active call (expanded)"
+    :aria-label="isImmersive ? 'Active call (immersive)' : 'Active call (expanded)'"
+    @pointermove="revealImmersiveChrome"
   >
-    <CallStageHeader :title="peerLabel" :subline="subline" />
+    <CallStageHeader
+      class="call-expanded__chrome call-expanded__header"
+      :title="peerLabel"
+      :subline="subline"
+    />
     <div
       v-if="lastError"
       class="call-expanded__error"
@@ -334,43 +422,49 @@ onBeforeUnmount(() => {
           @open-participants="openCallParticipants"
         />
       </div>
-      <CallDock
+      <div
         v-if="dockOpen"
-        :rows="rosterRows"
-        :active-tab="dockTab"
-        :chat-unread="chatUnread"
-        @set-tab="setCallDockTab"
-        @set-volume="setParticipantVolume"
-        @reset-all="resetParticipantVolumes"
-        @close="closeCallDock"
+        class="call-expanded__dock-overlay"
       >
-        <template #chat>
-          <CallChatPanel
-            v-model:draft="callChatDraft"
-            :messages="callChatMessages ?? []"
-            :visible="chatOpen"
-            :avatar-url-by-author="avatarUrlByAuthor ?? {}"
-            :is-sending="!!isSending"
-            :disabled="!!disabled || !callThreadOverride"
-            :giphy-api-key="giphyApiKey ?? ''"
-            :mention-candidates="mentionCandidates ?? []"
-            :slow-mode-cooldown="slowModeCooldown ?? 0"
-            :upload-progress="uploadProgress ?? { uploading: false, progress: 0, filename: '' }"
-            :in-muc="isMucCall"
-            :link-preview-lookup="linkPreviewLookup ?? null"
-            :link-preview-scope="linkPreviewScope ?? null"
-            @send="onSendCallChat"
-          />
-        </template>
-      </CallDock>
+        <CallDock
+          :rows="rosterRows"
+          :active-tab="dockTab"
+          :chat-unread="chatUnread"
+          @set-tab="setCallDockTab"
+          @set-volume="setParticipantVolume"
+          @reset-all="resetParticipantVolumes"
+          @close="closeCallDock"
+        >
+          <template #chat>
+            <CallChatPanel
+              v-model:draft="callChatDraft"
+              :messages="callChatMessages ?? []"
+              :visible="chatOpen"
+              :avatar-url-by-author="avatarUrlByAuthor ?? {}"
+              :is-sending="!!isSending"
+              :disabled="!!disabled || !callThreadOverride"
+              :giphy-api-key="giphyApiKey ?? ''"
+              :mention-candidates="mentionCandidates ?? []"
+              :slow-mode-cooldown="slowModeCooldown ?? 0"
+              :upload-progress="uploadProgress ?? { uploading: false, progress: 0, filename: '' }"
+              :in-muc="isMucCall"
+              :link-preview-lookup="linkPreviewLookup ?? null"
+              :link-preview-scope="linkPreviewScope ?? null"
+              @send="onSendCallChat"
+            />
+          </template>
+        </CallDock>
+      </div>
     </main>
-    <footer class="call-expanded__footer">
+    <footer class="call-expanded__chrome call-expanded__footer">
       <CallControls
         :mic-enabled="micEnabled"
         :cam-enabled="camEnabled"
         :screen-share-enabled="screenShareEnabled"
         :screen-share-supported="screenShareSupported"
         :is-expanded="true"
+        :is-immersive="isImmersive"
+        :is-native-fullscreen="nativeFullscreenActive"
         :participants-open="participantsOpen"
         :participant-count="participantCount"
         :chat-open="chatOpen"
@@ -380,7 +474,8 @@ onBeforeUnmount(() => {
         @toggle-mic="toggleMic"
         @toggle-cam="toggleCam"
         @toggle-screen-share="toggleScreenShare"
-        @toggle-expanded="collapseToSplit"
+        @toggle-expanded="toggleUiMode"
+        @toggle-native-fullscreen="toggleNativeFullscreen"
         @toggle-participants="toggleCallParticipants"
         @toggle-chat="toggleCallChat"
         @open-settings="settingsOpen = true"
@@ -406,6 +501,29 @@ onBeforeUnmount(() => {
   background: var(--background);
 }
 
+.call-expanded--immersive {
+  position: fixed;
+  z-index: 80;
+  background: #050507;
+}
+
+.call-expanded__chrome {
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+.call-expanded--chrome-hidden .call-expanded__chrome {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.call-expanded--chrome-hidden .call-expanded__header {
+  transform: translateY(-0.5rem);
+}
+
+.call-expanded--chrome-hidden .call-expanded__footer {
+  transform: translateY(0.5rem);
+}
+
 .call-expanded__error {
   border-bottom: 1px solid color-mix(in oklab, var(--destructive) 30%, transparent);
   background: color-mix(in oklab, var(--destructive) 10%, transparent);
@@ -429,6 +547,19 @@ onBeforeUnmount(() => {
   overflow: hidden;
 }
 
+.call-expanded__dock-overlay {
+  display: contents;
+}
+
+.call-expanded--immersive .call-expanded__dock-overlay {
+  position: absolute;
+  inset-block: 4.5rem 5rem;
+  inset-inline-end: 1rem;
+  z-index: 2;
+  display: flex;
+  max-width: min(24rem, calc(100vw - 2rem));
+}
+
 .call-expanded__footer {
   display: flex;
   align-items: center;
@@ -444,6 +575,16 @@ onBeforeUnmount(() => {
 @media (max-width: 760px) {
   .call-expanded__main {
     flex-direction: column;
+  }
+
+  .call-expanded--immersive .call-expanded__main {
+    flex-direction: row;
+  }
+
+  .call-expanded--immersive .call-expanded__dock-overlay {
+    inset-block: auto 5rem;
+    inset-inline: 0.75rem;
+    max-width: none;
   }
 }
 </style>

--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -363,7 +363,7 @@ function onKeydown(event: KeyboardEvent): void {
     return;
   }
   event.preventDefault();
-  $callUiMode.set(callUiModeAfterSurfaceEscape(uiMode.value));
+  void toggleExpandedSurface();
 }
 
 watch(isImmersive, (immersive) => {

--- a/chat/src/components/calls/CallOverlay.vue
+++ b/chat/src/components/calls/CallOverlay.vue
@@ -16,7 +16,7 @@ import {
   resetCallControls,
   seedCallControlsFromEngine,
 } from "@/lib/calls/call-controls";
-import { $callUiMode } from "@/lib/calls/ui-mode";
+import { $callUiMode, resetCallUiModeAfterCallEnd } from "@/lib/calls/ui-mode";
 import { resetCallViewState } from "@/lib/calls/call-view-state";
 
 /**
@@ -108,8 +108,8 @@ watch(
       // a sticky preference. Otherwise hanging up an expanded call
       // would leave the next call's split surface invisible because
       // the mode was still "expanded".
-      if ($callUiMode.get() === "expanded") {
-        $callUiMode.set("split");
+      if ($callUiMode.get() !== "split") {
+        $callUiMode.set(resetCallUiModeAfterCallEnd());
       }
     });
   },

--- a/chat/src/lib/calls/ui-mode.ts
+++ b/chat/src/lib/calls/ui-mode.ts
@@ -2,8 +2,10 @@ import { atom } from "nanostores";
 
 /**
  * How the in-call surface is presented to the user. Independent of
- * the call lifecycle in `$callState` so the user's last chosen
- * presentation outlives the connect/reconnect cycle.
+ * the call lifecycle in `$callState` so the user's last chosen split
+ * or expanded presentation outlives the connect/reconnect cycle.
+ * Immersive is intentionally not restored across page reloads because
+ * it hides the whole app chrome and should require an explicit user action.
  *
  * - `split`: the call renders inline above the channel's message lane
  *   so the chat is always visible beneath. A drag handle between the

--- a/chat/src/lib/calls/ui-mode.ts
+++ b/chat/src/lib/calls/ui-mode.ts
@@ -32,7 +32,7 @@ function readInitialMode(): CallUiMode {
   if (typeof window === "undefined") return "split";
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (raw === "split" || raw === "expanded" || raw === "immersive") {
+    if (raw === "split" || raw === "expanded") {
       return raw;
     }
   } catch {

--- a/chat/src/lib/calls/ui-mode.ts
+++ b/chat/src/lib/calls/ui-mode.ts
@@ -14,13 +14,17 @@ import { atom } from "nanostores";
  *   surrounding app shell (waddles rail, channel list, thread panel)
  *   stays visible so the user can still navigate; this is NOT the
  *   browser's native fullscreen.
+ * - `immersive`: the call stage fills the viewport edge-to-edge and
+ *   hides the surrounding app chrome. Native browser fullscreen can
+ *   be layered on top of this mode, but leaving browser fullscreen
+ *   returns to `expanded`.
  *
  * Anything that used to be `docked`, `floating`, `minimized`, or
  * `pip` is gone — see PR #743 for the rationale. The chat must never
  * be hidden behind the call, and the call must never escape the
  * channel that owns it.
  */
-type CallUiMode = "split" | "expanded";
+export type CallUiMode = "split" | "expanded" | "immersive";
 
 const STORAGE_KEY = "waddle:call-ui-mode";
 
@@ -28,7 +32,7 @@ function readInitialMode(): CallUiMode {
   if (typeof window === "undefined") return "split";
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (raw === "split" || raw === "expanded") {
+    if (raw === "split" || raw === "expanded" || raw === "immersive") {
       return raw;
     }
   } catch {
@@ -38,6 +42,32 @@ function readInitialMode(): CallUiMode {
 }
 
 export const $callUiMode = atom<CallUiMode>(readInitialMode());
+
+export function nextCallUiMode(mode: CallUiMode): CallUiMode {
+  if (mode === "split") return "expanded";
+  if (mode === "expanded") return "immersive";
+  return "expanded";
+}
+
+export function callUiModeAfterFullscreenExit(mode: CallUiMode): CallUiMode {
+  return mode === "immersive" ? "expanded" : mode;
+}
+
+export function callUiModeAfterSurfaceEscape(mode: CallUiMode): CallUiMode {
+  return mode === "immersive" ? "expanded" : "split";
+}
+
+export function shouldExitNativeFullscreenForModeChange(
+  currentMode: CallUiMode,
+  nextMode: CallUiMode,
+  nativeFullscreenActive: boolean,
+): boolean {
+  return currentMode === "immersive" && nextMode !== "immersive" && nativeFullscreenActive;
+}
+
+export function resetCallUiModeAfterCallEnd(): CallUiMode {
+  return "split";
+}
 
 $callUiMode.subscribe((mode) => {
   if (typeof window === "undefined") return;

--- a/chat/tests/call-controls.test.ts
+++ b/chat/tests/call-controls.test.ts
@@ -806,6 +806,36 @@ describe("call control bar hide self-view (#1021)", () => {
   });
 });
 
+describe("call control bar immersive mode (#1028)", () => {
+  test("expanded mode offers Immersive without browser fullscreen controls", async () => {
+    const html = await renderCallControls({ isExpanded: true, isImmersive: false });
+    expect(html).toContain("Make call immersive");
+    expect(html).not.toContain("Enter browser fullscreen");
+    expect(html).not.toContain("Exit browser fullscreen");
+  });
+
+  test("immersive mode offers a return action and browser fullscreen entry", async () => {
+    const html = await renderCallControls({
+      isExpanded: true,
+      isImmersive: true,
+      isNativeFullscreen: false,
+    });
+    expect(html).toContain("Return call to expanded view");
+    expect(html).toContain("Enter browser fullscreen");
+    expect(html).not.toContain("Exit browser fullscreen");
+  });
+
+  test("immersive native fullscreen action switches to exit while active", async () => {
+    const html = await renderCallControls({
+      isExpanded: true,
+      isImmersive: true,
+      isNativeFullscreen: true,
+    });
+    expect(html).toContain("Exit browser fullscreen");
+    expect(html).not.toContain("Enter browser fullscreen");
+  });
+});
+
 async function renderCallControls(overrides: Record<string, unknown>): Promise<string> {
   const component = await loadVueComponent("../src/components/calls/CallControls.vue");
   const props = {

--- a/chat/tests/call-controls.test.ts
+++ b/chat/tests/call-controls.test.ts
@@ -809,6 +809,7 @@ describe("call control bar hide self-view (#1021)", () => {
 describe("call control bar immersive mode (#1028)", () => {
   test("expanded mode offers Immersive without browser fullscreen controls", async () => {
     const html = await renderCallControls({ isExpanded: true, isImmersive: false });
+    expect(html).toContain("Collapse call to split view");
     expect(html).toContain("Make call immersive");
     expect(html).not.toContain("Enter browser fullscreen");
     expect(html).not.toContain("Exit browser fullscreen");

--- a/chat/tests/call-dock-wiring.test.ts
+++ b/chat/tests/call-dock-wiring.test.ts
@@ -135,4 +135,39 @@ describe("call surfaces use the Participants dock", () => {
     expect(guard).toContain("if (dockOpen.value)");
     expect(guard).toContain("closeCallDock()");
   });
+
+  test("Immersive keeps the stage edge-to-edge and overlays the dock", () => {
+    const source = surfaceSource("CallExpandedSurface.vue");
+    expect(source).toContain('uiMode.value === "immersive"');
+    expect(source).toContain("call-expanded--immersive");
+    expect(source).toContain("call-expanded__dock-overlay");
+    expect(source).toContain("chromeVisible");
+    expect(source).toContain("@pointermove=\"revealImmersiveChrome\"");
+    expect(source).toContain("watch(isImmersive");
+  });
+
+  test("Immersive layers browser fullscreen and exits back to Expanded", () => {
+    const surface = surfaceSource("CallExpandedSurface.vue");
+    expect(surface).toContain("requestFullscreen");
+    expect(surface).toContain("document.exitFullscreen()");
+    expect(surface).toContain("shouldExitNativeFullscreenForModeChange");
+    expect(surface).toContain("document.fullscreenElement === surfaceRef.value");
+    expect(surface).toContain("fullscreenchange");
+    expect(surface).toContain("callUiModeAfterFullscreenExit(uiMode.value)");
+    expect(surface).toContain("callUiModeAfterSurfaceEscape(uiMode.value)");
+    expect(surface).toContain("@toggle-native-fullscreen");
+
+    const controls = surfaceSource("CallControls.vue");
+    expect(controls).toContain("isImmersive");
+    expect(controls).toContain("isNativeFullscreen");
+    expect(controls).toContain("toggleNativeFullscreen");
+    expect(controls).toContain("Enter browser fullscreen");
+    expect(controls).toContain("Exit browser fullscreen");
+  });
+
+  test("call lifecycle cleanup resets any non-split UI mode for the next call", () => {
+    const source = surfaceSource("CallOverlay.vue");
+    expect(source).toContain('$callUiMode.get() !== "split"');
+    expect(source).toContain("resetCallUiModeAfterCallEnd()");
+  });
 });

--- a/chat/tests/call-dock-wiring.test.ts
+++ b/chat/tests/call-dock-wiring.test.ts
@@ -161,7 +161,7 @@ describe("call surfaces use the Participants dock", () => {
     expect(surface).toContain("if (wasNativeFullscreenActive && !nativeFullscreenActive.value)");
     expect(surface).toContain("fullscreenchange");
     expect(surface).toContain("callUiModeAfterFullscreenExit(uiMode.value)");
-    expect(surface).toContain("callUiModeAfterSurfaceEscape(uiMode.value)");
+    expect(surface).toContain("void toggleExpandedSurface()");
     expect(surface).toContain("@toggle-native-fullscreen");
     expect(surface).toContain("@toggle-immersive");
 

--- a/chat/tests/call-dock-wiring.test.ts
+++ b/chat/tests/call-dock-wiring.test.ts
@@ -143,7 +143,11 @@ describe("call surfaces use the Participants dock", () => {
     expect(source).toContain("call-expanded__dock-overlay");
     expect(source).toContain("chromeVisible");
     expect(source).toContain("@pointermove=\"revealImmersiveChrome\"");
+    expect(source).toContain("@focusin=\"revealImmersiveChrome\"");
+    expect(source).toContain("chromeHasFocus()");
     expect(source).toContain("watch(isImmersive");
+    expect(source).toContain("visibility: hidden");
+    expect(source).toContain("position: absolute");
   });
 
   test("Immersive layers browser fullscreen and exits back to Expanded", () => {
@@ -152,15 +156,19 @@ describe("call surfaces use the Participants dock", () => {
     expect(surface).toContain("document.exitFullscreen()");
     expect(surface).toContain("shouldExitNativeFullscreenForModeChange");
     expect(surface).toContain("document.fullscreenElement === surfaceRef.value");
+    expect(surface).toContain("if (document.fullscreenElement) return");
     expect(surface).toContain("fullscreenchange");
     expect(surface).toContain("callUiModeAfterFullscreenExit(uiMode.value)");
     expect(surface).toContain("callUiModeAfterSurfaceEscape(uiMode.value)");
     expect(surface).toContain("@toggle-native-fullscreen");
+    expect(surface).toContain("@toggle-immersive");
 
     const controls = surfaceSource("CallControls.vue");
     expect(controls).toContain("isImmersive");
     expect(controls).toContain("isNativeFullscreen");
     expect(controls).toContain("toggleNativeFullscreen");
+    expect(controls).toContain("toggleImmersive");
+    expect(controls).not.toContain(":aria-pressed=\"isExpanded\"");
     expect(controls).toContain("Enter browser fullscreen");
     expect(controls).toContain("Exit browser fullscreen");
   });

--- a/chat/tests/call-dock-wiring.test.ts
+++ b/chat/tests/call-dock-wiring.test.ts
@@ -157,6 +157,8 @@ describe("call surfaces use the Participants dock", () => {
     expect(surface).toContain("shouldExitNativeFullscreenForModeChange");
     expect(surface).toContain("document.fullscreenElement === surfaceRef.value");
     expect(surface).toContain("if (document.fullscreenElement) return");
+    expect(surface).toContain("const wasNativeFullscreenActive = nativeFullscreenActive.value");
+    expect(surface).toContain("if (wasNativeFullscreenActive && !nativeFullscreenActive.value)");
     expect(surface).toContain("fullscreenchange");
     expect(surface).toContain("callUiModeAfterFullscreenExit(uiMode.value)");
     expect(surface).toContain("callUiModeAfterSurfaceEscape(uiMode.value)");
@@ -167,6 +169,7 @@ describe("call surfaces use the Participants dock", () => {
     expect(controls).toContain("isImmersive");
     expect(controls).toContain("isNativeFullscreen");
     expect(controls).toContain("toggleNativeFullscreen");
+    expect(controls).toContain("isNativeFullscreen ? Minimize2 : Maximize2");
     expect(controls).toContain("toggleImmersive");
     expect(controls).not.toContain(":aria-pressed=\"isExpanded\"");
     expect(controls).toContain("Enter browser fullscreen");

--- a/chat/tests/call-ui-mode.test.ts
+++ b/chat/tests/call-ui-mode.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import {
+  callUiModeAfterFullscreenExit,
+  callUiModeAfterSurfaceEscape,
+  nextCallUiMode,
+  resetCallUiModeAfterCallEnd,
+  shouldExitNativeFullscreenForModeChange,
+} from "../src/lib/calls/ui-mode";
+
+describe("call UI mode transitions", () => {
+  test("cycles split to expanded to immersive", () => {
+    expect(nextCallUiMode("split")).toBe("expanded");
+    expect(nextCallUiMode("expanded")).toBe("immersive");
+    expect(nextCallUiMode("immersive")).toBe("expanded");
+  });
+
+  test("Esc from immersive returns to expanded", () => {
+    expect(callUiModeAfterSurfaceEscape("immersive")).toBe("expanded");
+    expect(callUiModeAfterSurfaceEscape("expanded")).toBe("split");
+  });
+
+  test("native fullscreen exit keeps non-immersive modes stable", () => {
+    expect(callUiModeAfterFullscreenExit("immersive")).toBe("expanded");
+    expect(callUiModeAfterFullscreenExit("expanded")).toBe("expanded");
+    expect(callUiModeAfterFullscreenExit("split")).toBe("split");
+  });
+
+  test("leaving immersive exits native fullscreen only when it is layered on", () => {
+    expect(shouldExitNativeFullscreenForModeChange("immersive", "expanded", true)).toBe(true);
+    expect(shouldExitNativeFullscreenForModeChange("immersive", "expanded", false)).toBe(false);
+    expect(shouldExitNativeFullscreenForModeChange("expanded", "immersive", true)).toBe(false);
+    expect(shouldExitNativeFullscreenForModeChange("expanded", "split", true)).toBe(false);
+  });
+
+  test("call end resets the next call to split", () => {
+    expect(resetCallUiModeAfterCallEnd()).toBe("split");
+  });
+});

--- a/chat/tests/call-ui-mode.test.ts
+++ b/chat/tests/call-ui-mode.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import {
   callUiModeAfterFullscreenExit,
   callUiModeAfterSurfaceEscape,
@@ -6,6 +6,40 @@ import {
   resetCallUiModeAfterCallEnd,
   shouldExitNativeFullscreenForModeChange,
 } from "../src/lib/calls/ui-mode";
+
+const originalWindow = globalThis.window;
+
+function memoryStorage(seed: Record<string, string> = {}): Storage {
+  const values = new Map(Object.entries(seed));
+  return {
+    get length() {
+      return values.size;
+    },
+    clear() {
+      values.clear();
+    },
+    getItem(key: string) {
+      return values.get(key) ?? null;
+    },
+    key(index: number) {
+      return [...values.keys()][index] ?? null;
+    },
+    removeItem(key: string) {
+      values.delete(key);
+    },
+    setItem(key: string, value: string) {
+      values.set(key, value);
+    },
+  };
+}
+
+afterEach(() => {
+  if (originalWindow === undefined) {
+    Reflect.deleteProperty(globalThis, "window");
+    return;
+  }
+  globalThis.window = originalWindow;
+});
 
 describe("call UI mode transitions", () => {
   test("cycles split to expanded to immersive", () => {
@@ -34,5 +68,19 @@ describe("call UI mode transitions", () => {
 
   test("call end resets the next call to split", () => {
     expect(resetCallUiModeAfterCallEnd()).toBe("split");
+  });
+
+  test("fresh loads restore split or expanded, but not immersive", async () => {
+    const loadMode = async (storedMode: string) => {
+      globalThis.window = {
+        localStorage: memoryStorage({ "waddle:call-ui-mode": storedMode }),
+      } as Window & typeof globalThis;
+      const module = await import(`../src/lib/calls/ui-mode?stored=${storedMode}`);
+      return module.$callUiMode.get();
+    };
+
+    expect(await loadMode("split")).toBe("split");
+    expect(await loadMode("expanded")).toBe("expanded");
+    expect(await loadMode("immersive")).toBe("split");
   });
 });


### PR DESCRIPTION
## Summary

Implements #1028.

- Adds `immersive` as the third call UI mode: Split -> Expanded -> Immersive.
- Renders Immersive as a fixed, edge-to-edge call stage that hides the surrounding app chrome.
- Auto-hides the call header and control bar on idle, with pointer/focus movement revealing them again.
- Overlays the dock in Immersive so the stage does not reflow.
- Adds a browser Fullscreen API control layered on top of Immersive.
- Returns native fullscreen exits and Immersive Escape back to Expanded.
- Routes Escape through the fullscreen-aware collapse path so layered native fullscreen is unwound.
- Resets non-split call UI modes after call teardown so the next call starts in Split.
- Keeps `immersive` session-only across page reloads; persisted `split`/`expanded` are still restored.

## Plan / acceptance mapping

- [x] Entering Immersive hides app chrome and fills the viewport with the stage.
- [x] Header and control bar auto-hide on idle and reappear on pointer/focus movement.
- [x] Dock overlays the stage in Immersive.
- [x] Browser fullscreen button layers OS fullscreen on top; exit returns to Expanded.
- [x] Split / Expanded / Immersive transitions covered by `bun test`.
- [x] Review feedback covered for fullscreen ownership, Escape behavior, hidden chrome focusability, fullscreen icon state, and reload persistence.

## Verification

- `cd chat && bun test tests/call-ui-mode.test.ts tests/call-dock-wiring.test.ts tests/call-controls.test.ts`
- `cd chat && bun run lint`
- `cd chat && bun run build`
- `cd chat && bun test`

## Notes

`bunx vue-tsc --noEmit` was also sampled after review feedback; it still reports existing repo-wide diagnostics outside this diff, and the modified-file timer-handle diagnostic identified during review was removed.

Fixes #1028
