### PR TITLE
fix(server): prevent kicked users rejoining private channels

### DIFF
--- a/chat/src/components/admin/ChannelCreateDialog.vue
+++ b/chat/src/components/admin/ChannelCreateDialog.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-// Admin V2 — modal for `adminChannelsCreate`. `is_public` defaults to
-// `true` per the V2 spec; the helper text reflects that.
+// Admin V2 — modal for `adminChannelsCreate`.
 import { ref, watch } from "vue";
 import { X } from "lucide-vue-next";
 import AppDialog from "@/components/ui/AppDialog.vue";
+import { requireMembershipForUnlistedChannel } from "./channelAdmissionPolicy";
 
 const open = defineModel<boolean>("open", { required: true });
 
@@ -13,13 +13,14 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  submit: [payload: { name: string; topic?: string | null; spaceJid?: string | null; spaceNode?: string | null; isPublic?: boolean | null }];
+  submit: [payload: { name: string; topic?: string | null; spaceJid?: string | null; spaceNode?: string | null; isPublic?: boolean | null; membersOnly?: boolean | null }];
 }>();
 
 const name = ref("");
 const topic = ref("");
 const spaceNode = ref("");
 const isPublic = ref(true);
+const membersOnly = ref(false);
 
 watch(open, (isOpen) => {
   if (isOpen) {
@@ -27,8 +28,18 @@ watch(open, (isOpen) => {
     topic.value = "";
     spaceNode.value = "";
     isPublic.value = true;
+    membersOnly.value = false;
   }
 });
+
+function handlePublicToggleChange() {
+  const policy = requireMembershipForUnlistedChannel({
+    isPublic: isPublic.value,
+    membersOnly: membersOnly.value,
+  });
+  isPublic.value = policy.isPublic;
+  membersOnly.value = policy.membersOnly;
+}
 
 function onSubmit() {
   if (!name.value.trim() || props.isSubmitting) return;
@@ -39,6 +50,7 @@ function onSubmit() {
     spaceJid: selectedSpace?.space_jid ?? null,
     spaceNode: selectedSpace?.space_node ?? null,
     isPublic: isPublic.value,
+    membersOnly: membersOnly.value,
   });
 }
 </script>
@@ -86,14 +98,18 @@ function onSubmit() {
           <option v-for="s in spaces" :key="s.space_node" :value="s.space_node">{{ s.name }}</option>
         </select>
       </label>
-      <div class="flex flex-col gap-1.5 rounded-lg border border-border bg-muted/30 px-3 py-2.5">
+      <div class="flex flex-col gap-2 rounded-lg border border-border bg-muted/30 px-3 py-2.5">
         <label class="flex items-center gap-2 cursor-pointer">
-          <input v-model="isPublic" type="checkbox" />
-          <span class="type-control">Public</span>
+          <input v-model="isPublic" type="checkbox" @change="handlePublicToggleChange" />
+          <span class="type-control">Listed in discovery</span>
+        </label>
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input v-model="membersOnly" type="checkbox" />
+          <span class="type-control">Require explicit membership</span>
         </label>
         <p class="type-caption text-muted-foreground">
-          Anyone in the community can join. Uncheck to require explicit
-          membership.
+          Discovery visibility and room admission are separate XMPP room
+          settings.
         </p>
       </div>
     </form>

--- a/chat/src/components/admin/ChannelDetailDrawer.vue
+++ b/chat/src/components/admin/ChannelDetailDrawer.vue
@@ -7,6 +7,7 @@ import AppDrawer from "@/components/ui/AppDrawer.vue";
 import ConfirmDialog from "@/components/ui/ConfirmDialog.vue";
 import AffiliationRow from "@/components/admin/AffiliationRow.vue";
 import OccupantRow from "@/components/admin/OccupantRow.vue";
+import { requireMembershipForUnlistedChannel } from "./channelAdmissionPolicy";
 import type { BrowserXmppClient } from "@/lib/xmpp";
 import type {
   WasmAdminChannelAffiliationEntry,
@@ -39,6 +40,7 @@ const tab = ref<Tab>("config");
 const editName = ref(props.channel.name);
 const editTopic = ref(props.channel.topic ?? "");
 const editIsPublic = ref(props.channel.is_public);
+const editMembersOnly = ref(props.channel.members_only);
 const editing = ref(false);
 const editError = ref("");
 
@@ -63,9 +65,19 @@ watch(() => props.channel, (c) => {
   editName.value = c.name;
   editTopic.value = c.topic ?? "";
   editIsPublic.value = c.is_public;
+  editMembersOnly.value = c.members_only;
   void loadAffiliations();
   void loadOccupants();
 }, { immediate: false });
+
+function handlePublicToggleChange() {
+  const policy = requireMembershipForUnlistedChannel({
+    isPublic: editIsPublic.value,
+    membersOnly: editMembersOnly.value,
+  });
+  editIsPublic.value = policy.isPublic;
+  editMembersOnly.value = policy.membersOnly;
+}
 
 async function loadAffiliations() {
   if (!props.xmppClient) return;
@@ -112,6 +124,7 @@ async function saveConfig() {
       name: editName.value.trim(),
       topic: editTopic.value.trim() || null,
       isPublic: editIsPublic.value,
+      membersOnly: editMembersOnly.value,
     });
     emit("changed");
   } catch (err: unknown) {
@@ -150,6 +163,7 @@ async function kickOccupant(entry: WasmAdminChannelOccupantEntry) {
       occupantJid: bareJid,
     });
     await loadOccupants();
+    await loadAffiliations();
     emit("changed");
   } catch (err: unknown) {
     occupantsError.value = err instanceof Error ? err.message : "Failed to kick occupant.";
@@ -228,14 +242,18 @@ const occupantCountLabel = computed(() => {
           <span class="type-section-label text-muted-foreground">Topic</span>
           <textarea v-model="editTopic" rows="3" class="chat-field-control chat-textarea-control type-field" />
         </label>
-        <div class="flex flex-col gap-1.5 rounded-lg border border-border bg-muted/30 px-3 py-2.5">
+        <div class="flex flex-col gap-2 rounded-lg border border-border bg-muted/30 px-3 py-2.5">
           <label class="flex items-center gap-2 cursor-pointer">
-            <input v-model="editIsPublic" type="checkbox" />
-            <span class="type-control">Public</span>
+            <input v-model="editIsPublic" type="checkbox" @change="handlePublicToggleChange" />
+            <span class="type-control">Listed in discovery</span>
+          </label>
+          <label class="flex items-center gap-2 cursor-pointer">
+            <input v-model="editMembersOnly" type="checkbox" />
+            <span class="type-control">Require explicit membership</span>
           </label>
           <p class="type-caption text-muted-foreground">
-            Anyone in the community can join. Uncheck to require explicit
-            membership.
+            Discovery visibility and room admission are separate XMPP room
+            settings.
           </p>
         </div>
         <div v-if="editError" class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 type-caption text-destructive" role="alert">{{ editError }}</div>

--- a/chat/src/components/admin/ChannelsPanel.vue
+++ b/chat/src/components/admin/ChannelsPanel.vue
@@ -137,7 +137,7 @@ async function loadMore(): Promise<void> {
   }
 }
 
-async function onCreate(payload: { name: string; topic?: string | null; spaceJid?: string | null; spaceNode?: string | null; isPublic?: boolean | null }) {
+async function onCreate(payload: { name: string; topic?: string | null; spaceJid?: string | null; spaceNode?: string | null; isPublic?: boolean | null; membersOnly?: boolean | null }) {
   if (!props.xmppClient) return;
   isSubmitting.value = true;
   try {
@@ -278,7 +278,8 @@ const dialogSpaces = computed(() =>
           <div class="flex flex-col gap-0.5 min-w-0 flex-1">
             <div class="flex items-center gap-2 min-w-0">
               <span class="type-control truncate">{{ entry.name }}</span>
-              <span v-if="!entry.is_public" class="type-caption rounded-full bg-muted px-2 py-0.5 flex-shrink-0">Private</span>
+              <span v-if="!entry.is_public" class="type-caption rounded-full bg-muted px-2 py-0.5 flex-shrink-0">Hidden</span>
+              <span v-if="entry.members_only" class="type-caption rounded-full bg-muted px-2 py-0.5 flex-shrink-0">Members-only</span>
             </div>
             <span class="type-caption text-muted-foreground truncate font-mono">{{ entry.channel_jid }}</span>
             <span v-if="entry.topic" class="type-caption text-muted-foreground truncate">{{ entry.topic }}</span>

--- a/chat/src/components/admin/channelAdmissionPolicy.ts
+++ b/chat/src/components/admin/channelAdmissionPolicy.ts
@@ -1,0 +1,11 @@
+export interface ChannelAdmissionPolicy {
+  isPublic: boolean;
+  membersOnly: boolean;
+}
+
+export function requireMembershipForUnlistedChannel(
+  policy: ChannelAdmissionPolicy,
+): ChannelAdmissionPolicy {
+  if (policy.isPublic || policy.membersOnly) return policy;
+  return { ...policy, membersOnly: true };
+}

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -3234,7 +3234,7 @@ export class BrowserXmppClient {
       after_cursor: opts.afterCursor ?? null,
     });
   }
-  async adminChannelsCreate(opts: { name: string; topic?: string | null; spaceJid?: string | null; spaceNode?: string | null; isPublic?: boolean | null }): Promise<WasmAdminChannelRef> {
+  async adminChannelsCreate(opts: { name: string; topic?: string | null; spaceJid?: string | null; spaceNode?: string | null; isPublic?: boolean | null; membersOnly?: boolean | null }): Promise<WasmAdminChannelRef> {
     const xmpp = await this.requireConnectedXmpp();
     if (!xmpp.admin_channels_create) throw new Error("admin_channels_create binding missing");
     return await xmpp.admin_channels_create({
@@ -3243,9 +3243,10 @@ export class BrowserXmppClient {
       space_jid: opts.spaceJid ?? null,
       space_node: opts.spaceNode ?? null,
       is_public: opts.isPublic ?? null,
+      members_only: opts.membersOnly ?? null,
     });
   }
-  async adminChannelsUpdate(opts: { channelJid: string; name?: string | null; topic?: string | null; isPublic?: boolean | null }): Promise<WasmAdminChannelRef> {
+  async adminChannelsUpdate(opts: { channelJid: string; name?: string | null; topic?: string | null; isPublic?: boolean | null; membersOnly?: boolean | null }): Promise<WasmAdminChannelRef> {
     const xmpp = await this.requireConnectedXmpp();
     if (!xmpp.admin_channels_update) throw new Error("admin_channels_update binding missing");
     return await xmpp.admin_channels_update({
@@ -3253,6 +3254,7 @@ export class BrowserXmppClient {
       name: opts.name ?? null,
       topic: opts.topic ?? null,
       is_public: opts.isPublic ?? null,
+      members_only: opts.membersOnly ?? null,
     });
   }
   async adminChannelsDelete(opts: { channelJid: string }): Promise<boolean> {

--- a/chat/src/lib/xmpp/wasm-types.ts
+++ b/chat/src/lib/xmpp/wasm-types.ts
@@ -561,6 +561,7 @@ export interface WasmAdminChannelRef {
   name: string;
   topic?: string | null;
   is_public: boolean;
+  members_only: boolean;
 }
 
 export interface WasmAdminChannelOccupantEntry {

--- a/chat/tests/admin-channels-panel.test.ts
+++ b/chat/tests/admin-channels-panel.test.ts
@@ -4,6 +4,8 @@
 // machine and exercise it against a fake `BrowserXmppClient`.
 
 import { describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { requireMembershipForUnlistedChannel } from "@/components/admin/channelAdmissionPolicy";
 import type {
   WasmAdminChannelListEntry,
   WasmAdminChannelsListResult,
@@ -12,6 +14,7 @@ import type {
 interface FakeClient {
   adminChannelsList: ReturnType<typeof mock>;
   adminChannelsCreate: ReturnType<typeof mock>;
+  adminChannelsUpdate?: ReturnType<typeof mock>;
   adminChannelsDelete: ReturnType<typeof mock>;
   adminChannelsAffiliations: ReturnType<typeof mock>;
   adminChannelsOccupants: ReturnType<typeof mock>;
@@ -68,8 +71,8 @@ class ChannelsPanelModel {
     }
   }
 
-  async create(name: string): Promise<void> {
-    await this.client.adminChannelsCreate({ name, isPublic: true });
+  async create(name: string, isPublic = true, membersOnly = false): Promise<void> {
+    await this.client.adminChannelsCreate({ name, isPublic, membersOnly });
     await this.fetchFirstPage(this.prefix, this.spaceFilter);
   }
 
@@ -77,6 +80,26 @@ class ChannelsPanelModel {
     if (!this.selected) return;
     await this.client.adminChannelsDelete({ channelJid: this.selected.channel_jid });
     this.selected = null;
+  }
+
+  async updateSelectedVisibility(isPublic: boolean): Promise<void> {
+    if (!this.selected || !this.client.adminChannelsUpdate) return;
+    const policy = requireMembershipForUnlistedChannel({
+      isPublic,
+      membersOnly: this.selected.members_only,
+    });
+    await this.updateSelectedConfig(policy.isPublic, policy.membersOnly);
+  }
+
+  async updateSelectedConfig(isPublic: boolean, membersOnly: boolean): Promise<void> {
+    if (!this.selected || !this.client.adminChannelsUpdate) return;
+    await this.client.adminChannelsUpdate({
+      channelJid: this.selected.channel_jid,
+      name: this.selected.name,
+      topic: this.selected.topic ?? null,
+      isPublic,
+      membersOnly,
+    });
   }
 
   async kickFirstOccupant(): Promise<void> {
@@ -90,6 +113,12 @@ class ChannelsPanelModel {
     await this.client.adminChannelsKick({
       channelJid: this.selected.channel_jid,
       occupantJid: bareJid,
+    });
+    await this.client.adminChannelsOccupants({
+      channelJid: this.selected.channel_jid,
+    });
+    await this.client.adminChannelsAffiliations({
+      channelJid: this.selected.channel_jid,
     });
   }
 }
@@ -134,13 +163,13 @@ describe("ChannelsPanel model — list + filter + search", () => {
     });
   });
 
-  test("create call defaults to isPublic=true (spec)", async () => {
-    let capturedArgs: { name?: string; isPublic?: boolean } | null = null;
+  test("create call defaults to listed and open admission", async () => {
+    let capturedArgs: { name?: string; isPublic?: boolean; membersOnly?: boolean } | null = null;
     const client: FakeClient = {
       adminChannelsList: mock(async () => ({ entries: [], next_cursor: null })),
-      adminChannelsCreate: mock(async (args: { name: string; isPublic?: boolean }) => {
+      adminChannelsCreate: mock(async (args: { name: string; isPublic?: boolean; membersOnly?: boolean }) => {
         capturedArgs = args;
-        return { channel_jid: "x@muc.localhost", name: args.name, is_public: true };
+        return { channel_jid: "x@muc.localhost", name: args.name, is_public: true, members_only: false };
       }),
       adminChannelsDelete: mock(async () => true),
       adminChannelsAffiliations: mock(async () => ({ entries: [] })),
@@ -152,6 +181,28 @@ describe("ChannelsPanel model — list + filter + search", () => {
     await model.create("general");
     expect(capturedArgs).not.toBeNull();
     expect(capturedArgs!.isPublic).toBe(true);
+    expect(capturedArgs!.membersOnly).toBe(false);
+  });
+
+  test("create call can request hidden members-only rooms", async () => {
+    let capturedArgs: { name?: string; isPublic?: boolean; membersOnly?: boolean } | null = null;
+    const client: FakeClient = {
+      adminChannelsList: mock(async () => ({ entries: [], next_cursor: null })),
+      adminChannelsCreate: mock(async (args: { name: string; isPublic?: boolean; membersOnly?: boolean }) => {
+        capturedArgs = args;
+        return { channel_jid: "x@muc.localhost", name: args.name, is_public: false, members_only: true };
+      }),
+      adminChannelsDelete: mock(async () => true),
+      adminChannelsAffiliations: mock(async () => ({ entries: [] })),
+      adminChannelsOccupants: mock(async () => ({ entries: [] })),
+      adminChannelsKick: mock(async () => ({})),
+      adminChannelsSetAffiliation: mock(async () => ({})),
+    };
+    const model = new ChannelsPanelModel(client);
+    await model.create("ops", false, true);
+    expect(capturedArgs).not.toBeNull();
+    expect(capturedArgs!.isPublic).toBe(false);
+    expect(capturedArgs!.membersOnly).toBe(true);
   });
 });
 
@@ -176,7 +227,7 @@ describe("ChannelsPanel model — destructive actions", () => {
     expect(client.adminChannelsDelete).toHaveBeenCalledTimes(1);
   });
 
-  test("kick forwards the bare JID (resource stripped)", async () => {
+  test("kick forwards the bare JID and refreshes occupants plus affiliations", async () => {
     const client: FakeClient = {
       adminChannelsList: mock(async () => ({ entries: [], next_cursor: null })),
       adminChannelsCreate: mock(async () => ({})),
@@ -196,5 +247,146 @@ describe("ChannelsPanel model — destructive actions", () => {
     model.selected = entry("general@muc.localhost");
     await model.kickFirstOccupant();
     expect(client.adminChannelsKick).toHaveBeenCalledTimes(1);
+    expect(client.adminChannelsOccupants).toHaveBeenCalledTimes(2);
+    expect(client.adminChannelsAffiliations).toHaveBeenCalledTimes(1);
+  });
+
+  test("private visibility update also requests members-only admission", async () => {
+    const client: FakeClient = {
+      adminChannelsList: mock(async () => ({ entries: [], next_cursor: null })),
+      adminChannelsCreate: mock(async () => ({})),
+      adminChannelsUpdate: mock(async (args: { channelJid: string; isPublic: boolean; membersOnly: boolean }) => {
+        expect(args.channelJid).toBe("general@muc.localhost");
+        expect(args.isPublic).toBe(false);
+        expect(args.membersOnly).toBe(true);
+        return { channel_jid: args.channelJid, name: "general", is_public: false, members_only: true };
+      }),
+      adminChannelsDelete: mock(async () => true),
+      adminChannelsAffiliations: mock(async () => ({ entries: [] })),
+      adminChannelsOccupants: mock(async () => ({ entries: [] })),
+      adminChannelsKick: mock(async () => ({})),
+      adminChannelsSetAffiliation: mock(async () => ({})),
+    };
+    const model = new ChannelsPanelModel(client);
+    model.selected = entry("general@muc.localhost", { name: "general", topic: null });
+    await model.updateSelectedVisibility(false);
+    expect(client.adminChannelsUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  test("unchanged visibility update preserves existing members-only policy", async () => {
+    const client: FakeClient = {
+      adminChannelsList: mock(async () => ({ entries: [], next_cursor: null })),
+      adminChannelsCreate: mock(async () => ({})),
+      adminChannelsUpdate: mock(async (args: { channelJid: string; isPublic: boolean; membersOnly: boolean }) => {
+        expect(args.channelJid).toBe("public-members@muc.localhost");
+        expect(args.isPublic).toBe(true);
+        expect(args.membersOnly).toBe(true);
+        return { channel_jid: args.channelJid, name: "public-members", is_public: true, members_only: true };
+      }),
+      adminChannelsDelete: mock(async () => true),
+      adminChannelsAffiliations: mock(async () => ({ entries: [] })),
+      adminChannelsOccupants: mock(async () => ({ entries: [] })),
+      adminChannelsKick: mock(async () => ({})),
+      adminChannelsSetAffiliation: mock(async () => ({})),
+    };
+    const model = new ChannelsPanelModel(client);
+    model.selected = entry("public-members@muc.localhost", {
+      name: "public-members",
+      is_public: true,
+      members_only: true,
+    });
+    await model.updateSelectedVisibility(true);
+    expect(client.adminChannelsUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  test("config update can preserve hidden-open channel semantics", async () => {
+    const client: FakeClient = {
+      adminChannelsList: mock(async () => ({ entries: [], next_cursor: null })),
+      adminChannelsCreate: mock(async () => ({})),
+      adminChannelsUpdate: mock(async (args: { channelJid: string; isPublic: boolean; membersOnly: boolean }) => {
+        expect(args.channelJid).toBe("hidden-open@muc.localhost");
+        expect(args.isPublic).toBe(false);
+        expect(args.membersOnly).toBe(false);
+        return { channel_jid: args.channelJid, name: "hidden-open", is_public: false, members_only: false };
+      }),
+      adminChannelsDelete: mock(async () => true),
+      adminChannelsAffiliations: mock(async () => ({ entries: [] })),
+      adminChannelsOccupants: mock(async () => ({ entries: [] })),
+      adminChannelsKick: mock(async () => ({})),
+      adminChannelsSetAffiliation: mock(async () => ({})),
+    };
+    const model = new ChannelsPanelModel(client);
+    model.selected = entry("hidden-open@muc.localhost", {
+      name: "hidden-open",
+      is_public: false,
+      members_only: false,
+    });
+    await model.updateSelectedConfig(false, false);
+    expect(client.adminChannelsUpdate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ChannelsPanel source wiring — XEP visibility vs admission", () => {
+  const readSource = (path: string) => readFileSync(new URL(path, import.meta.url), "utf8");
+
+  test("shared policy requires explicit membership when a channel becomes unlisted", () => {
+    expect(requireMembershipForUnlistedChannel({
+      isPublic: false,
+      membersOnly: false,
+    })).toEqual({
+      isPublic: false,
+      membersOnly: true,
+    });
+    expect(requireMembershipForUnlistedChannel({
+      isPublic: true,
+      membersOnly: false,
+    })).toEqual({
+      isPublic: true,
+      membersOnly: false,
+    });
+    expect(requireMembershipForUnlistedChannel({
+      isPublic: false,
+      membersOnly: true,
+    })).toEqual({
+      isPublic: false,
+      membersOnly: true,
+    });
+  });
+
+  test("create dialog exposes separate listed and members-only controls", () => {
+    const source = readSource("../src/components/admin/ChannelCreateDialog.vue");
+    expect(source).toContain("const membersOnly = ref(false)");
+    expect(source).toContain("handlePublicToggleChange");
+    expect(source).toContain("requireMembershipForUnlistedChannel");
+    expect(source).toContain("Listed in discovery");
+    expect(source).toContain("Require explicit membership");
+    expect(source).toContain("membersOnly: membersOnly.value");
+  });
+
+  test("detail drawer save sends both independent room settings", () => {
+    const source = readSource("../src/components/admin/ChannelDetailDrawer.vue");
+    expect(source).toContain("const editMembersOnly = ref(props.channel.members_only)");
+    expect(source).toContain("editMembersOnly.value = policy.membersOnly");
+    expect(source).toContain('v-model="editIsPublic" type="checkbox" @change="handlePublicToggleChange"');
+    expect(source).toContain("membersOnly: editMembersOnly.value");
+    expect(source).toContain("Listed in discovery");
+    expect(source).toContain("Require explicit membership");
+    expect(source).toMatch(
+      /adminChannelsKick[\s\S]*await loadOccupants\(\);[\s\S]*await loadAffiliations\(\);/,
+    );
+  });
+
+  test("channel list labels hidden and members-only independently", () => {
+    const source = readSource("../src/components/admin/ChannelsPanel.vue");
+    expect(source).toContain("entry.members_only");
+    expect(source).toContain(">Hidden<");
+    expect(source).toContain(">Members-only<");
+    expect(source).not.toContain(">Private<");
+  });
+
+  test("browser XMPP wrapper maps membersOnly into the WASM payload", () => {
+    const source = readSource("../src/lib/xmpp/client.ts");
+    expect(source).toContain("membersOnly?: boolean | null");
+    expect(source).toContain("members_only: opts.membersOnly ?? null");
   });
 });

--- a/server/crates/waddle-server/src/admin/channels.rs
+++ b/server/crates/waddle-server/src/admin/channels.rs
@@ -14,8 +14,8 @@
 //!   filtered to a single tier.
 //! - `set-affiliation` — grant/revoke owner/admin/member/none/outcast;
 //!   `outcast` is the XEP-0045 §10.2 ban.
-//! - `kick` — XEP-0045 §9.1 role-change to `none` (occupant leaves but can
-//!   rejoin).
+//! - `kick` — XEP-0045 §9.1 role-change to `none`; for Waddle-managed
+//!   members-only channels this also revokes an explicit `member` affiliation.
 //!
 //! All handlers delegate to the typed dependencies on [`AppState`]:
 //! `room_registry` (`waddle_xmpp::muc::room_registry_actor::*`), and
@@ -28,7 +28,7 @@ use std::{
 
 use jid::{BareJid, FullJid};
 use kameo::actor::ActorRef;
-use tokio::sync::{Mutex, OwnedMutexGuard};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use waddle_xmpp::commands::{CommandContext, CommandResult};
 use waddle_xmpp::muc::room_registry_actor::{
     CreateRoom, DestroyRoom, GetOrCreateRoom, GetRoom, ListRooms,
@@ -36,8 +36,9 @@ use waddle_xmpp::muc::room_registry_actor::{
 use waddle_xmpp::muc::{
     affiliation::FederatedAffiliationConfig,
     room_actor::{
-        ApplyAdminItems, ChangeAffiliation, GetAffiliation, GetConfig, LeaveByRealJid,
-        ListAffiliations, ListOccupants, OccupantCount, RoomActor, UpdateConfig,
+        ApplyAdminItems, ApplyAffiliationChange, ChangeAffiliation, EnforceMembersOnlyAffiliations,
+        GetAffiliation, GetConfig, LeaveByRealJid, ListAffiliations, ListOccupants, OccupantCount,
+        RoomActor, UpdateConfig,
     },
     AdminItem, PinPermission, RoomConfig,
 };
@@ -57,8 +58,8 @@ use crate::channel_space_links::{ChannelSpaceLink, ChannelSpaceLinkError};
 use crate::db::actor::{DbExecute, DbQuery};
 use crate::db::{row_value, ValueExt};
 use crate::permissions::{
-    DeleteTuple, Object, ObjectType, PermissionError, Relation, Subject, SubjectType, Tuple,
-    WriteTuple,
+    CheckPermission, DeleteTuple, Object, ObjectType, Permission, PermissionError, Relation,
+    Subject, SubjectType, Tuple, WriteTuple,
 };
 use crate::server::xmpp_state::{
     delete_xmpp_channel, get_xmpp_channel, upsert_xmpp_channel, XmppChannelRecord,
@@ -87,7 +88,7 @@ pub const DEFAULT_PAGE_SIZE: u32 = 50;
 pub const MAX_PAGE_SIZE: u32 = 200;
 const MAX_NAME_LEN: usize = 80;
 const NS_MUC_USER: &str = "http://jabber.org/protocol/muc#user";
-type RoomConfigLockMap = dashmap::DashMap<BareJid, Arc<Mutex<()>>>;
+type RoomConfigLockMap = dashmap::DashMap<BareJid, Arc<Semaphore>>;
 
 // ---------------------------------------------------------------------------
 // Affiliation wire vocabulary
@@ -363,10 +364,12 @@ pub async fn register(
     }
     {
         let state = Arc::clone(&app_state);
+        let connections = Arc::clone(&connection_registry);
         registry
             .register(NODE_UPDATE, "Admin · Update channel", move |ctx| {
                 let state = Arc::clone(&state);
-                async move { handle_update(ctx, state).await }
+                let connections = Arc::clone(&connections);
+                async move { handle_update(ctx, state, connections).await }
             })
             .await;
     }
@@ -399,13 +402,15 @@ pub async fn register(
     }
     {
         let state = Arc::clone(&app_state);
+        let connections = Arc::clone(&connection_registry);
         registry
             .register(
                 NODE_SET_AFFILIATION,
                 "Admin · Set affiliation",
                 move |ctx| {
                     let state = Arc::clone(&state);
-                    async move { handle_set_affiliation(ctx, state).await }
+                    let connections = Arc::clone(&connections);
+                    async move { handle_set_affiliation(ctx, state, connections).await }
                 },
             )
             .await;
@@ -596,7 +601,11 @@ async fn handle_group_dm_rename(
     }
 }
 
-async fn handle_update(ctx: CommandContext, state: Arc<AppState>) -> CommandResult {
+async fn handle_update(
+    ctx: CommandContext,
+    state: Arc<AppState>,
+    connections: Arc<ConnectionRegistry>,
+) -> CommandResult {
     if let Err(forbidden) = caller_or_forbidden(&ctx, &state).await {
         return *forbidden;
     }
@@ -604,7 +613,7 @@ async fn handle_update(ctx: CommandContext, state: Arc<AppState>) -> CommandResu
         Ok(args) => args,
         Err(error) => return *bad_request(error),
     };
-    match run_update(&state, &args).await {
+    match run_update(&state, &connections, &args).await {
         Ok(channel) => CommandResult::Completed {
             form: Some(build_channel_form(&channel)),
             notes: vec![],
@@ -664,15 +673,20 @@ async fn handle_affiliations(ctx: CommandContext, state: Arc<AppState>) -> Comma
     }
 }
 
-async fn handle_set_affiliation(ctx: CommandContext, state: Arc<AppState>) -> CommandResult {
-    if let Err(forbidden) = caller_or_forbidden(&ctx, &state).await {
-        return *forbidden;
-    }
+async fn handle_set_affiliation(
+    ctx: CommandContext,
+    state: Arc<AppState>,
+    connections: Arc<ConnectionRegistry>,
+) -> CommandResult {
+    let caller_bare = match caller_or_forbidden(&ctx, &state).await {
+        Ok(caller) => caller,
+        Err(forbidden) => return *forbidden,
+    };
     let args = match parse_set_affiliation_args(ctx.command.form.as_ref()) {
         Ok(args) => args,
         Err(error) => return *bad_request(error),
     };
-    match run_set_affiliation(&state, &args).await {
+    match run_set_affiliation(&state, &connections, &caller_bare, &args).await {
         Ok(result) => CommandResult::Completed {
             form: Some(build_set_affiliation_form(&result)),
             notes: vec![],
@@ -1351,6 +1365,151 @@ async fn delete_channel_parent_tuple(
         Err(error) => Err(internal_err(format!(
             "permission actor failed deleting channel parent tuple: {error}"
         ))),
+    }
+}
+
+fn channel_affiliation_relation(affiliation: Affiliation) -> Option<&'static str> {
+    match affiliation {
+        Affiliation::Owner => Some("owner"),
+        Affiliation::Admin => Some("admin"),
+        Affiliation::Member => Some("member"),
+        Affiliation::Outcast => Some("outcast"),
+        Affiliation::None => None,
+    }
+}
+
+pub(crate) async fn explicit_channel_affiliations_for_jids(
+    state: &AppState,
+    channel_id: &str,
+    jids: impl IntoIterator<Item = BareJid>,
+) -> Result<Vec<(BareJid, Affiliation)>, String> {
+    let object = Object::new(ObjectType::Channel, channel_id);
+    let mut seen = BTreeSet::new();
+    let mut affiliations = Vec::new();
+    for jid in jids {
+        if !seen.insert(jid.clone()) {
+            continue;
+        }
+        let subject = Subject::user(jid.to_string());
+        let affiliation = if check_explicit_channel_permission(
+            state,
+            object.clone(),
+            subject.clone(),
+            Permission::Custom("outcast".into()),
+        )
+        .await?
+        {
+            Affiliation::Outcast
+        } else if check_explicit_channel_permission(
+            state,
+            object.clone(),
+            subject.clone(),
+            Permission::Owner,
+        )
+        .await?
+        {
+            Affiliation::Owner
+        } else if check_explicit_channel_permission(
+            state,
+            object.clone(),
+            subject.clone(),
+            Permission::Admin,
+        )
+        .await?
+        {
+            Affiliation::Admin
+        } else if check_explicit_channel_permission(
+            state,
+            object.clone(),
+            subject,
+            Permission::Member,
+        )
+        .await?
+        {
+            Affiliation::Member
+        } else {
+            Affiliation::None
+        };
+        affiliations.push((jid, affiliation));
+    }
+    Ok(affiliations)
+}
+
+async fn check_explicit_channel_permission(
+    state: &AppState,
+    object: Object,
+    subject: Subject,
+    permission: Permission,
+) -> Result<bool, String> {
+    state
+        .permission_actor
+        .ask(CheckPermission {
+            object,
+            subject,
+            permission,
+        })
+        .await
+        .map(|response| response.allowed)
+        .map_err(|error| format!("permission actor failed checking channel affiliation: {error}"))
+}
+
+async fn persist_channel_affiliation(
+    state: &AppState,
+    channel_id: &str,
+    jid: &BareJid,
+    affiliation: Affiliation,
+) -> Result<(), AdminErr> {
+    let object = Object::new(ObjectType::Channel, channel_id);
+    let subject = Subject::user(jid.to_string());
+
+    for relation in ["owner", "admin", "member", "outcast"] {
+        let tuple = Tuple::new(object.clone(), Relation::new(relation), subject.clone());
+        match state.permission_actor.ask(DeleteTuple { tuple }).await {
+            Ok(()) | Err(kameo::error::SendError::HandlerError(PermissionError::TupleNotFound)) => {
+            }
+            Err(error) => {
+                return Err(internal_err(format!(
+                    "permission actor failed deleting channel affiliation tuple: {error}"
+                )));
+            }
+        }
+    }
+
+    let Some(relation) = channel_affiliation_relation(affiliation) else {
+        return Ok(());
+    };
+    let tuple = Tuple::new(object, Relation::new(relation), subject);
+    match state.permission_actor.ask(WriteTuple { tuple }).await {
+        Ok(())
+        | Err(kameo::error::SendError::HandlerError(PermissionError::TupleAlreadyExists)) => Ok(()),
+        Err(error) => Err(internal_err(format!(
+            "permission actor failed writing channel affiliation tuple: {error}"
+        ))),
+    }
+}
+
+async fn persist_channel_affiliation_or_restore(
+    state: &AppState,
+    channel_id: &str,
+    jid: &BareJid,
+    previous_affiliation: Affiliation,
+    next_affiliation: Affiliation,
+) -> Result<(), AdminErr> {
+    match persist_channel_affiliation(state, channel_id, jid, next_affiliation).await {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            if persist_channel_affiliation(state, channel_id, jid, previous_affiliation)
+                .await
+                .is_err()
+            {
+                tracing::warn!(
+                    channel_id = channel_id,
+                    jid = %jid,
+                    "failed to restore channel affiliation after persistence error"
+                );
+            }
+            Err(error)
+        }
     }
 }
 
@@ -2083,15 +2242,28 @@ async fn run_group_dm_rename(
     })
 }
 
-async fn acquire_room_config_lock(room_jid: &BareJid) -> OwnedMutexGuard<()> {
+fn room_config_lock(room_jid: &BareJid) -> Arc<Semaphore> {
     static LOCKS: OnceLock<RoomConfigLockMap> = OnceLock::new();
     // Retained process-local locks trade a small per-written-room map for no weak-lock race.
-    let lock = LOCKS
-        .get_or_init(RoomConfigLockMap::new)
-        .entry(room_jid.clone())
-        .or_insert_with(|| Arc::new(Mutex::new(())))
-        .clone();
-    lock.lock_owned().await
+    let locks = LOCKS.get_or_init(RoomConfigLockMap::new);
+    if let Some(existing) = locks.get(room_jid) {
+        return Arc::clone(existing.value());
+    }
+    let lock = Arc::new(Semaphore::new(1));
+    match locks.entry(room_jid.clone()) {
+        dashmap::mapref::entry::Entry::Occupied(existing) => Arc::clone(existing.get()),
+        dashmap::mapref::entry::Entry::Vacant(vacant) => {
+            vacant.insert(Arc::clone(&lock));
+            lock
+        }
+    }
+}
+
+pub(crate) async fn acquire_room_config_lock(room_jid: &BareJid) -> OwnedSemaphorePermit {
+    let lock = room_config_lock(room_jid);
+    lock.acquire_owned()
+        .await
+        .expect("room config lock semaphore is never closed")
 }
 
 async fn hydrate_group_dm_member_affiliations(
@@ -2288,6 +2460,17 @@ async fn rollback_room_config_if_revision(
         })
         .await
         .unwrap_or(false)
+}
+
+async fn broadcast_presence_updates(
+    connections: &ConnectionRegistry,
+    updates: Vec<(FullJid, xmpp_parsers::presence::Presence)>,
+) {
+    for (recipient, presence) in updates {
+        let _ = connections
+            .send_to(&recipient, Stanza::Presence(presence))
+            .await;
+    }
 }
 
 async fn group_dm_room_config_revision_is_current(
@@ -2643,7 +2826,11 @@ async fn validate_group_dm_members(
     Ok(())
 }
 
-async fn run_update(state: &AppState, args: &ChannelsUpdateArgs) -> Result<ChannelRef, AdminErr> {
+async fn run_update(
+    state: &AppState,
+    connections: &ConnectionRegistry,
+    args: &ChannelsUpdateArgs,
+) -> Result<ChannelRef, AdminErr> {
     let actor = state
         .room_registry
         .ask(GetRoom {
@@ -2700,6 +2887,26 @@ async fn run_update(state: &AppState, args: &ChannelsUpdateArgs) -> Result<Chann
         None
     };
 
+    let members_only_enforcement_affiliations = if !existing.members_only && new_members_only {
+        let snapshot = actor
+            .ask(waddle_xmpp::muc::room_actor::GetSnapshot)
+            .await
+            .map_err(send_err("room actor GetSnapshot"))?;
+        let occupant_jids: Vec<BareJid> = snapshot
+            .room
+            .occupants
+            .values()
+            .map(|occupant| occupant.real_jid.to_bare())
+            .collect();
+        Some(
+            explicit_channel_affiliations_for_jids(state, &channel_id, occupant_jids)
+                .await
+                .map_err(internal_err)?,
+        )
+    } else {
+        None
+    };
+
     let expected_revision = actor
         .ask(UpdateConfig {
             config: updated.clone(),
@@ -2752,6 +2959,16 @@ async fn run_update(state: &AppState, args: &ChannelsUpdateArgs) -> Result<Chann
             }
             return Err(error);
         }
+    }
+
+    if let Some(explicit_affiliations) = members_only_enforcement_affiliations {
+        let updates = actor
+            .ask(EnforceMembersOnlyAffiliations {
+                affiliations: explicit_affiliations,
+            })
+            .await
+            .map_err(send_err("room actor EnforceMembersOnlyAffiliations"))?;
+        broadcast_presence_updates(connections, updates).await;
     }
 
     Ok(ChannelRef {
@@ -3221,8 +3438,13 @@ async fn run_affiliations(
 
 async fn run_set_affiliation(
     state: &AppState,
+    connections: &ConnectionRegistry,
+    caller_bare: &BareJid,
     args: &ChannelsSetAffiliationArgs,
 ) -> Result<ChannelsSetAffiliationResult, AdminErr> {
+    let channel_id = waddle_xmpp::parse_managed_room_jid(&args.channel_jid)
+        .ok_or_else(|| bad_request("channel_jid must be a managed MUC room JID"))?;
+    let _config_guard = acquire_room_config_lock(&args.channel_jid).await;
     let actor = state
         .room_registry
         .ask(GetRoom {
@@ -3235,17 +3457,115 @@ async fn run_set_affiliation(
                 format!("no channel '{}'", args.channel_jid),
             ))))
         })?;
-    actor
-        .ask(ChangeAffiliation {
+    let previous_affiliation = actor
+        .ask(GetAffiliation {
             jid: args.member_jid.clone(),
-            affiliation: args.affiliation.to_muc(),
         })
         .await
-        .map_err(send_err("room actor ChangeAffiliation"))?;
+        .map_err(send_err("room actor GetAffiliation"))?;
+    let next_affiliation = args.affiliation.to_muc();
+    if next_affiliation != Affiliation::Owner && previous_affiliation == Affiliation::Owner {
+        let owners = actor
+            .ask(ListAffiliations {
+                filter: Some(Affiliation::Owner),
+            })
+            .await
+            .map_err(send_err("room actor ListAffiliations"))?;
+        if owners.len() == 1 && owners[0].jid == args.member_jid {
+            return Err(Box::new(CommandResult::Error(XmppError::conflict(Some(
+                "cannot remove the last owner from a room".to_string(),
+            )))));
+        }
+    }
+    let durable_previous_affiliation =
+        explicit_channel_affiliations_for_jids(state, &channel_id, [args.member_jid.clone()])
+            .await
+            .map_err(internal_err)?
+            .into_iter()
+            .next()
+            .map(|(_, affiliation)| affiliation)
+            .unwrap_or(Affiliation::None);
+    persist_channel_affiliation_or_restore(
+        state,
+        &channel_id,
+        &args.member_jid,
+        durable_previous_affiliation,
+        next_affiliation,
+    )
+    .await?;
+    let updates = match actor
+        .ask(ApplyAffiliationChange {
+            actor: Some(caller_bare.clone()),
+            jid: args.member_jid.clone(),
+            affiliation: next_affiliation,
+        })
+        .await
+    {
+        Ok(updates) => updates,
+        Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::AdminApplyError::CannotRemoveLastOwner,
+        )) => {
+            let _ = persist_channel_affiliation(
+                state,
+                &channel_id,
+                &args.member_jid,
+                durable_previous_affiliation,
+            )
+            .await;
+            return Err(Box::new(CommandResult::Error(XmppError::conflict(Some(
+                "cannot remove the last owner from a room".to_string(),
+            )))));
+        }
+        Err(error) => {
+            let _ = persist_channel_affiliation(
+                state,
+                &channel_id,
+                &args.member_jid,
+                durable_previous_affiliation,
+            )
+            .await;
+            return Err(send_err("room actor ApplyAffiliationChange")(error));
+        }
+    };
+    broadcast_presence_updates(connections, updates).await;
     Ok(ChannelsSetAffiliationResult {
         member_jid: args.member_jid.clone(),
         affiliation: args.affiliation,
     })
+}
+
+async fn sync_private_kick_affiliation_revocation(
+    state: &AppState,
+    connections: &ConnectionRegistry,
+    actor: &ActorRef<RoomActor>,
+    channel_id: &str,
+    caller_bare: &BareJid,
+    occupant_jid: &BareJid,
+    durable_previous_affiliation: Affiliation,
+) -> Result<(), AdminErr> {
+    match actor
+        .ask(ApplyAffiliationChange {
+            actor: Some(caller_bare.clone()),
+            jid: occupant_jid.clone(),
+            affiliation: Affiliation::None,
+        })
+        .await
+    {
+        Ok(affiliation_updates) => {
+            broadcast_presence_updates(connections, affiliation_updates).await;
+            Ok(())
+        }
+        Err(error) => {
+            let _ = persist_channel_affiliation(
+                state,
+                channel_id,
+                occupant_jid,
+                durable_previous_affiliation,
+            )
+            .await;
+            Err(send_err("room actor ApplyAffiliationChange (kick)")(error))
+        }
+    }
 }
 
 async fn run_kick(
@@ -3263,6 +3583,9 @@ async fn run_kick(
     // occupant presence stanzas via `build_kick_presence`. Admin V2
     // reuses the same actor message so the broadcast shape is
     // exactly identical to the IQ path.
+    let channel_id = waddle_xmpp::parse_managed_room_jid(&args.channel_jid)
+        .ok_or_else(|| bad_request("channel_jid must be a managed MUC room JID"))?;
+    let _config_guard = acquire_room_config_lock(&args.channel_jid).await;
     let actor = state
         .room_registry
         .ask(GetRoom {
@@ -3275,12 +3598,40 @@ async fn run_kick(
                 format!("no channel '{}'", args.channel_jid),
             ))))
         })?;
+    let config = actor
+        .ask(GetConfig)
+        .await
+        .map_err(send_err("room actor GetConfig"))?;
+    let caller_bare = caller_full.to_bare();
+    let durable_previous_affiliation = if config.members_only {
+        explicit_channel_affiliations_for_jids(state, &channel_id, [args.occupant_jid.clone()])
+            .await
+            .map_err(internal_err)?
+            .into_iter()
+            .next()
+            .map(|(_, affiliation)| affiliation)
+            .unwrap_or(Affiliation::None)
+    } else {
+        Affiliation::None
+    };
+    let revoke_members_only_member =
+        config.members_only && durable_previous_affiliation == Affiliation::Member;
+    if revoke_members_only_member {
+        persist_channel_affiliation_or_restore(
+            state,
+            &channel_id,
+            &args.occupant_jid,
+            durable_previous_affiliation,
+            Affiliation::None,
+        )
+        .await?;
+    }
     // Resolve the occupant's nick — `ApplyAdminItems` looks up by nick
     // in the role-change branch, so we must translate the caller's
-    // bare-JID handle into the room-nick first. If the target isn't
-    // currently joined, there's nothing on the wire to broadcast and
-    // no persistent state to mutate; complete with a stable result
-    // (see §9.1.1: the kick verb is about live occupants).
+    // bare-JID handle into the room-nick first. If the target is not
+    // currently joined, there is no role-kick presence to broadcast.
+    // Private managed-channel kicks still keep the durable membership
+    // revocation above and synchronize the actor affiliation list.
     let occupants = actor
         .ask(ListOccupants)
         .await
@@ -3290,6 +3641,18 @@ async fn run_kick(
         .find(|info| info.real_jid.to_bare() == args.occupant_jid)
         .map(|info| info.nick)
     else {
+        if revoke_members_only_member {
+            sync_private_kick_affiliation_revocation(
+                state,
+                connections,
+                &actor,
+                &channel_id,
+                &caller_bare,
+                &args.occupant_jid,
+                durable_previous_affiliation,
+            )
+            .await?;
+        }
         return Ok(ChannelsKickResult {
             occupant_jid: args.occupant_jid.clone(),
         });
@@ -3319,17 +3682,65 @@ async fn run_kick(
         .await
     {
         Ok(updates) => updates,
+        Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::AdminApplyError::OccupantNotFound(_),
+        )) if revoke_members_only_member => {
+            sync_private_kick_affiliation_revocation(
+                state,
+                connections,
+                &actor,
+                &channel_id,
+                &caller_bare,
+                &args.occupant_jid,
+                durable_previous_affiliation,
+            )
+            .await?;
+            return Ok(ChannelsKickResult {
+                occupant_jid: args.occupant_jid.clone(),
+            });
+        }
         Err(kameo::error::SendError::HandlerError(error)) => {
+            if revoke_members_only_member {
+                let _ = persist_channel_affiliation(
+                    state,
+                    &channel_id,
+                    &args.occupant_jid,
+                    durable_previous_affiliation,
+                )
+                .await;
+            }
             return Err(internal_err(format!(
                 "room actor ApplyAdminItems (kick) rejected: {error}"
             )));
         }
         Err(error) => {
+            if revoke_members_only_member {
+                let _ = persist_channel_affiliation(
+                    state,
+                    &channel_id,
+                    &args.occupant_jid,
+                    durable_previous_affiliation,
+                )
+                .await;
+            }
             return Err(internal_err(format!(
                 "room actor ApplyAdminItems (kick) failed: {error}"
             )));
         }
     };
+
+    if revoke_members_only_member {
+        sync_private_kick_affiliation_revocation(
+            state,
+            connections,
+            &actor,
+            &channel_id,
+            &caller_bare,
+            &args.occupant_jid,
+            durable_previous_affiliation,
+        )
+        .await?;
+    }
 
     for (recipient, presence) in updates {
         let _ = connections

--- a/server/crates/waddle-server/src/server/routes/interpret/bot.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/bot.rs
@@ -294,6 +294,7 @@ pub(crate) async fn dispatch_extension_bot_groupchat_response(
             nick: bot_nick.clone(),
             effective_affiliation: waddle_xmpp::Affiliation::Member,
             local_domain: state.deps.auth_state.xmpp_domain.clone(),
+            admission_revision: initial_snapshot.admission_revision,
         })
         .await
     {

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -69,12 +69,9 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
                         debug!(len = text.len(), "Received XMPP WebSocket message");
 
                         // Handle XMPP framing (RFC 7395)
-                        let mut responses = handle_xmpp_frame(
-                            &text,
-                            &domain,
-                            &state,
-                            &mut conn,
-                        ).await;
+                        let mut responses =
+                            handle_xmpp_frame(text.as_str(), &domain, state.as_ref(), &mut conn)
+                                .await;
 
                         // Mirror any phase transition `handle_xmpp_frame`
                         // performed (most importantly Ready → Closing on

--- a/server/crates/waddle-server/src/server/routes/websocket/frame.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame.rs
@@ -19,6 +19,15 @@ pub(super) async fn handle_xmpp_frame(
     state: &WebSocketState,
     conn: &mut WsConnState,
 ) -> Vec<String> {
+    handle_xmpp_frame_impl(frame, domain, state, conn).await
+}
+
+async fn handle_xmpp_frame_impl(
+    frame: &str,
+    domain: &str,
+    state: &WebSocketState,
+    conn: &mut WsConnState,
+) -> Vec<String> {
     if frame.len() > MAX_FRAME_SIZE {
         warn!(len = frame.len(), "Dropping oversized XMPP frame");
         return vec![];

--- a/server/crates/waddle-server/src/server/routes/websocket/frame_backstop.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame_backstop.rs
@@ -153,7 +153,7 @@ impl StanzaBackstop {
 /// conformant timeout response instead of letting the connection hang.
 pub(super) async fn run_with_backstop<F>(backstop: StanzaBackstop, dispatch: F) -> Vec<String>
 where
-    F: Future<Output = Vec<String>>,
+    F: Future<Output = Vec<String>> + Send,
 {
     let span = backstop.span.clone();
     match tokio::time::timeout(STANZA_HANDLER_WEDGE_TIMEOUT, dispatch.instrument(span)).await {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/errors.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/errors.rs
@@ -84,6 +84,29 @@ pub(crate) fn forbidden_iq_error(text: &str) -> StanzaError {
     )
 }
 
+/// `<not-allowed/>` (cancel) — requested operation is disallowed by
+/// the protocol or room policy even though the sender is otherwise
+/// authenticated.
+pub(crate) fn not_allowed_iq_error(text: &str) -> StanzaError {
+    StanzaError::new(
+        ErrorType::Cancel,
+        DefinedCondition::NotAllowed,
+        DEFAULT_LANG,
+        text,
+    )
+}
+
+/// `<conflict/>` (cancel) — a well-formed request conflicts with
+/// current state, e.g. removing the final room owner.
+pub(crate) fn conflict_iq_error(text: &str) -> StanzaError {
+    StanzaError::new(
+        ErrorType::Cancel,
+        DefinedCondition::Conflict,
+        DEFAULT_LANG,
+        text,
+    )
+}
+
 /// `<item-not-found/>` (cancel) — the addressed JID, node, or item
 /// does not exist.
 pub(crate) fn item_not_found_iq_error(text: &str) -> StanzaError {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
@@ -21,12 +21,12 @@ use waddle_xmpp::{
     muc::{
         admin::{
             build_admin_result, build_admin_set_result, build_role_result, is_muc_admin_iq,
-            is_role_change_query, parse_admin_query,
+            is_role_change_query, parse_admin_query, AdminItem,
         },
         owner::build_config_form,
         room_actor::{
-            ApplyAdminItems, GetAdminContext, GetOccupantByJid, GetSnapshot, PingSelfCheck,
-            UpdateConfig,
+            ApplyAdminItems, ChangeAffiliation, EnforceMembersOnly, EnforceMembersOnlyAffiliations,
+            GetAdminContext, GetOccupantByJid, GetSnapshot, PingSelfCheck, UpdateConfig,
         },
         DATA_FORMS_NS,
     },
@@ -146,9 +146,9 @@ pub use test_helpers::handle_iq;
 // IQ-error constructors without each having to re-import the
 // `errors` submodule directly.
 pub(super) use errors::{
-    bad_format_iq_error, bad_request_iq_error, feature_not_implemented_iq_error,
+    bad_format_iq_error, bad_request_iq_error, conflict_iq_error, feature_not_implemented_iq_error,
     forbidden_iq_error, internal_server_error_iq_error, item_not_found_iq_error,
-    jid_malformed_iq_error, not_acceptable_iq_error, not_authorized_iq_error,
+    jid_malformed_iq_error, not_acceptable_iq_error, not_allowed_iq_error, not_authorized_iq_error,
     service_unavailable_iq_error,
 };
 
@@ -200,8 +200,8 @@ use crate::db::roster::{
 };
 use crate::db::{row_value, Database, Value, ValueExt};
 use crate::permissions::{
-    CheckPermission, Object, ObjectType, Permission, PermissionError, Relation, Subject,
-    SubjectType, Tuple, WriteTuple,
+    CheckPermission, DeleteTuple, Object, ObjectType, Permission, PermissionError, Relation,
+    Subject, SubjectType, Tuple, WriteTuple,
 };
 use crate::server::bootstrap_membership::DEPLOYMENT_SERVER_ID;
 use crate::server::managed_channel_policy::{

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_admin.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_admin.rs
@@ -1,4 +1,102 @@
 use super::*;
+use crate::admin::channels::{acquire_room_config_lock, explicit_channel_affiliations_for_jids};
+
+fn admin_item_has_role_shape(item: &AdminItem) -> bool {
+    item.role.is_some()
+}
+
+fn admin_item_has_affiliation_shape(item: &AdminItem) -> bool {
+    item.affiliation.is_some()
+}
+
+fn has_mixed_admin_set_semantics(items: &[AdminItem]) -> bool {
+    let has_role = items.iter().any(admin_item_has_role_shape);
+    let has_affiliation = items.iter().any(admin_item_has_affiliation_shape);
+    items
+        .iter()
+        .any(|item| admin_item_has_role_shape(item) && admin_item_has_affiliation_shape(item))
+        || (has_role && has_affiliation)
+}
+
+fn has_incomplete_admin_set_item(items: &[AdminItem]) -> bool {
+    if is_role_change_query(items) {
+        return items
+            .iter()
+            .any(|item| item.nick.is_none() || item.role.is_none());
+    }
+    items
+        .iter()
+        .any(|item| item.jid.is_none() || item.affiliation.is_none())
+}
+
+fn channel_affiliation_relation(affiliation: Affiliation) -> Option<&'static str> {
+    match affiliation {
+        Affiliation::Owner => Some("owner"),
+        Affiliation::Admin => Some("admin"),
+        Affiliation::Member => Some("member"),
+        Affiliation::Outcast => Some("outcast"),
+        Affiliation::None => None,
+    }
+}
+
+fn can_change_affiliation(
+    sender_affiliation: Affiliation,
+    target_current_affiliation: Affiliation,
+    new_affiliation: Affiliation,
+) -> bool {
+    match new_affiliation {
+        Affiliation::Owner | Affiliation::Admin => sender_affiliation == Affiliation::Owner,
+        Affiliation::Member | Affiliation::None | Affiliation::Outcast
+            if target_current_affiliation == Affiliation::Admin =>
+        {
+            sender_affiliation == Affiliation::Owner
+        }
+        Affiliation::Member | Affiliation::None | Affiliation::Outcast => {
+            matches!(sender_affiliation, Affiliation::Owner | Affiliation::Admin)
+        }
+    }
+}
+
+async fn persist_managed_channel_affiliation(
+    state: &WebSocketState,
+    channel_id: &str,
+    jid: &BareJid,
+    affiliation: Affiliation,
+) -> Result<(), String> {
+    let object = Object::new(ObjectType::Channel, channel_id);
+    let subject = Subject::user(jid.to_string());
+
+    for relation in ["owner", "admin", "member", "outcast"] {
+        let tuple = Tuple::new(object.clone(), Relation::new(relation), subject.clone());
+        match state
+            .deps
+            .app_state
+            .permission_actor
+            .ask(DeleteTuple { tuple })
+            .await
+        {
+            Ok(()) | Err(kameo::error::SendError::HandlerError(PermissionError::TupleNotFound)) => {
+            }
+            Err(error) => return Err(format!("delete affiliation tuple failed: {error}")),
+        }
+    }
+
+    let Some(relation) = channel_affiliation_relation(affiliation) else {
+        return Ok(());
+    };
+    let tuple = Tuple::new(object, Relation::new(relation), subject);
+    match state
+        .deps
+        .app_state
+        .permission_actor
+        .ask(WriteTuple { tuple })
+        .await
+    {
+        Ok(())
+        | Err(kameo::error::SendError::HandlerError(PermissionError::TupleAlreadyExists)) => Ok(()),
+        Err(error) => Err(format!("write affiliation tuple failed: {error}")),
+    }
+}
 
 pub(super) async fn handle_muc_admin_iq(
     iq: &xmpp_parsers::iq::Iq,
@@ -30,6 +128,11 @@ pub(super) async fn handle_muc_admin_iq(
             response_to,
             item_not_found_iq_error("Requested item not found."),
         )];
+    };
+    let _config_guard = if query.is_get {
+        None
+    } else {
+        Some(acquire_room_config_lock(&query.room_jid).await)
     };
     let context = match room_actor
         .ask(GetAdminContext {
@@ -70,9 +173,9 @@ pub(super) async fn handle_muc_admin_iq(
             }
         };
         let to_jid = Jid::from(sender_jid.clone());
-        if is_role_change_query(&query.items) {
+        if query.items.iter().any(admin_item_has_role_shape) {
             let role_filter = query.items.iter().find_map(|item| item.role);
-            let items: Vec<(String, waddle_xmpp::Role, Option<BareJid>)> = snapshot
+            let items: Vec<(String, waddle_xmpp::Role, Affiliation, FullJid)> = snapshot
                 .occupants
                 .values()
                 .filter(|occupant| role_filter.is_none_or(|role| occupant.role == role))
@@ -80,7 +183,8 @@ pub(super) async fn handle_muc_admin_iq(
                     (
                         occupant.nick.clone(),
                         occupant.role,
-                        Some(occupant.real_jid.to_bare()),
+                        occupant.affiliation,
+                        occupant.real_jid.clone(),
                     )
                 })
                 .collect();
@@ -113,18 +217,303 @@ pub(super) async fn handle_muc_admin_iq(
         ))];
     }
     let room_jid = query.room_jid.clone();
+    let items = query.items;
+    if has_mixed_admin_set_semantics(&items) {
+        return vec![build_iq_error_xml_typed(
+            iq.id(),
+            response_from,
+            response_to,
+            bad_request_iq_error("MUC admin set cannot mix role and affiliation semantics."),
+        )];
+    }
+    if has_incomplete_admin_set_item(&items) {
+        return vec![build_iq_error_xml_typed(
+            iq.id(),
+            response_from,
+            response_to,
+            bad_request_iq_error("Malformed MUC admin set item."),
+        )];
+    }
+    let affiliation_updates: Vec<(BareJid, Affiliation)> = if is_role_change_query(&items) {
+        Vec::new()
+    } else {
+        items
+            .iter()
+            .filter_map(|item| item.jid.clone().zip(item.affiliation))
+            .collect()
+    };
+    let actor_previous_affiliations = if affiliation_updates.is_empty() {
+        Vec::new()
+    } else {
+        match room_actor.ask(GetSnapshot).await {
+            Ok(snapshot) => {
+                let mut final_affiliations: std::collections::BTreeMap<BareJid, Affiliation> =
+                    snapshot
+                        .room
+                        .get_all_affiliations()
+                        .into_iter()
+                        .map(|entry| (entry.jid, entry.affiliation))
+                        .collect();
+                let current_owner_count = snapshot
+                    .room
+                    .get_jids_by_affiliation(Affiliation::Owner)
+                    .len();
+                for (jid, affiliation) in &affiliation_updates {
+                    if *affiliation == Affiliation::Owner
+                        && context.affiliation != Affiliation::Owner
+                    {
+                        return vec![build_iq_error_xml_typed(
+                            iq.id(),
+                            response_from,
+                            response_to,
+                            forbidden_iq_error("Operation not permitted."),
+                        )];
+                    }
+                    if *affiliation == Affiliation::Outcast && *jid == sender_jid.to_bare() {
+                        return vec![build_iq_error_xml_typed(
+                            iq.id(),
+                            response_from,
+                            response_to,
+                            conflict_iq_error("Cannot ban yourself from a room."),
+                        )];
+                    }
+                    let previous_affiliation = snapshot.room.get_affiliation(jid);
+                    if *affiliation != Affiliation::Owner
+                        && previous_affiliation == Affiliation::Owner
+                        && context.affiliation == Affiliation::Admin
+                    {
+                        return vec![build_iq_error_xml_typed(
+                            iq.id(),
+                            response_from,
+                            response_to,
+                            not_allowed_iq_error("Admins cannot change an owner's affiliation."),
+                        )];
+                    }
+                    if !can_change_affiliation(
+                        context.affiliation,
+                        previous_affiliation,
+                        *affiliation,
+                    ) {
+                        return vec![build_iq_error_xml_typed(
+                            iq.id(),
+                            response_from,
+                            response_to,
+                            forbidden_iq_error("Operation not permitted."),
+                        )];
+                    }
+                    if *affiliation == Affiliation::None {
+                        final_affiliations.remove(jid);
+                    } else {
+                        final_affiliations.insert(jid.clone(), *affiliation);
+                    }
+                }
+                if current_owner_count > 0
+                    && !final_affiliations
+                        .values()
+                        .any(|affiliation| *affiliation == Affiliation::Owner)
+                {
+                    return vec![build_iq_error_xml_typed(
+                        iq.id(),
+                        response_from,
+                        response_to,
+                        conflict_iq_error("Cannot remove the last owner from a room."),
+                    )];
+                }
+                let mut previous_affiliations = Vec::with_capacity(affiliation_updates.len());
+                for (jid, _) in &affiliation_updates {
+                    previous_affiliations.push((jid.clone(), snapshot.room.get_affiliation(jid)));
+                }
+                previous_affiliations
+            }
+            Err(_) => {
+                return vec![build_iq_error_xml_typed(
+                    iq.id(),
+                    response_from,
+                    response_to,
+                    internal_server_error_iq_error("Internal server error."),
+                )];
+            }
+        }
+    };
+    let managed_channel_id = waddle_xmpp::parse_managed_room_jid(&room_jid);
+    let durable_previous_affiliations = if affiliation_updates.is_empty() {
+        Vec::new()
+    } else if let Some(channel_id) = managed_channel_id.as_deref() {
+        let target_jids: Vec<BareJid> = affiliation_updates
+            .iter()
+            .map(|(jid, _)| jid.clone())
+            .collect();
+        match explicit_channel_affiliations_for_jids(&state.deps.app_state, channel_id, target_jids)
+            .await
+        {
+            Ok(affiliations) => affiliations,
+            Err(error) => {
+                warn!(
+                    room = %room_jid,
+                    error = %error,
+                    "Failed to snapshot explicit channel affiliations before MUC admin update"
+                );
+                return vec![build_iq_error_xml_typed(
+                    iq.id(),
+                    response_from,
+                    response_to,
+                    internal_server_error_iq_error("Internal server error."),
+                )];
+            }
+        }
+    } else {
+        Vec::new()
+    };
+    if let Some(channel_id) = managed_channel_id.as_deref() {
+        for (jid, affiliation) in &affiliation_updates {
+            if let Err(error) =
+                persist_managed_channel_affiliation(state, channel_id, jid, *affiliation).await
+            {
+                warn!(
+                    room = %room_jid,
+                    target = %jid,
+                    error = %error,
+                    "Failed to persist MUC admin affiliation change before actor update"
+                );
+                for (previous_jid, previous_affiliation) in &durable_previous_affiliations {
+                    let _ = persist_managed_channel_affiliation(
+                        state,
+                        channel_id,
+                        previous_jid,
+                        *previous_affiliation,
+                    )
+                    .await;
+                }
+                return vec![build_iq_error_xml_typed(
+                    iq.id(),
+                    response_from,
+                    response_to,
+                    internal_server_error_iq_error("Internal server error."),
+                )];
+            }
+        }
+    }
     let updates = match room_actor
         .ask(ApplyAdminItems {
             sender_jid: sender_jid.clone(),
             sender_affiliation: context.affiliation,
             sender_role: context.role,
-            items: query.items,
+            items,
         })
         .await
     {
         Ok(updates) => updates,
+        Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::AdminApplyError::CannotRemoveLastOwner,
+        )) => {
+            warn!(room = %room_jid, "MUC admin set rejected because it would remove the last owner");
+            if let Some(channel_id) = managed_channel_id.as_deref() {
+                for (previous_jid, previous_affiliation) in &durable_previous_affiliations {
+                    let _ = persist_managed_channel_affiliation(
+                        state,
+                        channel_id,
+                        previous_jid,
+                        *previous_affiliation,
+                    )
+                    .await;
+                }
+                for (previous_jid, previous_affiliation) in &actor_previous_affiliations {
+                    let _ = room_actor
+                        .ask(ChangeAffiliation {
+                            jid: previous_jid.clone(),
+                            affiliation: *previous_affiliation,
+                        })
+                        .await;
+                }
+            }
+            return vec![build_iq_error_xml_typed(
+                iq.id(),
+                response_from,
+                response_to,
+                conflict_iq_error("Cannot remove the last owner from a room."),
+            )];
+        }
+        Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::AdminApplyError::CannotAdminModifyOwner,
+        )) => {
+            warn!(room = %room_jid, "MUC admin set rejected because an admin tried to change an owner affiliation");
+            if let Some(channel_id) = managed_channel_id.as_deref() {
+                for (previous_jid, previous_affiliation) in &durable_previous_affiliations {
+                    let _ = persist_managed_channel_affiliation(
+                        state,
+                        channel_id,
+                        previous_jid,
+                        *previous_affiliation,
+                    )
+                    .await;
+                }
+                for (previous_jid, previous_affiliation) in &actor_previous_affiliations {
+                    let _ = room_actor
+                        .ask(ChangeAffiliation {
+                            jid: previous_jid.clone(),
+                            affiliation: *previous_affiliation,
+                        })
+                        .await;
+                }
+            }
+            return vec![build_iq_error_xml_typed(
+                iq.id(),
+                response_from,
+                response_to,
+                not_allowed_iq_error("Admins cannot change an owner's affiliation."),
+            )];
+        }
+        Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::AdminApplyError::CannotModifyPrivilegedRole,
+        )) => {
+            warn!(room = %room_jid, "MUC admin set rejected because a non-owner tried to change an owner/admin role");
+            if let Some(channel_id) = managed_channel_id.as_deref() {
+                for (previous_jid, previous_affiliation) in &durable_previous_affiliations {
+                    let _ = persist_managed_channel_affiliation(
+                        state,
+                        channel_id,
+                        previous_jid,
+                        *previous_affiliation,
+                    )
+                    .await;
+                }
+                for (previous_jid, previous_affiliation) in &actor_previous_affiliations {
+                    let _ = room_actor
+                        .ask(ChangeAffiliation {
+                            jid: previous_jid.clone(),
+                            affiliation: *previous_affiliation,
+                        })
+                        .await;
+                }
+            }
+            return vec![build_iq_error_xml_typed(
+                iq.id(),
+                response_from,
+                response_to,
+                not_allowed_iq_error("Admins and moderators cannot change an owner or admin role."),
+            )];
+        }
         Err(kameo::error::SendError::HandlerError(error)) => {
             warn!(room = %room_jid, error = %error, "MUC admin set rejected");
+            if let Some(channel_id) = managed_channel_id.as_deref() {
+                for (previous_jid, previous_affiliation) in &durable_previous_affiliations {
+                    let _ = persist_managed_channel_affiliation(
+                        state,
+                        channel_id,
+                        previous_jid,
+                        *previous_affiliation,
+                    )
+                    .await;
+                }
+                for (previous_jid, previous_affiliation) in &actor_previous_affiliations {
+                    let _ = room_actor
+                        .ask(ChangeAffiliation {
+                            jid: previous_jid.clone(),
+                            affiliation: *previous_affiliation,
+                        })
+                        .await;
+                }
+            }
             return vec![build_iq_error_xml_typed(
                 iq.id(),
                 response_from,
@@ -134,6 +523,25 @@ pub(super) async fn handle_muc_admin_iq(
         }
         Err(error) => {
             warn!(room = %room_jid, error = ?error, "Failed to apply MUC admin IQ");
+            if let Some(channel_id) = managed_channel_id.as_deref() {
+                for (previous_jid, previous_affiliation) in &durable_previous_affiliations {
+                    let _ = persist_managed_channel_affiliation(
+                        state,
+                        channel_id,
+                        previous_jid,
+                        *previous_affiliation,
+                    )
+                    .await;
+                }
+                for (previous_jid, previous_affiliation) in &actor_previous_affiliations {
+                    let _ = room_actor
+                        .ask(ChangeAffiliation {
+                            jid: previous_jid.clone(),
+                            affiliation: *previous_affiliation,
+                        })
+                        .await;
+                }
+            }
             return vec![build_iq_error_xml_typed(
                 iq.id(),
                 response_from,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_config.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_config.rs
@@ -1,5 +1,6 @@
 use super::permissions::write_tuple_if_absent;
 use super::*;
+use crate::admin::channels::{acquire_room_config_lock, explicit_channel_affiliations_for_jids};
 
 fn data_form_value(form: &Element, var: &str) -> Option<String> {
     form.children()
@@ -26,12 +27,20 @@ pub(super) async fn apply_muc_owner_config(
     let room_actor = get_room_actor(state, room_jid)
         .await
         .ok_or_else(|| "room actor not found".to_string())?;
-    let mut config = room_actor
+    let _config_guard = acquire_room_config_lock(room_jid).await;
+    let snapshot = room_actor
         .ask(GetSnapshot)
         .await
-        .map_err(|error| format!("snapshot failed: {error:?}"))?
+        .map_err(|error| format!("snapshot failed: {error:?}"))?;
+    let previous_members_only = snapshot.room.config.members_only;
+    let previous_config = snapshot.room.config.clone();
+    let occupant_jids: Vec<BareJid> = snapshot
         .room
-        .config;
+        .occupants
+        .values()
+        .map(|occupant| occupant.real_jid.to_bare())
+        .collect();
+    let mut config = previous_config.clone();
 
     if let xmpp_parsers::iq::Iq::Set { payload: query, .. } = iq {
         if let Some(form) = query.get_child("x", DATA_FORMS_NS) {
@@ -78,16 +87,60 @@ pub(super) async fn apply_muc_owner_config(
     // Waddle rooms are persistent, non-anonymous collaboration surfaces.
     config.persistent = true;
 
-    room_actor
+    let channel_id = waddle_xmpp::parse_managed_room_jid(room_jid);
+    if let (Some(channel_id), Some(session)) = (channel_id.as_deref(), session) {
+        write_tuple_if_absent(
+            state,
+            Tuple::new(
+                Object::new(ObjectType::Channel, channel_id),
+                Relation::new("owner"),
+                Subject::user(&session.user_jid),
+            ),
+        )
+        .await
+        .map_err(|error| format!("channel owner tuple failed: {error}"))?;
+    }
+    let managed_enforcement_affiliations = if !previous_members_only && config.members_only {
+        if let Some(channel_id) = channel_id.as_deref() {
+            Some(
+                explicit_channel_affiliations_for_jids(
+                    &state.deps.app_state,
+                    channel_id,
+                    occupant_jids,
+                )
+                .await?,
+            )
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    let expected_revision = room_actor
         .ask(UpdateConfig {
             config: config.clone(),
         })
         .await
         .map_err(|error| format!("config update failed: {error:?}"))?;
 
-    let Some(channel_id) = waddle_xmpp::parse_managed_room_jid(room_jid) else {
+    let Some(channel_id) = channel_id else {
+        if !previous_members_only && config.members_only {
+            let updates = room_actor
+                .ask(EnforceMembersOnly)
+                .await
+                .map_err(|error| format!("members-only enforcement failed: {error:?}"))?;
+            for (recipient, presence) in updates {
+                let _ = state
+                    .deps
+                    .protocol
+                    .connection_registry
+                    .try_send_to(&recipient, Stanza::Presence(presence));
+            }
+        }
         return Ok(());
     };
+
     let now = chrono::Utc::now().to_rfc3339();
     let actor = state.deps.app_state.db_pool.global_actor().clone();
     let existing_channel_type = get_xmpp_channel(actor.clone(), &channel_id)
@@ -101,7 +154,7 @@ pub(super) async fn apply_muc_owner_config(
     } else {
         "text".to_string()
     };
-    actor
+    if let Err(error) = actor
         .ask(DbExecute {
             sql: r#"
                 INSERT INTO channels (id, name, description, channel_type, position, is_default, pin_permission, members_only, public_room, created_at, updated_at)
@@ -118,8 +171,8 @@ pub(super) async fn apply_muc_owner_config(
             .to_string(),
             params: vec![
                 channel_id.clone().into(),
-                config.name.into(),
-                config.description.into(),
+                config.name.clone().into(),
+                config.description.clone().into(),
                 channel_type.into(),
                 config.pin_permission.as_form_value().into(),
                 config.members_only.into(),
@@ -129,31 +182,45 @@ pub(super) async fn apply_muc_owner_config(
             ],
         })
         .await
-        .map_err(|error| format!("channel upsert failed: {error}"))?;
+    {
+        let _ = room_actor
+            .ask(waddle_xmpp::muc::room_actor::RollbackConfigIfRevision {
+                expected_revision,
+                config: previous_config,
+            })
+            .await;
+        return Err(format!("channel upsert failed: {error}"));
+    }
 
-    // Write channel#owner → session user so the creator can always rejoin the
-    // managed room after a server restart (before a Space bookmark is published).
-    // XEP-0045 §10 requires the room creator to be an owner; without this tuple
-    // the channel becomes unjoinable after restart.
-    match session {
-        Some(session) => {
-            write_tuple_if_absent(
-                state,
-                Tuple::new(
-                    Object::new(ObjectType::Channel, &channel_id),
-                    Relation::new("owner"),
-                    Subject::user(&session.user_jid),
-                ),
-            )
-            .await
-            .map_err(|error| format!("channel owner tuple failed: {error}"))?;
-        }
-        None => {
-            warn!(
-                channel_id = %channel_id,
-                "apply_muc_owner_config called without a session; \
-                 channel owner tuple not written — room may be inaccessible after server restart"
-            );
+    // The channel#owner tuple was written before the config update/upsert so the
+    // creator can always rejoin after restart, before a Space bookmark is
+    // published. XEP-0045 §10 requires the room creator to be an owner.
+    if session.is_none() {
+        warn!(
+            channel_id = %channel_id,
+            "apply_muc_owner_config called without a session; \
+             channel owner tuple not written — room may be inaccessible after server restart"
+        );
+    }
+
+    if !previous_members_only && config.members_only {
+        let updates = if let Some(affiliations) = managed_enforcement_affiliations {
+            room_actor
+                .ask(EnforceMembersOnlyAffiliations { affiliations })
+                .await
+                .map_err(|error| format!("members-only enforcement failed: {error:?}"))?
+        } else {
+            room_actor
+                .ask(EnforceMembersOnly)
+                .await
+                .map_err(|error| format!("members-only enforcement failed: {error:?}"))?
+        };
+        for (recipient, presence) in updates {
+            let _ = state
+                .deps
+                .protocol
+                .connection_registry
+                .try_send_to(&recipient, Stanza::Presence(presence));
         }
     }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence.rs
@@ -51,12 +51,31 @@ pub(super) use subscription::{
 };
 
 pub async fn handle_presence(
-    mut presence: xmpp_parsers::presence::Presence,
+    presence: xmpp_parsers::presence::Presence,
     domain: &str,
     muc_domain: &str,
     state: &WebSocketState,
     phase: &ConnectionPhase,
     _authenticated_session: &Option<Session>,
+) -> Vec<String> {
+    handle_presence_impl(
+        presence,
+        domain,
+        muc_domain,
+        state,
+        phase,
+        _authenticated_session,
+    )
+    .await
+}
+
+async fn handle_presence_impl(
+    mut presence: xmpp_parsers::presence::Presence,
+    domain: &str,
+    muc_domain: &str,
+    state: &WebSocketState,
+    phase: &ConnectionPhase,
+    authenticated_session: &Option<Session>,
 ) -> Vec<String> {
     strip_client_authored_delay(&mut presence);
     let is_unavailable = presence.type_ == xmpp_parsers::presence::Type::Unavailable;
@@ -111,7 +130,7 @@ pub async fn handle_presence(
             sender_jid,
             nick,
             presence_show,
-            _authenticated_session,
+            authenticated_session,
         )
         .await;
     }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -6,6 +6,7 @@ mod xml;
 pub use access::{get_managed_channel_for_room, parse_room_jid_context};
 
 use access::{resolve_managed_channel_affiliation, server_permission_allowed};
+use waddle_xmpp::muc::room_actor::GetSnapshot;
 use xml::{
     build_muc_conflict_presence_xml, build_muc_presence_error_xml, build_muc_self_unavailable_xml,
     create_presence_stanza,
@@ -23,366 +24,467 @@ pub async fn handle_muc_join(
 ) -> Vec<String> {
     info!(room = %room_jid, nick = %nick, sender = %sender_jid, "MUC join request");
 
-    let managed_channel = match get_managed_channel_for_room(state, room_jid).await {
-        Ok(channel) => channel,
-        Err(error) => {
-            warn!(room = %room_jid, error = %error, "Failed to resolve managed MUC channel");
-            return vec![build_muc_presence_error_xml(
-                room_jid,
-                nick,
-                sender_jid,
-                StanzaError::new(
-                    ErrorType::Wait,
-                    DefinedCondition::InternalServerError,
-                    "en",
-                    "Failed to resolve managed channel for room.",
-                ),
-            )];
-        }
-    };
-    let managed_room_is_group_dm = managed_channel
-        .as_ref()
-        .is_some_and(|channel| channel.channel_type == waddle_xmpp::admin::CHANNEL_TYPE_GROUP_DM);
-    let managed_affiliation = if let Some(channel) = managed_channel.as_ref() {
-        let Some(session) = authenticated_session else {
-            return vec![build_muc_presence_error_xml(
-                room_jid,
-                nick,
-                sender_jid,
-                StanzaError::new(
-                    ErrorType::Auth,
-                    DefinedCondition::NotAuthorized,
-                    "en",
-                    "Authentication required to join managed channel.",
-                ),
-            )];
-        };
-        match resolve_managed_channel_affiliation(state, session, &channel.id).await {
-            Ok(Some(Affiliation::Outcast)) => {
+    handle_muc_join_unlocked(
+        state,
+        domain.to_string(),
+        room_jid,
+        sender_jid,
+        nick.to_string(),
+        presence_show,
+        authenticated_session,
+    )
+    .await
+}
+
+async fn handle_muc_join_unlocked(
+    state: &WebSocketState,
+    domain: String,
+    room_jid: &BareJid,
+    sender_jid: &FullJid,
+    nick: String,
+    presence_show: Option<crate::notification_activity::NotificationPresenceShow>,
+    authenticated_session: &Option<Session>,
+) -> Vec<String> {
+    let mut retried_stale_admission = false;
+    loop {
+        let managed_channel = match get_managed_channel_for_room(state, room_jid).await {
+            Ok(channel) => channel,
+            Err(error) => {
+                warn!(room = %room_jid, error = %error, "Failed to resolve managed MUC channel");
                 return vec![build_muc_presence_error_xml(
                     room_jid,
-                    nick,
-                    sender_jid,
-                    StanzaError::new(
-                        ErrorType::Auth,
-                        DefinedCondition::Forbidden,
-                        "en",
-                        "Banned from managed channel.",
-                    ),
-                )];
-            }
-            Ok(Some(affiliation)) => Some(affiliation),
-            Ok(None) => {
-                if channel.members_only {
-                    return vec![build_muc_presence_error_xml(
-                        room_jid,
-                        nick,
-                        sender_jid,
-                        StanzaError::new(
-                            ErrorType::Auth,
-                            DefinedCondition::RegistrationRequired,
-                            "en",
-                            "Membership required to join managed channel.",
-                        ),
-                    )];
-                }
-                Some(Affiliation::None)
-            }
-            Err(()) => {
-                return vec![build_muc_presence_error_xml(
-                    room_jid,
-                    nick,
+                    &nick,
                     sender_jid,
                     StanzaError::new(
                         ErrorType::Wait,
                         DefinedCondition::InternalServerError,
                         "en",
-                        "Failed to resolve managed-channel affiliation.",
+                        "Failed to resolve managed channel for room.",
                     ),
                 )];
             }
-        }
-    } else {
-        None
-    };
-
-    let existing_room_actor = get_room_actor(state, room_jid).await;
-    let (room_actor, created_instant_room) = match existing_room_actor {
-        Some(actor) => (actor, false),
-        None => {
-            if managed_channel.is_none()
-                && !server_permission_allowed(
-                    state,
-                    authenticated_session.as_ref(),
-                    Permission::CreateMuc,
-                )
-                .await
-                .unwrap_or(false)
-            {
+        };
+        let existing_room_actor = get_room_actor(state, room_jid).await;
+        let existing_room_snapshot = if let Some(actor) = existing_room_actor.as_ref() {
+            match actor.ask(GetSnapshot).await {
+                Ok(snapshot) => Some(snapshot),
+                Err(error) => {
+                    warn!(room = %room_jid, error = ?error, "Failed to snapshot MUC room before join");
+                    return vec![build_muc_presence_error_xml(
+                        room_jid,
+                        &nick,
+                        sender_jid,
+                        StanzaError::new(
+                            ErrorType::Wait,
+                            DefinedCondition::InternalServerError,
+                            "en",
+                            "Failed to snapshot room before join.",
+                        ),
+                    )];
+                }
+            }
+        } else {
+            None
+        };
+        let admission_revision = existing_room_snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.admission_revision)
+            .unwrap_or(0);
+        let managed_affiliation = if let Some(channel) = managed_channel.as_ref() {
+            let Some(session) = authenticated_session else {
                 return vec![build_muc_presence_error_xml(
                     room_jid,
-                    nick,
+                    &nick,
                     sender_jid,
                     StanzaError::new(
-                        ErrorType::Cancel,
-                        DefinedCondition::NotAllowed,
+                        ErrorType::Auth,
+                        DefinedCondition::NotAuthorized,
                         "en",
-                        "Creating new MUC rooms is not permitted for this account.",
+                        "Authentication required to join managed channel.",
                     ),
                 )];
-            }
-
-            let config = managed_channel
-                .as_ref()
-                .map(|channel| RoomConfig {
-                    name: channel.name.clone(),
-                    description: channel.description.clone(),
-                    members_only: channel.members_only,
-                    public_room: channel.public_room,
-                    moderated: channel.channel_type == "announcement",
-                    forum: channel.channel_type == "forum",
-                    group_dm: channel.channel_type == waddle_xmpp::admin::CHANNEL_TYPE_GROUP_DM,
-                    // #422: load persisted pin policy so the actor's
-                    // snapshot matches the channel's last-saved value
-                    // even after eviction.
-                    pin_permission: channel.pin_permission,
-                    ..Default::default()
-                })
-                .unwrap_or_else(|| RoomConfig {
-                    name: room_jid
-                        .node()
-                        .map(|n| n.to_string())
-                        .unwrap_or_else(|| "Room".to_string()),
-                    members_only: false,
-                    ..Default::default()
-                });
-
-            let (waddle_id, channel_id) = managed_channel
-                .as_ref()
-                .map(|channel| {
-                    let (waddle_id, _) = parse_room_jid_context(room_jid);
-                    (waddle_id, channel.id.clone())
-                })
-                .unwrap_or_else(|| parse_room_jid_context(room_jid));
-
-            let Some(actor) =
-                get_or_create_room_actor(state, room_jid, config, waddle_id, channel_id).await
-            else {
-                return vec![];
             };
-            (actor, managed_channel.is_none())
-        }
-    };
-
-    let effective_affiliation = if created_instant_room {
-        Affiliation::Owner
-    } else if let Some(affiliation) = managed_affiliation {
-        affiliation
-    } else if managed_room_is_group_dm {
-        Affiliation::None
-    } else {
-        Affiliation::Member
-    };
-
-    let join_outcome = match room_actor
-        .ask(JoinWithAffiliation {
-            sender_jid: sender_jid.clone(),
-            nick: nick.to_string(),
-            effective_affiliation,
-            local_domain: domain.to_string(),
-        })
-        .await
-    {
-        Ok(outcome) => outcome,
-        Err(error) => {
-            let nick_collision = matches!(
-                &error,
-                kameo::error::SendError::HandlerError(
-                    waddle_xmpp::muc::room_actor::RoomActorError::NickAlreadyInUse(_)
-                )
-            );
-            if nick_collision {
-                warn!(
-                    room = %room_jid,
-                    nick = %nick,
-                    sender = %sender_jid,
-                    "MUC nick collision; returning conflict"
-                );
-                return vec![build_muc_conflict_presence_xml(room_jid, nick, sender_jid)];
+            let admission_members_only = existing_room_snapshot
+                .as_ref()
+                .map(|snapshot| snapshot.room.config.members_only)
+                .unwrap_or(channel.members_only);
+            match resolve_managed_channel_affiliation(
+                state,
+                session,
+                &channel.id,
+                admission_members_only,
+            )
+            .await
+            {
+                Ok(Some(Affiliation::Outcast)) => {
+                    return vec![build_muc_presence_error_xml(
+                        room_jid,
+                        &nick,
+                        sender_jid,
+                        StanzaError::new(
+                            ErrorType::Auth,
+                            DefinedCondition::Forbidden,
+                            "en",
+                            "Banned from managed channel.",
+                        ),
+                    )];
+                }
+                Ok(Some(affiliation)) => Some(affiliation),
+                Ok(None) => {
+                    if admission_members_only {
+                        return vec![build_muc_presence_error_xml(
+                            room_jid,
+                            &nick,
+                            sender_jid,
+                            StanzaError::new(
+                                ErrorType::Auth,
+                                DefinedCondition::RegistrationRequired,
+                                "en",
+                                "Membership required to join managed channel.",
+                            ),
+                        )];
+                    }
+                    Some(Affiliation::None)
+                }
+                Err(()) => {
+                    return vec![build_muc_presence_error_xml(
+                        room_jid,
+                        &nick,
+                        sender_jid,
+                        StanzaError::new(
+                            ErrorType::Wait,
+                            DefinedCondition::InternalServerError,
+                            "en",
+                            "Failed to resolve managed-channel affiliation.",
+                        ),
+                    )];
+                }
             }
-            warn!(room = %room_jid, nick = %nick, error = ?error, "Failed to join MUC room");
-            return vec![];
+        } else {
+            None
+        };
+
+        let (room_actor, created_instant_room) = match existing_room_actor {
+            Some(actor) => (actor, false),
+            None => {
+                if managed_channel.is_none()
+                    && !server_permission_allowed(
+                        state,
+                        authenticated_session.as_ref(),
+                        Permission::CreateMuc,
+                    )
+                    .await
+                    .unwrap_or(false)
+                {
+                    return vec![build_muc_presence_error_xml(
+                        room_jid,
+                        &nick,
+                        sender_jid,
+                        StanzaError::new(
+                            ErrorType::Cancel,
+                            DefinedCondition::NotAllowed,
+                            "en",
+                            "Creating new MUC rooms is not permitted for this account.",
+                        ),
+                    )];
+                }
+
+                let config = managed_channel
+                    .as_ref()
+                    .map(|channel| RoomConfig {
+                        name: channel.name.clone(),
+                        description: channel.description.clone(),
+                        members_only: channel.members_only,
+                        public_room: channel.public_room,
+                        moderated: channel.channel_type == "announcement",
+                        forum: channel.channel_type == "forum",
+                        group_dm: channel.channel_type == waddle_xmpp::admin::CHANNEL_TYPE_GROUP_DM,
+                        // #422: load persisted pin policy so the actor's
+                        // snapshot matches the channel's last-saved value
+                        // even after eviction.
+                        pin_permission: channel.pin_permission,
+                        ..Default::default()
+                    })
+                    .unwrap_or_else(|| RoomConfig {
+                        name: room_jid
+                            .node()
+                            .map(|n| n.to_string())
+                            .unwrap_or_else(|| "Room".to_string()),
+                        members_only: false,
+                        ..Default::default()
+                    });
+
+                let (waddle_id, channel_id) = managed_channel
+                    .as_ref()
+                    .map(|channel| {
+                        let (waddle_id, _) = parse_room_jid_context(room_jid);
+                        (waddle_id, channel.id.clone())
+                    })
+                    .unwrap_or_else(|| parse_room_jid_context(room_jid));
+
+                let Some(actor) =
+                    get_or_create_room_actor(state, room_jid, config, waddle_id, channel_id).await
+                else {
+                    return vec![];
+                };
+                (actor, managed_channel.is_none())
+            }
+        };
+
+        let effective_affiliation = if created_instant_room {
+            Affiliation::Owner
+        } else if let Some(affiliation) = managed_affiliation {
+            affiliation
+        } else {
+            Affiliation::None
+        };
+
+        let join_outcome = match room_actor
+            .ask(JoinWithAffiliation {
+                sender_jid: sender_jid.clone(),
+                nick: nick.clone(),
+                effective_affiliation,
+                local_domain: domain.clone(),
+                admission_revision,
+            })
+            .await
+        {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                let nick_collision = matches!(
+                    &error,
+                    kameo::error::SendError::HandlerError(
+                        waddle_xmpp::muc::room_actor::RoomActorError::NickAlreadyInUse(_)
+                    )
+                );
+                if nick_collision {
+                    warn!(
+                        room = %room_jid,
+                        nick = %nick,
+                        sender = %sender_jid,
+                        "MUC nick collision; returning conflict"
+                    );
+                    return vec![build_muc_conflict_presence_xml(room_jid, &nick, sender_jid)];
+                }
+                if let kameo::error::SendError::HandlerError(
+                    waddle_xmpp::muc::room_actor::RoomActorError::StaleAdmissionRevision,
+                ) = &error
+                {
+                    if !retried_stale_admission {
+                        retried_stale_admission = true;
+                        continue;
+                    }
+                    return vec![build_muc_presence_error_xml(
+                        room_jid,
+                        &nick,
+                        sender_jid,
+                        StanzaError::new(
+                            ErrorType::Wait,
+                            DefinedCondition::InternalServerError,
+                            "en",
+                            "Room admission changed while joining; please retry.",
+                        ),
+                    )];
+                }
+                if let kameo::error::SendError::HandlerError(
+                    waddle_xmpp::muc::room_actor::RoomActorError::JoinForbidden { members_only },
+                ) = &error
+                {
+                    let (error_type, condition, message) = if *members_only {
+                        (
+                            ErrorType::Auth,
+                            DefinedCondition::RegistrationRequired,
+                            "Membership required to join this room.",
+                        )
+                    } else {
+                        (
+                            ErrorType::Auth,
+                            DefinedCondition::Forbidden,
+                            "You are not allowed to join this room.",
+                        )
+                    };
+                    return vec![build_muc_presence_error_xml(
+                        room_jid,
+                        &nick,
+                        sender_jid,
+                        StanzaError::new(error_type, condition, "en", message),
+                    )];
+                }
+                warn!(room = %room_jid, nick = %nick, error = ?error, "Failed to join MUC room");
+                return vec![];
+            }
+        };
+
+        let occupant_count = join_outcome.occupant_count;
+        let self_muji = join_outcome
+            .existing_occupants
+            .iter()
+            .find(|existing| existing.nick == nick && existing.jid == *sender_jid)
+            .and_then(|existing| existing.muji.as_ref());
+        let self_hand_raised = join_outcome
+            .existing_occupants
+            .iter()
+            .find(|existing| existing.nick == nick && existing.jid == *sender_jid)
+            .is_some_and(|existing| existing.hand_raised);
+
+        info!(room = %room_jid, nick = %nick, occupants = occupant_count, "User joined MUC room");
+
+        // Notification activity ingest (slice 2b): a successful MUC join
+        // bumps `(sender_bare, room)` activity. The XEP-0513 `<active/>`
+        // filter consults this projection to admit ActiveChannelMention
+        // pushes for users who are present in the room. `presence_show` is
+        // passed in by the caller (`handle_presence`) when the incoming
+        // presence carried a typed `<show/>` token; on first join (or
+        // when no `<show/>` is present) we record `None` so the column
+        // stays NULL until the user actually broadcasts a state.
+        crate::server::routes::interpret::record_presence_available_activity_on_state(
+            state,
+            &sender_jid.to_bare(),
+            room_jid,
+            presence_show,
+        )
+        .await;
+
+        let mut responses = Vec::new();
+
+        // Replay one base occupant presence per nick to the joiner, then
+        // append extra same-nick Muji payloads for additional sessions
+        // that own call state. Active call membership is nick-level, but
+        // XEP-0272 preparing is resource-owned coordination state, so the
+        // joiner needs the exact full JID that advertised it.
+        let mut replayed_nicks = std::collections::HashSet::new();
+        let replay_occupants: Vec<_> = join_outcome
+            .existing_occupants
+            .iter()
+            .filter(|existing| existing.nick != nick)
+            .collect();
+        for existing in replay_occupants
+            .iter()
+            .copied()
+            .filter(|existing| replayed_nicks.insert(existing.nick.clone()))
+        {
+            // XEP-0045 §7.2 conformant occupant-list replay, plus the
+            // typed `<call xmlns='urn:waddle:muc-call:0'/>` extension when
+            // the room actor's snapshot still has an active advertisement
+            // for that occupant. Without this enrichment the joiner only
+            // sees the chip light up via the NEXT presence update from a
+            // call participant, which never happens if the call is steady
+            // state — the late joiner is the one we're trying to help.
+            responses.push(build_muc_join_presence_xml(MucJoinPresence {
+                occupant_id_secret: &state.deps.occupant_id_secret,
+                room_jid,
+                nick: &existing.nick,
+                to_jid: sender_jid,
+                affiliation: existing.affiliation,
+                role: existing.role,
+                real_jid: &existing.jid,
+                include_self_status: false,
+                muji: existing.muji.as_ref(),
+                hand_raised: existing.hand_raised,
+            }));
+
+            for extra in replay_occupants.iter().copied().filter(|candidate| {
+                candidate.nick == existing.nick
+                    && candidate.jid != existing.jid
+                    && (candidate.muji.is_some() || candidate.hand_raised)
+            }) {
+                responses.push(build_muc_join_presence_xml(MucJoinPresence {
+                    occupant_id_secret: &state.deps.occupant_id_secret,
+                    room_jid,
+                    nick: &extra.nick,
+                    to_jid: sender_jid,
+                    affiliation: extra.affiliation,
+                    role: extra.role,
+                    real_jid: &extra.jid,
+                    include_self_status: false,
+                    muji: extra.muji.as_ref(),
+                    hand_raised: extra.hand_raised,
+                }));
+            }
         }
-    };
 
-    let occupant_count = join_outcome.occupant_count;
-    let self_muji = join_outcome
-        .existing_occupants
-        .iter()
-        .find(|existing| existing.nick == nick && existing.jid == *sender_jid)
-        .and_then(|existing| existing.muji.as_ref());
-    let self_hand_raised = join_outcome
-        .existing_occupants
-        .iter()
-        .find(|existing| existing.nick == nick && existing.jid == *sender_jid)
-        .is_some_and(|existing| existing.hand_raised);
+        // Broadcast the new occupant's presence to all existing occupants.
+        // Non-blocking: a zombied/slow consumer must never stall the join path,
+        // which is how "Timed out waiting for self-presence" cascades start.
+        // Drop accounting is handled inside `try_send_to` (logs + metrics);
+        // per-occupant outcome is discarded here because a missed join
+        // presence self-heals via the next MUC presence/probe round-trip.
+        if !join_outcome.is_same_bare_multi_session_join && !join_outcome.is_existing_session_rejoin
+        {
+            for existing in &join_outcome.existing_occupants {
+                let presence_stanza = create_presence_stanza(
+                    state,
+                    room_jid,
+                    &nick,
+                    sender_jid,
+                    &existing.jid,
+                    join_outcome.new_occupant_affiliation,
+                    join_outcome.new_occupant_role,
+                );
+                let stanza = Stanza::Presence(presence_stanza);
+                let _outcome = state
+                    .deps
+                    .protocol
+                    .connection_registry
+                    .try_send_to(&existing.jid, stanza);
+            }
+        }
 
-    info!(room = %room_jid, nick = %nick, occupants = occupant_count, "User joined MUC room");
-
-    // Notification activity ingest (slice 2b): a successful MUC join
-    // bumps `(sender_bare, room)` activity. The XEP-0513 `<active/>`
-    // filter consults this projection to admit ActiveChannelMention
-    // pushes for users who are present in the room. `presence_show` is
-    // passed in by the caller (`handle_presence`) when the incoming
-    // presence carried a typed `<show/>` token; on first join (or
-    // when no `<show/>` is present) we record `None` so the column
-    // stays NULL until the user actually broadcasts a state.
-    crate::server::routes::interpret::record_presence_available_activity_on_state(
-        state,
-        &sender_jid.to_bare(),
-        room_jid,
-        presence_show,
-    )
-    .await;
-
-    let mut responses = Vec::new();
-
-    // Replay one base occupant presence per nick to the joiner, then
-    // append extra same-nick Muji payloads for additional sessions
-    // that own call state. Active call membership is nick-level, but
-    // XEP-0272 preparing is resource-owned coordination state, so the
-    // joiner needs the exact full JID that advertised it.
-    let mut replayed_nicks = std::collections::HashSet::new();
-    let replay_occupants: Vec<_> = join_outcome
-        .existing_occupants
-        .iter()
-        .filter(|existing| existing.nick != nick)
-        .collect();
-    for existing in replay_occupants
-        .iter()
-        .copied()
-        .filter(|existing| replayed_nicks.insert(existing.nick.clone()))
-    {
-        // XEP-0045 §7.2 conformant occupant-list replay, plus the
-        // typed `<call xmlns='urn:waddle:muc-call:0'/>` extension when
-        // the room actor's snapshot still has an active advertisement
-        // for that occupant. Without this enrichment the joiner only
-        // sees the chip light up via the NEXT presence update from a
-        // call participant, which never happens if the call is steady
-        // state — the late joiner is the one we're trying to help.
+        // Send self-presence to the joining user (with status code 110)
         responses.push(build_muc_join_presence_xml(MucJoinPresence {
             occupant_id_secret: &state.deps.occupant_id_secret,
             room_jid,
-            nick: &existing.nick,
+            nick: &nick,
             to_jid: sender_jid,
-            affiliation: existing.affiliation,
-            role: existing.role,
-            real_jid: &existing.jid,
-            include_self_status: false,
-            muji: existing.muji.as_ref(),
-            hand_raised: existing.hand_raised,
+            affiliation: join_outcome.new_occupant_affiliation,
+            role: join_outcome.new_occupant_role,
+            real_jid: sender_jid,
+            include_self_status: true,
+            muji: self_muji,
+            hand_raised: self_hand_raised,
         }));
 
-        for extra in replay_occupants.iter().copied().filter(|candidate| {
-            candidate.nick == existing.nick
-                && candidate.jid != existing.jid
-                && (candidate.muji.is_some() || candidate.hand_raised)
+        // Same-account sibling resources share one MUC nick. If a
+        // sibling already advertised Muji for this nick, reflect exact
+        // per-session snapshots after the new session's own plain
+        // self-presence so a refresh/new tab can show "call active on
+        // another device" without misattributing `<preparing/>` to the
+        // joining resource.
+        for existing in join_outcome.existing_occupants.iter().filter(|existing| {
+            existing.nick == nick
+                && existing.jid.to_bare() == sender_jid.to_bare()
+                && existing.jid != *sender_jid
+                && (existing.muji.is_some() || existing.hand_raised)
         }) {
             responses.push(build_muc_join_presence_xml(MucJoinPresence {
                 occupant_id_secret: &state.deps.occupant_id_secret,
                 room_jid,
-                nick: &extra.nick,
+                nick: &nick,
                 to_jid: sender_jid,
-                affiliation: extra.affiliation,
-                role: extra.role,
-                real_jid: &extra.jid,
-                include_self_status: false,
-                muji: extra.muji.as_ref(),
-                hand_raised: extra.hand_raised,
+                affiliation: existing.affiliation,
+                role: existing.role,
+                real_jid: &existing.jid,
+                include_self_status: true,
+                muji: existing.muji.as_ref(),
+                hand_raised: existing.hand_raised,
             }));
         }
-    }
 
-    // Broadcast the new occupant's presence to all existing occupants.
-    // Non-blocking: a zombied/slow consumer must never stall the join path,
-    // which is how "Timed out waiting for self-presence" cascades start.
-    // Drop accounting is handled inside `try_send_to` (logs + metrics);
-    // per-occupant outcome is discarded here because a missed join
-    // presence self-heals via the next MUC presence/probe round-trip.
-    if !join_outcome.is_same_bare_multi_session_join && !join_outcome.is_existing_session_rejoin {
-        for existing in &join_outcome.existing_occupants {
-            let presence_stanza = create_presence_stanza(
-                state,
-                room_jid,
-                nick,
-                sender_jid,
-                &existing.jid,
-                join_outcome.new_occupant_affiliation,
-                join_outcome.new_occupant_role,
-            );
-            let stanza = Stanza::Presence(presence_stanza);
-            let _outcome = state
-                .deps
-                .protocol
-                .connection_registry
-                .try_send_to(&existing.jid, stanza);
-        }
-    }
-
-    // Send self-presence to the joining user (with status code 110)
-    responses.push(build_muc_join_presence_xml(MucJoinPresence {
-        occupant_id_secret: &state.deps.occupant_id_secret,
-        room_jid,
-        nick,
-        to_jid: sender_jid,
-        affiliation: join_outcome.new_occupant_affiliation,
-        role: join_outcome.new_occupant_role,
-        real_jid: sender_jid,
-        include_self_status: true,
-        muji: self_muji,
-        hand_raised: self_hand_raised,
-    }));
-
-    // Same-account sibling resources share one MUC nick. If a
-    // sibling already advertised Muji for this nick, reflect exact
-    // per-session snapshots after the new session's own plain
-    // self-presence so a refresh/new tab can show "call active on
-    // another device" without misattributing `<preparing/>` to the
-    // joining resource.
-    for existing in join_outcome.existing_occupants.iter().filter(|existing| {
-        existing.nick == nick
-            && existing.jid.to_bare() == sender_jid.to_bare()
-            && existing.jid != *sender_jid
-            && (existing.muji.is_some() || existing.hand_raised)
-    }) {
-        responses.push(build_muc_join_presence_xml(MucJoinPresence {
-            occupant_id_secret: &state.deps.occupant_id_secret,
+        // XEP-0045 §7.2.15 historical room subject. The typed builder
+        // produces the conformant envelope: nick-form `from` + `<delay/>`
+        // + XEP-0421 `<occupant-id/>` when a setter is known, or bare-from
+        // empty `<subject/>` for a never-set room (matching the established
+        // resolution of XEP-0421 §3 vs §7.2.15 on never-set rooms).
+        let subject_msg = build_subject_message(
             room_jid,
-            nick,
-            to_jid: sender_jid,
-            affiliation: existing.affiliation,
-            role: existing.role,
-            real_jid: &existing.jid,
-            include_self_status: true,
-            muji: existing.muji.as_ref(),
-            hand_raised: existing.hand_raised,
-        }));
+            sender_jid,
+            join_outcome.subject_state.as_ref(),
+            &state.deps.occupant_id_secret,
+        );
+        responses.push(stanza_to_xml(&Stanza::Message(subject_msg)));
+
+        return responses;
     }
-
-    // XEP-0045 §7.2.15 historical room subject. The typed builder
-    // produces the conformant envelope: nick-form `from` + `<delay/>`
-    // + XEP-0421 `<occupant-id/>` when a setter is known, or bare-from
-    // empty `<subject/>` for a never-set room (matching the established
-    // resolution of XEP-0421 §3 vs §7.2.15 on never-set rooms).
-    let subject_msg = build_subject_message(
-        room_jid,
-        sender_jid,
-        join_outcome.subject_state.as_ref(),
-        &state.deps.occupant_id_secret,
-    );
-    responses.push(stanza_to_xml(&Stanza::Message(subject_msg)));
-
-    responses
 }
 
 /// Handle MUC room leave

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc/access.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc/access.rs
@@ -4,6 +4,7 @@ pub(super) async fn resolve_managed_channel_affiliation(
     state: &WebSocketState,
     session: &Session,
     channel_id: &str,
+    members_only: bool,
 ) -> Result<Option<Affiliation>, ()> {
     let object = Object::new(ObjectType::Channel, channel_id);
     let subject = Subject::user(&session.user_jid);
@@ -28,7 +29,7 @@ pub(super) async fn resolve_managed_channel_affiliation(
         }
     }
 
-    if matches!(channel_id, "chat" | "announcements" | "github-actions") {
+    if !members_only && matches!(channel_id, "chat" | "announcements" | "github-actions") {
         let server = Object::new(ObjectType::Server, DEPLOYMENT_SERVER_ID);
         if check_channel_permission(state, server.clone(), subject.clone(), Permission::Owner)
             .await?
@@ -45,9 +46,6 @@ pub(super) async fn resolve_managed_channel_affiliation(
         }
     }
 
-    if check_channel_permission(state, object, subject, Permission::Read).await? {
-        return Ok(Some(Affiliation::Member));
-    }
     Ok(None)
 }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests.rs
@@ -11,7 +11,9 @@ use super::{
 };
 use crate::config::ServerConfig;
 use crate::db::{DatabaseConfig, DatabasePool, MigrationRunner, PoolConfig};
-use crate::permissions::{Object, ObjectType, Permission, Relation, Subject, Tuple, WriteTuple};
+use crate::permissions::{
+    CheckPermission, Object, ObjectType, Permission, Relation, Subject, Tuple, WriteTuple,
+};
 use crate::server::bootstrap_membership::DEPLOYMENT_SERVER_ID;
 use crate::server::AppState;
 use hmac::{Hmac, KeyInit, Mac};
@@ -29,7 +31,8 @@ use handlers::presence::{handle_muc_join, handle_muc_leave, parse_room_jid_conte
 use waddle_extensions::ExtensionConfig;
 use waddle_xmpp::commands::{CommandContext, CommandResult};
 use waddle_xmpp::muc::room_actor::{
-    ChangeAffiliation, GetSnapshot, JoinWithAffiliation, SetSubject, UpdateConfig,
+    ApplyAdminItems, ChangeAffiliation, GetConfig, GetSnapshot, JoinWithAffiliation, SetSubject,
+    UpdateConfig,
 };
 use waddle_xmpp::registry::BroadcastOutcome;
 use waddle_xmpp::Affiliation;

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
@@ -189,6 +189,7 @@ async fn link_preview_lookup_for_muc_scope_allows_current_occupant_before_resolv
             nick: "alice".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: 0,
         })
         .await
         .expect("join room");

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
@@ -1,5 +1,15 @@
 use super::*;
 
+async fn current_admission_revision(
+    room_actor: &kameo::actor::ActorRef<waddle_xmpp::muc::room_actor::RoomActor>,
+) -> u64 {
+    room_actor
+        .ask(GetSnapshot)
+        .await
+        .expect("room snapshot")
+        .admission_revision
+}
+
 fn dm_call_message(from: &str, to: &str, payload: Element) -> xmpp_parsers::message::Message {
     let mut message = xmpp_parsers::message::Message::new(Some(to.parse().expect("to jid")));
     message.from = Some(from.parse().expect("from jid"));
@@ -1358,6 +1368,7 @@ async fn groupchat_personal_mention_pushes_affiliated_non_live_member() {
             nick: "alice".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: current_admission_revision(&room_actor).await,
         })
         .await
         .expect("join alice");
@@ -1444,6 +1455,7 @@ async fn groupchat_xep0513_occupant_id_mention_pushes_affiliated_member() {
             nick: "alice".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: current_admission_revision(&room_actor).await,
         })
         .await
         .expect("join alice");
@@ -1531,6 +1543,7 @@ async fn groupchat_xep0492_never_suppresses_personal_mentions_and_plain_messages
                 nick: "alice".to_string(),
                 effective_affiliation: Affiliation::Member,
                 local_domain: "example.com".to_string(),
+                admission_revision: current_admission_revision(&room_actor).await,
             })
             .await
             .expect("join alice");
@@ -1752,6 +1765,7 @@ async fn groupchat_public_default_suppresses_plain_push_until_always() {
                 nick: "alice".to_string(),
                 effective_affiliation: Affiliation::Member,
                 local_domain: "example.com".to_string(),
+                admission_revision: current_admission_revision(&room_actor).await,
             })
             .await
             .expect("join alice");
@@ -1860,6 +1874,7 @@ async fn groupchat_channel_mention_for_foreign_room_does_not_ping_current_room()
             nick: "alice".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: current_admission_revision(&room_actor).await,
         })
         .await
         .expect("join alice");
@@ -1955,6 +1970,7 @@ async fn groupchat_active_channel_mention_pushes_live_occupants_only() {
             // sender's role is fixture scaffolding.
             effective_affiliation: Affiliation::Admin,
             local_domain: "example.com".to_string(),
+            admission_revision: current_admission_revision(&room_actor).await,
         })
         .await
         .expect("join alice");
@@ -1964,6 +1980,7 @@ async fn groupchat_active_channel_mention_pushes_live_occupants_only() {
             nick: "bob".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: current_admission_revision(&room_actor).await,
         })
         .await
         .expect("join bob");
@@ -2051,6 +2068,7 @@ async fn groupchat_active_channel_mention_does_not_expand_to_live_unaffiliated_o
             // `NotifyAll` + no durable recipient = empty jobs).
             effective_affiliation: Affiliation::Admin,
             local_domain: "example.com".to_string(),
+            admission_revision: current_admission_revision(&room_actor).await,
         })
         .await
         .expect("join alice");
@@ -2060,6 +2078,7 @@ async fn groupchat_active_channel_mention_does_not_expand_to_live_unaffiliated_o
             nick: "bob".to_string(),
             effective_affiliation: Affiliation::None,
             local_domain: "example.com".to_string(),
+            admission_revision: current_admission_revision(&room_actor).await,
         })
         .await
         .expect("join bob without durable affiliation");
@@ -2151,6 +2170,7 @@ async fn groupchat_active_channel_mention_preserves_notify_all_for_non_live_alwa
             // members-only path; sender role is scaffolding.
             effective_affiliation: Affiliation::Admin,
             local_domain: "example.com".to_string(),
+            admission_revision: current_admission_revision(&room_actor).await,
         })
         .await
         .expect("join alice");
@@ -2160,6 +2180,7 @@ async fn groupchat_active_channel_mention_preserves_notify_all_for_non_live_alwa
             nick: "bob".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: current_admission_revision(&room_actor).await,
         })
         .await
         .expect("join bob");
@@ -3412,6 +3433,7 @@ async fn handle_message_groupchat_rejects_client_authored_extension_envelope() {
             nick: "alice".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: current_admission_revision(&room_actor).await,
         })
         .await
         .expect("join alice");
@@ -3487,6 +3509,7 @@ async fn handle_message_groupchat_extension_envelope_preserves_non_occupant_erro
             nick: "bob".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: current_admission_revision(&room_actor).await,
         })
         .await
         .expect("join bob");
@@ -4083,6 +4106,7 @@ async fn groupchat_messages_are_archived_and_returned_via_mam() {
             nick: "alice".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: current_admission_revision(&room_actor).await,
         })
         .await
         .expect("join room");
@@ -4178,6 +4202,7 @@ async fn groupchat_preview_request_is_stamped_and_archived_without_private_paylo
             nick: "alice".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: current_admission_revision(&room_actor).await,
         })
         .await
         .expect("join room");

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -167,6 +167,280 @@ async fn xep_0045_join_replay_exposes_existing_occupant_real_jids() {
 }
 
 #[tokio::test]
+async fn managed_members_only_join_requires_explicit_channel_member_affiliation() {
+    let state = create_test_websocket_state().await;
+    let session = crate::auth::Session::new("alice@example.com", "alice", "alice");
+    let room_jid: BareJid = "private-space@muc.example.com".parse().expect("room jid");
+    let sender_jid: FullJid = "alice@example.com/web".parse().expect("sender jid");
+
+    crate::server::xmpp_state::upsert_xmpp_channel(
+        state.deps.app_state.db_pool.global_actor().clone(),
+        &crate::server::xmpp_state::XmppChannelUpsert {
+            id: "private-space".to_string(),
+            name: "Private Space".to_string(),
+            description: None,
+            channel_type: "channel".to_string(),
+            position: 0,
+            is_default: false,
+            pin_permission: waddle_xmpp::muc::PinPermission::Anyone,
+            members_only: true,
+            public_room: false,
+        },
+    )
+    .await
+    .expect("channel upsert");
+
+    state
+        .deps
+        .app_state
+        .permission_actor
+        .ask(WriteTuple {
+            tuple: Tuple::new(
+                Object::new(ObjectType::Channel, "private-space"),
+                Relation::new("parent"),
+                Subject::userset(crate::permissions::SubjectType::Space, "team", ""),
+            ),
+        })
+        .await
+        .expect("channel parent tuple");
+    state
+        .deps
+        .app_state
+        .permission_actor
+        .ask(WriteTuple {
+            tuple: Tuple::new(
+                Object::new(ObjectType::Space, "team"),
+                Relation::new("member"),
+                Subject::user(&session.user_jid),
+            ),
+        })
+        .await
+        .expect("space member tuple");
+
+    crate::server::xmpp_state::upsert_xmpp_channel(
+        state.deps.app_state.db_pool.global_actor().clone(),
+        &crate::server::xmpp_state::XmppChannelUpsert {
+            id: "open-space".to_string(),
+            name: "Open Space".to_string(),
+            description: None,
+            channel_type: "channel".to_string(),
+            position: 0,
+            is_default: false,
+            pin_permission: waddle_xmpp::muc::PinPermission::Anyone,
+            members_only: false,
+            public_room: true,
+        },
+    )
+    .await
+    .expect("open channel upsert");
+    state
+        .deps
+        .app_state
+        .permission_actor
+        .ask(WriteTuple {
+            tuple: Tuple::new(
+                Object::new(ObjectType::Channel, "open-space"),
+                Relation::new("parent"),
+                Subject::userset(crate::permissions::SubjectType::Space, "team", ""),
+            ),
+        })
+        .await
+        .expect("open channel parent tuple");
+    let open_room_jid: BareJid = "open-space@muc.example.com".parse().expect("open room jid");
+    let open_join = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &open_room_jid,
+        &sender_jid,
+        "alice",
+        None,
+        &Some(session.clone()),
+    )
+    .await;
+    assert!(
+        open_join
+            .first()
+            .is_some_and(|frame| frame.contains("affiliation='none'")
+                || frame.contains(r#"affiliation="none""#)),
+        "inherited read access must not masquerade as persistent MUC membership in open rooms: {open_join:?}"
+    );
+
+    let denied = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &sender_jid,
+        "alice",
+        None,
+        &Some(session.clone()),
+    )
+    .await;
+    assert_eq!(denied.len(), 1);
+    assert!(
+        denied[0].contains("registration-required"),
+        "members-only MUC admission must not treat inherited read access as membership: {denied:?}"
+    );
+    assert!(
+        get_room_actor(state.as_ref(), &room_jid).await.is_none(),
+        "denied members-only join must not create the room actor"
+    );
+
+    state
+        .deps
+        .app_state
+        .permission_actor
+        .ask(WriteTuple {
+            tuple: Tuple::new(
+                Object::new(ObjectType::Channel, "private-space"),
+                Relation::new("member"),
+                Subject::user(&session.user_jid),
+            ),
+        })
+        .await
+        .expect("channel member tuple");
+
+    let admitted = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &sender_jid,
+        "alice",
+        None,
+        &Some(session),
+    )
+    .await;
+    assert!(
+        admitted
+            .first()
+            .is_some_and(|frame| frame.contains("affiliation='member'")
+                || frame.contains(r#"affiliation="member""#)),
+        "explicit channel member affiliation must admit the members-only join: {admitted:?}"
+    );
+}
+
+#[tokio::test]
+async fn managed_join_uses_live_actor_members_only_config_over_stale_channel_row() {
+    let state = create_test_websocket_state().await;
+    let session = create_test_session(state.as_ref(), "bob").await;
+    let room_jid: BareJid = "chat@muc.example.com".parse().expect("room jid");
+    let sender_jid: FullJid = "bob@example.com/web".parse().expect("sender jid");
+
+    crate::server::xmpp_state::upsert_xmpp_channel(
+        state.deps.app_state.db_pool.global_actor().clone(),
+        &crate::server::xmpp_state::XmppChannelUpsert {
+            id: "chat".to_string(),
+            name: "Chat".to_string(),
+            description: None,
+            channel_type: "channel".to_string(),
+            position: 0,
+            is_default: true,
+            pin_permission: waddle_xmpp::muc::PinPermission::Anyone,
+            members_only: false,
+            public_room: true,
+        },
+    )
+    .await
+    .expect("channel upsert");
+    state
+        .deps
+        .app_state
+        .permission_actor
+        .ask(WriteTuple {
+            tuple: Tuple::new(
+                Object::new(ObjectType::Server, DEPLOYMENT_SERVER_ID),
+                Relation::new("member"),
+                Subject::user(&session.user_jid),
+            ),
+        })
+        .await
+        .expect("server member tuple");
+
+    let actor = get_or_create_room_actor(
+        state.as_ref(),
+        &room_jid,
+        RoomConfig {
+            members_only: true,
+            ..RoomConfig::default()
+        },
+        "space".to_string(),
+        "chat".to_string(),
+    )
+    .await
+    .expect("room actor");
+
+    let denied = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &sender_jid,
+        "bob",
+        None,
+        &Some(session),
+    )
+    .await;
+
+    assert_eq!(denied.len(), 1);
+    assert!(
+        denied[0].contains("registration-required"),
+        "live actor members-only config must override stale open channel row: {denied:?}"
+    );
+    let snapshot = actor.ask(GetSnapshot).await.expect("snapshot").room;
+    assert!(snapshot.find_nick_by_real_jid(&sender_jid).is_none());
+}
+
+#[tokio::test]
+async fn standard_members_only_join_rejects_unaffiliated_user() {
+    let state = create_test_websocket_state().await;
+    let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let room_jid: BareJid = "standard-private@muc.example.com"
+        .parse()
+        .expect("room jid");
+    let alice_jid: FullJid = "alice@example.com/web".parse().expect("alice jid");
+    let bob_jid: FullJid = "bob@example.com/web".parse().expect("bob jid");
+
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &alice_jid,
+        "alice",
+        None,
+        &Some(owner_session),
+    )
+    .await;
+
+    let actor = get_room_actor(state.as_ref(), &room_jid)
+        .await
+        .expect("room actor");
+    let mut config = actor.ask(GetConfig).await.expect("config");
+    config.members_only = true;
+    actor
+        .ask(UpdateConfig { config })
+        .await
+        .expect("members-only config");
+
+    let denied = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &bob_jid,
+        "bob",
+        None,
+        &None,
+    )
+    .await;
+
+    assert_eq!(denied.len(), 1);
+    assert!(
+        denied[0].contains("registration-required"),
+        "standard members-only MUC admission must reject unaffiliated users: {denied:?}"
+    );
+    let snapshot = actor.ask(GetSnapshot).await.expect("snapshot").room;
+    assert_eq!(snapshot.occupant_count(), 1);
+    assert!(snapshot.find_nick_by_real_jid(&bob_jid).is_none());
+}
+
+#[tokio::test]
 async fn xep_0045_section_7_2_15_join_replay_serializes_full_subject_envelope() {
     // Boundary test for the WebSocket join wiring (Copilot review,
     // PR #319). Pre-populates `MucRoom.subject` with a multi-language
@@ -311,6 +585,1065 @@ fn test_parse_room_jid_fallback() {
     let (waddle, channel) = parse_room_jid_context(&jid);
     assert_eq!(waddle, "space");
     assert_eq!(channel, "singlename");
+}
+
+#[tokio::test]
+async fn native_muc_admin_rejects_mixed_role_and_affiliation_set() {
+    let state = create_test_websocket_state().await;
+    let session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let room_jid: BareJid = "admin-mixed@muc.example.com".parse().expect("room jid");
+    let alice_jid: FullJid = "alice@example.com/web".parse().expect("alice jid");
+    let ready = ready_phase(&alice_jid);
+
+    handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &alice_jid,
+        "alice",
+        None,
+        &Some(session.clone()),
+    )
+    .await;
+
+    let admin_iq = element_to_xml(
+        Element::builder("iq", waddle_xmpp::ns::JABBER_CLIENT)
+            .attr(minidom::rxml::xml_ncname!("id").to_owned(), "admin-mixed")
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "set")
+            .attr(
+                minidom::rxml::xml_ncname!("to").to_owned(),
+                room_jid.to_string(),
+            )
+            .append(
+                Element::builder("query", waddle_xmpp::muc::NS_MUC_ADMIN)
+                    .append(
+                        Element::builder("item", waddle_xmpp::muc::NS_MUC_ADMIN)
+                            .attr(minidom::rxml::xml_ncname!("nick").to_owned(), "alice")
+                            .attr(minidom::rxml::xml_ncname!("role").to_owned(), "none")
+                            .attr(
+                                minidom::rxml::xml_ncname!("jid").to_owned(),
+                                "alice@example.com",
+                            )
+                            .attr(
+                                minidom::rxml::xml_ncname!("affiliation").to_owned(),
+                                "outcast",
+                            )
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build(),
+    );
+
+    let responses = handle_iq(
+        &admin_iq,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(session),
+        &ready,
+    )
+    .await;
+    assert_eq!(responses.len(), 1, "admin response: {responses:?}");
+    assert!(responses[0].contains("type='error'"));
+    assert!(responses[0].contains("bad-request"));
+
+    let snapshot = get_room_actor(state.as_ref(), &room_jid)
+        .await
+        .expect("room actor")
+        .ask(GetSnapshot)
+        .await
+        .expect("snapshot")
+        .room;
+    assert_eq!(snapshot.occupant_count(), 1);
+    assert_ne!(
+        snapshot.get_affiliation(&alice_jid.to_bare()),
+        Affiliation::Outcast
+    );
+}
+
+#[tokio::test]
+async fn native_muc_admin_last_owner_demotion_returns_conflict() {
+    let state = create_test_websocket_state().await;
+    let session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let room_jid: BareJid = "admin-last-owner@muc.example.com"
+        .parse()
+        .expect("room jid");
+    let alice_jid: FullJid = "alice@example.com/web".parse().expect("alice jid");
+    let ready = ready_phase(&alice_jid);
+
+    handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &alice_jid,
+        "alice",
+        None,
+        &Some(session.clone()),
+    )
+    .await;
+
+    let admin_iq = element_to_xml(
+        Element::builder("iq", waddle_xmpp::ns::JABBER_CLIENT)
+            .attr(
+                minidom::rxml::xml_ncname!("id").to_owned(),
+                "admin-last-owner",
+            )
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "set")
+            .attr(
+                minidom::rxml::xml_ncname!("to").to_owned(),
+                room_jid.to_string(),
+            )
+            .append(
+                Element::builder("query", waddle_xmpp::muc::NS_MUC_ADMIN)
+                    .append(
+                        Element::builder("item", waddle_xmpp::muc::NS_MUC_ADMIN)
+                            .attr(
+                                minidom::rxml::xml_ncname!("jid").to_owned(),
+                                "alice@example.com",
+                            )
+                            .attr(
+                                minidom::rxml::xml_ncname!("affiliation").to_owned(),
+                                "member",
+                            )
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build(),
+    );
+
+    let responses = handle_iq(
+        &admin_iq,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(session),
+        &ready,
+    )
+    .await;
+    assert_eq!(responses.len(), 1, "admin response: {responses:?}");
+    assert!(responses[0].contains("type='error'"));
+    assert!(responses[0].contains("conflict"));
+
+    let snapshot = get_room_actor(state.as_ref(), &room_jid)
+        .await
+        .expect("room actor")
+        .ask(GetSnapshot)
+        .await
+        .expect("snapshot")
+        .room;
+    assert_eq!(
+        snapshot.get_affiliation(&alice_jid.to_bare()),
+        Affiliation::Owner
+    );
+}
+
+#[tokio::test]
+async fn native_muc_admin_admin_banning_owner_returns_not_allowed() {
+    let state = create_test_websocket_state().await;
+    let alice_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let bob_session = create_test_session(state.as_ref(), "bob").await;
+    let room_jid: BareJid = "admin-owner-ban@muc.example.com".parse().expect("room jid");
+    let alice_jid: FullJid = "alice@example.com/web".parse().expect("alice jid");
+    let bob_jid: FullJid = "bob@example.com/web".parse().expect("bob jid");
+    let carol_bare: BareJid = "carol@example.com".parse().expect("carol jid");
+    let ready = ready_phase(&bob_jid);
+
+    handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &alice_jid,
+        "alice",
+        None,
+        &Some(alice_session),
+    )
+    .await;
+
+    let actor = get_room_actor(state.as_ref(), &room_jid)
+        .await
+        .expect("room actor");
+    actor
+        .ask(ChangeAffiliation {
+            jid: bob_jid.to_bare(),
+            affiliation: Affiliation::Admin,
+        })
+        .await
+        .expect("bob admin affiliation");
+    actor
+        .ask(ChangeAffiliation {
+            jid: carol_bare,
+            affiliation: Affiliation::Owner,
+        })
+        .await
+        .expect("second owner affiliation");
+
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &bob_jid,
+        "bob",
+        None,
+        &Some(bob_session.clone()),
+    )
+    .await;
+
+    let admin_iq = element_to_xml(
+        Element::builder("iq", waddle_xmpp::ns::JABBER_CLIENT)
+            .attr(
+                minidom::rxml::xml_ncname!("id").to_owned(),
+                "admin-owner-ban",
+            )
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "set")
+            .attr(
+                minidom::rxml::xml_ncname!("to").to_owned(),
+                room_jid.to_string(),
+            )
+            .append(
+                Element::builder("query", waddle_xmpp::muc::NS_MUC_ADMIN)
+                    .append(
+                        Element::builder("item", waddle_xmpp::muc::NS_MUC_ADMIN)
+                            .attr(
+                                minidom::rxml::xml_ncname!("jid").to_owned(),
+                                "alice@example.com",
+                            )
+                            .attr(
+                                minidom::rxml::xml_ncname!("affiliation").to_owned(),
+                                "outcast",
+                            )
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build(),
+    );
+
+    let responses = handle_iq(
+        &admin_iq,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(bob_session),
+        &ready,
+    )
+    .await;
+    assert_eq!(responses.len(), 1, "admin response: {responses:?}");
+    assert!(responses[0].contains("type='error'"));
+    assert!(responses[0].contains("not-allowed"));
+
+    let snapshot = actor.ask(GetSnapshot).await.expect("snapshot").room;
+    assert_eq!(
+        snapshot.get_affiliation(&alice_jid.to_bare()),
+        Affiliation::Owner
+    );
+    assert_eq!(snapshot.find_nick_by_real_jid(&alice_jid), Some("alice"));
+}
+
+#[tokio::test]
+async fn native_muc_admin_admin_cannot_grant_admin_affiliation() {
+    let state = create_test_websocket_state().await;
+    let alice_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let bob_session = create_test_session(state.as_ref(), "bob").await;
+    let room_jid: BareJid = "admin-list-owner-only@muc.example.com"
+        .parse()
+        .expect("room jid");
+    let alice_jid: FullJid = "alice@example.com/web".parse().expect("alice jid");
+    let bob_jid: FullJid = "bob@example.com/web".parse().expect("bob jid");
+    let carol_bare: BareJid = "carol@example.com".parse().expect("carol jid");
+    let ready = ready_phase(&bob_jid);
+
+    handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &alice_jid,
+        "alice",
+        None,
+        &Some(alice_session),
+    )
+    .await;
+
+    let actor = get_room_actor(state.as_ref(), &room_jid)
+        .await
+        .expect("room actor");
+    actor
+        .ask(ChangeAffiliation {
+            jid: bob_jid.to_bare(),
+            affiliation: Affiliation::Admin,
+        })
+        .await
+        .expect("bob admin affiliation");
+    actor
+        .ask(ChangeAffiliation {
+            jid: carol_bare.clone(),
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("carol member affiliation");
+
+    let admin_iq = element_to_xml(
+        Element::builder("iq", waddle_xmpp::ns::JABBER_CLIENT)
+            .attr(
+                minidom::rxml::xml_ncname!("id").to_owned(),
+                "admin-grant-admin",
+            )
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "set")
+            .attr(
+                minidom::rxml::xml_ncname!("to").to_owned(),
+                room_jid.to_string(),
+            )
+            .append(
+                Element::builder("query", waddle_xmpp::muc::NS_MUC_ADMIN)
+                    .append(
+                        Element::builder("item", waddle_xmpp::muc::NS_MUC_ADMIN)
+                            .attr(
+                                minidom::rxml::xml_ncname!("jid").to_owned(),
+                                carol_bare.to_string(),
+                            )
+                            .attr(
+                                minidom::rxml::xml_ncname!("affiliation").to_owned(),
+                                "admin",
+                            )
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build(),
+    );
+
+    let responses = handle_iq(
+        &admin_iq,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(bob_session),
+        &ready,
+    )
+    .await;
+    assert_eq!(responses.len(), 1, "admin response: {responses:?}");
+    assert!(responses[0].contains("type='error'"));
+    assert!(responses[0].contains("forbidden"));
+
+    let snapshot = actor.ask(GetSnapshot).await.expect("snapshot").room;
+    assert_eq!(snapshot.get_affiliation(&carol_bare), Affiliation::Member);
+}
+
+#[tokio::test]
+async fn native_muc_admin_admin_cannot_kick_another_admin_role() {
+    let state = create_test_websocket_state().await;
+    let alice_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let bob_session = create_test_session(state.as_ref(), "bob").await;
+    let carol_session = create_test_session(state.as_ref(), "carol").await;
+    let room_jid: BareJid = "admin-role-admin-target@muc.example.com"
+        .parse()
+        .expect("room jid");
+    let alice_jid: FullJid = "alice@example.com/web".parse().expect("alice jid");
+    let bob_jid: FullJid = "bob@example.com/web".parse().expect("bob jid");
+    let carol_jid: FullJid = "carol@example.com/web".parse().expect("carol jid");
+    let ready = ready_phase(&bob_jid);
+
+    handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &alice_jid,
+        "alice",
+        None,
+        &Some(alice_session),
+    )
+    .await;
+
+    let actor = get_room_actor(state.as_ref(), &room_jid)
+        .await
+        .expect("room actor");
+    actor
+        .ask(ChangeAffiliation {
+            jid: bob_jid.to_bare(),
+            affiliation: Affiliation::Admin,
+        })
+        .await
+        .expect("bob admin affiliation");
+    actor
+        .ask(ChangeAffiliation {
+            jid: carol_jid.to_bare(),
+            affiliation: Affiliation::Admin,
+        })
+        .await
+        .expect("carol admin affiliation");
+
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &bob_jid,
+        "bob",
+        None,
+        &Some(bob_session.clone()),
+    )
+    .await;
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &carol_jid,
+        "carol",
+        None,
+        &Some(carol_session),
+    )
+    .await;
+
+    let admin_iq = element_to_xml(
+        Element::builder("iq", waddle_xmpp::ns::JABBER_CLIENT)
+            .attr(
+                minidom::rxml::xml_ncname!("id").to_owned(),
+                "admin-role-admin-target",
+            )
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "set")
+            .attr(
+                minidom::rxml::xml_ncname!("to").to_owned(),
+                room_jid.to_string(),
+            )
+            .append(
+                Element::builder("query", waddle_xmpp::muc::NS_MUC_ADMIN)
+                    .append(
+                        Element::builder("item", waddle_xmpp::muc::NS_MUC_ADMIN)
+                            .attr(minidom::rxml::xml_ncname!("nick").to_owned(), "carol")
+                            .attr(minidom::rxml::xml_ncname!("role").to_owned(), "none")
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build(),
+    );
+
+    let responses = handle_iq(
+        &admin_iq,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(bob_session),
+        &ready,
+    )
+    .await;
+    assert_eq!(responses.len(), 1, "admin response: {responses:?}");
+    assert!(responses[0].contains("type='error'"));
+    assert!(responses[0].contains("not-allowed"));
+
+    let snapshot = actor.ask(GetSnapshot).await.expect("snapshot").room;
+    let carol = snapshot.get_occupant("carol").expect("carol occupant");
+    assert_eq!(carol.role, waddle_xmpp::Role::Moderator);
+    assert_eq!(snapshot.find_nick_by_real_jid(&carol_jid), Some("carol"));
+}
+
+#[tokio::test]
+async fn native_muc_admin_membership_grant_allows_optional_nick() {
+    let state = create_test_websocket_state().await;
+    let alice_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let room_jid: BareJid = "admin-member-nick@muc.example.com"
+        .parse()
+        .expect("room jid");
+    let alice_jid: FullJid = "alice@example.com/web".parse().expect("alice jid");
+    let carol_bare: BareJid = "carol@example.com".parse().expect("carol jid");
+    let ready = ready_phase(&alice_jid);
+
+    handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &alice_jid,
+        "alice",
+        None,
+        &Some(alice_session.clone()),
+    )
+    .await;
+
+    let admin_iq = element_to_xml(
+        Element::builder("iq", waddle_xmpp::ns::JABBER_CLIENT)
+            .attr(
+                minidom::rxml::xml_ncname!("id").to_owned(),
+                "admin-member-nick",
+            )
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "set")
+            .attr(
+                minidom::rxml::xml_ncname!("to").to_owned(),
+                room_jid.to_string(),
+            )
+            .append(
+                Element::builder("query", waddle_xmpp::muc::NS_MUC_ADMIN)
+                    .append(
+                        Element::builder("item", waddle_xmpp::muc::NS_MUC_ADMIN)
+                            .attr(
+                                minidom::rxml::xml_ncname!("jid").to_owned(),
+                                carol_bare.to_string(),
+                            )
+                            .attr(
+                                minidom::rxml::xml_ncname!("affiliation").to_owned(),
+                                "member",
+                            )
+                            .attr(minidom::rxml::xml_ncname!("nick").to_owned(), "thirdwitch")
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build(),
+    );
+
+    let responses = handle_iq(
+        &admin_iq,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(alice_session),
+        &ready,
+    )
+    .await;
+    assert_eq!(responses.len(), 1, "admin response: {responses:?}");
+    assert!(responses[0].contains("type='result'"));
+
+    let snapshot = get_room_actor(state.as_ref(), &room_jid)
+        .await
+        .expect("room actor")
+        .ask(GetSnapshot)
+        .await
+        .expect("snapshot")
+        .room;
+    assert_eq!(snapshot.get_affiliation(&carol_bare), Affiliation::Member);
+}
+
+#[tokio::test]
+async fn native_muc_admin_get_role_list_accepts_role_without_nick() {
+    let state = create_test_websocket_state().await;
+    let alice_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let bob_session = create_test_session(state.as_ref(), "bob").await;
+    let room_jid: BareJid = "admin-role-list@muc.example.com".parse().expect("room jid");
+    let alice_jid: FullJid = "alice@example.com/web".parse().expect("alice jid");
+    let bob_jid: FullJid = "bob@example.com/web".parse().expect("bob jid");
+    let ready = ready_phase(&alice_jid);
+
+    handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &alice_jid,
+        "alice",
+        None,
+        &Some(alice_session.clone()),
+    )
+    .await;
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &bob_jid,
+        "bob",
+        None,
+        &Some(bob_session),
+    )
+    .await;
+
+    let actor = get_room_actor(state.as_ref(), &room_jid)
+        .await
+        .expect("room actor");
+    actor
+        .ask(ApplyAdminItems {
+            sender_jid: alice_jid.clone(),
+            sender_affiliation: Affiliation::Owner,
+            sender_role: waddle_xmpp::Role::Moderator,
+            items: vec![waddle_xmpp::muc::AdminItem {
+                jid: None,
+                nick: Some("bob".to_string()),
+                affiliation: None,
+                role: Some(waddle_xmpp::Role::Moderator),
+                reason: None,
+            }],
+        })
+        .await
+        .expect("owner grants temporary moderator role");
+
+    let admin_iq = element_to_xml(
+        Element::builder("iq", waddle_xmpp::ns::JABBER_CLIENT)
+            .attr(
+                minidom::rxml::xml_ncname!("id").to_owned(),
+                "admin-role-list",
+            )
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "get")
+            .attr(
+                minidom::rxml::xml_ncname!("to").to_owned(),
+                room_jid.to_string(),
+            )
+            .append(
+                Element::builder("query", waddle_xmpp::muc::NS_MUC_ADMIN)
+                    .append(
+                        Element::builder("item", waddle_xmpp::muc::NS_MUC_ADMIN)
+                            .attr(minidom::rxml::xml_ncname!("role").to_owned(), "moderator")
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build(),
+    );
+
+    let responses = handle_iq(
+        &admin_iq,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(alice_session),
+        &ready,
+    )
+    .await;
+    assert_eq!(responses.len(), 1, "admin response: {responses:?}");
+    assert!(responses[0].contains("type='result'"));
+    assert!(responses[0].contains("nick='bob'"));
+    assert!(responses[0].contains("role='moderator'"));
+    assert!(responses[0].contains("affiliation='none'"));
+    assert!(responses[0].contains("jid='bob@example.com/web'"));
+}
+
+#[tokio::test]
+async fn native_muc_admin_role_set_allows_jid_echo_without_affiliation() {
+    let state = create_test_websocket_state().await;
+    let alice_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let bob_session = create_test_session(state.as_ref(), "bob").await;
+    let room_jid: BareJid = "admin-role-jid-echo@muc.example.com"
+        .parse()
+        .expect("room jid");
+    let alice_jid: FullJid = "alice@example.com/web".parse().expect("alice jid");
+    let bob_jid: FullJid = "bob@example.com/web".parse().expect("bob jid");
+    let ready = ready_phase(&alice_jid);
+
+    handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &alice_jid,
+        "alice",
+        None,
+        &Some(alice_session.clone()),
+    )
+    .await;
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &bob_jid,
+        "bob",
+        None,
+        &Some(bob_session),
+    )
+    .await;
+
+    let admin_iq = element_to_xml(
+        Element::builder("iq", waddle_xmpp::ns::JABBER_CLIENT)
+            .attr(
+                minidom::rxml::xml_ncname!("id").to_owned(),
+                "admin-role-jid-echo",
+            )
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "set")
+            .attr(
+                minidom::rxml::xml_ncname!("to").to_owned(),
+                room_jid.to_string(),
+            )
+            .append(
+                Element::builder("query", waddle_xmpp::muc::NS_MUC_ADMIN)
+                    .append(
+                        Element::builder("item", waddle_xmpp::muc::NS_MUC_ADMIN)
+                            .attr(
+                                minidom::rxml::xml_ncname!("jid").to_owned(),
+                                bob_jid.to_bare().to_string(),
+                            )
+                            .attr(minidom::rxml::xml_ncname!("nick").to_owned(), "bob")
+                            .attr(minidom::rxml::xml_ncname!("role").to_owned(), "visitor")
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build(),
+    );
+
+    let responses = handle_iq(
+        &admin_iq,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(alice_session),
+        &ready,
+    )
+    .await;
+    assert_eq!(responses.len(), 1, "admin response: {responses:?}");
+    assert!(responses[0].contains("type='result'"));
+
+    let snapshot = get_room_actor(state.as_ref(), &room_jid)
+        .await
+        .expect("room actor")
+        .ask(GetSnapshot)
+        .await
+        .expect("snapshot")
+        .room;
+    let bob = snapshot.get_occupant("bob").expect("bob occupant");
+    assert_eq!(bob.role, waddle_xmpp::Role::Visitor);
+}
+
+#[tokio::test]
+async fn native_muc_admin_role_moderator_cannot_grant_moderator_role() {
+    let state = create_test_websocket_state().await;
+    let alice_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let bob_session = create_test_session(state.as_ref(), "bob").await;
+    let carol_session = create_test_session(state.as_ref(), "carol").await;
+    let room_jid: BareJid = "admin-role-moderator-grant@muc.example.com"
+        .parse()
+        .expect("room jid");
+    let alice_jid: FullJid = "alice@example.com/web".parse().expect("alice jid");
+    let bob_jid: FullJid = "bob@example.com/web".parse().expect("bob jid");
+    let carol_jid: FullJid = "carol@example.com/web".parse().expect("carol jid");
+    let ready = ready_phase(&bob_jid);
+
+    handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &alice_jid,
+        "alice",
+        None,
+        &Some(alice_session),
+    )
+    .await;
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &bob_jid,
+        "bob",
+        None,
+        &Some(bob_session.clone()),
+    )
+    .await;
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &carol_jid,
+        "carol",
+        None,
+        &Some(carol_session),
+    )
+    .await;
+
+    let actor = get_room_actor(state.as_ref(), &room_jid)
+        .await
+        .expect("room actor");
+    actor
+        .ask(ApplyAdminItems {
+            sender_jid: alice_jid.clone(),
+            sender_affiliation: Affiliation::Owner,
+            sender_role: waddle_xmpp::Role::Moderator,
+            items: vec![waddle_xmpp::muc::AdminItem {
+                jid: None,
+                nick: Some("bob".to_string()),
+                affiliation: None,
+                role: Some(waddle_xmpp::Role::Moderator),
+                reason: None,
+            }],
+        })
+        .await
+        .expect("owner grants temporary moderator role");
+
+    let admin_iq = element_to_xml(
+        Element::builder("iq", waddle_xmpp::ns::JABBER_CLIENT)
+            .attr(
+                minidom::rxml::xml_ncname!("id").to_owned(),
+                "moderator-grant-role",
+            )
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "set")
+            .attr(
+                minidom::rxml::xml_ncname!("to").to_owned(),
+                room_jid.to_string(),
+            )
+            .append(
+                Element::builder("query", waddle_xmpp::muc::NS_MUC_ADMIN)
+                    .append(
+                        Element::builder("item", waddle_xmpp::muc::NS_MUC_ADMIN)
+                            .attr(minidom::rxml::xml_ncname!("nick").to_owned(), "carol")
+                            .attr(minidom::rxml::xml_ncname!("role").to_owned(), "moderator")
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build(),
+    );
+
+    let responses = handle_iq(
+        &admin_iq,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(bob_session),
+        &ready,
+    )
+    .await;
+    assert_eq!(responses.len(), 1, "admin response: {responses:?}");
+    assert!(responses[0].contains("type='error'"));
+    assert!(responses[0].contains("forbidden"));
+
+    let snapshot = actor.ask(GetSnapshot).await.expect("snapshot").room;
+    let carol = snapshot.get_occupant("carol").expect("carol occupant");
+    assert_eq!(carol.role, waddle_xmpp::Role::Participant);
+}
+
+#[tokio::test]
+async fn native_muc_admin_role_moderator_cannot_write_affiliations_durably() {
+    let state = create_test_websocket_state().await;
+    let alice_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let bob_session = create_test_session(state.as_ref(), "bob").await;
+    let room_jid: BareJid = "moderator-durable@muc.example.com"
+        .parse()
+        .expect("room jid");
+    let channel_id = waddle_xmpp::parse_managed_room_jid(&room_jid).expect("managed channel id");
+    let alice_jid: FullJid = "alice@example.com/web".parse().expect("alice jid");
+    let bob_jid: FullJid = "bob@example.com/web".parse().expect("bob jid");
+    let carol_bare: BareJid = "carol@example.com".parse().expect("carol jid");
+    let ready = ready_phase(&bob_jid);
+
+    handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &alice_jid,
+        "alice",
+        None,
+        &Some(alice_session),
+    )
+    .await;
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &bob_jid,
+        "bob",
+        None,
+        &Some(bob_session.clone()),
+    )
+    .await;
+
+    let actor = get_room_actor(state.as_ref(), &room_jid)
+        .await
+        .expect("room actor");
+    actor
+        .ask(ApplyAdminItems {
+            sender_jid: alice_jid.clone(),
+            sender_affiliation: Affiliation::Owner,
+            sender_role: waddle_xmpp::Role::Moderator,
+            items: vec![waddle_xmpp::muc::AdminItem {
+                jid: None,
+                nick: Some("bob".to_string()),
+                affiliation: None,
+                role: Some(waddle_xmpp::Role::Moderator),
+                reason: None,
+            }],
+        })
+        .await
+        .expect("owner grants temporary moderator role");
+
+    let admin_iq = element_to_xml(
+        Element::builder("iq", waddle_xmpp::ns::JABBER_CLIENT)
+            .attr(
+                minidom::rxml::xml_ncname!("id").to_owned(),
+                "moderator-member-write",
+            )
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "set")
+            .attr(
+                minidom::rxml::xml_ncname!("to").to_owned(),
+                room_jid.to_string(),
+            )
+            .append(
+                Element::builder("query", waddle_xmpp::muc::NS_MUC_ADMIN)
+                    .append(
+                        Element::builder("item", waddle_xmpp::muc::NS_MUC_ADMIN)
+                            .attr(
+                                minidom::rxml::xml_ncname!("jid").to_owned(),
+                                carol_bare.to_string(),
+                            )
+                            .attr(
+                                minidom::rxml::xml_ncname!("affiliation").to_owned(),
+                                "member",
+                            )
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build(),
+    );
+
+    let responses = handle_iq(
+        &admin_iq,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(bob_session),
+        &ready,
+    )
+    .await;
+    assert_eq!(responses.len(), 1, "admin response: {responses:?}");
+    assert!(responses[0].contains("type='error'"));
+    assert!(responses[0].contains("forbidden"));
+
+    let snapshot = actor.ask(GetSnapshot).await.expect("snapshot").room;
+    assert_eq!(snapshot.get_affiliation(&carol_bare), Affiliation::None);
+
+    let durable_membership = state
+        .deps
+        .app_state
+        .permission_actor
+        .ask(CheckPermission {
+            subject: Subject::user(carol_bare.to_string()),
+            permission: Permission::Member,
+            object: Object::new(ObjectType::Channel, channel_id),
+        })
+        .await
+        .expect("permission check");
+    assert!(
+        !durable_membership.allowed,
+        "role-only moderators must not persist channel membership"
+    );
+}
+
+#[tokio::test]
+async fn native_muc_admin_self_ban_returns_conflict() {
+    let state = create_test_websocket_state().await;
+    let session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let room_jid: BareJid = "admin-self-ban@muc.example.com".parse().expect("room jid");
+    let alice_jid: FullJid = "alice@example.com/web".parse().expect("alice jid");
+    let ready = ready_phase(&alice_jid);
+
+    handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &alice_jid,
+        "alice",
+        None,
+        &Some(session.clone()),
+    )
+    .await;
+
+    let admin_iq = element_to_xml(
+        Element::builder("iq", waddle_xmpp::ns::JABBER_CLIENT)
+            .attr(
+                minidom::rxml::xml_ncname!("id").to_owned(),
+                "admin-self-ban",
+            )
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "set")
+            .attr(
+                minidom::rxml::xml_ncname!("to").to_owned(),
+                room_jid.to_string(),
+            )
+            .append(
+                Element::builder("query", waddle_xmpp::muc::NS_MUC_ADMIN)
+                    .append(
+                        Element::builder("item", waddle_xmpp::muc::NS_MUC_ADMIN)
+                            .attr(
+                                minidom::rxml::xml_ncname!("jid").to_owned(),
+                                "alice@example.com",
+                            )
+                            .attr(
+                                minidom::rxml::xml_ncname!("affiliation").to_owned(),
+                                "outcast",
+                            )
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build(),
+    );
+
+    let responses = handle_iq(
+        &admin_iq,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(session),
+        &ready,
+    )
+    .await;
+    assert_eq!(responses.len(), 1, "admin response: {responses:?}");
+    assert!(responses[0].contains("type='error'"));
+    assert!(responses[0].contains("conflict"));
+
+    let snapshot = get_room_actor(state.as_ref(), &room_jid)
+        .await
+        .expect("room actor")
+        .ask(GetSnapshot)
+        .await
+        .expect("snapshot")
+        .room;
+    assert_ne!(
+        snapshot.get_affiliation(&alice_jid.to_bare()),
+        Affiliation::Outcast
+    );
+    assert_eq!(snapshot.occupant_count(), 1);
+}
+
+#[tokio::test]
+async fn native_muc_admin_incomplete_affiliation_item_returns_bad_request() {
+    let state = create_test_websocket_state().await;
+    let session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let room_jid: BareJid = "admin-incomplete@muc.example.com"
+        .parse()
+        .expect("room jid");
+    let alice_jid: FullJid = "alice@example.com/web".parse().expect("alice jid");
+    let ready = ready_phase(&alice_jid);
+
+    handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &alice_jid,
+        "alice",
+        None,
+        &Some(session.clone()),
+    )
+    .await;
+
+    let admin_iq = element_to_xml(
+        Element::builder("iq", waddle_xmpp::ns::JABBER_CLIENT)
+            .attr(
+                minidom::rxml::xml_ncname!("id").to_owned(),
+                "admin-incomplete",
+            )
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "set")
+            .attr(
+                minidom::rxml::xml_ncname!("to").to_owned(),
+                room_jid.to_string(),
+            )
+            .append(
+                Element::builder("query", waddle_xmpp::muc::NS_MUC_ADMIN)
+                    .append(
+                        Element::builder("item", waddle_xmpp::muc::NS_MUC_ADMIN)
+                            .attr(
+                                minidom::rxml::xml_ncname!("jid").to_owned(),
+                                "bob@example.com",
+                            )
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build(),
+    );
+
+    let responses = handle_iq(
+        &admin_iq,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(session),
+        &ready,
+    )
+    .await;
+    assert_eq!(responses.len(), 1, "admin response: {responses:?}");
+    assert!(responses[0].contains("type='error'"));
+    assert!(responses[0].contains("bad-request"));
 }
 
 #[tokio::test]
@@ -830,7 +2163,7 @@ async fn muc_join_broadcast_includes_real_occupant_jid() {
     assert_eq!(presence.attr("from"), Some(expected_from.as_str()));
     assert_eq!(presence.attr("to"), Some(expected_to.as_str()));
     assert_eq!(item.attr("jid"), Some("bob@example.com/phone"));
-    assert_eq!(item.attr("affiliation"), Some("member"));
+    assert_eq!(item.attr("affiliation"), Some("none"));
     assert_eq!(item.attr("role"), Some("participant"));
     assert!(
         user_x

--- a/server/crates/waddle-server/tests/admin_channels_ws.rs
+++ b/server/crates/waddle-server/tests/admin_channels_ws.rs
@@ -568,6 +568,281 @@ async fn channels_update_renames() {
 }
 
 #[tokio::test]
+async fn channels_update_private_then_kick_blocks_non_member_rejoin() {
+    let _serial = TEST_SERIAL.lock().await;
+    let alice_pass = format!("alice-pass-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[("alice", &alice_pass)]);
+    let mut admin = admin_client(&server, "admin-channels-private-kick").await;
+    let mut alice = alice_client(&server, &alice_pass, "alice-channels-private-kick").await;
+
+    let create_resp = send_command(
+        &mut admin,
+        NODE_CHANNELS_CREATE,
+        "channels-private-kick-create",
+        &submit_form(NODE_CHANNELS_CREATE, &text_field("name", "private-kick")),
+    )
+    .await;
+    assert!(
+        is_result(&create_resp),
+        "expected create result, got: {create_resp}"
+    );
+    let channel_jid = extract_field(&create_resp, "channel_jid").expect("channel_jid");
+
+    let initial_join = join_muc(&mut alice, &channel_jid, "alice").await;
+    assert!(
+        initial_join.contains("affiliation='none'")
+            || initial_join.contains(r#"affiliation="none""#),
+        "public/open room should admit alice without granting membership, got: {initial_join}"
+    );
+
+    let update_extra = format!(
+        "{}{}{}",
+        text_field("channel_jid", &channel_jid),
+        bool_field("is_public", false),
+        bool_field("members_only", true),
+    );
+    let update_resp = send_command(
+        &mut admin,
+        NODE_CHANNELS_UPDATE,
+        "channels-private-kick-update",
+        &submit_form(NODE_CHANNELS_UPDATE, &update_extra),
+    )
+    .await;
+    assert!(
+        is_result(&update_resp),
+        "expected update result, got: {update_resp}"
+    );
+    assert_eq!(
+        extract_field(&update_resp, "is_public").as_deref(),
+        Some("0")
+    );
+    assert_eq!(
+        extract_field(&update_resp, "members_only").as_deref(),
+        Some("1")
+    );
+
+    let privacy_ejection = alice
+        .recv_matching(|frame| {
+            frame.contains("<presence")
+                && frame.contains(&channel_jid)
+                && frame.contains("alice")
+                && frame.contains("322")
+        })
+        .await
+        .expect("members-only conversion ejection presence");
+    assert!(
+        privacy_ejection.contains("type='unavailable'")
+            || privacy_ejection.contains(r#"type="unavailable""#),
+        "members-only conversion must remove current non-members, got: {privacy_ejection}"
+    );
+
+    let kick_extra = format!(
+        "{}{}",
+        text_field("channel_jid", &channel_jid),
+        text_field("occupant_jid", "alice@localhost"),
+    );
+    let kick_resp = send_command(
+        &mut admin,
+        NODE_CHANNELS_KICK,
+        "channels-private-kick-go",
+        &submit_form(NODE_CHANNELS_KICK, &kick_extra),
+    )
+    .await;
+    assert!(
+        is_result(&kick_resp),
+        "kick after members-only ejection should be a stable no-op result, got: {kick_resp}"
+    );
+
+    let denied_rejoin = join_muc(&mut alice, &channel_jid, "alice").await;
+    assert!(
+        denied_rejoin.contains("registration-required"),
+        "members-only room must deny a kicked non-member rejoin with XEP-0045 registration-required, got: {denied_rejoin}"
+    );
+
+    let grant_extra = format!(
+        "{}{}{}",
+        text_field("channel_jid", &channel_jid),
+        text_field("member_jid", "alice@localhost"),
+        text_field("affiliation", "member"),
+    );
+    let grant_resp = send_command(
+        &mut admin,
+        NODE_CHANNELS_SET_AFFILIATION,
+        "channels-private-kick-grant",
+        &submit_form(NODE_CHANNELS_SET_AFFILIATION, &grant_extra),
+    )
+    .await;
+    assert!(
+        is_result(&grant_resp),
+        "expected member grant result, got: {grant_resp}"
+    );
+
+    let admitted_join = join_muc(&mut alice, &channel_jid, "alice").await;
+    assert!(
+        admitted_join.contains("affiliation='member'")
+            || admitted_join.contains(r#"affiliation="member""#),
+        "explicit member affiliation should admit alice after private conversion, got: {admitted_join}"
+    );
+
+    let kick_member_resp = send_command(
+        &mut admin,
+        NODE_CHANNELS_KICK,
+        "channels-private-kick-member",
+        &submit_form(NODE_CHANNELS_KICK, &kick_extra),
+    )
+    .await;
+    assert!(
+        is_result(&kick_member_resp),
+        "kick should succeed for an explicit private-room member, got: {kick_member_resp}"
+    );
+    let member_kick_presence = alice
+        .recv_matching(|frame| {
+            frame.contains("<presence")
+                && frame.contains(&channel_jid)
+                && frame.contains("alice")
+                && frame.contains("307")
+        })
+        .await
+        .expect("explicit member kick presence");
+    assert!(
+        member_kick_presence.contains("type='unavailable'")
+            || member_kick_presence.contains(r#"type="unavailable""#),
+        "kicking an explicit member should still use XEP-0045 kick presence, got: {member_kick_presence}"
+    );
+
+    let denied_member_rejoin = join_muc(&mut alice, &channel_jid, "alice").await;
+    assert!(
+        denied_member_rejoin.contains("registration-required"),
+        "members-only room must deny an explicit member after admin-panel kick revoked membership, got: {denied_member_rejoin}"
+    );
+
+    let offline_grant_resp = send_command(
+        &mut admin,
+        NODE_CHANNELS_SET_AFFILIATION,
+        "channels-private-kick-offline-grant",
+        &submit_form(NODE_CHANNELS_SET_AFFILIATION, &grant_extra),
+    )
+    .await;
+    assert!(
+        is_result(&offline_grant_resp),
+        "expected offline member grant result, got: {offline_grant_resp}"
+    );
+    let offline_kick_resp = send_command(
+        &mut admin,
+        NODE_CHANNELS_KICK,
+        "channels-private-kick-offline-member",
+        &submit_form(NODE_CHANNELS_KICK, &kick_extra),
+    )
+    .await;
+    assert!(
+        is_result(&offline_kick_resp),
+        "offline private member kick should revoke membership as a stable result, got: {offline_kick_resp}"
+    );
+    let denied_offline_member_rejoin = join_muc(&mut alice, &channel_jid, "alice").await;
+    assert!(
+        denied_offline_member_rejoin.contains("registration-required"),
+        "members-only room must deny rejoin after offline private-member kick revoked membership, got: {denied_offline_member_rejoin}"
+    );
+
+    let _ = alice.close().await;
+    let _ = admin.close().await;
+}
+
+#[tokio::test]
+async fn channels_revoke_member_in_private_room_ejects_active_occupant() {
+    let _serial = TEST_SERIAL.lock().await;
+    let alice_pass = format!("alice-pass-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[("alice", &alice_pass)]);
+    let mut admin = admin_client(&server, "admin-channels-revoke-member").await;
+    let mut alice = alice_client(&server, &alice_pass, "alice-channels-revoke-member").await;
+
+    let create_extra = format!(
+        "{}{}{}",
+        text_field("name", "private-revoke"),
+        bool_field("is_public", false),
+        bool_field("members_only", true),
+    );
+    let create_resp = send_command(
+        &mut admin,
+        NODE_CHANNELS_CREATE,
+        "channels-private-revoke-create",
+        &submit_form(NODE_CHANNELS_CREATE, &create_extra),
+    )
+    .await;
+    assert!(
+        is_result(&create_resp),
+        "expected create result, got: {create_resp}"
+    );
+    let channel_jid = extract_field(&create_resp, "channel_jid").expect("channel_jid");
+
+    let grant_extra = format!(
+        "{}{}{}",
+        text_field("channel_jid", &channel_jid),
+        text_field("member_jid", "alice@localhost"),
+        text_field("affiliation", "member"),
+    );
+    let grant_resp = send_command(
+        &mut admin,
+        NODE_CHANNELS_SET_AFFILIATION,
+        "channels-private-revoke-grant",
+        &submit_form(NODE_CHANNELS_SET_AFFILIATION, &grant_extra),
+    )
+    .await;
+    assert!(
+        is_result(&grant_resp),
+        "expected grant result, got: {grant_resp}"
+    );
+
+    let admitted_join = join_muc(&mut alice, &channel_jid, "alice").await;
+    assert!(
+        admitted_join.contains("affiliation='member'")
+            || admitted_join.contains(r#"affiliation="member""#),
+        "explicit member affiliation should admit alice, got: {admitted_join}"
+    );
+
+    let revoke_extra = format!(
+        "{}{}{}",
+        text_field("channel_jid", &channel_jid),
+        text_field("member_jid", "alice@localhost"),
+        text_field("affiliation", "none"),
+    );
+    let revoke_resp = send_command(
+        &mut admin,
+        NODE_CHANNELS_SET_AFFILIATION,
+        "channels-private-revoke-none",
+        &submit_form(NODE_CHANNELS_SET_AFFILIATION, &revoke_extra),
+    )
+    .await;
+    assert!(
+        is_result(&revoke_resp),
+        "expected revoke result, got: {revoke_resp}"
+    );
+
+    let revoked = alice
+        .recv_matching(|frame| {
+            frame.contains("<presence")
+                && frame.contains(&channel_jid)
+                && frame.contains("alice")
+                && frame.contains("321")
+        })
+        .await
+        .expect("membership revocation ejection presence");
+    assert!(
+        revoked.contains("type='unavailable'") || revoked.contains(r#"type="unavailable""#),
+        "membership revocation must remove active occupants in private rooms, got: {revoked}"
+    );
+
+    let denied_rejoin = join_muc(&mut alice, &channel_jid, "alice").await;
+    assert!(
+        denied_rejoin.contains("registration-required"),
+        "revoked member must be denied rejoin to members-only room, got: {denied_rejoin}"
+    );
+
+    let _ = alice.close().await;
+    let _ = admin.close().await;
+}
+
+#[tokio::test]
 async fn standard_muc_owner_config_publicroom_false_hides_room_from_muc_disco_items() {
     let _serial = TEST_SERIAL.lock().await;
     let server = TestServer::start();
@@ -830,7 +1105,7 @@ async fn channels_set_affiliation_round_trips() {
     .await;
     let channel_jid = extract_field(&create_resp, "channel_jid").expect("channel_jid");
 
-    for affiliation in ["owner", "admin", "member", "outcast", "none"] {
+    for affiliation in ["admin", "member", "outcast", "none", "owner"] {
         let extra = format!(
             "{}{}{}",
             text_field("channel_jid", &channel_jid),

--- a/server/crates/waddle-server/tests/xep_waddle_in_call_ws.rs
+++ b/server/crates/waddle-server/tests/xep_waddle_in_call_ws.rs
@@ -13,12 +13,16 @@ const BOB_PASSWORD: &str = "bob-password";
 const CAROL: &str = "carol";
 const CAROL_PASSWORD: &str = "carol-password";
 const NS_CLIENT: &str = "jabber:client";
+const NS_COMMANDS: &str = "http://jabber.org/protocol/commands";
+const NS_DATA: &str = "jabber:x:data";
 const NS_HINTS: &str = "urn:xmpp:hints";
 const NS_MAM: &str = "urn:xmpp:mam:2";
 const NS_MUC: &str = "http://jabber.org/protocol/muc";
 const NS_MUJI: &str = "urn:xmpp:jingle:muji:0";
 const NS_RTP: &str = "urn:xmpp:jingle:apps:rtp:1";
 const NS_WADDLE_IN_CALL: &str = "urn:waddle:in-call:0";
+const NODE_CHANNELS_CREATE: &str = "urn:waddle:admin:channels:create:0";
+const NODE_CHANNELS_SET_AFFILIATION: &str = "urn:waddle:admin:channels:set-affiliation:0";
 static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
 
 fn attr(name: &'static str) -> minidom::rxml::NcName {
@@ -158,6 +162,79 @@ async fn join_room(client: &mut WsXmppClient, room: &str, nick: &str) {
         .recv_until(|frame| frame.contains("<subject"))
         .await
         .expect("join responses");
+}
+
+fn frame_has_iq_id(frame: &str, id: &str) -> bool {
+    frame.contains(&format!(r#"id='{id}'"#)) || frame.contains(&format!(r#"id="{id}""#))
+}
+
+fn submit_form(node: &str, extra: &str) -> String {
+    format!(
+        r#"<x xmlns="{NS_DATA}" type="submit"><field var="FORM_TYPE" type="hidden"><value>{node}</value></field>{extra}</x>"#
+    )
+}
+
+fn text_field(var: &str, value: &str) -> String {
+    format!(r#"<field var="{var}" type="text-single"><value>{value}</value></field>"#)
+}
+
+fn bool_field(var: &str, value: bool) -> String {
+    let value = if value { "1" } else { "0" };
+    format!(r#"<field var="{var}" type="boolean"><value>{value}</value></field>"#)
+}
+
+fn is_result(frame: &str) -> bool {
+    frame.contains(r#"type='result'"#) || frame.contains(r#"type="result""#)
+}
+
+fn extract_field(frame: &str, var: &str) -> Option<String> {
+    let marker_sq = format!(r#"var='{var}'"#);
+    let marker_dq = format!(r#"var="{var}""#);
+    let idx = frame.find(&marker_sq).or_else(|| frame.find(&marker_dq))?;
+    let after = &frame[idx..];
+    let open = after.find("<value>")?;
+    let inner = &after[open + "<value>".len()..];
+    let close = inner.find("</value>")?;
+    Some(inner[..close].to_string())
+}
+
+async fn send_admin_command(
+    client: &mut WsXmppClient,
+    node: &str,
+    id: &str,
+    form_xml: &str,
+) -> String {
+    let body = format!(
+        r#"<command xmlns="{NS_COMMANDS}" node="{node}" action="execute">{form_xml}</command>"#
+    );
+    client
+        .send(&format!(
+            r#"<iq type="set" id="{id}" to="{DOMAIN}">{body}</iq>"#
+        ))
+        .await
+        .expect("send admin command");
+    client
+        .recv_matching(|frame| frame.contains("<iq") && frame_has_iq_id(frame, id))
+        .await
+        .expect("admin command response")
+}
+
+async fn grant_channel_member(admin: &mut WsXmppClient, channel_jid: &str, member_jid: &str) {
+    let extra = format!(
+        "{}{}{}",
+        text_field("channel_jid", channel_jid),
+        text_field("member_jid", member_jid),
+        text_field("affiliation", "member"),
+    );
+    let id = format!("grant-member-{}", uuid::Uuid::new_v4());
+    let resp = send_admin_command(
+        admin,
+        NODE_CHANNELS_SET_AFFILIATION,
+        &id,
+        &submit_form(NODE_CHANNELS_SET_AFFILIATION, &extra),
+    )
+    .await;
+    assert!(is_result(&resp), "member grant failed: {resp}");
 }
 
 #[tokio::test]
@@ -316,6 +393,76 @@ async fn raised_hand_replays_to_late_joiner_and_clears_on_lower() {
 
     let _ = carol.close().await;
     let _ = alice.close().await;
+}
+
+#[tokio::test]
+async fn managed_members_only_join_replays_raised_hand_state() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server =
+        TestServer::start_with_extra_accounts(&[(BOB, BOB_PASSWORD), (CAROL, CAROL_PASSWORD)]);
+    let alice_password = server.fixed_account_password().to_string();
+    let mut admin = connect(&server, ALICE, &alice_password, "managed-hand-admin").await;
+    let mut bob = connect(&server, BOB, BOB_PASSWORD, "managed-hand-bob").await;
+    let mut carol = connect(&server, CAROL, CAROL_PASSWORD, "managed-hand-carol").await;
+
+    let extra = format!(
+        "{}{}{}",
+        text_field("name", &format!("managed-hand-{}", uuid::Uuid::new_v4())),
+        bool_field("is_public", false),
+        bool_field("members_only", true),
+    );
+    let create_resp = send_admin_command(
+        &mut admin,
+        NODE_CHANNELS_CREATE,
+        "managed-hand-create",
+        &submit_form(NODE_CHANNELS_CREATE, &extra),
+    )
+    .await;
+    assert!(
+        is_result(&create_resp),
+        "channel create failed: {create_resp}"
+    );
+    let channel_jid = extract_field(&create_resp, "channel_jid").expect("channel_jid");
+
+    grant_channel_member(&mut admin, &channel_jid, &format!("{BOB}@{DOMAIN}")).await;
+    grant_channel_member(&mut admin, &channel_jid, &format!("{CAROL}@{DOMAIN}")).await;
+
+    join_room(&mut bob, &channel_jid, BOB).await;
+
+    bob.send(&call_presence(&channel_jid, BOB, true))
+        .await
+        .expect("bob raises hand");
+    bob.recv_matching(|f| f.contains("<presence") && f.contains("hand-raised"))
+        .await
+        .expect("bob sees own raised-hand echo");
+
+    carol
+        .send(&muc_join_presence(&channel_jid, CAROL))
+        .await
+        .expect("carol joins members-only room");
+    let replay = carol
+        .recv_until(|f| f.contains("<subject"))
+        .await
+        .expect("carol join replay");
+    let bob_from = format!("{channel_jid}/{BOB}");
+    let carol_from = format!("{channel_jid}/{CAROL}");
+    assert!(
+        replay
+            .iter()
+            .any(|f| f.contains(&bob_from) && f.contains("hand-raised")),
+        "managed members-only replay should include bob's raised hand: {replay:?}"
+    );
+    assert!(
+        replay.iter().any(|f| {
+            f.contains(&carol_from)
+                && (f.contains("code='110'") || f.contains(r#"code="110""#))
+        }),
+        "allowed managed members-only join should include carol's self-presence status 110: {replay:?}"
+    );
+
+    let _ = carol.close().await;
+    let _ = bob.close().await;
+    let _ = admin.close().await;
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/muc_groupchat_fanout.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/muc_groupchat_fanout.cue
@@ -53,6 +53,13 @@ scenario: #Scenario & {
 			target:   alicePhone
 			contains: ["from='\(roomJid)/alice-desktop'"]
 		},
+		#SetMucAffiliation & {
+			actor:       alicePhone
+			room:        roomJid
+			jid:         bobPhone.bareJid
+			affiliation: "member"
+			id:          "cue-muc-fanout-set-bob-member"
+		},
 		#JoinMuc & {actor: bobPhone, room: roomJid, nick: "bob-phone"},
 		#ExpectPresence & {
 			target:   bobPhone

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0308_muc_message_correction.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0308_muc_message_correction.cue
@@ -30,6 +30,13 @@ scenario: #Scenario & {
 			target:   alicePhone
 			contains: ["from='\(roomJid)'", "<subject></subject>"]
 		},
+		#SetMucAffiliation & {
+			actor:       alicePhone
+			room:        roomJid
+			jid:         bobPhone.bareJid
+			affiliation: "member"
+			id:          "cue-muc-edit-set-bob-member"
+		},
 		#JoinMuc & {actor: bobPhone, room: roomJid, nick: "bob-phone"},
 		#ExpectPresence & {
 			target:   bobPhone

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0313_reconnect_after_catchup.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0313_reconnect_after_catchup.cue
@@ -150,6 +150,13 @@ scenario: #Scenario & {
 				target:   alicePhone
 				contains: ["from='\(roomJid)'", "<subject></subject>"]
 			},
+			#SetMucAffiliation & {
+				actor:       alicePhone
+				room:        roomJid
+				jid:         bobPhone.bareJid
+				affiliation: "member"
+				id:          "cue-room-catchup-set-bob-member"
+			},
 			#JoinMuc & {actor: bobPhone, room: roomJid, nick: "bob-phone"},
 			#ExpectPresence & {
 				target:   bobPhone

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0444_muc_reaction_refresh.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0444_muc_reaction_refresh.cue
@@ -30,6 +30,13 @@ scenario: #Scenario & {
 			target:   alicePhone
 			contains: ["from='\(roomJid)'", "<subject></subject>"]
 		},
+		#SetMucAffiliation & {
+			actor:       alicePhone
+			room:        roomJid
+			jid:         bobPhone.bareJid
+			affiliation: "member"
+			id:          "cue-muc-reaction-set-bob-member"
+		},
 		#JoinMuc & {actor: bobPhone, room: roomJid, nick: "bob-phone"},
 		#ExpectPresence & {
 			target:   bobPhone

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_muc_rich_payloads.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_muc_rich_payloads.cue
@@ -73,6 +73,13 @@ scenario: #Scenario & {
 			]
 			absentElements: [#XmlElement & {name: "hats", ns: "urn:xmpp:hats:0"}]
 		},
+		#SetMucAffiliation & {
+			actor:       adminPhone
+			room:        roomJid
+			jid:         bobPhone.bareJid
+			affiliation: "member"
+			id:          "cue-rich-set-bob-member"
+		},
 		#SendPresence & {
 			actor: bobPhone
 			to:    "\(roomJid)/bob"

--- a/server/crates/waddle-xmpp/src/muc/admin.rs
+++ b/server/crates/waddle-xmpp/src/muc/admin.rs
@@ -9,7 +9,7 @@
 //! - `http://jabber.org/protocol/muc#admin` - Admin operations
 //! - `http://jabber.org/protocol/muc#owner` - Owner operations (config, destroy)
 
-use jid::{BareJid, Jid};
+use jid::{BareJid, FullJid, Jid};
 use minidom::Element;
 use tracing::{debug, instrument};
 use xmpp_parsers::iq::Iq;
@@ -155,7 +155,14 @@ fn parse_admin_items(query: &Element) -> Result<Vec<AdminItem>, XmppError> {
 
     for child in query.children() {
         if child.name() == "item" {
-            let jid = child.attr("jid").and_then(|s| s.parse::<BareJid>().ok());
+            let jid = child
+                .attr("jid")
+                .map(|s| {
+                    s.parse::<Jid>()
+                        .map(|jid| jid.to_bare())
+                        .map_err(|_| XmppError::bad_request(Some(format!("Malformed jid: {s}"))))
+                })
+                .transpose()?;
 
             let nick = child.attr("nick").map(String::from);
 
@@ -337,24 +344,28 @@ pub fn build_role_result(
     iq_id: &str,
     from_room_jid: &BareJid,
     to_jid: &Jid,
-    items: &[(String, Role, Option<BareJid>)], // (nick, role, optional jid)
+    items: &[(String, Role, Affiliation, FullJid)],
 ) -> Iq {
     let mut query = Element::builder("query", NS_MUC_ADMIN);
 
-    for (nick, role, jid) in items {
-        let mut item_builder = Element::builder("item", NS_MUC_ADMIN)
+    for (nick, role, affiliation, jid) in items {
+        let item = Element::builder("item", NS_MUC_ADMIN)
             .attr(minidom::rxml::xml_ncname!("nick").to_owned(), nick.as_str())
             .attr(
                 minidom::rxml::xml_ncname!("role").to_owned(),
                 role_to_str(*role),
-            );
+            )
+            .attr(
+                minidom::rxml::xml_ncname!("affiliation").to_owned(),
+                affiliation_to_str(*affiliation),
+            )
+            .attr(
+                minidom::rxml::xml_ncname!("jid").to_owned(),
+                jid.to_string(),
+            )
+            .build();
 
-        if let Some(j) = jid {
-            item_builder =
-                item_builder.attr(minidom::rxml::xml_ncname!("jid").to_owned(), j.to_string());
-        }
-
-        query = query.append(item_builder.build());
+        query = query.append(item);
     }
 
     Iq::Result {

--- a/server/crates/waddle-xmpp/src/muc/admin/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/admin/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::{StanzaErrorCondition, StanzaErrorType};
 
 fn make_admin_get_iq(room_jid: &str, affiliation: &str) -> Iq {
     let query = Element::builder("query", NS_MUC_ADMIN)
@@ -89,6 +90,38 @@ fn test_parse_admin_query_set() {
 }
 
 #[test]
+fn test_parse_admin_query_set_normalizes_full_jid_to_bare() {
+    let iq = make_admin_set_iq("room@muc.example.com", "user@example.com/laptop", "member");
+    let query = parse_admin_query(&iq, "muc.example.com").unwrap();
+
+    assert_eq!(query.items.len(), 1);
+    assert_eq!(
+        query.items[0].jid.as_ref().unwrap().to_string(),
+        "user@example.com"
+    );
+    assert_eq!(query.items[0].affiliation, Some(Affiliation::Member));
+}
+
+#[test]
+fn test_parse_admin_query_set_rejects_malformed_jid() {
+    let iq = make_admin_set_iq("room@muc.example.com", "not a jid", "member");
+
+    let err = parse_admin_query(&iq, "muc.example.com").expect_err("malformed jid rejected");
+    match err {
+        XmppError::Stanza {
+            condition,
+            error_type,
+            text,
+        } => {
+            assert_eq!(condition, StanzaErrorCondition::BadRequest);
+            assert_eq!(error_type, StanzaErrorType::Modify);
+            assert_eq!(text.as_deref(), Some("Malformed jid: not a jid"));
+        }
+        other => panic!("expected bad-request stanza error, got {other:?}"),
+    }
+}
+
+#[test]
 fn test_parse_affiliation() {
     assert_eq!(parse_muc_affiliation("owner").unwrap(), Affiliation::Owner);
     assert_eq!(parse_muc_affiliation("admin").unwrap(), Affiliation::Admin);
@@ -133,6 +166,34 @@ fn test_build_admin_result() {
             ..
         }
     ));
+}
+
+#[test]
+fn test_build_role_result_includes_required_affiliation_and_full_jid() {
+    let room_jid: BareJid = "room@muc.example.com".parse().unwrap();
+    let to_jid: Jid = "requester@example.com/desktop".parse().unwrap();
+    let items = vec![(
+        "thirdwitch".to_string(),
+        Role::Moderator,
+        Affiliation::Member,
+        "hag66@example.com/pda".parse().unwrap(),
+    )];
+
+    let result = build_role_result("mod3", &room_jid, &to_jid, &items);
+    let Iq::Result {
+        payload: Some(query),
+        ..
+    } = result
+    else {
+        panic!("expected IQ result with query payload");
+    };
+    let item = query
+        .get_child("item", NS_MUC_ADMIN)
+        .expect("role result item");
+    assert_eq!(item.attr("nick"), Some("thirdwitch"));
+    assert_eq!(item.attr("role"), Some("moderator"));
+    assert_eq!(item.attr("affiliation"), Some("member"));
+    assert_eq!(item.attr("jid"), Some("hag66@example.com/pda"));
 }
 
 #[test]

--- a/server/crates/waddle-xmpp/src/muc/mod.rs
+++ b/server/crates/waddle-xmpp/src/muc/mod.rs
@@ -41,10 +41,10 @@ pub use pin::{
 };
 pub use presence::{
     build_affiliation_change_presence, build_ban_presence, build_destroy_notification,
-    build_kick_presence, build_leave_presence, build_occupant_presence,
-    build_occupant_presence_update, build_role_change_presence, parse_muc_presence, DestroyRequest,
-    HistoryRequest, MucJoinRequest, MucLeaveRequest, MucPresenceAction, MucPresenceUpdateRequest,
-    OutboundMucPresence,
+    build_kick_presence, build_leave_presence, build_membership_removal_presence,
+    build_occupant_presence, build_occupant_presence_update, build_role_change_presence,
+    parse_muc_presence, DestroyRequest, HistoryRequest, MucJoinRequest, MucLeaveRequest,
+    MucPresenceAction, MucPresenceUpdateRequest, OutboundMucPresence,
 };
 pub use room::{is_remote_jid, MucRoom, Occupant, RoomConfig};
 pub use room_actor::RoomActorError;

--- a/server/crates/waddle-xmpp/src/muc/presence.rs
+++ b/server/crates/waddle-xmpp/src/muc/presence.rs
@@ -368,6 +368,40 @@ pub fn build_ban_presence(
     presence
 }
 
+/// Build an unavailable presence for XEP-0045 membership removals.
+///
+/// Used for:
+/// - status 321: a user was removed because their affiliation changed.
+/// - status 322: a user was removed because the room became members-only.
+pub fn build_membership_removal_presence(
+    from_room_jid: &FullJid,
+    to_jid: &FullJid,
+    status_code: &'static str,
+    is_self: bool,
+    actor: Option<&BareJid>,
+    identity: &OccupantIdentity<'_>,
+) -> Presence {
+    let mut presence = Presence::new(PresenceType::Unavailable);
+    presence.from = Some(Jid::from(from_room_jid.clone()));
+    presence.to = Some(Jid::from(to_jid.clone()));
+
+    let mut status_codes: Vec<&str> = vec![status_code];
+    if identity.real_jid.is_some() {
+        status_codes.push("100");
+    }
+    if is_self {
+        status_codes.push("110");
+    }
+
+    let item = build_muc_user_item(Affiliation::None, "none", identity.real_jid, None, actor);
+    presence
+        .payloads
+        .push(build_muc_user_x_element(item, &status_codes));
+    add_presence_identity_payloads(&mut presence, from_room_jid, identity);
+
+    presence
+}
+
 /// Build a presence notification for affiliation change.
 ///
 /// Per XEP-0045 §9.6: When a user's affiliation changes, a presence update

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -23,7 +23,10 @@ mod snapshot_handlers;
 #[cfg(test)]
 mod tests;
 
-pub use admin_handlers::{ApplyAdminItems, GetAdminContext, IsOwner};
+pub use admin_handlers::{
+    ApplyAdminItems, ApplyAffiliationChange, EnforceMembersOnly, EnforceMembersOnlyAffiliations,
+    GetAdminContext, IsOwner,
+};
 pub use occupancy_handlers::{
     ClearMujiPresence, HandRaisedUpdateOutcome, JoinWithAffiliation, LeaveByRealJid,
     MujiPresenceUpdateOutcome, PingSelfCheck, PresenceUpdateData, ReconcileChannelBackedRoom,
@@ -51,6 +54,7 @@ pub struct OccupantInfo {
 pub struct RoomSnapshot {
     pub room: MucRoom,
     pub config_revision: u64,
+    pub admission_revision: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -135,6 +139,10 @@ pub enum AdminApplyError {
     OccupantNotFound(String),
     #[error("cannot remove the last owner from a room")]
     CannotRemoveLastOwner,
+    #[error("admin cannot change an owner's affiliation")]
+    CannotAdminModifyOwner,
+    #[error("admins and moderators cannot change an owner or admin role")]
+    CannotModifyPrivilegedRole,
     #[error("{0}")]
     PermissionDenied(String),
 }
@@ -162,6 +170,7 @@ impl OccupantInfo {
 pub struct RoomActor {
     room: MucRoom,
     config_revision: u64,
+    admission_revision: u64,
     occupant_id_secret: crate::xep::xep0421::OccupantIdSecret,
 }
 
@@ -175,6 +184,8 @@ pub enum RoomActorError {
     OccupantNotFound(String),
     #[error("join is forbidden (members_only={members_only})")]
     JoinForbidden { members_only: bool },
+    #[error("join admission snapshot is stale")]
+    StaleAdmissionRevision,
     /// XEP-0045 §7.4: sender is not an occupant of this room. Maps to
     /// the typed stanza error `<error type='cancel'><not-acceptable/></error>`.
     #[error("sender '{0}' is not an occupant of this room")]
@@ -198,6 +209,7 @@ impl RoomActor {
         Self {
             room,
             config_revision: 0,
+            admission_revision: 0,
             occupant_id_secret,
         }
     }
@@ -340,6 +352,7 @@ impl kameo::message::Message<UpdateConfig> for RoomActor {
     ) -> Self::Reply {
         self.room.config = msg.config;
         self.config_revision = self.config_revision.saturating_add(1);
+        self.admission_revision = self.admission_revision.saturating_add(1);
         self.config_revision
     }
 }
@@ -365,6 +378,7 @@ impl kameo::message::Message<RollbackConfigIfRevision> for RoomActor {
         }
         self.room.config = msg.config;
         self.config_revision = self.config_revision.saturating_add(1);
+        self.admission_revision = self.admission_revision.saturating_add(1);
         true
     }
 }
@@ -414,9 +428,11 @@ impl kameo::message::Message<UpdateGroupDmConfigByMember> for RoomActor {
         }
         self.room.config = msg.config;
         self.config_revision = self.config_revision.saturating_add(1);
+        self.admission_revision = self.admission_revision.saturating_add(1);
         Ok(RoomSnapshot {
             room: self.room.clone(),
             config_revision: self.config_revision,
+            admission_revision: self.admission_revision,
         })
     }
 }
@@ -507,7 +523,13 @@ impl kameo::message::Message<ChangeAffiliation> for RoomActor {
         msg: ChangeAffiliation,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        self.room.set_affiliation(msg.jid, msg.affiliation);
+        if self
+            .room
+            .set_affiliation(msg.jid, msg.affiliation)
+            .is_some()
+        {
+            self.admission_revision = self.admission_revision.saturating_add(1);
+        }
     }
 }
 
@@ -668,6 +690,7 @@ impl kameo::message::Message<GetSnapshot> for RoomActor {
         Ok(RoomSnapshot {
             room: self.room.clone(),
             config_revision: self.config_revision,
+            admission_revision: self.admission_revision,
         })
     }
 }

--- a/server/crates/waddle-xmpp/src/muc/room_actor/admin_handlers.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/admin_handlers.rs
@@ -1,4 +1,4 @@
-use std::convert::Infallible;
+use std::{collections::BTreeMap, convert::Infallible};
 
 use jid::{BareJid, FullJid};
 use kameo::message::Context;
@@ -8,10 +8,226 @@ use super::{AdminApplyError, AdminContext, RoomActor};
 use crate::muc::admin::{is_role_change_query, AdminItem};
 use crate::muc::{
     build_affiliation_change_presence, build_ban_presence, build_kick_presence,
-    build_role_change_presence,
+    build_membership_removal_presence, build_role_change_presence, MucRoom, Occupant,
 };
 use crate::types::{Affiliation, Role};
-use crate::xep::xep0421::OccupantIdentity;
+use crate::xep::xep0421::{OccupantIdSecret, OccupantIdentity};
+
+const STATUS_AFFILIATION_CHANGE_REMOVAL: &str = "321";
+const STATUS_MEMBERS_ONLY_CONFIG_REMOVAL: &str = "322";
+
+fn all_room_sessions(room: &MucRoom) -> Vec<FullJid> {
+    room.occupants
+        .values()
+        .flat_map(|occupant| room.get_occupant_sessions(&occupant.nick))
+        .collect()
+}
+
+fn occupants_for_bare(room: &MucRoom, target_jid: &BareJid) -> Vec<Occupant> {
+    room.occupants
+        .values()
+        .filter(|occupant| occupant.real_jid.to_bare() == *target_jid)
+        .cloned()
+        .collect()
+}
+
+fn removal_presence_updates(
+    room: &MucRoom,
+    occupant_id_secret: &OccupantIdSecret,
+    occupant: &Occupant,
+    status_code: &'static str,
+    actor: Option<&BareJid>,
+) -> Vec<(FullJid, Presence)> {
+    let from_room_jid = room
+        .room_jid
+        .with_resource_str(&occupant.nick)
+        .expect("nick was previously accepted as resource");
+    let occupant_bare = occupant.real_jid.to_bare();
+    let occupant_identity = OccupantIdentity {
+        bare_jid: &occupant_bare,
+        real_jid: Some(&occupant.real_jid),
+        secret: occupant_id_secret,
+    };
+    let removed_sessions = room.get_occupant_sessions(&occupant.nick);
+    all_room_sessions(room)
+        .into_iter()
+        .map(|recipient| {
+            let is_self = removed_sessions.iter().any(|jid| jid == &recipient);
+            let presence = build_membership_removal_presence(
+                &from_room_jid,
+                &recipient,
+                status_code,
+                is_self,
+                actor,
+                &occupant_identity,
+            );
+            (recipient, presence)
+        })
+        .collect()
+}
+
+fn apply_affiliation_change(
+    room: &mut MucRoom,
+    occupant_id_secret: &OccupantIdSecret,
+    target_jid: BareJid,
+    new_affiliation: Affiliation,
+    actor: Option<&BareJid>,
+    reason: Option<&str>,
+) -> Result<Vec<(FullJid, Presence)>, AdminApplyError> {
+    if new_affiliation != Affiliation::Owner {
+        let target_current_affiliation = room.get_affiliation(&target_jid);
+        if target_current_affiliation == Affiliation::Owner {
+            let owners = room.get_jids_by_affiliation(Affiliation::Owner);
+            if owners.len() == 1 && owners.contains(&target_jid) {
+                return Err(AdminApplyError::CannotRemoveLastOwner);
+            }
+        }
+    }
+
+    let change = room.set_affiliation(target_jid.clone(), new_affiliation);
+    if change.is_none() {
+        return Ok(Vec::new());
+    }
+
+    let affected_occupants = occupants_for_bare(room, &target_jid);
+    if affected_occupants.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    if new_affiliation == Affiliation::Outcast {
+        let mut updates = Vec::new();
+        for occupant in &affected_occupants {
+            let from_room_jid = room
+                .room_jid
+                .with_resource_str(&occupant.nick)
+                .expect("nick was previously accepted as resource");
+            let occupant_bare = occupant.real_jid.to_bare();
+            let occupant_identity = OccupantIdentity {
+                bare_jid: &occupant_bare,
+                real_jid: Some(&occupant.real_jid),
+                secret: occupant_id_secret,
+            };
+            let removed_sessions = room.get_occupant_sessions(&occupant.nick);
+            updates.extend(all_room_sessions(room).into_iter().map(|recipient| {
+                let is_self = removed_sessions.iter().any(|jid| jid == &recipient);
+                let presence = build_ban_presence(
+                    &from_room_jid,
+                    &recipient,
+                    is_self,
+                    reason,
+                    actor,
+                    &occupant_identity,
+                );
+                (recipient, presence)
+            }));
+        }
+        for occupant in affected_occupants {
+            room.remove_occupant(&occupant.nick);
+        }
+        return Ok(updates);
+    }
+
+    if room.config.members_only && new_affiliation < Affiliation::Member {
+        let mut updates = Vec::new();
+        for occupant in &affected_occupants {
+            updates.extend(removal_presence_updates(
+                room,
+                occupant_id_secret,
+                occupant,
+                STATUS_AFFILIATION_CHANGE_REMOVAL,
+                actor,
+            ));
+        }
+        for occupant in affected_occupants {
+            room.remove_occupant(&occupant.nick);
+        }
+        return Ok(updates);
+    }
+
+    let mut updates = Vec::new();
+    for occupant in &affected_occupants {
+        let from_room_jid = room
+            .room_jid
+            .with_resource_str(&occupant.nick)
+            .expect("nick was previously accepted as resource");
+        let occupant_bare = occupant.real_jid.to_bare();
+        let occupant_identity = OccupantIdentity {
+            bare_jid: &occupant_bare,
+            real_jid: Some(&occupant.real_jid),
+            secret: occupant_id_secret,
+        };
+        let affected_sessions = room.get_occupant_sessions(&occupant.nick);
+        updates.extend(all_room_sessions(room).into_iter().map(|recipient| {
+            let is_self = affected_sessions.iter().any(|jid| jid == &recipient);
+            let presence = build_affiliation_change_presence(
+                &from_room_jid,
+                &recipient,
+                new_affiliation,
+                occupant.role,
+                is_self,
+                &occupant_identity,
+            );
+            (recipient, presence)
+        }));
+    }
+    Ok(updates)
+}
+
+fn enforce_members_only(
+    room: &mut MucRoom,
+    occupant_id_secret: &OccupantIdSecret,
+) -> Vec<(FullJid, Presence)> {
+    if !room.config.members_only {
+        return Vec::new();
+    }
+    let removed_occupants: Vec<Occupant> = room
+        .occupants
+        .values()
+        .filter(|occupant| occupant.affiliation < Affiliation::Member)
+        .cloned()
+        .collect();
+    let mut presence_updates = Vec::new();
+    for occupant in &removed_occupants {
+        presence_updates.extend(removal_presence_updates(
+            room,
+            occupant_id_secret,
+            occupant,
+            STATUS_MEMBERS_ONLY_CONFIG_REMOVAL,
+            None,
+        ));
+    }
+    for occupant in removed_occupants {
+        room.remove_occupant(&occupant.nick);
+    }
+    presence_updates
+}
+
+fn authorize_role_change(
+    sender_affiliation: Affiliation,
+    sender_role: Role,
+    target_affiliation: Affiliation,
+    target_role: Role,
+    new_role: Role,
+) -> Result<(), AdminApplyError> {
+    if sender_affiliation == Affiliation::Owner {
+        return Ok(());
+    }
+    if matches!(target_affiliation, Affiliation::Owner | Affiliation::Admin) {
+        return Err(AdminApplyError::CannotModifyPrivilegedRole);
+    }
+    if sender_affiliation == Affiliation::Admin {
+        return Ok(());
+    }
+    if sender_role == Role::Moderator
+        && target_role != Role::Moderator
+        && matches!(new_role, Role::Participant | Role::Visitor | Role::None)
+    {
+        return Ok(());
+    }
+    Err(AdminApplyError::PermissionDenied(
+        "You don't have permission to change this user's role".to_string(),
+    ))
+}
 
 pub struct GetAdminContext {
     pub sender_jid: FullJid,
@@ -55,6 +271,25 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
         let mut occupants_to_kick: Vec<String> = Vec::new();
         if is_role_change_query(&msg.items) {
             for item in &msg.items {
+                let Some(target_nick) = item.nick.as_ref() else {
+                    continue;
+                };
+                let Some(new_role) = item.role else {
+                    continue;
+                };
+                let target_occupant = self
+                    .room
+                    .get_occupant(target_nick)
+                    .ok_or_else(|| AdminApplyError::OccupantNotFound(target_nick.clone()))?;
+                authorize_role_change(
+                    msg.sender_affiliation,
+                    msg.sender_role,
+                    target_occupant.affiliation,
+                    target_occupant.role,
+                    new_role,
+                )?;
+            }
+            for item in &msg.items {
                 let Some(target_nick) = item.nick.clone() else {
                     continue;
                 };
@@ -66,28 +301,13 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
                     .get_occupant(&target_nick)
                     .cloned()
                     .ok_or_else(|| AdminApplyError::OccupantNotFound(target_nick.clone()))?;
-                let can_modify = match (
+                authorize_role_change(
                     msg.sender_affiliation,
                     msg.sender_role,
                     target_occupant.affiliation,
+                    target_occupant.role,
                     new_role,
-                ) {
-                    (Affiliation::Owner, _, _, _) => true,
-                    (Affiliation::Admin, _, target_aff, _) if target_aff != Affiliation::Owner => {
-                        true
-                    }
-                    (_, Role::Moderator, target_aff, _)
-                        if !matches!(target_aff, Affiliation::Owner | Affiliation::Admin) =>
-                    {
-                        true
-                    }
-                    _ => false,
-                };
-                if !can_modify {
-                    return Err(AdminApplyError::PermissionDenied(
-                        "You don't have permission to change this user's role".to_string(),
-                    ));
-                }
+                )?;
                 let from_room_jid = self
                     .room
                     .room_jid
@@ -99,58 +319,69 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
                     real_jid: Some(&target_occupant.real_jid),
                     secret: &self.occupant_id_secret,
                 };
+                let target_sessions = self.room.get_occupant_sessions(&target_nick);
                 if new_role == Role::None {
-                    for (nick, occupant) in self.room.occupants.iter() {
-                        let is_self = nick == &target_nick;
+                    for recipient in all_room_sessions(&self.room) {
+                        let is_self = target_sessions.iter().any(|jid| jid == &recipient);
                         let presence = build_kick_presence(
                             &from_room_jid,
-                            &occupant.real_jid,
+                            &recipient,
                             target_occupant.affiliation,
                             is_self,
                             item.reason.as_deref(),
                             Some(&msg.sender_jid.to_bare()),
                             &target_identity,
                         );
-                        presence_updates.push((occupant.real_jid.clone(), presence));
+                        presence_updates.push((recipient, presence));
                     }
                     occupants_to_kick.push(target_nick);
                 } else {
                     if let Some(occ) = self.room.occupants.get_mut(&target_nick) {
                         occ.role = new_role;
                     }
-                    for (nick, occupant) in self.room.occupants.iter() {
-                        let is_self = nick == &target_nick;
+                    for recipient in all_room_sessions(&self.room) {
+                        let is_self = target_sessions.iter().any(|jid| jid == &recipient);
                         let presence = build_role_change_presence(
                             &from_room_jid,
-                            &occupant.real_jid,
+                            &recipient,
                             target_occupant.affiliation,
                             new_role,
                             is_self,
                             &target_identity,
                         );
-                        presence_updates.push((occupant.real_jid.clone(), presence));
+                        presence_updates.push((recipient, presence));
                     }
                 }
             }
         } else {
+            let mut final_affiliations: BTreeMap<BareJid, Affiliation> = self
+                .room
+                .get_all_affiliations()
+                .into_iter()
+                .map(|entry| (entry.jid, entry.affiliation))
+                .collect();
+            let current_owner_count = self.room.get_jids_by_affiliation(Affiliation::Owner).len();
             for item in &msg.items {
-                let Some(target_jid) = item.jid.clone() else {
+                let Some(target_jid) = item.jid.as_ref() else {
                     continue;
                 };
                 let Some(new_affiliation) = item.affiliation else {
                     continue;
                 };
+                let target_current_affiliation = self.room.get_affiliation(target_jid);
                 let can_modify = match new_affiliation {
-                    Affiliation::Owner => msg.sender_affiliation == Affiliation::Owner,
-                    Affiliation::Admin
-                    | Affiliation::Member
-                    | Affiliation::None
-                    | Affiliation::Outcast => {
-                        matches!(
-                            msg.sender_affiliation,
-                            Affiliation::Owner | Affiliation::Admin
-                        )
+                    Affiliation::Owner | Affiliation::Admin => {
+                        msg.sender_affiliation == Affiliation::Owner
                     }
+                    Affiliation::Member | Affiliation::None | Affiliation::Outcast
+                        if target_current_affiliation == Affiliation::Admin =>
+                    {
+                        msg.sender_affiliation == Affiliation::Owner
+                    }
+                    Affiliation::Member | Affiliation::None | Affiliation::Outcast => matches!(
+                        msg.sender_affiliation,
+                        Affiliation::Owner | Affiliation::Admin
+                    ),
                 };
                 if !can_modify {
                     return Err(AdminApplyError::PermissionDenied(format!(
@@ -158,74 +389,151 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
                         crate::muc::admin::affiliation_to_str(new_affiliation)
                     )));
                 }
-                if new_affiliation != Affiliation::Owner {
-                    let target_current_affiliation = self.room.get_affiliation(&target_jid);
-                    if target_current_affiliation == Affiliation::Owner {
-                        let owners = self.room.get_jids_by_affiliation(Affiliation::Owner);
-                        if owners.len() == 1 && owners.contains(&target_jid) {
-                            return Err(AdminApplyError::CannotRemoveLastOwner);
-                        }
-                    }
+                if msg.sender_affiliation == Affiliation::Admin
+                    && target_current_affiliation == Affiliation::Owner
+                    && new_affiliation != Affiliation::Owner
+                {
+                    return Err(AdminApplyError::CannotAdminModifyOwner);
                 }
-                let change = self
-                    .room
-                    .set_affiliation(target_jid.clone(), new_affiliation);
-                if change.is_none() {
-                    continue;
+                if new_affiliation == Affiliation::None {
+                    final_affiliations.remove(target_jid);
+                } else {
+                    final_affiliations.insert(target_jid.clone(), new_affiliation);
                 }
-                let affected_occupant = self
-                    .room
-                    .occupants
+            }
+            if current_owner_count > 0
+                && !final_affiliations
                     .values()
-                    .find(|o| o.real_jid.to_bare() == target_jid)
-                    .cloned();
-                if let Some(occupant) = affected_occupant {
-                    let from_room_jid = self
-                        .room
-                        .room_jid
-                        .with_resource_str(&occupant.nick)
-                        .expect("nick was previously accepted as resource");
-                    let occupant_bare = occupant.real_jid.to_bare();
-                    let occupant_identity = OccupantIdentity {
-                        bare_jid: &occupant_bare,
-                        real_jid: Some(&occupant.real_jid),
-                        secret: &self.occupant_id_secret,
-                    };
-                    if new_affiliation == Affiliation::Outcast {
-                        for (nick, occ) in self.room.occupants.iter() {
-                            let is_self = nick == &occupant.nick;
-                            let presence = build_ban_presence(
-                                &from_room_jid,
-                                &occ.real_jid,
-                                is_self,
-                                item.reason.as_deref(),
-                                Some(&msg.sender_jid.to_bare()),
-                                &occupant_identity,
-                            );
-                            presence_updates.push((occ.real_jid.clone(), presence));
-                        }
-                        occupants_to_kick.push(occupant.nick.clone());
-                    } else {
-                        for (nick, occ) in self.room.occupants.iter() {
-                            let is_self = nick == &occupant.nick;
-                            let presence = build_affiliation_change_presence(
-                                &from_room_jid,
-                                &occ.real_jid,
-                                new_affiliation,
-                                occupant.role,
-                                is_self,
-                                &occupant_identity,
-                            );
-                            presence_updates.push((occ.real_jid.clone(), presence));
-                        }
+                    .any(|affiliation| *affiliation == Affiliation::Owner)
+            {
+                return Err(AdminApplyError::CannotRemoveLastOwner);
+            }
+            for item in &msg.items {
+                let Some(target_jid) = item.jid.clone() else {
+                    continue;
+                };
+                let Some(new_affiliation) = item.affiliation else {
+                    continue;
+                };
+                let target_current_affiliation = self.room.get_affiliation(&target_jid);
+                let can_modify = match new_affiliation {
+                    Affiliation::Owner | Affiliation::Admin => {
+                        msg.sender_affiliation == Affiliation::Owner
                     }
+                    Affiliation::Member | Affiliation::None | Affiliation::Outcast
+                        if target_current_affiliation == Affiliation::Admin =>
+                    {
+                        msg.sender_affiliation == Affiliation::Owner
+                    }
+                    Affiliation::Member | Affiliation::None | Affiliation::Outcast => matches!(
+                        msg.sender_affiliation,
+                        Affiliation::Owner | Affiliation::Admin
+                    ),
+                };
+                if !can_modify {
+                    return Err(AdminApplyError::PermissionDenied(format!(
+                        "You don't have permission to set {} affiliation",
+                        crate::muc::admin::affiliation_to_str(new_affiliation)
+                    )));
                 }
+                if msg.sender_affiliation == Affiliation::Admin
+                    && target_current_affiliation == Affiliation::Owner
+                    && new_affiliation != Affiliation::Owner
+                {
+                    return Err(AdminApplyError::CannotAdminModifyOwner);
+                }
+                let actor = msg.sender_jid.to_bare();
+                let updates = apply_affiliation_change(
+                    &mut self.room,
+                    &self.occupant_id_secret,
+                    target_jid,
+                    new_affiliation,
+                    Some(&actor),
+                    item.reason.as_deref(),
+                )?;
+                if target_current_affiliation != new_affiliation {
+                    self.admission_revision = self.admission_revision.saturating_add(1);
+                }
+                presence_updates.extend(updates);
             }
         }
         for nick in occupants_to_kick {
             self.room.remove_occupant(&nick);
         }
         Ok(presence_updates)
+    }
+}
+
+pub struct ApplyAffiliationChange {
+    pub actor: Option<BareJid>,
+    pub jid: BareJid,
+    pub affiliation: Affiliation,
+}
+
+impl kameo::message::Message<ApplyAffiliationChange> for RoomActor {
+    type Reply = Result<Vec<(FullJid, Presence)>, AdminApplyError>;
+
+    async fn handle(
+        &mut self,
+        msg: ApplyAffiliationChange,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let previous_affiliation = self.room.get_affiliation(&msg.jid);
+        let updates = apply_affiliation_change(
+            &mut self.room,
+            &self.occupant_id_secret,
+            msg.jid,
+            msg.affiliation,
+            msg.actor.as_ref(),
+            None,
+        )?;
+        if previous_affiliation != msg.affiliation {
+            self.admission_revision = self.admission_revision.saturating_add(1);
+        }
+        Ok(updates)
+    }
+}
+
+pub struct EnforceMembersOnly;
+
+impl kameo::message::Message<EnforceMembersOnly> for RoomActor {
+    type Reply = Vec<(FullJid, Presence)>;
+
+    async fn handle(
+        &mut self,
+        _msg: EnforceMembersOnly,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        enforce_members_only(&mut self.room, &self.occupant_id_secret)
+    }
+}
+
+pub struct EnforceMembersOnlyAffiliations {
+    pub affiliations: Vec<(BareJid, Affiliation)>,
+}
+
+impl kameo::message::Message<EnforceMembersOnlyAffiliations> for RoomActor {
+    type Reply = Vec<(FullJid, Presence)>;
+
+    async fn handle(
+        &mut self,
+        msg: EnforceMembersOnlyAffiliations,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let affiliations: BTreeMap<BareJid, Affiliation> = msg.affiliations.into_iter().collect();
+        let occupied_jids: Vec<BareJid> = self
+            .room
+            .occupants
+            .values()
+            .map(|occupant| occupant.real_jid.to_bare())
+            .collect();
+        for jid in occupied_jids {
+            let affiliation = affiliations.get(&jid).copied().unwrap_or(Affiliation::None);
+            if self.room.set_affiliation(jid, affiliation).is_some() {
+                self.admission_revision = self.admission_revision.saturating_add(1);
+            }
+        }
+        enforce_members_only(&mut self.room, &self.occupant_id_secret)
     }
 }
 

--- a/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
@@ -15,6 +15,7 @@ pub struct JoinWithAffiliation {
     pub nick: String,
     pub effective_affiliation: Affiliation,
     pub local_domain: String,
+    pub admission_revision: u64,
 }
 
 impl kameo::message::Message<JoinWithAffiliation> for RoomActor {
@@ -25,6 +26,10 @@ impl kameo::message::Message<JoinWithAffiliation> for RoomActor {
         msg: JoinWithAffiliation,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        if msg.admission_revision != self.admission_revision {
+            return Err(RoomActorError::StaleAdmissionRevision);
+        }
+
         if msg.effective_affiliation != Affiliation::None {
             self.room.update_affiliation_from_resolver(
                 msg.sender_jid.to_bare(),

--- a/server/crates/waddle-xmpp/src/muc/room_actor/snapshot_handlers.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/snapshot_handlers.rs
@@ -54,6 +54,8 @@ pub struct RoomChainSnapshot {
     pub config: RoomConfig,
     /// Durable affiliation-derived recipients at dispatch start.
     pub durable_recipient_bare_jids: Vec<BareJid>,
+    /// Admission revision at dispatch start for stale-join rejection.
+    pub admission_revision: u64,
 }
 
 /// One occupant session in a [`RoomChainSnapshot`].
@@ -134,6 +136,7 @@ impl kameo::message::Message<GetRoomSnapshot> for RoomActor {
             sender_nickname_generation,
             config: self.room.config.clone(),
             durable_recipient_bare_jids,
+            admission_revision: self.admission_revision,
         })
     }
 }

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
@@ -4,6 +4,7 @@ use crate::muc::admin::AdminItem;
 use crate::xep::xep0421::OccupantIdSecret;
 use kameo::actor::{ActorRef, Spawn};
 use kameo::error::SendError;
+use xmpp_parsers::presence::{Presence, Type as PresenceType};
 
 fn test_secret() -> OccupantIdSecret {
     OccupantIdSecret::for_testing(b"test-secret".to_vec())
@@ -25,6 +26,12 @@ fn test_full_jid(user: &str) -> FullJid {
         .expect("valid jid")
 }
 
+fn test_full_jid_resource(user: &str, resource: &str) -> FullJid {
+    format!("{}@example.com/{}", user, resource)
+        .parse()
+        .expect("valid jid")
+}
+
 async fn spawn_room_actor() -> ActorRef<RoomActor> {
     RoomActor::spawn(RoomActor::new(test_room(), test_secret()))
 }
@@ -41,6 +48,18 @@ async fn spawn_room_actor_with_config(mut config: RoomConfig) -> ActorRef<RoomAc
         ),
         test_secret(),
     ))
+}
+
+fn presence_has_status(presence: &Presence, code: &str) -> bool {
+    presence.payloads.iter().any(|payload| {
+        payload.name() == "x"
+            && payload.ns() == "http://jabber.org/protocol/muc#user"
+            && payload.children().any(|child| {
+                child.name() == "status"
+                    && child.ns() == "http://jabber.org/protocol/muc#user"
+                    && child.attr("code") == Some(code)
+            })
+    })
 }
 
 #[tokio::test]
@@ -140,6 +159,7 @@ async fn test_join_existing_session_allowed_when_room_full() {
             nick: "alice".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: 0,
         })
         .await
         .expect("first join should succeed");
@@ -150,6 +170,7 @@ async fn test_join_existing_session_allowed_when_room_full() {
             nick: "alice".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: 0,
         })
         .await
         .expect("existing session rejoin should bypass full-room rejection");
@@ -274,6 +295,43 @@ async fn test_get_and_update_config() {
 }
 
 #[tokio::test]
+async fn members_only_enforcement_ejects_current_non_members_with_status_322() {
+    let actor = spawn_room_actor_with_config(RoomConfig {
+        members_only: false,
+        ..RoomConfig::default()
+    })
+    .await;
+    let alice = test_full_jid("alice");
+
+    actor
+        .ask(Join {
+            nick: "alice".to_string(),
+            real_jid: alice.clone(),
+            role: Role::Participant,
+            affiliation: Affiliation::None,
+        })
+        .await
+        .expect("join");
+
+    let mut config = actor.ask(GetConfig).await.expect("config");
+    config.members_only = true;
+    actor
+        .ask(UpdateConfig { config })
+        .await
+        .expect("config update");
+
+    let updates = actor.ask(EnforceMembersOnly).await.expect("enforce");
+    assert_eq!(updates.len(), 1, "only Alice should receive her removal");
+    assert_eq!(updates[0].0, alice);
+    assert_eq!(updates[0].1.type_, PresenceType::Unavailable);
+    assert!(presence_has_status(&updates[0].1, "322"));
+    assert!(presence_has_status(&updates[0].1, "110"));
+
+    let count = actor.ask(OccupantCount).await.expect("count");
+    assert_eq!(count, 0);
+}
+
+#[tokio::test]
 async fn test_change_and_get_affiliation() {
     let actor = spawn_room_actor().await;
     let jid: BareJid = "alice@example.com".parse().expect("jid");
@@ -294,6 +352,49 @@ async fn test_change_and_get_affiliation() {
 
     let aff = actor.ask(GetAffiliation { jid }).await.expect("ask");
     assert_eq!(aff, Affiliation::Admin);
+}
+
+#[tokio::test]
+async fn membership_revocation_in_members_only_room_ejects_occupant_with_status_321() {
+    let actor = spawn_room_actor().await;
+    let alice_bare: BareJid = "alice@example.com".parse().expect("jid");
+    let alice = test_full_jid("alice");
+
+    actor
+        .ask(ChangeAffiliation {
+            jid: alice_bare.clone(),
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("member grant");
+    let snapshot = actor.ask(GetSnapshot).await.expect("snapshot");
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: alice.clone(),
+            nick: "alice".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+            admission_revision: snapshot.admission_revision,
+        })
+        .await
+        .expect("join");
+
+    let updates = actor
+        .ask(ApplyAffiliationChange {
+            actor: Some("admin@example.com".parse().expect("admin")),
+            jid: alice_bare,
+            affiliation: Affiliation::None,
+        })
+        .await
+        .expect("apply");
+    assert_eq!(updates.len(), 1, "only Alice should receive her removal");
+    assert_eq!(updates[0].0, alice);
+    assert_eq!(updates[0].1.type_, PresenceType::Unavailable);
+    assert!(presence_has_status(&updates[0].1, "321"));
+    assert!(presence_has_status(&updates[0].1, "110"));
+
+    let count = actor.ask(OccupantCount).await.expect("count");
+    assert_eq!(count, 0);
 }
 
 #[tokio::test]
@@ -376,9 +477,9 @@ async fn test_apply_admin_items_rejects_moderator_role_change_on_admin() {
 
     assert!(matches!(
         result,
-        Err(SendError::HandlerError(AdminApplyError::PermissionDenied(
-            _
-        )))
+        Err(SendError::HandlerError(
+            AdminApplyError::CannotModifyPrivilegedRole
+        ))
     ));
 
     let occupant = actor
@@ -393,6 +494,113 @@ async fn test_apply_admin_items_rejects_moderator_role_change_on_admin() {
     let count = actor.ask(OccupantCount).await.expect("count");
     assert_eq!(
         count, 1,
+        "actor should stay healthy after permission denial"
+    );
+}
+
+#[tokio::test]
+async fn test_apply_admin_items_rejects_admin_role_change_on_admin() {
+    let actor = spawn_room_actor().await;
+
+    actor
+        .ask(Join {
+            nick: "alice".to_string(),
+            real_jid: test_full_jid("alice"),
+            role: Role::Moderator,
+            affiliation: Affiliation::Admin,
+        })
+        .await
+        .expect("join alice");
+
+    let result = actor
+        .ask(ApplyAdminItems {
+            sender_jid: test_full_jid("bob"),
+            sender_affiliation: Affiliation::Admin,
+            sender_role: Role::Moderator,
+            items: vec![AdminItem {
+                jid: None,
+                nick: Some("alice".to_string()),
+                affiliation: None,
+                role: Some(Role::None),
+                reason: None,
+            }],
+        })
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(SendError::HandlerError(
+            AdminApplyError::CannotModifyPrivilegedRole
+        ))
+    ));
+
+    let occupant = actor
+        .ask(GetOccupantByNick {
+            nick: "alice".to_string(),
+        })
+        .await
+        .expect("occupant")
+        .expect("occupant exists");
+    assert_eq!(occupant.role, Role::Moderator);
+}
+
+#[tokio::test]
+async fn test_apply_admin_items_rejects_moderator_grant_from_role_only_moderator() {
+    let actor = spawn_room_actor().await;
+
+    actor
+        .ask(Join {
+            nick: "bob".to_string(),
+            real_jid: test_full_jid("bob"),
+            role: Role::Moderator,
+            affiliation: Affiliation::None,
+        })
+        .await
+        .expect("join bob");
+    actor
+        .ask(Join {
+            nick: "carol".to_string(),
+            real_jid: test_full_jid("carol"),
+            role: Role::Participant,
+            affiliation: Affiliation::None,
+        })
+        .await
+        .expect("join carol");
+
+    let result = actor
+        .ask(ApplyAdminItems {
+            sender_jid: test_full_jid("bob"),
+            sender_affiliation: Affiliation::None,
+            sender_role: Role::Moderator,
+            items: vec![AdminItem {
+                jid: None,
+                nick: Some("carol".to_string()),
+                affiliation: None,
+                role: Some(Role::Moderator),
+                reason: None,
+            }],
+        })
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(SendError::HandlerError(AdminApplyError::PermissionDenied(
+            _
+        )))
+    ));
+
+    let occupant = actor
+        .ask(GetOccupantByNick {
+            nick: "carol".to_string(),
+        })
+        .await
+        .expect("occupant")
+        .expect("occupant exists");
+    assert_eq!(occupant.role, Role::Participant);
+
+    let count = actor.ask(OccupantCount).await.expect("count");
+    assert_eq!(
+        count, 2,
         "actor should stay healthy after permission denial"
     );
 }
@@ -437,6 +645,409 @@ async fn test_apply_admin_items_cannot_remove_last_owner() {
         .await
         .expect("owner check");
     assert!(still_owner, "last owner must be preserved");
+}
+
+#[tokio::test]
+async fn admin_cannot_ban_or_deaffiliate_owner() {
+    let actor = spawn_room_actor().await;
+    let owner_jid: BareJid = "owner@example.com".parse().expect("valid bare jid");
+    let other_owner_jid: BareJid = "other-owner@example.com".parse().expect("valid bare jid");
+
+    actor
+        .ask(ChangeAffiliation {
+            jid: owner_jid.clone(),
+            affiliation: Affiliation::Owner,
+        })
+        .await
+        .expect("set owner");
+    actor
+        .ask(ChangeAffiliation {
+            jid: other_owner_jid,
+            affiliation: Affiliation::Owner,
+        })
+        .await
+        .expect("set other owner");
+
+    let result = actor
+        .ask(ApplyAdminItems {
+            sender_jid: test_full_jid("admin"),
+            sender_affiliation: Affiliation::Admin,
+            sender_role: Role::Moderator,
+            items: vec![AdminItem {
+                jid: Some(owner_jid.clone()),
+                nick: None,
+                affiliation: Some(Affiliation::Outcast),
+                role: None,
+                reason: None,
+            }],
+        })
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(SendError::HandlerError(
+            AdminApplyError::CannotAdminModifyOwner
+        ))
+    ));
+
+    let still_owner = actor
+        .ask(IsOwner { jid: owner_jid })
+        .await
+        .expect("owner check");
+    assert!(still_owner, "admin must not be able to ban an owner");
+}
+
+#[tokio::test]
+async fn admin_cannot_modify_admin_affiliations() {
+    let actor = spawn_room_actor().await;
+    let target_admin: BareJid = "target-admin@example.com".parse().expect("target admin");
+    let target_member: BareJid = "target-member@example.com".parse().expect("target member");
+
+    actor
+        .ask(ChangeAffiliation {
+            jid: target_admin.clone(),
+            affiliation: Affiliation::Admin,
+        })
+        .await
+        .expect("target admin affiliation");
+    actor
+        .ask(ChangeAffiliation {
+            jid: target_member.clone(),
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("target member affiliation");
+
+    let demote_result = actor
+        .ask(ApplyAdminItems {
+            sender_jid: test_full_jid("admin"),
+            sender_affiliation: Affiliation::Admin,
+            sender_role: Role::Moderator,
+            items: vec![AdminItem {
+                jid: Some(target_admin.clone()),
+                nick: None,
+                affiliation: Some(Affiliation::Member),
+                role: None,
+                reason: None,
+            }],
+        })
+        .await;
+    assert!(matches!(
+        demote_result,
+        Err(SendError::HandlerError(AdminApplyError::PermissionDenied(
+            _
+        )))
+    ));
+
+    let promote_result = actor
+        .ask(ApplyAdminItems {
+            sender_jid: test_full_jid("admin"),
+            sender_affiliation: Affiliation::Admin,
+            sender_role: Role::Moderator,
+            items: vec![AdminItem {
+                jid: Some(target_member.clone()),
+                nick: None,
+                affiliation: Some(Affiliation::Admin),
+                role: None,
+                reason: None,
+            }],
+        })
+        .await;
+    assert!(matches!(
+        promote_result,
+        Err(SendError::HandlerError(AdminApplyError::PermissionDenied(
+            _
+        )))
+    ));
+
+    let snapshot = actor.ask(GetSnapshot).await.expect("snapshot").room;
+    assert_eq!(snapshot.get_affiliation(&target_admin), Affiliation::Admin);
+    assert_eq!(
+        snapshot.get_affiliation(&target_member),
+        Affiliation::Member
+    );
+}
+
+#[tokio::test]
+async fn affiliation_batch_validation_happens_before_members_only_ejection() {
+    let actor = spawn_room_actor_with_config(RoomConfig {
+        members_only: true,
+        ..RoomConfig::default()
+    })
+    .await;
+    let alice_bare: BareJid = "alice@example.com".parse().expect("alice bare");
+    let owner_bare: BareJid = "owner@example.com".parse().expect("owner bare");
+    let alice = test_full_jid("alice");
+
+    actor
+        .ask(ChangeAffiliation {
+            jid: alice_bare.clone(),
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("alice member");
+    actor
+        .ask(ChangeAffiliation {
+            jid: owner_bare.clone(),
+            affiliation: Affiliation::Owner,
+        })
+        .await
+        .expect("owner");
+    let snapshot = actor.ask(GetSnapshot).await.expect("snapshot");
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: alice.clone(),
+            nick: "alice".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+            admission_revision: snapshot.admission_revision,
+        })
+        .await
+        .expect("alice join");
+
+    let result = actor
+        .ask(ApplyAdminItems {
+            sender_jid: test_full_jid("admin"),
+            sender_affiliation: Affiliation::Admin,
+            sender_role: Role::Moderator,
+            items: vec![
+                AdminItem {
+                    jid: Some(alice_bare.clone()),
+                    nick: None,
+                    affiliation: Some(Affiliation::None),
+                    role: None,
+                    reason: None,
+                },
+                AdminItem {
+                    jid: Some(owner_bare.clone()),
+                    nick: None,
+                    affiliation: Some(Affiliation::Outcast),
+                    role: None,
+                    reason: None,
+                },
+            ],
+        })
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(SendError::HandlerError(
+            AdminApplyError::CannotAdminModifyOwner
+        ))
+    ));
+    let snapshot = actor.ask(GetSnapshot).await.expect("snapshot").room;
+    assert_eq!(snapshot.get_affiliation(&alice_bare), Affiliation::Member);
+    assert_eq!(snapshot.find_nick_by_real_jid(&alice), Some("alice"));
+    assert_eq!(snapshot.get_affiliation(&owner_bare), Affiliation::Owner);
+}
+
+#[tokio::test]
+async fn stale_admission_revision_returns_retryable_error_without_joining() {
+    let actor = spawn_room_actor().await;
+    let alice = test_full_jid("alice");
+    let config = RoomConfig {
+        name: "Renamed".to_string(),
+        ..RoomConfig::default()
+    };
+    actor
+        .ask(UpdateConfig { config })
+        .await
+        .expect("config update");
+
+    let result = actor
+        .ask(JoinWithAffiliation {
+            sender_jid: alice.clone(),
+            nick: "alice".to_string(),
+            effective_affiliation: Affiliation::None,
+            local_domain: "example.com".to_string(),
+            admission_revision: 0,
+        })
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(SendError::HandlerError(
+            RoomActorError::StaleAdmissionRevision
+        ))
+    ));
+    let snapshot = actor.ask(GetSnapshot).await.expect("snapshot").room;
+    assert!(snapshot.find_nick_by_real_jid(&alice).is_none());
+}
+
+#[tokio::test]
+async fn role_none_kick_notifies_same_nick_sibling_sessions() {
+    let actor = spawn_room_actor().await;
+    let alice_laptop = test_full_jid_resource("alice", "laptop");
+    let alice_phone = test_full_jid_resource("alice", "phone");
+
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: alice_laptop.clone(),
+            nick: "alice".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+            admission_revision: 0,
+        })
+        .await
+        .expect("first session join");
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: alice_phone.clone(),
+            nick: "alice".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+            admission_revision: 0,
+        })
+        .await
+        .expect("same nick sibling session join");
+
+    let updates = actor
+        .ask(ApplyAdminItems {
+            sender_jid: test_full_jid("owner"),
+            sender_affiliation: Affiliation::Owner,
+            sender_role: Role::Moderator,
+            items: vec![AdminItem {
+                jid: None,
+                nick: Some("alice".to_string()),
+                affiliation: None,
+                role: Some(Role::None),
+                reason: None,
+            }],
+        })
+        .await
+        .expect("kick succeeds");
+
+    assert!(updates.iter().any(|(recipient, presence)| {
+        recipient == &alice_laptop && presence_has_status(presence, "307")
+    }));
+    assert!(updates.iter().any(|(recipient, presence)| {
+        recipient == &alice_phone && presence_has_status(presence, "307")
+    }));
+    assert_eq!(actor.ask(OccupantCount).await.expect("count"), 0);
+}
+
+#[tokio::test]
+async fn members_only_revocation_removes_every_nick_for_bare_jid() {
+    let actor = spawn_room_actor_with_config(RoomConfig {
+        members_only: true,
+        ..RoomConfig::default()
+    })
+    .await;
+    let alice_laptop = test_full_jid_resource("alice", "laptop");
+    let alice_phone = test_full_jid_resource("alice", "phone");
+    let alice_bare = alice_laptop.to_bare();
+
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: alice_laptop.clone(),
+            nick: "alice".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+            admission_revision: 0,
+        })
+        .await
+        .expect("first nick join");
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: alice_phone.clone(),
+            nick: "alice-phone".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+            admission_revision: 0,
+        })
+        .await
+        .expect("second nick join");
+
+    let updates = actor
+        .ask(ApplyAffiliationChange {
+            actor: Some("owner@example.com".parse().expect("owner")),
+            jid: alice_bare,
+            affiliation: Affiliation::None,
+        })
+        .await
+        .expect("revocation succeeds");
+
+    assert!(updates.iter().any(|(recipient, presence)| {
+        recipient == &alice_laptop && presence_has_status(presence, "321")
+    }));
+    assert!(updates.iter().any(|(recipient, presence)| {
+        recipient == &alice_phone && presence_has_status(presence, "321")
+    }));
+    assert_eq!(actor.ask(OccupantCount).await.expect("count"), 0);
+}
+
+#[tokio::test]
+async fn managed_members_only_enforcement_uses_explicit_affiliation_snapshot() {
+    let actor = spawn_room_actor().await;
+    let alice = test_full_jid("alice");
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: alice.clone(),
+            nick: "alice".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+            admission_revision: 0,
+        })
+        .await
+        .expect("open-room inherited member join");
+
+    let config = RoomConfig {
+        members_only: true,
+        ..RoomConfig::default()
+    };
+    actor
+        .ask(UpdateConfig { config })
+        .await
+        .expect("members-only config");
+
+    let updates = actor
+        .ask(EnforceMembersOnlyAffiliations {
+            affiliations: vec![(alice.to_bare(), Affiliation::None)],
+        })
+        .await
+        .expect("managed enforcement succeeds");
+
+    assert!(updates.iter().any(|(recipient, presence)| {
+        recipient == &alice && presence_has_status(presence, "322")
+    }));
+    assert_eq!(actor.ask(OccupantCount).await.expect("count"), 0);
+}
+
+#[tokio::test]
+async fn managed_members_only_enforcement_treats_missing_snapshot_entry_as_none() {
+    let actor = spawn_room_actor().await;
+    let alice = test_full_jid("alice");
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: alice.clone(),
+            nick: "alice".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+            admission_revision: 0,
+        })
+        .await
+        .expect("stale-open join");
+
+    let config = RoomConfig {
+        members_only: true,
+        ..RoomConfig::default()
+    };
+    actor
+        .ask(UpdateConfig { config })
+        .await
+        .expect("members-only config");
+
+    let updates = actor
+        .ask(EnforceMembersOnlyAffiliations {
+            affiliations: Vec::new(),
+        })
+        .await
+        .expect("managed enforcement succeeds");
+
+    assert!(updates.iter().any(|(recipient, presence)| {
+        recipient == &alice && presence_has_status(presence, "322")
+    }));
+    assert_eq!(actor.ask(OccupantCount).await.expect("count"), 0);
 }
 
 #[tokio::test]
@@ -983,6 +1594,7 @@ async fn upsert_muji_presence_recipients_include_every_sibling_session_of_sender
             nick: "alice".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: 0,
         })
         .await
         .expect("desktop join");
@@ -992,6 +1604,7 @@ async fn upsert_muji_presence_recipients_include_every_sibling_session_of_sender
             nick: "alice".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: 0,
         })
         .await
         .expect("mobile join recognized as same-bare multi-session");
@@ -1030,6 +1643,7 @@ async fn same_nick_sibling_preparing_does_not_clobber_active_muji_snapshot() {
             nick: "alice".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: 0,
         })
         .await
         .expect("desktop join");
@@ -1039,6 +1653,7 @@ async fn same_nick_sibling_preparing_does_not_clobber_active_muji_snapshot() {
             nick: "alice".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: 0,
         })
         .await
         .expect("mobile join");
@@ -1082,6 +1697,7 @@ async fn same_nick_sibling_preparing_does_not_clobber_active_muji_snapshot() {
             nick: "bob".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: 0,
         })
         .await
         .expect("bob join");
@@ -1125,6 +1741,7 @@ async fn late_join_replay_includes_preparing_only_same_nick_muji_with_exact_owne
             nick: "alice".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: 0,
         })
         .await
         .expect("desktop join");
@@ -1134,6 +1751,7 @@ async fn late_join_replay_includes_preparing_only_same_nick_muji_with_exact_owne
             nick: "alice".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: 0,
         })
         .await
         .expect("mobile join");
@@ -1153,6 +1771,7 @@ async fn late_join_replay_includes_preparing_only_same_nick_muji_with_exact_owne
             nick: "bob".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: 0,
         })
         .await
         .expect("bob join");
@@ -1319,6 +1938,7 @@ async fn clear_muji_presence_clears_existing_state_without_muji_payload() {
             nick: "carol".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: 0,
         })
         .await
         .expect("carol join");
@@ -1391,6 +2011,7 @@ async fn join_replay_includes_active_muji_from_existing_occupant() {
             nick: "bob".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: 0,
         })
         .await
         .expect("bob join");
@@ -1443,6 +2064,7 @@ async fn leaving_occupant_clears_muji_state() {
             nick: "carol".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: 0,
         })
         .await
         .expect("carol join");
@@ -1472,6 +2094,7 @@ async fn leaving_originator_session_clears_muji_state_even_with_peer_sessions_re
             nick: "alice".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: 0,
         })
         .await
         .expect("desktop join");
@@ -1481,6 +2104,7 @@ async fn leaving_originator_session_clears_muji_state_even_with_peer_sessions_re
             nick: "alice".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: 0,
         })
         .await
         .expect("mobile join recognized as same-bare multi-session");
@@ -1529,6 +2153,7 @@ async fn leaving_originator_session_clears_muji_state_even_with_peer_sessions_re
             nick: "carol".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: 0,
         })
         .await
         .expect("carol join");
@@ -1560,6 +2185,7 @@ async fn leaving_non_originator_session_preserves_muji_state() {
             nick: "alice".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: 0,
         })
         .await
         .expect("desktop join");
@@ -1569,6 +2195,7 @@ async fn leaving_non_originator_session_preserves_muji_state() {
             nick: "alice".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: 0,
         })
         .await
         .expect("mobile join");
@@ -1598,6 +2225,7 @@ async fn leaving_non_originator_session_preserves_muji_state() {
             nick: "carol".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: 0,
         })
         .await
         .expect("carol join");
@@ -1625,6 +2253,7 @@ async fn leaving_one_active_same_nick_session_preserves_sibling_active_muji_stat
             nick: "alice".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: 0,
         })
         .await
         .expect("desktop join");
@@ -1634,6 +2263,7 @@ async fn leaving_one_active_same_nick_session_preserves_sibling_active_muji_stat
             nick: "alice".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: 0,
         })
         .await
         .expect("mobile join");
@@ -1677,6 +2307,7 @@ async fn leaving_one_active_same_nick_session_preserves_sibling_active_muji_stat
             nick: "carol".to_string(),
             effective_affiliation: Affiliation::Member,
             local_domain: "example.com".to_string(),
+            admission_revision: 0,
         })
         .await
         .expect("carol join");


### PR DESCRIPTION
## Summary

- split channel discovery visibility from members-only admission in the admin UI/API, defaulting hidden channels to explicit membership
- make admin-v2 private-channel kicks revoke explicit `member` affiliation before the XEP-0045 kick so kicked private-room users cannot rejoin
- harden MUC admission, config updates, membership revocation, stale admission retries, and native MUC admin role/affiliation authorization
- preserve rebased raised-hand MUC presence replay while keeping members-only admission revision checks intact
- refresh the admin drawer affiliations after kick so durable private-kick changes are visible immediately

## Plan / Completed

- Review relevant XEP-0045 membership, affiliation, role, and status-code behavior
- Update chat admin controls and XMPP admin-v2 payloads for independent visibility and members-only policy
- Enforce private/members-only admission and active ejection through MUC actor/admin flows
- Rebase onto current `main` and resolve the MUC join replay conflict with the raised-hand state work from #1061
- Address unresolved review comments by moving `GetSnapshot` into the MUC submodule and correcting the owner-tuple ordering comment
- Add regressions for private-then-kick rejoin, explicit-member private kicks, stale admission races, native MUC admin authorization, CUE membership scenarios, and raised-hand replay during a managed members-only join
- Run adversarial protocol, persistence, UI/API, rebase, and CI-risk review until no actionable findings remained

## Validation

- `bun test`
- `bun run lint`
- `bun run build` (rerun outside sandbox for Cloudflare/Vite local port probe)
- `cargo fmt --manifest-path server/Cargo.toml --all --check`
- `cargo test --manifest-path server/Cargo.toml -p waddle-xmpp muc::admin::tests`
- `cargo test --manifest-path server/Cargo.toml -p waddle-xmpp --lib room_actor`
- `cargo test --manifest-path server/Cargo.toml -p waddle-server --lib native_muc_admin`
- `cargo test --manifest-path server/Cargo.toml -p waddle-server --test admin_channels_ws`
- `cargo test --manifest-path server/Cargo.toml -p waddle-server --test xep_waddle_in_call_ws`
- `cargo clippy --manifest-path server/Cargo.toml -p waddle-server --all-targets -- -D warnings`
- `cargo clippy --manifest-path server/Cargo.toml --workspace --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path server/Cargo.toml -p waddle-server`
- `git diff --check`
