### PR TITLE
fix(chat): make calendar feed url usable

### DIFF
--- a/chat/src/components/community/CalendarFeedUrlPanel.vue
+++ b/chat/src/components/community/CalendarFeedUrlPanel.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { ExternalLink } from "lucide-vue-next";
+import { calendarFeedSubscriptionHref } from "@/lib/calendar-feed-url";
+
+const props = defineProps<{
+  url: string;
+}>();
+
+const subscriptionHref = computed(() => calendarFeedSubscriptionHref(props.url));
+
+function selectFeedUrl(event: FocusEvent) {
+  if (event.target instanceof HTMLInputElement) {
+    event.target.select();
+  }
+}
+</script>
+
+<template>
+  <div class="flex flex-wrap items-center gap-2 rounded-md border border-border bg-muted/30 px-3 py-2">
+    <span class="text-xs font-medium text-muted-foreground">
+      Calendar subscription URL
+    </span>
+    <a
+      v-if="subscriptionHref"
+      :href="subscriptionHref"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="inline-flex min-h-11 items-center gap-1 rounded-md border border-input px-2.5 py-1.5 text-xs font-medium text-primary hover:bg-background hover:underline"
+    >
+      <ExternalLink class="h-3.5 w-3.5" aria-hidden="true" />
+      Subscribe to calendar
+    </a>
+    <input
+      class="min-h-11 min-w-0 basis-full rounded-md border border-input bg-background px-2 py-1.5 text-xs text-foreground sm:basis-0 sm:flex-1"
+      readonly
+      :value="url"
+      aria-label="Calendar feed URL"
+      @focus="selectFeedUrl"
+    />
+  </div>
+</template>

