### PR TITLE
feat(chat): add broad call Picture-in-Picture support

### DIFF
--- a/chat/src/components/calls/CallControls.vue
+++ b/chat/src/components/calls/CallControls.vue
@@ -11,6 +11,7 @@ import {
   MonitorUp,
   MoreHorizontal,
   PhoneOff,
+  PictureInPicture2,
   ScanFace,
   SmilePlus,
   Settings,
@@ -58,6 +59,10 @@ const props = defineProps<{
   viewMode: CallViewMode;
   /** True while the local self-view tile is hidden from this client's stage. */
   selfViewHidden: boolean;
+  /** True when this browser can enter either Document PiP or video PiP. */
+  pictureInPictureSupported?: boolean;
+  /** True while the call is detached into Picture-in-Picture. */
+  pictureInPictureActive?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -73,6 +78,7 @@ const emit = defineEmits<{
   openSettings: [];
   setViewMode: [mode: CallViewMode];
   toggleSelfView: [];
+  togglePictureInPicture: [];
   hangup: [];
 }>();
 
@@ -468,6 +474,18 @@ onBeforeUnmount(() => {
         class="call-controls__unread"
         aria-hidden="true"
       >{{ chatUnread }}</span>
+    </button>
+    <button
+      v-if="pictureInPictureSupported"
+      type="button"
+      class="chat-icon-button chat-icon-button--md hover:bg-muted"
+      :class="{ 'bg-muted text-foreground': pictureInPictureActive }"
+      :title="pictureInPictureActive ? 'Return to call' : 'Picture-in-Picture'"
+      :aria-label="pictureInPictureActive ? 'Return to call' : 'Open Picture-in-Picture'"
+      :aria-pressed="pictureInPictureActive"
+      @click="emit('togglePictureInPicture')"
+    >
+      <PictureInPicture2 class="w-4 h-4" />
     </button>
     <div ref="moreWrapEl" class="call-controls__more">
       <button

--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -13,6 +13,7 @@ import {
 } from "@/lib/calls/ui-mode";
 import {
   $callSelfViewHidden,
+  $callPinnedTileKey,
   $callViewMode,
   setCallViewMode,
   toggleCallSelfViewHidden,
@@ -55,16 +56,30 @@ import {
 } from "@/lib/calls/in-call-reactions";
 import { barePeerJid } from "@/lib/xmpp/jid";
 import { expectedRemoteIdentitiesForCallState } from "@/lib/calls/call-tiles";
-import type { BrowserXmppClient } from "@/lib/xmpp/client";
+import { projectCallTiles } from "@/lib/calls/call-tile-projection";
+import {
+  $callPictureInPictureActive,
+  $callPictureInPictureMode,
+  $callPictureInPictureSupport,
+  enterDocumentCallPictureInPicture,
+  enterVideoCallPictureInPicture,
+  exitVideoCallPictureInPicture,
+  findCallPictureInPictureVideo,
+  installVideoPictureInPictureCloseHandlers,
+  refreshCallPictureInPictureSupport,
+  selectCallPictureInPictureTile,
+} from "@/lib/calls/call-picture-in-picture";
 import type { MentionCandidate } from "@/lib/mentions";
 import type { MarkupSpan, MessageReference, TimelineMessage } from "@/lib/chat-ui";
 import type { ComposerLinkPreviewLookup, ComposerLinkPreviewSendPayload } from "@/lib/link-preview-composer";
+import type { BrowserXmppClient } from "@/lib/xmpp/client";
 import CallTileGrid from "./CallTileGrid.vue";
 import CallStageHeader from "./CallStageHeader.vue";
 import CallControls from "./CallControls.vue";
 import CallSettingsDialog from "./CallSettingsDialog.vue";
 import CallMediaNotice from "./CallMediaNotice.vue";
 import CallSelfShareNotice from "./CallSelfShareNotice.vue";
+import CallPictureInPicturePanel from "./CallPictureInPicturePanel.vue";
 import CallDock from "./CallDock.vue";
 import CallChatPanel from "./CallChatPanel.vue";
 
@@ -129,6 +144,7 @@ const surfaceRef = ref<HTMLElement | null>(null);
 const state = useStore($callState);
 const uiMode = useStore($callUiMode);
 const viewMode = useStore($callViewMode);
+const pinnedTileKey = useStore($callPinnedTileKey);
 const selfViewHidden = useStore($callSelfViewHidden);
 const lastError = useStore($lastCallError);
 const connecting = useStore($callConnecting);
@@ -136,6 +152,9 @@ const micEnabled = useStore($callMicEnabled);
 const camEnabled = useStore($callCamEnabled);
 const screenShareEnabled = useStore($callScreenShareEnabled);
 const screenShareSupported = useStore($callScreenShareSupported);
+const pictureInPictureSupport = useStore($callPictureInPictureSupport);
+const pictureInPictureActive = useStore($callPictureInPictureActive);
+const pictureInPictureMode = useStore($callPictureInPictureMode);
 const { remoteTracks, localTracks, engine, activeSpeakerIdentities, promotedSpeakerIdentity } =
   useCallEngine();
 const { activeRoomJid, selfInCall } = useActiveMucCall();
@@ -143,7 +162,12 @@ const { activeRoomJid, selfInCall } = useActiveMucCall();
 const settingsOpen = ref(false);
 const chromeVisible = ref(true);
 const nativeFullscreenActive = ref(false);
+const pictureInPicturePanelRef = ref<HTMLElement | null>(null);
+const pictureInPictureParkingRef = ref<HTMLElement | null>(null);
 let chromeIdleTimer: number | null = null;
+let documentPictureInPictureWindow: Window | null = null;
+let videoPictureInPictureElement: HTMLVideoElement | null = null;
+let cleanupVideoPictureInPictureListeners: (() => void) | null = null;
 const dockOpen = useStore($callDockOpen);
 const dockTab = useStore($callDockTab);
 const chatUnread = useStore($callChatUnread);
@@ -241,6 +265,28 @@ const stageLocalTracks = computed(() =>
 const expectedRemoteIdentities = computed(() =>
   expectedRemoteIdentitiesForCallState(state.value),
 );
+const pictureInPictureTile = computed(() => {
+  const projection = projectCallTiles({
+    remoteTracks: remoteTracks.value,
+    localTracks: stageLocalTracks.value,
+    localIdentity: localIdentity.value,
+    expectedRemoteIdentities: expectedRemoteIdentities.value,
+    micEnabled: micEnabled.value,
+    seenRemoteScreenTrackKeys: new Set(),
+    pinnedTileKey: pinnedTileKey.value,
+    viewMode: viewMode.value,
+    promotedSpeakerIdentity: promotedSpeakerIdentity.value,
+    hideSelfView: selfViewHidden.value,
+  });
+  return selectCallPictureInPictureTile({
+    tiles: projection.tiles,
+    pinnedTileKey: pinnedTileKey.value,
+    activeSpeakerIdentities: activeSpeakerIdentities.value,
+  });
+});
+const pictureInPictureSupported = computed(() =>
+  pictureInPictureSupport.value !== "none" && pictureInPictureTile.value !== null,
+);
 
 const {
   rows: rosterRows,
@@ -323,11 +369,73 @@ function onFullscreenChange(): void {
 }
 
 async function onHangup(): Promise<void> {
+  await closePictureInPicture();
   await hangupActiveCall();
   // After hangup the surface unmounts on its own (phase flips out of
   // "active"); flip the mode back so the next call defaults to split
   // instead of inheriting "expanded".
   $callUiMode.set("split");
+}
+
+function parkPictureInPicturePanel(): void {
+  const panel = pictureInPicturePanelRef.value;
+  const parking = pictureInPictureParkingRef.value;
+  if (!panel || !parking || panel.parentElement === parking) return;
+  parking.appendChild(panel);
+}
+
+function onDocumentPictureInPictureClose(): void {
+  documentPictureInPictureWindow = null;
+  parkPictureInPicturePanel();
+  $callPictureInPictureActive.set(false);
+  $callPictureInPictureMode.set(null);
+}
+
+function onVideoPictureInPictureClose(): void {
+  cleanupVideoPictureInPictureListeners?.();
+  cleanupVideoPictureInPictureListeners = null;
+  videoPictureInPictureElement = null;
+  $callPictureInPictureActive.set(false);
+  $callPictureInPictureMode.set(null);
+}
+
+async function closePictureInPicture(): Promise<void> {
+  if (documentPictureInPictureWindow) {
+    const pipWindow = documentPictureInPictureWindow;
+    documentPictureInPictureWindow = null;
+    pipWindow.close();
+    parkPictureInPicturePanel();
+    $callPictureInPictureActive.set(false);
+    $callPictureInPictureMode.set(null);
+    return;
+  }
+  await exitVideoCallPictureInPicture(videoPictureInPictureElement);
+  onVideoPictureInPictureClose();
+}
+
+async function togglePictureInPicture(): Promise<void> {
+  if (pictureInPictureActive.value) {
+    await closePictureInPicture();
+    return;
+  }
+  const tile = pictureInPictureTile.value;
+  if (!tile) return;
+  if (pictureInPictureSupport.value === "document") {
+    const panel = pictureInPicturePanelRef.value;
+    if (!panel) return;
+    const pipWindow = await enterDocumentCallPictureInPicture(panel, { width: 360, height: 240 });
+    documentPictureInPictureWindow = pipWindow;
+    pipWindow.addEventListener("pagehide", onDocumentPictureInPictureClose, { once: true });
+    return;
+  }
+  const video = findCallPictureInPictureVideo(surfaceRef.value, tile.key);
+  if (!video) return;
+  await enterVideoCallPictureInPicture(video);
+  videoPictureInPictureElement = video;
+  cleanupVideoPictureInPictureListeners =
+    installVideoPictureInPictureCloseHandlers(video, onVideoPictureInPictureClose);
+  $callPictureInPictureActive.set(true);
+  $callPictureInPictureMode.set("video");
 }
 
 async function onSendCallChat(
@@ -412,6 +520,7 @@ watch(isImmersive, (immersive) => {
 
 onMounted(() => {
   refreshScreenShareSupported();
+  refreshCallPictureInPictureSupport();
   revealImmersiveChrome();
   if (typeof window !== "undefined") {
     window.addEventListener("keydown", onKeydown, true);
@@ -429,6 +538,16 @@ onBeforeUnmount(() => {
     reactionExpiryTimer = null;
   }
   clearInCallReactions();
+  if (documentPictureInPictureWindow) {
+    documentPictureInPictureWindow.close();
+    documentPictureInPictureWindow = null;
+  }
+  cleanupVideoPictureInPictureListeners?.();
+  cleanupVideoPictureInPictureListeners = null;
+  videoPictureInPictureElement = null;
+  $callPictureInPictureActive.set(false);
+  $callPictureInPictureMode.set(null);
+  parkPictureInPicturePanel();
   if (typeof window !== "undefined") {
     window.removeEventListener("keydown", onKeydown, true);
   }
@@ -472,7 +591,20 @@ onBeforeUnmount(() => {
     />
     <main class="call-expanded__main">
       <div class="call-expanded__grid">
+        <div
+          v-if="pictureInPictureMode === 'document'"
+          class="call-expanded__pip-placeholder"
+        >
+          <button
+            type="button"
+            class="chat-action-button chat-action-button--secondary"
+            @click="togglePictureInPicture"
+          >
+            Return to call
+          </button>
+        </div>
         <CallTileGrid
+          v-else
           :remote-tracks="remoteTracks"
           :local-tracks="stageLocalTracks"
           :local-identity="localIdentity"
@@ -542,6 +674,8 @@ onBeforeUnmount(() => {
         :chat-unread="chatUnread"
         :view-mode="viewMode"
         :self-view-hidden="selfViewHidden"
+        :picture-in-picture-supported="pictureInPictureSupported"
+        :picture-in-picture-active="pictureInPictureActive"
         @toggle-mic="toggleMic"
         @toggle-cam="toggleCam"
         @toggle-screen-share="toggleScreenShare"
@@ -554,10 +688,24 @@ onBeforeUnmount(() => {
         @set-view-mode="setCallViewMode"
         @toggle-self-view="toggleCallSelfViewHidden"
         @send-reaction="onSendInCallReaction"
+        @toggle-picture-in-picture="togglePictureInPicture"
         @hangup="onHangup"
       />
     </footer>
     <CallSettingsDialog v-model:open="settingsOpen" />
+    <div ref="pictureInPictureParkingRef" class="call-expanded__pip-parking" aria-hidden="true">
+      <div ref="pictureInPicturePanelRef">
+        <CallPictureInPicturePanel
+          :tile="pictureInPictureTile"
+          :mic-enabled="micEnabled"
+          :cam-enabled="camEnabled"
+          @toggle-mic="toggleMic"
+          @toggle-cam="toggleCam"
+          @return-to-call="togglePictureInPicture"
+          @hangup="onHangup"
+        />
+      </div>
+    </div>
   </div>
 </template>
 
@@ -676,6 +824,15 @@ onBeforeUnmount(() => {
   }
 }
 
+.call-expanded__pip-placeholder {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  height: 100%;
+  background: var(--muted);
+  color: var(--muted-foreground);
+}
+
 .call-expanded__dock-overlay {
   display: contents;
 }
@@ -695,6 +852,10 @@ onBeforeUnmount(() => {
   justify-content: center;
   border-top: 1px solid var(--border);
   padding: 0.75rem 1rem;
+}
+
+.call-expanded__pip-parking {
+  display: none;
 }
 
 /* On narrow viewports the dock becomes a full-width bottom panel (see

--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { useStore } from "@nanostores/vue";
 import {
   $callState,
@@ -56,7 +56,10 @@ import {
 } from "@/lib/calls/in-call-reactions";
 import { barePeerJid } from "@/lib/xmpp/jid";
 import { expectedRemoteIdentitiesForCallState } from "@/lib/calls/call-tiles";
-import { projectCallTiles } from "@/lib/calls/call-tile-projection";
+import {
+  projectCallTiles,
+  reconcileCallTileProjectionState,
+} from "@/lib/calls/call-tile-projection";
 import {
   $callPictureInPictureActive,
   $callPictureInPictureMode,
@@ -164,10 +167,14 @@ const chromeVisible = ref(true);
 const nativeFullscreenActive = ref(false);
 const pictureInPicturePanelRef = ref<HTMLElement | null>(null);
 const pictureInPictureParkingRef = ref<HTMLElement | null>(null);
+const mountedPictureInPictureVideo = ref<HTMLVideoElement | null>(null);
+const pictureInPictureSeenRemoteScreenTrackKeys = ref<ReadonlySet<string>>(new Set());
 let chromeIdleTimer: number | null = null;
 let documentPictureInPictureWindow: Window | null = null;
 let videoPictureInPictureElement: HTMLVideoElement | null = null;
 let cleanupVideoPictureInPictureListeners: (() => void) | null = null;
+let observedPictureInPictureRoot: HTMLElement | null = null;
+let pictureInPictureVideoObserver: MutationObserver | null = null;
 const dockOpen = useStore($callDockOpen);
 const dockTab = useStore($callDockTab);
 const chatUnread = useStore($callChatUnread);
@@ -265,28 +272,89 @@ const stageLocalTracks = computed(() =>
 const expectedRemoteIdentities = computed(() =>
   expectedRemoteIdentitiesForCallState(state.value),
 );
-const pictureInPictureTile = computed(() => {
-  const projection = projectCallTiles({
+const pictureInPictureProjection = computed(() =>
+  projectCallTiles({
     remoteTracks: remoteTracks.value,
     localTracks: stageLocalTracks.value,
     localIdentity: localIdentity.value,
     expectedRemoteIdentities: expectedRemoteIdentities.value,
     micEnabled: micEnabled.value,
-    seenRemoteScreenTrackKeys: new Set(),
+    seenRemoteScreenTrackKeys: pictureInPictureSeenRemoteScreenTrackKeys.value,
     pinnedTileKey: pinnedTileKey.value,
     viewMode: viewMode.value,
     promotedSpeakerIdentity: promotedSpeakerIdentity.value,
     hideSelfView: selfViewHidden.value,
+  }),
+);
+watch(pictureInPictureProjection, (next) => {
+  const reconciled = reconcileCallTileProjectionState({
+    tiles: next.tiles,
+    pinnedTileKey: pinnedTileKey.value,
+    currentSeenRemoteScreenTrackKeys: pictureInPictureSeenRemoteScreenTrackKeys.value,
+    nextSeenRemoteScreenTrackKeys: next.seenRemoteScreenTrackKeys,
   });
+  if (
+    pictureInPictureSeenRemoteScreenTrackKeys.value !==
+    reconciled.seenRemoteScreenTrackKeys
+  ) {
+    pictureInPictureSeenRemoteScreenTrackKeys.value = reconciled.seenRemoteScreenTrackKeys;
+  }
+}, { immediate: true });
+const pictureInPictureTile = computed(() => {
   return selectCallPictureInPictureTile({
-    tiles: projection.tiles,
+    tiles: pictureInPictureProjection.value.tiles,
     pinnedTileKey: pinnedTileKey.value,
     activeSpeakerIdentities: activeSpeakerIdentities.value,
   });
 });
-const pictureInPictureSupported = computed(() =>
-  pictureInPictureSupport.value !== "none" && pictureInPictureTile.value !== null,
-);
+const pictureInPictureSupported = computed(() => {
+  if (!pictureInPictureTile.value) return false;
+  if (pictureInPictureSupport.value === "document") return true;
+  if (pictureInPictureSupport.value === "video") {
+    return mountedPictureInPictureVideo.value !== null;
+  }
+  return false;
+});
+
+function refreshMountedPictureInPictureVideo(): void {
+  if (pictureInPictureSupport.value !== "video") {
+    mountedPictureInPictureVideo.value = null;
+    return;
+  }
+  const tile = pictureInPictureTile.value;
+  mountedPictureInPictureVideo.value = tile
+    ? findCallPictureInPictureVideo(surfaceRef.value, tile.key)
+    : null;
+}
+
+function observeMountedPictureInPictureVideos(root: HTMLElement | null): void {
+  if (root === observedPictureInPictureRoot) return;
+  disconnectMountedPictureInPictureVideoObserver();
+  observedPictureInPictureRoot = root;
+  if (!root || typeof MutationObserver === "undefined") return;
+  pictureInPictureVideoObserver = new MutationObserver(() => {
+    refreshMountedPictureInPictureVideo();
+  });
+  pictureInPictureVideoObserver.observe(root, { childList: true, subtree: true });
+}
+
+function disconnectMountedPictureInPictureVideoObserver(): void {
+  pictureInPictureVideoObserver?.disconnect();
+  pictureInPictureVideoObserver = null;
+  observedPictureInPictureRoot = null;
+}
+
+watch([pictureInPictureTile, pictureInPictureSupport, isOpen], async () => {
+  await nextTick();
+  observeMountedPictureInPictureVideos(isOpen.value ? surfaceRef.value : null);
+  refreshMountedPictureInPictureVideo();
+}, { immediate: true, flush: "post" });
+
+watch(isOpen, (open) => {
+  if (!open && hasLocalPictureInPictureHandle()) {
+    void closePictureInPictureSafely();
+  }
+});
 
 const {
   rows: rosterRows,
@@ -369,7 +437,7 @@ function onFullscreenChange(): void {
 }
 
 async function onHangup(): Promise<void> {
-  await closePictureInPicture();
+  await closePictureInPictureSafely();
   await hangupActiveCall();
   // After hangup the surface unmounts on its own (phase flips out of
   // "active"); flip the mode back so the next call defaults to split
@@ -385,37 +453,53 @@ function parkPictureInPicturePanel(): void {
 }
 
 function onDocumentPictureInPictureClose(): void {
-  documentPictureInPictureWindow = null;
-  parkPictureInPicturePanel();
-  $callPictureInPictureActive.set(false);
-  $callPictureInPictureMode.set(null);
+  resetLocalPictureInPictureState();
 }
 
 function onVideoPictureInPictureClose(): void {
+  resetLocalPictureInPictureState();
+}
+
+function hasLocalPictureInPictureHandle(): boolean {
+  return documentPictureInPictureWindow !== null || videoPictureInPictureElement !== null;
+}
+
+function resetLocalPictureInPictureState(): void {
   cleanupVideoPictureInPictureListeners?.();
   cleanupVideoPictureInPictureListeners = null;
+  documentPictureInPictureWindow = null;
   videoPictureInPictureElement = null;
   $callPictureInPictureActive.set(false);
   $callPictureInPictureMode.set(null);
+  parkPictureInPicturePanel();
 }
 
 async function closePictureInPicture(): Promise<void> {
   if (documentPictureInPictureWindow) {
     const pipWindow = documentPictureInPictureWindow;
     documentPictureInPictureWindow = null;
-    pipWindow.close();
-    parkPictureInPicturePanel();
-    $callPictureInPictureActive.set(false);
-    $callPictureInPictureMode.set(null);
+    try {
+      pipWindow.close();
+    } finally {
+      resetLocalPictureInPictureState();
+    }
     return;
   }
   await exitVideoCallPictureInPicture(videoPictureInPictureElement);
-  onVideoPictureInPictureClose();
+  resetLocalPictureInPictureState();
+}
+
+async function closePictureInPictureSafely(): Promise<void> {
+  try {
+    await closePictureInPicture();
+  } catch {
+    resetLocalPictureInPictureState();
+  }
 }
 
 async function togglePictureInPicture(): Promise<void> {
   if (pictureInPictureActive.value) {
-    await closePictureInPicture();
+    await closePictureInPictureSafely();
     return;
   }
   const tile = pictureInPictureTile.value;
@@ -428,7 +512,8 @@ async function togglePictureInPicture(): Promise<void> {
     pipWindow.addEventListener("pagehide", onDocumentPictureInPictureClose, { once: true });
     return;
   }
-  const video = findCallPictureInPictureVideo(surfaceRef.value, tile.key);
+  const video = mountedPictureInPictureVideo.value
+    ?? findCallPictureInPictureVideo(surfaceRef.value, tile.key);
   if (!video) return;
   await enterVideoCallPictureInPicture(video);
   videoPictureInPictureElement = video;
@@ -538,16 +623,12 @@ onBeforeUnmount(() => {
     reactionExpiryTimer = null;
   }
   clearInCallReactions();
-  if (documentPictureInPictureWindow) {
-    documentPictureInPictureWindow.close();
-    documentPictureInPictureWindow = null;
+  disconnectMountedPictureInPictureVideoObserver();
+  try {
+    documentPictureInPictureWindow?.close();
+  } finally {
+    resetLocalPictureInPictureState();
   }
-  cleanupVideoPictureInPictureListeners?.();
-  cleanupVideoPictureInPictureListeners = null;
-  videoPictureInPictureElement = null;
-  $callPictureInPictureActive.set(false);
-  $callPictureInPictureMode.set(null);
-  parkPictureInPicturePanel();
   if (typeof window !== "undefined") {
     window.removeEventListener("keydown", onKeydown, true);
   }

--- a/chat/src/components/calls/CallPictureInPicturePanel.vue
+++ b/chat/src/components/calls/CallPictureInPicturePanel.vue
@@ -1,0 +1,149 @@
+<script setup lang="ts">
+import { onBeforeUnmount } from "vue";
+import { Mic, MicOff, PhoneOff, RotateCcw, Video, VideoOff } from "lucide-vue-next";
+import type { CallTileModel } from "@/lib/calls/call-tiles";
+import { TileAttachments, type TileAttachable } from "@/lib/calls/tile-attach";
+import CallTile from "./CallTile.vue";
+
+const props = defineProps<{
+  tile: CallTileModel | null;
+  micEnabled: boolean;
+  camEnabled: boolean;
+}>();
+
+const emit = defineEmits<{
+  toggleMic: [];
+  toggleCam: [];
+  hangup: [];
+  returnToCall: [];
+}>();
+
+const attachments = new TileAttachments();
+
+function attach(
+  key: string,
+  el: HTMLMediaElement | null,
+  track: TileAttachable | null,
+): void {
+  attachments.sync(key, el, track);
+}
+
+onBeforeUnmount(() => {
+  attachments.detachAll();
+});
+</script>
+
+<template>
+  <section class="call-pip-panel" aria-label="Call Picture-in-Picture">
+    <div class="call-pip-panel__tile">
+      <CallTile
+        v-if="tile"
+        :key="tile.key"
+        :label="tile.label"
+        :attach-key="`pip:${tile.key}`"
+        :is-self="tile.isSelf"
+        :mirror-video="tile.mirrorVideo"
+        :shows-presenting-glyph="tile.showsPresentingGlyph"
+        :mic-enabled="tile.micEnabledHint"
+        :video-track="tile.videoTrack"
+        :attach="attach"
+        :interactive="false"
+      />
+      <div v-else class="call-pip-panel__empty">No active video</div>
+    </div>
+    <div class="call-pip-panel__controls">
+      <button
+        type="button"
+        class="call-pip-panel__button"
+        :aria-label="micEnabled ? 'Mute' : 'Unmute'"
+        :title="micEnabled ? 'Mute' : 'Unmute'"
+        @click="emit('toggleMic')"
+      >
+        <component :is="micEnabled ? Mic : MicOff" class="w-4 h-4" />
+      </button>
+      <button
+        type="button"
+        class="call-pip-panel__button"
+        :aria-label="camEnabled ? 'Camera off' : 'Camera on'"
+        :title="camEnabled ? 'Camera off' : 'Camera on'"
+        @click="emit('toggleCam')"
+      >
+        <component :is="camEnabled ? Video : VideoOff" class="w-4 h-4" />
+      </button>
+      <button
+        type="button"
+        class="call-pip-panel__button"
+        aria-label="Return to call"
+        title="Return to call"
+        @click="emit('returnToCall')"
+      >
+        <RotateCcw class="w-4 h-4" />
+      </button>
+      <button
+        type="button"
+        class="call-pip-panel__button call-pip-panel__button--danger"
+        aria-label="Hang up"
+        title="Hang up"
+        @click="emit('hangup')"
+      >
+        <PhoneOff class="w-4 h-4" />
+      </button>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.call-pip-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: 100vw;
+  height: 100vh;
+  padding: 0.5rem;
+  background: var(--background);
+  color: var(--foreground);
+  box-sizing: border-box;
+}
+
+.call-pip-panel__tile {
+  flex: 1 1 0%;
+  min-height: 0;
+}
+
+.call-pip-panel__empty {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  height: 100%;
+  border-radius: var(--radius-md);
+  background: var(--muted);
+  color: var(--muted-foreground);
+}
+
+.call-pip-panel__controls {
+  display: flex;
+  justify-content: center;
+  gap: 0.375rem;
+}
+
+.call-pip-panel__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: var(--radius-sm);
+  background: var(--secondary);
+  color: var(--secondary-foreground);
+}
+
+.call-pip-panel__button:hover,
+.call-pip-panel__button:focus-visible {
+  background: var(--muted);
+}
+
+.call-pip-panel__button--danger {
+  background: var(--destructive);
+  color: var(--destructive-foreground);
+}
+</style>

--- a/chat/src/components/calls/CallSplitContainer.vue
+++ b/chat/src/components/calls/CallSplitContainer.vue
@@ -8,6 +8,7 @@ import {
 import { $callUiMode } from "@/lib/calls/ui-mode";
 import {
   $callSelfViewHidden,
+  $callPinnedTileKey,
   $callViewMode,
   setCallViewMode,
   toggleCallSelfViewHidden,
@@ -43,6 +44,19 @@ import {
 } from "@/lib/calls/in-call-reactions";
 import { barePeerJid } from "@/lib/xmpp/jid";
 import { expectedRemoteIdentitiesForCallState } from "@/lib/calls/call-tiles";
+import { projectCallTiles } from "@/lib/calls/call-tile-projection";
+import {
+  $callPictureInPictureActive,
+  $callPictureInPictureMode,
+  $callPictureInPictureSupport,
+  enterDocumentCallPictureInPicture,
+  enterVideoCallPictureInPicture,
+  exitVideoCallPictureInPicture,
+  findCallPictureInPictureVideo,
+  installVideoPictureInPictureCloseHandlers,
+  refreshCallPictureInPictureSupport,
+  selectCallPictureInPictureTile,
+} from "@/lib/calls/call-picture-in-picture";
 import type { BrowserXmppClient } from "@/lib/xmpp/client";
 import CallTileGrid from "./CallTileGrid.vue";
 import CallStageHeader from "./CallStageHeader.vue";
@@ -50,6 +64,7 @@ import CallControls from "./CallControls.vue";
 import CallSettingsDialog from "./CallSettingsDialog.vue";
 import CallMediaNotice from "./CallMediaNotice.vue";
 import CallSelfShareNotice from "./CallSelfShareNotice.vue";
+import CallPictureInPicturePanel from "./CallPictureInPicturePanel.vue";
 import SplitDragHandle from "./SplitDragHandle.vue";
 
 /**
@@ -78,6 +93,7 @@ const props = defineProps<{
 const state = useStore($callState);
 const uiMode = useStore($callUiMode);
 const viewMode = useStore($callViewMode);
+const pinnedTileKey = useStore($callPinnedTileKey);
 const selfViewHidden = useStore($callSelfViewHidden);
 const lastError = useStore($lastCallError);
 const connecting = useStore($callConnecting);
@@ -85,6 +101,9 @@ const micEnabled = useStore($callMicEnabled);
 const camEnabled = useStore($callCamEnabled);
 const screenShareEnabled = useStore($callScreenShareEnabled);
 const screenShareSupported = useStore($callScreenShareSupported);
+const pictureInPictureSupport = useStore($callPictureInPictureSupport);
+const pictureInPictureActive = useStore($callPictureInPictureActive);
+const pictureInPictureMode = useStore($callPictureInPictureMode);
 const { remoteTracks, localTracks, engine, activeSpeakerIdentities, promotedSpeakerIdentity } =
   useCallEngine();
 const { activeRoomJid, selfInCall } = useActiveMucCall();
@@ -97,6 +116,11 @@ let reactionExpiryTimer: ReturnType<typeof setInterval> | null = null;
 const activeCallReactions = computed(() => {
   return activeInCallReactions(state.value, reactions.value);
 });
+const pictureInPicturePanelRef = ref<HTMLElement | null>(null);
+const pictureInPictureParkingRef = ref<HTMLElement | null>(null);
+let documentPictureInPictureWindow: Window | null = null;
+let videoPictureInPictureElement: HTMLVideoElement | null = null;
+let cleanupVideoPictureInPictureListeners: (() => void) | null = null;
 
 const normalizedRoomJid = computed(() =>
   normalizeMucCallRoomJid(props.roomJid ?? ""),
@@ -213,10 +237,33 @@ const stageLocalTracks = computed(() =>
 const expectedRemoteIdentities = computed(() =>
   expectedRemoteIdentitiesForCallState(state.value),
 );
+const pictureInPictureTile = computed(() => {
+  const projection = projectCallTiles({
+    remoteTracks: remoteTracks.value,
+    localTracks: stageLocalTracks.value,
+    localIdentity: localIdentity.value,
+    expectedRemoteIdentities: expectedRemoteIdentities.value,
+    micEnabled: micEnabled.value,
+    seenRemoteScreenTrackKeys: new Set(),
+    pinnedTileKey: pinnedTileKey.value,
+    viewMode: viewMode.value,
+    promotedSpeakerIdentity: promotedSpeakerIdentity.value,
+    hideSelfView: selfViewHidden.value,
+  });
+  return selectCallPictureInPictureTile({
+    tiles: projection.tiles,
+    pinnedTileKey: pinnedTileKey.value,
+    activeSpeakerIdentities: activeSpeakerIdentities.value,
+  });
+});
+const pictureInPictureSupported = computed(() =>
+  pictureInPictureSupport.value !== "none" && pictureInPictureTile.value !== null,
+);
 
 onMounted(() => {
   refreshScreenShareSupported();
   reactionExpiryTimer = setInterval(() => expireInCallReactions(), 400);
+  refreshCallPictureInPictureSupport();
 });
 
 onBeforeUnmount(() => {
@@ -225,9 +272,20 @@ onBeforeUnmount(() => {
     reactionExpiryTimer = null;
   }
   clearInCallReactions();
+  if (documentPictureInPictureWindow) {
+    documentPictureInPictureWindow.close();
+    documentPictureInPictureWindow = null;
+  }
+  cleanupVideoPictureInPictureListeners?.();
+  cleanupVideoPictureInPictureListeners = null;
+  videoPictureInPictureElement = null;
+  $callPictureInPictureActive.set(false);
+  $callPictureInPictureMode.set(null);
+  parkPictureInPicturePanel();
 });
 
 async function onHangup(): Promise<void> {
+  await closePictureInPicture();
   await hangupActiveCall();
 }
 
@@ -247,6 +305,66 @@ async function onSendInCallReaction(emoji: string): Promise<void> {
   }
 }
 
+function parkPictureInPicturePanel(): void {
+  const panel = pictureInPicturePanelRef.value;
+  const parking = pictureInPictureParkingRef.value;
+  if (!panel || !parking || panel.parentElement === parking) return;
+  parking.appendChild(panel);
+}
+
+function onDocumentPictureInPictureClose(): void {
+  documentPictureInPictureWindow = null;
+  parkPictureInPicturePanel();
+  $callPictureInPictureActive.set(false);
+  $callPictureInPictureMode.set(null);
+}
+
+function onVideoPictureInPictureClose(): void {
+  cleanupVideoPictureInPictureListeners?.();
+  cleanupVideoPictureInPictureListeners = null;
+  videoPictureInPictureElement = null;
+  $callPictureInPictureActive.set(false);
+  $callPictureInPictureMode.set(null);
+}
+
+async function closePictureInPicture(): Promise<void> {
+  if (documentPictureInPictureWindow) {
+    const pipWindow = documentPictureInPictureWindow;
+    documentPictureInPictureWindow = null;
+    pipWindow.close();
+    parkPictureInPicturePanel();
+    $callPictureInPictureActive.set(false);
+    $callPictureInPictureMode.set(null);
+    return;
+  }
+  await exitVideoCallPictureInPicture(videoPictureInPictureElement);
+  onVideoPictureInPictureClose();
+}
+
+async function togglePictureInPicture(): Promise<void> {
+  if (pictureInPictureActive.value) {
+    await closePictureInPicture();
+    return;
+  }
+  const tile = pictureInPictureTile.value;
+  if (!tile) return;
+  if (pictureInPictureSupport.value === "document") {
+    const panel = pictureInPicturePanelRef.value;
+    if (!panel) return;
+    const pipWindow = await enterDocumentCallPictureInPicture(panel, { width: 360, height: 240 });
+    documentPictureInPictureWindow = pipWindow;
+    pipWindow.addEventListener("pagehide", onDocumentPictureInPictureClose, { once: true });
+    return;
+  }
+  const video = findCallPictureInPictureVideo(containerRef.value, tile.key);
+  if (!video) return;
+  await enterVideoCallPictureInPicture(video);
+  videoPictureInPictureElement = video;
+  cleanupVideoPictureInPictureListeners =
+    installVideoPictureInPictureCloseHandlers(video, onVideoPictureInPictureClose);
+  $callPictureInPictureActive.set(true);
+  $callPictureInPictureMode.set("video");
+}
 </script>
 
 <template>
@@ -274,7 +392,20 @@ async function onSendInCallReaction(emoji: string): Promise<void> {
         compact
       />
       <div class="call-split__grid">
+        <div
+          v-if="pictureInPictureMode === 'document'"
+          class="call-split__pip-placeholder"
+        >
+          <button
+            type="button"
+            class="chat-action-button chat-action-button--secondary"
+            @click="togglePictureInPicture"
+          >
+            Return to call
+          </button>
+        </div>
         <CallTileGrid
+          v-else
           :remote-tracks="remoteTracks"
           :local-tracks="stageLocalTracks"
           :local-identity="localIdentity"
@@ -308,6 +439,8 @@ async function onSendInCallReaction(emoji: string): Promise<void> {
           :chat-unread="chatUnread"
           :view-mode="viewMode"
           :self-view-hidden="selfViewHidden"
+          :picture-in-picture-supported="pictureInPictureSupported"
+          :picture-in-picture-active="pictureInPictureActive"
           @toggle-mic="toggleMic"
           @toggle-cam="toggleCam"
           @toggle-screen-share="toggleScreenShare"
@@ -318,9 +451,23 @@ async function onSendInCallReaction(emoji: string): Promise<void> {
           @set-view-mode="setCallViewMode"
           @toggle-self-view="toggleCallSelfViewHidden"
           @send-reaction="onSendInCallReaction"
+          @toggle-picture-in-picture="togglePictureInPicture"
           @hangup="onHangup"
         />
       </footer>
+      <div ref="pictureInPictureParkingRef" class="call-split__pip-parking" aria-hidden="true">
+        <div ref="pictureInPicturePanelRef">
+          <CallPictureInPicturePanel
+            :tile="pictureInPictureTile"
+            :mic-enabled="micEnabled"
+            :cam-enabled="camEnabled"
+            @toggle-mic="toggleMic"
+            @toggle-cam="toggleCam"
+            @return-to-call="togglePictureInPicture"
+            @hangup="onHangup"
+          />
+        </div>
+      </div>
     </section>
     <SplitDragHandle
       :dragging="isDragging"
@@ -401,8 +548,22 @@ async function onSendInCallReaction(emoji: string): Promise<void> {
   }
 }
 
+.call-split__pip-placeholder {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  height: 100%;
+  min-height: 8rem;
+  background: var(--muted);
+  color: var(--muted-foreground);
+}
+
 .call-split__footer {
   padding: 0.5rem 0.75rem;
   border-top: 1px solid var(--border);
+}
+
+.call-split__pip-parking {
+  display: none;
 }
 </style>

--- a/chat/src/components/calls/CallSplitContainer.vue
+++ b/chat/src/components/calls/CallSplitContainer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref } from "vue";
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { useStore } from "@nanostores/vue";
 import {
   $callState,
@@ -44,7 +44,10 @@ import {
 } from "@/lib/calls/in-call-reactions";
 import { barePeerJid } from "@/lib/xmpp/jid";
 import { expectedRemoteIdentitiesForCallState } from "@/lib/calls/call-tiles";
-import { projectCallTiles } from "@/lib/calls/call-tile-projection";
+import {
+  projectCallTiles,
+  reconcileCallTileProjectionState,
+} from "@/lib/calls/call-tile-projection";
 import {
   $callPictureInPictureActive,
   $callPictureInPictureMode,
@@ -118,9 +121,13 @@ const activeCallReactions = computed(() => {
 });
 const pictureInPicturePanelRef = ref<HTMLElement | null>(null);
 const pictureInPictureParkingRef = ref<HTMLElement | null>(null);
+const mountedPictureInPictureVideo = ref<HTMLVideoElement | null>(null);
+const pictureInPictureSeenRemoteScreenTrackKeys = ref<ReadonlySet<string>>(new Set());
 let documentPictureInPictureWindow: Window | null = null;
 let videoPictureInPictureElement: HTMLVideoElement | null = null;
 let cleanupVideoPictureInPictureListeners: (() => void) | null = null;
+let observedPictureInPictureRoot: HTMLElement | null = null;
+let pictureInPictureVideoObserver: MutationObserver | null = null;
 
 const normalizedRoomJid = computed(() =>
   normalizeMucCallRoomJid(props.roomJid ?? ""),
@@ -237,28 +244,89 @@ const stageLocalTracks = computed(() =>
 const expectedRemoteIdentities = computed(() =>
   expectedRemoteIdentitiesForCallState(state.value),
 );
-const pictureInPictureTile = computed(() => {
-  const projection = projectCallTiles({
+const pictureInPictureProjection = computed(() =>
+  projectCallTiles({
     remoteTracks: remoteTracks.value,
     localTracks: stageLocalTracks.value,
     localIdentity: localIdentity.value,
     expectedRemoteIdentities: expectedRemoteIdentities.value,
     micEnabled: micEnabled.value,
-    seenRemoteScreenTrackKeys: new Set(),
+    seenRemoteScreenTrackKeys: pictureInPictureSeenRemoteScreenTrackKeys.value,
     pinnedTileKey: pinnedTileKey.value,
     viewMode: viewMode.value,
     promotedSpeakerIdentity: promotedSpeakerIdentity.value,
     hideSelfView: selfViewHidden.value,
+  }),
+);
+watch(pictureInPictureProjection, (next) => {
+  const reconciled = reconcileCallTileProjectionState({
+    tiles: next.tiles,
+    pinnedTileKey: pinnedTileKey.value,
+    currentSeenRemoteScreenTrackKeys: pictureInPictureSeenRemoteScreenTrackKeys.value,
+    nextSeenRemoteScreenTrackKeys: next.seenRemoteScreenTrackKeys,
   });
+  if (
+    pictureInPictureSeenRemoteScreenTrackKeys.value !==
+    reconciled.seenRemoteScreenTrackKeys
+  ) {
+    pictureInPictureSeenRemoteScreenTrackKeys.value = reconciled.seenRemoteScreenTrackKeys;
+  }
+}, { immediate: true });
+const pictureInPictureTile = computed(() => {
   return selectCallPictureInPictureTile({
-    tiles: projection.tiles,
+    tiles: pictureInPictureProjection.value.tiles,
     pinnedTileKey: pinnedTileKey.value,
     activeSpeakerIdentities: activeSpeakerIdentities.value,
   });
 });
-const pictureInPictureSupported = computed(() =>
-  pictureInPictureSupport.value !== "none" && pictureInPictureTile.value !== null,
-);
+const pictureInPictureSupported = computed(() => {
+  if (!pictureInPictureTile.value) return false;
+  if (pictureInPictureSupport.value === "document") return true;
+  if (pictureInPictureSupport.value === "video") {
+    return mountedPictureInPictureVideo.value !== null;
+  }
+  return false;
+});
+
+function refreshMountedPictureInPictureVideo(): void {
+  if (pictureInPictureSupport.value !== "video") {
+    mountedPictureInPictureVideo.value = null;
+    return;
+  }
+  const tile = pictureInPictureTile.value;
+  mountedPictureInPictureVideo.value = tile
+    ? findCallPictureInPictureVideo(containerRef.value, tile.key)
+    : null;
+}
+
+function observeMountedPictureInPictureVideos(root: HTMLElement | null): void {
+  if (root === observedPictureInPictureRoot) return;
+  disconnectMountedPictureInPictureVideoObserver();
+  observedPictureInPictureRoot = root;
+  if (!root || typeof MutationObserver === "undefined") return;
+  pictureInPictureVideoObserver = new MutationObserver(() => {
+    refreshMountedPictureInPictureVideo();
+  });
+  pictureInPictureVideoObserver.observe(root, { childList: true, subtree: true });
+}
+
+function disconnectMountedPictureInPictureVideoObserver(): void {
+  pictureInPictureVideoObserver?.disconnect();
+  pictureInPictureVideoObserver = null;
+  observedPictureInPictureRoot = null;
+}
+
+watch([pictureInPictureTile, pictureInPictureSupport, shouldRender], async () => {
+  await nextTick();
+  observeMountedPictureInPictureVideos(shouldRender.value ? containerRef.value : null);
+  refreshMountedPictureInPictureVideo();
+}, { immediate: true, flush: "post" });
+
+watch(shouldRender, (rendering) => {
+  if (!rendering && hasLocalPictureInPictureHandle()) {
+    void closePictureInPictureSafely();
+  }
+});
 
 onMounted(() => {
   refreshScreenShareSupported();
@@ -272,20 +340,16 @@ onBeforeUnmount(() => {
     reactionExpiryTimer = null;
   }
   clearInCallReactions();
-  if (documentPictureInPictureWindow) {
-    documentPictureInPictureWindow.close();
-    documentPictureInPictureWindow = null;
+  disconnectMountedPictureInPictureVideoObserver();
+  try {
+    documentPictureInPictureWindow?.close();
+  } finally {
+    resetLocalPictureInPictureState();
   }
-  cleanupVideoPictureInPictureListeners?.();
-  cleanupVideoPictureInPictureListeners = null;
-  videoPictureInPictureElement = null;
-  $callPictureInPictureActive.set(false);
-  $callPictureInPictureMode.set(null);
-  parkPictureInPicturePanel();
 });
 
 async function onHangup(): Promise<void> {
-  await closePictureInPicture();
+  await closePictureInPictureSafely();
   await hangupActiveCall();
 }
 
@@ -313,37 +377,53 @@ function parkPictureInPicturePanel(): void {
 }
 
 function onDocumentPictureInPictureClose(): void {
-  documentPictureInPictureWindow = null;
-  parkPictureInPicturePanel();
-  $callPictureInPictureActive.set(false);
-  $callPictureInPictureMode.set(null);
+  resetLocalPictureInPictureState();
 }
 
 function onVideoPictureInPictureClose(): void {
+  resetLocalPictureInPictureState();
+}
+
+function hasLocalPictureInPictureHandle(): boolean {
+  return documentPictureInPictureWindow !== null || videoPictureInPictureElement !== null;
+}
+
+function resetLocalPictureInPictureState(): void {
   cleanupVideoPictureInPictureListeners?.();
   cleanupVideoPictureInPictureListeners = null;
+  documentPictureInPictureWindow = null;
   videoPictureInPictureElement = null;
   $callPictureInPictureActive.set(false);
   $callPictureInPictureMode.set(null);
+  parkPictureInPicturePanel();
 }
 
 async function closePictureInPicture(): Promise<void> {
   if (documentPictureInPictureWindow) {
     const pipWindow = documentPictureInPictureWindow;
     documentPictureInPictureWindow = null;
-    pipWindow.close();
-    parkPictureInPicturePanel();
-    $callPictureInPictureActive.set(false);
-    $callPictureInPictureMode.set(null);
+    try {
+      pipWindow.close();
+    } finally {
+      resetLocalPictureInPictureState();
+    }
     return;
   }
   await exitVideoCallPictureInPicture(videoPictureInPictureElement);
-  onVideoPictureInPictureClose();
+  resetLocalPictureInPictureState();
+}
+
+async function closePictureInPictureSafely(): Promise<void> {
+  try {
+    await closePictureInPicture();
+  } catch {
+    resetLocalPictureInPictureState();
+  }
 }
 
 async function togglePictureInPicture(): Promise<void> {
   if (pictureInPictureActive.value) {
-    await closePictureInPicture();
+    await closePictureInPictureSafely();
     return;
   }
   const tile = pictureInPictureTile.value;
@@ -356,7 +436,8 @@ async function togglePictureInPicture(): Promise<void> {
     pipWindow.addEventListener("pagehide", onDocumentPictureInPictureClose, { once: true });
     return;
   }
-  const video = findCallPictureInPictureVideo(containerRef.value, tile.key);
+  const video = mountedPictureInPictureVideo.value
+    ?? findCallPictureInPictureVideo(containerRef.value, tile.key);
   if (!video) return;
   await enterVideoCallPictureInPicture(video);
   videoPictureInPictureElement = video;

--- a/chat/src/components/calls/CallTile.vue
+++ b/chat/src/components/calls/CallTile.vue
@@ -98,6 +98,7 @@ const emit = defineEmits<{
     :role="interactive ? 'button' : 'img'"
     :tabindex="interactive ? 0 : undefined"
     :aria-label="interactive ? `Open ${label} tile` : label"
+    :data-call-tile-key="attachKey"
     @click="activate"
     @keydown.enter="activate"
   >
@@ -118,6 +119,7 @@ const emit = defineEmits<{
       :ref="refVideo"
       class="call-tile__video"
       :class="{ 'call-tile__video--mirrored': mirrorVideo }"
+      :data-call-tile-key="attachKey"
       autoplay
       playsinline
       :muted="isSelf"

--- a/chat/src/lib/calls/call-picture-in-picture.ts
+++ b/chat/src/lib/calls/call-picture-in-picture.ts
@@ -81,16 +81,26 @@ export async function enterVideoCallPictureInPicture(video: HTMLVideoElement): P
   }
   const webKitVideo = video as WebKitPictureInPictureVideoPrototype;
   if (
-    typeof webKitVideo.webkitSupportsPresentationMode === "function" &&
-    webKitVideo.webkitSupportsPresentationMode("picture-in-picture") &&
     typeof webKitVideo.webkitSetPresentationMode === "function"
   ) {
+    if (
+      typeof webKitVideo.webkitSupportsPresentationMode !== "function" ||
+      !webKitVideo.webkitSupportsPresentationMode("picture-in-picture")
+    ) {
+      throw new Error("Video Picture-in-Picture is not available for this video element");
+    }
     webKitVideo.webkitSetPresentationMode("picture-in-picture");
+    return;
   }
+  throw new Error("Video Picture-in-Picture is not available");
 }
 
 export async function exitVideoCallPictureInPicture(video: HTMLVideoElement | null): Promise<void> {
-  if (typeof document !== "undefined" && document.pictureInPictureElement) {
+  if (
+    typeof document !== "undefined" &&
+    video !== null &&
+    document.pictureInPictureElement === video
+  ) {
     await document.exitPictureInPicture();
     return;
   }

--- a/chat/src/lib/calls/call-picture-in-picture.ts
+++ b/chat/src/lib/calls/call-picture-in-picture.ts
@@ -1,0 +1,184 @@
+import { atom } from "nanostores";
+import type { CallTileModel } from "./call-tiles";
+
+export type CallPictureInPictureSupport = "document" | "video" | "none";
+export type CallPictureInPictureMode = "document" | "video" | null;
+
+export type CallPictureInPictureSupportFlags = {
+  hasDocumentPictureInPicture: boolean;
+  hasStandardVideoPictureInPicture: boolean;
+  hasWebKitVideoPictureInPicture: boolean;
+};
+
+export const $callPictureInPictureSupport = atom<CallPictureInPictureSupport>("none");
+export const $callPictureInPictureActive = atom<boolean>(false);
+export const $callPictureInPictureMode = atom<CallPictureInPictureMode>(null);
+
+export function detectCallPictureInPictureSupport(
+  flags: CallPictureInPictureSupportFlags,
+): CallPictureInPictureSupport {
+  if (flags.hasDocumentPictureInPicture) return "document";
+  if (flags.hasStandardVideoPictureInPicture || flags.hasWebKitVideoPictureInPicture) {
+    return "video";
+  }
+  return "none";
+}
+
+function detectBrowserCallPictureInPictureSupport(): CallPictureInPictureSupport {
+  if (typeof window === "undefined" || typeof document === "undefined") return "none";
+  const browserWindow = window as Window & {
+    documentPictureInPicture?: {
+      requestWindow?: (options?: { width?: number; height?: number }) => Promise<Window>;
+    };
+  };
+  const videoPrototype = HTMLVideoElement.prototype as WebKitPictureInPictureVideoPrototype;
+  return detectCallPictureInPictureSupport({
+    hasDocumentPictureInPicture:
+      typeof browserWindow.documentPictureInPicture?.requestWindow === "function",
+    hasStandardVideoPictureInPicture:
+      document.pictureInPictureEnabled === true &&
+      typeof HTMLVideoElement.prototype.requestPictureInPicture === "function",
+    hasWebKitVideoPictureInPicture:
+      typeof videoPrototype.webkitSetPresentationMode === "function" &&
+      typeof videoPrototype.webkitSupportsPresentationMode === "function",
+  });
+}
+
+export function refreshCallPictureInPictureSupport(): void {
+  $callPictureInPictureSupport.set(detectBrowserCallPictureInPictureSupport());
+}
+
+export type SelectCallPictureInPictureTileInput = {
+  tiles: readonly CallTileModel[];
+  pinnedTileKey: string | null;
+  activeSpeakerIdentities: ReadonlySet<string>;
+};
+
+export function selectCallPictureInPictureTile(
+  input: SelectCallPictureInPictureTileInput,
+): CallTileModel | null {
+  const videoTiles = input.tiles.filter((tile) => tile.videoTrack !== null);
+  const pinned = input.pinnedTileKey
+    ? videoTiles.find((tile) => tile.key === input.pinnedTileKey) ?? null
+    : null;
+  if (pinned) return pinned;
+
+  const activeSpeaker = videoTiles.find((tile) =>
+    tile.source === "camera" && input.activeSpeakerIdentities.has(tile.identity)
+  ) ?? null;
+  if (activeSpeaker) return activeSpeaker;
+
+  return videoTiles.find((tile) => !tile.isSelf && tile.source === "camera")
+    ?? videoTiles.find((tile) => tile.source === "camera")
+    ?? videoTiles[0]
+    ?? null;
+}
+
+export async function enterVideoCallPictureInPicture(video: HTMLVideoElement): Promise<void> {
+  if (typeof video.requestPictureInPicture === "function") {
+    await video.requestPictureInPicture();
+    return;
+  }
+  const webKitVideo = video as WebKitPictureInPictureVideoPrototype;
+  if (
+    typeof webKitVideo.webkitSupportsPresentationMode === "function" &&
+    webKitVideo.webkitSupportsPresentationMode("picture-in-picture") &&
+    typeof webKitVideo.webkitSetPresentationMode === "function"
+  ) {
+    webKitVideo.webkitSetPresentationMode("picture-in-picture");
+  }
+}
+
+export async function exitVideoCallPictureInPicture(video: HTMLVideoElement | null): Promise<void> {
+  if (typeof document !== "undefined" && document.pictureInPictureElement) {
+    await document.exitPictureInPicture();
+    return;
+  }
+  const webKitVideo = video as WebKitPictureInPictureVideoPrototype | null;
+  if (
+    webKitVideo &&
+    typeof webKitVideo.webkitSetPresentationMode === "function"
+  ) {
+    webKitVideo.webkitSetPresentationMode("inline");
+  }
+}
+
+export function installVideoPictureInPictureCloseHandlers(
+  video: HTMLVideoElement,
+  onClose: () => void,
+): () => void {
+  let active = true;
+  const cleanup = () => {
+    if (!active) return;
+    active = false;
+    video.removeEventListener("leavepictureinpicture", onStandardLeave);
+    video.removeEventListener("webkitpresentationmodechanged", onWebKitModeChange);
+  };
+  const close = () => {
+    cleanup();
+    onClose();
+  };
+  const onStandardLeave = () => close();
+  const onWebKitModeChange = () => {
+    const webKitVideo = video as HTMLVideoElement & { webkitPresentationMode?: string };
+    if (webKitVideo.webkitPresentationMode !== "picture-in-picture") close();
+  };
+
+  video.addEventListener("leavepictureinpicture", onStandardLeave);
+  video.addEventListener("webkitpresentationmodechanged", onWebKitModeChange);
+  return cleanup;
+}
+
+export async function enterDocumentCallPictureInPicture(
+  panel: HTMLElement,
+  options: { width: number; height: number },
+): Promise<Window> {
+  const openerWindow = window as Window & {
+    documentPictureInPicture?: {
+      requestWindow: (options?: { width?: number; height?: number }) => Promise<Window>;
+    };
+  };
+  const pipWindow = await openerWindow.documentPictureInPicture?.requestWindow(options);
+  if (!pipWindow) {
+    throw new Error("Document Picture-in-Picture is not available");
+  }
+  copyStyleSheets(document, pipWindow.document);
+  pipWindow.document.body.className = "call-pip-document";
+  pipWindow.document.body.appendChild(panel);
+  $callPictureInPictureActive.set(true);
+  $callPictureInPictureMode.set("document");
+  return pipWindow;
+}
+
+export function findCallPictureInPictureVideo(
+  root: Pick<Element, "querySelectorAll"> | Pick<Document, "querySelectorAll"> | null,
+  tileKey: string,
+): HTMLVideoElement | null {
+  if (!root) return null;
+  for (const video of root.querySelectorAll<HTMLVideoElement>("video[data-call-tile-key]")) {
+    if (video.dataset.callTileKey === tileKey) return video;
+  }
+  return null;
+}
+
+function copyStyleSheets(source: Document, target: Document): void {
+  for (const styleSheet of Array.from(source.styleSheets)) {
+    try {
+      const rules = Array.from(styleSheet.cssRules).map((rule) => rule.cssText).join("");
+      const style = target.createElement("style");
+      style.textContent = rules;
+      target.head.appendChild(style);
+    } catch {
+      if (!styleSheet.href) continue;
+      const link = target.createElement("link");
+      link.rel = "stylesheet";
+      link.href = styleSheet.href;
+      target.head.appendChild(link);
+    }
+  }
+}
+
+type WebKitPictureInPictureVideoPrototype = HTMLVideoElement & {
+  webkitSupportsPresentationMode?: (mode: "picture-in-picture") => boolean;
+  webkitSetPresentationMode?: (mode: "inline" | "picture-in-picture") => void;
+};

--- a/chat/tests/call-controls.test.ts
+++ b/chat/tests/call-controls.test.ts
@@ -733,6 +733,40 @@ describe("call control bar chat toggle", () => {
   });
 });
 
+describe("call control bar Picture-in-Picture toggle", () => {
+  test("hides the PiP button when no browser PiP mode is available", async () => {
+    const html = await renderCallControls({ pictureInPictureSupported: false });
+
+    expect(html).not.toContain("Open Picture-in-Picture");
+  });
+
+  test("renders inactive and active PiP states accessibly", async () => {
+    const inactive = await renderCallControls({
+      pictureInPictureSupported: true,
+      pictureInPictureActive: false,
+    });
+    expect(inactive).toContain('aria-label="Open Picture-in-Picture"');
+    expect(inactive).toMatch(/aria-label="Open Picture-in-Picture"[^>]*aria-pressed="false"/);
+
+    const active = await renderCallControls({
+      pictureInPictureSupported: true,
+      pictureInPictureActive: true,
+    });
+    expect(active).toContain('aria-label="Return to call"');
+    expect(active).toMatch(/aria-label="Return to call"[^>]*aria-pressed="true"/);
+  });
+
+  test("wires the PiP toggle emit", () => {
+    const source = readFileSync(
+      new URL("../src/components/calls/CallControls.vue", import.meta.url),
+      "utf8",
+    );
+    expect(source).toContain("togglePictureInPicture");
+    expect(source).toContain("pictureInPictureSupported");
+    expect(source).toContain("pictureInPictureActive");
+  });
+});
+
 describe("call control bar restructure (#1020)", () => {
   test("no longer embeds the connection-quality indicator (now in the stage-header)", () => {
     // The indicator moved to CallStageHeader (asserted there via the recursive

--- a/chat/tests/call-picture-in-picture.test.ts
+++ b/chat/tests/call-picture-in-picture.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import type { CallTileModel } from "../src/lib/calls/call-tiles";
+import {
+  $callPictureInPictureActive,
+  $callPictureInPictureMode,
+  detectCallPictureInPictureSupport,
+  enterDocumentCallPictureInPicture,
+  enterVideoCallPictureInPicture,
+  exitVideoCallPictureInPicture,
+  installVideoPictureInPictureCloseHandlers,
+  selectCallPictureInPictureTile,
+} from "../src/lib/calls/call-picture-in-picture";
+
+const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+
+afterEach(() => {
+  restoreDescriptor(globalThis, "window", originalWindow);
+  restoreDescriptor(globalThis, "document", originalDocument);
+  $callPictureInPictureActive.set(false);
+  $callPictureInPictureMode.set(null);
+});
+
+describe("call Picture-in-Picture controller", () => {
+  test("prefers Document PiP, falls back to video PiP, and hides unsupported controls", () => {
+    expect(
+      detectCallPictureInPictureSupport({
+        hasDocumentPictureInPicture: true,
+        hasStandardVideoPictureInPicture: true,
+        hasWebKitVideoPictureInPicture: true,
+      }),
+    ).toBe("document");
+
+    expect(
+      detectCallPictureInPictureSupport({
+        hasDocumentPictureInPicture: false,
+        hasStandardVideoPictureInPicture: true,
+        hasWebKitVideoPictureInPicture: false,
+      }),
+    ).toBe("video");
+
+    expect(
+      detectCallPictureInPictureSupport({
+        hasDocumentPictureInPicture: false,
+        hasStandardVideoPictureInPicture: false,
+        hasWebKitVideoPictureInPicture: true,
+      }),
+    ).toBe("video");
+
+    expect(
+      detectCallPictureInPictureSupport({
+        hasDocumentPictureInPicture: false,
+        hasStandardVideoPictureInPicture: false,
+        hasWebKitVideoPictureInPicture: false,
+      }),
+    ).toBe("none");
+  });
+
+  test("selects a pinned video tile before falling back to the active speaker camera", () => {
+    const tiles = [
+      tile("self:alice@example.com/web:camera", "alice@example.com/web", "camera", false),
+      tile("remote:bob@example.com/web:camera", "bob@example.com/web", "camera", true),
+      tile("remote:carol@example.com/web:camera", "carol@example.com/web", "camera", true),
+    ];
+
+    expect(
+      selectCallPictureInPictureTile({
+        tiles,
+        pinnedTileKey: "remote:bob@example.com/web:camera",
+        activeSpeakerIdentities: new Set(["carol@example.com/web"]),
+      })?.key,
+    ).toBe("remote:bob@example.com/web:camera");
+
+    expect(
+      selectCallPictureInPictureTile({
+        tiles,
+        pinnedTileKey: null,
+        activeSpeakerIdentities: new Set(["carol@example.com/web"]),
+      })?.key,
+    ).toBe("remote:carol@example.com/web:camera");
+  });
+
+  test("enters standard or WebKit video Picture-in-Picture through one controller", async () => {
+    const standardCalls: string[] = [];
+    await enterVideoCallPictureInPicture({
+      requestPictureInPicture: async () => {
+        standardCalls.push("standard");
+      },
+    } as HTMLVideoElement);
+    expect(standardCalls).toEqual(["standard"]);
+
+    const webKitCalls: string[] = [];
+    await enterVideoCallPictureInPicture({
+      webkitSupportsPresentationMode: (mode: string) => mode === "picture-in-picture",
+      webkitSetPresentationMode: (mode: string) => {
+        webKitCalls.push(mode);
+      },
+    } as unknown as HTMLVideoElement);
+    expect(webKitCalls).toEqual(["picture-in-picture"]);
+  });
+
+  test("moves the panel into a Document PiP window and records document mode", async () => {
+    const panel = {};
+    const appended: unknown[] = [];
+    const pipDocument = {
+      body: {
+        className: "",
+        appendChild: (node: unknown) => {
+          appended.push(node);
+          return node;
+        },
+        contains: (node: unknown) => appended.includes(node),
+      },
+      head: { appendChild: (node: unknown) => node },
+      createElement: (tagName: string) => ({ tagName }),
+    };
+    const requestWindow = mock(async (options?: { width?: number; height?: number }) => {
+      expect(options).toEqual({ width: 360, height: 240 });
+      return { document: pipDocument } as Window;
+    });
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: { documentPictureInPicture: { requestWindow } },
+    });
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: { styleSheets: [] },
+    });
+
+    const pipWindow = await enterDocumentCallPictureInPicture(panel as HTMLElement, {
+      width: 360,
+      height: 240,
+    });
+
+    expect(pipWindow.document).toBe(pipDocument);
+    expect(pipDocument.body.contains(panel)).toBe(true);
+    expect(pipDocument.body.className).toBe("call-pip-document");
+    expect($callPictureInPictureActive.get()).toBe(true);
+    expect($callPictureInPictureMode.get()).toBe("document");
+  });
+
+  test("exits standard and WebKit video Picture-in-Picture", async () => {
+    const standardVideo = {};
+    const exitPictureInPicture = mock(async () => undefined);
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: {
+        pictureInPictureElement: standardVideo,
+        exitPictureInPicture,
+      },
+    });
+
+    await exitVideoCallPictureInPicture(standardVideo as HTMLVideoElement);
+    expect(exitPictureInPicture).toHaveBeenCalledTimes(1);
+
+    restoreDescriptor(globalThis, "document", originalDocument);
+    const webKitCalls: string[] = [];
+    await exitVideoCallPictureInPicture({
+      webkitSetPresentationMode: (mode: string) => {
+        webKitCalls.push(mode);
+      },
+    } as unknown as HTMLVideoElement);
+    expect(webKitCalls).toEqual(["inline"]);
+  });
+
+  test("keeps the WebKit close listener through enter and clears it on exit", () => {
+    const listeners = new Map<string, Set<() => void>>();
+    const video = {
+      webkitPresentationMode: "inline",
+      addEventListener: (type: string, listener: () => void) => {
+        const existing = listeners.get(type) ?? new Set<() => void>();
+        existing.add(listener);
+        listeners.set(type, existing);
+      },
+      removeEventListener: (type: string, listener: () => void) => {
+        listeners.get(type)?.delete(listener);
+      },
+    };
+    const onClose = mock(() => undefined);
+
+    installVideoPictureInPictureCloseHandlers(video as unknown as HTMLVideoElement, onClose);
+
+    video.webkitPresentationMode = "picture-in-picture";
+    dispatch(listeners, "webkitpresentationmodechanged");
+    expect(onClose).not.toHaveBeenCalled();
+    expect(listeners.get("webkitpresentationmodechanged")?.size).toBe(1);
+
+    video.webkitPresentationMode = "inline";
+    dispatch(listeners, "webkitpresentationmodechanged");
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(listeners.get("webkitpresentationmodechanged")?.size).toBe(0);
+  });
+});
+
+function tile(
+  key: string,
+  identity: string,
+  source: CallTileModel["source"],
+  hasVideo: boolean,
+): CallTileModel {
+  return {
+    key,
+    identity,
+    label: identity.split("@")[0] ?? identity,
+    source,
+    screenTrackKey: null,
+    isSelf: key.startsWith("self:"),
+    mirrorVideo: false,
+    showsPresentingGlyph: source === "screen_share",
+    micEnabledHint: true,
+    videoTrack: hasVideo ? ({} as never) : null,
+  };
+}
+
+function restoreDescriptor(
+  target: object,
+  key: PropertyKey,
+  descriptor: PropertyDescriptor | undefined,
+): void {
+  if (descriptor) {
+    Object.defineProperty(target, key, descriptor);
+    return;
+  }
+  Reflect.deleteProperty(target, key);
+}
+
+function dispatch(listeners: Map<string, Set<() => void>>, type: string): void {
+  for (const listener of Array.from(listeners.get(type) ?? [])) listener();
+}

--- a/chat/tests/call-picture-in-picture.test.ts
+++ b/chat/tests/call-picture-in-picture.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
 import type { CallTileModel } from "../src/lib/calls/call-tiles";
 import {
   $callPictureInPictureActive,
@@ -99,6 +100,17 @@ describe("call Picture-in-Picture controller", () => {
     expect(webKitCalls).toEqual(["picture-in-picture"]);
   });
 
+  test("rejects video Picture-in-Picture when a WebKit video element does not support it", async () => {
+    expect(
+      enterVideoCallPictureInPicture({
+        webkitSupportsPresentationMode: () => false,
+        webkitSetPresentationMode: () => {
+          throw new Error("should not set presentation mode");
+        },
+      } as unknown as HTMLVideoElement),
+    ).rejects.toThrow("Video Picture-in-Picture is not available for this video element");
+  });
+
   test("moves the panel into a Document PiP window and records document mode", async () => {
     const panel = {};
     const appended: unknown[] = [];
@@ -163,6 +175,23 @@ describe("call Picture-in-Picture controller", () => {
     expect(webKitCalls).toEqual(["inline"]);
   });
 
+  test("does not exit an unrelated standard video Picture-in-Picture session", async () => {
+    const callVideo = {};
+    const unrelatedVideo = {};
+    const exitPictureInPicture = mock(async () => undefined);
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: {
+        pictureInPictureElement: unrelatedVideo,
+        exitPictureInPicture,
+      },
+    });
+
+    await exitVideoCallPictureInPicture(callVideo as HTMLVideoElement);
+
+    expect(exitPictureInPicture).not.toHaveBeenCalled();
+  });
+
   test("keeps the WebKit close listener through enter and clears it on exit", () => {
     const listeners = new Map<string, Set<() => void>>();
     const video = {
@@ -190,6 +219,39 @@ describe("call Picture-in-Picture controller", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(listeners.get("webkitpresentationmodechanged")?.size).toBe(0);
   });
+});
+
+describe("call Picture-in-Picture surface wiring", () => {
+  for (const surface of ["CallSplitContainer.vue", "CallExpandedSurface.vue"] as const) {
+    test(`${surface} gates video PiP on a mounted source video`, () => {
+      const source = surfaceSource(surface);
+      expect(source).toContain("mountedPictureInPictureVideo.value !== null");
+      expect(source).toContain("findCallPictureInPictureVideo");
+      expect(source).toContain("new MutationObserver");
+      expect(source).toContain("observeMountedPictureInPictureVideos");
+    });
+
+    test(`${surface} safely closes local PiP before hangup or surface hide`, () => {
+      const source = surfaceSource(surface);
+      const resetBlock = source.slice(
+        source.indexOf("function resetLocalPictureInPictureState"),
+        source.indexOf("async function closePictureInPicture"),
+      );
+      expect(source).toContain("async function closePictureInPictureSafely()");
+      expect(source).toContain("resetLocalPictureInPictureState()");
+      expect(source).toContain("await closePictureInPictureSafely();\n  await hangupActiveCall();");
+      expect(source).toContain("hasLocalPictureInPictureHandle()");
+      expect(source).toContain("void closePictureInPictureSafely()");
+      expect(resetBlock).not.toContain("mountedPictureInPictureVideo.value = null");
+    });
+
+    test(`${surface} keeps PiP tile projection screen-share state stable`, () => {
+      const source = surfaceSource(surface);
+      expect(source).toContain("pictureInPictureSeenRemoteScreenTrackKeys");
+      expect(source).toContain("reconcileCallTileProjectionState");
+      expect(source).not.toContain("seenRemoteScreenTrackKeys: new Set()");
+    });
+  }
 });
 
 function tile(
@@ -226,4 +288,11 @@ function restoreDescriptor(
 
 function dispatch(listeners: Map<string, Set<() => void>>, type: string): void {
   for (const listener of Array.from(listeners.get(type) ?? [])) listener();
+}
+
+function surfaceSource(name: string): string {
+  return readFileSync(
+    new URL(`../src/components/calls/${name}`, import.meta.url),
+    "utf8",
+  );
 }


### PR DESCRIPTION
## Summary

Implements #1032 with broad progressive Picture-in-Picture support for active chat calls.

- Adds a tested call PiP controller that detects Document PiP, standard video PiP, and WebKit/Safari video PiP.
- Adds full Document PiP behavior: selected active/pinned tile in a detached PiP document window with mute, camera, return, and hangup controls.
- Adds a reduced video-only fallback for Safari/video-PiP browsers: the selected active/pinned source video enters PiP while the in-app video remains mounted.
- Hides the PiP control when no PiP-capable selected video tile is available.
- Shows the in-app Return to call placeholder only for Document PiP, because video PiP requires the source video element to stay mounted.
- Wires PiP into split, expanded, and immersive call surfaces through the shared control bar.

## Review Feedback Addressed

- Scoped standard video PiP exit to the exact video element opened by the call so teardown cannot close unrelated PiP sessions.
- Rejected unsupported WebKit element-level PiP entry instead of marking the call as PiP-active when Safari refuses that video.
- Gated video-only PiP on the selected source video actually being mounted, with a surface-level DOM observer so overflow/grid resize changes refresh the control state.
- Closed local PiP handles when switching/hiding call surfaces to avoid orphaned Document PiP windows.
- Made hangup use a safe PiP close path so browser PiP cleanup failures cannot block call teardown.
- Reused stable PiP tile projection state for remote screen-share churn instead of recomputing with a fresh screen-share seen set on every render.

## Scope Notes

The original issue text described Document PiP only. This PR intentionally expands that to broad PiP support per follow-up discussion: Document PiP gets the full detached controls experience; Safari/video-only browsers get a reduced selected-video fallback because browser video PiP cannot host custom HTML controls.

No XMPP wire behavior is changed. This is local browser media/UI behavior only.

## Verification

- `bun test tests/call-picture-in-picture.test.ts tests/call-controls.test.ts tests/call-tile-spotlight.test.ts tests/call-dock-wiring.test.ts tests/call-tile-grid-overflow.test.ts`
- `bun run lint`
- `bun test`
- Filtered `bunx vue-tsc --noEmit` diagnostics for touched PiP files returned no matches.
- Adversarial code-review and test-review passes found no remaining actionable issues after the final fix.

## Review

- Security/privacy adversarial review found no actionable issues.
- Test-engineer review requested additional Document PiP, video exit, and control-bar coverage; added.
- Correctness review found WebKit exit-state cleanup issue; fixed with regression coverage.
- PR review follow-up found mounted-video gating, surface-switch cleanup, WebKit unsupported-entry, unrelated PiP exit, safe-hangup, and stable projection-state issues; fixed with controller and surface guardrail coverage.

## Known Gaps

- Manual browser PiP interaction was not exercised locally.
- Full `bunx vue-tsc --noEmit` remains red from unrelated existing project diagnostics outside this PiP diff.
