### PR TITLE
feat(server): raise-hand as call presence state (#1029)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,49 @@
+# Waddle
+
+Glossary of domain terms used across the Waddle XMPP server and chat client. This file is a shared language reference, not a spec — it defines what terms *mean*, not how features are built.
+
+## Presence
+
+**Presence**:
+A user's network availability, broadcast to roster subscribers and reflected into joined rooms. Carries an availability state (the `<show>`), optional free-text status, and a priority. Distinct from *rich status* (mood/activity/tune), which is published separately via PEP.
+_Avoid_: Online/offline (that is only two of the states).
+
+**Show**:
+The XMPP availability state — the `<show>` value of a presence stanza. One of: *Available*, *Away*, *Extended Away*, *Do Not Disturb*, *Chat*. Absence of a show element means plain Available; an `unavailable` presence means Offline.
+_Avoid_: Status (reserve "status" for the free-text line).
+
+**Available**:
+Online and reachable, no qualifier. The default state when connected.
+_Avoid_: Online (online includes Away/Extended Away/DND too).
+
+**Away**:
+Online but temporarily not at the keyboard — a short, "stepped away" absence.
+_Avoid_: Idle, AFK.
+
+**Extended Away** (`xa`):
+Online but away from the computer for a longer period. This is the state meant by "online but away from computer."
+_Avoid_: Long away, gone.
+
+**Do Not Disturb** (`dnd`):
+Online but does not want to be interrupted. Busy.
+_Avoid_: Busy, offline-to-others.
+
+**Chat**:
+Online and actively interested in conversing ("free for chat").
+_Avoid_: Active.
+
+**Offline**:
+Not connected / no available resource. Sent as an `unavailable` presence.
+_Avoid_: Invisible (invisibility is a separate, unimplemented concept).
+
+**Idle**:
+How long since the user last interacted, stamped on a presence via XEP-0319 (`urn:xmpp:idle:1`). Orthogonal to the Show — an Away presence may also carry an idle timestamp so others can render "away, idle 20m."
+_Avoid_: Last seen (that is the offline XEP-0012 concept).
+
+**Manual status**:
+A Show the local user deliberately selected. Overrides auto-away.
+_Avoid_: Custom presence.
+
+**Auto-away**:
+A Show the client sets on the user's behalf after detected inactivity (Available → Away → Extended Away), stamped with an idle timestamp.
+_Avoid_: Auto-idle.

--- a/chat/src/components/calls/CallControls.vue
+++ b/chat/src/components/calls/CallControls.vue
@@ -5,6 +5,7 @@ import {
   LayoutGrid,
   Maximize2,
   MessageSquare,
+  Hand,
   Mic,
   MicOff,
   Minimize2,
@@ -63,6 +64,10 @@ const props = defineProps<{
   pictureInPictureSupported?: boolean;
   /** True while the call is detached into Picture-in-Picture. */
   pictureInPictureActive?: boolean;
+  /** True when raise-hand is offered — group (MUC) calls only (#1029). */
+  raisedHandAvailable?: boolean;
+  /** True while this client currently has its hand raised. */
+  raisedHandActive?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -75,6 +80,7 @@ const emit = defineEmits<{
   toggleParticipants: [];
   toggleChat: [];
   sendReaction: [emoji: string];
+  toggleRaisedHand: [];
   openSettings: [];
   setViewMode: [mode: CallViewMode];
   toggleSelfView: [];
@@ -441,6 +447,18 @@ onBeforeUnmount(() => {
         </button>
       </div>
     </div>
+    <button
+      v-if="raisedHandAvailable"
+      type="button"
+      class="chat-icon-button chat-icon-button--md hover:bg-muted"
+      :class="{ 'bg-muted text-foreground': raisedHandActive }"
+      :title="raisedHandActive ? 'Lower hand' : 'Raise hand'"
+      :aria-label="raisedHandActive ? 'Lower hand' : 'Raise hand'"
+      :aria-pressed="raisedHandActive ? 'true' : 'false'"
+      @click="emit('toggleRaisedHand')"
+    >
+      <Hand class="w-4 h-4" />
+    </button>
     <button
       type="button"
       class="call-controls__participants chat-icon-button chat-icon-button--md hover:bg-muted"

--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -54,7 +54,13 @@ import {
   hashInCallReactionId,
   receiveInCallReaction,
 } from "@/lib/calls/in-call-reactions";
-import { barePeerJid } from "@/lib/xmpp/jid";
+import { barePeerJid, fullJidIdentityKey } from "@/lib/xmpp/jid";
+import {
+  $mucRaisedHands,
+  $selfRaisedHand,
+  raisedHandKeysForRoom,
+  selfRaisedHandFor,
+} from "@/lib/calls/call-raised-hand";
 import { expectedRemoteIdentitiesForCallState } from "@/lib/calls/call-tiles";
 import {
   projectCallTiles,
@@ -260,6 +266,32 @@ const isMucCall = computed(
 );
 
 const localIdentity = computed(() => engine.localIdentity);
+
+// #1029: raised-hand call presence state. The store is the inbound view
+// (other occupants); self is folded in optimistically so the local tile
+// and control-bar button reflect the toggle before the server echo.
+const raisedHands = useStore($mucRaisedHands);
+const selfRaisedHandStore = useStore($selfRaisedHand);
+const selfHandRaised = computed(() =>
+  selfRaisedHandFor(normalizedRoomJid.value, selfRaisedHandStore.value),
+);
+const raisedHandIdentityKeys = computed(() => {
+  const keys = new Set(
+    raisedHandKeysForRoom(normalizedRoomJid.value, raisedHands.value),
+  );
+  const selfKey = fullJidIdentityKey(localIdentity.value);
+  if (selfHandRaised.value && selfKey) keys.add(selfKey);
+  return keys;
+});
+
+async function onToggleRaisedHand(): Promise<void> {
+  if (!props.xmppClient) return;
+  try {
+    await props.xmppClient.setCallHandRaised(!selfHandRaised.value);
+  } catch (err) {
+    reportCallError(err);
+  }
+}
 const selfSharePresentation = computed(() =>
   localScreenSharePresentation({
     screenShareEnabled: screenShareEnabled.value,
@@ -693,6 +725,7 @@ onBeforeUnmount(() => {
           :mic-enabled="micEnabled"
           :active-speaker-identities="activeSpeakerIdentities"
           :promoted-speaker-identity="promotedSpeakerIdentity"
+          :raised-hand-keys="raisedHandIdentityKeys"
           @open-participants="openCallParticipants"
         />
         <div class="call-expanded__reactions" aria-live="polite" aria-atomic="false">
@@ -757,6 +790,8 @@ onBeforeUnmount(() => {
         :self-view-hidden="selfViewHidden"
         :picture-in-picture-supported="pictureInPictureSupported"
         :picture-in-picture-active="pictureInPictureActive"
+        :raised-hand-available="isMucCall"
+        :raised-hand-active="selfHandRaised"
         @toggle-mic="toggleMic"
         @toggle-cam="toggleCam"
         @toggle-screen-share="toggleScreenShare"
@@ -769,6 +804,7 @@ onBeforeUnmount(() => {
         @set-view-mode="setCallViewMode"
         @toggle-self-view="toggleCallSelfViewHidden"
         @send-reaction="onSendInCallReaction"
+        @toggle-raised-hand="onToggleRaisedHand"
         @toggle-picture-in-picture="togglePictureInPicture"
         @hangup="onHangup"
       />

--- a/chat/src/components/calls/CallParticipantsPanel.vue
+++ b/chat/src/components/calls/CallParticipantsPanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, watch } from "vue";
-import { Mic, MicOff, Video, VideoOff, Volume2, VolumeX } from "lucide-vue-next";
+import { Hand, Mic, MicOff, Video, VideoOff, Volume2, VolumeX } from "lucide-vue-next";
 import {
   callVolumePercentToGain,
   type CallVolumeMixerRow,
@@ -80,6 +80,11 @@ function onResetAll(): void {
             aria-label="Speaking"
           />
           <span class="call-participants__name type-control truncate">{{ row.label }}</span>
+          <Hand
+            v-if="row.raisedHand"
+            class="call-participants__raised-hand"
+            aria-label="Hand raised"
+          />
           <span class="call-participants__media">
             <component
               :is="row.micOn ? Mic : MicOff"
@@ -188,6 +193,13 @@ function onResetAll(): void {
 .call-participants__name {
   flex: 1 1 auto;
   min-width: 0;
+}
+
+.call-participants__raised-hand {
+  flex: 0 0 auto;
+  width: 1rem;
+  height: 1rem;
+  color: oklch(0.78 0.16 85);
 }
 
 .call-participants__media {

--- a/chat/src/components/calls/CallSplitContainer.vue
+++ b/chat/src/components/calls/CallSplitContainer.vue
@@ -4,6 +4,7 @@ import { useStore } from "@nanostores/vue";
 import {
   $callState,
   $lastCallError,
+  reportCallError,
 } from "@/lib/calls/call-store";
 import { $callUiMode } from "@/lib/calls/ui-mode";
 import {
@@ -42,7 +43,13 @@ import {
   hashInCallReactionId,
   receiveInCallReaction,
 } from "@/lib/calls/in-call-reactions";
-import { barePeerJid } from "@/lib/xmpp/jid";
+import { barePeerJid, fullJidIdentityKey } from "@/lib/xmpp/jid";
+import {
+  $mucRaisedHands,
+  $selfRaisedHand,
+  raisedHandKeysForRoom,
+  selfRaisedHandFor,
+} from "@/lib/calls/call-raised-hand";
 import { expectedRemoteIdentitiesForCallState } from "@/lib/calls/call-tiles";
 import {
   projectCallTiles,
@@ -232,6 +239,21 @@ const callLabel = computed(() => {
 });
 
 const localIdentity = computed(() => engine.localIdentity);
+
+// #1029: raised-hand identity keys for the split-view tiles, self folded
+// in optimistically (mirrors CallExpandedSurface).
+const raisedHands = useStore($mucRaisedHands);
+const selfRaisedHandStore = useStore($selfRaisedHand);
+const raisedHandIdentityKeys = computed(() => {
+  const keys = new Set(
+    raisedHandKeysForRoom(normalizedRoomJid.value, raisedHands.value),
+  );
+  const selfKey = fullJidIdentityKey(localIdentity.value);
+  if (selfRaisedHandFor(normalizedRoomJid.value, selfRaisedHandStore.value) && selfKey) {
+    keys.add(selfKey);
+  }
+  return keys;
+});
 const selfSharePresentation = computed(() =>
   localScreenSharePresentation({
     screenShareEnabled: screenShareEnabled.value,
@@ -369,6 +391,22 @@ async function onSendInCallReaction(emoji: string): Promise<void> {
   }
 }
 
+// #1029: raise-hand toggle for the split-view control bar (MUC calls only).
+const isMucCall = computed(
+  () => state.value.phase === "active" && state.value.kind === "muc",
+);
+const selfHandRaised = computed(() =>
+  selfRaisedHandFor(normalizedRoomJid.value, selfRaisedHandStore.value),
+);
+async function onToggleRaisedHand(): Promise<void> {
+  if (!props.xmppClient) return;
+  try {
+    await props.xmppClient.setCallHandRaised(!selfHandRaised.value);
+  } catch (err) {
+    reportCallError(err);
+  }
+}
+
 function parkPictureInPicturePanel(): void {
   const panel = pictureInPicturePanelRef.value;
   const parking = pictureInPictureParkingRef.value;
@@ -494,6 +532,7 @@ async function togglePictureInPicture(): Promise<void> {
           :mic-enabled="micEnabled"
           :active-speaker-identities="activeSpeakerIdentities"
           :promoted-speaker-identity="promotedSpeakerIdentity"
+          :raised-hand-keys="raisedHandIdentityKeys"
           @open-participants="enterExpandedWithDock"
         />
         <div class="call-split__reactions" aria-live="polite" aria-atomic="false">
@@ -522,6 +561,8 @@ async function togglePictureInPicture(): Promise<void> {
           :self-view-hidden="selfViewHidden"
           :picture-in-picture-supported="pictureInPictureSupported"
           :picture-in-picture-active="pictureInPictureActive"
+          :raised-hand-available="isMucCall"
+          :raised-hand-active="selfHandRaised"
           @toggle-mic="toggleMic"
           @toggle-cam="toggleCam"
           @toggle-screen-share="toggleScreenShare"
@@ -532,6 +573,7 @@ async function togglePictureInPicture(): Promise<void> {
           @set-view-mode="setCallViewMode"
           @toggle-self-view="toggleCallSelfViewHidden"
           @send-reaction="onSendInCallReaction"
+          @toggle-raised-hand="onToggleRaisedHand"
           @toggle-picture-in-picture="togglePictureInPicture"
           @hangup="onHangup"
         />

--- a/chat/src/components/calls/CallTile.vue
+++ b/chat/src/components/calls/CallTile.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import { MicOff, ScreenShare } from "lucide-vue-next";
+import { Hand, MicOff, ScreenShare } from "lucide-vue-next";
 import { consistentColor } from "@/lib/chat-ui";
 import type { TileAttachable } from "@/lib/calls/tile-attach";
 
@@ -46,9 +46,13 @@ const props = withDefaults(defineProps<{
   /** Whether this participant is the (held) active speaker. Drives the
    *  highlight border in Gallery view. */
   speaking?: boolean;
+  /** Whether this participant advertises a raised hand (#1029). Drives
+   *  the nameplate hand badge. */
+  raisedHand?: boolean;
 }>(), {
   interactive: true,
   speaking: false,
+  raisedHand: false,
 });
 
 const initials = computed<string>(() => {
@@ -136,6 +140,13 @@ const emit = defineEmits<{
           aria-hidden="true"
         />
         {{ label }}
+      </span>
+      <span
+        v-if="raisedHand"
+        class="call-tile__raised-hand"
+        aria-label="Hand raised"
+      >
+        <Hand class="w-3.5 h-3.5" />
       </span>
       <span
         v-if="isSelf && !micEnabled"
@@ -333,6 +344,18 @@ const emit = defineEmits<{
   border-radius: 9999px;
   background: var(--destructive);
   color: var(--destructive-foreground);
+  flex-shrink: 0;
+}
+
+.call-tile__raised-hand {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 9999px;
+  background: oklch(0.78 0.16 85);
+  color: oklch(0.2 0.05 85);
   flex-shrink: 0;
 }
 </style>

--- a/chat/src/components/calls/CallTileGrid.vue
+++ b/chat/src/components/calls/CallTileGrid.vue
@@ -8,6 +8,7 @@ import { partitionStageTiles } from "@/lib/calls/stage-overflow";
 import type { CallTileModel } from "@/lib/calls/call-tiles";
 import { projectCallTiles, reconcileCallTileProjectionState } from "@/lib/calls/call-tile-projection";
 import { highlightedTileKeys } from "@/lib/calls/active-speakers";
+import { fullJidIdentityKey } from "@/lib/xmpp/jid";
 import {
   $callPinnedTileKey,
   $callSelfViewHidden,
@@ -61,6 +62,9 @@ const props = defineProps<{
   activeSpeakerIdentities?: ReadonlySet<string>;
   /** Participant the Speaker layout auto-promotes to the large tile. */
   promotedSpeakerIdentity?: string | null;
+  /** Identity keys (`fullJidIdentityKey`) of participants with a raised
+   *  hand (#1029); their camera tile shows the raised-hand badge. */
+  raisedHandKeys?: ReadonlySet<string>;
 }>();
 
 const emit = defineEmits<{
@@ -187,6 +191,21 @@ const speakingTileKeys = computed<ReadonlySet<string>>(() =>
   highlightedTileKeys(tiles.value, props.activeSpeakerIdentities ?? EMPTY_ACTIVE_SPEAKERS),
 );
 
+// Tile keys that carry the raised-hand badge (#1029). The raised-hand
+// store is keyed by `fullJidIdentityKey`, so normalize each tile's raw
+// LiveKit identity before matching. Like the speaker highlight, the badge
+// rides the person's camera tile, not their screen-share tile.
+const raisedHandTileKeys = computed<ReadonlySet<string>>(() => {
+  const raised = props.raisedHandKeys ?? EMPTY_ACTIVE_SPEAKERS;
+  if (raised.size === 0) return EMPTY_ACTIVE_SPEAKERS;
+  const keys = new Set<string>();
+  for (const tile of tiles.value) {
+    if (tile.source !== "camera") continue;
+    if (raised.has(fullJidIdentityKey(tile.identity))) keys.add(tile.key);
+  }
+  return keys;
+});
+
 // When the tile count exceeds the layout's capacity, the last cell becomes a
 // "+N more" Overflow tile instead of silently dropping people. `+N` counts the
 // participants who have no tile on the Stage; audio for them stays subscribed
@@ -223,6 +242,7 @@ const gridStyle = computed(() => ({
           :shows-presenting-glyph="focusedTile.showsPresentingGlyph"
           :mic-enabled="focusedTile.micEnabledHint"
           :video-track="focusedTile.videoTrack"
+          :raised-hand="raisedHandTileKeys.has(focusedTile.key)"
           :attach="attach"
           class="call-tile--focused"
           @activate="toggleFocus(focusedTile)"
@@ -239,6 +259,7 @@ const gridStyle = computed(() => ({
           :shows-presenting-glyph="tile.showsPresentingGlyph"
           :mic-enabled="tile.micEnabledHint"
           :video-track="tile.videoTrack"
+          :raised-hand="raisedHandTileKeys.has(tile.key)"
           :attach="attach"
           class="call-tile--thumb"
           @activate="toggleFocus(tile)"
@@ -267,6 +288,7 @@ const gridStyle = computed(() => ({
         :mic-enabled="tile.micEnabledHint"
         :video-track="tile.videoTrack"
         :speaking="speakingTileKeys.has(tile.key)"
+        :raised-hand="raisedHandTileKeys.has(tile.key)"
         :attach="attach"
         @activate="toggleFocus(tile)"
       />

--- a/chat/src/lib/calls/call-raised-hand.ts
+++ b/chat/src/lib/calls/call-raised-hand.ts
@@ -36,45 +36,52 @@ type RaisedHandAction =
 
 /**
  * Pure reducer over the room → identity-keys raised-hand record.
- * Never mutates `current`. Pruning an empty room keeps the record
- * free of stale keys so `Object.keys` reflects rooms with live hands.
+ * Never mutates `current`, and returns the SAME `current` reference for
+ * no-op updates (idempotent set, invalid room/id, clearing what's
+ * already absent) so a `$mucRaisedHands.set(...)` round-trip skips the
+ * store notification and avoids spurious rerenders. Pruning an empty
+ * room keeps the record free of stale keys so `Object.keys` reflects
+ * rooms with live hands.
  */
 export function reduceRaisedHands(
-  current: Record<string, readonly string[]>,
+  current: Record<string, string[]>,
   action: RaisedHandAction,
 ): Record<string, string[]> {
-  if (action.kind === "clear-all") return {};
+  if (action.kind === "clear-all") {
+    return Object.keys(current).length === 0 ? current : {};
+  }
 
   const room = normalizeMucCallRoomJid(action.roomJid);
-  const next = cloneRecord(current);
-  if (!room) return next;
+  if (!room) return current;
 
   if (action.kind === "clear-room") {
+    if (!(room in current)) return current;
+    const next = cloneRecord(current);
     delete next[room];
     return next;
   }
 
   const { identityKey, raised } = action;
-  if (!identityKey) return next;
-  const existing = next[room] ?? [];
+  if (!identityKey) return current;
+  const existing = current[room] ?? [];
   const has = existing.includes(identityKey);
 
   if (raised) {
-    if (has) return next;
+    if (has) return current;
+    const next = cloneRecord(current);
     next[room] = [...existing, identityKey].sort();
     return next;
   }
 
-  if (!has) return next;
+  if (!has) return current;
+  const next = cloneRecord(current);
   const filtered = existing.filter((key) => key !== identityKey);
   if (filtered.length === 0) delete next[room];
   else next[room] = filtered;
   return next;
 }
 
-function cloneRecord(
-  current: Record<string, readonly string[]>,
-): Record<string, string[]> {
+function cloneRecord(current: Record<string, string[]>): Record<string, string[]> {
   const next: Record<string, string[]> = {};
   for (const [room, keys] of Object.entries(current)) next[room] = [...keys];
   return next;

--- a/chat/src/lib/calls/call-raised-hand.ts
+++ b/chat/src/lib/calls/call-raised-hand.ts
@@ -1,0 +1,167 @@
+import { map } from "nanostores";
+import { fullJidIdentityKey } from "@/lib/xmpp/jid";
+import { normalizeMucCallRoomJid } from "./muc-call-presence";
+
+/**
+ * Per-room set of call participants advertising a raised hand
+ * (`urn:waddle:in-call:0` presence state, #1029). Keyed by normalized
+ * room JID, then by `fullJidIdentityKey` of the occupant's real full
+ * JID — the SAME identity key the call roster and tiles use — so the
+ * UI can join "who has a hand up" against the roster rows without a
+ * second lookup table.
+ *
+ * Fed by `applyRaisedHandPresence` from the chat-side presence wrapper:
+ * a MUC occupant's presence carries the raised-hand `<in-call>` child
+ * alongside `<muji/>` when up, and omits it when down. Leaving the call
+ * or the room clears the entry (lowered / unavailable presence).
+ *
+ * Shape: `{ "room@muc.host": ["alice@host/web", "bob@host/phone"] }`,
+ * each list sorted for stable render order.
+ */
+export const $mucRaisedHands = map<Record<string, string[]>>({});
+
+/**
+ * This client's own raised-hand state per room. Decoupled from the
+ * inbound `$mucRaisedHands` view so the control bar reflects the local
+ * intent immediately and every outbound call presence re-emits the
+ * current flag (presence is last-writer-wins, so a later video/media
+ * presence must not silently drop a raised hand).
+ */
+export const $selfRaisedHand = map<Record<string, boolean>>({});
+
+export type RaisedHandAction =
+  | { kind: "set"; roomJid: string; identityKey: string; raised: boolean }
+  | { kind: "clear-room"; roomJid: string }
+  | { kind: "clear-all" };
+
+/**
+ * Pure reducer over the room → identity-keys raised-hand record.
+ * Never mutates `current`. Pruning an empty room keeps the record
+ * free of stale keys so `Object.keys` reflects rooms with live hands.
+ */
+export function reduceRaisedHands(
+  current: Record<string, readonly string[]>,
+  action: RaisedHandAction,
+): Record<string, string[]> {
+  if (action.kind === "clear-all") return {};
+
+  const room = normalizeMucCallRoomJid(action.roomJid);
+  const next = cloneRecord(current);
+  if (!room) return next;
+
+  if (action.kind === "clear-room") {
+    delete next[room];
+    return next;
+  }
+
+  const { identityKey, raised } = action;
+  if (!identityKey) return next;
+  const existing = next[room] ?? [];
+  const has = existing.includes(identityKey);
+
+  if (raised) {
+    if (has) return next;
+    next[room] = [...existing, identityKey].sort();
+    return next;
+  }
+
+  if (!has) return next;
+  const filtered = existing.filter((key) => key !== identityKey);
+  if (filtered.length === 0) delete next[room];
+  else next[room] = filtered;
+  return next;
+}
+
+function cloneRecord(
+  current: Record<string, readonly string[]>,
+): Record<string, string[]> {
+  const next: Record<string, string[]> = {};
+  for (const [room, keys] of Object.entries(current)) next[room] = [...keys];
+  return next;
+}
+
+/** Minimal inbound presence shape this module reads. */
+export type RaisedHandPresence = {
+  from?: string;
+  presence_type?: string;
+  muc_jid?: string | null;
+  hand_raised?: boolean;
+};
+
+/**
+ * Map an inbound MUC presence to a raised-hand `set` action, or `null`
+ * when it carries no usable occupant identity. The occupant's real full
+ * JID (`muc_jid`) is the join key; an anonymous presence without one is
+ * ignored. An unavailable presence or a missing flag both lower the
+ * hand. Pure — the store side effect lives in `applyRaisedHandPresence`.
+ */
+export function raisedHandPresenceUpdate(
+  presence: RaisedHandPresence,
+): Extract<RaisedHandAction, { kind: "set" }> | null {
+  if (!presence.from) return null;
+  const slash = presence.from.indexOf("/");
+  if (slash < 0) return null;
+  const roomJid = normalizeMucCallRoomJid(presence.from.slice(0, slash));
+  if (!roomJid) return null;
+  const identityKey = fullJidIdentityKey(presence.muc_jid);
+  if (!identityKey) return null;
+  const raised = presence.presence_type !== "unavailable" && presence.hand_raised === true;
+  return { kind: "set", roomJid, identityKey, raised };
+}
+
+/** Apply an inbound presence's raised-hand state to the store. */
+export function applyRaisedHandPresence(presence: RaisedHandPresence): void {
+  const action = raisedHandPresenceUpdate(presence);
+  if (!action) return;
+  $mucRaisedHands.set(reduceRaisedHands($mucRaisedHands.get(), action));
+}
+
+/** Identity keys with a raised hand in `roomJid` (empty set if none). */
+export function raisedHandKeysForRoom(
+  roomJid: string,
+  raisedByRoom: Record<string, readonly string[]> = $mucRaisedHands.get(),
+): Set<string> {
+  const room = normalizeMucCallRoomJid(roomJid);
+  if (!room) return new Set();
+  return new Set(raisedByRoom[room] ?? []);
+}
+
+/** Whether this client currently advertises a raised hand in `roomJid`. */
+export function selfRaisedHandFor(
+  roomJid: string,
+  selfByRoom: Record<string, boolean> = $selfRaisedHand.get(),
+): boolean {
+  const room = normalizeMucCallRoomJid(roomJid);
+  return room ? selfByRoom[room] === true : false;
+}
+
+/** Set this client's own raised-hand intent for `roomJid`. */
+export function setSelfRaisedHand(roomJid: string, raised: boolean): void {
+  const room = normalizeMucCallRoomJid(roomJid);
+  if (!room) return;
+  if (raised) $selfRaisedHand.setKey(room, true);
+  else {
+    const next = { ...$selfRaisedHand.get() };
+    delete next[room];
+    $selfRaisedHand.set(next);
+  }
+}
+
+/** Drop all raised-hand state for a room (e.g. when the local call ends). */
+export function clearRaisedHandsForRoom(roomJid: string): void {
+  $mucRaisedHands.set(
+    reduceRaisedHands($mucRaisedHands.get(), { kind: "clear-room", roomJid }),
+  );
+  const room = normalizeMucCallRoomJid(roomJid);
+  if (room && room in $selfRaisedHand.get()) {
+    const next = { ...$selfRaisedHand.get() };
+    delete next[room];
+    $selfRaisedHand.set(next);
+  }
+}
+
+/** Forget every raised hand (logout / disconnect). */
+export function clearAllRaisedHands(): void {
+  $mucRaisedHands.set({});
+  $selfRaisedHand.set({});
+}

--- a/chat/src/lib/calls/call-raised-hand.ts
+++ b/chat/src/lib/calls/call-raised-hand.ts
@@ -29,7 +29,7 @@ export const $mucRaisedHands = map<Record<string, string[]>>({});
  */
 export const $selfRaisedHand = map<Record<string, boolean>>({});
 
-export type RaisedHandAction =
+type RaisedHandAction =
   | { kind: "set"; roomJid: string; identityKey: string; raised: boolean }
   | { kind: "clear-room"; roomJid: string }
   | { kind: "clear-all" };
@@ -81,7 +81,7 @@ function cloneRecord(
 }
 
 /** Minimal inbound presence shape this module reads. */
-export type RaisedHandPresence = {
+type RaisedHandPresence = {
   from?: string;
   presence_type?: string;
   muc_jid?: string | null;
@@ -141,19 +141,6 @@ export function setSelfRaisedHand(roomJid: string, raised: boolean): void {
   if (!room) return;
   if (raised) $selfRaisedHand.setKey(room, true);
   else {
-    const next = { ...$selfRaisedHand.get() };
-    delete next[room];
-    $selfRaisedHand.set(next);
-  }
-}
-
-/** Drop all raised-hand state for a room (e.g. when the local call ends). */
-export function clearRaisedHandsForRoom(roomJid: string): void {
-  $mucRaisedHands.set(
-    reduceRaisedHands($mucRaisedHands.get(), { kind: "clear-room", roomJid }),
-  );
-  const room = normalizeMucCallRoomJid(roomJid);
-  if (room && room in $selfRaisedHand.get()) {
     const next = { ...$selfRaisedHand.get() };
     delete next[room];
     $selfRaisedHand.set(next);

--- a/chat/src/lib/calls/call-roster.ts
+++ b/chat/src/lib/calls/call-roster.ts
@@ -17,6 +17,8 @@ export type CallRosterRow = {
   micOn: boolean;
   cameraOn: boolean;
   speaking: boolean;
+  /** True when this attendee advertises a raised hand (#1029). */
+  raisedHand: boolean;
   volumeRows: CallVolumeMixerRow[];
 };
 
@@ -28,6 +30,13 @@ export type BuildCallRosterInput = {
   localCameraEnabled: boolean;
   activeSpeakerIdentities: ReadonlySet<string>;
   volumeRows: readonly CallVolumeMixerRow[];
+  /**
+   * Identity keys (`fullJidIdentityKey`) of remote attendees with a
+   * raised hand (#1029). Defaults to empty.
+   */
+  raisedHandKeys?: ReadonlySet<string>;
+  /** Whether this client currently advertises a raised hand. */
+  selfRaisedHand?: boolean;
 };
 
 type MediaState = { micOn: boolean; cameraOn: boolean };
@@ -65,6 +74,8 @@ export function buildCallRoster(input: BuildCallRosterInput): CallRosterRow[] {
   // this same key so a remote can never collide with the self row.
   const selfRowKey = selfKey || "self";
 
+  const raisedHandKeys = input.raisedHandKeys ?? new Set<string>();
+
   const rows: CallRosterRow[] = [];
   rows.push({
     key: selfRowKey,
@@ -74,6 +85,7 @@ export function buildCallRoster(input: BuildCallRosterInput): CallRosterRow[] {
     micOn: input.localMicEnabled,
     cameraOn: input.localCameraEnabled,
     speaking: speakingKeys.has(selfKey),
+    raisedHand: input.selfRaisedHand === true || raisedHandKeys.has(selfKey),
     volumeRows: [],
   });
 
@@ -98,6 +110,7 @@ export function buildCallRoster(input: BuildCallRosterInput): CallRosterRow[] {
       micOn: media.micOn,
       cameraOn: media.cameraOn,
       speaking: speakingKeys.has(key),
+      raisedHand: raisedHandKeys.has(key),
       volumeRows: volumeRowsByKey.get(key) ?? [],
     });
   }

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -17,6 +17,7 @@ import {
   rememberMucCallSession,
 } from "./muc-call-session-cache";
 import { clearLiveCallParticipants } from "./muc-call-live-participants";
+import { selfRaisedHandFor, setSelfRaisedHand } from "./call-raised-hand";
 import { mediaErrorMessage } from "./call-media-issues";
 import {
   dmCallStartedAnchorFromTransition,
@@ -694,6 +695,7 @@ export async function tearDownActiveCall(
                   false, // active
                   false, // preparing
                   false, // video
+                    false, // hand_raised
                 );
               } catch (err) {
                 reportCallError(err);
@@ -751,6 +753,7 @@ export async function tearDownActiveCall(
                   false,
                   false,
                   false,
+                  false, // hand_raised
                 );
               } catch (err) {
                 reportCallError(err);
@@ -819,6 +822,7 @@ export type RawIqSender = {
     active: boolean,
     preparing: boolean,
     video: boolean,
+    hand_raised: boolean,
   ) => Promise<void>;
 };
 
@@ -884,6 +888,7 @@ async function rollbackMucCallSetup(
         false,
         false,
         false,
+        false, // hand_raised
       );
     } catch (err) {
       reportCallError(err);
@@ -980,6 +985,9 @@ export async function beginMucCall(
   if (!normalizedRoomJid) {
     throw new Error("Cannot start a group call without a room JID");
   }
+  // Fresh call: a hand left raised from a prior session in this room must
+  // not silently re-raise on the new active presence (#1029).
+  setSelfRaisedHand(normalizedRoomJid, false);
   if (!selfNick) {
     throw new Error("Cannot start a group call before MUC presence has a nick");
   }
@@ -1026,6 +1034,7 @@ export async function beginMucCall(
       false, // active (no <content/> yet)
       true, // preparing
       false, // video — irrelevant in preparing phase
+      false, // hand_raised — a hand can't be raised before joining
     );
     assertMucSetupStillPending(normalizedRoomJid, selfNick, attemptId);
     // XEP-0272 §Joining: "The client MUST then wait until the MUC
@@ -1051,6 +1060,7 @@ export async function beginMucCall(
       true, // active
       false, // preparing
       media.video, // video
+      selfRaisedHandFor(normalizedRoomJid), // hand_raised — preserve across re-emit
     );
     if (!mucSetupStillPending(normalizedRoomJid, selfNick, attemptId)) {
       await rollbackMucCallSetup(

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -695,12 +695,13 @@ export async function tearDownActiveCall(
                   false, // active
                   false, // preparing
                   false, // video
-                    false, // hand_raised
+                  false, // hand_raised
                 );
               } catch (err) {
                 reportCallError(err);
               } finally {
                 clearMucCallParticipant(s.peer, s.selfNick, s.selfFullJid);
+                setSelfRaisedHand(s.peer, false);
               }
             }
             clearLiveCallParticipants(s.peer);
@@ -759,6 +760,7 @@ export async function tearDownActiveCall(
                 reportCallError(err);
               } finally {
                 clearMucCallParticipant(s.peer, s.selfNick, s.selfFullJid);
+                setSelfRaisedHand(s.peer, false);
               }
             }
             if (s.activePresencePublished) {

--- a/chat/src/lib/calls/muc-call-actions.ts
+++ b/chat/src/lib/calls/muc-call-actions.ts
@@ -316,7 +316,12 @@ export async function setMucCallHandRaised(
     );
     return true;
   } catch (err) {
-    setSelfRaisedHand(roomJid, !raised); // revert optimistic flip
+    // Revert the optimistic flip — but only if a newer toggle hasn't
+    // already superseded it (rapid click / double tap), so we don't
+    // clobber the latest user intent with this stale request's rollback.
+    if (selfRaisedHandFor(roomJid) === raised) {
+      setSelfRaisedHand(roomJid, !raised);
+    }
     reportCallError(err);
     return false;
   }

--- a/chat/src/lib/calls/muc-call-actions.ts
+++ b/chat/src/lib/calls/muc-call-actions.ts
@@ -1,6 +1,7 @@
 import { $callState, beginMucCall, reportCallError, type RawIqSender } from "./call-store";
 import { LIVEKIT_JOIN_EXPIRY_SKEW_MS, liveKitJoinTokenExpiresAt } from "./dm-call-activity";
-import { clearMucCallParticipant } from "./muc-call-presence";
+import { clearMucCallParticipant, normalizeMucCallRoomJid } from "./muc-call-presence";
+import { selfRaisedHandFor, setSelfRaisedHand } from "./call-raised-hand";
 import {
   forgetMucCallSession,
   markMucCallSessionTerminatePending,
@@ -112,6 +113,7 @@ export async function leaveRetainedMucCallAction({
       false,
       false,
       false,
+      false, // hand_raised
     );
     clearMucCallParticipant(roomJid, selfNick, selfFullJid, {
       includeAggregate: true,
@@ -266,6 +268,7 @@ export async function resumeMucCallActivity({
         true, // active
         false, // preparing
         media.video,
+        selfRaisedHandFor(session.roomJid), // hand_raised — preserve across resume
       );
     } catch (err) {
       reportCallError(err);
@@ -273,4 +276,48 @@ export async function resumeMucCallActivity({
   }
 
   return true;
+}
+
+/**
+ * Raise or lower this client's hand in the active MUC call (#1029).
+ *
+ * The raised-hand state is a XEP-0045 presence extension carried
+ * alongside `<muji/>`, so "setting" it means re-emitting our current
+ * active call presence with the flag toggled — the wasm FFI builds the
+ * `<in-call><hand-raised/></in-call>` child when `raised` is true and
+ * omits it (lowering for everyone) when false. We optimistically record
+ * the local intent first so the control bar flips immediately and any
+ * later media re-emit preserves the flag; a send failure reverts it.
+ *
+ * No-op (returns `false`) unless we're in an active MUC call with a
+ * known nick and a wasm client that exposes the presence FFI.
+ */
+export async function setMucCallHandRaised(
+  sender: RawIqSender,
+  raised: boolean,
+): Promise<boolean> {
+  const state = $callState.get();
+  if (state.phase !== "active" || state.kind !== "muc" || !state.selfNick) {
+    return false;
+  }
+  if (!sender.update_muji_presence) return false;
+  const roomJid = normalizeMucCallRoomJid(state.peer);
+  if (!roomJid) return false;
+
+  setSelfRaisedHand(roomJid, raised);
+  try {
+    await sender.update_muji_presence(
+      roomJid,
+      state.selfNick,
+      true, // active — still in the call
+      false, // preparing
+      state.media.video,
+      raised,
+    );
+    return true;
+  } catch (err) {
+    setSelfRaisedHand(roomJid, !raised); // revert optimistic flip
+    reportCallError(err);
+    return false;
+  }
 }

--- a/chat/src/lib/calls/use-call-roster.ts
+++ b/chat/src/lib/calls/use-call-roster.ts
@@ -3,6 +3,12 @@ import { useStore } from "@nanostores/vue";
 import { $callState } from "./call-store";
 import { $callCamEnabled, $callMicEnabled } from "./call-controls";
 import { $mucCallLiveParticipants } from "./muc-call-live-participants";
+import {
+  $mucRaisedHands,
+  $selfRaisedHand,
+  raisedHandKeysForRoom,
+  selfRaisedHandFor,
+} from "./call-raised-hand";
 import { useCallEngine } from "./use-call-engine";
 import { useCallVolumeMixer } from "./use-call-volume-mixer";
 import { remoteParticipantIdentitiesForCall } from "./call-remote-identities";
@@ -32,6 +38,8 @@ export function useCallRoster(
   const camEnabled = useStore($callCamEnabled);
   const { remoteTracks, activeSpeakerIdentities } = useCallEngine();
   const volumeMixer = useCallVolumeMixer(normalizedRoomJid);
+  const raisedHands = useStore($mucRaisedHands);
+  const selfRaisedHand = useStore($selfRaisedHand);
 
   // Reactive local identity from the active call's LiveKit join, NOT the
   // engine's non-reactive `localIdentity` getter. A `computed` over the
@@ -62,6 +70,8 @@ export function useCallRoster(
       localCameraEnabled: camEnabled.value,
       activeSpeakerIdentities: activeSpeakerIdentities.value,
       volumeRows: volumeMixer.rows.value,
+      raisedHandKeys: raisedHandKeysForRoom(normalizedRoomJid.value, raisedHands.value),
+      selfRaisedHand: selfRaisedHandFor(normalizedRoomJid.value, selfRaisedHand.value),
     }),
   );
 

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -11,7 +11,8 @@ import {
   removeQueuedMessage,
   type PersistedQueuedDmMessage,
 } from "../outbound-queue-store";
-import { $callState, applyCallEvent, clearCallState, tearDownActiveCall } from "@/lib/calls/call-store";
+import { $callState, applyCallEvent, clearCallState, tearDownActiveCall, type RawIqSender } from "@/lib/calls/call-store";
+import { setMucCallHandRaised } from "@/lib/calls/muc-call-actions";
 import {
   DM_CALL_ACTIVITY_ACTIVE_WINDOW_MS,
   applyDmCallEvent,
@@ -23,6 +24,10 @@ import {
   applyMucCallPresence,
   clearMucCallParticipants,
 } from "@/lib/calls/muc-call-presence";
+import {
+  applyRaisedHandPresence,
+  clearAllRaisedHands,
+} from "@/lib/calls/call-raised-hand";
 import { clearAllLiveCallParticipants } from "@/lib/calls/muc-call-live-participants";
 import { useCallEngine } from "@/lib/calls/use-call-engine";
 import type { CallWireSender } from "@/lib/calls/outbound";
@@ -1306,6 +1311,7 @@ export class BrowserXmppClient {
     clearDmCallJoinCacheForAccount(this.session.jid);
     clearDmCallActivities();
     clearMucCallParticipants();
+    clearAllRaisedHands();
     clearAllLiveCallParticipants();
     // Best-effort hangup: if we're in a call when the user logs out
     // we want the peer to see session-terminate before the stream
@@ -1879,6 +1885,18 @@ export class BrowserXmppClient {
   async sendDisplayed(spaceId: string, channelId: string, messageId: string, thread?: { id: string; parent?: string }) { const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId); await this.compatSendDisplayed(xmpp, roomJid, "groupchat", messageId, thread); }
   async sendReaction(spaceId: string, channelId: string, messageId: string, emojis: string[], thread?: { id: string; parent?: string }) { const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId); await this.compatSendReaction(xmpp, roomJid, "groupchat", messageId, emojis, thread); }
   async sendInCallReaction(spaceId: string, channelId: string, sid: string, emoji: string) { const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId); await this.compatSendInCallReaction(xmpp, roomJid, "groupchat", sid, emoji); }
+  /**
+   * #1029: raise or lower this client's hand in the active MUC call. The
+   * raised-hand state is a presence extension carried alongside `<muji/>`,
+   * so this re-emits the active call presence with the flag toggled. The
+   * call-action reads the active call's room/nick/video from `$callState`;
+   * this wrapper only supplies the raw wasm sender. Returns whether the
+   * presence was emitted (no-op outside an active MUC call).
+   */
+  async setCallHandRaised(raised: boolean): Promise<boolean> {
+    const xmpp = await this.requireConnectedXmpp();
+    return setMucCallHandRaised(xmpp as unknown as RawIqSender, raised);
+  }
   /** #414: pin a message in the room. Server gates on Owner/Admin
    * affiliation; non-admins receive a `<forbidden/>` error which
    * surfaces as a rejected Promise. */
@@ -3472,6 +3490,7 @@ export class BrowserXmppClient {
     // connected).
     clearCallState();
     clearMucCallParticipants();
+    clearAllRaisedHands();
     clearAllLiveCallParticipants();
     void useCallEngine().engine.disconnect();
     this.rejectRoomJoinWaiters(new Error("XMPP disconnected while joining a room"));
@@ -3902,6 +3921,9 @@ export class BrowserXmppClient {
       // (channel header, sidebar, list) can render "N in call"
       // without subscribing to the raw presence stream.
       applyMucCallPresence(presence);
+      // #1029: the raised-hand `<in-call>` presence state rides the same
+      // stanza; mirror it into the per-room raised-hand store.
+      applyRaisedHandPresence(presence);
     });
     xmpp.set_on_message_delivery_acked?.((id: string) => {
       if (!this.isCurrentXmpp(xmpp)) return;
@@ -4007,6 +4029,7 @@ export class BrowserXmppClient {
       if (!this.isCurrentXmpp(xmpp)) return;
       this.handlePresence(presence);
       applyMucCallPresence(presence);
+      applyRaisedHandPresence(presence);
     });
   }
 }

--- a/chat/src/lib/xmpp/wasm-types.ts
+++ b/chat/src/lib/xmpp/wasm-types.ts
@@ -245,6 +245,13 @@ export interface WasmPresence {
   muc_status_codes?: number[];
   vcard_avatar?: string;
   muji?: WasmMujiPresence;
+  /**
+   * Waddle raised-hand call presence state (#1029). `true` when the
+   * occupant's presence carries
+   * `<in-call xmlns='urn:waddle:in-call:0'><hand-raised/></in-call>`
+   * alongside `<muji/>`. Absent/false means the hand is lowered.
+   */
+  hand_raised?: boolean;
 }
 
 /**

--- a/chat/tests/call-raised-hand.test.ts
+++ b/chat/tests/call-raised-hand.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  raisedHandPresenceUpdate,
+  reduceRaisedHands,
+} from "../src/lib/calls/call-raised-hand";
+
+describe("raised-hand reducer", () => {
+  test("set raises a participant's hand keyed by identity", () => {
+    const next = reduceRaisedHands(
+      {},
+      {
+        kind: "set",
+        roomJid: "room@muc.test",
+        identityKey: "alice@muc.test/web",
+        raised: true,
+      },
+    );
+    expect(next).toEqual({ "room@muc.test": ["alice@muc.test/web"] });
+  });
+
+  test("lowering removes the participant and prunes the empty room", () => {
+    const raised = { "room@muc.test": ["alice@muc.test/web"] };
+    const next = reduceRaisedHands(raised, {
+      kind: "set",
+      roomJid: "room@muc.test",
+      identityKey: "alice@muc.test/web",
+      raised: false,
+    });
+    expect(next).toEqual({});
+  });
+
+  test("a second raised hand coexists and the list stays sorted", () => {
+    let state = reduceRaisedHands(
+      {},
+      { kind: "set", roomJid: "r@muc.test", identityKey: "bob@muc.test/x", raised: true },
+    );
+    state = reduceRaisedHands(state, {
+      kind: "set",
+      roomJid: "r@muc.test",
+      identityKey: "alice@muc.test/y",
+      raised: true,
+    });
+    expect(state["r@muc.test"]).toEqual(["alice@muc.test/y", "bob@muc.test/x"]);
+  });
+
+  test("raising an already-raised hand is idempotent", () => {
+    const raised = { "r@muc.test": ["a@muc.test/1"] };
+    const next = reduceRaisedHands(raised, {
+      kind: "set",
+      roomJid: "r@muc.test",
+      identityKey: "a@muc.test/1",
+      raised: true,
+    });
+    expect(next).toEqual(raised);
+  });
+
+  test("clear-room drops only that room", () => {
+    const state = { r1: ["a@x/1"], r2: ["b@x/1"] };
+    expect(reduceRaisedHands(state, { kind: "clear-room", roomJid: "r1" })).toEqual({
+      r2: ["b@x/1"],
+    });
+  });
+
+  test("does not mutate the input record", () => {
+    const input = { "r@muc.test": ["a@x/1"] };
+    const snapshot = structuredClone(input);
+    reduceRaisedHands(input, {
+      kind: "set",
+      roomJid: "r@muc.test",
+      identityKey: "b@x/2",
+      raised: true,
+    });
+    expect(input).toEqual(snapshot);
+  });
+});
+
+describe("raisedHandPresenceUpdate", () => {
+  test("maps an active raised-hand presence to a set action keyed by real JID", () => {
+    expect(
+      raisedHandPresenceUpdate({
+        from: "room@muc.test/alice",
+        muc_jid: "alice@host/web",
+        hand_raised: true,
+      }),
+    ).toEqual({
+      kind: "set",
+      roomJid: "room@muc.test",
+      identityKey: "alice@host/web",
+      raised: true,
+    });
+  });
+
+  test("absent hand_raised lowers the hand", () => {
+    expect(
+      raisedHandPresenceUpdate({
+        from: "room@muc.test/alice",
+        muc_jid: "alice@host/web",
+      })?.raised,
+    ).toBe(false);
+  });
+
+  test("unavailable presence lowers the hand even when the flag is set", () => {
+    expect(
+      raisedHandPresenceUpdate({
+        from: "room@muc.test/alice",
+        presence_type: "unavailable",
+        muc_jid: "alice@host/web",
+        hand_raised: true,
+      })?.raised,
+    ).toBe(false);
+  });
+
+  test("returns null when the occupant's real JID is unknown", () => {
+    expect(
+      raisedHandPresenceUpdate({ from: "room@muc.test/alice", hand_raised: true }),
+    ).toBeNull();
+  });
+});

--- a/chat/tests/call-raised-hand.test.ts
+++ b/chat/tests/call-raised-hand.test.ts
@@ -62,6 +62,35 @@ describe("raised-hand reducer", () => {
     });
   });
 
+  test("returns the same reference for no-op updates (no spurious rerenders)", () => {
+    const state = { "r@muc.test": ["a@x/1"] };
+    // Raising an already-raised hand.
+    expect(
+      reduceRaisedHands(state, {
+        kind: "set",
+        roomJid: "r@muc.test",
+        identityKey: "a@x/1",
+        raised: true,
+      }),
+    ).toBe(state);
+    // Lowering a hand that was never raised.
+    expect(
+      reduceRaisedHands(state, {
+        kind: "set",
+        roomJid: "r@muc.test",
+        identityKey: "nobody@x/1",
+        raised: false,
+      }),
+    ).toBe(state);
+    // clear-room for a room with no raised hands.
+    expect(
+      reduceRaisedHands(state, { kind: "clear-room", roomJid: "other@muc.test" }),
+    ).toBe(state);
+    // clear-all on an already-empty record.
+    const empty = {};
+    expect(reduceRaisedHands(empty, { kind: "clear-all" })).toBe(empty);
+  });
+
   test("does not mutate the input record", () => {
     const input = { "r@muc.test": ["a@x/1"] };
     const snapshot = structuredClone(input);

--- a/chat/tests/call-roster.test.ts
+++ b/chat/tests/call-roster.test.ts
@@ -45,6 +45,39 @@ describe("buildCallRoster", () => {
     ]);
   });
 
+  test("flags raised hands by identity, including self", () => {
+    const rows = buildCallRoster({
+      remoteParticipantIdentities: [
+        "alice@waddle.test/web",
+        "bob@waddle.test/desktop",
+      ],
+      remoteTracks: [],
+      localIdentity: "me@waddle.test/browser",
+      localMicEnabled: true,
+      localCameraEnabled: false,
+      activeSpeakerIdentities: new Set<string>(),
+      volumeRows: [],
+      raisedHandKeys: new Set<string>(["alice@waddle.test/web"]),
+      selfRaisedHand: true,
+    });
+
+    const byLabel = Object.fromEntries(rows.map((row) => [row.label, row.raisedHand]));
+    expect(byLabel).toEqual({ You: true, alice: true, bob: false });
+  });
+
+  test("defaults raisedHand to false when no raised-hand input is given", () => {
+    const rows = buildCallRoster({
+      remoteParticipantIdentities: ["alice@waddle.test/web"],
+      remoteTracks: [],
+      localIdentity: "me@waddle.test/browser",
+      localMicEnabled: true,
+      localCameraEnabled: false,
+      activeSpeakerIdentities: new Set<string>(),
+      volumeRows: [],
+    });
+    expect(rows.every((row) => row.raisedHand === false)).toBe(true);
+  });
+
   test("derives mic and camera state from each remote participant's tracks", () => {
     const rows = buildCallRoster({
       remoteParticipantIdentities: [

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -1070,6 +1070,7 @@ describe("leaveRetainedMucCallAction", () => {
       false,
       false,
       false,
+      false,
     );
     expect($mucCallParticipants.get()).toEqual({
       "chan@muc.test": ["alice"],
@@ -1098,6 +1099,7 @@ describe("leaveRetainedMucCallAction", () => {
     expect(sender.update_muji_presence).toHaveBeenCalledWith(
       "chan@muc.test",
       "alice",
+      false,
       false,
       false,
       false,
@@ -1137,7 +1139,7 @@ describe("leaveRetainedMucCallAction", () => {
     })).resolves.toBe(true);
 
     expect(sent).toEqual([
-      ["presence", "chan@muc.test", "alice", false, false, false],
+      ["presence", "chan@muc.test", "alice", false, false, false, false],
       ["terminate", "chan@muc.test", "muc-recovered-live"],
     ]);
     expect($mucCallParticipants.get()).toEqual({});
@@ -1180,6 +1182,7 @@ describe("leaveRetainedMucCallAction", () => {
     expect(sender.update_muji_presence).toHaveBeenCalledWith(
       "chan@muc.test",
       "alice",
+      false,
       false,
       false,
       false,
@@ -1230,6 +1233,7 @@ describe("leaveRetainedMucCallAction", () => {
     expect(sender.update_muji_presence).toHaveBeenCalledWith(
       "chan@muc.test",
       "alice",
+      false,
       false,
       false,
       false,
@@ -2021,6 +2025,7 @@ describe("MUC group call", () => {
       true,
       false,
       true,
+      false,
     );
     expect(send_muji_session_initiate).toHaveBeenCalledTimes(1);
     expect($callState.get()).toMatchObject({
@@ -2200,6 +2205,7 @@ describe("MUC group call", () => {
       false,
       false,
       false,
+      false,
     );
     expect($callState.get()).toEqual({ phase: "idle" });
   });
@@ -2349,6 +2355,7 @@ describe("MUC group call", () => {
       false, // active
       true, // preparing
       false, // video — irrelevant in preparing phase
+      false, // hand_raised
     );
     expect(update_muji_presence).toHaveBeenNthCalledWith(
       2,
@@ -2357,6 +2364,7 @@ describe("MUC group call", () => {
       true, // active
       false, // preparing
       true, // video (audioVideo fixture has video=true)
+      false, // hand_raised
     );
     expect(send_muji_session_initiate).toHaveBeenCalledTimes(1);
   });
@@ -2391,6 +2399,7 @@ describe("MUC group call", () => {
       false, // active
       false, // preparing
       false, // video
+      false, // hand_raised
     );
     expect($callState.get()).toEqual({ phase: "idle" });
   });
@@ -2427,6 +2436,7 @@ describe("MUC group call", () => {
       false, // active
       false, // preparing
       false, // video
+      false, // hand_raised
     );
     expect($callState.get()).toEqual({ phase: "idle" });
   });

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -221,6 +221,11 @@ pub async fn handle_muc_join(
         .iter()
         .find(|existing| existing.nick == nick && existing.jid == *sender_jid)
         .and_then(|existing| existing.muji.as_ref());
+    let self_hand_raised = join_outcome
+        .existing_occupants
+        .iter()
+        .find(|existing| existing.nick == nick && existing.jid == *sender_jid)
+        .is_some_and(|existing| existing.hand_raised);
 
     info!(room = %room_jid, nick = %nick, occupants = occupant_count, "User joined MUC room");
 
@@ -275,12 +280,13 @@ pub async fn handle_muc_join(
             real_jid: &existing.jid,
             include_self_status: false,
             muji: existing.muji.as_ref(),
+            hand_raised: existing.hand_raised,
         }));
 
         for extra in replay_occupants.iter().copied().filter(|candidate| {
             candidate.nick == existing.nick
                 && candidate.jid != existing.jid
-                && candidate.muji.is_some()
+                && (candidate.muji.is_some() || candidate.hand_raised)
         }) {
             responses.push(build_muc_join_presence_xml(MucJoinPresence {
                 occupant_id_secret: &state.deps.occupant_id_secret,
@@ -292,6 +298,7 @@ pub async fn handle_muc_join(
                 real_jid: &extra.jid,
                 include_self_status: false,
                 muji: extra.muji.as_ref(),
+                hand_raised: extra.hand_raised,
             }));
         }
     }
@@ -333,6 +340,7 @@ pub async fn handle_muc_join(
         real_jid: sender_jid,
         include_self_status: true,
         muji: self_muji,
+        hand_raised: self_hand_raised,
     }));
 
     // Same-account sibling resources share one MUC nick. If a
@@ -345,7 +353,7 @@ pub async fn handle_muc_join(
         existing.nick == nick
             && existing.jid.to_bare() == sender_jid.to_bare()
             && existing.jid != *sender_jid
-            && existing.muji.is_some()
+            && (existing.muji.is_some() || existing.hand_raised)
     }) {
         responses.push(build_muc_join_presence_xml(MucJoinPresence {
             occupant_id_secret: &state.deps.occupant_id_secret,
@@ -357,6 +365,7 @@ pub async fn handle_muc_join(
             real_jid: &existing.jid,
             include_self_status: true,
             muji: existing.muji.as_ref(),
+            hand_raised: existing.hand_raised,
         }));
     }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc/xml.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc/xml.rs
@@ -17,6 +17,12 @@ pub(crate) struct MucJoinPresence<'a> {
     /// self-presence and for occupants without an active Muji
     /// advertisement.
     pub(crate) muji: Option<&'a waddle_xmpp::xep::xep0272::Muji>,
+    /// Whether to append an `<in-call><hand-raised/></in-call>`
+    /// (`urn:waddle:in-call:0`, #1029) payload alongside `<muji/>`. Set
+    /// for the join-replay path when the occupant being replayed has a
+    /// raised hand, so a late joiner sees it immediately. `false` for
+    /// joiners' own self-presence and for occupants with no raised hand.
+    pub(crate) hand_raised: bool,
 }
 
 pub(crate) fn build_muc_join_presence_xml(params: MucJoinPresence<'_>) -> String {
@@ -55,6 +61,16 @@ pub(super) fn build_muc_join_presence_stanza(
         // helper — never with `format!`-style XML concat (CLAUDE.md
         // XML hard rule).
         presence.payloads.push(muji.to_element());
+    }
+    if params.hand_raised {
+        // The raised-hand `<in-call>` state is a sibling of `<muji>`
+        // (never nested), an additional namespaced presence extension
+        // per XEP-0045 §5.1.3. Built via the typed carrier helper.
+        presence
+            .payloads
+            .push(waddle_xmpp::xep::build_in_call_presence_state_element(
+                &waddle_xmpp::xep::InCallPresenceState { hand_raised: true },
+            ));
     }
     presence
 }
@@ -164,5 +180,6 @@ pub(super) fn create_presence_stanza(
         real_jid,
         include_self_status: false,
         muji: None,
+        hand_raised: false,
     })
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
@@ -248,10 +248,21 @@ pub(super) async fn try_handle_muc_presence_update(
     // session's hand). The sender was already confirmed as an occupant
     // via the muji upsert above, so a `None`/error here just means no
     // hand state to reflect.
+    // Enforce the invariant "raised hand <-> active call participant"
+    // server-side: when this stanza is the XEP-0272 leave marker
+    // (`clears_muji_presence`), the occupant is no longer in the call, so the
+    // hand MUST be lowered regardless of any `<in-call><hand-raised/></in-call>`
+    // a buggy or hostile client left on the stanza. Only an in-call presence
+    // (muji active) may carry a raised hand.
+    let hand_raised_state = if clears_muji_presence {
+        InCallPresenceState::default()
+    } else {
+        extract_in_call_presence_state(incoming)
+    };
     let raised_hand_sessions = match actor
         .ask(UpsertHandRaised {
             sender_jid: sender_jid.clone(),
-            state: extract_in_call_presence_state(incoming),
+            state: hand_raised_state,
         })
         .await
     {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
@@ -37,14 +37,15 @@ use tracing::{debug, warn};
 use waddle_xmpp::muc::{
     build_occupant_presence_update,
     presence::NS_MUC,
-    room_actor::{ClearMujiPresence, UpsertMujiPresence},
+    room_actor::{ClearMujiPresence, UpsertHandRaised, UpsertMujiPresence},
 };
 use waddle_xmpp::xep::xep0167::MediaKind;
 use waddle_xmpp::xep::xep0272::{find_muji, Muji, NS_MUJI};
 use waddle_xmpp::xep::xep0421::OccupantIdentity;
 use waddle_xmpp::xep::{
-    build_call_thread_anchor, build_hint_element, CallThreadAnchor, CallThreadKind,
-    CallThreadMedia, Hint, NS_WADDLE_CALL_THREAD,
+    build_call_thread_anchor, build_hint_element, build_in_call_presence_state_element,
+    parse_in_call_presence_state, CallThreadAnchor, CallThreadKind, CallThreadMedia, Hint,
+    InCallPresenceState, NS_WADDLE_CALL_THREAD, NS_WADDLE_IN_CALL,
 };
 use waddle_xmpp::Stanza;
 use waddle_xmpp_core::mam::ThreadId;
@@ -70,6 +71,19 @@ pub(super) fn extract_muji(presence: &Presence) -> Option<Muji> {
         .iter()
         .find(|elem| elem.name() == "muji" && elem.ns() == NS_MUJI)
         .and_then(|elem| Muji::try_from(elem).ok())
+}
+
+/// Pull the typed [`InCallPresenceState`] out of an inbound presence's
+/// `<in-call xmlns='urn:waddle:in-call:0'>` child (#1029), defaulting to
+/// the lowered state when the child is absent or fails to parse — a
+/// missing/malformed marker is a cleared hand, not an error.
+pub(super) fn extract_in_call_presence_state(presence: &Presence) -> InCallPresenceState {
+    presence
+        .payloads
+        .iter()
+        .find(|elem| elem.name() == "in-call" && elem.ns() == NS_WADDLE_IN_CALL)
+        .and_then(|elem| parse_in_call_presence_state(elem).ok())
+        .unwrap_or_default()
 }
 
 fn is_muc_join_presence(presence: &Presence) -> bool {
@@ -226,6 +240,25 @@ pub(super) async fn try_handle_muc_presence_update(
         "Broadcasting MUC Muji presence update"
     );
 
+    // Apply the raised-hand presence state (#1029) carried on the same
+    // stanza. Tracked independently of muji so each stays single-purpose;
+    // the post-update per-session set decorates the reflected presences
+    // below with the room-authoritative `<in-call>` child rather than
+    // echoing the client payload (which would misattribute a sibling
+    // session's hand). The sender was already confirmed as an occupant
+    // via the muji upsert above, so a `None`/error here just means no
+    // hand state to reflect.
+    let raised_hand_sessions = match actor
+        .ask(UpsertHandRaised {
+            sender_jid: sender_jid.clone(),
+            state: extract_in_call_presence_state(incoming),
+        })
+        .await
+    {
+        Ok(Some(hand_outcome)) => hand_outcome.raised_hand_sessions,
+        Ok(None) | Err(_) => Vec::new(),
+    };
+
     let from_room_jid = room_jid
         .clone()
         .with_resource_str(&outcome.update.sender_nick)
@@ -295,6 +328,22 @@ pub(super) async fn try_handle_muc_presence_update(
                 .retain(|payload| !(payload.name() == "muji" && payload.ns() == NS_MUJI));
             if let Some(muji) = entry.muji {
                 presence.payloads.push(muji.to_element());
+            }
+
+            // Replace any client-authored `<in-call>` with the room
+            // actor's authoritative per-session raised-hand state, so a
+            // sibling resource's presence is never stamped with another
+            // session's hand (#1029). The element sits alongside `<muji>`.
+            presence.payloads.retain(|payload| {
+                !(payload.name() == "in-call" && payload.ns() == NS_WADDLE_IN_CALL)
+            });
+            if raised_hand_sessions
+                .iter()
+                .any(|jid| jid == entry.owner_jid)
+            {
+                presence.payloads.push(build_in_call_presence_state_element(
+                    &InCallPresenceState { hand_raised: true },
+                ));
             }
 
             if recipient == sender_jid {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/tests.rs
@@ -29,6 +29,7 @@ fn muc_join_presence_carries_authority_in_xep_0045_payload_only() {
         real_jid: &real_jid,
         include_self_status: false,
         muji: None,
+        hand_raised: false,
     });
 
     // XEP-0045: authority lives in the muc#user payload.

--- a/server/crates/waddle-server/tests/xep_waddle_in_call_ws.rs
+++ b/server/crates/waddle-server/tests/xep_waddle_in_call_ws.rs
@@ -99,6 +99,22 @@ fn call_presence(room: &str, nick: &str, hand_raised: bool) -> String {
     serialize(presence.build())
 }
 
+/// A XEP-0272 §Leaving presence (no `<muji/>`) that a buggy/hostile
+/// client still tags with the raised-hand `<in-call>` marker. The server
+/// must NOT honour the marker once call participation is cleared.
+fn leave_presence_with_stale_hand(room: &str, nick: &str) -> String {
+    serialize(
+        Element::builder("presence", NS_CLIENT)
+            .attr(attr("to"), format!("{room}/{nick}"))
+            .append(
+                Element::builder("in-call", NS_WADDLE_IN_CALL)
+                    .append(Element::builder("hand-raised", NS_WADDLE_IN_CALL).build())
+                    .build(),
+            )
+            .build(),
+    )
+}
+
 fn presence_in_call_child(frame: &str) -> Option<Element> {
     let element: Element = frame.parse().ok()?;
     if element.name() != "presence" {
@@ -195,6 +211,50 @@ async fn raise_hand_presence_reflects_in_call_child_alongside_muji() {
 
     let _ = bob.close().await;
     let _ = alice.close().await;
+}
+
+#[tokio::test]
+async fn leave_call_presence_forces_hand_lowered_despite_stale_marker() {
+    // Invariant: a raised hand only exists for an active call participant.
+    // When the XEP-0272 leave marker (no <muji/>) arrives, the server must
+    // force the hand lowered regardless of any <in-call><hand-raised/> the
+    // client still attached — otherwise a non-participant's hand is reflected
+    // and replayed to late joiners.
+    let _guard = TEST_SERIAL.lock().await;
+    let server = TestServer::start_with_extra_accounts(&[(BOB, BOB_PASSWORD)]);
+    let alice_password = server.fixed_account_password().to_string();
+    let mut alice = connect(&server, ALICE, &alice_password, "stale-alice").await;
+    let mut bob = connect(&server, BOB, BOB_PASSWORD, "stale-bob").await;
+    let room = format!("hand-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut alice, &room, ALICE).await;
+    join_room(&mut bob, &room, BOB).await;
+
+    // Alice raises her hand legitimately, then bob drains the raise.
+    alice
+        .send(&call_presence(&room, ALICE, true))
+        .await
+        .expect("alice raises hand");
+    bob.recv_matching(|f| f.contains("<presence") && f.contains("hand-raised"))
+        .await
+        .expect("bob sees the raise");
+
+    // Alice leaves the call but a buggy client keeps the <hand-raised/> marker.
+    alice
+        .send(&leave_presence_with_stale_hand(&room, ALICE))
+        .await
+        .expect("alice leaves call with stale hand marker");
+
+    let alice_from = format!("{room}/{ALICE}");
+    let leave = bob
+        .recv_matching(|f| {
+            f.contains("<presence") && f.contains(&alice_from) && !f.contains("muji")
+        })
+        .await
+        .expect("bob sees alice's reflected leave presence");
+    assert!(
+        !leave.contains("hand-raised"),
+        "server must force the hand lowered on a leave-call presence: {leave}"
+    );
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/tests/xep_waddle_in_call_ws.rs
+++ b/server/crates/waddle-server/tests/xep_waddle_in_call_ws.rs
@@ -10,10 +10,14 @@ const DOMAIN: &str = "localhost";
 const ALICE: &str = "admin";
 const BOB: &str = "bob";
 const BOB_PASSWORD: &str = "bob-password";
+const CAROL: &str = "carol";
+const CAROL_PASSWORD: &str = "carol-password";
 const NS_CLIENT: &str = "jabber:client";
 const NS_HINTS: &str = "urn:xmpp:hints";
 const NS_MAM: &str = "urn:xmpp:mam:2";
 const NS_MUC: &str = "http://jabber.org/protocol/muc";
+const NS_MUJI: &str = "urn:xmpp:jingle:muji:0";
+const NS_RTP: &str = "urn:xmpp:jingle:apps:rtp:1";
 const NS_WADDLE_IN_CALL: &str = "urn:waddle:in-call:0";
 static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
 
@@ -64,6 +68,48 @@ fn in_call_reaction_message(
     )
 }
 
+/// A MUC call presence: an active XEP-0272 `<muji/>` advertisement
+/// (one audio content), optionally carrying the `urn:waddle:in-call:0`
+/// `<hand-raised/>` presence state *alongside* (never inside) `<muji/>`.
+fn call_presence(room: &str, nick: &str, hand_raised: bool) -> String {
+    let muji = Element::builder("muji", NS_MUJI)
+        .append(
+            Element::builder("content", NS_MUJI)
+                .attr(attr("creator"), "initiator")
+                .attr(attr("name"), "audio")
+                .append(
+                    Element::builder("description", NS_RTP)
+                        .attr(attr("media"), "audio")
+                        .build(),
+                )
+                .build(),
+        )
+        .build();
+    let mut presence = Element::builder("presence", NS_CLIENT)
+        .attr(attr("to"), format!("{room}/{nick}"))
+        .append(Element::builder("x", NS_MUC).build())
+        .append(muji);
+    if hand_raised {
+        presence = presence.append(
+            Element::builder("in-call", NS_WADDLE_IN_CALL)
+                .append(Element::builder("hand-raised", NS_WADDLE_IN_CALL).build())
+                .build(),
+        );
+    }
+    serialize(presence.build())
+}
+
+fn presence_in_call_child(frame: &str) -> Option<Element> {
+    let element: Element = frame.parse().ok()?;
+    if element.name() != "presence" {
+        return None;
+    }
+    element
+        .children()
+        .find(|c| c.name() == "in-call" && c.ns() == NS_WADDLE_IN_CALL)
+        .cloned()
+}
+
 fn mam_query(to: &str, id: &str) -> String {
     serialize(
         Element::builder("iq", NS_CLIENT)
@@ -96,6 +142,120 @@ async fn join_room(client: &mut WsXmppClient, room: &str, nick: &str) {
         .recv_until(|frame| frame.contains("<subject"))
         .await
         .expect("join responses");
+}
+
+#[tokio::test]
+async fn raise_hand_presence_reflects_in_call_child_alongside_muji() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server = TestServer::start_with_extra_accounts(&[(BOB, BOB_PASSWORD)]);
+    let alice_password = server.fixed_account_password().to_string();
+    let mut alice = connect(&server, ALICE, &alice_password, "hand-alice").await;
+    let mut bob = connect(&server, BOB, BOB_PASSWORD, "hand-bob").await;
+    let room = format!("hand-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut alice, &room, ALICE).await;
+    join_room(&mut bob, &room, BOB).await;
+
+    // Alice enters the call and raises her hand in one presence update.
+    alice
+        .send(&call_presence(&room, ALICE, true))
+        .await
+        .expect("alice raises hand");
+
+    // Bob receives Alice's reflected presence carrying BOTH the muji call
+    // advertisement and the raised-hand `<in-call>` child, with the
+    // `<in-call>` sibling of `<muji>` rather than nested inside it.
+    let frame = bob
+        .recv_matching(|f| f.contains("<presence") && f.contains("hand-raised"))
+        .await
+        .expect("bob sees alice's raised hand");
+    let element: Element = frame.parse().expect("presence xml");
+    assert_eq!(
+        element.attr("from"),
+        Some(format!("{room}/{ALICE}").as_str()),
+        "reflection is from room/nick: {frame}"
+    );
+    let in_call = element
+        .children()
+        .find(|c| c.name() == "in-call" && c.ns() == NS_WADDLE_IN_CALL)
+        .unwrap_or_else(|| panic!("reflection carries an <in-call> child: {frame}"));
+    assert!(
+        in_call
+            .children()
+            .any(|c| c.name() == "hand-raised" && c.ns() == NS_WADDLE_IN_CALL),
+        "<in-call> carries the <hand-raised/> marker: {frame}"
+    );
+    let muji = element
+        .children()
+        .find(|c| c.name() == "muji" && c.ns() == NS_MUJI)
+        .unwrap_or_else(|| panic!("reflection still carries <muji>: {frame}"));
+    assert!(
+        muji.children().all(|c| c.name() != "in-call"),
+        "<in-call> must sit alongside, never inside, <muji>: {frame}"
+    );
+
+    let _ = bob.close().await;
+    let _ = alice.close().await;
+}
+
+#[tokio::test]
+async fn raised_hand_replays_to_late_joiner_and_clears_on_lower() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server =
+        TestServer::start_with_extra_accounts(&[(BOB, BOB_PASSWORD), (CAROL, CAROL_PASSWORD)]);
+    let alice_password = server.fixed_account_password().to_string();
+    let mut alice = connect(&server, ALICE, &alice_password, "late-alice").await;
+    let room = format!("hand-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut alice, &room, ALICE).await;
+
+    // Alice enters the call and raises her hand, then drains her own echo
+    // so the room actor has committed the state before Carol arrives.
+    alice
+        .send(&call_presence(&room, ALICE, true))
+        .await
+        .expect("alice raises hand");
+    alice
+        .recv_matching(|f| f.contains("hand-raised"))
+        .await
+        .expect("alice self echo");
+
+    // Carol joins mid-call: her XEP-0045 occupant-list replay must already
+    // show Alice's raised hand — no fresh update is coming for a steady call.
+    let mut carol = connect(&server, CAROL, CAROL_PASSWORD, "late-carol").await;
+    carol
+        .send(&muc_join_presence(&room, CAROL))
+        .await
+        .expect("carol joins");
+    let replay = carol
+        .recv_until(|f| f.contains("<subject"))
+        .await
+        .expect("carol join replay");
+    let alice_from = format!("{room}/{ALICE}");
+    assert!(
+        replay
+            .iter()
+            .any(|f| f.contains(&alice_from) && f.contains("hand-raised")),
+        "carol's join replay shows alice's raised hand: {replay:?}"
+    );
+
+    // Alice lowers her hand (stays in the call): the reflected presence drops
+    // the in-call child for everyone.
+    alice
+        .send(&call_presence(&room, ALICE, false))
+        .await
+        .expect("alice lowers hand");
+    let lowered = carol
+        .recv_matching(|f| f.contains("<presence") && f.contains(&alice_from) && f.contains("muji"))
+        .await
+        .expect("carol sees alice's lowered presence");
+    assert!(
+        presence_in_call_child(&lowered)
+            .map(|c| c.children().all(|g| g.name() != "hand-raised"))
+            .unwrap_or(true),
+        "lowered presence carries no raised-hand marker: {lowered}"
+    );
+
+    let _ = carol.close().await;
+    let _ = alice.close().await;
 }
 
 #[tokio::test]

--- a/server/crates/waddle-xmpp-client-wasm/src/client_rooms.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_rooms.rs
@@ -79,6 +79,15 @@ impl WaddleClient {
     ///   §Joining two-phase flow. Typically the client sends this
     ///   first, awaits the room's echo, then re-emits with contents
     ///   declared.
+    /// - `hand_raised=true`: appends an
+    ///   `<in-call xmlns='urn:waddle:in-call:0'><hand-raised/></in-call>`
+    ///   presence child *alongside* `<muji/>` (#1029). This is the FFI
+    ///   raise/lower-hand "set method": the caller re-emits its current
+    ///   call presence with the flag toggled, and the absence of the
+    ///   child lowers the hand for everyone (the server clears the
+    ///   stored state). Ignored unless the occupant is in the call
+    ///   (`active` or `preparing`), since a raised hand is meaningless
+    ///   without call participation.
     pub fn update_muji_presence(
         &self,
         room_jid: String,
@@ -86,6 +95,7 @@ impl WaddleClient {
         active: bool,
         preparing: bool,
         video: bool,
+        hand_raised: bool,
     ) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
@@ -105,6 +115,10 @@ impl WaddleClient {
                     active && video,
                 );
                 builder = builder.append(muji);
+                if hand_raised {
+                    builder = builder
+                        .append(waddle_xmpp_client::messaging::build_in_call_hand_raised_element());
+                }
             }
             builder = builder.append(waddle_xmpp_client::caps::build_client_caps_element());
             send_stanza_command(inner, builder.build()).await?;

--- a/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
@@ -768,6 +768,7 @@ pub(crate) fn presence_to_js(presence: InboundPresence) -> WaddlePresence {
             audio: m.audio,
             video: m.video,
         }),
+        hand_raised: presence.hand_raised,
     }
 }
 
@@ -1046,6 +1047,7 @@ mod inbound_to_js_tests {
             ],
             vcard_avatar: None,
             muji: None,
+            hand_raised: false,
         };
         let js = presence_to_js(presence);
         assert_eq!(js.muc_status_codes, vec![100, 110, 210]);

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -448,6 +448,12 @@ pub struct WaddlePresence {
     /// participant-tracking store. `None` per XEP-0272 §Leaving
     /// means the occupant has left the call.
     pub muji: Option<WaddleMujiPresence>,
+    /// Waddle raised-hand call presence state (#1029). `true` when the
+    /// occupant's presence carries
+    /// `<in-call xmlns='urn:waddle:in-call:0'><hand-raised/></in-call>`
+    /// alongside `<muji/>`. Defaults to `false` (lowered) so the chat
+    /// side can build a per-participant raised-hand map.
+    pub hand_raised: bool,
 }
 
 #[derive(Debug, Serialize)]

--- a/server/crates/waddle-xmpp-client/src/messaging.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging.rs
@@ -32,9 +32,9 @@ pub use call::{
     CallMedia, InboundCallEvent, LiveKitJoin,
 };
 pub use namespaces::{
-    build_muji_element, NS_CHAT_MARKERS, NS_CHAT_STATES, NS_CLIENT, NS_JINGLE_RTP,
-    NS_MESSAGE_CORRECT, NS_MESSAGE_MODERATE, NS_MESSAGE_RETRACT, NS_MUJI, NS_REACTIONS,
-    NS_WADDLE_IN_CALL, NS_WADDLE_PIN_V0,
+    build_in_call_hand_raised_element, build_muji_element, NS_CHAT_MARKERS, NS_CHAT_STATES,
+    NS_CLIENT, NS_JINGLE_RTP, NS_MESSAGE_CORRECT, NS_MESSAGE_MODERATE, NS_MESSAGE_RETRACT, NS_MUJI,
+    NS_REACTIONS, NS_WADDLE_IN_CALL, NS_WADDLE_PIN_V0,
 };
 #[cfg(all(feature = "native", not(target_arch = "wasm32")))]
 pub use native::MessagingExt;

--- a/server/crates/waddle-xmpp-client/src/messaging/namespaces.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/namespaces.rs
@@ -119,6 +119,19 @@ fn build_muji_content(media: &str) -> minidom::Element {
         .build()
 }
 
+/// Build the `<in-call xmlns='urn:waddle:in-call:0'><hand-raised/></in-call>`
+/// presence child (#1029), carried alongside (never inside) `<muji/>` in MUC
+/// call presence to advertise a raised hand. Mirrors the server-side
+/// `waddle_xmpp::xep::build_in_call_presence_state_element`.
+///
+/// CLAUDE.md XML hard rule: callers append this typed element rather than
+/// hand-rolling the `<in-call>` shape at the wasm boundary.
+pub fn build_in_call_hand_raised_element() -> minidom::Element {
+    minidom::Element::builder("in-call", NS_WADDLE_IN_CALL)
+        .append(minidom::Element::builder("hand-raised", NS_WADDLE_IN_CALL).build())
+        .build()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -164,5 +177,17 @@ mod tests {
     fn ns_constants_match_xep_namespaces() {
         assert_eq!(NS_MUJI, "urn:xmpp:jingle:muji:0");
         assert_eq!(NS_JINGLE_RTP, "urn:xmpp:jingle:apps:rtp:1");
+    }
+
+    #[test]
+    fn builds_in_call_hand_raised_element() {
+        let elem = build_in_call_hand_raised_element();
+        assert_eq!(elem.name(), "in-call");
+        assert_eq!(elem.ns(), NS_WADDLE_IN_CALL);
+        let marker = elem
+            .children()
+            .find(|c| c.name() == "hand-raised")
+            .expect("hand-raised marker child");
+        assert_eq!(marker.ns(), NS_WADDLE_IN_CALL);
     }
 }

--- a/server/crates/waddle-xmpp-client/src/messaging/presence.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/presence.rs
@@ -87,6 +87,18 @@ pub(super) fn parse_presence(el: &Element) -> InboundPresence {
         }
     });
 
+    // Waddle raised-hand call presence state (#1029): an
+    // `<in-call xmlns='urn:waddle:in-call:0'>` sibling of `<muji/>` with
+    // a `<hand-raised/>` marker child. Its absence means the hand is
+    // lowered.
+    let hand_raised = el
+        .get_child("in-call", NS_WADDLE_IN_CALL)
+        .is_some_and(|in_call| {
+            in_call
+                .children()
+                .any(|c| c.name() == "hand-raised" && c.ns() == NS_WADDLE_IN_CALL)
+        });
+
     InboundPresence {
         from,
         to,
@@ -100,6 +112,7 @@ pub(super) fn parse_presence(el: &Element) -> InboundPresence {
         muc_status,
         vcard_avatar,
         muji,
+        hand_raised,
     }
 }
 
@@ -150,6 +163,36 @@ mod tests {
         assert!(muji.active);
         assert!(muji.audio);
         assert!(muji.video);
+    }
+
+    #[test]
+    fn parses_in_call_hand_raised_alongside_muji() {
+        let xml = r#"<presence xmlns="jabber:client" from="room@muc.test/alice">
+            <muji xmlns="urn:xmpp:jingle:muji:0">
+                <content creator="initiator" name="audio">
+                    <description xmlns="urn:xmpp:jingle:apps:rtp:1" media="audio"/>
+                </content>
+            </muji>
+            <in-call xmlns="urn:waddle:in-call:0"><hand-raised/></in-call>
+        </presence>"#;
+        let elem: Element = xml.parse().unwrap();
+        let p = parse_presence(&elem);
+        assert!(p.muji.expect("muji parsed").active);
+        assert!(p.hand_raised, "raised-hand presence state parsed");
+    }
+
+    #[test]
+    fn lowered_hand_presence_has_no_in_call_child() {
+        let xml = r#"<presence xmlns="jabber:client" from="room@muc.test/alice">
+            <muji xmlns="urn:xmpp:jingle:muji:0">
+                <content creator="initiator" name="audio">
+                    <description xmlns="urn:xmpp:jingle:apps:rtp:1" media="audio"/>
+                </content>
+            </muji>
+        </presence>"#;
+        let elem: Element = xml.parse().unwrap();
+        let p = parse_presence(&elem);
+        assert!(!p.hand_raised, "no in-call child means hand lowered");
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client/src/messaging/types.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/types.rs
@@ -695,6 +695,13 @@ pub struct InboundPresence {
     /// the occupant is NOT in the call. Drives the chat-side "N in
     /// call" indicator.
     pub muji: Option<MujiPresence>,
+    /// Waddle raised-hand call presence state (#1029) —
+    /// `<in-call xmlns='urn:waddle:in-call:0'><hand-raised/></in-call>`
+    /// carried *alongside* `<muji/>` on a MUC occupant's presence. `true`
+    /// when the occupant currently advertises a raised hand; `false` when
+    /// the child is absent (lowered). Drives the chat-side raised-hand
+    /// indicator in the Participants panel and on tiles.
+    pub hand_raised: bool,
 }
 
 /// Parsed `<muji xmlns='urn:xmpp:jingle:muji:0'>` extension on a MUC

--- a/server/crates/waddle-xmpp/src/muc/room.rs
+++ b/server/crates/waddle-xmpp/src/muc/room.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use jid::{BareJid, FullJid};
 use serde::{Deserialize, Serialize};
@@ -147,6 +147,23 @@ pub struct MucRoom {
     /// still one occupant presence per nick; `muji_for_nick` aggregates
     /// these session entries, preferring active contents over preparing.
     pub(super) muji_state: HashMap<String, HashMap<FullJid, Muji>>,
+    /// Per-session raised-hand presence state (`urn:waddle:in-call:0`,
+    /// #1029), keyed by nick then by the set of full JIDs whose session
+    /// currently advertises `<in-call><hand-raised/></in-call>`. Mirrors
+    /// [`muji_state`](Self::muji_state):
+    ///
+    /// 1. Late joiners see who already has a hand raised — the join
+    ///    handler reads this map and appends the `<in-call>` payload to
+    ///    the replayed presence for any session that owns one.
+    /// 2. Presence-update broadcasts reflect the room-authoritative
+    ///    per-session state rather than echoing the client payload, so a
+    ///    sibling resource's presence cannot be stamped with another
+    ///    session's hand state.
+    ///
+    /// A nick is "hand raised" to the room when *any* of its sessions
+    /// advertise it. Entries are cleared when the session lowers its
+    /// hand, leaves the call (`<muji/>` cleared), or leaves the room.
+    pub(super) hand_raised_state: HashMap<String, HashSet<FullJid>>,
 }
 
 /// Result of applying one session's Muji presence update.
@@ -188,6 +205,7 @@ impl MucRoom {
             generation_floor: u64::try_from(chrono::Utc::now().timestamp_millis()).unwrap_or(0),
             pinned_entries: Vec::new(),
             muji_state: HashMap::new(),
+            hand_raised_state: HashMap::new(),
         }
     }
 
@@ -325,6 +343,66 @@ impl MucRoom {
         }
     }
 
+    /// Apply an `<in-call xmlns='urn:waddle:in-call:0'>` raised-hand
+    /// presence state (#1029) from `nick`'s `originator` session. A
+    /// raised state records the session; a lowered/empty state removes
+    /// it. Mirrors [`upsert_muji_presence`](Self::upsert_muji_presence):
+    /// the entry is bound to the exact emitting session so one resource
+    /// can lower its hand without disturbing a sibling's.
+    pub fn upsert_hand_raised(
+        &mut self,
+        nick: &str,
+        originator: FullJid,
+        state: crate::xep::InCallPresenceState,
+    ) {
+        if state.is_empty() {
+            self.clear_hand_raised(nick, &originator);
+        } else {
+            self.hand_raised_state
+                .entry(nick.to_owned())
+                .or_default()
+                .insert(originator);
+        }
+    }
+
+    /// Clear `originator`'s raised-hand advertisement for `nick`, if it
+    /// owns one. Used when a session lowers its hand, leaves the call,
+    /// or leaves the room.
+    pub fn clear_hand_raised(&mut self, nick: &str, originator: &FullJid) {
+        if let Some(sessions) = self.hand_raised_state.get_mut(nick) {
+            sessions.remove(originator);
+            if sessions.is_empty() {
+                self.hand_raised_state.remove(nick);
+            }
+        }
+    }
+
+    /// True when *any* of `nick`'s sessions currently has a raised hand.
+    /// This is the nick-level aggregate other occupants observe.
+    pub fn hand_raised_for_nick(&self, nick: &str) -> bool {
+        self.hand_raised_state
+            .get(nick)
+            .is_some_and(|sessions| !sessions.is_empty())
+    }
+
+    /// True when the exact `jid` session of `nick` has a raised hand.
+    pub fn hand_raised_for_session(&self, nick: &str, jid: &FullJid) -> bool {
+        self.hand_raised_state
+            .get(nick)
+            .is_some_and(|sessions| sessions.contains(jid))
+    }
+
+    /// Full JIDs of `nick`'s sessions with a raised hand, sorted for
+    /// deterministic replay and broadcast ordering.
+    pub fn hand_raised_sessions_for_nick(&self, nick: &str) -> Vec<FullJid> {
+        let Some(sessions) = self.hand_raised_state.get(nick) else {
+            return Vec::new();
+        };
+        let mut sessions: Vec<FullJid> = sessions.iter().cloned().collect();
+        sessions.sort_by_key(ToString::to_string);
+        sessions
+    }
+
     /// Add an occupant to the room.
     ///
     /// When this is a fresh join (nickname not currently present), the
@@ -354,6 +432,7 @@ impl MucRoom {
     pub fn remove_occupant(&mut self, nick: &str) -> Option<Occupant> {
         self.occupant_sessions.remove(nick);
         self.muji_state.remove(nick);
+        self.hand_raised_state.remove(nick);
         self.occupants.remove(nick)
     }
 
@@ -412,10 +491,20 @@ impl MucRoom {
                 self.muji_state.remove(nick);
             }
         }
+        // The raised-hand advertisement is session-owned just like the
+        // call advertisement above; drop the leaving session's entry so
+        // a lingering hand isn't replayed to late joiners.
+        if let Some(hands) = self.hand_raised_state.get_mut(nick) {
+            hands.remove(jid);
+            if hands.is_empty() {
+                self.hand_raised_state.remove(nick);
+            }
+        }
 
         if sessions.is_empty() {
             self.occupant_sessions.remove(nick);
             self.muji_state.remove(nick);
+            self.hand_raised_state.remove(nick);
             self.occupants.remove(nick);
             return Some(true);
         }
@@ -469,6 +558,7 @@ impl MucRoom {
             && self.pinned_entries.is_empty()
             && self.affiliation_list.is_empty()
             && self.muji_state.is_empty()
+            && self.hand_raised_state.is_empty()
     }
 
     /// Whether `bare_jid` is currently joined to this room as an
@@ -639,5 +729,81 @@ mod pin_state_tests {
         // must update this contract explicitly.
         let fresh = room();
         assert!(fresh.pinned_entries().is_empty());
+    }
+}
+
+#[cfg(test)]
+mod hand_raised_state_tests {
+    use super::*;
+    use crate::xep::InCallPresenceState;
+    use std::str::FromStr;
+
+    fn room() -> MucRoom {
+        MucRoom::new(
+            BareJid::from_str("room@conf.example").expect("valid bare jid"),
+            "wad-1".into(),
+            "chan-1".into(),
+            RoomConfig::default(),
+        )
+    }
+
+    fn full(s: &str) -> FullJid {
+        FullJid::from_str(s).expect("valid full jid")
+    }
+
+    fn raised() -> InCallPresenceState {
+        InCallPresenceState { hand_raised: true }
+    }
+
+    fn lowered() -> InCallPresenceState {
+        InCallPresenceState { hand_raised: false }
+    }
+
+    #[test]
+    fn upsert_raises_and_lower_clears_for_a_session() {
+        let mut r = room();
+        let web = full("alice@example.com/web");
+
+        r.upsert_hand_raised("alice", web.clone(), raised());
+        assert!(r.hand_raised_for_nick("alice"));
+        assert!(r.hand_raised_for_session("alice", &web));
+
+        r.upsert_hand_raised("alice", web.clone(), lowered());
+        assert!(!r.hand_raised_for_nick("alice"));
+        assert!(!r.hand_raised_for_session("alice", &web));
+    }
+
+    #[test]
+    fn raised_hand_aggregates_across_sessions() {
+        let mut r = room();
+        let web = full("alice@example.com/web");
+        let mobile = full("alice@example.com/mobile");
+
+        // Web raises; mobile explicitly lowered must not contribute.
+        r.upsert_hand_raised("alice", web.clone(), raised());
+        r.upsert_hand_raised("alice", mobile.clone(), lowered());
+        assert!(r.hand_raised_for_nick("alice"));
+        assert_eq!(r.hand_raised_sessions_for_nick("alice"), vec![web.clone()]);
+
+        // Mobile raises too — both sessions advertised, sorted by full JID.
+        r.upsert_hand_raised("alice", mobile.clone(), raised());
+        assert_eq!(
+            r.hand_raised_sessions_for_nick("alice"),
+            vec![mobile.clone(), web.clone()]
+        );
+
+        // Clearing web leaves the nick raised via mobile.
+        r.clear_hand_raised("alice", &web);
+        assert!(r.hand_raised_for_nick("alice"));
+        assert_eq!(r.hand_raised_sessions_for_nick("alice"), vec![mobile]);
+    }
+
+    #[test]
+    fn remove_occupant_clears_hand_state() {
+        let mut r = room();
+        let web = full("alice@example.com/web");
+        r.upsert_hand_raised("alice", web, raised());
+        r.remove_occupant("alice");
+        assert!(!r.hand_raised_for_nick("alice"));
     }
 }

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -25,8 +25,9 @@ mod tests;
 
 pub use admin_handlers::{ApplyAdminItems, GetAdminContext, IsOwner};
 pub use occupancy_handlers::{
-    ClearMujiPresence, JoinWithAffiliation, LeaveByRealJid, MujiPresenceUpdateOutcome,
-    PingSelfCheck, PresenceUpdateData, ReconcileChannelBackedRoom, UpsertMujiPresence,
+    ClearMujiPresence, HandRaisedUpdateOutcome, JoinWithAffiliation, LeaveByRealJid,
+    MujiPresenceUpdateOutcome, PingSelfCheck, PresenceUpdateData, ReconcileChannelBackedRoom,
+    UpsertHandRaised, UpsertMujiPresence,
 };
 pub use snapshot_handlers::{
     BuildGroupchatBroadcast, GetNicknameGeneration, GetRoomSnapshot, GroupchatBroadcastResult,
@@ -64,6 +65,11 @@ pub struct JoinExistingOccupant {
     /// coordination state, so join replay must not stamp an aggregate
     /// same-nick Muji payload onto an arbitrary full JID.
     pub muji: Option<crate::xep::xep0272::Muji>,
+    /// Whether this exact session advertises a raised hand
+    /// (`urn:waddle:in-call:0`, #1029) at join time. The join handler
+    /// appends an `<in-call><hand-raised/></in-call>` payload to the
+    /// replayed presence so a late joiner sees who already has a hand up.
+    pub hand_raised: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
@@ -66,12 +66,14 @@ impl kameo::message::Message<JoinWithAffiliation> for RoomActor {
                     .into_iter()
                     .map(|jid| {
                         let muji = self.room.muji_for_session(&o.nick, &jid);
+                        let hand_raised = self.room.hand_raised_for_session(&o.nick, &jid);
                         JoinExistingOccupant {
                             jid,
                             nick: o.nick.clone(),
                             affiliation: o.affiliation,
                             role: o.role,
                             muji,
+                            hand_raised,
                         }
                     })
             })
@@ -341,6 +343,49 @@ impl kameo::message::Message<ClearMujiPresence> for RoomActor {
             active_muji: muji_state.room_muji,
             session_mujis: muji_state.session_mujis,
             active_call_started: muji_state.active_call_started,
+        }))
+    }
+}
+
+/// Apply the calling session's `<in-call xmlns='urn:waddle:in-call:0'>`
+/// raised-hand presence state (#1029). Carried on the same MUC presence
+/// as the XEP-0272 `<muji/>` advertisement but tracked independently so
+/// muji handling stays single-purpose. Like [`UpsertMujiPresence`] this
+/// authenticates the sender as a current occupant; a non-occupant yields
+/// `Ok(None)` and the caller falls back to the join path.
+pub struct UpsertHandRaised {
+    pub sender_jid: FullJid,
+    pub state: crate::xep::InCallPresenceState,
+}
+
+#[derive(Debug, Clone)]
+pub struct HandRaisedUpdateOutcome {
+    /// Resolved nick of the sending occupant (room-authoritative).
+    pub sender_nick: String,
+    /// Full JIDs of the nick's sessions that advertise a raised hand
+    /// after the update. The presence broadcaster decorates each
+    /// reflected per-session presence whose owner appears here.
+    pub raised_hand_sessions: Vec<FullJid>,
+}
+
+impl kameo::message::Message<UpsertHandRaised> for RoomActor {
+    type Reply = Result<Option<HandRaisedUpdateOutcome>, Infallible>;
+
+    async fn handle(
+        &mut self,
+        msg: UpsertHandRaised,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let Some(sender_occupant) = self.room.find_occupant_by_real_jid(&msg.sender_jid) else {
+            return Ok(None);
+        };
+        let sender_nick = sender_occupant.nick.clone();
+        self.room
+            .upsert_hand_raised(&sender_nick, msg.sender_jid.clone(), msg.state);
+        let raised_hand_sessions = self.room.hand_raised_sessions_for_nick(&sender_nick);
+        Ok(Some(HandRaisedUpdateOutcome {
+            sender_nick,
+            raised_hand_sessions,
         }))
     }
 }

--- a/server/crates/waddle-xmpp/src/xep/exports.rs
+++ b/server/crates/waddle-xmpp/src/xep/exports.rs
@@ -448,9 +448,10 @@ pub use super::xep_waddle_link_preview::{
 };
 
 pub use super::xep_waddle_in_call::{
-    build_in_call_reaction_element, build_in_call_reaction_message, parse_in_call_signal,
-    parse_in_call_signal_child, InCallParseError, InCallReactionEmoji, InCallReactionSignal,
-    InCallSessionId, InCallSignal, NS_WADDLE_IN_CALL,
+    build_in_call_presence_state_element, build_in_call_reaction_element,
+    build_in_call_reaction_message, parse_in_call_presence_state, parse_in_call_signal,
+    parse_in_call_signal_child, InCallParseError, InCallPresenceState, InCallReactionEmoji,
+    InCallReactionSignal, InCallSessionId, InCallSignal, NS_WADDLE_IN_CALL,
 };
 
 pub use super::xep0503::{

--- a/server/crates/waddle-xmpp/src/xep/xep_waddle_in_call.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep_waddle_in_call.rs
@@ -1,4 +1,14 @@
-//! Waddle transient in-call signaling carrier (`urn:waddle:in-call:0`).
+//! Waddle in-call signaling carrier (`urn:waddle:in-call:0`).
+//!
+//! Two distinct shapes share this namespace and the `<in-call/>` root:
+//!
+//! - **Message-transient signals** (reactions): carried in a `<message/>`
+//!   marked `no-store`/`no-copy`, identified by a `sid` attribute and a
+//!   `<reaction/>` child. Fire-and-forget; never stored.
+//! - **Presence-durable state** (raised hand): carried in MUC occupant
+//!   presence as a child *alongside* (never inside) the `<muji/>` element,
+//!   with a `<hand-raised/>` marker child. Stored in room state, replayed to
+//!   late joiners, and cleared when the occupant leaves the call.
 
 use minidom::Element;
 use xmpp_parsers::jingle::SessionId;
@@ -7,6 +17,9 @@ use xmpp_parsers::message::{Id, Message, MessageType};
 use super::xep0334::{add_hint, Hint};
 
 pub const NS_WADDLE_IN_CALL: &str = "urn:waddle:in-call:0";
+
+const IN_CALL_NAME: &str = "in-call";
+const HAND_RAISED_NAME: &str = "hand-raised";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InCallSessionId(SessionId);
@@ -98,6 +111,54 @@ pub fn build_in_call_reaction_message(
     add_hint(&mut message, Hint::NoStore);
     add_hint(&mut message, Hint::NoCopy);
     message
+}
+
+/// Presence-durable in-call state for one occupant session, carried in MUC
+/// presence as `<in-call xmlns='urn:waddle:in-call:0'>` alongside `<muji/>`.
+///
+/// Currently models only a raised hand; the typed struct leaves room for
+/// further presence sub-states (mute, recording) without changing the wire
+/// root. An all-`false` value [`is_empty`](Self::is_empty) and clears the
+/// occupant's stored entry, mirroring `<muji/>` leave semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct InCallPresenceState {
+    pub hand_raised: bool,
+}
+
+impl InCallPresenceState {
+    /// True when no sub-state is advertised, i.e. the occupant carries no
+    /// in-call presence state and any stored entry should be cleared.
+    pub fn is_empty(&self) -> bool {
+        !self.hand_raised
+    }
+}
+
+/// Build the `<in-call xmlns='urn:waddle:in-call:0'>` presence child for the
+/// given state. A raised hand emits a `<hand-raised/>` marker child; a lowered
+/// hand emits an empty `<in-call/>` element (the canonical "no state" shape a
+/// peer may also omit entirely).
+pub fn build_in_call_presence_state_element(state: &InCallPresenceState) -> Element {
+    let mut builder = Element::builder(IN_CALL_NAME, NS_WADDLE_IN_CALL);
+    if state.hand_raised {
+        builder = builder.append(Element::builder(HAND_RAISED_NAME, NS_WADDLE_IN_CALL).build());
+    }
+    builder.build()
+}
+
+/// Parse an `<in-call xmlns='urn:waddle:in-call:0'>` presence child into its
+/// durable state. The presence shape carries no `sid` (the occupant presence
+/// already identifies the participant and room); a `<hand-raised/>` child
+/// raises the hand and its absence lowers it.
+pub fn parse_in_call_presence_state(
+    element: &Element,
+) -> Result<InCallPresenceState, InCallParseError> {
+    if element.name() != IN_CALL_NAME || element.ns() != NS_WADDLE_IN_CALL {
+        return Err(InCallParseError::NotInCall);
+    }
+    let hand_raised = element
+        .children()
+        .any(|child| child.name() == HAND_RAISED_NAME && child.ns() == NS_WADDLE_IN_CALL);
+    Ok(InCallPresenceState { hand_raised })
 }
 
 pub fn parse_in_call_signal(element: &Element) -> Result<InCallSignal, InCallParseError> {

--- a/server/crates/waddle-xmpp/tests/xep_waddle_in_call.rs
+++ b/server/crates/waddle-xmpp/tests/xep_waddle_in_call.rs
@@ -1,11 +1,35 @@
-//! `urn:waddle:in-call:0` — transient in-call signaling carrier.
+//! `urn:waddle:in-call:0` — in-call signaling carrier. Carries both
+//! message-transient signals (reactions) and presence-durable state
+//! (raised hand).
 
 use waddle_xmpp::xep::{
-    build_in_call_reaction_message, parse_in_call_signal, parse_in_call_signal_child, Hint,
-    InCallParseError, InCallReactionEmoji, InCallReactionSignal, InCallSessionId, InCallSignal,
-    NS_WADDLE_IN_CALL,
+    build_in_call_presence_state_element, build_in_call_reaction_message,
+    parse_in_call_presence_state, parse_in_call_signal, parse_in_call_signal_child, Hint,
+    InCallParseError, InCallPresenceState, InCallReactionEmoji, InCallReactionSignal,
+    InCallSessionId, InCallSignal, NS_WADDLE_IN_CALL,
 };
 use xmpp_parsers::message::MessageType;
+
+#[test]
+fn hand_raised_presence_state_round_trips() {
+    let element = build_in_call_presence_state_element(&InCallPresenceState { hand_raised: true });
+
+    // Carried as `<in-call xmlns='urn:waddle:in-call:0'>` so it sits next to
+    // (never inside) the `<muji/>` element in MUC call presence.
+    assert_eq!(element.name(), "in-call");
+    assert_eq!(element.ns(), NS_WADDLE_IN_CALL);
+    assert!(
+        element
+            .children()
+            .any(|child| child.name() == "hand-raised" && child.ns() == NS_WADDLE_IN_CALL),
+        "raised hand serializes a <hand-raised/> child"
+    );
+
+    assert_eq!(
+        parse_in_call_presence_state(&element),
+        Ok(InCallPresenceState { hand_raised: true })
+    );
+}
 
 #[test]
 fn in_call_reaction_message_round_trips_with_transient_hints() {
@@ -39,6 +63,36 @@ fn in_call_reaction_message_round_trips_with_transient_hints() {
     assert_eq!(
         parse_in_call_signal_child(&message),
         Some(InCallSignal::Reaction(InCallReactionSignal { sid, emoji }))
+    );
+}
+
+#[test]
+fn lowered_hand_is_empty_state_with_no_marker_child() {
+    let lowered = InCallPresenceState { hand_raised: false };
+    assert!(lowered.is_empty());
+    assert!(!InCallPresenceState { hand_raised: true }.is_empty());
+
+    let element = build_in_call_presence_state_element(&lowered);
+    assert_eq!(element.name(), "in-call");
+    assert_eq!(
+        element.children().count(),
+        0,
+        "a lowered hand carries no marker child"
+    );
+    assert_eq!(
+        parse_in_call_presence_state(&element),
+        Ok(InCallPresenceState { hand_raised: false })
+    );
+}
+
+#[test]
+fn parse_in_call_presence_state_rejects_foreign_element() {
+    let muji: minidom::Element = "<muji xmlns='urn:xmpp:jingle:muji:0'><preparing/></muji>"
+        .parse()
+        .expect("muji xml");
+    assert_eq!(
+        parse_in_call_presence_state(&muji),
+        Err(InCallParseError::NotInCall)
     );
 }
 

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -523,8 +523,17 @@ export class WaddleClient {
      *   §Joining two-phase flow. Typically the client sends this
      *   first, awaits the room's echo, then re-emits with contents
      *   declared.
+     * - `hand_raised=true`: appends an
+     *   `<in-call xmlns='urn:waddle:in-call:0'><hand-raised/></in-call>`
+     *   presence child *alongside* `<muji/>` (#1029). This is the FFI
+     *   raise/lower-hand "set method": the caller re-emits its current
+     *   call presence with the flag toggled, and the absence of the
+     *   child lowers the hand for everyone (the server clears the
+     *   stored state). Ignored unless the occupant is in the call
+     *   (`active` or `preparing`), since a raised hand is meaningless
+     *   without call participation.
      */
-    update_muji_presence(room_jid: string, nick: string, active: boolean, preparing: boolean, video: boolean): Promise<any>;
+    update_muji_presence(room_jid: string, nick: string, active: boolean, preparing: boolean, video: boolean, hand_raised: boolean): Promise<any>;
     /**
      * Fetch the latest calendar events from the community events
      * node. Returns ALL items including past events; chat-side

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=5bc181ad40ed";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=5bc181ad40ed";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=5bc181ad40ed";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=23e29ae929eb";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=23e29ae929eb";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=23e29ae929eb";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=5bc181ad40ed";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=23e29ae929eb";


### PR DESCRIPTION
## Summary

Implements #1029 (Call Zoom-parity epic #1017): **raised hand as a group-call
presence state**, carried in the `urn:waddle:in-call:0` namespace *alongside*
(never inside) the XEP-0272 `<muji/>` element. Built full-stack — server
carrier + MUC presence lifecycle, WASM FFI, and chat UI.

Raise-hand follows the established **MUJI presence-state lifecycle** (store
per-session, reflect room-authoritative state, replay to late joiners, clear on
lower / leave-call / leave-room) — deliberately *not* the transient
`no-store`/`no-copy` message shape used by #1022 in-call reactions.

## Wire shape

```xml
<presence from='room@muc/alice' ...>
  <muji xmlns='urn:xmpp:jingle:muji:0'>…</muji>
  <in-call xmlns='urn:waddle:in-call:0'>
    <hand-raised/>
  </in-call>
</presence>
```

Absence of the `<hand-raised/>` child (or of the whole `<in-call>` element) =
hand lowered.

## What changed

**Server (Rust)**
- `xep_waddle_in_call`: `InCallPresenceState` + typed build/parse for the
  presence carrier (struct-built, never `format!`).
- `MucRoom`: per-session `hand_raised_state` mirroring `muji_state` —
  upsert/clear/aggregate-by-nick, cleared on lower / session-leave / room-leave,
  folded into the dormancy predicate.
- `RoomActor`: new single-purpose `UpsertHandRaised` message (keeps muji
  handling untouched) returning the post-update per-session set.
- Presence-update handler: stores inbound hand state and reflects the
  room-authoritative `<in-call>` child per session (strips the client echo, so a
  sibling resource is never stamped with another session's hand).
- Join-replay path: surfaces existing raised hands to mid-call joiners
  (`JoinExistingOccupant.hand_raised` → `MucJoinPresence`).

**Client FFI (Rust WASM)**
- `build_in_call_hand_raised_element` + a `hand_raised` parameter on the
  `update_muji_presence` FFI (the raise/lower "set method": re-emits call
  presence with the flag toggled).
- Inbound presence parsing exposes `hand_raised` on `InboundPresence` /
  `WaddlePresence`.

**Client (TS/Vue)**
- `call-raised-hand.ts`: pure `reduceRaisedHands` reducer + `$mucRaisedHands`
  store keyed by `fullJidIdentityKey` (joins with the call roster) + self-state
  atom. Unit-tested via `bun test`.
- Inbound presence feeds the store; roster, video tiles (`CallTile` badge), and
  the Participants panel render the raised hand; a MUC-only control-bar
  Raise-hand toggle drives `WaddleClient.setCallHandRaised`.

## Acceptance criteria

- [x] Raising a hand sets a `urn:waddle:in-call:0` child in the call presence,
      alongside (not inside) the muji element.
- [x] A participant joining mid-call sees who already has a hand raised.
- [x] Lowering a hand or leaving the call clears the state for everyone.
- [x] Raised hands appear in the Participants panel and on tiles.
- [x] Presence-state roundtrip covered by the `xep_waddle_in_call` suite (unit +
      `xep_waddle_in_call_ws`); client raised-hand state map unit-tested via
      `bun test`.

## Tests

- `xep_waddle_in_call` (carrier round-trip, lowered/empty, foreign-element
  reject) + `MucRoom` storage unit tests.
- `xep_waddle_in_call_ws`: presence reflection alongside muji, late-joiner
  replay, clear-on-lower.
- Client: `build_in_call_hand_raised_element`, inbound presence parse, the
  `call-raised-hand` reducer, and roster `raisedHand` join (`bun test`).
- Full chat suite green (2577); `astro check` + `knip` clean; clippy
  `-D warnings` clean on all touched crates.

## XEP conformance

Uses the Waddle-private `urn:waddle:in-call:0` namespace (no official XEP shape
fits ad-hoc per-participant call UI state); attached as an additional namespaced
presence extension per XEP-0045 §5.1.3, leaving the XEP-0272 `<muji/>` element
untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
