### PR TITLE
fix(server): carry mute-state over XMPP, retire LiveKit data channel (#1030)

### DIFF
--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -61,6 +61,10 @@ import {
   raisedHandKeysForRoom,
   selfRaisedHandFor,
 } from "@/lib/calls/call-raised-hand";
+import {
+  $mucMutedParticipants,
+  mutedKeysForRoom,
+} from "@/lib/calls/call-mute";
 import { expectedRemoteIdentitiesForCallState } from "@/lib/calls/call-tiles";
 import {
   projectCallTiles,
@@ -284,6 +288,14 @@ const raisedHandIdentityKeys = computed(() => {
   return keys;
 });
 
+// #1030: muted call presence state. Pure INBOUND-REMOTE view — self-mute
+// is sourced from the local mic flag (`micEnabled`), so unlike raised-hand
+// the local identity is NOT folded in here.
+const mutedParticipants = useStore($mucMutedParticipants);
+const mutedIdentityKeys = computed(() =>
+  mutedKeysForRoom(normalizedRoomJid.value, mutedParticipants.value),
+);
+
 async function onToggleRaisedHand(): Promise<void> {
   if (!props.xmppClient) return;
   try {
@@ -311,6 +323,7 @@ const pictureInPictureProjection = computed(() =>
     localIdentity: localIdentity.value,
     expectedRemoteIdentities: expectedRemoteIdentities.value,
     micEnabled: micEnabled.value,
+    mutedKeys: mutedIdentityKeys.value,
     seenRemoteScreenTrackKeys: pictureInPictureSeenRemoteScreenTrackKeys.value,
     pinnedTileKey: pinnedTileKey.value,
     viewMode: viewMode.value,
@@ -726,6 +739,7 @@ onBeforeUnmount(() => {
           :active-speaker-identities="activeSpeakerIdentities"
           :promoted-speaker-identity="promotedSpeakerIdentity"
           :raised-hand-keys="raisedHandIdentityKeys"
+          :muted-keys="mutedIdentityKeys"
           @open-participants="openCallParticipants"
         />
         <div class="call-expanded__reactions" aria-live="polite" aria-atomic="false">

--- a/chat/src/components/calls/CallSplitContainer.vue
+++ b/chat/src/components/calls/CallSplitContainer.vue
@@ -50,6 +50,10 @@ import {
   raisedHandKeysForRoom,
   selfRaisedHandFor,
 } from "@/lib/calls/call-raised-hand";
+import {
+  $mucMutedParticipants,
+  mutedKeysForRoom,
+} from "@/lib/calls/call-mute";
 import { expectedRemoteIdentitiesForCallState } from "@/lib/calls/call-tiles";
 import {
   projectCallTiles,
@@ -254,6 +258,14 @@ const raisedHandIdentityKeys = computed(() => {
   }
   return keys;
 });
+
+// #1030: muted call presence state for the split-view tiles. Pure
+// INBOUND-REMOTE view — self-mute comes from `micEnabled`, so the local
+// identity is NOT folded in (unlike raised-hand above).
+const mutedParticipants = useStore($mucMutedParticipants);
+const mutedIdentityKeys = computed(() =>
+  mutedKeysForRoom(normalizedRoomJid.value, mutedParticipants.value),
+);
 const selfSharePresentation = computed(() =>
   localScreenSharePresentation({
     screenShareEnabled: screenShareEnabled.value,
@@ -273,6 +285,7 @@ const pictureInPictureProjection = computed(() =>
     localIdentity: localIdentity.value,
     expectedRemoteIdentities: expectedRemoteIdentities.value,
     micEnabled: micEnabled.value,
+    mutedKeys: mutedIdentityKeys.value,
     seenRemoteScreenTrackKeys: pictureInPictureSeenRemoteScreenTrackKeys.value,
     pinnedTileKey: pinnedTileKey.value,
     viewMode: viewMode.value,
@@ -533,6 +546,7 @@ async function togglePictureInPicture(): Promise<void> {
           :active-speaker-identities="activeSpeakerIdentities"
           :promoted-speaker-identity="promotedSpeakerIdentity"
           :raised-hand-keys="raisedHandIdentityKeys"
+          :muted-keys="mutedIdentityKeys"
           @open-participants="enterExpandedWithDock"
         />
         <div class="call-split__reactions" aria-live="polite" aria-atomic="false">

--- a/chat/src/components/calls/CallTile.vue
+++ b/chat/src/components/calls/CallTile.vue
@@ -33,8 +33,9 @@ const props = withDefaults(defineProps<{
   mirrorVideo: boolean;
   /** Whether to show the presenting affordance for screen tiles. */
   showsPresentingGlyph: boolean;
-  /** Whether the local mic is currently un-muted. Drives the
-   *  destructive `MicOff` badge on the self-tile. Ignored on remotes. */
+  /** Whether this tile's mic is currently un-muted. Drives the
+   *  destructive `MicOff` badge. Authoritative for both self (the local
+   *  mic flag) and remotes (presence-advertised mute, #1030). */
   micEnabled: boolean;
   /** Optional video track to render. When `null`, the placeholder
    *  layer shows through unchanged. */
@@ -149,9 +150,9 @@ const emit = defineEmits<{
         <Hand class="w-3.5 h-3.5" />
       </span>
       <span
-        v-if="isSelf && !micEnabled"
+        v-if="!micEnabled"
         class="call-tile__mic-off"
-        aria-label="Your mic is muted"
+        :aria-label="isSelf ? 'Your mic is muted' : 'Muted'"
       >
         <MicOff class="w-3.5 h-3.5" />
       </span>

--- a/chat/src/components/calls/CallTileGrid.vue
+++ b/chat/src/components/calls/CallTileGrid.vue
@@ -65,6 +65,9 @@ const props = defineProps<{
   /** Identity keys (`fullJidIdentityKey`) of participants with a raised
    *  hand (#1029); their camera tile shows the raised-hand badge. */
   raisedHandKeys?: ReadonlySet<string>;
+  /** Identity keys (`fullJidIdentityKey`) of remote participants muted via
+   *  `urn:waddle:in-call:0` presence (#1030); their tile mic hint is off. */
+  mutedKeys?: ReadonlySet<string>;
 }>();
 
 const emit = defineEmits<{
@@ -87,6 +90,7 @@ const projection = computed(() => {
     localIdentity: props.localIdentity,
     expectedRemoteIdentities: props.expectedRemoteIdentities,
     micEnabled: props.micEnabled,
+    mutedKeys: props.mutedKeys,
     seenRemoteScreenTrackKeys: seenRemoteScreenTrackKeys.value,
     pinnedTileKey: pinnedTileKey.value,
     viewMode: viewMode.value,

--- a/chat/src/lib/calls/call-controls.ts
+++ b/chat/src/lib/calls/call-controls.ts
@@ -7,6 +7,7 @@ import {
   type RawIqSender,
 } from "./call-store";
 import { broadcastMucCallSelfMute } from "./muc-call-actions";
+import { $callMicEnabled } from "./call-mic-state";
 import type { CallWireSender } from "./outbound";
 import { connectionStore } from "@/lib/connection-store";
 import { useCallEngine } from "./use-call-engine";
@@ -32,10 +33,15 @@ import {
  * The atoms here mirror the engine: when the user toggles mic via
  * the split-view control bar, the engine `setMicEnabled(false)` and
  * the atom flips at the same time. On failure the atom rolls back.
+ *
+ * `$callMicEnabled` is owned by the `call-mic-state` leaf (so the
+ * presence broadcaster in `muc-call-actions` can read it without a
+ * module cycle back into this file) and re-exported here for the many
+ * control-bar consumers that import it from `call-controls`.
  */
 export const $callConnecting = atom<boolean>(false);
-export const $callMicEnabled = atom<boolean>(true);
 export const $callCamEnabled = atom<boolean>(true);
+export { $callMicEnabled };
 export { $callScreenShareEnabled, $callScreenShareSupported, refreshScreenShareSupported };
 
 function isScreenSharePickerCancel(error: unknown): boolean {

--- a/chat/src/lib/calls/call-controls.ts
+++ b/chat/src/lib/calls/call-controls.ts
@@ -4,7 +4,9 @@ import {
   clearCallState,
   reportCallError,
   tearDownActiveCall,
+  type RawIqSender,
 } from "./call-store";
+import { broadcastMucCallSelfMute } from "./muc-call-actions";
 import type { CallWireSender } from "./outbound";
 import { connectionStore } from "@/lib/connection-store";
 import { useCallEngine } from "./use-call-engine";
@@ -63,6 +65,13 @@ export async function toggleMic(): Promise<void> {
     const { engine } = useCallEngine();
     await engine.setMicEnabled(next);
     clearMediaIssue("mic");
+    // #1030: broadcast the new mute state as `urn:waddle:in-call:0`
+    // presence so other participants' tiles and roster reflect it — the
+    // authoritative, XMPP-native remote-mute path (no LiveKit data
+    // channel). A no-op for DM calls; the broadcaster guards on an active
+    // MUC call. Fire-and-forget: a failed presence self-heals on the next.
+    const sender = getSender();
+    if (sender) void broadcastMucCallSelfMute(sender as unknown as RawIqSender, !next);
   } catch (err) {
     $callMicEnabled.set(!next);
     recordMediaIssue("mic", err);
@@ -178,6 +187,14 @@ export function seedCallControlsFromEngine(engine: {
   $callMicEnabled.set(engine.micEnabled);
   $callCamEnabled.set(engine.cameraEnabled);
   $callScreenShareEnabled.set(engine.screenShareEnabled ?? false);
+  // #1030: capture is best-effort, so the join-time mute advertisement
+  // (derived from the REQUESTED media) can be wrong — device missing,
+  // permission denied, or the user joined muted. Now that `$callMicEnabled`
+  // reflects the ACTUAL published mic, re-broadcast the true mute so peers'
+  // tiles/roster are accurate. No-op for DM calls; the broadcaster guards on
+  // an active MUC call, and `getSender()` is null outside a live connection.
+  const sender = getSender();
+  if (sender) void broadcastMucCallSelfMute(sender as unknown as RawIqSender, !engine.micEnabled);
 }
 
 /** Read the live call's peer label (`#room` for MUC, localpart for DM). */

--- a/chat/src/lib/calls/call-mic-state.ts
+++ b/chat/src/lib/calls/call-mic-state.ts
@@ -1,0 +1,27 @@
+import { atom } from "nanostores";
+
+/**
+ * Self mic / mute state, owned by a leaf module that imports nothing from
+ * the call surfaces — so the control bar (`call-controls.ts`) and the
+ * call-presence broadcaster (`muc-call-actions.ts`) can both read it
+ * without importing each other. Mirrors how `call-raised-hand.ts` owns the
+ * self raised-hand state independently; keeping this here is what keeps
+ * those two modules acyclic (the control bar calls the broadcaster, never
+ * the reverse).
+ *
+ * `$callMicEnabled` mirrors the engine: when the user toggles mic via a
+ * control bar, the engine `setMicEnabled(false)` and the atom flip
+ * together; on failure the atom rolls back. It is the single source of
+ * truth for self-mute (there is no separate mute-intent store).
+ */
+export const $callMicEnabled = atom<boolean>(true);
+
+/**
+ * This client's current self-mute, derived from the live mic toggle: muted
+ * ⇔ the mic is disabled. Every MUC call-presence re-emit must carry the
+ * CURRENT value so toggling the raised hand (or resuming) can't silently
+ * drop the `<muted/>` marker — presence is last-writer-wins (#1030).
+ */
+export function selfCallMuted(): boolean {
+  return !$callMicEnabled.get();
+}

--- a/chat/src/lib/calls/call-mute.ts
+++ b/chat/src/lib/calls/call-mute.ts
@@ -129,7 +129,11 @@ export function mutedKeysForRoom(
   return new Set(mutedByRoom[room] ?? []);
 }
 
-/** Forget every advertised mute (logout / disconnect). */
+/** Forget every advertised mute (logout / disconnect). Routed through the
+ *  reducer so an already-empty map returns the same reference and skips a
+ *  spurious store notification (and the re-renders it would trigger). */
 export function clearAllMuted(): void {
-  $mucMutedParticipants.set({});
+  $mucMutedParticipants.set(
+    reduceMutedParticipants($mucMutedParticipants.get(), { kind: "clear-all" }),
+  );
 }

--- a/chat/src/lib/calls/call-mute.ts
+++ b/chat/src/lib/calls/call-mute.ts
@@ -1,0 +1,135 @@
+import { map } from "nanostores";
+import { fullJidIdentityKey } from "@/lib/xmpp/jid";
+import { normalizeMucCallRoomJid } from "./muc-call-presence";
+
+/**
+ * Per-room set of call participants advertising a muted microphone
+ * (`urn:waddle:in-call:0` `<muted/>` presence state, #1030). Keyed by
+ * normalized room JID, then by `fullJidIdentityKey` of the occupant's
+ * real full JID — the SAME identity key the call roster and tiles use —
+ * so the UI can join "who is muted" against the roster rows and camera
+ * tiles without a second lookup table.
+ *
+ * This is the AUTHORITATIVE remote-mute view: it replaces LiveKit's own
+ * track-mute signalling (the non-XMPP control path) for displaying other
+ * participants' mute state. The local participant's own mute stays sourced
+ * from the LiveKit mic state (`$callMicEnabled`) — this map only carries
+ * remote occupants' presence-advertised mute.
+ *
+ * Fed by `applyMutePresence` from the chat-side presence wrapper: a MUC
+ * occupant's presence carries the `<muted/>` `<in-call>` child alongside
+ * `<muji/>` when muted, and omits it when unmuted. Leaving the call or the
+ * room clears the entry (unmuted / unavailable presence).
+ *
+ * Shape: `{ "room@muc.host": ["alice@host/web", "bob@host/phone"] }`,
+ * each list sorted for stable render order.
+ */
+export const $mucMutedParticipants = map<Record<string, string[]>>({});
+
+type MuteAction =
+  | { kind: "set"; roomJid: string; identityKey: string; muted: boolean }
+  | { kind: "clear-room"; roomJid: string }
+  | { kind: "clear-all" };
+
+/**
+ * Pure reducer over the room → identity-keys muted record. Never mutates
+ * `current`, and returns the SAME `current` reference for no-op updates
+ * (idempotent set, invalid room/id, clearing what's already absent) so a
+ * `$mucMutedParticipants.set(...)` round-trip skips the store notification
+ * and avoids spurious rerenders. Pruning an empty room keeps the record
+ * free of stale keys so `Object.keys` reflects rooms with live mutes.
+ */
+export function reduceMutedParticipants(
+  current: Record<string, string[]>,
+  action: MuteAction,
+): Record<string, string[]> {
+  if (action.kind === "clear-all") {
+    return Object.keys(current).length === 0 ? current : {};
+  }
+
+  const room = normalizeMucCallRoomJid(action.roomJid);
+  if (!room) return current;
+
+  if (action.kind === "clear-room") {
+    if (!(room in current)) return current;
+    const next = cloneRecord(current);
+    delete next[room];
+    return next;
+  }
+
+  const { identityKey, muted } = action;
+  if (!identityKey) return current;
+  const existing = current[room] ?? [];
+  const has = existing.includes(identityKey);
+
+  if (muted) {
+    if (has) return current;
+    const next = cloneRecord(current);
+    next[room] = [...existing, identityKey].sort();
+    return next;
+  }
+
+  if (!has) return current;
+  const next = cloneRecord(current);
+  const filtered = existing.filter((key) => key !== identityKey);
+  if (filtered.length === 0) delete next[room];
+  else next[room] = filtered;
+  return next;
+}
+
+function cloneRecord(current: Record<string, string[]>): Record<string, string[]> {
+  const next: Record<string, string[]> = {};
+  for (const [room, keys] of Object.entries(current)) next[room] = [...keys];
+  return next;
+}
+
+/** Minimal inbound presence shape this module reads. */
+type MutePresence = {
+  from?: string;
+  presence_type?: string;
+  muc_jid?: string | null;
+  muted?: boolean;
+};
+
+/**
+ * Map an inbound MUC presence to a mute `set` action, or `null` when it
+ * carries no usable occupant identity. The occupant's real full JID
+ * (`muc_jid`) is the join key; an anonymous presence without one is
+ * ignored. An unavailable presence or a missing flag both unmute. Pure —
+ * the store side effect lives in `applyMutePresence`.
+ */
+export function mutePresenceUpdate(
+  presence: MutePresence,
+): Extract<MuteAction, { kind: "set" }> | null {
+  if (!presence.from) return null;
+  const slash = presence.from.indexOf("/");
+  if (slash < 0) return null;
+  const roomJid = normalizeMucCallRoomJid(presence.from.slice(0, slash));
+  if (!roomJid) return null;
+  const identityKey = fullJidIdentityKey(presence.muc_jid);
+  if (!identityKey) return null;
+  const muted = presence.presence_type !== "unavailable" && presence.muted === true;
+  return { kind: "set", roomJid, identityKey, muted };
+}
+
+/** Apply an inbound presence's mute state to the store. */
+export function applyMutePresence(presence: MutePresence): void {
+  const action = mutePresenceUpdate(presence);
+  if (!action) return;
+  $mucMutedParticipants.set(reduceMutedParticipants($mucMutedParticipants.get(), action));
+}
+
+/** Identity keys muted in `roomJid` (empty set if none). */
+export function mutedKeysForRoom(
+  roomJid: string,
+  mutedByRoom: Record<string, readonly string[]> = $mucMutedParticipants.get(),
+): Set<string> {
+  const room = normalizeMucCallRoomJid(roomJid);
+  if (!room) return new Set();
+  return new Set(mutedByRoom[room] ?? []);
+}
+
+/** Forget every advertised mute (logout / disconnect). */
+export function clearAllMuted(): void {
+  $mucMutedParticipants.set({});
+}

--- a/chat/src/lib/calls/call-roster.ts
+++ b/chat/src/lib/calls/call-roster.ts
@@ -37,6 +37,14 @@ export type BuildCallRosterInput = {
   raisedHandKeys?: ReadonlySet<string>;
   /** Whether this client currently advertises a raised hand. */
   selfRaisedHand?: boolean;
+  /**
+   * Identity keys (`fullJidIdentityKey`) of remote attendees advertising
+   * a muted microphone via `urn:waddle:in-call:0` presence (#1030).
+   * Authoritative over track presence — LiveKit keeps a muted mic track
+   * published, so this presence signal is the only reliable remote-mute
+   * source. Defaults to empty. (Self mute comes from `localMicEnabled`.)
+   */
+  mutedKeys?: ReadonlySet<string>;
 };
 
 type MediaState = { micOn: boolean; cameraOn: boolean };
@@ -75,6 +83,7 @@ export function buildCallRoster(input: BuildCallRosterInput): CallRosterRow[] {
   const selfRowKey = selfKey || "self";
 
   const raisedHandKeys = input.raisedHandKeys ?? new Set<string>();
+  const mutedKeys = input.mutedKeys ?? new Set<string>();
 
   const rows: CallRosterRow[] = [];
   rows.push({
@@ -107,7 +116,8 @@ export function buildCallRoster(input: BuildCallRosterInput): CallRosterRow[] {
       identity,
       label: displayNameForIdentity(identity),
       isSelf: false,
-      micOn: media.micOn,
+      // Authoritative XMPP-presence mute wins over a still-published track.
+      micOn: media.micOn && !mutedKeys.has(key),
       cameraOn: media.cameraOn,
       speaking: speakingKeys.has(key),
       raisedHand: raisedHandKeys.has(key),

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -696,6 +696,7 @@ export async function tearDownActiveCall(
                   false, // preparing
                   false, // video
                   false, // hand_raised
+                  false, // muted — leaving clears all in-call state
                 );
               } catch (err) {
                 reportCallError(err);
@@ -755,6 +756,7 @@ export async function tearDownActiveCall(
                   false,
                   false,
                   false, // hand_raised
+                  false, // muted — leaving clears all in-call state
                 );
               } catch (err) {
                 reportCallError(err);
@@ -825,6 +827,7 @@ export type RawIqSender = {
     preparing: boolean,
     video: boolean,
     hand_raised: boolean,
+    muted: boolean,
   ) => Promise<void>;
 };
 
@@ -891,6 +894,7 @@ async function rollbackMucCallSetup(
         false,
         false,
         false, // hand_raised
+        false, // muted — rollback clears all in-call state
       );
     } catch (err) {
       reportCallError(err);
@@ -1037,6 +1041,7 @@ export async function beginMucCall(
       true, // preparing
       false, // video — irrelevant in preparing phase
       false, // hand_raised — a hand can't be raised before joining
+      false, // muted — in-call state isn't advertised before joining
     );
     assertMucSetupStillPending(normalizedRoomJid, selfNick, attemptId);
     // XEP-0272 §Joining: "The client MUST then wait until the MUC
@@ -1063,6 +1068,8 @@ export async function beginMucCall(
       false, // preparing
       media.video, // video
       selfRaisedHandFor(normalizedRoomJid), // hand_raised — preserve across re-emit
+      !media.audio, // muted — joining without mic capture advertises muted
+      // (#1030); a live mic toggle re-broadcasts the authoritative state
     );
     if (!mucSetupStillPending(normalizedRoomJid, selfNick, attemptId)) {
       await rollbackMucCallSetup(

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -689,15 +689,10 @@ export async function tearDownActiveCall(
             const raw = sender as RawIqSender;
             if (s.selfNick && raw.update_muji_presence) {
               try {
-                await raw.update_muji_presence(
-                  s.peer,
-                  s.selfNick,
-                  false, // active
-                  false, // preparing
-                  false, // video
-                  false, // hand_raised
-                  false, // muted — leaving clears all in-call state
-                );
+                await raw.update_muji_presence(s.peer, s.selfNick, false, false, false, {
+                  handRaised: false,
+                  muted: false, // leaving clears all in-call state
+                });
               } catch (err) {
                 reportCallError(err);
               } finally {
@@ -749,15 +744,10 @@ export async function tearDownActiveCall(
             const raw = sender as RawIqSender;
             if (s.selfNick && raw.update_muji_presence) {
               try {
-                await raw.update_muji_presence(
-                  s.peer,
-                  s.selfNick,
-                  false,
-                  false,
-                  false,
-                  false, // hand_raised
-                  false, // muted — leaving clears all in-call state
-                );
+                await raw.update_muji_presence(s.peer, s.selfNick, false, false, false, {
+                  handRaised: false,
+                  muted: false, // leaving clears all in-call state
+                });
               } catch (err) {
                 reportCallError(err);
               } finally {
@@ -826,8 +816,7 @@ export type RawIqSender = {
     active: boolean,
     preparing: boolean,
     video: boolean,
-    hand_raised: boolean,
-    muted: boolean,
+    in_call: { handRaised: boolean; muted: boolean },
   ) => Promise<void>;
 };
 
@@ -887,15 +876,10 @@ async function rollbackMucCallSetup(
 ): Promise<void> {
   if (sender.update_muji_presence) {
     try {
-      await sender.update_muji_presence(
-        roomJid,
-        selfNick,
-        false,
-        false,
-        false,
-        false, // hand_raised
-        false, // muted — rollback clears all in-call state
-      );
+      await sender.update_muji_presence(roomJid, selfNick, false, false, false, {
+        handRaised: false,
+        muted: false, // rollback clears all in-call state
+      });
     } catch (err) {
       reportCallError(err);
     } finally {
@@ -1034,15 +1018,11 @@ export async function beginMucCall(
       PREPARING_ECHO_TIMEOUT_MS,
       selfFullJid,
     );
-    await sender.update_muji_presence(
-      normalizedRoomJid,
-      selfNick,
-      false, // active (no <content/> yet)
-      true, // preparing
-      false, // video — irrelevant in preparing phase
-      false, // hand_raised — a hand can't be raised before joining
-      false, // muted — in-call state isn't advertised before joining
-    );
+    await sender.update_muji_presence(normalizedRoomJid, selfNick, false, true, false, {
+      // in-call state isn't advertised before joining
+      handRaised: false,
+      muted: false,
+    });
     assertMucSetupStillPending(normalizedRoomJid, selfNick, attemptId);
     // XEP-0272 §Joining: "The client MUST then wait until the MUC
     // rebroadcasts its presence message", then wait for other
@@ -1061,16 +1041,12 @@ export async function beginMucCall(
     // Step 2 — content-declaring presence. XEP-0272 §Joining says a
     // client advertises contents in MUC presence before initiating
     // the corresponding Jingle sessions.
-    await sender.update_muji_presence(
-      normalizedRoomJid,
-      selfNick,
-      true, // active
-      false, // preparing
-      media.video, // video
-      selfRaisedHandFor(normalizedRoomJid), // hand_raised — preserve across re-emit
-      !media.audio, // muted — joining without mic capture advertises muted
-      // (#1030); a live mic toggle re-broadcasts the authoritative state
-    );
+    await sender.update_muji_presence(normalizedRoomJid, selfNick, true, false, media.video, {
+      handRaised: selfRaisedHandFor(normalizedRoomJid), // preserve across re-emit
+      // joining without mic capture advertises muted (#1030); a live mic
+      // toggle re-broadcasts the authoritative state post-connect
+      muted: !media.audio,
+    });
     if (!mucSetupStillPending(normalizedRoomJid, selfNick, attemptId)) {
       await rollbackMucCallSetup(
         sender,

--- a/chat/src/lib/calls/call-tiles.ts
+++ b/chat/src/lib/calls/call-tiles.ts
@@ -1,7 +1,7 @@
 import type { CallTrackSource, LocalMediaTrack, RemoteMediaTrack } from "./engine";
 import type { TileAttachable } from "./tile-attach";
 import type { CallState } from "./types";
-import { barePeerJid } from "../xmpp/jid";
+import { barePeerJid, fullJidIdentityKey } from "../xmpp/jid";
 
 type TileSource = "camera" | "screen_share";
 
@@ -24,6 +24,13 @@ export type BuildCallTilesInput = {
   localIdentity: string | null;
   expectedRemoteIdentities?: readonly string[];
   micEnabled: boolean;
+  /**
+   * Identity keys (`fullJidIdentityKey`) of remote participants advertising
+   * a muted microphone via `urn:waddle:in-call:0` presence (#1030). A remote
+   * tile's `micEnabledHint` is the negation of membership here — authoritative
+   * over LiveKit track signalling. Self tiles always use `micEnabled`.
+   */
+  mutedKeys?: ReadonlySet<string>;
 };
 
 function displayNameForIdentity(identity: string): string {
@@ -61,7 +68,7 @@ function newTile(
   side: "self" | "remote",
   identity: string,
   source: TileSource,
-  micEnabled: boolean,
+  micEnabledHint: boolean,
 ): CallTileModel {
   const isSelf = side === "self";
   return {
@@ -73,7 +80,7 @@ function newTile(
     isSelf,
     mirrorVideo: isSelf && source === "camera",
     showsPresentingGlyph: source === "screen_share",
-    micEnabledHint: isSelf ? micEnabled : true,
+    micEnabledHint,
     videoTrack: null,
   };
 }
@@ -81,6 +88,12 @@ function newTile(
 export function buildCallTiles(input: BuildCallTilesInput): CallTileModel[] {
   const byKey = new Map<string, CallTileModel>();
   const activeRemoteBareIdentities = new Set<string>();
+  const mutedKeys = input.mutedKeys ?? new Set<string>();
+  // A remote tile's mic hint comes from authoritative XMPP presence mute
+  // (#1030), never a hard-coded `true`; LiveKit keeps a muted mic track
+  // published, so its track signalling can't tell us a remote is muted.
+  const remoteMicHint = (identity: string): boolean =>
+    !mutedKeys.has(fullJidIdentityKey(identity));
   const selfId = input.localTracks[0]?.participantIdentity ?? input.localIdentity ?? "you";
   byKey.set(callTileKey("self", selfId, "camera"), newTile("self", selfId, "camera", input.micEnabled));
 
@@ -102,7 +115,8 @@ export function buildCallTiles(input: BuildCallTilesInput): CallTileModel[] {
     if (remoteBareIdentity) activeRemoteBareIdentities.add(remoteBareIdentity);
     const source = tileSourceForTrack(remote.source);
     const key = callTileKey("remote", participantIdentity, source);
-    const existing = byKey.get(key) ?? newTile("remote", participantIdentity, source, input.micEnabled);
+    const existing =
+      byKey.get(key) ?? newTile("remote", participantIdentity, source, remoteMicHint(participantIdentity));
     if (remote.kind === "video") {
       existing.videoTrack = remote.track;
       if (source === "screen_share") existing.screenTrackKey = remote.publicationSid;
@@ -116,7 +130,7 @@ export function buildCallTiles(input: BuildCallTilesInput): CallTileModel[] {
     if (!bareIdentity || activeRemoteBareIdentities.has(bareIdentity)) continue;
     byKey.set(
       callTileKey("remote", trimmedIdentity, "camera"),
-      newTile("remote", trimmedIdentity, "camera", input.micEnabled),
+      newTile("remote", trimmedIdentity, "camera", remoteMicHint(trimmedIdentity)),
     );
   }
 

--- a/chat/src/lib/calls/call-tiles.ts
+++ b/chat/src/lib/calls/call-tiles.ts
@@ -80,7 +80,11 @@ function newTile(
     isSelf,
     mirrorVideo: isSelf && source === "camera",
     showsPresentingGlyph: source === "screen_share",
-    micEnabledHint,
+    // Mute is a microphone / person concept; a screen-share presentation
+    // tile has no mic, so it never carries a mute hint (#1030) — only the
+    // owner's camera tile reflects their mute, mirroring how #1029 confines
+    // the raised-hand badge to the camera tile.
+    micEnabledHint: source === "screen_share" ? true : micEnabledHint,
     videoTrack: null,
   };
 }

--- a/chat/src/lib/calls/muc-call-actions.ts
+++ b/chat/src/lib/calls/muc-call-actions.ts
@@ -1,20 +1,8 @@
 import { $callState, beginMucCall, reportCallError, type RawIqSender } from "./call-store";
-import { $callMicEnabled } from "./call-controls";
+import { selfCallMuted } from "./call-mic-state";
 import { LIVEKIT_JOIN_EXPIRY_SKEW_MS, liveKitJoinTokenExpiresAt } from "./dm-call-activity";
 import { clearMucCallParticipant, normalizeMucCallRoomJid } from "./muc-call-presence";
 import { selfRaisedHandFor, setSelfRaisedHand } from "./call-raised-hand";
-
-/**
- * This client's current self-mute, derived from the live mic toggle
- * (`$callMicEnabled`): muted ⇔ the mic is disabled. Mute has no separate
- * intent store (unlike the raised hand) — the LiveKit mic state IS the
- * source of truth. Every call-presence re-emit must carry the CURRENT
- * value so a hand toggle (or resume) can't silently drop the `<muted/>`
- * marker — presence is last-writer-wins (#1030).
- */
-function selfCallMuted(): boolean {
-  return !$callMicEnabled.get();
-}
 import {
   forgetMucCallSession,
   markMucCallSessionTerminatePending,

--- a/chat/src/lib/calls/muc-call-actions.ts
+++ b/chat/src/lib/calls/muc-call-actions.ts
@@ -120,15 +120,10 @@ export async function leaveRetainedMucCallAction({
   const cachedSession = readMucCallSession({ roomJid, selfFullJid });
   let terminated = !cachedSession;
   try {
-    await sender.update_muji_presence(
-      roomJid,
-      selfNick,
-      false,
-      false,
-      false,
-      false, // hand_raised
-      false, // muted — leaving the call clears all in-call state
-    );
+    await sender.update_muji_presence(roomJid, selfNick, false, false, false, {
+      handRaised: false,
+      muted: false, // leaving the call clears all in-call state
+    });
     clearMucCallParticipant(roomJid, selfNick, selfFullJid, {
       includeAggregate: true,
     });
@@ -276,15 +271,10 @@ export async function resumeMucCallActivity({
   const sender = getSender();
   if (sender?.update_muji_presence) {
     try {
-      await sender.update_muji_presence(
-        session.roomJid,
-        selfNick,
-        true, // active
-        false, // preparing
-        media.video,
-        selfRaisedHandFor(session.roomJid), // hand_raised — preserve across resume
-        selfCallMuted(), // muted — preserve across resume
-      );
+      await sender.update_muji_presence(session.roomJid, selfNick, true, false, media.video, {
+        handRaised: selfRaisedHandFor(session.roomJid), // preserve across resume
+        muted: selfCallMuted(), // preserve across resume
+      });
     } catch (err) {
       reportCallError(err);
     }
@@ -321,16 +311,12 @@ export async function setMucCallHandRaised(
 
   setSelfRaisedHand(roomJid, raised);
   try {
-    await sender.update_muji_presence(
-      roomJid,
-      state.selfNick,
-      true, // active — still in the call
-      false, // preparing
-      state.media.video,
-      raised,
-      selfCallMuted(), // muted — re-stamp current mute so a hand toggle
-      // never drops the `<muted/>` marker (presence is last-writer-wins)
-    );
+    await sender.update_muji_presence(roomJid, state.selfNick, true, false, state.media.video, {
+      handRaised: raised,
+      // re-stamp the current mute so a hand toggle never drops the
+      // `<muted/>` marker (presence is last-writer-wins)
+      muted: selfCallMuted(),
+    });
     return true;
   } catch (err) {
     // Revert the optimistic flip — but only if a newer toggle hasn't
@@ -374,15 +360,10 @@ export async function broadcastMucCallSelfMute(
   if (!roomJid) return false;
 
   try {
-    await sender.update_muji_presence(
-      roomJid,
-      state.selfNick,
-      true, // active — still in the call
-      false, // preparing
-      state.media.video,
-      selfRaisedHandFor(roomJid), // hand_raised — preserve across a mute toggle
+    await sender.update_muji_presence(roomJid, state.selfNick, true, false, state.media.video, {
+      handRaised: selfRaisedHandFor(roomJid), // preserve across a mute toggle
       muted,
-    );
+    });
     return true;
   } catch (err) {
     reportCallError(err);

--- a/chat/src/lib/calls/muc-call-actions.ts
+++ b/chat/src/lib/calls/muc-call-actions.ts
@@ -1,7 +1,20 @@
 import { $callState, beginMucCall, reportCallError, type RawIqSender } from "./call-store";
+import { $callMicEnabled } from "./call-controls";
 import { LIVEKIT_JOIN_EXPIRY_SKEW_MS, liveKitJoinTokenExpiresAt } from "./dm-call-activity";
 import { clearMucCallParticipant, normalizeMucCallRoomJid } from "./muc-call-presence";
 import { selfRaisedHandFor, setSelfRaisedHand } from "./call-raised-hand";
+
+/**
+ * This client's current self-mute, derived from the live mic toggle
+ * (`$callMicEnabled`): muted ⇔ the mic is disabled. Mute has no separate
+ * intent store (unlike the raised hand) — the LiveKit mic state IS the
+ * source of truth. Every call-presence re-emit must carry the CURRENT
+ * value so a hand toggle (or resume) can't silently drop the `<muted/>`
+ * marker — presence is last-writer-wins (#1030).
+ */
+function selfCallMuted(): boolean {
+  return !$callMicEnabled.get();
+}
 import {
   forgetMucCallSession,
   markMucCallSessionTerminatePending,
@@ -114,6 +127,7 @@ export async function leaveRetainedMucCallAction({
       false,
       false,
       false, // hand_raised
+      false, // muted — leaving the call clears all in-call state
     );
     clearMucCallParticipant(roomJid, selfNick, selfFullJid, {
       includeAggregate: true,
@@ -269,6 +283,7 @@ export async function resumeMucCallActivity({
         false, // preparing
         media.video,
         selfRaisedHandFor(session.roomJid), // hand_raised — preserve across resume
+        selfCallMuted(), // muted — preserve across resume
       );
     } catch (err) {
       reportCallError(err);
@@ -313,6 +328,8 @@ export async function setMucCallHandRaised(
       false, // preparing
       state.media.video,
       raised,
+      selfCallMuted(), // muted — re-stamp current mute so a hand toggle
+      // never drops the `<muted/>` marker (presence is last-writer-wins)
     );
     return true;
   } catch (err) {
@@ -322,6 +339,52 @@ export async function setMucCallHandRaised(
     if (selfRaisedHandFor(roomJid) === raised) {
       setSelfRaisedHand(roomJid, !raised);
     }
+    reportCallError(err);
+    return false;
+  }
+}
+
+/**
+ * Broadcast this client's mute state to the active MUC call as
+ * `urn:waddle:in-call:0` presence (#1030). Mirrors
+ * [`setMucCallHandRaised`]: "setting" mute means re-emitting our current
+ * active call presence with the `<muted/>` marker toggled — the wasm FFI
+ * builds the `<in-call>` child when `muted` is true and omits it (unmuting
+ * for everyone) when false. Re-stamps the CURRENT raised hand so a mute
+ * toggle never drops it.
+ *
+ * The local mic toggle (`$callMicEnabled`) is the source of truth and is
+ * already flipped by the caller, so there is no optimistic state to roll
+ * back here — a failed broadcast just leaves peers momentarily stale until
+ * the next presence, and is reported.
+ *
+ * No-op (returns `false`) unless we're in an active MUC call with a known
+ * nick and a wasm client that exposes the presence FFI.
+ */
+export async function broadcastMucCallSelfMute(
+  sender: RawIqSender,
+  muted: boolean,
+): Promise<boolean> {
+  const state = $callState.get();
+  if (state.phase !== "active" || state.kind !== "muc" || !state.selfNick) {
+    return false;
+  }
+  if (!sender.update_muji_presence) return false;
+  const roomJid = normalizeMucCallRoomJid(state.peer);
+  if (!roomJid) return false;
+
+  try {
+    await sender.update_muji_presence(
+      roomJid,
+      state.selfNick,
+      true, // active — still in the call
+      false, // preparing
+      state.media.video,
+      selfRaisedHandFor(roomJid), // hand_raised — preserve across a mute toggle
+      muted,
+    );
+    return true;
+  } catch (err) {
     reportCallError(err);
     return false;
   }

--- a/chat/src/lib/calls/use-call-roster.ts
+++ b/chat/src/lib/calls/use-call-roster.ts
@@ -9,6 +9,7 @@ import {
   raisedHandKeysForRoom,
   selfRaisedHandFor,
 } from "./call-raised-hand";
+import { $mucMutedParticipants, mutedKeysForRoom } from "./call-mute";
 import { useCallEngine } from "./use-call-engine";
 import { useCallVolumeMixer } from "./use-call-volume-mixer";
 import { remoteParticipantIdentitiesForCall } from "./call-remote-identities";
@@ -40,6 +41,7 @@ export function useCallRoster(
   const volumeMixer = useCallVolumeMixer(normalizedRoomJid);
   const raisedHands = useStore($mucRaisedHands);
   const selfRaisedHand = useStore($selfRaisedHand);
+  const mutedParticipants = useStore($mucMutedParticipants);
 
   // Reactive local identity from the active call's LiveKit join, NOT the
   // engine's non-reactive `localIdentity` getter. A `computed` over the
@@ -72,6 +74,7 @@ export function useCallRoster(
       volumeRows: volumeMixer.rows.value,
       raisedHandKeys: raisedHandKeysForRoom(normalizedRoomJid.value, raisedHands.value),
       selfRaisedHand: selfRaisedHandFor(normalizedRoomJid.value, selfRaisedHand.value),
+      mutedKeys: mutedKeysForRoom(normalizedRoomJid.value, mutedParticipants.value),
     }),
   );
 

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -28,6 +28,7 @@ import {
   applyRaisedHandPresence,
   clearAllRaisedHands,
 } from "@/lib/calls/call-raised-hand";
+import { applyMutePresence, clearAllMuted } from "@/lib/calls/call-mute";
 import { clearAllLiveCallParticipants } from "@/lib/calls/muc-call-live-participants";
 import { useCallEngine } from "@/lib/calls/use-call-engine";
 import type { CallWireSender } from "@/lib/calls/outbound";
@@ -1315,6 +1316,7 @@ export class BrowserXmppClient {
     clearDmCallActivities();
     clearMucCallParticipants();
     clearAllRaisedHands();
+    clearAllMuted();
     clearAllLiveCallParticipants();
     // Best-effort hangup: if we're in a call when the user logs out
     // we want the peer to see session-terminate before the stream
@@ -3496,6 +3498,7 @@ export class BrowserXmppClient {
     clearCallState();
     clearMucCallParticipants();
     clearAllRaisedHands();
+    clearAllMuted();
     clearAllLiveCallParticipants();
     void useCallEngine().engine.disconnect();
     this.rejectRoomJoinWaiters(new Error("XMPP disconnected while joining a room"));
@@ -3926,9 +3929,11 @@ export class BrowserXmppClient {
       // (channel header, sidebar, list) can render "N in call"
       // without subscribing to the raw presence stream.
       applyMucCallPresence(presence);
-      // #1029: the raised-hand `<in-call>` presence state rides the same
-      // stanza; mirror it into the per-room raised-hand store.
+      // #1029/#1030: the raised-hand and mute `<in-call>` presence states
+      // ride the same stanza; mirror each into its per-room store. Mute is
+      // the authoritative remote-mute source (replaces LiveKit signalling).
       applyRaisedHandPresence(presence);
+      applyMutePresence(presence);
     });
     xmpp.set_on_message_delivery_acked?.((id: string) => {
       if (!this.isCurrentXmpp(xmpp)) return;
@@ -4035,6 +4040,7 @@ export class BrowserXmppClient {
       this.handlePresence(presence);
       applyMucCallPresence(presence);
       applyRaisedHandPresence(presence);
+      applyMutePresence(presence);
     });
   }
 }

--- a/chat/src/lib/xmpp/wasm-types.ts
+++ b/chat/src/lib/xmpp/wasm-types.ts
@@ -252,6 +252,13 @@ export interface WasmPresence {
    * alongside `<muji/>`. Absent/false means the hand is lowered.
    */
   hand_raised?: boolean;
+  /**
+   * Waddle mute call presence state (#1030). `true` when the occupant's
+   * presence carries a `<muted/>` marker on the same `<in-call>` carrier.
+   * Absent/false means the microphone is unmuted. Drives the
+   * authoritative remote-mute indicator on tiles and in the roster.
+   */
+  muted?: boolean;
 }
 
 /**

--- a/chat/tests/call-mute.test.ts
+++ b/chat/tests/call-mute.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "bun:test";
+
+import { mutePresenceUpdate, reduceMutedParticipants } from "../src/lib/calls/call-mute";
+
+describe("muted-participants reducer", () => {
+  test("set marks a participant muted keyed by identity", () => {
+    const next = reduceMutedParticipants(
+      {},
+      {
+        kind: "set",
+        roomJid: "room@muc.test",
+        identityKey: "alice@muc.test/web",
+        muted: true,
+      },
+    );
+    expect(next).toEqual({ "room@muc.test": ["alice@muc.test/web"] });
+  });
+
+  test("unmuting removes the participant and prunes the empty room", () => {
+    const muted = { "room@muc.test": ["alice@muc.test/web"] };
+    const next = reduceMutedParticipants(muted, {
+      kind: "set",
+      roomJid: "room@muc.test",
+      identityKey: "alice@muc.test/web",
+      muted: false,
+    });
+    expect(next).toEqual({});
+  });
+
+  test("a second muted participant coexists and the list stays sorted", () => {
+    let state = reduceMutedParticipants(
+      {},
+      { kind: "set", roomJid: "r@muc.test", identityKey: "bob@muc.test/x", muted: true },
+    );
+    state = reduceMutedParticipants(state, {
+      kind: "set",
+      roomJid: "r@muc.test",
+      identityKey: "alice@muc.test/y",
+      muted: true,
+    });
+    expect(state["r@muc.test"]).toEqual(["alice@muc.test/y", "bob@muc.test/x"]);
+  });
+
+  test("muting an already-muted participant is idempotent", () => {
+    const muted = { "r@muc.test": ["a@muc.test/1"] };
+    const next = reduceMutedParticipants(muted, {
+      kind: "set",
+      roomJid: "r@muc.test",
+      identityKey: "a@muc.test/1",
+      muted: true,
+    });
+    expect(next).toEqual(muted);
+  });
+
+  test("clear-room drops only that room", () => {
+    const state = { r1: ["a@x/1"], r2: ["b@x/1"] };
+    expect(reduceMutedParticipants(state, { kind: "clear-room", roomJid: "r1" })).toEqual({
+      r2: ["b@x/1"],
+    });
+  });
+
+  test("returns the same reference for no-op updates (no spurious rerenders)", () => {
+    const state = { "r@muc.test": ["a@x/1"] };
+    // Muting an already-muted participant.
+    expect(
+      reduceMutedParticipants(state, {
+        kind: "set",
+        roomJid: "r@muc.test",
+        identityKey: "a@x/1",
+        muted: true,
+      }),
+    ).toBe(state);
+    // Unmuting a participant that was never muted.
+    expect(
+      reduceMutedParticipants(state, {
+        kind: "set",
+        roomJid: "r@muc.test",
+        identityKey: "nobody@x/1",
+        muted: false,
+      }),
+    ).toBe(state);
+    // clear-room for a room with no mutes.
+    expect(
+      reduceMutedParticipants(state, { kind: "clear-room", roomJid: "other@muc.test" }),
+    ).toBe(state);
+    // clear-all on an already-empty record.
+    const empty = {};
+    expect(reduceMutedParticipants(empty, { kind: "clear-all" })).toBe(empty);
+  });
+
+  test("does not mutate the input record", () => {
+    const input = { "r@muc.test": ["a@x/1"] };
+    const snapshot = structuredClone(input);
+    reduceMutedParticipants(input, {
+      kind: "set",
+      roomJid: "r@muc.test",
+      identityKey: "b@x/2",
+      muted: true,
+    });
+    expect(input).toEqual(snapshot);
+  });
+});
+
+describe("mutePresenceUpdate", () => {
+  test("maps a muted presence to a set action keyed by real JID", () => {
+    expect(
+      mutePresenceUpdate({
+        from: "room@muc.test/alice",
+        muc_jid: "alice@host/web",
+        muted: true,
+      }),
+    ).toEqual({
+      kind: "set",
+      roomJid: "room@muc.test",
+      identityKey: "alice@host/web",
+      muted: true,
+    });
+  });
+
+  test("absent muted flag unmutes", () => {
+    expect(
+      mutePresenceUpdate({
+        from: "room@muc.test/alice",
+        muc_jid: "alice@host/web",
+      })?.muted,
+    ).toBe(false);
+  });
+
+  test("unavailable presence unmutes even when the flag is set", () => {
+    expect(
+      mutePresenceUpdate({
+        from: "room@muc.test/alice",
+        presence_type: "unavailable",
+        muc_jid: "alice@host/web",
+        muted: true,
+      })?.muted,
+    ).toBe(false);
+  });
+
+  test("returns null when the occupant's real JID is unknown", () => {
+    expect(mutePresenceUpdate({ from: "room@muc.test/alice", muted: true })).toBeNull();
+  });
+});

--- a/chat/tests/call-roster.test.ts
+++ b/chat/tests/call-roster.test.ts
@@ -106,6 +106,32 @@ describe("buildCallRoster", () => {
     expect(byLabel.carol).toEqual({ micOn: false, cameraOn: false });
   });
 
+  test("presence-advertised mute overrides a live audio track for remote attendees (#1030)", () => {
+    const rows = buildCallRoster({
+      remoteParticipantIdentities: [
+        "alice@waddle.test/web",
+        "bob@waddle.test/desktop",
+      ],
+      // Both keep a published mic track — LiveKit's default leaves the track
+      // live while muted, so track presence alone cannot tell us mute state.
+      remoteTracks: [
+        remoteTrack("alice-mic", "alice@waddle.test/web", "audio", "microphone"),
+        remoteTrack("bob-mic", "bob@waddle.test/desktop", "audio", "microphone"),
+      ],
+      localIdentity: "me@waddle.test/browser",
+      localMicEnabled: true,
+      localCameraEnabled: false,
+      activeSpeakerIdentities: new Set<string>(),
+      volumeRows: [],
+      mutedKeys: new Set<string>(["alice@waddle.test/web"]),
+    });
+
+    const byLabel = Object.fromEntries(rows.map((row) => [row.label, row.micOn]));
+    // Authoritative XMPP presence mute wins over the live track.
+    expect(byLabel.alice).toBe(false);
+    expect(byLabel.bob).toBe(true);
+  });
+
   test("self mic and camera reflect the local flags, not self tracks", () => {
     const rows = buildCallRoster({
       remoteParticipantIdentities: [],

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -1070,8 +1070,7 @@ describe("leaveRetainedMucCallAction", () => {
       false,
       false,
       false,
-      false,
-      false, // muted — leaving clears all in-call state (#1030)
+      { handRaised: false, muted: false }, // leaving clears all in-call state (#1030)
     );
     expect($mucCallParticipants.get()).toEqual({
       "chan@muc.test": ["alice"],
@@ -1103,8 +1102,7 @@ describe("leaveRetainedMucCallAction", () => {
       false,
       false,
       false,
-      false,
-      false, // muted — leaving clears all in-call state (#1030)
+      { handRaised: false, muted: false }, // leaving clears all in-call state (#1030)
     );
     expect($mucCallParticipants.get()).toEqual({});
     expect($mucCallParticipantOwners.get()).toEqual({});
@@ -1141,7 +1139,7 @@ describe("leaveRetainedMucCallAction", () => {
     })).resolves.toBe(true);
 
     expect(sent).toEqual([
-      ["presence", "chan@muc.test", "alice", false, false, false, false, false],
+      ["presence", "chan@muc.test", "alice", false, false, false, { handRaised: false, muted: false }],
       ["terminate", "chan@muc.test", "muc-recovered-live"],
     ]);
     expect($mucCallParticipants.get()).toEqual({});
@@ -1187,8 +1185,7 @@ describe("leaveRetainedMucCallAction", () => {
       false,
       false,
       false,
-      false,
-      false, // muted — leaving clears all in-call state (#1030)
+      { handRaised: false, muted: false }, // leaving clears all in-call state (#1030)
     );
     expect(sender.send_muji_session_terminate).toHaveBeenCalledWith(
       "chan@muc.test",
@@ -1239,8 +1236,7 @@ describe("leaveRetainedMucCallAction", () => {
       false,
       false,
       false,
-      false,
-      false, // muted — leaving clears all in-call state (#1030)
+      { handRaised: false, muted: false }, // leaving clears all in-call state (#1030)
     );
     expect($mucCallParticipants.get()).toEqual({
       "chan@muc.test": ["alice"],
@@ -2029,8 +2025,8 @@ describe("MUC group call", () => {
       true,
       false,
       true,
-      false,
-      false, // muted — audioVideo fixture captures audio, so !audio = false (#1030)
+      // audioVideo fixture captures audio, so !audio = false (#1030)
+      { handRaised: false, muted: false },
     );
     expect(send_muji_session_initiate).toHaveBeenCalledTimes(1);
     expect($callState.get()).toMatchObject({
@@ -2210,8 +2206,7 @@ describe("MUC group call", () => {
       false,
       false,
       false,
-      false,
-      false, // muted — leaving clears all in-call state (#1030)
+      { handRaised: false, muted: false }, // leaving clears all in-call state (#1030)
     );
     expect($callState.get()).toEqual({ phase: "idle" });
   });
@@ -2361,8 +2356,8 @@ describe("MUC group call", () => {
       false, // active
       true, // preparing
       false, // video — irrelevant in preparing phase
-      false, // hand_raised
-      false, // muted — in-call state isn't advertised before joining (#1030)
+      // in-call state isn't advertised before joining (#1030)
+      { handRaised: false, muted: false },
     );
     expect(update_muji_presence).toHaveBeenNthCalledWith(
       2,
@@ -2371,8 +2366,8 @@ describe("MUC group call", () => {
       true, // active
       false, // preparing
       true, // video (audioVideo fixture has video=true)
-      false, // hand_raised
-      false, // muted — audioVideo fixture captures audio, so !audio = false (#1030)
+      // audioVideo fixture captures audio, so !audio = false (#1030)
+      { handRaised: false, muted: false },
     );
     expect(send_muji_session_initiate).toHaveBeenCalledTimes(1);
   });
@@ -2407,8 +2402,7 @@ describe("MUC group call", () => {
       false, // active
       false, // preparing
       false, // video
-      false, // hand_raised
-      false, // muted — teardown clears all in-call state (#1030)
+      { handRaised: false, muted: false }, // teardown clears all in-call state (#1030)
     );
     expect($callState.get()).toEqual({ phase: "idle" });
   });
@@ -2445,8 +2439,7 @@ describe("MUC group call", () => {
       false, // active
       false, // preparing
       false, // video
-      false, // hand_raised
-      false, // muted — teardown clears all in-call state (#1030)
+      { handRaised: false, muted: false }, // teardown clears all in-call state (#1030)
     );
     expect($callState.get()).toEqual({ phase: "idle" });
   });

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -1071,6 +1071,7 @@ describe("leaveRetainedMucCallAction", () => {
       false,
       false,
       false,
+      false, // muted — leaving clears all in-call state (#1030)
     );
     expect($mucCallParticipants.get()).toEqual({
       "chan@muc.test": ["alice"],
@@ -1103,6 +1104,7 @@ describe("leaveRetainedMucCallAction", () => {
       false,
       false,
       false,
+      false, // muted — leaving clears all in-call state (#1030)
     );
     expect($mucCallParticipants.get()).toEqual({});
     expect($mucCallParticipantOwners.get()).toEqual({});
@@ -1139,7 +1141,7 @@ describe("leaveRetainedMucCallAction", () => {
     })).resolves.toBe(true);
 
     expect(sent).toEqual([
-      ["presence", "chan@muc.test", "alice", false, false, false, false],
+      ["presence", "chan@muc.test", "alice", false, false, false, false, false],
       ["terminate", "chan@muc.test", "muc-recovered-live"],
     ]);
     expect($mucCallParticipants.get()).toEqual({});
@@ -1186,6 +1188,7 @@ describe("leaveRetainedMucCallAction", () => {
       false,
       false,
       false,
+      false, // muted — leaving clears all in-call state (#1030)
     );
     expect(sender.send_muji_session_terminate).toHaveBeenCalledWith(
       "chan@muc.test",
@@ -1237,6 +1240,7 @@ describe("leaveRetainedMucCallAction", () => {
       false,
       false,
       false,
+      false, // muted — leaving clears all in-call state (#1030)
     );
     expect($mucCallParticipants.get()).toEqual({
       "chan@muc.test": ["alice"],
@@ -2026,6 +2030,7 @@ describe("MUC group call", () => {
       false,
       true,
       false,
+      false, // muted — audioVideo fixture captures audio, so !audio = false (#1030)
     );
     expect(send_muji_session_initiate).toHaveBeenCalledTimes(1);
     expect($callState.get()).toMatchObject({
@@ -2206,6 +2211,7 @@ describe("MUC group call", () => {
       false,
       false,
       false,
+      false, // muted — leaving clears all in-call state (#1030)
     );
     expect($callState.get()).toEqual({ phase: "idle" });
   });
@@ -2356,6 +2362,7 @@ describe("MUC group call", () => {
       true, // preparing
       false, // video — irrelevant in preparing phase
       false, // hand_raised
+      false, // muted — in-call state isn't advertised before joining (#1030)
     );
     expect(update_muji_presence).toHaveBeenNthCalledWith(
       2,
@@ -2365,6 +2372,7 @@ describe("MUC group call", () => {
       false, // preparing
       true, // video (audioVideo fixture has video=true)
       false, // hand_raised
+      false, // muted — audioVideo fixture captures audio, so !audio = false (#1030)
     );
     expect(send_muji_session_initiate).toHaveBeenCalledTimes(1);
   });
@@ -2400,6 +2408,7 @@ describe("MUC group call", () => {
       false, // preparing
       false, // video
       false, // hand_raised
+      false, // muted — teardown clears all in-call state (#1030)
     );
     expect($callState.get()).toEqual({ phase: "idle" });
   });
@@ -2437,6 +2446,7 @@ describe("MUC group call", () => {
       false, // preparing
       false, // video
       false, // hand_raised
+      false, // muted — teardown clears all in-call state (#1030)
     );
     expect($callState.get()).toEqual({ phase: "idle" });
   });

--- a/chat/tests/call-tiles.test.ts
+++ b/chat/tests/call-tiles.test.ts
@@ -53,6 +53,30 @@ describe("buildCallTiles micEnabledHint", () => {
     expect(self?.micEnabledHint).toBe(false);
   });
 
+  test("a muted owner's screen-share tile keeps micEnabledHint true (#1030)", () => {
+    // A presenter who mutes their mic while sharing their screen must NOT
+    // get a mic-off badge on the screen-share tile — mute is a mic concept,
+    // not a screen concept. Only their camera tile reflects the mute.
+    const tiles = buildCallTiles({
+      remoteTracks: [
+        remoteTrack("alice-cam", "alice@waddle.test/web", "video", "camera"),
+        remoteTrack("alice-screen", "alice@waddle.test/web", "video", "screen_share"),
+      ],
+      localTracks: [],
+      localIdentity: "me@waddle.test/browser",
+      micEnabled: true,
+      mutedKeys: new Set<string>(["alice@waddle.test/web"]),
+    });
+    const camera = tiles.find(
+      (tile) => tile.identity === "alice@waddle.test/web" && tile.source === "camera",
+    );
+    const screen = tiles.find(
+      (tile) => tile.identity === "alice@waddle.test/web" && tile.source === "screen_share",
+    );
+    expect(camera?.micEnabledHint).toBe(false); // muted → camera tile shows it
+    expect(screen?.micEnabledHint).toBe(true); // screen tile never shows mute
+  });
+
   test("defaults remote mic hint to enabled when no mutedKeys given", () => {
     const tiles = buildCallTiles({
       remoteTracks: [remoteTrack("alice-cam", "alice@waddle.test/web", "video", "camera")],

--- a/chat/tests/call-tiles.test.ts
+++ b/chat/tests/call-tiles.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { buildCallTiles } from "../src/lib/calls/call-tiles";
+import type { CallTrackSource, LocalMediaTrack, RemoteMediaTrack } from "../src/lib/calls/engine";
+
+const fakeTrack = {} as never;
+
+function remoteTrack(
+  publicationSid: string,
+  participantIdentity: string,
+  kind: "audio" | "video",
+  source: CallTrackSource,
+): RemoteMediaTrack {
+  return { participantIdentity, publicationSid, kind, source, track: fakeTrack };
+}
+
+function localTrack(
+  participantIdentity: string,
+  kind: "audio" | "video",
+  source: CallTrackSource,
+): LocalMediaTrack {
+  return { participantIdentity, kind, source, track: fakeTrack, publicationSid: "self-pub" };
+}
+
+describe("buildCallTiles micEnabledHint", () => {
+  test("remote tile mic hint reflects presence mute, not a hard-coded true (#1030)", () => {
+    const tiles = buildCallTiles({
+      remoteTracks: [
+        remoteTrack("alice-cam", "alice@waddle.test/web", "video", "camera"),
+        remoteTrack("bob-cam", "bob@waddle.test/desktop", "video", "camera"),
+      ],
+      localTracks: [localTrack("me@waddle.test/browser", "video", "camera")],
+      localIdentity: "me@waddle.test/browser",
+      micEnabled: true,
+      mutedKeys: new Set<string>(["alice@waddle.test/web"]),
+    });
+
+    const alice = tiles.find((tile) => tile.identity === "alice@waddle.test/web" && tile.source === "camera");
+    const bob = tiles.find((tile) => tile.identity === "bob@waddle.test/desktop" && tile.source === "camera");
+    expect(alice?.micEnabledHint).toBe(false);
+    expect(bob?.micEnabledHint).toBe(true);
+  });
+
+  test("self tile mic hint reflects the local mic flag regardless of mutedKeys", () => {
+    const tiles = buildCallTiles({
+      remoteTracks: [],
+      localTracks: [localTrack("me@waddle.test/browser", "video", "camera")],
+      localIdentity: "me@waddle.test/browser",
+      micEnabled: false,
+      // Even if our own identity leaked into mutedKeys, self uses micEnabled.
+      mutedKeys: new Set<string>(["me@waddle.test/browser"]),
+    });
+    const self = tiles.find((tile) => tile.isSelf && tile.source === "camera");
+    expect(self?.micEnabledHint).toBe(false);
+  });
+
+  test("defaults remote mic hint to enabled when no mutedKeys given", () => {
+    const tiles = buildCallTiles({
+      remoteTracks: [remoteTrack("alice-cam", "alice@waddle.test/web", "video", "camera")],
+      localTracks: [],
+      localIdentity: "me@waddle.test/browser",
+      micEnabled: true,
+    });
+    const alice = tiles.find((tile) => tile.identity === "alice@waddle.test/web");
+    expect(alice?.micEnabledHint).toBe(true);
+  });
+});

--- a/cuenv.lock
+++ b/cuenv.lock
@@ -1,5 +1,11 @@
 version = 4
 
+[runtimes.chat]
+type = "nix"
+flake = ".."
+digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
+lockfile = "chat/../flake.lock"
+
 [runtimes.colony]
 type = "nix"
 flake = ".."
@@ -11,6 +17,18 @@ type = "nix"
 flake = "../.."
 digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
 lockfile = "infrastructure/waddle.cloud/../../flake.lock"
+
+[runtimes.server]
+type = "nix"
+flake = ".."
+digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
+lockfile = "server/../flake.lock"
+
+[runtimes.website]
+type = "nix"
+flake = ".."
+digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
+lockfile = "website/../flake.lock"
 
 [vcs.cuenv-skills]
 url = "https://github.com/cuenv/cuenv.git"

--- a/cuenv.lock
+++ b/cuenv.lock
@@ -1,11 +1,5 @@
 version = 4
 
-[runtimes.chat]
-type = "nix"
-flake = ".."
-digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
-lockfile = "chat/../flake.lock"
-
 [runtimes.colony]
 type = "nix"
 flake = ".."
@@ -17,18 +11,6 @@ type = "nix"
 flake = "../.."
 digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
 lockfile = "infrastructure/waddle.cloud/../../flake.lock"
-
-[runtimes.server]
-type = "nix"
-flake = ".."
-digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
-lockfile = "server/../flake.lock"
-
-[runtimes.website]
-type = "nix"
-flake = ".."
-digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
-lockfile = "website/../flake.lock"
 
 [vcs.cuenv-skills]
 url = "https://github.com/cuenv/cuenv.git"

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -322,11 +322,12 @@ async fn handle_muc_join_unlocked(
             .iter()
             .find(|existing| existing.nick == nick && existing.jid == *sender_jid)
             .and_then(|existing| existing.muji.as_ref());
-        let self_hand_raised = join_outcome
+        let self_in_call = join_outcome
             .existing_occupants
             .iter()
             .find(|existing| existing.nick == nick && existing.jid == *sender_jid)
-            .is_some_and(|existing| existing.hand_raised);
+            .map(|existing| existing.in_call)
+            .unwrap_or_default();
 
         info!(room = %room_jid, nick = %nick, occupants = occupant_count, "User joined MUC room");
 
@@ -381,13 +382,13 @@ async fn handle_muc_join_unlocked(
                 real_jid: &existing.jid,
                 include_self_status: false,
                 muji: existing.muji.as_ref(),
-                hand_raised: existing.hand_raised,
+                in_call: existing.in_call,
             }));
 
             for extra in replay_occupants.iter().copied().filter(|candidate| {
                 candidate.nick == existing.nick
                     && candidate.jid != existing.jid
-                    && (candidate.muji.is_some() || candidate.hand_raised)
+                    && (candidate.muji.is_some() || !candidate.in_call.is_empty())
             }) {
                 responses.push(build_muc_join_presence_xml(MucJoinPresence {
                     occupant_id_secret: &state.deps.occupant_id_secret,
@@ -399,7 +400,7 @@ async fn handle_muc_join_unlocked(
                     real_jid: &extra.jid,
                     include_self_status: false,
                     muji: extra.muji.as_ref(),
-                    hand_raised: extra.hand_raised,
+                    in_call: extra.in_call,
                 }));
             }
         }
@@ -442,7 +443,7 @@ async fn handle_muc_join_unlocked(
             real_jid: sender_jid,
             include_self_status: true,
             muji: self_muji,
-            hand_raised: self_hand_raised,
+            in_call: self_in_call,
         }));
 
         // Same-account sibling resources share one MUC nick. If a
@@ -455,7 +456,7 @@ async fn handle_muc_join_unlocked(
             existing.nick == nick
                 && existing.jid.to_bare() == sender_jid.to_bare()
                 && existing.jid != *sender_jid
-                && (existing.muji.is_some() || existing.hand_raised)
+                && (existing.muji.is_some() || !existing.in_call.is_empty())
         }) {
             responses.push(build_muc_join_presence_xml(MucJoinPresence {
                 occupant_id_secret: &state.deps.occupant_id_secret,
@@ -467,7 +468,7 @@ async fn handle_muc_join_unlocked(
                 real_jid: &existing.jid,
                 include_self_status: true,
                 muji: existing.muji.as_ref(),
-                hand_raised: existing.hand_raised,
+                in_call: existing.in_call,
             }));
         }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc/xml.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc/xml.rs
@@ -17,12 +17,14 @@ pub(crate) struct MucJoinPresence<'a> {
     /// self-presence and for occupants without an active Muji
     /// advertisement.
     pub(crate) muji: Option<&'a waddle_xmpp::xep::xep0272::Muji>,
-    /// Whether to append an `<in-call><hand-raised/></in-call>`
-    /// (`urn:waddle:in-call:0`, #1029) payload alongside `<muji/>`. Set
-    /// for the join-replay path when the occupant being replayed has a
-    /// raised hand, so a late joiner sees it immediately. `false` for
-    /// joiners' own self-presence and for occupants with no raised hand.
-    pub(crate) hand_raised: bool,
+    /// In-call presence state (`urn:waddle:in-call:0`, #1029 raised hand
+    /// / #1030 mute) to append as an `<in-call>` payload alongside
+    /// `<muji/>`. Set for the join-replay path when the occupant being
+    /// replayed advertises one, so a late joiner sees their hand/mute
+    /// immediately. Empty (default) for joiners' own self-presence and
+    /// for occupants advertising no in-call state — an empty state emits
+    /// no `<in-call>` element.
+    pub(crate) in_call: waddle_xmpp::xep::InCallPresenceState,
 }
 
 pub(crate) fn build_muc_join_presence_xml(params: MucJoinPresence<'_>) -> String {
@@ -62,14 +64,15 @@ pub(super) fn build_muc_join_presence_stanza(
         // XML hard rule).
         presence.payloads.push(muji.to_element());
     }
-    if params.hand_raised {
-        // The raised-hand `<in-call>` state is a sibling of `<muji>`
-        // (never nested), an additional namespaced presence extension
-        // per XEP-0045 §5.1.3. Built via the typed carrier helper.
+    if !params.in_call.is_empty() {
+        // The `<in-call>` state (raised hand / mute) is a sibling of
+        // `<muji>` (never nested), an additional namespaced presence
+        // extension per XEP-0045 §5.1.3. Built via the typed carrier
+        // helper, which emits one marker child per advertised sub-state.
         presence
             .payloads
             .push(waddle_xmpp::xep::build_in_call_presence_state_element(
-                &waddle_xmpp::xep::InCallPresenceState { hand_raised: true },
+                &params.in_call,
             ));
     }
     presence
@@ -180,6 +183,6 @@ pub(super) fn create_presence_stanza(
         real_jid,
         include_self_status: false,
         muji: None,
-        hand_raised: false,
+        in_call: waddle_xmpp::xep::InCallPresenceState::default(),
     })
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
@@ -37,7 +37,7 @@ use tracing::{debug, warn};
 use waddle_xmpp::muc::{
     build_occupant_presence_update,
     presence::NS_MUC,
-    room_actor::{ClearMujiPresence, UpsertHandRaised, UpsertMujiPresence},
+    room_actor::{ClearMujiPresence, UpsertInCallState, UpsertMujiPresence},
 };
 use waddle_xmpp::xep::xep0167::MediaKind;
 use waddle_xmpp::xep::xep0272::{find_muji, Muji, NS_MUJI};
@@ -240,33 +240,33 @@ pub(super) async fn try_handle_muc_presence_update(
         "Broadcasting MUC Muji presence update"
     );
 
-    // Apply the raised-hand presence state (#1029) carried on the same
-    // stanza. Tracked independently of muji so each stays single-purpose;
-    // the post-update per-session set decorates the reflected presences
-    // below with the room-authoritative `<in-call>` child rather than
-    // echoing the client payload (which would misattribute a sibling
-    // session's hand). The sender was already confirmed as an occupant
-    // via the muji upsert above, so a `None`/error here just means no
-    // hand state to reflect.
-    // Enforce the invariant "raised hand <-> active call participant"
+    // Apply the in-call presence state (#1029 raised hand / #1030 mute)
+    // carried on the same stanza. Tracked independently of muji so each
+    // stays single-purpose; the post-update per-session states decorate
+    // the reflected presences below with the room-authoritative
+    // `<in-call>` child rather than echoing the client payload (which
+    // would misattribute a sibling session's hand/mute). The sender was
+    // already confirmed as an occupant via the muji upsert above, so a
+    // `None`/error here just means no in-call state to reflect.
+    // Enforce the invariant "in-call state <-> active call participant"
     // server-side: when this stanza is the XEP-0272 leave marker
-    // (`clears_muji_presence`), the occupant is no longer in the call, so the
-    // hand MUST be lowered regardless of any `<in-call><hand-raised/></in-call>`
-    // a buggy or hostile client left on the stanza. Only an in-call presence
-    // (muji active) may carry a raised hand.
-    let hand_raised_state = if clears_muji_presence {
+    // (`clears_muji_presence`), the occupant is no longer in the call, so
+    // the hand MUST be lowered and the mute dropped regardless of any
+    // `<in-call>` a buggy or hostile client left on the stanza. Only an
+    // in-call presence (muji active) may carry in-call sub-states.
+    let in_call_state = if clears_muji_presence {
         InCallPresenceState::default()
     } else {
         extract_in_call_presence_state(incoming)
     };
-    let raised_hand_sessions = match actor
-        .ask(UpsertHandRaised {
+    let in_call_sessions = match actor
+        .ask(UpsertInCallState {
             sender_jid: sender_jid.clone(),
-            state: hand_raised_state,
+            state: in_call_state,
         })
         .await
     {
-        Ok(Some(hand_outcome)) => hand_outcome.raised_hand_sessions,
+        Ok(Some(in_call_outcome)) => in_call_outcome.in_call_sessions,
         Ok(None) | Err(_) => Vec::new(),
     };
 
@@ -342,19 +342,20 @@ pub(super) async fn try_handle_muc_presence_update(
             }
 
             // Replace any client-authored `<in-call>` with the room
-            // actor's authoritative per-session raised-hand state, so a
-            // sibling resource's presence is never stamped with another
-            // session's hand (#1029). The element sits alongside `<muji>`.
+            // actor's authoritative per-session state (raised hand / mute),
+            // so a sibling resource's presence is never stamped with
+            // another session's hand/mute (#1029/#1030). The element sits
+            // alongside `<muji>`.
             presence.payloads.retain(|payload| {
                 !(payload.name() == "in-call" && payload.ns() == NS_WADDLE_IN_CALL)
             });
-            if raised_hand_sessions
+            if let Some((_, owner_state)) = in_call_sessions
                 .iter()
-                .any(|jid| jid == entry.owner_jid)
+                .find(|(jid, _)| jid == entry.owner_jid)
             {
-                presence.payloads.push(build_in_call_presence_state_element(
-                    &InCallPresenceState { hand_raised: true },
-                ));
+                presence
+                    .payloads
+                    .push(build_in_call_presence_state_element(owner_state));
             }
 
             if recipient == sender_jid {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/tests.rs
@@ -29,7 +29,7 @@ fn muc_join_presence_carries_authority_in_xep_0045_payload_only() {
         real_jid: &real_jid,
         include_self_status: false,
         muji: None,
-        hand_raised: false,
+        in_call: waddle_xmpp::xep::InCallPresenceState::default(),
     });
 
     // XEP-0045: authority lives in the muc#user payload.

--- a/server/crates/waddle-server/tests/xep_waddle_in_call_ws.rs
+++ b/server/crates/waddle-server/tests/xep_waddle_in_call_ws.rs
@@ -74,8 +74,9 @@ fn in_call_reaction_message(
 
 /// A MUC call presence: an active XEP-0272 `<muji/>` advertisement
 /// (one audio content), optionally carrying the `urn:waddle:in-call:0`
-/// `<hand-raised/>` presence state *alongside* (never inside) `<muji/>`.
-fn call_presence(room: &str, nick: &str, hand_raised: bool) -> String {
+/// presence state (`<hand-raised/>` and/or `<muted/>`) *alongside*
+/// (never inside) `<muji/>`. Both markers ride one `<in-call/>` element.
+fn call_presence(room: &str, nick: &str, hand_raised: bool, muted: bool) -> String {
     let muji = Element::builder("muji", NS_MUJI)
         .append(
             Element::builder("content", NS_MUJI)
@@ -93,12 +94,15 @@ fn call_presence(room: &str, nick: &str, hand_raised: bool) -> String {
         .attr(attr("to"), format!("{room}/{nick}"))
         .append(Element::builder("x", NS_MUC).build())
         .append(muji);
-    if hand_raised {
-        presence = presence.append(
-            Element::builder("in-call", NS_WADDLE_IN_CALL)
-                .append(Element::builder("hand-raised", NS_WADDLE_IN_CALL).build())
-                .build(),
-        );
+    if hand_raised || muted {
+        let mut in_call = Element::builder("in-call", NS_WADDLE_IN_CALL);
+        if hand_raised {
+            in_call = in_call.append(Element::builder("hand-raised", NS_WADDLE_IN_CALL).build());
+        }
+        if muted {
+            in_call = in_call.append(Element::builder("muted", NS_WADDLE_IN_CALL).build());
+        }
+        presence = presence.append(in_call.build());
     }
     serialize(presence.build())
 }
@@ -250,7 +254,7 @@ async fn raise_hand_presence_reflects_in_call_child_alongside_muji() {
 
     // Alice enters the call and raises her hand in one presence update.
     alice
-        .send(&call_presence(&room, ALICE, true))
+        .send(&call_presence(&room, ALICE, true, false))
         .await
         .expect("alice raises hand");
 
@@ -308,7 +312,7 @@ async fn leave_call_presence_forces_hand_lowered_despite_stale_marker() {
 
     // Alice raises her hand legitimately, then bob drains the raise.
     alice
-        .send(&call_presence(&room, ALICE, true))
+        .send(&call_presence(&room, ALICE, true, false))
         .await
         .expect("alice raises hand");
     bob.recv_matching(|f| f.contains("<presence") && f.contains("hand-raised"))
@@ -347,7 +351,7 @@ async fn raised_hand_replays_to_late_joiner_and_clears_on_lower() {
     // Alice enters the call and raises her hand, then drains her own echo
     // so the room actor has committed the state before Carol arrives.
     alice
-        .send(&call_presence(&room, ALICE, true))
+        .send(&call_presence(&room, ALICE, true, false))
         .await
         .expect("alice raises hand");
     alice
@@ -377,7 +381,7 @@ async fn raised_hand_replays_to_late_joiner_and_clears_on_lower() {
     // Alice lowers her hand (stays in the call): the reflected presence drops
     // the in-call child for everyone.
     alice
-        .send(&call_presence(&room, ALICE, false))
+        .send(&call_presence(&room, ALICE, false, false))
         .await
         .expect("alice lowers hand");
     let lowered = carol
@@ -429,7 +433,7 @@ async fn managed_members_only_join_replays_raised_hand_state() {
 
     join_room(&mut bob, &channel_jid, BOB).await;
 
-    bob.send(&call_presence(&channel_jid, BOB, true))
+    bob.send(&call_presence(&channel_jid, BOB, true, false))
         .await
         .expect("bob raises hand");
     bob.recv_matching(|f| f.contains("<presence") && f.contains("hand-raised"))
@@ -463,6 +467,167 @@ async fn managed_members_only_join_replays_raised_hand_state() {
     let _ = carol.close().await;
     let _ = bob.close().await;
     let _ = admin.close().await;
+}
+
+#[tokio::test]
+async fn mute_presence_reflects_in_call_child_alongside_muji() {
+    // #1030: mute rides the same `urn:waddle:in-call:0` presence carrier as
+    // the raised hand — a `<muted/>` marker sibling of `<muji/>` (never
+    // nested). The server reflects the room-authoritative state to peers.
+    let _guard = TEST_SERIAL.lock().await;
+    let server = TestServer::start_with_extra_accounts(&[(BOB, BOB_PASSWORD)]);
+    let alice_password = server.fixed_account_password().to_string();
+    let mut alice = connect(&server, ALICE, &alice_password, "mute-alice").await;
+    let mut bob = connect(&server, BOB, BOB_PASSWORD, "mute-bob").await;
+    let room = format!("mute-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut alice, &room, ALICE).await;
+    join_room(&mut bob, &room, BOB).await;
+
+    // Alice enters the call muted in one presence update.
+    alice
+        .send(&call_presence(&room, ALICE, false, true))
+        .await
+        .expect("alice enters call muted");
+
+    let frame = bob
+        .recv_matching(|f| f.contains("<presence") && f.contains("<muted"))
+        .await
+        .expect("bob sees alice's muted state");
+    let element: Element = frame.parse().expect("presence xml");
+    assert_eq!(
+        element.attr("from"),
+        Some(format!("{room}/{ALICE}").as_str()),
+        "reflection is from room/nick: {frame}"
+    );
+    let in_call = element
+        .children()
+        .find(|c| c.name() == "in-call" && c.ns() == NS_WADDLE_IN_CALL)
+        .unwrap_or_else(|| panic!("reflection carries an <in-call> child: {frame}"));
+    assert!(
+        in_call
+            .children()
+            .any(|c| c.name() == "muted" && c.ns() == NS_WADDLE_IN_CALL),
+        "<in-call> carries the <muted/> marker: {frame}"
+    );
+    assert!(
+        in_call.children().all(|c| c.name() != "hand-raised"),
+        "a mute-only state carries no <hand-raised/> marker: {frame}"
+    );
+    let muji = element
+        .children()
+        .find(|c| c.name() == "muji" && c.ns() == NS_MUJI)
+        .unwrap_or_else(|| panic!("reflection still carries <muji>: {frame}"));
+    assert!(
+        muji.children().all(|c| c.name() != "in-call"),
+        "<in-call> must sit alongside, never inside, <muji>: {frame}"
+    );
+
+    let _ = bob.close().await;
+    let _ = alice.close().await;
+}
+
+#[tokio::test]
+async fn muted_state_replays_to_late_joiner_and_clears_on_unmute() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server =
+        TestServer::start_with_extra_accounts(&[(BOB, BOB_PASSWORD), (CAROL, CAROL_PASSWORD)]);
+    let alice_password = server.fixed_account_password().to_string();
+    let mut alice = connect(&server, ALICE, &alice_password, "mute-late-alice").await;
+    let room = format!("mute-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut alice, &room, ALICE).await;
+
+    // Alice enters the call muted, then drains her own echo so the room actor
+    // has committed the state before Carol arrives.
+    alice
+        .send(&call_presence(&room, ALICE, false, true))
+        .await
+        .expect("alice enters call muted");
+    alice
+        .recv_matching(|f| f.contains("<muted"))
+        .await
+        .expect("alice self echo");
+
+    // Carol joins mid-call: her XEP-0045 occupant-list replay must already
+    // show Alice's muted state — no fresh update is coming for a steady call.
+    let mut carol = connect(&server, CAROL, CAROL_PASSWORD, "mute-late-carol").await;
+    carol
+        .send(&muc_join_presence(&room, CAROL))
+        .await
+        .expect("carol joins");
+    let replay = carol
+        .recv_until(|f| f.contains("<subject"))
+        .await
+        .expect("carol join replay");
+    let alice_from = format!("{room}/{ALICE}");
+    assert!(
+        replay
+            .iter()
+            .any(|f| f.contains(&alice_from) && f.contains("<muted")),
+        "carol's join replay shows alice's muted state: {replay:?}"
+    );
+
+    // Alice unmutes (stays in the call): the reflected presence drops the
+    // `<muted/>` marker for everyone.
+    alice
+        .send(&call_presence(&room, ALICE, false, false))
+        .await
+        .expect("alice unmutes");
+    let unmuted = carol
+        .recv_matching(|f| f.contains("<presence") && f.contains(&alice_from) && f.contains("muji"))
+        .await
+        .expect("carol sees alice's unmuted presence");
+    assert!(
+        presence_in_call_child(&unmuted)
+            .map(|c| c.children().all(|g| g.name() != "muted"))
+            .unwrap_or(true),
+        "unmuted presence carries no <muted/> marker: {unmuted}"
+    );
+
+    let _ = carol.close().await;
+    let _ = alice.close().await;
+}
+
+#[tokio::test]
+async fn hand_raised_and_muted_coexist_on_the_wire() {
+    // Both sub-states advertised at once reflect as two sibling marker
+    // children of one `<in-call/>` element.
+    let _guard = TEST_SERIAL.lock().await;
+    let server = TestServer::start_with_extra_accounts(&[(BOB, BOB_PASSWORD)]);
+    let alice_password = server.fixed_account_password().to_string();
+    let mut alice = connect(&server, ALICE, &alice_password, "both-alice").await;
+    let mut bob = connect(&server, BOB, BOB_PASSWORD, "both-bob").await;
+    let room = format!("both-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut alice, &room, ALICE).await;
+    join_room(&mut bob, &room, BOB).await;
+
+    alice
+        .send(&call_presence(&room, ALICE, true, true))
+        .await
+        .expect("alice enters call muted with hand raised");
+
+    let frame = bob
+        .recv_matching(|f| {
+            f.contains("<presence") && f.contains("<muted") && f.contains("hand-raised")
+        })
+        .await
+        .expect("bob sees alice muted with hand raised");
+    let in_call = presence_in_call_child(&frame)
+        .unwrap_or_else(|| panic!("reflection carries an <in-call> child: {frame}"));
+    assert!(
+        in_call
+            .children()
+            .any(|c| c.name() == "muted" && c.ns() == NS_WADDLE_IN_CALL),
+        "carries <muted/>: {frame}"
+    );
+    assert!(
+        in_call
+            .children()
+            .any(|c| c.name() == "hand-raised" && c.ns() == NS_WADDLE_IN_CALL),
+        "carries <hand-raised/>: {frame}"
+    );
+
+    let _ = bob.close().await;
+    let _ = alice.close().await;
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/tests/xep_waddle_in_call_ws.rs
+++ b/server/crates/waddle-server/tests/xep_waddle_in_call_ws.rs
@@ -108,17 +108,27 @@ fn call_presence(room: &str, nick: &str, hand_raised: bool, muted: bool) -> Stri
 }
 
 /// A XEP-0272 §Leaving presence (no `<muji/>`) that a buggy/hostile
-/// client still tags with the raised-hand `<in-call>` marker. The server
-/// must NOT honour the marker once call participation is cleared.
-fn leave_presence_with_stale_hand(room: &str, nick: &str) -> String {
+/// client still tags with an `<in-call>` marker (`<hand-raised/>` and/or
+/// `<muted/>`). The server must NOT honour any marker once call
+/// participation is cleared — in-call state only exists for an active
+/// participant.
+fn leave_presence_with_stale_in_call(
+    room: &str,
+    nick: &str,
+    hand_raised: bool,
+    muted: bool,
+) -> String {
+    let mut in_call = Element::builder("in-call", NS_WADDLE_IN_CALL);
+    if hand_raised {
+        in_call = in_call.append(Element::builder("hand-raised", NS_WADDLE_IN_CALL).build());
+    }
+    if muted {
+        in_call = in_call.append(Element::builder("muted", NS_WADDLE_IN_CALL).build());
+    }
     serialize(
         Element::builder("presence", NS_CLIENT)
             .attr(attr("to"), format!("{room}/{nick}"))
-            .append(
-                Element::builder("in-call", NS_WADDLE_IN_CALL)
-                    .append(Element::builder("hand-raised", NS_WADDLE_IN_CALL).build())
-                    .build(),
-            )
+            .append(in_call.build())
             .build(),
     )
 }
@@ -321,7 +331,9 @@ async fn leave_call_presence_forces_hand_lowered_despite_stale_marker() {
 
     // Alice leaves the call but a buggy client keeps the <hand-raised/> marker.
     alice
-        .send(&leave_presence_with_stale_hand(&room, ALICE))
+        .send(&leave_presence_with_stale_in_call(
+            &room, ALICE, true, false,
+        ))
         .await
         .expect("alice leaves call with stale hand marker");
 
@@ -335,6 +347,52 @@ async fn leave_call_presence_forces_hand_lowered_despite_stale_marker() {
     assert!(
         !leave.contains("hand-raised"),
         "server must force the hand lowered on a leave-call presence: {leave}"
+    );
+}
+
+#[tokio::test]
+async fn leave_call_presence_forces_mute_cleared_despite_stale_marker() {
+    // #1030 mirror of the hand invariant: mute only exists for an active
+    // call participant. When the XEP-0272 leave marker (no <muji/>) arrives,
+    // the server must force mute cleared regardless of any <in-call><muted/>
+    // a buggy/hostile client still attached — otherwise a non-participant is
+    // reflected and replayed to late joiners as muted.
+    let _guard = TEST_SERIAL.lock().await;
+    let server = TestServer::start_with_extra_accounts(&[(BOB, BOB_PASSWORD)]);
+    let alice_password = server.fixed_account_password().to_string();
+    let mut alice = connect(&server, ALICE, &alice_password, "stale-mute-alice").await;
+    let mut bob = connect(&server, BOB, BOB_PASSWORD, "stale-mute-bob").await;
+    let room = format!("mute-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut alice, &room, ALICE).await;
+    join_room(&mut bob, &room, BOB).await;
+
+    // Alice enters the call muted legitimately, then bob drains the reflection.
+    alice
+        .send(&call_presence(&room, ALICE, false, true))
+        .await
+        .expect("alice enters call muted");
+    bob.recv_matching(|f| f.contains("<presence") && f.contains("<muted"))
+        .await
+        .expect("bob sees the mute");
+
+    // Alice leaves the call but a buggy client keeps the <muted/> marker.
+    alice
+        .send(&leave_presence_with_stale_in_call(
+            &room, ALICE, false, true,
+        ))
+        .await
+        .expect("alice leaves call with stale mute marker");
+
+    let alice_from = format!("{room}/{ALICE}");
+    let leave = bob
+        .recv_matching(|f| {
+            f.contains("<presence") && f.contains(&alice_from) && !f.contains("muji")
+        })
+        .await
+        .expect("bob sees alice's reflected leave presence");
+    assert!(
+        !leave.contains("<muted"),
+        "server must force mute cleared on a leave-call presence: {leave}"
     );
 }
 

--- a/server/crates/waddle-xmpp-client-wasm/src/client_rooms.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_rooms.rs
@@ -1,5 +1,18 @@
 use super::*;
 
+/// In-call presence sub-state flags (`urn:waddle:in-call:0`) the chat
+/// passes to [`WaddleClient::update_muji_presence`] as a plain JS object
+/// `{ handRaised, muted }`. Bundled into one FFI argument so the call
+/// presence carries both the #1029 raised hand and the #1030 mute — which
+/// share the single `<in-call>` presence child — without re-spelling each
+/// sub-state at the wasm boundary. Missing keys default to `false`.
+#[derive(Debug, Clone, Copy, Default, serde::Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct InCallPresenceFlags {
+    pub hand_raised: bool,
+    pub muted: bool,
+}
+
 #[wasm_bindgen]
 impl WaddleClient {
     pub fn join_room(&self, room_jid: String, nick: String) -> Promise {
@@ -79,15 +92,16 @@ impl WaddleClient {
     ///   §Joining two-phase flow. Typically the client sends this
     ///   first, awaits the room's echo, then re-emits with contents
     ///   declared.
-    /// - `hand_raised`/`muted`: append an `<in-call
+    /// - `in_call`: a plain JS object `{ handRaised, muted }`
+    ///   ([`InCallPresenceFlags`]) appended as an `<in-call
     ///   xmlns='urn:waddle:in-call:0'>` presence child *alongside*
-    ///   `<muji/>` (#1029 raised hand / #1030 mute) carrying one marker
-    ///   child per set flag. This is the FFI in-call "set method": the
-    ///   caller re-emits its current call presence with the flags
-    ///   toggled, and the absence of a marker clears that sub-state for
-    ///   everyone (the server drops the stored state). Ignored unless the
-    ///   occupant is in the call (`active` or `preparing`), since in-call
-    ///   state is meaningless without call participation.
+    ///   `<muji/>` (#1029 raised hand / #1030 mute), one marker child per
+    ///   set flag. This is the FFI in-call "set method": the caller
+    ///   re-emits its current call presence with the flags toggled, and
+    ///   the absence of a marker clears that sub-state for everyone (the
+    ///   server drops the stored state). Ignored unless the occupant is in
+    ///   the call (`active` or `preparing`), since in-call state is
+    ///   meaningless without call participation.
     pub fn update_muji_presence(
         &self,
         room_jid: String,
@@ -95,11 +109,12 @@ impl WaddleClient {
         active: bool,
         preparing: bool,
         video: bool,
-        hand_raised: bool,
-        muted: bool,
+        in_call: JsValue,
     ) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
+            let in_call: InCallPresenceFlags = serde_wasm_bindgen::from_value(in_call)
+                .map_err(|err| JsValue::from_str(&err.to_string()))?;
             let to = format!("{room_jid}/{nick}");
             let mut builder = Element::builder("presence", NS_CLIENT)
                 .attr(minidom::rxml::xml_ncname!("to").to_owned(), to.as_str());
@@ -116,11 +131,11 @@ impl WaddleClient {
                     active && video,
                 );
                 builder = builder.append(muji);
-                if hand_raised || muted {
+                if in_call.hand_raised || in_call.muted {
                     builder = builder.append(
                         waddle_xmpp_client::messaging::build_in_call_presence_state_element(
-                            hand_raised,
-                            muted,
+                            in_call.hand_raised,
+                            in_call.muted,
                         ),
                     );
                 }

--- a/server/crates/waddle-xmpp-client-wasm/src/client_rooms.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_rooms.rs
@@ -79,15 +79,15 @@ impl WaddleClient {
     ///   §Joining two-phase flow. Typically the client sends this
     ///   first, awaits the room's echo, then re-emits with contents
     ///   declared.
-    /// - `hand_raised=true`: appends an
-    ///   `<in-call xmlns='urn:waddle:in-call:0'><hand-raised/></in-call>`
-    ///   presence child *alongside* `<muji/>` (#1029). This is the FFI
-    ///   raise/lower-hand "set method": the caller re-emits its current
-    ///   call presence with the flag toggled, and the absence of the
-    ///   child lowers the hand for everyone (the server clears the
-    ///   stored state). Ignored unless the occupant is in the call
-    ///   (`active` or `preparing`), since a raised hand is meaningless
-    ///   without call participation.
+    /// - `hand_raised`/`muted`: append an `<in-call
+    ///   xmlns='urn:waddle:in-call:0'>` presence child *alongside*
+    ///   `<muji/>` (#1029 raised hand / #1030 mute) carrying one marker
+    ///   child per set flag. This is the FFI in-call "set method": the
+    ///   caller re-emits its current call presence with the flags
+    ///   toggled, and the absence of a marker clears that sub-state for
+    ///   everyone (the server drops the stored state). Ignored unless the
+    ///   occupant is in the call (`active` or `preparing`), since in-call
+    ///   state is meaningless without call participation.
     pub fn update_muji_presence(
         &self,
         room_jid: String,
@@ -96,6 +96,7 @@ impl WaddleClient {
         preparing: bool,
         video: bool,
         hand_raised: bool,
+        muted: bool,
     ) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
@@ -115,9 +116,13 @@ impl WaddleClient {
                     active && video,
                 );
                 builder = builder.append(muji);
-                if hand_raised {
-                    builder = builder
-                        .append(waddle_xmpp_client::messaging::build_in_call_hand_raised_element());
+                if hand_raised || muted {
+                    builder = builder.append(
+                        waddle_xmpp_client::messaging::build_in_call_presence_state_element(
+                            hand_raised,
+                            muted,
+                        ),
+                    );
                 }
             }
             builder = builder.append(waddle_xmpp_client::caps::build_client_caps_element());

--- a/server/crates/waddle-xmpp-client-wasm/src/client_rooms.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_rooms.rs
@@ -13,6 +13,67 @@ pub struct InCallPresenceFlags {
     pub muted: bool,
 }
 
+impl InCallPresenceFlags {
+    /// Legacy callers (pre-#1030, when the FFI argument was the bare
+    /// #1029 raised-hand boolean) may still pass `in_call` as a plain
+    /// `boolean`. Interpret it as the raised-hand flag with mute
+    /// cleared, so an older chat bundle never blocks the presence send.
+    fn from_legacy_bool(hand_raised: bool) -> Self {
+        Self {
+            hand_raised,
+            muted: false,
+        }
+    }
+}
+
+/// Representation-agnostic decision core of [`parse_in_call_flags`],
+/// split out from the `JsValue` probing so the branch precedence and the
+/// never-fails fallback are unit-testable without constructing a
+/// `JsValue` (which aborts under native `cargo test`). Precedence:
+///
+/// 1. `nullish` (`undefined`/`null`) → [`InCallPresenceFlags::default()`].
+/// 2. `legacy_bool` (a bare JS boolean) →
+///    [`InCallPresenceFlags::from_legacy_bool`].
+/// 3. otherwise the `deserialized` object, or `default()` if it was
+///    `None` (deserialization failed) — this is the guarantee that the
+///    parse NEVER fails.
+fn resolve_in_call_flags(
+    nullish: bool,
+    legacy_bool: Option<bool>,
+    deserialized: Option<InCallPresenceFlags>,
+) -> InCallPresenceFlags {
+    if nullish {
+        return InCallPresenceFlags::default();
+    }
+    if let Some(hand_raised) = legacy_bool {
+        return InCallPresenceFlags::from_legacy_bool(hand_raised);
+    }
+    deserialized.unwrap_or_default()
+}
+
+/// Best-effort parse of the `in_call` FFI argument into
+/// [`InCallPresenceFlags`]. This NEVER fails: presence sends — and in
+/// particular the call-teardown leave marker that clears `<muji/>` for
+/// remote occupants — must not be blocked by a malformed or stale
+/// `in_call` value. Each non-object shape degrades to a sensible flag set
+/// rather than a rejected Promise (see [`resolve_in_call_flags`]):
+///
+/// - `undefined` / `null` → [`InCallPresenceFlags::default()`] (both flags
+///   cleared); this is the shape leave/teardown paths want anyway.
+/// - a bare `boolean` (legacy caller) →
+///   [`InCallPresenceFlags::from_legacy_bool`].
+/// - anything else → deserialize the `{ handRaised, muted }` object,
+///   falling back to `default()` if deserialization fails for any reason.
+///   (A *partially* malformed object — e.g. a non-boolean field value —
+///   fails as a whole and defaults every flag, not just the bad one.)
+fn parse_in_call_flags(in_call: JsValue) -> InCallPresenceFlags {
+    // Probe the `JsValue` shape before the move-consuming deserialize.
+    let nullish = in_call.is_undefined() || in_call.is_null();
+    let legacy_bool = in_call.as_bool();
+    let deserialized = serde_wasm_bindgen::from_value(in_call).ok();
+    resolve_in_call_flags(nullish, legacy_bool, deserialized)
+}
+
 #[wasm_bindgen]
 impl WaddleClient {
     pub fn join_room(&self, room_jid: String, nick: String) -> Promise {
@@ -109,12 +170,20 @@ impl WaddleClient {
         active: bool,
         preparing: bool,
         video: bool,
+        // Tighten the generated `.d.ts` from `any` to the `{ handRaised,
+        // muted }` shape so TypeScript callers can't silently pass a
+        // malformed value. Both keys are optional because the parse
+        // defaults any missing flag (see `parse_in_call_flags`).
+        #[wasm_bindgen(unchecked_param_type = "{ handRaised?: boolean; muted?: boolean }")]
         in_call: JsValue,
     ) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
-            let in_call: InCallPresenceFlags = serde_wasm_bindgen::from_value(in_call)
-                .map_err(|err| JsValue::from_str(&err.to_string()))?;
+            // Best-effort: a malformed / undefined / legacy-boolean
+            // `in_call` MUST NOT block the presence send (notably the
+            // call-teardown leave marker), so this degrades to sensible
+            // flags instead of rejecting the Promise.
+            let in_call = parse_in_call_flags(in_call);
             let to = format!("{room_jid}/{nick}");
             let mut builder = Element::builder("presence", NS_CLIENT)
                 .attr(minidom::rxml::xml_ncname!("to").to_owned(), to.as_str());
@@ -229,5 +298,149 @@ impl WaddleClient {
                 .ok_or_else(|| js_error("could not parse upload slot"))?;
             to_js_value(&upload_slot_to_js(slot))
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_in_call_flags, InCallPresenceFlags};
+
+    // `parse_in_call_flags` itself takes a `JsValue`, and
+    // `wasm_bindgen::JsValue` panics under `cargo test` on native
+    // targets (it's only safe on `wasm32`). So we test the
+    // representation-independent pieces it composes — the legacy-bool
+    // mapping, the serde shape its `serde_wasm_bindgen::from_value` path
+    // relies on, and the `resolve_in_call_flags` decision core (branch
+    // precedence + never-fails fallback) — directly, with `serde_json`
+    // standing in for `serde_wasm_bindgen` (both drive the same
+    // `Deserialize` impl).
+
+    #[test]
+    fn resolve_nullish_clears_all_flags_even_over_other_inputs() {
+        // `undefined`/`null` is the leave/teardown shape and wins
+        // ahead of every other branch.
+        let flags = resolve_in_call_flags(
+            true,
+            Some(true),
+            Some(InCallPresenceFlags {
+                hand_raised: true,
+                muted: true,
+            }),
+        );
+        assert!(!flags.hand_raised);
+        assert!(!flags.muted);
+    }
+
+    #[test]
+    fn resolve_legacy_bool_takes_precedence_over_deserialized_object() {
+        // A bare boolean is the legacy raised-hand carrier; it is
+        // resolved before the object path.
+        let flags = resolve_in_call_flags(
+            false,
+            Some(true),
+            Some(InCallPresenceFlags {
+                hand_raised: false,
+                muted: true,
+            }),
+        );
+        assert!(flags.hand_raised);
+        assert!(!flags.muted);
+    }
+
+    #[test]
+    fn resolve_uses_deserialized_object_when_no_legacy_bool() {
+        let flags = resolve_in_call_flags(
+            false,
+            None,
+            Some(InCallPresenceFlags {
+                hand_raised: true,
+                muted: true,
+            }),
+        );
+        assert!(flags.hand_raised);
+        assert!(flags.muted);
+    }
+
+    #[test]
+    fn resolve_falls_back_to_default_when_deserialization_failed() {
+        // The never-reject guarantee: a value that is neither nullish
+        // nor a bool and that failed to deserialize (e.g. a number, a
+        // string, or a type-mismatched object) MUST still resolve to
+        // default flags so the presence is sent rather than blocked.
+        let flags = resolve_in_call_flags(false, None, None);
+        assert!(!flags.hand_raised);
+        assert!(!flags.muted);
+    }
+
+    #[test]
+    fn default_flags_clear_all_in_call_state() {
+        // The leave-marker / undefined path falls back to this: a bare
+        // call presence with neither hand nor mute marker, clearing both
+        // sub-states for remote occupants.
+        let flags = InCallPresenceFlags::default();
+        assert!(!flags.hand_raised);
+        assert!(!flags.muted);
+    }
+
+    #[test]
+    fn legacy_bool_true_means_raised_hand_only() {
+        // Pre-#1030 callers passed `in_call` as a bare boolean carrying
+        // the #1029 raised-hand intent; mute is unknown to them, so it
+        // stays cleared.
+        let flags = InCallPresenceFlags::from_legacy_bool(true);
+        assert!(flags.hand_raised);
+        assert!(!flags.muted);
+    }
+
+    #[test]
+    fn legacy_bool_false_clears_both() {
+        let flags = InCallPresenceFlags::from_legacy_bool(false);
+        assert!(!flags.hand_raised);
+        assert!(!flags.muted);
+    }
+
+    #[test]
+    fn empty_object_deserializes_to_default() {
+        let flags: InCallPresenceFlags =
+            serde_json::from_value(serde_json::json!({})).expect("empty object deserializes");
+        assert!(!flags.hand_raised);
+        assert!(!flags.muted);
+    }
+
+    #[test]
+    fn partial_object_defaults_missing_keys() {
+        let raised: InCallPresenceFlags =
+            serde_json::from_value(serde_json::json!({ "handRaised": true }))
+                .expect("partial object deserializes");
+        assert!(raised.hand_raised);
+        assert!(!raised.muted);
+
+        let muted: InCallPresenceFlags =
+            serde_json::from_value(serde_json::json!({ "muted": true }))
+                .expect("partial object deserializes");
+        assert!(!muted.hand_raised);
+        assert!(muted.muted);
+    }
+
+    #[test]
+    fn full_camel_case_object_deserializes_both_flags() {
+        let flags: InCallPresenceFlags =
+            serde_json::from_value(serde_json::json!({ "handRaised": true, "muted": true }))
+                .expect("full object deserializes");
+        assert!(flags.hand_raised);
+        assert!(flags.muted);
+    }
+
+    #[test]
+    fn unknown_keys_are_ignored() {
+        // A forward/backward-incompatible caller can sneak extra keys in;
+        // the lenient parse must still recover the flags it understands
+        // rather than rejecting the whole presence.
+        let flags: InCallPresenceFlags = serde_json::from_value(
+            serde_json::json!({ "handRaised": true, "speaking": true, "extra": 7 }),
+        )
+        .expect("unknown keys are ignored");
+        assert!(flags.hand_raised);
+        assert!(!flags.muted);
     }
 }

--- a/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
@@ -769,6 +769,7 @@ pub(crate) fn presence_to_js(presence: InboundPresence) -> WaddlePresence {
             video: m.video,
         }),
         hand_raised: presence.hand_raised,
+        muted: presence.muted,
     }
 }
 
@@ -1049,6 +1050,7 @@ mod inbound_to_js_tests {
             vcard_avatar: None,
             muji: None,
             hand_raised: false,
+            muted: false,
         };
         let js = presence_to_js(presence);
         assert_eq!(js.muc_status_codes, vec![100, 110, 210]);

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -454,6 +454,11 @@ pub struct WaddlePresence {
     /// alongside `<muji/>`. Defaults to `false` (lowered) so the chat
     /// side can build a per-participant raised-hand map.
     pub hand_raised: bool,
+    /// Waddle mute call presence state (#1030). `true` when the
+    /// occupant's presence carries a `<muted/>` marker on the same
+    /// `<in-call>` carrier. Defaults to `false` (unmuted) so the chat
+    /// side can build a per-participant mute map for tiles and the roster.
+    pub muted: bool,
 }
 
 #[derive(Debug, Serialize)]

--- a/server/crates/waddle-xmpp-client/src/messaging.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging.rs
@@ -32,7 +32,7 @@ pub use call::{
     CallMedia, InboundCallEvent, LiveKitJoin,
 };
 pub use namespaces::{
-    build_in_call_hand_raised_element, build_muji_element, NS_CHAT_MARKERS, NS_CHAT_STATES,
+    build_in_call_presence_state_element, build_muji_element, NS_CHAT_MARKERS, NS_CHAT_STATES,
     NS_CLIENT, NS_JINGLE_RTP, NS_MESSAGE_CORRECT, NS_MESSAGE_MODERATE, NS_MESSAGE_RETRACT, NS_MUJI,
     NS_REACTIONS, NS_WADDLE_IN_CALL, NS_WADDLE_PIN_V0,
 };

--- a/server/crates/waddle-xmpp-client/src/messaging/namespaces.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/namespaces.rs
@@ -119,17 +119,25 @@ fn build_muji_content(media: &str) -> minidom::Element {
         .build()
 }
 
-/// Build the `<in-call xmlns='urn:waddle:in-call:0'><hand-raised/></in-call>`
-/// presence child (#1029), carried alongside (never inside) `<muji/>` in MUC
-/// call presence to advertise a raised hand. Mirrors the server-side
+/// Build the `<in-call xmlns='urn:waddle:in-call:0'>` presence child
+/// (#1029 raised hand / #1030 mute), carried alongside (never inside)
+/// `<muji/>` in MUC call presence. Emits one marker child per advertised
+/// sub-state (`<hand-raised/>`, `<muted/>`); an all-`false` state yields
+/// an empty `<in-call/>`. Mirrors the server-side
 /// `waddle_xmpp::xep::build_in_call_presence_state_element`.
 ///
 /// CLAUDE.md XML hard rule: callers append this typed element rather than
 /// hand-rolling the `<in-call>` shape at the wasm boundary.
-pub fn build_in_call_hand_raised_element() -> minidom::Element {
-    minidom::Element::builder("in-call", NS_WADDLE_IN_CALL)
-        .append(minidom::Element::builder("hand-raised", NS_WADDLE_IN_CALL).build())
-        .build()
+pub fn build_in_call_presence_state_element(hand_raised: bool, muted: bool) -> minidom::Element {
+    let mut builder = minidom::Element::builder("in-call", NS_WADDLE_IN_CALL);
+    if hand_raised {
+        builder =
+            builder.append(minidom::Element::builder("hand-raised", NS_WADDLE_IN_CALL).build());
+    }
+    if muted {
+        builder = builder.append(minidom::Element::builder("muted", NS_WADDLE_IN_CALL).build());
+    }
+    builder.build()
 }
 
 #[cfg(test)]
@@ -181,7 +189,7 @@ mod tests {
 
     #[test]
     fn builds_in_call_hand_raised_element() {
-        let elem = build_in_call_hand_raised_element();
+        let elem = build_in_call_presence_state_element(true, false);
         assert_eq!(elem.name(), "in-call");
         assert_eq!(elem.ns(), NS_WADDLE_IN_CALL);
         let marker = elem
@@ -189,5 +197,30 @@ mod tests {
             .find(|c| c.name() == "hand-raised")
             .expect("hand-raised marker child");
         assert_eq!(marker.ns(), NS_WADDLE_IN_CALL);
+        assert!(
+            elem.children().all(|c| c.name() != "muted"),
+            "hand-only state carries no <muted/> marker"
+        );
+    }
+
+    #[test]
+    fn builds_in_call_muted_element() {
+        let elem = build_in_call_presence_state_element(false, true);
+        let marker = elem
+            .children()
+            .find(|c| c.name() == "muted")
+            .expect("muted marker child");
+        assert_eq!(marker.ns(), NS_WADDLE_IN_CALL);
+        assert!(
+            elem.children().all(|c| c.name() != "hand-raised"),
+            "mute-only state carries no <hand-raised/> marker"
+        );
+    }
+
+    #[test]
+    fn builds_in_call_hand_raised_and_muted_together() {
+        let elem = build_in_call_presence_state_element(true, true);
+        assert!(elem.children().any(|c| c.name() == "hand-raised"));
+        assert!(elem.children().any(|c| c.name() == "muted"));
     }
 }

--- a/server/crates/waddle-xmpp-client/src/messaging/presence.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/presence.rs
@@ -87,17 +87,19 @@ pub(super) fn parse_presence(el: &Element) -> InboundPresence {
         }
     });
 
-    // Waddle raised-hand call presence state (#1029): an
-    // `<in-call xmlns='urn:waddle:in-call:0'>` sibling of `<muji/>` with
-    // a `<hand-raised/>` marker child. Its absence means the hand is
-    // lowered.
-    let hand_raised = el
-        .get_child("in-call", NS_WADDLE_IN_CALL)
-        .is_some_and(|in_call| {
-            in_call
-                .children()
-                .any(|c| c.name() == "hand-raised" && c.ns() == NS_WADDLE_IN_CALL)
-        });
+    // Waddle in-call presence state (#1029 raised hand / #1030 mute): an
+    // `<in-call xmlns='urn:waddle:in-call:0'>` sibling of `<muji/>` whose
+    // marker children advertise each sub-state. A missing child (or a
+    // missing `<in-call/>`) means that sub-state is off.
+    let in_call = el.get_child("in-call", NS_WADDLE_IN_CALL);
+    let in_call_has = |name: &str| {
+        in_call.is_some_and(|el| {
+            el.children()
+                .any(|c| c.name() == name && c.ns() == NS_WADDLE_IN_CALL)
+        })
+    };
+    let hand_raised = in_call_has("hand-raised");
+    let muted = in_call_has("muted");
 
     InboundPresence {
         from,
@@ -113,6 +115,7 @@ pub(super) fn parse_presence(el: &Element) -> InboundPresence {
         vcard_avatar,
         muji,
         hand_raised,
+        muted,
     }
 }
 
@@ -193,6 +196,34 @@ mod tests {
         let elem: Element = xml.parse().unwrap();
         let p = parse_presence(&elem);
         assert!(!p.hand_raised, "no in-call child means hand lowered");
+        assert!(!p.muted, "no in-call child means unmuted");
+    }
+
+    #[test]
+    fn parses_in_call_muted_alongside_muji() {
+        let xml = r#"<presence xmlns="jabber:client" from="room@muc.test/alice">
+            <muji xmlns="urn:xmpp:jingle:muji:0">
+                <content creator="initiator" name="audio">
+                    <description xmlns="urn:xmpp:jingle:apps:rtp:1" media="audio"/>
+                </content>
+            </muji>
+            <in-call xmlns="urn:waddle:in-call:0"><muted/></in-call>
+        </presence>"#;
+        let elem: Element = xml.parse().unwrap();
+        let p = parse_presence(&elem);
+        assert!(p.muted, "muted presence state parsed (#1030)");
+        assert!(!p.hand_raised, "mute alone does not raise the hand");
+    }
+
+    #[test]
+    fn parses_in_call_hand_raised_and_muted_together() {
+        let xml = r#"<presence xmlns="jabber:client" from="room@muc.test/alice">
+            <in-call xmlns="urn:waddle:in-call:0"><hand-raised/><muted/></in-call>
+        </presence>"#;
+        let elem: Element = xml.parse().unwrap();
+        let p = parse_presence(&elem);
+        assert!(p.hand_raised, "hand parsed when both markers present");
+        assert!(p.muted, "mute parsed when both markers present");
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client/src/messaging/types.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/types.rs
@@ -702,6 +702,12 @@ pub struct InboundPresence {
     /// the child is absent (lowered). Drives the chat-side raised-hand
     /// indicator in the Participants panel and on tiles.
     pub hand_raised: bool,
+    /// Waddle mute call presence state (#1030) — a `<muted/>` marker on
+    /// the same `<in-call>` carrier. `true` when the occupant advertises a
+    /// muted microphone; `false` when the child is absent (unmuted).
+    /// Drives the authoritative remote-mute indicator on tiles and in the
+    /// roster.
+    pub muted: bool,
 }
 
 /// Parsed `<muji xmlns='urn:xmpp:jingle:muji:0'>` extension on a MUC

--- a/server/crates/waddle-xmpp/src/muc/room.rs
+++ b/server/crates/waddle-xmpp/src/muc/room.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use jid::{BareJid, FullJid};
 use serde::{Deserialize, Serialize};
@@ -8,6 +8,7 @@ use super::pin::{PinPermission, PinnedEntry};
 use super::subject::SubjectState;
 use crate::types::{Affiliation, Role};
 use crate::xep::xep0272::Muji;
+use crate::xep::InCallPresenceState;
 
 /// Check if a JID is from a remote server.
 ///
@@ -147,23 +148,24 @@ pub struct MucRoom {
     /// still one occupant presence per nick; `muji_for_nick` aggregates
     /// these session entries, preferring active contents over preparing.
     pub(super) muji_state: HashMap<String, HashMap<FullJid, Muji>>,
-    /// Per-session raised-hand presence state (`urn:waddle:in-call:0`,
-    /// #1029), keyed by nick then by the set of full JIDs whose session
-    /// currently advertises `<in-call><hand-raised/></in-call>`. Mirrors
+    /// Per-session in-call presence state (`urn:waddle:in-call:0`,
+    /// #1029/#1030), keyed by nick then by full JID, carrying the full
+    /// [`InCallPresenceState`](crate::xep::InCallPresenceState) (raised
+    /// hand + mute) that session advertises. Mirrors
     /// [`muji_state`](Self::muji_state):
     ///
-    /// 1. Late joiners see who already has a hand raised — the join
-    ///    handler reads this map and appends the `<in-call>` payload to
-    ///    the replayed presence for any session that owns one.
+    /// 1. Late joiners see who already has a hand raised or is muted —
+    ///    the join handler reads this map and appends the `<in-call>`
+    ///    payload to the replayed presence for any session that owns one.
     /// 2. Presence-update broadcasts reflect the room-authoritative
     ///    per-session state rather than echoing the client payload, so a
     ///    sibling resource's presence cannot be stamped with another
-    ///    session's hand state.
+    ///    session's in-call state.
     ///
-    /// A nick is "hand raised" to the room when *any* of its sessions
-    /// advertise it. Entries are cleared when the session lowers its
-    /// hand, leaves the call (`<muji/>` cleared), or leaves the room.
-    pub(super) hand_raised_state: HashMap<String, HashSet<FullJid>>,
+    /// Only non-empty states are stored; an entry is cleared when the
+    /// session lowers its hand and unmutes, leaves the call (`<muji/>`
+    /// cleared), or leaves the room.
+    pub(super) in_call_state: HashMap<String, HashMap<FullJid, InCallPresenceState>>,
 }
 
 /// Result of applying one session's Muji presence update.
@@ -205,7 +207,7 @@ impl MucRoom {
             generation_floor: u64::try_from(chrono::Utc::now().timestamp_millis()).unwrap_or(0),
             pinned_entries: Vec::new(),
             muji_state: HashMap::new(),
-            hand_raised_state: HashMap::new(),
+            in_call_state: HashMap::new(),
         }
     }
 
@@ -343,63 +345,63 @@ impl MucRoom {
         }
     }
 
-    /// Apply an `<in-call xmlns='urn:waddle:in-call:0'>` raised-hand
-    /// presence state (#1029) from `nick`'s `originator` session. A
-    /// raised state records the session; a lowered/empty state removes
-    /// it. Mirrors [`upsert_muji_presence`](Self::upsert_muji_presence):
-    /// the entry is bound to the exact emitting session so one resource
-    /// can lower its hand without disturbing a sibling's.
-    pub fn upsert_hand_raised(
+    /// Apply an `<in-call xmlns='urn:waddle:in-call:0'>` presence state
+    /// (#1029 raised hand / #1030 mute) from `nick`'s `originator`
+    /// session. A non-empty state records the session's full
+    /// [`InCallPresenceState`]; an empty state removes it. Mirrors
+    /// [`upsert_muji_presence`](Self::upsert_muji_presence): the entry is
+    /// bound to the exact emitting session so one resource can change its
+    /// in-call state without disturbing a sibling's.
+    pub fn upsert_in_call_state(
         &mut self,
         nick: &str,
         originator: FullJid,
-        state: crate::xep::InCallPresenceState,
+        state: InCallPresenceState,
     ) {
         if state.is_empty() {
-            self.clear_hand_raised(nick, &originator);
+            self.clear_in_call_state(nick, &originator);
         } else {
-            self.hand_raised_state
+            self.in_call_state
                 .entry(nick.to_owned())
                 .or_default()
-                .insert(originator);
+                .insert(originator, state);
         }
     }
 
-    /// Clear `originator`'s raised-hand advertisement for `nick`, if it
-    /// owns one. Used when a session lowers its hand, leaves the call,
-    /// or leaves the room.
-    pub fn clear_hand_raised(&mut self, nick: &str, originator: &FullJid) {
-        if let Some(sessions) = self.hand_raised_state.get_mut(nick) {
+    /// Clear `originator`'s in-call advertisement for `nick`, if it owns
+    /// one. Used when a session clears all its in-call sub-states, leaves
+    /// the call, or leaves the room.
+    pub fn clear_in_call_state(&mut self, nick: &str, originator: &FullJid) {
+        if let Some(sessions) = self.in_call_state.get_mut(nick) {
             sessions.remove(originator);
             if sessions.is_empty() {
-                self.hand_raised_state.remove(nick);
+                self.in_call_state.remove(nick);
             }
         }
     }
 
-    /// True when *any* of `nick`'s sessions currently has a raised hand.
-    /// This is the nick-level aggregate other occupants observe.
-    pub fn hand_raised_for_nick(&self, nick: &str) -> bool {
-        self.hand_raised_state
+    /// In-call presence state advertised by one exact `jid` session of
+    /// `nick`, or the empty default when that session advertises none.
+    pub fn in_call_state_for_session(&self, nick: &str, jid: &FullJid) -> InCallPresenceState {
+        self.in_call_state
             .get(nick)
-            .is_some_and(|sessions| !sessions.is_empty())
+            .and_then(|sessions| sessions.get(jid))
+            .copied()
+            .unwrap_or_default()
     }
 
-    /// True when the exact `jid` session of `nick` has a raised hand.
-    pub fn hand_raised_for_session(&self, nick: &str, jid: &FullJid) -> bool {
-        self.hand_raised_state
-            .get(nick)
-            .is_some_and(|sessions| sessions.contains(jid))
-    }
-
-    /// Full JIDs of `nick`'s sessions with a raised hand, sorted for
-    /// deterministic replay and broadcast ordering.
-    pub fn hand_raised_sessions_for_nick(&self, nick: &str) -> Vec<FullJid> {
-        let Some(sessions) = self.hand_raised_state.get(nick) else {
+    /// Per-session in-call states for `nick` (only non-empty), sorted by
+    /// full JID for deterministic replay and broadcast ordering.
+    pub fn in_call_sessions_for_nick(&self, nick: &str) -> Vec<(FullJid, InCallPresenceState)> {
+        let Some(sessions) = self.in_call_state.get(nick) else {
             return Vec::new();
         };
-        let mut sessions: Vec<FullJid> = sessions.iter().cloned().collect();
-        sessions.sort_by_key(ToString::to_string);
+        let mut sessions: Vec<(FullJid, InCallPresenceState)> = sessions
+            .iter()
+            .filter(|(_, state)| !state.is_empty())
+            .map(|(jid, state)| (jid.clone(), *state))
+            .collect();
+        sessions.sort_by_key(|(jid, _)| jid.to_string());
         sessions
     }
 
@@ -432,7 +434,7 @@ impl MucRoom {
     pub fn remove_occupant(&mut self, nick: &str) -> Option<Occupant> {
         self.occupant_sessions.remove(nick);
         self.muji_state.remove(nick);
-        self.hand_raised_state.remove(nick);
+        self.in_call_state.remove(nick);
         self.occupants.remove(nick)
     }
 
@@ -491,20 +493,20 @@ impl MucRoom {
                 self.muji_state.remove(nick);
             }
         }
-        // The raised-hand advertisement is session-owned just like the
-        // call advertisement above; drop the leaving session's entry so
-        // a lingering hand isn't replayed to late joiners.
-        if let Some(hands) = self.hand_raised_state.get_mut(nick) {
-            hands.remove(jid);
-            if hands.is_empty() {
-                self.hand_raised_state.remove(nick);
+        // The in-call advertisement is session-owned just like the call
+        // advertisement above; drop the leaving session's entry so a
+        // lingering hand/mute isn't replayed to late joiners.
+        if let Some(in_call) = self.in_call_state.get_mut(nick) {
+            in_call.remove(jid);
+            if in_call.is_empty() {
+                self.in_call_state.remove(nick);
             }
         }
 
         if sessions.is_empty() {
             self.occupant_sessions.remove(nick);
             self.muji_state.remove(nick);
-            self.hand_raised_state.remove(nick);
+            self.in_call_state.remove(nick);
             self.occupants.remove(nick);
             return Some(true);
         }
@@ -558,7 +560,7 @@ impl MucRoom {
             && self.pinned_entries.is_empty()
             && self.affiliation_list.is_empty()
             && self.muji_state.is_empty()
-            && self.hand_raised_state.is_empty()
+            && self.in_call_state.is_empty()
     }
 
     /// Whether `bare_jid` is currently joined to this room as an
@@ -733,9 +735,8 @@ mod pin_state_tests {
 }
 
 #[cfg(test)]
-mod hand_raised_state_tests {
+mod in_call_state_tests {
     use super::*;
-    use crate::xep::InCallPresenceState;
     use std::str::FromStr;
 
     fn room() -> MucRoom {
@@ -752,58 +753,107 @@ mod hand_raised_state_tests {
     }
 
     fn raised() -> InCallPresenceState {
-        InCallPresenceState { hand_raised: true }
+        InCallPresenceState {
+            hand_raised: true,
+            muted: false,
+        }
     }
 
-    fn lowered() -> InCallPresenceState {
-        InCallPresenceState { hand_raised: false }
+    fn muted() -> InCallPresenceState {
+        InCallPresenceState {
+            hand_raised: false,
+            muted: true,
+        }
+    }
+
+    fn nick_has_raised_hand(r: &MucRoom, nick: &str) -> bool {
+        r.in_call_sessions_for_nick(nick)
+            .iter()
+            .any(|(_, state)| state.hand_raised)
     }
 
     #[test]
-    fn upsert_raises_and_lower_clears_for_a_session() {
+    fn upsert_records_and_empty_state_clears_for_a_session() {
         let mut r = room();
         let web = full("alice@example.com/web");
 
-        r.upsert_hand_raised("alice", web.clone(), raised());
-        assert!(r.hand_raised_for_nick("alice"));
-        assert!(r.hand_raised_for_session("alice", &web));
+        r.upsert_in_call_state("alice", web.clone(), raised());
+        assert!(r.in_call_state_for_session("alice", &web).hand_raised);
+        assert!(nick_has_raised_hand(&r, "alice"));
 
-        r.upsert_hand_raised("alice", web.clone(), lowered());
-        assert!(!r.hand_raised_for_nick("alice"));
-        assert!(!r.hand_raised_for_session("alice", &web));
+        r.upsert_in_call_state("alice", web.clone(), InCallPresenceState::default());
+        assert!(!r.in_call_state_for_session("alice", &web).hand_raised);
+        assert!(!nick_has_raised_hand(&r, "alice"));
     }
 
     #[test]
-    fn raised_hand_aggregates_across_sessions() {
+    fn mute_is_carried_per_session_independently_of_the_hand() {
+        let mut r = room();
+        let web = full("alice@example.com/web");
+
+        // Muted but hand down — the session entry exists and carries mute.
+        r.upsert_in_call_state("alice", web.clone(), muted());
+        let state = r.in_call_state_for_session("alice", &web);
+        assert!(state.muted, "session advertises mute");
+        assert!(!state.hand_raised, "mute does not imply a raised hand");
+        assert_eq!(
+            r.in_call_sessions_for_nick("alice"),
+            vec![(web.clone(), muted())]
+        );
+
+        // Unmuting clears the session's entry entirely (empty state).
+        r.upsert_in_call_state("alice", web.clone(), InCallPresenceState::default());
+        assert!(!r.in_call_state_for_session("alice", &web).muted);
+        assert!(r.in_call_sessions_for_nick("alice").is_empty());
+    }
+
+    #[test]
+    fn hand_and_mute_combine_for_one_session() {
+        let mut r = room();
+        let web = full("alice@example.com/web");
+        let both = InCallPresenceState {
+            hand_raised: true,
+            muted: true,
+        };
+        r.upsert_in_call_state("alice", web.clone(), both);
+        assert_eq!(r.in_call_state_for_session("alice", &web), both);
+    }
+
+    #[test]
+    fn in_call_state_aggregates_across_sessions() {
         let mut r = room();
         let web = full("alice@example.com/web");
         let mobile = full("alice@example.com/mobile");
 
-        // Web raises; mobile explicitly lowered must not contribute.
-        r.upsert_hand_raised("alice", web.clone(), raised());
-        r.upsert_hand_raised("alice", mobile.clone(), lowered());
-        assert!(r.hand_raised_for_nick("alice"));
-        assert_eq!(r.hand_raised_sessions_for_nick("alice"), vec![web.clone()]);
-
-        // Mobile raises too — both sessions advertised, sorted by full JID.
-        r.upsert_hand_raised("alice", mobile.clone(), raised());
+        // Web raises; mobile explicitly empty must not contribute.
+        r.upsert_in_call_state("alice", web.clone(), raised());
+        r.upsert_in_call_state("alice", mobile.clone(), InCallPresenceState::default());
         assert_eq!(
-            r.hand_raised_sessions_for_nick("alice"),
-            vec![mobile.clone(), web.clone()]
+            r.in_call_sessions_for_nick("alice"),
+            vec![(web.clone(), raised())]
         );
 
-        // Clearing web leaves the nick raised via mobile.
-        r.clear_hand_raised("alice", &web);
-        assert!(r.hand_raised_for_nick("alice"));
-        assert_eq!(r.hand_raised_sessions_for_nick("alice"), vec![mobile]);
+        // Mobile mutes — both sessions advertised, sorted by full JID.
+        r.upsert_in_call_state("alice", mobile.clone(), muted());
+        assert_eq!(
+            r.in_call_sessions_for_nick("alice"),
+            vec![(mobile.clone(), muted()), (web.clone(), raised())]
+        );
+
+        // Clearing web leaves the nick's mobile mute advertised.
+        r.clear_in_call_state("alice", &web);
+        assert_eq!(
+            r.in_call_sessions_for_nick("alice"),
+            vec![(mobile, muted())]
+        );
     }
 
     #[test]
-    fn remove_occupant_clears_hand_state() {
+    fn remove_occupant_clears_in_call_state() {
         let mut r = room();
         let web = full("alice@example.com/web");
-        r.upsert_hand_raised("alice", web, raised());
+        r.upsert_in_call_state("alice", web, raised());
         r.remove_occupant("alice");
-        assert!(!r.hand_raised_for_nick("alice"));
+        assert!(r.in_call_sessions_for_nick("alice").is_empty());
     }
 }

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -28,9 +28,9 @@ pub use admin_handlers::{
     GetAdminContext, IsOwner,
 };
 pub use occupancy_handlers::{
-    ClearMujiPresence, HandRaisedUpdateOutcome, JoinWithAffiliation, LeaveByRealJid,
+    ClearMujiPresence, InCallPresenceUpdateOutcome, JoinWithAffiliation, LeaveByRealJid,
     MujiPresenceUpdateOutcome, PingSelfCheck, PresenceUpdateData, ReconcileChannelBackedRoom,
-    UpsertHandRaised, UpsertMujiPresence,
+    UpsertInCallState, UpsertMujiPresence,
 };
 pub use snapshot_handlers::{
     BuildGroupchatBroadcast, GetNicknameGeneration, GetRoomSnapshot, GroupchatBroadcastResult,
@@ -69,11 +69,12 @@ pub struct JoinExistingOccupant {
     /// coordination state, so join replay must not stamp an aggregate
     /// same-nick Muji payload onto an arbitrary full JID.
     pub muji: Option<crate::xep::xep0272::Muji>,
-    /// Whether this exact session advertises a raised hand
-    /// (`urn:waddle:in-call:0`, #1029) at join time. The join handler
-    /// appends an `<in-call><hand-raised/></in-call>` payload to the
-    /// replayed presence so a late joiner sees who already has a hand up.
-    pub hand_raised: bool,
+    /// This exact session's in-call presence state
+    /// (`urn:waddle:in-call:0`, #1029 raised hand / #1030 mute) at join
+    /// time. The join handler appends an `<in-call>` payload carrying
+    /// these sub-states to the replayed presence so a late joiner sees
+    /// who already has a hand up or is muted.
+    pub in_call: crate::xep::InCallPresenceState,
 }
 
 #[derive(Debug, Clone)]

--- a/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
@@ -71,14 +71,14 @@ impl kameo::message::Message<JoinWithAffiliation> for RoomActor {
                     .into_iter()
                     .map(|jid| {
                         let muji = self.room.muji_for_session(&o.nick, &jid);
-                        let hand_raised = self.room.hand_raised_for_session(&o.nick, &jid);
+                        let in_call = self.room.in_call_state_for_session(&o.nick, &jid);
                         JoinExistingOccupant {
                             jid,
                             nick: o.nick.clone(),
                             affiliation: o.affiliation,
                             role: o.role,
                             muji,
-                            hand_raised,
+                            in_call,
                         }
                     })
             })
@@ -353,32 +353,34 @@ impl kameo::message::Message<ClearMujiPresence> for RoomActor {
 }
 
 /// Apply the calling session's `<in-call xmlns='urn:waddle:in-call:0'>`
-/// raised-hand presence state (#1029). Carried on the same MUC presence
-/// as the XEP-0272 `<muji/>` advertisement but tracked independently so
-/// muji handling stays single-purpose. Like [`UpsertMujiPresence`] this
-/// authenticates the sender as a current occupant; a non-occupant yields
-/// `Ok(None)` and the caller falls back to the join path.
-pub struct UpsertHandRaised {
+/// presence state (#1029 raised hand / #1030 mute). Carried on the same
+/// MUC presence as the XEP-0272 `<muji/>` advertisement but tracked
+/// independently so muji handling stays single-purpose. Like
+/// [`UpsertMujiPresence`] this authenticates the sender as a current
+/// occupant; a non-occupant yields `Ok(None)` and the caller falls back
+/// to the join path.
+pub struct UpsertInCallState {
     pub sender_jid: FullJid,
     pub state: crate::xep::InCallPresenceState,
 }
 
 #[derive(Debug, Clone)]
-pub struct HandRaisedUpdateOutcome {
+pub struct InCallPresenceUpdateOutcome {
     /// Resolved nick of the sending occupant (room-authoritative).
     pub sender_nick: String,
-    /// Full JIDs of the nick's sessions that advertise a raised hand
-    /// after the update. The presence broadcaster decorates each
-    /// reflected per-session presence whose owner appears here.
-    pub raised_hand_sessions: Vec<FullJid>,
+    /// Per-session in-call states for the nick after the update (only
+    /// sessions advertising a non-empty state). The presence broadcaster
+    /// decorates each reflected per-session presence with its owner's
+    /// state from this list.
+    pub in_call_sessions: Vec<(FullJid, crate::xep::InCallPresenceState)>,
 }
 
-impl kameo::message::Message<UpsertHandRaised> for RoomActor {
-    type Reply = Result<Option<HandRaisedUpdateOutcome>, Infallible>;
+impl kameo::message::Message<UpsertInCallState> for RoomActor {
+    type Reply = Result<Option<InCallPresenceUpdateOutcome>, Infallible>;
 
     async fn handle(
         &mut self,
-        msg: UpsertHandRaised,
+        msg: UpsertInCallState,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         let Some(sender_occupant) = self.room.find_occupant_by_real_jid(&msg.sender_jid) else {
@@ -386,11 +388,11 @@ impl kameo::message::Message<UpsertHandRaised> for RoomActor {
         };
         let sender_nick = sender_occupant.nick.clone();
         self.room
-            .upsert_hand_raised(&sender_nick, msg.sender_jid.clone(), msg.state);
-        let raised_hand_sessions = self.room.hand_raised_sessions_for_nick(&sender_nick);
-        Ok(Some(HandRaisedUpdateOutcome {
+            .upsert_in_call_state(&sender_nick, msg.sender_jid.clone(), msg.state);
+        let in_call_sessions = self.room.in_call_sessions_for_nick(&sender_nick);
+        Ok(Some(InCallPresenceUpdateOutcome {
             sender_nick,
-            raised_hand_sessions,
+            in_call_sessions,
         }))
     }
 }

--- a/server/crates/waddle-xmpp/src/xep/xep_waddle_in_call.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep_waddle_in_call.rs
@@ -20,6 +20,7 @@ pub const NS_WADDLE_IN_CALL: &str = "urn:waddle:in-call:0";
 
 const IN_CALL_NAME: &str = "in-call";
 const HAND_RAISED_NAME: &str = "hand-raised";
+const MUTED_NAME: &str = "muted";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InCallSessionId(SessionId);
@@ -116,49 +117,61 @@ pub fn build_in_call_reaction_message(
 /// Presence-durable in-call state for one occupant session, carried in MUC
 /// presence as `<in-call xmlns='urn:waddle:in-call:0'>` alongside `<muji/>`.
 ///
-/// Currently models only a raised hand; the typed struct leaves room for
-/// further presence sub-states (mute, recording) without changing the wire
-/// root. An all-`false` value [`is_empty`](Self::is_empty) and clears the
-/// occupant's stored entry, mirroring `<muji/>` leave semantics.
+/// Models the durable in-call sub-states an occupant can advertise: a raised
+/// hand and a muted microphone. Each is an independent marker child of the same
+/// `<in-call/>` root, so the typed struct can grow further sub-states
+/// (recording, …) without changing the wire root. An all-`false` value
+/// [`is_empty`](Self::is_empty) and clears the occupant's stored entry,
+/// mirroring `<muji/>` leave semantics.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct InCallPresenceState {
     pub hand_raised: bool,
+    pub muted: bool,
 }
 
 impl InCallPresenceState {
     /// True when no sub-state is advertised, i.e. the occupant carries no
     /// in-call presence state and any stored entry should be cleared.
     pub fn is_empty(&self) -> bool {
-        !self.hand_raised
+        !self.hand_raised && !self.muted
     }
 }
 
 /// Build the `<in-call xmlns='urn:waddle:in-call:0'>` presence child for the
-/// given state. A raised hand emits a `<hand-raised/>` marker child; a lowered
-/// hand emits an empty `<in-call/>` element (the canonical "no state" shape a
-/// peer may also omit entirely).
+/// given state. Each advertised sub-state emits its own marker child
+/// (`<hand-raised/>`, `<muted/>`); a state with none advertised emits an empty
+/// `<in-call/>` element (the canonical "no state" shape a peer may also omit
+/// entirely).
 pub fn build_in_call_presence_state_element(state: &InCallPresenceState) -> Element {
     let mut builder = Element::builder(IN_CALL_NAME, NS_WADDLE_IN_CALL);
     if state.hand_raised {
         builder = builder.append(Element::builder(HAND_RAISED_NAME, NS_WADDLE_IN_CALL).build());
+    }
+    if state.muted {
+        builder = builder.append(Element::builder(MUTED_NAME, NS_WADDLE_IN_CALL).build());
     }
     builder.build()
 }
 
 /// Parse an `<in-call xmlns='urn:waddle:in-call:0'>` presence child into its
 /// durable state. The presence shape carries no `sid` (the occupant presence
-/// already identifies the participant and room); a `<hand-raised/>` child
-/// raises the hand and its absence lowers it.
+/// already identifies the participant and room); each marker child raises its
+/// sub-state and its absence lowers it.
 pub fn parse_in_call_presence_state(
     element: &Element,
 ) -> Result<InCallPresenceState, InCallParseError> {
     if element.name() != IN_CALL_NAME || element.ns() != NS_WADDLE_IN_CALL {
         return Err(InCallParseError::NotInCall);
     }
-    let hand_raised = element
-        .children()
-        .any(|child| child.name() == HAND_RAISED_NAME && child.ns() == NS_WADDLE_IN_CALL);
-    Ok(InCallPresenceState { hand_raised })
+    let has_marker = |name: &str| {
+        element
+            .children()
+            .any(|child| child.name() == name && child.ns() == NS_WADDLE_IN_CALL)
+    };
+    Ok(InCallPresenceState {
+        hand_raised: has_marker(HAND_RAISED_NAME),
+        muted: has_marker(MUTED_NAME),
+    })
 }
 
 pub fn parse_in_call_signal(element: &Element) -> Result<InCallSignal, InCallParseError> {

--- a/server/crates/waddle-xmpp/tests/xep_waddle_in_call.rs
+++ b/server/crates/waddle-xmpp/tests/xep_waddle_in_call.rs
@@ -12,7 +12,10 @@ use xmpp_parsers::message::MessageType;
 
 #[test]
 fn hand_raised_presence_state_round_trips() {
-    let element = build_in_call_presence_state_element(&InCallPresenceState { hand_raised: true });
+    let element = build_in_call_presence_state_element(&InCallPresenceState {
+        hand_raised: true,
+        muted: false,
+    });
 
     // Carried as `<in-call xmlns='urn:waddle:in-call:0'>` so it sits next to
     // (never inside) the `<muji/>` element in MUC call presence.
@@ -27,7 +30,90 @@ fn hand_raised_presence_state_round_trips() {
 
     assert_eq!(
         parse_in_call_presence_state(&element),
-        Ok(InCallPresenceState { hand_raised: true })
+        Ok(InCallPresenceState {
+            hand_raised: true,
+            muted: false,
+        })
+    );
+}
+
+#[test]
+fn muted_presence_state_round_trips() {
+    let element = build_in_call_presence_state_element(&InCallPresenceState {
+        muted: true,
+        ..InCallPresenceState::default()
+    });
+
+    // Same `<in-call xmlns='urn:waddle:in-call:0'>` root as the raised hand, so
+    // mute rides alongside `<muji/>` and any other in-call sub-state.
+    assert_eq!(element.name(), "in-call");
+    assert_eq!(element.ns(), NS_WADDLE_IN_CALL);
+    assert!(
+        element
+            .children()
+            .any(|child| child.name() == "muted" && child.ns() == NS_WADDLE_IN_CALL),
+        "muted serializes a <muted/> child"
+    );
+    assert!(
+        !element
+            .children()
+            .any(|child| child.name() == "hand-raised"),
+        "an unmuted-only state carries no <hand-raised/> child"
+    );
+
+    assert_eq!(
+        parse_in_call_presence_state(&element),
+        Ok(InCallPresenceState {
+            muted: true,
+            hand_raised: false,
+        })
+    );
+}
+
+#[test]
+fn hand_raised_and_muted_combine_in_one_in_call_element() {
+    let element = build_in_call_presence_state_element(&InCallPresenceState {
+        hand_raised: true,
+        muted: true,
+    });
+
+    // Both sub-states are carried as sibling marker children of the SAME
+    // `<in-call/>` element — never as nested or duplicated roots.
+    assert!(
+        element
+            .children()
+            .any(|child| child.name() == "hand-raised" && child.ns() == NS_WADDLE_IN_CALL),
+        "raised hand still serializes a <hand-raised/> child"
+    );
+    assert!(
+        element
+            .children()
+            .any(|child| child.name() == "muted" && child.ns() == NS_WADDLE_IN_CALL),
+        "muted still serializes a <muted/> child"
+    );
+
+    assert_eq!(
+        parse_in_call_presence_state(&element),
+        Ok(InCallPresenceState {
+            hand_raised: true,
+            muted: true,
+        })
+    );
+}
+
+#[test]
+fn muted_only_state_is_not_empty() {
+    assert!(
+        !InCallPresenceState {
+            muted: true,
+            ..InCallPresenceState::default()
+        }
+        .is_empty(),
+        "an advertised mute is in-call presence state"
+    );
+    assert!(
+        InCallPresenceState::default().is_empty(),
+        "no sub-state advertised is the empty/clearing state"
     );
 }
 
@@ -68,9 +154,16 @@ fn in_call_reaction_message_round_trips_with_transient_hints() {
 
 #[test]
 fn lowered_hand_is_empty_state_with_no_marker_child() {
-    let lowered = InCallPresenceState { hand_raised: false };
+    let lowered = InCallPresenceState {
+        hand_raised: false,
+        muted: false,
+    };
     assert!(lowered.is_empty());
-    assert!(!InCallPresenceState { hand_raised: true }.is_empty());
+    assert!(!InCallPresenceState {
+        hand_raised: true,
+        muted: false,
+    }
+    .is_empty());
 
     let element = build_in_call_presence_state_element(&lowered);
     assert_eq!(element.name(), "in-call");
@@ -81,7 +174,10 @@ fn lowered_hand_is_empty_state_with_no_marker_child() {
     );
     assert_eq!(
         parse_in_call_presence_state(&element),
-        Ok(InCallPresenceState { hand_raised: false })
+        Ok(InCallPresenceState {
+            hand_raised: false,
+            muted: false,
+        })
     );
 }
 

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -523,17 +523,17 @@ export class WaddleClient {
      *   §Joining two-phase flow. Typically the client sends this
      *   first, awaits the room's echo, then re-emits with contents
      *   declared.
-     * - `hand_raised=true`: appends an
-     *   `<in-call xmlns='urn:waddle:in-call:0'><hand-raised/></in-call>`
-     *   presence child *alongside* `<muji/>` (#1029). This is the FFI
-     *   raise/lower-hand "set method": the caller re-emits its current
-     *   call presence with the flag toggled, and the absence of the
-     *   child lowers the hand for everyone (the server clears the
-     *   stored state). Ignored unless the occupant is in the call
-     *   (`active` or `preparing`), since a raised hand is meaningless
-     *   without call participation.
+     * - `hand_raised`/`muted`: append an `<in-call
+     *   xmlns='urn:waddle:in-call:0'>` presence child *alongside*
+     *   `<muji/>` (#1029 raised hand / #1030 mute) carrying one marker
+     *   child per set flag. This is the FFI in-call "set method": the
+     *   caller re-emits its current call presence with the flags
+     *   toggled, and the absence of a marker clears that sub-state for
+     *   everyone (the server drops the stored state). Ignored unless the
+     *   occupant is in the call (`active` or `preparing`), since in-call
+     *   state is meaningless without call participation.
      */
-    update_muji_presence(room_jid: string, nick: string, active: boolean, preparing: boolean, video: boolean, hand_raised: boolean): Promise<any>;
+    update_muji_presence(room_jid: string, nick: string, active: boolean, preparing: boolean, video: boolean, hand_raised: boolean, muted: boolean): Promise<any>;
     /**
      * Fetch the latest calendar events from the community events
      * node. Returns ALL items including past events; chat-side

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -523,17 +523,18 @@ export class WaddleClient {
      *   §Joining two-phase flow. Typically the client sends this
      *   first, awaits the room's echo, then re-emits with contents
      *   declared.
-     * - `hand_raised`/`muted`: append an `<in-call
+     * - `in_call`: a plain JS object `{ handRaised, muted }`
+     *   ([`InCallPresenceFlags`]) appended as an `<in-call
      *   xmlns='urn:waddle:in-call:0'>` presence child *alongside*
-     *   `<muji/>` (#1029 raised hand / #1030 mute) carrying one marker
-     *   child per set flag. This is the FFI in-call "set method": the
-     *   caller re-emits its current call presence with the flags
-     *   toggled, and the absence of a marker clears that sub-state for
-     *   everyone (the server drops the stored state). Ignored unless the
-     *   occupant is in the call (`active` or `preparing`), since in-call
-     *   state is meaningless without call participation.
+     *   `<muji/>` (#1029 raised hand / #1030 mute), one marker child per
+     *   set flag. This is the FFI in-call "set method": the caller
+     *   re-emits its current call presence with the flags toggled, and
+     *   the absence of a marker clears that sub-state for everyone (the
+     *   server drops the stored state). Ignored unless the occupant is in
+     *   the call (`active` or `preparing`), since in-call state is
+     *   meaningless without call participation.
      */
-    update_muji_presence(room_jid: string, nick: string, active: boolean, preparing: boolean, video: boolean, hand_raised: boolean, muted: boolean): Promise<any>;
+    update_muji_presence(room_jid: string, nick: string, active: boolean, preparing: boolean, video: boolean, in_call: any): Promise<any>;
     /**
      * Fetch the latest calendar events from the community events
      * node. Returns ALL items including past events; chat-side

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -534,7 +534,7 @@ export class WaddleClient {
      *   the call (`active` or `preparing`), since in-call state is
      *   meaningless without call participation.
      */
-    update_muji_presence(room_jid: string, nick: string, active: boolean, preparing: boolean, video: boolean, in_call: any): Promise<any>;
+    update_muji_presence(room_jid: string, nick: string, active: boolean, preparing: boolean, video: boolean, in_call: { handRaised?: boolean; muted?: boolean }): Promise<any>;
     /**
      * Fetch the latest calendar events from the community events
      * node. Returns ALL items including past events; chat-side

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=a92f704f660c";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=a92f704f660c";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=a92f704f660c";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=47ff3429b53e";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=47ff3429b53e";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=47ff3429b53e";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=a92f704f660c";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=47ff3429b53e";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=47ff3429b53e";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=47ff3429b53e";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=47ff3429b53e";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=8d21e40891c1";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=8d21e40891c1";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=8d21e40891c1";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=47ff3429b53e";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=8d21e40891c1";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=6f209191697d";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=6f209191697d";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=6f209191697d";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=a92f704f660c";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=a92f704f660c";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=a92f704f660c";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=6f209191697d";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=a92f704f660c";


### PR DESCRIPTION
## Summary

Implements #1030 (Call Zoom-parity epic #1017): carries **call mute-state**
over the `urn:waddle:in-call:0` presence carrier instead of LiveKit's own
track-mute signalling (the non-XMPP control path). Local mute changes broadcast
as MUC occupant presence; tiles and the roster now reflect *authoritative remote
mute state* — previously only self-mute was shown. Restores the XMPP-native
rule.

Mirrors the just-landed raise-hand work (#1029): mute is a presence-durable
in-call sub-state carried as a `<muted/>` marker child *alongside* (never
inside) the XEP-0272 `<muji/>` element, following the same MUJI presence-state
lifecycle — store per session, reflect room-authoritative state, replay to late
joiners, clear on unmute / leave-call / leave-room.

> On "retire LiveKit data channel": there is no literal `publishData` mute path
> — remote mute simply lived only in LiveKit's own track signalling and was
> never surfaced. The deliverable is to make XMPP presence the authoritative
> source for remote mute; the local `TrackMuted` handler stays solely for
> AI-filter reconcile, never as a control path.

## Wire shape

```xml
<presence from='room@muc/alice' ...>
  <muji xmlns='urn:xmpp:jingle:muji:0'>…</muji>
  <in-call xmlns='urn:waddle:in-call:0'>
    <muted/>
    <hand-raised/>   <!-- if also raised -->
  </in-call>
</presence>
```

Absence of `<muted/>` (or of the whole `<in-call>` element) = unmuted. The
server force-clears all in-call state on a XEP-0272 leave marker, so mute only
ever exists for an active call participant.

## What changed

**Server (Rust)**
- `xep_waddle_in_call`: `InCallPresenceState` gains `muted`; typed build/parse of
  the `<muted/>` marker (struct-built, never `format!`); `is_empty()` covers it.
- `MucRoom`: **generalized** the #1029 `hand_raised_state` into a single
  `in_call_state: HashMap<nick, HashMap<FullJid, InCallPresenceState>>` carrying
  the full per-session in-call state (raise-hand + mute) — one source of truth,
  no parallel maps. Renamed the actor message `UpsertHandRaised` →
  `UpsertInCallState` and outcome → `InCallPresenceUpdateOutcome`.
- Presence handler: stores inbound mute and reflects the room-authoritative
  `<in-call>` child per session (client echo stripped, so a sibling resource is
  never mis-stamped). The muji-leave invariant clears mute too.
- Join-replay: surfaces muted occupants to mid-call joiners.

**Client FFI (Rust WASM)**
- Parse `<muted/>` into the typed inbound presence.
- `update_muji_presence` now takes the two `<in-call>` sub-state flags as one
  `InCallPresenceFlags { handRaised, muted }` object (serde-deserialized) — keeps
  the FFI within clippy's argument budget and mirrors the codebase's opts-object
  convention. Regenerated the wasm bindings.

**Chat (TypeScript/Vue)**
- New `call-mute.ts` store: inbound presence → per-room muted identity set (a
  pure remote view; self-mute stays sourced from the local mic flag). Wired into
  the inbound presence dispatch + clear-on-logout in `client.ts`.
- Local mic toggle broadcasts mute as presence; every call-presence re-emit
  carries the current hand AND mute (presence is last-writer-wins); a
  post-connect seed re-broadcasts the actual published mic so capture failures /
  join-muted are reflected accurately.
- Roster rows + tile `micEnabledHint` for remote participants sourced from
  presence (a muted remote's still-published mic track no longer reads as
  "on"); `CallTile` shows the mic-off badge for muted remotes — confined to
  camera tiles (a screen-share tile has no mic).

## Acceptance criteria

- [x] Local mute changes broadcast as presence state over `urn:waddle:in-call:0`.
- [x] Remote participants' mute state shown accurately on tiles and in the roster.
- [x] The LiveKit data-channel mute path is removed (remote mute is presence-sourced).
- [x] The mute presence roundtrip is covered by the `xep_waddle_in_call` suite.

## Testing

- `xep_waddle_in_call` carrier round-trip (mute, hand+mute coexistence, is_empty).
- `MucRoom` per-session in-call state unit tests (upsert/clear/aggregate/remove).
- WS integration (`xep_waddle_in_call_ws`): mute reflect alongside `<muji/>`,
  join-replay + clear-on-unmute, hand+mute coexist on the wire, and the
  leave-marker force-clears a stale `<muted/>`.
- WASM client parse tests; chat `call-mute` / `call-roster` / `call-tiles` bun
  suites; updated `call-teardown` FFI assertions.

## Review

Reviewed by adversarial XEP-conformance, Rust-correctness, and chat-correctness
personas. Round 1 surfaced two real defects — a clippy `too_many_arguments`
regression and a mute badge leaking onto screen-share tiles — both fixed; a
second focused round confirmed no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Code-review follow-up: best-effort `in_call` parsing

A reviewer flagged that `update_muji_presence(..., in_call: JsValue)`
deserialized `in_call` with `?`, rejecting the Promise on any failure
(`undefined`, `null`, a legacy boolean, or a malformed object) and so
blocking the presence send — including the call-teardown leave marker
that clears `<muji/>` for remote occupants, leaving them observing stale
call participation.

`in_call` parsing is now best-effort and NEVER rejects the send:

- `undefined` / `null` → `InCallPresenceFlags::default()` (both flags
  cleared) — the shape the leave/teardown paths want anyway.
- a bare `boolean` (legacy pre-#1030 caller) → `{ handRaised: <bool>,
  muted: false }`.
- otherwise deserialize the `{ handRaised, muted }` object, falling back
  to `default()` if deserialization fails for any reason.

The decision is split into a representation-agnostic
`resolve_in_call_flags` core so the branch precedence **and** the
never-fails fallback are pinned by native unit tests (`JsValue` aborts
under `cargo test`, per the documented `client_calls.rs` precedent; the
serde shape is exercised via `serde_json`, which drives the same
`Deserialize` impl). The `<muji/>` / `<in-call>` gate (`if preparing ||
active`) is unchanged, so a malformed `in_call` can never leak a marker
onto the leave path.

Also tightened the generated `.d.ts` parameter from `any` to
`{ handRaised?: boolean; muted?: boolean }` via wasm-bindgen
`unchecked_param_type`, and regenerated the wasm bindings. The only
non-`.d.ts` artifact change is the deterministic cache-bust `?b=` build
id in the wrapper `.js` (it had also corrected a pre-existing stale id
on the first rebuild).