--- a/chat/src/components/community/EventsPane.vue
+++ b/chat/src/components/community/EventsPane.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onUnmounted, ref, watch } from "vue";
+import { computed, onUnmounted, ref } from "vue";
 import {
   CalendarDays,
   ChevronLeft,
@@ -14,6 +14,7 @@ import {
   Trash2,
   X,
 } from "lucide-vue-next";
+import CalendarFeedUrlPanel from "@/components/community/CalendarFeedUrlPanel.vue";
 import RecurrencePicker from "@/components/community/RecurrencePicker.vue";
 import type {
   Attendee,
@@ -23,13 +24,7 @@ import type {
   Rrule,
   Weekday,
 } from "@/lib/xmpp-client";
-import {
-  copyCalendarFeedUrlToClipboard,
-  isSameCalendarFeedRequestInput,
-  nextCalendarFeedCopyViewState,
-  type CalendarFeedCopyResult,
-  type CalendarFeedRequestInput,
-} from "@/lib/calendar-feed-url";
+import { useCalendarFeedCopy } from "@/lib/use-calendar-feed-copy";
 
 interface EventsPaneProps {
   events: readonly CommunityEvent[];
@@ -310,36 +305,17 @@ const canSubmit = computed(
   () => props.canPost && !props.isPosting && summary.value.trim().length > 0,
 );
 
-type FeedCopyState = "idle" | "loading" | "copied" | "error";
-
-const feedCopyState = ref<FeedCopyState>("idle");
-const feedCopyFallbackUrl = ref<string | null>(null);
-let feedCopyResetTimer: ReturnType<typeof setTimeout> | null = null;
-let feedCopyAttempt = 0;
-
-const canCopyFeedUrl = computed(
-  () => !!props.communityJid && props.serverBaseUrl.trim().length > 0,
-);
-
-const feedCopyStatusLabel = computed(() => {
-  if (feedCopyState.value === "loading") return "Copying";
-  if (feedCopyState.value === "copied") return "Copied";
-  if (feedCopyState.value === "error") return "Couldn't copy";
-  return "";
+const calendarFeedCopy = useCalendarFeedCopy({
+  communityJid: () => props.communityJid,
+  serverBaseUrl: () => props.serverBaseUrl,
+  sessionId: () => props.sessionId,
 });
+const canCopyFeedUrl = calendarFeedCopy.canCopy;
+const feedCopyState = calendarFeedCopy.state;
+const feedCopyStatusLabel = calendarFeedCopy.statusLabel;
+const feedCopyUrl = calendarFeedCopy.url;
 
-onUnmounted(() => {
-  feedCopyAttempt += 1;
-  if (feedCopyResetTimer) clearTimeout(feedCopyResetTimer);
-});
-
-watch(
-  () => [props.communityJid, props.serverBaseUrl, props.sessionId] as const,
-  () => {
-    feedCopyAttempt += 1;
-    applyFeedCopyTransition({ contextChanged: true });
-  },
-);
+onUnmounted(calendarFeedCopy.dispose);
 
 /** Format an epoch-ms timestamp for the `<input type="datetime-local">` widget. */
 function toDatetimeLocal(ms: number | undefined): string {
@@ -438,60 +414,7 @@ function resetComposer() {
   rrule.value = null;
 }
 
-function scheduleFeedCopyReset(state: FeedCopyState) {
-  if (feedCopyResetTimer) clearTimeout(feedCopyResetTimer);
-  if (state === "copied" || state === "error") {
-    feedCopyResetTimer = setTimeout(() => {
-      feedCopyState.value = "idle";
-      feedCopyResetTimer = null;
-    }, 2_000);
-  }
-}
-
-function applyFeedCopyTransition(input: {
-  contextChanged?: boolean;
-  startAttempt?: boolean;
-  result?: CalendarFeedCopyResult;
-}) {
-  const next = nextCalendarFeedCopyViewState({
-    state: feedCopyState.value,
-    fallbackUrl: feedCopyFallbackUrl.value,
-    ...input,
-  });
-  feedCopyState.value = next.state;
-  feedCopyFallbackUrl.value = next.fallbackUrl;
-  scheduleFeedCopyReset(next.state);
-}
-
-function currentFeedRequestInput(): CalendarFeedRequestInput {
-  return {
-    communityJid: props.communityJid,
-    serverBaseUrl: props.serverBaseUrl,
-    sessionId: props.sessionId,
-  };
-}
-
-async function copyCalendarFeedUrl() {
-  if (!canCopyFeedUrl.value || feedCopyState.value === "loading") return;
-  const attempt = feedCopyAttempt + 1;
-  feedCopyAttempt = attempt;
-  const requestInput = currentFeedRequestInput();
-  applyFeedCopyTransition({ startAttempt: true });
-  const result = await copyCalendarFeedUrlToClipboard(requestInput);
-  if (
-    attempt !== feedCopyAttempt
-    || !isSameCalendarFeedRequestInput(requestInput, currentFeedRequestInput())
-  ) {
-    return;
-  }
-  applyFeedCopyTransition({ result });
-}
-
-function selectFallbackUrl(event: FocusEvent) {
-  if (event.target instanceof HTMLInputElement) {
-    event.target.select();
-  }
-}
+const copyCalendarFeedUrl = calendarFeedCopy.copy;
 
 const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 </script>
@@ -556,7 +479,7 @@ const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
         <!-- Calendar feed -->
         <button
           type="button"
-          class="inline-flex min-h-9 min-w-[7.5rem] items-center justify-center gap-1 rounded-md border border-transparent px-3 py-2 text-xs text-muted-foreground hover:bg-muted/50 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-muted-foreground sm:min-h-8 sm:px-2 sm:py-1"
+          class="inline-flex min-h-11 min-w-[7.5rem] items-center justify-center gap-1 rounded-md border border-transparent px-3 py-2 text-xs text-muted-foreground hover:bg-muted/50 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-muted-foreground sm:px-2 sm:py-1"
           :disabled="!canCopyFeedUrl || feedCopyState === 'loading'"
           @click="copyCalendarFeedUrl"
         >
@@ -593,21 +516,7 @@ const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
         </button>
       </header>
 
-      <div
-        v-if="feedCopyFallbackUrl"
-        class="flex flex-wrap items-center gap-2 rounded-md border border-border bg-muted/30 px-3 py-2"
-      >
-        <span class="text-xs font-medium text-muted-foreground">
-          Calendar subscription URL
-        </span>
-        <input
-          class="min-w-0 flex-1 rounded-md border border-input bg-background px-2 py-1.5 text-xs text-foreground"
-          readonly
-          :value="feedCopyFallbackUrl"
-          aria-label="Calendar feed URL"
-          @focus="selectFallbackUrl"
-        />
-      </div>
+      <CalendarFeedUrlPanel v-if="feedCopyUrl" :url="feedCopyUrl" />
 
       <!-- Error -->
       <div

--- a/chat/src/lib/calendar-feed-url.ts
+++ b/chat/src/lib/calendar-feed-url.ts
@@ -18,7 +18,30 @@ export type CalendarFeedCopyResult =
 
 export interface CalendarFeedCopyView {
   state: "idle" | "loading" | "copied" | "error";
-  fallbackUrl: string | null;
+  url: string | null;
+}
+
+function isLoopbackHost(hostname: string): boolean {
+  return hostname === "localhost"
+    || hostname === "127.0.0.1"
+    || hostname === "::1";
+}
+
+export function isAllowedCalendarFeedUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    if (url.protocol === "https:" || url.protocol === "webcal:") return true;
+    return url.protocol === "http:" && isLoopbackHost(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+export function calendarFeedSubscriptionHref(value: string): string | null {
+  if (!isAllowedCalendarFeedUrl(value)) return null;
+  const url = new URL(value);
+  if (url.protocol === "webcal:") return url.toString();
+  return `webcal:${url.toString().slice(url.protocol.length)}`;
 }
 
 export function nextCalendarFeedCopyViewState(input: CalendarFeedCopyView & {
@@ -27,21 +50,21 @@ export function nextCalendarFeedCopyViewState(input: CalendarFeedCopyView & {
   result?: CalendarFeedCopyResult;
 }): CalendarFeedCopyView {
   if (input.contextChanged) {
-    return { state: "idle", fallbackUrl: null };
+    return { state: "idle", url: null };
   }
   if (input.startAttempt) {
-    return { state: "loading", fallbackUrl: null };
+    return { state: "loading", url: null };
   }
   if (!input.result) {
-    return { state: input.state, fallbackUrl: input.fallbackUrl };
+    return { state: input.state, url: input.url };
   }
   switch (input.result.status) {
     case "copied":
-      return { state: "copied", fallbackUrl: null };
+      return { state: "copied", url: input.result.url };
     case "copy_failed":
-      return { state: "error", fallbackUrl: input.result.url };
+      return { state: "error", url: input.result.url };
     case "request_failed":
-      return { state: "error", fallbackUrl: null };
+      return { state: "error", url: null };
   }
 }
 
@@ -83,7 +106,11 @@ async function requestCalendarFeedUrl(
   if (!response.ok) throw new Error(`calendar feed request failed: ${response.status}`);
 
   const body = await response.json() as { url?: unknown };
-  if (typeof body.url !== "string" || body.url.length === 0) {
+  if (
+    typeof body.url !== "string"
+    || body.url.length === 0
+    || !isAllowedCalendarFeedUrl(body.url)
+  ) {
     throw new Error("calendar feed response missing url");
   }
   return body.url;

--- a/chat/src/lib/use-calendar-feed-copy.ts
+++ b/chat/src/lib/use-calendar-feed-copy.ts
@@ -1,0 +1,146 @@
+import {
+  computed,
+  hasInjectionContext,
+  inject,
+  ref,
+  watch,
+  type ComputedRef,
+  type InjectionKey,
+  type Ref,
+} from "vue";
+import {
+  copyCalendarFeedUrlToClipboard,
+  isSameCalendarFeedRequestInput,
+  nextCalendarFeedCopyViewState,
+  type CalendarFeedCopyResult,
+  type CalendarFeedCopyText,
+  type CalendarFeedFetch,
+  type CalendarFeedRequestInput,
+} from "@/lib/calendar-feed-url";
+
+type FeedCopyState = "idle" | "loading" | "copied" | "error";
+
+export interface CalendarFeedCopySource {
+  communityJid: () => string | null;
+  serverBaseUrl: () => string;
+  sessionId: () => string | null;
+  fetch?: CalendarFeedFetch;
+  copyText?: CalendarFeedCopyText;
+  resetDelayMs?: number;
+}
+
+export interface CalendarFeedCopyController {
+  canCopy: ComputedRef<boolean>;
+  copy: () => Promise<void>;
+  dispose: () => void;
+  state: Ref<FeedCopyState>;
+  statusLabel: ComputedRef<string>;
+  url: Ref<string | null>;
+}
+
+export const calendarFeedCopyControllerKey: InjectionKey<CalendarFeedCopyController> = Symbol(
+  "calendarFeedCopyController",
+);
+
+export function useCalendarFeedCopy(source: CalendarFeedCopySource): CalendarFeedCopyController {
+  if (hasInjectionContext()) {
+    const override = inject(calendarFeedCopyControllerKey, null);
+    if (override) return override;
+  }
+
+  const state = ref<FeedCopyState>("idle");
+  const url = ref<string | null>(null);
+  let resetTimer: ReturnType<typeof setTimeout> | null = null;
+  let attemptCounter = 0;
+
+  const canCopy = computed(
+    () => !!source.communityJid() && source.serverBaseUrl().trim().length > 0,
+  );
+
+  const statusLabel = computed(() => {
+    if (state.value === "loading") return "Copying";
+    if (state.value === "copied") return "Copied";
+    if (state.value === "error") {
+      return url.value ? "Couldn't copy" : "Couldn't get URL";
+    }
+    return "";
+  });
+
+  const stopContextWatch = watch(
+    () => [source.communityJid(), source.serverBaseUrl(), source.sessionId()] as const,
+    () => {
+      attemptCounter += 1;
+      applyTransition({ contextChanged: true });
+    },
+  );
+
+  function currentRequestInput(): CalendarFeedRequestInput {
+    return {
+      communityJid: source.communityJid(),
+      serverBaseUrl: source.serverBaseUrl(),
+      sessionId: source.sessionId(),
+    };
+  }
+
+  function scheduleReset(nextState: FeedCopyState) {
+    if (resetTimer) clearTimeout(resetTimer);
+    if (nextState === "copied" || nextState === "error") {
+      resetTimer = setTimeout(() => {
+        state.value = "idle";
+        resetTimer = null;
+      }, source.resetDelayMs ?? 2_000);
+    } else {
+      resetTimer = null;
+    }
+  }
+
+  function applyTransition(input: {
+    contextChanged?: boolean;
+    startAttempt?: boolean;
+    result?: CalendarFeedCopyResult;
+  }) {
+    const next = nextCalendarFeedCopyViewState({
+      state: state.value,
+      url: url.value,
+      ...input,
+    });
+    state.value = next.state;
+    url.value = next.url;
+    scheduleReset(next.state);
+  }
+
+  async function copy() {
+    if (!canCopy.value || state.value === "loading") return;
+    const attempt = attemptCounter + 1;
+    attemptCounter = attempt;
+    const requestInput = currentRequestInput();
+    applyTransition({ startAttempt: true });
+    const result = await copyCalendarFeedUrlToClipboard(requestInput, {
+      fetch: source.fetch,
+      copyText: source.copyText,
+    });
+    if (
+      attempt !== attemptCounter
+      || !isSameCalendarFeedRequestInput(requestInput, currentRequestInput())
+    ) {
+      return;
+    }
+    applyTransition({ result });
+  }
+
+  function dispose() {
+    attemptCounter += 1;
+    stopContextWatch();
+    if (resetTimer) clearTimeout(resetTimer);
+    resetTimer = null;
+  }
+
+  return {
+    canCopy,
+    copy,
+    dispose,
+    state,
+    statusLabel,
+    url,
+  };
+}

--- a/chat/tests/calendar-feed-url.test.ts
+++ b/chat/tests/calendar-feed-url.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, mock, test } from "bun:test";
+import { effectScope, nextTick, ref } from "vue";
 import {
   calendarFeedEndpoint,
+  calendarFeedSubscriptionHref,
   copyCalendarFeedUrlToClipboard,
+  isAllowedCalendarFeedUrl,
   isSameCalendarFeedRequestInput,
   nextCalendarFeedCopyViewState,
   type CalendarFeedFetch,
 } from "../src/lib/calendar-feed-url";
+import { useCalendarFeedCopy } from "../src/lib/use-calendar-feed-copy";
 
 describe("calendar feed URL helpers", () => {
   test("builds the authenticated helper endpoint with the community JID", () => {
@@ -16,6 +20,26 @@ describe("calendar feed URL helpers", () => {
     })).toBe(
       "https://server.example.com/api/calendar/community-feed-url?community_jid=community.example.com",
     );
+  });
+
+  test("allows safe calendar feed URL schemes and builds subscription hrefs", () => {
+    expect(isAllowedCalendarFeedUrl(
+      "https://server.example.com/api/calendar/community/token/events.ics",
+    )).toBe(true);
+    expect(calendarFeedSubscriptionHref(
+      "https://server.example.com/api/calendar/community/token/events.ics",
+    )).toBe("webcal://server.example.com/api/calendar/community/token/events.ics");
+    expect(calendarFeedSubscriptionHref(
+      "webcal://server.example.com/api/calendar/community/token/events.ics",
+    )).toBe("webcal://server.example.com/api/calendar/community/token/events.ics");
+    expect(isAllowedCalendarFeedUrl(
+      "http://localhost:8787/api/calendar/community/token/events.ics",
+    )).toBe(true);
+    expect(isAllowedCalendarFeedUrl(
+      "http://server.example.com/api/calendar/community/token/events.ics",
+    )).toBe(false);
+    expect(isAllowedCalendarFeedUrl("javascript:alert(1)")).toBe(false);
+    expect(calendarFeedSubscriptionHref("javascript:alert(1)")).toBeNull();
   });
 
   test("requests the feed URL with session credentials and copies it", async () => {
@@ -93,34 +117,137 @@ describe("calendar feed URL helpers", () => {
     expect(copyText).not.toHaveBeenCalled();
   });
 
-  test("copy view state clears stale fallback URLs on retry and context changes", () => {
+  test("rejects unsafe feed URL schemes before copying or rendering", async () => {
+    const fetchImpl = mock(async () =>
+      new Response(JSON.stringify({ url: "javascript:alert(document.cookie)" }))) as CalendarFeedFetch;
+    const copyText = mock(async () => {});
+
+    const result = await copyCalendarFeedUrlToClipboard({
+      communityJid: "community.example.com",
+      serverBaseUrl: "https://server.example.com",
+    }, { fetch: fetchImpl, copyText });
+
+    expect(result).toEqual({ status: "request_failed" });
+    expect(copyText).not.toHaveBeenCalled();
+  });
+
+  test("copy view state keeps fetched URLs usable and clears them on retry/context changes", () => {
+    const feedUrl = "https://server.example.com/api/calendar/community/token/events.ics";
+
+    const copied = nextCalendarFeedCopyViewState({
+      state: "loading",
+      url: null,
+      result: {
+        status: "copied",
+        url: feedUrl,
+      },
+    });
+
+    expect(copied).toEqual({
+      state: "copied",
+      url: feedUrl,
+    });
+
     const failed = nextCalendarFeedCopyViewState({
       state: "loading",
-      fallbackUrl: null,
+      url: null,
       result: {
         status: "copy_failed",
-        url: "https://server.example.com/api/calendar/community/token/events.ics",
+        url: feedUrl,
       },
     });
 
     expect(failed).toEqual({
       state: "error",
-      fallbackUrl: "https://server.example.com/api/calendar/community/token/events.ics",
+      url: feedUrl,
     });
     expect(nextCalendarFeedCopyViewState({
       state: "idle",
-      fallbackUrl: failed.fallbackUrl,
+      url: failed.url,
       startAttempt: true,
-    })).toEqual({ state: "loading", fallbackUrl: null });
+    })).toEqual({ state: "loading", url: null });
     expect(nextCalendarFeedCopyViewState({
       state: "error",
-      fallbackUrl: failed.fallbackUrl,
+      url: failed.url,
       contextChanged: true,
-    })).toEqual({ state: "idle", fallbackUrl: null });
+    })).toEqual({ state: "idle", url: null });
     expect(nextCalendarFeedCopyViewState({
       state: "loading",
-      fallbackUrl: failed.fallbackUrl,
+      url: failed.url,
       result: { status: "request_failed" },
-    })).toEqual({ state: "error", fallbackUrl: null });
+    })).toEqual({ state: "error", url: null });
+  });
+
+  test("copy controller keeps a fetched URL visible after copied status resets", async () => {
+    const feedUrl = "https://server.example.com/api/calendar/community/token/events.ics";
+    const scope = effectScope();
+    const communityJid = ref<string | null>("community.example.com");
+    const serverBaseUrl = ref("https://server.example.com");
+    const sessionId = ref<string | null>("session-1");
+    const fetchImpl = mock(async () => new Response(JSON.stringify({ url: feedUrl }))) as CalendarFeedFetch;
+    const copyText = mock(async () => {});
+    const controller = scope.run(() =>
+      useCalendarFeedCopy({
+        communityJid: () => communityJid.value,
+        serverBaseUrl: () => serverBaseUrl.value,
+        sessionId: () => sessionId.value,
+        fetch: fetchImpl,
+        copyText,
+        resetDelayMs: 0,
+      }),
+    );
+    if (!controller) throw new Error("failed to create calendar feed copy controller");
+
+    await controller.copy();
+
+    expect(fetchImpl.mock.calls[0]?.[0]).toBe(
+      "https://server.example.com/api/calendar/community-feed-url?community_jid=community.example.com",
+    );
+    expect(copyText).toHaveBeenCalledWith(feedUrl);
+    expect(controller.state.value).toBe("copied");
+    expect(controller.statusLabel.value).toBe("Copied");
+    expect(controller.url.value).toBe(feedUrl);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(controller.state.value).toBe("idle");
+    expect(controller.statusLabel.value).toBe("");
+    expect(controller.url.value).toBe(feedUrl);
+
+    communityJid.value = "community.other.example.com";
+    await nextTick();
+
+    expect(controller.state.value).toBe("idle");
+    expect(controller.url.value).toBeNull();
+    controller.dispose();
+    scope.stop();
+  });
+
+  test("copy controller still exposes the fetched URL after clipboard failure status resets", async () => {
+    const feedUrl = "https://server.example.com/api/calendar/community/token/events.ics";
+    const scope = effectScope();
+    const controller = scope.run(() =>
+      useCalendarFeedCopy({
+        communityJid: () => "community.example.com",
+        serverBaseUrl: () => "https://server.example.com",
+        sessionId: () => null,
+        fetch: mock(async () => new Response(JSON.stringify({ url: feedUrl }))) as CalendarFeedFetch,
+        copyText: mock(async () => {
+          throw new Error("clipboard denied");
+        }),
+        resetDelayMs: 0,
+      }),
+    );
+    if (!controller) throw new Error("failed to create calendar feed copy controller");
+
+    await controller.copy();
+
+    expect(controller.state.value).toBe("error");
+    expect(controller.statusLabel.value).toBe("Couldn't copy");
+    expect(controller.url.value).toBe(feedUrl);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(controller.state.value).toBe("idle");
+    expect(controller.statusLabel.value).toBe("");
+    expect(controller.url.value).toBe(feedUrl);
+    controller.dispose();
+    scope.stop();
   });
 });

--- a/chat/tests/events-pane-calendar-feed.test.ts
+++ b/chat/tests/events-pane-calendar-feed.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
+import { computed, ref } from "vue";
 import { renderVueComponent } from "./helpers/render-vue-sfc";
+import {
+  calendarFeedCopyControllerKey,
+  type CalendarFeedCopyController,
+} from "../src/lib/use-calendar-feed-copy";
 
 function props(overrides: Record<string, unknown> = {}) {
   return {
@@ -24,6 +29,22 @@ function calendarFeedButton(html: string): string {
   const start = html.lastIndexOf("<button", markerIndex);
   const end = html.indexOf("</button>", markerIndex);
   return html.slice(start, end + "</button>".length);
+}
+
+function elementWithText(html: string, tag: string, text: string): string {
+  const markerIndex = html.indexOf(text);
+  if (markerIndex === -1) return "";
+  const start = html.lastIndexOf(`<${tag}`, markerIndex);
+  const end = html.indexOf(`</${tag}>`, markerIndex);
+  return html.slice(start, end + tag.length + 3);
+}
+
+function elementWithAttribute(html: string, tag: string, attribute: string): string {
+  const markerIndex = html.indexOf(attribute);
+  if (markerIndex === -1) return "";
+  const start = html.lastIndexOf(`<${tag}`, markerIndex);
+  const end = html.indexOf(">", markerIndex);
+  return html.slice(start, end + 1);
 }
 
 describe("EventsPane calendar feed control", () => {
@@ -59,5 +80,51 @@ describe("EventsPane calendar feed control", () => {
 
     expect(html).toContain("Copy feed URL");
     expect(calendarFeedButton(html)).toMatch(/\sdisabled(?:[=>\s])/);
+  });
+
+  test("renders a feed URL panel as both an open link and selectable value", async () => {
+    const feedUrl = "https://xmpp.waddle.social/api/calendar/community/v1.community.signature/events.ics";
+    const subscriptionHref = "webcal://xmpp.waddle.social/api/calendar/community/v1.community.signature/events.ics";
+    const html = await renderVueComponent(
+      "../src/components/community/CalendarFeedUrlPanel.vue",
+      { url: feedUrl },
+      import.meta.url,
+    );
+    const openLink = elementWithText(html, "a", "Subscribe to calendar");
+    const urlInput = elementWithAttribute(html, "input", 'aria-label="Calendar feed URL"');
+
+    expect(openLink).toContain(`href="${subscriptionHref}"`);
+    expect(openLink).toContain('target="_blank"');
+    expect(openLink).toContain('rel="noopener noreferrer"');
+    expect(openLink).toContain("min-h-11");
+    expect(openLink).not.toContain("sm:min-h-8");
+    expect(urlInput).toContain(`value="${feedUrl}"`);
+    expect(urlInput).toContain("basis-full");
+    expect(urlInput).toContain("min-h-11");
+    expect(urlInput).not.toContain("sm:min-h-8");
+  });
+
+  test("renders the feed controller URL through EventsPane", async () => {
+    const feedUrl = "https://xmpp.waddle.social/api/calendar/community/v1.community.signature/events.ics";
+    const subscriptionHref = "webcal://xmpp.waddle.social/api/calendar/community/v1.community.signature/events.ics";
+    const controller: CalendarFeedCopyController = {
+      canCopy: computed(() => true),
+      copy: async () => {},
+      dispose: () => {},
+      state: ref("idle"),
+      statusLabel: computed(() => ""),
+      url: ref(feedUrl),
+    };
+    const html = await renderVueComponent(
+      "../src/components/community/EventsPane.vue",
+      props(),
+      import.meta.url,
+      (app) => app.provide(calendarFeedCopyControllerKey, controller),
+    );
+    const openLink = elementWithText(html, "a", "Subscribe to calendar");
+    const urlInput = elementWithAttribute(html, "input", 'aria-label="Calendar feed URL"');
+
+    expect(openLink).toContain(`href="${subscriptionHref}"`);
+    expect(urlInput).toContain(`value="${feedUrl}"`);
   });
 });

--- a/chat/tests/helpers/render-vue-sfc.ts
+++ b/chat/tests/helpers/render-vue-sfc.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
-import { createSSRApp, h } from "vue";
+import { createSSRApp, h, type App } from "vue";
 import { parse, compileScript } from "vue/compiler-sfc";
 import { renderToString } from "vue/server-renderer";
 import ts from "typescript";
@@ -29,11 +29,14 @@ export async function renderVueComponent(
   path: string,
   props: Record<string, unknown> = {},
   importMetaUrl: string,
+  configureApp?: (app: App<Element>) => void,
 ): Promise<string> {
   const outDir = mkdtempSync(join(tmpdir(), "waddle-vue-sfc-"));
   const moduleUrl = await compileSfcModule(new URL(path, importMetaUrl), outDir, new Map());
   const component = (await import(moduleUrl)).default;
-  return renderToString(createSSRApp({ render: () => h(component, props) }));
+  const app = createSSRApp({ render: () => h(component, props) });
+  configureApp?.(app);
+  return renderToString(app);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Keep the signed calendar feed URL after copy success and clipboard-denied fallback instead of discarding it.
- Render the fetched feed URL as an Open feed link plus a selectable readonly URL field.
- Make the action link use a `webcal://` subscription href while keeping the stable `https://` feed URL visible and copyable.
- Reject unsafe feed URL schemes before any returned URL can be copied or rendered.
- Move the feed copy lifecycle into a focused Vue composable so EventsPane stays thin and the URL remains visible after temporary status labels reset.
- Keep the calendar feed controls usable on touch devices and cover the EventsPane render path plus panel markup with focused tests.

## Deployment URL

- GitOps base URL: https://xmpp.waddle.social
- Community JID: community.waddle.social
- Helper endpoint: https://xmpp.waddle.social/api/calendar/community-feed-url?community_jid=community.waddle.social
- Returned feed URL shape: https://xmpp.waddle.social/api/calendar/community/<signed-token>/events.ics
- Visible/copyable feed URL remains `https://.../events.ics`; the clickable subscribe action rewrites safe feed URLs to `webcal://.../events.ics`.
- The signed feed token is stable: it has no timestamp or TTL and remains valid until the signing key, token version, or community config changes, or until the feed node is unavailable/non-open.

## XEP Review

- Source of truth remains the XMPP PubSub xCal events node.
- No XMPP wire shape or non-XMPP control semantics are added.
- The HTTP surface remains the existing read-only text/calendar export for external calendar clients.

## Verification

- bun test tests/calendar-feed-url.test.ts tests/events-pane-calendar-feed.test.ts
- bun test
- bun run lint
- bun run build
- Adversarial review: protocol/security, frontend usability/accessibility, and test-maintainability passes all reported no actionable findings after fixes.

Build note: `bun run build` still reports the existing Astro hint in `src/lib/xmpp/discovery.ts` and the existing Vite chunk-size warning, with 0 errors.
