### PR TITLE
feat(chat): add in-call reaction carrier

### DIFF
--- a/chat/src/components/calls/CallControls.vue
+++ b/chat/src/components/calls/CallControls.vue
@@ -12,6 +12,7 @@ import {
   MoreHorizontal,
   PhoneOff,
   ScanFace,
+  SmilePlus,
   Settings,
   SquareUser,
   Users,
@@ -68,6 +69,7 @@ const emit = defineEmits<{
   toggleNativeFullscreen: [];
   toggleParticipants: [];
   toggleChat: [];
+  sendReaction: [emoji: string];
   openSettings: [];
   setViewMode: [mode: CallViewMode];
   toggleSelfView: [];
@@ -114,9 +116,14 @@ function onViewKeydown(event: KeyboardEvent): void {
  * while Escape returns focus to the trigger.
  */
 const moreOpen = ref(false);
+const reactionsOpen = ref(false);
+const reactionsWrapEl = ref<HTMLElement | null>(null);
+const reactionsTriggerEl = ref<HTMLButtonElement | null>(null);
+const reactionsMenuEl = ref<HTMLElement | null>(null);
 const moreWrapEl = ref<HTMLElement | null>(null);
 const moreTriggerEl = ref<HTMLButtonElement | null>(null);
 const moreMenuEl = ref<HTMLElement | null>(null);
+const reactionEmojis = ["👍", "❤️", "😂", "🔥", "👏", "🎉"] as const;
 
 function menuItems(): HTMLElement[] {
   const root = moreMenuEl.value;
@@ -126,6 +133,70 @@ function menuItems(): HTMLElement[] {
   return Array.from(
     root.querySelectorAll<HTMLElement>('[role="menuitem"],[role="menuitemcheckbox"]'),
   );
+}
+
+function reactionItems(): HTMLElement[] {
+  const root = reactionsMenuEl.value;
+  if (!root) return [];
+  return Array.from(root.querySelectorAll<HTMLElement>('[role="menuitem"]'));
+}
+
+async function openReactions(focusFirst: boolean): Promise<void> {
+  reactionsOpen.value = true;
+  if (!focusFirst) return;
+  await nextTick();
+  reactionItems()[0]?.focus();
+}
+
+function closeReactions(returnFocus: boolean): void {
+  if (!reactionsOpen.value) return;
+  reactionsOpen.value = false;
+  if (returnFocus) reactionsTriggerEl.value?.focus();
+}
+
+function onReactionsTriggerKeydown(event: KeyboardEvent): void {
+  if (event.key === "ArrowDown" || event.key === "ArrowRight" || event.key === "Enter" || event.key === " ") {
+    event.preventDefault();
+    void openReactions(true);
+  } else if (event.key === "ArrowUp" || event.key === "ArrowLeft") {
+    event.preventDefault();
+    void openReactions(true).then(() => reactionItems().at(-1)?.focus());
+  } else if (event.key === "Escape") {
+    closeReactions(true);
+  }
+}
+
+function onReactionsMenuKeydown(event: KeyboardEvent): void {
+  const items = reactionItems();
+  if (items.length === 0) return;
+  const index = items.indexOf(document.activeElement as HTMLElement);
+  switch (event.key) {
+    case "Escape":
+      event.preventDefault();
+      closeReactions(true);
+      break;
+    case "Tab":
+      closeReactions(false);
+      break;
+    case "ArrowDown":
+    case "ArrowRight":
+      event.preventDefault();
+      items[(index + 1) % items.length]?.focus();
+      break;
+    case "ArrowUp":
+    case "ArrowLeft":
+      event.preventDefault();
+      items[(index - 1 + items.length) % items.length]?.focus();
+      break;
+    case "Home":
+      event.preventDefault();
+      items[0]?.focus();
+      break;
+    case "End":
+      event.preventDefault();
+      items.at(-1)?.focus();
+      break;
+  }
 }
 
 async function openMore(focusFirst: boolean): Promise<void> {
@@ -198,15 +269,22 @@ function selectSelfView(): void {
   closeMore(true);
 }
 
+function selectReaction(emoji: string): void {
+  emit("sendReaction", emoji);
+  closeReactions(true);
+}
+
 function onDocumentPointerDown(event: PointerEvent): void {
   const target = event.target as Node | null;
+  if (target && reactionsWrapEl.value?.contains(target)) return;
   if (target && moreWrapEl.value?.contains(target)) return;
+  closeReactions(false);
   closeMore(false);
 }
 
-watch(moreOpen, (open) => {
+watch([moreOpen, reactionsOpen], ([moreOpenValue, reactionsOpenValue]) => {
   if (typeof document === "undefined") return;
-  if (open) {
+  if (moreOpenValue || reactionsOpenValue) {
     document.addEventListener("pointerdown", onDocumentPointerDown, true);
   } else {
     document.removeEventListener("pointerdown", onDocumentPointerDown, true);
@@ -322,6 +400,41 @@ onBeforeUnmount(() => {
     >
       <component :is="isNativeFullscreen ? Minimize2 : Maximize2" class="w-4 h-4" />
     </button>
+    <div ref="reactionsWrapEl" class="call-controls__reactions">
+      <button
+        ref="reactionsTriggerEl"
+        type="button"
+        class="chat-icon-button chat-icon-button--md hover:bg-muted"
+        :class="{ 'bg-muted text-foreground': reactionsOpen }"
+        title="Reactions"
+        aria-label="Reactions"
+        aria-haspopup="menu"
+        :aria-expanded="reactionsOpen"
+        @click="reactionsOpen ? closeReactions(false) : openReactions(true)"
+        @keydown="onReactionsTriggerKeydown"
+      >
+        <SmilePlus class="w-4 h-4" />
+      </button>
+      <div
+        v-show="reactionsOpen"
+        ref="reactionsMenuEl"
+        class="call-controls__reaction-menu"
+        role="menu"
+        aria-label="Reactions"
+        @keydown="onReactionsMenuKeydown"
+      >
+        <button
+          v-for="emoji in reactionEmojis"
+          :key="emoji"
+          type="button"
+          role="menuitem"
+          class="call-controls__reaction-item"
+          @click="selectReaction(emoji)"
+        >
+          {{ emoji }}
+        </button>
+      </div>
+    </div>
     <button
       type="button"
       class="call-controls__participants chat-icon-button chat-icon-button--md hover:bg-muted"
@@ -435,6 +548,44 @@ onBeforeUnmount(() => {
   display: flex;
   align-items: center;
   gap: 2px;
+}
+
+.call-controls__reactions {
+  position: relative;
+  display: inline-flex;
+}
+
+.call-controls__reaction-menu {
+  position: absolute;
+  bottom: calc(100% + 0.375rem);
+  left: 50%;
+  z-index: 10;
+  display: grid;
+  grid-template-columns: repeat(6, 2rem);
+  gap: 0.125rem;
+  width: max-content;
+  padding: var(--space-2xs);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--popover, var(--background));
+  box-shadow: var(--shadow-lg, 0 10px 30px rgb(0 0 0 / 0.18));
+  transform: translateX(-50%);
+}
+
+.call-controls__reaction-item {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: var(--radius-sm);
+  font-size: var(--text-emoji-picker);
+  line-height: 1;
+}
+
+.call-controls__reaction-item:hover,
+.call-controls__reaction-item:focus-visible {
+  background: var(--muted);
 }
 
 /* More ▸ overflow. The menu floats above the bar (the bar sits at the

--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -45,8 +45,15 @@ import {
   toggleCallParticipants,
 } from "@/lib/calls/call-dock-state";
 import { $callChatUnread } from "@/lib/calls/call-chat-unread";
+import {
+  $inCallReactions,
+  clearInCallReactions,
+  expireInCallReactions,
+  receiveInCallReaction,
+} from "@/lib/calls/in-call-reactions";
 import { barePeerJid } from "@/lib/xmpp/jid";
 import { expectedRemoteIdentitiesForCallState } from "@/lib/calls/call-tiles";
+import type { BrowserXmppClient } from "@/lib/xmpp/client";
 import type { MentionCandidate } from "@/lib/mentions";
 import type { MarkupSpan, MessageReference, TimelineMessage } from "@/lib/chat-ui";
 import type { ComposerLinkPreviewLookup, ComposerLinkPreviewSendPayload } from "@/lib/link-preview-composer";
@@ -90,6 +97,9 @@ const props = defineProps<{
   /** The active call's XEP-0201 thread messages, rendered in the Chat tab. */
   callChatMessages?: readonly TimelineMessage[];
   avatarUrlByAuthor?: Record<string, string | null>;
+  xmppClient?: BrowserXmppClient | null;
+  spaceId?: string | null;
+  channelId?: string | null;
   sendCallChatMessage?: (
     body: string,
     markup: MarkupSpan[],
@@ -135,7 +145,9 @@ let chromeIdleTimer: number | null = null;
 const dockOpen = useStore($callDockOpen);
 const dockTab = useStore($callDockTab);
 const chatUnread = useStore($callChatUnread);
+const reactions = useStore($inCallReactions);
 const callChatDraft = ref("");
+let reactionExpiryTimer: ReturnType<typeof setInterval> | null = null;
 
 // The dock is shared with the Participants tab; split these out so the control
 // bar buttons reflect which tab (if any) the open dock is parked on.
@@ -329,6 +341,31 @@ async function onSendCallChat(
   callChatDraft.value = "";
 }
 
+async function onSendInCallReaction(emoji: string): Promise<void> {
+  const active = state.value;
+  if (active.phase !== "active") return;
+  if (active.kind === "muc") {
+    if (!props.xmppClient || !props.spaceId || !props.channelId) return;
+    await props.xmppClient.sendInCallReaction(props.spaceId, props.channelId, active.sid, emoji);
+  } else {
+    if (!props.xmppClient) return;
+    await props.xmppClient.sendDmInCallReaction(active.peer, active.sid, emoji);
+    receiveInCallReaction({
+      sid: active.sid,
+      emoji,
+      from: active.selfFullJid ?? "self",
+    });
+  }
+}
+
+function hashString(value: string): number {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) | 0;
+  }
+  return hash;
+}
+
 function onKeydown(event: KeyboardEvent): void {
   if (!isOpen.value) return;
   if (event.key !== "Escape") return;
@@ -384,10 +421,16 @@ onMounted(() => {
   if (typeof document !== "undefined") {
     document.addEventListener("fullscreenchange", onFullscreenChange);
   }
+  reactionExpiryTimer = setInterval(() => expireInCallReactions(), 400);
 });
 
 onBeforeUnmount(() => {
   clearChromeIdleTimer();
+  if (reactionExpiryTimer) {
+    clearInterval(reactionExpiryTimer);
+    reactionExpiryTimer = null;
+  }
+  clearInCallReactions();
   if (typeof window !== "undefined") {
     window.removeEventListener("keydown", onKeydown, true);
   }
@@ -441,6 +484,16 @@ onBeforeUnmount(() => {
           :promoted-speaker-identity="promotedSpeakerIdentity"
           @open-participants="openCallParticipants"
         />
+        <div class="call-expanded__reactions" aria-live="polite" aria-atomic="false">
+          <span
+            v-for="reaction in reactions"
+            :key="reaction.id"
+            class="call-expanded__reaction"
+            :style="{ '--reaction-x': `${Math.abs(hashString(reaction.id)) % 72}%` }"
+          >
+            {{ reaction.emoji }}
+          </span>
+        </div>
       </div>
       <div
         v-if="dockOpen"
@@ -502,6 +555,7 @@ onBeforeUnmount(() => {
         @open-settings="settingsOpen = true"
         @set-view-mode="setCallViewMode"
         @toggle-self-view="toggleCallSelfViewHidden"
+        @send-reaction="onSendInCallReaction"
         @hangup="onHangup"
       />
     </footer>
@@ -585,9 +639,43 @@ onBeforeUnmount(() => {
   flex: 1 1 0%;
   min-width: 0;
   min-height: 0;
+  position: relative;
   display: flex;
   flex-direction: column;
   overflow: hidden;
+}
+
+.call-expanded__reactions {
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  overflow: hidden;
+}
+
+.call-expanded__reaction {
+  position: absolute;
+  left: calc(14% + var(--reaction-x, 0%));
+  bottom: 16%;
+  font-size: 2.25rem;
+  line-height: 1;
+  filter: drop-shadow(0 0.25rem 0.5rem rgb(0 0 0 / 0.28));
+  animation: call-reaction-float 2.4s ease-out forwards;
+}
+
+@keyframes call-reaction-float {
+  0% {
+    opacity: 0;
+    transform: translate3d(0, 0.75rem, 0) scale(0.82);
+  }
+  12% {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translate3d(0, -8rem, 0) scale(1.18);
+  }
 }
 
 .call-expanded__dock-overlay {

--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -47,8 +47,10 @@ import {
 import { $callChatUnread } from "@/lib/calls/call-chat-unread";
 import {
   $inCallReactions,
+  activeInCallReactions,
   clearInCallReactions,
   expireInCallReactions,
+  hashInCallReactionId,
   receiveInCallReaction,
 } from "@/lib/calls/in-call-reactions";
 import { barePeerJid } from "@/lib/xmpp/jid";
@@ -148,6 +150,10 @@ const chatUnread = useStore($callChatUnread);
 const reactions = useStore($inCallReactions);
 const callChatDraft = ref("");
 let reactionExpiryTimer: ReturnType<typeof setInterval> | null = null;
+
+const activeCallReactions = computed(() => {
+  return activeInCallReactions(state.value, reactions.value);
+});
 
 // The dock is shared with the Participants tab; split these out so the control
 // bar buttons reflect which tab (if any) the open dock is parked on.
@@ -358,14 +364,6 @@ async function onSendInCallReaction(emoji: string): Promise<void> {
   }
 }
 
-function hashString(value: string): number {
-  let hash = 0;
-  for (let index = 0; index < value.length; index += 1) {
-    hash = (hash * 31 + value.charCodeAt(index)) | 0;
-  }
-  return hash;
-}
-
 function onKeydown(event: KeyboardEvent): void {
   if (!isOpen.value) return;
   if (event.key !== "Escape") return;
@@ -486,10 +484,10 @@ onBeforeUnmount(() => {
         />
         <div class="call-expanded__reactions" aria-live="polite" aria-atomic="false">
           <span
-            v-for="reaction in reactions"
+            v-for="reaction in activeCallReactions"
             :key="reaction.id"
             class="call-expanded__reaction"
-            :style="{ '--reaction-x': `${Math.abs(hashString(reaction.id)) % 72}%` }"
+            :style="{ '--reaction-x': `${Math.abs(hashInCallReactionId(reaction.id)) % 72}%` }"
           >
             {{ reaction.emoji }}
           </span>
@@ -660,10 +658,10 @@ onBeforeUnmount(() => {
   font-size: 2.25rem;
   line-height: 1;
   filter: drop-shadow(0 0.25rem 0.5rem rgb(0 0 0 / 0.28));
-  animation: call-reaction-float 2.4s ease-out forwards;
+  animation: call-expanded-reaction-float 2.4s ease-out forwards;
 }
 
-@keyframes call-reaction-float {
+@keyframes call-expanded-reaction-float {
   0% {
     opacity: 0;
     transform: translate3d(0, 0.75rem, 0) scale(0.82);

--- a/chat/src/components/calls/CallSplitContainer.vue
+++ b/chat/src/components/calls/CallSplitContainer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 import { useStore } from "@nanostores/vue";
 import {
   $callState,
@@ -33,8 +33,15 @@ import { normalizeMucCallRoomJid } from "@/lib/calls/muc-call-presence";
 import { useCallRoster } from "@/lib/calls/use-call-roster";
 import { openCallDock, setCallDockTab } from "@/lib/calls/call-dock-state";
 import { $callChatUnread } from "@/lib/calls/call-chat-unread";
+import {
+  $inCallReactions,
+  clearInCallReactions,
+  expireInCallReactions,
+  receiveInCallReaction,
+} from "@/lib/calls/in-call-reactions";
 import { barePeerJid } from "@/lib/xmpp/jid";
 import { expectedRemoteIdentitiesForCallState } from "@/lib/calls/call-tiles";
+import type { BrowserXmppClient } from "@/lib/xmpp/client";
 import CallTileGrid from "./CallTileGrid.vue";
 import CallStageHeader from "./CallStageHeader.vue";
 import CallControls from "./CallControls.vue";
@@ -61,6 +68,9 @@ const props = defineProps<{
   roomJid?: string;
   dmPeerJid?: string;
   dmPeerName?: string;
+  xmppClient?: BrowserXmppClient | null;
+  spaceId?: string | null;
+  channelId?: string | null;
 }>();
 
 const state = useStore($callState);
@@ -79,6 +89,8 @@ const { activeRoomJid, selfInCall } = useActiveMucCall();
 
 const settingsOpen = ref(false);
 const containerRef = ref<HTMLElement | null>(null);
+const reactions = useStore($inCallReactions);
+let reactionExpiryTimer: ReturnType<typeof setInterval> | null = null;
 
 const normalizedRoomJid = computed(() =>
   normalizeMucCallRoomJid(props.roomJid ?? ""),
@@ -198,10 +210,43 @@ const expectedRemoteIdentities = computed(() =>
 
 onMounted(() => {
   refreshScreenShareSupported();
+  reactionExpiryTimer = setInterval(() => expireInCallReactions(), 400);
+});
+
+onBeforeUnmount(() => {
+  if (reactionExpiryTimer) {
+    clearInterval(reactionExpiryTimer);
+    reactionExpiryTimer = null;
+  }
+  clearInCallReactions();
 });
 
 async function onHangup(): Promise<void> {
   await hangupActiveCall();
+}
+
+async function onSendInCallReaction(emoji: string): Promise<void> {
+  const active = state.value;
+  if (active.phase !== "active" || !props.xmppClient) return;
+  if (active.kind === "muc") {
+    if (!props.spaceId || !props.channelId) return;
+    await props.xmppClient.sendInCallReaction(props.spaceId, props.channelId, active.sid, emoji);
+  } else {
+    await props.xmppClient.sendDmInCallReaction(active.peer, active.sid, emoji);
+    receiveInCallReaction({
+      sid: active.sid,
+      emoji,
+      from: active.selfFullJid ?? "self",
+    });
+  }
+}
+
+function hashString(value: string): number {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) | 0;
+  }
+  return hash;
 }
 </script>
 
@@ -240,6 +285,16 @@ async function onHangup(): Promise<void> {
           :promoted-speaker-identity="promotedSpeakerIdentity"
           @open-participants="enterExpandedWithDock"
         />
+        <div class="call-split__reactions" aria-live="polite" aria-atomic="false">
+          <span
+            v-for="reaction in reactions"
+            :key="reaction.id"
+            class="call-split__reaction"
+            :style="{ '--reaction-x': `${Math.abs(hashString(reaction.id)) % 72}%` }"
+          >
+            {{ reaction.emoji }}
+          </span>
+        </div>
       </div>
       <footer class="call-split__footer">
         <CallControls
@@ -263,6 +318,7 @@ async function onHangup(): Promise<void> {
           @open-settings="settingsOpen = true"
           @set-view-mode="setCallViewMode"
           @toggle-self-view="toggleCallSelfViewHidden"
+          @send-reaction="onSendInCallReaction"
           @hangup="onHangup"
         />
       </footer>
@@ -305,11 +361,45 @@ async function onHangup(): Promise<void> {
 }
 
 .call-split__grid {
+  position: relative;
   flex: 1 1 0%;
   min-height: 0;
   display: flex;
   flex-direction: column;
   overflow: hidden;
+}
+
+.call-split__reactions {
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  overflow: hidden;
+}
+
+.call-split__reaction {
+  position: absolute;
+  left: calc(14% + var(--reaction-x, 0%));
+  bottom: 16%;
+  font-size: 2rem;
+  line-height: 1;
+  filter: drop-shadow(0 0.25rem 0.5rem rgb(0 0 0 / 0.28));
+  animation: call-reaction-float 2.4s ease-out forwards;
+}
+
+@keyframes call-reaction-float {
+  0% {
+    opacity: 0;
+    transform: translate3d(0, 0.75rem, 0) scale(0.82);
+  }
+  12% {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translate3d(0, -8rem, 0) scale(1.18);
+  }
 }
 
 .call-split__footer {

--- a/chat/src/components/calls/CallSplitContainer.vue
+++ b/chat/src/components/calls/CallSplitContainer.vue
@@ -35,8 +35,10 @@ import { openCallDock, setCallDockTab } from "@/lib/calls/call-dock-state";
 import { $callChatUnread } from "@/lib/calls/call-chat-unread";
 import {
   $inCallReactions,
+  activeInCallReactions,
   clearInCallReactions,
   expireInCallReactions,
+  hashInCallReactionId,
   receiveInCallReaction,
 } from "@/lib/calls/in-call-reactions";
 import { barePeerJid } from "@/lib/xmpp/jid";
@@ -91,6 +93,10 @@ const settingsOpen = ref(false);
 const containerRef = ref<HTMLElement | null>(null);
 const reactions = useStore($inCallReactions);
 let reactionExpiryTimer: ReturnType<typeof setInterval> | null = null;
+
+const activeCallReactions = computed(() => {
+  return activeInCallReactions(state.value, reactions.value);
+});
 
 const normalizedRoomJid = computed(() =>
   normalizeMucCallRoomJid(props.roomJid ?? ""),
@@ -241,13 +247,6 @@ async function onSendInCallReaction(emoji: string): Promise<void> {
   }
 }
 
-function hashString(value: string): number {
-  let hash = 0;
-  for (let index = 0; index < value.length; index += 1) {
-    hash = (hash * 31 + value.charCodeAt(index)) | 0;
-  }
-  return hash;
-}
 </script>
 
 <template>
@@ -287,10 +286,10 @@ function hashString(value: string): number {
         />
         <div class="call-split__reactions" aria-live="polite" aria-atomic="false">
           <span
-            v-for="reaction in reactions"
+            v-for="reaction in activeCallReactions"
             :key="reaction.id"
             class="call-split__reaction"
-            :style="{ '--reaction-x': `${Math.abs(hashString(reaction.id)) % 72}%` }"
+            :style="{ '--reaction-x': `${Math.abs(hashInCallReactionId(reaction.id)) % 72}%` }"
           >
             {{ reaction.emoji }}
           </span>
@@ -384,10 +383,10 @@ function hashString(value: string): number {
   font-size: 2rem;
   line-height: 1;
   filter: drop-shadow(0 0.25rem 0.5rem rgb(0 0 0 / 0.28));
-  animation: call-reaction-float 2.4s ease-out forwards;
+  animation: call-split-reaction-float 2.4s ease-out forwards;
 }
 
-@keyframes call-reaction-float {
+@keyframes call-split-reaction-float {
   0% {
     opacity: 0;
     transform: translate3d(0, 0.75rem, 0) scale(0.82);

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -1190,6 +1190,9 @@ function dayDividerLabel(createdAt: string): string {
       :room-jid="callRoomJid ?? undefined"
       :dm-peer-jid="dmPeer?.peerJid"
       :dm-peer-name="dmPeer?.peerUsername"
+      :xmpp-client="xmppClient"
+      :space-id="waddle?.id"
+      :channel-id="channel?.id"
     />
 
     <!-- Composer (social / top-pinned mode) -->
@@ -1606,6 +1609,9 @@ function dayDividerLabel(createdAt: string): string {
       :link-preview-lookup="linkPreviewLookup"
       :link-preview-scope="linkPreviewScope"
       :send-call-chat-message="sendCallChatMessage"
+      :xmpp-client="xmppClient"
+      :space-id="waddle?.id"
+      :channel-id="channel?.id"
       @send-call-chat="(...args) => emit('sendCallChat', ...args)"
     />
   </div>

--- a/chat/src/lib/calls/in-call-reactions.ts
+++ b/chat/src/lib/calls/in-call-reactions.ts
@@ -1,4 +1,5 @@
 import { atom } from "nanostores";
+import type { CallState } from "./types";
 
 const IN_CALL_REACTION_TTL_MS = 2_400;
 const MAX_IN_CALL_REACTIONS = 8;
@@ -49,6 +50,29 @@ export function reduceInCallReactions(
     case "clear":
       return [];
   }
+}
+
+export function isInCallReactionForActiveCall(
+  callState: CallState,
+  sid: string,
+): boolean {
+  return callState.phase === "active" && callState.sid === sid;
+}
+
+export function activeInCallReactions(
+  callState: CallState,
+  reactions: readonly InCallReactionAnimation[],
+): InCallReactionAnimation[] {
+  if (callState.phase !== "active") return [];
+  return reactions.filter((reaction) => reaction.sid === callState.sid);
+}
+
+export function hashInCallReactionId(value: string): number {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) | 0;
+  }
+  return hash;
 }
 
 export function receiveInCallReaction(input: {

--- a/chat/src/lib/calls/in-call-reactions.ts
+++ b/chat/src/lib/calls/in-call-reactions.ts
@@ -1,0 +1,83 @@
+import { atom } from "nanostores";
+
+const IN_CALL_REACTION_TTL_MS = 2_400;
+const MAX_IN_CALL_REACTIONS = 8;
+
+export type InCallReactionAnimation = {
+  id: string;
+  sid: string;
+  emoji: string;
+  from: string;
+  createdAt: number;
+  expiresAt: number;
+};
+
+export type InCallReactionAction =
+  | {
+      kind: "received";
+      sid: string;
+      emoji: string;
+      from: string;
+      now: number;
+    }
+  | { kind: "expire"; now: number }
+  | { kind: "clear" };
+
+export const $inCallReactions = atom<InCallReactionAnimation[]>([]);
+
+let sequence = 0;
+
+export function reduceInCallReactions(
+  current: readonly InCallReactionAnimation[],
+  action: InCallReactionAction,
+): InCallReactionAnimation[] {
+  switch (action.kind) {
+    case "received": {
+      const active = current.filter((reaction) => reaction.expiresAt > action.now);
+      const next: InCallReactionAnimation = {
+        id: `${action.sid}:${action.now}:${sequence++}`,
+        sid: action.sid,
+        emoji: action.emoji,
+        from: action.from,
+        createdAt: action.now,
+        expiresAt: action.now + IN_CALL_REACTION_TTL_MS,
+      };
+      return [...active, next].slice(-MAX_IN_CALL_REACTIONS);
+    }
+    case "expire":
+      return current.filter((reaction) => reaction.expiresAt > action.now);
+    case "clear":
+      return [];
+  }
+}
+
+export function receiveInCallReaction(input: {
+  sid: string;
+  emoji: string;
+  from: string;
+  now?: number;
+}): void {
+  const now = input.now ?? Date.now();
+  $inCallReactions.set(
+    reduceInCallReactions($inCallReactions.get(), {
+      kind: "received",
+      sid: input.sid,
+      emoji: input.emoji,
+      from: input.from,
+      now,
+    }),
+  );
+}
+
+export function expireInCallReactions(now = Date.now()): void {
+  $inCallReactions.set(
+    reduceInCallReactions($inCallReactions.get(), {
+      kind: "expire",
+      now,
+    }),
+  );
+}
+
+export function clearInCallReactions(): void {
+  $inCallReactions.set([]);
+}

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -28,7 +28,10 @@ import { useCallEngine } from "@/lib/calls/use-call-engine";
 import type { CallWireSender } from "@/lib/calls/outbound";
 import type { CallEvent, ExternalService } from "@/lib/calls/types";
 import { coerceExternalServices } from "@/lib/calls/ice-servers";
-import { receiveInCallReaction } from "@/lib/calls/in-call-reactions";
+import {
+  isInCallReactionForActiveCall,
+  receiveInCallReaction,
+} from "@/lib/calls/in-call-reactions";
 import { barePeerJid, fullJidIdentityKey, jidDomain, roomBareJidFor } from "./jid";
 import type {
   ChatStateEvent,
@@ -3594,10 +3597,11 @@ export class BrowserXmppClient {
       return;
     }
     if (message.displayed_marker_id) { if (message.is_muc) { const roomJid = barePeerJid(message.from ?? message.to ?? ""); const nick = (message.from ?? "").split("/")[1] ?? "unknown"; this.displayedHandler?.({ roomJid, nick, messageId: message.displayed_marker_id }); } else this.dmDisplayedHandler?.({ peerJid: barePeerJid(message.from ?? message.to ?? ""), messageId: message.displayed_marker_id }); return; }
-    if (message.in_call_sid && message.in_call_reaction_emoji) {
+    if (message.in_call?.kind === "reaction") {
+      if (!isInCallReactionForActiveCall($callState.get(), message.in_call.sid)) return;
       receiveInCallReaction({
-        sid: message.in_call_sid,
-        emoji: message.in_call_reaction_emoji,
+        sid: message.in_call.sid,
+        emoji: message.in_call.emoji,
         from: message.from ?? "",
       });
       return;

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -28,6 +28,7 @@ import { useCallEngine } from "@/lib/calls/use-call-engine";
 import type { CallWireSender } from "@/lib/calls/outbound";
 import type { CallEvent, ExternalService } from "@/lib/calls/types";
 import { coerceExternalServices } from "@/lib/calls/ice-servers";
+import { receiveInCallReaction } from "@/lib/calls/in-call-reactions";
 import { barePeerJid, fullJidIdentityKey, jidDomain, roomBareJidFor } from "./jid";
 import type {
   ChatStateEvent,
@@ -647,6 +648,7 @@ type XmppClientInstance = Partial<WasmClient> & CompatEmitter & {
   set_on_session_lifecycle?: (cb: (event: string) => void) => void;
   set_on_mds_displayed?: (cb: (entry: WasmMdsDisplayedEntry) => void) => void;
   set_on_pubsub_event?: (cb: (event: WasmPubsubEvent) => void) => void;
+  send_in_call_reaction?: (to: string, type: "chat" | "groupchat", sid: string, emoji: string) => Promise<void>;
   get_resume_state?: () => XmppResumeState | null;
   get_resume_state_handle?: () => XmppResumeStateHandle | undefined;
   publish_mds_displayed?: (chatId: string, stanzaId: string, stanzaIdBy: string) => Promise<void>;
@@ -1713,6 +1715,11 @@ export class BrowserXmppClient {
     throw new Error("XMPP session is not ready");
   }
 
+  private async compatSendInCallReaction(xmpp: XmppClientInstance, to: string, type: "chat" | "groupchat", sid: string, emoji: string) {
+    if (xmpp.send_in_call_reaction) return xmpp.send_in_call_reaction(to, type, sid, emoji);
+    throw new Error("XMPP session is not ready");
+  }
+
   private async compatSendRetraction(xmpp: XmppClientInstance, to: string, type: "chat" | "groupchat", id: string, thread?: { id: string; parent?: string }) {
     if (xmpp.send_retraction) return xmpp.send_retraction(to, type, id, thread?.id, thread?.parent);
     throw new Error("XMPP session is not ready");
@@ -1868,6 +1875,7 @@ export class BrowserXmppClient {
   async sendChatState(spaceId: string, channelId: string, state: ChatStateType, thread?: { id: string; parent?: string }) { const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId); await this.compatSendChatState(xmpp, roomJid, "groupchat", state, thread); }
   async sendDisplayed(spaceId: string, channelId: string, messageId: string, thread?: { id: string; parent?: string }) { const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId); await this.compatSendDisplayed(xmpp, roomJid, "groupchat", messageId, thread); }
   async sendReaction(spaceId: string, channelId: string, messageId: string, emojis: string[], thread?: { id: string; parent?: string }) { const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId); await this.compatSendReaction(xmpp, roomJid, "groupchat", messageId, emojis, thread); }
+  async sendInCallReaction(spaceId: string, channelId: string, sid: string, emoji: string) { const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId); await this.compatSendInCallReaction(xmpp, roomJid, "groupchat", sid, emoji); }
   /** #414: pin a message in the room. Server gates on Owner/Admin
    * affiliation; non-admins receive a `<forbidden/>` error which
    * surfaces as a rejected Promise. */
@@ -1957,6 +1965,7 @@ export class BrowserXmppClient {
     return await this.compatSendCorrection(xmpp, barePeerJid(peerJid), "chat", body, replacesId, opts);
   }
   async sendDmReaction(peerJid: string, messageId: string, emojis: string[], thread?: { id: string; parent?: string }): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await this.compatSendReaction(xmpp, barePeerJid(peerJid), "chat", messageId, emojis, thread); }
+  async sendDmInCallReaction(peerJid: string, sid: string, emoji: string): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await this.compatSendInCallReaction(xmpp, peerJid, "chat", sid, emoji); }
 
   /**
    * XEP-0490 §3 multi-device "read up to here" publish. `chatId` is
@@ -3585,6 +3594,14 @@ export class BrowserXmppClient {
       return;
     }
     if (message.displayed_marker_id) { if (message.is_muc) { const roomJid = barePeerJid(message.from ?? message.to ?? ""); const nick = (message.from ?? "").split("/")[1] ?? "unknown"; this.displayedHandler?.({ roomJid, nick, messageId: message.displayed_marker_id }); } else this.dmDisplayedHandler?.({ peerJid: barePeerJid(message.from ?? message.to ?? ""), messageId: message.displayed_marker_id }); return; }
+    if (message.in_call_sid && message.in_call_reaction_emoji) {
+      receiveInCallReaction({
+        sid: message.in_call_sid,
+        emoji: message.in_call_reaction_emoji,
+        from: message.from ?? "",
+      });
+      return;
+    }
     if (message.reaction_target_id) { if (message.is_muc) { const roomJid = barePeerJid(message.from ?? message.to ?? ""); const nick = (message.from ?? "").split("/")[1] ?? "unknown"; this.reactionHandler?.({ roomJid, nick, messageId: message.reaction_target_id, emojis: message.reaction_emojis }); } else { const fromBare = barePeerJid(message.from ?? ""); const toBare = barePeerJid(message.to ?? ""); const selfBare = barePeerJid(this.session.jid); const peerJid = fromBare === selfBare ? toBare : fromBare; const reactorJid = fromBare || selfBare; if (peerJid && reactorJid) this.dmReactionHandler?.({ peerJid, reactorJid, messageId: message.reaction_target_id, emojis: message.reaction_emojis }); } return; }
     if (message.pin_event) {
       const roomJid = message.is_muc

--- a/chat/src/lib/xmpp/wasm-types.ts
+++ b/chat/src/lib/xmpp/wasm-types.ts
@@ -136,8 +136,7 @@ export interface WasmMessage {
   displayed_marker_id?: string;
   reaction_target_id?: string;
   reaction_emojis: string[];
-  in_call_sid?: string;
-  in_call_reaction_emoji?: string;
+  in_call?: { kind: "reaction"; sid: string; emoji: string };
   is_muc: boolean;
   thread?: string;
   parent_thread_id?: string;

--- a/chat/src/lib/xmpp/wasm-types.ts
+++ b/chat/src/lib/xmpp/wasm-types.ts
@@ -136,6 +136,8 @@ export interface WasmMessage {
   displayed_marker_id?: string;
   reaction_target_id?: string;
   reaction_emojis: string[];
+  in_call_sid?: string;
+  in_call_reaction_emoji?: string;
   is_muc: boolean;
   thread?: string;
   parent_thread_id?: string;

--- a/chat/tests/in-call-reactions.test.ts
+++ b/chat/tests/in-call-reactions.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  activeInCallReactions,
+  hashInCallReactionId,
+  isInCallReactionForActiveCall,
   reduceInCallReactions,
   type InCallReactionAnimation,
 } from "../src/lib/calls/in-call-reactions";
+import type { CallState } from "../src/lib/calls/types";
 
 describe("in-call reaction reducer", () => {
   test("adds received reactions and expires them by timestamp", () => {
@@ -38,5 +42,50 @@ describe("in-call reaction reducer", () => {
       now: 3_499,
     });
     expect(expired.map((reaction) => reaction.emoji)).toEqual(["👍"]);
+  });
+
+  test("filters and accepts reactions only for the active call", () => {
+    const activeCall = {
+      phase: "active",
+      kind: "dm",
+      peer: "bob@example.com/laptop",
+      sid: "call-1",
+      media: { audio: true, video: false },
+      join: {
+        url: "wss://livekit.example.com",
+        token: "token",
+        room: "room",
+      },
+    } satisfies CallState;
+    const reactions: InCallReactionAnimation[] = [
+      {
+        id: "call-1:1000:0",
+        sid: "call-1",
+        emoji: "🔥",
+        from: "alice@example.com/phone",
+        createdAt: 1_000,
+        expiresAt: 3_400,
+      },
+      {
+        id: "call-2:1000:1",
+        sid: "call-2",
+        emoji: "👍",
+        from: "bob@example.com/laptop",
+        createdAt: 1_000,
+        expiresAt: 3_400,
+      },
+    ];
+
+    expect(isInCallReactionForActiveCall(activeCall, "call-1")).toBe(true);
+    expect(isInCallReactionForActiveCall(activeCall, "call-2")).toBe(false);
+    expect(activeInCallReactions(activeCall, reactions).map((reaction) => reaction.emoji)).toEqual([
+      "🔥",
+    ]);
+    expect(activeInCallReactions({ phase: "idle" }, reactions)).toEqual([]);
+  });
+
+  test("hashes reaction ids consistently", () => {
+    expect(hashInCallReactionId("call-1:1000:0")).toBe(hashInCallReactionId("call-1:1000:0"));
+    expect(hashInCallReactionId("call-1:1000:0")).not.toBe(hashInCallReactionId("call-2:1000:0"));
   });
 });

--- a/chat/tests/in-call-reactions.test.ts
+++ b/chat/tests/in-call-reactions.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  reduceInCallReactions,
+  type InCallReactionAnimation,
+} from "../src/lib/calls/in-call-reactions";
+
+describe("in-call reaction reducer", () => {
+  test("adds received reactions and expires them by timestamp", () => {
+    const first = reduceInCallReactions([], {
+      kind: "received",
+      sid: "call-1",
+      emoji: "🔥",
+      from: "alice@example.com/phone",
+      now: 1_000,
+    });
+
+    expect(first).toHaveLength(1);
+    expect(first[0]).toMatchObject({
+      sid: "call-1",
+      emoji: "🔥",
+      from: "alice@example.com/phone",
+      createdAt: 1_000,
+      expiresAt: 3_400,
+    } satisfies Partial<InCallReactionAnimation>);
+
+    const second = reduceInCallReactions(first, {
+      kind: "received",
+      sid: "call-1",
+      emoji: "👍",
+      from: "bob@example.com/laptop",
+      now: 1_100,
+    });
+    expect(second.map((reaction) => reaction.emoji)).toEqual(["🔥", "👍"]);
+
+    const expired = reduceInCallReactions(second, {
+      kind: "expire",
+      now: 3_499,
+    });
+    expect(expired.map((reaction) => reaction.emoji)).toEqual(["👍"]);
+  });
+});

--- a/server/crates/waddle-server/tests/xep_waddle_in_call_ws.rs
+++ b/server/crates/waddle-server/tests/xep_waddle_in_call_ws.rs
@@ -1,0 +1,151 @@
+//! Waddle in-call signaling integration tests over WebSocket.
+
+mod ws_common;
+
+use tokio::sync::Mutex;
+use ws_common::{TestServer, WsXmppClient};
+
+const DOMAIN: &str = "localhost";
+const ALICE: &str = "admin";
+const BOB: &str = "bob";
+const BOB_PASSWORD: &str = "bob-password";
+static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+async fn connect(
+    server: &TestServer,
+    username: &str,
+    password: &str,
+    resource_prefix: &str,
+) -> WsXmppClient {
+    let resource = format!("{resource_prefix}-{}", uuid::Uuid::new_v4());
+    WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, username, password, &resource)
+        .await
+        .expect("connect and auth")
+}
+
+async fn join_room(client: &mut WsXmppClient, room: &str, nick: &str) {
+    client
+        .send(&format!(
+            r#"<presence to="{room}/{nick}"><x xmlns="http://jabber.org/protocol/muc"/></presence>"#
+        ))
+        .await
+        .expect("send join");
+    client
+        .recv_until(|frame| frame.contains("<subject"))
+        .await
+        .expect("join responses");
+}
+
+#[tokio::test]
+async fn direct_in_call_reaction_routes_to_peer_full_jid_and_is_not_archived() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server = TestServer::start_with_extra_accounts(&[(BOB, BOB_PASSWORD)]);
+    let alice_password = server.fixed_account_password().to_string();
+    let mut alice = connect(&server, ALICE, &alice_password, "in-call-alice").await;
+    let mut bob = connect(&server, BOB, BOB_PASSWORD, "in-call-bob").await;
+    let bob_full = bob.full_jid.clone().expect("bob full jid");
+    let alice_bare = format!("{ALICE}@{DOMAIN}");
+    let bob_bare = format!("{BOB}@{DOMAIN}");
+
+    alice
+        .send(&format!(
+            r#"<message type="chat" to="{bob_full}" id="in-call-dm-1">
+                <in-call xmlns="urn:waddle:in-call:0" sid="dm-call-1">
+                    <reaction emoji="👍"/>
+                </in-call>
+                <no-store xmlns="urn:xmpp:hints"/>
+                <no-copy xmlns="urn:xmpp:hints"/>
+            </message>"#
+        ))
+        .await
+        .expect("send in-call reaction");
+
+    let delivered = bob
+        .recv_matching(|frame| frame.contains("urn:waddle:in-call:0") && frame.contains("👍"))
+        .await
+        .expect("bob receives in-call reaction");
+    assert!(delivered.contains("dm-call-1"));
+    assert!(delivered.contains("no-store"));
+    assert!(delivered.contains("no-copy"));
+
+    for (client, archive_jid, query_id) in [
+        (&mut alice, alice_bare.as_str(), "mam-in-call-alice"),
+        (&mut bob, bob_bare.as_str(), "mam-in-call-bob"),
+    ] {
+        client
+            .send(&format!(
+                r#"<iq type="set" id="{query_id}" to="{archive_jid}"><query xmlns="urn:xmpp:mam:2"/></iq>"#
+            ))
+            .await
+            .expect("send personal MAM query");
+        let frames = client
+            .recv_until(|frame| frame.contains(query_id) && frame.contains("<fin"))
+            .await
+            .expect("personal MAM frames");
+        assert!(
+            frames
+                .iter()
+                .all(|frame| !frame.contains("urn:waddle:in-call:0")),
+            "transient in-call reaction must not be archived: {frames:?}"
+        );
+    }
+
+    let _ = bob.close().await;
+    let _ = alice.close().await;
+}
+
+#[tokio::test]
+async fn muc_in_call_reaction_fans_out_to_room_and_is_not_archived() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server = TestServer::start_with_extra_accounts(&[(BOB, BOB_PASSWORD)]);
+    let alice_password = server.fixed_account_password().to_string();
+    let mut alice = connect(&server, ALICE, &alice_password, "in-call-muc-alice").await;
+    let mut bob = connect(&server, BOB, BOB_PASSWORD, "in-call-muc-bob").await;
+    let room = format!("in-call-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut alice, &room, ALICE).await;
+    join_room(&mut bob, &room, BOB).await;
+
+    alice
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="in-call-muc-1">
+                <in-call xmlns="urn:waddle:in-call:0" sid="muc-call-1">
+                    <reaction emoji="🔥"/>
+                </in-call>
+                <no-store xmlns="urn:xmpp:hints"/>
+                <no-copy xmlns="urn:xmpp:hints"/>
+            </message>"#
+        ))
+        .await
+        .expect("send room in-call reaction");
+
+    let delivered = bob
+        .recv_matching(|frame| frame.contains("urn:waddle:in-call:0") && frame.contains("🔥"))
+        .await
+        .expect("bob receives room in-call reaction");
+    assert!(delivered.contains("muc-call-1"));
+
+    alice
+        .recv_matching(|frame| frame.contains("urn:waddle:in-call:0") && frame.contains("🔥"))
+        .await
+        .expect("alice receives own room echo");
+
+    alice
+        .send(&format!(
+            r#"<iq type="set" id="mam-in-call-room" to="{room}"><query xmlns="urn:xmpp:mam:2"/></iq>"#
+        ))
+        .await
+        .expect("send room MAM query");
+    let frames = alice
+        .recv_until(|frame| frame.contains("mam-in-call-room") && frame.contains("<fin"))
+        .await
+        .expect("room MAM frames");
+    assert!(
+        frames
+            .iter()
+            .all(|frame| !frame.contains("urn:waddle:in-call:0")),
+        "transient room in-call reaction must not be archived: {frames:?}"
+    );
+
+    let _ = bob.close().await;
+    let _ = alice.close().await;
+}

--- a/server/crates/waddle-server/tests/xep_waddle_in_call_ws.rs
+++ b/server/crates/waddle-server/tests/xep_waddle_in_call_ws.rs
@@ -2,6 +2,7 @@
 
 mod ws_common;
 
+use minidom::Element;
 use tokio::sync::Mutex;
 use ws_common::{TestServer, WsXmppClient};
 
@@ -9,7 +10,70 @@ const DOMAIN: &str = "localhost";
 const ALICE: &str = "admin";
 const BOB: &str = "bob";
 const BOB_PASSWORD: &str = "bob-password";
+const NS_CLIENT: &str = "jabber:client";
+const NS_HINTS: &str = "urn:xmpp:hints";
+const NS_MAM: &str = "urn:xmpp:mam:2";
+const NS_MUC: &str = "http://jabber.org/protocol/muc";
+const NS_WADDLE_IN_CALL: &str = "urn:waddle:in-call:0";
 static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+fn attr(name: &'static str) -> minidom::rxml::NcName {
+    minidom::rxml::NcName::try_from(name).expect("valid XML attribute name")
+}
+
+fn serialize(element: Element) -> String {
+    let mut bytes = Vec::new();
+    element.write_to(&mut bytes).expect("serialize XML");
+    String::from_utf8(bytes).expect("XML is UTF-8")
+}
+
+fn muc_join_presence(room: &str, nick: &str) -> String {
+    serialize(
+        Element::builder("presence", NS_CLIENT)
+            .attr(attr("to"), format!("{room}/{nick}"))
+            .append(Element::builder("x", NS_MUC).build())
+            .build(),
+    )
+}
+
+fn in_call_reaction_message(
+    to: &str,
+    message_type: &str,
+    id: &str,
+    sid: &str,
+    emoji: &str,
+) -> String {
+    serialize(
+        Element::builder("message", NS_CLIENT)
+            .attr(attr("type"), message_type)
+            .attr(attr("to"), to)
+            .attr(attr("id"), id)
+            .append(
+                Element::builder("in-call", NS_WADDLE_IN_CALL)
+                    .attr(attr("sid"), sid)
+                    .append(
+                        Element::builder("reaction", NS_WADDLE_IN_CALL)
+                            .attr(attr("emoji"), emoji)
+                            .build(),
+                    )
+                    .build(),
+            )
+            .append(Element::builder("no-store", NS_HINTS).build())
+            .append(Element::builder("no-copy", NS_HINTS).build())
+            .build(),
+    )
+}
+
+fn mam_query(to: &str, id: &str) -> String {
+    serialize(
+        Element::builder("iq", NS_CLIENT)
+            .attr(attr("type"), "set")
+            .attr(attr("id"), id)
+            .attr(attr("to"), to)
+            .append(Element::builder("query", NS_MAM).build())
+            .build(),
+    )
+}
 
 async fn connect(
     server: &TestServer,
@@ -25,9 +89,7 @@ async fn connect(
 
 async fn join_room(client: &mut WsXmppClient, room: &str, nick: &str) {
     client
-        .send(&format!(
-            r#"<presence to="{room}/{nick}"><x xmlns="http://jabber.org/protocol/muc"/></presence>"#
-        ))
+        .send(&muc_join_presence(room, nick))
         .await
         .expect("send join");
     client
@@ -48,14 +110,12 @@ async fn direct_in_call_reaction_routes_to_peer_full_jid_and_is_not_archived() {
     let bob_bare = format!("{BOB}@{DOMAIN}");
 
     alice
-        .send(&format!(
-            r#"<message type="chat" to="{bob_full}" id="in-call-dm-1">
-                <in-call xmlns="urn:waddle:in-call:0" sid="dm-call-1">
-                    <reaction emoji="👍"/>
-                </in-call>
-                <no-store xmlns="urn:xmpp:hints"/>
-                <no-copy xmlns="urn:xmpp:hints"/>
-            </message>"#
+        .send(&in_call_reaction_message(
+            &bob_full,
+            "chat",
+            "in-call-dm-1",
+            "dm-call-1",
+            "👍",
         ))
         .await
         .expect("send in-call reaction");
@@ -73,9 +133,7 @@ async fn direct_in_call_reaction_routes_to_peer_full_jid_and_is_not_archived() {
         (&mut bob, bob_bare.as_str(), "mam-in-call-bob"),
     ] {
         client
-            .send(&format!(
-                r#"<iq type="set" id="{query_id}" to="{archive_jid}"><query xmlns="urn:xmpp:mam:2"/></iq>"#
-            ))
+            .send(&mam_query(archive_jid, query_id))
             .await
             .expect("send personal MAM query");
         let frames = client
@@ -106,14 +164,12 @@ async fn muc_in_call_reaction_fans_out_to_room_and_is_not_archived() {
     join_room(&mut bob, &room, BOB).await;
 
     alice
-        .send(&format!(
-            r#"<message type="groupchat" to="{room}" id="in-call-muc-1">
-                <in-call xmlns="urn:waddle:in-call:0" sid="muc-call-1">
-                    <reaction emoji="🔥"/>
-                </in-call>
-                <no-store xmlns="urn:xmpp:hints"/>
-                <no-copy xmlns="urn:xmpp:hints"/>
-            </message>"#
+        .send(&in_call_reaction_message(
+            &room,
+            "groupchat",
+            "in-call-muc-1",
+            "muc-call-1",
+            "🔥",
         ))
         .await
         .expect("send room in-call reaction");
@@ -130,9 +186,7 @@ async fn muc_in_call_reaction_fans_out_to_room_and_is_not_archived() {
         .expect("alice receives own room echo");
 
     alice
-        .send(&format!(
-            r#"<iq type="set" id="mam-in-call-room" to="{room}"><query xmlns="urn:xmpp:mam:2"/></iq>"#
-        ))
+        .send(&mam_query(&room, "mam-in-call-room"))
         .await
         .expect("send room MAM query");
     let frames = alice

--- a/server/crates/waddle-xmpp-client-wasm/src/client_messaging.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_messaging.rs
@@ -200,6 +200,38 @@ impl WaddleClient {
         })
     }
 
+    pub fn send_in_call_reaction(
+        &self,
+        to: String,
+        msg_type: String,
+        sid: String,
+        emoji: String,
+    ) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let recipient = match msg_type.as_str() {
+                "chat" => InCallReactionRecipient::Direct(
+                    to.parse::<FullJid>()
+                        .map_err(|_| js_error(format!("invalid in-call peer full JID: {to}")))?,
+                ),
+                "groupchat" => InCallReactionRecipient::Room(
+                    to.parse::<BareJid>()
+                        .map_err(|_| js_error(format!("invalid in-call room JID: {to}")))?,
+                ),
+                _ => {
+                    return Err(js_error(format!(
+                        "invalid in-call message type: {msg_type}"
+                    )))
+                }
+            };
+            let sid = InCallSessionId::new(sid).map_err(|err| js_error(err.to_string()))?;
+            let emoji = InCallReactionEmoji::new(emoji).map_err(|err| js_error(err.to_string()))?;
+            let stanza = build_in_call_reaction_message(&recipient, &sid, &emoji);
+            send_stanza_command(inner, stanza).await?;
+            Ok(JsValue::UNDEFINED)
+        })
+    }
+
     /// Publish a pin request (#414). `room_jid` is the bare MUC JID;
     /// `target_stanza_id` is the XEP-0359 `by=room` stanza-id of the
     /// message to pin. Server gates on Owner/Admin affiliation; a

--- a/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
@@ -50,6 +50,16 @@ pub(crate) fn references_to_js(references: Vec<messaging::ReferenceData>) -> Vec
         .collect()
 }
 
+fn in_call_signal_to_js(signal: Option<InCallSignal>) -> (Option<String>, Option<String>) {
+    match signal {
+        Some(InCallSignal::Reaction(payload)) => (
+            Some(payload.sid.as_str().to_string()),
+            Some(payload.emoji.as_str().to_string()),
+        ),
+        None => (None, None),
+    }
+}
+
 pub(crate) fn call_thread_to_js(
     anchor: waddle_xmpp_client::xep::call_thread::CallThreadAnchor,
 ) -> WaddleCallThreadAnchor {
@@ -189,6 +199,7 @@ pub(crate) fn inbound_to_js(message: InboundMessage) -> WaddleMessage {
     } else {
         None
     };
+    let (in_call_sid, in_call_reaction_emoji) = in_call_signal_to_js(message.in_call);
 
     WaddleMessage {
         id: message.id,
@@ -221,6 +232,8 @@ pub(crate) fn inbound_to_js(message: InboundMessage) -> WaddleMessage {
         displayed_marker_id: message.displayed_marker_id,
         reaction_target_id: message.reaction_target_id,
         reaction_emojis: message.reaction_emojis,
+        in_call_sid,
+        in_call_reaction_emoji,
         is_muc: message.message_type == "groupchat",
         thread: message.thread_id.or(message.thread),
         parent_thread_id: message.parent_thread_id,
@@ -347,6 +360,8 @@ pub(crate) fn inbox_push_to_js(
         displayed_marker_id: None,
         reaction_target_id: None,
         reaction_emojis: Vec::new(),
+        in_call_sid: None,
+        in_call_reaction_emoji: None,
         is_muc: false,
         thread: None,
         parent_thread_id: None,

--- a/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
@@ -50,13 +50,13 @@ pub(crate) fn references_to_js(references: Vec<messaging::ReferenceData>) -> Vec
         .collect()
 }
 
-fn in_call_signal_to_js(signal: Option<InCallSignal>) -> (Option<String>, Option<String>) {
+fn in_call_signal_to_js(signal: Option<InCallSignal>) -> Option<WaddleInCallSignal> {
     match signal {
-        Some(InCallSignal::Reaction(payload)) => (
-            Some(payload.sid.as_str().to_string()),
-            Some(payload.emoji.as_str().to_string()),
-        ),
-        None => (None, None),
+        Some(InCallSignal::Reaction(payload)) => Some(WaddleInCallSignal::Reaction {
+            sid: payload.sid.as_str().to_string(),
+            emoji: payload.emoji.as_str().to_string(),
+        }),
+        None => None,
     }
 }
 
@@ -199,7 +199,7 @@ pub(crate) fn inbound_to_js(message: InboundMessage) -> WaddleMessage {
     } else {
         None
     };
-    let (in_call_sid, in_call_reaction_emoji) = in_call_signal_to_js(message.in_call);
+    let in_call = in_call_signal_to_js(message.in_call);
 
     WaddleMessage {
         id: message.id,
@@ -232,8 +232,7 @@ pub(crate) fn inbound_to_js(message: InboundMessage) -> WaddleMessage {
         displayed_marker_id: message.displayed_marker_id,
         reaction_target_id: message.reaction_target_id,
         reaction_emojis: message.reaction_emojis,
-        in_call_sid,
-        in_call_reaction_emoji,
+        in_call,
         is_muc: message.message_type == "groupchat",
         thread: message.thread_id.or(message.thread),
         parent_thread_id: message.parent_thread_id,
@@ -360,8 +359,7 @@ pub(crate) fn inbox_push_to_js(
         displayed_marker_id: None,
         reaction_target_id: None,
         reaction_emojis: Vec::new(),
-        in_call_sid: None,
-        in_call_reaction_emoji: None,
+        in_call: None,
         is_muc: false,
         thread: None,
         parent_thread_id: None,

--- a/server/crates/waddle-xmpp-client-wasm/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/lib.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 
 use futures::channel::{mpsc, oneshot};
 use futures::{pin_mut, select, FutureExt, SinkExt, StreamExt};
-use jid::{BareJid, Jid};
+use jid::{BareJid, FullJid, Jid};
 use js_sys::{Function, Promise};
 use minidom::Element;
 use serde::{Deserialize, Serialize};
@@ -25,10 +25,11 @@ use waddle_xmpp_client::mds::{
 };
 use waddle_xmpp_client::messaging::{
     self, build_chat_state_message, build_correction_message, build_displayed_message,
-    build_moderation_message, build_outbound_message, build_pinned_message, build_reaction_message,
-    build_retraction_message, build_unpinned_message, InboundCallEvent, InboundMessage,
-    InboundPresence, LinkPreviewToken, MarkupSpanData, MarkupSpanType, MucAffiliation, MucRole,
-    ReferenceData, SendMessageOptions, SharedFileDisposition,
+    build_in_call_reaction_message, build_moderation_message, build_outbound_message,
+    build_pinned_message, build_reaction_message, build_retraction_message, build_unpinned_message,
+    InCallReactionEmoji, InCallReactionRecipient, InCallSessionId, InCallSignal, InboundCallEvent,
+    InboundMessage, InboundPresence, LinkPreviewToken, MarkupSpanData, MarkupSpanType,
+    MucAffiliation, MucRole, ReferenceData, SendMessageOptions, SharedFileDisposition,
 };
 use waddle_xmpp_client::pep::{
     build_pep_items_iq, build_publish_activity_iq, build_publish_mood_iq, build_publish_tune_iq,

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -55,6 +55,8 @@ pub struct WaddleMessage {
     pub displayed_marker_id: Option<String>,
     pub reaction_target_id: Option<String>,
     pub reaction_emojis: Vec<String>,
+    pub in_call_sid: Option<String>,
+    pub in_call_reaction_emoji: Option<String>,
     pub is_muc: bool,
     pub thread: Option<String>,
     pub parent_thread_id: Option<String>,

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -31,6 +31,12 @@ pub struct WaddleCallThreadEnded {
 }
 
 #[derive(Debug, Serialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum WaddleInCallSignal {
+    Reaction { sid: String, emoji: String },
+}
+
+#[derive(Debug, Serialize)]
 pub struct WaddleMessage {
     pub id: Option<String>,
     pub from: Option<String>,
@@ -55,8 +61,8 @@ pub struct WaddleMessage {
     pub displayed_marker_id: Option<String>,
     pub reaction_target_id: Option<String>,
     pub reaction_emojis: Vec<String>,
-    pub in_call_sid: Option<String>,
-    pub in_call_reaction_emoji: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub in_call: Option<WaddleInCallSignal>,
     pub is_muc: bool,
     pub thread: Option<String>,
     pub parent_thread_id: Option<String>,

--- a/server/crates/waddle-xmpp-client/src/messaging.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging.rs
@@ -17,9 +17,10 @@ mod types;
 
 pub use builders::{
     build_chat_state_message, build_correction_message, build_displayed_message,
-    build_file_sharing_element, build_moderation_message, build_outbound_message,
-    build_pinned_chat_message, build_pinned_message, build_reaction_message,
-    build_retraction_message, build_unpinned_chat_message, build_unpinned_message,
+    build_file_sharing_element, build_in_call_reaction_message, build_moderation_message,
+    build_outbound_message, build_pinned_chat_message, build_pinned_message,
+    build_reaction_message, build_retraction_message, build_unpinned_chat_message,
+    build_unpinned_message,
 };
 pub use call::{
     build_finish, build_finish_migrated, build_finish_with_options, build_finish_with_reason,
@@ -33,7 +34,7 @@ pub use call::{
 pub use namespaces::{
     build_muji_element, NS_CHAT_MARKERS, NS_CHAT_STATES, NS_CLIENT, NS_JINGLE_RTP,
     NS_MESSAGE_CORRECT, NS_MESSAGE_MODERATE, NS_MESSAGE_RETRACT, NS_MUJI, NS_REACTIONS,
-    NS_WADDLE_PIN_V0,
+    NS_WADDLE_IN_CALL, NS_WADDLE_PIN_V0,
 };
 #[cfg(all(feature = "native", not(target_arch = "wasm32")))]
 pub use native::MessagingExt;
@@ -48,10 +49,11 @@ pub use types::{
     ExtensionLaunchContextData, ExtensionLaunchData, ExtensionNamespace,
     ExtensionPayloadAttributeData, ExtensionPayloadElementData, ExtensionPluginId,
     ExtensionRoomJid, ExtensionSourceData, ExtensionTextId, ExtensionTimestamp, ExtensionXmlName,
-    InboundMessage, InboundPresence, InvalidLinkPreviewToken, LinkPreviewData, LinkPreviewPlayer,
-    LinkPreviewToken, MarkableMarkerPayload, MarkupSpan, MarkupSpanData, MarkupSpanType,
-    MdsDisplayedEntry, MessagingEvent, ModerationPayload, MucAffiliation, MucRole, MucStatus,
-    MujiPresence, PresenceHat, ReactionPayload, ReferenceData, RetractionPayload,
+    InCallReactionEmoji, InCallReactionPayload, InCallReactionRecipient, InCallSessionId,
+    InCallSignal, InboundMessage, InboundPresence, InvalidLinkPreviewToken, LinkPreviewData,
+    LinkPreviewPlayer, LinkPreviewToken, MarkableMarkerPayload, MarkupSpan, MarkupSpanData,
+    MarkupSpanType, MdsDisplayedEntry, MessagingEvent, ModerationPayload, MucAffiliation, MucRole,
+    MucStatus, MujiPresence, PresenceHat, ReactionPayload, ReferenceData, RetractionPayload,
     SendMessageOptions, SharedFile, SharedFileDisposition,
 };
 /// Re-export the xmpp-parsers Jingle types Waddle's call surface

--- a/server/crates/waddle-xmpp-client/src/messaging/builders.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/builders.rs
@@ -103,6 +103,40 @@ pub fn build_reaction_message(
         .build()
 }
 
+pub fn build_in_call_reaction_message(
+    recipient: &InCallReactionRecipient,
+    sid: &InCallSessionId,
+    emoji: &InCallReactionEmoji,
+) -> Element {
+    let to = recipient.to_jid_string();
+    Element::builder("message", NS_CLIENT)
+        .attr(minidom::rxml::xml_ncname!("to").to_owned(), to.as_str())
+        .attr(
+            minidom::rxml::xml_ncname!("type").to_owned(),
+            recipient.message_type(),
+        )
+        .attr(
+            minidom::rxml::xml_ncname!("id").to_owned(),
+            Uuid::new_v4().to_string(),
+        )
+        .append(
+            Element::builder("in-call", NS_WADDLE_IN_CALL)
+                .attr(minidom::rxml::xml_ncname!("sid").to_owned(), sid.as_str())
+                .append(
+                    Element::builder("reaction", NS_WADDLE_IN_CALL)
+                        .attr(
+                            minidom::rxml::xml_ncname!("emoji").to_owned(),
+                            emoji.as_str(),
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .append(Element::builder("no-store", NS_HINTS).build())
+        .append(Element::builder("no-copy", NS_HINTS).build())
+        .build()
+}
+
 /// Build a `<message><pinned target='…'/></message>` request for #414.
 /// `to` is the room bare JID; `target_stanza_id` is the XEP-0359
 /// stanza-id (`by=room`) of the message being pinned.

--- a/server/crates/waddle-xmpp-client/src/messaging/namespaces.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/namespaces.rs
@@ -11,6 +11,7 @@ pub const NS_MESSAGE_RETRACT: &str = "urn:xmpp:message-retract:1";
 pub const NS_MESSAGE_MODERATE: &str = "urn:xmpp:message-moderate:1";
 pub const NS_MESSAGE_CORRECT: &str = "urn:xmpp:message-correct:0";
 pub(crate) const NS_HINTS: &str = "urn:xmpp:hints";
+pub const NS_WADDLE_IN_CALL: &str = "urn:waddle:in-call:0";
 pub(crate) const NS_HATS: &str = "urn:xmpp:hats:0";
 pub(crate) const NS_SIMS: &str = "urn:xmpp:sims:1";
 pub(crate) const NS_SFS: &str = "urn:xmpp:sfs:0";

--- a/server/crates/waddle-xmpp-client/src/messaging/parsing/mod.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/parsing/mod.rs
@@ -18,8 +18,9 @@ use self::files::{parse_file_sharing_element, parse_shared_file};
 use self::markup::parse_markup_spans;
 pub use self::payloads::{
     parse_chat_state_payload, parse_correction_payload, parse_displayed_marker_payload,
-    parse_extension_envelope, parse_markable_marker_payload, parse_moderation_payload,
-    parse_reaction_payload, parse_retraction_payload, parse_retraction_tombstone_payload,
+    parse_extension_envelope, parse_in_call_reaction_payload, parse_markable_marker_payload,
+    parse_moderation_payload, parse_reaction_payload, parse_retraction_payload,
+    parse_retraction_tombstone_payload,
 };
 use super::namespaces::*;
 use super::presence::parse_presence;
@@ -112,6 +113,7 @@ fn parse_message(el: &Element) -> Option<InboundMessage> {
     let reaction = parse_reaction_payload(el);
     let reaction_target_id = reaction.as_ref().map(|payload| payload.target_id.clone());
     let reaction_emojis = reaction.map(|payload| payload.emojis).unwrap_or_default();
+    let in_call = parse_in_call_reaction_payload(el).map(InCallSignal::Reaction);
 
     let pin_event = crate::pin::extract_pin_event_from_message(el);
     let extension_envelope = parse_extension_envelope(el);
@@ -338,6 +340,7 @@ fn parse_message(el: &Element) -> Option<InboundMessage> {
         moderation_reason,
         reaction_target_id,
         reaction_emojis,
+        in_call,
         reply_to_id,
         reply_to_sender,
         reply_fallback,

--- a/server/crates/waddle-xmpp-client/src/messaging/parsing/payloads.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/parsing/payloads.rs
@@ -218,6 +218,25 @@ pub fn parse_reaction_payload(element: &Element) -> Option<ReactionPayload> {
     })
 }
 
+pub fn parse_in_call_reaction_payload(element: &Element) -> Option<InCallReactionPayload> {
+    let carrier = element.get_child("in-call", NS_WADDLE_IN_CALL)?;
+    let sid = carrier.attr("sid")?.trim();
+    if sid.is_empty() {
+        return None;
+    }
+    let emoji = carrier
+        .get_child("reaction", NS_WADDLE_IN_CALL)?
+        .attr("emoji")?
+        .trim();
+    if emoji.is_empty() {
+        return None;
+    }
+    Some(InCallReactionPayload {
+        sid: InCallSessionId::new(sid).ok()?,
+        emoji: InCallReactionEmoji::new(emoji).ok()?,
+    })
+}
+
 pub fn parse_retraction_payload(element: &Element) -> Option<RetractionPayload> {
     let retract = element.get_child("retract", NS_MESSAGE_RETRACT)?;
     if retract

--- a/server/crates/waddle-xmpp-client/src/messaging/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/tests.rs
@@ -2148,6 +2148,14 @@ fn in_call_reaction_values_reject_empty_wire_fields() {
 }
 
 #[test]
+fn in_call_reaction_values_trim_before_serialization() {
+    let sid = InCallSessionId::new(" call-1 ").expect("valid sid");
+    let emoji = InCallReactionEmoji::new(" 👍 ").expect("valid emoji");
+    assert_eq!(sid.as_str(), "call-1");
+    assert_eq!(emoji.as_str(), "👍");
+}
+
+#[test]
 fn build_retraction_message_has_expected_shape() {
     let stanza = build_retraction_message("room@muc.example", "groupchat", "msg-1", None);
     assert_origin_id_matches_message_id(&stanza);

--- a/server/crates/waddle-xmpp-client/src/messaging/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/tests.rs
@@ -35,6 +35,29 @@ fn parse_message_with_body() {
 }
 
 #[test]
+fn parse_message_with_in_call_reaction_payload() {
+    let e = el("<message xmlns='jabber:client' \
+         from='room@conf.example/alice' \
+         to='bob@example.com' \
+         type='groupchat' \
+         id='in-call-1'>\
+         <in-call xmlns='urn:waddle:in-call:0' sid='call-1'>\
+           <reaction emoji='🔥'/>\
+         </in-call>\
+         <no-store xmlns='urn:xmpp:hints'/>\
+         <no-copy xmlns='urn:xmpp:hints'/>\
+         </message>");
+    let MessagingEvent::Message(msg) = parse(&e).unwrap() else {
+        panic!("expected Message");
+    };
+    let Some(InCallSignal::Reaction(payload)) = msg.in_call else {
+        panic!("expected in-call reaction signal");
+    };
+    assert_eq!(payload.sid.as_str(), "call-1");
+    assert_eq!(payload.emoji.as_str(), "🔥");
+}
+
+#[test]
 fn parse_message_with_waddle_extension_envelope() {
     let e = el("<message xmlns='jabber:client' \
          from='room@conf.example/github' \
@@ -2088,6 +2111,40 @@ fn build_reaction_message_includes_thread_when_present() {
         .get_child("thread", "jabber:client")
         .expect("thread child present");
     assert_eq!(thread_el.text(), "thread-react");
+}
+
+#[test]
+fn build_in_call_reaction_message_has_transient_carrier_shape() {
+    let recipient =
+        InCallReactionRecipient::Direct("bob@example.com/phone".parse().expect("full jid"));
+    let sid = InCallSessionId::new("call-1").expect("valid sid");
+    let emoji = InCallReactionEmoji::new("👍").expect("valid emoji");
+    let stanza = build_in_call_reaction_message(&recipient, &sid, &emoji);
+    assert_eq!(stanza.attr("to"), Some("bob@example.com/phone"));
+    assert_eq!(stanza.attr("type"), Some("chat"));
+    assert!(stanza.get_child("body", NS_CLIENT).is_none());
+    assert!(stanza.get_child("origin-id", NS_ORIGIN_ID).is_none());
+
+    let carrier = stanza
+        .get_child("in-call", NS_WADDLE_IN_CALL)
+        .expect("in-call child");
+    assert_eq!(carrier.attr("sid"), Some("call-1"));
+    let reaction = carrier
+        .get_child("reaction", NS_WADDLE_IN_CALL)
+        .expect("reaction child");
+    assert_eq!(reaction.attr("emoji"), Some("👍"));
+
+    assert!(stanza.get_child("no-store", NS_HINTS).is_some());
+    assert!(stanza.get_child("no-copy", NS_HINTS).is_some());
+    assert!(stanza.get_child("store", NS_HINTS).is_none());
+}
+
+#[test]
+fn in_call_reaction_values_reject_empty_wire_fields() {
+    assert!(InCallSessionId::new("").is_err());
+    assert!(InCallSessionId::new("   ").is_err());
+    assert!(InCallReactionEmoji::new("").is_err());
+    assert!(InCallReactionEmoji::new("   ").is_err());
 }
 
 #[test]

--- a/server/crates/waddle-xmpp-client/src/messaging/types.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/types.rs
@@ -106,13 +106,14 @@ pub struct InCallSessionId(String);
 impl InCallSessionId {
     pub fn new(value: impl Into<String>) -> ClientResult<Self> {
         let value = value.into();
-        if value.trim().is_empty() {
+        let value = value.trim();
+        if value.is_empty() {
             return Err(CoreError::bad_request(Some(
                 "in-call session id must not be empty".to_string(),
             ))
             .into());
         }
-        Ok(Self(value))
+        Ok(Self(value.to_owned()))
     }
 
     pub fn as_str(&self) -> &str {
@@ -126,13 +127,14 @@ pub struct InCallReactionEmoji(String);
 impl InCallReactionEmoji {
     pub fn new(value: impl Into<String>) -> ClientResult<Self> {
         let value = value.into();
-        if value.trim().is_empty() {
+        let value = value.trim();
+        if value.is_empty() {
             return Err(CoreError::bad_request(Some(
                 "in-call reaction emoji must not be empty".to_string(),
             ))
             .into());
         }
-        Ok(Self(value))
+        Ok(Self(value.to_owned()))
     }
 
     pub fn as_str(&self) -> &str {

--- a/server/crates/waddle-xmpp-client/src/messaging/types.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/types.rs
@@ -1,10 +1,11 @@
 use chrono::{DateTime, Utc};
-use jid::BareJid;
+use jid::{BareJid, FullJid};
 use std::fmt;
 use url::Url;
 use waddle_xmpp_core::xep0359::StanzaId as StableStanzaId;
-use waddle_xmpp_core::{DirectVideoMediaType, PreviewImageMediaType};
+use waddle_xmpp_core::{CoreError, DirectVideoMediaType, PreviewImageMediaType};
 
+use crate::error::ClientResult;
 use crate::request::StanzaId;
 use crate::xep::encrypted_file::EncryptedFile;
 use crate::xep::{reply as xep_reply, thread as xep_thread};
@@ -100,6 +101,79 @@ pub struct ReactionPayload {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InCallSessionId(String);
+
+impl InCallSessionId {
+    pub fn new(value: impl Into<String>) -> ClientResult<Self> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            return Err(CoreError::bad_request(Some(
+                "in-call session id must not be empty".to_string(),
+            ))
+            .into());
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InCallReactionEmoji(String);
+
+impl InCallReactionEmoji {
+    pub fn new(value: impl Into<String>) -> ClientResult<Self> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            return Err(CoreError::bad_request(Some(
+                "in-call reaction emoji must not be empty".to_string(),
+            ))
+            .into());
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InCallReactionPayload {
+    pub sid: InCallSessionId,
+    pub emoji: InCallReactionEmoji,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InCallSignal {
+    Reaction(InCallReactionPayload),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InCallReactionRecipient {
+    Direct(FullJid),
+    Room(BareJid),
+}
+
+impl InCallReactionRecipient {
+    pub fn to_jid_string(&self) -> String {
+        match self {
+            Self::Direct(jid) => jid.to_string(),
+            Self::Room(jid) => jid.to_string(),
+        }
+    }
+
+    pub fn message_type(&self) -> &'static str {
+        match self {
+            Self::Direct(_) => "chat",
+            Self::Room(_) => "groupchat",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RetractionPayload {
     pub target_id: String,
 }
@@ -145,6 +219,7 @@ pub struct InboundMessage {
     pub moderation_reason: Option<String>,
     pub reaction_target_id: Option<String>,
     pub reaction_emojis: Vec<String>,
+    pub in_call: Option<InCallSignal>,
     pub reply_to_id: Option<String>,
     pub reply_to_sender: Option<String>,
     /// XEP-0428 fallback range, in Unicode scalar offsets, end exclusive.

--- a/server/crates/waddle-xmpp/src/xep/exports.rs
+++ b/server/crates/waddle-xmpp/src/xep/exports.rs
@@ -447,6 +447,12 @@ pub use super::xep_waddle_link_preview::{
     NS_WADDLE_LINK_PREVIEW,
 };
 
+pub use super::xep_waddle_in_call::{
+    build_in_call_reaction_element, build_in_call_reaction_message, parse_in_call_signal,
+    parse_in_call_signal_child, InCallParseError, InCallReactionEmoji, InCallReactionSignal,
+    InCallSessionId, InCallSignal, NS_WADDLE_IN_CALL,
+};
+
 pub use super::xep0503::{
     build_channel_item, build_muc_roominfo_form, build_muc_roominfo_pubsub_form,
     build_room_metadata_form, build_room_space_metadata_forms,

--- a/server/crates/waddle-xmpp/src/xep/mod.rs
+++ b/server/crates/waddle-xmpp/src/xep/mod.rs
@@ -207,6 +207,7 @@ pub mod xep_waddle_dm_bookmarks;
 pub mod xep_waddle_dnd;
 pub mod xep_waddle_forums;
 pub mod xep_waddle_group_dm;
+pub mod xep_waddle_in_call;
 pub mod xep_waddle_link_preview;
 pub mod xep_waddle_livekit_transport;
 pub mod xep_waddle_pin;

--- a/server/crates/waddle-xmpp/src/xep/xep_waddle_in_call.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep_waddle_in_call.rs
@@ -14,10 +14,11 @@ pub struct InCallSessionId(SessionId);
 impl InCallSessionId {
     pub fn new(value: impl Into<String>) -> Result<Self, InCallParseError> {
         let value = value.into();
-        if value.trim().is_empty() {
+        let value = value.trim();
+        if value.is_empty() {
             return Err(InCallParseError::EmptySessionId);
         }
-        Ok(Self(SessionId(value)))
+        Ok(Self(SessionId(value.to_owned())))
     }
 
     pub fn as_str(&self) -> &str {
@@ -31,10 +32,11 @@ pub struct InCallReactionEmoji(String);
 impl InCallReactionEmoji {
     pub fn new(value: impl Into<String>) -> Result<Self, InCallParseError> {
         let value = value.into();
-        if value.trim().is_empty() {
+        let value = value.trim();
+        if value.is_empty() {
             return Err(InCallParseError::EmptyReaction);
         }
-        Ok(Self(value))
+        Ok(Self(value.to_owned()))
     }
 
     pub fn as_str(&self) -> &str {
@@ -57,6 +59,7 @@ pub enum InCallSignal {
 pub enum InCallParseError {
     NotInCall,
     MissingAttribute(&'static str),
+    MissingChild(&'static str),
     EmptySessionId,
     EmptyReaction,
 }
@@ -106,8 +109,8 @@ pub fn parse_in_call_signal(element: &Element) -> Result<InCallSignal, InCallPar
     let reaction = element
         .children()
         .find(|child| child.name() == "reaction" && child.ns() == NS_WADDLE_IN_CALL)
-        .ok_or(InCallParseError::MissingAttribute("reaction"))?;
-    let emoji = InCallReactionEmoji::new(required_attr(reaction, "emoji")?.trim())?;
+        .ok_or(InCallParseError::MissingChild("reaction"))?;
+    let emoji = InCallReactionEmoji::new(required_attr(reaction, "emoji")?)?;
 
     Ok(InCallSignal::Reaction(InCallReactionSignal { sid, emoji }))
 }

--- a/server/crates/waddle-xmpp/src/xep/xep_waddle_in_call.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep_waddle_in_call.rs
@@ -1,0 +1,130 @@
+//! Waddle transient in-call signaling carrier (`urn:waddle:in-call:0`).
+
+use minidom::Element;
+use xmpp_parsers::jingle::SessionId;
+use xmpp_parsers::message::{Id, Message, MessageType};
+
+use super::xep0334::{add_hint, Hint};
+
+pub const NS_WADDLE_IN_CALL: &str = "urn:waddle:in-call:0";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InCallSessionId(SessionId);
+
+impl InCallSessionId {
+    pub fn new(value: impl Into<String>) -> Result<Self, InCallParseError> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            return Err(InCallParseError::EmptySessionId);
+        }
+        Ok(Self(SessionId(value)))
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0 .0.as_str()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InCallReactionEmoji(String);
+
+impl InCallReactionEmoji {
+    pub fn new(value: impl Into<String>) -> Result<Self, InCallParseError> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            return Err(InCallParseError::EmptyReaction);
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InCallReactionSignal {
+    pub sid: InCallSessionId,
+    pub emoji: InCallReactionEmoji,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InCallSignal {
+    Reaction(InCallReactionSignal),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InCallParseError {
+    NotInCall,
+    MissingAttribute(&'static str),
+    EmptySessionId,
+    EmptyReaction,
+}
+
+pub fn build_in_call_reaction_element(
+    sid: &InCallSessionId,
+    emoji: &InCallReactionEmoji,
+) -> Element {
+    Element::builder("in-call", NS_WADDLE_IN_CALL)
+        .attr(minidom::rxml::xml_ncname!("sid").to_owned(), sid.as_str())
+        .append(
+            Element::builder("reaction", NS_WADDLE_IN_CALL)
+                .attr(
+                    minidom::rxml::xml_ncname!("emoji").to_owned(),
+                    emoji.as_str(),
+                )
+                .build(),
+        )
+        .build()
+}
+
+pub fn build_in_call_reaction_message(
+    to: jid::Jid,
+    from: jid::Jid,
+    sid: &InCallSessionId,
+    emoji: &InCallReactionEmoji,
+    message_type: MessageType,
+) -> Message {
+    let mut message = Message::new(Some(to));
+    message.from = Some(from);
+    message.type_ = message_type;
+    message.id = Some(Id(uuid::Uuid::new_v4().to_string()));
+    message
+        .payloads
+        .push(build_in_call_reaction_element(sid, emoji));
+    add_hint(&mut message, Hint::NoStore);
+    add_hint(&mut message, Hint::NoCopy);
+    message
+}
+
+pub fn parse_in_call_signal(element: &Element) -> Result<InCallSignal, InCallParseError> {
+    if element.name() != "in-call" || element.ns() != NS_WADDLE_IN_CALL {
+        return Err(InCallParseError::NotInCall);
+    }
+
+    let sid = InCallSessionId::new(required_attr(element, "sid")?)?;
+    let reaction = element
+        .children()
+        .find(|child| child.name() == "reaction" && child.ns() == NS_WADDLE_IN_CALL)
+        .ok_or(InCallParseError::MissingAttribute("reaction"))?;
+    let emoji = InCallReactionEmoji::new(required_attr(reaction, "emoji")?.trim())?;
+
+    Ok(InCallSignal::Reaction(InCallReactionSignal { sid, emoji }))
+}
+
+pub fn parse_in_call_signal_child(message: &Message) -> Option<InCallSignal> {
+    message
+        .payloads
+        .iter()
+        .find(|payload| payload.name() == "in-call" && payload.ns() == NS_WADDLE_IN_CALL)
+        .and_then(|payload| parse_in_call_signal(payload).ok())
+}
+
+fn required_attr<'a>(
+    element: &'a Element,
+    name: &'static str,
+) -> Result<&'a str, InCallParseError> {
+    element
+        .attr(name)
+        .ok_or(InCallParseError::MissingAttribute(name))
+}

--- a/server/crates/waddle-xmpp/tests/xep_waddle_in_call.rs
+++ b/server/crates/waddle-xmpp/tests/xep_waddle_in_call.rs
@@ -55,3 +55,23 @@ fn in_call_reaction_rejects_empty_sid() {
         Err(InCallParseError::EmptySessionId)
     );
 }
+
+#[test]
+fn in_call_reaction_values_are_trimmed_before_serialization() {
+    let sid = InCallSessionId::new(" call-123 ").expect("valid sid");
+    let emoji = InCallReactionEmoji::new(" 👍 ").expect("valid emoji");
+    assert_eq!(sid.as_str(), "call-123");
+    assert_eq!(emoji.as_str(), "👍");
+}
+
+#[test]
+fn in_call_reaction_reports_missing_reaction_child() {
+    let carrier: minidom::Element = "<in-call xmlns='urn:waddle:in-call:0' sid='call-123'/>"
+        .parse()
+        .expect("carrier xml");
+
+    assert_eq!(
+        parse_in_call_signal(&carrier),
+        Err(InCallParseError::MissingChild("reaction"))
+    );
+}

--- a/server/crates/waddle-xmpp/tests/xep_waddle_in_call.rs
+++ b/server/crates/waddle-xmpp/tests/xep_waddle_in_call.rs
@@ -1,0 +1,57 @@
+//! `urn:waddle:in-call:0` — transient in-call signaling carrier.
+
+use waddle_xmpp::xep::{
+    build_in_call_reaction_message, parse_in_call_signal, parse_in_call_signal_child, Hint,
+    InCallParseError, InCallReactionEmoji, InCallReactionSignal, InCallSessionId, InCallSignal,
+    NS_WADDLE_IN_CALL,
+};
+use xmpp_parsers::message::MessageType;
+
+#[test]
+fn in_call_reaction_message_round_trips_with_transient_hints() {
+    let to = "bob@example.test/phone".parse().expect("peer full jid");
+    let from = "alice@example.test/laptop"
+        .parse()
+        .expect("sender full jid");
+    let sid = InCallSessionId::new("call-123").expect("valid sid");
+    let emoji = InCallReactionEmoji::new("👍").expect("valid emoji");
+    let message = build_in_call_reaction_message(to, from, &sid, &emoji, MessageType::Chat);
+
+    assert_eq!(message.type_, MessageType::Chat);
+    assert!(message.bodies.is_empty());
+
+    let carrier = message
+        .payloads
+        .iter()
+        .find(|payload| payload.name() == "in-call" && payload.ns() == NS_WADDLE_IN_CALL)
+        .expect("in-call payload");
+    assert_eq!(carrier.attr("sid"), Some("call-123"));
+
+    let reaction = carrier
+        .children()
+        .find(|child| child.name() == "reaction" && child.ns() == NS_WADDLE_IN_CALL)
+        .expect("reaction child");
+    assert_eq!(reaction.attr("emoji"), Some("👍"));
+
+    assert!(waddle_xmpp::xep::has_hint(&message, Hint::NoStore));
+    assert!(waddle_xmpp::xep::has_hint(&message, Hint::NoCopy));
+
+    assert_eq!(
+        parse_in_call_signal_child(&message),
+        Some(InCallSignal::Reaction(InCallReactionSignal { sid, emoji }))
+    );
+}
+
+#[test]
+fn in_call_reaction_rejects_empty_sid() {
+    let carrier: minidom::Element = "<in-call xmlns='urn:waddle:in-call:0' sid=''>\
+       <reaction emoji='👍'/>\
+       </in-call>"
+        .parse()
+        .expect("carrier xml");
+
+    assert_eq!(
+        parse_in_call_signal(&carrier),
+        Err(InCallParseError::EmptySessionId)
+    );
+}

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -317,6 +317,7 @@ export class WaddleClient {
     send_correction(to: string, msg_type: string, body: string, replaces_id: string, options: any): Promise<any>;
     send_displayed(to: string, msg_type: string, message_id: string, thread_id?: string | null, thread_parent?: string | null): Promise<any>;
     send_groupchat_message(room_jid: string, body: string, options: any): Promise<any>;
+    send_in_call_reaction(to: string, msg_type: string, sid: string, emoji: string): Promise<any>;
     send_moderation(to: string, msg_type: string, target_id: string, reason?: string | null): Promise<any>;
     /**
      * Send a Jingle `session-terminate` IQ to hang up. `reason` is

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=19dc297fce33";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=19dc297fce33";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=19dc297fce33";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=23c1c82b4751";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=23c1c82b4751";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=23c1c82b4751";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=19dc297fce33";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=23c1c82b4751";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=23c1c82b4751";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=23c1c82b4751";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=23c1c82b4751";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=5bc181ad40ed";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=5bc181ad40ed";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=5bc181ad40ed";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=23c1c82b4751";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=5bc181ad40ed";


### PR DESCRIPTION
## Summary

Implements #1022.

- Adds a typed `urn:waddle:in-call:0` XEP carrier for transient in-call reaction signals, with canonical trimmed session ids/reaction values and XEP-0334 `<no-store/>` + `<no-copy/>` hints.
- Adds Rust client parsing/building plus WASM `send_in_call_reaction`; `chat` requires a peer full JID and `groupchat` requires a room bare JID before stanza construction.
- Exposes inbound in-call signals to JS as one structured `in_call` object instead of independent optional fields.
- Adds websocket coverage for direct full-JID delivery and MUC room fan-out, verifying reactions are not returned by MAM.
- Adds chat-side send/receive wiring, active-call guarded reducer state, split + expanded stage overlays, and an accessible reactions menu in call controls.

## XEP review

- Reviewed `./xeps` for XEP-0334 message processing hints and used `no-store` / `no-copy` for transient reaction carriers.
- Reviewed XEP-0444 and XEP-0353 context; no official XEP-defined in-call reaction carrier exists, so this uses the project namespace `urn:waddle:in-call:0`.
- Websocket regression stanzas are built with `minidom::Element` builders rather than raw XML string construction.

## Validation

- `cargo test -p waddle-xmpp --test xep_waddle_in_call`
- `cargo test -p waddle-xmpp-client in_call_reaction`
- `cargo test -p waddle-server --test xep_waddle_in_call_ws`
- `cargo check -p waddle-xmpp-client-wasm`
- `cargo clippy -p waddle-xmpp -p waddle-xmpp-client -p waddle-xmpp-client-wasm -p waddle-server --tests -- -D warnings`
- `bun test tests/in-call-reactions.test.ts`
- `bun run lint`
- `git diff --check`

## Review notes

- Addressed Copilot review feedback: trim values before storing, distinguish missing child parse errors, use a structured JS in-call payload, build test stanzas with XML builders, and scope reaction intake/rendering to the active call SID.
- Extracted shared reaction filtering/hash helpers and gave split/expanded overlays distinct animation keyframe names.
- Ran adversarial protocol, test, and UI review passes until no actionable blockers remained.
- `bunx vue-tsc --noEmit` still fails on the existing broad Vue type-check baseline; the failures are not from the changed in-call reaction files.

## Residual risks

- Switching between split and expanded call layouts clears any in-flight reaction animation.

Closes #1022.
