### PR TITLE
fix(server): allow members to publish story media

### DIFF
--- a/server/crates/waddle-server/src/admin/mod.rs
+++ b/server/crates/waddle-server/src/admin/mod.rs
@@ -323,6 +323,16 @@ mod tests {
             ) -> Result<PublishResult, XmppError> {
                 boom("publish_item")
             }
+            async fn publish_item_if_missing_or_publisher(
+                &self,
+                _owner: &BareJid,
+                _node_name: &str,
+                _item: &PubSubItem,
+                _publisher: &BareJid,
+                _auto_create: bool,
+            ) -> Result<PublishResult, XmppError> {
+                boom("publish_item_if_missing_or_publisher")
+            }
             async fn get_items(
                 &self,
                 _owner: &BareJid,

--- a/server/crates/waddle-server/src/pubsub.rs
+++ b/server/crates/waddle-server/src/pubsub.rs
@@ -57,6 +57,24 @@ impl PubSubStorage for DatabasePubSubStorage {
             .await
     }
 
+    async fn publish_item_if_missing_or_publisher(
+        &self,
+        owner: &BareJid,
+        node_name: &str,
+        item: &PubSubItem,
+        publisher: &BareJid,
+        auto_create: bool,
+    ) -> Result<waddle_xmpp::pubsub::PublishResult, XmppError> {
+        self.publish_item_if_missing_or_publisher_impl(
+            owner,
+            node_name,
+            item,
+            publisher,
+            auto_create,
+        )
+        .await
+    }
+
     async fn get_items(
         &self,
         owner: &BareJid,

--- a/server/crates/waddle-server/src/pubsub/item.rs
+++ b/server/crates/waddle-server/src/pubsub/item.rs
@@ -21,6 +21,31 @@ impl DatabasePubSubStorage {
         publisher: Option<&BareJid>,
         auto_create: bool,
     ) -> Result<PublishResult, XmppError> {
+        self.publish_item_internal(owner, node_name, item, publisher, auto_create, false)
+            .await
+    }
+
+    pub(super) async fn publish_item_if_missing_or_publisher_impl(
+        &self,
+        owner: &BareJid,
+        node_name: &str,
+        item: &PubSubItem,
+        publisher: &BareJid,
+        auto_create: bool,
+    ) -> Result<PublishResult, XmppError> {
+        self.publish_item_internal(owner, node_name, item, Some(publisher), auto_create, true)
+            .await
+    }
+
+    async fn publish_item_internal(
+        &self,
+        owner: &BareJid,
+        node_name: &str,
+        item: &PubSubItem,
+        publisher: Option<&BareJid>,
+        auto_create: bool,
+        require_same_publisher: bool,
+    ) -> Result<PublishResult, XmppError> {
         let item_id = item
             .id
             .clone()
@@ -188,29 +213,61 @@ impl DatabasePubSubStorage {
             .await
             .map_err(|error| XmppError::internal(error.to_string()))?;
 
-        tx.execute(
-            r#"
-            INSERT INTO pubsub_items (
-                owner_jid, node_name, item_id, payload_xml, publisher_jid, published_at_ms
+        let rows_affected = if require_same_publisher {
+            tx.execute(
+                r#"
+                INSERT INTO pubsub_items (
+                    owner_jid, node_name, item_id, payload_xml, publisher_jid, published_at_ms
+                )
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(owner_jid, node_name, item_id) DO UPDATE SET
+                    seq = excluded.seq,
+                    payload_xml = excluded.payload_xml,
+                    publisher_jid = excluded.publisher_jid,
+                    published_at_ms = excluded.published_at_ms
+                WHERE pubsub_items.publisher_jid = excluded.publisher_jid
+                "#,
+                crate::db_params![
+                    owner.to_string(),
+                    node_name,
+                    item_id.clone(),
+                    payload_xml,
+                    publisher_jid,
+                    published_at_ms,
+                ],
             )
-            VALUES (?, ?, ?, ?, ?, ?)
-            ON CONFLICT(owner_jid, node_name, item_id) DO UPDATE SET
-                seq = excluded.seq,
-                payload_xml = excluded.payload_xml,
-                publisher_jid = excluded.publisher_jid,
-                published_at_ms = excluded.published_at_ms
-            "#,
-            crate::db_params![
-                owner.to_string(),
-                node_name,
-                item_id.clone(),
-                payload_xml,
-                publisher_jid,
-                published_at_ms,
-            ],
-        )
-        .await
-        .map_err(|error| XmppError::internal(error.to_string()))?;
+            .await
+            .map_err(|error| XmppError::internal(error.to_string()))?
+        } else {
+            tx.execute(
+                r#"
+                INSERT INTO pubsub_items (
+                    owner_jid, node_name, item_id, payload_xml, publisher_jid, published_at_ms
+                )
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(owner_jid, node_name, item_id) DO UPDATE SET
+                    seq = excluded.seq,
+                    payload_xml = excluded.payload_xml,
+                    publisher_jid = excluded.publisher_jid,
+                    published_at_ms = excluded.published_at_ms
+                "#,
+                crate::db_params![
+                    owner.to_string(),
+                    node_name,
+                    item_id.clone(),
+                    payload_xml,
+                    publisher_jid,
+                    published_at_ms,
+                ],
+            )
+            .await
+            .map_err(|error| XmppError::internal(error.to_string()))?
+        };
+        if rows_affected == 0 {
+            return Err(XmppError::forbidden(Some(
+                "PubSub item belongs to a different publisher".to_string(),
+            )));
+        }
         let evicted_item_ids = self
             .enforce_max_items_tx(&mut tx, owner, node_name, node.config.max_items)
             .await?;

--- a/server/crates/waddle-server/src/pubsub/tests.rs
+++ b/server/crates/waddle-server/src/pubsub/tests.rs
@@ -18,6 +18,12 @@ fn dnd_payload() -> minidom::Element {
         .expect("valid dnd payload")
 }
 
+fn story_payload(body: &str) -> minidom::Element {
+    format!("<story xmlns='urn:xmpp:stories:0'><body>{body}</body></story>")
+        .parse()
+        .expect("valid story payload")
+}
+
 #[tokio::test]
 async fn database_pubsub_storage_persists_file_backing() {
     let artifacts = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target/test-artifacts");
@@ -98,6 +104,74 @@ async fn spaces_config_keeps_multiple_items() {
         .await
         .expect("items");
     assert_eq!(items.len(), 2);
+}
+
+#[tokio::test]
+async fn publish_item_if_missing_or_publisher_rejects_different_publisher() {
+    let storage = DatabasePubSubStorage::open(Some("sqlite::memory:"))
+        .await
+        .expect("storage");
+    let owner = jid("community.example.com");
+    let alice = jid("alice@example.com");
+    let bob = jid("bob@example.com");
+    storage
+        .get_or_create_node(&owner, "stories")
+        .await
+        .expect("node");
+
+    let alice_item = PubSubItem {
+        id: Some("story-1".to_string()),
+        publisher: None,
+        payload: Some(story_payload("first")),
+    };
+    storage
+        .publish_item_if_missing_or_publisher(&owner, "stories", &alice_item, &alice, false)
+        .await
+        .expect("alice publish");
+
+    let alice_update = PubSubItem {
+        id: Some("story-1".to_string()),
+        publisher: None,
+        payload: Some(story_payload("updated")),
+    };
+    storage
+        .publish_item_if_missing_or_publisher(&owner, "stories", &alice_update, &alice, false)
+        .await
+        .expect("same publisher update");
+
+    let bob_update = PubSubItem {
+        id: Some("story-1".to_string()),
+        publisher: None,
+        payload: Some(story_payload("clobber")),
+    };
+    let error = storage
+        .publish_item_if_missing_or_publisher(&owner, "stories", &bob_update, &bob, false)
+        .await
+        .expect_err("different publisher must be rejected");
+    assert!(
+        matches!(
+            error,
+            waddle_xmpp::XmppError::Stanza {
+                condition: waddle_xmpp::StanzaErrorCondition::Forbidden,
+                ..
+            }
+        ),
+        "unexpected error for cross-publisher clobber: {error:?}"
+    );
+
+    let items = storage
+        .get_items(&owner, "stories", None, &["story-1".to_string()])
+        .await
+        .expect("items");
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].publisher.as_ref(), Some(&alice));
+    assert!(
+        items[0]
+            .payload_xml
+            .as_deref()
+            .is_some_and(|payload| payload.contains("updated")),
+        "cross-publisher publish must not replace existing payload: {items:?}"
+    );
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
@@ -932,8 +932,8 @@ pub(super) async fn handle_spaces_publish(
 /// `urn:xmpp:pubsub-social-feed:0` or XEP-0501 stories at
 /// `urn:xmpp:stories:0`. Both live on `community.<domain>` (distinct
 /// from the spaces service so the spaces enumeration only returns
-/// real spaces). The social feed is member-postable (gated by its
-/// pubsub publish-model); stories and calendar events keep the
+/// real spaces). Feed and stories are member-postable (gated by each
+/// node's pubsub publish-model); calendar event creation keeps the
 /// owner-only spaces gate. The standard pubsub fan-out runs either
 /// way so subscribers see new posts in real time.
 pub(super) async fn handle_community_publish(
@@ -1587,17 +1587,57 @@ pub(super) async fn handle_community_retract(
     {
         return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::NodeNotFound))];
     }
-    match spaces_node_mutation_allowed(state, session, node).await {
-        Ok(true) => {}
-        Ok(false) => return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))],
-        Err(error) => {
-            warn!(node, error = %error, "Failed to authorize community retract");
-            return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))];
-        }
-    }
     let Ok(community_jid) = community_domain.parse::<BareJid>() else {
         return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::InvalidJid))];
     };
