### PR TITLE
fix(chat): restore channel joins

### DIFF
--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -869,7 +869,7 @@ export class BrowserXmppClient {
   private readonly resumeDrainHooks: Array<(info: { buffered: number; durationMs: number }) => void> = [];
   private readonly roomJoinWaiters = new Map<
     string,
-    { promise: Promise<void>; resolve: () => void; reject: (error: Error) => void }
+    { promise: Promise<void>; requestedNick: string; resolve: () => void; reject: (error: Error) => void }
   >();
   private readonly carbonDedupIds = new Set<string>();
   readonly catchup: ReconnectCatchup;
@@ -1015,12 +1015,14 @@ export class BrowserXmppClient {
 
   private handleMucPresenceError(presence: WasmPresence): boolean {
     if (presence.presence_type !== "error") return false;
-    const room = presence.from?.split("/")[0]?.trim() ?? "";
+    const [rawRoom = "", errorNick = ""] = presence.from?.split("/") ?? [];
+    const room = rawRoom.trim();
     const key = this.roomJoinKey(room);
     if (!room || !key) return false;
 
     const waiter = this.roomJoinWaiters.get(key);
     if (!waiter) return false;
+    if (errorNick !== waiter.requestedNick) return false;
 
     waiter?.reject(new Error("Channel presence was rejected. Try again in a moment."));
     this.revokeMucReadiness(this.canonicalJoinedRoomJid(room), { keepPendingJoin: true });
@@ -1340,7 +1342,7 @@ export class BrowserXmppClient {
     this.discoveredRoomJids.set(channelId, normalizedRoomJid);
   }
 
-  private waitForRoomSelfPresence(roomJid: string): Promise<void> {
+  private waitForRoomSelfPresence(roomJid: string, requestedNick: string): Promise<void> {
     const key = this.roomJoinKey(roomJid);
     // Concurrent joins for JIDs that normalize to the same room key
     // (e.g. case variants from topology vs. retained-room replay) must
@@ -1362,6 +1364,7 @@ export class BrowserXmppClient {
     }, ROOM_SELF_PRESENCE_TIMEOUT_MS);
     this.roomJoinWaiters.set(key, {
       promise,
+      requestedNick,
       resolve: () => {
         clearTimeout(timeout);
         this.roomJoinWaiters.delete(key);
@@ -1488,7 +1491,7 @@ export class BrowserXmppClient {
     if (!xmpp.join_room && !xmpp.joinRoom) {
       throw new Error("XMPP client missing join_room binding");
     }
-    const ready = this.waitForRoomSelfPresence(roomJid);
+    const ready = this.waitForRoomSelfPresence(roomJid, this.session.username);
     const joinKey = this.roomJoinKey(roomJid);
     const joinWaiter = this.roomJoinWaiters.get(joinKey);
     try {

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -520,6 +520,44 @@ describe("client send readiness", () => {
     expect((client as unknown as { roomJoinWaiters: Map<string, unknown> }).roomJoinWaiters.size).toBe(0);
   });
 
+  test("room join ignores unrelated room presence errors while waiting for self-presence", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      muc_status_codes?: number[];
+    }) => void) | null = null;
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+
+    const joined = (client as unknown as { ensureJoined: (roomJid: string) => Promise<void> }).ensureJoined(roomJid);
+    const observed = joined.then(() => "resolved" as const, normalizeError);
+    await Promise.resolve();
+
+    onPresence?.({
+      from: `${roomJid}/not-the-join-nick`,
+      presence_type: "error",
+    });
+    await Promise.resolve();
+
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+    });
+
+    await expect(observed).resolves.toBe("resolved");
+    expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(true);
+  });
+
   test("MUC error presence after a completed join does not revoke readiness", async () => {
     const client = new BrowserXmppClient(session());
     const roomJid = roomBareJidFor(session(), "c1");

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
@@ -2065,6 +2065,25 @@ async fn cleanup_stale_space_bookmarks(
                     item: previous_item,
                     parent_tuple_deleted,
                 });
+                match delete_channel_parent_tuple(state, channel_id, stale).await {
+                    Ok(deleted) => {
+                        if deleted {
+                            if let Some(removed) = removed_stale.last_mut() {
+                                removed.parent_tuple_deleted = true;
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        restore_stale_space_bookmarks(
+                            state,
+                            spaces_jid,
+                            channel_id,
+                            &removed_stale,
+                        )
+                        .await;
+                        return Err(error);
+                    }
+                }
             }
             Err(error) => {
                 if parent_tuple_deleted {
@@ -2150,7 +2169,7 @@ pub(super) async fn handle_spaces_retract(
         return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::InvalidJid))];
     };
     let item_filter = [item_id.to_string()];
-    match state
+    let previous_item = match state
         .deps
         .protocol
         .pubsub_storage
@@ -2160,7 +2179,12 @@ pub(super) async fn handle_spaces_retract(
         Ok(items) if items.is_empty() => {
             return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::ItemNotFound))];
         }
-        Ok(_) => {}
+        Ok(items) => {
+            let Some(item) = items.into_iter().next() else {
+                return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::ItemNotFound))];
+            };
+            item.to_pubsub_item()
+        }
         Err(error) => {
             warn!(item_id, node, error = %error, "Failed to preflight Spaces item before retract");
             return vec![iq_to_xml(build_pubsub_error(
@@ -2168,7 +2192,7 @@ pub(super) async fn handle_spaces_retract(
                 PubSubError::InternalServerError,
             ))];
         }
-    }
+    };
     let link_to_restore = match state
         .deps
         .app_state
