### PR TITLE
feat(chat): add calendar subscription feed

### DIFF
--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -84,6 +84,7 @@ const {
   socialFeed,
   stories,
   communityEvents,
+  communityJid,
   xmppClient,
   notifySettings,
   activeMessages,
@@ -780,6 +781,9 @@ onUnmounted(() => {
         :error="communityEvents.error.value"
         :can-post="!!connectionStore.session"
         :self-jid="connectionStore.session?.jid ?? null"
+        :community-jid="communityJid.value"
+        :server-base-url="connectionStore.activeServerUrl"
+        :session-id="connectionStore.session?.session_id ?? null"
         :find-master="communityEvents.findMaster"
         @refresh="communityEvents.refresh()"
         @post="(input) => communityEvents.post(input)"

--- a/chat/src/components/community/EventsPane.vue
+++ b/chat/src/components/community/EventsPane.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, onUnmounted, ref, watch } from "vue";
 import {
   CalendarDays,
   ChevronLeft,
   ChevronRight,
+  Copy,
   List,
   Menu,
   Pencil,
@@ -22,6 +23,11 @@ import type {
   Rrule,
   Weekday,
 } from "@/lib/xmpp-client";
+import {
+  copyCalendarFeedUrlToClipboard,
+  isSameCalendarFeedRequestInput,
+  type CalendarFeedRequestInput,
+} from "@/lib/calendar-feed-url";
 
 interface EventsPaneProps {
   events: readonly CommunityEvent[];
@@ -30,6 +36,9 @@ interface EventsPaneProps {
   error: string | null;
   canPost: boolean;
   selfJid: string | null;
+  communityJid: string | null;
+  serverBaseUrl: string;
+  sessionId: string | null;
   /**
    * Resolver from a UID back to the unexpanded master event so the
    * pane can edit / cancel the actual pubsub item rather than the
@@ -299,6 +308,38 @@ const canSubmit = computed(
   () => props.canPost && !props.isPosting && summary.value.trim().length > 0,
 );
 
+type FeedCopyState = "idle" | "loading" | "copied" | "error";
+
+const feedCopyState = ref<FeedCopyState>("idle");
+const feedCopyFallbackUrl = ref<string | null>(null);
+let feedCopyResetTimer: ReturnType<typeof setTimeout> | null = null;
+let feedCopyAttempt = 0;
+
+const canCopyFeedUrl = computed(
+  () => !!props.communityJid && props.serverBaseUrl.trim().length > 0,
+);
+
+const feedCopyStatusLabel = computed(() => {
+  if (feedCopyState.value === "loading") return "Copying";
+  if (feedCopyState.value === "copied") return "Copied";
+  if (feedCopyState.value === "error") return "Couldn't copy";
+  return "";
+});
+
+onUnmounted(() => {
+  feedCopyAttempt += 1;
+  if (feedCopyResetTimer) clearTimeout(feedCopyResetTimer);
+});
+
+watch(
+  () => [props.communityJid, props.serverBaseUrl, props.sessionId] as const,
+  () => {
+    feedCopyAttempt += 1;
+    feedCopyFallbackUrl.value = null;
+    markFeedCopyState("idle");
+  },
+);
+
 /** Format an epoch-ms timestamp for the `<input type="datetime-local">` widget. */
 function toDatetimeLocal(ms: number | undefined): string {
   if (typeof ms !== "number") return "";
@@ -396,6 +437,60 @@ function resetComposer() {
   rrule.value = null;
 }
 
+function markFeedCopyState(state: FeedCopyState) {
+  feedCopyState.value = state;
+  if (feedCopyResetTimer) clearTimeout(feedCopyResetTimer);
+  if (state === "copied" || state === "error") {
+    feedCopyResetTimer = setTimeout(() => {
+      feedCopyState.value = "idle";
+      feedCopyResetTimer = null;
+    }, 2_000);
+  }
+}
+
+function currentFeedRequestInput(): CalendarFeedRequestInput {
+  return {
+    communityJid: props.communityJid,
+    serverBaseUrl: props.serverBaseUrl,
+    sessionId: props.sessionId,
+  };
+}
+
+async function copyCalendarFeedUrl() {
+  if (!canCopyFeedUrl.value || feedCopyState.value === "loading") return;
+  const attempt = feedCopyAttempt + 1;
+  feedCopyAttempt = attempt;
+  const requestInput = currentFeedRequestInput();
+  feedCopyFallbackUrl.value = null;
+  if (typeof fetch === "undefined") {
+    markFeedCopyState("error");
+    return;
+  }
+  markFeedCopyState("loading");
+  const result = await copyCalendarFeedUrlToClipboard(requestInput);
+  if (
+    attempt !== feedCopyAttempt
+    || !isSameCalendarFeedRequestInput(requestInput, currentFeedRequestInput())
+  ) {
+    return;
+  }
+  if (result.status === "copied") {
+    feedCopyFallbackUrl.value = null;
+    markFeedCopyState("copied");
+    return;
+  }
+  if (result.status === "copy_failed") {
+    feedCopyFallbackUrl.value = result.url;
+  }
+  markFeedCopyState("error");
+}
+
+function selectFallbackUrl(event: FocusEvent) {
+  if (event.target instanceof HTMLInputElement) {
+    event.target.select();
+  }
+}
+
 const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 </script>
 
@@ -456,6 +551,24 @@ const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
           {{ activeFilter === 'attending' ? 'Going / Maybe' : 'All events' }}
         </button>
 
+        <!-- Calendar feed -->
+        <button
+          type="button"
+          class="inline-flex min-h-9 min-w-[7.5rem] items-center justify-center gap-1 rounded-md border border-transparent px-3 py-2 text-xs text-muted-foreground hover:bg-muted/50 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-muted-foreground sm:min-h-8 sm:px-2 sm:py-1"
+          :disabled="!canCopyFeedUrl || feedCopyState === 'loading'"
+          @click="copyCalendarFeedUrl"
+        >
+          <Copy class="h-3.5 w-3.5" aria-hidden="true" />
+          Copy feed URL
+        </button>
+        <span
+          class="min-w-[5.5rem] text-xs text-muted-foreground"
+          role="status"
+          aria-live="polite"
+        >
+          {{ feedCopyStatusLabel }}
+        </span>
+
         <!-- New event / Refresh -->
         <button
           v-if="canPost"
@@ -477,6 +590,22 @@ const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
           Refresh
         </button>
       </header>
+
+      <div
+        v-if="feedCopyFallbackUrl"
+        class="flex flex-wrap items-center gap-2 rounded-md border border-border bg-muted/30 px-3 py-2"
+      >
+        <span class="text-xs font-medium text-muted-foreground">
+          Calendar subscription URL
+        </span>
+        <input
+          class="min-w-0 flex-1 rounded-md border border-input bg-background px-2 py-1.5 text-xs text-foreground"
+          readonly
+          :value="feedCopyFallbackUrl"
+          aria-label="Calendar feed URL"
+          @focus="selectFallbackUrl"
+        />
+      </div>
 
       <!-- Error -->
       <div

--- a/chat/src/components/community/EventsPane.vue
+++ b/chat/src/components/community/EventsPane.vue
@@ -26,6 +26,8 @@ import type {
 import {
   copyCalendarFeedUrlToClipboard,
   isSameCalendarFeedRequestInput,
+  nextCalendarFeedCopyViewState,
+  type CalendarFeedCopyResult,
   type CalendarFeedRequestInput,
 } from "@/lib/calendar-feed-url";
 
@@ -335,8 +337,7 @@ watch(
   () => [props.communityJid, props.serverBaseUrl, props.sessionId] as const,
   () => {
     feedCopyAttempt += 1;
-    feedCopyFallbackUrl.value = null;
-    markFeedCopyState("idle");
+    applyFeedCopyTransition({ contextChanged: true });
   },
 );
 
@@ -437,8 +438,7 @@ function resetComposer() {
   rrule.value = null;
 }
 
-function markFeedCopyState(state: FeedCopyState) {
-  feedCopyState.value = state;
+function scheduleFeedCopyReset(state: FeedCopyState) {
   if (feedCopyResetTimer) clearTimeout(feedCopyResetTimer);
   if (state === "copied" || state === "error") {
     feedCopyResetTimer = setTimeout(() => {
@@ -446,6 +446,21 @@ function markFeedCopyState(state: FeedCopyState) {
       feedCopyResetTimer = null;
     }, 2_000);
   }
+}
+
+function applyFeedCopyTransition(input: {
+  contextChanged?: boolean;
+  startAttempt?: boolean;
+  result?: CalendarFeedCopyResult;
+}) {
+  const next = nextCalendarFeedCopyViewState({
+    state: feedCopyState.value,
+    fallbackUrl: feedCopyFallbackUrl.value,
+    ...input,
+  });
+  feedCopyState.value = next.state;
+  feedCopyFallbackUrl.value = next.fallbackUrl;
+  scheduleFeedCopyReset(next.state);
 }
 
 function currentFeedRequestInput(): CalendarFeedRequestInput {
@@ -461,12 +476,7 @@ async function copyCalendarFeedUrl() {
   const attempt = feedCopyAttempt + 1;
   feedCopyAttempt = attempt;
   const requestInput = currentFeedRequestInput();
-  feedCopyFallbackUrl.value = null;
-  if (typeof fetch === "undefined") {
-    markFeedCopyState("error");
-    return;
-  }
-  markFeedCopyState("loading");
+  applyFeedCopyTransition({ startAttempt: true });
   const result = await copyCalendarFeedUrlToClipboard(requestInput);
   if (
     attempt !== feedCopyAttempt
@@ -474,15 +484,7 @@ async function copyCalendarFeedUrl() {
   ) {
     return;
   }
-  if (result.status === "copied") {
-    feedCopyFallbackUrl.value = null;
-    markFeedCopyState("copied");
-    return;
-  }
-  if (result.status === "copy_failed") {
-    feedCopyFallbackUrl.value = result.url;
-  }
-  markFeedCopyState("error");
+  applyFeedCopyTransition({ result });
 }
 
 function selectFallbackUrl(event: FocusEvent) {

--- a/chat/src/lib/calendar-feed-url.ts
+++ b/chat/src/lib/calendar-feed-url.ts
@@ -1,0 +1,122 @@
+export interface CalendarFeedRequestInput {
+  communityJid: string | null;
+  serverBaseUrl: string;
+  sessionId?: string | null;
+}
+
+export type CalendarFeedFetch = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export type CalendarFeedCopyText = (text: string) => Promise<void>;
+
+export type CalendarFeedCopyResult =
+  | { status: "copied"; url: string }
+  | { status: "copy_failed"; url: string }
+  | { status: "request_failed" };
+
+export interface CalendarFeedCopyView {
+  state: "idle" | "loading" | "copied" | "error";
+  fallbackUrl: string | null;
+}
+
+export function nextCalendarFeedCopyViewState(input: CalendarFeedCopyView & {
+  contextChanged?: boolean;
+  startAttempt?: boolean;
+  result?: CalendarFeedCopyResult;
+}): CalendarFeedCopyView {
+  if (input.contextChanged) {
+    return { state: "idle", fallbackUrl: null };
+  }
+  if (input.startAttempt) {
+    return { state: "loading", fallbackUrl: null };
+  }
+  if (!input.result) {
+    return { state: input.state, fallbackUrl: input.fallbackUrl };
+  }
+  switch (input.result.status) {
+    case "copied":
+      return { state: "copied", fallbackUrl: null };
+    case "copy_failed":
+      return { state: "error", fallbackUrl: input.result.url };
+    case "request_failed":
+      return { state: "error", fallbackUrl: null };
+  }
+}
+
+export function calendarFeedEndpoint(input: CalendarFeedRequestInput): string | null {
+  if (!input.communityJid) return null;
+  try {
+    const url = new URL("/api/calendar/community-feed-url", input.serverBaseUrl);
+    url.searchParams.set("community_jid", input.communityJid);
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+export function isSameCalendarFeedRequestInput(
+  a: CalendarFeedRequestInput,
+  b: CalendarFeedRequestInput,
+): boolean {
+  return a.communityJid === b.communityJid
+    && a.serverBaseUrl === b.serverBaseUrl
+    && (a.sessionId ?? null) === (b.sessionId ?? null);
+}
+
+async function requestCalendarFeedUrl(
+  input: CalendarFeedRequestInput,
+  fetchImpl: CalendarFeedFetch,
+): Promise<string> {
+  const endpoint = calendarFeedEndpoint(input);
+  if (!endpoint) throw new Error("calendar feed endpoint unavailable");
+
+  const headers: Record<string, string> = { "Accept": "application/json" };
+  if (input.sessionId) {
+    headers["X-Waddle-Session-Id"] = input.sessionId;
+  }
+  const response = await fetchImpl(endpoint, {
+    credentials: "include",
+    headers,
+  });
+  if (!response.ok) throw new Error(`calendar feed request failed: ${response.status}`);
+
+  const body = await response.json() as { url?: unknown };
+  if (typeof body.url !== "string" || body.url.length === 0) {
+    throw new Error("calendar feed response missing url");
+  }
+  return body.url;
+}
+
+async function copyTextToClipboard(text: string): Promise<void> {
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+  throw new Error("clipboard unavailable");
+}
+
+export async function copyCalendarFeedUrlToClipboard(
+  input: CalendarFeedRequestInput,
+  deps: {
+    fetch?: CalendarFeedFetch;
+    copyText?: CalendarFeedCopyText;
+  } = {},
+): Promise<CalendarFeedCopyResult> {
+  let url: string;
+  try {
+    const fetchImpl = deps.fetch ?? (typeof fetch !== "undefined" ? fetch : undefined);
+    if (!fetchImpl) return { status: "request_failed" };
+    url = await requestCalendarFeedUrl(input, fetchImpl);
+  } catch {
+    return { status: "request_failed" };
+  }
+
+  try {
+    await (deps.copyText ?? copyTextToClipboard)(url);
+    return { status: "copied", url };
+  } catch {
+    return { status: "copy_failed", url };
+  }
+}

--- a/chat/src/lib/xmpp/event-expansion.ts
+++ b/chat/src/lib/xmpp/event-expansion.ts
@@ -185,10 +185,7 @@ function advance(ms: number, freq: string, interval: number): number {
 }
 
 function occurrenceFromMaster(master: CommunityEvent, dtstartMs: number): CommunityEvent {
-  const durationMs =
-    typeof master.dtendMs === "number" && typeof master.dtstartMs === "number"
-      ? master.dtendMs - master.dtstartMs
-      : undefined;
+  const durationMs = masterDurationMs(master);
   return {
     ...master,
     id: `${master.id}::${dtstartMs}`,
@@ -205,15 +202,29 @@ function applyOverride(
   override: CommunityEvent,
   recurrenceIdMs: number,
 ): CommunityEvent {
+  const dtstartMs = override.dtstartMs ?? recurrenceIdMs;
+  const inheritedDurationMs = masterDurationMs(master);
   return {
     ...master,
     id: `${master.id}::${recurrenceIdMs}::override`,
     summary: override.summary || master.summary,
     ...(override.description !== undefined ? { description: override.description } : {}),
     ...(override.location !== undefined ? { location: override.location } : {}),
-    dtstartMs: override.dtstartMs ?? recurrenceIdMs,
-    ...(typeof override.dtendMs === "number" ? { dtendMs: override.dtendMs } : {}),
+    dtstartMs,
+    ...(typeof override.dtendMs === "number"
+      ? { dtendMs: override.dtendMs }
+      : typeof inheritedDurationMs === "number"
+        ? { dtendMs: dtstartMs + inheritedDurationMs }
+        : {}),
     recurrenceIdMs,
     rrule: undefined,
   };
+}
+
+function masterDurationMs(master: CommunityEvent): number | undefined {
+  if (typeof master.dtendMs !== "number" || typeof master.dtstartMs !== "number") {
+    return undefined;
+  }
+  const durationMs = master.dtendMs - master.dtstartMs;
+  return Number.isFinite(durationMs) && durationMs >= 0 ? durationMs : undefined;
 }

--- a/chat/src/lib/xmpp/event-types.ts
+++ b/chat/src/lib/xmpp/event-types.ts
@@ -224,6 +224,7 @@ function parseRsvpItemId(itemId: string): { masterUid: string; localpart: string
 export function groupEventsWithRsvps(items: readonly CommunityEvent[]): CommunityEvent[] {
   const masters = new Map<string, CommunityEvent>();
   const rsvps = new Map<string, Map<string, Attendee>>();
+  const overrides: CommunityEvent[] = [];
 
   for (const item of items) {
     const parsed = parseRsvpItemId(item.id);
@@ -234,6 +235,10 @@ export function groupEventsWithRsvps(items: readonly CommunityEvent[]): Communit
         bucket.set(single.uri, single);
         rsvps.set(parsed.masterUid, bucket);
       }
+      continue;
+    }
+    if (typeof item.recurrenceIdMs === "number") {
+      overrides.push(item);
       continue;
     }
     masters.set(item.uid, item);
@@ -254,7 +259,7 @@ export function groupEventsWithRsvps(items: readonly CommunityEvent[]): Communit
       ...(attendees.length > 0 ? { attendees } : {}),
     });
   }
-  return out;
+  return [...out, ...overrides];
 }
 
 /** Sort events by upcoming-first, past events at the end newest-first. */

--- a/chat/src/services/community-events.ts
+++ b/chat/src/services/community-events.ts
@@ -4,11 +4,9 @@
  * sorts upcoming-first and exposes typed event + RRULE state to the
  * UI.
  *
- * Recurrence expansion (computing each occurrence date from a master
- * event + RRULE) is deferred for now — the UI renders the master
- * event with its RRULE summary ("Weekly on Fridays · 10 occurrences").
- * Per-instance overrides will come back via RECURRENCE-ID in a
- * follow-up.
+ * Recurrence expansion and RECURRENCE-ID overrides are derived from the
+ * xCal masters here so the UI can render concrete upcoming instances while
+ * edit/cancel actions still target the stored PubSub master item.
  */
 import { computed, ref, type Ref } from "vue";
 import {
@@ -22,6 +20,7 @@ import {
 import {
   expandInstances,
   groupEventsWithOverrides,
+  type CalendarMaster,
 } from "@/lib/xmpp/event-expansion";
 
 export function useCommunityEvents(
@@ -38,10 +37,14 @@ export function useCommunityEvents(
   const pageSize = options.pageSize ?? 200;
   let fetchRequestId = 0;
 
-  const sortedEvents = computed(() => {
+  const calendarItems = computed<CalendarMaster[]>(() => {
     const merged = groupEventsWithRsvps(events.value);
+    return groupEventsWithOverrides(merged);
+  });
+
+  const sortedEvents = computed(() => {
     const expanded: CommunityEvent[] = [];
-    for (const group of groupEventsWithOverrides(merged)) {
+    for (const group of calendarItems.value) {
       if (group.master.rrule) {
         expanded.push(...expandInstances(group));
       } else {
@@ -61,8 +64,7 @@ export function useCommunityEvents(
    * and to read the master's RRULE / EXDATEs.
    */
   function findMaster(uid: string): CommunityEvent | null {
-    const merged = groupEventsWithRsvps(events.value);
-    for (const group of groupEventsWithOverrides(merged)) {
+    for (const group of calendarItems.value) {
       if (group.master.uid === uid) return group.master;
     }
     return null;
@@ -250,6 +252,7 @@ export function useCommunityEvents(
 
   return {
     events: sortedEvents,
+    calendarItems,
     isLoading,
     isPosting,
     error,

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -2591,6 +2591,7 @@ export function useChatAppController(giphyApiKey: string) {
       socialFeed,
       stories,
       communityEvents,
+      communityJid,
       dmMessaging,
       xmppClient,
       notifySettings,

--- a/chat/tests/calendar-feed-url.test.ts
+++ b/chat/tests/calendar-feed-url.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+  calendarFeedEndpoint,
+  copyCalendarFeedUrlToClipboard,
+  isSameCalendarFeedRequestInput,
+  nextCalendarFeedCopyViewState,
+  type CalendarFeedFetch,
+} from "../src/lib/calendar-feed-url";
+
+describe("calendar feed URL helpers", () => {
+  test("builds the authenticated helper endpoint with the community JID", () => {
+    expect(calendarFeedEndpoint({
+      communityJid: "community.example.com",
+      serverBaseUrl: "https://server.example.com",
+      sessionId: "session-1",
+    })).toBe(
+      "https://server.example.com/api/calendar/community-feed-url?community_jid=community.example.com",
+    );
+  });
+
+  test("requests the feed URL with session credentials and copies it", async () => {
+    const feedUrl = "https://server.example.com/api/calendar/community/token/events.ics";
+    const fetchImpl = mock(async () => new Response(JSON.stringify({ url: feedUrl }))) as CalendarFeedFetch;
+    const copyText = mock(async () => {});
+
+    const result = await copyCalendarFeedUrlToClipboard({
+      communityJid: "community.example.com",
+      serverBaseUrl: "https://server.example.com",
+      sessionId: "session-1",
+    }, { fetch: fetchImpl, copyText });
+
+    expect(result).toEqual({ status: "copied", url: feedUrl });
+    expect(fetchImpl.mock.calls[0]?.[0]).toBe(
+      "https://server.example.com/api/calendar/community-feed-url?community_jid=community.example.com",
+    );
+    expect(fetchImpl.mock.calls[0]?.[1]).toEqual({
+      credentials: "include",
+      headers: {
+        "Accept": "application/json",
+        "X-Waddle-Session-Id": "session-1",
+      },
+    });
+    expect(copyText).toHaveBeenCalledWith(feedUrl);
+  });
+
+  test("compares feed request context including session changes", () => {
+    const base = {
+      communityJid: "community.example.com",
+      serverBaseUrl: "https://server.example.com",
+      sessionId: "session-1",
+    };
+
+    expect(isSameCalendarFeedRequestInput(base, { ...base })).toBe(true);
+    expect(isSameCalendarFeedRequestInput(base, {
+      ...base,
+      communityJid: "community.other.example.com",
+    })).toBe(false);
+    expect(isSameCalendarFeedRequestInput(base, {
+      ...base,
+      serverBaseUrl: "https://other.example.com",
+    })).toBe(false);
+    expect(isSameCalendarFeedRequestInput(base, {
+      ...base,
+      sessionId: "session-2",
+    })).toBe(false);
+  });
+
+  test("returns the fetched URL when clipboard copy fails", async () => {
+    const feedUrl = "https://server.example.com/api/calendar/community/token/events.ics";
+    const fetchImpl = mock(async () => new Response(JSON.stringify({ url: feedUrl }))) as CalendarFeedFetch;
+    const copyText = mock(async () => {
+      throw new Error("denied");
+    });
+
+    const result = await copyCalendarFeedUrlToClipboard({
+      communityJid: "community.example.com",
+      serverBaseUrl: "https://server.example.com",
+    }, { fetch: fetchImpl, copyText });
+
+    expect(result).toEqual({ status: "copy_failed", url: feedUrl });
+  });
+
+  test("does not attempt clipboard copy when the helper request fails", async () => {
+    const fetchImpl = mock(async () => new Response("nope", { status: 500 })) as CalendarFeedFetch;
+    const copyText = mock(async () => {});
+
+    const result = await copyCalendarFeedUrlToClipboard({
+      communityJid: "community.example.com",
+      serverBaseUrl: "https://server.example.com",
+    }, { fetch: fetchImpl, copyText });
+
+    expect(result).toEqual({ status: "request_failed" });
+    expect(copyText).not.toHaveBeenCalled();
+  });
+
+  test("copy view state clears stale fallback URLs on retry and context changes", () => {
+    const failed = nextCalendarFeedCopyViewState({
+      state: "loading",
+      fallbackUrl: null,
+      result: {
+        status: "copy_failed",
+        url: "https://server.example.com/api/calendar/community/token/events.ics",
+      },
+    });
+
+    expect(failed).toEqual({
+      state: "error",
+      fallbackUrl: "https://server.example.com/api/calendar/community/token/events.ics",
+    });
+    expect(nextCalendarFeedCopyViewState({
+      state: "idle",
+      fallbackUrl: failed.fallbackUrl,
+      startAttempt: true,
+    })).toEqual({ state: "loading", fallbackUrl: null });
+    expect(nextCalendarFeedCopyViewState({
+      state: "error",
+      fallbackUrl: failed.fallbackUrl,
+      contextChanged: true,
+    })).toEqual({ state: "idle", fallbackUrl: null });
+    expect(nextCalendarFeedCopyViewState({
+      state: "loading",
+      fallbackUrl: failed.fallbackUrl,
+      result: { status: "request_failed" },
+    })).toEqual({ state: "error", fallbackUrl: null });
+  });
+});

--- a/chat/tests/community-events.test.ts
+++ b/chat/tests/community-events.test.ts
@@ -118,6 +118,55 @@ describe("useCommunityEvents", () => {
     expect(attendees.find((a) => a.uri === "xmpp:bob@example.com")?.partstat).toBe("DECLINED");
   });
 
+  test("refresh preserves recurrence overrides while grouping sibling RSVP items", async () => {
+    const start = Date.now() + 86_400_000;
+    const recurrenceId = start + 7 * 86_400_000;
+    const exdate = start + 14 * 86_400_000;
+    const weekday = (["SU", "MO", "TU", "WE", "TH", "FR", "SA"] as const)[
+      new Date(start).getUTCDay()
+    ];
+    const client = makeClient([
+      {
+        id: "evt-series",
+        uid: "evt-series",
+        summary: "Friday Game Night",
+        dtstartMs: start,
+        dtendMs: start + 60 * 60 * 1000,
+        rrule: { freq: "WEEKLY", byDay: [weekday], count: 4 },
+        exdatesMs: [exdate],
+      },
+      {
+        id: "evt-series::override::1",
+        uid: "evt-series",
+        summary: "Special Round",
+        recurrenceIdMs: recurrenceId,
+        dtstartMs: recurrenceId + 60 * 60 * 1000,
+      },
+      {
+        id: "evt-series-rsvp-alice",
+        uid: "evt-series",
+        summary: "",
+        attendees: [{ uri: "xmpp:alice@example.com", partstat: "ACCEPTED" }],
+      },
+    ]);
+    const events = useCommunityEvents(ref<BrowserXmppClient | null>(client), {
+      communityJid: ref<string | null>(COMMUNITY),
+    });
+    await events.refresh();
+
+    expect(events.calendarItems.value.length).toBe(1);
+    const [series] = events.calendarItems.value;
+    expect(series?.master.uid).toBe("evt-series");
+    expect(series?.master.attendees?.[0]?.uri).toBe("xmpp:alice@example.com");
+    expect(series?.master.exdatesMs).toEqual([exdate]);
+    expect(series?.overrides.length).toBe(1);
+    expect(series?.overrides[0]?.summary).toBe("Special Round");
+    expect(series?.overrides[0]?.recurrenceIdMs).toBe(recurrenceId);
+    const expandedOverride = events.events.value.find((event) => event.recurrenceIdMs === recurrenceId);
+    expect(expandedOverride?.dtstartMs).toBe(recurrenceId + 60 * 60 * 1000);
+    expect(expandedOverride?.dtendMs).toBe(recurrenceId + 2 * 60 * 60 * 1000);
+  });
+
   test("rsvp publishes via wasm and optimistically folds a self-attendee in", async () => {
     const future = Date.now() + 86_400_000;
     const client = makeClient([

--- a/chat/tests/events-pane-calendar-feed.test.ts
+++ b/chat/tests/events-pane-calendar-feed.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { renderVueComponent } from "./helpers/render-vue-sfc";
+
+function props(overrides: Record<string, unknown> = {}) {
+  return {
+    events: [],
+    isLoading: false,
+    isPosting: false,
+    error: null,
+    canPost: false,
+    selfJid: null,
+    communityJid: "community.example.com",
+    serverBaseUrl: "https://server.example.com",
+    sessionId: "session-1",
+    findMaster: () => null,
+    ...overrides,
+  };
+}
+
+function calendarFeedButton(html: string): string {
+  const marker = "Copy feed URL";
+  const markerIndex = html.indexOf(marker);
+  if (markerIndex === -1) return "";
+  const start = html.lastIndexOf("<button", markerIndex);
+  const end = html.indexOf("</button>", markerIndex);
+  return html.slice(start, end + "</button>".length);
+}
+
+describe("EventsPane calendar feed control", () => {
+  test("renders an enabled copy button when feed context is available", async () => {
+    const html = await renderVueComponent(
+      "../src/components/community/EventsPane.vue",
+      props(),
+      import.meta.url,
+    );
+
+    expect(html).toContain("Copy feed URL");
+    expect(html).toContain('role="status"');
+    expect(calendarFeedButton(html)).not.toMatch(/\sdisabled(?:[=>\s])/);
+  });
+
+  test("keeps copy available while events are loading", async () => {
+    const html = await renderVueComponent(
+      "../src/components/community/EventsPane.vue",
+      props({ isLoading: true }),
+      import.meta.url,
+    );
+
+    expect(html).toContain("Copy feed URL");
+    expect(calendarFeedButton(html)).not.toMatch(/\sdisabled(?:[=>\s])/);
+  });
+
+  test("disables copy when feed context is missing", async () => {
+    const html = await renderVueComponent(
+      "../src/components/community/EventsPane.vue",
+      props({ communityJid: null }),
+      import.meta.url,
+    );
+
+    expect(html).toContain("Copy feed URL");
+    expect(calendarFeedButton(html)).toMatch(/\sdisabled(?:[=>\s])/);
+  });
+});

--- a/server/crates/waddle-server/src/server/health.rs
+++ b/server/crates/waddle-server/src/server/health.rs
@@ -59,6 +59,7 @@ pub(crate) fn build_cors(origins: Option<&str>) -> CorsLayer {
                         HeaderName::from_static("traceparent"),
                         HeaderName::from_static("tracestate"),
                         HeaderName::from_static("baggage"),
+                        HeaderName::from_static("x-waddle-session-id"),
                     ])
                     .allow_credentials(true)
             }

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -230,6 +230,12 @@ pub(crate) async fn create_router(deps: RouterDeps) -> Result<Router> {
         routes::extension_webhooks::router(Arc::clone(&websocket_state));
     let livekit_webhook_router = routes::livekit_webhook::router(Arc::clone(&websocket_state));
     let websocket_router = routes::websocket::router(websocket_state.clone());
+    let calendar_feed_router =
+        routes::calendar_feed::router(Arc::new(routes::calendar_feed::CalendarFeedState::new(
+            Arc::clone(&auth_state),
+            Arc::clone(&websocket_state.deps.protocol.pubsub_storage),
+            server_config.session_key.as_bytes(),
+        )));
 
     // Upload router for XEP-0363 HTTP File Upload
     let upload_state = Arc::new(UploadState::new(state.clone()));
@@ -268,7 +274,8 @@ pub(crate) async fn create_router(deps: RouterDeps) -> Result<Router> {
         .merge(xmpp_oauth_router)
         .merge(auth_page_router)
         .merge(extension_webhooks_router)
-        .merge(livekit_webhook_router);
+        .merge(livekit_webhook_router)
+        .merge(calendar_feed_router);
 
     // Test-only profile-publish route. Only mounted when:
     // 1. The fixed-account flag is on (the test harness opt-in).

--- a/server/crates/waddle-server/src/server/routes/calendar_feed.rs
+++ b/server/crates/waddle-server/src/server/routes/calendar_feed.rs
@@ -1,0 +1,1176 @@
+//! Read-only iCalendar export for community xCal events.
+//!
+//! Waddle's source of truth stays the XMPP PubSub xCal node. This HTTP
+//! surface exists only so external calendar clients can subscribe to a stable
+//! `text/calendar` URL.
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path, Query, State},
+    http::{header, HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    routing::get,
+    Json, Router,
+};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use chrono::{DateTime, Utc};
+use hmac::{Hmac, KeyInit, Mac};
+use jid::BareJid;
+use minidom::Element;
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use tracing::{debug, warn};
+use waddle_xmpp::pubsub::{AccessModel, PubSubStorage, StoredItem};
+use waddle_xmpp_core::xcal::{CalendarItem, Rrule, RruleEnd, VEvent};
+
+use super::auth::AuthState;
+
+type HmacSha256 = Hmac<Sha256>;
+
+const TOKEN_VERSION: &str = "v1";
+const TOKEN_CONTEXT: &[u8] = b"waddle:calendar-feed:v1";
+const ICS_CONTENT_TYPE: &str = "text/calendar; charset=utf-8";
+const ICS_PRODUCT_ID: &str = "-//Waddle//Community xCal Events//EN";
+const MAX_CONTENT_LINE_BYTES: usize = 75;
+const CALENDAR_FEED_MAX_ITEMS: usize = 1_000;
+const CALENDAR_FEED_RAW_ITEM_SCAN_LIMIT: u32 = 10_000;
+const SESSION_ID_HEADER: &str = "x-waddle-session-id";
+const NO_STORE: &str = "no-store";
+
+#[derive(Clone)]
+pub struct CalendarFeedState {
+    auth_state: Arc<AuthState>,
+    pubsub_storage: Arc<dyn PubSubStorage>,
+    token_key: Arc<[u8]>,
+}
+
+impl CalendarFeedState {
+    pub fn new(
+        auth_state: Arc<AuthState>,
+        pubsub_storage: Arc<dyn PubSubStorage>,
+        token_key: impl AsRef<[u8]>,
+    ) -> Self {
+        Self {
+            auth_state,
+            pubsub_storage,
+            token_key: Arc::from(token_key.as_ref()),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct FeedUrlQuery {
+    community_jid: String,
+}
+
+#[derive(Debug, Serialize)]
+struct FeedUrlResponse {
+    url: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorResponse {
+    error: &'static str,
+    message: String,
+}
+
+struct StoredCalendarItem {
+    item: CalendarItem,
+    published_at: DateTime<Utc>,
+}
+
+pub fn router(state: Arc<CalendarFeedState>) -> Router {
+    Router::new()
+        .route(
+            "/api/calendar/community-feed-url",
+            get(community_feed_url_handler),
+        )
+        .route(
+            "/api/calendar/community/{token}/events.ics",
+            get(community_feed_handler),
+        )
+        .with_state(state)
+}
+
+async fn community_feed_url_handler(
+    State(state): State<Arc<CalendarFeedState>>,
+    Query(query): Query<FeedUrlQuery>,
+    headers: HeaderMap,
+) -> Response {
+    let Some(session_id) =
+        extract_session_header(&headers).or_else(|| extract_session_cookie(&headers))
+    else {
+        return json_error(
+            StatusCode::UNAUTHORIZED,
+            "missing_session",
+            "missing session cookie",
+        );
+    };
+    match state
+        .auth_state
+        .session_manager
+        .validate_session(&session_id)
+        .await
+    {
+        Ok(_) => {}
+        Err(error) => {
+            return json_error(
+                StatusCode::UNAUTHORIZED,
+                "invalid_session",
+                error.to_string(),
+            );
+        }
+    }
+
+    let requested = match query.community_jid.parse::<BareJid>() {
+        Ok(jid) => jid,
+        Err(error) => {
+            return json_error(StatusCode::BAD_REQUEST, "invalid_jid", error.to_string());
+        }
+    };
+    let expected = match expected_community_jid(&state.auth_state.xmpp_domain) {
+        Ok(jid) => jid,
+        Err(error) => {
+            return json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "calendar_feed_unavailable",
+                error,
+            );
+        }
+    };
+    if requested != expected {
+        return json_error(
+            StatusCode::FORBIDDEN,
+            "unsupported_community",
+            "calendar feeds are only available for this deployment's community service",
+        );
+    }
+
+    let token = sign_feed_token(&state.token_key, &requested);
+    let url = format!(
+        "{}/api/calendar/community/{}/events.ics",
+        state.auth_state.base_url.trim_end_matches('/'),
+        token,
+    );
+    (
+        StatusCode::OK,
+        [(header::CACHE_CONTROL, NO_STORE)],
+        Json(FeedUrlResponse { url }),
+    )
+        .into_response()
+}
+
+async fn community_feed_handler(
+    State(state): State<Arc<CalendarFeedState>>,
+    Path(token): Path<String>,
+) -> Response {
+    let community_jid = match verify_feed_token(&state.token_key, &token) {
+        Ok(jid) => jid,
+        Err(error) => {
+            debug!(error = %error, "Rejected invalid calendar feed token");
+            return text_response(StatusCode::NOT_FOUND, "Not found");
+        }
+    };
+    let expected = match expected_community_jid(&state.auth_state.xmpp_domain) {
+        Ok(jid) => jid,
+        Err(error) => {
+            warn!(error = %error, "Calendar feed unavailable: invalid community service JID");
+            return text_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Calendar feed unavailable",
+            );
+        }
+    };
+    if community_jid != expected {
+        return text_response(StatusCode::NOT_FOUND, "Not found");
+    }
+
+    let items = match load_calendar_items(&state, &community_jid).await {
+        Ok(Some(items)) => items,
+        Ok(None) => {
+            return text_response(StatusCode::NOT_FOUND, "Not found");
+        }
+        Err(error) => {
+            warn!(error = %error, "Failed to load calendar feed items");
+            return text_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Calendar feed unavailable",
+            );
+        }
+    };
+    let body = build_icalendar(&items);
+    (
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, ICS_CONTENT_TYPE),
+            (header::CACHE_CONTROL, NO_STORE),
+        ],
+        body,
+    )
+        .into_response()
+}
+
+async fn load_calendar_items(
+    state: &CalendarFeedState,
+    community_jid: &BareJid,
+) -> Result<Option<Vec<StoredCalendarItem>>, waddle_xmpp::XmppError> {
+    let node = waddle_xmpp_core::xcal::PUBSUB_NODE_EVENTS;
+    let Some(node_meta) = state.pubsub_storage.get_node(community_jid, node).await? else {
+        return Ok(Some(Vec::new()));
+    };
+    if node_meta.config.access_model != AccessModel::Open {
+        warn!(
+            community = %community_jid,
+            node,
+            access_model = %node_meta.config.access_model,
+            "Calendar feed disabled for non-open PubSub node"
+        );
+        return Ok(None);
+    }
+    let stored_items = state
+        .pubsub_storage
+        .get_items(
+            community_jid,
+            node,
+            Some(CALENDAR_FEED_RAW_ITEM_SCAN_LIMIT),
+            &[],
+        )
+        .await?;
+    let mut items = parse_stored_calendar_items(&stored_items);
+    if items.len() > CALENDAR_FEED_MAX_ITEMS {
+        let drop_count = items.len() - CALENDAR_FEED_MAX_ITEMS;
+        items.drain(0..drop_count);
+    }
+    Ok(Some(items))
+}
+
+fn parse_stored_calendar_items(stored_items: &[StoredItem]) -> Vec<StoredCalendarItem> {
+    let mut items = Vec::new();
+    for stored in stored_items {
+        let Some(payload_xml) = stored.payload_xml.as_deref() else {
+            continue;
+        };
+        let Ok(payload) = payload_xml.parse::<Element>() else {
+            continue;
+        };
+        let Some(item) = waddle_xmpp_core::xcal::parse_vcalendar_item(&stored.id, &payload) else {
+            continue;
+        };
+        if is_rsvp_calendar_item(&stored.id, &item) {
+            continue;
+        }
+        if item.master.dtstart.is_none()
+            && item
+                .overrides
+                .iter()
+                .all(|event| event.dtstart.is_none() && event.recurrence_id.is_none())
+        {
+            continue;
+        }
+        items.push(StoredCalendarItem {
+            item,
+            published_at: stored.published_at,
+        });
+    }
+    items
+}
+
+fn is_rsvp_calendar_item(item_id: &str, item: &CalendarItem) -> bool {
+    let Some(master_uid) = parse_rsvp_master_uid(item_id) else {
+        return false;
+    };
+    item.master.uid == master_uid
+        && item.master.dtstart.is_none()
+        && item.master.recurrence_id.is_none()
+        && !item.master.attendees.is_empty()
+}
+
+fn parse_rsvp_master_uid(item_id: &str) -> Option<&str> {
+    let (master_uid, localpart) = item_id.rsplit_once("-rsvp-")?;
+    if master_uid.is_empty() || localpart.is_empty() {
+        return None;
+    }
+    Some(master_uid)
+}
+
+fn build_icalendar(items: &[StoredCalendarItem]) -> String {
+    let mut lines = vec![
+        "BEGIN:VCALENDAR".to_string(),
+        "VERSION:2.0".to_string(),
+        property("PRODID", ICS_PRODUCT_ID),
+        "CALSCALE:GREGORIAN".to_string(),
+    ];
+
+    for stored in items {
+        lines.extend(event_lines(&stored.item.master, None, stored.published_at));
+        for override_event in &stored.item.overrides {
+            lines.extend(event_lines(
+                override_event,
+                Some(&stored.item.master),
+                stored.published_at,
+            ));
+        }
+    }
+
+    lines.push("END:VCALENDAR".to_string());
+    format!(
+        "{}\r\n",
+        lines
+            .iter()
+            .map(|line| fold_content_line(line))
+            .collect::<Vec<_>>()
+            .join("\r\n")
+    )
+}
+
+fn event_lines(
+    event: &VEvent,
+    master: Option<&VEvent>,
+    published_at: DateTime<Utc>,
+) -> Vec<String> {
+    let Some(dtstart) = event.dtstart.or(event.recurrence_id) else {
+        return Vec::new();
+    };
+    let dtstamp = event
+        .dtstamp
+        .or_else(|| master.and_then(|event| event.dtstamp))
+        .unwrap_or(published_at);
+    let dtend = event
+        .dtend
+        .or_else(|| master.and_then(|master| inherited_end(master, dtstart)));
+    let summary = if event.summary.is_empty() {
+        master.map(|event| event.summary.as_str()).unwrap_or("")
+    } else {
+        event.summary.as_str()
+    };
+    let description = event
+        .description
+        .as_deref()
+        .or_else(|| master.and_then(|event| event.description.as_deref()));
+    let location = event
+        .location
+        .as_deref()
+        .or_else(|| master.and_then(|event| event.location.as_deref()));
+    let organizer = event
+        .organizer
+        .as_deref()
+        .or_else(|| master.and_then(|event| event.organizer.as_deref()));
+
+    let mut lines = vec![
+        "BEGIN:VEVENT".to_string(),
+        property("UID", &event.uid),
+        date_property("DTSTAMP", dtstamp),
+        date_property("DTSTART", dtstart),
+    ];
+    if let Some(dtend) = dtend {
+        lines.push(date_property("DTEND", dtend));
+    }
+    if let Some(recurrence_id) = event.recurrence_id {
+        lines.push(date_property("RECURRENCE-ID", recurrence_id));
+    }
+    lines.push(property("SUMMARY", summary));
+    if let Some(description) = description {
+        lines.push(property("DESCRIPTION", description));
+    }
+    if let Some(location) = location {
+        lines.push(property("LOCATION", location));
+    }
+    if let Some(organizer) = organizer {
+        lines.push(property("ORGANIZER", organizer));
+    }
+    if let Some(rrule) = event.rrule.as_ref() {
+        lines.push(rrule_property(rrule));
+    }
+    if !event.exdates.is_empty() {
+        let mut exdates = event.exdates.clone();
+        exdates.sort();
+        lines.push(format!(
+            "EXDATE:{}",
+            exdates
+                .into_iter()
+                .map(format_utc_date)
+                .collect::<Vec<_>>()
+                .join(",")
+        ));
+    }
+    lines.push("END:VEVENT".to_string());
+    lines
+}
+
+fn inherited_end(master: &VEvent, dtstart: DateTime<Utc>) -> Option<DateTime<Utc>> {
+    let master_start = master.dtstart?;
+    let master_end = master.dtend?;
+    let duration = master_end.signed_duration_since(master_start);
+    if duration.num_milliseconds() < 0 {
+        return None;
+    }
+    dtstart.checked_add_signed(duration)
+}
+
+fn property(name: &str, value: &str) -> String {
+    format!("{name}:{}", escape_text(value))
+}
+
+fn date_property(name: &str, value: DateTime<Utc>) -> String {
+    format!("{name}:{}", format_utc_date(value))
+}
+
+fn rrule_property(rrule: &Rrule) -> String {
+    let mut parts = vec![format!("FREQ={}", rrule.freq.as_str())];
+    if let Some(interval) = rrule.interval {
+        parts.push(format!("INTERVAL={interval}"));
+    }
+    if !rrule.by_day.is_empty() {
+        parts.push(format!(
+            "BYDAY={}",
+            rrule
+                .by_day
+                .iter()
+                .map(|day| day.as_str())
+                .collect::<Vec<_>>()
+                .join(",")
+        ));
+    }
+    if !rrule.by_month_day.is_empty() {
+        parts.push(format!(
+            "BYMONTHDAY={}",
+            rrule
+                .by_month_day
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(",")
+        ));
+    }
+    match rrule.end {
+        Some(RruleEnd::Count(count)) => parts.push(format!("COUNT={count}")),
+        Some(RruleEnd::Until(until)) => parts.push(format!("UNTIL={}", format_utc_date(until))),
+        None => {}
+    }
+    format!("RRULE:{}", parts.join(";"))
+}
+
+fn escape_text(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    let mut chars = value.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '\r' => {
+                if chars.peek() == Some(&'\n') {
+                    chars.next();
+                }
+                out.push_str("\\n");
+            }
+            '\n' => out.push_str("\\n"),
+            ';' => out.push_str("\\;"),
+            ',' => out.push_str("\\,"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+fn format_utc_date(value: DateTime<Utc>) -> String {
+    value.format("%Y%m%dT%H%M%SZ").to_string()
+}
+
+fn fold_content_line(line: &str) -> String {
+    let mut out = String::new();
+    let mut current_bytes = 0;
+    for ch in line.chars() {
+        let char_bytes = ch.len_utf8();
+        if current_bytes > 0 && current_bytes + char_bytes > MAX_CONTENT_LINE_BYTES {
+            out.push_str("\r\n ");
+            current_bytes = 1;
+        }
+        out.push(ch);
+        current_bytes += char_bytes;
+    }
+    out
+}
+
+fn sign_feed_token(key: &[u8], community_jid: &BareJid) -> String {
+    let community = community_jid.to_string();
+    let community_b64 = URL_SAFE_NO_PAD.encode(community.as_bytes());
+    let signature = sign_token_payload(key, community.as_bytes());
+    format!(
+        "{TOKEN_VERSION}.{community_b64}.{}",
+        URL_SAFE_NO_PAD.encode(signature)
+    )
+}
+
+fn verify_feed_token(key: &[u8], token: &str) -> Result<BareJid, String> {
+    let mut parts = token.split('.');
+    let version = parts.next().ok_or_else(|| "missing version".to_string())?;
+    let community_b64 = parts.next().ok_or_else(|| "missing payload".to_string())?;
+    let signature_b64 = parts
+        .next()
+        .ok_or_else(|| "missing signature".to_string())?;
+    if parts.next().is_some() {
+        return Err("too many token parts".to_string());
+    }
+    if version != TOKEN_VERSION {
+        return Err("unsupported token version".to_string());
+    }
+
+    let community_bytes = URL_SAFE_NO_PAD
+        .decode(community_b64)
+        .map_err(|error| format!("invalid payload encoding: {error}"))?;
+    let signature = URL_SAFE_NO_PAD
+        .decode(signature_b64)
+        .map_err(|error| format!("invalid signature encoding: {error}"))?;
+    verify_token_signature(key, &community_bytes, &signature)?;
+    let community = String::from_utf8(community_bytes)
+        .map_err(|error| format!("invalid community utf8: {error}"))?;
+    community
+        .parse::<BareJid>()
+        .map_err(|error| format!("invalid community jid: {error}"))
+}
+
+fn sign_token_payload(key: &[u8], community: &[u8]) -> Vec<u8> {
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC supports any key");
+    mac.update(TOKEN_CONTEXT);
+    mac.update(&[0]);
+    mac.update(community);
+    mac.finalize().into_bytes().to_vec()
+}
+
+fn verify_token_signature(key: &[u8], community: &[u8], signature: &[u8]) -> Result<(), String> {
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC supports any key");
+    mac.update(TOKEN_CONTEXT);
+    mac.update(&[0]);
+    mac.update(community);
+    mac.verify_slice(signature)
+        .map_err(|_| "invalid signature".to_string())
+}
+
+fn expected_community_jid(xmpp_domain: &str) -> Result<BareJid, String> {
+    format!("community.{xmpp_domain}")
+        .parse::<BareJid>()
+        .map_err(|error| format!("invalid community service JID: {error}"))
+}
+
+fn extract_session_cookie(headers: &HeaderMap) -> Option<String> {
+    let cookie_header = headers.get(header::COOKIE)?.to_str().ok()?;
+    for pair in cookie_header.split(';') {
+        let trimmed = pair.trim();
+        let Some((name, value)) = trimmed.split_once('=') else {
+            continue;
+        };
+        if name == "waddle_session" && !value.is_empty() {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+fn extract_session_header(headers: &HeaderMap) -> Option<String> {
+    let session_id = headers.get(SESSION_ID_HEADER)?.to_str().ok()?.trim();
+    if session_id.is_empty() {
+        return None;
+    }
+    Some(session_id.to_string())
+}
+
+fn json_error(status: StatusCode, error: &'static str, message: impl Into<String>) -> Response {
+    (
+        status,
+        [(header::CACHE_CONTROL, NO_STORE)],
+        Json(ErrorResponse {
+            error,
+            message: message.into(),
+        }),
+    )
+        .into_response()
+}
+
+fn text_response(status: StatusCode, body: &'static str) -> Response {
+    (
+        status,
+        [
+            (header::CONTENT_TYPE, "text/plain; charset=utf-8"),
+            (header::CACHE_CONTROL, NO_STORE),
+        ],
+        body,
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::Session;
+    use crate::config::ServerConfig;
+    use crate::db::{DatabaseConfig, DatabasePool, MigrationRunner, PoolConfig};
+    use crate::server::AppState;
+    use axum::body::Body;
+    use axum::http::Request;
+    use chrono::TimeZone;
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+    use waddle_xmpp::pubsub::{InMemoryPubSubStorage, NodeConfig, PubSubItem};
+    use waddle_xmpp_core::xcal::{Freq, Rrule, Weekday};
+
+    fn ts(y: i32, mo: u32, d: u32, h: u32, mi: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(y, mo, d, h, mi, 0)
+            .single()
+            .expect("valid timestamp")
+    }
+
+    async fn test_auth_state() -> Arc<AuthState> {
+        let config = DatabaseConfig::default();
+        let pool_config = PoolConfig;
+        let db_pool = DatabasePool::new(config, pool_config).await.unwrap();
+        MigrationRunner::global()
+            .run(db_pool.global())
+            .await
+            .unwrap();
+        let mut server_config = ServerConfig::test_homeserver();
+        server_config.base_url = "https://server.example.com".to_string();
+        Arc::new(AuthState::new(
+            Arc::new(AppState::new(Arc::new(db_pool))),
+            &server_config,
+            Some(b"test-session-key"),
+        ))
+    }
+
+    #[test]
+    fn feed_token_round_trips_and_rejects_tampering() {
+        let community: BareJid = "community.localhost".parse().unwrap();
+        let token = sign_feed_token(b"secret", &community);
+        assert_eq!(verify_feed_token(b"secret", &token).unwrap(), community);
+
+        let mut tampered = token.clone();
+        tampered.push('x');
+        assert!(verify_feed_token(b"secret", &tampered).is_err());
+        assert!(verify_feed_token(b"other-secret", &token).is_err());
+    }
+
+    #[test]
+    fn icalendar_projection_preserves_recurrence_and_omits_attendees() {
+        let item = CalendarItem::new(
+            VEvent::new("evt-series", "Friday Game Night")
+                .with_dtstamp(ts(2026, 6, 1, 12, 0))
+                .with_dtstart(ts(2026, 6, 5, 19, 0))
+                .with_dtend(ts(2026, 6, 5, 22, 0))
+                .with_description("Bring snacks, drinks; and games\nSecond line")
+                .with_location("HQ, Room A")
+                .with_organizer("xmpp:alice@example.com")
+                .with_rrule(
+                    Rrule::new(Freq::Weekly)
+                        .with_interval(2)
+                        .with_by_day([Weekday::Friday])
+                        .with_count(4),
+                )
+                .with_exdates([ts(2026, 6, 19, 19, 0), ts(2026, 6, 12, 19, 0)])
+                .add_attendee(waddle_xmpp_core::xcal::Attendee::new(
+                    "xmpp:bob@example.com",
+                    waddle_xmpp_core::xcal::PartStat::Accepted,
+                )),
+        )
+        .add_override(
+            VEvent::new("evt-series", "")
+                .with_recurrence_id(ts(2026, 6, 12, 19, 0))
+                .with_dtstart(ts(2026, 6, 12, 20, 0)),
+        );
+
+        let ics = build_icalendar(&[StoredCalendarItem {
+            item,
+            published_at: ts(2026, 6, 1, 13, 0),
+        }]);
+
+        assert!(ics.starts_with("BEGIN:VCALENDAR\r\nVERSION:2.0\r\n"));
+        assert!(!ics.contains("METHOD:"));
+        assert_eq!(ics.matches("BEGIN:VEVENT").count(), 2);
+        assert!(ics.contains("UID:evt-series\r\n"));
+        assert!(ics.contains("RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=FR;COUNT=4\r\n"));
+        assert!(ics.contains("EXDATE:20260612T190000Z,20260619T190000Z\r\n"));
+        assert!(ics.contains("RECURRENCE-ID:20260612T190000Z\r\n"));
+        assert!(ics.contains("DTSTART:20260612T200000Z\r\n"));
+        assert!(ics.contains("DESCRIPTION:Bring snacks\\, drinks\\; and games\\nSecond line\r\n"));
+        assert!(!ics.contains("ATTENDEE"));
+        assert!(!ics.contains("bob@example.com"));
+        for line in ics.trim_end().split("\r\n") {
+            assert!(line.len() <= MAX_CONTENT_LINE_BYTES);
+        }
+    }
+
+    #[tokio::test]
+    async fn signed_feed_route_serves_pubsub_xcal_as_ics() {
+        let auth_state = test_auth_state().await;
+        let storage: Arc<dyn PubSubStorage> = Arc::new(InMemoryPubSubStorage::new());
+        let community = expected_community_jid(&auth_state.xmpp_domain).unwrap();
+        storage
+            .get_or_create_node(&community, waddle_xmpp_core::xcal::PUBSUB_NODE_EVENTS)
+            .await
+            .unwrap();
+        storage
+            .update_node_config(
+                &community,
+                waddle_xmpp_core::xcal::PUBSUB_NODE_EVENTS,
+                &NodeConfig::spaces_public(),
+            )
+            .await
+            .unwrap();
+        let payload = waddle_xmpp_core::xcal::build_vcalendar_with_event(
+            &VEvent::new("evt-1", "Game Night")
+                .with_dtstamp(ts(2026, 6, 1, 12, 0))
+                .with_dtstart(ts(2026, 6, 5, 19, 0)),
+        );
+        storage
+            .publish_item(
+                &community,
+                waddle_xmpp_core::xcal::PUBSUB_NODE_EVENTS,
+                &PubSubItem {
+                    id: Some("evt-1".to_string()),
+                    publisher: None,
+                    payload: Some(payload),
+                },
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+
+        let state = Arc::new(CalendarFeedState::new(
+            auth_state.clone(),
+            storage,
+            b"calendar-test-key",
+        ));
+        let token = sign_feed_token(b"calendar-test-key", &community);
+        let response = router(state)
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/calendar/community/{token}/events.ics"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE).unwrap(),
+            ICS_CONTENT_TYPE,
+        );
+        assert_eq!(
+            response.headers().get(header::CACHE_CONTROL).unwrap(),
+            NO_STORE,
+        );
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let ics = String::from_utf8(body.to_vec()).unwrap();
+        assert!(ics.contains("SUMMARY:Game Night\r\n"));
+        assert!(ics.contains("DTSTART:20260605T190000Z\r\n"));
+    }
+
+    #[tokio::test]
+    async fn signed_feed_route_refuses_non_open_pubsub_node() {
+        let auth_state = test_auth_state().await;
+        let storage: Arc<dyn PubSubStorage> = Arc::new(InMemoryPubSubStorage::new());
+        let community = expected_community_jid(&auth_state.xmpp_domain).unwrap();
+        storage
+            .get_or_create_node(&community, waddle_xmpp_core::xcal::PUBSUB_NODE_EVENTS)
+            .await
+            .unwrap();
+        let mut config = NodeConfig::spaces_public();
+        config.access_model = AccessModel::Whitelist;
+        storage
+            .update_node_config(
+                &community,
+                waddle_xmpp_core::xcal::PUBSUB_NODE_EVENTS,
+                &config,
+            )
+            .await
+            .unwrap();
+
+        let state = Arc::new(CalendarFeedState::new(
+            auth_state.clone(),
+            storage,
+            b"calendar-test-key",
+        ));
+        let token = sign_feed_token(b"calendar-test-key", &community);
+        let response = router(state)
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/calendar/community/{token}/events.ics"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn signed_feed_route_caps_pubsub_items() {
+        let auth_state = test_auth_state().await;
+        let storage: Arc<dyn PubSubStorage> = Arc::new(InMemoryPubSubStorage::new());
+        let community = expected_community_jid(&auth_state.xmpp_domain).unwrap();
+        storage
+            .get_or_create_node(&community, waddle_xmpp_core::xcal::PUBSUB_NODE_EVENTS)
+            .await
+            .unwrap();
+        storage
+            .update_node_config(
+                &community,
+                waddle_xmpp_core::xcal::PUBSUB_NODE_EVENTS,
+                &NodeConfig::spaces_public(),
+            )
+            .await
+            .unwrap();
+
+        for index in 0..=CALENDAR_FEED_MAX_ITEMS {
+            let summary = if index == 0 {
+                "Oldest Marker".to_string()
+            } else if index == CALENDAR_FEED_MAX_ITEMS {
+                "Newest Marker".to_string()
+            } else {
+                format!("Event {index}")
+            };
+            let id = format!("evt-{index}");
+            let payload = waddle_xmpp_core::xcal::build_vcalendar_with_event(
+                &VEvent::new(&id, &summary).with_dtstart(ts(2026, 6, 5, 19, 0)),
+            );
+            storage
+                .publish_item(
+                    &community,
+                    waddle_xmpp_core::xcal::PUBSUB_NODE_EVENTS,
+                    &PubSubItem {
+                        id: Some(id),
+                        publisher: None,
+                        payload: Some(payload),
+                    },
+                    None,
+                    false,
+                )
+                .await
+                .unwrap();
+        }
+
+        let state = Arc::new(CalendarFeedState::new(
+            auth_state.clone(),
+            storage,
+            b"calendar-test-key",
+        ));
+        let token = sign_feed_token(b"calendar-test-key", &community);
+        let response = router(state)
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/calendar/community/{token}/events.ics"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let ics = String::from_utf8(body.to_vec()).unwrap();
+        assert!(!ics.contains("SUMMARY:Oldest Marker\r\n"));
+        assert!(ics.contains("SUMMARY:Newest Marker\r\n"));
+    }
+
+    #[tokio::test]
+    async fn signed_feed_route_caps_after_filtering_rsvp_items() {
+        let auth_state = test_auth_state().await;
+        let storage: Arc<dyn PubSubStorage> = Arc::new(InMemoryPubSubStorage::new());
+        let community = expected_community_jid(&auth_state.xmpp_domain).unwrap();
+        storage
+            .get_or_create_node(&community, waddle_xmpp_core::xcal::PUBSUB_NODE_EVENTS)
+            .await
+            .unwrap();
+        storage
+            .update_node_config(
+                &community,
+                waddle_xmpp_core::xcal::PUBSUB_NODE_EVENTS,
+                &NodeConfig::spaces_public(),
+            )
+            .await
+            .unwrap();
+
+        let master_uid = "evt-rsvp-heavy";
+        let master_payload = waddle_xmpp_core::xcal::build_vcalendar_with_event(
+            &VEvent::new(master_uid, "RSVP Heavy Event").with_dtstart(ts(2026, 6, 5, 19, 0)),
+        );
+        storage
+            .publish_item(
+                &community,
+                waddle_xmpp_core::xcal::PUBSUB_NODE_EVENTS,
+                &PubSubItem {
+                    id: Some(master_uid.to_string()),
+                    publisher: None,
+                    payload: Some(master_payload),
+                },
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+
+        for index in 0..CALENDAR_FEED_MAX_ITEMS {
+            let rsvp_payload = waddle_xmpp_core::xcal::build_vcalendar_with_event(
+                &VEvent::new(master_uid, "").add_attendee(waddle_xmpp_core::xcal::Attendee::new(
+                    format!("xmpp:user{index}@example.com"),
+                    waddle_xmpp_core::xcal::PartStat::Accepted,
+                )),
+            );
+            storage
+                .publish_item(
+                    &community,
+                    waddle_xmpp_core::xcal::PUBSUB_NODE_EVENTS,
+                    &PubSubItem {
+                        id: Some(format!("{master_uid}-rsvp-user-{index}")),
+                        publisher: None,
+                        payload: Some(rsvp_payload),
+                    },
+                    None,
+                    false,
+                )
+                .await
+                .unwrap();
+        }
+
+        let state = Arc::new(CalendarFeedState::new(
+            auth_state.clone(),
+            storage,
+            b"calendar-test-key",
+        ));
+        let token = sign_feed_token(b"calendar-test-key", &community);
+        let response = router(state)
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/calendar/community/{token}/events.ics"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let ics = String::from_utf8(body.to_vec()).unwrap();
+        assert!(ics.contains("SUMMARY:RSVP Heavy Event\r\n"));
+        assert!(!ics.contains("user999@example.com"));
+    }
+
+    #[tokio::test]
+    async fn signed_feed_route_honors_raw_scan_bound() {
+        let auth_state = test_auth_state().await;
+        let storage: Arc<dyn PubSubStorage> = Arc::new(InMemoryPubSubStorage::new());
+        let community = expected_community_jid(&auth_state.xmpp_domain).unwrap();
+        storage
+            .get_or_create_node(&community, waddle_xmpp_core::xcal::PUBSUB_NODE_EVENTS)
+            .await
+            .unwrap();
+        storage
+            .update_node_config(
+                &community,
+                waddle_xmpp_core::xcal::PUBSUB_NODE_EVENTS,
+                &NodeConfig::spaces_public(),
+            )
+            .await
+            .unwrap();
+
+        let master_uid = "evt-outside-raw-scan";
+        let master_payload = waddle_xmpp_core::xcal::build_vcalendar_with_event(
+            &VEvent::new(master_uid, "Outside Raw Scan").with_dtstart(ts(2026, 6, 5, 19, 0)),
+        );
+        storage
+            .publish_item(
+                &community,
+                waddle_xmpp_core::xcal::PUBSUB_NODE_EVENTS,
+                &PubSubItem {
+                    id: Some(master_uid.to_string()),
+                    publisher: None,
+                    payload: Some(master_payload),
+                },
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+
+        for index in 0..CALENDAR_FEED_RAW_ITEM_SCAN_LIMIT {
+            let rsvp_payload = waddle_xmpp_core::xcal::build_vcalendar_with_event(
+                &VEvent::new(master_uid, "").add_attendee(waddle_xmpp_core::xcal::Attendee::new(
+                    format!("xmpp:scan-user{index}@example.com"),
+                    waddle_xmpp_core::xcal::PartStat::Accepted,
+                )),
+            );
+            storage
+                .publish_item(
+                    &community,
+                    waddle_xmpp_core::xcal::PUBSUB_NODE_EVENTS,
+                    &PubSubItem {
+                        id: Some(format!("{master_uid}-rsvp-scan-user-{index}")),
+                        publisher: None,
+                        payload: Some(rsvp_payload),
+                    },
+                    None,
+                    false,
+                )
+                .await
+                .unwrap();
+        }
+
+        let state = Arc::new(CalendarFeedState::new(
+            auth_state.clone(),
+            storage,
+            b"calendar-test-key",
+        ));
+        let token = sign_feed_token(b"calendar-test-key", &community);
+        let response = router(state)
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/calendar/community/{token}/events.ics"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let ics = String::from_utf8(body.to_vec()).unwrap();
+        assert!(!ics.contains("SUMMARY:Outside Raw Scan\r\n"));
+        assert!(!ics.contains("scan-user9999@example.com"));
+    }
+
+    #[tokio::test]
+    async fn signed_feed_route_keeps_master_item_ids_containing_rsvp_separator() {
+        let auth_state = test_auth_state().await;
+        let storage: Arc<dyn PubSubStorage> = Arc::new(InMemoryPubSubStorage::new());
+        let community = expected_community_jid(&auth_state.xmpp_domain).unwrap();
+        storage
+            .get_or_create_node(&community, waddle_xmpp_core::xcal::PUBSUB_NODE_EVENTS)
+            .await
+            .unwrap();
+        storage
+            .update_node_config(
+                &community,
+                waddle_xmpp_core::xcal::PUBSUB_NODE_EVENTS,
+                &NodeConfig::spaces_public(),
+            )
+            .await
+            .unwrap();
+        let payload = waddle_xmpp_core::xcal::build_vcalendar_with_event(
+            &VEvent::new("team-rsvp-retro", "RSVP Retrospective")
+                .with_dtstamp(ts(2026, 6, 1, 12, 0))
+                .with_dtstart(ts(2026, 6, 5, 19, 0)),
+        );
+        storage
+            .publish_item(
+                &community,
+                waddle_xmpp_core::xcal::PUBSUB_NODE_EVENTS,
+                &PubSubItem {
+                    id: Some("team-rsvp-retro".to_string()),
+                    publisher: None,
+                    payload: Some(payload),
+                },
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+
+        let state = Arc::new(CalendarFeedState::new(
+            auth_state.clone(),
+            storage,
+            b"calendar-test-key",
+        ));
+        let token = sign_feed_token(b"calendar-test-key", &community);
+        let response = router(state)
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/calendar/community/{token}/events.ics"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let ics = String::from_utf8(body.to_vec()).unwrap();
+        assert!(ics.contains("UID:team-rsvp-retro\r\n"));
+        assert!(ics.contains("SUMMARY:RSVP Retrospective\r\n"));
+    }
+
+    #[tokio::test]
+    async fn feed_url_endpoint_requires_session_and_returns_signed_url() {
+        let auth_state = test_auth_state().await;
+        let session = Session::new("alice@localhost", "alice", "alice");
+        auth_state
+            .session_manager
+            .create_session(&session)
+            .await
+            .unwrap();
+        let community = expected_community_jid(&auth_state.xmpp_domain).unwrap();
+        let state = Arc::new(CalendarFeedState::new(
+            auth_state.clone(),
+            Arc::new(InMemoryPubSubStorage::new()),
+            b"calendar-test-key",
+        ));
+
+        let response = router(state)
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/api/calendar/community-feed-url?community_jid={}",
+                        community
+                    ))
+                    .header(header::COOKIE, format!("waddle_session={}", session.id))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(header::CACHE_CONTROL).unwrap(),
+            NO_STORE,
+        );
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let url = json["url"].as_str().unwrap();
+        assert!(url.starts_with("https://server.example.com/api/calendar/community/"));
+        assert!(url.ends_with("/events.ics"));
+    }
+
+    #[tokio::test]
+    async fn feed_url_endpoint_accepts_fragment_session_id_header() {
+        let auth_state = test_auth_state().await;
+        let session = Session::new("alice@localhost", "alice", "alice");
+        auth_state
+            .session_manager
+            .create_session(&session)
+            .await
+            .unwrap();
+        let community = expected_community_jid(&auth_state.xmpp_domain).unwrap();
+        let state = Arc::new(CalendarFeedState::new(
+            auth_state.clone(),
+            Arc::new(InMemoryPubSubStorage::new()),
+            b"calendar-test-key",
+        ));
+
+        let response = router(state)
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/api/calendar/community-feed-url?community_jid={}",
+                        community
+                    ))
+                    .header(SESSION_ID_HEADER, session.id)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+}

--- a/server/crates/waddle-server/src/server/routes/calendar_feed.rs
+++ b/server/crates/waddle-server/src/server/routes/calendar_feed.rs
@@ -377,7 +377,7 @@ fn event_lines(
         lines.push(property("LOCATION", location));
     }
     if let Some(organizer) = organizer {
-        lines.push(property("ORGANIZER", organizer));
+        lines.push(cal_address_property("ORGANIZER", organizer));
     }
     if let Some(rrule) = event.rrule.as_ref() {
         lines.push(rrule_property(rrule));
@@ -410,6 +410,18 @@ fn inherited_end(master: &VEvent, dtstart: DateTime<Utc>) -> Option<DateTime<Utc
 
 fn property(name: &str, value: &str) -> String {
     format!("{name}:{}", escape_text(value))
+}
+
+fn cal_address_property(name: &str, value: &str) -> String {
+    let mut line = String::with_capacity(name.len() + value.len() + 1);
+    line.push_str(name);
+    line.push(':');
+    for ch in value.chars() {
+        if ch != '\r' && ch != '\n' {
+            line.push(ch);
+        }
+    }
+    line
 }
 
 fn date_property(name: &str, value: DateTime<Utc>) -> String {
@@ -657,7 +669,7 @@ mod tests {
                 .with_dtend(ts(2026, 6, 5, 22, 0))
                 .with_description("Bring snacks, drinks; and games\nSecond line")
                 .with_location("HQ, Room A")
-                .with_organizer("xmpp:alice@example.com")
+                .with_organizer("MAILTO:u+rsvp@example.com;type=rsvp,alt")
                 .with_rrule(
                     Rrule::new(Freq::Weekly)
                         .with_interval(2)
@@ -690,6 +702,8 @@ mod tests {
         assert!(ics.contains("RECURRENCE-ID:20260612T190000Z\r\n"));
         assert!(ics.contains("DTSTART:20260612T200000Z\r\n"));
         assert!(ics.contains("DESCRIPTION:Bring snacks\\, drinks\\; and games\\nSecond line\r\n"));
+        assert!(ics.contains("ORGANIZER:MAILTO:u+rsvp@example.com;type=rsvp,alt\r\n"));
+        assert!(!ics.contains("ORGANIZER:MAILTO:u+rsvp@example.com\\;type=rsvp\\,alt\r\n"));
         assert!(!ics.contains("ATTENDEE"));
         assert!(!ics.contains("bob@example.com"));
         for line in ics.trim_end().split("\r\n") {

--- a/server/crates/waddle-server/src/server/routes/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/mod.rs
@@ -1,6 +1,7 @@
 // Route modules for Waddle Server API
 pub mod auth; // Provider auth broker, session management
 pub mod auth_page; // Web-based auth page for XMPP credentials
+pub mod calendar_feed; // Read-only iCalendar projection of xCal community events
 pub mod device; // OAuth Device Flow for CLI
 pub mod extension_webhooks; // Extension webhook ingress
 pub mod interpret; // OutboundEvent effect interpreter for sans-I/O protocol

--- a/server/crates/waddle-server/src/server/tests.rs
+++ b/server/crates/waddle-server/src/server/tests.rs
@@ -552,6 +552,10 @@ async fn test_explicit_cors_allows_credentials() {
                 .uri("/health")
                 .header(header::ORIGIN, "https://waddle.chat")
                 .header(header::ACCESS_CONTROL_REQUEST_METHOD, "GET")
+                .header(
+                    header::ACCESS_CONTROL_REQUEST_HEADERS,
+                    "x-waddle-session-id",
+                )
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -572,6 +576,17 @@ async fn test_explicit_cors_allows_credentials() {
             .get("access-control-allow-credentials")
             .and_then(|value| value.to_str().ok()),
         Some("true")
+    );
+    let allow_headers = response
+        .headers()
+        .get("access-control-allow-headers")
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default();
+    assert!(
+        allow_headers
+            .split(',')
+            .any(|header| header.trim() == "x-waddle-session-id"),
+        "explicit CORS allow headers must include x-waddle-session-id: {allow_headers}",
     );
 }
 

--- a/server/crates/waddle-server/src/server/topology.rs
+++ b/server/crates/waddle-server/src/server/topology.rs
@@ -172,10 +172,10 @@ async fn seed_initial_xmpp_topology(
         .await
         .map_err(|error| anyhow::anyhow!("failed to configure stories node: {error}"))?;
 
-    // XEP-0471 Calendar Events — community-wide pubsub node for
+    // xCal Proto-calendar events — community-wide PubSub node for
     // events with optional RSVP tracking. Same hosting + access
     // model as the social feed; events carry their own scheduling
-    // metadata in the typed `<event/>` payload.
+    // metadata in the typed `<vcalendar/>` payload.
     pubsub_storage
         .get_or_create_node(&community_jid, waddle_xmpp_core::xcal::PUBSUB_NODE_EVENTS)
         .await

--- a/server/crates/waddle-server/src/server/trace.rs
+++ b/server/crates/waddle-server/src/server/trace.rs
@@ -1,3 +1,4 @@
+use axum::http::Uri;
 use opentelemetry::trace::TraceContextExt;
 use opentelemetry_http::HeaderExtractor;
 use tracing::{info_span, Span};
@@ -18,7 +19,7 @@ pub(crate) fn make_request_span(request: &axum::http::Request<axum::body::Body>)
     let span = info_span!(
         "http_request",
         method = %request.method(),
-        uri = %request.uri(),
+        uri = %redacted_request_uri(request.uri()),
         version = ?request.version(),
     );
     let parent_cx = opentelemetry::global::get_text_map_propagator(|propagator| {
@@ -28,4 +29,47 @@ pub(crate) fn make_request_span(request: &axum::http::Request<axum::body::Body>)
         let _ = span.set_parent(parent_cx);
     }
     span
+}
+
+fn redacted_request_uri(uri: &Uri) -> String {
+    let path = uri.path();
+    let Some(token_and_suffix) = path.strip_prefix("/api/calendar/community/") else {
+        return uri.to_string();
+    };
+    let Some(token) = token_and_suffix.strip_suffix("/events.ics") else {
+        return uri.to_string();
+    };
+    if token.is_empty() || token.contains('/') {
+        return uri.to_string();
+    }
+    "/api/calendar/community/:token/events.ics".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn calendar_feed_token_is_redacted_from_request_uri() {
+        let uri: Uri = "/api/calendar/community/v1.payload.signature/events.ics"
+            .parse()
+            .unwrap();
+
+        assert_eq!(
+            redacted_request_uri(&uri),
+            "/api/calendar/community/:token/events.ics",
+        );
+    }
+
+    #[test]
+    fn non_calendar_feed_uri_is_not_redacted() {
+        let uri: Uri = "/api/auth/session?session_id=still-owned-by-telemetry-redactor"
+            .parse()
+            .unwrap();
+
+        assert_eq!(
+            redacted_request_uri(&uri),
+            "/api/auth/session?session_id=still-owned-by-telemetry-redactor",
+        );
+    }
 }

--- a/server/crates/waddle-xmpp/src/xep/mod.rs
+++ b/server/crates/waddle-xmpp/src/xep/mod.rs
@@ -71,8 +71,8 @@
 //!   pack references, built on XEP-0446/0447 file sharing.
 //! - **XEP-0452**: MUC Mention Notifications - @mention alerts with
 //!   notification elements and per-room unread mention counter.
-//! - **XEP-0471**: Calendar Events - Community events with scheduling,
-//!   RSVP tracking (going/interested/not-going), and PubSub storage.
+//! - **Proto-calendar xCal**: Community events with scheduling, RSVP
+//!   tracking (going/interested/not-going), and PubSub storage.
 //! - **XEP-0470**: Pubsub Attachments - Reactions/comments on PubSub items
 //!   with attachment target and typed payloads.
 //! - **XEP-0472**: Pubsub Social Feed - Social posts and activity feeds

--- a/server/docs/specs/http-routes.md
+++ b/server/docs/specs/http-routes.md
@@ -20,6 +20,19 @@ stack, authentication bootstrap, upload transfer, or operations require it.
 - `POST /api/auth/device/poll`: Device authorization polling.
 - `GET /api/auth/device/verify`: Device authorization verification page.
 - `POST /api/auth/device/verify`: Device authorization verification submit.
+- `GET /api/calendar/community-feed-url?community_jid=:jid`: Authenticated
+  helper returning a signed iCalendar subscription URL for the deployment's
+  xCal community events PubSub node. It accepts the browser session from the
+  `waddle_session` cookie or `X-Waddle-Session-Id` request header and returns
+  `Cache-Control: no-store`.
+- `GET /api/calendar/community/:token/events.ics`: Read-only `text/calendar`
+  projection of the xCal community events PubSub node for external calendar
+  clients. The token is a bearer subscription secret stored by calendar
+  clients; the route serves data only while the backing PubSub node remains
+  public/open, returns `Cache-Control: no-store`, scans at most the latest
+  10,000 published PubSub rows, emits up to 1,000 feed-eligible calendar items
+  after filtering RSVP-only sibling rows from that bounded window, and it does
+  not expose Waddle CRUD or control semantics.
 - `PUT /api/upload/:slot_id`: XEP-0363 upload transfer after an XMPP slot request.
 - `OPTIONS /api/upload/:slot_id`: CORS preflight for XEP-0363 upload transfer.
 - `GET /api/files/:slot_id/:filename`: XEP-0363 download transfer.

--- a/server/docs/specs/http-routes.md
+++ b/server/docs/specs/http-routes.md
@@ -29,10 +29,13 @@ stack, authentication bootstrap, upload transfer, or operations require it.
   projection of the xCal community events PubSub node for external calendar
   clients. The token is a bearer subscription secret stored by calendar
   clients; the route serves data only while the backing PubSub node remains
-  public/open, returns `Cache-Control: no-store`, scans at most the latest
-  10,000 published PubSub rows, emits up to 1,000 feed-eligible calendar items
-  after filtering RSVP-only sibling rows from that bounded window, and it does
-  not expose Waddle CRUD or control semantics.
+  public/open. Subscription tokens are community-scoped and non-expiring; all
+  authenticated users receive the same URL for a community, and rotating the
+  server `session_key` mass-invalidates existing calendar subscriptions. The
+  route returns `Cache-Control: no-store`, scans at most the latest 10,000
+  published PubSub rows, emits up to 1,000 feed-eligible calendar items after
+  filtering RSVP-only sibling rows from that bounded window, and it does not
+  expose Waddle CRUD or control semantics.
 - `PUT /api/upload/:slot_id`: XEP-0363 upload transfer after an XMPP slot request.
 - `OPTIONS /api/upload/:slot_id`: CORS preflight for XEP-0363 upload transfer.
 - `GET /api/files/:slot_id/:filename`: XEP-0363 download transfer.


### PR DESCRIPTION
## Summary

Pivot the community events export from a one-time `.ics` download toward a calendar subscription URL that external clients such as Google Calendar and Fastmail can add.

## Plan and implementation

- Add a read-only `text/calendar` projection route for the deployment community xCal PubSub events node.
- Add an authenticated helper route that returns a signed subscription URL for the current community, using the session cookie or `X-Waddle-Session-Id` header without putting browser session ids in the URL.
- Wire the Events pane to copy the subscription URL, keep the action available while events are loading, ignore stale async copy results after context changes, and show a selectable fallback URL when clipboard write fails.
- Preserve recurrence overrides and master durations consistently between the chat UI and the iCalendar projection.
- Keep Waddle behavior XMPP-native: the source of truth remains the xCal Proto-calendar PubSub node, the HTTP route is a read-only interoperability projection only, and no Waddle CRUD/control semantics move to HTTP.
- Harden the bearer feed with `Cache-Control: no-store`, non-open PubSub node refusal, CORS support for the session header, calendar token trace redaction, and a bounded PubSub scan that emits at most 1,000 feed-eligible calendar items from the latest 10,000 published rows.
- Address review feedback by routing the Events pane through the tested copy-state helper, rendering `ORGANIZER` as a calendar-address URI instead of a TEXT value, and documenting that subscription tokens are community-scoped, non-expiring bearer URLs that are mass-invalidated by `session_key` rotation.
- Update route inventory docs and avoid advertising this as XEP-0471; the current wire shape is xCal Proto-calendar.

## Validation

- `bun test`
- `bun test tests/calendar-feed-url.test.ts tests/events-pane-calendar-feed.test.ts`
- `bun run lint`
- `bun run build`
- `cargo test --manifest-path server/Cargo.toml -p waddle-server calendar_feed`
- `cargo test --manifest-path server/Cargo.toml -p waddle-server test_explicit_cors_allows_credentials`
- `cargo clippy --manifest-path server/Cargo.toml -p waddle-server --all-targets -- -D warnings`
- `git diff --check`

## Review

- Protocol/security, frontend/product, and maintainability adversarial reviews were repeated until the final pass reported no actionable findings.