+    if node == waddle_xmpp_core::xep0472::PUBSUB_NODE_FEED
+        || node == waddle_xmpp_core::xep0501::PUBSUB_NODE_STORIES
+    {
+        match spaces_node_mutation_allowed(state, session, node).await {
+            Ok(true) => {}
+            Ok(false) => match community_member_publisher(state, session, &community_jid, node)
+                .await
+            {
+                Ok(Some(entity)) => {
+                    if let Some(error) =
+                        community_item_retract_error(state, &community_jid, node, item_id, &entity)
+                            .await
+                    {
+                        return vec![iq_to_xml(build_pubsub_error(iq, error))];
+                    }
+                }
+                Ok(None) => {
+                    return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))];
+                }
+                Err(error) => {
+                    warn!(node, error = %error, "Failed to authorize community member retract");
+                    return vec![iq_to_xml(build_pubsub_error(
+                        iq,
+                        PubSubError::InternalServerError,
+                    ))];
+                }
+            },
+            Err(error) => {
+                warn!(node, error = %error, "Failed to authorize community owner retract");
+                return vec![iq_to_xml(build_pubsub_error(
+                    iq,
+                    PubSubError::InternalServerError,
+                ))];
+            }
+        }
+    } else {
+        match spaces_node_mutation_allowed(state, session, node).await {
+            Ok(true) => {}
+            Ok(false) => return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))],
+            Err(error) => {
+                warn!(node, error = %error, "Failed to authorize community retract");
+                return vec![iq_to_xml(build_pubsub_error(
+                    iq,
+                    PubSubError::InternalServerError,
+                ))];
+            }
+        }
+    }
     match state
         .deps
         .protocol
