### PR TITLE
Fix event calendar spans and all-day events

### DIFF
--- a/chat/src/components/chat/ChatMobileDrawers.vue
+++ b/chat/src/components/chat/ChatMobileDrawers.vue
@@ -20,6 +20,7 @@ import SettingsMobileHeader from "@/components/chat/SettingsMobileHeader.vue";
 import ProfilePanel from "@/components/chat/ProfilePanel.vue";
 import AppDrawer from "@/components/ui/AppDrawer.vue";
 import { extensionRouteIconComponent, extensionRouteRailItems } from "./extension-route-rail-model";
+import { isEventUpcomingOrOngoing } from "@/lib/xmpp-client";
 import type { CallMedia } from "@/lib/calls/types";
 import type { DiscoveredExtensionRoute } from "@/lib/xmpp/extension-commands";
 import type { ChatAppController } from "@/shell/chat-app-controller";
@@ -219,7 +220,7 @@ function openExtensionRoute(route: DiscoveredExtensionRoute) {
           :thread-entries-fn="(roomJid: string) => channelUnread.threadEntries(roomJid)"
           :active-community-surface="ui.activeCommunitySurface.value"
           :stories-active-count="stories.activeStories.value.length"
-          :upcoming-event-count="communityEvents.events.value.filter((e: { dtstartMs?: number }) => typeof e.dtstartMs === 'number' && e.dtstartMs > Date.now()).length"
+          :upcoming-event-count="communityEvents.events.value.filter((event) => isEventUpcomingOrOngoing(event)).length"
           :is-threads-active="ui.activePage.value === 'threads'"
           :is-unread-active="ui.activePage.value === 'unread'"
           :unread-total-count="channelUnread.totalUnreadCount.value + channelUnread.totalThreadUnreadCount.value"

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -55,6 +55,7 @@ import type { MessageThreadEntry } from "@/channels/threads";
 import { jidDomain } from "@/lib/xmpp/jid";
 import type { ChatAppController } from "@/shell/chat-app-controller";
 import type { DiscoveredExtensionRoute } from "@/lib/xmpp/extension-commands";
+import { isEventUpcomingOrOngoing } from "@/lib/xmpp-client";
 import type { FeedPostInput, StoryPostInput } from "@/lib/xmpp-client";
 import type { ActivityPublication, MoodPublication, TunePublication } from "@/lib/xmpp/pep-types";
 import type { VCard4Profile } from "@/lib/xmpp/vcard4-types";
@@ -657,7 +658,7 @@ onUnmounted(() => {
           :thread-entries-fn="(roomJid: string) => channelUnread.threadEntries(roomJid)"
           :active-community-surface="ui.activeCommunitySurface.value"
           :stories-active-count="stories.activeStories.value.length"
-          :upcoming-event-count="communityEvents.events.value.filter((e: { dtstartMs?: number }) => typeof e.dtstartMs === 'number' && e.dtstartMs > Date.now()).length"
+          :upcoming-event-count="communityEvents.events.value.filter((event) => isEventUpcomingOrOngoing(event)).length"
           :is-threads-active="ui.activePage.value === 'threads'"
           :is-unread-active="ui.activePage.value === 'unread'"
           :unread-total-count="channelUnread.totalUnreadCount.value + channelUnread.totalThreadUnreadCount.value"
@@ -789,7 +790,7 @@ onUnmounted(() => {
         @post="(input) => communityEvents.post(input)"
         @edit="(id, input) => communityEvents.edit(id, input)"
         @cancel-series="(id) => communityEvents.cancel(id)"
-        @cancel-instance="(uid, dtstartMs) => communityEvents.cancelInstance(uid, dtstartMs)"
+        @cancel-instance="(uid, dtstart) => communityEvents.cancelInstance(uid, dtstart)"
         @rsvp="(event, partstat) => onCommunityRsvp(event, partstat)"
         @open-nav="ui.showMobileNav.value = true"
       />

--- a/chat/src/components/community/EventsPane.vue
+++ b/chat/src/components/community/EventsPane.vue
@@ -4,6 +4,7 @@ import {
   CalendarDays,
   ChevronLeft,
   ChevronRight,
+  Clock3,
   Copy,
   List,
   Menu,
@@ -18,11 +19,23 @@ import CalendarFeedUrlPanel from "@/components/community/CalendarFeedUrlPanel.vu
 import RecurrencePicker from "@/components/community/RecurrencePicker.vue";
 import type {
   Attendee,
+  CalendarDateValue,
   CommunityEvent,
   CommunityEventInput,
   PartStat,
   Rrule,
   Weekday,
+} from "@/lib/xmpp-client";
+import {
+  addDaysToDateString,
+  calendarDateStartMs,
+  dateTimeValue,
+  dateValue,
+  eventOverlapsRange,
+  isEventUpcomingOrOngoing,
+  localDateStringFromMs,
+  localDayRange,
+  sortEventsForDay,
 } from "@/lib/xmpp-client";
 import { useCalendarFeedCopy } from "@/lib/use-calendar-feed-copy";
 
@@ -50,7 +63,7 @@ const emit = defineEmits<{
   post: [input: CommunityEventInput];
   edit: [itemId: string, input: CommunityEventInput];
   cancelSeries: [masterId: string];
-  cancelInstance: [masterUid: string, instanceDtstartMs: number];
+  cancelInstance: [masterUid: string, instanceDtstart: CalendarDateValue];
   rsvp: [event: CommunityEvent, partstat: PartStat];
   openNav: [];
 }>();
@@ -89,7 +102,7 @@ const selfAttendeeUri = computed(() => {
 type ViewMode = "week" | "month";
 type EventFilter = "all" | "attending";
 
-const viewMode = ref<ViewMode>("week");
+const viewMode = ref<ViewMode>("month");
 const activeFilter = ref<EventFilter>("all");
 
 // ─── RSVP helpers ─────────────────────────────────────────────────────────────
@@ -131,24 +144,36 @@ const filteredEvents = computed(() => {
 
 // ─── 7-day list view ─────────────────────────────────────────────────────────
 
-const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+interface WeekEventDay {
+  startMs: number;
+  events: CommunityEvent[];
+}
 
-/** Events starting within the next 7 days, grouped by locale date string. */
-const weekEventsByDay = computed<Map<string, CommunityEvent[]>>(() => {
-  const now = Date.now();
-  const horizon = now + SEVEN_DAYS_MS;
-  const groups = new Map<string, CommunityEvent[]>();
-  const sorted = [...filteredEvents.value]
-    .filter((e): e is CommunityEvent & { dtstartMs: number } => typeof e.dtstartMs === "number")
-    .sort((a, b) => a.dtstartMs - b.dtstartMs);
-  for (const e of sorted) {
-    if (e.dtstartMs < now || e.dtstartMs > horizon) continue;
-    const key = new Date(e.dtstartMs).toLocaleDateString(undefined, {
+/** Future or ongoing events overlapping the next 7 local days, grouped by day. */
+const weekEventsByDay = computed<Map<string, WeekEventDay>>(() => {
+  const groups = new Map<string, WeekEventDay>();
+  const now = new Date();
+  const nowMs = now.getTime();
+  for (let offset = 0; offset < 7; offset += 1) {
+    const day = new Date(now.getFullYear(), now.getMonth(), now.getDate() + offset);
+    const { startMs: dayStart, endMs: dayEnd } = localDayRange(
+      day.getFullYear(),
+      day.getMonth(),
+      day.getDate(),
+    );
+    const dayEvents = sortEventsForDay(
+      filteredEvents.value.filter((event) =>
+        isEventUpcomingOrOngoing(event, nowMs) && eventOverlapsRange(event, dayStart, dayEnd),
+      ),
+      dayStart,
+    );
+    if (dayEvents.length === 0) continue;
+    const key = day.toLocaleDateString(undefined, {
       weekday: "long",
       month: "short",
       day: "numeric",
     });
-    (groups.get(key) ?? (groups.set(key, []), groups.get(key)!)).push(e);
+    groups.set(key, { startMs: dayStart, events: dayEvents });
   }
   return groups;
 });
@@ -186,6 +211,7 @@ function goToToday() {
 
 interface CalCell {
   day: number | null;
+  rangeStartMs: number | null;
   isToday: boolean;
   events: CommunityEvent[];
 }
@@ -201,25 +227,26 @@ const calGrid = computed<CalCell[][]>(() => {
 
   // Leading empty cells
   for (let i = 0; i < firstDow; i++) {
-    cells.push({ day: null, isToday: false, events: [] });
+    cells.push({ day: null, rangeStartMs: null, isToday: false, events: [] });
   }
 
   for (let d = 1; d <= daysInMonth; d++) {
     const cellDate = new Date(y, m, d);
-    const dayStart = cellDate.getTime();
-    const dayEnd = dayStart + 86_400_000;
-    const events = filteredEvents.value.filter(
-      (e) => typeof e.dtstartMs === "number" && e.dtstartMs >= dayStart && e.dtstartMs < dayEnd,
+    const { startMs: dayStart, endMs: dayEnd } = localDayRange(y, m, d);
+    const events = sortEventsForDay(
+      filteredEvents.value.filter((event) => eventOverlapsRange(event, dayStart, dayEnd)),
+      dayStart,
     );
     cells.push({
       day: d,
+      rangeStartMs: dayStart,
       isToday: cellDate.toDateString() === todayStr,
       events,
     });
   }
 
   // Trailing empty cells to complete last row
-  while (cells.length % 7 !== 0) cells.push({ day: null, isToday: false, events: [] });
+  while (cells.length % 7 !== 0) cells.push({ day: null, rangeStartMs: null, isToday: false, events: [] });
 
   const weeks: CalCell[][] = [];
   for (let i = 0; i < cells.length; i += 7) weeks.push(cells.slice(i, i + 7));
@@ -230,6 +257,12 @@ const selectedDayEvents = computed<CommunityEvent[]>(() => {
   const d = selectedDay.value;
   if (d === null) return [];
   return calGrid.value.flat().find((c) => c.day === d)?.events ?? [];
+});
+
+const selectedDayStartMs = computed(() => {
+  const d = selectedDay.value;
+  if (d === null) return null;
+  return localDayRange(calYear.value, calMonth.value, d).startMs;
 });
 
 // ─── Formatting ───────────────────────────────────────────────────────────────
@@ -245,22 +278,70 @@ const weekdayLabels: Record<Weekday, string> = {
 };
 
 function formatStart(event: CommunityEvent): string {
-  if (typeof event.dtstartMs !== "number") return "TBD";
-  return new Date(event.dtstartMs).toLocaleString(undefined, {
+  if (!event.dtstart) return "TBD";
+  if (event.dtstart.kind === "date") {
+    const start = dateLabel(event.dtstart.date);
+    const end = allDayInclusiveEnd(event);
+    return end && end !== event.dtstart.date ? `${start} - ${dateLabel(end)} · all day` : `${start} · all day`;
+  }
+  const start = new Date(event.dtstart.ms).toLocaleString(undefined, {
     weekday: "short",
     month: "short",
     day: "numeric",
     hour: "numeric",
     minute: "2-digit",
   });
+  if (event.dtend?.kind !== "date-time") return start;
+  return `${start} - ${new Date(event.dtend.ms).toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  })}`;
 }
 
 function formatTime(event: CommunityEvent): string {
-  if (typeof event.dtstartMs !== "number") return "TBD";
-  return new Date(event.dtstartMs).toLocaleTimeString(undefined, {
+  if (!event.dtstart) return "TBD";
+  if (event.dtstart.kind === "date") return "All day";
+  return new Date(event.dtstart.ms).toLocaleTimeString(undefined, {
     hour: "numeric",
     minute: "2-digit",
   });
+}
+
+function formatVisibleTime(event: CommunityEvent, dayStartMs: number | null): string {
+  if (!event.dtstart) return "TBD";
+  if (event.dtstart.kind === "date") return "All day";
+  if (dayStartMs === null) return formatTime(event);
+  const startDay = localDateStringFromMs(event.dtstart.ms);
+  const visibleDay = localDateStringFromMs(dayStartMs);
+  if (startDay === visibleDay) return formatTime(event);
+  if (event.dtend?.kind === "date-time" && localDateStringFromMs(event.dtend.ms) === visibleDay) {
+    return `continues until ${new Date(event.dtend.ms).toLocaleTimeString(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+    })}`;
+  }
+  return "continues";
+}
+
+function dateLabel(date: string): string {
+  return new Date(`${date}T00:00:00`).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function allDayInclusiveEnd(event: CommunityEvent): string | null {
+  if (event.dtstart?.kind !== "date") return null;
+  if (event.dtend?.kind !== "date") return event.dtstart.date;
+  return addDaysToDateString(event.dtend.date, -1);
+}
+
+function monthPillLabel(event: CommunityEvent, dayStartMs: number | null): string {
+  if (dayStartMs === null || event.dtstart?.kind !== "date-time") return event.summary;
+  const startDay = localDateStringFromMs(event.dtstart.ms);
+  const cellDay = localDateStringFromMs(dayStartMs);
+  if (startDay !== cellDay) return `continues ${event.summary}`;
+  return `${formatTime(event)} ${event.summary}`;
 }
 
 function summarizeRrule(rule: Rrule): string {
@@ -299,10 +380,51 @@ const description = ref("");
 const location = ref("");
 const dtstart = ref("");
 const dtend = ref("");
+const allDay = ref(false);
+const allDayStart = ref("");
+const allDayEnd = ref("");
+const durationChoice = ref("30");
 const rrule = ref<Rrule | null>(null);
+const composerTouched = ref(false);
+const composerSubmitted = ref(false);
+
+const DURATION_OPTIONS = [
+  { value: "30", label: "30 minutes" },
+  { value: "60", label: "1 hour" },
+  { value: "90", label: "90 minutes" },
+  { value: "120", label: "2 hours" },
+  { value: "180", label: "3 hours" },
+  { value: "custom", label: "Custom" },
+] as const;
+
+const composerError = computed(() => {
+  if (summary.value.trim().length === 0) return "Add an event title.";
+  if (allDay.value) {
+    if (!allDayStart.value) return "Choose a start date.";
+    const visibleEnd = allDayEnd.value || allDayStart.value;
+    const endExclusive = addDaysToDateString(visibleEnd, 1);
+    if (calendarDateStartMs(dateValue(endExclusive)) <= calendarDateStartMs(dateValue(allDayStart.value))) {
+      return "End date must be after the start date.";
+    }
+    if (typeof rrule.value?.untilMs === "number") {
+      return "All-day repeats need a count instead of an until date.";
+    }
+    return null;
+  }
+  if (!dtstart.value) return "Choose a start time.";
+  const startMs = Date.parse(dtstart.value);
+  const endMs = timedEndMs();
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) return "Choose a valid time.";
+  if (endMs <= startMs) return "End time must be after the start time.";
+  return null;
+});
 
 const canSubmit = computed(
-  () => props.canPost && !props.isPosting && summary.value.trim().length > 0,
+  () => props.canPost && !props.isPosting && composerError.value === null,
+);
+
+const visibleComposerError = computed(() =>
+  composerTouched.value || composerSubmitted.value ? composerError.value : null,
 );
 
 const calendarFeedCopy = useCalendarFeedCopy({
@@ -325,6 +447,34 @@ function toDatetimeLocal(ms: number | undefined): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
+function openComposer() {
+  resetComposerFields();
+  composerOpen.value = true;
+}
+
+function markComposerTouched() {
+  composerTouched.value = true;
+}
+
+function timedEndMs(): number {
+  const startMs = Date.parse(dtstart.value);
+  if (durationChoice.value === "custom") return Date.parse(dtend.value);
+  const durationMinutes = Number(durationChoice.value);
+  return Number.isFinite(startMs) && Number.isFinite(durationMinutes)
+    ? startMs + durationMinutes * 60_000
+    : Number.NaN;
+}
+
+function selectDurationForBounds(start: CalendarDateValue | undefined, end: CalendarDateValue | undefined) {
+  if (start?.kind !== "date-time" || end?.kind !== "date-time") {
+    durationChoice.value = "30";
+    return;
+  }
+  const minutes = Math.round((end.ms - start.ms) / 60_000);
+  const match = DURATION_OPTIONS.find((option) => option.value === String(minutes));
+  durationChoice.value = match ? match.value : "custom";
+}
+
 /**
  * Edits always target the unexpanded master so the RRULE / EXDATEs
  * are preserved and the resulting publish lands at the real pubsub
@@ -337,9 +487,26 @@ function startEdit(event: CommunityEvent) {
   summary.value = master.summary;
   description.value = master.description ?? "";
   location.value = master.location ?? "";
-  dtstart.value = toDatetimeLocal(master.dtstartMs);
-  dtend.value = toDatetimeLocal(master.dtendMs);
+  if (master.dtstart?.kind === "date") {
+    allDay.value = true;
+    allDayStart.value = master.dtstart.date;
+    allDayEnd.value = allDayInclusiveEnd(master) ?? master.dtstart.date;
+    dtstart.value = "";
+    dtend.value = "";
+  } else {
+    allDay.value = false;
+    dtstart.value = toDatetimeLocal(master.dtstart?.kind === "date-time" ? master.dtstart.ms : undefined);
+    dtend.value = toDatetimeLocal(master.dtend?.kind === "date-time" ? master.dtend.ms : undefined);
+    selectDurationForBounds(master.dtstart, master.dtend);
+    const allDayDefault = master.dtstart?.kind === "date-time"
+      ? localDateStringFromMs(master.dtstart.ms)
+      : todayDateString();
+    allDayStart.value = allDayDefault;
+    allDayEnd.value = allDayDefault;
+  }
   rrule.value = master.rrule ?? null;
+  composerTouched.value = false;
+  composerSubmitted.value = false;
   composerOpen.value = true;
 }
 
@@ -364,8 +531,8 @@ function onCancelEvent(event: CommunityEvent) {
 
 function confirmCancelInstance() {
   const event = cancelTarget.value;
-  if (!event || typeof event.dtstartMs !== "number") return;
-  emit("cancelInstance", event.uid, event.dtstartMs);
+  if (!event || !event.dtstart) return;
+  emit("cancelInstance", event.uid, event.dtstart);
   cancelTarget.value = null;
 }
 
@@ -382,8 +549,11 @@ function dismissCancelSheet() {
 }
 
 function submit() {
+  composerSubmitted.value = true;
   const summaryValue = summary.value.trim();
-  if (!summaryValue) return;
+  if (!summaryValue || composerError.value) return;
+  const dateFields = buildDateInput();
+  if (!dateFields) return;
   const input: CommunityEventInput = {
     summary: summaryValue,
     ...(description.value.trim() ? { description: description.value.trim() } : {}),
@@ -391,8 +561,7 @@ function submit() {
     ...(props.selfJid
       ? { organizer: `xmpp:${props.selfJid.split("/")[0] ?? props.selfJid}` }
       : {}),
-    ...(dtstart.value ? { dtstartMs: Date.parse(dtstart.value) } : {}),
-    ...(dtend.value ? { dtendMs: Date.parse(dtend.value) } : {}),
+    ...dateFields,
     ...(rrule.value ? { rrule: rrule.value } : {}),
   };
   if (editingId.value) {
@@ -406,12 +575,50 @@ function submit() {
 function resetComposer() {
   composerOpen.value = false;
   editingId.value = null;
+  resetComposerFields();
+}
+
+function resetComposerFields() {
   summary.value = "";
   description.value = "";
   location.value = "";
   dtstart.value = "";
   dtend.value = "";
+  allDay.value = false;
+  setDefaultAllDayDates();
+  durationChoice.value = "30";
   rrule.value = null;
+  composerTouched.value = false;
+  composerSubmitted.value = false;
+}
+
+function setDefaultAllDayDates() {
+  const today = todayDateString();
+  allDayStart.value = today;
+  allDayEnd.value = today;
+}
+
+function todayDateString(): string {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+}
+
+function buildDateInput(): Pick<CommunityEventInput, "dtstart" | "dtend"> | null {
+  if (allDay.value) {
+    if (!allDayStart.value) return null;
+    const visibleEnd = allDayEnd.value || allDayStart.value;
+    return {
+      dtstart: dateValue(allDayStart.value),
+      dtend: dateValue(addDaysToDateString(visibleEnd, 1)),
+    };
+  }
+  const startMs = Date.parse(dtstart.value);
+  const endMs = timedEndMs();
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) return null;
+  return {
+    dtstart: dateTimeValue(startMs),
+    dtend: dateTimeValue(endMs),
+  };
 }
 
 const copyCalendarFeedUrl = calendarFeedCopy.copy;
@@ -499,7 +706,7 @@ const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
           v-if="canPost"
           type="button"
           class="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground shadow-sm hover:bg-primary/90"
-          @click="composerOpen ? resetComposer() : (composerOpen = true)"
+          @click="composerOpen ? resetComposer() : openComposer()"
         >
           <Plus class="h-3.5 w-3.5" aria-hidden="true" />
           {{ composerOpen ? (editingId ? "Cancel edit" : "Close") : "New event" }}
@@ -530,6 +737,7 @@ const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
       <form
         v-if="composerOpen"
         class="grid gap-2 rounded-lg border border-border bg-card p-3"
+        @input="markComposerTouched"
         @submit.prevent="submit"
       >
         <input
@@ -540,7 +748,33 @@ const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
           required
           aria-label="Event title"
         />
-        <div class="grid gap-2 md:grid-cols-2">
+        <label class="inline-flex w-fit items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-xs text-foreground">
+          <input
+            v-model="allDay"
+            type="checkbox"
+            class="h-4 w-4 rounded border-input"
+          />
+          All day
+        </label>
+        <div v-if="allDay" class="grid gap-2 md:grid-cols-2">
+          <label class="grid gap-1 text-xs">
+            <span class="text-muted-foreground">Start date</span>
+            <input
+              v-model="allDayStart"
+              type="date"
+              class="rounded-md border border-input bg-background px-2 py-1.5 text-sm"
+            />
+          </label>
+          <label class="grid gap-1 text-xs">
+            <span class="text-muted-foreground">End date</span>
+            <input
+              v-model="allDayEnd"
+              type="date"
+              class="rounded-md border border-input bg-background px-2 py-1.5 text-sm"
+            />
+          </label>
+        </div>
+        <div v-else class="grid gap-2 md:grid-cols-2">
           <label class="grid gap-1 text-xs">
             <span class="text-muted-foreground">Starts</span>
             <input
@@ -550,6 +784,21 @@ const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
             />
           </label>
           <label class="grid gap-1 text-xs">
+            <span class="text-muted-foreground">Duration</span>
+            <select
+              v-model="durationChoice"
+              class="rounded-md border border-input bg-background px-2 py-1.5 text-sm"
+            >
+              <option
+                v-for="option in DURATION_OPTIONS"
+                :key="option.value"
+                :value="option.value"
+              >
+                {{ option.label }}
+              </option>
+            </select>
+          </label>
+          <label v-if="durationChoice === 'custom'" class="grid gap-1 text-xs md:col-span-2">
             <span class="text-muted-foreground">Ends</span>
             <input
               v-model="dtend"
@@ -572,6 +821,14 @@ const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
           aria-label="Event description"
         />
         <RecurrencePicker v-model="rrule" />
+        <p
+          v-if="visibleComposerError"
+          class="inline-flex items-center gap-1 text-xs text-destructive"
+          role="alert"
+        >
+          <Clock3 class="h-3.5 w-3.5" aria-hidden="true" />
+          {{ visibleComposerError }}
+        </p>
         <div class="flex items-center justify-end gap-2">
           <button
             type="button"
@@ -596,13 +853,13 @@ const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
       <template v-if="viewMode === 'week'">
         <div v-if="weekEventsByDay.size > 0" class="grid gap-4">
           <section
-            v-for="[dayLabel, dayEvents] in weekEventsByDay"
+            v-for="[dayLabel, day] in weekEventsByDay"
             :key="dayLabel"
             class="grid gap-2"
           >
             <h2 class="type-section-label text-muted-foreground">{{ dayLabel }}</h2>
             <article
-              v-for="event in dayEvents"
+              v-for="event in day.events"
               :key="event.id"
               class="grid gap-1.5 rounded-lg border border-border bg-card px-4 py-3"
             >
@@ -610,7 +867,7 @@ const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
                 <h3 class="type-control font-semibold text-foreground">{{ event.summary }}</h3>
                 <div class="flex shrink-0 items-center gap-1">
                   <span class="type-caption text-muted-foreground">
-                    {{ formatTime(event) }}
+                    {{ formatVisibleTime(event, day.startMs) }}
                   </span>
                   <template v-if="isOrganiser(event)">
                     <button
@@ -778,7 +1035,7 @@ const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
                       ? 'bg-primary/20 text-primary'
                       : 'bg-muted/60 text-muted-foreground'"
                   >
-                    {{ ev.summary }}
+                    {{ monthPillLabel(ev, cell.rangeStartMs) }}
                   </div>
                   <div
                     v-if="cell.events.length > 3"
@@ -805,7 +1062,7 @@ const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
             <header class="flex items-baseline justify-between gap-3">
               <h3 class="type-control font-semibold text-foreground">{{ event.summary }}</h3>
               <div class="flex shrink-0 items-center gap-1">
-                <span class="type-caption text-muted-foreground">{{ formatStart(event) }}</span>
+                <span class="type-caption text-muted-foreground">{{ formatVisibleTime(event, selectedDayStartMs) }}</span>
                 <template v-if="isOrganiser(event)">
                   <button
                     type="button"
@@ -906,7 +1163,7 @@ const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
           >
             <span>Just this occurrence</span>
             <span class="type-caption text-muted-foreground">
-              {{ cancelTarget.dtstartMs ? new Date(cancelTarget.dtstartMs).toLocaleString(undefined, { weekday: 'short', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' }) : '' }}
+              {{ formatStart(cancelTarget) }}
             </span>
           </button>
           <button

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -2795,12 +2795,8 @@ export class BrowserXmppClient {
       ...(input.description ? { description: input.description } : {}),
       ...(input.location ? { location: input.location } : {}),
       ...(input.organizer ? { organizer: input.organizer } : {}),
-      ...(typeof input.dtstartMs === "number"
-        ? { dtstart: new Date(input.dtstartMs).toISOString() }
-        : {}),
-      ...(typeof input.dtendMs === "number"
-        ? { dtend: new Date(input.dtendMs).toISOString() }
-        : {}),
+      ...(input.dtstart ? { dtstart: input.dtstart } : {}),
+      ...(input.dtend ? { dtend: input.dtend } : {}),
       ...(input.rrule ? { rrule: rruleToWasm(input.rrule) } : {}),
     }) as WasmVEvent | undefined;
     if (!result) {
@@ -2821,19 +2817,15 @@ export class BrowserXmppClient {
     input: CommunityEventInput,
   ): Promise<CommunityEvent> {
     const xmpp = await this.requireConnectedXmpp();
-    const exdates = (input.exdatesMs ?? []).map((ms) => new Date(ms).toISOString());
+    const exdates = input.exdates ?? [];
     const result = await xmpp.xcal_publish_item?.(communityJid, itemId, {
       master: {
         summary: input.summary,
         ...(input.description ? { description: input.description } : {}),
         ...(input.location ? { location: input.location } : {}),
         ...(input.organizer ? { organizer: input.organizer } : {}),
-        ...(typeof input.dtstartMs === "number"
-          ? { dtstart: new Date(input.dtstartMs).toISOString() }
-          : {}),
-        ...(typeof input.dtendMs === "number"
-          ? { dtend: new Date(input.dtendMs).toISOString() }
-          : {}),
+        ...(input.dtstart ? { dtstart: input.dtstart } : {}),
+        ...(input.dtend ? { dtend: input.dtend } : {}),
         ...(input.rrule ? { rrule: rruleToWasm(input.rrule) } : {}),
       },
       overrides: [],

--- a/chat/src/lib/xmpp/event-calendar.ts
+++ b/chat/src/lib/xmpp/event-calendar.ts
@@ -1,0 +1,149 @@
+import type { CalendarDateValue, CommunityEvent } from "./event-types";
+
+export interface CalendarEventBounds {
+  startMs: number;
+  endMs: number;
+  isAllDay: boolean;
+}
+
+export interface LocalDayRange {
+  startMs: number;
+  endMs: number;
+}
+
+export function dateTimeValue(ms: number): CalendarDateValue {
+  return { kind: "date-time", ms };
+}
+
+export function dateValue(date: string): CalendarDateValue {
+  return { kind: "date", date };
+}
+
+export function calendarDateKey(value: CalendarDateValue): string {
+  return value.kind === "date" ? `date:${value.date}` : `date-time:${value.ms}`;
+}
+
+export function localDateStringFromMs(ms: number): string {
+  const date = new Date(ms);
+  return localDateString(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+export function localDateString(year: number, monthIndex: number, day: number): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${year}-${pad(monthIndex + 1)}-${pad(day)}`;
+}
+
+export function addDaysToDateString(date: string, days: number): string {
+  const parts = parseDateParts(date);
+  if (!parts) return date;
+  const shifted = new Date(Date.UTC(parts.year, parts.monthIndex, parts.day + days));
+  return localDateString(shifted.getUTCFullYear(), shifted.getUTCMonth(), shifted.getUTCDate());
+}
+
+export function localDayRange(year: number, monthIndex: number, day: number): LocalDayRange {
+  const startMs = new Date(year, monthIndex, day).getTime();
+  const endMs = new Date(year, monthIndex, day + 1).getTime();
+  return { startMs, endMs };
+}
+
+export function calendarDateStartMs(value: CalendarDateValue): number {
+  if (value.kind === "date-time") return value.ms;
+  const parts = parseDateParts(value.date);
+  if (!parts) return Number.NaN;
+  return new Date(parts.year, parts.monthIndex, parts.day).getTime();
+}
+
+export function eventBounds(event: CommunityEvent): CalendarEventBounds | null {
+  if (!event.dtstart) return null;
+  const startMs = calendarDateStartMs(event.dtstart);
+  if (!Number.isFinite(startMs)) return null;
+  const isAllDay = event.dtstart.kind === "date";
+  const rawEndMs = event.dtend ? calendarDateStartMs(event.dtend) : Number.NaN;
+  const fallbackEndMs =
+    event.dtstart.kind === "date" ? fallbackAllDayEndMs(event.dtstart.date) : startMs + 1;
+  const endMs = Number.isFinite(rawEndMs) && rawEndMs > startMs ? rawEndMs : fallbackEndMs;
+  return { startMs, endMs, isAllDay };
+}
+
+export function eventOverlapsRange(
+  event: CommunityEvent,
+  rangeStartMs: number,
+  rangeEndMs: number,
+): boolean {
+  const bounds = eventBounds(event);
+  if (!bounds) return false;
+  return bounds.startMs < rangeEndMs && bounds.endMs > rangeStartMs;
+}
+
+export function isEventUpcomingOrOngoing(event: CommunityEvent, nowMs: number = Date.now()): boolean {
+  const bounds = eventBounds(event);
+  if (!bounds) return false;
+  return bounds.endMs > nowMs;
+}
+
+export function sortEventsUpcomingFirst(
+  events: readonly CommunityEvent[],
+  nowMs: number = Date.now(),
+): CommunityEvent[] {
+  const upcoming: CommunityEvent[] = [];
+  const past: CommunityEvent[] = [];
+  for (const event of events) {
+    if (isEventUpcomingOrOngoing(event, nowMs)) upcoming.push(event);
+    else past.push(event);
+  }
+  upcoming.sort((a, b) => compareEventsByBounds(a, b, true));
+  past.sort((a, b) => compareEventsByBounds(b, a, true));
+  return [...upcoming, ...past];
+}
+
+export function sortEventsForDay(
+  events: readonly CommunityEvent[],
+  dayStartMs: number,
+): CommunityEvent[] {
+  return [...events].sort((a, b) => {
+    const aBounds = eventBounds(a);
+    const bBounds = eventBounds(b);
+    if (!aBounds && !bBounds) return a.summary.localeCompare(b.summary);
+    if (!aBounds) return 1;
+    if (!bBounds) return -1;
+    if (aBounds.isAllDay !== bBounds.isAllDay) return aBounds.isAllDay ? -1 : 1;
+    const aVisible = Math.max(aBounds.startMs, dayStartMs);
+    const bVisible = Math.max(bBounds.startMs, dayStartMs);
+    return aVisible - bVisible || aBounds.endMs - bBounds.endMs || a.summary.localeCompare(b.summary);
+  });
+}
+
+export function compareCalendarDateValues(a: CalendarDateValue, b: CalendarDateValue): number {
+  if (a.kind === "date" && b.kind === "date") return a.date.localeCompare(b.date);
+  return calendarDateStartMs(a) - calendarDateStartMs(b);
+}
+
+function compareEventsByBounds(a: CommunityEvent, b: CommunityEvent, allDayFirst: boolean): number {
+  const aBounds = eventBounds(a);
+  const bBounds = eventBounds(b);
+  if (!aBounds && !bBounds) return a.summary.localeCompare(b.summary);
+  if (!aBounds) return 1;
+  if (!bBounds) return -1;
+  if (allDayFirst && aBounds.isAllDay !== bBounds.isAllDay) {
+    return aBounds.isAllDay ? -1 : 1;
+  }
+  return aBounds.startMs - bBounds.startMs || a.summary.localeCompare(b.summary);
+}
+
+function fallbackAllDayEndMs(date: string): number {
+  const parts = parseDateParts(addDaysToDateString(date, 1));
+  if (!parts) return Number.NaN;
+  return new Date(parts.year, parts.monthIndex, parts.day).getTime();
+}
+
+function parseDateParts(date: string):
+  | { year: number; monthIndex: number; day: number }
+  | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  if (!match) return null;
+  return {
+    year: Number(match[1]),
+    monthIndex: Number(match[2]) - 1,
+    day: Number(match[3]),
+  };
+}

--- a/chat/src/lib/xmpp/event-expansion.ts
+++ b/chat/src/lib/xmpp/event-expansion.ts
@@ -10,17 +10,25 @@
  *
  * For each candidate occurrence:
  *   - skipped if its DTSTART matches any value in the master's
- *     `exdatesMs`;
+ *     `exdates`;
  *   - replaced by the override's properties (summary, location,
  *     dtstart, dtend, description) when an override's
- *     `recurrenceIdMs` matches the occurrence.
+ *     `recurrenceId` matches the occurrence.
  *
  * Non-recurring events pass through unchanged as a single instance.
  */
 
-import type { CommunityEvent, Weekday } from "./event-types";
+import {
+  addDaysToDateString,
+  calendarDateKey,
+  calendarDateStartMs,
+  dateTimeValue,
+  eventBounds,
+} from "./event-calendar";
+import type { CalendarDateValue, CommunityEvent, Weekday } from "./event-types";
 
 const DAY_MS = 86_400_000;
+type CalendarDateOnly = Extract<CalendarDateValue, { kind: "date" }>;
 
 const WEEKDAY_INDEX: Record<Weekday, number> = {
   SU: 0,
@@ -51,8 +59,9 @@ interface ExpandInstancesOptions {
 
 /**
  * Expand a CalendarMaster into upcoming `CommunityEvent` instances.
- * Past occurrences (DTSTART <= nowMs) are dropped. The returned list
- * is sorted ascending by DTSTART.
+ * Occurrences whose effective end is not after `nowMs` are dropped,
+ * so ongoing spanning events are retained. The returned list is
+ * sorted ascending by DTSTART.
  */
 export function expandInstances(
   group: CalendarMaster,
@@ -63,21 +72,21 @@ export function expandInstances(
   const horizonMs = options.horizonMs ?? nowMs + 365 * DAY_MS;
   const maxCount = options.maxCount ?? 50;
 
-  const dtstart = master.dtstartMs;
-  if (typeof dtstart !== "number") {
+  const dtstart = master.dtstart;
+  if (!dtstart) {
     // No timeline anchor — surface the master as-is so it still renders.
     return [{ ...master }];
   }
   if (!master.rrule) {
-    if (dtstart <= nowMs) return [];
+    if ((eventBounds(master)?.endMs ?? 0) <= nowMs) return [];
     return [{ ...master }];
   }
 
-  const exdateSet = new Set(master.exdatesMs ?? []);
-  const overrideByDtstart = new Map<number, CommunityEvent>();
+  const exdateSet = new Set((master.exdates ?? []).map(calendarDateKey));
+  const overrideByDtstart = new Map<string, CommunityEvent>();
   for (const ov of overrides) {
-    if (typeof ov.recurrenceIdMs === "number") {
-      overrideByDtstart.set(ov.recurrenceIdMs, ov);
+    if (ov.recurrenceId) {
+      overrideByDtstart.set(calendarDateKey(ov.recurrenceId), ov);
     }
   }
 
@@ -95,8 +104,8 @@ export function expandInstances(
   let walked = 0;
 
   while (
-    cursor <= horizonMs &&
-    cursor <= until &&
+    calendarDateStartMs(cursor) <= horizonMs &&
+    calendarDateStartMs(cursor) <= until &&
     candidates < countCap &&
     emitted < maxCount &&
     walked < walkCap
@@ -104,14 +113,17 @@ export function expandInstances(
     walked += 1;
     if (matchesByDay(cursor, rrule.byDay) && matchesByMonthDay(cursor, rrule.byMonthDay)) {
       candidates += 1;
-      const skip = exdateSet.has(cursor);
-      if (!skip && cursor > nowMs) {
-        const override = overrideByDtstart.get(cursor);
+      const cursorKey = calendarDateKey(cursor);
+      const skip = exdateSet.has(cursorKey);
+      if (!skip) {
+        const override = overrideByDtstart.get(cursorKey);
         const instance = override
           ? applyOverride(master, override, cursor)
           : occurrenceFromMaster(master, cursor);
-        out.push(instance);
-        emitted += 1;
+        if ((eventBounds(instance)?.endMs ?? 0) > nowMs) {
+          out.push(instance);
+          emitted += 1;
+        }
       }
     }
     cursor = advance(cursor, rrule.freq, interval);
@@ -131,7 +143,7 @@ export function groupEventsWithOverrides(
   const masters = new Map<string, CommunityEvent>();
   const overrides = new Map<string, CommunityEvent[]>();
   for (const item of items) {
-    if (typeof item.recurrenceIdMs === "number") {
+    if (item.recurrenceId) {
       const bucket = overrides.get(item.uid) ?? [];
       bucket.push(item);
       overrides.set(item.uid, bucket);
@@ -146,51 +158,80 @@ export function groupEventsWithOverrides(
   return out;
 }
 
-function matchesByDay(ms: number, byDay: readonly Weekday[] | undefined): boolean {
+function matchesByDay(value: CalendarDateValue, byDay: readonly Weekday[] | undefined): boolean {
   if (!byDay || byDay.length === 0) return true;
-  const dow = new Date(ms).getUTCDay();
+  const dow = value.kind === "date"
+    ? dateStringUtcDate(value.date).getUTCDay()
+    : new Date(value.ms).getUTCDay();
   return byDay.some((wd) => WEEKDAY_INDEX[wd] === dow);
 }
 
-function matchesByMonthDay(ms: number, byMonthDay: readonly number[] | undefined): boolean {
+function matchesByMonthDay(value: CalendarDateValue, byMonthDay: readonly number[] | undefined): boolean {
   if (!byMonthDay || byMonthDay.length === 0) return true;
-  const dom = new Date(ms).getUTCDate();
+  const dom = value.kind === "date"
+    ? dateStringUtcDate(value.date).getUTCDate()
+    : new Date(value.ms).getUTCDate();
   return byMonthDay.includes(dom);
 }
 
-function advance(ms: number, freq: string, interval: number): number {
-  const d = new Date(ms);
+function advance(value: CalendarDateValue, freq: string, interval: number): CalendarDateValue {
+  if (value.kind === "date") {
+    return advanceDate(value, freq, interval);
+  }
+  const d = new Date(value.ms);
   switch (freq) {
     case "DAILY":
       d.setUTCDate(d.getUTCDate() + interval);
-      return d.getTime();
+      return dateTimeValue(d.getTime());
     case "WEEKLY":
       // Walk by single days; BYDAY filtering picks the right ones.
       // For multi-week intervals we still walk daily and let the
       // BYDAY filter + interval-week check handle it.
       d.setUTCDate(d.getUTCDate() + (interval === 1 ? 1 : 7 * interval));
-      return d.getTime();
+      return dateTimeValue(d.getTime());
     case "MONTHLY":
       d.setUTCMonth(d.getUTCMonth() + interval);
-      return d.getTime();
+      return dateTimeValue(d.getTime());
     case "YEARLY":
       d.setUTCFullYear(d.getUTCFullYear() + interval);
-      return d.getTime();
+      return dateTimeValue(d.getTime());
     default:
       // Unknown frequency — bail to "1 day" so the loop still
       // terminates against horizonMs / walkCap.
       d.setUTCDate(d.getUTCDate() + 1);
-      return d.getTime();
+      return dateTimeValue(d.getTime());
   }
 }
 
-function occurrenceFromMaster(master: CommunityEvent, dtstartMs: number): CommunityEvent {
-  const durationMs = masterDurationMs(master);
+function advanceDate(value: CalendarDateOnly, freq: string, interval: number): CalendarDateValue {
+  switch (freq) {
+    case "DAILY":
+      return { kind: "date", date: addDaysToDateString(value.date, interval) };
+    case "WEEKLY":
+      return { kind: "date", date: addDaysToDateString(value.date, interval === 1 ? 1 : 7 * interval) };
+    case "MONTHLY": {
+      const d = dateStringUtcDate(value.date);
+      d.setUTCMonth(d.getUTCMonth() + interval);
+      return { kind: "date", date: formatUtcDateString(d) };
+    }
+    case "YEARLY": {
+      const d = dateStringUtcDate(value.date);
+      d.setUTCFullYear(d.getUTCFullYear() + interval);
+      return { kind: "date", date: formatUtcDateString(d) };
+    }
+    default:
+      return { kind: "date", date: addDaysToDateString(value.date, 1) };
+  }
+}
+
+function occurrenceFromMaster(master: CommunityEvent, dtstart: CalendarDateValue): CommunityEvent {
+  const duration = masterDuration(master);
+  const dtend = duration ? addDuration(dtstart, duration) : undefined;
   return {
     ...master,
-    id: `${master.id}::${dtstartMs}`,
-    dtstartMs,
-    ...(typeof durationMs === "number" ? { dtendMs: dtstartMs + durationMs } : {}),
+    id: `${master.id}::${calendarDateKey(dtstart)}`,
+    dtstart,
+    ...(dtend ? { dtend } : {}),
     // Per-occurrence instances inherit the master's series — drop
     // RRULE so the UI shows "single occurrence" semantics.
     rrule: undefined,
@@ -200,31 +241,65 @@ function occurrenceFromMaster(master: CommunityEvent, dtstartMs: number): Commun
 function applyOverride(
   master: CommunityEvent,
   override: CommunityEvent,
-  recurrenceIdMs: number,
+  recurrenceId: CalendarDateValue,
 ): CommunityEvent {
-  const dtstartMs = override.dtstartMs ?? recurrenceIdMs;
-  const inheritedDurationMs = masterDurationMs(master);
+  const dtstart = override.dtstart ?? recurrenceId;
+  const inheritedDuration = masterDuration(master);
+  const inheritedEnd = inheritedDuration ? addDuration(dtstart, inheritedDuration) : undefined;
   return {
     ...master,
-    id: `${master.id}::${recurrenceIdMs}::override`,
+    id: `${master.id}::${calendarDateKey(recurrenceId)}::override`,
     summary: override.summary || master.summary,
     ...(override.description !== undefined ? { description: override.description } : {}),
     ...(override.location !== undefined ? { location: override.location } : {}),
-    dtstartMs,
-    ...(typeof override.dtendMs === "number"
-      ? { dtendMs: override.dtendMs }
-      : typeof inheritedDurationMs === "number"
-        ? { dtendMs: dtstartMs + inheritedDurationMs }
-        : {}),
-    recurrenceIdMs,
+    dtstart,
+    ...(override.dtend ? { dtend: override.dtend } : inheritedEnd ? { dtend: inheritedEnd } : {}),
+    recurrenceId,
     rrule: undefined,
   };
 }
 
-function masterDurationMs(master: CommunityEvent): number | undefined {
-  if (typeof master.dtendMs !== "number" || typeof master.dtstartMs !== "number") {
+type MasterDuration =
+  | { kind: "date-time"; ms: number }
+  | { kind: "date"; days: number };
+
+function masterDuration(master: CommunityEvent): MasterDuration | undefined {
+  if (!master.dtstart || !master.dtend || master.dtstart.kind !== master.dtend.kind) {
     return undefined;
   }
-  const durationMs = master.dtendMs - master.dtstartMs;
-  return Number.isFinite(durationMs) && durationMs >= 0 ? durationMs : undefined;
+  if (master.dtstart.kind === "date-time" && master.dtend.kind === "date-time") {
+    const durationMs = master.dtend.ms - master.dtstart.ms;
+    return Number.isFinite(durationMs) && durationMs >= 0
+      ? { kind: "date-time", ms: durationMs }
+      : undefined;
+  }
+  if (master.dtstart.kind === "date" && master.dtend.kind === "date") {
+    const durationDays = Math.round(
+      (calendarDateStartMs(master.dtend) - calendarDateStartMs(master.dtstart)) / DAY_MS,
+    );
+    return Number.isFinite(durationDays) && durationDays >= 0
+      ? { kind: "date", days: durationDays }
+      : undefined;
+  }
+  return undefined;
+}
+
+function addDuration(start: CalendarDateValue, duration: MasterDuration): CalendarDateValue | undefined {
+  if (start.kind === "date-time" && duration.kind === "date-time") {
+    return dateTimeValue(start.ms + duration.ms);
+  }
+  if (start.kind === "date" && duration.kind === "date") {
+    return { kind: "date", date: addDaysToDateString(start.date, duration.days) };
+  }
+  return undefined;
+}
+
+function dateStringUtcDate(date: string): Date {
+  const [year, month, day] = date.split("-").map(Number);
+  return new Date(Date.UTC(year ?? 0, (month ?? 1) - 1, day ?? 1));
+}
+
+function formatUtcDateString(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}`;
 }

--- a/chat/src/lib/xmpp/event-types.ts
+++ b/chat/src/lib/xmpp/event-types.ts
@@ -33,6 +33,10 @@ export interface Attendee {
   rsvp?: boolean;
 }
 
+export type CalendarDateValue =
+  | { kind: "date"; date: string }
+  | { kind: "date-time"; ms: number };
+
 export interface CommunityEvent {
   /** Pubsub item id (UUID). */
   id: string;
@@ -44,10 +48,8 @@ export interface CommunityEvent {
   organizer?: string;
   /** Epoch ms. */
   dtstampMs?: number;
-  /** Epoch ms. */
-  dtstartMs?: number;
-  /** Epoch ms. */
-  dtendMs?: number;
+  dtstart?: CalendarDateValue;
+  dtend?: CalendarDateValue;
   rrule?: Rrule;
   /**
    * RSVPs aggregated from sibling `<master-uid>-rsvp-<localpart>`
@@ -60,12 +62,12 @@ export interface CommunityEvent {
    * single occurrence of a recurring master. `undefined` on master
    * events.
    */
-  recurrenceIdMs?: number;
+  recurrenceId?: CalendarDateValue;
   /**
    * RFC 5545 EXDATE — occurrence DTSTART values to skip on a
    * recurring master. Empty on overrides and on non-recurring events.
    */
-  exdatesMs?: number[];
+  exdates?: CalendarDateValue[];
 }
 
 export interface CommunityEventInput {
@@ -73,17 +75,15 @@ export interface CommunityEventInput {
   description?: string;
   location?: string;
   organizer?: string;
-  /** Epoch ms. */
-  dtstartMs?: number;
-  /** Epoch ms. */
-  dtendMs?: number;
+  dtstart?: CalendarDateValue;
+  dtend?: CalendarDateValue;
   rrule?: Rrule;
   /**
-   * EXDATE list (epoch ms) — occurrence DTSTARTs to skip on a
-   * recurring master. Only meaningful when `rrule` is set. Empty /
-   * absent means no occurrences are excluded.
+   * EXDATE list — occurrence DTSTART values to skip on a recurring
+   * master. Only meaningful when `rrule` is set. Empty / absent
+   * means no occurrences are excluded.
    */
-  exdatesMs?: number[];
+  exdates?: CalendarDateValue[];
 }
 
 // ── Wasm boundary ───────────────────────────────────────────────────
@@ -112,12 +112,12 @@ export interface WasmVEvent {
   location?: string | null;
   organizer?: string | null;
   dtstamp?: string | null;
-  dtstart?: string | null;
-  dtend?: string | null;
+  dtstart?: CalendarDateValue | null;
+  dtend?: CalendarDateValue | null;
   rrule?: WasmRrule | null;
   attendees?: WasmAttendee[] | null;
-  recurrence_id?: string | null;
-  exdates?: string[] | null;
+  recurrence_id?: CalendarDateValue | null;
+  exdates?: CalendarDateValue[] | null;
 }
 
 const PARTSTATS: ReadonlySet<PartStat> = new Set([
@@ -178,16 +178,16 @@ export function rruleToWasm(rrule: Rrule): WasmRrule {
 
 export function eventFromWasm(event: WasmVEvent): CommunityEvent {
   const dtstamp = event.dtstamp ? Date.parse(event.dtstamp) : undefined;
-  const dtstart = event.dtstart ? Date.parse(event.dtstart) : undefined;
-  const dtend = event.dtend ? Date.parse(event.dtend) : undefined;
   const rrule = event.rrule ? rruleFromWasm(event.rrule) ?? undefined : undefined;
   const attendees = (event.attendees ?? [])
     .map(attendeeFromWasm)
     .filter((a): a is Attendee => a !== null);
-  const recurrenceIdMs = event.recurrence_id ? Date.parse(event.recurrence_id) : undefined;
-  const exdatesMs = (event.exdates ?? [])
-    .map((s) => Date.parse(s))
-    .filter((n) => Number.isFinite(n));
+  const dtstart = calendarDateFromWasm(event.dtstart);
+  const dtend = calendarDateFromWasm(event.dtend);
+  const recurrenceId = calendarDateFromWasm(event.recurrence_id);
+  const exdates = (event.exdates ?? [])
+    .map(calendarDateFromWasm)
+    .filter((value): value is CalendarDateValue => value !== undefined);
   return {
     id: event.id,
     uid: event.uid,
@@ -196,15 +196,24 @@ export function eventFromWasm(event: WasmVEvent): CommunityEvent {
     ...(event.location ? { location: event.location } : {}),
     ...(event.organizer ? { organizer: event.organizer } : {}),
     ...(typeof dtstamp === "number" && Number.isFinite(dtstamp) ? { dtstampMs: dtstamp } : {}),
-    ...(typeof dtstart === "number" && Number.isFinite(dtstart) ? { dtstartMs: dtstart } : {}),
-    ...(typeof dtend === "number" && Number.isFinite(dtend) ? { dtendMs: dtend } : {}),
+    ...(dtstart ? { dtstart } : {}),
+    ...(dtend ? { dtend } : {}),
     ...(rrule ? { rrule } : {}),
     ...(attendees.length > 0 ? { attendees } : {}),
-    ...(typeof recurrenceIdMs === "number" && Number.isFinite(recurrenceIdMs)
-      ? { recurrenceIdMs }
-      : {}),
-    ...(exdatesMs.length > 0 ? { exdatesMs } : {}),
+    ...(recurrenceId ? { recurrenceId } : {}),
+    ...(exdates.length > 0 ? { exdates } : {}),
   };
+}
+
+function calendarDateFromWasm(value: CalendarDateValue | null | undefined): CalendarDateValue | undefined {
+  if (!value) return undefined;
+  if (value.kind === "date") {
+    return /^\d{4}-\d{2}-\d{2}$/.test(value.date) ? value : undefined;
+  }
+  if (value.kind === "date-time") {
+    return Number.isFinite(value.ms) ? value : undefined;
+  }
+  return undefined;
 }
 
 function parseRsvpItemId(itemId: string): { masterUid: string; localpart: string } | null {
@@ -237,7 +246,7 @@ export function groupEventsWithRsvps(items: readonly CommunityEvent[]): Communit
       }
       continue;
     }
-    if (typeof item.recurrenceIdMs === "number") {
+    if (item.recurrenceId) {
       overrides.push(item);
       continue;
     }
@@ -260,23 +269,4 @@ export function groupEventsWithRsvps(items: readonly CommunityEvent[]): Communit
     });
   }
   return [...out, ...overrides];
-}
-
-/** Sort events by upcoming-first, past events at the end newest-first. */
-export function sortEventsUpcomingFirst(
-  events: readonly CommunityEvent[],
-  nowMs: number = Date.now(),
-): CommunityEvent[] {
-  const upcoming: CommunityEvent[] = [];
-  const past: CommunityEvent[] = [];
-  for (const event of events) {
-    if (typeof event.dtstartMs === "number" && event.dtstartMs < nowMs) {
-      past.push(event);
-    } else {
-      upcoming.push(event);
-    }
-  }
-  upcoming.sort((a, b) => (a.dtstartMs ?? Infinity) - (b.dtstartMs ?? Infinity));
-  past.sort((a, b) => (b.dtstartMs ?? 0) - (a.dtstartMs ?? 0));
-  return [...upcoming, ...past];
 }

--- a/chat/src/lib/xmpp/index.ts
+++ b/chat/src/lib/xmpp/index.ts
@@ -63,6 +63,7 @@ export type {
 export { groupEventsWithRsvps } from "./event-types";
 export {
   addDaysToDateString,
+  calendarDateKey,
   calendarDateStartMs,
   compareCalendarDateValues,
   dateTimeValue,

--- a/chat/src/lib/xmpp/index.ts
+++ b/chat/src/lib/xmpp/index.ts
@@ -52,6 +52,7 @@ export {
 } from "./story-reads-types";
 export type {
   Attendee,
+  CalendarDateValue,
   CommunityEvent,
   CommunityEventInput,
   Freq,
@@ -59,7 +60,21 @@ export type {
   Rrule,
   Weekday,
 } from "./event-types";
-export { groupEventsWithRsvps, sortEventsUpcomingFirst } from "./event-types";
+export { groupEventsWithRsvps } from "./event-types";
+export {
+  addDaysToDateString,
+  calendarDateStartMs,
+  compareCalendarDateValues,
+  dateTimeValue,
+  dateValue,
+  eventOverlapsRange,
+  isEventUpcomingOrOngoing,
+  localDateString,
+  localDateStringFromMs,
+  localDayRange,
+  sortEventsForDay,
+  sortEventsUpcomingFirst,
+} from "./event-calendar";
 export type { UserPepProfile } from "./pep-types";
 export type {
   DmChatStateEvent,

--- a/chat/src/services/community-events.ts
+++ b/chat/src/services/community-events.ts
@@ -11,8 +11,10 @@
 import { computed, ref, type Ref } from "vue";
 import {
   groupEventsWithRsvps,
+  compareCalendarDateValues,
   sortEventsUpcomingFirst,
   type BrowserXmppClient,
+  type CalendarDateValue,
   type CommunityEvent,
   type CommunityEventInput,
   type PartStat,
@@ -170,7 +172,7 @@ export function useCommunityEvents(
    */
   async function cancelInstance(
     masterUid: string,
-    instanceDtstartMs: number,
+    instanceDtstart: CalendarDateValue,
   ): Promise<boolean> {
     const master = findMaster(masterUid);
     if (!master) return false;
@@ -180,9 +182,9 @@ export function useCommunityEvents(
     const client = xmppClient.value;
     const jid = options.communityJid.value;
     if (!client || !jid) return false;
-    const existing = new Set(master.exdatesMs ?? []);
-    existing.add(instanceDtstartMs);
-    const nextExdatesMs = [...existing].sort((a, b) => a - b);
+    const existing = new Map((master.exdates ?? []).map((value) => [JSON.stringify(value), value]));
+    existing.set(JSON.stringify(instanceDtstart), instanceDtstart);
+    const nextExdates = [...existing.values()].sort(compareCalendarDateValues);
     isPosting.value = true;
     error.value = null;
     try {
@@ -191,10 +193,10 @@ export function useCommunityEvents(
         ...(master.description ? { description: master.description } : {}),
         ...(master.location ? { location: master.location } : {}),
         ...(master.organizer ? { organizer: master.organizer } : {}),
-        ...(typeof master.dtstartMs === "number" ? { dtstartMs: master.dtstartMs } : {}),
-        ...(typeof master.dtendMs === "number" ? { dtendMs: master.dtendMs } : {}),
+        ...(master.dtstart ? { dtstart: master.dtstart } : {}),
+        ...(master.dtend ? { dtend: master.dtend } : {}),
         ...(master.rrule ? { rrule: master.rrule } : {}),
-        exdatesMs: nextExdatesMs,
+        exdates: nextExdates,
       });
       events.value = events.value.map((e) => (e.id === master.id ? updated : e));
       return true;

--- a/chat/src/services/community-events.ts
+++ b/chat/src/services/community-events.ts
@@ -11,6 +11,7 @@
 import { computed, ref, type Ref } from "vue";
 import {
   groupEventsWithRsvps,
+  calendarDateKey,
   compareCalendarDateValues,
   sortEventsUpcomingFirst,
   type BrowserXmppClient,
@@ -182,8 +183,8 @@ export function useCommunityEvents(
     const client = xmppClient.value;
     const jid = options.communityJid.value;
     if (!client || !jid) return false;
-    const existing = new Map((master.exdates ?? []).map((value) => [JSON.stringify(value), value]));
-    existing.set(JSON.stringify(instanceDtstart), instanceDtstart);
+    const existing = new Map((master.exdates ?? []).map((value) => [calendarDateKey(value), value]));
+    existing.set(calendarDateKey(instanceDtstart), instanceDtstart);
     const nextExdates = [...existing.values()].sort(compareCalendarDateValues);
     isPosting.value = true;
     error.value = null;

--- a/chat/tests/community-events.test.ts
+++ b/chat/tests/community-events.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, mock, test } from "bun:test";
 import { ref } from "vue";
 import { useCommunityEvents } from "../src/services/community-events";
-import type { BrowserXmppClient, CommunityEvent, CommunityEventInput, Rrule } from "../src/lib/xmpp-client";
+import { dateTimeValue, dateValue } from "../src/lib/xmpp-client";
+import type {
+  BrowserXmppClient,
+  CalendarDateValue,
+  CommunityEvent,
+  CommunityEventInput,
+  Rrule,
+} from "../src/lib/xmpp-client";
 
 const COMMUNITY = "community.example.com";
 
@@ -24,9 +31,10 @@ function makeClient(events: CommunityEvent[] = []): MockClient {
         ...(input.description ? { description: input.description } : {}),
         ...(input.location ? { location: input.location } : {}),
         ...(input.organizer ? { organizer: input.organizer } : {}),
-        ...(typeof input.dtstartMs === "number" ? { dtstartMs: input.dtstartMs } : {}),
-        ...(typeof input.dtendMs === "number" ? { dtendMs: input.dtendMs } : {}),
+        ...(input.dtstart ? { dtstart: input.dtstart } : {}),
+        ...(input.dtend ? { dtend: input.dtend } : {}),
         ...(input.rrule ? { rrule: input.rrule } : {}),
+        ...(input.exdates ? { exdates: input.exdates } : {}),
       } satisfies CommunityEvent),
     ),
     updateCommunityEvent: mock((_jid: string, itemId: string, input: CommunityEventInput) =>
@@ -37,9 +45,10 @@ function makeClient(events: CommunityEvent[] = []): MockClient {
         ...(input.description ? { description: input.description } : {}),
         ...(input.location ? { location: input.location } : {}),
         ...(input.organizer ? { organizer: input.organizer } : {}),
-        ...(typeof input.dtstartMs === "number" ? { dtstartMs: input.dtstartMs } : {}),
-        ...(typeof input.dtendMs === "number" ? { dtendMs: input.dtendMs } : {}),
+        ...(input.dtstart ? { dtstart: input.dtstart } : {}),
+        ...(input.dtend ? { dtend: input.dtend } : {}),
         ...(input.rrule ? { rrule: input.rrule } : {}),
+        ...(input.exdates ? { exdates: input.exdates } : {}),
       } satisfies CommunityEvent),
     ),
     retractCommunityEvent: mock(() => Promise.resolve()),
@@ -47,19 +56,30 @@ function makeClient(events: CommunityEvent[] = []): MockClient {
   } as unknown as MockClient;
 }
 
+function ms(value: CalendarDateValue | undefined): number | undefined {
+  return value?.kind === "date-time" ? value.ms : undefined;
+}
+
 describe("useCommunityEvents", () => {
-  test("refresh sorts upcoming events first by DTSTART", async () => {
+  test("refresh sorts ongoing and upcoming events before past events", async () => {
     const now = Date.now();
     const client = makeClient([
-      { id: "soon", uid: "soon", summary: "Soon", dtstartMs: now + 60_000 },
-      { id: "later", uid: "later", summary: "Later", dtstartMs: now + 86_400_000 },
-      { id: "past", uid: "past", summary: "Past", dtstartMs: now - 86_400_000 },
+      {
+        id: "ongoing",
+        uid: "ongoing",
+        summary: "Ongoing",
+        dtstart: dateTimeValue(now - 60_000),
+        dtend: dateTimeValue(now + 60_000),
+      },
+      { id: "soon", uid: "soon", summary: "Soon", dtstart: dateTimeValue(now + 60_000) },
+      { id: "later", uid: "later", summary: "Later", dtstart: dateTimeValue(now + 86_400_000) },
+      { id: "past", uid: "past", summary: "Past", dtstart: dateTimeValue(now - 86_400_000) },
     ]);
     const events = useCommunityEvents(ref<BrowserXmppClient | null>(client), {
       communityJid: ref<string | null>(COMMUNITY),
     });
     await events.refresh();
-    expect(events.events.value.map((e) => e.id)).toEqual(["soon", "later", "past"]);
+    expect(events.events.value.map((e) => e.id)).toEqual(["ongoing", "soon", "later", "past"]);
   });
 
   test("post appends locally and rejects empty summary", async () => {
@@ -83,7 +103,7 @@ describe("useCommunityEvents", () => {
     const rrule: Rrule = { freq: "WEEKLY", byDay: ["FR"], count: 10 };
     const posted = await events.post({
       summary: "Friday Game Night",
-      dtstartMs: Date.parse("2026-06-05T19:00:00Z"),
+      dtstart: dateTimeValue(Date.parse("2026-06-05T19:00:00Z")),
       rrule,
     });
     expect(posted?.rrule).toEqual(rrule);
@@ -92,7 +112,7 @@ describe("useCommunityEvents", () => {
   test("refresh groups sibling RSVP items into the master event", async () => {
     const future = Date.now() + 86_400_000;
     const client = makeClient([
-      { id: "evt-1", uid: "evt-1", summary: "Game Night", dtstartMs: future },
+      { id: "evt-1", uid: "evt-1", summary: "Game Night", dtstart: dateTimeValue(future) },
       {
         id: "evt-1-rsvp-alice",
         uid: "evt-1",
@@ -130,17 +150,17 @@ describe("useCommunityEvents", () => {
         id: "evt-series",
         uid: "evt-series",
         summary: "Friday Game Night",
-        dtstartMs: start,
-        dtendMs: start + 60 * 60 * 1000,
+        dtstart: dateTimeValue(start),
+        dtend: dateTimeValue(start + 60 * 60 * 1000),
         rrule: { freq: "WEEKLY", byDay: [weekday], count: 4 },
-        exdatesMs: [exdate],
+        exdates: [dateTimeValue(exdate)],
       },
       {
         id: "evt-series::override::1",
         uid: "evt-series",
         summary: "Special Round",
-        recurrenceIdMs: recurrenceId,
-        dtstartMs: recurrenceId + 60 * 60 * 1000,
+        recurrenceId: dateTimeValue(recurrenceId),
+        dtstart: dateTimeValue(recurrenceId + 60 * 60 * 1000),
       },
       {
         id: "evt-series-rsvp-alice",
@@ -158,19 +178,19 @@ describe("useCommunityEvents", () => {
     const [series] = events.calendarItems.value;
     expect(series?.master.uid).toBe("evt-series");
     expect(series?.master.attendees?.[0]?.uri).toBe("xmpp:alice@example.com");
-    expect(series?.master.exdatesMs).toEqual([exdate]);
+    expect(series?.master.exdates).toEqual([dateTimeValue(exdate)]);
     expect(series?.overrides.length).toBe(1);
     expect(series?.overrides[0]?.summary).toBe("Special Round");
-    expect(series?.overrides[0]?.recurrenceIdMs).toBe(recurrenceId);
-    const expandedOverride = events.events.value.find((event) => event.recurrenceIdMs === recurrenceId);
-    expect(expandedOverride?.dtstartMs).toBe(recurrenceId + 60 * 60 * 1000);
-    expect(expandedOverride?.dtendMs).toBe(recurrenceId + 2 * 60 * 60 * 1000);
+    expect(ms(series?.overrides[0]?.recurrenceId)).toBe(recurrenceId);
+    const expandedOverride = events.events.value.find((event) => ms(event.recurrenceId) === recurrenceId);
+    expect(ms(expandedOverride?.dtstart)).toBe(recurrenceId + 60 * 60 * 1000);
+    expect(ms(expandedOverride?.dtend)).toBe(recurrenceId + 2 * 60 * 60 * 1000);
   });
 
   test("rsvp publishes via wasm and optimistically folds a self-attendee in", async () => {
     const future = Date.now() + 86_400_000;
     const client = makeClient([
-      { id: "evt-2", uid: "evt-2", summary: "Game Night", dtstartMs: future },
+      { id: "evt-2", uid: "evt-2", summary: "Game Night", dtstart: dateTimeValue(future) },
     ]);
     const events = useCommunityEvents(ref<BrowserXmppClient | null>(client), {
       communityJid: ref<string | null>(COMMUNITY),
@@ -201,7 +221,7 @@ describe("useCommunityEvents", () => {
   test("edit replaces the existing event by id and keeps it sorted", async () => {
     const future = Date.now() + 86_400_000;
     const client = makeClient([
-      { id: "evt-a", uid: "evt-a", summary: "Original", dtstartMs: future },
+      { id: "evt-a", uid: "evt-a", summary: "Original", dtstart: dateTimeValue(future) },
     ]);
     const events = useCommunityEvents(ref<BrowserXmppClient | null>(client), {
       communityJid: ref<string | null>(COMMUNITY),
@@ -209,7 +229,7 @@ describe("useCommunityEvents", () => {
     await events.refresh();
     const updated = await events.edit("evt-a", {
       summary: "Renamed",
-      dtstartMs: future,
+      dtstart: dateTimeValue(future),
     });
     expect(updated?.summary).toBe("Renamed");
     expect(client.updateCommunityEvent).toHaveBeenCalledWith(
@@ -222,7 +242,7 @@ describe("useCommunityEvents", () => {
 
   test("edit rejects empty summary", async () => {
     const client = makeClient([
-      { id: "evt-a", uid: "evt-a", summary: "Original", dtstartMs: Date.now() + 1000 },
+      { id: "evt-a", uid: "evt-a", summary: "Original", dtstart: dateTimeValue(Date.now() + 1000) },
     ]);
     const events = useCommunityEvents(ref<BrowserXmppClient | null>(client), {
       communityJid: ref<string | null>(COMMUNITY),
@@ -235,8 +255,8 @@ describe("useCommunityEvents", () => {
   test("cancel retracts and removes the event optimistically", async () => {
     const future = Date.now() + 86_400_000;
     const client = makeClient([
-      { id: "evt-a", uid: "evt-a", summary: "Going away", dtstartMs: future },
-      { id: "evt-b", uid: "evt-b", summary: "Stays", dtstartMs: future + 1000 },
+      { id: "evt-a", uid: "evt-a", summary: "Going away", dtstart: dateTimeValue(future) },
+      { id: "evt-b", uid: "evt-b", summary: "Stays", dtstart: dateTimeValue(future + 1000) },
     ]);
     const events = useCommunityEvents(ref<BrowserXmppClient | null>(client), {
       communityJid: ref<string | null>(COMMUNITY),
@@ -256,7 +276,7 @@ describe("useCommunityEvents", () => {
         id: "evt-series",
         uid: "evt-series",
         summary: "Friday Game Night",
-        dtstartMs: dtstart,
+        dtstart: dateTimeValue(dtstart),
         rrule: { freq: "WEEKLY", byDay: ["FR"], count: 4 },
       },
     ]);
@@ -264,26 +284,49 @@ describe("useCommunityEvents", () => {
       communityJid: ref<string | null>(COMMUNITY),
     });
     await events.refresh();
-    const ok = await events.cancelInstance("evt-series", skipInstance);
+    const ok = await events.cancelInstance("evt-series", dateTimeValue(skipInstance));
     expect(ok).toBe(true);
     expect(client.updateCommunityEvent).toHaveBeenCalledTimes(1);
     const updateCall = client.updateCommunityEvent.mock.calls[0];
     expect(updateCall?.[0]).toBe(COMMUNITY);
     expect(updateCall?.[1]).toBe("evt-series");
-    expect(updateCall?.[2]?.exdatesMs).toEqual([skipInstance]);
+    expect(updateCall?.[2]?.exdates).toEqual([dateTimeValue(skipInstance)]);
     expect(client.retractCommunityEvent).not.toHaveBeenCalled();
   });
 
-  test("cancelInstance falls back to retract for non-recurring events", async () => {
-    const future = Date.now() + 86_400_000;
+  test("cancelInstance appends DATE EXDATEs for all-day recurring masters", async () => {
     const client = makeClient([
-      { id: "evt-once", uid: "evt-once", summary: "One-off", dtstartMs: future },
+      {
+        id: "evt-all-day",
+        uid: "evt-all-day",
+        summary: "Festival",
+        dtstart: dateValue("2026-06-05"),
+        dtend: dateValue("2026-06-06"),
+        rrule: { freq: "WEEKLY", byDay: ["FR"], count: 4 },
+      },
     ]);
     const events = useCommunityEvents(ref<BrowserXmppClient | null>(client), {
       communityJid: ref<string | null>(COMMUNITY),
     });
     await events.refresh();
-    const ok = await events.cancelInstance("evt-once", future);
+    const ok = await events.cancelInstance("evt-all-day", dateValue("2026-06-12"));
+    expect(ok).toBe(true);
+    const updateCall = client.updateCommunityEvent.mock.calls[0];
+    expect(updateCall?.[2]?.exdates).toEqual([dateValue("2026-06-12")]);
+    expect(updateCall?.[2]?.dtstart).toEqual(dateValue("2026-06-05"));
+    expect(updateCall?.[2]?.dtend).toEqual(dateValue("2026-06-06"));
+  });
+
+  test("cancelInstance falls back to retract for non-recurring events", async () => {
+    const future = Date.now() + 86_400_000;
+    const client = makeClient([
+      { id: "evt-once", uid: "evt-once", summary: "One-off", dtstart: dateTimeValue(future) },
+    ]);
+    const events = useCommunityEvents(ref<BrowserXmppClient | null>(client), {
+      communityJid: ref<string | null>(COMMUNITY),
+    });
+    await events.refresh();
+    const ok = await events.cancelInstance("evt-once", dateTimeValue(future));
     expect(ok).toBe(true);
     expect(client.retractCommunityEvent).toHaveBeenCalledWith(COMMUNITY, "evt-once");
   });
@@ -295,7 +338,7 @@ describe("useCommunityEvents", () => {
         id: "evt-series",
         uid: "evt-series",
         summary: "Friday Game Night",
-        dtstartMs: dtstart,
+        dtstart: dateTimeValue(dtstart),
         rrule: { freq: "WEEKLY", byDay: ["FR"], count: 4 },
       },
     ]);

--- a/chat/tests/event-expansion.test.ts
+++ b/chat/tests/event-expansion.test.ts
@@ -9,7 +9,13 @@ import {
   groupEventsWithOverrides,
   type CalendarMaster,
 } from "../src/lib/xmpp/event-expansion";
-import type { CommunityEvent } from "../src/lib/xmpp/event-types";
+import {
+  dateTimeValue,
+  dateValue,
+  eventOverlapsRange,
+  localDayRange,
+} from "../src/lib/xmpp/event-calendar";
+import type { CalendarDateValue, CommunityEvent } from "../src/lib/xmpp/event-types";
 
 const NOW = Date.parse("2026-06-01T00:00:00Z");
 // 365 days from NOW — covers all the synthetic test events without
@@ -21,10 +27,18 @@ function master(overrides: Partial<CommunityEvent> = {}): CommunityEvent {
     id: "evt-1",
     uid: "evt-1",
     summary: "Game Night",
-    dtstartMs: Date.parse("2026-06-05T19:00:00Z"),
-    dtendMs: Date.parse("2026-06-05T22:00:00Z"),
+    dtstart: dateTimeValue(Date.parse("2026-06-05T19:00:00Z")),
+    dtend: dateTimeValue(Date.parse("2026-06-05T22:00:00Z")),
     ...overrides,
   };
+}
+
+function ms(value: CalendarDateValue | undefined): number | undefined {
+  return value?.kind === "date-time" ? value.ms : undefined;
+}
+
+function date(value: CalendarDateValue | undefined): string | undefined {
+  return value?.kind === "date" ? value.date : undefined;
 }
 
 describe("expandInstances", () => {
@@ -36,9 +50,22 @@ describe("expandInstances", () => {
   });
 
   test("non-recurring event in the past is dropped", () => {
-    const event = master({ dtstartMs: NOW - 86_400_000 });
+    const event = master({
+      dtstart: dateTimeValue(NOW - 86_400_000),
+      dtend: dateTimeValue(NOW - 86_400_000 + 60_000),
+    });
     const instances = expandInstances({ master: event, overrides: [] }, { nowMs: NOW, horizonMs: HORIZON });
     expect(instances.length).toBe(0);
+  });
+
+  test("non-recurring event that started earlier but is ongoing is kept", () => {
+    const event = master({
+      dtstart: dateTimeValue(NOW - 60 * 60 * 1000),
+      dtend: dateTimeValue(NOW + 60 * 60 * 1000),
+    });
+    const instances = expandInstances({ master: event, overrides: [] }, { nowMs: NOW, horizonMs: HORIZON });
+    expect(instances.length).toBe(1);
+    expect(instances[0]?.id).toBe(event.id);
   });
 
   test("weekly + BYDAY emits the right occurrences within COUNT", () => {
@@ -47,11 +74,11 @@ describe("expandInstances", () => {
     });
     const instances = expandInstances({ master: event, overrides: [] }, { nowMs: NOW, horizonMs: HORIZON });
     expect(instances.length).toBe(4);
-    expect(instances[0]?.dtstartMs).toBe(Date.parse("2026-06-05T19:00:00Z"));
-    expect(instances[3]?.dtstartMs).toBe(Date.parse("2026-06-26T19:00:00Z"));
+    expect(ms(instances[0]?.dtstart)).toBe(Date.parse("2026-06-05T19:00:00Z"));
+    expect(ms(instances[3]?.dtstart)).toBe(Date.parse("2026-06-26T19:00:00Z"));
     // Per-occurrence emission carries DTEND adjusted by the master's duration.
-    expect(instances[0]?.dtendMs).toBe(Date.parse("2026-06-05T22:00:00Z"));
-    expect(instances[3]?.dtendMs).toBe(Date.parse("2026-06-26T22:00:00Z"));
+    expect(ms(instances[0]?.dtend)).toBe(Date.parse("2026-06-05T22:00:00Z"));
+    expect(ms(instances[3]?.dtend)).toBe(Date.parse("2026-06-26T22:00:00Z"));
   });
 
   test("UNTIL terminates the series even without COUNT", () => {
@@ -69,10 +96,10 @@ describe("expandInstances", () => {
   test("EXDATE skips the matching occurrence", () => {
     const event = master({
       rrule: { freq: "WEEKLY", byDay: ["FR"], count: 4 },
-      exdatesMs: [Date.parse("2026-06-19T19:00:00Z")],
+      exdates: [dateTimeValue(Date.parse("2026-06-19T19:00:00Z"))],
     });
     const instances = expandInstances({ master: event, overrides: [] }, { nowMs: NOW, horizonMs: HORIZON });
-    const starts = instances.map((i) => i.dtstartMs);
+    const starts = instances.map((i) => ms(i.dtstart));
     expect(starts).not.toContain(Date.parse("2026-06-19T19:00:00Z"));
     expect(starts).toContain(Date.parse("2026-06-26T19:00:00Z"));
     // 4 in count - 1 EXDATE = 3 emitted
@@ -82,7 +109,7 @@ describe("expandInstances", () => {
   test("EXDATE that doesn't match any occurrence is a no-op", () => {
     const event = master({
       rrule: { freq: "WEEKLY", byDay: ["FR"], count: 3 },
-      exdatesMs: [Date.parse("2030-12-25T12:00:00Z")],
+      exdates: [dateTimeValue(Date.parse("2030-12-25T12:00:00Z"))],
     });
     const instances = expandInstances({ master: event, overrides: [] }, { nowMs: NOW, horizonMs: HORIZON });
     expect(instances.length).toBe(3);
@@ -97,29 +124,74 @@ describe("expandInstances", () => {
       id: "evt-1::override::1",
       uid: "evt-1",
       summary: "Special: Halo",
-      recurrenceIdMs: overrideRecurrence,
-      dtstartMs: Date.parse("2026-06-12T20:00:00Z"),
+      recurrenceId: dateTimeValue(overrideRecurrence),
+      dtstart: dateTimeValue(Date.parse("2026-06-12T20:00:00Z")),
     };
     const instances = expandInstances(
       { master: event, overrides: [override] },
       { nowMs: NOW, horizonMs: HORIZON },
     );
-    const replaced = instances.find((i) => i.recurrenceIdMs === overrideRecurrence);
+    const replaced = instances.find((i) => ms(i.recurrenceId) === overrideRecurrence);
     expect(replaced).toBeDefined();
     expect(replaced?.summary).toBe("Special: Halo");
-    expect(replaced?.dtstartMs).toBe(Date.parse("2026-06-12T20:00:00Z"));
+    expect(ms(replaced?.dtstart)).toBe(Date.parse("2026-06-12T20:00:00Z"));
     // Other 3 occurrences still come from the master.
     expect(instances.filter((i) => i.summary === "Game Night").length).toBe(3);
   });
 
+  test("RECURRENCE-ID override moved into the future is filtered by effective bounds", () => {
+    const event = master({
+      dtstart: dateTimeValue(Date.parse("2026-05-01T19:00:00Z")),
+      dtend: dateTimeValue(Date.parse("2026-05-01T20:00:00Z")),
+      rrule: { freq: "WEEKLY", byDay: ["FR"], count: 2 },
+    });
+    const override: CommunityEvent = {
+      id: "evt-1::override::future",
+      uid: "evt-1",
+      summary: "Moved forward",
+      recurrenceId: dateTimeValue(Date.parse("2026-05-08T19:00:00Z")),
+      dtstart: dateTimeValue(Date.parse("2026-06-12T20:00:00Z")),
+      dtend: dateTimeValue(Date.parse("2026-06-12T21:00:00Z")),
+    };
+
+    const instances = expandInstances(
+      { master: event, overrides: [override] },
+      { nowMs: NOW, horizonMs: HORIZON },
+    );
+
+    expect(instances.map((instance) => instance.summary)).toEqual(["Moved forward"]);
+  });
+
+  test("RECURRENCE-ID override moved into the past is dropped by effective bounds", () => {
+    const event = master({
+      rrule: { freq: "WEEKLY", byDay: ["FR"], count: 2 },
+    });
+    const override: CommunityEvent = {
+      id: "evt-1::override::past",
+      uid: "evt-1",
+      summary: "Moved backward",
+      recurrenceId: dateTimeValue(Date.parse("2026-06-05T19:00:00Z")),
+      dtstart: dateTimeValue(Date.parse("2026-05-01T20:00:00Z")),
+      dtend: dateTimeValue(Date.parse("2026-05-01T21:00:00Z")),
+    };
+
+    const instances = expandInstances(
+      { master: event, overrides: [override] },
+      { nowMs: NOW, horizonMs: HORIZON },
+    );
+
+    expect(instances.map((instance) => instance.summary)).toEqual(["Game Night"]);
+    expect(ms(instances[0]?.dtstart)).toBe(Date.parse("2026-06-12T19:00:00Z"));
+  });
+
   test("monthly + BYMONTHDAY emits day-of-month matches", () => {
     const event = master({
-      dtstartMs: Date.parse("2026-06-01T18:00:00Z"),
-      dtendMs: Date.parse("2026-06-01T20:00:00Z"),
+      dtstart: dateTimeValue(Date.parse("2026-06-01T18:00:00Z")),
+      dtend: dateTimeValue(Date.parse("2026-06-01T20:00:00Z")),
       rrule: { freq: "MONTHLY", byMonthDay: [1, 15], count: 6 },
     });
     const instances = expandInstances({ master: event, overrides: [] }, { nowMs: NOW, horizonMs: HORIZON });
-    const days = instances.map((i) => new Date(i.dtstartMs ?? 0).getUTCDate());
+    const days = instances.map((i) => new Date(ms(i.dtstart) ?? 0).getUTCDate());
     expect(days.every((d) => d === 1 || d === 15)).toBe(true);
     expect(instances.length).toBe(6);
   });
@@ -134,19 +206,63 @@ describe("expandInstances", () => {
     );
     expect(instances.length).toBe(7);
   });
+
+  test("all-day recurrence uses typed DATE DTSTART and DATE EXDATE", () => {
+    const event = master({
+      dtstart: dateValue("2026-06-05"),
+      dtend: dateValue("2026-06-06"),
+      rrule: { freq: "WEEKLY", byDay: ["FR"], count: 4 },
+      exdates: [dateValue("2026-06-19")],
+    });
+    const instances = expandInstances({ master: event, overrides: [] }, { nowMs: NOW, horizonMs: HORIZON });
+    expect(instances.map((instance) => date(instance.dtstart))).toEqual([
+      "2026-06-05",
+      "2026-06-12",
+      "2026-06-26",
+    ]);
+    expect(instances.every((instance) => instance.dtstart?.kind === "date")).toBe(true);
+  });
+
+  test("all-day multi-day duration is inherited by recurring instances", () => {
+    const event = master({
+      dtstart: dateValue("2026-06-05"),
+      dtend: dateValue("2026-06-08"),
+      rrule: { freq: "WEEKLY", byDay: ["FR"], count: 2 },
+    });
+    const instances = expandInstances({ master: event, overrides: [] }, { nowMs: NOW, horizonMs: HORIZON });
+    expect(date(instances[0]?.dtstart)).toBe("2026-06-05");
+    expect(date(instances[0]?.dtend)).toBe("2026-06-08");
+    expect(date(instances[1]?.dtstart)).toBe("2026-06-12");
+    expect(date(instances[1]?.dtend)).toBe("2026-06-15");
+  });
+
+  test("day overlap helper includes every day touched by a multi-day event", () => {
+    const event = master({
+      dtstart: dateValue("2026-06-05"),
+      dtend: dateValue("2026-06-08"),
+    });
+    const june5 = localDayRange(2026, 5, 5);
+    const june6 = localDayRange(2026, 5, 6);
+    const june7 = localDayRange(2026, 5, 7);
+    const june8 = localDayRange(2026, 5, 8);
+    expect(eventOverlapsRange(event, june5.startMs, june5.endMs)).toBe(true);
+    expect(eventOverlapsRange(event, june6.startMs, june6.endMs)).toBe(true);
+    expect(eventOverlapsRange(event, june7.startMs, june7.endMs)).toBe(true);
+    expect(eventOverlapsRange(event, june8.startMs, june8.endMs)).toBe(false);
+  });
 });
 
 describe("groupEventsWithOverrides", () => {
   test("buckets overrides by UID and surfaces masters as CalendarMaster", () => {
     const items: CommunityEvent[] = [
-      { id: "evt-a", uid: "evt-a", summary: "A", dtstartMs: NOW + 1000 },
+      { id: "evt-a", uid: "evt-a", summary: "A", dtstart: dateTimeValue(NOW + 1000) },
       {
         id: "evt-a::override::1",
         uid: "evt-a",
         summary: "A-override",
-        recurrenceIdMs: NOW + 2000,
+        recurrenceId: dateTimeValue(NOW + 2000),
       },
-      { id: "evt-b", uid: "evt-b", summary: "B", dtstartMs: NOW + 3000 },
+      { id: "evt-b", uid: "evt-b", summary: "B", dtstart: dateTimeValue(NOW + 3000) },
     ];
     const groups = groupEventsWithOverrides(items);
     expect(groups.length).toBe(2);

--- a/chat/tests/events-pane-calendar-feed.test.ts
+++ b/chat/tests/events-pane-calendar-feed.test.ts
@@ -5,9 +5,18 @@ import {
   calendarFeedCopyControllerKey,
   type CalendarFeedCopyController,
 } from "../src/lib/use-calendar-feed-copy";
+import {
+  dateTimeValue,
+  dateValue,
+  localDateString,
+} from "../src/lib/xmpp-client";
 
 const chatReadyShellSource = await Bun.file(
   new URL("../src/components/chat/ChatReadyShell.vue", import.meta.url),
+).text();
+
+const eventsPaneSource = await Bun.file(
+  new URL("../src/components/community/EventsPane.vue", import.meta.url),
 ).text();
 
 const computedCommunityJidBridge = `
@@ -180,5 +189,73 @@ describe("EventsPane calendar feed control", () => {
 
     expect(openLink).toContain(`href="${subscriptionHref}"`);
     expect(urlInput).toContain(`value="${feedUrl}"`);
+  });
+
+  test("composer source keeps 30-minute duration default, all-day controls, and validation copy", () => {
+    expect(eventsPaneSource).toContain('const durationChoice = ref("30")');
+    expect(eventsPaneSource).toContain('{ value: "30", label: "30 minutes" }');
+    expect(eventsPaneSource).toContain('{ value: "60", label: "1 hour" }');
+    expect(eventsPaneSource).toContain('{ value: "custom", label: "Custom" }');
+    expect(eventsPaneSource).toContain("All day");
+    expect(eventsPaneSource).toContain('v-model="allDayStart"');
+    expect(eventsPaneSource).toContain('v-model="allDayEnd"');
+    expect(eventsPaneSource).toContain("setDefaultAllDayDates()");
+    expect(eventsPaneSource).toContain("visibleComposerError");
+    expect(eventsPaneSource).toContain('return "End date must be after the start date."');
+    expect(eventsPaneSource).toContain('return "End time must be after the start time."');
+    expect(eventsPaneSource).toContain('return "All-day repeats need a count instead of an until date."');
+  });
+
+  test("renders multi-day all-day events in every covered month cell and selected day list", async () => {
+    const now = new Date();
+    const start = localDateString(now.getFullYear(), now.getMonth(), 1);
+    const nextMonth = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+    const endExclusive = localDateString(
+      nextMonth.getFullYear(),
+      nextMonth.getMonth(),
+      nextMonth.getDate(),
+    );
+    const html = await renderVueComponent(
+      "../src/components/community/EventsPane.vue",
+      props({
+        events: [{
+          id: "expo",
+          uid: "expo",
+          summary: "Three Day Expo",
+          organizer: "xmpp:alice@example.com",
+          dtstart: dateValue(start),
+          dtend: dateValue(endExclusive),
+        }],
+        selfJid: "alice@example.com",
+      }),
+      import.meta.url,
+    );
+
+    expect(html.match(/Three Day Expo/g)?.length ?? 0).toBeGreaterThanOrEqual(3);
+    expect(html).toContain("All day");
+  });
+
+  test("renders ongoing timed spans on a later visible day", async () => {
+    const now = new Date();
+    const startMs = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1, 23, 0).getTime();
+    const endMs = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, 1, 0).getTime();
+    const html = await renderVueComponent(
+      "../src/components/community/EventsPane.vue",
+      props({
+        events: [{
+          id: "overnight",
+          uid: "overnight",
+          summary: "Overnight Window",
+          organizer: "xmpp:alice@example.com",
+          dtstart: dateTimeValue(startMs),
+          dtend: dateTimeValue(endMs),
+        }],
+        selfJid: "alice@example.com",
+      }),
+      import.meta.url,
+    );
+
+    expect(html).toContain("continues Overnight Window");
+    expect(html).toContain("Overnight Window");
   });
 });

--- a/server/crates/waddle-server/src/server/routes/calendar_feed.rs
+++ b/server/crates/waddle-server/src/server/routes/calendar_feed.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use tracing::{debug, warn};
 use waddle_xmpp::pubsub::{AccessModel, PubSubStorage, StoredItem};
-use waddle_xmpp_core::xcal::{CalendarItem, Rrule, RruleEnd, VEvent};
+use waddle_xmpp_core::xcal::{CalendarDateValue, CalendarItem, Rrule, RruleEnd, VEvent};
 
 use super::auth::AuthState;
 
@@ -360,14 +360,14 @@ fn event_lines(
     let mut lines = vec![
         "BEGIN:VEVENT".to_string(),
         property("UID", &event.uid),
-        date_property("DTSTAMP", dtstamp),
-        date_property("DTSTART", dtstart),
+        date_time_property("DTSTAMP", dtstamp),
+        calendar_date_property("DTSTART", dtstart),
     ];
     if let Some(dtend) = dtend {
-        lines.push(date_property("DTEND", dtend));
+        lines.push(calendar_date_property("DTEND", dtend));
     }
     if let Some(recurrence_id) = event.recurrence_id {
-        lines.push(date_property("RECURRENCE-ID", recurrence_id));
+        lines.push(calendar_date_property("RECURRENCE-ID", recurrence_id));
     }
     lines.push(property("SUMMARY", summary));
     if let Some(description) = description {
@@ -385,27 +385,44 @@ fn event_lines(
     if !event.exdates.is_empty() {
         let mut exdates = event.exdates.clone();
         exdates.sort();
-        lines.push(format!(
-            "EXDATE:{}",
-            exdates
-                .into_iter()
-                .map(format_utc_date)
-                .collect::<Vec<_>>()
-                .join(",")
-        ));
+        lines.push(exdate_property(exdates));
     }
     lines.push("END:VEVENT".to_string());
     lines
 }
 
-fn inherited_end(master: &VEvent, dtstart: DateTime<Utc>) -> Option<DateTime<Utc>> {
+fn inherited_end(master: &VEvent, dtstart: CalendarDateValue) -> Option<CalendarDateValue> {
     let master_start = master.dtstart?;
     let master_end = master.dtend?;
-    let duration = master_end.signed_duration_since(master_start);
-    if duration.num_milliseconds() < 0 {
-        return None;
+    match (master_start, master_end, dtstart) {
+        (
+            CalendarDateValue::DateTime(master_start),
+            CalendarDateValue::DateTime(master_end),
+            CalendarDateValue::DateTime(dtstart),
+        ) => {
+            let duration = master_end.signed_duration_since(master_start);
+            if duration.num_milliseconds() < 0 {
+                return None;
+            }
+            dtstart
+                .checked_add_signed(duration)
+                .map(CalendarDateValue::DateTime)
+        }
+        (
+            CalendarDateValue::Date(master_start),
+            CalendarDateValue::Date(master_end),
+            CalendarDateValue::Date(dtstart),
+        ) => {
+            let duration = master_end.signed_duration_since(master_start);
+            if duration.num_days() < 0 {
+                return None;
+            }
+            dtstart
+                .checked_add_signed(duration)
+                .map(CalendarDateValue::Date)
+        }
+        _ => None,
     }
-    dtstart.checked_add_signed(duration)
 }
 
 fn property(name: &str, value: &str) -> String {
@@ -424,8 +441,38 @@ fn cal_address_property(name: &str, value: &str) -> String {
     line
 }
 
-fn date_property(name: &str, value: DateTime<Utc>) -> String {
-    format!("{name}:{}", format_utc_date(value))
+fn date_time_property(name: &str, value: DateTime<Utc>) -> String {
+    format!("{name}:{}", format_utc_date_time(value))
+}
+
+fn calendar_date_property(name: &str, value: CalendarDateValue) -> String {
+    match value {
+        CalendarDateValue::Date(date) => {
+            format!("{name};VALUE=DATE:{}", date.format("%Y%m%d"))
+        }
+        CalendarDateValue::DateTime(date_time) => {
+            format!("{name}:{}", format_utc_date_time(date_time))
+        }
+    }
+}
+
+fn exdate_property(values: Vec<CalendarDateValue>) -> String {
+    let all_day = values
+        .first()
+        .is_some_and(|value| matches!(value, CalendarDateValue::Date(_)));
+    let encoded = values
+        .into_iter()
+        .map(|value| match value {
+            CalendarDateValue::Date(date) => date.format("%Y%m%d").to_string(),
+            CalendarDateValue::DateTime(date_time) => format_utc_date_time(date_time),
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    if all_day {
+        format!("EXDATE;VALUE=DATE:{encoded}")
+    } else {
+        format!("EXDATE:{encoded}")
+    }
 }
 
 fn rrule_property(rrule: &Rrule) -> String {
@@ -457,7 +504,9 @@ fn rrule_property(rrule: &Rrule) -> String {
     }
     match rrule.end {
         Some(RruleEnd::Count(count)) => parts.push(format!("COUNT={count}")),
-        Some(RruleEnd::Until(until)) => parts.push(format!("UNTIL={}", format_utc_date(until))),
+        Some(RruleEnd::Until(until)) => {
+            parts.push(format!("UNTIL={}", format_utc_date_time(until)))
+        }
         None => {}
     }
     format!("RRULE:{}", parts.join(";"))
@@ -484,7 +533,7 @@ fn escape_text(value: &str) -> String {
     out
 }
 
-fn format_utc_date(value: DateTime<Utc>) -> String {
+fn format_utc_date_time(value: DateTime<Utc>) -> String {
     value.format("%Y%m%dT%H%M%SZ").to_string()
 }
 
@@ -631,6 +680,10 @@ mod tests {
             .expect("valid timestamp")
     }
 
+    fn day(y: i32, mo: u32, d: u32) -> chrono::NaiveDate {
+        chrono::NaiveDate::from_ymd_opt(y, mo, d).expect("valid date")
+    }
+
     async fn test_auth_state() -> Arc<AuthState> {
         let config = DatabaseConfig::default();
         let pool_config = PoolConfig;
@@ -709,6 +762,28 @@ mod tests {
         for line in ics.trim_end().split("\r\n") {
             assert!(line.len() <= MAX_CONTENT_LINE_BYTES);
         }
+    }
+
+    #[test]
+    fn icalendar_projection_exports_all_day_dates() {
+        let item = CalendarItem::new(
+            VEvent::new("evt-retreat", "Retreat")
+                .with_dtstamp(ts(2026, 6, 1, 12, 0))
+                .with_dtstart_date(day(2026, 6, 15))
+                .with_dtend_date(day(2026, 6, 18))
+                .with_exdate_dates([day(2026, 6, 22)]),
+        );
+
+        let ics = build_icalendar(&[StoredCalendarItem {
+            item,
+            published_at: ts(2026, 6, 1, 13, 0),
+        }]);
+
+        assert!(ics.contains("DTSTAMP:20260601T120000Z\r\n"));
+        assert!(ics.contains("DTSTART;VALUE=DATE:20260615\r\n"));
+        assert!(ics.contains("DTEND;VALUE=DATE:20260618\r\n"));
+        assert!(ics.contains("EXDATE;VALUE=DATE:20260622\r\n"));
+        assert!(!ics.contains("DTSTART:20260615T000000Z\r\n"));
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/tests/proto_calendar_overrides_ws.rs
+++ b/server/crates/waddle-server/tests/proto_calendar_overrides_ws.rs
@@ -47,21 +47,21 @@ async fn vcalendar_item_with_master_overrides_and_exdate_round_trips() {
                       <vevent>
                         <uid>{event_id}</uid>
                         <dtstamp>2026-06-01T12:00:00Z</dtstamp>
-                        <dtstart>2026-06-05T19:00:00Z</dtstart>
-                        <dtend>2026-06-05T22:00:00Z</dtend>
+                        <dtstart><date-time>2026-06-05T19:00:00Z</date-time></dtstart>
+                        <dtend><date-time>2026-06-05T22:00:00Z</date-time></dtend>
                         <summary>Friday Game Night</summary>
                         <rrule>
                           <freq>WEEKLY</freq>
                           <byday><weekday>FR</weekday></byday>
                           <count>8</count>
                         </rrule>
-                        <exdate>2026-06-19T19:00:00Z</exdate>
+                        <exdate><date-time>2026-06-19T19:00:00Z</date-time></exdate>
                       </vevent>
                       <vevent>
                         <uid>{event_id}</uid>
-                        <recurrence-id>2026-06-12T19:00:00Z</recurrence-id>
+                        <recurrence-id><date-time>2026-06-12T19:00:00Z</date-time></recurrence-id>
                         <summary>Special: Halo Tournament</summary>
-                        <dtstart>2026-06-12T20:00:00Z</dtstart>
+                        <dtstart><date-time>2026-06-12T20:00:00Z</date-time></dtstart>
                       </vevent>
                     </vcalendar>
                   </item>

--- a/server/crates/waddle-server/tests/proto_calendar_rsvp_ws.rs
+++ b/server/crates/waddle-server/tests/proto_calendar_rsvp_ws.rs
@@ -66,7 +66,7 @@ async fn non_owner_can_publish_rsvp_for_master_event() {
                       <vevent>
                         <uid>{event_id}</uid>
                         <dtstamp>2026-06-01T12:00:00Z</dtstamp>
-                        <dtstart>2026-06-05T19:00:00Z</dtstart>
+                        <dtstart><date-time>2026-06-05T19:00:00Z</date-time></dtstart>
                         <summary>Friday Game Night</summary>
                         <organizer>xmpp:admin@localhost</organizer>
                       </vevent>
@@ -171,7 +171,7 @@ async fn malformed_rsvp_for_other_user_is_rejected() {
                     <vcalendar xmlns="{NS_XCAL}">
                       <vevent>
                         <uid>{event_id}</uid>
-                        <dtstart>2026-06-05T19:00:00Z</dtstart>
+                        <dtstart><date-time>2026-06-05T19:00:00Z</date-time></dtstart>
                         <summary>Game Night</summary>
                       </vevent>
                     </vcalendar>
@@ -272,7 +272,7 @@ async fn rsvp_publish_bridges_to_social_feed() {
                       <version>2.0</version>
                       <vevent>
                         <uid>{event_id}</uid>
-                        <dtstart>2026-06-05T19:00:00Z</dtstart>
+                        <dtstart><date-time>2026-06-05T19:00:00Z</date-time></dtstart>
                         <summary>Friday Game Night</summary>
                       </vevent>
                     </vcalendar>

--- a/server/crates/waddle-server/tests/proto_calendar_xcal_ws.rs
+++ b/server/crates/waddle-server/tests/proto_calendar_xcal_ws.rs
@@ -68,8 +68,8 @@ async fn xcal_recurring_event_publish_and_items_round_trip() {
                       <vevent>
                         <uid>{event_id}</uid>
                         <dtstamp>2026-06-01T12:00:00Z</dtstamp>
-                        <dtstart>2026-06-05T19:00:00Z</dtstart>
-                        <dtend>2026-06-05T22:00:00Z</dtend>
+                        <dtstart><date-time>2026-06-05T19:00:00Z</date-time></dtstart>
+                        <dtend><date-time>2026-06-05T22:00:00Z</date-time></dtend>
                         <summary>Friday Game Night</summary>
                         <description>Weekly gaming</description>
                         <location>Voice #gaming</location>

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/proto_calendar_xcal.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/proto_calendar_xcal.cue
@@ -84,12 +84,24 @@ scenario: #Scenario & {
 													#XmlElement & {
 														name: "dtstart"
 														ns:   "urn:ietf:params:xml:ns:xcal"
-														text: "2026-06-05T19:00:00Z"
+														children: [
+															#XmlElement & {
+																name: "date-time"
+																ns:   "urn:ietf:params:xml:ns:xcal"
+																text: "2026-06-05T19:00:00Z"
+															},
+														]
 													},
 													#XmlElement & {
 														name: "dtend"
 														ns:   "urn:ietf:params:xml:ns:xcal"
-														text: "2026-06-05T22:00:00Z"
+														children: [
+															#XmlElement & {
+																name: "date-time"
+																ns:   "urn:ietf:params:xml:ns:xcal"
+																text: "2026-06-05T22:00:00Z"
+															},
+														]
 													},
 													#XmlElement & {
 														name: "summary"

--- a/server/crates/waddle-xmpp-client-wasm/src/client_xcal.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_xcal.rs
@@ -6,13 +6,14 @@
 //! recurrence flows through an `<rrule>` element with FREQ/INTERVAL/
 //! BYDAY/BYMONTHDAY/COUNT|UNTIL.
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, NaiveDate, Utc};
 use minidom::Element;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use waddle_xmpp_core::xcal::{
     build_vcalendar_with_event, build_vcalendar_with_item, parse_vcalendar_item, Attendee,
-    CalendarItem, Freq, PartStat, Rrule, RruleEnd, VEvent, Weekday, NS_XCAL, PUBSUB_NODE_EVENTS,
+    CalendarDateValue, CalendarItem, Freq, PartStat, Rrule, RruleEnd, VEvent, Weekday, NS_XCAL,
+    PUBSUB_NODE_EVENTS,
 };
 use wasm_bindgen::prelude::*;
 
@@ -48,19 +49,20 @@ pub(crate) struct JsVEvent {
     pub location: Option<String>,
     pub organizer: Option<String>,
     pub dtstamp: Option<String>,
-    pub dtstart: Option<String>,
-    pub dtend: Option<String>,
+    pub dtstart: Option<JsCalendarDateValue>,
+    pub dtend: Option<JsCalendarDateValue>,
     pub rrule: Option<JsRrule>,
     /// ATTENDEE list — empty for events with no RSVPs yet. The chat
     /// folds sibling `-rsvp-*` items into this list before render.
     #[serde(default)]
     pub attendees: Vec<JsAttendee>,
-    /// RFC3339 — set on override VEVENTs (one occurrence of a
-    /// recurring master). `None` on the master event itself.
-    pub recurrence_id: Option<String>,
-    /// RFC3339[] — per-instance cancellations on the master event.
+    /// Typed RECURRENCE-ID — set on override VEVENTs (one occurrence
+    /// of a recurring master). `None` on the master event itself.
+    pub recurrence_id: Option<JsCalendarDateValue>,
+    /// Typed EXDATE values — per-instance cancellations on the
+    /// master event.
     #[serde(default)]
-    pub exdates: Vec<String>,
+    pub exdates: Vec<JsCalendarDateValue>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -83,16 +85,129 @@ impl From<&Attendee> for JsAttendee {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn day(year: i32, month: u32, day: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(year, month, day).expect("valid test date")
+    }
+
+    #[test]
+    fn client_xcal_js_calendar_date_round_trips_date_and_date_time() {
+        let date = CalendarDateValue::try_from(JsCalendarDateValue::Date {
+            date: "2026-06-05".to_string(),
+        })
+        .expect("date converts");
+        assert_eq!(date, CalendarDateValue::Date(day(2026, 6, 5)));
+
+        let date_time = CalendarDateValue::try_from(JsCalendarDateValue::DateTime {
+            ms: 1_781_030_400_000.0,
+        })
+        .expect("date-time converts");
+        assert_eq!(
+            JsCalendarDateValue::from(&date_time),
+            JsCalendarDateValue::DateTime {
+                ms: 1_781_030_400_000.0
+            }
+        );
+    }
+
+    #[test]
+    fn client_xcal_vevent_from_vevent_emits_typed_all_day_shapes() {
+        let event = VEvent::new("evt-all-day", "Festival")
+            .with_dtstart_date(day(2026, 6, 5))
+            .with_dtend_date(day(2026, 6, 8))
+            .with_exdate_dates([day(2026, 6, 6)]);
+
+        let js = JsVEvent::from_vevent("item-1", event);
+
+        assert_eq!(
+            js.dtstart,
+            Some(JsCalendarDateValue::Date {
+                date: "2026-06-05".to_string()
+            })
+        );
+        assert_eq!(
+            js.dtend,
+            Some(JsCalendarDateValue::Date {
+                date: "2026-06-08".to_string()
+            })
+        );
+        assert_eq!(
+            js.exdates,
+            vec![JsCalendarDateValue::Date {
+                date: "2026-06-06".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn client_xcal_rejects_mixed_date_and_date_time_values() {
+        let event = VEvent::new("evt-mixed", "Mixed")
+            .with_dtstart_date(day(2026, 6, 5))
+            .with_dtend(DateTime::<Utc>::from_timestamp_millis(1_781_030_400_000).unwrap());
+
+        assert!(calendar_date_type_mismatch(&event));
+    }
+
+    #[test]
+    fn client_xcal_rejects_mixed_master_exdate_values() {
+        let master = VEvent::new("evt-mixed-exdate", "Mixed EXDATE")
+            .with_dtstart(DateTime::<Utc>::from_timestamp_millis(1_781_030_400_000).unwrap())
+            .add_exdate_date(day(2026, 6, 12));
+        let item = CalendarItem::new(master);
+
+        assert!(validate_calendar_item_data(&item).is_err());
+    }
+
+    #[test]
+    fn client_xcal_rejects_override_recurrence_id_type_mismatch() {
+        let master = VEvent::new("evt-override", "Override")
+            .with_dtstart(DateTime::<Utc>::from_timestamp_millis(1_781_030_400_000).unwrap());
+        let override_event = VEvent::new("evt-override", "All-day override")
+            .with_recurrence_id_date(day(2026, 6, 5));
+        let item = CalendarItem::new(master).add_override(override_event);
+
+        assert!(validate_calendar_item_data(&item).is_err());
+    }
+
+    #[test]
+    fn client_xcal_rejects_non_positive_dtend_duration() {
+        let event = VEvent::new("evt-order", "Order")
+            .with_dtstart_date(day(2026, 6, 5))
+            .with_dtend_date(day(2026, 6, 5));
+
+        assert!(validate_calendar_event(&event).is_err());
+    }
+
+    #[test]
+    fn client_xcal_rejects_all_day_rrule_until_date_time() {
+        let until = DateTime::<Utc>::from_timestamp_millis(1_781_030_400_000).unwrap();
+        let event = VEvent::new("evt-until", "Until")
+            .with_dtstart_date(day(2026, 6, 5))
+            .with_rrule(Rrule::new(Freq::Daily).with_until(until));
+
+        assert!(validate_calendar_event(&event).is_err());
+    }
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct JsVEventInput {
     pub summary: String,
     pub description: Option<String>,
     pub location: Option<String>,
     pub organizer: Option<String>,
-    /// RFC3339 strings.
-    pub dtstart: Option<String>,
-    pub dtend: Option<String>,
+    pub dtstart: Option<JsCalendarDateValue>,
+    pub dtend: Option<JsCalendarDateValue>,
     pub rrule: Option<JsRrule>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub(crate) enum JsCalendarDateValue {
+    Date { date: String },
+    DateTime { ms: f64 },
 }
 
 /// Full CalendarItem write input — master VEVENT plus optional
@@ -105,21 +220,60 @@ pub(crate) struct JsCalendarItemInput {
     pub master: JsVEventInput,
     #[serde(default)]
     pub overrides: Vec<JsOverrideInput>,
-    /// RFC3339[] — occurrence DTSTART values to skip on the master.
+    /// Occurrence DTSTART values to skip on the master.
     #[serde(default)]
-    pub exdates: Vec<String>,
+    pub exdates: Vec<JsCalendarDateValue>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct JsOverrideInput {
-    /// RFC3339. The occurrence this override replaces.
-    pub recurrence_id: String,
+    /// The occurrence this override replaces.
+    pub recurrence_id: JsCalendarDateValue,
     /// All fields optional — overrides patch a subset of the master.
     pub summary: Option<String>,
     pub description: Option<String>,
     pub location: Option<String>,
-    pub dtstart: Option<String>,
-    pub dtend: Option<String>,
+    pub dtstart: Option<JsCalendarDateValue>,
+    pub dtend: Option<JsCalendarDateValue>,
+}
+
+impl TryFrom<JsCalendarDateValue> for CalendarDateValue {
+    type Error = JsValue;
+
+    fn try_from(value: JsCalendarDateValue) -> Result<Self, Self::Error> {
+        match value {
+            JsCalendarDateValue::Date { date } => NaiveDate::parse_from_str(&date, "%Y-%m-%d")
+                .map(CalendarDateValue::Date)
+                .map_err(|err| js_error(format!("invalid date: {err}"))),
+            JsCalendarDateValue::DateTime { ms } => {
+                if !ms.is_finite() {
+                    return Err(js_error("invalid date-time: non-finite timestamp"));
+                }
+                let millis = ms.round();
+                if (millis - ms).abs() > f64::EPSILON {
+                    return Err(js_error(
+                        "invalid date-time: timestamp must be milliseconds",
+                    ));
+                }
+                DateTime::<Utc>::from_timestamp_millis(millis as i64)
+                    .map(CalendarDateValue::DateTime)
+                    .ok_or_else(|| js_error("invalid date-time: timestamp out of range"))
+            }
+        }
+    }
+}
+
+impl From<&CalendarDateValue> for JsCalendarDateValue {
+    fn from(value: &CalendarDateValue) -> Self {
+        match value {
+            CalendarDateValue::Date(date) => Self::Date {
+                date: date.format("%Y-%m-%d").to_string(),
+            },
+            CalendarDateValue::DateTime(date_time) => Self::DateTime {
+                ms: date_time.timestamp_millis() as f64,
+            },
+        }
+    }
 }
 
 impl From<&Rrule> for JsRrule {
@@ -193,12 +347,16 @@ impl JsVEvent {
             location: event.location,
             organizer: event.organizer,
             dtstamp: event.dtstamp.map(|ts| ts.to_rfc3339()),
-            dtstart: event.dtstart.map(|ts| ts.to_rfc3339()),
-            dtend: event.dtend.map(|ts| ts.to_rfc3339()),
+            dtstart: event.dtstart.as_ref().map(JsCalendarDateValue::from),
+            dtend: event.dtend.as_ref().map(JsCalendarDateValue::from),
             rrule: event.rrule.as_ref().map(JsRrule::from),
             attendees: event.attendees.iter().map(JsAttendee::from).collect(),
-            recurrence_id: event.recurrence_id.map(|ts| ts.to_rfc3339()),
-            exdates: event.exdates.iter().map(|ts| ts.to_rfc3339()).collect(),
+            recurrence_id: event.recurrence_id.as_ref().map(JsCalendarDateValue::from),
+            exdates: event
+                .exdates
+                .iter()
+                .map(JsCalendarDateValue::from)
+                .collect(),
         }
     }
 }
@@ -312,16 +470,10 @@ fn build_item_publish_iq(community_jid: &str, item_id: &str, item: &CalendarItem
 fn vevent_from_input(uid: &str, input: JsVEventInput) -> Result<VEvent, JsValue> {
     let mut event = VEvent::new(uid, input.summary).with_dtstamp(Utc::now());
     if let Some(dtstart) = input.dtstart {
-        let parsed: DateTime<Utc> = dtstart
-            .parse()
-            .map_err(|err| js_error(format!("invalid dtstart: {err}")))?;
-        event = event.with_dtstart(parsed);
+        event = event.with_dtstart_value(dtstart.try_into()?);
     }
     if let Some(dtend) = input.dtend {
-        let parsed: DateTime<Utc> = dtend
-            .parse()
-            .map_err(|err| js_error(format!("invalid dtend: {err}")))?;
-        event = event.with_dtend(parsed);
+        event = event.with_dtend_value(dtend.try_into()?);
     }
     if let Some(description) = input.description {
         event = event.with_description(description);
@@ -335,28 +487,20 @@ fn vevent_from_input(uid: &str, input: JsVEventInput) -> Result<VEvent, JsValue>
     if let Some(rrule) = input.rrule {
         event = event.with_rrule(rrule.into_rrule()?);
     }
+    validate_calendar_date_types(&event)?;
     Ok(event)
 }
 
 fn override_from_input(uid: &str, input: JsOverrideInput) -> Result<VEvent, JsValue> {
-    let recurrence_id: DateTime<Utc> = input
-        .recurrence_id
-        .parse()
-        .map_err(|err| js_error(format!("invalid recurrence_id: {err}")))?;
+    let recurrence_id: CalendarDateValue = input.recurrence_id.try_into()?;
     let mut event = VEvent::new(uid, input.summary.unwrap_or_default())
         .with_dtstamp(Utc::now())
-        .with_recurrence_id(recurrence_id);
+        .with_recurrence_id_value(recurrence_id);
     if let Some(dtstart) = input.dtstart {
-        let parsed: DateTime<Utc> = dtstart
-            .parse()
-            .map_err(|err| js_error(format!("invalid override dtstart: {err}")))?;
-        event = event.with_dtstart(parsed);
+        event = event.with_dtstart_value(dtstart.try_into()?);
     }
     if let Some(dtend) = input.dtend {
-        let parsed: DateTime<Utc> = dtend
-            .parse()
-            .map_err(|err| js_error(format!("invalid override dtend: {err}")))?;
-        event = event.with_dtend(parsed);
+        event = event.with_dtend_value(dtend.try_into()?);
     }
     if let Some(description) = input.description {
         event = event.with_description(description);
@@ -364,7 +508,87 @@ fn override_from_input(uid: &str, input: JsOverrideInput) -> Result<VEvent, JsVa
     if let Some(location) = input.location {
         event = event.with_location(location);
     }
+    validate_calendar_date_types(&event)?;
     Ok(event)
+}
+
+fn validate_calendar_date_types(event: &VEvent) -> Result<(), JsValue> {
+    validate_calendar_event(event).map_err(js_error)
+}
+
+fn validate_calendar_event(event: &VEvent) -> Result<(), &'static str> {
+    if calendar_date_type_mismatch(event) {
+        return Err("DTSTART, DTEND, RECURRENCE-ID, and EXDATE must use the same date value type");
+    }
+    if calendar_date_order_invalid(event) {
+        return Err("DTEND must be after DTSTART");
+    }
+    if all_day_until_invalid(event) {
+        return Err("All-day recurring events must use COUNT until DATE UNTIL is supported");
+    }
+    Ok(())
+}
+
+fn calendar_date_type_mismatch(event: &VEvent) -> bool {
+    let expected = event
+        .dtstart
+        .or(event.recurrence_id)
+        .map(CalendarDateValue::kind);
+    let Some(expected) = expected else {
+        return false;
+    };
+    event.dtend.is_some_and(|value| value.kind() != expected)
+        || event
+            .recurrence_id
+            .is_some_and(|value| value.kind() != expected)
+        || event.exdates.iter().any(|value| value.kind() != expected)
+}
+
+fn calendar_date_order_invalid(event: &VEvent) -> bool {
+    let Some(start) = event.dtstart.or(event.recurrence_id) else {
+        return false;
+    };
+    event
+        .dtend
+        .is_some_and(|end| !calendar_date_after(end, start))
+}
+
+fn all_day_until_invalid(event: &VEvent) -> bool {
+    matches!(event.dtstart, Some(CalendarDateValue::Date(_)))
+        && matches!(
+            event.rrule.as_ref().and_then(|rule| rule.end.clone()),
+            Some(RruleEnd::Until(_))
+        )
+}
+
+fn calendar_date_after(end: CalendarDateValue, start: CalendarDateValue) -> bool {
+    match (end, start) {
+        (CalendarDateValue::Date(end), CalendarDateValue::Date(start)) => end > start,
+        (CalendarDateValue::DateTime(end), CalendarDateValue::DateTime(start)) => end > start,
+        _ => false,
+    }
+}
+
+fn validate_calendar_item(item: &CalendarItem) -> Result<(), JsValue> {
+    validate_calendar_item_data(item).map_err(js_error)
+}
+
+fn validate_calendar_item_data(item: &CalendarItem) -> Result<(), &'static str> {
+    validate_calendar_event(&item.master)?;
+    let master_kind = item.master.dtstart.map(CalendarDateValue::kind);
+    for override_event in &item.overrides {
+        validate_calendar_event(override_event)?;
+        if master_kind.is_some_and(|kind| {
+            override_event
+                .recurrence_id
+                .is_some_and(|value| value.kind() != kind)
+        }) {
+            return Err(
+                "Override RECURRENCE-ID must use the same date value type as the master DTSTART",
+            );
+        }
+    }
+    Ok(())
 }
 
 fn build_event_publish_iq(community_jid: &str, item_id: &str, event: &VEvent) -> Element {
@@ -416,19 +640,26 @@ fn parse_events_items_result(iq: &Element) -> Vec<JsVEvent> {
             continue;
         };
         // Master comes back under the item id; each override gets a
-        // synthetic id `<item-id>::override::<recurrence-id-rfc3339>`
+        // synthetic id `<item-id>::override::<typed-recurrence-id>`
         // so the chat can address them individually without losing
         // the master/override correlation (preserved via `uid`).
         flattened.push(JsVEvent::from_vevent(item_id, parsed.master));
         for ov in parsed.overrides {
             let synthetic = ov
                 .recurrence_id
-                .map(|ts| format!("{item_id}::override::{}", ts.to_rfc3339()))
+                .map(|value| format!("{item_id}::override::{}", calendar_date_key(value)))
                 .unwrap_or_else(|| item_id.to_string());
             flattened.push(JsVEvent::from_vevent(&synthetic, ov));
         }
     }
     flattened
+}
+
+fn calendar_date_key(value: CalendarDateValue) -> String {
+    match value {
+        CalendarDateValue::Date(date) => format!("date:{}", date.format("%Y-%m-%d")),
+        CalendarDateValue::DateTime(ts) => format!("date-time:{}", ts.to_rfc3339()),
+    }
 }
 
 // ── Wasm methods ────────────────────────────────────────────────────
@@ -457,31 +688,7 @@ impl WaddleClient {
             let input: JsVEventInput = serde_wasm_bindgen::from_value(input)
                 .map_err(|err| js_error(format!("invalid event input: {err}")))?;
             let item_id = format!("evt-{}", Uuid::new_v4());
-            let mut event = VEvent::new(&item_id, input.summary).with_dtstamp(Utc::now());
-            if let Some(dtstart) = input.dtstart {
-                let parsed: DateTime<Utc> = dtstart
-                    .parse()
-                    .map_err(|err| js_error(format!("invalid dtstart: {err}")))?;
-                event = event.with_dtstart(parsed);
-            }
-            if let Some(dtend) = input.dtend {
-                let parsed: DateTime<Utc> = dtend
-                    .parse()
-                    .map_err(|err| js_error(format!("invalid dtend: {err}")))?;
-                event = event.with_dtend(parsed);
-            }
-            if let Some(description) = input.description {
-                event = event.with_description(description);
-            }
-            if let Some(location) = input.location {
-                event = event.with_location(location);
-            }
-            if let Some(organizer) = input.organizer {
-                event = event.with_organizer(organizer);
-            }
-            if let Some(rrule) = input.rrule {
-                event = event.with_rrule(rrule.into_rrule()?);
-            }
+            let event = vevent_from_input(&item_id, input)?;
             let iq = build_event_publish_iq(&community_jid, &item_id, &event);
             send_iq_command(inner, iq).await?;
             let js_event = JsVEvent::from_vevent(&item_id, event);
@@ -511,15 +718,13 @@ impl WaddleClient {
             }
             let mut master = vevent_from_input(&item_id, input.master)?;
             for exdate in input.exdates {
-                let parsed: DateTime<Utc> = exdate
-                    .parse()
-                    .map_err(|err| js_error(format!("invalid exdate: {err}")))?;
-                master = master.add_exdate(parsed);
+                master = master.add_exdate_value(exdate.try_into()?);
             }
             let mut item = CalendarItem::new(master);
             for ov in input.overrides {
                 item = item.add_override(override_from_input(&item_id, ov)?);
             }
+            validate_calendar_item(&item)?;
             let iq = build_item_publish_iq(&community_jid, &item_id, &item);
             send_iq_command(inner, iq).await?;
             let js_master = JsVEvent::from_vevent(&item_id, item.master);

--- a/server/crates/waddle-xmpp-core/src/xcal.rs
+++ b/server/crates/waddle-xmpp-core/src/xcal.rs
@@ -21,8 +21,8 @@
 //!     <vevent>
 //!       <uid>evt-1</uid>
 //!       <dtstamp>2026-06-01T12:00:00Z</dtstamp>
-//!       <dtstart>2026-06-05T19:00:00Z</dtstart>
-//!       <dtend>2026-06-05T22:00:00Z</dtend>
+//!       <dtstart><date-time>2026-06-05T19:00:00Z</date-time></dtstart>
+//!       <dtend><date-time>2026-06-05T22:00:00Z</date-time></dtend>
 //!       <summary>Game Night</summary>
 //!       <description>Weekly gaming session</description>
 //!       <location>Voice #gaming</location>
@@ -45,7 +45,7 @@
 //! aggregates per-user RSVP items into the master event and expands
 //! recurring instances client-side.
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, NaiveDate, Utc};
 use minidom::Element;
 
 /// xCal namespace (RFC 5545 in XML serialisation — xCal-Basic
@@ -140,6 +140,50 @@ impl Weekday {
 pub enum RruleEnd {
     Count(u32),
     Until(DateTime<Utc>),
+}
+
+/// DTSTART / DTEND / RECURRENCE-ID / EXDATE value. RFC 5545 allows
+/// VEVENTs to use either DATE-TIME values or date-only all-day values;
+/// xCal represents those as explicit `<date-time/>` or `<date/>`
+/// children inside the property element.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum CalendarDateValue {
+    Date(NaiveDate),
+    DateTime(DateTime<Utc>),
+}
+
+impl CalendarDateValue {
+    pub fn kind(self) -> CalendarDateValueKind {
+        match self {
+            Self::Date(_) => CalendarDateValueKind::Date,
+            Self::DateTime(_) => CalendarDateValueKind::DateTime,
+        }
+    }
+
+    pub fn as_datetime(self) -> Option<DateTime<Utc>> {
+        match self {
+            Self::DateTime(value) => Some(value),
+            Self::Date(_) => None,
+        }
+    }
+}
+
+impl From<DateTime<Utc>> for CalendarDateValue {
+    fn from(value: DateTime<Utc>) -> Self {
+        Self::DateTime(value)
+    }
+}
+
+impl From<NaiveDate> for CalendarDateValue {
+    fn from(value: NaiveDate) -> Self {
+        Self::Date(value)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CalendarDateValueKind {
+    Date,
+    DateTime,
 }
 
 /// Recurrence rule subset suitable for community events. RFC 5545
@@ -273,10 +317,10 @@ pub struct VEvent {
     /// last modified. Defaults to publish time at the call site.
     pub dtstamp: Option<DateTime<Utc>>,
     /// DTSTART (required for a usable event).
-    pub dtstart: Option<DateTime<Utc>>,
+    pub dtstart: Option<CalendarDateValue>,
     /// DTEND — optional, mutually exclusive with DURATION (we model
     /// only DTEND for now).
-    pub dtend: Option<DateTime<Utc>>,
+    pub dtend: Option<CalendarDateValue>,
     /// SUMMARY — required for a displayable event.
     pub summary: String,
     pub description: Option<String>,
@@ -292,11 +336,11 @@ pub struct VEvent {
     /// RFC 5545 §3.8.4.4 RECURRENCE-ID — set on override VEVENT
     /// components that replace a single occurrence of the master
     /// series. `None` on the master event itself.
-    pub recurrence_id: Option<DateTime<Utc>>,
+    pub recurrence_id: Option<CalendarDateValue>,
     /// RFC 5545 §3.8.5.1 EXDATE — occurrence DTSTART values that
     /// should be skipped (per-instance cancellations). Only
     /// meaningful on the master event.
-    pub exdates: Vec<DateTime<Utc>>,
+    pub exdates: Vec<CalendarDateValue>,
 }
 
 /// A logical calendar item: one master VEVENT plus any per-instance
@@ -347,11 +391,31 @@ impl VEvent {
     }
 
     pub fn with_dtstart(mut self, dtstart: DateTime<Utc>) -> Self {
-        self.dtstart = Some(dtstart);
+        self.dtstart = Some(CalendarDateValue::DateTime(dtstart));
         self
     }
 
     pub fn with_dtend(mut self, dtend: DateTime<Utc>) -> Self {
+        self.dtend = Some(CalendarDateValue::DateTime(dtend));
+        self
+    }
+
+    pub fn with_dtstart_date(mut self, dtstart: NaiveDate) -> Self {
+        self.dtstart = Some(CalendarDateValue::Date(dtstart));
+        self
+    }
+
+    pub fn with_dtend_date(mut self, dtend: NaiveDate) -> Self {
+        self.dtend = Some(CalendarDateValue::Date(dtend));
+        self
+    }
+
+    pub fn with_dtstart_value(mut self, dtstart: CalendarDateValue) -> Self {
+        self.dtstart = Some(dtstart);
+        self
+    }
+
+    pub fn with_dtend_value(mut self, dtend: CalendarDateValue) -> Self {
         self.dtend = Some(dtend);
         self
     }
@@ -387,16 +451,52 @@ impl VEvent {
     }
 
     pub fn with_recurrence_id(mut self, recurrence_id: DateTime<Utc>) -> Self {
+        self.recurrence_id = Some(CalendarDateValue::DateTime(recurrence_id));
+        self
+    }
+
+    pub fn with_recurrence_id_date(mut self, recurrence_id: NaiveDate) -> Self {
+        self.recurrence_id = Some(CalendarDateValue::Date(recurrence_id));
+        self
+    }
+
+    pub fn with_recurrence_id_value(mut self, recurrence_id: CalendarDateValue) -> Self {
         self.recurrence_id = Some(recurrence_id);
         self
     }
 
     pub fn with_exdates<I: IntoIterator<Item = DateTime<Utc>>>(mut self, exdates: I) -> Self {
+        self.exdates = exdates
+            .into_iter()
+            .map(CalendarDateValue::DateTime)
+            .collect();
+        self
+    }
+
+    pub fn with_exdate_dates<I: IntoIterator<Item = NaiveDate>>(mut self, exdates: I) -> Self {
+        self.exdates = exdates.into_iter().map(CalendarDateValue::Date).collect();
+        self
+    }
+
+    pub fn with_exdate_values<I: IntoIterator<Item = CalendarDateValue>>(
+        mut self,
+        exdates: I,
+    ) -> Self {
         self.exdates = exdates.into_iter().collect();
         self
     }
 
     pub fn add_exdate(mut self, exdate: DateTime<Utc>) -> Self {
+        self.exdates.push(CalendarDateValue::DateTime(exdate));
+        self
+    }
+
+    pub fn add_exdate_date(mut self, exdate: NaiveDate) -> Self {
+        self.exdates.push(CalendarDateValue::Date(exdate));
+        self
+    }
+
+    pub fn add_exdate_value(mut self, exdate: CalendarDateValue) -> Self {
         self.exdates.push(exdate);
         self
     }
@@ -406,7 +506,9 @@ impl VEvent {
     /// upcoming-instance expansion is a separate concern from the
     /// wire shape.
     pub fn is_upcoming(&self) -> bool {
-        self.dtstart.is_some_and(|s| s > Utc::now())
+        self.dtstart
+            .and_then(CalendarDateValue::as_datetime)
+            .is_some_and(|s| s > Utc::now())
     }
 }
 
@@ -416,6 +518,19 @@ fn append_text_child(parent: &mut Element, name: &str, value: &str) {
     let mut child = Element::builder(name, NS_XCAL).build();
     child.append_text_node(value);
     parent.append_child(child);
+}
+
+fn append_calendar_date_child(parent: &mut Element, name: &str, value: CalendarDateValue) {
+    let mut property = Element::builder(name, NS_XCAL).build();
+    match value {
+        CalendarDateValue::Date(date) => {
+            append_text_child(&mut property, "date", &date.format("%Y-%m-%d").to_string());
+        }
+        CalendarDateValue::DateTime(date_time) => {
+            append_text_child(&mut property, "date-time", &date_time.to_rfc3339());
+        }
+    }
+    parent.append_child(property);
 }
 
 fn build_rrule_element(rrule: &Rrule) -> Element {
@@ -483,10 +598,10 @@ fn build_vevent_element(event: &VEvent) -> Element {
         append_text_child(&mut vevent, "dtstamp", &dtstamp.to_rfc3339());
     }
     if let Some(dtstart) = event.dtstart {
-        append_text_child(&mut vevent, "dtstart", &dtstart.to_rfc3339());
+        append_calendar_date_child(&mut vevent, "dtstart", dtstart);
     }
     if let Some(dtend) = event.dtend {
-        append_text_child(&mut vevent, "dtend", &dtend.to_rfc3339());
+        append_calendar_date_child(&mut vevent, "dtend", dtend);
     }
     if !event.summary.is_empty() {
         append_text_child(&mut vevent, "summary", &event.summary);
@@ -504,10 +619,10 @@ fn build_vevent_element(event: &VEvent) -> Element {
         vevent.append_child(build_rrule_element(rrule));
     }
     if let Some(recurrence_id) = event.recurrence_id {
-        append_text_child(&mut vevent, "recurrence-id", &recurrence_id.to_rfc3339());
+        append_calendar_date_child(&mut vevent, "recurrence-id", recurrence_id);
     }
     for exdate in &event.exdates {
-        append_text_child(&mut vevent, "exdate", &exdate.to_rfc3339());
+        append_calendar_date_child(&mut vevent, "exdate", *exdate);
     }
     for attendee in &event.attendees {
         vevent.append_child(build_attendee_element(attendee));
@@ -545,6 +660,22 @@ fn xcal_text(parent: &Element, name: &str) -> Option<String> {
         .find(|c| c.name() == name && c.ns() == NS_XCAL)
         .map(|c| c.text())
         .filter(|t| !t.is_empty())
+}
+
+fn xcal_calendar_date(parent: &Element, name: &str) -> Option<CalendarDateValue> {
+    let property = xcal_child(parent, name)?;
+    if let Some(date) = xcal_text(property, "date") {
+        return NaiveDate::parse_from_str(&date, "%Y-%m-%d")
+            .ok()
+            .map(CalendarDateValue::Date);
+    }
+    if let Some(date_time) = xcal_text(property, "date-time") {
+        return date_time
+            .parse::<DateTime<Utc>>()
+            .ok()
+            .map(CalendarDateValue::DateTime);
+    }
+    None
 }
 
 fn xcal_child<'a>(parent: &'a Element, name: &str) -> Option<&'a Element> {
@@ -618,7 +749,7 @@ pub fn parse_vcalendar_item(item_id: &str, vcalendar: &Element) -> Option<Calend
     let mut master: Option<VEvent> = None;
     let mut overrides: Vec<VEvent> = Vec::new();
     for vevent in vevents {
-        let parsed = parse_vevent_element(item_id, vevent);
+        let parsed = parse_vevent_element(item_id, vevent)?;
         if parsed.recurrence_id.is_some() {
             overrides.push(parsed);
         } else if master.is_none() {
@@ -634,12 +765,12 @@ pub fn parse_vcalendar_item(item_id: &str, vcalendar: &Element) -> Option<Calend
     Some(CalendarItem { master, overrides })
 }
 
-fn parse_vevent_element(item_id: &str, vevent: &Element) -> VEvent {
+fn parse_vevent_element(item_id: &str, vevent: &Element) -> Option<VEvent> {
     let summary = xcal_text(vevent, "summary").unwrap_or_default();
     let uid = xcal_text(vevent, "uid").unwrap_or_else(|| item_id.to_string());
     let dtstamp = xcal_text(vevent, "dtstamp").and_then(|s| s.parse().ok());
-    let dtstart = xcal_text(vevent, "dtstart").and_then(|s| s.parse().ok());
-    let dtend = xcal_text(vevent, "dtend").and_then(|s| s.parse().ok());
+    let dtstart = xcal_calendar_date(vevent, "dtstart");
+    let dtend = xcal_calendar_date(vevent, "dtend");
     let description = xcal_text(vevent, "description");
     let location = xcal_text(vevent, "location");
     let organizer = xcal_text(vevent, "organizer");
@@ -649,16 +780,13 @@ fn parse_vevent_element(item_id: &str, vevent: &Element) -> VEvent {
         .filter(|c| c.name() == "attendee" && c.ns() == NS_XCAL)
         .filter_map(parse_attendee)
         .collect();
-    let recurrence_id = xcal_text(vevent, "recurrence-id").and_then(|s| s.parse().ok());
+    let recurrence_id = xcal_calendar_date(vevent, "recurrence-id");
     let exdates = vevent
         .children()
         .filter(|c| c.name() == "exdate" && c.ns() == NS_XCAL)
-        .filter_map(|c| {
-            let t = c.text();
-            t.trim().parse::<DateTime<Utc>>().ok()
-        })
+        .flat_map(parse_calendar_date_values)
         .collect();
-    VEvent {
+    let event = VEvent {
         uid,
         dtstamp,
         dtstart,
@@ -671,6 +799,81 @@ fn parse_vevent_element(item_id: &str, vevent: &Element) -> VEvent {
         attendees,
         recurrence_id,
         exdates,
+    };
+    if has_invalid_date_values(&event) {
+        return None;
+    }
+    Some(event)
+}
+
+fn parse_calendar_date_values(property: &Element) -> Vec<CalendarDateValue> {
+    let mut values = Vec::new();
+    for child in property.children().filter(|child| child.ns() == NS_XCAL) {
+        match child.name() {
+            "date" => {
+                if let Ok(date) = NaiveDate::parse_from_str(&child.text(), "%Y-%m-%d") {
+                    values.push(CalendarDateValue::Date(date));
+                }
+            }
+            "date-time" => {
+                if let Ok(date_time) = child.text().parse::<DateTime<Utc>>() {
+                    values.push(CalendarDateValue::DateTime(date_time));
+                }
+            }
+            _ => {}
+        }
+    }
+    values
+}
+
+fn has_invalid_date_values(event: &VEvent) -> bool {
+    has_mixed_date_value_types(event)
+        || has_non_positive_end(event)
+        || has_all_day_date_time_until(event)
+}
+
+fn has_mixed_date_value_types(event: &VEvent) -> bool {
+    let Some(expected_kind) = event
+        .dtstart
+        .or(event.recurrence_id)
+        .map(CalendarDateValue::kind)
+    else {
+        return false;
+    };
+    event
+        .dtend
+        .is_some_and(|value| value.kind() != expected_kind)
+        || event
+            .recurrence_id
+            .is_some_and(|value| value.kind() != expected_kind)
+        || event
+            .exdates
+            .iter()
+            .any(|value| value.kind() != expected_kind)
+}
+
+fn has_non_positive_end(event: &VEvent) -> bool {
+    let Some(start) = event.dtstart.or(event.recurrence_id) else {
+        return false;
+    };
+    event
+        .dtend
+        .is_some_and(|end| !calendar_date_after(end, start))
+}
+
+fn has_all_day_date_time_until(event: &VEvent) -> bool {
+    matches!(event.dtstart, Some(CalendarDateValue::Date(_)))
+        && matches!(
+            event.rrule.as_ref().and_then(|rule| rule.end.clone()),
+            Some(RruleEnd::Until(_))
+        )
+}
+
+fn calendar_date_after(end: CalendarDateValue, start: CalendarDateValue) -> bool {
+    match (end, start) {
+        (CalendarDateValue::Date(end), CalendarDateValue::Date(start)) => end > start,
+        (CalendarDateValue::DateTime(end), CalendarDateValue::DateTime(start)) => end > start,
+        _ => false,
     }
 }
 
@@ -722,6 +925,10 @@ mod tests {
             .expect("valid date")
     }
 
+    fn day(y: i32, mo: u32, d: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(y, mo, d).expect("valid date")
+    }
+
     #[test]
     fn freq_round_trip() {
         for f in [Freq::Daily, Freq::Weekly, Freq::Monthly, Freq::Yearly] {
@@ -762,12 +969,125 @@ mod tests {
         let parsed = parse_vcalendar_event("evt-1", &vcal).expect("parseable");
         assert_eq!(parsed.uid, "evt-1");
         assert_eq!(parsed.summary, "Game Night");
-        assert_eq!(parsed.dtstart, Some(ts(2026, 6, 15, 19, 0)));
-        assert_eq!(parsed.dtend, Some(ts(2026, 6, 15, 22, 0)));
+        assert_eq!(parsed.dtstart, Some(ts(2026, 6, 15, 19, 0).into()));
+        assert_eq!(parsed.dtend, Some(ts(2026, 6, 15, 22, 0).into()));
         assert_eq!(parsed.description.as_deref(), Some("Weekly gaming"));
         assert_eq!(parsed.location.as_deref(), Some("Voice #gaming"));
         assert_eq!(parsed.organizer.as_deref(), Some("xmpp:alice@example.com"));
         assert!(parsed.rrule.is_none());
+    }
+
+    #[test]
+    fn build_and_parse_one_day_all_day_event() {
+        let event = VEvent::new("evt-all-day", "Company Holiday")
+            .with_dtstart_date(day(2026, 6, 15))
+            .with_dtend_date(day(2026, 6, 16));
+        let vcal = build_vcalendar_with_event(&event);
+        let serialised = String::from(&vcal);
+        assert!(serialised.contains("<date>2026-06-15</date>"));
+        assert!(!serialised.contains("<date-time>"));
+
+        let parsed = parse_vcalendar_event("evt-all-day", &vcal).expect("parseable");
+        assert_eq!(parsed.dtstart, Some(day(2026, 6, 15).into()));
+        assert_eq!(parsed.dtend, Some(day(2026, 6, 16).into()));
+    }
+
+    #[test]
+    fn build_and_parse_multi_day_all_day_event_with_exdate() {
+        let event = VEvent::new("evt-retreat", "Retreat")
+            .with_dtstart_date(day(2026, 6, 15))
+            .with_dtend_date(day(2026, 6, 18))
+            .with_exdate_dates([day(2026, 6, 22)]);
+        let vcal = build_vcalendar_with_event(&event);
+        let parsed = parse_vcalendar_event("evt-retreat", &vcal).expect("parseable");
+        assert_eq!(parsed.dtstart, Some(day(2026, 6, 15).into()));
+        assert_eq!(parsed.dtend, Some(day(2026, 6, 18).into()));
+        assert_eq!(parsed.exdates, vec![day(2026, 6, 22).into()]);
+    }
+
+    #[test]
+    fn parse_rejects_mixed_date_and_date_time_bounds() {
+        let xml = r#"<vcalendar xmlns='urn:ietf:params:xml:ns:xcal'>
+  <vevent>
+    <uid>mixed</uid>
+    <dtstart><date>2026-06-15</date></dtstart>
+    <dtend><date-time>2026-06-16T00:00:00Z</date-time></dtend>
+    <summary>Mixed</summary>
+  </vevent>
+</vcalendar>"#;
+        let elem: Element = xml.parse().expect("valid xml");
+        assert!(parse_vcalendar_event("mixed", &elem).is_none());
+    }
+
+    #[test]
+    fn parse_rejects_mixed_recurrence_id_and_override_end() {
+        let xml = r#"<vcalendar xmlns='urn:ietf:params:xml:ns:xcal'>
+  <vevent>
+    <uid>mixed-override</uid>
+    <dtstart><date>2026-06-15</date></dtstart>
+    <summary>Mixed override master</summary>
+  </vevent>
+  <vevent>
+    <uid>mixed-override</uid>
+    <recurrence-id><date>2026-06-22</date></recurrence-id>
+    <dtend><date-time>2026-06-23T00:00:00Z</date-time></dtend>
+    <summary>Mixed override</summary>
+  </vevent>
+</vcalendar>"#;
+        let elem: Element = xml.parse().expect("valid xml");
+        assert!(parse_vcalendar_item("mixed-override", &elem).is_none());
+    }
+
+    #[test]
+    fn parse_preserves_multi_value_exdate_property() {
+        let xml = r#"<vcalendar xmlns='urn:ietf:params:xml:ns:xcal'>
+  <vevent>
+    <uid>multi-exdate</uid>
+    <dtstart><date-time>2026-06-05T19:00:00Z</date-time></dtstart>
+    <summary>Multi EXDATE</summary>
+    <exdate>
+      <date-time>2026-06-12T19:00:00Z</date-time>
+      <date-time>2026-06-19T19:00:00Z</date-time>
+    </exdate>
+  </vevent>
+</vcalendar>"#;
+        let elem: Element = xml.parse().expect("valid xml");
+        let parsed = parse_vcalendar_event("multi-exdate", &elem).expect("parseable");
+        assert_eq!(
+            parsed.exdates,
+            vec![ts(2026, 6, 12, 19, 0).into(), ts(2026, 6, 19, 19, 0).into()]
+        );
+    }
+
+    #[test]
+    fn parse_rejects_dtend_not_after_dtstart() {
+        let xml = r#"<vcalendar xmlns='urn:ietf:params:xml:ns:xcal'>
+  <vevent>
+    <uid>bad-end</uid>
+    <dtstart><date>2026-06-15</date></dtstart>
+    <dtend><date>2026-06-15</date></dtend>
+    <summary>Bad end</summary>
+  </vevent>
+</vcalendar>"#;
+        let elem: Element = xml.parse().expect("valid xml");
+        assert!(parse_vcalendar_event("bad-end", &elem).is_none());
+    }
+
+    #[test]
+    fn parse_rejects_all_day_rrule_until_date_time() {
+        let xml = r#"<vcalendar xmlns='urn:ietf:params:xml:ns:xcal'>
+  <vevent>
+    <uid>bad-until</uid>
+    <dtstart><date>2026-06-15</date></dtstart>
+    <summary>Bad until</summary>
+    <rrule>
+      <freq>DAILY</freq>
+      <until>2026-06-30T00:00:00Z</until>
+    </rrule>
+  </vevent>
+</vcalendar>"#;
+        let elem: Element = xml.parse().expect("valid xml");
+        assert!(parse_vcalendar_event("bad-until", &elem).is_none());
     }
 
     #[test]
@@ -830,8 +1150,8 @@ mod tests {
   <vevent>
     <uid>fcd5cb18</uid>
     <dtstamp>1997-06-11T19:00:00Z</dtstamp>
-    <dtstart>1997-07-14T17:00:00Z</dtstart>
-    <dtend>1997-07-15T03:59:59Z</dtend>
+    <dtstart><date-time>1997-07-14T17:00:00Z</date-time></dtstart>
+    <dtend><date-time>1997-07-15T03:59:59Z</date-time></dtend>
     <summary>Bastille Day Party</summary>
     <organizer>xmpp:a@example.com</organizer>
   </vevent>
@@ -851,7 +1171,7 @@ mod tests {
         let xml = r#"<vcalendar xmlns='urn:ietf:params:xml:ns:xcal'>
   <vevent>
     <uid>no-summary</uid>
-    <dtstart>2026-06-01T00:00:00Z</dtstart>
+    <dtstart><date-time>2026-06-01T00:00:00Z</date-time></dtstart>
   </vevent>
 </vcalendar>"#;
         let elem: Element = xml.parse().expect("valid xml");
@@ -971,7 +1291,7 @@ mod tests {
             uid: "evt-series".to_string(),
             summary: String::new(),
             location: Some("New venue".to_string()),
-            recurrence_id: Some(ts(2026, 6, 26, 19, 0)),
+            recurrence_id: Some(ts(2026, 6, 26, 19, 0).into()),
             ..VEvent::new("evt-series", "")
         };
         let item = CalendarItem::new(master)
@@ -987,16 +1307,16 @@ mod tests {
         assert_eq!(parsed.master.uid, "evt-series");
         assert_eq!(parsed.master.summary, "Game Night");
         assert_eq!(parsed.master.exdates.len(), 2);
-        assert_eq!(parsed.master.exdates[0], ts(2026, 6, 19, 19, 0));
+        assert_eq!(parsed.master.exdates[0], ts(2026, 6, 19, 19, 0).into());
         assert_eq!(parsed.overrides.len(), 2);
         assert_eq!(
             parsed.overrides[0].recurrence_id,
-            Some(ts(2026, 6, 12, 19, 0))
+            Some(ts(2026, 6, 12, 19, 0).into())
         );
         assert_eq!(parsed.overrides[0].summary, "Special: Halo");
         assert_eq!(
             parsed.overrides[1].recurrence_id,
-            Some(ts(2026, 6, 26, 19, 0))
+            Some(ts(2026, 6, 26, 19, 0).into())
         );
         assert_eq!(parsed.overrides[1].location.as_deref(), Some("New venue"));
         assert!(parsed.overrides[1].summary.is_empty());
@@ -1009,12 +1329,12 @@ mod tests {
         let xml = r#"<vcalendar xmlns='urn:ietf:params:xml:ns:xcal'>
   <vevent>
     <uid>evt-series</uid>
-    <recurrence-id>2026-06-12T19:00:00Z</recurrence-id>
+    <recurrence-id><date-time>2026-06-12T19:00:00Z</date-time></recurrence-id>
     <summary>Override</summary>
   </vevent>
   <vevent>
     <uid>evt-series</uid>
-    <dtstart>2026-06-05T19:00:00Z</dtstart>
+    <dtstart><date-time>2026-06-05T19:00:00Z</date-time></dtstart>
     <summary>Master</summary>
   </vevent>
 </vcalendar>"#;

--- a/server/crates/waddle-xmpp-core/src/xcal.rs
+++ b/server/crates/waddle-xmpp-core/src/xcal.rs
@@ -506,9 +506,11 @@ impl VEvent {
     /// upcoming-instance expansion is a separate concern from the
     /// wire shape.
     pub fn is_upcoming(&self) -> bool {
-        self.dtstart
-            .and_then(CalendarDateValue::as_datetime)
-            .is_some_and(|s| s > Utc::now())
+        match self.dtstart {
+            Some(CalendarDateValue::DateTime(dtstart)) => dtstart > Utc::now(),
+            Some(CalendarDateValue::Date(dtstart)) => dtstart >= Utc::now().date_naive(),
+            None => false,
+        }
     }
 }
 
@@ -675,7 +677,20 @@ fn xcal_calendar_date(parent: &Element, name: &str) -> Option<CalendarDateValue>
             .ok()
             .map(CalendarDateValue::DateTime);
     }
-    None
+    parse_calendar_date_text(&property.text())
+}
+
+fn parse_calendar_date_text(text: &str) -> Option<CalendarDateValue> {
+    let text = text.trim();
+    if text.is_empty() {
+        return None;
+    }
+    if let Ok(date_time) = text.parse::<DateTime<Utc>>() {
+        return Some(CalendarDateValue::DateTime(date_time));
+    }
+    NaiveDate::parse_from_str(text, "%Y-%m-%d")
+        .ok()
+        .map(CalendarDateValue::Date)
 }
 
 fn xcal_child<'a>(parent: &'a Element, name: &str) -> Option<&'a Element> {
@@ -822,6 +837,9 @@ fn parse_calendar_date_values(property: &Element) -> Vec<CalendarDateValue> {
             }
             _ => {}
         }
+    }
+    if values.is_empty() {
+        values.extend(parse_calendar_date_text(&property.text()));
     }
     values
 }
@@ -1163,6 +1181,26 @@ mod tests {
     }
 
     #[test]
+    fn parse_tolerates_legacy_flat_date_time_properties() {
+        let xml = r#"<vcalendar xmlns='urn:ietf:params:xml:ns:xcal'>
+  <version>2.0</version>
+  <vevent>
+    <uid>legacy-flat</uid>
+    <dtstart>2026-06-05T19:00:00Z</dtstart>
+    <dtend>2026-06-05T22:00:00Z</dtend>
+    <exdate>2026-06-12T19:00:00Z</exdate>
+    <summary>Legacy flat event</summary>
+  </vevent>
+</vcalendar>"#;
+        let elem: Element = xml.parse().expect("valid xml");
+        let event = parse_vcalendar_event("legacy-flat", &elem).expect("parseable");
+
+        assert_eq!(event.dtstart, Some(ts(2026, 6, 5, 19, 0).into()));
+        assert_eq!(event.dtend, Some(ts(2026, 6, 5, 22, 0).into()));
+        assert_eq!(event.exdates, vec![ts(2026, 6, 12, 19, 0).into()]);
+    }
+
+    #[test]
     fn parse_tolerates_missing_summary_for_overrides() {
         // RFC 5545 makes SUMMARY optional. Overrides that only patch
         // a different field (DTSTART, LOCATION, …) ship without one,
@@ -1191,8 +1229,14 @@ mod tests {
         let future = VEvent::new("e", "Future").with_dtstart(ts(2050, 1, 1, 0, 0));
         assert!(future.is_upcoming());
 
+        let future_all_day = VEvent::new("e", "Future all-day").with_dtstart_date(day(2050, 1, 1));
+        assert!(future_all_day.is_upcoming());
+
         let past = VEvent::new("e", "Past").with_dtstart(ts(2020, 1, 1, 0, 0));
         assert!(!past.is_upcoming());
+
+        let past_all_day = VEvent::new("e", "Past all-day").with_dtstart_date(day(2020, 1, 1));
+        assert!(!past_all_day.is_upcoming());
     }
 
     #[test]

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=8e039ec2603f";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=8e039ec2603f";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=8e039ec2603f";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=99d9afcdf5f2";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=99d9afcdf5f2";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=99d9afcdf5f2";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=8e039ec2603f";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=99d9afcdf5f2";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=5bc181ad40ed";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=5bc181ad40ed";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=5bc181ad40ed";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=8e039ec2603f";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=8e039ec2603f";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=8e039ec2603f";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=5bc181ad40ed";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=8e039ec2603f";


### PR DESCRIPTION
## Summary
- add typed DATE vs DATE-TIME calendar values through xCal, the wasm bridge, and chat TypeScript models
- serialize/parse xCal DATE and DATE-TIME for DTSTART, DTEND, RECURRENCE-ID, and EXDATE, with mixed-type and non-positive DTEND rejection
- tolerate legacy flat xCal date/date-time text while continuing to publish RFC 6321 typed child values, so older PubSub events stay visible in feeds
- export all-day ICS with RFC 5545 exclusive DTEND and VALUE=DATE while keeping timed UTC date-times
- render month, selected-day, week, and shell/mobile counts from overlapping/future-or-ongoing event bounds instead of start-only lists
- add all-day composer mode, 30-minute default duration selector, custom end controls, and inline validation
- use stable typed DATE/DATE-TIME keys when appending EXDATE cancellation markers
- update focused Rust, server feed, websocket fixture, chat expansion/composable, and EventsPane tests

## Plan
- [x] Keep calendar writes on the existing XMPP PubSub xCal path; no out-of-band APIs
- [x] Model all-day and timed values explicitly across Rust, wasm, and TypeScript
- [x] Use RFC 5545 all-day exclusive DTEND semantics and RFC 6321 xCal date/date-time representation
- [x] Fix spanning/ongoing display, upcoming counts, sorting, composer controls, and validation
- [x] Address review feedback for legacy xCal parsing, all-day upcoming checks, and typed EXDATE dedupe
- [x] Run adversarial review passes for xCal conformance, calendar edge cases, and UX/accessibility, then address actionable findings

## Validation
- `cargo test -p waddle-xmpp-core xcal`
- `cargo test -p waddle-xmpp-client-wasm client_xcal`
- `cargo test -p waddle-server calendar_feed`
- `cargo test -p waddle-server --test proto_calendar_xcal_ws --test proto_calendar_overrides_ws --test proto_calendar_rsvp_ws`
- `bun test tests/event-expansion.test.ts tests/community-events.test.ts tests/events-pane-calendar-feed.test.ts` from `chat/`
- `bun run lint` from `chat/`
- `bun run build` from `chat/`
- `just lint` from `server/`
- PR CI is green on head `94928980`
