### PR TITLE
fix(chat): enable calendar feed action context

### DIFF
--- a/chat/src/lib/calendar-feed-url.ts
+++ b/chat/src/lib/calendar-feed-url.ts
@@ -70,9 +70,13 @@ export function nextCalendarFeedCopyViewState(input: CalendarFeedCopyView & {
 
 export function calendarFeedEndpoint(input: CalendarFeedRequestInput): string | null {
   if (!input.communityJid) return null;
+  const serverBaseUrl = input.serverBaseUrl.trim();
+  const path = `/api/calendar/community-feed-url?${new URLSearchParams({
+    community_jid: input.communityJid,
+  }).toString()}`;
+  if (!serverBaseUrl) return path;
   try {
-    const url = new URL("/api/calendar/community-feed-url", input.serverBaseUrl);
-    url.searchParams.set("community_jid", input.communityJid);
+    const url = new URL(path, serverBaseUrl);
     return url.toString();
   } catch {
     return null;

--- a/chat/src/lib/use-calendar-feed-copy.ts
+++ b/chat/src/lib/use-calendar-feed-copy.ts
@@ -9,6 +9,7 @@ import {
   type Ref,
 } from "vue";
 import {
+  calendarFeedEndpoint,
   copyCalendarFeedUrlToClipboard,
   isSameCalendarFeedRequestInput,
   nextCalendarFeedCopyViewState,
@@ -53,9 +54,7 @@ export function useCalendarFeedCopy(source: CalendarFeedCopySource): CalendarFee
   let resetTimer: ReturnType<typeof setTimeout> | null = null;
   let attemptCounter = 0;
 
-  const canCopy = computed(
-    () => !!source.communityJid() && source.serverBaseUrl().trim().length > 0,
-  );
+  const canCopy = computed(() => calendarFeedEndpoint(currentRequestInput()) !== null);
 
   const statusLabel = computed(() => {
     if (state.value === "loading") return "Copying";

--- a/chat/tests/calendar-feed-url.test.ts
+++ b/chat/tests/calendar-feed-url.test.ts
@@ -22,6 +22,16 @@ describe("calendar feed URL helpers", () => {
     );
   });
 
+  test("builds a same-origin helper endpoint when no server base URL is configured", () => {
+    expect(calendarFeedEndpoint({
+      communityJid: "community.example.com",
+      serverBaseUrl: "",
+      sessionId: "session-1",
+    })).toBe(
+      "/api/calendar/community-feed-url?community_jid=community.example.com",
+    );
+  });
+
   test("allows safe calendar feed URL schemes and builds subscription hrefs", () => {
     expect(isAllowedCalendarFeedUrl(
       "https://server.example.com/api/calendar/community/token/events.ics",
@@ -217,6 +227,35 @@ describe("calendar feed URL helpers", () => {
 
     expect(controller.state.value).toBe("idle");
     expect(controller.url.value).toBeNull();
+    controller.dispose();
+    scope.stop();
+  });
+
+  test("copy controller can request the feed URL from the same-origin helper", async () => {
+    const feedUrl = "https://server.example.com/api/calendar/community/token/events.ics";
+    const scope = effectScope();
+    const fetchImpl = mock(async () => new Response(JSON.stringify({ url: feedUrl }))) as CalendarFeedFetch;
+    const copyText = mock(async () => {});
+    const controller = scope.run(() =>
+      useCalendarFeedCopy({
+        communityJid: () => "community.example.com",
+        serverBaseUrl: () => "",
+        sessionId: () => "session-1",
+        fetch: fetchImpl,
+        copyText,
+        resetDelayMs: 0,
+      }),
+    );
+    if (!controller) throw new Error("failed to create calendar feed copy controller");
+
+    expect(controller.canCopy.value).toBe(true);
+    await controller.copy();
+
+    expect(fetchImpl.mock.calls[0]?.[0]).toBe(
+      "/api/calendar/community-feed-url?community_jid=community.example.com",
+    );
+    expect(controller.state.value).toBe("copied");
+    expect(controller.url.value).toBe(feedUrl);
     controller.dispose();
     scope.stop();
   });

--- a/chat/tests/events-pane-calendar-feed.test.ts
+++ b/chat/tests/events-pane-calendar-feed.test.ts
@@ -71,6 +71,17 @@ describe("EventsPane calendar feed control", () => {
     expect(calendarFeedButton(html)).not.toMatch(/\sdisabled(?:[=>\s])/);
   });
 
+  test("keeps copy available when the feed helper uses same-origin API routes", async () => {
+    const html = await renderVueComponent(
+      "../src/components/community/EventsPane.vue",
+      props({ serverBaseUrl: "" }),
+      import.meta.url,
+    );
+
+    expect(html).toContain("Copy feed URL");
+    expect(calendarFeedButton(html)).not.toMatch(/\sdisabled(?:[=>\s])/);
+  });
+
   test("disables copy when feed context is missing", async () => {
     const html = await renderVueComponent(
       "../src/components/community/EventsPane.vue",


### PR DESCRIPTION
## Summary
- Enable the Events toolbar calendar feed action when `SERVER_BASE_URL` is unset by using the same-origin `/api/calendar/community-feed-url` helper route.
- Keep absolute helper URLs when a server base URL is configured, and keep safe-scheme validation for returned feed URLs.
- Add focused coverage for the same-origin endpoint path, copy controller behavior, and rendered EventsPane button state.

## Plan
- Trace feed action context from `ChatReadyShell`/controller wiring to `EventsPane`.
- Align calendar feed URL requests with the same-origin API behavior already used by auth/events when no server base URL is configured.
- Verify focused tests, full chat tests, lint, production build, and adversarial reviews.

## XEP / XMPP Review
- Reviewed the local `xeps/` surface for adjacent PubSub/MEP concepts.
- This patch does not change XMPP stanzas, advertised namespaces, or XEP wire shapes; it only fixes the authenticated HTTP helper route selection used to obtain the existing signed calendar feed URL.

## Verification
- `bun test tests/calendar-feed-url.test.ts tests/events-pane-calendar-feed.test.ts`
- `bun test`
- `bun run lint`
- `bun run build`
- Adversarial reviews: URL/security, UI-state, and XMPP/product reviewers found no actionable issues.