### PR TITLE
feat(chat): call keyboard shortcuts

### DIFF
--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -447,7 +447,9 @@ useCallShortcuts(
     "toggle-raise-hand": () => void onToggleRaisedHand(),
     "enter-immersive": () => {
       enterImmersive();
-      if (!nativeFullscreenActive.value) void toggleNativeFullscreen();
+      // requestFullscreen rejects if the gesture was consumed or denied;
+      // swallow it so the immersive switch still stands.
+      if (!nativeFullscreenActive.value) void toggleNativeFullscreen().catch(() => {});
     },
   },
   () => isOpen.value,
@@ -725,6 +727,7 @@ onBeforeUnmount(() => {
     }"
     role="region"
     :aria-label="isImmersive ? 'Active call (immersive)' : 'Active call (expanded)'"
+    tabindex="-1"
     @focusin="revealImmersiveChrome"
     @keydown="revealImmersiveChrome"
     @pointermove="revealImmersiveChrome"

--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -27,10 +27,12 @@ import {
   hangupActiveCall,
   peerLabelFromState,
   refreshScreenShareSupported,
+  setPushToTalkActive,
   toggleCam,
   toggleMic,
   toggleScreenShare,
 } from "@/lib/calls/call-controls";
+import { useCallShortcuts } from "@/lib/calls/use-call-shortcuts";
 import { useCallEngine } from "@/lib/calls/use-call-engine";
 import { useActiveMucCall } from "@/lib/calls/use-active-muc-call";
 import { localScreenSharePresentation } from "@/lib/calls/call-self-share";
@@ -429,6 +431,28 @@ function enterImmersive(): void {
   $callUiMode.set("immersive");
 }
 
+// #1034: keyboard shortcuts while the expanded/immersive surface is focused.
+// Gated on `isOpen` because the split surface stays mounted alongside this one
+// — without the gate every shortcut would fire twice. `F` enters immersive and
+// requests native fullscreen (idempotent: it never toggles fullscreen back
+// off). `Esc` is intentionally NOT mapped here: the bespoke `onKeydown` below
+// already owns Escape (menu/settings/dock/PiP/collapse precedence).
+useCallShortcuts(
+  {
+    "toggle-mic": () => void toggleMic(),
+    "push-to-talk-start": () => setPushToTalkActive(true),
+    "push-to-talk-end": () => setPushToTalkActive(false),
+    "toggle-camera": () => void toggleCam(),
+    "toggle-share": () => void toggleScreenShare(),
+    "toggle-raise-hand": () => void onToggleRaisedHand(),
+    "enter-immersive": () => {
+      enterImmersive();
+      if (!nativeFullscreenActive.value) void toggleNativeFullscreen();
+    },
+  },
+  () => isOpen.value,
+);
+
 function clearChromeIdleTimer(): void {
   if (typeof window === "undefined") return;
   if (chromeIdleTimer === null) return;
@@ -633,6 +657,13 @@ function onKeydown(event: KeyboardEvent): void {
   if (dockOpen.value) {
     event.preventDefault();
     closeCallDock();
+    return;
+  }
+  // #1034: Picture-in-Picture is another layer above the stage — Escape pops
+  // it before collapsing the surface, matching "Esc exits immersive/PiP".
+  if (pictureInPictureActive.value) {
+    event.preventDefault();
+    void closePictureInPictureSafely();
     return;
   }
   event.preventDefault();

--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -443,7 +443,11 @@ useCallShortcuts(
     "push-to-talk-start": () => setPushToTalkActive(true),
     "push-to-talk-end": () => setPushToTalkActive(false),
     "toggle-camera": () => void toggleCam(),
-    "toggle-share": () => void toggleScreenShare(),
+    "toggle-share": () => {
+      // Mirror the hidden Share button: don't start capture where unsupported.
+      if (!screenShareSupported.value) return false;
+      void toggleScreenShare();
+    },
     "toggle-raise-hand": () => void onToggleRaisedHand(),
     "enter-immersive": () => {
       enterImmersive();

--- a/chat/src/components/calls/CallSplitContainer.vue
+++ b/chat/src/components/calls/CallSplitContainer.vue
@@ -399,7 +399,11 @@ useCallShortcuts(
     "push-to-talk-start": () => setPushToTalkActive(true),
     "push-to-talk-end": () => setPushToTalkActive(false),
     "toggle-camera": () => void toggleCam(),
-    "toggle-share": () => void toggleScreenShare(),
+    "toggle-share": () => {
+      // Mirror the hidden Share button: don't start capture where unsupported.
+      if (!screenShareSupported.value) return false;
+      void toggleScreenShare();
+    },
     "toggle-raise-hand": () => void onToggleRaisedHand(),
     "enter-immersive": () => $callUiMode.set("immersive"),
     "exit-immersive": () => {

--- a/chat/src/components/calls/CallSplitContainer.vue
+++ b/chat/src/components/calls/CallSplitContainer.vue
@@ -23,10 +23,12 @@ import {
   hangupActiveCall,
   peerLabelFromState,
   refreshScreenShareSupported,
+  setPushToTalkActive,
   toggleCam,
   toggleMic,
   toggleScreenShare,
 } from "@/lib/calls/call-controls";
+import { useCallShortcuts } from "@/lib/calls/use-call-shortcuts";
 import { useCallEngine } from "@/lib/calls/use-call-engine";
 import { useActiveMucCall } from "@/lib/calls/use-active-muc-call";
 import { useSplitResize } from "@/lib/calls/use-split-resize";
@@ -382,6 +384,29 @@ onBeforeUnmount(() => {
     resetLocalPictureInPictureState();
   }
 });
+
+// #1034: keyboard shortcuts while the split call surface is focused. Gated on
+// `shouldRender` because the expanded surface stays mounted alongside this one
+// — without the gate every shortcut would fire twice. From the inline split
+// view, `F` promotes to the immersive surface (which owns native fullscreen),
+// and `Esc` closes Picture-in-Picture when one is open (otherwise it declines,
+// returning false, so the keystroke is left for other handlers).
+useCallShortcuts(
+  {
+    "toggle-mic": () => void toggleMic(),
+    "push-to-talk-start": () => setPushToTalkActive(true),
+    "push-to-talk-end": () => setPushToTalkActive(false),
+    "toggle-camera": () => void toggleCam(),
+    "toggle-share": () => void toggleScreenShare(),
+    "toggle-raise-hand": () => void onToggleRaisedHand(),
+    "enter-immersive": () => $callUiMode.set("immersive"),
+    "exit-immersive": () => {
+      if (!pictureInPictureActive.value) return false;
+      void closePictureInPictureSafely();
+    },
+  },
+  () => shouldRender.value,
+);
 
 async function onHangup(): Promise<void> {
   await closePictureInPictureSafely();

--- a/chat/src/components/calls/CallSplitContainer.vue
+++ b/chat/src/components/calls/CallSplitContainer.vue
@@ -388,9 +388,11 @@ onBeforeUnmount(() => {
 // #1034: keyboard shortcuts while the split call surface is focused. Gated on
 // `shouldRender` because the expanded surface stays mounted alongside this one
 // — without the gate every shortcut would fire twice. From the inline split
-// view, `F` promotes to the immersive surface (which owns native fullscreen),
-// and `Esc` closes Picture-in-Picture when one is open (otherwise it declines,
-// returning false, so the keystroke is left for other handlers).
+// view `F` enters immersive; native fullscreen can't be requested here because
+// switching modes remounts the surface (the requestFullscreen call would lose
+// its user-gesture), so the immersive surface requests it on its own `F`. `Esc`
+// closes Picture-in-Picture when one is open, otherwise it declines (returns
+// false) so the keystroke is left for other handlers.
 useCallShortcuts(
   {
     "toggle-mic": () => void toggleMic(),
@@ -533,6 +535,7 @@ async function togglePictureInPicture(): Promise<void> {
       :class="{ 'call-split--dragging': isDragging }"
       role="region"
       aria-label="Active call"
+      tabindex="-1"
     >
       <CallStageHeader :title="callLabel" :subline="subline" compact />
       <div

--- a/chat/src/lib/calls/call-controls.ts
+++ b/chat/src/lib/calls/call-controls.ts
@@ -57,43 +57,71 @@ function getSender(): CallWireSender | null {
 }
 
 /**
- * Toggle the local microphone, with optimistic UI + rollback. Doubles
- * as the recovery path: a device-less / permission-denied participant
- * who later plugs in a mic or grants access can click "unmute" to
- * retry capture. On success the recorded media issue is cleared; on
- * failure the atom rolls back and the issue is (re)recorded so the
- * non-blocking notice updates instead of a transient error toast.
+ * Serialize mic enable/disable (#1034). Push-to-talk fires `setCallMic`
+ * back-to-back on Space down/up; without ordering, a late-resolving enable
+ * could land after a newer disable and strand the mic open (and broadcast a
+ * stale mute). Each request bumps a generation token and chains behind the
+ * previous op, so engine calls never overlap and a request that is no longer
+ * the latest is dropped — before the engine call if it never started, or
+ * before its post-effects if it was superseded mid-flight. Only the last
+ * requested state is applied and broadcast.
+ */
+let micOpChain: Promise<void> = Promise.resolve();
+let micRequestGen = 0;
+
+/**
+ * Drive the local microphone to `next` with optimistic UI + rollback, the
+ * recorded media-issue notice, and the `urn:waddle:in-call:0` mute broadcast —
+ * serialized last-writer-wins (see [`micOpChain`]). Doubles as the recovery
+ * path: a device-less / permission-denied participant who later plugs in a mic
+ * or grants access can retry capture. Resolves once this request's effects
+ * have settled (or it was superseded).
+ */
+function setCallMic(next: boolean): Promise<void> {
+  const gen = ++micRequestGen;
+  $callMicEnabled.set(next); // optimistic
+  const op = micOpChain.then(async () => {
+    if (gen !== micRequestGen) return; // a newer request superseded this one
+    try {
+      const { engine } = useCallEngine();
+      await engine.setMicEnabled(next);
+      if (gen !== micRequestGen) return; // superseded while awaiting the engine
+      clearMediaIssue("mic");
+      // #1030: broadcast the new mute state as `urn:waddle:in-call:0`
+      // presence so other participants' tiles and roster reflect it — the
+      // authoritative, XMPP-native remote-mute path (no LiveKit data
+      // channel). A no-op for DM calls; the broadcaster guards on an active
+      // MUC call. Fire-and-forget: a failed presence self-heals on the next.
+      const sender = getSender();
+      if (sender) void broadcastMucCallSelfMute(sender as unknown as RawIqSender, !next);
+    } catch (err) {
+      if (gen === micRequestGen) {
+        $callMicEnabled.set(!next);
+        recordMediaIssue("mic", err);
+      }
+    }
+  });
+  micOpChain = op;
+  return op;
+}
+
+/**
+ * Toggle the local microphone. Thin wrapper over [`setCallMic`] so manual
+ * mute clicks share the same serialized, optimistic, rollback-and-broadcast
+ * path as push-to-talk.
  */
 export async function toggleMic(): Promise<void> {
-  const next = !$callMicEnabled.get();
-  $callMicEnabled.set(next);
-  try {
-    const { engine } = useCallEngine();
-    await engine.setMicEnabled(next);
-    clearMediaIssue("mic");
-    // #1030: broadcast the new mute state as `urn:waddle:in-call:0`
-    // presence so other participants' tiles and roster reflect it — the
-    // authoritative, XMPP-native remote-mute path (no LiveKit data
-    // channel). A no-op for DM calls; the broadcaster guards on an active
-    // MUC call. Fire-and-forget: a failed presence self-heals on the next.
-    const sender = getSender();
-    if (sender) void broadcastMucCallSelfMute(sender as unknown as RawIqSender, !next);
-  } catch (err) {
-    $callMicEnabled.set(!next);
-    recordMediaIssue("mic", err);
-  }
+  await setCallMic(!$callMicEnabled.get());
 }
 
 /**
  * Push-to-talk (#1034): force the mic on while the Space key is held and
- * off on release. Implemented on top of [`toggleMic`] so the optimistic
- * flip, rollback, recorded media issue, and `urn:waddle:in-call:0` mute
- * broadcast all match a manual mute toggle — and so it is a no-op when the
- * mic is already in the requested state (no redundant engine call or
- * presence churn while the key repeats or when the user already unmuted).
+ * off on release, via the serialized [`setCallMic`]. A no-op when the mic is
+ * already in the requested state, so a held/repeating key or an already-open
+ * mic doesn't churn the engine or the mute presence.
  */
 export function setPushToTalkActive(active: boolean): void {
-  if ($callMicEnabled.get() !== active) void toggleMic();
+  if ($callMicEnabled.get() !== active) void setCallMic(active);
 }
 
 /** Toggle the local camera, with optimistic UI + rollback. Mirrors

--- a/chat/src/lib/calls/call-controls.ts
+++ b/chat/src/lib/calls/call-controls.ts
@@ -84,6 +84,18 @@ export async function toggleMic(): Promise<void> {
   }
 }
 
+/**
+ * Push-to-talk (#1034): force the mic on while the Space key is held and
+ * off on release. Implemented on top of [`toggleMic`] so the optimistic
+ * flip, rollback, recorded media issue, and `urn:waddle:in-call:0` mute
+ * broadcast all match a manual mute toggle — and so it is a no-op when the
+ * mic is already in the requested state (no redundant engine call or
+ * presence churn while the key repeats or when the user already unmuted).
+ */
+export function setPushToTalkActive(active: boolean): void {
+  if ($callMicEnabled.get() !== active) void toggleMic();
+}
+
 /** Toggle the local camera, with optimistic UI + rollback. Mirrors
  *  [`toggleMic`] — also the retry path for a device-less / denied
  *  camera once a device is attached or access is granted. */

--- a/chat/src/lib/calls/call-shortcuts.ts
+++ b/chat/src/lib/calls/call-shortcuts.ts
@@ -1,0 +1,103 @@
+/**
+ * Pure keyboard-shortcut mapping for the in-call surfaces (#1034).
+ *
+ * The single source of truth for "which key does what" lives here as a
+ * total function from a keyboard-event descriptor to a typed intent — no
+ * DOM, no side effects — so the mapping can be exhaustively unit-tested
+ * and the Vue wiring stays a thin adapter that only translates DOM events
+ * into descriptors and dispatches the resulting intent to existing call
+ * actions.
+ */
+
+export type CallShortcutIntent =
+  | "toggle-mic"
+  | "push-to-talk-start"
+  | "push-to-talk-end"
+  | "toggle-camera"
+  | "toggle-share"
+  | "toggle-raise-hand"
+  | "enter-immersive"
+  | "exit-immersive";
+
+/**
+ * Everything the mapping needs to decide an intent, lifted out of the DOM
+ * `KeyboardEvent` so the decision is pure and testable. `surfaceFocused`
+ * (focus within a call surface) and `editableTarget` (typing into an
+ * input / contenteditable) are computed once by the wiring adapter.
+ */
+export type CallShortcutInput = {
+  key: string;
+  type: "keydown" | "keyup";
+  repeat: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  altKey: boolean;
+  editableTarget: boolean;
+  surfaceFocused: boolean;
+};
+
+/**
+ * Roots of the three in-call surfaces — split (inline above chat),
+ * expanded/immersive, and the document Picture-in-Picture window body.
+ * Focus within any of them scopes the shortcuts to "a focused call surface".
+ */
+const CALL_SURFACE_SELECTOR = ".call-split, .call-expanded, .call-pip-document";
+
+/**
+ * Text-entry targets where the keys must stay inert. Matches the editable
+ * guard used elsewhere in the chat shell (`isEditableKeyTarget`) so typing
+ * in the composer, a search box, or a settings field never toggles the call.
+ */
+const EDITABLE_SELECTOR = "input, textarea, select, [contenteditable='true']";
+
+/** The minimal slice of `Element` the target descriptor needs. */
+type ClosestQueryable = Pick<Element, "closest">;
+
+/**
+ * Derive the two scope booleans `resolveCallShortcut` consumes from the
+ * keyboard event's target. Pure: it only reads `closest`, so the wiring
+ * adapter narrows `event.target` to an element and hands it here.
+ */
+export function describeCallShortcutTarget(
+  target: ClosestQueryable | null,
+): { surfaceFocused: boolean; editableTarget: boolean } {
+  if (!target) return { surfaceFocused: false, editableTarget: false };
+  return {
+    surfaceFocused: target.closest(CALL_SURFACE_SELECTOR) !== null,
+    editableTarget: target.closest(EDITABLE_SELECTOR) !== null,
+  };
+}
+
+export function resolveCallShortcut(input: CallShortcutInput): CallShortcutIntent | null {
+  // Scoped to a focused call surface, and inert while the user is typing in
+  // chat — both checked before anything else so no key ever leaks through.
+  if (!input.surfaceFocused) return null;
+  if (input.editableTarget) return null;
+  // Never hijack OS / browser chords (Cmd+M, Ctrl+S, …) — only bare keys.
+  if (input.ctrlKey || input.metaKey || input.altKey) return null;
+
+  if (input.key === " ") {
+    if (input.type === "keyup") return "push-to-talk-end";
+    // Auto-repeat would spam push-to-talk-start while the key is held.
+    return input.repeat ? null : "push-to-talk-start";
+  }
+  // Toggles and one-shots fire on the initial keydown only — keyup and
+  // OS auto-repeat must not re-fire them.
+  if (input.type === "keyup" || input.repeat) return null;
+  switch (input.key.toLowerCase()) {
+    case "m":
+      return "toggle-mic";
+    case "v":
+      return "toggle-camera";
+    case "s":
+      return "toggle-share";
+    case "r":
+      return "toggle-raise-hand";
+    case "f":
+      return "enter-immersive";
+    case "escape":
+      return "exit-immersive";
+    default:
+      return null;
+  }
+}

--- a/chat/src/lib/calls/call-shortcuts.ts
+++ b/chat/src/lib/calls/call-shortcuts.ts
@@ -33,6 +33,12 @@ export type CallShortcutInput = {
   metaKey: boolean;
   altKey: boolean;
   editableTarget: boolean;
+  /**
+   * The focused element activates on Space/Enter (a button, link, menu item,
+   * …). Space must pass through to that native activation rather than being
+   * stolen for push-to-talk.
+   */
+  activationTarget: boolean;
   surfaceFocused: boolean;
 };
 
@@ -52,21 +58,34 @@ const CALL_SURFACE_SELECTOR = ".call-split, .call-expanded";
  */
 const EDITABLE_SELECTOR = "input, textarea, select, [contenteditable='true']";
 
+/**
+ * Controls whose default keyboard action is Space/Enter activation. When one
+ * is focused, Space belongs to the control (e.g. activating a focused Mute or
+ * Hang-up button), not to push-to-talk.
+ */
+const ACTIVATION_SELECTOR =
+  'button, a[href], summary, [role="button"], [role="menuitem"], ' +
+  '[role="menuitemcheckbox"], [role="menuitemradio"], [role="tab"], ' +
+  '[role="switch"], [role="option"]';
+
 /** The minimal slice of `Element` the target descriptor needs. */
 type ClosestQueryable = Pick<Element, "closest">;
 
 /**
- * Derive the two scope booleans `resolveCallShortcut` consumes from the
- * keyboard event's target. Pure: it only reads `closest`, so the wiring
- * adapter narrows `event.target` to an element and hands it here.
+ * Derive the scope booleans `resolveCallShortcut` consumes from the keyboard
+ * event's target. Pure: it only reads `closest`, so the wiring adapter narrows
+ * `event.target` to an element and hands it here.
  */
 export function describeCallShortcutTarget(
   target: ClosestQueryable | null,
-): { surfaceFocused: boolean; editableTarget: boolean } {
-  if (!target) return { surfaceFocused: false, editableTarget: false };
+): { surfaceFocused: boolean; editableTarget: boolean; activationTarget: boolean } {
+  if (!target) {
+    return { surfaceFocused: false, editableTarget: false, activationTarget: false };
+  }
   return {
     surfaceFocused: target.closest(CALL_SURFACE_SELECTOR) !== null,
     editableTarget: target.closest(EDITABLE_SELECTOR) !== null,
+    activationTarget: target.closest(ACTIVATION_SELECTOR) !== null,
   };
 }
 
@@ -79,6 +98,9 @@ export function resolveCallShortcut(input: CallShortcutInput): CallShortcutInten
   if (input.ctrlKey || input.metaKey || input.altKey) return null;
 
   if (input.key === " ") {
+    // A focused button/link/menu item owns Space for its own activation — let
+    // it through rather than stealing it (and suppressing it) for push-to-talk.
+    if (input.activationTarget) return null;
     if (input.type === "keyup") return "push-to-talk-end";
     // Auto-repeat would spam push-to-talk-start while the key is held.
     return input.repeat ? null : "push-to-talk-start";

--- a/chat/src/lib/calls/call-shortcuts.ts
+++ b/chat/src/lib/calls/call-shortcuts.ts
@@ -37,11 +37,13 @@ export type CallShortcutInput = {
 };
 
 /**
- * Roots of the three in-call surfaces — split (inline above chat),
- * expanded/immersive, and the document Picture-in-Picture window body.
- * Focus within any of them scopes the shortcuts to "a focused call surface".
+ * Roots of the in-call surfaces that live in the main document — split
+ * (inline above chat) and expanded/immersive. Focus within either scopes the
+ * shortcuts to "a focused call surface". The document Picture-in-Picture
+ * window is intentionally excluded: it is a separate `Window`, so its key
+ * events never reach this window's listener — it owns its own dismissal.
  */
-const CALL_SURFACE_SELECTOR = ".call-split, .call-expanded, .call-pip-document";
+const CALL_SURFACE_SELECTOR = ".call-split, .call-expanded";
 
 /**
  * Text-entry targets where the keys must stay inert. Matches the editable

--- a/chat/src/lib/calls/use-call-shortcuts.ts
+++ b/chat/src/lib/calls/use-call-shortcuts.ts
@@ -35,22 +35,48 @@ function closestQueryable(target: EventTarget | null): ClosestQueryable | null {
 
 /**
  * Install capture-phase keydown/keyup listeners that resolve and dispatch
- * call shortcuts. Returns a teardown that removes both listeners. Capture
+ * call shortcuts. Returns a teardown that removes the listeners. Capture
  * phase keeps the editable-target guard authoritative even when an inner
  * widget would otherwise stop propagation.
  *
  * `isActive` gates dispatch: both call surfaces stay mounted at once, so each
  * passes a predicate for "am I the visible surface?" — without it every
  * shortcut would fire twice. Defaults to always-active for single-surface use.
+ *
+ * Push-to-talk release is handled out-of-band from the pure mapping: once a
+ * hold has engaged the mic, the release must ALWAYS fire — even if focus moved
+ * into the chat composer mid-hold (the Space keyup still bubbles to the window)
+ * or the window lost focus entirely (alt-tab) — otherwise the mic sticks open.
+ * So the Space keyup, a window `blur`, and teardown all force a release while
+ * engaged, regardless of the focus/active scoping that gates the press.
  */
 export function installCallShortcuts(
   handlers: CallShortcutHandlers,
   target: ShortcutListenerTarget,
   isActive: () => boolean = () => true,
 ): () => void {
+  let pushToTalkEngaged = false;
+
+  const releasePushToTalk = (): void => {
+    if (!pushToTalkEngaged) return;
+    pushToTalkEngaged = false;
+    handlers["push-to-talk-end"]?.();
+  };
+
   const onKey = (event: Event): void => {
     const keyboardEvent = event as KeyboardEvent;
     if (keyboardEvent.type !== "keydown" && keyboardEvent.type !== "keyup") return;
+
+    // Release safety net first, before the focus/active scoping that gates the
+    // press: a held mic must come back down on release no matter where focus
+    // went. A Space keyup with no engaged hold is left untouched.
+    if (keyboardEvent.type === "keyup" && keyboardEvent.key === " ") {
+      if (!pushToTalkEngaged) return;
+      releasePushToTalk();
+      keyboardEvent.preventDefault();
+      return;
+    }
+
     if (!isActive()) return;
     const { surfaceFocused, editableTarget } = describeCallShortcutTarget(
       closestQueryable(keyboardEvent.target),
@@ -70,14 +96,20 @@ export function installCallShortcuts(
     if (handler === undefined) return;
     // A handler that returns false declined to act — leave the key alone.
     if (handler() === false) return;
+    if (intent === "push-to-talk-start") pushToTalkEngaged = true;
     keyboardEvent.preventDefault();
   };
 
+  const onBlur = (): void => releasePushToTalk();
+
   target.addEventListener("keydown", onKey, true);
   target.addEventListener("keyup", onKey, true);
+  target.addEventListener("blur", onBlur);
   return () => {
     target.removeEventListener("keydown", onKey, true);
     target.removeEventListener("keyup", onKey, true);
+    target.removeEventListener("blur", onBlur);
+    releasePushToTalk();
   };
 }
 

--- a/chat/src/lib/calls/use-call-shortcuts.ts
+++ b/chat/src/lib/calls/use-call-shortcuts.ts
@@ -77,7 +77,7 @@ export function installCallShortcuts(
     }
 
     if (!isActive()) return;
-    const { surfaceFocused, editableTarget } = describeCallShortcutTarget(
+    const { surfaceFocused, editableTarget, activationTarget } = describeCallShortcutTarget(
       closestQueryable(keyboardEvent.target),
     );
     const intent = resolveCallShortcut({
@@ -88,6 +88,7 @@ export function installCallShortcuts(
       metaKey: keyboardEvent.metaKey,
       altKey: keyboardEvent.altKey,
       editableTarget,
+      activationTarget,
       surfaceFocused,
     });
     if (intent === null) return;

--- a/chat/src/lib/calls/use-call-shortcuts.ts
+++ b/chat/src/lib/calls/use-call-shortcuts.ts
@@ -27,10 +27,9 @@ type ShortcutListenerTarget = Pick<Window, "addEventListener" | "removeEventList
 type ClosestQueryable = { closest(selectors: string): Element | null };
 
 function closestQueryable(target: EventTarget | null): ClosestQueryable | null {
-  return target !== null &&
-    typeof (target as { closest?: unknown }).closest === "function"
-    ? (target as ClosestQueryable)
-    : null;
+  if (target === null) return null;
+  const candidate = target as { closest?: unknown };
+  return typeof candidate.closest === "function" ? (candidate as ClosestQueryable) : null;
 }
 
 /**

--- a/chat/src/lib/calls/use-call-shortcuts.ts
+++ b/chat/src/lib/calls/use-call-shortcuts.ts
@@ -1,0 +1,103 @@
+import { onBeforeUnmount, onMounted } from "vue";
+import {
+  describeCallShortcutTarget,
+  resolveCallShortcut,
+  type CallShortcutIntent,
+} from "./call-shortcuts";
+
+/**
+ * Thin DOM/Vue adapter over the pure `call-shortcuts` mapping (#1034).
+ *
+ * The decision of "which key does what" lives in `resolveCallShortcut`; this
+ * module only translates real keyboard events into the descriptor that
+ * mapping consumes and dispatches the resulting intent to the handler a call
+ * surface supplies. A surface registers handlers only for the intents it
+ * owns — an unmapped key (e.g. Escape on the expanded surface, which has its
+ * own richer handler) is left untouched so existing listeners still run.
+ *
+ * A handler may return `false` to signal "I chose not to act" (e.g. Escape
+ * when no Picture-in-Picture is open), leaving the keystroke for other
+ * listeners; any other return value consumes it.
+ */
+export type CallShortcutHandlers = Partial<Record<CallShortcutIntent, () => boolean | void>>;
+
+type ShortcutListenerTarget = Pick<Window, "addEventListener" | "removeEventListener">;
+
+/** The minimal slice of an element the target descriptor needs. */
+type ClosestQueryable = { closest(selectors: string): Element | null };
+
+function closestQueryable(target: EventTarget | null): ClosestQueryable | null {
+  return target !== null &&
+    typeof (target as { closest?: unknown }).closest === "function"
+    ? (target as ClosestQueryable)
+    : null;
+}
+
+/**
+ * Install capture-phase keydown/keyup listeners that resolve and dispatch
+ * call shortcuts. Returns a teardown that removes both listeners. Capture
+ * phase keeps the editable-target guard authoritative even when an inner
+ * widget would otherwise stop propagation.
+ *
+ * `isActive` gates dispatch: both call surfaces stay mounted at once, so each
+ * passes a predicate for "am I the visible surface?" — without it every
+ * shortcut would fire twice. Defaults to always-active for single-surface use.
+ */
+export function installCallShortcuts(
+  handlers: CallShortcutHandlers,
+  target: ShortcutListenerTarget,
+  isActive: () => boolean = () => true,
+): () => void {
+  const onKey = (event: Event): void => {
+    const keyboardEvent = event as KeyboardEvent;
+    if (keyboardEvent.type !== "keydown" && keyboardEvent.type !== "keyup") return;
+    if (!isActive()) return;
+    const { surfaceFocused, editableTarget } = describeCallShortcutTarget(
+      closestQueryable(keyboardEvent.target),
+    );
+    const intent = resolveCallShortcut({
+      key: keyboardEvent.key,
+      type: keyboardEvent.type,
+      repeat: keyboardEvent.repeat,
+      ctrlKey: keyboardEvent.ctrlKey,
+      metaKey: keyboardEvent.metaKey,
+      altKey: keyboardEvent.altKey,
+      editableTarget,
+      surfaceFocused,
+    });
+    if (intent === null) return;
+    const handler = handlers[intent];
+    if (handler === undefined) return;
+    // A handler that returns false declined to act — leave the key alone.
+    if (handler() === false) return;
+    keyboardEvent.preventDefault();
+  };
+
+  target.addEventListener("keydown", onKey, true);
+  target.addEventListener("keyup", onKey, true);
+  return () => {
+    target.removeEventListener("keydown", onKey, true);
+    target.removeEventListener("keyup", onKey, true);
+  };
+}
+
+/**
+ * Vue lifecycle wrapper: install the shortcuts on `window` for the lifetime
+ * of the calling component (a mounted call surface) and tear them down on
+ * unmount. A no-op during SSR. `isActive` lets a surface that is mounted but
+ * not currently visible stand down so shortcuts never fire twice.
+ */
+export function useCallShortcuts(
+  handlers: CallShortcutHandlers,
+  isActive: () => boolean = () => true,
+): void {
+  if (typeof window === "undefined") return;
+  let teardown: (() => void) | null = null;
+  onMounted(() => {
+    teardown = installCallShortcuts(handlers, window, isActive);
+  });
+  onBeforeUnmount(() => {
+    teardown?.();
+    teardown = null;
+  });
+}

--- a/chat/tests/call-controls.test.ts
+++ b/chat/tests/call-controls.test.ts
@@ -358,6 +358,27 @@ describe("device-less call controls", () => {
     expect(calls).toEqual([false]);
   });
 
+  test("rapid push-to-talk tap settles on the released state without stranding the engine", async () => {
+    // Press + release in the same tick. The enable must never win late and
+    // re-open the mic — serialized last-writer-wins means only the disable
+    // reaches the engine and the final state is muted.
+    const { engine } = useCallEngine();
+    const calls: boolean[] = [];
+    (engine as unknown as { room: unknown }).room = {
+      localParticipant: {
+        setMicrophoneEnabled: async (on: boolean) => {
+          calls.push(on);
+        },
+      },
+    };
+    $callMicEnabled.set(false);
+    setPushToTalkActive(true);
+    setPushToTalkActive(false);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect($callMicEnabled.get()).toBe(false);
+    expect(calls).toEqual([false]);
+  });
+
   test("push-to-talk activation is a no-op when the mic is already live", async () => {
     const { engine } = useCallEngine();
     const calls: boolean[] = [];

--- a/chat/tests/call-controls.test.ts
+++ b/chat/tests/call-controls.test.ts
@@ -18,6 +18,7 @@ import {
   refreshScreenShareSupported,
   resetCallControls,
   seedCallControlsFromEngine,
+  setPushToTalkActive,
   suspendCallForPageHide,
   toggleScreenShare,
   toggleMic,
@@ -321,6 +322,57 @@ describe("device-less call controls", () => {
     expect($callMicEnabled.get()).toBe(true);
     expect($callCamEnabled.get()).toBe(true);
     expect($callScreenShareEnabled.get()).toBe(false);
+  });
+
+  test("push-to-talk activation unmutes a muted mic", async () => {
+    const { engine } = useCallEngine();
+    const calls: boolean[] = [];
+    (engine as unknown as { room: unknown }).room = {
+      localParticipant: {
+        setMicrophoneEnabled: async (on: boolean) => {
+          calls.push(on);
+        },
+      },
+    };
+    $callMicEnabled.set(false);
+    setPushToTalkActive(true);
+    await Promise.resolve();
+    expect($callMicEnabled.get()).toBe(true);
+    expect(calls).toEqual([true]);
+  });
+
+  test("push-to-talk release mutes a live mic", async () => {
+    const { engine } = useCallEngine();
+    const calls: boolean[] = [];
+    (engine as unknown as { room: unknown }).room = {
+      localParticipant: {
+        setMicrophoneEnabled: async (on: boolean) => {
+          calls.push(on);
+        },
+      },
+    };
+    $callMicEnabled.set(true);
+    setPushToTalkActive(false);
+    await Promise.resolve();
+    expect($callMicEnabled.get()).toBe(false);
+    expect(calls).toEqual([false]);
+  });
+
+  test("push-to-talk activation is a no-op when the mic is already live", async () => {
+    const { engine } = useCallEngine();
+    const calls: boolean[] = [];
+    (engine as unknown as { room: unknown }).room = {
+      localParticipant: {
+        setMicrophoneEnabled: async (on: boolean) => {
+          calls.push(on);
+        },
+      },
+    };
+    $callMicEnabled.set(true);
+    setPushToTalkActive(true);
+    await Promise.resolve();
+    expect($callMicEnabled.get()).toBe(true);
+    expect(calls).toEqual([]);
   });
 
   test("toggleMic retry that is still denied rolls back AND records a classified issue", async () => {

--- a/chat/tests/call-shortcuts.test.ts
+++ b/chat/tests/call-shortcuts.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test";
+import {
+  describeCallShortcutTarget,
+  resolveCallShortcut,
+  type CallShortcutInput,
+} from "../src/lib/calls/call-shortcuts";
+
+/**
+ * Stand-in for a focused DOM element: `closest(selectors)` matches when any
+ * comma-separated selector is in `matches`, mirroring `Element.closest`.
+ */
+function fakeTarget(matches: string[]): { closest(selectors: string): Element | null } {
+  return {
+    closest(selectors: string): Element | null {
+      const wanted = selectors.split(",").map((part) => part.trim());
+      return wanted.some((selector) => matches.includes(selector))
+        ? ({} as Element)
+        : null;
+    },
+  };
+}
+
+/**
+ * A focused, non-editable keydown on a live call surface — the baseline
+ * descriptor each behaviour test overrides the one field it cares about.
+ */
+function keydown(overrides: Partial<CallShortcutInput> = {}): CallShortcutInput {
+  return {
+    key: "",
+    type: "keydown",
+    repeat: false,
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    editableTarget: false,
+    surfaceFocused: true,
+    ...overrides,
+  };
+}
+
+describe("resolveCallShortcut", () => {
+  test("M toggles the mic", () => {
+    expect(resolveCallShortcut(keydown({ key: "m" }))).toBe("toggle-mic");
+  });
+
+  test("holding Space starts push-to-talk", () => {
+    expect(resolveCallShortcut(keydown({ key: " " }))).toBe("push-to-talk-start");
+  });
+
+  test("releasing Space ends push-to-talk", () => {
+    expect(resolveCallShortcut(keydown({ key: " ", type: "keyup" }))).toBe(
+      "push-to-talk-end",
+    );
+  });
+
+  test("V toggles the camera", () => {
+    expect(resolveCallShortcut(keydown({ key: "v" }))).toBe("toggle-camera");
+  });
+
+  test("S toggles screen share", () => {
+    expect(resolveCallShortcut(keydown({ key: "s" }))).toBe("toggle-share");
+  });
+
+  test("R toggles raise hand", () => {
+    expect(resolveCallShortcut(keydown({ key: "r" }))).toBe("toggle-raise-hand");
+  });
+
+  test("F enters immersive/fullscreen", () => {
+    expect(resolveCallShortcut(keydown({ key: "f" }))).toBe("enter-immersive");
+  });
+
+  test("Escape exits immersive", () => {
+    expect(resolveCallShortcut(keydown({ key: "Escape" }))).toBe("exit-immersive");
+  });
+
+  test("auto-repeat keydown does not re-fire a toggle", () => {
+    expect(resolveCallShortcut(keydown({ key: "m", repeat: true }))).toBeNull();
+  });
+
+  test("auto-repeat does not re-start push-to-talk", () => {
+    expect(resolveCallShortcut(keydown({ key: " ", repeat: true }))).toBeNull();
+  });
+
+  test("ignores modifier combinations so OS/browser shortcuts pass through", () => {
+    expect(resolveCallShortcut(keydown({ key: "m", metaKey: true }))).toBeNull();
+    expect(resolveCallShortcut(keydown({ key: "m", ctrlKey: true }))).toBeNull();
+    expect(resolveCallShortcut(keydown({ key: "s", altKey: true }))).toBeNull();
+  });
+
+  test("stays inert while typing in chat", () => {
+    expect(resolveCallShortcut(keydown({ key: "m", editableTarget: true }))).toBeNull();
+    // Even Space must not push-to-talk while composing a message.
+    expect(resolveCallShortcut(keydown({ key: " ", editableTarget: true }))).toBeNull();
+  });
+
+  test("only fires when a call surface is focused", () => {
+    expect(resolveCallShortcut(keydown({ key: "m", surfaceFocused: false }))).toBeNull();
+    expect(resolveCallShortcut(keydown({ key: " ", surfaceFocused: false }))).toBeNull();
+  });
+});
+
+describe("describeCallShortcutTarget", () => {
+  test("a null target is neither focused nor editable", () => {
+    expect(describeCallShortcutTarget(null)).toEqual({
+      surfaceFocused: false,
+      editableTarget: false,
+    });
+  });
+
+  test("focus inside the split surface counts as a focused call surface", () => {
+    expect(describeCallShortcutTarget(fakeTarget([".call-split"]))).toEqual({
+      surfaceFocused: true,
+      editableTarget: false,
+    });
+  });
+
+  test("focus inside the expanded/immersive surface counts too", () => {
+    expect(describeCallShortcutTarget(fakeTarget([".call-expanded"])).surfaceFocused).toBe(
+      true,
+    );
+  });
+
+  test("the picture-in-picture document counts as a focused surface", () => {
+    expect(
+      describeCallShortcutTarget(fakeTarget([".call-pip-document"])).surfaceFocused,
+    ).toBe(true);
+  });
+
+  test("an editable element is flagged so typing stays inert", () => {
+    expect(describeCallShortcutTarget(fakeTarget(["textarea"])).editableTarget).toBe(true);
+    expect(
+      describeCallShortcutTarget(fakeTarget(["[contenteditable='true']"])).editableTarget,
+    ).toBe(true);
+  });
+
+  test("a chat composer outside any call surface is editable but not focused", () => {
+    expect(describeCallShortcutTarget(fakeTarget(["[contenteditable='true']"]))).toEqual({
+      surfaceFocused: false,
+      editableTarget: true,
+    });
+  });
+});

--- a/chat/tests/call-shortcuts.test.ts
+++ b/chat/tests/call-shortcuts.test.ts
@@ -120,10 +120,11 @@ describe("describeCallShortcutTarget", () => {
     );
   });
 
-  test("the picture-in-picture document counts as a focused surface", () => {
+  test("the document picture-in-picture window is not treated as a focused surface", () => {
+    // It is a separate Window; its key events never reach this listener.
     expect(
       describeCallShortcutTarget(fakeTarget([".call-pip-document"])).surfaceFocused,
-    ).toBe(true);
+    ).toBe(false);
   });
 
   test("an editable element is flagged so typing stays inert", () => {

--- a/chat/tests/call-shortcuts.test.ts
+++ b/chat/tests/call-shortcuts.test.ts
@@ -33,6 +33,7 @@ function keydown(overrides: Partial<CallShortcutInput> = {}): CallShortcutInput 
     metaKey: false,
     altKey: false,
     editableTarget: false,
+    activationTarget: false,
     surfaceFocused: true,
     ...overrides,
   };
@@ -97,13 +98,30 @@ describe("resolveCallShortcut", () => {
     expect(resolveCallShortcut(keydown({ key: "m", surfaceFocused: false }))).toBeNull();
     expect(resolveCallShortcut(keydown({ key: " ", surfaceFocused: false }))).toBeNull();
   });
+
+  test("Space on a focused control passes through to native activation", () => {
+    // A focused Mute/Hang-up button must still activate on Space — don't
+    // hijack it for push-to-talk (keydown AND keyup, since buttons fire on up).
+    expect(resolveCallShortcut(keydown({ key: " ", activationTarget: true }))).toBeNull();
+    expect(
+      resolveCallShortcut(keydown({ key: " ", type: "keyup", activationTarget: true })),
+    ).toBeNull();
+  });
+
+  test("letter shortcuts still fire while a control is focused", () => {
+    // Letters don't collide with native button activation, so they still work.
+    expect(resolveCallShortcut(keydown({ key: "m", activationTarget: true }))).toBe(
+      "toggle-mic",
+    );
+  });
 });
 
 describe("describeCallShortcutTarget", () => {
-  test("a null target is neither focused nor editable", () => {
+  test("a null target is neither focused nor editable nor an activation target", () => {
     expect(describeCallShortcutTarget(null)).toEqual({
       surfaceFocused: false,
       editableTarget: false,
+      activationTarget: false,
     });
   });
 
@@ -111,7 +129,15 @@ describe("describeCallShortcutTarget", () => {
     expect(describeCallShortcutTarget(fakeTarget([".call-split"]))).toEqual({
       surfaceFocused: true,
       editableTarget: false,
+      activationTarget: false,
     });
+  });
+
+  test("a focused button is flagged as an activation target", () => {
+    expect(describeCallShortcutTarget(fakeTarget(["button"])).activationTarget).toBe(true);
+    expect(
+      describeCallShortcutTarget(fakeTarget(['[role="button"]'])).activationTarget,
+    ).toBe(true);
   });
 
   test("focus inside the expanded/immersive surface counts too", () => {
@@ -138,6 +164,7 @@ describe("describeCallShortcutTarget", () => {
     expect(describeCallShortcutTarget(fakeTarget(["[contenteditable='true']"]))).toEqual({
       surfaceFocused: false,
       editableTarget: true,
+      activationTarget: false,
     });
   });
 });

--- a/chat/tests/use-call-shortcuts.test.ts
+++ b/chat/tests/use-call-shortcuts.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+  installCallShortcuts,
+  type CallShortcutHandlers,
+} from "../src/lib/calls/use-call-shortcuts";
+
+/** Minimal window double that records capture listeners and replays events. */
+function fakeWindow() {
+  const listeners = new Map<string, Set<EventListener>>();
+  return {
+    addEventListener(type: string, fn: EventListener) {
+      (listeners.get(type) ?? listeners.set(type, new Set()).get(type)!).add(fn);
+    },
+    removeEventListener(type: string, fn: EventListener) {
+      listeners.get(type)?.delete(fn);
+    },
+    dispatch(event: { type: string }) {
+      for (const fn of listeners.get(event.type) ?? []) fn(event as unknown as Event);
+    },
+    count(type: string) {
+      return listeners.get(type)?.size ?? 0;
+    },
+  };
+}
+
+/** A keyboard event whose target reports membership via `closest`. */
+function keyEvent(
+  overrides: { type?: string; key?: string; repeat?: boolean; targetMatches?: string[] } = {},
+) {
+  const matches = overrides.targetMatches ?? [".call-split"];
+  return {
+    type: overrides.type ?? "keydown",
+    key: overrides.key ?? "m",
+    repeat: overrides.repeat ?? false,
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    preventDefault: mock(() => undefined),
+    target: {
+      closest(selectors: string): Element | null {
+        const wanted = selectors.split(",").map((part) => part.trim());
+        return wanted.some((selector) => matches.includes(selector))
+          ? ({} as Element)
+          : null;
+      },
+    },
+  };
+}
+
+function handlers(): CallShortcutHandlers & { calls: string[] } {
+  const calls: string[] = [];
+  return {
+    calls,
+    "toggle-mic": () => calls.push("toggle-mic"),
+    "push-to-talk-start": () => calls.push("ptt-start"),
+    "push-to-talk-end": () => calls.push("ptt-end"),
+  };
+}
+
+describe("installCallShortcuts", () => {
+  test("dispatches the mapped intent and consumes the event", () => {
+    const win = fakeWindow();
+    const h = handlers();
+    installCallShortcuts(h, win);
+
+    const event = keyEvent({ key: "m" });
+    win.dispatch(event);
+
+    expect(h.calls).toEqual(["toggle-mic"]);
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  test("routes Space keydown/keyup to push-to-talk start/end", () => {
+    const win = fakeWindow();
+    const h = handlers();
+    installCallShortcuts(h, win);
+
+    win.dispatch(keyEvent({ key: " ", type: "keydown" }));
+    win.dispatch(keyEvent({ key: " ", type: "keyup" }));
+
+    expect(h.calls).toEqual(["ptt-start", "ptt-end"]);
+  });
+
+  test("stays inert while typing and never consumes the keystroke", () => {
+    const win = fakeWindow();
+    const h = handlers();
+    installCallShortcuts(h, win);
+
+    const event = keyEvent({ key: "m", targetMatches: ["textarea"] });
+    win.dispatch(event);
+
+    expect(h.calls).toEqual([]);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  test("ignores keys with no registered handler so existing handlers run", () => {
+    const win = fakeWindow();
+    const h = handlers(); // no "exit-immersive" handler
+    installCallShortcuts(h, win);
+
+    const event = keyEvent({ key: "Escape" });
+    win.dispatch(event);
+
+    expect(h.calls).toEqual([]);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  test("does not dispatch while the surface is inactive", () => {
+    // Both surfaces stay mounted at once; only the visible one may act.
+    const win = fakeWindow();
+    const h = handlers();
+    installCallShortcuts(h, win, () => false);
+
+    const event = keyEvent({ key: "m" });
+    win.dispatch(event);
+
+    expect(h.calls).toEqual([]);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  test("a handler returning false leaves the event for other listeners", () => {
+    const win = fakeWindow();
+    const calls: string[] = [];
+    const h: CallShortcutHandlers = {
+      "exit-immersive": () => {
+        calls.push("esc");
+        return false;
+      },
+    };
+    installCallShortcuts(h, win);
+
+    const event = keyEvent({ key: "Escape" });
+    win.dispatch(event);
+
+    expect(calls).toEqual(["esc"]);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  test("cleanup removes both capture listeners", () => {
+    const win = fakeWindow();
+    const h = handlers();
+    const cleanup = installCallShortcuts(h, win);
+    expect(win.count("keydown")).toBe(1);
+    expect(win.count("keyup")).toBe(1);
+
+    cleanup();
+    win.dispatch(keyEvent({ key: "m" }));
+
+    expect(h.calls).toEqual([]);
+    expect(win.count("keydown")).toBe(0);
+    expect(win.count("keyup")).toBe(0);
+  });
+});

--- a/chat/tests/use-call-shortcuts.test.ts
+++ b/chat/tests/use-call-shortcuts.test.ts
@@ -51,9 +51,9 @@ function handlers(): CallShortcutHandlers & { calls: string[] } {
   const calls: string[] = [];
   return {
     calls,
-    "toggle-mic": () => calls.push("toggle-mic"),
-    "push-to-talk-start": () => calls.push("ptt-start"),
-    "push-to-talk-end": () => calls.push("ptt-end"),
+    "toggle-mic": () => void calls.push("toggle-mic"),
+    "push-to-talk-start": () => void calls.push("ptt-start"),
+    "push-to-talk-end": () => void calls.push("ptt-end"),
   };
 }
 

--- a/chat/tests/use-call-shortcuts.test.ts
+++ b/chat/tests/use-call-shortcuts.test.ts
@@ -151,3 +151,63 @@ describe("installCallShortcuts", () => {
     expect(win.count("keyup")).toBe(0);
   });
 });
+
+describe("push-to-talk release safety net", () => {
+  test("ends push-to-talk even when focus left the surface mid-hold", () => {
+    // Hold Space on the call surface, click into the chat composer, release.
+    // The keyup still reaches the window listener, so the mic must release.
+    const win = fakeWindow();
+    const h = handlers();
+    installCallShortcuts(h, win);
+
+    win.dispatch(keyEvent({ key: " ", type: "keydown", targetMatches: [".call-split"] }));
+    win.dispatch(keyEvent({ key: " ", type: "keyup", targetMatches: ["textarea"] }));
+
+    expect(h.calls).toEqual(["ptt-start", "ptt-end"]);
+  });
+
+  test("a stray Space keyup without an active push-to-talk does nothing", () => {
+    const win = fakeWindow();
+    const h = handlers();
+    installCallShortcuts(h, win);
+
+    // Space released in the composer where push-to-talk never engaged.
+    win.dispatch(keyEvent({ key: " ", type: "keyup", targetMatches: ["textarea"] }));
+
+    expect(h.calls).toEqual([]);
+  });
+
+  test("losing window focus mid-hold releases push-to-talk", () => {
+    const win = fakeWindow();
+    const h = handlers();
+    installCallShortcuts(h, win);
+
+    win.dispatch(keyEvent({ key: " ", type: "keydown" }));
+    win.dispatch({ type: "blur" });
+
+    expect(h.calls).toEqual(["ptt-start", "ptt-end"]);
+  });
+
+  test("teardown while holding releases push-to-talk", () => {
+    const win = fakeWindow();
+    const h = handlers();
+    const cleanup = installCallShortcuts(h, win);
+
+    win.dispatch(keyEvent({ key: " ", type: "keydown" }));
+    cleanup();
+
+    expect(h.calls).toEqual(["ptt-start", "ptt-end"]);
+  });
+
+  test("does not double-release on keyup after window blur", () => {
+    const win = fakeWindow();
+    const h = handlers();
+    installCallShortcuts(h, win);
+
+    win.dispatch(keyEvent({ key: " ", type: "keydown" }));
+    win.dispatch({ type: "blur" });
+    win.dispatch(keyEvent({ key: " ", type: "keyup" }));
+
+    expect(h.calls).toEqual(["ptt-start", "ptt-end"]);
+  });
+});


### PR DESCRIPTION
## Closes #1034

Call **keyboard shortcuts** for the in-call surfaces (child of #1017), scoped
to a focused call surface and inert while typing in chat.

| Key | Action |
| --- | --- |
| `M` | toggle mic |
| `Space` (hold) | push-to-talk — mic on while held, mic off on release |
| `V` | toggle camera |
| `S` | toggle screen share |
| `R` | toggle raise hand |
| `F` | enter immersive (+ native fullscreen on the expanded surface) |
| `Esc` | exit immersive / close Picture-in-Picture (expanded surface) |

## Design

Three thin layers, with the testable decision isolated as a pure function —
the deep-module / small-interface shape the acceptance criteria call for:

- **Pure mapping** (`call-shortcuts.ts`): `resolveCallShortcut(descriptor) →
  CallShortcutIntent | null` — a total, side-effect-free map from a typed
  keyboard descriptor to a typed intent. Auto-repeat and ctrl/meta/alt chords
  are ignored; inert when not focused on a call surface or when typing.
  `describeCallShortcutTarget` derives `surfaceFocused` (`.call-split` /
  `.call-expanded`) and `editableTarget` (input/textarea/select/contenteditable,
  matching the existing editable-guard idiom) from the event target.
- **DOM/Vue adapter** (`use-call-shortcuts.ts`): capture-phase keydown/keyup
  listeners that build the descriptor, dispatch the resolved intent to the
  handler a surface supplies, and tear down on unmount. An `isActive` gate is
  required because **both** surfaces stay mounted at once (`ContentArea` v-ifs
  on call context, not ui mode) — without it every shortcut would fire twice.
  Push-to-talk release is handled out-of-band: once a hold engages the mic, the
  release **always** fires — on the Space keyup wherever it lands, on window
  `blur` (alt-tab), and on teardown — so the mic never sticks open if focus
  leaves the surface mid-hold.
- **Wiring**: `setPushToTalkActive` in `call-controls.ts` (push-to-talk on top
  of `toggleMic`, so the optimistic flip, rollback, and mute-presence broadcast
  match a manual toggle and held/repeat keys don't churn presence). Mounted on
  both the split and expanded surfaces; the expanded surface keeps its existing
  richer Escape handler (now also popping PiP before collapsing). Surface roots
  are `tabindex="-1"` so clicking anywhere in the call scopes shortcuts to it.

## XEP / constitution conformance

- Pure client-side input feature — **no XMPP wire changes**. The actions it
  triggers (mute, raise-hand, …) go out over the existing
  `urn:waddle:in-call:0` presence paths unchanged.
- Intents are a typed discriminated union — no stringly-typed payloads.
- `knip` clean; Conventional Commits, single `chat` scope.

Note: push-to-talk reuses the established #1030 mute-broadcast path, so a hold
emits one mute-down + one mute-up presence (auto-repeat suppressed, no-op guard
prevents redundant broadcasts). Wire-conformant; a debounce would be a possible
follow-up but is not required here.

## Plan (TDD, vertical slices)

1. `M` → `toggle-mic` (tracer) → 2. `Space` push-to-talk start/end →
3. `V`/`S`/`R` → 4. `F`/`Esc` → 5. ignore repeat + modifier chords →
6. inert while typing / unfocused + target descriptor → 7. wire into both
surfaces (+ `setPushToTalkActive`, isActive gate) → 8. adversarial review →
green CI.

## Review hardening (from adversarial passes)

- **Blocker fixed**: push-to-talk could leave the mic stuck open if focus left
  the surface mid-hold — now force-released on keyup-anywhere / blur / teardown.
- Dropped unreachable `.call-pip-document` from the surface selector (Document
  PiP is a separate `Window`; its keys never reach this listener).
- `tabindex="-1"` on surface roots; swallowed a rejected `requestFullscreen`.

## Tests

- `tests/call-shortcuts.test.ts` — full mapping + scoping
- `tests/use-call-shortcuts.test.ts` — adapter dispatch, isActive gate,
  decline-via-false, and the push-to-talk release safety net
- `tests/call-controls.test.ts` — `setPushToTalkActive` (unmute / mute / no-op)
- Full `bun test`: 2647 pass (the lone failure is the pre-existing
  `startup-loading` case that needs `bun run build` first — unrelated).
- `bunx knip` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
