### PR TITLE
fix(server): align channel permissions and XEP payloads

### DIFF
--- a/chat/src/components/admin/ChannelCreateDialog.vue
+++ b/chat/src/components/admin/ChannelCreateDialog.vue
@@ -4,6 +4,7 @@ import { ref, watch } from "vue";
 import { X } from "lucide-vue-next";
 import AppDialog from "@/components/ui/AppDialog.vue";
 import { requireMembershipForUnlistedChannel } from "./channelAdmissionPolicy";
+import type { WasmAdminChannelType } from "@/lib/xmpp";
 
 const open = defineModel<boolean>("open", { required: true });
 
@@ -13,11 +14,12 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  submit: [payload: { name: string; topic?: string | null; spaceJid?: string | null; spaceNode?: string | null; isPublic?: boolean | null; membersOnly?: boolean | null }];
+  submit: [payload: { name: string; topic?: string | null; channelType?: WasmAdminChannelType | null; spaceJid?: string | null; spaceNode?: string | null; isPublic?: boolean | null; membersOnly?: boolean | null }];
 }>();
 
 const name = ref("");
 const topic = ref("");
+const channelType = ref<WasmAdminChannelType>("text");
 const spaceNode = ref("");
 const isPublic = ref(true);
 const membersOnly = ref(false);