@@ -1729,20 +1769,17 @@ async fn handle_story_attachment_retract(
     }
 }
 
-/// The authenticated publisher permitted to post to the XEP-0472
-/// social feed node, or `None` if the request is not authorized.
+/// The authenticated publisher permitted to post to an open community
+/// node, or `None` if the request is not authorized.
 ///
-/// The feed is member-postable: any authenticated member may post
-/// (the node's `publish_model` is Open). This honors the node's
+/// Feed and stories are member-postable: any authenticated member may
+/// post when the node's `publish_model` is Open. This honors the node's
 /// configured pubsub publish-model via `can_publish` rather than the
 /// owner-only Spaces structural gate, while still requiring an
-/// authenticated session and rejecting outcasts (XEP-0472
-/// §"Replying to a Post"; XEP-0060 §7.1.3). The returned JID is the
-/// server-side session principal — the value the service stamps as the
-/// item publisher (XEP-0060 §7.1.2.1: the publisher MUST be generated
-/// by the service, never taken from the client's item, to prevent
-/// spoofing).
-async fn community_feed_publisher(
+/// authenticated session and rejecting outcasts. The returned JID is
+/// the server-side session principal — the value the service stamps as
+/// the item publisher (XEP-0060 §7.1.2.1).
+async fn community_member_publisher(
     state: &WebSocketState,
     session: Option<&Session>,
     community_jid: &BareJid,
@@ -1751,10 +1788,9 @@ async fn community_feed_publisher(
     let Some(session) = session else {
         return Ok(None);
     };
-    let entity = session
-        .user_jid
-        .parse::<BareJid>()
-        .map_err(|error| format!("invalid session JID for feed publish: {error}"))?;
+    let user_domain = state.deps.auth_state.xmpp_domain.as_str();
+    let entity = session_bare_jid(session, user_domain)
+        .map_err(|_| "invalid session JID for community publish".to_string())?;
     let allowed = crate::pubsub_authz::can_publish(
         &state.deps.protocol.pubsub_storage,
         community_jid,
@@ -1763,24 +1799,20 @@ async fn community_feed_publisher(
         false,
     )
     .await
-    .map_err(|error| format!("can_publish failed for feed node: {error}"))?;
+    .map_err(|error| format!("can_publish failed for community node: {error}"))?;
     Ok(allowed.then_some(entity))
 }
 
-/// Refuse to let `entity` overwrite a social-feed item already published
-/// by a different member. The feed is one shared, open-publish node with
-/// client-chosen item ids, so without this a member could reuse another
-/// member's item id and clobber their post. Returns the stanza error to
-/// send, or `None` when the publish may proceed (a new id, or the
-/// existing item belongs to `entity`).
-async fn feed_item_ownership_error(
+/// Refuse to let `entity` retract an open community item published by a
+/// different member. Feed and story nodes are member-postable, but item
+/// deletion remains owner-admin or original-publisher only.
+async fn community_item_retract_error(
     state: &WebSocketState,
     community_jid: &BareJid,
     node: &str,
-    item: &PubSubItem,
+    item_id: &str,
     entity: &BareJid,
 ) -> Option<PubSubError> {
-    let item_id = item.id.as_deref()?;
     match state
         .deps
         .protocol
@@ -1792,10 +1824,11 @@ async fn feed_item_ownership_error(
             Some(existing_item) if existing_item.publisher.as_ref() != Some(entity) => {
                 Some(PubSubError::Forbidden)
             }
+            None => Some(PubSubError::ItemNotFound),
             _ => None,
         },
         Err(error) => {
-            warn!(node, item_id, error = %error, "Failed to check feed item ownership");
+            warn!(node, item_id, error = %error, "Failed to check community item retract ownership");
             Some(PubSubError::InternalServerError)
         }
     }
@@ -1803,11 +1836,11 @@ async fn feed_item_ownership_error(
 
 /// Publish a non-bookmark item to a community pubsub node. Used by
 /// `handle_community_publish` (feed + stories + calendar events on
-/// `community.<domain>`). The XEP-0472 social feed is member-postable
-/// (gated by the node's pubsub publish-model via
-/// `community_feed_publisher`) and the item is stamped with the
-/// server-derived publisher; stories and calendar events keep the
-/// owner-only Spaces gate. Either way the standard pubsub fan-out runs
+/// `community.<domain>`). Feed and stories are member-postable (gated
+/// by the node's pubsub publish-model via `community_member_publisher`)
+/// and the item is stamped with the server-derived publisher; calendar
+/// events keep the owner-only Spaces gate except for validated RSVP
+/// items handled earlier. Either way the standard pubsub fan-out runs
 /// so subscribers see new posts in real time.
 async fn handle_community_non_bookmark_publish(
     iq: &xmpp_parsers::iq::Iq,
@@ -1838,16 +1871,18 @@ async fn handle_community_non_bookmark_publish(
             return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::NodeNotFound))];
         }
     }
-    // The feed is member-postable and the service stamps the authenticated
-    // publisher on each item; stories/events stay owner-only and carry no
-    // publisher attribution (publisher == node owner). A storage/permission
-    // backend failure is an internal error, not an authorization denial.
-    let publisher = if node == waddle_xmpp_core::xep0472::PUBSUB_NODE_FEED {
-        match community_feed_publisher(state, session, &community_jid, node).await {
+    // Feed and stories are member-postable and the service stamps the
+    // authenticated publisher on each item. Calendar events stay owner-only
+    // and carry no publisher attribution here. A storage/permission backend
+    // failure is an internal error, not an authorization denial.
+    let publisher = if node == waddle_xmpp_core::xep0472::PUBSUB_NODE_FEED
+        || node == waddle_xmpp_core::xep0501::PUBSUB_NODE_STORIES
+    {
+        match community_member_publisher(state, session, &community_jid, node).await {
             Ok(Some(entity)) => Some(entity),
             Ok(None) => return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))],
             Err(error) => {
-                warn!(node, error = %error, "Failed to authorize community feed publish");
+                warn!(node, error = %error, "Failed to authorize community member publish");
                 return vec![iq_to_xml(build_pubsub_error(
                     iq,
                     PubSubError::InternalServerError,
@@ -1868,17 +1903,32 @@ async fn handle_community_non_bookmark_publish(
         }
     };
 
-    // The social feed is a single shared, open-publish node, so the
-    // service binds each item to its author: refuse to overwrite an item
-    // published by a different member (no clobbering posts via id reuse)
-    // and stamp the authenticated JID into the payload `<author>` so a
-    // member cannot impersonate another through the displayed author.
-    // `publisher` is `Some` only for the feed; stories/events skip this.
+    // Feed and stories are shared, open-publish nodes, so the service binds
+    // each item to its author: stamp the authenticated JID into payload
+    // `<author>` fields so a member cannot impersonate another. The storage
+    // write below atomically refuses cross-publisher item-id clobbering.
+    // `publisher` is `Some` only for open member-postable community nodes.
     if let Some(entity) = publisher.as_ref() {
-        if let Some(error) =
-            feed_item_ownership_error(state, &community_jid, node, &item, entity).await
-        {
-            return vec![iq_to_xml(build_pubsub_error(iq, error))];
+        if node == waddle_xmpp_core::xep0501::PUBSUB_NODE_STORIES {
+            let Some(payload) = item.payload.as_ref() else {
+                return vec![iq_to_xml(build_pubsub_error(
+                    iq,
+                    PubSubError::PayloadRequired,
+                ))];
+            };
+            let item_id = item.id.as_deref().unwrap_or_default();
+            let Some(story) = waddle_xmpp_core::xep0501::parse_story(item_id, payload) else {
+                return vec![iq_to_xml(build_pubsub_error(
+                    iq,
+                    PubSubError::InvalidPayload,
+                ))];
+            };
+            if story.body.is_none() && story.media_url.is_none() {
+                return vec![iq_to_xml(build_pubsub_error(
+                    iq,
+                    PubSubError::InvalidPayload,
+                ))];
+            }
         }
         if let Some(payload) = item.payload.as_ref() {
             if waddle_xmpp_core::xep0472::is_feed_entry(payload) {
@@ -1886,17 +1936,33 @@ async fn handle_community_non_bookmark_publish(
                     payload,
                     &entity.to_string(),
                 ));
+            } else if waddle_xmpp_core::xep0501::is_story_element(payload) {
+                let item_id = item.id.as_deref().unwrap_or_default();
+                item.payload = waddle_xmpp_core::xep0501::stamp_story_author(
+                    item_id,
+                    payload,
+                    &entity.to_string(),
+                );
             }
         }
     }
 
-    match state
-        .deps
-        .protocol
-        .pubsub_storage
-        .publish_item(&community_jid, node, &item, publisher.as_ref(), false)
-        .await
-    {
+    let publish_result = if let Some(entity) = publisher.as_ref() {
+        state
+            .deps
+            .protocol
+            .pubsub_storage
+            .publish_item_if_missing_or_publisher(&community_jid, node, &item, entity, false)
+            .await
+    } else {
+        state
+            .deps
+            .protocol
+            .pubsub_storage
+            .publish_item(&community_jid, node, &item, None, false)
+            .await
+    };
+    match publish_result {
         Ok(result) => {
             if node == waddle_xmpp_core::xep0501::PUBSUB_NODE_STORIES {
                 if let Err(error) =
@@ -1932,9 +1998,30 @@ async fn handle_community_non_bookmark_publish(
             warn!(node, error = %error, "Failed to publish community item");
             vec![iq_to_xml(build_pubsub_error(
                 iq,
-                PubSubError::InternalServerError,
+                community_publish_error_from_xmpp(&error),
             ))]
         }
+    }
+}
+
+fn community_publish_error_from_xmpp(error: &waddle_xmpp::XmppError) -> PubSubError {
+    match error {
+        waddle_xmpp::XmppError::PubSubPayloadRequired(_) => PubSubError::PayloadRequired,
+        waddle_xmpp::XmppError::PubSubInvalidPayload(_) => PubSubError::InvalidPayload,
+        waddle_xmpp::XmppError::Stanza {
+            condition: waddle_xmpp::StanzaErrorCondition::Forbidden,
+            ..
+        }
+        | waddle_xmpp::XmppError::PermissionDenied(_) => PubSubError::Forbidden,
+        waddle_xmpp::XmppError::Stanza {
+            condition: waddle_xmpp::StanzaErrorCondition::ItemNotFound,
+            ..
+        } => PubSubError::NodeNotFound,
+        waddle_xmpp::XmppError::Stanza {
+            condition: waddle_xmpp::StanzaErrorCondition::BadRequest,
+            ..
+        } => PubSubError::BadRequest,
+        _ => PubSubError::InternalServerError,
     }
 }
 

--- a/server/crates/waddle-server/src/server/topology.rs
+++ b/server/crates/waddle-server/src/server/topology.rs
@@ -134,8 +134,8 @@ async fn seed_initial_xmpp_topology(
     // announcements and microblog-style posts. Access model is
     // `community_feed()`: anyone can subscribe and read, and any
     // authenticated member may publish (`publish_model: Open`), per
-    // XEP-0472 §"Replying to a Post". Stories and calendar nodes below
-    // deliberately keep `spaces_public()` (owner-only publish).
+    // XEP-0472 §"Replying to a Post". Stories use the same member-postable
+    // access shape below; calendar keeps `spaces_public()` plus an RSVP carve-out.
     pubsub_storage
         .get_or_create_node(&community_jid, waddle_xmpp_core::xep0472::PUBSUB_NODE_FEED)
         .await
@@ -149,13 +149,11 @@ async fn seed_initial_xmpp_topology(
         .await
         .map_err(|error| anyhow::anyhow!("failed to configure social feed node: {error}"))?;
 
-    // XEP-0501 Stories — community-wide ephemeral pubsub node. Same
-    // hosting + access model as the social feed; stories carry an
-    // `expires` timestamp and the chat client filters expired items
-    // out of the view. (Server-side eviction of expired items is a
-    // future cleanup job; the items API and pubsub semantics work
-    // unmodified — the `expires` attribute is application-level
-    // metadata.)
+    // XEP-0501 Stories — community-wide ephemeral pubsub node. Any
+    // authenticated, non-outcast member may publish; the service stamps
+    // the authenticated author into the payload before storing it.
+    // Stories carry an `expires` timestamp and the chat client filters
+    // expired items out of the view.
     pubsub_storage
         .get_or_create_node(
             &community_jid,
@@ -167,15 +165,15 @@ async fn seed_initial_xmpp_topology(
         .update_node_config(
             &community_jid,
             waddle_xmpp_core::xep0501::PUBSUB_NODE_STORIES,
-            &NodeConfig::spaces_public(),
+            &NodeConfig::community_stories(),
         )
         .await
         .map_err(|error| anyhow::anyhow!("failed to configure stories node: {error}"))?;
 
     // xCal Proto-calendar events — community-wide PubSub node for
-    // events with optional RSVP tracking. Same hosting + access
-    // model as the social feed; events carry their own scheduling
-    // metadata in the typed `<vcalendar/>` payload.
+    // events with optional RSVP tracking. Calendar event creation stays
+    // owner-only; per-attendee RSVP items have a separate authenticated
+    // member carve-out in the IQ handler.
     pubsub_storage
         .get_or_create_node(&community_jid, waddle_xmpp_core::xcal::PUBSUB_NODE_EVENTS)
         .await

--- a/server/crates/waddle-server/tests/xep0470_story_reactions_ws.rs
+++ b/server/crates/waddle-server/tests/xep0470_story_reactions_ws.rs
@@ -1,8 +1,8 @@
 //! XEP-0470 Pubsub Attachments on XEP-0501 stories.
 //!
-//! Verifies the pull-based story reaction spine: story publishes remain
-//! owner-gated, while a non-owner member can publish/retract their own
-//! `<attachments/>` item under the story attachment node.
+//! Verifies the pull-based story reaction spine: stories and story
+//! reaction attachments are member-postable, while attachment items remain
+//! self-owned.
 
 mod ws_common;
 
@@ -156,8 +156,8 @@ async fn member_can_publish_read_and_retract_story_reaction_attachment() {
               <publish node="{STORIES_NODE}">
                 <item id="member-{story_id}">
                   <story xmlns="{NS_STORIES}" expires="2030-01-01T12:00:00Z">
-                    <body>must not publish</body>
-                    <author>alice@localhost</author>
+                    <body>member story</body>
+                    <author>spoofed@localhost</author>
                   </story>
                 </item>
               </publish>
@@ -166,8 +166,8 @@ async fn member_can_publish_read_and_retract_story_reaction_attachment() {
     )
     .await;
     assert!(
-        member_story.contains("type='error'") && member_story.contains("forbidden"),
-        "non-owner story publish must remain forbidden: {member_story}"
+        member_story.contains("type='result'"),
+        "member story publish should now succeed: {member_story}"
     );
 
     let attachment_node = story_attachment_node(&story_id);

--- a/server/crates/waddle-server/tests/xep0501_stories_ws.rs
+++ b/server/crates/waddle-server/tests/xep0501_stories_ws.rs
@@ -14,6 +14,8 @@ const DOMAIN: &str = "localhost";
 const USERNAME: &str = "admin";
 const MEMBER_USERNAME: &str = "member";
 const MEMBER_PASSWORD: &str = "xep0501-member-password";
+const OTHER_MEMBER_USERNAME: &str = "other";
+const OTHER_MEMBER_PASSWORD: &str = "xep0501-other-password";
 const COMMUNITY_JID: &str = "community.localhost";
 const STORIES_NODE: &str = "urn:xmpp:stories:0";
 const NS_STORIES: &str = "urn:xmpp:stories:0";
@@ -53,6 +55,202 @@ async fn community_disco_info_advertises_stories_namespace() {
     );
 
     let _ = client.close().await;
+}
+
+#[tokio::test]
+async fn member_story_publish_requires_story_payload() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server = TestServer::start_with_extra_accounts(&[(MEMBER_USERNAME, MEMBER_PASSWORD)]);
+    let resource = format!("xep0501-member-invalid-{}", uuid::Uuid::new_v4());
+    let mut client = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        MEMBER_USERNAME,
+        MEMBER_PASSWORD,
+        &resource,
+    )
+    .await
+    .expect("connect and auth as member");
+
+    client
+        .send(&format!(
+            r#"<iq type="set" id="member-story-missing-payload" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <publish node="{STORIES_NODE}"><item id="missing-payload"/></publish>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send missing payload publish");
+    let missing_payload = client
+        .recv_matching(|frame| frame.contains("member-story-missing-payload"))
+        .await
+        .expect("missing payload response");
+    assert!(
+        missing_payload.contains("type='error'") && missing_payload.contains("payload-required"),
+        "story publish without <story/> must be payload-required: {missing_payload}"
+    );
+
+    client
+        .send(&format!(
+            r#"<iq type="set" id="member-story-invalid-payload" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <publish node="{STORIES_NODE}">
+                  <item id="invalid-payload">
+                    <entry xmlns="urn:xmpp:pubsub-social-feed:0"><content>not a story</content></entry>
+                  </item>
+                </publish>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send invalid payload publish");
+    let invalid_payload = client
+        .recv_matching(|frame| frame.contains("member-story-invalid-payload"))
+        .await
+        .expect("invalid payload response");
+    assert!(
+        invalid_payload.contains("type='error'") && invalid_payload.contains("invalid-payload"),
+        "story publish with non-story payload must be invalid-payload: {invalid_payload}"
+    );
+
+    client
+        .send(&format!(
+            r#"<iq type="set" id="member-story-empty-payload" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <publish node="{STORIES_NODE}">
+                  <item id="empty-story">
+                    <story xmlns="{NS_STORIES}" expires="2030-01-01T12:00:00Z"/>
+                  </item>
+                </publish>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send empty story publish");
+    let empty_payload = client
+        .recv_matching(|frame| frame.contains("member-story-empty-payload"))
+        .await
+        .expect("empty story response");
+    assert!(
+        empty_payload.contains("type='error'") && empty_payload.contains("invalid-payload"),
+        "story publish with no body or media-url must be invalid-payload: {empty_payload}"
+    );
+
+    let _ = client.close().await;
+}
+
+#[tokio::test]
+async fn member_can_retract_own_story_but_not_another_member_story() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server = TestServer::start_with_extra_accounts(&[
+        (MEMBER_USERNAME, MEMBER_PASSWORD),
+        (OTHER_MEMBER_USERNAME, OTHER_MEMBER_PASSWORD),
+    ]);
+    let mut member = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        MEMBER_USERNAME,
+        MEMBER_PASSWORD,
+        &format!("xep0501-member-retract-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("connect and auth as member");
+    let mut other = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        OTHER_MEMBER_USERNAME,
+        OTHER_MEMBER_PASSWORD,
+        &format!("xep0501-other-retract-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("connect and auth as other member");
+
+    let story_id = format!("story-{}", uuid::Uuid::new_v4());
+    member
+        .send(&format!(
+            r#"<iq type="set" id="member-story-for-retract" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <publish node="{STORIES_NODE}">
+                  <item id="{story_id}">
+                    <story xmlns="{NS_STORIES}" expires="2030-01-01T12:00:00Z">
+                      <body>member-owned story</body>
+                    </story>
+                  </item>
+                </publish>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send publish");
+    let publish_result = member
+        .recv_matching(|frame| frame.contains("member-story-for-retract"))
+        .await
+        .expect("publish result");
+    assert!(
+        publish_result.contains("type='result'"),
+        "member story publish must succeed before retract: {publish_result}"
+    );
+
+    other
+        .send(&format!(
+            r#"<iq type="set" id="other-member-story-retract" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <retract node="{STORIES_NODE}"><item id="{story_id}"/></retract>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send other member retract");
+    let other_retract = other
+        .recv_matching(|frame| frame.contains("other-member-story-retract"))
+        .await
+        .expect("other retract response");
+    assert!(
+        other_retract.contains("type='error'") && other_retract.contains("forbidden"),
+        "another member must not retract a member-owned story: {other_retract}"
+    );
+
+    member
+        .send(&format!(
+            r#"<iq type="set" id="own-member-story-retract" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <retract node="{STORIES_NODE}"><item id="{story_id}"/></retract>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send own retract");
+    let own_retract = member
+        .recv_matching(|frame| frame.contains("own-member-story-retract"))
+        .await
+        .expect("own retract response");
+    assert!(
+        own_retract.contains("type='result'"),
+        "member should retract own story: {own_retract}"
+    );
+
+    member
+        .send(&format!(
+            r#"<iq type="get" id="own-member-story-after-retract" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <items node="{STORIES_NODE}"><item id="{story_id}"/></items>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send items query");
+    let after_retract = member
+        .recv_matching(|frame| frame.contains("own-member-story-after-retract"))
+        .await
+        .expect("items response after retract");
+    assert!(
+        after_retract.contains("type='result'") && !after_retract.contains(&story_id),
+        "retracted member story should not be returned: {after_retract}"
+    );
+
+    let _ = member.close().await;
+    let _ = other.close().await;
 }
 
 #[tokio::test]
@@ -127,10 +325,10 @@ async fn stories_publish_and_items_round_trip() {
 }
 
 #[tokio::test]
-async fn member_cannot_publish_to_stories() {
-    // Stories remain owner-only. Opening the social feed to member
-    // writes must NOT open stories: a non-owner member publishing a
-    // story must still be rejected with a `forbidden` auth error.
+async fn member_can_publish_story_media() {
+    // Stories are community-broadcast content. A non-owner authenticated
+    // member may publish media, and the service stamps the author from
+    // the authenticated session rather than trusting the payload.
     let _guard = TEST_SERIAL.lock().await;
     let server = TestServer::start_with_extra_accounts(&[(MEMBER_USERNAME, MEMBER_PASSWORD)]);
     let resource = format!("xep0501-member-{}", uuid::Uuid::new_v4());
@@ -152,8 +350,9 @@ async fn member_cannot_publish_to_stories() {
                 <publish node="{STORIES_NODE}">
                   <item id="{story_id}">
                     <story xmlns="{NS_STORIES}" expires="2030-01-01T12:00:00Z">
-                      <body>Should be rejected</body>
-                      <author>{MEMBER_USERNAME}@{DOMAIN}</author>
+                      <body>From the new office</body>
+                      <media-url>https://example.com/member-photo.jpg</media-url>
+                      <author>spoofed@localhost</author>
                     </story>
                   </item>
                 </publish>
@@ -167,8 +366,39 @@ async fn member_cannot_publish_to_stories() {
         .await
         .expect("publish result");
     assert!(
-        publish_result.contains("type='error'") && publish_result.contains("forbidden"),
-        "stories must stay owner-only — a member publish must be forbidden: {publish_result}"
+        publish_result.contains("type='result'"),
+        "member story media publish must succeed: {publish_result}"
+    );
+
+    client
+        .send(&format!(
+            r#"<iq type="get" id="member-story-items" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <items node="{STORIES_NODE}"><item id="{story_id}"/></items>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send items query");
+    let items_response = client
+        .recv_matching(|frame| frame.contains("member-story-items") && frame.contains("<story"))
+        .await
+        .expect("items response");
+    assert!(
+        items_response.contains("From the new office"),
+        "items query lost body: {items_response}"
+    );
+    assert!(
+        items_response.contains("https://example.com/member-photo.jpg"),
+        "items query lost media-url: {items_response}"
+    );
+    assert!(
+        items_response.contains(&format!("{MEMBER_USERNAME}@{DOMAIN}")),
+        "server did not stamp member author: {items_response}"
+    );
+    assert!(
+        !items_response.contains("spoofed@localhost"),
+        "server trusted spoofed story author: {items_response}"
     );
 
     let _ = client.close().await;

--- a/server/crates/waddle-xmpp-core/src/pubsub/node.rs
+++ b/server/crates/waddle-xmpp-core/src/pubsub/node.rs
@@ -228,6 +228,25 @@ impl NodeConfig {
         }
     }
 
+    /// Configuration for the XEP-0501 community stories node.
+    ///
+    /// Stories are community-broadcast content, like the social feed:
+    /// any authenticated, non-outcast member may publish. The server
+    /// still stamps the authenticated publisher into the story payload
+    /// before storing it.
+    pub fn community_stories() -> Self {
+        Self {
+            access_model: AccessModel::Open,
+            publish_model: PublishModel::Open,
+            max_items: u32::MAX,
+            persist_items: true,
+            deliver_payloads: true,
+            notify_retract: true,
+            notify_delete: true,
+            send_last_published_item: SendLastPublishedItem::OnSub,
+        }
+    }
+
     /// XEP-0503 configuration for a private Space node.
     pub fn spaces_private() -> Self {
         Self {

--- a/server/crates/waddle-xmpp-core/src/xep0501.rs
+++ b/server/crates/waddle-xmpp-core/src/xep0501.rs
@@ -184,6 +184,27 @@ pub fn build_story_element(story: &Story) -> Element {
     elem
 }
 
+/// Stamp a story payload with the authenticated publisher as author.
+pub fn stamp_story_author(item_id: &str, elem: &Element, author: &str) -> Option<Element> {
+    parse_story(item_id, elem)?;
+
+    let mut stamped = elem.clone();
+    let author_children: Vec<(String, String)> = stamped
+        .children()
+        .filter(|child| child.name() == "author" && child.ns() == NS_STORIES)
+        .map(|child| (child.name().to_owned(), child.ns()))
+        .collect();
+    for (name, ns) in author_children {
+        stamped.remove_child(&name, ns.as_str());
+    }
+
+    let mut child = Element::builder("author", NS_STORIES).build();
+    child.append_text_node(author);
+    stamped.append_child(child);
+
+    Some(stamped)
+}
+
 /// Filter a list of stories to only active (non-expired) ones.
 pub fn filter_active(stories: &[Story]) -> Vec<&Story> {
     stories.iter().filter(|s| s.is_active()).collect()
@@ -236,6 +257,46 @@ mod tests {
         );
         assert_eq!(parsed.author.as_deref(), Some("alice@example.com"));
         assert_eq!(parsed.expires, Some(future_time()));
+    }
+
+    #[test]
+    fn test_stamp_story_author_replaces_payload_author() {
+        let story = Story::new("s-1")
+            .with_body("Hello!")
+            .with_media("https://example.com/photo.jpg")
+            .with_author("spoof@example.com")
+            .with_expires_at(future_time());
+        let elem = build_story_element(&story);
+
+        let stamped = stamp_story_author("s-1", &elem, "alice@example.com").expect("story");
+        let parsed = parse_story("s-1", &stamped).expect("parseable");
+
+        assert_eq!(parsed.author.as_deref(), Some("alice@example.com"));
+        assert_eq!(parsed.body.as_deref(), Some("Hello!"));
+        assert_eq!(
+            parsed.media_url.as_deref(),
+            Some("https://example.com/photo.jpg")
+        );
+        assert_eq!(parsed.expires, story.expires);
+    }
+
+    #[test]
+    fn test_stamp_story_author_preserves_expires_wire_value() {
+        let elem: Element =
+            "<story xmlns='urn:xmpp:stories:0' expires='2030-01-01T12:00:00Z'><body>Hello!</body><author>spoof@example.com</author></story>"
+                .parse()
+                .expect("story element");
+
+        let stamped = stamp_story_author("s-1", &elem, "alice@example.com").expect("story");
+
+        assert_eq!(stamped.attr("expires"), Some("2030-01-01T12:00:00Z"));
+        assert_eq!(
+            parse_story("s-1", &stamped)
+                .expect("parseable")
+                .author
+                .as_deref(),
+            Some("alice@example.com")
+        );
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/pubsub/storage/memory.rs
+++ b/server/crates/waddle-xmpp/src/pubsub/storage/memory.rs
@@ -142,6 +142,64 @@ impl PubSubStorage for InMemoryPubSubStorage {
         })
     }
 
+    async fn publish_item_if_missing_or_publisher(
+        &self,
+        owner: &BareJid,
+        node_name: &str,
+        item: &PubSubItem,
+        publisher: &BareJid,
+        auto_create: bool,
+    ) -> Result<PublishResult, XmppError> {
+        let key = Self::key(owner, node_name);
+
+        let (node, node_created) = if let Some(node) = self.nodes.get(&key) {
+            (node.clone(), false)
+        } else if auto_create {
+            let node = PubSubNode::new_pep(owner.clone(), node_name.to_string());
+            self.nodes.insert(key.clone(), node.clone());
+            self.items.insert(key.clone(), Vec::new());
+            (node, true)
+        } else {
+            return Err(XmppError::item_not_found(Some(format!(
+                "Node '{}' does not exist",
+                node_name
+            ))));
+        };
+
+        let item_id = item.id.clone().unwrap_or_else(Self::generate_item_id);
+        let stored_item = StoredItem {
+            id: item_id.clone(),
+            payload_xml: item.payload.as_ref().map(String::from),
+            publisher: Some(publisher.clone()),
+            published_at: chrono::Utc::now(),
+        };
+
+        let mut items = self.items.entry(key).or_default();
+        if let Some(pos) = items.iter().position(|i| i.id == item_id) {
+            if items[pos].publisher.as_ref() != Some(publisher) {
+                return Err(XmppError::forbidden(Some(
+                    "PubSub item belongs to a different publisher".to_string(),
+                )));
+            }
+            items[pos] = stored_item;
+        } else {
+            items.push(stored_item);
+        }
+
+        let max_items = node.config.max_items as usize;
+        let mut evicted_item_ids = Vec::new();
+        if max_items > 0 && items.len() > max_items {
+            let excess = items.len() - max_items;
+            evicted_item_ids.extend(items.drain(0..excess).map(|item| item.id));
+        }
+
+        Ok(PublishResult {
+            item_id,
+            node_created,
+            evicted_item_ids,
+        })
+    }
+
     async fn get_items(
         &self,
         owner: &BareJid,

--- a/server/crates/waddle-xmpp/src/pubsub/storage/traits.rs
+++ b/server/crates/waddle-xmpp/src/pubsub/storage/traits.rs
@@ -55,6 +55,22 @@ pub trait PubSubStorage: Send + Sync + 'static {
         auto_create: bool,
     ) -> Result<PublishResult, XmppError>;
 
+    /// Publish an item only when the item id is unused or the existing
+    /// stored item was published by the same bare JID.
+    ///
+    /// Open community nodes use this to prevent two members from clobbering
+    /// each other's client-chosen item ids while still allowing a publisher
+    /// to update their own item. Implementations must enforce this in the
+    /// same critical section or transaction as the write.
+    async fn publish_item_if_missing_or_publisher(
+        &self,
+        owner: &BareJid,
+        node_name: &str,
+        item: &PubSubItem,
+        publisher: &BareJid,
+        auto_create: bool,
+    ) -> Result<PublishResult, XmppError>;
+
     /// Get items from a node.
     ///
     /// If item_ids is empty, returns all items (up to max_items if specified).


### PR DESCRIPTION
## Summary

Fix issue 13: authenticated community members can publish photo/story updates to the community stories PubSub node.

## Changes

- Configure the XEP-0501 stories node as member-open, matching the public/community feed policy.
- Authorize authenticated non-outcast members through the node publish model instead of the owner-only Spaces mutation gate.
- Stamp the authenticated bare JID into story payload authors server-side, preserving the submitted story payload shape.
- Reject missing, non-story, and empty story payloads with PubSub payload errors instead of storing junk items.
- Allow members to retract their own feed/story items while preventing cross-member retraction.
- Add a storage-level same-publisher conditional publish path so cross-member item-id clobbering is rejected atomically.
- Update XEP-0501 and XEP-0470 websocket regressions for member story media publish, own-story retract, payload validation, and story reaction behavior.

## Validation

- `cuenv exec -- cargo test -p waddle-server --test xep0501_stories_ws`
- `cuenv exec -- cargo test -p waddle-server --test xep0470_story_reactions_ws`
- `cuenv exec -- cargo test -p waddle-server pubsub::tests::publish_item_if_missing_or_publisher_rejects_different_publisher`
- `cuenv exec -- cargo test -p waddle-xmpp-core xep0501`
- `cuenv exec -- cargo fmt --check`
- `cuenv exec -- cargo clippy -p waddle-server -p waddle-xmpp -p waddle-xmpp-core --all-targets -- -D warnings`
- `git diff --check`

## XEP Review

Checked local `./xeps` for XEP-0060, XEP-0472, and XEP-0501. This PR fixes the immediate member publish/retract permission path. The existing Waddle story wire shape still uses `urn:xmpp:stories:0` with `<story/>` / `<media-url>`, while the local XEP-0501 text describes the `urn:xmpp:pubsub-social-feed:stories:0` profile and Atom enclosure media. That broader namespace/profile alignment touches chat, wasm, disco, e2e scenarios, and attachment-summary nodes, so it is intentionally left for the follow-up "all other fixes" PR.