@@ -2221,7 +2245,58 @@ pub(super) async fn handle_spaces_retract(
         .retract_item(&spaces_jid, node, item_id)
         .await
     {
-        Ok(true) => vec![iq_to_xml(build_pubsub_success(iq))],
+        Ok(true) => match delete_channel_parent_tuple(state, &channel_id, node).await {
+            Ok(_) => vec![iq_to_xml(build_pubsub_success(iq))],
+            Err(error) => {
+                if let Err(restore_error) = state
+                    .deps
+                    .protocol
+                    .pubsub_storage
+                    .publish_item(&spaces_jid, node, &previous_item, None, false)
+                    .await
+                {
+                    warn!(
+                        item_id,
+                        node,
+                        error = %restore_error,
+                        "Failed to restore Spaces item after final parent tuple cleanup failure"
+                    );
+                }
+                if parent_tuple_deleted {
+                    if let Err(restore_error) =
+                        write_channel_parent_tuple(state, &channel_id, node).await
+                    {
+                        warn!(
+                            item_id,
+                            node,
+                            error = %restore_error,
+                            "Failed to restore channel parent tuple after final cleanup failure"
+                        );
+                    }
+                }
+                if let Some(link) = link_to_restore.as_ref() {
+                    if let Err(restore_error) = state
+                        .deps
+                        .app_state
+                        .channel_space_link_store
+                        .set(link)
+                        .await
+                    {
+                        warn!(
+                            item_id,
+                            node,
+                            error = %restore_error,
+                            "Failed to restore channel-space link after final parent tuple cleanup failure"
+                        );
+                    }
+                }
+                warn!(item_id, node, error = %error, "Failed to clear channel parent tuple after Spaces retract");
+                vec![iq_to_xml(build_pubsub_error(
+                    iq,
+                    PubSubError::InternalServerError,
+                ))]
+            }
+        },
         Ok(false) => {
             if parent_tuple_deleted {
                 if let Err(restore_error) =

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -111,6 +111,7 @@ async fn handle_muc_join_unlocked(
             match resolve_managed_channel_affiliation(
                 state,
                 session,
+                room_jid,
                 &channel.id,
                 admission_members_only,
             )

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc/access.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc/access.rs
@@ -1,8 +1,10 @@
 use super::*;
+use crate::permissions::{DeleteTuple, PermissionError, Relation, SubjectType, Tuple, WriteTuple};
 
 pub(super) async fn resolve_managed_channel_affiliation(
     state: &WebSocketState,
     session: &Session,
+    room_jid: &BareJid,
     channel_id: &str,
     members_only: bool,
 ) -> Result<Option<Affiliation>, ()> {
@@ -46,7 +48,222 @@ pub(super) async fn resolve_managed_channel_affiliation(
         }
     }
 
+    if check_channel_permission(state, object.clone(), subject.clone(), Permission::Read).await? {
+        return Ok(read_access_affiliation(members_only));
+    }
+
+    restore_space_parent_tuples_for_room(state, room_jid, channel_id).await?;
+    if check_channel_permission(state, object, subject, Permission::Read).await? {
+        return Ok(read_access_affiliation(members_only));
+    }
     Ok(None)
+}
+
+fn read_access_affiliation(members_only: bool) -> Option<Affiliation> {
+    if members_only {
+        None
+    } else {
+        Some(Affiliation::None)
+    }
+}
+
+async fn restore_space_parent_tuples_for_room(
+    state: &WebSocketState,
+    room_jid: &BareJid,
+    channel_id: &str,
+) -> Result<(), ()> {
+    let item_id = room_jid.to_string();
+    let nodes = state
+        .deps
+        .protocol
+        .pubsub_storage
+        .list_node_names_for_item(&state.deps.app_state.spaces_jid, &item_id)
+        .await
+        .map_err(|error| {
+            warn!(
+                room = %room_jid,
+                channel_id,
+                error = %error,
+                "Failed to enumerate Spaces bookmarks while repairing managed MUC permissions"
+            );
+        })?;
+
+    let mut valid_nodes = Vec::new();
+    for node in nodes {
+        if space_node_has_room_bookmark(state, room_jid, channel_id, &node, &item_id).await? {
+            valid_nodes.push(node);
+        }
+    }
+
+    let repair_nodes = space_parent_repair_nodes(state, room_jid, channel_id, valid_nodes).await?;
+    for node in repair_nodes {
+        let tuple = Tuple::new(
+            Object::new(ObjectType::Channel, channel_id),
+            Relation::new("parent"),
+            Subject::userset(SubjectType::Space, &node, ""),
+        );
+        match state
+            .deps
+            .app_state
+            .permission_actor
+            .ask(WriteTuple {
+                tuple: tuple.clone(),
+            })
+            .await
+        {
+            Ok(())
+            | Err(kameo::error::SendError::HandlerError(PermissionError::TupleAlreadyExists)) => {}
+            Err(error) => {
+                warn!(
+                    room = %room_jid,
+                    channel_id,
+                    node,
+                    error = ?error,
+                    "Failed to repair managed MUC channel parent tuple"
+                );
+                return Err(());
+            }
+        }
+        if !space_node_has_room_bookmark(state, room_jid, channel_id, &node, &item_id).await? {
+            match state
+                .deps
+                .app_state
+                .permission_actor
+                .ask(DeleteTuple {
+                    tuple: tuple.clone(),
+                })
+                .await
+            {
+                Ok(())
+                | Err(kameo::error::SendError::HandlerError(PermissionError::TupleNotFound)) => {}
+                Err(error) => {
+                    warn!(
+                        room = %room_jid,
+                        channel_id,
+                        node,
+                        error = ?error,
+                        "Failed to clean up stale managed MUC channel parent tuple after revalidation"
+                    );
+                    return Err(());
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn space_node_has_room_bookmark(
+    state: &WebSocketState,
+    room_jid: &BareJid,
+    channel_id: &str,
+    node: &str,
+    item_id: &str,
+) -> Result<bool, ()> {
+    let item_filter = [item_id.to_string()];
+    let items = state
+        .deps
+        .protocol
+        .pubsub_storage
+        .get_items(
+            &state.deps.app_state.spaces_jid,
+            node,
+            Some(1),
+            &item_filter,
+        )
+        .await
+        .map_err(|error| {
+            warn!(
+                room = %room_jid,
+                channel_id,
+                node,
+                error = %error,
+                "Failed to load Spaces bookmark while repairing managed MUC permissions"
+            );
+        })?;
+    let Some(item) = items.first() else {
+        return Ok(false);
+    };
+    let Some(payload) = item
+        .payload_xml
+        .as_ref()
+        .and_then(|xml| xml.parse::<Element>().ok())
+    else {
+        return Ok(false);
+    };
+    let Ok(bookmark) = waddle_xmpp::xep::xep0402::parse_bookmark(&item.id, &payload) else {
+        return Ok(false);
+    };
+    Ok(bookmark.jid == *room_jid)
+}
+
+async fn space_parent_repair_nodes(
+    state: &WebSocketState,
+    room_jid: &BareJid,
+    channel_id: &str,
+    valid_nodes: Vec<String>,
+) -> Result<Vec<String>, ()> {
+    let link = state
+        .deps
+        .app_state
+        .channel_space_link_store
+        .get(room_jid)
+        .await
+        .map_err(|error| {
+            warn!(
+                room = %room_jid,
+                channel_id,
+                error = %error,
+                "Failed to read channel-space projection while repairing managed MUC permissions"
+            );
+        })?;
+    let Some(link) = link else {
+        return match valid_nodes.as_slice() {
+            [] => Ok(Vec::new()),
+            [node] => Ok(vec![node.clone()]),
+            nodes => {
+                warn!(
+                    room = %room_jid,
+                    channel_id,
+                    nodes = ?nodes,
+                    "Refusing to repair ambiguous managed MUC Space parents without a channel-space projection"
+                );
+                Ok(Vec::new())
+            }
+        };
+    };
+
+    if link.space_jid.domain() != state.deps.app_state.spaces_jid.domain() {
+        warn!(
+            room = %room_jid,
+            channel_id,
+            linked_space = %link.space_jid,
+            spaces = %state.deps.app_state.spaces_jid,
+            "Refusing to repair managed MUC Space parent from a different Spaces service"
+        );
+        return Ok(Vec::new());
+    }
+    let Some(node) = link.space_jid.node().map(|node| node.to_string()) else {
+        warn!(
+            room = %room_jid,
+            channel_id,
+            linked_space = %link.space_jid,
+            "Refusing to repair managed MUC Space parent without a Space node"
+        );
+        return Ok(Vec::new());
+    };
+    if valid_nodes.iter().any(|valid| valid == &node) {
+        return Ok(vec![node]);
+    }
+
+    warn!(
+        room = %room_jid,
+        channel_id,
+        linked_space = %link.space_jid,
+        nodes = ?valid_nodes,
+        "Refusing to repair managed MUC Space parent because the projected Space lacks the bookmark"
+    );
+    Ok(Vec::new())
 }
 
 async fn check_channel_permission(

--- a/server/crates/waddle-server/src/server/routes/websocket/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests.rs
@@ -11,9 +11,7 @@ use super::{
 };
 use crate::config::ServerConfig;
 use crate::db::{DatabaseConfig, DatabasePool, MigrationRunner, PoolConfig};
-use crate::permissions::{
-    CheckPermission, Object, ObjectType, Permission, Relation, Subject, Tuple, WriteTuple,
-};
+use crate::permissions::{Object, ObjectType, Permission, Relation, Subject, Tuple, WriteTuple};
 use crate::server::bootstrap_membership::DEPLOYMENT_SERVER_ID;
 use crate::server::AppState;
 use hmac::{Hmac, KeyInit, Mac};

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::permissions::CheckPermission;
 
 #[tokio::test]
 async fn muc_stale_leave_does_not_remove_current_resource() {
@@ -2041,6 +2042,281 @@ async fn active_room_disco_preserves_managed_announcement_channel_type() {
     assert!(
         !response.contains("<value>text</value>"),
         "announcement room must not be reported as text: {response}"
+    );
+}
+
+#[tokio::test]
+async fn managed_space_bookmark_join_repairs_missing_parent_tuple() {
+    let state = create_test_websocket_state().await;
+    let conn = state
+        .deps
+        .app_state
+        .db_pool
+        .global()
+        .guard()
+        .await
+        .expect("db connection");
+    conn.execute(
+        "INSERT INTO channels (id, name, description, channel_type, position, is_default, members_only, public_room) VALUES (?, ?, ?, 'text', 0, 0, 0, 1)",
+        crate::db_params!["legacy", "Legacy", "Legacy channel description"],
+    )
+    .await
+    .expect("insert channel");
+    drop(conn);
+
+    let spaces_jid = state.deps.app_state.spaces_jid.clone();
+    state
+        .deps
+        .protocol
+        .pubsub_storage
+        .get_or_create_node(&spaces_jid, "alpha")
+        .await
+        .expect("space node");
+    let channel = waddle_xmpp::ChannelInfo {
+        id: "legacy".to_string(),
+        name: "Legacy".to_string(),
+        channel_type: "text".to_string(),
+    };
+    let item =
+        waddle_xmpp::xep::build_channel_item(&channel, "muc.example.com").expect("bookmark item");
+    state
+        .deps
+        .protocol
+        .pubsub_storage
+        .publish_item(&spaces_jid, "alpha", &item, None, false)
+        .await
+        .expect("publish bookmark");
+
+    let viewer = create_test_session(state.as_ref(), "viewer").await;
+    state
+        .deps
+        .app_state
+        .permission_actor
+        .ask(WriteTuple {
+            tuple: Tuple::new(
+                Object::new(ObjectType::Space, "alpha"),
+                Relation::new("member"),
+                Subject::user(&viewer.user_jid),
+            ),
+        })
+        .await
+        .expect("space member tuple");
+    let allowed_before = state
+        .deps
+        .app_state
+        .permission_actor
+        .ask(CheckPermission {
+            subject: Subject::user(&viewer.user_jid),
+            permission: Permission::Read,
+            object: Object::new(ObjectType::Channel, "legacy"),
+        })
+        .await
+        .expect("permission actor")
+        .allowed;
+    assert!(
+        !allowed_before,
+        "test setup should start without the channel parent tuple"
+    );
+
+    let room_jid: BareJid = "legacy@muc.example.com".parse().expect("room jid");
+    let viewer_jid: FullJid = format!("{}@example.com/web", viewer.xmpp_localpart)
+        .parse()
+        .expect("viewer jid");
+    let responses = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &viewer_jid,
+        "viewer",
+        None,
+        &Some(viewer.clone()),
+    )
+    .await;
+
+    let presence = Element::from_str(responses.first().expect("self-presence response"))
+        .expect("presence XML");
+    assert_eq!(presence.name(), "presence");
+    assert_ne!(
+        presence.attr("type"),
+        Some("error"),
+        "managed Space bookmark join should not be rejected: {responses:?}"
+    );
+    let user_x = presence
+        .get_child("x", "http://jabber.org/protocol/muc#user")
+        .expect("muc user payload");
+    let item = user_x
+        .get_child("item", "http://jabber.org/protocol/muc#user")
+        .expect("muc user item");
+    assert_eq!(
+        item.attr("affiliation"),
+        Some("none"),
+        "repaired Space read access must not become persistent MUC membership: {responses:?}"
+    );
+    assert!(
+        user_x
+            .children()
+            .any(|child| child.name() == "status" && child.attr("code") == Some("110")),
+        "successful join must complete with XEP-0045 self-presence 110: {responses:?}"
+    );
+
+    let allowed_after = state
+        .deps
+        .app_state
+        .permission_actor
+        .ask(CheckPermission {
+            subject: Subject::user(&viewer.user_jid),
+            permission: Permission::Read,
+            object: Object::new(ObjectType::Channel, "legacy"),
+        })
+        .await
+        .expect("permission actor")
+        .allowed;
+    assert!(
+        allowed_after,
+        "join should repair the missing channel parent tuple"
+    );
+}
+
+#[tokio::test]
+async fn managed_space_bookmark_join_repairs_only_projected_parent_tuple() {
+    let state = create_test_websocket_state().await;
+    let conn = state
+        .deps
+        .app_state
+        .db_pool
+        .global()
+        .guard()
+        .await
+        .expect("db connection");
+    conn.execute(
+        "INSERT INTO channels (id, name, description, channel_type, position, is_default, members_only, public_room) VALUES (?, ?, ?, 'text', 0, 0, 1, 0)",
+        crate::db_params!["projected", "Projected", "Projected channel description"],
+    )
+    .await
+    .expect("insert channel");
+    drop(conn);
+
+    let spaces_jid = state.deps.app_state.spaces_jid.clone();
+    for node in ["alpha", "beta"] {
+        state
+            .deps
+            .protocol
+            .pubsub_storage
+            .get_or_create_node(&spaces_jid, node)
+            .await
+            .expect("space node");
+    }
+    let channel = waddle_xmpp::ChannelInfo {
+        id: "projected".to_string(),
+        name: "Projected".to_string(),
+        channel_type: "text".to_string(),
+    };
+    let item =
+        waddle_xmpp::xep::build_channel_item(&channel, "muc.example.com").expect("bookmark item");
+    for node in ["alpha", "beta"] {
+        state
+            .deps
+            .protocol
+            .pubsub_storage
+            .publish_item(&spaces_jid, node, &item, None, false)
+            .await
+            .expect("publish bookmark");
+    }
+
+    let room_jid: BareJid = "projected@muc.example.com".parse().expect("room jid");
+    state
+        .deps
+        .app_state
+        .channel_space_link_store
+        .set(&crate::channel_space_links::ChannelSpaceLink {
+            channel_jid: room_jid.clone(),
+            space_jid: format!("beta@{}", spaces_jid.domain())
+                .parse()
+                .expect("space jid"),
+            space_node: crate::space_identity::SpaceNode::from("beta"),
+            created_at: 0,
+        })
+        .await
+        .expect("channel-space link");
+
+    let stale_viewer = create_test_session(state.as_ref(), "stale-viewer").await;
+    state
+        .deps
+        .app_state
+        .permission_actor
+        .ask(WriteTuple {
+            tuple: Tuple::new(
+                Object::new(ObjectType::Space, "alpha"),
+                Relation::new("member"),
+                Subject::user(&stale_viewer.user_jid),
+            ),
+        })
+        .await
+        .expect("stale space member tuple");
+    let current_viewer = create_test_session(state.as_ref(), "current-viewer").await;
+    state
+        .deps
+        .app_state
+        .permission_actor
+        .ask(WriteTuple {
+            tuple: Tuple::new(
+                Object::new(ObjectType::Space, "beta"),
+                Relation::new("member"),
+                Subject::user(&current_viewer.user_jid),
+            ),
+        })
+        .await
+        .expect("current space member tuple");
+
+    let stale_jid: FullJid = format!("{}@example.com/web", stale_viewer.xmpp_localpart)
+        .parse()
+        .expect("stale viewer jid");
+    let stale_responses = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &stale_jid,
+        "stale-viewer",
+        None,
+        &Some(stale_viewer.clone()),
+    )
+    .await;
+    let stale_presence = Element::from_str(stale_responses.first().expect("stale join response"))
+        .expect("presence XML");
+    assert_eq!(
+        stale_presence.attr("type"),
+        Some("error"),
+        "stale Space member must remain denied: {stale_responses:?}"
+    );
+    assert!(
+        !state
+            .deps
+            .app_state
+            .permission_actor
+            .ask(CheckPermission {
+                subject: Subject::user(&stale_viewer.user_jid),
+                permission: Permission::Read,
+                object: Object::new(ObjectType::Channel, "projected"),
+            })
+            .await
+            .expect("permission actor")
+            .allowed,
+        "join must not restore the stale alpha parent tuple"
+    );
+    assert!(
+        state
+            .deps
+            .app_state
+            .permission_actor
+            .ask(CheckPermission {
+                subject: Subject::user(&current_viewer.user_jid),
+                permission: Permission::Read,
+                object: Object::new(ObjectType::Channel, "projected"),
+            })
+            .await
+            .expect("permission actor")
+            .allowed,
+        "join should repair only the projected beta parent tuple"
     );
 }
 


### PR DESCRIPTION
# Summary

- Restore channel joins by filtering MUC join errors to the requested nick on the chat client.
- Repair missing managed-channel Space parent tuples from valid XEP-0402 Space bookmarks before denying a join.
- Keep inherited Space read access as open-room admission only; it no longer becomes persistent MUC member affiliation or satisfies members-only rooms.
- Clean up stale Space bookmark permission tuples when bookmarks are removed or direct retract cleanup fails.

# Plan

1. Review XEP-0045 and XEP-0402 behavior around MUC join presence, bookmark payloads, and error routing.
2. Patch the chat join waiter so unrelated room errors do not reject the active join.
3. Patch server MUC admission to repair missing Space parent tuples from typed bookmark state, while preserving members-only affiliation rules.
4. Add focused client and server regression coverage.
5. Run local validation, push, and monitor CI until green.

# Validation

- chat: bun test tests/client-send-readiness.test.ts
- chat: bun run lint
- server: cargo fmt --check
- server: cargo test -p waddle-server managed_members_only_join_requires_explicit_channel_member_affiliation
- server: cargo test -p waddle-server managed_space_bookmark_join_repairs
- server: cargo test -p waddle-server --lib
- server: cargo clippy -p waddle-server --all-targets -- -D warnings
- root: bun test