@@ -26,6 +28,7 @@ watch(open, (isOpen) => {
   if (isOpen) {
     name.value = "";
     topic.value = "";
+    channelType.value = "text";
     spaceNode.value = "";
     isPublic.value = true;
     membersOnly.value = false;
@@ -47,6 +50,7 @@ function onSubmit() {
   emit("submit", {
     name: name.value.trim(),
     topic: topic.value.trim() || null,
+    channelType: channelType.value,
     spaceJid: selectedSpace?.space_jid ?? null,
     spaceNode: selectedSpace?.space_node ?? null,
     isPublic: isPublic.value,
@@ -96,6 +100,14 @@ function onSubmit() {
         <select v-model="spaceNode" class="chat-field-control type-field">
           <option value="">No space</option>
           <option v-for="s in spaces" :key="s.space_node" :value="s.space_node">{{ s.name }}</option>
+        </select>
+      </label>
+      <label class="flex flex-col gap-1">
+        <span class="type-section-label text-muted-foreground">Type</span>
+        <select v-model="channelType" class="chat-field-control type-field">
+          <option value="text">Text</option>
+          <option value="announcement">Announcement</option>
+          <option value="forum">Forum</option>
         </select>
       </label>
       <div class="flex flex-col gap-2 rounded-lg border border-border bg-muted/30 px-3 py-2.5">

--- a/chat/src/components/admin/ChannelDetailDrawer.vue
+++ b/chat/src/components/admin/ChannelDetailDrawer.vue
@@ -13,6 +13,7 @@ import type {
   WasmAdminChannelAffiliationEntry,
   WasmAdminChannelListEntry,
   WasmAdminChannelOccupantEntry,
+  WasmAdminChannelType,
 } from "@/lib/xmpp";
 
 type Affiliation = "owner" | "admin" | "member" | "none" | "outcast";
@@ -39,6 +40,7 @@ const tab = ref<Tab>("config");
 // Config edit state
 const editName = ref(props.channel.name);
 const editTopic = ref(props.channel.topic ?? "");
+const editChannelType = ref<WasmAdminChannelType>(props.channel.channel_type);
 const editIsPublic = ref(props.channel.is_public);
 const editMembersOnly = ref(props.channel.members_only);
 const editing = ref(false);
@@ -64,6 +66,7 @@ const deleteError = ref("");
 watch(() => props.channel, (c) => {
   editName.value = c.name;
   editTopic.value = c.topic ?? "";
+  editChannelType.value = c.channel_type;
   editIsPublic.value = c.is_public;
   editMembersOnly.value = c.members_only;
   void loadAffiliations();
@@ -123,6 +126,7 @@ async function saveConfig() {
       channelJid: props.channel.channel_jid,
       name: editName.value.trim(),
       topic: editTopic.value.trim() || null,
+      channelType: editChannelType.value,
       isPublic: editIsPublic.value,
       membersOnly: editMembersOnly.value,
     });
@@ -241,6 +245,14 @@ const occupantCountLabel = computed(() => {
         <label class="flex flex-col gap-1">
           <span class="type-section-label text-muted-foreground">Topic</span>
           <textarea v-model="editTopic" rows="3" class="chat-field-control chat-textarea-control type-field" />
+        </label>
+        <label class="flex flex-col gap-1">
+          <span class="type-section-label text-muted-foreground">Type</span>
+          <select v-model="editChannelType" class="chat-field-control type-field">
+            <option value="text">Text</option>
+            <option value="announcement">Announcement</option>
+            <option value="forum">Forum</option>
+          </select>
         </label>
         <div class="flex flex-col gap-2 rounded-lg border border-border bg-muted/30 px-3 py-2.5">
           <label class="flex items-center gap-2 cursor-pointer">

--- a/chat/src/components/admin/ChannelsPanel.vue
+++ b/chat/src/components/admin/ChannelsPanel.vue
@@ -6,6 +6,7 @@ import { Plus, Search } from "lucide-vue-next";
 import type { BrowserXmppClient } from "@/lib/xmpp";
 import type {
   WasmAdminChannelListEntry,
+  WasmAdminChannelType,
   WasmAdminChannelsListResult,
   WasmAdminSpaceListEntry,
 } from "@/lib/xmpp";
@@ -137,7 +138,7 @@ async function loadMore(): Promise<void> {
   }
 }
 
-async function onCreate(payload: { name: string; topic?: string | null; spaceJid?: string | null; spaceNode?: string | null; isPublic?: boolean | null; membersOnly?: boolean | null }) {
+async function onCreate(payload: { name: string; topic?: string | null; channelType?: WasmAdminChannelType | null; spaceJid?: string | null; spaceNode?: string | null; isPublic?: boolean | null; membersOnly?: boolean | null }) {
   if (!props.xmppClient) return;
   isSubmitting.value = true;
   try {
@@ -156,6 +157,19 @@ function openDetail(entry: WasmAdminChannelListEntry) {
 }
 function closeDetail() {
   selected.value = null;
+}
+function channelTypeLabel(type: WasmAdminChannelType): string {
+  switch (type) {
+    case "announcement":
+      return "Announcement";
+    case "forum":
+      return "Forum";
+    case "group-dm":
+      return "Group DM";
+    case "text":
+    default:
+      return "Text";
+  }
 }
 async function onDetailChanged() {
   await fetchFirstPage(prefix.value, spaceFilter.value);
@@ -278,6 +292,7 @@ const dialogSpaces = computed(() =>
           <div class="flex flex-col gap-0.5 min-w-0 flex-1">
             <div class="flex items-center gap-2 min-w-0">
               <span class="type-control truncate">{{ entry.name }}</span>
+              <span class="type-caption rounded-full bg-muted px-2 py-0.5 flex-shrink-0">{{ channelTypeLabel(entry.channel_type) }}</span>
               <span v-if="!entry.is_public" class="type-caption rounded-full bg-muted px-2 py-0.5 flex-shrink-0">Hidden</span>
               <span v-if="entry.members_only" class="type-caption rounded-full bg-muted px-2 py-0.5 flex-shrink-0">Members-only</span>
             </div>

--- a/chat/src/components/community/FeedUpdateComposer.vue
+++ b/chat/src/components/community/FeedUpdateComposer.vue
@@ -240,6 +240,7 @@ async function handleStorySubmit(payload: { body?: string; file: Blob; mediaKind
     await props.publishStory({
       ...(payload.body ? { body: payload.body } : {}),
       mediaUrl: uploaded.url,
+      mediaType: uploaded.contentType,
       ...(props.selfJid ? { author: props.selfJid.split("/")[0] } : {}),
     });
     storyComposerKey.value += 1;

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -146,6 +146,7 @@ import {
 } from "./wasm-message-codecs";
 import type {
   WasmAdminChannelRef,
+  WasmAdminChannelType,
   WasmAdminChannelsAffiliationsResult,
   WasmAdminChannelsKickResult,
   WasmAdminChannelsListResult,
@@ -2717,14 +2718,19 @@ export class BrowserXmppClient {
   }
 
   /**
-   * Publish a XEP-0501 story. At least one of `body`/`mediaUrl` is
-   * required (the server rejects empty stories).
+   * Publish a XEP-0501 story. `mediaUrl` is required; `body` is
+   * optional text content attached to that media.
    */
   async publishStory(communityJid: string, input: StoryPostInput): Promise<Story> {
+    const mediaUrl = input.mediaUrl.trim();
+    if (!mediaUrl) {
+      throw new Error("Story mediaUrl is required");
+    }
     const xmpp = await this.requireConnectedXmpp();
     const result = await xmpp.stories_publish?.(communityJid, {
       ...(input.body ? { body: input.body } : {}),
-      ...(input.mediaUrl ? { media_url: input.mediaUrl } : {}),
+      media_url: mediaUrl,
+      ...(input.mediaType ? { media_type: input.mediaType } : {}),
       ...(input.author ? { author: input.author } : {}),
       ...(typeof input.expiryHours === "number" ? { expiry_hours: input.expiryHours } : {}),
     }) as WasmStory | undefined;
@@ -3237,25 +3243,27 @@ export class BrowserXmppClient {
       after_cursor: opts.afterCursor ?? null,
     });
   }
-  async adminChannelsCreate(opts: { name: string; topic?: string | null; spaceJid?: string | null; spaceNode?: string | null; isPublic?: boolean | null; membersOnly?: boolean | null }): Promise<WasmAdminChannelRef> {
+  async adminChannelsCreate(opts: { name: string; topic?: string | null; channelType?: WasmAdminChannelType | null; spaceJid?: string | null; spaceNode?: string | null; isPublic?: boolean | null; membersOnly?: boolean | null }): Promise<WasmAdminChannelRef> {
     const xmpp = await this.requireConnectedXmpp();
     if (!xmpp.admin_channels_create) throw new Error("admin_channels_create binding missing");
     return await xmpp.admin_channels_create({
       name: opts.name,
       topic: opts.topic ?? null,
+      channel_type: opts.channelType ?? null,
       space_jid: opts.spaceJid ?? null,
       space_node: opts.spaceNode ?? null,
       is_public: opts.isPublic ?? null,
       members_only: opts.membersOnly ?? null,
     });
   }
-  async adminChannelsUpdate(opts: { channelJid: string; name?: string | null; topic?: string | null; isPublic?: boolean | null; membersOnly?: boolean | null }): Promise<WasmAdminChannelRef> {
+  async adminChannelsUpdate(opts: { channelJid: string; name?: string | null; topic?: string | null; channelType?: WasmAdminChannelType | null; isPublic?: boolean | null; membersOnly?: boolean | null }): Promise<WasmAdminChannelRef> {
     const xmpp = await this.requireConnectedXmpp();
     if (!xmpp.admin_channels_update) throw new Error("admin_channels_update binding missing");
     return await xmpp.admin_channels_update({
       channel_jid: opts.channelJid,
       name: opts.name ?? null,
       topic: opts.topic ?? null,
+      channel_type: opts.channelType ?? null,
       is_public: opts.isPublic ?? null,
       members_only: opts.membersOnly ?? null,
     });

--- a/chat/src/lib/xmpp/index.ts
+++ b/chat/src/lib/xmpp/index.ts
@@ -22,6 +22,7 @@ export type {
   WasmAdminChannelAffiliationEntry,
   WasmAdminChannelListEntry,
   WasmAdminChannelOccupantEntry,
+  WasmAdminChannelType,
   WasmAdminChannelsListResult,
   WasmAdminSpaceListEntry,
   WasmAdminSpaceMemberEntry,

--- a/chat/src/lib/xmpp/story-types.ts
+++ b/chat/src/lib/xmpp/story-types.ts
@@ -13,6 +13,8 @@ export interface Story {
   body?: string;
   /** Image / video URL. */
   mediaUrl?: string;
+  /** MIME type for the story media URL. */
+  mediaType?: string;
   /** Author bare JID. */
   author?: string;
   /** Epoch ms when the story was posted. */
@@ -38,13 +40,14 @@ export interface StoryReactionSummary {
 
 export const NS_PUBSUB_ATTACHMENTS = "urn:xmpp:pubsub-attachments:1";
 export const NS_PUBSUB_ATTACHMENTS_SUMMARY = "urn:xmpp:pubsub-attachments:summary:1";
-export const STORIES_NODE = "urn:xmpp:stories:0";
-export const STORY_REACTIONS_SUMMARY_NODE = `${NS_PUBSUB_ATTACHMENTS_SUMMARY}/urn:xmpp:stories:0`;
+export const STORIES_NODE = "urn:xmpp:pubsub-social-feed:stories:0";
+export const STORY_REACTIONS_SUMMARY_NODE = `${NS_PUBSUB_ATTACHMENTS_SUMMARY}/${STORIES_NODE}`;
 export const STORY_REACTIONS_MAX = 12;
 
 export interface StoryPostInput {
   body?: string;
-  mediaUrl?: string;
+  mediaUrl: string;
+  mediaType?: string;
   author?: string;
   /** Hours from now until expiry. Defaults to 24 server-side. */
   expiryHours?: number;
@@ -55,6 +58,7 @@ export interface WasmStory {
   id: string;
   body?: string | null;
   media_url?: string | null;
+  media_type?: string | null;
   author?: string | null;
   posted?: string | null;
   expires?: string | null;
@@ -67,6 +71,7 @@ export function storyFromWasm(story: WasmStory): Story {
     id: story.id,
     ...(story.body ? { body: story.body } : {}),
     ...(story.media_url ? { mediaUrl: story.media_url } : {}),
+    ...(story.media_type ? { mediaType: story.media_type } : {}),
     ...(story.author ? { author: story.author } : {}),
     ...(typeof postedMs === "number" && Number.isFinite(postedMs) ? { postedMs } : {}),
     ...(typeof expiresMs === "number" && Number.isFinite(expiresMs) ? { expiresMs } : {}),

--- a/chat/src/lib/xmpp/wasm-types.ts
+++ b/chat/src/lib/xmpp/wasm-types.ts
@@ -538,10 +538,13 @@ export interface WasmAdminSpacesSetRoleResult {
 
 // ─── Admin V2 — Channels ──────────────────────────────────────────────
 
+export type WasmAdminChannelType = "text" | "announcement" | "forum" | "group-dm";
+
 export interface WasmAdminChannelListEntry {
   channel_jid: string;
   name: string;
   topic?: string | null;
+  channel_type: WasmAdminChannelType;
   is_public: boolean;
   members_only: boolean;
   occupant_count: number;
@@ -560,6 +563,7 @@ export interface WasmAdminChannelRef {
   channel_jid: string;
   name: string;
   topic?: string | null;
+  channel_type: WasmAdminChannelType;
   is_public: boolean;
   members_only: boolean;
 }

--- a/chat/src/services/stories.ts
+++ b/chat/src/services/stories.ts
@@ -134,7 +134,7 @@ export function useStories(
     const client = xmppClient.value;
     const jid = options.communityJid.value;
     if (!client || !jid) return null;
-    if (!(input.body?.trim() || input.mediaUrl?.trim())) return null;
+    if (!input.mediaUrl.trim()) return null;
     isPosting.value = true;
     error.value = null;
     try {

--- a/chat/tests/admin-channels-panel.test.ts
+++ b/chat/tests/admin-channels-panel.test.ts
@@ -29,6 +29,7 @@ const entry = (
   channel_jid: jid,
   name: jid.split("@")[0] ?? jid,
   topic: null,
+  channel_type: "text",
   is_public: true,
   members_only: false,
   occupant_count: 0,

--- a/chat/tests/stories.test.ts
+++ b/chat/tests/stories.test.ts
@@ -52,7 +52,7 @@ function makeClient(stories: Story[] = []): MockClient {
     emitPubsubEvent: (event: PubsubEvent) => {
       for (const handler of pubsubEventHandlers) handler(event);
     },
-    publishStory: mock((_jid: string, input: { body?: string; mediaUrl?: string; author?: string }) =>
+    publishStory: mock((_jid: string, input: { body?: string; mediaUrl: string; author?: string }) =>
       Promise.resolve({
         id: "new-story",
         ...(input.body ? { body: input.body } : {}),
@@ -100,10 +100,18 @@ describe("useStories", () => {
       useStories(ref<BrowserXmppClient | null>(client), { communityJid: ref<string | null>(COMMUNITY) }),
     );
     story.nowMs.value = Date.parse("2026-06-01T12:00:00Z");
-    const empty = await story.post({ body: "  " });
+    const empty = await story.post({ body: "  ", mediaUrl: "  " });
     expect(empty).toBe(null);
     expect(client.publishStory).not.toHaveBeenCalled();
-    const posted = await story.post({ body: "hi", author: "alice@example.com" });
+    const bodyOnly = await story.post({ body: "hi", mediaUrl: "  ", author: "alice@example.com" });
+    expect(bodyOnly).toBe(null);
+    expect(client.publishStory).not.toHaveBeenCalled();
+    const posted = await story.post({
+      body: "hi",
+      mediaUrl: "https://example.com/story.jpg",
+      mediaType: "image/jpeg",
+      author: "alice@example.com",
+    });
     expect(posted?.id).toBe("new-story");
     expect(story.activeStories.value.map((s) => s.id)).toContain("new-story");
   });
@@ -190,7 +198,7 @@ describe("useStories", () => {
 
     client.emitPubsubEvent({
       from: COMMUNITY,
-      node: "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:stories:0",
+      node: "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:pubsub-social-feed:stories:0",
       items: [{
         id: "s1",
         payload: {
@@ -227,7 +235,7 @@ describe("useStories", () => {
 
     client.emitPubsubEvent({
       from: COMMUNITY,
-      node: "urn:xmpp:stories:0",
+      node: "urn:xmpp:pubsub-social-feed:stories:0",
       items: [{
         id: "s1",
         retracted: true,
@@ -250,7 +258,7 @@ describe("useStories", () => {
 
     client.emitPubsubEvent({
       from: COMMUNITY,
-      node: "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:stories:0",
+      node: "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:pubsub-social-feed:stories:0",
       items: [{
         id: "s1",
         retracted: true,
@@ -278,7 +286,7 @@ describe("useStories", () => {
 
     client.emitPubsubEvent({
       from: COMMUNITY,
-      node: "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:stories:0",
+      node: "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:pubsub-social-feed:stories:0",
       items: [{
         id: "s1",
         payload: {
@@ -307,7 +315,7 @@ describe("useStories", () => {
 
     client.emitPubsubEvent({
       from: COMMUNITY,
-      node: "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:stories:0",
+      node: "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:pubsub-social-feed:stories:0",
       items: [{
         id: "s1",
         payload: {
@@ -337,7 +345,7 @@ describe("useStories", () => {
     await Promise.resolve();
     client.emitPubsubEvent({
       from: COMMUNITY,
-      node: "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:stories:0",
+      node: "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:pubsub-social-feed:stories:0",
       items: [{
         id: "s1",
         payload: {
@@ -368,7 +376,7 @@ describe("useStories", () => {
 
     client.emitPubsubEvent({
       from: COMMUNITY,
-      node: "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:stories:0",
+      node: "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:pubsub-social-feed:stories:0",
       items: [{
         id: "s1",
         payload: {
@@ -383,7 +391,7 @@ describe("useStories", () => {
     firstScope.stop();
     client.emitPubsubEvent({
       from: COMMUNITY,
-      node: "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:stories:0",
+      node: "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:pubsub-social-feed:stories:0",
       items: [{
         id: "s1",
         payload: {
@@ -406,7 +414,7 @@ describe("useStories", () => {
 
     client.emitPubsubEvent({
       from: "other.example.com",
-      node: "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:stories:0",
+      node: "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:pubsub-social-feed:stories:0",
       items: [{
         id: "s1",
         payload: {

--- a/server/crates/waddle-server/src/admin/channels.rs
+++ b/server/crates/waddle-server/src/admin/channels.rs
@@ -48,7 +48,7 @@ use waddle_xmpp::stream_management::InMemorySmSessionRegistry;
 use waddle_xmpp::xep::xep0004::{DataForm, Field, FieldType, FormType};
 use waddle_xmpp::xep::xep0421::OccupantIdentity;
 use waddle_xmpp::XmppError;
-use waddle_xmpp::{Affiliation, ChannelInfo, Role, Stanza};
+use waddle_xmpp::{Affiliation, ChannelInfo, ChannelType, Role, Stanza};
 use xmpp_parsers::message::{Message, MessageType};
 use xmpp_parsers::minidom::Element;
 
@@ -176,6 +176,7 @@ pub struct ChannelListEntry {
     pub channel_jid: BareJid,
     pub name: String,
     pub topic: Option<String>,
+    pub channel_type: ChannelType,
     pub is_public: bool,
     pub members_only: bool,
     pub occupant_count: u32,
@@ -197,6 +198,7 @@ pub struct ChannelsCreateArgs {
     pub space_node: Option<SpaceNode>,
     pub name: String,
     pub topic: Option<String>,
+    pub channel_type: ChannelType,
     /// XEP-0045 `muc#roomconfig_publicroom`; default `true`.
     pub is_public: bool,
     /// XEP-0045 `muc#roomconfig_membersonly`. When omitted during create,
@@ -209,6 +211,7 @@ pub struct ChannelRef {
     pub channel_jid: BareJid,
     pub name: String,
     pub topic: Option<String>,
+    pub channel_type: ChannelType,
     pub is_public: bool,
     pub members_only: bool,
 }
@@ -218,6 +221,7 @@ pub struct ChannelsUpdateArgs {
     pub channel_jid: BareJid,
     pub name: Option<String>,
     pub topic: Option<String>,
+    pub channel_type: Option<ChannelType>,
     pub is_public: Option<bool>,
     pub members_only: Option<bool>,
 }
@@ -770,6 +774,19 @@ fn parse_optional_bool(form: &DataForm, var: &str) -> Result<Option<bool>, Strin
     }
 }
 
+fn parse_optional_channel_type(form: &DataForm, var: &str) -> Result<Option<ChannelType>, String> {
+    let Some(raw) = parse_optional_text(form, var) else {
+        return Ok(None);
+    };
+    let Some(channel_type) = ChannelType::parse(&raw) else {
+        return Err(format!("'{var}' has unsupported channel type '{raw}'"));
+    };
+    if matches!(channel_type, ChannelType::GroupDm) {
+        return Err(format!("'{var}' group-dm is managed by group-dm:create"));
+    }
+    Ok(Some(channel_type))
+}
+
 fn parse_page_size(form: &DataForm) -> Result<u32, String> {
     match form.get_value("page_size") {
         Some(raw) if !raw.is_empty() => {
@@ -850,6 +867,8 @@ pub fn parse_create_args(form: Option<&DataForm>) -> Result<ChannelsCreateArgs, 
         _ => None,
     };
     let space_node = parse_optional_text(form, "space_node").map(SpaceNode::from);
+    let channel_type =
+        parse_optional_channel_type(form, "channel_type")?.unwrap_or(ChannelType::Text);
     // XEP-0045 public-room discovery visibility defaults true.
     let is_public = parse_optional_bool(form, "is_public")?.unwrap_or(true);
     let members_only = parse_optional_bool(form, "members_only")?;
@@ -858,6 +877,7 @@ pub fn parse_create_args(form: Option<&DataForm>) -> Result<ChannelsCreateArgs, 
         space_node,
         name,
         topic,
+        channel_type,
         is_public,
         members_only,
     })
@@ -921,12 +941,14 @@ pub fn parse_update_args(form: Option<&DataForm>) -> Result<ChannelsUpdateArgs, 
         validate_name(name)?;
     }
     let topic = parse_optional_text(form, "topic");
+    let channel_type = parse_optional_channel_type(form, "channel_type")?;
     let is_public = parse_optional_bool(form, "is_public")?;
     let members_only = parse_optional_bool(form, "members_only")?;
     Ok(ChannelsUpdateArgs {
         channel_jid,
         name,
         topic,
+        channel_type,
         is_public,
         members_only,
     })
@@ -1079,6 +1101,14 @@ async fn run_list(
                 continue;
             }
         }
+        let channel_id = match waddle_xmpp::parse_managed_room_jid(room_jid) {
+            Some(channel_id) => channel_id,
+            None => continue,
+        };
+        let catalog_snapshot = get_xmpp_channel(state.db_pool.global_actor().clone(), &channel_id)
+            .await
+            .map_err(|error| internal_err(format!("channel catalog lookup failed: {error}")))?;
+        let channel_type = channel_type_from_catalog_or_config(catalog_snapshot.as_ref(), &config);
         let occupant_count = actor
             .ask(OccupantCount)
             .await
@@ -1105,6 +1135,7 @@ async fn run_list(
             channel_jid: room_jid.clone(),
             name: config.name,
             topic: config.description,
+            channel_type,
             is_public: config.public_room,
             members_only: config.members_only,
             occupant_count: u32::try_from(occupant_count).unwrap_or(u32::MAX),
@@ -1579,25 +1610,35 @@ fn channel_type_from_config(config: &RoomConfig) -> &'static str {
     }
     if config.forum {
         "forum"
+    } else if config.moderated {
+        "announcement"
     } else {
         "text"
     }
 }
 
-fn channel_type_for_catalog(config: &RoomConfig, existing: Option<&XmppChannelRecord>) -> String {
-    if config.forum {
-        return "forum".to_string();
-    }
-    if existing.is_some_and(|row| row.channel_type == "announcement") {
-        return "announcement".to_string();
-    }
-    channel_type_from_config(config).to_string()
+fn channel_type_from_catalog_or_config(
+    existing: Option<&XmppChannelRecord>,
+    config: &RoomConfig,
+) -> ChannelType {
+    existing
+        .and_then(|row| ChannelType::parse(&row.channel_type))
+        .unwrap_or_else(|| {
+            ChannelType::parse(channel_type_from_config(config)).unwrap_or(ChannelType::Text)
+        })
+}
+
+fn apply_channel_type(config: &mut RoomConfig, channel_type: ChannelType) {
+    config.group_dm = matches!(channel_type, ChannelType::GroupDm);
+    config.forum = matches!(channel_type, ChannelType::Forum);
+    config.moderated = matches!(channel_type, ChannelType::Announcement);
 }
 
 async fn upsert_channel_catalog(
     state: &AppState,
     channel_id: &str,
     config: &RoomConfig,
+    channel_type: ChannelType,
 ) -> Result<(), AdminErr> {
     let db_actor = state.db_pool.global_actor().clone();
     let existing = get_xmpp_channel(db_actor.clone(), channel_id)
@@ -1607,7 +1648,7 @@ async fn upsert_channel_catalog(
         id: channel_id.to_string(),
         name: config.name.clone(),
         description: config.description.clone(),
-        channel_type: channel_type_for_catalog(config, existing.as_ref()),
+        channel_type: channel_type.as_str().to_string(),
         position: existing.as_ref().map(|row| row.position).unwrap_or(0),
         is_default: existing.as_ref().map(|row| row.is_default).unwrap_or(false),
         pin_permission: config.pin_permission,
@@ -1714,12 +1755,25 @@ async fn rollback_channel_bookmark_item(
             return None;
         }
     };
-    let channel_type = channel_type_from_config(&config).to_string();
+    let catalog_snapshot =
+        match get_xmpp_channel(state.db_pool.global_actor().clone(), channel_id).await {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    room = %room_jid,
+                    channel_id,
+                    "channels rollback could not load channel catalog for missing Spaces bookmark",
+                );
+                return None;
+            }
+        };
+    let channel_type = channel_type_from_catalog_or_config(catalog_snapshot.as_ref(), &config);
     waddle_xmpp::xep::build_channel_item(
         &ChannelInfo {
             id: channel_id.to_string(),
             name: config.name,
-            channel_type,
+            channel_type: channel_type.as_str().to_string(),
         },
         &state.muc_domain.to_string(),
     )
@@ -1758,9 +1812,7 @@ async fn run_create(state: &AppState, args: &ChannelsCreateArgs) -> Result<Chann
         public_room: args.is_public,
         ..RoomConfig::default()
     };
-    // Spec: forum/announcement etc default off; only name/topic/visibility
-    // are exposed at the admin V2 wire.
-    config.moderated = false;
+    apply_channel_type(&mut config, args.channel_type);
     config.max_occupants = 0;
     config.enable_logging = true;
 
@@ -1775,7 +1827,8 @@ async fn run_create(state: &AppState, args: &ChannelsCreateArgs) -> Result<Chann
         .await
         .map_err(send_err("room_registry ask CreateRoom"))?;
 
-    if let Err(error) = upsert_channel_catalog(state, &localpart, &config).await {
+    if let Err(error) = upsert_channel_catalog(state, &localpart, &config, args.channel_type).await
+    {
         let _ = state
             .room_registry
             .ask(DestroyRoom {
@@ -1796,7 +1849,7 @@ async fn run_create(state: &AppState, args: &ChannelsCreateArgs) -> Result<Chann
             node,
             &localpart,
             &args.name,
-            channel_type_from_config(&config),
+            args.channel_type.as_str(),
         )
         .await
         {
@@ -1875,6 +1928,7 @@ async fn run_create(state: &AppState, args: &ChannelsCreateArgs) -> Result<Chann
         channel_jid,
         name: args.name.clone(),
         topic: args.topic.clone(),
+        channel_type: args.channel_type,
         is_public: args.is_public,
         members_only,
     })
@@ -2859,14 +2913,18 @@ async fn run_update(
     let catalog_snapshot = get_xmpp_channel(state.db_pool.global_actor().clone(), &channel_id)
         .await
         .map_err(|error| internal_err(format!("channel catalog lookup failed: {error}")))?;
+    let existing_channel_type =
+        channel_type_from_catalog_or_config(catalog_snapshot.as_ref(), &existing);
+    let new_channel_type = args.channel_type.unwrap_or(existing_channel_type);
 
-    let updated = RoomConfig {
+    let mut updated = RoomConfig {
         name: new_name.clone(),
         description: new_topic.clone(),
         members_only: new_members_only,
         public_room: new_public_room,
         ..existing.clone()
     };
+    apply_channel_type(&mut updated, new_channel_type);
     let linked_bookmark = if let Some(link) = state
         .channel_space_link_store
         .get(&args.channel_jid)
@@ -2914,13 +2972,14 @@ async fn run_update(
         .await
         .map_err(send_err("room actor UpdateConfig"))?;
 
-    if let Err(error) = upsert_channel_catalog(state, &channel_id, &updated).await {
+    if let Err(error) = upsert_channel_catalog(state, &channel_id, &updated, new_channel_type).await
+    {
         let _ = rollback_room_config_if_revision(&actor, expected_revision, existing.clone()).await;
         return Err(error);
     }
 
     if let Some((node, channel_id, item_id, previous_bookmark)) = linked_bookmark {
-        let bookmark_channel_type = channel_type_for_catalog(&updated, catalog_snapshot.as_ref());
+        let bookmark_channel_type = new_channel_type.as_str().to_string();
         let parent_tuple_created = match publish_channel_space_bookmark(
             state,
             &node,
@@ -2975,6 +3034,7 @@ async fn run_update(
         channel_jid: args.channel_jid.clone(),
         name: new_name,
         topic: new_topic,
+        channel_type: new_channel_type,
         is_public: new_public_room,
         members_only: new_members_only,
     })
@@ -3771,6 +3831,7 @@ pub fn build_list_form(result: &ChannelsListResult) -> DataForm {
         .add_reported(Field::new("channel_jid", FieldType::JidSingle).with_label("Channel JID"))
         .add_reported(Field::new("name", FieldType::TextSingle).with_label("Name"))
         .add_reported(Field::new("topic", FieldType::TextSingle).with_label("Topic"))
+        .add_reported(Field::new("channel_type", FieldType::TextSingle).with_label("Type"))
         .add_reported(Field::new("is_public", FieldType::Boolean).with_label("Public"))
         .add_reported(Field::new("members_only", FieldType::Boolean).with_label("Members only"))
         .add_reported(Field::new("occupant_count", FieldType::TextSingle).with_label("Occupants"))
@@ -3785,6 +3846,8 @@ pub fn build_list_form(result: &ChannelsListResult) -> DataForm {
             Field::new("name", FieldType::TextSingle).with_value(entry.name.clone()),
             Field::new("topic", FieldType::TextSingle)
                 .with_value(entry.topic.clone().unwrap_or_default()),
+            Field::new("channel_type", FieldType::TextSingle)
+                .with_value(entry.channel_type.as_str()),
             Field::boolean("is_public", entry.is_public),
             Field::boolean("members_only", entry.members_only),
             Field::new("occupant_count", FieldType::TextSingle)
@@ -3814,6 +3877,10 @@ pub fn build_channel_form(channel: &ChannelRef) -> DataForm {
                 .with_value(channel.channel_jid.to_string()),
         )
         .add_field(Field::text_single("name", channel.name.clone()))
+        .add_field(Field::text_single(
+            "channel_type",
+            channel.channel_type.as_str(),
+        ))
         .add_field(Field::text_single("is_public", bool_str(channel.is_public)))
         .add_field(Field::text_single(
             "members_only",
@@ -4031,6 +4098,7 @@ mod tests {
                 channel_jid: "general@muc.localhost".parse().expect("jid"),
                 name: "General".to_string(),
                 topic: Some("All things".to_string()),
+                channel_type: ChannelType::Text,
                 is_public: true,
                 members_only: false,
                 occupant_count: 7,
@@ -4043,7 +4111,7 @@ mod tests {
         };
         let form = build_list_form(&result);
         assert!(matches!(form.form_type, FormType::Result));
-        assert_eq!(form.reported.len(), 10);
+        assert_eq!(form.reported.len(), 11);
         assert_eq!(form.items.len(), 1);
     }
 
@@ -4053,12 +4121,39 @@ mod tests {
             channel_jid: "general@muc.localhost".parse().expect("jid"),
             name: "General".to_string(),
             topic: None,
+            channel_type: ChannelType::Text,
             is_public: true,
             members_only: true,
         };
         let form = build_channel_form(&channel);
         assert_eq!(form.get_value("is_public"), Some("1"));
         assert_eq!(form.get_value("members_only"), Some("1"));
+    }
+
+    #[test]
+    fn catalog_channel_type_takes_precedence_over_room_config() {
+        let record = XmppChannelRecord {
+            id: "announcements".to_string(),
+            name: "Announcements".to_string(),
+            description: None,
+            channel_type: "announcement".to_string(),
+            position: 0,
+            is_default: false,
+            pin_permission: PinPermission::Anyone,
+            members_only: false,
+            public_room: true,
+            created_at: "2026-06-21T00:00:00Z".to_string(),
+            updated_at: None,
+        };
+        let config = RoomConfig {
+            moderated: false,
+            ..RoomConfig::default()
+        };
+
+        assert_eq!(
+            channel_type_from_catalog_or_config(Some(&record), &config),
+            ChannelType::Announcement
+        );
     }
 
     #[test]

--- a/server/crates/waddle-server/src/admin/spaces.rs
+++ b/server/crates/waddle-server/src/admin/spaces.rs
@@ -37,7 +37,7 @@ use waddle_xmpp::muc::room_actor::GetConfig;
 use waddle_xmpp::muc::room_registry_actor::GetRoom;
 use waddle_xmpp::pubsub::{Affiliation as PubSubAffiliation, PubSubItem};
 use waddle_xmpp::xep::xep0004::{DataForm, Field, FieldType, FormType};
-use waddle_xmpp::{ChannelInfo, XmppError};
+use waddle_xmpp::{ChannelInfo, ChannelType, XmppError};
 
 use crate::admin::is_community_owner;
 use crate::channel_space_links::ChannelSpaceLink;
@@ -45,6 +45,7 @@ use crate::permissions::{
     DeleteTuple, Object, ObjectType, PermissionError, Relation, Subject, SubjectType, Tuple,
     WriteTuple,
 };
+use crate::server::xmpp_state::get_xmpp_channel;
 use crate::server::AppState;
 use crate::space_identity::{
     canonical_space_projection, space_jid_for_node, SpaceNode, SpaceProjectionError,
@@ -884,12 +885,31 @@ async fn rollback_channel_bookmark_item(
             return None;
         }
     };
-    let channel_type = if config.forum { "forum" } else { "text" };
+    let catalog_snapshot = match get_xmpp_channel(state.db_pool.global_actor().clone(), channel_id)
+        .await
+    {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                room = %room_jid,
+                channel_id,
+                "spaces:delete rollback could not load channel catalog for missing channel bookmark",
+            );
+            return None;
+        }
+    };
+    let channel_type = channel_type_from_catalog_or_room_config(
+        catalog_snapshot
+            .as_ref()
+            .map(|record| record.channel_type.as_str()),
+        &config,
+    );
     match waddle_xmpp::xep::build_channel_item(
         &ChannelInfo {
             id: channel_id.to_string(),
             name: config.name,
-            channel_type: channel_type.to_string(),
+            channel_type,
         },
         &state.muc_domain.to_string(),
     ) {
@@ -903,6 +923,28 @@ async fn rollback_channel_bookmark_item(
             None
         }
     }
+}
+
+fn channel_type_from_room_config(config: &waddle_xmpp::muc::RoomConfig) -> &'static str {
+    if config.group_dm {
+        waddle_xmpp::admin::CHANNEL_TYPE_GROUP_DM
+    } else if config.forum {
+        "forum"
+    } else if config.moderated {
+        "announcement"
+    } else {
+        "text"
+    }
+}
+
+fn channel_type_from_catalog_or_room_config(
+    catalog_channel_type: Option<&str>,
+    config: &waddle_xmpp::muc::RoomConfig,
+) -> String {
+    catalog_channel_type
+        .and_then(ChannelType::parse)
+        .map(|channel_type| channel_type.as_str().to_string())
+        .unwrap_or_else(|| channel_type_from_room_config(config).to_string())
 }
 
 async fn run_create(state: &AppState, args: &SpacesCreateArgs) -> Result<SpaceRef, AdminErr> {
@@ -1623,6 +1665,32 @@ mod tests {
         let form = build_space_form(NODE_UPDATE, &space);
         assert!(matches!(form.form_type, FormType::Result));
         assert_eq!(form.get_value("FORM_TYPE"), Some(NODE_UPDATE));
+    }
+
+    #[test]
+    fn channel_type_from_room_config_preserves_announcement() {
+        let config = waddle_xmpp::muc::RoomConfig {
+            moderated: true,
+            ..waddle_xmpp::muc::RoomConfig::default()
+        };
+
+        assert_eq!(
+            super::channel_type_from_room_config(&config),
+            "announcement"
+        );
+    }
+
+    #[test]
+    fn catalog_channel_type_takes_precedence_over_room_config() {
+        let config = waddle_xmpp::muc::RoomConfig {
+            moderated: false,
+            ..waddle_xmpp::muc::RoomConfig::default()
+        };
+
+        assert_eq!(
+            super::channel_type_from_catalog_or_room_config(Some("announcement"), &config),
+            "announcement"
+        );
     }
 
     #[test]

--- a/server/crates/waddle-server/src/pep_feed_bridge.rs
+++ b/server/crates/waddle-server/src/pep_feed_bridge.rs
@@ -3,7 +3,7 @@
 //! Observes successful PEP publishes (mood / activity / tune /
 //! avatar / vCard4) AND successful RSVP publishes on the calendar
 //! events node, and shadow-publishes a typed feed entry to
-//! `urn:xmpp:pubsub-social-feed:0` on the community service so the
+//! `urn:xmpp:pubsub-social-feed:1` on the community service so the
 //! Feed pane surfaces user activity automatically alongside manual
 //! posts.
 //!
@@ -473,25 +473,10 @@ fn render_vcard(payload: &Element) -> Option<String> {
 // ── Feed-entry builder ──────────────────────────────────────────────
 
 fn build_bridge_entry(item_id: &str, kind: PepKind, author: &BareJid, body: &str) -> Element {
-    let mut entry = Element::builder("entry", waddle_xmpp_core::xep0472::NS_SOCIAL_FEED).build();
-
-    let mut id_el = Element::builder("id", waddle_xmpp_core::xep0472::NS_SOCIAL_FEED).build();
-    id_el.append_text_node(item_id);
-    entry.append_child(id_el);
-
-    let mut author_el =
-        Element::builder("author", waddle_xmpp_core::xep0472::NS_SOCIAL_FEED).build();
-    author_el.append_text_node(author.to_string());
-    entry.append_child(author_el);
-
-    let mut body_el = Element::builder("body", waddle_xmpp_core::xep0472::NS_SOCIAL_FEED).build();
-    body_el.append_text_node(body);
-    entry.append_child(body_el);
-
-    let mut published_el =
-        Element::builder("published", waddle_xmpp_core::xep0472::NS_SOCIAL_FEED).build();
-    published_el.append_text_node(chrono::Utc::now().to_rfc3339());
-    entry.append_child(published_el);
+    let feed_entry = waddle_xmpp_core::xep0472::FeedEntry::new(item_id, body)
+        .with_author(author.to_string())
+        .with_published(chrono::Utc::now());
+    let mut entry = waddle_xmpp_core::xep0472::build_feed_entry_element(&feed_entry);
 
     let source = Element::builder("source", NS_FEED_SOURCE)
         .attr(minidom::rxml::xml_ncname!("kind").to_owned(), kind.as_str())
@@ -801,12 +786,12 @@ mod tests {
         );
         let xml = String::from(&entry);
         assert!(
-            xml.contains("<author>alice@example.com</author>"),
-            "author missing: {xml}"
+            xml.contains("http://www.w3.org/2005/Atom") && xml.contains("xmpp:alice@example.com"),
+            "Atom author missing: {xml}"
         );
         assert!(
-            xml.contains("<body>is feeling happy</body>"),
-            "body missing: {xml}"
+            xml.contains("is feeling happy"),
+            "Atom content missing: {xml}"
         );
         assert!(
             xml.contains("kind='mood'") || xml.contains("kind='mood'"),

--- a/server/crates/waddle-server/src/pubsub/node.rs
+++ b/server/crates/waddle-server/src/pubsub/node.rs
@@ -15,9 +15,9 @@ impl DatabasePubSubStorage {
             INSERT INTO pubsub_nodes (
                 owner_jid, node_name, access_model, publish_model, max_items,
                 persist_items, deliver_payloads, notify_retract, notify_delete,
-                send_last_published_item, created_at_ms
+                send_last_published_item, node_type, created_at_ms
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(owner_jid, node_name) DO NOTHING
             "#,
             crate::db_params![
@@ -31,6 +31,7 @@ impl DatabasePubSubStorage {
                 config.notify_retract,
                 config.notify_delete,
                 config.send_last_published_item.to_string(),
+                config.node_type.map(|node_type| node_type.to_string()),
                 node.created_at.timestamp_millis(),
             ],
         )
@@ -62,7 +63,7 @@ impl DatabasePubSubStorage {
                 r#"
                 SELECT owner_jid, node_name, access_model, publish_model, max_items,
                        persist_items, deliver_payloads, notify_retract, notify_delete,
-                       send_last_published_item, created_at_ms
+                       send_last_published_item, node_type, created_at_ms
                 FROM pubsub_nodes
                 WHERE owner_jid = ? AND node_name = ?
                 "#,
@@ -171,7 +172,7 @@ impl DatabasePubSubStorage {
                 r#"
                 SELECT n.owner_jid, n.node_name, n.access_model, n.publish_model, n.max_items,
                        n.persist_items, n.deliver_payloads, n.notify_retract, n.notify_delete,
-                       n.send_last_published_item, n.created_at_ms
+                       n.send_last_published_item, n.node_type, n.created_at_ms
                 FROM pubsub_nodes n
                 JOIN pubsub_items i
                   ON i.owner_jid = n.owner_jid AND i.node_name = n.node_name
@@ -243,7 +244,8 @@ impl DatabasePubSubStorage {
                     deliver_payloads = ?,
                     notify_retract = ?,
                     notify_delete = ?,
-                    send_last_published_item = ?
+                    send_last_published_item = ?,
+                    node_type = ?
                 WHERE owner_jid = ? AND node_name = ?
                 "#,
                 crate::db_params![
@@ -255,6 +257,7 @@ impl DatabasePubSubStorage {
                     config.notify_retract,
                     config.notify_delete,
                     config.send_last_published_item.to_string(),
+                    config.node_type.map(|node_type| node_type.to_string()),
                     owner.to_string(),
                     node_name,
                 ],
@@ -302,8 +305,16 @@ impl DatabasePubSubStorage {
         let send_last_raw: String = row
             .get(9)
             .map_err(|error| XmppError::internal(error.to_string()))?;
-        let created_at_ms: i64 = row
+        let node_type_raw: Option<String> = row
             .get(10)
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        let node_type = node_type_raw
+            .as_deref()
+            .map(str::parse)
+            .transpose()
+            .map_err(|_| XmppError::internal("invalid PubSub node_type".to_string()))?;
+        let created_at_ms: i64 = row
+            .get(11)
             .map_err(|error| XmppError::internal(error.to_string()))?;
         let created_at = chrono::DateTime::from_timestamp_millis(created_at_ms)
             .ok_or_else(|| XmppError::internal("invalid PubSub created_at_ms".to_string()))?;
@@ -314,6 +325,7 @@ impl DatabasePubSubStorage {
             config: NodeConfig {
                 access_model: access_model_raw.parse().unwrap_or_default(),
                 publish_model: publish_model_raw.parse().unwrap_or_default(),
+                node_type,
                 max_items: u32::try_from(max_items)
                     .map_err(|error| XmppError::internal(error.to_string()))?,
                 persist_items,

--- a/server/crates/waddle-server/src/pubsub/schema.rs
+++ b/server/crates/waddle-server/src/pubsub/schema.rs
@@ -19,7 +19,9 @@ use super::DatabasePubSubStorage;
 // v7 (#719): notification_settings_projection gains the
 // `rich_payload_opt_in` column (XEP-0492 `<advanced/>` rich-payload
 // opt-in). Version-gated drop-and-recreate carries the schema change.
-const PUBSUB_SCHEMA_VERSION: i64 = 7;
+// * v8 — pubsub_nodes gains nullable node_type for XEP-0060
+//   `pubsub#type` profile metadata (XEP-0472/XEP-0501).
+const PUBSUB_SCHEMA_VERSION: i64 = 8;
 
 impl DatabasePubSubStorage {
     pub(super) async fn initialize(&self) -> Result<(), XmppError> {
@@ -111,6 +113,7 @@ impl DatabasePubSubStorage {
                     node_name TEXT NOT NULL,
                     access_model TEXT NOT NULL,
                     publish_model TEXT NOT NULL,
+                    node_type TEXT,
                     max_items INTEGER NOT NULL,
                     persist_items INTEGER NOT NULL,
                     deliver_payloads INTEGER NOT NULL,
@@ -129,6 +132,7 @@ impl DatabasePubSubStorage {
                     node_name TEXT NOT NULL,
                     access_model TEXT NOT NULL,
                     publish_model TEXT NOT NULL,
+                    node_type TEXT,
                     max_items BIGINT NOT NULL,
                     persist_items INTEGER NOT NULL,
                     deliver_payloads INTEGER NOT NULL,

--- a/server/crates/waddle-server/src/pubsub/tests.rs
+++ b/server/crates/waddle-server/src/pubsub/tests.rs
@@ -19,9 +19,11 @@ fn dnd_payload() -> minidom::Element {
 }
 
 fn story_payload(body: &str) -> minidom::Element {
-    format!("<story xmlns='urn:xmpp:stories:0'><body>{body}</body></story>")
-        .parse()
-        .expect("valid story payload")
+    format!(
+        "<entry xmlns='http://www.w3.org/2005/Atom'><title type='text'>{body}</title><id>story-test</id><updated>2026-06-01T12:00:00Z</updated><content type='text'>{body}</content><link rel='enclosure' href='https://example.com/story-test.jpg' type='image/jpeg'/></entry>"
+    )
+    .parse()
+    .expect("valid story payload")
 }
 
 #[tokio::test]
@@ -104,6 +106,33 @@ async fn spaces_config_keeps_multiple_items() {
         .await
         .expect("items");
     assert_eq!(items.len(), 2);
+}
+
+#[tokio::test]
+async fn database_node_config_persists_pubsub_type() {
+    let storage = DatabasePubSubStorage::open(Some("sqlite::memory:"))
+        .await
+        .expect("storage");
+    let owner = jid("community.example.com");
+    let node = waddle_xmpp_core::xep0501::PUBSUB_NODE_STORIES;
+    storage
+        .get_or_create_node(&owner, node)
+        .await
+        .expect("node");
+    storage
+        .update_node_config(&owner, node, &NodeConfig::community_stories())
+        .await
+        .expect("config");
+
+    let stored = storage
+        .get_node(&owner, node)
+        .await
+        .expect("get node")
+        .expect("node exists");
+    assert_eq!(
+        stored.config.node_type,
+        Some(waddle_xmpp_core::pubsub::PubSubNodeType::PubsubSocialFeedStories)
+    );
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/disco_info/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/disco_info/muc.rs
@@ -356,6 +356,7 @@ pub(super) async fn handle_muc_disco_info<'a>(
         let mut features = muc_room_features(
             snapshot.config.persistent,
             snapshot.config.members_only,
+            snapshot.config.public_room,
             snapshot.config.moderated || channel_type == "announcement",
             snapshot.config.forum || channel_type == "forum",
         );
@@ -396,6 +397,7 @@ pub(super) async fn handle_muc_disco_info<'a>(
         let mut features = muc_room_features(
             true,
             channel.members_only,
+            channel.public_room,
             channel.channel_type == "announcement",
             channel.channel_type == "forum",
         );
@@ -430,7 +432,7 @@ pub(super) async fn handle_muc_disco_info<'a>(
         .map(|n| n.to_string())
         .unwrap_or_else(|| "Room".to_string());
     let identities = vec![Identity::muc_room(Some(&room_name))];
-    let mut features = muc_room_features(false, false, false, false);
+    let mut features = muc_room_features(false, false, true, false, false);
     features.extend(extension_features_for_disco(state));
     let response = build_disco_info_response(req.request_iq, &identities, &features, None);
     Some(DiscoInfoResponse::iq(response))

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_config.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_config.rs
@@ -18,6 +18,59 @@ fn data_form_bool(form: &Element, var: &str) -> Option<bool> {
     })
 }
 
+fn channel_type_from_config(config: &waddle_xmpp::muc::RoomConfig) -> waddle_xmpp::ChannelType {
+    if config.group_dm {
+        waddle_xmpp::ChannelType::GroupDm
+    } else if config.forum {
+        waddle_xmpp::ChannelType::Forum
+    } else if config.moderated {
+        waddle_xmpp::ChannelType::Announcement
+    } else {
+        waddle_xmpp::ChannelType::Text
+    }
+}
+
+pub(super) fn project_channel_type_to_config(
+    config: &mut waddle_xmpp::muc::RoomConfig,
+    channel_type: waddle_xmpp::ChannelType,
+) {
+    match channel_type {
+        waddle_xmpp::ChannelType::Text => {
+            config.group_dm = false;
+            config.forum = false;
+        }
+        waddle_xmpp::ChannelType::Announcement => {
+            config.group_dm = false;
+            config.forum = false;
+            config.moderated = true;
+        }
+        waddle_xmpp::ChannelType::Forum => {
+            config.group_dm = false;
+            config.forum = true;
+        }
+        waddle_xmpp::ChannelType::GroupDm => {
+            config.group_dm = true;
+            config.forum = false;
+        }
+    }
+}
+
+pub(super) async fn managed_channel_type_for_room(
+    state: &WebSocketState,
+    room_jid: &BareJid,
+) -> Result<Option<waddle_xmpp::ChannelType>, String> {
+    let Some(channel_id) = waddle_xmpp::parse_managed_room_jid(room_jid) else {
+        return Ok(None);
+    };
+    let actor = state.deps.app_state.db_pool.global_actor().clone();
+    get_xmpp_channel(actor, &channel_id)
+        .await
+        .map_err(|error| format!("channel lookup failed: {error}"))
+        .map(|channel| {
+            channel.and_then(|channel| waddle_xmpp::ChannelType::parse(&channel.channel_type))
+        })
+}
+
 pub(super) async fn apply_muc_owner_config(
     state: &WebSocketState,
     room_jid: &BareJid,
@@ -88,6 +141,10 @@ pub(super) async fn apply_muc_owner_config(
     config.persistent = true;
 
     let channel_id = waddle_xmpp::parse_managed_room_jid(room_jid);
+    let existing_channel_type = managed_channel_type_for_room(state, room_jid).await?;
+    if let Some(channel_type) = existing_channel_type {
+        project_channel_type_to_config(&mut config, channel_type);
+    }
     if let (Some(channel_id), Some(session)) = (channel_id.as_deref(), session) {
         write_tuple_if_absent(
             state,
@@ -143,17 +200,7 @@ pub(super) async fn apply_muc_owner_config(
 
     let now = chrono::Utc::now().to_rfc3339();
     let actor = state.deps.app_state.db_pool.global_actor().clone();
-    let existing_channel_type = get_xmpp_channel(actor.clone(), &channel_id)
-        .await
-        .map_err(|error| format!("channel lookup failed: {error}"))?
-        .map(|channel| channel.channel_type);
-    let channel_type = if config.forum {
-        "forum".to_string()
-    } else if config.moderated || existing_channel_type.as_deref() == Some("announcement") {
-        "announcement".to_string()
-    } else {
-        "text".to_string()
-    };
+    let channel_type = existing_channel_type.unwrap_or_else(|| channel_type_from_config(&config));
     if let Err(error) = actor
         .ask(DbExecute {
             sql: r#"
@@ -173,7 +220,7 @@ pub(super) async fn apply_muc_owner_config(
                 channel_id.clone().into(),
                 config.name.clone().into(),
                 config.description.clone().into(),
-                channel_type.into(),
+                channel_type.as_str().into(),
                 config.pin_permission.as_form_value().into(),
                 config.members_only.into(),
                 config.public_room.into(),
@@ -225,4 +272,40 @@ pub(super) async fn apply_muc_owner_config(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod channel_type_projection_tests {
+    use super::*;
+
+    #[test]
+    fn text_projection_preserves_xep_moderatedroom() {
+        let mut config = waddle_xmpp::muc::RoomConfig {
+            group_dm: true,
+            forum: true,
+            moderated: true,
+            ..waddle_xmpp::muc::RoomConfig::default()
+        };
+
+        project_channel_type_to_config(&mut config, waddle_xmpp::ChannelType::Text);
+
+        assert!(!config.group_dm);
+        assert!(!config.forum);
+        assert!(config.moderated);
+    }
+
+    #[test]
+    fn announcement_projection_forces_moderatedroom() {
+        let mut config = waddle_xmpp::muc::RoomConfig {
+            forum: true,
+            moderated: false,
+            ..waddle_xmpp::muc::RoomConfig::default()
+        };
+
+        project_channel_type_to_config(&mut config, waddle_xmpp::ChannelType::Announcement);
+
+        assert!(!config.group_dm);
+        assert!(!config.forum);
+        assert!(config.moderated);
+    }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_config.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_config.rs
@@ -149,7 +149,7 @@ pub(super) async fn apply_muc_owner_config(
         .map(|channel| channel.channel_type);
     let channel_type = if config.forum {
         "forum".to_string()
-    } else if existing_channel_type.as_deref() == Some("announcement") {
+    } else if config.moderated || existing_channel_type.as_deref() == Some("announcement") {
         "announcement".to_string()
     } else {
         "text".to_string()

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/permissions.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/permissions.rs
@@ -430,7 +430,13 @@ pub(super) async fn build_muc_owner_config_response(
         .ask(GetSnapshot)
         .await
         .map_err(|error| format!("snapshot failed: {error:?}"))?;
-    let form = build_config_form(&snapshot.room);
+    let mut room = snapshot.room;
+    if let Some(channel_type) =
+        super::muc_owner_config::managed_channel_type_for_room(state, room_jid).await?
+    {
+        super::muc_owner_config::project_channel_type_to_config(&mut room.config, channel_type);
+    }
+    let form = build_config_form(&room);
     let query = Element::builder("query", waddle_xmpp::muc::NS_MUC_OWNER)
         .append(form)
         .build();

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
@@ -344,12 +344,16 @@ async fn backfill_missing_space_bookmarks(
                 continue;
             }
         };
-        let channel_type = if config.forum { "forum" } else { "text" };
+        let Some(channel_type) =
+            channel_type_for_space_bookmark(state, &channel_id, &channel_jid, &config).await
+        else {
+            continue;
+        };
         let item = match waddle_xmpp::xep::build_channel_item(
             &waddle_xmpp::ChannelInfo {
                 id: channel_id.clone(),
                 name: config.name,
-                channel_type: channel_type.to_string(),
+                channel_type,
             },
             &state.deps.service_domains.muc,
         ) {
@@ -929,8 +933,8 @@ pub(super) async fn handle_spaces_publish(
 }
 
 /// Publish to a community pubsub node — XEP-0472 social feed at
-/// `urn:xmpp:pubsub-social-feed:0` or XEP-0501 stories at
-/// `urn:xmpp:stories:0`. Both live on `community.<domain>` (distinct
+/// `urn:xmpp:pubsub-social-feed:1` or XEP-0501 stories at
+/// `urn:xmpp:pubsub-social-feed:stories:0`. Both live on `community.<domain>` (distinct
 /// from the spaces service so the spaces enumeration only returns
 /// real spaces). Feed and stories are member-postable (gated by each
 /// node's pubsub publish-model); calendar event creation keeps the
@@ -1904,12 +1908,30 @@ async fn handle_community_non_bookmark_publish(
     };
 
     // Feed and stories are shared, open-publish nodes, so the service binds
-    // each item to its author: stamp the authenticated JID into payload
-    // `<author>` fields so a member cannot impersonate another. The storage
-    // write below atomically refuses cross-publisher item-id clobbering.
+    // each item to its author: stamp the authenticated JID into Atom author
+    // fields so a member cannot impersonate another. The storage write below
+    // atomically refuses cross-publisher item-id clobbering.
     // `publisher` is `Some` only for open member-postable community nodes.
     if let Some(entity) = publisher.as_ref() {
-        if node == waddle_xmpp_core::xep0501::PUBSUB_NODE_STORIES {
+        if node == waddle_xmpp_core::xep0472::PUBSUB_NODE_FEED {
+            let Some(payload) = item.payload.as_ref() else {
+                return vec![iq_to_xml(build_pubsub_error(
+                    iq,
+                    PubSubError::PayloadRequired,
+                ))];
+            };
+            let item_id = item.id.as_deref().unwrap_or_default();
+            if waddle_xmpp_core::xep0472::parse_feed_entry(item_id, payload).is_none() {
+                return vec![iq_to_xml(build_pubsub_error(
+                    iq,
+                    PubSubError::InvalidPayload,
+                ))];
+            }
+            item.payload = Some(waddle_xmpp_core::xep0472::stamp_feed_entry_author(
+                payload,
+                &entity.to_string(),
+            ));
+        } else if node == waddle_xmpp_core::xep0501::PUBSUB_NODE_STORIES {
             let Some(payload) = item.payload.as_ref() else {
                 return vec![iq_to_xml(build_pubsub_error(
                     iq,
@@ -1923,27 +1945,17 @@ async fn handle_community_non_bookmark_publish(
                     PubSubError::InvalidPayload,
                 ))];
             };
-            if story.body.is_none() && story.media_url.is_none() {
+            if story.media_url.is_none() {
                 return vec![iq_to_xml(build_pubsub_error(
                     iq,
                     PubSubError::InvalidPayload,
                 ))];
             }
-        }
-        if let Some(payload) = item.payload.as_ref() {
-            if waddle_xmpp_core::xep0472::is_feed_entry(payload) {
-                item.payload = Some(waddle_xmpp_core::xep0472::stamp_feed_entry_author(
-                    payload,
-                    &entity.to_string(),
-                ));
-            } else if waddle_xmpp_core::xep0501::is_story_element(payload) {
-                let item_id = item.id.as_deref().unwrap_or_default();
-                item.payload = waddle_xmpp_core::xep0501::stamp_story_author(
-                    item_id,
-                    payload,
-                    &entity.to_string(),
-                );
-            }
+            item.payload = waddle_xmpp_core::xep0501::stamp_story_author(
+                item_id,
+                payload,
+                &entity.to_string(),
+            );
         }
     }
 
@@ -2483,6 +2495,56 @@ pub(super) async fn room_space_metadata_extensions(
     }
 }
 
+async fn channel_type_for_space_bookmark(
+    state: &WebSocketState,
+    channel_id: &str,
+    channel_jid: &BareJid,
+    config: &waddle_xmpp::muc::RoomConfig,
+) -> Option<String> {
+    match get_xmpp_channel(
+        state.deps.app_state.db_pool.global_actor().clone(),
+        channel_id,
+    )
+    .await
+    {
+        Ok(existing) => Some(channel_type_from_catalog_or_room_config(
+            existing.as_ref().map(|row| row.channel_type.as_str()),
+            config,
+        )),
+        Err(error) => {
+            warn!(
+                channel = %channel_jid,
+                channel_id,
+                error = %error,
+                "Failed to load channel catalog type for Spaces bookmark backfill"
+            );
+            None
+        }
+    }
+}
+
+fn channel_type_from_catalog_or_room_config(
+    catalog_channel_type: Option<&str>,
+    config: &waddle_xmpp::muc::RoomConfig,
+) -> String {
+    catalog_channel_type
+        .and_then(waddle_xmpp::ChannelType::parse)
+        .map(|channel_type| channel_type.as_str().to_string())
+        .unwrap_or_else(|| channel_type_from_room_config(config).to_string())
+}
+
+fn channel_type_from_room_config(config: &waddle_xmpp::muc::RoomConfig) -> &'static str {
+    if config.group_dm {
+        waddle_xmpp::admin::CHANNEL_TYPE_GROUP_DM
+    } else if config.forum {
+        "forum"
+    } else if config.moderated {
+        "announcement"
+    } else {
+        "text"
+    }
+}
+
 #[cfg(test)]
 mod story_attachment_target_tests {
     use super::*;
@@ -2492,7 +2554,9 @@ mod story_attachment_target_tests {
 
     #[test]
     fn parses_only_canonical_story_attachment_target() {
-        let node = format!("{PREFIX}/xmpp:{COMMUNITY}?;node=urn%3Axmpp%3Astories%3A0;item=story-1");
+        let node = format!(
+            "{PREFIX}/xmpp:{COMMUNITY}?;node=urn%3Axmpp%3Apubsub-social-feed%3Astories%3A0;item=story-1"
+        );
 
         assert_eq!(
             parse_story_attachment_target(&node, COMMUNITY),
@@ -2504,20 +2568,51 @@ mod story_attachment_target_tests {
 
     #[test]
     fn rejects_lookalike_story_node_target() {
-        let node =
-            format!("{PREFIX}/xmpp:{COMMUNITY}?;node=urn%3Axmpp%3Astories%3A0evil;item=story-1");
+        let node = format!(
+            "{PREFIX}/xmpp:{COMMUNITY}?;node=urn%3Axmpp%3Apubsub-social-feed%3Astories%3A0evil;item=story-1"
+        );
 
         assert_eq!(parse_story_attachment_target(&node, COMMUNITY), None);
     }
 
     #[test]
     fn rejects_non_canonical_story_attachment_target() {
-        let wrong_host =
-            format!("{PREFIX}/xmpp:other.localhost?;node=urn%3Axmpp%3Astories%3A0;item=story-1");
-        let extra_param =
-            format!("{PREFIX}/xmpp:{COMMUNITY}?;node=urn%3Axmpp%3Astories%3A0;item=story-1;x=1");
+        let wrong_host = format!(
+            "{PREFIX}/xmpp:other.localhost?;node=urn%3Axmpp%3Apubsub-social-feed%3Astories%3A0;item=story-1"
+        );
+        let extra_param = format!(
+            "{PREFIX}/xmpp:{COMMUNITY}?;node=urn%3Axmpp%3Apubsub-social-feed%3Astories%3A0;item=story-1;x=1"
+        );
 
         assert_eq!(parse_story_attachment_target(&wrong_host, COMMUNITY), None);
         assert_eq!(parse_story_attachment_target(&extra_param, COMMUNITY), None);
+    }
+}
+
+#[cfg(test)]
+mod channel_type_projection_tests {
+    use super::*;
+
+    #[test]
+    fn channel_type_from_room_config_preserves_announcement() {
+        let config = waddle_xmpp::muc::RoomConfig {
+            moderated: true,
+            ..waddle_xmpp::muc::RoomConfig::default()
+        };
+
+        assert_eq!(channel_type_from_room_config(&config), "announcement");
+    }
+
+    #[test]
+    fn catalog_channel_type_takes_precedence_over_room_config() {
+        let config = waddle_xmpp::muc::RoomConfig {
+            moderated: false,
+            ..waddle_xmpp::muc::RoomConfig::default()
+        };
+
+        assert_eq!(
+            channel_type_from_catalog_or_room_config(Some("announcement"), &config),
+            "announcement"
+        );
     }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc/access.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc/access.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::permissions::{DeleteTuple, PermissionError, Relation, SubjectType, Tuple, WriteTuple};
+use crate::permissions::{
+    DeleteTuple, ListRelations, PermissionError, Relation, SubjectType, Tuple, WriteTuple,
+};
 
 pub(super) async fn resolve_managed_channel_affiliation(
     state: &WebSocketState,
@@ -10,28 +12,13 @@ pub(super) async fn resolve_managed_channel_affiliation(
 ) -> Result<Option<Affiliation>, ()> {
     let object = Object::new(ObjectType::Channel, channel_id);
     let subject = Subject::user(&session.user_jid);
-    if check_channel_permission(
-        state,
-        object.clone(),
-        subject.clone(),
-        Permission::Custom("outcast".into()),
-    )
-    .await?
+    if let Some(affiliation) =
+        direct_channel_affiliation(state, object.clone(), subject.clone()).await?
     {
-        return Ok(Some(Affiliation::Outcast));
+        return Ok(Some(affiliation));
     }
 
-    for (permission, affiliation) in [
-        (Permission::Owner, Affiliation::Owner),
-        (Permission::Admin, Affiliation::Admin),
-        (Permission::Member, Affiliation::Member),
-    ] {
-        if check_channel_permission(state, object.clone(), subject.clone(), permission).await? {
-            return Ok(Some(affiliation));
-        }
-    }
-
-    if !members_only && matches!(channel_id, "chat" | "announcements" | "github-actions") {
+    if !members_only {
         let server = Object::new(ObjectType::Server, DEPLOYMENT_SERVER_ID);
         if check_channel_permission(state, server.clone(), subject.clone(), Permission::Owner)
             .await?
@@ -44,7 +31,7 @@ pub(super) async fn resolve_managed_channel_affiliation(
             return Ok(Some(Affiliation::Admin));
         }
         if check_channel_permission(state, server, subject.clone(), Permission::Member).await? {
-            return Ok(Some(Affiliation::Member));
+            return Ok(Some(Affiliation::None));
         }
     }
 
@@ -57,6 +44,35 @@ pub(super) async fn resolve_managed_channel_affiliation(
         return Ok(read_access_affiliation(members_only));
     }
     Ok(None)
+}
+
+async fn direct_channel_affiliation(
+    state: &WebSocketState,
+    object: Object,
+    subject: Subject,
+) -> Result<Option<Affiliation>, ()> {
+    let relations = state
+        .deps
+        .app_state
+        .permission_actor
+        .ask(ListRelations { subject, object })
+        .await
+        .map_err(|error| {
+            warn!(error = ?error, "Failed to load direct managed MUC affiliation relations");
+        })?;
+
+    let affiliation = ["outcast", "owner", "admin", "member"]
+        .into_iter()
+        .find(|relation| relations.iter().any(|actual| actual.name == *relation))
+        .and_then(|relation| match relation {
+            "outcast" => Some(Affiliation::Outcast),
+            "owner" => Some(Affiliation::Owner),
+            "admin" => Some(Affiliation::Admin),
+            "member" => Some(Affiliation::Member),
+            _ => None,
+        });
+
+    Ok(affiliation)
 }
 
 fn read_access_affiliation(members_only: bool) -> Option<Affiliation> {

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -320,6 +320,77 @@ async fn managed_members_only_join_requires_explicit_channel_member_affiliation(
 }
 
 #[tokio::test]
+async fn managed_public_channel_allows_deployment_member_without_channel_tuple() {
+    let state = create_test_websocket_state().await;
+    let session = create_test_session(state.as_ref(), "alice").await;
+    let room_jid: BareJid = "project@muc.example.com".parse().expect("room jid");
+    let sender_jid: FullJid = "alice@example.com/web".parse().expect("sender jid");
+
+    crate::server::xmpp_state::upsert_xmpp_channel(
+        state.deps.app_state.db_pool.global_actor().clone(),
+        &crate::server::xmpp_state::XmppChannelUpsert {
+            id: "project".to_string(),
+            name: "Project".to_string(),
+            description: None,
+            channel_type: "text".to_string(),
+            position: 0,
+            is_default: false,
+            pin_permission: waddle_xmpp::muc::PinPermission::Anyone,
+            members_only: false,
+            public_room: true,
+        },
+    )
+    .await
+    .expect("channel upsert");
+    state
+        .deps
+        .app_state
+        .permission_actor
+        .ask(WriteTuple {
+            tuple: Tuple::new(
+                Object::new(ObjectType::Server, DEPLOYMENT_SERVER_ID),
+                Relation::new("member"),
+                Subject::user(&session.user_jid),
+            ),
+        })
+        .await
+        .expect("server member tuple");
+
+    let responses = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &sender_jid,
+        "alice",
+        None,
+        &Some(session),
+    )
+    .await;
+
+    let presence =
+        Element::from_str(responses.first().expect("self-presence")).expect("presence XML");
+    assert_eq!(presence.name(), "presence");
+    assert_ne!(
+        presence.attr("type"),
+        Some("error"),
+        "public/open managed channel must admit deployment members: {responses:?}"
+    );
+    let user_x = presence
+        .get_child("x", "http://jabber.org/protocol/muc#user")
+        .expect("muc user payload");
+    let item = user_x
+        .get_child("item", "http://jabber.org/protocol/muc#user")
+        .expect("muc user item");
+    assert_eq!(item.attr("affiliation"), Some("none"));
+    assert!(
+        user_x
+            .children()
+            .any(|child| child.name() == "status" && child.attr("code") == Some("110")),
+        "successful join must complete with XEP-0045 self-presence 110: {responses:?}"
+    );
+}
+
+#[tokio::test]
 async fn managed_join_uses_live_actor_members_only_config_over_stale_channel_row() {
     let state = create_test_websocket_state().await;
     let session = create_test_session(state.as_ref(), "bob").await;
@@ -2000,7 +2071,7 @@ async fn active_room_disco_preserves_managed_announcement_channel_type() {
         .await
         .expect("persistent connection");
     conn.execute(
-            "INSERT INTO channels (id, name, description, channel_type, position, is_default) VALUES (?, ?, ?, 'announcement', 0, 0)",
+            "INSERT INTO channels (id, name, description, channel_type, position, is_default, members_only, public_room) VALUES (?, ?, ?, 'announcement', 0, 0, 0, 1)",
             crate::db_params!["announcements", "Announcements", "Owner-posted announcements"],
         )
         .await
@@ -2034,6 +2105,12 @@ async fn active_room_disco_preserves_managed_announcement_channel_type() {
     .await;
     let response = responses.first().expect("room disco response");
     assert!(response.contains("muc_moderated"), "response: {response}");
+    assert!(response.contains("muc_open"), "response: {response}");
+    assert!(
+        !response.contains("muc_membersonly"),
+        "response: {response}"
+    );
+    assert!(response.contains("muc_public"), "response: {response}");
     assert!(
         response.contains("waddle#channel_type"),
         "response: {response}"

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -2123,6 +2123,199 @@ async fn active_room_disco_preserves_managed_announcement_channel_type() {
 }
 
 #[tokio::test]
+async fn muc_owner_config_cannot_unmoderate_managed_announcement_channel() {
+    let state = create_test_websocket_state().await;
+    let alice_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let bob_session = create_test_session(state.as_ref(), "bob").await;
+    let conn = state
+        .deps
+        .app_state
+        .db_pool
+        .global()
+        .guard()
+        .await
+        .expect("persistent connection");
+    conn.execute(
+        "INSERT INTO channels (id, name, description, channel_type, position, is_default, members_only, public_room) VALUES (?, ?, ?, 'announcement', 0, 0, 0, 1)",
+        crate::db_params![
+            "ops-announcements",
+            "Ops Announcements",
+            "Owner-posted operational updates"
+        ],
+    )
+    .await
+    .expect("insert announcement channel");
+    drop(conn);
+
+    let room_jid: BareJid = "ops-announcements@muc.example.com"
+        .parse()
+        .expect("room jid");
+    let alice_jid: FullJid = format!("{}@example.com/web", alice_session.xmpp_localpart)
+        .parse()
+        .expect("alice jid");
+    let bob_jid: FullJid = format!("{}@example.com/web", bob_session.xmpp_localpart)
+        .parse()
+        .expect("bob jid");
+    handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &alice_jid,
+        "alice",
+        None,
+        &Some(alice_session.clone()),
+    )
+    .await;
+
+    let submit_form = Element::builder("x", waddle_xmpp::muc::DATA_FORMS_NS)
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "submit")
+        .append(
+            Element::builder("field", waddle_xmpp::muc::DATA_FORMS_NS)
+                .attr(
+                    minidom::rxml::xml_ncname!("var").to_owned(),
+                    "muc#roomconfig_moderatedroom",
+                )
+                .append(
+                    Element::builder("value", waddle_xmpp::muc::DATA_FORMS_NS)
+                        .append("0")
+                        .build(),
+                )
+                .build(),
+        )
+        .build();
+    let owner_set = element_to_xml(
+        Element::builder("iq", waddle_xmpp::ns::JABBER_CLIENT)
+            .attr(
+                minidom::rxml::xml_ncname!("id").to_owned(),
+                "announcement-owner-submit",
+            )
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "set")
+            .attr(
+                minidom::rxml::xml_ncname!("to").to_owned(),
+                room_jid.to_string(),
+            )
+            .append(
+                Element::builder("query", waddle_xmpp::muc::NS_MUC_OWNER)
+                    .append(submit_form)
+                    .build(),
+            )
+            .build(),
+    );
+
+    let responses = handle_iq(
+        &owner_set,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(alice_session.clone()),
+        &ready_phase(&alice_jid),
+    )
+    .await;
+    assert_eq!(responses.len(), 1, "owner config response: {responses:?}");
+    assert!(responses[0].contains("type='result'"));
+
+    let snapshot = get_room_actor(state.as_ref(), &room_jid)
+        .await
+        .expect("room actor")
+        .ask(GetSnapshot)
+        .await
+        .expect("snapshot")
+        .room;
+    assert!(
+        snapshot.config.moderated,
+        "announcement owner config must keep the live room moderated"
+    );
+    assert!(
+        !snapshot.config.forum,
+        "announcement owner config must not drift into forum mode"
+    );
+
+    let owner_get = element_to_xml(
+        Element::builder("iq", waddle_xmpp::ns::JABBER_CLIENT)
+            .attr(
+                minidom::rxml::xml_ncname!("id").to_owned(),
+                "announcement-owner-get",
+            )
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "get")
+            .attr(
+                minidom::rxml::xml_ncname!("to").to_owned(),
+                room_jid.to_string(),
+            )
+            .append(Element::builder("query", waddle_xmpp::muc::NS_MUC_OWNER).build())
+            .build(),
+    );
+    let responses = handle_iq(
+        &owner_get,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(alice_session),
+        &ready_phase(&alice_jid),
+    )
+    .await;
+    assert_eq!(responses.len(), 1, "owner get response: {responses:?}");
+    let response =
+        Element::from_str(responses.first().expect("owner get response")).expect("owner get XML");
+    let form = response
+        .get_child("query", waddle_xmpp::muc::NS_MUC_OWNER)
+        .and_then(|query| query.get_child("x", waddle_xmpp::muc::DATA_FORMS_NS))
+        .expect("owner config form");
+    let moderated_field = form
+        .children()
+        .find(|field| {
+            field.name() == "field"
+                && field.ns() == waddle_xmpp::muc::DATA_FORMS_NS
+                && field.attr("var") == Some("muc#roomconfig_moderatedroom")
+        })
+        .expect("moderated field");
+    let moderated_value = moderated_field
+        .get_child("value", waddle_xmpp::muc::DATA_FORMS_NS)
+        .map(|value| value.texts().collect::<String>())
+        .expect("moderated value");
+    assert_eq!(
+        moderated_value, "1",
+        "owner config GET must project managed announcements as moderated"
+    );
+
+    handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &bob_jid,
+        "bob",
+        None,
+        &Some(bob_session.clone()),
+    )
+    .await;
+    let bob = snapshot_room(state.as_ref(), &room_jid)
+        .await
+        .room
+        .get_occupant("bob")
+        .expect("bob occupant")
+        .clone();
+    assert_eq!(bob.role, waddle_xmpp::Role::Visitor);
+
+    let message = format!(
+        "<message xmlns='jabber:client' to='{room_jid}' type='groupchat' id='bob-announcement-post'>\
+            <body>not an owner</body>\
+        </message>"
+    );
+    let responses = handle_message_for_test(
+        state.as_ref(),
+        &bob_jid,
+        Some(&bob_session),
+        parse_message_for_test(&message),
+    )
+    .await;
+    assert_eq!(responses.len(), 1, "message response: {responses:?}");
+    assert!(
+        responses[0].contains("type='error'") && responses[0].contains("forbidden"),
+        "announcement visitor post must be rejected: {}",
+        responses[0]
+    );
+}
+
+#[tokio::test]
 async fn managed_space_bookmark_join_repairs_missing_parent_tuple() {
     let state = create_test_websocket_state().await;
     let conn = state

--- a/server/crates/waddle-server/src/server/topology.rs
+++ b/server/crates/waddle-server/src/server/topology.rs
@@ -23,6 +23,8 @@ struct ManagedChannelSeed {
     position: i64,
     is_default: i64,
     channel_type: &'static str,
+    members_only: bool,
+    public_room: bool,
 }
 
 const INITIAL_MANAGED_CHANNELS: &[ManagedChannelSeed] = &[
@@ -33,6 +35,8 @@ const INITIAL_MANAGED_CHANNELS: &[ManagedChannelSeed] = &[
         position: 0,
         is_default: 1,
         channel_type: "text",
+        members_only: false,
+        public_room: true,
     },
     ManagedChannelSeed {
         id: "announcements",
@@ -41,6 +45,8 @@ const INITIAL_MANAGED_CHANNELS: &[ManagedChannelSeed] = &[
         position: 1,
         is_default: 0,
         channel_type: "announcement",
+        members_only: false,
+        public_room: true,
     },
     ManagedChannelSeed {
         id: "github-actions",
@@ -49,6 +55,8 @@ const INITIAL_MANAGED_CHANNELS: &[ManagedChannelSeed] = &[
         position: 2,
         is_default: 0,
         channel_type: "text",
+        members_only: false,
+        public_room: true,
     },
 ];
 
@@ -92,9 +100,16 @@ async fn seed_initial_xmpp_topology(
         actor
             .ask(DbExecute {
                 sql: r#"
-                    INSERT INTO channels (id, name, description, channel_type, position, is_default, created_at, updated_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                    ON CONFLICT(id) DO NOTHING
+                    INSERT INTO channels (
+                        id, name, description, channel_type, position, is_default,
+                        members_only, public_room, created_at, updated_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(id) DO UPDATE SET
+                        channel_type = excluded.channel_type,
+                        members_only = excluded.members_only,
+                        public_room = excluded.public_room,
+                        updated_at = excluded.updated_at
                 "#
                 .to_string(),
                 params: vec![
@@ -104,6 +119,8 @@ async fn seed_initial_xmpp_topology(
                     channel.channel_type.into(),
                     channel.position.into(),
                     channel.is_default.into(),
+                    channel.members_only.into(),
+                    channel.public_room.into(),
                     now.clone().into(),
                     now.clone().into(),
                 ],
@@ -359,5 +376,21 @@ mod tests {
 
         assert_eq!(channel.name, "GitHub Actions");
         assert_eq!(room_jid.to_string(), "github-actions@muc.waddle.social");
+    }
+
+    #[test]
+    fn initial_managed_channels_are_public_and_open() {
+        for channel in INITIAL_MANAGED_CHANNELS {
+            assert!(
+                !channel.members_only,
+                "seeded channel {} must be open",
+                channel.id
+            );
+            assert!(
+                channel.public_room,
+                "seeded channel {} must be public",
+                channel.id
+            );
+        }
     }
 }

--- a/server/crates/waddle-server/tests/group_dm_ws.rs
+++ b/server/crates/waddle-server/tests/group_dm_ws.rs
@@ -687,6 +687,10 @@ async fn group_dm_create_provisions_hidden_members_only_room_with_disco_feature(
         !disco.contains("muc_public"),
         "group DM room must stay hidden from public room discovery: {disco}"
     );
+    assert!(
+        disco.contains("muc_hidden"),
+        "group DM room must advertise hidden discovery status: {disco}"
+    );
 
     let _ = alice.close().await;
     drop(server);
@@ -704,6 +708,10 @@ async fn group_dm_create_provisions_hidden_members_only_room_with_disco_feature(
     assert!(
         disco.contains("muc_membersonly"),
         "restarted group DM room must stay members-only: {disco}"
+    );
+    assert!(
+        disco.contains("muc_hidden"),
+        "restarted group DM room must advertise hidden discovery status: {disco}"
     );
     let not_joined_rename = rename_group_dm(
         &mut alice,

--- a/server/crates/waddle-server/tests/pep_feed_bridge_ws.rs
+++ b/server/crates/waddle-server/tests/pep_feed_bridge_ws.rs
@@ -12,7 +12,7 @@ use ws_common::{TestServer, WsXmppClient};
 const DOMAIN: &str = "localhost";
 const USERNAME: &str = "admin";
 const COMMUNITY_JID: &str = "community.localhost";
-const FEED_NODE: &str = "urn:xmpp:pubsub-social-feed:0";
+const FEED_NODE: &str = "urn:xmpp:pubsub-social-feed:1";
 
 static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
 
@@ -78,11 +78,11 @@ async fn pep_mood_publish_emits_typed_feed_entry() {
         .expect("items response");
 
     assert!(
-        items_response.contains("<author>admin@localhost</author>"),
-        "bridged entry must carry author bare JID: {items_response}"
+        items_response.contains("xmpp:admin@localhost"),
+        "bridged entry must carry author URI: {items_response}"
     );
     assert!(
-        items_response.contains("<body>is feeling happy</body>"),
+        items_response.contains("is feeling happy"),
         "bridged entry must carry the rendered summary: {items_response}"
     );
     assert!(

--- a/server/crates/waddle-server/tests/proto_calendar_rsvp_ws.rs
+++ b/server/crates/waddle-server/tests/proto_calendar_rsvp_ws.rs
@@ -14,7 +14,7 @@ const DOMAIN: &str = "localhost";
 const ADMIN: &str = "admin";
 const COMMUNITY_JID: &str = "community.localhost";
 const EVENTS_NODE: &str = "urn:xmpp:calendar:0";
-const FEED_NODE: &str = "urn:xmpp:pubsub-social-feed:0";
+const FEED_NODE: &str = "urn:xmpp:pubsub-social-feed:1";
 const NS_XCAL: &str = "urn:ietf:params:xml:ns:xcal";
 
 static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
@@ -336,7 +336,7 @@ async fn rsvp_publish_bridges_to_social_feed() {
         .expect("feed response");
 
     assert!(
-        feed_response.contains("<author>bob@localhost</author>"),
+        feed_response.contains("<author><uri>xmpp:bob@localhost</uri></author>"),
         "feed entry must carry bob's bare JID: {feed_response}"
     );
     assert!(

--- a/server/crates/waddle-server/tests/xep0470_story_reactions_ws.rs
+++ b/server/crates/waddle-server/tests/xep0470_story_reactions_ws.rs
@@ -11,13 +11,15 @@ use ws_common::{TestServer, WsXmppClient};
 
 const DOMAIN: &str = "localhost";
 const COMMUNITY_JID: &str = "community.localhost";
-const STORIES_NODE: &str = "urn:xmpp:stories:0";
+const STORIES_NODE: &str = "urn:xmpp:pubsub-social-feed:stories:0";
 const NS_PUBSUB: &str = "http://jabber.org/protocol/pubsub";
 const NS_PUBSUB_EVENT: &str = "http://jabber.org/protocol/pubsub#event";
-const NS_STORIES: &str = "urn:xmpp:stories:0";
+const NS_ATOM: &str = "http://www.w3.org/2005/Atom";
+const NS_WADDLE_STORIES: &str = "urn:waddle:stories:0";
 const NS_ATTACHMENTS: &str = "urn:xmpp:pubsub-attachments:1";
 const NS_ATTACHMENTS_SUMMARY: &str = "urn:xmpp:pubsub-attachments:summary:1";
-const STORY_SUMMARY_NODE: &str = "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:stories:0";
+const STORY_SUMMARY_NODE: &str =
+    "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:pubsub-social-feed:stories:0";
 
 static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
 
@@ -54,7 +56,28 @@ async fn iq_get_to(client: &mut WsXmppClient, id: &str, to: &str, body: &str) ->
 
 fn story_attachment_node(story_id: &str) -> String {
     format!(
-        "{NS_ATTACHMENTS}/xmpp:community.localhost?;node=urn%3Axmpp%3Astories%3A0;item={story_id}"
+        "{NS_ATTACHMENTS}/xmpp:community.localhost?;node=urn%3Axmpp%3Apubsub-social-feed%3Astories%3A0;item={story_id}"
+    )
+}
+
+fn story_publish_body(item_id: &str, body: &str, author: &str) -> String {
+    format!(
+        r#"<pubsub xmlns="{NS_PUBSUB}">
+          <publish node="{STORIES_NODE}">
+            <item id="{item_id}">
+              <entry xmlns="{NS_ATOM}">
+                <title type="text">{body}</title>
+                <id>{item_id}</id>
+                <published>2026-06-01T12:00:00Z</published>
+                <updated>2026-06-01T12:00:00Z</updated>
+                <content type="text">{body}</content>
+                <author><uri>xmpp:{author}</uri></author>
+                <link rel="enclosure" href="https://example.com/{item_id}.jpg" type="image/jpeg"/>
+                <expires xmlns="{NS_WADDLE_STORIES}">2030-01-01T12:00:00Z</expires>
+              </entry>
+            </item>
+          </publish>
+        </pubsub>"#
     )
 }
 
@@ -114,18 +137,7 @@ async fn member_can_publish_read_and_retract_story_reaction_attachment() {
         &mut admin,
         "owner-story",
         COMMUNITY_JID,
-        &format!(
-            r#"<pubsub xmlns="{NS_PUBSUB}">
-              <publish node="{STORIES_NODE}">
-                <item id="{story_id}">
-                  <story xmlns="{NS_STORIES}" expires="2030-01-01T12:00:00Z">
-                    <body>story with reactions</body>
-                    <author>admin@localhost</author>
-                  </story>
-                </item>
-              </publish>
-            </pubsub>"#
-        ),
+        &story_publish_body(&story_id, "story with reactions", "admin@localhost"),
     )
     .await;
     assert!(
@@ -151,17 +163,10 @@ async fn member_can_publish_read_and_retract_story_reaction_attachment() {
         &mut alice,
         "member-story",
         COMMUNITY_JID,
-        &format!(
-            r#"<pubsub xmlns="{NS_PUBSUB}">
-              <publish node="{STORIES_NODE}">
-                <item id="member-{story_id}">
-                  <story xmlns="{NS_STORIES}" expires="2030-01-01T12:00:00Z">
-                    <body>member story</body>
-                    <author>spoofed@localhost</author>
-                  </story>
-                </item>
-              </publish>
-            </pubsub>"#
+        &story_publish_body(
+            &format!("member-{story_id}"),
+            "member story",
+            "spoofed@localhost",
         ),
     )
     .await;
@@ -341,7 +346,7 @@ async fn member_can_publish_read_and_retract_story_reaction_attachment() {
     );
 
     let crafted_node = format!(
-        "{NS_ATTACHMENTS}/xmpp:community.localhost?;node=urn%3Axmpp%3Astories%3A0evil;item={story_id}"
+        "{NS_ATTACHMENTS}/xmpp:community.localhost?;node=urn%3Axmpp%3Apubsub-social-feed%3Astories%3A0evil;item={story_id}"
     );
     let crafted_publish = iq_set_to(
         &mut alice,
@@ -366,7 +371,7 @@ async fn member_can_publish_read_and_retract_story_reaction_attachment() {
     );
 
     let wrong_host_node = format!(
-        "{NS_ATTACHMENTS}/xmpp:other.localhost?;node=urn%3Axmpp%3Astories%3A0;item={story_id}"
+        "{NS_ATTACHMENTS}/xmpp:other.localhost?;node=urn%3Axmpp%3Apubsub-social-feed%3Astories%3A0;item={story_id}"
     );
     let wrong_host_publish = iq_set_to(
         &mut alice,
@@ -391,7 +396,7 @@ async fn member_can_publish_read_and_retract_story_reaction_attachment() {
     );
 
     let extra_param_node = format!(
-        "{NS_ATTACHMENTS}/xmpp:community.localhost?;node=urn%3Axmpp%3Astories%3A0;item={story_id};foo=bar"
+        "{NS_ATTACHMENTS}/xmpp:community.localhost?;node=urn%3Axmpp%3Apubsub-social-feed%3Astories%3A0;item={story_id};foo=bar"
     );
     let extra_param_publish = iq_set_to(
         &mut alice,
@@ -573,18 +578,7 @@ async fn retracting_story_removes_attachment_node_and_summary_item() {
         &mut admin,
         "cleanup-story",
         COMMUNITY_JID,
-        &format!(
-            r#"<pubsub xmlns="{NS_PUBSUB}">
-              <publish node="{STORIES_NODE}">
-                <item id="{story_id}">
-                  <story xmlns="{NS_STORIES}" expires="2030-01-01T12:00:00Z">
-                    <body>story that will be removed</body>
-                    <author>admin@localhost</author>
-                  </story>
-                </item>
-              </publish>
-            </pubsub>"#
-        ),
+        &story_publish_body(&story_id, "story that will be removed", "admin@localhost"),
     )
     .await;
     assert!(
@@ -797,17 +791,10 @@ async fn retracting_story_without_summary_item_does_not_fan_out_summary_retract(
         &mut admin,
         "no-summary-seed-story",
         COMMUNITY_JID,
-        &format!(
-            r#"<pubsub xmlns="{NS_PUBSUB}">
-              <publish node="{STORIES_NODE}">
-                <item id="{seeded_story_id}">
-                  <story xmlns="{NS_STORIES}" expires="2030-01-01T12:00:00Z">
-                    <body>story that seeds summary node</body>
-                    <author>admin@localhost</author>
-                  </story>
-                </item>
-              </publish>
-            </pubsub>"#
+        &story_publish_body(
+            &seeded_story_id,
+            "story that seeds summary node",
+            "admin@localhost",
         ),
     )
     .await;
@@ -857,18 +844,7 @@ async fn retracting_story_without_summary_item_does_not_fan_out_summary_retract(
         &mut admin,
         "no-summary-story",
         COMMUNITY_JID,
-        &format!(
-            r#"<pubsub xmlns="{NS_PUBSUB}">
-              <publish node="{STORIES_NODE}">
-                <item id="{story_id}">
-                  <story xmlns="{NS_STORIES}" expires="2030-01-01T12:00:00Z">
-                    <body>story with no reactions</body>
-                    <author>admin@localhost</author>
-                  </story>
-                </item>
-              </publish>
-            </pubsub>"#
-        ),
+        &story_publish_body(&story_id, "story with no reactions", "admin@localhost"),
     )
     .await;
     assert!(

--- a/server/crates/waddle-server/tests/xep0472_social_feed_ws.rs
+++ b/server/crates/waddle-server/tests/xep0472_social_feed_ws.rs
@@ -1,7 +1,7 @@
 //! XEP-0472 Pubsub Social Feed integration tests over WebSocket.
 //!
 //! Verifies the server-side bootstrap: the spaces service hosts the
-//! global `urn:xmpp:pubsub-social-feed:0` node, advertises the
+//! global `urn:xmpp:pubsub-social-feed:1` node, advertises the
 //! namespace on disco#info, and accepts publish + items-query for
 //! `<entry/>` payloads built per XEP-0472 §3.
 
@@ -17,8 +17,9 @@ const MEMBER_PASSWORD: &str = "xep0472-member-password";
 const MEMBER2_USERNAME: &str = "member2";
 const MEMBER2_PASSWORD: &str = "xep0472-member2-password";
 const COMMUNITY_JID: &str = "community.localhost";
-const FEED_NODE: &str = "urn:xmpp:pubsub-social-feed:0";
-const NS_SOCIAL_FEED: &str = "urn:xmpp:pubsub-social-feed:0";
+const FEED_NODE: &str = "urn:xmpp:pubsub-social-feed:1";
+const NS_SOCIAL_FEED: &str = "urn:xmpp:pubsub-social-feed:1";
+const NS_ATOM: &str = "http://www.w3.org/2005/Atom";
 
 static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
 
@@ -50,6 +51,19 @@ async fn setup_member() -> (TestServer, WsXmppClient) {
     .await
     .expect("connect and auth as member");
     (server, client)
+}
+
+fn feed_entry_xml(item_id: &str, title: &str, body: &str, author: &str) -> String {
+    format!(
+        r#"<entry xmlns="{NS_ATOM}">
+          <title type="text">{title}</title>
+          <id>tag:localhost,2026:{item_id}</id>
+          <published>2026-06-17T12:00:00Z</published>
+          <updated>2026-06-17T12:00:00Z</updated>
+          <content type="text">{body}</content>
+          <author><uri>xmpp:{author}</uri></author>
+        </entry>"#
+    )
 }
 
 #[tokio::test]
@@ -93,16 +107,17 @@ async fn social_feed_publish_and_items_round_trip() {
               <pubsub xmlns="http://jabber.org/protocol/pubsub">
                 <publish node="{FEED_NODE}">
                   <item id="{post_id}">
-                    <entry xmlns="{NS_SOCIAL_FEED}">
-                      <title>Launch day</title>
-                      <body>The community feed is live!</body>
-                      <author>admin@localhost</author>
-                      <published>2026-05-16T12:00:00Z</published>
-                    </entry>
+                    {}
                   </item>
                 </publish>
               </pubsub>
-            </iq>"#
+            </iq>"#,
+            feed_entry_xml(
+                &post_id,
+                "Launch day",
+                "The community feed is live!",
+                "admin@localhost",
+            )
         ))
         .await
         .expect("send publish");
@@ -166,16 +181,17 @@ async fn member_can_publish_to_social_feed() {
               <pubsub xmlns="http://jabber.org/protocol/pubsub">
                 <publish node="{FEED_NODE}">
                   <item id="{post_id}" publisher="admin@{DOMAIN}">
-                    <entry xmlns="{NS_SOCIAL_FEED}">
-                      <title>Hello from a member</title>
-                      <body>Members can post to the feed now.</body>
-                      <author>admin@{DOMAIN}</author>
-                      <published>2026-06-17T12:00:00Z</published>
-                    </entry>
+                    {}
                   </item>
                 </publish>
               </pubsub>
-            </iq>"#
+            </iq>"#,
+            feed_entry_xml(
+                &post_id,
+                "Hello from a member",
+                "Members can post to the feed now.",
+                &format!("admin@{DOMAIN}"),
+            )
         ))
         .await
         .expect("send publish");
@@ -213,12 +229,92 @@ async fn member_can_publish_to_social_feed() {
         "feed item must be stamped with the server-derived publisher: {items_response}"
     );
     assert!(
-        items_response.contains(&format!(">{MEMBER_USERNAME}@{DOMAIN}<")),
-        "feed entry author must be stamped with the authenticated JID: {items_response}"
+        items_response.contains(&format!("xmpp:{MEMBER_USERNAME}@{DOMAIN}")),
+        "feed entry author URI must be stamped with the authenticated JID: {items_response}"
     );
     assert!(
         !items_response.contains(&format!("admin@{DOMAIN}")),
         "spoofed publisher AND author must be overridden by the server: {items_response}"
+    );
+
+    let _ = client.close().await;
+}
+
+#[tokio::test]
+async fn member_feed_publish_requires_atom_payload() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup_member().await;
+
+    client
+        .send(&format!(
+            r#"<iq type="set" id="feed-missing-payload" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <publish node="{FEED_NODE}"><item id="missing-feed-payload"/></publish>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send missing payload publish");
+    let missing_payload = client
+        .recv_matching(|frame| frame.contains("feed-missing-payload"))
+        .await
+        .expect("missing payload response");
+    assert!(
+        missing_payload.contains("type='error'") && missing_payload.contains("payload-required"),
+        "feed publish without Atom entry must be payload-required: {missing_payload}"
+    );
+
+    client
+        .send(&format!(
+            r#"<iq type="set" id="feed-invalid-payload" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <publish node="{FEED_NODE}">
+                  <item id="invalid-feed-payload">
+                    <entry xmlns="{NS_ATOM}">
+                      <id>invalid-feed-payload</id>
+                      <updated>2026-06-17T12:00:00Z</updated>
+                      <content type="text">missing title</content>
+                    </entry>
+                  </item>
+                </publish>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send invalid payload publish");
+    let invalid_payload = client
+        .recv_matching(|frame| frame.contains("feed-invalid-payload"))
+        .await
+        .expect("invalid payload response");
+    assert!(
+        invalid_payload.contains("type='error'") && invalid_payload.contains("invalid-payload"),
+        "feed publish with malformed Atom entry must be invalid-payload: {invalid_payload}"
+    );
+
+    client
+        .send(&format!(
+            r#"<iq type="set" id="feed-invalid-atom-updated" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <publish node="{FEED_NODE}">
+                  <item id="invalid-feed-updated">
+                    <entry xmlns="{NS_ATOM}">
+                      <title type="text">missing updated</title>
+                      <id>invalid-feed-updated</id>
+                    </entry>
+                  </item>
+                </publish>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send invalid Atom publish");
+    let invalid_atom = client
+        .recv_matching(|frame| frame.contains("feed-invalid-atom-updated"))
+        .await
+        .expect("invalid Atom response");
+    assert!(
+        invalid_atom.contains("type='error'") && invalid_atom.contains("invalid-payload"),
+        "feed publish missing required Atom fields must be invalid-payload: {invalid_atom}"
     );
 
     let _ = client.close().await;
@@ -260,11 +356,17 @@ async fn member_cannot_clobber_another_members_feed_post() {
               <pubsub xmlns="http://jabber.org/protocol/pubsub">
                 <publish node="{FEED_NODE}">
                   <item id="{post_id}">
-                    <entry xmlns="{NS_SOCIAL_FEED}"><body>Original by A</body></entry>
+                    {}
                   </item>
                 </publish>
               </pubsub>
-            </iq>"#
+            </iq>"#,
+            feed_entry_xml(
+                &post_id,
+                "Original by A",
+                "Original by A",
+                "member@localhost"
+            )
         ))
         .await
         .expect("A publish");
@@ -282,11 +384,17 @@ async fn member_cannot_clobber_another_members_feed_post() {
               <pubsub xmlns="http://jabber.org/protocol/pubsub">
                 <publish node="{FEED_NODE}">
                   <item id="{post_id}">
-                    <entry xmlns="{NS_SOCIAL_FEED}"><body>Hijacked by B</body></entry>
+                    {}
                   </item>
                 </publish>
               </pubsub>
-            </iq>"#
+            </iq>"#,
+        feed_entry_xml(
+            &post_id,
+            "Hijacked by B",
+            "Hijacked by B",
+            "member2@localhost"
+        )
     ))
     .await
     .expect("B publish");

--- a/server/crates/waddle-server/tests/xep0501_stories_ws.rs
+++ b/server/crates/waddle-server/tests/xep0501_stories_ws.rs
@@ -1,8 +1,8 @@
 //! XEP-0501 Pubsub Stories integration tests over WebSocket.
 //!
 //! Verifies the server bootstrap: the spaces service hosts the
-//! global `urn:xmpp:stories:0` node, advertises the namespace on
-//! disco#info, and accepts publish + items-query for `<story/>`
+//! global `urn:xmpp:pubsub-social-feed:stories:0` node, advertises the namespace on
+//! disco#info, and accepts publish + items-query for Atom `<entry/>`
 //! payloads built per XEP-0501.
 
 mod ws_common;
@@ -17,10 +17,34 @@ const MEMBER_PASSWORD: &str = "xep0501-member-password";
 const OTHER_MEMBER_USERNAME: &str = "other";
 const OTHER_MEMBER_PASSWORD: &str = "xep0501-other-password";
 const COMMUNITY_JID: &str = "community.localhost";
-const STORIES_NODE: &str = "urn:xmpp:stories:0";
-const NS_STORIES: &str = "urn:xmpp:stories:0";
+const STORIES_NODE: &str = "urn:xmpp:pubsub-social-feed:stories:0";
+const NS_STORIES: &str = "urn:xmpp:pubsub-social-feed:stories:0";
+const NS_ATOM: &str = "http://www.w3.org/2005/Atom";
+const NS_WADDLE_STORIES: &str = "urn:waddle:stories:0";
 
 static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+fn story_entry_xml(
+    item_id: &str,
+    body: &str,
+    media_url: &str,
+    media_type: &str,
+    author: &str,
+    expires: &str,
+) -> String {
+    format!(
+        r#"<entry xmlns="{NS_ATOM}">
+          <title type="text">{body}</title>
+          <id>{item_id}</id>
+          <published>2026-06-01T12:00:00Z</published>
+          <updated>2026-06-01T12:00:00Z</updated>
+          <content type="text">{body}</content>
+          <author><uri>xmpp:{author}</uri></author>
+          <link rel="enclosure" href="{media_url}" type="{media_type}"/>
+          <expires xmlns="{NS_WADDLE_STORIES}">{expires}</expires>
+        </entry>"#
+    )
+}
 
 async fn setup() -> (TestServer, WsXmppClient) {
     let server = TestServer::start();
@@ -58,6 +82,35 @@ async fn community_disco_info_advertises_stories_namespace() {
 }
 
 #[tokio::test]
+async fn stories_node_config_declares_xep0501_pubsub_type() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+
+    client
+        .send(&format!(
+            r#"<iq type="get" id="stories-node-config" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub#owner">
+                <configure node="{STORIES_NODE}"/>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send stories node configure get");
+    let frame = client
+        .recv_matching(|frame| frame.contains("stories-node-config"))
+        .await
+        .expect("stories node configure response");
+    assert!(
+        frame.contains("type='result'")
+            && frame.contains("var='pubsub#type'")
+            && frame.contains(&format!("<value>{STORIES_NODE}</value>")),
+        "stories node configure form must declare the XEP-0501 pubsub#type: {frame}"
+    );
+
+    let _ = client.close().await;
+}
+
+#[tokio::test]
 async fn member_story_publish_requires_story_payload() {
     let _guard = TEST_SERIAL.lock().await;
     let server = TestServer::start_with_extra_accounts(&[(MEMBER_USERNAME, MEMBER_PASSWORD)]);
@@ -88,7 +141,7 @@ async fn member_story_publish_requires_story_payload() {
         .expect("missing payload response");
     assert!(
         missing_payload.contains("type='error'") && missing_payload.contains("payload-required"),
-        "story publish without <story/> must be payload-required: {missing_payload}"
+        "story publish without an Atom entry must be payload-required: {missing_payload}"
     );
 
     client
@@ -97,7 +150,12 @@ async fn member_story_publish_requires_story_payload() {
               <pubsub xmlns="http://jabber.org/protocol/pubsub">
                 <publish node="{STORIES_NODE}">
                   <item id="invalid-payload">
-                    <entry xmlns="urn:xmpp:pubsub-social-feed:0"><content>not a story</content></entry>
+                    <entry xmlns="{NS_ATOM}">
+                      <title type="text">not a story</title>
+                      <id>invalid-payload</id>
+                      <updated>2026-06-01T12:00:00Z</updated>
+                      <content type="text">missing enclosure</content>
+                    </entry>
                   </item>
                 </publish>
               </pubsub>
@@ -120,7 +178,11 @@ async fn member_story_publish_requires_story_payload() {
               <pubsub xmlns="http://jabber.org/protocol/pubsub">
                 <publish node="{STORIES_NODE}">
                   <item id="empty-story">
-                    <story xmlns="{NS_STORIES}" expires="2030-01-01T12:00:00Z"/>
+                    <entry xmlns="{NS_ATOM}">
+                      <title type="text">no media</title>
+                      <id>empty-story</id>
+                      <updated>2026-06-01T12:00:00Z</updated>
+                    </entry>
                   </item>
                 </publish>
               </pubsub>
@@ -134,7 +196,91 @@ async fn member_story_publish_requires_story_payload() {
         .expect("empty story response");
     assert!(
         empty_payload.contains("type='error'") && empty_payload.contains("invalid-payload"),
-        "story publish with no body or media-url must be invalid-payload: {empty_payload}"
+        "story publish with no enclosure must be invalid-payload: {empty_payload}"
+    );
+
+    client
+        .send(&format!(
+            r#"<iq type="set" id="member-story-missing-updated" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <publish node="{STORIES_NODE}">
+                  <item id="missing-updated-story">
+                    <entry xmlns="{NS_ATOM}">
+                      <title type="text">missing updated</title>
+                      <id>missing-updated-story</id>
+                      <link rel="enclosure" href="https://example.com/photo.jpg" type="image/jpeg"/>
+                    </entry>
+                  </item>
+                </publish>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send story missing updated publish");
+    let missing_updated = client
+        .recv_matching(|frame| frame.contains("member-story-missing-updated"))
+        .await
+        .expect("story missing updated response");
+    assert!(
+        missing_updated.contains("type='error'") && missing_updated.contains("invalid-payload"),
+        "story publish missing required Atom fields must be invalid-payload: {missing_updated}"
+    );
+
+    client
+        .send(&format!(
+            r#"<iq type="set" id="member-story-blank-href" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <publish node="{STORIES_NODE}">
+                  <item id="blank-href-story">
+                    <entry xmlns="{NS_ATOM}">
+                      <title type="text">blank media</title>
+                      <id>blank-href-story</id>
+                      <updated>2026-06-01T12:00:00Z</updated>
+                      <link rel="enclosure" href="   " type="image/jpeg"/>
+                    </entry>
+                  </item>
+                </publish>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send story blank href publish");
+    let blank_href = client
+        .recv_matching(|frame| frame.contains("member-story-blank-href"))
+        .await
+        .expect("story blank href response");
+    assert!(
+        blank_href.contains("type='error'") && blank_href.contains("invalid-payload"),
+        "story publish with blank media href must be invalid-payload: {blank_href}"
+    );
+
+    client
+        .send(&format!(
+            r#"<iq type="set" id="member-story-bad-published" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <publish node="{STORIES_NODE}">
+                  <item id="bad-published-story">
+                    <entry xmlns="{NS_ATOM}">
+                      <title type="text">bad published</title>
+                      <id>bad-published-story</id>
+                      <updated>2026-06-01T12:00:00Z</updated>
+                      <published>not-a-date</published>
+                      <link rel="enclosure" href="https://example.com/photo.jpg" type="image/jpeg"/>
+                    </entry>
+                  </item>
+                </publish>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send story bad published publish");
+    let bad_published = client
+        .recv_matching(|frame| frame.contains("member-story-bad-published"))
+        .await
+        .expect("story bad published response");
+    assert!(
+        bad_published.contains("type='error'") && bad_published.contains("invalid-payload"),
+        "story publish with invalid published timestamp must be invalid-payload: {bad_published}"
     );
 
     let _ = client.close().await;
@@ -173,13 +319,19 @@ async fn member_can_retract_own_story_but_not_another_member_story() {
               <pubsub xmlns="http://jabber.org/protocol/pubsub">
                 <publish node="{STORIES_NODE}">
                   <item id="{story_id}">
-                    <story xmlns="{NS_STORIES}" expires="2030-01-01T12:00:00Z">
-                      <body>member-owned story</body>
-                    </story>
+                    {}
                   </item>
                 </publish>
               </pubsub>
-            </iq>"#
+            </iq>"#,
+            story_entry_xml(
+                &story_id,
+                "member-owned story",
+                "https://example.com/member-owned-story.jpg",
+                "image/jpeg",
+                "member@localhost",
+                "2030-01-01T12:00:00Z",
+            )
         ))
         .await
         .expect("send publish");
@@ -267,15 +419,19 @@ async fn stories_publish_and_items_round_trip() {
               <pubsub xmlns="http://jabber.org/protocol/pubsub">
                 <publish node="{STORIES_NODE}">
                   <item id="{story_id}">
-                    <story xmlns="{NS_STORIES}" expires="{expires}">
-                      <body>Look at this!</body>
-                      <media-url>https://example.com/photo.jpg</media-url>
-                      <author>admin@localhost</author>
-                    </story>
+                    {}
                   </item>
                 </publish>
               </pubsub>
-            </iq>"#
+            </iq>"#,
+            story_entry_xml(
+                &story_id,
+                "Look at this!",
+                "https://example.com/photo.jpg",
+                "image/jpeg",
+                "admin@localhost",
+                expires,
+            )
         ))
         .await
         .expect("send publish");
@@ -289,7 +445,7 @@ async fn stories_publish_and_items_round_trip() {
     );
 
     // Items query — the published story should round-trip with the
-    // typed `<story/>` payload intact (id, expires, body, media-url).
+    // typed Atom payload intact (id, expires, body, enclosure link).
     client
         .send(&format!(
             r#"<iq type="get" id="story-items" to="{COMMUNITY_JID}">
@@ -301,7 +457,7 @@ async fn stories_publish_and_items_round_trip() {
         .await
         .expect("send items query");
     let items_response = client
-        .recv_matching(|frame| frame.contains("story-items") && frame.contains("<story"))
+        .recv_matching(|frame| frame.contains("story-items") && frame.contains("<entry"))
         .await
         .expect("items response");
     assert!(
@@ -314,7 +470,7 @@ async fn stories_publish_and_items_round_trip() {
     );
     assert!(
         items_response.contains("https://example.com/photo.jpg"),
-        "items query lost media-url: {items_response}"
+        "items query lost enclosure href: {items_response}"
     );
     assert!(
         items_response.contains(expires),
@@ -349,15 +505,19 @@ async fn member_can_publish_story_media() {
               <pubsub xmlns="http://jabber.org/protocol/pubsub">
                 <publish node="{STORIES_NODE}">
                   <item id="{story_id}">
-                    <story xmlns="{NS_STORIES}" expires="2030-01-01T12:00:00Z">
-                      <body>From the new office</body>
-                      <media-url>https://example.com/member-photo.jpg</media-url>
-                      <author>spoofed@localhost</author>
-                    </story>
+                    {}
                   </item>
                 </publish>
               </pubsub>
-            </iq>"#
+            </iq>"#,
+            story_entry_xml(
+                &story_id,
+                "From the new office",
+                "https://example.com/member-photo.jpg",
+                "image/jpeg",
+                "spoofed@localhost",
+                "2030-01-01T12:00:00Z",
+            )
         ))
         .await
         .expect("send publish");
@@ -381,7 +541,7 @@ async fn member_can_publish_story_media() {
         .await
         .expect("send items query");
     let items_response = client
-        .recv_matching(|frame| frame.contains("member-story-items") && frame.contains("<story"))
+        .recv_matching(|frame| frame.contains("member-story-items") && frame.contains("<entry"))
         .await
         .expect("items response");
     assert!(
@@ -390,7 +550,7 @@ async fn member_can_publish_story_media() {
     );
     assert!(
         items_response.contains("https://example.com/member-photo.jpg"),
-        "items query lost media-url: {items_response}"
+        "items query lost enclosure href: {items_response}"
     );
     assert!(
         items_response.contains(&format!("{MEMBER_USERNAME}@{DOMAIN}")),

--- a/server/crates/waddle-server/tests/xmpp_e2e_cue.rs
+++ b/server/crates/waddle-server/tests/xmpp_e2e_cue.rs
@@ -136,8 +136,8 @@ const ADVERTISED_FEATURE_XEPS: &[(&str, &str)] = &[
     ("urn:xmpp:jingle-message:0", "XEP-0353"),
     ("urn:xmpp:extdisco:2", "XEP-0215"),
     ("urn:xmpp:jingle:muji:0", "XEP-0272"),
-    ("urn:xmpp:pubsub-social-feed:0", "XEP-0472"),
-    ("urn:xmpp:stories:0", "XEP-0501"),
+    ("urn:xmpp:pubsub-social-feed:1", "XEP-0472"),
+    ("urn:xmpp:pubsub-social-feed:stories:0", "XEP-0501"),
     ("urn:xmpp:spaces:0", "XEP-0503"),
     ("urn:xmpp:inbox:1", "XEP-0430"),
     // xCal calendar — XSF ProtoXEP "Calendaring Extensions to
@@ -174,6 +174,10 @@ const ADVERTISED_FEATURE_EXEMPTIONS: &[FeatureCoverageExemption] = &[
     },
     FeatureCoverageExemption {
         feature: "muc_public",
+        reason: "XEP-0045 room configuration identity flag, not a separate XEP namespace.",
+    },
+    FeatureCoverageExemption {
+        feature: "muc_hidden",
         reason: "XEP-0045 room configuration identity flag, not a separate XEP namespace.",
     },
     FeatureCoverageExemption {
@@ -1345,9 +1349,9 @@ fn add_text_xep_evidence(text: &str, evidence: &mut BTreeSet<&'static str>) {
         ("urn:xmpp:file:metadata:0", "XEP-0446"),
         ("urn:xmpp:sfs:0", "XEP-0447"),
         ("urn:xmpp:reply:0", "XEP-0461"),
-        ("urn:xmpp:pubsub-social-feed:0", "XEP-0472"),
+        ("urn:xmpp:pubsub-social-feed:1", "XEP-0472"),
         ("urn:xmpp:notification-settings:1", "XEP-0492"),
-        ("urn:xmpp:stories:0", "XEP-0501"),
+        ("urn:xmpp:pubsub-social-feed:stories:0", "XEP-0501"),
         ("urn:xmpp:spaces:0", "XEP-0503"),
         ("urn:xmpp:mentions:0", "XEP-0513"),
     ] {
@@ -1630,7 +1634,10 @@ fn advertised_feature_vars() -> BTreeSet<String> {
         .chain(waddle_xmpp::disco::info::spaces_service_features())
         .chain(waddle_xmpp::disco::info::muc_service_features())
         .chain(waddle_xmpp::disco::info::muc_room_features(
-            true, true, false, true,
+            true, true, false, false, true,
+        ))
+        .chain(waddle_xmpp::disco::info::muc_room_features(
+            true, false, true, false, false,
         ))
         .chain(waddle_xmpp::disco::info::call_features())
         .chain(waddle_xmpp::pubsub::pep_features())

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0472_social_feed.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0472_social_feed.cue
@@ -32,7 +32,7 @@ scenario: #Scenario & {
 			id:     "cue-feed-disco"
 			type:   "result"
 			contains: [
-				"var='urn:xmpp:pubsub-social-feed:0'",
+				"var='urn:xmpp:pubsub-social-feed:1'",
 			]
 		},
 		// 2. Publish a feed entry to the bootstrapped community feed
@@ -51,7 +51,7 @@ scenario: #Scenario & {
 					#XmlElement & {
 						name:  "publish"
 						ns:    "http://jabber.org/protocol/pubsub"
-						attrs: node: "urn:xmpp:pubsub-social-feed:0"
+						attrs: node: "urn:xmpp:pubsub-social-feed:1"
 						children: [
 							#XmlElement & {
 								name:  "item"
@@ -60,22 +60,45 @@ scenario: #Scenario & {
 								children: [
 									#XmlElement & {
 										name: "entry"
-										ns:   "urn:xmpp:pubsub-social-feed:0"
+										ns:   "http://www.w3.org/2005/Atom"
 										children: [
 											#XmlElement & {
-												name: "title"
-												ns:   "urn:xmpp:pubsub-social-feed:0"
+												name:  "title"
+												ns:    "http://www.w3.org/2005/Atom"
+												attrs: type: "text"
 												text: "First post"
 											},
 											#XmlElement & {
-												name: "body"
-												ns:   "urn:xmpp:pubsub-social-feed:0"
+												name: "id"
+												ns:   "http://www.w3.org/2005/Atom"
+												text: "tag:localhost,2026:cue-post-1"
+											},
+											#XmlElement & {
+												name: "published"
+												ns:   "http://www.w3.org/2005/Atom"
+												text: "2026-06-01T12:00:00Z"
+											},
+											#XmlElement & {
+												name: "updated"
+												ns:   "http://www.w3.org/2005/Atom"
+												text: "2026-06-01T12:00:00Z"
+											},
+											#XmlElement & {
+												name:  "content"
+												ns:    "http://www.w3.org/2005/Atom"
+												attrs: type: "text"
 												text: "Hello community feed!"
 											},
 											#XmlElement & {
 												name: "author"
-												ns:   "urn:xmpp:pubsub-social-feed:0"
-												text: "admin@\(scenario.domain)"
+												ns:   "http://www.w3.org/2005/Atom"
+												children: [
+													#XmlElement & {
+														name: "uri"
+														ns:   "http://www.w3.org/2005/Atom"
+														text: "xmpp:admin@\(scenario.domain)"
+													},
+												]
 											},
 										]
 									},
@@ -92,7 +115,8 @@ scenario: #Scenario & {
 			type:   "result"
 		},
 		// 3. Items query MUST return the published entry with the
-		//    typed <entry/> payload intact (id, title, body, author).
+		//    typed Atom <entry/> payload intact (id, title, content,
+		//    author).
 		#SendIq & {
 			actor: adminPhone
 			type:  "get"
@@ -105,7 +129,7 @@ scenario: #Scenario & {
 					#XmlElement & {
 						name:  "items"
 						ns:    "http://jabber.org/protocol/pubsub"
-						attrs: node: "urn:xmpp:pubsub-social-feed:0"
+						attrs: node: "urn:xmpp:pubsub-social-feed:1"
 					},
 				]
 			}
@@ -116,7 +140,8 @@ scenario: #Scenario & {
 			type:   "result"
 			contains: [
 				"id='cue-post-1'",
-				"urn:xmpp:pubsub-social-feed:0",
+				"urn:xmpp:pubsub-social-feed:1",
+				"http://www.w3.org/2005/Atom",
 				"First post",
 				"Hello community feed!",
 			]

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0501_stories.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0501_stories.cue
@@ -32,13 +32,13 @@ scenario: #Scenario & {
 			id:     "cue-stories-disco"
 			type:   "result"
 			contains: [
-				"var='urn:xmpp:stories:0'",
+				"var='urn:xmpp:pubsub-social-feed:stories:0'",
 			]
 		},
 		// 2. Publish a story to the bootstrapped community stories
 		//    node. The server bootstraps this node at startup with
-		//    spaces_public() access; server-owner affiliation seed
-		//    grants admin Publisher access.
+		//    the XEP-0501 story profile; server-owner affiliation
+		//    seed grants admin Publisher access.
 		#SendIq & {
 			actor: adminPhone
 			type:  "set"
@@ -51,7 +51,7 @@ scenario: #Scenario & {
 					#XmlElement & {
 						name:  "publish"
 						ns:    "http://jabber.org/protocol/pubsub"
-						attrs: node: "urn:xmpp:stories:0"
+						attrs: node: "urn:xmpp:pubsub-social-feed:stories:0"
 						children: [
 							#XmlElement & {
 								name:  "item"
@@ -59,24 +59,60 @@ scenario: #Scenario & {
 								attrs: id: "cue-story-1"
 								children: [
 									#XmlElement & {
-										name: "story"
-										ns:   "urn:xmpp:stories:0"
-										attrs: expires: "2030-01-01T12:00:00Z"
+										name: "entry"
+										ns:   "http://www.w3.org/2005/Atom"
 										children: [
 											#XmlElement & {
-												name: "body"
-												ns:   "urn:xmpp:stories:0"
+												name:  "title"
+												ns:    "http://www.w3.org/2005/Atom"
+												attrs: type: "text"
 												text: "Look at this!"
 											},
 											#XmlElement & {
-												name: "media-url"
-												ns:   "urn:xmpp:stories:0"
-												text: "https://example.com/photo.jpg"
+												name: "id"
+												ns:   "http://www.w3.org/2005/Atom"
+												text: "cue-story-1"
+											},
+											#XmlElement & {
+												name: "published"
+												ns:   "http://www.w3.org/2005/Atom"
+												text: "2026-06-01T12:00:00Z"
+											},
+											#XmlElement & {
+												name: "updated"
+												ns:   "http://www.w3.org/2005/Atom"
+												text: "2026-06-01T12:00:00Z"
+											},
+											#XmlElement & {
+												name:  "content"
+												ns:    "http://www.w3.org/2005/Atom"
+												attrs: type: "text"
+												text: "Look at this!"
 											},
 											#XmlElement & {
 												name: "author"
-												ns:   "urn:xmpp:stories:0"
-												text: "admin@\(scenario.domain)"
+												ns:   "http://www.w3.org/2005/Atom"
+												children: [
+													#XmlElement & {
+														name: "uri"
+														ns:   "http://www.w3.org/2005/Atom"
+														text: "xmpp:admin@\(scenario.domain)"
+													},
+												]
+											},
+											#XmlElement & {
+												name: "link"
+												ns:   "http://www.w3.org/2005/Atom"
+												attrs: {
+													rel:  "enclosure"
+													href: "https://example.com/photo.jpg"
+													type: "image/jpeg"
+												}
+											},
+											#XmlElement & {
+												name: "expires"
+												ns:   "urn:waddle:stories:0"
+												text: "2030-01-01T12:00:00Z"
 											},
 										]
 									},
@@ -93,8 +129,7 @@ scenario: #Scenario & {
 			type:   "result"
 		},
 		// 3. Items query MUST return the published story with the
-		//    typed <story/> payload intact (id, body, media-url,
-		//    expires).
+		//    typed Atom payload intact (id, body, enclosure, expires).
 		#SendIq & {
 			actor: adminPhone
 			type:  "get"
@@ -107,7 +142,7 @@ scenario: #Scenario & {
 					#XmlElement & {
 						name:  "items"
 						ns:    "http://jabber.org/protocol/pubsub"
-						attrs: node: "urn:xmpp:stories:0"
+						attrs: node: "urn:xmpp:pubsub-social-feed:stories:0"
 					},
 				]
 			}
@@ -118,7 +153,8 @@ scenario: #Scenario & {
 			type:   "result"
 			contains: [
 				"id='cue-story-1'",
-				"urn:xmpp:stories:0",
+				"urn:xmpp:pubsub-social-feed:stories:0",
+				"http://www.w3.org/2005/Atom",
 				"Look at this!",
 				"https://example.com/photo.jpg",
 				"2030-01-01T12:00:00Z",

--- a/server/crates/waddle-xmpp-client-wasm/src/client_admin_v2.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_admin_v2.rs
@@ -161,6 +161,7 @@ pub struct WaddleAdminChannelListEntry {
     pub channel_jid: String,
     pub name: String,
     pub topic: Option<String>,
+    pub channel_type: String,
     pub is_public: bool,
     pub members_only: bool,
     pub occupant_count: u32,
@@ -180,6 +181,7 @@ pub struct WaddleAdminChannelsListResult {
 pub struct WaddleAdminChannelsCreateArgs {
     pub name: String,
     pub topic: Option<String>,
+    pub channel_type: Option<String>,
     pub space_jid: Option<String>,
     pub space_node: Option<String>,
     /// Defaults to `true` per the V2 spec; the client wrapper passes
@@ -196,6 +198,7 @@ pub struct WaddleAdminChannelRef {
     pub channel_jid: String,
     pub name: String,
     pub topic: Option<String>,
+    pub channel_type: String,
     pub is_public: bool,
     pub members_only: bool,
 }
@@ -205,6 +208,7 @@ pub struct WaddleAdminChannelsUpdateArgs {
     pub channel_jid: String,
     pub name: Option<String>,
     pub topic: Option<String>,
+    pub channel_type: Option<String>,
     pub is_public: Option<bool>,
     pub members_only: Option<bool>,
 }
@@ -649,6 +653,9 @@ fn build_channels_create_iq(server_domain: &str, args: &WaddleAdminChannelsCreat
     if let Some(topic) = args.topic.as_deref() {
         form = form.append(text_single_field("topic", topic));
     }
+    if let Some(channel_type) = args.channel_type.as_deref() {
+        form = form.append(text_single_field("channel_type", channel_type));
+    }
     if let Some(space_jid) = args.space_jid.as_deref() {
         form = form.append(jid_field("space_jid", space_jid));
     }
@@ -672,6 +679,9 @@ fn build_channels_update_iq(server_domain: &str, args: &WaddleAdminChannelsUpdat
     }
     if let Some(topic) = args.topic.as_deref() {
         form = form.append(text_single_field("topic", topic));
+    }
+    if let Some(channel_type) = args.channel_type.as_deref() {
+        form = form.append(text_single_field("channel_type", channel_type));
     }
     if let Some(is_public) = args.is_public {
         form = form.append(boolean_field("is_public", is_public));
@@ -910,6 +920,7 @@ fn parse_channels_list_result(iq: &Element) -> AdminParseResult<WaddleAdminChann
             channel_jid: field_text_required(item, "channel_jid")?,
             name: field_text_required(item, "name")?,
             topic: field_text(item, "topic").filter(|s| !s.is_empty()),
+            channel_type: field_text_required(item, "channel_type")?,
             is_public: field_bool(item, "is_public")?,
             members_only: field_bool(item, "members_only")?,
             occupant_count: field_u32(item, "occupant_count")?,
@@ -931,6 +942,7 @@ fn parse_channel_ref_result(iq: &Element) -> AdminParseResult<WaddleAdminChannel
         channel_jid: top_level_field_text_required(form, "channel_jid")?,
         name: top_level_field_text_required(form, "name")?,
         topic: top_level_field_text_opt(form, "topic"),
+        channel_type: top_level_field_text_required(form, "channel_type")?,
         is_public: top_level_field_bool(form, "is_public")?,
         members_only: top_level_field_bool(form, "members_only")?,
     })

--- a/server/crates/waddle-xmpp-client-wasm/src/client_admin_v2_tests.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_admin_v2_tests.rs
@@ -79,6 +79,7 @@ fn parse_channels_list_extracts_booleans_and_counts() {
             <field var="channel_jid"><value>general@muc.localhost</value></field>
             <field var="name"><value>General</value></field>
             <field var="topic"><value>All things</value></field>
+            <field var="channel_type"><value>text</value></field>
             <field var="is_public" type="boolean"><value>1</value></field>
             <field var="members_only" type="boolean"><value>0</value></field>
             <field var="occupant_count"><value>7</value></field>
@@ -91,6 +92,7 @@ fn parse_channels_list_extracts_booleans_and_counts() {
     let result = parse_channels_list_result(&iq).expect("ok");
     assert_eq!(result.entries.len(), 1);
     let entry = &result.entries[0];
+    assert_eq!(entry.channel_type, "text");
     assert!(entry.is_public);
     assert!(!entry.members_only);
     assert_eq!(entry.occupant_count, 7);
@@ -121,6 +123,7 @@ fn parse_channels_list_rejects_malformed_counts_and_booleans() {
     let malformed_count = r#"<item>
             <field var="channel_jid"><value>general@muc.localhost</value></field>
             <field var="name"><value>General</value></field>
+            <field var="channel_type"><value>text</value></field>
             <field var="is_public" type="boolean"><value>1</value></field>
             <field var="members_only" type="boolean"><value>0</value></field>
             <field var="occupant_count"><value>many</value></field>
@@ -132,6 +135,7 @@ fn parse_channels_list_rejects_malformed_counts_and_booleans() {
     let malformed_bool = r#"<item>
             <field var="channel_jid"><value>general@muc.localhost</value></field>
             <field var="name"><value>General</value></field>
+            <field var="channel_type"><value>text</value></field>
             <field var="is_public" type="boolean"><value>sometimes</value></field>
             <field var="members_only" type="boolean"><value>0</value></field>
             <field var="occupant_count"><value>7</value></field>
@@ -191,6 +195,7 @@ fn build_channels_create_iq_includes_all_optional_fields() {
     let args = WaddleAdminChannelsCreateArgs {
         name: "general".to_string(),
         topic: Some("All things".to_string()),
+        channel_type: Some("forum".to_string()),
         space_jid: Some("eng@spaces.localhost".to_string()),
         space_node: Some("eng".to_string()),
         is_public: Some(true),
@@ -208,6 +213,7 @@ fn build_channels_create_iq_includes_all_optional_fields() {
         .collect();
     assert!(var_names.contains(&"name"));
     assert!(var_names.contains(&"topic"));
+    assert!(var_names.contains(&"channel_type"));
     assert!(var_names.contains(&"space_jid"));
     assert!(var_names.contains(&"space_node"));
     assert!(var_names.contains(&"is_public"));

--- a/server/crates/waddle-xmpp-client-wasm/src/client_social_feed.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_social_feed.rs
@@ -1,7 +1,7 @@
 //! XEP-0472 Pubsub Social Feed — wasm bridge surface.
 //!
 //! The server bootstraps a community feed node at
-//! `urn:xmpp:pubsub-social-feed:0` on the spaces service. These
+//! `urn:xmpp:pubsub-social-feed:1` on the spaces service. These
 //! wasm methods let the chat read the feed (`feed_items`) and
 //! publish new posts (`feed_publish`) via standard XEP-0060
 //! pubsub IQs, with the typed XEP-0472 `<entry/>` payload
@@ -12,7 +12,7 @@ use minidom::Element;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use waddle_xmpp_core::xep0472::{
-    build_feed_entry_element, parse_feed_entry, FeedEntry, NS_SOCIAL_FEED, PUBSUB_NODE_FEED,
+    build_feed_entry_element, parse_feed_entry, FeedEntry, NS_ATOM, PUBSUB_NODE_FEED,
 };
 use wasm_bindgen::prelude::*;
 
@@ -140,7 +140,7 @@ fn parse_feed_items_result(iq: &Element) -> Vec<JsFeedEntry> {
             let item_id = item.attr("id")?;
             let entry_el = item
                 .children()
-                .find(|child| child.name() == "entry" && child.ns() == NS_SOCIAL_FEED)?;
+                .find(|child| child.name() == "entry" && child.ns() == NS_ATOM)?;
             let source = extract_source_kind(entry_el);
             parse_feed_entry(item_id, entry_el).map(|entry| {
                 let mut js = JsFeedEntry::from(entry);

--- a/server/crates/waddle-xmpp-client-wasm/src/client_stories.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_stories.rs
@@ -1,7 +1,7 @@
 //! XEP-0501 Pubsub Stories — wasm bridge surface.
 //!
 //! The server bootstraps a community stories node at
-//! `urn:xmpp:stories:0` on the community service. These wasm methods
+//! `urn:xmpp:pubsub-social-feed:stories:0` on the community service. These wasm methods
 //! let the chat read active stories (`stories_items`, returns ALL
 //! items; the chat filters expired locally) and publish new stories
 //! with an expiry (`stories_publish`).
@@ -11,7 +11,7 @@ use minidom::Element;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use waddle_xmpp_core::xep0501::{
-    build_story_element, parse_story, Story, DEFAULT_EXPIRY_HOURS, NS_STORIES, PUBSUB_NODE_STORIES,
+    build_story_element, parse_story, Story, DEFAULT_EXPIRY_HOURS, NS_ATOM, PUBSUB_NODE_STORIES,
 };
 use wasm_bindgen::prelude::*;
 
@@ -25,6 +25,7 @@ pub(crate) struct JsStory {
     pub id: String,
     pub body: Option<String>,
     pub media_url: Option<String>,
+    pub media_type: Option<String>,
     pub author: Option<String>,
     pub posted: Option<String>,
     pub expires: Option<String>,
@@ -36,6 +37,7 @@ impl From<Story> for JsStory {
             id: story.id,
             body: story.body,
             media_url: story.media_url,
+            media_type: story.media_type.map(|media_type| media_type.to_string()),
             author: story.author,
             posted: story.posted.map(|ts| ts.to_rfc3339()),
             expires: story.expires.map(|ts| ts.to_rfc3339()),
@@ -47,6 +49,7 @@ impl From<Story> for JsStory {
 pub(crate) struct JsStoryInput {
     pub body: Option<String>,
     pub media_url: Option<String>,
+    pub media_type: Option<String>,
     pub author: Option<String>,
     pub expiry_hours: Option<i64>,
 }
@@ -114,7 +117,7 @@ fn parse_stories_items_result(iq: &Element) -> Vec<JsStory> {
             let item_id = item.attr("id")?;
             let story_el = item
                 .children()
-                .find(|child| child.name() == "story" && child.ns() == NS_STORIES)?;
+                .find(|child| child.name() == "entry" && child.ns() == NS_ATOM)?;
             parse_story(item_id, story_el).map(JsStory::from)
         })
         .collect()
@@ -136,24 +139,31 @@ impl WaddleClient {
         })
     }
 
-    /// Publish a new story. At least one of `body` / `media_url` is
-    /// required (the server rejects empty stories). `expiry_hours`
+    /// Publish a new story. `media_url` is required by XEP-0501; `body`
+    /// is optional text content attached to that media. `expiry_hours`
     /// defaults to 24.
     pub fn stories_publish(&self, community_jid: String, input: JsValue) -> js_sys::Promise {
         let inner = self.inner.clone();
         wasm_bindgen_futures::future_to_promise(async move {
             let input: JsStoryInput = serde_wasm_bindgen::from_value(input)
                 .map_err(|err| js_error(format!("invalid story input: {err}")))?;
-            if input.body.is_none() && input.media_url.is_none() {
-                return Err(js_error("story must have body or media_url"));
-            }
+            let media_url = input
+                .media_url
+                .map(|url| url.trim().to_owned())
+                .filter(|url| !url.is_empty())
+                .ok_or_else(|| js_error("story must have media_url"))?;
             let item_id = format!("story-{}", Uuid::new_v4());
             let mut story = Story::new(item_id.clone());
             if let Some(body) = input.body {
                 story = story.with_body(body);
             }
-            if let Some(url) = input.media_url {
-                story = story.with_media(url);
+            story = story.with_media(media_url);
+            if let Some(media_type) = input.media_type {
+                story = story.with_media_type(
+                    media_type
+                        .parse()
+                        .map_err(|_| js_error("invalid story media_type"))?,
+                );
             }
             if let Some(author) = input.author {
                 story = story.with_author(author);
@@ -168,6 +178,7 @@ impl WaddleClient {
                 id: item_id,
                 body: story.body,
                 media_url: story.media_url,
+                media_type: story.media_type.map(|media_type| media_type.to_string()),
                 author: story.author,
                 posted: Some(posted.to_rfc3339()),
                 expires: Some(expires.to_rfc3339()),

--- a/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
@@ -877,7 +877,8 @@ mod inbound_to_js_tests {
     fn pubsub_event_to_js_serializes_typed_and_opaque_payloads() {
         let event = waddle_xmpp_client::PubsubEvent {
             from: Some("community.example.com".parse().expect("valid event jid")),
-            node: "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:stories:0".to_string(),
+            node: "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:pubsub-social-feed:stories:0"
+                .to_string(),
             items: vec![
                 waddle_xmpp_client::PubsubEventItem {
                     id: Some("story-1".to_string()),

--- a/server/crates/waddle-xmpp-client/src/pubsub_event.rs
+++ b/server/crates/waddle-xmpp-client/src/pubsub_event.rs
@@ -165,7 +165,7 @@ mod tests {
     #[test]
     fn parses_attachment_summary_event() {
         let message = event_message(
-            "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:stories:0",
+            "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:pubsub-social-feed:stories:0",
             "story-1",
             Element::builder("summary", NS_PUBSUB_ATTACHMENTS_SUMMARY)
                 .append(
@@ -265,7 +265,7 @@ mod tests {
                         Element::builder("items", NS_PUBSUB_EVENT)
                             .attr(
                                 minidom::rxml::xml_ncname!("node").to_owned(),
-                                "urn:xmpp:stories:0",
+                                "urn:xmpp:pubsub-social-feed:stories:0",
                             )
                             .append(
                                 Element::builder("retract", NS_PUBSUB_EVENT)
@@ -280,7 +280,7 @@ mod tests {
 
         let events = parse_pubsub_events(&message);
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].node, "urn:xmpp:stories:0");
+        assert_eq!(events[0].node, "urn:xmpp:pubsub-social-feed:stories:0");
         assert_eq!(events[0].items[0].id.as_deref(), Some("story-1"));
         assert!(events[0].items[0].retracted);
         assert_eq!(events[0].items[0].payload, PubsubEventPayload::Empty);

--- a/server/crates/waddle-xmpp-core/src/disco/info.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info.rs
@@ -475,10 +475,10 @@ pub fn community_service_features() -> Vec<Feature> {
         Feature::new("http://jabber.org/protocol/pubsub#meta-data"),
         Feature::new("http://jabber.org/protocol/pubsub#item-ids"),
         // XEP-0472 Pubsub Social Feed — community feed node lives
-        // here at `urn:xmpp:pubsub-social-feed:0`.
+        // here at `urn:xmpp:pubsub-social-feed:1`.
         Feature::social_feed(),
         // XEP-0501 Pubsub Stories — community stories node lives
-        // here at `urn:xmpp:stories:0`.
+        // here at `urn:xmpp:pubsub-social-feed:stories:0`.
         Feature::stories(),
         // xCal community events node — payload is iCalendar in XML
         // (`urn:ietf:params:xml:ns:xcal`) per the XSF ProtoXEP
@@ -500,6 +500,7 @@ pub fn muc_service_features() -> Vec<Feature> {
 pub fn muc_room_features(
     persistent: bool,
     members_only: bool,
+    public_room: bool,
     moderated: bool,
     forum: bool,
 ) -> Vec<Feature> {
@@ -561,6 +562,12 @@ pub fn muc_room_features(
         features.push(Feature::muc_membersonly());
     } else {
         features.push(Feature::muc_open());
+    }
+
+    if public_room {
+        features.push(Feature::muc_public());
+    } else {
+        features.push(Feature::muc_hidden());
     }
 
     if moderated {

--- a/server/crates/waddle-xmpp-core/src/disco/info/features.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info/features.rs
@@ -203,12 +203,12 @@ impl Feature {
 
     /// XEP-0472 Pubsub Social Feed.
     pub fn social_feed() -> Self {
-        Self::new("urn:xmpp:pubsub-social-feed:0")
+        Self::new("urn:xmpp:pubsub-social-feed:1")
     }
 
     /// XEP-0501 Pubsub Stories.
     pub fn stories() -> Self {
-        Self::new("urn:xmpp:stories:0")
+        Self::new("urn:xmpp:pubsub-social-feed:stories:0")
     }
 
     /// xCal calendar events per the XSF ProtoXEP
@@ -261,6 +261,14 @@ impl Feature {
 
     pub fn muc_membersonly() -> Self {
         Self::new("muc_membersonly")
+    }
+
+    pub fn muc_public() -> Self {
+        Self::new("muc_public")
+    }
+
+    pub fn muc_hidden() -> Self {
+        Self::new("muc_hidden")
     }
 
     pub fn muc_semianonymous() -> Self {

--- a/server/crates/waddle-xmpp-core/src/disco/info/tests.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info/tests.rs
@@ -102,16 +102,26 @@ fn test_server_features_exclude_unimplemented_advertisements() {
 
 #[test]
 fn test_muc_room_features_forum_room() {
-    let features = muc_room_features(true, true, false, true);
+    let features = muc_room_features(true, true, false, false, true);
     assert!(!features.contains(&Feature::new("urn:xmpp:forums:0")));
     assert!(features.contains(&Feature::muc_persistent()));
     assert!(features.contains(&Feature::muc_membersonly()));
+    assert!(features.contains(&Feature::muc_hidden()));
     assert!(features.contains(&Feature::muc_unmoderated()));
     assert!(features.contains(&Feature::muc_self_ping_optimization()));
     assert!(features.contains(&Feature::mam_extended()));
     assert!(features.contains(&Feature::fulltext_mam()));
     assert!(features.contains(&Feature::chat_states()));
     assert_eq!(Feature::chat_states().0, NS_CHATSTATES);
+}
+
+#[test]
+fn test_muc_room_features_public_open_room() {
+    let features = muc_room_features(true, false, true, false, false);
+    assert!(features.contains(&Feature::muc_open()));
+    assert!(features.contains(&Feature::muc_public()));
+    assert!(!features.contains(&Feature::muc_membersonly()));
+    assert!(!features.contains(&Feature::muc_hidden()));
 }
 
 #[test]

--- a/server/crates/waddle-xmpp-core/src/domain.rs
+++ b/server/crates/waddle-xmpp-core/src/domain.rs
@@ -34,8 +34,12 @@ pub struct ChannelRoomInfo {
 pub enum ChannelType {
     /// Standard text chat channel.
     Text,
+    /// Owner/moderator announcement channel.
+    Announcement,
     /// Waddle thread-oriented channel.
     Forum,
+    /// Private group direct-message channel.
+    GroupDm,
 }
 
 impl ChannelType {
@@ -43,7 +47,9 @@ impl ChannelType {
     pub fn parse(value: &str) -> Option<Self> {
         match value.trim() {
             "text" => Some(Self::Text),
+            "announcement" => Some(Self::Announcement),
             "forum" => Some(Self::Forum),
+            "group-dm" => Some(Self::GroupDm),
             _ => None,
         }
     }
@@ -52,7 +58,9 @@ impl ChannelType {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Text => "text",
+            Self::Announcement => "announcement",
             Self::Forum => "forum",
+            Self::GroupDm => "group-dm",
         }
     }
 
@@ -144,7 +152,12 @@ mod tests {
     #[test]
     fn supported_channel_types_are_explicit() {
         assert_eq!(ChannelType::parse("text"), Some(ChannelType::Text));
+        assert_eq!(
+            ChannelType::parse("announcement"),
+            Some(ChannelType::Announcement)
+        );
         assert_eq!(ChannelType::parse("forum"), Some(ChannelType::Forum));
+        assert_eq!(ChannelType::parse("group-dm"), Some(ChannelType::GroupDm));
         assert_eq!(ChannelType::parse("voice"), None);
     }
 }

--- a/server/crates/waddle-xmpp-core/src/pubsub/mod.rs
+++ b/server/crates/waddle-xmpp-core/src/pubsub/mod.rs
@@ -8,7 +8,7 @@ pub mod subscription;
 
 pub use affiliation::Affiliation;
 pub use node::{
-    AccessModel, NodeConfig, NodeConfigPatch, PublishModel, SendLastPublishedItem,
+    AccessModel, NodeConfig, NodeConfigPatch, PubSubNodeType, PublishModel, SendLastPublishedItem,
     PEP_BOOKMARK_MAX_ITEMS,
 };
 pub use pep::{

--- a/server/crates/waddle-xmpp-core/src/pubsub/node.rs
+++ b/server/crates/waddle-xmpp-core/src/pubsub/node.rs
@@ -91,6 +91,40 @@ impl FromStr for PublishModel {
     }
 }
 
+/// XEP-0060 `pubsub#type` profile identifier for a PubSub node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PubSubNodeType {
+    PubsubSocialFeed,
+    PubsubSocialFeedStories,
+}
+
+impl PubSubNodeType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PubSubNodeType::PubsubSocialFeed => crate::xep0472::NS_SOCIAL_FEED,
+            PubSubNodeType::PubsubSocialFeedStories => crate::xep0501::NS_STORIES,
+        }
+    }
+}
+
+impl fmt::Display for PubSubNodeType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl FromStr for PubSubNodeType {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            crate::xep0472::NS_SOCIAL_FEED => Ok(PubSubNodeType::PubsubSocialFeed),
+            crate::xep0501::NS_STORIES => Ok(PubSubNodeType::PubsubSocialFeedStories),
+            _ => Err(()),
+        }
+    }
+}
+
 /// When to send the last published item to a subscriber.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum SendLastPublishedItem {
@@ -132,6 +166,7 @@ impl FromStr for SendLastPublishedItem {
 pub struct NodeConfig {
     pub access_model: AccessModel,
     pub publish_model: PublishModel,
+    pub node_type: Option<PubSubNodeType>,
     pub max_items: u32,
     pub persist_items: bool,
     pub deliver_payloads: bool,
@@ -145,6 +180,7 @@ pub struct NodeConfig {
 pub struct NodeConfigPatch {
     pub access_model: Option<AccessModel>,
     pub publish_model: Option<PublishModel>,
+    pub node_type: Option<PubSubNodeType>,
     pub max_items: Option<u32>,
     pub persist_items: Option<bool>,
     pub deliver_payloads: Option<bool>,
@@ -160,6 +196,9 @@ impl NodeConfigPatch {
         }
         if let Some(publish_model) = self.publish_model {
             config.publish_model = publish_model;
+        }
+        if let Some(node_type) = self.node_type {
+            config.node_type = Some(node_type);
         }
         if let Some(max_items) = self.max_items {
             config.max_items = max_items;
@@ -195,6 +234,7 @@ impl NodeConfig {
         Self {
             access_model: AccessModel::Open,
             publish_model: PublishModel::Publishers,
+            node_type: None,
             max_items: u32::MAX,
             persist_items: true,
             deliver_payloads: true,
@@ -219,6 +259,7 @@ impl NodeConfig {
         Self {
             access_model: AccessModel::Open,
             publish_model: PublishModel::Open,
+            node_type: Some(PubSubNodeType::PubsubSocialFeed),
             max_items: u32::MAX,
             persist_items: true,
             deliver_payloads: true,
@@ -238,6 +279,7 @@ impl NodeConfig {
         Self {
             access_model: AccessModel::Open,
             publish_model: PublishModel::Open,
+            node_type: Some(PubSubNodeType::PubsubSocialFeedStories),
             max_items: u32::MAX,
             persist_items: true,
             deliver_payloads: true,
@@ -252,6 +294,7 @@ impl NodeConfig {
         Self {
             access_model: AccessModel::Whitelist,
             publish_model: PublishModel::Publishers,
+            node_type: None,
             max_items: u32::MAX,
             persist_items: true,
             deliver_payloads: true,
@@ -266,6 +309,7 @@ impl NodeConfig {
         Self {
             access_model: AccessModel::Presence,
             publish_model: PublishModel::Publishers,
+            node_type: None,
             max_items: 1,
             persist_items: true,
             deliver_payloads: true,
@@ -319,6 +363,7 @@ impl NodeConfig {
         Self {
             access_model: AccessModel::Whitelist,
             publish_model: PublishModel::Publishers,
+            node_type: None,
             max_items: PEP_BOOKMARK_MAX_ITEMS,
             persist_items: true,
             deliver_payloads: true,
@@ -349,6 +394,7 @@ impl NodeConfig {
         Self {
             access_model: AccessModel::Whitelist,
             publish_model: PublishModel::Publishers,
+            node_type: None,
             max_items: 1,
             persist_items: true,
             deliver_payloads: true,
@@ -390,6 +436,7 @@ impl NodeConfig {
         Self {
             access_model: AccessModel::Whitelist,
             publish_model: PublishModel::Publishers,
+            node_type: None,
             max_items: u32::MAX,
             persist_items: true,
             deliver_payloads: true,
@@ -437,6 +484,7 @@ impl NodeConfig {
         Self {
             access_model: AccessModel::Open,
             publish_model: PublishModel::Publishers,
+            node_type: None,
             max_items: 10,
             persist_items: true,
             deliver_payloads: true,
@@ -451,6 +499,7 @@ impl NodeConfig {
         Self {
             access_model: AccessModel::Whitelist,
             publish_model: PublishModel::Publishers,
+            node_type: None,
             max_items: 10,
             persist_items: true,
             deliver_payloads: true,
@@ -470,6 +519,7 @@ impl NodeConfig {
         Self {
             access_model: AccessModel::Whitelist,
             publish_model: PublishModel::Publishers,
+            node_type: None,
             max_items: 10_000,
             persist_items: true,
             deliver_payloads: false,
@@ -501,10 +551,23 @@ mod tests {
     }
 
     #[test]
+    fn pubsub_node_type_round_trips() {
+        assert_eq!(
+            crate::xep0472::NS_SOCIAL_FEED.parse::<PubSubNodeType>(),
+            Ok(PubSubNodeType::PubsubSocialFeed)
+        );
+        assert_eq!(
+            PubSubNodeType::PubsubSocialFeedStories.to_string(),
+            crate::xep0501::NS_STORIES
+        );
+    }
+
+    #[test]
     fn community_feed_is_open_read_and_open_publish() {
         let config = NodeConfig::community_feed();
         assert_eq!(config.access_model, AccessModel::Open);
         assert_eq!(config.publish_model, PublishModel::Open);
+        assert_eq!(config.node_type, Some(PubSubNodeType::PubsubSocialFeed));
         assert!(config.persist_items);
         assert!(config.deliver_payloads);
         // Differs from spaces_public() only on publish-model: the feed
@@ -512,6 +575,15 @@ mod tests {
         assert_eq!(
             NodeConfig::spaces_public().publish_model,
             PublishModel::Publishers
+        );
+    }
+
+    #[test]
+    fn community_stories_sets_xep0501_node_type() {
+        let config = NodeConfig::community_stories();
+        assert_eq!(
+            config.node_type,
+            Some(PubSubNodeType::PubsubSocialFeedStories)
         );
     }
 

--- a/server/crates/waddle-xmpp-core/src/pubsub/stanzas.rs
+++ b/server/crates/waddle-xmpp-core/src/pubsub/stanzas.rs
@@ -462,6 +462,11 @@ fn parse_configure_form(form: &Element) -> CoreResult<NodeConfigPatch> {
                     CoreError::bad_request(Some(format!("invalid pubsub#publish_model: {value}")))
                 })?);
             }
+            "pubsub#type" => {
+                config.node_type = Some(value.parse().map_err(|_| {
+                    CoreError::bad_request(Some(format!("invalid pubsub#type: {value}")))
+                })?);
+            }
             "pubsub#max_items" => {
                 // XEP-0060 §16.4.3 + XEP-0490 §3 publish-options use the
                 // literal token "max" to mean "no upper bound". Accept it

--- a/server/crates/waddle-xmpp-core/src/pubsub/stanzas/builders.rs
+++ b/server/crates/waddle-xmpp-core/src/pubsub/stanzas/builders.rs
@@ -297,7 +297,7 @@ pub fn build_pubsub_configure_form_result(original_iq: &Iq, node: &str, config: 
             )
             .build()
     }
-    let form = Element::builder("x", "jabber:x:data")
+    let mut form_builder = Element::builder("x", "jabber:x:data")
         .attr(minidom::rxml::xml_ncname!("type").to_owned(), "form")
         .append(hidden_field(
             "FORM_TYPE",
@@ -310,7 +310,11 @@ pub fn build_pubsub_configure_form_result(original_iq: &Iq, node: &str, config: 
         .append(field(
             "pubsub#publish_model",
             &config.publish_model.to_string(),
-        ))
+        ));
+    if let Some(node_type) = config.node_type {
+        form_builder = form_builder.append(field("pubsub#type", node_type.as_str()));
+    }
+    let form = form_builder
         .append(field("pubsub#max_items", &config.max_items.to_string()))
         .append(field(
             "pubsub#persist_items",

--- a/server/crates/waddle-xmpp-core/src/pubsub/stanzas/tests.rs
+++ b/server/crates/waddle-xmpp-core/src/pubsub/stanzas/tests.rs
@@ -47,6 +47,13 @@ fn xdata_field(var: &str, value: &str) -> Element {
         .build()
 }
 
+fn xdata_field_value(form: &Element, var: &str) -> Option<String> {
+    form.children()
+        .find(|field| field.is("field", NS_XDATA) && field.attr("var") == Some(var))
+        .and_then(|field| field.get_child("value", NS_XDATA))
+        .map(|value| value.text())
+}
+
 #[test]
 fn parse_publish_request() {
     let item = PubSubItem::new(
@@ -218,6 +225,67 @@ fn parse_configure_set_keeps_partial_fields_partial() {
         }
         other => panic!("Expected configure-set request, got {other:?}"),
     }
+}
+
+#[test]
+fn parse_configure_set_accepts_typed_pubsub_type() {
+    let configure = Element::builder("configure", NS_PUBSUB_OWNER)
+        .attr(minidom::rxml::xml_ncname!("node").to_owned(), "stories")
+        .append(
+            Element::builder("x", NS_XDATA)
+                .attr(minidom::rxml::xml_ncname!("type").to_owned(), "submit")
+                .append(xdata_field("pubsub#type", crate::xep0501::NS_STORIES))
+                .build(),
+        )
+        .build();
+    let iq = iq_with_payload(
+        "cfg-set-type",
+        Some("owner@example.com"),
+        None,
+        TestIqPayload::Set(pubsub_payload(NS_PUBSUB_OWNER, [configure])),
+    );
+    let request = parse_pubsub_iq(&iq).expect("should parse");
+
+    match request {
+        PubSubRequest::ConfigureNodeSet { config, .. } => {
+            assert_eq!(
+                config.node_type,
+                Some(crate::pubsub::PubSubNodeType::PubsubSocialFeedStories)
+            );
+        }
+        other => panic!("Expected configure-set request, got {other:?}"),
+    }
+}
+
+#[test]
+fn configure_form_result_emits_pubsub_type_for_typed_node() {
+    let iq = iq_with_payload(
+        "cfg-get-type",
+        Some("owner@example.com"),
+        None,
+        TestIqPayload::Get(Element::builder("query", "jabber:iq:version").build()),
+    );
+    let result = build_pubsub_configure_form_result(
+        &iq,
+        "stories",
+        &crate::pubsub::NodeConfig::community_stories(),
+    );
+    let Iq::Result {
+        payload: Some(pubsub),
+        ..
+    } = result
+    else {
+        panic!("expected result payload");
+    };
+    let form = pubsub
+        .get_child("configure", NS_PUBSUB_OWNER)
+        .and_then(|configure| configure.get_child("x", NS_XDATA))
+        .expect("configure data form");
+
+    assert_eq!(
+        xdata_field_value(form, "pubsub#type").as_deref(),
+        Some(crate::xep0501::NS_STORIES)
+    );
 }
 
 #[test]

--- a/server/crates/waddle-xmpp-core/src/xep0472.rs
+++ b/server/crates/waddle-xmpp-core/src/xep0472.rs
@@ -8,10 +8,12 @@
 //! A social post published to PubSub:
 //! ```xml
 //! <item id='post-123' xmlns='http://jabber.org/protocol/pubsub'>
-//!   <entry xmlns='urn:xmpp:pubsub-social-feed:0'>
-//!     <title>Announcement</title>
-//!     <body>We're launching a new feature!</body>
-//!     <author>alice@example.com</author>
+//!   <entry xmlns='http://www.w3.org/2005/Atom'>
+//!     <title type='text'>Announcement</title>
+//!     <id>tag:example.com,2024:post-123</id>
+//!     <updated>2024-06-01T12:00:00Z</updated>
+//!     <content type='text'>We're launching a new feature!</content>
+//!     <author><uri>xmpp:alice@example.com</uri></author>
 //!     <published>2024-06-01T12:00:00Z</published>
 //!   </entry>
 //! </item>
@@ -27,10 +29,13 @@ use chrono::{DateTime, Utc};
 use minidom::Element;
 
 /// Namespace for XEP-0472 Social Feed.
-pub const NS_SOCIAL_FEED: &str = "urn:xmpp:pubsub-social-feed:0";
+pub const NS_SOCIAL_FEED: &str = "urn:xmpp:pubsub-social-feed:1";
+
+/// Atom namespace used for XEP-0472 feed item payloads.
+pub const NS_ATOM: &str = "http://www.w3.org/2005/Atom";
 
 /// PubSub node for social feed posts.
-pub const PUBSUB_NODE_FEED: &str = "urn:xmpp:pubsub-social-feed:0";
+pub const PUBSUB_NODE_FEED: &str = "urn:xmpp:pubsub-social-feed:1";
 
 /// A social feed post/entry.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -112,7 +117,7 @@ impl FeedEntry {
 
 /// Check if an element is a feed entry element.
 pub fn is_feed_entry(elem: &Element) -> bool {
-    elem.ns() == NS_SOCIAL_FEED && elem.name() == "entry"
+    elem.ns() == NS_ATOM && elem.name() == "entry"
 }
 
 // ── Extraction ───────────────────────────────────────────────────────
@@ -123,22 +128,25 @@ pub fn parse_feed_entry(item_id: &str, elem: &Element) -> Option<FeedEntry> {
         return None;
     }
 
-    let text = |name: &str| -> Option<String> {
-        elem.children()
-            .find(|c| c.name() == name && c.ns() == NS_SOCIAL_FEED)
-            .map(|c| c.text())
-            .filter(|t| !t.is_empty())
+    let title = atom_child_text(elem, "title")?;
+    let _atom_id = atom_child_text(elem, "id")?;
+    let updated = atom_child_text(elem, "updated")?.parse().ok()?;
+    let body = atom_child_text(elem, "content")
+        .or_else(|| atom_child_text(elem, "summary"))
+        .unwrap_or_else(|| title.clone());
+    let published = if let Some(published) = atom_child_text(elem, "published") {
+        Some(published.parse().ok()?)
+    } else {
+        Some(updated)
     };
-
-    let body = text("body")?;
 
     Some(FeedEntry {
         id: item_id.to_owned(),
-        title: text("title"),
+        title: Some(title),
         body,
-        author: text("author"),
-        published: text("published").and_then(|t| t.parse().ok()),
-        link: text("link"),
+        author: atom_author(elem),
+        published,
+        link: atom_link_href(elem, None),
     })
 }
 
@@ -146,48 +154,118 @@ pub fn parse_feed_entry(item_id: &str, elem: &Element) -> Option<FeedEntry> {
 
 /// Build an `<entry/>` element for PubSub publication.
 pub fn build_feed_entry_element(entry: &FeedEntry) -> Element {
-    let mut elem = Element::builder("entry", NS_SOCIAL_FEED).build();
+    let mut elem = Element::builder("entry", NS_ATOM).build();
+    let title = entry
+        .title
+        .as_deref()
+        .filter(|title| !title.trim().is_empty())
+        .unwrap_or_else(|| {
+            let preview = entry.preview(80).trim();
+            if preview.is_empty() {
+                "Untitled"
+            } else {
+                preview
+            }
+        });
+    let timestamp = entry.published.unwrap_or_else(Utc::now).to_rfc3339();
 
-    let add = |parent: &mut Element, name: &str, value: &str| {
-        let mut child = Element::builder(name, NS_SOCIAL_FEED).build();
-        child.append_text_node(value);
-        parent.append_child(child);
-    };
-
-    if let Some(ref title) = entry.title {
-        add(&mut elem, "title", title);
+    append_atom_text(&mut elem, "title", title, Some("text"));
+    append_atom_text(&mut elem, "id", &entry.id, None);
+    append_atom_text(&mut elem, "published", &timestamp, None);
+    append_atom_text(&mut elem, "updated", &timestamp, None);
+    if !entry.body.trim().is_empty() {
+        append_atom_text(&mut elem, "content", &entry.body, Some("text"));
     }
-    add(&mut elem, "body", &entry.body);
     if let Some(ref author) = entry.author {
-        add(&mut elem, "author", author);
-    }
-    if let Some(ts) = entry.published {
-        add(&mut elem, "published", &ts.to_rfc3339());
+        elem.append_child(build_atom_author(author));
     }
     if let Some(ref link) = entry.link {
-        add(&mut elem, "link", link);
+        elem.append_child(build_atom_link(link, Some("alternate"), None));
     }
 
     elem
 }
 
-/// Return a copy of a feed `<entry/>` whose `<author>` is `author`,
+/// Return a copy of a feed Atom `<entry/>` whose `<author>` is `author`,
 /// replacing any author the client supplied. On the open, member-postable
 /// feed the service stamps the authenticated publisher here so a member
 /// cannot impersonate another user through the displayed payload author.
 /// All other children are preserved.
 pub fn stamp_feed_entry_author(elem: &Element, author: &str) -> Element {
-    let mut stamped = Element::builder("entry", NS_SOCIAL_FEED).build();
-    for child in elem.children() {
-        if child.name() == "author" && child.ns() == NS_SOCIAL_FEED {
-            continue;
-        }
-        stamped.append_child(child.clone());
+    let mut stamped = elem.clone();
+    let author_children: Vec<(String, String)> = stamped
+        .children()
+        .filter(|child| child.name() == "author" && child.ns() == NS_ATOM)
+        .map(|child| (child.name().to_owned(), child.ns()))
+        .collect();
+    for (name, ns) in author_children {
+        stamped.remove_child(&name, ns.as_str());
     }
-    let mut author_el = Element::builder("author", NS_SOCIAL_FEED).build();
-    author_el.append_text_node(author);
-    stamped.append_child(author_el);
+    stamped.append_child(build_atom_author(author));
     stamped
+}
+
+fn atom_child_text(elem: &Element, name: &str) -> Option<String> {
+    elem.children()
+        .find(|c| c.name() == name && c.ns() == NS_ATOM)
+        .map(|c| c.text())
+        .map(|text| text.trim().to_owned())
+        .filter(|text| !text.is_empty())
+}
+
+fn atom_author(elem: &Element) -> Option<String> {
+    let author = elem
+        .children()
+        .find(|c| c.name() == "author" && c.ns() == NS_ATOM)?;
+    atom_child_text(author, "uri")
+        .map(|uri| uri.strip_prefix("xmpp:").unwrap_or(&uri).to_owned())
+        .or_else(|| atom_child_text(author, "name"))
+        .or_else(|| {
+            let text = author.text().trim().to_owned();
+            (!text.is_empty()).then_some(text)
+        })
+}
+
+fn atom_link_href(elem: &Element, rel: Option<&str>) -> Option<String> {
+    elem.children()
+        .filter(|c| c.name() == "link" && c.ns() == NS_ATOM)
+        .find(|link| match rel {
+            Some(expected) => match link.attr("rel") {
+                Some(actual) => actual == expected,
+                None => true,
+            },
+            None => true,
+        })
+        .and_then(|link| link.attr("href"))
+        .map(str::to_owned)
+}
+
+fn append_atom_text(parent: &mut Element, name: &str, value: &str, type_attr: Option<&str>) {
+    let mut builder = Element::builder(name, NS_ATOM);
+    if let Some(type_attr) = type_attr {
+        builder = builder.attr(minidom::rxml::xml_ncname!("type").to_owned(), type_attr);
+    }
+    let mut child = builder.build();
+    child.append_text_node(value);
+    parent.append_child(child);
+}
+
+fn build_atom_author(author: &str) -> Element {
+    let mut uri = Element::builder("uri", NS_ATOM).build();
+    uri.append_text_node(format!("xmpp:{author}"));
+    Element::builder("author", NS_ATOM).append(uri).build()
+}
+
+fn build_atom_link(href: &str, rel: Option<&str>, media_type: Option<&str>) -> Element {
+    let mut builder =
+        Element::builder("link", NS_ATOM).attr(minidom::rxml::xml_ncname!("href").to_owned(), href);
+    if let Some(rel) = rel {
+        builder = builder.attr(minidom::rxml::xml_ncname!("rel").to_owned(), rel);
+    }
+    if let Some(media_type) = media_type {
+        builder = builder.attr(minidom::rxml::xml_ncname!("type").to_owned(), media_type);
+    }
+    builder.build()
 }
 
 #[cfg(test)]
@@ -203,7 +281,7 @@ mod tests {
 
     #[test]
     fn test_is_feed_entry() {
-        let elem = Element::builder("entry", NS_SOCIAL_FEED).build();
+        let elem = Element::builder("entry", NS_ATOM).build();
         assert!(is_feed_entry(&elem));
 
         let wrong = Element::builder("entry", "jabber:client").build();
@@ -220,6 +298,7 @@ mod tests {
 
         let elem = build_feed_entry_element(&entry);
         assert_eq!(elem.name(), "entry");
+        assert_eq!(elem.ns(), NS_ATOM);
 
         let parsed = parse_feed_entry("p-1", &elem).expect("parseable");
         assert_eq!(parsed.id, "p-1");
@@ -232,23 +311,40 @@ mod tests {
 
     #[test]
     fn test_parse_minimal() {
-        let xml = "<entry xmlns='urn:xmpp:pubsub-social-feed:0'>\
-                    <body>Just a quick update</body>\
+        let xml = "<entry xmlns='http://www.w3.org/2005/Atom'>\
+                    <title type='text'>Just a quick update</title>\
+                    <id>tag:example.com,2024:p-2</id>\
+                    <updated>2024-06-01T12:00:00Z</updated>\
                     </entry>";
         let elem: Element = xml.parse().expect("valid");
         let entry = parse_feed_entry("p-2", &elem).expect("parseable");
         assert_eq!(entry.body, "Just a quick update");
-        assert_eq!(entry.title, None);
+        assert_eq!(entry.title.as_deref(), Some("Just a quick update"));
         assert_eq!(entry.author, None);
     }
 
     #[test]
-    fn test_parse_missing_body() {
-        let xml = "<entry xmlns='urn:xmpp:pubsub-social-feed:0'>\
-                    <title>No body</title>\
+    fn test_parse_missing_title() {
+        let xml = "<entry xmlns='http://www.w3.org/2005/Atom'>\
+                    <id>tag:example.com,2024:p-3</id>\
+                    <updated>2024-06-01T12:00:00Z</updated>\
+                    <content>No title</content>\
                     </entry>";
         let elem: Element = xml.parse().expect("valid");
         assert!(parse_feed_entry("p-3", &elem).is_none());
+    }
+
+    #[test]
+    fn test_parse_missing_required_atom_fields() {
+        for xml in [
+            "<entry xmlns='http://www.w3.org/2005/Atom'><title>No id</title><updated>2024-06-01T12:00:00Z</updated></entry>",
+            "<entry xmlns='http://www.w3.org/2005/Atom'><title>No updated</title><id>tag:example.com,2024:no-updated</id></entry>",
+            "<entry xmlns='http://www.w3.org/2005/Atom'><title>Bad updated</title><id>tag:example.com,2024:bad-updated</id><updated>not-a-date</updated></entry>",
+            "<entry xmlns='http://www.w3.org/2005/Atom'><title>Bad published</title><id>tag:example.com,2024:bad-published</id><updated>2024-06-01T12:00:00Z</updated><published>not-a-date</published></entry>",
+        ] {
+            let elem: Element = xml.parse().expect("valid");
+            assert!(parse_feed_entry("p-required", &elem).is_none());
+        }
     }
 
     #[test]
@@ -277,7 +373,7 @@ mod tests {
 
     #[test]
     fn test_pubsub_node() {
-        assert_eq!(PUBSUB_NODE_FEED, "urn:xmpp:pubsub-social-feed:0");
+        assert_eq!(PUBSUB_NODE_FEED, "urn:xmpp:pubsub-social-feed:1");
     }
 
     #[test]
@@ -304,7 +400,7 @@ mod tests {
         // Exactly one author element after stamping.
         let authors = stamped
             .children()
-            .filter(|c| c.name() == "author" && c.ns() == NS_SOCIAL_FEED)
+            .filter(|c| c.name() == "author" && c.ns() == NS_ATOM)
             .count();
         assert_eq!(authors, 1);
     }

--- a/server/crates/waddle-xmpp-core/src/xep0501.rs
+++ b/server/crates/waddle-xmpp-core/src/xep0501.rs
@@ -7,11 +7,17 @@
 //!
 //! ```xml
 //! <item id='story-123' xmlns='http://jabber.org/protocol/pubsub'>
-//!   <story xmlns='urn:xmpp:stories:0'
-//!          expires='2024-06-02T12:00:00Z'>
-//!     <body>Check out what we're building!</body>
-//!     <media-url>https://example.com/photo.jpg</media-url>
-//!   </story>
+//!   <entry xmlns='http://www.w3.org/2005/Atom'>
+//!     <title type='text'>Check out what we're building!</title>
+//!     <id>story-123</id>
+//!     <published>2024-06-01T12:00:00Z</published>
+//!     <updated>2024-06-01T12:00:00Z</updated>
+//!     <content type='text'>Check out what we're building!</content>
+//!     <link rel='enclosure'
+//!           href='https://example.com/photo.jpg'
+//!           type='image/jpeg'/>
+//!     <expires xmlns='urn:waddle:stories:0'>2024-06-02T12:00:00Z</expires>
+//!   </entry>
 //! </item>
 //! ```
 //!
@@ -21,17 +27,63 @@
 //! - Community "what's happening now" feed
 //! - Auto-cleanup of old content
 
+use std::{fmt, str::FromStr};
+
 use chrono::{DateTime, Duration, Utc};
 use minidom::Element;
 
 /// Namespace for XEP-0501 Stories.
-pub const NS_STORIES: &str = "urn:xmpp:stories:0";
+pub const NS_STORIES: &str = "urn:xmpp:pubsub-social-feed:stories:0";
+
+/// Atom namespace used for XEP-0501 story item payloads.
+pub const NS_ATOM: &str = "http://www.w3.org/2005/Atom";
+
+/// Waddle extension namespace for story fields Atom does not model.
+pub const NS_WADDLE_STORIES: &str = "urn:waddle:stories:0";
 
 /// PubSub node for stories.
-pub const PUBSUB_NODE_STORIES: &str = "urn:xmpp:stories:0";
+pub const PUBSUB_NODE_STORIES: &str = "urn:xmpp:pubsub-social-feed:stories:0";
 
 /// Default story expiry: 24 hours.
 pub const DEFAULT_EXPIRY_HOURS: i64 = 24;
+
+/// MIME type attached to a story Atom enclosure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoryMediaType(String);
+
+impl StoryMediaType {
+    pub fn parse(value: &str) -> Option<Self> {
+        let value = value.trim();
+        let (top, sub) = value.split_once('/')?;
+        if top.is_empty()
+            || sub.is_empty()
+            || value
+                .chars()
+                .any(|ch| ch.is_ascii_control() || ch.is_whitespace())
+        {
+            return None;
+        }
+        Some(Self(value.to_owned()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for StoryMediaType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for StoryMediaType {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s).ok_or(())
+    }
+}
 
 /// A story entry.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -42,6 +94,8 @@ pub struct Story {
     pub body: Option<String>,
     /// Media URL (image/video).
     pub media_url: Option<String>,
+    /// Media MIME type for the Atom enclosure link.
+    pub media_type: Option<StoryMediaType>,
     /// Author JID.
     pub author: Option<String>,
     /// When the story was posted.
@@ -57,6 +111,7 @@ impl Story {
             id: id.into(),
             body: None,
             media_url: None,
+            media_type: None,
             author: None,
             posted: Some(Utc::now()),
             expires: Some(Utc::now() + Duration::hours(DEFAULT_EXPIRY_HOURS)),
@@ -72,6 +127,12 @@ impl Story {
     /// Set a media URL.
     pub fn with_media(mut self, url: impl Into<String>) -> Self {
         self.media_url = Some(url.into());
+        self
+    }
+
+    /// Set the media MIME type.
+    pub fn with_media_type(mut self, media_type: StoryMediaType) -> Self {
+        self.media_type = Some(media_type);
         self
     }
 
@@ -115,70 +176,94 @@ impl Story {
 
 /// Check if an element is a story element.
 pub fn is_story_element(elem: &Element) -> bool {
-    elem.ns() == NS_STORIES && elem.name() == "story"
+    elem.ns() == NS_ATOM && elem.name() == "entry" && enclosure_links(elem).next().is_some()
 }
 
 // ── Extraction ───────────────────────────────────────────────────────
 
-/// Parse a story from a `<story/>` element.
+/// Parse a story from an Atom `<entry/>` element.
 pub fn parse_story(item_id: &str, elem: &Element) -> Option<Story> {
-    if !is_story_element(elem) {
+    if elem.ns() != NS_ATOM || elem.name() != "entry" {
         return None;
     }
 
-    let text = |name: &str| -> Option<String> {
-        elem.children()
-            .find(|c| c.name() == name && c.ns() == NS_STORIES)
-            .map(|c| c.text())
-            .filter(|t| !t.is_empty())
+    let _title = atom_child_text(elem, "title")?;
+    let _atom_id = atom_child_text(elem, "id")?;
+    let updated = atom_child_text(elem, "updated")?.parse().ok()?;
+    let mut enclosures = enclosure_links(elem);
+    let enclosure = enclosures.next()?;
+    if enclosures.next().is_some() {
+        return None;
+    }
+    let media_url = enclosure
+        .attr("href")
+        .map(str::trim)
+        .filter(|href| !href.is_empty())?
+        .to_owned();
+    let media_type = match enclosure.attr("type") {
+        Some(raw) => Some(StoryMediaType::parse(raw)?),
+        None => None,
     };
-
+    let posted = if let Some(posted) = atom_child_text(elem, "published") {
+        Some(posted.parse().ok()?)
+    } else {
+        Some(updated)
+    };
     let expires = elem
-        .attr("expires")
+        .children()
+        .find(|c| c.name() == "expires" && c.ns() == NS_WADDLE_STORIES)
+        .map(|c| c.text())
         .and_then(|s| s.parse::<DateTime<Utc>>().ok());
 
     Some(Story {
         id: item_id.to_owned(),
-        body: text("body"),
-        media_url: text("media-url"),
-        author: text("author"),
-        posted: text("posted").and_then(|t| t.parse().ok()),
+        body: atom_child_text(elem, "content").or_else(|| atom_child_text(elem, "summary")),
+        media_url: Some(media_url),
+        media_type,
+        author: atom_author(elem),
+        posted,
         expires,
     })
 }
 
 // ── Building ─────────────────────────────────────────────────────────
 
-/// Build a `<story/>` element.
+/// Build a story Atom `<entry/>` element.
 pub fn build_story_element(story: &Story) -> Element {
-    let mut builder = Element::builder("story", NS_STORIES);
+    let mut elem = Element::builder("entry", NS_ATOM).build();
+    let posted = story.posted.unwrap_or_else(Utc::now).to_rfc3339();
+    let title = story
+        .body
+        .as_deref()
+        .filter(|body| !body.trim().is_empty())
+        .unwrap_or("Story");
 
-    if let Some(expires) = story.expires {
-        builder = builder.attr(
-            minidom::rxml::xml_ncname!("expires").to_owned(),
-            expires.to_rfc3339(),
-        );
-    }
-
-    let mut elem = builder.build();
-
-    let add = |parent: &mut Element, name: &str, value: &str| {
-        let mut child = Element::builder(name, NS_STORIES).build();
-        child.append_text_node(value);
-        parent.append_child(child);
-    };
-
+    append_atom_text(&mut elem, "title", title, Some("text"));
+    append_atom_text(&mut elem, "id", &story.id, None);
+    append_atom_text(&mut elem, "published", &posted, None);
+    append_atom_text(&mut elem, "updated", &posted, None);
     if let Some(ref body) = story.body {
-        add(&mut elem, "body", body);
+        append_atom_text(&mut elem, "content", body, Some("text"));
     }
-    if let Some(ref url) = story.media_url {
-        add(&mut elem, "media-url", url);
+    if let Some(url) = story
+        .media_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|url| !url.is_empty())
+    {
+        elem.append_child(build_atom_link(
+            url,
+            Some("enclosure"),
+            story.media_type.as_ref().map(StoryMediaType::as_str),
+        ));
     }
     if let Some(ref author) = story.author {
-        add(&mut elem, "author", author);
+        elem.append_child(build_atom_author(author));
     }
-    if let Some(posted) = story.posted {
-        add(&mut elem, "posted", &posted.to_rfc3339());
+    if let Some(expires) = story.expires {
+        let mut expires_el = Element::builder("expires", NS_WADDLE_STORIES).build();
+        expires_el.append_text_node(expires.to_rfc3339());
+        elem.append_child(expires_el);
     }
 
     elem
@@ -191,16 +276,14 @@ pub fn stamp_story_author(item_id: &str, elem: &Element, author: &str) -> Option
     let mut stamped = elem.clone();
     let author_children: Vec<(String, String)> = stamped
         .children()
-        .filter(|child| child.name() == "author" && child.ns() == NS_STORIES)
+        .filter(|child| child.name() == "author" && child.ns() == NS_ATOM)
         .map(|child| (child.name().to_owned(), child.ns()))
         .collect();
     for (name, ns) in author_children {
         stamped.remove_child(&name, ns.as_str());
     }
 
-    let mut child = Element::builder("author", NS_STORIES).build();
-    child.append_text_node(author);
-    stamped.append_child(child);
+    stamped.append_child(build_atom_author(author));
 
     Some(stamped)
 }
@@ -208,6 +291,60 @@ pub fn stamp_story_author(item_id: &str, elem: &Element, author: &str) -> Option
 /// Filter a list of stories to only active (non-expired) ones.
 pub fn filter_active(stories: &[Story]) -> Vec<&Story> {
     stories.iter().filter(|s| s.is_active()).collect()
+}
+
+fn enclosure_links(elem: &Element) -> impl Iterator<Item = &Element> {
+    elem.children()
+        .filter(|c| c.name() == "link" && c.ns() == NS_ATOM && c.attr("rel") == Some("enclosure"))
+}
+
+fn atom_child_text(elem: &Element, name: &str) -> Option<String> {
+    elem.children()
+        .find(|c| c.name() == name && c.ns() == NS_ATOM)
+        .map(|c| c.text())
+        .map(|text| text.trim().to_owned())
+        .filter(|text| !text.is_empty())
+}
+
+fn atom_author(elem: &Element) -> Option<String> {
+    let author = elem
+        .children()
+        .find(|c| c.name() == "author" && c.ns() == NS_ATOM)?;
+    atom_child_text(author, "uri")
+        .map(|uri| uri.strip_prefix("xmpp:").unwrap_or(&uri).to_owned())
+        .or_else(|| atom_child_text(author, "name"))
+        .or_else(|| {
+            let text = author.text().trim().to_owned();
+            (!text.is_empty()).then_some(text)
+        })
+}
+
+fn append_atom_text(parent: &mut Element, name: &str, value: &str, type_attr: Option<&str>) {
+    let mut builder = Element::builder(name, NS_ATOM);
+    if let Some(type_attr) = type_attr {
+        builder = builder.attr(minidom::rxml::xml_ncname!("type").to_owned(), type_attr);
+    }
+    let mut child = builder.build();
+    child.append_text_node(value);
+    parent.append_child(child);
+}
+
+fn build_atom_author(author: &str) -> Element {
+    let mut uri = Element::builder("uri", NS_ATOM).build();
+    uri.append_text_node(format!("xmpp:{author}"));
+    Element::builder("author", NS_ATOM).append(uri).build()
+}
+
+fn build_atom_link(href: &str, rel: Option<&str>, media_type: Option<&str>) -> Element {
+    let mut builder =
+        Element::builder("link", NS_ATOM).attr(minidom::rxml::xml_ncname!("href").to_owned(), href);
+    if let Some(rel) = rel {
+        builder = builder.attr(minidom::rxml::xml_ncname!("rel").to_owned(), rel);
+    }
+    if let Some(media_type) = media_type {
+        builder = builder.attr(minidom::rxml::xml_ncname!("type").to_owned(), media_type);
+    }
+    builder.build()
 }
 
 #[cfg(test)]
@@ -229,10 +366,13 @@ mod tests {
 
     #[test]
     fn test_is_story_element() {
-        let elem = Element::builder("story", NS_STORIES).build();
+        let elem: Element =
+            "<entry xmlns='http://www.w3.org/2005/Atom'><link rel='enclosure' href='https://example.com/photo.jpg'/></entry>"
+                .parse()
+                .expect("atom story");
         assert!(is_story_element(&elem));
 
-        let wrong = Element::builder("story", "jabber:client").build();
+        let wrong = Element::builder("entry", NS_ATOM).build();
         assert!(!is_story_element(&wrong));
     }
 
@@ -241,12 +381,13 @@ mod tests {
         let story = Story::new("s-1")
             .with_body("Hello!")
             .with_media("https://example.com/photo.jpg")
+            .with_media_type("image/jpeg".parse().expect("media type"))
             .with_author("alice@example.com")
             .with_expires_at(future_time());
 
         let elem = build_story_element(&story);
-        assert_eq!(elem.name(), "story");
-        assert!(elem.attr("expires").is_some());
+        assert_eq!(elem.name(), "entry");
+        assert_eq!(elem.ns(), NS_ATOM);
 
         let parsed = parse_story("s-1", &elem).expect("parseable");
         assert_eq!(parsed.id, "s-1");
@@ -254,6 +395,10 @@ mod tests {
         assert_eq!(
             parsed.media_url.as_deref(),
             Some("https://example.com/photo.jpg")
+        );
+        assert_eq!(
+            parsed.media_type.as_ref().map(StoryMediaType::as_str),
+            Some("image/jpeg")
         );
         assert_eq!(parsed.author.as_deref(), Some("alice@example.com"));
         assert_eq!(parsed.expires, Some(future_time()));
@@ -283,13 +428,19 @@ mod tests {
     #[test]
     fn test_stamp_story_author_preserves_expires_wire_value() {
         let elem: Element =
-            "<story xmlns='urn:xmpp:stories:0' expires='2030-01-01T12:00:00Z'><body>Hello!</body><author>spoof@example.com</author></story>"
+            "<entry xmlns='http://www.w3.org/2005/Atom'><title>Hello!</title><id>s-1</id><updated>2026-06-01T12:00:00Z</updated><content>Hello!</content><author><uri>xmpp:spoof@example.com</uri></author><link rel='enclosure' href='https://example.com/photo.jpg' type='image/jpeg'/><expires xmlns='urn:waddle:stories:0'>2030-01-01T12:00:00Z</expires></entry>"
                 .parse()
                 .expect("story element");
 
         let stamped = stamp_story_author("s-1", &elem, "alice@example.com").expect("story");
 
-        assert_eq!(stamped.attr("expires"), Some("2030-01-01T12:00:00Z"));
+        assert_eq!(
+            stamped
+                .get_child("expires", NS_WADDLE_STORIES)
+                .map(|expires| expires.text())
+                .as_deref(),
+            Some("2030-01-01T12:00:00Z")
+        );
         assert_eq!(
             parse_story("s-1", &stamped)
                 .expect("parseable")
@@ -301,13 +452,36 @@ mod tests {
 
     #[test]
     fn test_parse_minimal() {
-        let xml = "<story xmlns='urn:xmpp:stories:0'>\
-                    <body>Quick update</body>\
-                    </story>";
+        let xml = "<entry xmlns='http://www.w3.org/2005/Atom'>\
+                    <title type='text'>Quick update</title>\
+                    <id>s-2</id>\
+                    <updated>2026-06-01T12:00:00Z</updated>\
+                    <content type='text'>Quick update</content>\
+                    <link rel='enclosure' href='https://example.com/photo.jpg'/>\
+                    </entry>";
         let elem: Element = xml.parse().expect("valid");
         let story = parse_story("s-2", &elem).expect("parseable");
         assert_eq!(story.body.as_deref(), Some("Quick update"));
-        assert_eq!(story.media_url, None);
+        assert_eq!(
+            story.media_url.as_deref(),
+            Some("https://example.com/photo.jpg")
+        );
+    }
+
+    #[test]
+    fn test_parse_missing_required_atom_fields() {
+        for xml in [
+            "<entry xmlns='http://www.w3.org/2005/Atom'><id>s</id><updated>2026-06-01T12:00:00Z</updated><link rel='enclosure' href='https://example.com/photo.jpg'/></entry>",
+            "<entry xmlns='http://www.w3.org/2005/Atom'><title>Story</title><updated>2026-06-01T12:00:00Z</updated><link rel='enclosure' href='https://example.com/photo.jpg'/></entry>",
+            "<entry xmlns='http://www.w3.org/2005/Atom'><title>Story</title><id>s</id><link rel='enclosure' href='https://example.com/photo.jpg'/></entry>",
+            "<entry xmlns='http://www.w3.org/2005/Atom'><title>Story</title><id>s</id><updated>not-a-date</updated><link rel='enclosure' href='https://example.com/photo.jpg'/></entry>",
+            "<entry xmlns='http://www.w3.org/2005/Atom'><title>Story</title><id>s</id><updated>2026-06-01T12:00:00Z</updated><link rel='enclosure' href='   '/></entry>",
+            "<entry xmlns='http://www.w3.org/2005/Atom'><title>Story</title><id>s</id><updated>2026-06-01T12:00:00Z</updated><published>not-a-date</published><link rel='enclosure' href='https://example.com/photo.jpg'/></entry>",
+            "<entry xmlns='http://www.w3.org/2005/Atom'><title>Story</title><id>s</id><updated>2026-06-01T12:00:00Z</updated><link rel='enclosure' href='https://example.com/photo.jpg' type='not-a-mime'/></entry>",
+        ] {
+            let elem: Element = xml.parse().expect("valid");
+            assert!(parse_story("s-required", &elem).is_none());
+        }
     }
 
     #[test]
@@ -351,12 +525,12 @@ mod tests {
 
     #[test]
     fn test_pubsub_node() {
-        assert_eq!(PUBSUB_NODE_STORIES, "urn:xmpp:stories:0");
+        assert_eq!(PUBSUB_NODE_STORIES, "urn:xmpp:pubsub-social-feed:stories:0");
     }
 
     #[test]
     fn test_is_story_element_negative() {
-        let wrong = Element::builder("other", NS_STORIES).build();
+        let wrong = Element::builder("other", NS_ATOM).build();
         assert!(!is_story_element(&wrong));
         let wrong_ns = Element::builder("story", "wrong:ns").build();
         assert!(!is_story_element(&wrong_ns));
@@ -372,9 +546,14 @@ mod tests {
         let s = Story::new("id")
             .with_body("hello")
             .with_media("https://example.com/img.jpg")
+            .with_media_type("image/jpeg".parse().expect("media type"))
             .with_author("alice@example.com");
         assert_eq!(s.body.as_deref(), Some("hello"));
         assert_eq!(s.media_url.as_deref(), Some("https://example.com/img.jpg"));
+        assert_eq!(
+            s.media_type.as_ref().map(StoryMediaType::as_str),
+            Some("image/jpeg")
+        );
         assert_eq!(s.author.as_deref(), Some("alice@example.com"));
     }
 

--- a/server/crates/waddle-xmpp/tests/xep0030_service_discovery.rs
+++ b/server/crates/waddle-xmpp/tests/xep0030_service_discovery.rs
@@ -354,7 +354,7 @@ fn xep0030_muc_rooms_advertise_disco_info() {
         for members_only in [false, true] {
             for moderated in [false, true] {
                 for forum in [false, true] {
-                    let feats = muc_room_features(persistent, members_only, moderated, forum);
+                    let feats = muc_room_features(persistent, members_only, true, moderated, forum);
                     assert!(
                         feats.iter().any(|f| f.0 == DISCO_INFO_NS),
                         "room ({persistent}, {members_only}, {moderated}, {forum}) \

--- a/server/crates/waddle-xmpp/tests/xep0085_chat_state_notifications.rs
+++ b/server/crates/waddle-xmpp/tests/xep0085_chat_state_notifications.rs
@@ -12,7 +12,7 @@ fn xep0085_advertisement_consistency_no_false_feature_claim() {
 
 #[test]
 fn xep0085_muc_rooms_advertise_chat_states() {
-    let features = muc_room_features(false, false, false, false);
+    let features = muc_room_features(false, false, true, false, false);
     assert!(features.contains(&Feature::chat_states()));
     assert_eq!(Feature::chat_states(), Feature::new(CHAT_STATES_NS));
 }

--- a/server/crates/waddle-xmpp/tests/xep0308_message_correction.rs
+++ b/server/crates/waddle-xmpp/tests/xep0308_message_correction.rs
@@ -56,7 +56,7 @@ fn xep0308_muc_rooms_advertise_correction_in_every_configuration() {
         for members_only in [false, true] {
             for moderated in [false, true] {
                 for forum in [false, true] {
-                    let feats = muc_room_features(persistent, members_only, moderated, forum);
+                    let feats = muc_room_features(persistent, members_only, true, moderated, forum);
                     assert!(
                         feats.iter().any(|f| f == &target),
                         "muc_room_features({persistent}, {members_only}, {moderated}, {forum}) \

--- a/server/crates/waddle-xmpp/tests/xep0313_mam.rs
+++ b/server/crates/waddle-xmpp/tests/xep0313_mam.rs
@@ -10,7 +10,7 @@ fn server_root_disco_does_not_advertise_a_domain_archive() {
 
 #[test]
 fn muc_room_disco_advertises_mam_extended_for_supported_id_filters() {
-    let features = muc_room_features(true, true, false, false);
+    let features = muc_room_features(true, true, true, false, false);
 
     assert!(features.contains(&Feature::mam()));
     assert!(features.contains(&Feature::mam_extended()));

--- a/server/crates/waddle-xmpp/tests/xep0333_displayed_markers.rs
+++ b/server/crates/waddle-xmpp/tests/xep0333_displayed_markers.rs
@@ -10,7 +10,7 @@ fn xep0333_server_and_muc_disco_advertise_displayed_markers() {
     let server = server_features();
     assert!(server.contains(&Feature::chat_markers()));
 
-    let room = muc_room_features(false, false, false, false);
+    let room = muc_room_features(false, false, true, false, false);
     assert!(room.contains(&Feature::chat_markers()));
 }
 

--- a/server/crates/waddle-xmpp/tests/xep0372_references.rs
+++ b/server/crates/waddle-xmpp/tests/xep0372_references.rs
@@ -70,7 +70,7 @@ fn xep0372_muc_rooms_advertise_references_in_every_configuration() {
         for members_only in [false, true] {
             for moderated in [false, true] {
                 for forum in [false, true] {
-                    let feats = muc_room_features(persistent, members_only, moderated, forum);
+                    let feats = muc_room_features(persistent, members_only, true, moderated, forum);
                     assert!(
                         feats.iter().any(|f| f == &target),
                         "muc_room_features({persistent}, {members_only}, {moderated}, {forum}) \

--- a/server/crates/waddle-xmpp/tests/xep0421_occupant_id.rs
+++ b/server/crates/waddle-xmpp/tests/xep0421_occupant_id.rs
@@ -53,7 +53,7 @@ fn xep0421_advertised_on_every_room_configuration() {
         for members_only in [false, true] {
             for moderated in [false, true] {
                 for forum in [false, true] {
-                    let feats = muc_room_features(persistent, members_only, moderated, forum);
+                    let feats = muc_room_features(persistent, members_only, true, moderated, forum);
                     assert!(
                         feats.iter().any(|f| f == &target),
                         "muc_room_features(persistent={persistent}, members_only={members_only}, moderated={moderated}, forum={forum}) \

--- a/server/crates/waddle-xmpp/tests/xep0424_message_retraction.rs
+++ b/server/crates/waddle-xmpp/tests/xep0424_message_retraction.rs
@@ -70,7 +70,7 @@ fn xep0424_muc_rooms_advertise_tombstone_feature_in_every_configuration() {
         for members_only in [false, true] {
             for moderated in [false, true] {
                 for forum in [false, true] {
-                    let feats = muc_room_features(persistent, members_only, moderated, forum);
+                    let feats = muc_room_features(persistent, members_only, true, moderated, forum);
                     assert!(
                         feats.iter().any(|f| f == &target),
                         "muc_room_features(persistent={persistent}, members_only={members_only}, \

--- a/server/crates/waddle-xmpp/tests/xep0425_message_moderation.rs
+++ b/server/crates/waddle-xmpp/tests/xep0425_message_moderation.rs
@@ -54,7 +54,7 @@ fn xep0425_advertised_on_every_room_configuration() {
         for members_only in [false, true] {
             for moderated in [false, true] {
                 for forum in [false, true] {
-                    let feats = muc_room_features(persistent, members_only, moderated, forum);
+                    let feats = muc_room_features(persistent, members_only, true, moderated, forum);
                     assert!(
                         feats.iter().any(|f| f == &target),
                         "muc_room_features(persistent={persistent}, members_only={members_only}, \

--- a/server/crates/waddle-xmpp/tests/xep0431_fulltext_mam.rs
+++ b/server/crates/waddle-xmpp/tests/xep0431_fulltext_mam.rs
@@ -65,7 +65,7 @@ fn xep0431_advertised_on_every_room_configuration() {
         for members_only in [false, true] {
             for moderated in [false, true] {
                 for forum in [false, true] {
-                    let feats = muc_room_features(persistent, members_only, moderated, forum);
+                    let feats = muc_room_features(persistent, members_only, true, moderated, forum);
                     assert!(
                         feats.iter().any(|f| f == &target),
                         "muc_room_features({persistent}, {members_only}, {moderated}, {forum}) \

--- a/server/crates/waddle-xmpp/tests/xep0444_message_reactions.rs
+++ b/server/crates/waddle-xmpp/tests/xep0444_message_reactions.rs
@@ -57,7 +57,7 @@ fn xep0444_muc_rooms_advertise_reactions_in_every_configuration() {
         for members_only in [false, true] {
             for moderated in [false, true] {
                 for forum in [false, true] {
-                    let feats = muc_room_features(persistent, members_only, moderated, forum);
+                    let feats = muc_room_features(persistent, members_only, true, moderated, forum);
                     assert!(
                         feats.iter().any(|f| f == &target),
                         "muc_room_features(persistent={persistent}, members_only={members_only}, \

--- a/server/crates/waddle-xmpp/tests/xep0461_message_replies.rs
+++ b/server/crates/waddle-xmpp/tests/xep0461_message_replies.rs
@@ -56,7 +56,7 @@ fn xep0461_muc_rooms_advertise_reply_feature_in_every_configuration() {
         for members_only in [false, true] {
             for moderated in [false, true] {
                 for forum in [false, true] {
-                    let feats = muc_room_features(persistent, members_only, moderated, forum);
+                    let feats = muc_room_features(persistent, members_only, true, moderated, forum);
                     assert!(
                         feats.iter().any(|f| f == &target),
                         "muc_room_features(persistent={persistent}, members_only={members_only}, \

--- a/server/crates/waddle-xmpp/tests/xep0513_mentions.rs
+++ b/server/crates/waddle-xmpp/tests/xep0513_mentions.rs
@@ -66,7 +66,7 @@ fn xep0513_muc_rooms_advertise_mentions_and_channel_mentions() {
         for members_only in [false, true] {
             for moderated in [false, true] {
                 for forum in [false, true] {
-                    let feats = muc_room_features(persistent, members_only, moderated, forum);
+                    let feats = muc_room_features(persistent, members_only, true, moderated, forum);
                     assert!(
                         feats.iter().any(|f| f == &mentions),
                         "muc_room_features({persistent}, {members_only}, {moderated}, {forum}) \

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -474,8 +474,8 @@ export class WaddleClient {
      */
     stories_items(community_jid: string, max_items?: number | null): Promise<any>;
     /**
-     * Publish a new story. At least one of `body` / `media_url` is
-     * required (the server rejects empty stories). `expiry_hours`
+     * Publish a new story. `media_url` is required by XEP-0501; `body`
+     * is optional text content attached to that media. `expiry_hours`
      * defaults to 24.
      */
     stories_publish(community_jid: string, input: any): Promise<any>;

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=824e278eeda8";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=824e278eeda8";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=824e278eeda8";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=6f209191697d";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=6f209191697d";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=6f209191697d";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=824e278eeda8";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=6f209191697d";


### PR DESCRIPTION
## Summary

- Make the seeded public managed channels (`chat`, `announcements`, `github-actions`) public/open for deployment members while keeping direct MUC affiliations authoritative.
- Add channel type plumbing across server admin commands, WASM bindings, and chat admin UI for `text`, `announcement`, `forum`, and `group-dm`.
- Preserve managed `announcement` semantics through admin, bookmark backfill, spaces rollback, disco metadata, and MUC owner config: owner forms can no longer make an announcement room live-unmoderated while it is still cataloged as `announcement`.
- Align XEP-0472 and XEP-0501 feed/story payloads with the repo-local XEP corpus, including Atom entries, current pubsub namespaces, strict required field/date/enclosure validation, authenticated author stamping, and typed story media types.
- Require story media URLs through chat, WASM, core parsing, and server publish gates so blank-media stories fail before publication.

## Plan

- [x] Review the permission and payload model against local `./xeps`.
- [x] Fix public/open managed channel seeding and MUC admission semantics.
- [x] Fix channel type surfaces and preserve announcement projections.
- [x] Fix XEP-0472/XEP-0501 feed and story wire shapes.
- [x] Add targeted Rust/chat tests for the changed behavior.
- [x] Run adversarial chat/admin/WASM review and address the owner-config blocker it found.
- [x] Run local validation before marking ready.

## Latest Validation

- `cargo fmt`
- `cargo test -p waddle-server --lib channel_type_projection_tests`
- `cargo test -p waddle-server --lib muc_owner_config`
- `cargo test -p waddle-xmpp-core xep0501`
- `cargo test -p waddle-xmpp-client-wasm stories` (compiled cleanly; no Rust tests matched the filter)
- `cargo clippy -p waddle-server --all-targets -- -D warnings`
- `git diff --check`

## Notes

- The local HTTP-spawning websocket integration fixture currently times out before writing its port file in this sandbox, so CI remains the authoritative integration signal for those tests.
- Story nodes keep the current open access model intentionally so authenticated community members can read and publish under the current pubsub authorization model.
